### PR TITLE
Allow build script feedback to the crate compiled

### DIFF
--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -379,6 +379,7 @@ fn scrape_target_config(config: &Config, triple: &str)
         let mut output = BuildOutput {
             library_paths: Vec::new(),
             library_links: Vec::new(),
+            cfgs: Vec::new(),
             metadata: Vec::new(),
         };
         let key = format!("{}.{}", key, lib_name);
@@ -406,6 +407,8 @@ fn scrape_target_config(config: &Config, triple: &str)
                         output.library_paths.extend(a.into_iter().map(|v| {
                             PathBuf::from(&v.0)
                         }));
+                    } else if k == "rustc-cfg" {
+                        output.cfgs.extend(a.into_iter().map(|v| v.0));
                     } else {
                         try!(config.expected("string", &k,
                                              ConfigValue::List(a, p)));

--- a/src/cargo/ops/cargo_rustc/mod.rs
+++ b/src/cargo/ops/cargo_rustc/mod.rs
@@ -436,9 +436,14 @@ fn rustc(package: &Package, target: &Target, profile: &Profile,
             for path in output.library_paths.iter() {
                 rustc.arg("-L").arg(path);
             }
-            if pass_l_flag && id == *current_id {
-                for name in output.library_links.iter() {
-                    rustc.arg("-l").arg(name);
+            if id == *current_id {
+                for cfg in &output.cfgs {
+                    rustc.arg("--cfg").arg(cfg);
+                }
+                if pass_l_flag {
+                    for name in output.library_links.iter() {
+                        rustc.arg("-l").arg(name);
+                    }
                 }
             }
         }

--- a/src/doc/build-script.md
+++ b/src/doc/build-script.md
@@ -79,18 +79,22 @@ Example output:
 ```notrust
 cargo:rustc-link-lib=static=foo
 cargo:rustc-link-search=native=/path/to/foo
+cargo:rustc-cfg=foo
 cargo:root=/path/to/foo
 cargo:libdir=/path/to/foo/lib
 cargo:include=/path/to/foo/include
 ```
 
-The `rustc-link-lib` key indicates that Cargo should pass a `-l` option to
-rustc. Similarly, `rustc-link-search` indicates that Cargo should pass a `-L`
-option.
+There are a few special keys that Cargo recognizes, affecting how the crate this
+build script is for is built:
 
-The `rustc-flags` key is special and indicates the flags that Cargo will
-pass to Rustc. Currently only `-l` and `-L` are accepted. Using
-`rustc-link-lib` and `rustc-link-search` is more robust.
+* `rustc-link-lib` indicates that the specified value should be passed to the
+  compiler as a `-l` flag.
+* `rustc-link-search` indicates the specified value should be passed to the
+  compiler as a `-L` flag.
+* `rustc-cfg` indicates that the specified directive will be passed as a `--cfg`
+  flag to the compiler. This is often useful for performing compile-time
+  detection of various features.
 
 Any other element is a user-defined metadata that will be passed to
 dependencies. More information about this can be found in the [`links`][links]


### PR DESCRIPTION
This commit enables the build script for a crate to provide feedback to the
crate itself about how it should be built. This is done through the `--cfg`
flags of the compiler, and each build script is now allowed to print `rustc-cfg`
directives to inform Cargo about what `--cfg` flags it should pass.

All `--cfg` flags are local to the current crate and are not propagated outwards
to transitive dependencies. The primary use-case that this feature is targeting
is compile-time feature detection for applications like C bindings or C
libraries where the version being targeted may change over time.

Closes #1478