### PR TITLE
Fix building with current rust by using rust-lang/glob

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,6 +6,7 @@ dependencies = [
  "docopt_macros 0.6.0 (git+https://github.com/burntsushi/docopt.rs#fc7ba2f1a5a351f7874257d880223d2ff5c75d36)",
  "flate2 0.0.1 (git+https://github.com/alexcrichton/flate2-rs#12593d1b9ccf09c2eabac176a6e233b171eed843)",
  "git2 0.0.1 (git+https://github.com/alexcrichton/git2-rs#d11091d4ac52d319301ad110ce9eacc0f0d88bab)",
+ "glob 0.0.1 (git+https://github.com/rust-lang/glob#c4495d9f2f2a1b22173b860f907760ba8c419843)",
  "hamcrest 0.1.0 (git+https://github.com/carllerche/hamcrest-rust.git#f0fd1546b0a7a278a12658ab8602b5c827cc3a42)",
  "semver 0.0.1 (git+https://github.com/rust-lang/semver#c78b40d7fdf8acd99b503e6ce394fbcf9eb8982f)",
  "tar 0.0.1 (git+https://github.com/alexcrichton/tar-rs#689bbc003ae47feae5bc99c53b56736e4ad994ba)",
@@ -43,6 +44,11 @@ source = "git+https://github.com/alexcrichton/git2-rs#d11091d4ac52d319301ad110ce
 dependencies = [
  "libgit2 0.0.1 (git+https://github.com/alexcrichton/git2-rs#d11091d4ac52d319301ad110ce9eacc0f0d88bab)",
 ]
+
+[[package]]
+name = "glob"
+version = "0.0.1"
+source = "git+https://github.com/rust-lang/glob#c4495d9f2f2a1b22173b860f907760ba8c419843"
 
 [[package]]
 name = "hamcrest"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,9 @@ git = "https://github.com/alexcrichton/flate2-rs"
 [dependencies.git2]
 git = "https://github.com/alexcrichton/git2-rs"
 
+[dependencies.glob]
+git = "https://github.com/rust-lang/glob"
+
 [[bin]]
 name = "cargo"
 test = false


### PR DESCRIPTION
The glob crate that comes with rust itself has been deprecated.
