### PR TITLE
Don't lock overrides if we're updating them

### DIFF
--- a/src/cargo/ops/cargo_generate_lockfile.rs
+++ b/src/cargo/ops/cargo_generate_lockfile.rs
@@ -37,10 +37,8 @@ pub fn update_lockfile(manifest_path: &Path,
     let package = try!(Package::for_path(manifest_path, opts.config));
 
     let previous_resolve = match try!(ops::load_pkg_lockfile(&package, opts.config)) {
-    	Some(resolve) => resolve,
-	None => {
-	     return generate_lockfile(manifest_path, opts.config);
-	}
+        Some(resolve) => resolve,
+        None => return generate_lockfile(manifest_path, opts.config),
     };
     let mut registry = PackageRegistry::new(opts.config);
     let mut to_avoid = HashSet::new();

--- a/src/cargo/ops/resolve.rs
+++ b/src/cargo/ops/resolve.rs
@@ -105,7 +105,9 @@ pub fn resolve_with_previous<'a>(registry: &mut PackageRegistry,
             let replace = package.manifest().replace();
             let replace = replace.iter().map(|&(ref spec, ref dep)| {
                 for (key, val) in r.replacements().iter() {
-                    if spec.matches(key) && dep.matches_id(val) {
+                    if spec.matches(key) &&
+                       dep.matches_id(val) &&
+                       keep(&val, to_avoid, &to_avoid_sources) {
                         return (spec.clone(), dep.clone().lock_to(val))
                     }
                 }


### PR DESCRIPTION
There was already a function for this, `keep`, it was just forgotten to be
called.

Closes #2766