### PR TITLE
Don't recompile nested deps too frequently

### DIFF
--- a/src/cargo/core/package.rs
+++ b/src/cargo/core/package.rs
@@ -128,7 +128,7 @@ impl Package {
         let sources = sources.iter().map(|source_id| {
             source_id.load(config)
         }).collect::<Vec<_>>();
-        SourceSet::new(sources).fingerprint()
+        SourceSet::new(sources).fingerprint(self)
     }
 }
 

--- a/src/cargo/core/source.rs
+++ b/src/cargo/core/source.rs
@@ -39,7 +39,10 @@ pub trait Source {
     /// This fingerprint is used to determine the "fresheness" of the source
     /// later on. It must be guaranteed that the fingerprint of a source is
     /// constant if and only if the output product will remain constant.
-    fn fingerprint(&self) -> CargoResult<String>;
+    ///
+    /// The `pkg` argument is the package which this fingerprint should only be
+    /// interested in for when this source may contain multiple packages.
+    fn fingerprint(&self, pkg: &Package) -> CargoResult<String>;
 }
 
 #[deriving(Show, Clone, PartialEq, Eq, PartialOrd, Ord)]
@@ -203,10 +206,10 @@ impl Source for SourceSet {
         Ok(ret)
     }
 
-    fn fingerprint(&self) -> CargoResult<String> {
+    fn fingerprint(&self, id: &Package) -> CargoResult<String> {
         let mut ret = String::new();
         for source in self.sources.iter() {
-            ret.push_str(try!(source.fingerprint()).as_slice());
+            ret.push_str(try!(source.fingerprint(id)).as_slice());
         }
         return Ok(ret);
     }

--- a/src/cargo/sources/git/source.rs
+++ b/src/cargo/sources/git/source.rs
@@ -133,7 +133,7 @@ impl<'a, 'b> Source for GitSource<'a, 'b> {
         self.path_source.get(ids)
     }
 
-    fn fingerprint(&self) -> CargoResult<String> {
+    fn fingerprint(&self, _pkg: &Package) -> CargoResult<String> {
         let db = self.remote.db_at(&self.db_path);
         db.rev_for(self.reference.as_slice())
     }


### PR DESCRIPTION
When compiling a package with a nested dependency, any modification to the outer
package would trigger a recompilation of the inner package. This commit alters
the fingerprint() method to take a PackageId to query about the location of a
package and only lookup the files relevant to that package.

The dependency structure of a PathSource is now everything rooted at the
original Cargo.toml minus all subdirectories which contain a Cargo.toml
