### PR TITLE
Don't document build dependencies

### DIFF
--- a/src/cargo/ops/cargo_rustc/context.rs
+++ b/src/cargo/ops/cargo_rustc/context.rs
@@ -8,6 +8,7 @@ use regex::Regex;
 
 use core::{SourceMap, Package, PackageId, PackageSet, Resolve, Target, Profile};
 use core::{TargetKind, LibKind, Profiles, Metadata, Dependency};
+use core::dependency::Kind as DepKind;
 use util::{self, CargoResult, ChainError, internal, Config, profile};
 use util::human;
 
@@ -420,7 +421,10 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
             pkg.dependencies().iter().filter(|d| {
                 d.name() == dep.name()
             }).any(|dep| {
-                dep.is_transitive() && self.dep_platform_activated(dep, kind)
+                match dep.kind() {
+                    DepKind::Normal => self.dep_platform_activated(dep, kind),
+                    _ => false,
+                }
             })
         }).filter_map(|dep| {
             dep.targets().iter().find(|t| t.is_lib()).map(|t| (dep, t))

--- a/tests/test_cargo_doc.rs
+++ b/tests/test_cargo_doc.rs
@@ -348,6 +348,37 @@ test!(target_specific_documented {
                 execs().with_status(0));
 });
 
+test!(no_document_build_deps {
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [package]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+
+            [build-dependencies]
+            a = { path = "a" }
+        "#)
+        .file("src/lib.rs", "
+            pub fn foo() {}
+        ")
+        .file("a/Cargo.toml", r#"
+            [package]
+            name = "a"
+            version = "0.0.1"
+            authors = []
+        "#)
+        .file("a/src/lib.rs", "
+            /// ```
+            /// ☃
+            /// ```
+            pub fn foo() {}
+        ");
+
+    assert_that(p.cargo_process("doc"),
+                execs().with_status(0));
+});
+
 test!(doc_release {
     let p = project("foo")
         .file("Cargo.toml", r#"


### PR DESCRIPTION
They're not actually relevant to the documentation, so omit them.