### PR TITLE
Try to debug a failing test on the windows bots

### DIFF
--- a/tests/test_cargo_compile_git_deps.rs
+++ b/tests/test_cargo_compile_git_deps.rs
@@ -515,7 +515,7 @@ test!(two_revs_same_deps {
 
     baz.build();
 
-    assert_that(foo.cargo_process("build"),
+    assert_that(foo.cargo_process("build").arg("-v"),
                 execs().with_status(0));
     assert_that(&foo.bin("foo"), existing_file());
     assert_that(foo.process(&foo.bin("foo")), execs().with_status(0));


### PR DESCRIPTION
This test is failing on the win64 bot, and I'm not 100% sure why, so trying to
get some more info out of it.