### PR TITLE
Implement cargo check

### DIFF
--- a/src/bin/bench.rs
+++ b/src/bin/bench.rs
@@ -1,7 +1,7 @@
 use cargo::core::Workspace;
 use cargo::ops;
 use cargo::util::{CliResult, CliError, Human, Config, human};
-use cargo::util::important_paths::{find_root_manifest_for_wd};
+use cargo::util::important_paths::find_root_manifest_for_wd;
 
 #[derive(RustcDecodable)]
 pub struct Options {
@@ -89,6 +89,7 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
                                             &options.flag_bench),
             target_rustdoc_args: None,
             target_rustc_args: None,
+            compile_check: false,
         },
     };
 
@@ -99,7 +100,7 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
         Some(err) => {
             Err(match err.exit.as_ref().and_then(|e| e.code()) {
                 Some(i) => CliError::new(human("bench failed"), i),
-                None => CliError::new(Box::new(Human(err)), 101)
+                None => CliError::new(Box::new(Human(err)), 101),
             })
         }
     }

--- a/src/bin/check.rs
+++ b/src/bin/check.rs
@@ -17,7 +17,6 @@ pub struct Options {
     flag_verbose: u32,
     flag_quiet: Option<bool>,
     flag_color: Option<String>,
-    flag_release: bool,
     flag_lib: bool,
     flag_bin: Vec<String>,
     flag_example: Vec<String>,
@@ -26,10 +25,10 @@ pub struct Options {
 }
 
 pub const USAGE: &'static str = "
-Compile a local package and all of its dependencies
+Compile a local package to check for compilation errors without creating an artifact
 
 Usage:
-    cargo build [options]
+    cargo check [options]
 
 Options:
     -h, --help                   Print this message
@@ -40,7 +39,6 @@ Options:
     --example NAME               Build only the specified example
     --test NAME                  Build only the specified test target
     --bench NAME                 Build only the specified benchmark target
-    --release                    Build artifacts in release mode, with optimizations
     --features FEATURES          Space-separated list of features to also build
     --no-default-features        Do not build the `default` feature
     --target TRIPLE              Build for the target triple
@@ -60,7 +58,7 @@ the --release flag will use the `release` profile instead.
 ";
 
 pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
-    debug!("executing; cmd=cargo-build; args={:?}",
+    debug!("executing; cmd=cargo-check; args={:?}",
            env::args().collect::<Vec<_>>());
     try!(config.configure_shell(options.flag_verbose,
                                 options.flag_quiet,
@@ -77,7 +75,7 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
         spec: &options.flag_package,
         exec_engine: None,
         mode: ops::CompileMode::Build,
-        release: options.flag_release,
+        release: false,
         filter: ops::CompileFilter::new(options.flag_lib,
                                         &options.flag_bin,
                                         &options.flag_test,
@@ -85,7 +83,7 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
                                         &options.flag_bench),
         target_rustdoc_args: None,
         target_rustc_args: None,
-        compile_check: false,
+        compile_check: true,
     };
 
     let ws = try!(Workspace::new(&root, config));

--- a/src/bin/doc.rs
+++ b/src/bin/doc.rs
@@ -1,7 +1,7 @@
 use cargo::core::Workspace;
 use cargo::ops;
 use cargo::util::{CliResult, Config};
-use cargo::util::important_paths::{find_root_manifest_for_wd};
+use cargo::util::important_paths::find_root_manifest_for_wd;
 
 #[derive(RustcDecodable)]
 pub struct Options {
@@ -77,11 +77,10 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
                                             &empty,
                                             &empty),
             release: options.flag_release,
-            mode: ops::CompileMode::Doc {
-                deps: !options.flag_no_deps,
-            },
+            mode: ops::CompileMode::Doc { deps: !options.flag_no_deps },
             target_rustc_args: None,
             target_rustdoc_args: None,
+            compile_check: false,
         },
     };
 

--- a/src/bin/install.rs
+++ b/src/bin/install.rs
@@ -103,10 +103,10 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
         exec_engine: None,
         mode: ops::CompileMode::Build,
         release: !options.flag_debug,
-        filter: ops::CompileFilter::new(false, &options.flag_bin, &[],
-                                        &options.flag_example, &[]),
+        filter: ops::CompileFilter::new(false, &options.flag_bin, &[], &options.flag_example, &[]),
         target_rustc_args: None,
         target_rustdoc_args: None,
+        compile_check: false,
     };
 
     let source = if let Some(url) = options.flag_git {
@@ -136,7 +136,12 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
     if options.flag_list {
         try!(ops::install_list(root, config));
     } else {
-        try!(ops::install(root, krate, &source, vers, &compile_opts, options.flag_force));
+        try!(ops::install(root,
+                          krate,
+                          &source,
+                          vers,
+                          &compile_opts,
+                          options.flag_force));
     }
     Ok(None)
 }

--- a/src/bin/run.rs
+++ b/src/bin/run.rs
@@ -1,7 +1,7 @@
 use cargo::core::Workspace;
 use cargo::ops;
 use cargo::util::{CliResult, CliError, Config, Human};
-use cargo::util::important_paths::{find_root_manifest_for_wd};
+use cargo::util::important_paths::find_root_manifest_for_wd;
 
 #[derive(RustcDecodable)]
 pub struct Options {
@@ -78,12 +78,16 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
             ops::CompileFilter::Everything
         } else {
             ops::CompileFilter::Only {
-                lib: false, tests: &[], benches: &[],
-                bins: &bins, examples: &examples,
+                lib: false,
+                tests: &[],
+                benches: &[],
+                bins: &bins,
+                examples: &examples,
             }
         },
         target_rustdoc_args: None,
         target_rustc_args: None,
