### PR TITLE
Warn about no useful metadata in `cargo package`.

### DIFF
--- a/src/bin/package.rs
+++ b/src/bin/package.rs
@@ -8,6 +8,7 @@ struct Options {
     flag_verbose: bool,
     flag_manifest_path: Option<String>,
     flag_no_verify: bool,
+    flag_no_metadata: bool,
     flag_list: bool,
 }
 
@@ -21,6 +22,7 @@ Options:
     -h, --help              Print this message
     -l, --list              Print files included in a package without making one
     --no-verify             Don't verify the contents by building them
+    --no-metadata           Ignore warnings about a lack of human-usable metadata
     --manifest-path PATH    Path to the manifest to compile
     -v, --verbose           Use verbose output
 
@@ -31,7 +33,8 @@ pub fn execute(options: Options, shell: &mut MultiShell) -> CliResult<Option<()>
     let root = try!(find_root_manifest_for_cwd(options.flag_manifest_path));
     ops::package(&root, shell,
                  !options.flag_no_verify,
-                 options.flag_list).map(|_| None).map_err(|err| {
+                 options.flag_list,
+                 !options.flag_no_metadata).map(|_| None).map_err(|err| {
         CliError::from_boxed(err, 101)
     })
 }

--- a/src/cargo/ops/registry.rs
+++ b/src/cargo/ops/registry.rs
@@ -32,8 +32,9 @@ pub fn publish(manifest_path: &Path,
     let (mut registry, reg_id) = try!(registry(shell, token, index));
     try!(verify_dependencies(&pkg, &reg_id));
 
-    // Prepare a tarball
-    let tarball = try!(ops::package(manifest_path, shell, verify, false)).unwrap();
+    // Prepare a tarball, with a non-surpressable warning if metadata
+    // is missing since this is being put online.
+    let tarball = try!(ops::package(manifest_path, shell, verify, false, true)).unwrap();
 
     // Upload said tarball to the specified destination
     try!(shell.status("Uploading", pkg.get_package_id().to_string()));

--- a/src/doc/manifest.md
+++ b/src/doc/manifest.md
@@ -96,6 +96,12 @@ keywords = ["...", "..."]
 license = "..."
 ```
 
+The [crates.io](https://crates.io) registry will render the description, display
+the license, link to the three URLs and categorize by the keywords. These keys
+provide useful information to users of the registry and also influence the
+search ranking of a crate. It is highly discouraged to omit everything in a
+published crate.
+
 
 # The `[dependencies.*]` Sections
 

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -516,3 +516,4 @@ pub static PACKAGING:   &'static str = "   Packaging";
 pub static DOWNLOADING: &'static str = " Downloading";
 pub static UPLOADING:   &'static str = "   Uploading";
 pub static VERIFYING:   &'static str = "   Verifying";
+pub static WARNING:     &'static str = "     Warning";

--- a/tests/test_cargo_package.rs
+++ b/tests/test_cargo_package.rs
@@ -4,7 +4,7 @@ use tar::Archive;
 use flate2::reader::GzDecoder;
 
 use support::{project, execs, cargo_dir, ResultTest};
-use support::{PACKAGING, VERIFYING, COMPILING};
+use support::{PACKAGING, WARNING, VERIFYING, COMPILING};
 use hamcrest::{assert_that, existing_file};
 
 fn setup() {
@@ -18,6 +18,8 @@ test!(simple {
             version = "0.0.1"
             authors = []
             exclude = ["*.txt"]
+            license = "MIT"
+            description = "foo"
         "#)
         .file("src/main.rs", r#"
             fn main() { println!("hello"); }
@@ -54,4 +56,77 @@ src[..]main.rs
                 fname == Path::new("foo-0.0.1/src/main.rs").as_vec(),
                 "unexpected filename: {}", f.filename())
     }
+})
+
+test!(metadata_warning {
+    let p = project("all")
+        .file("Cargo.toml", r#"
+            [project]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+        "#)
+        .file("src/main.rs", r#"
+            fn main() {}
+        "#);
+    assert_that(p.cargo_process("package"),
+                execs().with_status(0).with_stdout(format!("\
+{packaging} foo v0.0.1 ({dir})
+{verifying} foo v0.0.1 ({dir})
+{compiling} foo v0.0.1 ({dir}[..])
+",
+        packaging = PACKAGING,
+        verifying = VERIFYING,
+        compiling = COMPILING,
+        dir = p.url()).as_slice())
+                .with_stderr("Warning: manifest has no description or license. See \
+                              http://doc.crates.io/manifest.html#package-metadata for more info."));
+
+    let p = project("one")
+        .file("Cargo.toml", r#"
+            [project]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+            license = "MIT"
+        "#)
+        .file("src/main.rs", r#"
+            fn main() {}
+        "#);
+    assert_that(p.cargo_process("package"),
+                execs().with_status(0).with_stdout(format!("\
+{packaging} foo v0.0.1 ({dir})
+{verifying} foo v0.0.1 ({dir})
+{compiling} foo v0.0.1 ({dir}[..])
+",
+        packaging = PACKAGING,
+        verifying = VERIFYING,
+        compiling = COMPILING,
+        dir = p.url()).as_slice())
+                .with_stderr("Warning: manifest has no description. See \
+                              http://doc.crates.io/manifest.html#package-metadata for more info."));
+
+    let p = project("both")
+        .file("Cargo.toml", format!(r#"
+            [project]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+            license = "MIT"
+            description = "foo"
+        "#))
+        .file("src/main.rs", r#"
+            fn main() {}
+        "#);
+    assert_that(p.cargo_process("package"),
+                execs().with_status(0).with_stdout(format!("\
+{packaging} foo v0.0.1 ({dir})
+{verifying} foo v0.0.1 ({dir})
+{compiling} foo v0.0.1 ({dir}[..])
+",
+        packaging = PACKAGING,
+        verifying = VERIFYING,
+        compiling = COMPILING,
+        dir = p.url()).as_slice()));
+
 })

--- a/tests/test_cargo_publish.rs
+++ b/tests/test_cargo_publish.rs
@@ -41,6 +41,8 @@ test!(simple {
             name = "foo"
             version = "0.0.1"
             authors = []
+            license = "MIT"
+            description = "foo"
         "#)
         .file("src/main.rs", "fn main() {}");
 
@@ -82,6 +84,8 @@ test!(git_deps {
             name = "foo"
             version = "0.0.1"
             authors = []
+            license = "MIT"
+            description = "foo"
 
             [dependencies.foo]
             git = "git://path/to/nowhere"
@@ -102,6 +106,8 @@ test!(path_dependency_no_version {
             name = "foo"
             version = "0.0.1"
             authors = []
+            license = "MIT"
+            description = "foo"
 
             [dependencies.bar]
             path = "bar"

--- a/tests/test_cargo_registry.rs
+++ b/tests/test_cargo_registry.rs
@@ -175,6 +175,8 @@ test!(package_with_path_deps {
             name = "foo"
             version = "0.0.1"
             authors = []
+            license = "MIT"
+            description = "foo"
 
             [dependencies.notyet]
             version = "0.0.1"


### PR DESCRIPTION
It's very bad practice to not have a license in a
published (theoretically) open-source package, since the default
position is all-rights-reserved. Hence, cargo will now warn if this
metadata field is missing from the manifest when creating a package.

Similarly, a lack of description makes using crates.io less nice, since
there's no indication of what a package does other than the name (and
possibly documentation etc. links, but these are often missing too).

These metadata fields are not immediately obvious so `cargo` can be a
little intelligent and provide some hints that they exist.

Closes #902.
