### PR TITLE
Fix Rust and Cargo nightly Windows links.

### DIFF
--- a/src/doc/index.md
+++ b/src/doc/index.md
@@ -12,8 +12,8 @@ $ curl https://static.rust-lang.org/rustup.sh | sudo bash
 This will get you the latest Rust nightly for your platform along with
 the latest Cargo. You should run this script almost every day to get the latest updates.
 
-If you are on Windows, you can directly download the latest [Rust](http://static.rust-lang.org/dist/rust-nightly-install.exe)
-and [Cargo](http://static.rust-lang.org/cargo-dist/cargo-nightly-i686-pc-mingw32.tar.gz) nightlies.
+If you are on Windows, you can directly download the latest [Rust](https://static.rust-lang.org/dist/rust-nightly-i686-w64-mingw32.exe)
+and [Cargo](https://static.rust-lang.org/cargo-dist/cargo-nightly-i686-w64-mingw32.tar.gz) nightlies.
 
 Alternatively, you can build Cargo from source.
 


### PR DESCRIPTION
Closes #615.

Current links are 404. Updated to the i686-w64 nightlies.
