### PR TITLE
Fix a repeated `cargo test` with examples

### DIFF
--- a/src/cargo/ops/cargo_rustc/context.rs
+++ b/src/cargo/ops/cargo_rustc/context.rs
@@ -225,9 +225,8 @@ impl<'a, 'b> Context<'a, 'b> {
         let stem = target.file_stem();
 
         let mut ret = Vec::new();
-        if target.is_example() {
-            ret.push(format!("examples/{}{}", stem, self.target_exe));
-        } else if target.is_bin() || target.get_profile().is_test() {
+        if target.is_example() || target.is_bin() ||
+           target.get_profile().is_test() {
             ret.push(format!("{}{}", stem, self.target_exe));
         } else {
             if target.is_dylib() {

--- a/tests/test_cargo_test.rs
+++ b/tests/test_cargo_test.rs
@@ -1254,3 +1254,24 @@ test!(example_bin_same_name {
     assert_that(p.process(p.bin("examples/foo")),
                 execs().with_status(0).with_stdout("example\n"));
 })
+
+test!(test_with_example_twice {
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [package]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+        "#)
+        .file("src/bin/foo.rs", r#"fn main() { println!("bin"); }"#)
+        .file("examples/foo.rs", r#"fn main() { println!("example"); }"#);
+
+    println!("first");
+    assert_that(p.cargo_process("test").arg("-v"),
+                execs().with_status(0));
+    assert_that(&p.bin("examples/foo"), existing_file());
+    println!("second");
+    assert_that(p.process(cargo_dir().join("cargo")).arg("test").arg("-v"),
+                execs().with_status(0));
+    assert_that(&p.bin("examples/foo"), existing_file());
+})


### PR DESCRIPTION
The examples output directory was accidentally taken into account twice, and
this removes one source of the output directory confusion.

Closes #771 
