### PR TITLE
Refactor to remove code duplication and be more pipeliney

### DIFF
--- a/src/cargo/core/package.rs
+++ b/src/cargo/core/package.rs
@@ -4,12 +4,12 @@ use std::slice;
 use std::path::{Path, PathBuf};
 use semver::Version;
 
-use core::{Dependency, Manifest, PackageId, Registry, Target, Summary, Metadata};
+use core::{Dependency, Manifest, PackageId, SourceId, Registry, Target, Summary, Metadata};
+use ops;
 use core::dependency::SerializedDependency;
 use util::{CargoResult, graph, Config};
 use rustc_serialize::{Encoder,Encodable};
 use core::source::Source;
-use sources::PathSource;
 
 /// Informations about a package that is available somewhere in the file system.
 ///
@@ -60,9 +60,11 @@ impl Package {
     }
 
     pub fn for_path(manifest_path: &Path, config: &Config) -> CargoResult<Package> {
-        let mut source = try!(PathSource::for_path(manifest_path.parent().unwrap(),
-                                                   config));
-        source.root_package()
+        let path = manifest_path.parent().unwrap();
+        let source_id = try!(SourceId::for_path(path));
+        let (pkg, _) = try!(ops::read_package(&manifest_path, &source_id,
+                                              config));
+        Ok(pkg)
     }
 
     pub fn dependencies(&self) -> &[Dependency] { self.manifest.dependencies() }

--- a/src/cargo/core/package.rs
+++ b/src/cargo/core/package.rs
@@ -6,9 +6,10 @@ use semver::Version;
 
 use core::{Dependency, Manifest, PackageId, Registry, Target, Summary, Metadata};
 use core::dependency::SerializedDependency;
-use util::{CargoResult, graph};
+use util::{CargoResult, graph, Config};
 use rustc_serialize::{Encoder,Encodable};
 use core::source::Source;
+use sources::PathSource;
 
 /// Informations about a package that is available somewhere in the file system.
 ///
@@ -56,6 +57,12 @@ impl Package {
             manifest: manifest,
             manifest_path: manifest_path.to_path_buf(),
         }
+    }
+
+    pub fn for_path(manifest_path: &Path, config: &Config) -> CargoResult<Package> {
+        let mut source = try!(PathSource::for_path(manifest_path.parent().unwrap(),
+                                                   config));
+        source.root_package()
     }
 
     pub fn dependencies(&self) -> &[Dependency] { self.manifest.dependencies() }

--- a/src/cargo/core/registry.rs
+++ b/src/cargo/core/registry.rs
@@ -147,11 +147,6 @@ impl<'cfg> PackageRegistry<'cfg> {
         Ok(())
     }
 
