### PR TITLE
Fix for issue #1942 'cargo run fails if called from executable folder'

### DIFF
--- a/src/cargo/ops/cargo_run.rs
+++ b/src/cargo/ops/cargo_run.rs
@@ -48,7 +48,9 @@ pub fn run(manifest_path: &Path,
     let compile = try!(ops::compile(manifest_path, options));
     let exe = &compile.binaries[0];
     let exe = match util::without_prefix(&exe, config.cwd()) {
-        Some(path) => path,
+        Some(path) => if path.as_os_str() == path.file_name().unwrap() { &**exe } 
+                      else { path }, // workaround for being able to use
+                                     // `cargo run` from the executable path itself
         None => &**exe,
     };
     let mut process = try!(compile.target_process(exe, &root))

--- a/src/cargo/ops/cargo_run.rs
+++ b/src/cargo/ops/cargo_run.rs
@@ -48,10 +48,10 @@ pub fn run(manifest_path: &Path,
     let compile = try!(ops::compile(manifest_path, options));
     let exe = &compile.binaries[0];
     let exe = match util::without_prefix(&exe, config.cwd()) {
-        Some(path) => if path.as_os_str() == path.file_name().unwrap() { &**exe } 
-                      else { path }, // workaround for being able to use
-                                     // `cargo run` from the executable path itself
-        None => &**exe,
+        Some(path) if path.file_name() == Some(path.as_os_str())
+                   => Path::new(".").join(path).to_path_buf(),
+        Some(path) => path.to_path_buf(),
+        None => exe.to_path_buf(),
     };
     let mut process = try!(compile.target_process(exe, &root))
                                   .into_process_builder();

--- a/tests/test_cargo_run.rs
+++ b/tests/test_cargo_run.rs
@@ -479,9 +479,10 @@ test!(run_from_executable_folder {
 
     assert_that(p.cargo("run").cwd(cwd), 
                 execs().with_status(0).with_stdout(&format!("\
-{running} `./foo`
+{running} `.{sep}foo[..]`
 hello
 ",
-        running = RUNNING
+        running = RUNNING,
+        sep = SEP
         )));
 });

--- a/tests/test_cargo_run.rs
+++ b/tests/test_cargo_run.rs
@@ -461,3 +461,27 @@ test!(dashes_are_forwarded {
     assert_that(p.cargo_process("run").arg("--").arg("a").arg("--").arg("b"),
                 execs().with_status(0));
 });
+
+test!(run_from_executable_folder {
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [project]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+        "#)
+        .file("src/main.rs", r#"
+            fn main() { println!("hello"); }
+        "#);
+
+    let cwd = p.root().join("target").join("debug");
+    p.cargo_process("build").exec_with_output().unwrap();
+
+    assert_that(p.cargo("run").cwd(cwd), 
+                execs().with_status(0).with_stdout(&format!("\
+{running} `./foo`
+hello
+",
+        running = RUNNING
+        )));
+});


### PR DESCRIPTION
It maybe a tacky way, but I think that changing `util::without_prefix` is a bad approach. Maybe modify `process.build_command` could be another possible approach.

It could be worth to take more time to be sure to find the root of the problem. I am quite new to rust, if anybody can point out the right way of dealing with it, I will be happy to submit a new PR.