### PR TITLE
Don't clone remote repos, use fetch instead

### DIFF
--- a/src/cargo/sources/git/utils.rs
+++ b/src/cargo/sources/git/utils.rs
@@ -183,17 +183,9 @@ impl GitRemote {
             try!(rmdir_recursive(dst));
         }
         try!(mkdir_recursive(dst, UserDir));
-        let cfg = try!(git2::Config::open_default());
-        with_authentication(url.as_slice(), &cfg, |f| {
-            let cb = git2::RemoteCallbacks::new()
-                                           .credentials(f);
-            let repo = try!(git2::build::RepoBuilder::new()
-                                                     .bare(true)
-                                                     .hardlinks(false)
-                                                     .remote_callbacks(cb)
-                                                     .clone(url.as_slice(), dst));
-            Ok(repo)
-        })
+        let repo = try!(git2::Repository::init_bare(dst));
+        try!(fetch(&repo, url.as_slice()));
+        Ok(repo)
     }
 }
 

--- a/tests/test_cargo_compile_git_deps.rs
+++ b/tests/test_cargo_compile_git_deps.rs
@@ -125,7 +125,7 @@ test!(cargo_compile_git_dep_branch {
     }).assert();
 
     git_project.process("git").args(["checkout", "-b", "branchy"]).exec_with_output().assert();
-    git_project.process("git").args(["branch", "-d", "master"]).exec_with_output().assert();
+    git_project.process("git").args(["checkout", "master"]).exec_with_output().assert();
 
     let project = project
         .file("Cargo.toml", format!(r#"


### PR DESCRIPTION
When cloning a remote repository, the default behavior of libgit2 is to only
update the local ref that's actually checked out, when we actually would prefer
to update all refs of the remote repo. This removes a call to clone() to a
init_bare() + fetch() which should update all refs accordingly

Closes #565
