### PR TITLE
doc: manifest.md add explain about double-bracket

### DIFF
--- a/src/doc/manifest.md
+++ b/src/doc/manifest.md
@@ -468,7 +468,11 @@ the test files.
 
 All of the  `[[bin]]`, `[lib]`, `[[bench]]`, `[[test]]`, and `[[example]]`
 sections support similar configuration for specifying how a target should be
-built. The example below uses `[lib]`, but it also applies to all other sections
+built. The double-bracket sections like `[[bin]]` are array-of-table of
+[TOML](https://github.com/toml-lang/toml#array-of-tables), which means you can
+wirte more than one `[[bin]]` sections to make serval executables in your crate.
+
+The example below uses `[lib]`, but it also applies to all other sections
 as well. All values listed are the defaults for that option unless otherwise
 specified.
 


### PR DESCRIPTION
Add TOML doc ref to explain double-bracket sections like [[bin]].
It really confused me when I saw the double-bracket first. I search google, take some time, and then saw the TOML doc, recall that we can have more than one executable in Cargo, understood it. So it can be added to help someone like me (: