### PR TITLE
Correctly preserve plugin deps

### DIFF
--- a/src/cargo/ops/cargo_rustc/context.rs
+++ b/src/cargo/ops/cargo_rustc/context.rs
@@ -233,4 +233,18 @@ impl PlatformRequirement {
             _ => PluginAndTarget,
         }
     }
+
+    pub fn is_target(&self) -> bool {
+        match *self {
+            Target | PluginAndTarget => true,
+            Plugin => false
+        }
+    }
+
+    pub fn is_plugin(&self) -> bool {
+        match *self {
+            Plugin | PluginAndTarget => true,
+            Target => false
+        }
+    }
 }

--- a/tests/test_cargo_cross_compile.rs
+++ b/tests/test_cargo_cross_compile.rs
@@ -7,7 +7,7 @@ use std::os;
 use std::path;
 
 use support::{project, execs, basic_bin_manifest};
-use support::{RUNNING, COMPILING};
+use support::{RUNNING, COMPILING, cargo_dir};
 use hamcrest::{assert_that, existing_file};
 use cargo::util::process;
 
@@ -225,6 +225,9 @@ test!(plugin_to_the_max {
 
     let target = alternate();
     assert_that(foo.cargo_process("cargo-build").arg("--target").arg(target),
+                execs().with_status(0));
+    assert_that(foo.process(cargo_dir().join("cargo-build"))
+                   .arg("--target").arg(target),
                 execs().with_status(0));
     assert_that(&foo.target_bin(target, "foo"), existing_file());
 


### PR DESCRIPTION
When copying files over from the old root to the new root on a fresh
compilation, care must be taken to preserve the correct plugin/host version of
each dependency. The previous code copied back over at most one library, but
this commit fixes this behavior by copying over all targets necessary for
compilation.
