### PR TITLE
Use utime crate instead of manual reimplementation of `set_file_times`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,6 +29,7 @@ dependencies = [
  "time 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.2.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "utime 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -387,6 +388,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "matches 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "utime"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ tempdir = "0.3"
 hamcrest = "0.1"
 bufstream = "0.1"
 filetime = "0.1"
+utime = "0.1"
 
 [[bin]]
 name = "cargo"

--- a/tests/support/paths.rs
+++ b/tests/support/paths.rs
@@ -107,6 +107,8 @@ impl CargoPathExt for Path {
         }
 
         fn time_travel(path: &Path) -> io::Result<()> {
+            use utime::set_file_times;
+
             let stat = try!(path.c_metadata());
 
             let mtime = FileTime::from_last_modification_time(&stat);
@@ -122,60 +124,6 @@ impl CargoPathExt for Path {
             perms.set_readonly(false);
             try!(fs::set_permissions(path, perms));
             set_file_times(path, newtime, newtime)
-        }
-
-        #[cfg(unix)]
-        fn set_file_times(p: &Path, atime: u64, mtime: u64) -> io::Result<()> {
-            use std::os::unix::prelude::*;
-            use std::ffi::CString;
-            use libc::{timeval, time_t, c_char, c_int};
-
-            let p = try!(CString::new(p.as_os_str().as_bytes()));
-            let atime = timeval { tv_sec: atime as time_t, tv_usec: 0, };
-            let mtime = timeval { tv_sec: mtime as time_t, tv_usec: 0, };
-            let times = [atime, mtime];
-            extern {
-                fn utimes(name: *const c_char, times: *const timeval) -> c_int;
-            }
-            unsafe {
-                if utimes(p.as_ptr(), times.as_ptr()) == 0 {
-                    Ok(())
-                } else {
-                    Err(io::Error::last_os_error())
-                }
-            }
-        }
-
-        #[cfg(windows)]
-        fn set_file_times(p: &Path, atime: u64, mtime: u64) -> io::Result<()> {
-            use std::fs::OpenOptions;
-            use std::os::windows::prelude::*;
-            use winapi::{FILETIME, DWORD};
-            use kernel32;
-
-            let f = try!(OpenOptions::new().write(true).open(p));
-            let atime = to_filetime(atime);
-            let mtime = to_filetime(mtime);
-            return unsafe {
-                let ret = kernel32::SetFileTime(f.as_raw_handle() as *mut _,
-                                                0 as *const _,
-                                                &atime, &mtime);
-                if ret != 0 {
-                    Ok(())
-                } else {
-                    Err(io::Error::last_os_error())
-                }
-            };
-
-            fn to_filetime(seconds: u64) -> FILETIME {
-                // FILETIME is a count of 100ns intervals, and there are 10^7 of
-                // these in a second
-                let seconds = seconds * 10_000_000;
-                FILETIME {
-                    dwLowDateTime: seconds as DWORD,
-                    dwHighDateTime: (seconds >> 32) as DWORD,
-                }
-            }
         }
     }
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -10,6 +10,7 @@ extern crate tar;
 extern crate tempdir;
 extern crate term;
 extern crate url;
+extern crate utime;
 #[cfg(windows)] extern crate kernel32;
 #[cfg(windows)] extern crate winapi;
 


### PR DESCRIPTION
Previous implementation of `set_file_times` doesn't work properly in windows.

```diff
@@ -55,10 +55,10 @@ fn utime<P: AsRef<Path>>(path: P, atime: u64, mtime: u64) -> io::Result<()> {
 
     // FILETIME is a count of 100ns intervals, and there are 10^7 of these in a second
     fn to_filetime(seconds: u64) -> FILETIME {
-        let seconds = seconds * 10_000_000;
+        let intervals = seconds * 10000000 + 116444736000000000;
         FILETIME {
-            dwLowDateTime: seconds as DWORD,
-            dwHighDateTime: (seconds >> 32) as DWORD,
+            dwLowDateTime: intervals as DWORD,
+            dwHighDateTime: (intervals >> 32) as DWORD,
         }
     }
```
##### Reference
- https://github.com/simnalamburt/utime/commit/7a33507c5c
- https://github.com/alexcrichton/tar-rs/issues/27