### PR TITLE
Fix `make install` on Windows

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -174,7 +174,7 @@ endif
 install-$(1): prepare-manifest-$(1)
 	$$(PKGDIR_$(1))/install.sh \
 		--prefix="$$(CFG_PREFIX)" \
-		--destdir="$$(DESTDIR)/" $$(MAYBE_DISABLE_VERIFY)
+		--destdir="$$(DESTDIR)" $$(MAYBE_DISABLE_VERIFY)
 endef
 $(foreach target,$(CFG_TARGET),$(eval $(call DO_DIST_TARGET,$(target))))
 


### PR DESCRIPTION
Since `Makefile` passes `--destdir="$$(DESTDIR)/"` to `install.sh`,
`make install` tries to install libraries to
`$CFG_DESTDIR$CFG_PREFIX/$CFG_LIBDIR_RELATIVE` which is usually
`//path/to/usr/$CFG_LIBDIR_RELATIVE`.

The POSIX spec [1](http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap04.html#tag_04_12) states that if path begins with `//` it is
implementation-defined.
Usual systems treat them as normal abaolute path, but cygwin and MSYS
does not! They use `//hostname/path` syntax for network drives.
This caused `make install` issue on Windows.

This patch removes `/` of destdir to solve the issue.
