### PR TITLE
Rust updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: rust
 rust:
+  - 1.1.0
+  - 1.2.0
   - stable
   - beta
   - nightly

--- a/tests/test_cargo_compile.rs
+++ b/tests/test_cargo_compile.rs
@@ -1686,7 +1686,7 @@ test!(transitive_dependencies_not_available {
     assert_that(p.cargo_process("build").arg("-v"),
                 execs().with_status(101)
                        .with_stderr("\
-[..] can't find crate for `bbbbb`
+[..] can't find crate for `bbbbb`[..]
 [..] extern crate bbbbb; [..]
 [..]
 error: aborting due to previous error

--- a/tests/test_cargo_compile_custom_build.rs
+++ b/tests/test_cargo_compile_custom_build.rs
@@ -699,7 +699,7 @@ test!(build_deps_not_for_normal {
     assert_that(p.cargo_process("build").arg("-v").arg("--target").arg(&target),
                 execs().with_status(101)
                        .with_stderr("\
-[..]lib.rs[..] error: can't find crate for `aaaaa`
+[..]lib.rs[..] error: can't find crate for `aaaaa`[..]
 [..]lib.rs[..] extern crate aaaaa;
 [..]           ^~~~~~~~~~~~~~~~~~~
 error: aborting due to previous error


### PR DESCRIPTION
I noticed the tests on my PR were failing and for once it wasn't because I messed up expectations involving path separators on windows!!! 

They were failing because [nightly rust now has error code E0463](https://github.com/rust-lang/rust/commit/7358a5e8ea7c2ab0aaa76b503ef68161e44681a0) for "can't find crate" and the cargo tests weren't allowing for that. Just threw some `[..]`s in there so they should pass on all the rusts-- lmk if you'd like to have a comment that mentions the code could be added in there when rust 1.5 is released.

Speaking of rust trains, I also took this opportunity to change all the `connect`s to `join`s and remove the `allow(deprecated)`s since 1.3 was released! :sparkler: 