### PR TITLE
Mention doc tests with cargo test.

### DIFF
--- a/src/doc/guide.md
+++ b/src/doc/guide.md
@@ -408,6 +408,13 @@ test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
 Of course, if your project has tests, you'll see more output, with the
 correct number of tests.
 
+`cargo test` runs additional tests as well. For example, it will compile any
+examples, you’ve included, and will also test the examples in your
+documentation. Please see the [testing guide][testing] in the Rust
+documentation for more details.
+
+[testing]: https://doc.rust-lang.org/book/testing.html
+
 # Path Dependencies
 
 Over time our `hello_world` project has grown significantly in size! It's gotten

--- a/src/doc/manifest.md
+++ b/src/doc/manifest.md
@@ -439,6 +439,8 @@ When you run `cargo test`, Cargo will:
 
 * Compile your library's unit tests, which are in files reachable from
   `lib.rs`. Any sections marked with `#[cfg(test)]` will be included.
+* Compile your library’s documentation tests, which are embedded inside
+  of documentation blocks.
 * Compile your library's integration tests, which are located in
   `tests`. Files in `tests` load in your library by using `extern crate
   <library-name>` like any other code that depends on it.


### PR DESCRIPTION
While doing this, I noticed that the manifest documentation does mention that
'cargo test' tests examples, so this also includes some information about this
in the guide.

Fixes #1177