### PR TITLE
Remove --travis from `cargo new`

### DIFF
--- a/src/bin/new.rs
+++ b/src/bin/new.rs
@@ -8,7 +8,6 @@ use cargo::util::{CliResult, CliError};
 struct Options {
     flag_verbose: bool,
     flag_bin: bool,
-    flag_travis: bool,
     arg_path: String,
     flag_vcs: Option<ops::VersionControl>,
 }
@@ -25,7 +24,6 @@ Options:
     --vcs <vcs>         Initialize a new repository for the given version
                         control system (git or hg) or do not initialize any version
                         control at all (none) overriding a global configuration.
-    --travis            Create a .travis.yml file
     --bin               Use a binary instead of a library template
     -v, --verbose       Use verbose output
 ";
@@ -34,11 +32,10 @@ pub fn execute(options: Options, shell: &mut MultiShell) -> CliResult<Option<()>
     debug!("executing; cmd=cargo-new; args={:?}", os::args());
     shell.set_verbose(options.flag_verbose);
 
-    let Options { flag_travis, flag_bin, arg_path, flag_vcs, .. } = options;
+    let Options { flag_bin, arg_path, flag_vcs, .. } = options;
 
     let opts = ops::NewOptions {
         version_control: flag_vcs,
-        travis: flag_travis,
         path: arg_path.as_slice(),
         bin: flag_bin,
     };

--- a/src/cargo/ops/cargo_new.rs
+++ b/src/cargo/ops/cargo_new.rs
@@ -14,7 +14,6 @@ pub enum VersionControl { Git, Hg, NoVcs }
 
 pub struct NewOptions<'a> {
     pub version_control: Option<VersionControl>,
-    pub travis: bool,
     pub bin: bool,
     pub path: &'a str,
 }
@@ -101,10 +100,6 @@ fn mk(path: &Path, name: &str, opts: &NewOptions) -> CargoResult<()> {
         (Some(name), None, _, None) |
         (None, None, name, None) => name,
     };
-
-    if opts.travis {
-        try!(File::create(&path.join(".travis.yml")).write_str("language: rust\n"));
-    }
 
     try!(File::create(&path.join("Cargo.toml")).write_str(format!(
 r#"[package]

--- a/src/etc/_cargo
+++ b/src/etc/_cargo
@@ -125,7 +125,6 @@ case $state in
                     '(-h, --help)'{-h,--help}'[show help message]' \
                     '--hg[initialize new mercurial repo]' \
                     '--no-git[no new git repo]' \
-                    '--travis[create new .travis.yml]' \
                     '(-v, --verbose)'{-v,--verbose}'[use verbose output]' \
                     ;;
 

--- a/src/etc/cargo.bashcomp.sh
+++ b/src/etc/cargo.bashcomp.sh
@@ -69,7 +69,7 @@ _cargo() {
             return 0;;
         new)
             COMPREPLY=( $(compgen -W \
-                "--bin --git --help --hg --no-git --travis --verbose" \
+                "--bin --git --help --hg --no-git --verbose" \
                  -- "${cur}") )
             return 0;;
         run)

--- a/tests/test_cargo_new.rs
+++ b/tests/test_cargo_new.rs
@@ -68,20 +68,6 @@ test!(simple_git {
                 execs().with_status(0));
 });
 
-test!(simple_travis {
-    os::setenv("USER", "foo");
-    assert_that(cargo_process("new").arg("foo").arg("--travis"),
-                execs().with_status(0));
-
-    assert_that(&paths::root().join("foo"), existing_dir());
-    assert_that(&paths::root().join("foo/Cargo.toml"), existing_file());
-    assert_that(&paths::root().join("foo/src/lib.rs"), existing_file());
-    assert_that(&paths::root().join("foo/.travis.yml"), existing_file());
-
-    assert_that(cargo_process("build").cwd(paths::root().join("foo")),
-                execs().with_status(0));
-});
-
 test!(no_argument {
     assert_that(cargo_process("new"),
                 execs().with_status(1)


### PR DESCRIPTION
It's a little odd that Cargo only supports travis right now, and as #517 points
out it probably shouldn't be a top-level flag but rather a general "service
flag". Due to a lack of other services and the ease of adding your own travis
configuration, this commit removes the flag altogether for now. It can always be
added later when we've got some more impetus!

Closes #517
Closes #1115