### PR TITLE
Overhaul how cargo treats profiles

### DIFF
--- a/src/bin/bench.rs
+++ b/src/bin/bench.rs
@@ -50,20 +50,31 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
     let root = try!(find_root_manifest_for_cwd(options.flag_manifest_path));
     config.shell().set_verbose(options.flag_verbose);
 
+    let mut benches = Vec::new();
+    if let Some(s) = options.flag_bench {
+        benches.push(s);
+    }
+
     let ops = ops::TestOptions {
-        name: options.flag_bench.as_ref().map(|s| &s[..]),
         no_run: options.flag_no_run,
         compile_opts: ops::CompileOptions {
-            env: "bench",
             config: config,
             jobs: options.flag_jobs,
             target: options.flag_target.as_ref().map(|s| &s[..]),
-            dev_deps: true,
             features: &options.flag_features,
             no_default_features: options.flag_no_default_features,
             spec: options.flag_package.as_ref().map(|s| &s[..]),
-            lib_only: false,
             exec_engine: None,
+            release: true,
+            mode: ops::CompileMode::Bench,
+            filter: if benches.len() == 0 {
+                ops::CompileFilter::Everything
+            } else {
+                ops::CompileFilter::Only {
+                    lib: false, bins: &[], examples: &[], tests: &[],
+                    benches: &benches,
+                }
+            },
         },
     };
 

--- a/src/bin/bench.rs
+++ b/src/bin/bench.rs
@@ -67,7 +67,7 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
             exec_engine: None,
             release: true,
             mode: ops::CompileMode::Bench,
