### PR TITLE
Slightly improve error messages

### DIFF
--- a/src/cargo/ops/cargo_doc.rs
+++ b/src/cargo/ops/cargo_doc.rs
@@ -61,11 +61,11 @@ pub fn doc(manifest_path: &Path,
             match open_docs(&path) {
                 Ok(m) => try!(shell.status("Launching", m)),
                 Err(e) => {
-                    try!(shell.warn(
-                            "warning: could not determine a browser to open docs with, tried:"));
-                    for method in e {
-                        try!(shell.warn(format!("\t{}", method)));
-                    }
+                    let message = format!(
+                        "could not determine a browser to open docs with, tried:{}",
+                        e.into_iter().map(|method| format!("\n\t{}", method)).collect::<String>()
+                    );
+                    try!(shell.warn(message));
                 }
             }
         }

--- a/src/cargo/ops/cargo_rustc/job_queue.rs
+++ b/src/cargo/ops/cargo_rustc/job_queue.rs
@@ -4,7 +4,6 @@ use std::fmt;
 use std::sync::mpsc::{channel, Sender, Receiver};
 
 use crossbeam::{self, Scope};
-use term::color::YELLOW;
 
 use core::{PackageId, Target, Profile};
 use util::{Config, DependencyQueue, Fresh, Dirty, Freshness};
@@ -147,9 +146,8 @@ impl<'a> JobQueue<'a> {
                 }
                 Err(e) => {
                     if self.active > 0 {
-                        try!(config.shell().say(
-                                    "Build failed, waiting for other \
-                                     jobs to finish...", YELLOW));
+                        try!(config.shell().error(
+                                "build failed, waiting for other jobs to finish..."));
                         for _ in self.rx.iter().take(self.active as usize) {}
                     }
                     return Err(e)


### PR DESCRIPTION
* print "build failed" error to stderr (have not executed that line, but it should work :) )
* don't print "warning: warning:". Now the error looks like this:

```
warning: could not determine a browser to open docs with, tried:
        xdg-open
        gnome-open
        kde-open
```