### PR TITLE
Enable optimizations by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ rust:
   - nightly
 sudo: false
 script:
-  - ./configure --prefix=$HOME/cargo-install --disable-cross-tests
+  - ./configure --prefix=$HOME/cargo-install --disable-cross-tests --disable-optimize
   - make
   - make test
   - make distcheck

--- a/Makefile.in
+++ b/Makefile.in
@@ -34,10 +34,10 @@ else
 MAYBE_DISABLE_VERIFY=
 endif
 
-ifdef CFG_ENABLE_OPTIMIZE
-OPT_FLAG=--release
-else
+ifdef CFG_DISABLE_OPTIMIZE
 OPT_FLAG=
+else
+OPT_FLAG=--release
 endif
 
 ifdef VERBOSE

--- a/configure
+++ b/configure
@@ -293,7 +293,7 @@ BOOL_OPTIONS=""
 VAL_OPTIONS=""
 
 opt debug 1 "build with extra debug fun"
-opt optimize 0 "build with optimizations"
+opt optimize 1 "build with optimizations"
 opt nightly 0 "build nightly packages"
 opt verify-install 1 "verify installed binaries work"
 opt cross-tests 1 "run cross-compilation tests"


### PR DESCRIPTION
This change mirrors the compiler by enabling optimizations by default rather
than by default producing an unoptimized Cargo build. I was curious why #2033
hit a debug assertion when we don't ship any binaries with debug assertions
enabled, but it looked like Cargo was installed via Homebrew which [does not
currently enable optimizations][homebrew]. I'll also send a PR over there, but I
figured it'd be also good to nip this in the bud and just start enabling
optimizations by default.

[homebrew]: https://github.com/Homebrew/homebrew/blob/5d09dd/Library/Formula/rust.rb#L69