### PR TITLE
Cargo new in empty dir

### DIFF
--- a/src/bin/cargo.rs
+++ b/src/bin/cargo.rs
@@ -158,6 +158,10 @@ fn execute(flags: Flags, config: &Config) -> CliResult<Option<()>> {
 }
 
 fn find_closest(cmd: &str) -> Option<String> {
+    if cmd == "init" {
+        return Some("new .".to_string())
+    }
+
     let cmds = list_commands();
     // Only consider candidates with a lev_distance of 3 or less so we don't
     // suggest out-of-the-blue options.

--- a/src/cargo/ops/cargo_new.rs
+++ b/src/cargo/ops/cargo_new.rs
@@ -45,9 +45,41 @@ struct CargoNewConfig {
     version_control: Option<VersionControl>,
 }
 
+fn can_we_use_this_path_for_a_new_project (path: &Path) -> bool {
+    if let Some(path_metadata) = fs::metadata(&path).ok() {
+        if path_metadata.is_dir() {
+            if let Some(already_existing_files) = fs::read_dir(&path).ok() {
+                for entry in already_existing_files {
+                    if let Some(entry2) = entry.ok() {
+                        if let Some(preexisting_file) = entry2.file_name().to_str() {
+                            if preexisting_file == ".git" { continue }
+                            if preexisting_file == ".hg" { continue }
+                            if preexisting_file == ".gitignore" { continue }
+                            if preexisting_file == ".hgignore" { continue }
+                            if preexisting_file == ".svn" { continue }
+                            return false // directory with unknown file
+                        } else {
+                            return false // directory with a non-UTF8 filename
+                        }
+                    } else {
+                        return false // directory where some file can't be enumerated
+                    }
+                }
+                true // directory with only VCS-related files
+            } else {
+                false // can't enumerate files
+            }
+        } else {
+            false // not a directory
+        }
+    } else {
+        true // does not exist
+    }
+}
+
 pub fn new(opts: NewOptions, config: &Config) -> CargoResult<()> {
     let path = config.cwd().join(opts.path);
-    if fs::metadata(&path).is_ok() {
+    if ! can_we_use_this_path_for_a_new_project(&path) {
         return Err(human(format!("Destination `{}` already exists",
                                  path.display())))
     }
@@ -132,7 +164,9 @@ fn mk(config: &Config, path: &Path, name: &str,
             try!(file(&path.join(".hgignore"), ignore.as_bytes()));
         },
         VersionControl::NoVcs => {
-            try!(fs::create_dir(path));
+            if ! fs::metadata(path).is_ok() {
+                try!(fs::create_dir(path));
+            }
         },
     };
 

--- a/tests/test_cargo_new.rs
+++ b/tests/test_cargo_new.rs
@@ -85,6 +85,7 @@ Usage:
 test!(existing {
     let dst = paths::root().join("foo");
     fs::create_dir(&dst).unwrap();
+    File::create(&dst.join("Cargo.toml")).unwrap().write_all(b"qqq").unwrap();
     assert_that(cargo_process("new").arg("foo"),
                 execs().with_status(101)
                        .with_stderr(format!("Destination `{}` already exists\n",


### PR DESCRIPTION
* Implement `cargo new .`. It checks if directory is empty (or contains only VCS-related files)
* Make `cargo init` suggest `new .` instead of just `new`