### PR TITLE
Add feature dependencies to all targets but lib

### DIFF
--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -138,6 +138,7 @@ pub struct Target {
     name: String,
     src_path: PathBuf,
     metadata: Option<Metadata>,
+    features: Option<Vec<String>>,
     tested: bool,
     benched: bool,
     doc: bool,
@@ -226,6 +227,7 @@ impl Target {
             name: String::new(),
             src_path: PathBuf::new(),
             metadata: None,
+            features: None,
             doc: false,
             doctest: false,
             harness: true,
@@ -250,12 +252,14 @@ impl Target {
     }
 
     pub fn bin_target(name: &str, src_path: &Path,
-                      metadata: Option<Metadata>) -> Target {
+                      metadata: Option<Metadata>,
+                      features: Option<Vec<String>>) -> Target {
         Target {
             kind: TargetKind::Bin,
             name: name.to_string(),
             src_path: src_path.to_path_buf(),
             metadata: metadata,
+            features: features,
             doc: true,
             ..Target::blank()
         }
@@ -276,35 +280,41 @@ impl Target {
         }
     }
 
-    pub fn example_target(name: &str, src_path: &Path) -> Target {
+    pub fn example_target(name: &str, src_path: &Path,
+                          features: Option<Vec<String>>) -> Target {
         Target {
             kind: TargetKind::Example,
             name: name.to_string(),
             src_path: src_path.to_path_buf(),
+            features: features,
             benched: false,
             ..Target::blank()
         }
     }
 
     pub fn test_target(name: &str, src_path: &Path,
-                       metadata: Metadata) -> Target {
+                       metadata: Metadata,
+                       features: Option<Vec<String>>) -> Target {
         Target {
             kind: TargetKind::Test,
             name: name.to_string(),
             src_path: src_path.to_path_buf(),
             metadata: Some(metadata),
+            features: features,
             benched: false,
             ..Target::blank()
         }
     }
 
     pub fn bench_target(name: &str, src_path: &Path,
-                        metadata: Metadata) -> Target {
+                        metadata: Metadata,
+                        features: Option<Vec<String>>) -> Target {
         Target {
             kind: TargetKind::Bench,
             name: name.to_string(),
             src_path: src_path.to_path_buf(),
             metadata: Some(metadata),
+            features: features,
             tested: false,
             ..Target::blank()
         }
@@ -314,6 +324,7 @@ impl Target {
     pub fn crate_name(&self) -> String { self.name.replace("-", "_") }
     pub fn src_path(&self) -> &Path { &self.src_path }
     pub fn metadata(&self) -> Option<&Metadata> { self.metadata.as_ref() }
+    pub fn features(&self) -> Option<&Vec<String>> { self.features.as_ref() }
     pub fn kind(&self) -> &TargetKind { &self.kind }
     pub fn tested(&self) -> bool { self.tested }
     pub fn harness(&self) -> bool { self.harness }

--- a/src/cargo/util/toml.rs
+++ b/src/cargo/util/toml.rs
@@ -693,6 +693,7 @@ struct TomlTarget {
     doc: Option<bool>,
     plugin: Option<bool>,
     harness: Option<bool>,
+    features: Option<Vec<String>>,
 }
 
 #[derive(RustcDecodable, Clone)]
@@ -721,6 +722,7 @@ impl TomlTarget {
             doc: None,
             plugin: None,
             harness: None,
+            features: None
         }
     }
 
@@ -807,7 +809,7 @@ fn normalize(lib: &Option<TomlLibTarget>,
                 PathValue::Path(default(bin))
             });
             let mut target = Target::bin_target(&bin.name(), &path.to_path(),
-                                                None);
+                                                None, bin.features.clone());
             configure(bin, &mut target);
             dst.push(target);
         }
@@ -828,7 +830,8 @@ fn normalize(lib: &Option<TomlLibTarget>,
                 PathValue::Path(default(ex))
             });
 
-            let mut target = Target::example_target(&ex.name(), &path.to_path());
+            let mut target = Target::example_target(&ex.name(), &path.to_path(),
+                                                    ex.features.clone());
             configure(ex, &mut target);
             dst.push(target);
         }
