### PR TITLE
Handle missing files after `cargo rustc`

### DIFF
--- a/tests/test_cargo_compile.rs
+++ b/tests/test_cargo_compile.rs
@@ -1886,3 +1886,18 @@ test!(custom_target_dir {
     assert_that(&p.root().join("target/debug").join(&exe_name),
                 existing_file());
 });
+
+test!(rustc_no_trans {
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [package]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+        "#)
+        .file("src/main.rs", "fn main() {}");
+    p.build();
+
+    assert_that(p.cargo("rustc").arg("-v").arg("--").arg("-Zno-trans"),
+                execs().with_status(0));
+});


### PR DESCRIPTION
Some flags to the compiler could cause it to stop early or not emit some files
altogether (or perhaps emit files in different locations even). Currently cargo
expects a few outputs of the compiler after `cargo rustc` is run, but this
commit alters cargo to know that when `cargo rustc` is being run that the
outputs may not exist and that's ok.

Closes #1675