### PR TITLE
Better rational for build-dependencies and other kinds being disjoint.

### DIFF
--- a/src/doc/specifying-dependencies.md
+++ b/src/doc/specifying-dependencies.md
@@ -384,7 +384,10 @@ manifest:
 gcc = "0.3"
 ```
 
-The build script **does not** have access to the dependencies listed in the
-`dependencies` or `dev-dependencies` section (they’re not built yet!). All build
-dependencies will also not be available to the package itself unless listed
-under the `dependencies` section as well.
+The build script **does not** have access to the dependencies listed
+in the `dependencies` or `dev-dependencies` section. Build
+dependencies will likewise not be available to the package itself
+unless listed under the `dependencies` section as well. A package
+itself and its build script are built separately, so their
+dependencies need not coincide. Cargo is kept simpler and cleaner by
+using independent dependencies for independent purposes.


### PR DESCRIPTION
The old reason was bad because nothing prevents normal dependencies from
being built before the build script.