-            filter: if benches.len() == 0 {
+            filter: if benches.is_empty() {
                 ops::CompileFilter::Everything
             } else {
                 ops::CompileFilter::Only {

--- a/src/bin/cargo.rs
+++ b/src/bin/cargo.rs
@@ -105,7 +105,7 @@ fn execute(flags: Flags, config: &Config) -> CliResult<Option<()>> {
         // For the commands `cargo` and `cargo help`, re-execute ourselves as
         // `cargo -h` so we can go through the normal process of printing the
         // help message.
-        "" | "help" if flags.arg_args.len() == 0 => {
+        "" | "help" if flags.arg_args.is_empty() => {
             config.shell().set_verbose(true);
             let args = &["cargo".to_string(), "-h".to_string()];
             let r = cargo::call_main_without_stdin(execute, config, USAGE, args,

--- a/src/bin/doc.rs
+++ b/src/bin/doc.rs
@@ -46,7 +46,6 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
     let root = try!(find_root_manifest_for_cwd(options.flag_manifest_path));
 
     let mut doc_opts = ops::DocOptions {
-        all: !options.flag_no_deps,
         open_result: options.flag_open,
         compile_opts: ops::CompileOptions {
             config: config,
@@ -58,7 +57,9 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
             exec_engine: None,
             filter: ops::CompileFilter::Everything,
             release: false,
-            mode: ops::CompileMode::Build,
+            mode: ops::CompileMode::Doc {
+                deps: !options.flag_no_deps,
+            },
         },
     };
 

--- a/src/bin/doc.rs
+++ b/src/bin/doc.rs
@@ -49,16 +49,16 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
         all: !options.flag_no_deps,
         open_result: options.flag_open,
         compile_opts: ops::CompileOptions {
-            env: if options.flag_no_deps {"doc"} else {"doc-all"},
             config: config,
             jobs: options.flag_jobs,
             target: None,
-            dev_deps: false,
             features: &options.flag_features,
             no_default_features: options.flag_no_default_features,
             spec: options.flag_package.as_ref().map(|s| &s[..]),
-            lib_only: false,
             exec_engine: None,
+            filter: ops::CompileFilter::Everything,
+            release: false,
+            mode: ops::CompileMode::Build,
         },
     };
 

--- a/src/bin/run.rs
+++ b/src/bin/run.rs
@@ -64,7 +64,7 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
         exec_engine: None,
         release: options.flag_release,
         mode: ops::CompileMode::Build,
-        filter: if examples.len() == 0 && bins.len() == 0 {
+        filter: if examples.is_empty() && bins.is_empty() {
             ops::CompileFilter::Everything
         } else {
             ops::CompileFilter::Only {

--- a/src/bin/test.rs
+++ b/src/bin/test.rs
@@ -52,20 +52,31 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
     let root = try!(find_root_manifest_for_cwd(options.flag_manifest_path));
     config.shell().set_verbose(options.flag_verbose);
 
+    let mut tests = Vec::new();
+    if let Some(s) = options.flag_test {
+        tests.push(s);
+    }
+
     let ops = ops::TestOptions {
-        name: options.flag_test.as_ref().map(|s| &s[..]),
         no_run: options.flag_no_run,
         compile_opts: ops::CompileOptions {
-            env: "test",
             config: config,
             jobs: options.flag_jobs,
             target: options.flag_target.as_ref().map(|s| &s[..]),
-            dev_deps: true,
             features: &options.flag_features,
             no_default_features: options.flag_no_default_features,
             spec: options.flag_package.as_ref().map(|s| &s[..]),
-            lib_only: false,
             exec_engine: None,
+            release: false,
+            mode: ops::CompileMode::Test,
+            filter: if tests.len() == 0 {
+                ops::CompileFilter::Everything
+            } else {
+                ops::CompileFilter::Only {
+                    lib: false, bins: &[], examples: &[], benches: &[],
+                    tests: &tests,
+                }
+            }
         },
     };
 

--- a/src/bin/test.rs
+++ b/src/bin/test.rs
@@ -74,7 +74,7 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
             exec_engine: None,
             release: false,
             mode: ops::CompileMode::Test,
-            filter: if tests.len() == 0 && bins.len() == 0 {
+            filter: if tests.is_empty() && bins.is_empty() {
                 ops::CompileFilter::Everything
             } else {
                 ops::CompileFilter::Only {

--- a/src/bin/test.rs
+++ b/src/bin/test.rs
@@ -9,6 +9,7 @@ struct Options {
     flag_jobs: Option<u32>,
     flag_manifest_path: Option<String>,
     flag_test: Option<String>,
+    flag_bin: Option<String>,
     flag_no_default_features: bool,
     flag_no_run: bool,
     flag_package: Option<String>,
@@ -24,7 +25,8 @@ Usage:
 
 Options:
     -h, --help               Print this message
-    --test NAME              Name of the test executable to run
+    --test NAME              Name of the integration test to run
+    --bin NAME               Name of the binary to run tests for
     --no-run                 Compile, but don't run tests
     -p SPEC, --package SPEC  Package to run tests for
     -j N, --jobs N           The number of jobs to run in parallel
@@ -52,9 +54,12 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
     let root = try!(find_root_manifest_for_cwd(options.flag_manifest_path));
     config.shell().set_verbose(options.flag_verbose);
 
-    let mut tests = Vec::new();
+    let (mut tests, mut bins) = (Vec::new(), Vec::new());
     if let Some(s) = options.flag_test {
         tests.push(s);
+    }
+    if let Some(s) = options.flag_bin {
+        bins.push(s);
     }
 
     let ops = ops::TestOptions {
@@ -69,12 +74,12 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
             exec_engine: None,
             release: false,
             mode: ops::CompileMode::Test,
-            filter: if tests.len() == 0 {
+            filter: if tests.len() == 0 && bins.len() == 0 {
                 ops::CompileFilter::Everything
             } else {
                 ops::CompileFilter::Only {
-                    lib: false, bins: &[], examples: &[], benches: &[],
-                    tests: &tests,
+                    lib: false, examples: &[], benches: &[],
+                    tests: &tests, bins: &bins,
                 }
             }
         },

--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -1,4 +1,4 @@
-use std::hash;
+use std::default::Default;
 use std::path::{PathBuf, Path};
 
 use semver::Version;
@@ -10,7 +10,7 @@ use core::dependency::SerializedDependency;
 use util::{CargoResult, human};
 
 /// Contains all the informations about a package, as loaded from a Cargo.toml.
-#[derive(PartialEq,Clone, Debug)]
+#[derive(Clone, Debug)]
 pub struct Manifest {
     summary: Summary,
     targets: Vec<Target>,
@@ -21,6 +21,7 @@ pub struct Manifest {
     exclude: Vec<String>,
     include: Vec<String>,
     metadata: ManifestMetadata,
+    profiles: Profiles,
 }
 
 /// General metadata about a package which is just blindly uploaded to the
@@ -104,196 +105,31 @@ impl LibKind {
 pub enum TargetKind {
     Lib(Vec<LibKind>),
     Bin,
+    Test,
+    Bench,
     Example,
+    CustomBuild,
 }
 
-#[derive(RustcEncodable, RustcDecodable, Clone, PartialEq, Eq, Debug)]
+#[derive(RustcEncodable, RustcDecodable, Clone, PartialEq, Eq, Debug, Hash)]
 pub struct Profile {
-    env: String, // compile, test, dev, bench, etc.
-    opt_level: u32,
-    lto: bool,
-    codegen_units: Option<u32>,    // None = use rustc default
-    debug: bool,
-    rpath: bool,
-    test: bool,
-    doctest: bool,
-    doc: bool,
-    dest: String,
-    for_host: bool,
-    harness: bool, // whether to use the test harness (--test)
-    custom_build: bool,
+    pub opt_level: u32,
+    pub lto: bool,
+    pub codegen_units: Option<u32>,    // None = use rustc default
+    pub debuginfo: bool,
+    pub ndebug: bool,
+    pub rpath: bool,
+    pub test: bool,
+    pub doc: bool,
 }
 
-impl Profile {
-    fn default() -> Profile {
-        Profile {
-            env: String::new(),
-            opt_level: 0,
-            lto: false,
-            codegen_units: None,
-            debug: false,
-            rpath: false,
-            test: false,
-            doc: false,
-            dest: "debug".to_string(),
-            for_host: false,
-            doctest: false,
-            custom_build: false,
-            harness: true,
-        }
-    }
-
-    pub fn default_dev() -> Profile {
-        Profile {
-            env: "compile".to_string(), // run in the default environment only
-            opt_level: 0,
-            debug: true,
-            .. Profile::default()
-        }
-    }
-
-    pub fn default_test() -> Profile {
-        Profile {
-            env: "test".to_string(),
-            debug: true,
-            test: true,
-            .. Profile::default()
-        }
-    }
-
-    pub fn default_example() -> Profile {
-        Profile {
-            test: false,
-            .. Profile::default_test()
-        }
-    }
-
-    pub fn default_bench() -> Profile {
-        Profile {
-            env: "bench".to_string(),
-            test: true,
-            .. Profile::default_release()
-        }
-    }
-
-    pub fn default_release() -> Profile {
-        Profile {
-            env: "release".to_string(),
-            opt_level: 3,
-            dest: "release".to_string(),
-            .. Profile::default()
-        }
-    }
-
-    pub fn default_doc() -> Profile {
-        Profile {
-            env: "doc".to_string(),
-            doc: true,
-            .. Profile::default()
-        }
-    }
-
-    pub fn codegen_units(&self) -> Option<u32> { self.codegen_units }
-    pub fn debug(&self) -> bool { self.debug }
-    pub fn env(&self) -> &str { &self.env }
-    pub fn is_compile(&self) -> bool { self.env == "compile" }
-    pub fn is_custom_build(&self) -> bool { self.custom_build }
-    pub fn is_doc(&self) -> bool { self.doc }
-    pub fn is_doctest(&self) -> bool { self.doctest }
-    pub fn is_for_host(&self) -> bool { self.for_host }
-    pub fn is_test(&self) -> bool { self.test }
-    pub fn lto(&self) -> bool { self.lto }
-    pub fn opt_level(&self) -> u32 { self.opt_level }
-    pub fn rpath(&self) -> bool { self.rpath }
-    pub fn uses_test_harness(&self) -> bool { self.harness }
-    pub fn dest(&self) -> &str { &self.dest }
-
-    pub fn set_opt_level(mut self, level: u32) -> Profile {
-        self.opt_level = level;
-        self
-    }
-
-    pub fn set_lto(mut self, lto: bool) -> Profile {
-        self.lto = lto;
-        self
-    }
-
-    pub fn set_codegen_units(mut self, units: Option<u32>) -> Profile {
-        self.codegen_units = units;
-        self
-    }
-
-    pub fn set_debug(mut self, debug: bool) -> Profile {
-        self.debug = debug;
-        self
-    }
-
-    pub fn set_rpath(mut self, rpath: bool) -> Profile {
-        self.rpath = rpath;
-        self
-    }
-
-    pub fn set_test(mut self, test: bool) -> Profile {
-        self.test = test;
-        self
-    }
-
-    pub fn set_doctest(mut self, doctest: bool) -> Profile {
-        self.doctest = doctest;
-        self
-    }
-
-    pub fn set_doc(mut self, doc: bool) -> Profile {
-        self.doc = doc;
-        self
-    }
-
-    /// Sets whether the `Target` must be compiled for the host instead of the
-    /// target platform.
-    pub fn set_for_host(mut self, for_host: bool) -> Profile {
-        self.for_host = for_host;
-        self
-    }
-
-    pub fn set_harness(mut self, harness: bool) -> Profile {
-        self.harness = harness;
-        self
-    }
-
-    /// Sets whether the `Target` is a custom build script.
-    pub fn set_custom_build(mut self, custom_build: bool) -> Profile {
-        self.custom_build = custom_build;
-        self
-    }
-}
-
-impl hash::Hash for Profile {
-    fn hash<H: hash::Hasher>(&self, into: &mut H) {
-        // Be sure to match all fields explicitly, but ignore those not relevant
-        // to the actual hash of a profile.
-        let Profile {
-            opt_level,
-            lto,
-            codegen_units,
-            debug,
-            rpath,
-            for_host,
-            ref dest,
-            harness,
-
-            // test flags are separated by file, not by profile hash, and
-            // env/doc also don't matter for the actual contents of the output
-            // file, just where the output file is located.
-            doc: _,
-            env: _,
-            test: _,
-            doctest: _,
-
-            custom_build: _,
-        } = *self;
-        (opt_level, lto, codegen_units, debug,
-         rpath, for_host, dest, harness).hash(into)
-    }
+#[derive(Default, Clone, Debug)]
+pub struct Profiles {
+    pub release: Profile,
+    pub dev: Profile,
+    pub test: Profile,
+    pub bench: Profile,
+    pub doc: Profile,
 }
 
 /// Informations about a binary, a library, an example, etc. that is part of the
@@ -303,8 +139,13 @@ pub struct Target {
     kind: TargetKind,
     name: String,
     src_path: PathBuf,
-    profile: Profile,
     metadata: Option<Metadata>,
+    tested: bool,
+    benched: bool,
+    doc: bool,
+    doctest: bool,
+    harness: bool, // whether to use the test harness (--test)
+    for_host: bool,
 }
 
 #[derive(RustcEncodable)]
@@ -312,7 +153,6 @@ pub struct SerializedTarget {
     kind: Vec<&'static str>,
     name: String,
     src_path: String,
-    profile: Profile,
     metadata: Option<Metadata>
 }
 
@@ -324,13 +164,15 @@ impl Encodable for Target {
             }
             TargetKind::Bin => vec!("bin"),
             TargetKind::Example => vec!["example"],
+            TargetKind::Test => vec!["test"],
+            TargetKind::CustomBuild => vec!["custom-build"],
+            TargetKind::Bench => vec!["bench"],
         };
 
         SerializedTarget {
             kind: kind,
             name: self.name.clone(),
             src_path: self.src_path.display().to_string(),
-            profile: self.profile.clone(),
             metadata: self.metadata.clone()
         }.encode(s)
     }
@@ -342,7 +184,8 @@ impl Manifest {
                exclude: Vec<String>,
                include: Vec<String>,
                links: Option<String>,
-               metadata: ManifestMetadata) -> Manifest {
+               metadata: ManifestMetadata,
+               profiles: Profiles) -> Manifest {
         Manifest {
             summary: summary,
             targets: targets,
@@ -353,6 +196,7 @@ impl Manifest {
             include: include,
             links: links,
             metadata: metadata,
+            profiles: profiles,
         }
     }
 
@@ -368,6 +212,7 @@ impl Manifest {
     pub fn targets(&self) -> &[Target] { &self.targets }
     pub fn version(&self) -> &Version { self.package_id().version() }
     pub fn warnings(&self) -> &[String] { &self.warnings }
+    pub fn profiles(&self) -> &Profiles { &self.profiles }
     pub fn links(&self) -> Option<&str> {
         self.links.as_ref().map(|s| s.as_slice())
     }
@@ -386,85 +231,103 @@ impl Manifest {
 }
 
 impl Target {
-    pub fn file_stem(&self) -> String {
-        match self.metadata {
-            Some(ref metadata) => format!("{}{}", self.name,
-                                          metadata.extra_filename),
-            None => self.name.clone()
+    fn blank() -> Target {
+        Target {
+            kind: TargetKind::Bin,
+            name: String::new(),
+            src_path: PathBuf::new(""),
+            metadata: None,
+            doc: true,
+            doctest: true,
+            harness: true,
+            for_host: false,
+            tested: true,
+            benched: true,
         }
     }
 
     pub fn lib_target(name: &str, crate_targets: Vec<LibKind>,
-                      src_path: &Path, profile: &Profile,
+                      src_path: &Path,
                       metadata: Metadata) -> Target {
         Target {
             kind: TargetKind::Lib(crate_targets),
             name: name.to_string(),
             src_path: src_path.to_path_buf(),
-            profile: profile.clone(),
-            metadata: Some(metadata)
+            metadata: Some(metadata),
+            ..Target::blank()
         }
     }
 
-    pub fn bin_target(name: &str, src_path: &Path, profile: &Profile,
+    pub fn bin_target(name: &str, src_path: &Path,
                       metadata: Option<Metadata>) -> Target {
         Target {
             kind: TargetKind::Bin,
             name: name.to_string(),
             src_path: src_path.to_path_buf(),
-            profile: profile.clone(),
             metadata: metadata,
+            ..Target::blank()
         }
     }
 
     /// Builds a `Target` corresponding to the `build = "build.rs"` entry.
-    pub fn custom_build_target(name: &str, src_path: &Path, profile: &Profile,
+    pub fn custom_build_target(name: &str, src_path: &Path,
                                metadata: Option<Metadata>) -> Target {
         Target {
-            kind: TargetKind::Bin,
+            kind: TargetKind::CustomBuild,
             name: name.to_string(),
             src_path: src_path.to_path_buf(),
-            profile: profile.clone(),
             metadata: metadata,
+            for_host: true,
+            benched: false,
+            tested: false,
+            ..Target::blank()
         }
     }
 
-    pub fn example_target(name: &str, src_path: &Path, profile: &Profile) -> Target {
+    pub fn example_target(name: &str, src_path: &Path) -> Target {
         Target {
             kind: TargetKind::Example,
             name: name.to_string(),
             src_path: src_path.to_path_buf(),
-            profile: profile.clone(),
-            metadata: None,
+            benched: false,
+            ..Target::blank()
         }
     }
 
     pub fn test_target(name: &str, src_path: &Path,
-                       profile: &Profile, metadata: Metadata) -> Target {
+                       metadata: Metadata) -> Target {
         Target {
-            kind: TargetKind::Bin,
+            kind: TargetKind::Test,
             name: name.to_string(),
             src_path: src_path.to_path_buf(),
-            profile: profile.clone(),
             metadata: Some(metadata),
+            benched: false,
+            ..Target::blank()
         }
     }
 
     pub fn bench_target(name: &str, src_path: &Path,
-                        profile: &Profile, metadata: Metadata) -> Target {
+                        metadata: Metadata) -> Target {
         Target {
-            kind: TargetKind::Bin,
+            kind: TargetKind::Bench,
             name: name.to_string(),
             src_path: src_path.to_path_buf(),
-            profile: profile.clone(),
             metadata: Some(metadata),
+            tested: false,
+            ..Target::blank()
         }
     }
 
     pub fn name(&self) -> &str { &self.name }
     pub fn src_path(&self) -> &Path { &self.src_path }
-    pub fn profile(&self) -> &Profile { &self.profile }
     pub fn metadata(&self) -> Option<&Metadata> { self.metadata.as_ref() }
+    pub fn kind(&self) -> &TargetKind { &self.kind }
+    pub fn tested(&self) -> bool { self.tested }
+    pub fn harness(&self) -> bool { self.harness }
+    pub fn documented(&self) -> bool { self.doc }
+    pub fn doctested(&self) -> bool { self.doctest }
+    pub fn for_host(&self) -> bool { self.for_host }
+    pub fn benched(&self) -> bool { self.benched }
 
     pub fn is_lib(&self) -> bool {
         match self.kind {
@@ -473,43 +336,25 @@ impl Target {
         }
     }
 
-    pub fn is_dylib(&self) -> bool {
+    pub fn linkable(&self) -> bool {
         match self.kind {
-            TargetKind::Lib(ref kinds) => kinds.iter().any(|&k| k == LibKind::Dylib),
+            TargetKind::Lib(ref kinds) => {
+                kinds.iter().any(|k| {
+                    match *k {
+                        LibKind::Lib | LibKind::Rlib | LibKind::Dylib => true,
+                        LibKind::StaticLib => false,
+                    }
+                })
+            }
             _ => false
         }
     }
 
-    pub fn is_rlib(&self) -> bool {
-        match self.kind {
-            TargetKind::Lib(ref kinds) =>
-                kinds.iter().any(|&k| k == LibKind::Rlib || k == LibKind::Lib),
-            _ => false
-        }
-    }
-
-    pub fn is_staticlib(&self) -> bool {
-        match self.kind {
-            TargetKind::Lib(ref kinds) => kinds.iter().any(|&k| k == LibKind::StaticLib),
-            _ => false
-        }
-    }
-
-    /// Returns true for binary, bench, and tests.
-    pub fn is_bin(&self) -> bool {
-        match self.kind {
-            TargetKind::Bin => true,
-            _ => false
-        }
-    }
-
-    /// Returns true for exampels
-    pub fn is_example(&self) -> bool {
-        match self.kind {
-            TargetKind::Example => true,
-            _ => false
-        }
-    }
+    pub fn is_bin(&self) -> bool { self.kind == TargetKind::Bin }
+    pub fn is_example(&self) -> bool { self.kind == TargetKind::Example }
+    pub fn is_test(&self) -> bool { self.kind == TargetKind::Test }
+    pub fn is_bench(&self) -> bool { self.kind == TargetKind::Bench }
+    pub fn is_custom_build(&self) -> bool { self.kind == TargetKind::CustomBuild }
 
     /// Returns the arguments suitable for `--crate-type` to pass to rustc.
     pub fn rustc_crate_types(&self) -> Vec<&'static str> {
@@ -517,8 +362,97 @@ impl Target {
             TargetKind::Lib(ref kinds) => {
                 kinds.iter().map(|kind| kind.crate_type()).collect()
             },
+            TargetKind::CustomBuild |
+            TargetKind::Bench |
+            TargetKind::Test |
             TargetKind::Example |
             TargetKind::Bin => vec!("bin"),
+        }
+    }
+
+    pub fn can_lto(&self) -> bool {
+        match self.kind {
+            TargetKind::Lib(ref v) => *v == [LibKind::StaticLib],
+            _ => true,
+        }
+    }
+
+    pub fn set_tested(&mut self, tested: bool) -> &mut Target {
+        self.tested = tested;
+        self
+    }
+    pub fn set_benched(&mut self, benched: bool) -> &mut Target {
+        self.benched = benched;
+        self
+    }
+    pub fn set_doctest(&mut self, doctest: bool) -> &mut Target {
+        self.doctest = doctest;
+        self
+    }
+    pub fn set_for_host(&mut self, for_host: bool) -> &mut Target {
+        self.for_host = for_host;
+        self
+    }
+    pub fn set_harness(&mut self, harness: bool) -> &mut Target {
+        self.harness = harness;
+        self
+    }
+    pub fn set_doc(&mut self, doc: bool) -> &mut Target {
+        self.doc = doc;
+        self
+    }
+}
+
+impl Profile {
+    pub fn default_dev() -> Profile {
+        Profile {
+            debuginfo: true,
+            ..Profile::default()
+        }
+    }
+
+    pub fn default_release() -> Profile {
+        Profile {
+            opt_level: 3,
+            debuginfo: false,
+            ndebug: true,
+            ..Profile::default()
+        }
+    }
+
+    pub fn default_test() -> Profile {
+        Profile {
+            test: true,
+            ..Profile::default_dev()
+        }
+    }
+
+    pub fn default_bench() -> Profile {
+        Profile {
+            test: true,
+            ..Profile::default_release()
+        }
+    }
+
+    pub fn default_doc() -> Profile {
+        Profile {
+            doc: true,
+            ..Profile::default_dev()
+        }
+    }
+}
+
+impl Default for Profile {
+    fn default() -> Profile {
+        Profile {
+            opt_level: 0,
+            lto: false,
+            codegen_units: None,
+            debuginfo: false,
+            ndebug: false,
+            rpath: false,
+            test: false,
+            doc: false,
         }
     }
 }

--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -238,7 +238,7 @@ impl Target {
             src_path: PathBuf::new(""),
             metadata: None,
             doc: true,
-            doctest: true,
+            doctest: false,
             harness: true,
             for_host: false,
             tested: true,
@@ -254,6 +254,7 @@ impl Target {
             name: name.to_string(),
             src_path: src_path.to_path_buf(),
             metadata: Some(metadata),
+            doctest: true,
             ..Target::blank()
         }
     }

--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -237,7 +237,7 @@ impl Target {
             name: String::new(),
             src_path: PathBuf::new(""),
             metadata: None,
-            doc: true,
+            doc: false,
             doctest: false,
             harness: true,
             for_host: false,
@@ -255,6 +255,7 @@ impl Target {
             src_path: src_path.to_path_buf(),
             metadata: Some(metadata),
             doctest: true,
+            doc: true,
             ..Target::blank()
         }
     }
@@ -266,6 +267,7 @@ impl Target {
             name: name.to_string(),
             src_path: src_path.to_path_buf(),
             metadata: metadata,
+            doc: true,
             ..Target::blank()
         }
     }

--- a/src/cargo/core/mod.rs
+++ b/src/cargo/core/mod.rs
@@ -1,7 +1,7 @@
 pub use self::dependency::Dependency;
-pub use self::manifest::{Manifest, Target, TargetKind, Profile};
+pub use self::manifest::{Manifest, Target, TargetKind, Profile, LibKind, Profiles};
 pub use self::package::{Package, PackageSet};
-pub use self::package_id::PackageId;
+pub use self::package_id::{PackageId, Metadata};
 pub use self::package_id_spec::PackageIdSpec;
 pub use self::registry::Registry;
 pub use self::resolver::Resolve;

--- a/src/cargo/core/package.rs
+++ b/src/cargo/core/package.rs
@@ -85,7 +85,7 @@ impl Package {
     }
 
     pub fn has_custom_build(&self) -> bool {
-        self.targets().iter().any(|t| t.profile().is_custom_build())
+        self.targets().iter().any(|t| t.is_custom_build())
     }
 }
 

--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -208,8 +208,9 @@ fn generate_targets<'a>(pkg: &'a Package,
                         -> CargoResult<Vec<(&'a Target, &'a Profile)>> {
     let profiles = pkg.manifest().profiles();
     let build = if release {&profiles.release} else {&profiles.dev};
+    let test = if release {&profiles.bench} else {&profiles.test};
     let profile = match mode {
-        CompileMode::Test => if release {&profiles.bench} else {&profiles.test},
+        CompileMode::Test => test,
         CompileMode::Bench => &profiles.bench,
         CompileMode::Build => build,
     };
@@ -267,14 +268,14 @@ fn generate_targets<'a>(pkg: &'a Package,
                                                               named `{}`",
                                                              desc, name))),
                         };
+                        debug!("found {} `{}`", desc, name);
                         targets.push((t, profile));
                     }
                     Ok(())
                 };
                 try!(find(bins, "bin", TargetKind::Bin, profile));
-                try!(find(examples, "example", TargetKind::Example,
-                          &profiles.dev));
-                try!(find(tests, "test", TargetKind::Test, &profiles.test));
+                try!(find(examples, "example", TargetKind::Example, build));
+                try!(find(tests, "test", TargetKind::Test, test));
                 try!(find(benches, "bench", TargetKind::Bench, &profiles.bench));
             }
             Ok(targets)

--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -30,6 +30,7 @@ use std::sync::Arc;
 
 use core::registry::PackageRegistry;
 use core::{Source, SourceId, PackageSet, Package, Target, PackageId};
+use core::{Profile, TargetKind};
 use core::resolver::Method;
 use ops::{self, BuildOutput, ExecEngine};
 use sources::{PathSource};
@@ -38,19 +39,44 @@ use util::{CargoResult, internal, human, ChainError, profile};
 
 /// Contains informations about how a package should be compiled.
 pub struct CompileOptions<'a, 'b: 'a> {
-    pub env: &'a str,
     pub config: &'a Config<'b>,
     /// Number of concurrent jobs to use.
     pub jobs: Option<u32>,
     /// The target platform to compile for (example: `i686-unknown-linux-gnu`).
     pub target: Option<&'a str>,
-    /// True if dev-dependencies must be compiled.
-    pub dev_deps: bool,
+    /// Extra features to build for the root package
     pub features: &'a [String],
+    /// Flag if the default feature should be built for the root package
     pub no_default_features: bool,
+    /// Root package to build (if None it's the current one)
     pub spec: Option<&'a str>,
-    pub lib_only: bool,
+    /// Filter to apply to the root package to select which targets will be
+    /// built.
+    pub filter: CompileFilter<'a>,
+    /// Engine which drives compilation
     pub exec_engine: Option<Arc<Box<ExecEngine>>>,
+    /// Whether this is a release build or not
+    pub release: bool,
+    /// Mode for this compile.
+    pub mode: CompileMode,
+}
+
+#[derive(Copy, PartialEq)]
+pub enum CompileMode {
+    Test,
+    Build,
+    Bench,
+}
+
+pub enum CompileFilter<'a> {
+    Everything,
+    Only {
+        lib: bool,
+        bins: &'a [String],
+        examples: &'a [String],
+        tests: &'a [String],
+        benches: &'a [String],
+    }
 }
 
 pub fn compile(manifest_path: &Path,
@@ -74,9 +100,9 @@ pub fn compile(manifest_path: &Path,
 
 pub fn compile_pkg(package: &Package, options: &CompileOptions)
                    -> CargoResult<ops::Compilation> {
-    let CompileOptions { env, config, jobs, target, spec,
-                         dev_deps, features, no_default_features,
-                         lib_only, ref exec_engine } = *options;
+    let CompileOptions { config, jobs, target, spec, features,
+                         no_default_features, release, mode,
+                         ref filter, ref exec_engine } = *options;
 
     let target = target.map(|s| s.to_string());
     let features = features.iter().flat_map(|s| {
@@ -108,10 +134,10 @@ pub fn compile_pkg(package: &Package, options: &CompileOptions)
 
         try!(registry.add_overrides(override_ids));
 
-        let platform = target.as_ref().map(|e| e.as_slice()).or(Some(rustc_host.as_slice()));
+        let platform = target.as_ref().map(|e| &e[..]).or(Some(&rustc_host[..]));
 
         let method = Method::Required{
-            dev_deps: dev_deps,
+            dev_deps: true, // TODO: remove this option?
             features: &features,
             uses_default_features: !no_default_features,
             target_platform: platform};
@@ -135,31 +161,129 @@ pub fn compile_pkg(package: &Package, options: &CompileOptions)
         None => package.package_id(),
     };
     let to_build = packages.iter().find(|p| p.package_id() == pkgid).unwrap();
-    let targets = to_build.targets().iter().filter(|target| {
-        target.profile().is_custom_build() || match env {
-            // doc-all == document everything, so look for doc targets
-            "doc" | "doc-all" => target.profile().env() == "doc",
-            env => target.profile().env() == env,
-        }
-    }).filter(|target| !lib_only || target.is_lib()).collect::<Vec<&Target>>();
-
-    if lib_only && targets.len() == 0 {
-        return Err(human("There is no lib to build, remove `--lib` flag".to_string()));
-    }
+    let targets = try!(generate_targets(to_build, mode, filter, release));
 
     let ret = {
         let _p = profile::start("compiling");
-        let lib_overrides = try!(scrape_build_config(config, jobs, target));
+        let mut build_config = try!(scrape_build_config(config, jobs, target));
+        build_config.exec_engine = exec_engine.clone();
+        build_config.release = release;
 
-        try!(ops::compile_targets(&env, &targets, to_build,
+        try!(ops::compile_targets(&targets, to_build,
                                   &PackageSet::new(&packages),
                                   &resolve_with_overrides, &sources,
-                                  config, lib_overrides, exec_engine.clone()))
+                                  config,
+                                  build_config,
+                                  to_build.manifest().profiles()))
     };
 
     return Ok(ret);
 }
 
+impl<'a> CompileFilter<'a> {
+    pub fn matches(&self, target: &Target) -> bool {
+        match *self {
+            CompileFilter::Everything => true,
+            CompileFilter::Only { lib, bins, examples, tests, benches } => {
+                let list = match *target.kind() {
+                    TargetKind::Bin => bins,
+                    TargetKind::Test => tests,
+                    TargetKind::Bench => benches,
+                    TargetKind::Example => examples,
+                    TargetKind::Lib(..) => return lib,
+                    TargetKind::CustomBuild => return false,
+                };
+                list.iter().any(|x| *x == target.name())
+            }
+        }
+    }
+}
+
+/// Given the configuration for a build, this function will generate all
+/// target/profile combinations needed to be built.
+fn generate_targets<'a>(pkg: &'a Package,
+                        mode: CompileMode,
+                        filter: &CompileFilter,
+                        release: bool)
+                        -> CargoResult<Vec<(&'a Target, &'a Profile)>> {
+    let profiles = pkg.manifest().profiles();
+    let build = if release {&profiles.release} else {&profiles.dev};
+    let profile = match mode {
+        CompileMode::Test => if release {&profiles.bench} else {&profiles.test},
+        CompileMode::Bench => &profiles.bench,
+        CompileMode::Build => build,
+    };
+    return match *filter {
+        CompileFilter::Everything => {
+            match mode {
+                CompileMode::Bench => {
+                    Ok(pkg.targets().iter().filter(|t| t.benched()).map(|t| {
+                        (t, profile)
+                    }).collect::<Vec<_>>())
+                }
+                CompileMode::Test => {
+                    let mut base = pkg.targets().iter().filter(|t| {
+                        t.tested()
+                    }).map(|t| {
+                        (t, if t.is_example() {build} else {profile})
+                    }).collect::<Vec<_>>();
+
+                    // Always compile the library if we're testing everything as
+                    // it'll be needed for doctests
+                    if let Some(t) = pkg.targets().iter().find(|t| t.is_lib()) {
+                        if t.doctested() {
+                            base.push((t, build));
+                        }
+                    }
+                    Ok(base)
+                }
+                CompileMode::Build => {
+                    Ok(pkg.targets().iter().filter(|t| {
+                        t.is_bin() || t.is_lib()
+                    }).map(|t| (t, profile)).collect())
+                }
+            }
+        }
+        CompileFilter::Only { lib, bins, examples, tests, benches } => {
+            let mut targets = Vec::new();
+
+            if lib {
+                if let Some(t) = pkg.targets().iter().find(|t| t.is_lib()) {
+                    targets.push((t, profile));
+                } else {
+                    return Err(human(format!("no library targets found")))
+                }
+            }
+
+            {
+                let mut find = |names: &[String], desc, kind, profile| {
+                    for name in names {
+                        let target = pkg.targets().iter().find(|t| {
+                            t.name() == *name && *t.kind() == kind
+                        });
+                        let t = match target {
+                            Some(t) => t,
+                            None => return Err(human(format!("no {} target \
+                                                              named `{}`",
+                                                             desc, name))),
+                        };
+                        targets.push((t, profile));
+                    }
+                    Ok(())
+                };
+                try!(find(bins, "bin", TargetKind::Bin, profile));
+                try!(find(examples, "example", TargetKind::Example,
+                          &profiles.dev));
+                try!(find(tests, "test", TargetKind::Test, &profiles.test));
+                try!(find(benches, "bench", TargetKind::Bench, &profiles.bench));
+            }
+            Ok(targets)
+        }
+    };
+}
+
+/// Read the `paths` configuration variable to discover all path overrides that
+/// have been configured.
 fn source_ids_from_config(config: &Config, cur_path: &Path)
                           -> CargoResult<Vec<SourceId>> {
 
@@ -185,9 +309,17 @@ fn source_ids_from_config(config: &Config, cur_path: &Path)
     }).map(|p| SourceId::for_path(&p)).collect()
 }
 
+/// Parse all config files to learn about build configuration. Currently
+/// configured options are:
+///
+/// * build.jobs
+/// * target.$target.ar
+/// * target.$target.linker
+/// * target.$target.libfoo.metadata
 fn scrape_build_config(config: &Config,
                        jobs: Option<u32>,
-                       target: Option<String>) -> CargoResult<ops::BuildConfig> {
+                       target: Option<String>)
+                       -> CargoResult<ops::BuildConfig> {
     let cfg_jobs = match try!(config.get_i64("build.jobs")) {
         Some((n, p)) => {
             match n.to_u32() {
@@ -251,7 +383,8 @@ fn scrape_target_config(config: &Config, triple: &str)
             match try!(config.get(&key)).unwrap() {
                 ConfigValue::String(v, path) => {
                     if k == "rustc-flags" {
-                        let whence = format!("in `{}` (in {:?})", key, path);
+                        let whence = format!("in `{}` (in {})", key,
+                                             path.display());
                         let (paths, links) = try!(
                             BuildOutput::parse_rustc_flags(&v, &whence)
                         );
@@ -263,14 +396,18 @@ fn scrape_target_config(config: &Config, triple: &str)
                 },
                 ConfigValue::List(a, p) => {
                     if k == "rustc-link-lib" {
-                        output.library_links.extend(a.into_iter().map(|(v, _)| v));
+                        output.library_links.extend(a.into_iter().map(|v| v.0));
                     } else if k == "rustc-link-search" {
-                        output.library_paths.extend(a.into_iter().map(|(v, _)| PathBuf::new(&v)));
+                        output.library_paths.extend(a.into_iter().map(|v| {
+                            PathBuf::new(&v.0)
+                        }));
                     } else {
-                        try!(config.expected("string", &k, ConfigValue::List(a, p)));
+                        try!(config.expected("string", &k,
+                                             ConfigValue::List(a, p)));
                     }
                 },
-                // technically could be a list too, but that's the exception to the rule...
+                // technically could be a list too, but that's the exception to
+                // the rule...
                 cv => { try!(config.expected("string", &k, cv)); }
             }
         }

--- a/src/cargo/ops/cargo_doc.rs
+++ b/src/cargo/ops/cargo_doc.rs
@@ -10,7 +10,6 @@ use sources::PathSource;
 use util::{CargoResult, human};
 
 pub struct DocOptions<'a, 'b: 'a> {
-    pub all: bool,
     pub open_result: bool,
     pub compile_opts: ops::CompileOptions<'a, 'b>,
 }

--- a/src/cargo/ops/cargo_doc.rs
+++ b/src/cargo/ops/cargo_doc.rs
@@ -25,7 +25,7 @@ pub fn doc(manifest_path: &Path,
     let mut lib_names = HashSet::new();
     let mut bin_names = HashSet::new();
     if options.compile_opts.spec.is_none() {
-        for target in package.targets().iter().filter(|t| t.profile().is_doc()) {
+        for target in package.targets() {
             if target.is_lib() {
                 assert!(lib_names.insert(target.name()));
             } else {

--- a/src/cargo/ops/cargo_package.rs
+++ b/src/cargo/ops/cargo_package.rs
@@ -179,16 +179,16 @@ fn run_verify(config: &Config, pkg: &Package, tar: &Path)
 
     // Now that we've rewritten all our path dependencies, compile it!
     try!(ops::compile_pkg(&new_pkg, &ops::CompileOptions {
-        env: "compile",
         config: config,
         jobs: None,
         target: None,
-        dev_deps: false,
         features: &[],
         no_default_features: false,
         spec: None,
-        lib_only: false,
+        filter: ops::CompileFilter::Everything,
         exec_engine: None,
+        release: false,
+        mode: ops::CompileMode::Build,
     }));
 
     Ok(())

--- a/src/cargo/ops/cargo_run.rs
+++ b/src/cargo/ops/cargo_run.rs
@@ -18,7 +18,10 @@ pub fn run(manifest_path: &Path,
     // will verify that we're buliding at least one binary, so we don't check
     // for that form of existence here.
     let mut bins = root.manifest().targets().iter().filter(|a| {
-        options.filter.matches(a) && !a.is_lib() && !a.is_custom_build()
+        !a.is_lib() && !a.is_custom_build() && match options.filter {
+            CompileFilter::Everything => a.is_bin(),
+            CompileFilter::Only { .. } => options.filter.matches(a),
+        }
     });
     let _ = bins.next();
     if bins.next().is_some() {

--- a/src/cargo/ops/cargo_rustc/context.rs
+++ b/src/cargo/ops/cargo_rustc/context.rs
@@ -376,8 +376,7 @@ impl<'a, 'b: 'a> Context<'a, 'b> {
             ret.push((pkg, t, self.lib_profile(pkg.package_id())));
         }
 
-        // If this is a test profile, then we need to ensure that all binaries
-        // are built.
+        // Integration tests/benchmarks require binaries to be built
         if profile.test && (target.is_test() || target.is_bench()) {
             ret.extend(pkg.targets().iter().filter(|t| t.is_bin())
                           .map(|t| (pkg, t, self.lib_profile(pkg.package_id()))));

--- a/src/cargo/ops/cargo_rustc/context.rs
+++ b/src/cargo/ops/cargo_rustc/context.rs
@@ -378,7 +378,7 @@ impl<'a, 'b: 'a> Context<'a, 'b> {
 
         // If this is a test profile, then we need to ensure that all binaries
         // are built.
-        if profile.test {
+        if profile.test && (target.is_test() || target.is_bench()) {
             ret.extend(pkg.targets().iter().filter(|t| t.is_bin())
                           .map(|t| (pkg, t, self.lib_profile(pkg.package_id()))));
         }

--- a/src/cargo/ops/cargo_rustc/context.rs
+++ b/src/cargo/ops/cargo_rustc/context.rs
@@ -1,5 +1,5 @@
 use std::collections::hash_map::Entry::{Occupied, Vacant};
-use std::collections::hash_map::HashMap;
+use std::collections::{HashSet, HashMap};
 use std::str;
 use std::sync::Arc;
 use std::path::PathBuf;
@@ -7,6 +7,7 @@ use std::path::PathBuf;
 use regex::Regex;
 
 use core::{SourceMap, Package, PackageId, PackageSet, Resolve, Target, Profile};
+use core::{TargetKind, LibKind, Profiles, Metadata};
 use util::{self, CargoResult, ChainError, internal, Config, profile};
 use util::human;
 
@@ -31,9 +32,12 @@ pub struct Context<'a, 'b: 'a> {
     pub compilation: Compilation,
     pub build_state: Arc<BuildState>,
     pub exec_engine: Arc<Box<ExecEngine>>,
-    pub fingerprints: HashMap<(&'a PackageId, &'a Target, Kind), Fingerprint>,
+    pub fingerprints: HashMap<(&'a PackageId, &'a Target, &'a Profile, Kind),
+                              Fingerprint>,
+    pub initialized: HashSet<&'a PackageId>,
+    pub compiled: HashSet<(&'a PackageId, &'a Target, &'a Profile)>,
+    pub build_config: BuildConfig,
 
-    env: &'a str,
     host: Layout,
     target: Option<Layout>,
     target_triple: String,
@@ -43,19 +47,19 @@ pub struct Context<'a, 'b: 'a> {
     target_dylib: Option<(String, String)>,
     target_exe: String,
     requirements: HashMap<(&'a PackageId, &'a str), Platform>,
-    build_config: BuildConfig,
+    profiles: &'a Profiles,
 }
 
 impl<'a, 'b: 'a> Context<'a, 'b> {
-    pub fn new(env: &'a str,
-               resolve: &'a Resolve,
+    pub fn new(resolve: &'a Resolve,
                sources: &'a SourceMap<'a>,
                deps: &'a PackageSet,
                config: &'a Config<'b>,
                host: Layout,
                target_layout: Option<Layout>,
                root_pkg: &Package,
-               build_config: BuildConfig) -> CargoResult<Context<'a, 'b>> {
+               build_config: BuildConfig,
+               profiles: &'a Profiles) -> CargoResult<Context<'a, 'b>> {
         let target = build_config.requested_target.clone();
         let target = target.as_ref().map(|s| &s[..]);
         let (target_dylib, target_exe) = try!(Context::filename_parts(target));
@@ -65,9 +69,11 @@ impl<'a, 'b: 'a> Context<'a, 'b> {
             try!(Context::filename_parts(None))
         };
         let target_triple = target.unwrap_or(config.rustc_host()).to_string();
+        let engine = build_config.exec_engine.as_ref().cloned().unwrap_or({
+            Arc::new(Box::new(ProcessEngine) as Box<ExecEngine>)
+        });
         Ok(Context {
             target_triple: target_triple,
-            env: env,
             host: host,
             target: target_layout,
             resolve: resolve,
@@ -80,10 +86,13 @@ impl<'a, 'b: 'a> Context<'a, 'b> {
             host_exe: host_exe,
             requirements: HashMap::new(),
             compilation: Compilation::new(root_pkg),
-            build_state: Arc::new(BuildState::new(build_config.clone(), deps)),
+            build_state: Arc::new(BuildState::new(&build_config, deps)),
             build_config: build_config,
-            exec_engine: Arc::new(Box::new(ProcessEngine) as Box<ExecEngine>),
+            exec_engine: engine,
             fingerprints: HashMap::new(),
+            profiles: profiles,
+            compiled: HashSet::new(),
+            initialized: HashSet::new(),
         })
     }
 
@@ -129,7 +138,9 @@ impl<'a, 'b: 'a> Context<'a, 'b> {
 
     /// Prepare this context, ensuring that all filesystem directories are in
     /// place.
-    pub fn prepare(&mut self, pkg: &'a Package) -> CargoResult<()> {
+    pub fn prepare(&mut self, pkg: &'a Package,
+                   targets: &[(&'a Target, &'a Profile)])
+                   -> CargoResult<()> {
         let _p = profile::start("preparing layout");
 
         try!(self.host.prepare().chain_error(|| {
@@ -146,9 +157,8 @@ impl<'a, 'b: 'a> Context<'a, 'b> {
             None => {}
         }
 
-        let targets = pkg.targets().iter();
-        for target in targets.filter(|t| t.profile().is_compile()) {
-            self.build_requirements(pkg, target, Platform::Target);
+        for &(target, profile) in targets {
+            self.build_requirements(pkg, target, profile, Platform::Target);
         }
 
         let jobs = self.jobs();
@@ -163,8 +173,8 @@ impl<'a, 'b: 'a> Context<'a, 'b> {
     }
 
     fn build_requirements(&mut self, pkg: &'a Package, target: &'a Target,
-                          req: Platform) {
-        let req = if target.profile().is_for_host() {Platform::Plugin} else {req};
+                          profile: &Profile, req: Platform) {
+        let req = if target.for_host() {Platform::Plugin} else {req};
         match self.requirements.entry((pkg.package_id(), target.name())) {
             Occupied(mut entry) => match (*entry.get(), req) {
                 (Platform::Plugin, Platform::Plugin) |
@@ -177,13 +187,15 @@ impl<'a, 'b: 'a> Context<'a, 'b> {
             Vacant(entry) => { entry.insert(req); }
         };
 
-        for &(pkg, dep) in self.dep_targets(pkg, target).iter() {
-            self.build_requirements(pkg, dep, req);
+        for &(pkg, dep, profile) in self.dep_targets(pkg, target, profile).iter() {
+            self.build_requirements(pkg, dep, profile, req);
         }
 
-        match pkg.targets().iter().find(|t| t.profile().is_custom_build()) {
+        match pkg.targets().iter().find(|t| t.is_custom_build()) {
             Some(custom_build) => {
-                self.build_requirements(pkg, custom_build, Platform::Plugin);
+                let profile = self.build_script_profile(pkg.package_id());
+                self.build_requirements(pkg, custom_build, profile,
+                                        Platform::Plugin);
             }
             None => {}
         }
@@ -191,7 +203,7 @@ impl<'a, 'b: 'a> Context<'a, 'b> {
 
     pub fn get_requirement(&self, pkg: &'a Package,
                            target: &'a Target) -> Platform {
-        let default = if target.profile().is_for_host() {
+        let default = if target.for_host() {
             Platform::Plugin
         } else {
             Platform::Target
@@ -215,7 +227,7 @@ impl<'a, 'b: 'a> Context<'a, 'b> {
     /// target.
     pub fn out_dir(&self, pkg: &Package, kind: Kind, target: &Target) -> PathBuf {
         let out_dir = self.layout(pkg, kind);
-        if target.profile().is_custom_build() {
+        if target.is_custom_build() {
             out_dir.build(pkg)
         } else if target.is_example() {
             out_dir.examples().to_path_buf()
@@ -246,31 +258,68 @@ impl<'a, 'b: 'a> Context<'a, 'b> {
         &self.target_triple
     }
 
-    /// Return the exact filename of the target.
-    pub fn target_filenames(&self, target: &Target) -> CargoResult<Vec<String>> {
-        let stem = target.file_stem();
+    /// Get the metadata for a target in a specific profile
+    pub fn target_metadata(&self, target: &Target, profile: &Profile)
+                           -> Option<Metadata> {
+        let metadata = target.metadata();
+        if target.is_lib() && profile.test {
+            // Libs and their tests are built in parallel, so we need to make
+            // sure that their metadata is different.
+            metadata.map(|m| m.clone()).map(|mut m| {
+                m.mix(&"test");
+                m
+            })
+        } else if target.is_bin() && profile.test {
+            // Make sure that the name of this test executable doesn't
+            // conflicts with a library that has the same name and is
+            // being tested
+            let mut metadata = self.resolve.root().generate_metadata();
+            metadata.mix(&format!("bin-{}", target.name()));
+            Some(metadata)
+        } else {
+            metadata.map(|m| m.clone())
+        }
+    }
+
+    /// Returns the file stem for a given target/profile combo
+    pub fn file_stem(&self, target: &Target, profile: &Profile) -> String {
+        match self.target_metadata(target, profile) {
+            Some(ref metadata) => format!("{}{}", target.name(),
+                                          metadata.extra_filename),
+            None => target.name().to_string(),
+        }
+    }
+
+    /// Return the filenames that the given target for the given profile will
+    /// generate.
+    pub fn target_filenames(&self, target: &Target, profile: &Profile)
+                            -> CargoResult<Vec<String>> {
+        let stem = self.file_stem(target, profile);
+        let suffix = if target.for_host() {&self.host_exe} else {&self.target_exe};
 
         let mut ret = Vec::new();
-        if target.is_example() || target.is_bin() ||
-           target.profile().is_test() {
-            ret.push(format!("{}{}", stem,
-                             if target.profile().is_for_host() {
-                                 &self.host_exe
-                             } else {
-                                 &self.target_exe
-                             }));
-        } else {
-            if target.is_dylib() {
-                let plugin = target.profile().is_for_host();
-                let kind = if plugin {Kind::Host} else {Kind::Target};
-                let (prefix, suffix) = try!(self.dylib(kind));
-                ret.push(format!("{}{}{}", prefix, stem, suffix));
+        match *target.kind() {
+            TargetKind::Example | TargetKind::Bin | TargetKind::CustomBuild |
+            TargetKind::Bench | TargetKind::Test => {
+                ret.push(format!("{}{}", stem, suffix));
             }
-            if target.is_rlib() {
-                ret.push(format!("lib{}.rlib", stem));
+            TargetKind::Lib(..) if profile.test => {
+                ret.push(format!("{}{}", stem, suffix));
             }
-            if target.is_staticlib() {
-                ret.push(format!("lib{}.a", stem));
+            TargetKind::Lib(ref libs) => {
+                for lib in libs.iter() {
+                    match *lib {
+                        LibKind::Dylib => {
+                            let plugin = target.for_host();
+                            let kind = if plugin {Kind::Host} else {Kind::Target};
+                            let (prefix, suffix) = try!(self.dylib(kind));
+                            ret.push(format!("{}{}{}", prefix, stem, suffix));
+                        }
+                        LibKind::Lib |
+                        LibKind::Rlib => ret.push(format!("lib{}.rlib", stem)),
+                        LibKind::StaticLib => ret.push(format!("lib{}.a", stem)),
+                    }
+                }
             }
         }
         assert!(ret.len() > 0);
@@ -279,10 +328,11 @@ impl<'a, 'b: 'a> Context<'a, 'b> {
 
     /// For a package, return all targets which are registered as dependencies
     /// for that package.
-    pub fn dep_targets(&self, pkg: &Package, target: &Target)
-                       -> Vec<(&'a Package, &'a Target)> {
+    pub fn dep_targets(&self, pkg: &Package, target: &Target,
+                       profile: &Profile)
+                       -> Vec<(&'a Package, &'a Target, &'a Profile)> {
         let deps = match self.resolve.deps(pkg.package_id()) {
-            None => return vec!(),
+            None => return Vec::new(),
             Some(deps) => deps,
         };
         let mut ret = deps.map(|id| self.get_package(id)).filter(|dep| {
@@ -293,37 +343,46 @@ impl<'a, 'b: 'a> Context<'a, 'b> {
             // If this target is a build command, then we only want build
             // dependencies, otherwise we want everything *other than* build
             // dependencies.
-            let is_correct_dep =
-                target.profile().is_custom_build() == pkg_dep.is_build();
+            let is_correct_dep = target.is_custom_build() == pkg_dep.is_build();
 
             // If this dependency is *not* a transitive dependency, then it
             // only applies to test/example targets
             let is_actual_dep = pkg_dep.is_transitive() ||
-                                target.profile().is_test() ||
-                                target.is_example();
+                                target.is_test() ||
+                                target.is_example() ||
+                                profile.test;
 
             is_correct_dep && is_actual_dep
         }).filter_map(|pkg| {
-            pkg.targets().iter().find(|&t| self.is_relevant_target(t))
-               .map(|t| (pkg, t))
+            pkg.targets().iter().find(|t| t.is_lib()).map(|t| {
+                (pkg, t, self.lib_profile(pkg.package_id()))
+            })
         }).collect::<Vec<_>>();
+
+        // If a target isn't actually a build script itself, then it depends on
+        // the build script if there is one.
+        if target.is_custom_build() { return ret }
+        let pkg = self.get_package(pkg.package_id());
+        if let Some(t) = pkg.targets().iter().find(|t| t.is_custom_build()) {
+            ret.push((pkg, t, self.build_script_profile(pkg.package_id())));
+        }
 
         // If this target is a binary, test, example, etc, then it depends on
         // the library of the same package. The call to `resolve.deps` above
         // didn't include `pkg` in the return values, so we need to special case
         // it here and see if we need to push `(pkg, pkg_lib_target)`.
-        if !target.profile().is_custom_build() &&
-           (target.is_bin() || target.is_example()) {
-            let pkg = self.get_package(pkg.package_id());
-            let target = pkg.targets().iter().filter(|t| {
-                t.is_lib() && t.profile().is_compile() &&
-                    (t.is_rlib() || t.is_dylib())
-            }).next();
-            if let Some(t) = target {
-                ret.push((pkg, t));
-            }
+        if target.is_lib() { return ret }
+        if let Some(t) = pkg.targets().iter().find(|t| t.linkable()) {
+            ret.push((pkg, t, self.lib_profile(pkg.package_id())));
         }
-        return ret;
+
+        // If this is a test profile, then we need to ensure that all binaries
+        // are built.
+        if profile.test {
+            ret.extend(pkg.targets().iter().filter(|t| t.is_bin())
+                          .map(|t| (pkg, t, self.lib_profile(pkg.package_id()))));
+        }
+        return ret
     }
 
     /// Gets a package for the given package id.
@@ -331,26 +390,6 @@ impl<'a, 'b: 'a> Context<'a, 'b> {
         self.package_set.iter()
             .find(|pkg| id == pkg.package_id())
             .expect("Should have found package")
-    }
-
-    pub fn env(&self) -> &str {
-        // The "doc-all" environment just means to document everything (see
-        // below), but we want to canonicalize that the the "doc" profile
-        // environment, so do that here.
-        if self.env == "doc-all" {"doc"} else {self.env}
-    }
-
-    pub fn is_relevant_target(&self, target: &Target) -> bool {
-        target.is_lib() && match self.env {
-            "doc" | "test" => target.profile().is_compile(),
-            // doc-all == document everything, so look for doc targets and
-            //            compile targets in dependencies
-            "doc-all" => target.profile().is_compile() ||
-                         (target.profile().env() == "doc" &&
-                          target.profile().is_doc()),
-            _ => target.profile().env() == self.env &&
-                 !target.profile().is_test(),
-        }
     }
 
     /// Get the user-specified linker for a particular host or target
@@ -379,21 +418,18 @@ impl<'a, 'b: 'a> Context<'a, 'b> {
         self.build_config.requested_target.as_ref().map(|s| &s[..])
     }
 
-    /// Calculate the actual profile to use for a target's compliation.
-    ///
-    /// This may involve overriding some options such as debug information,
-    /// rpath, opt level, etc.
-    pub fn profile(&self, target: &Target) -> Profile {
-        let mut profile = target.profile().clone();
-        let root_package = self.get_package(self.resolve.root());
-        for target in root_package.manifest().targets().iter() {
-            let root_profile = target.profile();
-            if root_profile.env() != profile.env() { continue }
-            profile = profile.set_opt_level(root_profile.opt_level())
-                             .set_debug(root_profile.debug())
-                             .set_rpath(root_profile.rpath())
+    pub fn lib_profile(&self, _pkg: &PackageId) -> &'a Profile {
+        if self.build_config.release {
+            &self.profiles.release
+        } else {
+            &self.profiles.dev
         }
-        profile
+    }
+
+    pub fn build_script_profile(&self, _pkg: &PackageId) -> &'a Profile {
+        // TODO: should build scripts always be built with a dev
+        //       profile? How is this controlled at the CLI layer?
+        &self.profiles.dev
     }
 }
 

--- a/src/cargo/ops/cargo_rustc/fingerprint.rs
+++ b/src/cargo/ops/cargo_rustc/fingerprint.rs
@@ -64,7 +64,7 @@ pub fn prepare_target<'a, 'b>(cx: &mut Context<'a, 'b>,
 
             if profile.test {
                 cx.compilation.tests.push((target.name().to_string(), dst));
-            } else if target.is_bin() {
+            } else if target.is_bin() || target.is_example() {
                 cx.compilation.binaries.push(dst);
             } else if target.is_lib() {
                 let pkgid = pkg.package_id().clone();

--- a/src/cargo/ops/cargo_rustc/fingerprint.rs
+++ b/src/cargo/ops/cargo_rustc/fingerprint.rs
@@ -169,7 +169,11 @@ fn calculate<'a, 'b>(cx: &mut Context<'a, 'b>,
                                    profile));
 
     // Next, recursively calculate the fingerprint for all of our dependencies.
+    // Skip the fingerprints of build scripts as they may not always be
+    // available and the dirtiness propagation for modification is tracked
+    // elsewhere
     let deps = try!(cx.dep_targets(pkg, target, profile).into_iter()
+                      .filter(|&(_, t, _)| !t.is_custom_build())
                       .map(|(pkg, target, profile)| {
         let kind = match kind {
             Kind::Host => Kind::Host,

--- a/src/cargo/ops/cargo_rustc/fingerprint.rs
+++ b/src/cargo/ops/cargo_rustc/fingerprint.rs
@@ -62,7 +62,7 @@ pub fn prepare_target<'a, 'b>(cx: &mut Context<'a, 'b>,
             let dst = root.join(filename);
             missing_outputs |= fs::metadata(&dst).is_err();
 
-            if target.is_test() || profile.test {
+            if profile.test {
                 cx.compilation.tests.push((target.name().to_string(), dst));
             } else if target.is_bin() {
                 cx.compilation.binaries.push(dst);

--- a/src/cargo/ops/cargo_rustc/fingerprint.rs
+++ b/src/cargo/ops/cargo_rustc/fingerprint.rs
@@ -169,11 +169,14 @@ fn calculate<'a, 'b>(cx: &mut Context<'a, 'b>,
                                    profile));
 
     // Next, recursively calculate the fingerprint for all of our dependencies.
+    //
     // Skip the fingerprints of build scripts as they may not always be
     // available and the dirtiness propagation for modification is tracked
-    // elsewhere
+    // elsewhere. Also skip fingerprints of binaries because they don't actually
+    // induce a recompile, they're just dependencies in the sense that they need
+    // to be built.
     let deps = try!(cx.dep_targets(pkg, target, profile).into_iter()
-                      .filter(|&(_, t, _)| !t.is_custom_build())
+                      .filter(|&(_, t, _)| !t.is_custom_build() && !t.is_bin())
                       .map(|(pkg, target, profile)| {
         let kind = match kind {
             Kind::Host => Kind::Host,

--- a/src/cargo/ops/cargo_rustc/job_queue.rs
+++ b/src/cargo/ops/cargo_rustc/job_queue.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
 use std::collections::hash_map::HashMap;
-use std::collections::hash_map::Entry::{Occupied, Vacant};
+// use std::collections::hash_map::Entry::{Occupied, Vacant};
 use std::sync::mpsc::{channel, Sender, Receiver};
 
 use threadpool::ThreadPool;
@@ -27,7 +27,7 @@ pub struct JobQueue<'a> {
     packages: &'a PackageSet,
     active: u32,
     pending: HashMap<(&'a PackageId, Stage), PendingBuild>,
-    state: HashMap<&'a PackageId, Freshness>,
+    pkgids: HashSet<&'a PackageId>,
     printed: HashSet<&'a PackageId>,
 }
 
@@ -75,25 +75,17 @@ impl<'a> JobQueue<'a> {
             packages: packages,
             active: 0,
             pending: HashMap::new(),
-            state: HashMap::new(),
+            pkgids: HashSet::new(),
             printed: HashSet::new(),
         }
     }
 
-    pub fn enqueue(&mut self, pkg: &'a Package, stage: Stage,
-                   jobs: Vec<(Job, Freshness)>) {
-        // Record the freshness state of this package as dirty if any job is
-        // dirty or fresh otherwise
-        let fresh = jobs.iter().fold(Fresh, |f1, &(_, f2)| f1.combine(f2));
-        match self.state.entry(pkg.package_id()) {
-            Occupied(mut entry) => { *entry.get_mut() = entry.get().combine(fresh); }
-            Vacant(entry) => { entry.insert(fresh); }
-        };
-
-        // Add the package to the dependency graph
-        self.queue.enqueue(&(self.resolve, self.packages), Fresh,
-                           (pkg.package_id(), stage),
-                           (pkg, jobs));
+    pub fn queue(&mut self, pkg: &'a Package, stage: Stage)
+                 -> &mut Vec<(Job, Freshness)> {
+        self.pkgids.insert(pkg.package_id());
+        &mut self.queue.queue(&(self.resolve, self.packages), Fresh,
+                              (pkg.package_id(), stage),
+                              (pkg, Vec::new())).1
     }
 
     /// Execute all jobs necessary to build the dependency graph.
@@ -123,11 +115,11 @@ impl<'a> JobQueue<'a> {
             // scheduling work as quickly as possibly.
             let (id, stage, fresh, result) = self.rx.recv().unwrap();
             info!("  end: {} {:?}", id, stage);
-            let id = *self.state.keys().find(|&k| *k == &id).unwrap();
+            let id = *self.pkgids.iter().find(|&k| *k == &id).unwrap();
             self.active -= 1;
             match result {
                 Ok(()) => {
-                    let state = &mut self.pending[(id, stage)];
+                    let state = self.pending.get_mut(&(id, stage)).unwrap();
                     state.amt -= 1;
                     state.fresh = state.fresh.combine(fresh);
                     if state.amt == 0 {
@@ -171,9 +163,11 @@ impl<'a> JobQueue<'a> {
             fresh: fresh,
         });
 
-        let mut total_fresh = fresh.combine(self.state[pkg.package_id()]);
+        let mut total_fresh = fresh;
         let mut running = Vec::new();
+        debug!("start {:?} at {:?} for {}", total_fresh, stage, pkg);
         for (job, job_freshness) in jobs.into_iter() {
+            debug!("job: {:?} ({:?})", job_freshness, total_fresh);
             let fresh = job_freshness.combine(fresh);
             total_fresh = total_fresh.combine(fresh);
             let my_tx = self.tx.clone();
@@ -207,8 +201,7 @@ impl<'a> JobQueue<'a> {
         // run for a package, regardless of when that is. We then don't print
         // out any more information for a package after we've printed it once.
         let print = !self.printed.contains(&pkg.package_id());
-        if print && (stage == Stage::Libraries ||
-                     (total_fresh == Dirty && running.len() > 0)) {
+        if print && total_fresh == Dirty && running.len() > 0 {
             self.printed.insert(pkg.package_id());
             match total_fresh {
                 Fresh => try!(config.shell().verbose(|c| {

--- a/src/cargo/ops/cargo_rustc/links.rs
+++ b/src/cargo/ops/cargo_rustc/links.rs
@@ -23,9 +23,7 @@ pub fn validate(deps: &PackageSet) -> CargoResult<()> {
             }
             None => {}
         }
-        if !dep.manifest().targets().iter().any(|t| {
-            t.profile().is_custom_build()
-        }) {
+        if !dep.manifest().targets().iter().any(|t| t.is_custom_build()) {
             return Err(human(format!("package `{}` specifies that it links to \
                                       `{}` but does not have a custom build \
                                       script", dep.package_id(), lib)))

--- a/src/cargo/ops/cargo_rustc/mod.rs
+++ b/src/cargo/ops/cargo_rustc/mod.rs
@@ -278,6 +278,7 @@ fn prepare_init<'a, 'b>(cx: &mut Context<'a, 'b>,
     jobs.queue(pkg, Stage::Binaries);
     jobs.queue(pkg, Stage::LibraryTests);
     jobs.queue(pkg, Stage::BinaryTests);
+    jobs.queue(pkg, Stage::End);
 
     // Prepare the fingerprint directory as the first step of building a package
     let (target1, target2) = fingerprint::prepare_init(cx, pkg, Kind::Target);

--- a/src/cargo/ops/cargo_rustc/mod.rs
+++ b/src/cargo/ops/cargo_rustc/mod.rs
@@ -42,6 +42,7 @@ pub struct BuildConfig {
     pub requested_target: Option<String>,
     pub exec_engine: Option<Arc<Box<ExecEngine>>>,
     pub release: bool,
+    pub doc_all: bool,
 }
 
 #[derive(Clone, Default)]

--- a/src/cargo/ops/cargo_test.rs
+++ b/src/cargo/ops/cargo_test.rs
@@ -20,12 +20,11 @@ pub fn run_tests(manifest_path: &Path,
         Err(e) => return Ok(Some(e)),
     };
 
-    let libs = compile.package.targets().iter().filter_map(|target| {
-        if !target.doctested() || !target.is_lib() {
-            return None
-        }
-        Some((target.src_path(), target.name()))
-    });
+    if options.no_run { return Ok(None) }
+
+    let libs = compile.package.targets().iter()
+                      .filter(|t| t.doctested())
+                      .map(|t| (t.src_path(), t.name()));
 
     for (lib, name) in libs {
         try!(config.shell().status("Doc-tests", name));

--- a/src/cargo/ops/mod.rs
+++ b/src/cargo/ops/mod.rs
@@ -1,5 +1,6 @@
 pub use self::cargo_clean::{clean, CleanOptions};
 pub use self::cargo_compile::{compile, compile_pkg, CompileOptions};
+pub use self::cargo_compile::{CompileFilter, CompileMode};
 pub use self::cargo_read_manifest::{read_manifest,read_package,read_packages};
 pub use self::cargo_rustc::{compile_targets, Compilation, Layout, Kind, rustc_version};
 pub use self::cargo_rustc::{Context, LayoutProxy};

--- a/src/cargo/util/toml.rs
+++ b/src/cargo/util/toml.rs
@@ -670,9 +670,11 @@ fn normalize(libs: &[TomlLibTarget],
             vec![if l.plugin == Some(true) {LibKind::Dylib} else {LibKind::Lib}]
         });
 
-        dst.push(Target::lib_target(&l.name, crate_types.clone(),
-                                    &path.to_path(),
-                                    metadata.clone()));
+        let mut target = Target::lib_target(&l.name, crate_types.clone(),
+                                            &path.to_path(),
+                                            metadata.clone());
+        configure(l, &mut target);
+        dst.push(target);
     }
 
     fn bin_targets(dst: &mut Vec<Target>, bins: &[TomlBinTarget],

--- a/tests/test_cargo_bench.rs
+++ b/tests/test_cargo_bench.rs
@@ -55,19 +55,11 @@ test!(bench_tarname {
             name = "foo"
             version = "0.0.1"
             authors = []
-
-            [[bin]]
-            name="bin1"
-            path="src/bin1.rs"
-
-            [[bin]]
-            name="bin2"
-            path="src/bin2.rs"
         "#)
-        .file("src/bin1.rs", r#"
+        .file("benches/bin1.rs", r#"
             extern crate test;
             #[bench] fn run1(_ben: &mut test::Bencher) { }"#)
-        .file("src/bin2.rs", r#"
+        .file("benches/bin2.rs", r#"
             extern crate test;
             #[bench] fn run2(_ben: &mut test::Bencher) { }"#);
 

--- a/tests/test_cargo_build_lib.rs
+++ b/tests/test_cargo_build_lib.rs
@@ -51,7 +51,6 @@ test!(build_with_no_lib {
         "#);
 
     assert_that(p.cargo_process("build").arg("--lib"),
-                execs()
-                .with_status(101)
-                .with_stderr("There is no lib to build, remove `--lib` flag"));
+                execs().with_status(101)
+                       .with_stderr("no library targets found"));
 });

--- a/tests/test_cargo_compile.rs
+++ b/tests/test_cargo_compile.rs
@@ -600,13 +600,16 @@ test!(crate_version_env_vars {
             }
         "#);
 
-    assert_that(p.cargo_process("build"), execs().with_status(0));
+    println!("build");
+    assert_that(p.cargo_process("build").arg("-v"), execs().with_status(0));
 
+    println!("bin");
     assert_that(process(&p.bin("foo")).unwrap(),
                 execs().with_stdout(format!("0-5-1 @ alpha.1 in {}\n",
                                             p.root().display()).as_slice()));
 
-    assert_that(p.cargo("test"),
+    println!("test");
+    assert_that(p.cargo("test").arg("-v"),
                 execs().with_status(0));
 });
 
@@ -977,7 +980,7 @@ test!(explicit_examples {
             fn main() { println!("{}, {}!", world::get_goodbye(), world::get_world()); }
         "#);
 
-    assert_that(p.cargo_process("test"), execs().with_status(0));
+    assert_that(p.cargo_process("test").arg("-v"), execs().with_status(0));
     assert_that(process(&p.bin("examples/hello")).unwrap(),
                         execs().with_stdout("Hello, World!\n"));
     assert_that(process(&p.bin("examples/goodbye")).unwrap(),
@@ -1545,16 +1548,16 @@ test!(example_bin_same_name {
         .file("src/main.rs", "fn main() {}")
         .file("examples/foo.rs", "fn main() {}");
 
-    p.cargo_process("test").arg("--no-run")
+    p.cargo_process("test").arg("--no-run").arg("-v")
         .exec_with_output()
         .unwrap();
 
     assert_that(&p.bin("foo"), existing_file());
     assert_that(&p.bin("examples/foo"), existing_file());
 
-    p.cargo("test").arg("--no-run")
-        .exec_with_output()
-        .unwrap();
+    p.cargo("test").arg("--no-run").arg("-v")
+                   .exec_with_output()
+                   .unwrap();
 
     assert_that(&p.bin("foo"), existing_file());
     assert_that(&p.bin("examples/foo"), existing_file());

--- a/tests/test_cargo_compile.rs
+++ b/tests/test_cargo_compile.rs
@@ -5,7 +5,7 @@ use tempdir::TempDir;
 
 use support::{project, execs, main_file, basic_bin_manifest};
 use support::{COMPILING, RUNNING, ProjectBuilder};
-use hamcrest::{assert_that, existing_file};
+use hamcrest::{assert_that, existing_file, is_not};
 use support::paths::CargoPathExt;
 use cargo::util::process;
 
@@ -1349,9 +1349,7 @@ test!(dep_no_libs {
         "#)
         .file("bar/src/main.rs", "");
     assert_that(foo.cargo_process("build"),
-                execs().with_status(101)
-                       .with_stderr("\
-Package `bar v0.0.0 ([..])` has no library targets"));
+                execs().with_status(0));
 });
 
 test!(recompile_space_in_name {
@@ -1552,14 +1550,14 @@ test!(example_bin_same_name {
         .exec_with_output()
         .unwrap();
 
-    assert_that(&p.bin("foo"), existing_file());
+    assert_that(&p.bin("foo"), is_not(existing_file()));
     assert_that(&p.bin("examples/foo"), existing_file());
 
     p.cargo("test").arg("--no-run").arg("-v")
                    .exec_with_output()
                    .unwrap();
 
-    assert_that(&p.bin("foo"), existing_file());
+    assert_that(&p.bin("foo"), is_not(existing_file()));
     assert_that(&p.bin("examples/foo"), existing_file());
 });
 

--- a/tests/test_cargo_compile_custom_build.rs
+++ b/tests/test_cargo_compile_custom_build.rs
@@ -469,6 +469,7 @@ test!(testing_and_such {
             fn main() {}
         "#);
 
+    println!("build");
     assert_that(p.cargo_process("build").arg("-v"),
                 execs().with_status(0));
     p.root().move_into_the_past().unwrap();
@@ -476,6 +477,7 @@ test!(testing_and_such {
     File::create(&p.root().join("src/lib.rs")).unwrap();
     p.root().move_into_the_past().unwrap();
 
+    println!("test");
     assert_that(p.cargo("test").arg("-vj1"),
                 execs().with_status(0)
                        .with_stdout(format!("\
@@ -498,16 +500,17 @@ test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
 
 ", compiling = COMPILING, running = RUNNING, doctest = DOCTEST).as_slice()));
 
+    println!("doc");
     assert_that(p.cargo("doc").arg("-v"),
                 execs().with_status(0)
                        .with_stdout(format!("\
 {compiling} foo v0.5.0 (file://[..])
 {running} `rustdoc [..]`
-{running} `rustc [..]`
 ", compiling = COMPILING, running = RUNNING).as_slice()));
 
     File::create(&p.root().join("src/main.rs")).unwrap()
          .write_all(b"fn main() {}").unwrap();
+    println!("run");
     assert_that(p.cargo("run"),
                 execs().with_status(0)
                        .with_stdout(format!("\

--- a/tests/test_cargo_compile_custom_build.rs
+++ b/tests/test_cargo_compile_custom_build.rs
@@ -485,7 +485,7 @@ test!(testing_and_such {
 {running} `[..]build-script-build[..]`
 {running} `rustc [..] --crate-name foo [..]`
 {running} `rustc [..] --crate-name foo [..]`
-{running} `[..]foo-[..]`
+{running} `[..]foo-[..][..]`
 
 running 0 tests
 
@@ -515,7 +515,7 @@ test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
                 execs().with_status(0)
                        .with_stdout(format!("\
 {compiling} foo v0.5.0 (file://[..])
-{running} `target[..]foo`
+{running} `target[..]foo[..]`
 ", compiling = COMPILING, running = RUNNING).as_slice()));
 });
 

--- a/tests/test_cargo_compile_custom_build.rs
+++ b/tests/test_cargo_compile_custom_build.rs
@@ -91,7 +91,7 @@ test!(custom_build_env_vars {
                 assert_eq!(opt, "0");
 
                 let opt = env::var("PROFILE").unwrap();
-                assert_eq!(opt, "compile");
+                assert_eq!(opt, "debug");
 
                 let debug = env::var("DEBUG").unwrap();
                 assert_eq!(debug, "true");
@@ -1176,7 +1176,7 @@ test!(profile_and_opt_level_set_correctly {
 
               fn main() {
                   assert_eq!(env::var("OPT_LEVEL").unwrap(), "3");
-                  assert_eq!(env::var("PROFILE").unwrap(), "bench");
+                  assert_eq!(env::var("PROFILE").unwrap(), "release");
                   assert_eq!(env::var("DEBUG").unwrap(), "false");
               }
         "#);

--- a/tests/test_cargo_compile_git_deps.rs
+++ b/tests/test_cargo_compile_git_deps.rs
@@ -965,7 +965,7 @@ test!(dep_with_changed_submodule {
                 .with_stdout(format!("{} git repository `[..]`\n\
                                       {} dep1 v0.5.0 ([..])\n\
                                       {} foo v0.5.0 ([..])\n\
-                                      {} `target[..]foo`\n\
+                                      {} `target[..]foo[..]`\n\
                                       project2\
                                       ",
                                       UPDATING,
@@ -1010,7 +1010,7 @@ test!(dep_with_changed_submodule {
     assert_that(project.cargo("run"), execs()
                 .with_stdout(format!("{compiling} dep1 v0.5.0 ([..])\n\
                                       {compiling} foo v0.5.0 ([..])\n\
-                                      {running} `target[..]foo`\n\
+                                      {running} `target[..]foo[..]`\n\
                                       project3\
                                       ",
                                       compiling = COMPILING, running = RUNNING))

--- a/tests/test_cargo_compile_plugins.rs
+++ b/tests/test_cargo_compile_plugins.rs
@@ -49,7 +49,7 @@ test!(plugin_to_the_max {
             path = "../baz"
         "#)
         .file("src/lib.rs", r#"
-            #![feature(plugin_registrar)]
+            #![feature(plugin_registrar, rustc_private)]
 
             extern crate rustc;
             extern crate baz;
@@ -57,7 +57,7 @@ test!(plugin_to_the_max {
             use rustc::plugin::Registry;
 
             #[plugin_registrar]
-            pub fn foo(reg: &mut Registry) {
+            pub fn foo(_reg: &mut Registry) {
                 println!("{}", baz::baz());
             }
         "#);

--- a/tests/test_cargo_run.rs
+++ b/tests/test_cargo_run.rs
@@ -22,7 +22,7 @@ test!(simple {
     assert_that(p.cargo_process("run"),
                 execs().with_status(0).with_stdout(format!("\
 {compiling} foo v0.0.1 ({dir})
-{running} `target{sep}debug{sep}foo`
+{running} `target{sep}debug{sep}foo[..]`
 hello
 ",
         compiling = COMPILING,
@@ -125,7 +125,7 @@ test!(specify_name {
 {compiling} foo v0.0.1 ({dir})
 {running} `rustc src[..]lib.rs [..]`
 {running} `rustc src[..]a.rs [..]`
-{running} `target{sep}debug{sep}a`
+{running} `target{sep}debug{sep}a[..]`
 hello a.rs
 ",
         compiling = COMPILING,
@@ -137,7 +137,7 @@ hello a.rs
                 execs().with_status(0).with_stdout(format!("\
 {compiling} foo v0.0.1 ([..])
 {running} `rustc src[..]b.rs [..]`
-{running} `target{sep}debug{sep}b`
+{running} `target{sep}debug{sep}b[..]`
 hello b.rs
 ",
         running = RUNNING, compiling = COMPILING,
@@ -163,7 +163,7 @@ test!(run_example {
     assert_that(p.cargo_process("run").arg("--example").arg("a"),
                 execs().with_status(0).with_stdout(format!("\
 {compiling} foo v0.0.1 ({dir})
-{running} `target{sep}debug{sep}examples{sep}a`
+{running} `target{sep}debug{sep}examples{sep}a[..]`
 example
 ",
         compiling = COMPILING,
@@ -216,7 +216,7 @@ test!(one_bin_multiple_examples {
     assert_that(p.cargo_process("run"),
                 execs().with_status(0).with_stdout(format!("\
 {compiling} foo v0.0.1 ({dir})
-{running} `target{sep}debug{sep}main`
+{running} `target{sep}debug{sep}main[..]`
 hello main.rs
 ",
         compiling = COMPILING,
@@ -289,7 +289,7 @@ test!(example_with_release_flag {
         -L dependency={dir}{sep}target{sep}release \
         -L dependency={dir}{sep}target{sep}release{sep}deps \
          --extern bar={dir}{sep}target{sep}release{sep}deps{sep}libbar-[..].rlib`
-{running} `target{sep}release{sep}examples{sep}a`
+{running} `target{sep}release{sep}examples{sep}a[..]`
 fast1
 fast2
 ",
@@ -318,7 +318,7 @@ fast2
         -L dependency={dir}{sep}target{sep}debug \
         -L dependency={dir}{sep}target{sep}debug{sep}deps \
          --extern bar={dir}{sep}target{sep}debug{sep}deps{sep}libbar-[..].rlib`
-{running} `target{sep}debug{sep}examples{sep}a`
+{running} `target{sep}debug{sep}examples{sep}a[..]`
 slow1
 slow2
 ",
@@ -375,7 +375,7 @@ test!(release_works {
     assert_that(p.cargo_process("run").arg("--release"),
                 execs().with_status(0).with_stdout(format!("\
 {compiling} foo v0.0.1 ({dir})
-{running} `target{sep}release{sep}foo`
+{running} `target{sep}release{sep}foo[..]`
 ",
         compiling = COMPILING,
         running = RUNNING,

--- a/tests/test_cargo_test.rs
+++ b/tests/test_cargo_test.rs
@@ -898,7 +898,7 @@ test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
        running = RUNNING,
        dir = prj.url());
 
-    assert_that(prj.cargo_process("test").arg("--test").arg("bin2"),
+    assert_that(prj.cargo_process("test").arg("--bin").arg("bin2"),
         execs().with_status(0).with_stdout(expected_stdout.as_slice()));
 });
 

--- a/tests/test_cargo_test.rs
+++ b/tests/test_cargo_test.rs
@@ -1356,11 +1356,11 @@ test!(bad_example {
 
     assert_that(p.cargo_process("run").arg("--example").arg("foo"),
                 execs().with_status(101).with_stderr("\
-no example target named `foo` to run
+no example target named `foo`
 "));
     assert_that(p.cargo_process("run").arg("--bin").arg("foo"),
                 execs().with_status(101).with_stderr("\
-no bin target named `foo` to run
+no bin target named `foo`
 "));
 });
 

--- a/tests/test_cargo_test.rs
+++ b/tests/test_cargo_test.rs
@@ -1147,7 +1147,7 @@ test!(example_dev_dep {
         .file("bar/src/lib.rs", r#"
             #![feature(macro_rules)]
             // make sure this file takes awhile to compile
-            macro_rules! f0( () => (1u) );
+            macro_rules! f0( () => (1) );
             macro_rules! f1( () => ({(f0!()) + (f0!())}) );
             macro_rules! f2( () => ({(f1!()) + (f1!())}) );
             macro_rules! f3( () => ({(f2!()) + (f2!())}) );
@@ -1164,6 +1164,9 @@ test!(example_dev_dep {
             }
         "#);
     assert_that(p.cargo_process("test"),
+                execs().with_status(0));
+    assert_that(p.cargo("run")
+                 .arg("--example").arg("e1").arg("--release").arg("-v"),
                 execs().with_status(0));
 });
 

--- a/tests/test_cargo_test.rs
+++ b/tests/test_cargo_test.rs
@@ -924,13 +924,6 @@ test test_b ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
 
-{running} target[..]b-[..]
-
-running 1 test
-test test_b ... ok
-
-test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
-
 ",
        compiling = COMPILING,
        running = RUNNING,

--- a/tests/test_cargo_test.rs
+++ b/tests/test_cargo_test.rs
@@ -91,7 +91,7 @@ test!(many_similar_names {
             #[test] fn test_test() { foo::foo() }
         "#);
 
-    let output = p.cargo_process("test").exec_with_output().unwrap();
+    let output = p.cargo_process("test").arg("-v").exec_with_output().unwrap();
     let output = str::from_utf8(&output.stdout).unwrap();
     assert!(output.contains("test bin_test"), "bin_test missing\n{}", output);
     assert!(output.contains("test lib_test"), "lib_test missing\n{}", output);

--- a/tests/test_cargo_test.rs
+++ b/tests/test_cargo_test.rs
@@ -992,6 +992,7 @@ test!(selective_testing {
                 doctest = false
         "#)
         .file("d1/src/lib.rs", "")
+        .file("d1/src/main.rs", "extern crate d1; fn main() {}")
         .file("d2/Cargo.toml", r#"
             [package]
             name = "d2"
@@ -1002,7 +1003,8 @@ test!(selective_testing {
                 name = "d2"
                 doctest = false
         "#)
-        .file("d2/src/lib.rs", "");
+        .file("d2/src/lib.rs", "")
+        .file("d2/src/main.rs", "extern crate d2; fn main() {}");
     p.build();
 
     println!("d1");
@@ -1014,7 +1016,14 @@ test!(selective_testing {
 
 running 0 tests
 
-test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured\n
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
+
+{running} target[..]d1-[..]
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
+
 ", compiling = COMPILING, running = RUNNING,
    dir = p.url()).as_slice()));
 
@@ -1027,7 +1036,14 @@ test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured\n
 
 running 0 tests
 
-test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured\n
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
+
+{running} target[..]d2-[..]
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
+
 ", compiling = COMPILING, running = RUNNING,
    dir = p.url()).as_slice()));
 
@@ -1040,7 +1056,8 @@ test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured\n
 
 running 0 tests
 
-test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured\n
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
+
 ", compiling = COMPILING, running = RUNNING,
    dir = p.url()).as_slice()));
 });


### PR DESCRIPTION
This commit is a complete overhaul of how Cargo handles compilation profiles
internally. The external interface of Cargo is not affected by this change.

Previously each Target had a Profile embedded within it. Conceptually a Target
is an entry in the manifest (a binary, benchmark, etc) and a Profile controlled
various flags (e.g. --test, -C opt-level, etc). Each Package then contained many
profiles for each possible compilation mode. For example a Package would have
one target for testing a library, benchmarking a library, documenting a library,
etc. When it came to building these targets, Cargo would filter out the targets
listed to determine what needed to be built.

This filtering was largely done based off an "environment" represented as a
string. Each mode of compilation got a separate environment string like `"test"`
or `"bench"`. Altogether, however, this approach had a number of drawbacks:

* Examples in release mode do not currently work. This is due to how examples
  are classified and how release mode is handled (e.g. the "release" environment
  where examples are meant to be built in the "test" environment).
* It is not trivial to implement `cargo test --release` today.
* It is not trivial to implement `cargo build --bin foo` where *only* the binary
  `foo` is built. The same is true for examples.
* It is not trivial to add selective building of a number of
  binaries/examples/etc.
* Filtering the list of targets to build has some pretty hokey logic that
  involves pseudo-environments like "doc-all" vs "doc". This logic is duplicated
  in a few places and in general is quite brittle.
* The TOML parser greatly affects compilation due to the time at which profiles
  are generated, which seems somewhat backwards.
* Profiles must be overridden, but only partially, at compile time becuase only
  the top-level package's profile is applied.

In general, this system just needed an overhaul. This commit made a single
change of separating `Profile` from `Target` and then basically hit `make` until
all the tests passed again. The other large architectural changes are:

* Environment strings are now entirely gone.
* Filters are implemented in a much more robust fashion.
* Release mode is now handled much more gracefully.
* The unit of compilation in the backend is no longer (package, target) but
  rather (package, target, profile). This change had to be propagated many
  location in the `cargo_rustc` module.
* The backend does not filter targets to build *at all*. All filtering now
  happens entirely in the frontend.

I'll test issues after this change lands, but the motivation behind this is to
open the door to quickly fixing a number of outstanding issues against Cargo.
This change itself is not intended to close many bugs.