### PR TITLE
Allow to invoke Cargo commands with empty features

### DIFF
--- a/src/cargo/core/resolver.rs
+++ b/src/cargo/core/resolver.rs
@@ -457,6 +457,9 @@ fn build_features(s: &Summary, method: ResolveMethod)
                    deps: &mut HashSet<String>,
                    used: &mut HashSet<String>,
                    visited: &mut HashSet<String>) -> CargoResult<()> {
+        if feat.is_empty() {
+            return Ok(())
+        }
         if !visited.insert(feat.to_string()) {
             return Err(human(format!("Cyclic feature dependency: feature `{}` \
                                       depends on itself", feat)))

--- a/tests/test_cargo_features.rs
+++ b/tests/test_cargo_features.rs
@@ -462,3 +462,18 @@ test!(many_features_no_rebuilds {
     assert_that(p.process(cargo_dir().join("cargo")).arg("build"),
                 execs().with_status(0).with_stdout(""));
 })
+
+// Tests that all cmd lines work with `--features ""`
+test!(empty_features {
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [project]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+        "#)
+        .file("src/main.rs", "fn main() {}");
+
+    assert_that(p.cargo_process("build").arg("--features").arg(""),
+                execs().with_status(0));
+})


### PR DESCRIPTION
For automation it should be no difference between invocations 
of `--features "feat1 feat2 feat3"` and `--features ""`.

The problem is that in the latter case `docopt` sets flag_feature to vec![""]

Could be solved on 3 different levels:
- patching `docopt` to treat empty string for a Vec<String> flag
  as empty vec. Although I can't imagine that in some place it 
  might be required to treat empty string as vector of empty
  strings it is might have its own use
- filtering flags_feature right after parsing command line and
  before passing further. It means it should be fixed in at
  least 4 different places now and may be forgotten in future
- filtering empty string feature while resolving - perhaps 
  the easiest and more universal solution, implemented in this
  patch
