### PR TITLE
Add configuration keys for -v, --color

### DIFF
--- a/src/bin/bench.rs
+++ b/src/bin/bench.rs
@@ -11,8 +11,8 @@ pub struct Options {
     flag_no_default_features: bool,
     flag_target: Option<String>,
     flag_manifest_path: Option<String>,
-    flag_verbose: bool,
-    flag_quiet: bool,
+    flag_verbose: Option<bool>,
+    flag_quiet: Option<bool>,
     flag_color: Option<String>,
     flag_lib: bool,
     flag_bin: Vec<String>,
@@ -63,8 +63,9 @@ Compilation can be customized with the `bench` profile in the manifest.
 
 pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
     let root = try!(find_root_manifest_for_wd(options.flag_manifest_path, config.cwd()));
-    try!(config.shell().set_verbosity(options.flag_verbose, options.flag_quiet));
-    try!(config.shell().set_color_config(options.flag_color.as_ref().map(|s| &s[..])));
+    try!(config.configure_shell(options.flag_verbose,
+                                options.flag_quiet,
+                                &options.flag_color));
 
     let ops = ops::TestOptions {
         no_run: options.flag_no_run,

--- a/src/bin/build.rs
+++ b/src/bin/build.rs
@@ -13,8 +13,8 @@ pub struct Options {
     flag_no_default_features: bool,
     flag_target: Option<String>,
     flag_manifest_path: Option<String>,
-    flag_verbose: bool,
-    flag_quiet: bool,
+    flag_verbose: Option<bool>,
+    flag_quiet: Option<bool>,
     flag_color: Option<String>,
     flag_release: bool,
     flag_lib: bool,
@@ -61,8 +61,9 @@ the --release flag will use the `release` profile instead.
 pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
     debug!("executing; cmd=cargo-build; args={:?}",
            env::args().collect::<Vec<_>>());
-    try!(config.shell().set_verbosity(options.flag_verbose, options.flag_quiet));
-    try!(config.shell().set_color_config(options.flag_color.as_ref().map(|s| &s[..])));
+    try!(config.configure_shell(options.flag_verbose,
+                                options.flag_quiet,
+                                &options.flag_color));
 
     let root = try!(find_root_manifest_for_wd(options.flag_manifest_path, config.cwd()));
 

--- a/src/bin/cargo.rs
+++ b/src/bin/cargo.rs
@@ -16,9 +16,9 @@ use cargo::util::{self, CliResult, lev_distance, Config, human, CargoResult, Cha
 #[derive(RustcDecodable)]
 pub struct Flags {
     flag_list: bool,
-    flag_verbose: bool,
     flag_version: bool,
-    flag_quiet: bool,
+    flag_verbose: Option<bool>,
+    flag_quiet: Option<bool>,
     flag_color: Option<String>,
     arg_command: String,
     arg_args: Vec<String>,
@@ -108,8 +108,9 @@ mod subcommands {
   on this top-level information.
 */
 fn execute(flags: Flags, config: &Config) -> CliResult<Option<()>> {
-    try!(config.shell().set_verbosity(flags.flag_verbose, flags.flag_quiet));
-    try!(config.shell().set_color_config(flags.flag_color.as_ref().map(|s| &s[..])));
+    try!(config.configure_shell(flags.flag_verbose,
+                                flags.flag_quiet,
+                                &flags.flag_color));
 
     init_git_transports(config);
     cargo::util::job::setup();

--- a/src/bin/clean.rs
+++ b/src/bin/clean.rs
@@ -9,8 +9,8 @@ pub struct Options {
     flag_package: Vec<String>,
     flag_target: Option<String>,
     flag_manifest_path: Option<String>,
-    flag_verbose: bool,
-    flag_quiet: bool,
+    flag_verbose: Option<bool>,
+    flag_quiet: Option<bool>,
     flag_color: Option<String>,
     flag_release: bool,
 }
@@ -38,9 +38,10 @@ and its format, see the `cargo help pkgid` command.
 ";
 
 pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
-    try!(config.shell().set_verbosity(options.flag_verbose, options.flag_quiet));
-    try!(config.shell().set_color_config(options.flag_color.as_ref().map(|s| &s[..])));
     debug!("executing; cmd=cargo-clean; args={:?}", env::args().collect::<Vec<_>>());
+    try!(config.configure_shell(options.flag_verbose,
+                                options.flag_quiet,
+                                &options.flag_color));
 
     let root = try!(find_root_manifest_for_wd(options.flag_manifest_path, config.cwd()));
     let opts = ops::CleanOptions {

--- a/src/bin/doc.rs
+++ b/src/bin/doc.rs
@@ -11,9 +11,9 @@ pub struct Options {
     flag_no_default_features: bool,
     flag_no_deps: bool,
     flag_open: bool,
-    flag_verbose: bool,
     flag_release: bool,
-    flag_quiet: bool,
+    flag_verbose: Option<bool>,
+    flag_quiet: Option<bool>,
     flag_color: Option<String>,
     flag_package: Vec<String>,
 }
@@ -49,8 +49,9 @@ the `cargo help pkgid` command.
 ";
 
 pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
-    try!(config.shell().set_verbosity(options.flag_verbose, options.flag_quiet));
-    try!(config.shell().set_color_config(options.flag_color.as_ref().map(|s| &s[..])));
+    try!(config.configure_shell(options.flag_verbose,
+                                options.flag_quiet,
+                                &options.flag_color));
 
     let root = try!(find_root_manifest_for_wd(options.flag_manifest_path, config.cwd()));
 

--- a/src/bin/fetch.rs
+++ b/src/bin/fetch.rs
@@ -5,8 +5,8 @@ use cargo::util::important_paths::find_root_manifest_for_wd;
 #[derive(RustcDecodable)]
 pub struct Options {
     flag_manifest_path: Option<String>,
-    flag_verbose: bool,
-    flag_quiet: bool,
+    flag_verbose: Option<bool>,
+    flag_quiet: Option<bool>,
     flag_color: Option<String>,
 }
 
@@ -34,8 +34,9 @@ all updated.
 ";
 
 pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
-    try!(config.shell().set_verbosity(options.flag_verbose, options.flag_quiet));
-    try!(config.shell().set_color_config(options.flag_color.as_ref().map(|s| &s[..])));
+    try!(config.configure_shell(options.flag_verbose,
+                                options.flag_quiet,
+                                &options.flag_color));
     let root = try!(find_root_manifest_for_wd(options.flag_manifest_path, config.cwd()));
     try!(ops::fetch(&root, config));
     Ok(None)

--- a/src/bin/generate_lockfile.rs
+++ b/src/bin/generate_lockfile.rs
@@ -7,8 +7,8 @@ use cargo::util::important_paths::find_root_manifest_for_wd;
 #[derive(RustcDecodable)]
 pub struct Options {
     flag_manifest_path: Option<String>,
-    flag_verbose: bool,
-    flag_quiet: bool,
+    flag_verbose: Option<bool>,
+    flag_quiet: Option<bool>,
     flag_color: Option<String>,
 }
 
@@ -28,8 +28,9 @@ Options:
 
 pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
     debug!("executing; cmd=cargo-generate-lockfile; args={:?}", env::args().collect::<Vec<_>>());
-    try!(config.shell().set_verbosity(options.flag_verbose, options.flag_quiet));
-    try!(config.shell().set_color_config(options.flag_color.as_ref().map(|s| &s[..])));
+    try!(config.configure_shell(options.flag_verbose,
+                                options.flag_quiet,
+                                &options.flag_color));
     let root = try!(find_root_manifest_for_wd(options.flag_manifest_path, config.cwd()));
 
     try!(ops::generate_lockfile(&root, config));

--- a/src/bin/git_checkout.rs
+++ b/src/bin/git_checkout.rs
@@ -6,8 +6,8 @@ use cargo::util::{Config, CliResult, CliError, human, ToUrl};
 pub struct Options {
     flag_url: String,
     flag_reference: String,
-    flag_verbose: bool,
-    flag_quiet: bool,
+    flag_verbose: Option<bool>,
+    flag_quiet: Option<bool>,
     flag_color: Option<String>,
 }
 
@@ -26,8 +26,9 @@ Options:
 ";
 
 pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
-    try!(config.shell().set_verbosity(options.flag_verbose, options.flag_quiet));
-    try!(config.shell().set_color_config(options.flag_color.as_ref().map(|s| &s[..])));
+    try!(config.configure_shell(options.flag_verbose,
+                                options.flag_quiet,
+                                &options.flag_color));
     let Options { flag_url: url, flag_reference: reference, .. } = options;
 
     let url = try!(url.to_url().map_err(|e| {

--- a/src/bin/init.rs
+++ b/src/bin/init.rs
@@ -5,8 +5,8 @@ use cargo::util::{CliResult, Config};
 
 #[derive(RustcDecodable)]
 pub struct Options {
-    flag_verbose: bool,
-    flag_quiet: bool,
+    flag_verbose: Option<bool>,
+    flag_quiet: Option<bool>,
     flag_color: Option<String>,
     flag_bin: bool,
     arg_path: Option<String>,
@@ -35,8 +35,9 @@ Options:
 
 pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
     debug!("executing; cmd=cargo-init; args={:?}", env::args().collect::<Vec<_>>());
-    try!(config.shell().set_verbosity(options.flag_verbose, options.flag_quiet));
-    try!(config.shell().set_color_config(options.flag_color.as_ref().map(|s| &s[..])));
+    try!(config.configure_shell(options.flag_verbose,
+                                options.flag_quiet,
+                                &options.flag_color));
 
     let Options { flag_bin, arg_path, flag_name, flag_vcs, .. } = options;
 

--- a/src/bin/install.rs
+++ b/src/bin/install.rs
@@ -10,8 +10,8 @@ pub struct Options {
     flag_debug: bool,
     flag_bin: Vec<String>,
     flag_example: Vec<String>,
-    flag_verbose: bool,
-    flag_quiet: bool,
+    flag_verbose: Option<bool>,
+    flag_quiet: Option<bool>,
     flag_color: Option<String>,
     flag_root: Option<String>,
     flag_list: bool,
@@ -83,8 +83,9 @@ The `--list` option will list all installed packages (and their versions).
 ";
 
 pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
-    try!(config.shell().set_verbosity(options.flag_verbose, options.flag_quiet));
-    try!(config.shell().set_color_config(options.flag_color.as_ref().map(|s| &s[..])));
+    try!(config.configure_shell(options.flag_verbose,
+                                options.flag_quiet,
+                                &options.flag_color));
 
     let compile_opts = ops::CompileOptions {
         config: config,

--- a/src/bin/login.rs
+++ b/src/bin/login.rs
@@ -10,8 +10,8 @@ use cargo::util::{CliResult, Config, human, ChainError};
 pub struct Options {
     flag_host: Option<String>,
     arg_token: Option<String>,
-    flag_verbose: bool,
-    flag_quiet: bool,
+    flag_verbose: Option<bool>,
+    flag_quiet: Option<bool>,
     flag_color: Option<String>,
 }
 
@@ -31,8 +31,9 @@ Options:
 ";
 
 pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
-    try!(config.shell().set_verbosity(options.flag_verbose, options.flag_quiet));
-    try!(config.shell().set_color_config(options.flag_color.as_ref().map(|s| &s[..])));
+    try!(config.configure_shell(options.flag_verbose,
+                                options.flag_quiet,
+                                &options.flag_color));
     let token = match options.arg_token.clone() {
         Some(token) => token,
         None => {

--- a/src/bin/metadata.rs
+++ b/src/bin/metadata.rs
@@ -15,8 +15,8 @@ pub struct Options {
     flag_manifest_path: Option<String>,
     flag_no_default_features: bool,
     flag_no_deps: bool,
-    flag_quiet: bool,
-    flag_verbose: bool,
+    flag_quiet: Option<bool>,
+    flag_verbose: Option<bool>,
 }
 
 pub const USAGE: &'static str = "
@@ -41,8 +41,9 @@ Options:
 ";
 
 pub fn execute(options: Options, config: &Config) -> CliResult<Option<ExportInfo>> {
-    try!(config.shell().set_verbosity(options.flag_verbose, options.flag_quiet));
-    try!(config.shell().set_color_config(options.flag_color.as_ref().map(|s| &s[..])));
+    try!(config.configure_shell(options.flag_verbose,
+                                options.flag_quiet,
+                                &options.flag_color));
     let manifest = try!(find_root_manifest_for_wd(options.flag_manifest_path, config.cwd()));
 
     let options = OutputMetadataOptions {

--- a/src/bin/new.rs
+++ b/src/bin/new.rs
@@ -5,8 +5,8 @@ use cargo::util::{CliResult, Config};
 
 #[derive(RustcDecodable)]
 pub struct Options {
-    flag_verbose: bool,
-    flag_quiet: bool,
+    flag_verbose: Option<bool>,
+    flag_quiet: Option<bool>,
     flag_color: Option<String>,
     flag_bin: bool,
     arg_path: String,
@@ -35,8 +35,9 @@ Options:
 
 pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
     debug!("executing; cmd=cargo-new; args={:?}", env::args().collect::<Vec<_>>());
-    try!(config.shell().set_verbosity(options.flag_verbose, options.flag_quiet));
-    try!(config.shell().set_color_config(options.flag_color.as_ref().map(|s| &s[..])));
+    try!(config.configure_shell(options.flag_verbose,
+                                options.flag_quiet,
+                                &options.flag_color));
 
     let Options { flag_bin, arg_path, flag_name, flag_vcs, .. } = options;
 

--- a/src/bin/owner.rs
+++ b/src/bin/owner.rs
@@ -8,8 +8,8 @@ pub struct Options {
     flag_add: Option<Vec<String>>,
     flag_remove: Option<Vec<String>>,
     flag_index: Option<String>,
-    flag_verbose: bool,
-    flag_quiet: bool,
+    flag_verbose: Option<bool>,
+    flag_quiet: Option<bool>,
     flag_color: Option<String>,
     flag_list: bool,
 }
@@ -41,8 +41,9 @@ and troubleshooting.
 ";
 
 pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
-    try!(config.shell().set_verbosity(options.flag_verbose, options.flag_quiet));
-    try!(config.shell().set_color_config(options.flag_color.as_ref().map(|s| &s[..])));
+    try!(config.configure_shell(options.flag_verbose,
+                                options.flag_quiet,
+                                &options.flag_color));
     let opts = ops::OwnersOptions {
         krate: options.arg_crate,
         token: options.flag_token,

--- a/src/bin/package.rs
+++ b/src/bin/package.rs
@@ -4,8 +4,8 @@ use cargo::util::important_paths::find_root_manifest_for_wd;
 
 #[derive(RustcDecodable)]
 pub struct Options {
-    flag_verbose: bool,
-    flag_quiet: bool,
+    flag_verbose: Option<bool>,
+    flag_quiet: Option<bool>,
     flag_color: Option<String>,
     flag_manifest_path: Option<String>,
     flag_no_verify: bool,
@@ -32,8 +32,9 @@ Options:
 ";
 
 pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
-    try!(config.shell().set_verbosity(options.flag_verbose, options.flag_quiet));
-    try!(config.shell().set_color_config(options.flag_color.as_ref().map(|s| &s[..])));
+    try!(config.configure_shell(options.flag_verbose,
+                                options.flag_quiet,
+                                &options.flag_color));
     let root = try!(find_root_manifest_for_wd(options.flag_manifest_path, config.cwd()));
     try!(ops::package(&root, config,
                       !options.flag_no_verify,

--- a/src/bin/pkgid.rs
+++ b/src/bin/pkgid.rs
@@ -4,8 +4,8 @@ use cargo::util::important_paths::{find_root_manifest_for_wd};
 
 #[derive(RustcDecodable)]
 pub struct Options {
-    flag_verbose: bool,
-    flag_quiet: bool,
+    flag_verbose: Option<bool>,
+    flag_quiet: Option<bool>,
     flag_color: Option<String>,
     flag_manifest_path: Option<String>,
     arg_spec: Option<String>,
@@ -47,8 +47,9 @@ Example Package IDs
 
 pub fn execute(options: Options,
                config: &Config) -> CliResult<Option<()>> {
-    try!(config.shell().set_verbosity(options.flag_verbose, options.flag_quiet));
-    try!(config.shell().set_color_config(options.flag_color.as_ref().map(|s| &s[..])));
+    try!(config.configure_shell(options.flag_verbose,
+                                options.flag_quiet,
+                                &options.flag_color));
     let root = try!(find_root_manifest_for_wd(options.flag_manifest_path.clone(), config.cwd()));
 
     let spec = options.arg_spec.as_ref().map(|s| &s[..]);

--- a/src/bin/publish.rs
+++ b/src/bin/publish.rs
@@ -7,8 +7,8 @@ pub struct Options {
     flag_host: Option<String>,
     flag_token: Option<String>,
     flag_manifest_path: Option<String>,
-    flag_verbose: bool,
-    flag_quiet: bool,
+    flag_verbose: Option<bool>,
+    flag_quiet: Option<bool>,
     flag_color: Option<String>,
     flag_no_verify: bool,
 }
@@ -32,8 +32,9 @@ Options:
 ";
 
 pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
-    try!(config.shell().set_verbosity(options.flag_verbose, options.flag_quiet));
-    try!(config.shell().set_color_config(options.flag_color.as_ref().map(|s| &s[..])));
+    try!(config.configure_shell(options.flag_verbose,
+                                options.flag_quiet,
+                                &options.flag_color));
     let Options {
         flag_token: token,
         flag_host: host,

--- a/src/bin/run.rs
+++ b/src/bin/run.rs
@@ -11,8 +11,8 @@ pub struct Options {
     flag_no_default_features: bool,
     flag_target: Option<String>,
     flag_manifest_path: Option<String>,
-    flag_verbose: bool,
-    flag_quiet: bool,
+    flag_verbose: Option<bool>,
+    flag_quiet: Option<bool>,
     flag_color: Option<String>,
     flag_release: bool,
     arg_args: Vec<String>,
@@ -49,8 +49,9 @@ the ones before go to Cargo.
 ";
 
 pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
-    try!(config.shell().set_verbosity(options.flag_verbose, options.flag_quiet));
-    try!(config.shell().set_color_config(options.flag_color.as_ref().map(|s| &s[..])));
+    try!(config.configure_shell(options.flag_verbose,
+                                options.flag_quiet,
+                                &options.flag_color));
 
     let root = try!(find_root_manifest_for_wd(options.flag_manifest_path, config.cwd()));
 

--- a/src/bin/rustc.rs
+++ b/src/bin/rustc.rs
@@ -14,8 +14,8 @@ pub struct Options {
     flag_no_default_features: bool,
     flag_target: Option<String>,
     flag_manifest_path: Option<String>,
-    flag_verbose: bool,
-    flag_quiet: bool,
+    flag_verbose: Option<bool>,
+    flag_quiet: Option<bool>,
     flag_color: Option<String>,
     flag_release: bool,
     flag_lib: bool,
@@ -66,8 +66,9 @@ must be used to select which target is compiled.
 pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
     debug!("executing; cmd=cargo-rustc; args={:?}",
            env::args().collect::<Vec<_>>());
-    try!(config.shell().set_verbosity(options.flag_verbose, options.flag_quiet));
-    try!(config.shell().set_color_config(options.flag_color.as_ref().map(|s| &s[..])));
+    try!(config.configure_shell(options.flag_verbose,
+                                options.flag_quiet,
+                                &options.flag_color));
 
     let root = try!(find_root_manifest_for_wd(options.flag_manifest_path,
                                               config.cwd()));

--- a/src/bin/rustdoc.rs
+++ b/src/bin/rustdoc.rs
@@ -11,9 +11,9 @@ pub struct Options {
     flag_manifest_path: Option<String>,
     flag_no_default_features: bool,
     flag_open: bool,
-    flag_verbose: bool,
+    flag_verbose: Option<bool>,
     flag_release: bool,
-    flag_quiet: bool,
+    flag_quiet: Option<bool>,
     flag_color: Option<String>,
     flag_package: Option<String>,
     flag_lib: bool,
@@ -62,8 +62,9 @@ the `cargo help pkgid` command.
 ";
 
 pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
-    try!(config.shell().set_verbosity(options.flag_verbose, options.flag_quiet));
-    try!(config.shell().set_color_config(options.flag_color.as_ref().map(|s| &s[..])));
+    try!(config.configure_shell(options.flag_verbose,
+                                options.flag_quiet,
+                                &options.flag_color));
 
     let root = try!(find_root_manifest_for_wd(options.flag_manifest_path,
                                               config.cwd()));

--- a/src/bin/search.rs
+++ b/src/bin/search.rs
@@ -4,8 +4,8 @@ use cargo::util::{CliResult, Config};
 #[derive(RustcDecodable)]
 pub struct Options {
     flag_host: Option<String>,
-    flag_verbose: bool,
-    flag_quiet: bool,
+    flag_verbose: Option<bool>,
+    flag_quiet: Option<bool>,
     flag_color: Option<String>,
     arg_query: String
 }
@@ -26,8 +26,9 @@ Options:
 ";
 
 pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
-    try!(config.shell().set_verbosity(options.flag_verbose, options.flag_quiet));
-    try!(config.shell().set_color_config(options.flag_color.as_ref().map(|s| &s[..])));
+    try!(config.configure_shell(options.flag_verbose,
+                                options.flag_quiet,
+                                &options.flag_color));
     let Options {
         flag_host: host,
         arg_query: query,

--- a/src/bin/test.rs
+++ b/src/bin/test.rs
@@ -17,8 +17,8 @@ pub struct Options {
     flag_example: Vec<String>,
     flag_test: Vec<String>,
     flag_bench: Vec<String>,
-    flag_verbose: bool,
-    flag_quiet: bool,
+    flag_verbose: Option<bool>,
+    flag_quiet: Option<bool>,
     flag_color: Option<String>,
     flag_release: bool,
     flag_no_fail_fast: bool,
@@ -74,9 +74,10 @@ by passing `--nocapture` to the test binaries:
 ";
 
 pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
+    try!(config.configure_shell(options.flag_verbose,
+                                options.flag_quiet,
+                                &options.flag_color));
     let root = try!(find_root_manifest_for_wd(options.flag_manifest_path, config.cwd()));
-    try!(config.shell().set_verbosity(options.flag_verbose, options.flag_quiet));
-    try!(config.shell().set_color_config(options.flag_color.as_ref().map(|s| &s[..])));
 
     let ops = ops::TestOptions {
         no_run: options.flag_no_run,

--- a/src/bin/uninstall.rs
+++ b/src/bin/uninstall.rs
@@ -5,8 +5,8 @@ use cargo::util::{CliResult, Config};
 pub struct Options {
     flag_bin: Vec<String>,
     flag_root: Option<String>,
-    flag_verbose: bool,
-    flag_quiet: bool,
+    flag_verbose: Option<bool>,
+    flag_quiet: Option<bool>,
     flag_color: Option<String>,
 
     arg_spec: String,
@@ -34,8 +34,9 @@ only uninstall particular binaries.
 ";
 
 pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
-    try!(config.shell().set_verbosity(options.flag_verbose, options.flag_quiet));
-    try!(config.shell().set_color_config(options.flag_color.as_ref().map(|s| &s[..])));
+    try!(config.configure_shell(options.flag_verbose,
+                                options.flag_quiet,
+                                &options.flag_color));
 
     let root = options.flag_root.as_ref().map(|s| &s[..]);
     try!(ops::uninstall(root, &options.arg_spec, &options.flag_bin, config));

--- a/src/bin/update.rs
+++ b/src/bin/update.rs
@@ -10,8 +10,8 @@ pub struct Options {
     flag_aggressive: bool,
     flag_precise: Option<String>,
     flag_manifest_path: Option<String>,
-    flag_verbose: bool,
-    flag_quiet: bool,
+    flag_verbose: Option<bool>,
+    flag_quiet: Option<bool>,
     flag_color: Option<String>,
 }
 
@@ -54,8 +54,9 @@ For more information about package id specifications, see `cargo help pkgid`.
 
 pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
     debug!("executing; cmd=cargo-update; args={:?}", env::args().collect::<Vec<_>>());
-    try!(config.shell().set_verbosity(options.flag_verbose, options.flag_quiet));
-    try!(config.shell().set_color_config(options.flag_color.as_ref().map(|s| &s[..])));
+    try!(config.configure_shell(options.flag_verbose,
+                                options.flag_quiet,
+                                &options.flag_color));
     let root = try!(find_root_manifest_for_wd(options.flag_manifest_path, config.cwd()));
 
     let update_opts = ops::UpdateOptions {

--- a/src/bin/verify_project.rs
+++ b/src/bin/verify_project.rs
@@ -13,8 +13,8 @@ pub type Error = HashMap<String, String>;
 #[derive(RustcDecodable)]
 pub struct Flags {
     flag_manifest_path: Option<String>,
-    flag_verbose: bool,
-    flag_quiet: bool,
+    flag_verbose: Option<bool>,
+    flag_quiet: Option<bool>,
     flag_color: Option<String>,
 }
 
@@ -34,8 +34,9 @@ Options:
 ";
 
 pub fn execute(args: Flags, config: &Config) -> CliResult<Option<Error>> {
-    try!(config.shell().set_verbosity(args.flag_verbose, args.flag_quiet));
-    try!(config.shell().set_color_config(args.flag_color.as_ref().map(|s| &s[..])));
+    try!(config.configure_shell(args.flag_verbose,
+                                args.flag_quiet,
+                                &args.flag_color));
 
     let mut contents = String::new();
     let filename = args.flag_manifest_path.unwrap_or("Cargo.toml".into());

--- a/src/bin/yank.rs
+++ b/src/bin/yank.rs
@@ -7,8 +7,8 @@ pub struct Options {
     flag_token: Option<String>,
     flag_vers: Option<String>,
     flag_index: Option<String>,
-    flag_verbose: bool,
-    flag_quiet: bool,
+    flag_verbose: Option<bool>,
+    flag_quiet: Option<bool>,
     flag_color: Option<String>,
     flag_undo: bool,
 }
@@ -39,8 +39,9 @@ crates to be locked to any yanked version.
 ";
 
 pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
-    try!(config.shell().set_verbosity(options.flag_verbose, options.flag_quiet));
-    try!(config.shell().set_color_config(options.flag_color.as_ref().map(|s| &s[..])));
+    try!(config.configure_shell(options.flag_verbose,
+                                options.flag_quiet,
+                                &options.flag_color));
     try!(ops::yank(config,
                    options.arg_crate,
                    options.flag_vers,

--- a/src/cargo/util/errors.rs
+++ b/src/cargo/util/errors.rs
@@ -311,6 +311,7 @@ from_error! {
     ffi::NulError,
     term::Error,
     num::ParseIntError,
+    str::ParseBoolError,
 }
 
 impl From<string::ParseError> for Box<CargoError> {
@@ -338,6 +339,7 @@ impl CargoError for url::ParseError {}
 impl CargoError for ffi::NulError {}
 impl CargoError for term::Error {}
 impl CargoError for num::ParseIntError {}
+impl CargoError for str::ParseBoolError {}
 
 // =============================================================================
 // Construction helpers

--- a/src/doc/config.md
+++ b/src/doc/config.md
@@ -84,6 +84,10 @@ rustc = "rustc"        # the rust compiler tool
 rustdoc = "rustdoc"    # the doc generator tool
 target = "triple"      # build for the target triple
 target-dir = "target"  # path of where to place all generated artifacts
+
+[term]
+verbose = false        # whether cargo provides verbose output
+color = 'auto'         # whether cargo colorizes output
 ```
 
 # Environment Variables


### PR DESCRIPTION
This commit adds configuration keys for:

    [term]
    verbose = true
    color = 'auto'

These are all meant to be proxies for the command line flags but configured on a
global basis if desired.