### PR TITLE
list `clean` command in help

### DIFF
--- a/src/bin/cargo.rs
+++ b/src/bin/cargo.rs
@@ -50,7 +50,9 @@ fn execute() {
         "--help" | "-h" | "help" | "-?" => {
             println!("Commands:");
             println!("  build          # compile the current project");
-            println!("  test           # run the tests\n");
+            println!("  test           # run the tests");
+            println!("  clean          # remove the target directory\n");
+            
 
             let (_, options) = hammer::usage::<GlobalFlags>(false);
             println!("Options (for all commands):\n\n{}", options);


### PR DESCRIPTION
There are other unnamed commands like `verify-project` but I'm unsure if they are **not** listed on purpose because they should be used directly by the user less frequently. However, the clean command seems like a command that should be listed here.

Not sure about the wording though. It could be more abstract like _remove build artifacts_ but given it's current behavior I think _remove target directory_ is somehow straight forward, too.
