### PR TITLE
Add explicit dependency on regex.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,6 +10,7 @@ dependencies = [
  "glob 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "hamcrest 0.1.0 (git+https://github.com/carllerche/hamcrest-rust.git)",
  "log 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "registry 0.1.0",
  "rustc-serialize 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ docopt = "0.6"
 url = "0.2"
 rustc-serialize = "0.2"
 term = "0.1"
+regex = "0.1"
 
 [target.i686-pc-windows-gnu.dependencies]
 winapi = "0.1"


### PR DESCRIPTION
Fixes the following issue while building Cargo
```
   Compiling cargo v0.1.0 (file:///C:/msys64/home/Peter/cargo)
src\cargo\lib.rs:7:1: 7:20 error: can't find crate for `regex`
src\cargo\lib.rs:7 extern crate regex;
                   ^~~~~~~~~~~~~~~~~~~
error: aborting due to previous error
Could not compile `cargo`.
```