### PR TITLE
Lazy config

### DIFF
--- a/src/bin/cargo.rs
+++ b/src/bin/cargo.rs
@@ -150,8 +150,9 @@ fn execute(flags: Flags, config: &Config) -> CliResult<Option<()>> {
     }
 
     if let Some(ref code) = flags.flag_explain {
-        try!(process(config.rustc()).arg("--explain").arg(code).exec()
-                                    .map_err(human));
+        try!(process(&*try!(config.rustc()))
+                 .arg("--explain").arg(code).exec()
+                 .map_err(human));
         return Ok(None)
     }
 

--- a/src/bin/cargo.rs
+++ b/src/bin/cargo.rs
@@ -16,7 +16,6 @@ use cargo::core::shell::Verbosity;
 use cargo::execute_main_without_stdin;
 use cargo::util::{self, CliResult, lev_distance, Config, human, CargoResult};
 use cargo::util::CliError;
-use cargo::util::process_builder::process;
 
 #[derive(RustcDecodable)]
 pub struct Flags {
@@ -150,9 +149,8 @@ fn execute(flags: Flags, config: &Config) -> CliResult<Option<()>> {
     }
 
     if let Some(ref code) = flags.flag_explain {
-        try!(process(&*try!(config.rustc()))
-                 .arg("--explain").arg(code).exec()
-                 .map_err(human));
+        let mut procss = try!(config.rustc()).process();
+        try!(procss.arg("--explain").arg(code).exec().map_err(human));
         return Ok(None)
     }
 

--- a/src/cargo/core/package.rs
+++ b/src/cargo/core/package.rs
@@ -131,7 +131,7 @@ impl<'cfg> PackageSet<'cfg> {
                sources: SourceMap<'cfg>) -> PackageSet<'cfg> {
         PackageSet {
             packages: package_ids.iter().map(|id| {
-                (id.clone(), LazyCell::new(None))
+                (id.clone(), LazyCell::new())
             }).collect(),
             sources: RefCell::new(sources),
         }

--- a/src/cargo/ops/cargo_clean.rs
+++ b/src/cargo/ops/cargo_clean.rs
@@ -33,7 +33,7 @@ pub fn clean(ws: &Workspace, opts: &CleanOptions) -> CargoResult<()> {
     let packages = ops::get_resolved_packages(&resolve, registry);
 
     let profiles = try!(ws.current()).manifest().profiles();
-    let host_triple = try!(opts.config.rustc_info()).host.clone();
+    let host_triple = try!(opts.config.rustc()).host.clone();
     let mut cx = try!(Context::new(ws, &resolve, &packages, opts.config,
                                    BuildConfig {
                                        host_triple: host_triple,

--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -443,7 +443,7 @@ fn scrape_build_config(config: &Config,
     let cfg_target = try!(config.get_string("build.target")).map(|s| s.val);
     let target = target.or(cfg_target);
     let mut base = ops::BuildConfig {
-        host_triple: try!(config.rustc_info()).host.clone(),
+        host_triple: try!(config.rustc()).host.clone(),
         requested_target: target.clone(),
         jobs: jobs,
         ..Default::default()

--- a/src/cargo/ops/cargo_rustc/context.rs
+++ b/src/cargo/ops/cargo_rustc/context.rs
@@ -166,7 +166,7 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
                                       &self.build_config,
                                       kind,
                                       "RUSTFLAGS"));
-        let mut process = util::process(self.config.rustc());
+        let mut process = util::process(&*try!(self.config.rustc()));
         process.arg("-")
                .arg("--crate-name").arg("_")
                .arg("--print=file-names")

--- a/src/cargo/ops/cargo_rustc/context.rs
+++ b/src/cargo/ops/cargo_rustc/context.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use core::{Package, PackageId, PackageSet, Resolve, Target, Profile};
 use core::{TargetKind, Profiles, Metadata, Dependency, Workspace};
 use core::dependency::Kind as DepKind;
-use util::{self, CargoResult, ChainError, internal, Config, profile, Cfg, human};
+use util::{CargoResult, ChainError, internal, Config, profile, Cfg, human};
 
 use super::TargetConfig;
 use super::custom_build::{BuildState, BuildScripts};
@@ -166,7 +166,7 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
                                       &self.build_config,
                                       kind,
                                       "RUSTFLAGS"));
-        let mut process = util::process(&*try!(self.config.rustc()));
+        let mut process = try!(self.config.rustc()).process();
         process.arg("-")
                .arg("--crate-name").arg("_")
                .arg("--print=file-names")

--- a/src/cargo/ops/cargo_rustc/custom_build.rs
+++ b/src/cargo/ops/cargo_rustc/custom_build.rs
@@ -113,7 +113,7 @@ fn build_work<'a, 'cfg>(cx: &mut Context<'a, 'cfg>, unit: &Unit<'a>)
      .env("OPT_LEVEL", &profile.opt_level.to_string())
      .env("PROFILE", if cx.build_config.release {"release"} else {"debug"})
      .env("HOST", cx.host_triple())
-     .env("RUSTC", &*try!(cx.config.rustc()))
+     .env("RUSTC", &try!(cx.config.rustc()).path)
      .env("RUSTDOC", &*try!(cx.config.rustdoc()));
 
      if let Some(links) = unit.pkg.manifest().links(){

--- a/src/cargo/ops/cargo_rustc/custom_build.rs
+++ b/src/cargo/ops/cargo_rustc/custom_build.rs
@@ -113,8 +113,8 @@ fn build_work<'a, 'cfg>(cx: &mut Context<'a, 'cfg>, unit: &Unit<'a>)
      .env("OPT_LEVEL", &profile.opt_level.to_string())
      .env("PROFILE", if cx.build_config.release {"release"} else {"debug"})
      .env("HOST", cx.host_triple())
-     .env("RUSTC", &cx.config.rustc())
-     .env("RUSTDOC", &cx.config.rustdoc());
+     .env("RUSTC", &*try!(cx.config.rustc()))
+     .env("RUSTDOC", &*try!(cx.config.rustdoc()));
 
      if let Some(links) = unit.pkg.manifest().links(){
         p.env("CARGO_MANIFEST_LINKS", links);

--- a/src/cargo/ops/cargo_rustc/engine.rs
+++ b/src/cargo/ops/cargo_rustc/engine.rs
@@ -41,8 +41,8 @@ impl CommandPrototype {
         Ok(CommandPrototype {
             builder: {
                 let mut p = match ty {
-                    CommandType::Rustc => process(config.rustc()),
-                    CommandType::Rustdoc => process(config.rustdoc()),
+                    CommandType::Rustc => process(&*try!(config.rustc())),
+                    CommandType::Rustdoc => process(&*try!(config.rustdoc())),
                     CommandType::Target(ref s) |
                     CommandType::Host(ref s) => process(s),
                 };

--- a/src/cargo/ops/cargo_rustc/engine.rs
+++ b/src/cargo/ops/cargo_rustc/engine.rs
@@ -41,7 +41,7 @@ impl CommandPrototype {
         Ok(CommandPrototype {
             builder: {
                 let mut p = match ty {
-                    CommandType::Rustc => process(&*try!(config.rustc())),
+                    CommandType::Rustc => try!(config.rustc()).process(),
                     CommandType::Rustdoc => process(&*try!(config.rustdoc())),
                     CommandType::Target(ref s) |
                     CommandType::Host(ref s) => process(s),

--- a/src/cargo/ops/cargo_rustc/fingerprint.rs
+++ b/src/cargo/ops/cargo_rustc/fingerprint.rs
@@ -352,7 +352,7 @@ fn calculate<'a, 'cfg>(cx: &mut Context<'a, 'cfg>, unit: &Unit<'a>)
         try!(cx.rustflags_args(unit))
     };
     let fingerprint = Arc::new(Fingerprint {
-        rustc: util::hash_u64(&try!(cx.config.rustc_info()).verbose_version),
+        rustc: util::hash_u64(&try!(cx.config.rustc()).verbose_version),
         target: util::hash_u64(&unit.target),
         profile: util::hash_u64(&unit.profile),
         features: format!("{:?}", features),

--- a/src/cargo/ops/cargo_rustc/mod.rs
+++ b/src/cargo/ops/cargo_rustc/mod.rs
@@ -204,7 +204,7 @@ fn rustc(cx: &mut Context, unit: &Unit) -> CargoResult<Work> {
 
     let name = unit.pkg.name().to_string();
     if !cx.show_warnings(unit.pkg.package_id()) {
-        if try!(cx.config.rustc_info()).cap_lints {
+        if try!(cx.config.rustc()).cap_lints {
             rustc.arg("--cap-lints").arg("allow");
         } else {
             rustc.arg("-Awarnings");

--- a/src/cargo/ops/cargo_test.rs
+++ b/src/cargo/ops/cargo_test.rs
@@ -117,7 +117,7 @@ fn run_doc_tests(options: &TestOptions,
 
     // We don't build/rust doctests if target != host
     if let Some(target) = options.compile_opts.target {
-        if try!(config.rustc_info()).host != target {
+        if try!(config.rustc()).host != target {
             return Ok(errors);
         }
     }

--- a/src/cargo/util/config.rs
+++ b/src/cargo/util/config.rs
@@ -24,7 +24,7 @@ use self::ConfigValue as CV;
 pub struct Config {
     home_path: Filesystem,
     shell: RefCell<MultiShell>,
-    rustc_info: RefCell<Option<Rustc>>,
+    rustc: RefCell<Option<Rustc>>,
     values: RefCell<HashMap<String, ConfigValue>>,
     values_loaded: Cell<bool>,
     cwd: PathBuf,
@@ -42,7 +42,7 @@ impl Config {
         let mut cfg = Config {
             home_path: Filesystem::new(homedir),
             shell: RefCell::new(shell),
-            rustc_info: RefCell::new(None),
+            rustc: RefCell::new(None),
             cwd: cwd,
             values: RefCell::new(HashMap::new()),
             values_loaded: Cell::new(false),
@@ -96,11 +96,6 @@ impl Config {
         self.shell.borrow_mut()
     }
 
-    pub fn rustc(&self) -> CargoResult<Ref<Path>> {
-        let rustc = try!(self.rustc_info());
-        Ok(Ref::map(rustc, |r| r.path.as_ref()))
-    }
-
     pub fn rustdoc(&self) -> CargoResult<Ref<Path>> {
         if self.rustdoc.borrow().is_none() {
             *self.rustdoc.borrow_mut() = Some(try!(self.get_tool("rustdoc")));
@@ -108,12 +103,12 @@ impl Config {
         Ok(Ref::map(self.rustdoc.borrow(), |opt| opt.as_ref().map(AsRef::as_ref).unwrap()))
     }
 
-    pub fn rustc_info(&self) -> CargoResult<Ref<Rustc>> {
-        if self.rustc_info.borrow().is_none() {
+    pub fn rustc(&self) -> CargoResult<Ref<Rustc>> {
+        if self.rustc.borrow().is_none() {
             let path = try!(self.get_tool("rustc"));
-            *self.rustc_info.borrow_mut() = Some(try!(Rustc::new(path)));
+            *self.rustc.borrow_mut() = Some(try!(Rustc::new(path)));
         }
-        Ok(Ref::map(self.rustc_info.borrow(), |opt| opt.as_ref().unwrap()))
+        Ok(Ref::map(self.rustc.borrow(), |opt| opt.as_ref().unwrap()))
     }
 
     pub fn values(&self) -> CargoResult<Ref<HashMap<String, ConfigValue>>> {

--- a/src/cargo/util/config.rs
+++ b/src/cargo/util/config.rs
@@ -1,4 +1,4 @@
-use std::cell::{RefCell, RefMut, Ref, Cell};
+use std::cell::{RefCell, RefMut, Cell};
 use std::collections::hash_map::Entry::{Occupied, Vacant};
 use std::collections::hash_map::{HashMap};
 use std::env;
@@ -15,7 +15,7 @@ use toml;
 use core::shell::{Verbosity, ColorConfig};
 use core::{MultiShell, Workspace};
 use util::{CargoResult, CargoError, ChainError, Rustc, internal, human};
-use util::Filesystem;
+use util::{Filesystem, LazyCell};
 
 use util::toml as cargo_toml;
 
@@ -24,11 +24,10 @@ use self::ConfigValue as CV;
 pub struct Config {
     home_path: Filesystem,
     shell: RefCell<MultiShell>,
-    rustc: RefCell<Option<Rustc>>,
-    values: RefCell<HashMap<String, ConfigValue>>,
-    values_loaded: Cell<bool>,
+    rustc: LazyCell<Rustc>,
+    values: LazyCell<HashMap<String, ConfigValue>>,
     cwd: PathBuf,
-    rustdoc: RefCell<Option<PathBuf>>,
+    rustdoc: LazyCell<PathBuf>,
     target_dir: RefCell<Option<Filesystem>>,
     extra_verbose: Cell<bool>,
     frozen: Cell<bool>,
@@ -42,11 +41,10 @@ impl Config {
         let mut cfg = Config {
             home_path: Filesystem::new(homedir),
             shell: RefCell::new(shell),
-            rustc: RefCell::new(None),
+            rustc: LazyCell::new(),
             cwd: cwd,
-            values: RefCell::new(HashMap::new()),
-            values_loaded: Cell::new(false),
-            rustdoc: RefCell::new(None),
+            values: LazyCell::new(),
+            rustdoc: LazyCell::new(),
             target_dir: RefCell::new(None),
             extra_verbose: Cell::new(false),
             frozen: Cell::new(false),
@@ -96,27 +94,16 @@ impl Config {
         self.shell.borrow_mut()
     }
 
-    pub fn rustdoc(&self) -> CargoResult<Ref<Path>> {
-        if self.rustdoc.borrow().is_none() {
-            *self.rustdoc.borrow_mut() = Some(try!(self.get_tool("rustdoc")));
-        }
-        Ok(Ref::map(self.rustdoc.borrow(), |opt| opt.as_ref().map(AsRef::as_ref).unwrap()))
+    pub fn rustdoc(&self) -> CargoResult<&Path> {
+        self.rustdoc.get_or_try_init(|| self.get_tool("rustdoc")).map(AsRef::as_ref)
     }
 
-    pub fn rustc(&self) -> CargoResult<Ref<Rustc>> {
-        if self.rustc.borrow().is_none() {
-            let path = try!(self.get_tool("rustc"));
-            *self.rustc.borrow_mut() = Some(try!(Rustc::new(path)));
-        }
-        Ok(Ref::map(self.rustc.borrow(), |opt| opt.as_ref().unwrap()))
+    pub fn rustc(&self) -> CargoResult<&Rustc> {
+        self.rustc.get_or_try_init(|| Rustc::new(try!(self.get_tool("rustc"))))
     }
 
-    pub fn values(&self) -> CargoResult<Ref<HashMap<String, ConfigValue>>> {
-        if !self.values_loaded.get() {
-            try!(self.load_values());
-            self.values_loaded.set(true);
-        }
-        Ok(self.values.borrow())
+    pub fn values(&self) -> CargoResult<&HashMap<String, ConfigValue>> {
+        self.values.get_or_try_init(|| self.load_values())
     }
 
     pub fn cwd(&self) -> &Path { &self.cwd }
@@ -354,7 +341,7 @@ impl Config {
         !self.frozen.get() && !self.locked.get()
     }
 
-    fn load_values(&self) -> CargoResult<()> {
+    fn load_values(&self) -> CargoResult<HashMap<String, ConfigValue>> {
         let mut cfg = CV::Table(HashMap::new(), PathBuf::from("."));
 
         try!(walk_tree(&self.cwd, |mut file, path| {
@@ -376,11 +363,10 @@ impl Config {
         }).chain_error(|| human("Couldn't load Cargo configuration")));
 
 
-        *self.values.borrow_mut() = match cfg {
-            CV::Table(map, _) => map,
+        match cfg {
+            CV::Table(map, _) => Ok(map),
             _ => unreachable!(),
-        };
-        Ok(())
+        }
     }
 
     fn scrape_target_dir_config(&mut self) -> CargoResult<()> {

--- a/src/cargo/util/rustc.rs
+++ b/src/cargo/util/rustc.rs
@@ -1,8 +1,9 @@
-use std::path::Path;
+use std::path::PathBuf;
 
 use util::{self, CargoResult, internal, ChainError};
 
 pub struct Rustc {
+    pub path: PathBuf,
     pub verbose_version: String,
     pub host: String,
     /// Backwards compatibility: does this compiler support `--cap-lints` flag?
@@ -15,8 +16,8 @@ impl Rustc {
     ///
     /// If successful this function returns a description of the compiler along
     /// with a list of its capabilities.
-    pub fn new<P: AsRef<Path>>(path: P) -> CargoResult<Rustc> {
-        let mut cmd = util::process(path.as_ref());
+    pub fn new(path: PathBuf) -> CargoResult<Rustc> {
+        let mut cmd = util::process(&path);
         cmd.arg("-vV");
 
         let mut first = cmd.clone();
@@ -42,6 +43,7 @@ impl Rustc {
         };
 
         Ok(Rustc {
+            path: path,
             verbose_version: verbose_version,
             host: host,
             cap_lints: cap_lints,

--- a/src/cargo/util/rustc.rs
+++ b/src/cargo/util/rustc.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use util::{self, CargoResult, internal, ChainError};
+use util::{self, CargoResult, internal, ChainError, ProcessBuilder};
 
 pub struct Rustc {
     pub path: PathBuf,
@@ -48,5 +48,9 @@ impl Rustc {
             host: host,
             cap_lints: cap_lints,
         })
+    }
+
+    pub fn process(&self) -> ProcessBuilder {
+        util::process(&self.path)
     }
 }

--- a/tests/cargotest/lib.rs
+++ b/tests/cargotest/lib.rs
@@ -21,11 +21,12 @@ extern crate log;
 use cargo::util::Rustc;
 use std::ffi::OsStr;
 use std::time::Duration;
+use std::path::PathBuf;
 
 pub mod support;
 pub mod install;
 
-thread_local!(pub static RUSTC: Rustc = Rustc::new("rustc").unwrap());
+thread_local!(pub static RUSTC: Rustc = Rustc::new(PathBuf::from("rustc")).unwrap());
 
 pub fn rustc_host() -> String {
     RUSTC.with(|r| r.host.clone())


### PR DESCRIPTION
Next piece of #2848. 

* `config.rustc`  and `config.rustdoc` are now lazy.
* `Rustc` and not `config.rustc` now knows the path to the compiler.
* `LazyCell` is used to implement laziness

No new tests are added, because we need to lazify `target_path` to deal with broken cargo config. 

`target_path` is a bit peculiar. It is always accessed as `ws.config.target_path(ws)`, and has a setter. Perhaps it belongs to the workspace? Will look into that later. 