### PR TITLE
Add `--with` option to cargo run

### DIFF
--- a/src/bin/run.rs
+++ b/src/bin/run.rs
@@ -15,6 +15,7 @@ struct Options {
     flag_quiet: bool,
     flag_color: Option<String>,
     flag_release: bool,
+    flag_with: Option<String>,
     arg_args: Vec<String>,
 }
 
@@ -34,6 +35,7 @@ Options:
     --no-default-features   Do not build the `default` feature
     --target TRIPLE         Build for the target triple
     --manifest-path PATH    Path to the manifest to execute
+    -w, --with CMD          Run CMD and pass the path to the binary as its argument (see below)
     -v, --verbose           Use verbose output
     -q, --quiet             No output printed to stdout
     --color WHEN            Coloring: auto, always, never
@@ -46,6 +48,9 @@ and `--example` specifies the example target to run. At most one of `--bin` or
 All of the trailing arguments are passed to the binary to run. If you're passing
 arguments to both Cargo and the binary, the ones after `--` go to the binary,
 the ones before go to Cargo.
+If the -w option is used, arguments are passed to CMD instead;
+all arguments equal to \"{}\" are replaced with the binary path or,
+if no such argument is passed, the binary path is appended as the last argument.
 ";
 
 pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
@@ -86,6 +91,7 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
 
     let err = try!(ops::run(&root,
                             &compile_opts,
+                            options.flag_with,
                             &options.arg_args).map_err(|err| {
         CliError::from_boxed(err, 101)
     }));

--- a/src/cargo/ops/cargo_run.rs
+++ b/src/cargo/ops/cargo_run.rs
@@ -6,6 +6,7 @@ use core::Package;
 
 pub fn run(manifest_path: &Path,
            options: &ops::CompileOptions,
+           with: Option<String>,
            args: &[String]) -> CargoResult<Option<ProcessError>> {
     let config = options.config;
     let root = try!(Package::for_path(manifest_path, config));
@@ -49,10 +50,33 @@ pub fn run(manifest_path: &Path,
         Some(path) => path.to_path_buf(),
         None => exe.to_path_buf(),
     };
-    let mut process = try!(compile.target_process(exe, &root))
-                                  .into_process_builder();
-    process.args(args).cwd(config.cwd());
 
-    try!(config.shell().status("Running", process.to_string()));
-    Ok(process.exec().err())
+    match with {
+        Some(cmd) => {
+            let mut process = try!(compile.target_process(cmd, &root))
+                                          .into_process_builder();
+
+            let mut exe_passed = false;
+            for arg in args {
+                if arg == "{}" {
+                    exe_passed = true;
+                    process.arg(exe);
+                }
+                else { process.arg(arg); }
+            }
+            if !exe_passed { process.arg(exe); }
+
+            try!(config.shell().status("Running", process.to_string()));
+            Ok(process.exec().err())
+        },
+        None => {
+            let mut process = try!(compile.target_process(exe, &root))
+                                          .into_process_builder();
+
+            process.args(args).cwd(config.cwd());
+
+            try!(config.shell().status("Running", process.to_string()));
+            Ok(process.exec().err())
+        }
+    }
 }

--- a/src/cargo/ops/cargo_run.rs
+++ b/src/cargo/ops/cargo_run.rs
@@ -60,7 +60,7 @@ pub fn run(manifest_path: &Path,
             for arg in args {
                 if arg == "{}" {
                     exe_passed = true;
-                    process.arg(exe);
+                    process.arg(exe.clone());
                 }
                 else { process.arg(arg); }
             }


### PR DESCRIPTION
Implementing what I had in mind in #1726

There are likely imperfections in design / implementation, I'm opening this PR mostly to get feedback :)

Motivation / usage examples:

```
$ cargo run -w gdb
     Running `gdb target/debug/hello`
GNU gdb (GDB) 7.9.1
<snip>
(gdb) r foobar
Starting program: target/debug/hello foobar
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/usr/lib/libthread_db.so.1".
Hello!
Arguments:
target/debug/hello foobar
[Inferior 1 (process 7568) exited normally]

$ cargo run -w strace -- -e trace=write {} foobar
     Running `strace -e trace=write target/debug/hello foobar`
write(1, "Hello!\nArguments:\n", 18Hello!
Arguments:
)    = 18
write(1, "target/debug/hello foob"..., 36target/debug/hello foobar
) = 36
+++ exited with 0 +++
```
