### PR TITLE
Move generated tarballs under target/package

### DIFF
--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -433,6 +433,10 @@ impl Manifest {
     pub fn set_summary(&mut self, summary: Summary) {
         self.summary = summary;
     }
+
+    pub fn set_target_dir(&mut self, target_dir: Path) {
+        self.target_dir = target_dir;
+    }
 }
 
 impl Target {

--- a/src/cargo/sources/registry.rs
+++ b/src/cargo/sources/registry.rs
@@ -147,7 +147,7 @@
 //!     # This folder is a cache for all downloaded tarballs from a registry.
 //!     # Once downloaded and verified, a tarball never changes.
 //!     cache/
-//!         registry1-<hash>/<pkg>-<version>.tar.gz
+//!         registry1-<hash>/<pkg>-<version>.crate
 //!         ...
 //!
 //!     # Location in which all tarballs are unpacked. Each tarball is known to
@@ -296,7 +296,7 @@ impl<'a, 'b> RegistrySource<'a, 'b> {
     fn download_package(&mut self, pkg: &PackageId, url: &Url)
                         -> CargoResult<Path> {
         // TODO: should discover from the S3 redirect
-        let filename = format!("{}-{}.tar.gz", pkg.get_name(), pkg.get_version());
+        let filename = format!("{}-{}.crate", pkg.get_name(), pkg.get_version());
         let dst = self.cache_path.join(filename);
         if dst.exists() { return Ok(dst) }
         try!(self.config.shell().status("Downloading", pkg));

--- a/tests/test_cargo_package.rs
+++ b/tests/test_cargo_package.rs
@@ -34,11 +34,11 @@ test!(simple {
         verifying = VERIFYING,
         compiling = COMPILING,
         dir = p.url()).as_slice()));
-    assert_that(&p.root().join("foo-0.0.1.tar.gz"), existing_file());
+    assert_that(&p.root().join("target/package/foo-0.0.1.crate"), existing_file());
     assert_that(p.process(cargo_dir().join("cargo")).arg("package"),
                 execs().with_status(0).with_stdout(""));
 
-    let f = File::open(&p.root().join("foo-0.0.1.tar.gz")).assert();
+    let f = File::open(&p.root().join("target/package/foo-0.0.1.crate")).assert();
     let mut rdr = GzDecoder::new(f);
     let contents = rdr.read_to_end().assert();
     let ar = Archive::new(MemReader::new(contents));

--- a/tests/test_cargo_publish.rs
+++ b/tests/test_cargo_publish.rs
@@ -63,7 +63,7 @@ test!(simple {
 
     // Verify the tarball
     let mut rdr = GzDecoder::new(f).unwrap();
-    assert_eq!(rdr.header().filename(), Some(b"foo-0.0.1.tar.gz"));
+    assert_eq!(rdr.header().filename(), Some(b"foo-0.0.1.crate"));
     let inner = MemReader::new(rdr.read_to_end().unwrap());
     let ar = Archive::new(inner);
     for file in ar.files().unwrap() {

--- a/tests/test_cargo_registry.rs
+++ b/tests/test_cargo_registry.rs
@@ -209,7 +209,7 @@ version required: ^0.0.1
 {updating} registry `[..]`
 {downloading} notyet v0.0.1 (the package registry)
 {compiling} notyet v0.0.1 (the package registry)
-{compiling} foo v0.0.1 ({dir})
+{compiling} foo v0.0.1 ({dir}[..])
 ",
     packaging = PACKAGING,
     verifying = VERIFYING,


### PR DESCRIPTION
At the same time this commit renames the `.tar.gz` extension to `.crate`. This
helps our perception on Windows as we're not trying to leave them out in the
dark, and we'd also like the ability to modify the format later in the future.

Closes #777
