### PR TITLE
Correctly set up paths when packaging

### DIFF
--- a/src/cargo/util/to_semver.rs
+++ b/src/cargo/util/to_semver.rs
@@ -22,3 +22,9 @@ impl<'a> ToSemver for &'a String {
         (**self).to_semver()
     }
 }
+
+impl<'a> ToSemver for &'a Version {
+    fn to_semver(self) -> Result<Version, String> {
+        Ok(self.clone())
+    }
+}


### PR DESCRIPTION
A synthetic "Package" is being created as part of this step but its paths were
pointing at the original root, not the unpacked tarball for testing. This meant
that some assumptions about the relative-ness of paths didn't quite end up
working out.

Closes #1382