### PR TITLE
Fix tests for RUST_NEW_ERROR_FORMAT

### DIFF
--- a/tests/build-script.rs
+++ b/tests/build-script.rs
@@ -698,10 +698,9 @@ fn build_deps_not_for_normal() {
     assert_that(p.cargo_process("build").arg("-v").arg("--target").arg(&target),
                 execs().with_status(101)
                        .with_stderr_contains("\
-[..]lib.rs[..] error: can't find crate for `aaaaa`[..]
-[..]lib.rs[..] extern crate aaaaa;
-[..]           ^~~~~~~~~~~~~~~~~~~
-error: aborting due to previous error
+[..]can't find crate for `aaaaa`[..]
+")
+                       .with_stderr_contains("\
 [ERROR] Could not compile `foo`.
 
 Caused by:

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -238,11 +238,6 @@ fn cargo_compile_with_invalid_code() {
         execs()
         .with_status(101)
         .with_stderr_contains("\
-src[..]foo.rs:1:1: 1:8 error: expected item[..]found `invalid`
-src[..]foo.rs:1 invalid rust code!
-             ^~~~~~~
-")
-        .with_stderr_contains("\
 [ERROR] Could not compile `foo`.
 
 To learn more, run the command again with --verbose.\n"));
@@ -282,13 +277,8 @@ fn cargo_compile_with_warnings_in_the_root_package() {
         .file("src/foo.rs", "fn main() {} fn dead() {}");
 
     assert_that(p.cargo_process("build"),
-        execs()
-        .with_stderr("\
-[COMPILING] foo [..]
-src[..]foo.rs:1:14: 1:26 warning: function is never used: `dead`, \
-    #[warn(dead_code)] on by default
-src[..]foo.rs:1 fn main() {} fn dead() {}
-[..]                         ^~~~~~~~~~~~
+                execs().with_stderr_contains("\
+[..]function is never used: `dead`[..]
 "));
 }
 
@@ -333,13 +323,9 @@ fn cargo_compile_with_warnings_in_a_dep_package() {
         "#);
 
     assert_that(p.cargo_process("build"),
-        execs().with_stderr(&format!("\
-[COMPILING] bar v0.5.0 ({url}/bar)
-[..]warning: function is never used: `dead`[..]
-[..]fn dead() {{}}
-[..]^~~~~~~~~~~~
-[COMPILING] foo v0.5.0 ({url})
-", url = p.url())));
+        execs().with_stderr_contains("\
+[..]function is never used: `dead`[..]
+"));
 
     assert_that(&p.bin("foo"), existing_file());
 

--- a/tests/cross-compile.rs
+++ b/tests/cross-compile.rs
@@ -895,7 +895,7 @@ fn platform_specific_dependencies_do_not_leak() {
     assert_that(p.cargo_process("build").arg("-v").arg("--target").arg(&target),
                 execs().with_status(101)
                        .with_stderr_contains("\
-[..] error: can't find crate for `d2`[..]"));
+[..] can't find crate for `d2`[..]"));
 }
 
 #[test]

--- a/tests/install.rs
+++ b/tests/install.rs
@@ -527,10 +527,7 @@ fn compile_failure() {
     p.build();
 
     assert_that(cargo_process("install").arg("--path").arg(p.root()),
-                execs().with_status(101).with_stderr("\
-[COMPILING] foo v0.1.0 [..]
-error: main function not found
-error: aborting due to previous error
+                execs().with_status(101).with_stderr_contains("\
 [ERROR] failed to compile `foo v0.1.0 (file://[..])`, intermediate artifacts can be \
     found at `[..]target`
 


### PR DESCRIPTION
A few tests were a bit too strict in the output they were looking for, this
instead relaxes some assertions to just what we're interested in.