### PR TITLE
Pass full cargo command to subcommand

### DIFF
--- a/src/bin/cargo.rs
+++ b/src/bin/cargo.rs
@@ -164,7 +164,7 @@ fn execute_subcommand(cmd: &str, args: &[String], shell: &mut MultiShell) {
         }
     };
     let status = Command::new(command)
-                         .args(args)
+                         .args(&args[1..])
                          .stdin(InheritFd(0))
                          .stdout(InheritFd(1))
                          .stderr(InheritFd(2))


### PR DESCRIPTION
This reverts a change from ee5e24ff8b5.

Before it passed "foo" as `argv[0]`, which does not help much (consider the case there is one script symlinked to different names to handle different things).

This patch changes that to `cargo-{command}`. 

It also reverts the passing of "foo" on the help command. Before it used `os::arg`, a different (and ugly) solution would be:

    let args = &[env::args().next().unwrap().clone(), "-h".to_string()];
