### PR TITLE
Fix passing --extern and -L to doc tests

### DIFF
--- a/src/cargo/ops/cargo_rustc/compilation.rs
+++ b/src/cargo/ops/cargo_rustc/compilation.rs
@@ -14,7 +14,7 @@ pub struct Compilation {
     ///
     /// This is currently used for passing --extern flags to rustdoc tests later
     /// on.
-    pub libraries: HashMap<PackageId, Vec<PathBuf>>,
+    pub libraries: HashMap<PackageId, Vec<(String, PathBuf)>>,
 
     /// An array of all tests created during this compilation.
     pub tests: Vec<(String, PathBuf)>,

--- a/src/cargo/ops/cargo_rustc/fingerprint.rs
+++ b/src/cargo/ops/cargo_rustc/fingerprint.rs
@@ -58,18 +58,7 @@ pub fn prepare_target<'a, 'b>(cx: &mut Context<'a, 'b>,
     let mut missing_outputs = false;
     if !profile.doc {
         for filename in try!(cx.target_filenames(target, profile)).iter() {
-            let dst = root.join(filename);
-            missing_outputs |= fs::metadata(&dst).is_err();
-
-            if profile.test {
-                cx.compilation.tests.push((target.name().to_string(), dst));
-            } else if target.is_bin() || target.is_example() {
-                cx.compilation.binaries.push(dst);
-            } else if target.is_lib() {
-                let pkgid = pkg.package_id().clone();
-                cx.compilation.libraries.entry(pkgid).or_insert(Vec::new())
-                  .push(dst);
-            }
+            missing_outputs |= fs::metadata(root.join(filename)).is_err();
         }
     }
 

--- a/src/cargo/ops/cargo_test.rs
+++ b/src/cargo/ops/cargo_test.rs
@@ -31,8 +31,11 @@ pub fn run_tests(manifest_path: &Path,
         let mut p = try!(compile.rustdoc_process(&compile.package));
         p.arg("--test").arg(lib)
          .arg("--crate-name").arg(&crate_name)
-         .arg("-L").arg(&compile.root_output)
-         .arg("-L").arg(&compile.deps_output)
+         .arg("-L").arg(&{
+             let mut arg = OsString::from("dependency=");
+             arg.push(&compile.deps_output);
+             arg
+         })
          .cwd(compile.package.root());
 
         if test_args.len() > 0 {
@@ -43,9 +46,9 @@ pub fn run_tests(manifest_path: &Path,
             p.arg("--cfg").arg(&format!("feature=\"{}\"", feat));
         }
 
-        for (pkg, libs) in compile.libraries.iter() {
-            for lib in libs.iter() {
-                let mut arg = OsString::from(pkg.name());
+        for (_, libs) in compile.libraries.iter() {
+            for &(ref name, ref lib) in libs.iter() {
+                let mut arg = OsString::from(name);
                 arg.push("=");
                 arg.push(lib);
                 p.arg("--extern").arg(&arg);

--- a/tests/test_cargo_test.rs
+++ b/tests/test_cargo_test.rs
@@ -1416,6 +1416,6 @@ test!(dashes_to_underscores {
             pub fn foo() -> i32 { 1 }
         "#);
 
-    assert_that(p.cargo_process("test"),
+    assert_that(p.cargo_process("test").arg("-v"),
                 execs().with_status(0));
 });


### PR DESCRIPTION
Previously --extern was passed for *all* upstream dependencies, causing
conflicts if some had duplicate names. Now cargo only passes --extern for
libraries that were built including immediate dependencies. Cargo also
additionally now properly passes `-L dependency=` instead of just a plain `-L`.

Closes #1449