### PR TITLE
Improve message with unspecified install target.

### DIFF
--- a/src/cargo/ops/cargo_install.rs
+++ b/src/cargo/ops/cargo_install.rs
@@ -56,7 +56,8 @@ pub fn install(root: Option<&str>,
         try!(select_pkg(RegistrySource::new(source_id, config),
                         source_id, krate, vers,
                         &mut |_| Err(human("must specify a crate to install from \
-                                            crates.io"))))
+                                            crates.io, or use --path or --git to \
+                                            specify alternate source"))))
     };
 
     let mut list = try!(read_crate_list(&root));

--- a/tests/test_cargo_install.rs
+++ b/tests/test_cargo_install.rs
@@ -122,7 +122,8 @@ could not find `foo` in `registry file://[..]` with version `0.2.0`
 test!(no_crate {
     assert_that(cargo_process("install"),
                 execs().with_status(101).with_stderr("\
-must specify a crate to install from crates.io
+must specify a crate to install from crates.io, or use --path or --git \
+to specify alternate source
 "));
 });
 


### PR DESCRIPTION
When the crate to install is unspecified, we should really inform users about
where they can install from (other than crates.io).  This makes the message mention --path
and --git so that people know they exist.