### PR TITLE
Use stat() instead of lstat() in cargo --list

### DIFF
--- a/src/bin/cargo.rs
+++ b/src/bin/cargo.rs
@@ -247,9 +247,9 @@ fn list_commands(config: &Config) -> BTreeSet<String> {
 #[cfg(unix)]
 fn is_executable<P: AsRef<Path>>(path: P) -> bool {
     use std::os::unix::prelude::*;
-    fs::metadata(path).map(|metadata|
+    fs::metadata(path).map(|metadata| {
         metadata.is_file() && metadata.permissions().mode() & 0o111 != 0
-    ).unwrap_or(false)
+    }).unwrap_or(false)
 }
 #[cfg(windows)]
 fn is_executable<P: AsRef<Path>>(path: P) -> bool {

--- a/src/bin/cargo.rs
+++ b/src/bin/cargo.rs
@@ -9,7 +9,7 @@ extern crate toml;
 use std::collections::BTreeSet;
 use std::env;
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path,PathBuf};
 
 use cargo::execute_main_without_stdin;
 use cargo::util::{self, CliResult, lev_distance, Config, human, CargoResult, ChainError};
@@ -193,10 +193,9 @@ fn execute_subcommand(config: &Config,
     let path = search_directories(config)
                     .iter()
                     .map(|dir| dir.join(&command_exe))
-                    .filter_map(|dir| fs::metadata(&dir).ok().map(|m| (dir, m)))
-                    .find(|&(_, ref meta)| is_executable(meta));
+                    .find(|file| is_executable(file));
     let command = match path {
-        Some((command, _)) => command,
+        Some(command) => command,
         None => {
             return Err(human(match find_closest(config, cmd) {
                 Some(closest) => format!("no such subcommand\n\n\t\
@@ -231,11 +230,9 @@ fn list_commands(config: &Config) -> BTreeSet<String> {
             if !filename.starts_with(prefix) || !filename.ends_with(suffix) {
                 continue
             }
-            if let Ok(meta) = entry.metadata() {
-                if is_executable(&meta) {
-                    let end = filename.len() - suffix.len();
-                    commands.insert(filename[prefix.len()..end].to_string());
-                }
+            if is_executable(entry.path()) {
+                let end = filename.len() - suffix.len();
+                commands.insert(filename[prefix.len()..end].to_string());
             }
         }
     }
@@ -248,13 +245,15 @@ fn list_commands(config: &Config) -> BTreeSet<String> {
 }
 
 #[cfg(unix)]
-fn is_executable(metadata: &fs::Metadata) -> bool {
+fn is_executable<P: AsRef<Path>>(path: P) -> bool {
     use std::os::unix::prelude::*;
-    metadata.is_file() && metadata.permissions().mode() & 0o111 != 0
+    fs::metadata(path).map(|metadata|
+        metadata.is_file() && metadata.permissions().mode() & 0o111 != 0
+    ).unwrap_or(false)
 }
 #[cfg(windows)]
-fn is_executable(metadata: &fs::Metadata) -> bool {
-    metadata.is_file()
+fn is_executable<P: AsRef<Path>>(path: P) -> bool {
+    fs::metadata(path).map(|metadata| metadata.is_file()).unwrap_or(false)
 }
 
 fn search_directories(config: &Config) -> Vec<PathBuf> {

--- a/tests/test_cargo.rs
+++ b/tests/test_cargo.rs
@@ -7,12 +7,13 @@ use std::str;
 
 use cargo_process;
 use support::paths;
-use support::{cargo_dir, execs, project, mkdir_recursive, ProjectBuilder, ERROR};
+use support::{execs, project, mkdir_recursive, ProjectBuilder, ERROR};
 use hamcrest::{assert_that};
 
 fn setup() {
 }
 
+#[cfg_attr(windows,allow(dead_code))]
 enum FakeKind<'a> {
     Executable,
     Symlink{target:&'a Path},
@@ -78,6 +79,8 @@ test!(list_command_looks_at_path {
 // windows and symlinks don't currently agree that well
 #[cfg(unix)]
 test!(list_command_resolves_symlinks {
+    use support::cargo_dir;
+
     let proj = project("list-non-overlapping");
     let proj = fake_file(proj, &Path::new("path-test"), "cargo-2",
                          FakeKind::Symlink{target:&cargo_dir().join("cargo")});

--- a/tests/test_cargo.rs
+++ b/tests/test_cargo.rs
@@ -27,7 +27,7 @@ fn fake_executable(proj: ProjectBuilder, dir: &Path, name: &str) -> ProjectBuild
     fn make_executable(p: &Path) {
         use std::os::unix::prelude::*;
 
-        let mut perms = fs::metadata(p).unwrap().permissions();;
+        let mut perms = fs::metadata(p).unwrap().permissions();
         let mode = perms.mode();
         perms.set_mode(mode | 0o111);
         fs::set_permissions(p, perms).unwrap();
@@ -40,7 +40,7 @@ fn path() -> Vec<PathBuf> {
     env::split_paths(&env::var_os("PATH").unwrap_or(OsString::new())).collect()
 }
 
-test!(list_commands_looks_at_path {
+test!(list_command_looks_at_path {
     let proj = project("list-non-overlapping");
     let proj = fake_executable(proj, &Path::new("path-test"), "cargo-1");
     let mut pr = cargo_process();

--- a/tests/test_cargo.rs
+++ b/tests/test_cargo.rs
@@ -79,7 +79,8 @@ test!(list_command_looks_at_path {
 #[cfg(unix)]
 test!(list_command_resolves_symlinks {
     let proj = project("list-non-overlapping");
-    let proj = fake_file(proj, &Path::new("path-test"), "cargo-2", FakeKind::Symlink{target:&cargo_dir().join("cargo")});
+    let proj = fake_file(proj, &Path::new("path-test"), "cargo-2",
+                         FakeKind::Symlink{target:&cargo_dir().join("cargo")});
     let mut pr = cargo_process();
 
     let mut path = path();


### PR DESCRIPTION
The OS-specific implementation is necessary because according to the docs, [DirEntry::metadata is fast on Windows](https://doc.rust-lang.org/stable/std/fs/struct.DirEntry.html#method.metadata). Note  `is_executable` is used elsewhere so we can't change that directly to accept `DirEntry` instead of `Metadata`.

Fixes #2591