### PR TITLE
Dull the errors

### DIFF
--- a/src/bin/bench.rs
+++ b/src/bin/bench.rs
@@ -95,7 +95,7 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
         None => Ok(None),
         Some(err) => {
             Err(match err.exit.as_ref().and_then(|e| e.code()) {
-                Some(i) => CliError::new("", i),
+                Some(i) => CliError::new("bench failed", i),
                 None => CliError::from_error(Human(err), 101)
             })
         }

--- a/src/bin/test.rs
+++ b/src/bin/test.rs
@@ -107,7 +107,7 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
         None => Ok(None),
         Some(err) => {
             Err(match err.exit.as_ref().and_then(|e| e.code()) {
-                Some(i) => CliError::new("", i),
+                Some(i) => CliError::new("test failed", i),
                 None => CliError::from_error(Human(err), 101)
             })
         }

--- a/src/cargo/core/shell.rs
+++ b/src/cargo/core/shell.rs
@@ -96,7 +96,7 @@ impl MultiShell {
     }
 
     pub fn error<T: ToString>(&mut self, message: T) -> CargoResult<()> {
-        self.err().say(message, RED)
+        self.err().say_status("error", message.to_string(), RED)
     }
 
     pub fn warn<T: ToString>(&mut self, message: T) -> CargoResult<()> {

--- a/src/cargo/lib.rs
+++ b/src/cargo/lib.rs
@@ -181,9 +181,15 @@ pub fn shell(verbosity: Verbosity, color_config: ColorConfig) -> MultiShell {
 // For fatal errors, print to stderr;
 // and for others, e.g. docopt version info, print to stdout.
 fn output(err: String, shell: &mut MultiShell, fatal: bool) {
-    let std_shell = if fatal {shell.err()} else {shell.out()};
-    let color = if fatal {RED} else {BLACK};
-    let _ = std_shell.say(err, color);
+    let (std_shell, color, message) = if fatal {
+        (shell.err(), RED, Some("error"))
+    } else {
+        (shell.out(), BLACK, None)
+    };
+    let _ = match message{
+        Some(text) => std_shell.say_status(text, err.to_string(), color),
+        None => std_shell.say(err, color)
+    };
 }
 
 pub fn handle_error(err: CliError, shell: &mut MultiShell) {
@@ -194,7 +200,7 @@ pub fn handle_error(err: CliError, shell: &mut MultiShell) {
 
     let hide = unknown && shell.get_verbose() != Verbose;
     if hide {
-        let _ = shell.err().say("An unknown error occurred", RED);
+        let _ = shell.err().say_status("error", "An unknown error occurred", RED);
     } else {
         output(error.to_string(), shell, fatal);
     }

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -653,6 +653,7 @@ pub fn path2url(p: PathBuf) -> Url {
 
 pub static RUNNING:     &'static str = "     Running";
 pub static COMPILING:   &'static str = "   Compiling";
+pub static ERROR:       &'static str = "       error";
 pub static DOCUMENTING: &'static str = " Documenting";
 pub static FRESH:       &'static str = "       Fresh";
 pub static UPDATING:    &'static str = "    Updating";

--- a/tests/test_bad_manifest_path.rs
+++ b/tests/test_bad_manifest_path.rs
@@ -1,4 +1,4 @@
-use support::{project, execs, main_file, basic_bin_manifest};
+use support::{project, execs, main_file, basic_bin_manifest, ERROR};
 use hamcrest::{assert_that};
 
 fn setup() {}
@@ -12,7 +12,9 @@ fn assert_not_a_cargo_toml(command: &str, manifest_path_argument: &str) {
                  .arg("--manifest-path").arg(manifest_path_argument)
                  .cwd(p.root().parent().unwrap()),
                 execs().with_status(101)
-                       .with_stderr("the manifest-path must be a path to a Cargo.toml file"));
+                       .with_stderr(&format!("{error} the manifest-path must be a path \
+                                             to a Cargo.toml file",
+                                             error = ERROR)));
 }
 
 #[allow(deprecated)] // connect => join in 1.3
@@ -26,7 +28,8 @@ fn assert_cargo_toml_doesnt_exist(command: &str, manifest_path_argument: &str) {
                  .cwd(p.root().parent().unwrap()),
                 execs().with_status(101)
                        .with_stderr(
-                           format!("manifest path `{}` does not exist", expected_path)
+                           format!("{error} manifest path `{}` does not exist",
+                                   expected_path, error = ERROR)
                        ));
 }
 

--- a/tests/test_cargo.rs
+++ b/tests/test_cargo.rs
@@ -7,7 +7,7 @@ use std::str;
 
 use cargo_process;
 use support::paths;
-use support::{execs, project, mkdir_recursive, ProjectBuilder};
+use support::{execs, project, mkdir_recursive, ProjectBuilder, ERROR};
 use hamcrest::{assert_that};
 
 fn setup() {
@@ -61,11 +61,12 @@ test!(find_closest_biuld_to_build {
 
     assert_that(pr,
                 execs().with_status(101)
-                       .with_stderr("no such subcommand
+                       .with_stderr(&format!("{error} no such subcommand
 
 <tab>Did you mean `build`?
 
-"));
+",
+error = ERROR)));
 });
 
 // if a subcommand is more than 3 edit distance away, we don't make a suggestion
@@ -83,8 +84,9 @@ test!(find_closest_dont_correct_nonsense {
 
     assert_that(pr,
                 execs().with_status(101)
-                       .with_stderr("no such subcommand
-"));
+                       .with_stderr(&format!("{error} no such subcommand
+",
+error = ERROR)));
 });
 
 test!(override_cargo_home {

--- a/tests/test_cargo_build_auth.rs
+++ b/tests/test_cargo_build_auth.rs
@@ -6,7 +6,7 @@ use std::thread;
 use bufstream::BufStream;
 use git2;
 
-use support::{project, execs, UPDATING};
+use support::{project, execs, UPDATING, ERROR};
 use support::paths;
 use hamcrest::assert_that;
 
@@ -101,7 +101,7 @@ test!(http_auth_offered {
         addr = addr,
         ))
                       .with_stderr(&format!("\
-Unable to update http://{addr}/foo/bar
+{error} Unable to update http://{addr}/foo/bar
 
 Caused by:
   failed to clone into: [..]
@@ -112,7 +112,8 @@ attempted to find username/password via `credential.helper`, but [..]
 
 To learn more, run the command again with --verbose.
 ",
-        addr = addr)));
+        addr = addr,
+        error = ERROR)));
 
     t.join().ok().unwrap();
 });
@@ -145,7 +146,7 @@ test!(https_something_happens {
         addr = addr,
         ))
                       .with_stderr(&format!("\
-Unable to update https://{addr}/foo/bar
+{error} Unable to update https://{addr}/foo/bar
 
 Caused by:
   failed to clone into: [..]
@@ -154,6 +155,7 @@ Caused by:
   {errmsg}
 ",
         addr = addr,
+        error = ERROR,
         errmsg = if cfg!(windows) {
             "[[..]] failed to send request: [..]\n"
         } else if cfg!(target_os = "macos") {
@@ -196,7 +198,7 @@ test!(ssh_something_happens {
         addr = addr,
         ))
                       .with_stderr(&format!("\
-Unable to update ssh://{addr}/foo/bar
+{error} Unable to update ssh://{addr}/foo/bar
 
 Caused by:
   failed to clone into: [..]
@@ -204,6 +206,7 @@ Caused by:
 Caused by:
   [[..]] Failed to start SSH session: Failed getting banner
 ",
-        addr = addr)));
+        addr = addr,
+        error = ERROR)));
     t.join().ok().unwrap();
 });

