### PR TITLE
Fix testing the non-root package

### DIFF
--- a/src/cargo/ops/cargo_rustc/custom_build.rs
+++ b/src/cargo/ops/cargo_rustc/custom_build.rs
@@ -348,9 +348,9 @@ impl BuildOutput {
 /// The given set of targets to this function is the initial set of
 /// targets/profiles which are being built.
 pub fn build_map<'b, 'cfg>(cx: &mut Context<'b, 'cfg>,
+                           pkg: &'b Package,
                            targets: &[(&Target, &'b Profile)]) {
     let mut ret = HashMap::new();
-    let pkg = cx.get_package(cx.resolve.root());
     for &(target, profile) in targets {
         build(&mut ret, Kind::Target, pkg, target, profile, cx);
         build(&mut ret, Kind::Host, pkg, target, profile, cx);

--- a/src/cargo/ops/cargo_rustc/mod.rs
+++ b/src/cargo/ops/cargo_rustc/mod.rs
@@ -117,7 +117,7 @@ pub fn compile_targets<'a, 'cfg: 'a>(targets: &[(&'a Target, &'a Profile)],
         let _p = profile::start("preparing build directories");
         try!(cx.prepare(pkg, targets));
         prepare_init(&mut cx, pkg, &mut queue, &mut HashSet::new());
-        custom_build::build_map(&mut cx, targets);
+        custom_build::build_map(&mut cx, pkg, targets);
     }
 
     // Build up a list of pending jobs, each of which represent compiling a

--- a/tests/test_cargo_compile_custom_build.rs
+++ b/tests/test_cargo_compile_custom_build.rs
@@ -3,7 +3,7 @@ use std::fs::{self, File};
 use std::io::prelude::*;
 
 use support::{project, execs};
-use support::{COMPILING, RUNNING, DOCTEST};
+use support::{COMPILING, RUNNING, DOCTEST, FRESH};
 use support::paths::CargoPathExt;
 use hamcrest::{assert_that};
 
@@ -1355,4 +1355,17 @@ running 0 tests
 test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
 
 ", compiling = COMPILING, running = RUNNING)));
+
+    assert_that(p.cargo("test").arg("-v").arg("-pb").arg("--lib"),
+                execs().with_status(0).with_stdout(&format!("\
+{compiling} b v0.5.0 ([..]
+{running} `rustc b[..]src[..]lib.rs [..] -L test[..]`
+{fresh} a v0.5.0 ([..]
+{running} `[..]b-[..]`
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
+
+", compiling = COMPILING, running = RUNNING, fresh = FRESH)));
 });


### PR DESCRIPTION
The previous overhaul of how dependencies among build dependencies were
traversed ended up picking the wrong root package when the `-p` argument was
specified to commands. This commit fixes this up by making sure the right root
package is passed along.