### PR TITLE
make sure that environment-variables page is built

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -119,7 +119,8 @@ clean:
 
 # === Documentation
 
-DOCS := index faq config guide manifest build-script pkgid-spec crates-io
+DOCS := index faq config guide manifest build-script pkgid-spec crates-io \
+	environment-variables
 DOC_DIR := target/doc
 DOC_OPTS := --markdown-no-toc \
 		--markdown-css stylesheets/normalize.css \


### PR DESCRIPTION
#1845 seems to have forgotten to add the page to the DOCS variable in the makefile