### PR TITLE
Error refactoring

### DIFF
--- a/src/bin/bench.rs
+++ b/src/bin/bench.rs
@@ -1,5 +1,5 @@
 use cargo::ops;
-use cargo::util::{CliResult, CliError, Human, Config};
+use cargo::util::{CliResult, CliError, human, Config};
 use cargo::util::important_paths::{find_root_manifest_for_wd};
 
 #[derive(RustcDecodable)]
@@ -96,7 +96,7 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
         Some(err) => {
             Err(match err.exit.as_ref().and_then(|e| e.code()) {
                 Some(i) => CliError::new("bench failed", i),
-                None => CliError::from_error(Human(err), 101)
+                None => CliError::from_error(human(err), 101)
             })
         }
     }

--- a/src/bin/run.rs
+++ b/src/bin/run.rs
@@ -1,5 +1,5 @@
 use cargo::ops;
-use cargo::util::{CliResult, CliError, Config, Human};
+use cargo::util::{CliResult, CliError, Config, human};
 use cargo::util::important_paths::{find_root_manifest_for_wd};
 
 #[derive(RustcDecodable)]
@@ -89,7 +89,7 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
         None => Ok(None),
         Some(err) => {
             Err(match err.exit.as_ref().and_then(|e| e.code()) {
-                Some(code) => CliError::from_error(Human(err), code),
+                Some(code) => CliError::from_error(human(err), code),
                 None => CliError::from_error(err, 101),
             })
         }

--- a/src/bin/test.rs
+++ b/src/bin/test.rs
@@ -1,5 +1,5 @@
 use cargo::ops;
-use cargo::util::{CliResult, CliError, Human, Config};
+use cargo::util::{CliResult, CliError, human, Config};
 use cargo::util::important_paths::{find_root_manifest_for_wd};
 
 #[derive(RustcDecodable)]
@@ -108,7 +108,7 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
         Some(err) => {
             Err(match err.exit.as_ref().and_then(|e| e.code()) {
                 Some(i) => CliError::new("test failed", i),
-                None => CliError::from_error(Human(err), 101)
+                None => CliError::from_error(human(err), 101)
             })
         }
     }

--- a/src/cargo/ops/cargo_rustc/custom_build.rs
+++ b/src/cargo/ops/cargo_rustc/custom_build.rs
@@ -6,7 +6,7 @@ use std::str;
 use std::sync::{Mutex, Arc};
 
 use core::PackageId;
-use util::{CargoResult, Human};
+use util::{CargoResult, human};
 use util::{internal, ChainError, profile, paths};
 use util::Freshness;
 
