### PR TITLE
Warn if none of documentation, homepage or repository are provided

### DIFF
--- a/.travis.install.deps.sh
+++ b/.travis.install.deps.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 set -x
 set -e
 

--- a/src/cargo/ops/cargo_package.rs
+++ b/src/cargo/ops/cargo_package.rs
@@ -83,7 +83,7 @@ fn check_metadata(pkg: &Package, shell: &mut MultiShell) -> CargoResult<()> {
             )*
         }}
     }
-    lacking!(description, license || license_file)
+    lacking!(description, license || license_file, documentation || homepage || repository)
 
     if !missing.is_empty() {
         let mut things = missing.slice_to(missing.len() - 1).connect(", ");

--- a/tests/test_cargo_package.rs
+++ b/tests/test_cargo_package.rs
@@ -81,7 +81,8 @@ test!(metadata_warning {
         compiling = COMPILING,
         dir = p.url()).as_slice())
                 .with_stderr("\
-warning: manifest has no description, license or license-file. See \
+warning: manifest has no description, license, license-file, documentation, \
+homepage or repository. See \
 http://doc.crates.io/manifest.html#package-metadata for more info."));
 
     let p = project("one")
@@ -106,10 +107,10 @@ http://doc.crates.io/manifest.html#package-metadata for more info."));
         compiling = COMPILING,
         dir = p.url()).as_slice())
                 .with_stderr("\
-warning: manifest has no description. See \
+warning: manifest has no description, documentation, homepage or repository. See \
 http://doc.crates.io/manifest.html#package-metadata for more info."));
 
-    let p = project("both")
+    let p = project("all")
         .file("Cargo.toml", format!(r#"
             [project]
             name = "foo"
@@ -117,6 +118,7 @@ http://doc.crates.io/manifest.html#package-metadata for more info."));
             authors = []
             license = "MIT"
             description = "foo"
+            repository = "bar"
         "#))
         .file("src/main.rs", r#"
             fn main() {}

--- a/tests/test_cargo_registry.rs
+++ b/tests/test_cargo_registry.rs
@@ -179,6 +179,7 @@ test!(package_with_path_deps {
             authors = []
             license = "MIT"
             description = "foo"
+            repository = "bar"
 
             [dependencies.notyet]
             version = "0.0.1"
@@ -491,6 +492,7 @@ test!(bad_license_file {
             authors = []
             license-file = "foo"
             description = "bar"
+            repository = "baz"
         "#)
         .file("src/main.rs", r#"
             fn main() {}


### PR DESCRIPTION
It's really hard to find out any information about a project if it
doesn't have any of these.

As a bonus I added a shebang to .travis.install.deps.sh so the README
instructions actually work.

Closes #998
