### PR TITLE
Use "$PWD" instead of `pwd` in install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ git clone https://github.com/rust-lang/cargo
 cd cargo
 git submodule update --init
 ./.travis.install.deps.sh
-./configure --local-rust-root=`pwd`/rustc
+./configure --local-rust-root="$PWD"/rustc
 make
 make install
 ```


### PR DESCRIPTION
There's no need to promote the use of the `pwd` command when shells export the
current directory as `$PWD`. Using `$PWD` makes the commandline work in fish
as well. Additionally, quote the variable so it works properly even if the cwd
has a space in it.
