### PR TITLE
expose cargo package name as CARGO_PKG_NAME

### DIFF
--- a/src/cargo/ops/cargo_rustc/compilation.rs
+++ b/src/cargo/ops/cargo_rustc/compilation.rs
@@ -109,12 +109,17 @@ impl<'cfg> Compilation<'cfg> {
             }
         }
 
+	 let metadata = pkg.manifest().metadata();
+
         cmd.env("CARGO_MANIFEST_DIR", pkg.root())
            .env("CARGO_PKG_VERSION_MAJOR", &pkg.version().major.to_string())
            .env("CARGO_PKG_VERSION_MINOR", &pkg.version().minor.to_string())
            .env("CARGO_PKG_VERSION_PATCH", &pkg.version().patch.to_string())
            .env("CARGO_PKG_VERSION_PRE", &pre_version_component(pkg.version()))
            .env("CARGO_PKG_VERSION", &pkg.version().to_string())
+           .env("CARGO_PKG_NAME", &pkg.name())
+           .env("CARGO_PKG_DESCRIPTION", metadata.description.as_ref().unwrap_or(&String::new()))
+           .env("CARGO_PKG_HOMEPAGE", metadata.homepage.as_ref().unwrap_or(&String::new()))
            .cwd(pkg.root());
         Ok(cmd)
     }

--- a/tests/test_cargo_compile.rs
+++ b/tests/test_cargo_compile.rs
@@ -724,31 +724,40 @@ test!(ignores_carriage_return_in_lockfile {
                 execs().with_status(0));
 });
 
-test!(crate_version_env_vars {
+test!(crate_env_vars {
     let p = project("foo")
         .file("Cargo.toml", r#"
-            [project]
-            name = "foo"
-            version = "0.5.1-alpha.1"
-            authors = ["wycats@example.com"]
+	    [project]
+	    name = "foo"
+	    version = "0.5.1-alpha.1"
+	    description = "This is foo"
+	    homepage = "http://example.com"
+	    authors = ["wycats@example.com"]
         "#)
         .file("src/main.rs", r#"
             extern crate foo;
 
-            static VERSION_MAJOR: &'static str = env!("CARGO_PKG_VERSION_MAJOR");
-            static VERSION_MINOR: &'static str = env!("CARGO_PKG_VERSION_MINOR");
-            static VERSION_PATCH: &'static str = env!("CARGO_PKG_VERSION_PATCH");
-            static VERSION_PRE: &'static str = env!("CARGO_PKG_VERSION_PRE");
-            static VERSION: &'static str = env!("CARGO_PKG_VERSION");
-            static CARGO_MANIFEST_DIR: &'static str = env!("CARGO_MANIFEST_DIR");
+
+	    static VERSION_MAJOR: &'static str = env!("CARGO_PKG_VERSION_MAJOR");
+	    static VERSION_MINOR: &'static str = env!("CARGO_PKG_VERSION_MINOR");
+	    static VERSION_PATCH: &'static str = env!("CARGO_PKG_VERSION_PATCH");
+	    static VERSION_PRE: &'static str = env!("CARGO_PKG_VERSION_PRE");
+	    static VERSION: &'static str = env!("CARGO_PKG_VERSION");
+	    static CARGO_MANIFEST_DIR: &'static str = env!("CARGO_MANIFEST_DIR");
+	    static PKG_NAME: &'static str = env!("CARGO_PKG_NAME");
+	    static HOMEPAGE: &'static str = env!("CARGO_PKG_HOMEPAGE");
+	    static DESCRIPTION: &'static str = env!("CARGO_PKG_DESCRIPTION");
 
             fn main() {
                 let s = format!("{}-{}-{} @ {} in {}", VERSION_MAJOR,
                                 VERSION_MINOR, VERSION_PATCH, VERSION_PRE,
                                 CARGO_MANIFEST_DIR);
-                assert_eq!(s, foo::version());
-                println!("{}", s);
-                assert_eq!(s, VERSION);
+		 assert_eq!(s, foo::version());
+		 println!("{}", s);
+		 assert_eq!("foo", PKG_NAME);
+		 assert_eq!("http://example.com", HOMEPAGE);
+		 assert_eq!("This is foo", DESCRIPTION);
+		 assert_eq!(s, VERSION);
             }
         "#)
         .file("src/lib.rs", r#"


### PR DESCRIPTION
#2504    Expose cargo package name as `CARGO_PKG_NAME`, and package description and home page are exposed as  `CARGO_PKG_DESCRIPTION` and `CARGO_PKG_HOMEPAGE` respectively