### PR TITLE
Add a --no-run option to `cargo test`

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -85,7 +85,7 @@ style:
 	sh tests/check-style.sh
 
 no-exes:
-	find $$(git ls-files) -perm +111 -type f \
+	find $$(git ls-files | grep -v ttf) -perm +111 -type f \
 		-not -name configure -not -name '*.sh' -not -name '*.rs' | \
 		grep '.*' \
 		&& exit 1 || exit 0

--- a/src/bin/cargo-bench.rs
+++ b/src/bin/cargo-bench.rs
@@ -21,7 +21,9 @@ Usage:
 
 Options:
     -h, --help              Print this message
+    --no-run                Compile, but don't run benchmarks
     -j N, --jobs N          The number of jobs to run in parallel
+    --target TRIPLE         Build for the target triple
     --manifest-path PATH    Path to the manifest to build benchmarks for
     -v, --verbose           Use verbose output
 
@@ -39,16 +41,19 @@ fn execute(options: Options, shell: &mut MultiShell) -> CliResult<Option<()>> {
     let root = try!(find_root_manifest_for_cwd(options.flag_manifest_path));
     shell.set_verbose(options.flag_verbose);
 
-    let mut compile_opts = ops::CompileOptions {
-        update: false,
-        env: "bench",
-        shell: shell,
-        jobs: options.flag_jobs,
-        target: None,
-        dev_deps: true,
+    let mut ops = ops::TestOptions {
+        no_run: options.flag_no_run,
+        compile_opts: ops::CompileOptions {
+            update: false,
+            env: "bench",
+            shell: shell,
+            jobs: options.flag_jobs,
+            target: options.flag_target.as_ref().map(|s| s.as_slice()),
+            dev_deps: true,
+        },
     };
 
-    let err = try!(ops::run_benches(&root, &mut compile_opts,
+    let err = try!(ops::run_benches(&root, &mut ops,
                                     options.arg_args.as_slice()).map_err(|err| {
         CliError::from_boxed(err, 101)
     }));

--- a/src/bin/cargo-test.rs
+++ b/src/bin/cargo-test.rs
@@ -21,6 +21,7 @@ Usage:
 
 Options:
     -h, --help              Print this message
+    --no-run                Compile, but don't run tests
     -j N, --jobs N          The number of jobs to run in parallel
     --target TRIPLE         Build for the target triple
     -u, --update-remotes    Deprecated option, use `cargo update` instead
@@ -40,16 +41,19 @@ fn execute(options: Options, shell: &mut MultiShell) -> CliResult<Option<()>> {
     let root = try!(find_root_manifest_for_cwd(options.flag_manifest_path));
     shell.set_verbose(options.flag_verbose);
 
-    let mut compile_opts = ops::CompileOptions {
-        update: options.flag_update_remotes,
-        env: "test",
-        shell: shell,
-        jobs: options.flag_jobs,
-        target: options.flag_target.as_ref().map(|s| s.as_slice()),
-        dev_deps: true,
+    let mut ops = ops::TestOptions {
+        no_run: options.flag_no_run,
+        compile_opts: ops::CompileOptions {
+            update: options.flag_update_remotes,
+            env: "test",
+            shell: shell,
+            jobs: options.flag_jobs,
+            target: options.flag_target.as_ref().map(|s| s.as_slice()),
+            dev_deps: true,
+        },
     };
 
-    let err = try!(ops::run_tests(&root, &mut compile_opts,
+    let err = try!(ops::run_tests(&root, &mut ops,
                                   options.arg_args.as_slice()).map_err(|err| {
         CliError::from_boxed(err, 101)
     }));

--- a/src/cargo/ops/mod.rs
+++ b/src/cargo/ops/mod.rs
@@ -7,7 +7,7 @@ pub use self::cargo_new::{new, NewOptions};
 pub use self::cargo_doc::{doc, DocOptions};
 pub use self::cargo_generate_lockfile::{generate_lockfile, write_resolve};
 pub use self::cargo_generate_lockfile::{update_lockfile, load_lockfile};
-pub use self::cargo_test::{run_tests, run_benches};
+pub use self::cargo_test::{run_tests, run_benches, TestOptions};
 
 mod cargo_clean;
 mod cargo_compile;

--- a/tests/test_cargo_test.rs
+++ b/tests/test_cargo_test.rs
@@ -852,3 +852,25 @@ test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
                        fresh = FRESH,
                        dir = p.url()).as_slice()));
 })
+
+test!(test_no_run {
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [package]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+        "#)
+        .file("src/lib.rs", "
+            #[test]
+            fn foo() { fail!() }
+        ");
+
+    assert_that(p.cargo_process("cargo-test").arg("--no-run"),
+                execs().with_status(0)
+                       .with_stdout(format!("\
+{compiling} foo v0.0.1 ({dir})
+",
+                       compiling = COMPILING,
+                       dir = p.url()).as_slice()));
+})


### PR DESCRIPTION
This allows tests to be built, but not run.

Closes #406 
