### PR TITLE
Don't auto-build dotfiles in inferred folders

### DIFF
--- a/src/cargo/util/toml.rs
+++ b/src/cargo/util/toml.rs
@@ -53,6 +53,15 @@ fn try_add_files(files: &mut Vec<PathBuf>, root: PathBuf) {
                 dir.map(|d| d.path()).ok()
             }).filter(|f| {
                 f.extension().and_then(|s| s.to_str()) == Some("rs")
+            }).filter(|f| {
+                // Some unix editors may create "dotfiles" next to original
+                // source files while they're being edited, but these files are
+                // rarely actually valid Rust source files and sometimes aren't
+                // even valid UTF-8. Here we just ignore all of them and require
+                // that they are explicitly specified in Cargo.toml if desired.
+                f.file_name().and_then(|s| s.to_str()).map(|s| {
+                    !s.starts_with(".")
+                }).unwrap_or(true)
             }))
         }
         Err(_) => {/* just don't add anything if the directory doesn't exist, etc. */}

--- a/tests/test_cargo_compile.rs
+++ b/tests/test_cargo_compile.rs
@@ -1717,3 +1717,19 @@ test!(filtering {
     assert_that(&p.bin("examples/a"), existing_file());
     assert_that(&p.bin("examples/b"), is_not(existing_file()));
 });
+
+test!(ignore_dotfile {
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [package]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+        "#)
+        .file("src/bin/.a.rs", "")
+        .file("src/bin/a.rs", "fn main() {}");
+    p.build();
+
+    assert_that(p.cargo("build"),
+                execs().with_status(0));
+});


### PR DESCRIPTION
Whenever Cargo infers various targets for a project it currently picks up all
files in associated folders, but dotfiles are a common example of files which
editors generate which Cargo should not pick up, so this commit ignores all
dotfiles in the folders that it is looking at.

Closes #1615