### PR TITLE
Fit text within window in Safari when under 629px in width

### DIFF
--- a/src/doc/stylesheets/all.css
+++ b/src/doc/stylesheets/all.css
@@ -60,6 +60,7 @@ main {
   -webkit-flex-direction: column;
           flex-direction: column;
 
+  width: 100%;
   max-width: 900px;
   margin-bottom: 10px;
 


### PR DESCRIPTION
Text is not responsive under 629px in Safari.
