### PR TITLE
Even more manifest path consistency

### DIFF
--- a/src/bin/read_manifest.rs
+++ b/src/bin/read_manifest.rs
@@ -1,6 +1,5 @@
 use std::env;
 use std::error::Error;
-use std::path::PathBuf;
 
 use cargo::core::{Package, Source};
 use cargo::util::{CliResult, CliError, Config};
@@ -30,20 +29,7 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<Package>> 
            env::args().collect::<Vec<_>>());
     try!(config.shell().set_color_config(options.flag_color.as_ref().map(|s| &s[..])));
 
-    // Accept paths to directories containing Cargo.toml for backwards compatibility.
-    let root = match options.flag_manifest_path {
-        Some(path) => {
-            let mut path = PathBuf::from(path);
-            if !path.ends_with("Cargo.toml") {
-                path.push("Cargo.toml");
-            }
-            Some(path.display().to_string())
-        },
-        None => None,
-    };
-    let root = try!(find_root_manifest_for_cwd(root));
-
-    debug!("read-manifest; manifest-path={}", root.display());
+    let root = try!(find_root_manifest_for_cwd(options.flag_manifest_path));
 
     let mut source = try!(PathSource::for_path(root.parent().unwrap(), config).map_err(|e| {
         CliError::new(e.description(), 1)

--- a/src/bin/read_manifest.rs
+++ b/src/bin/read_manifest.rs
@@ -1,31 +1,51 @@
-use std::path::Path;
+use std::env;
 use std::error::Error;
+use std::path::PathBuf;
 
 use cargo::core::{Package, Source};
 use cargo::util::{CliResult, CliError, Config};
+use cargo::util::important_paths::{find_root_manifest_for_cwd};
 use cargo::sources::{PathSource};
 
 #[derive(RustcDecodable)]
 struct Options {
-    flag_manifest_path: String,
+    flag_manifest_path: Option<String>,
     flag_color: Option<String>,
 }
 
 pub const USAGE: &'static str = "
 Usage:
-    cargo read-manifest [options] --manifest-path=PATH
+    cargo read-manifest [options]
     cargo read-manifest -h | --help
 
 Options:
     -h, --help               Print this message
     -v, --verbose            Use verbose output
+    --manifest-path PATH     Path to the manifest to compile
     --color WHEN             Coloring: auto, always, never
 ";
 
 pub fn execute(options: Options, config: &Config) -> CliResult<Option<Package>> {
+    debug!("executing; cmd=cargo-read-manifest; args={:?}",
+           env::args().collect::<Vec<_>>());
     try!(config.shell().set_color_config(options.flag_color.as_ref().map(|s| &s[..])));
-    let path = Path::new(&options.flag_manifest_path);
-    let mut source = try!(PathSource::for_path(&path, config).map_err(|e| {
+
+    // Accept paths to directories containing Cargo.toml for backwards compatibility.
+    let root = match options.flag_manifest_path {
+        Some(path) => {
+            let mut path = PathBuf::from(path);
+            if !path.ends_with("Cargo.toml") {
+                path.push("Cargo.toml");
+            }
+            Some(path.display().to_string())
+        },
+        None => None,
+    };
+    let root = try!(find_root_manifest_for_cwd(root));
+
+    debug!("read-manifest; manifest-path={}", root.display());
+
+    let mut source = try!(PathSource::for_path(root.parent().unwrap(), config).map_err(|e| {
         CliError::new(e.description(), 1)
     }));
 

--- a/src/bin/verify_project.rs
+++ b/src/bin/verify_project.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::fs;
 use std::fs::File;
 use std::io::prelude::*;
 use std::process;
@@ -36,6 +37,14 @@ pub fn execute(args: Flags, config: &Config) -> CliResult<Option<Error>> {
 
     let mut contents = String::new();
     let filename = args.flag_manifest_path.unwrap_or("Cargo.toml".into());
+
+    if !filename.ends_with("Cargo.toml") {
+        fail("invalid", "the manifest-path must be a path to a Cargo.toml file")
+    }
+    if !fs::metadata(&filename).is_ok() {
+        fail("invalid", &format!("manifest path `{}` does not exist", filename))
+    }
+
     let file = File::open(&filename);
     match file.and_then(|mut f| f.read_to_string(&mut contents)) {
         Ok(_) => {},

--- a/src/bin/verify_project.rs
+++ b/src/bin/verify_project.rs
@@ -11,7 +11,7 @@ pub type Error = HashMap<String, String>;
 
 #[derive(RustcDecodable)]
 struct Flags {
-    flag_manifest_path: String,
+    flag_manifest_path: Option<String>,
     flag_verbose: bool,
     flag_quiet: bool,
     flag_color: Option<String>,
@@ -19,7 +19,7 @@ struct Flags {
 
 pub const USAGE: &'static str = "
 Usage:
-    cargo verify-project [options] --manifest-path PATH
+    cargo verify-project [options]
     cargo verify-project -h | --help
 
 Options:
@@ -35,7 +35,8 @@ pub fn execute(args: Flags, config: &Config) -> CliResult<Option<Error>> {
     try!(config.shell().set_color_config(args.flag_color.as_ref().map(|s| &s[..])));
 
     let mut contents = String::new();
-    let file = File::open(&args.flag_manifest_path);
+    let filename = args.flag_manifest_path.unwrap_or("Cargo.toml".into());
+    let file = File::open(&filename);
     match file.and_then(|mut f| f.read_to_string(&mut contents)) {
         Ok(_) => {},
         Err(e) => fail("invalid", &format!("error reading file: {}", e))

--- a/src/cargo/util/important_paths.rs
+++ b/src/cargo/util/important_paths.rs
@@ -41,7 +41,16 @@ pub fn find_root_manifest_for_cwd(manifest_path: Option<String>)
         human("Couldn't determine the current working directory")
     }));
     match manifest_path {
-        Some(path) => Ok(cwd.join(&path)),
+        Some(path) => {
+            let absolute_path = cwd.join(&path);
+            if !absolute_path.ends_with("Cargo.toml") {
+                return Err(human("the manifest-path must be a path to a Cargo.toml file"))
+            }
+            if !fs::metadata(&absolute_path).is_ok() {
+                return Err(human(format!("manifest path `{}` does not exist", path)))
+            }
+            Ok(absolute_path)
+        },
         None => find_project_manifest(&cwd, "Cargo.toml"),
     }
 }

--- a/tests/test_bad_manifest_path.rs
+++ b/tests/test_bad_manifest_path.rs
@@ -1,0 +1,308 @@
+use support::{project, execs, main_file, basic_bin_manifest};
+use hamcrest::{assert_that};
+
+fn setup() {}
+
+fn assert_not_a_cargo_toml(command: &str, manifest_path_argument: &str) {
+    let p = project("foo")
+        .file("Cargo.toml", &basic_bin_manifest("foo"))
+        .file("src/foo.rs", &main_file(r#""i am foo""#, &[]));
+
+    assert_that(p.cargo_process(command)
+                 .arg("--manifest-path").arg(manifest_path_argument)
+                 .cwd(p.root().parent().unwrap()),
+                execs().with_status(101)
+                       .with_stderr("the manifest-path must be a path to a Cargo.toml file"));
+}
+
+#[allow(deprecated)] // connect => join in 1.3
+fn assert_cargo_toml_doesnt_exist(command: &str, manifest_path_argument: &str) {
+    let p = project("foo");
+    let expected_path = manifest_path_argument
+        .split("/").collect::<Vec<_>>().connect("[..]");
+
+    assert_that(p.cargo_process(command)
+                 .arg("--manifest-path").arg(manifest_path_argument)
+                 .cwd(p.root().parent().unwrap()),
+                execs().with_status(101)
+                       .with_stderr(
+                           format!("manifest path `{}` does not exist", expected_path)
+                       ));
+}
+
+test!(bench_dir_containing_cargo_toml {
+    assert_not_a_cargo_toml("bench", "foo");
+});
+
+test!(bench_dir_plus_file {
+    assert_not_a_cargo_toml("bench", "foo/bar");
+});
+
+test!(bench_dir_plus_path {
+    assert_not_a_cargo_toml("bench", "foo/bar/baz");
+});
+
+test!(bench_dir_to_nonexistent_cargo_toml {
+    assert_cargo_toml_doesnt_exist("bench", "foo/bar/baz/Cargo.toml");
+});
+
+test!(build_dir_containing_cargo_toml {
+    assert_not_a_cargo_toml("build", "foo");
+});
+
+test!(build_dir_plus_file {
+    assert_not_a_cargo_toml("bench", "foo/bar");
+});
+
+test!(build_dir_plus_path {
+    assert_not_a_cargo_toml("bench", "foo/bar/baz");
+});
+
+test!(build_dir_to_nonexistent_cargo_toml {
+    assert_cargo_toml_doesnt_exist("build", "foo/bar/baz/Cargo.toml");
+});
+
+test!(clean_dir_containing_cargo_toml {
+    assert_not_a_cargo_toml("clean", "foo");
+});
+
+test!(clean_dir_plus_file {
+    assert_not_a_cargo_toml("clean", "foo/bar");
+});
+
+test!(clean_dir_plus_path {
+    assert_not_a_cargo_toml("clean", "foo/bar/baz");
+});
+
+test!(clean_dir_to_nonexistent_cargo_toml {
+    assert_cargo_toml_doesnt_exist("clean", "foo/bar/baz/Cargo.toml");
+});
+
+test!(doc_dir_containing_cargo_toml {
+    assert_not_a_cargo_toml("doc", "foo");
+});
+
+test!(doc_dir_plus_file {
+    assert_not_a_cargo_toml("doc", "foo/bar");
+});
+
+test!(doc_dir_plus_path {
+    assert_not_a_cargo_toml("doc", "foo/bar/baz");
+});
+
+test!(doc_dir_to_nonexistent_cargo_toml {
+    assert_cargo_toml_doesnt_exist("doc", "foo/bar/baz/Cargo.toml");
+});
+
+test!(fetch_dir_containing_cargo_toml {
+    assert_not_a_cargo_toml("fetch", "foo");
+});
+
+test!(fetch_dir_plus_file {
+    assert_not_a_cargo_toml("fetch", "foo/bar");
+});
+
+test!(fetch_dir_plus_path {
+    assert_not_a_cargo_toml("fetch", "foo/bar/baz");
+});
+
+test!(fetch_dir_to_nonexistent_cargo_toml {
+    assert_cargo_toml_doesnt_exist("fetch", "foo/bar/baz/Cargo.toml");
+});
+
+test!(generate_lockfile_dir_containing_cargo_toml {
+    assert_not_a_cargo_toml("generate-lockfile", "foo");
+});
+
+test!(generate_lockfile_dir_plus_file {
+    assert_not_a_cargo_toml("generate-lockfile", "foo/bar");
+});
+
+test!(generate_lockfile_dir_plus_path {
+    assert_not_a_cargo_toml("generate-lockfile", "foo/bar/baz");
+});
+
+test!(generate_lockfile_dir_to_nonexistent_cargo_toml {
+    assert_cargo_toml_doesnt_exist("generate-lockfile", "foo/bar/baz/Cargo.toml");
+});
+
+test!(package_dir_containing_cargo_toml {
+    assert_not_a_cargo_toml("package", "foo");
+});
+
+test!(package_dir_plus_file {
+    assert_not_a_cargo_toml("package", "foo/bar");
+});
+
+test!(package_dir_plus_path {
+    assert_not_a_cargo_toml("package", "foo/bar/baz");
+});
+
+test!(package_dir_to_nonexistent_cargo_toml {
+    assert_cargo_toml_doesnt_exist("package", "foo/bar/baz/Cargo.toml");
+});
+
+test!(pkgid_dir_containing_cargo_toml {
+    assert_not_a_cargo_toml("pkgid", "foo");
+});
+
+test!(pkgid_dir_plus_file {
+    assert_not_a_cargo_toml("pkgid", "foo/bar");
+});
+
+test!(pkgid_dir_plus_path {
+    assert_not_a_cargo_toml("pkgid", "foo/bar/baz");
+});
+
+test!(pkgid_dir_to_nonexistent_cargo_toml {
+    assert_cargo_toml_doesnt_exist("pkgid", "foo/bar/baz/Cargo.toml");
+});
+
+test!(publish_dir_containing_cargo_toml {
+    assert_not_a_cargo_toml("publish", "foo");
+});
+
+test!(publish_dir_plus_file {
+    assert_not_a_cargo_toml("publish", "foo/bar");
+});
+
+test!(publish_dir_plus_path {
+    assert_not_a_cargo_toml("publish", "foo/bar/baz");
+});
+
+test!(publish_dir_to_nonexistent_cargo_toml {
+    assert_cargo_toml_doesnt_exist("publish", "foo/bar/baz/Cargo.toml");
+});
+
+test!(read_manifest_dir_containing_cargo_toml {
+    assert_not_a_cargo_toml("read-manifest", "foo");
+});
+
+test!(read_manifest_dir_plus_file {
+    assert_not_a_cargo_toml("read-manifest", "foo/bar");
+});
+
+test!(read_manifest_dir_plus_path {
+    assert_not_a_cargo_toml("read-manifest", "foo/bar/baz");
+});
+
+test!(read_manifest_dir_to_nonexistent_cargo_toml {
+    assert_cargo_toml_doesnt_exist("read-manifest", "foo/bar/baz/Cargo.toml");
+});
+
+test!(run_dir_containing_cargo_toml {
+    assert_not_a_cargo_toml("run", "foo");
+});
+
+test!(run_dir_plus_file {
+    assert_not_a_cargo_toml("run", "foo/bar");
+});
+
+test!(run_dir_plus_path {
+    assert_not_a_cargo_toml("run", "foo/bar/baz");
+});
+
+test!(run_dir_to_nonexistent_cargo_toml {
+    assert_cargo_toml_doesnt_exist("run", "foo/bar/baz/Cargo.toml");
+});
+
+test!(rustc_dir_containing_cargo_toml {
+    assert_not_a_cargo_toml("rustc", "foo");
+});
+
+test!(rustc_dir_plus_file {
+    assert_not_a_cargo_toml("rustc", "foo/bar");
+});
+
+test!(rustc_dir_plus_path {
+    assert_not_a_cargo_toml("rustc", "foo/bar/baz");
+});
+
+test!(rustc_dir_to_nonexistent_cargo_toml {
+    assert_cargo_toml_doesnt_exist("rustc", "foo/bar/baz/Cargo.toml");
+});
+
+test!(test_dir_containing_cargo_toml {
+    assert_not_a_cargo_toml("test", "foo");
+});
+
+test!(test_dir_plus_file {
+    assert_not_a_cargo_toml("test", "foo/bar");
+});
+
+test!(test_dir_plus_path {
+    assert_not_a_cargo_toml("test", "foo/bar/baz");
+});
+
+test!(test_dir_to_nonexistent_cargo_toml {
+    assert_cargo_toml_doesnt_exist("test", "foo/bar/baz/Cargo.toml");
+});
+
+test!(update_dir_containing_cargo_toml {
+    assert_not_a_cargo_toml("update", "foo");
+});
+
+test!(update_dir_plus_file {
+    assert_not_a_cargo_toml("update", "foo/bar");
+});
+
+test!(update_dir_plus_path {
+    assert_not_a_cargo_toml("update", "foo/bar/baz");
+});
+
+test!(update_dir_to_nonexistent_cargo_toml {
+    assert_cargo_toml_doesnt_exist("update", "foo/bar/baz/Cargo.toml");
+});
+
+test!(verify_project_dir_containing_cargo_toml {
+    let p = project("foo")
+        .file("Cargo.toml", &basic_bin_manifest("foo"))
+        .file("src/foo.rs", &main_file(r#""i am foo""#, &[]));
+
+    assert_that(p.cargo_process("verify-project")
+                 .arg("--manifest-path").arg("foo")
+                 .cwd(p.root().parent().unwrap()),
+                execs().with_status(1)
+                       .with_stdout("\
+{\"invalid\":\"the manifest-path must be a path to a Cargo.toml file\"}\
+                        "));
+});
+
+test!(verify_project_dir_plus_file {
+    let p = project("foo")
+        .file("Cargo.toml", &basic_bin_manifest("foo"))
+        .file("src/foo.rs", &main_file(r#""i am foo""#, &[]));
+
+    assert_that(p.cargo_process("verify-project")
+                 .arg("--manifest-path").arg("foo/bar")
+                 .cwd(p.root().parent().unwrap()),
+                execs().with_status(1)
+                       .with_stdout("\
+{\"invalid\":\"the manifest-path must be a path to a Cargo.toml file\"}\
+                        "));
+});
+
+test!(verify_project_dir_plus_path {
+    let p = project("foo")
+        .file("Cargo.toml", &basic_bin_manifest("foo"))
+        .file("src/foo.rs", &main_file(r#""i am foo""#, &[]));
+
+    assert_that(p.cargo_process("verify-project")
+                 .arg("--manifest-path").arg("foo/bar/baz")
+                 .cwd(p.root().parent().unwrap()),
+                execs().with_status(1)
+                       .with_stdout("\
+{\"invalid\":\"the manifest-path must be a path to a Cargo.toml file\"}\
+                        "));
+});
+
+test!(verify_project_dir_to_nonexistent_cargo_toml {
+    let p = project("foo");
+    assert_that(p.cargo_process("verify-project")
+                 .arg("--manifest-path").arg("foo/bar/baz/Cargo.toml")
+                 .cwd(p.root().parent().unwrap()),
+                execs().with_status(1)
+                       .with_stdout("\
+{\"invalid\":\"manifest path `foo[..]bar[..]baz[..]Cargo.toml` does not exist\"}\
+                        "));
+});

--- a/tests/test_cargo_read_manifest.rs
+++ b/tests/test_cargo_read_manifest.rs
@@ -1,0 +1,79 @@
+use support::{project, execs, main_file, basic_bin_manifest};
+use hamcrest::{assert_that};
+
+fn setup() {}
+
+fn read_manifest_output() -> String {
+    "\
+{\
+    \"name\":\"foo\",\
+    \"version\":\"0.5.0\",\
+    \"dependencies\":[],\
+    \"targets\":[{\
+        \"kind\":[\"bin\"],\
+        \"name\":\"foo\",\
+        \"src_path\":\"src[..]foo.rs\",\
+        \"metadata\":null\
+    }],\
+    \"manifest_path\":\"[..]Cargo.toml\"\
+}".into()
+}
+
+test!(cargo_read_manifest_path_to_cargo_toml_relative {
+    let p = project("foo")
+        .file("Cargo.toml", &basic_bin_manifest("foo"))
+        .file("src/foo.rs", &main_file(r#""i am foo""#, &[]));
+
+    assert_that(p.cargo_process("read-manifest")
+                 .arg("--manifest-path").arg("foo/Cargo.toml")
+                 .cwd(p.root().parent().unwrap()),
+                execs().with_status(0)
+                       .with_stdout(read_manifest_output()));
+});
+
+test!(cargo_read_manifest_path_to_cargo_toml_absolute {
+    let p = project("foo")
+        .file("Cargo.toml", &basic_bin_manifest("foo"))
+        .file("src/foo.rs", &main_file(r#""i am foo""#, &[]));
+
+    assert_that(p.cargo_process("read-manifest")
+                 .arg("--manifest-path").arg(p.root().join("Cargo.toml"))
+                 .cwd(p.root().parent().unwrap()),
+                execs().with_status(0)
+                       .with_stdout(read_manifest_output()));
+});
+
+test!(cargo_read_manifest_path_to_cargo_toml_parent_relative {
+    let p = project("foo")
+        .file("Cargo.toml", &basic_bin_manifest("foo"))
+        .file("src/foo.rs", &main_file(r#""i am foo""#, &[]));
+
+    assert_that(p.cargo_process("read-manifest")
+                 .arg("--manifest-path").arg("foo")
+                 .cwd(p.root().parent().unwrap()),
+                execs().with_status(0)
+                       .with_stdout(read_manifest_output()));
+});
+
+test!(cargo_read_manifest_path_to_cargo_toml_parent_absolute {
+    let p = project("foo")
+        .file("Cargo.toml", &basic_bin_manifest("foo"))
+        .file("src/foo.rs", &main_file(r#""i am foo""#, &[]));
+
+    assert_that(p.cargo_process("read-manifest")
+                 .arg("--manifest-path").arg(p.root())
+                 .cwd(p.root().parent().unwrap()),
+                execs().with_status(0)
+                       .with_stdout(read_manifest_output()));
+});
+
+test!(cargo_read_manifest_cwd {
+    let p = project("foo")
+        .file("Cargo.toml", &basic_bin_manifest("foo"))
+        .file("src/foo.rs", &main_file(r#""i am foo""#, &[]));
+
+    assert_that(p.cargo_process("read-manifest")
+                 .cwd(p.root()),
+                execs().with_status(0)
+                       .with_stdout(read_manifest_output()));
+});

--- a/tests/test_cargo_read_manifest.rs
+++ b/tests/test_cargo_read_manifest.rs
@@ -51,8 +51,8 @@ test!(cargo_read_manifest_path_to_cargo_toml_parent_relative {
     assert_that(p.cargo_process("read-manifest")
                  .arg("--manifest-path").arg("foo")
                  .cwd(p.root().parent().unwrap()),
-                execs().with_status(0)
-                       .with_stdout(read_manifest_output()));
+                execs().with_status(101)
+                       .with_stderr("the manifest-path must be a path to a Cargo.toml file"));
 });
 
 test!(cargo_read_manifest_path_to_cargo_toml_parent_absolute {
@@ -63,8 +63,8 @@ test!(cargo_read_manifest_path_to_cargo_toml_parent_absolute {
     assert_that(p.cargo_process("read-manifest")
                  .arg("--manifest-path").arg(p.root())
                  .cwd(p.root().parent().unwrap()),
-                execs().with_status(0)
-                       .with_stdout(read_manifest_output()));
+                execs().with_status(101)
+                       .with_stderr("the manifest-path must be a path to a Cargo.toml file"));
 });
 
 test!(cargo_read_manifest_cwd {

--- a/tests/test_cargo_verify_project.rs
+++ b/tests/test_cargo_verify_project.rs
@@ -1,0 +1,43 @@
+use support::{project, execs, main_file, basic_bin_manifest};
+use hamcrest::{assert_that};
+
+fn setup() {}
+
+fn verify_project_success_output() -> String {
+    r#"{"success":"true"}"#.into()
+}
+
+test!(cargo_verify_project_path_to_cargo_toml_relative {
+    let p = project("foo")
+        .file("Cargo.toml", &basic_bin_manifest("foo"))
+        .file("src/foo.rs", &main_file(r#""i am foo""#, &[]));
+
+    assert_that(p.cargo_process("verify-project")
+                 .arg("--manifest-path").arg("foo/Cargo.toml")
+                 .cwd(p.root().parent().unwrap()),
+                execs().with_status(0)
+                       .with_stdout(verify_project_success_output()));
+});
+
+test!(cargo_verify_project_path_to_cargo_toml_absolute {
+    let p = project("foo")
+        .file("Cargo.toml", &basic_bin_manifest("foo"))
+        .file("src/foo.rs", &main_file(r#""i am foo""#, &[]));
+
+    assert_that(p.cargo_process("verify-project")
+                 .arg("--manifest-path").arg(p.root().join("Cargo.toml"))
+                 .cwd(p.root().parent().unwrap()),
+                execs().with_status(0)
+                       .with_stdout(verify_project_success_output()));
+});
+
+test!(cargo_verify_project_cwd {
+    let p = project("foo")
+        .file("Cargo.toml", &basic_bin_manifest("foo"))
+        .file("src/foo.rs", &main_file(r#""i am foo""#, &[]));
+
+    assert_that(p.cargo_process("verify-project")
+                 .cwd(p.root()),
+                execs().with_status(0)
+                       .with_stdout(verify_project_success_output()));
+});

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -51,6 +51,7 @@ mod test_cargo_new;
 mod test_cargo_package;
 mod test_cargo_profiles;
 mod test_cargo_publish;
+mod test_cargo_read_manifest;
 mod test_cargo_registry;
 mod test_cargo_run;
 mod test_cargo_rustc;

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -31,6 +31,7 @@ macro_rules! test {
 }
 
 mod test_bad_config;
+mod test_bad_manifest_path;
 mod test_cargo;
 mod test_cargo_bench;
 mod test_cargo_build_auth;

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -58,6 +58,7 @@ mod test_cargo_rustc;
 mod test_cargo_search;
 mod test_cargo_test;
 mod test_cargo_tool_paths;
+mod test_cargo_verify_project;
 mod test_cargo_version;
 mod test_shell;
 


### PR DESCRIPTION
Hiii :) This builds on #1953, so if yinz like this better, I'll close that one.

This PR makes all commands that take `--manifest-path` (except locate-project, see below) behave in a consistent way with regards to invalid paths, and hopefully gives better error messages.

This DOES break some instances where commands were "working", ie, completing their command successfully, with some path that they decided was right, not necessarily exactly the path that was passed in though. I'm not sure how this impacts whatever backwards compatibility guarantees cargo has. Given that those cases weren't using a valid path to an existing Cargo.toml, hopefully no one is relying on that behavior?

So locate-project... I'm not sure what to do about that one, exactly... If we define `--manifest-path` as a path to a Cargo.toml, then uhhhh we've located the project, it's right where you told us it is ;) So I think we should change it to be `--search-path` or similar? I'm too sleepy to take care of that tonight, so I just left it out of the manifest path tests.