### PR TITLE
list lieutenant

### DIFF
--- a/src/bin/cargo.rs
+++ b/src/bin/cargo.rs
@@ -151,6 +151,16 @@ fn execute(flags: Flags, config: &Config) -> CliResult<Option<()>> {
             return Ok(None)
         }
 
+        // For `cargo help --list`, print out the list of commands
+        "help" if flags.arg_args[0] == "--list" => {
+            config.shell().set_verbosity(Verbosity::Verbose);
+            let args = &["cargo".to_string(), "--list".to_string()];
+            let r = cargo::call_main_without_stdin(execute, config, USAGE, args,
+                                                   false);
+            cargo::process_executed(r, &mut config.shell());
+            return Ok(None)
+        }
+
         // For `cargo help -h` and `cargo help --help`, print out the help
         // message for `cargo help`
         "help" if flags.arg_args[0] == "-h" ||

--- a/src/bin/help.rs
+++ b/src/bin/help.rs
@@ -9,9 +9,11 @@ Get some help with a cargo command.
 Usage:
     cargo help <command>
     cargo help -h | --help
+    cargo help --list
 
 Options:
     -h, --help          Print this message
+    --list              List all commands
 ";
 
 pub fn execute(_: Options, _: &Config) -> CliResult<Option<()>> {

--- a/tests/test_cargo.rs
+++ b/tests/test_cargo.rs
@@ -6,8 +6,8 @@ use std::path::{Path, PathBuf};
 use std::str;
 
 use cargo_process;
-use support::paths;
-use support::{execs, project, mkdir_recursive, ProjectBuilder};
+use support::{execs, project, mkdir_recursive, ProjectBuilder, paths};
+use support::registry::Package;
 use hamcrest::{assert_that};
 
 fn setup() {
@@ -60,6 +60,21 @@ fn fake_file(proj: ProjectBuilder, dir: &Path, name: &str, kind: FakeKind) -> Pr
 fn path() -> Vec<PathBuf> {
     env::split_paths(&env::var_os("PATH").unwrap_or(OsString::new())).collect()
 }
+
+test!(help_list_command{
+    Package::new("cargo-foo", "1.0.0")
+        .file("src/main.rs", r#"
+            fn main() {
+                println!("bar");
+            }
+        "#)
+        .publish();
+    assert_that(cargo_process().arg("install").arg("cargo-foo"),
+                execs().with_status(0));
+    assert_that(cargo_process().arg("help").arg("--list"),
+                execs().with_status(0).with_stdout_contains("    foo\n"));
+});
+
 
 test!(list_command_looks_at_path {
     let proj = project("list-non-overlapping");


### PR DESCRIPTION
Dearest reviewer,

This resolves #1253 which was discussed in
https://github.com/rust-lang/cargo/pull/2683. A new list command was not
the desired direction to take this. Instead --list is added to help via
an alias. It was easier to open a new pull request instead of backing out
the new command code.

I added a new test case which was borrowed from the install test case
but is now using the help command.

Thanks
Becker