### PR TITLE
Translate '\' to '/' for submodule names

### DIFF
--- a/src/cargo/sources/path.rs
+++ b/src/cargo/sources/path.rs
@@ -162,7 +162,10 @@ impl<'a, 'b> PathSource<'a, 'b> {
                 let rel = try!(rel.to_str().chain_error(|| {
                     human(format!("invalid utf-8 filename: {}", rel.display()))
                 }));
-                let submodule = try!(repo.find_submodule(rel));
+                // Git submodules are currently only named through `/` path
+                // separators, explicitly not `\` which windows uses. Who knew?
+                let rel = rel.replace(r"\", "/");
+                let submodule = try!(repo.find_submodule(&rel));
                 let repo = match submodule.open() {
                     Ok(repo) => repo,
                     Err(..) => continue,

--- a/tests/test_cargo_compile_git_deps.rs
+++ b/tests/test_cargo_compile_git_deps.rs
@@ -51,7 +51,8 @@ fn add(repo: &git2::Repository) {
 
 fn add_submodule<'a>(repo: &'a git2::Repository, url: &str,
                      path: &Path) -> git2::Submodule<'a> {
-    let mut s = repo.submodule(url, path, false).unwrap();
+    let path = path.to_str().unwrap().replace(r"\", "/");
+    let mut s = repo.submodule(url, Path::new(&path), false).unwrap();
     let subrepo = s.open().unwrap();
     let mut origin = subrepo.find_remote("origin").unwrap();
     origin.add_fetch("refs/heads/*:refs/heads/*").unwrap();
@@ -1658,12 +1659,13 @@ test!(dont_require_submodules_are_checked_out {
         "#)
         .file("build.rs", "fn main() {}")
         .file("src/lib.rs", "")
+        .file("a/foo", "")
     }).unwrap();
     let git2 = git_repo("dep2", |p| p).unwrap();
 
     let repo = git2::Repository::open(&git1.root()).unwrap();
     let url = path2url(git2.root()).to_string();
-    add_submodule(&repo, &url, &Path::new("submodule"));
+    add_submodule(&repo, &url, &Path::new("a/submodule"));
     commit(&repo);
 
     git2::Repository::init(&project.root()).unwrap();


### PR DESCRIPTION
Apparently git submodules are checked in as '/' not '\' so if a '\' leaks
through it'll end up not being found!

Closes #1299