### PR TITLE
Add `cargo rustdoc` for passing arbitrary flags to rustdoc

### DIFF
--- a/src/bin/bench.rs
+++ b/src/bin/bench.rs
@@ -84,7 +84,7 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
                                             &options.flag_test,
                                             &options.flag_example,
                                             &options.flag_bench),
-            extra_rustdoc_args: vec![],
+            extra_rustdoc_args: Vec::new(),
             target_rustc_args: None,
         },
     };

--- a/src/bin/bench.rs
+++ b/src/bin/bench.rs
@@ -84,6 +84,7 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
                                             &options.flag_test,
                                             &options.flag_example,
                                             &options.flag_bench),
+            extra_rustdoc_args: None,
             target_rustc_args: None,
         },
     };

--- a/src/bin/bench.rs
+++ b/src/bin/bench.rs
@@ -84,7 +84,7 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
                                             &options.flag_test,
                                             &options.flag_example,
                                             &options.flag_bench),
-            extra_rustdoc_args: None,
+            extra_rustdoc_args: vec![],
             target_rustc_args: None,
         },
     };

--- a/src/bin/build.rs
+++ b/src/bin/build.rs
@@ -81,7 +81,7 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
                                         &options.flag_test,
                                         &options.flag_example,
                                         &options.flag_bench),
-        extra_rustdoc_args: vec![],
+        extra_rustdoc_args: Vec::new(),
         target_rustc_args: None,
     };
 

--- a/src/bin/build.rs
+++ b/src/bin/build.rs
@@ -81,7 +81,7 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
                                         &options.flag_test,
                                         &options.flag_example,
                                         &options.flag_bench),
-        extra_rustdoc_args: None,
+        extra_rustdoc_args: vec![],
         target_rustc_args: None,
     };
 

--- a/src/bin/build.rs
+++ b/src/bin/build.rs
@@ -81,6 +81,7 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
                                         &options.flag_test,
                                         &options.flag_example,
                                         &options.flag_bench),
+        extra_rustdoc_args: None,
         target_rustc_args: None,
     };
 

--- a/src/bin/cargo.rs
+++ b/src/bin/cargo.rs
@@ -79,6 +79,7 @@ macro_rules! each_subcommand{ ($mac:ident) => ({
     $mac!(read_manifest);
     $mac!(run);
     $mac!(rustc);
+    $mac!(rustdoc);
     $mac!(search);
     $mac!(test);
     $mac!(update);

--- a/src/bin/doc.rs
+++ b/src/bin/doc.rs
@@ -70,7 +70,7 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
                 deps: !options.flag_no_deps,
             },
             target_rustc_args: None,
-            extra_rustdoc_args: vec![],
+            extra_rustdoc_args: Vec::new(),
         },
     };
 

--- a/src/bin/doc.rs
+++ b/src/bin/doc.rs
@@ -70,7 +70,7 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
                 deps: !options.flag_no_deps,
             },
             target_rustc_args: None,
-            extra_rustdoc_args: None,
+            extra_rustdoc_args: vec![],
         },
     };
 

--- a/src/bin/run.rs
+++ b/src/bin/run.rs
@@ -80,6 +80,7 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
                 bins: &bins, examples: &examples,
             }
         },
+        extra_rustdoc_args: None,
         target_rustc_args: None,
     };
 

--- a/src/bin/run.rs
+++ b/src/bin/run.rs
@@ -80,7 +80,7 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
                 bins: &bins, examples: &examples,
             }
         },
-        extra_rustdoc_args: None,
+        extra_rustdoc_args: vec![],
         target_rustc_args: None,
     };
 

--- a/src/bin/run.rs
+++ b/src/bin/run.rs
@@ -80,7 +80,7 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
                 bins: &bins, examples: &examples,
             }
         },
-        extra_rustdoc_args: vec![],
+        extra_rustdoc_args: Vec::new(),
         target_rustc_args: None,
     };
 

--- a/src/bin/rustc.rs
+++ b/src/bin/rustc.rs
@@ -84,7 +84,7 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
                                         &options.flag_test,
                                         &options.flag_example,
                                         &options.flag_bench),
-        extra_rustdoc_args: vec![],
+        extra_rustdoc_args: Vec::new(),
         target_rustc_args: options.arg_opts.as_ref().map(|a| &a[..]),
     };
 

