### PR TITLE
kill unnecessary lifetime annotations

### DIFF
--- a/src/cargo/core/dependency.rs
+++ b/src/cargo/core/dependency.rs
@@ -25,15 +25,15 @@ impl Dependency {
         })
     }
 
-    pub fn get_version_req<'a>(&'a self) -> &'a VersionReq {
+    pub fn get_version_req(&self) -> &VersionReq {
         &self.req
     }
 
-    pub fn get_name<'a>(&'a self) -> &'a str {
+    pub fn get_name(&self) -> &str {
         self.name.as_slice()
     }
 
-    pub fn get_namespace<'a>(&'a self) -> &'a SourceId {
+    pub fn get_namespace(&self) -> &SourceId {
         &self.namespace
     }
 

--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -175,11 +175,11 @@ impl Profile {
         self.debug
     }
 
-    pub fn get_env<'a>(&'a self) -> &'a str {
+    pub fn get_env(&self) -> &str {
         self.env.as_slice()
     }
 
-    pub fn get_dest<'a>(&'a self) -> Option<&'a str> {
+    pub fn get_dest(&self) -> Option<&str> {
         self.dest.as_ref().map(|d| d.as_slice())
     }
 
@@ -262,43 +262,43 @@ impl Manifest {
         }
     }
 
-    pub fn get_summary<'a>(&'a self) -> &'a Summary {
+    pub fn get_summary(&self) -> &Summary {
         &self.summary
     }
 
-    pub fn get_package_id<'a>(&'a self) -> &'a PackageId {
+    pub fn get_package_id(&self) -> &PackageId {
         self.get_summary().get_package_id()
     }
 
-    pub fn get_name<'a>(&'a self) -> &'a str {
+    pub fn get_name(&self) -> &str {
         self.get_package_id().get_name()
     }
 
-    pub fn get_version<'a>(&'a self) -> &'a Version {
+    pub fn get_version(&self) -> &Version {
         self.get_summary().get_package_id().get_version()
     }
 
-    pub fn get_authors<'a>(&'a self) -> &'a [String] {
+    pub fn get_authors(&self) -> &[String] {
         self.authors.as_slice()
     }
 
-    pub fn get_dependencies<'a>(&'a self) -> &'a [Dependency] {
+    pub fn get_dependencies(&self) -> &[Dependency] {
         self.get_summary().get_dependencies()
     }
 
-    pub fn get_targets<'a>(&'a self) -> &'a [Target] {
+    pub fn get_targets(&self) -> &[Target] {
         self.targets.as_slice()
     }
 
-    pub fn get_target_dir<'a>(&'a self) -> &'a Path {
+    pub fn get_target_dir(&self) -> &Path {
         &self.target_dir
     }
 
-    pub fn get_source_ids<'a>(&'a self) -> &'a [SourceId] {
+    pub fn get_source_ids(&self) -> &[SourceId] {
         self.sources.as_slice()
     }
 
-    pub fn get_build<'a>(&'a self) -> &'a [String] {
+    pub fn get_build(&self) -> &[String] {
         self.build.as_slice()
     }
 
@@ -306,7 +306,7 @@ impl Manifest {
         self.unused_keys.push(s)
     }
 
-    pub fn get_unused_keys<'a>(&'a self) -> &'a [String] {
+    pub fn get_unused_keys(&self) -> &[String] {
         self.unused_keys.as_slice()
     }
 }
@@ -361,11 +361,11 @@ impl Target {
         }
     }
 
-    pub fn get_name<'a>(&'a self) -> &'a str {
+    pub fn get_name(&self) -> &str {
         self.name.as_slice()
     }
 
-    pub fn get_src_path<'a>(&'a self) -> &'a Path {
+    pub fn get_src_path(&self) -> &Path {
         &self.src_path
     }
 
@@ -398,11 +398,11 @@ impl Target {
         }
     }
 
-    pub fn get_profile<'a>(&'a self) -> &'a Profile {
+    pub fn get_profile(&self) -> &Profile {
         &self.profile
     }
 
