### PR TITLE
Add __pycache__ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ src/etc/*.pyc
 src/registry/target
 src/registry/Cargo.lock
 rustc
+__pycache__


### PR DESCRIPTION
Running `make` creates the `src/etc/__pycache__` directory which should
not be checked in.