### PR TITLE
Correctly record multiple native dirs per package

### DIFF
--- a/src/cargo/ops/cargo_rustc/compilation.rs
+++ b/src/cargo/ops/cargo_rustc/compilation.rs
@@ -27,7 +27,7 @@ pub struct Compilation<'cfg> {
     /// This is currently used to drive some entries which are added to the
     /// LD_LIBRARY_PATH as appropriate.
     // TODO: deprecated, remove
-    pub native_dirs: HashMap<PackageId, PathBuf>,
+    pub native_dirs: HashSet<PathBuf>,
 
     /// Root output directory (for the local package's artifacts)
     pub root_output: PathBuf,
@@ -51,7 +51,7 @@ impl<'cfg> Compilation<'cfg> {
     pub fn new(config: &'cfg Config) -> Compilation<'cfg> {
         Compilation {
             libraries: HashMap::new(),
-            native_dirs: HashMap::new(),  // TODO: deprecated, remove
+            native_dirs: HashSet::new(),  // TODO: deprecated, remove
             root_output: PathBuf::from("/"),
             deps_output: PathBuf::from("/"),
             tests: Vec::new(),
@@ -94,7 +94,7 @@ impl<'cfg> Compilation<'cfg> {
     pub fn process(&self, cmd: CommandType, pkg: &Package)
                    -> CargoResult<CommandPrototype> {
         let mut search_path = util::dylib_path();
-        for dir in self.native_dirs.values() {
+        for dir in self.native_dirs.iter() {
             search_path.push(dir.clone());
         }
         search_path.push(self.root_output.clone());

--- a/src/cargo/ops/cargo_rustc/mod.rs
+++ b/src/cargo/ops/cargo_rustc/mod.rs
@@ -161,7 +161,7 @@ pub fn compile_targets<'a, 'cfg: 'a>(pkg_targets: &'a PackagesToBuild<'a>,
             cx.compilation.cfgs.extend(output.cfgs.iter().cloned());
         }
         for dir in output.library_paths.iter() {
-            cx.compilation.native_dirs.insert(pkg.clone(), dir.clone());
+            cx.compilation.native_dirs.insert(dir.clone());
         }
     }
     Ok(cx.compilation)

--- a/src/cargo/ops/cargo_test.rs
+++ b/src/cargo/ops/cargo_test.rs
@@ -140,7 +140,7 @@ fn run_doc_tests(options: &TestOptions,
                 arg.push(rust_dep);
                 p.arg("-L").arg(arg);
             }
-            for native_dep in compilation.native_dirs.values() {
+            for native_dep in compilation.native_dirs.iter() {
                 p.arg("-L").arg(native_dep);
             }
 


### PR DESCRIPTION
This fixes a bug when a package's build script outputs multiple library search
paths.  Because Compilation::native_dirs is a `HashMap<PackageId, PathBuf>` it
can only store one path per package.  Currently if there are multiple paths,
all but the last will be inserted and then overwritten.

The key from this map is never used anyway, so this fixes the bug by changing
it from a HashMap to a HashSet.