### PR TITLE
bump depens versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,7 +12,7 @@ dependencies = [
  "semver 0.1.0 (git+https://github.com/rust-lang/semver#e7adaf4fa43f77408e640985cf3b3ec9ed81b5b8)",
  "tar 0.0.1 (git+https://github.com/alexcrichton/tar-rs#e7c9952ea75a75688966b516d8bbefb740f54208)",
  "toml 0.1.0 (git+https://github.com/alexcrichton/toml-rs#8cdb2747de86ea7de6491ce5ba5dc522421bed7f)",
- "url 0.1.0 (git+https://github.com/servo/rust-url#29f70a47230c2aa736e263977247c786e0b2c243)",
+ "url 0.1.0 (git+https://github.com/servo/rust-url#f320b1e64d5caaf3cf4a31c8960f646ff7e865f7)",
 ]
 
 [[package]]
@@ -22,7 +22,7 @@ source = "git+https://github.com/alexcrichton/curl-rust?ref=bundle#720d87fa32c73
 dependencies = [
  "curl-sys 0.0.1 (git+https://github.com/alexcrichton/curl-rust?ref=bundle#720d87fa32c738c397252cf3c26d428bdca697d4)",
  "link-config 0.0.1 (git+https://github.com/alexcrichton/link-config#1d3cd271612036b47c015a55f33a97e1524569ae)",
- "url 0.1.0 (git+https://github.com/servo/rust-url#29f70a47230c2aa736e263977247c786e0b2c243)",
+ "url 0.1.0 (git+https://github.com/servo/rust-url#f320b1e64d5caaf3cf4a31c8960f646ff7e865f7)",
 ]
 
 [[package]]
@@ -46,7 +46,7 @@ dependencies = [
 [[package]]
 name = "encoding"
 version = "0.1.0"
-source = "git+https://github.com/lifthrasiir/rust-encoding#1d26487807127f221afd55492f8f40cc4e718648"
+source = "git+https://github.com/lifthrasiir/rust-encoding#ea41c0226067331a4d13142c81d82b614135c82a"
 
 [[package]]
 name = "flate2"
@@ -59,7 +59,7 @@ version = "0.0.1"
 source = "git+https://github.com/alexcrichton/git2-rs#545b7d27180bef79dea1cbc5de46f74cb9f085f8"
 dependencies = [
  "libgit2 0.0.1 (git+https://github.com/alexcrichton/git2-rs#545b7d27180bef79dea1cbc5de46f74cb9f085f8)",
- "url 0.1.0 (git+https://github.com/servo/rust-url#29f70a47230c2aa736e263977247c786e0b2c243)",
+ "url 0.1.0 (git+https://github.com/servo/rust-url#f320b1e64d5caaf3cf4a31c8960f646ff7e865f7)",
 ]
 
 [[package]]
@@ -115,8 +115,8 @@ source = "git+https://github.com/alexcrichton/toml-rs#8cdb2747de86ea7de6491ce5ba
 [[package]]
 name = "url"
 version = "0.1.0"
-source = "git+https://github.com/servo/rust-url#29f70a47230c2aa736e263977247c786e0b2c243"
+source = "git+https://github.com/servo/rust-url#f320b1e64d5caaf3cf4a31c8960f646ff7e865f7"
 dependencies = [
- "encoding 0.1.0 (git+https://github.com/lifthrasiir/rust-encoding#1d26487807127f221afd55492f8f40cc4e718648)",
+ "encoding 0.1.0 (git+https://github.com/lifthrasiir/rust-encoding#ea41c0226067331a4d13142c81d82b614135c82a)",
 ]
 


### PR DESCRIPTION
`..` -> `...` required a handful of modifications to various and sundry depens of cargo. This patch is required to compile on my machine.
