### PR TITLE
Don't leave behind corrupt directories

### DIFF
--- a/tests/test_cargo_compile.rs
+++ b/tests/test_cargo_compile.rs
@@ -1683,4 +1683,5 @@ test!(ignore_bad_directories {
     fs::mkdir(&foo.root().join("tmp"), io::USER_EXEC ^ io::USER_EXEC).unwrap();
     assert_that(foo.process(cargo_dir().join("cargo")).arg("build"),
                 execs().with_status(0));
+    fs::chmod(&foo.root().join("tmp"), io::USER_DIR).unwrap();
 })


### PR DESCRIPTION
Ensure that a system `rm -rf target` will continue to work across test runs.
