### PR TITLE
Specifically look in the home dir for configuration

### DIFF
--- a/src/cargo/util/config.rs
+++ b/src/cargo/util/config.rs
@@ -307,6 +307,21 @@ fn walk_tree(pwd: &Path,
         if !current.pop() { break; }
     }
 
+    // Once we're done, also be sure to walk the home directory even if it's not
+    // in our history to be sure we pick up that standard location for
+    // information.
+    let home = try!(os::homedir().require(|| {
+        human("Cargo couldn't find your home directory. \
+              This probably means that $HOME was not set.")
+    }));
+    if !home.is_ancestor_of(pwd) {
+        let config = home.join(".cargo/config");
+        if config.exists() {
+            let file = try!(File::open(&config));
+            try!(walk(file));
+        }
+    }
+
     Ok(())
 }
 

--- a/tests/support/registry.rs
+++ b/tests/support/registry.rs
@@ -18,7 +18,7 @@ pub fn dl_path() -> Path { paths::root().join("dl") }
 pub fn dl_url() -> Url { Url::from_file_path(&dl_path()).unwrap() }
 
 pub fn init() {
-    let config = paths::root().join(".cargo/config");
+    let config = paths::home().join(".cargo/config");
     fs::mkdir_recursive(&config.dir_path(), io::USER_DIR).assert();
     File::create(&config).write_str(format!(r#"
         [registry]


### PR DESCRIPTION
Some workspaces, such as windows, often have the home directory not in the
hierarchy of where projects live, which means that configuration may not work by
default. The home directory, however, is already singled out for `cargo login`
and it's pretty semantically special, so this commit ensures that we always look
at the home directory for configuration if it exists.

Closes #933
