### PR TITLE
Move from hammer to docopt for option parsing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,13 @@ name = "cargo"
 path = "src/cargo/lib.rs"
 
 # TODO: remove all these `rev` markers once we have an official lockfile
-[dependencies.hammer]
-git = "https://github.com/wycats/hammer.rs"
-rev = "c085c639"
+[dependencies.docopt]
+git = "https://github.com/burntsushi/docopt.rs"
+rev = "0babd54a"
+
+[dependencies.docopt_macros]
+git = "https://github.com/burntsushi/docopt.rs"
+rev = "0babd54a"
 
 [dependencies.toml]
 git = "https://github.com/alexcrichton/toml-rs"

--- a/src/bin/cargo-git-checkout.rs
+++ b/src/bin/cargo-git-checkout.rs
@@ -1,12 +1,12 @@
-#![crate_name="cargo-git-checkout"]
 #![feature(phase)]
 
-extern crate cargo;
 extern crate serialize;
 extern crate url;
+#[phase(plugin, link)] extern crate log;
 
-#[phase(plugin, link)]
-extern crate hammer;
+extern crate cargo;
+extern crate docopt;
+#[phase(plugin)] extern crate docopt_macros;
 
 use cargo::{execute_main_without_stdin};
 use cargo::core::MultiShell;
@@ -15,20 +15,21 @@ use cargo::sources::git::{GitSource};
 use cargo::util::{Config, CliResult, CliError, Require, human};
 use url::Url;
 
