### PR TITLE
Fix the detection of directories when listing files using libgit2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,6 +14,7 @@ dependencies = [
  "hamcrest 0.1.0 (git+https://github.com/carllerche/hamcrest-rust.git)",
  "kernel32-sys 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libgit2-sys 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.1.30 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ git2 = { version = "0.2", features = ["unstable"] }
 git2-curl = "0.2"
 glob = "0.2"
 libc = "0.1"
+libgit2-sys = "0.2"
 log = "0.3"
 num_cpus = "0.1"
 regex = "0.1"

--- a/src/cargo/lib.rs
+++ b/src/cargo/lib.rs
@@ -10,6 +10,7 @@ extern crate flate2;
 extern crate git2;
 extern crate glob;
 extern crate libc;
+extern crate libgit2_sys;
 extern crate num_cpus;
 extern crate regex;
 extern crate registry;

--- a/src/cargo/sources/path.rs
+++ b/src/cargo/sources/path.rs
@@ -6,7 +6,6 @@ use std::path::{Path, PathBuf};
 
 use git2;
 use glob::Pattern;
-use libc;
 
 use core::{Package, PackageId, Summary, SourceId, Source, Dependency, Registry};
 use ops;
@@ -147,8 +146,8 @@ impl<'cfg> PathSource<'cfg> {
         // the untracked files are often part of a build and may become relevant
         // as part of a future commit.
         let index_files = index.iter().map(|entry| {
-            let is_dir = entry.mode & (libc::S_IFMT as u32) ==
-                                      (libc::S_IFDIR as u32);
+            use libgit2_sys::git_filemode_t::GIT_FILEMODE_COMMIT;
+            let is_dir = entry.mode == GIT_FILEMODE_COMMIT as u32;
             (join(&root, &entry.path), Some(is_dir))
         });
         let mut opts = git2::StatusOptions::new();

--- a/tests/support/git.rs
+++ b/tests/support/git.rs
@@ -5,7 +5,8 @@ use std::path::{Path, PathBuf};
 use url::Url;
 use git2;
 
-use support::path2url;
+use cargo::util::ProcessError;
+use support::{ProjectBuilder, project, path2url};
 
 pub struct RepoBuilder {
     repo: git2::Repository,
@@ -55,4 +56,66 @@ impl RepoBuilder {
     pub fn url(&self) -> Url {
         path2url(self.repo.workdir().unwrap().to_path_buf())
     }
+}
+
+pub fn new<F>(name: &str, callback: F) -> Result<ProjectBuilder, ProcessError>
+    where F: FnOnce(ProjectBuilder) -> ProjectBuilder
+{
+    let mut git_project = project(name);
+    git_project = callback(git_project);
+    git_project.build();
+
+    let repo = git2::Repository::init(&git_project.root()).unwrap();
+    let mut cfg = repo.config().unwrap();
+    cfg.set_str("user.email", "foo@bar.com").unwrap();
+    cfg.set_str("user.name", "Foo Bar").unwrap();
+    drop(cfg);
+    add(&repo);
+    commit(&repo);
+    Ok(git_project)
+}
+
+pub fn add(repo: &git2::Repository) {
+    // FIXME(libgit2/libgit2#2514): apparently add_all will add all submodules
+    // as well, and then fail b/c they're a directory. As a stopgap, we just
+    // ignore all submodules.
+    let mut s = repo.submodules().unwrap();
+    for submodule in s.iter_mut() {
+        submodule.add_to_index(false).unwrap();
+    }
+    let mut index = repo.index().unwrap();
+    index.add_all(["*"].iter(), git2::ADD_DEFAULT,
+                  Some(&mut (|a, _b| {
+        if s.iter().any(|s| a.starts_with(s.path())) {1} else {0}
+    }))).unwrap();
+    index.write().unwrap();
+}
+
+pub fn add_submodule<'a>(repo: &'a git2::Repository, url: &str,
+                         path: &Path) -> git2::Submodule<'a>
+{
+    let path = path.to_str().unwrap().replace(r"\", "/");
+    let mut s = repo.submodule(url, Path::new(&path), false).unwrap();
+    let subrepo = s.open().unwrap();
+    let mut origin = subrepo.find_remote("origin").unwrap();
+    origin.add_fetch("refs/heads/*:refs/heads/*").unwrap();
+    origin.fetch(&[], None).unwrap();
+    origin.save().unwrap();
+    subrepo.checkout_head(None).unwrap();
+    s.add_finalize().unwrap();
+    return s;
+}
+
+pub fn commit(repo: &git2::Repository) -> git2::Oid {
+    let tree_id = repo.index().unwrap().write_tree().unwrap();
+    let sig = repo.signature().unwrap();
+    let mut parents = Vec::new();
+    match repo.head().ok().map(|h| h.target().unwrap()) {
+        Some(parent) => parents.push(repo.find_commit(parent).unwrap()),
+        None => {}
+    }
+    let parents = parents.iter().collect::<Vec<_>>();
+    repo.commit(Some("HEAD"), &sig, &sig, "test",
+                &repo.find_tree(tree_id).unwrap(),
+                &parents).unwrap()
 }


### PR DESCRIPTION
The pull request addresses issue #1663. The problem is that `libgit2` [combines][1] `S_IFDIR ` with `S_IFLNK`, and, therefore, the [strict comparison][2] based on `S_ISDIR` rejects directories.


Regards,
Ivan

[1]: https://github.com/libgit2/libgit2/blob/47f37400253210f483d84fb9c2ecf44fb5986849/src/index.c#L308
[2]: https://github.com/rust-lang/cargo/blob/06dbe6555a4a15f5912bbfc841d446dad4d417cc/src/cargo/sources/path.rs#L150