### PR TITLE
Allow testing optional dependencies

### DIFF
--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -110,10 +110,6 @@ pub fn compile_pkg<'a>(root_package: &Package,
         s.split(' ')
     }).map(|s| s.to_string()).collect::<Vec<String>>();
 
-    if spec.len() > 0 && (no_default_features || features.len() > 0) {
-        return Err(human("features cannot be modified when the main package \
-                          is not being built"))
-    }
     if jobs == Some(0) {
         return Err(human("jobs must be at least 1"))
     }

--- a/tests/test_cargo_test.rs
+++ b/tests/test_cargo_test.rs
@@ -2057,3 +2057,33 @@ test!(selective_test_wonky_profile {
 {running} `rustc src[..]lib.rs [..]`
 ", compiling = COMPILING, running = RUNNING)));
 });
+
+test!(selective_test_optional_dep {
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [package]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+
+            [dependencies]
+            a = { path = "a", optional = true }
+        "#)
+        .file("src/lib.rs", "")
+        .file("a/Cargo.toml", r#"
+            [package]
+            name = "a"
+            version = "0.0.1"
+            authors = []
+        "#)
+        .file("a/src/lib.rs", "");
+    p.build();
+
+    assert_that(p.cargo("test").arg("-v").arg("--no-run")
+                 .arg("--features").arg("a").arg("-p").arg("a"),
+                execs().with_status(0).with_stdout(&format!("\
+{compiling} a v0.0.1 ([..])
+{running} `rustc a[..]src[..]lib.rs [..]`
+{running} `rustc a[..]src[..]lib.rs [..]`
+", compiling = COMPILING, running = RUNNING)));
+});


### PR DESCRIPTION
Previously a warning was issued if both -p and --features were passed as flags,
and the rationale for this was that if --features modified the activated set of
features in the package selected by -p it would alter Cargo.lock, which is
undesirable as Cargo.lock should be stable.

This commit, however, interprets --features as changing the resolved graph of
the top-level package, and then -p is a query on that resolved graph. This way
the Cargo.lock file never changes and you're allowed to test optional
dependencies.

Closes #2083