### PR TITLE
Lock all cargo invocations with an OS semaphore.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,6 +5,7 @@ dependencies = [
  "docopt 0.6.0 (git+https://github.com/burntsushi/docopt.rs#fd2377d1c36b2671136cd36566aad5d54c2fb17e)",
  "docopt_macros 0.6.0 (git+https://github.com/burntsushi/docopt.rs#fd2377d1c36b2671136cd36566aad5d54c2fb17e)",
  "hamcrest 0.1.0 (git+https://github.com/carllerche/hamcrest-rust.git#c23b8769f20f306c59a96b22532bb09b33faa764)",
+ "ipc 0.0.1 (git+https://github.com/alexcrichton/ipc-rs#498a0dc5984b7b36e2085f4026e0c22969abcd0e)",
  "semver 0.0.1 (git+https://github.com/rust-lang/semver#e17191f51d543529a6f07e6731802b77977fcef8)",
  "toml 0.1.0 (git+https://github.com/alexcrichton/toml-rs#934e093047ae15432fcc772d4e01fdf5fd56d2fb)",
  "url 0.1.0 (git+https://github.com/servo/rust-url#678bb4d52638b1cfdab78ef8e521566c9240fb1a)",
@@ -32,6 +33,11 @@ source = "git+https://github.com/lifthrasiir/rust-encoding#b82ad2104b2d079620bd2
 name = "hamcrest"
 version = "0.1.0"
 source = "git+https://github.com/carllerche/hamcrest-rust.git#c23b8769f20f306c59a96b22532bb09b33faa764"
+
+[[package]]
+name = "ipc"
+version = "0.0.1"
+source = "git+https://github.com/alexcrichton/ipc-rs#498a0dc5984b7b36e2085f4026e0c22969abcd0e"
 
 [[package]]
 name = "semver"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,9 @@ git = "https://github.com/servo/rust-url"
 [dependencies.semver]
 git = "https://github.com/rust-lang/semver"
 
+[dependencies.ipc]
+git = "https://github.com/alexcrichton/ipc-rs"
+
 [[bin]]
 name = "cargo"
 test = false

--- a/src/cargo/lib.rs
+++ b/src/cargo/lib.rs
@@ -17,6 +17,7 @@ extern crate url;
 #[phase(plugin, link)] extern crate log;
 
 extern crate docopt;
+extern crate ipc;
 extern crate toml;
 #[cfg(test)] extern crate hamcrest;
 
@@ -30,7 +31,7 @@ use docopt::FlagParser;
 use core::{Shell, MultiShell, ShellConfig};
 use term::color::{BLACK};
 
-pub use util::{CargoError, CliError, CliResult, human};
+pub use util::{CargoError, CliError, CliResult, human, internal};
 
 macro_rules! some(
     ($e:expr) => (

--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -34,7 +34,7 @@ use ops;
 use sources::{PathSource};
 use util::config::{Config, ConfigValue};
 use util::{CargoResult, Wrap, config, internal, human, ChainError};
-use util::profile;
+use util::{profile, global_lock};
 
 pub struct CompileOptions<'a> {
     pub update: bool,
@@ -58,6 +58,8 @@ pub fn compile(manifest_path: &Path,
         return Err(human("The -u flag has been deprecated, please use the \
                           `cargo update` command instead"));
     }
+
+    let _guard = try!(global_lock(*shell));
 
     let mut source = try!(PathSource::for_path(&manifest_path.dir_path()));
     try!(source.update());

--- a/src/cargo/util/lock.rs
+++ b/src/cargo/util/lock.rs
@@ -1,0 +1,29 @@
+use term;
+use ipc::Semaphore;
+
+use util::{CargoResult, ChainError, internal};
+use core::MultiShell;
+
+#[must_use]
+pub struct Guard {
+    sem: Semaphore,
+}
+
+pub fn global_lock(shell: &mut MultiShell) -> CargoResult<Guard> {
+    let sem = try!(Semaphore::new("cargo-lock", 1).chain_error(|| {
+        internal("failed to create the OS semaphore")
+    }));
+
+    if !sem.try_acquire() {
+        try!(shell.say("Waiting for another cargo process to exit...",
+                       term::color::YELLOW));
+        sem.acquire()
+    }
+    Ok(Guard { sem: sem })
+}
+
+impl Drop for Guard {
+    fn drop(&mut self) {
+        self.sem.release();
+    }
+}

--- a/src/cargo/util/mod.rs
+++ b/src/cargo/util/mod.rs
@@ -11,6 +11,7 @@ pub use self::dependency_queue::{DependencyQueue, Fresh, Dirty, Freshness};
 pub use self::dependency_queue::Dependency;
 pub use self::graph::Graph;
 pub use self::to_url::ToUrl;
+pub use self::lock::{global_lock, Guard};
 
 pub mod graph;
 pub mod process_builder;
@@ -25,3 +26,4 @@ pub mod profile;
 mod pool;
 mod dependency_queue;
 mod to_url;
+mod lock;


### PR DESCRIPTION
Using cargo concurrently on the same system often results in badness such as
corruption of the global git database, corruption of the local target directory,
corruption of output artifacts, etc. This is a pretty rare situation, but is
quite troubling to track down when it occurs.

To prevent this badness, cargo needs some method of synchronizing with other
cargo processes. This is often done with a file lock, but sadly file locks are
difficult to use correctly on linux and other flavors of unix [1](http://0pointer.de/blog/projects/locking.html).

Instead, another mechanism, an OS semaphore, is used. Semaphores provide the
exact functionality that is required here as there's no real need to lock a file
but rather just synchronize with another process. I wrote external bindings for
these semaphores [2](https://github.com/alexcrichton/ipc-rs) instead of bundling it directly in cargo itself.

Currently only windows, linux, and OSX are supported in ipc-rs, but adding new
platforms with System V compatibility is just a matter of looking up some
constants (nothing too too hard).
