### PR TITLE
Don't print `Running` for commands that aren't run

### DIFF
--- a/src/cargo/ops/cargo_rustc/job.rs
+++ b/src/cargo/ops/cargo_rustc/job.rs
@@ -1,14 +1,18 @@
+use std::io::IoResult;
+
+use core::MultiShell;
 use util::{CargoResult, Fresh, Dirty, Freshness};
 
-pub struct Job { dirty: Work, fresh: Work }
+pub struct Job { dirty: Work, fresh: Work, desc: String }
 
 pub type Work = proc():Send -> CargoResult<()>;
 
 impl Job {
     /// Create a new job representing a unit of work.
     pub fn new(dirty: proc():Send -> CargoResult<()>,
-               fresh: proc():Send -> CargoResult<()>) -> Job {
-        Job { dirty: dirty, fresh: fresh }
+               fresh: proc():Send -> CargoResult<()>,
+               desc: String) -> Job {
+        Job { dirty: dirty, fresh: fresh, desc: desc }
     }
 
     /// Consumes this job by running it, returning the result of the
@@ -18,5 +22,12 @@ impl Job {
             Fresh => (self.fresh)(),
             Dirty => (self.dirty)(),
         }
+    }
+
+    pub fn describe(&self, shell: &mut MultiShell) -> IoResult<()> {
+        if self.desc.len() > 0 {
+            try!(shell.status("Running", self.desc.as_slice()));
+        }
+        Ok(())
     }
 }

