### PR TITLE
Fix the usage of CFG_xxxABLE_OPTIMIZE variables in Makefiles

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -59,10 +59,10 @@ BIN_TARGETS := $(BIN_TARGETS:src/bin/%.rs=%)
 BIN_TARGETS := $(filter-out cargo,$(BIN_TARGETS))
 
 define DIST_TARGET
-ifdef CFG_ENABLE_OPTIMIZE
-TARGET_$(1) = $$(TARGET_ROOT)/$(1)/release
-else
+ifdef CFG_DISABLE_OPTIMIZE
 TARGET_$(1) = $$(TARGET_ROOT)/$(1)/debug
+else
+TARGET_$(1) = $$(TARGET_ROOT)/$(1)/release
 endif
 DISTDIR_$(1) = $$(TARGET_$(1))/dist
 IMGDIR_$(1) = $$(DISTDIR_$(1))/$$(PKG_NAME)-$(1)-image


### PR DESCRIPTION
Until now, there was a CFG_DISABLE_OPTIMIZE that controlled whether `--release` is passed to cargo during the build, and a CFG_ENABLE_OPTIMIZE that controlled where `make install` (among others) looked for the already built cargo executable. Unfortunately, if none of these were specified, `make all` built a release cargo but `make install` looked for it under `$(CFG_TARGET)/debug` (and aborted with "Please run `make` first"). This patch keeps CFG_DISABLE_OPTIMIZE only and uses it consistently.