### PR TITLE
Correct author order

### DIFF
--- a/src/cargo/ops/cargo_new.rs
+++ b/src/cargo/ops/cargo_new.rs
@@ -458,10 +458,11 @@ fn get_environment_variable(variables: &[&str] ) -> Option<String>{
 fn discover_author() -> CargoResult<(String, Option<String>)> {
     let git_config = GitConfig::open_default().ok();
     let git_config = git_config.as_ref();
-    let name_variables = ["NAME", "GIT_AUTHOR_NAME", "GIT_COMMITTER_NAME",
-                        "USER", "USERNAME"];
-    let name = git_config.and_then(|g| g.get_string("user.name").ok())
-                         .or_else(|| get_environment_variable(&name_variables));
+    let name_variables = ["CARGO_NAME", "GIT_AUTHOR_NAME", "GIT_COMMITTER_NAME",
+                         "USER", "USERNAME", "NAME"];
+    let name = get_environment_variable(&name_variables[0..3])
+                        .or_else(|| git_config.and_then(|g| g.get_string("user.name").ok()))
+                        .or_else(|| get_environment_variable(&name_variables[3..]));
 
     let name = match name {
         Some(name) => name,
@@ -471,9 +472,11 @@ fn discover_author() -> CargoResult<(String, Option<String>)> {
                   username_var)
         }
     };
-    let email_variables = ["EMAIL", "GIT_AUTHOR_EMAIL", "GIT_COMMITTER_EMAIL"];
-    let email = git_config.and_then(|g| g.get_string("user.email").ok())
-                          .or_else(|| get_environment_variable(&email_variables) );
+    let email_variables = ["CARGO_EMAIL", "GIT_AUTHOR_EMAIL", "GIT_COMMITTER_EMAIL",
+                          "EMAIL"];
+    let email = get_environment_variable(&email_variables[0..3])
+                          .or_else(|| git_config.and_then(|g| g.get_string("user.email").ok()))
+                          .or_else(|| get_environment_variable(&email_variables[3..]));
 
     let name = name.trim().to_string();
     let email = email.map(|s| s.trim().to_string());

--- a/tests/test_cargo_new.rs
+++ b/tests/test_cargo_new.rs
@@ -181,6 +181,24 @@ test!(finds_author_username {
     assert!(contents.contains(r#"authors = ["foo"]"#));
 });
 
+test!(finds_author_priority {
+    // Use a temp dir to make sure we don't pick up .cargo/config somewhere in
+    // the hierarchy
+    let td = TempDir::new("cargo").unwrap();
+    assert_that(cargo_process("new").arg("foo")
+                                    .env("USER", "bar2")
+                                    .env("EMAIL", "baz2")
+                                    .env("CARGO_NAME", "bar")
+                                    .env("CARGO_EMAIL", "baz")
+                                    .cwd(td.path().clone()),
+                execs().with_status(0));
+
+    let toml = td.path().join("foo/Cargo.toml");
+    let mut contents = String::new();
+    File::open(&toml).unwrap().read_to_string(&mut contents).unwrap();
+    assert!(contents.contains(r#"authors = ["bar <baz>"]"#));
+});
+
 test!(finds_author_email {
     // Use a temp dir to make sure we don't pick up .cargo/config somewhere in
     // the hierarchy


### PR DESCRIPTION
Dearest Reviewer,

PR #2696 added some new checks for environment variables for author and
email. After the pull request was merged a comment was left about gits
ordering for looking at the variables. This pull request closes #2705 by
reordering the look up and also addeds CARGO_NAME and CARGO_EMAIL to the
top of the order.

Thanks
Becker