### PR TITLE
Implement top-level overrides

### DIFF
--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -1,11 +1,10 @@
-use std::default::Default;
 use std::fmt;
 use std::path::{PathBuf, Path};
 
 use semver::Version;
 use rustc_serialize::{Encoder, Encodable};
 
-use core::{Dependency, PackageId, Summary};
+use core::{Dependency, PackageId, PackageIdSpec, Summary};
 use core::package_id::Metadata;
 use util::{CargoResult, human};
 
@@ -20,7 +19,8 @@ pub struct Manifest {
     include: Vec<String>,
     metadata: ManifestMetadata,
     profiles: Profiles,
-    publish: bool
+    publish: bool,
+    replace: Vec<(PackageIdSpec, Dependency)>,
 }
 
 /// General metadata about a package which is just blindly uploaded to the
@@ -165,7 +165,8 @@ impl Manifest {
                links: Option<String>,
                metadata: ManifestMetadata,
                profiles: Profiles,
-               publish: bool) -> Manifest {
+               publish: bool,
+               replace: Vec<(PackageIdSpec, Dependency)>) -> Manifest {
         Manifest {
             summary: summary,
             targets: targets,
@@ -176,6 +177,7 @@ impl Manifest {
             metadata: metadata,
             profiles: profiles,
             publish: publish,
+            replace: replace,
         }
     }
 
@@ -191,6 +193,7 @@ impl Manifest {
     pub fn warnings(&self) -> &[String] { &self.warnings }
     pub fn profiles(&self) -> &Profiles { &self.profiles }
     pub fn publish(&self) -> bool { self.publish }
+    pub fn replace(&self) -> &[(PackageIdSpec, Dependency)] { &self.replace }
     pub fn links(&self) -> Option<&str> {
         self.links.as_ref().map(|s| &s[..])
     }

--- a/src/cargo/ops/cargo_generate_lockfile.rs
+++ b/src/cargo/ops/cargo_generate_lockfile.rs
@@ -115,10 +115,8 @@ pub fn update_lockfile(manifest_path: &Path,
             return
         }
         set.insert(dep);
-        if let Some(deps) =  resolve.deps(dep) {
-            for dep in deps {
-                fill_with_deps(resolve, dep, set, visited);
-            }
+        for dep in resolve.deps(dep) {
+            fill_with_deps(resolve, dep, set, visited);
         }
     }
 

--- a/src/cargo/ops/cargo_output_metadata.rs
+++ b/src/cargo/ops/cargo_output_metadata.rs
@@ -92,9 +92,7 @@ impl Encodable for MetadataResolve {
             nodes: resolve.iter().map(|id| {
                 Node {
                     id: id,
-                    dependencies: resolve.deps(id)
-                        .map(|it| it.collect())
-                        .unwrap_or(Vec::new()),
+                    dependencies: resolve.deps(id).collect(),
                 }
             }).collect(),
         };

--- a/src/cargo/ops/cargo_rustc/context.rs
+++ b/src/cargo/ops/cargo_rustc/context.rs
@@ -351,7 +351,7 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
         }
 
         let id = unit.pkg.package_id();
-        let deps = self.resolve.deps(id).into_iter().flat_map(|a| a);
+        let deps = self.resolve.deps(id);
         let mut ret = try!(deps.filter(|dep| {
             unit.pkg.dependencies().iter().filter(|d| {
                 d.name() == dep.name()
@@ -479,8 +479,7 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
 
     /// Returns the dependencies necessary to document a package
     fn doc_deps(&self, unit: &Unit<'a>) -> CargoResult<Vec<Unit<'a>>> {
-        let deps = self.resolve.deps(unit.pkg.package_id()).into_iter();
-        let deps = deps.flat_map(|a| a).filter(|dep| {
+        let deps = self.resolve.deps(unit.pkg.package_id()).filter(|dep| {
             unit.pkg.dependencies().iter().filter(|d| {
                 d.name() == dep.name()
             }).any(|dep| {

--- a/src/cargo/ops/lockfile.rs
+++ b/src/cargo/ops/lockfile.rs
@@ -115,6 +115,8 @@ fn emit_package(dep: &toml::Table, out: &mut String) {
             out.push_str("]\n");
         }
         out.push_str("\n");
+    } else if dep.contains_key("replace") {
+        out.push_str(&format!("replace = {}\n\n", lookup(dep, "replace")));
     }
 }
 

--- a/src/cargo/ops/resolve.rs
+++ b/src/cargo/ops/resolve.rs
@@ -40,7 +40,6 @@ pub fn resolve_with_previous<'a>(registry: &mut PackageRegistry,
                                  previous: Option<&'a Resolve>,
                                  to_avoid: Option<&HashSet<&'a PackageId>>)
                                  -> CargoResult<Resolve> {
-
     try!(registry.add_sources(&[package.package_id().source_id()
                                        .clone()]));
 
@@ -52,20 +51,14 @@ pub fn resolve_with_previous<'a>(registry: &mut PackageRegistry,
     // TODO: This seems like a hokey reason to single out the registry as being
     //       different
     let mut to_avoid_sources = HashSet::new();
-    match to_avoid {
-        Some(set) => {
-            for package_id in set.iter() {
-                let source = package_id.source_id();
-                if !source.is_registry() {
-                    to_avoid_sources.insert(source);
-                }
-            }
-        }
-        None => {}
+    if let Some(to_avoid) = to_avoid {
+        to_avoid_sources.extend(to_avoid.iter()
+                                        .map(|p| p.source_id())
+                                        .filter(|s| !s.is_registry()));
     }
 
     let summary = package.summary().clone();
-    let summary = match previous {
+    let (summary, replace) = match previous {
         Some(r) => {
             // In the case where a previous instance of resolve is available, we
             // want to lock as many packages as possible to the previous version
@@ -89,31 +82,44 @@ pub fn resolve_with_previous<'a>(registry: &mut PackageRegistry,
             //    to the previously resolved version if the dependency listed
             //    still matches the locked version.
             for node in r.iter().filter(|p| keep(p, to_avoid, &to_avoid_sources)) {
-                let deps = r.deps(node).into_iter().flat_map(|i| i)
+                let deps = r.deps_not_replaced(node)
                             .filter(|p| keep(p, to_avoid, &to_avoid_sources))
                             .cloned().collect();
                 registry.register_lock(node.clone(), deps);
             }
 
-            let map = r.deps(r.root()).into_iter().flat_map(|i| i).filter(|p| {
-                keep(p, to_avoid, &to_avoid_sources)
-            }).map(|d| {
-                (d.name(), d)
-            }).collect::<HashMap<_, _>>();
-            summary.map_dependencies(|d| {
-                match map.get(d.name()) {
-                    Some(&lock) if d.matches_id(lock) => d.lock_to(lock),
-                    _ => d,
+            let summary = {
+                let map = r.deps_not_replaced(r.root()).filter(|p| {
+                    keep(p, to_avoid, &to_avoid_sources)
+                }).map(|d| {
+                    (d.name(), d)
+                }).collect::<HashMap<_, _>>();
+
+                summary.map_dependencies(|dep| {
+                    match map.get(dep.name()) {
+                        Some(&lock) if dep.matches_id(lock) => dep.lock_to(lock),
+                        _ => dep,
+                    }
+                })
+            };
+            let replace = package.manifest().replace();
+            let replace = replace.iter().map(|&(ref spec, ref dep)| {
+                for (key, val) in r.replacements().iter() {
+                    if spec.matches(key) && dep.matches_id(val) {
+                        return (spec.clone(), dep.clone().lock_to(val))
+                    }
                 }
-            })
+                (spec.clone(), dep.clone())
+            }).collect::<Vec<_>>();
+            (summary, replace)
         }
-        None => summary,
+        None => (summary, package.manifest().replace().to_owned()),
     };
 
-    let mut resolved = try!(resolver::resolve(&summary, &method, registry));
-    match previous {
-        Some(r) => resolved.copy_metadata(r),
-        None => {}
+    let mut resolved = try!(resolver::resolve(&summary, &method, &replace,
+                                              registry));
+    if let Some(previous) = previous {
+        resolved.copy_metadata(previous);
     }
     return Ok(resolved);
 

--- a/tests/resolve.rs
+++ b/tests/resolve.rs
@@ -18,7 +18,7 @@ fn resolve<R: Registry>(pkg: PackageId, deps: Vec<Dependency>,
                         -> CargoResult<Vec<PackageId>> {
     let summary = Summary::new(pkg, deps, HashMap::new()).unwrap();
     let method = Method::Everything;
-    Ok(try!(resolver::resolve(&summary, &method, registry)).iter().map(|p| {
+    Ok(try!(resolver::resolve(&summary, &method, &[], registry)).iter().map(|p| {
         p.clone()
     }).collect())
 }

--- a/tests/test_cargo_overrides.rs
+++ b/tests/test_cargo_overrides.rs
@@ -1,0 +1,528 @@
+use hamcrest::assert_that;
+
+use support::registry::{registry, Package};
+use support::{execs, project, UPDATING, DOWNLOADING, COMPILING};
+use support::git;
+use support::paths;
+
+fn setup() {}
+
+test!(override_simple {
+    Package::new("foo", "0.1.0").publish();
+
+    let foo = git::repo(&paths::root().join("override"))
+        .file("Cargo.toml", r#"
+            [package]
+            name = "foo"
+            version = "0.1.0"
+            authors = []
+        "#)
+        .file("src/lib.rs", "pub fn foo() {}");
+    foo.build();
+
+    let p = project("local")
+        .file("Cargo.toml", &format!(r#"
+            [package]
+            name = "local"
+            version = "0.0.1"
+            authors = []
+
+            [dependencies]
+            foo = "0.1.0"
+
+            [replace]
+            "foo:0.1.0" = {{ git = '{}' }}
+        "#, foo.url()))
+        .file("src/lib.rs", "
+            extern crate foo;
+            pub fn bar() {
+                foo::foo();
+            }
+        ");
+
+    assert_that(p.cargo_process("build"),
+                execs().with_status(0).with_stdout(&format!("\
+{updating} registry `file://[..]`
+{updating} git repository `[..]`
+{compiling} foo v0.1.0 (file://[..])
+{compiling} local v0.0.1 (file://[..])
+",
+    updating = UPDATING, compiling = COMPILING)));
+});
+
+test!(missing_version {
+    let p = project("local")
+        .file("Cargo.toml", r#"
+            [package]
+            name = "local"
+            version = "0.0.1"
+            authors = []
+
+            [dependencies]
+            foo = "0.1.0"
+
+            [replace]
+            foo = { git = 'https://example.com' }
+        "#)
+        .file("src/lib.rs", "");
+
+    assert_that(p.cargo_process("build"),
+                execs().with_status(101).with_stderr("\
+error: failed to parse manifest at `[..]`
+
+Caused by:
+  replacements must specify a version to replace, but `foo` does not
+"));
+});
+
+test!(different_version {
+    Package::new("foo", "0.2.0").publish();
+    Package::new("foo", "0.1.0").publish();
+
+    let p = project("local")
+        .file("Cargo.toml", r#"
+            [package]
+            name = "local"
+            version = "0.0.1"
+            authors = []
+
+            [dependencies]
+            foo = "0.1.0"
+
+            [replace]
+            "foo:0.1.0" = "0.2.0"
+        "#)
+        .file("src/lib.rs", "");
+
+    assert_that(p.cargo_process("build"),
+                execs().with_status(101).with_stderr("\
+error: failed to parse manifest at `[..]`
+
+Caused by:
+  replacements cannot specify a version requirement, but found one for [..]
+"));
+});
+
+test!(transitive {
+    Package::new("foo", "0.1.0").publish();
+    Package::new("bar", "0.2.0")
+            .dep("foo", "0.1.0")
+            .file("src/lib.rs", "extern crate foo; fn bar() { foo::foo(); }")
+            .publish();
+
+    let foo = git::repo(&paths::root().join("override"))
+        .file("Cargo.toml", r#"
+            [package]
+            name = "foo"
+            version = "0.1.0"
+            authors = []
+        "#)
+        .file("src/lib.rs", "pub fn foo() {}");
+    foo.build();
+
+    let p = project("local")
+        .file("Cargo.toml", &format!(r#"
+            [package]
+            name = "local"
+            version = "0.0.1"
+            authors = []
+
+            [dependencies]
+            bar = "0.2.0"
+
+            [replace]
+            "foo:0.1.0" = {{ git = '{}' }}
+        "#, foo.url()))
+        .file("src/lib.rs", "");
+
+    assert_that(p.cargo_process("build"),
+                execs().with_status(0).with_stdout(&format!("\
+{updating} registry `file://[..]`
+{updating} git repository `[..]`
+{downloading} bar v0.2.0 (registry [..])
+{compiling} foo v0.1.0 (file://[..])
+{compiling} bar v0.2.0 (registry [..])
+{compiling} local v0.0.1 (file://[..])
+",
+    updating = UPDATING, downloading = DOWNLOADING, compiling = COMPILING)));
+
+    assert_that(p.cargo("build"), execs().with_status(0).with_stdout(""));
+});
+
+test!(persists_across_rebuilds {
+    Package::new("foo", "0.1.0").publish();
+
+    let foo = git::repo(&paths::root().join("override"))
+        .file("Cargo.toml", r#"
+            [package]
+            name = "foo"
+            version = "0.1.0"
+            authors = []
+        "#)
+        .file("src/lib.rs", "pub fn foo() {}");
+    foo.build();
+
+    let p = project("local")
+        .file("Cargo.toml", &format!(r#"
+            [package]
+            name = "local"
+            version = "0.0.1"
+            authors = []
+
+            [dependencies]
+            foo = "0.1.0"
+
+            [replace]
+            "foo:0.1.0" = {{ git = '{}' }}
+        "#, foo.url()))
+        .file("src/lib.rs", "
+            extern crate foo;
+            pub fn bar() {
+                foo::foo();
+            }
+        ");
+
+    assert_that(p.cargo_process("build"),
+                execs().with_status(0).with_stdout(&format!("\
+{updating} registry `file://[..]`
+{updating} git repository `file://[..]`
+{compiling} foo v0.1.0 (file://[..])
+{compiling} local v0.0.1 (file://[..])
+",
+    updating = UPDATING, compiling = COMPILING)));
+
+    assert_that(p.cargo("build"),
+                execs().with_status(0).with_stdout(""));
+});
+
+test!(replace_registry_with_path {
+    Package::new("foo", "0.1.0").publish();
+
+    project("foo")
+        .file("Cargo.toml", r#"
+            [package]
+            name = "foo"
+            version = "0.1.0"
+            authors = []
+        "#)
+        .file("src/lib.rs", "pub fn foo() {}")
+        .build();
+
+    let p = project("local")
+        .file("Cargo.toml", r#"
+            [package]
+            name = "local"
+            version = "0.0.1"
+            authors = []
+
+            [dependencies]
+            foo = "0.1.0"
+
+            [replace]
+            "foo:0.1.0" = { path = "../foo" }
+        "#)
+        .file("src/lib.rs", "
+            extern crate foo;
+            pub fn bar() {
+                foo::foo();
+            }
+        ");
+
+    assert_that(p.cargo_process("build"),
+                execs().with_status(0).with_stdout(&format!("\
+{updating} registry `file://[..]`
+{compiling} foo v0.1.0 (file://[..])
+{compiling} local v0.0.1 (file://[..])
+",
+    compiling = COMPILING, updating = UPDATING)));
+});
+
+test!(use_a_spec_to_select {
+    Package::new("foo", "0.1.1")
+            .file("src/lib.rs", "pub fn foo1() {}")
+            .publish();
+    Package::new("foo", "0.2.0").publish();
+    Package::new("bar", "0.1.1")
+            .dep("foo", "0.2")
+            .file("src/lib.rs", "
+                extern crate foo;
+                pub fn bar() { foo::foo3(); }
+            ")
+            .publish();
+
+    let foo = git::repo(&paths::root().join("override"))
+        .file("Cargo.toml", r#"
+            [package]
+            name = "foo"
+            version = "0.2.0"
+            authors = []
+        "#)
+        .file("src/lib.rs", "pub fn foo3() {}");
+    foo.build();
+
+    let p = project("local")
+        .file("Cargo.toml", &format!(r#"
+            [package]
+            name = "local"
+            version = "0.0.1"
+            authors = []
+
+            [dependencies]
+            bar = "0.1"
+            foo = "0.1"
+
+            [replace]
+            "foo:0.2.0" = {{ git = '{}' }}
+        "#, foo.url()))
+        .file("src/lib.rs", "
+            extern crate foo;
+            extern crate bar;
+
+            fn local() {
+                foo::foo1();
+                bar::bar();
+            }
+        ");
+
+    assert_that(p.cargo_process("build"),
+                execs().with_status(0).with_stdout(&format!("\
+{updating} registry `file://[..]`
+{updating} git repository `[..]`
+{downloading} [..]
+{downloading} [..]
+{compiling} [..]
+{compiling} [..]
+{compiling} [..]
+{compiling} local v0.0.1 (file://[..])
+",
+    updating = UPDATING, downloading = DOWNLOADING, compiling = COMPILING)));
+});
+
+test!(override_adds_some_deps {
+    Package::new("foo", "0.1.1").publish();
+    Package::new("bar", "0.1.0").publish();
+
+    let foo = git::repo(&paths::root().join("override"))
+        .file("Cargo.toml", r#"
+            [package]
+            name = "bar"
+            version = "0.1.0"
+            authors = []
+
+            [dependencies]
+            foo = "0.1"
+        "#)
+        .file("src/lib.rs", "");
+    foo.build();
+
+    let p = project("local")
+        .file("Cargo.toml", &format!(r#"
+            [package]
+            name = "local"
+            version = "0.0.1"
+            authors = []
+
+            [dependencies]
+            bar = "0.1"
+
+            [replace]
+            "bar:0.1.0" = {{ git = '{}' }}
+        "#, foo.url()))
+        .file("src/lib.rs", "");
+
+    assert_that(p.cargo_process("build"),
+                execs().with_status(0).with_stdout(&format!("\
+{updating} registry `file://[..]`
+{updating} git repository `[..]`
+{downloading} foo v0.1.1 (registry [..])
+{compiling} foo v0.1.1 (registry [..])
+{compiling} bar v0.1.0 ([..])
+{compiling} local v0.0.1 (file://[..])
+",
+    updating = UPDATING, downloading = DOWNLOADING, compiling = COMPILING)));
+
+    assert_that(p.cargo("build"), execs().with_status(0).with_stdout(""));
+
+    Package::new("foo", "0.1.2").publish();
+    assert_that(p.cargo("update").arg("-p").arg(&format!("{}#bar", foo.url())),
+                execs().with_status(0).with_stdout(&format!("\
+{updating} git repository `file://[..]`
+", updating = UPDATING)));
+    assert_that(p.cargo("update").arg("-p").arg(&format!("{}#bar", registry())),
+                execs().with_status(0).with_stdout(&format!("\
+{updating} registry `file://[..]`
+", updating = UPDATING)));
+
+    assert_that(p.cargo("build"), execs().with_status(0).with_stdout(""));
+});
+
+test!(locked_means_locked_yes_no_seriously_i_mean_locked {
+    // this in theory exercises #2041
+    Package::new("foo", "0.1.0").publish();
+    Package::new("foo", "0.2.0").publish();
+    Package::new("bar", "0.1.0").publish();
+
+    let foo = git::repo(&paths::root().join("override"))
+        .file("Cargo.toml", r#"
+            [package]
+            name = "bar"
+            version = "0.1.0"
+            authors = []
+
+            [dependencies]
+            foo = "*"
+        "#)
+        .file("src/lib.rs", "");
+    foo.build();
+
+    let p = project("local")
+        .file("Cargo.toml", &format!(r#"
+            [package]
+            name = "local"
+            version = "0.0.1"
+            authors = []
+
+            [dependencies]
+            foo = "0.1"
+            bar = "0.1"
+
+            [replace]
+            "bar:0.1.0" = {{ git = '{}' }}
+        "#, foo.url()))
+        .file("src/lib.rs", "");
+
+    assert_that(p.cargo_process("build"),
+                execs().with_status(0));
+
+    assert_that(p.cargo("build"), execs().with_status(0).with_stdout(""));
+    assert_that(p.cargo("build"), execs().with_status(0).with_stdout(""));
+});
+
+test!(override_wrong_name {
+    Package::new("foo", "0.1.0").publish();
+
+    let foo = git::repo(&paths::root().join("override"))
+        .file("Cargo.toml", r#"
+            [package]
+            name = "bar"
+            version = "0.1.0"
+            authors = []
+        "#)
+        .file("src/lib.rs", "");
+    foo.build();
+
+    let p = project("local")
+        .file("Cargo.toml", &format!(r#"
+            [package]
+            name = "local"
+            version = "0.0.1"
+            authors = []
+
+            [dependencies]
+            foo = "0.1"
+
+            [replace]
+            "foo:0.1.0" = {{ git = '{}' }}
+        "#, foo.url()))
+        .file("src/lib.rs", "");
+
+    assert_that(p.cargo_process("build"),
+                execs().with_status(101).with_stderr("\
+error: no matching package for override `foo:0.1.0` found
+location searched: file://[..]
+version required: = 0.1.0
+"));
+});
+
+test!(override_with_nothing {
+    Package::new("foo", "0.1.0").publish();
+
+    let foo = git::repo(&paths::root().join("override"))
+        .file("src/lib.rs", "");
+    foo.build();
+
+    let p = project("local")
+        .file("Cargo.toml", &format!(r#"
+            [package]
+            name = "local"
+            version = "0.0.1"
+            authors = []
+
+            [dependencies]
+            foo = "0.1"
+
+            [replace]
+            "foo:0.1.0" = {{ git = '{}' }}
+        "#, foo.url()))
+        .file("src/lib.rs", "");
+
+    assert_that(p.cargo_process("build"),
+                execs().with_status(101).with_stderr("\
+error: Unable to update file://[..]
+
+Caused by:
+  Could not find Cargo.toml in `[..]`
+"));
+});
+
+test!(override_wrong_version {
+    let p = project("local")
+        .file("Cargo.toml", r#"
+            [package]
+            name = "local"
+            version = "0.0.1"
+            authors = []
+
+            [replace]
+            "foo:0.1.0" = { git = 'https://example.com', version = '0.2.0' }
+        "#)
+        .file("src/lib.rs", "");
+
+    assert_that(p.cargo_process("build"),
+                execs().with_status(101).with_stderr("\
+error: failed to parse manifest at `[..]`
+
+Caused by:
+  replacements cannot specify a version requirement, but found one for `foo:0.1.0`
+"));
+});
+
+test!(multiple_specs {
+    Package::new("foo", "0.1.0").publish();
+
+    let foo = git::repo(&paths::root().join("override"))
+        .file("Cargo.toml", r#"
+            [package]
+            name = "foo"
+            version = "0.1.0"
+            authors = []
+        "#)
+        .file("src/lib.rs", "pub fn foo() {}");
+    foo.build();
+
+    let p = project("local")
+        .file("Cargo.toml", &format!(r#"
+            [package]
+            name = "local"
+            version = "0.0.1"
+            authors = []
+
+            [dependencies]
+            foo = "0.1.0"
+
+            [replace]
+            "foo:0.1.0" = {{ git = '{0}' }}
+            "{1}#foo:0.1.0" = {{ git = '{0}' }}
+        "#, foo.url(), registry()))
+        .file("src/lib.rs", "");
+
+    assert_that(p.cargo_process("build"),
+                execs().with_status(101).with_stderr("\
+error: overlapping replacement specifications found:
+
+  * [..]
+  * [..]
+
+both specifications match: foo v0.1.0 ([..])
+"));
+});

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -58,6 +58,7 @@ mod test_cargo_metadata;
 mod test_cargo_new;
 mod test_cargo_package;
 mod test_cargo_profiles;
+mod test_cargo_overrides;
 mod test_cargo_publish;
 mod test_cargo_read_manifest;
 mod test_cargo_registry;


### PR DESCRIPTION
This commit is an implementation of top-level overrides to be encoded into the
manifest itself directly. This style of override is distinct from the existing
`paths` support in `.cargo/config` in two important ways:

* Top level overrides are intended to be checked in and shared amongst all
  developers of a project.
* Top level overrides are reflected in `Cargo.lock`.

The second point is crucially important here as it will ensure that an override
on one machine behaves the same as an override on another machine. This solves
many long-standing problems with `paths`-based overrides which suffer from some
level of nondeterminism as they're not encoded.

From a syntactical point of view, an override looks like:

```toml
[replace]
"libc:0.2.0" = { git = 'https://github.com/my-username/libc';, branch = '0.2-fork' }
```

This declaration indicates that whenever resolution would otherwise encounter
the `libc` package version 0.2.0 from crates.io, it should instead replace it
with the custom git dependency on a specific branch.

The key "libc:0.2.0" here is actually a package id specification which will
allow selecting various components of a graph. For example the same named
package coming from two distinct locations can be selected against, as well as
multiple versions of one crate in a dependency graph. The replacement dependency
has the same syntax as the `[dependencies]` section of Cargo.toml.

One of the major uses of this syntax will be, for example, using a temporary
fork of a crate while the changes are pushed upstream to the original repo. This
will avoid the need to change the intermediate projects immediately, and over
time once fixes have landed upstream the `[replace]` section in a `Cargo.toml`
can be removed.

There are also two crucial restrictions on overrides.

* A crate with the name `foo` can only get overridden with packages also of
  the name `foo`.
* A crate can only get overridden with a crate of the exact same version.

A consequence of these restrictions is that crates.io cannot be used to replace
anything from crates.io. There's only one version of something on crates.io, so
there's nothing else to replace it with (name/version are a unique key).

Closes #942