### PR TITLE
Fix crates with the same name as standard crates

### DIFF
--- a/src/cargo/ops/cargo_new.rs
+++ b/src/cargo/ops/cargo_new.rs
@@ -1,12 +1,9 @@
 use std::os;
 use std::io;
-use std::io::{fs, File, Command};
+use std::io::{fs, File};
 
-use ops;
-use util::{CargoResult, human, ProcessError, Config, ChainError, process};
+use util::{CargoResult, human, ChainError, process};
 use core::shell::MultiShell;
-use core::source::Source;
-use sources::PathSource;
 
 macro_rules! git( ($($a:expr),*) => ({
     process("git") $(.arg($a))* .exec_with_output()
@@ -18,8 +15,7 @@ pub struct NewOptions<'a> {
     pub path: &'a str,
 }
 
-pub fn new(opts: NewOptions, shell: &mut MultiShell) -> CargoResult<()> {
-    let config = try!(Config::new(shell, false, None, None));
+pub fn new(opts: NewOptions, _shell: &mut MultiShell) -> CargoResult<()> {
     let path = os::getcwd().join(opts.path);
     if path.exists() {
         return Err(human(format!("Destination `{}` already exists",

--- a/tests/test_cargo_compile.rs
+++ b/tests/test_cargo_compile.rs
@@ -1270,3 +1270,28 @@ test!(bad_cargo_toml_in_target_dir {
     assert_that(p.cargo_process("cargo-build"), execs().with_status(0));
     assert_that(process(p.bin("foo")), execs().with_status(0));
 })
+
+test!(lib_with_standard_name {
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [package]
+            name = "syntax"
+            version = "0.0.1"
+            authors = []
+        "#)
+        .file("src/lib.rs", "
+            pub fn foo() {}
+        ")
+        .file("src/main.rs", "
+            extern crate syntax;
+            fn main() { syntax::foo() }
+        ");
+
+    assert_that(p.cargo_process("cargo-build"),
+                execs().with_status(0)
+                       .with_stdout(format!("\
+{compiling} syntax v0.0.1 (file:{dir})
+",
+                       compiling = COMPILING,
+                       dir = p.root().display()).as_slice()));
+})

--- a/tests/test_cargo_test.rs
+++ b/tests/test_cargo_test.rs
@@ -390,3 +390,77 @@ test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured";
     assert!(out == format!("{}\n\n{}\n\n\n{}\n\n", head, bin, lib).as_slice() ||
             out == format!("{}\n\n{}\n\n\n{}\n\n", head, lib, bin).as_slice());
 })
+
+test!(lib_with_standard_name {
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [package]
+            name = "syntax"
+            version = "0.0.1"
+            authors = []
+
+            [[lib]]
+            name = "syntax"
+            test = false
+        "#)
+        .file("src/lib.rs", "
+            pub fn foo() {}
+        ")
+        .file("tests/test.rs", "
+            extern crate syntax;
+
+            #[test]
+            fn test() { syntax::foo() }
+        ");
+
+    assert_that(p.cargo_process("cargo-test"),
+                execs().with_status(0)
+                       .with_stdout(format!("\
+{compiling} syntax v0.0.1 (file:{dir})
+
+running 1 test
+test test ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured\n\n\
+                       ",
+                       compiling = COMPILING,
+                       dir = p.root().display()).as_slice()));
+})
+
+test!(lib_with_standard_name2 {
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [package]
+            name = "syntax"
+            version = "0.0.1"
+            authors = []
+
+            [[lib]]
+            name = "syntax"
+            test = false
+        "#)
+        .file("src/lib.rs", "
+            pub fn foo() {}
+        ")
+        .file("src/main.rs", "
+            extern crate syntax;
+
+            fn main() {}
+
+            #[test]
+            fn test() { syntax::foo() }
+        ");
+
+    assert_that(p.cargo_process("cargo-test"),
+                execs().with_status(0)
+                       .with_stdout(format!("\
+{compiling} syntax v0.0.1 (file:{dir})
+
+running 1 test
+test test ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured\n\n\
+                       ",
+                       compiling = COMPILING,
+                       dir = p.root().display()).as_slice()));
+})


### PR DESCRIPTION
The test and bin executables weren't getting the correct --extern flags when
tested and built, so the names were conflicting. This passes --extern for the
local crate to ensure the right crate is picked up.
