### PR TITLE
Pass native output directories of dependencies

### DIFF
--- a/src/cargo/ops/cargo_rustc/mod.rs
+++ b/src/cargo/ops/cargo_rustc/mod.rs
@@ -172,6 +172,17 @@ fn compile_custom(pkg: &Package, cmd: &str,
     for arg in cmd {
         p = p.arg(arg);
     }
+    for &(pkg, _) in cx.dep_targets(pkg).iter() {
+        let name: String = pkg.get_name().chars().map(|c| {
+            match c {
+                '-' => '_',
+                c => c.to_uppercase(),
+            }
+        }).collect();
+        p = p.env(format!("DEP_{}_OUT_DIR", name).as_slice(),
+                  Some(&layout.native(pkg)));
+    }
+
     Ok(proc() {
         if first {
             try!(if old_output.exists() {

--- a/src/doc/source/native-build.md
+++ b/src/doc/source/native-build.md
@@ -63,6 +63,22 @@ projects.
 [1]: http://doc.rust-lang.org/rust.html#linkage
 [2]: https://github.com/alexcrichton/link-config
 
+# Environment Variables
+
+The following environment variables are always available for build
+commands.
+
+* `OUT_DIR` - the folder in which all output should be placed.
+* `TARGET` - the target triple that is being compiled for. Native code should be
+             compiled for this triple.
+* `DEP_<name>_OUT_DIR` - This variable is present for all immediate dependencies
+                         of the package being built. The `<name>` will be the
+                         package's name, in uppercase, with `-` characters
+                         translated to a `_`. The value of this variable is the
+                         directory in which all the output of the dependency's
+                         build command was placed. This is useful for picking up
+                         things like header files and such from other packages.
+
 # A complete example
 
 The code blocks below lay out a cargo project which has a small and simple C

--- a/tests/test_cargo_compile.rs
+++ b/tests/test_cargo_compile.rs
@@ -742,6 +742,17 @@ task '<main>' failed at 'nope', {filename}:2\n\
 })
 
 test!(custom_build_env_vars {
+    let bar = project("bar")
+        .file("Cargo.toml", r#"
+            [package]
+            name = "bar-bar"
+            version = "0.0.1"
+            authors = []
+            build = "true"
+        "#)
+        .file("src/lib.rs", "");
+    bar.build();
+
     let mut p = project("foo");
     let mut build = project("builder");
     build = build
@@ -759,11 +770,15 @@ test!(custom_build_env_vars {
             use std::os;
             fn main() {{
                 let out = os::getenv("OUT_DIR").unwrap();
-                assert!(out.as_slice().starts_with(r"{}"));
+                assert!(out.as_slice().starts_with(r"{0}"));
+                assert!(Path::new(out).is_dir());
+
+                let out = os::getenv("DEP_BAR_BAR_OUT_DIR").unwrap();
+                assert!(out.as_slice().starts_with(r"{0}"));
                 assert!(Path::new(out).is_dir());
             }}
         "#,
-        p.root().join("target").join("native").join("foo-").display()));
+        p.root().join("target").join("native").display()));
     assert_that(build.cargo_process("build"), execs().with_status(0));
 
 
@@ -778,7 +793,10 @@ test!(custom_build_env_vars {
 
             [[bin]]
             name = "foo"
-        "#, build.bin("foo").display()))
+
+            [dependencies.bar-bar]
+            path = '{}'
+        "#, build.bin("foo").display(), bar.root().display()))
         .file("src/foo.rs", r#"
             fn main() {}
         "#);


### PR DESCRIPTION
This is often useful for picking up things like headers files from `*-sys`
packages when they had to compile locally (or perhaps for pkg-config).

Closes #449
