### PR TITLE
Fix panic with plugins and build commands

### DIFF
--- a/src/cargo/core/package.rs
+++ b/src/cargo/core/package.rs
@@ -110,6 +110,10 @@ impl Package {
     pub fn get_absolute_target_dir(&self) -> Path {
         self.get_root().join(self.get_target_dir())
     }
+
+    pub fn has_custom_build(&self) -> bool {
+        self.get_targets().iter().any(|t| t.get_profile().is_custom_build())
+    }
 }
 
 impl Show for Package {

--- a/src/cargo/ops/cargo_rustc/context.rs
+++ b/src/cargo/ops/cargo_rustc/context.rs
@@ -326,4 +326,21 @@ impl PlatformRequirement {
             _ => PlatformPluginAndTarget,
         }
     }
+
+    pub fn includes(self, kind: Kind) -> bool {
+        match (self, kind) {
+            (PlatformPluginAndTarget, _) |
+            (PlatformTarget, KindTarget) |
+            (PlatformPlugin, KindHost) => true,
+            _ => false,
+        }
+    }
+
+    pub fn each_kind(self, f: |Kind|) {
+        match self {
+            PlatformTarget => f(KindTarget),
+            PlatformPlugin => f(KindHost),
+            PlatformPluginAndTarget => { f(KindTarget); f(KindHost); }
+        }
+    }
 }

--- a/tests/test_cargo_compile_custom_build.rs
+++ b/tests/test_cargo_compile_custom_build.rs
@@ -897,3 +897,45 @@ test!(shared_dep_with_a_build_script {
     assert_that(p.cargo_process("build"),
                 execs().with_status(0));
 })
+
+test!(transitive_dep_host {
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [project]
+            name = "foo"
+            version = "0.5.0"
+            authors = []
+            build = "build.rs"
+
+            [build-dependencies.b]
+            path = "b"
+        "#)
+        .file("src/lib.rs", "")
+        .file("build.rs", "fn main() {}")
+        .file("a/Cargo.toml", r#"
+            [package]
+            name = "a"
+            version = "0.5.0"
+            authors = []
+            links = "foo"
+            build = "build.rs"
+        "#)
+        .file("a/build.rs", "fn main() {}")
+        .file("a/src/lib.rs", "")
+        .file("b/Cargo.toml", r#"
+            [package]
+            name = "b"
+            version = "0.5.0"
+            authors = []
+
+            [lib]
+            name = "b"
+            plugin = true
+
+            [dependencies.a]
+            path = "../a"
+        "#)
+        .file("b/src/lib.rs", "");
+    assert_that(p.cargo_process("build"),
+                execs().with_status(0));
+})


### PR DESCRIPTION
This fixes a bug in cargo where target executables and libraries would be linked
to plugin native dependencies (not wanted!).

Closes #885
