### PR TITLE
Remove 1.2.0 from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: rust
 rust:
-  - 1.2.0
   - stable
   - beta
   - nightly


### PR DESCRIPTION
There hasn't actually ever been a request to maintain compatibility with older
stable Rust versions, and it's becoming a bit of a maintenance burden, so just
switch CI to run on stable Rust.