### PR TITLE
Don't update the same path source multiple times

### DIFF
--- a/src/cargo/core/registry.rs
+++ b/src/cargo/core/registry.rs
@@ -140,6 +140,11 @@ impl<'cfg> PackageRegistry<'cfg> {
         Ok(())
     }
 
+    pub fn preload(&mut self, id: &SourceId, source: Box<Source + 'cfg>) {
+        self.sources.insert(id, source);
+        self.source_ids.insert(id.clone(), (id.clone(), Kind::Locked));
+    }
+
     pub fn add_sources(&mut self, ids: &[SourceId]) -> CargoResult<()> {
         for id in ids.iter() {
             try!(self.load(id, Kind::Locked));

--- a/src/cargo/ops/cargo_fetch.rs
+++ b/src/cargo/ops/cargo_fetch.rs
@@ -14,6 +14,7 @@ pub fn fetch(manifest_path: &Path, config: &Config) -> CargoResult<()> {
     let package = try!(source.root_package());
 
     let mut registry = PackageRegistry::new(config);
+    registry.preload(package.package_id().source_id(), Box::new(source));
     let resolve = try!(ops::resolve_pkg(&mut registry, &package));
 
     let ids: Vec<PackageId> = resolve.iter().cloned().collect();

--- a/src/cargo/ops/cargo_generate_lockfile.rs
+++ b/src/cargo/ops/cargo_generate_lockfile.rs
@@ -24,6 +24,7 @@ pub fn generate_lockfile(manifest_path: &Path, config: &Config)
     try!(source.update());
     let package = try!(source.root_package());
     let mut registry = PackageRegistry::new(config);
+    registry.preload(package.package_id().source_id(), Box::new(source));
     let resolve = try!(ops::resolve_with_previous(&mut registry, &package,
                                                   Method::Everything,
                                                   None, None));
@@ -84,6 +85,7 @@ pub fn update_lockfile(manifest_path: &Path,
         None => to_avoid.extend(previous_resolve.iter()),
     }
 
+    registry.preload(package.package_id().source_id(), Box::new(source));
     let resolve = try!(ops::resolve_with_previous(&mut registry,
                                                   &package,
                                                   Method::Everything,

--- a/src/cargo/ops/cargo_package.rs
+++ b/src/cargo/ops/cargo_package.rs
@@ -178,7 +178,7 @@ fn run_verify(config: &Config, pkg: &Package, tar: &Path)
     let new_pkg = Package::new(new_manifest, &manifest_path, &new_src);
 
     // Now that we've rewritten all our path dependencies, compile it!
-    try!(ops::compile_pkg(&new_pkg, &ops::CompileOptions {
+    try!(ops::compile_pkg(&new_pkg, None, &ops::CompileOptions {
         config: config,
         jobs: None,
         target: None,

--- a/src/cargo/ops/resolve.rs
+++ b/src/cargo/ops/resolve.rs
@@ -36,8 +36,6 @@ pub fn resolve_with_previous<'a>(registry: &mut PackageRegistry,
                                  previous: Option<&'a Resolve>,
                                  to_avoid: Option<&HashSet<&'a PackageId>>)
                                  -> CargoResult<Resolve> {
-    let root = package.package_id().source_id().clone();
-    try!(registry.add_sources(&[root]));
 
     // Here we place an artificial limitation that all non-registry sources
     // cannot be locked at more than one revision. This means that if a git

--- a/src/cargo/sources/path.rs
+++ b/src/cargo/sources/path.rs
@@ -59,7 +59,6 @@ impl<'cfg> PathSource<'cfg> {
     }
 
     pub fn read_packages(&self) -> CargoResult<Vec<Package>> {
-
         if self.updated {
             Ok(self.packages.clone())
         } else if self.id.is_path() && self.id.precise().is_some() {


### PR DESCRIPTION
Updating a path source can be a possibly expensive operation (lots of
directories that need to be traversed), and currently the root path source is
updated three times:

* Once when the root package is initially loaded.
* Again when the first resolution pass happens over a graph.
* Finally a third when the second resolution pass happens over the graph.

This commit pushes through the original `Source` trait object into the
`PackageRegistry` and removes the implicit call to `add_sources`, pushing that
call up to the stack a bit.