### PR TITLE
Tweak how source paths are passed to the compiler

### DIFF
--- a/src/cargo/ops/cargo_rustc/context.rs
+++ b/src/cargo/ops/cargo_rustc/context.rs
@@ -1,5 +1,6 @@
-use std::collections::hash_map::HashMap;
 use std::collections::hash_map::Entry::{Occupied, Vacant};
+use std::collections::hash_map::HashMap;
+use std::os;
 use std::str;
 use std::sync::Arc;
 
@@ -29,6 +30,7 @@ pub struct Context<'a, 'b: 'a> {
     pub compilation: Compilation,
     pub build_state: Arc<BuildState>,
     pub exec_engine: Arc<Box<ExecEngine>>,
+    pub cwd: Path,
 
     env: &'a str,
     host: Layout,
@@ -60,6 +62,9 @@ impl<'a, 'b: 'a> Context<'a, 'b> {
         };
         let target_triple = config.target().map(|s| s.to_string());
         let target_triple = target_triple.unwrap_or(config.rustc_host().to_string());
+        let cwd = try!(os::getcwd().chain_error(|| {
+            human("failed to get the current directory")
+        }));
         Ok(Context {
             target_triple: target_triple,
             env: env,
@@ -78,6 +83,7 @@ impl<'a, 'b: 'a> Context<'a, 'b> {
             build_state: Arc::new(BuildState::new(build_config.clone(), deps)),
             build_config: build_config,
             exec_engine: Arc::new(Box::new(ProcessEngine) as Box<ExecEngine>),
+            cwd: cwd,
         })
     }
 

