### PR TITLE
Refactor `host/target_triple` handling 

### DIFF
--- a/src/cargo/ops/cargo_clean.rs
+++ b/src/cargo/ops/cargo_clean.rs
@@ -35,8 +35,9 @@ pub fn clean(ws: &Workspace, opts: &CleanOptions) -> CargoResult<()> {
     let profiles = try!(ws.current()).manifest().profiles();
     let mut cx = try!(Context::new(ws, &resolve, &packages, opts.config,
                                    BuildConfig {
-                                       release: opts.release,
+                                       host_triple: opts.config.rustc_info().host.clone(),
                                        requested_target: opts.target.map(|s| s.to_owned()),
+                                       release: opts.release,
                                        ..BuildConfig::default()
                                    },
                                    profiles));

--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -443,11 +443,12 @@ fn scrape_build_config(config: &Config,
     let cfg_target = try!(config.get_string("build.target")).map(|s| s.val);
     let target = target.or(cfg_target);
     let mut base = ops::BuildConfig {
-        jobs: jobs,
+        host_triple: config.rustc_info().host.clone(),
         requested_target: target.clone(),
+        jobs: jobs,
         ..Default::default()
     };
-    base.host = try!(scrape_target_config(config, &config.rustc_info().host));
+    base.host = try!(scrape_target_config(config, &base.host_triple));
     base.target = match target.as_ref() {
         Some(triple) => try!(scrape_target_config(config, &triple)),
         None => base.host.clone(),

--- a/src/cargo/ops/cargo_rustc/context.rs
+++ b/src/cargo/ops/cargo_rustc/context.rs
@@ -264,9 +264,19 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
         }
     }
 
+    /// Return the host triple for this context
+    pub fn host_triple(&self) -> &str {
+        &self.config.rustc_info().host[..]
+    }
+
     /// Return the target triple which this context is targeting.
     pub fn target_triple(&self) -> &str {
         &self.target_triple
+    }
+
+    /// Requested (not actual) target for the build
+    pub fn requested_target(&self) -> Option<&str> {
+        self.build_config.requested_target.as_ref().map(|s| &s[..])
     }
 
     /// Get the metadata for a target in a specific profile
@@ -600,8 +610,8 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
             None => return true,
         };
         let (name, info) = match kind {
-            Kind::Host => (&self.config.rustc_info().host, &self.host_info),
-            Kind::Target => (&self.target_triple, &self.target_info),
+            Kind::Host => (self.host_triple(), &self.host_info),
+            Kind::Target => (self.target_triple(), &self.target_info),
         };
         platform.matches(name, info.cfg.as_ref().map(|cfg| &cfg[..]))
     }
@@ -631,11 +641,6 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
 
     /// Number of jobs specified for this build
     pub fn jobs(&self) -> u32 { self.build_config.jobs }
-
-    /// Requested (not actual) target for the build
-    pub fn requested_target(&self) -> Option<&str> {
-        self.build_config.requested_target.as_ref().map(|s| &s[..])
-    }
 
     pub fn lib_profile(&self, _pkg: &PackageId) -> &'a Profile {
         let (normal, test) = if self.build_config.release {

--- a/src/cargo/ops/cargo_rustc/context.rs
+++ b/src/cargo/ops/cargo_rustc/context.rs
@@ -42,7 +42,6 @@ pub struct Context<'a, 'cfg: 'a> {
 
     host: Layout,
     target: Option<Layout>,
-    target_triple: String,
     target_info: TargetInfo,
     host_info: TargetInfo,
     profiles: &'a Profiles,
@@ -71,16 +70,10 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
             None => None,
         };
 
