### PR TITLE
tests: deny warnings

### DIFF
--- a/tests/resolve.rs
+++ b/tests/resolve.rs
@@ -1,3 +1,5 @@
+#![deny(warnings)]
+
 extern crate hamcrest;
 extern crate cargo;
 

--- a/tests/test_cargo_new.rs
+++ b/tests/test_cargo_new.rs
@@ -7,7 +7,7 @@ use support::{execs, paths};
 use support::paths::CargoPathExt;
 use hamcrest::{assert_that, existing_file, existing_dir, is_not};
 
-use cargo::util::{process, ProcessBuilder};
+use cargo::util::ProcessBuilder;
 
 fn setup() {
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,3 +1,5 @@
+#![deny(warnings)]
+
 extern crate bufstream;
 extern crate cargo;
 extern crate filetime;


### PR DESCRIPTION
Warnings from unrelated tests can be a little disturbing. Maybe we should be stricter about them?

You can always temporary `#![allow(unused, warnings)]` in the module you are writing if you are in the middle of a new development and don't want the compiler putting a spoke in the wheel.