### PR TITLE
Build a CommandPrototype instead of a ProcessBuilder

### DIFF
--- a/src/bin/bench.rs
+++ b/src/bin/bench.rs
@@ -63,7 +63,8 @@ pub fn execute(options: Options, shell: &mut MultiShell) -> CliResult<Option<()>
             features: options.flag_features.as_slice(),
             no_default_features: options.flag_no_default_features,
             spec: options.flag_package.as_ref().map(|s| s.as_slice()),
-            lib_only: false
+            lib_only: false,
+            exec_engine: None,
         },
     };
 

--- a/src/bin/build.rs
+++ b/src/bin/build.rs
@@ -64,7 +64,8 @@ pub fn execute(options: Options, shell: &mut MultiShell) -> CliResult<Option<()>
         features: options.flag_features.as_slice(),
         no_default_features: options.flag_no_default_features,
         spec: options.flag_package.as_ref().map(|s| s.as_slice()),
-        lib_only: options.flag_lib
+        lib_only: options.flag_lib,
+        exec_engine: None,
     };
 
     ops::compile(&root, &mut opts).map(|_| None).map_err(|err| {

--- a/src/bin/doc.rs
+++ b/src/bin/doc.rs
@@ -58,7 +58,8 @@ pub fn execute(options: Options, shell: &mut MultiShell) -> CliResult<Option<()>
             features: options.flag_features.as_slice(),
             no_default_features: options.flag_no_default_features,
             spec: options.flag_package.as_ref().map(|s| s.as_slice()),
-            lib_only: false
+            lib_only: false,
+            exec_engine: None,
         },
     };
 

--- a/src/bin/run.rs
+++ b/src/bin/run.rs
@@ -67,7 +67,8 @@ pub fn execute(options: Options, shell: &mut MultiShell) -> CliResult<Option<()>
         features: options.flag_features.as_slice(),
         no_default_features: options.flag_no_default_features,
         spec: None,
-        lib_only: false
+        lib_only: false,
+        exec_engine: None,
     };
 
     let (target_kind, name) = match (options.flag_bin, options.flag_example) {

--- a/src/bin/test.rs
+++ b/src/bin/test.rs
@@ -65,7 +65,8 @@ pub fn execute(options: Options, shell: &mut MultiShell) -> CliResult<Option<()>
             features: options.flag_features.as_slice(),
             no_default_features: options.flag_no_default_features,
             spec: options.flag_package.as_ref().map(|s| s.as_slice()),
-            lib_only: false
+            lib_only: false,
+            exec_engine: None,
         },
     };
 

--- a/src/cargo/ops/cargo_package.rs
+++ b/src/cargo/ops/cargo_package.rs
@@ -180,6 +180,7 @@ fn run_verify(pkg: &Package, shell: &mut MultiShell, tar: &Path)
         no_default_features: false,
         spec: None,
         lib_only: false,
+        exec_engine: None,
     }));
 
     Ok(())

--- a/src/cargo/ops/cargo_run.rs
+++ b/src/cargo/ops/cargo_run.rs
@@ -1,6 +1,6 @@
 use std::os;
 
-use ops;
+use ops::{mod, ExecEngine};
 use util::{CargoResult, human, process, ProcessError, ChainError};
 use core::manifest::TargetKind;
 use core::source::Source;
@@ -49,7 +49,8 @@ pub fn run(manifest_path: &Path,
         Some(path) => path,
         None => exe,
     };
-    let process = try!(compile.process(exe, &root))
+    let process = try!(try!(compile.target_process(exe, &root))
+                              .into_process_builder())
                               .args(args)
                               .cwd(try!(os::getcwd()));
 

--- a/src/cargo/ops/cargo_rustc/context.rs
+++ b/src/cargo/ops/cargo_rustc/context.rs
@@ -11,6 +11,7 @@ use super::{Kind, Compilation, BuildConfig};
 use super::TargetConfig;
 use super::layout::{Layout, LayoutProxy};
 use super::custom_build::BuildState;
+use super::{ProcessEngine, ExecEngine};
 
 #[deriving(Show, Copy)]
 pub enum Platform {
@@ -25,6 +26,7 @@ pub struct Context<'a, 'b: 'a> {
     pub sources: &'a SourceMap<'b>,
     pub compilation: Compilation,
     pub build_state: Arc<BuildState>,
+    pub exec_engine: Arc<Box<ExecEngine>>,
 
     env: &'a str,
     host: Layout,
@@ -73,6 +75,7 @@ impl<'a, 'b: 'a> Context<'a, 'b> {
             compilation: Compilation::new(root_pkg),
             build_state: Arc::new(BuildState::new(build_config.clone(), deps)),
             build_config: build_config,
+            exec_engine: Arc::new(box ProcessEngine as Box<ExecEngine>),
         })
     }
 

