### PR TITLE
Fixed the bogus dev-dependencies pull in on regular build

### DIFF
--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -149,7 +149,8 @@ pub fn compile_pkg<'a>(package: &Package,
         let platform = target.as_ref().map(|e| &e[..]).or(Some(&rustc_host[..]));
 
         let method = Method::Required{
-            dev_deps: true, // TODO: remove this option?
+            dev_deps: options.mode == CompileMode::Test ||
+                options.mode == CompileMode::Bench,
             features: &features,
             uses_default_features: !no_default_features,
             target_platform: platform};


### PR DESCRIPTION
Do not pull in dev-dependencies unless it's a test or bench build (see #1796 for additional details).

The primary use case is proper cross-building of crates with unit tests, where it's impossible (or highly unreasonable) to cross-build the test frameworks.