### PR TITLE
Include reference to Rust code structuring

### DIFF
--- a/src/doc/manifest.md
+++ b/src/doc/manifest.md
@@ -427,6 +427,8 @@ integration tests, and benchmarks respectively.
   *.rs
 ```
 
+To structure your code after you've created the files and folders for your project, you should remember to use Rust's module system, which you can read about in [the book](https://doc.rust-lang.org/book/crates-and-modules.html).
+
 # Examples
 
 Files located under `examples` are example uses of the functionality provided by


### PR DESCRIPTION
Hey guys, I'm proposing this little addition to the manifest. When I first started with Rust, I wanted to make a simple crate, so the "Getting Started" (and from there, the manifest) document on crates.io was a natural entry point for me. However, it would have helped getting over some headaches initially if the Cargo documentation had driven me into the relevant Rust documentation; in the beginning at least it wasn't clear to me where Cargo ended and Rust began, especially with modules.

I'm not sure if this should be in the actual manifest or in the "Getting Stated" doc, or if you want it there at all, but it's a quality-of-life thing that I think past-me would have appreciated at least :)