-    pub fn preload(&mut self, id: &SourceId, source: Box<Source + 'cfg>) {
-        self.sources.insert(id, source);
-        self.source_ids.insert(id.clone(), (id.clone(), Kind::Locked));
-    }
-
     pub fn add_sources(&mut self, ids: &[SourceId]) -> CargoResult<()> {
         for id in ids.iter() {
             try!(self.load(id, Kind::Locked));

--- a/src/cargo/ops/cargo_clean.rs
+++ b/src/cargo/ops/cargo_clean.rs
@@ -19,7 +19,6 @@ pub struct CleanOptions<'a> {
 pub fn clean(manifest_path: &Path, opts: &CleanOptions) -> CargoResult<()> {
     let mut src = try!(PathSource::for_path(manifest_path.parent().unwrap(),
                                             opts.config));
-    try!(src.update());
     let root = try!(src.root_package());
     let target_dir = opts.config.target_dir(&root);
 

--- a/src/cargo/ops/cargo_clean.rs
+++ b/src/cargo/ops/cargo_clean.rs
@@ -3,9 +3,8 @@ use std::fs;
 use std::io::prelude::*;
 use std::path::Path;
 
-use core::{PackageSet, Profiles, Profile};
+use core::{Package, PackageSet, Profiles, Profile};
 use core::source::{Source, SourceMap};
-use sources::PathSource;
 use util::{CargoResult, human, ChainError, Config};
 use ops::{self, Layout, Context, BuildConfig, Kind};
 
@@ -17,9 +16,7 @@ pub struct CleanOptions<'a> {
 
 /// Cleans the project from build artifacts.
 pub fn clean(manifest_path: &Path, opts: &CleanOptions) -> CargoResult<()> {
-    let mut src = try!(PathSource::for_path(manifest_path.parent().unwrap(),
-                                            opts.config));
-    let root = try!(src.root_package());
+    let root = try!(Package::for_path(manifest_path, opts.config));
     let target_dir = opts.config.target_dir(&root);
 
     // If we have a spec, then we need to delete some package,s otherwise, just

--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -28,7 +28,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use core::registry::PackageRegistry;
-use core::{Source, SourceId, PackageSet, Package, Target, PackageId};
+use core::{Source, SourceId, PackageSet, Package, Target};
 use core::{Profile, TargetKind};
 use core::resolver::Method;
 use ops::{self, BuildOutput, ExecEngine};
@@ -142,12 +142,7 @@ pub fn compile_pkg<'a>(package: &Package,
                 try!(ops::resolve_with_previous(&mut registry, package, method,
                                                 Some(&resolve), None));
 
-        let req: Vec<PackageId> = resolved_with_overrides.iter().map(|r| {
-            r.clone()
-        }).collect();
-        let packages = try!(registry.get(&req).chain_error(|| {
-            human("Unable to get packages from source")
-        }));
+        let packages = try!(ops::get_resolved_packages(&resolved_with_overrides, &mut registry));
 
         (packages, resolved_with_overrides, registry.move_sources())
     };

--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -89,8 +89,6 @@ pub fn compile<'a>(manifest_path: &Path,
 
     let mut source = try!(PathSource::for_path(manifest_path.parent().unwrap(),
                                                options.config));
-    try!(source.update());
-
     // TODO: Move this into PathSource
     let package = try!(source.root_package());
     debug!("loaded package; package={}", package);

--- a/src/cargo/ops/cargo_doc.rs
+++ b/src/cargo/ops/cargo_doc.rs
@@ -4,7 +4,6 @@ use std::path::Path;
 use std::process::Command;
 
 use core::PackageIdSpec;
-use core::source::Source;
 use ops;
 use sources::PathSource;
 use util::{CargoResult, human};
@@ -18,7 +17,6 @@ pub fn doc(manifest_path: &Path,
            options: &DocOptions) -> CargoResult<()> {
     let mut source = try!(PathSource::for_path(manifest_path.parent().unwrap(),
                                                options.compile_opts.config));
-    try!(source.update());
     let package = try!(source.root_package());
 
     let mut lib_names = HashSet::new();

--- a/src/cargo/ops/cargo_doc.rs
+++ b/src/cargo/ops/cargo_doc.rs
@@ -3,9 +3,8 @@ use std::fs;
 use std::path::Path;
 use std::process::Command;
 
-use core::PackageIdSpec;
+use core::{Package, PackageIdSpec};
 use ops;
-use sources::PathSource;
 use util::{CargoResult, human};
 
 pub struct DocOptions<'a> {
@@ -15,9 +14,7 @@ pub struct DocOptions<'a> {
 
 pub fn doc(manifest_path: &Path,
            options: &DocOptions) -> CargoResult<()> {
-    let mut source = try!(PathSource::for_path(manifest_path.parent().unwrap(),
-                                               options.compile_opts.config));
-    let package = try!(source.root_package());
+    let package = try!(Package::for_path(manifest_path, options.compile_opts.config));
 
     let mut lib_names = HashSet::new();
     let mut bin_names = HashSet::new();

--- a/src/cargo/ops/cargo_fetch.rs
+++ b/src/cargo/ops/cargo_fetch.rs
@@ -10,7 +10,7 @@ pub fn fetch(manifest_path: &Path, config: &Config) -> CargoResult<()> {
     let package = try!(Package::for_path(manifest_path, config));
     let mut registry = PackageRegistry::new(config);
     let resolve = try!(ops::resolve_pkg(&mut registry, &package));
-    let _ = get_resolved_packages(&resolve, &mut registry);
+    let _ = try!(get_resolved_packages(&resolve, &mut registry));
     Ok(())
 }
 

--- a/src/cargo/ops/cargo_fetch.rs
+++ b/src/cargo/ops/cargo_fetch.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 
 use core::registry::PackageRegistry;
-use core::{Package, PackageId};
+use core::{Package, PackageId, Resolve};
 use ops;
 use util::{CargoResult, Config, human, ChainError};
 
@@ -10,10 +10,14 @@ pub fn fetch(manifest_path: &Path, config: &Config) -> CargoResult<()> {
     let package = try!(Package::for_path(manifest_path, config));
     let mut registry = PackageRegistry::new(config);
     let resolve = try!(ops::resolve_pkg(&mut registry, &package));
-
-    let ids: Vec<PackageId> = resolve.iter().cloned().collect();
-    try!(registry.get(&ids).chain_error(|| {
-        human("unable to get packages from source")
-    }));
+    let _ = get_resolved_packages(&resolve, &mut registry);
     Ok(())
+}
+
+pub fn get_resolved_packages(resolve: &Resolve, registry: &mut PackageRegistry)
+                             -> CargoResult<Vec<Package>> {
+    let ids: Vec<PackageId> = resolve.iter().cloned().collect();
+    registry.get(&ids).chain_error(|| {
+        human("Unable to get packages from source")
+    })
 }

--- a/src/cargo/ops/cargo_fetch.rs
+++ b/src/cargo/ops/cargo_fetch.rs
@@ -10,7 +10,6 @@ use util::{CargoResult, Config, human, ChainError};
 pub fn fetch(manifest_path: &Path, config: &Config) -> CargoResult<()> {
     let mut source = try!(PathSource::for_path(manifest_path.parent().unwrap(),
                                                config));
-    try!(source.update());
     let package = try!(source.root_package());
 
     let mut registry = PackageRegistry::new(config);

--- a/src/cargo/ops/cargo_fetch.rs
+++ b/src/cargo/ops/cargo_fetch.rs
@@ -1,19 +1,14 @@
 use std::path::Path;
 
 use core::registry::PackageRegistry;
-use core::{Source, PackageId};
+use core::{Package, PackageId};
 use ops;
-use sources::PathSource;
 use util::{CargoResult, Config, human, ChainError};
 
 /// Executes `cargo fetch`.
 pub fn fetch(manifest_path: &Path, config: &Config) -> CargoResult<()> {
-    let mut source = try!(PathSource::for_path(manifest_path.parent().unwrap(),
-                                               config));
-    let package = try!(source.root_package());
-
+    let package = try!(Package::for_path(manifest_path, config));
     let mut registry = PackageRegistry::new(config);
-    registry.preload(package.package_id().source_id(), Box::new(source));
     let resolve = try!(ops::resolve_pkg(&mut registry, &package));
 
     let ids: Vec<PackageId> = resolve.iter().cloned().collect();

--- a/src/cargo/ops/cargo_fetch.rs
+++ b/src/cargo/ops/cargo_fetch.rs
@@ -18,6 +18,6 @@ pub fn get_resolved_packages(resolve: &Resolve, registry: &mut PackageRegistry)
                              -> CargoResult<Vec<Package>> {
     let ids: Vec<PackageId> = resolve.iter().cloned().collect();
     registry.get(&ids).chain_error(|| {
-        human("Unable to get packages from source")
+        human("unable to get packages from source")
     })
 }

--- a/src/cargo/ops/cargo_generate_lockfile.rs
+++ b/src/cargo/ops/cargo_generate_lockfile.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 
 use core::PackageId;
 use core::registry::PackageRegistry;
-use core::{Source, Resolve, SourceId};
+use core::{Resolve, SourceId};
 use core::resolver::Method;
 use ops;
 use sources::{PathSource};
@@ -21,7 +21,6 @@ pub fn generate_lockfile(manifest_path: &Path, config: &Config)
                          -> CargoResult<()> {
     let mut source = try!(PathSource::for_path(manifest_path.parent().unwrap(),
                                                config));
-    try!(source.update());
     let package = try!(source.root_package());
     let mut registry = PackageRegistry::new(config);
     registry.preload(package.package_id().source_id(), Box::new(source));
@@ -36,7 +35,6 @@ pub fn update_lockfile(manifest_path: &Path,
                        opts: &UpdateOptions) -> CargoResult<()> {
     let mut source = try!(PathSource::for_path(manifest_path.parent().unwrap(),
                                                opts.config));
-    try!(source.update());
     let package = try!(source.root_package());
 
     let previous_resolve = match try!(ops::load_pkg_lockfile(&package)) {

--- a/src/cargo/ops/cargo_package.rs
+++ b/src/cargo/ops/cargo_package.rs
@@ -6,7 +6,7 @@ use tar::Archive;
 use flate2::{GzBuilder, Compression};
 use flate2::read::GzDecoder;
 
-use core::{Source, SourceId, Package, PackageId};
+use core::{SourceId, Package, PackageId};
 use sources::PathSource;
 use util::{self, CargoResult, human, internal, ChainError, Config};
 use ops;
@@ -29,7 +29,6 @@ pub fn package(manifest_path: &Path,
                metadata: bool) -> CargoResult<Option<PathBuf>> {
     let mut src = try!(PathSource::for_path(manifest_path.parent().unwrap(),
                                             config));
-    try!(src.update());
     let pkg = try!(src.root_package());
 
     if metadata {

--- a/src/cargo/ops/cargo_package.rs
+++ b/src/cargo/ops/cargo_package.rs
@@ -178,7 +178,7 @@ fn run_verify(config: &Config, pkg: &Package, tar: &Path)
     let new_pkg = Package::new(new_manifest, &manifest_path);
 
     // Now that we've rewritten all our path dependencies, compile it!
-    try!(ops::compile_pkg(&new_pkg, None, &ops::CompileOptions {
+    try!(ops::compile_pkg(&new_pkg, &ops::CompileOptions {
         config: config,
         jobs: None,
         target: None,

--- a/src/cargo/ops/cargo_pkgid.rs
+++ b/src/cargo/ops/cargo_pkgid.rs
@@ -1,16 +1,13 @@
 use std::path::Path;
 
 use ops;
-use core::{PackageIdSpec};
-use sources::{PathSource};
+use core::{PackageIdSpec, Package};
 use util::{CargoResult, human, Config};
 
 pub fn pkgid(manifest_path: &Path,
              spec: Option<&str>,
              config: &Config) -> CargoResult<PackageIdSpec> {
-    let mut source = try!(PathSource::for_path(&manifest_path.parent().unwrap(),
-                                               config));
-    let package = try!(source.root_package());
+    let package = try!(Package::for_path(manifest_path, config));
 
     let lockfile = package.root().join("Cargo.lock");
     let source_id = package.package_id().source_id();

--- a/src/cargo/ops/cargo_pkgid.rs
+++ b/src/cargo/ops/cargo_pkgid.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 
 use ops;
-use core::{Source, PackageIdSpec};
+use core::{PackageIdSpec};
 use sources::{PathSource};
 use util::{CargoResult, human, Config};
 
@@ -10,7 +10,6 @@ pub fn pkgid(manifest_path: &Path,
              config: &Config) -> CargoResult<PackageIdSpec> {
     let mut source = try!(PathSource::for_path(&manifest_path.parent().unwrap(),
                                                config));
-    try!(source.update());
     let package = try!(source.root_package());
 
     let lockfile = package.root().join("Cargo.lock");

--- a/src/cargo/ops/cargo_run.rs
+++ b/src/cargo/ops/cargo_run.rs
@@ -2,7 +2,6 @@ use std::path::Path;
 
 use ops::{self, ExecEngine, CompileFilter};
 use util::{self, CargoResult, human, process, ProcessError};
-use core::source::Source;
 use sources::PathSource;
 
 pub fn run(manifest_path: &Path,
@@ -11,7 +10,6 @@ pub fn run(manifest_path: &Path,
     let config = options.config;
     let mut src = try!(PathSource::for_path(&manifest_path.parent().unwrap(),
                                             config));
-    try!(src.update());
     let root = try!(src.root_package());
 
     let mut bins = root.manifest().targets().iter().filter(|a| {

--- a/src/cargo/ops/cargo_run.rs
+++ b/src/cargo/ops/cargo_run.rs
@@ -2,15 +2,13 @@ use std::path::Path;
 
 use ops::{self, ExecEngine, CompileFilter};
 use util::{self, CargoResult, human, process, ProcessError};
-use sources::PathSource;
+use core::Package;
 
 pub fn run(manifest_path: &Path,
            options: &ops::CompileOptions,
            args: &[String]) -> CargoResult<Option<ProcessError>> {
     let config = options.config;
-    let mut src = try!(PathSource::for_path(&manifest_path.parent().unwrap(),
-                                            config));
-    let root = try!(src.root_package());
+    let root = try!(Package::for_path(manifest_path, config));
 
     let mut bins = root.manifest().targets().iter().filter(|a| {
         !a.is_lib() && !a.is_custom_build() && match options.filter {

--- a/src/cargo/ops/mod.rs
+++ b/src/cargo/ops/mod.rs
@@ -20,7 +20,7 @@ pub use self::cargo_package::package;
 pub use self::registry::{publish, registry_configuration, RegistryConfig};
 pub use self::registry::{registry_login, search, http_proxy_exists, http_handle};
 pub use self::registry::{modify_owners, yank, OwnersOptions};
-pub use self::cargo_fetch::{fetch};
+pub use self::cargo_fetch::{fetch, get_resolved_packages};
 pub use self::cargo_pkgid::pkgid;
 pub use self::resolve::{resolve_pkg, resolve_with_previous};
 

--- a/src/cargo/ops/registry.rs
+++ b/src/cargo/ops/registry.rs
@@ -33,7 +33,6 @@ pub fn publish(manifest_path: &Path,
                verify: bool) -> CargoResult<()> {
     let mut src = try!(PathSource::for_path(manifest_path.parent().unwrap(),
                                             config));
-    try!(src.update());
     let pkg = try!(src.root_package());
 
     let (mut registry, reg_id) = try!(registry(config, token, index));
@@ -266,7 +265,6 @@ pub fn modify_owners(config: &Config, opts: &OwnersOptions) -> CargoResult<()> {
             let manifest_path = try!(find_root_manifest_for_cwd(None));
             let mut src = try!(PathSource::for_path(manifest_path.parent().unwrap(),
                                                     config));
-            try!(src.update());
             let pkg = try!(src.root_package());
             pkg.name().to_string()
         }
@@ -329,7 +327,6 @@ pub fn yank(config: &Config,
             let manifest_path = try!(find_root_manifest_for_cwd(None));
             let mut src = try!(PathSource::for_path(manifest_path.parent().unwrap(),
                                                     config));
-            try!(src.update());
             let pkg = try!(src.root_package());
             pkg.name().to_string()
         }

--- a/src/cargo/ops/registry.rs
+++ b/src/cargo/ops/registry.rs
@@ -15,7 +15,7 @@ use core::{Package, SourceId};
 use core::dependency::Kind;
 use core::manifest::ManifestMetadata;
 use ops;
-use sources::{PathSource, RegistrySource};
+use sources::{RegistrySource};
 use util::config;
 use util::{CargoResult, human, ChainError, ToUrl};
 use util::config::{Config, ConfigValue, Location};
@@ -31,9 +31,7 @@ pub fn publish(manifest_path: &Path,
                token: Option<String>,
                index: Option<String>,
                verify: bool) -> CargoResult<()> {
-    let mut src = try!(PathSource::for_path(manifest_path.parent().unwrap(),
-                                            config));
-    let pkg = try!(src.root_package());
+    let pkg = try!(Package::for_path(&manifest_path, config));
 
     let (mut registry, reg_id) = try!(registry(config, token, index));
     try!(verify_dependencies(&pkg, &reg_id));
@@ -263,9 +261,7 @@ pub fn modify_owners(config: &Config, opts: &OwnersOptions) -> CargoResult<()> {
         Some(ref name) => name.clone(),
         None => {
             let manifest_path = try!(find_root_manifest_for_cwd(None));
-            let mut src = try!(PathSource::for_path(manifest_path.parent().unwrap(),
-                                                    config));
-            let pkg = try!(src.root_package());
+            let pkg = try!(Package::for_path(&manifest_path, config));
             pkg.name().to_string()
         }
     };
@@ -325,9 +321,7 @@ pub fn yank(config: &Config,
         Some(name) => name,
         None => {
             let manifest_path = try!(find_root_manifest_for_cwd(None));
-            let mut src = try!(PathSource::for_path(manifest_path.parent().unwrap(),
-                                                    config));
-            let pkg = try!(src.root_package());
+            let pkg = try!(Package::for_path(&manifest_path, config));
             pkg.name().to_string()
         }
     };

--- a/src/cargo/ops/resolve.rs
+++ b/src/cargo/ops/resolve.rs
@@ -37,6 +37,9 @@ pub fn resolve_with_previous<'a>(registry: &mut PackageRegistry,
                                  to_avoid: Option<&HashSet<&'a PackageId>>)
                                  -> CargoResult<Resolve> {
 
+    try!(registry.add_sources(&[package.package_id().source_id()
+                                       .clone()]));
+
     // Here we place an artificial limitation that all non-registry sources
     // cannot be locked at more than one revision. This means that if a git
     // repository provides more than one package, they must all be updated in

--- a/src/cargo/sources/path.rs
+++ b/src/cargo/sources/path.rs
@@ -46,12 +46,10 @@ impl<'cfg> PathSource<'cfg> {
         }
     }
 
-    pub fn root_package(&self) -> CargoResult<Package> {
+    pub fn root_package(&mut self) -> CargoResult<Package> {
         trace!("root_package; source={:?}", self);
 
-        if !self.updated {
-            return Err(internal("source has not been updated"))
-        }
+        try!(self.update());
 
         match self.packages.iter().find(|p| p.root() == &*self.path) {
             Some(pkg) => Ok(pkg.clone()),

--- a/tests/test_cargo_compile_path_deps.rs
+++ b/tests/test_cargo_compile_path_deps.rs
@@ -513,8 +513,12 @@ test!(error_message_for_missing_manifest {
     assert_that(p.cargo_process("build"),
                 execs()
                 .with_status(101)
-                .with_stderr(&format!("Could not find `Cargo.toml` in `{}`\n",
-                                      p.root().join("src").join("bar").display())));
+                .with_stderr(&format!("\
+Unable to update file://[..]
+
+Caused by:
+  Could not find `Cargo.toml` in `{}`
+", p.root().join("src").join("bar").display())));
 
 });
 

--- a/tests/test_cargo_registry.rs
+++ b/tests/test_cargo_registry.rs
@@ -161,7 +161,7 @@ test!(bad_cksum {
 
     assert_that(p.cargo_process("build").arg("-v"),
                 execs().with_status(101).with_stderr("\
-Unable to get packages from source
+unable to get packages from source
 
 Caused by:
   Failed to download package `bad-cksum v0.0.1 (registry file://[..])` from [..]


### PR DESCRIPTION
Hi! This is an attempt to start refactoring some of the internals to be more like a pipeline, and eventually enable the kind of functionality I tried to add in #1968 without having to add as much duplication. Turns out there's a fair bit of duplication in the code today, I think this helps address it!

I may have totally gone against some abstractions... namely I made a way to create `Package`s from a `manifest_path` and a `config`, without needing a `Source`. I think it cleans up the code quite a bit, and I think makes things a bit more pipeliney in that the `Source` isn't updated until we really need it to be (as opposed to having to use `preload` to avoid updating it again). But I'm open to the possibility that I'm moving things around to where no one who knows the code well will be able to find them ;)

This *should* be a Real Refactor in the sense that these changes don't change behavior-- except in one test case, where the same error happens as did before, but it's going through a `chain_error` now so has a slightly different message. 
