### PR TITLE
Make Cargo obey platform-specific directory standards

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,7 +7,7 @@ dependencies = [
  "crates-io 0.1.0",
  "crossbeam 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "curl 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "dirs 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dirs 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "docopt 0.6.78 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "filetime 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -107,14 +107,13 @@ dependencies = [
 
 [[package]]
 name = "dirs"
-version = "0.2.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ole32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "shell32-sys 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "uuid-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "xdg 2.0.0-pre5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xdg 2.0.0-pre6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -480,15 +479,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "uuid-sys"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "winapi 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "winapi"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -509,6 +499,6 @@ dependencies = [
 
 [[package]]
 name = "xdg"
-version = "2.0.0-pre5"
+version = "2.0.0-pre6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,6 +7,7 @@ dependencies = [
  "crates-io 0.1.0",
  "crossbeam 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "curl 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dirs 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "docopt 0.6.78 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "filetime 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -102,6 +103,18 @@ dependencies = [
  "libz-sys 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl-sys 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "dirs"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "ole32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "shell32-sys 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uuid-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xdg 2.0.0-pre5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -308,6 +321,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ole32-sys"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -368,6 +390,15 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "nom 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "shell32-sys"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -449,6 +480,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "uuid-sys"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "winapi"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -466,4 +506,9 @@ dependencies = [
  "winapi 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "xdg"
+version = "2.0.0-pre5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ advapi32-sys = "0.1"
 crates-io = { path = "src/crates-io", version = "0.1" }
 crossbeam = "0.2"
 curl = "0.2"
+dirs = "0.2"
 docopt = "0.6"
 env_logger = "0.3"
 filetime = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ advapi32-sys = "0.1"
 crates-io = { path = "src/crates-io", version = "0.1" }
 crossbeam = "0.2"
 curl = "0.2"
-dirs = "0.2"
+dirs = "0.3.1"
 docopt = "0.6"
 env_logger = "0.3"
 filetime = "0.1"

--- a/src/bin/cargo.rs
+++ b/src/bin/cargo.rs
@@ -242,7 +242,7 @@ fn is_executable(metadata: &fs::Metadata) -> bool {
 }
 
 fn search_directories(config: &Config) -> Vec<PathBuf> {
-    let mut dirs = vec![config.home().join("bin")];
+    let mut dirs = vec![config.bin_path()];
     if let Some(val) = env::var_os("PATH") {
         dirs.extend(env::split_paths(&val));
     }

--- a/src/cargo/lib.rs
+++ b/src/cargo/lib.rs
@@ -6,6 +6,7 @@
 extern crate crates_io as registry;
 extern crate crossbeam;
 extern crate curl;
+extern crate dirs;
 extern crate docopt;
 extern crate filetime;
 extern crate flate2;

--- a/src/cargo/ops/cargo_install.rs
+++ b/src/cargo/ops/cargo_install.rs
@@ -263,6 +263,7 @@ fn read_crate_list(path: &Path) -> CargoResult<CrateListingV1> {
 }
 
 fn write_crate_list(path: &Path, listing: CrateListingV1) -> CargoResult<()> {
+    try!(fs::create_dir_all(path));
     let metadata = path.join(".crates.toml");
     (|| -> CargoResult<_> {
         let mut f = try!(File::create(&metadata));

--- a/src/cargo/util/config.rs
+++ b/src/cargo/util/config.rs
@@ -19,8 +19,14 @@ use util::toml as cargo_toml;
 
 use self::ConfigValue as CV;
 
+struct Paths {
+    pub bin: PathBuf,
+    pub cache: PathBuf,
+    pub config: PathBuf,
+}
+
 pub struct Config {
-    home_path: PathBuf,
+    paths: Paths,
     shell: RefCell<MultiShell>,
     rustc_info: Rustc,
     values: RefCell<HashMap<String, ConfigValue>>,
@@ -32,11 +38,9 @@ pub struct Config {
 }
 
 impl Config {
-    pub fn new(shell: MultiShell,
-               cwd: PathBuf,
-               homedir: PathBuf) -> CargoResult<Config> {
+    fn new(shell: MultiShell, cwd: PathBuf, paths: Paths) -> CargoResult<Config> {
         let mut cfg = Config {
-            home_path: homedir,
+            paths: paths,
             shell: RefCell::new(shell),
             rustc_info: Rustc::blank(),
             cwd: cwd,
@@ -59,33 +63,39 @@ impl Config {
         let cwd = try!(env::current_dir().chain_error(|| {
             human("couldn't get the current directory of the process")
         }));
-        let homedir = try!(homedir(&cwd).chain_error(|| {
+        let paths = try!(determine_paths(&cwd).chain_error(|| {
             human("Cargo couldn't find your home directory. \
                   This probably means that $HOME was not set.")
         }));
-        Config::new(shell, cwd, homedir)
+        Config::new(shell, cwd, paths)
     }
 
-    pub fn home(&self) -> &Path { &self.home_path }
+    pub fn bin_path(&self) -> PathBuf {
+        self.paths.bin.clone()
+    }
+
+    pub fn config_path(&self) -> PathBuf {
+        self.paths.config.clone()
+    }
 
     pub fn git_db_path(&self) -> PathBuf {
-        self.home_path.join("git").join("db")
+        self.paths.cache.join("git").join("db")
     }
 
     pub fn git_checkout_path(&self) -> PathBuf {
-        self.home_path.join("git").join("checkouts")
+        self.paths.cache.join("git").join("checkouts")
     }
 
     pub fn registry_index_path(&self) -> PathBuf {
-        self.home_path.join("registry").join("index")
+        self.paths.cache.join("registry").join("index")
     }
 
     pub fn registry_cache_path(&self) -> PathBuf {
-        self.home_path.join("registry").join("cache")
+        self.paths.cache.join("registry").join("cache")
     }
 
     pub fn registry_source_path(&self) -> PathBuf {
-        self.home_path.join("registry").join("src")
+        self.paths.cache.join("registry").join("src")
     }
 
     pub fn shell(&self) -> RefMut<MultiShell> {
@@ -207,7 +217,7 @@ impl Config {
     fn load_values(&self) -> CargoResult<()> {
         let mut cfg = CV::Table(HashMap::new(), PathBuf::from("."));
 
-        try!(walk_tree(&self.cwd, |mut file, path| {
+        try!(walk_tree(self, |mut file, path| {
             let mut contents = String::new();
             try!(file.read_to_string(&mut contents));
             let table = try!(cargo_toml::parse(&contents, &path).chain_error(|| {
@@ -464,18 +474,74 @@ impl ConfigValue {
     }
 }
 
-fn homedir(cwd: &Path) -> Option<PathBuf> {
-    let cargo_home = env::var_os("CARGO_HOME").map(|home| {
-        cwd.join(home)
-    });
-    let user_home = env::home_dir().map(|p| p.join(".cargo"));
-    cargo_home.or(user_home)
+fn determine_paths(cwd: &Path) -> Option<Paths> {
+    use dirs;
+    fn path_exists(path: PathBuf) -> Option<PathBuf> {
+        fs::metadata(&path).ok().map(|_| path)
+    }
+
+    // Strategy to determine where to put files:
+    //
+    // 1) Use the environment variable CARGO_HOME if it exists.
+    // 2) Use the platform-specific location if it exists.
+    // 3) Use the legacy location (~/.cargo) if it exists.
+    // 4) Fall back to platform-specific location if all of the above things
+    //    fail.
+
+    // 1)
+    if let Some(v) = env::var_os("CARGO_HOME").map(|p| cwd.join(p)) {
+        return Some(Paths {
+            bin: v.clone(),
+            cache: v.clone(),
+            config: v,
+        });
+    }
+
+    let user_home = env::home_dir();
+
+    let dirs = dirs::Directories::with_prefix("cargo", "Cargo").ok();
+
+    let legacy = user_home.map(|h| h.join(".cargo"));
+
+    let platform_bin = dirs.as_ref().map(|d| d.bin_home());
+    let platform_cache = dirs.as_ref().map(|d| d.cache_home());
+    let platform_config = dirs.as_ref().map(|d| d.config_home());
+
+    let mut bin: Option<PathBuf>;
+    let mut cache: Option<PathBuf>;
+    let mut config: Option<PathBuf>;
+
+    // 2)
+    bin = platform_bin.clone().map(|p| path_exists(p)).unwrap_or(None);
+    cache = platform_cache.clone().map(|p| path_exists(p)).unwrap_or(None);
+    config = platform_config.clone().map(|p| path_exists(p)).unwrap_or(None);
+
+    // 3)
+    if let Some(l) = legacy.map(|l| path_exists(l)).unwrap_or(None) {
+        cache = cache.or_else(|| Some(l.clone()));
+        bin = bin.or_else(|| Some(l.clone()));
+        config = config.or_else(|| Some(l));
+    }
+
+    // 4)
+    bin = bin.or(platform_bin);
+    cache = cache.or(platform_cache);
+    config = config.or(platform_config);
+
+    match (bin, cache, config) {
+        (Some(bin), Some(cache), Some(config)) => Some(Paths {
+            bin: bin,
+            cache: cache,
+            config: config,
+        }),
+        _ => None
+    }
 }
 
-fn walk_tree<F>(pwd: &Path, mut walk: F) -> CargoResult<()>
+fn walk_tree<F>(config: &Config, mut walk: F) -> CargoResult<()>
     where F: FnMut(File, &Path) -> CargoResult<()>
 {
-    let mut current = pwd;
+    let mut current: &Path = &config.cwd;
 
     loop {
         let possible = current.join(".cargo").join("config");
@@ -493,18 +559,13 @@ fn walk_tree<F>(pwd: &Path, mut walk: F) -> CargoResult<()>
     // Once we're done, also be sure to walk the home directory even if it's not
     // in our history to be sure we pick up that standard location for
     // information.
-    let home = try!(homedir(pwd).chain_error(|| {
-        human("Cargo couldn't find your home directory. \
-              This probably means that $HOME was not set.")
-    }));
-    if !pwd.starts_with(&home) {
-        let config = home.join("config");
+    if !config.cwd.starts_with(&config.paths.config) {
+        let config = config.paths.config.join("config");
         if fs::metadata(&config).is_ok() {
             let file = try!(File::open(&config));
             try!(walk(file, &config));
         }
     }
-
     Ok(())
 }
 
@@ -516,7 +577,7 @@ pub fn set_config(cfg: &Config, loc: Location, key: &str,
     // 2. This blows away all comments in a file
     // 3. This blows away the previous ordering of a file.
     let file = match loc {
-        Location::Global => cfg.home_path.join("config"),
+        Location::Global => cfg.paths.config.join("config"),
         Location::Project => unimplemented!(),
     };
     try!(fs::create_dir_all(file.parent().unwrap()));

--- a/src/cargo/util/config.rs
+++ b/src/cargo/util/config.rs
@@ -491,7 +491,7 @@ fn determine_paths(cwd: &Path) -> CargoResult<Paths> {
     // 1)
     if let Some(v) = env::var_os("CARGO_HOME").map(|p| cwd.join(p)) {
         return Ok(Paths {
-            bin: v.clone(),
+            bin: v.join("bin"),
             cache: v.clone(),
             config: v,
         });

--- a/src/cargo/util/errors.rs
+++ b/src/cargo/util/errors.rs
@@ -6,6 +6,7 @@ use std::process::{Output, ExitStatus};
 use std::str;
 
 use curl;
+use dirs;
 use git2;
 use rustc_serialize::json;
 use semver;
@@ -309,6 +310,7 @@ from_error! {
     toml::DecodeError,
     ffi::NulError,
     term::Error,
+    dirs::Error,
 }
 
 impl<E: CargoError> From<Human<E>> for Box<CargoError> {
@@ -329,6 +331,7 @@ impl CargoError for toml::DecodeError {}
 impl CargoError for url::ParseError {}
 impl CargoError for ffi::NulError {}
 impl CargoError for term::Error {}
+impl CargoError for dirs::Error {}
 
 // =============================================================================
 // Construction helpers

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -87,9 +87,10 @@ fn can_panic() -> bool {
 
 fn process<T: AsRef<OsStr>>(t: T) -> cargo::util::ProcessBuilder {
     let mut p = cargo::util::process(t.as_ref());
+    let home = support::paths::home();
     p.cwd(&support::paths::root())
-     .env("HOME", &support::paths::home())
-     .env_remove("CARGO_HOME")
+     .env("HOME", &home)
+     .env("CARGO_HOME", &home.join(".cargo"))
      .env_remove("CARGO_TARGET_DIR") // we assume 'target'
      .env_remove("MSYSTEM");    // assume cmd.exe everywhere on windows
     return p


### PR DESCRIPTION
Strategy for backward-compatiblity:

When checking for the relevant Cargo directories, check in the following
order of preference:

1) Use the environment variable `CARGO_HOME`.
2) Use the platform-specific directories if they exist.
3) Use the legacy location (~/.cargo) if it exists.
4) Fall back to the platform-specific directories if everything else fails.

The new platform-specific directories are as follows:

On Windows, use `AppData\Local\Temp\Cargo` for cache files (obtained via
`GetTempPath`), `AppData\Roaming\Cargo` for the config files
(`FOLDERID_RoamingAppData`) and `AppData\Local\Programs\Cargo` for
installed binaries (`FOLDERID_UserProgramFiles`).

On Unixy systems, use the XDG spec: `~/.cache/cargo` for cache files,
`~/.config/cargo` for config, `~/.local/bin` for installed binaries.

http://standards.freedesktop.org/basedir-spec/basedir-spec-0.8.html
http://www.freedesktop.org/software/systemd/man/file-hierarchy.html

On OS X, use `~/Library/Caches/Cargo` for cache files, `~/Library/Cargo`
for config files and `~/Library/Cargo/bin` for binary files.

Fixes #1734. Fixes #1976.