### PR TITLE
Implement cfg-based target-specific dependencies

### DIFF
--- a/src/cargo/ops/registry.rs
+++ b/src/cargo/ops/registry.rs
@@ -81,7 +81,7 @@ fn transmit(pkg: &Package, tarball: &Path, registry: &mut Registry)
             name: dep.name().to_string(),
             features: dep.features().to_vec(),
             version_req: dep.version_req().to_string(),
-            target: dep.only_for_platform().map(|s| s.to_string()),
+            target: dep.platform().map(|s| s.to_string()),
             kind: match dep.kind() {
                 Kind::Normal => "normal",
                 Kind::Build => "build",

--- a/src/cargo/sources/registry.rs
+++ b/src/cargo/sources/registry.rs
@@ -435,6 +435,11 @@ impl<'cfg> RegistrySource<'cfg> {
             _ => Kind::Normal,
         };
 
+        let platform = match target {
+            Some(target) => Some(try!(target.parse())),
+            None => None,
+        };
+
         // Unfortunately older versions of cargo and/or the registry ended up
         // publishing lots of entries where the features array contained the
         // empty feature, "", inside. This confuses the resolution process much
@@ -445,7 +450,7 @@ impl<'cfg> RegistrySource<'cfg> {
         Ok(dep.set_optional(optional)
               .set_default_features(default_features)
               .set_features(features)
-              .set_only_for_platform(target)
+              .set_platform(platform)
               .set_kind(kind)
               .into_dependency())
     }

--- a/src/cargo/util/cfg.rs
+++ b/src/cargo/util/cfg.rs
@@ -1,0 +1,261 @@
+use std::str::{self, FromStr};
+use std::iter;
+use std::fmt;
+
+use util::{CargoError, CargoResult, human};
+
+#[derive(Clone, PartialEq, Debug)]
+pub enum Cfg {
+    Name(String),
+    KeyPair(String, String),
+}
+
+#[derive(Clone, PartialEq, Debug)]
+pub enum CfgExpr {
+    Not(Box<CfgExpr>),
+    All(Vec<CfgExpr>),
+    Any(Vec<CfgExpr>),
+    Value(Cfg),
+}
+
+#[derive(PartialEq)]
+enum Token<'a> {
+    LeftParen,
+    RightParen,
+    Ident(&'a str),
+    Comma,
+    Equals,
+    String(&'a str),
+}
+
+struct Tokenizer<'a> {
+    s: iter::Peekable<str::CharIndices<'a>>,
+    orig: &'a str,
+}
+
+struct Parser<'a> {
+    t: iter::Peekable<Tokenizer<'a>>,
+}
+
+impl FromStr for Cfg {
+    type Err = Box<CargoError>;
+
+    fn from_str(s: &str) -> CargoResult<Cfg> {
+        let mut p = Parser::new(s);
+        let e = try!(p.cfg());
+        if p.t.next().is_some() {
+            bail!("malformed cfg value or key/value pair")
+        }
+        Ok(e)
+    }
+}
+
+impl fmt::Display for Cfg {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            Cfg::Name(ref s) => s.fmt(f),
+            Cfg::KeyPair(ref k, ref v) => write!(f, "{} = \"{}\"", k, v),
+        }
+    }
+}
+
+impl CfgExpr {
+    pub fn matches(&self, cfg: &[Cfg]) -> bool {
+        match *self {
+            CfgExpr::Not(ref e) => !e.matches(cfg),
+            CfgExpr::All(ref e) => e.iter().all(|e| e.matches(cfg)),
+            CfgExpr::Any(ref e) => e.iter().any(|e| e.matches(cfg)),
+            CfgExpr::Value(ref e) => cfg.contains(e),
+        }
+    }
+}
+
+impl FromStr for CfgExpr {
+    type Err = Box<CargoError>;
+
+    fn from_str(s: &str) -> CargoResult<CfgExpr> {
+        let mut p = Parser::new(s);
+        let e = try!(p.expr());
+        if p.t.next().is_some() {
+            bail!("can only have one cfg-expression, consider using all() or \
+                   any() explicitly")
+        }
+        Ok(e)
+    }
+}
+
+impl fmt::Display for CfgExpr {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            CfgExpr::Not(ref e) => write!(f, "not({})", e),
+            CfgExpr::All(ref e) => write!(f, "all({})", CommaSep(e)),
+            CfgExpr::Any(ref e) => write!(f, "any({})", CommaSep(e)),
+            CfgExpr::Value(ref e) => write!(f, "{}", e),
+        }
+    }
+}
+
+struct CommaSep<'a, T: 'a>(&'a [T]);
+
+impl<'a, T: fmt::Display> fmt::Display for CommaSep<'a, T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        for (i, v) in self.0.iter().enumerate() {
+            if i > 0 {
+                try!(write!(f, ", "));
+            }
+            try!(write!(f, "{}", v));
+        }
+        Ok(())
+    }
+}
+
+impl<'a> Parser<'a> {
+    fn new(s: &'a str) -> Parser<'a> {
+        Parser {
+            t: Tokenizer {
+                s: s.char_indices().peekable(),
+                orig: s,
+            }.peekable(),
+        }
+    }
+
+    fn expr(&mut self) -> CargoResult<CfgExpr> {
+        match self.t.peek() {
+            Some(&Ok(Token::Ident(op @ "all"))) |
+            Some(&Ok(Token::Ident(op @ "any"))) => {
+                self.t.next();
+                let mut e = Vec::new();
+                try!(self.eat(Token::LeftParen));
+                while !self.try(Token::RightParen) {
+                    e.push(try!(self.expr()));
+                    if !self.try(Token::Comma) {
+                        try!(self.eat(Token::RightParen));
+                        break
+                    }
+                }
+                if op == "all" {
+                    Ok(CfgExpr::All(e))
+                } else {
+                    Ok(CfgExpr::Any(e))
+                }
+            }
+            Some(&Ok(Token::Ident("not"))) => {
+                self.t.next();
+                try!(self.eat(Token::LeftParen));
+                let e = try!(self.expr());
+                try!(self.eat(Token::RightParen));
+                Ok(CfgExpr::Not(Box::new(e)))
+            }
+            Some(&Ok(..)) => self.cfg().map(CfgExpr::Value),
+            Some(&Err(..)) => {
+                Err(self.t.next().unwrap().err().unwrap())
+            }
+            None => bail!("expected start of a cfg expression, \
+                           found nothing"),
+        }
+    }
+
+    fn cfg(&mut self) -> CargoResult<Cfg> {
+        match self.t.next() {
+            Some(Ok(Token::Ident(name))) => {
+                let e = if self.try(Token::Equals) {
+                    let val = match self.t.next() {
+                        Some(Ok(Token::String(s))) => s,
+                        Some(Ok(t)) => bail!("expected a string, found {}",
+                                             t.classify()),
+                        Some(Err(e)) => return Err(e),
+                        None => bail!("expected a string, found nothing"),
+                    };
+                    Cfg::KeyPair(name.to_string(), val.to_string())
+                } else {
+                    Cfg::Name(name.to_string())
+                };
+                Ok(e)
+            }
+            Some(Ok(t)) => bail!("expected identifier, found {}", t.classify()),
+            Some(Err(e)) => Err(e),
+            None => bail!("expected identifier, found nothing"),
+        }
+    }
+
+    fn try(&mut self, token: Token<'a>) -> bool {
+        match self.t.peek() {
+            Some(&Ok(ref t)) if token == *t => {}
+            _ => return false,
+        }
+        self.t.next();
+        true
+    }
+
+    fn eat(&mut self, token: Token<'a>) -> CargoResult<()> {
+        match self.t.next() {
+            Some(Ok(ref t)) if token == *t => Ok(()),
+            Some(Ok(t)) => bail!("expected {}, found {}", token.classify(),
+                                 t.classify()),
+            Some(Err(e)) => Err(e),
+            None => bail!("expected {}, but cfg expr ended", token.classify()),
+        }
+    }
+}
+
+impl<'a> Iterator for Tokenizer<'a> {
+    type Item = CargoResult<Token<'a>>;
+
+    fn next(&mut self) -> Option<CargoResult<Token<'a>>> {
+        loop {
+            match self.s.next() {
+                Some((_, ' ')) => {}
+                Some((_, '(')) => return Some(Ok(Token::LeftParen)),
+                Some((_, ')')) => return Some(Ok(Token::RightParen)),
+                Some((_, ',')) => return Some(Ok(Token::Comma)),
+                Some((_, '=')) => return Some(Ok(Token::Equals)),
+                Some((start, '"')) => {
+                    while let Some((end, ch)) = self.s.next() {
+                        if ch == '"' {
+                            return Some(Ok(Token::String(&self.orig[start+1..end])))
+                        }
+                    }
+                    return Some(Err(human(format!("unterminated string in cfg"))))
+                }
+                Some((start, ch)) if is_ident_start(ch) => {
+                    while let Some(&(end, ch)) = self.s.peek() {
+                        if !is_ident_rest(ch) {
+                            return Some(Ok(Token::Ident(&self.orig[start..end])))
+                        } else {
+                            self.s.next();
+                        }
+                    }
+                    return Some(Ok(Token::Ident(&self.orig[start..])))
+                }
+                Some((_, ch)) => {
+                    return Some(Err(human(format!("unexpected character in \
+                                                   cfg `{}`, expected parens, \
+                                                   a comma, an identifier, or \
+                                                   a string", ch))))
+                }
+                None => return None
+            }
+        }
+    }
+}
+
+fn is_ident_start(ch: char) -> bool {
+    ch == '_' || ('a' <= ch && ch <= 'z') || ('A' <= ch && ch <= 'Z')
+}
+
+fn is_ident_rest(ch: char) -> bool {
+    is_ident_start(ch) || ('0' <= ch && ch <= '9')
+}
+
+impl<'a> Token<'a> {
+    fn classify(&self) -> &str {
+        match *self {
+            Token::LeftParen => "`(`",
+            Token::RightParen => "`)`",
+            Token::Ident(..) => "an identifier",
+            Token::Comma => "`,`",
+            Token::Equals => "`=`",
+            Token::String(..) => "a string",
+        }
+    }
+}

