### PR TITLE
Document env vars introduced in PR #2523 to the docs

### DIFF
--- a/src/doc/environment-variables.md
+++ b/src/doc/environment-variables.md
@@ -46,6 +46,9 @@ let version = env!("CARGO_PKG_VERSION");
 * `CARGO_PKG_VERSION_PATCH` - The patch version of your package.
 * `CARGO_PKG_VERSION_PRE` - The pre-release version of your package.
 * `CARGO_PKG_AUTHORS` - Colon seperated list of authors from the manifest of your package.
+* `CARGO_PKG_NAME` - The name of your package.
+* `CARGO_PKG_DESCRIPTION` - The description of your package.
+* `CARGO_PKG_HOMEPAGE` - The home page of your package.
 
 # Environment variables Cargo sets for build scripts
 


### PR DESCRIPTION
Document environment variables introduced in #2523 (`CARGO_PKG_NAME`, `CARGO_PKG_DESCRIPTION`, `CARGO_PKG_HOMEPAGE`).