### PR TITLE
Fix build scripts and cross compiling

### DIFF
--- a/src/cargo/ops/cargo_clean.rs
+++ b/src/cargo/ops/cargo_clean.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::default::Default;
 use std::io::fs::{mod, PathExtensions};
 
 use core::{MultiShell, PackageSet};
@@ -50,7 +50,7 @@ pub fn clean(manifest_path: &Path, opts: &mut CleanOptions) -> CargoResult<()> {
     let pkgs = PackageSet::new([]);
     let cx = try!(Context::new("compile", &resolve, &srcs, &pkgs, &mut cfg,
                                Layout::at(root.get_absolute_target_dir()),
-                               None, &pkg, HashMap::new()));
+                               None, &pkg, Default::default()));
 
     // And finally, clean everything out!
     for target in pkg.get_targets().iter() {

--- a/src/cargo/ops/mod.rs
+++ b/src/cargo/ops/mod.rs
@@ -5,7 +5,7 @@ pub use self::cargo_rustc::{compile_targets, Compilation, Layout, Kind, rustc_ve
 pub use self::cargo_rustc::{KindTarget, KindHost, Context, LayoutProxy};
 pub use self::cargo_rustc::{PlatformRequirement, PlatformTarget};
 pub use self::cargo_rustc::{PlatformPlugin, PlatformPluginAndTarget};
-pub use self::cargo_rustc::{BuildOutput};
+pub use self::cargo_rustc::{BuildOutput, BuildConfig, TargetConfig};
 pub use self::cargo_run::run;
 pub use self::cargo_new::{new, NewOptions};
 pub use self::cargo_doc::{doc, DocOptions};

--- a/src/cargo/util/config.rs
+++ b/src/cargo/util/config.rs
@@ -1,5 +1,5 @@
 use std::{fmt, os, mem};
-use std::cell::{RefCell, RefMut, Ref};
+use std::cell::{RefCell, RefMut};
 use std::collections::hash_map::{HashMap, Occupied, Vacant};
 use std::io::fs::{PathExtensions, File};
 use std::string;
@@ -17,8 +17,6 @@ pub struct Config<'a> {
     shell: RefCell<&'a mut MultiShell>,
     jobs: uint,
     target: Option<string::String>,
-    linker: RefCell<Option<string::String>>,
-    ar: RefCell<Option<string::String>>,
     rustc_version: string::String,
     /// The current host and default target of rustc
     rustc_host: string::String,
@@ -42,8 +40,6 @@ impl<'a> Config<'a> {
             shell: RefCell::new(shell),
             jobs: jobs.unwrap_or(os::num_cpus()),
             target: target,
-            ar: RefCell::new(None),
-            linker: RefCell::new(None),
             rustc_version: rustc_version,
             rustc_host: rustc_host,
         })
@@ -82,17 +78,6 @@ impl<'a> Config<'a> {
     pub fn target(&self) -> Option<&str> {
         self.target.as_ref().map(|t| t.as_slice())
     }
-
-    pub fn set_ar(&self, ar: string::String) {
-        *self.ar.borrow_mut() = Some(ar);
-    }
-
-    pub fn set_linker(&self, linker: string::String) {
-        *self.linker.borrow_mut() = Some(linker);
-    }
-
-    pub fn linker(&self) -> Ref<Option<string::String>> { self.linker.borrow() }
-    pub fn ar(&self) -> Ref<Option<string::String>> { self.ar.borrow() }
 
     /// Return the output of `rustc -v verbose`
     pub fn rustc_version(&self) -> &str {

--- a/src/doc/build-script.md
+++ b/src/doc/build-script.md
@@ -76,7 +76,7 @@ are interpreted by Cargo and must be of the form `key=value`.
 Example output:
 
 ```
-cargo:rustc-flags=-l static:foo -L /path/to/foo
+cargo:rustc-flags=-l foo:static -L /path/to/foo
 cargo:root=/path/to/foo
 cargo:libdir=/path/to/foo/lib
 cargo:include=/path/to/foo/include

--- a/tests/test_cargo_compile_custom_build.rs
+++ b/tests/test_cargo_compile_custom_build.rs
@@ -542,7 +542,7 @@ test!(propagation_of_l_flags {
 {running} `[..]a-[..]build-script-build[..]`
 {running} `rustc [..] --crate-name a [..]-L bar[..]-L foo[..]`
 {compiling} foo v0.5.0 (file://[..])
-{running} `rustc [..] --crate-name foo [..] -L bar[..]-L foo[..]`
+{running} `rustc [..] --crate-name foo [..] -L bar -L foo`
 ", compiling = COMPILING, running = RUNNING).as_slice()));
 })
 

--- a/tests/test_cargo_cross_compile.rs
+++ b/tests/test_cargo_cross_compile.rs
@@ -9,6 +9,7 @@ use support::{project, execs, basic_bin_manifest};
 use support::{RUNNING, COMPILING, DOCTEST, cargo_dir};
 use hamcrest::{assert_that, existing_file};
 use cargo::util::process;
+use cargo::ops::rustc_version;
 
 fn setup() {
 }
@@ -516,3 +517,84 @@ test!(cross_with_a_build_script {
    dir = p.root().display(), sep = path::SEP).as_slice()));
 })
 
+test!(build_script_needed_for_host_and_target {
+    if disabled() { return }
+
+    let target = alternate();
+    let (_, host) = rustc_version().unwrap();
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [package]
+            name = "foo"
+            version = "0.0.0"
+            authors = []
+            build = 'build.rs'
+
+            [dependencies.d1]
+            path = "d1"
+            [build-dependencies.d2]
+            path = "d2"
+        "#)
+
+        .file("build.rs", r#"
+            extern crate d2;
+            fn main() { d2::d2(); }
+        "#)
+        .file("src/main.rs", "
+            extern crate d1;
+            fn main() { d1::d1(); }
+        ")
+        .file("d1/Cargo.toml", r#"
+            [package]
+            name = "d1"
+            version = "0.0.0"
+            authors = []
+            build = 'build.rs'
+        "#)
+        .file("d1/src/lib.rs", "
+            pub fn d1() {}
+        ")
+        .file("d1/build.rs", r#"
+            use std::os;
+            fn main() {
+                let target = os::getenv("TARGET").unwrap();
+                println!("cargo:rustc-flags=-L /path/to/{}", target);
+            }
+        "#)
+        .file("d2/Cargo.toml", r#"
+            [package]
+            name = "d2"
+            version = "0.0.0"
+            authors = []
+
+            [dependencies.d1]
+            path = "../d1"
+        "#)
+        .file("d2/src/lib.rs", "
+            extern crate d1;
+            pub fn d2() { d1::d1(); }
+        ");
+
+    assert_that(p.cargo_process("build").arg("--target").arg(&target).arg("-v"),
+                execs().with_status(0)
+                       .with_stdout(format!("\
+{compiling} d1 v0.0.0 (file://{dir})
+{running} `rustc build.rs [..] --out-dir {dir}{sep}target{sep}build{sep}d1-[..]`
+{running} `{dir}{sep}target{sep}build{sep}d1-[..]build-script-build`
+{running} `{dir}{sep}target{sep}build{sep}d1-[..]build-script-build`
+{running} `rustc {dir}{sep}d1{sep}src{sep}lib.rs [..] --target {target} [..] \
+           -L /path/to/{target}`
+{running} `rustc {dir}{sep}d1{sep}src{sep}lib.rs [..] \
+           -L /path/to/{host}`
+{compiling} d2 v0.0.0 (file://{dir})
+{running} `rustc {dir}{sep}d2{sep}src{sep}lib.rs [..] \
+           -L /path/to/{host}`
+{compiling} foo v0.0.0 (file://{dir})
+{running} `rustc build.rs [..] --out-dir {dir}{sep}target{sep}build{sep}foo-[..] \
+           -L /path/to/{host}`
+{running} `{dir}{sep}target{sep}build{sep}foo-[..]build-script-build`
+{running} `rustc {dir}{sep}src{sep}main.rs [..] --target {target} [..] \
+           -L /path/to/{target}`
+", compiling = COMPILING, running = RUNNING, target = target, host = host,
+   dir = p.root().display(), sep = path::SEP).as_slice()));
+})


### PR DESCRIPTION
These commits contain a number of improvements to the usage of build scripts when cross compiling. A few erroneous assumptions were made to start out with, and this also fixes the long-standing bug of using build scripts in host packages (e.g. plugins and build dependencies).
