### PR TITLE
Propagate --color option to rustc

### DIFF
--- a/src/cargo/core/shell.rs
+++ b/src/cargo/core/shell.rs
@@ -25,6 +25,16 @@ pub enum ColorConfig {
     Never
 }
 
+impl fmt::Display for ColorConfig {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            ColorConfig::Auto => "auto",
+            ColorConfig::Always => "always",
+            ColorConfig::Never => "never",
+        }.fmt(f)
+    }
+}
+
 #[derive(Clone, Copy)]
 pub struct ShellConfig {
     pub color_config: ColorConfig,
@@ -128,6 +138,11 @@ impl MultiShell {
 
     pub fn get_verbose(&self) -> Verbosity {
         self.verbosity
+    }
+
+    pub fn color_config(&self) -> ColorConfig {
+        assert!(self.out.config.color_config == self.err.config.color_config);
+        self.out.config.color_config
     }
 }
 

--- a/src/cargo/ops/cargo_rustc/mod.rs
+++ b/src/cargo/ops/cargo_rustc/mod.rs
@@ -7,6 +7,7 @@ use std::sync::Arc;
 
 use core::{Package, PackageId, PackageSet, Target, Resolve};
 use core::{Profile, Profiles};
+use core::shell::ColorConfig;
 use util::{self, CargoResult, human};
 use util::{Config, internal, ChainError, profile, join_paths};
 
@@ -460,6 +461,11 @@ fn build_base_args(cx: &Context,
     cmd.cwd(cx.config.cwd());
 
     cmd.arg(&root_path(cx, unit));
+
+    let color_config = cx.config.shell().color_config();
+    if color_config != ColorConfig::Auto {
+        cmd.arg("--color").arg(&color_config.to_string());
+    }
 
     cmd.arg("--crate-name").arg(&unit.target.crate_name());
 

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -2212,3 +2212,31 @@ fn panic_abort_compiles_with_panic_abort() {
                 execs().with_status(0)
                        .with_stderr_contains("[..] -C panic=abort [..]"));
 }
+
+#[test]
+fn explicit_color_config_is_propagated_to_rustc() {
+    let mut p = project("foo");
+    p = p
+    .file("Cargo.toml", r#"
+            [package]
+
+            name = "test"
+            version = "0.0.0"
+            authors = []
+        "#)
+    .file("src/lib.rs", "");
+
+    assert_that(p.cargo_process("build").arg("-v").arg("--color").arg("always"),
+                execs().with_status(0).with_stderr_contains(
+                    "[..]rustc src[..]lib.rs --color always[..]"));
+
+    assert_that(p.cargo_process("build").arg("-v").arg("--color").arg("never"),
+                execs().with_status(0).with_stderr("\
+[COMPILING] test v0.0.0 ([..])
+[RUNNING] `rustc src[..]lib.rs --color never --crate-name test --crate-type lib -g \
+        --out-dir [..]target[..]debug \
+        --emit=dep-info,link \
+        -L dependency=[..]target[..]debug \
+        -L dependency=[..]target[..]debug[..]deps`
+"));
+}


### PR DESCRIPTION
closes #2740

Will try to add a test for this soon (and fix failing tests if any, compiling/running tests locally is slow :( ). 

I am not sure what is the right place to add `--color` option to the command line. I use [`build_base_args`]. [`process`] also looks like a good candidate, because it is more general, but if we look at the [`CommandType`] we see that only `rustc` command supports `--color`.

[`build_base_args`]: https://github.com/matklad/cargo/blob/1f7504397ce7c40ff708e2d31da164822e88ed37/src/cargo/ops/cargo_rustc/mod.rs#L449
[`process`]: https://github.com/matklad/cargo/blob/1f7504397ce7c40ff708e2d31da164822e88ed37/src/cargo/ops/cargo_rustc/mod.rs#L608
[`CommandType`]: https://github.com/matklad/cargo/blob/1f7504397ce7c40ff708e2d31da164822e88ed37/src/cargo/ops/cargo_rustc/engine.rs#L102