### PR TITLE
Fix `cargo new`'s VCS related options in completion script.

### DIFF
--- a/src/etc/_cargo
+++ b/src/etc/_cargo
@@ -131,7 +131,7 @@ case $state in
             new)
                 _arguments \
                     '--bin[use binary template]' \
-                    '--git[initialize new git repo]' \
+                    '--vcs:initialize a new repo with a given VCS:(git hg)' \
                     '(-h, --help)'{-h,--help}'[show help message]' \
                     '--hg[initialize new mercurial repo]' \
                     '--no-git[no new git repo]' \

--- a/src/etc/_cargo
+++ b/src/etc/_cargo
@@ -133,8 +133,6 @@ case $state in
                     '--bin[use binary template]' \
                     '--vcs:initialize a new repo with a given VCS:(git hg)' \
                     '(-h, --help)'{-h,--help}'[show help message]' \
-                    '--hg[initialize new mercurial repo]' \
-                    '--no-git[no new git repo]' \
                     '(-v, --verbose)'{-v,--verbose}'[use verbose output]' \
                     '--color=[colorization option]' \
                     ;;

--- a/src/etc/_cargo
+++ b/src/etc/_cargo
@@ -131,7 +131,7 @@ case $state in
             new)
                 _arguments \
                     '--bin[use binary template]' \
-                    '--vcs:initialize a new repo with a given VCS:(git hg)' \
+                    '--vcs:initialize a new repo with a given VCS:(git hg none)' \
                     '(-h, --help)'{-h,--help}'[show help message]' \
                     '(-v, --verbose)'{-v,--verbose}'[use verbose output]' \
                     '--color=[colorization option]' \


### PR DESCRIPTION
The existing zsh completion script refers to deprecated options for initializing a new cargo package with version control (`--(no-)git` & `--hg`). This PR removes these old options and adds a new completion option `--vcs` which accepts either `git`, `hg` or `none` as it's own options.