--- a/src/cargo/util/mod.rs
+++ b/src/cargo/util/mod.rs
@@ -1,3 +1,4 @@
+pub use self::cfg::{Cfg, CfgExpr};
 pub use self::config::Config;
 pub use self::dependency_queue::Dependency;
 pub use self::dependency_queue::{DependencyQueue, Fresh, Dirty, Freshness};
@@ -30,8 +31,9 @@ pub mod to_url;
 pub mod toml;
 pub mod lev_distance;
 pub mod job;
+mod cfg;
 mod dependency_queue;
+mod rustc;
 mod sha256;
 mod shell_escape;
 mod vcs;
-mod rustc;

--- a/src/doc/manifest.md
+++ b/src/doc/manifest.md
@@ -166,7 +166,29 @@ The syntax of the requirement strings is described in the [crates.io
 guide](crates-io.html#using-cratesio-based-crates).
 
 Platform-specific dependencies take the same format, but are listed under the
-`target.$triple` section:
+`target` section. Normally Rust-like `#[cfg]` syntax will be used to define
+these sections:
+
+```toml
+[target.'cfg(windows)'.dependencies]
+winhttp = "0.4.0"
+
+[target.'cfg(unix)'.dependencies]
+openssl = "1.0.1"
+
+[target.'cfg(target_pointer_width = "32")'.dependencies]
+native = { path = "native/i686" }
+
+[target.'cfg(target_pointer_width = "64")'.dependencies]
+native = { path = "native/i686" }
+```
+
+Like with Rust, the syntax here supports the `not`, `any`, and `all` operators
+to combine various cfg name/value pairs. Note that the `cfg` syntax has only
+been available since Cargo 0.9.0 (Rust 1.8.0).
+
+In addition to `#[cfg]` syntax, Cargo also supports listing out the full target
+the dependencies would apply to:
 
 ```toml
 [target.x86_64-pc-windows-gnu.dependencies]
@@ -174,11 +196,6 @@ winhttp = "0.4.0"
 
 [target.i686-unknown-linux-gnu.dependencies]
 openssl = "1.0.1"
-native = { path = "native/i686" }
-
-[target.x86_64-unknown-linux-gnu.dependencies]
-openssl = "1.0.1"
-native = { path = "native/x86_64" }
 ```
 
 If you’re using a custom target specification, quote the full path and file

--- a/tests/test_cargo_cfg.rs
+++ b/tests/test_cargo_cfg.rs
@@ -1,0 +1,333 @@
+use std::str::FromStr;
+use std::fmt;
+
+use cargo::util::{Cfg, CfgExpr};
+use hamcrest::assert_that;
+
+use support::{project, execs, COMPILING, UPDATING, DOWNLOADING};
+use support::registry::Package;
+
+macro_rules! c {
+    ($a:ident) => (
+        Cfg::Name(stringify!($a).to_string())
+    );
+    ($a:ident = $e:expr) => (
+        Cfg::KeyPair(stringify!($a).to_string(), $e.to_string())
+    );
+}
+
+macro_rules! e {
+    (any($($t:tt),*)) => (CfgExpr::Any(vec![$(e!($t)),*]));
+    (all($($t:tt),*)) => (CfgExpr::All(vec![$(e!($t)),*]));
+    (not($($t:tt)*)) => (CfgExpr::Not(Box::new(e!($($t)*))));
+    (($($t:tt)*)) => (e!($($t)*));
+    ($($t:tt)*) => (CfgExpr::Value(c!($($t)*)));
+}
+
+fn good<T>(s: &str, expected: T)
+    where T: FromStr + PartialEq + fmt::Debug,
+          T::Err: fmt::Display
+{
+    let c = match T::from_str(s) {
+        Ok(c) => c,
+        Err(e) => panic!("failed to parse `{}`: {}", s, e),
+    };
+    assert_eq!(c, expected);
+}
+
+fn bad<T>(s: &str, err: &str)
+    where T: FromStr + fmt::Display, T::Err: fmt::Display
+{
+    let e = match T::from_str(s) {
+        Ok(cfg) => panic!("expected `{}` to not parse but got {}", s, cfg),
+        Err(e) => e.to_string(),
+    };
+    assert!(e.contains(err), "when parsing `{}`,\n\"{}\" not contained \
+                              inside: {}", s, err, e);
+}
+
+#[test]
+fn cfg_syntax() {
+    good("foo", c!(foo));
+    good("_bar", c!(_bar));
+    good(" foo", c!(foo));
+    good(" foo  ", c!(foo));
+    good(" foo  = \"bar\"", c!(foo = "bar"));
+    good("foo=\"\"", c!(foo = ""));
+    good(" foo=\"3\"      ", c!(foo = "3"));
+    good("foo = \"3 e\"", c!(foo = "3 e"));
+}
+
+#[test]
+fn cfg_syntax_bad() {
+    bad::<Cfg>("", "found nothing");
+    bad::<Cfg>(" ", "found nothing");
+    bad::<Cfg>("\t", "unexpected character");
+    bad::<Cfg>("7", "unexpected character");
+    bad::<Cfg>("=", "expected identifier");
+    bad::<Cfg>(",", "expected identifier");
+    bad::<Cfg>("(", "expected identifier");
+    bad::<Cfg>("foo (", "malformed cfg value");
+    bad::<Cfg>("bar =", "expected a string");
+    bad::<Cfg>("bar = \"", "unterminated string");
+    bad::<Cfg>("foo, bar", "malformed cfg value");
+}
+
+#[test]
+fn cfg_expr() {
+    good("foo", e!(foo));
+    good("_bar", e!(_bar));
+    good(" foo", e!(foo));
+    good(" foo  ", e!(foo));
+    good(" foo  = \"bar\"", e!(foo = "bar"));
+    good("foo=\"\"", e!(foo = ""));
+    good(" foo=\"3\"      ", e!(foo = "3"));
+    good("foo = \"3 e\"", e!(foo = "3 e"));
+
+    good("all()", e!(all()));
+    good("all(a)", e!(all(a)));
+    good("all(a, b)", e!(all(a, b)));
+    good("all(a, )", e!(all(a)));
+    good("not(a = \"b\")", e!(not(a = "b")));
+    good("not(all(a))", e!(not(all(a))));
+}
+
+#[test]
+fn cfg_expr_bad() {
+    bad::<CfgExpr>(" ", "found nothing");
+    bad::<CfgExpr>(" all", "expected `(`");
+    bad::<CfgExpr>("all(a", "expected `)`");
+    bad::<CfgExpr>("not", "expected `(`");
+    bad::<CfgExpr>("not(a", "expected `)`");
+    bad::<CfgExpr>("a = ", "expected a string");
+    bad::<CfgExpr>("all(not())", "expected identifier");
+    bad::<CfgExpr>("foo(a)", "consider using all() or any() explicitly");
+}
+
+#[test]
+fn cfg_matches() {
+    assert!(e!(foo).matches(&[c!(bar), c!(foo), c!(baz)]));
+    assert!(e!(any(foo)).matches(&[c!(bar), c!(foo), c!(baz)]));
+    assert!(e!(any(foo, bar)).matches(&[c!(bar)]));
+    assert!(e!(any(foo, bar)).matches(&[c!(foo)]));
+    assert!(e!(all(foo, bar)).matches(&[c!(foo), c!(bar)]));
+    assert!(e!(all(foo, bar)).matches(&[c!(foo), c!(bar)]));
+    assert!(e!(not(foo)).matches(&[c!(bar)]));
+    assert!(e!(not(foo)).matches(&[]));
+    assert!(e!(any((not(foo)), (all(foo, bar)))).matches(&[c!(bar)]));
+    assert!(e!(any((not(foo)), (all(foo, bar)))).matches(&[c!(foo), c!(bar)]));
+
+    assert!(!e!(foo).matches(&[]));
+    assert!(!e!(foo).matches(&[c!(bar)]));
+    assert!(!e!(foo).matches(&[c!(fo)]));
+    assert!(!e!(any(foo)).matches(&[]));
+    assert!(!e!(any(foo)).matches(&[c!(bar)]));
+    assert!(!e!(any(foo)).matches(&[c!(bar), c!(baz)]));
+    assert!(!e!(all(foo)).matches(&[c!(bar), c!(baz)]));
+    assert!(!e!(all(foo, bar)).matches(&[c!(bar)]));
+    assert!(!e!(all(foo, bar)).matches(&[c!(foo)]));
+    assert!(!e!(all(foo, bar)).matches(&[]));
+    assert!(!e!(not(bar)).matches(&[c!(bar)]));
+    assert!(!e!(not(bar)).matches(&[c!(baz), c!(bar)]));
+    assert!(!e!(any((not(foo)), (all(foo, bar)))).matches(&[c!(foo)]));
+}
+
+fn setup() {}
+
+test!(cfg_easy {
+    if !::is_nightly() { return }
+
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [package]
+            name = "a"
+            version = "0.0.1"
+            authors = []
+
+            [target.'cfg(unix)'.dependencies]
+            b = { path = 'b' }
+            [target."cfg(windows)".dependencies]
+            b = { path = 'b' }
+        "#)
+        .file("src/lib.rs", "extern crate b;")
+        .file("b/Cargo.toml", r#"
+            [package]
+            name = "b"
+            version = "0.0.1"
+            authors = []
+        "#)
+        .file("b/src/lib.rs", "");
+    assert_that(p.cargo_process("build").arg("-v"),
+                execs().with_status(0));
+});
+
+test!(dont_include {
+    if !::is_nightly() { return }
+
+    let other_family = if cfg!(unix) {"windows"} else {"unix"};
+    let p = project("foo")
+        .file("Cargo.toml", &format!(r#"
+            [package]
+            name = "a"
+            version = "0.0.1"
+            authors = []
+
+            [target.'cfg({})'.dependencies]
+            b = {{ path = 'b' }}
+        "#, other_family))
+        .file("src/lib.rs", "")
+        .file("b/Cargo.toml", r#"
+            [package]
+            name = "b"
+            version = "0.0.1"
+            authors = []
+        "#)
+        .file("b/src/lib.rs", "");
+    assert_that(p.cargo_process("build"),
+                execs().with_status(0).with_stdout(&format!("\
+{compiling} a v0.0.1 ([..])
+", compiling = COMPILING)));
+});
+
+test!(works_through_the_registry {
+    if !::is_nightly() { return }
+
+    Package::new("foo", "0.1.0").publish();
+    Package::new("bar", "0.1.0")
+            .target_dep("foo", "0.1.0", "cfg(unix)")
+            .target_dep("foo", "0.1.0", "cfg(windows)")
+            .publish();
+
+    let p = project("a")
+        .file("Cargo.toml", &r#"
+            [package]
+            name = "a"
+            version = "0.0.1"
+            authors = []
+
+            [dependencies]
+            bar = "0.1.0"
+        "#)
+        .file("src/lib.rs", "extern crate bar;");
+
+    assert_that(p.cargo_process("build"),
+                execs().with_status(0).with_stdout(&format!("\
+{updating} registry [..]
+{downloading} [..]
+{downloading} [..]
+{compiling} foo v0.1.0 ([..])
+{compiling} bar v0.1.0 ([..])
+{compiling} a v0.0.1 ([..])
+", compiling = COMPILING, updating = UPDATING, downloading = DOWNLOADING)));
+});
+
+test!(bad_target_spec {
+    let p = project("a")
+        .file("Cargo.toml", &r#"
+            [package]
+            name = "a"
+            version = "0.0.1"
+            authors = []
+
+            [target.'cfg(4)'.dependencies]
+            bar = "0.1.0"
+        "#)
+        .file("src/lib.rs", "");
+
+    assert_that(p.cargo_process("build"),
+                execs().with_status(101).with_stderr("\
+failed to parse manifest at `[..]`
+
+Caused by:
+  failed to parse `4` as a cfg expression
+
+Caused by:
+  unexpected character in cfg `4`, [..]
+"));
+});
+
+test!(bad_target_spec2 {
+    let p = project("a")
+        .file("Cargo.toml", &r#"
+            [package]
+            name = "a"
+            version = "0.0.1"
+            authors = []
+
+            [target.'cfg(foo =)'.dependencies]
+            bar = "0.1.0"
+        "#)
+        .file("src/lib.rs", "");
+
+    assert_that(p.cargo_process("build"),
+                execs().with_status(101).with_stderr("\
+failed to parse manifest at `[..]`
+
+Caused by:
+  failed to parse `foo =` as a cfg expression
+
+Caused by:
+  expected a string, found nothing
+"));
+});
+
+test!(multiple_match_ok {
+    if !::is_nightly() { return }
+
+    let p = project("foo")
+        .file("Cargo.toml", &format!(r#"
+            [package]
+            name = "a"
+            version = "0.0.1"
+            authors = []
+
+            [target.'cfg(unix)'.dependencies]
+            b = {{ path = 'b' }}
+            [target.'cfg(target_family = "unix")'.dependencies]
+            b = {{ path = 'b' }}
+            [target."cfg(windows)".dependencies]
+            b = {{ path = 'b' }}
+            [target.'cfg(target_family = "windows")'.dependencies]
+            b = {{ path = 'b' }}
+            [target."cfg(any(windows, unix))".dependencies]
+            b = {{ path = 'b' }}
+
+            [target.{}.dependencies]
+            b = {{ path = 'b' }}
+        "#, ::rustc_host()))
+        .file("src/lib.rs", "extern crate b;")
+        .file("b/Cargo.toml", r#"
+            [package]
+            name = "b"
+            version = "0.0.1"
+            authors = []
+        "#)
+        .file("b/src/lib.rs", "");
+    assert_that(p.cargo_process("build").arg("-v"),
+                execs().with_status(0));
+});
+
+test!(any_ok {
+    if !::is_nightly() { return }
+
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [package]
+            name = "a"
+            version = "0.0.1"
+            authors = []
+
+            [target."cfg(any(windows, unix))".dependencies]
+            b = { path = 'b' }
+        "#)
+        .file("src/lib.rs", "extern crate b;")
+        .file("b/Cargo.toml", r#"
+            [package]
+            name = "b"
+            version = "0.0.1"
+            authors = []
+        "#)
+        .file("b/src/lib.rs", "");
+    assert_that(p.cargo_process("build").arg("-v"),
+                execs().with_status(0));
+});

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -70,6 +70,7 @@ mod test_cargo_verify_project;
 mod test_cargo_version;
 mod test_shell;
 mod test_cargo_death;
+mod test_cargo_cfg;
 
 thread_local!(static RUSTC: Rustc = Rustc::new("rustc").unwrap());
 


### PR DESCRIPTION
This commit is an implementation of [RFC 1361][rfc] which is an extension of
Cargo's `target` section in `Cargo.toml` to allow the use of `#[cfg]`-like
expressions for target-specific dependencies. Now that the compiler has been
extended with `--print cfg` each invocation of Cargo will scrape this output and
learn about the relevant `#[cfg]` directives in play for the target being
compiled. Cargo will then use these directives to decide whether a dependency
should be activated or not.

This should allow definition of dependencies along the lines of:

    [target.'cfg(unix)'.dependencies]
    [target.'cfg(target_os = "linux")'.dependencies]
    [target.'cfg(windows)'.dependencies]

Which is much more ergonomic and robust than listing all the triples out!