### PR TITLE
Fix a minor typo

### DIFF
--- a/guide.html
+++ b/guide.html
@@ -288,7 +288,7 @@ they&rsquo;ll use the exact same SHA, even though we didn&rsquo;t specify it in 
 <p>When we&rsquo;re ready to opt in to a new version of the library, Cargo can
 re-calculate the dependencies, and update things for us:</p>
 <pre><code class="highlight shell"><span class="gp">$ </span>cargo update       <span class="c"># updates all dependencies</span>
-<span class="gp">$ </span>cargo update color <span class="c"># updtes just 'color'</span>
+<span class="gp">$ </span>cargo update color <span class="c"># updates just 'color'</span>
 </code></pre>
 
 <p>This will write out a new <code>Cargo.lock</code> with the new version information.</p>


### PR DESCRIPTION
Was reading through the docs and found a small typo where instead of saying "$ cargo update color # updates just 'color'", there was "$ cargo update color # updtes just 'color'".
