### PR TITLE
Ensure --release examples are classified as benchmarks

### DIFF
--- a/src/bin/run.rs
+++ b/src/bin/run.rs
@@ -50,7 +50,8 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
     let root = try!(find_root_manifest_for_cwd(options.flag_manifest_path));
 
     let env = match (options.flag_release, options.flag_example.is_some()) {
-        (true, _) => "release",
+        (true, true) => "bench",
+        (true, false) => "release",
         (false, true) => "test",
         (false, false) => "compile"
     };

--- a/src/cargo/util/toml.rs
+++ b/src/cargo/util/toml.rs
@@ -791,7 +791,8 @@ fn normalize(libs: &[TomlLibTarget],
             let path = ex.path.clone().unwrap_or_else(|| PathValue::String(default(ex)));
 
             let profile = merge(Profile::default_example(), &profiles.test);
-            let profile_release = merge(Profile::default_release(), &profiles.release);
+            let profile_release = merge(Profile::default_bench(),
+                                        &profiles.bench);
             dst.push(Target::example_target(&ex.name,
                                             &path.to_path(),
                                             &profile));

--- a/tests/test_cargo_test.rs
+++ b/tests/test_cargo_test.rs
@@ -1154,7 +1154,7 @@ test!(example_dev_dep {
         .file("bar/src/lib.rs", r#"
             #![feature(macro_rules)]
             // make sure this file takes awhile to compile
-            macro_rules! f0( () => (1u) );
+            macro_rules! f0( () => (1) );
             macro_rules! f1( () => ({(f0!()) + (f0!())}) );
             macro_rules! f2( () => ({(f1!()) + (f1!())}) );
             macro_rules! f3( () => ({(f2!()) + (f2!())}) );
@@ -1171,6 +1171,9 @@ test!(example_dev_dep {
             }
         "#);
     assert_that(p.cargo_process("test"),
+                execs().with_status(0));
+    assert_that(p.process(cargo_dir().join("cargo")).arg("run")
+                 .arg("--example").arg("e1").arg("--release").arg("-v"),
                 execs().with_status(0));
 });
 


### PR DESCRIPTION
This puts them in the right spot of the dependency graph to be only available
after all dev-dependencies have been compiled.

Closes #1323