### PR TITLE
Remove auto-cleaning of the build directory

### DIFF
--- a/src/cargo/ops/cargo_rustc/fingerprint.rs
+++ b/src/cargo/ops/cargo_rustc/fingerprint.rs
@@ -46,7 +46,6 @@ pub fn prepare_target<'a, 'b>(cx: &mut Context<'a, 'b>,
                                     pkg.get_package_id(), target));
     let new = dir(cx, pkg, kind);
     let loc = new.join(filename(target));
-    cx.layout(pkg, kind).proxy().whitelist(&loc);
 
     info!("fingerprint at: {}", loc.display());
 
@@ -58,7 +57,6 @@ pub fn prepare_target<'a, 'b>(cx: &mut Context<'a, 'b>,
     if !target.get_profile().is_doc() {
         for filename in try!(cx.target_filenames(target)).iter() {
             let dst = root.join(filename);
-            cx.layout(pkg, kind).proxy().whitelist(&dst);
             missing_outputs |= !dst.exists();
 
             if target.get_profile().is_test() {
@@ -236,7 +234,6 @@ pub fn prepare_build_cmd(cx: &mut Context, pkg: &Package, kind: Kind,
                                     pkg.get_package_id()));
     let new = dir(cx, pkg, kind);
     let loc = new.join("build");
-    cx.layout(pkg, kind).proxy().whitelist(&loc);
 
     info!("fingerprint at: {}", loc.display());
 
@@ -305,9 +302,7 @@ pub fn dir(cx: &Context, pkg: &Package, kind: Kind) -> Path {
 /// Returns the (old, new) location for the dep info file of a target.
 pub fn dep_info_loc(cx: &Context, pkg: &Package, target: &Target,
                     kind: Kind) -> Path {
-    let ret = dir(cx, pkg, kind).join(format!("dep-{}", filename(target)));
-    cx.layout(pkg, kind).proxy().whitelist(&ret);
-    return ret;
+    dir(cx, pkg, kind).join(format!("dep-{}", filename(target)))
 }
 
 fn is_fresh(loc: &Path, new_fingerprint: &Fingerprint) -> CargoResult<bool> {

--- a/src/cargo/ops/cargo_rustc/mod.rs
+++ b/src/cargo/ops/cargo_rustc/mod.rs
@@ -183,10 +183,6 @@ pub fn compile_targets<'a, 'b>(env: &str,
 
     try!(compile(targets, pkg, true, &mut cx, &mut queue));
 
-    // Clean out any old files sticking around in directories.
-    try!(cx.layout(pkg, Kind::Host).proxy().clean());
-    try!(cx.layout(pkg, Kind::Target).proxy().clean());
-
     // Now that we've figured out everything that we're going to do, do it!
     try!(queue.execute(cx.config));
 

--- a/tests/test_cargo_compile_path_deps.rs
+++ b/tests/test_cargo_compile_path_deps.rs
@@ -1,4 +1,5 @@
-use std::old_io::{fs, File, USER_RWX};
+use std::old_io::{fs, File, USER_RWX, timer};
+use std::time::Duration;
 
 use support::{project, execs, main_file, cargo_dir};
 use support::{COMPILING, RUNNING};
@@ -353,7 +354,7 @@ test!(deep_dependencies_trigger_rebuild {
     //
     // We base recompilation off mtime, so sleep for at least a second to ensure
     // that this write will change the mtime.
-    p.root().move_into_the_past().unwrap();
+    timer::sleep(Duration::seconds(1));
     File::create(&p.root().join("baz/src/baz.rs")).write_str(r#"
         pub fn baz() { println!("hello!"); }
     "#).unwrap();
@@ -366,7 +367,7 @@ test!(deep_dependencies_trigger_rebuild {
                                             COMPILING, p.url())));
 
     // Make sure an update to bar doesn't trigger baz
-    p.root().move_into_the_past().unwrap();
+    timer::sleep(Duration::seconds(1));
     File::create(&p.root().join("bar/src/bar.rs")).write_str(r#"
         extern crate baz;
         pub fn bar() { println!("hello!"); baz::baz(); }

--- a/tests/test_cargo_test.rs
+++ b/tests/test_cargo_test.rs
@@ -1311,3 +1311,24 @@ test!(example_with_dev_dep {
 {running} `rustc [..] --crate-name ex [..] --extern a=[..]`
 ", running = RUNNING).as_slice()));
 });
+
+test!(bin_is_preserved {
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [package]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+        "#)
+        .file("src/lib.rs", "")
+        .file("src/main.rs", "fn main() {}");
+
+    assert_that(p.cargo_process("build").arg("-v"),
+                execs().with_status(0));
+    assert_that(&p.bin("foo"), existing_file());
+
+    println!("testing");
+    assert_that(p.process(cargo_dir().join("cargo")).arg("test").arg("-v"),
+                execs().with_status(0));
+    assert_that(&p.bin("foo"), existing_file());
+});


### PR DESCRIPTION
Over time this functionality has become obsolete through other means. Due to the
usage of `-L dependency=foo` it's not possible to pick up stale dependencies by
accident, and due to `--extern` you can only pick up a dependency. All of the
cases that auto-cleaning was fixing are now fixed through other methods, so
there's not much use ensuring a "clean build directory" any more.

This has the benefit of fixing issues like #961 where the downside of long
compiles outweighs the benefits of a "let's pretend we started from scratch"
build.

Closes #961