--- a/src/bin/rustc.rs
+++ b/src/bin/rustc.rs
@@ -84,6 +84,7 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
                                         &options.flag_test,
                                         &options.flag_example,
                                         &options.flag_bench),
+        extra_rustdoc_args: None,
         target_rustc_args: options.arg_opts.as_ref().map(|a| &a[..]),
     };
 

--- a/src/bin/rustc.rs
+++ b/src/bin/rustc.rs
@@ -84,7 +84,7 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
                                         &options.flag_test,
                                         &options.flag_example,
                                         &options.flag_bench),
-        extra_rustdoc_args: None,
+        extra_rustdoc_args: vec![],
         target_rustc_args: options.arg_opts.as_ref().map(|a| &a[..]),
     };
 

--- a/src/bin/rustdoc.rs
+++ b/src/bin/rustdoc.rs
@@ -20,7 +20,7 @@ struct Options {
 }
 
 pub const USAGE: &'static str = "
-Build a package's documentation
+Build a package's documentation, using specified custom flags.
 
 Usage:
     cargo rustdoc [options] [--] [<opts>...]
@@ -43,8 +43,16 @@ Options:
 By default the documentation for the local package and all dependencies is
 built. The output is all placed in `target/doc` in rustdoc's usual format.
 
-The specified <opts>... will all be passed to rustdoc for the main package and
-all of its dependencies.
+The specified target for the current package (or package specified by SPEC if
+provided) will be compiled along with all of its dependencies. The specified
+<opts>... will all be passed to the final rustdoc invocation, not any of the
+dependencies. Note that the compiler will still unconditionally receive
+arguments such as -L, --extern, and --crate-type, and the specified <opts>...
+will simply be added to the compiler invocation.
+
+This command requires that only one target is being compiled. If more than one
+target is available for the current package the filters of --lib, --bin, etc,
+must be used to select which target is compiled.
 
 If the --package argument is given, then SPEC is a package id specification
 which indicates which package should be documented. If it is not given, then the
@@ -73,7 +81,7 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
             mode: ops::CompileMode::Doc {
                 deps: !options.flag_no_deps,
             },
-            extra_rustdoc_args: options.arg_opts.as_ref().map(|a| &a[..]),
+            extra_rustdoc_args: options.arg_opts.unwrap_or(vec![]),
             target_rustc_args: None,
         },
     };

--- a/src/bin/rustdoc.rs
+++ b/src/bin/rustdoc.rs
@@ -44,9 +44,9 @@ By default the documentation for the local package and all dependencies is
 built. The output is all placed in `target/doc` in rustdoc's usual format.
 
 The specified target for the current package (or package specified by SPEC if
-provided) will be compiled along with all of its dependencies. The specified
+provided) will be documented along with all of its dependencies. The specified
 <opts>... will all be passed to the final rustdoc invocation, not any of the
-dependencies. Note that the compiler will still unconditionally receive
+dependencies. Note that rustdoc will still unconditionally receive
 arguments such as -L, --extern, and --crate-type, and the specified <opts>...
 will simply be added to the compiler invocation.
 
@@ -86,9 +86,7 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
         },
     };
 
-    try!(ops::doc(&root, &mut doc_opts).map_err(|err| {
-        CliError::from_boxed(err, 101)
-    }));
+    try!(ops::doc(&root, &mut doc_opts).map_err(|err| CliError::from_boxed(err, 101)));
 
     Ok(None)
 }

--- a/src/bin/rustdoc.rs
+++ b/src/bin/rustdoc.rs
@@ -4,6 +4,7 @@ use cargo::util::important_paths::{find_root_manifest_for_cwd};
 
 #[derive(RustcDecodable)]
 struct Options {
+    arg_opts: Option<Vec<String>>,
     flag_target: Option<String>,
     flag_features: Vec<String>,
     flag_jobs: Option<u32>,
@@ -22,7 +23,7 @@ pub const USAGE: &'static str = "
 Build a package's documentation
 
 Usage:
-    cargo doc [options]
+    cargo rustdoc [options] [--] [<opts>...]
 
 Options:
     -h, --help               Print this message
@@ -41,6 +42,9 @@ Options:
 
 By default the documentation for the local package and all dependencies is
 built. The output is all placed in `target/doc` in rustdoc's usual format.
+
+The specified <opts>... will all be passed to rustdoc for the main package and
+all of its dependencies.
 
 If the --package argument is given, then SPEC is a package id specification
 which indicates which package should be documented. If it is not given, then the
@@ -69,8 +73,8 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
             mode: ops::CompileMode::Doc {
                 deps: !options.flag_no_deps,
             },
+            extra_rustdoc_args: options.arg_opts.as_ref().map(|a| &a[..]),
             target_rustc_args: None,
-            extra_rustdoc_args: None,
         },
     };
 

