### PR TITLE
when compiling cargo itself, pass --verbose to cargo when VERBOSE env is set

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -34,6 +34,12 @@ else
 OPT_FLAG=
 endif
 
+ifdef VERBOSE
+VERBOSE_FLAG=--verbose
+else
+VERBOSE_FLAG=
+endif
+
 export CFG_VERSION
 export CFG_DISABLE_CROSS_TESTS
 
@@ -70,10 +76,11 @@ all: $(foreach target,$(CFG_TARGET),cargo-$(target))
 define CARGO_TARGET
 cargo-$(1): $$(CARGO)
 	"$$(CFG_RUSTC)" -V
-	$$(CARGO) build --target $(1) $$(OPT_FLAG) $$(ARGS)
+	"$$(CARGO)" --version
+	$$(CARGO) build --target $(1) $$(OPT_FLAG) $$(VERBOSE_FLAG) $$(ARGS)
 
 test-unit-$(1): $$(CARGO)
-	$$(CARGO) test --target $(1) $$(only)
+	$$(CARGO) test --target $(1) $$(VERBOSE_FLAG) $$(only)
 endef
 $(foreach target,$(CFG_TARGET),$(eval $(call CARGO_TARGET,$(target))))
 


### PR DESCRIPTION
and also show that cargo's version after rustc's one

Closes #1216 

**EDIT:** I should have mentioned this is only when compiling cargo!
**EDIT2:**

**before:**
```
$ make
"/home/emacs/build/rust/x86_64-unknown-linux-gnu/stage2/bin/rustc" -V
rustc 1.0.0-dev (e5c1f166a 2015-01-24 05:12:15 +0000)
target/snapshot/bin/cargo build --target x86_64-unknown-linux-gnu  
An unknown error occurred

To learn more, run the command again with --verbose.
Makefile:78: recipe for target 'cargo-x86_64-unknown-linux-gnu' failed
make: *** [cargo-x86_64-unknown-linux-gnu] Error 101
```

**after:**
```
$ make VERBOSE=1
"/home/emacs/build/rust/x86_64-unknown-linux-gnu/stage2/bin/rustc" -V
rustc 1.0.0-dev (e5c1f166a 2015-01-24 05:12:15 +0000)
"target/snapshot/bin/cargo" --version
cargo 0.0.1-pre-nightly (26ac282 2014-12-30 00:13:39 +0000)
target/snapshot/bin/cargo build --target x86_64-unknown-linux-gnu  --verbose 
An unknown error occurred
Process didn't exit successfully: `rustc - --crate-name - --crate-type dylib --crate-type bin --print-file-name --target x86_64-unknown-linux-gnu` (status=101)
--- stderr
error: Unrecognized option: 'print-file-name'.

Makefile:85: recipe for target 'cargo-x86_64-unknown-linux-gnu' failed
make: *** [cargo-x86_64-unknown-linux-gnu] Error 101
```