### PR TITLE
Improve the profiling output of Cargo

### DIFF
--- a/src/cargo/core/resolver/mod.rs
+++ b/src/cargo/core/resolver/mod.rs
@@ -138,7 +138,7 @@ pub fn resolve(summary: &Summary, method: Method,
         activations: HashMap::new(),
         visited: Rc::new(RefCell::new(HashSet::new())),
     });
-    let _p = profile::start(format!("resolving: {:?}", summary));
+    let _p = profile::start(format!("resolving: {}", summary.package_id()));
     match try!(activate(cx, registry, &summary, method)) {
         Ok(cx) => {
             debug!("resolved: {:?}", cx.resolve);

--- a/src/cargo/ops/cargo_rustc/fingerprint.rs
+++ b/src/cargo/ops/cargo_rustc/fingerprint.rs
@@ -44,8 +44,8 @@ pub fn prepare_target<'a, 'b>(cx: &mut Context<'a, 'b>,
                               pkg: &'a Package,
                               target: &'a Target,
                               kind: Kind) -> CargoResult<Preparation> {
-    let _p = profile::start(format!("fingerprint: {} / {:?}",
-                                    pkg.package_id(), target));
+    let _p = profile::start(format!("fingerprint: {} / {}",
+                                    pkg.package_id(), target.name()));
     let new = dir(cx, pkg, kind);
     let loc = new.join(&filename(target));
 


### PR DESCRIPTION
* Don't use `{:?}` in profiling output, it's too noisy
* Allow an integer to be specified with `CARGO_PROFILE` indicating how many
  levels deep should be printed.