### PR TITLE
Explicitly set curl proxy settings only when necessary

### DIFF
--- a/src/bin/cargo.rs
+++ b/src/bin/cargo.rs
@@ -255,8 +255,8 @@ fn init_git_transports(config: &Config) {
     // Only use a custom transport if a proxy is configured, right now libgit2
     // doesn't support proxies and we have to use a custom transport in this
     // case. The custom transport, however, is not as well battle-tested.
-    match cargo::ops::http_proxy(config) {
-        Ok(Some(..)) => {}
+    match cargo::ops::http_proxy_exists(config) {
+        Ok(true) => {}
         _ => return
     }
 

--- a/src/cargo/ops/mod.rs
+++ b/src/cargo/ops/mod.rs
@@ -17,7 +17,7 @@ pub use self::lockfile::{write_lockfile, write_pkg_lockfile};
 pub use self::cargo_test::{run_tests, run_benches, TestOptions};
 pub use self::cargo_package::package;
 pub use self::registry::{publish, registry_configuration, RegistryConfig};
-pub use self::registry::{registry_login, search, http_proxy, http_handle};
+pub use self::registry::{registry_login, search, http_proxy_exists, http_handle};
 pub use self::registry::{modify_owners, yank, OwnersOptions};
 pub use self::cargo_fetch::{fetch};
 pub use self::cargo_pkgid::pkgid;


### PR DESCRIPTION
Currently, cargo uses `curl_easy_setopt` to explicitly set the http proxy on a curl handle if any of the following are present:

* cargo config `http.proxy`
* git config `http.proxy`
* `HTTP_PROXY` environment variable

The act of explicitly setting the http proxy disables curl's logic for determining which proxy to use for a URL, and breaks the `no_proxy` environment variable. This PR privatizes `cargo::ops::registry::http_proxy` and adds an additional function `cargo::ops::registry::http_proxy_exists` to determine whether or not to use the `git2-curl` subtransport.