### PR TITLE
report status to stderr instead of stdout

### DIFF
--- a/src/cargo/core/shell.rs
+++ b/src/cargo/core/shell.rs
@@ -73,7 +73,7 @@ impl MultiShell {
     {
         match self.verbosity {
             Quiet => Ok(()),
-            _ => self.out().say_status(status, message, GREEN, true)
+            _ => self.err().say_status(status, message, GREEN, true)
         }
     }
 

--- a/tests/test_bad_config.rs
+++ b/tests/test_bad_config.rs
@@ -71,6 +71,7 @@ test!(bad3 {
         "#);
     assert_that(foo.cargo_process("publish").arg("-v"),
                 execs().with_status(101).with_stderr("\
+[UPDATING] registry `https://[..]`
 [ERROR] invalid configuration for key `http.proxy`
 expected a string, but found a boolean in [..]config
 "));
@@ -232,6 +233,7 @@ test!(bad_git_dependency {
 
     assert_that(foo.cargo_process("build").arg("-v"),
                 execs().with_status(101).with_stderr("\
+[UPDATING] git repository `file:///`
 [ERROR] Unable to update file:///
 
 Caused by:
@@ -258,6 +260,8 @@ test!(bad_crate_type {
     assert_that(foo.cargo_process("build").arg("-v"),
                 execs().with_status(0).with_stderr("\
 warning: crate-type \"bad_type\" was not one of lib|rlib|dylib|staticlib
+[COMPILING] foo v0.0.0 (file:///[..])
+[RUNNING] `rustc [..] --crate-type rlib [..]`
 "));
 });
 
@@ -430,6 +434,7 @@ test!(unused_keys {
     assert_that(foo.cargo_process("build"),
                 execs().with_status(0).with_stderr("\
 warning: unused manifest key: target.foo.bar
+[COMPILING] foo v0.1.0 (file:///[..])
 "));
 });
 

--- a/tests/test_cargo_bench.rs
+++ b/tests/test_cargo_bench.rs
@@ -36,16 +36,16 @@ test!(cargo_bench_simple {
                 execs().with_stdout("hello\n"));
 
     assert_that(p.cargo("bench"),
-                execs().with_stdout(&format!("\
+                execs().with_stderr(&format!("\
 [COMPILING] foo v0.5.0 ({})
-[RUNNING] target[..]release[..]foo-[..]
-
+[RUNNING] target[..]release[..]foo-[..]", p.url()))
+                       .with_stdout("
 running 1 test
 test bench_hello ... bench: [..] 0 ns/iter (+/- 0)
 
 test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured
 
-", p.url())));
+"));
 });
 
 test!(bench_tarname {

--- a/tests/test_cargo_bench.rs
+++ b/tests/test_cargo_bench.rs
@@ -929,7 +929,7 @@ test!(test_bench_no_run {
 
     assert_that(p.cargo_process("bench").arg("--no-run"),
                 execs().with_status(0)
-                       .with_stdout("\
+                       .with_stderr("\
 [COMPILING] foo v0.1.0 ([..])
 "));
 });

--- a/tests/test_cargo_bench.rs
+++ b/tests/test_cargo_bench.rs
@@ -96,17 +96,17 @@ test!(cargo_bench_verbose {
         "#);
 
     assert_that(p.cargo_process("bench").arg("-v").arg("hello"),
-        execs().with_stdout(&format!("\
+                execs().with_stderr(&format!("\
 [COMPILING] foo v0.5.0 ({url})
 [RUNNING] `rustc src[..]foo.rs [..]`
-[RUNNING] `[..]target[..]release[..]foo-[..] hello --bench`
-
+[RUNNING] `[..]target[..]release[..]foo-[..] hello --bench`", url = p.url()))
+                       .with_stdout("
 running 1 test
 test bench_hello ... bench: [..] 0 ns/iter (+/- 0)
 
 test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured
 
-", url = p.url())));
+"));
 });
 
 test!(many_similar_names {
@@ -230,24 +230,23 @@ test!(bench_with_lib_dep {
         ");
 
     assert_that(p.cargo_process("bench"),
-        execs().with_stdout(&format!("\
+                execs().with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({})
 [RUNNING] target[..]release[..]baz-[..]
-
+[RUNNING] target[..]release[..]foo-[..]", p.url()))
+                       .with_stdout("
 running 1 test
 test bin_bench ... bench: [..] 0 ns/iter (+/- 0)
 
 test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured
 
-[RUNNING] target[..]release[..]foo-[..]
 
 running 1 test
 test lib_bench ... bench: [..] 0 ns/iter (+/- 0)
 
 test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured
 
-",
-        p.url())))
+"))
 });
 
 test!(bench_with_deep_lib_dep {
@@ -292,18 +291,17 @@ test!(bench_with_deep_lib_dep {
     p2.build();
     assert_that(p.cargo_process("bench"),
                 execs().with_status(0)
-                       .with_stdout(&format!("\
+                       .with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ([..])
 [COMPILING] bar v0.0.1 ({dir})
-[RUNNING] target[..]
-
+[RUNNING] target[..]", dir = p.url()))
+                       .with_stdout("
 running 1 test
 test bar_bench ... bench: [..] 0 ns/iter (+/- 0)
 
 test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured
 
-",
-                       dir = p.url())));
+"));
 });
 
 test!(external_bench_explicit {
@@ -338,24 +336,23 @@ test!(external_bench_explicit {
         "#);
 
     assert_that(p.cargo_process("bench"),
-        execs().with_stdout(&format!("\
+                execs().with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({})
 [RUNNING] target[..]release[..]bench-[..]
-
+[RUNNING] target[..]release[..]foo-[..]", p.url()))
+                       .with_stdout("
 running 1 test
 test external_bench ... bench: [..] 0 ns/iter (+/- 0)
 
 test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured
 
-[RUNNING] target[..]release[..]foo-[..]
 
 running 1 test
 test internal_bench ... bench: [..] 0 ns/iter (+/- 0)
 
 test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured
 
-",
-        p.url())))
+"))
 });
 
 test!(external_bench_implicit {
@@ -387,24 +384,23 @@ test!(external_bench_implicit {
         "#);
 
     assert_that(p.cargo_process("bench"),
-        execs().with_stdout(&format!("\
+                execs().with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({})
 [RUNNING] target[..]release[..]external-[..]
-
+[RUNNING] target[..]release[..]foo-[..]", p.url()))
+                       .with_stdout("
 running 1 test
 test external_bench ... bench: [..] 0 ns/iter (+/- 0)
 
 test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured
 
-[RUNNING] target[..]release[..]foo-[..]
 
 running 1 test
 test internal_bench ... bench: [..] 0 ns/iter (+/- 0)
 
 test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured
 
-",
-        p.url())))
+"))
 });
 
 test!(dont_run_examples {
@@ -446,23 +442,22 @@ test!(pass_through_command_line {
 
     assert_that(p.cargo_process("bench").arg("bar"),
                 execs().with_status(0)
-                       .with_stdout(&format!("\
+                .with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({dir})
-[RUNNING] target[..]release[..]foo-[..]
-
+[RUNNING] target[..]release[..]foo-[..]", dir = p.url()))
+                .with_stdout("
 running 1 test
 test bar ... bench: [..] 0 ns/iter (+/- 0)
 
 test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured
 
-",
-                       dir = p.url())));
+"));
 
     assert_that(p.cargo("bench").arg("foo"),
                 execs().with_status(0)
-                       .with_stdout("\
-[RUNNING] target[..]release[..]foo-[..]
-
+                       .with_stderr("\
+[RUNNING] target[..]release[..]foo-[..]")
+                       .with_stdout("
 running 1 test
 test foo ... bench: [..] 0 ns/iter (+/- 0)
 
@@ -526,24 +521,23 @@ test!(lib_bin_same_name {
         ");
 
     assert_that(p.cargo_process("bench"),
-        execs().with_stdout(&format!("\
+                execs().with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({})
 [RUNNING] target[..]release[..]foo-[..]
+[RUNNING] target[..]release[..]foo-[..]", p.url()))
+                       .with_stdout("
+running 1 test
+test [..] ... bench: [..] 0 ns/iter (+/- 0)
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured
+
 
 running 1 test
 test [..] ... bench: [..] 0 ns/iter (+/- 0)
 
 test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured
 
-[RUNNING] target[..]release[..]foo-[..]
-
-running 1 test
-test [..] ... bench: [..] 0 ns/iter (+/- 0)
-
-test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured
-
-",
-        p.url())))
+"))
 });
 
 test!(lib_with_standard_name {
@@ -579,24 +573,23 @@ test!(lib_with_standard_name {
 
     assert_that(p.cargo_process("bench"),
                 execs().with_status(0)
-                       .with_stdout(&format!("\
+                       .with_stderr(&format!("\
 [COMPILING] syntax v0.0.1 ({dir})
 [RUNNING] target[..]release[..]bench-[..]
-
+[RUNNING] target[..]release[..]syntax-[..]", dir = p.url()))
+                       .with_stdout("
 running 1 test
 test bench ... bench: [..] 0 ns/iter (+/- 0)
 
 test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured
 
-[RUNNING] target[..]release[..]syntax-[..]
 
 running 1 test
 test foo_bench ... bench: [..] 0 ns/iter (+/- 0)
 
 test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured
 
-",
-                       dir = p.url())));
+"));
 });
 
 test!(lib_with_standard_name2 {
@@ -630,17 +623,16 @@ test!(lib_with_standard_name2 {
 
     assert_that(p.cargo_process("bench"),
                 execs().with_status(0)
-                       .with_stdout(&format!("\
+                       .with_stderr(&format!("\
 [COMPILING] syntax v0.0.1 ({dir})
-[RUNNING] target[..]release[..]syntax-[..]
-
+[RUNNING] target[..]release[..]syntax-[..]", dir = p.url()))
+                       .with_stdout("
 running 1 test
 test bench ... bench: [..] 0 ns/iter (+/- 0)
 
 test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured
 
-",
-                       dir = p.url())));
+"));
 });
 
 test!(bench_dylib {
@@ -694,7 +686,7 @@ test!(bench_dylib {
 
     assert_that(p.cargo_process("bench").arg("-v"),
                 execs().with_status(0)
-                       .with_stdout(&format!("\
+                       .with_stderr(&format!("\
 [COMPILING] bar v0.0.1 ({dir}/bar)
 [RUNNING] [..] -C opt-level=3 [..]
 [COMPILING] foo v0.0.1 ({dir})
@@ -702,43 +694,41 @@ test!(bench_dylib {
 [RUNNING] [..] -C opt-level=3 [..]
 [RUNNING] [..] -C opt-level=3 [..]
 [RUNNING] [..]target[..]release[..]bench-[..]
+[RUNNING] [..]target[..]release[..]foo-[..]", dir = p.url()))
+                       .with_stdout("
+running 1 test
+test foo ... bench: [..] 0 ns/iter (+/- 0)
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured
+
 
 running 1 test
 test foo ... bench: [..] 0 ns/iter (+/- 0)
 
 test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured
 
-[RUNNING] [..]target[..]release[..]foo-[..]
-
-running 1 test
-test foo ... bench: [..] 0 ns/iter (+/- 0)
-
-test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured
-
-",
-                       dir = p.url())));
+"));
     p.root().move_into_the_past().unwrap();
     assert_that(p.cargo("bench").arg("-v"),
                 execs().with_status(0)
-                       .with_stdout(&format!("\
+                       .with_stderr(&format!("\
 [FRESH] bar v0.0.1 ({dir}/bar)
 [FRESH] foo v0.0.1 ({dir})
 [RUNNING] [..]target[..]release[..]bench-[..]
+[RUNNING] [..]target[..]release[..]foo-[..]", dir = p.url()))
+                       .with_stdout("
+running 1 test
+test foo ... bench: [..] 0 ns/iter (+/- 0)
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured
+
 
 running 1 test
 test foo ... bench: [..] 0 ns/iter (+/- 0)
 
 test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured
 
-[RUNNING] [..]target[..]release[..]foo-[..]
-
-running 1 test
-test foo ... bench: [..] 0 ns/iter (+/- 0)
-
-test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured
-
-",
-                       dir = p.url())));
+"));
 });
 
 test!(bench_twice_with_build_cmd {
@@ -762,23 +752,22 @@ test!(bench_twice_with_build_cmd {
 
     assert_that(p.cargo_process("bench"),
                 execs().with_status(0)
-                       .with_stdout(&format!("\
+                       .with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({dir})
-[RUNNING] target[..]release[..]foo-[..]
-
+[RUNNING] target[..]release[..]foo-[..]", dir = p.url()))
+                       .with_stdout("
 running 1 test
 test foo ... bench: [..] 0 ns/iter (+/- 0)
 
 test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured
 
-",
-                       dir = p.url())));
+"));
 
     assert_that(p.cargo("bench"),
                 execs().with_status(0)
-                       .with_stdout("\
-[RUNNING] target[..]release[..]foo-[..]
-
+                       .with_stderr("\
+[RUNNING] target[..]release[..]foo-[..]")
+                       .with_stdout("
 running 1 test
 test foo ... bench: [..] 0 ns/iter (+/- 0)
 
@@ -842,28 +831,27 @@ test!(bench_with_examples {
 
     assert_that(p.cargo_process("bench").arg("-v"),
                 execs().with_status(0)
-                       .with_stdout(&format!("\
+                       .with_stderr(&format!("\
 [COMPILING] testbench v6.6.6 ({url})
 [RUNNING] `rustc [..]`
 [RUNNING] `rustc [..]`
 [RUNNING] `rustc [..]`
 [RUNNING] `{dir}[..]target[..]release[..]testb1-[..] --bench`
-
+[RUNNING] `{dir}[..]target[..]release[..]testbench-[..] --bench`",
+                dir = p.root().display(), url = p.url()))
+                       .with_stdout("
 running 1 test
 test bench_bench2 ... bench: [..] 0 ns/iter (+/- 0)
 
 test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured
 
-[RUNNING] `{dir}[..]target[..]release[..]testbench-[..] --bench`
 
 running 1 test
 test bench_bench1 ... bench: [..] 0 ns/iter (+/- 0)
 
 test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured
 
-",
-                       dir = p.root().display(),
-                       url = p.url())));
+"));
 });
 
 test!(test_a_bench {
@@ -893,10 +881,10 @@ test!(test_a_bench {
 
     assert_that(p.cargo_process("test"),
                 execs().with_status(0)
-                       .with_stdout("\
+                       .with_stderr("\
 [COMPILING] foo v0.1.0 ([..])
-[RUNNING] target[..]debug[..]b-[..]
-
+[RUNNING] target[..]debug[..]b-[..]")
+                       .with_stdout("
 running 1 test
 test foo ... ok
 

--- a/tests/test_cargo_bench.rs
+++ b/tests/test_cargo_bench.rs
@@ -987,17 +987,17 @@ test!(test_bench_multiple_packages {
 
     assert_that(p.cargo_process("bench").arg("-p").arg("bar").arg("-p").arg("baz"),
                 execs().with_status(0)
-                       .with_stdout_contains("\
-[RUNNING] target[..]release[..]bbaz-[..]
-
+                       .with_stderr_contains("\
+[RUNNING] target[..]release[..]bbaz-[..]")
+                       .with_stdout_contains("
 running 1 test
 test bench_baz ... bench:           0 ns/iter (+/- 0)
 
 test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured
 ")
-                       .with_stdout_contains("\
-[RUNNING] target[..]release[..]bbar-[..]
-
+                       .with_stderr_contains("\
+[RUNNING] target[..]release[..]bbar-[..]")
+                       .with_stdout_contains("
 running 1 test
 test bench_bar ... bench:           0 ns/iter (+/- 0)
 

--- a/tests/test_cargo_bench.rs
+++ b/tests/test_cargo_bench.rs
@@ -174,20 +174,18 @@ test!(cargo_bench_failing_test {
                 execs().with_stdout("hello\n"));
 
     assert_that(p.cargo("bench"),
-                execs().with_stdout_contains(&format!("\
+                execs().with_stdout_contains("
+running 1 test
+test bench_hello ... ")
+                       .with_stderr_contains(format!("\
 [COMPILING] foo v0.5.0 ({})
 [RUNNING] target[..]release[..]foo-[..]
-
-running 1 test
-test bench_hello ... ",
-        p.url()))
-              .with_stderr_contains("\
 thread '<main>' panicked at 'assertion failed: \
     `(left == right)` (left: \
     `\"hello\"`, right: `\"nope\"`)', src[..]foo.rs:14
 [..]
-")
-              .with_status(101));
+", p.url()))
+                       .with_status(101));
 });
 
 test!(bench_with_lib_dep {

--- a/tests/test_cargo_bench.rs
+++ b/tests/test_cargo_bench.rs
@@ -67,20 +67,19 @@ test!(bench_tarname {
             extern crate test;
             #[bench] fn run2(_ben: &mut test::Bencher) { }"#);
 
-    let expected_stdout = format!("\
+    assert_that(prj.cargo_process("bench").arg("--bench").arg("bin2"),
+        execs().with_status(0)
+               .with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({dir})
 [RUNNING] target[..]release[..]bin2[..]
-
+", dir = prj.url()))
+               .with_stdout("
 running 1 test
 test run2 ... bench: [..] 0 ns/iter (+/- 0)
 
 test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured
 
-",
-       dir = prj.url());
-
-    assert_that(prj.cargo_process("bench").arg("--bench").arg("bin2"),
-        execs().with_status(0).with_stdout(expected_stdout));
+"));
 });
 
 test!(cargo_bench_verbose {
@@ -793,6 +792,7 @@ test!(bench_with_examples {
         .file("src/lib.rs", r#"
             #![feature(test)]
             extern crate test;
+            #[cfg(test)]
             use test::Bencher;
 
             pub fn f1() {

--- a/tests/test_cargo_build_auth.rs
+++ b/tests/test_cargo_build_auth.rs
@@ -99,12 +99,8 @@ test!(http_auth_offered {
         ");
 
     assert_that(p.cargo_process("build"),
-                execs().with_status(101).with_stdout(&format!("\
+                execs().with_status(101).with_stderr(&format!("\
 [UPDATING] git repository `http://{addr}/foo/bar`
-",
-        addr = addr,
-        ))
-                      .with_stderr(&format!("\
 [ERROR] Unable to update http://{addr}/foo/bar
 
 Caused by:
@@ -146,7 +142,7 @@ test!(https_something_happens {
         ");
 
     assert_that(p.cargo_process("build").arg("-v"),
-                execs().with_status(101).with_stdout(&format!("\
+                execs().with_status(101).with_stderr_contains(&format!("\
 [UPDATING] git repository `https://{addr}/foo/bar`
 ",
         addr = addr,
@@ -190,7 +186,7 @@ test!(ssh_something_happens {
         .file("src/main.rs", "");
 
     assert_that(p.cargo_process("build").arg("-v"),
-                execs().with_status(101).with_stdout(&format!("\
+                execs().with_status(101).with_stderr_contains(&format!("\
 [UPDATING] git repository `ssh://{addr}/foo/bar`
 ",
         addr = addr,

--- a/tests/test_cargo_build_lib.rs
+++ b/tests/test_cargo_build_lib.rs
@@ -35,7 +35,7 @@ test!(build_lib_only {
     assert_that(p.cargo_process("build").arg("--lib").arg("-v"),
                 execs()
                 .with_status(0)
-                .with_stdout(verbose_output_for_lib(&p)));
+                .with_stderr(verbose_output_for_lib(&p)));
 });
 
 

--- a/tests/test_cargo_cfg.rs
+++ b/tests/test_cargo_cfg.rs
@@ -184,7 +184,7 @@ test!(dont_include {
         "#)
         .file("b/src/lib.rs", "");
     assert_that(p.cargo_process("build"),
-                execs().with_status(0).with_stdout("\
+                execs().with_status(0).with_stderr("\
 [COMPILING] a v0.0.1 ([..])
 "));
 });
@@ -211,7 +211,7 @@ test!(works_through_the_registry {
         .file("src/lib.rs", "extern crate bar;");
 
     assert_that(p.cargo_process("build"),
-                execs().with_status(0).with_stdout("\
+                execs().with_status(0).with_stderr("\
 [UPDATING] registry [..]
 [DOWNLOADING] [..]
 [DOWNLOADING] [..]

--- a/tests/test_cargo_clean.rs
+++ b/tests/test_cargo_clean.rs
@@ -127,7 +127,7 @@ test!(clean_release {
     assert_that(p.cargo("clean").arg("-p").arg("foo").arg("--release"),
                 execs().with_status(0));
     assert_that(p.cargo("build").arg("--release"),
-                execs().with_status(0).with_stdout("\
+                execs().with_status(0).with_stderr("\
 [COMPILING] foo v0.0.1 ([..])
 "));
 });
@@ -163,7 +163,7 @@ test!(build_script {
     assert_that(p.cargo("clean").arg("-p").arg("foo"),
                 execs().with_status(0));
     assert_that(p.cargo("build").arg("-v"),
-                execs().with_status(0).with_stdout("\
+                execs().with_status(0).with_stderr("\
 [COMPILING] foo v0.0.1 ([..])
 [RUNNING] `rustc build.rs [..]`
 [RUNNING] `[..]build-script-build[..]`

--- a/tests/test_cargo_compile.rs
+++ b/tests/test_cargo_compile.rs
@@ -996,7 +996,7 @@ test!(lto_build {
         "#)
         .file("src/main.rs", "fn main() {}");
     assert_that(p.cargo_process("build").arg("-v").arg("--release"),
-                execs().with_status(0).with_stdout(&format!("\
+                execs().with_status(0).with_stderr(&format!("\
 [COMPILING] test v0.0.0 ({url})
 [RUNNING] `rustc src[..]main.rs --crate-name test --crate-type bin \
         -C opt-level=3 \
@@ -1023,7 +1023,7 @@ test!(verbose_build {
         "#)
         .file("src/lib.rs", "");
     assert_that(p.cargo_process("build").arg("-v"),
-                execs().with_status(0).with_stdout(&format!("\
+                execs().with_status(0).with_stderr(&format!("\
 [COMPILING] test v0.0.0 ({url})
 [RUNNING] `rustc src[..]lib.rs --crate-name test --crate-type lib -g \
         --out-dir {dir}[..]target[..]debug \
@@ -1048,7 +1048,7 @@ test!(verbose_release_build {
         "#)
         .file("src/lib.rs", "");
     assert_that(p.cargo_process("build").arg("-v").arg("--release"),
-                execs().with_status(0).with_stdout(&format!("\
+                execs().with_status(0).with_stderr(&format!("\
 [COMPILING] test v0.0.0 ({url})
 [RUNNING] `rustc src[..]lib.rs --crate-name test --crate-type lib \
         -C opt-level=3 \
@@ -1089,7 +1089,7 @@ test!(verbose_release_build_deps {
         "#)
         .file("foo/src/lib.rs", "");
     assert_that(p.cargo_process("build").arg("-v").arg("--release"),
-                execs().with_status(0).with_stdout(&format!("\
+                execs().with_status(0).with_stderr(&format!("\
 [COMPILING] foo v0.0.0 ({url}/foo)
 [RUNNING] `rustc foo[..]src[..]lib.rs --crate-name foo \
         --crate-type dylib --crate-type rlib -C prefer-dynamic \

--- a/tests/test_cargo_compile.rs
+++ b/tests/test_cargo_compile.rs
@@ -267,6 +267,7 @@ test!(cargo_compile_with_warnings_in_the_root_package {
     assert_that(p.cargo_process("build"),
         execs()
         .with_stderr("\
+[COMPILING] foo [..]
 src[..]foo.rs:1:14: 1:26 warning: function is never used: `dead`, \
     #[warn(dead_code)] on by default
 src[..]foo.rs:1 fn main() {} fn dead() {}
@@ -314,16 +315,13 @@ test!(cargo_compile_with_warnings_in_a_dep_package {
         "#);
 
     assert_that(p.cargo_process("build"),
-        execs()
-        .with_stderr(&format!("[COMPILING] bar v0.5.0 ({}/bar)\n\
-                              [COMPILING] foo v0.5.0 ({})\n",
-                             p.url(),
-                             p.url()))
-        .with_stderr("\
+        execs().with_stderr(&format!("\
+[COMPILING] bar v0.5.0 ({url}/bar)
 [..]warning: function is never used: `dead`[..]
-[..]fn dead() {}
+[..]fn dead() {{}}
 [..]^~~~~~~~~~~~
-"));
+[COMPILING] foo v0.5.0 ({url})
+", url = p.url())));
 
     assert_that(&p.bin("foo"), existing_file());
 
@@ -888,6 +886,7 @@ test!(unused_keys {
                 execs().with_status(0)
                        .with_stderr("\
 warning: unused manifest key: project.bulid
+[COMPILING] foo [..]
 "));
 
     let mut p = project("bar");
@@ -911,6 +910,7 @@ warning: unused manifest key: project.bulid
                 execs().with_status(0)
                        .with_stderr("\
 warning: unused manifest key: lib.build
+[COMPILING] foo [..]
 "));
 });
 

--- a/tests/test_cargo_compile.rs
+++ b/tests/test_cargo_compile.rs
@@ -1312,7 +1312,7 @@ test!(lib_with_standard_name {
 
     assert_that(p.cargo_process("build"),
                 execs().with_status(0)
-                       .with_stdout(&format!("\
+                       .with_stderr(&format!("\
 [COMPILING] syntax v0.0.1 ({dir})
 ",
                        dir = p.url())));
@@ -1408,7 +1408,7 @@ test!(freshness_ignores_excluded {
 
     assert_that(foo.cargo("build"),
                 execs().with_status(0)
-                       .with_stdout(&format!("\
+                       .with_stderr(&format!("\
 [COMPILING] foo v0.0.0 ({url})
 ", url = foo.url())));
 
@@ -1455,14 +1455,14 @@ test!(rebuild_preserves_out_dir {
 
     assert_that(foo.cargo("build").env("FIRST", "1"),
                 execs().with_status(0)
-                       .with_stdout(&format!("\
+                       .with_stderr(&format!("\
 [COMPILING] foo v0.0.0 ({url})
 ", url = foo.url())));
 
     File::create(&foo.root().join("src/bar.rs")).unwrap();
     assert_that(foo.cargo("build"),
                 execs().with_status(0)
-                       .with_stdout(&format!("\
+                       .with_stderr(&format!("\
 [COMPILING] foo v0.0.0 ({url})
 ", url = foo.url())));
 });

--- a/tests/test_cargo_compile.rs
+++ b/tests/test_cargo_compile.rs
@@ -315,7 +315,7 @@ test!(cargo_compile_with_warnings_in_a_dep_package {
 
     assert_that(p.cargo_process("build"),
         execs()
-        .with_stdout(&format!("[COMPILING] bar v0.5.0 ({}/bar)\n\
+        .with_stderr(&format!("[COMPILING] bar v0.5.0 ({}/bar)\n\
                               [COMPILING] foo v0.5.0 ({})\n",
                              p.url(),
                              p.url()))

--- a/tests/test_cargo_compile_custom_build.rs
+++ b/tests/test_cargo_compile_custom_build.rs
@@ -556,7 +556,7 @@ test!(propagation_of_l_flags {
 
     assert_that(p.cargo_process("build").arg("-v").arg("-j1"),
                 execs().with_status(0)
-                       .with_stdout_contains("\
+                       .with_stderr_contains("\
 [RUNNING] `rustc [..] --crate-name a [..]-L bar[..]-L foo[..]`
 [COMPILING] foo v0.5.0 (file://[..])
 [RUNNING] `rustc [..] --crate-name foo [..] -L bar -L foo`
@@ -609,7 +609,7 @@ test!(propagation_of_l_flags_new {
 
     assert_that(p.cargo_process("build").arg("-v").arg("-j1"),
                 execs().with_status(0)
-                       .with_stdout_contains("\
+                       .with_stderr_contains("\
 [RUNNING] `rustc [..] --crate-name a [..]-L bar[..]-L foo[..]`
 [COMPILING] foo v0.5.0 (file://[..])
 [RUNNING] `rustc [..] --crate-name foo [..] -L bar -L foo`
@@ -1815,7 +1815,7 @@ test!(doctest_recieves_build_link_args {
 
     assert_that(p.cargo_process("test").arg("-v"),
                 execs().with_status(0)
-                       .with_stdout_contains("\
+                       .with_stderr_contains("\
 [RUNNING] `rustdoc --test [..] --crate-name foo [..]-L native=bar[..]`
 "));
 });
@@ -1855,7 +1855,7 @@ test!(please_respect_the_dag {
 
     assert_that(p.cargo_process("build").arg("-v"),
                 execs().with_status(0)
-                       .with_stdout_contains("\
+                       .with_stderr_contains("\
 [RUNNING] `rustc [..] -L native=foo -L native=bar[..]`
 "));
 });

--- a/tests/test_cargo_compile_custom_build.rs
+++ b/tests/test_cargo_compile_custom_build.rs
@@ -32,13 +32,10 @@ test!(custom_build_script_failed {
 [COMPILING] foo v0.5.0 ({url})
 [RUNNING] `rustc build.rs --crate-name build_script_build --crate-type bin [..]`
 [RUNNING] `[..]build-script-build[..]`
-",
-url = p.url()))
-                       .with_stderr(&format!("\
-[ERROR] failed to run custom build command for `foo v0.5.0 ({})`
+[ERROR] failed to run custom build command for `foo v0.5.0 ({url})`
 Process didn't exit successfully: `[..]build[..]build-script-build[..]` \
     (exit code: 101)",
-p.url())));
+url = p.url())));
 });
 
 test!(custom_build_env_vars {
@@ -133,7 +130,7 @@ test!(custom_build_script_wrong_rustc_flags {
 
     assert_that(p.cargo_process("build"),
                 execs().with_status(101)
-                       .with_stderr(&format!("\
+                       .with_stderr_contains(&format!("\
 [ERROR] Only `-l` and `-L` flags are allowed in build script of `foo v0.5.0 ({})`: \
 `-aaa -bbb`",
 p.url())));
@@ -679,7 +676,7 @@ test!(build_deps_not_for_normal {
 
     assert_that(p.cargo_process("build").arg("-v").arg("--target").arg(&target),
                 execs().with_status(101)
-                       .with_stderr("\
+                       .with_stderr_contains("\
 [..]lib.rs[..] error: can't find crate for `aaaaa`[..]
 [..]lib.rs[..] extern crate aaaaa;
 [..]           ^~~~~~~~~~~~~~~~~~~
@@ -819,11 +816,13 @@ test!(output_separate_lines {
         "#);
     assert_that(p.cargo_process("build").arg("-v"),
                 execs().with_status(101)
-                       .with_stderr("\
+                       .with_stderr_contains("\
 [COMPILING] foo v0.5.0 (file://[..])
 [RUNNING] `rustc build.rs [..]`
 [RUNNING] `[..]foo-[..]build-script-build[..]`
 [RUNNING] `rustc [..] --crate-name foo [..] -L foo -l static=foo`
+[ERROR] could not find native static library [..]
+[ERROR] Could not compile [..]
 "));
 });
 
@@ -845,11 +844,13 @@ test!(output_separate_lines_new {
         "#);
     assert_that(p.cargo_process("build").arg("-v"),
                 execs().with_status(101)
-                       .with_stderr("\
+                       .with_stderr_contains("\
 [COMPILING] foo v0.5.0 (file://[..])
 [RUNNING] `rustc build.rs [..]`
 [RUNNING] `[..]foo-[..]build-script-build[..]`
 [RUNNING] `rustc [..] --crate-name foo [..] -L foo -l static=foo`
+[ERROR] could not find native static library [..]
+[ERROR] Could not compile [..]
 "));
 });
 

--- a/tests/test_cargo_compile_custom_build.rs
+++ b/tests/test_cargo_compile_custom_build.rs
@@ -471,19 +471,19 @@ test!(testing_and_such {
     println!("test");
     assert_that(p.cargo("test").arg("-vj1"),
                 execs().with_status(0)
-                       .with_stdout("\
+                       .with_stderr("\
 [COMPILING] foo v0.5.0 (file://[..])
 [RUNNING] `[..]build-script-build[..]`
 [RUNNING] `rustc [..] --crate-name foo [..]`
 [RUNNING] `rustc [..] --crate-name foo [..]`
 [RUNNING] `[..]foo-[..][..]`
-
+[DOCTEST] foo
+[RUNNING] `rustdoc --test [..]`")
+                       .with_stdout("
 running 0 tests
 
 test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
 
-[DOCTEST] foo
-[RUNNING] `rustdoc --test [..]`
 
 running 0 tests
 
@@ -730,7 +730,7 @@ test!(build_cmd_with_a_build_cmd {
 
     assert_that(p.cargo_process("build").arg("-v"),
                 execs().with_status(0)
-                       .with_stdout("\
+                       .with_stderr("\
 [COMPILING] b v0.5.0 (file://[..])
 [RUNNING] `rustc [..] --crate-name b [..]`
 [COMPILING] a v0.5.0 (file://[..])
@@ -888,9 +888,10 @@ test!(code_generation {
         "#);
     assert_that(p.cargo_process("run"),
                 execs().with_status(0)
-                       .with_stdout("\
+                       .with_stderr("\
 [COMPILING] foo v0.5.0 (file://[..])
-[RUNNING] `target[..]foo`
+[RUNNING] `target[..]foo`")
+                       .with_stdout("\
 Hello, World!
 "));
 
@@ -1310,7 +1311,7 @@ test!(cfg_test {
             fn test_bar() {}
         "#);
     assert_that(p.cargo_process("test").arg("-v"),
-                execs().with_stdout(format!("\
+                execs().with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({dir})
 [RUNNING] [..] build.rs [..]
 [RUNNING] [..]build-script-build[..]
@@ -1318,28 +1319,28 @@ test!(cfg_test {
 [RUNNING] [..] --cfg foo[..]
 [RUNNING] [..] --cfg foo[..]
 [RUNNING] [..]foo-[..]
-
+[RUNNING] [..]test-[..]
+[DOCTEST] foo
+[RUNNING] [..] --cfg foo[..]", dir = p.url()))
+                       .with_stdout("
 running 1 test
 test test_foo ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
 
-[RUNNING] [..]test-[..]
 
 running 1 test
 test test_bar ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
 
-[DOCTEST] foo
-[RUNNING] [..] --cfg foo[..]
 
 running 1 test
 test foo_0 ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
 
-", dir = p.url())));
+"));
 });
 
 test!(cfg_doc {
@@ -1426,34 +1427,34 @@ test!(cfg_override_test {
             fn test_bar() {}
         "#);
     assert_that(p.cargo_process("test").arg("-v"),
-                execs().with_stdout(format!("\
+                execs().with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({dir})
 [RUNNING] `[..]`
 [RUNNING] `[..]`
 [RUNNING] `[..]`
 [RUNNING] [..]foo-[..]
-
+[RUNNING] [..]test-[..]
+[DOCTEST] foo
+[RUNNING] [..] --cfg foo[..]", dir = p.url()))
+                       .with_stdout("
 running 1 test
 test test_foo ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
 
-[RUNNING] [..]test-[..]
 
 running 1 test
 test test_bar ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
 
-[DOCTEST] foo
-[RUNNING] [..] --cfg foo[..]
 
 running 1 test
 test foo_0 ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
 
-", dir = p.url())));
+"));
 });
 
 test!(cfg_override_doc {
@@ -1537,7 +1538,8 @@ test!(flags_go_into_tests {
         "#);
 
     assert_that(p.cargo_process("test").arg("-v").arg("--test=foo"),
-                execs().with_status(0).with_stdout("\
+                execs().with_status(0)
+                       .with_stderr("\
 [COMPILING] a v0.5.0 ([..]
 [RUNNING] `rustc a[..]build.rs [..]`
 [RUNNING] `[..]build-script-build[..]`
@@ -1547,8 +1549,8 @@ test!(flags_go_into_tests {
 [COMPILING] foo v0.5.0 ([..]
 [RUNNING] `rustc src[..]lib.rs [..] -L test[..]`
 [RUNNING] `rustc tests[..]foo.rs [..] -L test[..]`
-[RUNNING] `[..]foo-[..]`
-
+[RUNNING] `[..]foo-[..]`")
+                       .with_stdout("
 running 0 tests
 
 test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
@@ -1556,12 +1558,13 @@ test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
 "));
 
     assert_that(p.cargo("test").arg("-v").arg("-pb").arg("--lib"),
-                execs().with_status(0).with_stdout("\
+                execs().with_status(0)
+                       .with_stderr("\
 [FRESH] a v0.5.0 ([..]
 [COMPILING] b v0.5.0 ([..]
 [RUNNING] `rustc b[..]src[..]lib.rs [..] -L test[..]`
-[RUNNING] `[..]b-[..]`
-
+[RUNNING] `[..]b-[..]`")
+                       .with_stdout("
 running 0 tests
 
 test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured

--- a/tests/test_cargo_compile_custom_build.rs
+++ b/tests/test_cargo_compile_custom_build.rs
@@ -174,7 +174,7 @@ test!(custom_build_script_rustc_flags {
     // TODO: TEST FAILS BECAUSE OF WRONG STDOUT (but otherwise, the build works)
     assert_that(p.cargo_process("build").arg("--verbose"),
                 execs().with_status(101)
-                       .with_stdout(&format!("\
+                       .with_stderr(&format!("\
 [COMPILING] bar v0.5.0 ({url})
 [RUNNING] `rustc {dir}{sep}src{sep}lib.rs --crate-name test --crate-type lib -g \
         -C metadata=[..] \

--- a/tests/test_cargo_compile_custom_build.rs
+++ b/tests/test_cargo_compile_custom_build.rs
@@ -28,7 +28,7 @@ test!(custom_build_script_failed {
         "#);
     assert_that(p.cargo_process("build").arg("-v"),
                 execs().with_status(101)
-                       .with_stdout(&format!("\
+                       .with_stderr(&format!("\
 [COMPILING] foo v0.5.0 ({url})
 [RUNNING] `rustc build.rs --crate-name build_script_build --crate-type bin [..]`
 [RUNNING] `[..]build-script-build[..]`

--- a/tests/test_cargo_compile_custom_build.rs
+++ b/tests/test_cargo_compile_custom_build.rs
@@ -289,7 +289,7 @@ test!(overrides_and_links {
 
     assert_that(p.cargo_process("build").arg("-v"),
                 execs().with_status(0)
-                       .with_stdout("\
+                       .with_stderr("\
 [..]
 [..]
 [..]
@@ -386,7 +386,7 @@ test!(only_rerun_build_script {
 
     assert_that(p.cargo("build").arg("-v"),
                 execs().with_status(0)
-                       .with_stdout("\
+                       .with_stderr("\
 [COMPILING] foo v0.5.0 (file://[..])
 [RUNNING] `[..]build-script-build[..]`
 [RUNNING] `rustc [..] --crate-name foo [..]`
@@ -494,7 +494,7 @@ test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
     println!("doc");
     assert_that(p.cargo("doc").arg("-v"),
                 execs().with_status(0)
-                       .with_stdout("\
+                       .with_stderr("\
 [DOCUMENTING] foo v0.5.0 (file://[..])
 [RUNNING] `rustdoc [..]`
 "));
@@ -504,7 +504,7 @@ test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
     println!("run");
     assert_that(p.cargo("run"),
                 execs().with_status(0)
-                       .with_stdout("\
+                       .with_stderr("\
 [COMPILING] foo v0.5.0 (file://[..])
 [RUNNING] `target[..]foo[..]`
 "));
@@ -642,7 +642,7 @@ test!(build_deps_simple {
 
     assert_that(p.cargo_process("build").arg("-v"),
                 execs().with_status(0)
-                       .with_stdout("\
+                       .with_stderr("\
 [COMPILING] a v0.5.0 (file://[..])
 [RUNNING] `rustc [..] --crate-name a [..]`
 [COMPILING] foo v0.5.0 (file://[..])
@@ -819,7 +819,7 @@ test!(output_separate_lines {
         "#);
     assert_that(p.cargo_process("build").arg("-v"),
                 execs().with_status(101)
-                       .with_stdout("\
+                       .with_stderr("\
 [COMPILING] foo v0.5.0 (file://[..])
 [RUNNING] `rustc build.rs [..]`
 [RUNNING] `[..]foo-[..]build-script-build[..]`
@@ -845,7 +845,7 @@ test!(output_separate_lines_new {
         "#);
     assert_that(p.cargo_process("build").arg("-v"),
                 execs().with_status(101)
-                       .with_stdout("\
+                       .with_stderr("\
 [COMPILING] foo v0.5.0 (file://[..])
 [RUNNING] `rustc build.rs [..]`
 [RUNNING] `[..]foo-[..]build-script-build[..]`
@@ -1617,7 +1617,7 @@ test!(diamond_passes_args_only_once {
         .file("c/src/lib.rs", "");
 
     assert_that(p.cargo_process("build").arg("-v"),
-                execs().with_status(0).with_stdout("\
+                execs().with_status(0).with_stderr("\
 [COMPILING] c v0.5.0 ([..]
 [RUNNING] `rustc [..]`
 [RUNNING] `[..]`
@@ -1651,7 +1651,7 @@ test!(adding_an_override_invalidates {
         "#);
 
     assert_that(p.cargo_process("build").arg("-v"),
-                execs().with_status(0).with_stdout("\
+                execs().with_status(0).with_stderr("\
 [COMPILING] foo v0.5.0 ([..]
 [RUNNING] `rustc [..]`
 [RUNNING] `[..]`
@@ -1664,7 +1664,7 @@ test!(adding_an_override_invalidates {
     ", target).as_bytes()).unwrap();
 
     assert_that(p.cargo("build").arg("-v"),
-                execs().with_status(0).with_stdout("\
+                execs().with_status(0).with_stderr("\
 [COMPILING] foo v0.5.0 ([..]
 [RUNNING] `rustc [..] -L native=bar`
 "));
@@ -1689,7 +1689,7 @@ test!(changing_an_override_invalidates {
         .file("build.rs", "");
 
     assert_that(p.cargo_process("build").arg("-v"),
-                execs().with_status(0).with_stdout("\
+                execs().with_status(0).with_stderr("\
 [COMPILING] foo v0.5.0 ([..]
 [RUNNING] `rustc [..] -L native=foo`
 "));
@@ -1700,7 +1700,7 @@ test!(changing_an_override_invalidates {
     ", target).as_bytes()).unwrap();
 
     assert_that(p.cargo("build").arg("-v"),
-                execs().with_status(0).with_stdout("\
+                execs().with_status(0).with_stderr("\
 [COMPILING] foo v0.5.0 ([..]
 [RUNNING] `rustc [..] -L native=bar`
 "));
@@ -1730,7 +1730,7 @@ test!(rebuild_only_on_explicit_paths {
     // files don't exist, so should always rerun if they don't exist
     println!("run without");
     assert_that(p.cargo("build").arg("-v"),
-                execs().with_status(0).with_stdout("\
+                execs().with_status(0).with_stderr("\
 [COMPILING] a v0.5.0 ([..])
 [RUNNING] `[..]build-script-build[..]`
 [RUNNING] `rustc src[..]lib.rs [..]`
@@ -1743,7 +1743,7 @@ test!(rebuild_only_on_explicit_paths {
     // now the exist, so run once, catch the mtime, then shouldn't run again
     println!("run with");
     assert_that(p.cargo("build").arg("-v"),
-                execs().with_status(0).with_stdout("\
+                execs().with_status(0).with_stderr("\
 [COMPILING] a v0.5.0 ([..])
 [RUNNING] `[..]build-script-build[..]`
 [RUNNING] `rustc src[..]lib.rs [..]`
@@ -1751,7 +1751,7 @@ test!(rebuild_only_on_explicit_paths {
 
     println!("run with2");
     assert_that(p.cargo("build").arg("-v"),
-                execs().with_status(0).with_stdout("\
+                execs().with_status(0).with_stderr("\
 [FRESH] a v0.5.0 ([..])
 "));
 
@@ -1761,7 +1761,7 @@ test!(rebuild_only_on_explicit_paths {
     println!("run baz");
     File::create(p.root().join("baz")).unwrap();
     assert_that(p.cargo("build").arg("-v"),
-                execs().with_status(0).with_stdout("\
+                execs().with_status(0).with_stderr("\
 [FRESH] a v0.5.0 ([..])
 "));
 
@@ -1769,7 +1769,7 @@ test!(rebuild_only_on_explicit_paths {
     println!("run foo change");
     File::create(p.root().join("foo")).unwrap();
     assert_that(p.cargo("build").arg("-v"),
-                execs().with_status(0).with_stdout("\
+                execs().with_status(0).with_stderr("\
 [COMPILING] a v0.5.0 ([..])
 [RUNNING] `[..]build-script-build[..]`
 [RUNNING] `rustc src[..]lib.rs [..]`
@@ -1779,7 +1779,7 @@ test!(rebuild_only_on_explicit_paths {
     println!("run foo delete");
     fs::remove_file(p.root().join("bar")).unwrap();
     assert_that(p.cargo("build").arg("-v"),
-                execs().with_status(0).with_stdout("\
+                execs().with_status(0).with_stderr("\
 [COMPILING] a v0.5.0 ([..])
 [RUNNING] `[..]build-script-build[..]`
 [RUNNING] `rustc src[..]lib.rs [..]`

--- a/tests/test_cargo_compile_git_deps.rs
+++ b/tests/test_cargo_compile_git_deps.rs
@@ -1553,7 +1553,7 @@ test!(switch_sources {
     p.build();
     assert_that(p.cargo("build"),
                 execs().with_status(0)
-                       .with_stdout("\
+                       .with_stderr("\
 [UPDATING] git repository `file://[..]a1`
 [COMPILING] a v0.5.0 ([..]a1#[..]
 [COMPILING] b v0.5.0 ([..])
@@ -1571,7 +1571,7 @@ test!(switch_sources {
 
     assert_that(p.cargo("build"),
                 execs().with_status(0)
-                       .with_stdout("\
+                       .with_stderr("\
 [UPDATING] git repository `file://[..]a2`
 [COMPILING] a v0.5.1 ([..]a2#[..]
 [COMPILING] b v0.5.0 ([..])
@@ -1677,7 +1677,7 @@ test!(lints_are_suppressed {
         .file("src/lib.rs", "");
 
     assert_that(p.cargo_process("build"),
-                execs().with_status(0).with_stdout("\
+                execs().with_status(0).with_stderr("\
 [UPDATING] git repository `[..]`
 [COMPILING] a v0.5.0 ([..])
 [COMPILING] foo v0.0.1 ([..])
@@ -1714,7 +1714,7 @@ test!(denied_lints_are_allowed {
         .file("src/lib.rs", "");
 
     assert_that(p.cargo_process("build"),
-                execs().with_status(0).with_stdout("\
+                execs().with_status(0).with_stderr("\
 [UPDATING] git repository `[..]`
 [COMPILING] a v0.5.0 ([..])
 [COMPILING] foo v0.0.1 ([..])

--- a/tests/test_cargo_compile_git_deps.rs
+++ b/tests/test_cargo_compile_git_deps.rs
@@ -850,7 +850,7 @@ test!(stale_cached_version {
     // Now build!
     assert_that(foo.cargo("build"),
                 execs().with_status(0)
-                       .with_stdout(&format!("\
+                       .with_stderr(&format!("\
 [UPDATING] git repository `{bar}`
 [COMPILING] bar v0.0.0 ({bar}#[..])
 [COMPILING] foo v0.0.0 ({foo})
@@ -990,7 +990,7 @@ test!(dev_deps_with_testing {
     // Generate a lockfile which did not use `bar` to compile, but had to update
     // `bar` to generate the lockfile
     assert_that(p.cargo_process("build"),
-        execs().with_stdout(&format!("\
+        execs().with_stderr(&format!("\
 [UPDATING] git repository `{bar}`
 [COMPILING] foo v0.5.0 ({url})
 ", url = p.url(), bar = p2.url())));
@@ -1032,7 +1032,7 @@ test!(git_build_cmd_freshness {
 
     assert_that(foo.cargo("build"),
                 execs().with_status(0)
-                       .with_stdout(&format!("\
+                       .with_stderr(&format!("\
 [COMPILING] foo v0.0.0 ({url})
 ", url = foo.url())));
 
@@ -1083,7 +1083,7 @@ test!(git_name_not_always_needed {
     // Generate a lockfile which did not use `bar` to compile, but had to update
     // `bar` to generate the lockfile
     assert_that(p.cargo_process("build"),
-        execs().with_stdout(&format!("\
+        execs().with_stderr(&format!("\
 [UPDATING] git repository `{bar}`
 [COMPILING] foo v0.5.0 ({url})
 ", url = p.url(), bar = p2.url())));
@@ -1116,7 +1116,7 @@ test!(git_repo_changing_no_rebuild {
     p1.build();
     p1.root().move_into_the_past().unwrap();
     assert_that(p1.cargo("build"),
-                execs().with_stdout(&format!("\
+                execs().with_stderr(&format!("\
 [UPDATING] git repository `{bar}`
 [COMPILING] [..]
 [COMPILING] [..]
@@ -1142,7 +1142,7 @@ test!(git_repo_changing_no_rebuild {
         "#, bar.url()))
         .file("src/main.rs", "fn main() {}");
     assert_that(p2.cargo_process("build"),
-                execs().with_stdout(&format!("\
+                execs().with_stderr(&format!("\
 [UPDATING] git repository `{bar}`
 [COMPILING] [..]
 [COMPILING] [..]
@@ -1238,7 +1238,7 @@ test!(fetch_downloads {
         "#, bar.url()))
         .file("src/main.rs", "fn main() {}");
     assert_that(p.cargo_process("fetch"),
-                execs().with_status(0).with_stdout(&format!("\
+                execs().with_status(0).with_stderr(&format!("\
 [UPDATING] git repository `{url}`
 ", url = bar.url())));
 
@@ -1373,7 +1373,7 @@ test!(update_one_dep_in_repo_with_many_deps {
     assert_that(p.cargo("update")
                  .arg("-p").arg("foo"),
                 execs().with_status(0)
-                       .with_stdout(&format!("\
+                       .with_stderr(&format!("\
 [UPDATING] git repository `{}`
 ", foo.url())));
 });
@@ -1427,7 +1427,7 @@ test!(switch_deps_does_not_update_transitive {
     p.build();
     assert_that(p.cargo("build"),
                 execs().with_status(0)
-                       .with_stdout(&format!("\
+                       .with_stderr(&format!("\
 [UPDATING] git repository `{}`
 [UPDATING] git repository `{}`
 [COMPILING] transitive [..]
@@ -1448,7 +1448,7 @@ test!(switch_deps_does_not_update_transitive {
 
     assert_that(p.cargo("build"),
                 execs().with_status(0)
-                       .with_stdout(&format!("\
+                       .with_stderr(&format!("\
 [UPDATING] git repository `{}`
 [COMPILING] dep [..]
 [COMPILING] project [..]

--- a/tests/test_cargo_compile_git_deps.rs
+++ b/tests/test_cargo_compile_git_deps.rs
@@ -615,7 +615,7 @@ test!(update_with_shared_deps {
 
     // First time around we should compile both foo and bar
     assert_that(p.cargo_process("build"),
-                execs().with_stdout(&format!("\
+                execs().with_stderr(&format!("\
 [UPDATING] git repository `{git}`
 [COMPILING] bar v0.5.0 ({git}#[..])
 [COMPILING] [..] v0.5.0 ([..])
@@ -670,7 +670,7 @@ To learn more, run the command again with --verbose.
     // Make sure we still only compile one version of the git repo
     println!("build");
     assert_that(p.cargo("build"),
-                execs().with_stdout(&format!("\
+                execs().with_stderr(&format!("\
 [COMPILING] bar v0.5.0 ({git}#[..])
 [COMPILING] [..] v0.5.0 ({dir}[..]dep[..])
 [COMPILING] [..] v0.5.0 ({dir}[..]dep[..])
@@ -998,11 +998,11 @@ test!(dev_deps_with_testing {
     // Make sure we use the previous resolution of `bar` instead of updating it
     // a second time.
     assert_that(p.cargo("test"),
-        execs().with_stdout("\
+                execs().with_stderr("\
 [COMPILING] [..] v0.5.0 ([..])
 [COMPILING] [..] v0.5.0 ([..]
-[RUNNING] target[..]foo-[..]
-
+[RUNNING] target[..]foo-[..]")
+                       .with_stdout("
 running 1 test
 test tests::foo ... ok
 

--- a/tests/test_cargo_compile_git_deps.rs
+++ b/tests/test_cargo_compile_git_deps.rs
@@ -56,7 +56,7 @@ test!(cargo_compile_simple_git_dep {
 
     assert_that(project.cargo_process("build"),
         execs()
-        .with_stdout(&format!("[UPDATING] git repository `{}`\n\
+        .with_stderr(&format!("[UPDATING] git repository `{}`\n\
                               [COMPILING] dep1 v0.5.0 ({}#[..])\n\
                               [COMPILING] foo v0.5.0 ({})\n",
                              path2url(git_root.clone()),
@@ -123,7 +123,7 @@ test!(cargo_compile_git_dep_branch {
 
     assert_that(project.cargo_process("build"),
         execs()
-        .with_stdout(&format!("[UPDATING] git repository `{}`\n\
+        .with_stderr(&format!("[UPDATING] git repository `{}`\n\
                               [COMPILING] dep1 v0.5.0 ({}?branch=branchy#[..])\n\
                               [COMPILING] foo v0.5.0 ({})\n",
                              path2url(git_root.clone()),
@@ -193,7 +193,7 @@ test!(cargo_compile_git_dep_tag {
 
     assert_that(project.cargo_process("build"),
         execs()
-        .with_stdout(&format!("[UPDATING] git repository `{}`\n\
+        .with_stderr(&format!("[UPDATING] git repository `{}`\n\
                               [COMPILING] dep1 v0.5.0 ({}?tag=v0.1.0#[..])\n\
                               [COMPILING] foo v0.5.0 ({})\n",
                              path2url(git_root.clone()),
@@ -496,7 +496,7 @@ test!(recompilation {
 
     // First time around we should compile both foo and bar
     assert_that(p.cargo_process("build"),
-                execs().with_stdout(&format!("[UPDATING] git repository `{}`\n\
+                execs().with_stderr(&format!("[UPDATING] git repository `{}`\n\
                                              [COMPILING] bar v0.5.0 ({}#[..])\n\
                                              [COMPILING] foo v0.5.0 ({})\n",
                                             git_project.url(),
@@ -516,7 +516,7 @@ test!(recompilation {
                 execs().with_stdout(""));
 
     assert_that(p.cargo("update"),
-                execs().with_stdout(&format!("[UPDATING] git repository `{}`",
+                execs().with_stderr(&format!("[UPDATING] git repository `{}`",
                                             git_project.url())));
 
     assert_that(p.cargo("build"),
@@ -535,13 +535,13 @@ test!(recompilation {
 
     // Update the dependency and carry on!
     assert_that(p.cargo("update"),
-                execs().with_stdout(&format!("[UPDATING] git repository `{}`\n\
+                execs().with_stderr(&format!("[UPDATING] git repository `{}`\n\
                                               [UPDATING] bar v0.5.0 ([..]) -> #[..]\n\
                                              ",
                                             git_project.url())));
     println!("going for the last compile");
     assert_that(p.cargo("build"),
-                execs().with_stdout(&format!("[COMPILING] bar v0.5.0 ({}#[..])\n\
+                execs().with_stderr(&format!("[COMPILING] bar v0.5.0 ({}#[..])\n\
                                              [COMPILING] foo v0.5.0 ({})\n",
                                             git_project.url(),
                                             p.url())));
@@ -551,7 +551,7 @@ test!(recompilation {
                  .arg("-p").arg("foo"),
                 execs().with_stdout(""));
     assert_that(p.cargo("build"),
-                execs().with_stdout(&format!("[COMPILING] foo v0.5.0 ({})\n",
+                execs().with_stderr(&format!("[COMPILING] foo v0.5.0 ({})\n",
                                             p.url())));
 });
 
@@ -663,7 +663,7 @@ To learn more, run the command again with --verbose.
     assert_that(p.cargo("update")
                  .arg("-p").arg("dep1")
                  .arg("--aggressive"),
-                execs().with_stdout(&format!("[UPDATING] git repository `{}`\n\
+                execs().with_stderr(&format!("[UPDATING] git repository `{}`\n\
                                               [UPDATING] bar v0.5.0 ([..]) -> #[..]\n\
                                              ", git_project.url())));
 
@@ -679,7 +679,7 @@ To learn more, run the command again with --verbose.
 
     // We should be able to update transitive deps
     assert_that(p.cargo("update").arg("-p").arg("bar"),
-                execs().with_stdout(&format!("[UPDATING] git repository `{}`",
+                execs().with_stderr(&format!("[UPDATING] git repository `{}`",
                                             git_project.url())));
 });
 
@@ -764,7 +764,7 @@ test!(two_deps_only_update_one {
 
     assert_that(project.cargo_process("build"),
         execs()
-        .with_stdout(&format!("[UPDATING] git repository `[..]`\n\
+        .with_stderr(&format!("[UPDATING] git repository `[..]`\n\
                               [UPDATING] git repository `[..]`\n\
                               [COMPILING] [..] v0.5.0 ([..])\n\
                               [COMPILING] [..] v0.5.0 ([..])\n\
@@ -782,7 +782,7 @@ test!(two_deps_only_update_one {
     assert_that(project.cargo("update")
                        .arg("-p").arg("dep1"),
         execs()
-        .with_stdout(&format!("[UPDATING] git repository `{}`\n\
+        .with_stderr(&format!("[UPDATING] git repository `{}`\n\
                                [UPDATING] dep1 v0.5.0 ([..]) -> #[..]\n\
                               ", git1.url()))
         .with_stderr(""));
@@ -937,7 +937,7 @@ test!(dep_with_changed_submodule {
     assert_that(project.cargo("update").arg("-v"),
                 execs()
                 .with_stderr("")
-                .with_stdout(&format!("[UPDATING] git repository `{}`\n\
+                .with_stderr(&format!("[UPDATING] git repository `{}`\n\
                                        [UPDATING] dep1 v0.5.0 ([..]) -> #[..]\n\
                                       ", git_project.url())));
 
@@ -1270,7 +1270,7 @@ test!(warnings_in_git_dep {
 
     assert_that(p.cargo_process("build"),
         execs()
-        .with_stdout(&format!("[UPDATING] git repository `{}`\n\
+        .with_stderr(&format!("[UPDATING] git repository `{}`\n\
                               [COMPILING] bar v0.5.0 ({}#[..])\n\
                               [COMPILING] foo v0.5.0 ({})\n",
                              bar.url(),

--- a/tests/test_cargo_compile_git_deps.rs
+++ b/tests/test_cargo_compile_git_deps.rs
@@ -61,8 +61,7 @@ test!(cargo_compile_simple_git_dep {
                               [COMPILING] foo v0.5.0 ({})\n",
                              path2url(git_root.clone()),
                              path2url(git_root),
-                             path2url(root)))
-        .with_stderr(""));
+                             path2url(root))));
 
     assert_that(&project.bin("foo"), existing_file());
 
@@ -128,8 +127,7 @@ test!(cargo_compile_git_dep_branch {
                               [COMPILING] foo v0.5.0 ({})\n",
                              path2url(git_root.clone()),
                              path2url(git_root),
-                             path2url(root)))
-        .with_stderr(""));
+                             path2url(root))));
 
     assert_that(&project.bin("foo"), existing_file());
 
@@ -645,6 +643,7 @@ test!(update_with_shared_deps {
                  .arg("-p").arg("bar")
                  .arg("--precise").arg("0.1.2"),
                 execs().with_status(101).with_stderr("\
+[UPDATING] git repository [..]
 [ERROR] Unable to update [..]
 
 To learn more, run the command again with --verbose.
@@ -721,7 +720,10 @@ test!(dep_with_submodule {
         ");
 
     assert_that(project.cargo_process("build"),
-                execs().with_stderr("").with_status(0));
+                execs().with_stderr("\
+[UPDATING] git repository [..]
+[COMPILING] dep1 [..]
+[COMPILING] foo [..]").with_status(0));
 });
 
 test!(two_deps_only_update_one {
@@ -769,8 +771,7 @@ test!(two_deps_only_update_one {
                               [COMPILING] [..] v0.5.0 ([..])\n\
                               [COMPILING] [..] v0.5.0 ([..])\n\
                               [COMPILING] foo v0.5.0 ({})\n",
-                             project.url()))
-        .with_stderr(""));
+                             project.url())));
 
     File::create(&git1.root().join("src/lib.rs")).unwrap().write_all(br#"
         pub fn foo() {}
@@ -784,8 +785,7 @@ test!(two_deps_only_update_one {
         execs()
         .with_stderr(&format!("[UPDATING] git repository `{}`\n\
                                [UPDATING] dep1 v0.5.0 ([..]) -> #[..]\n\
-                              ", git1.url()))
-        .with_stderr(""));
+                              ", git1.url())));
 });
 
 test!(stale_cached_version {
@@ -901,12 +901,11 @@ test!(dep_with_changed_submodule {
 
     println!("first run");
     assert_that(project.cargo_process("run"), execs()
-                .with_stdout("[UPDATING] git repository `[..]`\n\
+                .with_stderr("[UPDATING] git repository `[..]`\n\
                                       [COMPILING] dep1 v0.5.0 ([..])\n\
                                       [COMPILING] foo v0.5.0 ([..])\n\
-                                      [RUNNING] `target[..]foo[..]`\n\
-                                      project2")
-                .with_stderr("")
+                                      [RUNNING] `target[..]foo[..]`\n")
+                .with_stdout("project2\n")
                 .with_status(0));
 
     File::create(&git_project.root().join(".gitmodules")).unwrap()
@@ -943,12 +942,10 @@ test!(dep_with_changed_submodule {
 
     println!("last run");
     assert_that(project.cargo("run"), execs()
-                .with_stdout("[COMPILING] dep1 v0.5.0 ([..])\n\
+                .with_stderr("[COMPILING] dep1 v0.5.0 ([..])\n\
                                       [COMPILING] foo v0.5.0 ([..])\n\
-                                      [RUNNING] `target[..]foo[..]`\n\
-                                      project3\
-                                      ")
-                .with_stderr("")
+                                      [RUNNING] `target[..]foo[..]`\n")
+                .with_stdout("project3\n")
                 .with_status(0));
 });
 
@@ -1275,8 +1272,7 @@ test!(warnings_in_git_dep {
                               [COMPILING] foo v0.5.0 ({})\n",
                              bar.url(),
                              bar.url(),
-                             p.url()))
-        .with_stderr(""));
+                             p.url())));
 });
 
 test!(update_ambiguous {
@@ -1548,7 +1544,7 @@ test!(switch_sources {
             [dependencies.a]
             git = '{}'
         "#, a1.url()))
-        .file("b/src/lib.rs", "fn main() {}");
+        .file("b/src/lib.rs", "pub fn main() {}");
 
     p.build();
     assert_that(p.cargo("build"),

--- a/tests/test_cargo_compile_path_deps.rs
+++ b/tests/test_cargo_compile_path_deps.rs
@@ -741,16 +741,16 @@ test!(dev_deps_no_rebuild_lib {
 
     assert_that(p.cargo("test"),
                 execs().with_status(0)
-                       .with_stdout(&format!("\
+                       .with_stderr(&format!("\
 [COMPILING] [..] v0.5.0 ({url}[..])
 [COMPILING] [..] v0.5.0 ({url}[..])
-[RUNNING] target[..]foo-[..]
-
+[RUNNING] target[..]foo-[..]", url = p.url()))
+                       .with_stdout("
 running 0 tests
 
 test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
 
-", url = p.url())));
+"));
 });
 
 test!(custom_target_no_rebuild {

--- a/tests/test_cargo_compile_path_deps.rs
+++ b/tests/test_cargo_compile_path_deps.rs
@@ -783,7 +783,7 @@ test!(custom_target_no_rebuild {
     p.build();
     assert_that(p.cargo("build"),
                 execs().with_status(0)
-                       .with_stdout("\
+                       .with_stderr("\
 [COMPILING] a v0.5.0 ([..])
 [COMPILING] foo v0.5.0 ([..])
 "));
@@ -792,7 +792,7 @@ test!(custom_target_no_rebuild {
                  .arg("--manifest-path=b/Cargo.toml")
                  .env("CARGO_TARGET_DIR", "target"),
                 execs().with_status(0)
-                       .with_stdout("\
+                       .with_stderr("\
 [COMPILING] b v0.5.0 ([..])
 "));
 });
@@ -831,7 +831,7 @@ test!(override_and_depend {
     p.build();
     assert_that(p.cargo("build").cwd(p.root().join("b")),
                 execs().with_status(0)
-                       .with_stdout("\
+                       .with_stderr("\
 [COMPILING] a2 v0.5.0 ([..])
 [COMPILING] a1 v0.5.0 ([..])
 [COMPILING] b v0.5.0 ([..])

--- a/tests/test_cargo_compile_path_deps.rs
+++ b/tests/test_cargo_compile_path_deps.rs
@@ -71,7 +71,7 @@ test!(cargo_compile_with_nested_deps_shorthand {
 
     assert_that(p.cargo_process("build"),
         execs().with_status(0)
-               .with_stdout(&format!("[COMPILING] baz v0.5.0 ({}/bar/baz)\n\
+               .with_stderr(&format!("[COMPILING] baz v0.5.0 ({}/bar/baz)\n\
                                      [COMPILING] bar v0.5.0 ({}/bar)\n\
                                      [COMPILING] foo v0.5.0 ({})\n",
                                     p.url(),
@@ -89,13 +89,13 @@ test!(cargo_compile_with_nested_deps_shorthand {
     println!("building baz");
     assert_that(p.cargo("build").arg("-p").arg("baz"),
                 execs().with_status(0)
-                       .with_stdout(&format!("[COMPILING] baz v0.5.0 ({}/bar/baz)\n",
+                       .with_stderr(&format!("[COMPILING] baz v0.5.0 ({}/bar/baz)\n",
                                             p.url())));
     println!("building foo");
     assert_that(p.cargo("build")
                  .arg("-p").arg("foo"),
                 execs().with_status(0)
-                       .with_stdout(&format!("[COMPILING] bar v0.5.0 ({}/bar)\n\
+                       .with_stderr(&format!("[COMPILING] bar v0.5.0 ({}/bar)\n\
                                              [COMPILING] foo v0.5.0 ({})\n",
                                             p.url(),
                                             p.url())));
@@ -228,7 +228,7 @@ test!(cargo_compile_with_transitive_dev_deps {
         "#);
 
     assert_that(p.cargo_process("build"),
-        execs().with_stdout(&format!("[COMPILING] bar v0.5.0 ({}/bar)\n\
+        execs().with_stderr(&format!("[COMPILING] bar v0.5.0 ({}/bar)\n\
                                      [COMPILING] foo v0.5.0 ({})\n",
                                     p.url(),
                                     p.url())));
@@ -270,7 +270,7 @@ test!(no_rebuild_dependency {
         "#);
     // First time around we should compile both foo and bar
     assert_that(p.cargo_process("build"),
-                execs().with_stdout(&format!("[COMPILING] bar v0.5.0 ({}/bar)\n\
+                execs().with_stderr(&format!("[COMPILING] bar v0.5.0 ({}/bar)\n\
                                              [COMPILING] foo v0.5.0 ({})\n",
                                             p.url(),
                                             p.url())));
@@ -281,7 +281,7 @@ test!(no_rebuild_dependency {
 
     p.build(); // rebuild the files (rewriting them in the process)
     assert_that(p.cargo("build"),
-                execs().with_stdout(&format!("[COMPILING] bar v0.5.0 ({}/bar)\n\
+                execs().with_stderr(&format!("[COMPILING] bar v0.5.0 ({}/bar)\n\
                                              [COMPILING] foo v0.5.0 ({})\n",
                                             p.url(),
                                             p.url())));
@@ -336,7 +336,7 @@ test!(deep_dependencies_trigger_rebuild {
             pub fn baz() {}
         "#);
     assert_that(p.cargo_process("build"),
-                execs().with_stdout(&format!("[COMPILING] baz v0.5.0 ({}/baz)\n\
+                execs().with_stderr(&format!("[COMPILING] baz v0.5.0 ({}/baz)\n\
                                              [COMPILING] bar v0.5.0 ({}/bar)\n\
                                              [COMPILING] foo v0.5.0 ({})\n",
                                             p.url(),
@@ -354,7 +354,7 @@ test!(deep_dependencies_trigger_rebuild {
         pub fn baz() { println!("hello!"); }
     "#).unwrap();
     assert_that(p.cargo("build"),
-                execs().with_stdout(&format!("[COMPILING] baz v0.5.0 ({}/baz)\n\
+                execs().with_stderr(&format!("[COMPILING] baz v0.5.0 ({}/baz)\n\
                                              [COMPILING] bar v0.5.0 ({}/bar)\n\
                                              [COMPILING] foo v0.5.0 ({})\n",
                                             p.url(),
@@ -368,7 +368,7 @@ test!(deep_dependencies_trigger_rebuild {
         pub fn bar() { println!("hello!"); baz::baz(); }
     "#).unwrap();
     assert_that(p.cargo("build"),
-                execs().with_stdout(&format!("[COMPILING] bar v0.5.0 ({}/bar)\n\
+                execs().with_stderr(&format!("[COMPILING] bar v0.5.0 ({}/bar)\n\
                                              [COMPILING] foo v0.5.0 ({})\n",
                                             p.url(),
                                             p.url())));
@@ -425,7 +425,7 @@ test!(no_rebuild_two_deps {
             pub fn baz() {}
         "#);
     assert_that(p.cargo_process("build"),
-                execs().with_stdout(&format!("[COMPILING] baz v0.5.0 ({}/baz)\n\
+                execs().with_stderr(&format!("[COMPILING] baz v0.5.0 ({}/baz)\n\
                                              [COMPILING] bar v0.5.0 ({}/bar)\n\
                                              [COMPILING] foo v0.5.0 ({})\n",
                                             p.url(),
@@ -472,7 +472,7 @@ test!(nested_deps_recompile {
     let bar = p.url();
 
     assert_that(p.cargo_process("build"),
-                execs().with_stdout(&format!("[COMPILING] bar v0.5.0 ({}/src/bar)\n\
+                execs().with_stderr(&format!("[COMPILING] bar v0.5.0 ({}/src/bar)\n\
                                              [COMPILING] foo v0.5.0 ({})\n",
                                             bar,
                                             p.url())));
@@ -484,7 +484,7 @@ test!(nested_deps_recompile {
 
     // This shouldn't recompile `bar`
     assert_that(p.cargo("build"),
-                execs().with_stdout(&format!("[COMPILING] foo v0.5.0 ({})\n",
+                execs().with_stderr(&format!("[COMPILING] foo v0.5.0 ({})\n",
                                             p.url())));
 });
 
@@ -679,7 +679,7 @@ test!(path_dep_build_cmd {
     p.root().join("bar").move_into_the_past().unwrap();
 
     assert_that(p.cargo("build"),
-        execs().with_stdout(&format!("[COMPILING] bar v0.5.0 ({}/bar)\n\
+        execs().with_stderr(&format!("[COMPILING] bar v0.5.0 ({}/bar)\n\
                                      [COMPILING] foo v0.5.0 ({})\n",
                                     p.url(),
                                     p.url())));
@@ -696,7 +696,7 @@ test!(path_dep_build_cmd {
     }
 
     assert_that(p.cargo("build"),
-        execs().with_stdout(&format!("[COMPILING] bar v0.5.0 ({}/bar)\n\
+        execs().with_stderr(&format!("[COMPILING] bar v0.5.0 ({}/bar)\n\
                                      [COMPILING] foo v0.5.0 ({})\n",
                                     p.url(),
                                     p.url())));
@@ -736,7 +736,7 @@ test!(dev_deps_no_rebuild_lib {
     assert_that(p.cargo("build")
                  .env("FOO", "bar"),
                 execs().with_status(0)
-                       .with_stdout(&format!("[COMPILING] foo v0.5.0 ({})\n",
+                       .with_stderr(&format!("[COMPILING] foo v0.5.0 ({})\n",
                                             p.url())));
 
     assert_that(p.cargo("test"),

--- a/tests/test_cargo_compile_path_deps.rs
+++ b/tests/test_cargo_compile_path_deps.rs
@@ -174,11 +174,11 @@ test!(cargo_compile_with_root_dev_deps_with_testing {
 
     p2.build();
     assert_that(p.cargo_process("test"),
-        execs().with_stdout("\
+                execs().with_stderr("\
 [COMPILING] [..] v0.5.0 ([..])
 [COMPILING] [..] v0.5.0 ([..])
-[RUNNING] target[..]foo-[..]
-
+[RUNNING] target[..]foo-[..]")
+                       .with_stdout("
 running 0 tests
 
 test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured

--- a/tests/test_cargo_compile_path_deps.rs
+++ b/tests/test_cargo_compile_path_deps.rs
@@ -468,7 +468,7 @@ test!(nested_deps_recompile {
 
             name = "bar"
         "#)
-        .file("src/bar/src/bar.rs", "pub fn gimme() {}");
+        .file("src/bar/src/bar.rs", "pub fn gimme() -> i32 { 92 }");
     let bar = p.url();
 
     assert_that(p.cargo_process("build"),
@@ -722,7 +722,7 @@ test!(dev_deps_no_rebuild_lib {
         "#)
         .file("src/lib.rs", r#"
             #[cfg(test)] extern crate bar;
-            #[cfg(not(test))] fn foo() { env!("FOO"); }
+            #[cfg(not(test))] pub fn foo() { env!("FOO"); }
         "#)
         .file("bar/Cargo.toml", r#"
             [package]

--- a/tests/test_cargo_compile_plugins.rs
+++ b/tests/test_cargo_compile_plugins.rs
@@ -262,7 +262,7 @@ test!(native_plugin_dependency_with_custom_ar_linker {
 
     foo.build();
     assert_that(bar.cargo_process("build").arg("--verbose"),
-                execs().with_stdout("\
+                execs().with_stderr("\
 [COMPILING] foo v0.0.1 ([..])
 [RUNNING] `rustc [..] -C ar=nonexistent-ar -C linker=nonexistent-linker [..]`
 "));

--- a/tests/test_cargo_compile_plugins.rs
+++ b/tests/test_cargo_compile_plugins.rs
@@ -262,8 +262,9 @@ test!(native_plugin_dependency_with_custom_ar_linker {
 
     foo.build();
     assert_that(bar.cargo_process("build").arg("--verbose"),
-                execs().with_stderr("\
+                execs().with_stderr_contains("\
 [COMPILING] foo v0.0.1 ([..])
 [RUNNING] `rustc [..] -C ar=nonexistent-ar -C linker=nonexistent-linker [..]`
+[ERROR] could not exec the linker [..]
 "));
 });

--- a/tests/test_cargo_concurrent.rs
+++ b/tests/test_cargo_concurrent.rs
@@ -409,10 +409,10 @@ test!(debug_release_ok {
     let b = b.wait_with_output().unwrap();
     let a = a.join().unwrap();
 
-    assert_that(a, execs().with_status(0).with_stdout("\
+    assert_that(a, execs().with_status(0).with_stderr("\
 [COMPILING] foo v0.0.0 [..]
 "));
-    assert_that(b, execs().with_status(0).with_stdout("\
+    assert_that(b, execs().with_status(0).with_stderr("\
 [COMPILING] foo v0.0.0 [..]
 "));
 });

--- a/tests/test_cargo_cross_compile.rs
+++ b/tests/test_cargo_cross_compile.rs
@@ -347,7 +347,7 @@ test!(linker_and_ar {
     assert_that(p.cargo_process("build").arg("--target").arg(&target)
                                               .arg("-v"),
                 execs().with_status(101)
-                       .with_stdout(&format!("\
+                       .with_stderr(&format!("\
 [COMPILING] foo v0.5.0 ({url})
 [RUNNING] `rustc src[..]foo.rs --crate-name foo --crate-type bin -g \
     --out-dir {dir}[..]target[..]{target}[..]debug \

--- a/tests/test_cargo_cross_compile.rs
+++ b/tests/test_cargo_cross_compile.rs
@@ -594,7 +594,7 @@ test!(cross_with_a_build_script {
 
     assert_that(p.cargo_process("build").arg("--target").arg(&target).arg("-v"),
                 execs().with_status(0)
-                       .with_stdout(&format!("\
+                       .with_stderr(&format!("\
 [COMPILING] foo v0.0.0 (file://[..])
 [RUNNING] `rustc build.rs [..] --out-dir {dir}[..]target[..]build[..]foo-[..]`
 [RUNNING] `{dir}[..]target[..]build[..]foo-[..]build-script-build`
@@ -835,7 +835,7 @@ test!(build_script_with_platform_specific_dependencies {
 
     assert_that(p.cargo_process("build").arg("-v").arg("--target").arg(&target),
                 execs().with_status(0)
-                       .with_stdout(&format!("\
+                       .with_stderr(&format!("\
 [COMPILING] d2 v0.0.0 ([..])
 [RUNNING] `rustc d2[..]src[..]lib.rs [..]`
 [COMPILING] d1 v0.0.0 ([..])

--- a/tests/test_cargo_cross_compile.rs
+++ b/tests/test_cargo_cross_compile.rs
@@ -663,27 +663,27 @@ test!(build_script_needed_for_host_and_target {
 
     assert_that(p.cargo_process("build").arg("--target").arg(&target).arg("-v"),
                 execs().with_status(0)
-                       .with_stdout_contains(&format!("\
+                       .with_stderr_contains(&format!("\
 [COMPILING] d1 v0.0.0 ({url}/d1)", url = p.url()))
-                       .with_stdout_contains(&format!("\
+                       .with_stderr_contains(&format!("\
 [RUNNING] `rustc d1[..]build.rs [..] --out-dir {dir}[..]target[..]build[..]d1-[..]`",
     dir = p.root().display()))
-                       .with_stdout_contains(&format!("\
+                       .with_stderr_contains(&format!("\
 [RUNNING] `{dir}[..]target[..]build[..]d1-[..]build-script-build`",
     dir = p.root().display()))
-                       .with_stdout_contains("\
+                       .with_stderr_contains("\
 [RUNNING] `rustc d1[..]src[..]lib.rs [..]`")
-                       .with_stdout_contains(&format!("\
+                       .with_stderr_contains(&format!("\
 [COMPILING] d2 v0.0.0 ({url}/d2)", url = p.url()))
-                       .with_stdout_contains(&format!("\
+                       .with_stderr_contains(&format!("\
 [RUNNING] `rustc d2[..]src[..]lib.rs [..] \
            -L /path/to/{host}`", host = host))
-                       .with_stdout_contains(&format!("\
+                       .with_stderr_contains(&format!("\
 [COMPILING] foo v0.0.0 ({url})", url = p.url()))
-                       .with_stdout_contains(&format!("\
+                       .with_stderr_contains(&format!("\
 [RUNNING] `rustc build.rs [..] --out-dir {dir}[..]target[..]build[..]foo-[..] \
            -L /path/to/{host}`", dir = p.root().display(), host = host))
-                       .with_stdout_contains(&format!("\
+                       .with_stderr_contains(&format!("\
 [RUNNING] `rustc src[..]main.rs [..] --target {target} [..] \
            -L /path/to/{target}`", target = target)));
 });

--- a/tests/test_cargo_cross_compile.rs
+++ b/tests/test_cargo_cross_compile.rs
@@ -460,23 +460,23 @@ test!(cross_tests {
     let target = alternate();
     assert_that(p.cargo_process("test").arg("--target").arg(&target),
                 execs().with_status(0)
-                       .with_stdout(&format!("\
+                       .with_stderr(&format!("\
 [COMPILING] foo v0.0.0 ({foo})
 [RUNNING] target[..]{triple}[..]bar-[..]
-
+[RUNNING] target[..]{triple}[..]foo-[..]", foo = p.url(), triple = target))
+                       .with_stdout("
 running 1 test
 test test ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
 
-[RUNNING] target[..]{triple}[..]foo-[..]
 
 running 1 test
 test test_foo ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
 
-", foo = p.url(), triple = target)));
+"));
 });
 
 test!(no_cross_doctests {
@@ -525,15 +525,15 @@ test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
     let target = alternate();
     assert_that(p.cargo_process("test").arg("--target").arg(&target),
                 execs().with_status(0)
-                       .with_stdout(&format!("\
+                       .with_stderr(&format!("\
 [COMPILING] foo v0.0.0 ({foo})
-[RUNNING] target[..]{triple}[..]foo-[..]
-
+[RUNNING] target[..]{triple}[..]foo-[..]", foo = p.url(), triple = target))
+                       .with_stdout("
 running 0 tests
 
 test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
 
-", foo = p.url(), triple = target)));
+"));
 });
 
 test!(simple_cargo_run {

--- a/tests/test_cargo_cross_compile.rs
+++ b/tests/test_cargo_cross_compile.rs
@@ -789,7 +789,7 @@ test!(plugin_build_script_right_arch {
 
     assert_that(p.cargo_process("build").arg("-v").arg("--target").arg(alternate()),
                 execs().with_status(0)
-                       .with_stdout("\
+                       .with_stderr("\
 [COMPILING] foo v0.0.1 ([..])
 [RUNNING] `rustc build.rs [..]`
 [RUNNING] `[..]build-script-build[..]`

--- a/tests/test_cargo_doc.rs
+++ b/tests/test_cargo_doc.rs
@@ -240,7 +240,7 @@ test!(doc_dash_p {
 
     assert_that(p.cargo_process("doc").arg("-p").arg("a"),
                 execs().with_status(0)
-                       .with_stdout("\
+                       .with_stderr("\
 [..] b v0.0.1 (file://[..])
 [..] b v0.0.1 (file://[..])
 [DOCUMENTING] a v0.0.1 (file://[..])
@@ -426,7 +426,7 @@ test!(doc_release {
                 execs().with_status(0));
     assert_that(p.cargo("doc").arg("--release").arg("-v"),
                 execs().with_status(0)
-                       .with_stdout("\
+                       .with_stderr("\
 [DOCUMENTING] foo v0.0.1 ([..])
 [RUNNING] `rustdoc src[..]lib.rs [..]`
 "));

--- a/tests/test_cargo_doc.rs
+++ b/tests/test_cargo_doc.rs
@@ -22,7 +22,7 @@ test!(simple {
         "#);
 
     assert_that(p.cargo_process("doc"),
-                execs().with_status(0).with_stdout(&format!("\
+                execs().with_status(0).with_stderr(&format!("\
 [..] foo v0.0.1 ({dir})
 [..] foo v0.0.1 ({dir})
 ",
@@ -64,7 +64,7 @@ test!(doc_twice {
         "#);
 
     assert_that(p.cargo_process("doc"),
-                execs().with_status(0).with_stdout(&format!("\
+                execs().with_status(0).with_stderr(&format!("\
 [DOCUMENTING] foo v0.0.1 ({dir})
 ",
         dir = path2url(p.root()))));
@@ -99,7 +99,7 @@ test!(doc_deps {
         "#);
 
     assert_that(p.cargo_process("doc"),
-                execs().with_status(0).with_stdout(&format!("\
+                execs().with_status(0).with_stderr(&format!("\
 [..] bar v0.0.1 ({dir}/bar)
 [..] bar v0.0.1 ({dir}/bar)
 [DOCUMENTING] foo v0.0.1 ({dir})
@@ -145,7 +145,7 @@ test!(doc_no_deps {
         "#);
 
     assert_that(p.cargo_process("doc").arg("--no-deps"),
-                execs().with_status(0).with_stdout(&format!("\
+                execs().with_status(0).with_stderr(&format!("\
 [COMPILING] bar v0.0.1 ({dir}/bar)
 [DOCUMENTING] foo v0.0.1 ({dir})
 ",

--- a/tests/test_cargo_features.rs
+++ b/tests/test_cargo_features.rs
@@ -244,14 +244,14 @@ test!(no_feature_doesnt_build {
         .file("bar/src/lib.rs", "pub fn bar() {}");
 
     assert_that(p.cargo_process("build"),
-                execs().with_status(0).with_stdout(format!("\
+                execs().with_status(0).with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({dir})
 ", dir = p.url())));
     assert_that(p.process(&p.bin("foo")),
                 execs().with_status(0).with_stdout(""));
 
     assert_that(p.cargo("build").arg("--features").arg("bar"),
-                execs().with_status(0).with_stdout(format!("\
+                execs().with_status(0).with_stderr(format!("\
 [COMPILING] bar v0.0.1 ({dir}/bar)
 [COMPILING] foo v0.0.1 ({dir})
 ", dir = p.url())));
@@ -291,7 +291,7 @@ test!(default_feature_pulled_in {
         .file("bar/src/lib.rs", "pub fn bar() {}");
 
     assert_that(p.cargo_process("build"),
-                execs().with_status(0).with_stdout(format!("\
+                execs().with_status(0).with_stderr(format!("\
 [COMPILING] bar v0.0.1 ({dir}/bar)
 [COMPILING] foo v0.0.1 ({dir})
 ", dir = p.url())));
@@ -299,7 +299,7 @@ test!(default_feature_pulled_in {
                 execs().with_status(0).with_stdout("bar\n"));
 
     assert_that(p.cargo("build").arg("--no-default-features"),
-                execs().with_status(0).with_stdout(format!("\
+                execs().with_status(0).with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({dir})
 ", dir = p.url())));
     assert_that(p.process(&p.bin("foo")),
@@ -392,7 +392,7 @@ test!(groups_on_groups_on_groups {
         .file("baz/src/lib.rs", "pub fn baz() {}");
 
     assert_that(p.cargo_process("build"),
-                execs().with_status(0).with_stdout(format!("\
+                execs().with_status(0).with_stderr(format!("\
 [COMPILING] ba[..] v0.0.1 ({dir}/ba[..])
 [COMPILING] ba[..] v0.0.1 ({dir}/ba[..])
 [COMPILING] foo v0.0.1 ({dir})
@@ -436,7 +436,7 @@ test!(many_cli_features {
         .file("baz/src/lib.rs", "pub fn baz() {}");
 
     assert_that(p.cargo_process("build").arg("--features").arg("bar baz"),
-                execs().with_status(0).with_stdout(format!("\
+                execs().with_status(0).with_stderr(format!("\
 [COMPILING] ba[..] v0.0.1 ({dir}/ba[..])
 [COMPILING] ba[..] v0.0.1 ({dir}/ba[..])
 [COMPILING] foo v0.0.1 ({dir})
@@ -497,7 +497,7 @@ test!(union_features {
         "#);
 
     assert_that(p.cargo_process("build"),
-                execs().with_status(0).with_stdout(format!("\
+                execs().with_status(0).with_stderr(format!("\
 [COMPILING] d2 v0.0.1 ({dir}/d2)
 [COMPILING] d1 v0.0.1 ({dir}/d1)
 [COMPILING] foo v0.0.1 ({dir})
@@ -531,7 +531,7 @@ test!(many_features_no_rebuilds {
         .file("a/src/lib.rs", "");
 
     assert_that(p.cargo_process("build"),
-                execs().with_status(0).with_stdout(format!("\
+                execs().with_status(0).with_stderr(format!("\
 [COMPILING] a v0.1.0 ({dir}/a)
 [COMPILING] b v0.1.0 ({dir})
 ", dir = p.url())));

--- a/tests/test_cargo_features.rs
+++ b/tests/test_cargo_features.rs
@@ -538,7 +538,7 @@ test!(many_features_no_rebuilds {
     p.root().move_into_the_past().unwrap();
 
     assert_that(p.cargo("build").arg("-v"),
-                execs().with_status(0).with_stdout("\
+                execs().with_status(0).with_stderr("\
 [FRESH] a v0.1.0 ([..]/a)
 [FRESH] b v0.1.0 ([..])
 "));
@@ -764,7 +764,7 @@ test!(optional_and_dev_dep {
         .file("foo/src/lib.rs", "");
 
     assert_that(p.cargo_process("build"),
-                execs().with_status(0).with_stdout("\
+                execs().with_status(0).with_stderr("\
 [COMPILING] test v0.1.0 ([..])
 "));
 });

--- a/tests/test_cargo_freshness.rs
+++ b/tests/test_cargo_freshness.rs
@@ -151,19 +151,19 @@ test!(changing_features_is_ok {
 
     assert_that(p.cargo_process("build"),
                 execs().with_status(0)
-                       .with_stdout("\
+                       .with_stderr("\
 [..]Compiling foo v0.0.1 ([..])
 "));
 
     assert_that(p.cargo("build").arg("--features").arg("foo"),
                 execs().with_status(0)
-                       .with_stdout("\
+                       .with_stderr("\
 [..]Compiling foo v0.0.1 ([..])
 "));
 
     assert_that(p.cargo("build"),
                 execs().with_status(0)
-                       .with_stdout("\
+                       .with_stderr("\
 [..]Compiling foo v0.0.1 ([..])
 "));
 
@@ -249,7 +249,7 @@ test!(no_rebuild_transitive_target_deps {
                 execs().with_status(0));
     assert_that(p.cargo("test").arg("--no-run"),
                 execs().with_status(0)
-                       .with_stdout("\
+                       .with_stderr("\
 [COMPILING] c v0.0.1 ([..])
 [COMPILING] b v0.0.1 ([..])
 [COMPILING] foo v0.0.1 ([..])

--- a/tests/test_cargo_freshness.rs
+++ b/tests/test_cargo_freshness.rs
@@ -31,7 +31,7 @@ test!(modifying_and_moving {
     p.root().join("target").move_into_the_past().unwrap();
 
     File::create(&p.root().join("src/a.rs")).unwrap()
-         .write_all(b"fn main() {}").unwrap();
+         .write_all(b"#[allow(unused)]fn main() {}").unwrap();
     assert_that(p.cargo("build"),
                 execs().with_status(0).with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({dir})
@@ -73,12 +73,11 @@ test!(modify_only_some_files {
     let bin = p.root().join("src/b.rs");
 
     File::create(&lib).unwrap().write_all(b"invalid rust code").unwrap();
-    File::create(&bin).unwrap().write_all(b"fn foo() {}").unwrap();
+    File::create(&bin).unwrap().write_all(b"#[allow(unused)]fn foo() {}").unwrap();
     lib.move_into_the_past().unwrap();
 
     // Make sure the binary is rebuilt, not the lib
-    assert_that(p.cargo("build")
-                 .env("RUST_LOG", "cargo::ops::cargo_rustc::fingerprint"),
+    assert_that(p.cargo("build"),
                 execs().with_status(0).with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({dir})
 ", dir = path2url(p.root()))));

--- a/tests/test_cargo_freshness.rs
+++ b/tests/test_cargo_freshness.rs
@@ -21,7 +21,7 @@ test!(modifying_and_moving {
         .file("src/a.rs", "");
 
     assert_that(p.cargo_process("build"),
-                execs().with_status(0).with_stdout(format!("\
+                execs().with_status(0).with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({dir})
 ", dir = path2url(p.root()))));
 
@@ -33,7 +33,7 @@ test!(modifying_and_moving {
     File::create(&p.root().join("src/a.rs")).unwrap()
          .write_all(b"fn main() {}").unwrap();
     assert_that(p.cargo("build"),
-                execs().with_status(0).with_stdout(format!("\
+                execs().with_status(0).with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({dir})
 ", dir = path2url(p.root()))));
 
@@ -60,7 +60,7 @@ test!(modify_only_some_files {
         .file("tests/test.rs", "");
 
     assert_that(p.cargo_process("build"),
-                execs().with_status(0).with_stdout(format!("\
+                execs().with_status(0).with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({dir})
 ", dir = path2url(p.root()))));
     assert_that(p.cargo("test"),
@@ -79,7 +79,7 @@ test!(modify_only_some_files {
     // Make sure the binary is rebuilt, not the lib
     assert_that(p.cargo("build")
                  .env("RUST_LOG", "cargo::ops::cargo_rustc::fingerprint"),
-                execs().with_status(0).with_stdout(format!("\
+                execs().with_status(0).with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({dir})
 ", dir = path2url(p.root()))));
     assert_that(&p.bin("foo"), existing_file());

--- a/tests/test_cargo_freshness.rs
+++ b/tests/test_cargo_freshness.rs
@@ -340,14 +340,14 @@ test!(same_build_dir_cached_packages {
     p.build();
 
     assert_that(p.cargo("build").cwd(p.root().join("a1")),
-                execs().with_status(0).with_stdout(&format!("\
+                execs().with_status(0).with_stderr(&format!("\
 [COMPILING] d v0.0.1 ({dir}/d)
 [COMPILING] c v0.0.1 ({dir}/c)
 [COMPILING] b v0.0.1 ({dir}/b)
 [COMPILING] a1 v0.0.1 ({dir}/a1)
 ", dir = p.url())));
     assert_that(p.cargo("build").cwd(p.root().join("a2")),
-                execs().with_status(0).with_stdout(&format!("\
+                execs().with_status(0).with_stderr(&format!("\
 [COMPILING] a2 v0.0.1 ({dir}/a2)
 ", dir = p.url())));
 });

--- a/tests/test_cargo_install.rs
+++ b/tests/test_cargo_install.rs
@@ -619,7 +619,7 @@ test!(uninstall_piecemeal {
     assert_that(cargo_home(), has_installed_exe("bar"));
 
     assert_that(cargo_process("uninstall").arg("foo").arg("--bin=bar"),
-                execs().with_status(0).with_stdout("\
+                execs().with_status(0).with_stderr("\
 [REMOVING] [..]bar[..]
 "));
 
@@ -627,7 +627,7 @@ test!(uninstall_piecemeal {
     assert_that(cargo_home(), is_not(has_installed_exe("bar")));
 
     assert_that(cargo_process("uninstall").arg("foo").arg("--bin=foo"),
-                execs().with_status(0).with_stdout("\
+                execs().with_status(0).with_stderr("\
 [REMOVING] [..]foo[..]
 "));
     assert_that(cargo_home(), is_not(has_installed_exe("foo")));
@@ -683,7 +683,7 @@ test!(do_not_rebuilds_on_local_install {
     assert_that(p.cargo_process("build").arg("--release"),
                 execs().with_status(0));
     assert_that(cargo_process("install").arg("--path").arg(p.root()),
-                execs().with_status(0).with_stdout("\
+                execs().with_status(0).with_stderr("\
 [INSTALLING] [..]
 ").with_stderr("\
 warning: be sure to add `[..]` to your PATH to be able to run the installed binaries

--- a/tests/test_cargo_install.rs
+++ b/tests/test_cargo_install.rs
@@ -60,7 +60,7 @@ test!(simple {
     pkg("foo", "0.0.1");
 
     assert_that(cargo_process("install").arg("foo"),
-                execs().with_status(0).with_stdout(&format!("\
+                execs().with_status(0).with_stderr(&format!("\
 [UPDATING] registry `[..]`
 [DOWNLOADING] foo v0.0.1 (registry file://[..])
 [COMPILING] foo v0.0.1 (registry file://[..])
@@ -70,7 +70,7 @@ test!(simple {
     assert_that(cargo_home(), has_installed_exe("foo"));
 
     assert_that(cargo_process("uninstall").arg("foo"),
-                execs().with_status(0).with_stdout(&format!("\
+                execs().with_status(0).with_stderr(&format!("\
 [REMOVING] {home}[..]bin[..]foo[..]
 ",
         home = cargo_home().display())));
@@ -82,7 +82,7 @@ test!(pick_max_version {
     pkg("foo", "0.0.2");
 
     assert_that(cargo_process("install").arg("foo"),
-                execs().with_status(0).with_stdout(&format!("\
+                execs().with_status(0).with_stderr(&format!("\
 [UPDATING] registry `[..]`
 [DOWNLOADING] foo v0.0.2 (registry file://[..])
 [COMPILING] foo v0.0.2 (registry file://[..])
@@ -412,7 +412,7 @@ test!(install_force {
     p.build();
 
     assert_that(cargo_process("install").arg("--force").arg("--path").arg(p.root()),
-                execs().with_status(0).with_stdout(&format!("\
+                execs().with_status(0).with_stderr(&format!("\
 [COMPILING] foo v0.2.0 ([..])
 [REPLACING] {home}[..]bin[..]foo[..]
 ",
@@ -452,7 +452,7 @@ test!(install_force_partial_overlap {
     p.build();
 
     assert_that(cargo_process("install").arg("--force").arg("--path").arg(p.root()),
-                execs().with_status(0).with_stdout(&format!("\
+                execs().with_status(0).with_stderr(&format!("\
 [COMPILING] foo v0.2.0 ([..])
 [INSTALLING] {home}[..]bin[..]foo-bin3[..]
 [REPLACING] {home}[..]bin[..]foo-bin2[..]
@@ -500,7 +500,7 @@ test!(install_force_bin {
                     .arg("foo-bin2")
                     .arg("--path")
                     .arg(p.root()),
-                execs().with_status(0).with_stdout(&format!("\
+                execs().with_status(0).with_stderr(&format!("\
 [COMPILING] foo v0.2.0 ([..])
 [REPLACING] {home}[..]bin[..]foo-bin2[..]
 ",
@@ -552,7 +552,7 @@ test!(git_repo {
     p.build();
 
     assert_that(cargo_process("install").arg("--git").arg(p.url().to_string()),
-                execs().with_status(0).with_stdout(&format!("\
+                execs().with_status(0).with_stderr(&format!("\
 [UPDATING] git repository `[..]`
 [COMPILING] foo v0.1.0 ([..])
 [INSTALLING] {home}[..]bin[..]foo[..]

--- a/tests/test_cargo_install.rs
+++ b/tests/test_cargo_install.rs
@@ -65,6 +65,7 @@ test!(simple {
 [DOWNLOADING] foo v0.0.1 (registry file://[..])
 [COMPILING] foo v0.0.1 (registry file://[..])
 [INSTALLING] {home}[..]bin[..]foo[..]
+warning: be sure to add `[..]` to your PATH to be able to run the installed binaries
 ",
         home = cargo_home().display())));
     assert_that(cargo_home(), has_installed_exe("foo"));
@@ -87,6 +88,7 @@ test!(pick_max_version {
 [DOWNLOADING] foo v0.0.2 (registry file://[..])
 [COMPILING] foo v0.0.2 (registry file://[..])
 [INSTALLING] {home}[..]bin[..]foo[..]
+warning: be sure to add `[..]` to your PATH to be able to run the installed binaries
 ",
         home = cargo_home().display())));
     assert_that(cargo_home(), has_installed_exe("foo"));
@@ -96,6 +98,7 @@ test!(missing {
     pkg("foo", "0.0.1");
     assert_that(cargo_process("install").arg("bar"),
                 execs().with_status(101).with_stderr("\
+[UPDATING] registry [..]
 [ERROR] could not find `bar` in `registry file://[..]`
 "));
 });
@@ -104,6 +107,7 @@ test!(bad_version {
     pkg("foo", "0.0.1");
     assert_that(cargo_process("install").arg("foo").arg("--vers=0.2.0"),
                 execs().with_status(101).with_stderr("\
+[UPDATING] registry [..]
 [ERROR] could not find `foo` in `registry file://[..]` with version `0.2.0`
 "));
 });
@@ -210,6 +214,7 @@ test!(multiple_crates_error {
 
     assert_that(cargo_process("install").arg("--git").arg(p.url().to_string()),
                 execs().with_status(101).with_stderr("\
+[UPDATING] git repository [..]
 [ERROR] multiple packages with binaries found: bar, foo
 "));
 });
@@ -415,6 +420,7 @@ test!(install_force {
                 execs().with_status(0).with_stderr(&format!("\
 [COMPILING] foo v0.2.0 ([..])
 [REPLACING] {home}[..]bin[..]foo[..]
+warning: be sure to add `[..]` to your PATH to be able to run the installed binaries
 ",
         home = cargo_home().display())));
 
@@ -456,6 +462,7 @@ test!(install_force_partial_overlap {
 [COMPILING] foo v0.2.0 ([..])
 [INSTALLING] {home}[..]bin[..]foo-bin3[..]
 [REPLACING] {home}[..]bin[..]foo-bin2[..]
+warning: be sure to add `[..]` to your PATH to be able to run the installed binaries
 ",
         home = cargo_home().display())));
 
@@ -503,6 +510,7 @@ test!(install_force_bin {
                 execs().with_status(0).with_stderr(&format!("\
 [COMPILING] foo v0.2.0 ([..])
 [REPLACING] {home}[..]bin[..]foo-bin2[..]
+warning: be sure to add `[..]` to your PATH to be able to run the installed binaries
 ",
         home = cargo_home().display())));
 
@@ -528,6 +536,7 @@ test!(compile_failure {
 
     assert_that(cargo_process("install").arg("--path").arg(p.root()),
                 execs().with_status(101).with_stderr("\
+[COMPILING] foo v0.1.0 [..]
 error: main function not found
 error: aborting due to previous error
 [ERROR] failed to compile `foo v0.1.0 (file://[..])`, intermediate artifacts can be \
@@ -556,6 +565,7 @@ test!(git_repo {
 [UPDATING] git repository `[..]`
 [COMPILING] foo v0.1.0 ([..])
 [INSTALLING] {home}[..]bin[..]foo[..]
+warning: be sure to add `[..]` to your PATH to be able to run the installed binaries
 ",
         home = cargo_home().display())));
     assert_that(cargo_home(), has_installed_exe("foo"));
@@ -685,7 +695,6 @@ test!(do_not_rebuilds_on_local_install {
     assert_that(cargo_process("install").arg("--path").arg(p.root()),
                 execs().with_status(0).with_stderr("\
 [INSTALLING] [..]
-").with_stderr("\
 warning: be sure to add `[..]` to your PATH to be able to run the installed binaries
 "));
 

--- a/tests/test_cargo_overrides.rs
+++ b/tests/test_cargo_overrides.rs
@@ -274,7 +274,7 @@ test!(use_a_spec_to_select {
             extern crate foo;
             extern crate bar;
 
-            fn local() {
+            pub fn local() {
                 foo::foo1();
                 bar::bar();
             }
@@ -422,6 +422,8 @@ test!(override_wrong_name {
 
     assert_that(p.cargo_process("build"),
                 execs().with_status(101).with_stderr("\
+[UPDATING] registry [..]
+[UPDATING] git repository [..]
 error: no matching package for override `foo:0.1.0` found
 location searched: file://[..]
 version required: = 0.1.0
@@ -452,6 +454,8 @@ test!(override_with_nothing {
 
     assert_that(p.cargo_process("build"),
                 execs().with_status(101).with_stderr("\
+[UPDATING] registry [..]
+[UPDATING] git repository [..]
 error: Unable to update file://[..]
 
 Caused by:
@@ -512,6 +516,8 @@ test!(multiple_specs {
 
     assert_that(p.cargo_process("build"),
                 execs().with_status(101).with_stderr("\
+[UPDATING] registry [..]
+[UPDATING] git repository [..]
 error: overlapping replacement specifications found:
 
   * [..]

--- a/tests/test_cargo_overrides.rs
+++ b/tests/test_cargo_overrides.rs
@@ -41,7 +41,7 @@ test!(override_simple {
         ");
 
     assert_that(p.cargo_process("build"),
-                execs().with_status(0).with_stdout("\
+                execs().with_status(0).with_stderr("\
 [UPDATING] registry `file://[..]`
 [UPDATING] git repository `[..]`
 [COMPILING] foo v0.1.0 (file://[..])
@@ -135,7 +135,7 @@ test!(transitive {
         .file("src/lib.rs", "");
 
     assert_that(p.cargo_process("build"),
-                execs().with_status(0).with_stdout("\
+                execs().with_status(0).with_stderr("\
 [UPDATING] registry `file://[..]`
 [UPDATING] git repository `[..]`
 [DOWNLOADING] bar v0.2.0 (registry [..])
@@ -181,7 +181,7 @@ test!(persists_across_rebuilds {
         ");
 
     assert_that(p.cargo_process("build"),
-                execs().with_status(0).with_stdout("\
+                execs().with_status(0).with_stderr("\
 [UPDATING] registry `file://[..]`
 [UPDATING] git repository `file://[..]`
 [COMPILING] foo v0.1.0 (file://[..])
@@ -226,7 +226,7 @@ test!(replace_registry_with_path {
         ");
 
     assert_that(p.cargo_process("build"),
-                execs().with_status(0).with_stdout("\
+                execs().with_status(0).with_stderr("\
 [UPDATING] registry `file://[..]`
 [COMPILING] foo v0.1.0 (file://[..])
 [COMPILING] local v0.0.1 (file://[..])
@@ -281,7 +281,7 @@ test!(use_a_spec_to_select {
         ");
 
     assert_that(p.cargo_process("build"),
-                execs().with_status(0).with_stdout("\
+                execs().with_status(0).with_stderr("\
 [UPDATING] registry `file://[..]`
 [UPDATING] git repository `[..]`
 [DOWNLOADING] [..]
@@ -326,7 +326,7 @@ test!(override_adds_some_deps {
         .file("src/lib.rs", "");
 
     assert_that(p.cargo_process("build"),
-                execs().with_status(0).with_stdout("\
+                execs().with_status(0).with_stderr("\
 [UPDATING] registry `file://[..]`
 [UPDATING] git repository `[..]`
 [DOWNLOADING] foo v0.1.1 (registry [..])
@@ -339,11 +339,11 @@ test!(override_adds_some_deps {
 
     Package::new("foo", "0.1.2").publish();
     assert_that(p.cargo("update").arg("-p").arg(&format!("{}#bar", foo.url())),
-                execs().with_status(0).with_stdout("\
+                execs().with_status(0).with_stderr("\
 [UPDATING] git repository `file://[..]`
 "));
     assert_that(p.cargo("update").arg("-p").arg(&format!("{}#bar", registry())),
-                execs().with_status(0).with_stdout("\
+                execs().with_status(0).with_stderr("\
 [UPDATING] registry `file://[..]`
 "));
 

--- a/tests/test_cargo_package.rs
+++ b/tests/test_cargo_package.rs
@@ -152,7 +152,7 @@ test!(package_verbose {
 
     println!("package main repo");
     assert_that(cargo.clone().arg("package").arg("-v").arg("--no-verify"),
-                execs().with_status(0).with_stdout("\
+                execs().with_status(0).with_stderr("\
 [PACKAGING] foo v0.0.1 ([..])
 [ARCHIVING] [..]
 [ARCHIVING] [..]
@@ -161,7 +161,7 @@ test!(package_verbose {
     println!("package sub-repo");
     assert_that(cargo.arg("package").arg("-v").arg("--no-verify")
                      .cwd(p.root().join("a")),
-                execs().with_status(0).with_stdout("\
+                execs().with_status(0).with_stderr("\
 [PACKAGING] a v0.0.1 ([..])
 [ARCHIVING] [..]
 [ARCHIVING] [..]
@@ -206,7 +206,7 @@ test!(exclude {
         .file("src/bar.txt", "");
 
     assert_that(p.cargo_process("package").arg("--no-verify").arg("-v"),
-                execs().with_status(0).with_stdout("\
+                execs().with_status(0).with_stderr("\
 [PACKAGING] foo v0.0.1 ([..])
 [ARCHIVING] [..]
 [ARCHIVING] [..]
@@ -230,7 +230,7 @@ test!(include {
         .file("src/bar.txt", ""); // should be ignored when packaging
 
     assert_that(p.cargo_process("package").arg("--no-verify").arg("-v"),
-                execs().with_status(0).with_stdout("\
+                execs().with_status(0).with_stderr("\
 [PACKAGING] foo v0.0.1 ([..])
 [ARCHIVING] [..]
 [ARCHIVING] [..]
@@ -269,7 +269,7 @@ test!(package_new_git_repo {
 
     assert_that(::cargo_process().arg("package").cwd(p.root())
                  .arg("--no-verify").arg("-v"),
-                execs().with_status(0).with_stdout("\
+                execs().with_status(0).with_stderr("\
 [PACKAGING] foo v0.0.1 ([..])
 [ARCHIVING] [..]
 [ARCHIVING] [..]

--- a/tests/test_cargo_package.rs
+++ b/tests/test_cargo_package.rs
@@ -29,7 +29,7 @@ test!(simple {
         .file("src/bar.txt", ""); // should be ignored when packaging
 
     assert_that(p.cargo_process("package"),
-                execs().with_status(0).with_stdout(&format!("\
+                execs().with_status(0).with_stderr(&format!("\
 [PACKAGING] foo v0.0.1 ({dir})
 [VERIFYING] foo v0.0.1 ({dir})
 [COMPILING] foo v0.0.1 ({dir}[..])
@@ -71,7 +71,7 @@ test!(metadata_warning {
             fn main() {}
         "#);
     assert_that(p.cargo_process("package"),
-                execs().with_status(0).with_stdout(&format!("\
+                execs().with_status(0).with_stderr(&format!("\
 [PACKAGING] foo v0.0.1 ({dir})
 [VERIFYING] foo v0.0.1 ({dir})
 [COMPILING] foo v0.0.1 ({dir}[..])
@@ -94,7 +94,7 @@ http://doc.crates.io/manifest.html#package-metadata for more info."));
             fn main() {}
         "#);
     assert_that(p.cargo_process("package"),
-                execs().with_status(0).with_stdout(&format!("\
+                execs().with_status(0).with_stderr(&format!("\
 [PACKAGING] foo v0.0.1 ({dir})
 [VERIFYING] foo v0.0.1 ({dir})
 [COMPILING] foo v0.0.1 ({dir}[..])
@@ -118,7 +118,7 @@ http://doc.crates.io/manifest.html#package-metadata for more info."));
             fn main() {}
         "#);
     assert_that(p.cargo_process("package"),
-                execs().with_status(0).with_stdout(&format!("\
+                execs().with_status(0).with_stderr(&format!("\
 [PACKAGING] foo v0.0.1 ({dir})
 [VERIFYING] foo v0.0.1 ({dir})
 [COMPILING] foo v0.0.1 ({dir}[..])
@@ -182,7 +182,7 @@ test!(package_verification {
     assert_that(p.cargo_process("build"),
                 execs().with_status(0));
     assert_that(p.cargo("package"),
-                execs().with_status(0).with_stdout(&format!("\
+                execs().with_status(0).with_stderr(&format!("\
 [PACKAGING] foo v0.0.1 ({dir})
 [VERIFYING] foo v0.0.1 ({dir})
 [COMPILING] foo v0.0.1 ({dir}[..])
@@ -354,7 +354,7 @@ test!(ignore_nested {
         .file("a_dir/nested/src/main.rs", main_rs);
 
     assert_that(p.cargo_process("package"),
-                execs().with_status(0).with_stdout(&format!("\
+                execs().with_status(0).with_stderr(&format!("\
 [PACKAGING] nested v0.0.1 ({dir})
 [VERIFYING] nested v0.0.1 ({dir})
 [COMPILING] nested v0.0.1 ({dir}[..])

--- a/tests/test_cargo_package.rs
+++ b/tests/test_cargo_package.rs
@@ -30,6 +30,7 @@ test!(simple {
 
     assert_that(p.cargo_process("package"),
                 execs().with_status(0).with_stderr(&format!("\
+[WARNING] manifest has no documentation[..]
 [PACKAGING] foo v0.0.1 ({dir})
 [VERIFYING] foo v0.0.1 ({dir})
 [COMPILING] foo v0.0.1 ({dir}[..])
@@ -72,15 +73,14 @@ test!(metadata_warning {
         "#);
     assert_that(p.cargo_process("package"),
                 execs().with_status(0).with_stderr(&format!("\
+warning: manifest has no description, license, license-file, documentation, \
+homepage or repository. See \
+http://doc.crates.io/manifest.html#package-metadata for more info.
 [PACKAGING] foo v0.0.1 ({dir})
 [VERIFYING] foo v0.0.1 ({dir})
 [COMPILING] foo v0.0.1 ({dir}[..])
 ",
-        dir = p.url()))
-                .with_stderr("\
-warning: manifest has no description, license, license-file, documentation, \
-homepage or repository. See \
-http://doc.crates.io/manifest.html#package-metadata for more info."));
+        dir = p.url())));
 
     let p = project("one")
         .file("Cargo.toml", r#"
@@ -95,14 +95,13 @@ http://doc.crates.io/manifest.html#package-metadata for more info."));
         "#);
     assert_that(p.cargo_process("package"),
                 execs().with_status(0).with_stderr(&format!("\
+warning: manifest has no description, documentation, homepage or repository. See \
+http://doc.crates.io/manifest.html#package-metadata for more info.
 [PACKAGING] foo v0.0.1 ({dir})
 [VERIFYING] foo v0.0.1 ({dir})
 [COMPILING] foo v0.0.1 ({dir}[..])
 ",
-        dir = p.url()))
-                .with_stderr("\
-warning: manifest has no description, documentation, homepage or repository. See \
-http://doc.crates.io/manifest.html#package-metadata for more info."));
+        dir = p.url())));
 
     let p = project("all")
         .file("Cargo.toml", &format!(r#"
@@ -153,6 +152,7 @@ test!(package_verbose {
     println!("package main repo");
     assert_that(cargo.clone().arg("package").arg("-v").arg("--no-verify"),
                 execs().with_status(0).with_stderr("\
+[WARNING] manifest has no description[..]
 [PACKAGING] foo v0.0.1 ([..])
 [ARCHIVING] [..]
 [ARCHIVING] [..]
@@ -162,6 +162,7 @@ test!(package_verbose {
     assert_that(cargo.arg("package").arg("-v").arg("--no-verify")
                      .cwd(p.root().join("a")),
                 execs().with_status(0).with_stderr("\
+[WARNING] manifest has no description[..]
 [PACKAGING] a v0.0.1 ([..])
 [ARCHIVING] [..]
 [ARCHIVING] [..]
@@ -183,6 +184,7 @@ test!(package_verification {
                 execs().with_status(0));
     assert_that(p.cargo("package"),
                 execs().with_status(0).with_stderr(&format!("\
+[WARNING] manifest has no description[..]
 [PACKAGING] foo v0.0.1 ({dir})
 [VERIFYING] foo v0.0.1 ({dir})
 [COMPILING] foo v0.0.1 ({dir}[..])
@@ -207,6 +209,7 @@ test!(exclude {
 
     assert_that(p.cargo_process("package").arg("--no-verify").arg("-v"),
                 execs().with_status(0).with_stderr("\
+[WARNING] manifest has no description[..]
 [PACKAGING] foo v0.0.1 ([..])
 [ARCHIVING] [..]
 [ARCHIVING] [..]
@@ -231,6 +234,7 @@ test!(include {
 
     assert_that(p.cargo_process("package").arg("--no-verify").arg("-v"),
                 execs().with_status(0).with_stderr("\
+[WARNING] manifest has no description[..]
 [PACKAGING] foo v0.0.1 ([..])
 [ARCHIVING] [..]
 [ARCHIVING] [..]
@@ -270,6 +274,7 @@ test!(package_new_git_repo {
     assert_that(::cargo_process().arg("package").cwd(p.root())
                  .arg("--no-verify").arg("-v"),
                 execs().with_status(0).with_stderr("\
+[WARNING] manifest has no description[..]
 [PACKAGING] foo v0.0.1 ([..])
 [ARCHIVING] [..]
 [ARCHIVING] [..]
@@ -304,7 +309,7 @@ test!(package_git_submodule {
 
     assert_that(::cargo_process().arg("package").cwd(project.root())
                  .arg("--no-verify").arg("-v"),
-                execs().with_status(0).with_stdout_contains("[ARCHIVING] bar/Makefile"));
+                execs().with_status(0).with_stderr_contains("[ARCHIVING] bar/Makefile"));
 });
 
 test!(no_duplicates_from_modified_tracked_files {
@@ -355,6 +360,7 @@ test!(ignore_nested {
 
     assert_that(p.cargo_process("package"),
                 execs().with_status(0).with_stderr(&format!("\
+[WARNING] manifest has no documentation[..]
 [PACKAGING] nested v0.0.1 ({dir})
 [VERIFYING] nested v0.0.1 ({dir})
 [COMPILING] nested v0.0.1 ({dir}[..])
@@ -401,6 +407,7 @@ test!(package_weird_characters {
     assert_that(p.cargo_process("package"),
                 execs().with_status(101).with_stderr("\
 warning: [..]
+[PACKAGING] foo [..]
 [ERROR] failed to prepare local package for uploading
 
 Caused by:

--- a/tests/test_cargo_profiles.rs
+++ b/tests/test_cargo_profiles.rs
@@ -24,7 +24,7 @@ test!(profile_overrides {
         "#)
         .file("src/lib.rs", "");
     assert_that(p.cargo_process("build").arg("-v"),
-                execs().with_status(0).with_stdout(&format!("\
+                execs().with_status(0).with_stderr(&format!("\
 [COMPILING] test v0.0.0 ({url})
 [RUNNING] `rustc src{sep}lib.rs --crate-name test --crate-type lib \
         -C opt-level=1 \
@@ -75,7 +75,7 @@ test!(top_level_overrides_deps {
         "#)
         .file("foo/src/lib.rs", "");
     assert_that(p.cargo_process("build").arg("-v").arg("--release"),
-                execs().with_status(0).with_stdout(&format!("\
+                execs().with_status(0).with_stderr(&format!("\
 [COMPILING] foo v0.0.0 ({url}/foo)
 [RUNNING] `rustc foo{sep}src{sep}lib.rs --crate-name foo \
         --crate-type dylib --crate-type rlib -C prefer-dynamic \

--- a/tests/test_cargo_publish.rs
+++ b/tests/test_cargo_publish.rs
@@ -51,6 +51,7 @@ test!(simple {
     assert_that(p.cargo_process("publish").arg("--no-verify"),
                 execs().with_status(0).with_stderr(&format!("\
 [UPDATING] registry `{reg}`
+[WARNING] manifest has no documentation, [..]
 [PACKAGING] foo v0.0.1 ({dir})
 [UPLOADING] foo v0.0.1 ({dir})
 ",
@@ -100,6 +101,7 @@ test!(git_deps {
 
     assert_that(p.cargo_process("publish").arg("-v").arg("--no-verify"),
                 execs().with_status(101).with_stderr("\
+[UPDATING] registry [..]
 [ERROR] all dependencies must come from the same source.
 dependency `foo` comes from git://path/to/nowhere instead
 "));
@@ -129,6 +131,7 @@ test!(path_dependency_no_version {
 
     assert_that(p.cargo_process("publish"),
                 execs().with_status(101).with_stderr("\
+[UPDATING] registry [..]
 [ERROR] all path dependencies must have a version specified when publishing.
 dependency `bar` does not specify a version
 "));

--- a/tests/test_cargo_publish.rs
+++ b/tests/test_cargo_publish.rs
@@ -49,7 +49,7 @@ test!(simple {
         .file("src/main.rs", "fn main() {}");
 
     assert_that(p.cargo_process("publish").arg("--no-verify"),
-                execs().with_status(0).with_stdout(&format!("\
+                execs().with_status(0).with_stderr(&format!("\
 [UPDATING] registry `{reg}`
 [PACKAGING] foo v0.0.1 ({dir})
 [UPLOADING] foo v0.0.1 ({dir})

--- a/tests/test_cargo_registry.rs
+++ b/tests/test_cargo_registry.rs
@@ -239,7 +239,7 @@ version required: ^0.0.1
     Package::new("notyet", "0.0.1").publish();
 
     assert_that(p.cargo("package"),
-                execs().with_status(0).with_stdout(format!("\
+                execs().with_status(0).with_stderr(format!("\
 [PACKAGING] foo v0.0.1 ({dir})
 [VERIFYING] foo v0.0.1 ({dir})
 [UPDATING] registry `[..]`

--- a/tests/test_cargo_registry.rs
+++ b/tests/test_cargo_registry.rs
@@ -430,7 +430,7 @@ test!(update_with_lockfile_if_packages_missing {
 
     paths::home().join(".cargo/registry").rm_rf().unwrap();
     assert_that(p.cargo("build"),
-                execs().with_status(0).with_stdout("\
+                execs().with_status(0).with_stderr("\
 [UPDATING] registry `[..]`
 [DOWNLOADING] bar v0.0.1 (registry file://[..])
 "));
@@ -461,7 +461,7 @@ test!(update_lockfile {
     println!("0.0.2 update");
     assert_that(p.cargo("update")
                  .arg("-p").arg("bar").arg("--precise").arg("0.0.2"),
-                execs().with_status(0).with_stdout("\
+                execs().with_status(0).with_stderr("\
 [UPDATING] registry `[..]`
 [UPDATING] bar v0.0.1 (registry file://[..]) -> v0.0.2
 "));
@@ -478,7 +478,7 @@ test!(update_lockfile {
     println!("0.0.3 update");
     assert_that(p.cargo("update")
                  .arg("-p").arg("bar"),
-                execs().with_status(0).with_stdout("\
+                execs().with_status(0).with_stderr("\
 [UPDATING] registry `[..]`
 [UPDATING] bar v0.0.2 (registry file://[..]) -> v0.0.3
 "));
@@ -497,7 +497,7 @@ test!(update_lockfile {
    Package::new("spam", "0.2.5").publish();
    assert_that(p.cargo("update")
                 .arg("-p").arg("bar"),
-               execs().with_status(0).with_stdout("\
+               execs().with_status(0).with_stderr("\
 [UPDATING] registry `[..]`
 [UPDATING] bar v0.0.3 (registry file://[..]) -> v0.0.4
 [ADDING] spam v0.2.5 (registry file://[..])
@@ -507,7 +507,7 @@ test!(update_lockfile {
    Package::new("bar", "0.0.5").publish();
    assert_that(p.cargo("update")
                 .arg("-p").arg("bar"),
-               execs().with_status(0).with_stdout("\
+               execs().with_status(0).with_stderr("\
 [UPDATING] registry `[..]`
 [UPDATING] bar v0.0.4 (registry file://[..]) -> v0.0.5
 [REMOVING] spam v0.2.5 (registry file://[..])
@@ -735,7 +735,7 @@ test!(fetch_downloads {
 
     assert_that(p.cargo("fetch"),
                 execs().with_status(0)
-                       .with_stdout("\
+                       .with_stderr("\
 [UPDATING] registry `[..]`
 [DOWNLOADING] a v0.1.0 (registry [..])
 "));
@@ -765,14 +765,14 @@ test!(update_transitive_dependency {
 
     assert_that(p.cargo("update").arg("-pb"),
                 execs().with_status(0)
-                       .with_stdout("\
+                       .with_stderr("\
 [UPDATING] registry `[..]`
 [UPDATING] b v0.1.0 (registry [..]) -> v0.1.1
 "));
 
     assert_that(p.cargo("build"),
                 execs().with_status(0)
-                       .with_stdout("\
+                       .with_stderr("\
 [DOWNLOADING] b v0.1.1 (registry file://[..])
 [COMPILING] b v0.1.1 (registry [..])
 [COMPILING] a v0.1.0 (registry [..])
@@ -811,7 +811,7 @@ test!(update_backtracking_ok {
 
     assert_that(p.cargo("update").arg("-p").arg("hyper"),
                 execs().with_status(0)
-                       .with_stdout("\
+                       .with_stderr("\
 [UPDATING] registry `[..]`
 "));
 });
@@ -845,7 +845,7 @@ test!(update_multiple_packages {
 
     assert_that(p.cargo("update").arg("-pa").arg("-pb"),
                 execs().with_status(0)
-                       .with_stdout("\
+                       .with_stderr("\
 [UPDATING] registry `[..]`
 [UPDATING] a v0.1.0 (registry [..]) -> v0.1.1
 [UPDATING] b v0.1.0 (registry [..]) -> v0.1.1
@@ -853,7 +853,7 @@ test!(update_multiple_packages {
 
     assert_that(p.cargo("update").arg("-pb").arg("-pc"),
                 execs().with_status(0)
-                       .with_stdout("\
+                       .with_stderr("\
 [UPDATING] registry `[..]`
 [UPDATING] c v0.1.0 (registry [..]) -> v0.1.1
 "));
@@ -982,7 +982,7 @@ test!(only_download_relevant {
     Package::new("baz", "0.1.0").publish();
 
     assert_that(p.cargo("build"),
-                execs().with_status(0).with_stdout("\
+                execs().with_status(0).with_stderr("\
 [UPDATING] registry `[..]`
 [DOWNLOADING] baz v0.1.0 ([..])
 [COMPILING] baz v0.1.0 ([..])

--- a/tests/test_cargo_registry.rs
+++ b/tests/test_cargo_registry.rs
@@ -860,19 +860,19 @@ test!(update_multiple_packages {
 
     assert_that(p.cargo("build"),
                 execs().with_status(0)
-                       .with_stdout_contains("\
+                       .with_stderr_contains("\
 [DOWNLOADING] a v0.1.1 (registry file://[..])")
-                       .with_stdout_contains("\
+                       .with_stderr_contains("\
 [DOWNLOADING] b v0.1.1 (registry file://[..])")
-                       .with_stdout_contains("\
+                       .with_stderr_contains("\
 [DOWNLOADING] c v0.1.1 (registry file://[..])")
-                       .with_stdout_contains("\
+                       .with_stderr_contains("\
 [COMPILING] a v0.1.1 (registry [..])")
-                       .with_stdout_contains("\
+                       .with_stderr_contains("\
 [COMPILING] b v0.1.1 (registry [..])")
-                       .with_stdout_contains("\
+                       .with_stderr_contains("\
 [COMPILING] c v0.1.1 (registry [..])")
-                       .with_stdout_contains("\
+                       .with_stderr_contains("\
 [COMPILING] foo v0.5.0 ([..])"));
 });
 

--- a/tests/test_cargo_registry.rs
+++ b/tests/test_cargo_registry.rs
@@ -27,7 +27,7 @@ test!(simple {
     Package::new("bar", "0.0.1").publish();
 
     assert_that(p.cargo_process("build"),
-                execs().with_status(0).with_stdout(&format!("\
+                execs().with_status(0).with_stderr(&format!("\
 [UPDATING] registry `{reg}`
 [DOWNLOADING] bar v0.0.1 (registry file://[..])
 [COMPILING] bar v0.0.1 (registry file://[..])
@@ -38,7 +38,7 @@ test!(simple {
 
     // Don't download a second time
     assert_that(p.cargo_process("build"),
-                execs().with_status(0).with_stdout(&format!("\
+                execs().with_status(0).with_stderr(&format!("\
 [UPDATING] registry `{reg}`
 [..] bar v0.0.1 (registry file://[..])
 [..] foo v0.0.1 ({dir})
@@ -64,7 +64,7 @@ test!(deps {
     Package::new("bar", "0.0.1").dep("baz", "*").publish();
 
     assert_that(p.cargo_process("build"),
-                execs().with_status(0).with_stdout(&format!("\
+                execs().with_status(0).with_stderr(&format!("\
 [UPDATING] registry `{reg}`
 [DOWNLOADING] [..] v0.0.1 (registry file://[..])
 [DOWNLOADING] [..] v0.0.1 (registry file://[..])
@@ -189,7 +189,7 @@ version required: >= 0.0.0
     Package::new("notyet", "0.0.1").publish();
 
     assert_that(p.cargo("build"),
-                execs().with_status(0).with_stdout(&format!("\
+                execs().with_status(0).with_stderr(&format!("\
 [UPDATING] registry `{reg}`
 [DOWNLOADING] notyet v0.0.1 (registry file://[..])
 [COMPILING] notyet v0.0.1 (registry file://[..])
@@ -266,7 +266,7 @@ test!(lockfile_locks {
     Package::new("bar", "0.0.1").publish();
 
     assert_that(p.cargo("build"),
-                execs().with_status(0).with_stdout(&format!("\
+                execs().with_status(0).with_stderr(&format!("\
 [UPDATING] registry `[..]`
 [DOWNLOADING] bar v0.0.1 (registry file://[..])
 [COMPILING] bar v0.0.1 (registry file://[..])
@@ -299,7 +299,7 @@ test!(lockfile_locks_transitively {
     Package::new("bar", "0.0.1").dep("baz", "*").publish();
 
     assert_that(p.cargo("build"),
-                execs().with_status(0).with_stdout(&format!("\
+                execs().with_status(0).with_stderr(&format!("\
 [UPDATING] registry `[..]`
 [DOWNLOADING] [..] v0.0.1 (registry file://[..])
 [DOWNLOADING] [..] v0.0.1 (registry file://[..])
@@ -337,7 +337,7 @@ test!(yanks_are_not_used {
     Package::new("bar", "0.0.2").dep("baz", "*").yanked(true).publish();
 
     assert_that(p.cargo("build"),
-                execs().with_status(0).with_stdout(&format!("\
+                execs().with_status(0).with_stderr(&format!("\
 [UPDATING] registry `[..]`
 [DOWNLOADING] [..] v0.0.1 (registry file://[..])
 [DOWNLOADING] [..] v0.0.1 (registry file://[..])
@@ -468,7 +468,7 @@ test!(update_lockfile {
 
     println!("0.0.2 build");
     assert_that(p.cargo("build"),
-                execs().with_status(0).with_stdout(&format!("\
+                execs().with_status(0).with_stderr(&format!("\
 [DOWNLOADING] [..] v0.0.2 (registry file://[..])
 [COMPILING] bar v0.0.2 (registry file://[..])
 [COMPILING] foo v0.0.1 ({dir})
@@ -485,7 +485,7 @@ test!(update_lockfile {
 
     println!("0.0.3 build");
     assert_that(p.cargo("build"),
-                execs().with_status(0).with_stdout(&format!("\
+                execs().with_status(0).with_stderr(&format!("\
 [DOWNLOADING] [..] v0.0.3 (registry file://[..])
 [COMPILING] bar v0.0.3 (registry file://[..])
 [COMPILING] foo v0.0.1 ({dir})
@@ -532,7 +532,7 @@ test!(dev_dependency_not_used {
     Package::new("bar", "0.0.1").dev_dep("baz", "*").publish();
 
     assert_that(p.cargo("build"),
-                execs().with_status(0).with_stdout(&format!("\
+                execs().with_status(0).with_stderr(&format!("\
 [UPDATING] registry `[..]`
 [DOWNLOADING] [..] v0.0.1 (registry file://[..])
 [COMPILING] bar v0.0.1 (registry file://[..])
@@ -596,7 +596,7 @@ test!(updating_a_dep {
     Package::new("bar", "0.0.1").publish();
 
     assert_that(p.cargo("build"),
-                execs().with_status(0).with_stdout(&format!("\
+                execs().with_status(0).with_stderr(&format!("\
 [UPDATING] registry `[..]`
 [DOWNLOADING] bar v0.0.1 (registry file://[..])
 [COMPILING] bar v0.0.1 (registry file://[..])
@@ -618,7 +618,7 @@ test!(updating_a_dep {
 
     println!("second");
     assert_that(p.cargo("build"),
-                execs().with_status(0).with_stdout(&format!("\
+                execs().with_status(0).with_stderr(&format!("\
 [UPDATING] registry `[..]`
 [DOWNLOADING] bar v0.1.0 (registry file://[..])
 [COMPILING] bar v0.1.0 (registry file://[..])
@@ -661,7 +661,7 @@ test!(git_and_registry_dep {
 
     p.root().move_into_the_past().unwrap();
     assert_that(p.cargo("build"),
-                execs().with_status(0).with_stdout(&format!("\
+                execs().with_status(0).with_stderr(&format!("\
 [UPDATING] [..]
 [UPDATING] [..]
 [DOWNLOADING] a v0.0.1 (registry file://[..])
@@ -707,7 +707,7 @@ test!(update_publish_then_update {
 
     fs::remove_dir_all(&p.root().join("target")).unwrap();
     assert_that(p.cargo("build"),
-                execs().with_status(0).with_stdout(&format!("\
+                execs().with_status(0).with_stderr(&format!("\
 [UPDATING] [..]
 [DOWNLOADING] a v0.1.1 (registry file://[..])
 [COMPILING] a v0.1.1 (registry [..])

--- a/tests/test_cargo_registry.rs
+++ b/tests/test_cargo_registry.rs
@@ -93,6 +93,7 @@ test!(nonexistent {
 
     assert_that(p.cargo_process("build"),
                 execs().with_status(101).with_stderr("\
+[UPDATING] registry [..]
 [ERROR] no matching package named `nonexistent` found (required by `foo`)
 location searched: registry file://[..]
 version required: >= 0.0.0
@@ -116,7 +117,7 @@ test!(wrong_version {
     Package::new("foo", "0.0.2").publish();
 
     assert_that(p.cargo_process("build"),
-                execs().with_status(101).with_stderr("\
+                execs().with_status(101).with_stderr_contains("\
 [ERROR] no matching package named `foo` found (required by `foo`)
 location searched: registry file://[..]
 version required: >= 1.0.0
@@ -127,7 +128,7 @@ versions found: 0.0.2, 0.0.1
     Package::new("foo", "0.0.4").publish();
 
     assert_that(p.cargo_process("build"),
-                execs().with_status(101).with_stderr("\
+                execs().with_status(101).with_stderr_contains("\
 [ERROR] no matching package named `foo` found (required by `foo`)
 location searched: registry file://[..]
 version required: >= 1.0.0
@@ -154,6 +155,8 @@ test!(bad_cksum {
 
     assert_that(p.cargo_process("build").arg("-v"),
                 execs().with_status(101).with_stderr("\
+[UPDATING] registry [..]
+[DOWNLOADING] bad-cksum [..]
 [ERROR] unable to get packages from source
 
 Caused by:
@@ -180,7 +183,7 @@ test!(update_registry {
         .file("src/main.rs", "fn main() {}");
 
     assert_that(p.cargo_process("build"),
-                execs().with_status(101).with_stderr("\
+                execs().with_status(101).with_stderr_contains("\
 [ERROR] no matching package named `notyet` found (required by `foo`)
 location searched: registry file://[..]
 version required: >= 0.0.0
@@ -227,7 +230,7 @@ test!(package_with_path_deps {
     p.build();
 
     assert_that(p.cargo("package").arg("-v"),
-                execs().with_status(101).with_stderr("\
+                execs().with_status(101).with_stderr_contains("\
 [ERROR] failed to verify package tarball
 
 Caused by:
@@ -367,7 +370,7 @@ test!(relying_on_a_yank_is_bad {
     Package::new("bar", "0.0.1").dep("baz", "=0.0.2").publish();
 
     assert_that(p.cargo("build"),
-                execs().with_status(101).with_stderr("\
+                execs().with_status(101).with_stderr_contains("\
 [ERROR] no matching package named `baz` found (required by `bar`)
 location searched: registry file://[..]
 version required: = 0.0.2
@@ -402,7 +405,7 @@ test!(yanks_in_lockfiles_are_ok {
                 execs().with_status(0).with_stdout(""));
 
     assert_that(p.cargo("update"),
-                execs().with_status(101).with_stderr("\
+                execs().with_status(101).with_stderr_contains("\
 [ERROR] no matching package named `bar` found (required by `foo`)
 location searched: registry file://[..]
 version required: *
@@ -565,7 +568,7 @@ test!(bad_license_file {
         "#);
     assert_that(p.cargo_process("publish").arg("-v"),
                 execs().with_status(101)
-                       .with_stderr("\
+                       .with_stderr_contains("\
 [ERROR] the license file `foo` does not exist"));
 });
 

--- a/tests/test_cargo_run.rs
+++ b/tests/test_cargo_run.rs
@@ -197,24 +197,25 @@ test!(specify_name {
         "#);
 
     assert_that(p.cargo_process("run").arg("--bin").arg("a").arg("-v"),
-                execs().with_status(0).with_stdout(&format!("\
+                execs().with_status(0)
+                       .with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({dir})
 [RUNNING] `rustc src[..]lib.rs [..]`
 [RUNNING] `rustc src[..]a.rs [..]`
-[RUNNING] `target{sep}debug{sep}a[..]`
+[RUNNING] `target{sep}debug{sep}a[..]`", dir = path2url(p.root()), sep = SEP))
+                       .with_stdout("\
 hello a.rs
-",
-        dir = path2url(p.root()),
-        sep = SEP)));
+"));
 
     assert_that(p.cargo("run").arg("--bin").arg("b").arg("-v"),
-                execs().with_status(0).with_stdout(&format!("\
+                execs().with_status(0)
+                       .with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ([..])
 [RUNNING] `rustc src[..]b.rs [..]`
-[RUNNING] `target{sep}debug{sep}b[..]`
+[RUNNING] `target{sep}debug{sep}b[..]`", sep = SEP))
+                       .with_stdout("\
 hello b.rs
-",
-        sep = SEP)));
+"));
 });
 
 test!(run_example {
@@ -234,13 +235,13 @@ test!(run_example {
         "#);
 
     assert_that(p.cargo_process("run").arg("--example").arg("a"),
-                execs().with_status(0).with_stdout(&format!("\
+                execs().with_status(0)
+                       .with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({dir})
-[RUNNING] `target{sep}debug{sep}examples{sep}a[..]`
+[RUNNING] `target{sep}debug{sep}examples{sep}a[..]`", dir = path2url(p.root()), sep = SEP))
+                       .with_stdout("\
 example
-",
-        dir = path2url(p.root()),
-        sep = SEP)));
+"));
 });
 
 test!(run_with_filename {
@@ -323,13 +324,13 @@ test!(one_bin_multiple_examples {
         "#);
 
     assert_that(p.cargo_process("run"),
-                execs().with_status(0).with_stdout(&format!("\
+                execs().with_status(0)
+                       .with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({dir})
-[RUNNING] `target{sep}debug{sep}main[..]`
+[RUNNING] `target{sep}debug{sep}main[..]`", dir = path2url(p.root()), sep = SEP))
+                       .with_stdout("\
 hello main.rs
-",
-        dir = path2url(p.root()),
-        sep = SEP)));
+"));
 });
 
 test!(example_with_release_flag {
@@ -376,7 +377,8 @@ test!(example_with_release_flag {
         "#);
 
     assert_that(p.cargo_process("run").arg("-v").arg("--release").arg("--example").arg("a"),
-                execs().with_status(0).with_stdout(&format!("\
+                execs().with_status(0)
+                       .with_stderr(&format!("\
 [COMPILING] bar v0.0.1 ({url}/bar)
 [RUNNING] `rustc bar{sep}src{sep}bar.rs --crate-name bar --crate-type lib \
         -C opt-level=3 \
@@ -395,15 +397,17 @@ test!(example_with_release_flag {
         -L dependency={dir}{sep}target{sep}release{sep}deps \
          --extern bar={dir}{sep}target{sep}release{sep}deps{sep}libbar-[..].rlib`
 [RUNNING] `target{sep}release{sep}examples{sep}a[..]`
-fast1
-fast2
 ",
         dir = p.root().display(),
         url = path2url(p.root()),
-        sep = SEP)));
+        sep = SEP))
+                       .with_stdout("\
+fast1
+fast2"));
 
     assert_that(p.cargo("run").arg("-v").arg("--example").arg("a"),
-                execs().with_status(0).with_stdout(&format!("\
+                execs().with_status(0)
+                       .with_stderr(&format!("\
 [COMPILING] bar v0.0.1 ({url}/bar)
 [RUNNING] `rustc bar{sep}src{sep}bar.rs --crate-name bar --crate-type lib \
         -g \
@@ -422,12 +426,13 @@ fast2
         -L dependency={dir}{sep}target{sep}debug{sep}deps \
          --extern bar={dir}{sep}target{sep}debug{sep}deps{sep}libbar-[..].rlib`
 [RUNNING] `target{sep}debug{sep}examples{sep}a[..]`
-slow1
-slow2
 ",
         dir = p.root().display(),
         url = path2url(p.root()),
-        sep = SEP)));
+        sep = SEP))
+                       .with_stdout("\
+slow1
+slow2"));
 });
 
 test!(run_dylib_dep {
@@ -541,10 +546,10 @@ test!(run_from_executable_folder {
     p.cargo_process("build").exec_with_output().unwrap();
 
     assert_that(p.cargo("run").cwd(cwd),
-                execs().with_status(0).with_stdout(&format!("\
-[RUNNING] `.{sep}foo[..]`
+                execs().with_status(0)
+                       .with_stderr(&format!("\
+[RUNNING] `.{sep}foo[..]`", sep = SEP))
+                       .with_stdout("\
 hello
-",
-        sep = SEP
-        )));
+"));
 });

--- a/tests/test_cargo_run.rs
+++ b/tests/test_cargo_run.rs
@@ -120,6 +120,8 @@ test!(exit_code {
     assert_that(p.cargo_process("run"),
                 execs().with_status(2)
                        .with_stderr("\
+[COMPILING] foo v0.0.1 (file[..])
+[RUNNING] `target[..]`
 [ERROR] Process didn't exit successfully: `target[..]foo[..]` (exit code: 2)
 "));
 });
@@ -139,6 +141,9 @@ test!(exit_code_verbose {
     assert_that(p.cargo_process("run").arg("-v"),
                 execs().with_status(2)
                        .with_stderr("\
+[COMPILING] foo v0.0.1 (file[..])
+[RUNNING] `rustc [..]`
+[RUNNING] `target[..]`
 [ERROR] Process didn't exit successfully: `target[..]foo[..]` (exit code: 2)
 "));
 });

--- a/tests/test_cargo_run.rs
+++ b/tests/test_cargo_run.rs
@@ -19,13 +19,13 @@ test!(simple {
         "#);
 
     assert_that(p.cargo_process("run"),
-                execs().with_status(0).with_stdout(&format!("\
+                execs().with_status(0)
+                       .with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({dir})
-[RUNNING] `target{sep}debug{sep}foo[..]`
+[RUNNING] `target{sep}debug{sep}foo[..]`", dir = path2url(p.root()), sep = SEP))
+                       .with_stdout("\
 hello
-",
-        dir = path2url(p.root()),
-        sep = SEP)));
+"));
     assert_that(&p.bin("foo"), existing_file());
 });
 

--- a/tests/test_cargo_run.rs
+++ b/tests/test_cargo_run.rs
@@ -474,7 +474,7 @@ test!(release_works {
         "#);
 
     assert_that(p.cargo_process("run").arg("--release"),
-                execs().with_status(0).with_stdout(&format!("\
+                execs().with_status(0).with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({dir})
 [RUNNING] `target{sep}release{sep}foo[..]`
 ",

--- a/tests/test_cargo_rustc.rs
+++ b/tests/test_cargo_rustc.rs
@@ -84,7 +84,7 @@ test!(build_main_and_allow_unstable_options {
                 .arg("--").arg("-Z").arg("unstable-options"),
                 execs()
                 .with_status(0)
-                .with_stdout(&format!("\
+                .with_stderr(&format!("\
 [COMPILING] {name} v{version} ({url})
 [RUNNING] `rustc src{sep}lib.rs --crate-name {name} --crate-type lib -g \
         --out-dir {dir}{sep}target{sep}debug \
@@ -146,7 +146,7 @@ test!(build_with_args_to_one_of_multiple_binaries {
                 .arg("--").arg("-Z").arg("unstable-options"),
                 execs()
                 .with_status(0)
-                .with_stdout(format!("\
+                .with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({url})
 [RUNNING] `rustc src{sep}lib.rs --crate-name foo --crate-type lib -g \
         --out-dir {dir}{sep}target{sep}debug [..]`
@@ -199,7 +199,7 @@ test!(build_with_args_to_one_of_multiple_tests {
                 .arg("--").arg("-Z").arg("unstable-options"),
                 execs()
                 .with_status(0)
-                .with_stdout(format!("\
+                .with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({url})
 [RUNNING] `rustc src{sep}lib.rs --crate-name foo --crate-type lib -g \
         --out-dir {dir}{sep}target{sep}debug [..]`

--- a/tests/test_cargo_rustc.rs
+++ b/tests/test_cargo_rustc.rs
@@ -27,7 +27,7 @@ test!(build_lib_for_foo {
     assert_that(p.cargo_process("rustc").arg("--lib").arg("-v"),
                 execs()
                 .with_status(0)
-                .with_stdout(format!("\
+                .with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({url})
 [RUNNING] `rustc src{sep}lib.rs --crate-name foo --crate-type lib -g \
         --out-dir {dir}{sep}target{sep}debug \
@@ -55,7 +55,7 @@ test!(build_lib_and_allow_unstable_options {
                 .arg("--").arg("-Z").arg("unstable-options"),
                 execs()
                 .with_status(0)
-                .with_stdout(format!("\
+                .with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({url})
 [RUNNING] `rustc src{sep}lib.rs --crate-name foo --crate-type lib -g \
         -Z unstable-options \
@@ -241,7 +241,7 @@ test!(build_foo_with_bar_dependency {
     assert_that(foo.cargo_process("rustc").arg("-v").arg("--").arg("-Z").arg("unstable-options"),
                 execs()
                 .with_status(0)
-                .with_stdout(format!("\
+                .with_stderr(format!("\
 [COMPILING] bar v0.1.0 ([..])
 [RUNNING] `[..] -g -C [..]`
 [COMPILING] foo v0.0.1 ({url})

--- a/tests/test_cargo_rustc.rs
+++ b/tests/test_cargo_rustc.rs
@@ -283,7 +283,7 @@ test!(build_only_bar_dependency {
                 .arg("--").arg("-Z").arg("unstable-options"),
                 execs()
                 .with_status(0)
-                .with_stdout("\
+                .with_stderr("\
 [COMPILING] bar v0.1.0 ([..])
 [RUNNING] `[..]--crate-name bar --crate-type lib [..] -Z unstable-options [..]`
 "));

--- a/tests/test_cargo_rustdoc.rs
+++ b/tests/test_cargo_rustdoc.rs
@@ -19,7 +19,7 @@ test!(rustdoc_simple {
     assert_that(p.cargo_process("rustdoc").arg("-v"),
                 execs()
                 .with_status(0)
-                .with_stdout(format!("\
+                .with_stderr(format!("\
 [DOCUMENTING] foo v0.0.1 ({url})
 [RUNNING] `rustdoc src{sep}lib.rs --crate-name foo \
         -o {dir}{sep}target{sep}doc \
@@ -42,7 +42,7 @@ test!(rustdoc_args {
     assert_that(p.cargo_process("rustdoc").arg("-v").arg("--").arg("--no-defaults"),
                 execs()
                 .with_status(0)
-                .with_stdout(format!("\
+                .with_stderr(format!("\
 [DOCUMENTING] foo v0.0.1 ({url})
 [RUNNING] `rustdoc src{sep}lib.rs --crate-name foo \
         -o {dir}{sep}target{sep}doc \
@@ -85,7 +85,7 @@ test!(rustdoc_foo_with_bar_dependency {
     assert_that(foo.cargo_process("rustdoc").arg("-v").arg("--").arg("--no-defaults"),
                 execs()
                 .with_status(0)
-                .with_stdout(format!("\
+                .with_stderr(format!("\
 [COMPILING] bar v0.0.1 ([..])
 [RUNNING] `rustc [..]bar{sep}src{sep}lib.rs [..]`
 [DOCUMENTING] foo v0.0.1 ({url})
@@ -132,7 +132,7 @@ test!(rustdoc_only_bar_dependency {
                                             .arg("--").arg("--no-defaults"),
                 execs()
                 .with_status(0)
-                .with_stdout(format!("\
+                .with_stderr(format!("\
 [DOCUMENTING] bar v0.0.1 ([..])
 [RUNNING] `rustdoc [..]bar{sep}src{sep}lib.rs --crate-name bar \
         -o {dir}{sep}target{sep}doc \

--- a/tests/test_cargo_search.rs
+++ b/tests/test_cargo_search.rs
@@ -80,8 +80,10 @@ test!(simple {
     }
 
     assert_that(cargo_process("search").arg("postgres"),
-                execs().with_status(0).with_stdout("\
-[UPDATING] registry `[..]`
+                execs().with_status(0)
+                       .with_stderr("\
+[UPDATING] registry `[..]`")
+                       .with_stdout("\
 hoare (0.1.1)    Design by contract style assertions for Rust"));
 });
 
@@ -126,8 +128,10 @@ test!(multiple_query_params {
     }
 
     assert_that(cargo_process("search").arg("postgres").arg("sql"),
-                execs().with_status(0).with_stdout("\
-[UPDATING] registry `[..]`
+                execs().with_status(0)
+                       .with_stderr("\
+[UPDATING] registry `[..]`")
+                       .with_stdout("\
 hoare (0.1.1)    Design by contract style assertions for Rust"));
 });
 

--- a/tests/test_cargo_test.rs
+++ b/tests/test_cargo_test.rs
@@ -1855,27 +1855,28 @@ test!(no_fail_fast {
         "#);
     assert_that(p.cargo_process("test").arg("--no-fail-fast"),
                 execs().with_status(101)
-                       .with_stdout_contains("\
+                       .with_stderr_contains("\
 [COMPILING] foo v0.0.1 ([..])
 [RUNNING] target[..]foo[..]
-
+[RUNNING] target[..]test_add_one[..]")
+                       .with_stdout_contains("
 running 0 tests
 
 test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
 
-[RUNNING] target[..]test_add_one[..]
 ")
+                       .with_stderr_contains("\
+[RUNNING] target[..]test_sub_one[..]
+[DOCTEST] foo")
                        .with_stdout_contains("\
 test result: FAILED. 1 passed; 1 failed; 0 ignored; 0 measured
 
-[RUNNING] target[..]test_sub_one[..]
 
 running 1 test
 test sub_one_test ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
 
-[DOCTEST] foo
 
 running 1 test
 test sub_one_0 ... ok
@@ -1929,16 +1930,16 @@ test!(test_multiple_packages {
 
     assert_that(p.cargo("test").arg("-p").arg("d1").arg("-p").arg("d2"),
                 execs().with_status(0)
-                       .with_stdout_contains("\
-[RUNNING] target[..]debug[..]d1-[..]
-
+                       .with_stderr_contains("\
+[RUNNING] target[..]debug[..]d1-[..]")
+                       .with_stdout_contains("
 running 0 tests
 
 test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
 ")
-                       .with_stdout_contains("\
-[RUNNING] target[..]debug[..]d2-[..]
-
+                       .with_stderr_contains("\
+[RUNNING] target[..]debug[..]d2-[..]")
+                       .with_stdout_contains("
 running 0 tests
 
 test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured

--- a/tests/test_cargo_test.rs
+++ b/tests/test_cargo_test.rs
@@ -480,15 +480,15 @@ test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
 
     assert_that(p.cargo("test").arg("foo"),
                 execs().with_status(0)
-                       .with_stdout("\
+                       .with_stderr("\
 [RUNNING] target[..]foo-[..]
-
+[DOCTEST] foo")
+                       .with_stdout("
 running 1 test
 test foo ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
 
-[DOCTEST] foo
 
 running 0 tests
 
@@ -957,15 +957,15 @@ test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
     p.root().move_into_the_past().unwrap();
     assert_that(p.cargo("test"),
                 execs().with_status(0)
-                       .with_stdout("\
+                       .with_stderr("\
 [RUNNING] target[..]foo-[..]
-
+[RUNNING] target[..]test-[..]")
+                       .with_stdout("
 running 1 test
 test foo ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
 
-[RUNNING] target[..]test-[..]
 
 running 1 test
 test foo ... ok
@@ -1013,15 +1013,15 @@ test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
 
     assert_that(p.cargo("test"),
                 execs().with_status(0)
-                       .with_stdout("\
+                       .with_stderr("\
 [RUNNING] target[..]foo-[..]
-
+[DOCTEST] foo")
+                       .with_stdout("
 running 1 test
 test foo ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
 
-[DOCTEST] foo
 
 running 0 tests
 
@@ -1471,9 +1471,10 @@ test!(example_bin_same_name {
 
     assert_that(p.cargo("run"),
                 execs().with_status(0)
-                       .with_stdout("\
+                       .with_stderr("\
 [COMPILING] foo v0.0.1 ([..])
-[RUNNING] [..]
+[RUNNING] [..]")
+                       .with_stdout("\
 bin
 "));
     assert_that(&p.bin("foo"), existing_file());
@@ -1597,15 +1598,16 @@ test!(doctest_feature {
         "#);
 
     assert_that(p.cargo_process("test").arg("--features").arg("bar"),
-                execs().with_status(0).with_stdout("\
+                execs().with_status(0)
+                       .with_stderr("\
 [COMPILING] foo [..]
 [RUNNING] target[..]foo[..]
-
+[DOCTEST] foo")
+                       .with_stdout("
 running 0 tests
 
 test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
 
-[DOCTEST] foo
 
 running 1 test
 test foo_0 ... ok
@@ -1680,10 +1682,10 @@ test!(filter_no_doc_tests {
         .file("tests/foo.rs", "");
 
     assert_that(p.cargo_process("test").arg("--test=foo"),
-                execs().with_stdout("\
+                execs().with_stderr("\
 [COMPILING] foo v0.0.1 ([..])
-[RUNNING] target[..]debug[..]foo[..]
-
+[RUNNING] target[..]debug[..]foo[..]")
+                       .with_stdout("
 running 0 tests
 
 test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
@@ -1712,10 +1714,10 @@ test!(dylib_doctest {
         "#);
 
     assert_that(p.cargo_process("test"),
-                execs().with_stdout("\
+                execs().with_stderr("\
 [COMPILING] foo v0.0.1 ([..])
-[DOCTEST] foo
-
+[DOCTEST] foo")
+                       .with_stdout("
 running 1 test
 test foo_0 ... ok
 
@@ -1778,16 +1780,16 @@ test!(cyclic_dev_dep_doc_test {
             extern crate foo;
         "#);
     assert_that(p.cargo_process("test"),
-                execs().with_stdout("\
+                execs().with_stderr("\
 [COMPILING] foo v0.0.1 ([..])
 [COMPILING] bar v0.0.1 ([..])
 [RUNNING] target[..]foo[..]
-
+[DOCTEST] foo")
+                       .with_stdout("
 running 0 tests
 
 test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
 
-[DOCTEST] foo
 
 running 1 test
 test _0 ... ok

--- a/tests/test_cargo_test.rs
+++ b/tests/test_cargo_test.rs
@@ -1083,7 +1083,7 @@ test!(test_no_run {
 
     assert_that(p.cargo_process("test").arg("--no-run"),
                 execs().with_status(0)
-                       .with_stdout(&format!("\
+                       .with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({dir})
 ",
                        dir = p.url())));
@@ -1175,7 +1175,7 @@ test!(test_no_harness {
 
     assert_that(p.cargo_process("test").arg("--").arg("--nocapture"),
                 execs().with_status(0)
-                       .with_stdout(&format!("\
+                       .with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({dir})
 [RUNNING] target[..]bar-[..]
 ",
@@ -1457,7 +1457,7 @@ test!(example_bin_same_name {
 
     assert_that(p.cargo_process("test").arg("--no-run").arg("-v"),
                 execs().with_status(0)
-                       .with_stdout(&format!("\
+                       .with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({dir})
 [RUNNING] `rustc [..]`
 [RUNNING] `rustc [..]`

--- a/tests/test_cargo_test.rs
+++ b/tests/test_cargo_test.rs
@@ -184,10 +184,10 @@ test!(cargo_test_failing_test {
                 execs().with_stdout("hello\n"));
 
     assert_that(p.cargo("test"),
-                execs().with_stdout_contains(format!("\
+                execs().with_stderr(format!("\
 [COMPILING] foo v0.5.0 ({url})
-[RUNNING] target[..]foo-[..]
-
+[RUNNING] target[..]foo-[..]", url = p.url()))
+                       .with_stdout_contains("
 running 1 test
 test test_hello ... FAILED
 
@@ -197,14 +197,14 @@ failures:
 <tab>thread 'test_hello' panicked at 'assertion failed: \
     `(left == right)` (left: \
     `\"hello\"`, right: `\"nope\"`)', src[..]foo.rs:12
-", url = p.url()))
-                    .with_stdout_contains("\
+")
+                       .with_stdout_contains("\
 failures:
     test_hello
 
 test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured
 ")
-                    .with_status(101));
+                       .with_status(101));
 });
 
 test!(test_with_lib_dep {

--- a/tests/test_cargo_test.rs
+++ b/tests/test_cargo_test.rs
@@ -33,16 +33,16 @@ test!(cargo_test_simple {
                 execs().with_stdout("hello\n"));
 
     assert_that(p.cargo("test"),
-                execs().with_stdout(format!("\
+                execs().with_stderr(format!("\
 [COMPILING] foo v0.5.0 ({})
-[RUNNING] target[..]foo-[..]
-
+[RUNNING] target[..]foo-[..]", p.url()))
+                       .with_stdout("
 running 1 test
 test test_hello ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
 
-", p.url())));
+"));
 });
 
 test!(cargo_test_release {
@@ -78,7 +78,7 @@ test!(cargo_test_release {
         .file("bar/src/lib.rs", "pub fn bar() {}");
 
     assert_that(p.cargo_process("test").arg("-v").arg("--release"),
-                execs().with_stdout(format!("\
+                execs().with_stderr(format!("\
 [COMPILING] bar v0.0.1 ({dir}/bar)
 [RUNNING] [..] -C opt-level=3 [..]
 [COMPILING] foo v0.1.0 ({dir})
@@ -86,27 +86,27 @@ test!(cargo_test_release {
 [RUNNING] [..] -C opt-level=3 [..]
 [RUNNING] [..] -C opt-level=3 [..]
 [RUNNING] `[..]target[..]foo-[..]`
-
-running 1 test
-test test ... ok
-
-test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
-
 [RUNNING] `[..]target[..]test-[..]`
+[DOCTEST] foo
+[RUNNING] `rustdoc --test [..]lib.rs[..]`", dir = p.url()))
+                       .with_stdout("
+running 1 test
+test test ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
+
 
 running 1 test
 test test ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
 
-[DOCTEST] foo
-[RUNNING] `rustdoc --test [..]lib.rs[..]`
 
 running 0 tests
 
 test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
 
-", dir = p.url())));
+"));
 });
 
 test!(cargo_test_verbose {
@@ -118,17 +118,17 @@ test!(cargo_test_verbose {
         "#);
 
     assert_that(p.cargo_process("test").arg("-v").arg("hello"),
-        execs().with_stdout(format!("\
+                execs().with_stderr(format!("\
 [COMPILING] foo v0.5.0 ({url})
 [RUNNING] `rustc src[..]foo.rs [..]`
-[RUNNING] `[..]target[..]foo-[..] hello`
-
+[RUNNING] `[..]target[..]foo-[..] hello`", url = p.url()))
+                       .with_stdout("
 running 1 test
 test test_hello ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
 
-", url = p.url())));
+"));
 });
 
 test!(many_similar_names {
@@ -241,31 +241,30 @@ test!(test_with_lib_dep {
         ");
 
     assert_that(p.cargo_process("test"),
-        execs().with_stdout(format!("\
+                execs().with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({})
 [RUNNING] target[..]baz-[..]
-
+[RUNNING] target[..]foo[..]
+[DOCTEST] foo", p.url()))
+                       .with_stdout("
 running 1 test
 test bin_test ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
 
-[RUNNING] target[..]foo[..]
 
 running 1 test
 test lib_test ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
 
-[DOCTEST] foo
 
 running 1 test
 test foo_0 ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
 
-",
-        p.url())))
+"))
 });
 
 test!(test_with_deep_lib_dep {
@@ -308,25 +307,24 @@ test!(test_with_deep_lib_dep {
     p2.build();
     assert_that(p.cargo_process("test"),
                 execs().with_status(0)
-                       .with_stdout(&format!("\
+                       .with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ([..])
 [COMPILING] bar v0.0.1 ({dir})
 [RUNNING] target[..]
-
+[DOCTEST] bar", dir = p.url()))
+                       .with_stdout("
 running 1 test
 test bar_test ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
 
-[DOCTEST] bar
 
 running 1 test
 test bar_0 ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
 
-",
-                       dir = p.url())));
+"));
 });
 
 test!(external_test_explicit {
@@ -355,30 +353,29 @@ test!(external_test_explicit {
         "#);
 
     assert_that(p.cargo_process("test"),
-        execs().with_stdout(format!("\
+                execs().with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({})
 [RUNNING] target[..]foo-[..]
-
+[RUNNING] target[..]test-[..]
+[DOCTEST] foo", p.url()))
+                       .with_stdout("
 running 1 test
 test internal_test ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
 
-[RUNNING] target[..]test-[..]
 
 running 1 test
 test external_test ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
 
-[DOCTEST] foo
 
 running 0 tests
 
 test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
 
-",
-        p.url())))
+"))
 });
 
 test!(external_test_implicit {
@@ -403,29 +400,29 @@ test!(external_test_implicit {
         "#);
 
     assert_that(p.cargo_process("test"),
-        execs().with_stdout(format!("\
+                execs().with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({})
 [RUNNING] target[..]external-[..]
-
+[RUNNING] target[..]foo-[..]
+[DOCTEST] foo", p.url()))
+                       .with_stdout("
 running 1 test
 test external_test ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
 
-[RUNNING] target[..]foo-[..]
 
 running 1 test
 test internal_test ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
 
-[DOCTEST] foo
 
 running 0 tests
 
 test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
 
-", p.url())))
+"))
 });
 
 test!(dont_run_examples {
@@ -460,23 +457,22 @@ test!(pass_through_command_line {
 
     assert_that(p.cargo_process("test").arg("bar"),
                 execs().with_status(0)
-                       .with_stdout(&format!("\
+                       .with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({dir})
 [RUNNING] target[..]foo-[..]
-
+[DOCTEST] foo", dir = p.url()))
+                       .with_stdout("
 running 1 test
 test bar ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
 
-[DOCTEST] foo
 
 running 0 tests
 
 test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
 
-",
-                       dir = p.url())));
+"));
 
     assert_that(p.cargo("test").arg("foo"),
                 execs().with_status(0)
@@ -541,30 +537,29 @@ test!(lib_bin_same_name {
         ");
 
     assert_that(p.cargo_process("test"),
-        execs().with_stdout(format!("\
+                execs().with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({})
 [RUNNING] target[..]foo-[..]
-
-running 1 test
-test [..] ... ok
-
-test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
-
 [RUNNING] target[..]foo-[..]
+[DOCTEST] foo", p.url()))
+                       .with_stdout("
+running 1 test
+test [..] ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
+
 
 running 1 test
 test [..] ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
 
-[DOCTEST] foo
 
 running 0 tests
 
 test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
 
-",
-        p.url())))
+"))
 });
 
 test!(lib_with_standard_name {
@@ -593,30 +588,30 @@ test!(lib_with_standard_name {
 
     assert_that(p.cargo_process("test"),
                 execs().with_status(0)
-                       .with_stdout(&format!("\
+                       .with_stderr(&format!("\
 [COMPILING] syntax v0.0.1 ({dir})
 [RUNNING] target[..]syntax-[..]
-
+[RUNNING] target[..]test-[..]
+[DOCTEST] syntax", dir = p.url()))
+                       .with_stdout("
 running 1 test
 test foo_test ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
 
-[RUNNING] target[..]test-[..]
 
 running 1 test
 test test ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
 
-[DOCTEST] syntax
 
 running 1 test
 test foo_0 ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
 
-", dir = p.url())));
+"));
 });
 
 test!(lib_with_standard_name2 {
@@ -646,17 +641,16 @@ test!(lib_with_standard_name2 {
 
     assert_that(p.cargo_process("test"),
                 execs().with_status(0)
-                       .with_stdout(&format!("\
+                       .with_stderr(&format!("\
 [COMPILING] syntax v0.0.1 ({dir})
-[RUNNING] target[..]syntax-[..]
-
+[RUNNING] target[..]syntax-[..]", dir = p.url()))
+                       .with_stdout("
 running 1 test
 test test ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
 
-",
-                       dir = p.url())));
+"));
 });
 
 test!(lib_without_name {
@@ -685,16 +679,16 @@ test!(lib_without_name {
 
     assert_that(p.cargo_process("test"),
                 execs().with_status(0)
-                       .with_stdout(&format!("\
+                       .with_stderr(&format!("\
 [COMPILING] syntax v0.0.1 ({dir})
-[RUNNING] target[..]syntax-[..]
-
+[RUNNING] target[..]syntax-[..]", dir = p.url()))
+                       .with_stdout("
 running 1 test
 test test ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
 
-", dir = p.url())));
+"));
 });
 
 test!(bin_without_name {
@@ -935,25 +929,24 @@ test!(test_dylib {
 
     assert_that(p.cargo_process("test"),
                 execs().with_status(0)
-                       .with_stdout(&format!("\
+                       .with_stderr(&format!("\
 [COMPILING] bar v0.0.1 ({dir}/bar)
 [COMPILING] foo v0.0.1 ({dir})
 [RUNNING] target[..]foo-[..]
+[RUNNING] target[..]test-[..]", dir = p.url()))
+                       .with_stdout("
+running 1 test
+test foo ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
+
 
 running 1 test
 test foo ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
 
-[RUNNING] target[..]test-[..]
-
-running 1 test
-test foo ... ok
-
-test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
-
-",
-                       dir = p.url())));
+"));
     p.root().move_into_the_past().unwrap();
     assert_that(p.cargo("test"),
                 execs().with_status(0)
@@ -993,23 +986,22 @@ test!(test_twice_with_build_cmd {
 
     assert_that(p.cargo_process("test"),
                 execs().with_status(0)
-                       .with_stdout(&format!("\
+                       .with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({dir})
 [RUNNING] target[..]foo-[..]
-
+[DOCTEST] foo", dir = p.url()))
+                       .with_stdout("
 running 1 test
 test foo ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
 
-[DOCTEST] foo
 
 running 0 tests
 
 test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
 
-",
-                       dir = p.url())));
+"));
 
     assert_that(p.cargo("test"),
                 execs().with_status(0)
@@ -1045,23 +1037,22 @@ test!(test_then_build {
 
     assert_that(p.cargo_process("test"),
                 execs().with_status(0)
-                       .with_stdout(&format!("\
+                       .with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({dir})
 [RUNNING] target[..]foo-[..]
-
+[DOCTEST] foo", dir = p.url()))
+                       .with_stdout("
 running 1 test
 test foo ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
 
-[DOCTEST] foo
 
 running 0 tests
 
 test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
 
-",
-                       dir = p.url())));
+"));
 
     assert_that(p.cargo("build"),
                 execs().with_status(0)
@@ -1108,20 +1099,18 @@ test!(test_run_specific_bin_target {
         .file("src/bin1.rs", "#[test] fn test1() { }")
         .file("src/bin2.rs", "#[test] fn test2() { }");
 
-    let expected_stdout = format!("\
+    assert_that(prj.cargo_process("test").arg("--bin").arg("bin2"),
+                execs().with_status(0)
+                       .with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({dir})
-[RUNNING] target[..]bin2-[..]
-
+[RUNNING] target[..]bin2-[..]", dir = prj.url()))
+                       .with_stdout("
 running 1 test
 test test2 ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
 
-",
-       dir = prj.url());
-
-    assert_that(prj.cargo_process("test").arg("--bin").arg("bin2"),
-        execs().with_status(0).with_stdout(&expected_stdout));
+"));
 });
 
 test!(test_run_specific_test_target {
@@ -1137,20 +1126,18 @@ test!(test_run_specific_test_target {
         .file("tests/a.rs", "#[test] fn test_a() { }")
         .file("tests/b.rs", "#[test] fn test_b() { }");
 
-    let expected_stdout = format!("\
+    assert_that(prj.cargo_process("test").arg("--test").arg("b"),
+                execs().with_status(0)
+                       .with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({dir})
-[RUNNING] target[..]b-[..]
-
+[RUNNING] target[..]b-[..]", dir = prj.url()))
+                       .with_stdout("
 running 1 test
 test test_b ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
 
-",
-       dir = prj.url());
-
-    assert_that(prj.cargo_process("test").arg("--test").arg("b"),
-        execs().with_status(0).with_stdout(&expected_stdout));
+"));
 });
 
 test!(test_no_harness {
@@ -1229,56 +1216,53 @@ test!(selective_testing {
     println!("d1");
     assert_that(p.cargo("test").arg("-p").arg("d1"),
                 execs().with_status(0)
-                       .with_stdout(&format!("\
+                       .with_stderr(&format!("\
 [COMPILING] d1 v0.0.1 ({dir}/d1)
 [RUNNING] target[..]d1-[..]
+[RUNNING] target[..]d1-[..]", dir = p.url()))
+                       .with_stdout("
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
+
 
 running 0 tests
 
 test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
 
-[RUNNING] target[..]d1-[..]
-
-running 0 tests
-
-test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
-
-",
-   dir = p.url())));
+"));
 
     println!("d2");
     assert_that(p.cargo("test").arg("-p").arg("d2"),
                 execs().with_status(0)
-                       .with_stdout(&format!("\
+                       .with_stderr(&format!("\
 [COMPILING] d2 v0.0.1 ({dir}/d2)
 [RUNNING] target[..]d2-[..]
+[RUNNING] target[..]d2-[..]", dir = p.url()))
+                       .with_stdout("
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
+
 
 running 0 tests
 
 test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
 
-[RUNNING] target[..]d2-[..]
-
-running 0 tests
-
-test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
-
-",
-   dir = p.url())));
+"));
 
     println!("whole");
     assert_that(p.cargo("test"),
                 execs().with_status(0)
-                       .with_stdout(&format!("\
+                       .with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({dir})
-[RUNNING] target[..]foo-[..]
-
+[RUNNING] target[..]foo-[..]", dir = p.url()))
+                       .with_stdout("
 running 0 tests
 
 test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
 
-",
-   dir = p.url())));
+"));
 });
 
 test!(almost_cyclic_but_not_quite {
@@ -1427,21 +1411,21 @@ test!(selective_testing_with_docs {
 
     assert_that(p.cargo("test").arg("-p").arg("d1"),
                 execs().with_status(0)
-                       .with_stdout(&format!("\
+                       .with_stderr(&format!("\
 [COMPILING] d1 v0.0.1 ({dir}/d1)
 [RUNNING] target[..]deps[..]d1[..]
+[DOCTEST] d1", dir = p.url()))
+                       .with_stdout("
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
+
 
 running 0 tests
 
 test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
 
-[DOCTEST] d1
-
-running 0 tests
-
-test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
-
-", dir = p.url())));
+"));
 });
 
 test!(example_bin_same_name {

--- a/tests/test_cargo_test.rs
+++ b/tests/test_cargo_test.rs
@@ -186,7 +186,8 @@ test!(cargo_test_failing_test {
     assert_that(p.cargo("test"),
                 execs().with_stderr(format!("\
 [COMPILING] foo v0.5.0 ({url})
-[RUNNING] target[..]foo-[..]", url = p.url()))
+[RUNNING] target[..]foo-[..]
+[ERROR] test failed", url = p.url()))
                        .with_stdout_contains("
 running 1 test
 test test_hello ... FAILED
@@ -2058,15 +2059,16 @@ test!(only_test_docs {
     p.build();
 
     assert_that(p.cargo("test").arg("--doc"),
-                execs().with_status(0).with_stdout(&format!("\
+                execs().with_status(0)
+                       .with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ([..])
-[DOCTEST] foo
-
+[DOCTEST] foo"))
+                       .with_stdout("
 running 1 test
 test bar_0 ... ok
 
 test result: ok.[..]
 
-")));
+"));
 });
 

--- a/tests/test_cargo_test.rs
+++ b/tests/test_cargo_test.rs
@@ -1528,7 +1528,7 @@ test!(example_with_dev_dep {
 
     assert_that(p.cargo_process("test").arg("-v"),
                 execs().with_status(0)
-                       .with_stdout("\
+                       .with_stderr("\
 [..]
 [..]
 [..]
@@ -1981,7 +1981,7 @@ test!(bin_does_not_rebuild_tests {
 
     assert_that(p.cargo("test").arg("-v").arg("--no-run"),
                 execs().with_status(0)
-                       .with_stdout("\
+                       .with_stderr("\
 [COMPILING] foo v0.0.1 ([..])
 [RUNNING] `rustc src[..]main.rs [..]`
 [RUNNING] `rustc src[..]main.rs [..]`
@@ -2040,7 +2040,7 @@ test!(selective_test_optional_dep {
 
     assert_that(p.cargo("test").arg("-v").arg("--no-run")
                  .arg("--features").arg("a").arg("-p").arg("a"),
-                execs().with_status(0).with_stdout("\
+                execs().with_status(0).with_stderr("\
 [COMPILING] a v0.0.1 ([..])
 [RUNNING] `rustc a[..]src[..]lib.rs [..]`
 [RUNNING] `rustc a[..]src[..]lib.rs [..]`

--- a/tests/test_cargo_tool_paths.rs
+++ b/tests/test_cargo_tool_paths.rs
@@ -25,7 +25,7 @@ test!(pathless_tools {
         "#, target));
 
     assert_that(foo.cargo_process("build").arg("--verbose"),
-                execs().with_stdout(&format!("\
+                execs().with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({url})
 [RUNNING] `rustc [..] -C ar=nonexistent-ar -C linker=nonexistent-linker [..]`
 ", url = foo.url())))
@@ -65,7 +65,7 @@ test!(absolute_tools {
     };
 
     assert_that(foo.cargo_process("build").arg("--verbose"),
-                execs().with_stdout(&format!("\
+                execs().with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({url})
 [RUNNING] `rustc [..] -C ar={ar} -C linker={linker} [..]`
 ", url = foo.url(), ar = output.0, linker = output.1)))
@@ -112,7 +112,7 @@ test!(relative_tools {
     };
 
     assert_that(origin.cargo_process("build").cwd(foo_path).arg("--verbose"),
-                execs().with_stdout(&format!("\
+                execs().with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({url})
 [RUNNING] `rustc [..] -C ar={ar} -C linker={linker} [..]`
 ", url = foo_url, ar = output.0, linker = output.1)))


### PR DESCRIPTION
All status messages are printed to stderr instead of stdout now.

This changes exactly three letters of code and breaks 211 tests :fearful: 

I will hopefully fix all the tests here, but I decided to submit PR early in case somebody comes up with a less laborious way to do this. 

Fixes #1473, #2661 