### PR TITLE
Print nicer messages on 'no package named' errors

### DIFF
--- a/tests/resolve.rs
+++ b/tests/resolve.rs
@@ -335,7 +335,7 @@ fn resolving_but_no_exists() {
     assert!(res.is_err());
 
     assert_eq!(res.unwrap_err().to_string(), "\
-no package named `foo` found (required by `root`)
+no matching package named `foo` found (required by `root`)
 location searched: registry http://example.com/
 version required: ^1\
 ");


### PR DESCRIPTION
The new message will print out a selection of versions that were found if any
are to be had, as well as a recommendation to run `cargo update` if it's a path
dependency.

Closes #1145