-    pub fn get_metadata<'a>(&'a self) -> Option<&'a Metadata> {
+    pub fn get_metadata(&self) -> Option<&Metadata> {
         self.metadata.as_ref()
     }
 

--- a/src/cargo/core/package.rs
+++ b/src/cargo/core/package.rs
@@ -68,43 +68,43 @@ impl Package {
         }
     }
 
-    pub fn get_manifest<'a>(&'a self) -> &'a Manifest {
+    pub fn get_manifest(&self) -> &Manifest {
         &self.manifest
     }
 
-    pub fn get_summary<'a>(&'a self) -> &'a Summary {
+    pub fn get_summary(&self) -> &Summary {
         self.manifest.get_summary()
     }
 
-    pub fn get_package_id<'a>(&'a self) -> &'a PackageId {
+    pub fn get_package_id(&self) -> &PackageId {
         self.manifest.get_package_id()
     }
 
-    pub fn get_name<'a>(&'a self) -> &'a str {
+    pub fn get_name(&self) -> &str {
         self.get_package_id().get_name()
     }
 
-    pub fn get_version<'a>(&'a self) -> &'a Version {
+    pub fn get_version(&self) -> &Version {
         self.get_package_id().get_version()
     }
 
-    pub fn get_dependencies<'a>(&'a self) -> &'a [Dependency] {
+    pub fn get_dependencies(&self) -> &[Dependency] {
         self.get_manifest().get_dependencies()
     }
 
-    pub fn get_targets<'a>(&'a self) -> &'a [Target] {
+    pub fn get_targets(&self) -> &[Target] {
         self.get_manifest().get_targets()
     }
 
-    pub fn get_manifest_path<'a>(&'a self) -> &'a Path {
+    pub fn get_manifest_path(&self) -> &Path {
         &self.manifest_path
     }
 
-    pub fn get_root<'a>(&'a self) -> Path {
+    pub fn get_root(&self) -> Path {
         self.manifest_path.dir_path()
     }
 
-    pub fn get_target_dir<'a>(&'a self) -> &'a Path {
+    pub fn get_target_dir(&self) -> &Path {
         self.manifest.get_target_dir()
     }
 
@@ -165,16 +165,16 @@ impl PackageSet {
     }
 
     /// Get a package by name out of the set
-    pub fn get<'a>(&'a self, name: &str) -> &'a Package {
+    pub fn get(&self, name: &str) -> &Package {
         self.packages.iter().find(|pkg| name == pkg.get_name())
             .expect("PackageSet.get: empty set")
     }
 
-    pub fn get_all<'a>(&'a self, names: &[&str]) -> Vec<&'a Package> {
+    pub fn get_all(&self, names: &[&str]) -> Vec<&Package> {
         names.iter().map(|name| self.get(*name) ).collect()
     }
 
-    pub fn get_packages<'a>(&'a self) -> &'a [Package] {
+    pub fn get_packages(&self) -> &[Package] {
         self.packages.as_slice()
     }
 
@@ -200,7 +200,7 @@ impl PackageSet {
         })
     }
 
-    pub fn iter<'a>(&'a self) -> slice::Items<'a, Package> {
+    pub fn iter(&self) -> slice::Items<Package> {
         self.packages.iter()
     }
 }

--- a/src/cargo/core/package_id.rs
+++ b/src/cargo/core/package_id.rs
@@ -105,15 +105,15 @@ impl PackageId {
         })
     }
 
-    pub fn get_name<'a>(&'a self) -> &'a str {
+    pub fn get_name(&self) -> &str {
         self.name.as_slice()
     }
 
-    pub fn get_version<'a>(&'a self) -> &'a semver::Version {
+    pub fn get_version(&self) -> &semver::Version {
         &self.version
     }
 
-    pub fn get_source_id<'a>(&'a self) -> &'a SourceId {
+    pub fn get_source_id(&self) -> &SourceId {
         &self.source_id
     }
 