@@ -202,7 +202,7 @@ fn build_work<'a, 'cfg>(cx: &mut Context<'a, 'cfg>, unit: &Unit<'a>)
         let output = try!(exec_engine.exec_with_output(p).map_err(|mut e| {
             e.desc = format!("failed to run custom build command for `{}`\n{}",
                              pkg_name, e.desc);
-            Human(e)
+            human(e)
         }));
         try!(paths::write(&output_file, &output.stdout));
 

--- a/src/cargo/sources/path.rs
+++ b/src/cargo/sources/path.rs
@@ -9,7 +9,7 @@ use glob::Pattern;
 
 use core::{Package, PackageId, Summary, SourceId, Source, Dependency, Registry};
 use ops;
-use util::{self, CargoResult, internal, internal_error, human, ChainError};
+use util::{self, CargoResult, internal, human, ChainError};
 use util::Config;
 
 pub struct PathSource<'cfg> {
@@ -149,7 +149,7 @@ impl<'cfg> PathSource<'cfg> {
         warn!("list_files_git {}", pkg.package_id());
         let index = try!(repo.index());
         let root = try!(repo.workdir().chain_error(|| {
-            internal_error("Can't list files on a bare repository.", "")
+            internal("Can't list files on a bare repository.")
         }));
         let pkg_path = pkg.root();
 
@@ -338,7 +338,7 @@ impl<'cfg> Source for PathSource<'cfg> {
 
     fn fingerprint(&self, pkg: &Package) -> CargoResult<String> {
         if !self.updated {
-            return Err(internal_error("BUG: source was not updated", ""));
+            return Err(internal("BUG: source was not updated"));
         }
 
         let mut max = FileTime::zero();

--- a/src/cargo/util/cargo_error.rs
+++ b/src/cargo/util/cargo_error.rs
@@ -1,0 +1,208 @@
+use std::error::Error;
+use std::fmt;
+use std::str;
+
+pub type CargoResult<T> = Result<T, Box<CargoError>>;
+
+// =============================================================================
+// CargoError trait
+
+pub trait CargoError: Error + Send + 'static {
+    fn is_human(&self) -> bool { false }
+    fn cargo_cause(&self) -> Option<&CargoError>{ None }
+}
+
+impl Error for Box<CargoError> {
+    fn description(&self) -> &str { (**self).description() }
+    fn cause(&self) -> Option<&Error> { (**self).cause() }
+}
+
+impl CargoError for Box<CargoError> {
+    fn is_human(&self) -> bool { (**self).is_human() }
+    fn cargo_cause(&self) -> Option<&CargoError> { (**self).cargo_cause() }
+}
+
+// =============================================================================
+// Chaining errors
+
+pub trait ChainError<T> {
+    fn chain_error<E, F>(self, callback: F) -> CargoResult<T>
+                         where E: CargoError, F: FnOnce() -> E;
+}
+
+#[derive(Debug)]
+struct ChainedError<E> {
+    error: E,
+    cause: Box<CargoError>,
+}
+
+impl<'a, T, F> ChainError<T> for F where F: FnOnce() -> CargoResult<T> {
+    fn chain_error<E, C>(self, callback: C) -> CargoResult<T>
+                         where E: CargoError, C: FnOnce() -> E {
+        self().chain_error(callback)
+    }
+}
+
+impl<T, E: CargoError + 'static> ChainError<T> for Result<T, E> {
+    fn chain_error<E2: 'static, C>(self, callback: C) -> CargoResult<T>
+                         where E2: CargoError, C: FnOnce() -> E2 {
+        self.map_err(move |err| {
+            Box::new(ChainedError {
+                error: callback(),
+                cause: Box::new(err),
+            }) as Box<CargoError>
+        })
+    }
+}
+
+impl<T> ChainError<T> for Box<CargoError> {
+    fn chain_error<E2, C>(self, callback: C) -> CargoResult<T>
+                         where E2: CargoError, C: FnOnce() -> E2 {
+        Err(Box::new(ChainedError {
+            error: callback(),
+            cause: self,
+        }))
+    }
+}
+
+impl<T> ChainError<T> for Option<T> {
+    fn chain_error<E: 'static, C>(self, callback: C) -> CargoResult<T>
+                         where E: CargoError, C: FnOnce() -> E {
+        match self {
+            Some(t) => Ok(t),
+            None => Err(Box::new(callback())),
+        }
+    }
+}
+
+impl<E: Error> Error for ChainedError<E> {
+    fn description(&self) -> &str { self.error.description() }
+}
+
+impl<E: fmt::Display> fmt::Display for ChainedError<E> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Display::fmt(&self.error, f)
+    }
+}
+
+impl<E: CargoError> CargoError for ChainedError<E> {
+    fn is_human(&self) -> bool { self.error.is_human() }
+    fn cargo_cause(&self) -> Option<&CargoError> { Some(&*self.cause) }
+}
+
+// =============================================================================
+// Human errors
+
+#[derive(Debug)]
+pub struct Human<E>(pub E);
+
+impl<E: Error> Error for Human<E> {
+    fn description(&self) -> &str { self.0.description() }
+    fn cause(&self) -> Option<&Error> { self.0.cause() }
+}
+
+impl<E: fmt::Display> fmt::Display for Human<E> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Display::fmt(&self.0, f)
+    }
+}
+
+impl<E: CargoError> CargoError for Human<E> {
+    fn is_human(&self) -> bool { true }
+    fn cargo_cause(&self) -> Option<&CargoError> { self.0.cargo_cause() }
+}
+
+impl<E: CargoError> From<Human<E>> for Box<CargoError> {
+    fn from(t: Human<E>) -> Box<CargoError> { Box::new(t) }
+}
+
+// =============================================================================
+// Concrete errors
+
+struct ConcreteCargoError {
+    description: String,
+    detail: Option<String>,
+    cause: Option<Box<Error+Send>>,
+    is_human: bool,
+}
+
+impl fmt::Display for ConcreteCargoError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        try!(write!(f, "{}", self.description));
+        if let Some(ref s) = self.detail {
+            try!(write!(f, " ({})", s));
+        }
+        Ok(())
+    }
+}
+impl fmt::Debug for ConcreteCargoError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Display::fmt(self, f)
+    }
+}
+
+impl Error for ConcreteCargoError {
+    fn description(&self) -> &str { &self.description }
+    fn cause(&self) -> Option<&Error> {
+        self.cause.as_ref().map(|c| {
+            let e: &Error = &**c; e
+        })
+    }
+}
+
+impl CargoError for ConcreteCargoError {
+    fn is_human(&self) -> bool {
+        self.is_human
+    }
+}
+
+// =============================================================================
+// Stuff
+
+#[macro_export]
+macro_rules! from_error {
+    ($($p:ty,)*) => (
+        $(impl From<$p> for Box<CargoError> {
+            fn from(t: $p) -> Box<CargoError> { Box::new(t) }
+        })*
+    )
+}
+
+pub fn internal_error(error: &str, detail: &str) -> Box<CargoError> {
+    Box::new(ConcreteCargoError {
+        description: error.to_string(),
+        detail: Some(detail.to_string()),
+        cause: None,
+        is_human: false
+    })
+}
+
+pub fn internal<S: fmt::Display>(error: S) -> Box<CargoError> {
+    Box::new(ConcreteCargoError {
+        description: error.to_string(),
+        detail: None,
+        cause: None,
+        is_human: false
+    })
+}
+
+pub fn human<S: fmt::Display>(error: S) -> Box<CargoError> {
+    Box::new(ConcreteCargoError {
+        description: error.to_string(),
+        detail: None,
+        cause: None,
+        is_human: true
+    })
+}
+
+pub fn caused_human<S, E>(error: S, cause: E) -> Box<CargoError>
+    where S: fmt::Display,
+          E: Error + Send + 'static
+{
+    Box::new(ConcreteCargoError {
+        description: error.to_string(),
+        detail: None,
+        cause: Some(Box::new(cause)),
+        is_human: true
+    })
+}

