### PR TITLE
Ensure metadata for libs/bins are distinct

### DIFF
--- a/src/cargo/util/toml.rs
+++ b/src/cargo/util/toml.rs
@@ -835,9 +835,14 @@ fn normalize(lib: &Option<TomlLibTarget>,
             }
         };
 
+        // Binaries, examples, etc, may link to this library. Their crate names
+        // have a high likelihood to being the same as ours, however, so we need
+        // some extra metadata in our name to ensure symbols won't collide.
+        let mut metadata = metadata.clone();
+        metadata.mix(&"lib");
         let mut target = Target::lib_target(&l.name(), crate_types,
                                             &path.to_path(),
-                                            metadata.clone());
+                                            metadata);
         configure(l, &mut target);
         dst.push(target);
     }


### PR DESCRIPTION
It may be the case in the future that the compiler will require that the "salt"
(the `-C metadata` flag) for all crates with the same name are distinct. Right
now a Cargo project with a library and a binary, however, will have the same
salt with the same crate name.

This commit mixes in some extra data to the library's salt to ensure that its
symbols don't clash with the binary's.