### PR TITLE
Be sure to pass plugins to doctest --extern

### DIFF
--- a/src/cargo/ops/cargo_rustc/compilation.rs
+++ b/src/cargo/ops/cargo_rustc/compilation.rs
@@ -3,7 +3,7 @@ use std::ffi::OsStr;
 use std::path::PathBuf;
 use semver::Version;
 
-use core::{PackageId, Package};
+use core::{PackageId, Package, Target};
 use util::{self, CargoResult};
 
 use super::{CommandType, CommandPrototype};
@@ -14,7 +14,7 @@ pub struct Compilation {
     ///
     /// This is currently used for passing --extern flags to rustdoc tests later
     /// on.
-    pub libraries: HashMap<PackageId, Vec<(String, PathBuf)>>,
+    pub libraries: HashMap<PackageId, Vec<(Target, PathBuf)>>,
 
     /// An array of all tests created during this compilation.
     pub tests: Vec<(String, PathBuf)>,

--- a/src/cargo/ops/cargo_rustc/mod.rs
+++ b/src/cargo/ops/cargo_rustc/mod.rs
@@ -142,7 +142,7 @@ pub fn compile_targets<'a, 'b>(targets: &[(&'a Target, &'a Profile)],
             } else if target.is_lib() {
                 let pkgid = pkg.package_id().clone();
                 cx.compilation.libraries.entry(pkgid).or_insert(Vec::new())
-                  .push((target.crate_name(), dst));
+                  .push((target.clone(), dst));
             }
             if !target.is_lib() { continue }
 
@@ -156,7 +156,7 @@ pub fn compile_targets<'a, 'b>(targets: &[(&'a Target, &'a Profile)],
 
                 let v = try!(cx.target_filenames(target, profile));
                 let v = v.into_iter().map(|f| {
-                    (target.crate_name(),
+                    (target.clone(),
                      cx.out_dir(pkg, Kind::Target, target).join(f))
                 }).collect::<Vec<_>>();
                 cx.compilation.libraries.insert(pkgid.clone(), v);

--- a/src/cargo/ops/cargo_test.rs
+++ b/src/cargo/ops/cargo_test.rs
@@ -54,7 +54,7 @@ pub fn run_tests(manifest_path: &Path,
         }
 
         for (_, libs) in compile.libraries.iter() {
-            for &(ref name, ref lib) in libs.iter() {
+            for &(ref target, ref lib) in libs.iter() {
                 // Note that we can *only* doctest rlib outputs here.  A
                 // staticlib output cannot be linked by the compiler (it just
                 // doesn't do that). A dylib output, however, can be linked by
@@ -65,10 +65,11 @@ pub fn run_tests(manifest_path: &Path,
                 // dynamically as well, causing problems. As a result we only
                 // pass `--extern` for rlib deps and skip out on all other
                 // artifacts.
-                if lib.extension() != Some(OsStr::new("rlib")) {
+                if lib.extension() != Some(OsStr::new("rlib")) &&
+                   !target.for_host() {
                     continue
                 }
-                let mut arg = OsString::from(name);
+                let mut arg = OsString::from(target.crate_name());
                 arg.push("=");
                 arg.push(lib);
                 p.arg("--extern").arg(&arg);

--- a/tests/test_cargo_compile_plugins.rs
+++ b/tests/test_cargo_compile_plugins.rs
@@ -188,3 +188,34 @@ test!(plugin_integration {
     assert_that(p.cargo_process("test"),
                 execs().with_status(0));
 });
+
+test!(doctest_a_plugin {
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [package]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+
+            [dependencies]
+            bar = { path = "bar" }
+        "#)
+        .file("src/lib.rs", r#"
+            #[macro_use]
+            extern crate bar;
+        "#)
+        .file("bar/Cargo.toml", r#"
+            [package]
+            name = "bar"
+            version = "0.0.1"
+            authors = []
+
+            [lib]
+            name = "bar"
+            plugin = true
+        "#)
+        .file("bar/src/lib.rs", "");
+
+    assert_that(p.cargo_process("test").arg("-v"),
+                execs().with_status(0));
+});


### PR DESCRIPTION
They weren't rlibs so they were left out, but targets which have `plugin = true`
should be passed in to `--extern` regardless.

Closes #1512