### PR TITLE
Refactor git rev handling infrastructure

### DIFF
--- a/src/bin/git_checkout.rs
+++ b/src/bin/git_checkout.rs
@@ -1,5 +1,5 @@
 use cargo::core::MultiShell;
-use cargo::core::source::{Source, SourceId};
+use cargo::core::source::{Source, SourceId, GitReference};
 use cargo::sources::git::{GitSource};
 use cargo::util::{Config, CliResult, CliError, human, ToUrl};
 
@@ -30,7 +30,8 @@ pub fn execute(options: Options, shell: &mut MultiShell) -> CliResult<Option<()>
                    })
                    .map_err(|e| CliError::from_boxed(e, 1)));
 
-    let source_id = SourceId::for_git(&url, reference.as_slice());
+    let reference = GitReference::Branch(reference.to_string());
+    let source_id = SourceId::for_git(&url, reference);
 
     let mut config = try!(Config::new(shell, None, None).map_err(|e| {
         CliError::from_boxed(e, 1)

--- a/src/cargo/core/mod.rs
+++ b/src/cargo/core/mod.rs
@@ -6,7 +6,7 @@ pub use self::package_id_spec::PackageIdSpec;
 pub use self::registry::Registry;
 pub use self::resolver::Resolve;
 pub use self::shell::{Shell, MultiShell, ShellConfig};
-pub use self::source::{Source, SourceId, SourceMap, SourceSet};
+pub use self::source::{Source, SourceId, SourceMap, SourceSet, GitReference};
 pub use self::summary::Summary;
 
 pub mod source;

--- a/tests/resolve.rs
+++ b/tests/resolve.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 
 use hamcrest::{assert_that, equal_to, contains};
 
-use cargo::core::source::SourceId;
+use cargo::core::source::{SourceId, GitReference};
 use cargo::core::dependency::Kind::Development;
 use cargo::core::{Dependency, PackageId, Summary, Registry};
 use cargo::util::{CargoResult, ToUrl};
@@ -85,7 +85,8 @@ fn pkg_id(name: &str) -> PackageId {
 
 fn pkg_id_loc(name: &str, loc: &str) -> PackageId {
     let remote = loc.to_url();
-    let source_id = SourceId::for_git(&remote.unwrap(), "master");
+    let master = GitReference::Branch("master".to_string());
+    let source_id = SourceId::for_git(&remote.unwrap(), master);
 
     PackageId::new(name, "1.0.0", &source_id).unwrap()
 }
@@ -103,7 +104,8 @@ fn dep_req(name: &str, req: &str) -> Dependency {
 
 fn dep_loc(name: &str, location: &str) -> Dependency {
     let url = location.to_url().unwrap();
-    let source_id = SourceId::for_git(&url, "master");
+    let master = GitReference::Branch("master".to_string());
+    let source_id = SourceId::for_git(&url, master);
     Dependency::parse(name, Some("1.0.0"), &source_id).unwrap()
 }
 

--- a/tests/test_cargo_compile_git_deps.rs
+++ b/tests/test_cargo_compile_git_deps.rs
@@ -187,7 +187,7 @@ test!(cargo_compile_git_dep_branch {
     assert_that(project.cargo_process("build"),
         execs()
         .with_stdout(format!("{} git repository `{}`\n\
-                              {} dep1 v0.5.0 ({}?ref=branchy#[..])\n\
+                              {} dep1 v0.5.0 ({}?branch=branchy#[..])\n\
                               {} foo v0.5.0 ({})\n",
                              UPDATING, path2url(git_root.clone()),
                              COMPILING, path2url(git_root),
@@ -257,18 +257,19 @@ test!(cargo_compile_git_dep_tag {
     assert_that(project.cargo_process("build"),
         execs()
         .with_stdout(format!("{} git repository `{}`\n\
-                              {} dep1 v0.5.0 ({}?ref=v0.1.0#[..])\n\
+                              {} dep1 v0.5.0 ({}?tag=v0.1.0#[..])\n\
                               {} foo v0.5.0 ({})\n",
                              UPDATING, path2url(git_root.clone()),
                              COMPILING, path2url(git_root),
-                             COMPILING, path2url(root)))
-        .with_stderr(""));
+                             COMPILING, path2url(root))));
 
     assert_that(&project.bin("foo"), existing_file());
 
-    assert_that(
-      cargo::util::process(project.bin("foo")).unwrap(),
-      execs().with_stdout("hello world\n"));
+    assert_that(cargo::util::process(project.bin("foo")).unwrap(),
+                execs().with_stdout("hello world\n"));
+
+    assert_that(project.process(cargo_dir().join("cargo")).arg("build"),
+                execs().with_status(0));
 });
 
 test!(cargo_compile_with_nested_paths {


### PR DESCRIPTION
This commit unifies the notion of a "git revision" between a SourceId and the
GitSource. This pushes the request of a branch, tag, or revision all the way
down into a GitSource so special care can be taken for each case.

This primarily was discovered by #1069 where a git tag's id is different from
the commit that it points at, and we need to push the knowledge of whether it's
a tag or not all the way down to the point where we resolve what revision we
want (and perform appropriate operations to find the commit we want).

Closes #1069
