### PR TITLE
Make cargo compile against the nightly (url crate changes)

### DIFF
--- a/src/cargo/sources/git/source.rs
+++ b/src/cargo/sources/git/source.rs
@@ -68,7 +68,7 @@ fn ident(location: &Location) -> String {
             str::from_utf8(last).unwrap().to_str()
         }
         Remote(ref url) => {
-            let path = canonicalize_url(url.path.as_slice());
+            let path = canonicalize_url(url.path.path.as_slice());
             path.as_slice().split('/').last().unwrap().to_str()
         }
     };


### PR DESCRIPTION
On rust-lang/rust@ed47c479d73fd7b57d3b493e03c74e2932733163 (which landed yesterday via rust-lang/rust@b8ef5cf1310a7b1e31d0993885d867a6804597ad), `url.path` now returns a `Path`, not a `String`. This one-line patch makes cargo compile again (at least as of rust-lang/rust@b8ef5cf1310a7b1e31d0993885d867a6804597ad, the `crate_id` changes haven't reached me yet).
