### PR TITLE
Use consistent capitalization in doc headers

### DIFF
--- a/src/doc/config.md
+++ b/src/doc/config.md
@@ -21,7 +21,7 @@ With this structure you can specify local configuration per-project, and even
 possibly check it into version control. You can also specify personal default
 with a configuration file in your home directory.
 
-# Configuration Format
+# Configuration format
 
 All configuration is currently in the [TOML format][toml] (like the manifest),
 with simple key-value pairs inside of sections (tables) which all get merged
@@ -95,7 +95,7 @@ color = 'auto'         # whether cargo colorizes output
 retry = 2 # number of times a network call will automatically retried
 ```
 
-# Environment Variables
+# Environment variables
 
 Cargo can also be configured through environment variables in addition to the
 TOML syntax above. For each configuration key above of the form `foo.bar` the

--- a/src/doc/crates-io.md
+++ b/src/doc/crates-io.md
@@ -163,7 +163,7 @@ The syntax for teams is currently `github:org:team` (see examples above).
 In order to add a team as an owner one must be a member of that team. No
 such restriction applies to removing a team as an owner.
 
-## GitHub Permissions
+## GitHub permissions
 
 Team membership is not something GitHub provides simple public access to, and it
 is likely for you to encounter the following message when working with them:

--- a/src/doc/guide.md
+++ b/src/doc/guide.md
@@ -15,7 +15,7 @@ To accomplish this goal, Cargo does four things:
 * Invokes `rustc` or another build tool with the correct parameters to build your project.
 * Introduces conventions to make working with Rust projects easier.
 
-# Creating A New Project
+# Creating a new project
 
 To start a new project with Cargo, use `cargo new`:
 
@@ -123,7 +123,7 @@ To build, use `cargo build`:
 This will fetch all of the dependencies and then build them, along with the
 project.
 
-# Adding Dependencies from crates.io
+# Adding dependencies from crates.io
 
 [crates.io] is the Rust community's central repository that serves
 as a location to discover and download packages. `cargo` is configured to use
@@ -210,7 +210,7 @@ Running it will show:
 <span style="font-weight: bold" class="s1">     Running</span> `target/hello_world`
 Did our date match? true</code></pre>
 
-# Project Layout
+# Project layout
 
 Cargo uses conventions for file placement to make it easy to dive into a new
 Cargo project:

--- a/src/doc/index.md
+++ b/src/doc/index.md
@@ -17,7 +17,7 @@ and [Cargo](https://static.rust-lang.org/cargo-dist/cargo-nightly-i686-pc-window
 
 Alternatively, you can build Cargo from source.
 
-# Let’s Get Started
+# Let’s get started
 
 To start a new project with Cargo, use `cargo new`:
 
@@ -83,6 +83,6 @@ class="s1">     Fresh</span> hello_world v0.1.0 (file:///path/to/project/hello_w
 class="s1">   Running</span> `target/hello_world`
 Hello, world!</code></pre>
 
-# Going Further
+# Going further
 
 For more details on using Cargo, check out the [Cargo Guide](guide.html)

--- a/src/doc/manifest.md
+++ b/src/doc/manifest.md
@@ -1,6 +1,6 @@
 % The Manifest Format
 
-# The `[package]` Section
+# The `[package]` section
 
 The first section in a `Cargo.toml` is `[package]`.
 
@@ -13,7 +13,7 @@ authors = ["you@example.com"]
 
 All three of these fields are mandatory.
 
-## The `version` Field
+## The `version` field
 
 Cargo bakes in the concept of [Semantic
 Versioning](http://semver.org/), so make sure you follow some basic rules:
@@ -27,7 +27,7 @@ Versioning](http://semver.org/), so make sure you follow some basic rules:
   traits, fields, types, functions, methods or anything else.
 * Use version numbers with three numeric parts such as 1.0.0 rather than 1.0.
 
-## The `build` Field (optional)
+## The `build` field (optional)
 
 This field specifies a file in the repository which is a [build script][1] for
 building native code. More information can be found in the build script
@@ -41,7 +41,7 @@ building native code. More information can be found in the build script
 build = "build.rs"
 ```
 
-## The `exclude` and `include` Fields (optional)
+## The `exclude` and `include` fields (optional)
 
 You can explicitly specify to Cargo that a set of [globs][globs] should be
 ignored or included for the purposes of packaging and rebuilding a package. The
@@ -71,7 +71,7 @@ necessary source files may not be included.
 
 [globs]: http://doc.rust-lang.org/glob/glob/struct.Pattern.html
 
-## The `publish`  Field (optional)
+## The `publish`  field (optional)
 
 The `publish` field can be used to prevent a package from being published to a
 repository by mistake.
@@ -82,7 +82,7 @@ repository by mistake.
 publish = false
 ```
 
-## The `workspace`  Field (optional)
+## The `workspace`  field (optional)
 
 The `workspace` field can be used to configure the workspace that this package
 will be a member of. If not specified this will be inferred as the first
@@ -96,7 +96,7 @@ workspace = "path/to/root"
 
 For more information, see the documentation for the workspace table below.
 
-## Package Metadata
+## Package metadata
 
 There are a number of optional metadata fields also accepted under the
 `[package]` section:
@@ -140,7 +140,7 @@ provide useful information to users of the registry and also influence the
 search ranking of a crate. It is highly discouraged to omit everything in a
 published crate.
 
-## The `metadata` Table (optional)
+## The `metadata` table (optional)
 
 Cargo by default will warn about unused keys in `Cargo.toml` to assist in
 detecting typos and such. The `package.metadata` table, however, is completely
@@ -159,13 +159,13 @@ package-name = "my-awesome-android-app"
 assets = "path/to/static"
 ```
 
