### PR TITLE
install-deps.py: add x86_64-unknown-linux-musl target

### DIFF
--- a/src/etc/install-deps.py
+++ b/src/etc/install-deps.py
@@ -22,6 +22,7 @@ if sys.platform == 'linux' or sys.platform == 'linux2':
     targets = [
         'i686-unknown-linux-gnu',
         'x86_64-unknown-linux-gnu',
+        'x86_64-unknown-linux-musl',
         'arm-unknown-linux-gnueabi',
         'arm-unknown-linux-gnueabihf',
         'armv7-unknown-linux-gnueabihf',


### PR DESCRIPTION
This lets me build a statically linked cargo on our linux-cross Docker image with the following
commands:

$ apt-get install musl-tools # for musl-gcc, which is needed to build openssl
$ ./.travis.install.deps.sh
$ ./configure --local-rust-root=$(pwd)/rustc --enable-nightly --target=x86_64-unknown-linux-musl
$ make
$ file target/x86_64-unknown-linux-musl/release/cargo
cargo: ELF 64-bit LSB executable, x86-64, version 1 (GNU/Linux), statically linked (..)

---

r? @alexcrichton -- If we want start building cargo for this target on the bots, we'll have to modify the linux-cross Dockerfile to install musl-tools.
cc @eddyb