### PR TITLE
Fix `cargo test --doc` not testing examples

### DIFF
--- a/src/cargo/ops/cargo_test.rs
+++ b/src/cargo/ops/cargo_test.rs
@@ -20,7 +20,7 @@ pub fn run_tests(manifest_path: &Path,
         return Ok(None)
     }
     let mut errors = if options.only_doc {
-        Vec::new()
+        try!(run_doc_tests(options, test_args, &compilation))
     } else {
         try!(run_unit_tests(options, test_args, &compilation))
     };

--- a/tests/test_cargo_test.rs
+++ b/tests/test_cargo_test.rs
@@ -2048,10 +2048,10 @@ test!(selective_test_optional_dep {
 });
 
 test!(only_test_docs {
-    let p = project("foo")
+    let p = project("foo_docs")
         .file("Cargo.toml", r#"
             [package]
-            name = "foo"
+            name = "foo_docs"
             version = "0.0.1"
             authors = []
         "#)
@@ -2067,13 +2067,13 @@ test!(only_test_docs {
             pub fn bar() {
             }
         "#)
-        .file("tests/foo.rs", "this is not rust");
+        .file("tests/foo_docs.rs", "this is not rust");
     p.build();
 
     assert_that(p.cargo("test").arg("--doc"),
                 execs().with_status(0).with_stdout(&format!("\
-[COMPILING] foo v0.0.1 ([..])
-[DOCTEST] foo
+[COMPILING] foo_docs v0.0.1 ([..])
+[DOCTEST] foo_docs
 
 running 1 test
 test bar_0 ... ok

--- a/tests/test_cargo_test.rs
+++ b/tests/test_cargo_test.rs
@@ -2071,5 +2071,14 @@ test!(only_test_docs {
     p.build();
 
     assert_that(p.cargo("test").arg("--doc"),
-                execs().with_status(0));
+                execs().with_status(0).with_stdout(&format!("\
+[COMPILING] foo v0.0.1 ([..])
+[DOCTEST] foo
+
+running 1 test
+test bar_0 ... ok
+
+test result: ok.[..]
+")));
 });
+

--- a/tests/test_cargo_test.rs
+++ b/tests/test_cargo_test.rs
@@ -2079,6 +2079,7 @@ running 1 test
 test bar_0 ... ok
 
 test result: ok.[..]
+
 ")));
 });
 

--- a/tests/test_cargo_test.rs
+++ b/tests/test_cargo_test.rs
@@ -2048,10 +2048,10 @@ test!(selective_test_optional_dep {
 });
 
 test!(only_test_docs {
-    let p = project("foo_docs")
+    let p = project("foo")
         .file("Cargo.toml", r#"
             [package]
-            name = "foo_docs"
+            name = "foo"
             version = "0.0.1"
             authors = []
         "#)
@@ -2067,13 +2067,13 @@ test!(only_test_docs {
             pub fn bar() {
             }
         "#)
-        .file("tests/foo_docs.rs", "this is not rust");
+        .file("tests/foo.rs", "this is not rust");
     p.build();
 
     assert_that(p.cargo("test").arg("--doc"),
                 execs().with_status(0).with_stdout(&format!("\
-[COMPILING] foo_docs v0.0.1 ([..])
-[DOCTEST] foo_docs
+[COMPILING] foo v0.0.1 ([..])
+[DOCTEST] foo
 
 running 1 test
 test bar_0 ... ok


### PR DESCRIPTION
When running cargo doc --test in a project folder, cargo does not test documentation examples, it only builds the project and exits.

Refer to issue #2684 