### PR TITLE
Bump to 0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,6 +1,6 @@
 [root]
 name = "cargo"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "advapi32-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bufstream 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cargo"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Yehuda Katz <wycats@gmail.com>",
            "Carl Lerche <me@carllerche.com>",
            "Alex Crichton <alex@alexcrichton.com>"]

--- a/Makefile.in
+++ b/Makefile.in
@@ -1,4 +1,4 @@
-CFG_RELEASE_NUM=0.4.0
+CFG_RELEASE_NUM=0.5.0
 CFG_RELEASE_LABEL=
 
 include config.mk


### PR DESCRIPTION
Another Rust release rolled around so bump Cargo as well

r? @brson 

I'll tag 0.4.0 after this merges