### PR TITLE
cargo build --bins

### DIFF
--- a/src/bin/bench.rs
+++ b/src/bin/bench.rs
@@ -61,6 +61,7 @@ pub fn execute(options: Options, shell: &mut MultiShell) -> CliResult<Option<()>
             target: options.flag_target.as_ref().map(|s| s.as_slice()),
             dev_deps: true,
             features: options.flag_features.as_slice(),
+            bins: None,
             no_default_features: options.flag_no_default_features,
             spec: options.flag_package.as_ref().map(|s| s.as_slice()),
         },

--- a/src/bin/build.rs
+++ b/src/bin/build.rs
@@ -11,6 +11,7 @@ struct Options {
     flag_package: Option<String>,
     flag_jobs: Option<uint>,
     flag_features: Vec<String>,
+    flag_bin: Option<Vec<String>>,
     flag_no_default_features: bool,
     flag_target: Option<String>,
     flag_manifest_path: Option<String>,
@@ -30,6 +31,7 @@ Options:
     -j N, --jobs N           The number of jobs to run in parallel
     --release                Build artifacts in release mode, with optimizations
     --features FEATURES      Space-separated list of features to also build
+    --bin BIN                Space-separated list of binaries to build
     --no-default-features    Do not build the `default` feature
     --target TRIPLE          Build for the target triple
     --manifest-path PATH     Path to the manifest to compile
@@ -60,6 +62,7 @@ pub fn execute(options: Options, shell: &mut MultiShell) -> CliResult<Option<()>
         target: options.flag_target.as_ref().map(|t| t.as_slice()),
         dev_deps: false,
         features: options.flag_features.as_slice(),
+        bins: options.flag_bin,
         no_default_features: options.flag_no_default_features,
         spec: options.flag_package.as_ref().map(|s| s.as_slice()),
     };

--- a/src/bin/doc.rs
+++ b/src/bin/doc.rs
@@ -49,6 +49,7 @@ pub fn execute(options: Options, shell: &mut MultiShell) -> CliResult<Option<()>
             target: None,
             dev_deps: false,
             features: options.flag_features.as_slice(),
+            bins: None,
             no_default_features: options.flag_no_default_features,
             spec: None,
         },

--- a/src/bin/run.rs
+++ b/src/bin/run.rs
@@ -65,6 +65,7 @@ pub fn execute(options: Options, shell: &mut MultiShell) -> CliResult<Option<()>
         target: options.flag_target.as_ref().map(|t| t.as_slice()),
         dev_deps: true,
         features: options.flag_features.as_slice(),
+        bins: None,
         no_default_features: options.flag_no_default_features,
         spec: None,
     };

--- a/src/bin/test.rs
+++ b/src/bin/test.rs
@@ -63,6 +63,7 @@ pub fn execute(options: Options, shell: &mut MultiShell) -> CliResult<Option<()>
             target: options.flag_target.as_ref().map(|s| s.as_slice()),
             dev_deps: true,
             features: options.flag_features.as_slice(),
+            bins: None,
             no_default_features: options.flag_no_default_features,
             spec: options.flag_package.as_ref().map(|s| s.as_slice()),
         },

--- a/src/cargo/ops/cargo_package.rs
+++ b/src/cargo/ops/cargo_package.rs
@@ -124,6 +124,7 @@ fn run_verify(pkg: &Package, shell: &mut MultiShell, tar: &Path)
         target: None,
         dev_deps: false,
         features: [],
+        bins: None,
         no_default_features: false,
         spec: None,
     }));

--- a/src/cargo/ops/cargo_run.rs
+++ b/src/cargo/ops/cargo_run.rs
@@ -35,6 +35,9 @@ pub fn run(manifest_path: &Path,
         None => {}
     }
 
+    // only compile binary that should be run
+    options.bins = Some(vec![bin.get_name().to_string()]);
+
     let compile = try!(ops::compile(manifest_path, options));
     let dst = manifest_path.dir_path().join("target");
     let dst = match options.target {

--- a/tests/test_cargo_build_bin.rs
+++ b/tests/test_cargo_build_bin.rs
@@ -1,0 +1,59 @@
+use support::{project, execs};
+use hamcrest::{assert_that, is, is_not, existing_file};
+
+fn setup() {
+}
+
+test!(build_bin_only {
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [project]
+            name = "proj"
+            version = "0.0.1"
+            authors = ["wycats@example.com"]
+
+            [[bin]]
+            name = "foo"
+            path = "src/foo.rs"
+
+            [[bin]]
+            name = "bar"
+            path = "src/bar.rs"
+        "#)
+        .file("src/foo.rs", r#"
+            extern crate proj;
+            fn main() {}
+        "#)
+        .file("src/bar.rs", r#"
+            incorrect() program! should[] not<> be? built.
+        "#)
+        .file("src/lib.rs", r#" "#);
+    assert_that(p.cargo_process("build").arg("--bin").arg("foo"),
+    execs().with_status(0));
+    assert_that(&p.bin("foo"), is(existing_file()));
+    assert_that(&p.bin("bar"), is_not(existing_file()));
+})
+
+test!(build_bin_nonexistent {
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [project]
+            name = "proj"
+            version = "0.0.1"
+            authors = ["wycats@example.com"]
+
+            [[bin]]
+            name = "foo"
+            path = "src/foo.rs"
+        "#)
+        .file("src/foo.rs", r#"
+            extern crate proj;
+            fn main() {}
+        "#)
+        .file("src/lib.rs", r#" "#);
+    assert_that(p.cargo_process("build").arg("--bin").arg("noexistent"),
+    execs().with_status(101).with_stderr("\
+    unknown bin target: noexistent
+"));
+    assert_that(&p.bin("foo"), is_not(existing_file()));
+})

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -27,6 +27,7 @@ macro_rules! test(
 
 mod test_cargo;
 mod test_cargo_bench;
+mod test_cargo_build_bin;
 mod test_cargo_clean;
 mod test_cargo_compile;
 mod test_cargo_compile_custom_build;


### PR DESCRIPTION
Command `cargo build --bin BINS` where bins is space-separated list
of binaries rebuilds only those binaries.

As a side effect, `cargo run --name NAME` now build only binary to
be executed.
