### PR TITLE
List all the things #1253

### DIFF
--- a/src/bin/list.rs
+++ b/src/bin/list.rs
@@ -1,0 +1,31 @@
+use std::env;
+use cargo::util::{CliResult, Config};
+use cargo::list_commands;
+pub const USAGE: &'static str = "
+List all commands
+
+Usage:
+    cargo list
+";
+
+#[derive(RustcDecodable)]
+pub struct Options {
+    flag_verbose: Option<bool>,
+    flag_quiet: Option<bool>,
+    flag_color: Option<String>,
+}
+
+pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
+    debug!("executing; cmd=cargo-list; args={:?}",
+           env::args().collect::<Vec<_>>());
+    // No options are passed but the execute requires options
+    try!(config.configure_shell(options.flag_verbose,
+                                options.flag_quiet,
+                                &options.flag_color));
+
+    println!("Installed Commands:");
+    for command in list_commands(config) {
+        println!("    {}", command);
+    }
+    Ok(None)
+}

--- a/tests/test_cargo.rs
+++ b/tests/test_cargo.rs
@@ -69,7 +69,7 @@ test!(list_command_looks_at_path {
     let mut path = path();
     path.push(proj.root().join("path-test"));
     let path = env::join_paths(path.iter()).unwrap();
-    let output = pr.arg("-v").arg("--list")
+    let output = pr.arg("list")
                    .env("PATH", &path);
     let output = output.exec_with_output().unwrap();
     let output = str::from_utf8(&output.stdout).unwrap();


### PR DESCRIPTION
Dearest Reviewer,

This resolves #1253 which is about moving the --list command to a full
command. The command does not use any options currently. I left the list
flag with a deprecation message.

I moved some macros and other functions to the cargo lib so that I could
reuse them in the list command. However, there is an issue linked in the
pull request to the current version of rust failing to compile. I could
not figure out how to work around this so I left the copy of the macros
in the main program. Moving forward one would need to add an
main cargo bin.  I did not implement any options as I am unsure what
they would do.

Thanks
Becker