### PR TITLE
doc/manifest: add `cargo run --example`

### DIFF
--- a/src/doc/manifest.md
+++ b/src/doc/manifest.md
@@ -419,6 +419,8 @@ They must compile as executables (with a `main()` function) and load in the
 library by using `extern crate <library-name>`. They are compiled when you run
 your tests to protect them from bitrotting.
 
+You can run individual examples with the command `cargo run --example <example-name>`.
+
 # Tests
 
 When you run `cargo test`, Cargo will:


### PR DESCRIPTION
Closes #2251. Should it be mentioned anywhere else as well?