### PR TITLE
Add --destdir option to install.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,7 +135,7 @@ $(PKGDIR)/lib/cargo/manifest.in: $(BIN_TARGETS) Makefile
 	mv $(DISTDIR)/manifest-$(PKG_NAME).in $(PKGDIR)/lib/cargo/manifest.in
 
 install: $(PKGDIR)/lib/cargo/manifest.in
-	$(PKGDIR)/install.sh --prefix=$(PREFIX)
+	$(PKGDIR)/install.sh --prefix=$(PREFIX) --destdir=$(DESTDIR)
 
 # Setup phony tasks
 .PHONY: all clean distclean test test-unit test-integration libcargo style

--- a/src/install.sh
+++ b/src/install.sh
@@ -278,12 +278,14 @@ VAL_OPTIONS=""
 CFG_LIBDIR_RELATIVE=lib
 
 flag uninstall "only uninstall from the installation prefix"
+valopt destdir "" "set installation root"
 opt verify 1 "verify that the installed binaries run correctly"
 valopt prefix "/usr/local" "set installation prefix"
 # NB This isn't quite the same definition as in `configure`.
 # just using 'lib' instead of CFG_LIBDIR_RELATIVE
-valopt libdir "${CFG_PREFIX}/${CFG_LIBDIR_RELATIVE}" "install libraries"
-valopt mandir "${CFG_PREFIX}/share/man" "install man pages in PATH"
+valopt libdir "${CFG_DESTDIR}${CFG_PREFIX}/${CFG_LIBDIR_RELATIVE}" "install libraries"
+valopt mandir "${CFG_DESTDIR}${CFG_PREFIX}/share/man" "install man pages in PATH"
+
 
 if [ $HELP -eq 1 ]
 then
@@ -402,7 +404,7 @@ need_ok "failed to create installed manifest"
 while read p; do
 
     # Decide the destination of the file
-    FILE_INSTALL_PATH="${CFG_PREFIX}/$p"
+    FILE_INSTALL_PATH="${CFG_DESTDIR}${CFG_PREFIX}/$p"
 
     if echo "$p" | grep "^lib/" > /dev/null
     then
@@ -446,7 +448,7 @@ done < "${CFG_SRC_DIR}/${CFG_LIBDIR_RELATIVE}/cargo/manifest.in"
 if [ -z "${CFG_DISABLE_VERIFY}" ]
 then
     msg "verifying installed binaries are executable"
-    "${CFG_PREFIX}/bin/cargo" -h > /dev/null
+    "${CFG_DESTDIR}${CFG_PREFIX}/bin/cargo" -h > /dev/null
     if [ $? -ne 0 ]
     then
         ERR="can't execute installed rustc binary. "


### PR DESCRIPTION
Currently it seems like the `DESTDIR` option is ignored during the build process. This poses problems when packaging `rustc`, because it always tries to use `/` as a base path of the prefix. When packaging cargo for Arch Linux, everything should be installed into a separate directory, which content is used to create the package archive. At the moment this step requires `sudo`, which is discouraged in PKGBUILDs. Now, `make install DESTDIR=foo` prepends `DESTDIR` to all relevant paths during installation. 

This probably could be archived using `install --prefix=foo/usr/` as well, but the convention to separate prefix and destdir is rather common
