### PR TITLE
Remove the src/test.rs implicit test.

### DIFF
--- a/src/cargo/util/toml.rs
+++ b/src/cargo/util/toml.rs
@@ -60,8 +60,6 @@ pub fn project_layout(root: &Path) -> Layout {
 
     try_add_files(&mut examples, root, "examples");
 
-    // support two styles of tests: src/test.rs or tests/*.rs
-    try_add_file(&mut tests, root, "src/test.rs");
     try_add_files(&mut tests, root, "tests");
 
     Layout {

--- a/tests/test_cargo_test.rs
+++ b/tests/test_cargo_test.rs
@@ -194,7 +194,7 @@ test!(external_test_implicit {
             #[test]
             fn internal_test() {}
         "#)
-        .file("src/test.rs", r#"
+        .file("tests/external.rs", r#"
             extern crate foo;
 
             #[test]


### PR DESCRIPTION
It's not unreasonable to have unittests in a separate submodule of the
crate (being called `test` or `tests`), and having them in their own
file can be very sensible. Thus, the `src/test.rs` implicit default is
likely to trip up some perfectly reasonable use-cases. There's already
the `tests/...` default, so repairing a codebase after this removal is
just moving `src/test.rs` to `tests/whatever_name_you_want.rs`.

Closes #187.
