### PR TITLE
Have CLI take preference over config for verbosity

### DIFF
--- a/src/bin/cargo.rs
+++ b/src/bin/cargo.rs
@@ -11,8 +11,10 @@ use std::env;
 use std::fs;
 use std::path::PathBuf;
 
+use cargo::core::shell::Verbosity;
 use cargo::execute_main_without_stdin;
-use cargo::util::{self, CliResult, lev_distance, Config, human, CargoResult, ChainError};
+use cargo::util::ChainError;
+use cargo::util::{self, CliResult, lev_distance, Config, human, CargoResult};
 
 #[derive(RustcDecodable)]
 pub struct Flags {
@@ -132,7 +134,7 @@ fn execute(flags: Flags, config: &Config) -> CliResult<Option<()>> {
         // `cargo -h` so we can go through the normal process of printing the
         // help message.
         "" | "help" if flags.arg_args.is_empty() => {
-            config.shell().set_verbose(true);
+            config.shell().set_verbosity(Verbosity::Verbose);
             let args = &["cargo".to_string(), "-h".to_string()];
             let r = cargo::call_main_without_stdin(execute, config, USAGE, args,
                                                    false);
@@ -160,7 +162,7 @@ fn execute(flags: Flags, config: &Config) -> CliResult<Option<()>> {
 
     macro_rules! cmd{
         ($name:ident) => (if args[1] == stringify!($name).replace("_", "-") {
-            config.shell().set_verbose(true);
+            config.shell().set_verbosity(Verbosity::Verbose);
             let r = cargo::call_main_without_stdin($name::execute, config,
                                                    $name::USAGE,
                                                    &args,

--- a/src/cargo/core/shell.rs
+++ b/src/cargo/core/shell.rs
@@ -6,7 +6,7 @@ use term::color::{Color, BLACK, RED, GREEN, YELLOW};
 use term::{self, Terminal, TerminfoTerminal, color, Attr};
 
 use self::AdequateTerminal::{NoColor, Colored};
-use self::Verbosity::{Verbose, Normal, Quiet};
+use self::Verbosity::{Verbose, Quiet};
 use self::ColorConfig::{Auto, Always, Never};
 
 use util::errors::CargoResult;
@@ -103,23 +103,8 @@ impl MultiShell {
         self.err().say_status("warning:", message, YELLOW, false)
     }
 
-    pub fn set_verbosity(&mut self, verbose: bool, quiet: bool) -> CargoResult<()> {
-        self.verbosity = match (verbose, quiet) {
-            (true, true) => bail!("cannot set both --verbose and --quiet"),
-            (true, false) => Verbose,
-            (false, true) => Quiet,
-            (false, false) => Normal
-        };
-        Ok(())
-    }
-
-    /// shortcut for commands that don't have both --verbose and --quiet
-    pub fn set_verbose(&mut self, verbose: bool) {
-        if verbose {
-            self.verbosity = Verbose;
-        } else {
-            self.verbosity = Normal;
-        }
+    pub fn set_verbosity(&mut self, verbosity: Verbosity) {
+        self.verbosity = verbosity;
     }
 
     pub fn set_color_config(&mut self, color: Option<&str>) -> CargoResult<()> {

--- a/tests/test_cargo_run.rs
+++ b/tests/test_cargo_run.rs
@@ -70,6 +70,26 @@ test!(simple_quiet_and_verbose {
 error = ERROR)));
 });
 
+test!(quiet_and_verbose_config {
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [project]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+        "#)
+        .file(".cargo/config", r#"
+            [term]
+            verbose = true
+        "#)
+        .file("src/main.rs", r#"
+            fn main() { println!("hello"); }
+        "#);
+
+    assert_that(p.cargo_process("run").arg("-q"),
+                execs().with_status(0));
+});
+
 test!(simple_with_args {
     let p = project("foo")
         .file("Cargo.toml", r#"


### PR DESCRIPTION
If a CLI option is passed, that trumps any command line configuration, otherwise
just do what we did previously.

Closes #2588