### PR TITLE
Implement cargo project templates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,6 +17,7 @@ dependencies = [
  "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "libgit2-sys 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mustache 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.1.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "registry 0.1.0",
@@ -216,6 +217,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "gcc 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "mustache"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "log 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ time = "0.1"
 toml = "0.1"
 url = "0.2"
 winapi = "0.1"
+mustache = "0.6.1"
 
 [dev-dependencies]
 tempdir = "0.3"

--- a/src/bin/new.rs
+++ b/src/bin/new.rs
@@ -9,6 +9,7 @@ struct Options {
     flag_bin: bool,
     arg_path: String,
     flag_name: Option<String>,
+    flag_template: Option<String>,
     flag_vcs: Option<ops::VersionControl>,
 }
 
@@ -20,31 +21,31 @@ Usage:
     cargo new -h | --help
 
 Options:
-    -h, --help          Print this message
-    --vcs <vcs>         Initialize a new repository for the given version
-                        control system (git or hg) or do not initialize any version
-                        control at all (none) overriding a global configuration.
-    --bin               Use a binary instead of a library template
-    --name <name>       Set the resulting package name
-    -v, --verbose       Use verbose output
+    -h, --help             Print this message
+    --vcs <vcs>            Initialize a new repository for the given version
+                           control system (git or hg) or do not initialize any version
+                           control at all (none) overriding a global configuration.
+    --bin                  Use a binary instead of a library template
+    --name <name>          Set the resulting package name
+    --template <template>  Use a specified template
+    -v, --verbose          Use verbose output
 ";
 
 pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
     debug!("executing; cmd=cargo-new; args={:?}", env::args().collect::<Vec<_>>());
     config.shell().set_verbose(options.flag_verbose);
 
-    let Options { flag_bin, arg_path, flag_name, flag_vcs, .. } = options;
+    let Options { flag_bin, arg_path, flag_name, flag_vcs, flag_template, .. } = options;
 
     let opts = ops::NewOptions {
         version_control: flag_vcs,
         bin: flag_bin,
         path: &arg_path,
         name: flag_name.as_ref().map(|s| s.as_ref()),
+        template: flag_template.as_ref().map(|s| s.as_ref()),
     };
 
     ops::new(opts, config).map(|_| None).map_err(|err| {
         CliError::from_boxed(err, 101)
     })
 }
-
-

--- a/src/cargo/lib.rs
+++ b/src/cargo/lib.rs
@@ -22,6 +22,7 @@ extern crate threadpool;
 extern crate time;
 extern crate toml;
 extern crate url;
+extern crate mustache;
 
 use std::env;
 use std::error::Error;

