### PR TITLE
Stop capturing output of all dependencies

### DIFF
--- a/.travis.install.deps.sh
+++ b/.travis.install.deps.sh
@@ -25,6 +25,7 @@ host=static-rust-lang-org.s3.amazonaws.com
 # just install the right ones? This should enable cross compilation in the
 # future anyway.
 if [ -z "${windows}" ]; then
+    rm -rf rustc *.tar.gz
     curl -O https://$host/dist/rust-nightly-i686-$target.tar.gz
     curl -O https://$host/dist/rust-nightly-x86_64-$target.tar.gz
     tar xfz rust-nightly-i686-$target.tar.gz
@@ -49,6 +50,7 @@ if [ -z "${windows}" ]; then
     rm -f rust-nightly-i686-$target.tar.gz
     rm -f rust-nightly-x86_64-$target.tar.gz
 else
+    rm -rf rustc *.exe
     if [ "${BITS}" = "64" ]; then
         triple=x86_64-w64-mingw32
     else

--- a/tests/test_cargo_compile.rs
+++ b/tests/test_cargo_compile.rs
@@ -213,7 +213,11 @@ test!(cargo_compile_with_warnings_in_a_dep_package {
                               {} foo v0.5.0 ({})\n",
                              COMPILING, p.url(),
                              COMPILING, p.url()))
-        .with_stderr(""));
+        .with_stderr("\
+[..]warning: code is never used: `dead`[..]
+[..]fn dead() {}
+
+"));
 
     assert_that(&p.bin("foo"), existing_file());
 


### PR DESCRIPTION
There are some competing concerns when it comes to the output of compiling
dependencies:
- Not capturing anything leads to getting drowned in unrelated output
- Capturing requires coloration be compromised because of the way windows
  terminal colors are implemented.
- Path dependencies are often developed in tandem with the rest of a package,
  and capturing their output is not always desired.

To address these concerns, cargo previously captured output of dependent
compilations and then re-printed it to the screen if an error occurred. This
patch modifies the behavior to as follows:
- No output is captured. This preserves any coloration rustc provides.
- All dependencies are compiled with `-Awarnings`. This should suppress any
  extraneous output from the compiler and it is considered a bug otherwise if
  the compiler prints a warnings when `-Awarnings` is specified.
- All _path_ dependencies (`path="..."`, overrides, etc) are _not_ compiled with
  `-Awarnings`. The reason for this is that you are always in control of these
  packages and probably want to see warnings anyway.

Closes #490
Closes #496
