### PR TITLE
Fix the output type of `staticlib`

### DIFF
--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -416,6 +416,13 @@ impl Target {
         }
     }
 
+    pub fn is_staticlib(&self) -> bool {
+        match self.kind {
+            LibTarget(ref kinds) => kinds.iter().any(|&k| k == StaticLib),
+            _ => false
+        }
+    }
+
     pub fn is_bin(&self) -> bool {
         match self.kind {
             BinTarget => true,

--- a/src/cargo/ops/cargo_rustc/context.rs
+++ b/src/cargo/ops/cargo_rustc/context.rs
@@ -191,6 +191,9 @@ impl<'a, 'b> Context<'a, 'b> {
             if target.is_rlib() {
                 ret.push(format!("lib{}.rlib", stem));
             }
+            if target.is_staticlib() {
+                ret.push(format!("lib{}.a", stem));
+            }
         }
         assert!(ret.len() > 0);
         return ret;

--- a/tests/support/paths.rs
+++ b/tests/support/paths.rs
@@ -76,11 +76,6 @@ impl PathExt for Path {
 
             let hour = 1000 * 3600;
             let mut newtime = stat.modified - hour;
-            // FIXME: this looks like a bug on windows that needs to be fixed
-            // upstream
-            if cfg!(windows) {
-                newtime = newtime * 1000;
-            }
             fs::change_file_times(path, newtime, newtime)
         }
     }

--- a/tests/test_cargo_compile.rs
+++ b/tests/test_cargo_compile.rs
@@ -1396,3 +1396,20 @@ test!(lib_with_standard_name {
                        compiling = COMPILING,
                        dir = p.root().display()).as_slice()));
 })
+
+test!(simple_staticlib {
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+              [package]
+              name = "foo"
+              authors = []
+              version = "0.0.1"
+
+              [[lib]]
+              name = "foo"
+              crate-type = ["staticlib"]
+        "#)
+        .file("src/lib.rs", "pub fn foo() {}");
+
+    assert_that(p.cargo_process("cargo-build"), execs().with_status(0));
+})


### PR DESCRIPTION
The file-naming bits weren't handling the staticlib case
