### PR TITLE
Make a freshness test more robust on OSX

### DIFF
--- a/tests/test_cargo_freshness.rs
+++ b/tests/test_cargo_freshness.rs
@@ -1,5 +1,6 @@
 use std::fs::{self, File};
 use std::io::prelude::*;
+use std::thread;
 
 use support::{project, execs, path2url};
 use support::COMPILING;
@@ -66,6 +67,7 @@ test!(modify_only_some_files {
 ", compiling = COMPILING, dir = path2url(p.root()))));
     assert_that(p.cargo("test"),
                 execs().with_status(0));
+    thread::sleep_ms(1000);
 
     assert_that(&p.bin("foo"), existing_file());
 
@@ -73,12 +75,8 @@ test!(modify_only_some_files {
     let bin = p.root().join("src/b.rs");
 
     File::create(&lib).unwrap().write_all(b"invalid rust code").unwrap();
-    lib.move_into_the_past().unwrap();
-    p.root().move_into_the_past().unwrap();
-
     File::create(&bin).unwrap().write_all(b"fn foo() {}").unwrap();
-    // p.root().move_into_the_past().unwrap();
-    // p.root().join("target").move_into_the_past().unwrap();
+    lib.move_into_the_past().unwrap();
 
     // Make sure the binary is rebuilt, not the lib
     assert_that(p.cargo("build")


### PR DESCRIPTION
Tests are often flaky because the resolution of the OSX filesystem timestamps
appears to be 1s, so we often have to manually sleep for 1s to ensure that
enough time has passed to guarantee that the timestamp is different (used in
freshness calculations).