### PR TITLE
Fix naming of tests mod in cargo new

### DIFF
--- a/src/cargo/ops/cargo_new.rs
+++ b/src/cargo/ops/cargo_new.rs
@@ -414,7 +414,7 @@ fn main() {
         } else {
             b"\
 #[cfg(test)]
-mod test {
+mod tests {
     #[test]
     fn it_works() {
     }


### PR DESCRIPTION
In the default `lib.rs` provided by `cargo-new`, the "test" module is named "test" while Rust convention is using "tests" as the name of the module: https://doc.rust-lang.org/book/testing.html#the-tests-module
The plural form also conforms with the style used in special directories at project root such as "examples" and "tests".
This pull request conforms to the existing style.