### PR TITLE
Blacklist project names

### DIFF
--- a/src/cargo/util/toml.rs
+++ b/src/cargo/util/toml.rs
@@ -423,6 +423,15 @@ impl TomlManifest {
             None => inferred_bin_targets(&project.name, layout)
         };
 
+        let blacklist = vec!["build", "deps", "examples", "native"];
+
+        for bin in bins.iter() {
+            if blacklist.iter().find(|&x| *x == bin.name) != None {
+                return Err(human(&format!("the binary target name `{}` is forbidden", 
+                                          bin.name)));
+            }
+        }
+
         let examples = match self.example {
             Some(ref examples) => examples.clone(),
             None => inferred_example_targets(layout),

--- a/tests/test_cargo_compile.rs
+++ b/tests/test_cargo_compile.rs
@@ -158,6 +158,29 @@ Caused by:
 "))
 });
 
+test!(cargo_compile_with_forbidden_bin_target_name {
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [package]
+            name = "foo"
+            authors = []
+            version = "0.0.0"
+
+            [[bin]]
+            name = "build"
+        "#);
+
+    assert_that(p.cargo_process("build"),
+                execs()
+                .with_status(101)
+                .with_stderr("\
+failed to parse manifest at `[..]`
+
+Caused by:
+  the binary target name `build` is forbidden
+"))
+});
+
 test!(cargo_compile_with_invalid_lib_target_name {
     let p = project("foo")
         .file("Cargo.toml", r#"


### PR DESCRIPTION
Some project names caused problems as
they already exist in target/debug. When
the projects fail to be created, the error
message was also not descriptive.

This commit adds a blacklist and a more
descriptive error message.

See #1618.