### PR TITLE
More aggresively move_into_the_past for tests

### DIFF
--- a/tests/test_cargo_compile_custom_build.rs
+++ b/tests/test_cargo_compile_custom_build.rs
@@ -366,6 +366,7 @@ test!(only_rerun_build_script {
     p.root().move_into_the_past().unwrap();
 
     File::create(&p.root().join("some-new-file")).unwrap();
+    p.root().move_into_the_past().unwrap();
 
     assert_that(p.process(cargo_dir().join("cargo")).arg("build").arg("-v"),
                 execs().with_status(0)
@@ -421,6 +422,7 @@ test!(rebuild_continues_to_pass_env_vars {
     p.root().move_into_the_past().unwrap();
 
     File::create(&p.root().join("some-new-file")).unwrap();
+    p.root().move_into_the_past().unwrap();
 
     assert_that(p.process(cargo_dir().join("cargo")).arg("build").arg("-v"),
                 execs().with_status(0));
@@ -445,6 +447,7 @@ test!(testing_and_such {
     p.root().move_into_the_past().unwrap();
 
     File::create(&p.root().join("src/lib.rs")).unwrap();
+    p.root().move_into_the_past().unwrap();
 
     assert_that(p.process(cargo_dir().join("cargo")).arg("test").arg("-vj1"),
                 execs().with_status(0)

--- a/tests/test_cargo_features.rs
+++ b/tests/test_cargo_features.rs
@@ -1,5 +1,5 @@
 use support::{project, execs, cargo_dir};
-use support::COMPILING;
+use support::{COMPILING, FRESH};
 use support::paths::PathExt;
 use hamcrest::assert_that;
 
@@ -529,8 +529,11 @@ test!(many_features_no_rebuilds {
 ", compiling = COMPILING, dir = p.url()).as_slice()));
     p.root().move_into_the_past().unwrap();
 
-    assert_that(p.process(cargo_dir().join("cargo")).arg("build"),
-                execs().with_status(0).with_stdout(""));
+    assert_that(p.process(cargo_dir().join("cargo")).arg("build").arg("-v"),
+                execs().with_status(0).with_stdout(format!("\
+{fresh} a v0.1.0 ([..])
+{fresh} b v0.1.0 ([..])
+", fresh = FRESH).as_slice()));
 })
 
 // Tests that all cmd lines work with `--features ""`


### PR DESCRIPTION
Right now we're accidentally not actually leveraging this function well in some
tests due to this sequence of events:
1. The tests run at time X, building artifacts that remember the fingerprint is
   at time X.
2. The entire project is moved back one hour to (X-1).
3. A new file is created, at time X (second-level resolution on some systems).
4. On a rebuild, the maximum mtime is still X (due to the new file).

For this reason there are some more calls to move_into_the_past() to push files
back another hour after they've been created to make sure the maximum mtime is
(X-1), or something different than X.
