### PR TITLE
Don't fail!() when rustdoc fails to run

### DIFF
--- a/src/cargo/ops/cargo_rustc/mod.rs
+++ b/src/cargo/ops/cargo_rustc/mod.rs
@@ -273,8 +273,15 @@ fn rustdoc(package: &Package, target: &Target, cx: &mut Context) -> Work {
             }))
         } else {
             try!(rustdoc.exec_with_output().and(Ok(())).map_err(|err| {
-                caused_human(format!("Could not document `{}`.\n{}",
-                                     name, err.output().unwrap()), err)
+                match err.output() {
+                    Some(output) => {
+                        caused_human(format!("Could not document `{}`.\n{}",
+                                             name, output), err)
+                    }
+                    None => {
+                        caused_human("Failed to run rustdoc", err)
+                    }
+                }
             }))
         }
         Ok(())


### PR DESCRIPTION
The return value of `err.output()` will be `None` if the rustdoc executable
failed to spawn, in which case we can give a more graceful error message.

Closes #481
