### PR TITLE
Ensure LD_LIBRARY_PATH is correct for plugins

### DIFF
--- a/tests/test_cargo_compile_plugins.rs
+++ b/tests/test_cargo_compile_plugins.rs
@@ -1,0 +1,73 @@
+use std::os;
+use std::path;
+
+use support::{project, execs, basic_bin_manifest};
+use support::{RUNNING, COMPILING};
+use hamcrest::{assert_that, existing_file};
+use cargo::util::process;
+
+fn setup() {
+}
+
+test!(plugin_to_the_max {
+    let foo = project("foo")
+        .file("Cargo.toml", r#"
+            [package]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+
+            [dependencies.bar]
+            path = "../bar"
+        "#)
+        .file("src/main.rs", r#"
+            #![feature(phase)]
+            #[phase(plugin)] extern crate bar;
+
+            fn main() {}
+        "#);
+    let bar = project("bar")
+        .file("Cargo.toml", r#"
+            [package]
+            name = "bar"
+            version = "0.0.1"
+            authors = []
+
+            [[lib]]
+            name = "bar"
+            plugin = true
+
+            [dependencies.baz]
+            path = "../baz"
+        "#)
+        .file("src/lib.rs", r#"
+            #![feature(plugin_registrar)]
+
+            extern crate rustc;
+            extern crate baz;
+
+            use rustc::plugin::Registry;
+
+            #[plugin_registrar]
+            pub fn foo(reg: &mut Registry) {
+                println!("{}", baz::baz());
+            }
+        "#);
+    let baz = project("baz")
+        .file("Cargo.toml", r#"
+            [package]
+            name = "baz"
+            version = "0.0.1"
+            authors = []
+
+            [[lib]]
+            name = "baz"
+            crate_type = ["dylib"]
+        "#)
+        .file("src/lib.rs", "pub fn baz() -> int { 1 }");
+    bar.build();
+    baz.build();
+
+    assert_that(foo.cargo_process("cargo-build"),
+                execs().with_status(0));
+})

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -30,3 +30,4 @@ mod test_cargo_cross_compile;
 mod test_cargo_run;
 mod test_cargo_version;
 mod test_cargo_new;
+mod test_cargo_compile_plugins;


### PR DESCRIPTION
At runtime rustc will dlopen() plugins, and if plugins have dynamic dependencies
they're likely to be in target/deps, so we need to make sure that directory is
in the right search path.
