### PR TITLE
Remove ndebug, add config of debug assertions

### DIFF
--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -117,7 +117,7 @@ pub struct Profile {
     pub lto: bool,
     pub codegen_units: Option<u32>,    // None = use rustc default
     pub debuginfo: bool,
-    pub ndebug: bool,
+    pub debug_assertions: bool,
     pub rpath: bool,
     pub test: bool,
     pub doc: bool,
@@ -410,6 +410,7 @@ impl Profile {
     pub fn default_dev() -> Profile {
         Profile {
             debuginfo: true,
+            debug_assertions: true,
             ..Profile::default()
         }
     }
@@ -418,7 +419,6 @@ impl Profile {
         Profile {
             opt_level: 3,
             debuginfo: false,
-            ndebug: true,
             ..Profile::default()
         }
     }
@@ -452,7 +452,7 @@ impl Default for Profile {
             lto: false,
             codegen_units: None,
             debuginfo: false,
-            ndebug: false,
+            debug_assertions: false,
             rpath: false,
             test: false,
             doc: false,

--- a/src/cargo/ops/cargo_rustc/mod.rs
+++ b/src/cargo/ops/cargo_rustc/mod.rs
@@ -555,7 +555,7 @@ fn build_base_args(cx: &Context,
                    profile: &Profile,
                    crate_types: &[&str]) {
     let Profile {
-        opt_level, lto, codegen_units, debuginfo, ndebug, rpath, test,
+        opt_level, lto, codegen_units, debuginfo, debug_assertions, rpath, test,
         doc: _doc,
     } = *profile;
 
@@ -599,8 +599,10 @@ fn build_base_args(cx: &Context,
         cmd.arg("-g");
     }
 
-    if ndebug {
-        cmd.args(&["--cfg", "ndebug"]);
+    if debug_assertions && opt_level > 0 {
+        cmd.args(&["-C", "debug-assertions=on"]);
+    } else if !debug_assertions && opt_level == 0 {
+        cmd.args(&["-C", "debug-assertions=off"]);
     }
 
     if test && target.harness() {

--- a/src/cargo/util/toml.rs
+++ b/src/cargo/util/toml.rs
@@ -231,6 +231,7 @@ pub struct TomlProfile {
     lto: Option<bool>,
     codegen_units: Option<u32>,
     debug: Option<bool>,
+    debug_assertions: Option<bool>,
     rpath: Option<bool>,
 }
 
@@ -813,7 +814,7 @@ fn build_profiles(profiles: &Option<TomlProfiles>) -> Profiles {
 
     fn merge(profile: Profile, toml: Option<&TomlProfile>) -> Profile {
         let &TomlProfile {
-            opt_level, lto, codegen_units, debug, rpath
+            opt_level, lto, codegen_units, debug, debug_assertions, rpath
         } = match toml {
             Some(toml) => toml,
             None => return profile,
@@ -823,7 +824,7 @@ fn build_profiles(profiles: &Option<TomlProfiles>) -> Profiles {
             lto: lto.unwrap_or(profile.lto),
             codegen_units: codegen_units,
             debuginfo: debug.unwrap_or(profile.debuginfo),
-            ndebug: !debug.unwrap_or(!profile.ndebug),
+            debug_assertions: debug_assertions.unwrap_or(profile.debug_assertions),
             rpath: rpath.unwrap_or(profile.rpath),
             test: profile.test,
             doc: profile.doc,

--- a/src/doc/manifest.md
+++ b/src/doc/manifest.md
@@ -164,6 +164,7 @@ opt-level = 0  # Controls the --opt-level the compiler builds with
 debug = true   # Controls whether the compiler passes -g or `--cfg ndebug`
 rpath = false  # Controls whether the compiler passes `-C rpath`
 lto = false    # Controls `-C lto` for binaries and staticlibs
+debug-assertions = true  # Controls whether debug assertions are enabled
 
 # The release profile, used for `cargo build --release`
 [profile.release]
@@ -171,6 +172,7 @@ opt-level = 3
 debug = false
 rpath = false
 lto = false
+debug-assertions = false
 
 # The testing profile, used for `cargo test`
 [profile.test]
@@ -178,6 +180,7 @@ opt-level = 0
 debug = true
 rpath = false
 lto = false
+debug-assertions = true
 
 # The benchmarking profile, used for `cargo bench`
 [profile.bench]
@@ -185,6 +188,7 @@ opt-level = 3
 debug = false
 rpath = false
 lto = false
+debug-assertions = false
 
 # The documentation profile, used for `cargo doc`
 [profile.doc]
@@ -192,6 +196,7 @@ opt-level = 0
 debug = true
 rpath = false
 lto = false
+debug-assertions = true
 ```
 
 # The `[features]` Section

--- a/tests/test_cargo_bench.rs
+++ b/tests/test_cargo_bench.rs
@@ -428,10 +428,9 @@ test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured
                        compiling = COMPILING, running = RUNNING,
                        dir = p.url()).as_slice()));
 
-    assert_that(p.cargo_process("bench").arg("foo"),
+    assert_that(p.cargo("bench").arg("foo"),
                 execs().with_status(0)
-                       .with_stdout(format!("\
-{compiling} foo v0.0.1 ({dir})
+                       .with_stdout(&format!("\
 {running} target[..]release[..]foo-[..]
 
 running 1 test
@@ -439,9 +438,7 @@ test foo ... bench:         0 ns/iter (+/- 0)
 
 test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured
 
-",
-                       compiling = COMPILING, running = RUNNING,
-                       dir = p.url()).as_slice()));
+", running = RUNNING)));
 });
 
 // Regression test for running cargo-bench twice with

--- a/tests/test_cargo_compile.rs
+++ b/tests/test_cargo_compile.rs
@@ -815,7 +815,6 @@ test!(lto_build {
 {running} `rustc src[..]main.rs --crate-name test --crate-type bin \
         -C opt-level=3 \
         -C lto \
-        --cfg ndebug \
         --out-dir {dir}[..]target[..]release \
         --emit=dep-info,link \
         -L dependency={dir}[..]target[..]release \
@@ -871,7 +870,6 @@ test!(verbose_release_build {
 {compiling} test v0.0.0 ({url})
 {running} `rustc src[..]lib.rs --crate-name test --crate-type lib \
         -C opt-level=3 \
-        --cfg ndebug \
         -C metadata=[..] \
         -C extra-filename=-[..] \
         --out-dir {dir}[..]target[..]release \
@@ -917,7 +915,6 @@ test!(verbose_release_build_deps {
 {running} `rustc foo[..]src[..]lib.rs --crate-name foo \
         --crate-type dylib --crate-type rlib -C prefer-dynamic \
         -C opt-level=3 \
-        --cfg ndebug \
         -C metadata=[..] \
         -C extra-filename=-[..] \
         --out-dir {dir}[..]target[..]release[..]deps \
@@ -927,7 +924,6 @@ test!(verbose_release_build_deps {
 {compiling} test v0.0.0 ({url})
 {running} `rustc src[..]lib.rs --crate-name test --crate-type lib \
         -C opt-level=3 \
-        --cfg ndebug \
         -C metadata=[..] \
         -C extra-filename=-[..] \
         --out-dir {dir}[..]target[..]release \
@@ -1025,10 +1021,10 @@ test!(standard_build_no_ndebug {
         .file("Cargo.toml", &basic_bin_manifest("foo"))
         .file("src/foo.rs", r#"
             fn main() {
-                if cfg!(ndebug) {
-                    println!("fast")
-                } else {
+                if cfg!(debug_assertions) {
                     println!("slow")
+                } else {
+                    println!("fast")
                 }
             }
         "#);
@@ -1043,10 +1039,10 @@ test!(release_build_ndebug {
         .file("Cargo.toml", &basic_bin_manifest("foo"))
         .file("src/foo.rs", r#"
             fn main() {
-                if cfg!(ndebug) {
-                    println!("fast")
-                } else {
+                if cfg!(debug_assertions) {
                     println!("slow")
+                } else {
+                    println!("fast")
                 }
             }
         "#);

--- a/tests/test_cargo_profiles.rs
+++ b/tests/test_cargo_profiles.rs
@@ -29,7 +29,7 @@ test!(profile_overrides {
 {compiling} test v0.0.0 ({url})
 {running} `rustc src{sep}lib.rs --crate-name test --crate-type lib \
         -C opt-level=1 \
-        --cfg ndebug \
+        -C debug-assertions=on \
         -C metadata=[..] \
         -C extra-filename=-[..] \
         -C rpath \

--- a/tests/test_cargo_run.rs
+++ b/tests/test_cargo_run.rs
@@ -241,10 +241,10 @@ test!(example_with_release_flag {
             extern crate bar;
 
             fn main() {
-                if cfg!(ndebug) {
-                    println!("fast1")
-                } else {
+                if cfg!(debug_assertions) {
                     println!("slow1")
+                } else {
+                    println!("fast1")
                 }
                 bar::baz();
             }
@@ -260,10 +260,10 @@ test!(example_with_release_flag {
         "#)
         .file("bar/src/bar.rs", r#"
             pub fn baz() {
-                if cfg!(ndebug) {
-                    println!("fast2")
-                } else {
+                if cfg!(debug_assertions) {
                     println!("slow2")
+                } else {
+                    println!("fast2")
                 }
             }
         "#);
@@ -273,7 +273,6 @@ test!(example_with_release_flag {
 {compiling} bar v0.0.1 ({url})
 {running} `rustc bar{sep}src{sep}bar.rs --crate-name bar --crate-type lib \
         -C opt-level=3 \
-        --cfg ndebug \
         -C metadata=[..] \
         -C extra-filename=[..] \
         --out-dir {dir}{sep}target{sep}release{sep}deps \
@@ -283,7 +282,6 @@ test!(example_with_release_flag {
 {compiling} foo v0.0.1 ({url})
 {running} `rustc examples{sep}a.rs --crate-name a --crate-type bin \
         -C opt-level=3 \
-        --cfg ndebug \
         --out-dir {dir}{sep}target{sep}release{sep}examples \
         --emit=dep-info,link \
         -L dependency={dir}{sep}target{sep}release \
@@ -369,7 +367,7 @@ test!(release_works {
             authors = []
         "#)
         .file("src/main.rs", r#"
-            fn main() { if !cfg!(ndebug) { panic!() } }
+            fn main() { if cfg!(debug_assertions) { panic!() } }
         "#);
 
     assert_that(p.cargo_process("run").arg("--release"),

--- a/tests/test_cargo_test.rs
+++ b/tests/test_cargo_test.rs
@@ -1255,7 +1255,7 @@ test!(example_bin_same_name {
     assert_that(p.process(&p.bin("examples/foo")),
                 execs().with_status(0).with_stdout("example\n"));
 
-    assert_that(p.cargo_process("run"),
+    assert_that(p.cargo("run"),
                 execs().with_status(0)
                        .with_stdout(format!("\
 {compiling} foo v0.0.1 ([..])


### PR DESCRIPTION
This commit removes the ndebug support from Cargo and also adds a new
configuration option for profiles, `debug-assertions`, which controls whether
debug assertions in the compiler are turned on or not.

Closes #1398