### PR TITLE
Correct installation to follow standards

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ script:
   - ./.travis.check.style.sh
   - make CC="$CC" RUSTC="$RUSTC" -j4
   - make CC="$CC" RUSTC="$RUSTC" test -j4
+  - make install DESTDIR=${PWD}/destdir
 
 env:
   - ARCH=i686 CC='cc -m32'

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 RUSTC ?= rustc
 RUSTC_FLAGS ?=
-DESTDIR ?= /usr/local
+DESTDIR ?=
+PREFIX ?= /usr/local
+BINDIR ?= $(PREFIX)/bin
 
 # Link flags to pull in dependencies
 BINS = cargo \
@@ -75,7 +77,8 @@ distclean: clean
 	cd libs/toml-rs && make clean
 
 install:
-	cp target/cargo target/cargo-* $(DESTDIR)/bin
+	install -d $(DESTDIR)$(BINDIR)
+	install target/cargo target/cargo-* $(DESTDIR)$(BINDIR)
 
 # Setup phony tasks
 .PHONY: all clean distclean test test-unit test-integration libcargo


### PR DESCRIPTION
DESTDIR is usually empty, it is used by packaging tools to create an install into a temporary directory, to create a tarball that will then be extracted into the real root directory.

'cp' is incorrect for installing programs. Among other things, it will fail (with ETXTBUSY) if the program already installed is currently in use.

Directories must be created before you install files into them (an empty DESTDIR makes this fail most obviously).