--- a/src/cargo/ops/cargo_rustc/engine.rs
+++ b/src/cargo/ops/cargo_rustc/engine.rs
@@ -1,0 +1,138 @@
+use std::collections::HashMap;
+use std::c_str::CString;
+use std::io::process::ProcessOutput;
+use std::fmt::{mod, Show, Formatter};
+
+use util::{mod, CargoResult, ProcessError, ProcessBuilder};
+
+/// Trait for objects that can execute commands.
+pub trait ExecEngine: Send + Sync {
+    fn exec(&self, CommandPrototype) -> Result<(), ProcessError>;
+    fn exec_with_output(&self, CommandPrototype) -> Result<ProcessOutput, ProcessError>;
+}
+
+/// Default implementation of `ExecEngine`.
+#[deriving(Copy)]
+pub struct ProcessEngine;
+
+impl ExecEngine for ProcessEngine {
+    fn exec(&self, command: CommandPrototype) -> Result<(), ProcessError> {
+        command.into_process_builder().unwrap().exec()
+    }
+
+    fn exec_with_output(&self, command: CommandPrototype)
+                        -> Result<ProcessOutput, ProcessError> {
+        command.into_process_builder().unwrap().exec_with_output()
+    }
+}
+
+/// Prototype for a command that must be executed.
+#[deriving(Clone)]
+pub struct CommandPrototype {
+    ty: CommandType,
+    args: Vec<CString>,
+    env: HashMap<String, Option<CString>>,
+    cwd: Path,
+}
+
+impl CommandPrototype {
+    pub fn new(ty: CommandType) -> CargoResult<CommandPrototype> {
+        use std::os;
+
+        Ok(CommandPrototype {
+            ty: ty,
+            args: Vec::new(),
+            env: HashMap::new(),
+            cwd: try!(os::getcwd()),
+        })
+    }
+
+    pub fn get_type(&self) -> &CommandType {
+        &self.ty
+    }
+
+    pub fn arg<T: ToCStr>(mut self, arg: T) -> CommandPrototype {
+        self.args.push(arg.to_c_str());
+        self
+    }
+
+    pub fn args<T: ToCStr>(mut self, arguments: &[T]) -> CommandPrototype {
+        self.args.extend(arguments.iter().map(|t| t.to_c_str()));
+        self
+    }
+
+    pub fn get_args(&self) -> &[CString] {
+        self.args.as_slice()
+    }
+
+    pub fn cwd(mut self, path: Path) -> CommandPrototype {
+        self.cwd = path;
+        self
+    }
+
+    pub fn get_cwd(&self) -> &Path {
+        &self.cwd
+    }
+
+    pub fn env<T: ToCStr>(mut self, key: &str, val: Option<T>) -> CommandPrototype {
+        self.env.insert(key.to_string(), val.map(|t| t.to_c_str()));
+        self
+    }
+
+    pub fn get_envs(&self) -> &HashMap<String, Option<CString>> {
+        &self.env
+    }
+
+    pub fn into_process_builder(self) -> CargoResult<ProcessBuilder> {
+        let mut builder = try!(match self.ty {
+            CommandType::Rustc => util::process("rustc"),
+            CommandType::Rustdoc => util::process("rustdoc"),
+            CommandType::Target(ref cmd) | CommandType::Host(ref cmd) => {
+                util::process(cmd.as_bytes_no_nul())
+            },
+        });
+
+        for arg in self.args.into_iter() {
+            builder = builder.arg(arg.as_bytes_no_nul());
+        }
+
+        for (key, val) in self.env.into_iter() {
+            builder = builder.env(key.as_slice(), val.as_ref().map(|v| v.as_bytes_no_nul()));
+        }
+
+        builder = builder.cwd(self.cwd);
+
+        Ok(builder)
+    }
+}
+
+impl Show for CommandPrototype {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        match self.ty {
+            CommandType::Rustc => try!(write!(f, "`rustc")),
+            CommandType::Rustdoc => try!(write!(f, "`rustdoc")),
+            CommandType::Target(ref cmd) | CommandType::Host(ref cmd) => {
+                let cmd = String::from_utf8_lossy(cmd.as_bytes_no_nul());
+                try!(write!(f, "`{}", cmd));
+            },
+        }
+
+        for arg in self.args.iter() {
+            try!(write!(f, " {}", String::from_utf8_lossy(arg.as_bytes_no_nul())));
+        }
+
+        write!(f, "`")
+    }
+}
+
+#[deriving(Clone, Show)]
+pub enum CommandType {
+    Rustc,
+    Rustdoc,
+
+    /// The command is to be executed for the target architecture.
+    Target(CString),
+
+    /// The command is to be executed for the host architecture.
+    Host(CString),
+}

--- a/src/cargo/ops/mod.rs
+++ b/src/cargo/ops/mod.rs
@@ -5,6 +5,7 @@ pub use self::cargo_rustc::{compile_targets, Compilation, Layout, Kind, rustc_ve
 pub use self::cargo_rustc::{Context, LayoutProxy};
 pub use self::cargo_rustc::Platform;
 pub use self::cargo_rustc::{BuildOutput, BuildConfig, TargetConfig};
+pub use self::cargo_rustc::{CommandType, CommandPrototype, ExecEngine, ProcessEngine};
 pub use self::cargo_run::run;
 pub use self::cargo_new::{new, NewOptions};
 pub use self::cargo_doc::{doc, DocOptions};


### PR DESCRIPTION
With this change, the various commands in Cargo now build a `CommandPrototype` instead of a `ProcessBuilder`. This `CommandPrototype` is then passed to an object that implements the `CommandsExecution` trait, which executes them.

Ideally `CommandPrototype` would look like this:

```rust
enum CommandPrototype {
    Rustc {
        libraries: Vec<String>,
        opt_level: uint,
        input: Path,
        ... etc... (all the options that can be passed to rustc)
    },
    Rustdoc {
        ...  (all the options that can be passed to rustdoc)
    },
    Custom {
        cmd: ...,
        env: ...,
    }
}
```

...but that's a bit too much work for now (maybe in a follow-up).


What this enables is using the Cargo library to intercept the build commands and tweak them. I'm planning to write `cargo-emscripten` thanks to this change.

With this, one could also imagine embedding rustc and rustdoc directly inside cargo, if that is needed.