-#[deriving(PartialEq,Clone,Decodable)]
-struct Options {
-    url: String,
-    reference: String
-}
+docopt!(Options, "
+Usage:
+    cargo-git-checkout [options] --url=URL --reference=REF
 
-hammer_config!(Options)
+Options:
+    -h, --help              Print this message
+    -v, --verbose           Use verbose output
+")
 
 fn main() {
-    execute_main_without_stdin(execute);
+    execute_main_without_stdin(execute, false);
 }
 
 fn execute(options: Options, shell: &mut MultiShell) -> CliResult<Option<()>> {
-    let Options { url, reference, .. } = options;
+    let Options { flag_url: url, flag_reference: reference, .. } = options;
 
     let url: Url = try!(from_str(url.as_slice())
                         .require(|| human(format!("The URL `{}` you passed was \

--- a/src/bin/cargo-read-manifest.rs
+++ b/src/bin/cargo-read-manifest.rs
@@ -1,30 +1,31 @@
-#![crate_name="cargo-read-manifest"]
 #![feature(phase)]
 
-extern crate cargo;
 extern crate serialize;
-
-#[phase(plugin, link)]
-extern crate hammer;
+extern crate cargo;
+extern crate docopt;
+#[phase(plugin)] extern crate docopt_macros;
 
 use cargo::{execute_main_without_stdin};
 use cargo::core::{MultiShell, Package, Source};
 use cargo::util::{CliResult, CliError};
 use cargo::sources::{PathSource};
 
-#[deriving(PartialEq,Clone,Decodable)]
-struct Options {
-    manifest_path: String
-}
+docopt!(Options, "
+Usage:
+    cargo-clean [options] --manifest-path=PATH
 
-hammer_config!(Options)
+Options:
+    -h, --help              Print this message
+    -v, --verbose           Use verbose output
+")
 
 fn main() {
-    execute_main_without_stdin(execute);
+    execute_main_without_stdin(execute, false);
 }
 
 fn execute(options: Options, _: &mut MultiShell) -> CliResult<Option<Package>> {
-    let mut source = PathSource::for_path(&Path::new(options.manifest_path.as_slice()));
+    let path = Path::new(options.flag_manifest_path.as_slice());
+    let mut source = PathSource::for_path(&path);
 
     try!(source.update().map_err(|err| CliError::new(err.description(), 1)));
 

--- a/src/bin/cargo-run.rs
+++ b/src/bin/cargo-run.rs
@@ -1,11 +1,9 @@
 #![feature(phase)]
 
-#[phase(plugin, link)]
-extern crate cargo;
 extern crate serialize;
-
-#[phase(plugin, link)]
-extern crate hammer;
+extern crate cargo;
+extern crate docopt;
+#[phase(plugin)] extern crate docopt_macros;
 
 use std::io::process::ExitStatus;
 
@@ -15,35 +13,41 @@ use cargo::core::{MultiShell};
 use cargo::util::{CliResult, CliError};
 use cargo::util::important_paths::{find_root_manifest_for_cwd};
 
-#[deriving(PartialEq,Clone,Decodable)]
-struct Options {
-    manifest_path: Option<String>,
-    jobs: Option<uint>,
-    update: bool,
-    rest: Vec<String>,
-}
+docopt!(Options, "
+Run the main binary of the local package (src/main.rs)
 
-hammer_config!(Options "Run the package's main executable", |c| {
-    c.short("jobs", 'j').short("update", 'u')
-})
+Usage:
+    cargo-run [options] [--] [<args>...]
+
+Options:
+    -h, --help              Print this message
+    -j N, --jobs N          The number of jobs to run in parallel
+    -u, --update-remotes    Update all remote packages before compiling
+    --manifest-path PATH    Path to the manifest to compile
+    -v, --verbose           Use verbose output
+
+All of the trailing arguments are passed as to the binary to run.
+",  flag_jobs: Option<uint>, flag_target: Option<String>,
+    flag_manifest_path: Option<String>)
 
 fn main() {
-    execute_main_without_stdin(execute);
+    execute_main_without_stdin(execute, true);
 }
 
 fn execute(options: Options, shell: &mut MultiShell) -> CliResult<Option<()>> {
-    let root = try!(find_root_manifest_for_cwd(options.manifest_path));
+    let root = try!(find_root_manifest_for_cwd(options.flag_manifest_path));
+    shell.set_verbose(options.flag_verbose);
 
     let mut compile_opts = ops::CompileOptions {
-        update: options.update,
+        update: options.flag_update_remotes,
         env: "compile",
         shell: shell,
-        jobs: options.jobs,
+        jobs: options.flag_jobs,
         target: None,
     };
 
     let err = try!(ops::run(&root, &mut compile_opts,
-                            options.rest.as_slice()).map_err(|err| {
+                            options.arg_args.as_slice()).map_err(|err| {
         CliError::from_boxed(err, 101)
     }));
     match err {

--- a/src/bin/cargo-rustc.rs
+++ b/src/bin/cargo-rustc.rs
@@ -1,5 +1,3 @@
-#![crate_name="cargo-rustc"]
-
 extern crate cargo;
 
 fn main() {

--- a/src/bin/cargo-version.rs
+++ b/src/bin/cargo-version.rs
@@ -1,29 +1,27 @@
-#![crate_name="cargo-version"]
 #![feature(phase)]
 
-extern crate cargo;
-
-#[phase(plugin, link)]
-extern crate hammer;
-
-#[phase(plugin, link)]
-extern crate log;
-
 extern crate serialize;
+extern crate cargo;
+extern crate docopt;
+#[phase(plugin)] extern crate docopt_macros;
+#[phase(plugin, link)] extern crate log;
 
 use std::os;
 use cargo::execute_main_without_stdin;
 use cargo::core::MultiShell;
 use cargo::util::CliResult;
 
-#[deriving(Decodable,Encodable)]
-pub struct Options;
+docopt!(Options, "
+Usage:
+    cargo-version [options]
 
-hammer_config!(Options)
+Options:
+    -h, --help              Print this message
+    -v, --verbose           Use verbose output
+")
 
- 
 fn main() {
-    execute_main_without_stdin(execute);
+    execute_main_without_stdin(execute, false);
 }
 
 fn execute(_: Options, _: &mut MultiShell) -> CliResult<Option<()>> {

--- a/src/cargo/core/shell.rs
+++ b/src/cargo/core/shell.rs
@@ -67,6 +67,10 @@ impl MultiShell {
     pub fn warn<T: ToString>(&mut self, message: T) -> IoResult<()> {
         self.err().say(message, YELLOW)
     }
+
+    pub fn set_verbose(&mut self, verbose: bool) {
+        self.verbose = verbose;
+    }
 }
 
 pub type ShellCallback<'a> = |&mut Shell|:'a -> IoResult<()>;

--- a/src/cargo/ops/cargo_rustc/context.rs
+++ b/src/cargo/ops/cargo_rustc/context.rs
@@ -1,5 +1,4 @@
 use std::collections::{HashMap, HashSet};
-use std::os;
 use std::str;
 
 use core::{SourceMap, Package, PackageId, PackageSet, Resolve, Target};

--- a/src/etc/install.sh
+++ b/src/etc/install.sh
@@ -305,7 +305,7 @@ then
     if [ -z "${CFG_UNINSTALL}" ]
     then
         msg "verifying platform can run binaries"
-        "${CFG_SRC_DIR}/bin/cargo" -h > /dev/null
+        "${CFG_SRC_DIR}/bin/cargo" -V > /dev/null
         if [ $? -ne 0 ]
         then
             err "can't execute rustc binary on this platform"
@@ -448,7 +448,7 @@ done < "${CFG_SRC_DIR}/${CFG_LIBDIR_RELATIVE}/cargo/manifest.in"
 if [ -z "${CFG_DISABLE_VERIFY}" ]
 then
     msg "verifying installed binaries are executable"
-    "${CFG_DESTDIR}${CFG_PREFIX}/bin/cargo" -h > /dev/null
+    "${CFG_DESTDIR}${CFG_PREFIX}/bin/cargo" -V > /dev/null
     if [ $? -ne 0 ]
     then
         ERR="can't execute installed rustc binary. "

--- a/tests/test_cargo_new.rs
+++ b/tests/test_cargo_new.rs
@@ -68,7 +68,11 @@ test!(simple_git {
 test!(no_argument {
     assert_that(cargo_process("cargo-new"),
                 execs().with_status(1)
-                       .with_stderr("must have a path as an argument\n"));
+                       .with_stderr("Invalid arguments.
+Usage:
+    cargo-new [options] <path>
+    cargo-new -h | --help
+"));
 })
 
 test!(existing {


### PR DESCRIPTION
The hammer library currently has some shortcomings such as the inability to
document individual options. Additionally our handling with hammer of extra
arguments is dodgy at best currently.

This commit moves the repository to BurntSushi's docopt.rs library which seems
to more feature-complete at this time. Additionally, docopt has the great
benefit of a "document once, use everywhere" documentation strategy.

This migration solves two primary issues:
- Comprehensive and useful CLI documentation
- Gracefully handling flavorful combinations of arguments in odd combinations
