### PR TITLE
Use bourne shell for rustup.sh

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
 
 <p>The easiest way to get Cargo is to get the Rust nightly build by using
 the <code>rustup</code> script:</p>
-<pre><code class="highlight shell"><span class="gp">$ </span>curl www.rust-lang.org/rustup.sh | sudo bash
+<pre><code class="highlight shell"><span class="gp">$ </span>curl www.rust-lang.org/rustup.sh | sudo sh
 </code></pre>
 
 <p>This will get you the latest Rust nightly for your platform along with


### PR DESCRIPTION
Nothing's really broken, but rustup.sh does start with `#!/bin/sh`.
