### PR TITLE
Ban keywords from crate names

### DIFF
--- a/src/cargo/ops/cargo_new.rs
+++ b/src/cargo/ops/cargo_new.rs
@@ -88,7 +88,21 @@ fn get_name<'a>(path: &'a Path, opts: &'a NewOptions, config: &Config) -> CargoR
 }
 
 fn check_name(name: &str) -> CargoResult<()> {
-    if name == "test" {
+
+    // Ban keywords + test list found at
+    // https://doc.rust-lang.org/grammar.html#keywords
+    let blacklist = ["abstract", "alignof", "as", "become", "box",
+        "break", "const", "continue", "crate", "do",
+        "else", "enum", "extern", "false", "final",
+        "fn", "for", "if", "impl", "in",
+        "let", "loop", "macro", "match", "mod",
+        "move", "mut", "offsetof", "override", "priv",
+        "proc", "pub", "pure", "ref", "return",
+        "self", "sizeof", "static", "struct",
+        "super", "test", "trait", "true", "type", "typeof",
+        "unsafe", "unsized", "use", "virtual", "where",
+        "while", "yield"];
+    if blacklist.contains(&name) {
         bail!("The name `{}` cannot be used as a crate name\n\
                use --name to override crate name",
                name)

--- a/tests/test_cargo_new.rs
+++ b/tests/test_cargo_new.rs
@@ -101,6 +101,14 @@ test!(reserved_name {
 use --name to override crate name"));
 });
 
+test!(keyword_name {
+    assert_that(cargo_process("new").arg("pub"),
+                execs().with_status(101)
+                       .with_stderr("\
+[ERROR] The name `pub` cannot be used as a crate name\n\
+use --name to override crate name"));
+});
+
 test!(rust_prefix_stripped {
     assert_that(cargo_process("new").arg("rust-foo").env("USER", "foo"),
                 execs().with_status(0)


### PR DESCRIPTION
Dearest Reviewer,

This pull request extends the banned list of project names to include
all of the current keywords for rust. I got the list of keywords from
https://doc.rust-lang.org/grammar.html#keywords . This
closes #2699 . The original ticket said warn but I figured how test is
handled is most likely how all banned names should be handled.

Oddly enough a few keywords have made their way to the crates.io. fn and
proc are both examples I found spot checking keywords. I do not there is
any action to take on those crates.

Thanks
Becker