### PR TITLE
avoid warning when cargo not found

### DIFF
--- a/src/etc/cargo.bashcomp.sh
+++ b/src/etc/cargo.bashcomp.sh
@@ -81,7 +81,7 @@ _cargo()
 } &&
 complete -F _cargo cargo
 
-__cargo_commands=$(cargo --list | tail -n +2)
+__cargo_commands=$(cargo --list 2>/dev/null | tail -n +2)
 
 _locate_manifest(){
 	local manifest=`cargo locate-project 2>/dev/null`


### PR DESCRIPTION
The most common case is that if `cargo` is not installed to  `/usr` but somewhere else such as `/usr/local` (is this the default install prefix? don't remember...), user will see `cargo: command not found` after `sudo su` executed.

P.S. sorry for previous wrong PR... there was a redundant commit.