### PR TITLE
Canonicalize CARGO_HOME fallback on Windows

### DIFF
--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -92,8 +92,9 @@ fn is_nightly() -> bool {
 fn process<T: AsRef<OsStr>>(t: T) -> cargo::util::ProcessBuilder {
     let mut p = cargo::util::process(t.as_ref());
     p.cwd(&support::paths::root())
-     .env("HOME", &support::paths::home())
      .env_remove("CARGO_HOME")
+     .env("HOME", support::paths::home())
+     .env("CARGO_HOME", support::paths::home().join(".cargo"))
      .env_remove("RUSTC")
      .env_remove("RUSTFLAGS")
      .env_remove("XDG_CONFIG_HOME")      // see #2345


### PR DESCRIPTION
This commit ensures that we always return the same fallback value on Windows
regardless of whichever shell we happen to be run from. We do this by removing
the `$HOME` environment variable which `std::env::home_dir` will inspect to
force it to fall back to the system APIs. If the old directory exists then we
favor that one, but otherwise we favor locations like `C:\Users\$user`

Supercedes and closes #2604