### PR TITLE
Fix build on MSVC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,9 +15,9 @@ dependencies = [
  "hamcrest 0.1.0 (git+https://github.com/carllerche/hamcrest-rust.git)",
  "kernel32-sys 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "libgit2-sys 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libgit2-sys 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "num_cpus 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.1.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "registry 0.1.0",
  "rustc-serialize 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -26,10 +26,10 @@ dependencies = [
  "tempdir 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "term 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "threadpool 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.2.35 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -37,7 +37,7 @@ name = "advapi32-sys"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "winapi 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -55,7 +55,7 @@ name = "curl"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "curl-sys 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "curl-sys 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl-sys 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -64,11 +64,11 @@ dependencies = [
 
 [[package]]
 name = "curl-sys"
-version = "0.1.22"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "libz-sys 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libz-sys 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl-sys 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -108,7 +108,7 @@ dependencies = [
 
 [[package]]
 name = "gcc"
-version = "0.3.5"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -118,7 +118,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "libgit2-sys 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libgit2-sys 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.2.35 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -148,7 +148,7 @@ name = "kernel32-sys"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "winapi 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -158,12 +158,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.2.14"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "libssh2-sys 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "libz-sys 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libssh2-sys 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libz-sys 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl-sys 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -178,18 +178,18 @@ dependencies = [
 
 [[package]]
 name = "libssh2-sys"
-version = "0.1.24"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "libz-sys 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libz-sys 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl-sys 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "libz-sys"
-version = "0.1.3"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -214,16 +214,15 @@ name = "miniz-sys"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "gcc 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gcc 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "num_cpus"
-version = "0.1.0"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "gcc 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -232,7 +231,7 @@ name = "openssl-sys"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "gcc 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gcc 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "libressl-pnacl-sys 2.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -309,7 +308,7 @@ version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -319,10 +318,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "time"
-version = "0.1.25"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "gcc 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gcc 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -345,7 +344,7 @@ dependencies = [
 
 [[package]]
 name = "winapi"
-version = "0.1.17"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,17 +10,20 @@ name = "cargo"
 path = "src/cargo/lib.rs"
 
 [dependencies]
+advapi32-sys = "0.1"
 curl = "0.2"
 docopt = "0.6"
 env_logger = "0.3"
+filetime = "0.1"
 flate2 = "0.2"
 git2 = "0.2"
 git2-curl = "0.2"
 glob = "0.2"
+kernel32-sys = "0.1"
 libc = "0.1"
 libgit2-sys = "0.2"
 log = "0.3"
-num_cpus = "0.1"
+num_cpus = "0.2"
 regex = "0.1"
 registry = { path = "src/registry" }
 rustc-serialize = "0.3"
@@ -31,12 +34,7 @@ threadpool = "0.1"
 time = "0.1"
 toml = "0.1"
 url = "0.2"
-filetime = "0.1"
-
-[target.i686-pc-windows-gnu]
-dependencies = { winapi = "0.1", advapi32-sys = "0.1", kernel32-sys = "0.1" }
-[target.x86_64-pc-windows-gnu]
-dependencies = { winapi = "0.1", advapi32-sys = "0.1", kernel32-sys = "0.1" }
+winapi = "0.1"
 
 [dev-dependencies]
 tempdir = "0.3"

--- a/Makefile.in
+++ b/Makefile.in
@@ -53,6 +53,19 @@ BIN_TARGETS := cargo
 BIN_TARGETS := $(BIN_TARGETS:src/bin/%.rs=%)
 BIN_TARGETS := $(filter-out cargo,$(BIN_TARGETS))
 
+ifdef CFG_MSVC_INCLUDE_PATH
+export INCLUDE := $(CFG_MSVC_INCLUDE_PATH)
+endif
+ifdef CFG_MSVC_LIB_PATH
+export LIB := $(CFG_MSVC_LIB_PATH)
+endif
+ifdef CFG_MSVC_BIN
+export PATH := $(CFG_MSVC_BIN):$(PATH)
+endif
+ifdef CFG_MSVC_WINDOWS_SDK_DIR
+export PATH := $(CFG_MSVC_WINDOWS_SDK_DIR):$(PATH)
+endif
+
 define DIST_TARGET
 ifdef CFG_ENABLE_OPTIMIZE
 TARGET_$(1) = $$(TARGET_ROOT)/$(1)/release

--- a/configure
+++ b/configure
@@ -369,6 +369,52 @@ if [ "$CFG_SRC_DIR" != "$CFG_BUILD_DIR" ]; then
     err "cargo does not currently support an out-of-tree build dir"
 fi
 
+for i in $CFG_TARGET
+do
+    case $i in
+        x86_64-*-msvc)
+            # Use the REG program to figure out where VS is installed
+            # We need to figure out where cl.exe and link.exe are, so we do some
+            # munging and some probing here. We also look for the default
+            # INCLUDE and LIB variables for MSVC so we can set those in the
+            # build system as well.
+            install=$(reg QUERY \
+                       'HKLM\SOFTWARE\Wow6432Node\Microsoft\VisualStudio\12.0' \
+                       -v InstallDir)
+            need_ok "couldn't find visual studio install root"
+            CFG_MSVC_ROOT=$(echo "$install" | grep InstallDir | sed 's/.*REG_SZ[ ]*//')
+            CFG_MSVC_ROOT=$(dirname "$CFG_MSVC_ROOT")
+            CFG_MSVC_ROOT=$(dirname "$CFG_MSVC_ROOT")
+            CFG_MSVC_BIN="${CFG_MSVC_ROOT}/VC/bin/amd64"
+            CFG_MSVC_CL="${CFG_MSVC_BIN}/cl.exe"
+            CFG_MSVC_LIB="${CFG_MSVC_BIN}/lib.exe"
+            CFG_MSVC_LINK="${CFG_MSVC_BIN}/link.exe"
+
+            vcvarsall="${CFG_MSVC_ROOT}/VC/vcvarsall.bat"
+            CFG_MSVC_INCLUDE_PATH=$(cmd /c "\"$vcvarsall\" amd64 && cmd /c echo %INCLUDE%")
+            need_ok "failed to learn about MSVC's INCLUDE"
+            CFG_MSVC_LIB_PATH=$(cmd /c "\"$vcvarsall\" amd64 && cmd /c echo %LIB%")
+            need_ok "failed to learn about MSVC's LIB"
+            CFG_MSVC_WINDOWS_SDK_DIR=$(cmd /c \
+                "\"$vcvarsall\" amd64 && cmd /c echo %WindowsSdkDir%")
+            need_ok "failed to learn about MSVC's WindowsSdkDir"
+            export CFG_MSVC_WINDOWS_SDK_DIR="${CFG_MSVC_WINDOWS_SDK_DIR}bin/x64"
+
+            putvar CFG_MSVC_ROOT
+            putvar CFG_MSVC_BIN
+            putvar CFG_MSVC_CL
+            putvar CFG_MSVC_LIB
+            putvar CFG_MSVC_LINK
+            putvar CFG_MSVC_INCLUDE_PATH
+            putvar CFG_MSVC_LIB_PATH
+            putvar CFG_MSVC_WINDOWS_SDK_DIR
+            ;;
+
+        *)
+            ;;
+    esac
+done
+
 if [ ! -z "$CFG_ENABLE_NIGHTLY" ]; then
     if [ ! -f .cargo/config ]; then
         mkdir -p .cargo

