### PR TITLE
Update guide.html to pull rustup.sh over HTTPS

### DIFF
--- a/guide.html
+++ b/guide.html
@@ -381,7 +381,7 @@ correct number of tests.</p>
 
 <p>To test your project on Travis-CI, here is a sample <code>.travis.yml</code> file:</p>
 <pre><code class="highlight plaintext">install:
-  - curl http://www.rust-lang.org/rustup.sh | sudo sh -
+  - curl https://static.rust-lang.org/rustup.sh | sudo sh -
 script:
   - cargo build --verbose
   - cargo test --verbose


### PR DESCRIPTION
The old http URL has been deprecated.  This change brings guide.html in line with index.html, which had a similar change in commit fffa6780.
