### PR TITLE
Deprecate [[lib]] in favor of [lib]

### DIFF
--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -22,7 +22,7 @@ pub struct Manifest {
     doc_dir: Path,
     sources: Vec<SourceId>,
     build: Vec<String>,
-    unused_keys: Vec<String>,
+    warnings: Vec<String>,
 }
 
 impl Show for Manifest {
@@ -298,7 +298,7 @@ impl Manifest {
             doc_dir: doc_dir.clone(),
             sources: sources,
             build: build,
-            unused_keys: Vec::new(),
+            warnings: Vec::new(),
         }
     }
 
@@ -346,12 +346,12 @@ impl Manifest {
         self.build.as_slice()
     }
 
-    pub fn add_unused_key(&mut self, s: String) {
-        self.unused_keys.push(s)
+    pub fn add_warning(&mut self, s: String) {
+        self.warnings.push(s)
     }
 
-    pub fn get_unused_keys(&self) -> &[String] {
-        self.unused_keys.as_slice()
+    pub fn get_warnings(&self) -> &[String] {
+        self.warnings.as_slice()
     }
 }
 

--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -66,8 +66,8 @@ pub fn compile(manifest_path: &Path,
     let package = try!(source.get_root_package());
     debug!("loaded package; package={}", package);
 
-    for key in package.get_manifest().get_unused_keys().iter() {
-        try!(shell.warn(format!("unused manifest key: {}", key)));
+    for key in package.get_manifest().get_warnings().iter() {
+        try!(shell.warn(key))
     }
 
     let user_configs = try!(config::all_configs(os::getcwd()));

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -492,7 +492,7 @@ pub fn basic_lib_manifest(name: &str) -> String {
         version = "0.5.0"
         authors = ["wycats@example.com"]
 
-        [[lib]]
+        [lib]
 
         name = "{}"
     "#, name, name)

--- a/tests/test_cargo_compile.rs
+++ b/tests/test_cargo_compile.rs
@@ -180,7 +180,7 @@ test!(cargo_compile_with_warnings_in_a_dep_package {
             version = "0.5.0"
             authors = ["wycats@example.com"]
 
-            [[lib]]
+            [lib]
 
             name = "bar"
         "#)
@@ -383,7 +383,7 @@ test!(cargo_compile_with_nested_deps_shorthand {
 
             baz = "0.5.0"
 
-            [[lib]]
+            [lib]
 
             name = "bar"
         "#)
@@ -401,7 +401,7 @@ test!(cargo_compile_with_nested_deps_shorthand {
             version = "0.5.0"
             authors = ["wycats@example.com"]
 
-            [[lib]]
+            [lib]
 
             name = "baz"
         "#)
@@ -459,7 +459,7 @@ test!(cargo_compile_with_nested_deps_longhand {
 
             version = "0.5.0"
 
-            [[lib]]
+            [lib]
 
             name = "bar"
         "#)
@@ -477,7 +477,7 @@ test!(cargo_compile_with_nested_deps_longhand {
             version = "0.5.0"
             authors = ["wycats@example.com"]
 
-            [[lib]]
+            [lib]
 
             name = "baz"
         "#)
@@ -933,7 +933,7 @@ test!(many_crate_types_old_style_lib_location {
             version = "0.5.0"
             authors = ["wycats@example.com"]
 
-            [[lib]]
+            [lib]
 
             name = "foo"
             crate_type = ["rlib", "dylib"]
@@ -971,7 +971,7 @@ test!(many_crate_types_correct {
             version = "0.5.0"
             authors = ["wycats@example.com"]
 
-            [[lib]]
+            [lib]
 
             name = "foo"
             crate_type = ["rlib", "dylib"]
@@ -1010,7 +1010,7 @@ test!(unused_keys {
             authors = ["wycats@example.com"]
             bulid = "foo"
 
-            [[lib]]
+            [lib]
 
             name = "foo"
         "#)
@@ -1030,7 +1030,7 @@ test!(unused_keys {
             version = "0.5.0"
             authors = ["wycats@example.com"]
 
-            [[lib]]
+            [lib]
 
             name = "foo"
             build = "foo"
@@ -1057,7 +1057,7 @@ test!(self_dependency {
 
             path = "."
 
-            [[lib]]
+            [lib]
 
             name = "test"
         "#)
@@ -1093,7 +1093,7 @@ test!(missing_lib_and_bin {
         "#);
     assert_that(p.cargo_process("cargo-build"),
                 execs().with_status(101)
-                       .with_stderr("either a [[lib]] or [[bin]] section \
+                       .with_stderr("either a [lib] or [[bin]] section \
                                      must be present\n"));
 })
 
@@ -1174,7 +1174,7 @@ test!(verbose_release_build_deps {
             version = "0.0.0"
             authors = []
 
-            [[lib]]
+            [lib]
             name = "foo"
             crate_type = ["dylib", "rlib"]
         "#)
@@ -1222,7 +1222,7 @@ test!(explicit_examples {
             version = "1.0.0"
             authors = []
 
-            [[lib]]
+            [lib]
             name = "world"
             path = "src/lib.rs"
 
@@ -1414,7 +1414,7 @@ test!(simple_staticlib {
               authors = []
               version = "0.0.1"
 
-              [[lib]]
+              [lib]
               name = "foo"
               crate-type = ["staticlib"]
         "#)
@@ -1467,4 +1467,22 @@ test!(single_lib {
         "#)
         .file("src/bar.rs", "");
     assert_that(p.cargo_process("cargo-build"), execs().with_status(0));
+})
+
+test!(deprecated_lib {
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+              [package]
+              name = "foo"
+              authors = []
+              version = "0.0.1"
+
+              [[lib]]
+              name = "foo"
+        "#)
+        .file("src/foo.rs", "");
+    assert_that(p.cargo_process("cargo-build"),
+                execs().with_status(0)
+                       .with_stderr("\
+the [[lib]] section has been deprecated in favor of [lib]\n"));
 })

--- a/tests/test_cargo_compile_git_deps.rs
+++ b/tests/test_cargo_compile_git_deps.rs
@@ -51,7 +51,7 @@ test!(cargo_compile_simple_git_dep {
                 version = "0.5.0"
                 authors = ["carlhuda@example.com"]
 
-                [[lib]]
+                [lib]
 
                 name = "dep1"
             "#)
@@ -111,7 +111,7 @@ test!(cargo_compile_git_dep_branch {
                 version = "0.5.0"
                 authors = ["carlhuda@example.com"]
 
-                [[lib]]
+                [lib]
 
                 name = "dep1"
             "#)
@@ -175,7 +175,7 @@ test!(cargo_compile_git_dep_tag {
                 version = "0.5.0"
                 authors = ["carlhuda@example.com"]
 
-                [[lib]]
+                [lib]
 
                 name = "dep1"
             "#)
@@ -244,7 +244,7 @@ test!(cargo_compile_with_nested_paths {
                 version = "0.5.0"
                 path = "vendor/dep2"
 
-                [[lib]]
+                [lib]
 
                 name = "dep1"
             "#)
@@ -262,7 +262,7 @@ test!(cargo_compile_with_nested_paths {
                 version = "0.5.0"
                 authors = ["carlhuda@example.com"]
 
-                [[lib]]
+                [lib]
 
                 name = "dep2"
             "#)
@@ -314,7 +314,7 @@ test!(cargo_compile_with_meta_package {
                 version = "0.5.0"
                 authors = ["carlhuda@example.com"]
 
-                [[lib]]
+                [lib]
 
                 name = "dep1"
             "#)
@@ -330,7 +330,7 @@ test!(cargo_compile_with_meta_package {
                 version = "0.5.0"
                 authors = ["carlhuda@example.com"]
 
-                [[lib]]
+                [lib]
 
                 name = "dep2"
             "#)
@@ -490,7 +490,7 @@ test!(recompilation {
                 version = "0.5.0"
                 authors = ["carlhuda@example.com"]
 
-                [[lib]]
+                [lib]
                 name = "bar"
             "#)
             .file("src/bar.rs", r#"
@@ -593,7 +593,7 @@ test!(update_with_shared_deps {
                 version = "0.5.0"
                 authors = ["carlhuda@example.com"]
 
-                [[lib]]
+                [lib]
                 name = "bar"
             "#)
             .file("src/bar.rs", r#"

--- a/tests/test_cargo_compile_path_deps.rs
+++ b/tests/test_cargo_compile_path_deps.rs
@@ -42,7 +42,7 @@ test!(cargo_compile_with_nested_deps_shorthand {
             version = "0.5.0"
             path = "baz"
 
-            [[lib]]
+            [lib]
 
             name = "bar"
         "#)
@@ -60,7 +60,7 @@ test!(cargo_compile_with_nested_deps_shorthand {
             version = "0.5.0"
             authors = ["wycats@example.com"]
 
-            [[lib]]
+            [lib]
 
             name = "baz"
         "#)
@@ -201,7 +201,7 @@ test!(cargo_compile_with_transitive_dev_deps {
 
             git = "git://example.com/path/to/nowhere"
 
-            [[lib]]
+            [lib]
 
             name = "bar"
         "#)
@@ -252,7 +252,7 @@ test!(no_rebuild_dependency {
             version = "0.5.0"
             authors = ["wycats@example.com"]
 
-            [[lib]] name = "bar"
+            [lib] name = "bar"
         "#)
         .file("bar/src/bar.rs", r#"
             pub fn bar() {}
@@ -311,7 +311,7 @@ test!(deep_dependencies_trigger_rebuild {
             version = "0.5.0"
             authors = ["wycats@example.com"]
 
-            [[lib]]
+            [lib]
             name = "bar"
             [dependencies]
             baz = "0.5.0"
@@ -327,7 +327,7 @@ test!(deep_dependencies_trigger_rebuild {
             version = "0.5.0"
             authors = ["wycats@example.com"]
 
-            [[lib]]
+            [lib]
             name = "baz"
         "#)
         .file("baz/src/baz.rs", r#"
@@ -413,7 +413,7 @@ test!(no_rebuild_two_deps {
             version = "0.5.0"
             authors = ["wycats@example.com"]
 
-            [[lib]]
+            [lib]
             name = "bar"
             [dependencies]
             baz = "0.5.0"
@@ -428,7 +428,7 @@ test!(no_rebuild_two_deps {
             version = "0.5.0"
             authors = ["wycats@example.com"]
 
-            [[lib]]
+            [lib]
             name = "baz"
         "#)
         .file("baz/src/baz.rs", r#"
@@ -481,7 +481,7 @@ test!(nested_deps_recompile {
             version = "0.5.0"
             authors = ["wycats@example.com"]
 
-            [[lib]]
+            [lib]
 
             name = "bar"
         "#)
@@ -520,7 +520,7 @@ test!(error_message_for_missing_manifest {
 
             path = "src/bar"
 
-            [[lib]]
+            [lib]
 
             name = "foo"
         "#)

--- a/tests/test_cargo_compile_plugins.rs
+++ b/tests/test_cargo_compile_plugins.rs
@@ -12,7 +12,7 @@ test!(plugin_to_the_max {
             version = "0.0.1"
             authors = []
 
-            [[lib]]
+            [lib]
             name = "foo_lib"
 
             [dependencies.bar]
@@ -38,7 +38,7 @@ test!(plugin_to_the_max {
             version = "0.0.1"
             authors = []
 
-            [[lib]]
+            [lib]
             name = "bar"
             plugin = true
 
@@ -65,7 +65,7 @@ test!(plugin_to_the_max {
             version = "0.0.1"
             authors = []
 
-            [[lib]]
+            [lib]
             name = "baz"
             crate_type = ["dylib"]
         "#)

--- a/tests/test_cargo_cross_compile.rs
+++ b/tests/test_cargo_cross_compile.rs
@@ -120,7 +120,7 @@ test!(plugin_deps {
             version = "0.0.1"
             authors = []
 
-            [[lib]]
+            [lib]
             name = "bar"
             plugin = true
         "#)
@@ -198,7 +198,7 @@ test!(plugin_to_the_max {
             version = "0.0.1"
             authors = []
 
-            [[lib]]
+            [lib]
             name = "bar"
             plugin = true
 
@@ -317,7 +317,7 @@ test!(plugin_with_extra_dylib_dep {
             version = "0.0.1"
             authors = []
 
-            [[lib]]
+            [lib]
             name = "bar"
             plugin = true
 
@@ -344,7 +344,7 @@ test!(plugin_with_extra_dylib_dep {
             version = "0.0.1"
             authors = []
 
-            [[lib]]
+            [lib]
             name = "baz"
             crate_type = ["dylib"]
         "#)

--- a/tests/test_cargo_run.rs
+++ b/tests/test_cargo_run.rs
@@ -104,7 +104,7 @@ test!(run_dylib_dep {
             version = "0.0.1"
             authors = []
 
-            [[lib]]
+            [lib]
             name = "bar"
             crate-type = ["dylib"]
         "#)

--- a/tests/test_cargo_test.rs
+++ b/tests/test_cargo_test.rs
@@ -223,7 +223,7 @@ test!(test_with_deep_lib_dep {
             [dependencies.foo]
             path = "../foo"
 
-            [[lib]]
+            [lib]
             name = "bar"
             doctest = false
         "#)
@@ -466,7 +466,7 @@ test!(lib_bin_same_name {
             version = "0.0.1"
             authors = []
 
-            [[lib]]
+            [lib]
             name = "foo"
             [[bin]]
             name = "foo"
@@ -569,7 +569,7 @@ test!(lib_with_standard_name2 {
             version = "0.0.1"
             authors = []
 
-            [[lib]]
+            [lib]
             name = "syntax"
             test = false
             doctest = false
@@ -636,7 +636,7 @@ test!(test_dylib {
             version = "0.0.1"
             authors = []
 
-            [[lib]]
+            [lib]
             name = "foo"
             crate_type = ["dylib"]
 
@@ -663,7 +663,7 @@ test!(test_dylib {
             version = "0.0.1"
             authors = []
 
-            [[lib]]
+            [lib]
             name = "bar"
             crate_type = ["dylib"]
         "#)


### PR DESCRIPTION
The syntax was originally chosen to perhaps allow multiple libraries in the future, but that is less and less likely to happen at this point. This commit deprecates the now-misleading `[[lib]]` in favor of `[lib]` to indicate that only one can be present.

This does not start allowing `[bin]` or `[example]` and such as I felt that it was too many ways to specify what's essentially the same thing. This also as a bonus allows a top-level `bin = []` to completely opt-out of binary inference (as well as for tests and examples).

Closes #327 
