### PR TITLE
Allow documenting binary targets.

### DIFF
--- a/src/cargo/ops/cargo_doc.rs
+++ b/src/cargo/ops/cargo_doc.rs
@@ -1,5 +1,9 @@
+use std::collections::HashSet;
+
+use core::source::Source;
 use ops;
-use util::CargoResult;
+use sources::PathSource;
+use util::{CargoResult, human};
 
 pub struct DocOptions<'a> {
     pub all: bool,
@@ -8,6 +12,27 @@ pub struct DocOptions<'a> {
 
 pub fn doc(manifest_path: &Path,
            options: &mut DocOptions) -> CargoResult<()> {
+    let mut source = PathSource::for_path(&manifest_path.dir_path());
+    try!(source.update());
+    let package = try!(source.get_root_package());
+
+    let mut lib_names = HashSet::new();
+    let mut bin_names = HashSet::new();
+    for target in package.get_targets().iter().filter(|t| t.get_profile().is_doc()) {
+        if target.is_lib() {
+            assert!(lib_names.insert(target.get_name()));
+        } else {
+            assert!(bin_names.insert(target.get_name()));
+        }
+    }
+    for bin in bin_names.iter() {
+        if lib_names.contains(bin) {
+            return Err(human("Cannot document a package where a library and a \
+                              binary have the same name. Consider renaming one \
+                              or marking the target as `doc = false`"))
+        }
+    }
+
     try!(ops::compile(manifest_path, &mut options.compile_opts));
     Ok(())
 }

--- a/src/cargo/ops/cargo_rustc/mod.rs
+++ b/src/cargo/ops/cargo_rustc/mod.rs
@@ -237,12 +237,6 @@ fn prepare_rustc(package: &Package, target: &Target, crate_types: Vec<&str>,
 
 
 fn rustdoc(package: &Package, target: &Target, cx: &mut Context) -> Work {
-    // Can't document binaries, but they have a doc target listed so we can
-    // build documentation of dependencies even when `cargo doc` is run.
-    if target.is_bin() {
-        return proc() Ok(())
-    }
-
     let kind = KindTarget;
     let pkg_root = package.get_root();
     let cx_root = cx.layout(kind).proxy().dest().dir_path().join("doc");


### PR DESCRIPTION
This removes the check in the compilation phase, but adds an error if you're
documenting a library and a binary with the same name (as the rustdoc output
would conflict).

Closes #318
