### PR TITLE
Fix tons of unused value errors

### DIFF
--- a/src/cargo/lib.rs
+++ b/src/cargo/lib.rs
@@ -3,7 +3,7 @@
 
 #![feature(macro_rules, phase)]
 #![feature(default_type_params)]
-#![deny(bad_style, unused)]
+#![deny(bad_style)]
 
 extern crate libc;
 extern crate regex;


### PR DESCRIPTION
I'm not sure what changed, but unused value lints were popping up everwhere when I tried to build today.

This turns on the `if let` feature since it allows rewriting a lot of calls to `Option::map` that were only being used for their side effects into a clean form.  Cargo seems as good of a place as any to dogfood it.