--- a/src/etc/dl-snapshot.py
+++ b/src/etc/dl-snapshot.py
@@ -72,7 +72,7 @@ triple = "%s-%s-%s" % (arch, vendor, target_os)
 hash = snaps[date][platform]
 
 tarball = 'cargo-nightly-' + triple + '.tar.gz'
-url = 'https://static-rust-lang-org.s3.amazonaws.com/cargo-dist/%s/%s' % \
+url = 'https://static.rust-lang.org/cargo-dist/%s/%s' % \
   (date.strip(), tarball)
 dl_path = "target/dl/" + tarball
 dst = "target/snapshot"


### PR DESCRIPTION
* Download all snapshots and such from static.rust-lang.org (drive-by fix)
* Update dependencies to work and build on MSVC
  * ssh2-sys uses `nmake` to build libssh2
  * libgit2-sys uses `cmake` to build libgit2
  * curl-sys uses `nmake` to build libcurl
  * libz-sys uses `nmake` to build zlib
  * miniz-sys uses `gcc-rs` to drive `cl.exe` manually
  * term updated to pick up windows-specific deps on MSVC
* Updated .travis.install.deps.sh to install MSVC target libraries on Windows,
  so the compiler can be used to target MSVC. A 64-bit target is now used by
  default as well.
* Updated the configure script and Makefile to set appropriate environment
  variables to build Cargo from a MSYS shell with a MSVC target. This is similar
  to how Rust bootstraps on MSVC as well.

With this commit Cargo can successfully bootstrap itself on MSVC (use the MSVC
product to build itself again). The tests currently do not pass because
unwinding is not implemented, but soon!

Closes #1725