### PR TITLE
Expose CARGO_FEATURE_<foo> environment variables to tests

### DIFF
--- a/src/cargo/ops/cargo_rustc/mod.rs
+++ b/src/cargo/ops/cargo_rustc/mod.rs
@@ -615,7 +615,7 @@ pub fn process(cmd: CommandType, pkg: &Package,
     Ok(cmd)
 }
 
-fn envify(s: &str) -> String {
+pub fn envify(s: &str) -> String {
     s.chars()
      .flat_map(|c| c.to_uppercase())
      .map(|c| if c == '-' {'_'} else {c})

--- a/src/cargo/ops/cargo_test.rs
+++ b/src/cargo/ops/cargo_test.rs
@@ -89,6 +89,11 @@ fn run_unit_tests(options: &TestOptions,
         };
         let mut cmd = try!(compilation.target_process(exe, pkg));
         cmd.args(test_args);
+
+        for feat in options.compile_opts.features.iter() {
+            cmd.env(&format!("CARGO_FEATURE_{}", ops::envify(feat)), "1");
+        }
+
         try!(config.shell().concise(|shell| {
             shell.status("Running", to_display.display().to_string())
         }));

--- a/src/cargo/ops/mod.rs
+++ b/src/cargo/ops/mod.rs
@@ -3,7 +3,7 @@ pub use self::cargo_compile::{compile, compile_pkg, resolve_dependencies, Compil
 pub use self::cargo_compile::{CompileFilter, CompileMode};
 pub use self::cargo_read_manifest::{read_manifest,read_package,read_packages};
 pub use self::cargo_rustc::{compile_targets, Compilation, Layout, Kind, Unit};
-pub use self::cargo_rustc::{Context, LayoutProxy};
+pub use self::cargo_rustc::{envify, Context, LayoutProxy};
 pub use self::cargo_rustc::{BuildOutput, BuildConfig, TargetConfig};
 pub use self::cargo_rustc::{CommandType, CommandPrototype, ExecEngine, ProcessEngine};
 pub use self::cargo_run::run;

--- a/src/doc/environment-variables.md
+++ b/src/doc/environment-variables.md
@@ -84,6 +84,25 @@ let out_dir = env::var("OUT_DIR").unwrap();
 * `DEP_<name>_<key>` - For more information about this set of environment
                        variables, see build script documentation about [`links`][links].
 
+# Environment variables Cargo sets for tests
+
+Cargo sets several environment variables when tests are
+run. Because these variables are set at the run time of the test,
+the above example using `env!` won't work and instead you'll need
+to retrieve the values when the build script is run:
+
+```
+use std::env;
+let foo = env::var("CARGO_FEATURE_FOO").unwrap();
+```
+
+`foo` will now contain the value of `1` if the feature is active.
+
+* `CARGO_FEATURE_<name>` - For each activated feature of the package being
+                           built, this environment variable will be present
+                           where `<name>` is the name of the feature uppercased
+                           and having `-` translated to `_`.
+
 [links]: build-script.html#the-links-manifest-key
 [profile]: manifest.html#the-profile-sections
 [clang]:http://clang.llvm.org/docs/CrossCompilation.html#target-triple

--- a/tests/test_cargo_test.rs
+++ b/tests/test_cargo_test.rs
@@ -1651,6 +1651,45 @@ test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
 ", compiling = COMPILING, running = RUNNING, doctest = DOCTEST)))
 });
 
+test!(test_gets_env_features {
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [package]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+            [features]
+            bar = []
+        "#)
+        .file("src/lib.rs", r#"
+            #[test]
+            fn assert_features() {
+                use std::env;
+                assert_eq!(env::var("CARGO_FEATURE_BAR").unwrap(), "1");
+            }
+        "#)
+        .file("tests/test.rs", r#"
+            #[test]
+            fn assert_features() {
+                use std::env;
+                assert_eq!(env::var("CARGO_FEATURE_BAR").unwrap(), "1");
+            }
+        "#);
+
+    assert_that(p.cargo_process("test").arg("--features").arg("bar")
+                                       .arg("--test").arg("test"),
+                execs().with_status(0).with_stdout(format!("\
+{compiling} foo [..]
+{running} target[..]test-[..]
+
+running 1 test
+test assert_features ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
+
+", compiling = COMPILING, running = RUNNING)))
+});
+
 test!(dashes_to_underscores {
     let p = project("foo")
         .file("Cargo.toml", r#"


### PR DESCRIPTION
This can be useful if you need to enumerate the active features within an integration test which spawns builds.