### PR TITLE
Build examples into `target/examples`

### DIFF
--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -104,7 +104,8 @@ impl LibKind {
 #[deriving(Show, Clone, Hash, PartialEq, Encodable)]
 pub enum TargetKind {
     LibTarget(Vec<LibKind>),
-    BinTarget
+    BinTarget,
+    ExampleTarget,
 }
 
 #[deriving(Encodable, Decodable, Clone, PartialEq, Show)]
@@ -328,7 +329,8 @@ impl<E, S: Encoder<E>> Encodable<S, E> for Target {
     fn encode(&self, s: &mut S) -> Result<(), E> {
         let kind = match self.kind {
             LibTarget(ref kinds) => kinds.iter().map(|k| k.crate_type()).collect(),
-            BinTarget => vec!("bin")
+            BinTarget => vec!("bin"),
+            ExampleTarget => vec!["example"],
         };
 
         SerializedTarget {
@@ -457,7 +459,7 @@ impl Target {
 
     pub fn example_target(name: &str, src_path: &Path, profile: &Profile) -> Target {
         Target {
-            kind: BinTarget,
+            kind: ExampleTarget,
             name: name.to_string(),
             src_path: src_path.clone(),
             profile: profile.clone(),
@@ -524,10 +526,18 @@ impl Target {
         }
     }
 
-    /// Returns true for binary, bench, tests and examples.
+    /// Returns true for binary, bench, and tests.
     pub fn is_bin(&self) -> bool {
         match self.kind {
             BinTarget => true,
+            _ => false
+        }
+    }
+
+    /// Returns true for exampels
+    pub fn is_example(&self) -> bool {
+        match self.kind {
+            ExampleTarget => true,
             _ => false
         }
     }
@@ -546,7 +556,8 @@ impl Target {
             LibTarget(ref kinds) => {
                 kinds.iter().map(|kind| kind.crate_type()).collect()
             },
-            BinTarget => vec!("bin")
+            ExampleTarget |
+            BinTarget => vec!("bin"),
         }
     }
 }

--- a/src/cargo/ops/cargo_rustc/context.rs
+++ b/src/cargo/ops/cargo_rustc/context.rs
@@ -225,7 +225,9 @@ impl<'a, 'b> Context<'a, 'b> {
         let stem = target.file_stem();
 
         let mut ret = Vec::new();
-        if target.is_bin() || target.get_profile().is_test() {
+        if target.is_example() {
+            ret.push(format!("examples/{}{}", stem, self.target_exe));
+        } else if target.is_bin() || target.get_profile().is_test() {
             ret.push(format!("{}{}", stem, self.target_exe));
         } else {
             if target.is_dylib() {

--- a/src/cargo/ops/cargo_rustc/fingerprint.rs
+++ b/src/cargo/ops/cargo_rustc/fingerprint.rs
@@ -87,7 +87,11 @@ pub fn prepare_target(cx: &mut Context, pkg: &Package, target: &Target,
 
     let (old_root, root) = {
         let layout = cx.layout(pkg, kind);
-        (layout.old_root().clone(), layout.root().clone())
+        if target.is_example() {
+            (layout.old_examples().clone(), layout.examples().clone())
+        } else {
+            (layout.old_root().clone(), layout.root().clone())
+        }
     };
     let mut pairs = vec![(old_loc, new_loc.clone())];
     if !target.get_profile().is_doc() {

--- a/src/cargo/ops/cargo_rustc/mod.rs
+++ b/src/cargo/ops/cargo_rustc/mod.rs
@@ -431,7 +431,11 @@ fn build_base_args(cx: &Context,
 fn build_plugin_args(mut cmd: ProcessBuilder, cx: &Context, pkg: &Package,
                      target: &Target, kind: Kind) -> ProcessBuilder {
     cmd = cmd.arg("--out-dir");
-    cmd = cmd.arg(cx.layout(pkg, kind).root());
+    if target.is_example() {
+        cmd = cmd.arg(cx.layout(pkg, kind).examples());
+    } else {
+        cmd = cmd.arg(cx.layout(pkg, kind).root());
+    }
 
     let (_, dep_info_loc) = fingerprint::dep_info_loc(cx, pkg, target, kind);
     cmd = cmd.arg("--dep-info").arg(dep_info_loc);

--- a/tests/test_cargo_compile.rs
+++ b/tests/test_cargo_compile.rs
@@ -975,7 +975,7 @@ test!(many_crate_types_old_style_lib_location {
     let files = fs::readdir(&p.root().join("target")).assert();
     let mut files: Vec<String> = files.iter().filter_map(|f| {
         match f.filename_str().unwrap() {
-            "deps" => None,
+            "examples" | "deps" => None,
             s if s.contains("fingerprint") || s.contains("dSYM") => None,
             s => Some(s.to_string())
         }
@@ -1013,7 +1013,7 @@ test!(many_crate_types_correct {
     let files = fs::readdir(&p.root().join("target")).assert();
     let mut files: Vec<String> = files.iter().filter_map(|f| {
         match f.filename_str().unwrap() {
-            "deps" => None,
+            "examples" | "deps" => None,
             s if s.contains("fingerprint") || s.contains("dSYM") => None,
             s => Some(s.to_string())
         }
@@ -1280,8 +1280,10 @@ test!(explicit_examples {
         "#);
 
     assert_that(p.cargo_process("test"), execs());
-    assert_that(process(p.bin("hello")), execs().with_stdout("Hello, World!\n"));
-    assert_that(process(p.bin("goodbye")), execs().with_stdout("Goodbye, World!\n"));
+    assert_that(process(p.bin("examples/hello")),
+                        execs().with_stdout("Hello, World!\n"));
+    assert_that(process(p.bin("examples/goodbye")),
+                        execs().with_stdout("Goodbye, World!\n"));
 })
 
 test!(implicit_examples {
@@ -1307,8 +1309,10 @@ test!(implicit_examples {
         "#);
 
     assert_that(p.cargo_process("test"), execs().with_status(0));
-    assert_that(process(p.bin("hello")), execs().with_stdout("Hello, World!\n"));
-    assert_that(process(p.bin("goodbye")), execs().with_stdout("Goodbye, World!\n"));
+    assert_that(process(p.bin("examples/hello")),
+                execs().with_stdout("Hello, World!\n"));
+    assert_that(process(p.bin("examples/goodbye")),
+                execs().with_stdout("Goodbye, World!\n"));
 })
 
 test!(standard_build_no_ndebug {


### PR DESCRIPTION
This ends up killing two birds with one stone! The rationale behind this is that
the example and bin namespaces are not the same, and we don't mix metadata into
either filename, so the outputs need to be in different locations.

Closes #193
Closes #751
