### PR TITLE
Fix doc tests for libs with deps

### DIFF
--- a/src/cargo/ops/cargo_test.rs
+++ b/src/cargo/ops/cargo_test.rs
@@ -46,8 +46,8 @@ pub fn run_tests(manifest_path: &Path,
         let mut p = compile.process("rustdoc")
                            .arg("--test").arg(lib)
                            .arg("--crate-name").arg(name)
-                           .arg("-L").arg("target/test")
-                           .arg("-L").arg("target/test/deps")
+                           .arg("-L").arg(&compile.root_output)
+                           .arg("-L").arg(&compile.deps_output)
                            .cwd(package.get_root());
 
         // FIXME(rust-lang/rust#16272): this should just always be passed.

--- a/tests/test_cargo_test.rs
+++ b/tests/test_cargo_test.rs
@@ -226,13 +226,14 @@ test!(test_with_deep_lib_dep {
 
             [dependencies.foo]
             path = "../foo"
-
-            [lib]
-            name = "bar"
-            doctest = false
         "#)
         .file("src/lib.rs", "
             extern crate foo;
+            /// ```
+            /// bar::bar();
+            /// ```
+            pub fn bar() {}
+
             #[test]
             fn bar_test() {
                 foo::foo();
@@ -265,8 +266,16 @@ test bar_test ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
 
+{doctest} bar
+
+running 1 test
+test bar_0 ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
+
 ",
                        compiling = COMPILING, running = RUNNING,
+                       doctest = DOCTEST,
                        dir = p.url()).as_slice()));
 })
 


### PR DESCRIPTION
The movement of tests to the main `target` directory forgot to update a spot
where rustdoc used a -L flag.

Closes #411
