### PR TITLE
Command alias or Alias command #1091

### DIFF
--- a/src/doc/config.md
+++ b/src/doc/config.md
@@ -93,6 +93,15 @@ color = 'auto'         # whether cargo colorizes output
 # Network configuration
 [net]
 retry = 2 # number of times a network call will automatically retried
+
+# Alias cargo commands. The first 3 aliases are built in. If your
+command requires grouped whitespace use the list format.
+[alias]
+b = "build"
+t = "test"
+r = "run"
+rr = "run --release"
+space_example = ["run", "--release", "--", "\"command list\""]
 ```
 
 # Environment Variables

--- a/tests/cargo_alias_config.rs
+++ b/tests/cargo_alias_config.rs
@@ -1,0 +1,103 @@
+extern crate cargotest;
+extern crate hamcrest;
+use cargotest::support::{project, execs, basic_bin_manifest};
+use hamcrest::{assert_that};
+
+#[test]
+fn alias_incorrect_config_type() {
+    let p = project("foo")
+        .file("Cargo.toml", &basic_bin_manifest("foo"))
+        .file("src/main.rs", r#"
+            fn main() {
+        }"#)
+        .file(".cargo/config",r#"
+            [alias]
+            b-cargo-test = 5
+        "#);;
+
+    assert_that(p.cargo_process("b-cargo-test").arg("-v"),
+                execs().with_status(101).
+                with_stderr_contains("[ERROR] invalid configuration \
+for key `alias.b-cargo-test`
+expected a list, but found a integer in [..]"));
+}
+
+
+#[test]
+fn alias_default_config_overrides_config() {
+    let p = project("foo")
+        .file("Cargo.toml", &basic_bin_manifest("foo"))
+        .file("src/main.rs", r#"
+            fn main() {
+        }"#)
+        .file(".cargo/config",r#"
+            [alias]
+            b = "not_build"
+        "#);;
+
+    assert_that(p.cargo_process("b").arg("-v"),
+                execs().with_status(0).
+                with_stderr_contains("[COMPILING] foo v0.5.0 [..]"));
+}
+
+#[test]
+fn alias_config() {
+    let p = project("foo")
+        .file("Cargo.toml", &basic_bin_manifest("foo"))
+        .file("src/main.rs", r#"
+            fn main() {
+        }"#)
+        .file(".cargo/config",r#"
+            [alias]
+            b-cargo-test = "build"
+        "#);;
+
+    assert_that(p.cargo_process("b-cargo-test").arg("-v"),
+                execs().with_status(0).
+                with_stderr_contains("[COMPILING] foo v0.5.0 [..]
+[RUNNING] `rustc [..] --crate-name foo --crate-type \
+bin -g --out-dir [..] --emit=dep-info,link -L dependency=[..]\
+-L dependency=[..]"));
+}
+
+#[test]
+fn alias_list_test() {
+    let p = project("foo")
+        .file("Cargo.toml", &basic_bin_manifest("foo"))
+        .file("src/main.rs", r#"
+            fn main() {
+         }"#)
+        .file(".cargo/config",r#"
+            [alias]
+            b-cargo-test = ["build", "--release"]
+         "#);;
+
+    assert_that(p.cargo_process("b-cargo-test").arg("-v"),
+                execs().with_status(0).
+                with_stderr_contains("[COMPILING] foo v0.5.0 [..]").
+                with_stderr_contains("[RUNNING] `rustc [..] --crate-name foo \
+                                     --crate-type bin -C opt-level=3 --out-dir [..]\
+                                     --emit=dep-info,link -L dependency=[..]")
+                );
+}
+
+#[test]
+fn alias_with_flags_config() {
+    let p = project("foo")
+        .file("Cargo.toml", &basic_bin_manifest("foo"))
+        .file("src/main.rs", r#"
+            fn main() {
+         }"#)
+        .file(".cargo/config",r#"
+            [alias]
+            b-cargo-test = "build --release"
+         "#);;
+
+    assert_that(p.cargo_process("b-cargo-test").arg("-v"),
+                execs().with_status(0).
+                with_stderr_contains("[COMPILING] foo v0.5.0 [..]").
+                with_stderr_contains("[RUNNING] `rustc [..] --crate-name foo \
+                                     --crate-type bin -C opt-level=3 --out-dir [..]\
+                                     --emit=dep-info,link -L dependency=[..]")
+                );
+}


### PR DESCRIPTION
Dearest Reviewer,

This pull request closes #1091 which is a request to support aliases.
This is not as powerful as something like git's alias, however, I think
it sticks true to the original request.

I high jack the processing of the args. After a few flags are checked
and the args are parsed I check the config file for alias.COMMAND. If it
is there I split it like args does and replace args[1] (the original
command) with the alias command and its 'flags'.

As an extra measure I output the alias command with warn. I would be
willing to drop that or put it behind a verbose flag. Also the docs have
been updated.

Thanks!
Becker

<img width="784" alt="screen shot 2016-05-12 at 10 23 59 am" src="https://cloud.githubusercontent.com/assets/12170/15226012/d18a3336-1835-11e6-94c9-875a63a79856.png">
