### PR TITLE
Add the semicolon missing from the generated main.rs contents.

### DIFF
--- a/src/cargo/ops/cargo_new.rs
+++ b/src/cargo/ops/cargo_new.rs
@@ -92,7 +92,7 @@ authors = ["{}"]
     if opts.bin {
         try!(File::create(&path.join("src/main.rs")).write_str("\
 fn main() {
-    println!(\"Hello, world!\")
+    println!(\"Hello, world!\");
 }
 "));
     } else {


### PR DESCRIPTION
When you run `cargo new project-name --bin`, a project is generated by cargo
with a file, `src/main.rs`. This file has a main function with one line that
prints hello, world, but a semicolon is missing from the end of the
expression.
