### PR TITLE
Remove submodule directory before cloning

### DIFF
--- a/src/cargo/sources/git/utils.rs
+++ b/src/cargo/sources/git/utils.rs
@@ -339,6 +339,7 @@ impl<'a> GitCheckout<'a> {
                     }
                     Err(..) => {
                         let path = repo.workdir().unwrap().join(child.path());
+                        let _ = fs::remove_dir_all(&path);
                         try!(git2::Repository::clone(url, &path))
                     }
                 };


### PR DESCRIPTION
If the directory is in a corrupt state that caused an existing repository to not
successfully open, then we'll want to blow it away anything that already exists
to ensure we start from a clean slate.

Closes #2567
