### PR TITLE
Set target using config file

### DIFF
--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -412,6 +412,7 @@ fn source_ids_from_config(config: &Config, cur_path: &Path)
 /// configured options are:
 ///
 /// * build.jobs
+/// * build.target
 /// * target.$target.ar
 /// * target.$target.linker
 /// * target.$target.libfoo.metadata
@@ -432,6 +433,8 @@ fn scrape_build_config(config: &Config,
         None => None,
     };
     let jobs = jobs.or(cfg_jobs).unwrap_or(::num_cpus::get() as u32);
+    let cfg_target = try!(config.get_string("build.target")).map(|s| s.0);
+    let target = target.or(cfg_target);
     let mut base = ops::BuildConfig {
         jobs: jobs,
         requested_target: target.clone(),

--- a/src/doc/config.md
+++ b/src/doc/config.md
@@ -84,6 +84,7 @@ timeout = 60000   # Timeout for each HTTP request, in milliseconds
 jobs = 1               # number of jobs to run by default (default to # cpus)
 rustc = "rustc"        # the rust compiler tool
 rustdoc = "rustdoc"    # the doc generator tool
+target = "triple"      # build for the target triple
 target-dir = "target"  # path of where to place all generated artifacts
 ```
 


### PR DESCRIPTION
Fixed #2332.

This PR adds `build.target` to the Cargo config file, which behaves in the same way as passing `--target` to Cargo.  Example `.cargo/config`:

```
[build]
target = "thumbv6m-none-eabi"
```

Similar to how `--jobs` overrides `build.jobs`, `--target` will override `build.target`.

I added documentation to `config.md`, and a test to `test_cargo_cross_compile.rs`.  I couldn't get cross compile working on my machine for `cargo test`.  Hopefully travis passes it.

This is my first PR against Cargo; sorry if I missed any procedures.