### PR TITLE
Fix Missing Space Typo in "Single Source" Error

### DIFF
--- a/src/cargo/core/resolver.rs
+++ b/src/cargo/core/resolver.rs
@@ -39,7 +39,7 @@ pub fn resolve<R: Registry>(deps: &[Dependency],
         }
 
         if opts.len() > 1 {
-            return Err(internal(format!("At the moment, Cargo only supports a\
+            return Err(internal(format!("At the moment, Cargo only supports a \
                 single source for a particular package name ({}).", curr.get_name())));
         }
 


### PR DESCRIPTION
Currently, the "single source" error appears like this, with missing whitespace:

```
lib/game-of-life $ cargo build --verbose
An unknown error occurred

Caused by:
  At the moment, Cargo only supports asingle source for a particular package name (piston).
```

This fixes the typo.