--- a/src/cargo/ops/cargo_rustc/job_queue.rs
+++ b/src/cargo/ops/cargo_rustc/job_queue.rs
@@ -168,6 +168,9 @@ impl<'a, 'b> JobQueue<'a, 'b> {
             let fresh = job_freshness.combine(fresh);
             let my_tx = self.tx.clone();
             let id = id.clone();
+            if fresh == Dirty {
+                try!(config.shell().verbose(|shell| job.describe(shell)));
+            }
             self.pool.execute(proc() {
                 my_tx.send((id, stage, fresh, job.run(fresh)));
             });

--- a/tests/test_cargo_bench.rs
+++ b/tests/test_cargo_bench.rs
@@ -61,8 +61,8 @@ test!(cargo_bench_verbose {
 
     assert_that(p.cargo_process("bench").arg("-v").arg("hello"),
         execs().with_stdout(format!("\
-{running} `rustc src[..]foo.rs [..]`
 {compiling} foo v0.5.0 ({url})
+{running} `rustc src[..]foo.rs [..]`
 {running} `[..]target[..]release[..]foo-[..] hello --bench`
 
 running 1 test
@@ -654,12 +654,12 @@ test!(bench_dylib {
     assert_that(p.cargo_process("bench").arg("-v"),
                 execs().with_status(0)
                        .with_stdout(format!("\
-{running} [..]
-{running} [..]
-{running} [..]
-{running} [..]
 {compiling} bar v0.0.1 ({dir})
+{running} [..]
 {compiling} foo v0.0.1 ({dir})
+{running} [..]
+{running} [..]
+{running} [..]
 {running} [..]target[..]release[..]bench-[..]
 
 running 1 test
@@ -681,10 +681,6 @@ test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured
     assert_that(p.process(cargo_dir().join("cargo")).arg("bench").arg("-v"),
                 execs().with_status(0)
                        .with_stdout(format!("\
-{running} [..]
-{running} [..]
-{running} [..]
-{running} [..]
 {fresh} bar v0.0.1 ({dir})
 {fresh} foo v0.0.1 ({dir})
 {running} [..]target[..]release[..]bench-[..]

--- a/tests/test_cargo_compile.rs
+++ b/tests/test_cargo_compile.rs
@@ -1158,6 +1158,7 @@ test!(verbose_build {
         .file("src/lib.rs", "");
     assert_that(p.cargo_process("build").arg("-v"),
                 execs().with_status(0).with_stdout(format!("\
+{compiling} test v0.0.0 ({url})
 {running} `rustc {dir}{sep}src{sep}lib.rs --crate-name test --crate-type lib -g \
         -C metadata=[..] \
         -C extra-filename=-[..] \
@@ -1165,7 +1166,7 @@ test!(verbose_build {
         --dep-info [..] \
         -L {dir}{sep}target \
         -L {dir}{sep}target{sep}deps`
-{compiling} test v0.0.0 ({url})\n",
+",
 running = RUNNING, compiling = COMPILING, sep = path::SEP,
 dir = p.root().display(),
 url = p.url(),
@@ -1185,6 +1186,7 @@ test!(verbose_release_build {
         .file("src/lib.rs", "");
     assert_that(p.cargo_process("build").arg("-v").arg("--release"),
                 execs().with_status(0).with_stdout(format!("\
+{compiling} test v0.0.0 ({url})
 {running} `rustc {dir}{sep}src{sep}lib.rs --crate-name test --crate-type lib \
         --opt-level 3 \
         --cfg ndebug \
@@ -1194,7 +1196,7 @@ test!(verbose_release_build {
         --dep-info [..] \
         -L {dir}{sep}target{sep}release \
         -L {dir}{sep}target{sep}release{sep}deps`
-{compiling} test v0.0.0 ({url})\n",
+",
 running = RUNNING, compiling = COMPILING, sep = path::SEP,
 dir = p.root().display(),
 url = p.url(),
@@ -1229,6 +1231,7 @@ test!(verbose_release_build_deps {
         .file("foo/src/lib.rs", "");
     assert_that(p.cargo_process("build").arg("-v").arg("--release"),
                 execs().with_status(0).with_stdout(format!("\
+{compiling} foo v0.0.0 ({url})
 {running} `rustc {dir}{sep}foo{sep}src{sep}lib.rs --crate-name foo \
         --crate-type dylib --crate-type rlib \
         --opt-level 3 \
@@ -1239,6 +1242,7 @@ test!(verbose_release_build_deps {
         --dep-info [..] \
         -L {dir}{sep}target{sep}release{sep}deps \
         -L {dir}{sep}target{sep}release{sep}deps`
+{compiling} test v0.0.0 ({url})
 {running} `rustc {dir}{sep}src{sep}lib.rs --crate-name test --crate-type lib \
         --opt-level 3 \
         --cfg ndebug \
@@ -1251,8 +1255,7 @@ test!(verbose_release_build_deps {
         --extern foo={dir}{sep}target{sep}release{sep}deps/\
                      {prefix}foo-[..]{suffix} \
         --extern foo={dir}{sep}target{sep}release{sep}deps/libfoo-[..].rlib`
-{compiling} foo v0.0.0 ({url})
-{compiling} test v0.0.0 ({url})\n",
+",
                     running = RUNNING,
                     compiling = COMPILING,
                     dir = p.root().display(),

--- a/tests/test_cargo_cross_compile.rs
+++ b/tests/test_cargo_cross_compile.rs
@@ -295,6 +295,7 @@ test!(linker_and_ar {
                                               .arg("-v"),
                 execs().with_status(101)
                        .with_stdout(format!("\
+{compiling} foo v0.5.0 ({url})
 {running} `rustc src/foo.rs --crate-name foo --crate-type bin -g \
     --out-dir {dir}{sep}target{sep}{target} \
     --dep-info [..] \
@@ -302,7 +303,6 @@ test!(linker_and_ar {
     -C ar=my-ar-tool -C linker=my-linker-tool \
     -L {dir}{sep}target{sep}{target} \
     -L {dir}{sep}target{sep}{target}{sep}deps`
-{compiling} foo v0.5.0 ({url})
 ",
                             running = RUNNING,
                             compiling = COMPILING,

--- a/tests/test_cargo_profiles.rs
+++ b/tests/test_cargo_profiles.rs
@@ -25,6 +25,7 @@ test!(profile_overrides {
         .file("src/lib.rs", "");
     assert_that(p.cargo_process("build").arg("-v"),
                 execs().with_status(0).with_stdout(format!("\
+{compiling} test v0.0.0 ({url})
 {running} `rustc {dir}{sep}src{sep}lib.rs --crate-name test --crate-type lib \
         --opt-level 1 \
         --cfg ndebug \
@@ -34,7 +35,7 @@ test!(profile_overrides {
         --dep-info [..] \
         -L {dir}{sep}target \
         -L {dir}{sep}target{sep}deps`
-{compiling} test v0.0.0 ({url})\n",
+",
 running = RUNNING, compiling = COMPILING, sep = path::SEP,
 dir = p.root().display(),
 url = p.url(),
@@ -77,6 +78,7 @@ test!(top_level_overrides_deps {
         .file("foo/src/lib.rs", "");
     assert_that(p.cargo_process("build").arg("-v").arg("--release"),
                 execs().with_status(0).with_stdout(format!("\
+{compiling} foo v0.0.0 ({url})
 {running} `rustc {dir}{sep}foo{sep}src{sep}lib.rs --crate-name foo \
         --crate-type dylib --crate-type rlib \
         --opt-level 1 \
@@ -87,6 +89,7 @@ test!(top_level_overrides_deps {
         --dep-info [..] \
         -L {dir}{sep}target{sep}release{sep}deps \
         -L {dir}{sep}target{sep}release{sep}deps`
+{compiling} test v0.0.0 ({url})
 {running} `rustc {dir}{sep}src{sep}lib.rs --crate-name test --crate-type lib \
         --opt-level 1 \
         -g \
@@ -99,8 +102,7 @@ test!(top_level_overrides_deps {
         --extern foo={dir}{sep}target{sep}release{sep}deps/\
                      {prefix}foo-[..]{suffix} \
         --extern foo={dir}{sep}target{sep}release{sep}deps/libfoo-[..].rlib`
-{compiling} foo v0.0.0 ({url})
-{compiling} test v0.0.0 ({url})\n",
+",
                     running = RUNNING,
                     compiling = COMPILING,
                     dir = p.root().display(),

--- a/tests/test_cargo_test.rs
+++ b/tests/test_cargo_test.rs
@@ -58,8 +58,8 @@ test!(cargo_test_verbose {
 
     assert_that(p.cargo_process("test").arg("-v").arg("hello"),
         execs().with_stdout(format!("\
-{running} `rustc src[..]foo.rs [..]`
 {compiling} foo v0.5.0 ({url})
+{running} `rustc src[..]foo.rs [..]`
 {running} `[..]target[..]foo-[..] hello`
 
 running 1 test


### PR DESCRIPTION
Also print the commands only right before they're actually run.

Closes #215
