### PR TITLE
Canonicalize github urls for the resolver

### DIFF
--- a/src/cargo/sources/git/mod.rs
+++ b/src/cargo/sources/git/mod.rs
@@ -1,4 +1,4 @@
 pub use self::utils::{GitRemote,GitDatabase,GitCheckout};
-pub use self::source::{GitSource};
+pub use self::source::{GitSource, canonicalize_url};
 mod utils;
 mod source;


### PR DESCRIPTION
In addition to canonicalizing checkout locations, this canonicalizes packages
for the resolver. This allows two dependencies with slightly different urls
pointing to the same repository to resolve to the same location and package.

Closes #104
