### PR TITLE
Fix `cargo search -h`

### DIFF
--- a/src/bin/search.rs
+++ b/src/bin/search.rs
@@ -13,6 +13,7 @@ Search packages in crates.io
 
 Usage:
     cargo search [options] <query>
+    cargo search [-h | --help]
 
 Options:
     -h, --help              Print this message

--- a/tests/test_cargo_search.rs
+++ b/tests/test_cargo_search.rs
@@ -85,3 +85,10 @@ test!(simple {
 {updating} registry `[..]`
 hoare (0.1.1)    Design by contract style assertions for Rust", updating = UPDATING)));
 });
+
+test!(help {
+    assert_that(cargo_process("search").arg("-h"),
+                execs().with_status(0));
+    assert_that(cargo_process("help").arg("search"),
+                execs().with_status(0));
+});


### PR DESCRIPTION
That usage didn't match any docopt patterns so one just needed to be added.

Closes #1497