### PR TITLE
custom_build: add HOST env var

### DIFF
--- a/src/cargo/ops/cargo_rustc/custom_build.rs
+++ b/src/cargo/ops/cargo_rustc/custom_build.rs
@@ -61,7 +61,8 @@ pub fn prepare(pkg: &Package, target: &Target, req: Platform,
                      }))
                      .env("DEBUG", Some(profile.get_debug().to_string()))
                      .env("OPT_LEVEL", Some(profile.get_opt_level().to_string()))
-                     .env("PROFILE", Some(profile.get_env()));
+                     .env("PROFILE", Some(profile.get_env()))
+                     .env("HOST", Some(cx.config.rustc_host()));
 
     // Be sure to pass along all enabled features for this package, this is the
     // last piece of statically known information that we have.

--- a/src/doc/build-script.md
+++ b/src/doc/build-script.md
@@ -43,6 +43,7 @@ all passed in the form of environment variables:
 * `TARGET` - the target triple that is being compiled for. Native code should be
              compiled for this triple. Some more information about target
              triples can be found in [clang's own documentation][clang].
+* `HOST` - the host triple of the rust compiler.
 * `NUM_JOBS` - the parallelism specified as the top-level parallelism. This can
                be useful to pass a `-j` parameter to a system like `make`.
 * `CARGO_MANIFEST_DIR` - The directory containing the manifest for the package

--- a/tests/test_cargo_compile_custom_build.rs
+++ b/tests/test_cargo_compile_custom_build.rs
@@ -99,6 +99,8 @@ test!(custom_build_env_vars {
                 assert!(out.as_slice().starts_with(r"{0}"));
                 assert!(Path::new(out).is_dir());
 
+                let _host = os::getenv("HOST").unwrap();
+
                 let _feat = os::getenv("CARGO_FEATURE_FOO").unwrap();
             }}
         "#,


### PR DESCRIPTION
This is just to support some nice environment aliases in gcc-rs at the moment.
