### PR TITLE
Fix interception of subcommand --version flag by cargo

### DIFF
--- a/src/bin/cargo.rs
+++ b/src/bin/cargo.rs
@@ -17,6 +17,7 @@ use cargo::util::{self, CliResult, lev_distance, Config, human, CargoResult};
 pub struct Flags {
     flag_list: bool,
     flag_verbose: bool,
+    flag_version: bool,
     flag_quiet: bool,
     flag_color: Option<String>,
     arg_command: String,
@@ -103,6 +104,11 @@ fn execute(flags: Flags, config: &Config) -> CliResult<Option<()>> {
     try!(config.shell().set_color_config(flags.flag_color.as_ref().map(|s| &s[..])));
 
     init_git_transports(config);
+
+    if flags.flag_version {
+        println!("{}", cargo::version());
+        return Ok(None)
+    }
 
     if flags.flag_list {
         println!("Installed Commands:");

--- a/src/cargo/lib.rs
+++ b/src/cargo/lib.rs
@@ -248,8 +248,7 @@ fn flags_from_args<T>(usage: &str, args: &[String],
     let docopt = Docopt::new(usage).unwrap()
                                    .options_first(options_first)
                                    .argv(args.iter().map(|s| &s[..]))
-                                   .help(true)
-                                   .version(Some(version()));
+                                   .help(true);
     docopt.decode().map_err(|e| {
         let code = if e.fatal() {1} else {0};
         CliError::from_error(human(e.to_string()), code)

--- a/tests/test_cargo_version.rs
+++ b/tests/test_cargo_version.rs
@@ -16,3 +16,32 @@ test!(simple {
                                                             cargo::version())));
 
 });
+
+#[derive(RustcDecodable)]
+struct FooFlags {
+    flag_version: bool,
+}
+
+fn real_main(flags: FooFlags, _config: &cargo::Config) ->
+        cargo::CliResult<Option<String>> {
+    if flags.flag_version {
+        Ok(Some("foo <version>".to_string()))
+    } else {
+        Ok(None)
+    }
+}
+
+test!(subcommand_with_version_using_exec_main_without_stdin {
+    let usage = "
+Usage: cargo foo [--version]
+
+Options:
+    -V, --version       Print version info
+";
+    let args: Vec<String> = vec!["cargo", "foo", "--version"]
+        .into_iter().map(|s| s.to_string()).collect();
+    let result = cargo::call_main_without_stdin(
+                real_main, &cargo::Config::default().unwrap(),
+                usage, &args, false);
+    assert_eq!(result.unwrap(), Some("foo <version>".to_string()));
+});


### PR DESCRIPTION
Addresses #2286: when subcommand used `execute_main_without_stdin` and provided `--version` flag, cargo intercepted it and printed it's own version.