--- a/tests/test_cargo_bench.rs
+++ b/tests/test_cargo_bench.rs
@@ -840,8 +840,8 @@ test!(bench_with_examples {
                 execs().with_status(0)
                        .with_stdout(format!("\
 {compiling} testbench v6.6.6 ({url})
-{running} `rustc {dir}{sep}src{sep}lib.rs --crate-name testbench --crate-type lib [..]`
-{running} `rustc {dir}{sep}src{sep}lib.rs --crate-name testbench --crate-type lib [..]`
+{running} `rustc src{sep}lib.rs --crate-name testbench --crate-type lib [..]`
+{running} `rustc src{sep}lib.rs --crate-name testbench --crate-type lib [..]`
 {running} `rustc benches{sep}testb1.rs --crate-name testb1 --crate-type bin \
         [..] --test [..]`
 {running} `{dir}{sep}target{sep}release{sep}testb1-[..] --bench`

--- a/tests/test_cargo_build_lib.rs
+++ b/tests/test_cargo_build_lib.rs
@@ -9,7 +9,7 @@ fn setup() {
 fn verbose_output_for_lib(p: &ProjectBuilder) -> String {
     format!("\
 {compiling} {name} v{version} ({url})
-{running} `rustc {dir}{sep}src{sep}lib.rs --crate-name {name} --crate-type lib -g \
+{running} `rustc src{sep}lib.rs --crate-name {name} --crate-type lib -g \
         -C metadata=[..] \
         -C extra-filename=-[..] \
         --out-dir {dir}{sep}target \

--- a/tests/test_cargo_compile.rs
+++ b/tests/test_cargo_compile.rs
@@ -751,7 +751,7 @@ test!(lto_build {
     assert_that(p.cargo_process("build").arg("-v").arg("--release"),
                 execs().with_status(0).with_stdout(format!("\
 {compiling} test v0.0.0 ({url})
-{running} `rustc {dir}{sep}src{sep}main.rs --crate-name test --crate-type bin \
+{running} `rustc src{sep}main.rs --crate-name test --crate-type bin \
         -C opt-level=3 \
         -C lto \
         --cfg ndebug \
@@ -780,7 +780,7 @@ test!(verbose_build {
     assert_that(p.cargo_process("build").arg("-v"),
                 execs().with_status(0).with_stdout(format!("\
 {compiling} test v0.0.0 ({url})
-{running} `rustc {dir}{sep}src{sep}lib.rs --crate-name test --crate-type lib -g \
+{running} `rustc src{sep}lib.rs --crate-name test --crate-type lib -g \
         -C metadata=[..] \
         -C extra-filename=-[..] \
         --out-dir {dir}{sep}target \
@@ -808,7 +808,7 @@ test!(verbose_release_build {
     assert_that(p.cargo_process("build").arg("-v").arg("--release"),
                 execs().with_status(0).with_stdout(format!("\
 {compiling} test v0.0.0 ({url})
-{running} `rustc {dir}{sep}src{sep}lib.rs --crate-name test --crate-type lib \
+{running} `rustc src{sep}lib.rs --crate-name test --crate-type lib \
         -C opt-level=3 \
         --cfg ndebug \
         -C metadata=[..] \
@@ -853,7 +853,7 @@ test!(verbose_release_build_deps {
     assert_that(p.cargo_process("build").arg("-v").arg("--release"),
                 execs().with_status(0).with_stdout(format!("\
 {compiling} foo v0.0.0 ({url})
-{running} `rustc {dir}{sep}foo{sep}src{sep}lib.rs --crate-name foo \
+{running} `rustc foo{sep}src{sep}lib.rs --crate-name foo \
         --crate-type dylib --crate-type rlib -C prefer-dynamic \
         -C opt-level=3 \
         --cfg ndebug \
@@ -864,7 +864,7 @@ test!(verbose_release_build_deps {
         -L dependency={dir}{sep}target{sep}release{sep}deps \
         -L dependency={dir}{sep}target{sep}release{sep}deps`
 {compiling} test v0.0.0 ({url})
-{running} `rustc {dir}{sep}src{sep}lib.rs --crate-name test --crate-type lib \
+{running} `rustc src{sep}lib.rs --crate-name test --crate-type lib \
         -C opt-level=3 \
         --cfg ndebug \
         -C metadata=[..] \

--- a/tests/test_cargo_compile_custom_build.rs
+++ b/tests/test_cargo_compile_custom_build.rs
@@ -364,9 +364,9 @@ test!(links_passes_env_vars {
                 execs().with_status(0)
                        .with_stdout(format!("\
 {compiling} [..] v0.5.0 (file://[..])
-{running} `rustc build.rs [..]`
+{running} `rustc [..]build.rs [..]`
 {compiling} [..] v0.5.0 (file://[..])
-{running} `rustc build.rs [..]`
+{running} `rustc [..]build.rs [..]`
 {running} `[..]`
 {running} `[..]`
 {running} `[..]`
@@ -563,7 +563,7 @@ test!(propagation_of_l_flags {
                 execs().with_status(0)
                        .with_stdout(format!("\
 {compiling} a v0.5.0 (file://[..])
-{running} `rustc build.rs [..]`
+{running} `rustc a[..]build.rs [..]`
 {compiling} b v0.5.0 (file://[..])
 {running} `rustc [..] --crate-name b [..]-L foo[..]`
 {running} `[..]a-[..]build-script-build[..]`
@@ -691,7 +691,7 @@ test!(build_cmd_with_a_build_cmd {
 {compiling} b v0.5.0 (file://[..])
 {running} `rustc [..] --crate-name b [..]`
 {compiling} a v0.5.0 (file://[..])
-{running} `rustc build.rs [..] --extern b=[..]`
+{running} `rustc a[..]build.rs [..] --extern b=[..]`
 {running} `[..]a-[..]build-script-build[..]`
 {running} `rustc [..]lib.rs --crate-name a --crate-type lib -g \
     -C metadata=[..] -C extra-filename=-[..] \

--- a/tests/test_cargo_cross_compile.rs
+++ b/tests/test_cargo_cross_compile.rs
@@ -495,7 +495,7 @@ test!(cross_with_a_build_script {
 {compiling} foo v0.0.0 (file://[..])
 {running} `rustc build.rs [..] --out-dir {dir}{sep}target{sep}build{sep}foo-[..]`
 {running} `{dir}{sep}target{sep}build{sep}foo-[..]build-script-build`
-{running} `rustc {dir}{sep}src{sep}main.rs [..] --target {target} [..]`
+{running} `rustc src{sep}main.rs [..] --target {target} [..]`
 ", compiling = COMPILING, running = RUNNING, target = target,
    dir = p.root().display(), sep = path::SEP).as_slice()));
 });
@@ -562,21 +562,21 @@ test!(build_script_needed_for_host_and_target {
                 execs().with_status(0)
                        .with_stdout(format!("\
 {compiling} d1 v0.0.0 (file://{dir})
-{running} `rustc build.rs [..] --out-dir {dir}{sep}target{sep}build{sep}d1-[..]`
+{running} `rustc d1{sep}build.rs [..] --out-dir {dir}{sep}target{sep}build{sep}d1-[..]`
 {running} `{dir}{sep}target{sep}build{sep}d1-[..]build-script-build`
 {running} `{dir}{sep}target{sep}build{sep}d1-[..]build-script-build`
-{running} `rustc {dir}{sep}d1{sep}src{sep}lib.rs [..] --target {target} [..] \
+{running} `rustc d1{sep}src{sep}lib.rs [..] --target {target} [..] \
            -L /path/to/{target}`
-{running} `rustc {dir}{sep}d1{sep}src{sep}lib.rs [..] \
+{running} `rustc d1{sep}src{sep}lib.rs [..] \
            -L /path/to/{host}`
 {compiling} d2 v0.0.0 (file://{dir})
-{running} `rustc {dir}{sep}d2{sep}src{sep}lib.rs [..] \
+{running} `rustc d2{sep}src{sep}lib.rs [..] \
            -L /path/to/{host}`
 {compiling} foo v0.0.0 (file://{dir})
 {running} `rustc build.rs [..] --out-dir {dir}{sep}target{sep}build{sep}foo-[..] \
            -L /path/to/{host}`
 {running} `{dir}{sep}target{sep}build{sep}foo-[..]build-script-build`
-{running} `rustc {dir}{sep}src{sep}main.rs [..] --target {target} [..] \
+{running} `rustc src{sep}main.rs [..] --target {target} [..] \
            -L /path/to/{target}`
 ", compiling = COMPILING, running = RUNNING, target = target, host = host,
    dir = p.root().display(), sep = path::SEP).as_slice()));

--- a/tests/test_cargo_doc.rs
+++ b/tests/test_cargo_doc.rs
@@ -180,7 +180,7 @@ test!(doc_only_bin {
             pub fn bar() {}
         "#);
 
-    assert_that(p.cargo_process("doc"),
+    assert_that(p.cargo_process("doc").arg("-v"),
                 execs().with_status(0));
 
     assert_that(&p.root().join("target/doc"), existing_dir());

--- a/tests/test_cargo_profiles.rs
+++ b/tests/test_cargo_profiles.rs
@@ -27,7 +27,7 @@ test!(profile_overrides {
     assert_that(p.cargo_process("build").arg("-v"),
                 execs().with_status(0).with_stdout(format!("\
 {compiling} test v0.0.0 ({url})
-{running} `rustc {dir}{sep}src{sep}lib.rs --crate-name test --crate-type lib \
+{running} `rustc src{sep}lib.rs --crate-name test --crate-type lib \
         -C opt-level=1 \
         --cfg ndebug \
         -C metadata=[..] \
@@ -81,7 +81,7 @@ test!(top_level_overrides_deps {
     assert_that(p.cargo_process("build").arg("-v").arg("--release"),
                 execs().with_status(0).with_stdout(format!("\
 {compiling} foo v0.0.0 ({url})
-{running} `rustc {dir}{sep}foo{sep}src{sep}lib.rs --crate-name foo \
+{running} `rustc foo{sep}src{sep}lib.rs --crate-name foo \
         --crate-type dylib --crate-type rlib -C prefer-dynamic \
         -C opt-level=1 \
         -g \
@@ -92,7 +92,7 @@ test!(top_level_overrides_deps {
         -L dependency={dir}{sep}target{sep}release{sep}deps \
         -L dependency={dir}{sep}target{sep}release{sep}deps`
 {compiling} test v0.0.0 ({url})
-{running} `rustc {dir}{sep}src{sep}lib.rs --crate-name test --crate-type lib \
+{running} `rustc src{sep}lib.rs --crate-name test --crate-type lib \
         -C opt-level=1 \
         -g \
         -C metadata=[..] \

--- a/tests/test_cargo_run.rs
+++ b/tests/test_cargo_run.rs
@@ -266,7 +266,7 @@ test!(example_with_release_flag {
     assert_that(p.cargo_process("run").arg("-v").arg("--release").arg("--example").arg("a"),
                 execs().with_status(0).with_stdout(format!("\
 {compiling} bar v0.0.1 ({url})
-{running} `rustc src{sep}bar.rs --crate-name bar --crate-type lib \
+{running} `rustc bar{sep}src{sep}bar.rs --crate-name bar --crate-type lib \
         -C opt-level=3 \
         --cfg ndebug \
         -C metadata=[..] \
@@ -276,7 +276,7 @@ test!(example_with_release_flag {
         -L dependency={dir}{sep}target{sep}release{sep}deps \
         -L dependency={dir}{sep}target{sep}release{sep}deps`
 {compiling} foo v0.0.1 ({url})
-{running} `rustc {dir}{sep}examples{sep}a.rs --crate-name a --crate-type bin \
+{running} `rustc examples{sep}a.rs --crate-name a --crate-type bin \
         -C opt-level=3 \
         --cfg ndebug \
         --out-dir {dir}{sep}target{sep}release{sep}examples \
@@ -297,7 +297,7 @@ fast2
     assert_that(p.process(cargo_dir().join("cargo")).arg("run").arg("-v").arg("--example").arg("a"),
                 execs().with_status(0).with_stdout(format!("\
 {compiling} bar v0.0.1 ({url})
-{running} `rustc src{sep}bar.rs --crate-name bar --crate-type lib \
+{running} `rustc bar{sep}src{sep}bar.rs --crate-name bar --crate-type lib \
         -g \
         -C metadata=[..] \
         -C extra-filename=[..] \
@@ -306,7 +306,7 @@ fast2
         -L dependency={dir}{sep}target{sep}deps \
         -L dependency={dir}{sep}target{sep}deps`
 {compiling} foo v0.0.1 ({url})
-{running} `rustc {dir}{sep}examples{sep}a.rs --crate-name a --crate-type bin \
+{running} `rustc examples{sep}a.rs --crate-name a --crate-type bin \
         -g \
         --out-dir {dir}{sep}target{sep}examples \
         --emit=dep-info,link \


### PR DESCRIPTION
All paths printed will now be absolute paths unless the path is a descendant of
the current directory. This should keep error messages and warnings of a
reasonable length when working with the local project while still allowing
errors in registry/git dependencies to be tracked down.

Special care is taken in these situations to ensure that the error message from
the compiler prints a reasonable path.

Closes #209
Closes #694
Closes #1081