### PR TITLE
Strip `rust-` and `-rs` affixes in `cargo new`

### DIFF
--- a/src/bin/new.rs
+++ b/src/bin/new.rs
@@ -8,6 +8,7 @@ struct Options {
     flag_verbose: bool,
     flag_bin: bool,
     arg_path: String,
+    flag_name: Option<String>,
     flag_vcs: Option<ops::VersionControl>,
 }
 
@@ -24,6 +25,7 @@ Options:
                         control system (git or hg) or do not initialize any version
                         control at all (none) overriding a global configuration.
     --bin               Use a binary instead of a library template
+    --name <name>       Set the resulting package name
     -v, --verbose       Use verbose output
 ";
 
@@ -31,12 +33,13 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
     debug!("executing; cmd=cargo-new; args={:?}", env::args().collect::<Vec<_>>());
     config.shell().set_verbose(options.flag_verbose);
 
-    let Options { flag_bin, arg_path, flag_vcs, .. } = options;
+    let Options { flag_bin, arg_path, flag_name, flag_vcs, .. } = options;
 
     let opts = ops::NewOptions {
         version_control: flag_vcs,
-        path: &arg_path,
         bin: flag_bin,
+        path: &arg_path,
+        name: flag_name.as_ref().map(|s| s.as_ref()),
     };
 
     ops::new(opts, config).map(|_| None).map_err(|err| {

--- a/src/cargo/ops/cargo_new.rs
+++ b/src/cargo/ops/cargo_new.rs
@@ -8,6 +8,8 @@ use rustc_serialize::{Decodable, Decoder};
 
 use git2::Config as GitConfig;
 
+use term::color::BLACK;
+
 use util::{GitRepo, HgRepo, CargoResult, human, ChainError, internal};
 use util::Config;
 
@@ -57,7 +59,14 @@ pub fn new(opts: NewOptions, config: &Config) -> CargoResult<()> {
             if opts.bin {
                 dir_name
             } else {
-                strip_rust_affixes(dir_name)
+                let new_name = strip_rust_affixes(dir_name);
+                if new_name != dir_name {
+                    let message = format!(
+                        "Note: package will be named `{}`; use --name to override",
+                        new_name);
+                    try!(config.shell().say(&message, BLACK));
+                }
+                new_name
             }
         }
     };

--- a/src/cargo/ops/cargo_new.rs
+++ b/src/cargo/ops/cargo_new.rs
@@ -62,7 +62,7 @@ pub fn new(opts: NewOptions, config: &Config) -> CargoResult<()> {
                 let new_name = strip_rust_affixes(dir_name);
                 if new_name != dir_name {
                     let message = format!(
-                        "Note: package will be named `{}`; use --name to override",
+                        "note: package will be named `{}`; use --name to override",
                         new_name);
                     try!(config.shell().say(&message, BLACK));
                 }

--- a/tests/test_cargo_new.rs
+++ b/tests/test_cargo_new.rs
@@ -97,7 +97,7 @@ test!(invalid_characters {
 });
 
 test!(rust_prefix_stripped {
-    assert_that(cargo_process("new").arg("rust-foo"),
+    assert_that(cargo_process("new").arg("rust-foo").env("USER", "foo"),
                 execs().with_status(0)
                        .with_stdout("note: package will be named `foo`; use --name to override"));
     let toml = paths::root().join("rust-foo/Cargo.toml");
@@ -107,7 +107,7 @@ test!(rust_prefix_stripped {
 });
 
 test!(bin_disables_stripping {
-    assert_that(cargo_process("new").arg("rust-foo").arg("--bin"),
+    assert_that(cargo_process("new").arg("rust-foo").arg("--bin").env("USER", "foo"),
                 execs().with_status(0));
     let toml = paths::root().join("rust-foo/Cargo.toml");
     let mut contents = String::new();
@@ -116,7 +116,7 @@ test!(bin_disables_stripping {
 });
 
 test!(explicit_name_not_stripped {
-    assert_that(cargo_process("new").arg("foo").arg("--name").arg("rust-bar"),
+    assert_that(cargo_process("new").arg("foo").arg("--name").arg("rust-bar").env("USER", "foo"),
                 execs().with_status(0));
     let toml = paths::root().join("foo/Cargo.toml");
     let mut contents = String::new();

--- a/tests/test_cargo_new.rs
+++ b/tests/test_cargo_new.rs
@@ -96,6 +96,34 @@ test!(invalid_characters {
                        .with_stderr("Invalid character `.` in crate name: `foo.rs`"));
 });
 
+test!(rust_prefix_stripped {
+    assert_that(cargo_process("new").arg("rust-foo"),
+                execs().with_status(0)
+                       .with_stdout("Note: package will be named `foo`; use --name to override"));
+    let toml = paths::root().join("rust-foo/Cargo.toml");
+    let mut contents = String::new();
+    File::open(&toml).unwrap().read_to_string(&mut contents).unwrap();
+    assert!(contents.contains(r#"name = "foo""#));
+});
+
+test!(bin_disables_stripping {
+    assert_that(cargo_process("new").arg("rust-foo").arg("--bin"),
+                execs().with_status(0));
+    let toml = paths::root().join("rust-foo/Cargo.toml");
+    let mut contents = String::new();
+    File::open(&toml).unwrap().read_to_string(&mut contents).unwrap();
+    assert!(contents.contains(r#"name = "rust-foo""#));
+});
+
+test!(explicit_name_not_stripped {
+    assert_that(cargo_process("new").arg("foo").arg("--name").arg("rust-bar"),
+                execs().with_status(0));
+    let toml = paths::root().join("foo/Cargo.toml");
+    let mut contents = String::new();
+    File::open(&toml).unwrap().read_to_string(&mut contents).unwrap();
+    assert!(contents.contains(r#"name = "rust-bar""#));
+});
+
 test!(finds_author_user {
     // Use a temp dir to make sure we don't pick up .cargo/config somewhere in
     // the hierarchy

--- a/tests/test_cargo_new.rs
+++ b/tests/test_cargo_new.rs
@@ -99,7 +99,7 @@ test!(invalid_characters {
 test!(rust_prefix_stripped {
     assert_that(cargo_process("new").arg("rust-foo"),
                 execs().with_status(0)
-                       .with_stdout("Note: package will be named `foo`; use --name to override"));
+                       .with_stdout("note: package will be named `foo`; use --name to override"));
     let toml = paths::root().join("rust-foo/Cargo.toml");
     let mut contents = String::new();
     File::open(&toml).unwrap().read_to_string(&mut contents).unwrap();


### PR DESCRIPTION
If the user invokes `cargo new` with a name of the form `rust-foo` or `foo-rs` (or any variation of the two), and the `--bin` option is *not* present, then the resulting `Cargo.toml` will have a `name` field of just `foo` instead.

Closes #1532