### PR TITLE
Re-fix the `help` command's implementation

### DIFF
--- a/src/bin/cargo.rs
+++ b/src/bin/cargo.rs
@@ -118,14 +118,14 @@ fn execute(flags: Flags, config: &Config) -> CliResult<Option<()>> {
         // message for `cargo help`
         "help" if flags.arg_args[0] == "-h" ||
                   flags.arg_args[0] == "--help" => {
-            vec!["cargo".to_string(), "help".to_string(), "help".to_string()]
+            vec!["cargo".to_string(), "help".to_string(), "-h".to_string()]
         }
 
         // For `cargo help foo`, print out the usage message for the specified
         // subcommand by executing the command with the `-h` flag.
         "help" => {
-            vec!["cargo".to_string(), "help".to_string(),
-                 flags.arg_args[0].clone()]
+            vec!["cargo".to_string(), flags.arg_args[0].clone(),
+                 "-h".to_string()]
         }
 
         // For all other invocations, we're of the form `cargo foo args...`. We

--- a/tests/test_cargo.rs
+++ b/tests/test_cargo.rs
@@ -105,3 +105,24 @@ test!(override_cargo_home {
     File::open(&toml).unwrap().read_to_string(&mut contents).unwrap();
     assert!(contents.contains(r#"authors = ["foo <bar>"]"#));
 });
+
+test!(cargo_help {
+    assert_that(process(&cargo_dir().join("cargo")).unwrap(),
+                execs().with_status(0));
+    assert_that(process(&cargo_dir().join("cargo")).unwrap().arg("help"),
+                execs().with_status(0));
+    assert_that(process(&cargo_dir().join("cargo")).unwrap().arg("-h"),
+                execs().with_status(0));
+    assert_that(process(&cargo_dir().join("cargo")).unwrap()
+                       .arg("help").arg("build"),
+                execs().with_status(0));
+    assert_that(process(&cargo_dir().join("cargo")).unwrap()
+                       .arg("build").arg("-h"),
+                execs().with_status(0));
+    assert_that(process(&cargo_dir().join("cargo")).unwrap()
+                       .arg("help").arg("-h"),
+                execs().with_status(0));
+    assert_that(process(&cargo_dir().join("cargo")).unwrap()
+                       .arg("help").arg("help"),
+                execs().with_status(0));
+});


### PR DESCRIPTION
This was accidentally broken in a recent refactoring.

Closes #1421