### PR TITLE
Respect git conventions when validating certs

### DIFF
--- a/src/cargo/sources/git/utils.rs
+++ b/src/cargo/sources/git/utils.rs
@@ -1,6 +1,7 @@
+use std::env;
 use std::fmt;
-use std::path::{Path, PathBuf};
 use std::fs::{self, File};
+use std::path::{Path, PathBuf};
 
 use rustc_serialize::{Encodable, Encoder};
 use url::Url;
@@ -422,11 +423,17 @@ fn with_authentication<T, F>(url: &str, cfg: &git2::Config, mut f: F)
 
 pub fn fetch(repo: &git2::Repository, url: &str,
              refspec: &str) -> CargoResult<()> {
-    // Create a local anonymous remote in the repository to fetch the url
-
-    with_authentication(url, &try!(repo.config()), |f| {
+    let config = try!(repo.config());
+    let noverify = env::var("GIT_SSL_NO_VERIFY").is_ok() ||
+                   config.get_bool("http.sslVerify").ok() == Some(false);
+    with_authentication(url, &config, |f| {
         let mut cb = git2::RemoteCallbacks::new();
         cb.credentials(f);
+        if noverify {
+            cb.certificate_check(|_, _| true);
+        }
+
+        // Create a local anonymous remote in the repository to fetch the url
         let mut remote = try!(repo.remote_anonymous(&url));
         let mut opts = git2::FetchOptions::new();
         opts.remote_callbacks(cb)


### PR DESCRIPTION
Git supports the `http.sslVerify` option as well as the `GIT_SSL_NO_VERIFY`
environment variable for disabling validation of SSL certificates. This was
removed from libgit2 in libgit2/libgit2@41698f22 citing bad security practice
and how applications now had enough information to decide for themselves.

There seems to be enough corporate environments (as mentioned in #1180) where
certificate validation won't work that this seems prudent for Cargo to support.

Closes #1180