### PR TITLE
`cargo test --bench` should compile with --opt-level=3`

### DIFF
--- a/src/bin/cargo-test.rs
+++ b/src/bin/cargo-test.rs
@@ -22,18 +22,20 @@ struct Options {
     manifest_path: Option<String>,
     jobs: Option<uint>,
     update: bool,
+    bench: bool,
     rest: Vec<String>,
 }
 
 hammer_config!(Options "Run the package's test suite", |c| {
-    c.short("jobs", 'j').short("update", 'u')
+    c.short("jobs", 'j')
+     .short("update", 'u')
 })
 
 fn main() {
     execute_main_without_stdin(execute);
 }
 
-fn execute(options: Options, shell: &mut MultiShell) -> CliResult<Option<()>> {
+fn execute(mut options: Options, shell: &mut MultiShell) -> CliResult<Option<()>> {
     let root = match options.manifest_path {
         Some(path) => Path::new(path),
         None => try!(find_project_manifest(&os::getcwd(), "Cargo.toml")
@@ -44,9 +46,16 @@ fn execute(options: Options, shell: &mut MultiShell) -> CliResult<Option<()>> {
                     }))
     };
 
+    let env = if options.bench {
+        options.rest.push("--bench".to_string());
+        "bench"
+    } else {
+        "test"
+    };
+
     let mut compile_opts = ops::CompileOptions {
         update: options.update,
-        env: "test",
+        env: env,
         shell: shell,
         jobs: options.jobs,
         target: None,

--- a/src/cargo/ops/cargo_rustc/context.rs
+++ b/src/cargo/ops/cargo_rustc/context.rs
@@ -217,7 +217,7 @@ impl<'a, 'b> Context<'a, 'b> {
 
     pub fn is_relevant_target(&self, target: &Target) -> bool {
         target.is_lib() && match self.env {
-            "test" => target.get_profile().is_compile(),
+            "test" | "bench" => target.get_profile().is_compile(),
             _ => target.get_profile().get_env() == self.env,
         }
     }

--- a/src/cargo/util/toml.rs
+++ b/src/cargo/util/toml.rs
@@ -472,7 +472,11 @@ fn normalize(lib: Option<&[TomlLibTarget]>,
 
     fn target_profiles(target: &TomlTarget,
                        dep: Option<TestDep>) -> Vec<Profile> {
-        let mut ret = vec![Profile::default_dev(), Profile::default_release()];
+        let mut ret = vec![
+            Profile::default_dev(),
+            Profile::default_release(),
+            Profile::default_bench(),
+        ];
 
         match target.test {
             Some(true) | None => ret.push(Profile::default_test()),


### PR DESCRIPTION
I'm sure I did this wrong, but before this patch, `cargo test --bench` wouldn't use `--opt-level=3`, which forced end users to manually build things for benchmarks. This does a bit of a hack to catch when we're benchmarking and build an optimized version of whatever we're benchmarking. I consider it a bit of a stopgap until we get the environment support to work.

As an alternative to this PR, I can think of two alternatives. First, we could add a top level `cargo bench`, which just uses the `bench` profile instead of `test` to get the right optimization level. Second, we could add support to run `cargo test --opt-level=3 ...` If we go this route, I suggest we use the unix standard of separating outer and inner arguments with `--`. For example, `cargo test --opt-level=3 -Zlto -- --nocapture`. Everything before `--` is passed to rustc, everything after is passed to the binary.
