### PR TITLE
Don't fail `cargo login` if `~/.cargo` doesn't exist

### DIFF
--- a/src/cargo/util/config.rs
+++ b/src/cargo/util/config.rs
@@ -1,7 +1,8 @@
 use std::{fmt, os, mem};
 use std::cell::{RefCell, RefMut};
 use std::collections::hash_map::{HashMap, Occupied, Vacant};
-use std::io::fs::{PathExtensions, File};
+use std::io;
+use std::io::fs::{mod, PathExtensions, File};
 use std::string;
 
 use serialize::{Encodable,Encoder};
@@ -344,6 +345,7 @@ pub fn set_config(cfg: &Config, loc: Location, key: &str,
         Location::Global => cfg.home_path.join(".cargo").join("config"),
         Location::Project => unimplemented!(),
     };
+    try!(fs::mkdir_recursive(&file.dir_path(), io::USER_DIR));
     let contents = File::open(&file).read_to_string().unwrap_or("".to_string());
     let mut toml = try!(cargo_toml::parse(contents.as_slice(), &file));
     toml.insert(key.to_string(), value.into_toml());

--- a/tests/test_cargo_registry.rs
+++ b/tests/test_cargo_registry.rs
@@ -1,4 +1,5 @@
-use std::io::{fs, File};
+use std::io::{mod, fs, File};
+use cargo::util::process;
 
 use support::{project, execs, cargo_dir};
 use support::{UPDATING, DOWNLOADING, COMPILING, PACKAGING, VERIFYING};
@@ -468,4 +469,14 @@ test!(dev_dependency_not_used {
 {compiling} foo v0.0.1 ({dir})
 ", updating = UPDATING, downloading = DOWNLOADING, compiling = COMPILING,
    dir = p.url()).as_slice()));
+})
+
+test!(login_with_no_cargo_dir {
+    let home = paths::home().join("new-home");
+    fs::mkdir(&home, io::USER_DIR).unwrap();
+    assert_that(process(cargo_dir().join("cargo")).unwrap()
+                       .arg("login").arg("foo").arg("-v")
+                       .cwd(paths::root())
+                       .env("HOME", Some(home)),
+                execs().with_status(0));
 })


### PR DESCRIPTION
Closes #927
