### PR TITLE
Update guide.md to use "language: rust" in .travis.yml

### DIFF
--- a/src/doc/source/guide.md
+++ b/src/doc/source/guide.md
@@ -390,8 +390,7 @@ correct number of tests.
 To test your project on Travis-CI, here is a sample `.travis.yml` file:
 
 ```
-install:
-  - curl http://www.rust-lang.org/rustup.sh | sudo sh -
+language: rust
 script:
   - cargo build --verbose
   - cargo test --verbose


### PR DESCRIPTION
travis-ci now supports "language: rust", which eliminates the need to call rustup.sh in .travis.yml. See http://www.reddit.com/r/rust/comments/2ecocp/travis_ci_supports_rust/ for details.

This is the same change as #425, but on the master branch in guide.md, not guide.html.
