### PR TITLE
Minor enhancements of .travis.install.deps.sh

### DIFF
--- a/.travis.install.deps.sh
+++ b/.travis.install.deps.sh
@@ -1,7 +1,7 @@
 set -x
 set -e
 
-if [ "${TRAVIS_OS_NAME}" = "osx" ] || [ "${PLATFORM}" = "mac" ]; then
+if [ "${TRAVIS_OS_NAME}" = "osx" ] || [ "${PLATFORM}" = "mac" ] || [ "`uname`" = "Darwin" ]; then
     target=apple-darwin
 elif [ "${OS}" = "Windows_NT" ] || [ "${PLATFORM}" = "win" ]; then
     windows=1


### PR DESCRIPTION
- `set -e` (script should crash on first error)
- detect darwin if running not on travis (and `PLATFORM` and `TRAVIS_OS_NAME` variables are unset)
