### PR TITLE
Remove the name of the subcommand from the arguments passed to custom cargo subcommands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ src/etc/*.pyc
 src/registry/target
 src/registry/Cargo.lock
 rustc
+.DS_Store

--- a/src/bin/cargo.rs
+++ b/src/bin/cargo.rs
@@ -188,7 +188,9 @@ fn execute_subcommand(config: &Config,
             }))
         }
     };
-    try!(util::process(&command).args(&args[1..]).exec());
+    // Important: &args[2..] is to pop the subcommand name from the arguments to
+    // cargo, so that 'cargo check' does not become 'cargo-check check'
+    try!(util::process(&command).args(&args[2..]).exec());
     Ok(())
 }
 

--- a/src/cargo/util/process_builder.rs
+++ b/src/cargo/util/process_builder.rs
@@ -74,6 +74,7 @@ impl ProcessBuilder {
 
     pub fn exec(&self) -> Result<(), ProcessError> {
         let mut command = self.build_command();
+
         let exit = try!(command.status().map_err(|e| {
             process_error(&format!("Could not execute process `{}`",
                                    self.debug_string()),


### PR DESCRIPTION
The old behavior would turn 'cargo check <args>' into 'cargo-check check <args>'.
I have only observed this on OS X, but I assume that it affects all platforms.
I checked the behavior using two separate cargo subcommands (cargo-watch, and one I'm developing, cargo-linebreak).

**NOTE**
This would pretty much break all the existing subcommands, as they have chosen to expect the name of the subcommand as the first argument.
A discussion of whether this change really is for the better would probably be a good idea.