### PR TITLE
Deal with different encodings of Cargo.lock

### DIFF
--- a/src/cargo/core/resolver.rs
+++ b/src/cargo/core/resolver.rs
@@ -15,6 +15,7 @@ use semver;
 
 use util::{CargoResult, Graph, human, internal};
 
+#[deriving(PartialEq, Eq)]
 pub struct Resolve {
     graph: Graph<PackageId>,
     root: PackageId

--- a/src/cargo/util/graph.rs
+++ b/src/cargo/util/graph.rs
@@ -86,3 +86,8 @@ impl<N: fmt::Show + Eq + Hash> fmt::Show for Graph<N> {
         Ok(())
     }
 }
+
+impl<N: Eq + Hash> PartialEq for Graph<N> {
+    fn eq(&self, other: &Graph<N>) -> bool { self.nodes.eq(&other.nodes) }
+}
+impl<N: Eq + Hash> Eq for Graph<N> {}

--- a/tests/test_cargo_generate_lockfile.rs
+++ b/tests/test_cargo_generate_lockfile.rs
@@ -1,0 +1,35 @@
+use std::io::File;
+
+use support::{project, execs, cargo_dir, ResultTest};
+use support::paths::PathExt;
+use hamcrest::assert_that;
+
+fn setup() {}
+
+test!(ignores_carriage_return {
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [package]
+            name = "foo"
+            authors = []
+            version = "0.0.1"
+        "#)
+        .file("src/main.rs", r#"
+            mod a; fn main() {}
+        "#)
+        .file("src/a.rs", "");
+
+    assert_that(p.cargo_process("cargo-build"),
+                execs().with_status(0));
+
+    let lockfile = p.root().join("Cargo.lock");
+    let lock = File::open(&lockfile).read_to_string();
+    let lock = lock.assert();
+    let lock = lock.as_slice().replace("\n", "\r\n");
+    File::create(&lockfile).write_str(lock.as_slice()).assert();
+    lockfile.move_into_the_past().assert();
+    let mtime = lockfile.stat().assert().modified;
+    assert_that(p.process(cargo_dir().join("cargo-build")),
+                execs().with_status(0));
+    assert_eq!(lockfile.stat().assert().modified, mtime);
+})

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -33,3 +33,4 @@ mod test_cargo_new;
 mod test_cargo_compile_plugins;
 mod test_cargo_doc;
 mod test_cargo_freshness;
+mod test_cargo_generate_lockfile;


### PR DESCRIPTION
On windows, git will check out files with different line endings causing the
same serialized resolve to be resolved slightly differently. Instead of
comparing contents, this commit alters by testing whether the decoded resolve is
equivalent to the to-be-written resolve and only aborts writing if the two are
equal.
