### PR TITLE
.get() -> []

### DIFF
--- a/src/cargo/ops/cargo_rustc/job_queue.rs
+++ b/src/cargo/ops/cargo_rustc/job_queue.rs
@@ -147,7 +147,7 @@ impl<'a, 'b> JobQueue<'a, 'b> {
         let id = pkg.get_package_id().clone();
 
         if stage == StageStart {
-            let fresh = fresh.combine(*self.state.get(&pkg.get_package_id()));
+            let fresh = fresh.combine(self.state[pkg.get_package_id()]);
             let msg = match fresh { Fresh => "Fresh", Dirty => "Compiling" };
             try!(config.shell().status(msg, pkg));
         }

--- a/src/cargo/util/graph.rs
+++ b/src/cargo/util/graph.rs
@@ -56,7 +56,7 @@ impl<N: Eq + Hash + Clone> Graph<N> {
 
         marks.insert(node.clone(), InProgress);
 
-        for child in self.nodes.get(node).iter() {
+        for child in self.nodes[*node].iter() {
             self.visit(child, dst, marks);
         }
 


### PR DESCRIPTION
This fixes the build, which was broken due to the warnings.
