### PR TITLE
Shell escape process arguments that are printed out

### DIFF
--- a/src/cargo/util/mod.rs
+++ b/src/cargo/util/mod.rs
@@ -30,4 +30,5 @@ pub mod toml;
 pub mod lev_distance;
 mod dependency_queue;
 mod sha256;
+mod shell_escape;
 mod vcs;

--- a/src/cargo/util/process_builder.rs
+++ b/src/cargo/util/process_builder.rs
@@ -6,6 +6,7 @@ use std::path::Path;
 use std::process::{Command, Output};
 
 use util::{CargoResult, ProcessError, process_error};
+use util::shell_escape::shell_escape;
 
 #[derive(Clone, PartialEq, Debug)]
 pub struct ProcessBuilder {
@@ -20,7 +21,7 @@ impl fmt::Display for ProcessBuilder {
         try!(write!(f, "`{}", self.program.to_string_lossy()));
 
         for arg in self.args.iter() {
-            try!(write!(f, " {}", arg.to_string_lossy()));
+            try!(write!(f, " {}", shell_escape(arg.to_string_lossy())));
         }
 
         write!(f, "`")

--- a/src/cargo/util/shell_escape.rs
+++ b/src/cargo/util/shell_escape.rs
@@ -1,0 +1,40 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::borrow::Cow;
+
+static SHELL_SPECIAL: &'static str = r#"\$'"`!"#;
+
+/// Escape characters that may have special meaning in a shell.
+pub fn shell_escape(s: Cow<str>) -> Cow<str> {
+    let escape_char = '\\';
+    // check if string needs to be escaped
+    let clean = SHELL_SPECIAL.chars().all(|sp_char| !s.contains(sp_char));
+    if clean {
+        return s
+    }
+    let mut es = String::with_capacity(s.len());
+    for ch in s.chars() {
+        if SHELL_SPECIAL.contains(ch) {
+            es.push(escape_char);
+        }
+        es.push(ch)
+    }
+    es.into()
+}
+
+#[test]
+fn test_shell_escape() {
+    assert_eq!(shell_escape("--aaa=bbb ccc".into()), "--aaa=bbb ccc");
+    assert_eq!(shell_escape(r#"--features="default""#.into()),
+                            r#"--features=\"default\""#);
+    assert_eq!(shell_escape(r#"'!\$` \\ \n"#.into()),
+                            r#"\'\!\\\$\` \\\\ \\n"#);
+}

--- a/src/cargo/util/shell_escape.rs
+++ b/src/cargo/util/shell_escape.rs
@@ -10,9 +10,10 @@
 
 use std::borrow::Cow;
 
-static SHELL_SPECIAL: &'static str = r#"\$'"`!"#;
+static SHELL_SPECIAL: &'static str = r#" \$'"`!"#;
 
-/// Escape characters that may have special meaning in a shell.
+/// Escape characters that may have special meaning in a shell,
+/// including spaces.
 pub fn shell_escape(s: Cow<str>) -> Cow<str> {
     let escape_char = '\\';
     // check if string needs to be escaped
@@ -32,9 +33,11 @@ pub fn shell_escape(s: Cow<str>) -> Cow<str> {
 
 #[test]
 fn test_shell_escape() {
-    assert_eq!(shell_escape("--aaa=bbb ccc".into()), "--aaa=bbb ccc");
+    assert_eq!(shell_escape("--aaa=bbb-ccc".into()), "--aaa=bbb-ccc");
+    assert_eq!(shell_escape("linker=gcc -L/foo -Wl,bar".into()),
+                            r#"linker=gcc\ -L/foo\ -Wl,bar"#);
     assert_eq!(shell_escape(r#"--features="default""#.into()),
                             r#"--features=\"default\""#);
-    assert_eq!(shell_escape(r#"'!\$` \\ \n"#.into()),
-                            r#"\'\!\\\$\` \\\\ \\n"#);
+    assert_eq!(shell_escape(r#"'!\$`\\\n "#.into()),
+                            r#"\'\!\\\$\`\\\\\\n\ "#);
 }


### PR DESCRIPTION
Shell escape process arguments that are printed out

cargo build --verbose does output some command lines that cannot be
simply copy and pasted into the shell again. The problem is the
arguments which are output exactly like this: --feature="foo"

When pasted back into the shell, the shell will parse and remove the
double quotes. To counteract this, escape special shell characters when
printing commandlines. Cargo will print --feature=\"foo\" instead, which
can be pasted back into the shell.