### PR TITLE
Set build script env vars correctly

### DIFF
--- a/src/cargo/ops/cargo_rustc/custom_build.rs
+++ b/src/cargo/ops/cargo_rustc/custom_build.rs
@@ -50,8 +50,13 @@ pub fn prepare(pkg: &Package, target: &Target, req: Platform,
     let to_exec = script_output.join(to_exec);
 
     // Start preparing the process to execute, starting out with some
-    // environment variables.
-    let profile = target.profile();
+    // environment variables. Note that the profile-related environment
+    // variables are not set with this the build script's profile but rather the
+    // package's profile (some target which isn't a build script).
+    let profile_target = pkg.targets().iter().find(|t| {
+        cx.is_relevant_target(t) && !t.profile().is_custom_build()
+    }).unwrap_or(target);
+    let profile = cx.profile(profile_target);
     let to_exec = CString::from_slice(to_exec.as_vec());
     let p = try!(super::process(CommandType::Host(to_exec), pkg, target, cx));
     let mut p = p.env("OUT_DIR", Some(&build_output))

--- a/tests/test_cargo_compile_custom_build.rs
+++ b/tests/test_cargo_compile_custom_build.rs
@@ -1077,3 +1077,26 @@ test!(build_script_with_dynamic_native_dependency {
     assert_that(foo.cargo_process("build").env("SRC", Some(lib.as_vec())),
                 execs().with_status(0));
 });
+
+test!(profile_and_opt_level_set_correctly {
+    let build = project("builder")
+        .file("Cargo.toml", r#"
+            [package]
+            name = "builder"
+            version = "0.0.1"
+            authors = []
+            build = "build.rs"
+        "#)
+        .file("src/lib.rs", "")
+        .file("build.rs", r#"
+              use std::env;
+
+              fn main() {
+                  assert_eq!(env::var("OPT_LEVEL").unwrap(), "3");
+                  assert_eq!(env::var("PROFILE").unwrap(), "bench");
+                  assert_eq!(env::var("DEBUG").unwrap(), "false");
+              }
+        "#);
+    assert_that(build.cargo_process("bench"),
+                execs().with_status(0));
+});


### PR DESCRIPTION
Previously the build script's profile was used instead of the target's build
script, causing the wrong environment variables to get set.

Closes #1058