### PR TITLE
Fix cfg of platform-specific tests

### DIFF
--- a/tests/test_cargo_compile.rs
+++ b/tests/test_cargo_compile.rs
@@ -1357,7 +1357,7 @@ Caused by:
 "));
 });
 
-#[cfg(target_os = "linux")]
+#[cfg(all(any(target_arch = "x86", target_arch = "x86_64"), target_os = "linux"))]
 test!(cargo_platform_specific_dependency {
     let p = project("foo")
         .file("Cargo.toml", r#"
@@ -1398,7 +1398,7 @@ test!(cargo_platform_specific_dependency {
       execs().with_stdout("test passed\n"));
 });
 
-#[cfg(not(target_os = "linux"))]
+#[cfg(not(all(any(target_arch = "x86", target_arch = "x86_64"), target_os = "linux")))]
 test!(cargo_platform_specific_dependency {
     let p = project("foo")
         .file("Cargo.toml", r#"


### PR DESCRIPTION
For two tests, the `Cargo.toml`s and the `cfg`s don't match. E.g., the first test expects a successful build on all linux platforms but its `toml` is prepared for Intel linuxes only. The second test is very similar.

Here, the `cfg`s are amended to match the `toml`s.