### PR TITLE
Normalize hyphens to underscores in crate names

### DIFF
--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -322,6 +322,7 @@ impl Target {
     }
 
     pub fn name(&self) -> &str { &self.name }
+    pub fn crate_name(&self) -> String { self.name.replace("-", "_") }
     pub fn src_path(&self) -> &Path { &self.src_path }
     pub fn metadata(&self) -> Option<&Metadata> { self.metadata.as_ref() }
     pub fn kind(&self) -> &TargetKind { &self.kind }
@@ -331,6 +332,10 @@ impl Target {
     pub fn doctested(&self) -> bool { self.doctest }
     pub fn for_host(&self) -> bool { self.for_host }
     pub fn benched(&self) -> bool { self.benched }
+
+    pub fn allows_underscores(&self) -> bool {
+        self.is_bin() || self.is_example() || self.is_custom_build()
+    }
 
     pub fn is_lib(&self) -> bool {
         match self.kind {

--- a/src/cargo/ops/cargo_rustc/context.rs
+++ b/src/cargo/ops/cargo_rustc/context.rs
@@ -282,9 +282,10 @@ impl<'a, 'b: 'a> Context<'a, 'b> {
     /// Returns the file stem for a given target/profile combo
     pub fn file_stem(&self, target: &Target, profile: &Profile) -> String {
         match self.target_metadata(target, profile) {
-            Some(ref metadata) => format!("{}{}", target.name(),
+            Some(ref metadata) => format!("{}{}", target.crate_name(),
                                           metadata.extra_filename),
-            None => target.name().to_string(),
+            None if target.allows_underscores() => target.name().to_string(),
+            None => target.crate_name().to_string(),
         }
     }
 

--- a/src/cargo/ops/cargo_rustc/custom_build.rs
+++ b/src/cargo/ops/cargo_rustc/custom_build.rs
@@ -46,9 +46,7 @@ pub fn prepare(pkg: &Package, target: &Target, req: Platform,
     };
 
     // Building the command to execute
-    let profile = cx.build_script_profile(pkg.package_id());
-    let to_exec = try!(cx.target_filenames(target, profile))[0].clone();
-    let to_exec = script_output.join(&to_exec);
+    let to_exec = script_output.join(target.name());
 
     // Start preparing the process to execute, starting out with some
     // environment variables. Note that the profile-related environment

--- a/tests/test_cargo_compile.rs
+++ b/tests/test_cargo_compile.rs
@@ -1653,3 +1653,37 @@ test!(cyclic_deps_rejected {
 cyclic package dependency: package `foo v0.0.1 ([..])` depends on itself
 "));
 });
+
+test!(dashes_to_underscores {
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [package]
+            name = "foo-bar"
+            version = "0.0.1"
+            authors = []
+        "#)
+        .file("src/lib.rs", "")
+        .file("src/main.rs", "extern crate foo_bar; fn main() {}");
+
+    assert_that(p.cargo_process("build").arg("-v"),
+                execs().with_status(0));
+    assert_that(&p.bin("foo-bar"), existing_file());
+});
+
+test!(dashes_in_crate_name_bad {
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [package]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+
+            [lib]
+            name = "foo-bar"
+        "#)
+        .file("src/lib.rs", "")
+        .file("src/main.rs", "extern crate foo_bar; fn main() {}");
+
+    assert_that(p.cargo_process("build").arg("-v"),
+                execs().with_status(101));
+});

--- a/tests/test_cargo_compile_custom_build.rs
+++ b/tests/test_cargo_compile_custom_build.rs
@@ -33,7 +33,7 @@ test!(custom_build_script_failed {
                 execs().with_status(101)
                        .with_stdout(format!("\
 {compiling} foo v0.5.0 ({url})
-{running} `rustc build.rs --crate-name build-script-build --crate-type bin [..]`
+{running} `rustc build.rs --crate-name build_script_build --crate-type bin [..]`
 {running} `[..]build-script-build[..]`
 ",
 url = p.url(), compiling = COMPILING, running = RUNNING))
@@ -760,7 +760,7 @@ test!(build_cmd_with_a_build_cmd {
     --out-dir [..]target[..]deps --emit=dep-info,link \
     -L [..]target[..]deps -L [..]target[..]deps`
 {compiling} foo v0.5.0 (file://[..])
-{running} `rustc build.rs --crate-name build-script-build --crate-type bin \
+{running} `rustc build.rs --crate-name build_script_build --crate-type bin \
     -C prefer-dynamic -g \
     --out-dir [..]build[..]foo-[..] --emit=dep-info,link \
     -L [..]target[..]debug -L [..]target[..]deps \


### PR DESCRIPTION
This change allows *packages* to have hyphens in them, but they are always
translated to underscores when translated to a crate name. This means that all
crates are compiled with a `--crate-name` that has no hyphens (as well as
`--extern` directives having no hyphens).

Binaries and examples, however, are allowed to contain
hyphens in their name. The "crate name" will still have an underscore, but the
output will be in the same dasherized name.

Explicitly named targets are not allowed to have hyphens in them as well.