--- a/src/bin/rustdoc.rs
+++ b/src/bin/rustdoc.rs
@@ -4,7 +4,7 @@ use cargo::util::important_paths::{find_root_manifest_for_cwd};
 
 #[derive(RustcDecodable)]
 struct Options {
-    arg_opts: Option<Vec<String>>,
+    arg_opts: Vec<String>,
     flag_target: Option<String>,
     flag_features: Vec<String>,
     flag_jobs: Option<u32>,
@@ -48,11 +48,7 @@ provided) will be documented along with all of its dependencies. The specified
 <opts>... will all be passed to the final rustdoc invocation, not any of the
 dependencies. Note that rustdoc will still unconditionally receive
 arguments such as -L, --extern, and --crate-type, and the specified <opts>...
-will simply be added to the compiler invocation.
-
-This command requires that only one target is being compiled. If more than one
-target is available for the current package the filters of --lib, --bin, etc,
-must be used to select which target is compiled.
+will simply be added to the rustdoc invocation.
 
 If the --package argument is given, then SPEC is a package id specification
 which indicates which package should be documented. If it is not given, then the
@@ -81,7 +77,7 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
             mode: ops::CompileMode::Doc {
                 deps: !options.flag_no_deps,
             },
-            extra_rustdoc_args: options.arg_opts.unwrap_or(vec![]),
+            extra_rustdoc_args: options.arg_opts,
             target_rustc_args: None,
         },
     };

--- a/src/bin/test.rs
+++ b/src/bin/test.rs
@@ -90,6 +90,7 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
                                             &options.flag_test,
                                             &options.flag_example,
                                             &options.flag_bench),
+            extra_rustdoc_args: None,
             target_rustc_args: None,
         },
     };

--- a/src/bin/test.rs
+++ b/src/bin/test.rs
@@ -90,7 +90,7 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
                                             &options.flag_test,
                                             &options.flag_example,
                                             &options.flag_bench),
-            extra_rustdoc_args: vec![],
+            extra_rustdoc_args: Vec::new(),
             target_rustc_args: None,
         },
     };

--- a/src/bin/test.rs
+++ b/src/bin/test.rs
@@ -90,7 +90,7 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
                                             &options.flag_test,
                                             &options.flag_example,
                                             &options.flag_bench),
-            extra_rustdoc_args: None,
+            extra_rustdoc_args: vec![],
             target_rustc_args: None,
         },
     };

