### PR TITLE
Remove duplicated ${DESTDIR}.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -118,8 +118,8 @@ $$(PKGDIR_$(1))/lib/cargo/manifest.in: all
 
 install-$(1): $$(PKGDIR_$(1))/lib/cargo/manifest.in
 	$$(PKGDIR_$(1))/install.sh \
-		--prefix="$$(DESTDIR)$$(CFG_PREFIX)" \
-		--destdir="$$(DESTDIR)" $$(MAYBE_DISABLE_VERIFY)
+		--prefix="$$(CFG_PREFIX)" \
+		--destdir="$$(DESTDIR)/" $$(MAYBE_DISABLE_VERIFY)
 endef
 $(foreach target,$(CFG_TARGET),$(eval $(call DO_DIST_TARGET,$(target))))
 


### PR DESCRIPTION
Both Makefile.in and install.sh prepended `${DESTDIR}` to `${PREFIX}` so the installation prefix became `${DESTDIR}/${DESTDIR}/${PREFIX}`. Also, the script assumes that `${DESTDIR}` ends with a slash or `${PREFIX}` starts with it so I appended a slash to `${DESTDIR}`.
