### PR TITLE
ZSH normal completion for args in "cargo run -- <args>"

### DIFF
--- a/src/etc/_cargo
+++ b/src/etc/_cargo
@@ -183,6 +183,7 @@ case $state in
                     '--release=[build in release mode]' \
                     '--target=[target triple]' \
                     '(-v, --verbose)'{-v,--verbose}'[use verbose output]' \
+                    '*: :_normal' \
                 ;;
 
             test)


### PR DESCRIPTION
Running a Rust program with some arguments such as files is a common use
case. The ZSH completion did not declare support for extra arguments to
"cargo run", so file completion was impossible. In practice pressing TAB
after writing "cargo run -- " gave no completion at all.

After this patch, cargo run can do "normal completion",
which in practice does file/directory completion. This works nicely
with "cargo run -- ".
