### PR TITLE
Relax output restrictions to make a test less flaky

### DIFF
--- a/tests/test_cargo_compile_custom_build.rs
+++ b/tests/test_cargo_compile_custom_build.rs
@@ -563,10 +563,10 @@ test!(propagation_of_l_flags {
     assert_that(p.cargo_process("build").arg("-v").arg("-j1"),
                 execs().with_status(0)
                        .with_stdout(format!("\
-{compiling} a v0.5.0 (file://[..])
-{running} `rustc a[..]build.rs [..]`
-{compiling} b v0.5.0 (file://[..])
-{running} `rustc [..] --crate-name b [..]-L foo[..]`
+[..]
+[..]
+[..]
+[..]
 {running} `[..]a-[..]build-script-build[..]`
 {running} `rustc [..] --crate-name a [..]-L bar[..]-L foo[..]`
 {compiling} foo v0.5.0 (file://[..])


### PR DESCRIPTION
Due to random hash map traversals this test could build either crate `a` or
crate `b` first, causing the first four output lines to possibly change. Two of
the first four lines are guaranteed to be the compilation of `b` and the other
two are the compilation of `a` as well as building its build script, but no
other lines about compiling `a` can happen until the dependency `b` has finished
compiling.