### PR TITLE
Probe for a C compiler in the configure script

### DIFF
--- a/configure
+++ b/configure
@@ -342,6 +342,7 @@ step_msg "looking for build programs"
 
 probe_need CFG_CURLORWGET  curl wget
 probe_need CFG_PYTHON      python
+probe_need CFG_CC          cc gcc clang
 
 if [ ! -z "${CFG_LOCAL_RUST_ROOT}" ]; then
     CFG_RUSTDOC="${CFG_LOCAL_RUST_ROOT}/bin/rustdoc"


### PR DESCRIPTION
Probably a good sanity check to have up front to ensure that you've got a C
compiler locally!

Closes #820