### PR TITLE
Only run appveyor on the master branch

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,3 +25,7 @@ build: false
 
 test_script:
   - cargo test
+
+branches:
+  only:
+    - master


### PR DESCRIPTION
We're generating a lot of builds for the `tmp`, `auto-cargo`, and `gh-pages` branches...