### PR TITLE
Shorten paths in the test runner for windows

### DIFF
--- a/tests/support/paths.rs
+++ b/tests/support/paths.rs
@@ -12,9 +12,11 @@ thread_local!(static TASK_ID: usize = NEXT_ID.fetch_add(1, Ordering::SeqCst));
 
 pub fn root() -> PathBuf {
     env::current_exe().unwrap()
-                  .parent().unwrap()
+                  .parent().unwrap() // chop off exe name
+                  .parent().unwrap() // chop off 'debug'
+                  .parent().unwrap() // chop off target
                   .join(CARGO_INTEGRATION_TEST_DIR)
-                  .join(&TASK_ID.with(|my_id| format!("test-{}", my_id)))
+                  .join(&TASK_ID.with(|my_id| format!("t{}", my_id)))
 }
 
 pub fn home() -> PathBuf {

--- a/tests/test_cargo_test.rs
+++ b/tests/test_cargo_test.rs
@@ -101,7 +101,7 @@ test test ... ok
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
 
 {doctest} foo
-{running} `[..]target[..]test-[..]`
+{running} `rustdoc --test [..]lib.rs[..]`
 
 running 0 tests
 


### PR DESCRIPTION
Unfortunately paths are getting a little too long on Windows and libgit2 is
given us back the error:

      Failed to rename lockfile to 'C:/bot/slave/nightly-dist-cargo-win-gnu-64-64/build/target/x86_64-pc-windows-gnu/debug/cit/test-155/home/.cargo/git/checkouts/meta-dep-27104ee87001fd00/08c585f6f3927118da012a2d682b67a789c35211/.git/objects/pack/pack-ba5fd201f4c1be9792e6d54eef194e6b733ae719.idx': The data area passed to a system call is too small.

Windows isn't always the best at handling long paths, so this commit changes the
location of the `cit` output directory where tests are located as well as
shortening the name of each test's folder to hopefully get the folder sizes a
little under the limit.

I believe this test is only failing on the nightly bots because the folder name
for the nightly bots is longer than the folder name for the auto bots. Hurray!