### PR TITLE
Don't require all submodules are checked out

### DIFF
--- a/src/cargo/sources/path.rs
+++ b/src/cargo/sources/path.rs
@@ -155,7 +155,10 @@ impl<'a, 'b> PathSource<'a, 'b> {
                     human(format!("invalid utf-8 filename: {}", rel.display()))
                 }));
                 let submodule = try!(repo.find_submodule(rel));
-                let repo = try!(submodule.open());
+                let repo = match submodule.open() {
+                    Ok(repo) => repo,
+                    Err(..) => continue,
+                };
                 let files = try!(self.list_files_git(pkg, repo, filter));
                 ret.extend(files.into_iter());
             } else if (*filter)(&file_path) {


### PR DESCRIPTION
When probing a repository for files that should be considered as inputs for a
build script we should just skip submodules that haven't been checked out
instead of throwing an error.

Closes #1248