### PR TITLE
Cargo command help

### DIFF
--- a/src/bin/cargo-build.rs
+++ b/src/bin/cargo-build.rs
@@ -19,7 +19,7 @@ docopt!(Options, "
 Compile a local package and all of its dependencies
 
 Usage:
-    cargo-build [options]
+    cargo build [options]
 
 Options:
     -h, --help              Print this message

--- a/src/bin/cargo-clean.rs
+++ b/src/bin/cargo-clean.rs
@@ -18,7 +18,7 @@ docopt!(Options, "
 Remove artifacts that cargo has generated in the past
 
 Usage:
-    cargo-clean [options]
+    cargo clean [options]
 
 Options:
     -h, --help              Print this message

--- a/src/bin/cargo-doc.rs
+++ b/src/bin/cargo-doc.rs
@@ -15,7 +15,7 @@ docopt!(Options, "
 Build a package's documentation
 
 Usage:
-    cargo-doc [options]
+    cargo doc [options]
 
 Options:
     -h, --help              Print this message

--- a/src/bin/cargo-generate-lockfile.rs
+++ b/src/bin/cargo-generate-lockfile.rs
@@ -17,7 +17,7 @@ docopt!(Options, "
 Generate the lockfile for a project
 
 Usage:
-    cargo-generate-lockfile [options]
+    cargo generate-lockfile [options]
 
 Options:
     -h, --help              Print this message

--- a/src/bin/cargo-git-checkout.rs
+++ b/src/bin/cargo-git-checkout.rs
@@ -16,7 +16,7 @@ use cargo::util::{Config, CliResult, CliError, human, ToUrl};
 
 docopt!(Options, "
 Usage:
-    cargo-git-checkout [options] --url=URL --reference=REF
+    cargo git-checkout [options] --url=URL --reference=REF
 
 Options:
     -h, --help              Print this message

--- a/src/bin/cargo-new.rs
+++ b/src/bin/cargo-new.rs
@@ -15,8 +15,8 @@ docopt!(Options, "
 Create a new cargo package at <path>
 
 Usage:
-    cargo-new [options] <path>
-    cargo-new -h | --help
+    cargo new [options] <path>
+    cargo new -h | --help
 
 Options:
     -h, --help          Print this message

--- a/src/bin/cargo-read-manifest.rs
+++ b/src/bin/cargo-read-manifest.rs
@@ -12,7 +12,7 @@ use cargo::sources::{PathSource};
 
 docopt!(Options, "
 Usage:
-    cargo-clean [options] --manifest-path=PATH
+    cargo clean [options] --manifest-path=PATH
 
 Options:
     -h, --help              Print this message

--- a/src/bin/cargo-run.rs
+++ b/src/bin/cargo-run.rs
@@ -17,7 +17,7 @@ docopt!(Options, "
 Run the main binary of the local package (src/main.rs)
 
 Usage:
-    cargo-run [options] [--] [<args>...]
+    cargo run [options] [--] [<args>...]
 
 Options:
     -h, --help              Print this message

--- a/src/bin/cargo-test.rs
+++ b/src/bin/cargo-test.rs
@@ -17,7 +17,7 @@ docopt!(Options, "
 Execute all unit and integration tests of a local package
 
 Usage:
-    cargo-test [options] [--] [<args>...]
+    cargo test [options] [--] [<args>...]
 
 Options:
     -h, --help              Print this message

--- a/src/bin/cargo-update.rs
+++ b/src/bin/cargo-update.rs
@@ -17,7 +17,7 @@ docopt!(Options, "
 Update dependencies as recorded in the local lock file.
 
 Usage:
-    cargo-update [options] [<name>]
+    cargo update [options] [<name>]
 
 Options:
     -h, --help              Print this message

--- a/src/bin/cargo-verify-project.rs
+++ b/src/bin/cargo-verify-project.rs
@@ -8,7 +8,7 @@ use std::os::{args, set_exit_status};
 use getopts::{reqopt, getopts};
 
 /**
-    cargo-verify-project --manifest=LOCATION
+    cargo verify-project --manifest=LOCATION
 */
 
 fn main() {

--- a/src/bin/cargo-version.rs
+++ b/src/bin/cargo-version.rs
@@ -13,7 +13,7 @@ use cargo::util::CliResult;
 
 docopt!(Options, "
 Usage:
-    cargo-version [options]
+    cargo version [options]
 
 Options:
     -h, --help              Print this message


### PR DESCRIPTION
`cargo <command> help` shows the real binary from src/bin and not the "user command".

Example:

```
$  cargo new -h
Create a new cargo package at <path>

Usage:
    cargo-new [options] <path>
    cargo-new -h | --help

Options:
    -h, --help          Print this message
    --git               Initialize a new git repository with a .gitignore
    --bin               Use a binary instead of a library template
    -v, --verbose       Use verbose output
```

This PR changes every Usage section to use the "user command".

Example:

```
$  cargo new -h
Create a new cargo package at <path>

Usage:
    cargo new [options] <path>
    cargo new -h | --help

Options:
    -h, --help          Print this message
    --git               Initialize a new git repository with a .gitignore
    --bin               Use a binary instead of a library template
    -v, --verbose       Use verbose output
```
