### PR TITLE
The Missing Link

### DIFF
--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -1,3 +1,4 @@
+use std::env;
 use std::fmt;
 use std::path::{PathBuf, Path};
 
@@ -167,6 +168,7 @@ impl Manifest {
                profiles: Profiles,
                publish: bool,
                replace: Vec<(PackageIdSpec, Dependency)>) -> Manifest {
+        let links = env::var("RUST_LIB").ok().or(links);
         Manifest {
             summary: summary,
             targets: targets,

--- a/src/doc/build-script.md
+++ b/src/doc/build-script.md
@@ -116,7 +116,8 @@ build = "build.rs"
 This manifest states that the package links to the `libfoo` native library, and
 it also has a build script for locating and/or building the library. Cargo
 requires that a `build` command is specified if a `links` entry is also
-specified.
+specified. `links` can be also be overridden with the environment variable
+`RUST_LIB=value`.
 
 The purpose of this manifest key is to give Cargo an understanding about the set
 of native dependencies that a package has, as well as providing a principled

--- a/tests/test_cargo_compile_custom_build.rs
+++ b/tests/test_cargo_compile_custom_build.rs
@@ -190,6 +190,24 @@ url = p.url(),
 });
 */
 
+test!(links_environment_variable{
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [project]
+            name = "foo"
+            version = "0.5.0"
+            authors = []
+        "#)
+        .file("src/lib.rs", "");
+
+    assert_that(p.cargo_process("build").env("RUST_LIB", "ENVVAR"),
+                execs().with_status(101)
+                       .with_stderr("\
+[ERROR] package `foo v0.5.0 (file://[..])` specifies that it links to `ENVVAR` but does \
+not have a custom build script
+"));
+});
+
 test!(links_no_build_cmd {
     let p = project("foo")
         .file("Cargo.toml", r#"


### PR DESCRIPTION
Dearest reviewer,

This pull request allows the value of project.links to be passed into
the build script via an environment variable. This closes #1220 . I have
added a test that makes sure that the environment variable is set. Also
note I am using RUST_LIB not LIB because it appears to be used for
windows in appveyor. I think RUST_LIB fits better.

At the core of it when the manifest is created the code now check for
the environment variable and uses it instead of the value from the
file.

I have also updated the documentation to reflect the new variable.

Thanks!
Becker