### PR TITLE
Update the git2 dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ dependencies = [
  "docopt 0.6.0 (git+https://github.com/burntsushi/docopt.rs#fc7ba2f1a5a351f7874257d880223d2ff5c75d36)",
  "docopt_macros 0.6.0 (git+https://github.com/burntsushi/docopt.rs#fc7ba2f1a5a351f7874257d880223d2ff5c75d36)",
  "flate2 0.0.1 (git+https://github.com/alexcrichton/flate2-rs#12593d1b9ccf09c2eabac176a6e233b171eed843)",
- "git2 0.0.1 (git+https://github.com/alexcrichton/git2-rs#16142ef9d77b9cf5615085326a571a29cba7d683)",
+ "git2 0.0.1 (git+https://github.com/alexcrichton/git2-rs#d83ce44b5cd9526d98187ded639475e1b6e45c9f)",
  "glob 0.0.1 (git+https://github.com/rust-lang/glob#c4495d9f2f2a1b22173b860f907760ba8c419843)",
  "hamcrest 0.1.0 (git+https://github.com/carllerche/hamcrest-rust.git#f0fd1546b0a7a278a12658ab8602b5c827cc3a42)",
  "semver 0.0.1 (git+https://github.com/rust-lang/semver#c78b40d7fdf8acd99b503e6ce394fbcf9eb8982f)",
@@ -40,9 +40,9 @@ source = "git+https://github.com/alexcrichton/flate2-rs#12593d1b9ccf09c2eabac176
 [[package]]
 name = "git2"
 version = "0.0.1"
-source = "git+https://github.com/alexcrichton/git2-rs#16142ef9d77b9cf5615085326a571a29cba7d683"
+source = "git+https://github.com/alexcrichton/git2-rs#d83ce44b5cd9526d98187ded639475e1b6e45c9f"
 dependencies = [
- "libgit2 0.0.1 (git+https://github.com/alexcrichton/git2-rs#16142ef9d77b9cf5615085326a571a29cba7d683)",
+ "libgit2 0.0.1 (git+https://github.com/alexcrichton/git2-rs#d83ce44b5cd9526d98187ded639475e1b6e45c9f)",
 ]
 
 [[package]]
@@ -58,7 +58,7 @@ source = "git+https://github.com/carllerche/hamcrest-rust.git#f0fd1546b0a7a278a1
 [[package]]
 name = "libgit2"
 version = "0.0.1"
-source = "git+https://github.com/alexcrichton/git2-rs#16142ef9d77b9cf5615085326a571a29cba7d683"
+source = "git+https://github.com/alexcrichton/git2-rs#d83ce44b5cd9526d98187ded639475e1b6e45c9f"
 dependencies = [
  "link-config 0.0.1 (git+https://github.com/alexcrichton/link-config#f08103ea7d2e2d3369c2c5e66b0220c8d16b92c9)",
  "openssl-static-sys 0.0.1 (git+git://github.com/alexcrichton/openssl-static-sys#b8f2500c39932e9d022dcc2590493ab0cc144e2a)",


### PR DESCRIPTION
It turned out most of the methods in libgit2 don't actually require a Signature
structure, they're all mostly optional. This commit updates to this version of
libgit2 where the arguments are all optional.

Closes #463
