### PR TITLE
Update libgit2-sys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,7 +17,7 @@ dependencies = [
  "hamcrest 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "kernel32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "libgit2-sys 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libgit2-sys 0.3.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.1.48 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -166,7 +166,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "libgit2-sys 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libgit2-sys 0.3.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.2.38 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -210,7 +210,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cmake 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",


### PR DESCRIPTION
Fixes a linkage error on linux if libhttp_parser is already installed.