### PR TITLE
bin/new: Use uppercase option arguments

### DIFF
--- a/src/bin/new.rs
+++ b/src/bin/new.rs
@@ -23,11 +23,11 @@ Usage:
 
 Options:
     -h, --help          Print this message
-    --vcs <vcs>         Initialize a new repository for the given version
+    --vcs VCS           Initialize a new repository for the given version
                         control system (git or hg) or do not initialize any version
                         control at all (none) overriding a global configuration.
     --bin               Use a binary instead of a library template
-    --name <name>       Set the resulting package name
+    --name NAME         Set the resulting package name
     -v, --verbose       Use verbose output
     -q, --quiet         No output printed to stdout
     --color WHEN        Coloring: auto, always, never


### PR DESCRIPTION
Every other command except for `cargo new` is using <argument> for positional arguments and ARG for option arguments.