### PR TITLE
Remove dependence on various plugins

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,8 +3,7 @@ name = "cargo"
 version = "0.0.1-pre"
 dependencies = [
  "curl 0.0.1 (git+https://github.com/alexcrichton/curl-rust?ref=bundle#1d43e08f629dc22ffbc99d7ea8e97dfc7ab0b91a)",
- "docopt 0.6.4 (git+https://github.com/docopt/docopt.rs#db3abbb1d55aec986daefcf4b6131a61ff78513c)",
- "docopt_macros 0.6.4 (git+https://github.com/docopt/docopt.rs#db3abbb1d55aec986daefcf4b6131a61ff78513c)",
+ "docopt 0.6.4 (git+https://github.com/docopt/docopt.rs#4544a9f422b115c2ffef4ee9baf27ceb07c34602)",
  "flate2 0.0.1 (git+https://github.com/alexcrichton/flate2-rs#68971ae77a523c7ec3f19b4bcd195f76291ea390)",
  "git2 0.0.1 (git+https://github.com/alexcrichton/git2-rs#c01b0b279470552c48cf7f902ae5baf132df0a6d)",
  "glob 0.0.1 (git+https://github.com/rust-lang/glob#27338cbd4736d3c8146294fc090c6f8f06c32d72)",
@@ -33,15 +32,7 @@ source = "git+https://github.com/alexcrichton/curl-rust?ref=bundle#1d43e08f629dc
 [[package]]
 name = "docopt"
 version = "0.6.4"
-source = "git+https://github.com/docopt/docopt.rs#db3abbb1d55aec986daefcf4b6131a61ff78513c"
-
-[[package]]
-name = "docopt_macros"
-version = "0.6.4"
-source = "git+https://github.com/docopt/docopt.rs#db3abbb1d55aec986daefcf4b6131a61ff78513c"
-dependencies = [
- "docopt 0.6.4 (git+https://github.com/docopt/docopt.rs#db3abbb1d55aec986daefcf4b6131a61ff78513c)",
-]
+source = "git+https://github.com/docopt/docopt.rs#4544a9f422b115c2ffef4ee9baf27ceb07c34602"
 
 [[package]]
 name = "encoding"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,6 @@ path = "src/cargo/lib.rs"
 [dependencies.docopt]
 git = "https://github.com/docopt/docopt.rs"
 
-[dependencies.docopt_macros]
-git = "https://github.com/docopt/docopt.rs"
-
 [dependencies.toml]
 git = "https://github.com/alexcrichton/toml-rs"
 

--- a/src/bin/bench.rs
+++ b/src/bin/bench.rs
@@ -4,9 +4,21 @@ use cargo::ops;
 use cargo::core::MultiShell;
 use cargo::util::{CliResult, CliError, CargoError};
 use cargo::util::important_paths::{find_root_manifest_for_cwd};
-use docopt;
 
-docopt!(Options, "
+#[deriving(Decodable)]
+struct Options {
+    flag_no_run: bool,
+    flag_package: Option<String>,
+    flag_jobs: Option<uint>,
+    flag_features: Vec<String>,
+    flag_no_default_features: bool,
+    flag_target: Option<String>,
+    flag_manifest_path: Option<String>,
+    flag_verbose: bool,
+    arg_args: Vec<String>,
+}
+
+pub const USAGE: &'static str = "
 Execute all benchmarks of a local package
 
 Usage:
@@ -31,9 +43,7 @@ If the --package argument is given, then SPEC is a package id specification
 which indicates which package should be benchmarked. If it is not given, then
 the current package is benchmarked. For more information on SPEC and its format,
 see the `cargo help pkgid` command.
-",  flag_jobs: Option<uint>, flag_target: Option<String>,
-    flag_manifest_path: Option<String>, flag_features: Vec<String>,
-    flag_package: Option<String>)
+";
 
 pub fn execute(options: Options, shell: &mut MultiShell) -> CliResult<Option<()>> {
     let root = try!(find_root_manifest_for_cwd(options.flag_manifest_path));

--- a/src/bin/build.rs
+++ b/src/bin/build.rs
@@ -5,9 +5,20 @@ use cargo::ops::CompileOptions;
 use cargo::ops;
 use cargo::util::important_paths::{find_root_manifest_for_cwd};
 use cargo::util::{CliResult, CliError};
-use docopt;
 
-docopt!(Options, "
+#[deriving(Decodable)]
+struct Options {
+    flag_package: Option<String>,
+    flag_jobs: Option<uint>,
+    flag_features: Vec<String>,
+    flag_no_default_features: bool,
+    flag_target: Option<String>,
+    flag_manifest_path: Option<String>,
+    flag_verbose: bool,
+    flag_release: bool,
+}
+
+pub const USAGE: &'static str = "
 Compile a local package and all of its dependencies
 
 Usage:
@@ -28,9 +39,7 @@ If the --package argument is given, then SPEC is a package id specification
 which indicates which package should be built. If it is not given, then the
 current package is built. For more information on SPEC and its format, see the
 `cargo help pkgid` command.
-",  flag_jobs: Option<uint>, flag_target: Option<String>,
-    flag_manifest_path: Option<String>, flag_features: Vec<String>,
-    flag_package: Option<String>)
+";
 
 pub fn execute(options: Options, shell: &mut MultiShell) -> CliResult<Option<()>> {
     debug!("executing; cmd=cargo-build; args={}", os::args());

--- a/src/bin/clean.rs
+++ b/src/bin/clean.rs
@@ -1,12 +1,19 @@
 use std::os;
-use docopt;
 
 use cargo::ops;
 use cargo::core::MultiShell;
 use cargo::util::{CliResult, CliError};
 use cargo::util::important_paths::{find_root_manifest_for_cwd};
 
-docopt!(Options, "
+#[deriving(Decodable)]
+struct Options {
+    flag_package: Option<String>,
+    flag_target: Option<String>,
+    flag_manifest_path: Option<String>,
+    flag_verbose: bool,
+}
+
+pub const USAGE: &'static str = "
 Remove artifacts that cargo has generated in the past
 
 Usage:
@@ -23,8 +30,7 @@ If the --package argument is given, then SPEC is a package id specification
 which indicates which package's artifacts should be cleaned out. If it is not
 given, then all packages' artifacts are removed. For more information on SPEC
 and its format, see the `cargo help pkgid` command.
-",  flag_manifest_path: Option<String>, flag_package: Option<String>,
-    flag_target: Option<String>)
+";
 
 pub fn execute(options: Options, shell: &mut MultiShell) -> CliResult<Option<()>> {
     shell.set_verbose(options.flag_verbose);

--- a/src/bin/config_for_key.rs
+++ b/src/bin/config_for_key.rs
@@ -1,23 +1,28 @@
 use std::os;
 use std::collections::HashMap;
-use docopt;
 
 use cargo::core::MultiShell;
 use cargo::util::{CliResult, CliError, config};
+
+#[deriving(Decodable)]
+struct ConfigForKeyFlags {
+    flag_human: bool,
+    flag_key: String,
+}
 
 #[deriving(Encodable)]
 struct ConfigOut {
     values: HashMap<String, config::ConfigValue>
 }
 
-docopt!(ConfigForKeyFlags, "
+pub const USAGE: &'static str = "
 Usage:
     cargo config-for-key --human --key=<key>
     cargo config-for-key -h | --help
 
 Options:
     -h, --help          Print this message
-")
+";
 
 pub fn execute(args: ConfigForKeyFlags,
                _: &mut MultiShell) -> CliResult<Option<ConfigOut>> {

--- a/src/bin/config_list.rs
+++ b/src/bin/config_list.rs
@@ -1,23 +1,27 @@
 use std::os;
 use std::collections::HashMap;
-use docopt;
 
 use cargo::core::MultiShell;
 use cargo::util::{CliResult, CliError, config};
+
+#[deriving(Decodable)]
+struct ConfigListFlags {
+    flag_human: bool,
+}
 
 #[deriving(Encodable)]
 struct ConfigOut {
     values: HashMap<String, config::ConfigValue>
 }
 
-docopt!(ConfigListFlags, "
+pub const USAGE: &'static str = "
 Usage:
     cargo config-list --human
     cargo config-list -h | --help
 
 Options:
     -h, --help          Print this message
-")
+";
 
 pub fn execute(args: ConfigListFlags,
                _: &mut MultiShell) -> CliResult<Option<ConfigOut>> {

--- a/src/bin/doc.rs
+++ b/src/bin/doc.rs
@@ -1,11 +1,20 @@
-use docopt;
-
 use cargo::ops;
 use cargo::core::{MultiShell};
 use cargo::util::{CliResult, CliError};
 use cargo::util::important_paths::{find_root_manifest_for_cwd};
 
-docopt!(Options, "
+#[deriving(Decodable)]
+struct Options {
+    flag_features: Vec<String>,
+    flag_jobs: Option<uint>,
+    flag_manifest_path: Option<String>,
+    flag_no_default_features: bool,
+    flag_no_deps: bool,
+    flag_open: bool,
+    flag_verbose: bool,
+}
+
+pub const USAGE: &'static str = "
 Build a package's documentation
 
 Usage:
@@ -23,9 +32,7 @@ Options:
 
 By default the documentation for the local package and all dependencies is
 built. The output is all placed in `target/doc` in rustdoc's usual format.
-",  flag_jobs: Option<uint>,
-    flag_manifest_path: Option<String>,
-    flag_features: Vec<String>)
+";
 
 pub fn execute(options: Options, shell: &mut MultiShell) -> CliResult<Option<()>> {
     shell.set_verbose(options.flag_verbose);

--- a/src/bin/fetch.rs
+++ b/src/bin/fetch.rs
@@ -1,11 +1,15 @@
-use docopt;
-
 use cargo::ops;
 use cargo::core::{MultiShell};
 use cargo::util::{CliResult, CliError};
 use cargo::util::important_paths::find_root_manifest_for_cwd;
 
-docopt!(Options, "
+#[deriving(Decodable)]
+struct Options {
+    flag_manifest_path: Option<String>,
+    flag_verbose: bool,
+}
+
+pub const USAGE: &'static str = "
 Fetch dependencies of a package from the network.
 
 Usage:
@@ -24,7 +28,7 @@ the lockfile changes.
 If the lockfile is not available, then this is the equivalent of
 `cargo generate-lockfile`. A lockfile is generated and dependencies are also
 all updated.
-",  flag_manifest_path: Option<String>)
+";
 
 pub fn execute(options: Options, shell: &mut MultiShell) -> CliResult<Option<()>> {
     shell.set_verbose(options.flag_verbose);

--- a/src/bin/generate_lockfile.rs
+++ b/src/bin/generate_lockfile.rs
@@ -1,12 +1,17 @@
 use std::os;
-use docopt;
 
 use cargo::ops;
 use cargo::core::MultiShell;
 use cargo::util::{CliResult, CliError};
 use cargo::util::important_paths::find_root_manifest_for_cwd;
 
-docopt!(Options, "
+#[deriving(Decodable)]
+struct Options {
+    flag_manifest_path: Option<String>,
+    flag_verbose: bool,
+}
+
+pub const USAGE: &'static str = "
 Generate the lockfile for a project
 
 Usage:
@@ -16,7 +21,7 @@ Options:
     -h, --help              Print this message
     --manifest-path PATH    Path to the manifest to generate a lockfile for
     -v, --verbose           Use verbose output
-",  flag_manifest_path: Option<String>)
+";
 
 pub fn execute(options: Options, shell: &mut MultiShell) -> CliResult<Option<()>> {
     debug!("executing; cmd=cargo-generate-lockfile; args={}", os::args());

--- a/src/bin/git_checkout.rs
+++ b/src/bin/git_checkout.rs
@@ -1,11 +1,16 @@
-use docopt;
-
 use cargo::core::MultiShell;
 use cargo::core::source::{Source, SourceId};
 use cargo::sources::git::{GitSource};
 use cargo::util::{Config, CliResult, CliError, human, ToUrl};
 
-docopt!(Options, "
+#[deriving(Decodable)]
+struct Options {
+    flag_url: String,
+    flag_reference: String,
+    flag_verbose: bool,
+}
+
+pub const USAGE: &'static str = "
 Usage:
     cargo git-checkout [options] --url=URL --reference=REF
     cargo git-checkout -h | --help
@@ -13,9 +18,10 @@ Usage:
 Options:
     -h, --help              Print this message
     -v, --verbose           Use verbose output
-")
+";
 
 pub fn execute(options: Options, shell: &mut MultiShell) -> CliResult<Option<()>> {
+    shell.set_verbose(options.flag_verbose);
     let Options { flag_url: url, flag_reference: reference, .. } = options;
 
     let url = try!(url.as_slice().to_url().map_err(|e| {

--- a/src/bin/help.rs
+++ b/src/bin/help.rs
@@ -1,9 +1,10 @@
-use docopt;
-
 use cargo::core::MultiShell;
 use cargo::util::{CliResult, CliError};
 
-docopt!(Options, "
+#[deriving(Decodable)]
+struct Options;
+
+pub const USAGE: &'static str = "
 Get some help with a cargo command.
 
 Usage:
@@ -12,7 +13,7 @@ Usage:
 
 Options:
     -h, --help          Print this message
-")
+";
 
 pub fn execute(_: Options, _: &mut MultiShell) -> CliResult<Option<()>> {
     // This is a dummy command just so that `cargo help help` works.

--- a/src/bin/locate_project.rs
+++ b/src/bin/locate_project.rs
@@ -1,17 +1,20 @@
-use docopt;
-
 use cargo::core::MultiShell;
 use cargo::util::{CliResult, CliError, human, Require};
 use cargo::util::important_paths::{find_root_manifest_for_cwd};
 
-docopt!(LocateProjectFlags, "
+#[deriving(Decodable)]
+struct LocateProjectFlags {
+    flag_manifest_path: Option<String>,
+}
+
+pub const USAGE: &'static str = "
 Usage:
     cargo locate-project [options]
 
 Options:
     --manifest-path PATH    Path to the manifest to build benchmarks for
     -h, --help              Print this message
-", flag_manifest_path: Option<String>)
+";
 
 #[deriving(Encodable)]
 struct ProjectLocation {

--- a/src/bin/login.rs
+++ b/src/bin/login.rs
@@ -1,12 +1,18 @@
 use std::io;
-use docopt;
 
 use cargo::ops;
 use cargo::core::{MultiShell};
 use cargo::sources::RegistrySource;
 use cargo::util::{CliResult, CliError};
 
-docopt!(Options, "
+#[deriving(Decodable)]
+struct Options {
+    flag_host: Option<String>,
+    arg_token: Option<String>,
+    flag_verbose: bool,
+}
+
+pub const USAGE: &'static str = "
 Save an api token from the registry locally
 
 Usage:
@@ -17,7 +23,7 @@ Options:
     --host HOST             Host to set the token for
     -v, --verbose           Use verbose output
 
-",  arg_token: Option<String>, flag_host: Option<String>)
+";
 
 pub fn execute(options: Options, shell: &mut MultiShell) -> CliResult<Option<()>> {
     shell.set_verbose(options.flag_verbose);

--- a/src/bin/new.rs
+++ b/src/bin/new.rs
@@ -1,11 +1,21 @@
 use std::os;
-use docopt;
 
 use cargo::ops;
 use cargo::core::MultiShell;
 use cargo::util::{CliResult, CliError};
 
-docopt!(Options, "
+#[deriving(Decodable)]
+struct Options {
+    flag_verbose: bool,
+    flag_bin: bool,
+    flag_travis: bool,
+    flag_hg: bool,
+    flag_git: bool,
+    flag_no_git: bool,
+    arg_path: String,
+}
+
+pub const USAGE: &'static str = "
 Create a new cargo package at <path>
 
 Usage:
@@ -21,7 +31,7 @@ Options:
     --travis            Create a .travis.yml file
     --bin               Use a binary instead of a library template
     -v, --verbose       Use verbose output
-")
+";
 
 pub fn execute(options: Options, shell: &mut MultiShell) -> CliResult<Option<()>> {
     debug!("executing; cmd=cargo-new; args={}", os::args());

--- a/src/bin/package.rs
+++ b/src/bin/package.rs
@@ -1,10 +1,15 @@
-use docopt;
 use cargo::ops;
 use cargo::core::{MultiShell};
 use cargo::util::{CliResult, CliError};
 use cargo::util::important_paths::find_root_manifest_for_cwd;
 
-docopt!(Options, "
+#[deriving(Decodable)]
+struct Options {
+    flag_verbose: bool,
+    flag_manifest_path: Option<String>,
+}
+
+pub const USAGE: &'static str = "
 Assemble a the local package into a distributable tarball
 
 Usage:
@@ -15,7 +20,7 @@ Options:
     --manifest-path PATH    Path to the manifest to compile
     -v, --verbose           Use verbose output
 
-", flag_manifest_path: Option<String>)
+";
 
 pub fn execute(options: Options, shell: &mut MultiShell) -> CliResult<Option<()>> {
     shell.set_verbose(options.flag_verbose);

--- a/src/bin/pkgid.rs
+++ b/src/bin/pkgid.rs
@@ -1,11 +1,16 @@
-use docopt;
-
 use cargo::ops;
 use cargo::core::MultiShell;
 use cargo::util::{CliResult, CliError};
 use cargo::util::important_paths::{find_root_manifest_for_cwd};
 
-docopt!(Options, "
+#[deriving(Decodable)]
+struct Options {
+    flag_verbose: bool,
+    flag_manifest_path: Option<String>,
+    arg_spec: Option<String>,
+}
+
+pub const USAGE: &'static str = "
 Print a fully qualified package specification
 
 Usage:
@@ -35,7 +40,7 @@ Example Package IDs
      crates.io/bar#foo:1.2.3      | foo    | 1.2.3     | *://crates.io/bar
      http://crates.io/foo#1.2.3   | foo    | 1.2.3     | http://crates.io/foo
 
-",  flag_manifest_path: Option<String>, arg_spec: Option<String>)
+";
 
 pub fn execute(options: Options,
                shell: &mut MultiShell) -> CliResult<Option<()>> {

--- a/src/bin/read_manifest.rs
+++ b/src/bin/read_manifest.rs
@@ -1,10 +1,13 @@
-use docopt;
-
 use cargo::core::{MultiShell, Package, Source};
 use cargo::util::{CliResult, CliError};
 use cargo::sources::{PathSource};
 
-docopt!(Options, "
+#[deriving(Decodable)]
+struct Options {
+    flag_manifest_path: String,
+}
+
+pub const USAGE: &'static str = "
 Usage:
     cargo read-manifest [options] --manifest-path=PATH
     cargo read-manifest -h | --help
@@ -12,7 +15,7 @@ Usage:
 Options:
     -h, --help              Print this message
     -v, --verbose           Use verbose output
-")
+";
 
 pub fn execute(options: Options, _: &mut MultiShell) -> CliResult<Option<Package>> {
     let path = Path::new(options.flag_manifest_path.as_slice());

--- a/src/bin/run.rs
+++ b/src/bin/run.rs
@@ -1,12 +1,23 @@
 use std::io::process::ExitStatus;
-use docopt;
 
 use cargo::ops;
 use cargo::core::{MultiShell};
 use cargo::util::{CliResult, CliError};
 use cargo::util::important_paths::{find_root_manifest_for_cwd};
 
-docopt!(Options, "
+#[deriving(Decodable)]
+struct Options {
+    flag_jobs: Option<uint>,
+    flag_features: Vec<String>,
+    flag_no_default_features: bool,
+    flag_target: Option<String>,
+    flag_manifest_path: Option<String>,
+    flag_verbose: bool,
+    flag_release: bool,
+    arg_args: Vec<String>,
+}
+
+pub const USAGE: &'static str = "
 Run the main binary of the local package (src/main.rs)
 
 Usage:
@@ -23,8 +34,7 @@ Options:
     -v, --verbose           Use verbose output
 
 All of the trailing arguments are passed as to the binary to run.
-",  flag_jobs: Option<uint>, flag_target: Option<String>,
-    flag_manifest_path: Option<String>, flag_features: Vec<String>)
+";
 
 pub fn execute(options: Options, shell: &mut MultiShell) -> CliResult<Option<()>> {
     shell.set_verbose(options.flag_verbose);

--- a/src/bin/test.rs
+++ b/src/bin/test.rs
@@ -1,12 +1,24 @@
 use std::io::process::ExitStatus;
-use docopt;
 
 use cargo::ops;
 use cargo::core::MultiShell;
 use cargo::util::{CliResult, CliError, CargoError};
 use cargo::util::important_paths::{find_root_manifest_for_cwd};
 
-docopt!(Options, "
+#[deriving(Decodable)]
+struct Options {
+    arg_args: Vec<String>,
+    flag_features: Vec<String>,
+    flag_jobs: Option<uint>,
+    flag_manifest_path: Option<String>,
+    flag_no_default_features: bool,
+    flag_no_run: bool,
+    flag_package: Option<String>,
+    flag_target: Option<String>,
+    flag_verbose: bool,
+}
+
+pub const USAGE: &'static str = "
 Execute all unit and integration tests of a local package
 
 Usage:
@@ -30,9 +42,7 @@ If the --package argument is given, then SPEC is a package id specification
 which indicates which package should be tested. If it is not given, then the
 current package is tested. For more information on SPEC and its format, see the
 `cargo help pkgid` command.
-",  flag_jobs: Option<uint>, flag_target: Option<String>,
-    flag_manifest_path: Option<String>, flag_features: Vec<String>,
-    flag_package: Option<String>)
+";
 
 pub fn execute(options: Options, shell: &mut MultiShell) -> CliResult<Option<()>> {
     let root = try!(find_root_manifest_for_cwd(options.flag_manifest_path));

--- a/src/bin/update.rs
+++ b/src/bin/update.rs
@@ -1,12 +1,21 @@
 use std::os;
-use docopt;
 
 use cargo::ops;
 use cargo::core::MultiShell;
 use cargo::util::{CliResult, CliError};
 use cargo::util::important_paths::find_root_manifest_for_cwd;
 
-docopt!(Options, "
+#[deriving(Decodable)]
+struct Options {
+    arg_spec: Option<String>,
+    flag_package: Option<String>,
+    flag_aggressive: bool,
+    flag_precise: Option<String>,
+    flag_manifest_path: Option<String>,
+    flag_verbose: bool,
+}
+
+pub const USAGE: &'static str = "
 Update dependencies as recorded in the local lock file.
 
 Usage:
@@ -40,8 +49,7 @@ If SPEC is not given, then all dependencies will be re-resolved and
 updated.
 
 For more information about package id specifications, see `cargo help pkgid`.
-",  flag_manifest_path: Option<String>, arg_spec: Option<String>,
-    flag_precise: Option<String>, flag_package: Option<String>)
+";
 
 pub fn execute(options: Options, shell: &mut MultiShell) -> CliResult<Option<()>> {
     debug!("executing; cmd=cargo-update; args={}", os::args());

--- a/src/bin/upload.rs
+++ b/src/bin/upload.rs
@@ -1,11 +1,17 @@
-use docopt;
-
 use cargo::ops;
 use cargo::core::{MultiShell};
 use cargo::util::{CliResult, CliError};
 use cargo::util::important_paths::find_root_manifest_for_cwd;
 
-docopt!(Options, "
+#[deriving(Decodable)]
+struct Options {
+    flag_host: Option<String>,
+    flag_token: Option<String>,
+    flag_manifest_path: Option<String>,
+    flag_verbose: bool,
+}
+
+pub const USAGE: &'static str = "
 Upload a package to the registry
 
 Usage:
@@ -18,8 +24,7 @@ Options:
     --manifest-path PATH    Path to the manifest to compile
     -v, --verbose           Use verbose output
 
-", flag_host: Option<String>, flag_token: Option<String>,
-   flag_manifest_path: Option<String>)
+";
 
 pub fn execute(options: Options, shell: &mut MultiShell) -> CliResult<Option<()>> {
     shell.set_verbose(options.flag_verbose);

--- a/src/bin/verify_project.rs
+++ b/src/bin/verify_project.rs
@@ -3,14 +3,19 @@ extern crate toml;
 use std::collections::HashMap;
 use std::io::File;
 use std::os;
-use docopt;
 
 use cargo::core::MultiShell;
 use cargo::util::CliResult;
 
 pub type Error = HashMap<String, String>;
 
-docopt!(Flags, "
+#[deriving(Decodable)]
+struct Flags {
+    flag_manifest_path: String,
+    flag_verbose: bool,
+}
+
+pub const USAGE: &'static str = "
 Usage:
     cargo verify-project [options] --manifest-path PATH
     cargo verify-project -h | --help
@@ -19,7 +24,7 @@ Options:
     -h, --help              Print this message
     --manifest-path PATH    Path to the manifest to verify
     -v, --verbose           Use verbose output
-")
+";
 
 pub fn execute(args: Flags,
                shell: &mut MultiShell) -> CliResult<Option<Error>> {

--- a/src/bin/version.rs
+++ b/src/bin/version.rs
@@ -1,18 +1,20 @@
 use std::os;
-use docopt;
 
 use cargo;
 use cargo::core::MultiShell;
 use cargo::util::CliResult;
 
-docopt!(Options, "
+#[deriving(Decodable)]
+struct Options;
+
+pub const USAGE: &'static str = "
 Usage:
     cargo version [options]
 
 Options:
     -h, --help              Print this message
     -v, --verbose           Use verbose output
-")
+";
 
 pub fn execute(_: Options, _: &mut MultiShell) -> CliResult<Option<()>> {
     debug!("executing; cmd=cargo-version; args={}", os::args());

--- a/src/cargo/core/package_id.rs
+++ b/src/cargo/core/package_id.rs
@@ -4,6 +4,8 @@ use std::fmt::{mod, Show, Formatter};
 use std::hash;
 use serialize::{Encodable, Encoder, Decodable, Decoder};
 
+use regex::Regex;
+
 use util::{CargoResult, CargoError, short_hash, ToSemver};
 use core::source::SourceId;
 
@@ -25,7 +27,7 @@ impl<E, S: Encoder<E>> Encodable<S, E> for PackageId {
 impl<E, D: Decoder<E>> Decodable<D, E> for PackageId {
     fn decode(d: &mut D) -> Result<PackageId, E> {
         let string: String = raw_try!(Decodable::decode(d));
-        let regex = regex!(r"^([^ ]+) ([^ ]+) \(([^\)]+)\)$");
+        let regex = Regex::new(r"^([^ ]+) ([^ ]+) \(([^\)]+)\)$").unwrap();
         let captures = regex.captures(string.as_slice()).expect("invalid serialized PackageId");
 
         let name = captures.at(1);

--- a/src/cargo/core/resolver.rs
+++ b/src/cargo/core/resolver.rs
@@ -1,7 +1,8 @@
 use std::collections::hashmap::{HashMap, HashSet, Occupied, Vacant};
 use std::fmt;
-use semver;
 
+use regex::Regex;
+use semver;
 use serialize::{Encodable, Encoder, Decodable, Decoder};
 
 use core::{PackageId, Registry, SourceId, Summary, Dependency};
@@ -107,7 +108,7 @@ impl<E, S: Encoder<E>> Encodable<S, E> for EncodablePackageId {
 impl<E, D: Decoder<E>> Decodable<D, E> for EncodablePackageId {
     fn decode(d: &mut D) -> Result<EncodablePackageId, E> {
         let string: String = raw_try!(Decodable::decode(d));
-        let regex = regex!(r"^([^ ]+) ([^ ]+)(?: \(([^\)]+)\))?$");
+        let regex = Regex::new(r"^([^ ]+) ([^ ]+)(?: \(([^\)]+)\))?$").unwrap();
         let captures = regex.captures(string.as_slice())
                             .expect("invalid serialized PackageId");
 


### PR DESCRIPTION
It's looking more likely like plugins will not make it into the stable channel
of Rust, so this commits removes Cargo's personal dependence on the two
plugin-based pieces of functionality it was using:
1. Uses of the `regex!` macro now go through `Regex::new`.
2. Uses of the `docopt!` macro now go through `deriving(Decodable)` instead.
