### PR TITLE
Build and test examples when invoking `cargo test`

### DIFF
--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -324,9 +324,13 @@ fn generate_targets<'a>(pkg: &'a Package,
                 CompileMode::Test => {
                     let mut base = pkg.targets().iter().filter(|t| {
                         t.tested()
-                    }).map(|t| {
-                        (t, if t.is_example() {build} else {profile})
-                    }).collect::<Vec<_>>();
+                    }).map(|t| (t, profile)).collect::<Vec<_>>();
+
+                    for example in pkg.targets().iter().filter(|t| t.is_example()) {
+                        // Always build the examples even when they are being tested
+                        // so that code inside `main` which has errors will be caught.
+                        base.push((example, build));
+                    }
 
                     // Always compile the library if we're testing everything as
                     // it'll be needed for doctests
@@ -384,6 +388,7 @@ fn generate_targets<'a>(pkg: &'a Package,
                     }
                     Ok(())
                 };
+
                 try!(find(bins, "bin", TargetKind::Bin, profile));
                 try!(find(examples, "example", TargetKind::Example, build));
                 try!(find(tests, "test", TargetKind::Test, test));

--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -392,7 +392,7 @@ fn generate_targets<'a>(pkg: &'a Package,
                 };
 
                 try!(find(bins, "bin", TargetKind::Bin, profile));
-                try!(find(examples, "example", TargetKind::Example, build));
+                try!(find(examples, "example", TargetKind::Example, profile));
                 try!(find(tests, "test", TargetKind::Test, test));
                 try!(find(benches, "bench", TargetKind::Bench, &profiles.bench));
             }

--- a/src/cargo/ops/cargo_rustc/context.rs
+++ b/src/cargo/ops/cargo_rustc/context.rs
@@ -272,12 +272,17 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
                 m.mix(&"test");
                 m
             })
-        } else if unit.target.is_bin() && unit.profile.test {
+        } else if (unit.target.is_bin() || unit.target.is_example()) && unit.profile.test {
             // Make sure that the name of this test executable doesn't
             // conflict with a library that has the same name and is
             // being tested
             let mut metadata = unit.pkg.generate_metadata();
-            metadata.mix(&format!("bin-{}", unit.target.name()));
+            metadata.mix(
+                &format!("{}-{}",
+                    if unit.target.is_bin() { "bin" } else { "example" },
+                    unit.target.name()
+                )
+            );
             Some(metadata)
         } else if unit.pkg.package_id() == self.resolve.root() &&
                   !unit.profile.test {

--- a/src/doc/guide.md
+++ b/src/doc/guide.md
@@ -412,8 +412,8 @@ You can also run a specific test by passing a filter:
 
 This will run any test with `foo` in its name.
 
-`cargo test` runs additional tests as well. For example, it will compile any
-examples, you’ve included, and will also test the examples in your
+`cargo test` runs additional tests as well. For example, it will compile and
+test any examples, you’ve included, and will also test the examples in your
 documentation. Please see the [testing guide][testing] in the Rust
 documentation for more details.
 

--- a/src/doc/manifest.md
+++ b/src/doc/manifest.md
@@ -455,7 +455,7 @@ When you run `cargo test`, Cargo will:
 * compile and run your library’s documentation tests, which are embedded inside
   of documentation blocks;
 * compile and run your library’s [integration tests](#integration-tests); and
-* compile your library’s examples.
+* compile and test your library’s examples.
 
 ## Integration Tests
 

--- a/tests/test_cargo_test.rs
+++ b/tests/test_cargo_test.rs
@@ -436,6 +436,237 @@ test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
         COMPILING, p.url(), running = RUNNING, doctest = DOCTEST)))
 });
 