--- a/src/cargo/ops/cargo_new.rs
+++ b/src/cargo/ops/cargo_new.rs
@@ -177,7 +177,8 @@ fn mk(config: &Config, path: &Path, name: &str,
             let repo_name = match path.components().last().unwrap() {
                 Component::Normal(p) => p,
                 _ => {
-                    return Err(human(format!("Could not determine repository name from: {}", path.display())))
+                    return Err(human(format!(
+                        "Could not determine repository name from: {}", path.display())))
                 }
             };
             let template_path = template_dir.join(repo_name);
@@ -185,7 +186,8 @@ fn mk(config: &Config, path: &Path, name: &str,
             match Repository::clone(template, &*template_path) {
                 Ok(_) => {},
                 Err(e) => {
-                    return Err(human(format!("Failed to clone repository: {} - {}", path.display(), e)))
+                    return Err(human(format!(
+                        "Failed to clone repository: {} - {}", path.display(), e)))
                 }
             };
 

--- a/src/cargo/sources/git/utils.rs
+++ b/src/cargo/sources/git/utils.rs
@@ -146,7 +146,7 @@ impl GitRemote {
         fetch(dst, &url, refspec)
     }
 
-    pub fn clone_into(&self, dst: &Path) -> CargoResult<git2::Repository> {
+    fn clone_into(&self, dst: &Path) -> CargoResult<git2::Repository> {
         let url = self.url.to_string();
         if fs::metadata(&dst).is_ok() {
             try!(fs::remove_dir_all(dst));
@@ -159,7 +159,7 @@ impl GitRemote {
 }
 
 impl GitDatabase {
-    pub fn path<'a>(&'a self) -> &'a Path {
+    fn path<'a>(&'a self) -> &'a Path {
         &self.path
     }
 

--- a/src/cargo/sources/git/utils.rs
+++ b/src/cargo/sources/git/utils.rs
@@ -146,7 +146,7 @@ impl GitRemote {
         fetch(dst, &url, refspec)
     }
 
-    fn clone_into(&self, dst: &Path) -> CargoResult<git2::Repository> {
+    pub fn clone_into(&self, dst: &Path) -> CargoResult<git2::Repository> {
         let url = self.url.to_string();
         if fs::metadata(&dst).is_ok() {
             try!(fs::remove_dir_all(dst));
@@ -159,7 +159,7 @@ impl GitRemote {
 }
 
 impl GitDatabase {
-    fn path<'a>(&'a self) -> &'a Path {
+    pub fn path<'a>(&'a self) -> &'a Path {
         &self.path
     }
 

--- a/src/cargo/util/config.rs
+++ b/src/cargo/util/config.rs
@@ -64,6 +64,10 @@ impl Config {
 
     pub fn home(&self) -> &Path { &self.home_path }
 
+    pub fn template_path(&self) -> PathBuf {
+        self.home_path.join("templates")
+    }
+
     pub fn git_db_path(&self) -> PathBuf {
         self.home_path.join("git").join("db")
     }

--- a/src/doc/guide.md
+++ b/src/doc/guide.md
@@ -35,6 +35,9 @@ We're passing `--bin` because we're making a binary program: if we
 were making a library, we'd leave it off. If you'd like to not initialize a new
 git repository as well (the default), you can also pass `--vcs none`.
 
+You can also use your own template to scaffold cargo projects! See the
+[Templates](#templates) section for more details.
+
 Let's check out what Cargo has generated for us:
 
 ```shell
@@ -439,3 +442,62 @@ To test your project on Travis-CI, here is a sample `.travis.yml` file:
 ```
 language: rust
 ```
+
+# Templates
+
+Cargo uses the mustache library to compile the templates used to scaffold
+projects. By default, there are only two templates available, `bin` and `lib`.
+These are used by cargo to create the standard project structure.
+
+You can also specify other templates from which to scaffold your project. The
+`--template` argument to `cargo new` accepts either a template name that you
+have downloaded on your system, or a URL to a remote Git repository containing
+the project template.
+
+```
+# use the mytemplate template which is located in .cargo/templates/mytemplate
+$ cargo new myproj --template mytemplate
+
+# download the template called mytemplate from your github package
+$ cargo new myproj --template http://github.com/you/mytemplate
+```
+
+## Creating new templates
+
+A cargo template is just a folder containing one or more files. Usually, there
+is a `Cargo.toml` and a `src` directory. Each file in the template directory
+will be treated as a mustache template. This means you can use mustache
+variables wherever you want dynamic content, and cargo will render the proper
+values. Let's create a simple example. Create a new folder called `mytemplate`.
+Add the following files:
+
+```toml
+# Cargo.toml
+[project]
+name = "{{name}}"
+version = "0.1.0"
+authors = [{{{authors}}}]
+```
+
+```rust
+// src/main.rs
+fn main() {
+    prinln!("This is the {{name}} project!");
+}
+```
+
+Upload this to a public git repository and anyone can now use it to start their
+projects with this command:
+
+```
+$ cargo new proj --template http://your/project/repo
+```
+
+## Available variables
+
+The variables available for use are:
+
+- name: the name of the project
+- authors: the toml formatted name of the project author
+
+In the future, more variables may be added. Suggestions welcome!

--- a/src/etc/_cargo
+++ b/src/etc/_cargo
@@ -126,6 +126,7 @@ case $state in
                     '(-h, --help)'{-h,--help}'[show help message]' \
                     '--hg[initialize new mercurial repo]' \
                     '--no-git[no new git repo]' \
+                    '--template[template from which to scaffold your project]' \
                     '(-v, --verbose)'{-v,--verbose}'[use verbose output]' \
                     ;;
 
@@ -284,7 +285,7 @@ regexp-replace manifest '\{"root":"|"\}' ''
 echo $manifest
 }
 
-# Extracts the values of "name" from the array given in $1 and shows them as 
+# Extracts the values of "name" from the array given in $1 and shows them as
 # command line options for completion
 _get_names_from_array()
 {
@@ -303,7 +304,7 @@ _get_names_from_array()
     do
         if [[ $last_line == "[[$block_name]]" ]]; then
             in_block=true
-        else 
+        else
             if [[ $last_line =~ '.*\[\[.*' ]]; then
                 in_block=false
             fi
@@ -314,7 +315,7 @@ _get_names_from_array()
                 regexp-replace line '^.*name *= *|"' ""
                 names+=$line
             fi
-        fi 
+        fi
 
         last_line=$line
     done < $manifest

--- a/src/etc/cargo.bashcomp.sh
+++ b/src/etc/cargo.bashcomp.sh
@@ -24,7 +24,7 @@ _cargo()
 	local opt__git_checkout="$opt_common --reference= --url="
 	local opt__locate_project="$opt_mani -h --help"
 	local opt__login="$opt_common --host"
-	local opt__new="$opt_common --vcs --bin --name"
+	local opt__new="$opt_common --vcs --bin --name --template"
 	local opt__owner="$opt_common -a --add -r --remove -l --list --index --token"
 	local opt__pkgid="${opt__fetch}"
 	local opt__publish="$opt_common $opt_mani --host --token --no-verify"


### PR DESCRIPTION
Project templates allow users to define custom templates which can be
used to scaffold projects. These templates consists of a directory of
files, each of which will be treated as a mustache template.

Example:

    cargo new myproject --template=http://github.com/someone/nickel-template

This would download the template called 'nickel-template' to
~/.cargo/templates/nickel-template. Each file in that directory would
then be compiled and rendered to the new project directory created by
cargo. Once the template is downloaded, future uses can just reference
it by name:

    cargo new webapp --template nickel-template

Certain files will be ignored in template directories. These are namely
files which mustache will not be able to compile. Image files, for
example are all ignored.

Closes issue #396