### PR TITLE
RFC of WIP: Concurrent Cargo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,7 +107,7 @@ dependencies = [
 [[package]]
 name = "file-lock"
 version = "0.0.16"
-source = "git+https://github.com/Byron/file-lock?branch=cargo-adjustments#b940b1d98fe874a51249efa437f6eac3ba16e10c"
+source = "git+https://github.com/Byron/file-lock?branch=cargo-adjustments#eaff0d3b74e55df69893a95802eacf3c7fe196a5"
 dependencies = [
  "gcc 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,6 +7,7 @@ dependencies = [
  "curl 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "docopt 0.6.67 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "errno 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "file-lock 0.0.16 (git+https://github.com/Byron/file-lock?branch=cargo-adjustments)",
  "filetime 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "flate2 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -91,6 +92,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "log 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.1.30 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "errno"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,7 +7,7 @@ dependencies = [
  "curl 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "docopt 0.6.67 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "file-lock 0.0.16 (git+https://github.com/Byron/file-lock?branch=api-adjustment)",
+ "file-lock 0.0.16 (git+https://github.com/Byron/file-lock?branch=cargo-adjustments)",
  "filetime 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "flate2 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "git2 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -96,7 +96,7 @@ dependencies = [
 [[package]]
 name = "file-lock"
 version = "0.0.16"
-source = "git+https://github.com/Byron/file-lock?branch=api-adjustment#2c1b709c3439b4947fccbeb90ff055f4d6dde81a"
+source = "git+https://github.com/Byron/file-lock?branch=cargo-adjustments#b940b1d98fe874a51249efa437f6eac3ba16e10c"
 dependencies = [
  "gcc 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,6 +7,7 @@ dependencies = [
  "curl 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "docopt 0.6.67 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "file-lock 0.0.16 (git+https://github.com/Byron/file-lock?branch=api-adjustment)",
  "filetime 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "flate2 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "git2 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -90,6 +91,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "log 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.1.30 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "file-lock"
+version = "0.0.16"
+source = "git+https://github.com/Byron/file-lock?branch=api-adjustment#2c1b709c3439b4947fccbeb90ff055f4d6dde81a"
+dependencies = [
+ "gcc 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ time = "0.1"
 toml = "0.1"
 url = "0.2"
 winapi = "0.1"
+errno = "0.1.2"
 
 [dependencies.file-lock]
 git = "https://github.com/Byron/file-lock"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,10 @@ toml = "0.1"
 url = "0.2"
 winapi = "0.1"
 
+[dependencies.file-lock]
+git = "https://github.com/Byron/file-lock"
+branch = "api-adjustment"
+
 [dev-dependencies]
 tempdir = "0.3"
 hamcrest = { git = "https://github.com/carllerche/hamcrest-rust.git" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ winapi = "0.1"
 
 [dependencies.file-lock]
 git = "https://github.com/Byron/file-lock"
-branch = "api-adjustment"
+branch = "cargo-adjustments"
 
 [dev-dependencies]
 tempdir = "0.3"

--- a/src/cargo/lib.rs
+++ b/src/cargo/lib.rs
@@ -22,6 +22,7 @@ extern crate threadpool;
 extern crate time;
 extern crate toml;
 extern crate url;
+extern crate file_lock;
 
 use std::env;
 use std::error::Error;

--- a/src/cargo/lib.rs
+++ b/src/cargo/lib.rs
@@ -23,6 +23,7 @@ extern crate time;
 extern crate toml;
 extern crate url;
 extern crate file_lock;
+extern crate errno;
 
 use std::env;
 use std::error::Error;

--- a/src/cargo/ops/cargo_rustc/mod.rs
+++ b/src/cargo/ops/cargo_rustc/mod.rs
@@ -232,7 +232,7 @@ fn compile<'a, 'cfg>(targets: &[(&'a Target, &'a Profile)],
                 }
                 (false, false, _) => jobs.queue(pkg, Stage::Binaries),
             };
-            dst.push((Job::new(dirty, fresh), freshness));
+            dst.push((Job::new(dirty, fresh), freshness, Some(target.clone())));
         }
         drop(profiling_marker);
 
@@ -279,7 +279,7 @@ fn compile<'a, 'cfg>(targets: &[(&'a Target, &'a Profile)],
             let (dirty, fresh, freshness) =
                 try!(custom_build::prepare(pkg, target, req, cx));
             let run_custom = jobs.queue(pkg, Stage::RunCustomBuild);
-            run_custom.push((Job::new(dirty, fresh), freshness));
+            run_custom.push((Job::new(dirty, fresh), freshness, Some(target.clone())));
         }
 
         // If we didn't actually run the custom build command, then there's no
@@ -319,9 +319,9 @@ fn prepare_init<'a, 'cfg>(cx: &mut Context<'a, 'cfg>,
     if cx.requested_target().is_some() {
         let (plugin1, plugin2) = fingerprint::prepare_init(cx, pkg,
                                                            Kind::Host);
-        init.push((Job::new(plugin1, plugin2), Fresh));
+        init.push((Job::new(plugin1, plugin2), Fresh, None));
     }
-    init.push((Job::new(target1, target2), Fresh));
+    init.push((Job::new(target1, target2), Fresh, None));
 }
 
 fn rustc(package: &Package, target: &Target, profile: &Profile,

--- a/src/cargo/sources/registry.rs
+++ b/src/cargo/sources/registry.rs
@@ -279,7 +279,7 @@ impl<'cfg> RegistrySource<'cfg> {
     /// configured by default.
     fn open(&self) -> CargoResult<git2::Repository> {
         let mut fl = CargoLock::new(self.config.home().join(".registry-open-or-init.lock"), 
-                                    self.config);
+                                    try!(CargoLock::lock_kind(self.config)));
 
         try!(fl.lock().chain_error(|| {
             human("Failed to lock registry for opening or initialization")
@@ -314,7 +314,7 @@ impl<'cfg> RegistrySource<'cfg> {
 
         let mut lfp = dst.parent().unwrap().to_path_buf();
         lfp.set_file_name(format!(".{}.lock", filename));
-        let mut fl = CargoLock::new(lfp, self.config);
+        let mut fl = CargoLock::new(lfp, try!(CargoLock::lock_kind(self.config)));
 
         try!(fl.lock().chain_error(|| {
             human(format!("Failed to lock download for crate {}", pkg))
@@ -496,7 +496,7 @@ impl<'cfg> RegistrySource<'cfg> {
         let repo = try!(self.open());
 
         let mut fl = CargoLock::new(self.checkout_path.join(".registry-update.lock"), 
-                                    self.config);
+                                    try!(CargoLock::lock_kind(self.config)));
 
         try!(fl.lock().chain_error(|| {
             human("Failed to lock registry for update")

--- a/src/cargo/sources/registry.rs
+++ b/src/cargo/sources/registry.rs
@@ -502,7 +502,8 @@ impl<'cfg> RegistrySource<'cfg> {
             human("Failed to lock registry for update")
         }));
 
-        // TODO(ST): Try to determine if we have waited or if the repo has just been updated
+        // NOTE(ST): The repo might just have been updated by a collaborative process. We will
+        //           just do it again, which is fast and save.
         try!(self.config.shell().status("Updating",
              format!("registry `{}`", self.source_id.url())));
 

--- a/src/cargo/sources/registry.rs
+++ b/src/cargo/sources/registry.rs
@@ -327,7 +327,6 @@ impl<'cfg> RegistrySource<'cfg> {
             // we do right now.
             drop(fl);
 
-            try!(self.config.shell().status("Verifying", pkg));
             let actual = {
                 // TODO: don't load it into memory. Ideally, Sha256 would support
                 // `Write` so io::copy() can be used

--- a/src/cargo/util/lock.rs
+++ b/src/cargo/util/lock.rs
@@ -2,8 +2,9 @@ use file_lock::{FileLock, LockKind, AccessMode, ParseError};
 use file_lock::flock::Error as FileLockError;
 
 use std::path::PathBuf;
+use std::fs;
 
-use util::{Config, CargoError, CargoResult};
+use util::{Config, CargoError, CargoResult, human};
 
 impl From<FileLockError> for Box<CargoError> {
     fn from(t: FileLockError) -> Self {
@@ -26,7 +27,7 @@ pub struct CargoLock<'cfg> {
 }
 
 impl<'cfg> CargoLock<'cfg> {
-    pub fn new_exclusive(path: PathBuf, config: &'cfg Config) -> CargoLock<'cfg> {
+    pub fn new(path: PathBuf, config: &'cfg Config) -> CargoLock<'cfg> {
         CargoLock {
             config: config,
             inner: FileLock::new(path, AccessMode::Write)
@@ -41,12 +42,25 @@ impl<'cfg> CargoLock<'cfg> {
     }
 
     pub fn lock(&mut self) -> CargoResult<()> {
-        let kind: LockKind = try!(try!(self.config.get_string("build.lock-kind"))
+        const CONFIG_KEY: &'static str = "build.lock-kind";
+        let kind_string = try!(self.config.get_string(CONFIG_KEY))
                                                   .map(|t| t.0)
                                                   .unwrap_or_else(|| LockKind::NonBlocking
                                                                                 .as_ref()
-                                                                                .to_owned())
-                                .parse());
+                                                                                .to_owned());
+        let kind: LockKind = match kind_string.parse() {
+            Ok(kind) => kind,
+            Err(_) => return Err(human(format!("Failed to parse value '{}' at configuration key \
+                                               '{}'. Must be one of '{}' and '{}'", 
+                                               kind_string, CONFIG_KEY,
+                                               LockKind::NonBlocking.as_ref(), 
+                                               LockKind::Blocking.as_ref())))
+        };
+        // NOTE(ST): This could fail if cargo is run concurrently for the first time
+        // The only way to prevent it would be to take a lock in a directory which exists.
+        // This is why we don't try! here, but hope the directory exists when we 
+        // try to create the lock file
+        fs::create_dir_all(self.inner.path().parent().unwrap()).ok();
         Ok(try!(self.inner.any_lock(kind)))
     }
 }

--- a/src/cargo/util/lock.rs
+++ b/src/cargo/util/lock.rs
@@ -1,0 +1,52 @@
+use file_lock::{FileLock, LockKind, AccessMode, ParseError};
+use file_lock::flock::Error as FileLockError;
+
+use std::path::PathBuf;
+
+use util::{Config, CargoError, CargoResult};
+
+impl From<FileLockError> for Box<CargoError> {
+    fn from(t: FileLockError) -> Self {
+        Box::new(t)
+    }
+}
+
+impl From<ParseError> for Box<CargoError> {
+    fn from(t: ParseError) -> Self {
+        Box::new(t)
+    }
+}
+
+impl CargoError for FileLockError {}
+impl CargoError for ParseError {}
+
+pub struct CargoLock<'cfg> {
+    config: &'cfg Config, 
+    inner: FileLock,
+}
+
+impl<'cfg> CargoLock<'cfg> {
+    pub fn new_exclusive(path: PathBuf, config: &'cfg Config) -> CargoLock<'cfg> {
+        CargoLock {
+            config: config,
+            inner: FileLock::new(path, AccessMode::Write)
+        }
+    }
+
+    pub fn new_shared(path: PathBuf, config: &'cfg Config) -> CargoLock<'cfg> {
+        CargoLock {
+            config: config,
+            inner: FileLock::new(path, AccessMode::Read)
+        }
+    }
+
+    pub fn lock(&mut self) -> CargoResult<()> {
+        let kind: LockKind = try!(try!(self.config.get_string("build.lock-kind"))
+                                                  .map(|t| t.0)
+                                                  .unwrap_or_else(|| LockKind::NonBlocking
+                                                                                .as_ref()
+                                                                                .to_owned())
+                                .parse());
+        Ok(try!(self.inner.any_lock(kind)))
+    }
+}

--- a/src/cargo/util/lock.rs
+++ b/src/cargo/util/lock.rs
@@ -1,5 +1,8 @@
 use file_lock::{FileLock, AccessMode, ParseError};
 use file_lock::flock::Error as FileLockError;
+use file_lock::lock::Error as LockError;
+use errno;
+use libc;
 
 use std::path::PathBuf;
 use std::fs;
@@ -85,6 +88,26 @@ impl CargoLock {
             }
         }
         debug!("About to acquire file lock: '{}'", self.inner.path().display());
-        Ok(try!(self.inner.any_lock(self.kind.clone())))
+        // TODO(ST): This evil hack will just retry until we have the lock or 
+        //           fail with an error that is no "Deadlock avoided".
+        //           When there is high intra-process contention thanks to threads,
+        //           this issue occours even though I would hope that we don't try to 
+        //           to have multiple threads obtain a lock on the same lock file.
+        //           However, apparently this does happen.
+        //           Even if it does I don't understand why this is a deadlock for him.
+        //           The good news is that building now works in my manual tests.
+        loop {
+            match self.inner.any_lock(self.kind.clone()) {
+                Err(FileLockError::LockError(
+                        LockError::Errno(
+                            errno::Errno(libc::consts::os::posix88::EDEADLK)))) 
+                    => { 
+                        sleep_ms(100);
+                        continue
+                },
+                Err(any_err) => return Err(any_err.into()),
+                Ok(()) => return Ok(())
+            }
+        }
     }
 }

--- a/src/cargo/util/lock.rs
+++ b/src/cargo/util/lock.rs
@@ -21,7 +21,9 @@ impl From<ParseError> for Box<CargoError> {
     }
 }
 
-impl CargoError for FileLockError {}
+impl CargoError for FileLockError {
+    fn is_human(&self) -> bool { true }
+}
 impl CargoError for ParseError {}
 
 pub struct CargoLock {
@@ -82,6 +84,7 @@ impl CargoLock {
                 }
             }
         }
+        debug!("About to acquire file lock: '{}'", self.inner.path().display());
         Ok(try!(self.inner.any_lock(self.kind.clone())))
     }
 }

--- a/src/cargo/util/lock.rs
+++ b/src/cargo/util/lock.rs
@@ -1,10 +1,13 @@
-use file_lock::{FileLock, LockKind, AccessMode, ParseError};
+use file_lock::{FileLock, AccessMode, ParseError};
 use file_lock::flock::Error as FileLockError;
 
 use std::path::PathBuf;
 use std::fs;
+use std::thread::sleep_ms;
 
-use util::{Config, CargoError, CargoResult, human};
+use util::{Config, CargoError, CargoResult, human, caused_human};
+
+pub use file_lock::LockKind;
 
 impl From<FileLockError> for Box<CargoError> {
     fn from(t: FileLockError) -> Self {
@@ -21,45 +24,64 @@ impl From<ParseError> for Box<CargoError> {
 impl CargoError for FileLockError {}
 impl CargoError for ParseError {}
 
-pub struct CargoLock<'cfg> {
-    config: &'cfg Config, 
+pub struct CargoLock {
+    kind: LockKind, 
     inner: FileLock,
 }
 
-impl<'cfg> CargoLock<'cfg> {
-    pub fn new(path: PathBuf, config: &'cfg Config) -> CargoLock<'cfg> {
+impl CargoLock {
+
+    pub fn lock_kind(config: &Config) -> CargoResult<LockKind> {
+        const CONFIG_KEY: &'static str = "build.lock-kind";
+        match try!(config.get_string(CONFIG_KEY)).map(|t| t.0) {
+            None => Ok(LockKind::NonBlocking),
+            Some(kind_string) => match kind_string.parse() {
+                Ok(kind) => Ok(kind),
+                Err(_) => Err(human(format!("Failed to parse value '{}' at configuration key \
+                                            '{}'. Must be one of '{}' and '{}'",
+                                            kind_string, CONFIG_KEY,
+                                            LockKind::NonBlocking.as_ref(), 
+                                            LockKind::Blocking.as_ref())))
+            }
+        }
+    }
+
+    pub fn new(path: PathBuf, kind: LockKind) -> CargoLock {
         CargoLock {
-            config: config,
+            kind: kind,
             inner: FileLock::new(path, AccessMode::Write)
         }
     }
 
-    pub fn new_shared(path: PathBuf, config: &'cfg Config) -> CargoLock<'cfg> {
+    pub fn new_shared(path: PathBuf, kind: LockKind) -> CargoLock {
         CargoLock {
-            config: config,
+            kind: kind,
             inner: FileLock::new(path, AccessMode::Read)
         }
     }
 
     pub fn lock(&mut self) -> CargoResult<()> {
-        const CONFIG_KEY: &'static str = "build.lock-kind";
-        let kind = match try!(self.config.get_string(CONFIG_KEY)).map(|t| t.0) {
-            None => LockKind::NonBlocking,
-            Some(kind_string) => match kind_string.parse() {
-                Ok(kind) => kind,
-                Err(_) => return Err(human(format!("Failed to parse value '{}' at \
-                                                   configuration key '{}'.\
-                                                   Must be one of '{}' and '{}'",
-                                                   kind_string, CONFIG_KEY,
-                                                   LockKind::NonBlocking.as_ref(), 
-                                                   LockKind::Blocking.as_ref())))
-            }
-        };
         // NOTE(ST): This could fail if cargo is run concurrently for the first time
         // The only way to prevent it would be to take a lock in a directory which exists.
         // This is why we don't try! here, but hope the directory exists when we 
         // try to create the lock file
-        fs::create_dir_all(self.inner.path().parent().unwrap()).ok();
-        Ok(try!(self.inner.any_lock(kind)))
+        {
+            let lock_dir = self.inner.path().parent().unwrap();
+            if let Err(_) = fs::create_dir_all(lock_dir) {
+                // We might compete to create one or more directories here
+                // Give the competing process some time to finish. Then we will
+                // retry, hoping it the creation works (maybe just because the )
+                // directory is available already.
+                // TODO(ST): magic numbers, especially in sleep, will fail at some point ... .
+                sleep_ms(100);
+                if let Err(io_err) = fs::create_dir_all(lock_dir) {
+                    // Fail permanently if it still didn't work ... 
+                    return Err(caused_human(format!("Failed to create parent directory of \
+                                                     lock-file at '{}'", 
+                                                     lock_dir.display()), io_err));
+                }
+            }
+        }
+        Ok(try!(self.inner.any_lock(self.kind.clone())))
     }
 }

--- a/src/cargo/util/mod.rs
+++ b/src/cargo/util/mod.rs
@@ -15,7 +15,7 @@ pub use self::to_url::ToUrl;
 pub use self::to_semver::ToSemver;
 pub use self::vcs::{GitRepo, HgRepo};
 pub use self::sha256::Sha256;
-pub use self::lock::CargoLock;
+pub use self::lock::{CargoLock, LockKind};
 
 pub mod config;
 pub mod errors;

--- a/src/cargo/util/mod.rs
+++ b/src/cargo/util/mod.rs
@@ -15,6 +15,7 @@ pub use self::to_url::ToUrl;
 pub use self::to_semver::ToSemver;
 pub use self::vcs::{GitRepo, HgRepo};
 pub use self::sha256::Sha256;
+pub use self::lock::CargoLock;
 
 pub mod config;
 pub mod errors;
@@ -28,6 +29,7 @@ pub mod to_semver;
 pub mod to_url;
 pub mod toml;
 pub mod lev_distance;
+mod lock;
 mod dependency_queue;
 mod sha256;
 mod vcs;

--- a/tests/test_cargo_compile.rs
+++ b/tests/test_cargo_compile.rs
@@ -729,7 +729,7 @@ test!(many_crate_types_old_style_lib_location {
     let mut files: Vec<String> = files.map(|e| e.unwrap().path()).filter_map(|f| {
         match f.file_name().unwrap().to_str().unwrap() {
             "build" | "examples" | "deps" => None,
-            s if s.contains("fingerprint") || s.contains("dSYM") => None,
+            s if s.contains("fingerprint") || s.contains("dSYM") || s.ends_with(".lock") => None,
             s => Some(s.to_string())
         }
     }).collect();
@@ -767,7 +767,7 @@ test!(many_crate_types_correct {
     let mut files: Vec<String> = files.map(|f| f.unwrap().path()).filter_map(|f| {
         match f.file_name().unwrap().to_str().unwrap() {
             "build" | "examples" | "deps" => None,
-            s if s.contains("fingerprint") || s.contains("dSYM") => None,
+            s if s.contains("fingerprint") || s.contains("dSYM") || s.ends_with(".lock") => None,
             s => Some(s.to_string())
         }
     }).collect();


### PR DESCRIPTION
In the current state, using cargo concurrently on the same system results in [undesired behaviour](https://github.com/alfiedotwtf/file-lock/pull/6).

One way to alleviate this would be to use the *local* file-system's locking facilities to lock resources before trying to use or adjust them. Both Windows ([LockFileEx(...)][MSDNLockFileEx]) and Unix ([fcntl(...)][fcntl]) provide such facilities, which should allow a cross-platform implementation with equivalent behaviour. 

There are two ways to deal with locks:

* Abort gracefully when a lock could not be acquired without blocking (similar to `try_lock()`). This is equivalent to the current behaviour, except that the cargo process who managed to acquire the lock will not be disturbed by the competing process.
* Wait for a lock, and try to avoid duplication of work when the lock was acquired (similar to `lock()`). This allows multiple concurrent cargo processes to work collaboratively.

The choice above should be configurable.

In the past days I have been adjusting the [file-lock](https://github.com/alfiedotwtf/file-lock/pull/6) crate, which will eventually provide the required cross-platform locking functionality. Currently it is only implemented for Non-Windows though.

# Caveats

* file-system based locking may not be fully supported on all file-systems. Network filesystem can be problematic, even though both *SMB* and *NFS* provide locking support. If one cannot trust the file-system, cargo will unwillingly revert to the previous, somewhat undefined behaviour.
* It's unsafe to delete a lock-file after creation, which means there will be additional (possibly hidden) files in the `CARGO_HOME` and `target-dir`s.

# RFC

I am submitting the PR early to get a chance for early feedback. This shall help to get the code on track soon, instead of having a whole pile of unusable nonsense later. As these are my first steps within the cargo codebase (which is teaching me every day), code-quality will certainly need to improve in many ways. Therefore I will be happy to make adjustments as soon as a review is coming in.

This PR's text will be updated throughout its lifetime, based on comments and reviews.

# Progress

* [x] **configurable locking semantics**
  - Currently using `build.lock-kind`, with support for `wait` and `nowait`.
* [x] **build different packages without shared dependencies**
 - [ ] unit-test
 - works thanks to lock on `Registry::open()` and `Registry::do_update()`
* [x] **build same package**
 - [ ] unit-test
* [ ] **fetch same package** (*more testing required*)
 - [ ] unit-test
* [x] **build different package with shared dependencies**
 - [ ] unit-test
* [ ] **build documentation of various targets with shared dependencies into same target-dir**
 - [ ] unit-test
 - It currently rebuilds even existing documentation, which might be a different issue.

# Issues to fix

Issues mentioned here are the ones I am quite aware off, even though I have no clear idea on how to alleviate them. Input on these topics are particularly welcome.

* [ ] cargo-rustc now allows invalid/half-finished files ([see code][issue-rustc])
* [ ] `CargoLock::lock(...)` method is hacky (look [here][issue-lock-sleep] and [here][issue-lock-loop]

# Testing

Currently I test manually, which is accomplished as follows:

```Bash
$ git clone https://github.com/Byron/google-apis-rs
$ cd google-apis-rs
# Build 4 targets with plenty of dependencies in parallel. Depending on the `build.jobs` variable 
# in `.cargo.config`, there is more or less intra-process contention.
$ CARGO_HOME=$PWD/cargo_home make -j4 groupsmigration1-cli-cargo discovery1-cli-cargo translate2-cli-cargo audit1-cli-cargo ARGS=build
```

The `.cargo/config` contained in the aforementioned repository is used to configure cargo. Currently it looks like this:

```toml
[build]
target-dir = "target"
lock-kind = "wait"
```

At the current time, intra-process contention seems to be the most troublesome, as I get `deadlock avoided` errors when trying to wait on a lock ... sometimes.

[MSDNLockFileEx]: https://www.google.de/webhp?sourceid=chrome-instant&ion=1&espv=2&ie=UTF-8#q=LockFileEx
[fcntl]: http://linux.die.net/man/2/fcntl
[issue-rustc]: https://github.com/rust-lang/cargo/blob/concurrency/src/cargo/ops/cargo_rustc/mod.rs#L383
[issue-lock-sleep]: https://github.com/Byron/cargo/blob/concurrency/src/cargo/util/lock.rs#L80
[issue-lock-loop]: https://github.com/Byron/cargo/blob/concurrency/src/cargo/util/lock.rs#L91