+test!(example_test {
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [project]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+        "#)
+        .file("src/lib.rs", r#"
+            pub fn get_hello() -> &'static str { "hello" }
+
+            #[test]
+            fn internal_test() {}
+        "#)
+        .file("examples/i-have-tests.rs", r#"
+            extern crate foo;
+
+            #[test]
+            fn inside_example_test() {
+                assert_eq!(foo::get_hello(), "hello")
+            }
+
+            fn main() { panic!("Examples should not be run by 'cargo test'"); }
+        "#);
+    assert_that(p.cargo_process("test"),
+                execs().with_stdout(format!("\
+{} foo v0.0.1 ({})
+{running} target[..]foo-[..]
+
+running 1 test
+test internal_test ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
+
+{running} target[..]i_have_tests-[..]
+
+running 1 test
+test inside_example_test ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
+
+{doctest} foo
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
+
+",
+        COMPILING, p.url(), running = RUNNING, doctest = DOCTEST)));
+});
+
+test!(example_test_failing {
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [project]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+        "#)
+        .file("src/lib.rs", r#"
+            pub fn get_hello() -> &'static str { "hello" }
+
+            #[test]
+            fn internal_test() {}
+        "#)
+        .file("examples/i-have-tests.rs", r#"
+            extern crate foo;
+
+            #[test]
+            fn inside_example_test() {
+                assert_eq!(foo::get_hello(), "nope")
+            }
+
+            fn main() { panic!("Examples should not be run by 'cargo test'"); }
+        "#);
+    assert_that(p.cargo_process("test"),
+                execs().with_stdout_contains(format!("\
+{} foo v0.0.1 ({})
+{running} target[..]foo-[..]
+
+running 1 test
+test internal_test ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
+
+{running} target[..]i_have_tests-[..]
+
+running 1 test
+test inside_example_test ... FAILED
+
+failures:
+
+---- inside_example_test stdout ----
+<tab>thread 'inside_example_test' panicked at 'assertion failed: \
+    `(left == right)` (left: \
+    `\"hello\"`, right: `\"nope\"`)', examples[..]i-have-tests.rs:6",
+        COMPILING, p.url(), running = RUNNING))
+                .with_stdout_contains("\
+failures:
+    inside_example_test
+
+test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured
+")
+                 .with_status(101));
+});
+
+test!(example_test_disabled {
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [project]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+
+            [[example]]
+            name = "i-have-tests"
+            path = "examples/i-have-tests.rs"
+            test = false
+        "#)
+        .file("src/lib.rs", r#"
+            pub fn get_hello() -> &'static str { "hello" }
+
+            #[test]
+            fn internal_test() {}
+        "#)
+        .file("examples/i-have-tests.rs", r#"
+            extern crate foo;
+
+            #[test]
+            fn inside_example_test() {
+                assert_eq!(foo::get_hello(), "hello")
+            }
+
+            fn main() { panic!("Examples should not be run by 'cargo test'"); }
+        "#);
+    assert_that(p.cargo_process("test"),
+                execs().with_stdout(format!("\
+{} foo v0.0.1 ({})
+{running} target[..]foo-[..]
+
+running 1 test
+test internal_test ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
+
+{doctest} foo
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
+
+",
+        COMPILING, p.url(), running = RUNNING, doctest = DOCTEST)));
+});
+
+test!(example_test_feature {
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [project]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+            [features]
+            bar = []
+        "#)
+        .file("src/lib.rs", r#"
+            pub fn get_hello() -> &'static str { "hello" }
+
+            #[test]
+            fn internal_test() {}
+        "#)
+        .file("examples/i-have-tests.rs", r#"
+            extern crate foo;
+
+            #[test]
+            #[cfg(feature = "bar")]
+            fn inside_example_test() {
+                assert_eq!(foo::get_hello(), "hello")
+            }
+
+            fn main() { panic!("Examples should not be run by 'cargo test'"); }
+        "#);
+    assert_that(p.cargo_process("test").arg("--features").arg("bar"),
+                execs().with_stdout(format!("\
+{} foo v0.0.1 ({})
+{running} target[..]foo-[..]
+
+running 1 test
+test internal_test ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
+
+{running} target[..]i_have_tests-[..]
+
+running 1 test
+test inside_example_test ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
+
+{doctest} foo
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
+
+",
+        COMPILING, p.url(), running = RUNNING, doctest = DOCTEST)));
+});
+
+test!(test_example_failing_in_non_test_code {
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [project]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+        "#)
+        .file("src/lib.rs", r#"
+        "#)
+        .file("examples/has-broken-code.rs", r#"
+            #[cfg(not(test))]
+            fn main() { unknown::method() }
+        "#);
+    assert_that(p.cargo_process("test"),
+                execs().with_stderr_contains("\
+[..]error: failed to resolve[..]
+[..]fn main() { unknown::method() }
+[..]            ^~~~~~~~~~~~~~~
+").with_status(101));
+});
+
 test!(dont_run_examples {
     let p = project("foo")
         .file("Cargo.toml", r#"
@@ -1495,6 +1726,7 @@ test!(example_bin_same_name {
 {compiling} foo v0.0.1 ({dir})
 {running} `rustc [..]`
 {running} `rustc [..]`
+{running} `rustc [..]`
 ", compiling = COMPILING, running = RUNNING, dir = p.url())));
 
     assert_that(&p.bin("foo"), is_not(existing_file()));
@@ -1568,6 +1800,13 @@ test!(example_with_dev_dep {
 [..]
 [..]
 {running} `rustc [..] --crate-name ex [..] --extern a=[..]`
+[..]
+[..]
+[..]
+[..]
+[..]
+[..]
+[..]
 ", running = RUNNING)));
 });
 


### PR DESCRIPTION
This patch currently only adds new behaviour of testing and doesn't move building of the examples to `cargo build` as there may be people relying on that behaviour?

_How should this be opt-in / Improvement to consider:_
During `cargo test` we're only really using the `test` flag from the `[[example]]` config to determine if we should add it to the compilation unit. But, if we don't move the building of the examples to `cargo build` then perhaps we can use a `build` flag to determine if the examples get built during `cargo test`. This would allow only building and not testing examples. If we do that, should `example.test` be false (opt-in) by default then? (can therefore only activate it in explicit examples?)