### PR TITLE
Add dependency header in default Cargo.toml

### DIFF
--- a/src/cargo/ops/cargo_new.rs
+++ b/src/cargo/ops/cargo_new.rs
@@ -147,6 +147,8 @@ r#"[package]
 name = "{}"
 version = "0.1.0"
 authors = [{}]
+
+[dependencies]
 "#, name, toml::Value::String(author)).as_bytes()));
 
     try!(fs::create_dir(&path.join("src")));


### PR DESCRIPTION
Almost any project beyond "hello world" will have some dependencies.
Including the `[dependencies]` header by default makes this slightly
simpler.

For new users of the language, this can potentially save some
frustration since crates.io currently does not mention the header, just
the line that goes beneath it.

For all users, this makes adding the first dependency to a project less
of a special case than to subsequent dependencies.