### PR TITLE
If --target is specified, pass that to build commands

### DIFF
--- a/src/cargo/ops/cargo_rustc/context.rs
+++ b/src/cargo/ops/cargo_rustc/context.rs
@@ -48,7 +48,9 @@ impl<'a, 'b> Context<'a, 'b> {
             let (dylib, _) = try!(Context::filename_parts(None));
             dylib
         };
-        let (rustc_version, target_triple) = try!(Context::rustc_version());
+        let (rustc_version, rustc_host) = try!(Context::rustc_version());
+        let target_triple = config.target().map(|s| s.to_string());
+        let target_triple = target_triple.unwrap_or(rustc_host);
         Ok(Context {
             rustc_version: rustc_version,
             target_triple: target_triple,

--- a/tests/test_cargo_compile_git_deps.rs
+++ b/tests/test_cargo_compile_git_deps.rs
@@ -919,7 +919,7 @@ test!(dep_with_changed_submodule {
 
     let mut file = File::create(&git_project.root().join(".gitmodules"));
     file.write_str(format!("[submodule \"src\"]\n\tpath = src\n\turl={}",
-                           git_project3.url()).as_slice());
+                           git_project3.url()).as_slice()).assert();
 
     git_project.process("git").args(["submodule", "sync"]).exec_with_output().assert();
     git_project.process("git").args(["fetch"]).cwd(git_project.root().join("src"))

--- a/tests/test_cargo_cross_compile.rs
+++ b/tests/test_cargo_cross_compile.rs
@@ -32,9 +32,31 @@ fn alternate() -> &'static str {
 test!(simple_cross {
     if disabled() { return }
 
+    let mut build = project("builder");
+    build = build
+        .file("Cargo.toml", r#"
+            [project]
+            name = "foo"
+            version = "0.5.0"
+            authors = ["wycats@example.com"]
+        "#)
+        .file("src/main.rs", format!(r#"
+            fn main() {{
+                assert_eq!(std::os::getenv("TARGET").unwrap().as_slice(), "{}");
+            }}
+        "#, alternate()).as_slice());
+    assert_that(build.cargo_process("cargo-build"),
+                execs().with_status(0));
+
     let p = project("foo")
-        .file("Cargo.toml", basic_bin_manifest("foo").as_slice())
-        .file("src/foo.rs", r#"
+        .file("Cargo.toml", format!(r#"
+            [package]
+            name = "foo"
+            version = "0.0.0"
+            authors = []
+            build = '{}'
+        "#, build.bin("foo").display()))
+        .file("src/main.rs", r#"
             use std::os;
             fn main() {
                 assert_eq!(os::consts::ARCH, "x86");


### PR DESCRIPTION
0c834d7b accidentally broke this by favoring rustc's target triple over the
actual target triple.
