### PR TITLE
Use a custom trace! macro in resolution

### DIFF
--- a/src/cargo/core/resolver/mod.rs
+++ b/src/cargo/core/resolver/mod.rs
@@ -110,6 +110,14 @@ pub use self::encode::Metadata;
 
 mod encode;
 
+macro_rules! trace {
+    ($($e:tt)*) => (
+        if cfg!(debug_assertions) {
+            debug!($($e)*);
+        }
+    )
+}
+
 /// Represents a fully resolved package dependency graph. Each node in the graph
 /// is a package and edges represent dependencies between packages.
 ///
@@ -280,7 +288,7 @@ fn activate(mut cx: Box<Context>,
         cx.visited.remove(id);
         return finished(cx, registry)
     }
-    debug!("activating {}", parent.package_id());
+    trace!("activating {}", parent.package_id());
 
     let deps = try!(cx.build_deps(registry, parent, method));
 


### PR DESCRIPTION
Apparently not actually emitting the calls to trace! saves a good deal of stack
space, fixing the overflow found in #1875.

Closes #1875