### PR TITLE
Note the build profile in output by default

### DIFF
--- a/src/cargo/ops/cargo_rustc/mod.rs
+++ b/src/cargo/ops/cargo_rustc/mod.rs
@@ -128,7 +128,8 @@ pub fn compile_targets<'a, 'b>(env: &str,
         cx.exec_engine = exec_engine.clone();
     }
 
-    let mut queue = JobQueue::new(cx.resolve, deps, cx.jobs());
+    let mut queue = JobQueue::new(cx.resolve, deps, cx.jobs(),
+                                  dest.unwrap_or("debug"));
 
     // First ensure that the destination directory exists
     try!(cx.prepare(pkg));

--- a/tests/test_cargo_bench.rs
+++ b/tests/test_cargo_bench.rs
@@ -35,17 +35,15 @@ test!(cargo_bench_simple {
 
     assert_that(p.cargo("bench"),
                 execs().with_stdout(format!("\
-{} foo v0.5.0 ({})
-{} target[..]release[..]foo-[..]
+{compiling} (release) foo v0.5.0 ({url})
+{running} target[..]release[..]foo-[..]
 
 running 1 test
 test bench_hello ... bench:         0 ns/iter (+/- 0)
 
 test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured
 
-",
-        COMPILING, p.url(),
-        RUNNING)));
+", compiling = COMPILING, url = p.url(), running = RUNNING)));
 });
 
 test!(bench_tarname {
@@ -72,7 +70,7 @@ test!(bench_tarname {
             #[bench] fn run2(_ben: &mut test::Bencher) { }"#);
 
     let expected_stdout = format!("\
-{compiling} foo v0.0.1 ({dir})
+{compiling} (release) foo v0.0.1 ({dir})
 {runnning} target[..]release[..]bin2[..]
 
 running 1 test
@@ -100,7 +98,7 @@ test!(cargo_bench_verbose {
 
     assert_that(p.cargo_process("bench").arg("-v").arg("hello"),
         execs().with_stdout(format!("\
-{compiling} foo v0.5.0 ({url})
+{compiling} (release) foo v0.5.0 ({url})
 {running} `rustc src[..]foo.rs [..]`
 {running} `[..]target[..]release[..]foo-[..] hello --bench`
 
@@ -172,12 +170,12 @@ test!(cargo_bench_failing_test {
 
     assert_that(p.cargo("bench"),
                 execs().with_stdout(format!("\
-{} foo v0.5.0 ({})
-{} target[..]release[..]foo-[..]
+{compiling} (release) foo v0.5.0 ({url})
+{running} target[..]release[..]foo-[..]
 
 running 1 test
 test bench_hello ... ",
-        COMPILING, p.url(), RUNNING))
+        compiling = COMPILING, url = p.url(), running = RUNNING))
               .with_stderr("\
 thread '<main>' panicked at 'assertion failed: \
     `(left == right) && (right == left)` (left: \
@@ -224,7 +222,7 @@ test!(bench_with_lib_dep {
 
     assert_that(p.cargo_process("bench"),
         execs().with_stdout(format!("\
-{} foo v0.0.1 ({})
+{compiling} (release) foo v0.0.1 ({url})
 {running} target[..]release[..]baz-[..]
 
 running 1 test
@@ -240,7 +238,7 @@ test lib_bench ... bench:         0 ns/iter (+/- 0)
 test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured
 
 ",
-        COMPILING, p.url(), running = RUNNING)))
+        compiling = COMPILING, url = p.url(), running = RUNNING)))
 });
 
 test!(bench_with_deep_lib_dep {
@@ -282,8 +280,8 @@ test!(bench_with_deep_lib_dep {
     assert_that(p.cargo_process("bench"),
                 execs().with_status(0)
                        .with_stdout(format!("\
-{compiling} foo v0.0.1 ({dir})
-{compiling} bar v0.0.1 ({dir})
+{compiling} (release) foo v0.0.1 ({dir})
+{compiling} (release) bar v0.0.1 ({dir})
 {running} target[..]
 
 running 1 test
@@ -325,7 +323,7 @@ test!(external_bench_explicit {
 
     assert_that(p.cargo_process("bench"),
         execs().with_stdout(format!("\
-{} foo v0.0.1 ({})
+{compiling} (release) foo v0.0.1 ({url})
 {running} target[..]release[..]bench-[..]
 
 running 1 test
@@ -340,8 +338,7 @@ test internal_bench ... bench:         0 ns/iter (+/- 0)
 
 test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured
 
-",
-        COMPILING, p.url(), running = RUNNING)))
+", compiling = COMPILING, url = p.url(), running = RUNNING)))
 });
 
 test!(external_bench_implicit {
@@ -370,7 +367,7 @@ test!(external_bench_implicit {
 
     assert_that(p.cargo_process("bench"),
         execs().with_stdout(format!("\
-{} foo v0.0.1 ({})
+{compiling} (release) foo v0.0.1 ({url})
 {running} target[..]release[..]external-[..]
 
 running 1 test
@@ -385,8 +382,7 @@ test internal_bench ... bench:         0 ns/iter (+/- 0)
 
 test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured
 
-",
-        COMPILING, p.url(), running = RUNNING)))
+", compiling = COMPILING, url = p.url(), running = RUNNING)))
 });
 
 test!(dont_run_examples {
@@ -424,7 +420,7 @@ test!(pass_through_command_line {
     assert_that(p.cargo_process("bench").arg("bar"),
                 execs().with_status(0)
                        .with_stdout(format!("\
-{compiling} foo v0.0.1 ({dir})
+{compiling} (release) foo v0.0.1 ({dir})
 {running} target[..]release[..]foo-[..]
 
 running 1 test
@@ -439,7 +435,7 @@ test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured
     assert_that(p.cargo_process("bench").arg("foo"),
                 execs().with_status(0)
                        .with_stdout(format!("\
-{compiling} foo v0.0.1 ({dir})
+{compiling} (release) foo v0.0.1 ({dir})
 {running} target[..]release[..]foo-[..]
 
 running 1 test
@@ -501,7 +497,7 @@ test!(lib_bin_same_name {
 
     assert_that(p.cargo_process("bench"),
         execs().with_stdout(format!("\
-{} foo v0.0.1 ({})
+{compiling} (release) foo v0.0.1 ({url})
 {running} target[..]release[..]foo-[..]
 
 running 1 test
@@ -516,8 +512,7 @@ test [..] ... bench:         0 ns/iter (+/- 0)
 
 test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured
 
-",
-        COMPILING, p.url(), running = RUNNING)))
+", compiling = COMPILING, url = p.url(), running = RUNNING)))
 });
 
 test!(lib_with_standard_name {
@@ -550,7 +545,7 @@ test!(lib_with_standard_name {
     assert_that(p.cargo_process("bench"),
                 execs().with_status(0)
                        .with_stdout(format!("\
-{compiling} syntax v0.0.1 ({dir})
+{compiling} (release) syntax v0.0.1 ({dir})
 {running} target[..]release[..]bench-[..]
 
 running 1 test
@@ -599,7 +594,7 @@ test!(lib_with_standard_name2 {
     assert_that(p.cargo_process("bench"),
                 execs().with_status(0)
                        .with_stdout(format!("\
-{compiling} syntax v0.0.1 ({dir})
+{compiling} (release) syntax v0.0.1 ({dir})
 {running} target[..]release[..]syntax-[..]
 
 running 1 test
@@ -693,9 +688,9 @@ test!(bench_dylib {
     assert_that(p.cargo_process("bench").arg("-v"),
                 execs().with_status(0)
                        .with_stdout(format!("\
-{compiling} bar v0.0.1 ({dir})
+{compiling} (release) bar v0.0.1 ({dir})
 {running} [..] -C opt-level=3 [..]
-{compiling} foo v0.0.1 ({dir})
+{compiling} (release) foo v0.0.1 ({dir})
 {running} [..] -C opt-level=3 [..]
 {running} [..] -C opt-level=3 [..]
 {running} [..] -C opt-level=3 [..]
@@ -720,8 +715,8 @@ test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured
     assert_that(p.cargo("bench").arg("-v"),
                 execs().with_status(0)
                        .with_stdout(format!("\
-{fresh} bar v0.0.1 ({dir})
-{fresh} foo v0.0.1 ({dir})
+{fresh} (release) bar v0.0.1 ({dir})
+{fresh} (release) foo v0.0.1 ({dir})
 {running} [..]target[..]release[..]bench-[..]
 
 running 1 test
@@ -760,7 +755,7 @@ test!(bench_twice_with_build_cmd {
     assert_that(p.cargo_process("bench"),
                 execs().with_status(0)
                        .with_stdout(format!("\
-{compiling} foo v0.0.1 ({dir})
+{compiling} (release) foo v0.0.1 ({dir})
 {running} target[..]release[..]foo-[..]
 
 running 1 test
@@ -838,7 +833,7 @@ test!(bench_with_examples {
     assert_that(p.cargo_process("bench").arg("-v"),
                 execs().with_status(0)
                        .with_stdout(format!("\
-{compiling} testbench v6.6.6 ({url})
+{compiling} (release) testbench v6.6.6 ({url})
 {running} `rustc src[..]lib.rs --crate-name testbench --crate-type lib [..]`
 {running} `rustc src[..]lib.rs --crate-name testbench --crate-type lib [..]`
 {running} `rustc benches[..]testb1.rs --crate-name testb1 --crate-type bin \

--- a/tests/test_cargo_build_lib.rs
+++ b/tests/test_cargo_build_lib.rs
@@ -8,7 +8,7 @@ fn setup() {
 
 fn verbose_output_for_lib(p: &ProjectBuilder) -> String {
     format!("\
-{compiling} {name} v{version} ({url})
+{compiling} (debug) {name} v{version} ({url})
 {running} `rustc src{sep}lib.rs --crate-name {name} --crate-type lib -g \
         -C metadata=[..] \
         -C extra-filename=-[..] \

--- a/tests/test_cargo_compile.rs
+++ b/tests/test_cargo_compile.rs
@@ -222,12 +222,11 @@ test!(cargo_compile_with_warnings_in_a_dep_package {
         "#);
 
     assert_that(p.cargo_process("build"),
-        execs()
-        .with_stdout(format!("{} bar v0.5.0 ({})\n\
-                              {} foo v0.5.0 ({})\n",
-                             COMPILING, p.url(),
-                             COMPILING, p.url()))
-        .with_stderr("\
+                execs().with_stdout(format!("\
+{compiling} (debug) bar v0.5.0 ({url})
+{compiling} (debug) foo v0.5.0 ({url})
+", compiling = COMPILING, url = p.url()))
+                       .with_stderr("\
 [..]warning: function is never used: `dead`[..]
 [..]fn dead() {}
 [..]^~~~~~~~~~~~
@@ -807,7 +806,7 @@ test!(lto_build {
         .file("src/main.rs", "fn main() {}");
     assert_that(p.cargo_process("build").arg("-v").arg("--release"),
                 execs().with_status(0).with_stdout(format!("\
-{compiling} test v0.0.0 ({url})
+{compiling} (release) test v0.0.0 ({url})
 {running} `rustc src[..]main.rs --crate-name test --crate-type bin \
         -C opt-level=3 \
         -C lto \
@@ -836,7 +835,7 @@ test!(verbose_build {
         .file("src/lib.rs", "");
     assert_that(p.cargo_process("build").arg("-v"),
                 execs().with_status(0).with_stdout(format!("\
-{compiling} test v0.0.0 ({url})
+{compiling} (debug) test v0.0.0 ({url})
 {running} `rustc src[..]lib.rs --crate-name test --crate-type lib -g \
         -C metadata=[..] \
         -C extra-filename=-[..] \
@@ -864,7 +863,7 @@ test!(verbose_release_build {
         .file("src/lib.rs", "");
     assert_that(p.cargo_process("build").arg("-v").arg("--release"),
                 execs().with_status(0).with_stdout(format!("\
-{compiling} test v0.0.0 ({url})
+{compiling} (release) test v0.0.0 ({url})
 {running} `rustc src[..]lib.rs --crate-name test --crate-type lib \
         -C opt-level=3 \
         --cfg ndebug \
@@ -909,7 +908,7 @@ test!(verbose_release_build_deps {
         .file("foo/src/lib.rs", "");
     assert_that(p.cargo_process("build").arg("-v").arg("--release"),
                 execs().with_status(0).with_stdout(format!("\
-{compiling} foo v0.0.0 ({url})
+{compiling} (release) foo v0.0.0 ({url})
 {running} `rustc foo[..]src[..]lib.rs --crate-name foo \
         --crate-type dylib --crate-type rlib -C prefer-dynamic \
         -C opt-level=3 \
@@ -920,7 +919,7 @@ test!(verbose_release_build_deps {
         --emit=dep-info,link \
         -L dependency={dir}[..]target[..]release[..]deps \
         -L dependency={dir}[..]target[..]release[..]deps`
-{compiling} test v0.0.0 ({url})
+{compiling} (release) test v0.0.0 ({url})
 {running} `rustc src[..]lib.rs --crate-name test --crate-type lib \
         -C opt-level=3 \
         --cfg ndebug \
@@ -1138,7 +1137,7 @@ test!(lib_with_standard_name {
     assert_that(p.cargo_process("build"),
                 execs().with_status(0)
                        .with_stdout(format!("\
-{compiling} syntax v0.0.1 ({dir})
+{compiling} (debug) syntax v0.0.1 ({dir})
 ",
                        compiling = COMPILING,
                        dir = p.url()).as_slice()));
@@ -1266,7 +1265,7 @@ test!(freshness_ignores_excluded {
     assert_that(foo.cargo("build"),
                 execs().with_status(0)
                        .with_stdout(format!("\
-{compiling} foo v0.0.0 ({url})
+{compiling} (debug) foo v0.0.0 ({url})
 ", compiling = COMPILING, url = foo.url())));
 
     // Smoke test to make sure it doesn't compile again
@@ -1312,14 +1311,14 @@ test!(rebuild_preserves_out_dir {
     assert_that(foo.cargo("build").env("FIRST", "1"),
                 execs().with_status(0)
                        .with_stdout(format!("\
-{compiling} foo v0.0.0 ({url})
+{compiling} (debug) foo v0.0.0 ({url})
 ", compiling = COMPILING, url = foo.url())));
 
     File::create(&foo.root().join("src/bar.rs")).unwrap();
     assert_that(foo.cargo("build"),
                 execs().with_status(0)
                        .with_stdout(format!("\
-{compiling} foo v0.0.0 ({url})
+{compiling} (debug) foo v0.0.0 ({url})
 ", compiling = COMPILING, url = foo.url())));
 });
 

--- a/tests/test_cargo_compile_custom_build.rs
+++ b/tests/test_cargo_compile_custom_build.rs
@@ -32,7 +32,7 @@ test!(custom_build_script_failed {
     assert_that(p.cargo_process("build").arg("-v"),
                 execs().with_status(101)
                        .with_stdout(format!("\
-{compiling} foo v0.5.0 ({url})
+{compiling} (debug) foo v0.5.0 ({url})
 {running} `rustc build.rs --crate-name build-script-build --crate-type bin [..]`
 {running} `[..]build-script-build[..]`
 ",
@@ -177,7 +177,7 @@ test!(custom_build_script_rustc_flags {
     assert_that(p.cargo_process("build").arg("--verbose"),
                 execs().with_status(101)
                        .with_stdout(format!("\
-{compiling} bar v0.5.0 ({url})
+{compiling} (debug) bar v0.5.0 ({url})
 {running} `rustc {dir}{sep}src{sep}lib.rs --crate-name test --crate-type lib -g \
         -C metadata=[..] \
         -C extra-filename=-[..] \
@@ -363,9 +363,9 @@ test!(links_passes_env_vars {
     assert_that(p.cargo_process("build").arg("-v"),
                 execs().with_status(0)
                        .with_stdout(format!("\
-{compiling} [..] v0.5.0 (file://[..])
+{compiling} (debug) [..] v0.5.0 (file://[..])
 {running} `rustc [..]build.rs [..]`
-{compiling} [..] v0.5.0 (file://[..])
+{compiling} (debug) [..] v0.5.0 (file://[..])
 {running} `rustc [..]build.rs [..]`
 {running} `[..]`
 {running} `[..]`
@@ -398,7 +398,7 @@ test!(only_rerun_build_script {
     assert_that(p.cargo("build").arg("-v"),
                 execs().with_status(0)
                        .with_stdout(format!("\
-{compiling} foo v0.5.0 (file://[..])
+{compiling} (debug) foo v0.5.0 (file://[..])
 {running} `[..]build-script-build[..]`
 {running} `rustc [..] --crate-name foo [..]`
 ", compiling = COMPILING, running = RUNNING).as_slice()));
@@ -479,7 +479,7 @@ test!(testing_and_such {
     assert_that(p.cargo("test").arg("-vj1"),
                 execs().with_status(0)
                        .with_stdout(format!("\
-{compiling} foo v0.5.0 (file://[..])
+{compiling} (debug) foo v0.5.0 (file://[..])
 {running} `[..]build-script-build[..]`
 {running} `rustc [..] --crate-name foo [..]`
 {running} `rustc [..] --crate-name foo [..]`
@@ -501,7 +501,7 @@ test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
     assert_that(p.cargo("doc").arg("-v"),
                 execs().with_status(0)
                        .with_stdout(format!("\
-{compiling} foo v0.5.0 (file://[..])
+{compiling} (debug) foo v0.5.0 (file://[..])
 {running} `rustdoc [..]`
 {running} `rustc [..]`
 ", compiling = COMPILING, running = RUNNING).as_slice()));
@@ -511,7 +511,7 @@ test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
     assert_that(p.cargo("run"),
                 execs().with_status(0)
                        .with_stdout(format!("\
-{compiling} foo v0.5.0 (file://[..])
+{compiling} (debug) foo v0.5.0 (file://[..])
 {running} `target[..]foo`
 ", compiling = COMPILING, running = RUNNING).as_slice()));
 });
@@ -569,7 +569,7 @@ test!(propagation_of_l_flags {
 [..]
 {running} `[..]a-[..]build-script-build[..]`
 {running} `rustc [..] --crate-name a [..]-L bar[..]-L foo[..]`
-{compiling} foo v0.5.0 (file://[..])
+{compiling} (debug) foo v0.5.0 (file://[..])
 {running} `rustc [..] --crate-name foo [..] -L bar -L foo`
 ", compiling = COMPILING, running = RUNNING).as_slice()));
 });
@@ -601,9 +601,9 @@ test!(build_deps_simple {
     assert_that(p.cargo_process("build").arg("-v"),
                 execs().with_status(0)
                        .with_stdout(format!("\
-{compiling} a v0.5.0 (file://[..])
+{compiling} (debug) a v0.5.0 (file://[..])
 {running} `rustc [..] --crate-name a [..]`
-{compiling} foo v0.5.0 (file://[..])
+{compiling} (debug) foo v0.5.0 (file://[..])
 {running} `rustc build.rs [..] --extern a=[..]`
 {running} `[..]foo-[..]build-script-build[..]`
 {running} `rustc [..] --crate-name foo [..]`
@@ -689,16 +689,16 @@ test!(build_cmd_with_a_build_cmd {
     assert_that(p.cargo_process("build").arg("-v"),
                 execs().with_status(0)
                        .with_stdout(format!("\
-{compiling} b v0.5.0 (file://[..])
+{compiling} (debug) b v0.5.0 (file://[..])
 {running} `rustc [..] --crate-name b [..]`
-{compiling} a v0.5.0 (file://[..])
+{compiling} (debug) a v0.5.0 (file://[..])
 {running} `rustc a[..]build.rs [..] --extern b=[..]`
 {running} `[..]a-[..]build-script-build[..]`
 {running} `rustc [..]lib.rs --crate-name a --crate-type lib -g \
     -C metadata=[..] -C extra-filename=-[..] \
     --out-dir [..]target[..]deps --emit=dep-info,link \
     -L [..]target[..]deps -L [..]target[..]deps`
-{compiling} foo v0.5.0 (file://[..])
+{compiling} (debug) foo v0.5.0 (file://[..])
 {running} `rustc build.rs --crate-name build-script-build --crate-type bin \
     -C prefer-dynamic -g \
     --out-dir [..]build[..]foo-[..] --emit=dep-info,link \
@@ -778,7 +778,7 @@ test!(output_separate_lines {
     assert_that(p.cargo_process("build").arg("-v"),
                 execs().with_status(101)
                        .with_stdout(format!("\
-{compiling} foo v0.5.0 (file://[..])
+{compiling} (debug) foo v0.5.0 (file://[..])
 {running} `rustc build.rs [..]`
 {running} `[..]foo-[..]build-script-build[..]`
 {running} `rustc [..] --crate-name foo [..] -L foo -l foo:static`
@@ -819,7 +819,7 @@ test!(code_generation {
     assert_that(p.cargo_process("run"),
                 execs().with_status(0)
                        .with_stdout(format!("\
-{compiling} foo v0.5.0 (file://[..])
+{compiling} (debug) foo v0.5.0 (file://[..])
 {running} `target[..]foo`
 Hello, World!
 ", compiling = COMPILING, running = RUNNING).as_slice()));

--- a/tests/test_cargo_compile_git_deps.rs
+++ b/tests/test_cargo_compile_git_deps.rs
@@ -121,14 +121,13 @@ test!(cargo_compile_simple_git_dep {
     let git_root = git_project.root();
 
     assert_that(project.cargo_process("build"),
-        execs()
-        .with_stdout(format!("{} git repository `{}`\n\
-                              {} dep1 v0.5.0 ({}#[..])\n\
-                              {} foo v0.5.0 ({})\n",
-                             UPDATING, path2url(git_root.clone()),
-                             COMPILING, path2url(git_root),
-                             COMPILING, path2url(root)))
-        .with_stderr(""));
+                execs().with_stderr("")
+                       .with_stdout(format!("\
+{updating} git repository `{url}`
+{compiling} (debug) dep1 v0.5.0 ({url}#[..])
+{compiling} (debug) foo v0.5.0 ({path})
+", updating = UPDATING, compiling = COMPILING, url = path2url(git_root),
+   path = path2url(root))));
 
     assert_that(&project.bin("foo"), existing_file());
 
@@ -188,14 +187,13 @@ test!(cargo_compile_git_dep_branch {
     let git_root = git_project.root();
 
     assert_that(project.cargo_process("build"),
-        execs()
-        .with_stdout(format!("{} git repository `{}`\n\
-                              {} dep1 v0.5.0 ({}?branch=branchy#[..])\n\
-                              {} foo v0.5.0 ({})\n",
-                             UPDATING, path2url(git_root.clone()),
-                             COMPILING, path2url(git_root),
-                             COMPILING, path2url(root)))
-        .with_stderr(""));
+                execs().with_stderr("")
+                       .with_stdout(format!("\
+{updating} git repository `{url}`
+{compiling} (debug) dep1 v0.5.0 ({url}?branch=branchy#[..])
+{compiling} (debug) foo v0.5.0 ({path})
+", updating = UPDATING, compiling = COMPILING, url = path2url(git_root),
+   path = path2url(root))));
 
     assert_that(&project.bin("foo"), existing_file());
 
@@ -258,13 +256,13 @@ test!(cargo_compile_git_dep_tag {
     let git_root = git_project.root();
 
     assert_that(project.cargo_process("build"),
-        execs()
-        .with_stdout(format!("{} git repository `{}`\n\
-                              {} dep1 v0.5.0 ({}?tag=v0.1.0#[..])\n\
-                              {} foo v0.5.0 ({})\n",
-                             UPDATING, path2url(git_root.clone()),
-                             COMPILING, path2url(git_root),
-                             COMPILING, path2url(root))));
+                execs().with_stderr("")
+                       .with_stdout(format!("\
+{updating} git repository `{url}`
+{compiling} (debug) dep1 v0.5.0 ({url}?tag=v0.1.0#[..])
+{compiling} (debug) foo v0.5.0 ({path})
+", updating = UPDATING, compiling = COMPILING, url = path2url(git_root),
+   path = path2url(root))));
 
     assert_that(&project.bin("foo"), existing_file());
 
@@ -562,12 +560,13 @@ test!(recompilation {
 
     // First time around we should compile both foo and bar
     assert_that(p.cargo_process("build"),
-                execs().with_stdout(format!("{} git repository `{}`\n\
-                                             {} bar v0.5.0 ({}#[..])\n\
-                                             {} foo v0.5.0 ({})\n",
-                                            UPDATING, git_project.url(),
-                                            COMPILING, git_project.url(),
-                                            COMPILING, p.url())));
+                execs().with_stderr("")
+                       .with_stdout(format!("\
+{updating} git repository `{url}`\n\
+{compiling} (debug) bar v0.5.0 ({url}#[..])\n\
+{compiling} (debug) foo v0.5.0 ({path})
+", updating = UPDATING, compiling = COMPILING, url = git_project.url(),
+   path = p.url())));
 
     // Don't recompile the second time
     assert_that(p.cargo("build"),
@@ -582,9 +581,9 @@ test!(recompilation {
                 execs().with_stdout(""));
 
     assert_that(p.cargo("update"),
-                execs().with_stdout(format!("{} git repository `{}`",
-                                            UPDATING,
-                                            git_project.url())));
+                execs().with_stdout(format!("\
+{updating} git repository `{url}`
+", updating = UPDATING, url = git_project.url())));
 
     assert_that(p.cargo("build"),
                 execs().with_stdout(""));
@@ -602,23 +601,26 @@ test!(recompilation {
 
     // Update the dependency and carry on!
     assert_that(p.cargo("update"),
-                execs().with_stdout(format!("{} git repository `{}`",
-                                            UPDATING,
-                                            git_project.url())));
+                execs().with_stdout(format!("\
+{updating} git repository `{url}`
+", updating = UPDATING, url = git_project.url())));
     println!("going for the last compile");
     assert_that(p.cargo("build"),
-                execs().with_stdout(format!("{} bar v0.5.0 ({}#[..])\n\
-                                             {} foo v0.5.0 ({})\n",
-                                            COMPILING, git_project.url(),
-                                            COMPILING, p.url())));
+                execs().with_stderr("")
+                       .with_stdout(format!("\
+{compiling} (debug) bar v0.5.0 ({url}#[..])
+{compiling} (debug) foo v0.5.0 ({path})
+", compiling = COMPILING, url = git_project.url(), path = p.url())));
 
     // Make sure clean only cleans one dep
     assert_that(p.cargo("clean")
                  .arg("-p").arg("foo"),
                 execs().with_stdout(""));
     assert_that(p.cargo("build"),
-                execs().with_stdout(format!("{} foo v0.5.0 ({})\n",
-                                            COMPILING, p.url())));
+                execs().with_stderr("")
+                       .with_stdout(format!("\
+{compiling} (debug) foo v0.5.0 ({path})
+", compiling = COMPILING, path = p.url())));
 });
 
 test!(update_with_shared_deps {
@@ -683,10 +685,10 @@ test!(update_with_shared_deps {
     assert_that(p.cargo_process("build"),
                 execs().with_stdout(format!("\
 {updating} git repository `{git}`
-{compiling} bar v0.5.0 ({git}#[..])
-{compiling} [..] v0.5.0 ({dir})
-{compiling} [..] v0.5.0 ({dir})
-{compiling} foo v0.5.0 ({dir})\n",
+{compiling} (debug) bar v0.5.0 ({git}#[..])
+{compiling} (debug) [..] v0.5.0 ({dir})
+{compiling} (debug) [..] v0.5.0 ({dir})
+{compiling} (debug) foo v0.5.0 ({dir})\n",
                     updating = UPDATING, git = git_project.url(),
                     compiling = COMPILING, dir = p.url())));
 
@@ -728,10 +730,10 @@ test!(update_with_shared_deps {
     println!("build");
     assert_that(p.cargo("build"),
                 execs().with_stdout(format!("\
-{compiling} bar v0.5.0 ({git}#[..])
-{compiling} [..] v0.5.0 ({dir})
-{compiling} [..] v0.5.0 ({dir})
-{compiling} foo v0.5.0 ({dir})\n",
+{compiling} (debug) bar v0.5.0 ({git}#[..])
+{compiling} (debug) [..] v0.5.0 ({dir})
+{compiling} (debug) [..] v0.5.0 ({dir})
+{compiling} (debug) foo v0.5.0 ({dir})\n",
                     git = git_project.url(),
                     compiling = COMPILING, dir = p.url())));
 
@@ -822,18 +824,14 @@ test!(two_deps_only_update_one {
         .file("src/main.rs", "fn main() {}");
 
     assert_that(project.cargo_process("build"),
-        execs()
-        .with_stdout(format!("{} git repository `[..]`\n\
-                              {} git repository `[..]`\n\
-                              {} [..] v0.5.0 ([..])\n\
-                              {} [..] v0.5.0 ([..])\n\
-                              {} foo v0.5.0 ({})\n",
-                             UPDATING,
-                             UPDATING,
-                             COMPILING,
-                             COMPILING,
-                             COMPILING, project.url()))
-        .with_stderr(""));
+                execs().with_stderr("")
+                       .with_stdout(format!("\
+{updating} git repository `[..]`
+{updating} git repository `[..]`
+{compiling} (debug) [..] v0.5.0 ([..])
+{compiling} (debug) [..] v0.5.0 ([..])
+{compiling} (debug) foo v0.5.0 ({path})
+", updating = UPDATING, compiling = COMPILING, path = project.url())));
 
     File::create(&git1.root().join("src/lib.rs")).unwrap().write_all(br#"
         pub fn foo() {}
@@ -842,12 +840,11 @@ test!(two_deps_only_update_one {
     add(&repo);
     commit(&repo);
 
-    assert_that(project.cargo("update")
-                       .arg("-p").arg("dep1"),
-        execs()
-        .with_stdout(format!("{} git repository `{}`\n",
-                             UPDATING, git1.url()))
-        .with_stderr(""));
+    assert_that(project.cargo("update").arg("-pdep1"),
+                execs().with_stderr("")
+                       .with_stdout(format!("\
+{updating} git repository `{url}`
+", updating = UPDATING, url = git1.url())));
 });
 
 test!(stale_cached_version {
@@ -914,8 +911,8 @@ test!(stale_cached_version {
                 execs().with_status(0)
                        .with_stdout(format!("\
 {updating} git repository `{bar}`
-{compiling} bar v0.0.0 ({bar}#[..])
-{compiling} foo v0.0.0 ({foo})
+{compiling} (debug) bar v0.0.0 ({bar}#[..])
+{compiling} (debug) foo v0.0.0 ({foo})
 ", updating = UPDATING, compiling = COMPILING, bar = bar.url(), foo = foo.url())));
     assert_that(foo.process(&foo.bin("foo")), execs().with_status(0));
 });
@@ -962,19 +959,16 @@ test!(dep_with_changed_submodule {
         ");
 
     println!("first run");
-    assert_that(project.cargo_process("run"), execs()
-                .with_stdout(format!("{} git repository `[..]`\n\
-                                      {} dep1 v0.5.0 ([..])\n\
-                                      {} foo v0.5.0 ([..])\n\
-                                      {} `target[..]foo`\n\
-                                      project2\
-                                      ",
-                                      UPDATING,
-                                      COMPILING,
-                                      COMPILING,
-                                      RUNNING))
-                .with_stderr("")
-                .with_status(0));
+    assert_that(project.cargo_process("run"),
+                execs().with_stderr("")
+                       .with_status(0)
+                       .with_stdout(format!("\
+{updating} git repository `[..]`
+{compiling} (debug) dep1 v0.5.0 ([..])
+{compiling} (debug) foo v0.5.0 ([..])
+{running} `target[..]foo`
+project2\
+", updating = UPDATING, compiling = COMPILING, running = RUNNING)));
 
     File::create(&git_project.root().join(".gitmodules")).unwrap()
          .write_all(format!("[submodule \"src\"]\n\tpath = src\n\turl={}",
@@ -1001,22 +995,22 @@ test!(dep_with_changed_submodule {
     // Update the dependency and carry on!
     println!("update");
     assert_that(project.cargo("update").arg("-v"),
-                execs()
-                .with_stderr("")
-                .with_stdout(format!("{} git repository `{}`",
-                                     UPDATING,
-                                     git_project.url())));
+                execs().with_stderr("")
+                       .with_status(0)
+                       .with_stdout(format!("\
+{updating} git repository `{url}`
+", updating = UPDATING, url = git_project.url())));
 
     println!("last run");
-    assert_that(project.cargo("run"), execs()
-                .with_stdout(format!("{compiling} dep1 v0.5.0 ([..])\n\
-                                      {compiling} foo v0.5.0 ([..])\n\
-                                      {running} `target[..]foo`\n\
-                                      project3\
-                                      ",
-                                      compiling = COMPILING, running = RUNNING))
-                .with_stderr("")
-                .with_status(0));
+    assert_that(project.cargo("run"),
+                execs().with_stderr("")
+                       .with_status(0)
+                       .with_stdout(format!("\
+{compiling} (debug) dep1 v0.5.0 ([..])
+{compiling} (debug) foo v0.5.0 ([..])
+{running} `target[..]foo`
+project3\
+", compiling = COMPILING, running = RUNNING)));
 });
 
 test!(dev_deps_with_testing {
@@ -1059,15 +1053,15 @@ test!(dev_deps_with_testing {
     assert_that(p.cargo_process("build"),
         execs().with_stdout(format!("\
 {updating} git repository `{bar}`
-{compiling} foo v0.5.0 ({url})
+{compiling} (debug) foo v0.5.0 ({url})
 ", updating = UPDATING, compiling = COMPILING, url = p.url(), bar = p2.url())));
 
     // Make sure we use the previous resolution of `bar` instead of updating it
     // a second time.
     assert_that(p.cargo("test"),
         execs().with_stdout(format!("\
-{compiling} [..] v0.5.0 ([..])
-{compiling} [..] v0.5.0 ([..]
+{compiling} (debug) [..] v0.5.0 ([..])
+{compiling} (debug) [..] v0.5.0 ([..]
 {running} target[..]foo-[..]
 
 running 1 test
@@ -1100,7 +1094,7 @@ test!(git_build_cmd_freshness {
     assert_that(foo.cargo("build"),
                 execs().with_status(0)
                        .with_stdout(format!("\
-{compiling} foo v0.0.0 ({url})
+{compiling} (debug) foo v0.0.0 ({url})
 ", compiling = COMPILING, url = foo.url())));
 
     // Smoke test to make sure it doesn't compile again
@@ -1152,7 +1146,7 @@ test!(git_name_not_always_needed {
     assert_that(p.cargo_process("build"),
         execs().with_stdout(format!("\
 {updating} git repository `{bar}`
-{compiling} foo v0.5.0 ({url})
+{compiling} (debug) foo v0.5.0 ({url})
 ", updating = UPDATING, compiling = COMPILING, url = p.url(), bar = p2.url())));
 });
 
@@ -1185,8 +1179,8 @@ test!(git_repo_changing_no_rebuild {
     assert_that(p1.cargo("build"),
                 execs().with_stdout(format!("\
 {updating} git repository `{bar}`
-{compiling} [..]
-{compiling} [..]
+{compiling} (debug) [..]
+{compiling} (debug) [..]
 ", updating = UPDATING, compiling = COMPILING, bar = bar.url())));
 
     // Make a commit to lock p2 to a different rev
@@ -1211,8 +1205,8 @@ test!(git_repo_changing_no_rebuild {
     assert_that(p2.cargo_process("build"),
                 execs().with_stdout(format!("\
 {updating} git repository `{bar}`
-{compiling} [..]
-{compiling} [..]
+{compiling} (debug) [..]
+{compiling} (debug) [..]
 ", updating = UPDATING, compiling = COMPILING, bar = bar.url())));
 
     // And now for the real test! Make sure that p1 doesn't get rebuilt
@@ -1337,14 +1331,12 @@ test!(warnings_in_git_dep {
         .file("src/main.rs", "fn main() {}");
 
     assert_that(p.cargo_process("build"),
-        execs()
-        .with_stdout(format!("{} git repository `{}`\n\
-                              {} bar v0.5.0 ({}#[..])\n\
-                              {} foo v0.5.0 ({})\n",
-                             UPDATING, bar.url(),
-                             COMPILING, bar.url(),
-                             COMPILING, p.url()))
-        .with_stderr(""));
+                execs().with_stderr("")
+                       .with_stdout(format!("\
+{updating} git repository `{url}`
+{compiling} (debug) bar v0.5.0 ({url}#[..])
+{compiling} (debug) foo v0.5.0 ({path})
+", updating = UPDATING, url = bar.url(), compiling = COMPILING, path = p.url())));
 });
 
 test!(update_ambiguous {
@@ -1498,9 +1490,9 @@ test!(switch_deps_does_not_update_transitive {
                        .with_stdout(format!("\
 Updating git repository `{}`
 Updating git repository `{}`
-{compiling} transitive [..]
-{compiling} dep [..]
-{compiling} project [..]
+{compiling} (debug) transitive [..]
+{compiling} (debug) dep [..]
+{compiling} (debug) project [..]
 ", dep1.url(), transitive.url(), compiling = COMPILING)));
 
     // Update the dependency to point to the second repository, but this
@@ -1518,8 +1510,8 @@ Updating git repository `{}`
                 execs().with_status(0)
                        .with_stdout(format!("\
 Updating git repository `{}`
-{compiling} dep [..]
-{compiling} project [..]
+{compiling} (debug) dep [..]
+{compiling} (debug) project [..]
 ", dep2.url(), compiling = COMPILING)));
 });
 
@@ -1623,9 +1615,9 @@ test!(switch_sources {
                 execs().with_status(0)
                        .with_stdout(format!("\
 {updating} git repository `file://[..]a1`
-{compiling} a v0.5.0 ([..]a1#[..]
-{compiling} b v0.5.0 ([..])
-{compiling} project v0.5.0 ([..])
+{compiling} (debug) a v0.5.0 ([..]a1#[..]
+{compiling} (debug) b v0.5.0 ([..])
+{compiling} (debug) project v0.5.0 ([..])
 ", updating = UPDATING, compiling = COMPILING).as_slice()));
 
     File::create(&p.root().join("b/Cargo.toml")).unwrap().write_all(format!(r#"
@@ -1641,9 +1633,9 @@ test!(switch_sources {
                 execs().with_status(0)
                        .with_stdout(format!("\
 {updating} git repository `file://[..]a2`
-{compiling} a v0.5.1 ([..]a2#[..]
-{compiling} b v0.5.0 ([..])
-{compiling} project v0.5.0 ([..])
+{compiling} (debug) a v0.5.1 ([..]a2#[..]
+{compiling} (debug) b v0.5.0 ([..])
+{compiling} (debug) project v0.5.0 ([..])
 ", updating = UPDATING, compiling = COMPILING).as_slice()));
 });
 

--- a/tests/test_cargo_compile_path_deps.rs
+++ b/tests/test_cargo_compile_path_deps.rs
@@ -75,12 +75,11 @@ test!(cargo_compile_with_nested_deps_shorthand {
 
     assert_that(p.cargo_process("build"),
         execs().with_status(0)
-               .with_stdout(format!("{} baz v0.5.0 ({})\n\
-                                     {} bar v0.5.0 ({})\n\
-                                     {} foo v0.5.0 ({})\n",
-                                    COMPILING, p.url(),
-                                    COMPILING, p.url(),
-                                    COMPILING, p.url())));
+               .with_stdout(format!("\
+{compiling} (debug) baz v0.5.0 ({url})
+{compiling} (debug) bar v0.5.0 ({url})
+{compiling} (debug) foo v0.5.0 ({url})
+", compiling = COMPILING, url = p.url())));
 
     assert_that(&p.bin("foo"), existing_file());
 
@@ -92,17 +91,18 @@ test!(cargo_compile_with_nested_deps_shorthand {
                 execs().with_stdout("").with_status(0));
     println!("building baz");
     assert_that(p.cargo("build").arg("-p").arg("baz"),
-                execs().with_status(0)
-                       .with_stdout(format!("{} baz v0.5.0 ({})\n",
-                                            COMPILING, p.url())));
+        execs().with_status(0)
+               .with_stdout(format!("\
+{compiling} (debug) baz v0.5.0 ({url})
+", compiling = COMPILING, url = p.url())));
+
     println!("building foo");
-    assert_that(p.cargo("build")
-                 .arg("-p").arg("foo"),
-                execs().with_status(0)
-                       .with_stdout(format!("{} bar v0.5.0 ({})\n\
-                                             {} foo v0.5.0 ({})\n",
-                                            COMPILING, p.url(),
-                                            COMPILING, p.url())));
+    assert_that(p.cargo("build").arg("-p").arg("foo"),
+        execs().with_status(0)
+               .with_stdout(format!("\
+{compiling} (debug) bar v0.5.0 ({url})
+{compiling} (debug) foo v0.5.0 ({url})
+", compiling = COMPILING, url = p.url())));
 });
 
 test!(cargo_compile_with_root_dev_deps {
@@ -179,8 +179,8 @@ test!(cargo_compile_with_root_dev_deps_with_testing {
     p2.build();
     assert_that(p.cargo_process("test"),
         execs().with_stdout(format!("\
-{compiling} [..] v0.5.0 ({url})
-{compiling} [..] v0.5.0 ({url})
+{compiling} (debug) [..] v0.5.0 ({url})
+{compiling} (debug) [..] v0.5.0 ({url})
 {running} target[..]foo-[..]
 
 running 0 tests
@@ -232,10 +232,10 @@ test!(cargo_compile_with_transitive_dev_deps {
         "#);
 
     assert_that(p.cargo_process("build"),
-        execs().with_stdout(format!("{} bar v0.5.0 ({})\n\
-                                     {} foo v0.5.0 ({})\n",
-                                    COMPILING, p.url(),
-                                    COMPILING, p.url())));
+                execs().with_stdout(format!("\
+{compiling} (debug) bar v0.5.0 ({url})
+{compiling} (debug) foo v0.5.0 ({url})
+", compiling = COMPILING, url = p.url())));
 
     assert_that(&p.bin("foo"), existing_file());
 
@@ -274,10 +274,10 @@ test!(no_rebuild_dependency {
         "#);
     // First time around we should compile both foo and bar
     assert_that(p.cargo_process("build"),
-                execs().with_stdout(format!("{} bar v0.5.0 ({})\n\
-                                             {} foo v0.5.0 ({})\n",
-                                            COMPILING, p.url(),
-                                            COMPILING, p.url())));
+                execs().with_stdout(format!("\
+{compiling} (debug) bar v0.5.0 ({url})
+{compiling} (debug) foo v0.5.0 ({url})
+", compiling = COMPILING, url = p.url())));
     // This time we shouldn't compile bar
     assert_that(p.cargo("build"),
                 execs().with_stdout(""));
@@ -285,10 +285,10 @@ test!(no_rebuild_dependency {
 
     p.build(); // rebuild the files (rewriting them in the process)
     assert_that(p.cargo("build"),
-                execs().with_stdout(format!("{} bar v0.5.0 ({})\n\
-                                             {} foo v0.5.0 ({})\n",
-                                            COMPILING, p.url(),
-                                            COMPILING, p.url())));
+                execs().with_stdout(format!("\
+{compiling} (debug) bar v0.5.0 ({url})
+{compiling} (debug) foo v0.5.0 ({url})
+", compiling = COMPILING, url = p.url())));
 });
 
 test!(deep_dependencies_trigger_rebuild {
@@ -340,12 +340,11 @@ test!(deep_dependencies_trigger_rebuild {
             pub fn baz() {}
         "#);
     assert_that(p.cargo_process("build"),
-                execs().with_stdout(format!("{} baz v0.5.0 ({})\n\
-                                             {} bar v0.5.0 ({})\n\
-                                             {} foo v0.5.0 ({})\n",
-                                            COMPILING, p.url(),
-                                            COMPILING, p.url(),
-                                            COMPILING, p.url())));
+                execs().with_stdout(format!("\
+{compiling} (debug) baz v0.5.0 ({url})
+{compiling} (debug) bar v0.5.0 ({url})
+{compiling} (debug) foo v0.5.0 ({url})
+", compiling = COMPILING, url = p.url())));
     assert_that(p.cargo("build"),
                 execs().with_stdout(""));
 
@@ -358,12 +357,11 @@ test!(deep_dependencies_trigger_rebuild {
         pub fn baz() { println!("hello!"); }
     "#).unwrap();
     assert_that(p.cargo("build"),
-                execs().with_stdout(format!("{} baz v0.5.0 ({})\n\
-                                             {} bar v0.5.0 ({})\n\
-                                             {} foo v0.5.0 ({})\n",
-                                            COMPILING, p.url(),
-                                            COMPILING, p.url(),
-                                            COMPILING, p.url())));
+                execs().with_stdout(format!("\
+{compiling} (debug) baz v0.5.0 ({url})
+{compiling} (debug) bar v0.5.0 ({url})
+{compiling} (debug) foo v0.5.0 ({url})
+", compiling = COMPILING, url = p.url())));
 
     // Make sure an update to bar doesn't trigger baz
     timer::sleep(Duration::seconds(1));
@@ -372,10 +370,10 @@ test!(deep_dependencies_trigger_rebuild {
         pub fn bar() { println!("hello!"); baz::baz(); }
     "#).unwrap();
     assert_that(p.cargo("build"),
-                execs().with_stdout(format!("{} bar v0.5.0 ({})\n\
-                                             {} foo v0.5.0 ({})\n",
-                                            COMPILING, p.url(),
-                                            COMPILING, p.url())));
+                execs().with_stdout(format!("\
+{compiling} (debug) bar v0.5.0 ({url})
+{compiling} (debug) foo v0.5.0 ({url})
+", compiling = COMPILING, url = p.url())));
 
 });
 
@@ -429,12 +427,11 @@ test!(no_rebuild_two_deps {
             pub fn baz() {}
         "#);
     assert_that(p.cargo_process("build"),
-                execs().with_stdout(format!("{} baz v0.5.0 ({})\n\
-                                             {} bar v0.5.0 ({})\n\
-                                             {} foo v0.5.0 ({})\n",
-                                            COMPILING, p.url(),
-                                            COMPILING, p.url(),
-                                            COMPILING, p.url())));
+                execs().with_stdout(format!("\
+{compiling} (debug) baz v0.5.0 ({url})
+{compiling} (debug) bar v0.5.0 ({url})
+{compiling} (debug) foo v0.5.0 ({url})
+", compiling = COMPILING, url = p.url())));
     assert_that(&p.bin("foo"), existing_file());
     assert_that(p.cargo("build"),
                 execs().with_stdout(""));
@@ -476,10 +473,10 @@ test!(nested_deps_recompile {
     let bar = p.url();
 
     assert_that(p.cargo_process("build"),
-                execs().with_stdout(format!("{} bar v0.5.0 ({})\n\
-                                             {} foo v0.5.0 ({})\n",
-                                            COMPILING, bar,
-                                            COMPILING, p.url())));
+                execs().with_stdout(format!("\
+{compiling} (debug) bar v0.5.0 ({bar})
+{compiling} (debug) foo v0.5.0 ({url})
+", compiling = COMPILING, bar = bar, url = p.url())));
     p.root().move_into_the_past().unwrap();
 
     File::create(&p.root().join("src/foo.rs")).unwrap().write_all(br#"
@@ -488,8 +485,9 @@ test!(nested_deps_recompile {
 
     // This shouldn't recompile `bar`
     assert_that(p.cargo("build"),
-                execs().with_stdout(format!("{} foo v0.5.0 ({})\n",
-                                            COMPILING, p.url())));
+                execs().with_stdout(format!("\
+{compiling} (debug) foo v0.5.0 ({url})
+", compiling = COMPILING, url = p.url())));
 });
 
 test!(error_message_for_missing_manifest {
@@ -677,10 +675,10 @@ test!(path_dep_build_cmd {
     p.root().join("bar").move_into_the_past().unwrap();
 
     assert_that(p.cargo("build"),
-        execs().with_stdout(format!("{} bar v0.5.0 ({})\n\
-                                     {} foo v0.5.0 ({})\n",
-                                    COMPILING, p.url(),
-                                    COMPILING, p.url())));
+                execs().with_stdout(format!("\
+{compiling} (debug) bar v0.5.0 ({url})
+{compiling} (debug) foo v0.5.0 ({url})
+", compiling = COMPILING, url = p.url())));
 
     assert_that(&p.bin("foo"), existing_file());
 
@@ -694,10 +692,10 @@ test!(path_dep_build_cmd {
     }
 
     assert_that(p.cargo("build"),
-        execs().with_stdout(format!("{} bar v0.5.0 ({})\n\
-                                     {} foo v0.5.0 ({})\n",
-                                    COMPILING, p.url(),
-                                    COMPILING, p.url())));
+                execs().with_stdout(format!("\
+{compiling} (debug) bar v0.5.0 ({url})
+{compiling} (debug) foo v0.5.0 ({url})
+", compiling = COMPILING, url = p.url())));
 
     assert_that(cargo::util::process(&p.bin("foo")).unwrap(),
                 execs().with_stdout("1\n"));
@@ -734,19 +732,20 @@ test!(dev_deps_no_rebuild_lib {
     assert_that(p.cargo("build")
                  .env("FOO", "bar"),
                 execs().with_status(0)
-                       .with_stdout(format!("{} foo v0.5.0 ({})\n",
-                                            COMPILING, p.url())));
+                       .with_stdout(format!("\
+{compiling} (debug) foo v0.5.0 ({url})
+", compiling = COMPILING, url = p.url())));
 
     assert_that(p.cargo("test"),
                 execs().with_status(0)
                        .with_stdout(format!("\
-{} [..] v0.5.0 ({})
-{} [..] v0.5.0 ({})
+{compiling} (debug) [..] v0.5.0 ({url})
+{compiling} (debug) [..] v0.5.0 ({url})
 Running target[..]foo-[..]
 
 running 0 tests
 
 test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
 
-", COMPILING, p.url(), COMPILING, p.url())));
+", compiling = COMPILING, url = p.url())));
 });

--- a/tests/test_cargo_cross_compile.rs
+++ b/tests/test_cargo_cross_compile.rs
@@ -280,7 +280,7 @@ test!(linker_and_ar {
                                               .arg("-v"),
                 execs().with_status(101)
                        .with_stdout(format!("\
-{compiling} foo v0.5.0 ({url})
+{compiling} (debug) foo v0.5.0 ({url})
 {running} `rustc src/foo.rs --crate-name foo --crate-type bin -g \
     --out-dir {dir}[..]target[..]{target} \
     --emit=dep-info,link \
@@ -394,7 +394,7 @@ test!(cross_tests {
     assert_that(p.cargo_process("test").arg("--target").arg(target),
                 execs().with_status(0)
                        .with_stdout(format!("\
-{compiling} foo v0.0.0 ({foo})
+{compiling} (debug) foo v0.0.0 ({foo})
 {running} target[..]{triple}[..]bar-[..]
 
 running 1 test
@@ -474,7 +474,7 @@ test!(cross_with_a_build_script {
     assert_that(p.cargo_process("build").arg("--target").arg(&target).arg("-v"),
                 execs().with_status(0)
                        .with_stdout(format!("\
-{compiling} foo v0.0.0 (file://[..])
+{compiling} (debug) foo v0.0.0 (file://[..])
 {running} `rustc build.rs [..] --out-dir {dir}[..]target[..]build[..]foo-[..]`
 {running} `{dir}[..]target[..]build[..]foo-[..]build-script-build`
 {running} `rustc src[..]main.rs [..] --target {target} [..]`
@@ -543,7 +543,7 @@ test!(build_script_needed_for_host_and_target {
     assert_that(p.cargo_process("build").arg("--target").arg(&target).arg("-v"),
                 execs().with_status(0)
                        .with_stdout(format!("\
-{compiling} d1 v0.0.0 (file://{dir})
+{compiling} (debug) d1 v0.0.0 (file://{dir})
 {running} `rustc d1[..]build.rs [..] --out-dir {dir}[..]target[..]build[..]d1-[..]`
 {running} `{dir}[..]target[..]build[..]d1-[..]build-script-build`
 {running} `{dir}[..]target[..]build[..]d1-[..]build-script-build`
@@ -551,10 +551,10 @@ test!(build_script_needed_for_host_and_target {
            -L /path/to/{target}`
 {running} `rustc d1[..]src[..]lib.rs [..] \
            -L /path/to/{host}`
-{compiling} d2 v0.0.0 (file://{dir})
+{compiling} (debug) d2 v0.0.0 (file://{dir})
 {running} `rustc d2[..]src[..]lib.rs [..] \
            -L /path/to/{host}`
-{compiling} foo v0.0.0 (file://{dir})
+{compiling} (debug) foo v0.0.0 (file://{dir})
 {running} `rustc build.rs [..] --out-dir {dir}[..]target[..]build[..]foo-[..] \
            -L /path/to/{host}`
 {running} `{dir}[..]target[..]build[..]foo-[..]build-script-build`
@@ -666,7 +666,7 @@ test!(plugin_build_script_right_arch {
     assert_that(p.cargo_process("build").arg("-v").arg("--target").arg(alternate()),
                 execs().with_status(0)
                        .with_stdout(format!("\
-{compiling} foo v0.0.1 ([..])
+{compiling} (debug) foo v0.0.1 ([..])
 {running} `rustc build.rs [..]`
 {running} `[..]build-script-build[..]`
 {running} `rustc src[..]lib.rs [..]`

--- a/tests/test_cargo_doc.rs
+++ b/tests/test_cargo_doc.rs
@@ -21,7 +21,7 @@ test!(simple {
 
     assert_that(p.cargo_process("doc"),
                 execs().with_status(0).with_stdout(format!("\
-{compiling} foo v0.0.1 ({dir})
+{compiling} (debug) foo v0.0.1 ({dir})
 ",
         compiling = COMPILING,
         dir = path2url(p.root())).as_slice()));
@@ -63,7 +63,7 @@ test!(doc_twice {
 
     assert_that(p.cargo_process("doc"),
                 execs().with_status(0).with_stdout(format!("\
-{compiling} foo v0.0.1 ({dir})
+{compiling} (debug) foo v0.0.1 ({dir})
 ",
         compiling = COMPILING,
         dir = path2url(p.root())).as_slice()));
@@ -99,8 +99,8 @@ test!(doc_deps {
 
     assert_that(p.cargo_process("doc"),
                 execs().with_status(0).with_stdout(format!("\
-{compiling} bar v0.0.1 ({dir})
-{compiling} foo v0.0.1 ({dir})
+{compiling} (debug) bar v0.0.1 ({dir})
+{compiling} (debug) foo v0.0.1 ({dir})
 ",
         compiling = COMPILING,
         dir = path2url(p.root())).as_slice()));
@@ -145,8 +145,8 @@ test!(doc_no_deps {
 
     assert_that(p.cargo_process("doc").arg("--no-deps"),
                 execs().with_status(0).with_stdout(format!("\
-{compiling} bar v0.0.1 ({dir})
-{compiling} foo v0.0.1 ({dir})
+{compiling} (debug) bar v0.0.1 ({dir})
+{compiling} (debug) foo v0.0.1 ({dir})
 ",
         compiling = COMPILING,
         dir = path2url(p.root())).as_slice()));
@@ -241,7 +241,7 @@ test!(doc_dash_p {
     assert_that(p.cargo_process("doc").arg("-p").arg("a"),
                 execs().with_status(0)
                        .with_stdout(format!("\
-{compiling} b v0.0.1 (file://[..])
-{compiling} a v0.0.1 (file://[..])
+{compiling} (debug) b v0.0.1 (file://[..])
+{compiling} (debug) a v0.0.1 (file://[..])
 ", compiling = COMPILING).as_slice()));
 });

--- a/tests/test_cargo_features.rs
+++ b/tests/test_cargo_features.rs
@@ -246,15 +246,15 @@ test!(no_feature_doesnt_build {
 
     assert_that(p.cargo_process("build"),
                 execs().with_status(0).with_stdout(format!("\
-{compiling} foo v0.0.1 ({dir})
+{compiling} (debug) foo v0.0.1 ({dir})
 ", compiling = COMPILING, dir = p.url()).as_slice()));
     assert_that(p.process(&p.bin("foo")),
                 execs().with_status(0).with_stdout(""));
 
     assert_that(p.cargo("build").arg("--features").arg("bar"),
                 execs().with_status(0).with_stdout(format!("\
-{compiling} bar v0.0.1 ({dir})
-{compiling} foo v0.0.1 ({dir})
+{compiling} (debug) bar v0.0.1 ({dir})
+{compiling} (debug) foo v0.0.1 ({dir})
 ", compiling = COMPILING, dir = p.url()).as_slice()));
     assert_that(p.process(&p.bin("foo")),
                 execs().with_status(0).with_stdout("bar\n"));
@@ -293,15 +293,15 @@ test!(default_feature_pulled_in {
 
     assert_that(p.cargo_process("build"),
                 execs().with_status(0).with_stdout(format!("\
-{compiling} bar v0.0.1 ({dir})
-{compiling} foo v0.0.1 ({dir})
+{compiling} (debug) bar v0.0.1 ({dir})
+{compiling} (debug) foo v0.0.1 ({dir})
 ", compiling = COMPILING, dir = p.url()).as_slice()));
     assert_that(p.process(&p.bin("foo")),
                 execs().with_status(0).with_stdout("bar\n"));
 
     assert_that(p.cargo("build").arg("--no-default-features"),
                 execs().with_status(0).with_stdout(format!("\
-{compiling} foo v0.0.1 ({dir})
+{compiling} (debug) foo v0.0.1 ({dir})
 ", compiling = COMPILING, dir = p.url()).as_slice()));
     assert_that(p.process(&p.bin("foo")),
                 execs().with_status(0).with_stdout(""));
@@ -394,9 +394,9 @@ test!(groups_on_groups_on_groups {
 
     assert_that(p.cargo_process("build"),
                 execs().with_status(0).with_stdout(format!("\
-{compiling} ba[..] v0.0.1 ({dir})
-{compiling} ba[..] v0.0.1 ({dir})
-{compiling} foo v0.0.1 ({dir})
+{compiling} (debug) ba[..] v0.0.1 ({dir})
+{compiling} (debug) ba[..] v0.0.1 ({dir})
+{compiling} (debug) foo v0.0.1 ({dir})
 ", compiling = COMPILING, dir = p.url()).as_slice()));
 });
 
@@ -438,9 +438,9 @@ test!(many_cli_features {
 
     assert_that(p.cargo_process("build").arg("--features").arg("bar baz"),
                 execs().with_status(0).with_stdout(format!("\
-{compiling} ba[..] v0.0.1 ({dir})
-{compiling} ba[..] v0.0.1 ({dir})
-{compiling} foo v0.0.1 ({dir})
+{compiling} (debug) ba[..] v0.0.1 ({dir})
+{compiling} (debug) ba[..] v0.0.1 ({dir})
+{compiling} (debug) foo v0.0.1 ({dir})
 ", compiling = COMPILING, dir = p.url()).as_slice()));
 });
 
@@ -499,9 +499,9 @@ test!(union_features {
 
     assert_that(p.cargo_process("build"),
                 execs().with_status(0).with_stdout(format!("\
-{compiling} d2 v0.0.1 ({dir})
-{compiling} d1 v0.0.1 ({dir})
-{compiling} foo v0.0.1 ({dir})
+{compiling} (debug) d2 v0.0.1 ({dir})
+{compiling} (debug) d1 v0.0.1 ({dir})
+{compiling} (debug) foo v0.0.1 ({dir})
 ", compiling = COMPILING, dir = p.url()).as_slice()));
 });
 
@@ -533,15 +533,15 @@ test!(many_features_no_rebuilds {
 
     assert_that(p.cargo_process("build"),
                 execs().with_status(0).with_stdout(format!("\
-{compiling} a v0.1.0 ({dir})
-{compiling} b v0.1.0 ({dir})
+{compiling} (debug) a v0.1.0 ({dir})
+{compiling} (debug) b v0.1.0 ({dir})
 ", compiling = COMPILING, dir = p.url()).as_slice()));
     p.root().move_into_the_past().unwrap();
 
     assert_that(p.cargo("build").arg("-v"),
                 execs().with_status(0).with_stdout(format!("\
-{fresh} a v0.1.0 ([..])
-{fresh} b v0.1.0 ([..])
+{fresh} (debug) a v0.1.0 ([..])
+{fresh} (debug) b v0.1.0 ([..])
 ", fresh = FRESH).as_slice()));
 });
 

--- a/tests/test_cargo_freshness.rs
+++ b/tests/test_cargo_freshness.rs
@@ -23,7 +23,7 @@ test!(modifying_and_moving {
 
     assert_that(p.cargo_process("build"),
                 execs().with_status(0).with_stdout(format!("\
-{compiling} foo v0.0.1 ({dir})
+{compiling} (debug) foo v0.0.1 ({dir})
 ", compiling = COMPILING, dir = path2url(p.root()))));
 
     assert_that(p.cargo("build"),
@@ -35,7 +35,7 @@ test!(modifying_and_moving {
          .write_all(b"fn main() {}").unwrap();
     assert_that(p.cargo("build"),
                 execs().with_status(0).with_stdout(format!("\
-{compiling} foo v0.0.1 ({dir})
+{compiling} (debug) foo v0.0.1 ({dir})
 ", compiling = COMPILING, dir = path2url(p.root()))));
 
     fs::rename(&p.root().join("src/a.rs"), &p.root().join("src/b.rs")).unwrap();
@@ -62,7 +62,7 @@ test!(modify_only_some_files {
 
     assert_that(p.cargo_process("build"),
                 execs().with_status(0).with_stdout(format!("\
-{compiling} foo v0.0.1 ({dir})
+{compiling} (debug) foo v0.0.1 ({dir})
 ", compiling = COMPILING, dir = path2url(p.root()))));
     assert_that(p.cargo("test"),
                 execs().with_status(0));
@@ -82,7 +82,7 @@ test!(modify_only_some_files {
     assert_that(p.cargo("build")
                  .env("RUST_LOG", "cargo::ops::cargo_rustc::fingerprint"),
                 execs().with_status(0).with_stdout(format!("\
-{compiling} foo v0.0.1 ({dir})
+{compiling} (debug) foo v0.0.1 ({dir})
 ", compiling = COMPILING, dir = path2url(p.root()))));
     assert_that(&p.bin("foo"), existing_file());
 });
@@ -154,19 +154,19 @@ test!(changing_features_is_ok {
     assert_that(p.cargo_process("build"),
                 execs().with_status(0)
                        .with_stdout("\
-[..]Compiling foo v0.0.1 ([..])
+[..]Compiling (debug) foo v0.0.1 ([..])
 "));
 
     assert_that(p.cargo("build").arg("--features").arg("foo"),
                 execs().with_status(0)
                        .with_stdout("\
-[..]Compiling foo v0.0.1 ([..])
+[..]Compiling (debug) foo v0.0.1 ([..])
 "));
 
     assert_that(p.cargo("build"),
                 execs().with_status(0)
                        .with_stdout("\
-[..]Compiling foo v0.0.1 ([..])
+[..]Compiling (debug) foo v0.0.1 ([..])
 "));
 
     assert_that(p.cargo("build"),

--- a/tests/test_cargo_package.rs
+++ b/tests/test_cargo_package.rs
@@ -33,7 +33,7 @@ test!(simple {
                 execs().with_status(0).with_stdout(format!("\
 {packaging} foo v0.0.1 ({dir})
 {verifying} foo v0.0.1 ({dir})
-{compiling} foo v0.0.1 ({dir}[..])
+{compiling} (debug) foo v0.0.1 ({dir}[..])
 ",
         packaging = PACKAGING,
         verifying = VERIFYING,
@@ -77,7 +77,7 @@ test!(metadata_warning {
                 execs().with_status(0).with_stdout(format!("\
 {packaging} foo v0.0.1 ({dir})
 {verifying} foo v0.0.1 ({dir})
-{compiling} foo v0.0.1 ({dir}[..])
+{compiling} (debug) foo v0.0.1 ({dir}[..])
 ",
         packaging = PACKAGING,
         verifying = VERIFYING,
@@ -103,7 +103,7 @@ http://doc.crates.io/manifest.html#package-metadata for more info."));
                 execs().with_status(0).with_stdout(format!("\
 {packaging} foo v0.0.1 ({dir})
 {verifying} foo v0.0.1 ({dir})
-{compiling} foo v0.0.1 ({dir}[..])
+{compiling} (debug) foo v0.0.1 ({dir}[..])
 ",
         packaging = PACKAGING,
         verifying = VERIFYING,
@@ -130,7 +130,7 @@ http://doc.crates.io/manifest.html#package-metadata for more info."));
                 execs().with_status(0).with_stdout(format!("\
 {packaging} foo v0.0.1 ({dir})
 {verifying} foo v0.0.1 ({dir})
-{compiling} foo v0.0.1 ({dir}[..])
+{compiling} (debug) foo v0.0.1 ({dir}[..])
 ",
         packaging = PACKAGING,
         verifying = VERIFYING,
@@ -189,7 +189,7 @@ test!(package_verification {
                 execs().with_status(0).with_stdout(format!("\
 {packaging} foo v0.0.1 ({dir})
 {verifying} foo v0.0.1 ({dir})
-{compiling} foo v0.0.1 ({dir}[..])
+{compiling} (debug) foo v0.0.1 ({dir}[..])
 ",
         packaging = PACKAGING,
         verifying = VERIFYING,

--- a/tests/test_cargo_profiles.rs
+++ b/tests/test_cargo_profiles.rs
@@ -26,7 +26,7 @@ test!(profile_overrides {
         .file("src/lib.rs", "");
     assert_that(p.cargo_process("build").arg("-v"),
                 execs().with_status(0).with_stdout(format!("\
-{compiling} test v0.0.0 ({url})
+{compiling} (debug) test v0.0.0 ({url})
 {running} `rustc src{sep}lib.rs --crate-name test --crate-type lib \
         -C opt-level=1 \
         --cfg ndebug \
@@ -80,7 +80,7 @@ test!(top_level_overrides_deps {
         .file("foo/src/lib.rs", "");
     assert_that(p.cargo_process("build").arg("-v").arg("--release"),
                 execs().with_status(0).with_stdout(format!("\
-{compiling} foo v0.0.0 ({url})
+{compiling} (release) foo v0.0.0 ({url})
 {running} `rustc foo{sep}src{sep}lib.rs --crate-name foo \
         --crate-type dylib --crate-type rlib -C prefer-dynamic \
         -C opt-level=1 \
@@ -91,7 +91,7 @@ test!(top_level_overrides_deps {
         --emit=dep-info,link \
         -L dependency={dir}{sep}target{sep}release{sep}deps \
         -L dependency={dir}{sep}target{sep}release{sep}deps`
-{compiling} test v0.0.0 ({url})
+{compiling} (release) test v0.0.0 ({url})
 {running} `rustc src{sep}lib.rs --crate-name test --crate-type lib \
         -C opt-level=1 \
         -g \

--- a/tests/test_cargo_registry.rs
+++ b/tests/test_cargo_registry.rs
@@ -33,8 +33,8 @@ test!(simple {
                 execs().with_status(0).with_stdout(format!("\
 {updating} registry `{reg}`
 {downloading} bar v0.0.1 (registry file://[..])
-{compiling} bar v0.0.1 (registry file://[..])
-{compiling} foo v0.0.1 ({dir})
+{compiling} (debug) bar v0.0.1 (registry file://[..])
+{compiling} (debug) foo v0.0.1 ({dir})
 ",
         updating = UPDATING,
         downloading = DOWNLOADING,
@@ -75,9 +75,9 @@ test!(deps {
 {updating} registry `{reg}`
 {downloading} [..] v0.0.1 (registry file://[..])
 {downloading} [..] v0.0.1 (registry file://[..])
-{compiling} baz v0.0.1 (registry file://[..])
-{compiling} bar v0.0.1 (registry file://[..])
-{compiling} foo v0.0.1 ({dir})
+{compiling} (debug) baz v0.0.1 (registry file://[..])
+{compiling} (debug) bar v0.0.1 (registry file://[..])
+{compiling} (debug) foo v0.0.1 ({dir})
 ",
         updating = UPDATING,
         downloading = DOWNLOADING,
@@ -197,8 +197,8 @@ version required: >= 0.0.0
                 execs().with_status(0).with_stdout(format!("\
 {updating} registry `{reg}`
 {downloading} notyet v0.0.1 (registry file://[..])
-{compiling} notyet v0.0.1 (registry file://[..])
-{compiling} foo v0.0.1 ({dir})
+{compiling} (debug) notyet v0.0.1 (registry file://[..])
+{compiling} (debug) foo v0.0.1 ({dir})
 ",
         updating = UPDATING,
         downloading = DOWNLOADING,
@@ -250,8 +250,8 @@ version required: ^0.0.1
 {verifying} foo v0.0.1 ({dir})
 {updating} registry `[..]`
 {downloading} notyet v0.0.1 (registry file://[..])
-{compiling} notyet v0.0.1 (registry file://[..])
-{compiling} foo v0.0.1 ({dir}[..])
+{compiling} (debug) notyet v0.0.1 (registry file://[..])
+{compiling} (debug) foo v0.0.1 ({dir}[..])
 ",
     packaging = PACKAGING,
     verifying = VERIFYING,
@@ -282,8 +282,8 @@ test!(lockfile_locks {
                 execs().with_status(0).with_stdout(format!("\
 {updating} registry `[..]`
 {downloading} bar v0.0.1 (registry file://[..])
-{compiling} bar v0.0.1 (registry file://[..])
-{compiling} foo v0.0.1 ({dir})
+{compiling} (debug) bar v0.0.1 (registry file://[..])
+{compiling} (debug) foo v0.0.1 ({dir})
 ", updating = UPDATING, downloading = DOWNLOADING, compiling = COMPILING,
    dir = p.url()).as_slice()));
 
@@ -316,9 +316,9 @@ test!(lockfile_locks_transitively {
 {updating} registry `[..]`
 {downloading} [..] v0.0.1 (registry file://[..])
 {downloading} [..] v0.0.1 (registry file://[..])
-{compiling} baz v0.0.1 (registry file://[..])
-{compiling} bar v0.0.1 (registry file://[..])
-{compiling} foo v0.0.1 ({dir})
+{compiling} (debug) baz v0.0.1 (registry file://[..])
+{compiling} (debug) bar v0.0.1 (registry file://[..])
+{compiling} (debug) foo v0.0.1 ({dir})
 ", updating = UPDATING, downloading = DOWNLOADING, compiling = COMPILING,
    dir = p.url()).as_slice()));
 
@@ -354,9 +354,9 @@ test!(yanks_are_not_used {
 {updating} registry `[..]`
 {downloading} [..] v0.0.1 (registry file://[..])
 {downloading} [..] v0.0.1 (registry file://[..])
-{compiling} baz v0.0.1 (registry file://[..])
-{compiling} bar v0.0.1 (registry file://[..])
-{compiling} foo v0.0.1 ({dir})
+{compiling} (debug) baz v0.0.1 (registry file://[..])
+{compiling} (debug) bar v0.0.1 (registry file://[..])
+{compiling} (debug) foo v0.0.1 ({dir})
 ", updating = UPDATING, downloading = DOWNLOADING, compiling = COMPILING,
    dir = p.url()).as_slice()));
 });
@@ -482,8 +482,8 @@ test!(update_lockfile {
     assert_that(p.cargo("build"),
                 execs().with_status(0).with_stdout(format!("\
 {downloading} [..] v0.0.2 (registry file://[..])
-{compiling} bar v0.0.2 (registry file://[..])
-{compiling} foo v0.0.1 ({dir})
+{compiling} (debug) bar v0.0.2 (registry file://[..])
+{compiling} (debug) foo v0.0.1 ({dir})
 ", downloading = DOWNLOADING, compiling = COMPILING,
    dir = p.url()).as_slice()));
 
@@ -498,8 +498,8 @@ test!(update_lockfile {
     assert_that(p.cargo("build"),
                 execs().with_status(0).with_stdout(format!("\
 {downloading} [..] v0.0.3 (registry file://[..])
-{compiling} bar v0.0.3 (registry file://[..])
-{compiling} foo v0.0.1 ({dir})
+{compiling} (debug) bar v0.0.3 (registry file://[..])
+{compiling} (debug) foo v0.0.1 ({dir})
 ", downloading = DOWNLOADING, compiling = COMPILING,
    dir = p.url()).as_slice()));
 });
@@ -525,8 +525,8 @@ test!(dev_dependency_not_used {
                 execs().with_status(0).with_stdout(format!("\
 {updating} registry `[..]`
 {downloading} [..] v0.0.1 (registry file://[..])
-{compiling} bar v0.0.1 (registry file://[..])
-{compiling} foo v0.0.1 ({dir})
+{compiling} (debug) bar v0.0.1 (registry file://[..])
+{compiling} (debug) foo v0.0.1 ({dir})
 ", updating = UPDATING, downloading = DOWNLOADING, compiling = COMPILING,
    dir = p.url()).as_slice()));
 });
@@ -591,9 +591,9 @@ test!(updating_a_dep {
                 execs().with_status(0).with_stdout(format!("\
 {updating} registry `[..]`
 {downloading} bar v0.0.1 (registry file://[..])
-{compiling} bar v0.0.1 (registry file://[..])
-{compiling} a v0.0.1 ({dir})
-{compiling} foo v0.0.1 ({dir})
+{compiling} (debug) bar v0.0.1 (registry file://[..])
+{compiling} (debug) a v0.0.1 ({dir})
+{compiling} (debug) foo v0.0.1 ({dir})
 ", updating = UPDATING, downloading = DOWNLOADING, compiling = COMPILING,
    dir = p.url()).as_slice()));
 
@@ -613,9 +613,9 @@ test!(updating_a_dep {
                 execs().with_status(0).with_stdout(format!("\
 {updating} registry `[..]`
 {downloading} bar v0.1.0 (registry file://[..])
-{compiling} bar v0.1.0 (registry file://[..])
-{compiling} a v0.0.1 ({dir})
-{compiling} foo v0.0.1 ({dir})
+{compiling} (debug) bar v0.1.0 (registry file://[..])
+{compiling} (debug) a v0.0.1 ({dir})
+{compiling} (debug) foo v0.0.1 ({dir})
 ", updating = UPDATING, downloading = DOWNLOADING, compiling = COMPILING,
    dir = p.url()).as_slice()));
 });
@@ -657,9 +657,9 @@ test!(git_and_registry_dep {
 {updating} [..]
 {updating} [..]
 {downloading} a v0.0.1 (registry file://[..])
-{compiling} a v0.0.1 (registry [..])
-{compiling} b v0.0.1 ([..])
-{compiling} foo v0.0.1 ({dir})
+{compiling} (debug) a v0.0.1 (registry [..])
+{compiling} (debug) b v0.0.1 ([..])
+{compiling} (debug) foo v0.0.1 ({dir})
 ", updating = UPDATING, downloading = DOWNLOADING, compiling = COMPILING,
    dir = p.url()).as_slice()));
     p.root().move_into_the_past().unwrap();
@@ -703,8 +703,8 @@ test!(update_publish_then_update {
                 execs().with_status(0).with_stdout(format!("\
 {updating} [..]
 {downloading} a v0.1.1 (registry file://[..])
-{compiling} a v0.1.1 (registry [..])
-{compiling} foo v0.5.0 ({dir})
+{compiling} (debug) a v0.1.1 (registry [..])
+{compiling} (debug) foo v0.5.0 ({dir})
 ", updating = UPDATING, downloading = DOWNLOADING, compiling = COMPILING,
    dir = p.url()).as_slice()));
 

--- a/tests/test_cargo_run.rs
+++ b/tests/test_cargo_run.rs
@@ -21,7 +21,7 @@ test!(simple {
 
     assert_that(p.cargo_process("run"),
                 execs().with_status(0).with_stdout(format!("\
-{compiling} foo v0.0.1 ({dir})
+{compiling} (debug) foo v0.0.1 ({dir})
 {running} `target{sep}foo`
 hello
 ",
@@ -122,7 +122,7 @@ test!(specify_name {
 
     assert_that(p.cargo_process("run").arg("--bin").arg("a"),
                 execs().with_status(0).with_stdout(format!("\
-{compiling} foo v0.0.1 ({dir})
+{compiling} (debug) foo v0.0.1 ({dir})
 {running} `target{sep}a`
 hello a.rs
 ",
@@ -158,7 +158,7 @@ test!(run_example {
 
     assert_that(p.cargo_process("run").arg("--example").arg("a"),
                 execs().with_status(0).with_stdout(format!("\
-{compiling} foo v0.0.1 ({dir})
+{compiling} (debug) foo v0.0.1 ({dir})
 {running} `target{sep}examples{sep}a`
 example
 ",
@@ -210,7 +210,7 @@ test!(one_bin_multiple_examples {
 
     assert_that(p.cargo_process("run"),
                 execs().with_status(0).with_stdout(format!("\
-{compiling} foo v0.0.1 ({dir})
+{compiling} (debug) foo v0.0.1 ({dir})
 {running} `target{sep}main`
 hello main.rs
 ",
@@ -265,7 +265,7 @@ test!(example_with_release_flag {
 
     assert_that(p.cargo_process("run").arg("-v").arg("--release").arg("--example").arg("a"),
                 execs().with_status(0).with_stdout(format!("\
-{compiling} bar v0.0.1 ({url})
+{compiling} (release) bar v0.0.1 ({url})
 {running} `rustc bar{sep}src{sep}bar.rs --crate-name bar --crate-type lib \
         -C opt-level=3 \
         --cfg ndebug \
@@ -275,7 +275,7 @@ test!(example_with_release_flag {
         --emit=dep-info,link \
         -L dependency={dir}{sep}target{sep}release{sep}deps \
         -L dependency={dir}{sep}target{sep}release{sep}deps`
-{compiling} foo v0.0.1 ({url})
+{compiling} (release) foo v0.0.1 ({url})
 {running} `rustc examples{sep}a.rs --crate-name a --crate-type bin \
         -C opt-level=3 \
         --cfg ndebug \
@@ -296,7 +296,7 @@ fast2
 
     assert_that(p.cargo("run").arg("-v").arg("--example").arg("a"),
                 execs().with_status(0).with_stdout(format!("\
-{compiling} bar v0.0.1 ({url})
+{compiling} (debug) bar v0.0.1 ({url})
 {running} `rustc bar{sep}src{sep}bar.rs --crate-name bar --crate-type lib \
         -g \
         -C metadata=[..] \
@@ -305,7 +305,7 @@ fast2
         --emit=dep-info,link \
         -L dependency={dir}{sep}target{sep}deps \
         -L dependency={dir}{sep}target{sep}deps`
-{compiling} foo v0.0.1 ({url})
+{compiling} (debug) foo v0.0.1 ({url})
 {running} `rustc examples{sep}a.rs --crate-name a --crate-type bin \
         -g \
         --out-dir {dir}{sep}target{sep}examples \
@@ -369,7 +369,7 @@ test!(release_works {
 
     assert_that(p.cargo_process("run").arg("--release"),
                 execs().with_status(0).with_stdout(format!("\
-{compiling} foo v0.0.1 ({dir})
+{compiling} (release) foo v0.0.1 ({dir})
 {running} `target{sep}release{sep}foo`
 ",
         compiling = COMPILING,

--- a/tests/test_cargo_test.rs
+++ b/tests/test_cargo_test.rs
@@ -33,7 +33,7 @@ test!(cargo_test_simple {
 
     assert_that(p.cargo("test"),
                 execs().with_stdout(format!("\
-{} foo v0.5.0 ({})
+{} (debug) foo v0.5.0 ({})
 {} target[..]foo-[..]
 
 running 1 test
@@ -56,7 +56,7 @@ test!(cargo_test_verbose {
 
     assert_that(p.cargo_process("test").arg("-v").arg("hello"),
         execs().with_stdout(format!("\
-{compiling} foo v0.5.0 ({url})
+{compiling} (debug) foo v0.5.0 ({url})
 {running} `rustc src[..]foo.rs [..]`
 {running} `[..]target[..]foo-[..] hello`
 
@@ -123,7 +123,7 @@ test!(cargo_test_failing_test {
 
     assert_that(p.cargo("test"),
                 execs().with_stdout(format!("\
-{} foo v0.5.0 ({})
+{} (debug) foo v0.5.0 ({})
 {} target[..]foo-[..]
 
 running 1 test
@@ -187,7 +187,7 @@ test!(test_with_lib_dep {
 
     assert_that(p.cargo_process("test"),
         execs().with_stdout(format!("\
-{} foo v0.0.1 ({})
+{} (debug) foo v0.0.1 ({})
 {running} target[..]baz-[..]
 
 running 1 test
@@ -254,8 +254,8 @@ test!(test_with_deep_lib_dep {
     assert_that(p.cargo_process("test"),
                 execs().with_status(0)
                        .with_stdout(format!("\
-{compiling} foo v0.0.1 ({dir})
-{compiling} bar v0.0.1 ({dir})
+{compiling} (debug) foo v0.0.1 ({dir})
+{compiling} (debug) bar v0.0.1 ({dir})
 {running} target[..]
 
 running 1 test
@@ -303,7 +303,7 @@ test!(external_test_explicit {
 
     assert_that(p.cargo_process("test"),
         execs().with_stdout(format!("\
-{} foo v0.0.1 ({})
+{} (debug) foo v0.0.1 ({})
 {running} target[..]foo-[..]
 
 running 1 test
@@ -351,7 +351,7 @@ test!(external_test_implicit {
 
     assert_that(p.cargo_process("test"),
         execs().with_stdout(format!("\
-{} foo v0.0.1 ({})
+{} (debug) foo v0.0.1 ({})
 {running} target[..]external-[..]
 
 running 1 test
@@ -409,7 +409,7 @@ test!(pass_through_command_line {
     assert_that(p.cargo_process("test").arg("bar"),
                 execs().with_status(0)
                        .with_stdout(format!("\
-{compiling} foo v0.0.1 ({dir})
+{compiling} (debug) foo v0.0.1 ({dir})
 {running} target[..]foo-[..]
 
 running 1 test
@@ -431,7 +431,7 @@ test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
     assert_that(p.cargo_process("test").arg("foo"),
                 execs().with_status(0)
                        .with_stdout(format!("\
-{compiling} foo v0.0.1 ({dir})
+{compiling} (debug) foo v0.0.1 ({dir})
 {running} target[..]foo-[..]
 
 running 1 test
@@ -496,7 +496,7 @@ test!(lib_bin_same_name {
 
     assert_that(p.cargo_process("test"),
         execs().with_stdout(format!("\
-{} foo v0.0.1 ({})
+{} (debug) foo v0.0.1 ({})
 {running} target[..]foo-[..]
 
 running 1 test
@@ -548,7 +548,7 @@ test!(lib_with_standard_name {
     assert_that(p.cargo_process("test"),
                 execs().with_status(0)
                        .with_stdout(format!("\
-{compiling} syntax v0.0.1 ({dir})
+{compiling} (debug) syntax v0.0.1 ({dir})
 {running} target[..]syntax-[..]
 
 running 1 test
@@ -603,7 +603,7 @@ test!(lib_with_standard_name2 {
     assert_that(p.cargo_process("test"),
                 execs().with_status(0)
                        .with_stdout(format!("\
-{compiling} syntax v0.0.1 ({dir})
+{compiling} (debug) syntax v0.0.1 ({dir})
 {running} target[..]syntax-[..]
 
 running 1 test
@@ -689,8 +689,8 @@ test!(test_dylib {
     assert_that(p.cargo_process("test"),
                 execs().with_status(0)
                        .with_stdout(format!("\
-{compiling} bar v0.0.1 ({dir})
-{compiling} foo v0.0.1 ({dir})
+{compiling} (debug) bar v0.0.1 ({dir})
+{compiling} (debug) foo v0.0.1 ({dir})
 {running} target[..]foo-[..]
 
 running 1 test
@@ -763,7 +763,7 @@ test!(test_twice_with_build_cmd {
     assert_that(p.cargo_process("test"),
                 execs().with_status(0)
                        .with_stdout(format!("\
-{compiling} foo v0.0.1 ({dir})
+{compiling} (debug) foo v0.0.1 ({dir})
 {running} target[..]foo-[..]
 
 running 1 test
@@ -819,7 +819,7 @@ test!(test_then_build {
     assert_that(p.cargo_process("test"),
                 execs().with_status(0)
                        .with_stdout(format!("\
-{compiling} foo v0.0.1 ({dir})
+{compiling} (debug) foo v0.0.1 ({dir})
 {running} target[..]foo-[..]
 
 running 1 test
@@ -859,7 +859,7 @@ test!(test_no_run {
     assert_that(p.cargo_process("test").arg("--no-run"),
                 execs().with_status(0)
                        .with_stdout(format!("\
-{compiling} foo v0.0.1 ({dir})
+{compiling} (debug) foo v0.0.1 ({dir})
 ",
                        compiling = COMPILING,
                        dir = p.url()).as_slice()));
@@ -885,7 +885,7 @@ test!(test_run_specific_bin_target {
         .file("src/bin2.rs", "#[test] fn test2() { }");
 
     let expected_stdout = format!("\
-{compiling} foo v0.0.1 ({dir})
+{compiling} (debug) foo v0.0.1 ({dir})
 {running} target[..]bin2-[..]
 
 running 1 test
@@ -916,7 +916,7 @@ test!(test_run_specific_test_target {
         .file("tests/b.rs", "#[test] fn test_b() { }");
 
     let expected_stdout = format!("\
-{compiling} foo v0.0.1 ({dir})
+{compiling} (debug) foo v0.0.1 ({dir})
 {running} target[..]b-[..]
 
 running 1 test
@@ -963,7 +963,7 @@ test!(test_no_harness {
     assert_that(p.cargo_process("test").arg("--").arg("--nocapture"),
                 execs().with_status(0)
                        .with_stdout(format!("\
-{compiling} foo v0.0.1 ({dir})
+{compiling} (debug) foo v0.0.1 ({dir})
 {running} target[..]bar-[..]
 ",
                        compiling = COMPILING, running = RUNNING,
@@ -1016,7 +1016,7 @@ test!(selective_testing {
     assert_that(p.cargo("test").arg("-p").arg("d1"),
                 execs().with_status(0)
                        .with_stdout(format!("\
-{compiling} d1 v0.0.1 ({dir})
+{compiling} (debug) d1 v0.0.1 ({dir})
 {running} target[..]d1-[..]
 
 running 0 tests
@@ -1029,7 +1029,7 @@ test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured\n
     assert_that(p.cargo("test").arg("-p").arg("d2"),
                 execs().with_status(0)
                        .with_stdout(format!("\
-{compiling} d2 v0.0.1 ({dir})
+{compiling} (debug) d2 v0.0.1 ({dir})
 {running} target[..]d2-[..]
 
 running 0 tests
@@ -1042,7 +1042,7 @@ test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured\n
     assert_that(p.cargo("test"),
                 execs().with_status(0)
                        .with_stdout(format!("\
-{compiling} foo v0.0.1 ({dir})
+{compiling} (debug) foo v0.0.1 ({dir})
 {running} target[..]foo-[..]
 
 running 0 tests
@@ -1200,7 +1200,7 @@ test!(selective_testing_with_docs {
     assert_that(p.cargo("test").arg("-p").arg("d1"),
                 execs().with_status(0)
                        .with_stdout(format!("\
-{compiling} d1 v0.0.1 ({dir})
+{compiling} (debug) d1 v0.0.1 ({dir})
 {running} target[..]deps[..]d1[..]
 
 running 0 tests
@@ -1231,7 +1231,7 @@ test!(example_bin_same_name {
     assert_that(p.cargo_process("test").arg("--no-run").arg("-v"),
                 execs().with_status(0)
                        .with_stdout(format!("\
-{compiling} foo v0.0.1 ({dir})
+{compiling} (debug) foo v0.0.1 ({dir})
 {running} `rustc [..]bin[..]foo.rs [..] --test [..]`
 {running} `rustc [..]bin[..]foo.rs [..]`
 {running} `rustc [..]examples[..]foo.rs [..]`
@@ -1365,7 +1365,7 @@ test!(doctest_feature {
 
     assert_that(p.cargo_process("test").arg("--features").arg("bar"),
                 execs().with_status(0).with_stdout(format!("\
-{compiling} foo [..]
+{compiling} (debug) foo [..]
 {running} target[..]foo[..]
 
 running 0 tests


### PR DESCRIPTION
This commit changes the "Compiling" message of cargo:

    # old
    Compiling foo v0.1.0

    # new
    Compiling (debug) foo v0.1.0

This change is aimed at preventing mistakenly thinking that `cargo build`
produces optimized binaries as well as providing a clear indication of whether
the build is a debug build or a release build.

Closes #1309