### PR TITLE
Don't build docs/tests into separate dirs

### DIFF
--- a/src/cargo/ops/cargo_rustc/mod.rs
+++ b/src/cargo/ops/cargo_rustc/mod.rs
@@ -246,7 +246,7 @@ fn prepare_rustc(package: &Package, target: &Target, crate_types: Vec<&str>,
 fn rustdoc(package: &Package, target: &Target, cx: &mut Context) -> Work {
     let kind = KindTarget;
     let pkg_root = package.get_root();
-    let cx_root = cx.layout(kind).proxy().dest().dir_path().join("doc");
+    let cx_root = cx.layout(kind).proxy().dest().join("doc");
     let rustdoc = process("rustdoc", package, cx).cwd(pkg_root.clone());
     let rustdoc = rustdoc.arg(target.get_src_path())
                          .arg("-o").arg(cx_root)

--- a/tests/test_cargo_bench.rs
+++ b/tests/test_cargo_bench.rs
@@ -38,7 +38,7 @@ test!(cargo_bench_simple {
     assert_that(p.process(cargo_dir().join("cargo-bench")),
         execs().with_stdout(format!("\
 {} foo v0.5.0 ({})
-{} target[..]bench[..]foo
+{} target[..]release[..]foo
 
 running 1 test
 test bench_hello ... bench:         0 ns/iter (+/- 0)
@@ -63,7 +63,7 @@ test!(cargo_bench_verbose {
         execs().with_stdout(format!("\
 {running} `rustc src[..]foo.rs [..]`
 {compiling} foo v0.5.0 ({url})
-{running} `[..]target[..]bench[..]foo-[..] hello --bench`
+{running} `[..]target[..]release[..]foo-[..] hello --bench`
 
 running 1 test
 test bench_hello ... bench:         0 ns/iter (+/- 0)
@@ -134,7 +134,7 @@ test!(cargo_bench_failing_test {
     assert_that(p.process(cargo_dir().join("cargo-bench")),
         execs().with_stdout(format!("\
 {} foo v0.5.0 ({})
-{} target[..]bench[..]foo
+{} target[..]release[..]foo
 
 running 1 test
 test bench_hello ... ",
@@ -185,14 +185,14 @@ test!(bench_with_lib_dep {
     assert_that(p.cargo_process("cargo-bench"),
         execs().with_stdout(format!("\
 {} foo v0.0.1 ({})
-{running} target[..]bench[..]baz-[..]
+{running} target[..]release[..]baz-[..]
 
 running 1 test
 test bin_bench ... bench:         0 ns/iter (+/- 0)
 
 test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured
 
-{running} target[..]bench[..]foo
+{running} target[..]release[..]foo
 
 running 1 test
 test lib_bench ... bench:         0 ns/iter (+/- 0)
@@ -300,14 +300,14 @@ test!(external_bench_explicit {
     assert_that(p.cargo_process("cargo-bench"),
         execs().with_stdout(format!("\
 {} foo v0.0.1 ({})
-{running} target[..]bench[..]bench-[..]
+{running} target[..]release[..]bench-[..]
 
 running 1 test
 test external_bench ... bench:         0 ns/iter (+/- 0)
 
 test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured
 
-{running} target[..]bench[..]foo-[..]
+{running} target[..]release[..]foo-[..]
 
 running 1 test
 test internal_bench ... bench:         0 ns/iter (+/- 0)
@@ -351,14 +351,14 @@ test!(external_bench_implicit {
     assert_that(p.cargo_process("cargo-bench"),
         execs().with_stdout(format!("\
 {} foo v0.0.1 ({})
-{running} target[..]bench[..]external-[..]
+{running} target[..]release[..]external-[..]
 
 running 1 test
 test external_bench ... bench:         0 ns/iter (+/- 0)
 
 test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured
 
-{running} target[..]bench[..]foo-[..]
+{running} target[..]release[..]foo-[..]
 
 running 1 test
 test internal_bench ... bench:         0 ns/iter (+/- 0)
@@ -411,7 +411,7 @@ test!(pass_through_command_line {
                 execs().with_status(0)
                        .with_stdout(format!("\
 {compiling} foo v0.0.1 ({dir})
-{running} target[..]bench[..]foo
+{running} target[..]release[..]foo
 
 running 1 test
 test bar ... bench:         0 ns/iter (+/- 0)
@@ -433,7 +433,7 @@ test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
                 execs().with_status(0)
                        .with_stdout(format!("\
 {compiling} foo v0.0.1 ({dir})
-{running} target[..]bench[..]foo
+{running} target[..]release[..]foo
 
 running 1 test
 test foo ... bench:         0 ns/iter (+/- 0)
@@ -502,14 +502,14 @@ test!(lib_bin_same_name {
     assert_that(p.cargo_process("cargo-bench"),
         execs().with_stdout(format!("\
 {} foo v0.0.1 ({})
-{running} target[..]bench[..]foo-[..]
+{running} target[..]release[..]foo-[..]
 
 running 1 test
 test [..] ... bench:         0 ns/iter (+/- 0)
 
 test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured
 
-{running} target[..]bench[..]foo-[..]
+{running} target[..]release[..]foo-[..]
 
 running 1 test
 test [..] ... bench:         0 ns/iter (+/- 0)
@@ -557,14 +557,14 @@ test!(lib_with_standard_name {
                 execs().with_status(0)
                        .with_stdout(format!("\
 {compiling} syntax v0.0.1 ({dir})
-{running} target[..]bench[..]bench-[..]
+{running} target[..]release[..]bench-[..]
 
 running 1 test
 test bench ... bench:         0 ns/iter (+/- 0)
 
 test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured
 
-{running} target[..]bench[..]syntax-[..]
+{running} target[..]release[..]syntax-[..]
 
 running 1 test
 test foo_bench ... bench:         0 ns/iter (+/- 0)
@@ -613,7 +613,7 @@ test!(lib_with_standard_name2 {
                 execs().with_status(0)
                        .with_stdout(format!("\
 {compiling} syntax v0.0.1 ({dir})
-{running} target[..]bench[..]syntax-[..]
+{running} target[..]release[..]syntax-[..]
 
 running 1 test
 test bench ... bench:         0 ns/iter (+/- 0)
@@ -643,7 +643,7 @@ test!(bin_there_for_integration {
             use std::io::Command;
             #[bench]
             fn bench_bench(_b: &mut test::Bencher) {
-                let status = Command::new("target/bench/foo").status().unwrap();
+                let status = Command::new("target/release/foo").status().unwrap();
                 assert!(status.matches_exit_status(1));
             }
         "#);
@@ -708,14 +708,14 @@ test!(bench_dylib {
                        .with_stdout(format!("\
 {compiling} bar v0.0.1 ({dir})
 {compiling} foo v0.0.1 ({dir})
-{running} target[..]bench[..]bench-[..]
+{running} target[..]release[..]bench-[..]
 
 running 1 test
 test foo ... bench:         0 ns/iter (+/- 0)
 
 test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured
 
-{running} target[..]bench[..]foo-[..]
+{running} target[..]release[..]foo-[..]
 
 running 1 test
 test foo ... bench:         0 ns/iter (+/- 0)
@@ -738,14 +738,14 @@ test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
                        .with_stdout(format!("\
 {fresh} bar v0.0.1 ({dir})
 {fresh} foo v0.0.1 ({dir})
-{running} target[..]bench[..]bench-[..]
+{running} target[..]release[..]bench-[..]
 
 running 1 test
 test foo ... bench:         0 ns/iter (+/- 0)
 
 test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured
 
-{running} target[..]bench[..]foo-[..]
+{running} target[..]release[..]foo-[..]
 
 running 1 test
 test foo ... bench:         0 ns/iter (+/- 0)
@@ -783,7 +783,7 @@ test!(bench_twice_with_build_cmd {
                 execs().with_status(0)
                        .with_stdout(format!("\
 {compiling} foo v0.0.1 ({dir})
-{running} target[..]bench[..]foo-[..]
+{running} target[..]release[..]foo-[..]
 
 running 1 test
 test foo ... bench:         0 ns/iter (+/- 0)
@@ -805,7 +805,7 @@ test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
                 execs().with_status(0)
                        .with_stdout(format!("\
 {fresh} foo v0.0.1 ({dir})
-{running} target[..]bench[..]foo-[..]
+{running} target[..]release[..]foo-[..]
 
 running 1 test
 test foo ... bench:         0 ns/iter (+/- 0)

--- a/tests/test_cargo_compile.rs
+++ b/tests/test_cargo_compile.rs
@@ -1249,8 +1249,8 @@ test!(explicit_examples {
         "#);
 
     assert_that(p.cargo_process("cargo-test"), execs());
-    assert_that(process(p.bin("test/hello")), execs().with_stdout("Hello, World!\n"));
-    assert_that(process(p.bin("test/goodbye")), execs().with_stdout("Goodbye, World!\n"));
+    assert_that(process(p.bin("hello")), execs().with_stdout("Hello, World!\n"));
+    assert_that(process(p.bin("goodbye")), execs().with_stdout("Goodbye, World!\n"));
 })
 
 test!(implicit_examples {
@@ -1276,8 +1276,8 @@ test!(implicit_examples {
         "#);
 
     assert_that(p.cargo_process("cargo-test"), execs().with_status(0));
-    assert_that(process(p.bin("test/hello")), execs().with_stdout("Hello, World!\n"));
-    assert_that(process(p.bin("test/goodbye")), execs().with_stdout("Goodbye, World!\n"));
+    assert_that(process(p.bin("hello")), execs().with_stdout("Hello, World!\n"));
+    assert_that(process(p.bin("goodbye")), execs().with_stdout("Goodbye, World!\n"));
 })
 
 test!(standard_build_no_ndebug {

--- a/tests/test_cargo_compile_git_deps.rs
+++ b/tests/test_cargo_compile_git_deps.rs
@@ -1002,7 +1002,7 @@ test!(dev_deps_with_testing {
         execs().with_stdout(format!("\
 {compiling} bar v0.5.0 ({bar}#[..])
 {compiling} foo v0.5.0 ({url})
-{running} target[..]test[..]foo-[..]
+{running} target[..]foo-[..]
 
 running 1 test
 test tests::foo ... ok

--- a/tests/test_cargo_compile_path_deps.rs
+++ b/tests/test_cargo_compile_path_deps.rs
@@ -161,7 +161,7 @@ test!(cargo_compile_with_root_dev_deps_with_testing {
         execs().with_stdout(format!("\
 {compiling} bar v0.5.0 ({url})
 {compiling} foo v0.5.0 ({url})
-{running} target[..]test[..]foo-[..]
+{running} target[..]foo-[..]
 
 running 0 tests
 

--- a/tests/test_cargo_cross_compile.rs
+++ b/tests/test_cargo_cross_compile.rs
@@ -411,14 +411,14 @@ test!(cross_tests {
                 execs().with_status(0)
                        .with_stdout(format!("\
 {compiling} foo v0.0.0 ({foo})
-{running} target[..]{triple}[..]test[..]bar-[..]
+{running} target[..]{triple}[..]bar-[..]
 
 running 1 test
 test test ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
 
-{running} target[..]{triple}[..]test[..]foo-[..]
+{running} target[..]{triple}[..]foo-[..]
 
 running 1 test
 test test_foo ... ok

--- a/tests/test_cargo_test.rs
+++ b/tests/test_cargo_test.rs
@@ -36,7 +36,7 @@ test!(cargo_test_simple {
     assert_that(p.process(cargo_dir().join("cargo-test")),
         execs().with_stdout(format!("\
 {} foo v0.5.0 ({})
-{} target[..]test[..]foo
+{} target[..]foo
 
 running 1 test
 test test_hello ... ok
@@ -60,7 +60,7 @@ test!(cargo_test_verbose {
         execs().with_stdout(format!("\
 {running} `rustc src[..]foo.rs [..]`
 {compiling} foo v0.5.0 ({url})
-{running} `[..]target[..]test[..]foo-[..] hello`
+{running} `[..]target[..]foo-[..] hello`
 
 running 1 test
 test test_hello ... ok
@@ -127,7 +127,7 @@ test!(cargo_test_failing_test {
     assert_that(p.process(cargo_dir().join("cargo-test")),
         execs().with_stdout(format!("\
 {} foo v0.5.0 ({})
-{} target[..]test[..]foo
+{} target[..]foo
 
 running 1 test
 test test_hello ... FAILED
@@ -191,14 +191,14 @@ test!(test_with_lib_dep {
     assert_that(p.cargo_process("cargo-test"),
         execs().with_stdout(format!("\
 {} foo v0.0.1 ({})
-{running} target[..]test[..]baz-[..]
+{running} target[..]baz-[..]
 
 running 1 test
 test bin_test ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
 
-{running} target[..]test[..]foo
+{running} target[..]foo
 
 running 1 test
 test lib_test ... ok
@@ -298,14 +298,14 @@ test!(external_test_explicit {
     assert_that(p.cargo_process("cargo-test"),
         execs().with_stdout(format!("\
 {} foo v0.0.1 ({})
-{running} target[..]test[..]foo-[..]
+{running} target[..]foo-[..]
 
 running 1 test
 test internal_test ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
 
-{running} target[..]test[..]test-[..]
+{running} target[..]test-[..]
 
 running 1 test
 test external_test ... ok
@@ -346,14 +346,14 @@ test!(external_test_implicit {
     assert_that(p.cargo_process("cargo-test"),
         execs().with_stdout(format!("\
 {} foo v0.0.1 ({})
-{running} target[..]test[..]external-[..]
+{running} target[..]external-[..]
 
 running 1 test
 test external_test ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
 
-{running} target[..]test[..]foo-[..]
+{running} target[..]foo-[..]
 
 running 1 test
 test internal_test ... ok
@@ -404,7 +404,7 @@ test!(pass_through_command_line {
                 execs().with_status(0)
                        .with_stdout(format!("\
 {compiling} foo v0.0.1 ({dir})
-{running} target[..]test[..]foo
+{running} target[..]foo
 
 running 1 test
 test bar ... ok
@@ -426,7 +426,7 @@ test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
                 execs().with_status(0)
                        .with_stdout(format!("\
 {compiling} foo v0.0.1 ({dir})
-{running} target[..]test[..]foo
+{running} target[..]foo
 
 running 1 test
 test foo ... ok
@@ -491,14 +491,14 @@ test!(lib_bin_same_name {
     assert_that(p.cargo_process("cargo-test"),
         execs().with_stdout(format!("\
 {} foo v0.0.1 ({})
-{running} target[..]test[..]foo-[..]
+{running} target[..]foo-[..]
 
 running 1 test
 test [..] ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
 
-{running} target[..]test[..]foo-[..]
+{running} target[..]foo-[..]
 
 running 1 test
 test [..] ... ok
@@ -543,14 +543,14 @@ test!(lib_with_standard_name {
                 execs().with_status(0)
                        .with_stdout(format!("\
 {compiling} syntax v0.0.1 ({dir})
-{running} target[..]test[..]syntax-[..]
+{running} target[..]syntax-[..]
 
 running 1 test
 test foo_test ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
 
-{running} target[..]test[..]test-[..]
+{running} target[..]test-[..]
 
 running 1 test
 test test ... ok
@@ -598,7 +598,7 @@ test!(lib_with_standard_name2 {
                 execs().with_status(0)
                        .with_stdout(format!("\
 {compiling} syntax v0.0.1 ({dir})
-{running} target[..]test[..]syntax-[..]
+{running} target[..]syntax-[..]
 
 running 1 test
 test test ... ok
@@ -626,7 +626,7 @@ test!(bin_there_for_integration {
             use std::io::Command;
             #[test]
             fn test_test() {
-                let status = Command::new("target/test/foo").status().unwrap();
+                let status = Command::new("target/foo").status().unwrap();
                 assert!(status.matches_exit_status(1));
             }
         "#);
@@ -685,14 +685,14 @@ test!(test_dylib {
                        .with_stdout(format!("\
 {compiling} bar v0.0.1 ({dir})
 {compiling} foo v0.0.1 ({dir})
-{running} target[..]test[..]foo-[..]
+{running} target[..]foo-[..]
 
 running 1 test
 test foo ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
 
-{running} target[..]test[..]test-[..]
+{running} target[..]test-[..]
 
 running 1 test
 test foo ... ok
@@ -715,14 +715,14 @@ test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
                        .with_stdout(format!("\
 {fresh} bar v0.0.1 ({dir})
 {fresh} foo v0.0.1 ({dir})
-{running} target[..]test[..]foo-[..]
+{running} target[..]foo-[..]
 
 running 1 test
 test foo ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
 
-{running} target[..]test[..]test-[..]
+{running} target[..]test-[..]
 
 running 1 test
 test foo ... ok
@@ -759,7 +759,7 @@ test!(test_twice_with_build_cmd {
                 execs().with_status(0)
                        .with_stdout(format!("\
 {compiling} foo v0.0.1 ({dir})
-{running} target[..]test[..]foo-[..]
+{running} target[..]foo-[..]
 
 running 1 test
 test foo ... ok
@@ -781,7 +781,7 @@ test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
                 execs().with_status(0)
                        .with_stdout(format!("\
 {fresh} foo v0.0.1 ({dir})
-{running} target[..]test[..]foo-[..]
+{running} target[..]foo-[..]
 
 running 1 test
 test foo ... ok
@@ -797,5 +797,49 @@ test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
 ",
                        fresh = FRESH, running = RUNNING,
                        doctest = DOCTEST,
+                       dir = p.url()).as_slice()));
+})
+
+test!(test_then_build {
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [package]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+        "#)
+        .file("src/lib.rs", "
+            #[test]
+            fn foo() {}
+        ");
+
+    assert_that(p.cargo_process("cargo-test"),
+                execs().with_status(0)
+                       .with_stdout(format!("\
+{compiling} foo v0.0.1 ({dir})
+{running} target[..]foo-[..]
+
+running 1 test
+test foo ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
+
+{doctest} foo
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
+
+",
+                       compiling = COMPILING, running = RUNNING,
+                       doctest = DOCTEST,
+                       dir = p.url()).as_slice()));
+
+    assert_that(p.process(cargo_dir().join("cargo-build")),
+                execs().with_status(0)
+                       .with_stdout(format!("\
+{fresh} foo v0.0.1 ({dir})
+",
+                       fresh = FRESH,
                        dir = p.url()).as_slice()));
 })


### PR DESCRIPTION
This commit changes the hash of Profile to only take into account
flags/variables that affect the actual output file itself (as opposed to its
location), and then changes cargo {test, build, doc} to all use the same
directory of output (in order to share deps).

This will cause a `cargo build` to remove all of the tests generated by `cargo
test`, but it speeds up the cycle of `cargo test` followed by a `cargo build` by
not needing to rebuild all dependencies.

Additionally, `cargo bench` now shares the same directory as
`cargo build --release` for the same reasons as above.

Closes #348
