### PR TITLE
Get rid of warnings because of `use x::{mod, y};` and `#[deriving(z)]` constructs.

### DIFF
--- a/src/bin/bench.rs
+++ b/src/bin/bench.rs
@@ -5,7 +5,7 @@ use cargo::core::MultiShell;
 use cargo::util::{CliResult, CliError, Human};
 use cargo::util::important_paths::{find_root_manifest_for_cwd};
 
-#[deriving(RustcDecodable)]
+#[derive(RustcDecodable)]
 struct Options {
     flag_no_run: bool,
     flag_package: Option<String>,

--- a/src/bin/build.rs
+++ b/src/bin/build.rs
@@ -6,7 +6,7 @@ use cargo::ops;
 use cargo::util::important_paths::{find_root_manifest_for_cwd};
 use cargo::util::{CliResult, CliError};
 
-#[deriving(RustcDecodable)]
+#[derive(RustcDecodable)]
 struct Options {
     flag_package: Option<String>,
     flag_jobs: Option<uint>,

--- a/src/bin/cargo.rs
+++ b/src/bin/cargo.rs
@@ -7,14 +7,14 @@ extern crate "rustc-serialize" as rustc_serialize;
 use std::collections::BTreeSet;
 use std::os;
 use std::io;
-use std::io::fs::{mod, PathExtensions};
+use std::io::fs::{self, PathExtensions};
 use std::io::process::{Command,InheritFd,ExitStatus,ExitSignal};
 
 use cargo::{execute_main_without_stdin, handle_error, shell};
 use cargo::core::MultiShell;
 use cargo::util::{CliError, CliResult, lev_distance};
 
-#[deriving(RustcDecodable)]
+#[derive(RustcDecodable)]
 struct Flags {
     flag_list: bool,
     flag_verbose: bool,

--- a/src/bin/clean.rs
+++ b/src/bin/clean.rs
@@ -5,7 +5,7 @@ use cargo::core::MultiShell;
 use cargo::util::{CliResult, CliError};
 use cargo::util::important_paths::{find_root_manifest_for_cwd};
 
-#[deriving(RustcDecodable)]
+#[derive(RustcDecodable)]
 struct Options {
     flag_package: Option<String>,
     flag_target: Option<String>,

--- a/src/bin/config_for_key.rs
+++ b/src/bin/config_for_key.rs
@@ -4,13 +4,13 @@ use std::collections::HashMap;
 use cargo::core::MultiShell;
 use cargo::util::{CliResult, CliError, config};
 
-#[deriving(RustcDecodable)]
+#[derive(RustcDecodable)]
 struct ConfigForKeyFlags {
     flag_human: bool,
     flag_key: String,
 }
 
-#[deriving(RustcEncodable)]
+#[derive(RustcEncodable)]
 struct ConfigOut {
     values: HashMap<String, config::ConfigValue>
 }

--- a/src/bin/config_list.rs
+++ b/src/bin/config_list.rs
@@ -4,12 +4,12 @@ use std::collections::HashMap;
 use cargo::core::MultiShell;
 use cargo::util::{CliResult, CliError, config};
 
-#[deriving(RustcDecodable)]
+#[derive(RustcDecodable)]
 struct ConfigListFlags {
     flag_human: bool,
 }
 
-#[deriving(RustcEncodable)]
+#[derive(RustcEncodable)]
 struct ConfigOut {
     values: HashMap<String, config::ConfigValue>
 }

--- a/src/bin/doc.rs
+++ b/src/bin/doc.rs
@@ -3,7 +3,7 @@ use cargo::core::{MultiShell};
 use cargo::util::{CliResult, CliError};
 use cargo::util::important_paths::{find_root_manifest_for_cwd};
 
-#[deriving(RustcDecodable)]
+#[derive(RustcDecodable)]
 struct Options {
     flag_features: Vec<String>,
     flag_jobs: Option<uint>,

--- a/src/bin/fetch.rs
+++ b/src/bin/fetch.rs
@@ -3,7 +3,7 @@ use cargo::core::{MultiShell};
 use cargo::util::{CliResult, CliError};
 use cargo::util::important_paths::find_root_manifest_for_cwd;
 
-#[deriving(RustcDecodable)]
+#[derive(RustcDecodable)]
 struct Options {
     flag_manifest_path: Option<String>,
     flag_verbose: bool,

--- a/src/bin/generate_lockfile.rs
+++ b/src/bin/generate_lockfile.rs
@@ -5,7 +5,7 @@ use cargo::core::MultiShell;
 use cargo::util::{CliResult, CliError};
 use cargo::util::important_paths::find_root_manifest_for_cwd;
 
-#[deriving(RustcDecodable)]
+#[derive(RustcDecodable)]
 struct Options {
     flag_manifest_path: Option<String>,
     flag_verbose: bool,

--- a/src/bin/git_checkout.rs
+++ b/src/bin/git_checkout.rs
@@ -3,7 +3,7 @@ use cargo::core::source::{Source, SourceId, GitReference};
 use cargo::sources::git::{GitSource};
 use cargo::util::{Config, CliResult, CliError, human, ToUrl};
 
-#[deriving(RustcDecodable)]
+#[derive(RustcDecodable)]
 struct Options {
     flag_url: String,
     flag_reference: String,

--- a/src/bin/help.rs
+++ b/src/bin/help.rs
@@ -1,7 +1,7 @@
 use cargo::core::MultiShell;
 use cargo::util::{CliResult, CliError};
 
-#[deriving(RustcDecodable)]
+#[derive(RustcDecodable)]
 struct Options;
 
 pub const USAGE: &'static str = "

--- a/src/bin/locate_project.rs
+++ b/src/bin/locate_project.rs
@@ -2,7 +2,7 @@ use cargo::core::MultiShell;
 use cargo::util::{CliResult, CliError, human, ChainError};
 use cargo::util::important_paths::{find_root_manifest_for_cwd};
 
-#[deriving(RustcDecodable)]
+#[derive(RustcDecodable)]
 struct LocateProjectFlags {
     flag_manifest_path: Option<String>,
 }
@@ -16,7 +16,7 @@ Options:
     -h, --help              Print this message
 ";
 
-#[deriving(RustcEncodable)]
+#[derive(RustcEncodable)]
 struct ProjectLocation {
     root: String
 }

--- a/src/bin/login.rs
+++ b/src/bin/login.rs
@@ -5,7 +5,7 @@ use cargo::core::{MultiShell, SourceId, Source};
 use cargo::sources::RegistrySource;
 use cargo::util::{CliResult, CliError, Config};
 
-#[deriving(RustcDecodable)]
+#[derive(RustcDecodable)]
 struct Options {
     flag_host: Option<String>,
     arg_token: Option<String>,

--- a/src/bin/new.rs
+++ b/src/bin/new.rs
@@ -4,7 +4,7 @@ use cargo::ops;
 use cargo::core::MultiShell;
 use cargo::util::{CliResult, CliError};
 
-#[deriving(RustcDecodable)]
+#[derive(RustcDecodable)]
 struct Options {
     flag_verbose: bool,
     flag_bin: bool,

--- a/src/bin/owner.rs
+++ b/src/bin/owner.rs
@@ -2,7 +2,7 @@ use cargo::ops;
 use cargo::core::MultiShell;
 use cargo::util::{CliResult, CliError};
 
-#[deriving(RustcDecodable)]
+#[derive(RustcDecodable)]
 struct Options {
     arg_crate: Option<String>,
     flag_token: Option<String>,

--- a/src/bin/package.rs
+++ b/src/bin/package.rs
@@ -3,7 +3,7 @@ use cargo::core::{MultiShell};
 use cargo::util::{CliResult, CliError};
 use cargo::util::important_paths::find_root_manifest_for_cwd;
 
-#[deriving(RustcDecodable)]
+#[derive(RustcDecodable)]
 struct Options {
     flag_verbose: bool,
     flag_manifest_path: Option<String>,

--- a/src/bin/pkgid.rs
+++ b/src/bin/pkgid.rs
@@ -3,7 +3,7 @@ use cargo::core::MultiShell;
 use cargo::util::{CliResult, CliError};
 use cargo::util::important_paths::{find_root_manifest_for_cwd};
 
-#[deriving(RustcDecodable)]
+#[derive(RustcDecodable)]
 struct Options {
     flag_verbose: bool,
     flag_manifest_path: Option<String>,

--- a/src/bin/publish.rs
+++ b/src/bin/publish.rs
@@ -3,7 +3,7 @@ use cargo::core::{MultiShell};
 use cargo::util::{CliResult, CliError};
 use cargo::util::important_paths::find_root_manifest_for_cwd;
 
-#[deriving(RustcDecodable)]
+#[derive(RustcDecodable)]
 struct Options {
     flag_host: Option<String>,
     flag_token: Option<String>,

--- a/src/bin/read_manifest.rs
+++ b/src/bin/read_manifest.rs
@@ -2,7 +2,7 @@ use cargo::core::{MultiShell, Package, Source};
 use cargo::util::{CliResult, CliError};
 use cargo::sources::{PathSource};
 
-#[deriving(RustcDecodable)]
+#[derive(RustcDecodable)]
 struct Options {
     flag_manifest_path: String,
 }

--- a/src/bin/run.rs
+++ b/src/bin/run.rs
@@ -6,7 +6,7 @@ use cargo::core::manifest::TargetKind;
 use cargo::util::{CliResult, CliError, human};
 use cargo::util::important_paths::{find_root_manifest_for_cwd};
 
-#[deriving(RustcDecodable)]
+#[derive(RustcDecodable)]
 struct Options {
     flag_bin: Option<String>,
     flag_example: Option<String>,

--- a/src/bin/search.rs
+++ b/src/bin/search.rs
@@ -2,7 +2,7 @@ use cargo::ops;
 use cargo::core::{MultiShell};
 use cargo::util::{CliResult, CliError};
 
-#[deriving(RustcDecodable)]
+#[derive(RustcDecodable)]
 struct Options {
     flag_host: Option<String>,
     flag_verbose: bool,

--- a/src/bin/test.rs
+++ b/src/bin/test.rs
@@ -5,7 +5,7 @@ use cargo::core::MultiShell;
 use cargo::util::{CliResult, CliError, Human};
 use cargo::util::important_paths::{find_root_manifest_for_cwd};
 
-#[deriving(RustcDecodable)]
+#[derive(RustcDecodable)]
 struct Options {
     arg_args: Vec<String>,
     flag_features: Vec<String>,

--- a/src/bin/update.rs
+++ b/src/bin/update.rs
@@ -5,7 +5,7 @@ use cargo::core::MultiShell;
 use cargo::util::{CliResult, CliError};
 use cargo::util::important_paths::find_root_manifest_for_cwd;
 
-#[deriving(RustcDecodable)]
+#[derive(RustcDecodable)]
 struct Options {
     arg_spec: Option<String>,
     flag_package: Option<String>,

--- a/src/bin/verify_project.rs
+++ b/src/bin/verify_project.rs
@@ -9,7 +9,7 @@ use cargo::util::CliResult;
 
 pub type Error = HashMap<String, String>;
 
-#[deriving(RustcDecodable)]
+#[derive(RustcDecodable)]
 struct Flags {
     flag_manifest_path: String,
     flag_verbose: bool,

--- a/src/bin/version.rs
+++ b/src/bin/version.rs
@@ -4,7 +4,7 @@ use cargo;
 use cargo::core::MultiShell;
 use cargo::util::CliResult;
 
-#[deriving(RustcDecodable)]
+#[derive(RustcDecodable)]
 struct Options;
 
 pub const USAGE: &'static str = "

--- a/src/bin/yank.rs
+++ b/src/bin/yank.rs
@@ -3,7 +3,7 @@ use cargo::core::MultiShell;
 use cargo::util::{CliResult, CliError};
 use cargo::util::important_paths::find_root_manifest_for_cwd;
 
-#[deriving(RustcDecodable)]
+#[derive(RustcDecodable)]
 struct Options {
     arg_crate: Option<String>,
     flag_token: Option<String>,

--- a/src/cargo/core/dependency.rs
+++ b/src/cargo/core/dependency.rs
@@ -4,7 +4,7 @@ use core::{SourceId, Summary, PackageId};
 use util::CargoResult;
 
 /// Informations about a dependency requested by a Cargo manifest.
-#[deriving(PartialEq,Clone,Show)]
+#[derive(PartialEq,Clone,Show)]
 pub struct Dependency {
     name: String,
     source_id: SourceId,
@@ -22,7 +22,7 @@ pub struct Dependency {
     only_for_platform: Option<String>,
 }
 
-#[deriving(PartialEq, Clone, Show, Copy)]
+#[derive(PartialEq, Clone, Show, Copy)]
 pub enum Kind {
     Normal,
     Development,
@@ -184,7 +184,7 @@ impl Dependency {
     }
 }
 
-#[deriving(PartialEq,Clone,RustcEncodable)]
+#[derive(PartialEq,Clone,RustcEncodable)]
 pub struct SerializedDependency {
     name: String,
     req: String

--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -1,5 +1,5 @@
 use std::hash;
-use std::fmt::{mod, Show, Formatter};
+use std::fmt::{self, Show, Formatter};
 
 use semver::Version;
 use rustc_serialize::{Encoder,Encodable};
@@ -10,7 +10,7 @@ use core::dependency::SerializedDependency;
 use util::{CargoResult, human};
 
 /// Contains all the informations about a package, as loaded from a Cargo.toml.
-#[deriving(PartialEq,Clone)]
+#[derive(PartialEq,Clone)]
 pub struct Manifest {
     summary: Summary,
     targets: Vec<Target>,
@@ -40,7 +40,7 @@ impl Show for Manifest {
 /// validated by cargo itself, but rather it is up to the registry when uploaded
 /// to validate these fields. Cargo will itself accept any valid TOML
 /// specification for these values.
-#[deriving(PartialEq, Clone)]
+#[derive(PartialEq, Clone)]
 pub struct ManifestMetadata {
     pub authors: Vec<String>,
     pub keywords: Vec<String>,
@@ -53,7 +53,7 @@ pub struct ManifestMetadata {
     pub documentation: Option<String>,  // url
 }
 
-#[deriving(PartialEq,Clone,RustcEncodable)]
+#[derive(PartialEq,Clone,RustcEncodable)]
 pub struct SerializedManifest {
     name: String,
     version: String,
@@ -81,7 +81,7 @@ impl<E, S: Encoder<E>> Encodable<S, E> for Manifest {
     }
 }
 
-#[deriving(Show, Clone, PartialEq, Hash, RustcEncodable, Copy)]
+#[derive(Show, Clone, PartialEq, Hash, RustcEncodable, Copy)]
 pub enum LibKind {
     Lib,
     Rlib,
@@ -116,14 +116,14 @@ impl LibKind {
     }
 }
 
-#[deriving(Show, Clone, Hash, PartialEq, RustcEncodable)]
+#[derive(Show, Clone, Hash, PartialEq, RustcEncodable)]
 pub enum TargetKind {
     Lib(Vec<LibKind>),
     Bin,
     Example,
 }
 
-#[deriving(RustcEncodable, RustcDecodable, Clone, PartialEq, Show)]
+#[derive(RustcEncodable, RustcDecodable, Clone, PartialEq, Show)]
 pub struct Profile {
     env: String, // compile, test, dev, bench, etc.
     opt_level: uint,
@@ -351,7 +351,7 @@ impl<H: hash::Writer> hash::Hash<H> for Profile {
 }
 
 /// Informations about a binary, a library, an example, etc. that is part of the package.
-#[deriving(Clone, Hash, PartialEq)]
+#[derive(Clone, Hash, PartialEq)]
 pub struct Target {
     kind: TargetKind,
     name: String,
@@ -360,7 +360,7 @@ pub struct Target {
     metadata: Option<Metadata>,
 }
 
-#[deriving(RustcEncodable)]
+#[derive(RustcEncodable)]
 pub struct SerializedTarget {
     kind: Vec<&'static str>,
     name: String,

--- a/src/cargo/core/package.rs
+++ b/src/cargo/core/package.rs
@@ -1,4 +1,4 @@
-use std::fmt::{mod, Show, Formatter};
+use std::fmt::{self, Show, Formatter};
 use std::hash;
 use std::slice;
 use semver::Version;
@@ -20,7 +20,7 @@ use core::source::{SourceId, Source};
 ///
 /// A package is a `Cargo.toml` file, plus all the files that are part of it.
 // TODO: Is manifest_path a relic?
-#[deriving(Clone)]
+#[derive(Clone)]
 pub struct Package {
     // The package's manifest
     manifest: Manifest,
@@ -30,7 +30,7 @@ pub struct Package {
     source_id: SourceId,
 }
 
-#[deriving(RustcEncodable)]
+#[derive(RustcEncodable)]
 struct SerializedPackage {
     name: String,
     version: String,
@@ -137,7 +137,7 @@ impl hash::Hash for Package {
     }
 }
 
-#[deriving(PartialEq,Clone,Show)]
+#[derive(PartialEq,Clone,Show)]
 pub struct PackageSet {
     packages: Vec<Package>,
 }

--- a/src/cargo/core/package_id.rs
+++ b/src/cargo/core/package_id.rs
@@ -2,7 +2,7 @@ use semver;
 use std::error::{Error, FromError};
 use std::hash::Hash;
 use std::sync::Arc;
-use std::fmt::{mod, Show, Formatter};
+use std::fmt::{self, Show, Formatter};
 use std::hash;
 use rustc_serialize::{Encodable, Encoder, Decodable, Decoder};
 
@@ -12,12 +12,12 @@ use util::{CargoResult, CargoError, short_hash, ToSemver};
 use core::source::SourceId;
 
 /// Identifier for a specific version of a package in a specific source.
-#[deriving(Clone)]
+#[derive(Clone)]
 pub struct PackageId {
     inner: Arc<PackageIdInner>,
 }
 
-#[deriving(PartialEq, PartialOrd, Eq, Ord)]
+#[derive(PartialEq, PartialOrd, Eq, Ord)]
 struct PackageIdInner {
     name: String,
     version: semver::Version,
@@ -80,7 +80,7 @@ impl Ord for PackageId {
     }
 }
 
-#[deriving(Clone, Show, PartialEq)]
+#[derive(Clone, Show, PartialEq)]
 pub enum PackageIdError {
     InvalidVersion(String),
     InvalidNamespace(String)
@@ -108,7 +108,7 @@ impl FromError<PackageIdError> for Box<CargoError> {
     fn from_error(t: PackageIdError) -> Box<CargoError> { box t }
 }
 
-#[deriving(PartialEq, Hash, Clone, RustcEncodable)]
+#[derive(PartialEq, Hash, Clone, RustcEncodable)]
 pub struct Metadata {
     pub metadata: String,
     pub extra_filename: String

--- a/src/cargo/core/package_id_spec.rs
+++ b/src/cargo/core/package_id_spec.rs
@@ -1,11 +1,11 @@
 use std::fmt;
 use semver::Version;
-use url::{mod, Url, UrlParser};
+use url::{self, Url, UrlParser};
 
 use core::PackageId;
 use util::{CargoResult, ToUrl, human, ToSemver, ChainError};
 
-#[deriving(Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct PackageIdSpec {
     name: String,
     version: Option<Version>,

--- a/src/cargo/core/registry.rs
+++ b/src/cargo/core/registry.rs
@@ -64,7 +64,7 @@ pub struct PackageRegistry<'a> {
     locked: HashMap<SourceId, HashMap<String, Vec<(PackageId, Vec<PackageId>)>>>,
 }
 
-#[deriving(PartialEq, Eq, Copy)]
+#[derive(PartialEq, Eq, Copy)]
 enum Kind {
     Override,
     Locked,

--- a/src/cargo/core/resolver/encode.rs
+++ b/src/cargo/core/resolver/encode.rs
@@ -8,7 +8,7 @@ use util::{CargoResult, Graph};
 
 use super::Resolve;
 
-#[deriving(RustcEncodable, RustcDecodable, Show)]
+#[derive(RustcEncodable, RustcDecodable, Show)]
 pub struct EncodableResolve {
     package: Option<Vec<EncodableDependency>>,
     root: EncodableDependency,
@@ -76,7 +76,7 @@ impl EncodableResolve {
     }
 }
 
-#[deriving(RustcEncodable, RustcDecodable, Show, PartialOrd, Ord, PartialEq, Eq)]
+#[derive(RustcEncodable, RustcDecodable, Show, PartialOrd, Ord, PartialEq, Eq)]
 pub struct EncodableDependency {
     name: String,
     version: String,
@@ -93,7 +93,7 @@ impl EncodableDependency {
     }
 }
 
-#[deriving(Show, PartialOrd, Ord, PartialEq, Eq)]
+#[derive(Show, PartialOrd, Ord, PartialEq, Eq)]
 pub struct EncodablePackageId {
     name: String,
     version: String,

--- a/src/cargo/core/resolver/mod.rs
+++ b/src/cargo/core/resolver/mod.rs
@@ -22,7 +22,7 @@ mod encode;
 ///
 /// Each instance of `Resolve` also understands the full set of features used
 /// for each package as well as what the root package is.
-#[deriving(PartialEq, Eq, Clone)]
+#[derive(PartialEq, Eq, Clone)]
 pub struct Resolve {
     graph: Graph<PackageId>,
     features: HashMap<PackageId, HashSet<String>>,
@@ -30,7 +30,7 @@ pub struct Resolve {
     metadata: Option<Metadata>,
 }
 
-#[deriving(Copy)]
+#[derive(Copy)]
 pub enum Method<'a> {
     Everything,
     Required(/* dev_deps = */ bool,
@@ -122,7 +122,7 @@ impl fmt::Show for Resolve {
     }
 }
 
-#[deriving(Clone)]
+#[derive(Clone)]
 struct Context {
     activations: HashMap<(String, SourceId), Vec<Rc<Summary>>>,
     resolve: Resolve,

--- a/src/cargo/core/shell.rs
+++ b/src/cargo/core/shell.rs
@@ -6,7 +6,7 @@ use std::fmt::Show;
 
 use self::AdequateTerminal::{NoColor, Colored};
 
-#[deriving(Copy)]
+#[derive(Copy)]
 pub struct ShellConfig {
     pub color: bool,
     pub verbose: bool,

--- a/src/cargo/core/source.rs
+++ b/src/cargo/core/source.rs
@@ -1,5 +1,5 @@
 use std::collections::hash_map::{HashMap, Values, IterMut};
-use std::fmt::{mod, Show, Formatter};
+use std::fmt::{self, Show, Formatter};
 use std::hash;
 use std::mem;
 use std::sync::Arc;
@@ -42,7 +42,7 @@ pub trait Source: Registry {
     fn fingerprint(&self, pkg: &Package) -> CargoResult<String>;
 }
 
-#[deriving(Show, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Show, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 enum Kind {
     /// Kind::Git(<git reference>) represents a git repository
     Git(GitReference),
@@ -52,7 +52,7 @@ enum Kind {
     Registry,
 }
 
-#[deriving(Show, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Show, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum GitReference {
     Tag(String),
     Branch(String),
@@ -62,12 +62,12 @@ pub enum GitReference {
 type Error = Box<CargoError + Send>;
 
 /// Unique identifier for a source of packages.
-#[deriving(Clone, Eq)]
+#[derive(Clone, Eq)]
 pub struct SourceId {
     inner: Arc<SourceIdInner>,
 }
 
-#[deriving(Eq, Clone)]
+#[derive(Eq, Clone)]
 struct SourceIdInner {
     url: Url,
     kind: Kind,

--- a/src/cargo/core/summary.rs
+++ b/src/cargo/core/summary.rs
@@ -10,7 +10,7 @@ use util::{CargoResult, human};
 /// a package.
 ///
 /// Summaries are cloned, and should not be mutated after creation
-#[deriving(Show,Clone)]
+#[derive(Show,Clone)]
 pub struct Summary {
     package_id: PackageId,
     dependencies: Vec<Dependency>,

--- a/src/cargo/lib.rs
+++ b/src/cargo/lib.rs
@@ -29,7 +29,7 @@ extern crate registry;
 use std::os;
 use std::error::Error;
 use std::io::stdio::{stdout_raw, stderr_raw};
-use std::io::{mod, stdout, stderr};
+use std::io::{self, stdout, stderr};
 use rustc_serialize::{Decoder, Encoder, Decodable, Encodable};
 use rustc_serialize::json;
 use docopt::Docopt;

--- a/src/cargo/ops/cargo_clean.rs
+++ b/src/cargo/ops/cargo_clean.rs
@@ -1,11 +1,11 @@
 use std::default::Default;
-use std::io::fs::{mod, PathExtensions};
+use std::io::fs::{self, PathExtensions};
 
 use core::{MultiShell, PackageSet};
 use core::source::{Source, SourceMap};
 use sources::PathSource;
 use util::{CargoResult, human, ChainError, Config};
-use ops::{mod, Layout, Context};
+use ops::{self, Layout, Context};
 
 pub struct CleanOptions<'a> {
     pub spec: Option<&'a str>,

--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -30,7 +30,7 @@ use std::sync::Arc;
 use core::registry::PackageRegistry;
 use core::{MultiShell, Source, SourceId, PackageSet, Package, Target, PackageId};
 use core::resolver::Method;
-use ops::{mod, BuildOutput, ExecEngine};
+use ops::{self, BuildOutput, ExecEngine};
 use sources::{PathSource};
 use util::config::{Config, ConfigValue};
 use util::{CargoResult, config, internal, human, ChainError, profile};

--- a/src/cargo/ops/cargo_new.rs
+++ b/src/cargo/ops/cargo_new.rs
@@ -1,5 +1,5 @@
 use std::os;
-use std::io::{mod, fs, File};
+use std::io::{self, fs, File};
 use std::io::fs::PathExtensions;
 
 use git2::Config;

--- a/src/cargo/ops/cargo_read_manifest.rs
+++ b/src/cargo/ops/cargo_read_manifest.rs
@@ -1,9 +1,9 @@
 use std::collections::HashSet;
-use std::io::{mod, File, fs};
+use std::io::{self, File, fs};
 use std::io::fs::PathExtensions;
 
 use core::{Package,Manifest,SourceId};
-use util::{mod, CargoResult, human};
+use util::{self, CargoResult, human};
 use util::important_paths::find_project_manifest_exact;
 use util::toml::{Layout, project_layout};
 use std::error::FromError;

--- a/src/cargo/ops/cargo_run.rs
+++ b/src/cargo/ops/cargo_run.rs
@@ -1,6 +1,6 @@
 use std::os;
 
-use ops::{mod, ExecEngine};
+use ops::{self, ExecEngine};
 use util::{CargoResult, human, process, ProcessError, ChainError};
 use core::manifest::TargetKind;
 use core::source::Source;

--- a/src/cargo/ops/cargo_rustc/compilation.rs
+++ b/src/cargo/ops/cargo_rustc/compilation.rs
@@ -3,7 +3,7 @@ use std::dynamic_lib::DynamicLibrary;
 use semver::Version;
 
 use core::{PackageId, Package};
-use util::{mod, CargoResult};
+use util::{self, CargoResult};
 
 use super::{CommandType, CommandPrototype};
 

--- a/src/cargo/ops/cargo_rustc/context.rs
+++ b/src/cargo/ops/cargo_rustc/context.rs
@@ -4,7 +4,7 @@ use std::str;
 use std::sync::Arc;
 
 use core::{SourceMap, Package, PackageId, PackageSet, Resolve, Target};
-use util::{mod, CargoResult, ChainError, internal, Config, profile};
+use util::{self, CargoResult, ChainError, internal, Config, profile};
 use util::human;
 
 use super::{Kind, Compilation, BuildConfig};
@@ -13,7 +13,7 @@ use super::layout::{Layout, LayoutProxy};
 use super::custom_build::BuildState;
 use super::{ProcessEngine, ExecEngine};
 
-#[deriving(Show, Copy)]
+#[derive(Show, Copy)]
 pub enum Platform {
     Target,
     Plugin,

--- a/src/cargo/ops/cargo_rustc/custom_build.rs
+++ b/src/cargo/ops/cargo_rustc/custom_build.rs
@@ -15,7 +15,7 @@ use super::CommandType;
 use util::Freshness;
 
 /// Contains the parsed output of a custom build script.
-#[deriving(Clone)]
+#[derive(Clone)]
 pub struct BuildOutput {
     /// Paths to pass to rustc with the `-L` flag
     pub library_paths: Vec<Path>,

--- a/src/cargo/ops/cargo_rustc/engine.rs
+++ b/src/cargo/ops/cargo_rustc/engine.rs
@@ -1,9 +1,9 @@
 use std::collections::HashMap;
 use std::c_str::CString;
 use std::io::process::ProcessOutput;
-use std::fmt::{mod, Show, Formatter};
+use std::fmt::{self, Show, Formatter};
 
-use util::{mod, CargoResult, ProcessError, ProcessBuilder};
+use util::{self, CargoResult, ProcessError, ProcessBuilder};
 
 /// Trait for objects that can execute commands.
 pub trait ExecEngine: Send + Sync {
@@ -12,7 +12,7 @@ pub trait ExecEngine: Send + Sync {
 }
 
 /// Default implementation of `ExecEngine`.
-#[deriving(Copy)]
+#[derive(Copy)]
 pub struct ProcessEngine;
 
 impl ExecEngine for ProcessEngine {
@@ -27,7 +27,7 @@ impl ExecEngine for ProcessEngine {
 }
 
 /// Prototype for a command that must be executed.
-#[deriving(Clone)]
+#[derive(Clone)]
 pub struct CommandPrototype {
     ty: CommandType,
     args: Vec<CString>,
@@ -125,7 +125,7 @@ impl Show for CommandPrototype {
     }
 }
 
-#[deriving(Clone, Show)]
+#[derive(Clone, Show)]
 pub enum CommandType {
     Rustc,
     Rustdoc,

--- a/src/cargo/ops/cargo_rustc/fingerprint.rs
+++ b/src/cargo/ops/cargo_rustc/fingerprint.rs
@@ -1,7 +1,7 @@
 use std::collections::hash_map::Entry::{Occupied, Vacant};
 use std::hash::{Hash, Hasher};
 use std::hash::sip::SipHasher;
-use std::io::{mod, fs, File, BufferedReader};
+use std::io::{self, fs, File, BufferedReader};
 use std::io::fs::PathExtensions;
 
 use core::{Package, Target};

--- a/src/cargo/ops/cargo_rustc/job_queue.rs
+++ b/src/cargo/ops/cargo_rustc/job_queue.rs
@@ -48,7 +48,7 @@ struct PendingBuild {
 ///
 /// Each build step for a package is registered with one of these stages, and
 /// each stage has a vector of work to perform in parallel.
-#[deriving(Hash, PartialEq, Eq, Clone, PartialOrd, Ord, Show, Copy)]
+#[derive(Hash, PartialEq, Eq, Clone, PartialOrd, Ord, Show, Copy)]
 pub enum Stage {
     Start,
     BuildCustomBuild,

--- a/src/cargo/ops/cargo_rustc/layout.rs
+++ b/src/cargo/ops/cargo_rustc/layout.rs
@@ -48,7 +48,7 @@
 use std::cell::RefCell;
 use std::collections::HashSet;
 use std::io::fs::PathExtensions;
-use std::io::{mod, fs, IoResult};
+use std::io::{self, fs, IoResult};
 use std::mem;
 
 use core::Package;

--- a/src/cargo/ops/cargo_rustc/mod.rs
+++ b/src/cargo/ops/cargo_rustc/mod.rs
@@ -5,7 +5,7 @@ use std::io::fs::PathExtensions;
 use std::sync::Arc;
 
 use core::{SourceMap, Package, PackageId, PackageSet, Target, Resolve};
-use util::{mod, CargoResult, human, caused_human};
+use util::{self, CargoResult, human, caused_human};
 use util::{Config, internal, ChainError, Fresh, profile, join_paths, Human};
 
 use self::job::{Job, Work};
@@ -28,16 +28,16 @@ mod job_queue;
 mod layout;
 mod links;
 
-#[deriving(PartialEq, Eq, Hash, Show, Copy)]
+#[derive(PartialEq, Eq, Hash, Show, Copy)]
 pub enum Kind { Host, Target }
 
-#[deriving(Default, Clone)]
+#[derive(Default, Clone)]
 pub struct BuildConfig {
     pub host: TargetConfig,
     pub target: TargetConfig,
 }
 
-#[deriving(Clone, Default)]
+#[derive(Clone, Default)]
 pub struct TargetConfig {
     pub ar: Option<String>,
     pub linker: Option<String>,

--- a/src/cargo/ops/cargo_test.rs
+++ b/src/cargo/ops/cargo_test.rs
@@ -2,7 +2,7 @@ use std::os;
 
 use core::Source;
 use sources::PathSource;
-use ops::{mod, ExecEngine, ProcessEngine};
+use ops::{self, ExecEngine, ProcessEngine};
 use util::{CargoResult, ProcessError};
 
 pub struct TestOptions<'a> {

--- a/src/cargo/ops/lockfile.rs
+++ b/src/cargo/ops/lockfile.rs
@@ -1,7 +1,7 @@
 use std::io::File;
 
 use rustc_serialize::{Encodable, Decodable};
-use toml::{mod, Encoder, Value};
+use toml::{self, Encoder, Value};
 
 use core::{Resolve, resolver, Package, SourceId};
 use util::CargoResult;

--- a/src/cargo/ops/resolve.rs
+++ b/src/cargo/ops/resolve.rs
@@ -2,7 +2,7 @@ use std::collections::{HashMap, HashSet};
 
 use core::{Package, PackageId, SourceId};
 use core::registry::PackageRegistry;
-use core::resolver::{mod, Resolve, Method};
+use core::resolver::{self, Resolve, Method};
 use ops;
 use util::CargoResult;
 

--- a/src/cargo/sources/git/source.rs
+++ b/src/cargo/sources/git/source.rs
@@ -1,8 +1,8 @@
-use std::fmt::{mod, Show, Formatter};
+use std::fmt::{self, Show, Formatter};
 use std::hash::Hasher;
 use std::hash::sip::SipHasher;
 use std::mem;
-use url::{mod, Url};
+use url::{self, Url};
 
 use core::source::{Source, SourceId};
 use core::GitReference;

--- a/src/cargo/sources/git/utils.rs
+++ b/src/cargo/sources/git/utils.rs
@@ -1,4 +1,4 @@
-use std::fmt::{mod, Show, Formatter};
+use std::fmt::{self, Show, Formatter};
 use std::io::{USER_DIR};
 use std::io::fs::{mkdir_recursive, rmdir_recursive, PathExtensions};
 use rustc_serialize::{Encodable, Encoder};
@@ -8,7 +8,7 @@ use git2;
 use core::GitReference;
 use util::{CargoResult, ChainError, human, ToUrl, internal};
 
-#[deriving(PartialEq, Clone)]
+#[derive(PartialEq, Clone)]
 #[allow(missing_copy_implementations)]
 pub struct GitRevision(git2::Oid);
 
@@ -20,12 +20,12 @@ impl Show for GitRevision {
 
 /// GitRemote represents a remote repository. It gets cloned into a local
 /// GitDatabase.
-#[deriving(PartialEq,Clone,Show)]
+#[derive(PartialEq,Clone,Show)]
 pub struct GitRemote {
     url: Url,
 }
 
-#[deriving(PartialEq,Clone,RustcEncodable)]
+#[derive(PartialEq,Clone,RustcEncodable)]
 struct EncodableGitRemote {
     url: String,
 }
@@ -46,7 +46,7 @@ pub struct GitDatabase {
     repo: git2::Repository,
 }
 
-#[deriving(RustcEncodable)]
+#[derive(RustcEncodable)]
 pub struct EncodableGitDatabase {
     remote: GitRemote,
     path: String,
@@ -71,7 +71,7 @@ pub struct GitCheckout<'a> {
     repo: git2::Repository,
 }
 
-#[deriving(RustcEncodable)]
+#[derive(RustcEncodable)]
 pub struct EncodableGitCheckout {
     database: EncodableGitDatabase,
     location: String,

--- a/src/cargo/sources/path.rs
+++ b/src/cargo/sources/path.rs
@@ -1,6 +1,6 @@
 use std::cmp;
-use std::fmt::{mod, Show, Formatter};
-use std::io::fs::{mod, PathExtensions};
+use std::fmt::{self, Show, Formatter};
+use std::io::fs::{self, PathExtensions};
 use glob::Pattern;
 use git2;
 

--- a/src/cargo/sources/registry.rs
+++ b/src/cargo/sources/registry.rs
@@ -158,7 +158,7 @@
 //!         ...
 //! ```
 
-use std::io::{mod, fs, File};
+use std::io::{self, fs, File};
 use std::io::fs::PathExtensions;
 use std::collections::HashMap;
 
@@ -192,7 +192,7 @@ pub struct RegistrySource<'a, 'b:'a> {
     updated: bool,
 }
 
-#[deriving(RustcDecodable)]
+#[derive(RustcDecodable)]
 pub struct RegistryConfig {
     /// Download endpoint for all crates. This will be appended with
     /// `/<crate>/<version>/download` and then will be hit with an HTTP GET
@@ -204,7 +204,7 @@ pub struct RegistryConfig {
     pub api: String,
 }
 
-#[deriving(RustcDecodable)]
+#[derive(RustcDecodable)]
 struct RegistryPackage {
     name: String,
     vers: String,
@@ -214,7 +214,7 @@ struct RegistryPackage {
     yanked: Option<bool>,
 }
 
-#[deriving(RustcDecodable)]
+#[derive(RustcDecodable)]
 struct RegistryDependency {
     name: String,
     req: String,

--- a/src/cargo/util/config.rs
+++ b/src/cargo/util/config.rs
@@ -3,7 +3,7 @@ use std::cell::{RefCell, RefMut};
 use std::collections::hash_map::{HashMap};
 use std::collections::hash_map::Entry::{Occupied, Vacant};
 use std::io;
-use std::io::fs::{mod, PathExtensions, File};
+use std::io::fs::{self, PathExtensions, File};
 use std::string;
 
 use rustc_serialize::{Encodable,Encoder};
@@ -94,13 +94,13 @@ impl<'a> Config<'a> {
     }
 }
 
-#[deriving(Eq, PartialEq, Clone, RustcEncodable, RustcDecodable, Copy)]
+#[derive(Eq, PartialEq, Clone, RustcEncodable, RustcDecodable, Copy)]
 pub enum Location {
     Project,
     Global
 }
 
-#[deriving(Eq,PartialEq,Clone,RustcDecodable)]
+#[derive(Eq,PartialEq,Clone,RustcDecodable)]
 pub enum ConfigValue {
     String(string::String, Path),
     List(Vec<(string::String, Path)>),

--- a/src/cargo/util/dependency_queue.rs
+++ b/src/cargo/util/dependency_queue.rs
@@ -40,7 +40,7 @@ pub struct DependencyQueue<K, V> {
 ///
 /// A fresh package does not necessarily need to be rebuilt (unless a dependency
 /// was also rebuilt), and a dirty package must always be rebuilt.
-#[deriving(PartialEq, Eq, Show, Copy)]
+#[derive(PartialEq, Eq, Show, Copy)]
 pub enum Freshness {
     Fresh,
     Dirty,

--- a/src/cargo/util/errors.rs
+++ b/src/cargo/util/errors.rs
@@ -1,5 +1,5 @@
 use std::error::{FromError, Error};
-use std::fmt::{mod, Show};
+use std::fmt::{self, Show};
 use std::io::IoError;
 use std::io::process::{ProcessOutput, ProcessExit, ExitStatus, ExitSignal};
 use std::str;
@@ -164,7 +164,7 @@ impl<E: Error> CargoError for Human<E> {
 
 pub type CliResult<T> = Result<T, CliError>;
 
-#[deriving(Show)]
+#[derive(Show)]
 pub struct CliError {
     pub error: Box<CargoError>,
     pub unknown: bool,

--- a/src/cargo/util/process_builder.rs
+++ b/src/cargo/util/process_builder.rs
@@ -1,4 +1,4 @@
-use std::fmt::{mod, Show, Formatter};
+use std::fmt::{self, Show, Formatter};
 use std::os;
 use std::c_str::CString;
 use std::io::process::{Command, ProcessOutput, InheritFd};
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 
 use util::{CargoResult, ProcessError, process_error};
 
-#[deriving(Clone,PartialEq)]
+#[derive(Clone,PartialEq)]
 pub struct ProcessBuilder {
     program: CString,
     args: Vec<CString>,

--- a/src/cargo/util/to_url.rs
+++ b/src/cargo/util/to_url.rs
@@ -1,4 +1,4 @@
-use url::{mod, Url, UrlParser};
+use url::{self, Url, UrlParser};
 
 pub trait ToUrl {
     fn to_url(self) -> Result<Url, String>;

--- a/src/cargo/util/toml.rs
+++ b/src/cargo/util/toml.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use std::fmt;
-use std::io::fs::{mod, PathExtensions};
+use std::io::fs::{self, PathExtensions};
 use std::os;
 use std::slice;
 use std::str;
@@ -21,7 +21,7 @@ use util::{CargoResult, human, ToUrl, ToSemver, ChainError};
 ///
 /// This structure is used to hold references to all project files that are relevant to cargo.
 
-#[deriving(Clone)]
+#[derive(Clone)]
 pub struct Layout {
     root: Path,
     lib: Option<Path>,
@@ -182,14 +182,14 @@ type TomlBenchTarget = TomlTarget;
  * TODO: Make all struct fields private
  */
 
-#[deriving(RustcDecodable)]
+#[derive(RustcDecodable)]
 pub enum TomlDependency {
     Simple(String),
     Detailed(DetailedTomlDependency)
 }
 
 
-#[deriving(RustcDecodable, Clone, Default)]
+#[derive(RustcDecodable, Clone, Default)]
 pub struct DetailedTomlDependency {
     version: Option<String>,
     path: Option<String>,
@@ -202,7 +202,7 @@ pub struct DetailedTomlDependency {
     default_features: Option<bool>,
 }
 
-#[deriving(RustcDecodable)]
+#[derive(RustcDecodable)]
 pub struct TomlManifest {
     package: Option<Box<TomlProject>>,
     project: Option<Box<TomlProject>>,
@@ -219,7 +219,7 @@ pub struct TomlManifest {
     target: Option<HashMap<String, TomlPlatform>>,
 }
 
-#[deriving(RustcDecodable, Clone, Default)]
+#[derive(RustcDecodable, Clone, Default)]
 pub struct TomlProfiles {
     test: Option<TomlProfile>,
     doc: Option<TomlProfile>,
@@ -228,7 +228,7 @@ pub struct TomlProfiles {
     release: Option<TomlProfile>,
 }
 
-#[deriving(RustcDecodable, Clone, Default)]
+#[derive(RustcDecodable, Clone, Default)]
 #[allow(missing_copy_implementations)]
 pub struct TomlProfile {
     opt_level: Option<uint>,
@@ -238,7 +238,7 @@ pub struct TomlProfile {
     rpath: Option<bool>,
 }
 
-#[deriving(RustcDecodable)]
+#[derive(RustcDecodable)]
 pub enum ManyOrOne<T> {
     Many(Vec<T>),
     One(T),
@@ -253,7 +253,7 @@ impl<T> ManyOrOne<T> {
     }
 }
 
-#[deriving(RustcDecodable)]
+#[derive(RustcDecodable)]
 pub struct TomlProject {
     name: String,
     version: TomlVersion,
@@ -274,7 +274,7 @@ pub struct TomlProject {
 }
 
 // TODO: deprecated, remove
-#[deriving(RustcDecodable)]
+#[derive(RustcDecodable)]
 pub enum BuildCommand {
     Single(String),
     Multiple(Vec<String>)
@@ -605,7 +605,7 @@ fn process_dependencies<'a>(cx: &mut Context<'a>,
     Ok(())
 }
 
-#[deriving(RustcDecodable, Show, Clone)]
+#[derive(RustcDecodable, Show, Clone)]
 struct TomlTarget {
     name: String,
     crate_type: Option<Vec<String>>,
@@ -618,14 +618,14 @@ struct TomlTarget {
     harness: Option<bool>,
 }
 
-#[deriving(RustcDecodable, Clone)]
+#[derive(RustcDecodable, Clone)]
 enum PathValue {
     String(String),
     Path(Path),
 }
 
 /// Corresponds to a `target` entry, but `TomlTarget` is already used.
-#[deriving(RustcDecodable)]
+#[derive(RustcDecodable)]
 struct TomlPlatform {
     dependencies: Option<HashMap<String, TomlDependency>>,
 }
@@ -675,7 +675,7 @@ fn normalize(libs: &[TomlLibTarget],
     log!(4, "normalizing toml targets; lib={}; bin={}; example={}; test={}, benches={}",
          libs, bins, examples, tests, benches);
 
-    #[deriving(Copy)]
+    #[derive(Copy)]
     enum TestDep { Needed, NotNeeded }
 
     fn merge(profile: Profile, toml: &Option<TomlProfile>) -> Profile {

--- a/src/registry/lib.rs
+++ b/src/registry/lib.rs
@@ -2,7 +2,7 @@ extern crate curl;
 extern crate "rustc-serialize" as rustc_serialize;
 
 use std::fmt;
-use std::io::{mod, fs, MemReader, MemWriter, File};
+use std::io::{self, fs, MemReader, MemWriter, File};
 use std::collections::HashMap;
 use std::io::util::ChainedReader;
 use std::result;
@@ -21,7 +21,7 @@ pub struct Registry {
 
 pub type Result<T> = result::Result<T, Error>;
 
-#[deriving(PartialEq, Copy)]
+#[derive(PartialEq, Copy)]
 pub enum Auth {
     Authorized,
     Unauthorized
@@ -37,14 +37,14 @@ pub enum Error {
     Io(io::IoError),
 }
 
-#[deriving(RustcDecodable)]
+#[derive(RustcDecodable)]
 pub struct Crate {
     pub name: String,
     pub description: Option<String>,
     pub max_version: String
 }
 
-#[deriving(RustcEncodable)]
+#[derive(RustcEncodable)]
 pub struct NewCrate {
     pub name: String,
     pub vers: String,
@@ -61,7 +61,7 @@ pub struct NewCrate {
     pub repository: Option<String>,
 }
 
-#[deriving(RustcEncodable)]
+#[derive(RustcEncodable)]
 pub struct NewCrateDependency {
     pub optional: bool,
     pub default_features: bool,
@@ -72,7 +72,7 @@ pub struct NewCrateDependency {
     pub kind: String,
 }
 
-#[deriving(RustcDecodable)]
+#[derive(RustcDecodable)]
 pub struct User {
     pub id: uint,
     pub login: String,
@@ -81,12 +81,12 @@ pub struct User {
     pub name: Option<String>,
 }
 
-#[deriving(RustcDecodable)] struct R { ok: bool }
-#[deriving(RustcDecodable)] struct ApiErrorList { errors: Vec<ApiError> }
-#[deriving(RustcDecodable)] struct ApiError { detail: String }
-#[deriving(RustcEncodable)] struct OwnersReq<'a> { users: &'a [&'a str] }
-#[deriving(RustcDecodable)] struct Users { users: Vec<User> }
-#[deriving(RustcDecodable)] struct Crates { crates: Vec<Crate> }
+#[derive(RustcDecodable)] struct R { ok: bool }
+#[derive(RustcDecodable)] struct ApiErrorList { errors: Vec<ApiError> }
+#[derive(RustcDecodable)] struct ApiError { detail: String }
+#[derive(RustcEncodable)] struct OwnersReq<'a> { users: &'a [&'a str] }
+#[derive(RustcDecodable)] struct Users { users: Vec<User> }
+#[derive(RustcDecodable)] struct Crates { crates: Vec<Crate> }
 
 impl Registry {
     pub fn new(host: String, token: Option<String>) -> Registry {

--- a/tests/resolve.rs
+++ b/tests/resolve.rs
@@ -11,7 +11,7 @@ use cargo::core::source::{SourceId, GitReference};
 use cargo::core::dependency::Kind::Development;
 use cargo::core::{Dependency, PackageId, Summary, Registry};
 use cargo::util::{CargoResult, ToUrl};
-use cargo::core::resolver::{mod, Method};
+use cargo::core::resolver::{self, Method};
 
 fn resolve<R: Registry>(pkg: PackageId, deps: Vec<Dependency>,
                         registry: &mut R)

--- a/tests/support/git.rs
+++ b/tests/support/git.rs
@@ -1,4 +1,4 @@
-use std::io::{mod, fs, File};
+use std::io::{self, fs, File};
 
 use url::Url;
 use git2;

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -1,11 +1,11 @@
 use std::error::Error;
-use std::fmt::{mod, Show};
-use std::io::fs::{mod, PathExtensions};
+use std::fmt::{self, Show};
+use std::io::fs::{self, PathExtensions};
 use std::io::process::{ProcessOutput};
 use std::io;
 use std::os;
 use std::path::{Path,BytesContainer};
-use std::str::{mod, Str};
+use std::str::{self, Str};
 
 use url::Url;
 use hamcrest as ham;
@@ -24,7 +24,7 @@ pub mod registry;
  *
  */
 
-#[deriving(PartialEq,Clone)]
+#[derive(PartialEq,Clone)]
 struct FileBuilder {
     path: Path,
     body: String
@@ -53,7 +53,7 @@ impl FileBuilder {
     }
 }
 
-#[deriving(PartialEq,Clone)]
+#[derive(PartialEq,Clone)]
 struct SymlinkBuilder {
     dst: Path,
     src: Path
@@ -77,7 +77,7 @@ impl SymlinkBuilder {
     }
 }
 
-#[deriving(PartialEq,Clone)]
+#[derive(PartialEq,Clone)]
 pub struct ProjectBuilder {
     name: String,
     root: Path,
@@ -241,7 +241,7 @@ pub fn cargo_dir() -> Path {
  *
  */
 
-#[deriving(Clone)]
+#[derive(Clone)]
 struct Execs {
     expect_stdout: Option<String>,
     expect_stdin: Option<String>,
@@ -419,7 +419,7 @@ pub fn execs() -> Execs {
     }
 }
 
-#[deriving(Clone)]
+#[derive(Clone)]
 struct ShellWrites {
     expected: String
 }

--- a/tests/support/paths.rs
+++ b/tests/support/paths.rs
@@ -1,5 +1,5 @@
 use std::io::IoResult;
-use std::io::fs::{mod, PathExtensions};
+use std::io::fs::{self, PathExtensions};
 use std::sync::atomic;
 use std::{io, os};
 

--- a/tests/support/registry.rs
+++ b/tests/support/registry.rs
@@ -1,4 +1,4 @@
-use std::io::{mod, fs, File};
+use std::io::{self, fs, File};
 
 use flate2::CompressionLevel::Default;
 use flate2::writer::GzEncoder;

--- a/tests/test_cargo.rs
+++ b/tests/test_cargo.rs
@@ -1,4 +1,4 @@
-use std::io::fs::{mod, PathExtensions};
+use std::io::fs::{self, PathExtensions};
 use std::io;
 use std::io::{USER_RWX, File};
 use std::os;

--- a/tests/test_cargo_compile.rs
+++ b/tests/test_cargo_compile.rs
@@ -1,4 +1,4 @@
-use std::io::{mod, fs, TempDir, File};
+use std::io::{self, fs, TempDir, File};
 use std::os;
 use std::path;
 

--- a/tests/test_cargo_compile_path_deps.rs
+++ b/tests/test_cargo_compile_path_deps.rs
@@ -2,7 +2,7 @@ use std::io::{fs, File, USER_RWX};
 
 use support::{project, execs, main_file, cargo_dir};
 use support::{COMPILING, RUNNING};
-use support::paths::{mod, PathExt};
+use support::paths::{self, PathExt};
 use hamcrest::{assert_that, existing_file};
 use cargo;
 use cargo::util::{process};

--- a/tests/test_cargo_publish.rs
+++ b/tests/test_cargo_publish.rs
@@ -1,4 +1,4 @@
-use std::io::{mod, fs, File, MemReader};
+use std::io::{self, fs, File, MemReader};
 
 use flate2::reader::GzDecoder;
 use tar::Archive;

--- a/tests/test_cargo_registry.rs
+++ b/tests/test_cargo_registry.rs
@@ -1,9 +1,9 @@
-use std::io::{mod, fs, File};
+use std::io::{self, fs, File};
 use cargo::util::process;
 
 use support::{project, execs, cargo_dir};
 use support::{UPDATING, DOWNLOADING, COMPILING, PACKAGING, VERIFYING};
-use support::paths::{mod, PathExt};
+use support::paths::{self, PathExt};
 use support::registry as r;
 use support::git;
 

--- a/tests/test_cargo_search.rs
+++ b/tests/test_cargo_search.rs
@@ -1,4 +1,4 @@
-use std::io::{mod, fs, File};
+use std::io::{self, fs, File};
 
 use url::Url;
 


### PR DESCRIPTION
Replace them with `use x::{self, y};` and `#[derive(z)]`, respectively.