### PR TITLE
Don't intermingle targets between packages

### DIFF
--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -131,14 +131,11 @@ pub fn compile_pkg(package: &Package, options: &CompileOptions)
         (packages, resolved_with_overrides, registry.move_sources())
     };
 
-    let to_build = match spec {
-        Some(spec) => {
-            let pkgid = try!(resolve_with_overrides.query(spec));
-            packages.iter().find(|p| p.package_id() == pkgid).unwrap()
-        }
-        None => package,
+    let pkgid = match spec {
+        Some(spec) => try!(resolve_with_overrides.query(spec)),
+        None => package.package_id(),
     };
-
+    let to_build = packages.iter().find(|p| p.package_id() == pkgid).unwrap();
     let targets = to_build.targets().iter().filter(|target| {
         target.profile().is_custom_build() || match env {
             // doc-all == document everything, so look for doc targets

--- a/tests/test_cargo_package.rs
+++ b/tests/test_cargo_package.rs
@@ -244,3 +244,21 @@ test!(include {
 {archiving} [..]
 ", packaging = PACKAGING, archiving = ARCHIVING).as_slice()));
 });
+
+test!(package_lib_with_bin {
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [project]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+        "#)
+        .file("src/main.rs", r#"
+            extern crate foo;
+            fn main() {}
+        "#)
+        .file("src/lib.rs", "");
+
+    assert_that(p.cargo_process("package").arg("-v"),
+                execs().with_status(0));
+});


### PR DESCRIPTION
When loading targets to compile, be sure to use the targets from the package
that's being passed down to the compilation step, not the one that was passed in
which is overridden.

Closes #1404