### PR TITLE
Use a stamp file to protect against corrupt checkouts

### DIFF
--- a/tests/test_cargo_compile.rs
+++ b/tests/test_cargo_compile.rs
@@ -1508,7 +1508,7 @@ test!(cargo_platform_specific_dependency {
                 execs().with_status(0));
 
     assert_that(&p.bin("foo"), existing_file());
-    assert_that(p.cargo_process("test"),
+    assert_that(p.cargo("test"),
                 execs().with_status(0));
 });
 


### PR DESCRIPTION
We already take this strategy for extracting tarballs from crates.io for
example, so this just applies the same strategy to checkouts of git repos.

Closes #1979