### PR TITLE
Update git2-rs

### DIFF
--- a/tests/test_cargo_compile_git_deps.rs
+++ b/tests/test_cargo_compile_git_deps.rs
@@ -890,6 +890,7 @@ test!(dep_with_changed_submodule {
     }).assert();
 
     git_project.process("git").args(["submodule", "add"])
+               .arg("--name").arg("bar")
                .arg(git_project2.url().to_string()).arg("src").exec_with_output()
                .assert();
     git_project.process("git").args(["add", "."]).exec_with_output().assert();
@@ -926,7 +927,7 @@ test!(dep_with_changed_submodule {
                 .with_status(0));
 
     let mut file = File::create(&git_project.root().join(".gitmodules"));
-    file.write_str(format!("[submodule \"src\"]\n\tpath = src\n\turl={}",
+    file.write_str(format!("[submodule \"bar\"]\n\tpath = src\n\turl={}",
                            git_project3.url()).as_slice()).assert();
 
     git_project.process("git").args(["submodule", "sync"]).exec_with_output().assert();


### PR DESCRIPTION
This fixes a case where a submodule's name was not equal to its path.

Closes #464
