### PR TITLE
Fix documenting target-specific dependencies for real

### DIFF
--- a/src/cargo/ops/cargo_rustc/context.rs
+++ b/src/cargo/ops/cargo_rustc/context.rs
@@ -417,10 +417,11 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
         let deps = deps.flat_map(|a| a).map(|id| {
             self.get_package(id)
         }).filter(|dep| {
-            let dep = pkg.dependencies().iter().find(|d| {
+            pkg.dependencies().iter().filter(|d| {
                 d.name() == dep.name()
-            }).unwrap();
-            dep.is_transitive() && self.dep_platform_activated(dep, kind)
+            }).any(|dep| {
+                dep.is_transitive() && self.dep_platform_activated(dep, kind)
+            })
         }).filter_map(|dep| {
             dep.targets().iter().find(|t| t.is_lib()).map(|t| (dep, t))
         });

--- a/tests/test_cargo_doc.rs
+++ b/tests/test_cargo_doc.rs
@@ -313,3 +313,37 @@ test!(target_specific_not_documented {
     assert_that(p.cargo_process("doc"),
                 execs().with_status(0));
 });
+
+test!(target_specific_documented {
+    let p = project("foo")
+        .file("Cargo.toml", &format!(r#"
+            [package]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+
+            [target.foo.dependencies]
+            a = {{ path = "a" }}
+            [target.{}.dependencies]
+            a = {{ path = "a" }}
+        "#, ::rustc_host()))
+        .file("src/lib.rs", "
+            extern crate a;
+
+            /// test
+            pub fn foo() {}
+        ")
+        .file("a/Cargo.toml", r#"
+            [package]
+            name = "a"
+            version = "0.0.1"
+            authors = []
+        "#)
+        .file("a/src/lib.rs", "
+            /// test
+            pub fn foo() {}
+        ");
+
+    assert_that(p.cargo_process("doc"),
+                execs().with_status(0));
+});


### PR DESCRIPTION
It's possible to have multiple dependencies of the same name for a project if a
dependency shows up multiple times as a target-specific dependency. This means
that we can't just find the first one with the relevant name and assume it's the
right one, we instead need to check all of them.