### PR TITLE
Make util::cfg module public

### DIFF
--- a/src/cargo/util/mod.rs
+++ b/src/cargo/util/mod.rs
@@ -20,6 +20,7 @@ pub use self::to_url::ToUrl;
 pub use self::vcs::{GitRepo, HgRepo};
 pub use self::read2::read2;
 
+pub mod cfg;
 pub mod config;
 pub mod errors;
 pub mod graph;
@@ -34,7 +35,6 @@ pub mod toml;
 pub mod lev_distance;
 pub mod job;
 pub mod network;
-mod cfg;
 mod dependency_queue;
 mod rustc;
 mod sha256;


### PR DESCRIPTION
This module is useful outside of cargo as well.
Because the Cargo.toml file supports cfg syntax for target
specification, any program that wants to parse Cargo.toml files needs to
support that as well.