### PR TITLE
Pass link search path to doctests even if build script gave no links

### DIFF
--- a/src/cargo/ops/cargo_rustc/mod.rs
+++ b/src/cargo/ops/cargo_rustc/mod.rs
@@ -162,7 +162,9 @@ pub fn compile_targets<'a, 'cfg: 'a>(pkg_targets: &'a PackagesToBuild<'a>,
         let any_dylib = output.library_links.iter().any(|l| {
             !l.starts_with("static=") && !l.starts_with("framework=")
         });
-        if !any_dylib { continue }
+        if !any_dylib && !output.library_links.is_empty() {
+            continue
+        }
         for dir in output.library_paths.iter() {
             cx.compilation.native_dirs.insert(pkg.clone(), dir.clone());
         }

--- a/src/cargo/ops/cargo_rustc/mod.rs
+++ b/src/cargo/ops/cargo_rustc/mod.rs
@@ -159,12 +159,6 @@ pub fn compile_targets<'a, 'cfg: 'a>(pkg_targets: &'a PackagesToBuild<'a>,
         if pkg == root_pkg {
             cx.compilation.cfgs.extend(output.cfgs.iter().cloned());
         }
-        let any_dylib = output.library_links.iter().any(|l| {
-            !l.starts_with("static=") && !l.starts_with("framework=")
-        });
-        if !any_dylib && !output.library_links.is_empty() {
-            continue
-        }
         for dir in output.library_paths.iter() {
             cx.compilation.native_dirs.insert(pkg.clone(), dir.clone());
         }


### PR DESCRIPTION
It is entirely possible for a crate to have a build script that is simply
the equivalent to

```rustc
fn main() {
    println!("cargo:rustc-link-search=native=/some/path");
}
```

Without actually giving anything to link (for example, because the code
contains `#[link(name="foo")]`. In this case, we aren't actually passing
`-L` through when running doctests, even though they're passed when
compiling the main crate.

Fixes #1592