### PR TITLE
respect configure options for paths

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -276,7 +276,7 @@ prepare-image-$(1):
 	rm -rf $$(IMGDIR_$(1))
 	mkdir -p $$(IMGDIR_$(1))/bin $$(IMGDIR_$(1))/$(CFG_LIBDIR)/cargo \
 		$$(IMGDIR_$(1))$(CFG_MANDIR)/man1 \
-		$$(IMGDIR_$(1))$(CFG_DATADIR)/doc/cargo \
+		$$(IMGDIR_$(1))$(CFG_DOCDIR) \
 		$$(IMGDIR_$(1))$(CFG_DATADIR)/zsh/site-functions \
 		$$(IMGDIR_$(1))$(CFG_SYSCONFDIR)/bash_completion.d
 	cp $$(TARGET_$(1))/cargo$$(X) $$(IMGDIR_$(1))/bin
@@ -285,7 +285,7 @@ prepare-image-$(1):
 	cp $(S)src/etc/cargo.bashcomp.sh $$(IMGDIR_$(1))$(CFG_SYSCONFDIR)/bash_completion.d/cargo
 	cp $(S)README.md $(S)LICENSE-MIT $(S)LICENSE-APACHE \
 		$(S)LICENSE-THIRD-PARTY \
-		$$(IMGDIR_$(1))$(CFG_DATADIR)/doc/cargo
+		$$(IMGDIR_$(1))$(CFG_DOCDIR)
 
 prepare-overlay-$(1):
 	rm -Rf $$(OVERLAYDIR_$(1))

--- a/Makefile.in
+++ b/Makefile.in
@@ -274,18 +274,18 @@ prepare-image-$(1):
 	@[ -f $$(TARGET_$(1))/cargo$$(X) ] || echo 'Please run `make` first'
 	@[ -f $$(TARGET_$(1))/cargo$$(X) ]
 	rm -rf $$(IMGDIR_$(1))
-	mkdir -p $$(IMGDIR_$(1))/bin $$(IMGDIR_$(1))/lib/cargo \
-		$$(IMGDIR_$(1))/share/man/man1 \
-		$$(IMGDIR_$(1))/share/doc/cargo \
-		$$(IMGDIR_$(1))/share/zsh/site-functions \
-		$$(IMGDIR_$(1))/etc/bash_completion.d
+	mkdir -p $$(IMGDIR_$(1))/bin $$(IMGDIR_$(1))/$(CFG_LIBDIR)/cargo \
+		$$(IMGDIR_$(1))$(CFG_MANDIR)/man1 \
+		$$(IMGDIR_$(1))$(CFG_DATADIR)/doc/cargo \
+		$$(IMGDIR_$(1))$(CFG_DATADIR)/zsh/site-functions \
+		$$(IMGDIR_$(1))$(CFG_SYSCONFDIR)/bash_completion.d
 	cp $$(TARGET_$(1))/cargo$$(X) $$(IMGDIR_$(1))/bin