--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -111,6 +111,7 @@ pub struct Profile {
     pub lto: bool,
     pub codegen_units: Option<u32>,    // None = use rustc default
     pub rustc_args: Option<Vec<String>>,
+    pub rustdoc_args: Option<Vec<String>>,
     pub debuginfo: bool,
     pub debug_assertions: bool,
     pub rpath: bool,
@@ -451,6 +452,7 @@ impl Default for Profile {
             lto: false,
             codegen_units: None,
             rustc_args: None,
+            rustdoc_args: None,
             debuginfo: false,
             debug_assertions: false,
             rpath: false,

--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -179,12 +179,6 @@ pub fn compile_pkg<'a>(package: &Package,
     let mut target_with_rustdoc = None;
     if !extra_rustdoc_args.is_empty() {
         let mut target_with_rustdoc_inner = Vec::new();
-        if targets.len() > 1 {
-            return Err(human("extra arguments to `rustdoc` can only be passed to \
-                  one target, consider filtering\nthe package by \
-                  passing e.g. `--lib` or `--bin NAME` to specify \
-                  a single target"));
-        }
         for &(target, profile) in &targets {
             if profile.doc {
                 let mut profile = profile.clone();
@@ -196,7 +190,9 @@ pub fn compile_pkg<'a>(package: &Package,
     };
 
     let targets = target_with_rustdoc.as_ref().map_or(targets,
-                                             |o| o.into_iter().map(|&(t, ref p)| (t, p)).collect());
+                                             |o| o.into_iter()
+                                                  .map(|&(t, ref p)| (t, p))
+                                                  .collect());
     let ret = {
         let _p = profile::start("compiling");
         let mut build_config = try!(scrape_build_config(config, jobs, target));

--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -57,6 +57,8 @@ pub struct CompileOptions<'a> {
     pub release: bool,
     /// Mode for this compile.
     pub mode: CompileMode,
+    /// Extra arguments to be passed to rustdoc (for main crate and dependencies)
+    pub extra_rustdoc_args: Option<&'a [String]>,
     /// The specified target will be compiled with all the available arguments,
     /// note that this only accounts for the *final* invocation of rustc
     pub target_rustc_args: Option<&'a [String]>,
@@ -101,6 +103,7 @@ pub fn compile_pkg<'a>(package: &Package,
     let CompileOptions { config, jobs, target, spec, features,
                          no_default_features, release, mode,
                          ref filter, ref exec_engine,
+                         ref extra_rustdoc_args,
                          ref target_rustc_args } = *options;
 
     let target = target.map(|s| s.to_string());
@@ -173,6 +176,19 @@ pub fn compile_pkg<'a>(package: &Package,
     let targets = target_with_args.as_ref().map(|&(t, ref p)| vec![(t, p)])
                                            .unwrap_or(targets);
 
+    let mut target_with_rustdoc = None;
+    if let Some(args) = *extra_rustdoc_args {
+        let mut target_with_rustdoc_inner = Vec::new();
+        for &(target, profile) in &targets {
+            let mut profile = profile.clone();
+            profile.rustdoc_args = Some(args.to_vec());
+            target_with_rustdoc_inner.push((target, profile));
+        }
+        target_with_rustdoc = Some(target_with_rustdoc_inner);
+    };
+
+    let targets = target_with_rustdoc.as_ref().map_or(targets,
+                                             |o| o.into_iter().map(|&(t, ref p)| (t, p)).collect());
     let ret = {
         let _p = profile::start("compiling");
         let mut build_config = try!(scrape_build_config(config, jobs, target));

--- a/src/cargo/ops/cargo_package.rs
+++ b/src/cargo/ops/cargo_package.rs
@@ -189,6 +189,7 @@ fn run_verify(config: &Config, pkg: &Package, tar: &Path)
         exec_engine: None,
         release: false,
         mode: ops::CompileMode::Build,
+        extra_rustdoc_args: None,
         target_rustc_args: None,
     }));
 

--- a/src/cargo/ops/cargo_package.rs
+++ b/src/cargo/ops/cargo_package.rs
@@ -189,7 +189,7 @@ fn run_verify(config: &Config, pkg: &Package, tar: &Path)
         exec_engine: None,
         release: false,
         mode: ops::CompileMode::Build,
-        extra_rustdoc_args: vec![],
+        extra_rustdoc_args: Vec::new(),
         target_rustc_args: None,
     }));
 

--- a/src/cargo/ops/cargo_package.rs
+++ b/src/cargo/ops/cargo_package.rs
@@ -189,7 +189,7 @@ fn run_verify(config: &Config, pkg: &Package, tar: &Path)
         exec_engine: None,
         release: false,
         mode: ops::CompileMode::Build,
-        extra_rustdoc_args: None,
+        extra_rustdoc_args: vec![],
         target_rustc_args: None,
     }));
 

--- a/src/cargo/ops/cargo_rustc/mod.rs
+++ b/src/cargo/ops/cargo_rustc/mod.rs
@@ -579,7 +579,8 @@ fn build_base_args(cx: &Context,
     let Profile {
         opt_level, lto, codegen_units, ref rustc_args,
         rustdoc_args: _, debuginfo, debug_assertions, rpath,
-        test, doc: _doc } = *profile;
+        test, doc: _doc
+    } = *profile;
 
     // Move to cwd so the root_path() passed below is actually correct
     cmd.cwd(cx.config.cwd());

