### PR TITLE
Make help command accept -h and --help

### DIFF
--- a/src/bin/cargo.rs
+++ b/src/bin/cargo.rs
@@ -106,6 +106,9 @@ fn execute(flags: Flags, shell: &mut MultiShell) -> CliResult<Option<()>> {
             cargo::process_executed(r, shell);
             return Ok(None)
         }
+        "help" if flags.arg_args[0].as_slice() == "-h" ||
+                  flags.arg_args[0].as_slice() == "--help" =>
+            (flags.arg_args, "help"),
         "help" => (vec!["-h".to_string()], flags.arg_args[0].as_slice()),
         s => (flags.arg_args.clone(), s),
     };


### PR DESCRIPTION
Fixes #762. I'm not sure if I've used the correct style here. Apologies if it is and/or if the way I've fixed this is wrong!
