### PR TITLE
Add an `rpath` option to the profile section

### DIFF
--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -111,6 +111,7 @@ pub struct Profile {
     opt_level: uint,
     codegen_units: Option<uint>,    // None = use rustc default
     debug: bool,
+    rpath: bool,
     test: bool,
     doctest: bool,
     doc: bool,
@@ -126,6 +127,7 @@ impl Profile {
             opt_level: 0,
             codegen_units: None,
             debug: false,
+            rpath: false,
             test: false,
             doc: false,
             dest: None,
@@ -218,6 +220,10 @@ impl Profile {
         self.debug
     }
 
+    pub fn get_rpath(&self) -> bool {
+        self.rpath
+    }
+
     pub fn get_env(&self) -> &str {
         self.env.as_slice()
     }
@@ -238,6 +244,11 @@ impl Profile {
 
     pub fn debug(mut self, debug: bool) -> Profile {
         self.debug = debug;
+        self
+    }
+
+    pub fn rpath(mut self, rpath: bool) -> Profile {
+        self.rpath = rpath;
         self
     }
 
@@ -275,6 +286,7 @@ impl<H: hash::Writer> hash::Hash<H> for Profile {
             opt_level,
             codegen_units,
             debug,
+            rpath,
             plugin,
             dest: ref dest,
             harness: harness,
@@ -287,7 +299,7 @@ impl<H: hash::Writer> hash::Hash<H> for Profile {
             test: _,
             doctest: _,
         } = *self;
-        (opt_level, codegen_units, debug, plugin, dest, harness).hash(into)
+        (opt_level, codegen_units, debug, rpath, plugin, dest, harness).hash(into)
     }
 }
 

--- a/src/cargo/ops/cargo_rustc/mod.rs
+++ b/src/cargo/ops/cargo_rustc/mod.rs
@@ -366,7 +366,8 @@ fn build_base_args(cx: &Context,
         let root_profile = target.get_profile();
         if root_profile.get_env() != profile.get_env() { continue }
         profile = profile.opt_level(root_profile.get_opt_level())
-                         .debug(root_profile.get_debug());
+                         .debug(root_profile.get_debug())
+                         .rpath(root_profile.get_rpath())
     }
 
     if profile.get_opt_level() != 0 {
@@ -403,6 +404,10 @@ fn build_base_args(cx: &Context,
             cmd = cmd.arg("-C").arg(format!("extra-filename={}", m.extra_filename));
         }
         None => {}
+    }
+
+    if profile.get_rpath() {
+        cmd = cmd.arg("-C").arg("rpath");
     }
 
     return cmd;

--- a/src/cargo/util/toml.rs
+++ b/src/cargo/util/toml.rs
@@ -227,6 +227,7 @@ pub struct TomlProfile {
     opt_level: Option<uint>,
     codegen_units: Option<uint>,
     debug: Option<bool>,
+    rpath: Option<bool>,
 }
 
 #[deriving(Decodable)]
@@ -613,7 +614,9 @@ fn normalize(libs: &[TomlLibTarget],
         let opt_level = toml.opt_level.unwrap_or(profile.get_opt_level());
         let codegen_units = toml.codegen_units;
         let debug = toml.debug.unwrap_or(profile.get_debug());
+        let rpath = toml.rpath.unwrap_or(profile.get_rpath());
         profile.opt_level(opt_level).codegen_units(codegen_units).debug(debug)
+               .rpath(rpath)
     }
 
     fn target_profiles(target: &TomlTarget, profiles: &TomlProfiles,

--- a/tests/test_cargo_profiles.rs
+++ b/tests/test_cargo_profiles.rs
@@ -21,6 +21,7 @@ test!(profile_overrides {
             [profile.dev]
             opt-level = 1
             debug = false
+            rpath = true
         "#)
         .file("src/lib.rs", "");
     assert_that(p.cargo_process("build").arg("-v"),
@@ -31,6 +32,7 @@ test!(profile_overrides {
         --cfg ndebug \
         -C metadata=[..] \
         -C extra-filename=-[..] \
+        -C rpath \
         --out-dir {dir}{sep}target \
         --dep-info [..] \
         -L {dir}{sep}target \


### PR DESCRIPTION
This will enable passing `-C rpath` on all compiles to rustc itself.

Closes #705
