### PR TITLE
Use the more portable `find -perm` syntax

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -108,7 +108,7 @@ no-exes:
 	find $$(git ls-files) -type f \
 		\( -perm -u+x -or -perm -g+x -or -perm -o+x \) \
 		-not -name configure -not -name '*.sh' -not -name '*.rs' \
-		-not -wholename "*/rust-installer/*" | \
+		-not -name '*.py' -not -wholename "*/rust-installer/*" | \
 		grep '.*' \
 		&& exit 1 || exit 0
 

--- a/Makefile.in
+++ b/Makefile.in
@@ -105,7 +105,8 @@ style:
 	sh tests/check-style.sh
 
 no-exes:
-	find $$(git ls-files) -perm +a+x -type f \
+	find $$(git ls-files) -type f \
+		\( -perm -u+x -or -perm -g+x -or -perm -o+x \) \
 		-not -name configure -not -name '*.sh' -not -name '*.rs' \
 		-not -wholename "*/rust-installer/*" | \
 		grep '.*' \


### PR DESCRIPTION
This is an improvement of fd781a12 adopted by rustc in https://github.com/rust-lang/rust/commit/f001f9a7
See also #822