### PR TITLE
add codegen-units option to profile section

### DIFF
--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -107,6 +107,7 @@ pub enum TargetKind {
 pub struct Profile {
     env: String, // compile, test, dev, bench, etc.
     opt_level: uint,
+    codegen_units: Option<uint>,    // None = use rustc default
     debug: bool,
     test: bool,
     doctest: bool,
@@ -121,6 +122,7 @@ impl Profile {
         Profile {
             env: String::new(),
             opt_level: 0,
+            codegen_units: None,
             debug: false,
             test: false,
             doc: false,
@@ -206,6 +208,10 @@ impl Profile {
         self.opt_level
     }
 
+    pub fn get_codegen_units(&self) -> Option<uint> {
+        self.codegen_units
+    }
+
     pub fn get_debug(&self) -> bool {
         self.debug
     }
@@ -220,6 +226,11 @@ impl Profile {
 
     pub fn opt_level(mut self, level: uint) -> Profile {
         self.opt_level = level;
+        self
+    }
+
+    pub fn codegen_units(mut self, units: Option<uint>) -> Profile {
+        self.codegen_units = units;
         self
     }
 
@@ -260,6 +271,7 @@ impl<H: hash::Writer> hash::Hash<H> for Profile {
         // to the actual hash of a profile.
         let Profile {
             opt_level,
+            codegen_units,
             debug,
             plugin,
             dest: ref dest,
@@ -273,7 +285,7 @@ impl<H: hash::Writer> hash::Hash<H> for Profile {
             test: _,
             doctest: _,
         } = *self;
-        (opt_level, debug, plugin, dest, harness).hash(into)
+        (opt_level, codegen_units, debug, plugin, dest, harness).hash(into)
     }
 }
 

--- a/src/cargo/ops/cargo_rustc/mod.rs
+++ b/src/cargo/ops/cargo_rustc/mod.rs
@@ -352,6 +352,11 @@ fn build_base_args(cx: &Context, mut cmd: ProcessBuilder,
         cmd = cmd.arg("--opt-level").arg(profile.get_opt_level().to_string());
     }
 
+    match profile.get_codegen_units() {
+        Some(n) => cmd = cmd.arg("-C").arg(format!("codegen-units={}", n)),
+        None => {},
+    }
+
     if profile.get_debug() {
         cmd = cmd.arg("-g");
     } else {

--- a/src/cargo/util/toml.rs
+++ b/src/cargo/util/toml.rs
@@ -221,6 +221,7 @@ pub struct TomlProfiles {
 #[deriving(Decodable, Clone, Default)]
 pub struct TomlProfile {
     opt_level: Option<uint>,
+    codegen_units: Option<uint>,
     debug: Option<bool>,
 }
 
@@ -604,8 +605,9 @@ fn normalize(libs: &[TomlLibTarget],
             None => return profile,
         };
         let opt_level = toml.opt_level.unwrap_or(profile.get_opt_level());
+        let codegen_units = toml.codegen_units;
         let debug = toml.debug.unwrap_or(profile.get_debug());
-        profile.opt_level(opt_level).debug(debug)
+        profile.opt_level(opt_level).codegen_units(codegen_units).debug(debug)
     }
 
     fn target_profiles(target: &TomlTarget, profiles: &TomlProfiles,


### PR DESCRIPTION
If the profile sets `codegen-units`, the value will be passed to `rustc`'s `-C codegen-units` option.  If no value is set, then no argument will be passed, so `rustc` will use its default settings.
