### PR TITLE
Fix the root output directory when cleaning examples

### DIFF
--- a/src/cargo/ops/cargo_rustc/context.rs
+++ b/src/cargo/ops/cargo_rustc/context.rs
@@ -197,6 +197,19 @@ impl<'a, 'b: 'a> Context<'a, 'b> {
         }
     }
 
+    /// Returns the appropriate output directory for the specified package and
+    /// target.
+    pub fn out_dir(&self, pkg: &Package, kind: Kind, target: &Target) -> Path {
+        let out_dir = self.layout(pkg, kind);
+        if target.get_profile().is_custom_build() {
+            out_dir.build(pkg)
+        } else if target.is_example() {
+            out_dir.examples().clone()
+        } else {
+            out_dir.root().clone()
+        }
+    }
+
     /// Return the (prefix, suffix) pair for dynamic libraries.
     ///
     /// If `plugin` is true, the pair corresponds to the host platform,

--- a/src/cargo/ops/cargo_rustc/fingerprint.rs
+++ b/src/cargo/ops/cargo_rustc/fingerprint.rs
@@ -82,16 +82,7 @@ pub fn prepare_target(cx: &mut Context, pkg: &Package, target: &Target,
     };
     let is_rustc_fresh = try!(is_fresh(&loc, rustc_fingerprint.as_slice()));
 
-    let root = {
-        let layout = cx.layout(pkg, kind);
-        if target.get_profile().is_custom_build() {
-            layout.build(pkg)
-        } else if target.is_example() {
-            layout.examples().clone()
-        } else {
-            layout.root().clone()
-        }
-    };
+    let root = cx.out_dir(pkg, kind, target);
     if !target.get_profile().is_doc() {
         for filename in try!(cx.target_filenames(target)).iter() {
             let dst = root.join(filename);

--- a/src/cargo/ops/cargo_rustc/mod.rs
+++ b/src/cargo/ops/cargo_rustc/mod.rs
@@ -387,7 +387,7 @@ fn rustc(package: &Package, target: &Target,
         let rustc = if show_warnings {rustc} else {rustc.arg("-Awarnings")};
 
         let filenames = try!(cx.target_filenames(target));
-        let root = cx.layout(package, kind).root().clone();
+        let root = cx.out_dir(package, kind, target);
 
         // Prepare the native lib state (extra -L and -l flags)
         let build_state = cx.build_state.clone();
@@ -634,17 +634,8 @@ fn build_base_args(cx: &Context,
 
 fn build_plugin_args(mut cmd: ProcessBuilder, cx: &Context, pkg: &Package,
                      target: &Target, kind: Kind) -> ProcessBuilder {
-    let out_dir = cx.layout(pkg, kind);
-    let out_dir = if target.get_profile().is_custom_build() {
-        out_dir.build(pkg)
-    } else if target.is_example() {
-        out_dir.examples().clone()
-    } else {
-        out_dir.root().clone()
-    };
-
     cmd = cmd.arg("--out-dir");
-    cmd = cmd.arg(out_dir);
+    cmd = cmd.arg(cx.out_dir(pkg, kind, target));
 
     let dep_info_loc = fingerprint::dep_info_loc(cx, pkg, target, kind);
     cmd = cmd.arg("--dep-info").arg(dep_info_loc);

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -517,5 +517,3 @@ pub static PACKAGING:   &'static str = "   Packaging";
 pub static DOWNLOADING: &'static str = " Downloading";
 pub static UPLOADING:   &'static str = "   Uploading";
 pub static VERIFYING:   &'static str = "   Verifying";
-#[allow(dead_code)]
-pub static WARNING:     &'static str = "     Warning";

--- a/tests/test_cargo_compile.rs
+++ b/tests/test_cargo_compile.rs
@@ -1470,3 +1470,29 @@ test!(cargo_platform_specific_dependency_wrong_platform {
     let lockfile = File::open(&lockfile).read_to_string().assert();
     assert!(lockfile.as_slice().contains("bar"))
 })
+
+test!(example_bin_same_name {
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [package]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+        "#)
+        .file("src/main.rs", "fn main() {}")
+        .file("examples/foo.rs", "fn main() {}");
+
+    p.cargo_process("test").arg("--no-run")
+        .exec_with_output()
+        .assert();
+
+    assert_that(&p.bin("foo"), existing_file());
+    assert_that(&p.bin("examples/foo"), existing_file());
+
+    p.process(cargo_dir().join("cargo")).arg("test").arg("--no-run")
+        .exec_with_output()
+        .assert();
+
+    assert_that(&p.bin("foo"), existing_file());
+    assert_that(&p.bin("examples/foo"), existing_file());
+})


### PR DESCRIPTION
This forgot to take into account the logic from some other locations, so I added
a helper method!

Closes #912
