### PR TITLE
Don't link build scripts dynamically

### DIFF
--- a/src/cargo/ops/cargo_rustc/mod.rs
+++ b/src/cargo/ops/cargo_rustc/mod.rs
@@ -600,7 +600,7 @@ fn build_base_args(cx: &Context,
         cmd.arg("--crate-type").arg(crate_type);
     }
 
-    let prefer_dynamic = target.for_host() ||
+    let prefer_dynamic = (target.for_host() && !target.is_custom_build()) ||
                          (crate_types.contains(&"dylib") &&
                           pkg.package_id() != cx.resolve.root());
     if prefer_dynamic {

--- a/tests/test_cargo_compile_custom_build.rs
+++ b/tests/test_cargo_compile_custom_build.rs
@@ -761,7 +761,7 @@ test!(build_cmd_with_a_build_cmd {
     -L [..]target[..]deps -L [..]target[..]deps`
 {compiling} foo v0.5.0 (file://[..])
 {running} `rustc build.rs --crate-name build_script_build --crate-type bin \
-    -C prefer-dynamic -g \
+    -g \
     --out-dir [..]build[..]foo-[..] --emit=dep-info,link \
     -L [..]target[..]debug -L [..]target[..]deps \
     --extern a=[..]liba-[..].rlib`
@@ -1109,6 +1109,7 @@ test!(build_script_with_dynamic_native_dependency {
             [lib]
             name = "builder"
             crate-type = ["dylib"]
+            plugin = true
         "#)
         .file("src/lib.rs", r#"
             #[no_mangle]


### PR DESCRIPTION
There's no real reason to eagerly link build scripts dynamically as they're not
going to benefit that much from dynamic linking. Most of the time they only have
one dynamic dependency, libstd, and most other Rust programs don't link it
dynamically so there's not really many space savings either.