### PR TITLE
Suggest the best matching target for cargo run

### DIFF
--- a/src/bin/run.rs
+++ b/src/bin/run.rs
@@ -1,5 +1,7 @@
+use cargo::core::package::Package;
+use cargo::core::manifest::TargetKind;
 use cargo::ops;
-use cargo::util::{CliResult, CliError, Config, Human};
+use cargo::util::{CliResult, CliError, Config, Human, human, lev_distance};
 use cargo::util::important_paths::{find_root_manifest_for_wd};
 
 #[derive(RustcDecodable)]
@@ -48,18 +50,49 @@ arguments to both Cargo and the binary, the ones after `--` go to the binary,
 the ones before go to Cargo.
 ";
 
+fn find_closest_target<'a>(package: &'a Package, target: &str, kind: TargetKind) -> Option<&'a str> {
+    let targets = package.targets();
+    let mut filtered = targets.iter().filter(|t| *t.kind() == kind)
+                                     .map(|t| (lev_distance(target, t.name()), t))
+                                     .filter(|&(d, _)| d < 4)
+                                     .collect::<Vec<_>>();
+    filtered.sort_by(|a, b| a.0.cmp(&b.0));
+    filtered.get(0).map(|t| t.1.name().clone())
+}
+
 pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
     try!(config.configure_shell(options.flag_verbose,
                                 options.flag_quiet,
                                 &options.flag_color));
 
     let root = try!(find_root_manifest_for_wd(options.flag_manifest_path, config.cwd()));
+    let package = try!(Package::for_path(&root, &config));
 
     let (mut examples, mut bins) = (Vec::new(), Vec::new());
     if let Some(s) = options.flag_bin {
+        let target = package.targets().iter().find(|t| {
+            t.name() == s && *t.kind() == TargetKind::Bin
+        });
+        if target.is_none() {
+            return Err(CliError::from_error(human(match find_closest_target(&package, &s, TargetKind::Bin) {
+                Some(closest) => format!("no bin target named `{}`\n\n\
+                                          Did you mean `{}`?", s, closest),
+                None => format!("no bin target named `{}`", s),
+            }), 101));
+        }
         bins.push(s);
     }
     if let Some(s) = options.flag_example {
+        let target = package.targets().iter().find(|t| {
+            t.name() == s && *t.kind() == TargetKind::Example
+        });
+        if target.is_none() {
+            return Err(CliError::from_error(human(match find_closest_target(&package, &s, TargetKind::Example) {
+                Some(closest) => format!("no example target named `{}`\n\n\
+                                          Did you mean `{}`?", s, closest),
+                None => format!("no example target named `{}`", s),
+            }), 101));
+        }
         examples.push(s);
     }
 

--- a/tests/test_cargo_run.rs
+++ b/tests/test_cargo_run.rs
@@ -234,6 +234,58 @@ example
         sep = SEP)));
 });
 
+test!(run_bin_filename {
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [project]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+        "#)
+        .file("src/lib.rs", "")
+        .file("src/bin/a.rs", r#"
+            extern crate foo;
+            fn main() { println!("hello a.rs"); }
+        "#);
+
+    assert_that(p.cargo_process("run").arg("--bin").arg("bin.rs"),
+                execs().with_status(101).with_stderr("\
+no bin target named `bin.rs`
+"));
+
+    assert_that(p.cargo_process("run").arg("--bin").arg("a.rs"),
+                execs().with_status(101).with_stderr("\
+no bin target named `a.rs`
+
+Did you mean `a`?
+"));
+});
+
+test!(run_example_filename {
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [project]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+        "#).file("src/lib.rs", "")
+        .file("examples/a.rs", r#"
+            fn main() { println!("example"); }
+        "#);
+
+    assert_that(p.cargo_process("run").arg("--example").arg("example.rs"),
+                execs().with_status(101).with_stderr(&format!("\
+no example target named `example.rs`
+")));
+
+assert_that(p.cargo_process("run").arg("--example").arg("a.rs"),
+            execs().with_status(101).with_stderr(&format!("\
+no example target named `a.rs`
+
+Did you mean `a`?
+")));
+});
+
 test!(either_name_or_example {
     let p = project("foo")
         .file("Cargo.toml", r#"


### PR DESCRIPTION
Gets a Package from the root file path in order to look up the targets
in the project. If the specified example is not found, cargo will bail
out. Otherwise, it's added to the list of targets.

The test cases create a project with an empty lib.rs and a bin or
example source file. It then attempts to run them with target names that
are way off (bin.rs/example.rs) and names that are just a bit off (a.rs)
and analyses the result for the correct return codes and output.