### PR TITLE
Update documentation link for API docs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Yehuda Katz <wycats@gmail.com>",
 license = "MIT/Apache-2.0"
 homepage = "https://crates.io"
 repository = "https://github.com/rust-lang/cargo"
-documentation = "http://doc.crates.io"
+documentation = "http://doc.crates.io/cargo"
 description = """
 Cargo, a package manager for Rust.
 """


### PR DESCRIPTION
The API docs for Cargo live at doc.crates.io/cargo, not doc.crates.io in
general.