### PR TITLE
Fix default path for [[bin]] example

### DIFF
--- a/manifest.html
+++ b/manifest.html
@@ -166,7 +166,7 @@ which will change this requirement.</p>
 
 <span class="nn">[[bin]]</span>
 
-<span class="py">name</span> <span class="p">=</span> <span class="s">"hiya"</span> <span class="c"># defaults to src/fun-times.rs</span>
+<span class="py">name</span> <span class="p">=</span> <span class="s">"hiya"</span> <span class="c"># defaults to src/hiya.rs</span>
 
 <span class="nn">[[bin]]</span>
 


### PR DESCRIPTION
This looks like it is what was intended, but I don’t know. The previous text didn’t make sense to me.
