### PR TITLE
Missed backtick fix

### DIFF
--- a/src/bin/cargo.rs
+++ b/src/bin/cargo.rs
@@ -154,7 +154,7 @@ fn execute_subcommand(cmd: &str, args: &[String], shell: &mut MultiShell) {
         Some(command) => command,
         None => {
             let msg = match find_closest(cmd) {
-                Some(closest) => format!("No such subcommand\n\n\tDid you mean ``{}''?\n", closest),
+                Some(closest) => format!("No such subcommand\n\n\tDid you mean `{}`?\n", closest),
                 None => "No such subcommand".to_string()
             };
             return handle_error(CliError::new(msg, 127), shell)

--- a/tests/test_cargo.rs
+++ b/tests/test_cargo.rs
@@ -55,7 +55,7 @@ test!(find_closest_biuld_to_build {
                 execs().with_status(127)
                        .with_stderr("No such subcommand
 
-Did you mean ``build''?
+Did you mean `build`?
 
 "));
 })
@@ -71,4 +71,3 @@ test!(find_closest_dont_correct_nonsense {
                        .with_stderr("No such subcommand
 "));
 })
-


### PR DESCRIPTION
19:09 < ianconnolly> hey, i was browsing the cargo code, any particular reason why this string is mixed backticks + straight apostrophes?
                     https://github.com/rust-lang/cargo/blob/master/src/bin/cargo.rs#L157
19:10 < acrichto> ianconnolly: oh I think I missed that, it should probably just be `{}` like the rest of cargo
