### PR TITLE
Include publish command in help text

### DIFF
--- a/src/bin/cargo.rs
+++ b/src/bin/cargo.rs
@@ -48,6 +48,7 @@ Some common cargo commands are:
     bench       Run the benchmarks
     update      Update dependencies listed in Cargo.lock
     search      Search registry for crates
+    publish     Package and upload this project to the registry
     install     Install a Rust binary
 
 See 'cargo help <command>' for more information on a specific command.

--- a/src/etc/cargo.1
+++ b/src/etc/cargo.1
@@ -65,6 +65,9 @@ Update dependencies in Cargo.lock
 \fBcargo package\fR
 Generate a source tarball for the current package
 .TP
+\fBcargo publish\fR
+Package and upload this project to the registry
+.TP
 \fBcargo uninstall\fR
 Remove a Rust binary
 .TP


### PR DESCRIPTION
This is pretty commonly-used command, so I think it merits inclusion in the help text.