### PR TITLE
Fix intermittent failures in path_dep_build_cmd and git_dep_build_cmd

### DIFF
--- a/tests/test_cargo_compile_git_deps.rs
+++ b/tests/test_cargo_compile_git_deps.rs
@@ -1181,6 +1181,8 @@ test!(git_dep_build_cmd {
         "#)
     }).assert();
 
+    p.root().join("bar").move_into_the_past().assert();
+
     assert_that(p.process(cargo_dir().join("cargo")).arg("build"),
         execs().with_status(0));
 

--- a/tests/test_cargo_compile_path_deps.rs
+++ b/tests/test_cargo_compile_path_deps.rs
@@ -667,7 +667,10 @@ test!(path_dep_build_cmd {
             pub fn gimme() -> int { 0 }
         "#);
 
-    assert_that(p.cargo_process("build"),
+    p.build();
+    p.root().join("bar").move_into_the_past().assert();
+
+    assert_that(p.process(cargo_dir().join("cargo")).arg("build"),
         execs().with_stdout(format!("{} bar v0.5.0 ({})\n\
                                      {} foo v0.5.0 ({})\n",
                                     COMPILING, p.url(),


### PR DESCRIPTION
Travis is showing intermittent failures in `test_cargo_compile_path_deps::path_dep_build_cmd` and `test_cargo_compile_git_deps::git_dep_build_cmd` (added in #561 and #563).

I haven't managed to reproduce these failures locally, but I suspect the tests are timing-sensitive.  This tries to fix the failure by sleeping for a second between the two operations.
