### PR TITLE
Clarifying 'path' dependency parameter

### DIFF
--- a/src/doc/manifest.md
+++ b/src/doc/manifest.md
@@ -153,6 +153,9 @@ You can specify the source of a dependency in one of two ways at the moment:
 * `path = "<relative-path>"`: A path relative to the current `Cargo.toml`
   with a `Cargo.toml` in its root.
 
+Note that when specifying a `path`, the crate name in any `use` statements will
+need to be prefix with `self::`.
+
 Dependencies from crates.io are not declared with separate sections:
 
 ```toml


### PR DESCRIPTION
I wanted to emphasise that adding a 'path' is not a complete drop-in
replacement, as code changes will need to be made in order for it
to work.