### PR TITLE
Improve errors for invalid manifests

### DIFF
--- a/src/cargo/ops/cargo_read_manifest.rs
+++ b/src/cargo/ops/cargo_read_manifest.rs
@@ -9,8 +9,12 @@ use util::toml::{Layout, project_layout};
 use std::error::FromError;
 
 pub fn read_manifest(contents: &[u8], layout: Layout, source_id: &SourceId)
-    -> CargoResult<(Manifest, Vec<Path>)> {
-    util::toml::to_manifest(contents, source_id, layout).map_err(human)
+                     -> CargoResult<(Manifest, Vec<Path>)> {
+    let root = layout.root.clone();
+    util::toml::to_manifest(contents, source_id, layout).map_err(|e| {
+        human(format!("failed to parse manifest at `{:?}`\n{}",
+                      root.join("Cargo.toml"), e))
+    })
 }
 
 pub fn read_package(path: &Path, source_id: &SourceId)

--- a/src/cargo/util/toml.rs
+++ b/src/cargo/util/toml.rs
@@ -23,7 +23,7 @@ use util::{CargoResult, human, ToUrl, ToSemver, ChainError};
 
 #[derive(Clone)]
 pub struct Layout {
-    root: Path,
+    pub root: Path,
     lib: Option<Path>,
     bins: Vec<Path>,
     examples: Vec<Path>,
@@ -154,7 +154,7 @@ pub fn parse(toml: &str, file: &Path) -> CargoResult<toml::Table> {
         Some(toml) => return Ok(toml),
         None => {}
     }
-    let mut error_str = format!("could not parse input TOML\n");
+    let mut error_str = format!("could not parse input as TOML\n");
     for error in parser.errors.iter() {
         let (loline, locol) = parser.to_linecol(error.lo);
         let (hiline, hicol) = parser.to_linecol(error.hi);

--- a/tests/test_cargo_compile.rs
+++ b/tests/test_cargo_compile.rs
@@ -43,8 +43,12 @@ test!(cargo_compile_with_invalid_manifest {
     assert_that(p.cargo_process("build"),
         execs()
         .with_status(101)
-        .with_stderr("Cargo.toml is not a valid manifest\n\n\
-                      No `package` or `project` section found.\n"))
+        .with_stderr("\
+failed to parse manifest at `[..]`
+Cargo.toml is not a valid manifest
+
+No `package` or `project` section found.
+"))
 });
 
 test!(cargo_compile_with_invalid_manifest2 {
@@ -57,8 +61,12 @@ test!(cargo_compile_with_invalid_manifest2 {
     assert_that(p.cargo_process("build"),
         execs()
         .with_status(101)
-        .with_stderr("could not parse input TOML\n\
-                      Cargo.toml:3:19-3:20 expected a value\n\n"))
+        .with_stderr("\
+failed to parse manifest at `[..]`
+could not parse input as TOML
+Cargo.toml:3:19-3:20 expected a value
+
+"))
 });
 
 test!(cargo_compile_with_invalid_manifest3 {
@@ -75,8 +83,10 @@ test!(cargo_compile_with_invalid_manifest3 {
                  .arg("src/Cargo.toml"),
         execs()
         .with_status(101)
-        .with_stderr("could not parse input TOML\n\
-                      src[..]Cargo.toml:1:5-1:6 expected a value\n\n"))
+        .with_stderr("\
+failed to parse manifest at `[..]`
+could not parse input as TOML\n\
+src[..]Cargo.toml:1:5-1:6 expected a value\n\n"))
 });
 
 test!(cargo_compile_with_invalid_version {
@@ -91,9 +101,12 @@ test!(cargo_compile_with_invalid_version {
     assert_that(p.cargo_process("build"),
                 execs()
                 .with_status(101)
-                .with_stderr("Cargo.toml is not a valid manifest\n\n\
-                              cannot parse '1.0' as a semver for the key \
-                              `project.version`\n"))
+                .with_stderr("\
+failed to parse manifest at `[..]`
+Cargo.toml is not a valid manifest
+
+cannot parse '1.0' as a semver for the key `project.version`
+"))
 
 });
 
@@ -730,8 +743,9 @@ test!(missing_lib_and_bin {
         "#);
     assert_that(p.cargo_process("build"),
                 execs().with_status(101)
-                       .with_stderr("either a [lib] or [[bin]] section \
-                                     must be present\n"));
+                       .with_stderr("\
+failed to parse manifest at `[..]Cargo.toml`
+either a [lib] or [[bin]] section must be present\n"));
 });
 
 test!(lto_build {
@@ -1351,7 +1365,7 @@ Caused by:
   could not parse Toml manifest; path=[..]
 
 Caused by:
-  could not parse input TOML
+  could not parse input as TOML
 [..].cargo[..]config:2:20-2:21 expected `=`, but found `i`
 
 "));

--- a/tests/test_cargo_compile_custom_build.rs
+++ b/tests/test_cargo_compile_custom_build.rs
@@ -857,8 +857,9 @@ test!(build_script_only {
         .file("build.rs", r#"fn main() {}"#);
     assert_that(p.cargo_process("build").arg("-v"),
                 execs().with_status(101)
-                       .with_stderr("either a [lib] or [[bin]] section must \
-                                     be present"));
+                       .with_stderr("\
+failed to parse manifest at `[..]`
+either a [lib] or [[bin]] section must be present"));
 });
 
 test!(shared_dep_with_a_build_script {

--- a/tests/test_cargo_compile_git_deps.rs
+++ b/tests/test_cargo_compile_git_deps.rs
@@ -445,8 +445,12 @@ test!(cargo_compile_with_short_ssh_git {
     assert_that(project.cargo_process("build"),
         execs()
         .with_stdout("")
-        .with_stderr(format!("Cargo.toml is not a valid manifest\n\n\
-                              invalid url `{}`: relative URL without a base\n", url)));
+        .with_stderr(format!("\
+failed to parse manifest at `[..]`
+Cargo.toml is not a valid manifest
+
+invalid url `{}`: relative URL without a base
+", url)));
 });
 
 test!(two_revs_same_deps {

--- a/tests/test_cargo_features.rs
+++ b/tests/test_cargo_features.rs
@@ -23,6 +23,7 @@ test!(invalid1 {
 
     assert_that(p.cargo_process("build"),
                 execs().with_status(101).with_stderr(format!("\
+failed to parse manifest at `[..]`
 Cargo.toml is not a valid manifest
 
 Feature `bar` includes `baz` which is neither a dependency nor another feature
@@ -47,6 +48,7 @@ test!(invalid2 {
 
     assert_that(p.cargo_process("build"),
                 execs().with_status(101).with_stderr(format!("\
+failed to parse manifest at `[..]`
 Cargo.toml is not a valid manifest
 
 Features and dependencies cannot have the same name: `bar`
@@ -71,6 +73,7 @@ test!(invalid3 {
 
     assert_that(p.cargo_process("build"),
                 execs().with_status(101).with_stderr(format!("\
+failed to parse manifest at `[..]`
 Cargo.toml is not a valid manifest
 
 Feature `bar` depends on `baz` which is not an optional dependency.
@@ -133,6 +136,7 @@ test!(invalid5 {
 
     assert_that(p.cargo_process("build"),
                 execs().with_status(101).with_stderr(format!("\
+failed to parse manifest at `[..]`
 Cargo.toml is not a valid manifest
 
 Dev-dependencies are not allowed to be optional: `bar`
@@ -154,6 +158,7 @@ test!(invalid6 {
 
     assert_that(p.cargo_process("build").arg("--features").arg("foo"),
                 execs().with_status(101).with_stderr(format!("\
+failed to parse manifest at `[..]`
 Cargo.toml is not a valid manifest
 
 Feature `foo` requires `bar` which is not an optional dependency
@@ -176,6 +181,7 @@ test!(invalid7 {
 
     assert_that(p.cargo_process("build").arg("--features").arg("foo"),
                 execs().with_status(101).with_stderr(format!("\
+failed to parse manifest at `[..]`
 Cargo.toml is not a valid manifest
 
 Feature `foo` requires `bar` which is not an optional dependency


### PR DESCRIPTION
Print out the path to the manifest in question whenever a parsing error is
encountered.

Closes #979