### PR TITLE
Fix nightly dist builds

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -166,11 +166,9 @@ $(DOC_DIR)/%: src/doc/%
 	@mkdir -p $(@D)
 	cp $< $@
 
-ifdef CFG_ENABLE_NIGHTLY
-
 OPENSSL_OS_x86_64-unknown-linux-gnu := linux-x86_64
 OPENSSL_OS_x86_64-unknown-linux-musl := linux-x86_64
-OPENSSL_OS_i686-unknown-linux-gnu := linux-x32
+OPENSSL_OS_i686-unknown-linux-gnu := linux-elf
 OPENSSL_OS_arm-unknown-linux-gnueabi := linux-armv4
 OPENSSL_OS_arm-unknown-linux-gnueabihf := linux-armv4
 OPENSSL_OS_armv7-unknown-linux-gnueabihf := linux-armv4
@@ -194,7 +192,12 @@ OPENSSL_AR_armv7-unknown-linux-gnueabihf := armv7-linux-gnueabihf-ar
 OPENSSL_AR_x86_64-unknown-freebsd := x86_64-unknown-freebsd10-ar
 OPENSSL_AR_x86_64-unknown-netbsd := x86_64-unknown-netbsd-ar
 
+SETARCH_i686-unknown-linux-gnu := setarch i386
+OPENSSL_CFLAGS_i686-unknown-linux-gnu := -m32
+
 define BUILD_OPENSSL
+ifdef OPENSSL_OS_$(1)
+ifdef CFG_ENABLE_NIGHTLY
 OPENSSL_INSTALL_$(1) := $$(CFG_BUILD_DIR)/target/openssl/$(1)-install
 
 target/openssl/$(1).stamp: target/openssl/openssl-$$(OPENSSL_VERS).tar.gz \
@@ -204,8 +207,8 @@ target/openssl/$(1).stamp: target/openssl/openssl-$$(OPENSSL_VERS).tar.gz \
 	(cd target/openssl/$(1) && \
 	 CC=$$(OPENSSL_CC_$(1)) \
 	 AR=$$(OPENSSL_AR_$(1)) \
-	 ./Configure --prefix=$$(OPENSSL_INSTALL_$(1)) \
-	   no-dso $$(OPENSSL_OS_$(1)) -fPIC && \
+	 $$(SETARCH_$(1)) ./Configure --prefix=$$(OPENSSL_INSTALL_$(1)) \
+	   no-dso $$(OPENSSL_OS_$(1)) -fPIC $$(OPENSSL_CFLAGS_$(1))&& \
 	 $(MAKE) -j10 && \
 	 $(MAKE) install)
 	touch $$@
@@ -215,9 +218,19 @@ cargo-$(1): export OPENSSL_STATIC := 1
 cargo-$(1): export OPENSSL_ROOT_DIR := $$(OPENSSL_INSTALL_$(1))
 cargo-$(1): export OPENSSL_LIB_DIR := $$(OPENSSL_INSTALL_$(1))/lib
 cargo-$(1): export OPENSSL_INCLUDE_DIR := $$(OPENSSL_INSTALL_$(1))/include
+test-unit-$(1): export OPENSSL_STATIC := 1
+test-unit-$(1): export OPENSSL_ROOT_DIR := $$(OPENSSL_INSTALL_$(1))
+test-unit-$(1): export OPENSSL_LIB_DIR := $$(OPENSSL_INSTALL_$(1))/lib
+test-unit-$(1): export OPENSSL_INCLUDE_DIR := $$(OPENSSL_INSTALL_$(1))/include
 
 # build libz statically into the cargo we're producing
 cargo-$(1): export LIBZ_SYS_STATIC := 1
+else
+target/openssl/$(1).stamp:
+endif
+else
+target/openssl/$(1).stamp:
+endif
 endef
 
 $(foreach target,$(CFG_TARGET),$(eval $(call BUILD_OPENSSL,$(target))))
@@ -229,12 +242,6 @@ target/openssl/openssl-$(OPENSSL_VERS).tar.gz: | target/openssl/
 
 target/openssl/:
 	mkdir -p $(@)
-else
-define BUILD_OPENSSL
-target/openssl/$(1).stamp:
-endef
-$(foreach target,$(CFG_TARGET),$(eval $(call BUILD_OPENSSL,$(target))))
-endif
 
 # === Distribution
 

--- a/src/etc/install-deps.py
+++ b/src/etc/install-deps.py
@@ -14,23 +14,35 @@ else:
     host_bits = 'x86_64'
     extra_bits = 'i686'
 
-extra = None
+
 
 # Figure out our target triple
 if sys.platform == 'linux' or sys.platform == 'linux2':
     host = host_bits + '-unknown-linux-gnu'
-    extra = extra_bits + '-unknown-linux-gnu'
+    targets = [
+        'i686-unknown-linux-gnu',
+        'x86_64-unknown-linux-gnu',
+        'arm-unknown-linux-gnueabi',
+        'arm-unknown-linux-gnueabihf',
+        'armv7-unknown-linux-gnueabihf',
+        'x86_64-unknown-freebsd',
+        'x86_64-unknown-netbsd',
+    ]
 elif sys.platform == 'darwin':
     host = host_bits + '-apple-darwin'
-    extra = extra_bits + '-apple-darwin'
+    targets = ['i686-apple-darwin', 'x86_64-apple-darwin']
 elif sys.platform == 'win32':
     if os.environ.get('MSVC') == '1':
         host = host_bits + '-pc-windows-msvc'
-        extra = extra_bits + '-pc-windows-msvc'
+        targets = [
+            'i686-pc-windows-msvc',
+            'x86_64-pc-windows-msvc',
+        ]
     else:
         host = host_bits + '-pc-windows-gnu'
+        targets = [host]
 else:
-    exit_msg = "There is no official Cargo snapshot for {} platform, sorry." 
+    exit_msg = "There is no official Cargo snapshot for {} platform, sorry."
     sys.exit(exit_msg.format(sys.platform))
 
 rust_date = open('src/rustversion.txt').read().strip()
@@ -48,9 +60,8 @@ def install_via_tarballs():
     os.remove(host_fname)
 
     # Download all target libraries needed
-    fetch_std(host)
-    if extra is not None:
-        fetch_std(extra)
+    for target in targets:
+        fetch_std(target)
 
     if os.path.isdir("rustc"):
         shutil.rmtree("rustc")


### PR DESCRIPTION
* When downloading rustc, also download a number of cross-std libraries so we
  can cross compile with that compiler.
* Only build OpenSSL on some --enable-nightly builds, not all. For example
  Windows and OSX don't want to link statically to OpenSSL.