### PR TITLE
deny warnings only when compiling for tests

### DIFF
--- a/src/cargo/lib.rs
+++ b/src/cargo/lib.rs
@@ -1,4 +1,4 @@
-#![deny(unused)]
+#![cfg_attr(test, deny(unused))]
 #![cfg_attr(test, deny(warnings))]
 
 #[cfg(test)] extern crate hamcrest;

--- a/tests/resolve.rs
+++ b/tests/resolve.rs
@@ -1,4 +1,4 @@
-#![deny(warnings)]
+#![cfg_attr(test, deny(warnings))]
 
 extern crate hamcrest;
 extern crate cargo;

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,4 +1,4 @@
-#![deny(warnings)]
+#![cfg_attr(test, deny(warnings))]
 
 extern crate bufstream;
 extern crate cargo;


### PR DESCRIPTION
deny warnings only when compiling for tests

This makes cargo forward-compatible with lint changes upstream in rust.

This relates to rust-lang/rust/pull/33091. This PR makes cargo never stop compiling from denied lints, but tests may still fail. This allows using `cap-lints warn` sensibly in rust's cargotest, since we know it will not break cargo itself.