### PR TITLE
Support configuration of what compiler to run

### DIFF
--- a/src/cargo/core/registry.rs
+++ b/src/cargo/core/registry.rs
@@ -32,9 +32,9 @@ impl Registry for Vec<Summary> {
 /// `SourceMap` structure contained within which is a mapping of a `SourceId` to
 /// a `Source`. Each `Source` in the map has been updated (using network
 /// operations if necessary) and is ready to be queried for packages.
-pub struct PackageRegistry<'a, 'b: 'a> {
-    sources: SourceMap<'a>,
-    config: &'a Config<'b>,
+pub struct PackageRegistry<'cfg> {
+    sources: SourceMap<'cfg>,
+    config: &'cfg Config,
 
     // A list of sources which are considered "overrides" which take precedent
     // when querying for packages.
@@ -67,8 +67,8 @@ enum Kind {
     Normal,
 }
 
-impl<'a, 'b> PackageRegistry<'a, 'b> {
-    pub fn new(config: &'a Config<'b>) -> PackageRegistry<'a, 'b> {
+impl<'cfg> PackageRegistry<'cfg> {
+    pub fn new(config: &'cfg Config) -> PackageRegistry<'cfg> {
         PackageRegistry {
             sources: SourceMap::new(),
             source_ids: HashMap::new(),
@@ -100,7 +100,7 @@ impl<'a, 'b> PackageRegistry<'a, 'b> {
         Ok(ret)
     }
 
-    pub fn move_sources(self) -> SourceMap<'a> {
+    pub fn move_sources(self) -> SourceMap<'cfg> {
         self.sources
     }
 
@@ -275,7 +275,7 @@ impl<'a, 'b> PackageRegistry<'a, 'b> {
     }
 }
 
-impl<'a, 'b> Registry for PackageRegistry<'a, 'b> {
+impl<'cfg> Registry for PackageRegistry<'cfg> {
     fn query(&mut self, dep: &Dependency) -> CargoResult<Vec<Summary>> {
         let overrides = try!(self.query_overrides(dep));
 

--- a/src/cargo/ops/cargo_clean.rs
+++ b/src/cargo/ops/cargo_clean.rs
@@ -9,10 +9,10 @@ use sources::PathSource;
 use util::{CargoResult, human, ChainError, Config};
 use ops::{self, Layout, Context, BuildConfig, Kind};
 
-pub struct CleanOptions<'a, 'b: 'a> {
+pub struct CleanOptions<'a> {
     pub spec: Option<&'a str>,
     pub target: Option<&'a str>,
-    pub config: &'a Config<'b>,
+    pub config: &'a Config,
 }
 
 /// Cleans the project from build artifacts.

--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -82,9 +82,9 @@ pub enum CompileFilter<'a> {
     }
 }
 
-pub fn compile(manifest_path: &Path,
-               options: &CompileOptions)
-               -> CargoResult<ops::Compilation> {
+pub fn compile<'a>(manifest_path: &Path,
+                   options: &CompileOptions<'a>)
+                   -> CargoResult<ops::Compilation<'a>> {
     debug!("compile; manifest-path={}", manifest_path.display());
 
     let mut source = try!(PathSource::for_path(manifest_path.parent().unwrap(),
@@ -101,8 +101,9 @@ pub fn compile(manifest_path: &Path,
     compile_pkg(&package, options)
 }
 
-pub fn compile_pkg(package: &Package, options: &CompileOptions)
-                   -> CargoResult<ops::Compilation> {
+pub fn compile_pkg<'a>(package: &Package,
+                       options: &CompileOptions<'a>)
+                       -> CargoResult<ops::Compilation<'a>> {
     let CompileOptions { config, jobs, target, spec, features,
                          no_default_features, release, mode,
                          ref filter, ref exec_engine,
@@ -174,10 +175,12 @@ pub fn compile_pkg(package: &Package, options: &CompileOptions)
             profile.rustc_args = Some(args.to_vec());
             Some((target, profile))
         }
-        Some(_) =>
-            return Err(human("extra arguments to `rustc` can only be passed to one target, \
-                              consider filtering\nthe package by passing e.g. `--lib` or \
-                              `--bin NAME` to specify a single target")),
+        Some(_) => {
+            return Err(human("extra arguments to `rustc` can only be passed to \
+                              one target, consider filtering\nthe package by \
+                              passing e.g. `--lib` or `--bin NAME` to specify \
+                              a single target"))
+        }
         None => None,
     };
 
@@ -195,7 +198,8 @@ pub fn compile_pkg(package: &Package, options: &CompileOptions)
 
         try!(ops::compile_targets(&targets, to_build,
                                   &PackageSet::new(&packages),
-                                  &resolve_with_overrides, &sources,
+                                  &resolve_with_overrides,
+                                  &sources,
                                   config,
                                   build_config,
                                   to_build.manifest().profiles()))

--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -37,8 +37,8 @@ use util::config::{ConfigValue, Config};
 use util::{CargoResult, internal, human, ChainError, profile};
 
 /// Contains informations about how a package should be compiled.
-pub struct CompileOptions<'a, 'b: 'a> {
-    pub config: &'a Config<'b>,
+pub struct CompileOptions<'a> {
+    pub config: &'a Config,
     /// Number of concurrent jobs to use.
     pub jobs: Option<u32>,
     /// The target platform to compile for (example: `i686-unknown-linux-gnu`).

--- a/src/cargo/ops/cargo_doc.rs
+++ b/src/cargo/ops/cargo_doc.rs
@@ -9,9 +9,9 @@ use ops;
 use sources::PathSource;
 use util::{CargoResult, human};
 
-pub struct DocOptions<'a, 'b: 'a> {
+pub struct DocOptions<'a> {
     pub open_result: bool,
-    pub compile_opts: ops::CompileOptions<'a, 'b>,
+    pub compile_opts: ops::CompileOptions<'a>,
 }
 
 pub fn doc(manifest_path: &Path,

--- a/src/cargo/ops/cargo_generate_lockfile.rs
+++ b/src/cargo/ops/cargo_generate_lockfile.rs
@@ -10,8 +10,8 @@ use sources::{PathSource};
 use util::config::{Config};
 use util::{CargoResult, human};
 
-pub struct UpdateOptions<'a, 'b: 'a> {
-    pub config: &'a Config<'b>,
+pub struct UpdateOptions<'a> {
+    pub config: &'a Config,
     pub to_update: Option<&'a str>,
     pub precise: Option<&'a str>,
     pub aggressive: bool,

--- a/src/cargo/ops/cargo_rustc/context.rs
+++ b/src/cargo/ops/cargo_rustc/context.rs
@@ -25,8 +25,8 @@ pub enum Platform {
     PluginAndTarget,
 }
 
-pub struct Context<'a, 'b: 'a> {
-    pub config: &'a Config<'b>,
+pub struct Context<'a> {
+    pub config: &'a Config,
     pub resolve: &'a Resolve,
     pub sources: &'a SourceMap<'a>,
     pub compilation: Compilation,
@@ -49,16 +49,16 @@ pub struct Context<'a, 'b: 'a> {
     profiles: &'a Profiles,
 }
 
-impl<'a, 'b: 'a> Context<'a, 'b> {
+impl<'a> Context<'a> {
     pub fn new(resolve: &'a Resolve,
                sources: &'a SourceMap<'a>,
                deps: &'a PackageSet,
-               config: &'a Config<'b>,
+               config: &'a Config,
                host: Layout,
                target_layout: Option<Layout>,
                root_pkg: &Package,
                build_config: BuildConfig,
-               profiles: &'a Profiles) -> CargoResult<Context<'a, 'b>> {
+               profiles: &'a Profiles) -> CargoResult<Context<'a>> {
         let target = build_config.requested_target.clone();
         let target = target.as_ref().map(|s| &s[..]);
         let (target_dylib, target_exe) = try!(Context::filename_parts(target));

--- a/src/cargo/ops/cargo_rustc/context.rs
+++ b/src/cargo/ops/cargo_rustc/context.rs
@@ -98,7 +98,7 @@ impl<'a, 'b: 'a> Context<'a, 'b> {
     /// specified as well as the exe suffix
     fn filename_parts(target: Option<&str>)
                       -> CargoResult<(Option<(String, String)>, String)> {
-        let mut process = try!(util::process("rustc"));
+        let mut process = try!(util::process(util::rustc()));
         process.arg("-")
                .arg("--crate-name").arg("_")
                .arg("--crate-type").arg("dylib")

--- a/src/cargo/ops/cargo_rustc/context.rs
+++ b/src/cargo/ops/cargo_rustc/context.rs
@@ -25,11 +25,11 @@ pub enum Platform {
     PluginAndTarget,
 }
 
-pub struct Context<'a> {
-    pub config: &'a Config,
+pub struct Context<'a, 'cfg: 'a> {
+    pub config: &'cfg Config,
     pub resolve: &'a Resolve,
-    pub sources: &'a SourceMap<'a>,
-    pub compilation: Compilation,
+    pub sources: &'a SourceMap<'cfg>,
+    pub compilation: Compilation<'cfg>,
     pub build_state: Arc<BuildState>,
     pub exec_engine: Arc<Box<ExecEngine>>,
     pub fingerprints: HashMap<(&'a PackageId, &'a Target, &'a Profile, Kind),
@@ -49,23 +49,24 @@ pub struct Context<'a> {
     profiles: &'a Profiles,
 }
 
-impl<'a> Context<'a> {
+impl<'a, 'cfg> Context<'a, 'cfg> {
     pub fn new(resolve: &'a Resolve,
-               sources: &'a SourceMap<'a>,
+               sources: &'a SourceMap<'cfg>,
                deps: &'a PackageSet,
-               config: &'a Config,
+               config: &'cfg Config,
                host: Layout,
                target_layout: Option<Layout>,
                root_pkg: &Package,
                build_config: BuildConfig,
-               profiles: &'a Profiles) -> CargoResult<Context<'a>> {
+               profiles: &'a Profiles) -> CargoResult<Context<'a, 'cfg>> {
         let target = build_config.requested_target.clone();
         let target = target.as_ref().map(|s| &s[..]);
-        let (target_dylib, target_exe) = try!(Context::filename_parts(target));
+        let (target_dylib, target_exe) = try!(Context::filename_parts(target,
+                                                                      config));
         let (host_dylib, host_exe) = if build_config.requested_target.is_none() {
             (target_dylib.clone(), target_exe.clone())
         } else {
-            try!(Context::filename_parts(None))
+            try!(Context::filename_parts(None, config))
         };
         let target_triple = target.unwrap_or(config.rustc_host()).to_string();
         let engine = build_config.exec_engine.as_ref().cloned().unwrap_or({
@@ -84,7 +85,7 @@ impl<'a> Context<'a> {
             host_dylib: host_dylib,
             host_exe: host_exe,
             requirements: HashMap::new(),
-            compilation: Compilation::new(root_pkg),
+            compilation: Compilation::new(root_pkg, config),
             build_state: Arc::new(BuildState::new(&build_config, deps)),
             build_config: build_config,
             exec_engine: engine,
@@ -96,9 +97,9 @@ impl<'a> Context<'a> {
 
     /// Run `rustc` to discover the dylib prefix/suffix for the target
     /// specified as well as the exe suffix
-    fn filename_parts(target: Option<&str>)
+    fn filename_parts(target: Option<&str>, cfg: &Config)
                       -> CargoResult<(Option<(String, String)>, String)> {
-        let mut process = try!(util::process(util::rustc()));
+        let mut process = try!(util::process(cfg.rustc()));
         process.arg("-")
                .arg("--crate-name").arg("_")
                .arg("--crate-type").arg("dylib")

--- a/src/cargo/ops/cargo_rustc/engine.rs
+++ b/src/cargo/ops/cargo_rustc/engine.rs
@@ -4,7 +4,7 @@ use std::fmt;
 use std::path::Path;
 use std::process::Output;
 
-use util::{CargoResult, ProcessError, ProcessBuilder, process};
+use util::{self, CargoResult, ProcessError, ProcessBuilder, process};
 
 /// Trait for objects that can execute commands.
 pub trait ExecEngine: Send + Sync {
@@ -38,8 +38,8 @@ impl CommandPrototype {
     pub fn new(ty: CommandType) -> CargoResult<CommandPrototype> {
         Ok(CommandPrototype {
             builder: try!(match ty {
-                CommandType::Rustc => process("rustc"),
-                CommandType::Rustdoc => process("rustdoc"),
+                CommandType::Rustc => process(util::rustc()),
+                CommandType::Rustdoc => process(util::rustdoc()),
                 CommandType::Target(ref s) |
                 CommandType::Host(ref s) => process(s),
             }),

--- a/src/cargo/ops/cargo_rustc/engine.rs
+++ b/src/cargo/ops/cargo_rustc/engine.rs
@@ -4,7 +4,8 @@ use std::fmt;
 use std::path::Path;
 use std::process::Output;
 
-use util::{self, CargoResult, ProcessError, ProcessBuilder, process};
+use util::{CargoResult, ProcessError, ProcessBuilder, process};
+use util::Config;
 
 /// Trait for objects that can execute commands.
 pub trait ExecEngine: Send + Sync {
@@ -35,11 +36,12 @@ pub struct CommandPrototype {
 }
 
 impl CommandPrototype {
-    pub fn new(ty: CommandType) -> CargoResult<CommandPrototype> {
+    pub fn new(ty: CommandType, config: &Config)
+               -> CargoResult<CommandPrototype> {
         Ok(CommandPrototype {
             builder: try!(match ty {
-                CommandType::Rustc => process(util::rustc()),
-                CommandType::Rustdoc => process(util::rustdoc()),
+                CommandType::Rustc => process(config.rustc()),
+                CommandType::Rustdoc => process(config.rustdoc()),
                 CommandType::Target(ref s) |
                 CommandType::Host(ref s) => process(s),
             }),

--- a/src/cargo/ops/cargo_rustc/fingerprint.rs
+++ b/src/cargo/ops/cargo_rustc/fingerprint.rs
@@ -39,11 +39,11 @@ pub type Preparation = (Freshness, Work, Work);
 /// This function will calculate the fingerprint for a target and prepare the
 /// work necessary to either write the fingerprint or copy over all fresh files
 /// from the old directories to their new locations.
-pub fn prepare_target<'a>(cx: &mut Context<'a>,
-                          pkg: &'a Package,
-                          target: &'a Target,
-                          profile: &'a Profile,
-                          kind: Kind) -> CargoResult<Preparation> {
+pub fn prepare_target<'a, 'cfg>(cx: &mut Context<'a, 'cfg>,
+                                pkg: &'a Package,
+                                target: &'a Target,
+                                profile: &'a Profile,
+                                kind: Kind) -> CargoResult<Preparation> {
     let _p = profile::start(format!("fingerprint: {} / {}",
                                     pkg.package_id(), target.name()));
     let new = dir(cx, pkg, kind);
@@ -131,12 +131,12 @@ impl Fingerprint {
 ///
 /// Information like file modification time is only calculated for path
 /// dependencies and is calculated in `calculate_target_fresh`.
-fn calculate<'a>(cx: &mut Context<'a>,
-                 pkg: &'a Package,
-                 target: &'a Target,
-                 profile: &'a Profile,
-                 kind: Kind)
-                 -> CargoResult<Fingerprint> {
+fn calculate<'a, 'cfg>(cx: &mut Context<'a, 'cfg>,
+                       pkg: &'a Package,
+                       target: &'a Target,
+                       profile: &'a Profile,
+                       kind: Kind)
+                       -> CargoResult<Fingerprint> {
     let key = (pkg.package_id(), target, profile, kind);
     match cx.fingerprints.get(&key) {
         Some(s) => return Ok(s.clone()),

--- a/src/cargo/ops/cargo_rustc/fingerprint.rs
+++ b/src/cargo/ops/cargo_rustc/fingerprint.rs
@@ -39,11 +39,11 @@ pub type Preparation = (Freshness, Work, Work);
 /// This function will calculate the fingerprint for a target and prepare the
 /// work necessary to either write the fingerprint or copy over all fresh files
 /// from the old directories to their new locations.
-pub fn prepare_target<'a, 'b>(cx: &mut Context<'a, 'b>,
-                              pkg: &'a Package,
-                              target: &'a Target,
-                              profile: &'a Profile,
-                              kind: Kind) -> CargoResult<Preparation> {
+pub fn prepare_target<'a>(cx: &mut Context<'a>,
+                          pkg: &'a Package,
+                          target: &'a Target,
+                          profile: &'a Profile,
+                          kind: Kind) -> CargoResult<Preparation> {
     let _p = profile::start(format!("fingerprint: {} / {}",
                                     pkg.package_id(), target.name()));
     let new = dir(cx, pkg, kind);
@@ -131,12 +131,12 @@ impl Fingerprint {
 ///
 /// Information like file modification time is only calculated for path
 /// dependencies and is calculated in `calculate_target_fresh`.
-fn calculate<'a, 'b>(cx: &mut Context<'a, 'b>,
-                     pkg: &'a Package,
-                     target: &'a Target,
-                     profile: &'a Profile,
-                     kind: Kind)
-                     -> CargoResult<Fingerprint> {
+fn calculate<'a>(cx: &mut Context<'a>,
+                 pkg: &'a Package,
+                 target: &'a Target,
+                 profile: &'a Profile,
+                 kind: Kind)
+                 -> CargoResult<Fingerprint> {
     let key = (pkg.package_id(), target, profile, kind);
     match cx.fingerprints.get(&key) {
         Some(s) => return Ok(s.clone()),

--- a/src/cargo/ops/cargo_rustc/mod.rs
+++ b/src/cargo/ops/cargo_rustc/mod.rs
@@ -57,7 +57,7 @@ pub struct TargetConfig {
 /// The second element of the tuple returned is the target triple that rustc
 /// is a host for.
 pub fn rustc_version() -> CargoResult<(String, String)> {
-    let output = try!(try!(util::process("rustc"))
+    let output = try!(try!(util::process(util::rustc()))
         .arg("-vV")
         .exec_with_output());
     let output = try!(String::from_utf8(output.stdout).map_err(|_| {

--- a/src/cargo/ops/cargo_rustc/mod.rs
+++ b/src/cargo/ops/cargo_rustc/mod.rs
@@ -77,15 +77,15 @@ pub fn rustc_version() -> CargoResult<(String, String)> {
 
 // Returns a mapping of the root package plus its immediate dependencies to
 // where the compiled libraries are all located.
-pub fn compile_targets<'a, 'b>(targets: &[(&'a Target, &'a Profile)],
-                               pkg: &'a Package,
-                               deps: &PackageSet,
-                               resolve: &'a Resolve,
-                               sources: &'a SourceMap<'a>,
-                               config: &'a Config<'b>,
-                               build_config: BuildConfig,
-                               profiles: &'a Profiles)
-                               -> CargoResult<Compilation> {
+pub fn compile_targets<'a>(targets: &[(&'a Target, &'a Profile)],
+                           pkg: &'a Package,
+                           deps: &PackageSet,
+                           resolve: &'a Resolve,
+                           sources: &'a SourceMap<'a>,
+                           config: &'a Config,
+                           build_config: BuildConfig,
+                           profiles: &'a Profiles)
+                           -> CargoResult<Compilation> {
     if targets.is_empty() {
         return Ok(Compilation::new(pkg))
     }
@@ -181,10 +181,10 @@ pub fn compile_targets<'a, 'b>(targets: &[(&'a Target, &'a Profile)],
     Ok(cx.compilation)
 }
 
-fn compile<'a, 'b>(targets: &[(&'a Target, &'a Profile)],
-                   pkg: &'a Package,
-                   cx: &mut Context<'a, 'b>,
-                   jobs: &mut JobQueue<'a>) -> CargoResult<()> {
+fn compile<'a>(targets: &[(&'a Target, &'a Profile)],
+               pkg: &'a Package,
+               cx: &mut Context<'a>,
+               jobs: &mut JobQueue<'a>) -> CargoResult<()> {
     debug!("compile_pkg; pkg={}", pkg);
     let profiling_marker = profile::start(format!("preparing: {}", pkg));
 
@@ -292,10 +292,10 @@ fn compile<'a, 'b>(targets: &[(&'a Target, &'a Profile)],
     Ok(())
 }
 
-fn prepare_init<'a, 'b>(cx: &mut Context<'a, 'b>,
-                        pkg: &'a Package,
-                        jobs: &mut JobQueue<'a>,
-                        visited: &mut HashSet<&'a PackageId>) {
+fn prepare_init<'a>(cx: &mut Context<'a>,
+                    pkg: &'a Package,
+                    jobs: &mut JobQueue<'a>,
+                    visited: &mut HashSet<&'a PackageId>) {
     if !visited.insert(pkg.package_id()) { return }
 
     // Set up all dependencies

--- a/src/cargo/ops/cargo_test.rs
+++ b/src/cargo/ops/cargo_test.rs
@@ -6,8 +6,8 @@ use sources::PathSource;
 use ops::{self, ExecEngine, ProcessEngine, Compilation};
 use util::{self, CargoResult, ProcessError};
 
-pub struct TestOptions<'a, 'b: 'a> {
-    pub compile_opts: ops::CompileOptions<'a, 'b>,
+pub struct TestOptions<'a> {
+    pub compile_opts: ops::CompileOptions<'a>,
     pub no_run: bool,
 }
 

--- a/src/cargo/ops/cargo_test.rs
+++ b/src/cargo/ops/cargo_test.rs
@@ -101,10 +101,10 @@ pub fn run_benches(manifest_path: &Path,
     Ok(try!(build_and_run(manifest_path, options, &args)).err())
 }
 
-fn build_and_run(manifest_path: &Path,
-                 options: &TestOptions,
-                 test_args: &[String])
-                 -> CargoResult<Result<Compilation, ProcessError>> {
+fn build_and_run<'a>(manifest_path: &Path,
+                     options: &TestOptions<'a>,
+                     test_args: &[String])
+                     -> CargoResult<Result<Compilation<'a>, ProcessError>> {
     let config = options.compile_opts.config;
     let mut source = try!(PathSource::for_path(&manifest_path.parent().unwrap(),
                                                config));

--- a/src/cargo/sources/git/source.rs
+++ b/src/cargo/sources/git/source.rs
@@ -14,20 +14,20 @@ use sources::git::utils::{GitRemote, GitRevision};
 
 /* TODO: Refactor GitSource to delegate to a PathSource
  */
-pub struct GitSource<'a, 'b:'a> {
+pub struct GitSource<'cfg> {
     remote: GitRemote,
     reference: GitReference,
     db_path: PathBuf,
     checkout_path: PathBuf,
     source_id: SourceId,
-    path_source: Option<PathSource<'a, 'b>>,
+    path_source: Option<PathSource<'cfg>>,
     rev: Option<GitRevision>,
-    config: &'a Config<'b>,
+    config: &'cfg Config,
 }
 
-impl<'a, 'b> GitSource<'a, 'b> {
+impl<'cfg> GitSource<'cfg> {
     pub fn new(source_id: &SourceId,
-               config: &'a Config<'b>) -> GitSource<'a, 'b> {
+               config: &'cfg Config) -> GitSource<'cfg> {
         assert!(source_id.is_git(), "id is not git, id={}", source_id);
 
         let reference = match source_id.git_reference() {
@@ -141,7 +141,7 @@ pub fn canonicalize_url(url: &Url) -> Url {
     return url;
 }
 
-impl<'a, 'b> Debug for GitSource<'a, 'b> {
+impl<'cfg> Debug for GitSource<'cfg> {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         try!(write!(f, "git repo at {}", self.remote.url()));
 
@@ -152,7 +152,7 @@ impl<'a, 'b> Debug for GitSource<'a, 'b> {
     }
 }
 
-impl<'a, 'b> Registry for GitSource<'a, 'b> {
+impl<'cfg> Registry for GitSource<'cfg> {
     fn query(&mut self, dep: &Dependency) -> CargoResult<Vec<Summary>> {
         let src = self.path_source.as_mut()
                       .expect("BUG: update() must be called before query()");
@@ -160,7 +160,7 @@ impl<'a, 'b> Registry for GitSource<'a, 'b> {
     }
 }
 
-impl<'a, 'b> Source for GitSource<'a, 'b> {
+impl<'cfg> Source for GitSource<'cfg> {
     fn update(&mut self) -> CargoResult<()> {
         let actual_rev = self.remote.rev_for(&self.db_path, &self.reference);
         let should_update = actual_rev.is_err() ||

--- a/src/cargo/sources/path.rs
+++ b/src/cargo/sources/path.rs
@@ -12,19 +12,19 @@ use ops;
 use util::{self, CargoResult, internal, internal_error, human, ChainError};
 use util::{MTime, Config};
 
-pub struct PathSource<'a, 'b: 'a> {
+pub struct PathSource<'cfg> {
     id: SourceId,
     path: PathBuf,
     updated: bool,
     packages: Vec<Package>,
-    config: &'a Config<'b>,
+    config: &'cfg Config,
 }
 
 // TODO: Figure out if packages should be discovered in new or self should be
 // mut and packages are discovered in update
-impl<'a, 'b> PathSource<'a, 'b> {
-    pub fn for_path(path: &Path, config: &'a Config<'b>)
-                    -> CargoResult<PathSource<'a, 'b>> {
+impl<'cfg> PathSource<'cfg> {
+    pub fn for_path(path: &Path, config: &'cfg Config)
+                    -> CargoResult<PathSource<'cfg>> {
         trace!("PathSource::for_path; path={}", path.display());
         Ok(PathSource::new(path, &try!(SourceId::for_path(path)), config))
     }
@@ -32,8 +32,8 @@ impl<'a, 'b> PathSource<'a, 'b> {
     /// Invoked with an absolute path to a directory that contains a Cargo.toml.
     /// The source will read the manifest and find any other packages contained
     /// in the directory structure reachable by the root manifest.
-    pub fn new(path: &Path, id: &SourceId, config: &'a Config<'b>)
-               -> PathSource<'a, 'b> {
+    pub fn new(path: &Path, id: &SourceId, config: &'cfg Config)
+               -> PathSource<'cfg> {
         trace!("new; id={}", id);
 
         PathSource {
@@ -259,13 +259,13 @@ impl<'a, 'b> PathSource<'a, 'b> {
     }
 }
 
-impl<'a, 'b> Debug for PathSource<'a, 'b> {
+impl<'cfg> Debug for PathSource<'cfg> {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "the paths source")
     }
 }
 
-impl<'a, 'b> Registry for PathSource<'a, 'b> {
+impl<'cfg> Registry for PathSource<'cfg> {
     fn query(&mut self, dep: &Dependency) -> CargoResult<Vec<Summary>> {
         let mut summaries: Vec<Summary> = self.packages.iter()
                                               .map(|p| p.summary().clone())
@@ -274,7 +274,7 @@ impl<'a, 'b> Registry for PathSource<'a, 'b> {
     }
 }
 
-impl<'a, 'b> Source for PathSource<'a, 'b> {
+impl<'cfg> Source for PathSource<'cfg> {
     fn update(&mut self) -> CargoResult<()> {
         if !self.updated {
             let packages = try!(self.read_packages());

--- a/src/cargo/sources/registry.rs
+++ b/src/cargo/sources/registry.rs
@@ -180,14 +180,14 @@ use ops;
 
 static DEFAULT: &'static str = "https://github.com/rust-lang/crates.io-index";
 
-pub struct RegistrySource<'a, 'b:'a> {
+pub struct RegistrySource<'cfg> {
     source_id: SourceId,
     checkout_path: PathBuf,
     cache_path: PathBuf,
     src_path: PathBuf,
-    config: &'a Config<'b>,
+    config: &'cfg Config,
     handle: Option<http::Handle>,
-    sources: Vec<PathSource<'a, 'b>>,
+    sources: Vec<PathSource<'cfg>>,
     hashes: HashMap<(String, String), String>, // (name, vers) => cksum
     cache: HashMap<String, Vec<(Summary, bool)>>,
     updated: bool,
@@ -226,9 +226,9 @@ struct RegistryDependency {
     kind: Option<String>,
 }
 
-impl<'a, 'b> RegistrySource<'a, 'b> {
+impl<'cfg> RegistrySource<'cfg> {
     pub fn new(source_id: &SourceId,
-               config: &'a Config<'b>) -> RegistrySource<'a, 'b> {
+               config: &'cfg Config) -> RegistrySource<'cfg> {
         let hash = hex::short_hash(source_id);
         let ident = source_id.url().host().unwrap().to_string();
         let part = format!("{}-{}", ident, hash);
@@ -472,7 +472,7 @@ impl<'a, 'b> RegistrySource<'a, 'b> {
     }
 }
 
-impl<'a, 'b> Registry for RegistrySource<'a, 'b> {
+impl<'cfg> Registry for RegistrySource<'cfg> {
     fn query(&mut self, dep: &Dependency) -> CargoResult<Vec<Summary>> {
         // If this is a precise dependency, then it came from a lockfile and in
         // theory the registry is known to contain this version. If, however, we
@@ -511,7 +511,7 @@ impl<'a, 'b> Registry for RegistrySource<'a, 'b> {
     }
 }
 
-impl<'a, 'b> Source for RegistrySource<'a, 'b> {
+impl<'cfg> Source for RegistrySource<'cfg> {
     fn update(&mut self) -> CargoResult<()> {
         // If we have an imprecise version then we don't know what we're going
         // to look for, so we always atempt to perform an update here.

--- a/src/cargo/util/config.rs
+++ b/src/cargo/util/config.rs
@@ -18,9 +18,9 @@ use util::toml as cargo_toml;
 
 use self::ConfigValue as CV;
 
-pub struct Config<'a> {
+pub struct Config {
     home_path: PathBuf,
-    shell: RefCell<&'a mut MultiShell>,
+    shell: RefCell<MultiShell>,
     rustc_version: String,
     /// The current host and default target of rustc
     rustc_host: String,
@@ -29,8 +29,8 @@ pub struct Config<'a> {
     cwd: PathBuf,
 }
 
-impl<'a> Config<'a> {
-    pub fn new(shell: &'a mut MultiShell) -> CargoResult<Config<'a>> {
+impl Config {
+    pub fn new(shell: MultiShell) -> CargoResult<Config> {
         let cwd = try!(env::current_dir().chain_error(|| {
             human("couldn't get the current directory of the process")
         }));
@@ -72,7 +72,7 @@ impl<'a> Config<'a> {
         self.home_path.join("registry").join("src")
     }
 
-    pub fn shell(&self) -> RefMut<&'a mut MultiShell> {
+    pub fn shell(&self) -> RefMut<MultiShell> {
         self.shell.borrow_mut()
     }
 

--- a/src/cargo/util/config.rs
+++ b/src/cargo/util/config.rs
@@ -394,6 +394,14 @@ fn homedir() -> Option<PathBuf> {
     return cargo_home.or(user_home);
 }
 
+pub fn rustc() -> String {
+    env::var("RUSTC").unwrap_or_else(|_| "rustc".to_string())
+}
+
+pub fn rustdoc() -> String {
+    env::var("RUSTDOC").unwrap_or_else(|_| "rustdoc".to_string())
+}
+
 fn walk_tree<F>(pwd: &Path, mut walk: F) -> CargoResult<()>
     where F: FnMut(File, &Path) -> CargoResult<()>
 {

--- a/src/cargo/util/config.rs
+++ b/src/cargo/util/config.rs
@@ -2,6 +2,7 @@ use std::cell::{RefCell, RefMut, Ref, Cell};
 use std::collections::hash_map::Entry::{Occupied, Vacant};
 use std::collections::hash_map::{HashMap};
 use std::env;
+use std::ffi::OsString;
 use std::fmt;
 use std::fs::{self, File};
 use std::io::prelude::*;
@@ -27,6 +28,8 @@ pub struct Config {
     values: RefCell<HashMap<String, ConfigValue>>,
     values_loaded: Cell<bool>,
     cwd: PathBuf,
+    rustc: PathBuf,
+    rustdoc: PathBuf,
 }
 
 impl Config {
@@ -34,20 +37,29 @@ impl Config {
         let cwd = try!(env::current_dir().chain_error(|| {
             human("couldn't get the current directory of the process")
         }));
-        let (rustc_version, rustc_host) = try!(ops::rustc_version());
 
-        Ok(Config {
+        let mut cfg = Config {
             home_path: try!(homedir().chain_error(|| {
                 human("Cargo couldn't find your home directory. \
                       This probably means that $HOME was not set.")
             })),
             shell: RefCell::new(shell),
-            rustc_version: rustc_version,
-            rustc_host: rustc_host,
+            rustc_version: String::new(),
+            rustc_host: String::new(),
             cwd: cwd,
             values: RefCell::new(HashMap::new()),
             values_loaded: Cell::new(false),
-        })
+            rustc: PathBuf::from("rustc"),
+            rustdoc: PathBuf::from("rustdoc"),
+        };
+
+        cfg.rustc = try!(cfg.get_tool("rustc"));
+        cfg.rustdoc = try!(cfg.get_tool("rustdoc"));
+        let (rustc_version, rustc_host) = try!(ops::rustc_version(cfg.rustc()));
+        cfg.rustc_version = rustc_version;
+        cfg.rustc_host = rustc_host;
+
+        Ok(cfg)
     }
 
     pub fn home(&self) -> &Path { &self.home_path }
@@ -75,6 +87,10 @@ impl Config {
     pub fn shell(&self) -> RefMut<MultiShell> {
         self.shell.borrow_mut()
     }
+
+    pub fn rustc(&self) -> &Path { &self.rustc }
+
+    pub fn rustdoc(&self) -> &Path { &self.rustdoc }
 
     /// Return the output of `rustc -v verbose`
     pub fn rustc_version(&self) -> &str { &self.rustc_version }
@@ -188,6 +204,20 @@ impl Config {
             _ => unreachable!(),
         };
         Ok(())
+    }
+
+    fn get_tool(&self, tool: &str) -> CargoResult<PathBuf> {
+        let var = format!("build.{}", tool);
+        if let Some((tool, path)) = try!(self.get_string(&var)) {
+            if tool.contains("/") || (cfg!(windows) && tool.contains("\\")) {
+                return Ok(path.join(tool))
+            }
+            return Ok(PathBuf::from(tool))
+        }
+
+        let var = tool.chars().flat_map(|c| c.to_uppercase()).collect::<String>();
+        let tool = env::var_os(&var).unwrap_or_else(|| OsString::from(tool));
+        Ok(PathBuf::from(tool))
     }
 }
 
@@ -392,14 +422,6 @@ fn homedir() -> Option<PathBuf> {
     let cargo_home = env::var_os("CARGO_HOME").map(PathBuf::from);
     let user_home = env::home_dir().map(|p| p.join(".cargo"));
     return cargo_home.or(user_home);
-}
-
-pub fn rustc() -> String {
-    env::var("RUSTC").unwrap_or_else(|_| "rustc".to_string())
-}
-
-pub fn rustdoc() -> String {
-    env::var("RUSTDOC").unwrap_or_else(|_| "rustdoc".to_string())
 }
 
 fn walk_tree<F>(pwd: &Path, mut walk: F) -> CargoResult<()>

--- a/src/cargo/util/mod.rs
+++ b/src/cargo/util/mod.rs
@@ -1,4 +1,4 @@
-pub use self::config::{Config, rustc, rustdoc};
+pub use self::config::Config;
 pub use self::process_builder::{process, ProcessBuilder};
 pub use self::errors::{CargoResult, CargoError, ChainError, CliResult};
 pub use self::errors::{CliError, ProcessError};

--- a/src/cargo/util/mod.rs
+++ b/src/cargo/util/mod.rs
@@ -1,4 +1,4 @@
-pub use self::config::Config;
+pub use self::config::{Config, rustc, rustdoc};
 pub use self::process_builder::{process, ProcessBuilder};
 pub use self::errors::{CargoResult, CargoError, ChainError, CliResult};
 pub use self::errors::{CliError, ProcessError};

--- a/src/cargo/util/toml.rs
+++ b/src/cargo/util/toml.rs
@@ -277,11 +277,11 @@ impl TomlProject {
     }
 }
 
-struct Context<'a, 'b, 'c: 'b> {
+struct Context<'a, 'b> {
     deps: &'a mut Vec<Dependency>,
     source_id: &'a SourceId,
     nested_paths: &'a mut Vec<PathBuf>,
-    config: &'b Config<'c>,
+    config: &'b Config,
 }
 
 // These functions produce the equivalent of specific manifest entries. One

--- a/src/doc/config.md
+++ b/src/doc/config.md
@@ -79,9 +79,14 @@ timeout = 60000   # Timeout for each HTTP request, in milliseconds
 jobs = 1        # number of jobs to run by default (default to # cpus)
 ```
 
-# Configuration of registry cache
+# Environment Variables
 
-Cargo maintains a local cache of the registry index and of git
-checkouts of crates.  By default these are stored under
-`$HOME/.cargo`. The location can be overridden by setting the
-`CARGO_HOME` environment variable.
+Cargo recognizes a few global environment variables to configure how it runs:
+
+* `CARGO_HOME` - Cargo maintains a local cache of the registry index and of git
+  checkouts of crates.  By default these are stored under `$HOME/.cargo`, but
+  this variable overrides the location of this directory.
+* `RUSTC` - Instead of running `rustc`, Cargo will execute this specified
+  compiler instead.
+* `RUSTDOC` - Instead of running `rustdoc`, Cargo will execute this specified
+  `rustdoc` instance instead.

--- a/src/doc/config.md
+++ b/src/doc/config.md
@@ -76,7 +76,9 @@ proxy = "..."     # HTTP proxy to use for HTTP requests (defaults to none)
 timeout = 60000   # Timeout for each HTTP request, in milliseconds
 
 [build]
-jobs = 1        # number of jobs to run by default (default to # cpus)
+jobs = 1             # number of jobs to run by default (default to # cpus)
+rustc = "rustc"      # path to the compiler to execute
+rustdoc = "rustdoc"  # path to the doc generator to execute
 ```
 
 # Environment Variables

--- a/tests/test_bad_config.rs
+++ b/tests/test_bad_config.rs
@@ -102,10 +102,7 @@ test!(bad5 {
     assert_that(foo.cargo("new")
                    .arg("-v").arg("foo").cwd(&foo.root().join("foo")),
                 execs().with_status(101).with_stderr("\
-Failed to create project `foo` at `[..]`
-
-Caused by:
-  Couldn't load Cargo configuration
+Couldn't load Cargo configuration
 
 Caused by:
   failed to merge key `foo` between files:
@@ -186,10 +183,7 @@ test!(invalid_global_config {
 
     assert_that(foo.cargo_process("build").arg("-v"),
                 execs().with_status(101).with_stderr("\
-failed to parse manifest at `[..]Cargo.toml`
-
-Caused by:
-  Couldn't load Cargo configuration
+Couldn't load Cargo configuration
 
 Caused by:
   could not parse TOML configuration in `[..]config`

--- a/tests/test_cargo_compile.rs
+++ b/tests/test_cargo_compile.rs
@@ -1758,6 +1758,29 @@ test!(dashes_in_crate_name_bad {
                 execs().with_status(101));
 });
 
+test!(rustc_env_var {
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [package]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+        "#)
+        .file("src/lib.rs", "");
+    p.build();
+
+    assert_that(p.cargo("build")
+                 .env("RUSTC", "rustc-that-does-not-exist").arg("-v"),
+                execs().with_status(101)
+                       .with_stderr("\
+Could not execute process `rustc-that-does-not-exist -vV` ([..])
+
+Caused by:
+[..]
+"));
+    assert_that(&p.bin("a"), is_not(existing_file()));
+});
+
 test!(filtering {
     let p = project("foo")
         .file("Cargo.toml", r#"

--- a/tests/test_cargo_compile.rs
+++ b/tests/test_cargo_compile.rs
@@ -9,7 +9,6 @@ use support::{COMPILING, RUNNING, ProjectBuilder};
 use hamcrest::{assert_that, existing_file, is_not};
 use support::paths::CargoPathExt;
 use cargo::util::process;
-use cargo::ops::rustc_version;
 
 fn setup() {
 }
@@ -1449,7 +1448,7 @@ Caused by:
 });
 
 test!(cargo_platform_specific_dependency {
-    let (_, host) = rustc_version().unwrap();
+    let host = ::rustc_host();
     let p = project("foo")
         .file("Cargo.toml", &format!(r#"
             [project]
@@ -1776,8 +1775,7 @@ test!(rustc_env_var {
 Could not execute process `rustc-that-does-not-exist -vV` ([..])
 
 Caused by:
-[..]
-"));
+[..]".to_string() + if cfg!(windows) {"\n[..]\n"} else {"\n"}));
     assert_that(&p.bin("a"), is_not(existing_file()));
 });
 

--- a/tests/test_cargo_compile_custom_build.rs
+++ b/tests/test_cargo_compile_custom_build.rs
@@ -251,7 +251,7 @@ linked to by one package
 });
 
 test!(overrides_and_links {
-    let (_, target) = ::cargo::ops::rustc_version().unwrap();
+    let target = ::rustc_host();
 
     let p = project("foo")
         .file("Cargo.toml", r#"
@@ -302,7 +302,7 @@ test!(overrides_and_links {
 });
 
 test!(unused_overrides {
-    let (_, target) = ::cargo::ops::rustc_version().unwrap();
+    let target = ::rustc_host();
 
     let p = project("foo")
         .file("Cargo.toml", r#"
@@ -521,7 +521,7 @@ test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
 });
 
 test!(propagation_of_l_flags {
-    let (_, target) = ::cargo::ops::rustc_version().unwrap();
+    let target = ::rustc_host();
     let p = project("foo")
         .file("Cargo.toml", r#"
             [project]
@@ -579,7 +579,7 @@ test!(propagation_of_l_flags {
 });
 
 test!(propagation_of_l_flags_new {
-    let (_, target) = ::cargo::ops::rustc_version().unwrap();
+    let target = ::rustc_host();
     let p = project("foo")
         .file("Cargo.toml", r#"
             [project]
@@ -673,7 +673,7 @@ test!(build_deps_simple {
 });
 
 test!(build_deps_not_for_normal {
-    let (_, target) = ::cargo::ops::rustc_version().unwrap();
+    let target = ::rustc_host();
     let p = project("foo")
         .file("Cargo.toml", r#"
             [project]
@@ -1276,7 +1276,7 @@ test!(cfg_feedback {
 });
 
 test!(cfg_override {
-    let (_, target) = ::cargo::ops::rustc_version().unwrap();
+    let target = ::rustc_host();
 
     let p = project("foo")
         .file("Cargo.toml", r#"

--- a/tests/test_cargo_compile_plugins.rs
+++ b/tests/test_cargo_compile_plugins.rs
@@ -223,7 +223,7 @@ test!(doctest_a_plugin {
 
 // See #1515
 test!(native_plugin_dependency_with_custom_ar_linker {
-    let (_, target) = ::cargo::ops::rustc_version().unwrap();
+    let target = ::rustc_host();
 
     let foo = project("foo")
         .file("Cargo.toml", r#"

--- a/tests/test_cargo_cross_compile.rs
+++ b/tests/test_cargo_cross_compile.rs
@@ -4,7 +4,6 @@ use support::{project, execs, basic_bin_manifest};
 use support::{RUNNING, COMPILING, DOCTEST};
 use hamcrest::{assert_that, existing_file};
 use cargo::util::process;
-use cargo::ops::rustc_version;
 
 fn setup() {
 }
@@ -491,7 +490,7 @@ test!(build_script_needed_for_host_and_target {
     if disabled() { return }
 
     let target = alternate();
-    let (_, host) = rustc_version().unwrap();
+    let host = ::rustc_host();
     let p = project("foo")
         .file("Cargo.toml", r#"
             [package]

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -54,3 +54,7 @@ mod test_cargo_search;
 mod test_cargo_test;
 mod test_cargo_version;
 mod test_shell;
+
+fn rustc_host() -> String {
+    cargo::ops::rustc_version("rustc").unwrap().1
+}


### PR DESCRIPTION
These commits add two vectors through which the compiler run can be configured:

* A `RUSTC` environment variable
* A `build.rustc` configuration variable in a `.cargo/config` file