### PR TITLE
Handle misformatted versions with a nicer error message.

### DIFF
--- a/src/cargo/core/resolver.rs
+++ b/src/cargo/core/resolver.rs
@@ -88,19 +88,19 @@ mod test {
                 Dependency::parse(*s, Some("1.0.0"), &source_id).unwrap()
             }).collect();
             Summary::new(&PackageId::new($name, "1.0.0",
-                                         "http://www.example.com/"),
+                                         "http://www.example.com/").unwrap(),
                          d.as_slice())
             }
         );
 
         ($name:expr) => (
             Summary::new(&PackageId::new($name, "1.0.0",
-                                         "http://www.example.com/"), [])
+                                         "http://www.example.com/").unwrap(), [])
         )
     )
 
     fn pkg(name: &str) -> Summary {
-        Summary::new(&PackageId::new(name, "1.0.0", "http://www.example.com/"),
+        Summary::new(&PackageId::new(name, "1.0.0", "http://www.example.com/").unwrap(),
                      &[])
     }
 
@@ -116,7 +116,7 @@ mod test {
 
     fn names(names: &[&'static str]) -> Vec<PackageId> {
         names.iter()
-            .map(|name| PackageId::new(*name, "1.0.0", "http://www.example.com/"))
+            .map(|name| PackageId::new(*name, "1.0.0", "http://www.example.com/").unwrap())
             .collect()
     }
 

--- a/src/cargo/util/toml.rs
+++ b/src/cargo/util/toml.rs
@@ -88,13 +88,14 @@ pub struct TomlManifest {
 #[deriving(Decodable,Encodable,PartialEq,Clone,Show)]
 pub struct TomlProject {
     pub name: String,
+    // FIXME #54: should be a Version to be able to be Decodable'd directly.
     pub version: String,
     pub authors: Vec<String>,
     build: Option<String>,
 }
 
 impl TomlProject {
-    pub fn to_package_id(&self, namespace: &Url) -> PackageId {
+    pub fn to_package_id(&self, namespace: &Url) -> CargoResult<PackageId> {
         PackageId::new(self.name.as_slice(), self.version.as_slice(), namespace)
     }
 }
@@ -161,7 +162,7 @@ impl TomlManifest {
         let project = try!(project.require(|| human("No `package` or `project` section found.")));
 
         Ok((Manifest::new(
-                &Summary::new(&project.to_package_id(source_id.get_url()),
+                &Summary::new(&try!(project.to_package_id(source_id.get_url())),
                               deps.as_slice()),
                 targets.as_slice(),
                 &Path::new("target"),

--- a/tests/test_cargo_compile.rs
+++ b/tests/test_cargo_compile.rs
@@ -51,6 +51,7 @@ test!(cargo_compile_with_invalid_manifest {
                       No `package` or `project` section found.\n"))
 })
 
+
 test!(cargo_compile_with_invalid_manifest2 {
     let p = project("foo")
         .file("Cargo.toml", r"
@@ -63,6 +64,23 @@ test!(cargo_compile_with_invalid_manifest2 {
         .with_status(101)
         .with_stderr("could not parse input TOML\n\
                       Cargo.toml:3:19-3:20 expected a value\n\n"))
+})
+
+test!(cargo_compile_with_invalid_version {
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [project]
+            name = "foo"
+            authors = []
+            version = "1.0"
+        "#);
+
+    assert_that(p.cargo_process("cargo-build"),
+                execs()
+                .with_status(101)
+                .with_stderr("Cargo.toml is not a valid manifest\n\n\
+                              invalid version: cannot parse '1.0' as a semver\n"))
+
 })
 
 test!(cargo_compile_without_manifest {


### PR DESCRIPTION
Fixes https://github.com/rust-lang/cargo/issues/61.
