### PR TITLE
Weed out empty features from the registry

### DIFF
--- a/src/cargo/core/resolver/mod.rs
+++ b/src/cargo/core/resolver/mod.rs
@@ -523,7 +523,7 @@ fn build_features(s: &Summary, method: Method)
                                  &mut visited));
             }
         }
-        Method::Required{features: requested_features, ..} =>  {
+        Method::Required { features: requested_features, .. } =>  {
             for feat in requested_features.iter() {
                 try!(add_feature(s, feat, &mut deps, &mut used, &mut visited));
             }
@@ -683,8 +683,8 @@ impl Context {
             }
         });
 
-        let (mut feature_deps, used_features) =
-            try!(build_features(parent, method));
+        let (mut feature_deps, used_features) = try!(build_features(parent,
+                                                                    method));
         let mut ret = Vec::new();
 
         // Next, sanitize all requested features by whitelisting all the
@@ -726,8 +726,8 @@ impl Context {
         if used_features.len() > 0 {
             let pkgid = parent.package_id();
             self.resolve.features.entry(pkgid.clone())
-              .or_insert(HashSet::new())
-              .extend(used_features);
+                .or_insert(HashSet::new())
+                .extend(used_features);
         }
 
         Ok(ret)

--- a/src/cargo/sources/registry.rs
+++ b/src/cargo/sources/registry.rs
@@ -438,6 +438,13 @@ impl<'cfg> RegistrySource<'cfg> {
             _ => Kind::Normal,
         };
 
+        // Unfortunately older versions of cargo and/or the registry ended up
+        // publishing lots of entries where the features array contained the
+        // empty feature, "", inside. This confuses the resolution process much
+        // later on and these features aren't actually valid, so filter them all
+        // out here.
+        let features = features.into_iter().filter(|s| !s.is_empty()).collect();
+
         Ok(dep.set_optional(optional)
               .set_default_features(default_features)
               .set_features(features)


### PR DESCRIPTION
It looks like the empty string is leaking in as a feature to all crates being
published on crates.io unintentionally. This means that each dependency edge
activates the feature `""`. This in turn confuses the resolution process quite a
bit, causing it to be far more recursive than it should be.

The empty feature, `""`, is weeded out during activation of features but it's
never explicitly activated. This means that each new dependency we see has one
requested feature (the empty one) with no activated features (as it doesn't have
any). This ends up causing us to recurse to attempt to reactivate the
dependency. This extreme recursion ended up blowing the stack on some smaller
crates and this commit fixes that.