### PR TITLE
Consider all targets for platform requirements

### DIFF
--- a/src/cargo/ops/cargo_rustc/context.rs
+++ b/src/cargo/ops/cargo_rustc/context.rs
@@ -360,7 +360,7 @@ impl<'a, 'b: 'a> Context<'a, 'b> {
 }
 
 impl Platform {
-    fn combine(self, other: Platform) -> Platform {
+    pub fn combine(self, other: Platform) -> Platform {
         match (self, other) {
             (Platform::Target, Platform::Target) => Platform::Target,
             (Platform::Plugin, Platform::Plugin) => Platform::Plugin,

--- a/tests/test_cargo_compile_plugins.rs
+++ b/tests/test_cargo_compile_plugins.rs
@@ -165,3 +165,25 @@ test!(plugin_with_dynamic_native_dependency {
     assert_that(foo.cargo_process("build").env("SRC", Some(lib.as_vec())),
                 execs().with_status(0));
 });
+
+test!(plugin_integration {
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [package]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+            build = "build.rs"
+
+            [lib]
+            name = "foo"
+            plugin = true
+            doctest = false
+        "#)
+        .file("build.rs", "fn main() {}")
+        .file("src/lib.rs", "")
+        .file("tests/it_works.rs", "");
+
+    assert_that(p.cargo_process("test"),
+                execs().with_status(0));
+});

--- a/tests/test_cargo_cross_compile.rs
+++ b/tests/test_cargo_cross_compile.rs
@@ -652,3 +652,30 @@ test!(build_script_only_host {
     assert_that(p.cargo_process("build").arg("--target").arg(&target).arg("-v"),
                 execs().with_status(0));
 });
+
+test!(plugin_build_script_right_arch {
+    if disabled() { return }
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [package]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+            build = "build.rs"
+
+            [lib]
+            name = "foo"
+            plugin = true
+        "#)
+        .file("build.rs", "fn main() {}")
+        .file("src/lib.rs", "");
+
+    assert_that(p.cargo_process("build").arg("-v").arg("--target").arg(alternate()),
+                execs().with_status(0)
+                       .with_stdout(format!("\
+{compiling} foo v0.0.1 ([..])
+{running} `rustc build.rs [..]`
+{running} `[..]build-script-build[..]`
+{running} `rustc src[..]lib.rs [..]`
+", compiling = COMPILING, running = RUNNING)));
+});


### PR DESCRIPTION
Previously a build script would assign itself to the platform requirement for
the first target of a package, but it's more correct to consider all targets for
platform requirements as there may be both a plugin and target requirement.

Closes #1239 