--- a/src/cargo/core/resolver.rs
+++ b/src/cargo/core/resolver.rs
@@ -21,11 +21,11 @@ impl Resolve {
         Resolve { graph: Graph::new() }
     }
 
-    pub fn iter<'a>(&'a self) -> Nodes<'a, PackageId> {
+    pub fn iter(&self) -> Nodes<PackageId> {
         self.graph.iter()
     }
 
-    pub fn deps<'a>(&'a self, pkg: &PackageId) -> Option<Edges<'a, PackageId>> {
+    pub fn deps(&self, pkg: &PackageId) -> Option<Edges<PackageId>> {
         self.graph.edges(pkg)
     }
 }

--- a/src/cargo/core/shell.rs
+++ b/src/cargo/core/shell.rs
@@ -34,11 +34,11 @@ impl MultiShell {
         MultiShell { out: out, err: err, verbose: verbose }
     }
 
-    pub fn out<'a>(&'a mut self) -> &'a mut Shell {
+    pub fn out(&mut self) -> &mut Shell {
         &mut self.out
     }
 
-    pub fn err<'a>(&'a mut self) -> &'a mut Shell {
+    pub fn err(&mut self) -> &mut Shell {
         &mut self.err
     }
 

--- a/src/cargo/core/source.rs
+++ b/src/cargo/core/source.rs
@@ -183,7 +183,7 @@ impl SourceId {
                       Remote(Url::parse("https://example.com").unwrap()))
     }
 
-    pub fn get_location<'a>(&'a self) -> &'a Location {
+    pub fn get_location(&self) -> &Location {
         &self.location
     }
 

--- a/src/cargo/core/summary.rs
+++ b/src/cargo/core/summary.rs
@@ -20,23 +20,23 @@ impl Summary {
         }
     }
 
-    pub fn get_package_id<'a>(&'a self) -> &'a PackageId {
+    pub fn get_package_id(&self) -> &PackageId {
         &self.package_id
     }
 
-    pub fn get_name<'a>(&'a self) -> &'a str {
+    pub fn get_name(&self) -> &str {
         self.get_package_id().get_name()
     }
 
-    pub fn get_version<'a>(&'a self) -> &'a Version {
+    pub fn get_version(&self) -> &Version {
         self.get_package_id().get_version()
     }
 
-    pub fn get_source_id<'a>(&'a self) -> &'a SourceId {
+    pub fn get_source_id(&self) -> &SourceId {
         self.package_id.get_source_id()
     }
 
-    pub fn get_dependencies<'a>(&'a self) -> &'a [Dependency] {
+    pub fn get_dependencies(&self) -> &[Dependency] {
         self.dependencies.as_slice()
     }
 }

--- a/src/cargo/ops/cargo_rustc/context.rs
+++ b/src/cargo/ops/cargo_rustc/context.rs
@@ -152,7 +152,7 @@ impl<'a, 'b> Context<'a, 'b> {
     }
 
     /// Returns the appropriate directory layout for either a plugin or not.
-    pub fn layout<'a>(&'a self, plugin: bool) -> LayoutProxy<'a> {
+    pub fn layout(&self, plugin: bool) -> LayoutProxy {
         if plugin {
             LayoutProxy::new(&self.host, self.primary)
         } else {
@@ -165,7 +165,7 @@ impl<'a, 'b> Context<'a, 'b> {
     ///
     /// If `plugin` is true, the pair corresponds to the host platform,
     /// otherwise it corresponds to the target platform.
-    fn dylib<'a>(&'a self, plugin: bool) -> (&'a str, &'a str) {
+    fn dylib(&self, plugin: bool) -> (&str, &str) {
         let pair = if plugin {&self.host_dylib} else {&self.target_dylib};
         (pair.ref0().as_slice(), pair.ref1().as_slice())
     }

--- a/src/cargo/sources/git/source.rs
+++ b/src/cargo/sources/git/source.rs
@@ -51,7 +51,7 @@ impl<'a, 'b> GitSource<'a, 'b> {
         }
     }
 
-    pub fn get_namespace<'a>(&'a self) -> &'a Location {
+    pub fn get_namespace(&self) -> &Location {
         self.remote.get_location()
     }
 }
