### PR TITLE
Fix output matching in tests

### DIFF
--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -440,15 +440,33 @@ impl Execs {
 }
 
 fn lines_match(expected: &str, mut actual: &str) -> bool {
-    for part in expected.split("[..]") {
+    for (i, part) in expected.split("[..]").enumerate() {
         match actual.find(part) {
-            Some(i) => actual = &actual[i + part.len()..],
+            Some(j) => {
+                if i == 0 && j != 0 {
+                    return false
+                }
+                actual = &actual[j + part.len()..];
+            }
             None => {
                 return false
             }
         }
     }
     actual.is_empty() || expected.ends_with("[..]")
+}
+
+#[test]
+fn lines_match_works() {
+    assert!(lines_match("a b", "a b"));
+    assert!(lines_match("a[..]b", "a b"));
+    assert!(lines_match("a[..]", "a b"));
+    assert!(lines_match("[..]", "a b"));
+    assert!(lines_match("[..]b", "a b"));
+
+    assert!(!lines_match("[..]b", "c"));
+    assert!(!lines_match("b", "c"));
+    assert!(!lines_match("b", "cb"));
 }
 
 // Compares JSON object for approximate equality.

--- a/tests/test_cargo.rs
+++ b/tests/test_cargo.rs
@@ -63,7 +63,7 @@ test!(find_closest_biuld_to_build {
                 execs().with_status(101)
                        .with_stderr("no such subcommand
 
-Did you mean `build`?
+<tab>Did you mean `build`?
 
 "));
 });

--- a/tests/test_cargo_compile_git_deps.rs
+++ b/tests/test_cargo_compile_git_deps.rs
@@ -1401,8 +1401,8 @@ test!(update_one_dep_in_repo_with_many_deps {
                  .arg("-p").arg("foo"),
                 execs().with_status(0)
                        .with_stdout(&format!("\
-Updating git repository `{}`
-", foo.url())));
+{updating} git repository `{}`
+", foo.url(), updating = UPDATING)));
 });
 
 test!(switch_deps_does_not_update_transitive {
@@ -1455,12 +1455,12 @@ test!(switch_deps_does_not_update_transitive {
     assert_that(p.cargo("build"),
                 execs().with_status(0)
                        .with_stdout(&format!("\
-Updating git repository `{}`
-Updating git repository `{}`
+{updating} git repository `{}`
+{updating} git repository `{}`
 {compiling} transitive [..]
 {compiling} dep [..]
 {compiling} project [..]
-", dep1.url(), transitive.url(), compiling = COMPILING)));
+", dep1.url(), transitive.url(), compiling = COMPILING, updating = UPDATING)));
 
     // Update the dependency to point to the second repository, but this
     // shouldn't update the transitive dependency which is the same.
@@ -1476,10 +1476,10 @@ Updating git repository `{}`
     assert_that(p.cargo("build"),
                 execs().with_status(0)
                        .with_stdout(&format!("\
-Updating git repository `{}`
+{updating} git repository `{}`
 {compiling} dep [..]
 {compiling} project [..]
-", dep2.url(), compiling = COMPILING)));
+", dep2.url(), compiling = COMPILING, updating = UPDATING)));
 });
 
 test!(update_one_source_updates_all_packages_in_that_git_source {

--- a/tests/test_cargo_compile_path_deps.rs
+++ b/tests/test_cargo_compile_path_deps.rs
@@ -741,15 +741,15 @@ test!(dev_deps_no_rebuild_lib {
     assert_that(p.cargo("test"),
                 execs().with_status(0)
                        .with_stdout(&format!("\
-{} [..] v0.5.0 ({})
-{} [..] v0.5.0 ({})
-Running target[..]foo-[..]
+{compiling} [..] v0.5.0 ({url})
+{compiling} [..] v0.5.0 ({url})
+{running} target[..]foo-[..]
 
 running 0 tests
 
 test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
 
-", COMPILING, p.url(), COMPILING, p.url())));
+", url = p.url(), compiling = COMPILING, running = RUNNING)));
 });
 
 test!(custom_target_no_rebuild {

--- a/tests/test_cargo_install.rs
+++ b/tests/test_cargo_install.rs
@@ -527,7 +527,7 @@ test!(subcommand_works_out_of_the_box {
     assert_that(cargo_process("foo"),
                 execs().with_status(0).with_stdout("bar\n"));
     assert_that(cargo_process("--list"),
-                execs().with_status(0).with_stdout_contains("  foo\n"));
+                execs().with_status(0).with_stdout_contains("    foo\n"));
 });
 
 test!(installs_from_cwd_by_default {
@@ -558,9 +558,9 @@ test!(do_not_rebuilds_on_local_install {
     assert_that(p.cargo_process("build").arg("--release"),
                 execs().with_status(0));
     assert_that(cargo_process("install").arg("--path").arg(p.root()),
-                execs().with_status(0).with_stdout("\
-  Installing [..]
-").with_stderr("\
+                execs().with_status(0).with_stdout(&format!("\
+{installing} [..]
+", installing = INSTALLING)).with_stderr("\
 be sure to add `[..]` to your PATH to be able to run the installed binaries
 "));
 
@@ -580,7 +580,7 @@ test!(reports_unsuccessful_subcommand_result {
     assert_that(cargo_process("install").arg("cargo-fail"),
                 execs().with_status(0));
     assert_that(cargo_process("--list"),
-                execs().with_status(0).with_stdout_contains("  fail\n"));
+                execs().with_status(0).with_stdout_contains("    fail\n"));
     assert_that(cargo_process("fail"),
                 execs().with_status(101).with_stderr_contains("\
 thread '<main>' panicked at 'explicit panic', [..]


### PR DESCRIPTION
Right now we only match a suffix of the line, assuming all lines start with
`[..]`. Instead this ensures that the first match is anchored at the start.