### PR TITLE
Deny all warnings when building cargo

### DIFF
--- a/src/cargo/lib.rs
+++ b/src/cargo/lib.rs
@@ -3,6 +3,7 @@
 
 #![feature(macro_rules, phase)]
 #![feature(default_type_params)]
+#![deny(warnings)]
 
 extern crate debug;
 extern crate term;


### PR DESCRIPTION
This helps keep the build a little cleaner and any breakage that happens due to
rust changing will likely be mitigated by nightlies.
