### PR TITLE
Improve the error message for missing dependencies.

### DIFF
--- a/src/cargo/core/resolver.rs
+++ b/src/cargo/core/resolver.rs
@@ -78,7 +78,13 @@ fn resolve_deps<'a, R: Registry>(parent: &PackageId,
         let pkgs = try!(ctx.registry.query(dep));
 
         if pkgs.is_empty() {
-            return Err(human(format!("No package named {} found", dep)));
+            return Err(human(format!("No package named `{:s}` found (required by `{:s}`).\n\
+                Location searched: {}\n\
+                Version required: {}",
+                dep.get_name(),
+                parent.get_name(),
+                dep.get_namespace(),
+                dep.get_version_req())));
         }
 
         if pkgs.len() > 1 {


### PR DESCRIPTION
I've changed the error message that appears when a dependency can't be located. With my changes, mismatches between Cargo.toml dependency names and actual dependency package names are (slightly) more apparent. This doesn't change the error that appears when a dependency has an invalid source.

Example:

``` toml
# Cargo.toml
...
[dependencies.foo]

path = "foo"
```

``` toml
# foo/Cargo.toml
[package]

name = "not_foo"
```

Previously:

```
$ cargo build
No package named Dependency { name: foo, namespace: file:/home/michael/cargo_test, req: *, transitive: true } found
```

Now:

```
$ cargo build
No package named `foo` found (required by `bar`).
Location searched: /some/folder/not_foo
Version required: *
```

In verbose mode I think it would be also nice to print a list of packages that Cargo _does_ know about. Something like: "Known packages amongst dependencies: not_foo, etc"
