### PR TITLE
Cleanup some warnings from Clippy

### DIFF
--- a/src/cargo/core/package.rs
+++ b/src/cargo/core/package.rs
@@ -129,6 +129,10 @@ impl PackageSet {
         PackageSet { packages: packages.to_vec() }
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.packages.is_empty()
+    }
+
     pub fn len(&self) -> usize {
         self.packages.len()
     }

--- a/src/cargo/core/registry.rs
+++ b/src/cargo/core/registry.rs
@@ -15,7 +15,7 @@ pub trait Registry {
 impl Registry for Vec<Summary> {
     fn query(&mut self, dep: &Dependency) -> CargoResult<Vec<Summary>> {
         Ok(self.iter().filter(|summary| dep.matches(*summary))
-               .map(|summary| summary.clone()).collect())
+               .cloned().collect())
     }
 }
 

--- a/src/cargo/core/registry.rs
+++ b/src/cargo/core/registry.rs
@@ -295,7 +295,7 @@ impl<'cfg> Registry for PackageRegistry<'cfg> {
     fn query(&mut self, dep: &Dependency) -> CargoResult<Vec<Summary>> {
         let overrides = try!(self.query_overrides(dep));
 
-        let ret = if overrides.len() == 0 {
+        let ret = if overrides.is_empty() {
             // Ensure the requested source_id is loaded
             try!(self.ensure_loaded(dep.source_id(), Kind::Normal));
             let mut ret = Vec::new();

--- a/src/cargo/core/resolver/mod.rs
+++ b/src/cargo/core/resolver/mod.rs
@@ -453,7 +453,7 @@ fn activation_error(cx: &Context,
     candidates.sort_by(|a, b| {
         b.version().cmp(a.version())
     });
-    if candidates.len() > 0 {
+    if !candidates.is_empty() {
         msg.push_str("\nversions found: ");
         for (i, c) in candidates.iter().take(3).enumerate() {
             if i != 0 { msg.push_str(", "); }
@@ -469,7 +469,7 @@ fn activation_error(cx: &Context,
     // update`. In this case try to print a helpful error!
     if dep.source_id().is_path() &&
        dep.version_req().to_string().starts_with("=") &&
-       candidates.len() > 0 {
+       !candidates.is_empty() {
         msg.push_str("\nconsider running `cargo update` to update \
                       a path dependency's locked version");
 
@@ -607,7 +607,7 @@ impl Context {
                     (!use_default || prev.contains("default") ||
                      !has_default_feature)
             }
-            None => features.len() == 0 && (!use_default || !has_default_feature)
+            None => features.is_empty() && (!use_default || !has_default_feature)
         }
     }
 
@@ -686,10 +686,10 @@ impl Context {
         // they should have all been weeded out by the above iteration. Any
         // remaining features are bugs in that the package does not actually
         // have those features.
-        if feature_deps.len() > 0 {
+        if !feature_deps.is_empty() {
             let unknown = feature_deps.keys().map(|s| &s[..])
                                       .collect::<Vec<&str>>();
-            if unknown.len() > 0 {
+            if !unknown.is_empty() {
                 let features = unknown.connect(", ");
                 bail!("Package `{}` does not have these features: `{}`",
                       parent.package_id(), features)
@@ -697,7 +697,7 @@ impl Context {
         }
 
         // Record what list of features is active for this package.
-        if used_features.len() > 0 {
+        if !used_features.is_empty() {
             let pkgid = parent.package_id();
             self.resolve.features.entry(pkgid.clone())
                 .or_insert(HashSet::new())

--- a/src/cargo/core/resolver/mod.rs
+++ b/src/cargo/core/resolver/mod.rs
@@ -384,7 +384,7 @@ fn find_candidate(backtrack_stack: &mut Vec<BacktrackFrame>,
             return Some(candidate)
         }
     }
-    return None
+    None
 }
 
 #[allow(deprecated)] // connect => join in 1.3

--- a/src/cargo/core/shell.rs
+++ b/src/cargo/core/shell.rs
@@ -81,7 +81,7 @@ impl MultiShell {
         where F: FnMut(&mut MultiShell) -> io::Result<()>
     {
         match self.verbosity {
-            Verbose => return callback(self),
+            Verbose => callback(self),
             _ => Ok(())
         }
     }
@@ -91,7 +91,7 @@ impl MultiShell {
     {
         match self.verbosity {
             Verbose => Ok(()),
-            _ => return callback(self)
+            _ => callback(self)
         }
     }
 

--- a/src/cargo/core/source.rs
+++ b/src/cargo/core/source.rs
@@ -419,6 +419,10 @@ impl<'src> SourceMap<'src> {
         self.map.insert(id.clone(), source);
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.map.is_empty()
+    }
+
     pub fn len(&self) -> usize {
         self.map.len()
     }

--- a/src/cargo/lib.rs
+++ b/src/cargo/lib.rs
@@ -241,7 +241,7 @@ pub fn version() -> String {
     })
 }
 
-fn flags_from_args<'a, T>(usage: &str, args: &[String],
+fn flags_from_args<T>(usage: &str, args: &[String],
                           options_first: bool) -> CliResult<T>
     where T: Decodable
 {

--- a/src/cargo/ops/cargo_clean.rs
+++ b/src/cargo/ops/cargo_clean.rs
@@ -22,7 +22,7 @@ pub fn clean(manifest_path: &Path, opts: &CleanOptions) -> CargoResult<()> {
 
     // If we have a spec, then we need to delete some packages, otherwise, just
     // remove the whole target directory and be done with it!
-    if opts.spec.len() == 0 {
+    if opts.spec.is_empty() {
         return rm_rf(&target_dir);
     }
 

--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -257,7 +257,7 @@ pub fn compile_pkg<'a>(root_package: &Package,
 
     ret.to_doc_test = to_builds.iter().map(|&p| p.clone()).collect();
 
-    return Ok(ret);
+    Ok(ret)
 }
 
 impl<'a> CompileFilter<'a> {
@@ -311,7 +311,7 @@ fn generate_targets<'a>(pkg: &'a Package,
         CompileMode::Build => build,
         CompileMode::Doc { .. } => &profiles.doc,
     };
-    return match *filter {
+    match *filter {
         CompileFilter::Everything => {
             match mode {
                 CompileMode::Bench => {
@@ -379,7 +379,7 @@ fn generate_targets<'a>(pkg: &'a Package,
             }
             Ok(targets)
         }
-    };
+    }
 }
 
 /// Read the `paths` configuration variable to discover all path overrides that

--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -176,7 +176,7 @@ pub fn compile_pkg<'a>(root_package: &Package,
         vec![root_package.package_id()]
     };
 
-    if spec.len() > 0 && invalid_spec.len() > 0 {
+    if !spec.is_empty() && !invalid_spec.is_empty() {
         bail!("could not find package matching spec `{}`",
               invalid_spec.connect(", "))
     }

--- a/src/cargo/ops/cargo_doc.rs
+++ b/src/cargo/ops/cargo_doc.rs
@@ -18,7 +18,7 @@ pub fn doc(manifest_path: &Path,
 
     let mut lib_names = HashSet::new();
     let mut bin_names = HashSet::new();
-    if options.compile_opts.spec.len() == 0 {
+    if options.compile_opts.spec.is_empty() {
         for target in package.targets().iter().filter(|t| t.documented()) {
             if target.is_lib() {
                 assert!(lib_names.insert(target.crate_name()));

--- a/src/cargo/ops/cargo_doc.rs
+++ b/src/cargo/ops/cargo_doc.rs
@@ -42,7 +42,7 @@ pub fn doc(manifest_path: &Path,
             bail!("Passing multiple packages and `open` is not supported")
         } else if options.compile_opts.spec.len() == 1 {
             try!(PackageIdSpec::parse(&options.compile_opts.spec[0]))
-                                             .name().replace("-", "_").to_string()
+                                             .name().replace("-", "_")
         } else {
             match lib_names.iter().chain(bin_names.iter()).nth(0) {
                 Some(s) => s.to_string(),

--- a/src/cargo/ops/cargo_generate_lockfile.rs
+++ b/src/cargo/ops/cargo_generate_lockfile.rs
@@ -43,7 +43,7 @@ pub fn update_lockfile(manifest_path: &Path,
     let mut registry = PackageRegistry::new(opts.config);
     let mut to_avoid = HashSet::new();
 
-    if opts.to_update.len() == 0 {
+    if opts.to_update.is_empty() {
         to_avoid.extend(previous_resolve.iter());
     } else {
         let mut sources = Vec::new();

--- a/src/cargo/ops/cargo_install.rs
+++ b/src/cargo/ops/cargo_install.rs
@@ -312,7 +312,7 @@ pub fn uninstall(root: Option<&str>,
             }
         }
 
-        if bins.len() == 0 {
+        if bins.is_empty() {
             to_remove.extend(installed.get().iter().map(|b| dst.join(b)));
             installed.get_mut().clear();
         } else {
@@ -321,7 +321,7 @@ pub fn uninstall(root: Option<&str>,
                 installed.get_mut().remove(bin);
             }
         }
-        if installed.get().len() == 0 {
+        if installed.get().is_empty() {
             installed.remove();
         }
     }

--- a/src/cargo/ops/cargo_new.rs
+++ b/src/cargo/ops/cargo_new.rs
@@ -175,7 +175,6 @@ fn discover_author() -> CargoResult<(String, Option<String>)> {
     let git_config = GitConfig::open_default().ok();
     let git_config = git_config.as_ref();
     let name = git_config.and_then(|g| g.get_string("user.name").ok())
-                         .map(|s| s.to_string())
                          .or_else(|| env::var("USER").ok())      // unix
                          .or_else(|| env::var("USERNAME").ok()); // windows
     let name = match name {

--- a/src/cargo/ops/cargo_rustc/context.rs
+++ b/src/cargo/ops/cargo_rustc/context.rs
@@ -213,7 +213,7 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
         if unit.target.is_lib() && unit.profile.test {
             // Libs and their tests are built in parallel, so we need to make
             // sure that their metadata is different.
-            metadata.map(|m| m.clone()).map(|mut m| {
+            metadata.cloned().map(|mut m| {
                 m.mix(&"test");
                 m
             })
@@ -232,7 +232,7 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
             // file names like `target/debug/libfoo.{a,so,rlib}` and such.
             None
         } else {
-            metadata.map(|m| m.clone())
+            metadata.cloned()
         }
     }
 

--- a/src/cargo/ops/cargo_rustc/context.rs
+++ b/src/cargo/ops/cargo_rustc/context.rs
@@ -282,7 +282,7 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
                 }
             }
         }
-        assert!(ret.len() > 0);
+        assert!(!ret.is_empty());
         Ok(ret)
     }
 

--- a/src/cargo/ops/cargo_rustc/context.rs
+++ b/src/cargo/ops/cargo_rustc/context.rs
@@ -134,7 +134,7 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
             lines.next().unwrap().trim()
                  .split('_').skip(1).next().unwrap().to_string()
         };
-        Ok((dylib, exe_suffix.to_string()))
+        Ok((dylib, exe_suffix))
     }
 
     /// Prepare this context, ensuring that all filesystem directories are in
@@ -244,7 +244,7 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
             None if unit.target.allows_underscores() => {
                 unit.target.name().to_string()
             }
-            None => unit.target.crate_name().to_string(),
+            None => unit.target.crate_name(),
         }
     }
 

--- a/src/cargo/ops/cargo_rustc/context.rs
+++ b/src/cargo/ops/cargo_rustc/context.rs
@@ -159,7 +159,7 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
         self.compilation.deps_output =
                 self.layout(root, Kind::Target).proxy().deps().to_path_buf();
 
-        return Ok(());
+        Ok(())
     }
 
     /// Returns the appropriate directory layout for either a plugin or not.
@@ -283,7 +283,7 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
             }
         }
         assert!(ret.len() > 0);
-        return Ok(ret);
+        Ok(ret)
     }
 
     /// For a package, return all targets which are registered as dependencies
@@ -374,7 +374,7 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
                 }
             }));
         }
-        return ret
+        ret
     }
 
     /// Returns the dependencies needed to run a build script.
@@ -462,7 +462,7 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
         if unit.target.is_bin() {
             ret.extend(self.maybe_lib(unit));
         }
-        return ret
+        ret
     }
 
     /// If a build script is scheduled to be run for the package specified by

--- a/src/cargo/ops/cargo_rustc/custom_build.rs
+++ b/src/cargo/ops/cargo_rustc/custom_build.rs
@@ -399,6 +399,6 @@ pub fn build_map<'b, 'cfg>(cx: &mut Context<'b, 'cfg>,
         let prev = out.entry(*unit).or_insert(BuildScripts::default());
         prev.to_link.extend(to_link);
         prev.plugins.extend(plugins);
-        return prev
+        prev
     }
 }

--- a/src/cargo/ops/cargo_rustc/fingerprint.rs
+++ b/src/cargo/ops/cargo_rustc/fingerprint.rs
@@ -141,7 +141,7 @@ impl Fingerprint {
         }
         let ret = util::hash_u64(self);
         *self.memoized_hash.lock().unwrap() = Some(ret);
-        return ret
+        ret
     }
 
     fn compare(&self, old: &Fingerprint) -> CargoResult<()> {

--- a/src/cargo/ops/cargo_rustc/fingerprint.rs
+++ b/src/cargo/ops/cargo_rustc/fingerprint.rs
@@ -398,7 +398,7 @@ pub fn prepare_build_cmd<'a, 'cfg>(cx: &mut Context<'a, 'cfg>, unit: &Unit<'a>)
             None => {
                 let &(ref output, ref deps) = &cx.build_explicit_deps[unit];
 
-                let local = if deps.len() == 0 {
+                let local = if deps.is_empty() {
                     let s = try!(pkg_fingerprint(cx, unit.pkg));
                     LocalFingerprint::Precalculated(s)
                 } else {
@@ -440,7 +440,7 @@ pub fn prepare_build_cmd<'a, 'cfg>(cx: &mut Context<'a, 'cfg>, unit: &Unit<'a>)
     let write_fingerprint = Work::new(move |_| {
         if let Some(output_path) = output_path {
             let outputs = state.outputs.lock().unwrap();
-            if outputs[&key].rerun_if_changed.len() > 0 {
+            if !outputs[&key].rerun_if_changed.is_empty() {
                 let slot = MtimeSlot(Mutex::new(None));
                 fingerprint.local = LocalFingerprint::MtimeBased(slot,
                                                                  output_path);

--- a/src/cargo/ops/cargo_rustc/job_queue.rs
+++ b/src/cargo/ops/cargo_rustc/job_queue.rs
@@ -104,7 +104,7 @@ impl<'a> JobQueue<'a> {
         // and then immediately return.
         loop {
             while self.active < self.jobs {
-                if queue.len() > 0 {
+                if !queue.is_empty() {
                     let (key, job, fresh) = queue.remove(0);
                     try!(self.run(key, fresh, job, config, scope));
                 } else if let Some((fresh, key, jobs)) = self.queue.dequeue() {
@@ -152,7 +152,7 @@ impl<'a> JobQueue<'a> {
             }
         }
 
-        if self.queue.len() == 0 {
+        if self.queue.is_empty() {
             Ok(())
         } else {
             debug!("queue: {:#?}", self.queue);

--- a/src/cargo/ops/cargo_rustc/layout.rs
+++ b/src/cargo/ops/cargo_rustc/layout.rs
@@ -113,9 +113,9 @@ impl Layout {
         }
     }
 
-    pub fn dest<'a>(&'a self) -> &'a Path { &self.root }
-    pub fn deps<'a>(&'a self) -> &'a Path { &self.deps }
-    pub fn examples<'a>(&'a self) -> &'a Path { &self.examples }
+    pub fn dest(&self) -> &Path { &self.root }
+    pub fn deps(&self) -> &Path { &self.deps }
+    pub fn examples(&self) -> &Path { &self.examples }
 
     pub fn fingerprint(&self, package: &Package) -> PathBuf {
         self.fingerprint.join(&self.pkg_dir(package))

--- a/src/cargo/ops/cargo_test.rs
+++ b/src/cargo/ops/cargo_test.rs
@@ -24,7 +24,7 @@ pub fn run_tests(manifest_path: &Path,
     let mut errors = try!(run_unit_tests(options, test_args, &compilation));
 
     // If we have an error and want to fail fast, return
-    if errors.len() > 0 && !options.no_fail_fast {
+    if !errors.is_empty() && !options.no_fail_fast {
         return Ok(Some(CargoTestError::new(errors)))
     }
 
@@ -38,7 +38,7 @@ pub fn run_tests(manifest_path: &Path,
     }
 
     errors.extend(try!(run_doc_tests(options, test_args, &compilation)));
-    if errors.len() == 0 {
+    if errors.is_empty() {
         Ok(None)
     } else {
         Ok(Some(CargoTestError::new(errors)))

--- a/src/cargo/ops/cargo_test.rs
+++ b/src/cargo/ops/cargo_test.rs
@@ -93,7 +93,7 @@ fn run_unit_tests(options: &TestOptions,
             shell.status("Running", cmd.to_string())
         }));
 
-        if let Err(e) = ExecEngine::exec(&mut ProcessEngine, cmd) {
+        if let Err(e) = ExecEngine::exec(&ProcessEngine, cmd) {
             errors.push(e);
             if !options.no_fail_fast {
                 break
@@ -166,7 +166,7 @@ fn run_doc_tests(options: &TestOptions,
             try!(config.shell().verbose(|shell| {
                 shell.status("Running", p.to_string())
             }));
-            if let Err(e) = ExecEngine::exec(&mut ProcessEngine, p) {
+            if let Err(e) = ExecEngine::exec(&ProcessEngine, p) {
                 errors.push(e);
                 if !options.no_fail_fast {
                     return Ok(errors);

--- a/src/cargo/ops/registry.rs
+++ b/src/cargo/ops/registry.rs
@@ -366,7 +366,7 @@ pub fn search(query: &str, config: &Config, index: Option<String>) -> CargoResul
             Some(desc) => {
                 let space = repeat(' ').take(description_margin - name.len())
                                        .collect::<String>();
-                name.to_string() + &space + &desc
+                name + &space + &desc
             }
             None => name
         };

--- a/src/cargo/ops/resolve.rs
+++ b/src/cargo/ops/resolve.rs
@@ -89,7 +89,7 @@ pub fn resolve_with_previous<'a>(registry: &mut PackageRegistry,
             for node in r.iter().filter(|p| keep(p, to_avoid, &to_avoid_sources)) {
                 let deps = r.deps(node).into_iter().flat_map(|i| i)
                             .filter(|p| keep(p, to_avoid, &to_avoid_sources))
-                            .map(|p| p.clone()).collect();
+                            .cloned().collect();
                 registry.register_lock(node.clone(), deps);
             }
 

--- a/src/cargo/sources/git/source.rs
+++ b/src/cargo/sources/git/source.rs
@@ -145,7 +145,7 @@ pub fn canonicalize_url(url: &Url) -> Url {
         _ => {}
     }
 
-    return url;
+    url
 }
 
 impl<'cfg> Debug for GitSource<'cfg> {

--- a/src/cargo/sources/git/utils.rs
+++ b/src/cargo/sources/git/utils.rs
@@ -159,7 +159,7 @@ impl GitRemote {
 }
 
 impl GitDatabase {
-    fn path<'a>(&'a self) -> &'a Path {
+    fn path(&self) -> &Path {
         &self.path
     }
 

--- a/src/cargo/sources/path.rs
+++ b/src/cargo/sources/path.rs
@@ -106,7 +106,7 @@ impl<'cfg> PathSource<'cfg> {
         let mut filter = |p: &Path| {
             let relative_path = util::without_prefix(p, &root).unwrap();
             include.iter().any(|p| p.matches_path(&relative_path)) || {
-                include.len() == 0 &&
+                include.is_empty() &&
                  !exclude.iter().any(|p| p.matches_path(&relative_path))
             }
         };

--- a/src/cargo/sources/path.rs
+++ b/src/cargo/sources/path.rs
@@ -312,7 +312,7 @@ impl<'cfg> Source for PathSource<'cfg> {
 
         Ok(self.packages.iter()
            .filter(|pkg| ids.iter().any(|id| pkg.package_id() == id))
-           .map(|pkg| pkg.clone())
+           .cloned()
            .collect())
     }
 

--- a/src/cargo/sources/path.rs
+++ b/src/cargo/sources/path.rs
@@ -244,7 +244,7 @@ impl<'cfg> PathSource<'cfg> {
             let loc = pkg.root();
             try!(PathSource::walk(loc, &mut ret, true, filter));
         }
-        return Ok(ret);
+        Ok(ret)
     }
 
     fn walk(path: &Path, ret: &mut Vec<PathBuf>,
@@ -275,7 +275,7 @@ impl<'cfg> PathSource<'cfg> {
             }
             try!(PathSource::walk(&dir, ret, false, filter));
         }
-        return Ok(())
+        Ok(())
     }
 }
 

--- a/src/cargo/sources/registry.rs
+++ b/src/cargo/sources/registry.rs
@@ -487,7 +487,7 @@ impl<'cfg> Registry for RegistrySource<'cfg> {
             let mut summaries = try!(self.summaries(dep.name())).iter().map(|s| {
                 s.0.clone()
             }).collect::<Vec<_>>();
-            if try!(summaries.query(dep)).len() == 0 {
+            if try!(summaries.query(dep)).is_empty() {
                 try!(self.do_update());
             }
         }

--- a/src/cargo/sources/registry.rs
+++ b/src/cargo/sources/registry.rs
@@ -561,7 +561,7 @@ impl<'cfg> Source for RegistrySource<'cfg> {
         for src in self.sources.values() {
             ret.extend(try!(src.get(packages)).into_iter());
         }
-        return Ok(ret);
+        Ok(ret)
     }
 
     fn fingerprint(&self, pkg: &Package) -> CargoResult<String> {

--- a/src/cargo/util/config.rs
+++ b/src/cargo/util/config.rs
@@ -469,7 +469,7 @@ fn homedir(cwd: &Path) -> Option<PathBuf> {
         cwd.join(home)
     });
     let user_home = env::home_dir().map(|p| p.join(".cargo"));
-    return cargo_home.or(user_home);
+    cargo_home.or(user_home)
 }
 
 fn walk_tree<F>(pwd: &Path, mut walk: F) -> CargoResult<()>

--- a/src/cargo/util/dependency_queue.rs
+++ b/src/cargo/util/dependency_queue.rs
@@ -99,7 +99,7 @@ impl<K: Dependency, V> DependencyQueue<K, V> {
     /// `None` is returned then no packages are ready to be built.
     pub fn dequeue(&mut self) -> Option<(Freshness, K, V)> {
         let key = match self.dep_map.iter()
-                                    .find(|&(_, &(ref deps, _))| deps.len() == 0)
+                                    .find(|&(_, &(ref deps, _))| deps.is_empty())
                                     .map(|(key, _)| key.clone()) {
             Some(key) => key,
             None => return None

--- a/src/cargo/util/dependency_queue.rs
+++ b/src/cargo/util/dependency_queue.rs
@@ -110,6 +110,11 @@ impl<K: Dependency, V> DependencyQueue<K, V> {
         Some((fresh, key, data))
     }
 
+    /// Returns whether there are remaining packages to be built.
+    pub fn is_empty(&self) -> bool {
+        self.dep_map.is_empty() && self.pending.is_empty()
+    }
+
     /// Returns the number of remaining packages to be built.
     pub fn len(&self) -> usize {
         self.dep_map.len() + self.pending.len()

--- a/src/cargo/util/errors.rs
+++ b/src/cargo/util/errors.rs
@@ -142,7 +142,7 @@ pub struct CargoTestError {
 impl CargoTestError {
     #[allow(deprecated)] // connect => join in 1.3
     pub fn new(errors: Vec<ProcessError>) -> Self {
-        if errors.len() == 0 {
+        if errors.is_empty() {
             panic!("Cannot create CargoTestError from empty Vec")
         }
         let desc = errors.iter().map(|error| error.desc.clone())

--- a/src/cargo/util/errors.rs
+++ b/src/cargo/util/errors.rs
@@ -360,8 +360,8 @@ pub fn process_error(msg: &str,
 
     ProcessError {
         desc: desc,
-        exit: status.map(|a| a.clone()),
-        output: output.map(|a| a.clone()),
+        exit: status.cloned(),
+        output: output.cloned(),
         cause: cause,
     }
 }

--- a/src/cargo/util/graph.rs
+++ b/src/cargo/util/graph.rs
@@ -21,7 +21,7 @@ impl<N: Eq + Hash + Clone> Graph<N> {
     }
 
     pub fn add(&mut self, node: N, children: &[N]) {
-        self.nodes.insert(node, children.iter().map(|n| n.clone()).collect());
+        self.nodes.insert(node, children.iter().cloned().collect());
     }
 
     pub fn link(&mut self, node: N, child: N) {

--- a/src/cargo/util/graph.rs
+++ b/src/cargo/util/graph.rs
@@ -25,7 +25,7 @@ impl<N: Eq + Hash + Clone> Graph<N> {
     }
 
     pub fn link(&mut self, node: N, child: N) {
-        self.nodes.entry(node).or_insert_with(|| HashSet::new()).insert(child);
+        self.nodes.entry(node).or_insert_with(HashSet::new).insert(child);
     }
 
     pub fn get_nodes(&self) -> &HashMap<N, HashSet<N>> {

--- a/src/cargo/util/sha256.rs
+++ b/src/cargo/util/sha256.rs
@@ -36,7 +36,7 @@ mod imp {
                 let ret = Sha256 { ctx: ctx };
                 let n = EVP_DigestInit_ex(ret.ctx, EVP_sha256(), 0 as *mut _);
                 assert_eq!(n, 1);
-                return ret;
+                ret
             }
         }
 
@@ -55,7 +55,7 @@ mod imp {
                 let n = EVP_DigestFinal_ex(self.ctx, ret.as_mut_ptr(), &mut out);
                 assert_eq!(n, 1);
                 assert_eq!(out, 32);
-                return ret;
+                ret
             }
         }
     }
@@ -104,7 +104,7 @@ mod imp {
                 CryptCreateHash(ret.hcryptprov, CALG_SHA_256,
                                 0, 0, &mut ret.hcrypthash)
             });
-            return ret;
+            ret
         }
 
         pub fn update(&mut self, bytes: &[u8]) {
@@ -122,7 +122,7 @@ mod imp {
                                   &mut len, 0)
             });
             assert_eq!(len as usize, ret.len());
-            return ret;
+            ret
         }
     }
 

--- a/src/cargo/util/toml.rs
+++ b/src/cargo/util/toml.rs
@@ -138,7 +138,7 @@ pub fn to_manifest(contents: &[u8],
         match *toml {
             toml::Value::Table(ref table) => {
                 for (k, v) in table.iter() {
-                    add_unused_keys(m, v, if key.len() == 0 {
+                    add_unused_keys(m, v, if key.is_empty() {
                         k.clone()
                     } else {
                         key.clone() + "." + k

--- a/src/cargo/util/vcs.rs
+++ b/src/cargo/util/vcs.rs
@@ -10,7 +10,7 @@ pub struct GitRepo;
 impl GitRepo {
     pub fn init(path: &Path, _: &Path) -> CargoResult<GitRepo> {
         try!(git2::Repository::init(path));
-        return Ok(GitRepo)
+        Ok(GitRepo)
     }
     pub fn discover(path: &Path, _: &Path) -> Result<git2::Repository,git2::Error> {
         git2::Repository::discover(path)
@@ -20,11 +20,11 @@ impl GitRepo {
 impl HgRepo {
     pub fn init(path: &Path, cwd: &Path) -> CargoResult<HgRepo> {
         try!(process("hg").cwd(cwd).arg("init").arg(path).exec());
-        return Ok(HgRepo)
+        Ok(HgRepo)
     }
     pub fn discover(path: &Path, cwd: &Path) -> CargoResult<HgRepo> {
         try!(process("hg").cwd(cwd).arg("root").cwd(path).exec_with_output());
-        return Ok(HgRepo)
+        Ok(HgRepo)
     }
 }
 

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -370,7 +370,7 @@ impl Execs {
         } else {
             self.diff_lines(a, e, partial)
         };
-        ham::expect(diffs.len() == 0,
+        ham::expect(diffs.is_empty(),
                     format!("differences:\n\
                             {}\n\n\
                             other output:\n\
@@ -416,7 +416,7 @@ fn lines_match(expected: &str, mut actual: &str) -> bool {
             }
         }
     }
-    actual.len() == 0 || expected.ends_with("[..]")
+    actual.is_empty() || expected.ends_with("[..]")
 }
 
 struct ZipAll<I1: Iterator, I2: Iterator> {

--- a/tests/support/registry.rs
+++ b/tests/support/registry.rs
@@ -157,7 +157,7 @@ impl Package {
         let f = File::create(&dst).unwrap();
         let a = Archive::new(GzEncoder::new(f, Default));
         self.append(&a, "Cargo.toml", &manifest);
-        if self.files.len() == 0 {
+        if self.files.is_empty() {
             self.append(&a, "src/lib.rs", "");
         } else {
             for &(ref name, ref contents) in self.files.iter() {


### PR DESCRIPTION
For information, here is the [log before and after](https://gist.github.com/mcarton/684c030321c4c60d6bc9) with Clippy.
Remaining warnings from Clippy are mostly false positive or `str` to `string` conversion (too many of them for this PR).


```
warnings before:
     cmp_owned : 2
     cyclomatic_complexity : 1
     deprecated : 11
     explicit_iter_loop : 57
     identity_op : 3
     len_without_is_empty : 3
     len_zero : 20
     let_and_return : 3
     map_clone : 14
     needless_lifetimes : 4
     needless_return : 24
     ok_expect : 2
     option_map_unwrap_or : 10
     private_in_public : 28
     redundant_closure : 2
     should_implement_trait : 2
     single_match : 3
     str_to_string : 112
     string_to_string : 12
     type_complexity : 3
     unnecessary_mut_passed : 2
     unneeded_field_pattern : 3
     unused_lifetimes : 1
     unused_variables : 2
     while_let_loop : 2

warnings after:
     cmp_owned : 2
     cyclomatic_complexity : 1
     identity_op : 1
     let_and_return : 3
     map_clone : 1
     needless_return : 3
     ok_expect : 2
     option_map_unwrap_or : 1
     private_in_public : 28
     should_implement_trait : 2
     str_to_string : 80
     type_complexity : 3
     while_let_loop : 2
```