### PR TITLE
Add native dependencies to doctest

### DIFF
--- a/src/cargo/ops/cargo_test.rs
+++ b/src/cargo/ops/cargo_test.rs
@@ -45,6 +45,10 @@ pub fn run_tests(manifest_path: &Path,
          })
          .cwd(compile.package.root());
 
+        for native_dep in compile.native_dirs.values() {
+            p.arg("-L").arg(native_dep);
+        }
+
         if test_args.len() > 0 {
             p.arg("--test-args").arg(&test_args.connect(" "));
         }


### PR DESCRIPTION
This will traverse all native dependencies and add them to the rustdoc command when running tests.

Fixes #1245