### PR TITLE
Add support for RUSTDOCFLAGS

### DIFF
--- a/src/cargo/ops/cargo_rustc/fingerprint.rs
+++ b/src/cargo/ops/cargo_rustc/fingerprint.rs
@@ -346,6 +346,11 @@ fn calculate<'a, 'cfg>(cx: &mut Context<'a, 'cfg>, unit: &Unit<'a>)
     };
     let mut deps = deps;
     deps.sort_by(|&(ref a, _), &(ref b, _)| a.cmp(b));
+    let extra_flags = if unit.profile.doc {
+        try!(cx.rustdocflags_args(unit))
+    } else {
+        try!(cx.rustflags_args(unit))
+    };
     let fingerprint = Arc::new(Fingerprint {
         rustc: util::hash_u64(&cx.config.rustc_info().verbose_version),
         target: util::hash_u64(&unit.target),
@@ -354,7 +359,7 @@ fn calculate<'a, 'cfg>(cx: &mut Context<'a, 'cfg>, unit: &Unit<'a>)
         deps: deps,
         local: local,
         memoized_hash: Mutex::new(None),
-        rustflags: try!(cx.rustflags_args(unit)),
+        rustflags: extra_flags,
     });
     cx.fingerprints.insert(*unit, fingerprint.clone());
     Ok(fingerprint)

--- a/src/cargo/ops/cargo_rustc/mod.rs
+++ b/src/cargo/ops/cargo_rustc/mod.rs
@@ -245,7 +245,7 @@ fn rustc(cx: &mut Context, unit: &Unit) -> CargoResult<Work> {
     let dep_info_loc = fingerprint::dep_info_loc(cx, unit);
     let cwd = cx.config.cwd().to_path_buf();
 
-    let rustflags = try!(cx.rustflags_args(unit));
+    rustc.args(&try!(cx.rustflags_args(unit)));
 
     return Ok(Work::new(move |state| {
         // Only at runtime have we discovered what the extra -L and -l
@@ -268,9 +268,6 @@ fn rustc(cx: &mut Context, unit: &Unit) -> CargoResult<Work> {
                 try!(fs::remove_file(&dst));
             }
         }
-
-        // Add the arguments from RUSTFLAGS
-        rustc.args(&rustflags);
 
         state.running(&rustc);
         try!(exec_engine.exec(rustc).chain_error(|| {
@@ -404,6 +401,8 @@ fn rustdoc(cx: &mut Context, unit: &Unit) -> CargoResult<Work> {
         rustdoc.env("OUT_DIR", &cx.layout(unit.pkg, unit.kind)
                                   .build_out(unit.pkg));
     }
+
+    rustdoc.args(&try!(cx.rustdocflags_args(unit)));
 
     let name = unit.pkg.name().to_string();
     let build_state = cx.build_state.clone();

--- a/tests/rustdocflags.rs
+++ b/tests/rustdocflags.rs
@@ -1,0 +1,85 @@
+extern crate cargotest;
+extern crate hamcrest;
+
+use cargotest::support::{project, execs};
+use hamcrest::assert_that;
+
+#[test]
+fn parses_env() {
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [package]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+        "#)
+        .file("src/lib.rs", "");
+    p.build();
+
+    assert_that(p.cargo("doc").env("RUSTDOCFLAGS", "--cfg=foo").arg("-v"),
+                execs().with_status(0)
+                       .with_stderr_contains("\
+[RUNNING] `rustdoc [..] --cfg=foo[..]`
+"));
+}
+
+#[test]
+fn parses_config() {
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [package]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+        "#)
+        .file("src/lib.rs", "")
+        .file(".cargo/config", r#"
+            [build]
+            rustdocflags = ["--cfg", "foo"]
+        "#);
+    p.build();
+
+    assert_that(p.cargo("doc").arg("-v"),
+                execs().with_status(0)
+                       .with_stderr_contains("\
+[RUNNING] `rustdoc [..] --cfg foo[..]`
+"));
+}
+
+#[test]
+fn bad_flags() {
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [package]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+        "#)
+        .file("src/lib.rs", "");
+    p.build();
+
+    assert_that(p.cargo("doc").env("RUSTDOCFLAGS", "--bogus"),
+                execs().with_status(101));
+}
+
+#[test]
+fn rerun() {
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [package]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+        "#)
+        .file("src/lib.rs", "");
+    p.build();
+
+    assert_that(p.cargo("doc").env("RUSTDOCFLAGS", "--cfg=foo"),
+                execs().with_status(0));
+    assert_that(p.cargo("doc").env("RUSTDOCFLAGS", "--cfg=foo"),
+                execs().with_status(0).with_stderr(""));
+    assert_that(p.cargo("doc").env("RUSTDOCFLAGS", "--cfg=bar"),
+                execs().with_status(0).with_stderr("\
+[DOCUMENTING] foo v0.0.1 ([..])
+"));
+}


### PR DESCRIPTION
Like with RUSTFLAGS, parse this variable to pass along extra arguments to
invocations of `rustdoc`.