### PR TITLE
Don't require Cargo.toml for `cargo yank`

### DIFF
--- a/src/bin/yank.rs
+++ b/src/bin/yank.rs
@@ -1,7 +1,6 @@
 use cargo::ops;
 use cargo::core::MultiShell;
 use cargo::util::{CliResult, CliError};
-use cargo::util::important_paths::find_root_manifest_for_cwd;
 
 #[derive(RustcDecodable)]
 struct Options {
@@ -38,8 +37,7 @@ crates to be locked to any yanked version.
 
 pub fn execute(options: Options, shell: &mut MultiShell) -> CliResult<Option<()>> {
     shell.set_verbose(options.flag_verbose);
-    let root = try!(find_root_manifest_for_cwd(None));
-    try!(ops::yank(&root, shell,
+    try!(ops::yank(shell,
                    options.arg_crate,
                    options.flag_vers,
                    options.flag_token,

--- a/src/cargo/ops/registry.rs
+++ b/src/cargo/ops/registry.rs
@@ -304,8 +304,7 @@ pub fn modify_owners(shell: &mut MultiShell,
     Ok(())
 }
 
-pub fn yank(manifest_path: &Path,
-            shell: &mut MultiShell,
+pub fn yank(shell: &mut MultiShell,
             krate: Option<String>,
             version: Option<String>,
             token: Option<String>,
@@ -314,6 +313,7 @@ pub fn yank(manifest_path: &Path,
     let name = match krate {
         Some(name) => name,
         None => {
+            let manifest_path = try!(find_root_manifest_for_cwd(None));
             let mut src = try!(PathSource::for_path(&manifest_path.dir_path()));
             try!(src.update());
             let pkg = try!(src.get_root_package());

--- a/src/cargo/sources/git/utils.rs
+++ b/src/cargo/sources/git/utils.rs
@@ -3,7 +3,7 @@ use std::io::{USER_DIR};
 use std::io::fs::{mkdir_recursive, rmdir_recursive, PathExtensions};
 use rustc_serialize::{Encodable, Encoder};
 use url::Url;
-use git2::{mod, ObjectType};
+use git2::{self, ObjectType};
 
 use core::GitReference;
 use util::{CargoResult, ChainError, human, ToUrl, internal};


### PR DESCRIPTION
Same fix as #923.

Closes #1138