### PR TITLE
Rebuild files if target directory is corrupt

### DIFF
--- a/src/cargo/ops/cargo_rustc/fingerprint.rs
+++ b/src/cargo/ops/cargo_rustc/fingerprint.rs
@@ -63,8 +63,8 @@ pub fn prepare_target(cx: &mut Context, pkg: &Package, target: &Target,
     // First bit of the freshness calculation, whether the dep-info file
     // indicates that the target is fresh.
     let dep_info = dep_info_loc(cx, pkg, target, kind);
-    let are_files_fresh = use_pkg ||
-                          try!(calculate_target_fresh(pkg, &dep_info));
+    let mut are_files_fresh = use_pkg ||
+                              try!(calculate_target_fresh(pkg, &dep_info));
 
     // Second bit of the freshness calculation, whether rustc itself, the
     // target are fresh, and the enabled set of features are all fresh.
@@ -87,6 +87,9 @@ pub fn prepare_target(cx: &mut Context, pkg: &Package, target: &Target,
         for filename in try!(cx.target_filenames(target)).iter() {
             let dst = root.join(filename);
             cx.layout(pkg, kind).proxy().whitelist(&dst);
+            if are_files_fresh && !dst.exists() {
+                are_files_fresh = false;
+            }
 
             if target.get_profile().is_test() {
                 cx.compilation.tests.push((target.get_name().into_string(), dst));

--- a/tests/test_cargo_compile.rs
+++ b/tests/test_cargo_compile.rs
@@ -1496,3 +1496,20 @@ test!(example_bin_same_name {
     assert_that(&p.bin("foo"), existing_file());
     assert_that(&p.bin("examples/foo"), existing_file());
 })
+
+test!(compile_then_delete {
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [package]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+        "#)
+        .file("src/main.rs", "fn main() {}");
+
+    assert_that(p.cargo_process("run"), execs().with_status(0));
+    assert_that(&p.bin("foo"), existing_file());
+    fs::unlink(&p.bin("foo")).unwrap();
+    assert_that(p.process(cargo_dir().join("cargo")).arg("run"),
+                execs().with_status(0));
+})


### PR DESCRIPTION
If manual modifications have been made or if cargo/rustc died for some sort of
error, then we don't consider a target as being fresh. If any of the files
output by a target don't end up existing in the target directory (even if the
fingerprint says they do), then we consider the target not fresh.

cc #986
