### PR TITLE
Disable LTO for host (plugin, build script) builds

### DIFF
--- a/src/cargo/ops/cargo_rustc/mod.rs
+++ b/src/cargo/ops/cargo_rustc/mod.rs
@@ -587,7 +587,12 @@ fn build_base_args(cx: &Context,
     if profile.opt_level() != 0 {
         cmd.arg("-C").arg(&format!("opt-level={}", profile.opt_level()));
     }
-    if (target.is_bin() || target.is_staticlib()) && profile.lto() {
+
+    // Disable LTO for host builds as prefer_dynamic and it are mutually
+    // exclusive.
+    let lto = (target.is_bin() || target.is_staticlib()) && profile.lto() &&
+              !profile.is_for_host();
+    if lto {
         cmd.args(&["-C", "lto"]);
     } else {
         // There are some restrictions with LTO and codegen-units, so we

--- a/tests/test_cargo_compile_custom_build.rs
+++ b/tests/test_cargo_compile_custom_build.rs
@@ -1099,3 +1099,24 @@ test!(profile_and_opt_level_set_correctly {
     assert_that(build.cargo_process("bench"),
                 execs().with_status(0));
 });
+
+test!(build_script_with_lto {
+    let build = project("builder")
+        .file("Cargo.toml", r#"
+            [package]
+            name = "builder"
+            version = "0.0.1"
+            authors = []
+            build = "build.rs"
+
+            [profile.dev]
+            lto = true
+        "#)
+        .file("src/lib.rs", "")
+        .file("build.rs", r#"
+              fn main() {
+              }
+        "#);
+    assert_that(build.cargo_process("build"),
+                execs().with_status(0));
+});


### PR DESCRIPTION
When building host code, -C prefer-dynamic is passed, but that option
is mutually exclusive with -C lto. Thus when LTO is specified, rustc
errors out.