### PR TITLE
Start rustformat config

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,1 @@
+max_width = 80


### PR DESCRIPTION
Dearest Reviewer,

rustfmt seems to be the winning formatter. Cargo holds to a 80 character line max. It  would be good if the formatter would just work for the project. Discussed a bit in #2467 I checked and about 330 lines are currently over 80 characters. Keeping the style check at a limit of 100 would prevent a bulk reformatting and allow it to happen over time.

Thanks
Becker