### PR TITLE
Base get_fingerprint on a PackageId

### DIFF
--- a/src/cargo/core/package.rs
+++ b/src/cargo/core/package.rs
@@ -12,9 +12,9 @@ use core::{
     Summary
 };
 use core::dependency::SerializedDependency;
-use util::{CargoResult, graph, Config};
+use util::{CargoResult, graph};
 use serialize::{Encoder,Encodable};
-use core::source::{SourceId, SourceSet, Source};
+use core::source::{SourceId, Source};
 
 // TODO: Is manifest_path a relic?
 #[deriving(Clone)]
@@ -115,20 +115,6 @@ impl Package {
         let mut ret = vec!(self.source_id.clone());
         ret.push_all(self.manifest.get_source_ids());
         ret
-    }
-
-    pub fn get_fingerprint(&self, config: &mut Config) -> CargoResult<String> {
-        let mut sources = self.get_source_ids();
-        // Sort the sources just to make sure we have a consistent fingerprint.
-        sources.sort_by(|a, b| {
-            let a = (&a.kind, a.location.to_string());
-            let b = (&b.kind, b.location.to_string());
-            a.cmp(&b)
-        });
-        let sources = sources.iter().map(|source_id| {
-            source_id.load(config)
-        }).collect::<Vec<_>>();
-        SourceSet::new(sources).fingerprint(self)
     }
 }
 

--- a/tests/test_cargo_compile_path_deps.rs
+++ b/tests/test_cargo_compile_path_deps.rs
@@ -161,8 +161,7 @@ test!(cargo_compile_with_transitive_dev_deps {
 
             [dev-dependencies.baz]
 
-            version = "0.5.0"
-            path = "baz"
+            git = "git://example.com/path/to/nowhere"
 
             [[lib]]
 
@@ -171,22 +170,6 @@ test!(cargo_compile_with_transitive_dev_deps {
         .file("bar/src/bar.rs", r#"
             pub fn gimme() -> &'static str {
                 "zoidberg"
-            }
-        "#)
-        .file("bar/baz/Cargo.toml", r#"
-            [project]
-
-            name = "baz"
-            version = "0.5.0"
-            authors = ["wycats@example.com"]
-
-            [[lib]]
-
-            name = "baz"
-        "#)
-        .file("bar/baz/src/baz.rs", r#"
-            pub fn gimme() -> &'static str {
-                "nope"
             }
         "#);
 

--- a/tests/test_cargo_compile_plugins.rs
+++ b/tests/test_cargo_compile_plugins.rs
@@ -1,10 +1,5 @@
-use std::os;
-use std::path;
-
-use support::{project, execs, basic_bin_manifest};
-use support::{RUNNING, COMPILING};
-use hamcrest::{assert_that, existing_file};
-use cargo::util::process;
+use support::{project, execs};
+use hamcrest::assert_that;
 
 fn setup() {
 }


### PR DESCRIPTION
The fingerprinting code was erroneously using all sources from a manifest when
calculating the fingerprint which meant that sources not yet downloaded were
attempted to be fingerprinted.

The correct source to fingerprint is located in the SourceId field of the
resolved PackageId.

Closes #259
