### PR TITLE
path: do not recurse into hidden/dot directories

### DIFF
--- a/src/cargo/ops/cargo_read_manifest.rs
+++ b/src/cargo/ops/cargo_read_manifest.rs
@@ -43,8 +43,9 @@ pub fn read_packages(path: &Path, source_id: &SourceId, config: &Config)
     try!(walk(path, &mut |dir| {
         trace!("looking for child package: {}", dir.display());
 
-        // Don't recurse into git databases
-        if dir.file_name().and_then(|s| s.to_str()) == Some(".git") {
+        // Don't recurse into hidden/dot directories
+        let name = dir.file_name().and_then(|s| s.to_str());
+        if name.map(|s| s.starts_with(".")) == Some(true) {
             return Ok(false)
         }
 

--- a/src/cargo/sources/path.rs
+++ b/src/cargo/sources/path.rs
@@ -255,11 +255,16 @@ impl<'cfg> PathSource<'cfg> {
         }
         for dir in try!(fs::read_dir(path)) {
             let dir = try!(dir).path();
-            match (is_root, dir.file_name().and_then(|s| s.to_str())) {
-                (_,    Some(".git")) |
-                (true, Some("target")) |
-                (true, Some("Cargo.lock")) => continue,
-                _ => {}
+            let name = dir.file_name().and_then(|s| s.to_str());
+            // Skip dotfile directories
+            if name.map(|s| s.starts_with(".")) == Some(true) {
+                continue
+            } else if is_root {
+                // Skip cargo artifacts
+                match name {
+                    Some("target") | Some("Cargo.lock") => continue,
+                    _ => {}
+                }
             }
             try!(PathSource::walk(&dir, ret, false, filter));
         }

--- a/tests/test_cargo_compile.rs
+++ b/tests/test_cargo_compile.rs
@@ -1828,6 +1828,24 @@ test!(ignore_dotfile {
                 execs().with_status(0));
 });
 
+test!(ignore_dotdirs {
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [package]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+        "#)
+        .file("src/bin/a.rs", "fn main() {}")
+        .file(".git/Cargo.toml", "")
+        .file(".pc/dummy-fix.patch/Cargo.toml", "");
+    p.build();
+
+    assert_that(p.cargo("build"),
+                execs().with_status(0));
+});
+
+
 test!(custom_target_dir {
     let p = project("foo")
         .file("Cargo.toml", r#"


### PR DESCRIPTION
Cargo recursively looks for TOML manifest into child directories,
sometimes getting into unrelated files when exploring hidden
directories (eg. quilt .pc).

This commit lets cargo skip dot directories, to partially avoid
the issues described in #1423.

Signed-off-by: Luca Bruno <lucab@debian.org>

Closes #978 