### PR TITLE
Optimize the number of fs::metadata calls

### DIFF
--- a/src/cargo/lib.rs
+++ b/src/cargo/lib.rs
@@ -1,5 +1,5 @@
 #![deny(unused)]
-#![feature(metadata_ext)]
+#![feature(metadata_ext, file_type, dir_entry_ext)]
 #![cfg_attr(test, deny(warnings))]
 
 #[cfg(test)] extern crate hamcrest;


### PR DESCRIPTION
Traversing large directory trees can take quite some time, and this commit optimizes a few locations to reduce the number of calls to `fs::metadata`.