### PR TITLE
Fix snapshot downloading on Python 3

### DIFF
--- a/src/etc/dl-snapshot.py
+++ b/src/etc/dl-snapshot.py
@@ -31,7 +31,7 @@ with open('src/snapshots.txt') as f:
         # no need to look past the first section.
         break
 
-date = snaps.keys()[0]
+date = current
 triple = sys.argv[1]
 
 ts = triple.split('-')


### PR DESCRIPTION
This regression, introduced in d3f590f59ff72f1d3b457ed3716483ce472053c6 in #1674, caused `make` to fail on machines where `python` is Python 3 rather than Python 2, because `dict.keys()` returns a set-like object that does not support indexing rather than a list.

`date = next(iter(snaps.keys()))` would be an adequate fix too, but I’m not particularly happy with either of them, for neither would stand up to the removal of the `break` statement: one is inadequate because dictionaries are unordered collections, the other is inadequate because `current` would refer to the *last* rather than the *first* snapshot in the file.