### PR TITLE
Fix updating the registry too often

### DIFF
--- a/src/cargo/core/registry.rs
+++ b/src/cargo/core/registry.rs
@@ -89,7 +89,7 @@ impl<'a> PackageRegistry<'a> {
         // source
         let mut ret = Vec::new();
 
-        for source in self.sources.sources_mut() {
+        for (_, source) in self.sources.sources_mut() {
             try!(source.download(package_ids));
             let packages = try!(source.get(package_ids));
 
@@ -283,8 +283,10 @@ impl<'a> Registry for PackageRegistry<'a> {
             // Ensure the requested source_id is loaded
             try!(self.ensure_loaded(dep.get_source_id()));
             let mut ret = Vec::new();
-            for src in self.sources.sources_mut() {
-                ret.extend(try!(src.query(dep)).into_iter());
+            for (id, src) in self.sources.sources_mut() {
+                if id == dep.get_source_id() {
+                    ret.extend(try!(src.query(dep)).into_iter());
+                }
             }
             ret
         } else {

--- a/src/cargo/core/source.rs
+++ b/src/cargo/core/source.rs
@@ -327,7 +327,7 @@ pub struct SourceMap<'src> {
 pub type Sources<'a, 'src> = Values<'a, SourceId, Box<Source+'src>>;
 pub type SourcesMut<'a, 'src> = iter::Map<'static, (&'a SourceId,
                                                   &'a mut Box<Source+'src>),
-                                    &'a mut (Source+'src),
+                                    (&'a SourceId, &'a mut (Source+'src)),
                                     MutEntries<'a, SourceId, Box<Source+'src>>>;
 
 impl<'src> SourceMap<'src> {
@@ -374,7 +374,7 @@ impl<'src> SourceMap<'src> {
     }
 
     pub fn sources_mut<'a>(&'a mut self) -> SourcesMut<'a, 'src> {
-        self.map.iter_mut().map(|(_, v)| &mut **v)
+        self.map.iter_mut().map(|(k, v)| (k, &mut **v))
     }
 }
 

--- a/tests/support/git.rs
+++ b/tests/support/git.rs
@@ -1,6 +1,9 @@
 use std::io::{mod, fs, File};
 
+use url::Url;
 use git2;
+
+use support::path2url;
 
 pub struct RepoBuilder {
     repo: git2::Repository,
@@ -47,4 +50,6 @@ impl RepoBuilder {
         self.repo.commit(Some("HEAD"), &sig, &sig,
                          "Initial commit", &tree, &[]).unwrap();
     }
+
+    pub fn url(&self) -> Url { path2url(self.repo.path().dir_path()) }
 }


### PR DESCRIPTION
It turns out that the registry was being queried with git dependencies as well,
so this commit alters the core registry not query sources with dependencies that
did not originate from the source.

Closes #991
