### PR TITLE
Add "Cargo" to documentation page titles

### DIFF
--- a/src/doc/build-script.md
+++ b/src/doc/build-script.md
@@ -1,4 +1,4 @@
-% Build Script Support
+% Build Script Support - Cargo Documentation
 
 Some packages need to compile third-party non-Rust code, for example C
 libraries. Other packages need to link to C libraries which can either be

--- a/src/doc/config.md
+++ b/src/doc/config.md
@@ -1,4 +1,4 @@
-% Configuration
+% Configuration - Cargo Documentation
 
 This document will explain how cargo's configuration system works, as well as
 available keys or configuration.  For configuration of a project through its

--- a/src/doc/faq.md
+++ b/src/doc/faq.md
@@ -1,4 +1,4 @@
-% Frequently Asked Questions
+% Frequently Asked Questions - Cargo Documentation
 
 # Is the plan to use Github as a package repository?
 

--- a/src/doc/guide.md
+++ b/src/doc/guide.md
@@ -1,4 +1,4 @@
-% Guide
+% Cargo Guide
 
 Welcome to the Cargo guide. This guide will give you all that you need to know
 about how to use Cargo to develop Rust projects.

--- a/src/doc/manifest.md
+++ b/src/doc/manifest.md
@@ -1,4 +1,4 @@
-% The Manifest Format
+% The Manifest Format - Cargo Documentation
 
 # The `[package]` Section
 

--- a/src/doc/pkgid-spec.md
+++ b/src/doc/pkgid-spec.md
@@ -1,4 +1,4 @@
-% Package ID Specifications
+% Package ID Specifications - Cargo Documentation
 
 # Package ID Specifications
 


### PR DESCRIPTION
This should make them easier to find via search engines, or in browser history/bookmarks.

See #1302 for an old version of this PR.