### PR TITLE
Migrate from liburl to rust-url

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,10 @@ rev = "a3c7f2c3"
 git = "https://github.com/carllerche/hamcrest-rust.git"
 rev = "05acf768"
 
+[dependencies.url]
+git = "https://github.com/servo/rust-url"
+rev = "98a28e85"
+
 [[bin]]
 name = "cargo"
 test = false

--- a/src/bin/cargo-git-checkout.rs
+++ b/src/bin/cargo-git-checkout.rs
@@ -12,7 +12,7 @@ use cargo::{execute_main_without_stdin};
 use cargo::core::MultiShell;
 use cargo::core::source::{Source, SourceId};
 use cargo::sources::git::{GitSource};
-use cargo::util::{Config, CliResult, CliError, Require, human};
+use cargo::util::{Config, CliResult, CliError, human};
 use url::Url;
 
 docopt!(Options, "
@@ -31,9 +31,10 @@ fn main() {
 fn execute(options: Options, shell: &mut MultiShell) -> CliResult<Option<()>> {
     let Options { flag_url: url, flag_reference: reference, .. } = options;
 
-    let url: Url = try!(from_str(url.as_slice())
-                        .require(|| human(format!("The URL `{}` you passed was \
-                                                   not a valid URL", url)))
+    let url: Url = try!(Url::parse(url.as_slice()).map_err(|e| {
+                            human(format!("The URL `{}` you passed was \
+                                           not a valid URL: {}", url, e))
+                        })
                         .map_err(|e| CliError::from_boxed(e, 1)));
 
     let source_id = SourceId::for_git(&url, reference.as_slice());

--- a/src/cargo/core/package_id.rs
+++ b/src/cargo/core/package_id.rs
@@ -1,5 +1,4 @@
 use semver;
-use url::Url;
 use std::hash::Hash;
 use std::fmt;
 use std::fmt::{Show,Formatter};
@@ -30,28 +29,6 @@ impl<'a> ToVersion for &'a str {
             Some(v) => Ok(v),
             None => Err(format!("cannot parse '{}' as a semver", self)),
         }
-    }
-}
-
-trait ToUrl {
-    fn to_url(self) -> Result<Url, String>;
-}
-
-impl<'a> ToUrl for &'a str {
-    fn to_url(self) -> Result<Url, String> {
-        Url::parse(self)
-    }
-}
-
-impl ToUrl for Url {
-    fn to_url(self) -> Result<Url, String> {
-        Ok(self)
-    }
-}
-
-impl<'a> ToUrl for &'a Url {
-    fn to_url(self) -> Result<Url, String> {
-        Ok(self.clone())
     }
 }
 

--- a/src/cargo/core/resolver.rs
+++ b/src/cargo/core/resolver.rs
@@ -135,7 +135,7 @@ mod test {
 
     use core::source::{SourceId, RegistryKind, GitKind, Location, Remote};
     use core::{Dependency, PackageId, Summary, Registry};
-    use util::CargoResult;
+    use util::{CargoResult, ToUrl};
 
     fn resolve<R: Registry>(pkg: &PackageId, deps: &[Dependency], registry: &mut R)
                             -> CargoResult<Vec<PackageId>> {
@@ -148,7 +148,7 @@ mod test {
 
     impl ToDep for &'static str {
         fn to_dep(self) -> Dependency {
-            let url = from_str("http://example.com").unwrap();
+            let url = "http://example.com".to_url().unwrap();
             let source_id = SourceId::new(RegistryKind, Remote(url));
             Dependency::parse(self, Some("1.0.0"), &source_id).unwrap()
         }
@@ -200,13 +200,13 @@ mod test {
     }
 
     fn dep(name: &str) -> Dependency {
-        let url = from_str("http://example.com").unwrap();
+        let url = "http://example.com".to_url().unwrap();
         let source_id = SourceId::new(RegistryKind, Remote(url));
         Dependency::parse(name, Some("1.0.0"), &source_id).unwrap()
     }
 
     fn dep_loc(name: &str, location: &str) -> Dependency {
-        let url = from_str(location).unwrap();
+        let url = location.to_url().unwrap();
         let source_id = SourceId::new(GitKind("master".to_string()), Remote(url));
         Dependency::parse(name, Some("1.0.0"), &source_id).unwrap()
     }

--- a/src/cargo/core/source.rs
+++ b/src/cargo/core/source.rs
@@ -330,13 +330,14 @@ impl Source for SourceSet {
 #[cfg(test)]
 mod tests {
     use super::{SourceId, Remote, GitKind};
+    use util::ToUrl;
 
     #[test]
     fn github_sources_equal() {
-        let loc = Remote(from_str("https://github.com/foo/bar").unwrap());
+        let loc = Remote("https://github.com/foo/bar".to_url().unwrap());
         let s1 = SourceId::new(GitKind("master".to_string()), loc);
 
-        let loc = Remote(from_str("git://github.com/foo/bar").unwrap());
+        let loc = Remote("git://github.com/foo/bar".to_url().unwrap());
         let mut s2 = SourceId::new(GitKind("master".to_string()), loc);
 
         assert_eq!(s1, s2);

--- a/src/cargo/sources/git/source.rs
+++ b/src/cargo/sources/git/source.rs
@@ -68,7 +68,8 @@ fn ident(location: &Location) -> String {
             str::from_utf8(last).unwrap().to_string()
         }
         Remote(ref url) => {
-            let path = canonicalize_url(url.path.path.as_slice());
+            let path = url.path().unwrap().connect("/");
+            let path = canonicalize_url(path.as_slice());
             path.as_slice().split('/').last().unwrap().to_string()
         }
     };
@@ -184,6 +185,7 @@ mod test {
     use url::Url;
     use core::source::Remote;
     use super::ident;
+    use util::ToUrl;
 
     #[test]
     pub fn test_url_to_path_ident_with_path() {
@@ -226,6 +228,6 @@ mod test {
     }
 
     fn url(s: &str) -> Url {
-        from_str(s).unwrap()
+        s.to_url().unwrap()
     }
 }

--- a/src/cargo/util/mod.rs
+++ b/src/cargo/util/mod.rs
@@ -9,6 +9,7 @@ pub use self::hex::{to_hex, short_hash};
 pub use self::pool::TaskPool;
 pub use self::dependency_queue::{DependencyQueue, Fresh, Dirty, Freshness};
 pub use self::graph::Graph;
+pub use self::to_url::ToUrl;
 
 pub mod graph;
 pub mod process_builder;
@@ -21,3 +22,4 @@ pub mod errors;
 pub mod hex;
 mod pool;
 mod dependency_queue;
+mod to_url;

--- a/src/cargo/util/to_url.rs
+++ b/src/cargo/util/to_url.rs
@@ -1,0 +1,34 @@
+use url;
+use url::{Url, UrlParser};
+
+pub trait ToUrl {
+    fn to_url(self) -> Result<Url, String>;
+}
+
+impl ToUrl for Url {
+    fn to_url(self) -> Result<Url, String> {
+        Ok(self)
+    }
+}
+
+impl<'a> ToUrl for &'a Url {
+    fn to_url(self) -> Result<Url, String> {
+        Ok(self.clone())
+    }
+}
+
+impl<'a> ToUrl for &'a str {
+    fn to_url(self) -> Result<Url, String> {
+        UrlParser::new().scheme_type_mapper(mapper).parse(self).map_err(|s| {
+            s.to_string()
+        })
+    }
+}
+
+fn mapper(s: &str) -> url::SchemeType {
+    match s {
+        "git" => url::RelativeScheme("9418"),
+        "ssh" => url::RelativeScheme("22"),
+        s => url::whatwg_scheme_type_mapper(s),
+    }
+}

--- a/tests/test_cargo_compile_git_deps.rs
+++ b/tests/test_cargo_compile_git_deps.rs
@@ -456,7 +456,7 @@ test!(cargo_compile_with_short_ssh_git {
         execs()
         .with_stdout("")
         .with_stderr(format!("Cargo.toml is not a valid manifest\n\n\
-                              invalid url `{}`: `url: Invalid character in scheme.\n", url)));
+                              invalid url `{}`: `Relative URL without a base\n", url)));
 })
 
 test!(two_revs_same_deps {


### PR DESCRIPTION
The standard url library is soon-to-be deprecated, and now that we're
bootstrapping it's trivial to move over to rust-url.

Closes #204
