### PR TITLE
Allow updating to a precise revision

### DIFF
--- a/src/cargo/ops/mod.rs
+++ b/src/cargo/ops/mod.rs
@@ -7,6 +7,7 @@ pub use self::cargo_new::{new, NewOptions};
 pub use self::cargo_doc::{doc, DocOptions};
 pub use self::cargo_generate_lockfile::{generate_lockfile, write_resolve};
 pub use self::cargo_generate_lockfile::{update_lockfile, load_lockfile};
+pub use self::cargo_generate_lockfile::UpdateOptions;
 pub use self::cargo_test::{run_tests, run_benches, TestOptions};
 pub use self::cargo_package::package;
 pub use self::cargo_upload::{upload, upload_configuration, UploadConfig};

--- a/src/cargo/util/config.rs
+++ b/src/cargo/util/config.rs
@@ -144,13 +144,13 @@ impl ConfigValue {
                         toml::String(val) => Ok((val, path.clone())),
                         _ => Err(internal("")),
                     }
-                }).collect::<Result<_, _>>())))
+                }).collect::<CargoResult<_>>())))
             }
             toml::Table(val) => {
                 Ok(Table(try!(val.into_iter().map(|(key, value)| {
                     let value = raw_try!(ConfigValue::from_toml(path, value));
                     Ok((key, value))
-                }).collect::<Result<_, _>>())))
+                }).collect::<CargoResult<_>>())))
             }
             _ => return Err(internal(""))
         }


### PR DESCRIPTION
This commit adds a flag, --precise, to cargo update. This flag is used to update
a dependency to precisely an exact revision (or branch) as part of an update
step. For git repositories the argument is some form of reference, while
registry packages this will be a version number.

The flag --precise forces a non-aggressive update and will fail if the
--aggresive flag is specified.

Closes #484

r? @wycats
