### PR TITLE
Subcommand dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,6 +10,7 @@ dependencies = [
  "glob 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "hamcrest 0.1.0 (git+https://github.com/carllerche/hamcrest-rust.git)",
  "log 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "registry 0.1.0",
  "rustc-serialize 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ docopt = "0.6"
 url = "0.2"
 rustc-serialize = "0.2"
 term = "0.1"
+regex = "0.1"
 
 [target.i686-pc-windows-gnu.dependencies]
 winapi = "0.1"

--- a/src/bin/cargo.rs
+++ b/src/bin/cargo.rs
@@ -56,6 +56,7 @@ macro_rules! each_subcommand{ ($mac:ident) => ({
     $mac!(bench);
     $mac!(build);
     $mac!(clean);
+    $mac!(dependencies);
     $mac!(doc);
     $mac!(fetch);
     $mac!(generate_lockfile);

--- a/src/bin/dependencies.rs
+++ b/src/bin/dependencies.rs
@@ -1,0 +1,54 @@
+use std::os;
+use cargo::ops;
+use cargo::util::{CliResult, CliError, Config};
+use cargo::util::important_paths::find_root_manifest_for_cwd;
+
+#[derive(RustcDecodable)]
+struct Options {
+    flag_output_path: Option<String>,
+    flag_manifest_path: Option<String>,
+    flag_verbose: bool,
+}
+
+pub const USAGE: &'static str = "
+Output the resolved dependencies of a project, the concrete used versions
+including overrides, in a TOML format
+
+Usage:
+    cargo dependencies [options]
+
+Options:
+    -h, --help              Print this message
+    -o, --output-path PATH  Path the output is written to, otherwise stdout is used
+    --manifest-path PATH    Path to the manifest
+    -v, --verbose           Use verbose output
+
+The TOML format is e.g.:
+
+   [dependencies.libA]
+   version = \"0.1\",
+   path = '/home/user/.cargo/registry/src/github.com-1ecc6299db9ec823/libA-0.1'
+   dependencies = [\"libB\"]
+   
+   [dependencies.libB]
+   version = \"0.4\",
+   path = '/home/user/.cargo/registry/src/github.com-1ecc6299db9ec823/libB-0.4'
+   dependencies = []
+
+";
+
+pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
+    debug!("executing; cmd=cargo-dependencies; args={:?}", os::args());
+    config.shell().set_verbose(options.flag_verbose);
+
+    let manifest = try!(find_root_manifest_for_cwd(options.flag_manifest_path));
+
+    let out = options.flag_output_path
+        .map_or(ops::OutputTo::StdOut, |str| ops::OutputTo::Path(Path::new(str)));
+
+    let options = ops::OutputOptions { out: out, config: config };
+
+    ops::output_dependencies(&manifest, &options)
+        .map(|_| None)
+        .map_err(|err| CliError::from_boxed(err, 101))
+}

--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -29,12 +29,12 @@ use std::os;
 use std::sync::Arc;
 
 use core::registry::PackageRegistry;
-use core::{Source, SourceId, PackageSet, Package, Target, PackageId};
+use core::{Source, PackageSet, Package, Target, PackageId};
 use core::resolver::Method;
 use ops::{self, BuildOutput, ExecEngine};
 use sources::{PathSource};
 use util::config::Config;
-use util::{CargoResult, internal, human, ChainError, profile};
+use util::{CargoResult, human, ChainError, profile};
 
 /// Contains informations about how a package should be compiled.
 pub struct CompileOptions<'a, 'b: 'a> {
@@ -91,8 +91,8 @@ pub fn compile_pkg(package: &Package, options: &CompileOptions)
         return Err(human("jobs must be at least 1"))
     }
 
-    let override_ids = try!(source_ids_from_config(config,
-                                                   package.get_root()));
+    let override_ids = try!(ops::source_ids_from_config(config,
+                                                        package.get_root()));
 
     let (packages, resolve_with_overrides, sources) = {
         let rustc_host = config.rustc_host().to_string();
@@ -159,31 +159,6 @@ pub fn compile_pkg(package: &Package, options: &CompileOptions)
     };
 
     return Ok(ret);
-}
-
-fn source_ids_from_config(config: &Config, cur_path: Path)
-                          -> CargoResult<Vec<SourceId>> {
-
-    let configs = try!(config.values());
-    debug!("loaded config; configs={:?}", configs);
-    let config_paths = match configs.get("paths") {
-        Some(cfg) => cfg,
-        None => return Ok(Vec::new())
-    };
-    let paths = try!(config_paths.list().chain_error(|| {
-        internal("invalid configuration for the key `paths`")
-    }));
-
-    paths.iter().map(|&(ref s, ref p)| {
-        // The path listed next to the string is the config file in which the
-        // key was located, so we want to pop off the `.cargo/config` component
-        // to get the directory containing the `.cargo` folder.
-        p.dir_path().dir_path().join(s.as_slice())
-    }).filter(|p| {
-        // Make sure we don't override the local package, even if it's in the
-        // list of override paths.
-        cur_path != *p
-    }).map(|p| SourceId::for_path(&p)).collect()
 }
 
 fn scrape_build_config(config: &Config,

--- a/src/cargo/ops/cargo_output_dependencies.rs
+++ b/src/cargo/ops/cargo_output_dependencies.rs
@@ -1,0 +1,159 @@
+use std::io;
+use std::collections::HashMap;
+use std::collections::hash_map::Entry::{Occupied, Vacant};
+use util::{CargoResult, profile};
+use util::config::Config;
+use core::{Source, SourceId, PackageId};
+use core::registry::PackageRegistry;
+use core::resolver::{Resolve, Method};
+use sources::PathSource;
+use ops;
+
+#[derive(Eq, PartialEq)]
+/// Where the dependencies should be written to.
+pub enum OutputTo {
+    Path(Path),
+    StdOut
+}
+
+pub struct OutputOptions<'a, 'b: 'a> {
+    pub out: OutputTo,
+    pub config: &'a Config<'b>
+}
+
+/// Loads the manifest, resolves the dependencies of the project to the concrete
+/// used versions - considering overrides - and writes all dependencies in a TOML
+/// format to stdout or the specified file.
+///
+/// The TOML format is e.g.:
+///
+///     [dependencies.libA]
+///     version = "0.1",
+///     path = '/home/user/.cargo/registry/src/github.com-1ecc6299db9ec823/libA-0.1'
+///     dependencies = ["libB"]
+///
+///     [dependencies.libB]
+///     version = "0.4",
+///     path = '/home/user/.cargo/registry/src/github.com-1ecc6299db9ec823/libB-0.4'
+///     dependencies = []
+///
+pub fn output_dependencies(manifest: &Path, options: &OutputOptions) -> CargoResult<()> {
+    let OutputOptions { ref out, config } = *options;
+    let resolved_deps = try!(resolve_dependencies(manifest, config));
+    let src_paths = try!(source_paths(&resolved_deps, config));
+
+    struct Dependency {
+        name: String,
+        version: String,
+        path: Path,
+        dependencies: Vec<String>
+    };
+
+    let mut dependencies: Vec<Dependency> = Vec::new();
+
+    for (package_id, src_path) in src_paths.iter() {
+        if *package_id == *resolved_deps.root() {
+            continue;
+        }
+
+        let mut dependency = Dependency {
+            name: package_id.get_name().to_string(),
+            version: format!("{}", package_id.get_version()),
+            path: src_path.clone(),
+            dependencies: Vec::new()
+        };
+
+        if let Some(mut dep_deps) = resolved_deps.deps(package_id) {
+            for dep_dep in dep_deps {
+                dependency.dependencies.push(dep_dep.get_name().to_string());
+            }
+        }
+
+        dependencies.push(dependency);
+    }
+
+    let mut toml_str = String::new();
+
+    for dep in dependencies.iter() {
+        toml_str.push_str(format!("\n[dependencies.{}]\n", dep.name).as_slice());
+        toml_str.push_str(format!("version = \"{}\"\n", dep.version).as_slice());
+        toml_str.push_str(format!("path = '{:?}'\n", dep.path).as_slice());
+        toml_str.push_str(format!("dependencies = {:?}\n", dep.dependencies).as_slice());
+    }
+
+    match *out {
+        OutputTo::StdOut         => println!("{}", toml_str),
+        OutputTo::Path(ref path) => {
+            let mut file = try!(io::File::open_mode(path, io::Truncate, io::ReadWrite));
+            try!(file.write_str(toml_str.as_slice()));
+        }
+    }
+
+    Ok(())
+}
+
+/// Returns the source path for each `PackageId` in `Resolve`.
+fn source_paths(resolve: &Resolve, config: &Config) -> CargoResult<HashMap<PackageId, Path>> {
+    let package_ids: Vec<&PackageId> = resolve.iter().collect();
+    let mut source_id_to_package_ids: HashMap<&SourceId, Vec<PackageId>> = HashMap::new();
+
+    // group PackageId by SourceId
+    for package_id in package_ids.iter() {
+        match source_id_to_package_ids.entry(package_id.get_source_id()) {
+            Occupied(mut entry) => entry.get_mut().push((*package_id).clone()),
+            Vacant(entry)       => { entry.insert(vec![(*package_id).clone()]); }
+        }
+    }
+
+    let mut package_id_to_path: HashMap<PackageId, Path> = HashMap::new();
+
+    for (mut source_id, ref package_ids) in source_id_to_package_ids.iter() {
+        let mut source = source_id.load(config);
+        try!(source.update());
+        try!(source.download(package_ids.as_slice()));
+        let packages = try!(source.get(package_ids.as_slice()));
+
+        for package in packages.iter() {
+            match package_id_to_path.entry(package.get_package_id().clone()) {
+                Occupied(_)   => {},
+                Vacant(entry) => { entry.insert(package.get_root()); }
+            }
+        }
+    }
+
+    Ok(package_id_to_path)
+}
+
+/// Loads the manifest and resolves the dependencies of the project to the
+/// concrete used versions. Afterwards available overrides of dependencies are applied.
+fn resolve_dependencies(manifest: &Path, config: &Config) -> CargoResult<Resolve> {
+    let mut source = try!(PathSource::for_path(&manifest.dir_path(), config));
+    try!(source.update());
+
+    let package = try!(source.get_root_package());
+    debug!("loaded package; package={}", package);
+
+    for key in package.get_manifest().get_warnings().iter() {
+        try!(config.shell().warn(key))
+    }
+
+    let override_ids = try!(ops::source_ids_from_config(config, package.get_root()));
+    let rustc_host = config.rustc_host().to_string();
+    let mut registry = PackageRegistry::new(config);
+
+    // First, resolve the package's *listed* dependencies, as well as
+    // downloading and updating all remotes and such.
+    let resolved = try!(ops::resolve_pkg(&mut registry, &package));
+
+    // Second, resolve with precisely what we're doing. Filter out
+    // transitive dependencies if necessary, specify features, handle
+    // overrides, etc.
+    let _p = profile::start("resolving w/ overrides...");
+
+    try!(registry.add_overrides(override_ids));
+
+    let platform = Some(rustc_host.as_slice());
+    let method = Method::Required(false, &[], true, platform);
+
+    ops::resolve_with_previous(&mut registry, &package, method, Some(&resolved), None)
+}

--- a/src/cargo/ops/mod.rs
+++ b/src/cargo/ops/mod.rs
@@ -30,6 +30,7 @@ mod cargo_doc;
 mod cargo_fetch;
 mod cargo_generate_lockfile;
 mod cargo_new;
+mod cargo_output_dependencies;
 mod cargo_package;
 mod cargo_pkgid;
 mod cargo_read_manifest;

--- a/src/cargo/ops/mod.rs
+++ b/src/cargo/ops/mod.rs
@@ -21,7 +21,8 @@ pub use self::registry::{registry_login, search, http_proxy, http_handle};
 pub use self::registry::{modify_owners, yank, OwnersOptions};
 pub use self::cargo_fetch::{fetch};
 pub use self::cargo_pkgid::pkgid;
-pub use self::resolve::{resolve_pkg, resolve_with_previous};
+pub use self::resolve::{resolve_pkg, resolve_with_previous, source_ids_from_config};
+pub use self::cargo_output_dependencies::{output_dependencies, OutputTo, OutputOptions};
 
 mod cargo_clean;
 mod cargo_compile;

--- a/src/cargo/ops/resolve.rs
+++ b/src/cargo/ops/resolve.rs
@@ -4,7 +4,8 @@ use core::{Package, PackageId, SourceId};
 use core::registry::PackageRegistry;
 use core::resolver::{self, Resolve, Method};
 use ops;
-use util::CargoResult;
+use util::{CargoResult, ChainError, internal};
+use util::config::Config;
 
 /// Resolve all dependencies for the specified `package` using the previous
 /// lockfile as a guide if present.
@@ -121,4 +122,27 @@ pub fn resolve_with_previous<'a>(registry: &mut PackageRegistry,
             None => true,
         }
     }
+}
+
+pub fn source_ids_from_config(config: &Config, cur_path: Path) -> CargoResult<Vec<SourceId>> {
+    let configs = try!(config.values());
+    debug!("loaded config; configs={:?}", configs);
+    let config_paths = match configs.get("paths") {
+        Some(cfg) => cfg,
+        None => return Ok(Vec::new())
+    };
+    let paths = try!(config_paths.list().chain_error(|| {
+        internal("invalid configuration for the key `paths`")
+    }));
+
+    paths.iter().map(|&(ref s, ref p)| {
+        // The path listed next to the string is the config file in which the
+        // key was located, so we want to pop off the `.cargo/config` component
+        // to get the directory containing the `.cargo` folder.
+        p.dir_path().dir_path().join(s.as_slice())
+    }).filter(|p| {
+        // Make sure we don't override the local package, even if it's in the
+        // list of override paths.
+        cur_path != *p
+    }).map(|p| SourceId::for_path(&p)).collect()
 }


### PR DESCRIPTION
The subcommand dependencies outputs the resolved dependencies
of a project, the concrete used versions including overrides,
in a TOML format.