@@ -84,7 +84,7 @@ fn ident(location: &Location) -> String {
     format!("{}-{}", ident, to_hex(hasher.hash(&location.as_slice())))
 }
 
-fn strip_trailing_slash<'a>(path: &'a str) -> &'a str {
+fn strip_trailing_slash(path: &str) -> &str {
     // Remove the trailing '/' so that 'split' doesn't give us
     // an empty string, making '../foo/' and '../foo' both
     // result in the name 'foo' (#84)

--- a/src/cargo/sources/git/utils.rs
+++ b/src/cargo/sources/git/utils.rs
@@ -24,7 +24,7 @@ impl GitReference {
 }
 
 impl Str for GitReference {
-    fn as_slice<'a>(&'a self) -> &'a str {
+    fn as_slice(&self) -> &str {
         match *self {
             Master => "master",
             Other(ref string) => string.as_slice()
@@ -142,7 +142,7 @@ impl GitRemote {
         GitRemote { location: location.clone() }
     }
 
-    pub fn get_location<'a>(&'a self) -> &'a Location {
+    pub fn get_location(&self) -> &Location {
         &self.location
     }
 

--- a/src/cargo/util/config.rs
+++ b/src/cargo/util/config.rs
@@ -47,7 +47,7 @@ impl<'a> Config<'a> {
         self.home_path.join(".cargo").join("git").join("checkouts")
     }
 
-    pub fn shell<'a>(&'a mut self) -> &'a mut MultiShell {
+    pub fn shell(&mut self) -> &mut MultiShell {
         &mut *self.shell
     }
 
@@ -59,7 +59,7 @@ impl<'a> Config<'a> {
         self.jobs
     }
 
-    pub fn target<'a>(&'a self) -> Option<&'a str> {
+    pub fn target(&self) -> Option<&str> {
         self.target.as_ref().map(|t| t.as_slice())
     }
 
@@ -67,10 +67,10 @@ impl<'a> Config<'a> {
 
     pub fn set_linker(&mut self, linker: String) { self.linker = Some(linker); }
 
-    pub fn linker<'a>(&'a self) -> Option<&'a str> {
+    pub fn linker(&self) -> Option<&str> {
         self.linker.as_ref().map(|t| t.as_slice())
     }
-    pub fn ar<'a>(&'a self) -> Option<&'a str> {
+    pub fn ar(&self) -> Option<&str> {
         self.ar.as_ref().map(|t| t.as_slice())
     }
 }
@@ -119,7 +119,7 @@ impl ConfigValue {
         ConfigValue { value: List(vec!()), path: vec!() }
     }
 
-    pub fn get_value<'a>(&'a self) -> &'a ConfigValueValue {
+    pub fn get_value(&self) -> &ConfigValueValue {
         &self.value
     }
 
@@ -177,7 +177,7 @@ impl ConfigValue {
         Ok(())
     }
 
