### PR TITLE
Fix dep_targets for tests depending on libraries

### DIFF
--- a/src/cargo/ops/cargo_rustc/mod.rs
+++ b/src/cargo/ops/cargo_rustc/mod.rs
@@ -678,17 +678,6 @@ fn build_deps_args(cmd: &mut CommandPrototype, target: &Target,
         try!(link_to(cmd, pkg, target, cx, kind));
     }
 
-    let targets = package.targets().iter().filter(|target| {
-        target.is_lib() && target.profile().is_compile()
-    });
-
-    if (target.is_bin() || target.is_example()) &&
-       !target.profile().is_custom_build() {
-        for target in targets.filter(|f| f.is_rlib() || f.is_dylib()) {
-            try!(link_to(cmd, package, target, cx, kind));
-        }
-    }
-
     return Ok(());
 
     fn link_to(cmd: &mut CommandPrototype, pkg: &Package, target: &Target,


### PR DESCRIPTION
Before this commit the `dep_targets` function of `Context` didn't actually
return all dependencies in the sense that unit tests (and likely examples) would
not have the same package's library listed as a dependency. This commit
rectifies the situation by ensuring that the package's library is included
whenever necessary in the dependency list.

Closes #1289