### PR TITLE
Manifest path consistency

### DIFF
--- a/src/bin/read_manifest.rs
+++ b/src/bin/read_manifest.rs
@@ -1,31 +1,51 @@
-use std::path::Path;
+use std::env;
 use std::error::Error;
+use std::path::PathBuf;
 
 use cargo::core::{Package, Source};
 use cargo::util::{CliResult, CliError, Config};
+use cargo::util::important_paths::{find_root_manifest_for_cwd};
 use cargo::sources::{PathSource};
 
 #[derive(RustcDecodable)]
 struct Options {
-    flag_manifest_path: String,
+    flag_manifest_path: Option<String>,
     flag_color: Option<String>,
 }
 
 pub const USAGE: &'static str = "
 Usage:
-    cargo read-manifest [options] --manifest-path=PATH
+    cargo read-manifest [options]
     cargo read-manifest -h | --help
 
 Options:
     -h, --help               Print this message
     -v, --verbose            Use verbose output
+    --manifest-path PATH     Path to the manifest to compile
     --color WHEN             Coloring: auto, always, never
 ";
 
 pub fn execute(options: Options, config: &Config) -> CliResult<Option<Package>> {
+    debug!("executing; cmd=cargo-read-manifest; args={:?}",
+           env::args().collect::<Vec<_>>());
     try!(config.shell().set_color_config(options.flag_color.as_ref().map(|s| &s[..])));
-    let path = Path::new(&options.flag_manifest_path);
-    let mut source = try!(PathSource::for_path(&path, config).map_err(|e| {
+
+    // Accept paths to directories containing Cargo.toml for backwards compatibility.
+    let root = match options.flag_manifest_path {
+        Some(path) => {
+            let mut path = PathBuf::from(path);
+            if !path.ends_with("Cargo.toml") {
+                path.push("Cargo.toml");
+            }
+            Some(path.display().to_string())
+        },
+        None => None,
+    };
+    let root = try!(find_root_manifest_for_cwd(root));
+
+    debug!("read-manifest; manifest-path={}", root.display());
+
+    let mut source = try!(PathSource::for_path(root.parent().unwrap(), config).map_err(|e| {
         CliError::new(e.description(), 1)
     }));
 

--- a/src/bin/verify_project.rs
+++ b/src/bin/verify_project.rs
@@ -11,7 +11,7 @@ pub type Error = HashMap<String, String>;
 
 #[derive(RustcDecodable)]
 struct Flags {
-    flag_manifest_path: String,
+    flag_manifest_path: Option<String>,
     flag_verbose: bool,
     flag_quiet: bool,
     flag_color: Option<String>,
@@ -19,7 +19,7 @@ struct Flags {
 
 pub const USAGE: &'static str = "
 Usage:
-    cargo verify-project [options] --manifest-path PATH
+    cargo verify-project [options]
     cargo verify-project -h | --help
 
 Options:
@@ -35,7 +35,8 @@ pub fn execute(args: Flags, config: &Config) -> CliResult<Option<Error>> {
     try!(config.shell().set_color_config(args.flag_color.as_ref().map(|s| &s[..])));
 
     let mut contents = String::new();
-    let file = File::open(&args.flag_manifest_path);
+    let filename = args.flag_manifest_path.unwrap_or("Cargo.toml".into());
+    let file = File::open(&filename);
     match file.and_then(|mut f| f.read_to_string(&mut contents)) {
         Ok(_) => {},
         Err(e) => fail("invalid", &format!("error reading file: {}", e))

--- a/tests/test_cargo_read_manifest.rs
+++ b/tests/test_cargo_read_manifest.rs
@@ -1,0 +1,79 @@
+use support::{project, execs, main_file, basic_bin_manifest, ProjectBuilder};
+use hamcrest::{assert_that};
+
+fn setup() {}
+
+fn read_manifest_output() -> String {
+    "\
+{\
+    \"name\":\"foo\",\
+    \"version\":\"0.5.0\",\
+    \"dependencies\":[],\
+    \"targets\":[{\
+        \"kind\":[\"bin\"],\
+        \"name\":\"foo\",\
+        \"src_path\":\"src[..]foo.rs\",\
+        \"metadata\":null\
+    }],\
+    \"manifest_path\":\"[..]Cargo.toml\"\
+}".into()
+}
+
+test!(cargo_read_manifest_path_to_cargo_toml_relative {
+    let p = project("foo")
+        .file("Cargo.toml", &basic_bin_manifest("foo"))
+        .file("src/foo.rs", &main_file(r#""i am foo""#, &[]));
+
+    assert_that(p.cargo_process("read-manifest")
+                 .arg("--manifest-path").arg("foo/Cargo.toml")
+                 .cwd(p.root().parent().unwrap()),
+                execs().with_status(0)
+                       .with_stdout(read_manifest_output()));
+});
+
+test!(cargo_read_manifest_path_to_cargo_toml_absolute {
+    let p = project("foo")
+        .file("Cargo.toml", &basic_bin_manifest("foo"))
+        .file("src/foo.rs", &main_file(r#""i am foo""#, &[]));
+
+    assert_that(p.cargo_process("read-manifest")
+                 .arg("--manifest-path").arg(p.root().join("Cargo.toml"))
+                 .cwd(p.root().parent().unwrap()),
+                execs().with_status(0)
+                       .with_stdout(read_manifest_output()));
+});
+
+test!(cargo_read_manifest_path_to_cargo_toml_parent_relative {
+    let p = project("foo")
+        .file("Cargo.toml", &basic_bin_manifest("foo"))
+        .file("src/foo.rs", &main_file(r#""i am foo""#, &[]));
+
+    assert_that(p.cargo_process("read-manifest")
+                 .arg("--manifest-path").arg("foo")
+                 .cwd(p.root().parent().unwrap()),
+                execs().with_status(0)
+                       .with_stdout(read_manifest_output()));
+});
+
+test!(cargo_read_manifest_path_to_cargo_toml_parent_absolute {
+    let p = project("foo")
+        .file("Cargo.toml", &basic_bin_manifest("foo"))
+        .file("src/foo.rs", &main_file(r#""i am foo""#, &[]));
+
+    assert_that(p.cargo_process("read-manifest")
+                 .arg("--manifest-path").arg(p.root())
+                 .cwd(p.root().parent().unwrap()),
+                execs().with_status(0)
+                       .with_stdout(read_manifest_output()));
+});
+
+test!(cargo_read_manifest_cwd {
+    let p = project("foo")
+        .file("Cargo.toml", &basic_bin_manifest("foo"))
+        .file("src/foo.rs", &main_file(r#""i am foo""#, &[]));
+
+    assert_that(p.cargo_process("read-manifest")
+                 .cwd(p.root()),
+                execs().with_status(0)
+                       .with_stdout(read_manifest_output()));
+});

--- a/tests/test_cargo_verify_project.rs
+++ b/tests/test_cargo_verify_project.rs
@@ -1,0 +1,43 @@
+use support::{project, execs, main_file, basic_bin_manifest};
+use hamcrest::{assert_that};
+
+fn setup() {}
+
+fn verify_project_success_output() -> String {
+    r#"{"success":"true"}"#.into()
+}
+
+test!(cargo_verify_project_path_to_cargo_toml_relative {
+    let p = project("foo")
+        .file("Cargo.toml", &basic_bin_manifest("foo"))
+        .file("src/foo.rs", &main_file(r#""i am foo""#, &[]));
+
+    assert_that(p.cargo_process("verify-project")
+                 .arg("--manifest-path").arg("foo/Cargo.toml")
+                 .cwd(p.root().parent().unwrap()),
+                execs().with_status(0)
+                       .with_stdout(verify_project_success_output()));
+});
+
+test!(cargo_verify_project_path_to_cargo_toml_absolute {
+    let p = project("foo")
+        .file("Cargo.toml", &basic_bin_manifest("foo"))
+        .file("src/foo.rs", &main_file(r#""i am foo""#, &[]));
+
+    assert_that(p.cargo_process("verify-project")
+                 .arg("--manifest-path").arg(p.root().join("Cargo.toml"))
+                 .cwd(p.root().parent().unwrap()),
+                execs().with_status(0)
+                       .with_stdout(verify_project_success_output()));
+});
+
+test!(cargo_verify_project_cwd {
+    let p = project("foo")
+        .file("Cargo.toml", &basic_bin_manifest("foo"))
+        .file("src/foo.rs", &main_file(r#""i am foo""#, &[]));
+
+    assert_that(p.cargo_process("verify-project")
+                 .cwd(p.root()),
+                execs().with_status(0)
+                       .with_stdout(verify_project_success_output()));
+});

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -51,6 +51,7 @@ mod test_cargo_new;
 mod test_cargo_package;
 mod test_cargo_profiles;
 mod test_cargo_publish;
+mod test_cargo_read_manifest;
 mod test_cargo_registry;
 mod test_cargo_run;
 mod test_cargo_rustc;

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -58,6 +58,7 @@ mod test_cargo_rustc;
 mod test_cargo_search;
 mod test_cargo_test;
 mod test_cargo_tool_paths;
+mod test_cargo_verify_project;
 mod test_cargo_version;
 mod test_shell;
 


### PR DESCRIPTION
Hi! 

While working on something else, I noticed that `cargo read-manifest` and `cargo verify-project` behave differently in regards to `--manifest-path` than all the other subcommands. Namely:

* `read-manifest` only accepted an absolute path to a directory containing a `Cargo.toml`; all other subcommands expect `--manifest-path` to be a path to a `Cargo.toml` that can either be absolute or relative.
* Both `read-manifest` and `verify-project` required the `--manifest-path` option; all other subcommands will look at the current working directory's `Cargo.toml` if no `--manifest-path` option is given.

So I've added test cases and made these two accept the same things the other subcommands do-- but for backwards compatibility, I made `read-manifest` also continue to support the current behavior... so `read-manifest` isn't completely consistent with everything else. Please let me know if this isn't necessary or desired and I can take it out!