--- a/src/cargo/util/cargo_error.rs
+++ b/src/cargo/util/cargo_error.rs
@@ -227,8 +227,8 @@ pub fn caused_human<S, E>(error: S, cause: E) -> Box<CargoError>
     where S: fmt::Display,
           E: Error + Send + 'static
 {
-    human(Box::new(ChainedError {
-        error: error,
+    Box::new(HumanError(Box::new(ChainedError {
+        error: StringError(error.to_string()),
         cause: Box::new(ConcreteError(Box::new(cause)))
-    }))
+    })))
 }

--- a/src/cargo/util/cargo_error.rs
+++ b/src/cargo/util/cargo_error.rs
@@ -94,7 +94,7 @@ impl<E: CargoError> CargoError for ChainedError<E> {
 // Human errors
 
 #[derive(Debug)]
-pub struct Human<E>(E);
+struct Human<E>(E);
 
 impl<E: Error> Error for Human<E> {
     fn description(&self) -> &str { self.0.description() }
@@ -120,7 +120,7 @@ impl<E: CargoError> From<Human<E>> for Box<CargoError> {
 // Internal errors
 
 #[derive(Debug)]
-pub struct Internal<E>(E);
+struct Internal<E>(E);
 
 impl<E: Error> Error for Internal<E> {
     fn description(&self) -> &str { self.0.description() }

--- a/src/cargo/util/cargo_error.rs
+++ b/src/cargo/util/cargo_error.rs
@@ -121,7 +121,6 @@ impl<E: CargoError> From<Human<E>> for Box<CargoError> {
 
 struct ConcreteCargoError {
     description: String,
-    detail: Option<String>,
     cause: Option<Box<Error+Send>>,
     is_human: bool,
 }
@@ -129,9 +128,6 @@ struct ConcreteCargoError {
 impl fmt::Display for ConcreteCargoError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         try!(write!(f, "{}", self.description));
-        if let Some(ref s) = self.detail {
-            try!(write!(f, " ({})", s));
-        }
         Ok(())
     }
 }
@@ -171,7 +167,6 @@ macro_rules! from_error {
 pub fn internal<S: fmt::Display>(error: S) -> Box<CargoError> {
     Box::new(ConcreteCargoError {
         description: error.to_string(),
-        detail: None,
         cause: None,
         is_human: false
     })
@@ -180,7 +175,6 @@ pub fn internal<S: fmt::Display>(error: S) -> Box<CargoError> {
 pub fn human<S: fmt::Display>(error: S) -> Box<CargoError> {
     Box::new(ConcreteCargoError {
         description: error.to_string(),
-        detail: None,
         cause: None,
         is_human: true
     })
@@ -192,7 +186,6 @@ pub fn caused_human<S, E>(error: S, cause: E) -> Box<CargoError>
 {
     Box::new(ConcreteCargoError {
         description: error.to_string(),
-        detail: None,
         cause: Some(Box::new(cause)),
         is_human: true
     })

--- a/src/cargo/util/cargo_error.rs
+++ b/src/cargo/util/cargo_error.rs
@@ -94,7 +94,7 @@ impl<E: CargoError> CargoError for ChainedError<E> {
 // Human errors
 
 #[derive(Debug)]
-pub struct Human<E>(pub E);
+pub struct Human<E>(E);
 
 impl<E: Error> Error for Human<E> {
     fn description(&self) -> &str { self.0.description() }

--- a/src/cargo/util/cargo_error.rs
+++ b/src/cargo/util/cargo_error.rs
@@ -168,15 +168,6 @@ macro_rules! from_error {
     )
 }
 
-pub fn internal_error(error: &str, detail: &str) -> Box<CargoError> {
-    Box::new(ConcreteCargoError {
-        description: error.to_string(),
-        detail: Some(detail.to_string()),
-        cause: None,
-        is_human: false
-    })
-}
-
 pub fn internal<S: fmt::Display>(error: S) -> Box<CargoError> {
     Box::new(ConcreteCargoError {
         description: error.to_string(),

--- a/src/cargo/util/cargo_error.rs
+++ b/src/cargo/util/cargo_error.rs
@@ -91,55 +91,55 @@ impl<E: CargoError> CargoError for ChainedError<E> {
 }
 
 // =============================================================================
-// Human errors
+// HumanError errors
 
 #[derive(Debug)]
-struct Human<E>(E);
+struct HumanError<E>(E);
 
-impl<E: Error> Error for Human<E> {
+impl<E: Error> Error for HumanError<E> {
     fn description(&self) -> &str { self.0.description() }
     fn cause(&self) -> Option<&Error> { self.0.cause() }
 }
 
-impl<E: fmt::Display> fmt::Display for Human<E> {
+impl<E: fmt::Display> fmt::Display for HumanError<E> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::Display::fmt(&self.0, f)
     }
 }
 
-impl<E: CargoError> CargoError for Human<E> {
+impl<E: CargoError> CargoError for HumanError<E> {
     fn is_human(&self) -> bool { true }
     fn cargo_cause(&self) -> Option<&CargoError> { self.0.cargo_cause() }
 }
 
-impl<E: CargoError> From<Human<E>> for Box<CargoError> {
-    fn from(t: Human<E>) -> Box<CargoError> { Box::new(t) }
+impl<E: CargoError> From<HumanError<E>> for Box<CargoError> {
+    fn from(t: HumanError<E>) -> Box<CargoError> { Box::new(t) }
 }
 
 // =============================================================================
-// Internal errors
+// InternalError errors
 
 #[derive(Debug)]
-struct Internal<E>(E);
+struct InternalError<E>(E);
 
-impl<E: Error> Error for Internal<E> {
+impl<E: Error> Error for InternalError<E> {
     fn description(&self) -> &str { self.0.description() }
     fn cause(&self) -> Option<&Error> { self.0.cause() }
 }
 
-impl<E: fmt::Display> fmt::Display for Internal<E> {
+impl<E: fmt::Display> fmt::Display for InternalError<E> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::Display::fmt(&self.0, f)
     }
 }
 
-impl<E: CargoError> CargoError for Internal<E> {
+impl<E: CargoError> CargoError for InternalError<E> {
     fn is_human(&self) -> bool { false }
     fn cargo_cause(&self) -> Option<&CargoError> { self.0.cargo_cause() }
 }
 
-impl<E: CargoError> From<Internal<E>> for Box<CargoError> {
-    fn from(t: Internal<E>) -> Box<CargoError> { Box::new(t) }
+impl<E: CargoError> From<InternalError<E>> for Box<CargoError> {
+    fn from(t: InternalError<E>) -> Box<CargoError> { Box::new(t) }
 }
 
 // =============================================================================
@@ -214,7 +214,7 @@ macro_rules! from_error {
 }
 
 pub fn internal<S: fmt::Display>(error: S) -> Box<CargoError> {
-    Box::new(Internal(StringError(error.to_string())))
+    Box::new(InternalError(StringError(error.to_string())))
 }
 
 pub fn caused_internal<S, E>(error: S, cause: E) -> Box<CargoError>
@@ -231,7 +231,7 @@ pub fn caused_internal<S, E>(error: S, cause: E) -> Box<CargoError>
 }
 
 pub fn human<S: fmt::Display>(error: S) -> Box<CargoError> {
-    Box::new(Human(StringError(error.to_string())))
+    Box::new(HumanError(StringError(error.to_string())))
 }
 
 pub fn caused_human<S, E>(error: S, cause: E) -> Box<CargoError>

--- a/src/cargo/util/cargo_error.rs
+++ b/src/cargo/util/cargo_error.rs
@@ -148,7 +148,6 @@ impl<E: CargoError> From<Internal<E>> for Box<CargoError> {
 struct ConcreteCargoError {
     description: String,
     cause: Option<Box<Error+Send>>,
-    is_human: bool,
 }
 
 impl fmt::Display for ConcreteCargoError {
@@ -173,9 +172,7 @@ impl Error for ConcreteCargoError {
 }
 
 impl CargoError for ConcreteCargoError {
-    fn is_human(&self) -> bool {
-        self.is_human
-    }
+    fn is_human(&self) -> bool { false }
 }
 
 // =============================================================================
@@ -229,7 +226,6 @@ pub fn caused_internal<S, E>(error: S, cause: E) -> Box<CargoError>
         cause: Box::new(ConcreteCargoError {
             description: cause.description().to_string(),
             cause: Some(Box::new(cause)),
-            is_human: false,
         })
     })
 }
@@ -242,12 +238,11 @@ pub fn caused_human<S, E>(error: S, cause: E) -> Box<CargoError>
     where S: fmt::Display,
           E: Error + Send + 'static
 {
-    Box::new(ChainedError {
-        error: human(error),
+    human(Box::new(ChainedError {
+        error: error,
         cause: Box::new(ConcreteCargoError {
             description: cause.description().to_string(),
             cause: Some(Box::new(cause)),
-            is_human: false,
         })
-    })
+    }))
 }

--- a/src/cargo/util/cargo_error.rs
+++ b/src/cargo/util/cargo_error.rs
@@ -94,52 +94,52 @@ impl<E: CargoError> CargoError for ChainedError<E> {
 // HumanError errors
 
 #[derive(Debug)]
-struct HumanError<E>(E);
+struct HumanError(Box<CargoError>);
 
-impl<E: Error> Error for HumanError<E> {
+impl Error for HumanError {
     fn description(&self) -> &str { self.0.description() }
     fn cause(&self) -> Option<&Error> { self.0.cause() }
 }
 
-impl<E: fmt::Display> fmt::Display for HumanError<E> {
+impl fmt::Display for HumanError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::Display::fmt(&self.0, f)
     }
 }
 
-impl<E: CargoError> CargoError for HumanError<E> {
+impl CargoError for HumanError {
     fn is_human(&self) -> bool { true }
     fn cargo_cause(&self) -> Option<&CargoError> { self.0.cargo_cause() }
 }
 
-impl<E: CargoError> From<HumanError<E>> for Box<CargoError> {
-    fn from(t: HumanError<E>) -> Box<CargoError> { Box::new(t) }
+impl From<HumanError> for Box<CargoError> {
+    fn from(t: HumanError) -> Box<CargoError> { Box::new(t) }
 }
 
 // =============================================================================
 // InternalError errors
 
 #[derive(Debug)]
-struct InternalError<E>(E);
+struct InternalError(Box<CargoError>);
 
-impl<E: Error> Error for InternalError<E> {
+impl Error for InternalError {
     fn description(&self) -> &str { self.0.description() }
     fn cause(&self) -> Option<&Error> { self.0.cause() }
 }
 
-impl<E: fmt::Display> fmt::Display for InternalError<E> {
+impl fmt::Display for InternalError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::Display::fmt(&self.0, f)
     }
 }
 
-impl<E: CargoError> CargoError for InternalError<E> {
+impl CargoError for InternalError {
     fn is_human(&self) -> bool { false }
     fn cargo_cause(&self) -> Option<&CargoError> { self.0.cargo_cause() }
 }
 
-impl<E: CargoError> From<InternalError<E>> for Box<CargoError> {
-    fn from(t: InternalError<E>) -> Box<CargoError> { Box::new(t) }
+impl From<InternalError> for Box<CargoError> {
+    fn from(t: InternalError) -> Box<CargoError> { Box::new(t) }
 }
 
 // =============================================================================
@@ -214,7 +214,7 @@ macro_rules! from_error {
 }
 
 pub fn internal<S: fmt::Display>(error: S) -> Box<CargoError> {
-    Box::new(InternalError(StringError(error.to_string())))
+    Box::new(InternalError(Box::new(StringError(error.to_string()))))
 }
 
 pub fn caused_internal<S, E>(error: S, cause: E) -> Box<CargoError>
@@ -231,7 +231,7 @@ pub fn caused_internal<S, E>(error: S, cause: E) -> Box<CargoError>
 }
 
 pub fn human<S: fmt::Display>(error: S) -> Box<CargoError> {
-    Box::new(HumanError(StringError(error.to_string())))
+    Box::new(HumanError(Box::new(StringError(error.to_string()))))
 }
 
 pub fn caused_human<S, E>(error: S, cause: E) -> Box<CargoError>

--- a/src/cargo/util/cargo_error.rs
+++ b/src/cargo/util/cargo_error.rs
@@ -145,25 +145,25 @@ impl From<InternalError> for Box<CargoError> {
 // =============================================================================
 // Concrete errors
 
-struct ConcreteCargoError(Box<Error+Send>);
+struct ConcreteError(Box<Error+Send>);
 
-impl fmt::Display for ConcreteCargoError {
+impl fmt::Display for ConcreteError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.0.fmt(f)
     }
 }
-impl fmt::Debug for ConcreteCargoError {
+impl fmt::Debug for ConcreteError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.0.fmt(f)
     }
 }
 
-impl Error for ConcreteCargoError {
+impl Error for ConcreteError {
     fn description(&self) -> &str { &self.0.description() }
     fn cause(&self) -> Option<&Error> { Some(&*self.0) }
 }
 
-impl CargoError for ConcreteCargoError {
+impl CargoError for ConcreteError {
     fn is_human(&self) -> bool { false }
 }
 
@@ -215,7 +215,7 @@ pub fn caused_internal<S, E>(error: S, cause: E) -> Box<CargoError>
 {
     Box::new(ChainedError {
         error: internal(error),
-        cause: Box::new(ConcreteCargoError(Box::new(cause)))
+        cause: Box::new(ConcreteError(Box::new(cause)))
     })
 }
 
@@ -229,6 +229,6 @@ pub fn caused_human<S, E>(error: S, cause: E) -> Box<CargoError>
 {
     human(Box::new(ChainedError {
         error: error,
-        cause: Box::new(ConcreteCargoError(Box::new(cause)))
+        cause: Box::new(ConcreteError(Box::new(cause)))
     }))
 }

--- a/src/cargo/util/errors.rs
+++ b/src/cargo/util/errors.rs
@@ -15,93 +15,7 @@ use term;
 use toml;
 use url;
 
-pub type CargoResult<T> = Result<T, Box<CargoError>>;
-
-// =============================================================================
-// CargoError trait
-
-pub trait CargoError: Error + Send + 'static {
-    fn is_human(&self) -> bool { false }
-    fn cargo_cause(&self) -> Option<&CargoError>{ None }
-}
-
-impl Error for Box<CargoError> {
-    fn description(&self) -> &str { (**self).description() }
-    fn cause(&self) -> Option<&Error> { (**self).cause() }
-}
-
-impl CargoError for Box<CargoError> {
-    fn is_human(&self) -> bool { (**self).is_human() }
-    fn cargo_cause(&self) -> Option<&CargoError> { (**self).cargo_cause() }
-}
-
-// =============================================================================
-// Chaining errors
-
-pub trait ChainError<T> {
-    fn chain_error<E, F>(self, callback: F) -> CargoResult<T>
-                         where E: CargoError, F: FnOnce() -> E;
-}
-
-#[derive(Debug)]
-struct ChainedError<E> {
-    error: E,
-    cause: Box<CargoError>,
-}
-
-impl<'a, T, F> ChainError<T> for F where F: FnOnce() -> CargoResult<T> {
-    fn chain_error<E, C>(self, callback: C) -> CargoResult<T>
-                         where E: CargoError, C: FnOnce() -> E {
-        self().chain_error(callback)
-    }
-}
-
-impl<T, E: CargoError + 'static> ChainError<T> for Result<T, E> {
-    fn chain_error<E2: 'static, C>(self, callback: C) -> CargoResult<T>
-                         where E2: CargoError, C: FnOnce() -> E2 {
-        self.map_err(move |err| {
-            Box::new(ChainedError {
-                error: callback(),
-                cause: Box::new(err),
-            }) as Box<CargoError>
-        })
-    }
-}
-
-impl<T> ChainError<T> for Box<CargoError> {
-    fn chain_error<E2, C>(self, callback: C) -> CargoResult<T>
-                         where E2: CargoError, C: FnOnce() -> E2 {
-        Err(Box::new(ChainedError {
-            error: callback(),
-            cause: self,
-        }))
-    }
-}
-
-impl<T> ChainError<T> for Option<T> {
-    fn chain_error<E: 'static, C>(self, callback: C) -> CargoResult<T>
-                         where E: CargoError, C: FnOnce() -> E {
-        match self {
-            Some(t) => Ok(t),
-            None => Err(Box::new(callback())),
-        }
-    }
-}
-
-impl<E: Error> Error for ChainedError<E> {
-    fn description(&self) -> &str { self.error.description() }
-}
-
-impl<E: fmt::Display> fmt::Display for ChainedError<E> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::Display::fmt(&self.error, f)
-    }
-}
-
-impl<E: CargoError> CargoError for ChainedError<E> {
-    fn is_human(&self) -> bool { self.error.is_human() }
-    fn cargo_cause(&self) -> Option<&CargoError> { Some(&*self.cause) }
-}
+pub use super::cargo_error::*;
 
 // =============================================================================
 // Process errors
@@ -176,69 +90,6 @@ impl Error for CargoTestError {
     }
 }
 
-
-// =============================================================================
-// Concrete errors
-
-struct ConcreteCargoError {
-    description: String,
-    detail: Option<String>,
-    cause: Option<Box<Error+Send>>,
-    is_human: bool,
-}
-
-impl fmt::Display for ConcreteCargoError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        try!(write!(f, "{}", self.description));
-        if let Some(ref s) = self.detail {
-            try!(write!(f, " ({})", s));
-        }
-        Ok(())
-    }
-}
-impl fmt::Debug for ConcreteCargoError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::Display::fmt(self, f)
-    }
-}
-
-impl Error for ConcreteCargoError {
-    fn description(&self) -> &str { &self.description }
-    fn cause(&self) -> Option<&Error> {
-        self.cause.as_ref().map(|c| {
-            let e: &Error = &**c; e
-        })
-    }
-}
-
-impl CargoError for ConcreteCargoError {
-    fn is_human(&self) -> bool {
-        self.is_human
-    }
-}
-
-// =============================================================================
-// Human errors
-
-#[derive(Debug)]
-pub struct Human<E>(pub E);
-
-impl<E: Error> Error for Human<E> {
-    fn description(&self) -> &str { self.0.description() }
-    fn cause(&self) -> Option<&Error> { self.0.cause() }
-}
-
-impl<E: fmt::Display> fmt::Display for Human<E> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::Display::fmt(&self.0, f)
-    }
-}
-
-impl<E: CargoError> CargoError for Human<E> {
-    fn is_human(&self) -> bool { true }
-    fn cargo_cause(&self) -> Option<&CargoError> { self.0.cargo_cause() }
-}
-
 // =============================================================================
 // CLI errors
 
@@ -288,14 +139,6 @@ impl From<Box<CargoError>> for CliError {
 // =============================================================================
 // various impls
 
-macro_rules! from_error {
-    ($($p:ty,)*) => (
-        $(impl From<$p> for Box<CargoError> {
-            fn from(t: $p) -> Box<CargoError> { Box::new(t) }
-        })*
-    )
-}
-
 from_error! {
     semver::ReqParseError,
     io::Error,
@@ -318,10 +161,6 @@ impl From<string::ParseError> for Box<CargoError> {
     fn from(t: string::ParseError) -> Box<CargoError> {
         match t {}
     }
-}
-
-impl<E: CargoError> From<Human<E>> for Box<CargoError> {
-    fn from(t: Human<E>) -> Box<CargoError> { Box::new(t) }
 }
 
 impl CargoError for semver::ReqParseError {}
@@ -413,41 +252,3 @@ pub fn process_error(msg: &str,
     }
 }
 
-pub fn internal_error(error: &str, detail: &str) -> Box<CargoError> {
-    Box::new(ConcreteCargoError {
-        description: error.to_string(),
-        detail: Some(detail.to_string()),
-        cause: None,
-        is_human: false
-    })
-}
-
-pub fn internal<S: fmt::Display>(error: S) -> Box<CargoError> {
-    Box::new(ConcreteCargoError {
-        description: error.to_string(),
-        detail: None,
-        cause: None,
-        is_human: false
-    })
-}
-
-pub fn human<S: fmt::Display>(error: S) -> Box<CargoError> {
-    Box::new(ConcreteCargoError {
-        description: error.to_string(),
-        detail: None,
-        cause: None,
-        is_human: true
-    })
-}
-
-pub fn caused_human<S, E>(error: S, cause: E) -> Box<CargoError>
-    where S: fmt::Display,
-          E: Error + Send + 'static
-{
-    Box::new(ConcreteCargoError {
-        description: error.to_string(),
-        detail: None,
-        cause: Some(Box::new(cause)),
-        is_human: true
-    })
-}

--- a/src/cargo/util/mod.rs
+++ b/src/cargo/util/mod.rs
@@ -3,7 +3,7 @@ pub use self::config::Config;
 pub use self::dependency_queue::{DependencyQueue, Fresh, Dirty, Freshness};
 pub use self::errors::{CargoResult, CargoError, ChainError, CliResult};
 pub use self::errors::{CliError, ProcessError, CargoTestError};
-pub use self::errors::{Human, caused_human};
+pub use self::errors::{caused_human};
 pub use self::errors::{process_error, internal, human};
 pub use self::flock::{FileLock, Filesystem};
 pub use self::graph::Graph;

--- a/src/cargo/util/mod.rs
+++ b/src/cargo/util/mod.rs
@@ -20,6 +20,8 @@ pub use self::to_url::ToUrl;
 pub use self::vcs::{GitRepo, HgRepo};
 
 pub mod config;
+#[macro_use]
+mod cargo_error;
 pub mod errors;
 pub mod graph;
 pub mod hex;

--- a/src/cargo/util/mod.rs
+++ b/src/cargo/util/mod.rs
@@ -4,7 +4,7 @@ pub use self::dependency_queue::{DependencyQueue, Fresh, Dirty, Freshness};
 pub use self::errors::{CargoResult, CargoError, ChainError, CliResult};
 pub use self::errors::{CliError, ProcessError, CargoTestError};
 pub use self::errors::{Human, caused_human};
-pub use self::errors::{process_error, internal_error, internal, human};
+pub use self::errors::{process_error, internal, human};
 pub use self::flock::{FileLock, Filesystem};
 pub use self::graph::Graph;
 pub use self::hex::{to_hex, short_hash, hash_u64};


### PR DESCRIPTION
Well, this ultimately accomplishes very little, but I thought I'd post it and see what you think. It's basically just cleanup. The `Human` type and `human` function are unified into one concept, with the `human` function returning a boxed `Human`. Other than that there aren't any API changes.

I started doing this with the intent of extracting it to its own crate, but due to coherence problems I don't see a way to do it ergonomically. Losing all the `From` conversions to `Box<CargoError>` generates 145 errors, and adding explicit conversions every time you cross the "error boundary" is not something I want to do.

I'm not sure if my failure to extract this module indicates that passing `Box<AnythingOtherThanStdError>` is not a viable cross-crate error handling strategy, or if there are other formulations that can make it work comfortably.

This leaves a `cargo_error` module along side the `errors` module, but if you actually want this patch I can merge them back together.