### PR TITLE
Remove the built-on date from --version

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -24,7 +24,7 @@ CFG_VERSION = $(CFG_RELEASE) (built $(CFG_BUILD_DATE))
 else
 CFG_VER_DATE = $(shell git log -1 --date=short --pretty=format:'%cd')
 CFG_VER_HASH = $(shell git rev-parse --short HEAD)
-CFG_VERSION = $(CFG_RELEASE) ($(CFG_VER_HASH) $(CFG_VER_DATE)) (built $(CFG_BUILD_DATE))
+CFG_VERSION = $(CFG_RELEASE) ($(CFG_VER_HASH) $(CFG_VER_DATE))
 endif
 PKG_NAME = cargo-$(CFG_PACKAGE_VERS)
 


### PR DESCRIPTION
rustc no longer does this, so neither should Cargo.