### PR TITLE
Remove $ from lines in readme to improve copyability

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ Cargo has nightlies available for use. The cargo source is not always guaranteed
 to compile on rust master as it may lag behind by a day or two. Nightlies,
 however, will run regardless of this fact!
 
-```
-$ triple=x86_64-unknown-linux-gnu
-$ curl -O http://static.rust-lang.org/cargo-dist/cargo-nightly-$triple.tar.gz
-$ tar xf cargo-nightly-$triple.tar.gz
-$ ./cargo-nightly-$triple/install.sh
+```sh
+triple=x86_64-unknown-linux-gnu
+curl -O http://static.rust-lang.org/cargo-dist/cargo-nightly-$triple.tar.gz
+tar xf cargo-nightly-$triple.tar.gz
+./cargo-nightly-$triple/install.sh
 ```
 
 Nightlies are available for the following triples:
@@ -30,12 +30,12 @@ as well as MSYS. The installation script needs to be run inside the MSYS shell.
 
 Cargo can be compiled like many other standard unix-like projects:
 
-```
-$ git clone https://github.com/rust-lang/cargo
-$ cd cargo
-$ ./configure
-$ make
-$ make install
+```sh
+git clone https://github.com/rust-lang/cargo
+cd cargo
+./configure
+make
+make install
 ```
 
 More options can be discovered through `./configure`, such as compiling cargo


### PR DESCRIPTION
When a $ is present, it prevents someone from easily copying and pasting the whole block.
