### PR TITLE
rustc subcommand

### DIFF
--- a/src/bin/bench.rs
+++ b/src/bin/bench.rs
@@ -75,6 +75,7 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
                                             &options.flag_test,
                                             &options.flag_example,
                                             &options.flag_bench),
+            target_rustc_args: None,
         },
     };
 

--- a/src/bin/build.rs
+++ b/src/bin/build.rs
@@ -76,6 +76,7 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
                                         &options.flag_test,
                                         &options.flag_example,
                                         &options.flag_bench),
+        target_rustc_args: None,
     };
 
     ops::compile(&root, &opts).map(|_| None).map_err(|err| {

--- a/src/bin/cargo.rs
+++ b/src/bin/cargo.rs
@@ -75,6 +75,7 @@ macro_rules! each_subcommand{ ($mac:ident) => ({
     $mac!(publish);
     $mac!(read_manifest);
     $mac!(run);
+    $mac!(rustc);
     $mac!(search);
     $mac!(test);
     $mac!(update);

--- a/src/bin/doc.rs
+++ b/src/bin/doc.rs
@@ -62,6 +62,7 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
             mode: ops::CompileMode::Doc {
                 deps: !options.flag_no_deps,
             },
+            target_rustc_args: None,
         },
     };
 

--- a/src/bin/run.rs
+++ b/src/bin/run.rs
@@ -72,6 +72,7 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
                 bins: &bins, examples: &examples,
             }
         },
+        target_rustc_args: None,
     };
 
     let err = try!(ops::run(&root,

--- a/src/bin/rustc.rs
+++ b/src/bin/rustc.rs
@@ -1,0 +1,95 @@
+use std::env;
+
+use cargo::ops::CompileOptions;
+use cargo::ops;
+use cargo::util::important_paths::{find_root_manifest_for_cwd};
+use cargo::util::{CliResult, CliError, Config};
+
+#[derive(RustcDecodable)]
+struct Options {
+    arg_pkgid: Option<String>,
+    arg_opts: Option<Vec<String>>,
+    flag_profile: Option<String>,
+    flag_jobs: Option<u32>,
+    flag_features: Vec<String>,
+    flag_no_default_features: bool,
+    flag_target: Option<String>,
+    flag_manifest_path: Option<String>,
+    flag_verbose: bool,
+    flag_release: bool,
+    flag_lib: bool,
+    flag_bin: Vec<String>,
+    flag_example: Vec<String>,
+    flag_test: Vec<String>,
+    flag_bench: Vec<String>,
+}
+
+pub const USAGE: &'static str = "
+Compile a package and all of its dependencies
+
+Usage:
+    cargo rustc [options] [<pkgid>] [--] [<opts>...]
+
+Options:
+    -h, --help              Print this message
+    -p, --profile PROFILE   The profile to compile for
+    -j N, --jobs N          The number of jobs to run in parallel
+    --lib                   Build only this package's library
+    --bin NAME              Build only the specified binary
+    --example NAME          Build only the specified example
+    --test NAME             Build only the specified test
+    --bench NAME            Build only the specified benchmark
+    --release               Build artifacts in release mode, with optimizations
+    --features FEATURES     Features to compile for the package
+    --no-default-features   Do not compile default features for the package
+    --target TRIPLE         Target triple which compiles will be for
+    --manifest-path PATH    Path to the manifest to fetch depednencies for
+    -v, --verbose           Use verbose output
+
+The <pkgid> specified (defaults to the current package) will have all of its
+dependencies compiled, and then the package itself will be compiled. This
+command requires that a lockfile is available and dependencies have been
+fetched.
+
+All of the trailing arguments are passed through to the *final* rustc
+invocation, not any of the dependencies.
+
+Dependencies will not be recompiled if they do not need to be, but the package
+specified will always be compiled. The compiler will receive a number of
+arguments unconditionally such as --extern, -L, etc. Note that dependencies are
+recompiled when the flags they're compiled with change, so it is not allowed to
+manually compile a package's dependencies and then compile the package against
+the artifacts just generated.
+";
+
+pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
+    debug!("executing; cmd=cargo-rustc; args={:?}",
+           env::args().collect::<Vec<_>>());
+    config.shell().set_verbose(options.flag_verbose);
+
+    let root = try!(find_root_manifest_for_cwd(options.flag_manifest_path));
+    let spec = options.arg_pkgid.as_ref().map(|s| &s[..]);
+
+    let opts = CompileOptions {
+        config: config,
+        jobs: options.flag_jobs,
+        target: options.flag_target.as_ref().map(|t| &t[..]),
+        features: &options.flag_features,
+        no_default_features: options.flag_no_default_features,
+        spec: spec,
+        exec_engine: None,
+        mode: ops::CompileMode::Build,
+        release: options.flag_release,
+        filter: ops::CompileFilter::new(options.flag_lib,
+                                        &options.flag_bin,
+                                        &options.flag_test,
+                                        &options.flag_example,
+                                        &options.flag_bench),
+    };
+
+    ops::compile(&root, &opts).map(|_| None).map_err(|err| {
+        CliError::from_boxed(err, 101)
+    })
+}
+
+

--- a/src/bin/rustc.rs
+++ b/src/bin/rustc.rs
@@ -7,9 +7,8 @@ use cargo::util::{CliResult, CliError, Config};
 
 #[derive(RustcDecodable)]
 struct Options {
-    arg_pkgid: Option<String>,
     arg_opts: Option<Vec<String>>,
-    flag_profile: Option<String>,
+    flag_package: Option<String>,
     flag_jobs: Option<u32>,
     flag_features: Vec<String>,
     flag_no_default_features: bool,
@@ -28,23 +27,23 @@ pub const USAGE: &'static str = "
 Compile a package and all of its dependencies
 
 Usage:
-    cargo rustc [options] [<pkgid>] [--] [<opts>...]
+    cargo rustc [options] [--] [<opts>...]
 
 Options:
-    -h, --help              Print this message
-    -p, --profile PROFILE   The profile to compile for
-    -j N, --jobs N          The number of jobs to run in parallel
-    --lib                   Build only this package's library
-    --bin NAME              Build only the specified binary
-    --example NAME          Build only the specified example
-    --test NAME             Build only the specified test
-    --bench NAME            Build only the specified benchmark
-    --release               Build artifacts in release mode, with optimizations
-    --features FEATURES     Features to compile for the package
-    --no-default-features   Do not compile default features for the package
-    --target TRIPLE         Target triple which compiles will be for
-    --manifest-path PATH    Path to the manifest to fetch depednencies for
-    -v, --verbose           Use verbose output
+    -h, --help               Print this message
+    -p SPEC, --package SPEC  The profile to compile for
+    -j N, --jobs N           The number of jobs to run in parallel
+    --lib                    Build only this package's library
+    --bin NAME               Build only the specified binary
+    --example NAME           Build only the specified example
+    --test NAME              Build only the specified test
+    --bench NAME             Build only the specified benchmark
+    --release                Build artifacts in release mode, with optimizations
+    --features FEATURES      Features to compile for the package
+    --no-default-features    Do not compile default features for the package
+    --target TRIPLE          Target triple which compiles will be for
+    --manifest-path PATH     Path to the manifest to fetch depednencies for
+    -v, --verbose            Use verbose output
 
 The <pkgid> specified (defaults to the current package) will have all of its
 dependencies compiled, and then the package itself will be compiled. This
@@ -68,7 +67,6 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
     config.shell().set_verbose(options.flag_verbose);
 
     let root = try!(find_root_manifest_for_cwd(options.flag_manifest_path));
-    let spec = options.arg_pkgid.as_ref().map(|s| &s[..]);
 
     let opts = CompileOptions {
         config: config,
@@ -76,7 +74,7 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
         target: options.flag_target.as_ref().map(|t| &t[..]),
         features: &options.flag_features,
         no_default_features: options.flag_no_default_features,
-        spec: spec,
+        spec: options.flag_package.as_ref().map(|s| &s[..]),
         exec_engine: None,
         mode: ops::CompileMode::Build,
         release: options.flag_release,

--- a/src/bin/rustc.rs
+++ b/src/bin/rustc.rs
@@ -45,20 +45,16 @@ Options:
     --manifest-path PATH     Path to the manifest to fetch depednencies for
     -v, --verbose            Use verbose output
 
-The <pkgid> specified (defaults to the current package) will have all of its
-dependencies compiled, and then the package itself will be compiled. This
-command requires that a lockfile is available and dependencies have been
-fetched.
+The specified target for the current package (or package specified by SPEC if
+provided) will be compiled along with all of its dependencies. The specified
+<opts>... will all be passed to the final compiler invocation, not any of the
+dependencies. Note that the compiler will still unconditionally receive
+arguments such as -L, --extern, and --crate-type, and the specified <opts>...
+will simply be added to the compiler invocation.
 
-All of the trailing arguments are passed through to the *final* rustc
-invocation, not any of the dependencies.
-
-Dependencies will not be recompiled if they do not need to be, but the package
-specified will always be compiled. The compiler will receive a number of
-arguments unconditionally such as --extern, -L, etc. Note that dependencies are
-recompiled when the flags they're compiled with change, so it is not allowed to
-manually compile a package's dependencies and then compile the package against
-the artifacts just generated.
+This command requires that only one target is being compiled. If more than one
+target is available for the current package the filters of --lib, --bin, etc,
+must be used to select which target is compiled.
 ";
 
 pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {

--- a/src/bin/rustc.rs
+++ b/src/bin/rustc.rs
@@ -85,7 +85,7 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
                                         &options.flag_test,
                                         &options.flag_example,
                                         &options.flag_bench),
-        target_rustc_args: None,
+        target_rustc_args: options.arg_opts.as_ref().map(|a| &a[..]),
     };
 
     ops::compile(&root, &opts).map(|_| None).map_err(|err| {

--- a/src/bin/rustc.rs
+++ b/src/bin/rustc.rs
@@ -85,6 +85,7 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
                                         &options.flag_test,
                                         &options.flag_example,
                                         &options.flag_bench),
+        target_rustc_args: None,
     };
 
     ops::compile(&root, &opts).map(|_| None).map_err(|err| {

--- a/src/bin/test.rs
+++ b/src/bin/test.rs
@@ -79,6 +79,7 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
                                             &options.flag_test,
                                             &options.flag_example,
                                             &options.flag_bench),
+            target_rustc_args: None,
         },
     };
 

--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -116,6 +116,7 @@ pub struct Profile {
     pub opt_level: u32,
     pub lto: bool,
     pub codegen_units: Option<u32>,    // None = use rustc default
+    pub rustc_args: Option<Vec<String>>,
     pub debuginfo: bool,
     pub debug_assertions: bool,
     pub rpath: bool,
@@ -464,6 +465,7 @@ impl Default for Profile {
             opt_level: 0,
             lto: false,
             codegen_units: None,
+            rustc_args: None,
             debuginfo: false,
             debug_assertions: false,
             rpath: false,

--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -167,8 +167,8 @@ pub fn compile_pkg(package: &Package, options: &CompileOptions)
     let to_build = packages.iter().find(|p| p.package_id() == pkgid).unwrap();
     let targets = try!(generate_targets(to_build, mode, filter, release));
 
-    let target_with_args = match target_rustc_args {
-        &Some(args) => {
+    let target_with_args = match *target_rustc_args {
+        Some(args) => {
             if targets.len() > 1 {
                 return Err(human("extra arguments to `rustc` can only be \
                                   invoked for one target"))
@@ -178,10 +178,10 @@ pub fn compile_pkg(package: &Package, options: &CompileOptions)
             profile.rustc_args = Some(args.to_vec());
             Some((target, profile))
         },
-        &None => None,
+        None => None,
     };
 
-    let targets = target_with_args.as_ref().map(|&(t, ref p)| vec!((t, p)))
+    let targets = target_with_args.as_ref().map(|&(t, ref p)| vec![(t, p)])
                                            .unwrap_or(targets);
 
     let ret = {

--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -58,6 +58,9 @@ pub struct CompileOptions<'a, 'b: 'a> {
     pub release: bool,
     /// Mode for this compile.
     pub mode: CompileMode,
+    /// The specified target will be compiled with all the available arguments,
+    /// note that this only accounts for the *final* invocation of rustc
+    pub target_rustc_args: Option<&'a [String]>,
 }
 
 #[derive(Clone, Copy, PartialEq)]
@@ -102,7 +105,8 @@ pub fn compile_pkg(package: &Package, options: &CompileOptions)
                    -> CargoResult<ops::Compilation> {
     let CompileOptions { config, jobs, target, spec, features,
                          no_default_features, release, mode,
-                         ref filter, ref exec_engine } = *options;
+                         ref filter, ref exec_engine,
+                         ref target_rustc_args } = *options;
 
     let target = target.map(|s| s.to_string());
     let features = features.iter().flat_map(|s| {
@@ -168,6 +172,7 @@ pub fn compile_pkg(package: &Package, options: &CompileOptions)
         let mut build_config = try!(scrape_build_config(config, jobs, target));
         build_config.exec_engine = exec_engine.clone();
         build_config.release = release;
+        build_config.target_rustc_args = target_rustc_args.map(|a| a.to_vec());
         if let CompileMode::Doc { deps } = mode {
             build_config.doc_all = deps;
         }

--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -168,16 +168,16 @@ pub fn compile_pkg(package: &Package, options: &CompileOptions)
     let targets = try!(generate_targets(to_build, mode, filter, release));
 
     let target_with_args = match *target_rustc_args {
-        Some(args) => {
-            if targets.len() > 1 {
-                return Err(human("extra arguments to `rustc` can only be \
-                                  invoked for one target"))
-            }
+        Some(args) if targets.len() == 1 => {
             let (target, profile) = targets[0];
             let mut profile = profile.clone();
             profile.rustc_args = Some(args.to_vec());
             Some((target, profile))
-        },
+        }
+        Some(_) =>
+            return Err(human("extra arguments to `rustc` can only be passed to one target, \
+                              consider filtering\nthe package by passing e.g. `--lib` or \
+                              `--bin NAME` to specify a single target")),
         None => None,
     };
 

--- a/src/cargo/ops/cargo_package.rs
+++ b/src/cargo/ops/cargo_package.rs
@@ -189,6 +189,7 @@ fn run_verify(config: &Config, pkg: &Package, tar: &Path)
         exec_engine: None,
         release: false,
         mode: ops::CompileMode::Build,
+        target_rustc_args: None,
     }));
 
     Ok(())

--- a/src/cargo/ops/cargo_rustc/mod.rs
+++ b/src/cargo/ops/cargo_rustc/mod.rs
@@ -43,6 +43,7 @@ pub struct BuildConfig {
     pub exec_engine: Option<Arc<Box<ExecEngine>>>,
     pub release: bool,
     pub doc_all: bool,
+    pub target_rustc_args: Option<Vec<String>>,
 }
 
 #[derive(Clone, Default)]

--- a/src/cargo/ops/cargo_rustc/mod.rs
+++ b/src/cargo/ops/cargo_rustc/mod.rs
@@ -43,7 +43,6 @@ pub struct BuildConfig {
     pub exec_engine: Option<Arc<Box<ExecEngine>>>,
     pub release: bool,
     pub doc_all: bool,
-    pub target_rustc_args: Option<Vec<String>>,
 }
 
 #[derive(Clone, Default)]
@@ -624,7 +623,6 @@ fn build_base_args(cx: &Context,
         opt_level, lto, codegen_units, ref rustc_args, debuginfo, debug_assertions,
         rpath, test, doc: _doc,
     } = *profile;
-    let _ = rustc_args;
 
     // Move to cwd so the root_path() passed below is actually correct
     cmd.cwd(cx.config.cwd());
@@ -666,7 +664,7 @@ fn build_base_args(cx: &Context,
         cmd.arg("-g");
     }
 
-    if let Some(ref args) = cx.build_config.target_rustc_args {
+    if let &Some(ref args) = rustc_args {
         cmd.args(args);
     }
 

--- a/src/cargo/ops/cargo_rustc/mod.rs
+++ b/src/cargo/ops/cargo_rustc/mod.rs
@@ -664,7 +664,7 @@ fn build_base_args(cx: &Context,
         cmd.arg("-g");
     }
 
-    if let &Some(ref args) = rustc_args {
+    if let Some(ref args) = *rustc_args {
         cmd.args(args);
     }
 

--- a/src/cargo/ops/cargo_rustc/mod.rs
+++ b/src/cargo/ops/cargo_rustc/mod.rs
@@ -621,9 +621,10 @@ fn build_base_args(cx: &Context,
                    profile: &Profile,
                    crate_types: &[&str]) {
     let Profile {
-        opt_level, lto, codegen_units, debuginfo, debug_assertions, rpath, test,
-        doc: _doc,
+        opt_level, lto, codegen_units, ref rustc_args, debuginfo, debug_assertions,
+        rpath, test, doc: _doc,
     } = *profile;
+    let _ = rustc_args;
 
     // Move to cwd so the root_path() passed below is actually correct
     cmd.cwd(cx.config.cwd());

--- a/src/cargo/ops/cargo_rustc/mod.rs
+++ b/src/cargo/ops/cargo_rustc/mod.rs
@@ -665,6 +665,10 @@ fn build_base_args(cx: &Context,
         cmd.arg("-g");
     }
 
+    if let Some(ref args) = cx.build_config.target_rustc_args {
+        cmd.args(args);
+    }
+
     if debug_assertions && opt_level > 0 {
         cmd.args(&["-C", "debug-assertions=on"]);
     } else if !debug_assertions && opt_level == 0 {

--- a/src/cargo/util/toml.rs
+++ b/src/cargo/util/toml.rs
@@ -814,6 +814,7 @@ fn build_profiles(profiles: &Option<TomlProfiles>) -> Profiles {
             opt_level: opt_level.unwrap_or(profile.opt_level),
             lto: lto.unwrap_or(profile.lto),
             codegen_units: codegen_units,
+            rustc_args: None,
             debuginfo: debug.unwrap_or(profile.debuginfo),
             debug_assertions: debug_assertions.unwrap_or(profile.debug_assertions),
             rpath: rpath.unwrap_or(profile.rpath),

--- a/tests/test_cargo_rustc.rs
+++ b/tests/test_cargo_rustc.rs
@@ -43,7 +43,7 @@ test!(build_lib_for_foo {
         "#)
         .file("src/lib.rs", r#" "#);
 
-    assert_that(p.cargo_process("rustc").arg("--lib").arg("-v").arg("foo"),
+    assert_that(p.cargo_process("rustc").arg("--lib").arg("-v"),
                 execs()
                 .with_status(0)
                 .with_stdout(verbose_output_for_target(true, &p)));
@@ -63,7 +63,7 @@ test!(build_lib_and_allow_unstable_options {
         "#)
         .file("src/lib.rs", r#" "#);
 
-    assert_that(p.cargo_process("rustc").arg("--lib").arg("-v").arg("foo")
+    assert_that(p.cargo_process("rustc").arg("--lib").arg("-v")
                 .arg("--").arg("-Z").arg("unstable-options"),
                 execs()
                 .with_status(0)
@@ -84,7 +84,7 @@ test!(build_main_and_allow_unstable_options {
             fn main() {}
         "#);
 
-    assert_that(p.cargo_process("rustc").arg("-v").arg("foo")
+    assert_that(p.cargo_process("rustc").arg("-v")
                 .arg("--").arg("-Z").arg("unstable-options"),
                 execs()
                 .with_status(0)

--- a/tests/test_cargo_rustc.rs
+++ b/tests/test_cargo_rustc.rs
@@ -1,42 +1,18 @@
 use std::path::MAIN_SEPARATOR as SEP;
-use support::{execs, project, ProjectBuilder};
+use support::{execs, project};
 use support::{COMPILING, RUNNING};
 use hamcrest::{assert_that};
 
 fn setup() {
 }
 
-fn verbose_output_for_target(lib: bool, p: &ProjectBuilder) -> String {
-    let (target, kind) = match lib {
-        true => ("lib", "lib"),
-        false => ("main", "bin"),
-    };
-    format!("\
-{compiling} {name} v{version} ({url})
-{running} `rustc src{sep}{target}.rs --crate-name {name} --crate-type {kind} -g \
-        --out-dir {dir}{sep}target{sep}debug \
-        --emit=dep-info,link \
-        -L dependency={dir}{sep}target{sep}debug \
-        -L dependency={dir}{sep}target{sep}debug{sep}deps`
-",
-            running = RUNNING, compiling = COMPILING, sep = SEP,
-            dir = p.root().display(), url = p.url(),
-            target = target, kind = kind,
-            name = "foo", version = "0.0.1")
-}
-
-fn verbose_output_for_target_with_args(lib: bool, p: &ProjectBuilder, args: &str) -> String {
-    verbose_output_for_target(lib, p).replace(" -g ", &format!(" -g {} ", args))
-}
-
 test!(build_lib_for_foo {
     let p = project("foo")
         .file("Cargo.toml", r#"
             [package]
-
             name = "foo"
             version = "0.0.1"
-            authors = ["wycats@example.com"]
+            authors = []
         "#)
         .file("src/main.rs", r#"
             fn main() {}
@@ -46,17 +22,25 @@ test!(build_lib_for_foo {
     assert_that(p.cargo_process("rustc").arg("--lib").arg("-v"),
                 execs()
                 .with_status(0)
-                .with_stdout(verbose_output_for_target(true, &p)));
+                .with_stdout(format!("\
+{compiling} foo v0.0.1 ({url})
+{running} `rustc src{sep}lib.rs --crate-name foo --crate-type lib -g \
+        --out-dir {dir}{sep}target{sep}debug \
+        --emit=dep-info,link \
+        -L dependency={dir}{sep}target{sep}debug \
+        -L dependency={dir}{sep}target{sep}debug{sep}deps`
+",
+            running = RUNNING, compiling = COMPILING, sep = SEP,
+            dir = p.root().display(), url = p.url())));
 });
 
 test!(build_lib_and_allow_unstable_options {
     let p = project("foo")
         .file("Cargo.toml", r#"
             [package]
-
             name = "foo"
             version = "0.0.1"
-            authors = ["wycats@example.com"]
+            authors = []
         "#)
         .file("src/main.rs", r#"
             fn main() {}
@@ -67,18 +51,26 @@ test!(build_lib_and_allow_unstable_options {
                 .arg("--").arg("-Z").arg("unstable-options"),
                 execs()
                 .with_status(0)
-                .with_stdout(verbose_output_for_target_with_args(true, &p,
-                                                                 "-Z unstable-options")));
+                .with_stdout(format!("\
+{compiling} foo v0.0.1 ({url})
+{running} `rustc src{sep}lib.rs --crate-name foo --crate-type lib -g \
+        -Z unstable-options \
+        --out-dir {dir}{sep}target{sep}debug \
+        --emit=dep-info,link \
+        -L dependency={dir}{sep}target{sep}debug \
+        -L dependency={dir}{sep}target{sep}debug{sep}deps`
+",
+            running = RUNNING, compiling = COMPILING, sep = SEP,
+            dir = p.root().display(), url = p.url())))
 });
 
 test!(build_main_and_allow_unstable_options {
     let p = project("foo")
         .file("Cargo.toml", r#"
             [package]
-
             name = "foo"
             version = "0.0.1"
-            authors = ["wycats@example.com"]
+            authors = []
         "#)
         .file("src/main.rs", r#"
             fn main() {}
@@ -113,10 +105,9 @@ test!(fails_when_trying_to_build_main_and_lib_with_args {
     let p = project("foo")
         .file("Cargo.toml", r#"
             [package]
-
             name = "foo"
             version = "0.0.1"
-            authors = ["wycats@example.com"]
+            authors = []
         "#)
         .file("src/main.rs", r#"
             fn main() {}

--- a/tests/test_cargo_rustc.rs
+++ b/tests/test_cargo_rustc.rs
@@ -91,3 +91,25 @@ test!(build_main_and_allow_unstable_options {
                 .with_stdout(verbose_output_for_target_with_args(false, &p,
                                                                  "-Z unstable-options")));
 });
+
+test!(fails_when_trying_to_build_main_and_lib_with_args {
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [package]
+
+            name = "foo"
+            version = "0.0.1"
+            authors = ["wycats@example.com"]
+        "#)
+        .file("src/main.rs", r#"
+            fn main() {}
+        "#)
+        .file("src/lib.rs", r#" "#);
+
+
+    assert_that(p.cargo_process("rustc").arg("-v")
+                .arg("--").arg("-Z").arg("unstable-options"),
+                execs()
+                .with_status(101)
+                .with_stderr("extra arguments to `rustc` can only be invoked for one target"));
+});

--- a/tests/test_cargo_rustc.rs
+++ b/tests/test_cargo_rustc.rs
@@ -6,6 +6,11 @@ use hamcrest::{assert_that};
 fn setup() {
 }
 
+fn cargo_rustc_error() -> &'static str {
+    "extra arguments to `rustc` can only be passed to one target, consider filtering\n\
+    the package by passing e.g. `--lib` or `--bin NAME` to specify a single target"
+}
+
 test!(build_lib_for_foo {
     let p = project("foo")
         .file("Cargo.toml", r#"
@@ -118,7 +123,7 @@ test!(fails_when_trying_to_build_main_and_lib_with_args {
                 .arg("--").arg("-Z").arg("unstable-options"),
                 execs()
                 .with_status(101)
-                .with_stderr("extra arguments to `rustc` can only be invoked for one target"));
+                .with_stderr(cargo_rustc_error()));
 });
 
 test!(build_with_args_to_one_of_multiple_binaries {
@@ -178,7 +183,7 @@ test!(fails_with_args_to_all_binaries {
                 .arg("--").arg("-Z").arg("unstable-options"),
                 execs()
                 .with_status(101)
-                .with_stderr("extra arguments to `rustc` can only be invoked for one target"));
+                .with_stderr(cargo_rustc_error()));
 });
 
 test!(build_with_args_to_one_of_multiple_tests {

--- a/tests/test_cargo_rustc.rs
+++ b/tests/test_cargo_rustc.rs
@@ -6,10 +6,14 @@ use hamcrest::{assert_that};
 fn setup() {
 }
 
-fn verbose_output_for_lib(p: &ProjectBuilder) -> String {
+fn verbose_output_for_target(lib: bool, p: &ProjectBuilder) -> String {
+    let (target, kind) = match lib {
+        true => ("lib", "lib"),
+        false => ("main", "bin"),
+    };
     format!("\
 {compiling} {name} v{version} ({url})
-{running} `rustc src{sep}lib.rs --crate-name {name} --crate-type lib -g \
+{running} `rustc src{sep}{target}.rs --crate-name {name} --crate-type {kind} -g \
         --out-dir {dir}{sep}target{sep}debug \
         --emit=dep-info,link \
         -L dependency={dir}{sep}target{sep}debug \
@@ -17,7 +21,12 @@ fn verbose_output_for_lib(p: &ProjectBuilder) -> String {
 ",
             running = RUNNING, compiling = COMPILING, sep = SEP,
             dir = p.root().display(), url = p.url(),
+            target = target, kind = kind,
             name = "foo", version = "0.0.1")
+}
+
+fn verbose_output_for_target_with_args(lib: bool, p: &ProjectBuilder, args: &str) -> String {
+    verbose_output_for_target(lib, p).replace(" -g ", &format!(" -g {} ", args))
 }
 
 test!(build_lib_for_foo {
@@ -37,5 +46,48 @@ test!(build_lib_for_foo {
     assert_that(p.cargo_process("rustc").arg("--lib").arg("-v").arg("foo"),
                 execs()
                 .with_status(0)
-                .with_stdout(verbose_output_for_lib(&p)));
+                .with_stdout(verbose_output_for_target(true, &p)));
+});
+
+test!(build_lib_and_allow_unstable_options {
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [package]
+
+            name = "foo"
+            version = "0.0.1"
+            authors = ["wycats@example.com"]
+        "#)
+        .file("src/main.rs", r#"
+            fn main() {}
+        "#)
+        .file("src/lib.rs", r#" "#);
+
+    assert_that(p.cargo_process("rustc").arg("--lib").arg("-v").arg("foo")
+                .arg("--").arg("-Z").arg("unstable-options"),
+                execs()
+                .with_status(0)
+                .with_stdout(verbose_output_for_target_with_args(true, &p,
+                                                                 "-Z unstable-options")));
+});
+
+test!(build_main_and_allow_unstable_options {
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [package]
+
+            name = "foo"
+            version = "0.0.1"
+            authors = ["wycats@example.com"]
+        "#)
+        .file("src/main.rs", r#"
+            fn main() {}
+        "#);
+
+    assert_that(p.cargo_process("rustc").arg("-v").arg("foo")
+                .arg("--").arg("-Z").arg("unstable-options"),
+                execs()
+                .with_status(0)
+                .with_stdout(verbose_output_for_target_with_args(false, &p,
+                                                                 "-Z unstable-options")));
 });

--- a/tests/test_cargo_rustc.rs
+++ b/tests/test_cargo_rustc.rs
@@ -1,0 +1,41 @@
+use std::path::MAIN_SEPARATOR as SEP;
+use support::{execs, project, ProjectBuilder};
+use support::{COMPILING, RUNNING};
+use hamcrest::{assert_that};
+
+fn setup() {
+}
+
+fn verbose_output_for_lib(p: &ProjectBuilder) -> String {
+    format!("\
+{compiling} {name} v{version} ({url})
+{running} `rustc src{sep}lib.rs --crate-name {name} --crate-type lib -g \
+        --out-dir {dir}{sep}target{sep}debug \
+        --emit=dep-info,link \
+        -L dependency={dir}{sep}target{sep}debug \
+        -L dependency={dir}{sep}target{sep}debug{sep}deps`
+",
+            running = RUNNING, compiling = COMPILING, sep = SEP,
+            dir = p.root().display(), url = p.url(),
+            name = "foo", version = "0.0.1")
+}
+
+test!(build_lib_for_foo {
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [package]
+
+            name = "foo"
+            version = "0.0.1"
+            authors = ["wycats@example.com"]
+        "#)
+        .file("src/main.rs", r#"
+            fn main() {}
+        "#)
+        .file("src/lib.rs", r#" "#);
+
+    assert_that(p.cargo_process("rustc").arg("--lib").arg("-v").arg("foo"),
+                execs()
+                .with_status(0)
+                .with_stdout(verbose_output_for_lib(&p)));
+});

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -48,6 +48,7 @@ mod test_cargo_profiles;
 mod test_cargo_publish;
 mod test_cargo_registry;
 mod test_cargo_run;
+mod test_cargo_rustc;
 mod test_cargo_search;
 mod test_cargo_test;
 mod test_cargo_version;


### PR DESCRIPTION
## Work in progress
I have followed issue #595 for a while now. I hope that this PR can solve it, after it's done of course.

@alexcrichton: on IRC the other day, you suggested adding a `Vec<String>` to the `CompileOptions`. I have done this, but wasn't sure what the best way to identify the correct `Target` would be, so currently everything gets compiled with the additional arguments. 
I considered adding a `Target` structure to the `CompileOptions` as well, and then in `cargo_rustc::build_base_args` only append the arguments if the `Target` matches. What do you think about this? Is there an easier way of figuring out the correct `Target`?

r? @alexcrichton 