### PR TITLE
Generate the same lock always in a workspace

### DIFF
--- a/src/cargo/core/resolver/mod.rs
+++ b/src/cargo/core/resolver/mod.rs
@@ -61,7 +61,7 @@ use util::ChainError;
 use util::graph::{Nodes, Edges};
 
 pub use self::encode::{EncodableResolve, EncodableDependency, EncodablePackageId};
-pub use self::encode::Metadata;
+pub use self::encode::{Metadata, WorkspaceResolve};
 
 mod encode;
 
@@ -674,7 +674,7 @@ fn build_features(s: &Summary, method: &Method)
         match s.features().get(feat) {
             Some(wanted_features) => {
                 for entry in wanted_features {
-                    // If the entry is of the form `foo/bar`, then we just lookup package 
+                    // If the entry is of the form `foo/bar`, then we just lookup package
                     // `foo` and enable its feature `bar`. We also add `foo` to the used
                     // set because `foo` might have been an optional dependency.
                     //
@@ -703,7 +703,7 @@ fn build_features(s: &Summary, method: &Method)
                 deps.entry(feat.to_string()).or_insert(Vec::new());
             }
         }
-        
+
         visited.remove(&feat.to_string());
 
         Ok(())

--- a/src/cargo/ops/lockfile.rs
+++ b/src/cargo/ops/lockfile.rs
@@ -4,6 +4,7 @@ use rustc_serialize::{Encodable, Decodable};
 use toml::{self, Encoder, Value};
 
 use core::{Resolve, resolver, Workspace};
+use core::resolver::WorkspaceResolve;
 use util::{CargoResult, ChainError, human, Filesystem};
 use util::toml as cargo_toml;
 
@@ -33,7 +34,10 @@ pub fn load_pkg_lockfile(ws: &Workspace) -> CargoResult<Option<Resolve>> {
 
 pub fn write_pkg_lockfile(ws: &Workspace, resolve: &Resolve) -> CargoResult<()> {
     let mut e = Encoder::new();
-    resolve.encode(&mut e).unwrap();
+    WorkspaceResolve {
+        ws: ws,
+        resolve: resolve,
+    }.encode(&mut e).unwrap();
 
     let mut out = String::new();
 


### PR DESCRIPTION
Previously the "root" of a lock file would erroneously change over time, so
instead just ensure that the root of a lock file is always the root of the
workspace. Otherwise the contents should always be the same.

Closes #2837