### PR TITLE
Fix update --precise with the registry source

### DIFF
--- a/src/cargo/sources/registry.rs
+++ b/src/cargo/sources/registry.rs
@@ -505,7 +505,8 @@ impl<'cfg> Registry for RegistrySource<'cfg> {
         // version requested (agument to `--precise`).
         summaries.retain(|s| {
             match self.source_id.precise() {
-                Some(p) if p.starts_with(dep.name()) => {
+                Some(p) if p.starts_with(dep.name()) &&
+                           p[dep.name().len()..].starts_with("=") => {
                     let vers = &p[dep.name().len() + 1..];
                     s.version().to_string() == vers
                 }


### PR DESCRIPTION
There was a previous bug where if any crate's name was the start of the crate
being updated that the crate wouldn't resolve at all, and this fixes the prefix
checking error bug.

cc #2293