### PR TITLE
Fix build scripts and panic=abort

### DIFF
--- a/src/cargo/ops/cargo_rustc/context.rs
+++ b/src/cargo/ops/cargo_rustc/context.rs
@@ -632,10 +632,10 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
         }
     }
 
-    pub fn build_script_profile(&self, _pkg: &PackageId) -> &'a Profile {
-        // TODO: should build scripts always be built with a dev
+    pub fn build_script_profile(&self, pkg: &PackageId) -> &'a Profile {
+        // TODO: should build scripts always be built with the same library
         //       profile? How is this controlled at the CLI layer?
-        &self.profiles.dev
+        self.lib_profile(pkg)
     }
 
     pub fn rustflags_args(&self, unit: &Unit) -> CargoResult<Vec<String>> {


### PR DESCRIPTION
Build scripts were apparently always compiled with the "dev" profile rather than
the standard "match whatever the normal build was" profile, which meant that if
dev/release disagreed on panic=abort you'd get compile errors. Seems bad!

This commit fixes this by just having build scripts always compile with the same
profile as libraries (for now), as this was the original intention anyway.

Closes #2726