### PR TITLE
add ability to optimize dependencies in dev

### DIFF
--- a/src/cargo/core/mod.rs
+++ b/src/cargo/core/mod.rs
@@ -1,5 +1,5 @@
 pub use self::dependency::{Dependency, DependencyInner};
-pub use self::manifest::{Manifest, Target, TargetKind, Profile, LibKind, Profiles};
+pub use self::manifest::{Manifest, Target, TargetKind, Profile, ProfileId, LibKind, Profiles};
 pub use self::package::{Package, PackageSet};
 pub use self::package_id::{PackageId, Metadata};
 pub use self::package_id_spec::PackageIdSpec;

--- a/src/cargo/core/package.rs
+++ b/src/cargo/core/package.rs
@@ -88,6 +88,10 @@ impl Package {
     pub fn generate_metadata(&self) -> Metadata {
         self.package_id().generate_metadata(self.root())
     }
+
+    pub fn is_local(&self) -> bool {
+        self.manifest.summary().source_id().is_path()
+    }
 }
 
 impl fmt::Display for Package {

--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -240,6 +240,7 @@ pub fn compile_pkg<'a>(root_package: &Package,
         let mut build_config = try!(scrape_build_config(config, jobs, target));
         build_config.exec_engine = exec_engine.clone();
         build_config.release = release;
+        build_config.deps_profile = root_package.manifest().deps_profile().cloned();
         if let CompileMode::Doc { deps } = mode {
             build_config.doc_all = deps;
         }

--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -240,7 +240,9 @@ pub fn compile_pkg<'a>(root_package: &Package,
         let mut build_config = try!(scrape_build_config(config, jobs, target));
         build_config.exec_engine = exec_engine.clone();
         build_config.release = release;
-        build_config.deps_profile = root_package.manifest().deps_profile().cloned();
+        build_config.deps_profile = if release { &profiles.release } else { &profiles.dev }
+            .deps_profile.clone();
+
         if let CompileMode::Doc { deps } = mode {
             build_config.doc_all = deps;
         }

--- a/src/cargo/ops/cargo_rustc/context.rs
+++ b/src/cargo/ops/cargo_rustc/context.rs
@@ -374,7 +374,7 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
                 Unit {
                     pkg: pkg,
                     target: t,
-                    profile: self.lib_profile(id),
+                    profile: self.lib_profile(pkg),
                     kind: unit.kind.for_target(t),
                 }
             })
@@ -404,7 +404,7 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
                 Unit {
                     pkg: unit.pkg,
                     target: t,
-                    profile: self.lib_profile(id),
+                    profile: self.lib_profile(unit.pkg),
                     kind: unit.kind.for_target(t),
                 }
             }));
@@ -477,7 +477,7 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
             ret.push(Unit {
                 pkg: dep,
                 target: lib,
-                profile: self.lib_profile(dep.package_id()),
+                profile: self.lib_profile(dep),
                 kind: unit.kind.for_target(lib),
             });
             if self.build_config.doc_all {
@@ -523,7 +523,7 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
             Unit {
                 pkg: unit.pkg,
                 target: t,
-                profile: self.lib_profile(unit.pkg.package_id()),
+                profile: self.lib_profile(unit.pkg),
                 kind: unit.kind.for_target(t),
             }
         })
@@ -576,9 +576,16 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
         self.build_config.requested_target.as_ref().map(|s| &s[..])
     }
 
-    pub fn lib_profile(&self, _pkg: &PackageId) -> &'a Profile {
+    pub fn lib_profile(&self, pkg: &Package) -> &'a Profile {
         if self.build_config.release {
-            &self.profiles.release
+            return &self.profiles.release
+        }
+        if pkg.is_local() {
+            return &self.profiles.dev
+        }
+
+        if let Some(ref id) = self.build_config.deps_profile {
+            self.profiles.by_id(id)
         } else {
             &self.profiles.dev
         }

--- a/src/cargo/ops/cargo_rustc/context.rs
+++ b/src/cargo/ops/cargo_rustc/context.rs
@@ -577,18 +577,12 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
     }
 
     pub fn lib_profile(&self, pkg: &Package) -> &'a Profile {
-        if self.build_config.release {
-            return &self.profiles.release
+        if !pkg.is_local() {
+            if let Some(ref id) = self.build_config.deps_profile {
+                return self.profiles.by_id(id)
+            }
         }
-        if pkg.is_local() {
-            return &self.profiles.dev
-        }
-
-        if let Some(ref id) = self.build_config.deps_profile {
-            self.profiles.by_id(id)
-        } else {
-            &self.profiles.dev
-        }
+        if self.build_config.release { &self.profiles.release } else { &self.profiles.dev }
     }
 
     pub fn build_script_profile(&self, _pkg: &PackageId) -> &'a Profile {

