### PR TITLE
Let the help command work consistently everywhere

### DIFF
--- a/src/bin/cargo.rs
+++ b/src/bin/cargo.rs
@@ -58,6 +58,7 @@ macro_rules! each_subcommand( ($macro:ident) => ({
     $macro!(fetch)
     $macro!(generate_lockfile)
     $macro!(git_checkout)
+    $macro!(help)
     $macro!(locate_project)
     $macro!(login)
     $macro!(new)

--- a/src/bin/config_for_key.rs
+++ b/src/bin/config_for_key.rs
@@ -11,7 +11,12 @@ struct ConfigOut {
 }
 
 docopt!(ConfigForKeyFlags, "
-Usage: cargo config-for-key --human --key=<key>
+Usage:
+    cargo config-for-key --human --key=<key>
+    cargo config-for-key -h | --help
+
+Options:
+    -h, --help          Print this message
 ")
 
 pub fn execute(args: ConfigForKeyFlags,

--- a/src/bin/config_list.rs
+++ b/src/bin/config_list.rs
@@ -11,7 +11,12 @@ struct ConfigOut {
 }
 
 docopt!(ConfigListFlags, "
-Usage: cargo config-list --human
+Usage:
+    cargo config-list --human
+    cargo config-list -h | --help
+
+Options:
+    -h, --help          Print this message
 ")
 
 pub fn execute(args: ConfigListFlags,

--- a/src/bin/git_checkout.rs
+++ b/src/bin/git_checkout.rs
@@ -8,6 +8,7 @@ use cargo::util::{Config, CliResult, CliError, human, ToUrl};
 docopt!(Options, "
 Usage:
     cargo git-checkout [options] --url=URL --reference=REF
+    cargo git-checkout -h | --help
 
 Options:
     -h, --help              Print this message

--- a/src/bin/help.rs
+++ b/src/bin/help.rs
@@ -1,0 +1,22 @@
+use docopt;
+
+use cargo::core::MultiShell;
+use cargo::util::{CliResult, CliError};
+
+docopt!(Options, "
+Get some help with a cargo command.
+
+Usage:
+    cargo help <command>
+    cargo help -h | --help
+
+Options:
+    -h, --help          Print this message
+")
+
+pub fn execute(_: Options, _: &mut MultiShell) -> CliResult<Option<()>> {
+    // This is a dummy command just so that `cargo help help` works.
+    // The actual delegation of help flag to subcommands is handled by the
+    // cargo command.
+    Err(CliError::new("Help command should not be executed directly.", 101))
+}

--- a/src/bin/locate_project.rs
+++ b/src/bin/locate_project.rs
@@ -10,6 +10,7 @@ Usage:
 
 Options:
     --manifest-path PATH    Path to the manifest to build benchmarks for
+    -h, --help              Print this message
 ", flag_manifest_path: Option<String>)
 
 #[deriving(Encodable)]

--- a/src/bin/read_manifest.rs
+++ b/src/bin/read_manifest.rs
@@ -6,7 +6,8 @@ use cargo::sources::{PathSource};
 
 docopt!(Options, "
 Usage:
-    cargo clean [options] --manifest-path=PATH
+    cargo read-manifest [options] --manifest-path=PATH
+    cargo read-manifest -h | --help
 
 Options:
     -h, --help              Print this message

--- a/src/bin/verify_project.rs
+++ b/src/bin/verify_project.rs
@@ -13,6 +13,7 @@ pub type Error = HashMap<String, String>;
 docopt!(Flags, "
 Usage:
     cargo verify-project [options] --manifest-path PATH
+    cargo verify-project -h | --help
 
 Options:
     -h, --help              Print this message


### PR DESCRIPTION
This adds a dummy help command so that it's usage can be documented with docopt! This lets `cargo help help` work.

Also adds help flags to all of the subcommands that were missing them. Without
that `cargo help sub-command` shows Invalid Argument before the usage text.
