### PR TITLE
Remove references to prefering nightly Rust.

### DIFF
--- a/src/doc/faq.md
+++ b/src/doc/faq.md
@@ -9,13 +9,6 @@ We plan to support git repositories as a source of packages forever,
 because they can be used for early development and temporary patches,
 even when people use the registry as the primary source of packages.
 
-At the moment, the Rust team is still making regular changes to the
-language, and the Rust project recommends using nightly builds. This
-means that for now, package authors make regular changes in order to
-track the latest Rust. This makes downloading the latest `master` from
-Github the best approach to getting packages at the current point in the
-community's lifecycle.
-
 # Why build crates.io rather than use Github as a registry?
 
 We think that it's very important to support multiple ways to download

--- a/src/doc/index.md
+++ b/src/doc/index.md
@@ -2,18 +2,18 @@
 
 # Installing
 
-The easiest way to get Cargo is to get the Rust nightly build by using
-the `rustup` script:
+The easiest way to get Cargo is to get the current stable release of Rust by
+using the `rustup` script:
 
 ```shell
-$ curl -sS https://static.rust-lang.org/rustup.sh | sudo bash
+$ curl -sSf https://static.rust-lang.org/rustup.sh | sh
 ```
 
-This will get you the latest Rust nightly for your platform along with
-the latest Cargo. You should run this script almost every day to get the latest updates.
+This will get you the current stable release of Rust for your platform along
+with the latest Cargo.
 
-If you are on Windows, you can directly download the latest 32bit ([Rust](https://static.rust-lang.org/dist/rust-nightly-i686-pc-windows-gnu.exe)
-and [Cargo](https://static.rust-lang.org/cargo-dist/cargo-nightly-i686-pc-windows-gnu.tar.gz)) or 64bit ([Rust](https://static.rust-lang.org/dist/rust-nightly-x86_64-pc-windows-gnu.exe) and [Cargo](https://static.rust-lang.org/cargo-dist/cargo-nightly-x86_64-pc-windows-gnu.tar.gz)) nightlies.
+If you are on Windows, you can directly download the latest 32bit ([Rust](https://static.rust-lang.org/dist/rust-1.0.0-i686-pc-windows-gnu.msi)
+and [Cargo](https://static.rust-lang.org/cargo-dist/cargo-nightly-i686-pc-windows-gnu.tar.gz)) or 64bit ([Rust](https://static.rust-lang.org/dist/rust-1.0.0-x86_64-pc-windows-gnu.msi) and [Cargo](https://static.rust-lang.org/cargo-dist/cargo-nightly-x86_64-pc-windows-gnu.tar.gz)) Rust stable releases or Cargo nightlies.
 
 Alternatively, you can build Cargo from source.
 


### PR DESCRIPTION
Change references to the current stable Rust. Also correct Windows
install links to point to the new .msi installers.

I totally removed the nightly paragraph from the FAQ as I couldn't think of anything to replace it with.