### PR TITLE
Change the initial version of new packages to 0.1.0, per SemVer

### DIFF
--- a/src/cargo/ops/cargo_new.rs
+++ b/src/cargo/ops/cargo_new.rs
@@ -114,7 +114,7 @@ fn mk(config: &Config, path: &Path, name: &str,
     try!(file(&path.join("Cargo.toml"), format!(
 r#"[package]
 name = "{}"
-version = "0.0.1"
+version = "0.1.0"
 authors = ["{}"]
 "#, name, author).as_bytes()));
 

--- a/src/doc/build-script.md
+++ b/src/doc/build-script.md
@@ -205,7 +205,7 @@ Here we can see that we have a `build.rs` build script and our binary in
 
 [package]
 name = "hello-from-generated-code"
-version = "0.0.1"
+version = "0.1.0"
 authors = ["you@example.com"]
 build = "build.rs"
 ```
@@ -293,7 +293,7 @@ Pretty similar to before! Next, the manifest:
 
 [package]
 name = "hello-world-from-c"
-version = "0.0.1"
+version = "0.1.0"
 authors = [ "you@example.com" ]
 build = "build.rs"
 ```
@@ -433,7 +433,7 @@ relevant Cargo package.
 ```toml
 [package]
 name = "libgit2-sys"
-version = "0.0.1"
+version = "0.1.0"
 authors = ["..."]
 links = "git2"
 build = "build.rs"

--- a/src/doc/guide.md
+++ b/src/doc/guide.md
@@ -55,7 +55,7 @@ we need to get started. First, let's check out `Cargo.toml`:
 ```toml
 [package]
 name = "hello_world"
-version = "0.0.1"
+version = "0.1.0"
 authors = ["Your Name <you@example.com>"]
 ```
 
@@ -74,7 +74,7 @@ Cargo generated a 'hello world' for us. Let's compile it:
 
 <pre><code class="language-shell"><span class="gp">$</span> cargo build
 <span style="font-weight: bold"
-class="s1">   Compiling</span> hello_world v0.0.1 (file:///path/to/project/hello_world)</code></pre>
+class="s1">   Compiling</span> hello_world v0.1.0 (file:///path/to/project/hello_world)</code></pre>
 
 And then run it:
 
@@ -87,7 +87,7 @@ We can also use `cargo run` to compile and then run it, all in one step:
 
 <pre><code class="language-shell"><span class="gp">$</span> cargo run
 <span style="font-weight: bold"
-class="s1">     Fresh</span> hello_world v0.0.1 (file:///path/to/project/hello_world)
+class="s1">     Fresh</span> hello_world v0.1.0 (file:///path/to/project/hello_world)
 <span style="font-weight: bold"
 class="s1">   Running</span> `target/debug/hello_world`
 Hello, world!</code></pre>
@@ -99,7 +99,7 @@ Once you're ready for release, you can use `cargo build --release` to compile yo
 
 <pre><code class="language-shell"><span class="gp">$</span> cargo build --release
 <span style="font-weight: bold"
-class="s1">   Compiling</span> hello_world v0.0.1 (file:///path/to/project/hello_world)</code></pre>
+class="s1">   Compiling</span> hello_world v0.1.0 (file:///path/to/project/hello_world)</code></pre>
 
 ## Adding a dependency
 
@@ -127,7 +127,7 @@ $ cd color-rs
 To build, just use `cargo build`:
 
 <pre><code class="language-shell"><span class="gp">$</span> cargo build
-<span style="font-weight: bold" class="s1">   Compiling</span> color v0.0.1 (file:///path/to/project/color-rs)</code></pre>
+<span style="font-weight: bold" class="s1">   Compiling</span> color v0.1.0 (file:///path/to/project/color-rs)</code></pre>
 
 This will fetch all of the dependencies and then build them, along with the
 project.
@@ -139,7 +139,7 @@ To depend on a library, add it to your `Cargo.toml`.
 ```toml
 [package]
 name = "hello_world"
-version = "0.0.1"
+version = "0.1.0"
 authors = ["Your Name <you@example.com>"]
 
 [dependencies.color]
@@ -172,8 +172,8 @@ Let's tell Cargo to fetch this new dependency and update the `Cargo.lock`:
 Compile it:
 
 <pre><code class="language-shell"><span class="gp">$</span> cargo run
-<span style="font-weight: bold" class="s1">   Compiling</span> color v0.0.1 (https://github.com/bjz/color-rs.git#bf739419)
-<span style="font-weight: bold" class="s1">   Compiling</span> hello_world v0.0.1 (file:///path/to/project/hello_world)
+<span style="font-weight: bold" class="s1">   Compiling</span> color v0.1.0 (https://github.com/bjz/color-rs.git#bf739419)
+<span style="font-weight: bold" class="s1">   Compiling</span> hello_world v0.1.0 (file:///path/to/project/hello_world)
 <span style="font-weight: bold" class="s1">     Running</span> `target/hello_world`
 Converting RGB to HSV!
 HSV: HSV { h: 0, s: 1, v: 1 }</code></pre>
@@ -184,14 +184,14 @@ contains the exact information about which revision we used:
 ```toml
 [root]
 name = "hello_world"
-version = "0.0.1"
+version = "0.1.0"
 dependencies = [
- "color 0.0.1 (git+https://github.com/bjz/color-rs.git#bf739419e2d31050615c1ba1a395b474269a4b98)",
+ "color 0.1.0 (git+https://github.com/bjz/color-rs.git#bf739419e2d31050615c1ba1a395b474269a4b98)",
 ]
 
 [[package]]
 name = "color"
-version = "0.0.1"
+version = "0.1.0"
 source = "git+https://github.com/bjz/color-rs.git#bf739419e2d31050615c1ba1a395b474269a4b98"
 
 ```
@@ -230,7 +230,7 @@ on another project:
 ```toml
 [package]
 name = "hello_world"
-version = "0.0.1"
+version = "0.1.0"
 authors = ["Your Name <you@example.com>"]
 
 [dependencies.color]
@@ -267,7 +267,7 @@ manifest like this:
 ```toml
 [package]
 name = "hello_world"
-version = "0.0.1"
+version = "0.1.0"
 authors = ["Your Name <you@example.com>"]
 
 [dependencies.color]
@@ -280,14 +280,14 @@ Cargo will take the latest commit, and write that information out into our
 ```toml
 [root]
 name = "hello_world"
-version = "0.0.1"
+version = "0.1.0"
 dependencies = [
- "color 0.0.1 (git+https://github.com/bjz/color-rs.git#bf739419e2d31050615c1ba1a395b474269a4b98)",
+ "color 0.1.0 (git+https://github.com/bjz/color-rs.git#bf739419e2d31050615c1ba1a395b474269a4b98)",
 ]
 
 [[package]]
 name = "color"
-version = "0.0.1"
+version = "0.1.0"
 source = "git+https://github.com/bjz/color-rs.git#bf739419e2d31050615c1ba1a395b474269a4b98"
 
 ```
@@ -320,7 +320,7 @@ patch. Here's what `conduit-static`'s `Cargo.toml` looks like:
 ```toml
 [package]
 name = "conduit-static"
-version = "0.0.1"
+version = "0.1.0"
 authors = ["Yehuda Katz <wycats@example.com>"]
 
 [dependencies.conduit]
@@ -385,9 +385,9 @@ To run your tests, just run `cargo test`:
 
 <pre><code class="language-shell"><span class="gp">$</span> cargo test
 <span style="font-weight: bold"
-class="s1">   Compiling</span> color v0.0.1 (https://github.com/bjz/color-rs.git#bf739419)
+class="s1">   Compiling</span> color v0.1.0 (https://github.com/bjz/color-rs.git#bf739419)
 <span style="font-weight: bold"
-class="s1">   Compiling</span> hello_world v0.0.1 (file:///path/to/project/hello_world)
+class="s1">   Compiling</span> hello_world v0.1.0 (file:///path/to/project/hello_world)
 <span style="font-weight: bold"
 class="s1">     Running</span> target/test/hello_world-9c2b65bbb79eabce
 

--- a/src/doc/index.md
+++ b/src/doc/index.md
@@ -46,7 +46,7 @@ This is all we need to get started. First, let's check out `Cargo.toml`:
 ```toml
 [package]
 name = "hello_world"
-version = "0.0.1"
+version = "0.1.0"
 authors = ["Your Name <you@example.com>"]
 ```
 
@@ -65,7 +65,7 @@ Cargo generated a 'hello world' for us. Let's compile it:
 
 <pre><code class="language-shell">$ cargo build
 <span style="font-weight: bold"
-class="s1">   Compiling</span> hello_world v0.0.1 (file:///path/to/project/hello_world)</code></pre>
+class="s1">   Compiling</span> hello_world v0.1.0 (file:///path/to/project/hello_world)</code></pre>
 
 And then run it:
 
@@ -78,7 +78,7 @@ We can also use `cargo run` to compile and then run it, all in one step:
 
 <pre><code class="language-shell">$ cargo run
 <span style="font-weight: bold"
-class="s1">     Fresh</span> hello_world v0.0.1 (file:///path/to/project/hello_world)
+class="s1">     Fresh</span> hello_world v0.1.0 (file:///path/to/project/hello_world)
 <span style="font-weight: bold"
 class="s1">   Running</span> `target/hello_world`
 Hello, world!</code></pre>

--- a/src/doc/manifest.md
+++ b/src/doc/manifest.md
@@ -7,7 +7,7 @@ The first section in a `Cargo.toml` is `[package]`.
 ```toml
 [package]
 name = "hello_world" # the name of the package
-version = "0.0.1"    # the current version, obeying semver
+version = "0.1.0"    # the current version, obeying semver
 authors = [ "you@example.com" ]
 ```
 


### PR DESCRIPTION
This patch updates the initial version of packages generated with `cargo new` to 0.1.0 (rather than 0.0.1), which better follows SemVer. The docs are also updated to show examples that follow this convention.

For reference, the same change was recently made in Bundler for the Ruby ecosystem: bundler/bundler#3322