### PR TITLE
Slim down the `cargo --list` test

### DIFF
--- a/tests/test_cargo.rs
+++ b/tests/test_cargo.rs
@@ -2,7 +2,7 @@ use std::io::fs;
 use std::io;
 use std::os;
 use std::str;
-use cargo::util::{process, ProcessBuilder};
+use cargo::util::process;
 
 use support::paths;
 use support::{project, cargo_dir, mkdir_recursive, ProjectBuilder, ResultTest};
@@ -21,19 +21,6 @@ fn fake_executable(proj: ProjectBuilder, dir: &Path, name: &str) -> ProjectBuild
     proj
 }
 
-/// Copy real cargo exeutable just built to specified location, and
-/// prepare to run it.
-fn copied_executable_process(proj: &ProjectBuilder, name: &str, dir: &Path) -> ProcessBuilder {
-    let name = format!("{}{}", name, os::consts::EXE_SUFFIX);
-    let path_src = cargo_dir().join(name.clone());
-    let path_dst = proj.root().join(dir).join(name);
-    mkdir_recursive(&Path::new(path_dst.dirname())).assert();
-    fs::copy(&path_src, &path_dst).assert();
-    process(path_dst)
-        .cwd(proj.root())
-        .env("HOME", Some(paths::home().as_vec()))
-}
-
 // We can't entirely obliterate PATH because windows needs it for paths to
 // things like libgcc, but we want to filter out everything which has a `cargo`
 // installation as we don't want it to muck with the --list tests
@@ -43,17 +30,11 @@ fn new_path() -> Vec<Path> {
         !p.join(format!("cargo{}", os::consts::EXE_SUFFIX)).exists()
     }).collect()
 }
-test!(list_commands_non_overlapping {
-    // lib/cargo | cargo-3
-    // bin/       | cargo-2
-    // PATH       | cargo-1
-    // Check if --list searches all 3 targets.
-    // Also checks that results are in lexicographic order.
+test!(list_commands_looks_at_path {
     let proj = project("list-non-overlapping");
-    let proj = fake_executable(proj, &Path::new("lib/cargo"), "cargo-3");
-    let proj = fake_executable(proj, &Path::new("bin"), "cargo-2");
     let proj = fake_executable(proj, &Path::new("path-test"), "cargo-1");
-    let pr = copied_executable_process(&proj, "cargo", &Path::new("bin"));
+    let pr = process(cargo_dir().join("cargo")).cwd(proj.root())
+                    .env("HOME", Some(paths::home()));
 
     let mut path = new_path();
     path.push(proj.root().join("path-test"));
@@ -62,6 +43,4 @@ test!(list_commands_non_overlapping {
     let output = output.exec_with_output().assert();
     let output = str::from_utf8(output.output.as_slice()).assert();
     assert!(output.contains("\n    1\n"), "missing 1: {}", output);
-    assert!(output.contains("\n    2\n"), "missing 2: {}", output);
-    assert!(output.contains("\n    3\n"), "missing 3: {}", output);
 })


### PR DESCRIPTION
This test has been flaky on the bots for quite some time now, and the cause has
now been discovered. The root cause of the failure is that the execve for the
`cargo --list` command was failing with ETXTBUSY. In querying the manpage, this
means:

```
Executable was open for writing by one or more processes.
```

This error can be explained by the following trace:
1. Thread A, running the `cargo --list` test, opens the destination executable
   for writing because it's copying the current executable into a different
   location.
2. Thread B, some other test, forks the process. The file descriptor of the
   destination executable of thread A is now duplicated in this process.
3. Thread A closes all files and such, and then goes to fork/exec
   `cargo --list`.
4. Thread B has not had time to close all its descriptors. so it still has the
   executable open for writing, causing the `execve` of thread A to fail.

This commit just removes these tested portions of the test, only testing that
cargo probes PATH.
