### PR TITLE
Fix listing of untracked files to not include tracked but modified ones

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -297,7 +297,7 @@ name = "num"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rand 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -338,7 +338,7 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "advapi32-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -391,7 +391,7 @@ name = "tempdir"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rand 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -445,7 +445,7 @@ name = "uuid"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rand 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/src/cargo/sources/path.rs
+++ b/src/cargo/sources/path.rs
@@ -161,8 +161,11 @@ impl<'cfg> PathSource<'cfg> {
             opts.pathspec(suffix);
         }
         let statuses = try!(repo.statuses(Some(&mut opts)));
-        let untracked = statuses.iter().map(|entry| {
-            (join(&root, entry.path_bytes()), None)
+        let untracked = statuses.iter().filter_map(|entry| {
+            match entry.status() {
+                git2::STATUS_WT_NEW => Some((join(&root, entry.path_bytes()), None)),
+                _ => None
+            }
         });
 
         'outer: for (file_path, is_dir) in index_files.chain(untracked) {


### PR DESCRIPTION
The logic in `sources/path.rs` that finds files that are untracked by the version control system was incorrectly including files that *are* tracked, but had been modified without the modification being committed to Git.

This manifested itself as strange duplications of files (e.g. in `cargo package --list`), since they were listed once as tracked files, and once more as allegedly "untracked" ones. It also caused failures when trying to package the crate when files had been deleted, but the deletion was not yet committed to Git.

Fixes #2199