### PR TITLE
Make `cargo doc --open` work correctly in Windows

### DIFF
--- a/src/cargo/ops/cargo_doc.rs
+++ b/src/cargo/ops/cargo_doc.rs
@@ -87,7 +87,7 @@ fn open_docs(path: &Path) {
 
 #[cfg(target_os = "windows")]
 fn open_docs(path: &Path) {
-    match Command::new("start").arg(path).status() {
+    match Command::new("cmd").arg("/C").arg("start").arg("").arg(path).status() {
         Ok(_) => return,
         Err(_) => ()
     };


### PR DESCRIPTION
`start` is not an actual executable, but rather a built-in command in Command Prompt. The correct way of launching a file using the default application is thus: `cmd /C start "" <file>`.

Fixes #741.