### PR TITLE
LD_LIBRARY_PATH is not necessary in .travis.yml

### DIFF
--- a/guide.html
+++ b/guide.html
@@ -322,8 +322,6 @@ correct number of tests.</p>
 script:
   - cargo build --verbose
   - cargo test --verbose
-env:
-  - LD_LIBRARY_PATH=/usr/local/lib
 </code></pre>
 
 


### PR DESCRIPTION
`rustup.sh` defaults to installing in `/usr/lib`, not `/usr/lib/local`.
