### PR TITLE
Add a Kind argument to target_filenames

### DIFF
--- a/src/cargo/ops/cargo_clean.rs
+++ b/src/cargo/ops/cargo_clean.rs
@@ -7,7 +7,7 @@ use core::{PackageSet, Profiles, Profile};
 use core::source::{Source, SourceMap};
 use sources::PathSource;
 use util::{CargoResult, human, ChainError, Config};
-use ops::{self, Layout, Context, BuildConfig};
+use ops::{self, Layout, Context, BuildConfig, Kind};
 
 pub struct CleanOptions<'a, 'b: 'a> {
     pub spec: Option<&'a str>,
@@ -63,7 +63,8 @@ pub fn clean(manifest_path: &Path, opts: &CleanOptions) -> CargoResult<()> {
         try!(rm_rf(&layout.fingerprint(&pkg)));
         let profiles = [Profile::default_dev(), Profile::default_test()];
         for profile in profiles.iter() {
-            for filename in try!(cx.target_filenames(&pkg, target, profile)).iter() {
+            for filename in try!(cx.target_filenames(&pkg, target, profile,
+                                                     Kind::Target)).iter() {
                 try!(rm_rf(&layout.dest().join(&filename)));
                 try!(rm_rf(&layout.deps().join(&filename)));
             }

--- a/src/cargo/ops/cargo_rustc/context.rs
+++ b/src/cargo/ops/cargo_rustc/context.rs
@@ -299,7 +299,8 @@ impl<'a, 'b: 'a> Context<'a, 'b> {
     /// Return the filenames that the given target for the given profile will
     /// generate.
     pub fn target_filenames(&self, pkg: &Package, target: &Target,
-                            profile: &Profile) -> CargoResult<Vec<String>> {
+                            profile: &Profile, kind: Kind)
+                            -> CargoResult<Vec<String>> {
         let stem = self.file_stem(pkg, target, profile);
         let suffix = if target.for_host() {&self.host_exe} else {&self.target_exe};
 
@@ -316,8 +317,6 @@ impl<'a, 'b: 'a> Context<'a, 'b> {
                 for lib in libs.iter() {
                     match *lib {
                         LibKind::Dylib => {
-                            let plugin = target.for_host();
-                            let kind = if plugin {Kind::Host} else {Kind::Target};
                             let (prefix, suffix) = try!(self.dylib(kind));
                             ret.push(format!("{}{}{}", prefix, stem, suffix));
                         }

--- a/src/cargo/ops/cargo_rustc/fingerprint.rs
+++ b/src/cargo/ops/cargo_rustc/fingerprint.rs
@@ -51,13 +51,14 @@ pub fn prepare_target<'a, 'b>(cx: &mut Context<'a, 'b>,
 
     info!("fingerprint at: {}", loc.display());
 
-    let fingerprint = try!(calculate(cx, pkg, target, profile, kind));
-    let is_fresh = try!(is_fresh(&loc, &fingerprint));
+    let mut fingerprint = try!(calculate(cx, pkg, target, profile, kind));
+    let is_fresh = try!(is_fresh(&loc, &mut fingerprint));
 
     let root = cx.out_dir(pkg, kind, target);
     let mut missing_outputs = false;
     if !profile.doc {
-        for filename in try!(cx.target_filenames(pkg, target, profile)).iter() {
+        for filename in try!(cx.target_filenames(pkg, target, profile,
+                                                 kind)).iter() {
             missing_outputs |= fs::metadata(root.join(filename)).is_err();
         }
     }


### PR DESCRIPTION
Knowing the target architecture for calculating the filename is needed when
calculating the name of a dynamic library, and previously this was only taken
into account when a target was a plugin. Targets can, however, request that they
are built as a dynamic library which also needs to be taken into account.

Closes #1589