### PR TITLE
Update the UI around using crates.io

### DIFF
--- a/src/cargo/core/package_id.rs
+++ b/src/cargo/core/package_id.rs
@@ -152,13 +152,11 @@ impl Metadata {
     }
 }
 
-static CENTRAL_REPO: &'static str = "http://rust-lang.org/central-repo";
-
 impl Show for PackageId {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         try!(write!(f, "{} v{}", self.inner.name, self.inner.version));
 
-        if self.inner.source_id.to_string().as_slice() != CENTRAL_REPO {
+        if !self.inner.source_id.is_default_registry() {
             try!(write!(f, " ({})", self.inner.source_id));
         }
 
@@ -168,13 +166,14 @@ impl Show for PackageId {
 
 #[cfg(test)]
 mod tests {
-    use super::{PackageId, CENTRAL_REPO};
+    use super::PackageId;
     use core::source::SourceId;
+    use sources::RegistrySource;
     use util::ToUrl;
 
     #[test]
     fn invalid_version_handled_nicely() {
-        let loc = CENTRAL_REPO.to_url().unwrap();
+        let loc = RegistrySource::default_url().to_url().unwrap();
         let repo = SourceId::for_registry(&loc);
 
         assert!(PackageId::new("foo", "1.0", &repo).is_err());

--- a/src/cargo/core/source.rs
+++ b/src/cargo/core/source.rs
@@ -219,6 +219,14 @@ impl SourceId {
             }),
         }
     }
+
+    pub fn is_default_registry(&self) -> bool {
+        match self.inner.kind {
+            RegistryKind => {}
+            _ => return false,
+        }
+        self.inner.url.to_string() == RegistrySource::default_url()
+    }
 }
 
 impl PartialEq for SourceId {
@@ -276,12 +284,7 @@ impl Show for SourceId {
                 Ok(())
             },
             SourceIdInner { kind: RegistryKind, ref url, .. } => {
-                let default = RegistrySource::url().ok();
-                if default.as_ref() == Some(url) {
-                    write!(f, "the package registry")
-                } else {
-                    write!(f, "registry {}", url)
-                }
+                write!(f, "registry {}", url)
             }
         }
     }

--- a/src/cargo/ops/registry.rs
+++ b/src/cargo/ops/registry.rs
@@ -48,14 +48,14 @@ fn verify_dependencies(pkg: &Package, registry_src: &SourceId)
         if dep.get_source_id().is_path() {
             if dep.get_specified_req().is_none() {
                 return Err(human(format!("all path dependencies must have \
-                                          a version specified when being \
-                                          uploaded to the registry.\n\
+                                          a version specified when \
+                                          publishing.\n\
                                           dependency `{}` does not specify \
                                           a version", dep.get_name())))
             }
         } else if dep.get_source_id() != registry_src {
             return Err(human(format!("all dependencies must come from the \
-                                      same registry.\ndependency `{}` comes \
+                                      same source.\ndependency `{}` comes \
                                       from {} instead", dep.get_name(),
                                      dep.get_source_id())))
         }

--- a/src/cargo/sources/registry.rs
+++ b/src/cargo/sources/registry.rs
@@ -177,7 +177,7 @@ use util::{CargoResult, Config, internal, ChainError, ToUrl, human};
 use util::{hex, Require, Sha256};
 use ops;
 
-static CENTRAL: &'static str = "https://example.com";
+static DEFAULT: &'static str = "https://github.com/rust-lang/crates.io-index";
 
 pub struct RegistrySource<'a, 'b:'a> {
     source_id: SourceId,
