### PR TITLE
Tweak native-build.md example

### DIFF
--- a/src/doc/native-build.md
+++ b/src/doc/native-build.md
@@ -115,8 +115,8 @@ CFLAGS += -m64 -fPIC
 endif
 
 all:
-    $(CC) $(CFLAGS) hello.c -c -o $(OUT_DIR)/hello.o
-    $(AR) crus $(OUT_DIR)/libhello.a $(OUT_DIR)/hello.o
+    $(CC) $(CFLAGS) hello.c -c -o "$$OUT_DIR"/hello.o
+    $(AR) crus "$$OUT_DIR"/libhello.a "$$OUT_DIR"/hello.o
 
 ```
 


### PR DESCRIPTION
`$(OUT_DIR)` may contain spaces, so it needs to be quoted. It also needs to be expanded by the shell, not by `make`, or any quotes/backslashes in the value will cause problems.
