### PR TITLE
Add a new CARGO_MANIFEST_DIR environment variable

### DIFF
--- a/src/cargo/ops/cargo_run.rs
+++ b/src/cargo/ops/cargo_run.rs
@@ -22,7 +22,7 @@ pub fn run(manifest_path: &Path,
         Some(path) => path,
         None => exe,
     };
-    let process = compile.process(exe).args(args);
+    let process = compile.process(exe, &root).args(args).cwd(os::getcwd());
 
     try!(options.shell.status("Running", process.to_string()));
     Ok(process.exec().err())

--- a/src/cargo/ops/cargo_rustc/context.rs
+++ b/src/cargo/ops/cargo_rustc/context.rs
@@ -1,6 +1,5 @@
 use std::collections::{HashMap, HashSet};
 use std::str;
-use semver::Version;
 
 use core::{SourceMap, Package, PackageId, PackageSet, Resolve, Target};
 use util::{mod, CargoResult, ChainError, internal, Config, profile, Require};
@@ -147,32 +146,7 @@ impl<'a, 'b> Context<'a, 'b> {
         self.compilation.root_output = self.layout(KindTarget).proxy().dest().clone();
         self.compilation.deps_output = self.layout(KindTarget).proxy().deps().clone();
 
-        let env = &mut self.compilation.extra_env;
-        env.insert("CARGO_PKG_VERSION_MAJOR".to_string(),
-                   Some(pkg.get_version().major.to_string()));
-        env.insert("CARGO_PKG_VERSION_MINOR".to_string(),
-                   Some(pkg.get_version().minor.to_string()));
-        env.insert("CARGO_PKG_VERSION_PATCH".to_string(),
-                   Some(pkg.get_version().patch.to_string()));
-        env.insert("CARGO_PKG_VERSION_PRE".to_string(),
-                   pre_version_component(pkg.get_version()));
-
         return Ok(());
-
-        fn pre_version_component(v: &Version) -> Option<String> {
-            if v.pre.is_empty() {
-                return None;
-            }
-
-            let mut ret = String::new();
-
-            for (i, x) in v.pre.iter().enumerate() {
-                if i != 0 { ret.push_char('.') };
-                ret.push_str(x.to_string().as_slice());
-            }
-
-            Some(ret)
-        }
     }
 
     fn build_requirements(&mut self, pkg: &'a Package, target: &'a Target,

--- a/src/cargo/ops/cargo_rustc/mod.rs
+++ b/src/cargo/ops/cargo_rustc/mod.rs
@@ -438,7 +438,6 @@ pub fn process<T: ToCStr>(cmd: T, pkg: &Package, cx: &Context) -> ProcessBuilder
 
     // We want to use the same environment and such as normal processes, but we
     // want to override the dylib search path with the one we just calculated.
-    cx.compilation.process(cmd).cwd(pkg.get_root())
-                               .env(DynamicLibrary::envvar(),
-                                    Some(search_path.as_slice()))
+    cx.compilation.process(cmd, pkg)
+                  .env(DynamicLibrary::envvar(), Some(search_path.as_slice()))
 }

--- a/src/cargo/ops/cargo_test.rs
+++ b/src/cargo/ops/cargo_test.rs
@@ -21,7 +21,7 @@ pub fn run_tests(manifest_path: &Path,
             Some(path) => path,
             None => exe.clone(),
         };
-        let cmd = compile.process(exe).args(args);
+        let cmd = compile.process(exe, &package).args(args);
         try!(options.shell.concise(|shell| {
             shell.status("Running", to_display.display().to_string())
         }));
@@ -43,7 +43,7 @@ pub fn run_tests(manifest_path: &Path,
 
     for (lib, name) in libs {
         try!(options.shell.status("Doc-tests", name));
-        let mut p = compile.process("rustdoc")
+        let mut p = compile.process("rustdoc", &package)
                            .arg("--test").arg(lib)
                            .arg("--crate-name").arg(name)
                            .arg("-L").arg(&compile.root_output)

--- a/tests/test_cargo_compile.rs
+++ b/tests/test_cargo_compile.rs
@@ -799,21 +799,24 @@ test!(crate_version_env_vars {
             static VERSION_MINOR: &'static str = env!("CARGO_PKG_VERSION_MINOR");
             static VERSION_PATCH: &'static str = env!("CARGO_PKG_VERSION_PATCH");
             static VERSION_PRE: &'static str = env!("CARGO_PKG_VERSION_PRE");
+            static CARGO_MANIFEST_DIR: &'static str = env!("CARGO_MANIFEST_DIR");
 
             fn main() {
-                let s = format!("{}-{}-{} @ {}", VERSION_MAJOR, VERSION_MINOR,
-                                VERSION_PATCH, VERSION_PRE);
+                let s = format!("{}-{}-{} @ {} in {}", VERSION_MAJOR,
+                                VERSION_MINOR, VERSION_PATCH, VERSION_PRE,
+                                CARGO_MANIFEST_DIR);
                 assert_eq!(s, foo::version());
                 println!("{}", s);
             }
         "#)
         .file("src/lib.rs", r#"
             pub fn version() -> String {
-                format!("{}-{}-{} @ {}",
+                format!("{}-{}-{} @ {} in {}",
                         env!("CARGO_PKG_VERSION_MAJOR"),
                         env!("CARGO_PKG_VERSION_MINOR"),
                         env!("CARGO_PKG_VERSION_PATCH"),
-                        env!("CARGO_PKG_VERSION_PRE"))
+                        env!("CARGO_PKG_VERSION_PRE"),
+                        env!("CARGO_MANIFEST_DIR"))
             }
         "#);
 
@@ -821,7 +824,8 @@ test!(crate_version_env_vars {
 
     assert_that(
       process(p.bin("foo")),
-      execs().with_stdout("0-5-1 @ alpha.1\n"));
+      execs().with_stdout(format!("0-5-1 @ alpha.1 in {}\n",
+                                  p.root().display()).as_slice()));
 
     assert_that(p.process(cargo_dir().join("cargo-test")), execs().with_status(0));
 })


### PR DESCRIPTION
All subprocesses will now be invoked with CARGO_MANIFEST_DIR pointing at the root of the
source directory that they are working on (compiling). This commit also
reorganizes the version environment variables to use the new infrastructure.

Closes #433
