### PR TITLE
add missing Option to avatar

### DIFF
--- a/src/crates-io/lib.rs
+++ b/src/crates-io/lib.rs
@@ -77,7 +77,7 @@ pub struct NewCrateDependency {
 pub struct User {
     pub id: u32,
     pub login: String,
-    pub avatar: String,
+    pub avatar: Option<String>,
     pub email: Option<String>,
     pub name: Option<String>,
 }


### PR DESCRIPTION
This Option is present in crates.io's definition of EncodableUser, so I think it should be in Cargo too.