### PR TITLE
Remove dependency on DynamicLibrary

### DIFF
--- a/src/cargo/ops/cargo_rustc/compilation.rs
+++ b/src/cargo/ops/cargo_rustc/compilation.rs
@@ -1,5 +1,4 @@
 use std::collections::{HashMap, HashSet};
-use std::dynamic_lib::DynamicLibrary;
 use std::ffi::AsOsStr;
 use std::path::PathBuf;
 use semver::Version;
@@ -98,9 +97,9 @@ impl Compilation {
         search_path.push(self.root_output.clone());
         search_path.push(self.deps_output.clone());
         let search_path = try!(util::join_paths(&search_path,
-                                                DynamicLibrary::envvar()));
+                                                util::dylib_path_envvar()));
         let mut cmd = try!(CommandPrototype::new(cmd));
-        cmd.env(DynamicLibrary::envvar(), &search_path);
+        cmd.env(util::dylib_path_envvar(), &search_path);
         for (k, v) in self.extra_env.iter() {
             cmd.env(k, v);
         }

--- a/src/cargo/ops/cargo_rustc/mod.rs
+++ b/src/cargo/ops/cargo_rustc/mod.rs
@@ -1,5 +1,4 @@
 use std::collections::{HashSet, HashMap};
-use std::dynamic_lib::DynamicLibrary;
 use std::env;
 use std::ffi::OsString;
 use std::fs;
@@ -428,7 +427,7 @@ fn add_plugin_deps(rustc: &mut CommandPrototype,
                    build_state: &BuildMap,
                    plugin_deps: Vec<PackageId>)
                    -> CargoResult<()> {
-    let var = DynamicLibrary::envvar();
+    let var = util::dylib_path_envvar();
     let search_path = rustc.get_env(var).unwrap_or(OsString::new());
     let mut search_path = env::split_paths(&search_path).collect::<Vec<_>>();
     for id in plugin_deps.into_iter() {
@@ -702,9 +701,9 @@ pub fn process(cmd: CommandType, pkg: &Package, _target: &Target,
 
     // We want to use the same environment and such as normal processes, but we
     // want to override the dylib search path with the one we just calculated.
-    let search_path = try!(join_paths(&search_path, DynamicLibrary::envvar()));
+    let search_path = try!(join_paths(&search_path, util::dylib_path_envvar()));
     let mut cmd = try!(cx.compilation.process(cmd, pkg));
-    cmd.env(DynamicLibrary::envvar(), &search_path);
+    cmd.env(util::dylib_path_envvar(), &search_path);
     Ok(cmd)
 }
 

--- a/src/cargo/util/mod.rs
+++ b/src/cargo/util/mod.rs
@@ -5,7 +5,7 @@ pub use self::errors::{CliError, ProcessError};
 pub use self::errors::{process_error, internal_error, internal, human};
 pub use self::errors::{Human, caused_human};
 pub use self::paths::{join_paths, path2bytes, bytes2path, dylib_path};
-pub use self::paths::normalize_path;
+pub use self::paths::{normalize_path, dylib_path_envvar};
 pub use self::lev_distance::{lev_distance};
 pub use self::hex::{to_hex, short_hash};
 pub use self::dependency_queue::{DependencyQueue, Fresh, Dirty, Freshness};

--- a/src/cargo/util/paths.rs
+++ b/src/cargo/util/paths.rs
@@ -1,5 +1,4 @@
 use std::env;
-use std::dynamic_lib::DynamicLibrary;
 use std::ffi::{AsOsStr, OsString};
 use std::path::{Path, PathBuf, Component};
 
@@ -18,8 +17,14 @@ pub fn join_paths<T: AsOsStr>(paths: &[T], env: &str) -> CargoResult<OsString> {
     })
 }
 
+pub fn dylib_path_envvar() -> &'static str {
+    if cfg!(windows) {"PATH"}
+    else if cfg!(target_os = "macos") {"DYLD_LIBRARY_PATH"}
+    else {"LD_LIBRARY_PATH"}
+}
+
 pub fn dylib_path() -> Vec<PathBuf> {
-    match env::var_os(DynamicLibrary::envvar()) {
+    match env::var_os(dylib_path_envvar()) {
         Some(var) => env::split_paths(&var).collect(),
         None => Vec::new(),
     }


### PR DESCRIPTION
This may not end up being stable for 1.0, and we don't really need much
functionality from it anyway.