--- a/src/cargo/ops/cargo_rustc/custom_build.rs
+++ b/src/cargo/ops/cargo_rustc/custom_build.rs
@@ -95,7 +95,7 @@ fn build_work<'a, 'cfg>(cx: &mut Context<'a, 'cfg>, unit: &Unit<'a>)
     // environment variables. Note that the profile-related environment
     // variables are not set with this the build script's profile but rather the
     // package's library profile.
-    let profile = cx.lib_profile(unit.pkg.package_id());
+    let profile = cx.lib_profile(unit.pkg);
     let to_exec = to_exec.into_os_string();
     let mut p = try!(super::process(CommandType::Host(to_exec), unit.pkg, cx));
     p.env("OUT_DIR", &build_output)

--- a/src/cargo/ops/cargo_rustc/mod.rs
+++ b/src/cargo/ops/cargo_rustc/mod.rs
@@ -7,7 +7,7 @@ use std::path::{self, PathBuf};
 use std::sync::Arc;
 
 use core::{SourceMap, Package, PackageId, PackageSet, Target, Resolve};
-use core::{Profile, Profiles};
+use core::{Profile, ProfileId, Profiles};
 use util::{self, CargoResult, human};
 use util::{Config, internal, ChainError, profile, join_paths};
 
@@ -42,6 +42,7 @@ pub struct BuildConfig {
     pub exec_engine: Option<Arc<Box<ExecEngine>>>,
     pub release: bool,
     pub doc_all: bool,
+    pub deps_profile: Option<ProfileId>,
 }
 
 #[derive(Clone, Default)]

--- a/src/cargo/ops/cargo_rustc/mod.rs
+++ b/src/cargo/ops/cargo_rustc/mod.rs
@@ -449,7 +449,7 @@ fn build_base_args(cx: &Context,
     let Profile {
         opt_level, lto, codegen_units, ref rustc_args, debuginfo,
         debug_assertions, rpath, test, doc: _doc, run_custom_build,
-        rustdoc_args: _,
+        rustdoc_args: _, deps_profile: _,
     } = *unit.profile;
     assert!(!run_custom_build);
 

--- a/tests/test_cargo_profiles.rs
+++ b/tests/test_cargo_profiles.rs
@@ -116,11 +116,12 @@ test!(dependencies_profile_in_dev {
     let p = project("foo")
         .file("Cargo.toml", r#"
             [package]
-            dependencies-profile="release"
-
             name = "test"
             version = "0.0.0"
             authors = []
+
+            [profile.dev]
+            dependencies-profile = "release"
 
             [profile.release]
             opt-level = 3
@@ -167,7 +168,6 @@ test!(dependencies_profile_in_release {
     let p = project("foo")
         .file("Cargo.toml", r#"
             [package]
-            dependencies-profile="dev"
 
             name = "test"
             version = "0.0.0"
@@ -175,6 +175,9 @@ test!(dependencies_profile_in_release {
 
             [profile.dev]
             opt-level = 1
+
+            [profile.release]
+            dependencies-profile = "dev"
 
             [dependencies]
             baz = "*"
@@ -214,3 +217,23 @@ test!(dependencies_profile_in_release {
             dir = p.root().display())
         ));
 });
+
+test!(invalid_dependencies_profile {
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [package]
+            name = "test"
+            version = "0.0.0"
+            authors = []
+
+            [profile.dev]
+            dependencies-profile = "spam"
+        "#);
+
+    assert_that(p.cargo_process("build").arg("-v"),
+        execs().with_status(101).with_stderr("failed to parse manifest at [..]
+
+Caused by:
+no such profile: spam"));
+});
+


### PR DESCRIPTION
fixes #1359 

Ok, I've tried to implement what we've discussed so far (with "non-local", and a package level toml option). 

>I suspect that it's likely to be a local decision per-profile (especially if we grow custom profiles)

I agree about "local decision", but I'm not sure about "per-profile". As I see it, several profiles may be used for different packages during a single `cargo` run. But the decision about profile for deps should be unique withing a single `cargo` run. 

I am afraid, we won't be able to find the right solution here until we have custom profiles, improve dev/test thing and resolve https://github.com/rust-lang/cargo/issues/2085. What would be the conservative option here? Overriding profile for dependencies only in dev mode?