### PR TITLE
One does not simply `make` Cargo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /Makefile
 /config.mk
 src/doc/build
+rustc

--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ Cargo can then be compiled like many other standard unix-like projects:
 ```sh
 git clone https://github.com/rust-lang/cargo
 cd cargo
-./configure
+./.travis.install.deps.sh
+./configure --local-rust-root=`pwd`/rustc
 make
 make install
 ```


### PR DESCRIPTION
README fix with correct build instructions for building from source.
