### PR TITLE
Allow specifying a custom output directory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,6 +1,6 @@
 [root]
 name = "cargo"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "advapi32-sys 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bufstream 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cargo"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Yehuda Katz <wycats@gmail.com>",
            "Carl Lerche <me@carllerche.com>",
            "Alex Crichton <alex@alexcrichton.com>"]

--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -14,8 +14,6 @@ use util::{CargoResult, human};
 pub struct Manifest {
     summary: Summary,
     targets: Vec<Target>,
-    target_dir: PathBuf,
-    doc_dir: PathBuf,
     links: Option<String>,
     warnings: Vec<String>,
     exclude: Vec<String>,
@@ -51,8 +49,6 @@ pub struct SerializedManifest {
     version: String,
     dependencies: Vec<SerializedDependency>,
     targets: Vec<Target>,
-    target_dir: String,
-    doc_dir: String,
 }
 
 impl Encodable for Manifest {
@@ -64,8 +60,6 @@ impl Encodable for Manifest {
                 SerializedDependency::from_dependency(d)
             }).collect(),
             targets: self.targets.clone(),
-            target_dir: self.target_dir.display().to_string(),
-            doc_dir: self.doc_dir.display().to_string(),
         }.encode(s)
     }
 }
@@ -181,7 +175,6 @@ impl Encodable for Target {
 
 impl Manifest {
     pub fn new(summary: Summary, targets: Vec<Target>,
-               target_dir: PathBuf, doc_dir: PathBuf,
                exclude: Vec<String>,
                include: Vec<String>,
                links: Option<String>,
@@ -190,8 +183,6 @@ impl Manifest {
         Manifest {
             summary: summary,
             targets: targets,
-            target_dir: target_dir,
-            doc_dir: doc_dir,
             warnings: Vec::new(),
             exclude: exclude,
             include: include,
@@ -202,14 +193,12 @@ impl Manifest {
     }
 
     pub fn dependencies(&self) -> &[Dependency] { self.summary.dependencies() }
-    pub fn doc_dir(&self) -> &Path { &self.doc_dir }
     pub fn exclude(&self) -> &[String] { &self.exclude }
     pub fn include(&self) -> &[String] { &self.include }
     pub fn metadata(&self) -> &ManifestMetadata { &self.metadata }
     pub fn name(&self) -> &str { self.package_id().name() }
     pub fn package_id(&self) -> &PackageId { self.summary.package_id() }
     pub fn summary(&self) -> &Summary { &self.summary }
-    pub fn target_dir(&self) -> &Path { &self.target_dir }
     pub fn targets(&self) -> &[Target] { &self.targets }
     pub fn version(&self) -> &Version { self.package_id().version() }
     pub fn warnings(&self) -> &[String] { &self.warnings }
@@ -224,10 +213,6 @@ impl Manifest {
 
     pub fn set_summary(&mut self, summary: Summary) {
         self.summary = summary;
-    }
-
-    pub fn set_target_dir(&mut self, target_dir: PathBuf) {
-        self.target_dir = target_dir;
     }
 }
 

--- a/src/cargo/core/package.rs
+++ b/src/cargo/core/package.rs
@@ -76,13 +76,8 @@ impl Package {
     pub fn package_id(&self) -> &PackageId { self.manifest.package_id() }
     pub fn root(&self) -> &Path { self.manifest_path.parent().unwrap() }
     pub fn summary(&self) -> &Summary { self.manifest.summary() }
-    pub fn target_dir(&self) -> &Path { self.manifest.target_dir() }
     pub fn targets(&self) -> &[Target] { self.manifest().targets() }
     pub fn version(&self) -> &Version { self.package_id().version() }
-
-    pub fn absolute_target_dir(&self) -> PathBuf {
-        self.root().join(self.target_dir())
-    }
 
     pub fn has_custom_build(&self) -> bool {
         self.targets().iter().any(|t| t.is_custom_build())

--- a/src/cargo/ops/cargo_doc.rs
+++ b/src/cargo/ops/cargo_doc.rs
@@ -54,8 +54,8 @@ pub fn doc(manifest_path: &Path,
             }
         };
 
-        let path = package.absolute_target_dir().join("doc").join(&name)
-                                                    .join("index.html");
+        let target_dir = options.compile_opts.config.target_dir(&package);
+        let path = target_dir.join("doc").join(&name).join("index.html");
         if fs::metadata(&path).is_ok() {
             open_docs(&path);
         }

--- a/src/cargo/ops/cargo_package.rs
+++ b/src/cargo/ops/cargo_package.rs
@@ -49,7 +49,8 @@ pub fn package(manifest_path: &Path,
     }
 
     let filename = format!("package/{}-{}.crate", pkg.name(), pkg.version());
-    let dst = pkg.absolute_target_dir().join(&filename);
+    let target_dir = config.target_dir(&pkg);
+    let dst = target_dir.join(&filename);
     if fs::metadata(&dst).is_ok() { return Ok(Some(dst)) }
 
     let mut bomb = Bomb { path: Some(dst.clone()) };
@@ -174,7 +175,6 @@ fn run_verify(config: &Config, pkg: &Package, tar: &Path)
     });
     let mut new_manifest = pkg.manifest().clone();
     new_manifest.set_summary(new_summary.override_id(new_pkgid));
-    new_manifest.set_target_dir(dst.join("target"));
     let new_pkg = Package::new(new_manifest, &manifest_path, &new_src);
 
     // Now that we've rewritten all our path dependencies, compile it!

--- a/src/cargo/ops/cargo_rustc/layout.rs
+++ b/src/cargo/ops/cargo_rustc/layout.rs
@@ -50,6 +50,7 @@ use std::io;
 use std::path::{PathBuf, Path};
 
 use core::Package;
+use util::Config;
 use util::hex::short_hash;
 
 pub struct Layout {
@@ -67,8 +68,9 @@ pub struct LayoutProxy<'a> {
 }
 
 impl Layout {
-    pub fn new(pkg: &Package, triple: Option<&str>, dest: &str) -> Layout {
-        let mut path = pkg.absolute_target_dir();
+    pub fn new(config: &Config, pkg: &Package, triple: Option<&str>,
+               dest: &str) -> Layout {
+        let mut path = config.target_dir(pkg);
         // Flexible target specifications often point at filenames, so interpret
         // the target triple as a Path and then just use the file stem as the
         // component for the directory name.

--- a/src/cargo/ops/cargo_rustc/mod.rs
+++ b/src/cargo/ops/cargo_rustc/mod.rs
@@ -100,9 +100,9 @@ pub fn compile_targets<'a, 'cfg: 'a>(targets: &[(&'a Target, &'a Profile)],
     } else {
         deps.iter().find(|p| p.package_id() == resolve.root()).unwrap()
     };
-    let host_layout = Layout::new(root, None, &dest);
+    let host_layout = Layout::new(config, root, None, &dest);
     let target_layout = build_config.requested_target.as_ref().map(|target| {
-        layout::Layout::new(root, Some(&target), &dest)
+        layout::Layout::new(config, root, Some(&target), &dest)
     });
 
     let mut cx = try!(Context::new(resolve, sources, deps, config,
@@ -535,20 +535,19 @@ fn prepare_rustc(package: &Package, target: &Target, profile: &Profile,
 fn rustdoc(package: &Package, target: &Target, profile: &Profile,
            cx: &mut Context) -> CargoResult<Work> {
     let kind = Kind::Target;
-    let mut doc_dir = cx.get_package(cx.resolve.root()).absolute_target_dir();
     let mut rustdoc = try!(process(CommandType::Rustdoc, package, target, cx));
     rustdoc.arg(&root_path(cx, package, target))
            .cwd(cx.config.cwd())
            .arg("--crate-name").arg(&target.crate_name());
 
+    let mut doc_dir = cx.config.target_dir(cx.get_package(cx.resolve.root()));
     if let Some(target) = cx.requested_target() {
         rustdoc.arg("--target").arg(target);
         doc_dir.push(target);
     }
 
     doc_dir.push("doc");
-
-    rustdoc.arg("-o").arg(&doc_dir);
+    rustdoc.arg("-o").arg(doc_dir);
 
     match cx.resolve.features(package.package_id()) {
         Some(features) => {

--- a/src/cargo/util/toml.rs
+++ b/src/cargo/util/toml.rs
@@ -519,8 +519,6 @@ impl TomlManifest {
         let profiles = build_profiles(&self.profile);
         let mut manifest = Manifest::new(summary,
                                          targets,
-                                         layout.root.join("target"),
-                                         layout.root.join("doc"),
                                          exclude,
                                          include,
                                          project.links.clone(),

--- a/src/doc/config.md
+++ b/src/doc/config.md
@@ -76,9 +76,10 @@ proxy = "..."     # HTTP proxy to use for HTTP requests (defaults to none)
 timeout = 60000   # Timeout for each HTTP request, in milliseconds
 
 [build]
-jobs = 1             # number of jobs to run by default (default to # cpus)
-rustc = "rustc"      # path to the compiler to execute
-rustdoc = "rustdoc"  # path to the doc generator to execute
+jobs = 1               # number of jobs to run by default (default to # cpus)
+rustc = "rustc"        # path to the compiler to execute
+rustdoc = "rustdoc"    # path to the doc generator to execute
+target-dir = "target"  # path of where to place all generated artifacts
 ```
 
 # Environment Variables
@@ -92,3 +93,5 @@ Cargo recognizes a few global environment variables to configure how it runs:
   compiler instead.
 * `RUSTDOC` - Instead of running `rustdoc`, Cargo will execute this specified
   `rustdoc` instance instead.
+* `CARGO_TARGET_DIR` - Location of where to place all generated artifacts,
+  relative to the current working directory.


### PR DESCRIPTION
This commit adds support to allow specifying a custom output directory to Cargo.
First, the `build.target-dir` configuration key is checked, and failing that the
`CARGO_TARGET_DIR` environment variable is checked, and failing that the root
package's directory joined with the directory name "target" is used.

There are a few caveats to switching target directories, however:

* If the target directory is in the current source tree, and the folder name is
  not called "target", then Cargo may walk the output directory when determining
  whether a tree is fresh.
* If the target directory is not called "target", then Cargo may look inside it
  currently for `Cargo.toml` files to learn about local packages.
* Concurrent usage of Cargo will still result in badness (#354), and this is now
  exascerbated because many Cargo projects can share the same output directory.
* The top-level crate is not cached for future compilations, so if a crate is
  built into directory `foo` and then that crate is later used as a dependency,
  it will be recompiled.

The naming limitations can be overcome in time, but for now it greatly
simplifies the crawling routines and shouldn't have much of a negative impact
other than some Cargo runtimes (which can in turn be negated by following the
"target" name convention).

Closes #482