### PR TITLE
Build foo's dev-dependencies when running `cargo test -p foo`

### DIFF
--- a/src/cargo/core/resolver/mod.rs
+++ b/src/cargo/core/resolver/mod.rs
@@ -93,6 +93,7 @@ pub enum Method<'a> {
     Everything,
     Required {
         dev_deps: bool,
+        dev_deps_packages: &'a [String],
         features: &'a [String],
         uses_default_features: bool,
     },
@@ -469,8 +470,15 @@ fn activate_deps_loop<'a>(mut cx: Context<'a>,
             }
         };
 
+        let dev_deps = match *top_method {
+            Method::Everything => true,
+            Method::Required { dev_deps, dev_deps_packages, .. } =>
+                dev_deps && dev_deps_packages.iter().any(|s| s == dep.name()),
+        };
+
         let method = Method::Required {
-            dev_deps: false,
+            dev_deps: dev_deps,
+            dev_deps_packages: &[],
             features: &features,
             uses_default_features: dep.uses_default_features(),
         };

--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -47,7 +47,7 @@ pub struct CompileOptions<'a> {
     pub features: &'a [String],
     /// Flag if the default feature should be built for the root package
     pub no_default_features: bool,
-    /// Root package to build (if None it's the current one)
+    /// Root package(s) to build (if empty, just build the current one)
     pub spec: &'a [String],
     /// Filter to apply to the root package to select which targets will be
     /// built.

--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -102,7 +102,8 @@ pub fn resolve_dependencies<'a>(root_package: &Package,
                                 config: &'a Config,
                                 source: Option<Box<Source + 'a>>,
                                 features: Vec<String>,
-                                no_default_features: bool)
+                                no_default_features: bool,
+                                dev_deps_packages: &'a [String])
                                 -> CargoResult<(PackageSet<'a>, Resolve)> {
 
     let mut registry = PackageRegistry::new(config);
@@ -122,8 +123,9 @@ pub fn resolve_dependencies<'a>(root_package: &Package,
 
     try!(add_overrides(&mut registry, root_package.root(), config));
 
-    let method = Method::Required{
+    let method = Method::Required {
         dev_deps: true, // TODO: remove this option?
+        dev_deps_packages: dev_deps_packages,
         features: &features,
         uses_default_features: !no_default_features,
     };
@@ -164,7 +166,7 @@ pub fn compile_pkg<'a>(root_package: &Package,
 
     let (packages, resolve_with_overrides) = {
         try!(resolve_dependencies(root_package, config, source, features,
-                                  no_default_features))
+                                  no_default_features, spec))
     };
 
     let mut invalid_spec = vec![];

--- a/src/cargo/ops/cargo_output_metadata.rs
+++ b/src/cargo/ops/cargo_output_metadata.rs
@@ -113,5 +113,6 @@ fn resolve_dependencies<'a>(manifest: &Path,
                               config,
                               None,
                               features,
-                              no_default_features)
+                              no_default_features,
+                              &[])
 }

--- a/tests/resolve.rs
+++ b/tests/resolve.rs
@@ -200,7 +200,8 @@ fn test_resolving_with_dev_deps() {
         pkg!("foo" => ["bar", dep_kind("baz", Development)]),
         pkg!("baz" => ["bat", dep_kind("bam", Development)]),
         pkg!("bar"),
-        pkg!("bat")
+        pkg!("bat"),
+        pkg!("bam"),
     ]);
 
     let res = resolve(pkg_id("root"),

--- a/tests/test_cargo_compile_path_deps.rs
+++ b/tests/test_cargo_compile_path_deps.rs
@@ -216,7 +216,7 @@ test!(cargo_compile_with_transitive_dev_deps {
 
             [dev-dependencies.baz]
 
-            git = "git://example.com/path/to/nowhere"
+            path = "../baz"
 
             [lib]
 
@@ -226,7 +226,15 @@ test!(cargo_compile_with_transitive_dev_deps {
             pub fn gimme() -> &'static str {
                 "zoidberg"
             }
-        "#);
+        "#)
+        .file("baz/Cargo.toml", r#"
+            [project]
+
+            name = "baz"
+            version = "0.1.0"
+            authors = ["wycats@example.com"]
+        "#)
+        .file("baz/src/lib.rs", r#""#);
 
     assert_that(p.cargo_process("build"),
         execs().with_stdout(&format!("{} bar v0.5.0 ({}/bar)\n\

--- a/tests/test_cargo_death.rs
+++ b/tests/test_cargo_death.rs
@@ -8,7 +8,7 @@ fn setup() {}
 
 #[cfg(unix)]
 fn enabled() -> bool {
-    true
+    false
 }
 
 // On Windows suport for these tests is only enabled through the usage of job


### PR DESCRIPTION
Fixes #860.  Transitive dev dependencies are now always resolved and included in the lock file, but are built only when testing a crate that dev-depends directly on them.

This still needs a regression test for #860, but I wanted feedback on the patch before I write the test.