### PR TITLE
Ensure all subcommands have summary description documentation

### DIFF
--- a/src/bin/git_checkout.rs
+++ b/src/bin/git_checkout.rs
@@ -12,6 +12,8 @@ struct Options {
 }
 
 pub const USAGE: &'static str = "
+Checkout a copy of a Git repository
+
 Usage:
     cargo git-checkout [options] --url=URL --reference=REF
     cargo git-checkout -h | --help

--- a/src/bin/locate_project.rs
+++ b/src/bin/locate_project.rs
@@ -7,11 +7,13 @@ struct LocateProjectFlags {
 }
 
 pub const USAGE: &'static str = "
+Print a JSON representation of a Cargo.toml file's location
+
 Usage:
     cargo locate-project [options]
 
 Options:
-    --manifest-path PATH    Path to the manifest to build benchmarks for
+    --manifest-path PATH    Path to the manifest to locate
     -h, --help              Print this message
 ";
 

--- a/src/bin/publish.rs
+++ b/src/bin/publish.rs
@@ -24,7 +24,7 @@ Options:
     --host HOST              Host to upload the package to
     --token TOKEN            Token to use when uploading
     --no-verify              Don't verify package tarball before publish
-    --manifest-path PATH     Path to the manifest to compile
+    --manifest-path PATH     Path to the manifest of the package to publish
     -v, --verbose            Use verbose output
     -q, --quiet              No output printed to stdout
     --color WHEN             Coloring: auto, always, never

--- a/src/bin/read_manifest.rs
+++ b/src/bin/read_manifest.rs
@@ -12,6 +12,8 @@ struct Options {
 }
 
 pub const USAGE: &'static str = "
+Print a JSON representation of a Cargo.toml manifest
+
 Usage:
     cargo read-manifest [options]
     cargo read-manifest -h | --help
@@ -19,7 +21,7 @@ Usage:
 Options:
     -h, --help               Print this message
     -v, --verbose            Use verbose output
-    --manifest-path PATH     Path to the manifest to compile
+    --manifest-path PATH     Path to the manifest
     --color WHEN             Coloring: auto, always, never
 ";
 

--- a/src/bin/update.rs
+++ b/src/bin/update.rs
@@ -26,7 +26,7 @@ Options:
     -p SPEC, --package SPEC ...  Package to update
     --aggressive                 Force updating all dependencies of <name> as well
     --precise PRECISE            Update a single dependency to exactly PRECISE
-    --manifest-path PATH         Path to the manifest to compile
+    --manifest-path PATH         Path to the crate's manifest
     -v, --verbose                Use verbose output
     -q, --quiet                  No output printed to stdout
     --color WHEN                 Coloring: auto, always, never
@@ -68,4 +68,3 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
     try!(ops::update_lockfile(&root, &update_opts));
     Ok(None)
 }
-

--- a/src/bin/verify_project.rs
+++ b/src/bin/verify_project.rs
@@ -19,6 +19,8 @@ struct Flags {
 }
 
 pub const USAGE: &'static str = "
+Check correctness of crate manifest
+
 Usage:
     cargo verify-project [options]
     cargo verify-project -h | --help

--- a/src/bin/version.rs
+++ b/src/bin/version.rs
@@ -7,6 +7,8 @@ use cargo::util::{CliResult, Config};
 struct Options;
 
 pub const USAGE: &'static str = "
+Show version information
+
 Usage:
     cargo version [options]
 


### PR DESCRIPTION
Almost all commands have info on what they are for, but a few were
missing it.

Also cleans up some copy/paste misdocumentation along the way.
