### PR TITLE
If --vcs flag specified, use vcs even if under an existing repo

### DIFF
--- a/src/cargo/ops/cargo_new.rs
+++ b/src/cargo/ops/cargo_new.rs
@@ -118,7 +118,7 @@ fn mk(config: &Config, path: &Path, name: &str,
     let vcs = match (opts.version_control, cfg.version_control, in_existing_vcs_repo) {
         (None, None, false) => VersionControl::Git,
         (None, Some(option), false) => option,
-        (Some(option), _, false) => option,
+        (Some(option), _, _) => option,
         (_, _, true) => VersionControl::NoVcs,
     };
 

--- a/tests/test_cargo_new.rs
+++ b/tests/test_cargo_new.rs
@@ -257,6 +257,23 @@ test!(subpackage_no_git {
                  is_not(existing_file()));
 });
 
+test!(subpackage_git_with_vcs_arg {
+    assert_that(cargo_process("new").arg("foo").env("USER", "foo"),
+                execs().with_status(0));
+
+    let subpackage = paths::root().join("foo").join("components");
+    fs::create_dir(&subpackage).unwrap();
+    assert_that(cargo_process("new").arg("foo/components/subcomponent")
+                                    .arg("--vcs").arg("git")
+                                    .env("USER", "foo"),
+                execs().with_status(0));
+
+    assert_that(&paths::root().join("foo/components/subcomponent/.git"),
+                 existing_dir());
+    assert_that(&paths::root().join("foo/components/subcomponent/.gitignore"),
+                 existing_file());
+});
+
 test!(unknown_flags {
     assert_that(cargo_process("new").arg("foo").arg("--flag"),
                 execs().with_status(1)


### PR DESCRIPTION
Fixes #1210. If either `--vcs git` or `--vcs hg` is specified, assume
that means the user really wants the new project to use that VCS, even
if the project's location would be beneath an existing repository.

This was surprisingly easy! And would make me so happy-- my home dir is a git repo :) 