### PR TITLE
docs: Improve grammar/wording for `cargo owner`

### DIFF
--- a/src/doc/config.md
+++ b/src/doc/config.md
@@ -23,9 +23,11 @@ with a configuration file in your home directory.
 
 # Configuration Format
 
-All configuration is currently in the TOML format (like the manifest), with
-simple key-value pairs inside of sections (tables) which all get merged
+All configuration is currently in the [TOML format][toml] (like the manifest),
+with simple key-value pairs inside of sections (tables) which all get merged
 together.
+
+[toml]: https://github.com/toml-lang/toml
 
 # Configuration keys
 

--- a/src/doc/crates-io.md
+++ b/src/doc/crates-io.md
@@ -174,9 +174,9 @@ Be sure to check out the [metadata you can
 specify](manifest.html#package-metadata) to ensure your crate can be discovered
 more easily!
 
-## Limitations
+## Restrictions
 
-There are a few limitations when publish a crate in the registry:
+There are a few restrictions when publishing a crate in the registry:
 
 * Once a version is uploaded, it can never be overwritten. To upload a new copy
   of a crate you must upload a new version.
@@ -192,19 +192,19 @@ to manage a crate.
 
 ## `cargo owner`
 
-A crate is often not developed by only one person, or perhaps the main developer
-changes over time! The owners of a crate is the only person allowed to publish
-new versions of the crate, but owners may also add other owners! This subcommand
-allows you to allow others to publish new versions as well as add new owners
-themselves:
+A crate is often developed by more than one person, or the primary maintainer
+may change over time! The owner of a crate is the only person allowed to publish
+new versions of the crate, but an owner may designate additional owners. Using
+this subcommand, an owner allows others to publish new versions, as well as to
+manage the list of owners themselves:
 
 ```notrust
 $ cargo owner --add my-buddy
 $ cargo owner --remove my-buddy
 ```
 
-The logins specified are the GitHub logins used by the user in question. The
-owner being added must also already have logged into crates.io previously.
+The owner IDs given to these commands must be GitHub user names. In order to be
+added, an owner must have also logged into crates.io previously.
 
 ## `cargo yank`
 


### PR DESCRIPTION
While reading through the docs, this section broke my concentration even though the functionality's purpose is fairly obvious, because of a grammatical agreement problem and some redundant/wordy terms. I hope this is an improvement.

A couple of other minor changes:

1. "Limitations" sound like things Cargo is *incapable* of doing. The points here are conscious decisions, so calling them "restrictions" seemed more appropriate to me.
2. TOML's source is linked to on the FAQ page, but I'm pretty likely to land directly on the Configuration page from a search, so a direct link from there seemed helpful.

r? @steveklabnik for docs.