### PR TITLE
Print a message when a command receives a signal

### DIFF
--- a/src/bin/cargo.rs
+++ b/src/bin/cargo.rs
@@ -94,8 +94,12 @@ fn execute() {
 
             match command {
                 Ok(ExitStatus(0)) => (),
-                Ok(ExitStatus(i)) | Ok(ExitSignal(i)) => {
+                Ok(ExitStatus(i)) => {
                     handle_error(CliError::new("", i as uint), &mut shell(false))
+                }
+                Ok(ExitSignal(i)) => {
+                    let msg = format!("subcommand failed with signal: {}", i);
+                    handle_error(CliError::new(msg, 1), &mut shell(false))
                 }
                 Err(_) => handle_error(CliError::new("No such subcommand", 127), &mut shell(false))
             }
@@ -105,7 +109,7 @@ fn execute() {
 
 fn process(args: Vec<String>) -> (String, Vec<String>) {
     let mut args = Vec::from_slice(args.tail());
-    let head = args.shift().unwrap_or("--help".to_string());
+    let head = args.remove(0).unwrap_or("--help".to_string());
 
     (head, args)
 }

--- a/src/cargo/core/registry.rs
+++ b/src/cargo/core/registry.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::vec::Vec;
 use core::{Source, SourceId, SourceMap, Summary, Dependency, PackageId, Package};
 use util::{CargoResult, ChainError, Config, human};

--- a/src/cargo/core/resolver.rs
+++ b/src/cargo/core/resolver.rs
@@ -1,6 +1,5 @@
 use std::collections::HashMap;
 use std::fmt;
-use serialize::{Encodable, Encoder};
 use util::graph::{Nodes,Edges};
 
 use core::{

--- a/src/cargo/ops/cargo_rustc/fingerprint.rs
+++ b/src/cargo/ops/cargo_rustc/fingerprint.rs
@@ -5,7 +5,7 @@ use std::io::{fs, File};
 use core::{Package, Target};
 use util;
 use util::hex::short_hash;
-use util::{CargoResult, Fresh, Dirty, Freshness, Config};
+use util::{CargoResult, Fresh, Dirty, Freshness};
 
 use super::job::Job;
 use super::context::Context;


### PR DESCRIPTION
Receiving a signal is normally indicative of violent termination, so the
subcommand can't be relied upon to have printed some status information. As a
result, signals now have some extra errors printed to stderr when they fail.

Closes #261. The actual signal is still a bug, but it's an upstream rust bug.
