### PR TITLE
Don't require a manifest for `cargo owner` commands

### DIFF
--- a/src/bin/owner.rs
+++ b/src/bin/owner.rs
@@ -1,7 +1,6 @@
 use cargo::ops;
 use cargo::core::MultiShell;
 use cargo::util::{CliResult, CliError};
-use cargo::util::important_paths::find_root_manifest_for_cwd;
 
 #[deriving(Decodable)]
 struct Options {
@@ -36,7 +35,6 @@ versions, and also modify the set of owners, so take caution!
 
 pub fn execute(options: Options, shell: &mut MultiShell) -> CliResult<Option<()>> {
     shell.set_verbose(options.flag_verbose);
-    let root = try!(find_root_manifest_for_cwd(None));
     let opts = ops::OwnersOptions {
         krate: options.arg_crate,
         token: options.flag_token,
@@ -45,7 +43,7 @@ pub fn execute(options: Options, shell: &mut MultiShell) -> CliResult<Option<()>
         to_remove: options.flag_remove,
         list: options.flag_list,
     };
-    try!(ops::modify_owners(&root, shell, &opts).map_err(|e| {
+    try!(ops::modify_owners(shell, &opts).map_err(|e| {
         CliError::from_boxed(e, 101)
     }));
     Ok(None)

--- a/src/cargo/ops/registry.rs
+++ b/src/cargo/ops/registry.rs
@@ -14,6 +14,7 @@ use sources::{PathSource, RegistrySource};
 use util::config;
 use util::{CargoResult, human, internal, ChainError, Require, ToUrl};
 use util::config::{Config, ConfigValue, Location};
+use util::important_paths::find_root_manifest_for_cwd;
 
 pub struct RegistryConfig {
     pub index: Option<String>,
@@ -229,12 +230,12 @@ pub struct OwnersOptions {
     pub list: bool,
 }
 
-pub fn modify_owners(manifest_path: &Path,
-                     shell: &mut MultiShell,
+pub fn modify_owners(shell: &mut MultiShell,
                      opts: &OwnersOptions) -> CargoResult<()> {
     let name = match opts.krate {
         Some(ref name) => name.clone(),
         None => {
+            let manifest_path = try!(find_root_manifest_for_cwd(None));
             let mut src = try!(PathSource::for_path(&manifest_path.dir_path()));
             try!(src.update());
             let pkg = try!(src.get_root_package());


### PR DESCRIPTION
Closes #923
