### PR TITLE
Rename --name flags to --<target-name>

### DIFF
--- a/src/bin/bench.rs
+++ b/src/bin/bench.rs
@@ -11,7 +11,7 @@ struct Options {
     flag_package: Option<String>,
     flag_jobs: Option<uint>,
     flag_features: Vec<String>,
-    flag_name: Option<String>,
+    flag_bench: Option<String>,
     flag_no_default_features: bool,
     flag_target: Option<String>,
     flag_manifest_path: Option<String>,
@@ -27,7 +27,7 @@ Usage:
 
 Options:
     -h, --help               Print this message
-    --name NAME              Name of the bench to run
+    --bench NAME             Name of the bench to run
     --no-run                 Compile, but don't run benchmarks
     -p SPEC, --package SPEC  Package to run benchmarks for
     -j N, --jobs N           The number of jobs to run in parallel
@@ -52,7 +52,7 @@ pub fn execute(options: Options, shell: &mut MultiShell) -> CliResult<Option<()>
     shell.set_verbose(options.flag_verbose);
 
     let mut ops = ops::TestOptions {
-        name: options.flag_name.as_ref().map(|s| s.as_slice()),
+        name: options.flag_bench.as_ref().map(|s| s.as_slice()),
         no_run: options.flag_no_run,
         compile_opts: ops::CompileOptions {
             env: "bench",

--- a/src/bin/run.rs
+++ b/src/bin/run.rs
@@ -8,7 +8,7 @@ use cargo::util::important_paths::{find_root_manifest_for_cwd};
 
 #[deriving(Decodable)]
 struct Options {
-    flag_name: Option<String>,
+    flag_bin: Option<String>,
     flag_example: Option<String>,
     flag_jobs: Option<uint>,
     flag_features: Vec<String>,
@@ -28,7 +28,7 @@ Usage:
 
 Options:
     -h, --help              Print this message
-    --name NAME             Name of the bin target to run
+    --bin NAME              Name of the bin target to run
     --example NAME          Name of the example target to run
     -j N, --jobs N          The number of jobs to run in parallel
     --release               Build artifacts in release mode, with optimizations
@@ -38,9 +38,9 @@ Options:
     --manifest-path PATH    Path to the manifest to execute
     -v, --verbose           Use verbose output
 
-If neither `--name` or `--example` are given, then if the project only has one
-bin target it will be run. Otherwise `--name` specifies the bin target to run,
-and `--example` specifies the example target to run. At most one of `--name` or
+If neither `--bin` or `--example` are given, then if the project only has one
+bin target it will be run. Otherwise `--bin` specifies the bin target to run,
+and `--example` specifies the example target to run. At most one of `--bin` or
 `--example` can be provided.
 
 All of the trailing arguments are passed as to the binary to run.
@@ -69,12 +69,12 @@ pub fn execute(options: Options, shell: &mut MultiShell) -> CliResult<Option<()>
         spec: None,
     };
 
-    let (target_kind, name) = match (options.flag_name, options.flag_example) {
+    let (target_kind, name) = match (options.flag_bin, options.flag_example) {
         (Some(bin), None) => (BinTarget, Some(bin)),
         (None, Some(example)) => (ExampleTarget, Some(example)),
         (None, None) => (BinTarget, None),
         (Some(_), Some(_)) => return Err(CliError::from_boxed(
-            human("specify either `--name` or `--example`, not both"), 1)),
+            human("specify either `--bin` or `--example`, not both"), 1)),
     };
 
     let err = try!(ops::run(&root,

--- a/src/bin/test.rs
+++ b/src/bin/test.rs
@@ -11,7 +11,7 @@ struct Options {
     flag_features: Vec<String>,
     flag_jobs: Option<uint>,
     flag_manifest_path: Option<String>,
-    flag_name: Option<String>,
+    flag_test: Option<String>,
     flag_no_default_features: bool,
     flag_no_run: bool,
     flag_package: Option<String>,
@@ -27,7 +27,7 @@ Usage:
 
 Options:
     -h, --help               Print this message
-    --name NAME              Name of the test executable to run
+    --test NAME              Name of the test executable to run
     --no-run                 Compile, but don't run tests
     -p SPEC, --package SPEC  Package to run tests for
     -j N, --jobs N           The number of jobs to run in parallel
@@ -54,7 +54,7 @@ pub fn execute(options: Options, shell: &mut MultiShell) -> CliResult<Option<()>
     shell.set_verbose(options.flag_verbose);
 
     let mut ops = ops::TestOptions {
-        name: options.flag_name.as_ref().map(|s| s.as_slice()),
+        name: options.flag_test.as_ref().map(|s| s.as_slice()),
         no_run: options.flag_no_run,
         compile_opts: ops::CompileOptions {
             env: "test",

--- a/src/cargo/ops/cargo_run.rs
+++ b/src/cargo/ops/cargo_run.rs
@@ -31,7 +31,7 @@ pub fn run(manifest_path: &Path,
     match bins.next() {
         Some(..) => return Err(
             human("`cargo run` requires that a project only have one executable. \
-                   Use the `--name` option to specify which one to run")),
+                   Use the `--bin` option to specify which one to run")),
         None => {}
     }
 

--- a/tests/test_cargo_bench.rs
+++ b/tests/test_cargo_bench.rs
@@ -87,7 +87,7 @@ test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured
        runnning = RUNNING,
        dir = prj.url());
 
-    assert_that(prj.cargo_process("bench").arg("--name").arg("bin2"),
+    assert_that(prj.cargo_process("bench").arg("--bench").arg("bin2"),
         execs().with_status(0).with_stdout(expected_stdout.as_slice()));
 })
 

--- a/tests/test_cargo_run.rs
+++ b/tests/test_cargo_run.rs
@@ -98,7 +98,7 @@ test!(too_many_bins {
     assert_that(p.cargo_process("run"),
                 execs().with_status(101)
                        .with_stderr("`cargo run` requires that a project only \
-                                     have one executable. Use the `--name` option \
+                                     have one executable. Use the `--bin` option \
                                      to specify which one to run\n"));
 })
 
@@ -120,7 +120,7 @@ test!(specify_name {
             fn main() { println!("hello b.rs"); }
         "#);
 
-    assert_that(p.cargo_process("run").arg("--name").arg("a"),
+    assert_that(p.cargo_process("run").arg("--bin").arg("a"),
                 execs().with_status(0).with_stdout(format!("\
 {compiling} foo v0.0.1 ({dir})
 {running} `target{sep}a`
@@ -131,7 +131,7 @@ hello a.rs
         dir = path2url(p.root()),
         sep = path::SEP).as_slice()));
 
-    assert_that(p.process(cargo_dir().join("cargo")).arg("run").arg("--name").arg("b"),
+    assert_that(p.process(cargo_dir().join("cargo")).arg("run").arg("--bin").arg("b"),
                 execs().with_status(0).with_stdout(format!("\
 {running} `target{sep}b`
 hello b.rs
@@ -183,9 +183,9 @@ test!(either_name_or_example {
             fn main() { println!("hello b.rs"); }
         "#);
 
-    assert_that(p.cargo_process("run").arg("--name").arg("a").arg("--example").arg("b"),
+    assert_that(p.cargo_process("run").arg("--bin").arg("a").arg("--example").arg("b"),
                 execs().with_status(1)
-                       .with_stderr("specify either `--name` or `--example`, \
+                       .with_stderr("specify either `--bin` or `--example`, \
                                      not both"));
 })
 

--- a/tests/test_cargo_test.rs
+++ b/tests/test_cargo_test.rs
@@ -900,7 +900,7 @@ test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
        running = RUNNING,
        dir = prj.url());
 
-    assert_that(prj.cargo_process("test").arg("--name").arg("bin2"),
+    assert_that(prj.cargo_process("test").arg("--test").arg("bin2"),
         execs().with_status(0).with_stdout(expected_stdout.as_slice()));
 })
 
@@ -938,7 +938,7 @@ test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
        running = RUNNING,
        dir = prj.url());
 
-    assert_that(prj.cargo_process("test").arg("--name").arg("b"),
+    assert_that(prj.cargo_process("test").arg("--test").arg("b"),
         execs().with_status(0).with_stdout(expected_stdout.as_slice()));
 })
 


### PR DESCRIPTION
With #843 and #839 coming around the bend soon, the original decision for
`--name` everywhere isn't making as much sense, for consistence this is renaming
these flags back to `--<target-name>` for the respective targets.
