### PR TITLE
The missing lib

### DIFF
--- a/src/cargo/ops/cargo_rustc/custom_build.rs
+++ b/src/cargo/ops/cargo_rustc/custom_build.rs
@@ -109,6 +109,10 @@ fn build_work<'a, 'cfg>(cx: &mut Context<'a, 'cfg>, unit: &Unit<'a>)
      .env("PROFILE", if cx.build_config.release {"release"} else {"debug"})
      .env("HOST", &cx.config.rustc_info().host);
 
+     if let Some(links) = unit.pkg.manifest().links(){
+        p.env("CARGO_MANIFEST_LINKS", links);
+     }
+
     // Be sure to pass along all enabled features for this package, this is the
     // last piece of statically known information that we have.
     if let Some(features) = cx.resolve.features(unit.pkg.package_id()) {

--- a/src/doc/environment-variables.md
+++ b/src/doc/environment-variables.md
@@ -68,6 +68,7 @@ let out_dir = env::var("OUT_DIR").unwrap();
                          script). Also note that this is the value of the
                          current working directory of the build script when it
                          starts.
+* `CARGO_MANIFEST_LINKS` - the manifest `links` value.
 * `CARGO_FEATURE_<name>` - For each activated feature of the package being
                            built, this environment variable will be present
                            where `<name>` is the name of the feature uppercased

--- a/tests/test_cargo_compile_custom_build.rs
+++ b/tests/test_cargo_compile_custom_build.rs
@@ -353,7 +353,11 @@ test!(links_passes_env_vars {
         "#)
         .file("a/src/lib.rs", "")
         .file("a/build.rs", r#"
+            use std::env;
             fn main() {
+                let lib = env::var("CARGO_MANIFEST_LINKS").unwrap();
+                assert_eq!(lib, "foo");
+
                 println!("cargo:foo=bar");
                 println!("cargo:bar=baz");
             }


### PR DESCRIPTION
Dearest Reviewer,

This pull request allows the value of project.links to be passed into
the build script via an environment variable. This closes #1220 . I have
added a test that makes sure that the environment variable is set. Also
note I am using CARGO_LIB not LIB because it appears to be used for
windows in appveyor. I think CARGO_LIB fits better.

I have also updated the documentation to reflect the new variable.

Thanks!
Becker