### PR TITLE
Explicitly remove RUST_LOG when crawling output

### DIFF
--- a/src/cargo/ops/cargo_rustc/context.rs
+++ b/src/cargo/ops/cargo_rustc/context.rs
@@ -96,7 +96,8 @@ impl<'a, 'b: 'a> Context<'a, 'b> {
                .arg("--crate-name").arg("_")
                .arg("--crate-type").arg("dylib")
                .arg("--crate-type").arg("bin")
-               .arg("--print=file-names");
+               .arg("--print=file-names")
+               .env_remove("RUST_LOG");
         if let Some(s) = target {
             process.arg("--target").arg(s);
         };

--- a/tests/test_cargo_compile.rs
+++ b/tests/test_cargo_compile.rs
@@ -1158,7 +1158,9 @@ test!(simple_staticlib {
         "#)
         .file("src/lib.rs", "pub fn foo() {}");
 
-    assert_that(p.cargo_process("build"), execs().with_status(0));
+    // env var is a test for #1381
+    assert_that(p.cargo_process("build").env("RUST_LOG", "nekoneko=trace"),
+                execs().with_status(0));
 });
 
 test!(staticlib_rlib_and_bin {


### PR DESCRIPTION
Ensure we don't get erroneous information about invalid log levels or such.

Closes #1381