### PR TITLE
Only document platform-relevant dependencies

### DIFF
--- a/tests/test_cargo_doc.rs
+++ b/tests/test_cargo_doc.rs
@@ -289,3 +289,27 @@ test!(doc_target {
     assert_that(&p.root().join(&format!("target/{}/doc", TARGET)), existing_dir());
     assert_that(&p.root().join(&format!("target/{}/doc/foo/index.html", TARGET)), existing_file());
 });
+
+test!(target_specific_not_documented {
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [package]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+
+            [target.foo.dependencies]
+            a = { path = "a" }
+        "#)
+        .file("src/lib.rs", "")
+        .file("a/Cargo.toml", r#"
+            [package]
+            name = "a"
+            version = "0.0.1"
+            authors = []
+        "#)
+        .file("a/src/lib.rs", "not rust");
+
+    assert_that(p.cargo_process("doc"),
+                execs().with_status(0));
+});


### PR DESCRIPTION
The recent change in #1939 ended up accidentally pulling in irrelevant
platform-specific dependencies into a normal `cargo doc`, causing those builds
to fail. This change tweaks the logic for calculating documentation dependencies
to account for filtering based on the relevant platform.