### PR TITLE
Ignore *.bk files generated by rustfmt in cargo-generated .gitignore

### DIFF
--- a/src/cargo/ops/cargo_new.rs
+++ b/src/cargo/ops/cargo_new.rs
@@ -316,7 +316,7 @@ fn mk(config: &Config, opts: &MkOptions) -> CargoResult<()> {
     let path = opts.path;
     let name = opts.name;
     let cfg = try!(global_config(config));
-    let mut ignore = "target\n".to_string();
+    let mut ignore = "target\n*.bk\n".to_string();
     let in_existing_vcs_repo = existing_vcs_repo(path.parent().unwrap(), config.cwd());
     if !opts.bin {
         ignore.push_str("Cargo.lock\n");


### PR DESCRIPTION
This will also avoid having `.bk` files published to crates.io.