### PR TITLE
Network retry issue 1602

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,6 +7,7 @@ dependencies = [
  "crates-io 0.2.0",
  "crossbeam 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "curl 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "curl-sys 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
  "docopt 0.6.78 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "filetime 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ advapi32-sys = "0.1"
 crates-io = { path = "src/crates-io", version = "0.2" }
 crossbeam = "0.2"
 curl = "0.2"
+curl-sys = "0.1"
 docopt = "0.6"
 env_logger = "0.3"
 filetime = "0.1"

--- a/src/cargo/lib.rs
+++ b/src/cargo/lib.rs
@@ -6,6 +6,7 @@
 extern crate crates_io as registry;
 extern crate crossbeam;
 extern crate curl;
+extern crate curl_sys;
 extern crate docopt;
 extern crate filetime;
 extern crate flate2;

--- a/src/cargo/sources/git/source.rs
+++ b/src/cargo/sources/git/source.rs
@@ -162,7 +162,8 @@ impl<'cfg> Source for GitSource<'cfg> {
                 format!("git repository `{}`", self.remote.url())));
 
             trace!("updating git source `{:?}`", self.remote);
-            let repo = try!(self.remote.checkout(&db_path));
+
+            let repo = try!(self.remote.checkout(&db_path, &self.config));
             let rev = try!(repo.rev_for(&self.reference));
             (repo, rev)
         } else {
@@ -172,7 +173,7 @@ impl<'cfg> Source for GitSource<'cfg> {
         // Copy the database to the checkout location. After this we could drop
         // the lock on the database as we no longer needed it, but we leave it
         // in scope so the destructors here won't tamper with too much.
-        try!(repo.copy_to(actual_rev.clone(), &checkout_path));
+        try!(repo.copy_to(actual_rev.clone(), &checkout_path, &self.config));
 
         let source_id = self.source_id.with_precise(Some(actual_rev.to_string()));
         let path_source = PathSource::new_recursive(&checkout_path,

--- a/src/cargo/sources/registry.rs
+++ b/src/cargo/sources/registry.rs
@@ -483,7 +483,8 @@ impl<'cfg> RegistrySource<'cfg> {
         // git fetch origin
         let url = self.source_id.url().to_string();
         let refspec = "refs/heads/*:refs/remotes/origin/*";
-        try!(git::fetch(&repo, &url, refspec).chain_error(|| {
+
+        try!(git::fetch(&repo, &url, refspec, &self.config).chain_error(|| {
             internal(format!("failed to fetch `{}`", url))
         }));
 

--- a/src/cargo/util/config.rs
+++ b/src/cargo/util/config.rs
@@ -265,6 +265,21 @@ impl Config {
         }
     }
 
+    pub fn net_retry(&self) -> CargoResult<i64> {
+        match try!(self.get_i64("net.retry")) {
+            Some(v) => {
+                let value = v.val;
+                if value < 0 {
+                    bail!("net.retry must be positive, but found {} in {}",
+                      v.val, v.definition)
+                } else {
+                    Ok(value)
+                }
+            }
+            None => Ok(2),
+        }
+    }
+
     pub fn expected<T>(&self, ty: &str, key: &str, val: CV) -> CargoResult<T> {
         val.expected(ty).map_err(|e| {
             human(format!("invalid configuration for key `{}`\n{}", key, e))

--- a/src/cargo/util/mod.rs
+++ b/src/cargo/util/mod.rs
@@ -32,6 +32,7 @@ pub mod to_url;
 pub mod toml;
 pub mod lev_distance;
 pub mod job;
+pub mod network;
 mod cfg;
 mod dependency_queue;
 mod rustc;

--- a/src/cargo/util/network.rs
+++ b/src/cargo/util/network.rs
@@ -1,0 +1,86 @@
+use util::{CargoResult, Config, errors};
+
+/// Wrapper method for network call retry logic.
+///
+/// Retry counts provided by Config object 'net.retry'. Config shell outputs
+/// a warning on per retry.
+///
+/// Closure must return a CargoResult.
+///
+/// Example:
+/// use util::network;
+/// cargo_result = network.with_retry(&config, || something.download());
+pub fn with_retry<T, E, F>(config: &Config, mut callback: F) -> CargoResult<T>
+    where F: FnMut() -> Result<T, E>,
+          E: errors::NetworkError
+{
+    let mut remaining = try!(config.net_retry());
+    loop {
+        match callback() {
+            Ok(ret) => return Ok(ret),
+            Err(ref e) if e.maybe_spurious() && remaining > 0 => {
+                let msg = format!("spurious network error ({} tries \
+                          remaining): {}", remaining, e);
+                try!(config.shell().warn(msg));
+                remaining -= 1;
+            }
+            Err(e) => return Err(Box::new(e)),
+        }
+    }
+}
+#[test]
+fn with_retry_repeats_the_call_then_works() {
+
+    use std::error::Error;
+    use util::human;
+    use std::fmt;
+
+    #[derive(Debug)]
+    struct NetworkRetryError {
+        error: Box<errors::CargoError>,
+    }
+
+    impl Error for NetworkRetryError {
+        fn description(&self) -> &str {
+            self.error.description()
+        }
+        fn cause(&self) -> Option<&Error> {
+            self.error.cause()
+        }
+    }
+
+    impl NetworkRetryError {
+        fn new(error: &str) -> NetworkRetryError {
+            let error = human(error.to_string());
+            NetworkRetryError {
+                error: error,
+            }
+        }
+    }
+
+    impl fmt::Display for NetworkRetryError {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            fmt::Display::fmt(&self.error, f)
+        }
+    }
+
+    impl errors::CargoError for NetworkRetryError {
+        fn is_human(&self) -> bool {
+            false
+        }
+    }
+
+    impl errors::NetworkError for NetworkRetryError {
+        fn maybe_spurious(&self) -> bool {
+            true
+        }
+    }
+
+    let error1 = NetworkRetryError::new("one");
+    let error2 = NetworkRetryError::new("two");
+    let mut results: Vec<Result<(), NetworkRetryError>> = vec![Ok(()),
+    Err(error1), Err(error2)];
+    let config = Config::default().unwrap();
+    let result = with_retry(&config, || results.pop().unwrap());
+    assert_eq!(result.unwrap(), ())
+}

--- a/src/doc/config.md
+++ b/src/doc/config.md
@@ -89,6 +89,10 @@ rustflags = ["..", ".."]  # custom flags to pass to all compiler invocations
 [term]
 verbose = false        # whether cargo provides verbose output
 color = 'auto'         # whether cargo colorizes output
+
+# Network configuration
+[net]
+retry = 2 # number of times a network call will automatically retried
 ```
 
 # Environment Variables

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -662,6 +662,7 @@ fn substitute_macros(input: &str) -> String {
         ("[RUNNING]",     "     Running"),
         ("[COMPILING]",   "   Compiling"),
         ("[ERROR]",       "error:"),
+        ("[WARNING]",     "warning:"),
         ("[DOCUMENTING]", " Documenting"),
         ("[FRESH]",       "       Fresh"),
         ("[UPDATING]",    "    Updating"),

--- a/tests/test_cargo_build_auth.rs
+++ b/tests/test_cargo_build_auth.rs
@@ -72,6 +72,7 @@ test!(http_auth_offered {
                 println!("password=bar");
             }
         "#);
+
     assert_that(script.cargo_process("build").arg("-v"),
                 execs().with_status(0));
     let script = script.bin("script");
@@ -91,7 +92,11 @@ test!(http_auth_offered {
             [dependencies.bar]
             git = "http://127.0.0.1:{}/foo/bar"
         "#, addr.port()))
-        .file("src/main.rs", "");
+        .file("src/main.rs", "")
+        .file(".cargo/config","\
+        [net]
+        retry = 0
+        ");
 
     assert_that(p.cargo_process("build"),
                 execs().with_status(101).with_stdout(&format!("\
@@ -134,7 +139,11 @@ test!(https_something_happens {
             [dependencies.bar]
             git = "https://127.0.0.1:{}/foo/bar"
         "#, addr.port()))
-        .file("src/main.rs", "");
+        .file("src/main.rs", "")
+        .file(".cargo/config","\
+        [net]
+        retry = 0
+        ");
 
     assert_that(p.cargo_process("build").arg("-v"),
                 execs().with_status(101).with_stdout(&format!("\

--- a/tests/test_cargo_net_config.rs
+++ b/tests/test_cargo_net_config.rs
@@ -1,0 +1,53 @@
+use support::{project, execs};
+use hamcrest::assert_that;
+
+fn setup() {}
+
+test!(net_retry_loads_from_config {
+    let p = project("foo")
+        .file("Cargo.toml", &format!(r#"
+            [project]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+
+            [dependencies.bar]
+            git = "https://127.0.0.1:11/foo/bar"
+        "#))
+        .file("src/main.rs", "").file(".cargo/config", r#"
+        [net]
+        retry=1
+        [http]
+        timeout=1
+         "#);
+
+    assert_that(p.cargo_process("build").arg("-v"),
+                execs().with_status(101)
+                .with_stderr_contains(&format!("[WARNING] spurious network error \
+(1 tries remaining): [2/-1] [..]")));
+});
+
+test!(net_retry_git_outputs_warning{
+    let p = project("foo")
+        .file("Cargo.toml", &format!(r#"
+            [project]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+
+            [dependencies.bar]
+            git = "https://127.0.0.1:11/foo/bar"
+        "#))
+        .file(".cargo/config", r#"
+        [http]
+        timeout=1
+         "#)
+        .file("src/main.rs", "");
+
+    assert_that(p.cargo_process("build").arg("-v").arg("-j").arg("1"),
+                execs().with_status(101)
+                .with_stderr_contains(&format!("[WARNING] spurious network error \
+(2 tries remaining): [2/-1] [..]"))
+                .with_stderr_contains(&format!("\
+[WARNING] spurious network error (1 tries remaining): [2/-1] [..]")));
+});

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -75,6 +75,7 @@ mod test_cargo_version;
 mod test_shell;
 mod test_cargo_death;
 mod test_cargo_cfg;
+mod test_cargo_net_config;
 
 thread_local!(static RUSTC: Rustc = Rustc::new("rustc").unwrap());
 


### PR DESCRIPTION
Dearest Reviewer,

This branch resolves #1602 which relates to retrying network
issues automatically. There is a new utility helper for retrying
any network call.

There is a new config called net.retry value in the .cargo.config
file. The default value is 2. The documentation has also been
updated to reflect the new value.

Thanks
Becker