### PR TITLE
Don't put hashes in libraries of the root crate

### DIFF
--- a/src/cargo/ops/cargo_clean.rs
+++ b/src/cargo/ops/cargo_clean.rs
@@ -63,7 +63,7 @@ pub fn clean(manifest_path: &Path, opts: &CleanOptions) -> CargoResult<()> {
         try!(rm_rf(&layout.fingerprint(&pkg)));
         let profiles = [Profile::default_dev(), Profile::default_test()];
         for profile in profiles.iter() {
-            for filename in try!(cx.target_filenames(target, profile)).iter() {
+            for filename in try!(cx.target_filenames(&pkg, target, profile)).iter() {
                 try!(rm_rf(&layout.dest().join(&filename)));
                 try!(rm_rf(&layout.deps().join(&filename)));
             }

--- a/src/cargo/ops/cargo_rustc/fingerprint.rs
+++ b/src/cargo/ops/cargo_rustc/fingerprint.rs
@@ -57,7 +57,7 @@ pub fn prepare_target<'a, 'b>(cx: &mut Context<'a, 'b>,
     let root = cx.out_dir(pkg, kind, target);
     let mut missing_outputs = false;
     if !profile.doc {
-        for filename in try!(cx.target_filenames(target, profile)).iter() {
+        for filename in try!(cx.target_filenames(pkg, target, profile)).iter() {
             missing_outputs |= fs::metadata(root.join(filename)).is_err();
         }
     }

--- a/src/cargo/ops/cargo_rustc/mod.rs
+++ b/src/cargo/ops/cargo_rustc/mod.rs
@@ -133,7 +133,7 @@ pub fn compile_targets<'a, 'b>(targets: &[(&'a Target, &'a Profile)],
     cx.compilation.extra_env.insert("OUT_DIR".to_string(), out_dir);
 
     for &(target, profile) in targets {
-        for filename in try!(cx.target_filenames(target, profile)).iter() {
+        for filename in try!(cx.target_filenames(pkg, target, profile)).iter() {
             let dst = cx.out_dir(pkg, Kind::Target, target).join(filename);
             if profile.test {
                 cx.compilation.tests.push((target.name().to_string(), dst));
@@ -154,7 +154,7 @@ pub fn compile_targets<'a, 'b>(targets: &[(&'a Target, &'a Profile)],
                 if profile.doc { continue }
                 if cx.compilation.libraries.contains_key(&pkgid) { continue }
 
-                let v = try!(cx.target_filenames(target, profile));
+                let v = try!(cx.target_filenames(pkg, target, profile));
                 let v = v.into_iter().map(|f| {
                     (target.clone(),
                      cx.out_dir(pkg, Kind::Target, target).join(f))
@@ -342,7 +342,7 @@ fn rustc(package: &Package, target: &Target, profile: &Profile,
         }
         let exec_engine = cx.exec_engine.clone();
 
-        let filenames = try!(cx.target_filenames(target, profile));
+        let filenames = try!(cx.target_filenames(package, target, profile));
         let root = cx.out_dir(package, kind, target);
 
         // Prepare the native lib state (extra -L and -l flags)
@@ -367,7 +367,7 @@ fn rustc(package: &Package, target: &Target, profile: &Profile,
         let rustc_dep_info_loc = if do_rename {
             root.join(&crate_name)
         } else {
-            root.join(&cx.file_stem(target, profile))
+            root.join(&cx.file_stem(package, target, profile))
         }.with_extension("d");
         let dep_info_loc = fingerprint::dep_info_loc(cx, package, target,
                                                      profile, kind);
@@ -678,7 +678,7 @@ fn build_base_args(cx: &Context,
         None => {}
     }
 
-    match cx.target_metadata(target, profile) {
+    match cx.target_metadata(pkg, target, profile) {
         Some(m) => {
             cmd.arg("-C").arg(&format!("metadata={}", m.metadata));
             cmd.arg("-C").arg(&format!("extra-filename={}", m.extra_filename));
@@ -753,7 +753,7 @@ fn build_deps_args(cmd: &mut CommandPrototype,
             Kind::Target => Kind::Target,
         });
 
-        for filename in try!(cx.target_filenames(target, profile)).iter() {
+        for filename in try!(cx.target_filenames(pkg, target, profile)).iter() {
             if filename.ends_with(".a") { continue }
             let mut v = OsString::new();
             v.push(&target.crate_name());

--- a/tests/test_cargo_build_lib.rs
+++ b/tests/test_cargo_build_lib.rs
@@ -10,8 +10,6 @@ fn verbose_output_for_lib(p: &ProjectBuilder) -> String {
     format!("\
 {compiling} {name} v{version} ({url})
 {running} `rustc src{sep}lib.rs --crate-name {name} --crate-type lib -g \
-        -C metadata=[..] \
-        -C extra-filename=-[..] \
         --out-dir {dir}{sep}target{sep}debug \
         --emit=dep-info,link \
         -L dependency={dir}{sep}target{sep}debug \

--- a/tests/test_cargo_compile_custom_build.rs
+++ b/tests/test_cargo_compile_custom_build.rs
@@ -768,7 +768,6 @@ test!(build_cmd_with_a_build_cmd {
     --extern a=[..]liba-[..].rlib`
 {running} `[..]foo-[..]build-script-build[..]`
 {running} `rustc [..]lib.rs --crate-name foo --crate-type lib -g \
-    -C metadata=[..] -C extra-filename=-[..] \
     --out-dir [..]target[..]debug --emit=dep-info,link \
     -L [..]target[..]debug -L [..]target[..]deps`
 ", compiling = COMPILING, running = RUNNING)));

--- a/tests/test_cargo_profiles.rs
+++ b/tests/test_cargo_profiles.rs
@@ -30,8 +30,6 @@ test!(profile_overrides {
 {running} `rustc src{sep}lib.rs --crate-name test --crate-type lib \
         -C opt-level=1 \
         -C debug-assertions=on \
-        -C metadata=[..] \
-        -C extra-filename=-[..] \
         -C rpath \
         --out-dir {dir}{sep}target{sep}debug \
         --emit=dep-info,link \
@@ -95,8 +93,6 @@ test!(top_level_overrides_deps {
 {running} `rustc src{sep}lib.rs --crate-name test --crate-type lib \
         -C opt-level=1 \
         -g \
-        -C metadata=[..] \
-        -C extra-filename=-[..] \
         --out-dir {dir}{sep}target{sep}release \
         --emit=dep-info,link \
         -L dependency={dir}{sep}target{sep}release \


### PR DESCRIPTION
The root crate often has artifacts which are later intended for distribution of
some form, so adding a hash will just make predicting the file name difficult.
The hash also isn't necessary as it's guaranteed to not conflict with other
files (no other dependencies are in the same directory) and all other libraries
have metadata so symbols will not conflict.

Closes #1484