### PR TITLE
Simplify tests

### DIFF
--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -354,7 +354,7 @@ impl Execs {
                  description: &str, extra: &[u8],
                  partial: bool) -> ham::MatchResult {
         let out = match expected {
-            Some(out) => out,
+            Some(out) => substitute_macros(out),
             None => return ham::success(),
         };
         let actual = match str::from_utf8(actual) {
@@ -655,6 +655,32 @@ pub fn basic_lib_manifest(name: &str) -> String {
 
 pub fn path2url(p: PathBuf) -> Url {
     Url::from_file_path(&*p).ok().unwrap()
+}
+
+fn substitute_macros(input: &str) -> String {
+    let macros = [
+        ("[RUNNING]",     "     Running"),
+        ("[COMPILING]",   "   Compiling"),
+        ("[ERROR]",       "error:"),
+        ("[DOCUMENTING]", " Documenting"),
+        ("[FRESH]",       "       Fresh"),
+        ("[UPDATING]",    "    Updating"),
+        ("[ADDING]",      "      Adding"),
+        ("[REMOVING]",    "    Removing"),
+        ("[DOCTEST]",     "   Doc-tests"),
+        ("[PACKAGING]",   "   Packaging"),
+        ("[DOWNLOADING]", " Downloading"),
+        ("[UPLOADING]",   "   Uploading"),
+        ("[VERIFYING]",   "   Verifying"),
+        ("[ARCHIVING]",   "   Archiving"),
+        ("[INSTALLING]",  "  Installing"),
+        ("[REPLACING]",   "   Replacing")
+    ];
+    let mut result = input.to_owned();
+    for &(pat, subst) in macros.iter() {
+        result = result.replace(pat, subst)
+    }
+    return result;
 }
 
 pub static RUNNING:     &'static str = "     Running";

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -683,12 +683,6 @@ fn substitute_macros(input: &str) -> String {
     return result;
 }
 
-pub static RUNNING:     &'static str = "     Running";
-pub static COMPILING:   &'static str = "   Compiling";
-pub static ERROR:       &'static str = "error:";
-pub static DOCUMENTING: &'static str = " Documenting";
-pub static FRESH:       &'static str = "       Fresh";
-pub static UPDATING:    &'static str = "    Updating";
 pub static ADDING:      &'static str = "      Adding";
 pub static REMOVING:    &'static str = "    Removing";
 pub static DOCTEST:     &'static str = "   Doc-tests";

--- a/tests/test_bad_config.rs
+++ b/tests/test_bad_config.rs
@@ -1,4 +1,4 @@
-use support::{project, execs, ERROR};
+use support::{project, execs};
 use support::registry::Package;
 use hamcrest::assert_that;
 
@@ -19,11 +19,10 @@ test!(bad1 {
         "#);
     assert_that(foo.cargo_process("build").arg("-v")
                    .arg("--target=nonexistent-target"),
-                execs().with_status(101).with_stderr(&format!("\
-{error} expected table for configuration key `target.nonexistent-target`, \
+                execs().with_status(101).with_stderr("\
+[ERROR] expected table for configuration key `target.nonexistent-target`, \
 but found string in [..]config
-",
-    error = ERROR)));
+"));
 });
 
 test!(bad2 {
@@ -40,8 +39,8 @@ test!(bad2 {
                 proxy = 3.0
         "#);
     assert_that(foo.cargo_process("publish").arg("-v"),
-                execs().with_status(101).with_stderr(&format!("\
-{error} Couldn't load Cargo configuration
+                execs().with_status(101).with_stderr("\
+[ERROR] Couldn't load Cargo configuration
 
 Caused by:
   failed to load TOML configuration from `[..]config`
@@ -54,7 +53,7 @@ Caused by:
 
 Caused by:
   found TOML configuration value of unknown type `float`
-", error = ERROR)));
+"));
 });
 
 test!(bad3 {
@@ -71,11 +70,10 @@ test!(bad3 {
               proxy = true
         "#);
     assert_that(foo.cargo_process("publish").arg("-v"),
-                execs().with_status(101).with_stderr(&format!("\
-{error} invalid configuration for key `http.proxy`
+                execs().with_status(101).with_stderr("\
+[ERROR] invalid configuration for key `http.proxy`
 expected a string, but found a boolean in [..]config
-",
-    error = ERROR)));
+"));
 });
 
 test!(bad4 {
@@ -85,14 +83,13 @@ test!(bad4 {
               name = false
         "#);
     assert_that(foo.cargo_process("new").arg("-v").arg("foo"),
-                execs().with_status(101).with_stderr(&format!("\
-{error} Failed to create project `foo` at `[..]`
+                execs().with_status(101).with_stderr("\
+[ERROR] Failed to create project `foo` at `[..]`
 
 Caused by:
   invalid configuration for key `cargo-new.name`
 expected a string, but found a boolean in [..]config
-",
-    error = ERROR)));
+"));
 });
 
 test!(bad5 {
@@ -106,8 +103,8 @@ test!(bad5 {
     foo.build();
     assert_that(foo.cargo("new")
                    .arg("-v").arg("foo").cwd(&foo.root().join("foo")),
-                execs().with_status(101).with_stderr(&format!("\
-{error} Couldn't load Cargo configuration
+                execs().with_status(101).with_stderr("\
+[ERROR] Couldn't load Cargo configuration
 
 Caused by:
   failed to merge key `foo` between files:
@@ -116,8 +113,7 @@ Caused by:
 
 Caused by:
   expected integer, but found string
-",
-    error = ERROR)));
+"));
 });
 
 test!(bad_cargo_config_jobs {
@@ -134,10 +130,9 @@ test!(bad_cargo_config_jobs {
         jobs = -1
     "#);
     assert_that(foo.cargo_process("build").arg("-v"),
-                execs().with_status(101).with_stderr(&format!("\
-{error} build.jobs must be positive, but found -1 in [..]
-",
-    error = ERROR)));
+                execs().with_status(101).with_stderr("\
+[ERROR] build.jobs must be positive, but found -1 in [..]
+"));
 });
 
 test!(default_cargo_config_jobs {
@@ -189,8 +184,8 @@ test!(invalid_global_config {
     .file("src/lib.rs", "");
 
     assert_that(foo.cargo_process("build").arg("-v"),
-                execs().with_status(101).with_stderr(&format!("\
-{error} Couldn't load Cargo configuration
+                execs().with_status(101).with_stderr("\
+[ERROR] Couldn't load Cargo configuration
 
 Caused by:
   could not parse TOML configuration in `[..]config`
@@ -199,8 +194,7 @@ Caused by:
   could not parse input as TOML
 [..]config:1:2 expected `=`, but found eof
 
-",
-    error = ERROR)));
+"));
 });
 
 test!(bad_cargo_lock {
@@ -215,13 +209,12 @@ test!(bad_cargo_lock {
     .file("src/lib.rs", "");
 
     assert_that(foo.cargo_process("build").arg("-v"),
-                execs().with_status(101).with_stderr(&format!("\
-{error} failed to parse lock file at: [..]Cargo.lock
+                execs().with_status(101).with_stderr("\
+[ERROR] failed to parse lock file at: [..]Cargo.lock
 
 Caused by:
   expected a section for the key `root`
-",
-    error = ERROR)));
+"));
 });
 
 test!(bad_git_dependency {
@@ -238,16 +231,15 @@ test!(bad_git_dependency {
     .file("src/lib.rs", "");
 
     assert_that(foo.cargo_process("build").arg("-v"),
-                execs().with_status(101).with_stderr(&format!("\
-{error} Unable to update file:///
+                execs().with_status(101).with_stderr("\
+[ERROR] Unable to update file:///
 
 Caused by:
   failed to clone into: [..]
 
 Caused by:
   [[..]] 'file:///' is not a valid local file URI
-",
-    error = ERROR)));
+"));
 });
 
 test!(bad_crate_type {
@@ -285,15 +277,14 @@ test!(malformed_override {
     .file("src/lib.rs", "");
 
     assert_that(foo.cargo_process("build"),
-                execs().with_status(101).with_stderr(&format!("\
-{error} failed to parse manifest at `[..]`
+                execs().with_status(101).with_stderr("\
+[ERROR] failed to parse manifest at `[..]`
 
 Caused by:
   could not parse input as TOML
 Cargo.toml:[..]
 
-",
-    error = ERROR)));
+"));
 });
 
 test!(duplicate_binary_names {
@@ -316,13 +307,12 @@ test!(duplicate_binary_names {
     .file("b.rs", r#"fn main() -> () {}"#);
 
     assert_that(foo.cargo_process("build"),
-                execs().with_status(101).with_stderr(&format!("\
-{error} failed to parse manifest at `[..]`
+                execs().with_status(101).with_stderr("\
+[ERROR] failed to parse manifest at `[..]`
 
 Caused by:
   found duplicate binary name e, but all binary targets must have a unique name
-",
-    error = ERROR)));
+"));
 });
 
 test!(duplicate_example_names {
@@ -345,13 +335,12 @@ test!(duplicate_example_names {
     .file("examples/ex2.rs", r#"fn main () -> () {}"#);
 
     assert_that(foo.cargo_process("build").arg("--example").arg("ex"),
-                execs().with_status(101).with_stderr(&format!("\
-{error} failed to parse manifest at `[..]`
+                execs().with_status(101).with_stderr("\
+[ERROR] failed to parse manifest at `[..]`
 
 Caused by:
   found duplicate example name ex, but all binary targets must have a unique name
-",
-    error = ERROR)));
+"));
 });
 
 test!(duplicate_bench_names {
@@ -374,13 +363,12 @@ test!(duplicate_bench_names {
     .file("benches/ex2.rs", r#"fn main () {}"#);
 
     assert_that(foo.cargo_process("bench"),
-                execs().with_status(101).with_stderr(&format!("\
-{error} failed to parse manifest at `[..]`
+                execs().with_status(101).with_stderr("\
+[ERROR] failed to parse manifest at `[..]`
 
 Caused by:
   found duplicate bench name ex, but all binary targets must have a unique name
-",
-    error = ERROR)));
+"));
 });
 
 test!(duplicate_deps {
@@ -418,13 +406,12 @@ test!(duplicate_deps {
     .file("src/main.rs", r#"fn main () {}"#);
 
     assert_that(foo.cargo_process("build"),
-                execs().with_status(101).with_stderr(&format!("\
-{error} failed to parse manifest at `[..]`
+                execs().with_status(101).with_stderr("\
+[ERROR] failed to parse manifest at `[..]`
 
 Caused by:
   found duplicate dependency name bar, but all dependencies must have a unique name
-",
-    error = ERROR)));
+"));
 });
 
 test!(unused_keys {

--- a/tests/test_bad_manifest_path.rs
+++ b/tests/test_bad_manifest_path.rs
@@ -1,4 +1,4 @@
-use support::{project, execs, main_file, basic_bin_manifest, ERROR};
+use support::{project, execs, main_file, basic_bin_manifest};
 use hamcrest::{assert_that};
 
 fn setup() {}
@@ -12,9 +12,8 @@ fn assert_not_a_cargo_toml(command: &str, manifest_path_argument: &str) {
                  .arg("--manifest-path").arg(manifest_path_argument)
                  .cwd(p.root().parent().unwrap()),
                 execs().with_status(101)
-                       .with_stderr(&format!("{error} the manifest-path must be a path \
-                                             to a Cargo.toml file",
-                                             error = ERROR)));
+                       .with_stderr(&format!("[ERROR] the manifest-path must be a path \
+                                             to a Cargo.toml file")));
 }
 
 #[allow(deprecated)] // connect => join in 1.3
@@ -28,8 +27,8 @@ fn assert_cargo_toml_doesnt_exist(command: &str, manifest_path_argument: &str) {
                  .cwd(p.root().parent().unwrap()),
                 execs().with_status(101)
                        .with_stderr(
-                           format!("{error} manifest path `{}` does not exist",
-                                   expected_path, error = ERROR)
+                           format!("[ERROR] manifest path `{}` does not exist",
+                                   expected_path)
                        ));
 }
 

--- a/tests/test_cargo.rs
+++ b/tests/test_cargo.rs
@@ -7,7 +7,7 @@ use std::str;
 
 use cargo_process;
 use support::paths;
-use support::{execs, project, mkdir_recursive, ProjectBuilder, ERROR};
+use support::{execs, project, mkdir_recursive, ProjectBuilder};
 use hamcrest::{assert_that};
 
 fn setup() {
@@ -102,12 +102,11 @@ test!(find_closest_biuld_to_build {
 
     assert_that(pr,
                 execs().with_status(101)
-                       .with_stderr(&format!("{error} no such subcommand
+                       .with_stderr(&format!("[ERROR] no such subcommand
 
 <tab>Did you mean `build`?
 
-",
-error = ERROR)));
+")));
 });
 
 // if a subcommand is more than 3 edit distance away, we don't make a suggestion
@@ -118,9 +117,8 @@ test!(find_closest_dont_correct_nonsense {
 
     assert_that(pr,
                 execs().with_status(101)
-                       .with_stderr(&format!("{error} no such subcommand
-",
-error = ERROR)));
+                       .with_stderr(&format!("[ERROR] no such subcommand
+")));
 });
 
 test!(override_cargo_home {

--- a/tests/test_cargo_bench.rs
+++ b/tests/test_cargo_bench.rs
@@ -1,7 +1,6 @@
 use std::str;
 
 use support::{project, execs, basic_bin_manifest, basic_lib_manifest};
-use support::{COMPILING, FRESH, RUNNING};
 use support::paths::CargoPathExt;
 use hamcrest::{assert_that, existing_file};
 use cargo::util::process;
@@ -38,17 +37,15 @@ test!(cargo_bench_simple {
 
     assert_that(p.cargo("bench"),
                 execs().with_stdout(&format!("\
-{} foo v0.5.0 ({})
-{} target[..]release[..]foo-[..]
+[COMPILING] foo v0.5.0 ({})
+[RUNNING] target[..]release[..]foo-[..]
 
 running 1 test
 test bench_hello ... bench: [..] 0 ns/iter (+/- 0)
 
 test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured
 
-",
-        COMPILING, p.url(),
-        RUNNING)));
+", p.url())));
 });
 
 test!(bench_tarname {
@@ -71,8 +68,8 @@ test!(bench_tarname {
             #[bench] fn run2(_ben: &mut test::Bencher) { }"#);
 
     let expected_stdout = format!("\
-{compiling} foo v0.0.1 ({dir})
-{running} target[..]release[..]bin2[..]
+[COMPILING] foo v0.0.1 ({dir})
+[RUNNING] target[..]release[..]bin2[..]
 
 running 1 test
 test run2 ... bench: [..] 0 ns/iter (+/- 0)
@@ -80,8 +77,6 @@ test run2 ... bench: [..] 0 ns/iter (+/- 0)
 test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured
 
 ",
-       compiling = COMPILING,
-       running = RUNNING,
        dir = prj.url());
 
     assert_that(prj.cargo_process("bench").arg("--bench").arg("bin2"),
@@ -102,17 +97,16 @@ test!(cargo_bench_verbose {
 
     assert_that(p.cargo_process("bench").arg("-v").arg("hello"),
         execs().with_stdout(&format!("\
-{compiling} foo v0.5.0 ({url})
-{running} `rustc src[..]foo.rs [..]`
-{running} `[..]target[..]release[..]foo-[..] hello --bench`
+[COMPILING] foo v0.5.0 ({url})
+[RUNNING] `rustc src[..]foo.rs [..]`
+[RUNNING] `[..]target[..]release[..]foo-[..] hello --bench`
 
 running 1 test
 test bench_hello ... bench: [..] 0 ns/iter (+/- 0)
 
 test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured
 
-",
-        compiling = COMPILING, url = p.url(), running = RUNNING)));
+", url = p.url())));
 });
 
 test!(many_similar_names {
@@ -181,12 +175,12 @@ test!(cargo_bench_failing_test {
 
     assert_that(p.cargo("bench"),
                 execs().with_stdout_contains(&format!("\
-{} foo v0.5.0 ({})
-{} target[..]release[..]foo-[..]
+[COMPILING] foo v0.5.0 ({})
+[RUNNING] target[..]release[..]foo-[..]
 
 running 1 test
 test bench_hello ... ",
-        COMPILING, p.url(), RUNNING))
+        p.url()))
               .with_stderr_contains("\
 thread '<main>' panicked at 'assertion failed: \
     `(left == right)` (left: \
@@ -237,15 +231,15 @@ test!(bench_with_lib_dep {
 
     assert_that(p.cargo_process("bench"),
         execs().with_stdout(&format!("\
-{} foo v0.0.1 ({})
-{running} target[..]release[..]baz-[..]
+[COMPILING] foo v0.0.1 ({})
+[RUNNING] target[..]release[..]baz-[..]
 
 running 1 test
 test bin_bench ... bench: [..] 0 ns/iter (+/- 0)
 
 test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured
 
-{running} target[..]release[..]foo-[..]
+[RUNNING] target[..]release[..]foo-[..]
 
 running 1 test
 test lib_bench ... bench: [..] 0 ns/iter (+/- 0)
@@ -253,7 +247,7 @@ test lib_bench ... bench: [..] 0 ns/iter (+/- 0)
 test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured
 
 ",
-        COMPILING, p.url(), running = RUNNING)))
+        p.url())))
 });
 
 test!(bench_with_deep_lib_dep {
@@ -299,9 +293,9 @@ test!(bench_with_deep_lib_dep {
     assert_that(p.cargo_process("bench"),
                 execs().with_status(0)
                        .with_stdout(&format!("\
-{compiling} foo v0.0.1 ([..])
-{compiling} bar v0.0.1 ({dir})
-{running} target[..]
+[COMPILING] foo v0.0.1 ([..])
+[COMPILING] bar v0.0.1 ({dir})
+[RUNNING] target[..]
 
 running 1 test
 test bar_bench ... bench: [..] 0 ns/iter (+/- 0)
@@ -309,7 +303,6 @@ test bar_bench ... bench: [..] 0 ns/iter (+/- 0)
 test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured
 
 ",
-                       compiling = COMPILING, running = RUNNING,
                        dir = p.url())));
 });
 
@@ -346,15 +339,15 @@ test!(external_bench_explicit {
 
     assert_that(p.cargo_process("bench"),
         execs().with_stdout(&format!("\
-{} foo v0.0.1 ({})
-{running} target[..]release[..]bench-[..]
+[COMPILING] foo v0.0.1 ({})
+[RUNNING] target[..]release[..]bench-[..]
 
 running 1 test
 test external_bench ... bench: [..] 0 ns/iter (+/- 0)
 
 test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured
 
-{running} target[..]release[..]foo-[..]
+[RUNNING] target[..]release[..]foo-[..]
 
 running 1 test
 test internal_bench ... bench: [..] 0 ns/iter (+/- 0)
@@ -362,7 +355,7 @@ test internal_bench ... bench: [..] 0 ns/iter (+/- 0)
 test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured
 
 ",
-        COMPILING, p.url(), running = RUNNING)))
+        p.url())))
 });
 
 test!(external_bench_implicit {
@@ -395,15 +388,15 @@ test!(external_bench_implicit {
 
     assert_that(p.cargo_process("bench"),
         execs().with_stdout(&format!("\
-{} foo v0.0.1 ({})
-{running} target[..]release[..]external-[..]
+[COMPILING] foo v0.0.1 ({})
+[RUNNING] target[..]release[..]external-[..]
 
 running 1 test
 test external_bench ... bench: [..] 0 ns/iter (+/- 0)
 
 test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured
 
-{running} target[..]release[..]foo-[..]
+[RUNNING] target[..]release[..]foo-[..]
 
 running 1 test
 test internal_bench ... bench: [..] 0 ns/iter (+/- 0)
@@ -411,7 +404,7 @@ test internal_bench ... bench: [..] 0 ns/iter (+/- 0)
 test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured
 
 ",
-        COMPILING, p.url(), running = RUNNING)))
+        p.url())))
 });
 
 test!(dont_run_examples {
@@ -454,8 +447,8 @@ test!(pass_through_command_line {
     assert_that(p.cargo_process("bench").arg("bar"),
                 execs().with_status(0)
                        .with_stdout(&format!("\
-{compiling} foo v0.0.1 ({dir})
-{running} target[..]release[..]foo-[..]
+[COMPILING] foo v0.0.1 ({dir})
+[RUNNING] target[..]release[..]foo-[..]
 
 running 1 test
 test bar ... bench: [..] 0 ns/iter (+/- 0)
@@ -463,20 +456,19 @@ test bar ... bench: [..] 0 ns/iter (+/- 0)
 test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured
 
 ",
-                       compiling = COMPILING, running = RUNNING,
                        dir = p.url())));
 
     assert_that(p.cargo("bench").arg("foo"),
                 execs().with_status(0)
                        .with_stdout(&format!("\
-{running} target[..]release[..]foo-[..]
+[RUNNING] target[..]release[..]foo-[..]
 
 running 1 test
 test foo ... bench: [..] 0 ns/iter (+/- 0)
 
 test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured
 
-", running = RUNNING)));
+")));
 });
 
 // Regression test for running cargo-bench twice with
@@ -535,15 +527,15 @@ test!(lib_bin_same_name {
 
     assert_that(p.cargo_process("bench"),
         execs().with_stdout(&format!("\
-{} foo v0.0.1 ({})
-{running} target[..]release[..]foo-[..]
+[COMPILING] foo v0.0.1 ({})
+[RUNNING] target[..]release[..]foo-[..]
 
 running 1 test
 test [..] ... bench: [..] 0 ns/iter (+/- 0)
 
 test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured
 
-{running} target[..]release[..]foo-[..]
+[RUNNING] target[..]release[..]foo-[..]
 
 running 1 test
 test [..] ... bench: [..] 0 ns/iter (+/- 0)
@@ -551,7 +543,7 @@ test [..] ... bench: [..] 0 ns/iter (+/- 0)
 test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured
 
 ",
-        COMPILING, p.url(), running = RUNNING)))
+        p.url())))
 });
 
 test!(lib_with_standard_name {
@@ -588,15 +580,15 @@ test!(lib_with_standard_name {
     assert_that(p.cargo_process("bench"),
                 execs().with_status(0)
                        .with_stdout(&format!("\
-{compiling} syntax v0.0.1 ({dir})
-{running} target[..]release[..]bench-[..]
+[COMPILING] syntax v0.0.1 ({dir})
+[RUNNING] target[..]release[..]bench-[..]
 
 running 1 test
 test bench ... bench: [..] 0 ns/iter (+/- 0)
 
 test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured
 
-{running} target[..]release[..]syntax-[..]
+[RUNNING] target[..]release[..]syntax-[..]
 
 running 1 test
 test foo_bench ... bench: [..] 0 ns/iter (+/- 0)
@@ -604,7 +596,6 @@ test foo_bench ... bench: [..] 0 ns/iter (+/- 0)
 test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured
 
 ",
-                       compiling = COMPILING, running = RUNNING,
                        dir = p.url())));
 });
 
@@ -640,8 +631,8 @@ test!(lib_with_standard_name2 {
     assert_that(p.cargo_process("bench"),
                 execs().with_status(0)
                        .with_stdout(&format!("\
-{compiling} syntax v0.0.1 ({dir})
-{running} target[..]release[..]syntax-[..]
+[COMPILING] syntax v0.0.1 ({dir})
+[RUNNING] target[..]release[..]syntax-[..]
 
 running 1 test
 test bench ... bench: [..] 0 ns/iter (+/- 0)
@@ -649,7 +640,6 @@ test bench ... bench: [..] 0 ns/iter (+/- 0)
 test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured
 
 ",
-                       compiling = COMPILING, running = RUNNING,
                        dir = p.url())));
 });
 
@@ -705,20 +695,20 @@ test!(bench_dylib {
     assert_that(p.cargo_process("bench").arg("-v"),
                 execs().with_status(0)
                        .with_stdout(&format!("\
-{compiling} bar v0.0.1 ({dir}/bar)
-{running} [..] -C opt-level=3 [..]
-{compiling} foo v0.0.1 ({dir})
-{running} [..] -C opt-level=3 [..]
-{running} [..] -C opt-level=3 [..]
-{running} [..] -C opt-level=3 [..]
-{running} [..]target[..]release[..]bench-[..]
+[COMPILING] bar v0.0.1 ({dir}/bar)
+[RUNNING] [..] -C opt-level=3 [..]
+[COMPILING] foo v0.0.1 ({dir})
+[RUNNING] [..] -C opt-level=3 [..]
+[RUNNING] [..] -C opt-level=3 [..]
+[RUNNING] [..] -C opt-level=3 [..]
+[RUNNING] [..]target[..]release[..]bench-[..]
 
 running 1 test
 test foo ... bench: [..] 0 ns/iter (+/- 0)
 
 test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured
 
-{running} [..]target[..]release[..]foo-[..]
+[RUNNING] [..]target[..]release[..]foo-[..]
 
 running 1 test
 test foo ... bench: [..] 0 ns/iter (+/- 0)
@@ -726,22 +716,21 @@ test foo ... bench: [..] 0 ns/iter (+/- 0)
 test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured
 
 ",
-                       compiling = COMPILING, running = RUNNING,
                        dir = p.url())));
     p.root().move_into_the_past().unwrap();
     assert_that(p.cargo("bench").arg("-v"),
                 execs().with_status(0)
                        .with_stdout(&format!("\
-{fresh} bar v0.0.1 ({dir}/bar)
-{fresh} foo v0.0.1 ({dir})
-{running} [..]target[..]release[..]bench-[..]
+[FRESH] bar v0.0.1 ({dir}/bar)
+[FRESH] foo v0.0.1 ({dir})
+[RUNNING] [..]target[..]release[..]bench-[..]
 
 running 1 test
 test foo ... bench: [..] 0 ns/iter (+/- 0)
 
 test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured
 
-{running} [..]target[..]release[..]foo-[..]
+[RUNNING] [..]target[..]release[..]foo-[..]
 
 running 1 test
 test foo ... bench: [..] 0 ns/iter (+/- 0)
@@ -749,7 +738,6 @@ test foo ... bench: [..] 0 ns/iter (+/- 0)
 test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured
 
 ",
-                       fresh = FRESH, running = RUNNING,
                        dir = p.url())));
 });
 
@@ -775,8 +763,8 @@ test!(bench_twice_with_build_cmd {
     assert_that(p.cargo_process("bench"),
                 execs().with_status(0)
                        .with_stdout(&format!("\
-{compiling} foo v0.0.1 ({dir})
-{running} target[..]release[..]foo-[..]
+[COMPILING] foo v0.0.1 ({dir})
+[RUNNING] target[..]release[..]foo-[..]
 
 running 1 test
 test foo ... bench: [..] 0 ns/iter (+/- 0)
@@ -784,21 +772,19 @@ test foo ... bench: [..] 0 ns/iter (+/- 0)
 test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured
 
 ",
-                       compiling = COMPILING, running = RUNNING,
                        dir = p.url())));
 
     assert_that(p.cargo("bench"),
                 execs().with_status(0)
                        .with_stdout(&format!("\
-{running} target[..]release[..]foo-[..]
+[RUNNING] target[..]release[..]foo-[..]
 
 running 1 test
 test foo ... bench: [..] 0 ns/iter (+/- 0)
 
 test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured
 
-",
-                       running = RUNNING)));
+")));
 });
 
 test!(bench_with_examples {
@@ -857,18 +843,18 @@ test!(bench_with_examples {
     assert_that(p.cargo_process("bench").arg("-v"),
                 execs().with_status(0)
                        .with_stdout(&format!("\
-{compiling} testbench v6.6.6 ({url})
-{running} `rustc [..]`
-{running} `rustc [..]`
-{running} `rustc [..]`
-{running} `{dir}[..]target[..]release[..]testb1-[..] --bench`
+[COMPILING] testbench v6.6.6 ({url})
+[RUNNING] `rustc [..]`
+[RUNNING] `rustc [..]`
+[RUNNING] `rustc [..]`
+[RUNNING] `{dir}[..]target[..]release[..]testb1-[..] --bench`
 
 running 1 test
 test bench_bench2 ... bench: [..] 0 ns/iter (+/- 0)
 
 test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured
 
-{running} `{dir}[..]target[..]release[..]testbench-[..] --bench`
+[RUNNING] `{dir}[..]target[..]release[..]testbench-[..] --bench`
 
 running 1 test
 test bench_bench1 ... bench: [..] 0 ns/iter (+/- 0)
@@ -876,8 +862,6 @@ test bench_bench1 ... bench: [..] 0 ns/iter (+/- 0)
 test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured
 
 ",
-                       compiling = COMPILING,
-                       running = RUNNING,
                        dir = p.root().display(),
                        url = p.url())));
 });
@@ -910,15 +894,15 @@ test!(test_a_bench {
     assert_that(p.cargo_process("test"),
                 execs().with_status(0)
                        .with_stdout(&format!("\
-{compiling} foo v0.1.0 ([..])
-{running} target[..]debug[..]b-[..]
+[COMPILING] foo v0.1.0 ([..])
+[RUNNING] target[..]debug[..]b-[..]
 
 running 1 test
 test foo ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
 
-", compiling = COMPILING, running = RUNNING)));
+")));
 });
 
 test!(test_bench_no_run {
@@ -946,8 +930,8 @@ test!(test_bench_no_run {
     assert_that(p.cargo_process("bench").arg("--no-run"),
                 execs().with_status(0)
                        .with_stdout(&format!("\
-{compiling} foo v0.1.0 ([..])
-", compiling = COMPILING)));
+[COMPILING] foo v0.1.0 ([..])
+")));
 });
 
 test!(test_bench_multiple_packages {
@@ -1018,19 +1002,19 @@ test!(test_bench_multiple_packages {
     assert_that(p.cargo_process("bench").arg("-p").arg("bar").arg("-p").arg("baz"),
                 execs().with_status(0)
                        .with_stdout_contains(&format!("\
-{running} target[..]release[..]bbaz-[..]
+[RUNNING] target[..]release[..]bbaz-[..]
 
 running 1 test
 test bench_baz ... bench:           0 ns/iter (+/- 0)
 
 test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured
-", running = RUNNING))
+"))
                        .with_stdout_contains(&format!("\
-{running} target[..]release[..]bbar-[..]
+[RUNNING] target[..]release[..]bbar-[..]
 
 running 1 test
 test bench_bar ... bench:           0 ns/iter (+/- 0)
 
 test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured
-", running = RUNNING)));
+")));
 });

--- a/tests/test_cargo_build_auth.rs
+++ b/tests/test_cargo_build_auth.rs
@@ -6,7 +6,7 @@ use std::thread;
 use bufstream::BufStream;
 use git2;
 
-use support::{project, execs, UPDATING, ERROR};
+use support::{project, execs};
 use support::paths;
 use hamcrest::assert_that;
 
@@ -95,13 +95,12 @@ test!(http_auth_offered {
 
     assert_that(p.cargo_process("build"),
                 execs().with_status(101).with_stdout(&format!("\
-{updating} git repository `http://{addr}/foo/bar`
+[UPDATING] git repository `http://{addr}/foo/bar`
 ",
-        updating = UPDATING,
         addr = addr,
         ))
                       .with_stderr(&format!("\
-{error} Unable to update http://{addr}/foo/bar
+[ERROR] Unable to update http://{addr}/foo/bar
 
 Caused by:
   failed to clone into: [..]
@@ -112,8 +111,7 @@ attempted to find username/password via `credential.helper`, but [..]
 
 To learn more, run the command again with --verbose.
 ",
-        addr = addr,
-        error = ERROR)));
+        addr = addr)));
 
     t.join().ok().unwrap();
 });
@@ -140,9 +138,8 @@ test!(https_something_happens {
 
     assert_that(p.cargo_process("build").arg("-v"),
                 execs().with_status(101).with_stdout(&format!("\
-{updating} git repository `https://{addr}/foo/bar`
+[UPDATING] git repository `https://{addr}/foo/bar`
 ",
-        updating = UPDATING,
         addr = addr,
         ))
                       .with_stderr_contains(&format!("\
@@ -185,9 +182,8 @@ test!(ssh_something_happens {
 
     assert_that(p.cargo_process("build").arg("-v"),
                 execs().with_status(101).with_stdout(&format!("\
-{updating} git repository `ssh://{addr}/foo/bar`
+[UPDATING] git repository `ssh://{addr}/foo/bar`
 ",
-        updating = UPDATING,
         addr = addr,
         ))
                       .with_stderr_contains("\

--- a/tests/test_cargo_build_lib.rs
+++ b/tests/test_cargo_build_lib.rs
@@ -1,6 +1,5 @@
 use std::path::MAIN_SEPARATOR as SEP;
 use support::{basic_bin_manifest, execs, project, ProjectBuilder};
-use support::{COMPILING, RUNNING, ERROR};
 use hamcrest::{assert_that};
 
 fn setup() {
@@ -8,14 +7,13 @@ fn setup() {
 
 fn verbose_output_for_lib(p: &ProjectBuilder) -> String {
     format!("\
-{compiling} {name} v{version} ({url})
-{running} `rustc src{sep}lib.rs --crate-name {name} --crate-type lib -g \
+[COMPILING] {name} v{version} ({url})
+[RUNNING] `rustc src{sep}lib.rs --crate-name {name} --crate-type lib -g \
         --out-dir {dir}{sep}target{sep}debug \
         --emit=dep-info,link \
         -L dependency={dir}{sep}target{sep}debug \
         -L dependency={dir}{sep}target{sep}debug{sep}deps`
-",
-            running = RUNNING, compiling = COMPILING, sep = SEP,
+", sep = SEP,
             dir = p.root().display(), url = p.url(),
             name = "foo", version = "0.0.1")
 }
@@ -50,7 +48,7 @@ test!(build_with_no_lib {
 
     assert_that(p.cargo_process("build").arg("--lib"),
                 execs().with_status(101)
-                       .with_stderr(&format!("{error} no library targets found", error = ERROR)));
+                       .with_stderr(&format!("[ERROR] no library targets found")));
 });
 
 test!(build_with_relative_cargo_home_path {

--- a/tests/test_cargo_cfg.rs
+++ b/tests/test_cargo_cfg.rs
@@ -4,7 +4,7 @@ use std::fmt;
 use cargo::util::{Cfg, CfgExpr};
 use hamcrest::assert_that;
 
-use support::{project, execs, COMPILING, UPDATING, DOWNLOADING, ERROR};
+use support::{project, execs, DOWNLOADING};
 use support::registry::Package;
 
 macro_rules! c {
@@ -185,8 +185,8 @@ test!(dont_include {
         .file("b/src/lib.rs", "");
     assert_that(p.cargo_process("build"),
                 execs().with_status(0).with_stdout(&format!("\
-{compiling} a v0.0.1 ([..])
-", compiling = COMPILING)));
+[COMPILING] a v0.0.1 ([..])
+")));
 });
 
 test!(works_through_the_registry {
@@ -212,13 +212,13 @@ test!(works_through_the_registry {
 
     assert_that(p.cargo_process("build"),
                 execs().with_status(0).with_stdout(&format!("\
-{updating} registry [..]
+[UPDATING] registry [..]
 {downloading} [..]
 {downloading} [..]
-{compiling} foo v0.1.0 ([..])
-{compiling} bar v0.1.0 ([..])
-{compiling} a v0.0.1 ([..])
-", compiling = COMPILING, updating = UPDATING, downloading = DOWNLOADING)));
+[COMPILING] foo v0.1.0 ([..])
+[COMPILING] bar v0.1.0 ([..])
+[COMPILING] a v0.0.1 ([..])
+", downloading = DOWNLOADING)));
 });
 
 test!(bad_target_spec {
@@ -236,15 +236,14 @@ test!(bad_target_spec {
 
     assert_that(p.cargo_process("build"),
                 execs().with_status(101).with_stderr(&format!("\
-{error} failed to parse manifest at `[..]`
+[ERROR] failed to parse manifest at `[..]`
 
 Caused by:
   failed to parse `4` as a cfg expression
 
 Caused by:
   unexpected character in cfg `4`, [..]
-",
-error = ERROR)));
+")));
 });
 
 test!(bad_target_spec2 {
@@ -262,15 +261,14 @@ test!(bad_target_spec2 {
 
     assert_that(p.cargo_process("build"),
                 execs().with_status(101).with_stderr(&format!("\
-{error} failed to parse manifest at `[..]`
+[ERROR] failed to parse manifest at `[..]`
 
 Caused by:
   failed to parse `foo =` as a cfg expression
 
 Caused by:
   expected a string, found nothing
-",
-error = ERROR)));
+")));
 });
 
 test!(multiple_match_ok {

--- a/tests/test_cargo_clean.rs
+++ b/tests/test_cargo_clean.rs
@@ -1,7 +1,6 @@
 use std::env;
 
 use support::{git, project, execs, main_file, basic_bin_manifest};
-use support::{COMPILING, RUNNING};
 use support::registry::Package;
 use hamcrest::{assert_that, existing_dir, existing_file, is_not};
 
@@ -129,8 +128,8 @@ test!(clean_release {
                 execs().with_status(0));
     assert_that(p.cargo("build").arg("--release"),
                 execs().with_status(0).with_stdout(&format!("\
-{compiling} foo v0.0.1 ([..])
-", compiling = COMPILING)));
+[COMPILING] foo v0.0.1 ([..])
+")));
 });
 
 test!(build_script {
@@ -165,11 +164,11 @@ test!(build_script {
                 execs().with_status(0));
     assert_that(p.cargo("build").arg("-v"),
                 execs().with_status(0).with_stdout(&format!("\
-{compiling} foo v0.0.1 ([..])
-{running} `rustc build.rs [..]`
-{running} `[..]build-script-build[..]`
-{running} `rustc src[..]main.rs [..]`
-", compiling = COMPILING, running = RUNNING)));
+[COMPILING] foo v0.0.1 ([..])
+[RUNNING] `rustc build.rs [..]`
+[RUNNING] `[..]build-script-build[..]`
+[RUNNING] `rustc src[..]main.rs [..]`
+")));
 });
 
 test!(clean_git {

--- a/tests/test_cargo_compile.rs
+++ b/tests/test_cargo_compile.rs
@@ -4,7 +4,7 @@ use std::io::prelude::*;
 use tempdir::TempDir;
 
 use support::{project, execs, main_file, basic_bin_manifest};
-use support::{COMPILING, RUNNING, ProjectBuilder, ERROR};
+use support::{ProjectBuilder};
 use hamcrest::{assert_that, existing_file, is_not};
 use support::paths::{CargoPathExt,root};
 use cargo::util::process;
@@ -44,12 +44,11 @@ test!(cargo_compile_with_invalid_manifest {
         execs()
         .with_status(101)
         .with_stderr(&format!("\
-{error} failed to parse manifest at `[..]`
+[ERROR] failed to parse manifest at `[..]`
 
 Caused by:
   no `package` or `project` section found.
-",
-error = ERROR)))
+")))
 });
 
 test!(cargo_compile_with_invalid_manifest2 {
@@ -63,14 +62,13 @@ test!(cargo_compile_with_invalid_manifest2 {
         execs()
         .with_status(101)
         .with_stderr(&format!("\
-{error} failed to parse manifest at `[..]`
+[ERROR] failed to parse manifest at `[..]`
 
 Caused by:
   could not parse input as TOML
 Cargo.toml:3:19-3:20 expected a value
 
-",
-error = ERROR)))
+")))
 });
 
 test!(cargo_compile_with_invalid_manifest3 {
@@ -88,12 +86,11 @@ test!(cargo_compile_with_invalid_manifest3 {
         execs()
         .with_status(101)
         .with_stderr(&format!("\
-{error} failed to parse manifest at `[..]`
+[ERROR] failed to parse manifest at `[..]`
 
 Caused by:
   could not parse input as TOML\n\
-src[..]Cargo.toml:1:5-1:6 expected a value\n\n",
-error = ERROR)))
+src[..]Cargo.toml:1:5-1:6 expected a value\n\n")))
 });
 
 test!(cargo_compile_with_invalid_version {
@@ -109,12 +106,11 @@ test!(cargo_compile_with_invalid_version {
                 execs()
                 .with_status(101)
                 .with_stderr(&format!("\
-{error} failed to parse manifest at `[..]`
+[ERROR] failed to parse manifest at `[..]`
 
 Caused by:
   cannot parse '1.0' as a semver for the key `project.version`
-",
-error = ERROR)))
+")))
 
 });
 
@@ -131,12 +127,11 @@ test!(cargo_compile_with_invalid_package_name {
                 execs()
                 .with_status(101)
                 .with_stderr(&format!("\
-{error} failed to parse manifest at `[..]`
+[ERROR] failed to parse manifest at `[..]`
 
 Caused by:
   package name cannot be an empty string.
-",
-error = ERROR)))
+")))
 });
 
 test!(cargo_compile_with_invalid_bin_target_name {
@@ -155,12 +150,11 @@ test!(cargo_compile_with_invalid_bin_target_name {
                 execs()
                 .with_status(101)
                 .with_stderr(&format!("\
-{error} failed to parse manifest at `[..]`
+[ERROR] failed to parse manifest at `[..]`
 
 Caused by:
   binary target names cannot be empty.
-",
-error = ERROR)))
+")))
 });
 
 test!(cargo_compile_with_forbidden_bin_target_name {
@@ -179,12 +173,11 @@ test!(cargo_compile_with_forbidden_bin_target_name {
                 execs()
                 .with_status(101)
                 .with_stderr(&format!("\
-{error} failed to parse manifest at `[..]`
+[ERROR] failed to parse manifest at `[..]`
 
 Caused by:
   the binary target name `build` is forbidden
-",
-error = ERROR)))
+")))
 });
 
 test!(cargo_compile_with_invalid_lib_target_name {
@@ -203,12 +196,11 @@ test!(cargo_compile_with_invalid_lib_target_name {
                 execs()
                 .with_status(101)
                 .with_stderr(&format!("\
-{error} failed to parse manifest at `[..]`
+[ERROR] failed to parse manifest at `[..]`
 
 Caused by:
   library target names cannot be empty.
-",
-error = ERROR)))
+")))
 });
 
 test!(cargo_compile_without_manifest {
@@ -218,9 +210,8 @@ test!(cargo_compile_without_manifest {
     assert_that(p.cargo_process("build"),
                 execs().with_status(101)
                        .with_stderr(&format!("\
-{error} could not find `Cargo.toml` in `[..]` or any parent directory
-",
-error = ERROR)));
+[ERROR] could not find `Cargo.toml` in `[..]` or any parent directory
+")));
 });
 
 test!(cargo_compile_with_invalid_code {
@@ -237,9 +228,9 @@ src[..]foo.rs:1 invalid rust code!
              ^~~~~~~
 ")
         .with_stderr_contains(format!("\
-{error} Could not compile `foo`.
+[ERROR] Could not compile `foo`.
 
-To learn more, run the command again with --verbose.\n", error = ERROR)));
+To learn more, run the command again with --verbose.\n")));
     assert_that(&p.root().join("Cargo.lock"), existing_file());
 });
 
@@ -324,10 +315,10 @@ test!(cargo_compile_with_warnings_in_a_dep_package {
 
     assert_that(p.cargo_process("build"),
         execs()
-        .with_stdout(&format!("{} bar v0.5.0 ({}/bar)\n\
-                              {} foo v0.5.0 ({})\n",
-                             COMPILING, p.url(),
-                             COMPILING, p.url()))
+        .with_stdout(&format!("[COMPILING] bar v0.5.0 ({}/bar)\n\
+                              [COMPILING] foo v0.5.0 ({})\n",
+                             p.url(),
+                             p.url()))
         .with_stderr("\
 [..]warning: function is never used: `dead`[..]
 [..]fn dead() {}
@@ -615,10 +606,10 @@ test!(cargo_compile_with_dep_name_mismatch {
 
     assert_that(p.cargo_process("build"),
                 execs().with_status(101).with_stderr(&format!(
-r#"{error} no matching package named `notquitebar` found (required by `foo`)
+r#"[ERROR] no matching package named `notquitebar` found (required by `foo`)
 location searched: {proj_dir}/bar
 version required: *
-"#, error = ERROR, proj_dir = p.url())));
+"#, proj_dir = p.url())));
 });
 
 test!(cargo_compile_with_filename{
@@ -640,23 +631,23 @@ test!(cargo_compile_with_filename{
 
     assert_that(p.cargo_process("build").arg("--bin").arg("bin.rs"),
                 execs().with_status(101).with_stderr(&format!("\
-{error} no bin target named `bin.rs`", error = ERROR)));
+[ERROR] no bin target named `bin.rs`")));
 
     assert_that(p.cargo_process("build").arg("--bin").arg("a.rs"),
                 execs().with_status(101).with_stderr(&format!("\
-{error} no bin target named `a.rs`
+[ERROR] no bin target named `a.rs`
 
-Did you mean `a`?", error = ERROR)));
+Did you mean `a`?")));
 
     assert_that(p.cargo_process("build").arg("--example").arg("example.rs"),
                 execs().with_status(101).with_stderr(&format!("\
-{error} no example target named `example.rs`", error = ERROR)));
+[ERROR] no example target named `example.rs`")));
 
     assert_that(p.cargo_process("build").arg("--example").arg("a.rs"),
                 execs().with_status(101).with_stderr(&format!("\
-{error} no example target named `a.rs`
+[ERROR] no example target named `a.rs`
 
-Did you mean `a`?", error = ERROR)));
+Did you mean `a`?")));
 });
 
 test!(compile_path_dep_then_change_version {
@@ -690,13 +681,12 @@ test!(compile_path_dep_then_change_version {
 
     assert_that(p.cargo("build"),
                 execs().with_status(101).with_stderr(&format!("\
-{error} no matching package named `bar` found (required by `foo`)
+[ERROR] no matching package named `bar` found (required by `foo`)
 location searched: [..]
 version required: = 0.0.1
 versions found: 0.0.2
 consider running `cargo update` to update a path dependency's locked version
-",
-error = ERROR)));
+")));
 });
 
 test!(ignores_carriage_return_in_lockfile {
@@ -946,9 +936,8 @@ test!(self_dependency {
     assert_that(p.cargo_process("build"),
                 execs().with_status(101)
                        .with_stderr(&format!("\
-{error} cyclic package dependency: package `test v0.0.0 ([..])` depends on itself
-",
-error = ERROR)));
+[ERROR] cyclic package dependency: package `test v0.0.0 ([..])` depends on itself
+")));
 });
 
 test!(ignore_broken_symlinks {
@@ -980,12 +969,11 @@ test!(missing_lib_and_bin {
     assert_that(p.cargo_process("build"),
                 execs().with_status(101)
                        .with_stderr(&format!("\
-{error} failed to parse manifest at `[..]Cargo.toml`
+[ERROR] failed to parse manifest at `[..]Cargo.toml`
 
 Caused by:
   no targets specified in the manifest
-  either src/lib.rs, src/main.rs, a [lib] section, or [[bin]] section must be present\n",
-error = ERROR)));
+  either src/lib.rs, src/main.rs, a [lib] section, or [[bin]] section must be present\n")));
 });
 
 test!(lto_build {
@@ -1009,8 +997,8 @@ test!(lto_build {
         .file("src/main.rs", "fn main() {}");
     assert_that(p.cargo_process("build").arg("-v").arg("--release"),
                 execs().with_status(0).with_stdout(&format!("\
-{compiling} test v0.0.0 ({url})
-{running} `rustc src[..]main.rs --crate-name test --crate-type bin \
+[COMPILING] test v0.0.0 ({url})
+[RUNNING] `rustc src[..]main.rs --crate-name test --crate-type bin \
         -C opt-level=3 \
         -C lto \
         --out-dir {dir}[..]target[..]release \
@@ -1018,7 +1006,6 @@ test!(lto_build {
         -L dependency={dir}[..]target[..]release \
         -L dependency={dir}[..]target[..]release[..]deps`
 ",
-running = RUNNING, compiling = COMPILING,
 dir = p.root().display(),
 url = p.url(),
 )));
@@ -1037,14 +1024,13 @@ test!(verbose_build {
         .file("src/lib.rs", "");
     assert_that(p.cargo_process("build").arg("-v"),
                 execs().with_status(0).with_stdout(&format!("\
-{compiling} test v0.0.0 ({url})
-{running} `rustc src[..]lib.rs --crate-name test --crate-type lib -g \
+[COMPILING] test v0.0.0 ({url})
+[RUNNING] `rustc src[..]lib.rs --crate-name test --crate-type lib -g \
         --out-dir {dir}[..]target[..]debug \
         --emit=dep-info,link \
         -L dependency={dir}[..]target[..]debug \
         -L dependency={dir}[..]target[..]debug[..]deps`
 ",
-running = RUNNING, compiling = COMPILING,
 dir = p.root().display(),
 url = p.url(),
 )));
@@ -1063,15 +1049,14 @@ test!(verbose_release_build {
         .file("src/lib.rs", "");
     assert_that(p.cargo_process("build").arg("-v").arg("--release"),
                 execs().with_status(0).with_stdout(&format!("\
-{compiling} test v0.0.0 ({url})
-{running} `rustc src[..]lib.rs --crate-name test --crate-type lib \
+[COMPILING] test v0.0.0 ({url})
+[RUNNING] `rustc src[..]lib.rs --crate-name test --crate-type lib \
         -C opt-level=3 \
         --out-dir {dir}[..]target[..]release \
         --emit=dep-info,link \
         -L dependency={dir}[..]target[..]release \
         -L dependency={dir}[..]target[..]release[..]deps`
 ",
-running = RUNNING, compiling = COMPILING,
 dir = p.root().display(),
 url = p.url(),
 )));
@@ -1105,8 +1090,8 @@ test!(verbose_release_build_deps {
         .file("foo/src/lib.rs", "");
     assert_that(p.cargo_process("build").arg("-v").arg("--release"),
                 execs().with_status(0).with_stdout(&format!("\
-{compiling} foo v0.0.0 ({url}/foo)
-{running} `rustc foo[..]src[..]lib.rs --crate-name foo \
+[COMPILING] foo v0.0.0 ({url}/foo)
+[RUNNING] `rustc foo[..]src[..]lib.rs --crate-name foo \
         --crate-type dylib --crate-type rlib -C prefer-dynamic \
         -C opt-level=3 \
         -C metadata=[..] \
@@ -1115,8 +1100,8 @@ test!(verbose_release_build_deps {
         --emit=dep-info,link \
         -L dependency={dir}[..]target[..]release[..]deps \
         -L dependency={dir}[..]target[..]release[..]deps`
-{compiling} test v0.0.0 ({url})
-{running} `rustc src[..]lib.rs --crate-name test --crate-type lib \
+[COMPILING] test v0.0.0 ({url})
+[RUNNING] `rustc src[..]lib.rs --crate-name test --crate-type lib \
         -C opt-level=3 \
         --out-dir {dir}[..]target[..]release \
         --emit=dep-info,link \
@@ -1126,8 +1111,6 @@ test!(verbose_release_build_deps {
                      {prefix}foo-[..]{suffix} \
         --extern foo={dir}[..]target[..]release[..]deps[..]libfoo-[..].rlib`
 ",
-                    running = RUNNING,
-                    compiling = COMPILING,
                     dir = p.root().display(),
                     url = p.url(),
                     prefix = env::consts::DLL_PREFIX,
@@ -1330,9 +1313,8 @@ test!(lib_with_standard_name {
     assert_that(p.cargo_process("build"),
                 execs().with_status(0)
                        .with_stdout(&format!("\
-{compiling} syntax v0.0.1 ({dir})
+[COMPILING] syntax v0.0.1 ({dir})
 ",
-                       compiling = COMPILING,
                        dir = p.url())));
 });
 
@@ -1427,8 +1409,8 @@ test!(freshness_ignores_excluded {
     assert_that(foo.cargo("build"),
                 execs().with_status(0)
                        .with_stdout(&format!("\
-{compiling} foo v0.0.0 ({url})
-", compiling = COMPILING, url = foo.url())));
+[COMPILING] foo v0.0.0 ({url})
+", url = foo.url())));
 
     // Smoke test to make sure it doesn't compile again
     println!("first pass");
@@ -1474,15 +1456,15 @@ test!(rebuild_preserves_out_dir {
     assert_that(foo.cargo("build").env("FIRST", "1"),
                 execs().with_status(0)
                        .with_stdout(&format!("\
-{compiling} foo v0.0.0 ({url})
-", compiling = COMPILING, url = foo.url())));
+[COMPILING] foo v0.0.0 ({url})
+", url = foo.url())));
 
     File::create(&foo.root().join("src/bar.rs")).unwrap();
     assert_that(foo.cargo("build"),
                 execs().with_status(0)
                        .with_stdout(&format!("\
-{compiling} foo v0.0.0 ({url})
-", compiling = COMPILING, url = foo.url())));
+[COMPILING] foo v0.0.0 ({url})
+", url = foo.url())));
 });
 
 test!(dep_no_libs {
@@ -1565,7 +1547,7 @@ test!(bad_cargo_config {
         "#);
     assert_that(foo.cargo_process("build").arg("-v"),
                 execs().with_status(101).with_stderr(&format!("\
-{error} Couldn't load Cargo configuration
+[ERROR] Couldn't load Cargo configuration
 
 Caused by:
   could not parse TOML configuration in `[..]`
@@ -1574,8 +1556,7 @@ Caused by:
   could not parse input as TOML
 [..].cargo[..]config:2:20-2:21 expected `=`, but found `i`
 
-",
-error = ERROR)));
+")));
 });
 
 test!(cargo_platform_specific_dependency {
@@ -1793,12 +1774,11 @@ test!(transitive_dependencies_not_available {
 [..] extern crate bbbbb; [..]
 [..]
 error: aborting due to previous error
-{error} Could not compile `foo`.
+[ERROR] Could not compile `foo`.
 
 Caused by:
   [..]
-",
-error = ERROR)));
+")));
 });
 
 test!(cyclic_deps_rejected {
@@ -1827,9 +1807,8 @@ test!(cyclic_deps_rejected {
     assert_that(p.cargo_process("build").arg("-v"),
                 execs().with_status(101)
                        .with_stderr(&format!("\
-{error} cyclic package dependency: package `foo v0.0.1 ([..])` depends on itself
-",
-error = ERROR)));
+[ERROR] cyclic package dependency: package `foo v0.0.1 ([..])` depends on itself
+")));
 });
 
 test!(predictable_filenames {
@@ -1904,12 +1883,11 @@ test!(rustc_env_var {
                  .env("RUSTC", "rustc-that-does-not-exist").arg("-v"),
                 execs().with_status(101)
                        .with_stderr(&format!("\
-{error} Could not execute process `rustc-that-does-not-exist -vV` ([..])
+[ERROR] Could not execute process `rustc-that-does-not-exist -vV` ([..])
 
 Caused by:
 [..]
-",
-error = ERROR)));
+")));
     assert_that(&p.bin("a"), is_not(existing_file()));
 });
 
@@ -2137,11 +2115,11 @@ test!(invalid_spec {
 
     assert_that(p.cargo_process("build").arg("-p").arg("notAValidDep"),
                 execs().with_status(101).with_stderr(&format!(
-                    "{error} could not find package matching spec `notAValidDep`", error = ERROR)));
+                    "[ERROR] could not find package matching spec `notAValidDep`")));
 
     assert_that(p.cargo_process("build").arg("-p").arg("d1").arg("-p").arg("notAValidDep"),
                 execs().with_status(101).with_stderr(&format!(
-                    "{error} could not find package matching spec `notAValidDep`", error = ERROR)));
+                    "[ERROR] could not find package matching spec `notAValidDep`")));
 
 });
 

--- a/tests/test_cargo_compile_plugins.rs
+++ b/tests/test_cargo_compile_plugins.rs
@@ -2,7 +2,6 @@ use std::fs;
 use std::env;
 
 use support::{project, execs};
-use support::{COMPILING, RUNNING};
 use hamcrest::assert_that;
 
 fn setup() {
@@ -264,7 +263,7 @@ test!(native_plugin_dependency_with_custom_ar_linker {
     foo.build();
     assert_that(bar.cargo_process("build").arg("--verbose"),
                 execs().with_stdout(&format!("\
-{compiling} foo v0.0.1 ([..])
-{running} `rustc [..] -C ar=nonexistent-ar -C linker=nonexistent-linker [..]`
-", compiling = COMPILING, running = RUNNING)));
+[COMPILING] foo v0.0.1 ([..])
+[RUNNING] `rustc [..] -C ar=nonexistent-ar -C linker=nonexistent-linker [..]`
+")));
 });

--- a/tests/test_cargo_concurrent.rs
+++ b/tests/test_cargo_concurrent.rs
@@ -8,7 +8,7 @@ use std::thread;
 use git2;
 use hamcrest::{assert_that, existing_file};
 
-use support::{execs, project, ERROR, COMPILING};
+use support::{execs, project};
 use support::git;
 use support::registry::Package;
 use test_cargo_install::{cargo_home, has_installed_exe};
@@ -118,8 +118,8 @@ test!(one_install_should_be_bad {
 
     let (bad, good) = if a.status.code() == Some(101) {(a, b)} else {(b, a)};
     assert_that(bad, execs().with_status(101).with_stderr_contains(&format!("\
-{error} binary `foo[..]` already exists in destination as part of `[..]`
-", error = ERROR)));
+[ERROR] binary `foo[..]` already exists in destination as part of `[..]`
+")));
     assert_that(good, execs().with_status(0).with_stderr_contains("\
 warning: be sure to add `[..]` to your PATH [..]
 "));
@@ -357,7 +357,7 @@ test!(killing_cargo_releases_the_lock {
     p.build();
 
     // Our build script will connect to our local TCP socket to inform us that
-    // it's started running, and that's how we know that `a` will have the lock
+    // it's started  and that's how we know that `a` will have the lock
     // when we kill it.
     let l = TcpListener::bind("127.0.0.1:0").unwrap();
     let mut a = p.cargo("build").build_command();
@@ -410,9 +410,9 @@ test!(debug_release_ok {
     let a = a.join().unwrap();
 
     assert_that(a, execs().with_status(0).with_stdout(&format!("\
-{compiling} foo v0.0.0 [..]
-", compiling = COMPILING)));
+[COMPILING] foo v0.0.0 [..]
+")));
     assert_that(b, execs().with_status(0).with_stdout(&format!("\
-{compiling} foo v0.0.0 [..]
-", compiling = COMPILING)));
+[COMPILING] foo v0.0.0 [..]
+")));
 });

--- a/tests/test_cargo_cross_compile.rs
+++ b/tests/test_cargo_cross_compile.rs
@@ -1,7 +1,7 @@
 use std::env;
 
 use support::{project, execs, basic_bin_manifest};
-use support::{RUNNING, COMPILING, DOCTEST, ERROR};
+use support::{DOCTEST};
 use hamcrest::{assert_that, existing_file};
 use cargo::util::process;
 
@@ -349,8 +349,8 @@ test!(linker_and_ar {
                                               .arg("-v"),
                 execs().with_status(101)
                        .with_stdout(&format!("\
-{compiling} foo v0.5.0 ({url})
-{running} `rustc src[..]foo.rs --crate-name foo --crate-type bin -g \
+[COMPILING] foo v0.5.0 ({url})
+[RUNNING] `rustc src[..]foo.rs --crate-name foo --crate-type bin -g \
     --out-dir {dir}[..]target[..]{target}[..]debug \
     --emit=dep-info,link \
     --target {target} \
@@ -358,8 +358,6 @@ test!(linker_and_ar {
     -L dependency={dir}[..]target[..]{target}[..]debug \
     -L dependency={dir}[..]target[..]{target}[..]debug[..]deps`
 ",
-                            running = RUNNING,
-                            compiling = COMPILING,
                             dir = p.root().display(),
                             url = p.url(),
                             target = target,
@@ -464,22 +462,22 @@ test!(cross_tests {
     assert_that(p.cargo_process("test").arg("--target").arg(&target),
                 execs().with_status(0)
                        .with_stdout(&format!("\
-{compiling} foo v0.0.0 ({foo})
-{running} target[..]{triple}[..]bar-[..]
+[COMPILING] foo v0.0.0 ({foo})
+[RUNNING] target[..]{triple}[..]bar-[..]
 
 running 1 test
 test test ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
 
-{running} target[..]{triple}[..]foo-[..]
+[RUNNING] target[..]{triple}[..]foo-[..]
 
 running 1 test
 test test_foo ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
 
-", compiling = COMPILING, running = RUNNING, foo = p.url(), triple = target)));
+", foo = p.url(), triple = target)));
 });
 
 test!(no_cross_doctests {
@@ -500,8 +498,8 @@ test!(no_cross_doctests {
         "#);
 
     let host_output = format!("\
-{compiling} foo v0.0.0 ({foo})
-{running} target[..]foo-[..]
+[COMPILING] foo v0.0.0 ({foo})
+[RUNNING] target[..]foo-[..]
 
 running 0 tests
 
@@ -514,7 +512,7 @@ test _0 ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
 
-", compiling = COMPILING, running = RUNNING, foo = p.url(), doctest = DOCTEST);
+", foo = p.url(), doctest = DOCTEST);
 
     assert_that(p.cargo_process("test"),
                 execs().with_status(0)
@@ -529,14 +527,14 @@ test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
     assert_that(p.cargo_process("test").arg("--target").arg(&target),
                 execs().with_status(0)
                        .with_stdout(&format!("\
-{compiling} foo v0.0.0 ({foo})
-{running} target[..]{triple}[..]foo-[..]
+[COMPILING] foo v0.0.0 ({foo})
+[RUNNING] target[..]{triple}[..]foo-[..]
 
 running 0 tests
 
 test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
 
-", compiling = COMPILING, running = RUNNING, foo = p.url(), triple = target)));
+", foo = p.url(), triple = target)));
 });
 
 test!(simple_cargo_run {
@@ -598,11 +596,11 @@ test!(cross_with_a_build_script {
     assert_that(p.cargo_process("build").arg("--target").arg(&target).arg("-v"),
                 execs().with_status(0)
                        .with_stdout(&format!("\
-{compiling} foo v0.0.0 (file://[..])
-{running} `rustc build.rs [..] --out-dir {dir}[..]target[..]build[..]foo-[..]`
-{running} `{dir}[..]target[..]build[..]foo-[..]build-script-build`
-{running} `rustc src[..]main.rs [..] --target {target} [..]`
-", compiling = COMPILING, running = RUNNING, target = target,
+[COMPILING] foo v0.0.0 (file://[..])
+[RUNNING] `rustc build.rs [..] --out-dir {dir}[..]target[..]build[..]foo-[..]`
+[RUNNING] `{dir}[..]target[..]build[..]foo-[..]build-script-build`
+[RUNNING] `rustc src[..]main.rs [..] --target {target} [..]`
+", target = target,
    dir = p.root().display())));
 });
 
@@ -667,28 +665,28 @@ test!(build_script_needed_for_host_and_target {
     assert_that(p.cargo_process("build").arg("--target").arg(&target).arg("-v"),
                 execs().with_status(0)
                        .with_stdout_contains(&format!("\
-{compiling} d1 v0.0.0 ({url}/d1)", compiling = COMPILING, url = p.url()))
+[COMPILING] d1 v0.0.0 ({url}/d1)", url = p.url()))
                        .with_stdout_contains(&format!("\
-{running} `rustc d1[..]build.rs [..] --out-dir {dir}[..]target[..]build[..]d1-[..]`",
-    running = RUNNING, dir = p.root().display()))
-                       .with_stdout_contains(&format!("\
-{running} `{dir}[..]target[..]build[..]d1-[..]build-script-build`", running = RUNNING,
+[RUNNING] `rustc d1[..]build.rs [..] --out-dir {dir}[..]target[..]build[..]d1-[..]`",
     dir = p.root().display()))
                        .with_stdout_contains(&format!("\
-{running} `rustc d1[..]src[..]lib.rs [..]`", running = RUNNING))
+[RUNNING] `{dir}[..]target[..]build[..]d1-[..]build-script-build`",
+    dir = p.root().display()))
                        .with_stdout_contains(&format!("\
-{compiling} d2 v0.0.0 ({url}/d2)", compiling = COMPILING, url = p.url()))
+[RUNNING] `rustc d1[..]src[..]lib.rs [..]`"))
                        .with_stdout_contains(&format!("\
-{running} `rustc d2[..]src[..]lib.rs [..] \
-           -L /path/to/{host}`", running = RUNNING, host = host))
+[COMPILING] d2 v0.0.0 ({url}/d2)", url = p.url()))
                        .with_stdout_contains(&format!("\
-{compiling} foo v0.0.0 ({url})", compiling = COMPILING, url = p.url()))
+[RUNNING] `rustc d2[..]src[..]lib.rs [..] \
+           -L /path/to/{host}`", host = host))
                        .with_stdout_contains(&format!("\
-{running} `rustc build.rs [..] --out-dir {dir}[..]target[..]build[..]foo-[..] \
-           -L /path/to/{host}`", running = RUNNING, dir = p.root().display(), host = host))
+[COMPILING] foo v0.0.0 ({url})", url = p.url()))
                        .with_stdout_contains(&format!("\
-{running} `rustc src[..]main.rs [..] --target {target} [..] \
-           -L /path/to/{target}`", running = RUNNING, target = target)));
+[RUNNING] `rustc build.rs [..] --out-dir {dir}[..]target[..]build[..]foo-[..] \
+           -L /path/to/{host}`", dir = p.root().display(), host = host))
+                       .with_stdout_contains(&format!("\
+[RUNNING] `rustc src[..]main.rs [..] --target {target} [..] \
+           -L /path/to/{target}`", target = target)));
 });
 
 test!(build_deps_for_the_right_arch {
@@ -793,11 +791,11 @@ test!(plugin_build_script_right_arch {
     assert_that(p.cargo_process("build").arg("-v").arg("--target").arg(alternate()),
                 execs().with_status(0)
                        .with_stdout(&format!("\
-{compiling} foo v0.0.1 ([..])
-{running} `rustc build.rs [..]`
-{running} `[..]build-script-build[..]`
-{running} `rustc src[..]lib.rs [..]`
-", compiling = COMPILING, running = RUNNING)));
+[COMPILING] foo v0.0.1 ([..])
+[RUNNING] `rustc build.rs [..]`
+[RUNNING] `[..]build-script-build[..]`
+[RUNNING] `rustc src[..]lib.rs [..]`
+")));
 });
 
 test!(build_script_with_platform_specific_dependencies {
@@ -839,15 +837,15 @@ test!(build_script_with_platform_specific_dependencies {
     assert_that(p.cargo_process("build").arg("-v").arg("--target").arg(&target),
                 execs().with_status(0)
                        .with_stdout(&format!("\
-{compiling} d2 v0.0.0 ([..])
-{running} `rustc d2[..]src[..]lib.rs [..]`
-{compiling} d1 v0.0.0 ([..])
-{running} `rustc d1[..]src[..]lib.rs [..]`
-{compiling} foo v0.0.1 ([..])
-{running} `rustc build.rs [..]`
-{running} `{dir}[..]target[..]build[..]foo-[..]build-script-build`
-{running} `rustc src[..]lib.rs [..] --target {target} [..]`
-", compiling = COMPILING, running = RUNNING, dir = p.root().display(), target = target)));
+[COMPILING] d2 v0.0.0 ([..])
+[RUNNING] `rustc d2[..]src[..]lib.rs [..]`
+[COMPILING] d1 v0.0.0 ([..])
+[RUNNING] `rustc d1[..]src[..]lib.rs [..]`
+[COMPILING] foo v0.0.1 ([..])
+[RUNNING] `rustc build.rs [..]`
+[RUNNING] `{dir}[..]target[..]build[..]foo-[..]build-script-build`
+[RUNNING] `rustc src[..]lib.rs [..] --target {target} [..]`
+", dir = p.root().display(), target = target)));
 });
 
 test!(platform_specific_dependencies_do_not_leak {
@@ -896,11 +894,11 @@ test!(platform_specific_dependencies_do_not_leak {
 [..] extern crate d2;
 [..]
 error: aborting due to previous error
-{error} Could not compile `d1`.
+[ERROR] Could not compile `d1`.
 
 Caused by:
   [..]
-", error = ERROR)));
+")));
 });
 
 test!(platform_specific_variables_reflected_in_build_scripts {

--- a/tests/test_cargo_doc.rs
+++ b/tests/test_cargo_doc.rs
@@ -2,7 +2,6 @@ use std::str;
 use std::fs;
 
 use support::{project, execs, path2url};
-use support::{COMPILING, DOCUMENTING, RUNNING, ERROR};
 use hamcrest::{assert_that, existing_file, existing_dir, is_not};
 
 fn setup() {
@@ -66,9 +65,8 @@ test!(doc_twice {
 
     assert_that(p.cargo_process("doc"),
                 execs().with_status(0).with_stdout(&format!("\
-{documenting} foo v0.0.1 ({dir})
+[DOCUMENTING] foo v0.0.1 ({dir})
 ",
-        documenting = DOCUMENTING,
         dir = path2url(p.root()))));
 
     assert_that(p.cargo("doc"),
@@ -104,9 +102,8 @@ test!(doc_deps {
                 execs().with_status(0).with_stdout(&format!("\
 [..] bar v0.0.1 ({dir}/bar)
 [..] bar v0.0.1 ({dir}/bar)
-{documenting} foo v0.0.1 ({dir})
+[DOCUMENTING] foo v0.0.1 ({dir})
 ",
-        documenting = DOCUMENTING,
         dir = path2url(p.root()))));
 
     assert_that(&p.root().join("target/doc"), existing_dir());
@@ -149,10 +146,9 @@ test!(doc_no_deps {
 
     assert_that(p.cargo_process("doc").arg("--no-deps"),
                 execs().with_status(0).with_stdout(&format!("\
-{compiling} bar v0.0.1 ({dir}/bar)
-{documenting} foo v0.0.1 ({dir})
+[COMPILING] bar v0.0.1 ({dir}/bar)
+[DOCUMENTING] foo v0.0.1 ({dir})
 ",
-        documenting = DOCUMENTING, compiling = COMPILING,
         dir = path2url(p.root()))));
 
     assert_that(&p.root().join("target/doc"), existing_dir());
@@ -207,10 +203,9 @@ test!(doc_lib_bin_same_name {
     assert_that(p.cargo_process("doc"),
                 execs().with_status(101)
                        .with_stderr(&format!("\
-{error} cannot document a package where a library and a binary have the same name. \
+[ERROR] cannot document a package where a library and a binary have the same name. \
 Consider renaming one or marking the target as `doc = false`
-",
-error = ERROR)));
+")));
 });
 
 test!(doc_dash_p {
@@ -248,8 +243,8 @@ test!(doc_dash_p {
                        .with_stdout(&format!("\
 [..] b v0.0.1 (file://[..])
 [..] b v0.0.1 (file://[..])
-{documenting} a v0.0.1 (file://[..])
-", documenting = DOCUMENTING)));
+[DOCUMENTING] a v0.0.1 (file://[..])
+")));
 });
 
 test!(doc_same_name {
@@ -432,9 +427,9 @@ test!(doc_release {
     assert_that(p.cargo("doc").arg("--release").arg("-v"),
                 execs().with_status(0)
                        .with_stdout(&format!("\
-{documenting} foo v0.0.1 ([..])
-{running} `rustdoc src[..]lib.rs [..]`
-", documenting = DOCUMENTING, running = RUNNING)));
+[DOCUMENTING] foo v0.0.1 ([..])
+[RUNNING] `rustdoc src[..]lib.rs [..]`
+")));
 });
 
 test!(doc_multiple_deps {

--- a/tests/test_cargo_features.rs
+++ b/tests/test_cargo_features.rs
@@ -2,7 +2,6 @@ use std::fs::File;
 use std::io::prelude::*;
 
 use support::{project, execs};
-use support::{COMPILING, FRESH, ERROR};
 use support::paths::CargoPathExt;
 use hamcrest::assert_that;
 
@@ -24,12 +23,11 @@ test!(invalid1 {
 
     assert_that(p.cargo_process("build"),
                 execs().with_status(101).with_stderr(&format!("\
-{error} failed to parse manifest at `[..]`
+[ERROR] failed to parse manifest at `[..]`
 
 Caused by:
   Feature `bar` includes `baz` which is neither a dependency nor another feature
-",
-error = ERROR)));
+")));
 });
 
 test!(invalid2 {
@@ -50,12 +48,11 @@ test!(invalid2 {
 
     assert_that(p.cargo_process("build"),
                 execs().with_status(101).with_stderr(&format!("\
-{error} failed to parse manifest at `[..]`
+[ERROR] failed to parse manifest at `[..]`
 
 Caused by:
   Features and dependencies cannot have the same name: `bar`
-",
-error = ERROR)));
+")));
 });
 
 test!(invalid3 {
@@ -76,13 +73,12 @@ test!(invalid3 {
 
     assert_that(p.cargo_process("build"),
                 execs().with_status(101).with_stderr(&format!("\
-{error} failed to parse manifest at `[..]`
+[ERROR] failed to parse manifest at `[..]`
 
 Caused by:
   Feature `bar` depends on `baz` which is not an optional dependency.
 Consider adding `optional = true` to the dependency
-",
-error = ERROR)));
+")));
 });
 
 test!(invalid4 {
@@ -108,9 +104,8 @@ test!(invalid4 {
 
     assert_that(p.cargo_process("build"),
                 execs().with_status(101).with_stderr(&format!("\
-{error} Package `bar v0.0.1 ([..])` does not have these features: `bar`
-",
-error = ERROR)));
+[ERROR] Package `bar v0.0.1 ([..])` does not have these features: `bar`
+")));
 
     let p = p.file("Cargo.toml", r#"
             [project]
@@ -121,9 +116,8 @@ error = ERROR)));
 
     assert_that(p.cargo_process("build").arg("--features").arg("test"),
                 execs().with_status(101).with_stderr(&format!("\
-{error} Package `foo v0.0.1 ([..])` does not have these features: `test`
-",
-error = ERROR)));
+[ERROR] Package `foo v0.0.1 ([..])` does not have these features: `test`
+")));
 });
 
 test!(invalid5 {
@@ -142,12 +136,11 @@ test!(invalid5 {
 
     assert_that(p.cargo_process("build"),
                 execs().with_status(101).with_stderr(&format!("\
-{error} failed to parse manifest at `[..]`
+[ERROR] failed to parse manifest at `[..]`
 
 Caused by:
   Dev-dependencies are not allowed to be optional: `bar`
-",
-error = ERROR)));
+")));
 });
 
 test!(invalid6 {
@@ -165,12 +158,11 @@ test!(invalid6 {
 
     assert_that(p.cargo_process("build").arg("--features").arg("foo"),
                 execs().with_status(101).with_stderr(&format!("\
-{error} failed to parse manifest at `[..]`
+[ERROR] failed to parse manifest at `[..]`
 
 Caused by:
   Feature `foo` requires `bar` which is not an optional dependency
-",
-error = ERROR)));
+")));
 });
 
 test!(invalid7 {
@@ -189,12 +181,11 @@ test!(invalid7 {
 
     assert_that(p.cargo_process("build").arg("--features").arg("foo"),
                 execs().with_status(101).with_stderr(&format!("\
-{error} failed to parse manifest at `[..]`
+[ERROR] failed to parse manifest at `[..]`
 
 Caused by:
   Feature `foo` requires `bar` which is not an optional dependency
-",
-error = ERROR)));
+")));
 });
 
 test!(invalid8 {
@@ -220,9 +211,8 @@ test!(invalid8 {
 
     assert_that(p.cargo_process("build").arg("--features").arg("foo"),
                 execs().with_status(101).with_stderr(&format!("\
-{error} features in dependencies cannot enable features in other dependencies: `foo/bar`
-",
-error = ERROR)));
+[ERROR] features in dependencies cannot enable features in other dependencies: `foo/bar`
+")));
 });
 
 test!(no_feature_doesnt_build {
@@ -255,16 +245,16 @@ test!(no_feature_doesnt_build {
 
     assert_that(p.cargo_process("build"),
                 execs().with_status(0).with_stdout(format!("\
-{compiling} foo v0.0.1 ({dir})
-", compiling = COMPILING, dir = p.url())));
+[COMPILING] foo v0.0.1 ({dir})
+", dir = p.url())));
     assert_that(p.process(&p.bin("foo")),
                 execs().with_status(0).with_stdout(""));
 
     assert_that(p.cargo("build").arg("--features").arg("bar"),
                 execs().with_status(0).with_stdout(format!("\
-{compiling} bar v0.0.1 ({dir}/bar)
-{compiling} foo v0.0.1 ({dir})
-", compiling = COMPILING, dir = p.url())));
+[COMPILING] bar v0.0.1 ({dir}/bar)
+[COMPILING] foo v0.0.1 ({dir})
+", dir = p.url())));
     assert_that(p.process(&p.bin("foo")),
                 execs().with_status(0).with_stdout("bar\n"));
 });
@@ -302,16 +292,16 @@ test!(default_feature_pulled_in {
 
     assert_that(p.cargo_process("build"),
                 execs().with_status(0).with_stdout(format!("\
-{compiling} bar v0.0.1 ({dir}/bar)
-{compiling} foo v0.0.1 ({dir})
-", compiling = COMPILING, dir = p.url())));
+[COMPILING] bar v0.0.1 ({dir}/bar)
+[COMPILING] foo v0.0.1 ({dir})
+", dir = p.url())));
     assert_that(p.process(&p.bin("foo")),
                 execs().with_status(0).with_stdout("bar\n"));
 
     assert_that(p.cargo("build").arg("--no-default-features"),
                 execs().with_status(0).with_stdout(format!("\
-{compiling} foo v0.0.1 ({dir})
-", compiling = COMPILING, dir = p.url())));
+[COMPILING] foo v0.0.1 ({dir})
+", dir = p.url())));
     assert_that(p.process(&p.bin("foo")),
                 execs().with_status(0).with_stdout(""));
 });
@@ -331,9 +321,8 @@ test!(cyclic_feature {
 
     assert_that(p.cargo_process("build"),
                 execs().with_status(101).with_stderr(&format!("\
-{error} Cyclic feature dependency: feature `default` depends on itself
-",
-error = ERROR)));
+[ERROR] Cyclic feature dependency: feature `default` depends on itself
+")));
 });
 
 test!(cyclic_feature2 {
@@ -352,9 +341,8 @@ test!(cyclic_feature2 {
 
     assert_that(p.cargo_process("build"),
                 execs().with_status(101).with_stderr(&format!("\
-{error} Cyclic feature dependency: feature `[..]` depends on itself
-",
-error = ERROR)));
+[ERROR] Cyclic feature dependency: feature `[..]` depends on itself
+")));
 });
 
 test!(groups_on_groups_on_groups {
@@ -405,10 +393,10 @@ test!(groups_on_groups_on_groups {
 
     assert_that(p.cargo_process("build"),
                 execs().with_status(0).with_stdout(format!("\
-{compiling} ba[..] v0.0.1 ({dir}/ba[..])
-{compiling} ba[..] v0.0.1 ({dir}/ba[..])
-{compiling} foo v0.0.1 ({dir})
-", compiling = COMPILING, dir = p.url())));
+[COMPILING] ba[..] v0.0.1 ({dir}/ba[..])
+[COMPILING] ba[..] v0.0.1 ({dir}/ba[..])
+[COMPILING] foo v0.0.1 ({dir})
+", dir = p.url())));
 });
 
 test!(many_cli_features {
@@ -449,10 +437,10 @@ test!(many_cli_features {
 
     assert_that(p.cargo_process("build").arg("--features").arg("bar baz"),
                 execs().with_status(0).with_stdout(format!("\
-{compiling} ba[..] v0.0.1 ({dir}/ba[..])
-{compiling} ba[..] v0.0.1 ({dir}/ba[..])
-{compiling} foo v0.0.1 ({dir})
-", compiling = COMPILING, dir = p.url())));
+[COMPILING] ba[..] v0.0.1 ({dir}/ba[..])
+[COMPILING] ba[..] v0.0.1 ({dir}/ba[..])
+[COMPILING] foo v0.0.1 ({dir})
+", dir = p.url())));
 });
 
 test!(union_features {
@@ -510,10 +498,10 @@ test!(union_features {
 
     assert_that(p.cargo_process("build"),
                 execs().with_status(0).with_stdout(format!("\
-{compiling} d2 v0.0.1 ({dir}/d2)
-{compiling} d1 v0.0.1 ({dir}/d1)
-{compiling} foo v0.0.1 ({dir})
-", compiling = COMPILING, dir = p.url())));
+[COMPILING] d2 v0.0.1 ({dir}/d2)
+[COMPILING] d1 v0.0.1 ({dir}/d1)
+[COMPILING] foo v0.0.1 ({dir})
+", dir = p.url())));
 });
 
 test!(many_features_no_rebuilds {
@@ -544,16 +532,16 @@ test!(many_features_no_rebuilds {
 
     assert_that(p.cargo_process("build"),
                 execs().with_status(0).with_stdout(format!("\
-{compiling} a v0.1.0 ({dir}/a)
-{compiling} b v0.1.0 ({dir})
-", compiling = COMPILING, dir = p.url())));
+[COMPILING] a v0.1.0 ({dir}/a)
+[COMPILING] b v0.1.0 ({dir})
+", dir = p.url())));
     p.root().move_into_the_past().unwrap();
 
     assert_that(p.cargo("build").arg("-v"),
                 execs().with_status(0).with_stdout(format!("\
-{fresh} a v0.1.0 ([..]/a)
-{fresh} b v0.1.0 ([..])
-", fresh = FRESH)));
+[FRESH] a v0.1.0 ([..]/a)
+[FRESH] b v0.1.0 ([..])
+")));
 });
 
 // Tests that all cmd lines work with `--features ""`
@@ -777,8 +765,8 @@ test!(optional_and_dev_dep {
 
     assert_that(p.cargo_process("build"),
                 execs().with_status(0).with_stdout(format!("\
-{compiling} test v0.1.0 ([..])
-", compiling = COMPILING)));
+[COMPILING] test v0.1.0 ([..])
+")));
 });
 
 test!(activating_feature_activates_dep {

--- a/tests/test_cargo_freshness.rs
+++ b/tests/test_cargo_freshness.rs
@@ -2,7 +2,6 @@ use std::fs::{self, File};
 use std::io::prelude::*;
 
 use support::{project, execs, path2url};
-use support::COMPILING;
 use support::paths::CargoPathExt;
 use hamcrest::{assert_that, existing_file};
 
@@ -23,8 +22,8 @@ test!(modifying_and_moving {
 
     assert_that(p.cargo_process("build"),
                 execs().with_status(0).with_stdout(format!("\
-{compiling} foo v0.0.1 ({dir})
-", compiling = COMPILING, dir = path2url(p.root()))));
+[COMPILING] foo v0.0.1 ({dir})
+", dir = path2url(p.root()))));
 
     assert_that(p.cargo("build"),
                 execs().with_status(0).with_stdout(""));
@@ -35,8 +34,8 @@ test!(modifying_and_moving {
          .write_all(b"fn main() {}").unwrap();
     assert_that(p.cargo("build"),
                 execs().with_status(0).with_stdout(format!("\
-{compiling} foo v0.0.1 ({dir})
-", compiling = COMPILING, dir = path2url(p.root()))));
+[COMPILING] foo v0.0.1 ({dir})
+", dir = path2url(p.root()))));
 
     fs::rename(&p.root().join("src/a.rs"), &p.root().join("src/b.rs")).unwrap();
     assert_that(p.cargo("build"),
@@ -62,8 +61,8 @@ test!(modify_only_some_files {
 
     assert_that(p.cargo_process("build"),
                 execs().with_status(0).with_stdout(format!("\
-{compiling} foo v0.0.1 ({dir})
-", compiling = COMPILING, dir = path2url(p.root()))));
+[COMPILING] foo v0.0.1 ({dir})
+", dir = path2url(p.root()))));
     assert_that(p.cargo("test"),
                 execs().with_status(0));
     ::sleep_ms(1000);
@@ -81,8 +80,8 @@ test!(modify_only_some_files {
     assert_that(p.cargo("build")
                  .env("RUST_LOG", "cargo::ops::cargo_rustc::fingerprint"),
                 execs().with_status(0).with_stdout(format!("\
-{compiling} foo v0.0.1 ({dir})
-", compiling = COMPILING, dir = path2url(p.root()))));
+[COMPILING] foo v0.0.1 ({dir})
+", dir = path2url(p.root()))));
     assert_that(&p.bin("foo"), existing_file());
 });
 
@@ -251,10 +250,10 @@ test!(no_rebuild_transitive_target_deps {
     assert_that(p.cargo("test").arg("--no-run"),
                 execs().with_status(0)
                        .with_stdout(&format!("\
-{compiling} c v0.0.1 ([..])
-{compiling} b v0.0.1 ([..])
-{compiling} foo v0.0.1 ([..])
-", compiling = COMPILING)));
+[COMPILING] c v0.0.1 ([..])
+[COMPILING] b v0.0.1 ([..])
+[COMPILING] foo v0.0.1 ([..])
+")));
 });
 
 test!(rerun_if_changed_in_dep {
@@ -342,13 +341,13 @@ test!(same_build_dir_cached_packages {
 
     assert_that(p.cargo("build").cwd(p.root().join("a1")),
                 execs().with_status(0).with_stdout(&format!("\
-{compiling} d v0.0.1 ({dir}/d)
-{compiling} c v0.0.1 ({dir}/c)
-{compiling} b v0.0.1 ({dir}/b)
-{compiling} a1 v0.0.1 ({dir}/a1)
-", compiling = COMPILING, dir = p.url())));
+[COMPILING] d v0.0.1 ({dir}/d)
+[COMPILING] c v0.0.1 ({dir}/c)
+[COMPILING] b v0.0.1 ({dir}/b)
+[COMPILING] a1 v0.0.1 ({dir}/a1)
+", dir = p.url())));
     assert_that(p.cargo("build").cwd(p.root().join("a2")),
                 execs().with_status(0).with_stdout(&format!("\
-{compiling} a2 v0.0.1 ({dir}/a2)
-", compiling = COMPILING, dir = p.url())));
+[COMPILING] a2 v0.0.1 ({dir}/a2)
+", dir = p.url())));
 });

--- a/tests/test_cargo_init.rs
+++ b/tests/test_cargo_init.rs
@@ -2,7 +2,7 @@ use std::fs::{self, File};
 use std::io::prelude::*;
 use std::env;
 use tempdir::TempDir;
-use support::{execs, paths, cargo_dir, ERROR};
+use support::{execs, paths, cargo_dir};
 use hamcrest::{assert_that, existing_file, existing_dir, is_not};
 
 use cargo::util::{process, ProcessBuilder};
@@ -126,9 +126,8 @@ test!(confused_by_multiple_lib_files {
     assert_that(cargo_process("init").arg("--vcs").arg("none")
                                     .env("USER", "foo").cwd(&path),
                 execs().with_status(101).with_stderr(&format!("\
-{error} cannot have a project with multiple libraries, found both `src/lib.rs` and `lib.rs`
-",
-error = ERROR)));
+[ERROR] cannot have a project with multiple libraries, found both `src/lib.rs` and `lib.rs`
+")));
 
     assert_that(&paths::root().join("foo/Cargo.toml"), is_not(existing_file()));
 });
@@ -157,12 +156,11 @@ test!(multibin_project_name_clash {
     assert_that(cargo_process("init").arg("--vcs").arg("none")
                                     .env("USER", "foo").cwd(&path),
                 execs().with_status(101).with_stderr(&format!("\
-{error} multiple possible binary sources found:
+[ERROR] multiple possible binary sources found:
   main.rs
   foo.rs
 cannot automatically generate Cargo.toml as the main target would be ambiguous
-",
-error = ERROR)));
+")));
 
     assert_that(&paths::root().join("foo/Cargo.toml"), is_not(existing_file()));
 });
@@ -231,10 +229,9 @@ test!(invalid_dir_name {
     assert_that(cargo_process("init").cwd(foo.clone())
                                      .env("USER", "foo"),
                 execs().with_status(101).with_stderr(&format!("\
-{error} Invalid character `.` in crate name: `foo.bar`
+[ERROR] Invalid character `.` in crate name: `foo.bar`
 use --name to override crate name
-",
-error = ERROR)));
+")));
 
     assert_that(&foo.join("Cargo.toml"), is_not(existing_file()));
 });
@@ -245,10 +242,9 @@ test!(reserved_name {
     assert_that(cargo_process("init").cwd(test.clone())
                                      .env("USER", "foo"),
                 execs().with_status(101).with_stderr(&format!("\
-{error} The name `test` cannot be used as a crate name\n\
+[ERROR] The name `test` cannot be used as a crate name\n\
 use --name to override crate name
-",
-error = ERROR)));
+")));
 
     assert_that(&test.join("Cargo.toml"), is_not(existing_file()));
 });
@@ -375,13 +371,12 @@ test!(unknown_flags {
     assert_that(cargo_process("init").arg("foo").arg("--flag"),
                 execs().with_status(1)
                        .with_stderr(&format!("\
-{error} Unknown flag: '--flag'
+[ERROR] Unknown flag: '--flag'
 
 Usage:
     cargo init [options] [<path>]
     cargo init -h | --help
-",
-error = ERROR)));
+")));
 });
 
 #[cfg(not(windows))]
@@ -389,7 +384,6 @@ test!(no_filename {
     assert_that(cargo_process("init").arg("/"),
                 execs().with_status(101)
                        .with_stderr(&format!("\
-{error} cannot auto-detect project name from path \"/\" ; use --name to override
-",
-error = ERROR)));
+[ERROR] cannot auto-detect project name from path \"/\" ; use --name to override
+")));
 });

--- a/tests/test_cargo_install.rs
+++ b/tests/test_cargo_install.rs
@@ -8,7 +8,7 @@ use cargo::util::ProcessBuilder;
 use hamcrest::{assert_that, existing_file, is_not, Matcher, MatchResult};
 
 use support::{project, execs};
-use support::{UPDATING, DOWNLOADING, COMPILING, INSTALLING, REPLACING, REMOVING, ERROR};
+use support::{DOWNLOADING, INSTALLING, REPLACING, REMOVING};
 use support::paths;
 use support::registry::Package;
 use support::git;
@@ -84,14 +84,12 @@ test!(pick_max_version {
 
     assert_that(cargo_process("install").arg("foo"),
                 execs().with_status(0).with_stdout(&format!("\
-{updating} registry `[..]`
+[UPDATING] registry `[..]`
 {downloading} foo v0.0.2 (registry file://[..])
-{compiling} foo v0.0.2 (registry file://[..])
+[COMPILING] foo v0.0.2 (registry file://[..])
 {installing} {home}[..]bin[..]foo[..]
 ",
-        updating = UPDATING,
         downloading = DOWNLOADING,
-        compiling = COMPILING,
         installing = INSTALLING,
         home = cargo_home().display())));
     assert_that(cargo_home(), has_installed_exe("foo"));
@@ -101,32 +99,29 @@ test!(missing {
     pkg("foo", "0.0.1");
     assert_that(cargo_process("install").arg("bar"),
                 execs().with_status(101).with_stderr(&format!("\
-{error} could not find `bar` in `registry file://[..]`
-",
-error = ERROR)));
+[ERROR] could not find `bar` in `registry file://[..]`
+")));
 });
 
 test!(bad_version {
     pkg("foo", "0.0.1");
     assert_that(cargo_process("install").arg("foo").arg("--vers=0.2.0"),
                 execs().with_status(101).with_stderr(&format!("\
-{error} could not find `foo` in `registry file://[..]` with version `0.2.0`
-",
-error = ERROR)));
+[ERROR] could not find `foo` in `registry file://[..]` with version `0.2.0`
+")));
 });
 
 test!(no_crate {
     assert_that(cargo_process("install"),
                 execs().with_status(101).with_stderr(&format!("\
-{error} `[..]` is not a crate root; specify a crate to install [..]
+[ERROR] `[..]` is not a crate root; specify a crate to install [..]
 
 Caused by:
   failed to read `[..]Cargo.toml`
 
 Caused by:
   [..] (os error [..])
-",
-error = ERROR)));
+")));
 });
 
 test!(install_location_precedence {
@@ -193,10 +188,9 @@ test!(install_path {
     assert_that(cargo_home(), has_installed_exe("foo"));
     assert_that(cargo_process("install").arg("--path").arg(".").cwd(p.root()),
                 execs().with_status(101).with_stderr(&format!("\
-{error} binary `foo[..]` already exists in destination as part of `foo v0.1.0 [..]`
+[ERROR] binary `foo[..]` already exists in destination as part of `foo v0.1.0 [..]`
 Add --force to overwrite
-",
-error = ERROR)));
+")));
 });
 
 test!(multiple_crates_error {
@@ -219,9 +213,8 @@ test!(multiple_crates_error {
 
     assert_that(cargo_process("install").arg("--git").arg(p.url().to_string()),
                 execs().with_status(101).with_stderr(&format!("\
-{error} multiple packages with binaries found: bar, foo
-",
-error = ERROR)));
+[ERROR] multiple packages with binaries found: bar, foo
+")));
 });
 
 test!(multiple_crates_select {
@@ -335,9 +328,8 @@ test!(no_binaries_or_examples {
 
     assert_that(cargo_process("install").arg("--path").arg(p.root()),
                 execs().with_status(101).with_stderr(&format!("\
-{error} no packages found with binaries or examples
-",
-error = ERROR)));
+[ERROR] no packages found with binaries or examples
+")));
 });
 
 test!(no_binaries {
@@ -354,9 +346,8 @@ test!(no_binaries {
 
     assert_that(cargo_process("install").arg("--path").arg(p.root()).arg("foo"),
                 execs().with_status(101).with_stderr(&format!("\
-{error} specified package has no binaries
-",
-error = ERROR)));
+[ERROR] specified package has no binaries
+")));
 });
 
 test!(examples {
@@ -393,11 +384,10 @@ test!(install_twice {
                 execs().with_status(0));
     assert_that(cargo_process("install").arg("--path").arg(p.root()),
                 execs().with_status(101).with_stderr(&format!("\
-{error} binary `foo-bin1[..]` already exists in destination as part of `foo v0.1.0 ([..])`
+[ERROR] binary `foo-bin1[..]` already exists in destination as part of `foo v0.1.0 ([..])`
 binary `foo-bin2[..]` already exists in destination as part of `foo v0.1.0 ([..])`
 Add --force to overwrite
-",
-error = ERROR)));
+")));
 });
 
 test!(install_force {
@@ -426,10 +416,9 @@ test!(install_force {
 
     assert_that(cargo_process("install").arg("--force").arg("--path").arg(p.root()),
                 execs().with_status(0).with_stdout(&format!("\
-{compiling} foo v0.2.0 ([..])
+[COMPILING] foo v0.2.0 ([..])
 {replacing} {home}[..]bin[..]foo[..]
 ",
-        compiling = COMPILING,
         replacing = REPLACING,
         home = cargo_home().display())));
 
@@ -468,11 +457,10 @@ test!(install_force_partial_overlap {
 
     assert_that(cargo_process("install").arg("--force").arg("--path").arg(p.root()),
                 execs().with_status(0).with_stdout(&format!("\
-{compiling} foo v0.2.0 ([..])
+[COMPILING] foo v0.2.0 ([..])
 {installing} {home}[..]bin[..]foo-bin3[..]
 {replacing} {home}[..]bin[..]foo-bin2[..]
 ",
-        compiling = COMPILING,
         installing = INSTALLING,
         replacing = REPLACING,
         home = cargo_home().display())));
@@ -519,10 +507,9 @@ test!(install_force_bin {
                     .arg("--path")
                     .arg(p.root()),
                 execs().with_status(0).with_stdout(&format!("\
-{compiling} foo v0.2.0 ([..])
+[COMPILING] foo v0.2.0 ([..])
 {replacing} {home}[..]bin[..]foo-bin2[..]
 ",
-        compiling = COMPILING,
         replacing = REPLACING,
         home = cargo_home().display())));
 
@@ -550,15 +537,14 @@ test!(compile_failure {
                 execs().with_status(101).with_stderr(&format!("\
 error: main function not found
 error: aborting due to previous error
-{error} failed to compile `foo v0.1.0 (file://[..])`, intermediate artifacts can be \
+[ERROR] failed to compile `foo v0.1.0 (file://[..])`, intermediate artifacts can be \
     found at `[..]target`
 
 Caused by:
   Could not compile `foo`.
 
 To learn more, run the command again with --verbose.
-",
-error = ERROR)));
+")));
 });
 
 test!(git_repo {
@@ -574,12 +560,10 @@ test!(git_repo {
 
     assert_that(cargo_process("install").arg("--git").arg(p.url().to_string()),
                 execs().with_status(0).with_stdout(&format!("\
-{updating} git repository `[..]`
-{compiling} foo v0.1.0 ([..])
+[UPDATING] git repository `[..]`
+[COMPILING] foo v0.1.0 ([..])
 {installing} {home}[..]bin[..]foo[..]
 ",
-        updating = UPDATING,
-        compiling = COMPILING,
         installing = INSTALLING,
         home = cargo_home().display())));
     assert_that(cargo_home(), has_installed_exe("foo"));
@@ -610,9 +594,8 @@ foo v0.0.1 (registry [..]):
 test!(uninstall_pkg_does_not_exist {
     assert_that(cargo_process("uninstall").arg("foo"),
                 execs().with_status(101).with_stderr(&format!("\
-{error} package id specification `foo` matched no packages
-",
-error = ERROR)));
+[ERROR] package id specification `foo` matched no packages
+")));
 });
 
 test!(uninstall_bin_does_not_exist {
@@ -622,9 +605,8 @@ test!(uninstall_bin_does_not_exist {
                 execs().with_status(0));
     assert_that(cargo_process("uninstall").arg("foo").arg("--bin=bar"),
                 execs().with_status(101).with_stderr(&format!("\
-{error} binary `bar[..]` not installed as part of `foo v0.0.1 ([..])`
-",
-error = ERROR)));
+[ERROR] binary `bar[..]` not installed as part of `foo v0.0.1 ([..])`
+")));
 });
 
 test!(uninstall_piecemeal {
@@ -660,9 +642,8 @@ test!(uninstall_piecemeal {
 
     assert_that(cargo_process("uninstall").arg("foo"),
                 execs().with_status(101).with_stderr(&format!("\
-{error} package id specification `foo` matched no packages
-",
-error = ERROR)));
+[ERROR] package id specification `foo` matched no packages
+")));
 });
 
 test!(subcommand_works_out_of_the_box {
@@ -737,11 +718,10 @@ test!(reports_unsuccessful_subcommand_result {
                 execs().with_status(101).with_stderr_contains("\
 thread '<main>' panicked at 'explicit panic', [..]
 ").with_stderr_contains(format!("\
-{error} third party subcommand `cargo-fail[..]` exited unsuccessfully
+[ERROR] third party subcommand `cargo-fail[..]` exited unsuccessfully
 
 To learn more, run the command again with --verbose.
-",
-error = ERROR)));
+")));
 });
 
 test!(git_with_lockfile {

--- a/tests/test_cargo_install.rs
+++ b/tests/test_cargo_install.rs
@@ -62,23 +62,18 @@ test!(simple {
 
     assert_that(cargo_process("install").arg("foo"),
                 execs().with_status(0).with_stdout(&format!("\
-{updating} registry `[..]`
-{downloading} foo v0.0.1 (registry file://[..])
-{compiling} foo v0.0.1 (registry file://[..])
-{installing} {home}[..]bin[..]foo[..]
+[UPDATING] registry `[..]`
+[DOWNLOADING] foo v0.0.1 (registry file://[..])
+[COMPILING] foo v0.0.1 (registry file://[..])
+[INSTALLING] {home}[..]bin[..]foo[..]
 ",
-        updating = UPDATING,
-        downloading = DOWNLOADING,
-        compiling = COMPILING,
-        installing = INSTALLING,
         home = cargo_home().display())));
     assert_that(cargo_home(), has_installed_exe("foo"));
 
     assert_that(cargo_process("uninstall").arg("foo"),
                 execs().with_status(0).with_stdout(&format!("\
-{removing} {home}[..]bin[..]foo[..]
+[REMOVING] {home}[..]bin[..]foo[..]
 ",
-        removing = REMOVING,
         home = cargo_home().display())));
     assert_that(cargo_home(), is_not(has_installed_exe("foo")));
 });

--- a/tests/test_cargo_metadata.rs
+++ b/tests/test_cargo_metadata.rs
@@ -1,6 +1,6 @@
 use hamcrest::assert_that;
 use support::registry::Package;
-use support::{project, execs, basic_bin_manifest, main_file, ERROR};
+use support::{project, execs, basic_bin_manifest, main_file};
 
 
 fn setup() {}
@@ -178,11 +178,10 @@ test!(cargo_metadata_with_invalid_manifest {
 
     assert_that(p.cargo_process("metadata"), execs().with_status(101)
                                                     .with_stderr(&format!("\
-{error} failed to parse manifest at `[..]`
+[ERROR] failed to parse manifest at `[..]`
 
 Caused by:
-  no `package` or `project` section found.",
-  error = ERROR)))
+  no `package` or `project` section found.")))
 });
 
 const MANIFEST_OUTPUT: &'static str=
@@ -239,9 +238,8 @@ test!(cargo_metadata_no_deps_path_to_cargo_toml_parent_relative {
                  .arg("--manifest-path").arg("foo")
                  .cwd(p.root().parent().unwrap()),
                 execs().with_status(101)
-                       .with_stderr(&format!("{error} the manifest-path must be \
-                                             a path to a Cargo.toml file",
-                                             error = ERROR)));
+                       .with_stderr(&format!("[ERROR] the manifest-path must be \
+                                             a path to a Cargo.toml file")));
 });
 
 test!(cargo_metadata_no_deps_path_to_cargo_toml_parent_absolute {
@@ -253,9 +251,8 @@ test!(cargo_metadata_no_deps_path_to_cargo_toml_parent_absolute {
                  .arg("--manifest-path").arg(p.root())
                  .cwd(p.root().parent().unwrap()),
                 execs().with_status(101)
-                       .with_stderr(&format!("{error} the manifest-path must be \
-                                             a path to a Cargo.toml file",
-                                             error = ERROR)));
+                       .with_stderr(&format!("[ERROR] the manifest-path must be \
+                                             a path to a Cargo.toml file")));
 });
 
 test!(cargo_metadata_no_deps_cwd {
@@ -278,6 +275,5 @@ test!(carg_metadata_bad_version {
                  .arg("--format-version").arg("2")
                  .cwd(p.root()),
                 execs().with_status(101)
-    .with_stderr(&format!("{error} metadata version 2 not supported, only 1 is currently supported",
-                          error = ERROR)));
+    .with_stderr("[ERROR] metadata version 2 not supported, only 1 is currently supported"));
 });

--- a/tests/test_cargo_new.rs
+++ b/tests/test_cargo_new.rs
@@ -3,7 +3,7 @@ use std::io::prelude::*;
 use std::env;
 use tempdir::TempDir;
 
-use support::{execs, paths, ERROR};
+use support::{execs, paths};
 use support::paths::CargoPathExt;
 use hamcrest::{assert_that, existing_file, existing_dir, is_not};
 
@@ -68,13 +68,12 @@ test!(no_argument {
     assert_that(cargo_process("new"),
                 execs().with_status(1)
                        .with_stderr(&format!("\
-{error} Invalid arguments.
+[ERROR] Invalid arguments.
 
 Usage:
     cargo new [options] <path>
     cargo new -h | --help
-",
-error = ERROR)));
+")));
 });
 
 test!(existing {
@@ -82,26 +81,24 @@ test!(existing {
     fs::create_dir(&dst).unwrap();
     assert_that(cargo_process("new").arg("foo"),
                 execs().with_status(101)
-                       .with_stderr(format!("{error} destination `{}` already exists\n",
-                                            dst.display(), error = ERROR)));
+                       .with_stderr(format!("[ERROR] destination `{}` already exists\n",
+                                            dst.display())));
 });
 
 test!(invalid_characters {
     assert_that(cargo_process("new").arg("foo.rs"),
                 execs().with_status(101)
                        .with_stderr(&format!("\
-{error} Invalid character `.` in crate name: `foo.rs`
-use --name to override crate name",
-error = ERROR)));
+[ERROR] Invalid character `.` in crate name: `foo.rs`
+use --name to override crate name")));
 });
 
 test!(reserved_name {
     assert_that(cargo_process("new").arg("test"),
                 execs().with_status(101)
                        .with_stderr(&format!("\
-{error} The name `test` cannot be used as a crate name\n\
-use --name to override crate name",
-error = ERROR)));
+[ERROR] The name `test` cannot be used as a crate name\n\
+use --name to override crate name")));
 });
 
 test!(rust_prefix_stripped {
@@ -285,11 +282,10 @@ test!(unknown_flags {
     assert_that(cargo_process("new").arg("foo").arg("--flag"),
                 execs().with_status(1)
                        .with_stderr(&format!("\
-{error} Unknown flag: '--flag'
+[ERROR] Unknown flag: '--flag'
 
 Usage:
     cargo new [..]
     cargo new [..]
-",
-error = ERROR)));
+")));
 });

--- a/tests/test_cargo_overrides.rs
+++ b/tests/test_cargo_overrides.rs
@@ -1,7 +1,7 @@
 use hamcrest::assert_that;
 
 use support::registry::{registry, Package};
-use support::{execs, project, UPDATING, DOWNLOADING, COMPILING};
+use support::{execs, project, DOWNLOADING};
 use support::git;
 use support::paths;
 
@@ -42,12 +42,11 @@ test!(override_simple {
 
     assert_that(p.cargo_process("build"),
                 execs().with_status(0).with_stdout(&format!("\
-{updating} registry `file://[..]`
-{updating} git repository `[..]`
-{compiling} foo v0.1.0 (file://[..])
-{compiling} local v0.0.1 (file://[..])
-",
-    updating = UPDATING, compiling = COMPILING)));
+[UPDATING] registry `file://[..]`
+[UPDATING] git repository `[..]`
+[COMPILING] foo v0.1.0 (file://[..])
+[COMPILING] local v0.0.1 (file://[..])
+")));
 });
 
 test!(missing_version {
@@ -137,14 +136,13 @@ test!(transitive {
 
     assert_that(p.cargo_process("build"),
                 execs().with_status(0).with_stdout(&format!("\
-{updating} registry `file://[..]`
-{updating} git repository `[..]`
+[UPDATING] registry `file://[..]`
+[UPDATING] git repository `[..]`
 {downloading} bar v0.2.0 (registry [..])
-{compiling} foo v0.1.0 (file://[..])
-{compiling} bar v0.2.0 (registry [..])
-{compiling} local v0.0.1 (file://[..])
-",
-    updating = UPDATING, downloading = DOWNLOADING, compiling = COMPILING)));
+[COMPILING] foo v0.1.0 (file://[..])
+[COMPILING] bar v0.2.0 (registry [..])
+[COMPILING] local v0.0.1 (file://[..])
+", downloading = DOWNLOADING)));
 
     assert_that(p.cargo("build"), execs().with_status(0).with_stdout(""));
 });
@@ -184,12 +182,11 @@ test!(persists_across_rebuilds {
 
     assert_that(p.cargo_process("build"),
                 execs().with_status(0).with_stdout(&format!("\
-{updating} registry `file://[..]`
-{updating} git repository `file://[..]`
-{compiling} foo v0.1.0 (file://[..])
-{compiling} local v0.0.1 (file://[..])
-",
-    updating = UPDATING, compiling = COMPILING)));
+[UPDATING] registry `file://[..]`
+[UPDATING] git repository `file://[..]`
+[COMPILING] foo v0.1.0 (file://[..])
+[COMPILING] local v0.0.1 (file://[..])
+")));
 
     assert_that(p.cargo("build"),
                 execs().with_status(0).with_stdout(""));
@@ -230,11 +227,10 @@ test!(replace_registry_with_path {
 
     assert_that(p.cargo_process("build"),
                 execs().with_status(0).with_stdout(&format!("\
-{updating} registry `file://[..]`
-{compiling} foo v0.1.0 (file://[..])
-{compiling} local v0.0.1 (file://[..])
-",
-    compiling = COMPILING, updating = UPDATING)));
+[UPDATING] registry `file://[..]`
+[COMPILING] foo v0.1.0 (file://[..])
+[COMPILING] local v0.0.1 (file://[..])
+")));
 });
 
 test!(use_a_spec_to_select {
@@ -286,16 +282,15 @@ test!(use_a_spec_to_select {
 
     assert_that(p.cargo_process("build"),
                 execs().with_status(0).with_stdout(&format!("\
-{updating} registry `file://[..]`
-{updating} git repository `[..]`
+[UPDATING] registry `file://[..]`
+[UPDATING] git repository `[..]`
 {downloading} [..]
 {downloading} [..]
-{compiling} [..]
-{compiling} [..]
-{compiling} [..]
-{compiling} local v0.0.1 (file://[..])
-",
-    updating = UPDATING, downloading = DOWNLOADING, compiling = COMPILING)));
+[COMPILING] [..]
+[COMPILING] [..]
+[COMPILING] [..]
+[COMPILING] local v0.0.1 (file://[..])
+", downloading = DOWNLOADING)));
 });
 
 test!(override_adds_some_deps {
@@ -332,26 +327,25 @@ test!(override_adds_some_deps {
 
     assert_that(p.cargo_process("build"),
                 execs().with_status(0).with_stdout(&format!("\
-{updating} registry `file://[..]`
-{updating} git repository `[..]`
+[UPDATING] registry `file://[..]`
+[UPDATING] git repository `[..]`
 {downloading} foo v0.1.1 (registry [..])
-{compiling} foo v0.1.1 (registry [..])
-{compiling} bar v0.1.0 ([..])
-{compiling} local v0.0.1 (file://[..])
-",
-    updating = UPDATING, downloading = DOWNLOADING, compiling = COMPILING)));
+[COMPILING] foo v0.1.1 (registry [..])
+[COMPILING] bar v0.1.0 ([..])
+[COMPILING] local v0.0.1 (file://[..])
+", downloading = DOWNLOADING)));
 
     assert_that(p.cargo("build"), execs().with_status(0).with_stdout(""));
 
     Package::new("foo", "0.1.2").publish();
     assert_that(p.cargo("update").arg("-p").arg(&format!("{}#bar", foo.url())),
                 execs().with_status(0).with_stdout(&format!("\
-{updating} git repository `file://[..]`
-", updating = UPDATING)));
+[UPDATING] git repository `file://[..]`
+")));
     assert_that(p.cargo("update").arg("-p").arg(&format!("{}#bar", registry())),
                 execs().with_status(0).with_stdout(&format!("\
-{updating} registry `file://[..]`
-", updating = UPDATING)));
+[UPDATING] registry `file://[..]`
+")));
 
     assert_that(p.cargo("build"), execs().with_status(0).with_stdout(""));
 });

--- a/tests/test_cargo_package.rs
+++ b/tests/test_cargo_package.rs
@@ -7,7 +7,7 @@ use git2;
 use tar::Archive;
 
 use support::{project, execs, paths, git, path2url};
-use support::{PACKAGING, VERIFYING, COMPILING, ARCHIVING};
+use support::{PACKAGING, VERIFYING, ARCHIVING};
 use hamcrest::{assert_that, existing_file};
 
 fn setup() {
@@ -33,11 +33,10 @@ test!(simple {
                 execs().with_status(0).with_stdout(&format!("\
 {packaging} foo v0.0.1 ({dir})
 {verifying} foo v0.0.1 ({dir})
-{compiling} foo v0.0.1 ({dir}[..])
+[COMPILING] foo v0.0.1 ({dir}[..])
 ",
         packaging = PACKAGING,
         verifying = VERIFYING,
-        compiling = COMPILING,
         dir = p.url())));
     assert_that(&p.root().join("target/package/foo-0.0.1.crate"), existing_file());
     assert_that(p.cargo("package").arg("-l"),
@@ -78,11 +77,10 @@ test!(metadata_warning {
                 execs().with_status(0).with_stdout(&format!("\
 {packaging} foo v0.0.1 ({dir})
 {verifying} foo v0.0.1 ({dir})
-{compiling} foo v0.0.1 ({dir}[..])
+[COMPILING] foo v0.0.1 ({dir}[..])
 ",
         packaging = PACKAGING,
         verifying = VERIFYING,
-        compiling = COMPILING,
         dir = p.url()))
                 .with_stderr("\
 warning: manifest has no description, license, license-file, documentation, \
@@ -104,11 +102,10 @@ http://doc.crates.io/manifest.html#package-metadata for more info."));
                 execs().with_status(0).with_stdout(&format!("\
 {packaging} foo v0.0.1 ({dir})
 {verifying} foo v0.0.1 ({dir})
-{compiling} foo v0.0.1 ({dir}[..])
+[COMPILING] foo v0.0.1 ({dir}[..])
 ",
         packaging = PACKAGING,
         verifying = VERIFYING,
-        compiling = COMPILING,
         dir = p.url()))
                 .with_stderr("\
 warning: manifest has no description, documentation, homepage or repository. See \
@@ -131,11 +128,10 @@ http://doc.crates.io/manifest.html#package-metadata for more info."));
                 execs().with_status(0).with_stdout(&format!("\
 {packaging} foo v0.0.1 ({dir})
 {verifying} foo v0.0.1 ({dir})
-{compiling} foo v0.0.1 ({dir}[..])
+[COMPILING] foo v0.0.1 ({dir}[..])
 ",
         packaging = PACKAGING,
         verifying = VERIFYING,
-        compiling = COMPILING,
         dir = p.url())));
 });
 
@@ -202,11 +198,10 @@ test!(package_verification {
                 execs().with_status(0).with_stdout(&format!("\
 {packaging} foo v0.0.1 ({dir})
 {verifying} foo v0.0.1 ({dir})
-{compiling} foo v0.0.1 ({dir}[..])
+[COMPILING] foo v0.0.1 ({dir}[..])
 ",
         packaging = PACKAGING,
         verifying = VERIFYING,
-        compiling = COMPILING,
         dir = p.url())));
 });
 
@@ -379,11 +374,10 @@ test!(ignore_nested {
                 execs().with_status(0).with_stdout(&format!("\
 {packaging} nested v0.0.1 ({dir})
 {verifying} nested v0.0.1 ({dir})
-{compiling} nested v0.0.1 ({dir}[..])
+[COMPILING] nested v0.0.1 ({dir}[..])
 ",
         packaging = PACKAGING,
         verifying = VERIFYING,
-        compiling = COMPILING,
         dir = p.url())));
     assert_that(&p.root().join("target/package/nested-0.0.1.crate"), existing_file());
     assert_that(p.cargo("package").arg("-l"),
@@ -411,8 +405,6 @@ src[..]main.rs
 
 #[cfg(unix)] // windows doesn't allow these characters in filenames
 test!(package_weird_characters {
-
-    use support::ERROR;
     let p = project("foo")
         .file("Cargo.toml", r#"
             [project]
@@ -428,10 +420,9 @@ test!(package_weird_characters {
     assert_that(p.cargo_process("package"),
                 execs().with_status(101).with_stderr(format!("\
 warning: [..]
-{error} failed to prepare local package for uploading
+[ERROR] failed to prepare local package for uploading
 
 Caused by:
   cannot package a filename with a special character `:`: src/:foo
-",
-error = ERROR)));
+")));
 });

--- a/tests/test_cargo_profiles.rs
+++ b/tests/test_cargo_profiles.rs
@@ -2,7 +2,6 @@ use std::env;
 use std::path::MAIN_SEPARATOR as SEP;
 
 use support::{project, execs};
-use support::{COMPILING, RUNNING};
 use hamcrest::assert_that;
 
 fn setup() {
@@ -26,8 +25,8 @@ test!(profile_overrides {
         .file("src/lib.rs", "");
     assert_that(p.cargo_process("build").arg("-v"),
                 execs().with_status(0).with_stdout(&format!("\
-{compiling} test v0.0.0 ({url})
-{running} `rustc src{sep}lib.rs --crate-name test --crate-type lib \
+[COMPILING] test v0.0.0 ({url})
+[RUNNING] `rustc src{sep}lib.rs --crate-name test --crate-type lib \
         -C opt-level=1 \
         -C debug-assertions=on \
         -C rpath \
@@ -35,8 +34,7 @@ test!(profile_overrides {
         --emit=dep-info,link \
         -L dependency={dir}{sep}target{sep}debug \
         -L dependency={dir}{sep}target{sep}debug{sep}deps`
-",
-running = RUNNING, compiling = COMPILING, sep = SEP,
+", sep = SEP,
 dir = p.root().display(),
 url = p.url(),
 )));
@@ -78,8 +76,8 @@ test!(top_level_overrides_deps {
         .file("foo/src/lib.rs", "");
     assert_that(p.cargo_process("build").arg("-v").arg("--release"),
                 execs().with_status(0).with_stdout(&format!("\
-{compiling} foo v0.0.0 ({url}/foo)
-{running} `rustc foo{sep}src{sep}lib.rs --crate-name foo \
+[COMPILING] foo v0.0.0 ({url}/foo)
+[RUNNING] `rustc foo{sep}src{sep}lib.rs --crate-name foo \
         --crate-type dylib --crate-type rlib -C prefer-dynamic \
         -C opt-level=1 \
         -g \
@@ -89,8 +87,8 @@ test!(top_level_overrides_deps {
         --emit=dep-info,link \
         -L dependency={dir}{sep}target{sep}release{sep}deps \
         -L dependency={dir}{sep}target{sep}release{sep}deps`
-{compiling} test v0.0.0 ({url})
-{running} `rustc src{sep}lib.rs --crate-name test --crate-type lib \
+[COMPILING] test v0.0.0 ({url})
+[RUNNING] `rustc src{sep}lib.rs --crate-name test --crate-type lib \
         -C opt-level=1 \
         -g \
         --out-dir {dir}{sep}target{sep}release \
@@ -101,8 +99,6 @@ test!(top_level_overrides_deps {
                      {prefix}foo-[..]{suffix} \
         --extern foo={dir}{sep}target{sep}release{sep}deps{sep}libfoo-[..].rlib`
 ",
-                    running = RUNNING,
-                    compiling = COMPILING,
                     dir = p.root().display(),
                     url = p.url(),
                     sep = SEP,

--- a/tests/test_cargo_publish.rs
+++ b/tests/test_cargo_publish.rs
@@ -8,7 +8,7 @@ use tar::Archive;
 use url::Url;
 
 use support::{project, execs};
-use support::{UPDATING, PACKAGING, UPLOADING, ERROR};
+use support::{PACKAGING, UPLOADING};
 use support::paths;
 use support::git::repo;
 
@@ -51,11 +51,10 @@ test!(simple {
 
     assert_that(p.cargo_process("publish").arg("--no-verify"),
                 execs().with_status(0).with_stdout(&format!("\
-{updating} registry `{reg}`
+[UPDATING] registry `{reg}`
 {packaging} foo v0.0.1 ({dir})
 {uploading} foo v0.0.1 ({dir})
 ",
-        updating = UPDATING,
         uploading = UPLOADING,
         packaging = PACKAGING,
         dir = p.url(),
@@ -104,10 +103,9 @@ test!(git_deps {
 
     assert_that(p.cargo_process("publish").arg("-v").arg("--no-verify"),
                 execs().with_status(101).with_stderr(&format!("\
-{error} all dependencies must come from the same source.
+[ERROR] all dependencies must come from the same source.
 dependency `foo` comes from git://path/to/nowhere instead
-",
-error = ERROR)));
+")));
 });
 
 test!(path_dependency_no_version {
@@ -134,10 +132,9 @@ test!(path_dependency_no_version {
 
     assert_that(p.cargo_process("publish"),
                 execs().with_status(101).with_stderr(&format!("\
-{error} all path dependencies must have a version specified when publishing.
+[ERROR] all path dependencies must have a version specified when publishing.
 dependency `bar` does not specify a version
-",
-error = ERROR)));
+")));
 });
 
 test!(unpublishable_crate {
@@ -155,8 +152,7 @@ test!(unpublishable_crate {
 
     assert_that(p.cargo_process("publish"),
                 execs().with_status(101).with_stderr(&format!("\
-{error} some crates cannot be published.
+[ERROR] some crates cannot be published.
 `foo` is marked as unpublishable
-",
-error = ERROR)));
+")));
 });

--- a/tests/test_cargo_read_manifest.rs
+++ b/tests/test_cargo_read_manifest.rs
@@ -1,4 +1,4 @@
-use support::{project, execs, main_file, basic_bin_manifest, ERROR};
+use support::{project, execs, main_file, basic_bin_manifest};
 use hamcrest::{assert_that};
 
 fn setup() {}
@@ -58,8 +58,8 @@ test!(cargo_read_manifest_path_to_cargo_toml_parent_relative {
                  .arg("--manifest-path").arg("foo")
                  .cwd(p.root().parent().unwrap()),
                 execs().with_status(101)
-                       .with_stderr(&format!("{error} the manifest-path must be \
-                                             a path to a Cargo.toml file", error = ERROR)));
+                       .with_stderr(&format!("[ERROR] the manifest-path must be \
+                                             a path to a Cargo.toml file")));
 });
 
 test!(cargo_read_manifest_path_to_cargo_toml_parent_absolute {
@@ -71,8 +71,8 @@ test!(cargo_read_manifest_path_to_cargo_toml_parent_absolute {
                  .arg("--manifest-path").arg(p.root())
                  .cwd(p.root().parent().unwrap()),
                 execs().with_status(101)
-                       .with_stderr(&format!("{error} the manifest-path must be \
-                                             a path to a Cargo.toml file", error = ERROR)));
+                       .with_stderr(&format!("[ERROR] the manifest-path must be \
+                                             a path to a Cargo.toml file")));
 });
 
 test!(cargo_read_manifest_cwd {

--- a/tests/test_cargo_run.rs
+++ b/tests/test_cargo_run.rs
@@ -1,7 +1,6 @@
 use std::path::MAIN_SEPARATOR as SEP;
 
 use support::{project, execs, path2url};
-use support::{COMPILING, RUNNING, ERROR};
 use hamcrest::{assert_that, existing_file};
 
 fn setup() {
@@ -21,12 +20,10 @@ test!(simple {
 
     assert_that(p.cargo_process("run"),
                 execs().with_status(0).with_stdout(&format!("\
-{compiling} foo v0.0.1 ({dir})
-{running} `target{sep}debug{sep}foo[..]`
+[COMPILING] foo v0.0.1 ({dir})
+[RUNNING] `target{sep}debug{sep}foo[..]`
 hello
 ",
-        compiling = COMPILING,
-        running = RUNNING,
         dir = path2url(p.root()),
         sep = SEP)));
     assert_that(&p.bin("foo"), existing_file());
@@ -65,9 +62,8 @@ test!(simple_quiet_and_verbose {
 
     assert_that(p.cargo_process("run").arg("-q").arg("-v"),
                 execs().with_status(101).with_stderr(&format!("\
-{error} cannot set both --verbose and --quiet
-",
-error = ERROR)));
+[ERROR] cannot set both --verbose and --quiet
+")));
 });
 
 test!(quiet_and_verbose_config {
@@ -124,9 +120,8 @@ test!(exit_code {
     assert_that(p.cargo_process("run"),
                 execs().with_status(2)
                        .with_stderr(&format!("\
-{error} Process didn't exit successfully: `target[..]foo[..]` (exit code: 2)
-",
-error = ERROR)));
+[ERROR] Process didn't exit successfully: `target[..]foo[..]` (exit code: 2)
+")));
 });
 
 test!(exit_code_verbose {
@@ -144,9 +139,8 @@ test!(exit_code_verbose {
     assert_that(p.cargo_process("run").arg("-v"),
                 execs().with_status(2)
                        .with_stderr(&format!("\
-{error} Process didn't exit successfully: `target[..]foo[..]` (exit code: 2)
-",
-error = ERROR)));
+[ERROR] Process didn't exit successfully: `target[..]foo[..]` (exit code: 2)
+")));
 });
 
 test!(no_main_file {
@@ -161,8 +155,8 @@ test!(no_main_file {
 
     assert_that(p.cargo_process("run"),
                 execs().with_status(101)
-                       .with_stderr(&format!("{error} a bin target must be available \
-                                     for `cargo run`\n", error = ERROR)));
+                       .with_stderr(&format!("[ERROR] a bin target must be available \
+                                     for `cargo run`\n")));
 });
 
 test!(too_many_bins {
@@ -179,9 +173,9 @@ test!(too_many_bins {
 
     assert_that(p.cargo_process("run"),
                 execs().with_status(101)
-                       .with_stderr(&format!("{error} `cargo run` requires that a project only \
+                       .with_stderr(&format!("[ERROR] `cargo run` requires that a project only \
                                      have one executable; use the `--bin` option \
-                                     to specify which one to run\n", error = ERROR)));
+                                     to specify which one to run\n")));
 });
 
 test!(specify_name {
@@ -204,25 +198,22 @@ test!(specify_name {
 
     assert_that(p.cargo_process("run").arg("--bin").arg("a").arg("-v"),
                 execs().with_status(0).with_stdout(&format!("\
-{compiling} foo v0.0.1 ({dir})
-{running} `rustc src[..]lib.rs [..]`
-{running} `rustc src[..]a.rs [..]`
-{running} `target{sep}debug{sep}a[..]`
+[COMPILING] foo v0.0.1 ({dir})
+[RUNNING] `rustc src[..]lib.rs [..]`
+[RUNNING] `rustc src[..]a.rs [..]`
+[RUNNING] `target{sep}debug{sep}a[..]`
 hello a.rs
 ",
-        compiling = COMPILING,
-        running = RUNNING,
         dir = path2url(p.root()),
         sep = SEP)));
 
     assert_that(p.cargo("run").arg("--bin").arg("b").arg("-v"),
                 execs().with_status(0).with_stdout(&format!("\
-{compiling} foo v0.0.1 ([..])
-{running} `rustc src[..]b.rs [..]`
-{running} `target{sep}debug{sep}b[..]`
+[COMPILING] foo v0.0.1 ([..])
+[RUNNING] `rustc src[..]b.rs [..]`
+[RUNNING] `target{sep}debug{sep}b[..]`
 hello b.rs
 ",
-        running = RUNNING, compiling = COMPILING,
         sep = SEP)));
 });
 
@@ -244,12 +235,10 @@ test!(run_example {
 
     assert_that(p.cargo_process("run").arg("--example").arg("a"),
                 execs().with_status(0).with_stdout(&format!("\
-{compiling} foo v0.0.1 ({dir})
-{running} `target{sep}debug{sep}examples{sep}a[..]`
+[COMPILING] foo v0.0.1 ({dir})
+[RUNNING] `target{sep}debug{sep}examples{sep}a[..]`
 example
 ",
-        compiling = COMPILING,
-        running = RUNNING,
         dir = path2url(p.root()),
         sep = SEP)));
 });
@@ -273,23 +262,23 @@ test!(run_with_filename {
 
     assert_that(p.cargo_process("run").arg("--bin").arg("bin.rs"),
                 execs().with_status(101).with_stderr(&format!("\
-{error} no bin target named `bin.rs`", error = ERROR)));
+[ERROR] no bin target named `bin.rs`")));
 
     assert_that(p.cargo_process("run").arg("--bin").arg("a.rs"),
                 execs().with_status(101).with_stderr(&format!("\
-{error} no bin target named `a.rs`
+[ERROR] no bin target named `a.rs`
 
-Did you mean `a`?", error = ERROR)));
+Did you mean `a`?")));
 
     assert_that(p.cargo_process("run").arg("--example").arg("example.rs"),
                 execs().with_status(101).with_stderr(&format!("\
-{error} no example target named `example.rs`", error = ERROR)));
+[ERROR] no example target named `example.rs`")));
 
     assert_that(p.cargo_process("run").arg("--example").arg("a.rs"),
                 execs().with_status(101).with_stderr(&format!("\
-{error} no example target named `a.rs`
+[ERROR] no example target named `a.rs`
 
-Did you mean `a`?", error = ERROR)));
+Did you mean `a`?")));
 });
 
 test!(either_name_or_example {
@@ -309,10 +298,9 @@ test!(either_name_or_example {
 
     assert_that(p.cargo_process("run").arg("--bin").arg("a").arg("--example").arg("b"),
                 execs().with_status(101)
-                       .with_stderr(&format!("{error} `cargo run` can run at most one \
+                       .with_stderr(&format!("[ERROR] `cargo run` can run at most one \
                                      executable, but multiple were \
-                                     specified",
-                                     error = ERROR)));
+                                     specified")));
 });
 
 test!(one_bin_multiple_examples {
@@ -336,12 +324,10 @@ test!(one_bin_multiple_examples {
 
     assert_that(p.cargo_process("run"),
                 execs().with_status(0).with_stdout(&format!("\
-{compiling} foo v0.0.1 ({dir})
-{running} `target{sep}debug{sep}main[..]`
+[COMPILING] foo v0.0.1 ({dir})
+[RUNNING] `target{sep}debug{sep}main[..]`
 hello main.rs
 ",
-        compiling = COMPILING,
-        running = RUNNING,
         dir = path2url(p.root()),
         sep = SEP)));
 });
@@ -391,8 +377,8 @@ test!(example_with_release_flag {
 
     assert_that(p.cargo_process("run").arg("-v").arg("--release").arg("--example").arg("a"),
                 execs().with_status(0).with_stdout(&format!("\
-{compiling} bar v0.0.1 ({url}/bar)
-{running} `rustc bar{sep}src{sep}bar.rs --crate-name bar --crate-type lib \
+[COMPILING] bar v0.0.1 ({url}/bar)
+[RUNNING] `rustc bar{sep}src{sep}bar.rs --crate-name bar --crate-type lib \
         -C opt-level=3 \
         -C metadata=[..] \
         -C extra-filename=[..] \
@@ -400,28 +386,26 @@ test!(example_with_release_flag {
         --emit=dep-info,link \
         -L dependency={dir}{sep}target{sep}release{sep}deps \
         -L dependency={dir}{sep}target{sep}release{sep}deps`
-{compiling} foo v0.0.1 ({url})
-{running} `rustc examples{sep}a.rs --crate-name a --crate-type bin \
+[COMPILING] foo v0.0.1 ({url})
+[RUNNING] `rustc examples{sep}a.rs --crate-name a --crate-type bin \
         -C opt-level=3 \
         --out-dir {dir}{sep}target{sep}release{sep}examples \
         --emit=dep-info,link \
         -L dependency={dir}{sep}target{sep}release \
         -L dependency={dir}{sep}target{sep}release{sep}deps \
          --extern bar={dir}{sep}target{sep}release{sep}deps{sep}libbar-[..].rlib`
-{running} `target{sep}release{sep}examples{sep}a[..]`
+[RUNNING] `target{sep}release{sep}examples{sep}a[..]`
 fast1
 fast2
 ",
-        compiling = COMPILING,
-        running = RUNNING,
         dir = p.root().display(),
         url = path2url(p.root()),
         sep = SEP)));
 
     assert_that(p.cargo("run").arg("-v").arg("--example").arg("a"),
                 execs().with_status(0).with_stdout(&format!("\
-{compiling} bar v0.0.1 ({url}/bar)
-{running} `rustc bar{sep}src{sep}bar.rs --crate-name bar --crate-type lib \
+[COMPILING] bar v0.0.1 ({url}/bar)
+[RUNNING] `rustc bar{sep}src{sep}bar.rs --crate-name bar --crate-type lib \
         -g \
         -C metadata=[..] \
         -C extra-filename=[..] \
@@ -429,20 +413,18 @@ fast2
         --emit=dep-info,link \
         -L dependency={dir}{sep}target{sep}debug{sep}deps \
         -L dependency={dir}{sep}target{sep}debug{sep}deps`
-{compiling} foo v0.0.1 ({url})
-{running} `rustc examples{sep}a.rs --crate-name a --crate-type bin \
+[COMPILING] foo v0.0.1 ({url})
+[RUNNING] `rustc examples{sep}a.rs --crate-name a --crate-type bin \
         -g \
         --out-dir {dir}{sep}target{sep}debug{sep}examples \
         --emit=dep-info,link \
         -L dependency={dir}{sep}target{sep}debug \
         -L dependency={dir}{sep}target{sep}debug{sep}deps \
          --extern bar={dir}{sep}target{sep}debug{sep}deps{sep}libbar-[..].rlib`
-{running} `target{sep}debug{sep}examples{sep}a[..]`
+[RUNNING] `target{sep}debug{sep}examples{sep}a[..]`
 slow1
 slow2
 ",
-        compiling = COMPILING,
-        running = RUNNING,
         dir = p.root().display(),
         url = path2url(p.root()),
         sep = SEP)));
@@ -493,11 +475,9 @@ test!(release_works {
 
     assert_that(p.cargo_process("run").arg("--release"),
                 execs().with_status(0).with_stdout(&format!("\
-{compiling} foo v0.0.1 ({dir})
-{running} `target{sep}release{sep}foo[..]`
+[COMPILING] foo v0.0.1 ({dir})
+[RUNNING] `target{sep}release{sep}foo[..]`
 ",
-        compiling = COMPILING,
-        running = RUNNING,
         dir = path2url(p.root()),
         sep = SEP)));
     assert_that(&p.release_bin("foo"), existing_file());
@@ -562,10 +542,9 @@ test!(run_from_executable_folder {
 
     assert_that(p.cargo("run").cwd(cwd),
                 execs().with_status(0).with_stdout(&format!("\
-{running} `.{sep}foo[..]`
+[RUNNING] `.{sep}foo[..]`
 hello
 ",
-        running = RUNNING,
         sep = SEP
         )));
 });

--- a/tests/test_cargo_rustc.rs
+++ b/tests/test_cargo_rustc.rs
@@ -1,7 +1,6 @@
 use std::path::MAIN_SEPARATOR as SEP;
 
 use support::{execs, project};
-use support::{COMPILING, RUNNING, ERROR};
 
 use hamcrest::assert_that;
 
@@ -9,9 +8,9 @@ fn setup() {
 }
 
 fn cargo_rustc_error() -> String {
-    format!("{error} extra arguments to `rustc` can only be passed to one target, \
+    format!("[ERROR] extra arguments to `rustc` can only be passed to one target, \
     consider filtering\nthe package by passing e.g. `--lib` or `--bin NAME` to \
-    specify a single target", error = ERROR)
+    specify a single target")
 }
 
 test!(build_lib_for_foo {
@@ -31,14 +30,13 @@ test!(build_lib_for_foo {
                 execs()
                 .with_status(0)
                 .with_stdout(format!("\
-{compiling} foo v0.0.1 ({url})
-{running} `rustc src{sep}lib.rs --crate-name foo --crate-type lib -g \
+[COMPILING] foo v0.0.1 ({url})
+[RUNNING] `rustc src{sep}lib.rs --crate-name foo --crate-type lib -g \
         --out-dir {dir}{sep}target{sep}debug \
         --emit=dep-info,link \
         -L dependency={dir}{sep}target{sep}debug \
         -L dependency={dir}{sep}target{sep}debug{sep}deps`
-",
-            running = RUNNING, compiling = COMPILING, sep = SEP,
+", sep = SEP,
             dir = p.root().display(), url = p.url())));
 });
 
@@ -60,15 +58,14 @@ test!(build_lib_and_allow_unstable_options {
                 execs()
                 .with_status(0)
                 .with_stdout(format!("\
-{compiling} foo v0.0.1 ({url})
-{running} `rustc src{sep}lib.rs --crate-name foo --crate-type lib -g \
+[COMPILING] foo v0.0.1 ({url})
+[RUNNING] `rustc src{sep}lib.rs --crate-name foo --crate-type lib -g \
         -Z unstable-options \
         --out-dir {dir}{sep}target{sep}debug \
         --emit=dep-info,link \
         -L dependency={dir}{sep}target{sep}debug \
         -L dependency={dir}{sep}target{sep}debug{sep}deps`
-",
-            running = RUNNING, compiling = COMPILING, sep = SEP,
+", sep = SEP,
             dir = p.root().display(), url = p.url())))
 });
 
@@ -90,21 +87,20 @@ test!(build_main_and_allow_unstable_options {
                 execs()
                 .with_status(0)
                 .with_stdout(&format!("\
-{compiling} {name} v{version} ({url})
-{running} `rustc src{sep}lib.rs --crate-name {name} --crate-type lib -g \
+[COMPILING] {name} v{version} ({url})
+[RUNNING] `rustc src{sep}lib.rs --crate-name {name} --crate-type lib -g \
         --out-dir {dir}{sep}target{sep}debug \
         --emit=dep-info,link \
         -L dependency={dir}{sep}target{sep}debug \
         -L dependency={dir}{sep}target{sep}debug{sep}deps`
-{running} `rustc src{sep}main.rs --crate-name {name} --crate-type bin -g \
+[RUNNING] `rustc src{sep}main.rs --crate-name {name} --crate-type bin -g \
         -Z unstable-options \
         --out-dir {dir}{sep}target{sep}debug \
         --emit=dep-info,link \
         -L dependency={dir}{sep}target{sep}debug \
         -L dependency={dir}{sep}target{sep}debug{sep}deps \
         --extern {name}={dir}{sep}target{sep}debug{sep}lib{name}.rlib`
-",
-            running = RUNNING, compiling = COMPILING, sep = SEP,
+", sep = SEP,
             dir = p.root().display(), url = p.url(),
             name = "foo", version = "0.0.1")));
 });
@@ -153,13 +149,12 @@ test!(build_with_args_to_one_of_multiple_binaries {
                 execs()
                 .with_status(0)
                 .with_stdout(format!("\
-{compiling} foo v0.0.1 ({url})
-{running} `rustc src{sep}lib.rs --crate-name foo --crate-type lib -g \
+[COMPILING] foo v0.0.1 ({url})
+[RUNNING] `rustc src{sep}lib.rs --crate-name foo --crate-type lib -g \
         --out-dir {dir}{sep}target{sep}debug [..]`
-{running} `rustc src{sep}bin{sep}bar.rs --crate-name bar --crate-type bin -g \
+[RUNNING] `rustc src{sep}bin{sep}bar.rs --crate-name bar --crate-type bin -g \
         -Z unstable-options [..]`
-",
-                compiling = COMPILING, running = RUNNING, sep = SEP,
+", sep = SEP,
                 dir = p.root().display(), url = p.url())));
 });
 
@@ -207,13 +202,12 @@ test!(build_with_args_to_one_of_multiple_tests {
                 execs()
                 .with_status(0)
                 .with_stdout(format!("\
-{compiling} foo v0.0.1 ({url})
-{running} `rustc src{sep}lib.rs --crate-name foo --crate-type lib -g \
+[COMPILING] foo v0.0.1 ({url})
+[RUNNING] `rustc src{sep}lib.rs --crate-name foo --crate-type lib -g \
         --out-dir {dir}{sep}target{sep}debug [..]`
-{running} `rustc tests{sep}bar.rs --crate-name bar --crate-type bin -g \
+[RUNNING] `rustc tests{sep}bar.rs --crate-name bar --crate-type bin -g \
         -Z unstable-options [..]--test[..]`
-",
-                compiling = COMPILING, running = RUNNING, sep = SEP,
+", sep = SEP,
                 dir = p.root().display(), url = p.url())));
 });
 
@@ -250,12 +244,11 @@ test!(build_foo_with_bar_dependency {
                 execs()
                 .with_status(0)
                 .with_stdout(format!("\
-{compiling} bar v0.1.0 ([..])
-{running} `[..] -g -C [..]`
-{compiling} foo v0.0.1 ({url})
-{running} `[..] -g -Z unstable-options [..]`
+[COMPILING] bar v0.1.0 ([..])
+[RUNNING] `[..] -g -C [..]`
+[COMPILING] foo v0.0.1 ({url})
+[RUNNING] `[..] -g -Z unstable-options [..]`
 ",
-                compiling = COMPILING, running = RUNNING,
                 url = foo.url())));
 });
 
@@ -293,10 +286,9 @@ test!(build_only_bar_dependency {
                 execs()
                 .with_status(0)
                 .with_stdout(format!("\
-{compiling} bar v0.1.0 ([..])
-{running} `[..]--crate-name bar --crate-type lib [..] -Z unstable-options [..]`
-",
-                compiling = COMPILING, running = RUNNING)));
+[COMPILING] bar v0.1.0 ([..])
+[RUNNING] `[..]--crate-name bar --crate-type lib [..] -Z unstable-options [..]`
+")));
 });
 
 test!(fail_with_multiple_packages {
@@ -349,10 +341,10 @@ test!(fail_with_multiple_packages {
     assert_that(foo.cargo("rustc").arg("-v").arg("-p").arg("bar")
                                           .arg("-p").arg("baz"),
                 execs().with_status(1).with_stderr(format!("\
-{error} Invalid arguments.
+[ERROR] Invalid arguments.
 
 Usage:
-    cargo rustc [options] [--] [<opts>...]", error = ERROR)));
+    cargo rustc [options] [--] [<opts>...]")));
 });
 
 test!(rustc_with_other_profile {

--- a/tests/test_cargo_rustdoc.rs
+++ b/tests/test_cargo_rustdoc.rs
@@ -1,6 +1,5 @@
 use std::path::MAIN_SEPARATOR as SEP;
 use support::{execs, project};
-use support::{COMPILING, RUNNING, DOCUMENTING, ERROR};
 use hamcrest::{assert_that};
 
 fn setup() {
@@ -21,13 +20,12 @@ test!(rustdoc_simple {
                 execs()
                 .with_status(0)
                 .with_stdout(format!("\
-{documenting} foo v0.0.1 ({url})
-{running} `rustdoc src{sep}lib.rs --crate-name foo \
+[DOCUMENTING] foo v0.0.1 ({url})
+[RUNNING] `rustdoc src{sep}lib.rs --crate-name foo \
         -o {dir}{sep}target{sep}doc \
         -L dependency={dir}{sep}target{sep}debug \
         -L dependency={dir}{sep}target{sep}debug{sep}deps`
-",
-            running = RUNNING, documenting = DOCUMENTING, sep = SEP,
+", sep = SEP,
             dir = p.root().display(), url = p.url())));
 });
 
@@ -45,14 +43,13 @@ test!(rustdoc_args {
                 execs()
                 .with_status(0)
                 .with_stdout(format!("\
-{documenting} foo v0.0.1 ({url})
-{running} `rustdoc src{sep}lib.rs --crate-name foo \
+[DOCUMENTING] foo v0.0.1 ({url})
+[RUNNING] `rustdoc src{sep}lib.rs --crate-name foo \
         -o {dir}{sep}target{sep}doc \
         --no-defaults \
         -L dependency={dir}{sep}target{sep}debug \
         -L dependency={dir}{sep}target{sep}debug{sep}deps`
-",
-            running = RUNNING, documenting = DOCUMENTING, sep = SEP,
+", sep = SEP,
             dir = p.root().display(), url = p.url())));
 });
 
@@ -89,18 +86,16 @@ test!(rustdoc_foo_with_bar_dependency {
                 execs()
                 .with_status(0)
                 .with_stdout(format!("\
-{compiling} bar v0.0.1 ([..])
-{running} `rustc [..]bar{sep}src{sep}lib.rs [..]`
-{documenting} foo v0.0.1 ({url})
-{running} `rustdoc src{sep}lib.rs --crate-name foo \
+[COMPILING] bar v0.0.1 ([..])
+[RUNNING] `rustc [..]bar{sep}src{sep}lib.rs [..]`
+[DOCUMENTING] foo v0.0.1 ({url})
+[RUNNING] `rustdoc src{sep}lib.rs --crate-name foo \
         -o {dir}{sep}target{sep}doc \
         --no-defaults \
         -L dependency={dir}{sep}target{sep}debug \
         -L dependency={dir}{sep}target{sep}debug{sep}deps \
         --extern [..]`
-",
-            running = RUNNING, compiling = COMPILING, sep = SEP,
-            documenting = DOCUMENTING,
+", sep = SEP,
             dir = foo.root().display(), url = foo.url())));
 });
 
@@ -138,14 +133,13 @@ test!(rustdoc_only_bar_dependency {
                 execs()
                 .with_status(0)
                 .with_stdout(format!("\
-{documenting} bar v0.0.1 ([..])
-{running} `rustdoc [..]bar{sep}src{sep}lib.rs --crate-name bar \
+[DOCUMENTING] bar v0.0.1 ([..])
+[RUNNING] `rustdoc [..]bar{sep}src{sep}lib.rs --crate-name bar \
         -o {dir}{sep}target{sep}doc \
         --no-defaults \
         -L dependency={dir}{sep}target{sep}debug{sep}deps \
         -L dependency={dir}{sep}target{sep}debug{sep}deps`
-",
-            running = RUNNING, documenting = DOCUMENTING, sep = SEP,
+", sep = SEP,
             dir = foo.root().display())));
 });
 
@@ -167,8 +161,7 @@ test!(rustdoc_same_name_err {
                  .arg("--").arg("--no-defaults"),
                 execs()
                 .with_status(101)
-                .with_stderr(&format!("{error} cannot document a package where a library and a \
+                .with_stderr(&format!("[ERROR] cannot document a package where a library and a \
                               binary have the same name. Consider renaming one \
-                              or marking the target as `doc = false`",
-                              error = ERROR)));
+                              or marking the target as `doc = false`")));
 });

--- a/tests/test_cargo_search.rs
+++ b/tests/test_cargo_search.rs
@@ -5,7 +5,6 @@ use std::path::PathBuf;
 use url::Url;
 
 use cargo::util::ProcessBuilder;
-use support::UPDATING;
 use support::execs;
 use support::paths;
 use support::git::repo;
@@ -82,8 +81,8 @@ test!(simple {
 
     assert_that(cargo_process("search").arg("postgres"),
                 execs().with_status(0).with_stdout(format!("\
-{updating} registry `[..]`
-hoare (0.1.1)    Design by contract style assertions for Rust", updating = UPDATING)));
+[UPDATING] registry `[..]`
+hoare (0.1.1)    Design by contract style assertions for Rust")));
 });
 
 test!(multiple_query_params {
@@ -128,8 +127,8 @@ test!(multiple_query_params {
 
     assert_that(cargo_process("search").arg("postgres").arg("sql"),
                 execs().with_status(0).with_stdout(format!("\
-{updating} registry `[..]`
-hoare (0.1.1)    Design by contract style assertions for Rust", updating = UPDATING)));
+[UPDATING] registry `[..]`
+hoare (0.1.1)    Design by contract style assertions for Rust")));
 });
 
 test!(help {

--- a/tests/test_cargo_test.rs
+++ b/tests/test_cargo_test.rs
@@ -3,7 +3,7 @@ use std::io::prelude::*;
 use std::str;
 
 use support::{project, execs, basic_bin_manifest, basic_lib_manifest};
-use support::{COMPILING, RUNNING, DOCTEST, ERROR};
+use support::{DOCTEST};
 use support::paths::CargoPathExt;
 use hamcrest::{assert_that, existing_file, is_not};
 use cargo::util::process;
@@ -35,17 +35,15 @@ test!(cargo_test_simple {
 
     assert_that(p.cargo("test"),
                 execs().with_stdout(format!("\
-{} foo v0.5.0 ({})
-{} target[..]foo-[..]
+[COMPILING] foo v0.5.0 ({})
+[RUNNING] target[..]foo-[..]
 
 running 1 test
 test test_hello ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
 
-",
-        COMPILING, p.url(),
-        RUNNING)));
+", p.url())));
 });
 
 test!(cargo_test_release {
@@ -82,20 +80,20 @@ test!(cargo_test_release {
 
     assert_that(p.cargo_process("test").arg("-v").arg("--release"),
                 execs().with_stdout(format!("\
-{compiling} bar v0.0.1 ({dir}/bar)
-{running} [..] -C opt-level=3 [..]
-{compiling} foo v0.1.0 ({dir})
-{running} [..] -C opt-level=3 [..]
-{running} [..] -C opt-level=3 [..]
-{running} [..] -C opt-level=3 [..]
-{running} `[..]target[..]foo-[..]`
+[COMPILING] bar v0.0.1 ({dir}/bar)
+[RUNNING] [..] -C opt-level=3 [..]
+[COMPILING] foo v0.1.0 ({dir})
+[RUNNING] [..] -C opt-level=3 [..]
+[RUNNING] [..] -C opt-level=3 [..]
+[RUNNING] [..] -C opt-level=3 [..]
+[RUNNING] `[..]target[..]foo-[..]`
 
 running 1 test
 test test ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
 
-{running} `[..]target[..]test-[..]`
+[RUNNING] `[..]target[..]test-[..]`
 
 running 1 test
 test test ... ok
@@ -103,14 +101,13 @@ test test ... ok
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
 
 {doctest} foo
-{running} `rustdoc --test [..]lib.rs[..]`
+[RUNNING] `rustdoc --test [..]lib.rs[..]`
 
 running 0 tests
 
 test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
 
-",
-compiling = COMPILING, dir = p.url(), running = RUNNING, doctest = DOCTEST)));
+", dir = p.url(), doctest = DOCTEST)));
 });
 
 test!(cargo_test_verbose {
@@ -123,17 +120,16 @@ test!(cargo_test_verbose {
 
     assert_that(p.cargo_process("test").arg("-v").arg("hello"),
         execs().with_stdout(format!("\
-{compiling} foo v0.5.0 ({url})
-{running} `rustc src[..]foo.rs [..]`
-{running} `[..]target[..]foo-[..] hello`
+[COMPILING] foo v0.5.0 ({url})
+[RUNNING] `rustc src[..]foo.rs [..]`
+[RUNNING] `[..]target[..]foo-[..] hello`
 
 running 1 test
 test test_hello ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
 
-",
-        compiling = COMPILING, url = p.url(), running = RUNNING)));
+", url = p.url())));
 });
 
 test!(many_similar_names {
@@ -190,8 +186,8 @@ test!(cargo_test_failing_test {
 
     assert_that(p.cargo("test"),
                 execs().with_stdout_contains(format!("\
-{compiling} foo v0.5.0 ({url})
-{running} target[..]foo-[..]
+[COMPILING] foo v0.5.0 ({url})
+[RUNNING] target[..]foo-[..]
 
 running 1 test
 test test_hello ... FAILED
@@ -202,7 +198,7 @@ failures:
 <tab>thread 'test_hello' panicked at 'assertion failed: \
     `(left == right)` (left: \
     `\"hello\"`, right: `\"nope\"`)', src[..]foo.rs:12
-", compiling = COMPILING, url = p.url(), running = RUNNING))
+", url = p.url()))
                     .with_stdout_contains("\
 failures:
     test_hello
@@ -247,15 +243,15 @@ test!(test_with_lib_dep {
 
     assert_that(p.cargo_process("test"),
         execs().with_stdout(format!("\
-{} foo v0.0.1 ({})
-{running} target[..]baz-[..]
+[COMPILING] foo v0.0.1 ({})
+[RUNNING] target[..]baz-[..]
 
 running 1 test
 test bin_test ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
 
-{running} target[..]foo[..]
+[RUNNING] target[..]foo[..]
 
 running 1 test
 test lib_test ... ok
@@ -270,7 +266,7 @@ test foo_0 ... ok
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
 
 ",
-        COMPILING, p.url(), running = RUNNING, doctest = DOCTEST)))
+        p.url(), doctest = DOCTEST)))
 });
 
 test!(test_with_deep_lib_dep {
@@ -314,9 +310,9 @@ test!(test_with_deep_lib_dep {
     assert_that(p.cargo_process("test"),
                 execs().with_status(0)
                        .with_stdout(&format!("\
-{compiling} foo v0.0.1 ([..])
-{compiling} bar v0.0.1 ({dir})
-{running} target[..]
+[COMPILING] foo v0.0.1 ([..])
+[COMPILING] bar v0.0.1 ({dir})
+[RUNNING] target[..]
 
 running 1 test
 test bar_test ... ok
@@ -331,7 +327,6 @@ test bar_0 ... ok
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
 
 ",
-                       compiling = COMPILING, running = RUNNING,
                        doctest = DOCTEST,
                        dir = p.url())));
 });
@@ -363,15 +358,15 @@ test!(external_test_explicit {
 
     assert_that(p.cargo_process("test"),
         execs().with_stdout(format!("\
-{} foo v0.0.1 ({})
-{running} target[..]foo-[..]
+[COMPILING] foo v0.0.1 ({})
+[RUNNING] target[..]foo-[..]
 
 running 1 test
 test internal_test ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
 
-{running} target[..]test-[..]
+[RUNNING] target[..]test-[..]
 
 running 1 test
 test external_test ... ok
@@ -385,7 +380,7 @@ running 0 tests
 test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
 
 ",
-        COMPILING, p.url(), running = RUNNING, doctest = DOCTEST)))
+        p.url(), doctest = DOCTEST)))
 });
 
 test!(external_test_implicit {
@@ -411,15 +406,15 @@ test!(external_test_implicit {
 
     assert_that(p.cargo_process("test"),
         execs().with_stdout(format!("\
-{} foo v0.0.1 ({})
-{running} target[..]external-[..]
+[COMPILING] foo v0.0.1 ({})
+[RUNNING] target[..]external-[..]
 
 running 1 test
 test external_test ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
 
-{running} target[..]foo-[..]
+[RUNNING] target[..]foo-[..]
 
 running 1 test
 test internal_test ... ok
@@ -432,8 +427,7 @@ running 0 tests
 
 test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
 
-",
-        COMPILING, p.url(), running = RUNNING, doctest = DOCTEST)))
+", p.url(), doctest = DOCTEST)))
 });
 
 test!(dont_run_examples {
@@ -469,8 +463,8 @@ test!(pass_through_command_line {
     assert_that(p.cargo_process("test").arg("bar"),
                 execs().with_status(0)
                        .with_stdout(&format!("\
-{compiling} foo v0.0.1 ({dir})
-{running} target[..]foo-[..]
+[COMPILING] foo v0.0.1 ({dir})
+[RUNNING] target[..]foo-[..]
 
 running 1 test
 test bar ... ok
@@ -484,14 +478,13 @@ running 0 tests
 test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
 
 ",
-                       compiling = COMPILING, running = RUNNING,
                        doctest = DOCTEST,
                        dir = p.url())));
 
     assert_that(p.cargo("test").arg("foo"),
                 execs().with_status(0)
                        .with_stdout(&format!("\
-{running} target[..]foo-[..]
+[RUNNING] target[..]foo-[..]
 
 running 1 test
 test foo ... ok
@@ -505,7 +498,6 @@ running 0 tests
 test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
 
 ",
-                       running = RUNNING,
                        doctest = DOCTEST)));
 });
 
@@ -554,15 +546,15 @@ test!(lib_bin_same_name {
 
     assert_that(p.cargo_process("test"),
         execs().with_stdout(format!("\
-{} foo v0.0.1 ({})
-{running} target[..]foo-[..]
+[COMPILING] foo v0.0.1 ({})
+[RUNNING] target[..]foo-[..]
 
 running 1 test
 test [..] ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
 
-{running} target[..]foo-[..]
+[RUNNING] target[..]foo-[..]
 
 running 1 test
 test [..] ... ok
@@ -576,7 +568,7 @@ running 0 tests
 test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
 
 ",
-        COMPILING, p.url(), running = RUNNING, doctest = DOCTEST)))
+        p.url(), doctest = DOCTEST)))
 });
 
 test!(lib_with_standard_name {
@@ -606,15 +598,15 @@ test!(lib_with_standard_name {
     assert_that(p.cargo_process("test"),
                 execs().with_status(0)
                        .with_stdout(&format!("\
-{compiling} syntax v0.0.1 ({dir})
-{running} target[..]syntax-[..]
+[COMPILING] syntax v0.0.1 ({dir})
+[RUNNING] target[..]syntax-[..]
 
 running 1 test
 test foo_test ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
 
-{running} target[..]test-[..]
+[RUNNING] target[..]test-[..]
 
 running 1 test
 test test ... ok
@@ -629,7 +621,6 @@ test foo_0 ... ok
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
 
 ",
-                       compiling = COMPILING, running = RUNNING,
                        doctest = DOCTEST, dir = p.url())));
 });
 
@@ -661,8 +652,8 @@ test!(lib_with_standard_name2 {
     assert_that(p.cargo_process("test"),
                 execs().with_status(0)
                        .with_stdout(&format!("\
-{compiling} syntax v0.0.1 ({dir})
-{running} target[..]syntax-[..]
+[COMPILING] syntax v0.0.1 ({dir})
+[RUNNING] target[..]syntax-[..]
 
 running 1 test
 test test ... ok
@@ -670,7 +661,6 @@ test test ... ok
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
 
 ",
-                       compiling = COMPILING, running = RUNNING,
                        dir = p.url())));
 });
 
@@ -701,15 +691,15 @@ test!(lib_without_name {
     assert_that(p.cargo_process("test"),
                 execs().with_status(0)
                        .with_stdout(&format!("\
-{compiling} syntax v0.0.1 ({dir})
-{running} target[..]syntax-[..]
+[COMPILING] syntax v0.0.1 ({dir})
+[RUNNING] target[..]syntax-[..]
 
 running 1 test
 test test ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
 
-", compiling = COMPILING, running = RUNNING, dir = p.url())));
+", dir = p.url())));
 });
 
 test!(bin_without_name {
@@ -742,11 +732,10 @@ test!(bin_without_name {
     assert_that(p.cargo_process("test"),
                 execs().with_status(101)
                        .with_stderr(&format!("\
-{error} failed to parse manifest at `[..]`
+[ERROR] failed to parse manifest at `[..]`
 
 Caused by:
-  binary target bin.name is required",
-  error = ERROR)));
+  binary target bin.name is required")));
 });
 
 test!(bench_without_name {
@@ -787,11 +776,10 @@ test!(bench_without_name {
     assert_that(p.cargo_process("test"),
                 execs().with_status(101)
                        .with_stderr(&format!("\
-{error} failed to parse manifest at `[..]`
+[ERROR] failed to parse manifest at `[..]`
 
 Caused by:
-  bench target bench.name is required",
-    error = ERROR)));
+  bench target bench.name is required")));
 });
 
 test!(test_without_name {
@@ -831,11 +819,10 @@ test!(test_without_name {
     assert_that(p.cargo_process("test"),
                 execs().with_status(101)
                        .with_stderr(&format!("\
-{error} failed to parse manifest at `[..]`
+[ERROR] failed to parse manifest at `[..]`
 
 Caused by:
-  test target test.name is required",
-  error = ERROR)));
+  test target test.name is required")));
 });
 
 test!(example_without_name {
@@ -875,11 +862,10 @@ test!(example_without_name {
     assert_that(p.cargo_process("test"),
                 execs().with_status(101)
                        .with_stderr(&format!("\
-{error} failed to parse manifest at `[..]`
+[ERROR] failed to parse manifest at `[..]`
 
 Caused by:
-  example target example.name is required",
-  error = ERROR)));
+  example target example.name is required")));
 });
 
 test!(bin_there_for_integration {
@@ -955,16 +941,16 @@ test!(test_dylib {
     assert_that(p.cargo_process("test"),
                 execs().with_status(0)
                        .with_stdout(&format!("\
-{compiling} bar v0.0.1 ({dir}/bar)
-{compiling} foo v0.0.1 ({dir})
-{running} target[..]foo-[..]
+[COMPILING] bar v0.0.1 ({dir}/bar)
+[COMPILING] foo v0.0.1 ({dir})
+[RUNNING] target[..]foo-[..]
 
 running 1 test
 test foo ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
 
-{running} target[..]test-[..]
+[RUNNING] target[..]test-[..]
 
 running 1 test
 test foo ... ok
@@ -972,28 +958,26 @@ test foo ... ok
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
 
 ",
-                       compiling = COMPILING, running = RUNNING,
                        dir = p.url())));
     p.root().move_into_the_past().unwrap();
     assert_that(p.cargo("test"),
                 execs().with_status(0)
                        .with_stdout(format!("\
-{running} target[..]foo-[..]
+[RUNNING] target[..]foo-[..]
 
 running 1 test
 test foo ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
 
-{running} target[..]test-[..]
+[RUNNING] target[..]test-[..]
 
 running 1 test
 test foo ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
 
-",
-                       running = RUNNING)));
+")));
 
 });
 
@@ -1015,8 +999,8 @@ test!(test_twice_with_build_cmd {
     assert_that(p.cargo_process("test"),
                 execs().with_status(0)
                        .with_stdout(&format!("\
-{compiling} foo v0.0.1 ({dir})
-{running} target[..]foo-[..]
+[COMPILING] foo v0.0.1 ({dir})
+[RUNNING] target[..]foo-[..]
 
 running 1 test
 test foo ... ok
@@ -1030,14 +1014,13 @@ running 0 tests
 test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
 
 ",
-                       compiling = COMPILING, running = RUNNING,
                        doctest = DOCTEST,
                        dir = p.url())));
 
     assert_that(p.cargo("test"),
                 execs().with_status(0)
                        .with_stdout(format!("\
-{running} target[..]foo-[..]
+[RUNNING] target[..]foo-[..]
 
 running 1 test
 test foo ... ok
@@ -1051,7 +1034,6 @@ running 0 tests
 test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
 
 ",
-                       running = RUNNING,
                        doctest = DOCTEST)));
 });
 
@@ -1071,8 +1053,8 @@ test!(test_then_build {
     assert_that(p.cargo_process("test"),
                 execs().with_status(0)
                        .with_stdout(&format!("\
-{compiling} foo v0.0.1 ({dir})
-{running} target[..]foo-[..]
+[COMPILING] foo v0.0.1 ({dir})
+[RUNNING] target[..]foo-[..]
 
 running 1 test
 test foo ... ok
@@ -1086,7 +1068,6 @@ running 0 tests
 test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
 
 ",
-                       compiling = COMPILING, running = RUNNING,
                        doctest = DOCTEST,
                        dir = p.url())));
 
@@ -1111,9 +1092,8 @@ test!(test_no_run {
     assert_that(p.cargo_process("test").arg("--no-run"),
                 execs().with_status(0)
                        .with_stdout(&format!("\
-{compiling} foo v0.0.1 ({dir})
+[COMPILING] foo v0.0.1 ({dir})
 ",
-                       compiling = COMPILING,
                        dir = p.url())));
 });
 
@@ -1137,8 +1117,8 @@ test!(test_run_specific_bin_target {
         .file("src/bin2.rs", "#[test] fn test2() { }");
 
     let expected_stdout = format!("\
-{compiling} foo v0.0.1 ({dir})
-{running} target[..]bin2-[..]
+[COMPILING] foo v0.0.1 ({dir})
+[RUNNING] target[..]bin2-[..]
 
 running 1 test
 test test2 ... ok
@@ -1146,8 +1126,6 @@ test test2 ... ok
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
 
 ",
-       compiling = COMPILING,
-       running = RUNNING,
        dir = prj.url());
 
     assert_that(prj.cargo_process("test").arg("--bin").arg("bin2"),
@@ -1168,8 +1146,8 @@ test!(test_run_specific_test_target {
         .file("tests/b.rs", "#[test] fn test_b() { }");
 
     let expected_stdout = format!("\
-{compiling} foo v0.0.1 ({dir})
-{running} target[..]b-[..]
+[COMPILING] foo v0.0.1 ({dir})
+[RUNNING] target[..]b-[..]
 
 running 1 test
 test test_b ... ok
@@ -1177,8 +1155,6 @@ test test_b ... ok
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
 
 ",
-       compiling = COMPILING,
-       running = RUNNING,
        dir = prj.url());
 
     assert_that(prj.cargo_process("test").arg("--test").arg("b"),
@@ -1208,10 +1184,9 @@ test!(test_no_harness {
     assert_that(p.cargo_process("test").arg("--").arg("--nocapture"),
                 execs().with_status(0)
                        .with_stdout(&format!("\
-{compiling} foo v0.0.1 ({dir})
-{running} target[..]bar-[..]
+[COMPILING] foo v0.0.1 ({dir})
+[RUNNING] target[..]bar-[..]
 ",
-                       compiling = COMPILING, running = RUNNING,
                        dir = p.url())));
 });
 
@@ -1263,54 +1238,54 @@ test!(selective_testing {
     assert_that(p.cargo("test").arg("-p").arg("d1"),
                 execs().with_status(0)
                        .with_stdout(&format!("\
-{compiling} d1 v0.0.1 ({dir}/d1)
-{running} target[..]d1-[..]
+[COMPILING] d1 v0.0.1 ({dir}/d1)
+[RUNNING] target[..]d1-[..]
 
 running 0 tests
 
 test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
 
-{running} target[..]d1-[..]
+[RUNNING] target[..]d1-[..]
 
 running 0 tests
 
 test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
 
-", compiling = COMPILING, running = RUNNING,
+",
    dir = p.url())));
 
     println!("d2");
     assert_that(p.cargo("test").arg("-p").arg("d2"),
                 execs().with_status(0)
                        .with_stdout(&format!("\
-{compiling} d2 v0.0.1 ({dir}/d2)
-{running} target[..]d2-[..]
+[COMPILING] d2 v0.0.1 ({dir}/d2)
+[RUNNING] target[..]d2-[..]
 
 running 0 tests
 
 test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
 
-{running} target[..]d2-[..]
+[RUNNING] target[..]d2-[..]
 
 running 0 tests
 
 test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
 
-", compiling = COMPILING, running = RUNNING,
+",
    dir = p.url())));
 
     println!("whole");
     assert_that(p.cargo("test"),
                 execs().with_status(0)
                        .with_stdout(&format!("\
-{compiling} foo v0.0.1 ({dir})
-{running} target[..]foo-[..]
+[COMPILING] foo v0.0.1 ({dir})
+[RUNNING] target[..]foo-[..]
 
 running 0 tests
 
 test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
 
-", compiling = COMPILING, running = RUNNING,
+",
    dir = p.url())));
 });
 
@@ -1461,8 +1436,8 @@ test!(selective_testing_with_docs {
     assert_that(p.cargo("test").arg("-p").arg("d1"),
                 execs().with_status(0)
                        .with_stdout(&format!("\
-{compiling} d1 v0.0.1 ({dir}/d1)
-{running} target[..]deps[..]d1[..]
+[COMPILING] d1 v0.0.1 ({dir}/d1)
+[RUNNING] target[..]deps[..]d1[..]
 
 running 0 tests
 
@@ -1474,7 +1449,7 @@ running 0 tests
 
 test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
 
-", compiling = COMPILING, running = RUNNING, dir = p.url(),
+", dir = p.url(),
    doctest = DOCTEST)));
 });
 
@@ -1492,10 +1467,10 @@ test!(example_bin_same_name {
     assert_that(p.cargo_process("test").arg("--no-run").arg("-v"),
                 execs().with_status(0)
                        .with_stdout(&format!("\
-{compiling} foo v0.0.1 ({dir})
-{running} `rustc [..]`
-{running} `rustc [..]`
-", compiling = COMPILING, running = RUNNING, dir = p.url())));
+[COMPILING] foo v0.0.1 ({dir})
+[RUNNING] `rustc [..]`
+[RUNNING] `rustc [..]`
+", dir = p.url())));
 
     assert_that(&p.bin("foo"), is_not(existing_file()));
     assert_that(&p.bin("examples/foo"), existing_file());
@@ -1506,10 +1481,10 @@ test!(example_bin_same_name {
     assert_that(p.cargo("run"),
                 execs().with_status(0)
                        .with_stdout(&format!("\
-{compiling} foo v0.0.1 ([..])
-{running} [..]
+[COMPILING] foo v0.0.1 ([..])
+[RUNNING] [..]
 bin
-", compiling = COMPILING, running = RUNNING)));
+")));
     assert_that(&p.bin("foo"), existing_file());
 });
 
@@ -1567,8 +1542,8 @@ test!(example_with_dev_dep {
 [..]
 [..]
 [..]
-{running} `rustc [..] --crate-name ex [..] --extern a=[..]`
-", running = RUNNING)));
+[RUNNING] `rustc [..] --crate-name ex [..] --extern a=[..]`
+")));
 });
 
 test!(bin_is_preserved {
@@ -1604,14 +1579,12 @@ test!(bad_example {
 
     assert_that(p.cargo_process("run").arg("--example").arg("foo"),
                 execs().with_status(101).with_stderr(&format!("\
-{error} no example target named `foo`
-",
-    error = ERROR)));
+[ERROR] no example target named `foo`
+")));
     assert_that(p.cargo_process("run").arg("--bin").arg("foo"),
                 execs().with_status(101).with_stderr(&format!("\
-{error} no bin target named `foo`
-",
-    error = ERROR)));
+[ERROR] no bin target named `foo`
+")));
 });
 
 test!(doctest_feature {
@@ -1634,8 +1607,8 @@ test!(doctest_feature {
 
     assert_that(p.cargo_process("test").arg("--features").arg("bar"),
                 execs().with_status(0).with_stdout(format!("\
-{compiling} foo [..]
-{running} target[..]foo[..]
+[COMPILING] foo [..]
+[RUNNING] target[..]foo[..]
 
 running 0 tests
 
@@ -1648,7 +1621,7 @@ test foo_0 ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
 
-", compiling = COMPILING, running = RUNNING, doctest = DOCTEST)))
+", doctest = DOCTEST)))
 });
 
 test!(dashes_to_underscores {
@@ -1717,14 +1690,14 @@ test!(filter_no_doc_tests {
 
     assert_that(p.cargo_process("test").arg("--test=foo"),
                 execs().with_stdout(format!("\
-{compiling} foo v0.0.1 ([..])
-{running} target[..]debug[..]foo[..]
+[COMPILING] foo v0.0.1 ([..])
+[RUNNING] target[..]debug[..]foo[..]
 
 running 0 tests
 
 test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
 
-", compiling = COMPILING, running = RUNNING)));
+")));
 });
 
 test!(dylib_doctest {
@@ -1749,7 +1722,7 @@ test!(dylib_doctest {
 
     assert_that(p.cargo_process("test"),
                 execs().with_stdout(format!("\
-{compiling} foo v0.0.1 ([..])
+[COMPILING] foo v0.0.1 ([..])
 {doctest} foo
 
 running 1 test
@@ -1757,7 +1730,7 @@ test foo_0 ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
 
-", compiling = COMPILING, doctest = DOCTEST)));
+", doctest = DOCTEST)));
 });
 
 test!(dylib_doctest2 {
@@ -1815,9 +1788,9 @@ test!(cyclic_dev_dep_doc_test {
         "#);
     assert_that(p.cargo_process("test"),
                 execs().with_stdout(format!("\
-{compiling} foo v0.0.1 ([..])
-{compiling} bar v0.0.1 ([..])
-{running} target[..]foo[..]
+[COMPILING] foo v0.0.1 ([..])
+[COMPILING] bar v0.0.1 ([..])
+[RUNNING] target[..]foo[..]
 
 running 0 tests
 
@@ -1830,7 +1803,7 @@ test _0 ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
 
-", compiling = COMPILING, running = RUNNING, doctest = DOCTEST)))
+", doctest = DOCTEST)))
 });
 
 test!(dev_dep_with_build_script {
@@ -1906,19 +1879,19 @@ test!(no_fail_fast {
     assert_that(p.cargo_process("test").arg("--no-fail-fast"),
                 execs().with_status(101)
                        .with_stdout_contains(format!("\
-{compiling} foo v0.0.1 ([..])
-{running} target[..]foo[..]
+[COMPILING] foo v0.0.1 ([..])
+[RUNNING] target[..]foo[..]
 
 running 0 tests
 
 test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
 
-{running} target[..]test_add_one[..]
-", compiling = COMPILING, running = RUNNING))
+[RUNNING] target[..]test_add_one[..]
+"))
                        .with_stdout_contains(format!("\
 test result: FAILED. 1 passed; 1 failed; 0 ignored; 0 measured
 
-{running} target[..]test_sub_one[..]
+[RUNNING] target[..]test_sub_one[..]
 
 running 1 test
 test sub_one_test ... ok
@@ -1932,7 +1905,7 @@ test sub_one_0 ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
 
-", running = RUNNING, doctest = DOCTEST)))
+", doctest = DOCTEST)))
 });
 
 test!(test_multiple_packages {
@@ -1980,19 +1953,19 @@ test!(test_multiple_packages {
     assert_that(p.cargo("test").arg("-p").arg("d1").arg("-p").arg("d2"),
                 execs().with_status(0)
                        .with_stdout_contains(&format!("\
-{running} target[..]debug[..]d1-[..]
+[RUNNING] target[..]debug[..]d1-[..]
 
 running 0 tests
 
 test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
-", running = RUNNING))
+"))
                        .with_stdout_contains(&format!("\
-{running} target[..]debug[..]d2-[..]
+[RUNNING] target[..]debug[..]d2-[..]
 
 running 0 tests
 
 test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
-", running = RUNNING)));
+")));
 });
 
 test!(bin_does_not_rebuild_tests {
@@ -2018,10 +1991,10 @@ test!(bin_does_not_rebuild_tests {
     assert_that(p.cargo("test").arg("-v").arg("--no-run"),
                 execs().with_status(0)
                        .with_stdout(&format!("\
-{compiling} foo v0.0.1 ([..])
-{running} `rustc src[..]main.rs [..]`
-{running} `rustc src[..]main.rs [..]`
-", compiling = COMPILING, running = RUNNING)));
+[COMPILING] foo v0.0.1 ([..])
+[RUNNING] `rustc src[..]main.rs [..]`
+[RUNNING] `rustc src[..]main.rs [..]`
+")));
 });
 
 test!(selective_test_wonky_profile {
@@ -2077,10 +2050,10 @@ test!(selective_test_optional_dep {
     assert_that(p.cargo("test").arg("-v").arg("--no-run")
                  .arg("--features").arg("a").arg("-p").arg("a"),
                 execs().with_status(0).with_stdout(&format!("\
-{compiling} a v0.0.1 ([..])
-{running} `rustc a[..]src[..]lib.rs [..]`
-{running} `rustc a[..]src[..]lib.rs [..]`
-", compiling = COMPILING, running = RUNNING)));
+[COMPILING] a v0.0.1 ([..])
+[RUNNING] `rustc a[..]src[..]lib.rs [..]`
+[RUNNING] `rustc a[..]src[..]lib.rs [..]`
+")));
 });
 
 test!(only_test_docs {

--- a/tests/test_cargo_tool_paths.rs
+++ b/tests/test_cargo_tool_paths.rs
@@ -1,5 +1,4 @@
 use support::{path2url, project, execs};
-use support::{COMPILING, RUNNING};
 use hamcrest::assert_that;
 
 fn setup() {
@@ -27,9 +26,9 @@ test!(pathless_tools {
 
     assert_that(foo.cargo_process("build").arg("--verbose"),
                 execs().with_stdout(&format!("\
-{compiling} foo v0.0.1 ({url})
-{running} `rustc [..] -C ar=nonexistent-ar -C linker=nonexistent-linker [..]`
-", compiling = COMPILING, running = RUNNING, url = foo.url())))
+[COMPILING] foo v0.0.1 ({url})
+[RUNNING] `rustc [..] -C ar=nonexistent-ar -C linker=nonexistent-linker [..]`
+", url = foo.url())))
 });
 
 test!(absolute_tools {
@@ -67,9 +66,9 @@ test!(absolute_tools {
 
     assert_that(foo.cargo_process("build").arg("--verbose"),
                 execs().with_stdout(&format!("\
-{compiling} foo v0.0.1 ({url})
-{running} `rustc [..] -C ar={ar} -C linker={linker} [..]`
-", compiling = COMPILING, running = RUNNING, url = foo.url(), ar = output.0, linker = output.1)))
+[COMPILING] foo v0.0.1 ({url})
+[RUNNING] `rustc [..] -C ar={ar} -C linker={linker} [..]`
+", url = foo.url(), ar = output.0, linker = output.1)))
 });
 
 test!(relative_tools {
@@ -114,7 +113,7 @@ test!(relative_tools {
 
     assert_that(origin.cargo_process("build").cwd(foo_path).arg("--verbose"),
                 execs().with_stdout(&format!("\
-{compiling} foo v0.0.1 ({url})
-{running} `rustc [..] -C ar={ar} -C linker={linker} [..]`
-", compiling = COMPILING, running = RUNNING, url = foo_url, ar = output.0, linker = output.1)))
+[COMPILING] foo v0.0.1 ({url})
+[RUNNING] `rustc [..] -C ar={ar} -C linker={linker} [..]`
+", url = foo_url, ar = output.0, linker = output.1)))
 });


### PR DESCRIPTION
@alexcrichton I think there is one bit of tests that could be simplified.

What do you think about writing this

```Rust
test!(simple {
    pkg("foo", "0.0.1");

    assert_that(cargo_process("install").arg("foo"),
                execs().with_status(0).with_stdout(&format!("\
[UPDATING] registry `[..]`
[DOWNLOADING] foo v0.0.1 (registry file://[..])
[COMPILING] foo v0.0.1 (registry file://[..])
[INSTALLING] {home}[..]bin[..]foo[..]
",
        home = cargo_home().display())));
    assert_that(cargo_home(), has_installed_exe("foo"));

    assert_that(cargo_process("uninstall").arg("foo"),
                execs().with_status(0).with_stdout(&format!("\
[REMOVING] {home}[..]bin[..]foo[..]
",
        home = cargo_home().display())));
    assert_that(cargo_home(), is_not(has_installed_exe("foo")));
});
```

instead of this

```Rust
test!(simple {
    pkg("foo", "0.0.1");

    assert_that(cargo_process("install").arg("foo"),
                execs().with_status(0).with_stdout(&format!("\
{updating} registry `[..]`
{downloading} foo v0.0.1 (registry file://[..])
{compiling} foo v0.0.1 (registry file://[..])
{installing} {home}[..]bin[..]foo[..]
",
        updating = UPDATING,
        downloading = DOWNLOADING,
        compiling = COMPILING,
        installing = INSTALLING,
        home = cargo_home().display())));
    assert_that(cargo_home(), has_installed_exe("foo"));

    assert_that(cargo_process("uninstall").arg("foo"),
                execs().with_status(0).with_stdout(&format!("\
{removing} {home}[..]bin[..]foo[..]
",
        removing = REMOVING,
        home = cargo_home().display())));
    assert_that(cargo_home(), is_not(has_installed_exe("foo")));
});
```

This PR has a proof of concept implementation of this feature applied to a couple of tests. 

r? @alexcrichton 