### PR TITLE
Add release and debug target indicators

### DIFF
--- a/src/cargo/ops/cargo_rustc/mod.rs
+++ b/src/cargo/ops/cargo_rustc/mod.rs
@@ -81,11 +81,13 @@ pub fn compile_targets<'a, 'cfg: 'a>(ws: &Workspace<'cfg>,
         })
     }).collect::<Vec<_>>();
 
+    let is_release = build_config.release;
+
     let root = try!(packages.get(resolve.root()));
     let mut cx = try!(Context::new(ws, resolve, packages, config,
                                    build_config, profiles));
 
-    let mut queue = JobQueue::new(&cx);
+    let mut queue = JobQueue::new(&cx, if is_release { "release" } else { "debug" });
 
     try!(cx.prepare(root));
     try!(cx.probe_target_info(&units));

--- a/tests/bad-config.rs
+++ b/tests/bad-config.rs
@@ -451,7 +451,7 @@ fn unused_keys() {
     assert_that(foo.cargo_process("build"),
                 execs().with_status(0).with_stderr("\
 warning: unused manifest key: target.foo.bar
-[COMPILING] foo v0.1.0 (file:///[..])
+[COMPILING] (debug) foo v0.1.0 (file:///[..])
 "));
 }
 
@@ -501,6 +501,6 @@ The TOML spec requires newlines after table definitions (e.g. `[a] b = 1` is
 invalid), but this file has a table header which does not have a newline after
 it. A newline needs to be added and this warning will soon become a hard error
 in the future.
-[COMPILING] empty_deps v0.0.0 ([..])
+[COMPILING] (debug) empty_deps v0.0.0 ([..])
 "));
 }

--- a/tests/bench.rs
+++ b/tests/bench.rs
@@ -41,7 +41,7 @@ fn cargo_bench_simple() {
 
     assert_that(p.cargo("bench"),
                 execs().with_stderr(&format!("\
-[COMPILING] foo v0.5.0 ({})
+[COMPILING] (release) foo v0.5.0 ({})
 [RUNNING] target[..]release[..]foo-[..]", p.url()))
                        .with_stdout("
 running 1 test
@@ -75,7 +75,7 @@ fn bench_tarname() {
     assert_that(prj.cargo_process("bench").arg("--bench").arg("bin2"),
         execs().with_status(0)
                .with_stderr(format!("\
-[COMPILING] foo v0.0.1 ({dir})
+[COMPILING] (release) foo v0.0.1 ({dir})
 [RUNNING] target[..]release[..]bin2[..]
 ", dir = prj.url()))
                .with_stdout("
@@ -102,7 +102,7 @@ fn cargo_bench_verbose() {
 
     assert_that(p.cargo_process("bench").arg("-v").arg("hello"),
                 execs().with_stderr(&format!("\
-[COMPILING] foo v0.5.0 ({url})
+[COMPILING] (release) foo v0.5.0 ({url})
 [RUNNING] `rustc src[..]foo.rs [..]`
 [RUNNING] `[..]target[..]release[..]foo-[..] hello --bench`", url = p.url()))
                        .with_stdout("
@@ -185,7 +185,7 @@ fn cargo_bench_failing_test() {
 running 1 test
 test bench_hello ... ")
                        .with_stderr_contains(format!("\
-[COMPILING] foo v0.5.0 ({})
+[COMPILING] (release) foo v0.5.0 ({})
 [RUNNING] target[..]release[..]foo-[..]
 thread '[..]' panicked at 'assertion failed: \
     `(left == right)` (left: \
@@ -237,7 +237,7 @@ fn bench_with_lib_dep() {
 
     assert_that(p.cargo_process("bench"),
                 execs().with_stderr(&format!("\
-[COMPILING] foo v0.0.1 ({})
+[COMPILING] (release) foo v0.0.1 ({})
 [RUNNING] target[..]release[..]baz-[..]
 [RUNNING] target[..]release[..]foo-[..]", p.url()))
                        .with_stdout("
@@ -299,8 +299,8 @@ fn bench_with_deep_lib_dep() {
     assert_that(p.cargo_process("bench"),
                 execs().with_status(0)
                        .with_stderr(&format!("\
-[COMPILING] foo v0.0.1 ([..])
-[COMPILING] bar v0.0.1 ({dir})
+[COMPILING] (release) foo v0.0.1 ([..])
+[COMPILING] (release) bar v0.0.1 ({dir})
 [RUNNING] target[..]", dir = p.url()))
                        .with_stdout("
 running 1 test
@@ -345,7 +345,7 @@ fn external_bench_explicit() {
 
     assert_that(p.cargo_process("bench"),
                 execs().with_stderr(&format!("\
-[COMPILING] foo v0.0.1 ({})
+[COMPILING] (release) foo v0.0.1 ({})
 [RUNNING] target[..]release[..]bench-[..]
 [RUNNING] target[..]release[..]foo-[..]", p.url()))
                        .with_stdout("
@@ -394,7 +394,7 @@ fn external_bench_implicit() {
 
     assert_that(p.cargo_process("bench"),
                 execs().with_stderr(&format!("\
-[COMPILING] foo v0.0.1 ({})
+[COMPILING] (release) foo v0.0.1 ({})
 [RUNNING] target[..]release[..]external-[..]
 [RUNNING] target[..]release[..]foo-[..]", p.url()))
                        .with_stdout("
@@ -454,7 +454,7 @@ fn pass_through_command_line() {
     assert_that(p.cargo_process("bench").arg("bar"),
                 execs().with_status(0)
                 .with_stderr(&format!("\
-[COMPILING] foo v0.0.1 ({dir})
+[COMPILING] (release) foo v0.0.1 ({dir})
 [RUNNING] target[..]release[..]foo-[..]", dir = p.url()))
                 .with_stdout("
 running 1 test
@@ -535,7 +535,7 @@ fn lib_bin_same_name() {
 
     assert_that(p.cargo_process("bench"),
                 execs().with_stderr(&format!("\
-[COMPILING] foo v0.0.1 ({})
+[COMPILING] (release) foo v0.0.1 ({})
 [RUNNING] target[..]release[..]foo-[..]
 [RUNNING] target[..]release[..]foo-[..]", p.url()))
                        .with_stdout("
@@ -588,7 +588,7 @@ fn lib_with_standard_name() {
     assert_that(p.cargo_process("bench"),
                 execs().with_status(0)
                        .with_stderr(&format!("\
-[COMPILING] syntax v0.0.1 ({dir})
+[COMPILING] (release) syntax v0.0.1 ({dir})
 [RUNNING] target[..]release[..]bench-[..]
 [RUNNING] target[..]release[..]syntax-[..]", dir = p.url()))
                        .with_stdout("
@@ -639,7 +639,7 @@ fn lib_with_standard_name2() {
     assert_that(p.cargo_process("bench"),
                 execs().with_status(0)
                        .with_stderr(&format!("\
-[COMPILING] syntax v0.0.1 ({dir})
+[COMPILING] (release) syntax v0.0.1 ({dir})
 [RUNNING] target[..]release[..]syntax-[..]", dir = p.url()))
                        .with_stdout("
 running 1 test
@@ -703,9 +703,9 @@ fn bench_dylib() {
     assert_that(p.cargo_process("bench").arg("-v"),
                 execs().with_status(0)
                        .with_stderr(&format!("\
-[COMPILING] bar v0.0.1 ({dir}/bar)
+[COMPILING] (release) bar v0.0.1 ({dir}/bar)
 [RUNNING] [..] -C opt-level=3 [..]
-[COMPILING] foo v0.0.1 ({dir})
+[COMPILING] (release) foo v0.0.1 ({dir})
 [RUNNING] [..] -C opt-level=3 [..]
 [RUNNING] [..] -C opt-level=3 [..]
 [RUNNING] [..] -C opt-level=3 [..]
@@ -770,7 +770,7 @@ fn bench_twice_with_build_cmd() {
     assert_that(p.cargo_process("bench"),
                 execs().with_status(0)
                        .with_stderr(&format!("\
-[COMPILING] foo v0.0.1 ({dir})
+[COMPILING] (release) foo v0.0.1 ({dir})
 [RUNNING] target[..]release[..]foo-[..]", dir = p.url()))
                        .with_stdout("
 running 1 test
@@ -851,7 +851,7 @@ fn bench_with_examples() {
     assert_that(p.cargo_process("bench").arg("-v"),
                 execs().with_status(0)
                        .with_stderr(&format!("\
-[COMPILING] testbench v6.6.6 ({url})
+[COMPILING] (release) testbench v6.6.6 ({url})
 [RUNNING] `rustc [..]`
 [RUNNING] `rustc [..]`
 [RUNNING] `rustc [..]`
@@ -902,7 +902,7 @@ fn test_a_bench() {
     assert_that(p.cargo_process("test"),
                 execs().with_status(0)
                        .with_stderr("\
-[COMPILING] foo v0.1.0 ([..])
+[COMPILING] (debug) foo v0.1.0 ([..])
 [RUNNING] target[..]debug[..]b-[..]")
                        .with_stdout("
 running 1 test
@@ -939,7 +939,7 @@ fn test_bench_no_run() {
     assert_that(p.cargo_process("bench").arg("--no-run"),
                 execs().with_status(0)
                        .with_stderr("\
-[COMPILING] foo v0.1.0 ([..])
+[COMPILING] (release) foo v0.1.0 ([..])
 "));
 }
 

--- a/tests/build-lib.rs
+++ b/tests/build-lib.rs
@@ -8,7 +8,7 @@ use hamcrest::{assert_that};
 
 fn verbose_output_for_lib(p: &ProjectBuilder) -> String {
     format!("\
-[COMPILING] {name} v{version} ({url})
+[COMPILING] (debug) {name} v{version} ({url})
 [RUNNING] `rustc src{sep}lib.rs --crate-name {name} --crate-type lib -g \
         --out-dir {dir}{sep}target{sep}debug \
         --emit=dep-info,link \

--- a/tests/build-script.rs
+++ b/tests/build-script.rs
@@ -32,7 +32,7 @@ fn custom_build_script_failed() {
     assert_that(p.cargo_process("build").arg("-v"),
                 execs().with_status(101)
                        .with_stderr(&format!("\
-[COMPILING] foo v0.5.0 ({url})
+[COMPILING] (debug) foo v0.5.0 ({url})
 [RUNNING] `rustc build.rs --crate-name build_script_build --crate-type bin [..]`
 [RUNNING] `[..]build-script-build[..]`
 [ERROR] failed to run custom build command for `foo v0.5.0 ({url})`
@@ -183,7 +183,7 @@ fn custom_build_script_rustc_flags() {
     assert_that(p.cargo_process("build").arg("--verbose"),
                 execs().with_status(101)
                        .with_stderr(&format!("\
-[COMPILING] bar v0.5.0 ({url})
+[COMPILING] (debug) bar v0.5.0 ({url})
 [RUNNING] `rustc {dir}{sep}src{sep}lib.rs --crate-name test --crate-type lib -g \
         -C metadata=[..] \
         -C extra-filename=-[..] \
@@ -405,7 +405,7 @@ fn only_rerun_build_script() {
     assert_that(p.cargo("build").arg("-v"),
                 execs().with_status(0)
                        .with_stderr("\
-[COMPILING] foo v0.5.0 (file://[..])
+[COMPILING] (debug) foo v0.5.0 (file://[..])
 [RUNNING] `[..]build-script-build[..]`
 [RUNNING] `rustc [..] --crate-name foo [..]`
 "));
@@ -492,7 +492,7 @@ fn testing_and_such() {
     assert_that(p.cargo("test").arg("-vj1"),
                 execs().with_status(0)
                        .with_stderr("\
-[COMPILING] foo v0.5.0 (file://[..])
+[COMPILING] (debug) foo v0.5.0 (file://[..])
 [RUNNING] `[..]build-script-build[..]`
 [RUNNING] `rustc [..] --crate-name foo [..]`
 [RUNNING] `rustc [..] --crate-name foo [..]`
@@ -525,7 +525,7 @@ test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
     assert_that(p.cargo("run"),
                 execs().with_status(0)
                        .with_stderr("\
-[COMPILING] foo v0.5.0 (file://[..])
+[COMPILING] (debug) foo v0.5.0 (file://[..])
 [RUNNING] `target[..]foo[..]`
 "));
 }
@@ -579,7 +579,7 @@ fn propagation_of_l_flags() {
                 execs().with_status(0)
                        .with_stderr_contains("\
 [RUNNING] `rustc [..] --crate-name a [..]-L bar[..]-L foo[..]`
-[COMPILING] foo v0.5.0 (file://[..])
+[COMPILING] (debug) foo v0.5.0 (file://[..])
 [RUNNING] `rustc [..] --crate-name foo [..] -L bar -L foo`
 "));
 }
@@ -633,7 +633,7 @@ fn propagation_of_l_flags_new() {
                 execs().with_status(0)
                        .with_stderr_contains("\
 [RUNNING] `rustc [..] --crate-name a [..]-L bar[..]-L foo[..]`
-[COMPILING] foo v0.5.0 (file://[..])
+[COMPILING] (debug) foo v0.5.0 (file://[..])
 [RUNNING] `rustc [..] --crate-name foo [..] -L bar -L foo`
 "));
 }
@@ -666,9 +666,9 @@ fn build_deps_simple() {
     assert_that(p.cargo_process("build").arg("-v"),
                 execs().with_status(0)
                        .with_stderr("\
-[COMPILING] a v0.5.0 (file://[..])
+[COMPILING] (debug) a v0.5.0 (file://[..])
 [RUNNING] `rustc [..] --crate-name a [..]`
-[COMPILING] foo v0.5.0 (file://[..])
+[COMPILING] (debug) foo v0.5.0 (file://[..])
 [RUNNING] `rustc build.rs [..] --extern a=[..]`
 [RUNNING] `[..]foo-[..]build-script-build[..]`
 [RUNNING] `rustc [..] --crate-name foo [..]`
@@ -755,16 +755,16 @@ fn build_cmd_with_a_build_cmd() {
     assert_that(p.cargo_process("build").arg("-v"),
                 execs().with_status(0)
                        .with_stderr("\
-[COMPILING] b v0.5.0 (file://[..])
+[COMPILING] (debug) b v0.5.0 (file://[..])
 [RUNNING] `rustc [..] --crate-name b [..]`
-[COMPILING] a v0.5.0 (file://[..])
+[COMPILING] (debug) a v0.5.0 (file://[..])
 [RUNNING] `rustc a[..]build.rs [..] --extern b=[..]`
 [RUNNING] `[..]a-[..]build-script-build[..]`
 [RUNNING] `rustc [..]lib.rs --crate-name a --crate-type lib -g \
     -C metadata=[..] -C extra-filename=-[..] \
     --out-dir [..]target[..]deps --emit=dep-info,link \
     -L [..]target[..]deps -L [..]target[..]deps`
-[COMPILING] foo v0.5.0 (file://[..])
+[COMPILING] (debug) foo v0.5.0 (file://[..])
 [RUNNING] `rustc build.rs --crate-name build_script_build --crate-type bin \
     -g \
     --out-dir [..]build[..]foo-[..] --emit=dep-info,link \
@@ -846,12 +846,11 @@ fn output_separate_lines() {
     assert_that(p.cargo_process("build").arg("-v"),
                 execs().with_status(101)
                        .with_stderr_contains("\
-[COMPILING] foo v0.5.0 (file://[..])
+[COMPILING] (debug) foo v0.5.0 (file://[..])
 [RUNNING] `rustc build.rs [..]`
 [RUNNING] `[..]foo-[..]build-script-build[..]`
 [RUNNING] `rustc [..] --crate-name foo [..] -L foo -l static=foo`
 [ERROR] could not find native static library [..]
-[ERROR] Could not compile [..]
 "));
 }
 
@@ -875,12 +874,11 @@ fn output_separate_lines_new() {
     assert_that(p.cargo_process("build").arg("-v"),
                 execs().with_status(101)
                        .with_stderr_contains("\
-[COMPILING] foo v0.5.0 (file://[..])
+[COMPILING] (debug) foo v0.5.0 (file://[..])
 [RUNNING] `rustc build.rs [..]`
 [RUNNING] `[..]foo-[..]build-script-build[..]`
 [RUNNING] `rustc [..] --crate-name foo [..] -L foo -l static=foo`
 [ERROR] could not find native static library [..]
-[ERROR] Could not compile [..]
 "));
 }
 
@@ -921,7 +919,7 @@ fn code_generation() {
     assert_that(p.cargo_process("run"),
                 execs().with_status(0)
                        .with_stderr("\
-[COMPILING] foo v0.5.0 (file://[..])
+[COMPILING] (debug) foo v0.5.0 (file://[..])
 [RUNNING] `target[..]foo`")
                        .with_stdout("\
 Hello, World!
@@ -1357,7 +1355,7 @@ fn cfg_test() {
         "#);
     assert_that(p.cargo_process("test").arg("-v"),
                 execs().with_stderr(format!("\
-[COMPILING] foo v0.0.1 ({dir})
+[COMPILING] (debug) foo v0.0.1 ({dir})
 [RUNNING] [..] build.rs [..]
 [RUNNING] [..]build-script-build[..]
 [RUNNING] [..] --cfg foo[..]
@@ -1475,7 +1473,7 @@ fn cfg_override_test() {
         "#);
     assert_that(p.cargo_process("test").arg("-v"),
                 execs().with_stderr(format!("\
-[COMPILING] foo v0.0.1 ({dir})
+[COMPILING] (debug) foo v0.0.1 ({dir})
 [RUNNING] `[..]`
 [RUNNING] `[..]`
 [RUNNING] `[..]`
@@ -1589,13 +1587,13 @@ fn flags_go_into_tests() {
     assert_that(p.cargo_process("test").arg("-v").arg("--test=foo"),
                 execs().with_status(0)
                        .with_stderr("\
-[COMPILING] a v0.5.0 ([..]
+[COMPILING] (debug) a v0.5.0 ([..]
 [RUNNING] `rustc a[..]build.rs [..]`
 [RUNNING] `[..]build-script-build[..]`
 [RUNNING] `rustc a[..]src[..]lib.rs [..] -L test[..]`
-[COMPILING] b v0.5.0 ([..]
+[COMPILING] (debug) b v0.5.0 ([..]
 [RUNNING] `rustc b[..]src[..]lib.rs [..] -L test[..]`
-[COMPILING] foo v0.5.0 ([..]
+[COMPILING] (debug) foo v0.5.0 ([..]
 [RUNNING] `rustc src[..]lib.rs [..] -L test[..]`
 [RUNNING] `rustc tests[..]foo.rs [..] -L test[..]`
 [RUNNING] `[..]foo-[..]`")
@@ -1610,7 +1608,7 @@ test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
                 execs().with_status(0)
                        .with_stderr("\
 [FRESH] a v0.5.0 ([..]
-[COMPILING] b v0.5.0 ([..]
+[COMPILING] (debug) b v0.5.0 ([..]
 [RUNNING] `rustc b[..]src[..]lib.rs [..] -L test[..]`
 [RUNNING] `[..]b-[..]`")
                        .with_stdout("
@@ -1671,15 +1669,15 @@ fn diamond_passes_args_only_once() {
 
     assert_that(p.cargo_process("build").arg("-v"),
                 execs().with_status(0).with_stderr("\
-[COMPILING] c v0.5.0 ([..]
+[COMPILING] (debug) c v0.5.0 ([..]
 [RUNNING] `rustc [..]`
 [RUNNING] `[..]`
 [RUNNING] `rustc [..]`
-[COMPILING] b v0.5.0 ([..]
+[COMPILING] (debug) b v0.5.0 ([..]
 [RUNNING] `rustc [..]`
-[COMPILING] a v0.5.0 ([..]
+[COMPILING] (debug) a v0.5.0 ([..]
 [RUNNING] `rustc [..]`
-[COMPILING] foo v0.5.0 ([..]
+[COMPILING] (debug) foo v0.5.0 ([..]
 [RUNNING] `[..]rlib -L native=test`
 "));
 }
@@ -1706,7 +1704,7 @@ fn adding_an_override_invalidates() {
 
     assert_that(p.cargo_process("build").arg("-v"),
                 execs().with_status(0).with_stderr("\
-[COMPILING] foo v0.5.0 ([..]
+[COMPILING] (debug) foo v0.5.0 ([..]
 [RUNNING] `rustc [..]`
 [RUNNING] `[..]`
 [RUNNING] `rustc [..] -L native=foo`
@@ -1719,7 +1717,7 @@ fn adding_an_override_invalidates() {
 
     assert_that(p.cargo("build").arg("-v"),
                 execs().with_status(0).with_stderr("\
-[COMPILING] foo v0.5.0 ([..]
+[COMPILING] (debug) foo v0.5.0 ([..]
 [RUNNING] `rustc [..] -L native=bar`
 "));
 }
@@ -1745,7 +1743,7 @@ fn changing_an_override_invalidates() {
 
     assert_that(p.cargo_process("build").arg("-v"),
                 execs().with_status(0).with_stderr("\
-[COMPILING] foo v0.5.0 ([..]
+[COMPILING] (debug) foo v0.5.0 ([..]
 [RUNNING] `rustc [..] -L native=foo`
 "));
 
@@ -1756,7 +1754,7 @@ fn changing_an_override_invalidates() {
 
     assert_that(p.cargo("build").arg("-v"),
                 execs().with_status(0).with_stderr("\
-[COMPILING] foo v0.5.0 ([..]
+[COMPILING] (debug) foo v0.5.0 ([..]
 [RUNNING] `rustc [..] -L native=bar`
 "));
 }
@@ -1787,7 +1785,7 @@ fn rebuild_only_on_explicit_paths() {
     println!("run without");
     assert_that(p.cargo("build").arg("-v"),
                 execs().with_status(0).with_stderr("\
-[COMPILING] a v0.5.0 ([..])
+[COMPILING] (debug) a v0.5.0 ([..])
 [RUNNING] `[..]build-script-build[..]`
 [RUNNING] `rustc src[..]lib.rs [..]`
 "));
@@ -1800,7 +1798,7 @@ fn rebuild_only_on_explicit_paths() {
     println!("run with");
     assert_that(p.cargo("build").arg("-v"),
                 execs().with_status(0).with_stderr("\
-[COMPILING] a v0.5.0 ([..])
+[COMPILING] (debug) a v0.5.0 ([..])
 [RUNNING] `[..]build-script-build[..]`
 [RUNNING] `rustc src[..]lib.rs [..]`
 "));
@@ -1826,7 +1824,7 @@ fn rebuild_only_on_explicit_paths() {
     File::create(p.root().join("foo")).unwrap();
     assert_that(p.cargo("build").arg("-v"),
                 execs().with_status(0).with_stderr("\
-[COMPILING] a v0.5.0 ([..])
+[COMPILING] (debug) a v0.5.0 ([..])
 [RUNNING] `[..]build-script-build[..]`
 [RUNNING] `rustc src[..]lib.rs [..]`
 "));
@@ -1836,7 +1834,7 @@ fn rebuild_only_on_explicit_paths() {
     fs::remove_file(p.root().join("bar")).unwrap();
     assert_that(p.cargo("build").arg("-v"),
                 execs().with_status(0).with_stderr("\
-[COMPILING] a v0.5.0 ([..])
+[COMPILING] (debug) a v0.5.0 ([..])
 [RUNNING] `[..]build-script-build[..]`
 [RUNNING] `rustc src[..]lib.rs [..]`
 "));
@@ -2047,7 +2045,7 @@ fn warnings_emitted() {
     assert_that(p.cargo_process("build").arg("-v"),
                 execs().with_status(0)
                        .with_stderr("\
-[COMPILING] foo v0.5.0 ([..])
+[COMPILING] (debug) foo v0.5.0 ([..])
 [RUNNING] `rustc [..]`
 [RUNNING] `[..]`
 warning: foo
@@ -2092,11 +2090,11 @@ fn warnings_hidden_for_upstream() {
                        .with_stderr("\
 [UPDATING] registry `[..]`
 [DOWNLOADING] bar v0.1.0 ([..])
-[COMPILING] bar v0.1.0 ([..])
+[COMPILING] (debug) bar v0.1.0 ([..])
 [RUNNING] `rustc [..]`
 [RUNNING] `[..]`
 [RUNNING] `rustc [..]`
-[COMPILING] foo v0.5.0 ([..])
+[COMPILING] (debug) foo v0.5.0 ([..])
 [RUNNING] `rustc [..]`
 "));
 }
@@ -2137,13 +2135,13 @@ fn warnings_printed_on_vv() {
                        .with_stderr("\
 [UPDATING] registry `[..]`
 [DOWNLOADING] bar v0.1.0 ([..])
-[COMPILING] bar v0.1.0 ([..])
+[COMPILING] (debug) bar v0.1.0 ([..])
 [RUNNING] `rustc [..]`
 [RUNNING] `[..]`
 warning: foo
 warning: bar
 [RUNNING] `rustc [..]`
-[COMPILING] foo v0.5.0 ([..])
+[COMPILING] (debug) foo v0.5.0 ([..])
 [RUNNING] `rustc [..]`
 "));
 }
@@ -2174,7 +2172,7 @@ fn output_shows_on_vv() {
 stdout
 ")
                        .with_stderr("\
-[COMPILING] foo v0.5.0 ([..])
+[COMPILING] (debug) foo v0.5.0 ([..])
 [RUNNING] `rustc [..]`
 [RUNNING] `[..]`
 stderr

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -903,7 +903,7 @@ fn unused_keys() {
                 execs().with_status(0)
                        .with_stderr("\
 warning: unused manifest key: project.bulid
-[COMPILING] foo [..]
+[COMPILING] (debug) foo [..]
 "));
 
     let mut p = project("bar");
@@ -927,7 +927,7 @@ warning: unused manifest key: project.bulid
                 execs().with_status(0)
                        .with_stderr("\
 warning: unused manifest key: lib.build
-[COMPILING] foo [..]
+[COMPILING] (debug) foo [..]
 "));
 }
 
@@ -1018,7 +1018,7 @@ fn lto_build() {
         .file("src/main.rs", "fn main() {}");
     assert_that(p.cargo_process("build").arg("-v").arg("--release"),
                 execs().with_status(0).with_stderr(&format!("\
-[COMPILING] test v0.0.0 ({url})
+[COMPILING] (release) test v0.0.0 ({url})
 [RUNNING] `rustc src[..]main.rs --crate-name test --crate-type bin \
         -C opt-level=3 \
         -C lto \
@@ -1046,7 +1046,7 @@ fn verbose_build() {
         .file("src/lib.rs", "");
     assert_that(p.cargo_process("build").arg("-v"),
                 execs().with_status(0).with_stderr(&format!("\
-[COMPILING] test v0.0.0 ({url})
+[COMPILING] (debug) test v0.0.0 ({url})
 [RUNNING] `rustc src[..]lib.rs --crate-name test --crate-type lib -g \
         --out-dir {dir}[..]target[..]debug \
         --emit=dep-info,link \
@@ -1072,7 +1072,7 @@ fn verbose_release_build() {
         .file("src/lib.rs", "");
     assert_that(p.cargo_process("build").arg("-v").arg("--release"),
                 execs().with_status(0).with_stderr(&format!("\
-[COMPILING] test v0.0.0 ({url})
+[COMPILING] (release) test v0.0.0 ({url})
 [RUNNING] `rustc src[..]lib.rs --crate-name test --crate-type lib \
         -C opt-level=3 \
         --out-dir {dir}[..]target[..]release \
@@ -1114,7 +1114,7 @@ fn verbose_release_build_deps() {
         .file("foo/src/lib.rs", "");
     assert_that(p.cargo_process("build").arg("-v").arg("--release"),
                 execs().with_status(0).with_stderr(&format!("\
-[COMPILING] foo v0.0.0 ({url}/foo)
+[COMPILING] (release) foo v0.0.0 ({url}/foo)
 [RUNNING] `rustc foo[..]src[..]lib.rs --crate-name foo \
         --crate-type dylib --crate-type rlib -C prefer-dynamic \
         -C opt-level=3 \
@@ -1124,7 +1124,7 @@ fn verbose_release_build_deps() {
         --emit=dep-info,link \
         -L dependency={dir}[..]target[..]release[..]deps \
         -L dependency={dir}[..]target[..]release[..]deps`
-[COMPILING] test v0.0.0 ({url})
+[COMPILING] (release) test v0.0.0 ({url})
 [RUNNING] `rustc src[..]lib.rs --crate-name test --crate-type lib \
         -C opt-level=3 \
         --out-dir {dir}[..]target[..]release \
@@ -1345,7 +1345,7 @@ fn lib_with_standard_name() {
     assert_that(p.cargo_process("build"),
                 execs().with_status(0)
                        .with_stderr(&format!("\
-[COMPILING] syntax v0.0.1 ({dir})
+[COMPILING] (debug) syntax v0.0.1 ({dir})
 ",
                        dir = p.url())));
 }
@@ -1446,7 +1446,7 @@ fn freshness_ignores_excluded() {
     assert_that(foo.cargo("build"),
                 execs().with_status(0)
                        .with_stderr(&format!("\
-[COMPILING] foo v0.0.0 ({url})
+[COMPILING] (debug) foo v0.0.0 ({url})
 ", url = foo.url())));
 
     // Smoke test to make sure it doesn't compile again
@@ -1494,14 +1494,14 @@ fn rebuild_preserves_out_dir() {
     assert_that(foo.cargo("build").env("FIRST", "1"),
                 execs().with_status(0)
                        .with_stderr(&format!("\
-[COMPILING] foo v0.0.0 ({url})
+[COMPILING] (debug) foo v0.0.0 ({url})
 ", url = foo.url())));
 
     File::create(&foo.root().join("src/bar.rs")).unwrap();
     assert_that(foo.cargo("build"),
                 execs().with_status(0)
                        .with_stderr(&format!("\
-[COMPILING] foo v0.0.0 ({url})
+[COMPILING] (debug) foo v0.0.0 ({url})
 ", url = foo.url())));
 }
 
@@ -2232,7 +2232,7 @@ fn explicit_color_config_is_propagated_to_rustc() {
 
     assert_that(p.cargo_process("build").arg("-v").arg("--color").arg("never"),
                 execs().with_status(0).with_stderr("\
-[COMPILING] test v0.0.0 ([..])
+[COMPILING] (debug) test v0.0.0 ([..])
 [RUNNING] `rustc src[..]lib.rs --color never --crate-name test --crate-type lib -g \
         --out-dir [..]target[..]debug \
         --emit=dep-info,link \

--- a/tests/cargo_alias_config.rs
+++ b/tests/cargo_alias_config.rs
@@ -37,7 +37,7 @@ fn alias_default_config_overrides_config() {
 
     assert_that(p.cargo_process("b").arg("-v"),
                 execs().with_status(0).
-                with_stderr_contains("[COMPILING] foo v0.5.0 [..]"));
+                with_stderr_contains("[COMPILING] (debug) foo v0.5.0 [..]"));
 }
 
 #[test]
@@ -54,7 +54,7 @@ fn alias_config() {
 
     assert_that(p.cargo_process("b-cargo-test").arg("-v"),
                 execs().with_status(0).
-                with_stderr_contains("[COMPILING] foo v0.5.0 [..]
+                with_stderr_contains("[COMPILING] (debug) foo v0.5.0 [..]
 [RUNNING] `rustc [..] --crate-name foo --crate-type \
 bin -g --out-dir [..] --emit=dep-info,link -L dependency=[..]\
 -L dependency=[..]"));
@@ -74,7 +74,7 @@ fn alias_list_test() {
 
     assert_that(p.cargo_process("b-cargo-test").arg("-v"),
                 execs().with_status(0).
-                with_stderr_contains("[COMPILING] foo v0.5.0 [..]").
+                with_stderr_contains("[COMPILING] (release) foo v0.5.0 [..]").
                 with_stderr_contains("[RUNNING] `rustc [..] --crate-name foo \
                                      --crate-type bin -C opt-level=3 --out-dir [..]\
                                      --emit=dep-info,link -L dependency=[..]")
@@ -95,7 +95,7 @@ fn alias_with_flags_config() {
 
     assert_that(p.cargo_process("b-cargo-test").arg("-v"),
                 execs().with_status(0).
-                with_stderr_contains("[COMPILING] foo v0.5.0 [..]").
+                with_stderr_contains("[COMPILING] (release) foo v0.5.0 [..]").
                 with_stderr_contains("[RUNNING] `rustc [..] --crate-name foo \
                                      --crate-type bin -C opt-level=3 --out-dir [..]\
                                      --emit=dep-info,link -L dependency=[..]")

--- a/tests/cfg.rs
+++ b/tests/cfg.rs
@@ -189,7 +189,7 @@ fn dont_include() {
         .file("b/src/lib.rs", "");
     assert_that(p.cargo_process("build"),
                 execs().with_status(0).with_stderr("\
-[COMPILING] a v0.0.1 ([..])
+[COMPILING] (debug) a v0.0.1 ([..])
 "));
 }
 
@@ -220,9 +220,9 @@ fn works_through_the_registry() {
 [UPDATING] registry [..]
 [DOWNLOADING] [..]
 [DOWNLOADING] [..]
-[COMPILING] foo v0.1.0 ([..])
-[COMPILING] bar v0.1.0 ([..])
-[COMPILING] a v0.0.1 ([..])
+[COMPILING] (debug) foo v0.1.0 ([..])
+[COMPILING] (debug) bar v0.1.0 ([..])
+[COMPILING] (debug) a v0.0.1 ([..])
 "));
 }
 

--- a/tests/clean.rs
+++ b/tests/clean.rs
@@ -132,7 +132,7 @@ fn clean_release() {
                 execs().with_status(0));
     assert_that(p.cargo("build").arg("--release"),
                 execs().with_status(0).with_stderr("\
-[COMPILING] foo v0.0.1 ([..])
+[COMPILING] (release) foo v0.0.1 ([..])
 "));
 }
 
@@ -169,7 +169,7 @@ fn build_script() {
                 execs().with_status(0));
     assert_that(p.cargo("build").arg("-v"),
                 execs().with_status(0).with_stderr("\
-[COMPILING] foo v0.0.1 ([..])
+[COMPILING] (debug) foo v0.0.1 ([..])
 [RUNNING] `rustc build.rs [..]`
 [RUNNING] `[..]build-script-build[..]`
 [RUNNING] `rustc src[..]main.rs [..]`

--- a/tests/concurrent.rs
+++ b/tests/concurrent.rs
@@ -420,9 +420,9 @@ fn debug_release_ok() {
     let a = a.join().unwrap();
 
     assert_that(a, execs().with_status(0).with_stderr("\
-[COMPILING] foo v0.0.0 [..]
+[COMPILING] (debug) foo v0.0.0 [..]
 "));
     assert_that(b, execs().with_status(0).with_stderr("\
-[COMPILING] foo v0.0.0 [..]
+[COMPILING] (release) foo v0.0.0 [..]
 "));
 }

--- a/tests/cross-compile.rs
+++ b/tests/cross-compile.rs
@@ -356,7 +356,7 @@ fn linker_and_ar() {
                                               .arg("-v"),
                 execs().with_status(101)
                        .with_stderr_contains(&format!("\
-[COMPILING] foo v0.5.0 ({url})
+[COMPILING] (debug) foo v0.5.0 ({url})
 [RUNNING] `rustc src[..]foo.rs --crate-name foo --crate-type bin -g \
     --out-dir {dir}[..]target[..]{target}[..]debug \
     --emit=dep-info,link \
@@ -471,7 +471,7 @@ fn cross_tests() {
     assert_that(p.cargo_process("test").arg("--target").arg(&target),
                 execs().with_status(0)
                        .with_stderr(&format!("\
-[COMPILING] foo v0.0.0 ({foo})
+[COMPILING] (debug) foo v0.0.0 ({foo})
 [RUNNING] target[..]{triple}[..]bar-[..]
 [RUNNING] target[..]{triple}[..]foo-[..]", foo = p.url(), triple = target))
                        .with_stdout("
@@ -508,7 +508,7 @@ fn no_cross_doctests() {
         "#);
 
     let host_output = format!("\
-[COMPILING] foo v0.0.0 ({foo})
+[COMPILING] (debug) foo v0.0.0 ({foo})
 [RUNNING] target[..]foo-[..]
 [DOCTEST] foo
 ", foo = p.url());
@@ -529,7 +529,7 @@ fn no_cross_doctests() {
     assert_that(p.cargo_process("test").arg("--target").arg(&target),
                 execs().with_status(0)
                        .with_stderr(&format!("\
-[COMPILING] foo v0.0.0 ({foo})
+[COMPILING] (debug) foo v0.0.0 ({foo})
 [RUNNING] target[..]{triple}[..]foo-[..]
 ", foo = p.url(), triple = target)));
 }
@@ -595,7 +595,7 @@ fn cross_with_a_build_script() {
     assert_that(p.cargo_process("build").arg("--target").arg(&target).arg("-v"),
                 execs().with_status(0)
                        .with_stderr(&format!("\
-[COMPILING] foo v0.0.0 (file://[..])
+[COMPILING] (debug) foo v0.0.0 (file://[..])
 [RUNNING] `rustc build.rs [..] --out-dir {dir}[..]target[..]build[..]foo-[..]`
 [RUNNING] `{dir}[..]target[..]build[..]foo-[..]build-script-build`
 [RUNNING] `rustc src[..]main.rs [..] --target {target} [..]`
@@ -665,7 +665,7 @@ fn build_script_needed_for_host_and_target() {
     assert_that(p.cargo_process("build").arg("--target").arg(&target).arg("-v"),
                 execs().with_status(0)
                        .with_stderr_contains(&format!("\
-[COMPILING] d1 v0.0.0 ({url}/d1)", url = p.url()))
+[COMPILING] (debug) d1 v0.0.0 ({url}/d1)", url = p.url()))
                        .with_stderr_contains(&format!("\
 [RUNNING] `rustc d1[..]build.rs [..] --out-dir {dir}[..]target[..]build[..]d1-[..]`",
     dir = p.root().display()))
@@ -675,12 +675,12 @@ fn build_script_needed_for_host_and_target() {
                        .with_stderr_contains("\
 [RUNNING] `rustc d1[..]src[..]lib.rs [..]`")
                        .with_stderr_contains(&format!("\
-[COMPILING] d2 v0.0.0 ({url}/d2)", url = p.url()))
+[COMPILING] (debug) d2 v0.0.0 ({url}/d2)", url = p.url()))
                        .with_stderr_contains(&format!("\
 [RUNNING] `rustc d2[..]src[..]lib.rs [..] \
            -L /path/to/{host}`", host = host))
                        .with_stderr_contains(&format!("\
-[COMPILING] foo v0.0.0 ({url})", url = p.url()))
+[COMPILING] (debug) foo v0.0.0 ({url})", url = p.url()))
                        .with_stderr_contains(&format!("\
 [RUNNING] `rustc build.rs [..] --out-dir {dir}[..]target[..]build[..]foo-[..] \
            -L /path/to/{host}`", dir = p.root().display(), host = host))
@@ -794,7 +794,7 @@ fn plugin_build_script_right_arch() {
     assert_that(p.cargo_process("build").arg("-v").arg("--target").arg(alternate()),
                 execs().with_status(0)
                        .with_stderr("\
-[COMPILING] foo v0.0.1 ([..])
+[COMPILING] (debug) foo v0.0.1 ([..])
 [RUNNING] `rustc build.rs [..]`
 [RUNNING] `[..]build-script-build[..]`
 [RUNNING] `rustc src[..]lib.rs [..]`
@@ -841,11 +841,11 @@ fn build_script_with_platform_specific_dependencies() {
     assert_that(p.cargo_process("build").arg("-v").arg("--target").arg(&target),
                 execs().with_status(0)
                        .with_stderr(&format!("\
-[COMPILING] d2 v0.0.0 ([..])
+[COMPILING] (debug) d2 v0.0.0 ([..])
 [RUNNING] `rustc d2[..]src[..]lib.rs [..]`
-[COMPILING] d1 v0.0.0 ([..])
+[COMPILING] (debug) d1 v0.0.0 ([..])
 [RUNNING] `rustc d1[..]src[..]lib.rs [..]`
-[COMPILING] foo v0.0.1 ([..])
+[COMPILING] (debug) foo v0.0.1 ([..])
 [RUNNING] `rustc build.rs [..]`
 [RUNNING] `{dir}[..]target[..]build[..]foo-[..]build-script-build`
 [RUNNING] `rustc src[..]lib.rs [..] --target {target} [..]`

--- a/tests/doc.rs
+++ b/tests/doc.rs
@@ -152,7 +152,7 @@ fn doc_no_deps() {
 
     assert_that(p.cargo_process("doc").arg("--no-deps"),
                 execs().with_status(0).with_stderr(&format!("\
-[COMPILING] bar v0.0.1 ({dir}/bar)
+[COMPILING] (debug) bar v0.0.1 ({dir}/bar)
 [DOCUMENTING] foo v0.0.1 ({dir})
 ",
         dir = path2url(p.root()))));

--- a/tests/features.rs
+++ b/tests/features.rs
@@ -306,15 +306,15 @@ fn no_feature_doesnt_build() {
 
     assert_that(p.cargo_process("build"),
                 execs().with_status(0).with_stderr(format!("\
-[COMPILING] foo v0.0.1 ({dir})
+[COMPILING] (debug) foo v0.0.1 ({dir})
 ", dir = p.url())));
     assert_that(p.process(&p.bin("foo")),
                 execs().with_status(0).with_stdout(""));
 
     assert_that(p.cargo("build").arg("--features").arg("bar"),
                 execs().with_status(0).with_stderr(format!("\
-[COMPILING] bar v0.0.1 ({dir}/bar)
-[COMPILING] foo v0.0.1 ({dir})
+[COMPILING] (debug) bar v0.0.1 ({dir}/bar)
+[COMPILING] (debug) foo v0.0.1 ({dir})
 ", dir = p.url())));
     assert_that(p.process(&p.bin("foo")),
                 execs().with_status(0).with_stdout("bar\n"));
@@ -354,15 +354,15 @@ fn default_feature_pulled_in() {
 
     assert_that(p.cargo_process("build"),
                 execs().with_status(0).with_stderr(format!("\
-[COMPILING] bar v0.0.1 ({dir}/bar)
-[COMPILING] foo v0.0.1 ({dir})
+[COMPILING] (debug) bar v0.0.1 ({dir}/bar)
+[COMPILING] (debug) foo v0.0.1 ({dir})
 ", dir = p.url())));
     assert_that(p.process(&p.bin("foo")),
                 execs().with_status(0).with_stdout("bar\n"));
 
     assert_that(p.cargo("build").arg("--no-default-features"),
                 execs().with_status(0).with_stderr(format!("\
-[COMPILING] foo v0.0.1 ({dir})
+[COMPILING] (debug) foo v0.0.1 ({dir})
 ", dir = p.url())));
     assert_that(p.process(&p.bin("foo")),
                 execs().with_status(0).with_stdout(""));
@@ -458,9 +458,9 @@ fn groups_on_groups_on_groups() {
 
     assert_that(p.cargo_process("build"),
                 execs().with_status(0).with_stderr(format!("\
-[COMPILING] ba[..] v0.0.1 ({dir}/ba[..])
-[COMPILING] ba[..] v0.0.1 ({dir}/ba[..])
-[COMPILING] foo v0.0.1 ({dir})
+[COMPILING] (debug) ba[..] v0.0.1 ({dir}/ba[..])
+[COMPILING] (debug) ba[..] v0.0.1 ({dir}/ba[..])
+[COMPILING] (debug) foo v0.0.1 ({dir})
 ", dir = p.url())));
 }
 
@@ -503,9 +503,9 @@ fn many_cli_features() {
 
     assert_that(p.cargo_process("build").arg("--features").arg("bar baz"),
                 execs().with_status(0).with_stderr(format!("\
-[COMPILING] ba[..] v0.0.1 ({dir}/ba[..])
-[COMPILING] ba[..] v0.0.1 ({dir}/ba[..])
-[COMPILING] foo v0.0.1 ({dir})
+[COMPILING] (debug) ba[..] v0.0.1 ({dir}/ba[..])
+[COMPILING] (debug) ba[..] v0.0.1 ({dir}/ba[..])
+[COMPILING] (debug) foo v0.0.1 ({dir})
 ", dir = p.url())));
 }
 
@@ -565,9 +565,9 @@ fn union_features() {
 
     assert_that(p.cargo_process("build"),
                 execs().with_status(0).with_stderr(format!("\
-[COMPILING] d2 v0.0.1 ({dir}/d2)
-[COMPILING] d1 v0.0.1 ({dir}/d1)
-[COMPILING] foo v0.0.1 ({dir})
+[COMPILING] (debug) d2 v0.0.1 ({dir}/d2)
+[COMPILING] (debug) d1 v0.0.1 ({dir}/d1)
+[COMPILING] (debug) foo v0.0.1 ({dir})
 ", dir = p.url())));
 }
 
@@ -600,8 +600,8 @@ fn many_features_no_rebuilds() {
 
     assert_that(p.cargo_process("build"),
                 execs().with_status(0).with_stderr(format!("\
-[COMPILING] a v0.1.0 ({dir}/a)
-[COMPILING] b v0.1.0 ({dir})
+[COMPILING] (debug) a v0.1.0 ({dir}/a)
+[COMPILING] (debug) b v0.1.0 ({dir})
 ", dir = p.url())));
     p.root().move_into_the_past();
 
@@ -839,7 +839,7 @@ fn optional_and_dev_dep() {
 
     assert_that(p.cargo_process("build"),
                 execs().with_status(0).with_stderr("\
-[COMPILING] test v0.1.0 ([..])
+[COMPILING] (debug) test v0.1.0 ([..])
 "));
 }
 

--- a/tests/freshness.rs
+++ b/tests/freshness.rs
@@ -25,7 +25,7 @@ fn modifying_and_moving() {
 
     assert_that(p.cargo_process("build"),
                 execs().with_status(0).with_stderr(format!("\
-[COMPILING] foo v0.0.1 ({dir})
+[COMPILING] (debug) foo v0.0.1 ({dir})
 ", dir = path2url(p.root()))));
 
     assert_that(p.cargo("build"),
@@ -37,7 +37,7 @@ fn modifying_and_moving() {
          .write_all(b"#[allow(unused)]fn main() {}").unwrap();
     assert_that(p.cargo("build"),
                 execs().with_status(0).with_stderr(format!("\
-[COMPILING] foo v0.0.1 ({dir})
+[COMPILING] (debug) foo v0.0.1 ({dir})
 ", dir = path2url(p.root()))));
 
     fs::rename(&p.root().join("src/a.rs"), &p.root().join("src/b.rs")).unwrap();
@@ -65,7 +65,7 @@ fn modify_only_some_files() {
 
     assert_that(p.cargo_process("build"),
                 execs().with_status(0).with_stderr(format!("\
-[COMPILING] foo v0.0.1 ({dir})
+[COMPILING] (debug) foo v0.0.1 ({dir})
 ", dir = path2url(p.root()))));
     assert_that(p.cargo("test"),
                 execs().with_status(0));
@@ -83,7 +83,7 @@ fn modify_only_some_files() {
     // Make sure the binary is rebuilt, not the lib
     assert_that(p.cargo("build"),
                 execs().with_status(0).with_stderr(format!("\
-[COMPILING] foo v0.0.1 ({dir})
+[COMPILING] (debug) foo v0.0.1 ({dir})
 ", dir = path2url(p.root()))));
     assert_that(&p.bin("foo"), existing_file());
 }
@@ -157,19 +157,19 @@ fn changing_features_is_ok() {
     assert_that(p.cargo_process("build"),
                 execs().with_status(0)
                        .with_stderr("\
-[..]Compiling foo v0.0.1 ([..])
+[..]Compiling (debug) foo v0.0.1 ([..])
 "));
 
     assert_that(p.cargo("build").arg("--features").arg("foo"),
                 execs().with_status(0)
                        .with_stderr("\
-[..]Compiling foo v0.0.1 ([..])
+[..]Compiling (debug) foo v0.0.1 ([..])
 "));
 
     assert_that(p.cargo("build"),
                 execs().with_status(0)
                        .with_stderr("\
-[..]Compiling foo v0.0.1 ([..])
+[..]Compiling (debug) foo v0.0.1 ([..])
 "));
 
     assert_that(p.cargo("build"),
@@ -257,9 +257,9 @@ fn no_rebuild_transitive_target_deps() {
     assert_that(p.cargo("test").arg("--no-run"),
                 execs().with_status(0)
                        .with_stderr("\
-[COMPILING] c v0.0.1 ([..])
-[COMPILING] b v0.0.1 ([..])
-[COMPILING] foo v0.0.1 ([..])
+[COMPILING] (debug) c v0.0.1 ([..])
+[COMPILING] (debug) b v0.0.1 ([..])
+[COMPILING] (debug) foo v0.0.1 ([..])
 "));
 }
 
@@ -350,13 +350,13 @@ fn same_build_dir_cached_packages() {
 
     assert_that(p.cargo("build").cwd(p.root().join("a1")),
                 execs().with_status(0).with_stderr(&format!("\
-[COMPILING] d v0.0.1 ({dir}/d)
-[COMPILING] c v0.0.1 ({dir}/c)
-[COMPILING] b v0.0.1 ({dir}/b)
-[COMPILING] a1 v0.0.1 ({dir}/a1)
+[COMPILING] (debug) d v0.0.1 ({dir}/d)
+[COMPILING] (debug) c v0.0.1 ({dir}/c)
+[COMPILING] (debug) b v0.0.1 ({dir}/b)
+[COMPILING] (debug) a1 v0.0.1 ({dir}/a1)
 ", dir = p.url())));
     assert_that(p.cargo("build").cwd(p.root().join("a2")),
                 execs().with_status(0).with_stderr(&format!("\
-[COMPILING] a2 v0.0.1 ({dir}/a2)
+[COMPILING] (debug) a2 v0.0.1 ({dir}/a2)
 ", dir = p.url())));
 }

--- a/tests/git.rs
+++ b/tests/git.rs
@@ -60,8 +60,8 @@ fn cargo_compile_simple_git_dep() {
     assert_that(project.cargo_process("build"),
         execs()
         .with_stderr(&format!("[UPDATING] git repository `{}`\n\
-                              [COMPILING] dep1 v0.5.0 ({}#[..])\n\
-                              [COMPILING] foo v0.5.0 ({})\n",
+                              [COMPILING] (debug) dep1 v0.5.0 ({}#[..])\n\
+                              [COMPILING] (debug) foo v0.5.0 ({})\n",
                              path2url(git_root.clone()),
                              path2url(git_root),
                              path2url(root))));
@@ -127,8 +127,8 @@ fn cargo_compile_git_dep_branch() {
     assert_that(project.cargo_process("build"),
         execs()
         .with_stderr(&format!("[UPDATING] git repository `{}`\n\
-                              [COMPILING] dep1 v0.5.0 ({}?branch=branchy#[..])\n\
-                              [COMPILING] foo v0.5.0 ({})\n",
+                              [COMPILING] (debug) dep1 v0.5.0 ({}?branch=branchy#[..])\n\
+                              [COMPILING] (debug) foo v0.5.0 ({})\n",
                              path2url(git_root.clone()),
                              path2url(git_root),
                              path2url(root))));
@@ -197,8 +197,8 @@ fn cargo_compile_git_dep_tag() {
     assert_that(project.cargo_process("build"),
         execs()
         .with_stderr(&format!("[UPDATING] git repository `{}`\n\
-                              [COMPILING] dep1 v0.5.0 ({}?tag=v0.1.0#[..])\n\
-                              [COMPILING] foo v0.5.0 ({})\n",
+                              [COMPILING] (debug) dep1 v0.5.0 ({}?tag=v0.1.0#[..])\n\
+                              [COMPILING] (debug) foo v0.5.0 ({})\n",
                              path2url(git_root.clone()),
                              path2url(git_root),
                              path2url(root))));
@@ -505,8 +505,8 @@ fn recompilation() {
     // First time around we should compile both foo and bar
     assert_that(p.cargo_process("build"),
                 execs().with_stderr(&format!("[UPDATING] git repository `{}`\n\
-                                             [COMPILING] bar v0.5.0 ({}#[..])\n\
-                                             [COMPILING] foo v0.5.0 ({})\n",
+                                             [COMPILING] (debug) bar v0.5.0 ({}#[..])\n\
+                                             [COMPILING] (debug) foo v0.5.0 ({})\n",
                                             git_project.url(),
                                             git_project.url(),
                                             p.url())));
@@ -549,8 +549,8 @@ fn recompilation() {
                                             git_project.url())));
     println!("going for the last compile");
     assert_that(p.cargo("build"),
-                execs().with_stderr(&format!("[COMPILING] bar v0.5.0 ({}#[..])\n\
-                                             [COMPILING] foo v0.5.0 ({})\n",
+                execs().with_stderr(&format!("[COMPILING] (debug) bar v0.5.0 ({}#[..])\n\
+                                             [COMPILING] (debug) foo v0.5.0 ({})\n",
                                             git_project.url(),
                                             p.url())));
 
@@ -559,7 +559,7 @@ fn recompilation() {
                  .arg("-p").arg("foo"),
                 execs().with_stdout(""));
     assert_that(p.cargo("build"),
-                execs().with_stderr(&format!("[COMPILING] foo v0.5.0 ({})\n",
+                execs().with_stderr(&format!("[COMPILING] (debug) foo v0.5.0 ({})\n",
                                             p.url())));
 }
 
@@ -626,10 +626,10 @@ fn update_with_shared_deps() {
     assert_that(p.cargo_process("build"),
                 execs().with_stderr(&format!("\
 [UPDATING] git repository `{git}`
-[COMPILING] bar v0.5.0 ({git}#[..])
-[COMPILING] [..] v0.5.0 ([..])
-[COMPILING] [..] v0.5.0 ([..])
-[COMPILING] foo v0.5.0 ({dir})\n", git = git_project.url(), dir = p.url())));
+[COMPILING] (debug) bar v0.5.0 ({git}#[..])
+[COMPILING] (debug) [..] v0.5.0 ([..])
+[COMPILING] (debug) [..] v0.5.0 ([..])
+[COMPILING] (debug) foo v0.5.0 ({dir})\n", git = git_project.url(), dir = p.url())));
 
     // Modify a file manually, and commit it
     File::create(&git_project.root().join("src/bar.rs")).unwrap().write_all(br#"
@@ -681,10 +681,10 @@ To learn more, run the command again with --verbose.
     println!("build");
     assert_that(p.cargo("build"),
                 execs().with_stderr(&format!("\
-[COMPILING] bar v0.5.0 ({git}#[..])
-[COMPILING] [..] v0.5.0 ({dir}[..]dep[..])
-[COMPILING] [..] v0.5.0 ({dir}[..]dep[..])
-[COMPILING] foo v0.5.0 ({dir})\n",
+[COMPILING] (debug) bar v0.5.0 ({git}#[..])
+[COMPILING] (debug) [..] v0.5.0 ({dir}[..]dep[..])
+[COMPILING] (debug) [..] v0.5.0 ({dir}[..]dep[..])
+[COMPILING] (debug) foo v0.5.0 ({dir})\n",
                     git = git_project.url(), dir = p.url())));
 
     // We should be able to update transitive deps
@@ -734,8 +734,8 @@ fn dep_with_submodule() {
     assert_that(project.cargo_process("build"),
                 execs().with_stderr("\
 [UPDATING] git repository [..]
-[COMPILING] dep1 [..]
-[COMPILING] foo [..]").with_status(0));
+[COMPILING] (debug) dep1 [..]
+[COMPILING] (debug) foo [..]").with_status(0));
 }
 
 #[test]
@@ -781,9 +781,9 @@ fn two_deps_only_update_one() {
         execs()
         .with_stderr(&format!("[UPDATING] git repository `[..]`\n\
                               [UPDATING] git repository `[..]`\n\
-                              [COMPILING] [..] v0.5.0 ([..])\n\
-                              [COMPILING] [..] v0.5.0 ([..])\n\
-                              [COMPILING] foo v0.5.0 ({})\n",
+                              [COMPILING] (debug) [..] v0.5.0 ([..])\n\
+                              [COMPILING] (debug) [..] v0.5.0 ([..])\n\
+                              [COMPILING] (debug) foo v0.5.0 ({})\n",
                              project.url())));
 
     File::create(&git1.root().join("src/lib.rs")).unwrap().write_all(br#"
@@ -866,8 +866,8 @@ fn stale_cached_version() {
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [UPDATING] git repository `{bar}`
-[COMPILING] bar v0.0.0 ({bar}#[..])
-[COMPILING] foo v0.0.0 ({foo})
+[COMPILING] (debug) bar v0.0.0 ({bar}#[..])
+[COMPILING] (debug) foo v0.0.0 ({foo})
 ", bar = bar.url(), foo = foo.url())));
     assert_that(foo.process(&foo.bin("foo")), execs().with_status(0));
 }
@@ -917,8 +917,8 @@ fn dep_with_changed_submodule() {
     println!("first run");
     assert_that(project.cargo_process("run"), execs()
                 .with_stderr("[UPDATING] git repository `[..]`\n\
-                                      [COMPILING] dep1 v0.5.0 ([..])\n\
-                                      [COMPILING] foo v0.5.0 ([..])\n\
+                                      [COMPILING] (debug) dep1 v0.5.0 ([..])\n\
+                                      [COMPILING] (debug) foo v0.5.0 ([..])\n\
                                       [RUNNING] `target[..]foo[..]`\n")
                 .with_stdout("project2\n")
                 .with_status(0));
@@ -957,8 +957,8 @@ fn dep_with_changed_submodule() {
 
     println!("last run");
     assert_that(project.cargo("run"), execs()
-                .with_stderr("[COMPILING] dep1 v0.5.0 ([..])\n\
-                                      [COMPILING] foo v0.5.0 ([..])\n\
+                .with_stderr("[COMPILING] (debug) dep1 v0.5.0 ([..])\n\
+                                      [COMPILING] (debug) foo v0.5.0 ([..])\n\
                                       [RUNNING] `target[..]foo[..]`\n")
                 .with_stdout("project3\n")
                 .with_status(0));
@@ -1005,15 +1005,15 @@ fn dev_deps_with_testing() {
     assert_that(p.cargo_process("build"),
         execs().with_stderr(&format!("\
 [UPDATING] git repository `{bar}`
-[COMPILING] foo v0.5.0 ({url})
+[COMPILING] (debug) foo v0.5.0 ({url})
 ", url = p.url(), bar = p2.url())));
 
     // Make sure we use the previous resolution of `bar` instead of updating it
     // a second time.
     assert_that(p.cargo("test"),
                 execs().with_stderr("\
-[COMPILING] [..] v0.5.0 ([..])
-[COMPILING] [..] v0.5.0 ([..]
+[COMPILING] (debug) [..] v0.5.0 ([..])
+[COMPILING] (debug) [..] v0.5.0 ([..]
 [RUNNING] target[..]foo-[..]")
                        .with_stdout("
 running 1 test
@@ -1047,7 +1047,7 @@ fn git_build_cmd_freshness() {
     assert_that(foo.cargo("build"),
                 execs().with_status(0)
                        .with_stderr(&format!("\
-[COMPILING] foo v0.0.0 ({url})
+[COMPILING] (debug) foo v0.0.0 ({url})
 ", url = foo.url())));
 
     // Smoke test to make sure it doesn't compile again
@@ -1100,7 +1100,7 @@ fn git_name_not_always_needed() {
     assert_that(p.cargo_process("build"),
         execs().with_stderr(&format!("\
 [UPDATING] git repository `{bar}`
-[COMPILING] foo v0.5.0 ({url})
+[COMPILING] (debug) foo v0.5.0 ({url})
 ", url = p.url(), bar = p2.url())));
 }
 
@@ -1134,8 +1134,8 @@ fn git_repo_changing_no_rebuild() {
     assert_that(p1.cargo("build"),
                 execs().with_stderr(&format!("\
 [UPDATING] git repository `{bar}`
-[COMPILING] [..]
-[COMPILING] [..]
+[COMPILING] (debug) [..]
+[COMPILING] (debug) [..]
 ", bar = bar.url())));
 
     // Make a commit to lock p2 to a different rev
@@ -1160,8 +1160,8 @@ fn git_repo_changing_no_rebuild() {
     assert_that(p2.cargo_process("build"),
                 execs().with_stderr(&format!("\
 [UPDATING] git repository `{bar}`
-[COMPILING] [..]
-[COMPILING] [..]
+[COMPILING] (debug) [..]
+[COMPILING] (debug) [..]
 ", bar = bar.url())));
 
     // And now for the real test! Make sure that p1 doesn't get rebuilt
@@ -1290,8 +1290,8 @@ fn warnings_in_git_dep() {
     assert_that(p.cargo_process("build"),
         execs()
         .with_stderr(&format!("[UPDATING] git repository `{}`\n\
-                              [COMPILING] bar v0.5.0 ({}#[..])\n\
-                              [COMPILING] foo v0.5.0 ({})\n",
+                              [COMPILING] (debug) bar v0.5.0 ({}#[..])\n\
+                              [COMPILING] (debug) foo v0.5.0 ({})\n",
                              bar.url(),
                              bar.url(),
                              p.url())));
@@ -1451,9 +1451,9 @@ fn switch_deps_does_not_update_transitive() {
                        .with_stderr(&format!("\
 [UPDATING] git repository `{}`
 [UPDATING] git repository `{}`
-[COMPILING] transitive [..]
-[COMPILING] dep [..]
-[COMPILING] project [..]
+[COMPILING] (debug) transitive [..]
+[COMPILING] (debug) dep [..]
+[COMPILING] (debug) project [..]
 ", dep1.url(), transitive.url())));
 
     // Update the dependency to point to the second repository, but this
@@ -1471,8 +1471,8 @@ fn switch_deps_does_not_update_transitive() {
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [UPDATING] git repository `{}`
-[COMPILING] dep [..]
-[COMPILING] project [..]
+[COMPILING] (debug) dep [..]
+[COMPILING] (debug) project [..]
 ", dep2.url())));
 }
 
@@ -1578,9 +1578,9 @@ fn switch_sources() {
                 execs().with_status(0)
                        .with_stderr("\
 [UPDATING] git repository `file://[..]a1`
-[COMPILING] a v0.5.0 ([..]a1#[..]
-[COMPILING] b v0.5.0 ([..])
-[COMPILING] project v0.5.0 ([..])
+[COMPILING] (debug) a v0.5.0 ([..]a1#[..]
+[COMPILING] (debug) b v0.5.0 ([..])
+[COMPILING] (debug) project v0.5.0 ([..])
 "));
 
     File::create(&p.root().join("b/Cargo.toml")).unwrap().write_all(format!(r#"
@@ -1596,9 +1596,9 @@ fn switch_sources() {
                 execs().with_status(0)
                        .with_stderr("\
 [UPDATING] git repository `file://[..]a2`
-[COMPILING] a v0.5.1 ([..]a2#[..]
-[COMPILING] b v0.5.0 ([..])
-[COMPILING] project v0.5.0 ([..])
+[COMPILING] (debug) a v0.5.1 ([..]a2#[..]
+[COMPILING] (debug) b v0.5.0 ([..])
+[COMPILING] (debug) project v0.5.0 ([..])
 "));
 }
 
@@ -1705,8 +1705,8 @@ fn lints_are_suppressed() {
     assert_that(p.cargo_process("build"),
                 execs().with_status(0).with_stderr("\
 [UPDATING] git repository `[..]`
-[COMPILING] a v0.5.0 ([..])
-[COMPILING] foo v0.0.1 ([..])
+[COMPILING] (debug) a v0.5.0 ([..])
+[COMPILING] (debug) foo v0.0.1 ([..])
 "));
 }
 
@@ -1743,8 +1743,8 @@ fn denied_lints_are_allowed() {
     assert_that(p.cargo_process("build"),
                 execs().with_status(0).with_stderr("\
 [UPDATING] git repository `[..]`
-[COMPILING] a v0.5.0 ([..])
-[COMPILING] foo v0.0.1 ([..])
+[COMPILING] (debug) a v0.5.0 ([..])
+[COMPILING] (debug) foo v0.0.1 ([..])
 "));
 }
 

--- a/tests/install.rs
+++ b/tests/install.rs
@@ -37,7 +37,7 @@ fn simple() {
                 execs().with_status(0).with_stderr(&format!("\
 [UPDATING] registry `[..]`
 [DOWNLOADING] foo v0.0.1 (registry file://[..])
-[COMPILING] foo v0.0.1 (registry file://[..])
+[COMPILING] (release) foo v0.0.1 (registry file://[..])
 [INSTALLING] {home}[..]bin[..]foo[..]
 warning: be sure to add `[..]` to your PATH to be able to run the installed binaries
 ",
@@ -61,7 +61,7 @@ fn pick_max_version() {
                 execs().with_status(0).with_stderr(&format!("\
 [UPDATING] registry `[..]`
 [DOWNLOADING] foo v0.0.2 (registry file://[..])
-[COMPILING] foo v0.0.2 (registry file://[..])
+[COMPILING] (release) foo v0.0.2 (registry file://[..])
 [INSTALLING] {home}[..]bin[..]foo[..]
 warning: be sure to add `[..]` to your PATH to be able to run the installed binaries
 ",
@@ -407,7 +407,7 @@ fn install_force() {
 
     assert_that(cargo_process("install").arg("--force").arg("--path").arg(p.root()),
                 execs().with_status(0).with_stderr(&format!("\
-[COMPILING] foo v0.2.0 ([..])
+[COMPILING] (release) foo v0.2.0 ([..])
 [REPLACING] {home}[..]bin[..]foo[..]
 warning: be sure to add `[..]` to your PATH to be able to run the installed binaries
 ",
@@ -449,7 +449,7 @@ fn install_force_partial_overlap() {
 
     assert_that(cargo_process("install").arg("--force").arg("--path").arg(p.root()),
                 execs().with_status(0).with_stderr(&format!("\
-[COMPILING] foo v0.2.0 ([..])
+[COMPILING] (release) foo v0.2.0 ([..])
 [INSTALLING] {home}[..]bin[..]foo-bin3[..]
 [REPLACING] {home}[..]bin[..]foo-bin2[..]
 warning: be sure to add `[..]` to your PATH to be able to run the installed binaries
@@ -499,7 +499,7 @@ fn install_force_bin() {
                     .arg("--path")
                     .arg(p.root()),
                 execs().with_status(0).with_stderr(&format!("\
-[COMPILING] foo v0.2.0 ([..])
+[COMPILING] (release) foo v0.2.0 ([..])
 [REPLACING] {home}[..]bin[..]foo-bin2[..]
 warning: be sure to add `[..]` to your PATH to be able to run the installed binaries
 ",
@@ -553,7 +553,7 @@ fn git_repo() {
     assert_that(cargo_process("install").arg("--git").arg(p.url().to_string()),
                 execs().with_status(0).with_stderr(&format!("\
 [UPDATING] git repository `[..]`
-[COMPILING] foo v0.1.0 ([..])
+[COMPILING] (release) foo v0.1.0 ([..])
 [INSTALLING] {home}[..]bin[..]foo[..]
 warning: be sure to add `[..]` to your PATH to be able to run the installed binaries
 ",

--- a/tests/overrides.rs
+++ b/tests/overrides.rs
@@ -45,8 +45,8 @@ fn override_simple() {
                 execs().with_status(0).with_stderr("\
 [UPDATING] registry `file://[..]`
 [UPDATING] git repository `[..]`
-[COMPILING] foo v0.1.0 (file://[..])
-[COMPILING] local v0.0.1 (file://[..])
+[COMPILING] (debug) foo v0.1.0 (file://[..])
+[COMPILING] (debug) local v0.0.1 (file://[..])
 "));
 }
 
@@ -143,9 +143,9 @@ fn transitive() {
 [UPDATING] registry `file://[..]`
 [UPDATING] git repository `[..]`
 [DOWNLOADING] bar v0.2.0 (registry [..])
-[COMPILING] foo v0.1.0 (file://[..])
-[COMPILING] bar v0.2.0 (registry [..])
-[COMPILING] local v0.0.1 (file://[..])
+[COMPILING] (debug) foo v0.1.0 (file://[..])
+[COMPILING] (debug) bar v0.2.0 (registry [..])
+[COMPILING] (debug) local v0.0.1 (file://[..])
 "));
 
     assert_that(p.cargo("build"), execs().with_status(0).with_stdout(""));
@@ -189,8 +189,8 @@ fn persists_across_rebuilds() {
                 execs().with_status(0).with_stderr("\
 [UPDATING] registry `file://[..]`
 [UPDATING] git repository `file://[..]`
-[COMPILING] foo v0.1.0 (file://[..])
-[COMPILING] local v0.0.1 (file://[..])
+[COMPILING] (debug) foo v0.1.0 (file://[..])
+[COMPILING] (debug) local v0.0.1 (file://[..])
 "));
 
     assert_that(p.cargo("build"),
@@ -234,8 +234,8 @@ fn replace_registry_with_path() {
     assert_that(p.cargo_process("build"),
                 execs().with_status(0).with_stderr("\
 [UPDATING] registry `file://[..]`
-[COMPILING] foo v0.1.0 (file://[..])
-[COMPILING] local v0.0.1 (file://[..])
+[COMPILING] (debug) foo v0.1.0 (file://[..])
+[COMPILING] (debug) local v0.0.1 (file://[..])
 "));
 }
 
@@ -293,10 +293,10 @@ fn use_a_spec_to_select() {
 [UPDATING] git repository `[..]`
 [DOWNLOADING] [..]
 [DOWNLOADING] [..]
-[COMPILING] [..]
-[COMPILING] [..]
-[COMPILING] [..]
-[COMPILING] local v0.0.1 (file://[..])
+[COMPILING] (debug) [..]
+[COMPILING] (debug) [..]
+[COMPILING] (debug) [..]
+[COMPILING] (debug) local v0.0.1 (file://[..])
 "));
 }
 
@@ -338,9 +338,9 @@ fn override_adds_some_deps() {
 [UPDATING] registry `file://[..]`
 [UPDATING] git repository `[..]`
 [DOWNLOADING] foo v0.1.1 (registry [..])
-[COMPILING] foo v0.1.1 (registry [..])
-[COMPILING] bar v0.1.0 ([..])
-[COMPILING] local v0.0.1 (file://[..])
+[COMPILING] (debug) foo v0.1.1 (registry [..])
+[COMPILING] (debug) bar v0.1.0 ([..])
+[COMPILING] (debug) local v0.0.1 (file://[..])
 "));
 
     assert_that(p.cargo("build"), execs().with_status(0).with_stdout(""));

--- a/tests/package.rs
+++ b/tests/package.rs
@@ -38,7 +38,7 @@ fn simple() {
 [WARNING] manifest has no documentation[..]
 [PACKAGING] foo v0.0.1 ({dir})
 [VERIFYING] foo v0.0.1 ({dir})
-[COMPILING] foo v0.0.1 ({dir}[..])
+[COMPILING] (debug) foo v0.0.1 ({dir}[..])
 ",
         dir = p.url())));
     assert_that(&p.root().join("target/package/foo-0.0.1.crate"), existing_file());
@@ -84,7 +84,7 @@ homepage or repository. See \
 http://doc.crates.io/manifest.html#package-metadata for more info.
 [PACKAGING] foo v0.0.1 ({dir})
 [VERIFYING] foo v0.0.1 ({dir})
-[COMPILING] foo v0.0.1 ({dir}[..])
+[COMPILING] (debug) foo v0.0.1 ({dir}[..])
 ",
         dir = p.url())));
 
@@ -105,7 +105,7 @@ warning: manifest has no description, documentation, homepage or repository. See
 http://doc.crates.io/manifest.html#package-metadata for more info.
 [PACKAGING] foo v0.0.1 ({dir})
 [VERIFYING] foo v0.0.1 ({dir})
-[COMPILING] foo v0.0.1 ({dir}[..])
+[COMPILING] (debug) foo v0.0.1 ({dir}[..])
 ",
         dir = p.url())));
 
@@ -126,7 +126,7 @@ http://doc.crates.io/manifest.html#package-metadata for more info.
                 execs().with_status(0).with_stderr(&format!("\
 [PACKAGING] foo v0.0.1 ({dir})
 [VERIFYING] foo v0.0.1 ({dir})
-[COMPILING] foo v0.0.1 ({dir}[..])
+[COMPILING] (debug) foo v0.0.1 ({dir}[..])
 ",
         dir = p.url())));
 }
@@ -195,7 +195,7 @@ fn package_verification() {
 [WARNING] manifest has no description[..]
 [PACKAGING] foo v0.0.1 ({dir})
 [VERIFYING] foo v0.0.1 ({dir})
-[COMPILING] foo v0.0.1 ({dir}[..])
+[COMPILING] (debug) foo v0.0.1 ({dir}[..])
 ",
         dir = p.url())));
 }
@@ -356,7 +356,7 @@ fn ignore_nested() {
 [WARNING] manifest has no documentation[..]
 [PACKAGING] nested v0.0.1 ({dir})
 [VERIFYING] nested v0.0.1 ({dir})
-[COMPILING] nested v0.0.1 ({dir}[..])
+[COMPILING] (debug) nested v0.0.1 ({dir}[..])
 ",
         dir = p.url())));
     assert_that(&p.root().join("target/package/nested-0.0.1.crate"), existing_file());
@@ -443,7 +443,7 @@ fn repackage_on_source_change() {
 [WARNING] [..]
 [PACKAGING] foo v0.0.1 ({dir})
 [VERIFYING] foo v0.0.1 ({dir})
-[COMPILING] foo v0.0.1 ({dir}[..])
+[COMPILING] (debug) foo v0.0.1 ({dir}[..])
 ",
         dir = p.url())));
 

--- a/tests/path.rs
+++ b/tests/path.rs
@@ -74,9 +74,9 @@ fn cargo_compile_with_nested_deps_shorthand() {
 
     assert_that(p.cargo_process("build"),
         execs().with_status(0)
-               .with_stderr(&format!("[COMPILING] baz v0.5.0 ({}/bar/baz)\n\
-                                     [COMPILING] bar v0.5.0 ({}/bar)\n\
-                                     [COMPILING] foo v0.5.0 ({})\n",
+               .with_stderr(&format!("[COMPILING] (debug) baz v0.5.0 ({}/bar/baz)\n\
+                                     [COMPILING] (debug) bar v0.5.0 ({}/bar)\n\
+                                     [COMPILING] (debug) foo v0.5.0 ({})\n",
                                     p.url(),
                                     p.url(),
                                     p.url())));
@@ -92,14 +92,14 @@ fn cargo_compile_with_nested_deps_shorthand() {
     println!("building baz");
     assert_that(p.cargo("build").arg("-p").arg("baz"),
                 execs().with_status(0)
-                       .with_stderr(&format!("[COMPILING] baz v0.5.0 ({}/bar/baz)\n",
+                       .with_stderr(&format!("[COMPILING] (debug) baz v0.5.0 ({}/bar/baz)\n",
                                             p.url())));
     println!("building foo");
     assert_that(p.cargo("build")
                  .arg("-p").arg("foo"),
                 execs().with_status(0)
-                       .with_stderr(&format!("[COMPILING] bar v0.5.0 ({}/bar)\n\
-                                             [COMPILING] foo v0.5.0 ({})\n",
+                       .with_stderr(&format!("[COMPILING] (debug) bar v0.5.0 ({}/bar)\n\
+                                             [COMPILING] (debug) foo v0.5.0 ({})\n",
                                             p.url(),
                                             p.url())));
 }
@@ -180,8 +180,8 @@ fn cargo_compile_with_root_dev_deps_with_testing() {
     p2.build();
     assert_that(p.cargo_process("test"),
                 execs().with_stderr("\
-[COMPILING] [..] v0.5.0 ([..])
-[COMPILING] [..] v0.5.0 ([..])
+[COMPILING] (debug) [..] v0.5.0 ([..])
+[COMPILING] (debug) [..] v0.5.0 ([..])
 [RUNNING] target[..]foo-[..]")
                        .with_stdout("
 running 0 tests
@@ -234,8 +234,8 @@ fn cargo_compile_with_transitive_dev_deps() {
         "#);
 
     assert_that(p.cargo_process("build"),
-        execs().with_stderr(&format!("[COMPILING] bar v0.5.0 ({}/bar)\n\
-                                     [COMPILING] foo v0.5.0 ({})\n",
+        execs().with_stderr(&format!("[COMPILING] (debug) bar v0.5.0 ({}/bar)\n\
+                                     [COMPILING] (debug) foo v0.5.0 ({})\n",
                                     p.url(),
                                     p.url())));
 
@@ -280,8 +280,8 @@ fn no_rebuild_dependency() {
         "#);
     // First time around we should compile both foo and bar
     assert_that(p.cargo_process("build"),
-                execs().with_stderr(&format!("[COMPILING] bar v0.5.0 ({}/bar)\n\
-                                             [COMPILING] foo v0.5.0 ({})\n",
+                execs().with_stderr(&format!("[COMPILING] (debug) bar v0.5.0 ({}/bar)\n\
+                                             [COMPILING] (debug) foo v0.5.0 ({})\n",
                                             p.url(),
                                             p.url())));
     // This time we shouldn't compile bar
@@ -291,8 +291,8 @@ fn no_rebuild_dependency() {
 
     p.build(); // rebuild the files (rewriting them in the process)
     assert_that(p.cargo("build"),
-                execs().with_stderr(&format!("[COMPILING] bar v0.5.0 ({}/bar)\n\
-                                             [COMPILING] foo v0.5.0 ({})\n",
+                execs().with_stderr(&format!("[COMPILING] (debug) bar v0.5.0 ({}/bar)\n\
+                                             [COMPILING] (debug) foo v0.5.0 ({})\n",
                                             p.url(),
                                             p.url())));
 }
@@ -347,9 +347,9 @@ fn deep_dependencies_trigger_rebuild() {
             pub fn baz() {}
         "#);
     assert_that(p.cargo_process("build"),
-                execs().with_stderr(&format!("[COMPILING] baz v0.5.0 ({}/baz)\n\
-                                             [COMPILING] bar v0.5.0 ({}/bar)\n\
-                                             [COMPILING] foo v0.5.0 ({})\n",
+                execs().with_stderr(&format!("[COMPILING] (debug) baz v0.5.0 ({}/baz)\n\
+                                             [COMPILING] (debug) bar v0.5.0 ({}/bar)\n\
+                                             [COMPILING] (debug) foo v0.5.0 ({})\n",
                                             p.url(),
                                             p.url(),
                                             p.url())));
@@ -365,9 +365,9 @@ fn deep_dependencies_trigger_rebuild() {
         pub fn baz() { println!("hello!"); }
     "#).unwrap();
     assert_that(p.cargo("build"),
-                execs().with_stderr(&format!("[COMPILING] baz v0.5.0 ({}/baz)\n\
-                                             [COMPILING] bar v0.5.0 ({}/bar)\n\
-                                             [COMPILING] foo v0.5.0 ({})\n",
+                execs().with_stderr(&format!("[COMPILING] (debug) baz v0.5.0 ({}/baz)\n\
+                                             [COMPILING] (debug) bar v0.5.0 ({}/bar)\n\
+                                             [COMPILING] (debug) foo v0.5.0 ({})\n",
                                             p.url(),
                                             p.url(),
                                             p.url())));
@@ -379,8 +379,8 @@ fn deep_dependencies_trigger_rebuild() {
         pub fn bar() { println!("hello!"); baz::baz(); }
     "#).unwrap();
     assert_that(p.cargo("build"),
-                execs().with_stderr(&format!("[COMPILING] bar v0.5.0 ({}/bar)\n\
-                                             [COMPILING] foo v0.5.0 ({})\n",
+                execs().with_stderr(&format!("[COMPILING] (debug) bar v0.5.0 ({}/bar)\n\
+                                             [COMPILING] (debug) foo v0.5.0 ({})\n",
                                             p.url(),
                                             p.url())));
 
@@ -437,9 +437,9 @@ fn no_rebuild_two_deps() {
             pub fn baz() {}
         "#);
     assert_that(p.cargo_process("build"),
-                execs().with_stderr(&format!("[COMPILING] baz v0.5.0 ({}/baz)\n\
-                                             [COMPILING] bar v0.5.0 ({}/bar)\n\
-                                             [COMPILING] foo v0.5.0 ({})\n",
+                execs().with_stderr(&format!("[COMPILING] (debug) baz v0.5.0 ({}/baz)\n\
+                                             [COMPILING] (debug) bar v0.5.0 ({}/bar)\n\
+                                             [COMPILING] (debug) foo v0.5.0 ({})\n",
                                             p.url(),
                                             p.url(),
                                             p.url())));
@@ -485,8 +485,8 @@ fn nested_deps_recompile() {
     let bar = p.url();
 
     assert_that(p.cargo_process("build"),
-                execs().with_stderr(&format!("[COMPILING] bar v0.5.0 ({}/src/bar)\n\
-                                             [COMPILING] foo v0.5.0 ({})\n",
+                execs().with_stderr(&format!("[COMPILING] (debug) bar v0.5.0 ({}/src/bar)\n\
+                                             [COMPILING] (debug) foo v0.5.0 ({})\n",
                                             bar,
                                             p.url())));
     sleep_ms(1000);
@@ -497,7 +497,7 @@ fn nested_deps_recompile() {
 
     // This shouldn't recompile `bar`
     assert_that(p.cargo("build"),
-                execs().with_stderr(&format!("[COMPILING] foo v0.5.0 ({})\n",
+                execs().with_stderr(&format!("[COMPILING] (debug) foo v0.5.0 ({})\n",
                                             p.url())));
 }
 
@@ -697,8 +697,8 @@ fn path_dep_build_cmd() {
     p.root().join("bar").move_into_the_past();
 
     assert_that(p.cargo("build"),
-        execs().with_stderr(&format!("[COMPILING] bar v0.5.0 ({}/bar)\n\
-                                     [COMPILING] foo v0.5.0 ({})\n",
+        execs().with_stderr(&format!("[COMPILING] (debug) bar v0.5.0 ({}/bar)\n\
+                                     [COMPILING] (debug) foo v0.5.0 ({})\n",
                                     p.url(),
                                     p.url())));
 
@@ -714,8 +714,8 @@ fn path_dep_build_cmd() {
     }
 
     assert_that(p.cargo("build"),
-        execs().with_stderr(&format!("[COMPILING] bar v0.5.0 ({}/bar)\n\
-                                     [COMPILING] foo v0.5.0 ({})\n",
+        execs().with_stderr(&format!("[COMPILING] (debug) bar v0.5.0 ({}/bar)\n\
+                                     [COMPILING] (debug) foo v0.5.0 ({})\n",
                                     p.url(),
                                     p.url())));
 
@@ -755,14 +755,14 @@ fn dev_deps_no_rebuild_lib() {
     assert_that(p.cargo("build")
                  .env("FOO", "bar"),
                 execs().with_status(0)
-                       .with_stderr(&format!("[COMPILING] foo v0.5.0 ({})\n",
+                       .with_stderr(&format!("[COMPILING] (debug) foo v0.5.0 ({})\n",
                                             p.url())));
 
     assert_that(p.cargo("test"),
                 execs().with_status(0)
                        .with_stderr(&format!("\
-[COMPILING] [..] v0.5.0 ({url}[..])
-[COMPILING] [..] v0.5.0 ({url}[..])
+[COMPILING] (debug) [..] v0.5.0 ({url}[..])
+[COMPILING] (debug) [..] v0.5.0 ({url}[..])
 [RUNNING] target[..]foo-[..]", url = p.url()))
                        .with_stdout("
 running 0 tests
@@ -804,8 +804,8 @@ fn custom_target_no_rebuild() {
     assert_that(p.cargo("build"),
                 execs().with_status(0)
                        .with_stderr("\
-[COMPILING] a v0.5.0 ([..])
-[COMPILING] foo v0.5.0 ([..])
+[COMPILING] (debug) a v0.5.0 ([..])
+[COMPILING] (debug) foo v0.5.0 ([..])
 "));
 
     assert_that(p.cargo("build")
@@ -813,7 +813,7 @@ fn custom_target_no_rebuild() {
                  .env("CARGO_TARGET_DIR", "target"),
                 execs().with_status(0)
                        .with_stderr("\
-[COMPILING] b v0.5.0 ([..])
+[COMPILING] (debug) b v0.5.0 ([..])
 "));
 }
 
@@ -853,9 +853,9 @@ fn override_and_depend() {
     assert_that(p.cargo("build").cwd(p.root().join("b")),
                 execs().with_status(0)
                        .with_stderr("\
-[COMPILING] a2 v0.5.0 ([..])
-[COMPILING] a1 v0.5.0 ([..])
-[COMPILING] b v0.5.0 ([..])
+[COMPILING] (debug) a2 v0.5.0 ([..])
+[COMPILING] (debug) a1 v0.5.0 ([..])
+[COMPILING] (debug) b v0.5.0 ([..])
 "));
 }
 

--- a/tests/plugins.rs
+++ b/tests/plugins.rs
@@ -269,7 +269,7 @@ fn native_plugin_dependency_with_custom_ar_linker() {
     foo.build();
     assert_that(bar.cargo_process("build").arg("--verbose"),
                 execs().with_stderr_contains("\
-[COMPILING] foo v0.0.1 ([..])
+[COMPILING] (debug) foo v0.0.1 ([..])
 [RUNNING] `rustc [..] -C ar=nonexistent-ar -C linker=nonexistent-linker [..]`
 [ERROR] could not exec the linker [..]
 "));

--- a/tests/profiles.rs
+++ b/tests/profiles.rs
@@ -26,7 +26,7 @@ fn profile_overrides() {
         .file("src/lib.rs", "");
     assert_that(p.cargo_process("build").arg("-v"),
                 execs().with_status(0).with_stderr(&format!("\
-[COMPILING] test v0.0.0 ({url})
+[COMPILING] (debug) test v0.0.0 ({url})
 [RUNNING] `rustc src{sep}lib.rs --crate-name test --crate-type lib \
         -C opt-level=1 \
         -C debug-assertions=on \
@@ -78,7 +78,7 @@ fn top_level_overrides_deps() {
         .file("foo/src/lib.rs", "");
     assert_that(p.cargo_process("build").arg("-v").arg("--release"),
                 execs().with_status(0).with_stderr(&format!("\
-[COMPILING] foo v0.0.0 ({url}/foo)
+[COMPILING] (release) foo v0.0.0 ({url}/foo)
 [RUNNING] `rustc foo{sep}src{sep}lib.rs --crate-name foo \
         --crate-type dylib --crate-type rlib -C prefer-dynamic \
         -C opt-level=1 \
@@ -89,7 +89,7 @@ fn top_level_overrides_deps() {
         --emit=dep-info,link \
         -L dependency={dir}{sep}target{sep}release{sep}deps \
         -L dependency={dir}{sep}target{sep}release{sep}deps`
-[COMPILING] test v0.0.0 ({url})
+[COMPILING] (release) test v0.0.0 ({url})
 [RUNNING] `rustc src{sep}lib.rs --crate-name test --crate-type lib \
         -C opt-level=1 \
         -g \

--- a/tests/publish.rs
+++ b/tests/publish.rs
@@ -349,7 +349,7 @@ fn dry_run() {
 [WARNING] manifest has no documentation, [..]
 [PACKAGING] foo v0.0.1 ({dir})
 [VERIFYING] foo v0.0.1 ({dir})
-[COMPILING] foo v0.0.1 [..]
+[COMPILING] (debug) foo v0.0.1 [..]
 [UPLOADING] foo v0.0.1 ({dir})
 [WARNING] aborting upload due to dry run
 ",

--- a/tests/registry.rs
+++ b/tests/registry.rs
@@ -32,8 +32,8 @@ fn simple() {
                 execs().with_status(0).with_stderr(&format!("\
 [UPDATING] registry `{reg}`
 [DOWNLOADING] bar v0.0.1 (registry file://[..])
-[COMPILING] bar v0.0.1 (registry file://[..])
-[COMPILING] foo v0.0.1 ({dir})
+[COMPILING] (debug) bar v0.0.1 (registry file://[..])
+[COMPILING] (debug) foo v0.0.1 ({dir})
 ",
         dir = p.url(),
         reg = registry::registry())));
@@ -71,9 +71,9 @@ fn deps() {
 [UPDATING] registry `{reg}`
 [DOWNLOADING] [..] v0.0.1 (registry file://[..])
 [DOWNLOADING] [..] v0.0.1 (registry file://[..])
-[COMPILING] baz v0.0.1 (registry file://[..])
-[COMPILING] bar v0.0.1 (registry file://[..])
-[COMPILING] foo v0.0.1 ({dir})
+[COMPILING] (debug) baz v0.0.1 (registry file://[..])
+[COMPILING] (debug) bar v0.0.1 (registry file://[..])
+[COMPILING] (debug) foo v0.0.1 ({dir})
 ",
         dir = p.url(),
         reg = registry::registry())));
@@ -202,8 +202,8 @@ version required: >= 0.0.0
                 execs().with_status(0).with_stderr(&format!("\
 [UPDATING] registry `{reg}`
 [DOWNLOADING] notyet v0.0.1 (registry file://[..])
-[COMPILING] notyet v0.0.1 (registry file://[..])
-[COMPILING] foo v0.0.1 ({dir})
+[COMPILING] (debug) notyet v0.0.1 (registry file://[..])
+[COMPILING] (debug) foo v0.0.1 ({dir})
 ",
         dir = p.url(),
         reg = registry::registry())));
@@ -255,8 +255,8 @@ version required: ^0.0.1
 [VERIFYING] foo v0.0.1 ({dir})
 [UPDATING] registry `[..]`
 [DOWNLOADING] notyet v0.0.1 (registry file://[..])
-[COMPILING] notyet v0.0.1 (registry file://[..])
-[COMPILING] foo v0.0.1 ({dir}[..])
+[COMPILING] (debug) notyet v0.0.1 (registry file://[..])
+[COMPILING] (debug) foo v0.0.1 ({dir}[..])
 ", dir = p.url())));
 }
 
@@ -281,8 +281,8 @@ fn lockfile_locks() {
                 execs().with_status(0).with_stderr(&format!("\
 [UPDATING] registry `[..]`
 [DOWNLOADING] bar v0.0.1 (registry file://[..])
-[COMPILING] bar v0.0.1 (registry file://[..])
-[COMPILING] foo v0.0.1 ({dir})
+[COMPILING] (debug) bar v0.0.1 (registry file://[..])
+[COMPILING] (debug) foo v0.0.1 ({dir})
 ",
    dir = p.url())));
 
@@ -316,9 +316,9 @@ fn lockfile_locks_transitively() {
 [UPDATING] registry `[..]`
 [DOWNLOADING] [..] v0.0.1 (registry file://[..])
 [DOWNLOADING] [..] v0.0.1 (registry file://[..])
-[COMPILING] baz v0.0.1 (registry file://[..])
-[COMPILING] bar v0.0.1 (registry file://[..])
-[COMPILING] foo v0.0.1 ({dir})
+[COMPILING] (debug) baz v0.0.1 (registry file://[..])
+[COMPILING] (debug) bar v0.0.1 (registry file://[..])
+[COMPILING] (debug) foo v0.0.1 ({dir})
 ",
    dir = p.url())));
 
@@ -355,9 +355,9 @@ fn yanks_are_not_used() {
 [UPDATING] registry `[..]`
 [DOWNLOADING] [..] v0.0.1 (registry file://[..])
 [DOWNLOADING] [..] v0.0.1 (registry file://[..])
-[COMPILING] baz v0.0.1 (registry file://[..])
-[COMPILING] bar v0.0.1 (registry file://[..])
-[COMPILING] foo v0.0.1 ({dir})
+[COMPILING] (debug) baz v0.0.1 (registry file://[..])
+[COMPILING] (debug) bar v0.0.1 (registry file://[..])
+[COMPILING] (debug) foo v0.0.1 ({dir})
 ",
    dir = p.url())));
 }
@@ -488,8 +488,8 @@ fn update_lockfile() {
     assert_that(p.cargo("build"),
                 execs().with_status(0).with_stderr(&format!("\
 [DOWNLOADING] [..] v0.0.2 (registry file://[..])
-[COMPILING] bar v0.0.2 (registry file://[..])
-[COMPILING] foo v0.0.1 ({dir})
+[COMPILING] (debug) bar v0.0.2 (registry file://[..])
+[COMPILING] (debug) foo v0.0.1 ({dir})
 ",
    dir = p.url())));
 
@@ -505,8 +505,8 @@ fn update_lockfile() {
     assert_that(p.cargo("build"),
                 execs().with_status(0).with_stderr(&format!("\
 [DOWNLOADING] [..] v0.0.3 (registry file://[..])
-[COMPILING] bar v0.0.3 (registry file://[..])
-[COMPILING] foo v0.0.1 ({dir})
+[COMPILING] (debug) bar v0.0.3 (registry file://[..])
+[COMPILING] (debug) foo v0.0.1 ({dir})
 ",
    dir = p.url())));
 
@@ -554,8 +554,8 @@ fn dev_dependency_not_used() {
                 execs().with_status(0).with_stderr(&format!("\
 [UPDATING] registry `[..]`
 [DOWNLOADING] [..] v0.0.1 (registry file://[..])
-[COMPILING] bar v0.0.1 (registry file://[..])
-[COMPILING] foo v0.0.1 ({dir})
+[COMPILING] (debug) bar v0.0.1 (registry file://[..])
+[COMPILING] (debug) foo v0.0.1 ({dir})
 ",
    dir = p.url())));
 }
@@ -621,9 +621,9 @@ fn updating_a_dep() {
                 execs().with_status(0).with_stderr(&format!("\
 [UPDATING] registry `[..]`
 [DOWNLOADING] bar v0.0.1 (registry file://[..])
-[COMPILING] bar v0.0.1 (registry file://[..])
-[COMPILING] a v0.0.1 ({dir}/a)
-[COMPILING] foo v0.0.1 ({dir})
+[COMPILING] (debug) bar v0.0.1 (registry file://[..])
+[COMPILING] (debug) a v0.0.1 ({dir}/a)
+[COMPILING] (debug) foo v0.0.1 ({dir})
 ",
    dir = p.url())));
 
@@ -643,9 +643,9 @@ fn updating_a_dep() {
                 execs().with_status(0).with_stderr(&format!("\
 [UPDATING] registry `[..]`
 [DOWNLOADING] bar v0.1.0 (registry file://[..])
-[COMPILING] bar v0.1.0 (registry file://[..])
-[COMPILING] a v0.0.1 ({dir}/a)
-[COMPILING] foo v0.0.1 ({dir})
+[COMPILING] (debug) bar v0.1.0 (registry file://[..])
+[COMPILING] (debug) a v0.0.1 ({dir}/a)
+[COMPILING] (debug) foo v0.0.1 ({dir})
 ",
    dir = p.url())));
 }
@@ -688,9 +688,9 @@ fn git_and_registry_dep() {
 [UPDATING] [..]
 [UPDATING] [..]
 [DOWNLOADING] a v0.0.1 (registry file://[..])
-[COMPILING] a v0.0.1 (registry [..])
-[COMPILING] b v0.0.1 ([..])
-[COMPILING] foo v0.0.1 ({dir})
+[COMPILING] (debug) a v0.0.1 (registry [..])
+[COMPILING] (debug) b v0.0.1 ([..])
+[COMPILING] (debug) foo v0.0.1 ({dir})
 ",
    dir = p.url())));
     p.root().move_into_the_past();
@@ -734,8 +734,8 @@ fn update_publish_then_update() {
                 execs().with_status(0).with_stderr(&format!("\
 [UPDATING] [..]
 [DOWNLOADING] a v0.1.1 (registry file://[..])
-[COMPILING] a v0.1.1 (registry [..])
-[COMPILING] foo v0.5.0 ({dir})
+[COMPILING] (debug) a v0.1.1 (registry [..])
+[COMPILING] (debug) foo v0.5.0 ({dir})
 ",
    dir = p.url())));
 
@@ -800,9 +800,9 @@ fn update_transitive_dependency() {
                 execs().with_status(0)
                        .with_stderr("\
 [DOWNLOADING] b v0.1.1 (registry file://[..])
-[COMPILING] b v0.1.1 (registry [..])
-[COMPILING] a v0.1.0 (registry [..])
-[COMPILING] foo v0.5.0 ([..])
+[COMPILING] (debug) b v0.1.1 (registry [..])
+[COMPILING] (debug) a v0.1.0 (registry [..])
+[COMPILING] (debug) foo v0.5.0 ([..])
 "));
 }
 
@@ -895,13 +895,13 @@ fn update_multiple_packages() {
                        .with_stderr_contains("\
 [DOWNLOADING] c v0.1.1 (registry file://[..])")
                        .with_stderr_contains("\
-[COMPILING] a v0.1.1 (registry [..])")
+[COMPILING] (debug) a v0.1.1 (registry [..])")
                        .with_stderr_contains("\
-[COMPILING] b v0.1.1 (registry [..])")
+[COMPILING] (debug) b v0.1.1 (registry [..])")
                        .with_stderr_contains("\
-[COMPILING] c v0.1.1 (registry [..])")
+[COMPILING] (debug) c v0.1.1 (registry [..])")
                        .with_stderr_contains("\
-[COMPILING] foo v0.5.0 ([..])"));
+[COMPILING] (debug) foo v0.5.0 ([..])"));
 }
 
 #[test]
@@ -1017,8 +1017,8 @@ fn only_download_relevant() {
                 execs().with_status(0).with_stderr("\
 [UPDATING] registry `[..]`
 [DOWNLOADING] baz v0.1.0 ([..])
-[COMPILING] baz v0.1.0 ([..])
-[COMPILING] bar v0.5.0 ([..])
+[COMPILING] (debug) baz v0.1.0 ([..])
+[COMPILING] (debug) bar v0.5.0 ([..])
 "));
 }
 

--- a/tests/run.rs
+++ b/tests/run.rs
@@ -24,7 +24,7 @@ fn simple() {
     assert_that(p.cargo_process("run"),
                 execs().with_status(0)
                        .with_stderr(&format!("\
-[COMPILING] foo v0.0.1 ({dir})
+[COMPILING] (debug) foo v0.0.1 ({dir})
 [RUNNING] `target{sep}debug{sep}foo[..]`", dir = path2url(p.root()), sep = SEP))
                        .with_stdout("\
 hello
@@ -128,7 +128,7 @@ fn exit_code() {
     assert_that(p.cargo_process("run"),
                 execs().with_status(2)
                        .with_stderr("\
-[COMPILING] foo v0.0.1 (file[..])
+[COMPILING] (debug) foo v0.0.1 (file[..])
 [RUNNING] `target[..]`
 [ERROR] Process didn't exit successfully: `target[..]foo[..]` (exit code: 2)
 "));
@@ -150,7 +150,7 @@ fn exit_code_verbose() {
     assert_that(p.cargo_process("run").arg("-v"),
                 execs().with_status(2)
                        .with_stderr("\
-[COMPILING] foo v0.0.1 (file[..])
+[COMPILING] (debug) foo v0.0.1 (file[..])
 [RUNNING] `rustc [..]`
 [RUNNING] `target[..]`
 [ERROR] Process didn't exit successfully: `target[..]foo[..]` (exit code: 2)
@@ -216,7 +216,7 @@ fn specify_name() {
     assert_that(p.cargo_process("run").arg("--bin").arg("a").arg("-v"),
                 execs().with_status(0)
                        .with_stderr(&format!("\
-[COMPILING] foo v0.0.1 ({dir})
+[COMPILING] (debug) foo v0.0.1 ({dir})
 [RUNNING] `rustc src[..]lib.rs [..]`
 [RUNNING] `rustc src[..]a.rs [..]`
 [RUNNING] `target{sep}debug{sep}a[..]`", dir = path2url(p.root()), sep = SEP))
@@ -227,7 +227,7 @@ hello a.rs
     assert_that(p.cargo("run").arg("--bin").arg("b").arg("-v"),
                 execs().with_status(0)
                        .with_stderr(&format!("\
-[COMPILING] foo v0.0.1 ([..])
+[COMPILING] (debug) foo v0.0.1 ([..])
 [RUNNING] `rustc src[..]b.rs [..]`
 [RUNNING] `target{sep}debug{sep}b[..]`", sep = SEP))
                        .with_stdout("\
@@ -255,7 +255,7 @@ fn run_example() {
     assert_that(p.cargo_process("run").arg("--example").arg("a"),
                 execs().with_status(0)
                        .with_stderr(&format!("\
-[COMPILING] foo v0.0.1 ({dir})
+[COMPILING] (debug) foo v0.0.1 ({dir})
 [RUNNING] `target{sep}debug{sep}examples{sep}a[..]`", dir = path2url(p.root()), sep = SEP))
                        .with_stdout("\
 example
@@ -347,7 +347,7 @@ fn one_bin_multiple_examples() {
     assert_that(p.cargo_process("run"),
                 execs().with_status(0)
                        .with_stderr(&format!("\
-[COMPILING] foo v0.0.1 ({dir})
+[COMPILING] (debug) foo v0.0.1 ({dir})
 [RUNNING] `target{sep}debug{sep}main[..]`", dir = path2url(p.root()), sep = SEP))
                        .with_stdout("\
 hello main.rs
@@ -401,7 +401,7 @@ fn example_with_release_flag() {
     assert_that(p.cargo_process("run").arg("-v").arg("--release").arg("--example").arg("a"),
                 execs().with_status(0)
                        .with_stderr(&format!("\
-[COMPILING] bar v0.0.1 ({url}/bar)
+[COMPILING] (release) bar v0.0.1 ({url}/bar)
 [RUNNING] `rustc bar{sep}src{sep}bar.rs --crate-name bar --crate-type lib \
         -C opt-level=3 \
         -C metadata=[..] \
@@ -410,7 +410,7 @@ fn example_with_release_flag() {
         --emit=dep-info,link \
         -L dependency={dir}{sep}target{sep}release{sep}deps \
         -L dependency={dir}{sep}target{sep}release{sep}deps`
-[COMPILING] foo v0.0.1 ({url})
+[COMPILING] (release) foo v0.0.1 ({url})
 [RUNNING] `rustc examples{sep}a.rs --crate-name a --crate-type bin \
         -C opt-level=3 \
         --out-dir {dir}{sep}target{sep}release{sep}examples \
@@ -430,7 +430,7 @@ fast2"));
     assert_that(p.cargo("run").arg("-v").arg("--example").arg("a"),
                 execs().with_status(0)
                        .with_stderr(&format!("\
-[COMPILING] bar v0.0.1 ({url}/bar)
+[COMPILING] (debug) bar v0.0.1 ({url}/bar)
 [RUNNING] `rustc bar{sep}src{sep}bar.rs --crate-name bar --crate-type lib \
         -g \
         -C metadata=[..] \
@@ -439,7 +439,7 @@ fast2"));
         --emit=dep-info,link \
         -L dependency={dir}{sep}target{sep}debug{sep}deps \
         -L dependency={dir}{sep}target{sep}debug{sep}deps`
-[COMPILING] foo v0.0.1 ({url})
+[COMPILING] (debug) foo v0.0.1 ({url})
 [RUNNING] `rustc examples{sep}a.rs --crate-name a --crate-type bin \
         -g \
         --out-dir {dir}{sep}target{sep}debug{sep}examples \
@@ -504,7 +504,7 @@ fn release_works() {
 
     assert_that(p.cargo_process("run").arg("--release"),
                 execs().with_status(0).with_stderr(&format!("\
-[COMPILING] foo v0.0.1 ({dir})
+[COMPILING] (release) foo v0.0.1 ({dir})
 [RUNNING] `target{sep}release{sep}foo[..]`
 ",
         dir = path2url(p.root()),

--- a/tests/rustc.rs
+++ b/tests/rustc.rs
@@ -28,7 +28,7 @@ fn build_lib_for_foo() {
                 execs()
                 .with_status(0)
                 .with_stderr(format!("\
-[COMPILING] foo v0.0.1 ({url})
+[COMPILING] (debug) foo v0.0.1 ({url})
 [RUNNING] `rustc src{sep}lib.rs --crate-name foo --crate-type lib -g \
         --out-dir {dir}{sep}target{sep}debug \
         --emit=dep-info,link \
@@ -57,7 +57,7 @@ fn lib() {
                 execs()
                 .with_status(0)
                 .with_stderr(format!("\
-[COMPILING] foo v0.0.1 ({url})
+[COMPILING] (debug) foo v0.0.1 ({url})
 [RUNNING] `rustc src{sep}lib.rs --crate-name foo --crate-type lib -g \
         -C debug-assertions=off \
         --out-dir {dir}{sep}target{sep}debug \
@@ -87,7 +87,7 @@ fn build_main_and_allow_unstable_options() {
                 execs()
                 .with_status(0)
                 .with_stderr(&format!("\
-[COMPILING] {name} v{version} ({url})
+[COMPILING] (debug) {name} v{version} ({url})
 [RUNNING] `rustc src{sep}lib.rs --crate-name {name} --crate-type lib -g \
         --out-dir {dir}{sep}target{sep}debug \
         --emit=dep-info,link \
@@ -151,7 +151,7 @@ fn build_with_args_to_one_of_multiple_binaries() {
                 execs()
                 .with_status(0)
                 .with_stderr(format!("\
-[COMPILING] foo v0.0.1 ({url})
+[COMPILING] (debug) foo v0.0.1 ({url})
 [RUNNING] `rustc src{sep}lib.rs --crate-name foo --crate-type lib -g \
         --out-dir {dir}{sep}target{sep}debug [..]`
 [RUNNING] `rustc src{sep}bin{sep}bar.rs --crate-name bar --crate-type bin -g \
@@ -206,7 +206,7 @@ fn build_with_args_to_one_of_multiple_tests() {
                 execs()
                 .with_status(0)
                 .with_stderr(format!("\
-[COMPILING] foo v0.0.1 ({url})
+[COMPILING] (debug) foo v0.0.1 ({url})
 [RUNNING] `rustc src{sep}lib.rs --crate-name foo --crate-type lib -g \
         --out-dir {dir}{sep}target{sep}debug [..]`
 [RUNNING] `rustc tests{sep}bar.rs --crate-name bar -g \
@@ -249,9 +249,9 @@ fn build_foo_with_bar_dependency() {
                 execs()
                 .with_status(0)
                 .with_stderr(format!("\
-[COMPILING] bar v0.1.0 ([..])
+[COMPILING] (debug) bar v0.1.0 ([..])
 [RUNNING] `[..] -g -C [..]`
-[COMPILING] foo v0.0.1 ({url})
+[COMPILING] (debug) foo v0.0.1 ({url})
 [RUNNING] `[..] -g -C debug-assertions [..]`
 ",
                 url = foo.url())));
@@ -292,7 +292,7 @@ fn build_only_bar_dependency() {
                 execs()
                 .with_status(0)
                 .with_stderr("\
-[COMPILING] bar v0.1.0 ([..])
+[COMPILING] (debug) bar v0.1.0 ([..])
 [RUNNING] `[..]--crate-name bar --crate-type lib [..] -C debug-assertions [..]`
 "));
 }

--- a/tests/rustdoc.rs
+++ b/tests/rustdoc.rs
@@ -89,7 +89,7 @@ fn rustdoc_foo_with_bar_dependency() {
                 execs()
                 .with_status(0)
                 .with_stderr(format!("\
-[COMPILING] bar v0.0.1 ([..])
+[COMPILING] (debug) bar v0.0.1 ([..])
 [RUNNING] `rustc [..]bar{sep}src{sep}lib.rs [..]`
 [DOCUMENTING] foo v0.0.1 ({url})
 [RUNNING] `rustdoc src{sep}lib.rs --crate-name foo \

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -38,7 +38,7 @@ fn cargo_test_simple() {
 
     assert_that(p.cargo("test"),
                 execs().with_stderr(format!("\
-[COMPILING] foo v0.5.0 ({})
+[COMPILING] (debug) foo v0.5.0 ({})
 [RUNNING] target[..]foo-[..]", p.url()))
                        .with_stdout("
 running 1 test
@@ -84,9 +84,9 @@ fn cargo_test_release() {
 
     assert_that(p.cargo_process("test").arg("-v").arg("--release"),
                 execs().with_stderr(format!("\
-[COMPILING] bar v0.0.1 ({dir}/bar)
+[COMPILING] (release) bar v0.0.1 ({dir}/bar)
 [RUNNING] [..] -C opt-level=3 [..]
-[COMPILING] foo v0.1.0 ({dir})
+[COMPILING] (release) foo v0.1.0 ({dir})
 [RUNNING] [..] -C opt-level=3 [..]
 [RUNNING] [..] -C opt-level=3 [..]
 [RUNNING] [..] -C opt-level=3 [..]
@@ -125,7 +125,7 @@ fn cargo_test_verbose() {
 
     assert_that(p.cargo_process("test").arg("-v").arg("hello"),
                 execs().with_stderr(format!("\
-[COMPILING] foo v0.5.0 ({url})
+[COMPILING] (debug) foo v0.5.0 ({url})
 [RUNNING] `rustc src[..]foo.rs [..]`
 [RUNNING] `[..]target[..]foo-[..] hello`", url = p.url()))
                        .with_stdout("
@@ -193,7 +193,7 @@ fn cargo_test_failing_test() {
 
     assert_that(p.cargo("test"),
                 execs().with_stderr(format!("\
-[COMPILING] foo v0.5.0 ({url})
+[COMPILING] (debug) foo v0.5.0 ({url})
 [RUNNING] target[..]foo-[..]
 [ERROR] test failed", url = p.url()))
                        .with_stdout_contains("
@@ -252,7 +252,7 @@ fn test_with_lib_dep() {
 
     assert_that(p.cargo_process("test"),
                 execs().with_stderr(format!("\
-[COMPILING] foo v0.0.1 ({})
+[COMPILING] (debug) foo v0.0.1 ({})
 [RUNNING] target[..]baz-[..]
 [RUNNING] target[..]foo[..]
 [DOCTEST] foo", p.url()))
@@ -319,8 +319,8 @@ fn test_with_deep_lib_dep() {
     assert_that(p.cargo_process("test"),
                 execs().with_status(0)
                        .with_stderr(&format!("\
-[COMPILING] foo v0.0.1 ([..])
-[COMPILING] bar v0.0.1 ({dir})
+[COMPILING] (debug) foo v0.0.1 ([..])
+[COMPILING] (debug) bar v0.0.1 ({dir})
 [RUNNING] target[..]
 [DOCTEST] bar", dir = p.url()))
                        .with_stdout("
@@ -366,7 +366,7 @@ fn external_test_explicit() {
 
     assert_that(p.cargo_process("test"),
                 execs().with_stderr(format!("\
-[COMPILING] foo v0.0.1 ({})
+[COMPILING] (debug) foo v0.0.1 ({})
 [RUNNING] target[..]foo-[..]
 [RUNNING] target[..]test-[..]
 [DOCTEST] foo", p.url()))
@@ -414,7 +414,7 @@ fn external_test_implicit() {
 
     assert_that(p.cargo_process("test"),
                 execs().with_stderr(format!("\
-[COMPILING] foo v0.0.1 ({})
+[COMPILING] (debug) foo v0.0.1 ({})
 [RUNNING] target[..]external-[..]
 [RUNNING] target[..]foo-[..]
 [DOCTEST] foo", p.url()))
@@ -473,7 +473,7 @@ fn pass_through_command_line() {
     assert_that(p.cargo_process("test").arg("bar"),
                 execs().with_status(0)
                        .with_stderr(&format!("\
-[COMPILING] foo v0.0.1 ({dir})
+[COMPILING] (debug) foo v0.0.1 ({dir})
 [RUNNING] target[..]foo-[..]
 [DOCTEST] foo", dir = p.url()))
                        .with_stdout("
@@ -555,7 +555,7 @@ fn lib_bin_same_name() {
 
     assert_that(p.cargo_process("test"),
                 execs().with_stderr(format!("\
-[COMPILING] foo v0.0.1 ({})
+[COMPILING] (debug) foo v0.0.1 ({})
 [RUNNING] target[..]foo-[..]
 [RUNNING] target[..]foo-[..]
 [DOCTEST] foo", p.url()))
@@ -607,7 +607,7 @@ fn lib_with_standard_name() {
     assert_that(p.cargo_process("test"),
                 execs().with_status(0)
                        .with_stderr(&format!("\
-[COMPILING] syntax v0.0.1 ({dir})
+[COMPILING] (debug) syntax v0.0.1 ({dir})
 [RUNNING] target[..]syntax-[..]
 [RUNNING] target[..]test-[..]
 [DOCTEST] syntax", dir = p.url()))
@@ -661,7 +661,7 @@ fn lib_with_standard_name2() {
     assert_that(p.cargo_process("test"),
                 execs().with_status(0)
                        .with_stderr(&format!("\
-[COMPILING] syntax v0.0.1 ({dir})
+[COMPILING] (debug) syntax v0.0.1 ({dir})
 [RUNNING] target[..]syntax-[..]", dir = p.url()))
                        .with_stdout("
 running 1 test
@@ -700,7 +700,7 @@ fn lib_without_name() {
     assert_that(p.cargo_process("test"),
                 execs().with_status(0)
                        .with_stderr(&format!("\
-[COMPILING] syntax v0.0.1 ({dir})
+[COMPILING] (debug) syntax v0.0.1 ({dir})
 [RUNNING] target[..]syntax-[..]", dir = p.url()))
                        .with_stdout("
 running 1 test
@@ -956,8 +956,8 @@ fn test_dylib() {
     assert_that(p.cargo_process("test"),
                 execs().with_status(0)
                        .with_stderr(&format!("\
-[COMPILING] bar v0.0.1 ({dir}/bar)
-[COMPILING] foo v0.0.1 ({dir})
+[COMPILING] (debug) bar v0.0.1 ({dir}/bar)
+[COMPILING] (debug) foo v0.0.1 ({dir})
 [RUNNING] target[..]foo-[..]
 [RUNNING] target[..]test-[..]", dir = p.url()))
                        .with_stdout("
@@ -1014,7 +1014,7 @@ fn test_twice_with_build_cmd() {
     assert_that(p.cargo_process("test"),
                 execs().with_status(0)
                        .with_stderr(&format!("\
-[COMPILING] foo v0.0.1 ({dir})
+[COMPILING] (debug) foo v0.0.1 ({dir})
 [RUNNING] target[..]foo-[..]
 [DOCTEST] foo", dir = p.url()))
                        .with_stdout("
@@ -1066,7 +1066,7 @@ fn test_then_build() {
     assert_that(p.cargo_process("test"),
                 execs().with_status(0)
                        .with_stderr(&format!("\
-[COMPILING] foo v0.0.1 ({dir})
+[COMPILING] (debug) foo v0.0.1 ({dir})
 [RUNNING] target[..]foo-[..]
 [DOCTEST] foo", dir = p.url()))
                        .with_stdout("
@@ -1104,7 +1104,7 @@ fn test_no_run() {
     assert_that(p.cargo_process("test").arg("--no-run"),
                 execs().with_status(0)
                        .with_stderr(&format!("\
-[COMPILING] foo v0.0.1 ({dir})
+[COMPILING] (debug) foo v0.0.1 ({dir})
 ",
                        dir = p.url())));
 }
@@ -1132,7 +1132,7 @@ fn test_run_specific_bin_target() {
     assert_that(prj.cargo_process("test").arg("--bin").arg("bin2"),
                 execs().with_status(0)
                        .with_stderr(format!("\
-[COMPILING] foo v0.0.1 ({dir})
+[COMPILING] (debug) foo v0.0.1 ({dir})
 [RUNNING] target[..]bin2-[..]", dir = prj.url()))
                        .with_stdout("
 running 1 test
@@ -1160,7 +1160,7 @@ fn test_run_specific_test_target() {
     assert_that(prj.cargo_process("test").arg("--test").arg("b"),
                 execs().with_status(0)
                        .with_stderr(format!("\
-[COMPILING] foo v0.0.1 ({dir})
+[COMPILING] (debug) foo v0.0.1 ({dir})
 [RUNNING] target[..]b-[..]", dir = prj.url()))
                        .with_stdout("
 running 1 test
@@ -1195,7 +1195,7 @@ fn test_no_harness() {
     assert_that(p.cargo_process("test").arg("--").arg("--nocapture"),
                 execs().with_status(0)
                        .with_stderr(&format!("\
-[COMPILING] foo v0.0.1 ({dir})
+[COMPILING] (debug) foo v0.0.1 ({dir})
 [RUNNING] target[..]bar-[..]
 ",
                        dir = p.url())));
@@ -1250,7 +1250,7 @@ fn selective_testing() {
     assert_that(p.cargo("test").arg("-p").arg("d1"),
                 execs().with_status(0)
                        .with_stderr(&format!("\
-[COMPILING] d1 v0.0.1 ({dir}/d1)
+[COMPILING] (debug) d1 v0.0.1 ({dir}/d1)
 [RUNNING] target[..]d1-[..]
 [RUNNING] target[..]d1-[..]", dir = p.url()))
                        .with_stdout("
@@ -1269,7 +1269,7 @@ test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
     assert_that(p.cargo("test").arg("-p").arg("d2"),
                 execs().with_status(0)
                        .with_stderr(&format!("\
-[COMPILING] d2 v0.0.1 ({dir}/d2)
+[COMPILING] (debug) d2 v0.0.1 ({dir}/d2)
 [RUNNING] target[..]d2-[..]
 [RUNNING] target[..]d2-[..]", dir = p.url()))
                        .with_stdout("
@@ -1288,7 +1288,7 @@ test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
     assert_that(p.cargo("test"),
                 execs().with_status(0)
                        .with_stderr(&format!("\
-[COMPILING] foo v0.0.1 ({dir})
+[COMPILING] (debug) foo v0.0.1 ({dir})
 [RUNNING] target[..]foo-[..]", dir = p.url()))
                        .with_stdout("
 running 0 tests
@@ -1449,7 +1449,7 @@ fn selective_testing_with_docs() {
     assert_that(p.cargo("test").arg("-p").arg("d1"),
                 execs().with_status(0)
                        .with_stderr(&format!("\
-[COMPILING] d1 v0.0.1 ({dir}/d1)
+[COMPILING] (debug) d1 v0.0.1 ({dir}/d1)
 [RUNNING] target[..]deps[..]d1[..]
 [DOCTEST] d1", dir = p.url()))
                        .with_stdout("
@@ -1480,7 +1480,7 @@ fn example_bin_same_name() {
     assert_that(p.cargo_process("test").arg("--no-run").arg("-v"),
                 execs().with_status(0)
                        .with_stderr(&format!("\
-[COMPILING] foo v0.0.1 ({dir})
+[COMPILING] (debug) foo v0.0.1 ({dir})
 [RUNNING] `rustc [..]`
 [RUNNING] `rustc [..]`
 ", dir = p.url())));
@@ -1494,7 +1494,7 @@ fn example_bin_same_name() {
     assert_that(p.cargo("run"),
                 execs().with_status(0)
                        .with_stderr("\
-[COMPILING] foo v0.0.1 ([..])
+[COMPILING] (debug) foo v0.0.1 ([..])
 [RUNNING] [..]")
                        .with_stdout("\
 bin
@@ -1627,7 +1627,7 @@ fn doctest_feature() {
     assert_that(p.cargo_process("test").arg("--features").arg("bar"),
                 execs().with_status(0)
                        .with_stderr("\
-[COMPILING] foo [..]
+[COMPILING] (debug) foo [..]
 [RUNNING] target[..]foo[..]
 [DOCTEST] foo")
                        .with_stdout("
@@ -1713,7 +1713,7 @@ fn filter_no_doc_tests() {
 
     assert_that(p.cargo_process("test").arg("--test=foo"),
                 execs().with_stderr("\
-[COMPILING] foo v0.0.1 ([..])
+[COMPILING] (debug) foo v0.0.1 ([..])
 [RUNNING] target[..]debug[..]foo[..]")
                        .with_stdout("
 running 0 tests
@@ -1746,7 +1746,7 @@ fn dylib_doctest() {
 
     assert_that(p.cargo_process("test"),
                 execs().with_stderr("\
-[COMPILING] foo v0.0.1 ([..])
+[COMPILING] (debug) foo v0.0.1 ([..])
 [DOCTEST] foo")
                        .with_stdout("
 running 1 test
@@ -1814,8 +1814,8 @@ fn cyclic_dev_dep_doc_test() {
         "#);
     assert_that(p.cargo_process("test"),
                 execs().with_stderr("\
-[COMPILING] foo v0.0.1 ([..])
-[COMPILING] bar v0.0.1 ([..])
+[COMPILING] (debug) foo v0.0.1 ([..])
+[COMPILING] (debug) bar v0.0.1 ([..])
 [RUNNING] target[..]foo[..]
 [DOCTEST] foo")
                        .with_stdout("
@@ -1907,7 +1907,7 @@ fn no_fail_fast() {
     assert_that(p.cargo_process("test").arg("--no-fail-fast"),
                 execs().with_status(101)
                        .with_stderr_contains("\
-[COMPILING] foo v0.0.1 ([..])
+[COMPILING] (debug) foo v0.0.1 ([..])
 [RUNNING] target[..]foo[..]
 [RUNNING] target[..]test_add_one[..]")
                        .with_stdout_contains("
@@ -2022,7 +2022,7 @@ fn bin_does_not_rebuild_tests() {
     assert_that(p.cargo("test").arg("-v").arg("--no-run"),
                 execs().with_status(0)
                        .with_stderr("\
-[COMPILING] foo v0.0.1 ([..])
+[COMPILING] (debug) foo v0.0.1 ([..])
 [RUNNING] `rustc src[..]main.rs [..]`
 [RUNNING] `rustc src[..]main.rs [..]`
 "));
@@ -2083,7 +2083,7 @@ fn selective_test_optional_dep() {
     assert_that(p.cargo("test").arg("-v").arg("--no-run")
                  .arg("--features").arg("a").arg("-p").arg("a"),
                 execs().with_status(0).with_stderr("\
-[COMPILING] a v0.0.1 ([..])
+[COMPILING] (debug) a v0.0.1 ([..])
 [RUNNING] `rustc a[..]src[..]lib.rs [..]`
 [RUNNING] `rustc a[..]src[..]lib.rs [..]`
 "));
@@ -2116,7 +2116,7 @@ fn only_test_docs() {
     assert_that(p.cargo("test").arg("--doc"),
                 execs().with_status(0)
                        .with_stderr("\
-[COMPILING] foo v0.0.1 ([..])
+[COMPILING] (debug) foo v0.0.1 ([..])
 [DOCTEST] foo")
                        .with_stdout("
 running 1 test
@@ -2188,7 +2188,7 @@ fn cfg_test_even_with_no_harness() {
                 execs().with_status(0)
                        .with_stdout("hello!\n")
                        .with_stderr("\
-[COMPILING] foo v0.0.1 ([..])
+[COMPILING] (debug) foo v0.0.1 ([..])
 [RUNNING] `rustc [..]`
 [RUNNING] `[..]`
 "));

--- a/tests/tool-paths.rs
+++ b/tests/tool-paths.rs
@@ -28,7 +28,7 @@ fn pathless_tools() {
 
     assert_that(foo.cargo_process("build").arg("--verbose"),
                 execs().with_stderr(&format!("\
-[COMPILING] foo v0.0.1 ({url})
+[COMPILING] (debug) foo v0.0.1 ({url})
 [RUNNING] `rustc [..] -C ar=nonexistent-ar -C linker=nonexistent-linker [..]`
 ", url = foo.url())))
 }
@@ -69,7 +69,7 @@ fn absolute_tools() {
 
     assert_that(foo.cargo_process("build").arg("--verbose"),
                 execs().with_stderr(&format!("\
-[COMPILING] foo v0.0.1 ({url})
+[COMPILING] (debug) foo v0.0.1 ({url})
 [RUNNING] `rustc [..] -C ar={ar} -C linker={linker} [..]`
 ", url = foo.url(), ar = output.0, linker = output.1)))
 }
@@ -117,7 +117,7 @@ fn relative_tools() {
 
     assert_that(origin.cargo_process("build").cwd(foo_path).arg("--verbose"),
                 execs().with_stderr(&format!("\
-[COMPILING] foo v0.0.1 ({url})
+[COMPILING] (debug) foo v0.0.1 ({url})
 [RUNNING] `rustc [..] -C ar={ar} -C linker={linker} [..]`
 ", url = foo_url, ar = output.0, linker = output.1)))
 }

--- a/tests/workspaces.rs
+++ b/tests/workspaces.rs
@@ -501,8 +501,8 @@ fn share_dependencies() {
                        .with_stderr("\
 [UPDATING] registry `[..]`
 [DOWNLOADING] dep1 v0.1.3 ([..])
-[COMPILING] dep1 v0.1.3 ([..])
-[COMPILING] foo v0.1.0 ([..])
+[COMPILING] (debug) dep1 v0.1.3 ([..])
+[COMPILING] (debug) foo v0.1.0 ([..])
 "));
 }
 
@@ -585,16 +585,16 @@ fn lock_works_for_everyone() {
                 execs().with_status(0)
                        .with_stderr("\
 [DOWNLOADING] dep2 v0.1.0 ([..])
-[COMPILING] dep2 v0.1.0 ([..])
-[COMPILING] foo v0.1.0 ([..])
+[COMPILING] (debug) dep2 v0.1.0 ([..])
+[COMPILING] (debug) foo v0.1.0 ([..])
 "));
 
     assert_that(p.cargo("build").cwd(p.root().join("bar")),
                 execs().with_status(0)
                        .with_stderr("\
 [DOWNLOADING] dep1 v0.1.0 ([..])
-[COMPILING] dep1 v0.1.0 ([..])
-[COMPILING] bar v0.1.0 ([..])
+[COMPILING] (debug) dep1 v0.1.0 ([..])
+[COMPILING] (debug) bar v0.1.0 ([..])
 "));
 }
 


### PR DESCRIPTION
This resurrects https://github.com/rust-lang/cargo/pull/1374 and implements an indicator of whether the current build is a release or debug.  This should help avoid issues like 

https://www.reddit.com/r/rust/comments/4tikmf/why_is_my_forth_virtual_machine_written_in_rust/

Specifically, this change includes the target indicator, as @alexcrichton mentions in the original PR:

```term
# old
Compiling foo v0.1.0

# new
Compiling (debug) foo v0.1.0
```

r? @alexcrichton