### PR TITLE
Fix caching features across backtracking

### DIFF
--- a/tests/test_cargo_cfg.rs
+++ b/tests/test_cargo_cfg.rs
@@ -194,8 +194,8 @@ test!(works_through_the_registry {
 
     Package::new("foo", "0.1.0").publish();
     Package::new("bar", "0.1.0")
-            .target_dep("foo", "0.1.0", "cfg(unix)")
-            .target_dep("foo", "0.1.0", "cfg(windows)")
+            .target_dep("foo", "0.1.0", "'cfg(unix)'")
+            .target_dep("foo", "0.1.0", "'cfg(windows)'")
             .publish();
 
     let p = project("a")

--- a/tests/test_cargo_registry.rs
+++ b/tests/test_cargo_registry.rs
@@ -1015,3 +1015,26 @@ test!(only_download_relevant {
 {compiling} bar v0.5.0 ([..])
 ", downloading = DOWNLOADING, compiling = COMPILING, updating = UPDATING)));
 });
+
+test!(resolve_and_backtracking {
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [project]
+            name = "bar"
+            version = "0.5.0"
+            authors = []
+
+            [dependencies]
+            foo = "*"
+        "#)
+        .file("src/main.rs", "fn main() {}");
+    p.build();
+
+    Package::new("foo", "0.1.1")
+            .feature_dep("bar", "0.1", &["a", "b"])
+            .publish();
+    Package::new("foo", "0.1.0").publish();
+
+    assert_that(p.cargo("build"),
+                execs().with_status(0));
+});


### PR DESCRIPTION
In the local loop during resolution all variables need to be reset whenever we
backtrack up a frame, but currently the `method` and `features` set are
accidentally not reset whenever we backtrack. Calculate the `method` later and
cache `features` in each frame so we can properly backtrack.

Closes #2472