### PR TITLE
`cargo doc --open` should work for binary-only packages too

### DIFF
--- a/src/cargo/ops/cargo_doc.rs
+++ b/src/cargo/ops/cargo_doc.rs
@@ -47,7 +47,7 @@ pub fn doc(manifest_path: &Path,
         let name = match options.compile_opts.spec {
             Some(spec) => try!(PackageIdSpec::parse(spec)).name().to_string(),
             None => {
-                match lib_names.iter().nth(0) {
+                match lib_names.iter().chain(bin_names.iter()).nth(0) {
                     Some(s) => s.to_string(),
                     None => return Ok(())
                 }


### PR DESCRIPTION
Since #318, the `doc` command generates documentation for binaries in addition to libraries. But currently running `cargo doc --open` would not launch the browser for binary-only packages, even though it should. This commit changes the logic: binaries will be searched when there are no libraries in the package.

A simple test case:

`Cargo.toml`:

    [package]
    name = "foo"
    version = "0.1.0"
    authors = []

`src/main.rs`:

    pub fn main() {
        println!("Hello, world!");
    }

EDIT: I should add that this should fix #1472