### PR TITLE
Add relocation-model option to build profiles

### DIFF
--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -117,6 +117,7 @@ pub struct Profile {
     pub test: bool,
     pub doc: bool,
     pub relocation_model: Option<String>,
+    pub emit: Option<Vec<String>>,
 }
 
 #[derive(Default, Clone, Debug)]
@@ -458,6 +459,7 @@ impl Default for Profile {
             test: false,
             doc: false,
             relocation_model: None,
+            emit: None,
         }
     }
 }

--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -116,6 +116,7 @@ pub struct Profile {
     pub rpath: bool,
     pub test: bool,
     pub doc: bool,
+    pub relocation_model: Option<String>,
 }
 
 #[derive(Default, Clone, Debug)]
@@ -456,6 +457,7 @@ impl Default for Profile {
             rpath: false,
             test: false,
             doc: false,
+            relocation_model: None,
         }
     }
 }

--- a/src/cargo/ops/cargo_rustc/mod.rs
+++ b/src/cargo/ops/cargo_rustc/mod.rs
@@ -585,7 +585,7 @@ fn build_base_args(cx: &Context,
                    crate_types: &[&str]) {
     let Profile {
         opt_level, lto, codegen_units, ref rustc_args, debuginfo, debug_assertions,
-        rpath, test, doc: _doc,
+        rpath, test, doc: _doc, ref relocation_model,
     } = *profile;
 
     // Move to cwd so the root_path() passed below is actually correct
@@ -661,6 +661,13 @@ fn build_base_args(cx: &Context,
 
     if rpath {
         cmd.arg("-C").arg("rpath");
+    }
+
+    match *relocation_model {
+        Some(ref model) => {
+            cmd.arg("-C").arg(&format!("relocation-model={}", model));
+        }
+        None => {}
     }
 }
 

--- a/src/cargo/ops/cargo_rustc/mod.rs
+++ b/src/cargo/ops/cargo_rustc/mod.rs
@@ -577,6 +577,7 @@ fn root_path(cx: &Context, pkg: &Package, target: &Target) -> PathBuf {
     }
 }
 
+#[allow(deprecated)] // connect => join in 1.3
 fn build_base_args(cx: &Context,
                    cmd: &mut CommandPrototype,
                    pkg: &Package,
@@ -585,7 +586,7 @@ fn build_base_args(cx: &Context,
                    crate_types: &[&str]) {
     let Profile {
         opt_level, lto, codegen_units, ref rustc_args, debuginfo, debug_assertions,
-        rpath, test, doc: _doc, ref relocation_model,
+        rpath, test, doc: _doc, ref relocation_model, ref emit
     } = *profile;
 
     // Move to cwd so the root_path() passed below is actually correct
@@ -669,6 +670,13 @@ fn build_base_args(cx: &Context,
         }
         None => {}
     }
+
+	match *emit {
+		Some(ref targets) => {
+			cmd.arg("--emit").arg(targets.connect(","));
+		}
+		None => {}
+	}
 }
 
 

--- a/src/cargo/util/toml.rs
+++ b/src/cargo/util/toml.rs
@@ -242,6 +242,7 @@ pub struct TomlProfile {
     debug: Option<bool>,
     debug_assertions: Option<bool>,
     rpath: Option<bool>,
+    relocation_model: Option<String>,
 }
 
 #[derive(RustcDecodable)]
@@ -909,7 +910,7 @@ fn build_profiles(profiles: &Option<TomlProfiles>) -> Profiles {
 
     fn merge(profile: Profile, toml: Option<&TomlProfile>) -> Profile {
         let &TomlProfile {
-            opt_level, lto, codegen_units, debug, debug_assertions, rpath
+            opt_level, lto, codegen_units, debug, debug_assertions, rpath, ref relocation_model,
         } = match toml {
             Some(toml) => toml,
             None => return profile,
@@ -924,6 +925,7 @@ fn build_profiles(profiles: &Option<TomlProfiles>) -> Profiles {
             rpath: rpath.unwrap_or(profile.rpath),
             test: profile.test,
             doc: profile.doc,
+            relocation_model: relocation_model.clone(),
         }
     }
 }

--- a/src/cargo/util/toml.rs
+++ b/src/cargo/util/toml.rs
@@ -243,6 +243,7 @@ pub struct TomlProfile {
     debug_assertions: Option<bool>,
     rpath: Option<bool>,
     relocation_model: Option<String>,
+    emit: Option<Vec<String>>,
 }
 
 #[derive(RustcDecodable)]
@@ -911,6 +912,7 @@ fn build_profiles(profiles: &Option<TomlProfiles>) -> Profiles {
     fn merge(profile: Profile, toml: Option<&TomlProfile>) -> Profile {
         let &TomlProfile {
             opt_level, lto, codegen_units, debug, debug_assertions, rpath, ref relocation_model,
+            ref emit,
         } = match toml {
             Some(toml) => toml,
             None => return profile,
@@ -926,6 +928,7 @@ fn build_profiles(profiles: &Option<TomlProfiles>) -> Profiles {
             test: profile.test,
             doc: profile.doc,
             relocation_model: relocation_model.clone(),
+            emit: emit.clone(),
         }
     }
 }


### PR DESCRIPTION
rustc has an option to change the way symbol relocation happens at compile
time. While the default of pic is often preferred, there are some cases where
a user may need to output an object where the symbols are non-relocatable
(some kernels, for instance).

Expose the relocation-model argument to the user through the profiles stanza
in Cargo.toml.