### PR TITLE
Emit a warning when manifest specifies empty dependency constraints

### DIFF
--- a/src/cargo/util/toml.rs
+++ b/src/cargo/util/toml.rs
@@ -515,11 +515,11 @@ impl TomlManifest {
 
             // Collect the deps
             try!(process_dependencies(&mut cx, self.dependencies.as_ref(),
-                                      |dep| dep));
+                                      |dep| dep, &mut warnings));
             try!(process_dependencies(&mut cx, self.dev_dependencies.as_ref(),
-                                      |dep| dep.set_kind(Kind::Development)));
+                                      |dep| dep.set_kind(Kind::Development), &mut warnings));
             try!(process_dependencies(&mut cx, self.build_dependencies.as_ref(),
-                                      |dep| dep.set_kind(Kind::Build)));
+                                      |dep| dep.set_kind(Kind::Build), &mut warnings));
 
             if let Some(targets) = self.target.as_ref() {
                 for (name, platform) in targets.iter() {
@@ -527,19 +527,19 @@ impl TomlManifest {
                                               platform.dependencies.as_ref(),
                                               |dep| {
                         dep.set_only_for_platform(Some(name.clone()))
-                    }));
+                    }, &mut warnings));
                     try!(process_dependencies(&mut cx,
                                               platform.build_dependencies.as_ref(),
                                               |dep| {
                         dep.set_only_for_platform(Some(name.clone()))
                            .set_kind(Kind::Build)
-                    }));
+                    }, &mut warnings));
                     try!(process_dependencies(&mut cx,
                                               platform.dev_dependencies.as_ref(),
                                               |dep| {
                         dep.set_only_for_platform(Some(name.clone()))
                            .set_kind(Kind::Development)
-                    }));
+                    }, &mut warnings));
                 }
             }
         }
@@ -664,7 +664,8 @@ fn validate_bench_name(target: &TomlTarget) -> CargoResult<()> {
 
 fn process_dependencies<F>(cx: &mut Context,
                            new_deps: Option<&HashMap<String, TomlDependency>>,
-                           mut f: F) -> CargoResult<()>
+                           mut f: F,
+                           warnings: &mut Vec<String>) -> CargoResult<()>
     where F: FnMut(DependencyInner) -> DependencyInner
 {
     let dependencies = match new_deps {
@@ -680,6 +681,13 @@ fn process_dependencies<F>(cx: &mut Context,
             }
             TomlDependency::Detailed(ref details) => details.clone(),
         };
+
+        if details.version.is_none() && details.path.is_none() && details.git.is_none() {
+            warnings.push(format!("warning: dependency ({}) specified without providing a local \
+                                   path, Git repository, or version to use. This will be \
+                                   considered an error in future versions", n));
+        }
+
         let reference = details.branch.clone().map(GitReference::Branch)
             .or_else(|| details.tag.clone().map(GitReference::Tag))
             .or_else(|| details.rev.clone().map(GitReference::Rev))

--- a/tests/test_bad_config.rs
+++ b/tests/test_bad_config.rs
@@ -1,4 +1,5 @@
 use support::{project, execs};
+use support::registry::Package;
 use hamcrest::assert_that;
 
 fn setup() {}
@@ -385,5 +386,27 @@ test!(unused_keys {
     assert_that(foo.cargo_process("build"),
                 execs().with_status(0).with_stderr("\
 unused manifest key: target.foo.bar
+"));
+});
+
+test!(empty_dependencies {
+    let p = project("empty_deps")
+    .file("Cargo.toml", r#"
+        [package]
+        name = "empty_deps"
+        version = "0.0.0"
+        authors = []
+
+        [dependencies]
+        foo = {}
+    "#)
+    .file("src/main.rs", "fn main() {}");
+
+    Package::new("foo", "0.0.1").publish();
+
+    assert_that(p.cargo_process("build"),
+                execs().with_status(0).with_stderr_contains("\
+warning: dependency (foo) specified without providing a local path, Git repository, or version \
+to use. This will be considered an error in future versions
 "));
 });


### PR DESCRIPTION
This warns when encountering dependencies of either of these forms:
```
  [dependencies]
  foo = {}
```
and
```
  [dependencies.foo]
```
(with nothing further provided).

In the future, this should likely become a hard error.

Related to #2147 