### PR TITLE
Add build flair

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@ Cargo downloads your Rust project’s dependencies and compiles your project.
 
 Learn more at http://doc.crates.io/
 
+## Code Status
+[![Build Status](https://travis-ci.org/rust-lang/cargo.svg?branch=master)](https://travis-ci.org/rust-lang/cargo)
+[![Build Status](https://ci.appveyor.com/api/projects/status/jnh54531mpidb2c2?svg=true)](https://ci.appveyor.com/project/alexcrichton/cargo)
+
 ## Installing Cargo
 
 Cargo is distributed by default with Rust, so if you've got `rustc` installed


### PR DESCRIPTION
Dearest Reviewer

I have add the travis-ci build badge to the README. I pushed the image down towards the bottom. I was thinking that most people reading the readme do not care about the build status. I have seen the badge done in different locations and with different titles. I am easy on where it goes. I added it because I found that I was looking for the status when my branch was failing. I have since learned the travis interface. 

<3 Becker

<img width="415" alt="screen shot 2016-03-12 at 10 51 43 am" src="https://cloud.githubusercontent.com/assets/12170/13724615/7fe41e36-e840-11e5-8815-3ac1f13dc2fd.png">
