### PR TITLE
Document the CARGO_HOME env var

### DIFF
--- a/src/doc/config.md
+++ b/src/doc/config.md
@@ -78,3 +78,10 @@ timeout = 60000   # Timeout for each HTTP request, in milliseconds
 [build]
 jobs = 1        # number of jobs to run by default (default to # cpus)
 ```
+
+# Configuration of registry cache
+
+Cargo maintains a local cache of the registry index and of git
+checkouts of crates.  By default these are stored under
+`$HOME/.cargo`. The location can be overridden by setting the
+`CARGO_HOME` environment variable.


### PR DESCRIPTION
Adds CARGO_HOME to the config documentation.