### PR TITLE
Implement -l/--list for `cargo package`

### DIFF
--- a/src/bin/package.rs
+++ b/src/bin/package.rs
@@ -8,6 +8,7 @@ struct Options {
     flag_verbose: bool,
     flag_manifest_path: Option<String>,
     flag_no_verify: bool,
+    flag_list: bool,
 }
 
 pub const USAGE: &'static str = "
@@ -18,8 +19,9 @@ Usage:
 
 Options:
     -h, --help              Print this message
-    --manifest-path PATH    Path to the manifest to compile
+    -l, --list              Print files included in a package without making one
     --no-verify             Don't verify the contents by building them
+    --manifest-path PATH    Path to the manifest to compile
     -v, --verbose           Use verbose output
 
 ";
@@ -27,7 +29,9 @@ Options:
 pub fn execute(options: Options, shell: &mut MultiShell) -> CliResult<Option<()>> {
     shell.set_verbose(options.flag_verbose);
     let root = try!(find_root_manifest_for_cwd(options.flag_manifest_path));
-    ops::package(&root, shell, !options.flag_no_verify).map(|_| None).map_err(|err| {
+    ops::package(&root, shell,
+                 !options.flag_no_verify,
+                 options.flag_list).map(|_| None).map_err(|err| {
         CliError::from_boxed(err, 101)
     })
 }

--- a/src/cargo/ops/registry.rs
+++ b/src/cargo/ops/registry.rs
@@ -33,7 +33,7 @@ pub fn publish(manifest_path: &Path,
     try!(verify_dependencies(&pkg, &reg_id));
 
     // Prepare a tarball
-    let tarball = try!(ops::package(manifest_path, shell, verify));
+    let tarball = try!(ops::package(manifest_path, shell, verify, false)).unwrap();
 
     // Upload said tarball to the specified destination
     try!(shell.status("Uploading", pkg.get_package_id().to_string()));

--- a/tests/test_cargo_package.rs
+++ b/tests/test_cargo_package.rs
@@ -35,6 +35,11 @@ test!(simple {
         compiling = COMPILING,
         dir = p.url()).as_slice()));
     assert_that(&p.root().join("target/package/foo-0.0.1.crate"), existing_file());
+    assert_that(p.process(cargo_dir().join("cargo")).arg("package").arg("-l"),
+                execs().with_status(0).with_stdout("\
+Cargo.toml
+src[..]main.rs
+"));
     assert_that(p.process(cargo_dir().join("cargo")).arg("package"),
                 execs().with_status(0).with_stdout(""));
 


### PR DESCRIPTION
This provides a method of listing the files that will be in a package without
actually creating one.

Closes #855
