### PR TITLE
Point to spdx.org/licenses in license field docs

### DIFF
--- a/src/doc/manifest.md
+++ b/src/doc/manifest.md
@@ -82,7 +82,8 @@ keywords = ["...", "..."]
 
 # This is a string description of the license for this package. Currently
 # crates.io will validate the license provided against a whitelist of known
-# licenses. Multiple licenses can be separated with a `/`
+# license identifiers from http://spdx.org/licenses/. Multiple licenses can 
+# be separated with a `/`
 license = "..."
 ```
 


### PR DESCRIPTION
I expected the comment about the whitelist to say where you could find the whitelist. This mirrors the information given in the error message if you specify an invalid license identifier.

I didn't make this a markdown link since it's within markdown within code within markdown, but I'm happy to edit this in any way you see fit.

Thank you!! :heart: 
