### PR TITLE
Read configuration from environment variables

### DIFF
--- a/src/cargo/ops/cargo_install.rs
+++ b/src/cargo/ops/cargo_install.rs
@@ -340,11 +340,11 @@ pub fn uninstall(root: Option<&str>,
 }
 
 fn resolve_root(flag: Option<&str>, config: &Config) -> CargoResult<PathBuf> {
-    let config_root = try!(config.get_string("install.root"));
+    let config_root = try!(config.get_path("install.root"));
     Ok(flag.map(PathBuf::from).or_else(|| {
         env::var_os("CARGO_INSTALL_ROOT").map(PathBuf::from)
-    }).or_else(|| {
-        config_root.clone().map(|(v, _)| PathBuf::from(v))
+    }).or_else(move || {
+        config_root.map(|v| v.val)
     }).unwrap_or_else(|| {
         config.home().to_owned()
     }))

--- a/src/cargo/ops/registry.rs
+++ b/src/cargo/ops/registry.rs
@@ -126,8 +126,8 @@ fn transmit(pkg: &Package, tarball: &Path, registry: &mut Registry)
 }
 
 pub fn registry_configuration(config: &Config) -> CargoResult<RegistryConfig> {
-    let index = try!(config.get_string("registry.index")).map(|p| p.0);
-    let token = try!(config.get_string("registry.token")).map(|p| p.0);
+    let index = try!(config.get_string("registry.index")).map(|p| p.val);
+    let token = try!(config.get_string("registry.token")).map(|p| p.val);
     Ok(RegistryConfig { index: index, token: token })
 }
 
@@ -182,7 +182,7 @@ pub fn http_handle(config: &Config) -> CargoResult<http::Handle> {
 /// via environment variables are picked up by libcurl.
 fn http_proxy(config: &Config) -> CargoResult<Option<String>> {
     match try!(config.get_string("http.proxy")) {
-        Some((s, _)) => return Ok(Some(s)),
+        Some(s) => return Ok(Some(s.val)),
         None => {}
     }
     match git2::Config::open_default() {
@@ -218,7 +218,7 @@ pub fn http_proxy_exists(config: &Config) -> CargoResult<bool> {
 
 pub fn http_timeout(config: &Config) -> CargoResult<Option<i64>> {
     match try!(config.get_i64("http.timeout")) {
-        Some((s, _)) => return Ok(Some(s)),
+        Some(s) => return Ok(Some(s.val)),
         None => {}
     }
     Ok(env::var("HTTP_TIMEOUT").ok().and_then(|s| s.parse().ok()))

--- a/src/cargo/util/config.rs
+++ b/src/cargo/util/config.rs
@@ -117,7 +117,7 @@ impl Config {
         *self.target_dir.borrow_mut() = Some(path.to_owned());
     }
 
-    pub fn get(&self, key: &str) -> CargoResult<Option<ConfigValue>> {
+    fn get(&self, key: &str) -> CargoResult<Option<ConfigValue>> {
         let vals = try!(self.values());
         let mut parts = key.split('.').enumerate();
         let mut val = match vals.get(parts.next().unwrap().1) {
@@ -496,7 +496,7 @@ impl ConfigValue {
 }
 
 impl Definition {
-    pub fn root<'a>(&'a self, config: &'a Config) -> &'a Path {
+    pub fn root<'a>(&'a self, _config: &'a Config) -> &'a Path {
         match *self {
             Definition::Path(ref p) => p.parent().unwrap().parent().unwrap(),
         }

--- a/src/cargo/util/errors.rs
+++ b/src/cargo/util/errors.rs
@@ -2,8 +2,10 @@ use std::error::Error;
 use std::ffi;
 use std::fmt;
 use std::io;
+use std::num;
 use std::process::{Output, ExitStatus};
 use std::str;
+use std::string;
 
 use curl;
 use git2;
@@ -308,6 +310,13 @@ from_error! {
     toml::DecodeError,
     ffi::NulError,
     term::Error,
+    num::ParseIntError,
+}
+
+impl From<string::ParseError> for Box<CargoError> {
+    fn from(t: string::ParseError) -> Box<CargoError> {
+        match t {}
+    }
 }
 
 impl<E: CargoError> From<Human<E>> for Box<CargoError> {
@@ -328,6 +337,7 @@ impl CargoError for toml::DecodeError {}
 impl CargoError for url::ParseError {}
 impl CargoError for ffi::NulError {}
 impl CargoError for term::Error {}
+impl CargoError for num::ParseIntError {}
 
 // =============================================================================
 // Construction helpers

--- a/src/doc/config.md
+++ b/src/doc/config.md
@@ -90,8 +90,16 @@ target-dir = "target"  # path of where to place all generated artifacts
 
 # Environment Variables
 
-Cargo recognizes a few global [environment variables][env] to configure itself.
-Settings specified via config files take precedence over those specified via
+Cargo can also be configured through environment variables in addition to the
+TOML syntax above. For each configuration key above of the form `foo.bar` the
+environment variable `CARGO_FOO_BAR` can also be used to define the value. For
+example the `build.jobs` key can also be defined by `CARGO_BUILD_JOBS`.
+
+Environment variables will take precedent over TOML configuration, and currently
+only integer, boolean, and string keys are supported to be defined by
 environment variables.
+
+In addition to the system above, Cargo recognizes a few other specific
+[environment variables][env].
 
 [env]: environment-variables.html

--- a/tests/test_cargo_config.rs
+++ b/tests/test_cargo_config.rs
@@ -1,0 +1,26 @@
+use support::{project, execs};
+use hamcrest::assert_that;
+
+fn setup() {
+}
+
+test!(read_env_vars_for_config {
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [package]
+            name = "foo"
+            authors = []
+            version = "0.0.0"
+            build = "build.rs"
+        "#)
+        .file("src/lib.rs", "")
+        .file("build.rs", r#"
+            use std::env;
+            fn main() {
+                assert_eq!(env::var("NUM_JOBS").unwrap(), "100");
+            }
+        "#);
+
+    assert_that(p.cargo_process("build").env("CARGO_BUILD_JOBS", "100"),
+                execs().with_status(0));
+});

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -66,6 +66,7 @@ mod test_cargo_rustdoc;
 mod test_cargo_search;
 mod test_cargo_test;
 mod test_cargo_tool_paths;
+mod test_cargo_config;
 mod test_cargo_verify_project;
 mod test_cargo_version;
 mod test_shell;


### PR DESCRIPTION
This commit adds a more principled system to rationalize what ends up being a
configuration value versus an environment variable. This problem is solved by
just saying that they're one and the same! Similar to Bundler, this commit
supports overriding the `foo.bar` configuration value with the `CARGO_FOO_BAR`
environment variable.

Currently this is used as part of the `get_string` and `get_i64` methods on
`Config`. This means, for example, that the following environment variables can
now be used to configure Cargo:

* CARGO_BUILD_JOBS
* CARGO_HTTP_TIMEOUT
* CARGO_HTTP_PROXY

Currently it's not supported to encode a list in an environment variable, so for
example `CARGO_PATHS` would not be read when reading the global `paths`
configuration value.

cc #2362
cc #2395 -- intended to close this in tandem with #2397