-    pub fn string<'a>(&'a self) -> CargoResult<&'a str> {
+    pub fn string(&self) -> CargoResult<&str> {
         match self.value {
             Table(_) => Err(internal("expected a string, but found a table")),
             List(_) => Err(internal("expected a string, but found a list")),
@@ -185,7 +185,7 @@ impl ConfigValue {
         }
     }
 
-    pub fn table<'a>(&'a self) -> CargoResult<&'a HashMap<String, ConfigValue>> {
+    pub fn table(&self) -> CargoResult<&HashMap<String, ConfigValue>> {
         match self.value {
             String(_) => Err(internal("expected a table, but found a string")),
             List(_) => Err(internal("expected a table, but found a list")),
@@ -193,7 +193,7 @@ impl ConfigValue {
         }
     }
 
-    pub fn list<'a>(&'a self) -> CargoResult<&'a [String]> {
+    pub fn list(&self) -> CargoResult<&[String]> {
         match self.value {
             String(_) => Err(internal("expected a list, but found a string")),
             Table(_) => Err(internal("expected a list, but found a table")),

--- a/src/cargo/util/errors.rs
+++ b/src/cargo/util/errors.rs
@@ -9,7 +9,7 @@ use TomlError = toml::Error;
 pub trait CargoError: Send {
     fn description(&self) -> String;
     fn detail(&self) -> Option<String> { None }
-    fn cause<'a>(&'a self) -> Option<&'a CargoError + Send> { None }
+    fn cause(&self) -> Option<&CargoError + Send> { None }
     fn is_human(&self) -> bool { false }
 
     fn to_error<E: FromError<Self>>(self) -> E {
@@ -78,7 +78,7 @@ impl CargoError for Box<CargoError + Send> {
         (*self).detail()
     }
 
-    fn cause<'a>(&'a self) -> Option<&'a CargoError + Send> {
+    fn cause(&self) -> Option<&CargoError + Send> {
         (*self).cause()
     }
 
@@ -184,7 +184,7 @@ impl CargoError for ProcessError {
         self.detail.clone()
     }
 
-    fn cause<'a>(&'a self) -> Option<&'a CargoError + Send> {
+    fn cause(&self) -> Option<&CargoError + Send> {
         self.cause.as_ref().map(|c| { let err: &CargoError + Send = *c; err })
     }
 
@@ -217,7 +217,7 @@ impl CargoError for ConcreteCargoError {
         self.detail.clone()
     }
 
-    fn cause<'a>(&'a self) -> Option<&'a CargoError + Send> {
+    fn cause(&self) -> Option<&CargoError + Send> {
         self.cause.as_ref().map(|c| { let err: &CargoError + Send = *c; err })
     }
 

--- a/src/cargo/util/graph.rs
+++ b/src/cargo/util/graph.rs
@@ -29,11 +29,11 @@ impl<N: Eq + Hash + Clone> Graph<N> {
             .insert(child);
     }
 
-    pub fn get_nodes<'a>(&'a self) -> &'a HashMap<N, HashSet<N>> {
+    pub fn get_nodes(&self) -> &HashMap<N, HashSet<N>> {
         &self.nodes
     }
 
-    pub fn edges<'a>(&'a self, node: &N) -> Option<Edges<'a, N>> {
+    pub fn edges(&self, node: &N) -> Option<Edges<N>> {
         self.nodes.find(node).map(|set| set.iter())
     }
 
@@ -63,7 +63,7 @@ impl<N: Eq + Hash + Clone> Graph<N> {
         marks.insert(node.clone(), Done);
     }
 
-    pub fn iter<'a>(&'a self) -> Nodes<'a, N> {
+    pub fn iter(&self) -> Nodes<N> {
         self.nodes.keys()
     }
 }

--- a/src/cargo/util/process_builder.rs
+++ b/src/cargo/util/process_builder.rs
@@ -45,7 +45,7 @@ impl ProcessBuilder {
         self
     }
 
-    pub fn get_args<'a>(&'a self) -> &'a [String] {
+    pub fn get_args(&self) -> &[String] {
         self.args.as_slice()
     }
 

--- a/src/cargo/util/toml.rs
+++ b/src/cargo/util/toml.rs
@@ -25,7 +25,7 @@ pub struct Layout {
 }
 
 impl Layout {
-    fn main<'a>(&'a self) -> Option<&'a Path> {
+    fn main(&self) -> Option<&Path> {
         self.bins.iter().find(|p| {
             match p.filename_str() {
                 Some(s) => s == "main.rs",

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -134,7 +134,7 @@ impl ProjectBuilder {
     }
 
     // TODO: return something different than a ProjectBuilder
-    pub fn build<'a>(&'a self) -> &'a ProjectBuilder {
+    pub fn build(&self) -> &ProjectBuilder {
         match self.build_with_result() {
             Err(e) => fail!(e),
             _ => return self


### PR DESCRIPTION
This commit removes lifetime annotations
that are now automatically inferred by
the compiler.
