### PR TITLE
Update toml dependency to catch more unused keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,7 +27,7 @@ dependencies = [
  "tempdir 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "term 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
- "toml 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.2.38 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -409,7 +409,7 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.1.23"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/tests/test_bad_config.rs
+++ b/tests/test_bad_config.rs
@@ -368,3 +368,22 @@ Caused by:
   found duplicate bench name ex, but all binary targets must have a unique name
 "));
 });
+
+test!(unused_keys {
+    let foo = project("foo")
+        .file("Cargo.toml", r#"
+           [package]
+           name = "foo"
+           version = "0.1.0"
+           authors = []
+
+           [target.foo]
+           bar = "3"
+        "#)
+        .file("src/lib.rs", "");
+
+    assert_that(foo.cargo_process("build"),
+                execs().with_status(0).with_stderr("\
+unused manifest key: target.foo.bar
+"));
+});


### PR DESCRIPTION
This includes alexcrichton/toml-rs@39d77b6d which ensures that more unused
fields stick around when decoding TOML, allowing this to:

Closes #2230