### PR TITLE
Always display vertical scrollbar

### DIFF
--- a/src/doc/stylesheets/all.css
+++ b/src/doc/stylesheets/all.css
@@ -17,6 +17,7 @@ body {
   -webkit-align-items: center;
           align-items: center;
   font-family: sans-serif;
+  overflow-y: scroll;
 }
 
 a { color: #00ac5b; text-decoration: none; }


### PR DESCRIPTION
While browsing through the site, the content shifts a few pixels left or right as the vertical scrollbar is shown or hidden depending on the height of the page. This does not affect e.g. OS X due to its overlaid scrollbars, but is quite jarring on e.g. Windows.