-# Dependency Sections
+# Dependency sections
 
 See the [specifying dependencies page](specifying-dependencies.html) for
 information on the `[dependencies]`, `[dev-dependencies]`, and target-specific
 `[target.*.dependencies]` sections.
 
-# The `[profile.*]` Sections
+# The `[profile.*]` sections
 
 Cargo supports custom configuration of how rustc is invoked through profiles at
 the top level. Any manifest may declare a profile, but only the top level
@@ -230,7 +230,7 @@ codegen-units = 1
 panic = 'unwind'
 ```
 
-# The `[features]` Section
+# The `[features]` section
 
 Cargo supports features to allow expression of:
 
@@ -313,7 +313,7 @@ Note that it is explicitly allowed for features to not actually activate any
 optional dependencies. This allows packages to internally enable/disable
 features without requiring a new dependency.
 
-## Usage in End Products
+## Usage in end products
 
 One major use-case for this feature is specifying optional features in
 end-products. For example, the Servo project may want to include optional
@@ -328,7 +328,7 @@ $ cargo build --release --features "shumway pdf"
 
 Default features could be excluded using `--no-default-features`.
 
-## Usage in Packages
+## Usage in packages
 
 In most cases, the concept of *optional dependency* in a library is best
 expressed as a separate package that the top-level application depends on.
@@ -355,7 +355,7 @@ In almost all cases, it is an antipattern to use these features outside of
 high-level packages that are designed for curation. If a feature is optional, it
 can almost certainly be expressed as a separate package.
 
-# The `[workspace]` Section
+# The `[workspace]` section
 
 Projects can define a workspace which is a set of crates that will all share the
 same `Cargo.lock` and output directory. The `[workspace]` table can be defined
@@ -402,7 +402,7 @@ and also be a member crate of another workspace (contain `package.workspace`).
 Most of the time workspaces will not need to be dealt with as `cargo new` and
 `cargo init` will handle workspace configuration automatically.
 
-# The Project Layout
+# The project layout
 
 If your project is an executable, name the main source file `src/main.rs`. If it
 is a library, name the main source file `src/lib.rs`.
@@ -451,7 +451,7 @@ When you run `cargo test`, Cargo will:
 * compile and run your library’s [integration tests](#integration-tests); and
 * compile your library’s examples.
 
-## Integration Tests
+## Integration tests
 
 Each file in `tests/*.rs` is an integration test. When you run `cargo test`,
 Cargo will compile each of these files as a separate crate. The crate can link
@@ -464,7 +464,7 @@ example, if you want several integration tests to share some code, you can put
 the shared code in `tests/common/mod.rs` and then put `mod common;` in each of
 the test files.
 
-# Configuring a Target
+# Configuring a target
 
 All of the  `[[bin]]`, `[lib]`, `[[bench]]`, `[[test]]`, and `[[example]]`
 sections support similar configuration for specifying how a target should be
@@ -508,7 +508,7 @@ plugin = false
 harness = true
 ```
 
-# Building Dynamic or Static Libraries
+# Building dynamic or static libraries
 
 If your project produces a library, you can specify which kind of library to
 build by explicitly listing the library in your `Cargo.toml`:

--- a/src/doc/pkgid-spec.md
+++ b/src/doc/pkgid-spec.md
@@ -1,6 +1,6 @@
 % Package ID Specifications
 
-# Package ID Specifications
+# Package ID specifications
 
 Subcommands of Cargo frequently need to refer to a particular package within a
 dependency graph for various operations like updating, cleaning, building, etc.
@@ -22,7 +22,7 @@ proto := "http" | "git" | ...
 
 Here, brackets indicate that the contents are optional.
 
-## Example Specifications
+## Example specifications
 
 These could all be references to a package `foo` version `1.2.3` from the
 registry at `crates.io`
@@ -36,7 +36,7 @@ registry at `crates.io`
 | `crates.io/bar#foo:1.2.3`      | foo    | 1.2.3     | *://crates.io/bar    |
 | `http://crates.io/foo#1.2.3`   | foo    | 1.2.3     | http://crates.io/foo |
 
-## Brevity of Specifications
+## Brevity of specifications
 
 The goal of this is to enable both succinct and exhaustive syntaxes for
 referring to packages in a dependency graph. Ambiguous references may refer to

--- a/src/doc/specifying-dependencies.md
+++ b/src/doc/specifying-dependencies.md
@@ -7,7 +7,7 @@ dependency that you are working on locally. You can have different
 dependencies for different platforms, and dependencies that are only used during
 development. Let's take a look at how to do each of these.
 
-# Specifying Dependencies from crates.io
+# Specifying dependencies from crates.io
 
 Cargo is configured to look for dependencies on [crates.io] by default. Only
 the name and a version string are required in this case. In [the cargo
@@ -162,7 +162,7 @@ repository location) and specify its version in the dependencies line as well:
 hello_utils = { path = "hello_utils", version = "0.1.0" }
 ```
 
-# Overriding Dependencies
+# Overriding dependencies
 
 Sometimes you may want to override one of Cargo’s dependencies. For example,
 let’s say you’re working on a project,


### PR DESCRIPTION
There was a pretty even mix of upper-case and lower-case, so I chose lower. This appears to be consistent with other rust docs.