### PR TITLE
cargo package: overwrite existing tarballs

### DIFF
--- a/src/cargo/ops/cargo_package.rs
+++ b/src/cargo/ops/cargo_package.rs
@@ -52,12 +52,9 @@ pub fn package(ws: &Workspace,
 
     let filename = format!("{}-{}.crate", pkg.name(), pkg.version());
     let dir = config.target_dir(ws).join("package");
-    let mut dst = match dir.open_ro(&filename, config, "packaged crate") {
-        Ok(f) => return Ok(Some(f)),
-        Err(..) => {
-            let tmp = format!(".{}", filename);
-            try!(dir.open_rw(&tmp, config, "package scratch space"))
-        }
+    let mut dst = {
+        let tmp = format!(".{}", filename);
+        try!(dir.open_rw(&tmp, config, "package scratch space"))
     };
 
     // Package up and test a temporary tarball and only move it to the final


### PR DESCRIPTION
Previously, cargo package did not do anything if a tarball already
existed. This is wrong, because the source may have changed and cargo
does not do any dependency tracking for package tarballs yet, so it did
not notice this.

This commit changes cargo package to always overwrite existing tarballs,
which works fine until proper dependency tracking is implemented.

Fixes #2799