### PR TITLE
Make the usage of newlines in Cargo.toml consistent

### DIFF
--- a/src/cargo/ops/cargo_new.rs
+++ b/src/cargo/ops/cargo_new.rs
@@ -113,7 +113,6 @@ fn mk(config: &Config, path: &Path, name: &str,
 
     try!(file(&path.join("Cargo.toml"), format!(
 r#"[package]
-
 name = "{}"
 version = "0.0.1"
 authors = ["{}"]

--- a/src/doc/build-script.md
+++ b/src/doc/build-script.md
@@ -204,7 +204,6 @@ Here we can see that we have a `build.rs` build script and our binary in
 # Cargo.toml
 
 [package]
-
 name = "hello-from-generated-code"
 version = "0.0.1"
 authors = ["you@example.com"]
@@ -293,7 +292,6 @@ Pretty similar to before! Next, the manifest:
 # Cargo.toml
 
 [package]
-
 name = "hello-world-from-c"
 version = "0.0.1"
 authors = [ "you@example.com" ]

--- a/src/doc/config.md
+++ b/src/doc/config.md
@@ -54,7 +54,6 @@ vcs = "none"
 # literal string "$triple", and it will apply whenever that target triple is
 # being compiled to.
 [target]
-
 # For cargo builds which do not mention --target, these are the ar/linker which
 # are passed to rustc to use (via `-C ar=` and `-C linker=`). By default these
 # flags are not passed to the compiler.
@@ -66,7 +65,6 @@ linker = ".."
 # the `$triple` is being compiled for.
 ar = ".."
 linker = ".."
-
 
 # Configuration keys related to the registry
 [registry]

--- a/src/doc/guide.md
+++ b/src/doc/guide.md
@@ -54,7 +54,6 @@ we need to get started. First, let's check out `Cargo.toml`:
 
 ```toml
 [package]
-
 name = "hello_world"
 version = "0.0.1"
 authors = ["Your Name <you@example.com>"]
@@ -139,13 +138,11 @@ To depend on a library, add it to your `Cargo.toml`.
 
 ```toml
 [package]
-
 name = "hello_world"
 version = "0.0.1"
 authors = ["Your Name <you@example.com>"]
 
 [dependencies.color]
-
 git = "https://github.com/bjz/color-rs.git"
 ```
 
@@ -232,13 +229,11 @@ on another project:
 
 ```toml
 [package]
-
 name = "hello_world"
 version = "0.0.1"
 authors = ["Your Name <you@example.com>"]
 
 [dependencies.color]
-
 git = "https://github.com/bjz/color-rs.git"
 ```
 
@@ -257,7 +252,6 @@ We could fix this problem by putting a `rev` line in our `Cargo.toml`:
 
 ```toml
 [dependencies.color]
-
 git = "https://github.com/bjz/color-rs.git"
 rev = "bf739419e2d31050615c1ba1a395b474269a4"
 ```
@@ -272,13 +266,11 @@ manifest like this:
 
 ```toml
 [package]
-
 name = "hello_world"
 version = "0.0.1"
 authors = ["Your Name <you@example.com>"]
 
 [dependencies.color]
-
 git = "https://github.com/bjz/color-rs.git"
 ```
 
@@ -327,13 +319,11 @@ patch. Here's what `conduit-static`'s `Cargo.toml` looks like:
 
 ```toml
 [package]
-
 name = "conduit-static"
 version = "0.0.1"
 authors = ["Yehuda Katz <wycats@example.com>"]
 
 [dependencies.conduit]
-
 git = "https://github.com/conduit-rust/conduit.git"
 ```
 

--- a/src/doc/index.md
+++ b/src/doc/index.md
@@ -45,7 +45,6 @@ This is all we need to get started. First, let's check out `Cargo.toml`:
 
 ```toml
 [package]
-
 name = "hello_world"
 version = "0.0.1"
 authors = ["Your Name <you@example.com>"]

--- a/src/doc/manifest.md
+++ b/src/doc/manifest.md
@@ -211,7 +211,6 @@ features. The format for specifying features is:
 name = "awesome"
 
 [features]
-
 # The "default" set of optional packages. Most people will
 # want to use these packages, but they are strictly optional.
 # Note that `session` is not a package but rather another
@@ -230,7 +229,6 @@ secure-password = ["bcrypt"]
 session = ["cookie/session"]
 
 [dependencies]
-
 # These packages are mandatory and form the core of this
 # package's distribution
 cookie = "1.2.0"
@@ -400,7 +398,6 @@ values listed are the defaults for that option unless otherwise specified.
 # ...
 
 [lib]
-
 # The name of a target is the name of the library that will be generated. This
 # is defaulted to the name of the package or project.
 name = "foo"
@@ -441,7 +438,6 @@ library to build by explicitly listing the library in your `Cargo.toml`:
 # ...
 
 [lib]
-
 name = "..."
 # this could be "staticlib" as well
 crate-type = ["dylib"]


### PR DESCRIPTION
Hi,

It seems that people generally prefer not having newlines after section headers in their `Cargo.toml`s. However, when one creates a new package via `cargo new`, a newline gets automatically inserted after `[package]`. Then a typical `Cargo.toml` ends up being some what inconsistent: there is a newline after `[package]`, and there are no newlines after other headers.

On top of that, the examples given on crates.io do not seem to be consistent: [sometimes](http://doc.crates.io/index.html) there is a newline after `[package]`, and [sometimes](http://doc.crates.io/manifest.html) there is none. The same applies to other section names.

I am wondering if there should be some style conventions in this regard.

Regards,
Ivan