### PR TITLE
Remove config references to the `ar` tool

### DIFF
--- a/src/doc/config.md
+++ b/src/doc/config.md
@@ -59,16 +59,14 @@ vcs = "none"
 # literal string "$triple", and it will apply whenever that target triple is
 # being compiled to.
 [target]
-# For Cargo builds which do not mention --target, these are the ar/linker tools
-# which are passed to rustc to use (via `-C ar=` and `-C linker=`). By default
-# these flags are not passed to the compiler.
-ar = ".."
+# For Cargo builds which do not mention --target, this is the linker
+# which is passed to rustc (via `-C linker=`). By default this flag is not
+# passed to the compiler.
 linker = ".."
 
 [target.$triple]
-# Similar to the above ar/linker tool configuration, but this only applies to
+# Similar to the above linker configuration, but this only applies to
 # when the `$triple` is being compiled for.
-ar = ".."
 linker = ".."
 
 # Configuration keys related to the registry


### PR DESCRIPTION
This is largely no longer needed as we bundle llvm-ar and use that (and it's
cross platform). Note that the underlying support still exists in Cargo as the
flag hasn't been removed from the compiler outright, and older compilers may
still be in use. Just no need to document it so prominently when it's no longer
needed!