### PR TITLE
docs: fix shared library compilation error

### DIFF
--- a/src/doc/build-script.md
+++ b/src/doc/build-script.md
@@ -312,7 +312,7 @@ fn main() {
 
     // note that there are a number of downsides to this approach, the comments
     // below detail how to improve the portability of these commands.
-    Command::new("gcc").args(&["src/hello.c", "-c", "-o"])
+    Command::new("gcc").args(&["src/hello.c", "-c", "-fPIC", "-o"])
                        .arg(&format!("{}/hello.o", out_dir))
                        .status().unwrap();
     Command::new("ar").args(&["crus", "libhello.a", "hello.o"])


### PR DESCRIPTION
Currently getting:

note: /usr/bin/ld: /home/alfie/tmp/test/target/debug/build/test-39af07f97c17512a/out/libhello.a(hello.o):
relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC