### PR TITLE
Implement --no-fail-fast flag for cargo test.

### DIFF
--- a/src/bin/bench.rs
+++ b/src/bin/bench.rs
@@ -95,10 +95,7 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
     match err {
         None => Ok(None),
         Some(err) => {
-            Err(match err.exit.as_ref().and_then(|c| c.code()) {
-                Some(i) => CliError::new("", i),
-                None => CliError::from_error(Human(err), 101)
-            })
+            Err(CliError::from_error(Human(err), 101))
         }
     }
 }

--- a/src/bin/bench.rs
+++ b/src/bin/bench.rs
@@ -68,6 +68,7 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
 
     let ops = ops::TestOptions {
         no_run: options.flag_no_run,
+        no_fail_fast: false,
         compile_opts: ops::CompileOptions {
             config: config,
             jobs: options.flag_jobs,

--- a/src/bin/bench.rs
+++ b/src/bin/bench.rs
@@ -95,7 +95,10 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
     match err {
         None => Ok(None),
         Some(err) => {
-            Err(CliError::from_error(Human(err), 101))
+            Err(match err.exit.as_ref().and_then(|e| e.code()) {
+                Some(i) => CliError::new("", i),
+                None => CliError::from_error(Human(err), 101)
+            })
         }
     }
 }

--- a/src/bin/test.rs
+++ b/src/bin/test.rs
@@ -21,6 +21,7 @@ struct Options {
     flag_quiet: bool,
     flag_color: Option<String>,
     flag_release: bool,
+    flag_no_fail_fast: bool,
 }
 
 pub const USAGE: &'static str = "
@@ -47,6 +48,7 @@ Options:
     -v, --verbose            Use verbose output
     -q, --quiet              No output printed to stdout
     --color WHEN             Coloring: auto, always, never
+    --no-fail-fast           Run all tests regardless of failure
 
 All of the trailing arguments are passed to the test binaries generated for
 filtering tests and generally providing options configuring how they run. For
@@ -72,6 +74,7 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
 
     let ops = ops::TestOptions {
         no_run: options.flag_no_run,
+        no_fail_fast: options.flag_no_fail_fast,
         compile_opts: ops::CompileOptions {
             config: config,
             jobs: options.flag_jobs,

--- a/src/bin/test.rs
+++ b/src/bin/test.rs
@@ -101,7 +101,10 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
     match err {
         None => Ok(None),
         Some(err) => {
-            Err(CliError::from_error(Human(err), 101))
+            Err(match err.exit.as_ref().and_then(|e| e.code()) {
+                Some(i) => CliError::new("", i),
+                None => CliError::from_error(Human(err), 101)
+            })
         }
     }
 }

--- a/src/bin/test.rs
+++ b/src/bin/test.rs
@@ -101,10 +101,7 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
     match err {
         None => Ok(None),
         Some(err) => {
-            Err(match err.exit.as_ref().and_then(|e| e.code()) {
-                Some(i) => CliError::new("", i),
-                None => CliError::from_error(Human(err), 101)
-            })
+            Err(CliError::from_error(Human(err), 101))
         }
     }
 }

--- a/src/cargo/ops/cargo_test.rs
+++ b/src/cargo/ops/cargo_test.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 use core::Source;
 use sources::PathSource;
 use ops::{self, ExecEngine, ProcessEngine, Compilation};
-use util::{self, CargoResult, CargoError, internal};
+use util::{self, CargoResult, CargoTestError, ProcessError};
 
 pub struct TestOptions<'a> {
     pub compile_opts: ops::CompileOptions<'a>,
@@ -12,47 +12,124 @@ pub struct TestOptions<'a> {
     pub no_fail_fast: bool,
 }
 
+
+
 #[allow(deprecated)] // connect => join in 1.3
 pub fn run_tests(manifest_path: &Path,
                  options: &TestOptions,
-                 test_args: &[String]) -> CargoResult<Option<Box<CargoError>>> {
-    let config = options.compile_opts.config;
-    let (compile, error) = try!(build_and_run(manifest_path, options, test_args));
+                 test_args: &[String]) -> CargoResult<Option<CargoTestError>> {
+    let compilation = try!(compile_tests(manifest_path, options));
 
-    // If we have an error and want to fail fast, return
-    if error.is_some() && !options.no_fail_fast {
-        return Ok(error)
-    }
-    // If a specific test was requested or we're not running any tests at all,
-    // don't run any doc tests.
-    if let ops::CompileFilter::Only { .. } = options.compile_opts.filter {
-        return Ok(None)
-    }
     if options.no_run {
         return Ok(None)
     }
+    let mut errors = try!(run_unit_tests(options, test_args, &compilation));
 
-    let libs = compile.package.targets().iter()
-                      .filter(|t| t.doctested())
-                      .map(|t| (t.src_path(), t.name(), t.crate_name()));
+    // If we have an error and want to fail fast, return
+    if errors.len() > 0 && !options.no_fail_fast {
+        return Ok(Some(CargoTestError::from(&errors[..])))
+    }
 
-    let mut errors = match error {
-        None => Vec::new(),
-        Some(err) => vec![err],
-    };
+    // If a specific test was requested or we're not running any tests at all,
+    // don't run any doc tests.
+    if let ops::CompileFilter::Only { .. } = options.compile_opts.filter {
+        match errors.len() {
+            0 => return Ok(None),
+            _ => return Ok(Some(CargoTestError::from(&errors[..])))
+        }
+    }
+
+    errors.extend(try!(run_doc_tests(options, test_args, &compilation)));
+    if errors.len() == 0 {
+        Ok(None)
+    } else {
+        Ok(Some(CargoTestError::from(&errors[..])))
+    }
+}
+
+pub fn run_benches(manifest_path: &Path,
+                   options: &TestOptions,
+                   args: &[String]) -> CargoResult<Option<CargoTestError>> {
+    let mut args = args.to_vec();
+    args.push("--bench".to_string());
+    let compilation = try!(compile_tests(manifest_path, options));
+    let errors = try!(run_unit_tests(options, &args, &compilation));
+    match errors.len() {
+        0 => Ok(None),
+        _ => Ok(Some(CargoTestError::from(&errors[..]))),
+    }
+}
+
+fn compile_tests<'a>(manifest_path: &Path,
+                     options: &TestOptions<'a>)
+                     -> CargoResult<Compilation<'a>> {
+    let config = options.compile_opts.config;
+    let mut source = try!(PathSource::for_path(&manifest_path.parent().unwrap(),
+                                               config));
+    try!(source.update());
+
+    let mut compilation = try!(ops::compile(manifest_path, &options.compile_opts));
+    compilation.tests.sort();
+    Ok(compilation)
+}
+
+/// Run the unit and integration tests of a project.
+fn run_unit_tests(options: &TestOptions,
+                  test_args: &[String],
+                  compilation: &Compilation)
+                  -> CargoResult<Vec<ProcessError>> {
+    let config = options.compile_opts.config;
+    let cwd = options.compile_opts.config.cwd();
+
+    let mut errors = Vec::new();
+
+    for &(_, ref exe) in &compilation.tests {
+        let to_display = match util::without_prefix(exe, &cwd) {
+            Some(path) => path,
+            None => &**exe,
+        };
+        let mut cmd = try!(compilation.target_process(exe, &compilation.package));
+        cmd.args(test_args);
+        try!(config.shell().concise(|shell| {
+            shell.status("Running", to_display.display().to_string())
+        }));
+        try!(config.shell().verbose(|shell| {
+            shell.status("Running", cmd.to_string())
+        }));
+
+        if let Err(e) = ExecEngine::exec(&mut ProcessEngine, cmd) {
+            errors.push(e);
+            if !options.no_fail_fast {
+                break
+            }
+        }
+    }
+    Ok(errors)
+}
+
+#[allow(deprecated)] // connect => join in 1.3
+fn run_doc_tests(options: &TestOptions,
+                 test_args: &[String],
+                 compilation: &Compilation)
+                 -> CargoResult<Vec<ProcessError>> {
+    let mut errors = Vec::new();
+    let config = options.compile_opts.config;
+    let libs = compilation.package.targets().iter()
+                    .filter(|t| t.doctested())
+                    .map(|t| (t.src_path(), t.name(), t.crate_name()));
     for (lib, name, crate_name) in libs {
         try!(config.shell().status("Doc-tests", name));
-        let mut p = try!(compile.rustdoc_process(&compile.package));
+        let mut p = try!(compilation.rustdoc_process(&compilation.package));
         p.arg("--test").arg(lib)
          .arg("--crate-name").arg(&crate_name)
-         .cwd(compile.package.root());
+         .cwd(compilation.package.root());
 
-        for &rust_dep in &[&compile.deps_output, &compile.root_output] {
+        for &rust_dep in &[&compilation.deps_output, &compilation.root_output] {
             let mut arg = OsString::from("dependency=");
             arg.push(rust_dep);
             p.arg("-L").arg(arg);
         }
-        for native_dep in compile.native_dirs.values() {
+        for native_dep in compilation.native_dirs.values() {
             p.arg("-L").arg(native_dep);
         }
 
@@ -60,11 +137,11 @@ pub fn run_tests(manifest_path: &Path,
             p.arg("--test-args").arg(&test_args.connect(" "));
         }
 
-        for feat in compile.features.iter() {
+        for feat in compilation.features.iter() {
             p.arg("--cfg").arg(&format!("feature=\"{}\"", feat));
         }
 
-        for (_, libs) in compile.libraries.iter() {
+        for (_, libs) in compilation.libraries.iter() {
             for &(ref target, ref lib) in libs.iter() {
                 // Note that we can *only* doctest rlib outputs here.  A
                 // staticlib output cannot be linked by the compiler (it just
@@ -91,81 +168,11 @@ pub fn run_tests(manifest_path: &Path,
             shell.status("Running", p.to_string())
         }));
         if let Err(e) = ExecEngine::exec(&mut ProcessEngine, p) {
-            errors.push(Box::new(e));
-            if !options.no_fail_fast {
-                break
-            }
-        }
-    }
-    if errors.is_empty() {
-        Ok(None)
-    } else if errors.len() == 1 {
-        Ok(Some(errors.pop().unwrap()))
-    } else {
-        let err = internal("Multiple tests failed");
-        Ok(Some(err))
-    }
-
-}
-
-pub fn run_benches(manifest_path: &Path,
-                   options: &TestOptions,
-                   args: &[String]) -> CargoResult<Option<Box<CargoError>>> {
-    let mut args = args.to_vec();
-    args.push("--bench".to_string());
-
-    match try!(build_and_run(manifest_path, options, &args)).1 {
-        Some(err) => Ok(Some(err)),
-        None => Ok(None)
-    }
-}
-
-// This function always has to return the Compilation, regardless of errors.
-// Otherwise --no-fail-fast is not possible.
-fn build_and_run<'a>(manifest_path: &Path,
-                     options: &TestOptions<'a>,
-                     test_args: &[String])
-                     -> CargoResult<(Compilation<'a>, Option<Box<CargoError>>)> {
-    let config = options.compile_opts.config;
-    let mut source = try!(PathSource::for_path(&manifest_path.parent().unwrap(),
-                                               config));
-    try!(source.update());
-
-    let mut compile = try!(ops::compile(manifest_path, &options.compile_opts));
-    if options.no_run { return Ok((compile, None)) }
-    compile.tests.sort();
-
-    let cwd = config.cwd();
-    let mut errors = Vec::new();
-    for &(_, ref exe) in &compile.tests {
-        let to_display = match util::without_prefix(exe, &cwd) {
-            Some(path) => path,
-            None => &**exe,
-        };
-        let mut cmd = try!(compile.target_process(exe, &compile.package));
-        cmd.args(test_args);
-        try!(config.shell().concise(|shell| {
-            shell.status("Running", to_display.display().to_string())
-        }));
-        try!(config.shell().verbose(|shell| {
-            shell.status("Running", cmd.to_string())
-        }));
-
-        if let Err(e) = ExecEngine::exec(&mut ProcessEngine, cmd) {
             errors.push(e);
             if !options.no_fail_fast {
                 break
             }
         }
     }
-    if errors.is_empty() {
-        Ok((compile, None))
-    } else if errors.len() == 1 {
-        // Just one error occured => we can return it.
-        Ok((compile, Some(Box::new(errors.pop().unwrap()))))
-    } else {
-        // Multiple tests failed => Create a more generic error
-        let err = internal("Multiple tests failed");
-        Ok((compile, Some(err)))
-    }
+    Ok(errors)
 }

--- a/src/cargo/ops/cargo_test.rs
+++ b/src/cargo/ops/cargo_test.rs
@@ -27,7 +27,7 @@ pub fn run_tests(manifest_path: &Path,
 
     // If we have an error and want to fail fast, return
     if errors.len() > 0 && !options.no_fail_fast {
-        return Ok(Some(CargoTestError::from(&errors[..])))
+        return Ok(Some(CargoTestError::new(errors)))
     }
 
     // If a specific test was requested or we're not running any tests at all,
@@ -35,7 +35,7 @@ pub fn run_tests(manifest_path: &Path,
     if let ops::CompileFilter::Only { .. } = options.compile_opts.filter {
         match errors.len() {
             0 => return Ok(None),
-            _ => return Ok(Some(CargoTestError::from(&errors[..])))
+            _ => return Ok(Some(CargoTestError::new(errors)))
         }
     }
 
@@ -43,7 +43,7 @@ pub fn run_tests(manifest_path: &Path,
     if errors.len() == 0 {
         Ok(None)
     } else {
-        Ok(Some(CargoTestError::from(&errors[..])))
+        Ok(Some(CargoTestError::new(errors)))
     }
 }
 
@@ -56,7 +56,7 @@ pub fn run_benches(manifest_path: &Path,
     let errors = try!(run_unit_tests(options, &args, &compilation));
     match errors.len() {
         0 => Ok(None),
-        _ => Ok(Some(CargoTestError::from(&errors[..]))),
+        _ => Ok(Some(CargoTestError::new(errors))),
     }
 }
 

--- a/src/cargo/ops/cargo_test.rs
+++ b/src/cargo/ops/cargo_test.rs
@@ -102,7 +102,10 @@ pub fn run_tests(manifest_path: &Path,
     } else if process_errors.len() == 1 {
         Ok(Some(process_errors.pop().unwrap()))
     } else {
-        let err = process_error("Multiple tests failed", None, process_errors[0].exit.as_ref(), process_errors[0].output.as_ref());
+        let err = process_error("Multiple tests failed",
+                                None,
+                                process_errors[0].exit.as_ref(),
+                                process_errors[0].output.as_ref());
         Ok(Some(err))
     }
 
@@ -165,7 +168,10 @@ fn build_and_run<'a>(manifest_path: &Path,
         Ok((compile, Some(errors.pop().unwrap())))
     } else {
         // Multiple tests failed => Create a more generic error
-        let err = process_error("Multiple tests failed", None, errors[0].exit.as_ref(), errors[0].output.as_ref());
+        let err = process_error("Multiple tests failed",
+                                None,
+                                errors[0].exit.as_ref(),
+                                errors[0].output.as_ref());
         Ok((compile, Some(err)))
     }
 }

--- a/src/cargo/util/mod.rs
+++ b/src/cargo/util/mod.rs
@@ -2,7 +2,7 @@ pub use self::config::Config;
 pub use self::dependency_queue::Dependency;
 pub use self::dependency_queue::{DependencyQueue, Fresh, Dirty, Freshness};
 pub use self::errors::{CargoResult, CargoError, ChainError, CliResult};
-pub use self::errors::{CliError, ProcessError};
+pub use self::errors::{CliError, ProcessError, CargoTestError};
 pub use self::errors::{Human, caused_human};
 pub use self::errors::{process_error, internal_error, internal, human};
 pub use self::graph::Graph;

--- a/tests/test_cargo_bench.rs
+++ b/tests/test_cargo_bench.rs
@@ -192,7 +192,7 @@ test bench_hello ... ",
 thread '<main>' panicked at 'assertion failed: \
     `(left == right)` (left: \
     `\"hello\"`, right: `\"nope\"`)', src[..]foo.rs:14
-
+[..]
 ")
               .with_status(101));
 });

--- a/tests/test_cargo_test.rs
+++ b/tests/test_cargo_test.rs
@@ -1857,6 +1857,7 @@ test!(dev_dep_with_build_script {
 });
 
 test!(no_fail_fast {
+    if !::can_panic() { return }
     let p = project("foo")
         .file("Cargo.toml", r#"
             [package]

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -74,5 +74,5 @@ fn is_nightly() -> bool {
 }
 
 fn can_panic() -> bool {
-    RUSTC.with(|r| !r.host.contains("msvc"))
+    RUSTC.with(|r| !(r.host.contains("msvc") && !r.host.contains("x86_64")))
 }


### PR DESCRIPTION
This flag can be used to force cargo to run all tests, even if previous
tests failed. See #1904