### PR TITLE
Fix broken links in documentation

### DIFF
--- a/src/doc/build-script.md
+++ b/src/doc/build-script.md
@@ -73,6 +73,8 @@ Any other element is a user-defined metadata that will be passed to
 dependencies. More information about this can be found in the [`links`][links]
 section.
 
+[links]: #the-links-manifest-key
+
 ## Build Dependencies
 
 Build scripts are also allowed to have dependencies on other Cargo-based crates.
@@ -115,7 +117,7 @@ In other words, it's forbidden to have two packages link to the same native
 library. Note, however, that there are [conventions in place][star-sys] to
 alleviate this.
 
-[star-sys]: #*-sys-packages
+[star-sys]: #-sys-packages
 
 As mentioned above in the output format, each build script can generate an
 arbitrary set of metadata in the form of key-value pairs. This metadata is

--- a/src/doc/crates-io.md
+++ b/src/doc/crates-io.md
@@ -34,7 +34,7 @@ num = "0.0.4"
 The string value for each key in this table is a [semver][semver] version
 requirement.
 
-[semver]: http://doc.rust-lang.org/semver/semver/#requirements
+[semver]: https://github.com/steveklabnik/semver#requirements
 
 **Caret requirements** allow SemVer compatible updates to a specified version.
 

--- a/src/doc/environment-variables.md
+++ b/src/doc/environment-variables.md
@@ -54,7 +54,7 @@ Here are a list of the variables Cargo sets, organized by when it sets them:
                        variables, see build script documentation about [`links`][links].
 
 [links]: build-script.html#the-links-manifest-key
-[profile]: manifest.html#the-[profile.*]-sections
+[profile]: manifest.html#the-profile-sections
 [clang]:http://clang.llvm.org/docs/CrossCompilation.html#target-triple
 
 # Environment variables Cargo sets for crates

--- a/src/doc/faq.md
+++ b/src/doc/faq.md
@@ -74,7 +74,7 @@ on the platform. Cargo also supports [platform-specific
 dependencies][target-deps], and we plan to support more per-platform
 configuration in `Cargo.toml` in the future.
 
-[target-deps]: manifest.html#the-[dependencies.*]-sections
+[target-deps]: manifest.html#the-dependencies-section
 
 In the longer-term, we're looking at ways to conveniently cross-compile
 projects using Cargo.
@@ -83,7 +83,7 @@ projects using Cargo.
 
 We support environments through the use of [profiles][profile] to support:
 
-[profile]: manifest.html#the-[profile.*]-sections
+[profile]: manifest.html#the-profile-sections
 
 * environment-specific flags (like `-g --opt-level=0` for development
   and `--opt-level=3` for production).

--- a/src/doc/manifest.md
+++ b/src/doc/manifest.md
@@ -25,7 +25,7 @@ basic rules:
 * Use version numbers with three numeric parts such as 1.0.0 rather than 1.0.
 
 For more on versions, see [this
-documentation](crates-io.html#using-crates.io-based-crates).
+documentation](crates-io.html#using-cratesio-based-crates).
 
 ## The `build` Field (optional)
 
@@ -151,7 +151,7 @@ color = "> 0.6.0, < 0.8.0"
 ```
 
 The syntax of the requirement strings is described in the [crates.io
-guide](crates-io.html#using-crates.io-based-crates).
+guide](crates-io.html#using-cratesio-based-crates).
 
 Platform-specific dependencies take the same format, but are listed under the
 `target.$triple` section:


### PR DESCRIPTION
The semver documentation doesn't seem to be hosted anywhere at the moment so I made that link point at GitHub.