### PR TITLE
Fix a panic when building with build scripts

### DIFF
--- a/tests/test_cargo_compile_custom_build.rs
+++ b/tests/test_cargo_compile_custom_build.rs
@@ -853,3 +853,43 @@ test!(build_script_only {
                        .with_stderr("either a [lib] or [[bin]] section must \
                                      be present"));
 })
+
+test!(shared_dep_with_a_build_script {
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [project]
+            name = "foo"
+            version = "0.5.0"
+            authors = []
+            build = "build.rs"
+
+            [dependencies.a]
+            path = "a"
+
+            [build-dependencies.b]
+            path = "b"
+        "#)
+        .file("src/lib.rs", "")
+        .file("build.rs", "fn main() {}")
+        .file("a/Cargo.toml", r#"
+            [package]
+            name = "a"
+            version = "0.5.0"
+            authors = []
+            build = "build.rs"
+        "#)
+        .file("a/build.rs", "fn main() {}")
+        .file("a/src/lib.rs", "")
+        .file("b/Cargo.toml", r#"
+            [package]
+            name = "b"
+            version = "0.5.0"
+            authors = []
+
+            [dependencies.a]
+            path = "../b"
+        "#)
+        .file("b/src/lib.rs", "");
+    assert_that(p.cargo_process("build"),
+                execs().with_status(0));
+})


### PR DESCRIPTION
A package can be required to be built for both the host and target architectures
in some cases. For example a crate could be a normal dependency and a build
dependency. Cargo specially handles this case with respect to the build script
to ensure that the build script is run once per output platform.

Cargo also has logic, however, to run the build script only once when the target
and host platforms are the same. In this case Cargo previously wasn't filling in
the local build script output cache for both the host and target platforms, just
the target platform. This commit remedies this situation by ensuring that cargo
populates both the host and target locations in the cache.

Closes #838
