### PR TITLE
Update how a PathSource is traversed for git repos

### DIFF
--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -20,6 +20,7 @@ pub struct Manifest {
     links: Option<String>,
     warnings: Vec<String>,
     exclude: Vec<String>,
+    include: Vec<String>,
     metadata: ManifestMetadata,
 }
 
@@ -412,7 +413,10 @@ impl Show for Target {
 impl Manifest {
     pub fn new(summary: Summary, targets: Vec<Target>,
                target_dir: Path, doc_dir: Path,
-               build: Vec<String>, exclude: Vec<String>, links: Option<String>,
+               build: Vec<String>,
+               exclude: Vec<String>,
+               include: Vec<String>,
+               links: Option<String>,
                metadata: ManifestMetadata) -> Manifest {
         Manifest {
             summary: summary,
@@ -422,6 +426,7 @@ impl Manifest {
             build: build,     // TODO: deprecated, remove
             warnings: Vec::new(),
             exclude: exclude,
+            include: include,
             links: links,
             metadata: metadata,
         }
@@ -477,6 +482,10 @@ impl Manifest {
 
     pub fn get_exclude(&self) -> &[String] {
         self.exclude.as_slice()
+    }
+
+    pub fn get_include(&self) -> &[String] {
+        self.include.as_slice()
     }
 
     pub fn get_metadata(&self) -> &ManifestMetadata { &self.metadata }

--- a/src/cargo/ops/cargo_new.rs
+++ b/src/cargo/ops/cargo_new.rs
@@ -9,7 +9,7 @@ use git2::Config;
 use util::{GitRepo, HgRepo, CargoResult, human, ChainError, config, internal};
 use core::shell::MultiShell;
 
-#[deriving(Copy, Show, PartialEq)]
+#[derive(Copy, Show, PartialEq)]
 pub enum VersionControl { Git, Hg, NoVcs }
 
 pub struct NewOptions<'a> {

--- a/src/cargo/util/toml.rs
+++ b/src/cargo/util/toml.rs
@@ -261,6 +261,7 @@ pub struct TomlProject {
     build: Option<BuildCommand>,       // TODO: `String` instead
     links: Option<String>,
     exclude: Option<Vec<String>>,
+    include: Option<Vec<String>>,
 
     // package metadata
     description: Option<String>,
@@ -508,6 +509,7 @@ impl TomlManifest {
         }
 
         let exclude = project.exclude.clone().unwrap_or(Vec::new());
+        let include = project.include.clone().unwrap_or(Vec::new());
 
         let has_old_build = old_build.len() >= 1;
 
@@ -531,6 +533,7 @@ impl TomlManifest {
                                          layout.root.join("doc"),
                                          old_build,
                                          exclude,
+                                         include,
                                          project.links.clone(),
                                          metadata);
         if used_deprecated_lib {

--- a/src/doc/crates-io.md
+++ b/src/doc/crates-io.md
@@ -144,7 +144,18 @@ exclude = [
 ```
 
 The syntax of each element in this array is what
-[rust-lang/glob](https://github.com/rust-lang/glob) accepts.
+[rust-lang/glob](https://github.com/rust-lang/glob) accepts. If you'd rather
+roll with a whitelist instead of a blacklist, Cargo also supports an `include`
+key:
+
+```toml
+[package]
+# ...
+include = [
+    "**/*.rs",
+    "Cargo.toml",
+]
+```
 
 ## Uploading the crate
 

--- a/tests/test_cargo_registry.rs
+++ b/tests/test_cargo_registry.rs
@@ -497,7 +497,7 @@ test!(bad_license_file {
         .file("src/main.rs", r#"
             fn main() {}
         "#);
-    assert_that(p.cargo_process("publish"),
+    assert_that(p.cargo_process("publish").arg("-v"),
                 execs().with_status(101)
                        .with_stderr("\
 the license file `foo` does not exist"));


### PR DESCRIPTION
This fixes a number of bugs along the way:

* Submodules are now recursed into explicitly for packaging, fixing #943
* A whitelist has been implemented, fixing #880
* Git repos are now always used if there is a package that resides at the root,
  not just if the current package resides at the root.