### PR TITLE
Use CommandExt::exec for `cargo run` on Unix (#2343)

### DIFF
--- a/src/cargo/ops/cargo_run.rs
+++ b/src/cargo/ops/cargo_run.rs
@@ -52,5 +52,5 @@ pub fn run(ws: &Workspace,
     process.args(args).cwd(config.cwd());
 
     try!(config.shell().status("Running", process.to_string()));
-    Ok(process.exec().err())
+    Ok(process.exec_replace().err())
 }

--- a/src/cargo/util/process_builder.rs
+++ b/src/cargo/util/process_builder.rs
@@ -89,6 +89,22 @@ impl ProcessBuilder {
         }
     }
 
+    #[cfg(unix)]
+    pub fn exec_replace(&self) -> Result<(), ProcessError> {
+        use std::os::unix::process::CommandExt;
+
+        let mut command = self.build_command();
+        let error = command.exec();
+        Err(process_error(&format!("could not execute process `{}`",
+                                   self.debug_string()),
+                          Some(Box::new(error)), None, None))
+    }
+
+    #[cfg(windows)]
+    pub fn exec_replace(&self) -> Result<(), ProcessError> {
+        self.exec()
+    }
+
     pub fn exec_with_output(&self) -> Result<Output, ProcessError> {
         let mut command = self.build_command();
 

--- a/tests/run.rs
+++ b/tests/run.rs
@@ -126,14 +126,18 @@ fn exit_code() {
             fn main() { std::process::exit(2); }
         "#);
 
-    assert_that(p.cargo_process("run"),
-                execs().with_status(2)
-                       .with_stderr("\
+    let mut output = String::from("\
 [COMPILING] foo v0.0.1 (file[..])
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `target[..]`
+");
+    if !cfg!(unix) {
+        output.push_str("\
 [ERROR] process didn't exit successfully: `target[..]foo[..]` (exit code: 2)
-"));
+");
+    }
+    assert_that(p.cargo_process("run"),
+                execs().with_status(2).with_stderr(output));
 }
 
 #[test]
@@ -149,15 +153,20 @@ fn exit_code_verbose() {
             fn main() { std::process::exit(2); }
         "#);
 
-    assert_that(p.cargo_process("run").arg("-v"),
-                execs().with_status(2)
-                       .with_stderr("\
+    let mut output = String::from("\
 [COMPILING] foo v0.0.1 (file[..])
 [RUNNING] `rustc [..]`
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `target[..]`
+");
+    if !cfg!(unix) {
+        output.push_str("\
 [ERROR] process didn't exit successfully: `target[..]foo[..]` (exit code: 2)
-"));
+");
+    }
+
+    assert_that(p.cargo_process("run").arg("-v"),
+                execs().with_status(2).with_stderr(output));
 }
 
 #[test]


### PR DESCRIPTION
Before, we would spawn a child process for the program. One of the
problems with that is when killing the cargo process, the program
continues running.

With this change, the cargo process is replaced by the program, and
killing it works.

Before (`cargo run` is the parent):

> 502  7615  7614   0  2:26PM ttys012    0:00.12 /Users/rstocker/.multirust/toolchains/stable-x86_64-apple-darwin/bin/cargo run
> 502  7620  7615   0  2:26PM ttys012    0:00.01 target/debug/program

After (the shell is the parent):

> 502 81649 81648   0  5:27PM ttys012    0:00.69 -zsh
> 502  7739 81649   0  2:26PM ttys012    0:01.27 target/debug/program