### PR TITLE
Don't print extra info on -q + `cargo run`

### DIFF
--- a/src/bin/bench.rs
+++ b/src/bin/bench.rs
@@ -1,5 +1,5 @@
 use cargo::ops;
-use cargo::util::{CliResult, CliError, Human, Config};
+use cargo::util::{CliResult, CliError, Human, Config, human};
 use cargo::util::important_paths::{find_root_manifest_for_wd};
 
 #[derive(RustcDecodable)]
@@ -96,8 +96,8 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
         None => Ok(None),
         Some(err) => {
             Err(match err.exit.as_ref().and_then(|e| e.code()) {
-                Some(i) => CliError::new("bench failed", i),
-                None => CliError::from_error(Human(err), 101)
+                Some(i) => CliError::new(human("bench failed"), i),
+                None => CliError::new(Box::new(Human(err)), 101)
             })
         }
     }

--- a/src/bin/cargo.rs
+++ b/src/bin/cargo.rs
@@ -221,9 +221,9 @@ fn execute_subcommand(config: &Config,
     };
 
     if let Some(code) = err.exit.as_ref().and_then(|c| c.code()) {
-        Err(CliError::new("", code))
+        Err(CliError::code(code))
     } else {
-        Err(CliError::from_error(err, 101))
+        Err(CliError::new(Box::new(err), 101))
     }
 }
 

--- a/src/bin/git_checkout.rs
+++ b/src/bin/git_checkout.rs
@@ -35,7 +35,7 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
                        human(format!("The URL `{}` you passed was \
                                       not a valid URL: {}", url, e))
                    })
-                   .map_err(|e| CliError::from_boxed(e, 1)));
+                   .map_err(|e| CliError::new(e, 1)));
 
     let reference = GitReference::Branch(reference.clone());
     let source_id = SourceId::for_git(&url, reference);
@@ -43,7 +43,7 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
     let mut source = GitSource::new(&source_id, config);
 
     try!(source.update().map_err(|e| {
-        CliError::new(&format!("Couldn't update {:?}: {:?}", source, e), 1)
+        CliError::new(human(format!("Couldn't update {:?}: {:?}", source, e)), 1)
     }));
 
     Ok(None)

--- a/src/bin/help.rs
+++ b/src/bin/help.rs
@@ -1,4 +1,4 @@
-use cargo::util::{CliResult, CliError, Config};
+use cargo::util::{CliResult, CliError, Config, human};
 
 #[derive(RustcDecodable)]
 pub struct Options;
@@ -18,5 +18,5 @@ pub fn execute(_: Options, _: &Config) -> CliResult<Option<()>> {
     // This is a dummy command just so that `cargo help help` works.
     // The actual delegation of help flag to subcommands is handled by the
     // cargo command.
-    Err(CliError::new("Help command should not be executed directly.", 101))
+    Err(CliError::new(human("help command should not be executed directly"), 101))
 }

--- a/src/bin/locate_project.rs
+++ b/src/bin/locate_project.rs
@@ -30,7 +30,7 @@ pub fn execute(flags: LocateProjectFlags,
                       .chain_error(|| human("Your project path contains \
                                              characters not representable in \
                                              Unicode"))
-                      .map_err(|e| CliError::from_boxed(e, 1)));
+                      .map_err(|e| CliError::new(e, 1)));
 
     Ok(Some(ProjectLocation { root: string.to_string() }))
 }

--- a/src/bin/rustc.rs
+++ b/src/bin/rustc.rs
@@ -3,7 +3,7 @@ use std::env;
 use cargo::ops::{CompileOptions, CompileMode};
 use cargo::ops;
 use cargo::util::important_paths::{find_root_manifest_for_wd};
-use cargo::util::{CliResult, CliError, Config};
+use cargo::util::{CliResult, CliError, Config, human};
 
 #[derive(RustcDecodable)]
 pub struct Options {
@@ -79,8 +79,9 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
         Some("test") => CompileMode::Test,
         Some("bench") => CompileMode::Bench,
         Some(mode) => {
-            return Err(CliError::new(&format!("unknown profile: `{}`, use dev,
-                                               test, or bench", mode), 101))
+            let err = human(format!("unknown profile: `{}`, use dev,
+                                     test, or bench", mode));
+            return Err(CliError::new(err, 101))
         }
     };
 

--- a/src/bin/test.rs
+++ b/src/bin/test.rs
@@ -1,5 +1,5 @@
 use cargo::ops;
-use cargo::util::{CliResult, CliError, Human, Config};
+use cargo::util::{CliResult, CliError, Human, human, Config};
 use cargo::util::important_paths::{find_root_manifest_for_wd};
 
 #[derive(RustcDecodable)]
@@ -120,8 +120,8 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
         None => Ok(None),
         Some(err) => {
             Err(match err.exit.as_ref().and_then(|e| e.code()) {
-                Some(i) => CliError::new("test failed", i),
-                None => CliError::from_error(Human(err), 101)
+                Some(i) => CliError::new(human("test failed"), i),
+                None => CliError::new(Box::new(Human(err)), 101)
             })
         }
     }

--- a/tests/run.rs
+++ b/tests/run.rs
@@ -610,3 +610,24 @@ fn run_with_library_paths() {
 
     assert_that(p.cargo_process("run"), execs().with_status(0));
 }
+
+#[test]
+fn fail_no_extra_verbose() {
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [project]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+        "#)
+        .file("src/main.rs", r#"
+            fn main() {
+                std::process::exit(1);
+            }
+        "#);
+
+    assert_that(p.cargo_process("run").arg("-q"),
+                execs().with_status(1)
+                       .with_stdout("")
+                       .with_stderr(""));
+}


### PR DESCRIPTION
If a process fails then it's probably printing out why and Cargo doesn't need to
do it all over again.

Closes #2735