### PR TITLE
Only doctest rlibs

### DIFF
--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -329,9 +329,17 @@ impl Target {
     pub fn tested(&self) -> bool { self.tested }
     pub fn harness(&self) -> bool { self.harness }
     pub fn documented(&self) -> bool { self.doc }
-    pub fn doctested(&self) -> bool { self.doctest }
     pub fn for_host(&self) -> bool { self.for_host }
     pub fn benched(&self) -> bool { self.benched }
+
+    pub fn doctested(&self) -> bool {
+        self.doctest && match self.kind {
+            TargetKind::Lib(ref kinds) => {
+                kinds.contains(&LibKind::Rlib) || kinds.contains(&LibKind::Lib)
+            }
+            _ => false,
+        }
+    }
 
     pub fn allows_underscores(&self) -> bool {
         self.is_bin() || self.is_example() || self.is_custom_build()


### PR DESCRIPTION
This commit fixes two problems in Cargo:

1. Only libraries targets that produce an rlib can be doc tested
2. Only the rlib output can be doc tested

The rationale for this is listed in listed in the comments of the commit.

Closes #1496