### PR TITLE
Fix propagation of build script args

### DIFF
--- a/src/cargo/ops/cargo_rustc/context.rs
+++ b/src/cargo/ops/cargo_rustc/context.rs
@@ -36,8 +36,8 @@ pub struct Context<'a, 'cfg: 'a> {
                               Fingerprint>,
     pub compiled: HashSet<(&'a PackageId, &'a Target, &'a Profile)>,
     pub build_config: BuildConfig,
-    pub build_scripts: HashMap<(&'a PackageId, Kind),
-                               Vec<(&'a PackageId, Profile)>>,
+    pub build_scripts: HashMap<(&'a PackageId, Kind, &'a Profile),
+                               Vec<&'a PackageId>>,
 
     host: Layout,
     target: Option<Layout>,

--- a/src/cargo/ops/cargo_rustc/mod.rs
+++ b/src/cargo/ops/cargo_rustc/mod.rs
@@ -451,16 +451,12 @@ fn rustc(package: &Package, target: &Target, profile: &Profile,
     }
 }
 
-fn load_build_deps(cx: &Context, pkg: &Package, profile: &Profile,
-                   kind: Kind) -> Vec<PackageId> {
+fn load_build_deps(cx: &Context, pkg: &Package,
+                   profile: &Profile, kind: Kind) -> Vec<PackageId> {
     let pkg = cx.get_package(pkg.package_id());
-    let deps = match cx.build_scripts.get(&(pkg.package_id(), kind)) {
-        Some(a) => a,
-        None => return Vec::new(),
-    };
-    deps.iter().filter(|&&(_, ref dep_profile)| profile == dep_profile)
-        .map(|&(x, _)| x.clone())
-        .collect()
+    cx.build_scripts.get(&(pkg.package_id(), kind, profile)).map(|deps| {
+        deps.iter().map(|&d| d.clone()).collect::<Vec<_>>()
+    }).unwrap_or(Vec::new())
 }
 
 // For all plugin dependencies, add their -L paths (now calculated and


### PR DESCRIPTION
It looks like the recent restructuring into an O(N) pass had a regression
(reported in #1695) where deps-of-deps didn't have their build script arguments
propagated upwards. This fixes the caching logic to take into account the
profile as part of the key to ensure that we traverse targets twice if
necessary.

Closes #1695