### PR TITLE
Add support for custom local tasks

### DIFF
--- a/src/bin/cargo.rs
+++ b/src/bin/cargo.rs
@@ -251,7 +251,7 @@ fn list_commands() -> BTreeSet<String> {
             };
             if filename.ends_with(env::consts::EXE_SUFFIX) &&
                is_executable(&entry) {
-                let command = &filename[filename.len() - env::consts::EXE_SUFFIX.len()];
+                let command = &filename[..filename.len() - env::consts::EXE_SUFFIX.len()];
                 commands.insert(command.to_string());
             }
         }

--- a/src/bin/cargo.rs
+++ b/src/bin/cargo.rs
@@ -290,7 +290,7 @@ fn find_command(cmd: &str) -> Option<PathBuf> {
 fn list_local_tasks_directory() -> Vec<PathBuf> {
     let mut dirs = vec![];
     if let Ok(path) = env::current_dir() {
-        dirs.push(path.join("../tasks"))
+        dirs.push(path.join("./tasks"))
     }
     dirs
 }


### PR DESCRIPTION
This allows user to create custom **local** tasks for Cargo using `tasks/`
directory. Any executable in that dir will became new cargo Command (no need for
normal `cargo-` prefix).

Ex.:

`text/foo`:

```sh
#!/bin/sh
echo "Foo"
```

```
$ cargo foo
Foo
```