### PR TITLE
Fix rerunning rustdoc when output deleted

### DIFF
--- a/src/cargo/ops/cargo_rustc/context.rs
+++ b/src/cargo/ops/cargo_rustc/context.rs
@@ -213,7 +213,11 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
     /// Returns the appropriate output directory for the specified package and
     /// target.
     pub fn out_dir(&self, unit: &Unit) -> PathBuf {
-        self.layout(unit.pkg, unit.kind).out_dir(unit.pkg, unit.target)
+        if unit.profile.doc {
+            self.layout(unit.pkg, unit.kind).doc_root()
+        } else {
+            self.layout(unit.pkg, unit.kind).out_dir(unit.pkg, unit.target)
+        }
     }
 
     /// Return the (prefix, suffix) pair for dynamic libraries.

--- a/src/cargo/ops/cargo_rustc/fingerprint.rs
+++ b/src/cargo/ops/cargo_rustc/fingerprint.rs
@@ -59,7 +59,10 @@ pub fn prepare_target<'a, 'cfg>(cx: &mut Context<'a, 'cfg>,
 
     let root = cx.out_dir(unit);
     let mut missing_outputs = false;
-    if !unit.profile.doc {
+    if unit.profile.doc {
+        missing_outputs = !root.join(unit.target.crate_name())
+                               .join("index.html").exists();
+    } else {
         for filename in try!(cx.target_filenames(unit)).iter() {
             missing_outputs |= fs::metadata(root.join(filename)).is_err();
         }

--- a/src/cargo/ops/cargo_rustc/layout.rs
+++ b/src/cargo/ops/cargo_rustc/layout.rs
@@ -165,4 +165,10 @@ impl<'a> LayoutProxy<'a> {
             self.root().to_path_buf()
         }
     }
+
+    pub fn doc_root(&self) -> PathBuf {
+        // the "root" directory ends in 'debug' or 'release', and we want it to
+        // end in 'doc' instead
+        self.root.root().parent().unwrap().join("doc")
+    }
 }

--- a/src/cargo/ops/cargo_rustc/mod.rs
+++ b/src/cargo/ops/cargo_rustc/mod.rs
@@ -374,10 +374,7 @@ fn rustdoc(cx: &mut Context, unit: &Unit) -> CargoResult<Work> {
         rustdoc.arg("--target").arg(target);
     }
 
-    // the "root" directory ends in 'debug' or 'release', and we want it to end
-    // in 'doc' instead
-    let doc_dir = cx.layout(unit.pkg, unit.kind).proxy().root();
-    let doc_dir = doc_dir.parent().unwrap().join("doc");
+    let doc_dir = cx.out_dir(unit);
 
     // Create the documentation directory ahead of time as rustdoc currently has
     // a bug where concurrent invocations will race to create this directory if


### PR DESCRIPTION
If `crate/index.html` is missing, we need to rerun rustdoc!

Closes #2379