### PR TITLE
Stop testing 32-bit on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,15 +10,11 @@ script:
 after_success: |
   [ $TRAVIS_BRANCH = master ] &&
   [ $TRAVIS_PULL_REQUEST = false ] &&
-  [ $BITS = 64 ] &&
   [ $(uname -s) = Linux ] &&
   sudo pip install ghp-import &&
   ghp-import -n target/doc &&
   git push -f https://${TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git gh-pages
 env:
-  matrix:
-    - BITS=32 PKG_CONFIG_PATH=/usr/lib/i386-linux-gnu/pkgconfig
-    - BITS=64
   global:
     secure: scGpeetUfba5RWyuS4yt10bPoFAI9wpHEReIFqEx7eH5vr2Anajk6+70jW6GdrWVdUvdINiArlQ3An2DeB9vEUWcBjw8WvuPtOH0tDMoSsuVloPlFD8yn1Ac0Bx9getAO5ofxqtoNg+OV4MDVuGabEesqAOWqURNrBC7XK+ntC8=
 os:


### PR DESCRIPTION
This has been broken for quite awhile now on 32-bit linux due to what looks like
libcurl going awry. This can be reactivated later, but consistently green travis
builds are more important right now.

Additionally, we already have coverage on the buildbots for 32-bit flavors of
architectures.
