### PR TITLE
[WIP] per profile sysroot via Cargo.toml

### DIFF
--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -113,6 +113,7 @@ pub struct Profile {
     pub test: bool,
     pub doc: bool,
     pub run_custom_build: bool,
+    pub sysroot: Option<PathBuf>,
 }
 
 #[derive(Default, Clone, Debug)]
@@ -466,6 +467,7 @@ impl Default for Profile {
             test: false,
             doc: false,
             run_custom_build: false,
+            sysroot: None,
         }
     }
 }

--- a/src/cargo/util/toml.rs
+++ b/src/cargo/util/toml.rs
@@ -243,6 +243,7 @@ pub struct TomlProfile {
     debug: Option<bool>,
     debug_assertions: Option<bool>,
     rpath: Option<bool>,
+    sysroot: Option<String>,
 }
 
 #[derive(RustcDecodable)]
@@ -973,7 +974,7 @@ fn build_profiles(profiles: &Option<TomlProfiles>) -> Profiles {
 
     fn merge(profile: Profile, toml: Option<&TomlProfile>) -> Profile {
         let &TomlProfile {
-            opt_level, lto, codegen_units, debug, debug_assertions, rpath
+            opt_level, lto, codegen_units, debug, debug_assertions, rpath, ref sysroot
         } = match toml {
             Some(toml) => toml,
             None => return profile,
@@ -990,6 +991,9 @@ fn build_profiles(profiles: &Option<TomlProfiles>) -> Profiles {
             test: profile.test,
             doc: profile.doc,
             run_custom_build: profile.run_custom_build,
+            // FIXME if 'sysroot' is a relative path it should be relative to the root of the cargo
+            // project (???)
+            sysroot: sysroot.as_ref().map(|s| PathBuf::from(s)),
         }
     }
 }


### PR DESCRIPTION
This patch lets you use the 'profile.$profile.sysroot' key in Cargo.toml to pass `--sysroot $path`
to `rustc` during the compilation of the current crate and its dependencies.

Main use cases are kernel development and bare metal programming (e.g. microcontrollers) where the
application depends on a minimal set of "core" crates like `core`, `alloc`, `collections`, etc.
These dependencies need to be cross compiled for the target platform/architecture and a "sysroot"
(*) provides, IMO ,the cleanest way to make these core dependencies available to the many crates
that conform the application.

(*) A sysroot is basically a directory that holds the already (cross) compiled "standard" crates
(i.e. `core`, `std`, etc) that are linked to your Rust programs when you call `rustc`. The important
bit is that you don't explicitly spell out these dependencies in e.g. a Cargo.toml; they are
implicitly available. The fastest way to familiarize with sysroots is to explore the default sysroot
with something like `tree $(rustc --print sysroot)`.

cc #2312

---

This is minimal PoC to start the discussion. There are a few unresolved questions.

- The [RUSTFLAGS feature] can also be used to pass `--sysroot` to `rustc`. Should we just use that
  feature and not implement this one?
- Does this setting belong in the project's Cargo.toml or in a project local .cargo/config?
- What happens if the user uses a relative path for the value of sysroot? Is this path relative to
  the call site or relative the root of the cargo project? Example, if the user sets 'sysroot =
  foo' in their Cargo project and then calls `cargo build --manifest-path some/path/Cargo.toml`
  should `$(pwd)/foo` or `some/path/foo` be used as the sysroot?

[RUSTFLAGS feature]: https://github.com/rust-lang/cargo/pull/2241

cc @alexcrichton @Zoxc