### PR TITLE
avoid an unnecessary clone in without_prefix

### DIFF
--- a/src/cargo/util/paths.rs
+++ b/src/cargo/util/paths.rs
@@ -47,20 +47,19 @@ pub fn normalize_path(path: &Path) -> PathBuf {
             Component::Normal(c) => { ret.push(c); }
         }
     }
-    return ret;
+    ret
 }
 
 pub fn without_prefix<'a>(a: &'a Path, b: &'a Path) -> Option<&'a Path> {
     let mut a = a.components();
     let mut b = b.components();
     loop {
-        let mut a2 = a.clone();
-        match (a2.next(), b.next()) {
-            (Some(x), Some(y)) if x == y => a = a2,
-            (Some(_), Some(_)) |
-            (None, Some(_)) => return None,
-            (Some(_), None) |
-            (None, None) => return Some(a.as_path()),
+        match b.next() {
+            Some(y) => match a.next() {
+                Some(x) if x == y => continue,
+                _ => return None,
+            }, 
+            None => return Some(a.as_path()),
         }
     }
 }


### PR DESCRIPTION
This is a very tiny optimization ...

An unnecessary clone was done because of matching on a tuple.
Checking items separately avoids it entirely.