### PR TITLE
Problem: make install fail on non-existing rust-installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Cargo can then be compiled like many other standard unix-like projects:
 ```sh
 git clone https://github.com/rust-lang/cargo
 cd cargo
+git submodule update --init src/rust-installer
 python src/etc/install-deps.py
 ./configure --local-rust-root="$PWD"/rustc
 make

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Cargo can then be compiled like many other standard unix-like projects:
 ```sh
 git clone https://github.com/rust-lang/cargo
 cd cargo
-git submodule update --init src/rust-installer
+git submodule update --init
 python src/etc/install-deps.py
 ./configure --local-rust-root="$PWD"/rustc
 make


### PR DESCRIPTION
Solution: add a note about calling git submodule to README.md