### PR TITLE
Filter statuses only by the relevant path

### DIFF
--- a/src/cargo/sources/path.rs
+++ b/src/cargo/sources/path.rs
@@ -153,6 +153,9 @@ impl<'cfg> PathSource<'cfg> {
         });
         let mut opts = git2::StatusOptions::new();
         opts.include_untracked(true);
+        if let Some(suffix) = util::without_prefix(pkg_path, &root) {
+            opts.pathspec(suffix);
+        }
         let statuses = try!(repo.statuses(Some(&mut opts)));
         let untracked = statuses.iter().map(|entry| {
             (join(&root, entry.path_bytes()), None)


### PR DESCRIPTION
This enables libgit2 to not traverse the majority of the tree, saving a lot of
otherwise unnecessary syscalls.

For me this locally reduced the `cargo test` time of winapi-rs from 1.2s to 0.27s