--- a/src/cargo/ops/cargo_rustc/mod.rs
+++ b/src/cargo/ops/cargo_rustc/mod.rs
@@ -525,6 +525,10 @@ fn rustdoc(package: &Package, target: &Target, profile: &Profile,
         None => {}
     }
 
+    if let Some(ref args) = profile.rustdoc_args {
+        rustdoc.args(args);
+    }
+
     try!(build_deps_args(&mut rustdoc, target, profile, package, cx, kind));
 
     if package.has_custom_build() {
@@ -573,9 +577,9 @@ fn build_base_args(cx: &Context,
                    profile: &Profile,
                    crate_types: &[&str]) {
     let Profile {
-        opt_level, lto, codegen_units, ref rustc_args, debuginfo, debug_assertions,
-        rpath, test, doc: _doc,
-    } = *profile;
+        opt_level, lto, codegen_units, ref rustc_args,
+        rustdoc_args: _, debuginfo, debug_assertions, rpath,
+        test, doc: _doc } = *profile;
 
     // Move to cwd so the root_path() passed below is actually correct
     cmd.cwd(cx.config.cwd());

--- a/src/cargo/util/toml.rs
+++ b/src/cargo/util/toml.rs
@@ -940,6 +940,7 @@ fn build_profiles(profiles: &Option<TomlProfiles>) -> Profiles {
             lto: lto.unwrap_or(profile.lto),
             codegen_units: codegen_units,
             rustc_args: None,
+            rustdoc_args: None,
             debuginfo: debug.unwrap_or(profile.debuginfo),
             debug_assertions: debug_assertions.unwrap_or(profile.debug_assertions),
             rpath: rpath.unwrap_or(profile.rpath),

--- a/tests/test_cargo_rustdoc.rs
+++ b/tests/test_cargo_rustdoc.rs
@@ -56,3 +56,100 @@ test!(rustdoc_args {
             dir = p.root().display(), url = p.url())));
 });
 
