### PR TITLE
Add `cargo test --doc`

### DIFF
--- a/src/bin/bench.rs
+++ b/src/bin/bench.rs
@@ -70,6 +70,7 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
     let ops = ops::TestOptions {
         no_run: options.flag_no_run,
         no_fail_fast: false,
+        only_doc: false,
         compile_opts: ops::CompileOptions {
             config: config,
             jobs: options.flag_jobs,

--- a/src/cargo/ops/cargo_test.rs
+++ b/src/cargo/ops/cargo_test.rs
@@ -8,9 +8,8 @@ pub struct TestOptions<'a> {
     pub compile_opts: ops::CompileOptions<'a>,
     pub no_run: bool,
     pub no_fail_fast: bool,
+    pub only_doc: bool,
 }
-
-
 
 pub fn run_tests(manifest_path: &Path,
                  options: &TestOptions,
@@ -20,7 +19,11 @@ pub fn run_tests(manifest_path: &Path,
     if options.no_run {
         return Ok(None)
     }
-    let mut errors = try!(run_unit_tests(options, test_args, &compilation));
+    let mut errors = if options.only_doc {
+        Vec::new()
+    } else {
+        try!(run_unit_tests(options, test_args, &compilation))
+    };
 
     // If we have an error and want to fail fast, return
     if !errors.is_empty() && !options.no_fail_fast {

--- a/tests/test_cargo_test.rs
+++ b/tests/test_cargo_test.rs
@@ -2082,3 +2082,30 @@ test!(selective_test_optional_dep {
 {running} `rustc a[..]src[..]lib.rs [..]`
 ", compiling = COMPILING, running = RUNNING)));
 });
+
+test!(only_test_docs {
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [package]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+        "#)
+        .file("src/lib.rs", r#"
+            #[test]
+            fn foo() {
+                let a: u32 = "hello";
+            }
+
+            /// ```
+            /// println!("ok");
+            /// ```
+            pub fn bar() {
+            }
+        "#)
+        .file("tests/foo.rs", "this is not rust");
+    p.build();
+
+    assert_that(p.cargo("test").arg("--doc"),
+                execs().with_status(0));
+});


### PR DESCRIPTION
Supports testing only the documentation (like `--lib`, `--bin`, etc).
