### PR TITLE
update to recent rust changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,14 +9,14 @@ dependencies = [
  "git2 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "glob 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "hamcrest 0.1.0 (git+https://github.com/carllerche/hamcrest-rust.git)",
- "log 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "registry 0.1.0",
- "rustc-serialize 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "semver 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "semver 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "tar 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "term 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "term 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "toml 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -39,19 +39,20 @@ name = "curl"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "curl-sys 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "curl-sys 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl-sys 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "curl-sys"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
+ "libc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libz-sys 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl-sys 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "pkg-config 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -60,7 +61,7 @@ version = "0.6.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "regex 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -73,7 +74,7 @@ dependencies = [
 
 [[package]]
 name = "gcc"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -97,14 +98,27 @@ version = "0.1.0"
 source = "git+https://github.com/carllerche/hamcrest-rust.git#445dc78024c7d912d2e52dcd3ef3dfe2c8dbab47"
 
 [[package]]
+name = "kernel32-sys"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "libc"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "libgit2-sys"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libssh2-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libssh2-sys 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "libz-sys 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl-sys 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "pkg-config 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -117,12 +131,12 @@ dependencies = [
 
 [[package]]
 name = "libssh2-sys"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libz-sys 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl-sys 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "pkg-config 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -130,12 +144,12 @@ name = "libz-sys"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "pkg-config 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "log"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "regex 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -151,7 +165,7 @@ name = "miniz-sys"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "gcc 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gcc 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -160,12 +174,12 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libressl-pnacl-sys 2.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "pkg-config 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "pkg-config"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -183,17 +197,17 @@ name = "registry"
 version = "0.1.0"
 dependencies = [
  "curl 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rustc-serialize"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "semver"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -203,10 +217,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "term"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "log 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kernel32-sys 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -214,15 +230,15 @@ name = "time"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "gcc 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gcc 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "toml"
-version = "0.1.13"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rustc-serialize 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -231,7 +247,7 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "matches 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = "0.1.0"
 dependencies = [
  "advapi32-sys 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "curl 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "docopt 0.6.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "docopt 0.6.31 (registry+https://github.com/rust-lang/crates.io-index)",
  "flate2 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "git2 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "git2 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "glob 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "hamcrest 0.1.0 (git+https://github.com/carllerche/hamcrest-rust.git)",
  "log 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -15,9 +15,9 @@ dependencies = [
  "semver 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "tar 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "term 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -41,7 +41,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "curl-sys 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl-sys 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -57,7 +57,7 @@ dependencies = [
 
 [[package]]
 name = "docopt"
-version = "0.6.30"
+version = "0.6.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "regex 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -79,12 +79,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "git2"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libgit2-sys 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libgit2-sys 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -112,7 +112,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libssh2-sys 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -227,10 +227,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.12"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "gcc 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -243,7 +244,7 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "matches 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/cargo/core/dependency.rs
+++ b/src/cargo/core/dependency.rs
@@ -4,7 +4,7 @@ use core::{SourceId, Summary, PackageId};
 use util::CargoResult;
 
 /// Informations about a dependency requested by a Cargo manifest.
-#[derive(PartialEq,Clone,Show)]
+#[derive(PartialEq,Clone,Debug)]
 pub struct Dependency {
     name: String,
     source_id: SourceId,
@@ -22,7 +22,7 @@ pub struct Dependency {
     only_for_platform: Option<String>,
 }
 
-#[derive(PartialEq, Clone, Show, Copy)]
+#[derive(PartialEq, Clone, Debug, Copy)]
 pub enum Kind {
     Normal,
     Development,

--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -9,7 +9,7 @@ use core::dependency::SerializedDependency;
 use util::{CargoResult, human};
 
 /// Contains all the informations about a package, as loaded from a Cargo.toml.
-#[derive(PartialEq,Clone, Show)]
+#[derive(PartialEq,Clone, Debug)]
 pub struct Manifest {
     summary: Summary,
     targets: Vec<Target>,
@@ -30,7 +30,7 @@ pub struct Manifest {
 /// validated by cargo itself, but rather it is up to the registry when uploaded
 /// to validate these fields. Cargo will itself accept any valid TOML
 /// specification for these values.
-#[derive(PartialEq, Clone, Show)]
+#[derive(PartialEq, Clone, Debug)]
 pub struct ManifestMetadata {
     pub authors: Vec<String>,
     pub keywords: Vec<String>,
@@ -68,7 +68,7 @@ impl Encodable for Manifest {
     }
 }
 
-#[derive(Show, Clone, PartialEq, Hash, RustcEncodable, Copy)]
+#[derive(Debug, Clone, PartialEq, Hash, RustcEncodable, Copy)]
 pub enum LibKind {
     Lib,
     Rlib,
@@ -103,14 +103,14 @@ impl LibKind {
     }
 }
 
-#[derive(Show, Clone, Hash, PartialEq, RustcEncodable)]
+#[derive(Debug, Clone, Hash, PartialEq, RustcEncodable)]
 pub enum TargetKind {
     Lib(Vec<LibKind>),
     Bin,
     Example,
 }
 
-#[derive(RustcEncodable, RustcDecodable, Clone, PartialEq, Show)]
+#[derive(RustcEncodable, RustcDecodable, Clone, PartialEq, Debug)]
 pub struct Profile {
     env: String, // compile, test, dev, bench, etc.
     opt_level: u32,
@@ -345,7 +345,7 @@ impl<H: hash::Writer + hash::Hasher> hash::Hash<H> for Profile {
 }
 
 /// Informations about a binary, a library, an example, etc. that is part of the package.
-#[derive(Clone, Hash, PartialEq, Show)]
+#[derive(Clone, Hash, PartialEq, Debug)]
 pub struct Target {
     kind: TargetKind,
     name: String,

--- a/src/cargo/core/package.rs
+++ b/src/cargo/core/package.rs
@@ -20,7 +20,7 @@ use core::source::{SourceId, Source};
 ///
 /// A package is a `Cargo.toml` file, plus all the files that are part of it.
 // TODO: Is manifest_path a relic?
-#[derive(Clone, Show)]
+#[derive(Clone, Debug)]
 pub struct Package {
     // The package's manifest
     manifest: Manifest,
@@ -117,7 +117,7 @@ impl Package {
     }
 }
 
-impl fmt::String for Package {
+impl fmt::Display for Package {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.get_summary().get_package_id())
     }
@@ -137,7 +137,7 @@ impl<H: hash::Writer + hash::Hasher> hash::Hash<H> for Package {
     }
 }
 
-#[derive(PartialEq,Clone,Show)]
+#[derive(PartialEq,Clone,Debug)]
 pub struct PackageSet {
     packages: Vec<Package>,
 }

--- a/src/cargo/core/package_id.rs
+++ b/src/cargo/core/package_id.rs
@@ -13,12 +13,12 @@ use util::{CargoResult, CargoError, short_hash, ToSemver};
 use core::source::SourceId;
 
 /// Identifier for a specific version of a package in a specific source.
-#[derive(Clone, Show)]
+#[derive(Clone, Debug)]
 pub struct PackageId {
     inner: Arc<PackageIdInner>,
 }
 
-#[derive(PartialEq, PartialOrd, Eq, Ord, Show)]
+#[derive(PartialEq, PartialOrd, Eq, Ord, Debug)]
 struct PackageIdInner {
     name: String,
     version: semver::Version,
@@ -81,7 +81,7 @@ impl Ord for PackageId {
     }
 }
 
-#[derive(Clone, Show, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum PackageIdError {
     InvalidVersion(String),
     InvalidNamespace(String)
@@ -109,7 +109,7 @@ impl FromError<PackageIdError> for Box<CargoError> {
     fn from_error(t: PackageIdError) -> Box<CargoError> { Box::new(t) }
 }
 
-#[derive(PartialEq, Hash, Clone, RustcEncodable, Show)]
+#[derive(PartialEq, Hash, Clone, RustcEncodable, Debug)]
 pub struct Metadata {
     pub metadata: String,
     pub extra_filename: String
@@ -168,7 +168,7 @@ impl Metadata {
     }
 }
 
-impl fmt::String for PackageId {
+impl fmt::Display for PackageId {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         try!(write!(f, "{} v{}", self.inner.name, self.inner.version));
 

--- a/src/cargo/core/package_id.rs
+++ b/src/cargo/core/package_id.rs
@@ -89,15 +89,18 @@ pub enum PackageIdError {
 
 impl Error for PackageIdError {
     fn description(&self) -> &str { "failed to parse package id" }
-    fn detail(&self) -> Option<String> {
-        Some(match *self {
+}
+
+impl fmt::Display for PackageIdError {
+    fn fmt(self, f: fmt::Formatter) {
+        match self {
             PackageIdError::InvalidVersion(ref v) => {
-                format!("invalid version: {}", *v)
+                write!(f, "invalid version: {}", *v)
             }
             PackageIdError::InvalidNamespace(ref ns) => {
-                format!("invalid namespace: {}", *ns)
+                write!(f, "invalid namespace: {}", *ns)
             }
-        })
+        }
     }
 }
 

--- a/src/cargo/core/package_id_spec.rs
+++ b/src/cargo/core/package_id_spec.rs
@@ -5,7 +5,7 @@ use url::{self, Url, UrlParser};
 use core::PackageId;
 use util::{CargoResult, ToUrl, human, ToSemver, ChainError};
 
-#[derive(Clone, PartialEq, Eq, Show)]
+#[derive(Clone, PartialEq, Eq, Debug)]
 pub struct PackageIdSpec {
     name: String,
     version: Option<Version>,
@@ -129,7 +129,7 @@ fn url(s: &str) -> url::ParseResult<Url> {
 
 }
 
-impl fmt::String for PackageIdSpec {
+impl fmt::Display for PackageIdSpec {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let mut printed_name = false;
         match self.url {

--- a/src/cargo/core/resolver/encode.rs
+++ b/src/cargo/core/resolver/encode.rs
@@ -8,7 +8,7 @@ use util::{CargoResult, Graph};
 
 use super::Resolve;
 
-#[derive(RustcEncodable, RustcDecodable, Show)]
+#[derive(RustcEncodable, RustcDecodable, Debug)]
 pub struct EncodableResolve {
     package: Option<Vec<EncodableDependency>>,
     root: EncodableDependency,
@@ -78,7 +78,7 @@ impl EncodableResolve {
     }
 }
 
-#[derive(RustcEncodable, RustcDecodable, Show, PartialOrd, Ord, PartialEq, Eq)]
+#[derive(RustcEncodable, RustcDecodable, Debug, PartialOrd, Ord, PartialEq, Eq)]
 pub struct EncodableDependency {
     name: String,
     version: String,
@@ -95,7 +95,7 @@ impl EncodableDependency {
     }
 }
 
-#[derive(Show, PartialOrd, Ord, PartialEq, Eq)]
+#[derive(Debug, PartialOrd, Ord, PartialEq, Eq)]
 pub struct EncodablePackageId {
     name: String,
     version: String,

--- a/src/cargo/core/resolver/mod.rs
+++ b/src/cargo/core/resolver/mod.rs
@@ -115,7 +115,7 @@ impl Resolve {
     }
 }
 
-impl fmt::Show for Resolve {
+impl fmt::Debug for Resolve {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         self.graph.fmt(fmt)
     }

--- a/src/cargo/core/shell.rs
+++ b/src/cargo/core/shell.rs
@@ -52,7 +52,7 @@ impl MultiShell {
     }
 
     pub fn status<T, U>(&mut self, status: T, message: U) -> IoResult<()>
-        where T: fmt::String, U: fmt::String
+        where T: fmt::Display, U: fmt::Display
     {
         self.out().say_status(status, message, GREEN)
     }
@@ -129,7 +129,7 @@ impl Shell {
 
     pub fn say_status<T, U>(&mut self, status: T, message: U, color: Color)
                             -> IoResult<()>
-        where T: fmt::String, U: fmt::String
+        where T: fmt::Display, U: fmt::Display
     {
         try!(self.reset());
         if color != BLACK { try!(self.fg(color)); }

--- a/src/cargo/core/source.rs
+++ b/src/cargo/core/source.rs
@@ -43,7 +43,7 @@ pub trait Source: Registry {
     fn fingerprint(&self, pkg: &Package) -> CargoResult<String>;
 }
 
-#[derive(Show, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 enum Kind {
     /// Kind::Git(<git reference>) represents a git repository
     Git(GitReference),
@@ -53,7 +53,7 @@ enum Kind {
     Registry,
 }
 
-#[derive(Show, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum GitReference {
     Tag(String),
     Branch(String),
@@ -63,12 +63,12 @@ pub enum GitReference {
 type Error = Box<CargoError + Send>;
 
 /// Unique identifier for a source of packages.
-#[derive(Clone, Eq, Show)]
+#[derive(Clone, Eq, Debug)]
 pub struct SourceId {
     inner: Arc<SourceIdInner>,
 }
 
-#[derive(Eq, Clone, Show)]
+#[derive(Eq, Clone, Debug)]
 struct SourceIdInner {
     url: Url,
     kind: Kind,
@@ -273,11 +273,11 @@ impl Decodable for SourceId {
     }
 }
 
-impl fmt::String for SourceId {
+impl fmt::Display for SourceId {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         match *self.inner {
             SourceIdInner { kind: Kind::Path, ref url, .. } => {
-                fmt::String::fmt(url, f)
+                fmt::Display::fmt(url, f)
             }
             SourceIdInner { kind: Kind::Git(ref reference), ref url,
                             ref precise, .. } => {

--- a/src/cargo/core/summary.rs
+++ b/src/cargo/core/summary.rs
@@ -10,7 +10,7 @@ use util::{CargoResult, human};
 /// a package.
 ///
 /// Summaries are cloned, and should not be mutated after creation
-#[derive(Show,Clone)]
+#[derive(Debug,Clone)]
 pub struct Summary {
     package_id: PackageId,
     dependencies: Vec<Dependency>,

--- a/src/cargo/ops/cargo_new.rs
+++ b/src/cargo/ops/cargo_new.rs
@@ -9,7 +9,7 @@ use git2::Config as GitConfig;
 use util::{GitRepo, HgRepo, CargoResult, human, ChainError, internal};
 use util::Config;
 
-#[derive(Copy, Show, PartialEq)]
+#[derive(Copy, Debug, PartialEq)]
 pub enum VersionControl { Git, Hg, NoVcs }
 
 pub struct NewOptions<'a> {

--- a/src/cargo/ops/cargo_rustc/context.rs
+++ b/src/cargo/ops/cargo_rustc/context.rs
@@ -15,7 +15,7 @@ use super::layout::{Layout, LayoutProxy};
 use super::custom_build::BuildState;
 use super::{ProcessEngine, ExecEngine};
 
-#[derive(Show, Copy)]
+#[derive(Debug, Copy)]
 pub enum Platform {
     Target,
     Plugin,

--- a/src/cargo/ops/cargo_rustc/custom_build.rs
+++ b/src/cargo/ops/cargo_rustc/custom_build.rs
@@ -15,7 +15,7 @@ use super::CommandType;
 use util::Freshness;
 
 /// Contains the parsed output of a custom build script.
-#[derive(Clone, Show)]
+#[derive(Clone, Debug)]
 pub struct BuildOutput {
     /// Paths to pass to rustc with the `-L` flag
     pub library_paths: Vec<Path>,

--- a/src/cargo/ops/cargo_rustc/engine.rs
+++ b/src/cargo/ops/cargo_rustc/engine.rs
@@ -117,7 +117,7 @@ impl CommandPrototype {
     }
 }
 
-impl fmt::String for CommandPrototype {
+impl fmt::Display for CommandPrototype {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self.ty {
             CommandType::Rustc => try!(write!(f, "`rustc")),
@@ -135,7 +135,7 @@ impl fmt::String for CommandPrototype {
     }
 }
 
-#[derive(Clone, Show)]
+#[derive(Clone, Debug)]
 pub enum CommandType {
     Rustc,
     Rustdoc,

--- a/src/cargo/ops/cargo_rustc/job_queue.rs
+++ b/src/cargo/ops/cargo_rustc/job_queue.rs
@@ -49,7 +49,7 @@ struct PendingBuild {
 ///
 /// Each build step for a package is registered with one of these stages, and
 /// each stage has a vector of work to perform in parallel.
-#[derive(Hash, PartialEq, Eq, Clone, PartialOrd, Ord, Show, Copy)]
+#[derive(Hash, PartialEq, Eq, Clone, PartialOrd, Ord, Debug, Copy)]
 pub enum Stage {
     Start,
     BuildCustomBuild,

--- a/src/cargo/ops/cargo_rustc/mod.rs
+++ b/src/cargo/ops/cargo_rustc/mod.rs
@@ -30,7 +30,7 @@ mod job_queue;
 mod layout;
 mod links;
 
-#[derive(PartialEq, Eq, Hash, Show, Copy)]
+#[derive(PartialEq, Eq, Hash, Debug, Copy)]
 pub enum Kind { Host, Target }
 
 #[derive(Default, Clone)]

--- a/src/cargo/sources/git/source.rs
+++ b/src/cargo/sources/git/source.rs
@@ -1,4 +1,4 @@
-use std::fmt::{self, Show, Formatter};
+use std::fmt::{self, Debug, Formatter};
 use std::hash::{Hash, Hasher, SipHasher};
 use std::mem;
 use url::{self, Url};
@@ -143,7 +143,7 @@ pub fn canonicalize_url(url: &Url) -> Url {
     return url;
 }
 
-impl<'a, 'b> Show for GitSource<'a, 'b> {
+impl<'a, 'b> Debug for GitSource<'a, 'b> {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         try!(write!(f, "git repo at {}", self.remote.get_url()));
 

--- a/src/cargo/sources/git/utils.rs
+++ b/src/cargo/sources/git/utils.rs
@@ -8,19 +8,19 @@ use git2::{self, ObjectType};
 use core::GitReference;
 use util::{CargoResult, ChainError, human, ToUrl, internal};
 
-#[derive(PartialEq, Clone, Show)]
+#[derive(PartialEq, Clone, Debug)]
 #[allow(missing_copy_implementations)]
 pub struct GitRevision(git2::Oid);
 
-impl fmt::String for GitRevision {
+impl fmt::Display for GitRevision {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        fmt::String::fmt(&self.0, f)
+        fmt::Display::fmt(&self.0, f)
     }
 }
 
 /// GitRemote represents a remote repository. It gets cloned into a local
 /// GitDatabase.
-#[derive(PartialEq,Clone,Show)]
+#[derive(PartialEq,Clone,Debug)]
 pub struct GitRemote {
     url: Url,
 }

--- a/src/cargo/sources/path.rs
+++ b/src/cargo/sources/path.rs
@@ -1,5 +1,5 @@
 use std::cmp;
-use std::fmt::{self, Show, Formatter};
+use std::fmt::{self, Debug, Formatter};
 use std::io::fs::{self, PathExtensions};
 use glob::Pattern;
 use git2;
@@ -201,7 +201,7 @@ impl<'a, 'b> PathSource<'a, 'b> {
     }
 }
 
-impl<'a, 'b> Show for PathSource<'a, 'b> {
+impl<'a, 'b> Debug for PathSource<'a, 'b> {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "the paths source")
     }

--- a/src/cargo/util/config.rs
+++ b/src/cargo/util/config.rs
@@ -199,7 +199,7 @@ pub enum ConfigValue {
     Boolean(bool, Path),
 }
 
-impl fmt::Show for ConfigValue {
+impl fmt::Debug for ConfigValue {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             CV::Integer(i, ref path) => write!(f, "{} (from {:?})", i, path),

--- a/src/cargo/util/dependency_queue.rs
+++ b/src/cargo/util/dependency_queue.rs
@@ -40,7 +40,7 @@ pub struct DependencyQueue<K, V> {
 ///
 /// A fresh package does not necessarily need to be rebuilt (unless a dependency
 /// was also rebuilt), and a dirty package must always be rebuilt.
-#[derive(PartialEq, Eq, Show, Copy)]
+#[derive(PartialEq, Eq, Debug, Copy)]
 pub enum Freshness {
     Fresh,
     Dirty,

--- a/src/cargo/util/errors.rs
+++ b/src/cargo/util/errors.rs
@@ -22,15 +22,15 @@ pub trait CargoError: Error {
     fn cargo_cause(&self) -> Option<&CargoError>{ None }
 }
 
-impl fmt::String for Box<CargoError> {
+impl fmt::Display for Box<CargoError> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         try!(write!(f, "{}", self.description()));
         Ok(())
     }
 }
-impl fmt::Show for Box<CargoError> {
+impl fmt::Debug for Box<CargoError> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::String::fmt(self, f)
+        fmt::Display::fmt(self, f)
     }
 }
 
@@ -115,14 +115,14 @@ impl Error for ProcessError {
     }
 }
 
-impl fmt::String for ProcessError {
+impl fmt::Display for ProcessError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::String::fmt(&self.desc, f)
+        fmt::Display::fmt(&self.desc, f)
     }
 }
-impl fmt::Show for ProcessError {
+impl fmt::Debug for ProcessError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::String::fmt(self, f)
+        fmt::Display::fmt(self, f)
     }
 }
 
@@ -136,14 +136,14 @@ struct ConcreteCargoError {
     is_human: bool,
 }
 
-impl fmt::String for ConcreteCargoError {
+impl fmt::Display for ConcreteCargoError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description)
     }
 }
-impl fmt::Show for ConcreteCargoError {
+impl fmt::Debug for ConcreteCargoError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::String::fmt(self, f)
+        fmt::Display::fmt(self, f)
     }
 }
 
@@ -182,7 +182,7 @@ impl<E: CargoError> CargoError for Human<E> {
 
 pub type CliResult<T> = Result<T, CliError>;
 
-#[derive(Show)]
+#[derive(Debug)]
 pub struct CliError {
     pub error: Box<CargoError>,
     pub unknown: bool,
@@ -300,7 +300,7 @@ pub fn internal_error<S1: Str, S2: Str>(error: S1,
     })
 }
 
-pub fn internal<S: fmt::String>(error: S) -> Box<CargoError> {
+pub fn internal<S: fmt::Display>(error: S) -> Box<CargoError> {
     Box::new(ConcreteCargoError {
         description: error.to_string(),
         detail: None,
@@ -309,7 +309,7 @@ pub fn internal<S: fmt::String>(error: S) -> Box<CargoError> {
     })
 }
 
-pub fn human<S: fmt::String>(error: S) -> Box<CargoError> {
+pub fn human<S: fmt::Display>(error: S) -> Box<CargoError> {
     Box::new(ConcreteCargoError {
         description: error.to_string(),
         detail: None,
@@ -318,7 +318,7 @@ pub fn human<S: fmt::String>(error: S) -> Box<CargoError> {
     })
 }
 
-pub fn caused_human<S: fmt::String, E: Error>(error: S, cause: E) -> Box<CargoError> {
+pub fn caused_human<S: fmt::Display, E: Error>(error: S, cause: E) -> Box<CargoError> {
     Box::new(ConcreteCargoError {
         description: error.to_string(),
         detail: None,

--- a/src/cargo/util/errors.rs
+++ b/src/cargo/util/errors.rs
@@ -36,7 +36,6 @@ impl fmt::Debug for Box<CargoError> {
 
 impl Error for Box<CargoError> {
     fn description(&self) -> &str { (**self).description() }
-    fn detail(&self) -> Option<String> { (**self).detail() }
     fn cause(&self) -> Option<&Error> { (**self).cause() }
 }
 
@@ -89,7 +88,12 @@ impl<T> ChainError<T> for Option<T> {
 
 impl<E: Error> Error for ChainedError<E> {
     fn description(&self) -> &str { self.error.description() }
-    fn detail(&self) -> Option<String> { self.error.detail() }
+}
+
+impl<E: fmt::Display> fmt::Display for ChainedError<E> {
+    fn fmt(&self, f: fmt::Formatter) {
+        fmt::Display::fmt(self.error, f)
+    }
 }
 
 impl<E: CargoError> CargoError for ChainedError<E> {
@@ -109,7 +113,6 @@ pub struct ProcessError {
 
 impl Error for ProcessError {
     fn description(&self) -> &str { self.desc.as_slice() }
-    fn detail(&self) -> Option<String> { None }
     fn cause(&self) -> Option<&Error> {
         self.cause.as_ref().map(|s| s as &Error)
     }
@@ -149,7 +152,6 @@ impl fmt::Debug for ConcreteCargoError {
 
 impl Error for ConcreteCargoError {
     fn description(&self) -> &str { self.description.as_slice() }
-    fn detail(&self) -> Option<String> { self.detail.clone() }
     fn cause(&self) -> Option<&Error> {
         self.cause.as_ref().map(|c| &**c)
     }
@@ -168,8 +170,13 @@ pub struct Human<E>(pub E);
 
 impl<E: Error> Error for Human<E> {
     fn description(&self) -> &str { self.0.description() }
-    fn detail(&self) -> Option<String> { self.0.detail() }
     fn cause(&self) -> Option<&Error> { self.0.cause() }
+}
+
+impl<E: fmt::Display> fmt::Display for Human<E> {
+    fn fmt(self, f: fmt::Formatter) {
+        fmt::Display::fmt(self.0, f)
+    }
 }
 
 impl<E: CargoError> CargoError for Human<E> {
@@ -191,8 +198,13 @@ pub struct CliError {
 
 impl Error for CliError {
     fn description(&self) -> &str { self.error.description() }
-    fn detail(&self) -> Option<String> { self.error.detail() }
     fn cause(&self) -> Option<&Error> { self.error.cause() }
+}
+
+impl fmt::Display for CliError {
+    fn fmt(self, f: fmt::Formatter) {
+        fmt::Display::fmt(self.error, f)
+    }
 }
 
 impl CliError {

--- a/src/cargo/util/graph.rs
+++ b/src/cargo/util/graph.rs
@@ -72,7 +72,7 @@ impl<N: Eq + Hash<Hasher> + Clone> Graph<N> {
     }
 }
 
-impl<N: fmt::Show + Eq + Hash<Hasher>> fmt::Show for Graph<N> {
+impl<N: fmt::Debug + Eq + Hash<Hasher>> fmt::Debug for Graph<N> {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         try!(writeln!(fmt, "Graph {{"));
 

--- a/src/cargo/util/process_builder.rs
+++ b/src/cargo/util/process_builder.rs
@@ -7,7 +7,7 @@ use std::path::BytesContainer;
 
 use util::{CargoResult, ProcessError, process_error};
 
-#[derive(Clone, PartialEq, Show)]
+#[derive(Clone, PartialEq, Debug)]
 pub struct ProcessBuilder {
     program: CString,
     args: Vec<CString>,
@@ -15,7 +15,7 @@ pub struct ProcessBuilder {
     cwd: Path,
 }
 
-impl fmt::String for ProcessBuilder {
+impl fmt::Display for ProcessBuilder {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         try!(write!(f, "`{}", String::from_utf8_lossy(self.program.as_bytes())));
 

--- a/src/cargo/util/profile.rs
+++ b/src/cargo/util/profile.rs
@@ -16,7 +16,7 @@ pub struct Profiler {
 
 fn enabled() -> bool { os::getenv("CARGO_PROFILE").is_some() }
 
-pub fn start<T: fmt::String>(desc: T) -> Profiler {
+pub fn start<T: fmt::Display>(desc: T) -> Profiler {
     if !enabled() { return Profiler { desc: String::new() } }
 
     PROFILE_STACK.with(|stack| stack.borrow_mut().push(time::precise_time_ns()));

--- a/src/cargo/util/toml.rs
+++ b/src/cargo/util/toml.rs
@@ -579,7 +579,7 @@ fn process_dependencies<F>(cx: &mut Context,
     Ok(())
 }
 
-#[derive(RustcDecodable, Show, Clone)]
+#[derive(RustcDecodable, Debug, Clone)]
 struct TomlTarget {
     name: String,
     crate_type: Option<Vec<String>>,
@@ -629,7 +629,7 @@ impl PathValue {
     }
 }
 
-impl fmt::Show for PathValue {
+impl fmt::Debug for PathValue {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             PathValue::String(ref s) => s.fmt(f),

--- a/src/registry/lib.rs
+++ b/src/registry/lib.rs
@@ -233,7 +233,7 @@ fn handle(response: result::Result<http::Response, curl::ErrCode>)
     Ok(body)
 }
 
-impl fmt::String for Error {
+impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             Error::NonUtf8Body => write!(f, "reponse body was not utf-8"),

--- a/src/registry/lib.rs
+++ b/src/registry/lib.rs
@@ -105,7 +105,7 @@ impl Registry {
     }
 
     pub fn add_owners(&mut self, krate: &str, owners: &[&str]) -> Result<()> {
-        let body = json::encode(&OwnersReq { users: owners });
+        let body = json::encode(&OwnersReq { users: owners }).unwrap();
         let body = try!(self.put(format!("/crates/{}/owners", krate),
                                  body.as_bytes()));
         assert!(json::decode::<R>(body.as_slice()).unwrap().ok);
@@ -113,7 +113,7 @@ impl Registry {
     }
 
     pub fn remove_owners(&mut self, krate: &str, owners: &[&str]) -> Result<()> {
-        let body = json::encode(&OwnersReq { users: owners });
+        let body = json::encode(&OwnersReq { users: owners }).unwrap();
         let body = try!(self.delete(format!("/crates/{}/owners", krate),
                                     Some(body.as_bytes())));
         assert!(json::decode::<R>(body.as_slice()).unwrap().ok);
@@ -126,7 +126,7 @@ impl Registry {
     }
 
     pub fn publish(&mut self, krate: &NewCrate, tarball: &Path) -> Result<()> {
-        let json = json::encode(krate);
+        let json = json::encode(krate).unwrap();
         // Prepare the body. The format of the upload request is:
         //
         //      <le u32 of json>

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -215,7 +215,7 @@ trait ErrMsg<T> {
     fn with_err_msg(self, val: String) -> Result<T, String>;
 }
 
-impl<T, E: fmt::String> ErrMsg<T> for Result<T, E> {
+impl<T, E: fmt::Display> ErrMsg<T> for Result<T, E> {
     fn with_err_msg(self, val: String) -> Result<T, String> {
         match self {
             Ok(val) => Ok(val),
@@ -383,7 +383,7 @@ fn zip_all<T, I1: Iterator<Item=T>, I2: Iterator<Item=T>>(a: I1, b: I2) -> ZipAl
     }
 }
 
-impl fmt::String for Execs {
+impl fmt::Display for Execs {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "execs")
     }
@@ -425,7 +425,7 @@ struct ShellWrites {
     expected: String
 }
 
-impl fmt::String for ShellWrites {
+impl fmt::Display for ShellWrites {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "`{}` written to the shell", self.expected)
     }
@@ -441,7 +441,7 @@ impl<'a> ham::Matcher<&'a [u8]> for ShellWrites {
     }
 }
 
-pub fn shell_writes<T: fmt::String>(string: T) -> ShellWrites {
+pub fn shell_writes<T: fmt::Display>(string: T) -> ShellWrites {
     ShellWrites { expected: string.to_string() }
 }
 


### PR DESCRIPTION
A story about how I just wanted to build fresh cargo.

Question about errors.rs: implementation of `fmt::Display` for `Box<CargoError>` uses `self.description()`, but `detail()` method uses `(**self).detail()`. Since `detail()` is deprecated in favor of `fmt::Display`, what exactly should be used?