### PR TITLE
Pass all formats via --extern for libs

### DIFF
--- a/src/cargo/ops/cargo_rustc/context.rs
+++ b/src/cargo/ops/cargo_rustc/context.rs
@@ -172,17 +172,19 @@ impl<'a, 'b> Context<'a, 'b> {
     }
 
     /// Return the exact filename of the target.
-    pub fn target_filename(&self, target: &Target) -> String {
+    pub fn target_filenames(&self, target: &Target) -> Vec<String> {
         let stem = target.file_stem();
 
+        let mut ret = Vec::new();
         if target.is_dylib() {
             let (prefix, suffix) = self.dylib(target.get_profile().is_plugin());
-            format!("{}{}{}", prefix, stem, suffix)
-        } else if target.is_rlib() {
-            format!("lib{}.rlib", stem)
-        } else {
-            unreachable!()
+            ret.push(format!("{}{}{}", prefix, stem, suffix));
         }
+        if target.is_rlib() {
+            ret.push(format!("lib{}.rlib", stem));
+        }
+        assert!(ret.len() > 0);
+        return ret;
     }
 
     /// For a package, return all targets which are registered as dependencies

--- a/src/cargo/ops/cargo_rustc/mod.rs
+++ b/src/cargo/ops/cargo_rustc/mod.rs
@@ -295,10 +295,12 @@ fn build_deps_args(dst: &mut Args, package: &Package, cx: &Context,
     dst.push(cx.deps_dir(plugin).display().to_string());
 
     for &(_, target) in cx.dep_targets(package).iter() {
-        dst.push("--extern".to_string());
-        dst.push(format!("{}={}/{}",
-                 target.get_name(),
-                 cx.deps_dir(target.get_profile().is_plugin()).display(),
-                 cx.target_filename(target)));
+        for filename in cx.target_filenames(target).iter() {
+            dst.push("--extern".to_string());
+            dst.push(format!("{}={}/{}",
+                     target.get_name(),
+                     cx.deps_dir(target.get_profile().is_plugin()).display(),
+                     filename));
+        }
     }
 }

--- a/tests/test_cargo_compile.rs
+++ b/tests/test_cargo_compile.rs
@@ -1063,6 +1063,10 @@ test!(verbose_release_build_deps {
             name = "foo"
             version = "0.0.0"
             authors = []
+
+            [[lib]]
+            name = "foo"
+            crate_type = ["dylib", "rlib"]
         "#)
         .file("foo/src/lib.rs", "");
     let output = p.cargo_process("cargo-build").arg("-v").arg("--release")
@@ -1074,7 +1078,7 @@ test!(verbose_release_build_deps {
     let hash2 = out.slice_from(pos1 + 10 + pos2 + 15).slice_to(17);
     assert_eq!(out, format!("\
 {running} `rustc {dir}{sep}foo{sep}src{sep}lib.rs --crate-name foo \
-        --crate-type lib \
+        --crate-type dylib --crate-type rlib \
         --opt-level 3 \
         --cfg ndebug \
         -C metadata=foo:-:0.0.0:-:file:{dir} \
@@ -1090,6 +1094,8 @@ test!(verbose_release_build_deps {
         --out-dir {dir}{sep}target{sep}release \
         -L {dir}{sep}target{sep}release \
         -L {dir}{sep}target{sep}release{sep}deps \
+        --extern foo={dir}{sep}target{sep}release{sep}deps/\
+                     {prefix}foo{hash1}{suffix} \
         --extern foo={dir}{sep}target{sep}release{sep}deps/libfoo{hash1}.rlib`
 {compiling} foo v0.0.0 (file:{dir})
 {compiling} test v0.0.0 (file:{dir})\n",
@@ -1098,7 +1104,9 @@ test!(verbose_release_build_deps {
                     dir = p.root().display(),
                     sep = path::SEP,
                     hash1 = hash1,
-                    hash2 = hash2).as_slice());
+                    hash2 = hash2,
+                    prefix = os::consts::DLL_PREFIX,
+                    suffix = os::consts::DLL_SUFFIX).as_slice());
 })
 
 test!(explicit_examples {


### PR DESCRIPTION
While we support the `crate_type` key in the manifest, we need to pass through
all crate types to the `--extern` flag.

Closes #177
