### PR TITLE
doc: make the pages’ titles consistent

### DIFF
--- a/src/doc/build-script.md
+++ b/src/doc/build-script.md
@@ -1,4 +1,4 @@
-% Build Script Support - Cargo Documentation
+% Build Script Support
 
 Some packages need to compile third-party non-Rust code, for example C
 libraries. Other packages need to link to C libraries which can either be

--- a/src/doc/config.md
+++ b/src/doc/config.md
@@ -1,4 +1,4 @@
-% Configuration - Cargo Documentation
+% Configuration
 
 This document will explain how Cargo’s configuration system works, as well as
 available keys or configuration.  For configuration of a project through its

--- a/src/doc/faq.md
+++ b/src/doc/faq.md
@@ -1,4 +1,4 @@
-% Frequently Asked Questions - Cargo Documentation
+% Frequently Asked Questions
 
 # Is the plan to use GitHub as a package repository?
 

--- a/src/doc/manifest.md
+++ b/src/doc/manifest.md
@@ -1,4 +1,4 @@
-% The Manifest Format - Cargo Documentation
+% The Manifest Format
 
 # The `[package]` Section
 

--- a/src/doc/pkgid-spec.md
+++ b/src/doc/pkgid-spec.md
@@ -1,4 +1,4 @@
-% Package ID Specifications - Cargo Documentation
+% Package ID Specifications
 
 # Package ID Specifications
 


### PR DESCRIPTION
The titles of some of the pages end with “Cargo Documentation” (_e.g._, [Frequently Asked Questions](http://doc.crates.io/faq.html)) whereas the titles of some other pages do not (_e.g._, [Environment Variables](http://doc.crates.io/environment-variables.html)), which is a bit inconsistent. Perhaps one should either add that ending to all the titles or eliminate it from all of them. This pull request does the latter, which can be changed if needed. I personally think that such long titles are reasonable for the `title` HTML tag but a bit too verbose when displayed on the page.