### PR TITLE
Be sure to include dev-deps for doctests with --extern

### DIFF
--- a/src/cargo/ops/cargo_rustc/mod.rs
+++ b/src/cargo/ops/cargo_rustc/mod.rs
@@ -143,23 +143,23 @@ pub fn compile_targets<'a, 'b>(targets: &[(&'a Target, &'a Profile)],
                 let pkgid = pkg.package_id().clone();
                 cx.compilation.libraries.entry(pkgid).or_insert(Vec::new())
                   .push((target.crate_name(), dst));
+            }
+            if !target.is_lib() { continue }
+
+            // Include immediate lib deps as well
+            for dep in cx.dep_targets(pkg, target, profile).iter() {
+                let (pkg, target, profile) = *dep;
+                let pkgid = pkg.package_id();
                 if !target.is_lib() { continue }
+                if profile.doc { continue }
+                if cx.compilation.libraries.contains_key(&pkgid) { continue }
 
-                // Include immediate lib deps as well
-                for dep in cx.dep_targets(pkg, target, profile).iter() {
-                    let (pkg, target, profile) = *dep;
-                    let pkgid = pkg.package_id();
-                    if !target.is_lib() { continue }
-                    if profile.doc { continue }
-                    if cx.compilation.libraries.contains_key(&pkgid) { continue }
-
-                    let v = try!(cx.target_filenames(target, profile));
-                    let v = v.into_iter().map(|f| {
-                        (target.crate_name(),
-                         cx.out_dir(pkg, Kind::Target, target).join(f))
-                    }).collect::<Vec<_>>();
-                    cx.compilation.libraries.insert(pkgid.clone(), v);
-                }
+                let v = try!(cx.target_filenames(target, profile));
+                let v = v.into_iter().map(|f| {
+                    (target.crate_name(),
+                     cx.out_dir(pkg, Kind::Target, target).join(f))
+                }).collect::<Vec<_>>();
+                cx.compilation.libraries.insert(pkgid.clone(), v);
             }
         }
     }

--- a/tests/test_cargo_test.rs
+++ b/tests/test_cargo_test.rs
@@ -1419,3 +1419,32 @@ test!(dashes_to_underscores {
     assert_that(p.cargo_process("test").arg("-v"),
                 execs().with_status(0));
 });
+
+test!(doctest_dev_dep {
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [package]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+
+            [dev-dependencies]
+            b = { path = "b" }
+        "#)
+        .file("src/lib.rs", r#"
+            /// ```
+            /// extern crate b;
+            /// ```
+            pub fn foo() {}
+        "#)
+        .file("b/Cargo.toml", r#"
+            [package]
+            name = "b"
+            version = "0.0.1"
+            authors = []
+        "#)
+        .file("b/src/lib.rs", "");
+
+    assert_that(p.cargo_process("test").arg("-v"),
+                execs().with_status(0));
+});


### PR DESCRIPTION
Previously the "add immediate deps" logic bailed out too soon and didn't pick up
all dev-dependencies.

Closes #1474