### PR TITLE
Restore python3 support.

### DIFF
--- a/src/etc/dl-snapshot.py
+++ b/src/etc/dl-snapshot.py
@@ -31,7 +31,7 @@ with open('src/snapshots.txt') as f:
         # no need to look past the first section.
         break
 
-date = snaps.keys()[0]
+date = list(snaps.keys())[0]
 triple = sys.argv[1]
 
 ts = triple.split('-')


### PR DESCRIPTION
Explicitly convert dict.keys() to a list before fetching its first element.