-	cp $(S)src/etc/man/*.1 $$(IMGDIR_$(1))/share/man/man1
-	cp $(S)src/etc/_cargo $$(IMGDIR_$(1))/share/zsh/site-functions/_cargo
-	cp $(S)src/etc/cargo.bashcomp.sh $$(IMGDIR_$(1))/etc/bash_completion.d/cargo
+	cp $(S)src/etc/man/*.1 $$(IMGDIR_$(1))$(CFG_MANDIR)/man1
+	cp $(S)src/etc/_cargo $$(IMGDIR_$(1))$(CFG_DATADIR)/zsh/site-functions/_cargo
+	cp $(S)src/etc/cargo.bashcomp.sh $$(IMGDIR_$(1))$(CFG_SYSCONFDIR)/bash_completion.d/cargo
 	cp $(S)README.md $(S)LICENSE-MIT $(S)LICENSE-APACHE \
 		$(S)LICENSE-THIRD-PARTY \
-		$$(IMGDIR_$(1))/share/doc/cargo
+		$$(IMGDIR_$(1))$(CFG_DATADIR)/doc/cargo
 
 prepare-overlay-$(1):
 	rm -Rf $$(OVERLAYDIR_$(1))

--- a/configure
+++ b/configure
@@ -325,6 +325,7 @@ valopt localstatedir "/var/lib" "local state directory"
 valopt sysconfdir "/etc" "install system configuration files"
 valopt datadir "${CFG_PREFIX}/share" "install data"
 valopt infodir "${CFG_PREFIX}/share/info" "install additional info"
+valopt docdir "${CFG_PREFIX}/share/doc/cargo" "install extra docs"
 valopt mandir "${CFG_PREFIX}/share/man" "install man pages in PATH"
 valopt libdir "${CFG_PREFIX}/lib" "install libraries"
 valopt local-cargo "" "local cargo to bootstrap from"
@@ -355,6 +356,7 @@ fi
 CFG_PREFIX=${CFG_PREFIX%/}
 CFG_DATADIR=${CFG_DATADIR%/}
 CFG_INFODIR=${CFG_INFODIR%/}
+CFG_DOCDIR=${CFG_DOCDIR%/}
 CFG_MANDIR=${CFG_MANDIR%/}
 CFG_LIBDIR=${CFG_LIBDIR%/}
 CFG_HOST="$(echo $CFG_HOST | tr ',' ' ')"
@@ -364,6 +366,7 @@ CFG_TARGET="$(echo $CFG_TARGET | tr ',' ' ')"
 # install.sh's --prefix value can be used instead
 CFG_DATADIR=${CFG_DATADIR#${CFG_PREFIX}}
 CFG_INFODIR=${CFG_INFODIR#${CFG_PREFIX}}
+CFG_DOCDIR=${CFG_DOCDIR#${CFG_PREFIX}}
 CFG_MANDIR=${CFG_MANDIR#${CFG_PREFIX}}
 CFG_LIBDIR=${CFG_LIBDIR#${CFG_PREFIX}}
 
@@ -412,6 +415,7 @@ putvar CFG_BUILD
 putvar CFG_HOST
 putvar CFG_TARGET
 putvar CFG_DATADIR
+putvar CFG_DOCDIR
 putvar CFG_INFODIR
 putvar CFG_MANDIR
 putvar CFG_LIBDIR

--- a/configure
+++ b/configure
@@ -353,7 +353,10 @@ fi
 
 # a little post-processing of various config values
 CFG_PREFIX=${CFG_PREFIX%/}
+CFG_DATADIR=${CFG_DATADIR%/}
+CFG_INFODIR=${CFG_INFODIR%/}
 CFG_MANDIR=${CFG_MANDIR%/}
+CFG_LIBDIR=${CFG_LIBDIR%/}
 CFG_HOST="$(echo $CFG_HOST | tr ',' ' ')"
 CFG_TARGET="$(echo $CFG_TARGET | tr ',' ' ')"
 
@@ -408,8 +411,10 @@ putvar CFG_PREFIX
 putvar CFG_BUILD
 putvar CFG_HOST
 putvar CFG_TARGET
-putvar CFG_LIBDIR
+putvar CFG_DATADIR
+putvar CFG_INFODIR
 putvar CFG_MANDIR
+putvar CFG_LIBDIR
 putvar CFG_RUSTC
 putvar CFG_RUSTDOC
 

--- a/configure
+++ b/configure
@@ -357,6 +357,13 @@ CFG_MANDIR=${CFG_MANDIR%/}
 CFG_HOST="$(echo $CFG_HOST | tr ',' ' ')"
 CFG_TARGET="$(echo $CFG_TARGET | tr ',' ' ')"
 
+# strip CFG_PREFIX from variables used for installation so that
+# install.sh's --prefix value can be used instead
+CFG_DATADIR=${CFG_DATADIR#${CFG_PREFIX}}
+CFG_INFODIR=${CFG_INFODIR#${CFG_PREFIX}}
+CFG_MANDIR=${CFG_MANDIR#${CFG_PREFIX}}
+CFG_LIBDIR=${CFG_LIBDIR#${CFG_PREFIX}}
+
 # copy host-triples to target-triples so that hosts are a subset of targets
 V_TEMP=""
 for i in $CFG_HOST $CFG_TARGET;


### PR DESCRIPTION
This change causes the installed paths of some files to respect the options passed to configure. It additionally adds another option and removes an unused option.