### PR TITLE
Replace deprecated slice::connect with slice::join.

### DIFF
--- a/src/cargo/core/package_id_spec.rs
+++ b/src/cargo/core/package_id_spec.rs
@@ -185,14 +185,13 @@ fn url(s: &str) -> url::ParseResult<Url> {
 }
 
 impl fmt::Display for PackageIdSpec {
-    #[allow(deprecated)] // connect => join in 1.3
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let mut printed_name = false;
         match self.url {
             Some(ref url) => {
                 if url.scheme == "cargo" {
                     try!(write!(f, "{}/{}", url.host().unwrap(),
-                                url.path().unwrap().connect("/")));
+                                url.path().unwrap().join("/")));
                 } else {
                     try!(write!(f, "{}", url));
                 }

--- a/src/cargo/core/resolver/mod.rs
+++ b/src/cargo/core/resolver/mod.rs
@@ -387,7 +387,6 @@ fn find_candidate(backtrack_stack: &mut Vec<BacktrackFrame>,
     None
 }
 
-#[allow(deprecated)] // connect => join in 1.3
 fn activation_error(cx: &Context,
                     registry: &mut Registry,
                     parent: &Summary,
@@ -424,7 +423,7 @@ fn activation_error(cx: &Context,
                                         .map(|v| v.version())
                                         .map(|v| v.to_string())
                                         .collect::<Vec<_>>()
-                                        .connect(", ")));
+                                        .join(", ")));
 
         return human(msg)
     }
@@ -648,7 +647,6 @@ impl Context {
         self.activations.get(&key).map(|v| &v[..]).unwrap_or(&[])
     }
 
-    #[allow(deprecated)] // connect => join in 1.3
     fn resolve_features(&mut self, parent: &Summary, method: &Method)
             -> CargoResult<Vec<(Dependency, Vec<String>)>> {
         let dev_deps = match *method {
@@ -690,7 +688,7 @@ impl Context {
             let unknown = feature_deps.keys().map(|s| &s[..])
                                       .collect::<Vec<&str>>();
             if !unknown.is_empty() {
-                let features = unknown.connect(", ");
+                let features = unknown.join(", ");
                 bail!("Package `{}` does not have these features: `{}`",
                       parent.package_id(), features)
             }

--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -139,7 +139,6 @@ pub fn resolve_dependencies<'a>(root_package: &Package,
     Ok((packages, resolved_with_overrides, registry.move_sources()))
 }
 
-#[allow(deprecated)] // connect => join in 1.3
 pub fn compile_pkg<'a>(root_package: &Package,
                        source: Option<Box<Source + 'a>>,
                        options: &CompileOptions<'a>)
@@ -178,7 +177,7 @@ pub fn compile_pkg<'a>(root_package: &Package,
 
     if !spec.is_empty() && !invalid_spec.is_empty() {
         bail!("could not find package matching spec `{}`",
-              invalid_spec.connect(", "))
+              invalid_spec.join(", "))
     }
 
     let to_builds = packages.iter().filter(|p| pkgids.contains(&p.package_id()))

--- a/src/cargo/ops/cargo_install.rs
+++ b/src/cargo/ops/cargo_install.rs
@@ -162,12 +162,11 @@ fn select_pkg<'a, T>(mut source: T,
             };
             return Ok((pkg.clone(), Box::new(source)));
 
-            #[allow(deprecated)] // connect => join in 1.3
             fn multi_err(kind: &str, mut pkgs: Vec<&Package>) -> String {
                 pkgs.sort_by(|a, b| a.name().cmp(b.name()));
                 format!("multiple packages with {} found: {}", kind,
                         pkgs.iter().map(|p| p.name()).collect::<Vec<_>>()
-                            .connect(", "))
+                            .join(", "))
             }
         }
     }

--- a/src/cargo/ops/cargo_package.rs
+++ b/src/cargo/ops/cargo_package.rs
@@ -66,7 +66,6 @@ pub fn package(manifest_path: &Path,
 
 // check that the package has some piece of metadata that a human can
 // use to tell what the package is about.
-#[allow(deprecated)] // connect => join in 1.3
 fn check_metadata(pkg: &Package, config: &Config) -> CargoResult<()> {
     let md = pkg.manifest().metadata();
 
@@ -84,7 +83,7 @@ fn check_metadata(pkg: &Package, config: &Config) -> CargoResult<()> {
     lacking!(description, license || license_file, documentation || homepage || repository);
 
     if !missing.is_empty() {
-        let mut things = missing[..missing.len() - 1].connect(", ");
+        let mut things = missing[..missing.len() - 1].join(", ");
         // things will be empty if and only if length == 1 (i.e. the only case
         // to have no `or`).
         if !things.is_empty() {

--- a/src/cargo/ops/cargo_test.rs
+++ b/src/cargo/ops/cargo_test.rs
@@ -12,7 +12,6 @@ pub struct TestOptions<'a> {
 
 
 
-#[allow(deprecated)] // connect => join in 1.3
 pub fn run_tests(manifest_path: &Path,
                  options: &TestOptions,
                  test_args: &[String]) -> CargoResult<Option<CargoTestError>> {
@@ -103,7 +102,6 @@ fn run_unit_tests(options: &TestOptions,
     Ok(errors)
 }
 
-#[allow(deprecated)] // connect => join in 1.3
 fn run_doc_tests(options: &TestOptions,
                  test_args: &[String],
                  compilation: &Compilation)
@@ -133,7 +131,7 @@ fn run_doc_tests(options: &TestOptions,
             }
 
             if test_args.len() > 0 {
-                p.arg("--test-args").arg(&test_args.connect(" "));
+                p.arg("--test-args").arg(&test_args.join(" "));
             }
 
             for cfg in compilation.cfgs.iter() {

--- a/src/cargo/util/errors.rs
+++ b/src/cargo/util/errors.rs
@@ -140,14 +140,13 @@ pub struct CargoTestError {
 }
 
 impl CargoTestError {
-    #[allow(deprecated)] // connect => join in 1.3
     pub fn new(errors: Vec<ProcessError>) -> Self {
         if errors.is_empty() {
             panic!("Cannot create CargoTestError from empty Vec")
         }
         let desc = errors.iter().map(|error| error.desc.clone())
                                 .collect::<Vec<String>>()
-                                .connect("\n");
+                                .join("\n");
         CargoTestError {
             desc: desc,
             exit: errors[0].exit,


### PR DESCRIPTION
std::slice::SliceConcatExt::connect() was deprecated in 1.3.0
and renamed to join(). Now that 1.6.0 is the stable release,
we can transition to the newer method name.