@@ -250,13 +250,13 @@ impl<'a, 'b> RegistrySource<'a, 'b> {
     /// a .cargo/config
     pub fn url() -> CargoResult<Url> {
         let config = try!(ops::registry_configuration());
-        let url = config.index.unwrap_or(CENTRAL.to_string());
+        let url = config.index.unwrap_or(DEFAULT.to_string());
         url.as_slice().to_url().map_err(human)
     }
 
     /// Get the default url for the registry
     pub fn default_url() -> String {
-        CENTRAL.to_string()
+        DEFAULT.to_string()
     }
 
     /// Decode the configuration stored within the registry.

--- a/tests/test_cargo_publish.rs
+++ b/tests/test_cargo_publish.rs
@@ -90,7 +90,7 @@ test!(git_deps {
 
     assert_that(p.cargo_process("publish").arg("-v").arg("--no-verify"),
                 execs().with_status(101).with_stderr("\
-all dependencies must come from the same registry.
+all dependencies must come from the same source.
 dependency `foo` comes from git://path/to/nowhere instead
 "));
 })
@@ -117,8 +117,7 @@ test!(path_dependency_no_version {
 
     assert_that(p.cargo_process("publish"),
                 execs().with_status(101).with_stderr("\
-all path dependencies must have a version specified when being uploaded \
-to the registry.
+all path dependencies must have a version specified when publishing.
 dependency `bar` does not specify a version
 "));
 })

--- a/tests/test_cargo_registry.rs
+++ b/tests/test_cargo_registry.rs
@@ -29,8 +29,8 @@ test!(simple {
     assert_that(p.cargo_process("build"),
                 execs().with_status(0).with_stdout(format!("\
 {updating} registry `{reg}`
-{downloading} bar v0.0.1 (the package registry)
-{compiling} bar v0.0.1 (the package registry)
+{downloading} bar v0.0.1 (registry file://[..])
+{compiling} bar v0.0.1 (registry file://[..])
 {compiling} foo v0.0.1 ({dir})
 ",
         updating = UPDATING,
@@ -43,7 +43,7 @@ test!(simple {
     assert_that(p.cargo_process("build"),
                 execs().with_status(0).with_stdout(format!("\
 {updating} registry `{reg}`
-[..] bar v0.0.1 (the package registry)
+[..] bar v0.0.1 (registry file://[..])
 [..] foo v0.0.1 ({dir})
 ",
         updating = UPDATING,
@@ -70,10 +70,10 @@ test!(deps {
     assert_that(p.cargo_process("build"),
                 execs().with_status(0).with_stdout(format!("\
 {updating} registry `{reg}`
-{downloading} [..] v0.0.1 (the package registry)
-{downloading} [..] v0.0.1 (the package registry)
-{compiling} baz v0.0.1 (the package registry)
-{compiling} bar v0.0.1 (the package registry)
+{downloading} [..] v0.0.1 (registry file://[..])
+{downloading} [..] v0.0.1 (registry file://[..])
+{compiling} baz v0.0.1 (registry file://[..])
+{compiling} bar v0.0.1 (registry file://[..])
 {compiling} foo v0.0.1 ({dir})
 ",
         updating = UPDATING,
@@ -99,7 +99,7 @@ test!(nonexistent {
     assert_that(p.cargo_process("build"),
                 execs().with_status(101).with_stderr("\
 no package named `nonexistent` found (required by `foo`)
-location searched: the package registry
+location searched: registry file://[..]
 version required: >= 0.0.0
 "));
 })
@@ -125,10 +125,10 @@ test!(bad_cksum {
 Unable to get packages from source
 
 Caused by:
-  Failed to download package `bad-cksum v0.0.1 (the package registry)` from [..]
+  Failed to download package `bad-cksum v0.0.1 (registry file://[..])` from [..]
 
 Caused by:
-  Failed to verify the checksum of `bad-cksum v0.0.1 (the package registry)`
+  Failed to verify the checksum of `bad-cksum v0.0.1 (registry file://[..])`
 "));
 })
 
@@ -148,7 +148,7 @@ test!(update_registry {
     assert_that(p.cargo_process("build"),
                 execs().with_status(101).with_stderr("\
 no package named `notyet` found (required by `foo`)
-location searched: the package registry
+location searched: registry file://[..]
 version required: >= 0.0.0
 "));
 
@@ -157,8 +157,8 @@ version required: >= 0.0.0
     assert_that(p.process(cargo_dir().join("cargo")).arg("build"),
                 execs().with_status(0).with_stdout(format!("\
 {updating} registry `{reg}`
-{downloading} notyet v0.0.1 (the package registry)
-{compiling} notyet v0.0.1 (the package registry)
+{downloading} notyet v0.0.1 (registry file://[..])
+{compiling} notyet v0.0.1 (registry file://[..])
 {compiling} foo v0.0.1 ({dir})
 ",
         updating = UPDATING,
@@ -196,7 +196,7 @@ failed to verify package tarball
 
 Caused by:
   no package named `notyet` found (required by `foo`)
-location searched: the package registry
+location searched: registry file://[..]
 version required: ^0.0.1
 "));
 
@@ -207,8 +207,8 @@ version required: ^0.0.1
 {packaging} foo v0.0.1 ({dir})
 {verifying} foo v0.0.1 ({dir})
 {updating} registry `[..]`
-{downloading} notyet v0.0.1 (the package registry)
-{compiling} notyet v0.0.1 (the package registry)
+{downloading} notyet v0.0.1 (registry file://[..])
+{compiling} notyet v0.0.1 (registry file://[..])
 {compiling} foo v0.0.1 ({dir}[..])
 ",
     packaging = PACKAGING,
@@ -239,8 +239,8 @@ test!(lockfile_locks {
     assert_that(p.process(cargo_dir().join("cargo")).arg("build"),
                 execs().with_status(0).with_stdout(format!("\
 {updating} registry `[..]`
-{downloading} bar v0.0.1 (the package registry)
-{compiling} bar v0.0.1 (the package registry)
+{downloading} bar v0.0.1 (registry file://[..])
+{compiling} bar v0.0.1 (registry file://[..])
 {compiling} foo v0.0.1 ({dir})
 ", updating = UPDATING, downloading = DOWNLOADING, compiling = COMPILING,
    dir = p.url()).as_slice()));
@@ -272,10 +272,10 @@ test!(lockfile_locks_transitively {
     assert_that(p.process(cargo_dir().join("cargo")).arg("build"),
                 execs().with_status(0).with_stdout(format!("\
 {updating} registry `[..]`
-{downloading} [..] v0.0.1 (the package registry)
-{downloading} [..] v0.0.1 (the package registry)
-{compiling} baz v0.0.1 (the package registry)
-{compiling} bar v0.0.1 (the package registry)
+{downloading} [..] v0.0.1 (registry file://[..])
+{downloading} [..] v0.0.1 (registry file://[..])
+{compiling} baz v0.0.1 (registry file://[..])
+{compiling} bar v0.0.1 (registry file://[..])
 {compiling} foo v0.0.1 ({dir})
 ", updating = UPDATING, downloading = DOWNLOADING, compiling = COMPILING,
    dir = p.url()).as_slice()));
@@ -310,10 +310,10 @@ test!(yanks_are_not_used {
     assert_that(p.process(cargo_dir().join("cargo")).arg("build"),
                 execs().with_status(0).with_stdout(format!("\
 {updating} registry `[..]`
-{downloading} [..] v0.0.1 (the package registry)
-{downloading} [..] v0.0.1 (the package registry)
-{compiling} baz v0.0.1 (the package registry)
-{compiling} bar v0.0.1 (the package registry)
+{downloading} [..] v0.0.1 (registry file://[..])
+{downloading} [..] v0.0.1 (registry file://[..])
+{compiling} baz v0.0.1 (registry file://[..])
+{compiling} bar v0.0.1 (registry file://[..])
 {compiling} foo v0.0.1 ({dir})
 ", updating = UPDATING, downloading = DOWNLOADING, compiling = COMPILING,
    dir = p.url()).as_slice()));
@@ -340,7 +340,7 @@ test!(relying_on_a_yank_is_bad {
     assert_that(p.process(cargo_dir().join("cargo")).arg("build"),
                 execs().with_status(101).with_stderr("\
 no package named `baz` found (required by `bar`)
-location searched: the package registry
+location searched: registry file://[..]
 version required: = 0.0.2
 "));
 })
@@ -374,7 +374,7 @@ test!(yanks_in_lockfiles_are_ok {
     assert_that(p.process(cargo_dir().join("cargo")).arg("update"),
                 execs().with_status(101).with_stderr("\
 no package named `bar` found (required by `foo`)
-location searched: the package registry
+location searched: registry file://[..]
 version required: *
 "));
 })
@@ -402,7 +402,7 @@ test!(update_with_lockfile_if_packages_missing {
     assert_that(p.process(cargo_dir().join("cargo")).arg("build"),
                 execs().with_status(0).with_stdout(format!("\
 {updating} registry `[..]`
-{downloading} bar v0.0.1 (the package registry)
+{downloading} bar v0.0.1 (registry file://[..])
 ", updating = UPDATING, downloading = DOWNLOADING).as_slice()));
 })
 
@@ -434,8 +434,8 @@ test!(update_lockfile {
 
     assert_that(p.process(cargo_dir().join("cargo")).arg("build"),
                 execs().with_status(0).with_stdout(format!("\
-{downloading} [..] v0.0.2 (the package registry)
-{compiling} bar v0.0.2 (the package registry)
+{downloading} [..] v0.0.2 (registry file://[..])
+{compiling} bar v0.0.2 (registry file://[..])
 {compiling} foo v0.0.1 ({dir})
 ", downloading = DOWNLOADING, compiling = COMPILING,
    dir = p.url()).as_slice()));


### PR DESCRIPTION
Try to purge the word "registry" as much as possible in favor of just referring
to crates.io as "crates.io". This also enables the default index as being the
official rust-lang crates.io index.
