### PR TITLE
Add a Target to the build script deps key

### DIFF
--- a/src/cargo/ops/cargo_rustc/context.rs
+++ b/src/cargo/ops/cargo_rustc/context.rs
@@ -36,7 +36,7 @@ pub struct Context<'a, 'cfg: 'a> {
                               Fingerprint>,
     pub compiled: HashSet<(&'a PackageId, &'a Target, &'a Profile)>,
     pub build_config: BuildConfig,
-    pub build_scripts: HashMap<(&'a PackageId, Kind, &'a Profile),
+    pub build_scripts: HashMap<(&'a PackageId, &'a Target, &'a Profile, Kind),
                                Vec<&'a PackageId>>,
 
     host: Layout,

--- a/tests/test_cargo_test.rs
+++ b/tests/test_cargo_test.rs
@@ -1631,3 +1631,29 @@ test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
 
 ", compiling = COMPILING, running = RUNNING, doctest = DOCTEST)))
 });
+
+test!(dev_dep_with_build_script {
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [package]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+
+            [dev-dependencies]
+            bar = { path = "bar" }
+        "#)
+        .file("src/lib.rs", "")
+        .file("examples/foo.rs", "fn main() {}")
+        .file("bar/Cargo.toml", r#"
+            [package]
+            name = "bar"
+            version = "0.0.1"
+            authors = []
+            build = "build.rs"
+        "#)
+        .file("bar/src/lib.rs", "")
+        .file("bar/build.rs", "fn main() {}");
+    assert_that(p.cargo_process("test"),
+                execs().with_status(0));
+});


### PR DESCRIPTION
Previously a Target was not considered to be in the key of the map to build
script dependencies, but this meant that information like whether it was a
dev-dependency was lost. As a result libraries would depend on the build scripts
of their dev-dependencies, causing an internal error when the build script
hadn't finished yet when the library was being built.

Closes #1751