### PR TITLE
tests: remove unused variable

### DIFF
--- a/tests/test_cargo_compile_plugins.rs
+++ b/tests/test_cargo_compile_plugins.rs
@@ -111,9 +111,6 @@ test!(plugin_with_dynamic_native_dependency {
         lib.starts_with(env::consts::DLL_PREFIX) &&
             lib.ends_with(env::consts::DLL_SUFFIX)
     }).unwrap();
-    let libname = lib.file_name().unwrap().to_str().unwrap();
-    let libname = &libname[env::consts::DLL_PREFIX.len()..
-                           libname.len() - env::consts::DLL_SUFFIX.len()];
 
     let foo = project("foo")
         .file("Cargo.toml", r#"


### PR DESCRIPTION
It became unused after https://github.com/rust-lang/cargo/commit/3194a23a706c17037556c11e7bf4303ea233f208

Is this intentional that unused variables are not denied in tests?