### PR TITLE
Fix some warnings with recent version of Rust

### DIFF
--- a/src/cargo/core/resolver.rs
+++ b/src/cargo/core/resolver.rs
@@ -78,7 +78,7 @@ fn resolve_deps<'a, R: Registry>(parent: &PackageId,
                 single source for a particular package name ({}).", dep)));
         }
 
-        let summary = pkgs.get(0).clone();
+        let summary = pkgs[0].clone();
         let name = summary.get_name().to_string();
         let source_id = summary.get_source_id().clone();
         let version = summary.get_version().clone();

--- a/src/cargo/ops/cargo_rustc/context.rs
+++ b/src/cargo/ops/cargo_rustc/context.rs
@@ -83,7 +83,7 @@ impl<'a, 'b> Context<'a, 'b> {
         let parts: Vec<&str> = output.trim().split('-').collect();
         assert!(parts.len() == 2, "rustc --print-file-name output has changed");
 
-        Ok((parts.get(0).to_string(), parts.get(1).to_string()))
+        Ok((parts[0].to_string(), parts[1].to_string()))
     }
 
     /// Prepare this context, ensuring that all filesystem directories are in

--- a/tests/test_cargo_compile.rs
+++ b/tests/test_cargo_compile.rs
@@ -837,8 +837,8 @@ test!(many_crate_types_old_style_lib_location {
         }
     }).collect();
     files.sort();
-    let file0 = files.get(0).as_slice();
-    let file1 = files.get(1).as_slice();
+    let file0 = files[0].as_slice();
+    let file1 = files[1].as_slice();
     println!("{} {}", file0, file1);
     assert!(file0.ends_with(".rlib") || file1.ends_with(".rlib"));
     assert!(file0.ends_with(os::consts::DLL_SUFFIX) ||
@@ -875,8 +875,8 @@ test!(many_crate_types_correct {
         }
     }).collect();
     files.sort();
-    let file0 = files.get(0).as_slice();
-    let file1 = files.get(1).as_slice();
+    let file0 = files[0].as_slice();
+    let file1 = files[1].as_slice();
     println!("{} {}", file0, file1);
     assert!(file0.ends_with(".rlib") || file1.ends_with(".rlib"));
     assert!(file0.ends_with(os::consts::DLL_SUFFIX) ||


### PR DESCRIPTION
This patch replaces `get()` calls with indexing for vectors and `str::from_utf8_lossy` with `String::from_ut8_lossy` to silence recent rustc warnings
