### PR TITLE
External crate is gcc, not cc

### DIFF
--- a/src/doc/build-script.md
+++ b/src/doc/build-script.md
@@ -350,16 +350,24 @@ portable, and standardized. For example, the build script could be written as:
 ```rust,ignore
 // build.rs
 
-// Bring in a dependency on an externally maintained `cc` package which manages
+// Bring in a dependency on an externally maintained `gcc` package which manages
 // invoking the C compiler.
-extern crate cc;
+extern crate gcc;
 
 fn main() {
-    cc::compile_library("libhello.a", &["src/hello.c"]).unwrap();
+    gcc::compile_library("libhello.a", &["src/hello.c"]).unwrap();
 }
 ```
 
-This example is a little hand-wavy, but we can assume that the `cc` crate
+The `gcc` package becomes available to the build script by adding the following
+to Cargo.toml:
+
+```
+[build-dependencies]
+gcc = "*"
+```
+
+This example is a little hand-wavy, but we can assume that the `gcc` crate
 performs tasks such as:
 
 * It invokes the appropriate compiler (MSVC for windows, `gcc` for MinGW, `cc`


### PR DESCRIPTION
I couldn't get the examples to work with `extern crate cc;`, but the `gcc` crate seemed to do the job. I also added instructions for how to make that package available.

I'm not certain this is the intended crate, though. If that's not the case, I'd be interested to know what `cc` crate is intended.