### PR TITLE
Don't abort on possibly-corrupt submodules

### DIFF
--- a/src/cargo/sources/git/utils.rs
+++ b/src/cargo/sources/git/utils.rs
@@ -324,9 +324,12 @@ impl<'a> GitCheckout<'a> {
                 // clone it. If it has been checked out and the head is the same
                 // as the submodule's head, then we can bail out and go to the
                 // next submodule.
-                let repo = match child.open() {
-                    Ok(repo) => {
-                        if child.head_id() == try!(repo.head()).target() {
+                let head_and_repo = child.open().and_then(|repo| {
+                    Ok((try!(repo.head()).target(), repo))
+                });
+                let repo = match head_and_repo {
+                    Ok((head, repo)) => {
+                        if child.head_id() == head {
                             continue
                         }
                         repo


### PR DESCRIPTION
If a submodule's head commit doesn't exist, then we should attempt to update it
rather than aborting the updating process. This commit moves a local `try!` into
a `and_then` closure to prevent returning from the outer function to hopefully
catch more cases where the submodule needs to be updated.

cc #993, but I'm not sure if this fixes it
