### PR TITLE
Fix `cargo doc --open` on Windows

### DIFF
--- a/src/cargo/ops/cargo_doc.rs
+++ b/src/cargo/ops/cargo_doc.rs
@@ -99,9 +99,9 @@ fn open_docs(path: &Path) -> Result<&'static str, Vec<&'static str>> {
 
 #[cfg(target_os = "windows")]
 fn open_docs(path: &Path) -> Result<&'static str, Vec<&'static str>> {
-    match Command::new("cmd").arg("/C").arg("start").arg("").arg(path).status() {
-        Ok(_) => return Ok("cmd /C start"),
-        Err(_) => return Err(vec!["cmd /C start"])
+    match Command::new("cmd").arg("/C").arg(path).status() {
+        Ok(_) => return Ok("cmd /C"),
+        Err(_) => return Err(vec!["cmd /C"])
     };
 }
 


### PR DESCRIPTION
This fixes #2446. Note that I have not built cargo with this change, but I have tested the functionality in isolation (on Windows 10).

As to the issue itself, I don't know why the previous version didn't work, but `start` is redundant when `cmd /C` is used.