### PR TITLE
Correct a typo in layout preparation

### DIFF
--- a/src/cargo/ops/cargo_rustc/layout.rs
+++ b/src/cargo/ops/cargo_rustc/layout.rs
@@ -84,7 +84,7 @@ impl Layout {
             try!(fs::rmdir_recursive(&self.old_root));
         }
         if self.old_native.exists() {
-            try!(fs::rmdir_recursive(&self.old_root));
+            try!(fs::rmdir_recursive(&self.old_native));
         }
         if self.deps.exists() {
             try!(fs::rename(&self.deps, &self.old_deps));


### PR DESCRIPTION
If a build was canceled halfway-through, this would lead to problems when the
project was rebuilt again.
