### PR TITLE
Update curl bindings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ dependencies = [
  "advapi32-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bufstream 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "crates-io 0.1.0",
- "curl 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "curl 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "docopt 0.6.70 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "filetime 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -71,13 +71,13 @@ dependencies = [
 name = "crates-io"
 version = "0.1.0"
 dependencies = [
- "curl 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "curl 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "curl"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "curl-sys 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -162,7 +162,7 @@ name = "git2-curl"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "curl 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "curl 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "git2 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.2.37 (registry+https://github.com/rust-lang/crates.io-index)",


### PR DESCRIPTION
Includes a fix for #1937 to not panic on downloading crates on newer OSX
versions.

Closes #1937