### PR TITLE
Prevent duplicate warnings about unused keys with array values

### DIFF
--- a/src/cargo/util/toml.rs
+++ b/src/cargo/util/toml.rs
@@ -144,11 +144,6 @@ pub fn to_manifest(contents: &[u8],
                     })
                 }
             }
-            toml::Value::Array(ref arr) => {
-                for v in arr.iter() {
-                    add_unused_keys(m, v, key.clone());
-                }
-            }
             _ => m.add_warning(format!("unused manifest key: {}", key)),
         }
     }

--- a/tests/test_cargo_compile.rs
+++ b/tests/test_cargo_compile.rs
@@ -799,6 +799,27 @@ test!(unused_keys {
     assert_that(p.cargo_process("build"),
                 execs().with_status(0)
                        .with_stderr("unused manifest key: lib.build\n"));
+
+    let mut p = project("bar");
+    p = p
+        .file("Cargo.toml", r#"
+            [project]
+
+            name = "foo"
+            version = "0.5.0"
+            authors = ["wycats@example.com"]
+
+            [lib]
+
+            name = "foo"
+            some_key = [1, 2, 3]
+        "#)
+        .file("src/foo.rs", r#"
+            pub fn foo() {}
+        "#);
+    assert_that(p.cargo_process("build"),
+                execs().with_status(0)
+                       .with_stderr("unused manifest key: lib.some_key\n"));
 });
 
 test!(self_dependency {


### PR DESCRIPTION
Fixes #1817

Prior to this commit, if there was an unused array of size N in the
manifest, there would be N warnings about unused manifest keys