### PR TITLE
Make sure dev-deps are compiled for examples

### DIFF
--- a/src/cargo/ops/cargo_rustc/job_queue.rs
+++ b/src/cargo/ops/cargo_rustc/job_queue.rs
@@ -108,6 +108,7 @@ impl<'a, 'b> JobQueue<'a, 'b> {
             loop {
                 match self.queue.dequeue() {
                     Some((fresh, (_, stage), (pkg, jobs))) => {
+                        info!("start: {} {}", pkg, stage);
                         try!(self.run(pkg, stage, fresh, jobs, config));
                     }
                     None => break,
@@ -118,6 +119,7 @@ impl<'a, 'b> JobQueue<'a, 'b> {
             // of work to finish. If any package fails to build then we stop
             // scheduling work as quickly as possibly.
             let (id, stage, fresh, result) = self.rx.recv();
+            info!("  end: {} {}", id, stage);
             let id = *self.state.keys().find(|&k| *k == &id).unwrap();
             self.active -= 1;
             match result {

--- a/src/cargo/ops/cargo_rustc/mod.rs
+++ b/src/cargo/ops/cargo_rustc/mod.rs
@@ -171,6 +171,7 @@ fn compile<'a, 'b>(targets: &[&'a Target], pkg: &'a Package,
         let dst = match (target.is_lib(), target.get_profile().is_test()) {
             (_, true) => &mut tests,
             (true, _) => &mut libs,
+            (false, false) if target.get_profile().get_env() == "test" => &mut tests,
             (false, false) => &mut bins,
         };
         for (work, kind, desc) in work.into_iter() {

--- a/tests/test_cargo_test.rs
+++ b/tests/test_cargo_test.rs
@@ -1054,6 +1054,52 @@ test!(build_then_selective_test {
                 execs().with_status(0));
 })
 
+test!(example_dev_dep {
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [project]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+
+            [dev-dependencies.bar]
+            path = "bar"
+        "#)
+        .file("src/lib.rs", r#"
+        "#)
+        .file("examples/e1.rs", r#"
+            extern crate bar;
+            fn main() { }
+        "#)
+        .file("bar/Cargo.toml", r#"
+            [package]
+            name = "bar"
+            version = "0.0.1"
+            authors = []
+        "#)
+        .file("bar/src/lib.rs", r#"
+            #![feature(macro_rules)]
+            // make sure this file takes awhile to compile
+            macro_rules! f0( () => (1u) )
+            macro_rules! f1( () => ({(f0!()) + (f0!())}) )
+            macro_rules! f2( () => ({(f1!()) + (f1!())}) )
+            macro_rules! f3( () => ({(f2!()) + (f2!())}) )
+            macro_rules! f4( () => ({(f3!()) + (f3!())}) )
+            macro_rules! f5( () => ({(f4!()) + (f4!())}) )
+            macro_rules! f6( () => ({(f5!()) + (f5!())}) )
+            macro_rules! f7( () => ({(f6!()) + (f6!())}) )
+            macro_rules! f8( () => ({(f7!()) + (f7!())}) )
+            macro_rules! f9( () => ({(f8!()) + (f8!())}) )
+            macro_rules! f10( () => ({(f9!()) + (f9!())}) )
+            macro_rules! f11( () => ({(f10!()) + (f10!())}) )
+            pub fn bar() {
+                f11!();
+            }
+        "#);
+    assert_that(p.cargo_process("test"),
+                execs().with_status(0));
+})
+
 test!(selective_testing_with_docs {
     let p = project("foo")
         .file("Cargo.toml", r#"


### PR DESCRIPTION
Examples are classified as binaries, but do not have the `test` flag set on
their Profile. They do, however, have their environment set to `test`. Be sure
to place them into the `tests` bucket so they have development dependencies
available for their compilation.

Closes #668 
