### PR TITLE
Support for multiple and cleaner build commands

### DIFF
--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -19,7 +19,7 @@ pub struct Manifest {
     targets: Vec<Target>,
     target_dir: Path,
     sources: Vec<SourceId>,
-    build: Option<String>,
+    build: Vec<String>,
     unused_keys: Vec<String>,
 }
 
@@ -40,7 +40,7 @@ pub struct SerializedManifest {
     authors: Vec<String>,
     targets: Vec<Target>,
     target_dir: String,
-    build: Option<String>,
+    build: Option<Vec<String>>,
 }
 
 impl<E, S: Encoder<E>> Encodable<S, E> for Manifest {
@@ -54,7 +54,7 @@ impl<E, S: Encoder<E>> Encodable<S, E> for Manifest {
             authors: self.authors.clone(),
             targets: self.targets.clone(),
             target_dir: self.target_dir.display().to_str(),
-            build: self.build.clone(),
+            build: if self.build.len() == 0 { None } else { Some(self.build.clone()) },
         }.encode(s)
     }
 }
@@ -185,7 +185,7 @@ impl Show for Target {
 impl Manifest {
     pub fn new(summary: &Summary, targets: &[Target],
                target_dir: &Path, sources: Vec<SourceId>,
-               build: Option<String>) -> Manifest {
+               build: Vec<String>) -> Manifest {
         Manifest {
             summary: summary.clone(),
             authors: Vec::new(),
@@ -233,8 +233,8 @@ impl Manifest {
         self.sources.as_slice()
     }
 
-    pub fn get_build<'a>(&'a self) -> Option<&'a str> {
-        self.build.as_ref().map(|s| s.as_slice())
+    pub fn get_build<'a>(&'a self) -> &'a [String] {
+        self.build.as_slice()
     }
 
     pub fn add_unused_key(&mut self, s: String) {

--- a/src/cargo/ops/cargo_rustc.rs
+++ b/src/cargo/ops/cargo_rustc.rs
@@ -109,9 +109,8 @@ fn compile(targets: &[&Target], pkg: &Package,
     let mut cmds = Vec::new();
 
     // TODO: Should this be on the target or the package?
-    match pkg.get_manifest().get_build() {
-        Some(cmd) => cmds.push(compile_custom(pkg, cmd, cx)),
-        None => {}
+    for build_cmd in pkg.get_manifest().get_build().iter() {
+        cmds.push(compile_custom(pkg, build_cmd.as_slice(), cx));
     }
 
     // After the custom command has run, execute rustc for all targets of our

--- a/src/cargo/util/toml.rs
+++ b/src/cargo/util/toml.rs
@@ -119,7 +119,13 @@ pub struct TomlProject {
     // FIXME #54: should be a Version to be able to be Decodable'd directly.
     pub version: String,
     pub authors: Vec<String>,
-    build: Option<String>,
+    build: Option<TomlBuildCommandsList>,
+}
+
+#[deriving(Encodable,Decodable,PartialEq,Clone,Show)]
+pub enum TomlBuildCommandsList {
+    SingleBuildCommand(String),
+    MultipleBuildCommands(Vec<String>)
 }
 
 impl TomlProject {
@@ -178,7 +184,11 @@ impl TomlManifest {
                 targets.as_slice(),
                 &Path::new("target"),
                 sources,
-                project.build.clone()),
+                match project.build {
+                    Some(SingleBuildCommand(ref cmd)) => vec!(cmd.clone()),
+                    Some(MultipleBuildCommands(ref cmd)) => cmd.clone(),
+                    None => Vec::new()
+                }),
            nested_paths))
     }
 }


### PR DESCRIPTION
Closes #69

Adds a new syntax for the `build =` command:

```
build = [
    ["./configure"],
    ["make", "lib/libovr.a"],
    ["/bin/mkdir", "target"],
    ["/bin/cp", "lib/libovr.a", "target/"]
]
```

The current syntax `build = "make"` still works.

`build = [ "a", "b" ]` is forbidden because it is ambiguous.
