### PR TITLE
fix: prefer env variables over config files

### DIFF
--- a/tests/test_cargo_compile.rs
+++ b/tests/test_cargo_compile.rs
@@ -1913,9 +1913,9 @@ test!(custom_target_dir {
     fs::create_dir(p.root().join(".cargo")).unwrap();
     File::create(p.root().join(".cargo/config")).unwrap().write_all(br#"
         [build]
-        target-dir = "bar/target"
+        target-dir = "foo/target"
     "#).unwrap();
-    assert_that(p.cargo("build").env("CARGO_TARGET_DIR", "foo/target"),
+    assert_that(p.cargo("build").env("CARGO_TARGET_DIR", "bar/target"),
                 execs().with_status(0));
     assert_that(&p.root().join("bar/target/debug").join(&exe_name),
                 existing_file());


### PR DESCRIPTION
This patches fixes the precedence in these cases:

- CARGO_TARGET_ROOT is now preferred over build.target-dir
- RUSTC is now preferred over build.rustc
- RUSTDOC is now preferred over build.rustdoc

r? @alexcrichton 