### PR TITLE
fix help for cargo rustc -p

### DIFF
--- a/src/bin/rustc.rs
+++ b/src/bin/rustc.rs
@@ -35,7 +35,7 @@ Usage:
 
 Options:
     -h, --help               Print this message
-    -p SPEC, --package SPEC  The profile to compile for
+    -p SPEC, --package SPEC  Package to build
     -j N, --jobs N           Number of parallel jobs, defaults to # of CPUs
     --lib                    Build only this package's library
     --bin NAME               Build only the specified binary


### PR DESCRIPTION
cargo rustc -p does the same as cargo build -p, so I just copied it from there.