### PR TITLE
Add --release flag to `cargo doc`

### DIFF
--- a/src/bin/doc.rs
+++ b/src/bin/doc.rs
@@ -12,6 +12,7 @@ struct Options {
     flag_no_deps: bool,
     flag_open: bool,
     flag_verbose: bool,
+    flag_release: bool,
     flag_quiet: bool,
     flag_color: Option<String>,
     flag_package: Option<String>,
@@ -29,6 +30,7 @@ Options:
     -p SPEC, --package SPEC  Package to document
     --no-deps                Don't build documentation for dependencies
     -j N, --jobs N           The number of jobs to run in parallel
+    --release                Build artifacts in release mode, with optimizations
     --features FEATURES      Space-separated list of features to also build
     --no-default-features    Do not build the `default` feature
     --target TRIPLE          Build for the target triple
@@ -63,7 +65,7 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
             spec: options.flag_package.as_ref().map(|s| &s[..]),
             exec_engine: None,
             filter: ops::CompileFilter::Everything,
-            release: false,
+            release: options.flag_release,
             mode: ops::CompileMode::Doc {
                 deps: !options.flag_no_deps,
             },

--- a/tests/test_cargo_doc.rs
+++ b/tests/test_cargo_doc.rs
@@ -1,5 +1,5 @@
 use support::{project, execs, path2url};
-use support::COMPILING;
+use support::{COMPILING, RUNNING};
 use hamcrest::{assert_that, existing_file, existing_dir, is_not};
 
 fn setup() {
@@ -346,4 +346,24 @@ test!(target_specific_documented {
 
     assert_that(p.cargo_process("doc"),
                 execs().with_status(0));
+});
+
+test!(doc_release {
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [package]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+        "#)
+        .file("src/lib.rs", "");
+
+    assert_that(p.cargo_process("build").arg("--release"),
+                execs().with_status(0));
+    assert_that(p.cargo("doc").arg("--release").arg("-v"),
+                execs().with_status(0)
+                       .with_stdout(&format!("\
+{compiling} foo v0.0.1 ([..])
+{running} `rustdoc src[..]lib.rs [..]`
+", compiling = COMPILING, running = RUNNING)));
 });


### PR DESCRIPTION
While this may not necessarily make sense all the time, this enables Cargo to
not rebuild anything if a `cargo build --release` was previously executed.