### PR TITLE
Hide SerializedDependency

### DIFF
--- a/src/cargo/core/dependency.rs
+++ b/src/cargo/core/dependency.rs
@@ -1,4 +1,5 @@
 use semver::VersionReq;
+use rustc_serialize::{Encoder, Encodable};
 
 use core::{SourceId, Summary, PackageId};
 use std::rc::Rc;
@@ -28,6 +29,22 @@ pub struct DependencyInner {
 #[derive(PartialEq,Clone,Debug)]
 pub struct Dependency {
     inner: Rc<DependencyInner>,
+}
+
+
+#[derive(RustcEncodable)]
+struct SerializedDependency {
+    name: String,
+    req: String
+}
+
+impl Encodable for Dependency {
+    fn encode<S: Encoder>(&self, s: &mut S) -> Result<(), S::Error> {
+        SerializedDependency {
+            name: self.name().to_string(),
+            req: self.version_req().to_string()
+        }.encode(s)
+    }
 }
 
 #[derive(PartialEq, Clone, Debug, Copy)]
@@ -219,17 +236,3 @@ impl Dependency {
     }
 }
 
-#[derive(PartialEq,Clone,RustcEncodable)]
-pub struct SerializedDependency {
-    name: String,
-    req: String
-}
-
-impl SerializedDependency {
-    pub fn from_dependency(dep: &Dependency) -> SerializedDependency {
-        SerializedDependency {
-            name: dep.name().to_string(),
-            req: dep.version_req().to_string()
-        }
-    }
-}

--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -3,11 +3,10 @@ use std::fmt;
 use std::path::{PathBuf, Path};
 
 use semver::Version;
-use rustc_serialize::{Encoder,Encodable};
+use rustc_serialize::{Encoder, Encodable};
 
 use core::{Dependency, PackageId, Summary};
 use core::package_id::Metadata;
-use core::dependency::SerializedDependency;
 use util::{CargoResult, human};
 
 /// Contains all the information about a package, as loaded from a Cargo.toml.
@@ -45,10 +44,10 @@ pub struct ManifestMetadata {
 }
 
 #[derive(RustcEncodable)]
-struct SerializedManifest {
+struct SerializedManifest<'a> {
     name: String,
     version: String,
-    dependencies: Vec<SerializedDependency>,
+    dependencies: &'a [Dependency],
     targets: Vec<Target>,
 }
 
@@ -57,9 +56,7 @@ impl Encodable for Manifest {
         SerializedManifest {
             name: self.summary.name().to_string(),
             version: self.summary.version().to_string(),
-            dependencies: self.summary.dependencies().iter().map(|d| {
-                SerializedDependency::from_dependency(d)
-            }).collect(),
+            dependencies: self.summary.dependencies(),
             targets: self.targets.clone(),
         }.encode(s)
     }

--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -44,8 +44,8 @@ pub struct ManifestMetadata {
     pub documentation: Option<String>,  // url
 }
 
-#[derive(PartialEq,Clone,RustcEncodable)]
-pub struct SerializedManifest {
+#[derive(RustcEncodable)]
+struct SerializedManifest {
     name: String,
     version: String,
     dependencies: Vec<SerializedDependency>,

--- a/src/cargo/core/package.rs
+++ b/src/cargo/core/package.rs
@@ -6,7 +6,6 @@ use semver::Version;
 
 use core::{Dependency, Manifest, PackageId, SourceId, Registry, Target, Summary, Metadata};
 use ops;
-use core::dependency::SerializedDependency;
 use util::{CargoResult, graph, Config};
 use rustc_serialize::{Encoder,Encodable};
 use core::source::Source;
@@ -24,10 +23,10 @@ pub struct Package {
 }
 
 #[derive(RustcEncodable)]
-struct SerializedPackage {
+struct SerializedPackage<'a> {
     name: String,
     version: String,
-    dependencies: Vec<SerializedDependency>,
+    dependencies: &'a [Dependency],
     targets: Vec<Target>,
     manifest_path: String,
 }
@@ -41,9 +40,7 @@ impl Encodable for Package {
         SerializedPackage {
             name: package_id.name().to_string(),
             version: package_id.version().to_string(),
-            dependencies: summary.dependencies().iter().map(|d| {
-                SerializedDependency::from_dependency(d)
-            }).collect(),
+            dependencies: summary.dependencies(),
             targets: manifest.targets().to_vec(),
             manifest_path: self.manifest_path.display().to_string()
         }.encode(s)


### PR DESCRIPTION
This hides `SerializedDependency` from general public, as requested [here](https://github.com/rust-lang/cargo/pull/1434#issuecomment-97886950). It also hides `SerializedManifest` which was (wrongly?) exposed. 

This is required for #2196. I want to move in small steps this time, hence the separate PR. 

Technically this break backwards compatibility, because `SerializedDependency` and `SerializedManifest` were public (`SerializedPackage` was private however). Are such changes allowed in cargo? 