### PR TITLE
Ensure crates are tested after packaged

### DIFF
--- a/src/cargo/ops/cargo_package.rs
+++ b/src/cargo/ops/cargo_package.rs
@@ -165,6 +165,7 @@ fn run_verify(pkg: &Package, shell: &mut MultiShell, tar: &Path)
     });
     let mut new_manifest = pkg.get_manifest().clone();
     new_manifest.set_summary(new_summary);
+    new_manifest.set_target_dir(dst.join("target"));
     let new_pkg = Package::new(new_manifest, &manifest_path,
                                pkg.get_package_id().get_source_id());
 

--- a/src/cargo/ops/cargo_rustc/mod.rs
+++ b/src/cargo/ops/cargo_rustc/mod.rs
@@ -98,7 +98,11 @@ pub fn compile_targets<'a>(env: &str, targets: &[&'a Target], pkg: &'a Package,
     try!(links::validate(deps));
 
     let dest = uniq_target_dest(targets);
-    let root = deps.iter().find(|p| p.get_package_id() == resolve.root()).unwrap();
+    let root = if resolve.root() == pkg.get_package_id() {
+        pkg
+    } else {
+        deps.iter().find(|p| p.get_package_id() == resolve.root()).unwrap()
+    };
     let host_layout = Layout::new(root, None, dest);
     let target_layout = config.target().map(|target| {
         layout::Layout::new(root, Some(target), dest)

--- a/tests/test_cargo_package.rs
+++ b/tests/test_cargo_package.rs
@@ -130,3 +130,28 @@ test!(metadata_warning {
         dir = p.url()).as_slice()));
 
 })
+
+test!(package_verification {
+    let p = project("all")
+        .file("Cargo.toml", r#"
+            [project]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+        "#)
+        .file("src/main.rs", r#"
+            fn main() {}
+        "#);
+    assert_that(p.cargo_process("build"),
+                execs().with_status(0));
+    assert_that(p.process(cargo_dir().join("cargo")).arg("package"),
+                execs().with_status(0).with_stdout(format!("\
+{packaging} foo v0.0.1 ({dir})
+{verifying} foo v0.0.1 ({dir})
+{compiling} foo v0.0.1 ({dir}[..])
+",
+        packaging = PACKAGING,
+        verifying = VERIFYING,
+        compiling = COMPILING,
+        dir = p.url()).as_slice()));
+})


### PR DESCRIPTION
The `target` directory was erroneously being used from the crate root rather
than the root of the package directory itself, leading to packages not actually
testing what's precisely being published.
