### PR TITLE
Avoid redundant overwriting of Cargo.lock and preserve CRLF line endings

### DIFF
--- a/src/cargo/ops/lockfile.rs
+++ b/src/cargo/ops/lockfile.rs
@@ -70,6 +70,9 @@ pub fn write_lockfile(dst: &Path, resolve: &Resolve) -> CargoResult<()> {
 
     // Load the original lockfile if it exists.
     if let Ok(orig) = paths::read(dst) {
+        if has_crlf_line_endings(&orig) {
+            out = out.replace("\n", "\r\n");
+        }
         if out == orig {
             // The lockfile contents haven't changed so don't rewrite it.
             // This is helpful on read-only filesystems.
@@ -79,6 +82,15 @@ pub fn write_lockfile(dst: &Path, resolve: &Resolve) -> CargoResult<()> {
 
     try!(paths::write(dst, out.as_bytes()));
     Ok(())
+}
+
+fn has_crlf_line_endings(s: &str) -> bool {
+    // Only check the first line.
+    if let Some(lf) = s.find('\n') {
+        s[..lf].ends_with('\r')
+    } else {
+        false
+    }
 }
 
 fn emit_package(dep: &toml::Table, out: &mut String) {

--- a/src/cargo/ops/lockfile.rs
+++ b/src/cargo/ops/lockfile.rs
@@ -68,6 +68,15 @@ pub fn write_lockfile(dst: &Path, resolve: &Resolve) -> CargoResult<()> {
         None => {}
     }
 
+    // Load the original lockfile if it exists.
+    if let Ok(orig) = paths::read(dst) {
+        if out == orig {
+            // The lockfile contents haven't changed so don't rewrite it.
+            // This is helpful on read-only filesystems.
+            return Ok(())
+        }
+    }
+
     try!(paths::write(dst, out.as_bytes()));
     Ok(())
 }

--- a/tests/test_cargo_generate_lockfile.rs
+++ b/tests/test_cargo_generate_lockfile.rs
@@ -2,7 +2,7 @@ use std::fs::File;
 use std::io::prelude::*;
 
 use support::{project, execs};
-use hamcrest::assert_that;
+use hamcrest::{assert_that, existing_file};
 
 fn setup() {}
 
@@ -121,4 +121,53 @@ foo = "bar"
     let mut lock = String::new();
     File::open(&lockfile).unwrap().read_to_string(&mut lock).unwrap();
     assert!(lock.contains(metadata.trim()), "{}", lock);
+});
+
+test!(preserve_line_endings_issue_2076 {
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [package]
+            name = "foo"
+            authors = []
+            version = "0.0.1"
+        "#)
+        .file("src/main.rs", "fn main() {}")
+        .file("bar/Cargo.toml", r#"
+            [package]
+            name = "bar"
+            authors = []
+            version = "0.0.1"
+        "#)
+        .file("bar/src/lib.rs", "");
+
+    let lockfile = p.root().join("Cargo.lock");
+    assert_that(p.cargo_process("generate-lockfile"),
+                execs().with_status(0));
+    assert_that(&lockfile,
+                existing_file());
+    assert_that(p.cargo("generate-lockfile"),
+                execs().with_status(0));
+
+    let mut lock0 = String::new();
+    {
+        File::open(&lockfile).unwrap().read_to_string(&mut lock0).unwrap();
+    }
+
+    assert!(lock0.starts_with("[root]\n"));
+
+    let lock1 = lock0.replace("\n", "\r\n");
+    {
+        File::create(&lockfile).unwrap().write_all(lock1.as_bytes()).unwrap();
+    }
+
+    assert_that(p.cargo("generate-lockfile"),
+                execs().with_status(0));
+
+    let mut lock2 = String::new();
+    {
+        File::open(&lockfile).unwrap().read_to_string(&mut lock2).unwrap();
+    }
+
+    assert!(lock2.starts_with("[root]\r\n"));
+    assert_eq!(lock1, lock2);
 });


### PR DESCRIPTION
Before writing the lockfile read the existing one and

 * detect the line endings style, fixes #2076, #1722;
 * compare the contents to avoid redundant overwriting.

