### PR TITLE
Generate a lockfile sooner in `cargo build`

### DIFF
--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -71,7 +71,7 @@ pub fn compile(manifest_path: &Path,
     let override_ids = try!(source_ids_from_config(&user_configs,
                                                    manifest_path.dir_path()));
 
-    let (packages, resolve, resolve_with_overrides, sources) = {
+    let (packages, resolve_with_overrides, sources) = {
         let _p = profile::start("resolving...");
         let lockfile = manifest_path.dir_path().join("Cargo.lock");
         let source_id = package.get_package_id().get_source_id();
@@ -90,6 +90,7 @@ pub fn compile(manifest_path: &Path,
         let resolved = try!(resolver::resolve(package.get_package_id(),
                                               package.get_dependencies(),
                                               &mut registry));
+        try!(ops::write_resolve(&package, &resolved));
 
         try!(registry.add_overrides(override_ids));
         let resolved_with_overrides =
@@ -104,7 +105,7 @@ pub fn compile(manifest_path: &Path,
             human("Unable to get packages from source")
         }));
 
-        (packages, resolved, resolved_with_overrides, registry.move_sources())
+        (packages, resolved_with_overrides, registry.move_sources())
     };
 
     debug!("packages={}", packages);
@@ -127,8 +128,6 @@ pub fn compile(manifest_path: &Path,
                                   &resolve_with_overrides, &sources,
                                   &mut config))
     };
-
-    try!(ops::write_resolve(&package, &resolve));
 
     return Ok(ret);
 }

--- a/tests/test_cargo_compile.rs
+++ b/tests/test_cargo_compile.rs
@@ -125,6 +125,7 @@ Could not compile `foo`.
 
 To learn more, run the command again with --verbose.\n",
             filename = format!("src{}foo.rs", path::SEP)).as_slice()));
+    assert_that(&p.root().join("Cargo.lock"), existing_file());
 })
 
 test!(cargo_compile_with_invalid_code_in_deps {


### PR DESCRIPTION
It's quite annoying if you update a dependency, but it takes you awhile to get
the dependency building. Previously the dependency graph would have to be
updated each time because the lockfile was only written _after_ a successful
build.

Other tools like `cargo generate-lockfile` will already generate a lockfile at
any time, so just make it easier by moving it up in the compilation process.
