### PR TITLE
Add "extension-css" option

### DIFF
--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -21,6 +21,7 @@ pub struct Manifest {
     profiles: Profiles,
     publish: bool,
     replace: Vec<(PackageIdSpec, Dependency)>,
+    css_extension: Option<String>,
 }
 
 /// General metadata about a package which is just blindly uploaded to the
@@ -166,7 +167,8 @@ impl Manifest {
                metadata: ManifestMetadata,
                profiles: Profiles,
                publish: bool,
-               replace: Vec<(PackageIdSpec, Dependency)>) -> Manifest {
+               replace: Vec<(PackageIdSpec, Dependency)>,
+               css_extension: Option<String>) -> Manifest {
         Manifest {
             summary: summary,
             targets: targets,
@@ -178,6 +180,7 @@ impl Manifest {
             profiles: profiles,
             publish: publish,
             replace: replace,
+            css_extension: css_extension,
         }
     }
 
@@ -196,6 +199,9 @@ impl Manifest {
     pub fn replace(&self) -> &[(PackageIdSpec, Dependency)] { &self.replace }
     pub fn links(&self) -> Option<&str> {
         self.links.as_ref().map(|s| &s[..])
+    }
+    pub fn css_extension(&self) -> Option<&str> {
+        self.css_extension.as_ref().map(|s| &s[..])
     }
 
     pub fn add_warning(&mut self, s: String) {

--- a/src/cargo/ops/cargo_rustc/mod.rs
+++ b/src/cargo/ops/cargo_rustc/mod.rs
@@ -379,6 +379,12 @@ fn rustdoc(cx: &mut Context, unit: &Unit) -> CargoResult<Work> {
         rustdoc.arg("--target").arg(target);
     }
 
+    if let Some(css_extension) = unit.pkg.manifest().css_extension() {
+        // We need to activate nightly option to make this option available
+        rustdoc.arg("-Z").arg("unstable-options");
+        rustdoc.arg("--extend-css").arg(css_extension);
+    }
+
     let doc_dir = cx.out_dir(unit);
 
     // Create the documentation directory ahead of time as rustdoc currently has

--- a/src/cargo/util/toml.rs
+++ b/src/cargo/util/toml.rs
@@ -250,6 +250,7 @@ pub struct TomlProject {
     exclude: Option<Vec<String>>,
     include: Option<Vec<String>>,
     publish: Option<bool>,
+    css_extension: Option<String>,
 
     // package metadata
     description: Option<String>,
@@ -584,6 +585,7 @@ impl TomlManifest {
 
         let exclude = project.exclude.clone().unwrap_or(Vec::new());
         let include = project.include.clone().unwrap_or(Vec::new());
+        let css_extension = project.css_extension.clone();
 
         let summary = try!(Summary::new(pkgid, deps,
                                         self.features.clone()
@@ -609,7 +611,8 @@ impl TomlManifest {
                                          metadata,
                                          profiles,
                                          publish,
-                                         replace);
+                                         replace,
+                                         css_extension);
         if project.license_file.is_some() && project.license.is_some() {
             manifest.add_warning(format!("only one of `license` or \
                                           `license-file` is necessary"));


### PR DESCRIPTION
It is the continuation of the merged [extend-css](https://github.com/rust-lang/rust/pull/32230) into rustdoc.