### PR TITLE
Rename main thread from '<main>' to 'main'.

### DIFF
--- a/tests/bench.rs
+++ b/tests/bench.rs
@@ -187,7 +187,7 @@ test bench_hello ... ")
                        .with_stderr_contains(format!("\
 [COMPILING] foo v0.5.0 ({})
 [RUNNING] target[..]release[..]foo-[..]
-thread 'main' panicked at 'assertion failed: \
+thread '[..]' panicked at 'assertion failed: \
     `(left == right)` (left: \
     `\"hello\"`, right: `\"nope\"`)', src[..]foo.rs:14
 [..]

--- a/tests/bench.rs
+++ b/tests/bench.rs
@@ -187,7 +187,7 @@ test bench_hello ... ")
                        .with_stderr_contains(format!("\
 [COMPILING] foo v0.5.0 ({})
 [RUNNING] target[..]release[..]foo-[..]
-thread '<main>' panicked at 'assertion failed: \
+thread 'main' panicked at 'assertion failed: \
     `(left == right)` (left: \
     `\"hello\"`, right: `\"nope\"`)', src[..]foo.rs:14
 [..]

--- a/tests/install.rs
+++ b/tests/install.rs
@@ -715,7 +715,7 @@ fn reports_unsuccessful_subcommand_result() {
                 execs().with_status(0).with_stdout_contains("    fail\n"));
     assert_that(cargo_process("fail"),
                 execs().with_status(101).with_stderr_contains("\
-thread 'main' panicked at 'explicit panic', [..]
+thread '[..]' panicked at 'explicit panic', [..]
 "));
 }
 

--- a/tests/install.rs
+++ b/tests/install.rs
@@ -715,7 +715,7 @@ fn reports_unsuccessful_subcommand_result() {
                 execs().with_status(0).with_stdout_contains("    fail\n"));
     assert_that(cargo_process("fail"),
                 execs().with_status(101).with_stderr_contains("\
-thread '<main>' panicked at 'explicit panic', [..]
+thread 'main' panicked at 'explicit panic', [..]
 "));
 }
 


### PR DESCRIPTION
This pull request resolves the test failure in rust pull request 33803
https://github.com/rust-lang/rust/pull/33803