### PR TITLE
Use `mod` where possible

### DIFF
--- a/src/cargo/core/errors.rs
+++ b/src/cargo/core/errors.rs
@@ -1,5 +1,4 @@
-use std::fmt;
-use std::fmt::{Show,Formatter};
+use std::fmt::{mod, Show, Formatter};
 use std::io::IoError;
 
 /*

--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -1,7 +1,6 @@
 use std::hash;
 use std::result;
-use std::fmt;
-use std::fmt::{Show,Formatter};
+use std::fmt::{mod, Show, Formatter};
 use semver::Version;
 use serialize::{Encoder,Encodable};
 use core::source::SourceId;

--- a/src/cargo/core/package.rs
+++ b/src/cargo/core/package.rs
@@ -1,5 +1,4 @@
-use std::fmt::{Show,Formatter};
-use std::fmt;
+use std::fmt::{mod, Show, Formatter};
 use std::slice;
 use semver::Version;
 

--- a/src/cargo/core/package_id.rs
+++ b/src/cargo/core/package_id.rs
@@ -1,7 +1,6 @@
 use semver;
 use std::hash::Hash;
-use std::fmt;
-use std::fmt::{Show,Formatter};
+use std::fmt::{mod, Show, Formatter};
 use collections::hash;
 use serialize::{
     Encodable,

--- a/src/cargo/core/shell.rs
+++ b/src/cargo/core/shell.rs
@@ -1,5 +1,4 @@
-use term;
-use term::{Terminal,color};
+use term::{mod, Terminal, color};
 use term::color::{Color, BLACK, RED, GREEN, YELLOW};
 use term::attr::{Attr, Bold};
 use std::io::{IoResult, stderr};

--- a/src/cargo/core/source.rs
+++ b/src/cargo/core/source.rs
@@ -1,8 +1,7 @@
 use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::collections::hashmap::{Values, MutEntries};
-use std::fmt::{Show, Formatter};
-use std::fmt;
+use std::fmt::{mod, Show, Formatter};
 use std::hash;
 use std::iter;
 use std::mem;

--- a/src/cargo/lib.rs
+++ b/src/cargo/lib.rs
@@ -23,8 +23,7 @@ extern crate toml;
 
 use std::os;
 use std::io::stdio::{stdout_raw, stderr_raw};
-use std::io::{stdout, stderr};
-use std::io;
+use std::io::{mod, stdout, stderr};
 use serialize::{Decoder, Encoder, Decodable, Encodable, json};
 use docopt::FlagParser;
 

--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -28,13 +28,11 @@ use std::result;
 
 use core::registry::PackageRegistry;
 use core::{MultiShell, Source, SourceId, PackageSet, Target, PackageId};
-use core::{Package, Summary, Resolve};
-use core::resolver;
+use core::{Package, Summary, Resolve, resolver};
 use ops;
 use sources::{PathSource};
 use util::config::{Config, ConfigValue};
-use util::{CargoResult, Wrap, config, internal, human, ChainError};
-use util::profile;
+use util::{CargoResult, Wrap, config, internal, human, ChainError, profile};
 
 pub struct CompileOptions<'a> {
     pub update: bool,

--- a/src/cargo/ops/cargo_generate_lockfile.rs
+++ b/src/cargo/ops/cargo_generate_lockfile.rs
@@ -3,8 +3,7 @@ use std::collections::HashSet;
 use std::io::File;
 
 use serialize::{Encodable, Decodable};
-use toml::Encoder;
-use toml as toml;
+use toml::{mod, Encoder};
 
 use core::registry::PackageRegistry;
 use core::{MultiShell, Source, Resolve, resolver, Package, SourceId};

--- a/src/cargo/ops/cargo_new.rs
+++ b/src/cargo/ops/cargo_new.rs
@@ -1,6 +1,5 @@
 use std::os;
-use std::io;
-use std::io::{fs, File};
+use std::io::{mod, fs, File};
 
 use util::{CargoResult, human, ChainError, process};
 use core::shell::MultiShell;

--- a/src/cargo/ops/cargo_read_manifest.rs
+++ b/src/cargo/ops/cargo_read_manifest.rs
@@ -1,8 +1,7 @@
 use std::collections::HashSet;
 use std::io::{File, fs};
-use util;
 use core::{Package,Manifest,SourceId};
-use util::{CargoResult, human};
+use util::{mod, CargoResult, human};
 use util::important_paths::find_project_manifest_exact;
 use util::toml::{Layout, project_layout};
 

--- a/src/cargo/ops/cargo_rustc/context.rs
+++ b/src/cargo/ops/cargo_rustc/context.rs
@@ -3,8 +3,7 @@ use std::str;
 use semver::Version;
 
 use core::{SourceMap, Package, PackageId, PackageSet, Resolve, Target};
-use util;
-use util::{CargoResult, ChainError, internal, Config, profile, Require};
+use util::{mod, CargoResult, ChainError, internal, Config, profile, Require};
 
 use super::{Kind, KindPlugin, KindTarget, Compilation};
 use super::layout::{Layout, LayoutProxy};

--- a/src/cargo/ops/cargo_rustc/layout.rs
+++ b/src/cargo/ops/cargo_rustc/layout.rs
@@ -46,8 +46,7 @@
 //!     old-fingerprint/
 //! ```
 
-use std::io;
-use std::io::{fs, IoResult};
+use std::io::{mod, fs, IoResult};
 
 use core::Package;
 use util::hex::short_hash;

--- a/src/cargo/sources/git/source.rs
+++ b/src/cargo/sources/git/source.rs
@@ -1,5 +1,4 @@
-use std::fmt::{Show,Formatter};
-use std::fmt;
+use std::fmt::{mod, Show, Formatter};
 use std::hash::Hasher;
 use std::hash::sip::SipHasher;
 use std::mem;

--- a/src/cargo/sources/git/utils.rs
+++ b/src/cargo/sources/git/utils.rs
@@ -1,5 +1,4 @@
-use std::fmt;
-use std::fmt::{Show,Formatter};
+use std::fmt::{mod, Show, Formatter};
 use std::io::{UserDir};
 use std::io::fs::{mkdir_recursive,rmdir_recursive};
 use serialize::{Encodable,Encoder};

--- a/src/cargo/sources/path.rs
+++ b/src/cargo/sources/path.rs
@@ -1,6 +1,5 @@
 use std::cmp;
-use std::fmt::{Show, Formatter};
-use std::fmt;
+use std::fmt::{mod, Show, Formatter};
 use std::io::fs;
 use glob::Pattern;
 

--- a/src/cargo/util/errors.rs
+++ b/src/cargo/util/errors.rs
@@ -1,7 +1,6 @@
 use std::io::process::{ProcessOutput, ProcessExit, ExitStatus, ExitSignal};
 use std::io::IoError;
-use std::fmt;
-use std::fmt::{Show, Formatter, FormatError};
+use std::fmt::{mod, Show, Formatter, FormatError};
 use std::str;
 
 use docopt;

--- a/src/cargo/util/process_builder.rs
+++ b/src/cargo/util/process_builder.rs
@@ -1,5 +1,4 @@
-use std::fmt;
-use std::fmt::{Show, Formatter};
+use std::fmt::{mod, Show, Formatter};
 use std::os;
 use std::c_str::CString;
 use std::io::process::{Command, ProcessOutput, InheritFd};

--- a/src/cargo/util/to_url.rs
+++ b/src/cargo/util/to_url.rs
@@ -1,5 +1,4 @@
-use url;
-use url::{Url, UrlParser};
+use url::{mod, Url, UrlParser};
 
 pub trait ToUrl {
     fn to_url(self) -> Result<Url, String>;


### PR DESCRIPTION
Example:

```
use std::fmt;
use std::fmt::Show;
```

becomes

```
use std::fmt::{mod, Show};
```
