### PR TITLE
Add a new CARGO_PKG_AUTHORS environment variable

### DIFF
--- a/src/cargo/core/package.rs
+++ b/src/cargo/core/package.rs
@@ -80,6 +80,7 @@ impl Package {
     pub fn summary(&self) -> &Summary { self.manifest.summary() }
     pub fn targets(&self) -> &[Target] { self.manifest().targets() }
     pub fn version(&self) -> &Version { self.package_id().version() }
+    pub fn authors(&self) -> &Vec<String> { &self.manifest.metadata().authors }
     pub fn publish(&self) -> bool { self.manifest.publish() }
 
     pub fn has_custom_build(&self) -> bool {

--- a/src/cargo/ops/cargo_rustc/compilation.rs
+++ b/src/cargo/ops/cargo_rustc/compilation.rs
@@ -120,6 +120,7 @@ impl<'cfg> Compilation<'cfg> {
            .env("CARGO_PKG_NAME", &pkg.name())
            .env("CARGO_PKG_DESCRIPTION", metadata.description.as_ref().unwrap_or(&String::new()))
            .env("CARGO_PKG_HOMEPAGE", metadata.homepage.as_ref().unwrap_or(&String::new()))
+           .env("CARGO_PKG_AUTHORS", &pkg.authors().join(":"))
            .cwd(pkg.root());
         Ok(cmd)
     }

--- a/src/doc/environment-variables.md
+++ b/src/doc/environment-variables.md
@@ -45,6 +45,7 @@ let version = env!("CARGO_PKG_VERSION");
 * `CARGO_PKG_VERSION_MINOR` - The minor version of your package.
 * `CARGO_PKG_VERSION_PATCH` - The patch version of your package.
 * `CARGO_PKG_VERSION_PRE` - The pre-release version of your package.
+* `CARGO_PKG_AUTHORS` - Colon seperated list of authors from the manifest of your package.
 
 # Environment variables Cargo sets for build scripts
 


### PR DESCRIPTION
This will allow crates to use the CARGO_PKG_AUTHORS env variable to get a comma
seperated list of the authors declared in the manifest.

Closes #2441