### PR TITLE
Regenerate Makefile if Makefile.in or configure change

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -113,6 +113,10 @@ no-exes:
 
 # === Misc
 
+Makefile config.mk: config.stamp
+config.stamp: $(CFG_SRC_DIR)configure $(CFG_SRC_DIR)Makefile.in
+	$(CFG_SRC_DIR)configure $(CFG_CONFIGURE_ARGS)
+
 clean-all: clean
 clean:
 	rm -rf $(TARGET_ROOT)


### PR DESCRIPTION
Based on rust's mk/reconfig.mk

Fixes #587 and #1993