+
+
+test!(rustdoc_foo_with_bar_dependency {
+    let foo = project("foo")
+        .file("Cargo.toml", r#"
+            [package]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+
+            [dependencies.bar]
+            path = "../bar"
+        "#)
+        .file("src/lib.rs", r#"
+            extern crate bar;
+            pub fn foo() {}
+        "#);
+    let bar = project("bar")
+        .file("Cargo.toml", r#"
+            [package]
+            name = "bar"
+            version = "0.0.1"
+            authors = []
+        "#)
+        .file("src/lib.rs", r#"
+            pub fn baz() {}
+        "#);
+    bar.build();
+
+    assert_that(foo.cargo_process("rustdoc").arg("-v").arg("--").arg("--no-defaults"),
+                execs()
+                .with_status(0)
+                .with_stdout(format!("\
+{compiling} bar v0.0.1 ({url})
+{running} `rustc {bar_dir}{sep}src{sep}lib.rs [..]`
+{running} `rustdoc {bar_dir}{sep}src{sep}lib.rs --crate-name bar \
+        -o {dir}{sep}target{sep}doc \
+        -L dependency={dir}{sep}target{sep}debug{sep}deps \
+        -L dependency={dir}{sep}target{sep}debug{sep}deps`
+{compiling} foo v0.0.1 ({url})
+{running} `rustdoc src{sep}lib.rs --crate-name foo \
+        -o {dir}{sep}target{sep}doc \
+        --no-defaults \
+        -L dependency={dir}{sep}target{sep}debug \
+        -L dependency={dir}{sep}target{sep}debug{sep}deps \
+        --extern [..]`
+",
+            running = RUNNING, compiling = COMPILING, sep = SEP,
+            dir = foo.root().display(), url = foo.url(),
+            bar_dir = bar.root().display())));
+});
+
+test!(rustdoc_only_bar_dependency {
+    let foo = project("foo")
+        .file("Cargo.toml", r#"
+            [package]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+
+            [dependencies.bar]
+            path = "../bar"
+        "#)
+        .file("src/main.rs", r#"
+            extern crate bar;
+            fn main() {
+                bar::baz()
+            }
+        "#);
+    let bar = project("bar")
+        .file("Cargo.toml", r#"
+            [package]
+            name = "bar"
+            version = "0.0.1"
+            authors = []
+        "#)
+        .file("src/lib.rs", r#"
+            pub fn baz() {}
+        "#);
+    bar.build();
+
+    assert_that(foo.cargo_process("rustdoc").arg("-v").arg("-p").arg("bar")
+                                            .arg("--").arg("--no-defaults"),
+                execs()
+                .with_status(0)
+                .with_stdout(format!("\
+{compiling} bar v0.0.1 ({url})
+{running} `rustdoc {bar_dir}{sep}src{sep}lib.rs --crate-name bar \
+        -o {dir}{sep}target{sep}doc \
+        --no-defaults \
+        -L dependency={dir}{sep}target{sep}debug{sep}deps \
+        -L dependency={dir}{sep}target{sep}debug{sep}deps`
+",
+            running = RUNNING, compiling = COMPILING, sep = SEP,
+            dir = foo.root().display(), url = foo.url(),
+            bar_dir = bar.root().display())));
+});

--- a/tests/test_cargo_rustdoc.rs
+++ b/tests/test_cargo_rustdoc.rs
@@ -153,3 +153,26 @@ test!(rustdoc_only_bar_dependency {
             dir = foo.root().display(), url = foo.url(),
             bar_dir = bar.root().display())));
 });
+
+
+test!(rustdoc_same_name_err {
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [package]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+        "#)
+        .file("src/main.rs", r#"
+            fn main() {}
+        "#)
+        .file("src/lib.rs", r#" "#);
+
+    assert_that(p.cargo_process("rustdoc").arg("-v")
+                 .arg("--").arg("--no-defaults"),
+                execs()
+                .with_status(101)
+                .with_stderr("Cannot document a package where a library and a \
+                              binary have the same name. Consider renaming one \
+                              or marking the target as `doc = false`"));
+});

--- a/tests/test_cargo_rustdoc.rs
+++ b/tests/test_cargo_rustdoc.rs
@@ -1,0 +1,58 @@
+use std::path::MAIN_SEPARATOR as SEP;
+use support::{execs, project};
+use support::{COMPILING, RUNNING};
+use hamcrest::{assert_that};
+
+fn setup() {
+}
+
+
+test!(rustdoc_simple {
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [package]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+        "#)
+        .file("src/lib.rs", r#" "#);
+
+    assert_that(p.cargo_process("rustdoc").arg("-v"),
+                execs()
+                .with_status(0)
+                .with_stdout(format!("\
+{compiling} foo v0.0.1 ({url})
+{running} `rustdoc src{sep}lib.rs --crate-name foo \
+        -o {dir}{sep}target{sep}doc \
+        -L dependency={dir}{sep}target{sep}debug \
+        -L dependency={dir}{sep}target{sep}debug{sep}deps`
+",
+            running = RUNNING, compiling = COMPILING, sep = SEP,
+            dir = p.root().display(), url = p.url())));
+});
+
+test!(rustdoc_args {
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [package]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+        "#)
+        .file("src/lib.rs", r#" "#);
+
+    assert_that(p.cargo_process("rustdoc").arg("-v").arg("--").arg("--no-defaults"),
+                execs()
+                .with_status(0)
+                .with_stdout(format!("\
+{compiling} foo v0.0.1 ({url})
+{running} `rustdoc src{sep}lib.rs --crate-name foo \
+        -o {dir}{sep}target{sep}doc \
+        --no-defaults \
+        -L dependency={dir}{sep}target{sep}debug \
+        -L dependency={dir}{sep}target{sep}debug{sep}deps`
+",
+            running = RUNNING, compiling = COMPILING, sep = SEP,
+            dir = p.root().display(), url = p.url())));
+});
+

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -56,6 +56,7 @@ mod test_cargo_read_manifest;
 mod test_cargo_registry;
 mod test_cargo_run;
 mod test_cargo_rustc;
+mod test_cargo_rustdoc;
 mod test_cargo_search;
 mod test_cargo_test;
 mod test_cargo_tool_paths;


### PR DESCRIPTION
Quite useful for doing `cargo rustdoc -- --no-defaults` to get a doc package with private items.

This is similar to `cargo rustc`, except that the flags passed to `cargo rustdoc` are applied to both the main package and dependencies.

A friend of mine was looking for this feature, couldn't find a way to do it without directly calling rustdoc. This would probably be useful for using the full configurability of rustdoc in cargo-applications.

r? @alexcrichton