### PR TITLE
Add compiled python files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ src/doc/build
 src/registry/target
 src/registry/Cargo.lock
 rustc
+*.pyc


### PR DESCRIPTION
This is a very tiny change but I like my `git status` reports clean. And python tends to mess that up by creating untracked files like `src/etc/download.pyc`.