### PR TITLE
Do not skip the root path if it's a dotdir

### DIFF
--- a/src/cargo/ops/cargo_read_manifest.rs
+++ b/src/cargo/ops/cargo_read_manifest.rs
@@ -43,15 +43,17 @@ pub fn read_packages(path: &Path, source_id: &SourceId, config: &Config)
     try!(walk(path, &mut |dir| {
         trace!("looking for child package: {}", dir.display());
 
-        // Don't recurse into hidden/dot directories
-        let name = dir.file_name().and_then(|s| s.to_str());
-        if name.map(|s| s.starts_with(".")) == Some(true) {
-            return Ok(false)
-        }
+        // Don't recurse into hidden/dot directories unless we're at the toplevel
+        if dir != path {
+            let name = dir.file_name().and_then(|s| s.to_str());
+            if name.map(|s| s.starts_with(".")) == Some(true) {
+                return Ok(false)
+            }
 
-        // Don't automatically discover packages across git submodules
-        if dir != path && fs::metadata(&dir.join(".git")).is_ok() {
-            return Ok(false)
+            // Don't automatically discover packages across git submodules
+            if fs::metadata(&dir.join(".git")).is_ok() {
+                return Ok(false)
+            }
         }
 
         // Don't ever look at target directories

--- a/tests/test_cargo_compile.rs
+++ b/tests/test_cargo_compile.rs
@@ -7,7 +7,7 @@ use tempdir::TempDir;
 use support::{project, execs, main_file, basic_bin_manifest};
 use support::{COMPILING, RUNNING, ProjectBuilder};
 use hamcrest::{assert_that, existing_file, is_not};
-use support::paths::CargoPathExt;
+use support::paths::{CargoPathExt,root};
 use cargo::util::process;
 
 fn setup() {
@@ -1864,6 +1864,20 @@ test!(ignore_dotdirs {
         .file(".pc/dummy-fix.patch/Cargo.toml", "");
     p.build();
 
+    assert_that(p.cargo("build"),
+                execs().with_status(0));
+});
+
+test!(dotdir_root {
+    let p = ProjectBuilder::new("foo", root().join(".foo"))
+        .file("Cargo.toml", r#"
+            [package]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+        "#)
+        .file("src/bin/a.rs", "fn main() {}");
+    p.build();
     assert_that(p.cargo("build"),
                 execs().with_status(0));
 });


### PR DESCRIPTION
When traversing the directory tree, cargo will omit paths that start
with a period character to avoid interfering with other software.
Unfortunately this also prevents a crate from being located in a
directory prefixed with a period. Address this by extending the test
against the traversal root that already guards Git submodules.

Fixes issue #1999 which was introduced with commit 11144645f..