### PR TITLE
Don't always run doc tests for the root package

### DIFF
--- a/src/cargo/ops/cargo_clean.rs
+++ b/src/cargo/ops/cargo_clean.rs
@@ -49,7 +49,7 @@ pub fn clean(manifest_path: &Path, opts: &mut CleanOptions) -> CargoResult<()> {
     let pkgs = PackageSet::new([]);
     let cx = try!(Context::new("compile", &resolve, &srcs, &pkgs, &mut cfg,
                                Layout::at(root.get_absolute_target_dir()),
-                               None));
+                               None, &pkg));
 
     // And finally, clean everything out!
     for target in pkg.get_targets().iter() {

--- a/src/cargo/ops/cargo_rustc/compilation.rs
+++ b/src/cargo/ops/cargo_rustc/compilation.rs
@@ -35,10 +35,13 @@ pub struct Compilation {
     /// Extra environment variables that were passed to compilations and should
     /// be passed to future invocations of programs.
     pub extra_env: HashMap<String, Option<String>>,
+
+    /// Top-level package that was compiled
+    pub package: Package,
 }
 
 impl Compilation {
-    pub fn new() -> Compilation {
+    pub fn new(pkg: &Package) -> Compilation {
         Compilation {
             libraries: HashMap::new(),
             native_dirs: HashMap::new(),
@@ -47,6 +50,7 @@ impl Compilation {
             tests: Vec::new(),
             binaries: Vec::new(),
             extra_env: HashMap::new(),
+            package: pkg.clone(),
         }
     }
 

--- a/src/cargo/ops/cargo_rustc/context.rs
+++ b/src/cargo/ops/cargo_rustc/context.rs
@@ -38,7 +38,8 @@ pub struct Context<'a, 'b> {
 impl<'a, 'b> Context<'a, 'b> {
     pub fn new(env: &'a str, resolve: &'a Resolve, sources: &'a SourceMap,
                deps: &'a PackageSet, config: &'b mut Config<'b>,
-               host: Layout, target: Option<Layout>)
+               host: Layout, target: Option<Layout>,
+               root_pkg: &Package)
                -> CargoResult<Context<'a, 'b>> {
         let (target_dylib, target_exe) =
                 try!(Context::filename_parts(config.target()));
@@ -66,7 +67,7 @@ impl<'a, 'b> Context<'a, 'b> {
             target_exe: target_exe,
             host_dylib: host_dylib,
             requirements: HashMap::new(),
-            compilation: Compilation::new(),
+            compilation: Compilation::new(root_pkg),
         })
     }
 

--- a/src/cargo/ops/cargo_rustc/mod.rs
+++ b/src/cargo/ops/cargo_rustc/mod.rs
@@ -54,7 +54,7 @@ pub fn compile_targets<'a>(env: &str, targets: &[&'a Target], pkg: &'a Package,
                            config: &'a mut Config<'a>)
                            -> CargoResult<Compilation> {
     if targets.is_empty() {
-        return Ok(Compilation::new())
+        return Ok(Compilation::new(pkg))
     }
 
     debug!("compile_targets; targets={}; pkg={}; deps={}", targets, pkg, deps);
@@ -67,7 +67,7 @@ pub fn compile_targets<'a>(env: &str, targets: &[&'a Target], pkg: &'a Package,
     });
 
     let mut cx = try!(Context::new(env, resolve, sources, deps, config,
-                                   host_layout, target_layout));
+                                   host_layout, target_layout, pkg));
     let mut queue = JobQueue::new(cx.resolve, deps, cx.config);
 
     // First ensure that the destination directory exists

--- a/src/cargo/ops/cargo_test.rs
+++ b/src/cargo/ops/cargo_test.rs
@@ -42,7 +42,7 @@ pub fn run_tests(manifest_path: &Path,
 
     if options.compile_opts.env == "bench" { return Ok(None) }
 
-    let mut libs = package.get_targets().iter().filter_map(|target| {
+    let mut libs = compile.package.get_targets().iter().filter_map(|target| {
         if !target.get_profile().is_doctest() || !target.is_lib() {
             return None
         }


### PR DESCRIPTION
When using `cargo test -p`, be sure to run only the doc tests for the package
actually being tested.

Closes #660
