### PR TITLE
Add a metadata section to the lockfile

### DIFF
--- a/src/cargo/core/resolver/mod.rs
+++ b/src/cargo/core/resolver/mod.rs
@@ -11,6 +11,7 @@ use util::profile;
 use util::graph::{Nodes, Edges};
 
 pub use self::encode::{EncodableResolve, EncodableDependency, EncodablePackageId};
+pub use self::encode::Metadata;
 
 mod encode;
 
@@ -23,7 +24,8 @@ mod encode;
 pub struct Resolve {
     graph: Graph<PackageId>,
     features: HashMap<PackageId, HashSet<String>>,
-    root: PackageId
+    root: PackageId,
+    metadata: Option<Metadata>,
 }
 
 pub enum ResolveMethod<'a> {
@@ -37,7 +39,11 @@ impl Resolve {
     fn new(root: PackageId) -> Resolve {
         let mut g = Graph::new();
         g.add(root.clone(), []);
-        Resolve { graph: g, root: root, features: HashMap::new() }
+        Resolve { graph: g, root: root, features: HashMap::new(), metadata: None }
+    }
+
+    pub fn copy_metadata(&mut self, other: &Resolve) {
+        self.metadata = other.metadata.clone();
     }
 
     pub fn iter(&self) -> Nodes<PackageId> {


### PR DESCRIPTION
In terms of future compatibility, Cargo may wish to add more information to
lockfiles in the future. For example, the minimum required Rust version may one
day be encoded into a lockfile.

One of the major goals of a lockfile is for it to rarely change, and when it
does change the diffs should be minimal. In terms of adding more information to
the lockfile in the future, this presents a problem for older Cargo clients:
1. Cargo 2.0 adds a minimum required version of rust under the metadata.rustc
   key of the lockfile.
2. Cargo 1.0 is then used to update the `foo` dependency in the lockfile. When
   regenerating the lockfile, Cargo 1.0 discards the metadata inserted by Cargo
   2.0.

In order to future-proof ourselves in allowing new metadata in the future, Cargo
is growing support now for transporting an opaque payload of metadata from one
version of a lockfile to a new versions. This should solve the problem presented
above.

This metadata section is designed to be safely ignored by older Cargo versions
(may just have some surprising behavior), while still allowing newer versions of
Cargo to process the data. For example Cargo 2.0 would gracefully fail on an
out-of-date rustc, while Cargo 1.0 may just present an obscure error message.

r? @wycats