--- a/tests/test_cargo_build_lib.rs
+++ b/tests/test_cargo_build_lib.rs
@@ -1,6 +1,6 @@
 use std::path::MAIN_SEPARATOR as SEP;
 use support::{basic_bin_manifest, execs, project, ProjectBuilder};
-use support::{COMPILING, RUNNING};
+use support::{COMPILING, RUNNING, ERROR};
 use hamcrest::{assert_that};
 
 fn setup() {
@@ -50,7 +50,7 @@ test!(build_with_no_lib {
 
     assert_that(p.cargo_process("build").arg("--lib"),
                 execs().with_status(101)
-                       .with_stderr("no library targets found"));
+                       .with_stderr(&format!("{error} no library targets found", error = ERROR)));
 });
 
 test!(build_with_relative_cargo_home_path {

--- a/tests/test_cargo_cfg.rs
+++ b/tests/test_cargo_cfg.rs
@@ -4,7 +4,7 @@ use std::fmt;
 use cargo::util::{Cfg, CfgExpr};
 use hamcrest::assert_that;
 
-use support::{project, execs, COMPILING, UPDATING, DOWNLOADING};
+use support::{project, execs, COMPILING, UPDATING, DOWNLOADING, ERROR};
 use support::registry::Package;
 
 macro_rules! c {
@@ -235,15 +235,16 @@ test!(bad_target_spec {
         .file("src/lib.rs", "");
 
     assert_that(p.cargo_process("build"),
-                execs().with_status(101).with_stderr("\
-failed to parse manifest at `[..]`
+                execs().with_status(101).with_stderr(&format!("\
+{error} failed to parse manifest at `[..]`
 
 Caused by:
   failed to parse `4` as a cfg expression
 
 Caused by:
   unexpected character in cfg `4`, [..]
-"));
+",
+error = ERROR)));
 });
 
 test!(bad_target_spec2 {
@@ -260,15 +261,16 @@ test!(bad_target_spec2 {
         .file("src/lib.rs", "");
 
     assert_that(p.cargo_process("build"),
-                execs().with_status(101).with_stderr("\
-failed to parse manifest at `[..]`
+                execs().with_status(101).with_stderr(&format!("\
+{error} failed to parse manifest at `[..]`
 
 Caused by:
   failed to parse `foo =` as a cfg expression
 
 Caused by:
   expected a string, found nothing
-"));
+",
+error = ERROR)));
 });
 
 test!(multiple_match_ok {

--- a/tests/test_cargo_compile_git_deps.rs
+++ b/tests/test_cargo_compile_git_deps.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 use git2;
 
 use support::{git, project, execs, main_file, path2url};
-use support::{COMPILING, UPDATING, RUNNING};
+use support::{COMPILING, UPDATING, RUNNING, ERROR};
 use support::paths::{self, CargoPathExt};
 use hamcrest::{assert_that,existing_file};
 use cargo::util::process;
@@ -381,11 +381,11 @@ test!(cargo_compile_with_short_ssh_git {
         execs()
         .with_stdout("")
         .with_stderr(&format!("\
-failed to parse manifest at `[..]`
+{error} failed to parse manifest at `[..]`
 
 Caused by:
   invalid url `{}`: relative URL without a base
-", url)));
+", url, error = ERROR)));
 });
 
 test!(two_revs_same_deps {
@@ -650,11 +650,12 @@ test!(update_with_shared_deps {
     assert_that(p.cargo("update")
                  .arg("-p").arg("bar")
                  .arg("--precise").arg("0.1.2"),
-                execs().with_status(101).with_stderr("\
-Unable to update [..]
+                execs().with_status(101).with_stderr(&format!("\
+{error} Unable to update [..]
 
 To learn more, run the command again with --verbose.
-"));
+",
+error = ERROR)));
 
     // Specifying a precise rev to the old rev shouldn't actually update
     // anything because we already have the rev in the db.
@@ -1355,14 +1356,15 @@ test!(update_ambiguous {
     assert_that(p.cargo("update")
                  .arg("-p").arg("foo"),
                 execs().with_status(101)
-                       .with_stderr("\
-There are multiple `foo` packages in your project, and the specification `foo` \
+                       .with_stderr(&format!("\
+{error} There are multiple `foo` packages in your project, and the specification `foo` \
 is ambiguous.
 Please re-run this command with `-p <spec>` where `<spec>` is one of the \
 following:
   foo:0.[..].0
   foo:0.[..].0
-"));
+",
+error = ERROR)));
 });
 
 test!(update_one_dep_in_repo_with_many_deps {

--- a/tests/test_cargo_compile_path_deps.rs
+++ b/tests/test_cargo_compile_path_deps.rs
@@ -2,7 +2,7 @@ use std::fs::{self, File};
 use std::io::prelude::*;
 
 use support::{project, execs, main_file};
-use support::{COMPILING, RUNNING};
+use support::{COMPILING, RUNNING, ERROR};
 use support::paths::{self, CargoPathExt};
 use hamcrest::{assert_that, existing_file};
 use cargo::util::process;
@@ -510,15 +510,16 @@ test!(error_message_for_missing_manifest {
 
     assert_that(p.cargo_process("build"),
                 execs().with_status(101)
-                       .with_stderr("\
-Unable to update file://[..]
+                       .with_stderr(&format!("\
+{error} Unable to update file://[..]
 
 Caused by:
   failed to read `[..]bar[..]Cargo.toml`
 
 Caused by:
   [..] (os error [..])
-"));
+",
+error = ERROR)));
 
 });
 
@@ -854,8 +855,8 @@ test!(missing_path_dependency {
     p.build();
     assert_that(p.cargo("build"),
                 execs().with_status(101)
-                       .with_stderr("\
-failed to update path override `[..]../whoa-this-does-not-exist` \
+                       .with_stderr(format!("\
+{error} failed to update path override `[..]../whoa-this-does-not-exist` \
 (defined in `[..]`)
 
 Caused by:
@@ -863,5 +864,5 @@ Caused by:
 
 Caused by:
   [..] (os error [..])
-"));
+", error = ERROR)));
 });

--- a/tests/test_cargo_cross_compile.rs
+++ b/tests/test_cargo_cross_compile.rs
@@ -1,7 +1,7 @@
 use std::env;
 
 use support::{project, execs, basic_bin_manifest};
-use support::{RUNNING, COMPILING, DOCTEST};
+use support::{RUNNING, COMPILING, DOCTEST, ERROR};
 use hamcrest::{assert_that, existing_file};
 use cargo::util::process;
 
@@ -826,16 +826,16 @@ test!(platform_specific_dependencies_do_not_leak {
 
     assert_that(p.cargo_process("build").arg("-v").arg("--target").arg(&target),
                 execs().with_status(101)
-                       .with_stderr("\
+                       .with_stderr(format!("\
 [..] error: can't find crate for `d2`[..]
 [..] extern crate d2;
 [..]
 error: aborting due to previous error
-Could not compile `d1`.
+{error} Could not compile `d1`.
 
 Caused by:
   [..]
-"));
+", error = ERROR)));
 });
 
 test!(platform_specific_variables_reflected_in_build_scripts {

--- a/tests/test_cargo_doc.rs
+++ b/tests/test_cargo_doc.rs
@@ -2,7 +2,7 @@ use std::str;
 use std::fs;
 
 use support::{project, execs, path2url};
-use support::{COMPILING, DOCUMENTING, RUNNING};
+use support::{COMPILING, DOCUMENTING, RUNNING, ERROR};
 use hamcrest::{assert_that, existing_file, existing_dir, is_not};
 
 fn setup() {
@@ -206,10 +206,11 @@ test!(doc_lib_bin_same_name {
 
     assert_that(p.cargo_process("doc"),
                 execs().with_status(101)
-                       .with_stderr("\
-cannot document a package where a library and a binary have the same name. \
+                       .with_stderr(&format!("\
+{error} cannot document a package where a library and a binary have the same name. \
 Consider renaming one or marking the target as `doc = false`
-"));
+",
+error = ERROR)));
 });
 
 test!(doc_dash_p {

--- a/tests/test_cargo_features.rs
+++ b/tests/test_cargo_features.rs
@@ -2,7 +2,7 @@ use std::fs::File;
 use std::io::prelude::*;
 
 use support::{project, execs};
-use support::{COMPILING, FRESH};
+use support::{COMPILING, FRESH, ERROR};
 use support::paths::CargoPathExt;
 use hamcrest::assert_that;
 
@@ -24,11 +24,12 @@ test!(invalid1 {
 
     assert_that(p.cargo_process("build"),
                 execs().with_status(101).with_stderr(&format!("\
-failed to parse manifest at `[..]`
+{error} failed to parse manifest at `[..]`
 
 Caused by:
   Feature `bar` includes `baz` which is neither a dependency nor another feature
-")));
+",
+error = ERROR)));
 });
 
 test!(invalid2 {
@@ -49,11 +50,12 @@ test!(invalid2 {
 
     assert_that(p.cargo_process("build"),
                 execs().with_status(101).with_stderr(&format!("\
-failed to parse manifest at `[..]`
+{error} failed to parse manifest at `[..]`
 
 Caused by:
   Features and dependencies cannot have the same name: `bar`
-")));
+",
+error = ERROR)));
 });
 
 test!(invalid3 {
@@ -74,12 +76,13 @@ test!(invalid3 {
 
     assert_that(p.cargo_process("build"),
                 execs().with_status(101).with_stderr(&format!("\
-failed to parse manifest at `[..]`
+{error} failed to parse manifest at `[..]`
 
 Caused by:
   Feature `bar` depends on `baz` which is not an optional dependency.
 Consider adding `optional = true` to the dependency
-")));
+",
+error = ERROR)));
 });
 
 test!(invalid4 {
@@ -105,8 +108,9 @@ test!(invalid4 {
 
     assert_that(p.cargo_process("build"),
                 execs().with_status(101).with_stderr(&format!("\
-Package `bar v0.0.1 ([..])` does not have these features: `bar`
-")));
+{error} Package `bar v0.0.1 ([..])` does not have these features: `bar`
+",
+error = ERROR)));
 
     let p = p.file("Cargo.toml", r#"
             [project]
@@ -117,8 +121,9 @@ Package `bar v0.0.1 ([..])` does not have these features: `bar`
 
     assert_that(p.cargo_process("build").arg("--features").arg("test"),
                 execs().with_status(101).with_stderr(&format!("\
-Package `foo v0.0.1 ([..])` does not have these features: `test`
-")));
+{error} Package `foo v0.0.1 ([..])` does not have these features: `test`
+",
+error = ERROR)));
 });
 
 test!(invalid5 {
@@ -137,11 +142,12 @@ test!(invalid5 {
 
     assert_that(p.cargo_process("build"),
                 execs().with_status(101).with_stderr(&format!("\
-failed to parse manifest at `[..]`
+{error} failed to parse manifest at `[..]`
 
 Caused by:
   Dev-dependencies are not allowed to be optional: `bar`
-")));
+",
+error = ERROR)));
 });
 
 test!(invalid6 {
@@ -159,11 +165,12 @@ test!(invalid6 {
 
     assert_that(p.cargo_process("build").arg("--features").arg("foo"),
                 execs().with_status(101).with_stderr(&format!("\
-failed to parse manifest at `[..]`
+{error} failed to parse manifest at `[..]`
 
 Caused by:
   Feature `foo` requires `bar` which is not an optional dependency
-")));
+",
+error = ERROR)));
 });
 
 test!(invalid7 {
@@ -182,11 +189,12 @@ test!(invalid7 {
 
     assert_that(p.cargo_process("build").arg("--features").arg("foo"),
                 execs().with_status(101).with_stderr(&format!("\
-failed to parse manifest at `[..]`
+{error} failed to parse manifest at `[..]`
 
 Caused by:
   Feature `foo` requires `bar` which is not an optional dependency
-")));
+",
+error = ERROR)));
 });
 
 test!(invalid8 {
@@ -212,8 +220,9 @@ test!(invalid8 {
 
     assert_that(p.cargo_process("build").arg("--features").arg("foo"),
                 execs().with_status(101).with_stderr(&format!("\
-features in dependencies cannot enable features in other dependencies: `foo/bar`
-")));
+{error} features in dependencies cannot enable features in other dependencies: `foo/bar`
+",
+error = ERROR)));
 });
 
 test!(no_feature_doesnt_build {
@@ -321,9 +330,10 @@ test!(cyclic_feature {
         .file("src/main.rs", "");
 
     assert_that(p.cargo_process("build"),
-                execs().with_status(101).with_stderr("\
-Cyclic feature dependency: feature `default` depends on itself
-"));
+                execs().with_status(101).with_stderr(&format!("\
+{error} Cyclic feature dependency: feature `default` depends on itself
+",
+error = ERROR)));
 });
 
 test!(cyclic_feature2 {
@@ -341,9 +351,10 @@ test!(cyclic_feature2 {
         .file("src/main.rs", "");
 
     assert_that(p.cargo_process("build"),
-                execs().with_status(101).with_stderr("\
-Cyclic feature dependency: feature `[..]` depends on itself
-"));
+                execs().with_status(101).with_stderr(&format!("\
+{error} Cyclic feature dependency: feature `[..]` depends on itself
+",
+error = ERROR)));
 });
 
 test!(groups_on_groups_on_groups {

--- a/tests/test_cargo_init.rs
+++ b/tests/test_cargo_init.rs
@@ -2,7 +2,7 @@ use std::fs::{self, File};
 use std::io::prelude::*;
 use std::env;
 use tempdir::TempDir;
-use support::{execs, paths, cargo_dir};
+use support::{execs, paths, cargo_dir, ERROR};
 use hamcrest::{assert_that, existing_file, existing_dir, is_not};
 
 use cargo::util::{process, ProcessBuilder};
@@ -49,17 +49,17 @@ test!(simple_bin {
 fn bin_already_exists(explicit: bool, rellocation: &str) {
     let path = paths::root().join("foo");
     fs::create_dir_all(&path.join("src")).unwrap();
-    
+
     let sourcefile_path = path.join(rellocation);
-    
+
     let content = br#"
         fn main() {
             println!("Hello, world 2!");
         }
     "#;
-    
+
     File::create(&sourcefile_path).unwrap().write_all(content).unwrap();
-    
+
     if explicit {
         assert_that(cargo_process("init").arg("--bin").arg("--vcs").arg("none")
                                         .env("USER", "foo").cwd(&path),
@@ -72,7 +72,7 @@ fn bin_already_exists(explicit: bool, rellocation: &str) {
 
     assert_that(&paths::root().join("foo/Cargo.toml"), existing_file());
     assert_that(&paths::root().join("foo/src/lib.rs"), is_not(existing_file()));
-    
+
     // Check that our file is not overwritten
     let mut new_content = Vec::new();
     File::open(&sourcefile_path).unwrap().read_to_end(&mut new_content).unwrap();
@@ -106,29 +106,30 @@ test!(bin_already_exists_implicit_namesrc {
 test!(confused_by_multiple_lib_files {
     let path = paths::root().join("foo");
     fs::create_dir_all(&path.join("src")).unwrap();
-    
+
     let sourcefile_path1 = path.join("src/lib.rs");
-    
+
     File::create(&sourcefile_path1).unwrap().write_all(br#"
         fn qqq () {
             println!("Hello, world 2!");
         }
     "#).unwrap();
-    
+
     let sourcefile_path2 = path.join("lib.rs");
-    
+
     File::create(&sourcefile_path2).unwrap().write_all(br#"
         fn qqq () {
             println!("Hello, world 3!");
         }
     "#).unwrap();
-    
+
     assert_that(cargo_process("init").arg("--vcs").arg("none")
                                     .env("USER", "foo").cwd(&path),
-                execs().with_status(101).with_stderr("\
-cannot have a project with multiple libraries, found both `src/lib.rs` and `lib.rs`
-"));
-    
+                execs().with_status(101).with_stderr(&format!("\
+{error} cannot have a project with multiple libraries, found both `src/lib.rs` and `lib.rs`
+",
+error = ERROR)));
+
     assert_that(&paths::root().join("foo/Cargo.toml"), is_not(existing_file()));
 });
 
@@ -136,54 +137,55 @@ cannot have a project with multiple libraries, found both `src/lib.rs` and `lib.
 test!(multibin_project_name_clash {
     let path = paths::root().join("foo");
     fs::create_dir(&path).unwrap();
-    
+
     let sourcefile_path1 = path.join("foo.rs");
-    
+
     File::create(&sourcefile_path1).unwrap().write_all(br#"
         fn main () {
             println!("Hello, world 2!");
         }
     "#).unwrap();
-    
+
     let sourcefile_path2 = path.join("main.rs");
-    
+
     File::create(&sourcefile_path2).unwrap().write_all(br#"
         fn main () {
             println!("Hello, world 3!");
         }
     "#).unwrap();
-    
+
     assert_that(cargo_process("init").arg("--vcs").arg("none")
                                     .env("USER", "foo").cwd(&path),
-                execs().with_status(101).with_stderr("\
-multiple possible binary sources found:
+                execs().with_status(101).with_stderr(&format!("\
+{error} multiple possible binary sources found:
   main.rs
   foo.rs
 cannot automatically generate Cargo.toml as the main target would be ambiguous
-"));
-                
+",
+error = ERROR)));
+
     assert_that(&paths::root().join("foo/Cargo.toml"), is_not(existing_file()));
 });
 
 fn lib_already_exists(rellocation: &str) {
     let path = paths::root().join("foo");
     fs::create_dir_all(&path.join("src")).unwrap();
-    
+
     let sourcefile_path = path.join(rellocation);
-    
+
     let content = br#"
         pub fn qqq() {}
     "#;
-    
+
     File::create(&sourcefile_path).unwrap().write_all(content).unwrap();
-    
+
     assert_that(cargo_process("init").arg("--vcs").arg("none")
                                     .env("USER", "foo").cwd(&path),
                 execs().with_status(0));
 
     assert_that(&paths::root().join("foo/Cargo.toml"), existing_file());
     assert_that(&paths::root().join("foo/src/main.rs"), is_not(existing_file()));
-    
+
     // Check that our file is not overwritten
     let mut new_content = Vec::new();
     File::open(&sourcefile_path).unwrap().read_to_end(&mut new_content).unwrap();
@@ -228,21 +230,22 @@ test!(invalid_dir_name {
     fs::create_dir_all(&foo).unwrap();
     assert_that(cargo_process("init").cwd(foo.clone())
                                      .env("USER", "foo"),
-                execs().with_status(101).with_stderr("\
-Invalid character `.` in crate name: `foo.bar`
+                execs().with_status(101).with_stderr(&format!("\
+{error} Invalid character `.` in crate name: `foo.bar`
 use --name to override crate name
-"));
+",
+error = ERROR)));
 
     assert_that(&foo.join("Cargo.toml"), is_not(existing_file()));
 });
 
 test!(git_autodetect {
     fs::create_dir(&paths::root().join(".git")).unwrap();
-    
+
     assert_that(cargo_process("init")
                                     .env("USER", "foo"),
                 execs().with_status(0));
-    
+
 
     assert_that(&paths::root().join("Cargo.toml"), existing_file());
     assert_that(&paths::root().join("src/lib.rs"), existing_file());
@@ -253,11 +256,11 @@ test!(git_autodetect {
 
 test!(mercurial_autodetect {
     fs::create_dir(&paths::root().join(".hg")).unwrap();
-    
+
     assert_that(cargo_process("init")
                                     .env("USER", "foo"),
                 execs().with_status(0));
-    
+
 
     assert_that(&paths::root().join("Cargo.toml"), existing_file());
     assert_that(&paths::root().join("src/lib.rs"), existing_file());
@@ -267,19 +270,19 @@ test!(mercurial_autodetect {
 
 test!(gitignore_appended_not_replaced {
     fs::create_dir(&paths::root().join(".git")).unwrap();
-    
+
     File::create(&paths::root().join(".gitignore")).unwrap().write_all(b"qqqqqq\n").unwrap();
-    
+
     assert_that(cargo_process("init")
                                     .env("USER", "foo"),
                 execs().with_status(0));
-    
+
 
     assert_that(&paths::root().join("Cargo.toml"), existing_file());
     assert_that(&paths::root().join("src/lib.rs"), existing_file());
     assert_that(&paths::root().join(".git"), existing_dir());
     assert_that(&paths::root().join(".gitignore"), existing_file());
-    
+
     let mut contents = String::new();
     File::open(&paths::root().join(".gitignore")).unwrap().read_to_string(&mut contents).unwrap();
     assert!(contents.contains(r#"qqqqqq"#));
@@ -287,13 +290,13 @@ test!(gitignore_appended_not_replaced {
 
 test!(cargo_lock_gitignored_if_lib1 {
     fs::create_dir(&paths::root().join(".git")).unwrap();
-    
+
     assert_that(cargo_process("init").arg("--vcs").arg("git")
                                      .env("USER", "foo"),
                 execs().with_status(0));
-    
+
     assert_that(&paths::root().join(".gitignore"), existing_file());
-    
+
     let mut contents = String::new();
     File::open(&paths::root().join(".gitignore")).unwrap().read_to_string(&mut contents).unwrap();
     assert!(contents.contains(r#"Cargo.lock"#));
@@ -301,15 +304,15 @@ test!(cargo_lock_gitignored_if_lib1 {
 
 test!(cargo_lock_gitignored_if_lib2 {
     fs::create_dir(&paths::root().join(".git")).unwrap();
-    
+
     File::create(&paths::root().join("lib.rs")).unwrap().write_all(br#""#).unwrap();
 
     assert_that(cargo_process("init").arg("--vcs").arg("git")
                                      .env("USER", "foo"),
                 execs().with_status(0));
-    
+
     assert_that(&paths::root().join(".gitignore"), existing_file());
-    
+
     let mut contents = String::new();
     File::open(&paths::root().join(".gitignore")).unwrap().read_to_string(&mut contents).unwrap();
     assert!(contents.contains(r#"Cargo.lock"#));
@@ -317,14 +320,14 @@ test!(cargo_lock_gitignored_if_lib2 {
 
 test!(cargo_lock_not_gitignored_if_bin1 {
     fs::create_dir(&paths::root().join(".git")).unwrap();
-    
+
     assert_that(cargo_process("init").arg("--vcs").arg("git")
                                      .arg("--bin")
                                      .env("USER", "foo"),
                 execs().with_status(0));
-    
+
     assert_that(&paths::root().join(".gitignore"), existing_file());
-    
+
     let mut contents = String::new();
     File::open(&paths::root().join(".gitignore")).unwrap().read_to_string(&mut contents).unwrap();
     assert!(!contents.contains(r#"Cargo.lock"#));
@@ -332,15 +335,15 @@ test!(cargo_lock_not_gitignored_if_bin1 {
 
 test!(cargo_lock_not_gitignored_if_bin2 {
     fs::create_dir(&paths::root().join(".git")).unwrap();
-    
+
     File::create(&paths::root().join("main.rs")).unwrap().write_all(br#""#).unwrap();
 
     assert_that(cargo_process("init").arg("--vcs").arg("git")
                                      .env("USER", "foo"),
                 execs().with_status(0));
-    
+
     assert_that(&paths::root().join(".gitignore"), existing_file());
-    
+
     let mut contents = String::new();
     File::open(&paths::root().join(".gitignore")).unwrap().read_to_string(&mut contents).unwrap();
     assert!(!contents.contains(r#"Cargo.lock"#));
@@ -357,20 +360,22 @@ test!(with_argument {
 test!(unknown_flags {
     assert_that(cargo_process("init").arg("foo").arg("--flag"),
                 execs().with_status(1)
-                       .with_stderr("\
-Unknown flag: '--flag'
+                       .with_stderr(&format!("\
+{error} Unknown flag: '--flag'
 
 Usage:
     cargo init [options] [<path>]
     cargo init -h | --help
-"));
+",
+error = ERROR)));
 });
 
 #[cfg(not(windows))]
 test!(no_filename {
     assert_that(cargo_process("init").arg("/"),
                 execs().with_status(101)
-                       .with_stderr("\
-cannot auto-detect project name from path \"/\" ; use --name to override
-"));
+                       .with_stderr(&format!("\
+{error} cannot auto-detect project name from path \"/\" ; use --name to override
+",
+error = ERROR)));
 });

--- a/tests/test_cargo_metadata.rs
+++ b/tests/test_cargo_metadata.rs
@@ -1,6 +1,6 @@
 use hamcrest::assert_that;
 use support::registry::Package;
-use support::{project, execs, basic_bin_manifest, main_file};
+use support::{project, execs, basic_bin_manifest, main_file, ERROR};
 
 
 fn setup() {}
@@ -177,11 +177,12 @@ test!(cargo_metadata_with_invalid_manifest {
             .file("Cargo.toml", "");
 
     assert_that(p.cargo_process("metadata"), execs().with_status(101)
-                                                    .with_stderr("\
-failed to parse manifest at `[..]`
+                                                    .with_stderr(&format!("\
+{error} failed to parse manifest at `[..]`
 
 Caused by:
-  no `package` or `project` section found."))
+  no `package` or `project` section found.",
+  error = ERROR)))
 });
 
 const MANIFEST_OUTPUT: &'static str=
@@ -238,7 +239,9 @@ test!(cargo_metadata_no_deps_path_to_cargo_toml_parent_relative {
                  .arg("--manifest-path").arg("foo")
                  .cwd(p.root().parent().unwrap()),
                 execs().with_status(101)
-                       .with_stderr("the manifest-path must be a path to a Cargo.toml file"));
+                       .with_stderr(&format!("{error} the manifest-path must be \
+                                             a path to a Cargo.toml file",
+                                             error = ERROR)));
 });
 
 test!(cargo_metadata_no_deps_path_to_cargo_toml_parent_absolute {
@@ -250,7 +253,9 @@ test!(cargo_metadata_no_deps_path_to_cargo_toml_parent_absolute {
                  .arg("--manifest-path").arg(p.root())
                  .cwd(p.root().parent().unwrap()),
                 execs().with_status(101)
-                       .with_stderr("the manifest-path must be a path to a Cargo.toml file"));
+                       .with_stderr(&format!("{error} the manifest-path must be \
+                                             a path to a Cargo.toml file",
+                                             error = ERROR)));
 });
 
 test!(cargo_metadata_no_deps_cwd {
@@ -273,5 +278,6 @@ test!(carg_metadata_bad_version {
                  .arg("--format-version").arg("2")
                  .cwd(p.root()),
                 execs().with_status(101)
-    .with_stderr("metadata version 2 not supported, only 1 is currently supported"));
+    .with_stderr(&format!("{error} metadata version 2 not supported, only 1 is currently supported",
+                          error = ERROR)));
 });

--- a/tests/test_cargo_new.rs
+++ b/tests/test_cargo_new.rs
@@ -3,7 +3,7 @@ use std::io::prelude::*;
 use std::env;
 use tempdir::TempDir;
 
-use support::{execs, paths};
+use support::{execs, paths, ERROR};
 use support::paths::CargoPathExt;
 use hamcrest::{assert_that, existing_file, existing_dir, is_not};
 
@@ -67,13 +67,14 @@ test!(simple_git {
 test!(no_argument {
     assert_that(cargo_process("new"),
                 execs().with_status(1)
-                       .with_stderr("\
-Invalid arguments.
+                       .with_stderr(&format!("\
+{error} Invalid arguments.
 
 Usage:
     cargo new [options] <path>
     cargo new -h | --help
-"));
+",
+error = ERROR)));
 });
 
 test!(existing {
@@ -81,16 +82,17 @@ test!(existing {
     fs::create_dir(&dst).unwrap();
     assert_that(cargo_process("new").arg("foo"),
                 execs().with_status(101)
-                       .with_stderr(format!("destination `{}` already exists\n",
-                                            dst.display())));
+                       .with_stderr(format!("{error} destination `{}` already exists\n",
+                                            dst.display(), error = ERROR)));
 });
 
 test!(invalid_characters {
     assert_that(cargo_process("new").arg("foo.rs"),
                 execs().with_status(101)
-                       .with_stderr("\
-Invalid character `.` in crate name: `foo.rs`
-use --name to override crate name"));
+                       .with_stderr(&format!("\
+{error} Invalid character `.` in crate name: `foo.rs`
+use --name to override crate name",
+error = ERROR)));
 });
 
 test!(rust_prefix_stripped {
@@ -273,11 +275,12 @@ test!(subpackage_git_with_vcs_arg {
 test!(unknown_flags {
     assert_that(cargo_process("new").arg("foo").arg("--flag"),
                 execs().with_status(1)
-                       .with_stderr("\
-Unknown flag: '--flag'
+                       .with_stderr(&format!("\
+{error} Unknown flag: '--flag'
 
 Usage:
     cargo new [..]
     cargo new [..]
-"));
+",
+error = ERROR)));
 });

--- a/tests/test_cargo_package.rs
+++ b/tests/test_cargo_package.rs
@@ -411,6 +411,8 @@ src[..]main.rs
 
 #[cfg(unix)] // windows doesn't allow these characters in filenames
 test!(package_weird_characters {
+
+    use support::ERROR;
     let p = project("foo")
         .file("Cargo.toml", r#"
             [project]
@@ -424,11 +426,12 @@ test!(package_weird_characters {
         .file("src/:foo", "");
 
     assert_that(p.cargo_process("package"),
-                execs().with_status(101).with_stderr("\
+                execs().with_status(101).with_stderr(format!("\
 warning: [..]
-failed to prepare local package for uploading
+{error} failed to prepare local package for uploading
 
 Caused by:
   cannot package a filename with a special character `:`: src/:foo
-"));
+",
+error = ERROR)));
 });

--- a/tests/test_cargo_publish.rs
+++ b/tests/test_cargo_publish.rs
@@ -8,7 +8,7 @@ use tar::Archive;
 use url::Url;
 
 use support::{project, execs};
-use support::{UPDATING, PACKAGING, UPLOADING};
+use support::{UPDATING, PACKAGING, UPLOADING, ERROR};
 use support::paths;
 use support::git::repo;
 
@@ -103,10 +103,11 @@ test!(git_deps {
         .file("src/main.rs", "fn main() {}");
 
     assert_that(p.cargo_process("publish").arg("-v").arg("--no-verify"),
-                execs().with_status(101).with_stderr("\
-all dependencies must come from the same source.
+                execs().with_status(101).with_stderr(&format!("\
+{error} all dependencies must come from the same source.
 dependency `foo` comes from git://path/to/nowhere instead
-"));
+",
+error = ERROR)));
 });
 
 test!(path_dependency_no_version {
@@ -132,10 +133,11 @@ test!(path_dependency_no_version {
         .file("bar/src/lib.rs", "");
 
     assert_that(p.cargo_process("publish"),
-                execs().with_status(101).with_stderr("\
-all path dependencies must have a version specified when publishing.
+                execs().with_status(101).with_stderr(&format!("\
+{error} all path dependencies must have a version specified when publishing.
 dependency `bar` does not specify a version
-"));
+",
+error = ERROR)));
 });
 
 test!(unpublishable_crate {
@@ -152,8 +154,9 @@ test!(unpublishable_crate {
         .file("src/main.rs", "fn main() {}");
 
     assert_that(p.cargo_process("publish"),
-                execs().with_status(101).with_stderr("\
-some crates cannot be published.
+                execs().with_status(101).with_stderr(&format!("\
+{error} some crates cannot be published.
 `foo` is marked as unpublishable
-"));
+",
+error = ERROR)));
 });

--- a/tests/test_cargo_read_manifest.rs
+++ b/tests/test_cargo_read_manifest.rs
@@ -1,4 +1,4 @@
-use support::{project, execs, main_file, basic_bin_manifest};
+use support::{project, execs, main_file, basic_bin_manifest, ERROR};
 use hamcrest::{assert_that};
 
 fn setup() {}
@@ -58,7 +58,8 @@ test!(cargo_read_manifest_path_to_cargo_toml_parent_relative {
                  .arg("--manifest-path").arg("foo")
                  .cwd(p.root().parent().unwrap()),
                 execs().with_status(101)
-                       .with_stderr("the manifest-path must be a path to a Cargo.toml file"));
+                       .with_stderr(&format!("{error} the manifest-path must be \
+                                             a path to a Cargo.toml file", error = ERROR)));
 });
 
 test!(cargo_read_manifest_path_to_cargo_toml_parent_absolute {
@@ -70,7 +71,8 @@ test!(cargo_read_manifest_path_to_cargo_toml_parent_absolute {
                  .arg("--manifest-path").arg(p.root())
                  .cwd(p.root().parent().unwrap()),
                 execs().with_status(101)
-                       .with_stderr("the manifest-path must be a path to a Cargo.toml file"));
+                       .with_stderr(&format!("{error} the manifest-path must be \
+                                             a path to a Cargo.toml file", error = ERROR)));
 });
 
 test!(cargo_read_manifest_cwd {

--- a/tests/test_cargo_registry.rs
+++ b/tests/test_cargo_registry.rs
@@ -2,7 +2,7 @@ use std::fs::{self, File};
 use std::io::prelude::*;
 
 use support::{project, execs};
-use support::{UPDATING, DOWNLOADING, COMPILING, PACKAGING, VERIFYING, ADDING, REMOVING};
+use support::{UPDATING, DOWNLOADING, COMPILING, PACKAGING, VERIFYING, ADDING, REMOVING, ERROR};
 use support::paths::{self, CargoPathExt};
 use support::registry::{self, Package};
 use support::git;
@@ -100,11 +100,12 @@ test!(nonexistent {
         .file("src/main.rs", "fn main() {}");
 
     assert_that(p.cargo_process("build"),
-                execs().with_status(101).with_stderr("\
-no matching package named `nonexistent` found (required by `foo`)
+                execs().with_status(101).with_stderr(&format!("\
+{error} no matching package named `nonexistent` found (required by `foo`)
 location searched: registry file://[..]
 version required: >= 0.0.0
-"));
+",
+error = ERROR)));
 });
 
 test!(wrong_version {
@@ -124,23 +125,25 @@ test!(wrong_version {
     Package::new("foo", "0.0.2").publish();
 
     assert_that(p.cargo_process("build"),
-                execs().with_status(101).with_stderr("\
-no matching package named `foo` found (required by `foo`)
+                execs().with_status(101).with_stderr(&format!("\
+{error} no matching package named `foo` found (required by `foo`)
 location searched: registry file://[..]
 version required: >= 1.0.0
 versions found: 0.0.2, 0.0.1
-"));
+",
+error = ERROR)));
 
     Package::new("foo", "0.0.3").publish();
     Package::new("foo", "0.0.4").publish();
 
     assert_that(p.cargo_process("build"),
-                execs().with_status(101).with_stderr("\
-no matching package named `foo` found (required by `foo`)
+                execs().with_status(101).with_stderr(&format!("\
+{error} no matching package named `foo` found (required by `foo`)
 location searched: registry file://[..]
 version required: >= 1.0.0
 versions found: 0.0.4, 0.0.3, 0.0.2, ...
-"));
+",
+error = ERROR)));
 });
 
 test!(bad_cksum {
@@ -161,15 +164,16 @@ test!(bad_cksum {
     File::create(&pkg.archive_dst()).unwrap();
 
     assert_that(p.cargo_process("build").arg("-v"),
-                execs().with_status(101).with_stderr("\
-unable to get packages from source
+                execs().with_status(101).with_stderr(&format!("\
+{error} unable to get packages from source
 
 Caused by:
   failed to download package `bad-cksum v0.0.1 (registry file://[..])` from [..]
 
 Caused by:
   failed to verify the checksum of `bad-cksum v0.0.1 (registry file://[..])`
-"));
+",
+error = ERROR)));
 });
 
 test!(update_registry {
@@ -188,11 +192,12 @@ test!(update_registry {
         .file("src/main.rs", "fn main() {}");
 
     assert_that(p.cargo_process("build"),
-                execs().with_status(101).with_stderr("\
-no matching package named `notyet` found (required by `foo`)
+                execs().with_status(101).with_stderr(&format!("\
+{error} no matching package named `notyet` found (required by `foo`)
 location searched: registry file://[..]
 version required: >= 0.0.0
-"));
+",
+error = ERROR)));
 
     Package::new("notyet", "0.0.1").publish();
 
@@ -238,14 +243,15 @@ test!(package_with_path_deps {
     p.build();
 
     assert_that(p.cargo("package").arg("-v"),
-                execs().with_status(101).with_stderr("\
-failed to verify package tarball
+                execs().with_status(101).with_stderr(&format!("\
+{error} failed to verify package tarball
 
 Caused by:
   no matching package named `notyet` found (required by `foo`)
 location searched: registry file://[..]
 version required: ^0.0.1
-"));
+",
+error = ERROR)));
 
     Package::new("notyet", "0.0.1").publish();
 
@@ -385,12 +391,13 @@ test!(relying_on_a_yank_is_bad {
     Package::new("bar", "0.0.1").dep("baz", "=0.0.2").publish();
 
     assert_that(p.cargo("build"),
-                execs().with_status(101).with_stderr("\
-no matching package named `baz` found (required by `bar`)
+                execs().with_status(101).with_stderr(&format!("\
+{error} no matching package named `baz` found (required by `bar`)
 location searched: registry file://[..]
 version required: = 0.0.2
 versions found: 0.0.1
-"));
+",
+error = ERROR)));
 });
 
 test!(yanks_in_lockfiles_are_ok {
@@ -420,11 +427,12 @@ test!(yanks_in_lockfiles_are_ok {
                 execs().with_status(0).with_stdout(""));
 
     assert_that(p.cargo("update"),
-                execs().with_status(101).with_stderr("\
-no matching package named `bar` found (required by `foo`)
+                execs().with_status(101).with_stderr(&format!("\
+{error} no matching package named `bar` found (required by `foo`)
 location searched: registry file://[..]
 version required: *
-"));
+",
+error = ERROR)));
 });
 
 test!(update_with_lockfile_if_packages_missing {
@@ -583,8 +591,8 @@ test!(bad_license_file {
         "#);
     assert_that(p.cargo_process("publish").arg("-v"),
                 execs().with_status(101)
-                       .with_stderr("\
-the license file `foo` does not exist"));
+                       .with_stderr(&format!("\
+{error} the license file `foo` does not exist", error = ERROR)));
 });
 
 test!(updating_a_dep {

--- a/tests/test_cargo_run.rs
+++ b/tests/test_cargo_run.rs
@@ -1,7 +1,7 @@
 use std::path::MAIN_SEPARATOR as SEP;
 
 use support::{project, execs, path2url};
-use support::{COMPILING, RUNNING};
+use support::{COMPILING, RUNNING, ERROR};
 use hamcrest::{assert_that, existing_file};
 
 fn setup() {
@@ -64,10 +64,10 @@ test!(simple_quiet_and_verbose {
         "#);
 
     assert_that(p.cargo_process("run").arg("-q").arg("-v"),
-                execs().with_status(101).with_stderr("\
-cannot set both --verbose and --quiet
-")
-    );
+                execs().with_status(101).with_stderr(&format!("\
+{error} cannot set both --verbose and --quiet
+",
+error = ERROR)));
 });
 
 test!(simple_with_args {
@@ -104,9 +104,9 @@ test!(exit_code {
     assert_that(p.cargo_process("run"),
                 execs().with_status(2)
                        .with_stderr(&format!("\
-Process didn't exit successfully: `target[..]foo[..]` (exit code: 2)
+{error} Process didn't exit successfully: `target[..]foo[..]` (exit code: 2)
 ",
-        )));
+error = ERROR)));
 });
 
 test!(exit_code_verbose {
@@ -124,9 +124,9 @@ test!(exit_code_verbose {
     assert_that(p.cargo_process("run").arg("-v"),
                 execs().with_status(2)
                        .with_stderr(&format!("\
-Process didn't exit successfully: `target[..]foo[..]` (exit code: 2)
+{error} Process didn't exit successfully: `target[..]foo[..]` (exit code: 2)
 ",
-        )));
+error = ERROR)));
 });
 
 test!(no_main_file {
@@ -141,8 +141,8 @@ test!(no_main_file {
 
     assert_that(p.cargo_process("run"),
                 execs().with_status(101)
-                       .with_stderr("a bin target must be available \
-                                     for `cargo run`\n"));
+                       .with_stderr(&format!("{error} a bin target must be available \
+                                     for `cargo run`\n", error = ERROR)));
 });
 
 test!(too_many_bins {
@@ -159,9 +159,9 @@ test!(too_many_bins {
 
     assert_that(p.cargo_process("run"),
                 execs().with_status(101)
-                       .with_stderr("`cargo run` requires that a project only \
+                       .with_stderr(&format!("{error} `cargo run` requires that a project only \
                                      have one executable; use the `--bin` option \
-                                     to specify which one to run\n"));
+                                     to specify which one to run\n", error = ERROR)));
 });
 
 test!(specify_name {
@@ -251,9 +251,10 @@ test!(either_name_or_example {
 
     assert_that(p.cargo_process("run").arg("--bin").arg("a").arg("--example").arg("b"),
                 execs().with_status(101)
-                       .with_stderr("`cargo run` can run at most one \
+                       .with_stderr(&format!("{error} `cargo run` can run at most one \
                                      executable, but multiple were \
-                                     specified"));
+                                     specified",
+                                     error = ERROR)));
 });
 
 test!(one_bin_multiple_examples {

--- a/tests/test_cargo_rustc.rs
+++ b/tests/test_cargo_rustc.rs
@@ -1,16 +1,17 @@
 use std::path::MAIN_SEPARATOR as SEP;
 
 use support::{execs, project};
-use support::{COMPILING, RUNNING};
+use support::{COMPILING, RUNNING, ERROR};
 
 use hamcrest::assert_that;
 
 fn setup() {
 }
 
-fn cargo_rustc_error() -> &'static str {
-    "extra arguments to `rustc` can only be passed to one target, consider filtering\n\
-    the package by passing e.g. `--lib` or `--bin NAME` to specify a single target"
+fn cargo_rustc_error() -> String {
+    format!("{error} extra arguments to `rustc` can only be passed to one target, \
+    consider filtering\nthe package by passing e.g. `--lib` or `--bin NAME` to \
+    specify a single target", error = ERROR)
 }
 
 test!(build_lib_for_foo {
@@ -125,7 +126,7 @@ test!(fails_when_trying_to_build_main_and_lib_with_args {
                 .arg("--").arg("-Z").arg("unstable-options"),
                 execs()
                 .with_status(101)
-                .with_stderr(cargo_rustc_error()));
+                .with_stderr(&cargo_rustc_error()));
 });
 
 test!(build_with_args_to_one_of_multiple_binaries {
@@ -185,7 +186,7 @@ test!(fails_with_args_to_all_binaries {
                 .arg("--").arg("-Z").arg("unstable-options"),
                 execs()
                 .with_status(101)
-                .with_stderr(cargo_rustc_error()));
+                .with_stderr(&cargo_rustc_error()));
 });
 
 test!(build_with_args_to_one_of_multiple_tests {
@@ -347,11 +348,11 @@ test!(fail_with_multiple_packages {
 
     assert_that(foo.cargo("rustc").arg("-v").arg("-p").arg("bar")
                                           .arg("-p").arg("baz"),
-                execs().with_status(1).with_stderr("\
-Invalid arguments.
+                execs().with_status(1).with_stderr(format!("\
+{error} Invalid arguments.
 
 Usage:
-    cargo rustc [options] [--] [<opts>...]".to_string()));
+    cargo rustc [options] [--] [<opts>...]", error = ERROR)));
 });
 
 test!(rustc_with_other_profile {

--- a/tests/test_cargo_rustdoc.rs
+++ b/tests/test_cargo_rustdoc.rs
@@ -1,6 +1,6 @@
 use std::path::MAIN_SEPARATOR as SEP;
 use support::{execs, project};
-use support::{COMPILING, RUNNING, DOCUMENTING};
+use support::{COMPILING, RUNNING, DOCUMENTING, ERROR};
 use hamcrest::{assert_that};
 
 fn setup() {
@@ -167,7 +167,8 @@ test!(rustdoc_same_name_err {
                  .arg("--").arg("--no-defaults"),
                 execs()
                 .with_status(101)
-                .with_stderr("cannot document a package where a library and a \
+                .with_stderr(&format!("{error} cannot document a package where a library and a \
                               binary have the same name. Consider renaming one \
-                              or marking the target as `doc = false`"));
+                              or marking the target as `doc = false`",
+                              error = ERROR)));
 });

--- a/tests/test_cargo_test.rs
+++ b/tests/test_cargo_test.rs
@@ -3,7 +3,7 @@ use std::io::prelude::*;
 use std::str;
 
 use support::{project, execs, basic_bin_manifest, basic_lib_manifest};
-use support::{COMPILING, RUNNING, DOCTEST};
+use support::{COMPILING, RUNNING, DOCTEST, ERROR};
 use support::paths::CargoPathExt;
 use hamcrest::{assert_that, existing_file, is_not};
 use cargo::util::process;
@@ -742,10 +742,11 @@ test!(bin_without_name {
     assert_that(p.cargo_process("test"),
                 execs().with_status(101)
                        .with_stderr(&format!("\
-failed to parse manifest at `[..]`
+{error} failed to parse manifest at `[..]`
 
 Caused by:
-  binary target bin.name is required")));
+  binary target bin.name is required",
+  error = ERROR)));
 });
 
 test!(bench_without_name {
@@ -786,10 +787,11 @@ test!(bench_without_name {
     assert_that(p.cargo_process("test"),
                 execs().with_status(101)
                        .with_stderr(&format!("\
-failed to parse manifest at `[..]`
+{error} failed to parse manifest at `[..]`
 
 Caused by:
-  bench target bench.name is required")));
+  bench target bench.name is required",
+    error = ERROR)));
 });
 
 test!(test_without_name {
@@ -829,10 +831,11 @@ test!(test_without_name {
     assert_that(p.cargo_process("test"),
                 execs().with_status(101)
                        .with_stderr(&format!("\
-failed to parse manifest at `[..]`
+{error} failed to parse manifest at `[..]`
 
 Caused by:
-  test target test.name is required")));
+  test target test.name is required",
+  error = ERROR)));
 });
 
 test!(example_without_name {
@@ -872,10 +875,11 @@ test!(example_without_name {
     assert_that(p.cargo_process("test"),
                 execs().with_status(101)
                        .with_stderr(&format!("\
-failed to parse manifest at `[..]`
+{error} failed to parse manifest at `[..]`
 
 Caused by:
-  example target example.name is required")));
+  example target example.name is required",
+  error = ERROR)));
 });
 
 test!(bin_there_for_integration {
@@ -1599,13 +1603,15 @@ test!(bad_example {
         .file("src/lib.rs", "");
 
     assert_that(p.cargo_process("run").arg("--example").arg("foo"),
-                execs().with_status(101).with_stderr("\
-no example target named `foo`
-"));
+                execs().with_status(101).with_stderr(&format!("\
+{error} no example target named `foo`
+",
+    error = ERROR)));
     assert_that(p.cargo_process("run").arg("--bin").arg("foo"),
-                execs().with_status(101).with_stderr("\
-no bin target named `foo`
-"));
+                execs().with_status(101).with_stderr(&format!("\
+{error} no bin target named `foo`
+",
+    error = ERROR)));
 });
 
 test!(doctest_feature {


### PR DESCRIPTION
This resolves #426

Dearest Reviewer,

I have updated the error messages to use say_status at the shell level. I have also changed say_status to print the message in bold. I do think it looks nice but it does have the side effect of making some seemingly unrelated text bold. I do think it looks better bold but it is also very easy to revert. I have included examples of both. 

Thank you,
Becker

Bold: Note the usage is bold. 
<img width="1072" alt="screen shot 2016-02-27 at 10 49 05 am" src="https://cloud.githubusercontent.com/assets/12170/13374778/0efd54ec-dd43-11e5-9f02-f0224608132a.png">

No bold:
<img width="885" alt="screen shot 2016-02-27 at 10 46 35 am" src="https://cloud.githubusercontent.com/assets/12170/13374775/fa3a6612-dd42-11e5-9c09-8f23506f5f0c.png">

Both rendered on a mac with iterm 2.9.0