+        compile_check: false,
     };
 
     let ws = try!(Workspace::new(&root, config));

--- a/src/bin/rustc.rs
+++ b/src/bin/rustc.rs
@@ -3,7 +3,7 @@ use std::env;
 use cargo::core::Workspace;
 use cargo::ops::{CompileOptions, CompileMode};
 use cargo::ops;
-use cargo::util::important_paths::{find_root_manifest_for_wd};
+use cargo::util::important_paths::find_root_manifest_for_wd;
 use cargo::util::{CliResult, CliError, Config, human};
 
 #[derive(RustcDecodable)]
@@ -73,16 +73,16 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
                                 options.flag_quiet,
                                 &options.flag_color));
 
-    let root = try!(find_root_manifest_for_wd(options.flag_manifest_path,
-                                              config.cwd()));
+    let root = try!(find_root_manifest_for_wd(options.flag_manifest_path, config.cwd()));
     let mode = match options.flag_profile.as_ref().map(|t| &t[..]) {
         Some("dev") | None => CompileMode::Build,
         Some("test") => CompileMode::Test,
         Some("bench") => CompileMode::Bench,
         Some(mode) => {
             let err = human(format!("unknown profile: `{}`, use dev,
-                                     test, or bench", mode));
-            return Err(CliError::new(err, 101))
+                                     test, or bench",
+                                    mode));
+            return Err(CliError::new(err, 101));
         }
     };
 
@@ -103,10 +103,10 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
                                         &options.flag_bench),
         target_rustdoc_args: None,
         target_rustc_args: options.arg_opts.as_ref().map(|a| &a[..]),
+        compile_check: false,
     };
 
     let ws = try!(Workspace::new(&root, config));
     try!(ops::compile(&ws, &opts));
     Ok(None)
 }
-

--- a/src/bin/rustdoc.rs
+++ b/src/bin/rustdoc.rs
@@ -1,7 +1,7 @@
 use cargo::core::Workspace;
 use cargo::ops;
 use cargo::util::{CliResult, Config};
-use cargo::util::important_paths::{find_root_manifest_for_wd};
+use cargo::util::important_paths::find_root_manifest_for_wd;
 
 #[derive(RustcDecodable)]
 pub struct Options {
@@ -67,8 +67,7 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
                                 options.flag_quiet,
                                 &options.flag_color));
 
-    let root = try!(find_root_manifest_for_wd(options.flag_manifest_path,
-                                              config.cwd()));
+    let root = try!(find_root_manifest_for_wd(options.flag_manifest_path, config.cwd()));
 
     let doc_opts = ops::DocOptions {
         open_result: options.flag_open,
@@ -89,6 +88,7 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
             mode: ops::CompileMode::Doc { deps: false },
             target_rustdoc_args: Some(&options.arg_opts),
             target_rustc_args: None,
+            compile_check: false,
         },
     };
 

--- a/src/bin/test.rs
+++ b/src/bin/test.rs
@@ -1,7 +1,7 @@
 use cargo::core::Workspace;
 use cargo::ops;
 use cargo::util::{CliResult, CliError, Human, human, Config};
-use cargo::util::important_paths::{find_root_manifest_for_wd};
+use cargo::util::important_paths::find_root_manifest_for_wd;
 
 #[derive(RustcDecodable)]
 pub struct Options {
@@ -117,6 +117,7 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
             filter: filter,
             target_rustdoc_args: None,
             target_rustc_args: None,
+            compile_check: false,
         },
     };
 
@@ -127,7 +128,7 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
         Some(err) => {
             Err(match err.exit.as_ref().and_then(|e| e.code()) {
                 Some(i) => CliError::new(human("test failed"), i),
-                None => CliError::new(Box::new(Human(err)), 101)
+                None => CliError::new(Box::new(Human(err)), 101),
             })
         }
     }


### PR DESCRIPTION
Attempt to implement #1313 

It's the first time I dive into the code of Cargo, so take your time to review this properly. It's mostly copy paste from other commands with little tweaks until it worked like intended (at least I think it does).

Also sorry for the noise, I have rustfmt set up to run on save.

### To summarize what I did and why

For linters that are integrated in text editors / IDEs compiling with `-Z no-trans` reduces the error reporting time. But the problem is that you can't pass custom arguments to rustc when you have multiple targets, for example a lib and a bin or multiple bins. To allow custom arguments to rustc for multiple targets would not be "safe" because cargo has no idea what is passed to rustc and some needed artifacts may or may not be created. See #2642 

To allow `-Z no-trans` on multiple targets without having to remove the restrictions on `cargo rustc`I have added a new command `cargo check`

I created a new flag in 

```rust
pub struct CompileOptions<'a> {
    // [...]
    /// The compilation will stop before the generation of any artifacts: -Z no-trans
    pub compile_check: bool,
}
```

It is set to false for all commands except `cargo check`. 

In `compile_ws` I added an extra [`if`](https://github.com/rust-lang/cargo/pull/2834/files#diff-495d1e5cb2769d1b76ee0efb1f31ca8eR222) for when `compile_check` is true (this occurs only whit `cargo check`). When it is true cargo passes `-Z no-trans` to rustc.

That's it.