### PR TITLE
Remove the deprecated -u flag

### DIFF
--- a/src/bin/bench.rs
+++ b/src/bin/bench.rs
@@ -35,7 +35,6 @@ pub fn execute(options: Options, shell: &mut MultiShell) -> CliResult<Option<()>
     let mut ops = ops::TestOptions {
         no_run: options.flag_no_run,
         compile_opts: ops::CompileOptions {
-            update: false,
             env: "bench",
             shell: shell,
             jobs: options.flag_jobs,

--- a/src/bin/build.rs
+++ b/src/bin/build.rs
@@ -20,7 +20,6 @@ Options:
     --features FEATURES     Space-separated list of features to also build
     --no-default-features   Do not build the `default` feature
     --target TRIPLE         Build for the target triple
-    -u, --update-remotes    Deprecated option, use `cargo update` instead
     --manifest-path PATH    Path to the manifest to compile
     -v, --verbose           Use verbose output
 ",  flag_jobs: Option<uint>, flag_target: Option<String>,
@@ -39,7 +38,6 @@ pub fn execute(options: Options, shell: &mut MultiShell) -> CliResult<Option<()>
     };
 
     let mut opts = CompileOptions {
-        update: options.flag_update_remotes,
         env: env,
         shell: shell,
         jobs: options.flag_jobs,

--- a/src/bin/doc.rs
+++ b/src/bin/doc.rs
@@ -17,7 +17,6 @@ Options:
     -j N, --jobs N          The number of jobs to run in parallel
     --features FEATURES     Space-separated list of features to also build
     --no-default-features   Do not build the `default` feature
-    -u, --update-remotes    Deprecated option, use `cargo update` instead
     --manifest-path PATH    Path to the manifest to document
     -v, --verbose           Use verbose output
 
@@ -35,7 +34,6 @@ pub fn execute(options: Options, shell: &mut MultiShell) -> CliResult<Option<()>
     let mut doc_opts = ops::DocOptions {
         all: !options.flag_no_deps,
         compile_opts: ops::CompileOptions {
-            update: options.flag_update_remotes,
             env: if options.flag_no_deps {"doc"} else {"doc-all"},
             shell: shell,
             jobs: options.flag_jobs,

--- a/src/bin/run.rs
+++ b/src/bin/run.rs
@@ -19,7 +19,6 @@ Options:
     --features FEATURES     Space-separated list of features to also build
     --no-default-features   Do not build the `default` feature
     --target TRIPLE         Build for the target triple
-    -u, --update-remotes    Deprecated option, use `cargo update` instead
     --manifest-path PATH    Path to the manifest to execute
     -v, --verbose           Use verbose output
 
@@ -32,7 +31,6 @@ pub fn execute(options: Options, shell: &mut MultiShell) -> CliResult<Option<()>
     let root = try!(find_root_manifest_for_cwd(options.flag_manifest_path));
 
     let mut compile_opts = ops::CompileOptions {
-        update: options.flag_update_remotes,
         env: if options.flag_release { "release" } else { "compile" },
         shell: shell,
         jobs: options.flag_jobs,

--- a/src/bin/test.rs
+++ b/src/bin/test.rs
@@ -19,7 +19,6 @@ Options:
     --features FEATURES     Space-separated list of features to also build
     --no-default-features   Do not build the `default` feature
     --target TRIPLE         Build for the target triple
-    -u, --update-remotes    Deprecated option, use `cargo update` instead
     --manifest-path PATH    Path to the manifest to build tests for
     -v, --verbose           Use verbose output
 
@@ -35,7 +34,6 @@ pub fn execute(options: Options, shell: &mut MultiShell) -> CliResult<Option<()>
     let mut ops = ops::TestOptions {
         no_run: options.flag_no_run,
         compile_opts: ops::CompileOptions {
-            update: options.flag_update_remotes,
             env: "test",
             shell: shell,
             jobs: options.flag_jobs,

--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -34,7 +34,6 @@ use util::config::{Config, ConfigValue};
 use util::{CargoResult, Wrap, config, internal, human, ChainError, profile};
 
 pub struct CompileOptions<'a> {
-    pub update: bool,
     pub env: &'a str,
     pub shell: &'a mut MultiShell<'a>,
     pub jobs: Option<uint>,
@@ -47,7 +46,7 @@ pub struct CompileOptions<'a> {
 pub fn compile(manifest_path: &Path,
                options: &mut CompileOptions)
                -> CargoResult<ops::Compilation> {
-    let CompileOptions { update, env, ref mut shell, jobs, target,
+    let CompileOptions { env, ref mut shell, jobs, target,
                          dev_deps, features, no_default_features } = *options;
     let target = target.map(|s| s.to_string());
     let features = features.iter().flat_map(|s| {
@@ -55,11 +54,6 @@ pub fn compile(manifest_path: &Path,
     }).map(|s| s.to_string()).collect::<Vec<String>>();
 
     log!(4, "compile; manifest-path={}", manifest_path.display());
-
-    if update {
-        return Err(human("The -u flag has been deprecated, please use the \
-                          `cargo update` command instead"));
-    }
 
     let mut source = try!(PathSource::for_path(&manifest_path.dir_path()));
     try!(source.update());


### PR DESCRIPTION
This flag has been deprecated in favor of `cargo update` for quite some time
now.

r? @brson
