### PR TITLE
Don't blow away target/doc

### DIFF
--- a/src/cargo/ops/cargo_doc.rs
+++ b/src/cargo/ops/cargo_doc.rs
@@ -1,9 +1,5 @@
-use std::io::fs;
-
 use ops;
 use util::CargoResult;
-use core::source::Source;
-use sources::PathSource;
 
 pub struct DocOptions<'a> {
     pub all: bool,
@@ -12,11 +8,6 @@ pub struct DocOptions<'a> {
 
 pub fn doc(manifest_path: &Path,
            options: &mut DocOptions) -> CargoResult<()> {
-    let mut src = PathSource::for_path(&manifest_path.dir_path());
-    try!(src.update());
-    let root = try!(src.get_root_package());
-    let output = root.get_manifest().get_target_dir().join("doc");
-    let _ = fs::rmdir_recursive(&output);
     try!(ops::compile(manifest_path, &mut options.compile_opts));
     Ok(())
 }

--- a/tests/test_cargo_doc.rs
+++ b/tests/test_cargo_doc.rs
@@ -1,5 +1,5 @@
-use support::{project, execs};
-use support::{COMPILING};
+use support::{project, execs, cargo_dir};
+use support::{COMPILING, FRESH};
 use hamcrest::{assert_that, existing_file, existing_dir, is_not};
 
 fn setup() {
@@ -85,11 +85,11 @@ test!(doc_twice {
         compiling = COMPILING,
         dir = p.root().display()).as_slice()));
 
-    assert_that(p.cargo_process("cargo-doc"),
+    assert_that(p.process(cargo_dir().join("cargo-doc")),
                 execs().with_status(0).with_stdout(format!("\
-{compiling} foo v0.0.1 (file:{dir})
+{fresh} foo v0.0.1 (file:{dir})
 ",
-        compiling = COMPILING,
+        fresh = FRESH,
         dir = p.root().display()).as_slice()));
 })
 
@@ -124,6 +124,18 @@ test!(doc_deps {
 {compiling} foo v0.0.1 (file:{dir})
 ",
         compiling = COMPILING,
+        dir = p.root().display()).as_slice()));
+
+    assert_that(&p.root().join("target/doc"), existing_dir());
+    assert_that(&p.root().join("target/doc/foo/index.html"), existing_file());
+    assert_that(&p.root().join("target/doc/bar/index.html"), existing_file());
+
+    assert_that(p.process(cargo_dir().join("cargo-doc")),
+                execs().with_status(0).with_stdout(format!("\
+{fresh} bar v0.0.1 (file:{dir})
+{fresh} foo v0.0.1 (file:{dir})
+",
+        fresh = FRESH,
         dir = p.root().display()).as_slice()));
 
     assert_that(&p.root().join("target/doc"), existing_dir());


### PR DESCRIPTION
The existing rustdoc behavior for working with an already-present directory is
good enough, so there's no need for cargo to help out by blowing things away.
This also makes the copy-back portion easier by just not having it.

Closes #284
