### PR TITLE
doc/manifest: fix "default-features" example

### DIFF
--- a/src/doc/manifest.md
+++ b/src/doc/manifest.md
@@ -304,11 +304,11 @@ To use the package `awesome`:
 
 ```toml
 [dependencies]
-awesome = { version = "1.3.5", features = ["secure-password", "civet"] }
-
-# do not include the default features, and optionally
-# cherry-pick individual features
-default-features = false
+awesome = { version = "1.3.5",
+            default-features = false, # do not include the default features, and optionally
+                                      # cherry-pick individual features
+            features = ["secure-password", "civet"]
+          }
 ```
 
 ## Rules

--- a/src/doc/manifest.md
+++ b/src/doc/manifest.md
@@ -304,11 +304,7 @@ To use the package `awesome`:
 
 ```toml
 [dependencies]
-awesome = { version = "1.3.5",
-            default-features = false, # do not include the default features, and optionally
-                                      # cherry-pick individual features
-            features = ["secure-password", "civet"]
-          }
+awesome = { version = "1.3.5", default-features = false, features = ["secure-password", "civet"] }
 ```
 
 ## Rules

--- a/src/doc/manifest.md
+++ b/src/doc/manifest.md
@@ -303,8 +303,11 @@ civet = { version = "*", optional = true }
 To use the package `awesome`:
 
 ```toml
-[dependencies]
-awesome = { version = "1.3.5", default-features = false, features = ["secure-password", "civet"] }
+[dependencies.awesome]
+version = "1.3.5"
+default-features = false # do not include the default features, and optionally
+                         # cherry-pick individual features
+features = ["secure-password", "civet"]
 ```
 
 ## Rules


### PR DESCRIPTION
In c9f1b9bf1e535a651f624897bd53a3f81af7501f the format of this example was changed from a `[dependencies.awesome]` section to the newly-recommended inline table syntax, but one of the attributes was left out.

I had to use some slightly weird formatting to keep the comment in place, is that OK?