### PR TITLE
Pre-create the output doc directory

### DIFF
--- a/src/cargo/ops/cargo_rustc/mod.rs
+++ b/src/cargo/ops/cargo_rustc/mod.rs
@@ -380,8 +380,13 @@ fn rustdoc(cx: &mut Context, unit: &Unit) -> CargoResult<Work> {
         rustdoc.arg("--target").arg(target);
         doc_dir.push(target);
     }
-
     doc_dir.push("doc");
+
+    // Create the documentation directory ahead of time as rustdoc currently has
+    // a bug where concurrent invocations will race to create this directory if
+    // it doesn't already exist.
+    try!(fs::create_dir_all(&doc_dir));
+
     rustdoc.arg("-o").arg(doc_dir);
 
     if let Some(features) = cx.resolve.features(unit.pkg.package_id()) {

--- a/tests/test_cargo_doc.rs
+++ b/tests/test_cargo_doc.rs
@@ -470,7 +470,10 @@ test!(doc_multiple_deps {
             pub fn baz() {}
         "#);
 
-    assert_that(p.cargo_process("doc").arg("-p").arg("bar").arg("-p").arg("baz"),
+    assert_that(p.cargo_process("doc")
+                  .arg("-p").arg("bar")
+                  .arg("-p").arg("baz")
+                  .arg("-v"),
                 execs().with_status(0));
 
     assert_that(&p.root().join("target/doc"), existing_dir());


### PR DESCRIPTION
Cargo will run rustdoc concurrently if it can, and rustdoc is instructed to
place output in a central location. Rustdoc itself knows how to handle
concurrent invocations, but it requires that the output location exists for this
to work correctly (as otherwise the rustdoc processes will race to create the
directory). While this may also be fixable upstream, for now just precreate the
doc directory to ensure that rustdoc doesn't race trying to create it.