### PR TITLE
Fix version info when built without git repo

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -17,10 +17,15 @@ else
 CFG_RELEASE=$(CFG_RELEASE_NUM)$(CFG_RELEASE_LABEL)
 CFG_PACKAGE_VERS=$(CFG_RELEASE)
 endif
+CFG_BUILD_DATE = $(shell date +%F)
+
+ifeq ($(wildcard .git),)
+CFG_VERSION = $(CFG_RELEASE) (built $(CFG_BUILD_DATE))
+else
 CFG_VER_DATE = $(shell git log -1 --date=short --pretty=format:'%cd')
 CFG_VER_HASH = $(shell git rev-parse --short HEAD)
-CFG_BUILD_DATE = $(shell date +%F)
 CFG_VERSION = $(CFG_RELEASE) ($(CFG_VER_HASH) $(CFG_VER_DATE)) (built $(CFG_BUILD_DATE))
+endif
 PKG_NAME = cargo-$(CFG_PACKAGE_VERS)
 
 ifdef CFG_DISABLE_VERIFY_INSTALL


### PR DESCRIPTION
When built from archive, downloaded from https://github.com/rust-lang/cargo/releases
 version info looks like this: `cargo 0.3.0 ( ) (built 2015-05-16)`.
Patch will make it look like this: `cargo 0.3.0 (built 2015-05-16)`