### PR TITLE
Fix platform-specific dependency resolution for cross-compiled custom builds

### DIFF
--- a/src/cargo/core/dependency.rs
+++ b/src/cargo/core/dependency.rs
@@ -152,15 +152,6 @@ impl Dependency {
             (self.only_match_name || (self.req.matches(id.version()) &&
                                       &self.source_id == id.source_id()))
     }
-
-    /// Returns true if the dependency should be built for this platform.
-    pub fn is_active_for_platform(&self, platform: &str) -> bool {
-        match self.only_for_platform {
-            None => true,
-            Some(ref p) if *p == platform => true,
-            _ => false
-        }
-    }
 }
 
 #[derive(PartialEq,Clone,RustcEncodable)]

--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -145,13 +145,10 @@ pub fn compile_pkg<'a>(package: &Package,
 
         try!(registry.add_overrides(override_ids));
 
-        let platform = target.as_ref().unwrap_or(&config.rustc_info().host);
-
         let method = Method::Required {
             dev_deps: true, // TODO: remove this option?
             features: &features,
             uses_default_features: !no_default_features,
-            target_platform: Some(&platform[..]),
         };
 
         let resolved_with_overrides =

--- a/src/cargo/ops/cargo_rustc/fingerprint.rs
+++ b/src/cargo/ops/cargo_rustc/fingerprint.rs
@@ -176,7 +176,7 @@ fn calculate<'a, 'cfg>(cx: &mut Context<'a, 'cfg>,
     // elsewhere. Also skip fingerprints of binaries because they don't actually
     // induce a recompile, they're just dependencies in the sense that they need
     // to be built.
-    let deps = try!(cx.dep_targets(pkg, target, profile).into_iter()
+    let deps = try!(cx.dep_targets(pkg, target, kind, profile).into_iter()
                       .filter(|&(_, t, _)| !t.is_custom_build() && !t.is_bin())
                       .map(|(pkg, target, profile)| {
         let kind = match kind {


### PR DESCRIPTION
This fixes a specific issue with platform-specific dependencies of build dependencies when cross-compiling. The gist of the problem is that when dependencies are initially resolved, only the target platform is considered, which can cause the later analysis of the graph by the custom build process to miss dependencies.

I fixed the issue by including both target and host platforms in the dependency resolution process. I'm brand new to the Rust ecosystem and language, so I'm not sure if this is the right route architecturally, or if my code is even remotely acceptable. Any feedback would be greatly appreciated!

I've also included a test case to demonstrate the problem; it fails against the current master.

Thanks!