### PR TITLE
Ensure env vars are set for cargo-doc

### DIFF
--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -109,11 +109,24 @@ pub struct Profile {
     opt_level: uint,
     debug: bool,
     test: bool,
+    doc: bool,
     dest: Option<String>,
     plugin: bool,
 }
 
 impl Profile {
+    fn default() -> Profile {
+        Profile {
+            env: String::new(),
+            opt_level: 0,
+            debug: false,
+            test: false,
+            doc: false,
+            dest: None,
+            plugin: false,
+        }
+    }
+
     pub fn default_dev() -> Profile {
         Profile {
             env: "compile".to_string(), // run in the default environment only
@@ -122,50 +135,45 @@ impl Profile {
             test: false, // whether or not to pass --test
             dest: None,
             plugin: false,
+            doc: false,
         }
     }
 
     pub fn default_test() -> Profile {
         Profile {
-            env: "test".to_string(), // run in the default environment only
-            opt_level: 0,
+            env: "test".to_string(),
             debug: true,
-            test: true, // whether or not to pass --test
+            test: true,
             dest: Some("test".to_string()),
-            plugin: false,
+            .. Profile::default()
         }
     }
 
     pub fn default_bench() -> Profile {
         Profile {
-            env: "bench".to_string(), // run in the default environment only
+            env: "bench".to_string(),
             opt_level: 3,
-            debug: false,
-            test: true, // whether or not to pass --test
+            test: true,
             dest: Some("bench".to_string()),
-            plugin: false,
+            .. Profile::default()
         }
     }
 
     pub fn default_release() -> Profile {
         Profile {
-            env: "release".to_string(), // run in the default environment only
+            env: "release".to_string(),
             opt_level: 3,
-            debug: false,
-            test: false, // whether or not to pass --test
             dest: Some("release".to_string()),
-            plugin: false,
+            .. Profile::default()
         }
     }
 
     pub fn default_doc() -> Profile {
         Profile {
             env: "doc".to_string(),
-            opt_level: 0,
-            debug: false,
-            test: false,
             dest: Some("doc-build".to_string()),
-            plugin: false,
+            doc: true,
+            .. Profile::default()
         }
     }
 
@@ -174,7 +182,7 @@ impl Profile {
     }
 
     pub fn is_doc(&self) -> bool {
-        self.env.as_slice() == "doc"
+        self.doc
     }
 
     pub fn is_test(&self) -> bool {
@@ -213,6 +221,11 @@ impl Profile {
 
     pub fn test(mut self, test: bool) -> Profile {
         self.test = test;
+        self
+    }
+
+    pub fn doc(mut self, doc: bool) -> Profile {
+        self.doc = doc;
         self
     }
 

--- a/src/cargo/ops/cargo_rustc/context.rs
+++ b/src/cargo/ops/cargo_rustc/context.rs
@@ -227,7 +227,8 @@ impl<'a, 'b> Context<'a, 'b> {
             // doc-all == document everything, so look for doc targets and
             //            compile targets in dependencies
             "doc-all" => target.get_profile().is_compile() ||
-                         target.get_profile().is_doc(),
+                         (target.get_profile().get_env() == "doc" &&
+                          target.get_profile().is_doc()),
             _ => target.get_profile().get_env() == self.env,
         }
     }

--- a/src/cargo/ops/cargo_rustc/mod.rs
+++ b/src/cargo/ops/cargo_rustc/mod.rs
@@ -240,7 +240,7 @@ fn rustdoc(package: &Package, target: &Target, cx: &mut Context) -> Work {
     let kind = KindTarget;
     let pkg_root = package.get_root();
     let cx_root = cx.layout(kind).proxy().dest().dir_path().join("doc");
-    let rustdoc = util::process("rustdoc").cwd(pkg_root.clone());
+    let rustdoc = process("rustdoc", package, cx).cwd(pkg_root.clone());
     let rustdoc = rustdoc.arg(target.get_src_path())
                          .arg("-o").arg(cx_root)
                          .arg("--crate-name").arg(target.get_name());

--- a/src/cargo/util/toml.rs
+++ b/src/cargo/util/toml.rs
@@ -513,7 +513,10 @@ fn normalize(libs: &[TomlLibTarget],
         }
 
         match dep {
-            Needed => ret.push(Profile::default_test().test(false)),
+            Needed => {
+                ret.push(Profile::default_test().test(false));
+                ret.push(Profile::default_doc().doc(false));
+            }
             _ => {}
         }
 

--- a/tests/support/paths.rs
+++ b/tests/support/paths.rs
@@ -75,7 +75,7 @@ impl PathExt for Path {
             let stat = try!(path.stat());
 
             let hour = 1000 * 3600;
-            let mut newtime = stat.modified - hour;
+            let newtime = stat.modified - hour;
             fs::change_file_times(path, newtime, newtime)
         }
     }


### PR DESCRIPTION
This erroneously used util::process instead of the custom process function in
the cargo_rustc module.
