### PR TITLE
custom_build: build output goes in the directory for the req, not hard coded to Target

### DIFF
--- a/src/cargo/ops/cargo_rustc/custom_build.rs
+++ b/src/cargo/ops/cargo_rustc/custom_build.rs
@@ -39,7 +39,7 @@ pub fn prepare(pkg: &Package, target: &Target, req: Platform,
     let kind = match req { Platform::Plugin => Kind::Host, _ => Kind::Target, };
     let (script_output, build_output) = {
         (cx.layout(pkg, Kind::Host).build(pkg),
-         cx.layout(pkg, Kind::Target).build_out(pkg))
+         cx.layout(pkg, kind).build_out(pkg))
     };
 
     // Building the command to execute


### PR DESCRIPTION
This broke crossbuilds that had Host deps that used custom build
scripts, typically resulting in a failure to link (due to bad
relocations or symbols) the final executable or library.

Probably should have rustc check when generating an rlib that all the
containing objects have the appropriate arch.

For reference, here's a failing build: https://gist.github.com/jmesmon/74b6b888cbca0c431636
And here's the contents of the rlib in question: https://gist.github.com/jmesmon/d64e0066decd7548f463
