### PR TITLE
Allow more advanced filtering of what to build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,8 @@ after_success: |
   git push -f https://${TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git gh-pages
 env:
   global:
-    secure: scGpeetUfba5RWyuS4yt10bPoFAI9wpHEReIFqEx7eH5vr2Anajk6+70jW6GdrWVdUvdINiArlQ3An2DeB9vEUWcBjw8WvuPtOH0tDMoSsuVloPlFD8yn1Ac0Bx9getAO5ofxqtoNg+OV4MDVuGabEesqAOWqURNrBC7XK+ntC8=
+    - secure: scGpeetUfba5RWyuS4yt10bPoFAI9wpHEReIFqEx7eH5vr2Anajk6+70jW6GdrWVdUvdINiArlQ3An2DeB9vEUWcBjw8WvuPtOH0tDMoSsuVloPlFD8yn1Ac0Bx9getAO5ofxqtoNg+OV4MDVuGabEesqAOWqURNrBC7XK+ntC8=
+    - RUST_TEST_THREADS=1
 os:
   - linux
   - osx

--- a/src/bin/build.rs
+++ b/src/bin/build.rs
@@ -15,7 +15,11 @@ struct Options {
     flag_manifest_path: Option<String>,
     flag_verbose: bool,
     flag_release: bool,
-    flag_lib: bool
+    flag_lib: bool,
+    flag_bin: Vec<String>,
+    flag_example: Vec<String>,
+    flag_test: Vec<String>,
+    flag_bench: Vec<String>,
 }
 
 pub const USAGE: &'static str = "
@@ -28,7 +32,11 @@ Options:
     -h, --help               Print this message
     -p SPEC, --package SPEC  Package to build
     -j N, --jobs N           The number of jobs to run in parallel
-    --lib                    Build only lib (if present in package)
+    --lib                    Build only this package's library
+    --bin NAME               Build only the specified binary
+    --example NAME           Build only the specified example
+    --test NAME              Build only the specified test
+    --bench NAME             Build only the specified benchmark
     --release                Build artifacts in release mode, with optimizations
     --features FEATURES      Space-separated list of features to also build
     --no-default-features    Do not build the `default` feature
@@ -63,13 +71,11 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
         exec_engine: None,
         mode: ops::CompileMode::Build,
         release: options.flag_release,
-        filter: if options.flag_lib {
-            ops::CompileFilter::Only {
-                lib: true, bins: &[], examples: &[], benches: &[], tests: &[]
-            }
-        } else {
-            ops::CompileFilter::Everything
-        },
+        filter: ops::CompileFilter::new(options.flag_lib,
+                                        &options.flag_bin,
+                                        &options.flag_test,
+                                        &options.flag_example,
+                                        &options.flag_bench),
     };
 
     ops::compile(&root, &opts).map(|_| None).map_err(|err| {

--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -184,6 +184,22 @@ pub fn compile_pkg(package: &Package, options: &CompileOptions)
 }
 
 impl<'a> CompileFilter<'a> {
+    pub fn new(lib_only: bool,
+               bins: &'a [String],
+               tests: &'a [String],
+               examples: &'a [String],
+               benches: &'a [String]) -> CompileFilter<'a> {
+        if lib_only || !bins.is_empty() || !tests.is_empty() ||
+           !examples.is_empty() || !benches.is_empty() {
+            CompileFilter::Only {
+                lib: lib_only, bins: bins, examples: examples, benches: benches,
+                tests: tests,
+            }
+        } else {
+            CompileFilter::Everything
+        }
+    }
+
     pub fn matches(&self, target: &Target) -> bool {
         match *self {
             CompileFilter::Everything => true,


### PR DESCRIPTION
This commit fills out the functionality of `--lib`, `--test`, `--bin`,
`--bench`, and `--example` for the `cargo {test,build,bench}` commands all at
once. The support for all of this was introduced long ago, and the flags just
weren't exposed at the time.