### PR TITLE
Convert time_t into FILETIME correctly

### DIFF
--- a/tests/support/paths.rs
+++ b/tests/support/paths.rs
@@ -168,12 +168,11 @@ impl CargoPathExt for Path {
             };
 
             fn to_filetime(seconds: u64) -> FILETIME {
-                // FILETIME is a count of 100ns intervals, and there are 10^7 of
-                // these in a second
-                let seconds = seconds * 10_000_000;
+                // FILETIME is a count of 100ns intervals since January 1, 1601 (UTC).
+                let intervals = seconds * 10_000_000 + 116444736000000000;
                 FILETIME {
-                    dwLowDateTime: seconds as DWORD,
-                    dwHighDateTime: (seconds >> 32) as DWORD,
+                    dwLowDateTime: intervals as DWORD,
+                    dwHighDateTime: (intervals >> 32) as DWORD,
                 }
             }
         }


### PR DESCRIPTION
This PR succeeds #1858

Existing implementation of [`to_filetime`][t] function doesn't convert [`FILETIME`][f] into [`time_t`][tt] as author's intention.

##### Reference
- [MSDN: Converting a time_t Value to a File Time][msdn]
- https://github.com/simnalamburt/utime/commit/7a33507c5c

[t]: https://github.com/rust-lang/cargo/blob/5c1da067d46ab2c246e35ec40bfe8f06493ee394/tests/support/paths.rs#L170
[f]: https://msdn.microsoft.com/en-us/library/windows/desktop/ms724284(v=vs.85).aspx
[tt]: http://en.cppreference.com/w/c/chrono/time_t
[msdn]: https://msdn.microsoft.com/en-us/library/windows/desktop/ms724228(v=vs.85).aspx