### PR TITLE
Ignore Cargo.lock for libs in `cargo-new`

### DIFF
--- a/src/cargo/ops/cargo_new.rs
+++ b/src/cargo/ops/cargo_new.rs
@@ -32,7 +32,11 @@ fn mk(path: &Path, name: &str, opts: &NewOptions) -> CargoResult<()> {
 
     if opts.git {
         try!(git!("init", path));
-        try!(File::create(&path.join(".gitignore")).write(b"/target\n"));
+        let mut gitignore = "/target\n".to_string();
+        if !opts.bin {
+            gitignore.push_str("/Cargo.lock\n");
+        }
+        try!(File::create(&path.join(".gitignore")).write(gitignore.as_bytes()));
     } else {
         try!(fs::mkdir(path, io::UserRWX));
     }


### PR DESCRIPTION
The lockfile should only be checked in for bins, not libs.

Closes #304
