### PR TITLE
Clarify that --jobs doesn't affect parallelism when running the resulting binary

### DIFF
--- a/src/bin/bench.rs
+++ b/src/bin/bench.rs
@@ -51,6 +51,9 @@ which indicates which package should be benchmarked. If it is not given, then
 the current package is benchmarked. For more information on SPEC and its format,
 see the `cargo help pkgid` command.
 
+The --jobs argument affects the building of the benchmark executable but does
+not affect how many jobs are used when running the benchmarks.
+
 Compilation can be customized with the `bench` profile in the manifest.
 ";
 

--- a/src/bin/test.rs
+++ b/src/bin/test.rs
@@ -55,6 +55,9 @@ which indicates which package should be tested. If it is not given, then the
 current package is tested. For more information on SPEC and its format, see the
 `cargo help pkgid` command.
 
+The --jobs argument affects the building of the test executable but does
+not affect how many jobs are used when running the tests.
+
 Compilation can be configured via the `test` profile in the manifest.
 ";
 


### PR DESCRIPTION
Addresses #1591.

I believe this issue only affects `cargo bench` and `cargo test`. If it's applicable to any of the other commands, let me know and I'll amend this.