### PR TITLE
Teach publish the `--dry-run` flag

### DIFF
--- a/src/bin/publish.rs
+++ b/src/bin/publish.rs
@@ -9,6 +9,7 @@ struct Options {
     flag_manifest_path: Option<String>,
     flag_verbose: bool,
     flag_no_verify: bool,
+    flag_dry_run: bool,
 }
 
 pub const USAGE: &'static str = "
@@ -23,6 +24,7 @@ Options:
     --token TOKEN           Token to use when uploading
     --no-verify             Don't verify package tarball before publish
     --manifest-path PATH    Path to the manifest to compile
+    --dry-run               Performs all checks without uploading
     -v, --verbose           Use verbose output
 
 ";
@@ -34,11 +36,13 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
         flag_host: host,
         flag_manifest_path,
         flag_no_verify: no_verify,
+        flag_dry_run: dry,
         ..
     } = options;
 
     let root = try!(find_root_manifest_for_cwd(flag_manifest_path.clone()));
-    ops::publish(&root, config, token, host, !no_verify).map(|_| None).map_err(|err| {
+    ops::publish(&root, config, token, host,
+                 !no_verify, dry).map(|_| None).map_err(|err| {
         CliError::from_boxed(err, 101)
     })
 }


### PR DESCRIPTION
Closes #1332

Open to feedback on rewording messages and such. I tried to follow [this precedent](https://github.com/rust-lang/cargo/blob/master/src/cargo/ops/cargo_generate_lockfile.rs#L48) for erroring on conflicting flags.