-        let target = build_config.requested_target.clone();
-        let target = target.as_ref().map(|s| &s[..]);
-        let target_triple = target.unwrap_or_else(|| {
-            &config.rustc_info().host[..]
-        }).to_string();
         let engine = build_config.exec_engine.as_ref().cloned().unwrap_or({
             Arc::new(Box::new(ProcessEngine))
         });
         Ok(Context {
-            target_triple: target_triple,
             host: host_layout,
             target: target_layout,
             resolve: resolve,
@@ -138,7 +131,7 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
             try!(self.visit_crate_type(unit, &mut crate_types));
         }
         try!(self.probe_target_info_kind(&crate_types, Kind::Target));
-        if self.build_config.requested_target.is_none() {
+        if self.requested_target().is_none() {
             self.host_info = self.target_info.clone();
         } else {
             try!(self.probe_target_info_kind(&crate_types, Kind::Host));
@@ -184,7 +177,7 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
             process.arg("--crate-type").arg(crate_type);
         }
         if kind == Kind::Target {
-            process.arg("--target").arg(&self.target_triple);
+            process.arg("--target").arg(&self.target_triple());
         }
 
         let mut with_cfg = process.clone();
@@ -266,12 +259,12 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
 
     /// Return the host triple for this context
     pub fn host_triple(&self) -> &str {
-        &self.config.rustc_info().host[..]
+        &self.build_config.host_triple
     }
 
     /// Return the target triple which this context is targeting.
     pub fn target_triple(&self) -> &str {
-        &self.target_triple
+        self.requested_target().unwrap_or(self.host_triple())
     }
 
     /// Requested (not actual) target for the build
@@ -376,11 +369,11 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
             if unsupported.len() > 0 {
                 bail!("cannot produce {} for `{}` as the target `{}` \
                        does not support these crate types",
-                      unsupported.join(", "), unit.pkg, self.target_triple)
+                      unsupported.join(", "), unit.pkg, self.target_triple())
             }
             bail!("cannot compile `{}` as the target `{}` does not \
                    support any of the output crate types",
-                  unit.pkg, self.target_triple);
+                  unit.pkg, self.target_triple());
         }
         Ok(ret)
     }

--- a/src/cargo/ops/cargo_rustc/custom_build.rs
+++ b/src/cargo/ops/cargo_rustc/custom_build.rs
@@ -106,13 +106,13 @@ fn build_work<'a, 'cfg>(cx: &mut Context<'a, 'cfg>, unit: &Unit<'a>)
      .env("CARGO_MANIFEST_DIR", unit.pkg.root())
      .env("NUM_JOBS", &cx.jobs().to_string())
      .env("TARGET", &match unit.kind {
-         Kind::Host => &cx.config.rustc_info().host[..],
+         Kind::Host => cx.host_triple(),
          Kind::Target => cx.target_triple(),
      })
      .env("DEBUG", &profile.debuginfo.to_string())
      .env("OPT_LEVEL", &profile.opt_level.to_string())
      .env("PROFILE", if cx.build_config.release {"release"} else {"debug"})
-     .env("HOST", &cx.config.rustc_info().host)
+     .env("HOST", cx.host_triple())
      .env("RUSTC", &cx.config.rustc())
      .env("RUSTDOC", &cx.config.rustdoc());
 

--- a/src/cargo/ops/cargo_rustc/mod.rs
+++ b/src/cargo/ops/cargo_rustc/mod.rs
@@ -35,10 +35,11 @@ pub enum Kind { Host, Target }
 
 #[derive(Default, Clone)]
 pub struct BuildConfig {
+    pub host_triple: String,
     pub host: TargetConfig,
+    pub requested_target: Option<String>,
     pub target: TargetConfig,
     pub jobs: u32,
-    pub requested_target: Option<String>,
     pub exec_engine: Option<Arc<Box<ExecEngine>>>,
     pub release: bool,
     pub test: bool,


### PR DESCRIPTION
This PR adds an explicit `host_triple` filed to `BuildConfig`. It allows to unify host and target handling and to reduce the number of accesses to `config.rustc_info()`. As a side effect, the explicit `target_triple` field of `Context` is gone because it can now be calculated from the `BuildConfig`. 