### PR TITLE
Clean up the `cargo update` implementation a bit

### DIFF
--- a/src/cargo/core/source.rs
+++ b/src/cargo/core/source.rs
@@ -253,17 +253,7 @@ impl PartialOrd for SourceId {
 
 impl Ord for SourceId {
     fn cmp(&self, other: &SourceId) -> Ordering {
-        match self.inner.kind.cmp(&other.inner.kind) {
-            Ordering::Equal => {}
-            ord => return ord,
-        }
-        if let Kind::Git(..) = self.inner.kind {
-            match self.inner.precise.cmp(&other.inner.precise) {
-                Ordering::Equal => {}
-                ord => return ord,
-            }
-        }
-        self.inner.url.cmp(&other.inner.url)
+        self.inner.cmp(&other.inner)
     }
 }
 
@@ -320,6 +310,31 @@ impl PartialEq for SourceIdInner {
                 ref1 == ref2 && self.canonical_url == other.canonical_url
             }
             _ => false,
+        }
+    }
+}
+
+impl PartialOrd for SourceIdInner {
+    fn partial_cmp(&self, other: &SourceIdInner) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for SourceIdInner {
+    fn cmp(&self, other: &SourceIdInner) -> Ordering {
+        match self.kind.cmp(&other.kind) {
+            Ordering::Equal => {}
+            ord => return ord,
+        }
+        match self.url.cmp(&other.url) {
+            Ordering::Equal => {}
+            ord => return ord,
+        }
+        match (&self.kind, &other.kind) {
+            (&Kind::Git(ref ref1), &Kind::Git(ref ref2)) => {
+                (ref1, &self.canonical_url).cmp(&(ref2, &other.canonical_url))
+            }
+            _ => self.kind.cmp(&other.kind)
         }
     }
 }


### PR DESCRIPTION
I've noticed some slightly odd output from `cargo update` in the past and I
believe this cleanup should address what's going on under the hood. There were a
few minor issues with the previous implementation.

* When adding the previous graph to the list of changes, packages with multiple
  versions would override one another instead of all get added to one list.
* The `Ord` implementation for `SourceId` was actually incorrect in that it
  disagreed with the `Eq` implementation. This could end up causing subtle bugs
  here and there. dependening on what operators were used.

This tweak fixes both points and I believe should touch up the odd output I've
been seeing from `cargo update`.