### PR TITLE
Hash url serialization to ensure hash stability

### DIFF
--- a/src/cargo/core/source.rs
+++ b/src/cargo/core/source.rs
@@ -341,14 +341,17 @@ impl Ord for SourceIdInner {
     }
 }
 
+// The hash of SourceId is used in the name of some Cargo folders, so shouldn't
+// vary. `as_str` gives the serialisation of a url (which has a spec) and so
+// insulates against possible changes in how the url crate does hashing.
 impl hash::Hash for SourceId {
     fn hash<S: hash::Hasher>(&self, into: &mut S) {
         self.inner.kind.hash(into);
         match *self.inner {
             SourceIdInner { kind: Kind::Git(..), ref canonical_url, .. } => {
-                canonical_url.hash(into)
+                canonical_url.as_str().hash(into)
             }
-            _ => self.inner.url.hash(into),
+            _ => self.inner.url.as_str().hash(into),
         }
     }
 }


### PR DESCRIPTION
`as_str` is documented to return the serialization of a url (http://servo.github.io/rust-url/url/struct.Url.html#method.as_str).
The serialization of a url has a spec (https://url.spec.whatwg.org/#url-serializing).

Hashing the serialization of a url insulates cargo against possible decisions to alter how rust-url does hashing (I've observed it happening twice). Note that rust-url happens to do this internally (but is not guaranteed to in future) and so this change doesn't actually have any effect on hash values.

r? @alexcrichton 

Closes #1710