### PR TITLE
Fix running tests using git on systems with customized git templates

### DIFF
--- a/tests/test_cargo_compile_git_deps.rs
+++ b/tests/test_cargo_compile_git_deps.rs
@@ -30,7 +30,7 @@ fn git_repo(name: &str, callback: |ProjectBuilder| -> ProjectBuilder)
     git_project.build();
 
     log!(5, "git init");
-    try!(git_project.process("git").args(["init"]).exec_with_output());
+    try!(git_project.process("git").args(["init", "--template="]).exec_with_output());
     log!(5, "building git project");
     log!(5, "git add .");
     try!(git_project.process("git").args(["add", "."]).exec_with_output());


### PR DESCRIPTION
I customized my git repo template to default to the standard pre-commit
hook that checks for e.g. trailing whitespace and refuses to commit if
any trailing whitespace was found. This causes some of cargo's tests to
fail.

To be independent of the user's git template, create the repo for the
test without using any, by specifying an empty template.
