### PR TITLE
Don't throw away errors with `-p` arguments

### DIFF
--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -167,22 +167,14 @@ pub fn compile_pkg<'a>(root_package: &Package,
                                   no_default_features))
     };
 
-    let mut invalid_spec = vec![];
-    let pkgids = if spec.len() > 0 {
-        spec.iter().filter_map(|p| {
-            match resolve_with_overrides.query(&p) {
-                Ok(p) => Some(p),
-                Err(..) => { invalid_spec.push(p.to_string()); None }
-            }
-        }).collect::<Vec<_>>()
+    let mut pkgids = Vec::new();
+    if spec.len() > 0 {
+        for p in spec {
+            pkgids.push(try!(resolve_with_overrides.query(&p)));
+        }
     } else {
-        vec![root_package.package_id()]
+        pkgids.push(root_package.package_id());
     };
-
-    if !spec.is_empty() && !invalid_spec.is_empty() {
-        bail!("could not find package matching spec `{}`",
-              invalid_spec.join(", "))
-    }
 
     let to_builds = try!(pkgids.iter().map(|id| {
         packages.get(id)

--- a/tests/test_cargo_compile.rs
+++ b/tests/test_cargo_compile.rs
@@ -2107,13 +2107,14 @@ test!(invalid_spec {
     p.build();
 
     assert_that(p.cargo_process("build").arg("-p").arg("notAValidDep"),
-                execs().with_status(101).with_stderr(&format!(
-                    "[ERROR] could not find package matching spec `notAValidDep`")));
+                execs().with_status(101).with_stderr("\
+[ERROR] package id specification `notAValidDep` matched no packages
+"));
 
     assert_that(p.cargo_process("build").arg("-p").arg("d1").arg("-p").arg("notAValidDep"),
-                execs().with_status(101).with_stderr(&format!(
-                    "[ERROR] could not find package matching spec `notAValidDep`")));
-
+                execs().with_status(101).with_stderr("\
+[ERROR] package id specification `notAValidDep` matched no packages
+"));
 });
 
 test!(manifest_with_bom_is_ok {


### PR DESCRIPTION
This was unfortunately ignoring errors which would helpfully tell you how to
rerun a command with a more precise specification.

Closes #2641