### PR TITLE
bash completion for targets

### DIFF
--- a/src/etc/cargo.bashcomp.sh
+++ b/src/etc/cargo.bashcomp.sh
@@ -100,7 +100,12 @@ _get_examples(){
 }
 
 _get_targets(){
-	local CURRENT_PATH=$(_locate_manifest)
+	local CURRENT_PATH
+	if [ `uname -o` == "Cygwin" -a -f "$PWD"/Cargo.toml ]; then
+		CURRENT_PATH=$PWD
+	else
+		CURRENT_PATH=$(_locate_manifest)
+	fi
 	if [[ -z "$CURRENT_PATH" ]]; then
 		return 1
 	fi

--- a/src/etc/cargo.bashcomp.sh
+++ b/src/etc/cargo.bashcomp.sh
@@ -103,6 +103,7 @@ _get_targets(){
 	local TARGETS=()
 	local FIND_PATHS=( "/" )
 	local CURRENT_PATH=$(_locate_manifest)
+	local FIND_PATH LINES LINE
 	while [[ "$CURRENT_PATH" != "/" ]]; do
 	    FIND_PATHS+=( "$CURRENT_PATH" )
 	    CURRENT_PATH=$(dirname $CURRENT_PATH)

--- a/src/etc/cargo.bashcomp.sh
+++ b/src/etc/cargo.bashcomp.sh
@@ -62,6 +62,9 @@ _cargo()
 			--example)
 				COMPREPLY=( $( compgen -W "$(_get_examples)" -- "$cur" ) )
 				;;
+			--target)
+				COMPREPLY=( $( compgen -W "$(_get_targets)" -- "$cur" ) )
+				;;
 			help)
 				COMPREPLY=( $( compgen -W "$__cargo_commands" -- "$cur" ) )
 				;;
@@ -94,5 +97,24 @@ _get_examples(){
 	if [[ "${names[@]}" != "*" ]]; then
 		echo "${names[@]}"
 	fi
+}
+
+_get_targets(){
+	local TARGETS=()
+	local FIND_PATHS=( "/" )
+	local CURRENT_PATH=$(_locate_manifest)
+	while [[ "$CURRENT_PATH" != "/" ]]; do
+	    FIND_PATHS+=( "$CURRENT_PATH" )
+	    CURRENT_PATH=$(dirname $CURRENT_PATH)
+	done
+	for FIND_PATH in ${FIND_PATHS[@]}; do
+	    if [[ -f "$FIND_PATH"/.cargo/config ]]; then
+		LINES=( `grep "$FIND_PATH"/.cargo/config -e "^\[target\."` )
+		for LINE in ${LINES[@]}; do
+		    TARGETS+=(`sed 's/^\[target\.\(.*\)\]$/\1/' <<< $LINE`)
+		done
+	    fi
+	done
+	echo "${TARGETS[@]}"
 }
 # vim:ft=sh

--- a/src/etc/cargo.bashcomp.sh
+++ b/src/etc/cargo.bashcomp.sh
@@ -100,9 +100,12 @@ _get_examples(){
 }
 
 _get_targets(){
+	local CURRENT_PATH=$(_locate_manifest)
+	if [[ -z "$CURRENT_PATH" ]]; then
+		return 1
+	fi
 	local TARGETS=()
 	local FIND_PATHS=( "/" )
-	local CURRENT_PATH=$(_locate_manifest)
 	local FIND_PATH LINES LINE
 	while [[ "$CURRENT_PATH" != "/" ]]; do
 	    FIND_PATHS+=( "$CURRENT_PATH" )


### PR DESCRIPTION
This BASH function will find available cargo configurations recursively from the project directory to root and provide options for `--target`.