### PR TITLE
Made all working directories refer to `Config::cwd()`

### DIFF
--- a/src/bin/bench.rs
+++ b/src/bin/bench.rs
@@ -1,6 +1,6 @@
 use cargo::ops;
 use cargo::util::{CliResult, CliError, Human, Config};
-use cargo::util::important_paths::{find_root_manifest_for_cwd};
+use cargo::util::important_paths::{find_root_manifest_for_wd};
 
 #[derive(RustcDecodable)]
 struct Options {
@@ -62,7 +62,7 @@ Compilation can be customized with the `bench` profile in the manifest.
 ";
 
 pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
-    let root = try!(find_root_manifest_for_cwd(options.flag_manifest_path));
+    let root = try!(find_root_manifest_for_wd(options.flag_manifest_path, config.cwd()));
     try!(config.shell().set_verbosity(options.flag_verbose, options.flag_quiet));
     try!(config.shell().set_color_config(options.flag_color.as_ref().map(|s| &s[..])));
 

--- a/src/bin/build.rs
+++ b/src/bin/build.rs
@@ -2,7 +2,7 @@ use std::env;
 
 use cargo::ops::CompileOptions;
 use cargo::ops;
-use cargo::util::important_paths::{find_root_manifest_for_cwd};
+use cargo::util::important_paths::{find_root_manifest_for_wd};
 use cargo::util::{CliResult, CliError, Config};
 
 #[derive(RustcDecodable)]
@@ -64,7 +64,7 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
     try!(config.shell().set_verbosity(options.flag_verbose, options.flag_quiet));
     try!(config.shell().set_color_config(options.flag_color.as_ref().map(|s| &s[..])));
 
-    let root = try!(find_root_manifest_for_cwd(options.flag_manifest_path));
+    let root = try!(find_root_manifest_for_wd(options.flag_manifest_path, config.cwd()));
 
     let opts = CompileOptions {
         config: config,

--- a/src/bin/clean.rs
+++ b/src/bin/clean.rs
@@ -2,7 +2,7 @@ use std::env;
 
 use cargo::ops;
 use cargo::util::{CliResult, CliError, Config};
-use cargo::util::important_paths::{find_root_manifest_for_cwd};
+use cargo::util::important_paths::{find_root_manifest_for_wd};
 
 #[derive(RustcDecodable)]
 struct Options {
@@ -40,7 +40,7 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
     try!(config.shell().set_color_config(options.flag_color.as_ref().map(|s| &s[..])));
     debug!("executing; cmd=cargo-clean; args={:?}", env::args().collect::<Vec<_>>());
 
-    let root = try!(find_root_manifest_for_cwd(options.flag_manifest_path));
+    let root = try!(find_root_manifest_for_wd(options.flag_manifest_path, config.cwd()));
     let opts = ops::CleanOptions {
         config: config,
         spec: &options.flag_package,

--- a/src/bin/doc.rs
+++ b/src/bin/doc.rs
@@ -1,6 +1,6 @@
 use cargo::ops;
 use cargo::util::{CliResult, CliError, Config};
-use cargo::util::important_paths::{find_root_manifest_for_cwd};
+use cargo::util::important_paths::{find_root_manifest_for_wd};
 
 #[derive(RustcDecodable)]
 struct Options {
@@ -52,7 +52,7 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
     try!(config.shell().set_verbosity(options.flag_verbose, options.flag_quiet));
     try!(config.shell().set_color_config(options.flag_color.as_ref().map(|s| &s[..])));
 
-    let root = try!(find_root_manifest_for_cwd(options.flag_manifest_path));
+    let root = try!(find_root_manifest_for_wd(options.flag_manifest_path, config.cwd()));
 
     let mut doc_opts = ops::DocOptions {
         open_result: options.flag_open,

--- a/src/bin/fetch.rs
+++ b/src/bin/fetch.rs
@@ -1,6 +1,6 @@
 use cargo::ops;
 use cargo::util::{CliResult, CliError, Config};
-use cargo::util::important_paths::find_root_manifest_for_cwd;
+use cargo::util::important_paths::find_root_manifest_for_wd;
 
 #[derive(RustcDecodable)]
 struct Options {
@@ -36,7 +36,7 @@ all updated.
 pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
     try!(config.shell().set_verbosity(options.flag_verbose, options.flag_quiet));
     try!(config.shell().set_color_config(options.flag_color.as_ref().map(|s| &s[..])));
-    let root = try!(find_root_manifest_for_cwd(options.flag_manifest_path));
+    let root = try!(find_root_manifest_for_wd(options.flag_manifest_path, config.cwd()));
     try!(ops::fetch(&root, config).map_err(|e| {
         CliError::from_boxed(e, 101)
     }));

--- a/src/bin/generate_lockfile.rs
+++ b/src/bin/generate_lockfile.rs
@@ -2,7 +2,7 @@ use std::env;
 
 use cargo::ops;
 use cargo::util::{CliResult, CliError, Config};
-use cargo::util::important_paths::find_root_manifest_for_cwd;
+use cargo::util::important_paths::find_root_manifest_for_wd;
 
 #[derive(RustcDecodable)]
 struct Options {
@@ -30,7 +30,7 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
     debug!("executing; cmd=cargo-generate-lockfile; args={:?}", env::args().collect::<Vec<_>>());
     try!(config.shell().set_verbosity(options.flag_verbose, options.flag_quiet));
     try!(config.shell().set_color_config(options.flag_color.as_ref().map(|s| &s[..])));
-    let root = try!(find_root_manifest_for_cwd(options.flag_manifest_path));
+    let root = try!(find_root_manifest_for_wd(options.flag_manifest_path, config.cwd()));
 
     ops::generate_lockfile(&root, config)
         .map(|_| None).map_err(|err| CliError::from_boxed(err, 101))

--- a/src/bin/locate_project.rs
+++ b/src/bin/locate_project.rs
@@ -1,5 +1,5 @@
 use cargo::util::{CliResult, CliError, human, ChainError, Config};
-use cargo::util::important_paths::{find_root_manifest_for_cwd};
+use cargo::util::important_paths::{find_root_manifest_for_wd};
 
 #[derive(RustcDecodable)]
 struct LocateProjectFlags {
@@ -21,8 +21,8 @@ struct ProjectLocation {
 }
 
 pub fn execute(flags: LocateProjectFlags,
-               _: &Config) -> CliResult<Option<ProjectLocation>> {
-    let root = try!(find_root_manifest_for_cwd(flags.flag_manifest_path));
+               config: &Config) -> CliResult<Option<ProjectLocation>> {
+    let root = try!(find_root_manifest_for_wd(flags.flag_manifest_path, config.cwd()));
 
     let string = try!(root.to_str()
                       .chain_error(|| human("Your project path contains \

--- a/src/bin/package.rs
+++ b/src/bin/package.rs
@@ -1,6 +1,6 @@
 use cargo::ops;
 use cargo::util::{CliResult, CliError, Config};
-use cargo::util::important_paths::find_root_manifest_for_cwd;
+use cargo::util::important_paths::find_root_manifest_for_wd;
 
 #[derive(RustcDecodable)]
 struct Options {
@@ -34,7 +34,7 @@ Options:
 pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
     try!(config.shell().set_verbosity(options.flag_verbose, options.flag_quiet));
     try!(config.shell().set_color_config(options.flag_color.as_ref().map(|s| &s[..])));
-    let root = try!(find_root_manifest_for_cwd(options.flag_manifest_path));
+    let root = try!(find_root_manifest_for_wd(options.flag_manifest_path, config.cwd()));
     ops::package(&root, config,
                  !options.flag_no_verify,
                  options.flag_list,

--- a/src/bin/pkgid.rs
+++ b/src/bin/pkgid.rs
@@ -1,6 +1,6 @@
 use cargo::ops;
 use cargo::util::{CliResult, CliError, Config};
-use cargo::util::important_paths::{find_root_manifest_for_cwd};
+use cargo::util::important_paths::{find_root_manifest_for_wd};
 
 #[derive(RustcDecodable)]
 struct Options {
@@ -49,7 +49,7 @@ pub fn execute(options: Options,
                config: &Config) -> CliResult<Option<()>> {
     try!(config.shell().set_verbosity(options.flag_verbose, options.flag_quiet));
     try!(config.shell().set_color_config(options.flag_color.as_ref().map(|s| &s[..])));
-    let root = try!(find_root_manifest_for_cwd(options.flag_manifest_path.clone()));
+    let root = try!(find_root_manifest_for_wd(options.flag_manifest_path.clone(), config.cwd()));
 
     let spec = options.arg_spec.as_ref().map(|s| &s[..]);
     let spec = try!(ops::pkgid(&root, spec, config).map_err(|err| {

--- a/src/bin/publish.rs
+++ b/src/bin/publish.rs
@@ -1,6 +1,6 @@
 use cargo::ops;
 use cargo::util::{CliResult, CliError, Config};
-use cargo::util::important_paths::find_root_manifest_for_cwd;
+use cargo::util::important_paths::find_root_manifest_for_wd;
 
 #[derive(RustcDecodable)]
 struct Options {
@@ -42,7 +42,7 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
         ..
     } = options;
 
-    let root = try!(find_root_manifest_for_cwd(flag_manifest_path.clone()));
+    let root = try!(find_root_manifest_for_wd(flag_manifest_path.clone(), config.cwd()));
     ops::publish(&root, config, token, host, !no_verify).map(|_| None).map_err(|err| {
         CliError::from_boxed(err, 101)
     })

--- a/src/bin/read_manifest.rs
+++ b/src/bin/read_manifest.rs
@@ -3,7 +3,7 @@ use std::error::Error;
 
 use cargo::core::{Package, Source};
 use cargo::util::{CliResult, CliError, Config};
-use cargo::util::important_paths::{find_root_manifest_for_cwd};
+use cargo::util::important_paths::{find_root_manifest_for_wd};
 use cargo::sources::{PathSource};
 
 #[derive(RustcDecodable)]
@@ -29,7 +29,7 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<Package>> 
            env::args().collect::<Vec<_>>());
     try!(config.shell().set_color_config(options.flag_color.as_ref().map(|s| &s[..])));
 
-    let root = try!(find_root_manifest_for_cwd(options.flag_manifest_path));
+    let root = try!(find_root_manifest_for_wd(options.flag_manifest_path, config.cwd()));
 
     let mut source = try!(PathSource::for_path(root.parent().unwrap(), config).map_err(|e| {
         CliError::new(e.description(), 1)

--- a/src/bin/run.rs
+++ b/src/bin/run.rs
@@ -1,6 +1,6 @@
 use cargo::ops;
 use cargo::util::{CliResult, CliError, Config, Human};
-use cargo::util::important_paths::{find_root_manifest_for_cwd};
+use cargo::util::important_paths::{find_root_manifest_for_wd};
 
 #[derive(RustcDecodable)]
 struct Options {
@@ -52,7 +52,7 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
     try!(config.shell().set_verbosity(options.flag_verbose, options.flag_quiet));
     try!(config.shell().set_color_config(options.flag_color.as_ref().map(|s| &s[..])));
 
-    let root = try!(find_root_manifest_for_cwd(options.flag_manifest_path));
+    let root = try!(find_root_manifest_for_wd(options.flag_manifest_path, config.cwd()));
 
     let (mut examples, mut bins) = (Vec::new(), Vec::new());
     if let Some(s) = options.flag_bin {

--- a/src/bin/rustc.rs
+++ b/src/bin/rustc.rs
@@ -2,7 +2,7 @@ use std::env;
 
 use cargo::ops::CompileOptions;
 use cargo::ops;
-use cargo::util::important_paths::{find_root_manifest_for_cwd};
+use cargo::util::important_paths::{find_root_manifest_for_wd};
 use cargo::util::{CliResult, CliError, Config};
 
 #[derive(RustcDecodable)]
@@ -67,7 +67,7 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
     try!(config.shell().set_verbosity(options.flag_verbose, options.flag_quiet));
     try!(config.shell().set_color_config(options.flag_color.as_ref().map(|s| &s[..])));
 
-    let root = try!(find_root_manifest_for_cwd(options.flag_manifest_path));
+    let root = try!(find_root_manifest_for_wd(options.flag_manifest_path, config.cwd()));
 
     let opts = CompileOptions {
         config: config,

--- a/src/bin/test.rs
+++ b/src/bin/test.rs
@@ -1,6 +1,6 @@
 use cargo::ops;
 use cargo::util::{CliResult, CliError, Human, Config};
-use cargo::util::important_paths::{find_root_manifest_for_cwd};
+use cargo::util::important_paths::{find_root_manifest_for_wd};
 
 #[derive(RustcDecodable)]
 struct Options {
@@ -68,7 +68,7 @@ Compilation can be configured via the `test` profile in the manifest.
 ";
 
 pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
-    let root = try!(find_root_manifest_for_cwd(options.flag_manifest_path));
+    let root = try!(find_root_manifest_for_wd(options.flag_manifest_path, config.cwd()));
     try!(config.shell().set_verbosity(options.flag_verbose, options.flag_quiet));
     try!(config.shell().set_color_config(options.flag_color.as_ref().map(|s| &s[..])));
 

--- a/src/bin/update.rs
+++ b/src/bin/update.rs
@@ -2,7 +2,7 @@ use std::env;
 
 use cargo::ops;
 use cargo::util::{CliResult, CliError, Config};
-use cargo::util::important_paths::find_root_manifest_for_cwd;
+use cargo::util::important_paths::find_root_manifest_for_wd;
 
 #[derive(RustcDecodable)]
 struct Options {
@@ -56,7 +56,7 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
     debug!("executing; cmd=cargo-update; args={:?}", env::args().collect::<Vec<_>>());
     try!(config.shell().set_verbosity(options.flag_verbose, options.flag_quiet));
     try!(config.shell().set_color_config(options.flag_color.as_ref().map(|s| &s[..])));
-    let root = try!(find_root_manifest_for_cwd(options.flag_manifest_path));
+    let root = try!(find_root_manifest_for_wd(options.flag_manifest_path, config.cwd()));
 
     let update_opts = ops::UpdateOptions {
         aggressive: options.flag_aggressive,

--- a/src/bin/verify_project.rs
+++ b/src/bin/verify_project.rs
@@ -3,7 +3,7 @@ use std::fs::File;
 use std::io::prelude::*;
 use std::process;
 
-use cargo::util::important_paths::{find_root_manifest_for_cwd};
+use cargo::util::important_paths::{find_root_manifest_for_wd};
 use cargo::util::{CliResult, Config};
 use rustc_serialize::json;
 use toml;
@@ -37,7 +37,7 @@ pub fn execute(args: Flags, config: &Config) -> CliResult<Option<Error>> {
 
     let mut contents = String::new();
     let filename = args.flag_manifest_path.unwrap_or("Cargo.toml".into());
-    let filename = match find_root_manifest_for_cwd(Some(filename)) {
+    let filename = match find_root_manifest_for_wd(Some(filename), config.cwd()) {
         Ok(manifest_path) => manifest_path,
         Err(e) => fail("invalid", &e.to_string()),
     };

--- a/src/cargo/lib.rs
+++ b/src/cargo/lib.rs
@@ -97,7 +97,10 @@ fn process<V, F>(mut callback: F)
 {
     let mut config = None;
     let result = (|| {
-        config = Some(try!(Config::new(shell(Verbose, Auto))));
+        let cwd = try!(env::current_dir().chain_error(|| {
+            human("couldn't get the current directory of the process")
+        }));
+        config = Some(try!(Config::new(shell(Verbose, Auto), cwd)));
         let args: Vec<_> = try!(env::args_os().map(|s| {
             s.into_string().map_err(|s| {
                 human(format!("invalid unicode in argument: {:?}", s))

--- a/src/cargo/ops/cargo_new.rs
+++ b/src/cargo/ops/cargo_new.rs
@@ -97,15 +97,15 @@ fn strip_rust_affixes(name: &str) -> &str {
     name
 }
 
-fn existing_vcs_repo(path: &Path) -> bool {
-    GitRepo::discover(path).is_ok() || HgRepo::discover(path).is_ok()
+fn existing_vcs_repo(path: &Path, cwd: &Path) -> bool {
+    GitRepo::discover(path, cwd).is_ok() || HgRepo::discover(path, cwd).is_ok()
 }
 
 fn mk(config: &Config, path: &Path, name: &str,
       opts: &NewOptions) -> CargoResult<()> {
     let cfg = try!(global_config(config));
     let mut ignore = "target\n".to_string();
-    let in_existing_vcs_repo = existing_vcs_repo(path.parent().unwrap());
+    let in_existing_vcs_repo = existing_vcs_repo(path.parent().unwrap(), config.cwd());
     if !opts.bin {
         ignore.push_str("Cargo.lock\n");
     }
@@ -119,11 +119,11 @@ fn mk(config: &Config, path: &Path, name: &str,
 
     match vcs {
         VersionControl::Git => {
-            try!(GitRepo::init(path));
+            try!(GitRepo::init(path, config.cwd()));
             try!(paths::write(&path.join(".gitignore"), ignore.as_bytes()));
         },
         VersionControl::Hg => {
-            try!(HgRepo::init(path));
+            try!(HgRepo::init(path, config.cwd()));
             try!(paths::write(&path.join(".hgignore"), ignore.as_bytes()));
         },
         VersionControl::NoVcs => {

--- a/src/cargo/ops/cargo_rustc/context.rs
+++ b/src/cargo/ops/cargo_rustc/context.rs
@@ -100,7 +100,7 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
     /// specified as well as the exe suffix
     fn filename_parts(target: Option<&str>, cfg: &Config)
                       -> CargoResult<(Option<(String, String)>, String)> {
-        let mut process = try!(util::process(cfg.rustc(), cfg.cwd()));
+        let mut process = util::process(cfg.rustc());
         process.arg("-")
                .arg("--crate-name").arg("_")
                .arg("--crate-type").arg("dylib")

--- a/src/cargo/ops/cargo_rustc/context.rs
+++ b/src/cargo/ops/cargo_rustc/context.rs
@@ -100,7 +100,7 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
     /// specified as well as the exe suffix
     fn filename_parts(target: Option<&str>, cfg: &Config)
                       -> CargoResult<(Option<(String, String)>, String)> {
-        let mut process = try!(util::process(cfg.rustc()));
+        let mut process = try!(util::process(cfg.rustc(), cfg.cwd()));
         process.arg("-")
                .arg("--crate-name").arg("_")
                .arg("--crate-type").arg("dylib")

--- a/src/cargo/ops/cargo_rustc/engine.rs
+++ b/src/cargo/ops/cargo_rustc/engine.rs
@@ -40,10 +40,10 @@ impl CommandPrototype {
                -> CargoResult<CommandPrototype> {
         Ok(CommandPrototype {
             builder: try!(match ty {
-                CommandType::Rustc => process(config.rustc()),
-                CommandType::Rustdoc => process(config.rustdoc()),
+                CommandType::Rustc => process(config.rustc(), config.cwd()),
+                CommandType::Rustdoc => process(config.rustdoc(), config.cwd()),
                 CommandType::Target(ref s) |
-                CommandType::Host(ref s) => process(s),
+                CommandType::Host(ref s) => process(s, config.cwd()),
             }),
             ty: ty,
         })

--- a/src/cargo/ops/cargo_rustc/engine.rs
+++ b/src/cargo/ops/cargo_rustc/engine.rs
@@ -39,12 +39,16 @@ impl CommandPrototype {
     pub fn new(ty: CommandType, config: &Config)
                -> CargoResult<CommandPrototype> {
         Ok(CommandPrototype {
-            builder: try!(match ty {
-                CommandType::Rustc => process(config.rustc(), config.cwd()),
-                CommandType::Rustdoc => process(config.rustdoc(), config.cwd()),
-                CommandType::Target(ref s) |
-                CommandType::Host(ref s) => process(s, config.cwd()),
-            }),
+            builder: {
+                let mut p = match ty {
+                    CommandType::Rustc => process(config.rustc()),
+                    CommandType::Rustdoc => process(config.rustdoc()),
+                    CommandType::Target(ref s) |
+                    CommandType::Host(ref s) => process(s),
+                };
+                p.cwd(config.cwd());
+                p
+            },
             ty: ty,
         })
     }
@@ -73,7 +77,7 @@ impl CommandPrototype {
     }
 
     pub fn get_args(&self) -> &[OsString] { self.builder.get_args() }
-    pub fn get_cwd(&self) -> &Path { self.builder.get_cwd() }
+    pub fn get_cwd(&self) -> Option<&Path> { self.builder.get_cwd() }
 
     pub fn get_env(&self, var: &str) -> Option<OsString> {
         self.builder.get_env(var)

--- a/src/cargo/ops/registry.rs
+++ b/src/cargo/ops/registry.rs
@@ -20,7 +20,7 @@ use util::config;
 use util::paths;
 use util::{CargoResult, human, ChainError, ToUrl};
 use util::config::{Config, ConfigValue, Location};
-use util::important_paths::find_root_manifest_for_cwd;
+use util::important_paths::find_root_manifest_for_wd;
 
 pub struct RegistryConfig {
     pub index: Option<String>,
@@ -252,7 +252,7 @@ pub fn modify_owners(config: &Config, opts: &OwnersOptions) -> CargoResult<()> {
     let name = match opts.krate {
         Some(ref name) => name.clone(),
         None => {
-            let manifest_path = try!(find_root_manifest_for_cwd(None));
+            let manifest_path = try!(find_root_manifest_for_wd(None, config.cwd()));
             let pkg = try!(Package::for_path(&manifest_path, config));
             pkg.name().to_string()
         }
@@ -312,7 +312,7 @@ pub fn yank(config: &Config,
     let name = match krate {
         Some(name) => name,
         None => {
-            let manifest_path = try!(find_root_manifest_for_cwd(None));
+            let manifest_path = try!(find_root_manifest_for_wd(None, config.cwd()));
             let pkg = try!(Package::for_path(&manifest_path, config));
             pkg.name().to_string()
         }

--- a/src/cargo/util/config.rs
+++ b/src/cargo/util/config.rs
@@ -31,11 +31,7 @@ pub struct Config {
 }
 
 impl Config {
-    pub fn new(shell: MultiShell) -> CargoResult<Config> {
-        let cwd = try!(env::current_dir().chain_error(|| {
-            human("couldn't get the current directory of the process")
-        }));
-
+    pub fn new(shell: MultiShell, cwd: PathBuf) -> CargoResult<Config> {
         let mut cfg = Config {
             home_path: try!(homedir(cwd.as_path()).chain_error(|| {
                 human("Cargo couldn't find your home directory. \
@@ -231,7 +227,7 @@ impl Config {
     }
 
     fn scrape_rustc_version(&mut self) -> CargoResult<()> {
-        self.rustc_info = try!(Rustc::new(&self.rustc));
+        self.rustc_info = try!(Rustc::new(&self.rustc, self.cwd()));
         Ok(())
     }
 

--- a/src/cargo/util/important_paths.rs
+++ b/src/cargo/util/important_paths.rs
@@ -1,7 +1,6 @@
-use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
-use util::{CargoResult, human, ChainError};
+use util::{CargoResult, human};
 
 /// Iteratively search for `file` in `pwd` and its parents, returning
 /// the path of the directory.
@@ -35,11 +34,8 @@ pub fn find_project_manifest(pwd: &Path, file: &str) -> CargoResult<PathBuf> {
 }
 
 /// Find the root Cargo.toml
-pub fn find_root_manifest_for_cwd(manifest_path: Option<String>)
+pub fn find_root_manifest_for_wd(manifest_path: Option<String>, cwd: &Path)
                                   -> CargoResult<PathBuf> {
-    let cwd = try!(env::current_dir().chain_error(|| {
-        human("Couldn't determine the current working directory")
-    }));
     match manifest_path {
         Some(path) => {
             let absolute_path = cwd.join(&path);

--- a/src/cargo/util/process_builder.rs
+++ b/src/cargo/util/process_builder.rs
@@ -60,7 +60,9 @@ impl ProcessBuilder {
     pub fn get_args(&self) -> &[OsString] {
         &self.args
     }
-    pub fn get_cwd(&self) -> &Path { Path::new(&self.cwd) }
+    pub fn get_cwd(&self) -> &Path {
+        Path::new(&self.cwd)
+    }
 
     pub fn get_env(&self, var: &str) -> Option<OsString> {
         self.env.get(var).cloned().or_else(|| Some(env::var_os(var)))
@@ -106,7 +108,7 @@ impl ProcessBuilder {
 
     pub fn build_command(&self) -> Command {
         let mut command = Command::new(&self.program);
-        command.current_dir(&self.cwd);
+        command.current_dir(&self.get_cwd());
         for arg in self.args.iter() {
             command.arg(arg);
         }
@@ -129,11 +131,11 @@ impl ProcessBuilder {
     }
 }
 
-pub fn process<T: AsRef<OsStr>>(cmd: T) -> CargoResult<ProcessBuilder> {
+pub fn process<T: AsRef<OsStr>, U: AsRef<OsStr>>(cmd: T, cwd: U) -> CargoResult<ProcessBuilder> {
     Ok(ProcessBuilder {
         program: cmd.as_ref().to_os_string(),
         args: Vec::new(),
-        cwd: try!(env::current_dir()).as_os_str().to_os_string(),
+        cwd: cwd.as_ref().to_os_string(),
         env: HashMap::new(),
     })
 }

--- a/src/cargo/util/rustc.rs
+++ b/src/cargo/util/rustc.rs
@@ -15,8 +15,8 @@ impl Rustc {
     /// If successful this function returns a description of the compiler along
     /// with a list of its capabilities.
     pub fn new<P: AsRef<Path>>(path: P, cwd: &Path) -> CargoResult<Rustc> {
-        let mut cmd = try!(util::process(path.as_ref(), cwd));
-        cmd.arg("-vV");
+        let mut cmd = util::process(path.as_ref());
+        cmd.cwd(cwd).arg("-vV");
 
         let mut ret = Rustc::blank();
         let mut first = cmd.clone();

--- a/src/cargo/util/rustc.rs
+++ b/src/cargo/util/rustc.rs
@@ -14,8 +14,8 @@ impl Rustc {
     ///
     /// If successful this function returns a description of the compiler along
     /// with a list of its capabilities.
-    pub fn new<P: AsRef<Path>>(path: P) -> CargoResult<Rustc> {
-        let mut cmd = try!(util::process(path.as_ref()));
+    pub fn new<P: AsRef<Path>>(path: P, cwd: &Path) -> CargoResult<Rustc> {
+        let mut cmd = try!(util::process(path.as_ref(), cwd));
         cmd.arg("-vV");
 
         let mut ret = Rustc::blank();

--- a/src/cargo/util/vcs.rs
+++ b/src/cargo/util/vcs.rs
@@ -8,22 +8,22 @@ pub struct HgRepo;
 pub struct GitRepo;
 
 impl GitRepo {
-    pub fn init(path: &Path) -> CargoResult<GitRepo> {
+    pub fn init(path: &Path, _: &Path) -> CargoResult<GitRepo> {
         try!(git2::Repository::init(path));
         return Ok(GitRepo)
     }
-    pub fn discover(path: &Path) -> Result<git2::Repository,git2::Error> {
+    pub fn discover(path: &Path, _: &Path) -> Result<git2::Repository,git2::Error> {
         git2::Repository::discover(path)
     }
 }
 
 impl HgRepo {
-    pub fn init(path: &Path) -> CargoResult<HgRepo> {
-        try!(try!(process("hg")).arg("init").arg(path).exec());
+    pub fn init(path: &Path, cwd: &Path) -> CargoResult<HgRepo> {
+        try!(try!(process("hg", cwd)).arg("init").arg(path).exec());
         return Ok(HgRepo)
     }
-    pub fn discover(path: &Path) -> CargoResult<HgRepo> {
-        try!(try!(process("hg")).arg("root").cwd(path).exec_with_output());
+    pub fn discover(path: &Path, cwd: &Path) -> CargoResult<HgRepo> {
+        try!(try!(process("hg", cwd)).arg("root").cwd(path).exec_with_output());
         return Ok(HgRepo)
     }
 }

--- a/src/cargo/util/vcs.rs
+++ b/src/cargo/util/vcs.rs
@@ -19,11 +19,11 @@ impl GitRepo {
 
 impl HgRepo {
     pub fn init(path: &Path, cwd: &Path) -> CargoResult<HgRepo> {
-        try!(try!(process("hg", cwd)).arg("init").arg(path).exec());
+        try!(process("hg").cwd(cwd).arg("init").arg(path).exec());
         return Ok(HgRepo)
     }
     pub fn discover(path: &Path, cwd: &Path) -> CargoResult<HgRepo> {
-        try!(try!(process("hg", cwd)).arg("root").cwd(path).exec_with_output());
+        try!(process("hg").cwd(cwd).arg("root").cwd(path).exec_with_output());
         return Ok(HgRepo)
     }
 }

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -12,8 +12,9 @@ use std::usize;
 
 use url::Url;
 use hamcrest as ham;
-use cargo::util::{process,ProcessBuilder};
+use cargo::util::ProcessBuilder;
 use cargo::util::ProcessError;
+use cargo::util::process;
 
 use support::paths::CargoPathExt;
 
@@ -134,7 +135,7 @@ impl ProjectBuilder {
     }
 
     pub fn process<T: AsRef<OsStr>>(&self, program: T) -> ProcessBuilder {
-        let mut p = process(program).unwrap();
+        let mut p = process(program);
         p.cwd(&self.root())
          .env("HOME", &paths::home())
          .env_remove("CARGO_HOME")  // make sure we don't pick up an outer one
@@ -548,6 +549,10 @@ pub fn basic_lib_manifest(name: &str) -> String {
 
 pub fn path2url(p: PathBuf) -> Url {
     Url::from_file_path(&*p).ok().unwrap()
+}
+
+pub fn cwd() -> PathBuf {
+    env::current_dir().unwrap()
 }
 
 pub static RUNNING:     &'static str = "     Running";

--- a/tests/test_cargo.rs
+++ b/tests/test_cargo.rs
@@ -43,7 +43,7 @@ fn path() -> Vec<PathBuf> {
 test!(list_commands_looks_at_path {
     let proj = project("list-non-overlapping");
     let proj = fake_executable(proj, &Path::new("path-test"), "cargo-1");
-    let mut pr = process(&cargo_dir().join("cargo")).unwrap();
+    let mut pr = process(&cargo_dir().join("cargo"));
     pr.cwd(&proj.root())
       .env("HOME", &paths::home());
 
@@ -58,7 +58,7 @@ test!(list_commands_looks_at_path {
 });
 
 test!(find_closest_biuld_to_build {
-    let mut pr = process(&cargo_dir().join("cargo")).unwrap();
+    let mut pr = process(&cargo_dir().join("cargo"));
     pr.arg("biuld").cwd(&paths::root()).env("HOME", &paths::home());
 
     assert_that(pr,
@@ -72,7 +72,7 @@ Did you mean `build`?
 
 // if a subcommand is more than 3 edit distance away, we don't make a suggestion
 test!(find_closest_dont_correct_nonsense {
-    let mut pr = process(&cargo_dir().join("cargo")).unwrap();
+    let mut pr = process(&cargo_dir().join("cargo"));
     pr.arg("asdf").cwd(&paths::root()).env("HOME", &paths::home());
 
     assert_that(pr,
@@ -92,7 +92,7 @@ test!(override_cargo_home {
         git = false
     "#).unwrap();
 
-    assert_that(process(&cargo_dir().join("cargo")).unwrap()
+    assert_that(process(&cargo_dir().join("cargo"))
                     .arg("new").arg("foo")
                     .cwd(&paths::root())
                     .env("USER", "foo")
@@ -107,22 +107,22 @@ test!(override_cargo_home {
 });
 
 test!(cargo_help {
-    assert_that(process(&cargo_dir().join("cargo")).unwrap(),
+    assert_that(process(&cargo_dir().join("cargo")),
                 execs().with_status(0));
-    assert_that(process(&cargo_dir().join("cargo")).unwrap().arg("help"),
+    assert_that(process(&cargo_dir().join("cargo")).arg("help"),
                 execs().with_status(0));
-    assert_that(process(&cargo_dir().join("cargo")).unwrap().arg("-h"),
+    assert_that(process(&cargo_dir().join("cargo")).arg("-h"),
                 execs().with_status(0));
-    assert_that(process(&cargo_dir().join("cargo")).unwrap()
+    assert_that(process(&cargo_dir().join("cargo"))
                        .arg("help").arg("build"),
                 execs().with_status(0));
-    assert_that(process(&cargo_dir().join("cargo")).unwrap()
+    assert_that(process(&cargo_dir().join("cargo"))
                        .arg("build").arg("-h"),
                 execs().with_status(0));
-    assert_that(process(&cargo_dir().join("cargo")).unwrap()
+    assert_that(process(&cargo_dir().join("cargo"))
                        .arg("help").arg("-h"),
                 execs().with_status(0));
-    assert_that(process(&cargo_dir().join("cargo")).unwrap()
+    assert_that(process(&cargo_dir().join("cargo"))
                        .arg("help").arg("help"),
                 execs().with_status(0));
 });

--- a/tests/test_cargo_bench.rs
+++ b/tests/test_cargo_bench.rs
@@ -33,7 +33,7 @@ test!(cargo_bench_simple {
     assert_that(p.cargo_process("build"), execs());
     assert_that(&p.bin("foo"), existing_file());
 
-    assert_that(process(&p.bin("foo")).unwrap(),
+    assert_that(process(&p.bin("foo")),
                 execs().with_stdout("hello\n"));
 
     assert_that(p.cargo("bench"),
@@ -177,7 +177,7 @@ test!(cargo_bench_failing_test {
     assert_that(p.cargo_process("build"), execs());
     assert_that(&p.bin("foo"), existing_file());
 
-    assert_that(process(&p.bin("foo")).unwrap(),
+    assert_that(process(&p.bin("foo")),
                 execs().with_stdout("hello\n"));
 
     assert_that(p.cargo("bench"),

--- a/tests/test_cargo_compile.rs
+++ b/tests/test_cargo_compile.rs
@@ -21,7 +21,7 @@ test!(cargo_compile_simple {
     assert_that(p.cargo_process("build"), execs());
     assert_that(&p.bin("foo"), existing_file());
 
-    assert_that(process(&p.bin("foo")).unwrap(),
+    assert_that(process(&p.bin("foo")),
                 execs().with_stdout("i am foo\n"));
 });
 
@@ -327,7 +327,7 @@ test!(cargo_compile_with_warnings_in_a_dep_package {
     assert_that(&p.bin("foo"), existing_file());
 
     assert_that(
-      process(&p.bin("foo")).unwrap(),
+      process(&p.bin("foo")),
       execs().with_stdout("test passed\n"));
 });
 
@@ -385,7 +385,7 @@ test!(cargo_compile_with_nested_deps_inferred {
     assert_that(&p.bin("foo"), existing_file());
 
     assert_that(
-      process(&p.bin("foo")).unwrap(),
+      process(&p.bin("foo")),
       execs().with_stdout("test passed\n"));
 });
 
@@ -443,7 +443,7 @@ test!(cargo_compile_with_nested_deps_correct_bin {
     assert_that(&p.bin("foo"), existing_file());
 
     assert_that(
-      process(&p.bin("foo")).unwrap(),
+      process(&p.bin("foo")),
       execs().with_stdout("test passed\n"));
 });
 
@@ -510,7 +510,7 @@ test!(cargo_compile_with_nested_deps_shorthand {
     assert_that(&p.bin("foo"), existing_file());
 
     assert_that(
-      process(&p.bin("foo")).unwrap(),
+      process(&p.bin("foo")),
       execs().with_stdout("test passed\n"));
 });
 
@@ -576,7 +576,7 @@ test!(cargo_compile_with_nested_deps_longhand {
 
     assert_that(&p.bin("foo"), existing_file());
 
-    assert_that(process(&p.bin("foo")).unwrap(),
+    assert_that(process(&p.bin("foo")),
                 execs().with_stdout("test passed\n"));
 });
 
@@ -717,7 +717,7 @@ test!(crate_version_env_vars {
     assert_that(p.cargo_process("build").arg("-v"), execs().with_status(0));
 
     println!("bin");
-    assert_that(process(&p.bin("foo")).unwrap(),
+    assert_that(process(&p.bin("foo")),
                 execs().with_stdout(&format!("0-5-1 @ alpha.1 in {}\n",
                                             p.root().display())));
 
@@ -862,7 +862,7 @@ test!(ignore_broken_symlinks {
     assert_that(p.cargo_process("build"), execs());
     assert_that(&p.bin("foo"), existing_file());
 
-    assert_that(process(&p.bin("foo")).unwrap(),
+    assert_that(process(&p.bin("foo")),
                 execs().with_stdout("i am foo\n"));
 });
 
@@ -1067,9 +1067,9 @@ test!(explicit_examples {
         "#);
 
     assert_that(p.cargo_process("test").arg("-v"), execs().with_status(0));
-    assert_that(process(&p.bin("examples/hello")).unwrap(),
+    assert_that(process(&p.bin("examples/hello")),
                         execs().with_stdout("Hello, World!\n"));
-    assert_that(process(&p.bin("examples/goodbye")).unwrap(),
+    assert_that(process(&p.bin("examples/goodbye")),
                         execs().with_stdout("Goodbye, World!\n"));
 });
 
@@ -1100,9 +1100,9 @@ test!(implicit_examples {
         "#);
 
     assert_that(p.cargo_process("test"), execs().with_status(0));
-    assert_that(process(&p.bin("examples/hello")).unwrap(),
+    assert_that(process(&p.bin("examples/hello")),
                 execs().with_stdout("Hello, World!\n"));
-    assert_that(process(&p.bin("examples/goodbye")).unwrap(),
+    assert_that(process(&p.bin("examples/goodbye")),
                 execs().with_stdout("Goodbye, World!\n"));
 });
 
@@ -1120,7 +1120,7 @@ test!(standard_build_no_ndebug {
         "#);
 
     assert_that(p.cargo_process("build"), execs().with_status(0));
-    assert_that(process(&p.bin("foo")).unwrap(),
+    assert_that(process(&p.bin("foo")),
                 execs().with_stdout("slow\n"));
 });
 
@@ -1139,7 +1139,7 @@ test!(release_build_ndebug {
 
     assert_that(p.cargo_process("build").arg("--release"),
                 execs().with_status(0));
-    assert_that(process(&p.release_bin("foo")).unwrap(),
+    assert_that(process(&p.release_bin("foo")),
                 execs().with_stdout("fast\n"));
 });
 
@@ -1156,7 +1156,7 @@ test!(inferred_main_bin {
         "#);
 
     assert_that(p.cargo_process("build"), execs().with_status(0));
-    assert_that(process(&p.bin("foo")).unwrap(), execs().with_status(0));
+    assert_that(process(&p.bin("foo")), execs().with_status(0));
 });
 
 test!(deletion_causes_failure {
@@ -1206,7 +1206,7 @@ test!(bad_cargo_toml_in_target_dir {
         .file("target/Cargo.toml", "bad-toml");
 
     assert_that(p.cargo_process("build"), execs().with_status(0));
-    assert_that(process(&p.bin("foo")).unwrap(), execs().with_status(0));
+    assert_that(process(&p.bin("foo")), execs().with_status(0));
 });
 
 test!(lib_with_standard_name {
@@ -1597,7 +1597,7 @@ test!(cargo_platform_specific_dependency_wrong_platform {
     p.cargo_process("build").exec_with_output().unwrap();
 
     assert_that(&p.bin("foo"), existing_file());
-    assert_that(process(&p.bin("foo")).unwrap(),
+    assert_that(process(&p.bin("foo")),
                 execs());
 
     let loc = p.root().join("Cargo.lock");
@@ -1986,7 +1986,7 @@ test!(build_multiple_packages {
                 execs());
 
     assert_that(&p.bin("foo"), existing_file());
-    assert_that(process(&p.bin("foo")).unwrap(),
+    assert_that(process(&p.bin("foo")),
                 execs().with_stdout("i am foo\n"));
 
     let d1_path = &p.build_dir().join("debug").join("deps")
@@ -1995,10 +1995,10 @@ test!(build_multiple_packages {
                                 .join(format!("d2{}", env::consts::EXE_SUFFIX));
 
     assert_that(d1_path, existing_file());
-    assert_that(process(d1_path).unwrap(), execs().with_stdout("d1"));
+    assert_that(process(d1_path), execs().with_stdout("d1"));
 
     assert_that(d2_path, existing_file());
-    assert_that(process(d2_path).unwrap(),
+    assert_that(process(d2_path),
                 execs().with_stdout("d2"));
 });
 

--- a/tests/test_cargo_compile_git_deps.rs
+++ b/tests/test_cargo_compile_git_deps.rs
@@ -8,7 +8,6 @@ use support::{git, project, execs, main_file, path2url};
 use support::{COMPILING, UPDATING, RUNNING};
 use support::paths::{self, CargoPathExt};
 use hamcrest::{assert_that,existing_file};
-use cargo;
 use cargo::util::process;
 
 fn setup() {
@@ -70,7 +69,7 @@ test!(cargo_compile_simple_git_dep {
     assert_that(&project.bin("foo"), existing_file());
 
     assert_that(
-      cargo::util::process(&project.bin("foo")).unwrap(),
+      process(&project.bin("foo")),
       execs().with_stdout("hello world\n"));
 });
 
@@ -137,7 +136,7 @@ test!(cargo_compile_git_dep_branch {
     assert_that(&project.bin("foo"), existing_file());
 
     assert_that(
-      cargo::util::process(&project.bin("foo")).unwrap(),
+      process(&project.bin("foo")),
       execs().with_stdout("hello world\n"));
 });
 
@@ -205,7 +204,7 @@ test!(cargo_compile_git_dep_tag {
 
     assert_that(&project.bin("foo"), existing_file());
 
-    assert_that(cargo::util::process(&project.bin("foo")).unwrap(),
+    assert_that(process(&project.bin("foo")),
                 execs().with_stdout("hello world\n"));
 
     assert_that(project.cargo("build"),
@@ -282,7 +281,7 @@ test!(cargo_compile_with_nested_paths {
 
     assert_that(&p.bin("parent"), existing_file());
 
-    assert_that(cargo::util::process(&p.bin("parent")).unwrap(),
+    assert_that(process(&p.bin("parent")),
                 execs().with_stdout("hello world\n"));
 });
 
@@ -354,7 +353,7 @@ test!(cargo_compile_with_meta_package {
 
     assert_that(&p.bin("parent"), existing_file());
 
-    assert_that(cargo::util::process(&p.bin("parent")).unwrap(),
+    assert_that(process(&p.bin("parent")),
                 execs().with_stdout("this is dep1 this is dep2\n"));
 });
 
@@ -1220,7 +1219,7 @@ test!(git_dep_build_cmd {
     assert_that(p.cargo("build"),
                 execs().with_status(0));
 
-    assert_that(cargo::util::process(&p.bin("foo")).unwrap(),
+    assert_that(process(&p.bin("foo")),
                 execs().with_stdout("0\n"));
 
     // Touching bar.rs.in should cause the `build` command to run again.
@@ -1230,7 +1229,7 @@ test!(git_dep_build_cmd {
     assert_that(p.cargo("build"),
                 execs().with_status(0));
 
-    assert_that(cargo::util::process(&p.bin("foo")).unwrap(),
+    assert_that(process(&p.bin("foo")),
                 execs().with_stdout("1\n"));
 });
 

--- a/tests/test_cargo_compile_path_deps.rs
+++ b/tests/test_cargo_compile_path_deps.rs
@@ -6,8 +6,7 @@ use support::{project, execs, main_file};
 use support::{COMPILING, RUNNING};
 use support::paths::{self, CargoPathExt};
 use hamcrest::{assert_that, existing_file};
-use cargo;
-use cargo::util::{process};
+use cargo::util::process;
 
 fn setup() {
 }
@@ -83,7 +82,7 @@ test!(cargo_compile_with_nested_deps_shorthand {
 
     assert_that(&p.bin("foo"), existing_file());
 
-    assert_that(cargo::util::process(&p.bin("foo")).unwrap(),
+    assert_that(process(&p.bin("foo")),
                 execs().with_stdout("test passed\n").with_status(0));
 
     println!("cleaning");
@@ -238,7 +237,7 @@ test!(cargo_compile_with_transitive_dev_deps {
 
     assert_that(&p.bin("foo"), existing_file());
 
-    assert_that(cargo::util::process(&p.bin("foo")).unwrap(),
+    assert_that(process(&p.bin("foo")),
                 execs().with_stdout("zoidberg\n"));
 });
 
@@ -687,7 +686,7 @@ test!(path_dep_build_cmd {
 
     assert_that(&p.bin("foo"), existing_file());
 
-    assert_that(cargo::util::process(&p.bin("foo")).unwrap(),
+    assert_that(process(&p.bin("foo")),
                 execs().with_stdout("0\n"));
 
     // Touching bar.rs.in should cause the `build` command to run again.
@@ -702,7 +701,7 @@ test!(path_dep_build_cmd {
                                     COMPILING, p.url(),
                                     COMPILING, p.url())));
 
-    assert_that(cargo::util::process(&p.bin("foo")).unwrap(),
+    assert_that(process(&p.bin("foo")),
                 execs().with_stdout("1\n"));
 });
 

--- a/tests/test_cargo_cross_compile.rs
+++ b/tests/test_cargo_cross_compile.rs
@@ -74,7 +74,7 @@ test!(simple_cross {
                 execs().with_status(0));
     assert_that(&p.target_bin(&target, "foo"), existing_file());
 
-    assert_that(process(&p.target_bin(&target, "foo")).unwrap(),
+    assert_that(process(&p.target_bin(&target, "foo")),
                 execs().with_status(0));
 });
 
@@ -110,7 +110,7 @@ test!(simple_deps {
                 execs().with_status(0));
     assert_that(&p.target_bin(&target, "foo"), existing_file());
 
-    assert_that(process(&p.target_bin(&target, "foo")).unwrap(),
+    assert_that(process(&p.target_bin(&target, "foo")),
                 execs().with_status(0));
 });
 
@@ -187,7 +187,7 @@ test!(plugin_deps {
                 execs().with_status(0));
     assert_that(&foo.target_bin(&target, "foo"), existing_file());
 
-    assert_that(process(&foo.target_bin(&target, "foo")).unwrap(),
+    assert_that(process(&foo.target_bin(&target, "foo")),
                 execs().with_status(0));
 });
 
@@ -272,7 +272,7 @@ test!(plugin_to_the_max {
                 execs().with_status(0));
     assert_that(&foo.target_bin(&target, "foo"), existing_file());
 
-    assert_that(process(&foo.target_bin(&target, "foo")).unwrap(),
+    assert_that(process(&foo.target_bin(&target, "foo")),
                 execs().with_status(0));
 });
 

--- a/tests/test_cargo_install.rs
+++ b/tests/test_cargo_install.rs
@@ -19,7 +19,7 @@ fn setup() {
 }
 
 fn cargo_process(s: &str) -> ProcessBuilder {
-    let mut p = process(&cargo_dir().join("cargo")).unwrap();
+    let mut p = process(&cargo_dir().join("cargo"));
     p.arg(s).cwd(&paths::root())
      .env("HOME", &paths::home())
      .env_remove("CARGO_HOME");

--- a/tests/test_cargo_new.rs
+++ b/tests/test_cargo_new.rs
@@ -13,13 +13,13 @@ fn setup() {
 }
 
 fn my_process(s: &str) -> ProcessBuilder {
-    let mut p = process(s).unwrap();
+    let mut p = process(s);
     p.cwd(&paths::root()).env("HOME", &paths::home());
     return p;
 }
 
 fn cargo_process(s: &str) -> ProcessBuilder {
-    let mut p = process(&cargo_dir().join("cargo")).unwrap();
+    let mut p = process(&cargo_dir().join("cargo"));
     p.arg(s).cwd(&paths::root()).env("HOME", &paths::home());
     return p;
 }

--- a/tests/test_cargo_package.rs
+++ b/tests/test_cargo_package.rs
@@ -217,7 +217,7 @@ test!(package_verbose {
         "#)
         .file("a/src/lib.rs", "");
     p.build();
-    let mut cargo = process(&cargo_dir().join("cargo")).unwrap();
+    let mut cargo = process(&cargo_dir().join("cargo"));
     cargo.cwd(&root).env("HOME", &paths::home());
     assert_that(cargo.clone().arg("build"), execs().with_status(0));
     assert_that(cargo.arg("package").arg("-v").arg("--no-verify"),

--- a/tests/test_cargo_registry.rs
+++ b/tests/test_cargo_registry.rs
@@ -557,7 +557,7 @@ test!(dev_dependency_not_used {
 test!(login_with_no_cargo_dir {
     let home = paths::home().join("new-home");
     fs::create_dir(&home).unwrap();
-    assert_that(process(&cargo_dir().join("cargo")).unwrap()
+    assert_that(process(&cargo_dir().join("cargo"))
                        .arg("login").arg("foo").arg("-v")
                        .cwd(&paths::root())
                        .env("HOME", &home),

--- a/tests/test_cargo_search.rs
+++ b/tests/test_cargo_search.rs
@@ -35,7 +35,7 @@ fn setup() {
 }
 
 fn cargo_process(s: &str) -> ProcessBuilder {
-    let mut b = process(&cargo_dir().join("cargo")).unwrap();
+    let mut b = process(&cargo_dir().join("cargo"));
     b.arg(s).cwd(&paths::root()).env("HOME", &paths::home());
     b
 }

--- a/tests/test_cargo_test.rs
+++ b/tests/test_cargo_test.rs
@@ -31,7 +31,7 @@ test!(cargo_test_simple {
     assert_that(p.cargo_process("build"), execs());
     assert_that(&p.bin("foo"), existing_file());
 
-    assert_that(process(&p.bin("foo")).unwrap(),
+    assert_that(process(&p.bin("foo")),
                 execs().with_stdout("hello\n"));
 
     assert_that(p.cargo("test"),
@@ -188,7 +188,7 @@ test!(cargo_test_failing_test {
     assert_that(p.cargo_process("build"), execs());
     assert_that(&p.bin("foo"), existing_file());
 
-    assert_that(process(&p.bin("foo")).unwrap(),
+    assert_that(process(&p.bin("foo")),
                 execs().with_stdout("hello\n"));
 
     assert_that(p.cargo("test"),

--- a/tests/test_shell.rs
+++ b/tests/test_shell.rs
@@ -81,7 +81,7 @@ test!(color_explicitly_enabled {
 
 test!(no_term {
     // Verify that shell creation is successful when $TERM does not exist.
-    assert_that(process(&cargo_dir().join("cargo")).unwrap()
+    assert_that(process(&cargo_dir().join("cargo"))
                     .env_remove("TERM"),
                 execs().with_stderr(""));
 });

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -64,7 +64,7 @@ mod test_cargo_verify_project;
 mod test_cargo_version;
 mod test_shell;
 
-thread_local!(static RUSTC: Rustc = Rustc::new("rustc").unwrap());
+thread_local!(static RUSTC: Rustc = Rustc::new("rustc", &support::cwd()).unwrap());
 
 fn rustc_host() -> String {
     RUSTC.with(|r| r.host.clone())


### PR DESCRIPTION
Right now, there are a few places in in cargo where it queries `env::current_directory` directly, ignoring the value of `Config::cwd()`. This PR rectifies that by passing down the `config.cwd()` value to all locations where a working directory is needed.