### PR TITLE
Don't blow away checked out git repos

### DIFF
--- a/tests/test_cargo_compile_git_deps.rs
+++ b/tests/test_cargo_compile_git_deps.rs
@@ -475,8 +475,7 @@ test!(two_revs_same_deps {
 
     baz.build();
 
-    // TODO: -j1 is a hack
-    assert_that(foo.cargo_process("build").arg("-j").arg("1"),
+    assert_that(foo.cargo_process("build"),
                 execs().with_status(0));
     assert_that(&foo.bin("foo"), existing_file());
     assert_that(foo.process(foo.bin("foo")), execs().with_status(0));


### PR DESCRIPTION
This primarily blows away all _submodules_ as well, which sometimes can be quite
large and take some time to update. Instead, re-use an existing checkout, just
reset it to the right revision if possible.

Also, move the submodule update step to occur unconditionally to account for
corrupt submodule checkouts or interrupted downloads. This update step should be
much faster than `git submodule update` because we're using libgit2, so yay!
