### PR TITLE
Update guide.html to use "language: rust" in .travis.yml

### DIFF
--- a/guide.html
+++ b/guide.html
@@ -380,8 +380,7 @@ correct number of tests.</p>
 <h2>Travis-CI</h2>
 
 <p>To test your project on Travis-CI, here is a sample <code>.travis.yml</code> file:</p>
-<pre><code class="highlight plaintext">install:
-  - curl http://www.rust-lang.org/rustup.sh | sudo sh -
+<pre><code class="highlight plaintext">language: rust
 script:
   - cargo build --verbose
   - cargo test --verbose


### PR DESCRIPTION
travis-ci now supports "language: rust", which eliminates the need to call rustup.sh in .travis.yml.  See http://www.reddit.com/r/rust/comments/2ecocp/travis_ci_supports_rust/ for details.
