### PR TITLE
Teach fetch the --retry option.

### DIFF
--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -161,7 +161,7 @@ pub fn compile_pkg<'a>(package: &Package,
         let req: Vec<PackageId> = resolved_with_overrides.iter().map(|r| {
             r.clone()
         }).collect();
-        let packages = try!(registry.get(&req).chain_error(|| {
+        let packages = try!(registry.get(&req, 0).chain_error(|| {
             human("Unable to get packages from source")
         }));
 

--- a/src/cargo/ops/cargo_fetch.rs
+++ b/src/cargo/ops/cargo_fetch.rs
@@ -6,19 +6,28 @@ use ops;
 use sources::PathSource;
 use util::{CargoResult, Config, human, ChainError};
 
+/// Contains informations about how a package should be fetched.
+pub struct FetchOptions<'a> {
+    pub config: &'a Config,
+    pub num_tries: Option<u32>,
+}
+
 /// Executes `cargo fetch`.
-pub fn fetch(manifest_path: &Path, config: &Config) -> CargoResult<()> {
+pub fn fetch(manifest_path: &Path, opts: &FetchOptions) -> CargoResult<()> {
     let mut source = try!(PathSource::for_path(manifest_path.parent().unwrap(),
-                                               config));
+                                               opts.config));
     try!(source.update());
     let package = try!(source.root_package());
 
-    let mut registry = PackageRegistry::new(config);
+    let mut registry = PackageRegistry::new(opts.config);
     registry.preload(package.package_id().source_id(), Box::new(source));
     let resolve = try!(ops::resolve_pkg(&mut registry, &package));
 
     let ids: Vec<PackageId> = resolve.iter().cloned().collect();
-    try!(registry.get(&ids).chain_error(|| {
+
+    let num_tries = opts.num_tries.unwrap_or(0);
+
+    try!(registry.get(&ids, num_tries).chain_error(|| {
         human("unable to get packages from source")
     }));
     Ok(())

--- a/src/cargo/ops/mod.rs
+++ b/src/cargo/ops/mod.rs
@@ -20,7 +20,7 @@ pub use self::cargo_package::package;
 pub use self::registry::{publish, registry_configuration, RegistryConfig};
 pub use self::registry::{registry_login, search, http_proxy_exists, http_handle};
 pub use self::registry::{modify_owners, yank, OwnersOptions};
-pub use self::cargo_fetch::{fetch};
+pub use self::cargo_fetch::{fetch, FetchOptions};
 pub use self::cargo_pkgid::pkgid;
 pub use self::resolve::{resolve_pkg, resolve_with_previous};
 


### PR DESCRIPTION
cargo::core::registry.get now takes in a num_tries and attempts that
many times to download the given file.

This should fix #1602.