### PR TITLE
document rpath option in manifest

### DIFF
--- a/src/doc/manifest.md
+++ b/src/doc/manifest.md
@@ -108,7 +108,7 @@ along with the defaults for each profile.
 [profile.dev]
 opt-level = 0  # Controls the --opt-level the compiler builds with
 debug = true   # Controls whether the compiler passes -g or `--cfg ndebug`
-rpath = true   # Controls whether the compiler passes `-C rpath`
+rpath = false   # Controls whether the compiler passes `-C rpath`
 
 # The release profile, used for `cargo build --release`
 [profile.release]
@@ -120,7 +120,7 @@ rpath = false
 [profile.test]
 opt-level = 0
 debug = true
-rpath = true
+rpath = false
 
 # The benchmarking profile, used for `cargo bench`
 [profile.bench]
@@ -132,6 +132,7 @@ rpath = false
 [profile.doc]
 opt-level = 0
 debug = true
+rpath = false
 ```
 
 # The `[features]` Section


### PR DESCRIPTION
The `rpath` option was added (awesome!) but not documented.
