### PR TITLE
Fix cases where a registry is not updated

### DIFF
--- a/src/cargo/sources/registry.rs
+++ b/src/cargo/sources/registry.rs
@@ -464,9 +464,13 @@ impl<'a, 'b> Registry for RegistrySource<'a, 'b> {
         // theory the registry is known to contain this version. If, however, we
         // come back with no summaries, then our registry may need to be
         // updated, so we fall back to performing a lazy update.
-        if dep.get_source_id().get_precise().is_some() &&
-           try!(self.summaries(dep.get_name())).len() == 0 {
-            try!(self.do_update());
+        if dep.get_source_id().get_precise().is_some() {
+            let mut summaries = try!(self.summaries(dep.get_name())).iter().map(|s| {
+                s.0.clone()
+            }).collect::<Vec<_>>();
+            if try!(summaries.query(dep)).len() == 0 {
+                try!(self.do_update());
+            }
         }
 
         let summaries = try!(self.summaries(dep.get_name()));


### PR DESCRIPTION
If a registry already knew about a package, but didn't know about newly
published version of a package, then the registry would occasionally not be
updated when it otherwise needed to be.
