### PR TITLE
zsh completion: fix [[ ... ]] conditional syntax

### DIFF
--- a/src/etc/_cargo
+++ b/src/etc/_cargo
@@ -290,7 +290,7 @@ _get_names_from_array()
 {
     local -a filelist;
     local manifest=$(_locate_manifest)
-    if ! [[ $manifest ]]; then
+    if [[ -z $manifest ]]; then
         return 0
     fi
 


### PR DESCRIPTION
Fixes a syntax error in the zsh completion definition.

The `[[ $foo ]]` test isn't valid for zsh; it needs `-z` or `-n`. This PR changes the `! [[ $manifest ]]` which appeared to be checking for an empty manifest to `[[ -z $manifest ]]`, which is the zsh syntax for it.

Fixes #1852.
Addresses homebrew/homebrew#41374.

I tested this on OS X 10.9. I only tested the `zsh` completion behavior, since Rust itself is unchanged by this.

The #920 PR looks like it was trying to do the same thing, but it got the semantics wrong. Putting `!` and `[[` together as `![[` removes the syntax error, but not because `![[ $x ]]` is a test for nonempty; `![[` is now a history backreference. The `!` needs to be its own word to be used as a logical "not".
