### PR TITLE
Always generate a lockfile with dev-dependencies

### DIFF
--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -91,7 +91,7 @@ pub fn compile(manifest_path: &Path,
         }
 
         let resolved = try!(resolver::resolve(package.get_package_id(),
-                                              dependencies.as_slice(),
+                                              package.get_dependencies(),
                                               &mut registry));
 
         try!(registry.add_overrides(override_ids));


### PR DESCRIPTION
Previously an invocation of `cargo build` would generate a lockfile _without_
dev dependencies, but an invocation of `cargo test` would generate a lockfile
_with_ dependencies. This causes odd problems and diffs with the lockfile.

This commit switches the resolve-to-be-a-lockfile to using all dependencies of a
package, while the resolve-to-be-compiled continues to use just the dependencies
needed for the current build.