@@ -847,7 +850,7 @@ fn normalize(lib: &Option<TomlLibTarget>,
             metadata.mix(&format!("test-{}", test.name()));
 
             let mut target = Target::test_target(&test.name(), &path.to_path(),
-                                                 metadata);
+                                                 metadata, test.features.clone());
             configure(test, &mut target);
             dst.push(target);
         }
@@ -867,7 +870,8 @@ fn normalize(lib: &Option<TomlLibTarget>,
 
             let mut target = Target::bench_target(&bench.name(),
                                                   &path.to_path(),
-                                                  metadata);
+                                                  metadata,
+                                                  bench.features.clone());
             configure(bench, &mut target);
             dst.push(target);
         }

--- a/tests/test_cargo_compile_feature_deps.rs
+++ b/tests/test_cargo_compile_feature_deps.rs
@@ -1,0 +1,104 @@
+use support::{project, execs};
+use hamcrest::{assert_that, existing_file, not};
+
+fn setup() {
+}
+
+test!(compile_simple_feature_deps {
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [project]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+
+            [features]
+            default = ["a"]
+            a = []
+
+            [[bin]]
+            name = "foo"
+            features = ["a"]
+        "#)
+        .file("src/main.rs", "fn main() {}");
+
+    assert_that(p.cargo_process("build"),
+                execs().with_status(0));
+
+    assert_that(&p.bin("foo"), existing_file());
+
+    assert_that(p.cargo_process("build").arg("--no-default-features"),
+                execs().with_status(0));
+
+    assert_that(&p.bin("foo"), not(existing_file()));
+});
+
+test!(compile_simple_feature_deps_args {
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [project]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+
+            [features]
+            a = []
+
+            [[bin]]
+            name = "foo"
+            features = ["a"]
+        "#)
+        .file("src/main.rs", "fn main() {}");
+
+    assert_that(p.cargo_process("build").arg("--features").arg("a"),
+                execs().with_status(0));
+
+    assert_that(&p.bin("foo"), existing_file());
+});
+
+test!(compile_multiple_feature_deps {
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [project]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+
+            [features]
+            default = ["a", "b"]
+            a = []
+            b = ["a"]
+            c = []
+
+            [[bin]]
+            name = "foo_1"
+            path = "src/foo_1.rs"
+            features = ["b", "c"]
+
+            [[bin]]
+            name = "foo_2"
+            path = "src/foo_2.rs"
+            features = ["a"]
+        "#)
+        .file("src/foo_1.rs", "fn main() {}")
+        .file("src/foo_2.rs", "fn main() {}");
+
+    assert_that(p.cargo_process("build"),
+                execs().with_status(0));
+
+    assert_that(&p.bin("foo_1"), not(existing_file()));
+    assert_that(&p.bin("foo_2"), existing_file());
+
+    assert_that(p.cargo_process("build").arg("--features").arg("c"),
+                execs().with_status(0));
+
+    assert_that(&p.bin("foo_1"), existing_file());
+    assert_that(&p.bin("foo_2"), existing_file());
+
+    assert_that(p.cargo_process("build").arg("--no-default-features"),
+                execs().with_status(0));
+
+    assert_that(&p.bin("foo_1"), not(existing_file()));
+    assert_that(&p.bin("foo_2"), not(existing_file()));
+});
+

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -39,6 +39,7 @@ mod test_cargo_build_lib;
 mod test_cargo_clean;
 mod test_cargo_compile;
 mod test_cargo_compile_custom_build;
+mod test_cargo_compile_feature_deps;
 mod test_cargo_compile_git_deps;
 mod test_cargo_compile_path_deps;
 mod test_cargo_compile_plugins;


### PR DESCRIPTION
This small PR adds the ability to use feature dependencies for all targets but lib fixing issue #1570

```toml
# ...

[features]
a = []
b = []

[[example]]
name = "ex_5"
features = ["a", "b"]

[[bin]]
name = "foobar"
path = "src/foo.rs"
features = ["a"]
```

Please tell me if and how the user should be notified about ignored targets as I am not sure how verbose cargo should be. Big thanks to @alexcrichton for guiding me.

As always, critique is much appreciated.