### PR TITLE
Don't require all build script output to be utf-8

### DIFF
--- a/src/cargo/util/paths.rs
+++ b/src/cargo/util/paths.rs
@@ -68,10 +68,21 @@ pub fn without_prefix<'a>(a: &'a Path, b: &'a Path) -> Option<&'a Path> {
 }
 
 pub fn read(path: &Path) -> CargoResult<String> {
-    (|| -> CargoResult<String> {
+    (|| -> CargoResult<_> {
         let mut ret = String::new();
         let mut f = try!(File::open(path));
         try!(f.read_to_string(&mut ret));
+        Ok(ret)
+    })().map_err(human).chain_error(|| {
+        human(format!("failed to read `{}`", path.display()))
+    })
+}
+
+pub fn read_bytes(path: &Path) -> CargoResult<Vec<u8>> {
+    (|| -> CargoResult<_> {
+        let mut ret = Vec::new();
+        let mut f = try!(File::open(path));
+        try!(f.read_to_end(&mut ret));
         Ok(ret)
     })().map_err(human).chain_error(|| {
         human(format!("failed to read `{}`", path.display()))


### PR DESCRIPTION
Build scripts often stream output of native build systems like cmake/make and
those aren't always guaranteed to produce utf-8 output. For example  German
MSVC cmake build has been reported to print non-utf-8 umlauts.

This commit instead only attempts to interpret each line as utf-8 rather than
the entire build script output. All non-utf-8 output is ignored.

Closes #2556