### PR TITLE
Relax some output assertions in tests

### DIFF
--- a/tests/test_cargo_bench.rs
+++ b/tests/test_cargo_bench.rs
@@ -859,10 +859,9 @@ test!(bench_with_examples {
                 execs().with_status(0)
                        .with_stdout(&format!("\
 {compiling} testbench v6.6.6 ({url})
-{running} `rustc src[..]lib.rs --crate-name testbench --crate-type lib [..]`
-{running} `rustc src[..]lib.rs --crate-name testbench --crate-type lib [..]`
-{running} `rustc benches[..]testb1.rs --crate-name testb1 --crate-type bin \
-        [..] --test [..]`
+{running} `rustc [..]`
+{running} `rustc [..]`
+{running} `rustc [..]`
 {running} `{dir}[..]target[..]release[..]testb1-[..] --bench`
 
 running 1 test

--- a/tests/test_cargo_compile_custom_build.rs
+++ b/tests/test_cargo_compile_custom_build.rs
@@ -362,17 +362,7 @@ test!(links_passes_env_vars {
         "#);
 
     assert_that(p.cargo_process("build").arg("-v"),
-                execs().with_status(0)
-                       .with_stdout(&format!("\
-{compiling} [..] v0.5.0 (file://[..])
-{running} `rustc [..]build.rs [..]`
-{compiling} [..] v0.5.0 (file://[..])
-{running} `rustc [..]build.rs [..]`
-{running} `[..]`
-{running} `[..]`
-{running} `[..]`
-{running} `rustc [..] --crate-name foo [..]`
-", compiling = COMPILING, running = RUNNING)));
+                execs().with_status(0));
 });
 
 test!(only_rerun_build_script {
@@ -1324,9 +1314,9 @@ test!(cfg_test {
 {compiling} foo v0.0.1 ({dir})
 {running} [..] build.rs [..]
 {running} [..]build-script-build[..]
-{running} [..] src[..]lib.rs [..] --cfg foo[..]
-{running} [..] src[..]lib.rs [..] --cfg foo[..]
-{running} [..] tests[..]test.rs [..] --cfg foo[..]
+{running} [..] --cfg foo[..]
+{running} [..] --cfg foo[..]
+{running} [..] --cfg foo[..]
 {running} [..]foo-[..]
 
 running 1 test
@@ -1439,9 +1429,9 @@ test!(cfg_override_test {
     assert_that(p.cargo_process("test").arg("-v"),
                 execs().with_stdout(format!("\
 {compiling} foo v0.0.1 ({dir})
-{running} [..] src[..]lib.rs [..] --cfg foo[..]
-{running} [..] src[..]lib.rs [..] --cfg foo[..]
-{running} [..] tests[..]test.rs [..] --cfg foo[..]
+{running} `[..]`
+{running} `[..]`
+{running} `[..]`
 {running} [..]foo-[..]
 
 running 1 test

--- a/tests/test_cargo_test.rs
+++ b/tests/test_cargo_test.rs
@@ -2048,14 +2048,7 @@ test!(selective_test_wonky_profile {
 
     assert_that(p.cargo("test").arg("-v").arg("--no-run").arg("--release")
                  .arg("-p").arg("foo").arg("-p").arg("a"),
-                execs().with_status(0).with_stdout(&format!("\
-{compiling} a v0.0.1 ([..])
-{running} `rustc a[..]src[..]lib.rs [..]`
-{running} `rustc a[..]src[..]lib.rs [..]`
-{compiling} foo v0.0.1 ([..])
-{running} `rustc src[..]lib.rs [..]`
-{running} `rustc src[..]lib.rs [..]`
-", compiling = COMPILING, running = RUNNING)));
+                execs().with_status(0));
 });
 
 test!(selective_test_optional_dep {


### PR DESCRIPTION
These were all exhibiting some nondeterminism which meant that they were failing
tests on CI.