### PR TITLE
Upload dependency kinds to the registry

### DIFF
--- a/src/cargo/core/dependency.rs
+++ b/src/cargo/core/dependency.rs
@@ -90,6 +90,8 @@ impl Dependency {
         &self.source_id
     }
 
+    pub fn get_kind(&self) -> Kind { self.kind }
+
     pub fn kind(mut self, kind: Kind) -> Dependency {
         self.kind = kind;
         self

--- a/src/cargo/ops/registry.rs
+++ b/src/cargo/ops/registry.rs
@@ -9,6 +9,7 @@ use registry::{Registry, NewCrate, NewCrateDependency};
 
 use core::source::Source;
 use core::{Package, MultiShell, SourceId};
+use core::dependency::Kind;
 use core::manifest::ManifestMetadata;
 use ops;
 use sources::{PathSource, RegistrySource};
@@ -76,6 +77,11 @@ fn transmit(pkg: &Package, tarball: &Path, registry: &mut Registry)
             features: dep.get_features().to_vec(),
             version_req: dep.get_version_req().to_string(),
             target: dep.get_only_for_platform().map(|s| s.to_string()),
+            kind: match dep.get_kind() {
+                Kind::Normal => "normal",
+                Kind::Build => "build",
+                Kind::Development => "dev",
+            }.to_string(),
         }
     }).collect::<Vec<NewCrateDependency>>();
     let manifest = pkg.get_manifest();

--- a/src/registry/lib.rs
+++ b/src/registry/lib.rs
@@ -66,6 +66,7 @@ pub struct NewCrateDependency {
     pub features: Vec<String>,
     pub version_req: String,
     pub target: Option<String>,
+    pub kind: String,
 }
 
 #[deriving(Decodable)]


### PR DESCRIPTION
This ensures that the registry understands whether dependencies are build
dependencies or dev dependencies.

Closes rust-lang/crates.io#38
