### PR TITLE
Clean up some uses of `Option::map` only for its side effects

### DIFF
--- a/src/cargo/core/resolver.rs
+++ b/src/cargo/core/resolver.rs
@@ -97,9 +97,9 @@ pub struct EncodablePackageId {
 impl<E, S: Encoder<E>> Encodable<S, E> for EncodablePackageId {
     fn encode(&self, s: &mut S) -> Result<(), E> {
         let mut out = format!("{} {}", self.name, self.version);
-        self.source.as_ref().map(|s| {
-            out.push_str(format!(" ({})", s.to_url()).as_slice())
-        });
+        if let Some(ref s) = self.source {
+            out.push_str(format!(" ({})", s.to_url()).as_slice());
+        }
         out.encode(s)
     }
 }

--- a/src/cargo/ops/cargo_generate_lockfile.rs
+++ b/src/cargo/ops/cargo_generate_lockfile.rs
@@ -153,11 +153,11 @@ fn emit_package(dep: &toml::TomlTable, out: &mut String) {
     out.push_str(format!("name = {}\n", lookup(dep, "name")).as_slice());
     out.push_str(format!("version = {}\n", lookup(dep, "version")).as_slice());
 
-    dep.find(&"source".to_string()).map(|_| {
+    if dep.contains_key(&"source".to_string()) {
         out.push_str(format!("source = {}\n", lookup(dep, "source")).as_slice());
-    });
+    }
 
-    dep.find(&"dependencies".to_string()).map(|s| {
+    if let Some(ref s) = dep.find(&"dependencies".to_string()) {
         let slice = s.as_slice().unwrap();
 
         if !slice.is_empty() {
@@ -170,7 +170,7 @@ fn emit_package(dep: &toml::TomlTable, out: &mut String) {
             out.push_str("]\n");
         }
         out.push_str("\n");
-    });
+    }
 }
 
 fn lookup<'a>(table: &'a toml::TomlTable, key: &str) -> &'a toml::Value {

--- a/src/cargo/util/errors.rs
+++ b/src/cargo/util/errors.rs
@@ -179,7 +179,9 @@ impl Show for ProcessError {
             None => "never executed".to_string()
         };
         try!(write!(f, "{} (status={})", self.msg, exit));
-        self.output().map(|out| { let _ = write!(f, "{}", out); });
+        if let Some(out) = self.output() {
+            try!(write!(f, "{}", out));
+        }
         Ok(())
     }
 }


### PR DESCRIPTION
This reduces syntactic noise and is a good use case for `if let`, which I turned on.
