### PR TITLE
Check crate name for invalid characters in cargo new

### DIFF
--- a/src/cargo/ops/cargo_new.rs
+++ b/src/cargo/ops/cargo_new.rs
@@ -29,6 +29,12 @@ pub fn new(opts: NewOptions, _shell: &mut MultiShell) -> CargoResult<()> {
                                  path.display())))
     }
     let name = path.filename_str().unwrap();
+    for c in name.chars() {
+        if c.is_alphanumeric() { continue }
+        if c == '_' || c == '-' { continue }
+        return Err(human(format!("Invalid character `{}` in crate name: `{}`",
+                                 c, name).as_slice()));
+    }
     mk(&path, name, &opts).chain_error(|| {
         human(format!("Failed to create project `{}` at `{}`",
                       name, path.display()))

--- a/tests/test_cargo_new.rs
+++ b/tests/test_cargo_new.rs
@@ -100,6 +100,12 @@ test!(existing {
                                             dst.display())));
 })
 
+test!(invalid_characters {
+    assert_that(cargo_process("new").arg("foo.rs"),
+                execs().with_status(101)
+                       .with_stderr("Invalid character `.` in crate name: `foo.rs`"));
+})
+
 test!(finds_author_user {
     // Use a temp dir to make sure we don't pick up .cargo/config somewhere in
     // the hierarchy


### PR DESCRIPTION
Crate names have tight restrictions in Rust. `cargo new` should not allow invalid characters in crate names, as such crates will just fail to compile later on.

This check is based on the one found in rustc's `validate_crate_name` (https://github.com/rust-lang/rust/blob/master/src/librustc/metadata/creader.rs#L185-L189).
