### PR TITLE
Do not pass static lib targets to rustc

### DIFF
--- a/src/cargo/ops/cargo_rustc/mod.rs
+++ b/src/cargo/ops/cargo_rustc/mod.rs
@@ -405,6 +405,10 @@ fn build_deps_args(mut cmd: ProcessBuilder, target: &Target, package: &Package,
 
     if target.is_bin() {
         for target in targets {
+            if target.is_staticlib() {
+                continue;
+            }
+
             cmd = try!(link_to(cmd, target, cx, kind, LocalLib));
         }
     }

--- a/tests/test_cargo_compile.rs
+++ b/tests/test_cargo_compile.rs
@@ -1466,6 +1466,29 @@ test!(simple_staticlib {
     assert_that(p.cargo_process("build"), execs().with_status(0));
 })
 
+test!(staticlib_rlib_and_bin {
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+              [package]
+              name = "foo"
+              authors = []
+              version = "0.0.1"
+
+              [lib]
+              name = "foo"
+              crate-type = ["staticlib", "rlib"]
+        "#)
+        .file("src/lib.rs", "pub fn foo() {}")
+        .file("src/main.rs", r#"
+              extern crate foo;
+
+              fn main() {
+                  foo::foo();
+              }"#);
+
+    assert_that(p.cargo_process("build"), execs().with_status(0));
+})
+
 test!(opt_out_of_lib {
     let p = project("foo")
         .file("Cargo.toml", r#"


### PR DESCRIPTION
rustc cannot take .a files, so don't pass them
