### PR TITLE
Add a flag to force resolution of a fingerprint

### DIFF
--- a/tests/test_cargo_compile_path_deps.rs
+++ b/tests/test_cargo_compile_path_deps.rs
@@ -1,4 +1,5 @@
-use std::old_io::{fs, File, USER_RWX};
+use std::old_io::{fs, File, USER_RWX, timer};
+use std::time::Duration;
 
 use support::{project, execs, main_file, cargo_dir};
 use support::{COMPILING, RUNNING};
@@ -353,7 +354,7 @@ test!(deep_dependencies_trigger_rebuild {
     //
     // We base recompilation off mtime, so sleep for at least a second to ensure
     // that this write will change the mtime.
-    p.root().move_into_the_past().unwrap();
+    timer::sleep(Duration::seconds(1));
     File::create(&p.root().join("baz/src/baz.rs")).write_str(r#"
         pub fn baz() { println!("hello!"); }
     "#).unwrap();
@@ -366,7 +367,7 @@ test!(deep_dependencies_trigger_rebuild {
                                             COMPILING, p.url())));
 
     // Make sure an update to bar doesn't trigger baz
-    p.root().move_into_the_past().unwrap();
+    timer::sleep(Duration::seconds(1));
     File::create(&p.root().join("bar/src/bar.rs")).write_str(r#"
         extern crate baz;
         pub fn bar() { println!("hello!"); baz::baz(); }

--- a/tests/test_cargo_freshness.rs
+++ b/tests/test_cargo_freshness.rs
@@ -135,3 +135,40 @@ test!(rebuild_sub_package_then_while_package {
     assert_that(p.process(cargo_dir().join("cargo")).arg("build"),
                 execs().with_status(0));
 });
+
+test!(changing_features_is_ok {
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [package]
+            name = "foo"
+            authors = []
+            version = "0.0.1"
+
+            [features]
+            foo = []
+        "#)
+        .file("src/lib.rs", "");
+
+    assert_that(p.cargo_process("build"),
+                execs().with_status(0)
+                       .with_stdout("\
+[..]Compiling foo v0.0.1 ([..])
+"));
+
+    assert_that(p.process(cargo_dir().join("cargo")).arg("build")
+                 .arg("--features").arg("foo"),
+                execs().with_status(0)
+                       .with_stdout("\
+[..]Compiling foo v0.0.1 ([..])
+"));
+
+    assert_that(p.process(cargo_dir().join("cargo")).arg("build"),
+                execs().with_status(0)
+                       .with_stdout("\
+[..]Compiling foo v0.0.1 ([..])
+"));
+
+    assert_that(p.process(cargo_dir().join("cargo")).arg("build"),
+                execs().with_status(0)
+                       .with_stdout(""));
+});


### PR DESCRIPTION
Previously if a fingerprint was considered fresh based on mtime, it would not
get updated once a compilation finished with the new precise fingerprint (it
would use the older fingerprint). This alters the `resolve` method to take a
flag which disables this behavior and forces looking at the filesystem for a
fingerprint.

Closes #1259