### PR TITLE
cargo new/init: Conditionalize adding Cargo.lock to gitignore

### DIFF
--- a/src/cargo/ops/cargo_new.rs
+++ b/src/cargo/ops/cargo_new.rs
@@ -36,6 +36,7 @@ struct MkOptions<'a> {
     path: &'a Path,
     name: &'a str,
     source_files: Vec<SourceFileInformation>,
+    bin: bool,
 }
 
 impl Decodable for VersionControl {
@@ -222,6 +223,7 @@ pub fn new(opts: NewOptions, config: &Config) -> CargoResult<()> {
         path: &path,
         name: name,
         source_files: vec![plan_new_source_file(opts.bin, name.to_string())],
+        bin: opts.bin,
     };
     
     mk(config, &mkopts).chain_error(|| {
@@ -282,6 +284,7 @@ pub fn init(opts: NewOptions, config: &Config) -> CargoResult<()> {
         version_control: version_control,
         path: &path,
         name: name,
+        bin: src_paths_types.iter().any(|x|x.bin),
         source_files: src_paths_types,
     };
     
@@ -315,7 +318,9 @@ fn mk(config: &Config, opts: &MkOptions) -> CargoResult<()> {
     let cfg = try!(global_config(config));
     let mut ignore = "target\n".to_string();
     let in_existing_vcs_repo = existing_vcs_repo(path.parent().unwrap(), config.cwd());
-    ignore.push_str("Cargo.lock\n");
+    if !opts.bin {
+        ignore.push_str("Cargo.lock\n");
+    }
 
     let vcs = match (opts.version_control, cfg.version_control, in_existing_vcs_repo) {
         (None, None, false) => VersionControl::Git,

--- a/tests/test_cargo_init.rs
+++ b/tests/test_cargo_init.rs
@@ -285,6 +285,67 @@ test!(gitignore_appended_not_replaced {
     assert!(contents.contains(r#"qqqqqq"#));
 });
 
+test!(cargo_lock_gitignored_if_lib1 {
+    fs::create_dir(&paths::root().join(".git")).unwrap();
+    
+    assert_that(cargo_process("init").arg("--vcs").arg("git")
+                                     .env("USER", "foo"),
+                execs().with_status(0));
+    
+    assert_that(&paths::root().join(".gitignore"), existing_file());
+    
+    let mut contents = String::new();
+    File::open(&paths::root().join(".gitignore")).unwrap().read_to_string(&mut contents).unwrap();
+    assert!(contents.contains(r#"Cargo.lock"#));
+});
+
+test!(cargo_lock_gitignored_if_lib2 {
+    fs::create_dir(&paths::root().join(".git")).unwrap();
+    
+    File::create(&paths::root().join("lib.rs")).unwrap().write_all(br#""#).unwrap();
+
+    assert_that(cargo_process("init").arg("--vcs").arg("git")
+                                     .env("USER", "foo"),
+                execs().with_status(0));
+    
+    assert_that(&paths::root().join(".gitignore"), existing_file());
+    
+    let mut contents = String::new();
+    File::open(&paths::root().join(".gitignore")).unwrap().read_to_string(&mut contents).unwrap();
+    assert!(contents.contains(r#"Cargo.lock"#));
+});
+
+test!(cargo_lock_not_gitignored_if_bin1 {
+    fs::create_dir(&paths::root().join(".git")).unwrap();
+    
+    assert_that(cargo_process("init").arg("--vcs").arg("git")
+                                     .arg("--bin")
+                                     .env("USER", "foo"),
+                execs().with_status(0));
+    
+    assert_that(&paths::root().join(".gitignore"), existing_file());
+    
+    let mut contents = String::new();
+    File::open(&paths::root().join(".gitignore")).unwrap().read_to_string(&mut contents).unwrap();
+    assert!(!contents.contains(r#"Cargo.lock"#));
+});
+
+test!(cargo_lock_not_gitignored_if_bin2 {
+    fs::create_dir(&paths::root().join(".git")).unwrap();
+    
+    File::create(&paths::root().join("main.rs")).unwrap().write_all(br#""#).unwrap();
+
+    assert_that(cargo_process("init").arg("--vcs").arg("git")
+                                     .env("USER", "foo"),
+                execs().with_status(0));
+    
+    assert_that(&paths::root().join(".gitignore"), existing_file());
+    
+    let mut contents = String::new();
+    File::open(&paths::root().join(".gitignore")).unwrap().read_to_string(&mut contents).unwrap();
+    assert!(!contents.contains(r#"Cargo.lock"#));
+});
+
 test!(with_argument {
     assert_that(cargo_process("init").arg("foo").arg("--vcs").arg("none")
                                      .env("USER", "foo"),


### PR DESCRIPTION
For cargo new, it depends on --bin option

For cargo init, it depends on detected files
(--bin option may be used or may be ignored)

No tests conver this code so far.