### PR TITLE
Lift the requirement that cargo is built with make

### DIFF
--- a/src/cargo/lib.rs
+++ b/src/cargo/lib.rs
@@ -200,7 +200,14 @@ fn handle_cause(err: &CargoError, shell: &mut MultiShell) {
 }
 
 pub fn version() -> String {
-    format!("cargo {}", env!("CFG_VERSION"))
+    format!("cargo {}", match option_env!("CFG_VERSION") {
+        Some(s) => s.to_string(),
+        None => format!("{}.{}.{}{}",
+                        env!("CARGO_PKG_VERSION_MAJOR"),
+                        env!("CARGO_PKG_VERSION_MINOR"),
+                        env!("CARGO_PKG_VERSION_PATCH"),
+                        option_env!("CARGO_PKG_VERSION_PRE").unwrap_or(""))
+    })
 }
 
 fn flags_from_args<T: FlagParser>(args: &[String],


### PR DESCRIPTION
Cargo should be able to build with cargo so others can depend on the cargo
library. This means that the one requirement of the CFG_VERSION env var will not
be available. This alters `version()` to prioritize CFG_VERSION but fall back to
the cargo-specified variables.
