### PR TITLE
Add convenience syntax to install current crate

### DIFF
--- a/src/bin/install.rs
+++ b/src/bin/install.rs
@@ -75,6 +75,10 @@ crate has multiple binaries, the `--bin` argument can selectively install only
 one of them, and if you'd rather install examples the `--example` argument can
 be used as well.
 
+As a special convenience, omitting the <crate> specification entirely will
+install the crate in the current directory. That is, `install` is equivalent to
+the more explicit `install --path .`.
+
 The `--list` option will list all installed packages (and their versions).
 ";
 
@@ -112,6 +116,8 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
         SourceId::for_git(&url, gitref)
     } else if let Some(path) = options.flag_path {
         try!(SourceId::for_path(&config.cwd().join(path)))
+    } else if options.arg_crate == None {
+        try!(SourceId::for_path(&config.cwd()))
     } else {
         try!(SourceId::for_central(config))
     };

--- a/src/cargo/ops/cargo_install.rs
+++ b/src/cargo/ops/cargo_install.rs
@@ -51,7 +51,11 @@ pub fn install(root: Option<&str>,
                             .expect("path sources must have a valid path");
         try!(select_pkg(PathSource::new(&path, source_id, config),
                         source_id, krate, vers,
-                        &mut |path| path.read_packages()))
+                        &mut |path| path.read_packages())
+                 .chain_error(|| human(format!("`{}` is not a crate root; specify a \
+                                                crate to install from crates.io, or \
+                                                use --path or --git to specify an \
+                                                alternate source", path.display()))))
     } else {
         try!(select_pkg(RegistrySource::new(source_id, config),
                         source_id, krate, vers,


### PR DESCRIPTION
Fixes #2142.  Essentially, `cargo install` becomes a synonym for
`cargo install --path .`.  This makes it easy and intuitive to install
the crate in the current directory, as in the following:

    $ cargo build --release
    $ cargo install

Note that this only works from the crate root.

r? @alexcrichton