### PR TITLE
Probe $CARGO_HOME/bin for subcommands by default

### DIFF
--- a/src/bin/run.rs
+++ b/src/bin/run.rs
@@ -84,12 +84,7 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
         target_rustc_args: None,
     };
 
-    let err = try!(ops::run(&root,
-                            &compile_opts,
-                            &options.arg_args).map_err(|err| {
-        CliError::from_boxed(err, 101)
-    }));
-    match err {
+    match try!(ops::run(&root, &compile_opts, &options.arg_args)) {
         None => Ok(None),
         Some(err) => {
             Err(match err.exit.as_ref().and_then(|e| e.code()) {

--- a/tests/test_cargo.rs
+++ b/tests/test_cargo.rs
@@ -62,8 +62,8 @@ test!(find_closest_biuld_to_build {
     pr.arg("biuld").cwd(&paths::root()).env("HOME", &paths::home());
 
     assert_that(pr,
-                execs().with_status(127)
-                       .with_stderr("No such subcommand
+                execs().with_status(101)
+                       .with_stderr("no such subcommand
 
 Did you mean `build`?
 
@@ -76,8 +76,8 @@ test!(find_closest_dont_correct_nonsense {
     pr.arg("asdf").cwd(&paths::root()).env("HOME", &paths::home());
 
     assert_that(pr,
-                execs().with_status(127)
-                       .with_stderr("No such subcommand
+                execs().with_status(101)
+                       .with_stderr("no such subcommand
 "));
 });
 

--- a/tests/test_cargo_install.rs
+++ b/tests/test_cargo_install.rs
@@ -512,3 +512,19 @@ test!(uninstall_piecemeal {
 package id specification `foo` matched no packages
 "));
 });
+
+test!(subcommand_works_out_of_the_box {
+    Package::new("cargo-foo", "1.0.0")
+        .file("src/main.rs", r#"
+            fn main() {
+                println!("bar");
+            }
+        "#)
+        .publish();
+    assert_that(cargo_process("install").arg("cargo-foo"),
+                execs().with_status(0));
+    assert_that(cargo_process("foo"),
+                execs().with_status(0).with_stdout("bar\n"));
+    assert_that(cargo_process("--list"),
+                execs().with_status(0).with_stdout_contains("  foo\n"));
+});


### PR DESCRIPTION
Don't require PATH modifications for new cargo subcommands by looking
specifically in $CARGO_HOME/bin for installed commands.

Closes #2189