### PR TITLE
Fix resolution with `default-features = false`

### DIFF
--- a/src/cargo/core/resolver/mod.rs
+++ b/src/cargo/core/resolver/mod.rs
@@ -234,12 +234,14 @@ fn flag_activated(cx: &mut Context,
         }
         Method::Everything => return false,
     };
+
+    let has_default_feature = summary.features().contains_key("default");
     match cx.resolve.features(id) {
         Some(prev) => {
             features.iter().all(|f| prev.contains(f)) &&
-                (!use_default || prev.contains("default"))
+                (!use_default || prev.contains("default") || !has_default_feature)
         }
-        None => features.len() == 0,
+        None => features.len() == 0 && (!use_default || !has_default_feature)
     }
 }
 

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -134,7 +134,9 @@ impl ProjectBuilder {
 
     pub fn process<T: AsRef<OsStr>>(&self, program: T) -> ProcessBuilder {
         let mut p = process(program).unwrap();
-        p.cwd(&self.root()).env("HOME", &paths::home());
+        p.cwd(&self.root())
+         .env("HOME", &paths::home())
+         .env_remove("CARGO_HOME");
         return p;
     }
 


### PR DESCRIPTION
There was previously a bug in resolve where turning off the default set of
features would cause resolve to not correctly settle on the set of features
activated for a package. If one dependency turned off all features, and then the
next dependency to be activated only turned on the default feature, the default
feature wouldn't actually end up getting activated.

This commit alters the check to see if the package has been previously activated
to more rigorously check to see if the 'default' feature is activated
previously. If a dependency doesn't use the default feature, or if the package
itself does not have the feature "default", then the package is considered
activated, but otherwise it needs to go through another cycle of resolution.