### PR TITLE
Fix the build.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,23 +13,28 @@ path = "src/cargo/lib.rs"
 # TODO: remove all these `rev` markers once we have an official lockfile
 [dependencies.docopt]
 git = "https://github.com/burntsushi/docopt.rs"
-rev = "0babd54a"
+rev = "fd2377d"
 
 [dependencies.docopt_macros]
 git = "https://github.com/burntsushi/docopt.rs"
-rev = "0babd54a"
+rev = "fd2377d"
 
 [dependencies.toml]
 git = "https://github.com/alexcrichton/toml-rs"
-rev = "a3c7f2c3"
+rev = "7e1c1e1"
 
 [dependencies.hamcrest]
 git = "https://github.com/carllerche/hamcrest-rust.git"
-rev = "05acf768"
+rev = "c23b876"
 
 [dependencies.url]
 git = "https://github.com/servo/rust-url"
-rev = "98a28e85"
+rev = "3d54552"
+
+[dependencies.semver]
+git = "https://github.com/rust-lang/semver"
+rev = "e17191f"
+
 
 [[bin]]
 name = "cargo"


### PR DESCRIPTION
After an upstream fix in docopt, cargo now builds on rust HEAD. Also,
move to the semver crate rather than the deprecated built-in one.
