### PR TITLE
Add support for a license-file manifest key

### DIFF
--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -45,6 +45,7 @@ pub struct ManifestMetadata {
     pub authors: Vec<String>,
     pub keywords: Vec<String>,
     pub license: Option<String>,
+    pub license_file: Option<String>,
     pub description: Option<String>,    // not markdown
     pub readme: Option<String>,         // file, not contents
     pub homepage: Option<String>,       // url

--- a/src/cargo/util/toml.rs
+++ b/src/cargo/util/toml.rs
@@ -267,6 +267,7 @@ pub struct TomlProject {
     readme: Option<String>,
     keywords: Option<Vec<String>>,
     license: Option<String>,
+    license_file: Option<String>,
     repository: Option<String>,
 }
 
@@ -518,6 +519,7 @@ impl TomlManifest {
             readme: project.readme.clone(),
             authors: project.authors.clone(),
             license: project.license.clone(),
+            license_file: project.license_file.clone(),
             repository: project.repository.clone(),
             keywords: project.keywords.clone().unwrap_or(Vec::new()),
         };
@@ -541,6 +543,11 @@ impl TomlManifest {
             manifest.add_warning(format!("         For more information, see \
                                           http://doc.crates.io/build-script.html"));
         }
+        if project.license_file.is_some() && project.license.is_some() {
+            manifest.add_warning(format!("warning: only one of `license` or \
+                                                   `license-file` is necessary"));
+        }
+
         Ok((manifest, nested_paths))
     }
 }

--- a/src/doc/manifest.md
+++ b/src/doc/manifest.md
@@ -82,9 +82,14 @@ keywords = ["...", "..."]
 
 # This is a string description of the license for this package. Currently
 # crates.io will validate the license provided against a whitelist of known
-# license identifiers from http://spdx.org/licenses/. Multiple licenses can 
+# license identifiers from http://spdx.org/licenses/. Multiple licenses can
 # be separated with a `/`
 license = "..."
+
+# If a project is using a nonstandard license, then this key may be specified in
+# lieu of the above key and must point to a file relative to this manifest
+# (similar to the readme key)
+license-file = "..."
 ```
 
 The [crates.io](https://crates.io) registry will render the description, display

--- a/src/registry/lib.rs
+++ b/src/registry/lib.rs
@@ -55,6 +55,7 @@ pub struct NewCrate {
     pub readme: Option<String>,
     pub keywords: Vec<String>,
     pub license: Option<String>,
+    pub license_file: Option<String>,
     pub repository: Option<String>,
 }
 

--- a/tests/test_cargo_package.rs
+++ b/tests/test_cargo_package.rs
@@ -80,8 +80,9 @@ test!(metadata_warning {
         verifying = VERIFYING,
         compiling = COMPILING,
         dir = p.url()).as_slice())
-                .with_stderr("Warning: manifest has no description or license. See \
-                              http://doc.crates.io/manifest.html#package-metadata for more info."));
+                .with_stderr("\
+warning: manifest has no description, license or license-file. See \
+http://doc.crates.io/manifest.html#package-metadata for more info."));
 
     let p = project("one")
         .file("Cargo.toml", r#"
@@ -104,8 +105,9 @@ test!(metadata_warning {
         verifying = VERIFYING,
         compiling = COMPILING,
         dir = p.url()).as_slice())
-                .with_stderr("Warning: manifest has no description. See \
-                              http://doc.crates.io/manifest.html#package-metadata for more info."));
+                .with_stderr("\
+warning: manifest has no description. See \
+http://doc.crates.io/manifest.html#package-metadata for more info."));
 
     let p = project("both")
         .file("Cargo.toml", format!(r#"

--- a/tests/test_cargo_registry.rs
+++ b/tests/test_cargo_registry.rs
@@ -480,3 +480,22 @@ test!(login_with_no_cargo_dir {
                        .env("HOME", Some(home)),
                 execs().with_status(0));
 })
+
+test!(bad_license_file {
+    let p = project("all")
+        .file("Cargo.toml", r#"
+            [project]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+            license-file = "foo"
+            description = "bar"
+        "#)
+        .file("src/main.rs", r#"
+            fn main() {}
+        "#);
+    assert_that(p.cargo_process("publish"),
+                execs().with_status(101)
+                       .with_stderr("\
+the license file `foo` does not exist"));
+})


### PR DESCRIPTION
This key will support projects with nonstandard licenses and the registry will
display the license as "nonstandard".

Closes #940
