### PR TITLE
Fix activating features in dependencies transitively

### DIFF
--- a/src/cargo/core/resolver/mod.rs
+++ b/src/cargo/core/resolver/mod.rs
@@ -556,6 +556,7 @@ fn build_features(s: &Summary, method: Method)
         match parts.next() {
             Some(feat) => {
                 let package = feat_or_package;
+                used.insert(package.to_string());
                 deps.entry(package.to_string())
                     .or_insert(Vec::new())
                     .push(feat.to_string());


### PR DESCRIPTION
When activating the feature `foo/bar` you're actually activating both the
feature `foo` and the `bar` feature of the relevant package. Cargo previously
forgot to activate the `foo` feature, and this commit fixes that up.

Closes #1871