### PR TITLE
hide curl progress output

### DIFF
--- a/src/doc/index.md
+++ b/src/doc/index.md
@@ -6,7 +6,7 @@ The easiest way to get Cargo is to get the Rust nightly build by using
 the `rustup` script:
 
 ```shell
-$ curl https://static.rust-lang.org/rustup.sh | sudo bash
+$ curl -sS https://static.rust-lang.org/rustup.sh | sudo bash
 ```
 
 This will get you the latest Rust nightly for your platform along with


### PR DESCRIPTION
Currently the command output looks like this on Fedora:

```
$ curl https://static.rust-lang.org/rustup.sh | sudo bash
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  9866  100  9866    0     0  39592      0 --:--:-- --:--:-- --:--:-- 39622[sudo] password for jakob: 
```

The first time I ran it, I didn't even realize it is asking for a password. By using the options for `silent` and `show-error`, we get this:

```
$ curl -sS https://static.rust-lang.org/rustup.sh | sudo bash
[sudo] password for jakob:
```

And errors are still displayed:

```
$ curl -sS https://example.invalid | sudo bash
curl: (6) Could not resolve host: example.invalid
[sudo] password for jakob: 
```
