### PR TITLE
set CC environment variable

### DIFF
--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -26,6 +26,7 @@ use std::collections::HashMap;
 use std::default::Default;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::env::set_var;
 
 use core::registry::PackageRegistry;
 use core::{Source, SourceId, PackageSet, Package, Target};
@@ -393,6 +394,10 @@ fn scrape_target_config(config: &Config, triple: &str)
         linker: try!(config.get_path(&format!("{}.linker", key))),
         overrides: HashMap::new(),
     };
+    match ret.linker {
+        Some(ref path) => set_var("CC", path.clone().into_os_string()),
+        _ => {},
+    }
     let table = match try!(config.get_table(&key)) {
         Some((table, _)) => table,
         None => return Ok(ret),


### PR DESCRIPTION
Building `rustc` needs the tuple's vendor of toolchains to be empty, however, the vendor is set to `unknown` when cross-compiling rust codes, making projects like [curl-rust](https://github.com/carllerche/curl-rust) unable to select the correct compiler.

So we can set `CC` to enable most build systems to choose the correct toolchain. (I'm not sure whether the lines should be added here but it did work for me.)