### PR TITLE
Document --nocapture to reduce confusion running tests.

### DIFF
--- a/src/bin/test.rs
+++ b/src/bin/test.rs
@@ -65,6 +65,12 @@ The --jobs argument affects the building of the test executable but does
 not affect how many jobs are used when running the tests.
 
 Compilation can be configured via the `test` profile in the manifest.
+
+By default the rust test harness hides output from test execution to
+keep results readable. Test output can be recovered (e.g. for debugging)
+by passing `--nocapture` to the test binaries:
+
+  cargo test -- --nocapture
 ";
 
 pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {


### PR DESCRIPTION
Although this is a feature of rustc's test harness and
not cargo's test driver, I can never remember how to
invoke it. Describing the switch in `cargo test --help`
makes it more discoverable.