### PR TITLE
Add a missing semicolon to the hello world program in the docs.

### DIFF
--- a/src/doc/guide.md
+++ b/src/doc/guide.md
@@ -65,7 +65,7 @@ Here's what's in `src/main.rs`:
 
 ```
 fn main() {
-    println!("Hello, world!")
+    println!("Hello, world!");
 }
 ```
 

--- a/src/doc/index.md
+++ b/src/doc/index.md
@@ -58,7 +58,7 @@ Here's what's in `src/main.rs`:
 
 ```
 fn main() {
-    println!("Hello, world!")
+    println!("Hello, world!");
 }
 ```
 


### PR DESCRIPTION
Both the `index.md` and `guide.md` files show the hello world program source
(generated by `cargo new`) without a semicolon (`;`) at the end of the
`println!` line. The file generated by `cargo new` does and should have a
semicolon. This commit brings the docs in sync with the generated code.
