### PR TITLE
Don't fail if dylib outputs aren't supported

### DIFF
--- a/src/cargo/ops/cargo_rustc/context.rs
+++ b/src/cargo/ops/cargo_rustc/context.rs
@@ -324,8 +324,9 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
                 for lib in libs.iter() {
                     match *lib {
                         LibKind::Dylib => {
-                            let (prefix, suffix) = try!(self.dylib(kind));
-                            ret.push(format!("{}{}{}", prefix, stem, suffix));
+                            if let Ok((prefix, suffix)) = self.dylib(kind) {
+                                ret.push(format!("{}{}{}", prefix, stem, suffix));
+                            }
                         }
                         LibKind::Lib |
                         LibKind::Rlib => ret.push(format!("lib{}.rlib", stem)),


### PR DESCRIPTION
Currently it's not possible to inform Cargo about target-specific crate types,
so generating a hard error whenever a dylib is seen for a target that can't
produce dylibs is a little heavy. This commit disables management of the output
dylib (which won't actually exists) and relies on the compiler to print a
warning in the case of a dylib output on a non-dylib target.