### PR TITLE
update threadpool dependency from v0.1.1 to v0.1.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,7 +22,7 @@ dependencies = [
  "tar 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "term 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "threadpool 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "threadpool 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.2.29 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -288,7 +288,7 @@ dependencies = [
 
 [[package]]
 name = "threadpool"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ url = "0.2.23"
 rustc-serialize = "0.3.1"
 term = "0.2"
 regex = "0.1.18"
-threadpool = "0.1.1"
+threadpool = "0.1.4"
 libc = "0.1.2"
 registry = { path = "src/registry" }
 num_cpus = "0.1"


### PR DESCRIPTION
fixes #1536 .  Tested with rustc 1.0.0-nightly (a52182ffd 2015-04-17) (built 2015-04-17).