### PR TITLE
Prompt for password if needed

### DIFF
--- a/src/cargo/sources/git/utils.rs
+++ b/src/cargo/sources/git/utils.rs
@@ -1,5 +1,5 @@
 use std::fmt::{self, Formatter};
-use std::old_io::{USER_DIR};
+use std::old_io::{USER_DIR, stdout, stdin};
 use std::old_io::fs::{mkdir_recursive, rmdir_recursive, PathExtensions};
 use rustc_serialize::{Encodable, Encoder};
 use url::Url;
@@ -340,6 +340,22 @@ impl<'a> GitCheckout<'a> {
     }
 }
 
+fn prompt_for_password(username: Option<&str>)->(String, String) {
+    let mut stdout = stdout();
+    let mut stdin = stdin();
+    let username = match username {
+        Some(x) => x.to_string(),
+        _ => {
+            stdout.write_str("Enter username:").unwrap();
+            stdout.flush().unwrap();
+            stdin.read_line().unwrap().trim().to_string()
+        }
+    };
+    stdout.write_str(&*format!("Enter password for {}:", &username)).unwrap();
+    stdout.flush().unwrap();
+    (username, stdin.read_line().unwrap().trim().to_string())
+}
+
 fn with_authentication<T, F>(url: &str, cfg: &git2::Config, mut f: F)
                              -> CargoResult<T>
     where F: FnMut(&mut git2::Credentials) -> CargoResult<T>
@@ -371,7 +387,13 @@ fn with_authentication<T, F>(url: &str, cfg: &git2::Config, mut f: F)
                                .unwrap_or("git".to_string());
             git2::Cred::ssh_key_from_agent(&user)
         } else if allowed.contains(git2::USER_PASS_PLAINTEXT) {
-            git2::Cred::credential_helper(cfg, url, username)
+            match git2::Cred::credential_helper(cfg, url, username) {
+                Err(_) => {
+                    let (username, password) = prompt_for_password(username);
+                    git2::Cred::userpass_plaintext(&username, &password)
+                },
+                x => x
+            }
         } else if allowed.contains(git2::DEFAULT) {
             git2::Cred::default()
         } else {

--- a/src/cargo/sources/git/utils.rs
+++ b/src/cargo/sources/git/utils.rs
@@ -351,7 +351,7 @@ fn prompt_for_password(username: Option<&str>)->(String, String) {
             stdin.read_line().unwrap().trim().to_string()
         }
     };
-    stdout.write_str(&*format!("Enter password for {}:", &username)).unwrap();
+    stdout.write_str(&format!("Enter password for {}:", &username)).unwrap();
     stdout.flush().unwrap();
     (username, stdin.read_line().unwrap().trim().to_string())
 }


### PR DESCRIPTION
Try to fix https://github.com/rust-lang/cargo/issues/1306
This cannot be merged now, since it don't hide password because I cannot find a cross-platform way to do it using std library or `crates.io`. (rpassword don't build on Windows because of the dependency to termios)

https://github.com/jeaye/ncurses-rs seems close to work on Windows, maybe we could make a new crate that handle password input through ncurses-rs. BTW, ncurses-rs isn't on crates.io (yet).

And after all, maybe the whole idea about prompting on `cargo update` is wrong.

So I make this PR mainly for help and revise.
