### PR TITLE
Support relative URLs, closes #2252

### DIFF
--- a/src/cargo/sources/registry.rs
+++ b/src/cargo/sources/registry.rs
@@ -174,7 +174,7 @@ use url::Url;
 use core::{Source, SourceId, PackageId, Package, Summary, Registry};
 use core::dependency::{Dependency, DependencyInner, Kind};
 use sources::{PathSource, git};
-use util::{CargoResult, Config, internal, ChainError, ToUrl, human};
+use util::{CargoResult, Config, internal, ChainError, ToUrl, ToUrlWithBase, human};
 use util::{hex, Sha256, paths};
 use ops;
 
@@ -251,9 +251,12 @@ impl<'cfg> RegistrySource<'cfg> {
     /// This is the main cargo registry by default, but it can be overridden in
     /// a .cargo/config
     pub fn url(config: &Config) -> CargoResult<Url> {
-        let config = try!(ops::registry_configuration(config));
-        let url = config.index.unwrap_or(DEFAULT.to_string());
-        url.to_url().map_err(human)
+        let result = match try!(config.get_string("registry.index")) {
+            Some((value, path)) => value.to_url_with_base(path.as_path().clone()),
+            None => DEFAULT.to_string().to_url(),
+        };
+
+        Ok(try!(result.map_err(human)))
     }
 
     /// Get the default url for the registry

--- a/src/cargo/util/mod.rs
+++ b/src/cargo/util/mod.rs
@@ -14,7 +14,7 @@ pub use self::process_builder::{process, ProcessBuilder};
 pub use self::rustc::Rustc;
 pub use self::sha256::Sha256;
 pub use self::to_semver::ToSemver;
-pub use self::to_url::ToUrl;
+pub use self::to_url::{ToUrl, ToUrlWithBase};
 pub use self::vcs::{GitRepo, HgRepo};
 
 pub mod config;

--- a/src/cargo/util/to_url.rs
+++ b/src/cargo/util/to_url.rs
@@ -5,6 +5,10 @@ pub trait ToUrl {
     fn to_url(self) -> Result<Url, String>;
 }
 
+pub trait ToUrlWithBase {
+    fn to_url_with_base<U: ToUrl>(self, base: U) -> Result<Url, String>;
+}
+
 impl ToUrl for Url {
     fn to_url(self) -> Result<Url, String> {
         Ok(self)
@@ -22,6 +26,22 @@ impl<'a> ToUrl for &'a str {
         UrlParser::new().scheme_type_mapper(mapper).parse(self).map_err(|s| {
             format!("invalid url `{}`: {}", self, s)
         })
+    }
+}
+
+impl<'a> ToUrlWithBase for &'a str {
+    fn to_url_with_base<U: ToUrl>(self, base: U) -> Result<Url, String> {
+        let base_url: Result<Url, String> = base.to_url().map_err(|s| {
+            format!("invalid url `{}`: {}", self, s)
+        });
+        let base_url = try!(base_url);
+
+        UrlParser::new()
+            .scheme_type_mapper(mapper)
+            .base_url(&base_url)
+            .parse(self).map_err(|s| {
+                format!("invalid url `{}`: {}", self, s)
+            })
     }
 }
 


### PR DESCRIPTION
See #2252 for a description of the problem.

This PR adds support for having a relative URL to a registry. The registry is considered relative to the `.cargo/config` file that defined the URL.