### PR TITLE
Configure colors of both stdout/stderr

### DIFF
--- a/src/cargo/core/shell.rs
+++ b/src/cargo/core/shell.rs
@@ -111,7 +111,7 @@ impl MultiShell {
     }
 
     pub fn set_color_config(&mut self, color: Option<&str>) -> CargoResult<()> {
-        self.out.set_color_config(match color {
+        let cfg = match color {
             Some("auto") => Auto,
             Some("always") => Always,
             Some("never") => Never,
@@ -120,7 +120,9 @@ impl MultiShell {
 
             Some(arg) => bail!("argument for --color must be auto, always, or \
                                 never, but found `{}`", arg),
-        });
+        };
+        self.out.set_color_config(cfg);
+        self.err.set_color_config(cfg);
         Ok(())
     }
 


### PR DESCRIPTION
Previously color configuration only affected stdout, not stder as well.

Closes #2734