### PR TITLE
Fix cargo doc with custom build commands

### DIFF
--- a/src/cargo/ops/cargo_rustc/context.rs
+++ b/src/cargo/ops/cargo_rustc/context.rs
@@ -22,8 +22,8 @@ pub struct Context<'a, 'b> {
     pub resolve: &'a Resolve,
     pub sources: &'a SourceMap<'b>,
     pub compilation: Compilation,
-    pub env: &'a str,
 
+    env: &'a str,
     host: Layout,
     target: Option<Layout>,
     target_triple: String,
@@ -266,6 +266,13 @@ impl<'a, 'b> Context<'a, 'b> {
         self.package_set.iter()
             .find(|pkg| id == pkg.get_package_id())
             .expect("Should have found package")
+    }
+
+    pub fn env(&self) -> &str {
+        // The "doc-all" environment just means to document everything (see
+        // below), but we want to canonicalize that the the "doc" profile
+        // environment, so do that here.
+        if self.env == "doc-all" {"doc"} else {self.env}
     }
 
     pub fn is_relevant_target(&self, target: &Target) -> bool {

--- a/src/cargo/ops/cargo_rustc/mod.rs
+++ b/src/cargo/ops/cargo_rustc/mod.rs
@@ -172,11 +172,11 @@ fn compile_custom(pkg: &Package, cmd: &str,
                   cx: &Context, first: bool) -> CargoResult<Work> {
     let root = cx.get_package(cx.resolve.root());
     let profile = root.get_manifest().get_targets().iter()
-                      .find(|target| target.get_profile().get_env() == cx.env)
+                      .find(|target| target.get_profile().get_env() == cx.env())
                       .map(|target| target.get_profile());
     let profile = match profile {
         Some(profile) => profile,
-        None => return Err(internal(format!("no profile for {}", cx.env)))
+        None => return Err(internal(format!("no profile for {}", cx.env())))
     };
 
     // TODO: this needs to be smarter about splitting

--- a/tests/test_cargo_doc.rs
+++ b/tests/test_cargo_doc.rs
@@ -12,6 +12,7 @@ test!(simple {
             name = "foo"
             version = "0.0.1"
             authors = []
+            build = 'true'
         "#)
         .file("src/lib.rs", r#"
             pub fn foo() {}


### PR DESCRIPTION
There's no "doc-all" profile, so it needs to be canonicalized when finding the
name of the profile to pass to a build command.
