### PR TITLE
Move documentation to doc.crates.io

### DIFF
--- a/src/doc/CNAME
+++ b/src/doc/CNAME
@@ -1,1 +1,1 @@
-crates.io
+doc.crates.io


### PR DESCRIPTION
The actual crates.io domain will become the registry itself, but the
auto-generated documentation from this repository will continue to be available
at the doc.crates.io domain.

In the meantime, we've set up redirects from crates.io and www.crates.io to
doc.crates.io and the github-pages site will now be doc.crates.io
