### PR TITLE
Get `make test` working on MSVC

### DIFF
--- a/tests/test_cargo_bench.rs
+++ b/tests/test_cargo_bench.rs
@@ -154,6 +154,7 @@ test!(many_similar_names {
 
 test!(cargo_bench_failing_test {
     if !::is_nightly() { return }
+    if !::can_panic() { return }
 
     let p = project("foo")
         .file("Cargo.toml", &basic_bin_manifest("foo"))

--- a/tests/test_cargo_compile.rs
+++ b/tests/test_cargo_compile.rs
@@ -722,24 +722,12 @@ test!(many_crate_types_old_style_lib_location {
         .file("src/foo.rs", r#"
             pub fn foo() {}
         "#);
-    assert_that(p.cargo_process("build"),
-                execs().with_status(0));
+    assert_that(p.cargo_process("build"), execs().with_status(0));
 
-    let files = fs::read_dir(&p.root().join("target/debug")).unwrap();
-    let mut files: Vec<String> = files.map(|e| e.unwrap().path()).filter_map(|f| {
-        match f.file_name().unwrap().to_str().unwrap() {
-            "build" | "examples" | "deps" => None,
-            s if s.contains("fingerprint") || s.contains("dSYM") => None,
-            s => Some(s.to_string())
-        }
-    }).collect();
-    files.sort();
-    let file0 = &files[0];
-    let file1 = &files[1];
-    println!("{} {}", file0, file1);
-    assert!(file0.ends_with(".rlib") || file1.ends_with(".rlib"));
-    assert!(file0.ends_with(env::consts::DLL_SUFFIX) ||
-            file1.ends_with(env::consts::DLL_SUFFIX));
+    assert_that(&p.root().join("target/debug/libfoo.rlib"), existing_file());
+    let fname = format!("{}foo{}", env::consts::DLL_PREFIX,
+                        env::consts::DLL_SUFFIX);
+    assert_that(&p.root().join("target/debug").join(&fname), existing_file());
 });
 
 test!(many_crate_types_correct {
@@ -763,21 +751,10 @@ test!(many_crate_types_correct {
     assert_that(p.cargo_process("build"),
                 execs().with_status(0));
 
-    let files = fs::read_dir(&p.root().join("target/debug")).unwrap();
-    let mut files: Vec<String> = files.map(|f| f.unwrap().path()).filter_map(|f| {
-        match f.file_name().unwrap().to_str().unwrap() {
-            "build" | "examples" | "deps" => None,
-            s if s.contains("fingerprint") || s.contains("dSYM") => None,
-            s => Some(s.to_string())
-        }
-    }).collect();
-    files.sort();
-    let file0 = &files[0];
-    let file1 = &files[1];
-    println!("{} {}", file0, file1);
-    assert!(file0.ends_with(".rlib") || file1.ends_with(".rlib"));
-    assert!(file0.ends_with(env::consts::DLL_SUFFIX) ||
-            file1.ends_with(env::consts::DLL_SUFFIX));
+    assert_that(&p.root().join("target/debug/libfoo.rlib"), existing_file());
+    let fname = format!("{}foo{}", env::consts::DLL_PREFIX,
+                        env::consts::DLL_SUFFIX);
+    assert_that(&p.root().join("target/debug").join(&fname), existing_file());
 });
 
 test!(unused_keys {

--- a/tests/test_cargo_compile_plugins.rs
+++ b/tests/test_cargo_compile_plugins.rs
@@ -218,7 +218,9 @@ test!(doctest_a_plugin {
             name = "bar"
             plugin = true
         "#)
-        .file("bar/src/lib.rs", "");
+        .file("bar/src/lib.rs", r#"
+            pub fn bar() {}
+        "#);
 
     assert_that(p.cargo_process("test").arg("-v"),
                 execs().with_status(0));

--- a/tests/test_cargo_test.rs
+++ b/tests/test_cargo_test.rs
@@ -164,6 +164,8 @@ test!(many_similar_names {
 });
 
 test!(cargo_test_failing_test {
+    if !::can_panic() { return }
+
     let p = project("foo")
         .file("Cargo.toml", &basic_bin_manifest("foo"))
         .file("src/foo.rs", r#"
@@ -690,7 +692,7 @@ test!(bin_there_for_integration {
             authors = []
         "#)
         .file("src/main.rs", "
-            fn main() { panic!(); }
+            fn main() { std::process::exit(101); }
             #[test] fn main_test() {}
         ")
         .file("tests/foo.rs", r#"

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -65,3 +65,8 @@ fn is_nightly() -> bool {
     let version_info = cargo::ops::rustc_version("rustc").unwrap().0;
     version_info.contains("-nightly") || version_info.contains("-dev")
 }
+
+fn can_panic() -> bool {
+    let host = cargo::ops::rustc_version("rustc").unwrap().1;
+    !host.contains("msvc")
+}


### PR DESCRIPTION
This commit updates Cargo's unit tests to pass `make check` entirely on MSVC
targets. Two tests are ignored on MSVC as it requires panicking to be
implemented, which currently isn't, but otherwise Cargo is fully functional.