### PR TITLE
Create hg repo with --hg flag on cargo new

### DIFF
--- a/src/bin/new.rs
+++ b/src/bin/new.rs
@@ -17,6 +17,7 @@ Options:
     --no-git            Don't initialize a new git repository
     --git               Initialize a new git repository, overriding a
                         global `git = false` configuration
+    --hg                Initialize a new hg repository
     --travis            Create a .travis.yml file
     --bin               Use a binary instead of a library template
     -v, --verbose       Use verbose output
@@ -26,11 +27,13 @@ pub fn execute(options: Options, shell: &mut MultiShell) -> CliResult<Option<()>
     debug!("executing; cmd=cargo-new; args={}", os::args());
     shell.set_verbose(options.flag_verbose);
 
-    let Options { flag_no_git, flag_travis, flag_bin, arg_path, flag_git, .. } = options;
+    let Options { flag_no_git, flag_travis,
+                  flag_bin,arg_path, flag_git, flag_hg, .. } = options;
 
     let opts = ops::NewOptions {
         no_git: flag_no_git,
         git: flag_git,
+        hg: flag_hg,
         travis: flag_travis,
         path: arg_path.as_slice(),
         bin: flag_bin,

--- a/src/cargo/ops/cargo_new.rs
+++ b/src/cargo/ops/cargo_new.rs
@@ -1,14 +1,15 @@
 use std::os;
 use std::io::{mod, fs, File};
 
-use git2::{Repository, Config};
+use git2::Config;
 
-use util::{CargoResult, human, ChainError, config, internal};
+use util::{GitRepo, HgRepo, CargoResult, human, ChainError, config, internal};
 use core::shell::MultiShell;
 
 pub struct NewOptions<'a> {
     pub no_git: bool,
     pub git: bool,
+    pub hg: bool,
     pub travis: bool,
     pub bin: bool,
     pub path: &'a str,
@@ -35,15 +36,19 @@ pub fn new(opts: NewOptions, _shell: &mut MultiShell) -> CargoResult<()> {
 
 fn mk(path: &Path, name: &str, opts: &NewOptions) -> CargoResult<()> {
     let cfg = try!(global_config());
-    if !opts.git && (opts.no_git || cfg.git == Some(false)) {
+    let mut ignore = "/target\n".to_string();
+    if !opts.bin {
+        ignore.push_str("/Cargo.lock\n");
+    }
+
+    if opts.hg {
+        try!(HgRepo::init(path));
+        try!(File::create(&path.join(".hgignore")).write(ignore.as_bytes()));
+    } else if !opts.git && (opts.no_git || cfg.git == Some(false)) {
         try!(fs::mkdir(path, io::UserRWX));
     } else {
-        try!(Repository::init(path));
-        let mut gitignore = "/target\n".to_string();
-        if !opts.bin {
-            gitignore.push_str("/Cargo.lock\n");
-        }
-        try!(File::create(&path.join(".gitignore")).write(gitignore.as_bytes()));
+        try!(GitRepo::init(path));
+        try!(File::create(&path.join(".gitignore")).write(ignore.as_bytes()));
     }
 
     let (author_name, email) = try!(discover_author());

--- a/src/cargo/util/mod.rs
+++ b/src/cargo/util/mod.rs
@@ -11,6 +11,7 @@ pub use self::dependency_queue::{DependencyQueue, Fresh, Dirty, Freshness};
 pub use self::dependency_queue::Dependency;
 pub use self::graph::Graph;
 pub use self::to_url::ToUrl;
+pub use self::vcs::{GitRepo, HgRepo};
 
 pub mod graph;
 pub mod process_builder;
@@ -25,3 +26,4 @@ pub mod profile;
 mod pool;
 mod dependency_queue;
 mod to_url;
+pub mod vcs;

--- a/src/cargo/util/vcs.rs
+++ b/src/cargo/util/vcs.rs
@@ -1,0 +1,21 @@
+use git2;
+
+use util::{CargoResult, process};
+
+pub struct HgRepo;
+pub struct GitRepo;
+
+impl GitRepo {
+    pub fn init(path: &Path) -> CargoResult<GitRepo> {
+        try!(git2::Repository::init(path));
+        return Ok(GitRepo)
+    }
+}
+
+impl HgRepo {
+    pub fn init(path: &Path) -> CargoResult<HgRepo> {
+        let path_str = path.as_str().unwrap();
+        try!(process("hg").arg("init").arg(path_str).exec());
+        return Ok(HgRepo)
+    }
+}


### PR DESCRIPTION
Allows the client to initialize a mercurial repo when creating a new cargo project with `cargo new --hg`. This would close #510.

This is my first time writing code in rust outside of a toy program so please feel free to tear it apart or suggest an alternative solution.
