### PR TITLE
Fix transitively updating dependencies

### DIFF
--- a/src/cargo/ops/cargo_generate_lockfile.rs
+++ b/src/cargo/ops/cargo_generate_lockfile.rs
@@ -73,7 +73,11 @@ pub fn update_lockfile(manifest_path: &Path,
                                          .with_precise(Some(precise));
                         try!(registry.add_sources(&[precise]));
                     }
-                    None => {}
+                    None => {
+                        let imprecise = dep.source_id().clone()
+                                           .with_precise(None);
+                        try!(registry.add_sources(&[imprecise]));
+                    }
                 }
             }
         }


### PR DESCRIPTION
Currently when a dependency is transitively updated the source may not itself be
updated, so an update may not happen at all. This commit modifies this behavior
to be sure to add the non-updated source to the registry for any matching
package which will trigger the source to update itself.