### PR TITLE
Don't consider $HOME when finding the home dir on Windows

### DIFF
--- a/src/cargo/util/config.rs
+++ b/src/cargo/util/config.rs
@@ -600,8 +600,99 @@ fn homedir(cwd: &Path) -> Option<PathBuf> {
     let cargo_home = env::var_os("CARGO_HOME").map(|home| {
         cwd.join(home)
     });
-    let user_home = env::home_dir().map(|p| p.join(".cargo"));
+    let user_home = os_home_dir().map(|p| p.join(".cargo"));
     cargo_home.or(user_home)
+}
+
+// On windows, unlike std, cargo does *not* consider the
+// HOME variable. If it did then the install dir would change
+// depending on whether you happened to install under msys.
+#[cfg(windows)]
+pub fn os_home_dir() -> Option<PathBuf> {
+    use std::ptr;
+    use kernel32::{GetCurrentProcess, GetLastError, CloseHandle};
+    use advapi32::OpenProcessToken;
+    use userenv::GetUserProfileDirectoryW;
+    use winapi::ERROR_INSUFFICIENT_BUFFER;
+    use winapi::winnt::TOKEN_READ;
+    use scopeguard;
+
+    ::std::env::var_os("USERPROFILE").map(PathBuf::from).or_else(|| unsafe {
+        let me = GetCurrentProcess();
+        let mut token = ptr::null_mut();
+        if OpenProcessToken(me, TOKEN_READ, &mut token) == 0 {
+            return None
+        }
+        let _g = scopeguard::guard(token, |h| { let _ = CloseHandle(*h); });
+        fill_utf16_buf(|buf, mut sz| {
+            match GetUserProfileDirectoryW(token, buf, &mut sz) {
+                0 if GetLastError() != ERROR_INSUFFICIENT_BUFFER => 0,
+                0 => sz,
+                _ => sz - 1, // sz includes the null terminator
+            }
+        }, os2path).ok()
+    })
+}
+
+#[cfg(windows)]
+fn os2path(s: &[u16]) -> PathBuf {
+    use std::os::windows::ffi::OsStringExt;
+    PathBuf::from(OsString::from_wide(s))
+}
+
+#[cfg(windows)]
+fn fill_utf16_buf<F1, F2, T>(mut f1: F1, f2: F2) -> io::Result<T>
+    where F1: FnMut(*mut u16, DWORD) -> DWORD,
+          F2: FnOnce(&[u16]) -> T
+{
+    use kernel32::{GetLastError, SetLastError};
+    use winapi::{ERROR_INSUFFICIENT_BUFFER};
+
+    // Start off with a stack buf but then spill over to the heap if we end up
+    // needing more space.
+    let mut stack_buf = [0u16; 512];
+    let mut heap_buf = Vec::new();
+    unsafe {
+        let mut n = stack_buf.len();
+        loop {
+            let buf = if n <= stack_buf.len() {
+                &mut stack_buf[..]
+            } else {
+                let extra = n - heap_buf.len();
+                heap_buf.reserve(extra);
+                heap_buf.set_len(n);
+                &mut heap_buf[..]
+            };
+
+            // This function is typically called on windows API functions which
+            // will return the correct length of the string, but these functions
+            // also return the `0` on error. In some cases, however, the
+            // returned "correct length" may actually be 0!
+            //
+            // To handle this case we call `SetLastError` to reset it to 0 and
+            // then check it again if we get the "0 error value". If the "last
+            // error" is still 0 then we interpret it as a 0 length buffer and
+            // not an actual error.
+            SetLastError(0);
+            let k = match f1(buf.as_mut_ptr(), n as DWORD) {
+                0 if GetLastError() == 0 => 0,
+                0 => return Err(io::Error::last_os_error()),
+                n => n,
+            } as usize;
+            if k == n && GetLastError() == ERROR_INSUFFICIENT_BUFFER {
+                n *= 2;
+            } else if k >= n {
+                n = k;
+            } else {
+                return Ok(f2(&buf[..k]))
+            }
+        }
+    }
+}
+
+#[cfg(unix)]
+pub fn os_home_dir() -> Option<PathBuf> {
+    ::std::env::home_dir()
 }
 
 fn walk_tree<F>(pwd: &Path, mut walk: F) -> CargoResult<()>


### PR DESCRIPTION
Same as rustup. HOME is not a windows thing so allowing it
to control the cargo directory means that the directory can
change depending on whether you are working under mingw or not.

This change makes Cargo always use the windows AppData path.

This is a breaking change but if anybody is actually impacted
Cargo should just silently start using a different directory. There
may be surprises related to `cargo install`.

Users of rustup and multirust won't be affected because both
override CARGO_HOME.