### PR TITLE
Note about extern crate rol in linking sys packages

### DIFF
--- a/src/doc/build-script.md
+++ b/src/doc/build-script.md
@@ -124,6 +124,9 @@ depends on `libfoo`, then if `libfoo` generates `key=value` as part of its
 metadata, then the build script of `libbar` will have the environment variables
 `DEP_FOO_KEY=value`.
 
+Make sure to add `extern crate libfoo;` to your `lib.rs` or `main.rs`, otherwise the
+libraries provided by the `*-sys` package will not be linked.
+
 Note that metadata is only passed to immediate dependents, not transitive
 dependents. The motivation for this metadata passing is outlined in the linking
 to system libraries case study below.


### PR DESCRIPTION
I just spent a couple of hours debugging why a sys package didn't link. It turns out that declaring it as a crate in your code is necessary for this to work.