### PR TITLE
Drop wildcard crates.io warning

### DIFF
--- a/src/cargo/ops/cargo_package.rs
+++ b/src/cargo/ops/cargo_package.rs
@@ -2,13 +2,11 @@ use std::io::prelude::*;
 use std::fs::{self, File};
 use std::path::{self, Path, PathBuf};
 
-use semver::VersionReq;
 use tar::Archive;
 use flate2::{GzBuilder, Compression};
 use flate2::read::GzDecoder;
 
 use core::{SourceId, Package, PackageId};
-use core::dependency::Kind;
 use sources::PathSource;
 use util::{self, CargoResult, human, internal, ChainError, Config};
 use ops;
@@ -25,8 +23,6 @@ pub fn package(manifest_path: &Path,
     if metadata {
         try!(check_metadata(&pkg, config));
     }
-
-    try!(check_dependencies(&pkg, config));
 
     if list {
         let root = pkg.root();
@@ -100,32 +96,6 @@ fn check_metadata(pkg: &Package, config: &Config) -> CargoResult<()> {
             &format!("warning: manifest has no {things}. \
                     See http://doc.crates.io/manifest.html#package-metadata for more info.",
                     things = things)))
-    }
-    Ok(())
-}
-
-// Warn about wildcard deps which will soon be prohibited on crates.io
-#[allow(deprecated)] // connect => join in 1.3
-fn check_dependencies(pkg: &Package, config: &Config) -> CargoResult<()> {
-    let wildcard = VersionReq::parse("*").unwrap();
-
-    let mut wildcard_deps = vec![];
-    for dep in pkg.dependencies() {
-        if dep.kind() != Kind::Development && dep.version_req() == &wildcard {
-            wildcard_deps.push(dep.name());
-        }
-    }
-
-    if !wildcard_deps.is_empty() {
-        let deps = wildcard_deps.connect(", ");
-        try!(config.shell().warn(
-            "warning: some dependencies have wildcard (\"*\") version constraints. \
-             On January 22nd, 2016, crates.io will begin rejecting packages with \
-             wildcard dependency constraints. See \
-             http://doc.crates.io/crates-io.html#using-crates.io-based-crates \
-             for information on version constraints."));
-        try!(config.shell().warn(
-            &format!("dependencies for these crates have wildcard constraints: {}", deps)));
     }
     Ok(())
 }

--- a/tests/test_cargo_package.rs
+++ b/tests/test_cargo_package.rs
@@ -141,59 +141,6 @@ http://doc.crates.io/manifest.html#package-metadata for more info."));
         dir = p.url())));
 });
 
-test!(wildcard_deps {
-    let p = project("foo")
-        .file("Cargo.toml", r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-            license = "MIT"
-            description = "foo"
-            repository = "bar"
-
-            [dependencies]
-            bar = "*"
-
-            [build-dependencies]
-            baz = "*"
-
-            [dev-dependencies]
-            buz = "*"
-        "#)
-        .file("src/main.rs", "fn main() {}");
-
-    Package::new("baz", "0.0.1").publish();
-    Package::new("bar", "0.0.1").dep("baz", "0.0.1").publish();
-    Package::new("buz", "0.0.1").dep("bar", "0.0.1").publish();
-
-    assert_that(p.cargo_process("package"),
-                execs().with_status(0).with_stdout(&format!("\
-{packaging} foo v0.0.1 ({dir})
-{verifying} foo v0.0.1 ({dir})
-{updating} registry `{reg}`
-{downloading} [..] v0.0.1 (registry file://[..])
-{downloading} [..] v0.0.1 (registry file://[..])
-{downloading} [..] v0.0.1 (registry file://[..])
-{compiling} baz v0.0.1 (registry file://[..])
-{compiling} bar v0.0.1 (registry file://[..])
-{compiling} foo v0.0.1 ({dir}[..])
-",
-        packaging = PACKAGING,
-        verifying = VERIFYING,
-        updating = UPDATING,
-        downloading = DOWNLOADING,
-        compiling = COMPILING,
-        dir = p.url(),
-        reg = registry::registry()))
-                .with_stderr("\
-warning: some dependencies have wildcard (\"*\") version constraints. On January 22nd, 2016, \
-crates.io will begin rejecting packages with wildcard dependency constraints. See \
-http://doc.crates.io/crates-io.html#using-crates.io-based-crates for information on version \
-constraints.
-dependencies for these crates have wildcard constraints: bar, baz"));
-});
-
 test!(package_verbose {
     let root = paths::root().join("all");
     let p = git::repo(&root)


### PR DESCRIPTION
The crates.io change is going through, so we don't want this warning
around after it lands.

r? @alexcrichton 

This would perferrably make it into the Cargo that's shipping with 1.6.