### PR TITLE
Block publishing on dirty directories

### DIFF
--- a/src/bin/publish.rs
+++ b/src/bin/publish.rs
@@ -8,6 +8,7 @@ pub struct Options {
     flag_token: Option<String>,
     flag_manifest_path: Option<String>,
     flag_verbose: Option<bool>,
+    flag_allow_untracked: bool,
     flag_quiet: Option<bool>,
     flag_color: Option<String>,
     flag_no_verify: bool,
@@ -26,6 +27,7 @@ Options:
     --no-verify              Don't verify package tarball before publish
     --manifest-path PATH     Path to the manifest of the package to publish
     -v, --verbose            Use verbose output
+    --allow-untracked        Allows publishing with untracked and uncommitted files
     -q, --quiet              No output printed to stdout
     --color WHEN             Coloring: auto, always, never
 
@@ -40,10 +42,11 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
         flag_host: host,
         flag_manifest_path,
         flag_no_verify: no_verify,
+        flag_allow_untracked: allow_untracked,
         ..
     } = options;
 
     let root = try!(find_root_manifest_for_wd(flag_manifest_path.clone(), config.cwd()));
-    try!(ops::publish(&root, config, token, host, !no_verify));
+    try!(ops::publish(&root, config, token, host, !no_verify, allow_untracked));
     Ok(None)
 }

--- a/tests/test_bad_config.rs
+++ b/tests/test_bad_config.rs
@@ -1,5 +1,6 @@
-use support::{project, execs};
+use support::{project, execs, paths};
 use support::registry::Package;
+use support::git::repo;
 use hamcrest::assert_that;
 
 fn setup() {}
@@ -57,7 +58,8 @@ Caused by:
 });
 
 test!(bad3 {
-    let foo = project("foo")
+    let root = paths::root().join("bad3");
+    let p = repo(&root)
         .file("Cargo.toml", r#"
             [package]
             name = "foo"
@@ -69,7 +71,11 @@ test!(bad3 {
             [http]
               proxy = true
         "#);
-    assert_that(foo.cargo_process("publish").arg("-v"),
+    p.build();
+
+    let mut cargo = ::cargo_process();
+    cargo.cwd(p.root());
+    assert_that(cargo.arg("publish").arg("-v"),
                 execs().with_status(101).with_stderr("\
 [ERROR] invalid configuration for key `http.proxy`
 expected a string, but found a boolean in [..]config


### PR DESCRIPTION
Dearest reviewer,

This is part of #841 which is about the publishing and tagging flow.
This pull request just prevents publishing with uncommitted or untracked
files. I have included a flag for turning this off. There are two new
test and I have also updated the docs.

More details about the full flow at
https://github.com/rust-lang/cargo/pull/2443 . I plan on doing more
work on the flow, however, I felt this was useful enough to do stand
alone. When I tried the flow before I was doing to much at once.

closes #1597 

Thanks!
Becker