### PR TITLE
Update manpage with some missing cargo commands

### DIFF
--- a/src/etc/cargo.1
+++ b/src/etc/cargo.1
@@ -65,6 +65,9 @@ Run the benchmarks for the package
 \fBcargo update\fR
 Update dependencies in Cargo.lock
 .TP
+\fBcargo rustc\fR
+Compile the current project, and optionally pass additional rustc parameters
+.TP
 \fBcargo package\fR
 Generate a source tarball for the current package
 .TP
@@ -76,6 +79,9 @@ Remove a Rust binary
 .TP
 \fBcargo search\fR
 Search registry for crates
+.TP
+\fBcargo help\fR
+Display help for a cargo command
 .TP
 \fBcargo version\fR
 Print cargo's version and exit


### PR DESCRIPTION
the manpage of cargo is missing a few important cargo commands, and I've added `rustc` and `help`. Hopefully everything's alright.