### PR TITLE
Add path to executable in error

### DIFF
--- a/src/bin/test.rs
+++ b/src/bin/test.rs
@@ -126,7 +126,7 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
         None => Ok(None),
         Some(err) => {
             Err(match err.exit.as_ref().and_then(|e| e.code()) {
-                Some(i) => CliError::new(human("test failed"), i),
+                Some(i) => CliError::new(human(format!("test `{}` failed", err.exec)), i),
                 None => CliError::new(Box::new(Human(err)), 101)
             })
         }

--- a/src/cargo/ops/cargo_rustc/custom_build.rs
+++ b/src/cargo/ops/cargo_rustc/custom_build.rs
@@ -480,7 +480,7 @@ fn stream_output(state: &JobState, cmd: &ProcessBuilder)
         child.wait()
     })().map_err(|e| {
         let msg = format!("could not exeute process {}", cmd);
-        process_error(&msg, Some(e), None, None)
+        process_error(&msg, Some(e), None, None, None)
     }));
     let output = Output {
         stdout: stdout,
@@ -489,7 +489,7 @@ fn stream_output(state: &JobState, cmd: &ProcessBuilder)
     };
     if !output.status.success() {
         let msg = format!("process didn't exit successfully: {}", cmd);
-        Err(process_error(&msg, None, Some(&status), Some(&output)))
+        Err(process_error(&msg, None, Some(&status), None, Some(&output)))
     } else {
         Ok(output)
     }

--- a/src/cargo/util/errors.rs
+++ b/src/cargo/util/errors.rs
@@ -110,6 +110,7 @@ pub struct ProcessError {
     pub desc: String,
     pub exit: Option<ExitStatus>,
     pub output: Option<Output>,
+    pub exec: String,
     cause: Option<io::Error>,
 }
 
@@ -137,6 +138,7 @@ impl fmt::Debug for ProcessError {
 /// Error when testcases fail
 pub struct CargoTestError {
     pub desc: String,
+    pub exec: String,
     pub exit: Option<ExitStatus>,
     pub causes: Vec<ProcessError>,
 }
@@ -149,14 +151,15 @@ impl CargoTestError {
         let desc = errors.iter().map(|error| error.desc.clone())
                                 .collect::<Vec<String>>()
                                 .join("\n");
+
         CargoTestError {
             desc: desc,
+            exec: errors[0].exec.clone(),
             exit: errors[0].exit,
             causes: errors,
         }
     }
 }
-
 impl fmt::Display for CargoTestError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::Display::fmt(&self.desc, f)
@@ -377,6 +380,7 @@ impl CargoError for str::ParseBoolError {}
 pub fn process_error(msg: &str,
                      cause: Option<io::Error>,
                      status: Option<&ExitStatus>,
+                     cmd: Option<String>,
                      output: Option<&Output>) -> ProcessError {
     let exit = match status {
         Some(s) => status_to_string(s),
@@ -400,11 +404,16 @@ pub fn process_error(msg: &str,
             Ok(..) | Err(..) => {}
         }
     }
+    let exec = match cmd {
+        Some(e) => e,
+        None => "".to_string()
+    };
 
     return ProcessError {
         desc: desc,
         exit: status.cloned(),
         output: output.cloned(),
+        exec: exec,
         cause: cause,
     };
 

--- a/src/cargo/util/process_builder.rs
+++ b/src/cargo/util/process_builder.rs
@@ -77,7 +77,7 @@ impl ProcessBuilder {
         let exit = try!(command.status().map_err(|e| {
             process_error(&format!("Could not execute process `{}`",
                                    self.debug_string()),
-                          Some(e), None, None)
+                          Some(e), None, Some(self.debug_string()), None)
         }));
 
         if exit.success() {
@@ -85,7 +85,7 @@ impl ProcessBuilder {
         } else {
             Err(process_error(&format!("Process didn't exit successfully: `{}`",
                                        self.debug_string()),
-                              None, Some(&exit), None))
+                              None, Some(&exit), Some(self.debug_string()), None))
         }
     }
 
@@ -95,7 +95,7 @@ impl ProcessBuilder {
         let output = try!(command.output().map_err(|e| {
             process_error(&format!("Could not execute process `{}`",
                                self.debug_string()),
-                          Some(e), None, None)
+                          Some(e), None, Some(self.debug_string()), None)
         }));
 
         if output.status.success() {
@@ -103,7 +103,7 @@ impl ProcessBuilder {
         } else {
             Err(process_error(&format!("Process didn't exit successfully: `{}`",
                                        self.debug_string()),
-                              None, Some(&output.status), Some(&output)))
+                              None, Some(&output.status), Some(self.debug_string()), Some(&output)))
         }
     }
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -195,7 +195,7 @@ fn cargo_test_failing_test() {
                 execs().with_stderr(format!("\
 [COMPILING] foo v0.5.0 ({url})
 [RUNNING] target[..]foo-[..]
-[ERROR] test failed", url = p.url()))
+[ERROR] test `[..]foo-[..]` failed", url = p.url()))
                        .with_stdout_contains("
 running 1 test
 test test_hello ... FAILED


### PR DESCRIPTION
Returns the path to the exec that failed on error. Ref: https://github.com/rust-lang/cargo/issues/2529