### PR TITLE
Switch to output release/debug after compile

### DIFF
--- a/tests/bad-config.rs
+++ b/tests/bad-config.rs
@@ -459,6 +459,7 @@ fn unused_keys() {
                 execs().with_status(0).with_stderr("\
 warning: unused manifest key: target.foo.bar
 [COMPILING] foo v0.1.0 (file:///[..])
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 "));
 }
 
@@ -509,5 +510,6 @@ invalid), but this file has a table header which does not have a newline after
 it. A newline needs to be added and this warning will soon become a hard error
 in the future.
 [COMPILING] empty_deps v0.0.0 ([..])
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 "));
 }

--- a/tests/bench.rs
+++ b/tests/bench.rs
@@ -42,6 +42,7 @@ fn cargo_bench_simple() {
     assert_that(p.cargo("bench"),
                 execs().with_stderr(&format!("\
 [COMPILING] foo v0.5.0 ({})
+[FINISHED] release [optimized] target(s) in [..]
 [RUNNING] target[..]release[..]foo-[..]", p.url()))
                        .with_stdout("
 running 1 test
@@ -76,6 +77,7 @@ fn bench_tarname() {
         execs().with_status(0)
                .with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({dir})
+[FINISHED] release [optimized] target(s) in [..]
 [RUNNING] target[..]release[..]bin2[..]
 ", dir = prj.url()))
                .with_stdout("
@@ -104,6 +106,7 @@ fn cargo_bench_verbose() {
                 execs().with_stderr(&format!("\
 [COMPILING] foo v0.5.0 ({url})
 [RUNNING] `rustc src[..]foo.rs [..]`
+[FINISHED] release [optimized] target(s) in [..]
 [RUNNING] `[..]target[..]release[..]foo-[..] hello --bench`", url = p.url()))
                        .with_stdout("
 running 1 test
@@ -186,6 +189,7 @@ running 1 test
 test bench_hello ... ")
                        .with_stderr_contains(format!("\
 [COMPILING] foo v0.5.0 ({})
+[FINISHED] release [optimized] target(s) in [..]
 [RUNNING] target[..]release[..]foo-[..]
 thread '[..]' panicked at 'assertion failed: \
     `(left == right)` (left: \
@@ -238,6 +242,7 @@ fn bench_with_lib_dep() {
     assert_that(p.cargo_process("bench"),
                 execs().with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({})
+[FINISHED] release [optimized] target(s) in [..]
 [RUNNING] target[..]release[..]baz-[..]
 [RUNNING] target[..]release[..]foo-[..]", p.url()))
                        .with_stdout("
@@ -301,6 +306,7 @@ fn bench_with_deep_lib_dep() {
                        .with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ([..])
 [COMPILING] bar v0.0.1 ({dir})
+[FINISHED] release [optimized] target(s) in [..]
 [RUNNING] target[..]", dir = p.url()))
                        .with_stdout("
 running 1 test
@@ -346,6 +352,7 @@ fn external_bench_explicit() {
     assert_that(p.cargo_process("bench"),
                 execs().with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({})
+[FINISHED] release [optimized] target(s) in [..]
 [RUNNING] target[..]release[..]bench-[..]
 [RUNNING] target[..]release[..]foo-[..]", p.url()))
                        .with_stdout("
@@ -395,6 +402,7 @@ fn external_bench_implicit() {
     assert_that(p.cargo_process("bench"),
                 execs().with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({})
+[FINISHED] release [optimized] target(s) in [..]
 [RUNNING] target[..]release[..]external-[..]
 [RUNNING] target[..]release[..]foo-[..]", p.url()))
                        .with_stdout("
@@ -455,6 +463,7 @@ fn pass_through_command_line() {
                 execs().with_status(0)
                 .with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({dir})
+[FINISHED] release [optimized] target(s) in [..]
 [RUNNING] target[..]release[..]foo-[..]", dir = p.url()))
                 .with_stdout("
 running 1 test
@@ -466,7 +475,7 @@ test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured
 
     assert_that(p.cargo("bench").arg("foo"),
                 execs().with_status(0)
-                       .with_stderr("\
+                       .with_stderr("[FINISHED] release [optimized] target(s) in [..]
 [RUNNING] target[..]release[..]foo-[..]")
                        .with_stdout("
 running 1 test
@@ -536,6 +545,7 @@ fn lib_bin_same_name() {
     assert_that(p.cargo_process("bench"),
                 execs().with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({})
+[FINISHED] release [optimized] target(s) in [..]
 [RUNNING] target[..]release[..]foo-[..]
 [RUNNING] target[..]release[..]foo-[..]", p.url()))
                        .with_stdout("
@@ -589,6 +599,7 @@ fn lib_with_standard_name() {
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] syntax v0.0.1 ({dir})
+[FINISHED] release [optimized] target(s) in [..]
 [RUNNING] target[..]release[..]bench-[..]
 [RUNNING] target[..]release[..]syntax-[..]", dir = p.url()))
                        .with_stdout("
@@ -640,6 +651,7 @@ fn lib_with_standard_name2() {
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] syntax v0.0.1 ({dir})
+[FINISHED] release [optimized] target(s) in [..]
 [RUNNING] target[..]release[..]syntax-[..]", dir = p.url()))
                        .with_stdout("
 running 1 test
@@ -709,6 +721,7 @@ fn bench_dylib() {
 [RUNNING] [..] -C opt-level=3 [..]
 [RUNNING] [..] -C opt-level=3 [..]
 [RUNNING] [..] -C opt-level=3 [..]
+[FINISHED] release [optimized] target(s) in [..]
 [RUNNING] [..]target[..]release[..]bench-[..]
 [RUNNING] [..]target[..]release[..]foo-[..]", dir = p.url()))
                        .with_stdout("
@@ -730,6 +743,7 @@ test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured
                        .with_stderr(&format!("\
 [FRESH] bar v0.0.1 ({dir}/bar)
 [FRESH] foo v0.0.1 ({dir})
+[FINISHED] release [optimized] target(s) in [..]
 [RUNNING] [..]target[..]release[..]bench-[..]
 [RUNNING] [..]target[..]release[..]foo-[..]", dir = p.url()))
                        .with_stdout("
@@ -771,6 +785,7 @@ fn bench_twice_with_build_cmd() {
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({dir})
+[FINISHED] release [optimized] target(s) in [..]
 [RUNNING] target[..]release[..]foo-[..]", dir = p.url()))
                        .with_stdout("
 running 1 test
@@ -782,7 +797,7 @@ test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured
 
     assert_that(p.cargo("bench"),
                 execs().with_status(0)
-                       .with_stderr("\
+                       .with_stderr("[FINISHED] release [optimized] target(s) in [..]
 [RUNNING] target[..]release[..]foo-[..]")
                        .with_stdout("
 running 1 test
@@ -855,6 +870,7 @@ fn bench_with_examples() {
 [RUNNING] `rustc [..]`
 [RUNNING] `rustc [..]`
 [RUNNING] `rustc [..]`
+[FINISHED] release [optimized] target(s) in [..]
 [RUNNING] `{dir}[..]target[..]release[..]testb1-[..] --bench`
 [RUNNING] `{dir}[..]target[..]release[..]testbench-[..] --bench`",
                 dir = p.root().display(), url = p.url()))
@@ -903,6 +919,7 @@ fn test_a_bench() {
                 execs().with_status(0)
                        .with_stderr("\
 [COMPILING] foo v0.1.0 ([..])
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target[..]debug[..]b-[..]")
                        .with_stdout("
 running 1 test
@@ -940,6 +957,7 @@ fn test_bench_no_run() {
                 execs().with_status(0)
                        .with_stderr("\
 [COMPILING] foo v0.1.0 ([..])
+[FINISHED] release [optimized] target(s) in [..]
 "));
 }
 

--- a/tests/build-lib.rs
+++ b/tests/build-lib.rs
@@ -14,6 +14,7 @@ fn verbose_output_for_lib(p: &ProjectBuilder) -> String {
         --emit=dep-info,link \
         -L dependency={dir}{sep}target{sep}debug \
         -L dependency={dir}{sep}target{sep}debug{sep}deps`
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 ", sep = SEP,
             dir = p.root().display(), url = p.url(),
             name = "foo", version = "0.0.1")

--- a/tests/build-script.rs
+++ b/tests/build-script.rs
@@ -307,6 +307,7 @@ fn overrides_and_links() {
 [..]
 [..]
 [RUNNING] `rustc [..] --crate-name foo [..] -L foo -L bar[..]`
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 "));
 }
 
@@ -408,6 +409,7 @@ fn only_rerun_build_script() {
 [COMPILING] foo v0.5.0 (file://[..])
 [RUNNING] `[..]build-script-build[..]`
 [RUNNING] `rustc [..] --crate-name foo [..]`
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 "));
 }
 
@@ -496,6 +498,7 @@ fn testing_and_such() {
 [RUNNING] `[..]build-script-build[..]`
 [RUNNING] `rustc [..] --crate-name foo [..]`
 [RUNNING] `rustc [..] --crate-name foo [..]`
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `[..]foo-[..][..]`
 [DOCTEST] foo
 [RUNNING] `rustdoc --test [..]`")
@@ -526,6 +529,7 @@ test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
                 execs().with_status(0)
                        .with_stderr("\
 [COMPILING] foo v0.5.0 (file://[..])
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `target[..]foo[..]`
 "));
 }
@@ -672,6 +676,7 @@ fn build_deps_simple() {
 [RUNNING] `rustc build.rs [..] --extern a=[..]`
 [RUNNING] `[..]foo-[..]build-script-build[..]`
 [RUNNING] `rustc [..] --crate-name foo [..]`
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 "));
 }
 
@@ -774,6 +779,7 @@ fn build_cmd_with_a_build_cmd() {
 [RUNNING] `rustc [..]lib.rs --crate-name foo --crate-type lib -g \
     --out-dir [..]target[..]debug --emit=dep-info,link \
     -L [..]target[..]debug -L [..]target[..]deps`
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 "));
 }
 
@@ -922,6 +928,7 @@ fn code_generation() {
                 execs().with_status(0)
                        .with_stderr("\
 [COMPILING] foo v0.5.0 (file://[..])
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `target[..]foo`")
                        .with_stdout("\
 Hello, World!
@@ -1363,6 +1370,7 @@ fn cfg_test() {
 [RUNNING] [..] --cfg foo[..]
 [RUNNING] [..] --cfg foo[..]
 [RUNNING] [..] --cfg foo[..]
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] [..]foo-[..]
 [RUNNING] [..]test-[..]
 [DOCTEST] foo
@@ -1479,6 +1487,7 @@ fn cfg_override_test() {
 [RUNNING] `[..]`
 [RUNNING] `[..]`
 [RUNNING] `[..]`
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] [..]foo-[..]
 [RUNNING] [..]test-[..]
 [DOCTEST] foo
@@ -1598,6 +1607,7 @@ fn flags_go_into_tests() {
 [COMPILING] foo v0.5.0 ([..]
 [RUNNING] `rustc src[..]lib.rs [..] -L test[..]`
 [RUNNING] `rustc tests[..]foo.rs [..] -L test[..]`
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `[..]foo-[..]`")
                        .with_stdout("
 running 0 tests
@@ -1612,6 +1622,7 @@ test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
 [FRESH] a v0.5.0 ([..]
 [COMPILING] b v0.5.0 ([..]
 [RUNNING] `rustc b[..]src[..]lib.rs [..] -L test[..]`
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `[..]b-[..]`")
                        .with_stdout("
 running 0 tests
@@ -1681,6 +1692,7 @@ fn diamond_passes_args_only_once() {
 [RUNNING] `rustc [..]`
 [COMPILING] foo v0.5.0 ([..]
 [RUNNING] `[..]rlib -L native=test`
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 "));
 }
 
@@ -1710,6 +1722,7 @@ fn adding_an_override_invalidates() {
 [RUNNING] `rustc [..]`
 [RUNNING] `[..]`
 [RUNNING] `rustc [..] -L native=foo`
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 "));
 
     File::create(p.root().join(".cargo/config")).unwrap().write_all(format!("
@@ -1721,6 +1734,7 @@ fn adding_an_override_invalidates() {
                 execs().with_status(0).with_stderr("\
 [COMPILING] foo v0.5.0 ([..]
 [RUNNING] `rustc [..] -L native=bar`
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 "));
 }
 
@@ -1747,6 +1761,7 @@ fn changing_an_override_invalidates() {
                 execs().with_status(0).with_stderr("\
 [COMPILING] foo v0.5.0 ([..]
 [RUNNING] `rustc [..] -L native=foo`
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 "));
 
     File::create(p.root().join(".cargo/config")).unwrap().write_all(format!("
@@ -1758,6 +1773,7 @@ fn changing_an_override_invalidates() {
                 execs().with_status(0).with_stderr("\
 [COMPILING] foo v0.5.0 ([..]
 [RUNNING] `rustc [..] -L native=bar`
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 "));
 }
 
@@ -1790,6 +1806,7 @@ fn rebuild_only_on_explicit_paths() {
 [COMPILING] a v0.5.0 ([..])
 [RUNNING] `[..]build-script-build[..]`
 [RUNNING] `rustc src[..]lib.rs [..]`
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 "));
 
     sleep_ms(1000);
@@ -1803,12 +1820,14 @@ fn rebuild_only_on_explicit_paths() {
 [COMPILING] a v0.5.0 ([..])
 [RUNNING] `[..]build-script-build[..]`
 [RUNNING] `rustc src[..]lib.rs [..]`
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 "));
 
     println!("run with2");
     assert_that(p.cargo("build").arg("-v"),
                 execs().with_status(0).with_stderr("\
 [FRESH] a v0.5.0 ([..])
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 "));
 
     sleep_ms(1000);
@@ -1819,6 +1838,7 @@ fn rebuild_only_on_explicit_paths() {
     assert_that(p.cargo("build").arg("-v"),
                 execs().with_status(0).with_stderr("\
 [FRESH] a v0.5.0 ([..])
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 "));
 
     // but changing dependent files does
@@ -1829,6 +1849,7 @@ fn rebuild_only_on_explicit_paths() {
 [COMPILING] a v0.5.0 ([..])
 [RUNNING] `[..]build-script-build[..]`
 [RUNNING] `rustc src[..]lib.rs [..]`
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 "));
 
     // .. as does deleting a file
@@ -1839,6 +1860,7 @@ fn rebuild_only_on_explicit_paths() {
 [COMPILING] a v0.5.0 ([..])
 [RUNNING] `[..]build-script-build[..]`
 [RUNNING] `rustc src[..]lib.rs [..]`
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 "));
 }
 
@@ -2053,6 +2075,7 @@ fn warnings_emitted() {
 warning: foo
 warning: bar
 [RUNNING] `rustc [..]`
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 "));
 }
 
@@ -2098,6 +2121,7 @@ fn warnings_hidden_for_upstream() {
 [RUNNING] `rustc [..]`
 [COMPILING] foo v0.5.0 ([..])
 [RUNNING] `rustc [..]`
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 "));
 }
 
@@ -2145,6 +2169,7 @@ warning: bar
 [RUNNING] `rustc [..]`
 [COMPILING] foo v0.5.0 ([..])
 [RUNNING] `rustc [..]`
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 "));
 }
 
@@ -2179,6 +2204,7 @@ stdout
 [RUNNING] `[..]`
 stderr
 [RUNNING] `rustc [..]`
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 "));
 }
 

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -904,6 +904,7 @@ fn unused_keys() {
                        .with_stderr("\
 warning: unused manifest key: project.bulid
 [COMPILING] foo [..]
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 "));
 
     let mut p = project("bar");
@@ -928,6 +929,7 @@ warning: unused manifest key: project.bulid
                        .with_stderr("\
 warning: unused manifest key: lib.build
 [COMPILING] foo [..]
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 "));
 }
 
@@ -1026,6 +1028,7 @@ fn lto_build() {
         --emit=dep-info,link \
         -L dependency={dir}[..]target[..]release \
         -L dependency={dir}[..]target[..]release[..]deps`
+[FINISHED] release [optimized] target(s) in [..]
 ",
 dir = p.root().display(),
 url = p.url(),
@@ -1052,6 +1055,7 @@ fn verbose_build() {
         --emit=dep-info,link \
         -L dependency={dir}[..]target[..]debug \
         -L dependency={dir}[..]target[..]debug[..]deps`
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 ",
 dir = p.root().display(),
 url = p.url(),
@@ -1079,6 +1083,7 @@ fn verbose_release_build() {
         --emit=dep-info,link \
         -L dependency={dir}[..]target[..]release \
         -L dependency={dir}[..]target[..]release[..]deps`
+[FINISHED] release [optimized] target(s) in [..]
 ",
 dir = p.root().display(),
 url = p.url(),
@@ -1134,6 +1139,7 @@ fn verbose_release_build_deps() {
         --extern foo={dir}[..]target[..]release[..]deps[..]\
                      {prefix}foo-[..]{suffix} \
         --extern foo={dir}[..]target[..]release[..]deps[..]libfoo-[..].rlib`
+[FINISHED] release [optimized] target(s) in [..]
 ",
                     dir = p.root().display(),
                     url = p.url(),
@@ -1346,6 +1352,7 @@ fn lib_with_standard_name() {
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] syntax v0.0.1 ({dir})
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 ",
                        dir = p.url())));
 }
@@ -1447,6 +1454,7 @@ fn freshness_ignores_excluded() {
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] foo v0.0.0 ({url})
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 ", url = foo.url())));
 
     // Smoke test to make sure it doesn't compile again
@@ -1495,6 +1503,7 @@ fn rebuild_preserves_out_dir() {
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] foo v0.0.0 ({url})
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 ", url = foo.url())));
 
     File::create(&foo.root().join("src/bar.rs")).unwrap();
@@ -1502,6 +1511,7 @@ fn rebuild_preserves_out_dir() {
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] foo v0.0.0 ({url})
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 ", url = foo.url())));
 }
 
@@ -2238,6 +2248,7 @@ fn explicit_color_config_is_propagated_to_rustc() {
         --emit=dep-info,link \
         -L dependency=[..]target[..]debug \
         -L dependency=[..]target[..]debug[..]deps`
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 "));
 }
 
@@ -2261,5 +2272,6 @@ fn no_warn_about_package_metadata() {
         .file("src/lib.rs", "");
     assert_that(p.cargo_process("build"),
                 execs().with_status(0)
-                       .with_stderr("[..] foo v0.0.1 ([..])\n"));
+                       .with_stderr("[..] foo v0.0.1 ([..])\n\
+                       [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]\n"));
 }

--- a/tests/cargo_alias_config.rs
+++ b/tests/cargo_alias_config.rs
@@ -118,5 +118,6 @@ fn cant_shadow_builtin() {
                 execs().with_status(0)
                        .with_stderr("\
 [COMPILING] foo v0.5.0 ([..])
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 "));
 }

--- a/tests/cargotest/support/mod.rs
+++ b/tests/cargotest/support/mod.rs
@@ -636,6 +636,7 @@ fn substitute_macros(input: &str) -> String {
     let macros = [
         ("[RUNNING]",     "     Running"),
         ("[COMPILING]",   "   Compiling"),
+        ("[FINISHED]",    "    Finished"),
         ("[ERROR]",       "error:"),
         ("[WARNING]",     "warning:"),
         ("[DOCUMENTING]", " Documenting"),

--- a/tests/cfg.rs
+++ b/tests/cfg.rs
@@ -190,6 +190,7 @@ fn dont_include() {
     assert_that(p.cargo_process("build"),
                 execs().with_status(0).with_stderr("\
 [COMPILING] a v0.0.1 ([..])
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 "));
 }
 
@@ -223,6 +224,7 @@ fn works_through_the_registry() {
 [COMPILING] foo v0.1.0 ([..])
 [COMPILING] bar v0.1.0 ([..])
 [COMPILING] a v0.0.1 ([..])
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 "));
 }
 

--- a/tests/clean.rs
+++ b/tests/clean.rs
@@ -133,6 +133,7 @@ fn clean_release() {
     assert_that(p.cargo("build").arg("--release"),
                 execs().with_status(0).with_stderr("\
 [COMPILING] foo v0.0.1 ([..])
+[FINISHED] release [optimized] target(s) in [..]
 "));
 }
 
@@ -173,6 +174,7 @@ fn build_script() {
 [RUNNING] `rustc build.rs [..]`
 [RUNNING] `[..]build-script-build[..]`
 [RUNNING] `rustc src[..]main.rs [..]`
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 "));
 }
 

--- a/tests/concurrent.rs
+++ b/tests/concurrent.rs
@@ -421,8 +421,10 @@ fn debug_release_ok() {
 
     assert_that(a, execs().with_status(0).with_stderr("\
 [COMPILING] foo v0.0.0 [..]
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 "));
     assert_that(b, execs().with_status(0).with_stderr("\
 [COMPILING] foo v0.0.0 [..]
+[FINISHED] release [optimized] target(s) in [..]
 "));
 }

--- a/tests/cross-compile.rs
+++ b/tests/cross-compile.rs
@@ -472,6 +472,7 @@ fn cross_tests() {
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] foo v0.0.0 ({foo})
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target[..]{triple}[..]bar-[..]
 [RUNNING] target[..]{triple}[..]foo-[..]", foo = p.url(), triple = target))
                        .with_stdout("
@@ -509,6 +510,7 @@ fn no_cross_doctests() {
 
     let host_output = format!("\
 [COMPILING] foo v0.0.0 ({foo})
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target[..]foo-[..]
 [DOCTEST] foo
 ", foo = p.url());
@@ -530,6 +532,7 @@ fn no_cross_doctests() {
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] foo v0.0.0 ({foo})
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target[..]{triple}[..]foo-[..]
 ", foo = p.url(), triple = target)));
 }
@@ -599,6 +602,7 @@ fn cross_with_a_build_script() {
 [RUNNING] `rustc build.rs [..] --out-dir {dir}[..]target[..]build[..]foo-[..]`
 [RUNNING] `{dir}[..]target[..]build[..]foo-[..]build-script-build`
 [RUNNING] `rustc src[..]main.rs [..] --target {target} [..]`
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 ", target = target,
    dir = p.root().display())));
 }
@@ -798,6 +802,7 @@ fn plugin_build_script_right_arch() {
 [RUNNING] `rustc build.rs [..]`
 [RUNNING] `[..]build-script-build[..]`
 [RUNNING] `rustc src[..]lib.rs [..]`
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 "));
 }
 
@@ -849,6 +854,7 @@ fn build_script_with_platform_specific_dependencies() {
 [RUNNING] `rustc build.rs [..]`
 [RUNNING] `{dir}[..]target[..]build[..]foo-[..]build-script-build`
 [RUNNING] `rustc src[..]lib.rs [..] --target {target} [..]`
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 ", dir = p.root().display(), target = target)));
 }
 

--- a/tests/doc.rs
+++ b/tests/doc.rs
@@ -154,6 +154,7 @@ fn doc_no_deps() {
                 execs().with_status(0).with_stderr(&format!("\
 [COMPILING] bar v0.0.1 ({dir}/bar)
 [DOCUMENTING] foo v0.0.1 ({dir})
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 ",
         dir = path2url(p.root()))));
 

--- a/tests/features.rs
+++ b/tests/features.rs
@@ -307,6 +307,7 @@ fn no_feature_doesnt_build() {
     assert_that(p.cargo_process("build"),
                 execs().with_status(0).with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({dir})
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 ", dir = p.url())));
     assert_that(p.process(&p.bin("foo")),
                 execs().with_status(0).with_stdout(""));
@@ -315,6 +316,7 @@ fn no_feature_doesnt_build() {
                 execs().with_status(0).with_stderr(format!("\
 [COMPILING] bar v0.0.1 ({dir}/bar)
 [COMPILING] foo v0.0.1 ({dir})
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 ", dir = p.url())));
     assert_that(p.process(&p.bin("foo")),
                 execs().with_status(0).with_stdout("bar\n"));
@@ -356,6 +358,7 @@ fn default_feature_pulled_in() {
                 execs().with_status(0).with_stderr(format!("\
 [COMPILING] bar v0.0.1 ({dir}/bar)
 [COMPILING] foo v0.0.1 ({dir})
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 ", dir = p.url())));
     assert_that(p.process(&p.bin("foo")),
                 execs().with_status(0).with_stdout("bar\n"));
@@ -363,6 +366,7 @@ fn default_feature_pulled_in() {
     assert_that(p.cargo("build").arg("--no-default-features"),
                 execs().with_status(0).with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({dir})
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 ", dir = p.url())));
     assert_that(p.process(&p.bin("foo")),
                 execs().with_status(0).with_stdout(""));
@@ -461,6 +465,7 @@ fn groups_on_groups_on_groups() {
 [COMPILING] ba[..] v0.0.1 ({dir}/ba[..])
 [COMPILING] ba[..] v0.0.1 ({dir}/ba[..])
 [COMPILING] foo v0.0.1 ({dir})
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 ", dir = p.url())));
 }
 
@@ -506,6 +511,7 @@ fn many_cli_features() {
 [COMPILING] ba[..] v0.0.1 ({dir}/ba[..])
 [COMPILING] ba[..] v0.0.1 ({dir}/ba[..])
 [COMPILING] foo v0.0.1 ({dir})
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 ", dir = p.url())));
 }
 
@@ -568,6 +574,7 @@ fn union_features() {
 [COMPILING] d2 v0.0.1 ({dir}/d2)
 [COMPILING] d1 v0.0.1 ({dir}/d1)
 [COMPILING] foo v0.0.1 ({dir})
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 ", dir = p.url())));
 }
 
@@ -602,6 +609,7 @@ fn many_features_no_rebuilds() {
                 execs().with_status(0).with_stderr(format!("\
 [COMPILING] a v0.1.0 ({dir}/a)
 [COMPILING] b v0.1.0 ({dir})
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 ", dir = p.url())));
     p.root().move_into_the_past();
 
@@ -609,6 +617,7 @@ fn many_features_no_rebuilds() {
                 execs().with_status(0).with_stderr("\
 [FRESH] a v0.1.0 ([..]/a)
 [FRESH] b v0.1.0 ([..])
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 "));
 }
 
@@ -840,6 +849,7 @@ fn optional_and_dev_dep() {
     assert_that(p.cargo_process("build"),
                 execs().with_status(0).with_stderr("\
 [COMPILING] test v0.1.0 ([..])
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 "));
 }
 

--- a/tests/freshness.rs
+++ b/tests/freshness.rs
@@ -26,6 +26,7 @@ fn modifying_and_moving() {
     assert_that(p.cargo_process("build"),
                 execs().with_status(0).with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({dir})
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 ", dir = path2url(p.root()))));
 
     assert_that(p.cargo("build"),
@@ -38,6 +39,7 @@ fn modifying_and_moving() {
     assert_that(p.cargo("build"),
                 execs().with_status(0).with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({dir})
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 ", dir = path2url(p.root()))));
 
     fs::rename(&p.root().join("src/a.rs"), &p.root().join("src/b.rs")).unwrap();
@@ -66,6 +68,7 @@ fn modify_only_some_files() {
     assert_that(p.cargo_process("build"),
                 execs().with_status(0).with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({dir})
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 ", dir = path2url(p.root()))));
     assert_that(p.cargo("test"),
                 execs().with_status(0));
@@ -84,6 +87,7 @@ fn modify_only_some_files() {
     assert_that(p.cargo("build"),
                 execs().with_status(0).with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({dir})
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 ", dir = path2url(p.root()))));
     assert_that(&p.bin("foo"), existing_file());
 }
@@ -158,18 +162,21 @@ fn changing_features_is_ok() {
                 execs().with_status(0)
                        .with_stderr("\
 [..]Compiling foo v0.0.1 ([..])
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 "));
 
     assert_that(p.cargo("build").arg("--features").arg("foo"),
                 execs().with_status(0)
                        .with_stderr("\
 [..]Compiling foo v0.0.1 ([..])
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 "));
 
     assert_that(p.cargo("build"),
                 execs().with_status(0)
                        .with_stderr("\
 [..]Compiling foo v0.0.1 ([..])
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 "));
 
     assert_that(p.cargo("build"),
@@ -260,6 +267,7 @@ fn no_rebuild_transitive_target_deps() {
 [COMPILING] c v0.0.1 ([..])
 [COMPILING] b v0.0.1 ([..])
 [COMPILING] foo v0.0.1 ([..])
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 "));
 }
 
@@ -354,9 +362,11 @@ fn same_build_dir_cached_packages() {
 [COMPILING] c v0.0.1 ({dir}/c)
 [COMPILING] b v0.0.1 ({dir}/b)
 [COMPILING] a1 v0.0.1 ({dir}/a1)
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 ", dir = p.url())));
     assert_that(p.cargo("build").cwd(p.root().join("a2")),
                 execs().with_status(0).with_stderr(&format!("\
 [COMPILING] a2 v0.0.1 ({dir}/a2)
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 ", dir = p.url())));
 }

--- a/tests/git.rs
+++ b/tests/git.rs
@@ -61,7 +61,8 @@ fn cargo_compile_simple_git_dep() {
         execs()
         .with_stderr(&format!("[UPDATING] git repository `{}`\n\
                               [COMPILING] dep1 v0.5.0 ({}#[..])\n\
-                              [COMPILING] foo v0.5.0 ({})\n",
+                              [COMPILING] foo v0.5.0 ({})\n\
+                              [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]\n",
                              path2url(git_root.clone()),
                              path2url(git_root),
                              path2url(root))));
@@ -128,7 +129,8 @@ fn cargo_compile_git_dep_branch() {
         execs()
         .with_stderr(&format!("[UPDATING] git repository `{}`\n\
                               [COMPILING] dep1 v0.5.0 ({}?branch=branchy#[..])\n\
-                              [COMPILING] foo v0.5.0 ({})\n",
+                              [COMPILING] foo v0.5.0 ({})\n\
+                              [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]\n",
                              path2url(git_root.clone()),
                              path2url(git_root),
                              path2url(root))));
@@ -198,7 +200,8 @@ fn cargo_compile_git_dep_tag() {
         execs()
         .with_stderr(&format!("[UPDATING] git repository `{}`\n\
                               [COMPILING] dep1 v0.5.0 ({}?tag=v0.1.0#[..])\n\
-                              [COMPILING] foo v0.5.0 ({})\n",
+                              [COMPILING] foo v0.5.0 ({})\n\
+                              [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]\n",
                              path2url(git_root.clone()),
                              path2url(git_root),
                              path2url(root))));
@@ -506,7 +509,9 @@ fn recompilation() {
     assert_that(p.cargo_process("build"),
                 execs().with_stderr(&format!("[UPDATING] git repository `{}`\n\
                                              [COMPILING] bar v0.5.0 ({}#[..])\n\
-                                             [COMPILING] foo v0.5.0 ({})\n",
+                                             [COMPILING] foo v0.5.0 ({})\n\
+                                             [FINISHED] debug [unoptimized + debuginfo] target(s) \
+                                             in [..]\n",
                                             git_project.url(),
                                             git_project.url(),
                                             p.url())));
@@ -550,7 +555,9 @@ fn recompilation() {
     println!("going for the last compile");
     assert_that(p.cargo("build"),
                 execs().with_stderr(&format!("[COMPILING] bar v0.5.0 ({}#[..])\n\
-                                             [COMPILING] foo v0.5.0 ({})\n",
+                                             [COMPILING] foo v0.5.0 ({})\n\
+                                             [FINISHED] debug [unoptimized + debuginfo] target(s) \
+                                             in [..]\n",
                                             git_project.url(),
                                             p.url())));
 
@@ -559,7 +566,9 @@ fn recompilation() {
                  .arg("-p").arg("foo"),
                 execs().with_stdout(""));
     assert_that(p.cargo("build"),
-                execs().with_stderr(&format!("[COMPILING] foo v0.5.0 ({})\n",
+                execs().with_stderr(&format!("[COMPILING] foo v0.5.0 ({})\n\
+                                              [FINISHED] debug [unoptimized + debuginfo] target(s) \
+                                              in [..]\n",
                                             p.url())));
 }
 
@@ -629,7 +638,9 @@ fn update_with_shared_deps() {
 [COMPILING] bar v0.5.0 ({git}#[..])
 [COMPILING] [..] v0.5.0 ([..])
 [COMPILING] [..] v0.5.0 ([..])
-[COMPILING] foo v0.5.0 ({dir})\n", git = git_project.url(), dir = p.url())));
+[COMPILING] foo v0.5.0 ({dir})
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]\n",
+git = git_project.url(), dir = p.url())));
 
     // Modify a file manually, and commit it
     File::create(&git_project.root().join("src/bar.rs")).unwrap().write_all(br#"
@@ -684,7 +695,8 @@ To learn more, run the command again with --verbose.
 [COMPILING] bar v0.5.0 ({git}#[..])
 [COMPILING] [..] v0.5.0 ({dir}[..]dep[..])
 [COMPILING] [..] v0.5.0 ({dir}[..]dep[..])
-[COMPILING] foo v0.5.0 ({dir})\n",
+[COMPILING] foo v0.5.0 ({dir})
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]\n",
                     git = git_project.url(), dir = p.url())));
 
     // We should be able to update transitive deps
@@ -735,7 +747,8 @@ fn dep_with_submodule() {
                 execs().with_stderr("\
 [UPDATING] git repository [..]
 [COMPILING] dep1 [..]
-[COMPILING] foo [..]").with_status(0));
+[COMPILING] foo [..]
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]\n").with_status(0));
 }
 
 #[test]
@@ -783,7 +796,8 @@ fn two_deps_only_update_one() {
                               [UPDATING] git repository `[..]`\n\
                               [COMPILING] [..] v0.5.0 ([..])\n\
                               [COMPILING] [..] v0.5.0 ([..])\n\
-                              [COMPILING] foo v0.5.0 ({})\n",
+                              [COMPILING] foo v0.5.0 ({})\n\
+                              [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]\n",
                              project.url())));
 
     File::create(&git1.root().join("src/lib.rs")).unwrap().write_all(br#"
@@ -868,6 +882,7 @@ fn stale_cached_version() {
 [UPDATING] git repository `{bar}`
 [COMPILING] bar v0.0.0 ({bar}#[..])
 [COMPILING] foo v0.0.0 ({foo})
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 ", bar = bar.url(), foo = foo.url())));
     assert_that(foo.process(&foo.bin("foo")), execs().with_status(0));
 }
@@ -919,6 +934,8 @@ fn dep_with_changed_submodule() {
                 .with_stderr("[UPDATING] git repository `[..]`\n\
                                       [COMPILING] dep1 v0.5.0 ([..])\n\
                                       [COMPILING] foo v0.5.0 ([..])\n\
+                                      [FINISHED] debug [unoptimized + debuginfo] target(s) in \
+                                      [..]\n\
                                       [RUNNING] `target[..]foo[..]`\n")
                 .with_stdout("project2\n")
                 .with_status(0));
@@ -959,6 +976,8 @@ fn dep_with_changed_submodule() {
     assert_that(project.cargo("run"), execs()
                 .with_stderr("[COMPILING] dep1 v0.5.0 ([..])\n\
                                       [COMPILING] foo v0.5.0 ([..])\n\
+                                      [FINISHED] debug [unoptimized + debuginfo] target(s) in \
+                                      [..]\n\
                                       [RUNNING] `target[..]foo[..]`\n")
                 .with_stdout("project3\n")
                 .with_status(0));
@@ -1006,6 +1025,7 @@ fn dev_deps_with_testing() {
         execs().with_stderr(&format!("\
 [UPDATING] git repository `{bar}`
 [COMPILING] foo v0.5.0 ({url})
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 ", url = p.url(), bar = p2.url())));
 
     // Make sure we use the previous resolution of `bar` instead of updating it
@@ -1014,6 +1034,7 @@ fn dev_deps_with_testing() {
                 execs().with_stderr("\
 [COMPILING] [..] v0.5.0 ([..])
 [COMPILING] [..] v0.5.0 ([..]
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target[..]foo-[..]")
                        .with_stdout("
 running 1 test
@@ -1048,6 +1069,7 @@ fn git_build_cmd_freshness() {
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] foo v0.0.0 ({url})
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 ", url = foo.url())));
 
     // Smoke test to make sure it doesn't compile again
@@ -1101,6 +1123,7 @@ fn git_name_not_always_needed() {
         execs().with_stderr(&format!("\
 [UPDATING] git repository `{bar}`
 [COMPILING] foo v0.5.0 ({url})
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 ", url = p.url(), bar = p2.url())));
 }
 
@@ -1136,6 +1159,7 @@ fn git_repo_changing_no_rebuild() {
 [UPDATING] git repository `{bar}`
 [COMPILING] [..]
 [COMPILING] [..]
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 ", bar = bar.url())));
 
     // Make a commit to lock p2 to a different rev
@@ -1162,6 +1186,7 @@ fn git_repo_changing_no_rebuild() {
 [UPDATING] git repository `{bar}`
 [COMPILING] [..]
 [COMPILING] [..]
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 ", bar = bar.url())));
 
     // And now for the real test! Make sure that p1 doesn't get rebuilt
@@ -1291,7 +1316,8 @@ fn warnings_in_git_dep() {
         execs()
         .with_stderr(&format!("[UPDATING] git repository `{}`\n\
                               [COMPILING] bar v0.5.0 ({}#[..])\n\
-                              [COMPILING] foo v0.5.0 ({})\n",
+                              [COMPILING] foo v0.5.0 ({})\n\
+                              [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]\n",
                              bar.url(),
                              bar.url(),
                              p.url())));
@@ -1454,6 +1480,7 @@ fn switch_deps_does_not_update_transitive() {
 [COMPILING] transitive [..]
 [COMPILING] dep [..]
 [COMPILING] project [..]
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 ", dep1.url(), transitive.url())));
 
     // Update the dependency to point to the second repository, but this
@@ -1473,6 +1500,7 @@ fn switch_deps_does_not_update_transitive() {
 [UPDATING] git repository `{}`
 [COMPILING] dep [..]
 [COMPILING] project [..]
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 ", dep2.url())));
 }
 
@@ -1581,6 +1609,7 @@ fn switch_sources() {
 [COMPILING] a v0.5.0 ([..]a1#[..]
 [COMPILING] b v0.5.0 ([..])
 [COMPILING] project v0.5.0 ([..])
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 "));
 
     File::create(&p.root().join("b/Cargo.toml")).unwrap().write_all(format!(r#"
@@ -1599,6 +1628,7 @@ fn switch_sources() {
 [COMPILING] a v0.5.1 ([..]a2#[..]
 [COMPILING] b v0.5.0 ([..])
 [COMPILING] project v0.5.0 ([..])
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 "));
 }
 
@@ -1707,6 +1737,7 @@ fn lints_are_suppressed() {
 [UPDATING] git repository `[..]`
 [COMPILING] a v0.5.0 ([..])
 [COMPILING] foo v0.0.1 ([..])
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 "));
 }
 
@@ -1745,6 +1776,7 @@ fn denied_lints_are_allowed() {
 [UPDATING] git repository `[..]`
 [COMPILING] a v0.5.0 ([..])
 [COMPILING] foo v0.0.1 ([..])
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 "));
 }
 

--- a/tests/install.rs
+++ b/tests/install.rs
@@ -38,6 +38,7 @@ fn simple() {
 [UPDATING] registry `[..]`
 [DOWNLOADING] foo v0.0.1 (registry file://[..])
 [COMPILING] foo v0.0.1 (registry file://[..])
+[FINISHED] release [optimized] target(s) in [..]
 [INSTALLING] {home}[..]bin[..]foo[..]
 warning: be sure to add `[..]` to your PATH to be able to run the installed binaries
 ",
@@ -62,6 +63,7 @@ fn pick_max_version() {
 [UPDATING] registry `[..]`
 [DOWNLOADING] foo v0.0.2 (registry file://[..])
 [COMPILING] foo v0.0.2 (registry file://[..])
+[FINISHED] release [optimized] target(s) in [..]
 [INSTALLING] {home}[..]bin[..]foo[..]
 warning: be sure to add `[..]` to your PATH to be able to run the installed binaries
 ",
@@ -408,6 +410,7 @@ fn install_force() {
     assert_that(cargo_process("install").arg("--force").arg("--path").arg(p.root()),
                 execs().with_status(0).with_stderr(&format!("\
 [COMPILING] foo v0.2.0 ([..])
+[FINISHED] release [optimized] target(s) in [..]
 [REPLACING] {home}[..]bin[..]foo[..]
 warning: be sure to add `[..]` to your PATH to be able to run the installed binaries
 ",
@@ -450,6 +453,7 @@ fn install_force_partial_overlap() {
     assert_that(cargo_process("install").arg("--force").arg("--path").arg(p.root()),
                 execs().with_status(0).with_stderr(&format!("\
 [COMPILING] foo v0.2.0 ([..])
+[FINISHED] release [optimized] target(s) in [..]
 [INSTALLING] {home}[..]bin[..]foo-bin3[..]
 [REPLACING] {home}[..]bin[..]foo-bin2[..]
 warning: be sure to add `[..]` to your PATH to be able to run the installed binaries
@@ -500,6 +504,7 @@ fn install_force_bin() {
                     .arg(p.root()),
                 execs().with_status(0).with_stderr(&format!("\
 [COMPILING] foo v0.2.0 ([..])
+[FINISHED] release [optimized] target(s) in [..]
 [REPLACING] {home}[..]bin[..]foo-bin2[..]
 warning: be sure to add `[..]` to your PATH to be able to run the installed binaries
 ",
@@ -554,6 +559,7 @@ fn git_repo() {
                 execs().with_status(0).with_stderr(&format!("\
 [UPDATING] git repository `[..]`
 [COMPILING] foo v0.1.0 ([..])
+[FINISHED] release [optimized] target(s) in [..]
 [INSTALLING] {home}[..]bin[..]foo[..]
 warning: be sure to add `[..]` to your PATH to be able to run the installed binaries
 ",
@@ -690,7 +696,7 @@ fn do_not_rebuilds_on_local_install() {
     assert_that(p.cargo_process("build").arg("--release"),
                 execs().with_status(0));
     assert_that(cargo_process("install").arg("--path").arg(p.root()),
-                execs().with_status(0).with_stderr("\
+                execs().with_status(0).with_stderr("[FINISHED] release [optimized] target(s) in [..]
 [INSTALLING] [..]
 warning: be sure to add `[..]` to your PATH to be able to run the installed binaries
 "));

--- a/tests/overrides.rs
+++ b/tests/overrides.rs
@@ -47,6 +47,7 @@ fn override_simple() {
 [UPDATING] git repository `[..]`
 [COMPILING] foo v0.1.0 (file://[..])
 [COMPILING] local v0.0.1 (file://[..])
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 "));
 }
 
@@ -146,6 +147,7 @@ fn transitive() {
 [COMPILING] foo v0.1.0 (file://[..])
 [COMPILING] bar v0.2.0 (registry [..])
 [COMPILING] local v0.0.1 (file://[..])
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 "));
 
     assert_that(p.cargo("build"), execs().with_status(0).with_stdout(""));
@@ -191,6 +193,7 @@ fn persists_across_rebuilds() {
 [UPDATING] git repository `file://[..]`
 [COMPILING] foo v0.1.0 (file://[..])
 [COMPILING] local v0.0.1 (file://[..])
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 "));
 
     assert_that(p.cargo("build"),
@@ -236,6 +239,7 @@ fn replace_registry_with_path() {
 [UPDATING] registry `file://[..]`
 [COMPILING] foo v0.1.0 (file://[..])
 [COMPILING] local v0.0.1 (file://[..])
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 "));
 }
 
@@ -297,6 +301,7 @@ fn use_a_spec_to_select() {
 [COMPILING] [..]
 [COMPILING] [..]
 [COMPILING] local v0.0.1 (file://[..])
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 "));
 }
 
@@ -341,6 +346,7 @@ fn override_adds_some_deps() {
 [COMPILING] foo v0.1.1 (registry [..])
 [COMPILING] bar v0.1.0 ([..])
 [COMPILING] local v0.0.1 (file://[..])
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 "));
 
     assert_that(p.cargo("build"), execs().with_status(0).with_stdout(""));

--- a/tests/package.rs
+++ b/tests/package.rs
@@ -39,6 +39,7 @@ fn simple() {
 [PACKAGING] foo v0.0.1 ({dir})
 [VERIFYING] foo v0.0.1 ({dir})
 [COMPILING] foo v0.0.1 ({dir}[..])
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 ",
         dir = p.url())));
     assert_that(&p.root().join("target/package/foo-0.0.1.crate"), existing_file());
@@ -85,6 +86,7 @@ http://doc.crates.io/manifest.html#package-metadata for more info.
 [PACKAGING] foo v0.0.1 ({dir})
 [VERIFYING] foo v0.0.1 ({dir})
 [COMPILING] foo v0.0.1 ({dir}[..])
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 ",
         dir = p.url())));
 
@@ -106,6 +108,7 @@ http://doc.crates.io/manifest.html#package-metadata for more info.
 [PACKAGING] foo v0.0.1 ({dir})
 [VERIFYING] foo v0.0.1 ({dir})
 [COMPILING] foo v0.0.1 ({dir}[..])
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 ",
         dir = p.url())));
 
@@ -127,6 +130,7 @@ http://doc.crates.io/manifest.html#package-metadata for more info.
 [PACKAGING] foo v0.0.1 ({dir})
 [VERIFYING] foo v0.0.1 ({dir})
 [COMPILING] foo v0.0.1 ({dir}[..])
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 ",
         dir = p.url())));
 }
@@ -196,6 +200,7 @@ fn package_verification() {
 [PACKAGING] foo v0.0.1 ({dir})
 [VERIFYING] foo v0.0.1 ({dir})
 [COMPILING] foo v0.0.1 ({dir}[..])
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 ",
         dir = p.url())));
 }
@@ -357,6 +362,7 @@ fn ignore_nested() {
 [PACKAGING] nested v0.0.1 ({dir})
 [VERIFYING] nested v0.0.1 ({dir})
 [COMPILING] nested v0.0.1 ({dir}[..])
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 ",
         dir = p.url())));
     assert_that(&p.root().join("target/package/nested-0.0.1.crate"), existing_file());
@@ -444,6 +450,7 @@ fn repackage_on_source_change() {
 [PACKAGING] foo v0.0.1 ({dir})
 [VERIFYING] foo v0.0.1 ({dir})
 [COMPILING] foo v0.0.1 ({dir}[..])
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 ",
         dir = p.url())));
 

--- a/tests/path.rs
+++ b/tests/path.rs
@@ -76,7 +76,9 @@ fn cargo_compile_with_nested_deps_shorthand() {
         execs().with_status(0)
                .with_stderr(&format!("[COMPILING] baz v0.5.0 ({}/bar/baz)\n\
                                      [COMPILING] bar v0.5.0 ({}/bar)\n\
-                                     [COMPILING] foo v0.5.0 ({})\n",
+                                     [COMPILING] foo v0.5.0 ({})\n\
+                                     [FINISHED] debug [unoptimized + debuginfo] target(s) \
+                                     in [..]\n",
                                     p.url(),
                                     p.url(),
                                     p.url())));
@@ -92,14 +94,18 @@ fn cargo_compile_with_nested_deps_shorthand() {
     println!("building baz");
     assert_that(p.cargo("build").arg("-p").arg("baz"),
                 execs().with_status(0)
-                       .with_stderr(&format!("[COMPILING] baz v0.5.0 ({}/bar/baz)\n",
+                       .with_stderr(&format!("[COMPILING] baz v0.5.0 ({}/bar/baz)\n\
+                                              [FINISHED] debug [unoptimized + debuginfo] target(s) \
+                                              in [..]\n",
                                             p.url())));
     println!("building foo");
     assert_that(p.cargo("build")
                  .arg("-p").arg("foo"),
                 execs().with_status(0)
                        .with_stderr(&format!("[COMPILING] bar v0.5.0 ({}/bar)\n\
-                                             [COMPILING] foo v0.5.0 ({})\n",
+                                             [COMPILING] foo v0.5.0 ({})\n\
+                                             [FINISHED] debug [unoptimized + debuginfo] target(s) \
+                                             in [..]\n",
                                             p.url(),
                                             p.url())));
 }
@@ -182,6 +188,7 @@ fn cargo_compile_with_root_dev_deps_with_testing() {
                 execs().with_stderr("\
 [COMPILING] [..] v0.5.0 ([..])
 [COMPILING] [..] v0.5.0 ([..])
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target[..]foo-[..]")
                        .with_stdout("
 running 0 tests
@@ -235,7 +242,9 @@ fn cargo_compile_with_transitive_dev_deps() {
 
     assert_that(p.cargo_process("build"),
         execs().with_stderr(&format!("[COMPILING] bar v0.5.0 ({}/bar)\n\
-                                     [COMPILING] foo v0.5.0 ({})\n",
+                                     [COMPILING] foo v0.5.0 ({})\n\
+                                     [FINISHED] debug [unoptimized + debuginfo] target(s) in \
+                                     [..]\n",
                                     p.url(),
                                     p.url())));
 
@@ -281,7 +290,9 @@ fn no_rebuild_dependency() {
     // First time around we should compile both foo and bar
     assert_that(p.cargo_process("build"),
                 execs().with_stderr(&format!("[COMPILING] bar v0.5.0 ({}/bar)\n\
-                                             [COMPILING] foo v0.5.0 ({})\n",
+                                             [COMPILING] foo v0.5.0 ({})\n\
+                                             [FINISHED] debug [unoptimized + debuginfo] target(s) \
+                                             in [..]\n",
                                             p.url(),
                                             p.url())));
     // This time we shouldn't compile bar
@@ -292,7 +303,9 @@ fn no_rebuild_dependency() {
     p.build(); // rebuild the files (rewriting them in the process)
     assert_that(p.cargo("build"),
                 execs().with_stderr(&format!("[COMPILING] bar v0.5.0 ({}/bar)\n\
-                                             [COMPILING] foo v0.5.0 ({})\n",
+                                             [COMPILING] foo v0.5.0 ({})\n\
+                                             [FINISHED] debug [unoptimized + debuginfo] target(s) \
+                                             in [..]\n",
                                             p.url(),
                                             p.url())));
 }
@@ -349,7 +362,9 @@ fn deep_dependencies_trigger_rebuild() {
     assert_that(p.cargo_process("build"),
                 execs().with_stderr(&format!("[COMPILING] baz v0.5.0 ({}/baz)\n\
                                              [COMPILING] bar v0.5.0 ({}/bar)\n\
-                                             [COMPILING] foo v0.5.0 ({})\n",
+                                             [COMPILING] foo v0.5.0 ({})\n\
+                                             [FINISHED] debug [unoptimized + debuginfo] target(s) \
+                                             in [..]\n",
                                             p.url(),
                                             p.url(),
                                             p.url())));
@@ -367,7 +382,9 @@ fn deep_dependencies_trigger_rebuild() {
     assert_that(p.cargo("build"),
                 execs().with_stderr(&format!("[COMPILING] baz v0.5.0 ({}/baz)\n\
                                              [COMPILING] bar v0.5.0 ({}/bar)\n\
-                                             [COMPILING] foo v0.5.0 ({})\n",
+                                             [COMPILING] foo v0.5.0 ({})\n\
+                                             [FINISHED] debug [unoptimized + debuginfo] target(s) \
+                                             in [..]\n",
                                             p.url(),
                                             p.url(),
                                             p.url())));
@@ -380,7 +397,9 @@ fn deep_dependencies_trigger_rebuild() {
     "#).unwrap();
     assert_that(p.cargo("build"),
                 execs().with_stderr(&format!("[COMPILING] bar v0.5.0 ({}/bar)\n\
-                                             [COMPILING] foo v0.5.0 ({})\n",
+                                             [COMPILING] foo v0.5.0 ({})\n\
+                                             [FINISHED] debug [unoptimized + debuginfo] target(s) \
+                                             in [..]\n",
                                             p.url(),
                                             p.url())));
 
@@ -439,7 +458,9 @@ fn no_rebuild_two_deps() {
     assert_that(p.cargo_process("build"),
                 execs().with_stderr(&format!("[COMPILING] baz v0.5.0 ({}/baz)\n\
                                              [COMPILING] bar v0.5.0 ({}/bar)\n\
-                                             [COMPILING] foo v0.5.0 ({})\n",
+                                             [COMPILING] foo v0.5.0 ({})\n\
+                                             [FINISHED] debug [unoptimized + debuginfo] target(s) \
+                                             in [..]\n",
                                             p.url(),
                                             p.url(),
                                             p.url())));
@@ -486,7 +507,9 @@ fn nested_deps_recompile() {
 
     assert_that(p.cargo_process("build"),
                 execs().with_stderr(&format!("[COMPILING] bar v0.5.0 ({}/src/bar)\n\
-                                             [COMPILING] foo v0.5.0 ({})\n",
+                                             [COMPILING] foo v0.5.0 ({})\n\
+                                             [FINISHED] debug [unoptimized + debuginfo] target(s) \
+                                             in [..]\n",
                                             bar,
                                             p.url())));
     sleep_ms(1000);
@@ -497,7 +520,9 @@ fn nested_deps_recompile() {
 
     // This shouldn't recompile `bar`
     assert_that(p.cargo("build"),
-                execs().with_stderr(&format!("[COMPILING] foo v0.5.0 ({})\n",
+                execs().with_stderr(&format!("[COMPILING] foo v0.5.0 ({})\n\
+                                              [FINISHED] debug [unoptimized + debuginfo] target(s) \
+                                              in [..]\n",
                                             p.url())));
 }
 
@@ -701,7 +726,9 @@ fn path_dep_build_cmd() {
 
     assert_that(p.cargo("build"),
         execs().with_stderr(&format!("[COMPILING] bar v0.5.0 ({}/bar)\n\
-                                     [COMPILING] foo v0.5.0 ({})\n",
+                                     [COMPILING] foo v0.5.0 ({})\n\
+                                     [FINISHED] debug [unoptimized + debuginfo] target(s) in \
+                                     [..]\n",
                                     p.url(),
                                     p.url())));
 
@@ -718,7 +745,9 @@ fn path_dep_build_cmd() {
 
     assert_that(p.cargo("build"),
         execs().with_stderr(&format!("[COMPILING] bar v0.5.0 ({}/bar)\n\
-                                     [COMPILING] foo v0.5.0 ({})\n",
+                                     [COMPILING] foo v0.5.0 ({})\n\
+                                     [FINISHED] debug [unoptimized + debuginfo] target(s) in \
+                                     [..]\n",
                                     p.url(),
                                     p.url())));
 
@@ -758,14 +787,17 @@ fn dev_deps_no_rebuild_lib() {
     assert_that(p.cargo("build")
                  .env("FOO", "bar"),
                 execs().with_status(0)
-                       .with_stderr(&format!("[COMPILING] foo v0.5.0 ({})\n",
-                                            p.url())));
+                       .with_stderr(&format!("[COMPILING] foo v0.5.0 ({})\n\
+                                              [FINISHED] debug [unoptimized + debuginfo] target(s) \
+                                              in [..]\n",
+                                              p.url())));
 
     assert_that(p.cargo("test"),
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] [..] v0.5.0 ({url}[..])
 [COMPILING] [..] v0.5.0 ({url}[..])
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target[..]foo-[..]", url = p.url()))
                        .with_stdout("
 running 0 tests
@@ -809,6 +841,7 @@ fn custom_target_no_rebuild() {
                        .with_stderr("\
 [COMPILING] a v0.5.0 ([..])
 [COMPILING] foo v0.5.0 ([..])
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 "));
 
     assert_that(p.cargo("build")
@@ -817,6 +850,7 @@ fn custom_target_no_rebuild() {
                 execs().with_status(0)
                        .with_stderr("\
 [COMPILING] b v0.5.0 ([..])
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 "));
 }
 
@@ -859,6 +893,7 @@ fn override_and_depend() {
 [COMPILING] a2 v0.5.0 ([..])
 [COMPILING] a1 v0.5.0 ([..])
 [COMPILING] b v0.5.0 ([..])
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 "));
 }
 

--- a/tests/profiles.rs
+++ b/tests/profiles.rs
@@ -35,6 +35,7 @@ fn profile_overrides() {
         --emit=dep-info,link \
         -L dependency={dir}{sep}target{sep}debug \
         -L dependency={dir}{sep}target{sep}debug{sep}deps`
+[FINISHED] debug [optimized] target(s) in [..]
 ", sep = SEP,
 dir = p.root().display(),
 url = p.url(),
@@ -100,6 +101,7 @@ fn top_level_overrides_deps() {
         --extern foo={dir}{sep}target{sep}release{sep}deps{sep}\
                      {prefix}foo-[..]{suffix} \
         --extern foo={dir}{sep}target{sep}release{sep}deps{sep}libfoo-[..].rlib`
+[FINISHED] release [optimized + debuginfo] target(s) in [..]
 ",
                     dir = p.root().display(),
                     url = p.url(),

--- a/tests/publish.rs
+++ b/tests/publish.rs
@@ -350,6 +350,7 @@ fn dry_run() {
 [PACKAGING] foo v0.0.1 ({dir})
 [VERIFYING] foo v0.0.1 ({dir})
 [COMPILING] foo v0.0.1 [..]
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 [UPLOADING] foo v0.0.1 ({dir})
 [WARNING] aborting upload due to dry run
 ",

--- a/tests/registry.rs
+++ b/tests/registry.rs
@@ -34,6 +34,7 @@ fn simple() {
 [DOWNLOADING] bar v0.0.1 (registry file://[..])
 [COMPILING] bar v0.0.1 (registry file://[..])
 [COMPILING] foo v0.0.1 ({dir})
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..] secs
 ",
         dir = p.url(),
         reg = registry::registry())));
@@ -44,6 +45,7 @@ fn simple() {
 [UPDATING] registry `{reg}`
 [..] bar v0.0.1 (registry file://[..])
 [..] foo v0.0.1 ({dir})
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..] secs
 ",
         dir = p.url(),
         reg = registry::registry())));
@@ -74,6 +76,7 @@ fn deps() {
 [COMPILING] baz v0.0.1 (registry file://[..])
 [COMPILING] bar v0.0.1 (registry file://[..])
 [COMPILING] foo v0.0.1 ({dir})
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..] secs
 ",
         dir = p.url(),
         reg = registry::registry())));
@@ -204,6 +207,7 @@ version required: >= 0.0.0
 [DOWNLOADING] notyet v0.0.1 (registry file://[..])
 [COMPILING] notyet v0.0.1 (registry file://[..])
 [COMPILING] foo v0.0.1 ({dir})
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..] secs
 ",
         dir = p.url(),
         reg = registry::registry())));
@@ -257,6 +261,7 @@ version required: ^0.0.1
 [DOWNLOADING] notyet v0.0.1 (registry file://[..])
 [COMPILING] notyet v0.0.1 (registry file://[..])
 [COMPILING] foo v0.0.1 ({dir}[..])
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..] secs
 ", dir = p.url())));
 }
 
@@ -283,6 +288,7 @@ fn lockfile_locks() {
 [DOWNLOADING] bar v0.0.1 (registry file://[..])
 [COMPILING] bar v0.0.1 (registry file://[..])
 [COMPILING] foo v0.0.1 ({dir})
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..] secs
 ",
    dir = p.url())));
 
@@ -319,6 +325,7 @@ fn lockfile_locks_transitively() {
 [COMPILING] baz v0.0.1 (registry file://[..])
 [COMPILING] bar v0.0.1 (registry file://[..])
 [COMPILING] foo v0.0.1 ({dir})
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..] secs
 ",
    dir = p.url())));
 
@@ -358,6 +365,7 @@ fn yanks_are_not_used() {
 [COMPILING] baz v0.0.1 (registry file://[..])
 [COMPILING] bar v0.0.1 (registry file://[..])
 [COMPILING] foo v0.0.1 ({dir})
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..] secs
 ",
    dir = p.url())));
 }
@@ -450,6 +458,7 @@ fn update_with_lockfile_if_packages_missing() {
                 execs().with_status(0).with_stderr("\
 [UPDATING] registry `[..]`
 [DOWNLOADING] bar v0.0.1 (registry file://[..])
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..] secs
 "));
 }
 
@@ -490,6 +499,7 @@ fn update_lockfile() {
 [DOWNLOADING] [..] v0.0.2 (registry file://[..])
 [COMPILING] bar v0.0.2 (registry file://[..])
 [COMPILING] foo v0.0.1 ({dir})
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..] secs
 ",
    dir = p.url())));
 
@@ -507,6 +517,7 @@ fn update_lockfile() {
 [DOWNLOADING] [..] v0.0.3 (registry file://[..])
 [COMPILING] bar v0.0.3 (registry file://[..])
 [COMPILING] foo v0.0.1 ({dir})
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..] secs
 ",
    dir = p.url())));
 
@@ -556,6 +567,7 @@ fn dev_dependency_not_used() {
 [DOWNLOADING] [..] v0.0.1 (registry file://[..])
 [COMPILING] bar v0.0.1 (registry file://[..])
 [COMPILING] foo v0.0.1 ({dir})
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..] secs
 ",
    dir = p.url())));
 }
@@ -624,6 +636,7 @@ fn updating_a_dep() {
 [COMPILING] bar v0.0.1 (registry file://[..])
 [COMPILING] a v0.0.1 ({dir}/a)
 [COMPILING] foo v0.0.1 ({dir})
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..] secs
 ",
    dir = p.url())));
 
@@ -646,6 +659,7 @@ fn updating_a_dep() {
 [COMPILING] bar v0.1.0 (registry file://[..])
 [COMPILING] a v0.0.1 ({dir}/a)
 [COMPILING] foo v0.0.1 ({dir})
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..] secs
 ",
    dir = p.url())));
 }
@@ -691,6 +705,7 @@ fn git_and_registry_dep() {
 [COMPILING] a v0.0.1 (registry [..])
 [COMPILING] b v0.0.1 ([..])
 [COMPILING] foo v0.0.1 ({dir})
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..] secs
 ",
    dir = p.url())));
     p.root().move_into_the_past();
@@ -736,6 +751,7 @@ fn update_publish_then_update() {
 [DOWNLOADING] a v0.1.1 (registry file://[..])
 [COMPILING] a v0.1.1 (registry [..])
 [COMPILING] foo v0.5.0 ({dir})
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..] secs
 ",
    dir = p.url())));
 
@@ -803,6 +819,7 @@ fn update_transitive_dependency() {
 [COMPILING] b v0.1.1 (registry [..])
 [COMPILING] a v0.1.0 (registry [..])
 [COMPILING] foo v0.5.0 ([..])
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..] secs
 "));
 }
 
@@ -1019,6 +1036,7 @@ fn only_download_relevant() {
 [DOWNLOADING] baz v0.1.0 ([..])
 [COMPILING] baz v0.1.0 ([..])
 [COMPILING] bar v0.5.0 ([..])
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..] secs
 "));
 }
 

--- a/tests/run.rs
+++ b/tests/run.rs
@@ -25,6 +25,7 @@ fn simple() {
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({dir})
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `target{sep}debug{sep}foo[..]`", dir = path2url(p.root()), sep = SEP))
                        .with_stdout("\
 hello
@@ -129,6 +130,7 @@ fn exit_code() {
                 execs().with_status(2)
                        .with_stderr("\
 [COMPILING] foo v0.0.1 (file[..])
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `target[..]`
 [ERROR] Process didn't exit successfully: `target[..]foo[..]` (exit code: 2)
 "));
@@ -152,6 +154,7 @@ fn exit_code_verbose() {
                        .with_stderr("\
 [COMPILING] foo v0.0.1 (file[..])
 [RUNNING] `rustc [..]`
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `target[..]`
 [ERROR] Process didn't exit successfully: `target[..]foo[..]` (exit code: 2)
 "));
@@ -219,6 +222,7 @@ fn specify_name() {
 [COMPILING] foo v0.0.1 ({dir})
 [RUNNING] `rustc src[..]lib.rs [..]`
 [RUNNING] `rustc src[..]a.rs [..]`
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `target{sep}debug{sep}a[..]`", dir = path2url(p.root()), sep = SEP))
                        .with_stdout("\
 hello a.rs
@@ -229,6 +233,7 @@ hello a.rs
                        .with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ([..])
 [RUNNING] `rustc src[..]b.rs [..]`
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `target{sep}debug{sep}b[..]`", sep = SEP))
                        .with_stdout("\
 hello b.rs
@@ -256,6 +261,7 @@ fn run_example() {
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({dir})
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `target{sep}debug{sep}examples{sep}a[..]`", dir = path2url(p.root()), sep = SEP))
                        .with_stdout("\
 example
@@ -348,6 +354,7 @@ fn one_bin_multiple_examples() {
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({dir})
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `target{sep}debug{sep}main[..]`", dir = path2url(p.root()), sep = SEP))
                        .with_stdout("\
 hello main.rs
@@ -418,6 +425,7 @@ fn example_with_release_flag() {
         -L dependency={dir}{sep}target{sep}release \
         -L dependency={dir}{sep}target{sep}release{sep}deps \
          --extern bar={dir}{sep}target{sep}release{sep}deps{sep}libbar-[..].rlib`
+[FINISHED] release [optimized] target(s) in [..]
 [RUNNING] `target{sep}release{sep}examples{sep}a[..]`
 ",
         dir = p.root().display(),
@@ -447,6 +455,7 @@ fast2"));
         -L dependency={dir}{sep}target{sep}debug \
         -L dependency={dir}{sep}target{sep}debug{sep}deps \
          --extern bar={dir}{sep}target{sep}debug{sep}deps{sep}libbar-[..].rlib`
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `target{sep}debug{sep}examples{sep}a[..]`
 ",
         dir = p.root().display(),
@@ -505,6 +514,7 @@ fn release_works() {
     assert_that(p.cargo_process("run").arg("--release"),
                 execs().with_status(0).with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({dir})
+[FINISHED] release [optimized] target(s) in [..]
 [RUNNING] `target{sep}release{sep}foo[..]`
 ",
         dir = path2url(p.root()),
@@ -575,6 +585,7 @@ fn run_from_executable_folder() {
     assert_that(p.cargo("run").cwd(cwd),
                 execs().with_status(0)
                        .with_stderr(&format!("\
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]\n\
 [RUNNING] `.{sep}foo[..]`", sep = SEP))
                        .with_stdout("\
 hello

--- a/tests/rustc.rs
+++ b/tests/rustc.rs
@@ -34,6 +34,7 @@ fn build_lib_for_foo() {
         --emit=dep-info,link \
         -L dependency={dir}{sep}target{sep}debug \
         -L dependency={dir}{sep}target{sep}debug{sep}deps`
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 ", sep = SEP,
             dir = p.root().display(), url = p.url())));
 }
@@ -64,6 +65,7 @@ fn lib() {
         --emit=dep-info,link \
         -L dependency={dir}{sep}target{sep}debug \
         -L dependency={dir}{sep}target{sep}debug{sep}deps`
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 ", sep = SEP,
             dir = p.root().display(), url = p.url())))
 }
@@ -100,6 +102,7 @@ fn build_main_and_allow_unstable_options() {
         -L dependency={dir}{sep}target{sep}debug \
         -L dependency={dir}{sep}target{sep}debug{sep}deps \
         --extern {name}={dir}{sep}target{sep}debug{sep}lib{name}.rlib`
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 ", sep = SEP,
             dir = p.root().display(), url = p.url(),
             name = "foo", version = "0.0.1")));
@@ -156,6 +159,7 @@ fn build_with_args_to_one_of_multiple_binaries() {
         --out-dir {dir}{sep}target{sep}debug [..]`
 [RUNNING] `rustc src{sep}bin{sep}bar.rs --crate-name bar --crate-type bin -g \
         -C debug-assertions [..]`
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 ", sep = SEP,
                 dir = p.root().display(), url = p.url())));
 }
@@ -211,6 +215,7 @@ fn build_with_args_to_one_of_multiple_tests() {
         --out-dir {dir}{sep}target{sep}debug [..]`
 [RUNNING] `rustc tests{sep}bar.rs --crate-name bar -g \
         -C debug-assertions [..]--test[..]`
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 ", sep = SEP,
                 dir = p.root().display(), url = p.url())));
 }
@@ -253,6 +258,7 @@ fn build_foo_with_bar_dependency() {
 [RUNNING] `[..] -g -C [..]`
 [COMPILING] foo v0.0.1 ({url})
 [RUNNING] `[..] -g -C debug-assertions [..]`
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 ",
                 url = foo.url())));
 }
@@ -294,6 +300,7 @@ fn build_only_bar_dependency() {
                 .with_stderr("\
 [COMPILING] bar v0.1.0 ([..])
 [RUNNING] `[..]--crate-name bar --crate-type lib [..] -C debug-assertions [..]`
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 "));
 }
 

--- a/tests/rustdoc.rs
+++ b/tests/rustdoc.rs
@@ -26,6 +26,7 @@ fn rustdoc_simple() {
         -o {dir}{sep}target{sep}doc \
         -L dependency={dir}{sep}target{sep}debug \
         -L dependency={dir}{sep}target{sep}debug{sep}deps`
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 ", sep = SEP,
             dir = p.root().display(), url = p.url())));
 }
@@ -51,6 +52,7 @@ fn rustdoc_args() {
         --no-defaults \
         -L dependency={dir}{sep}target{sep}debug \
         -L dependency={dir}{sep}target{sep}debug{sep}deps`
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 ", sep = SEP,
             dir = p.root().display(), url = p.url())));
 }
@@ -98,6 +100,7 @@ fn rustdoc_foo_with_bar_dependency() {
         -L dependency={dir}{sep}target{sep}debug \
         -L dependency={dir}{sep}target{sep}debug{sep}deps \
         --extern [..]`
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 ", sep = SEP,
             dir = foo.root().display(), url = foo.url())));
 }
@@ -143,6 +146,7 @@ fn rustdoc_only_bar_dependency() {
         --no-defaults \
         -L dependency={dir}{sep}target{sep}debug{sep}deps \
         -L dependency={dir}{sep}target{sep}debug{sep}deps`
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 ", sep = SEP,
             dir = foo.root().display())));
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -39,6 +39,7 @@ fn cargo_test_simple() {
     assert_that(p.cargo("test"),
                 execs().with_stderr(format!("\
 [COMPILING] foo v0.5.0 ({})
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target[..]foo-[..]", p.url()))
                        .with_stdout("
 running 1 test
@@ -90,6 +91,7 @@ fn cargo_test_release() {
 [RUNNING] [..] -C opt-level=3 [..]
 [RUNNING] [..] -C opt-level=3 [..]
 [RUNNING] [..] -C opt-level=3 [..]
+[FINISHED] release [optimized] target(s) in [..]
 [RUNNING] `[..]target[..]foo-[..]`
 [RUNNING] `[..]target[..]test-[..]`
 [DOCTEST] foo
@@ -127,6 +129,7 @@ fn cargo_test_verbose() {
                 execs().with_stderr(format!("\
 [COMPILING] foo v0.5.0 ({url})
 [RUNNING] `rustc src[..]foo.rs [..]`
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `[..]target[..]foo-[..] hello`", url = p.url()))
                        .with_stdout("
 running 1 test
@@ -194,6 +197,7 @@ fn cargo_test_failing_test() {
     assert_that(p.cargo("test"),
                 execs().with_stderr(format!("\
 [COMPILING] foo v0.5.0 ({url})
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target[..]foo-[..]
 [ERROR] test failed", url = p.url()))
                        .with_stdout_contains("
@@ -253,6 +257,7 @@ fn test_with_lib_dep() {
     assert_that(p.cargo_process("test"),
                 execs().with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({})
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target[..]baz-[..]
 [RUNNING] target[..]foo[..]
 [DOCTEST] foo", p.url()))
@@ -321,6 +326,7 @@ fn test_with_deep_lib_dep() {
                        .with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ([..])
 [COMPILING] bar v0.0.1 ({dir})
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target[..]
 [DOCTEST] bar", dir = p.url()))
                        .with_stdout("
@@ -367,6 +373,7 @@ fn external_test_explicit() {
     assert_that(p.cargo_process("test"),
                 execs().with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({})
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target[..]foo-[..]
 [RUNNING] target[..]test-[..]
 [DOCTEST] foo", p.url()))
@@ -415,6 +422,7 @@ fn external_test_implicit() {
     assert_that(p.cargo_process("test"),
                 execs().with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({})
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target[..]external-[..]
 [RUNNING] target[..]foo-[..]
 [DOCTEST] foo", p.url()))
@@ -474,6 +482,7 @@ fn pass_through_command_line() {
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({dir})
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target[..]foo-[..]
 [DOCTEST] foo", dir = p.url()))
                        .with_stdout("
@@ -492,6 +501,7 @@ test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
     assert_that(p.cargo("test").arg("foo"),
                 execs().with_status(0)
                        .with_stderr("\
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target[..]foo-[..]
 [DOCTEST] foo")
                        .with_stdout("
@@ -556,6 +566,7 @@ fn lib_bin_same_name() {
     assert_that(p.cargo_process("test"),
                 execs().with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({})
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target[..]foo-[..]
 [RUNNING] target[..]foo-[..]
 [DOCTEST] foo", p.url()))
@@ -608,6 +619,7 @@ fn lib_with_standard_name() {
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] syntax v0.0.1 ({dir})
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target[..]syntax-[..]
 [RUNNING] target[..]test-[..]
 [DOCTEST] syntax", dir = p.url()))
@@ -662,6 +674,7 @@ fn lib_with_standard_name2() {
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] syntax v0.0.1 ({dir})
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target[..]syntax-[..]", dir = p.url()))
                        .with_stdout("
 running 1 test
@@ -701,6 +714,7 @@ fn lib_without_name() {
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] syntax v0.0.1 ({dir})
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target[..]syntax-[..]", dir = p.url()))
                        .with_stdout("
 running 1 test
@@ -958,6 +972,7 @@ fn test_dylib() {
                        .with_stderr(&format!("\
 [COMPILING] bar v0.0.1 ({dir}/bar)
 [COMPILING] foo v0.0.1 ({dir})
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target[..]foo-[..]
 [RUNNING] target[..]test-[..]", dir = p.url()))
                        .with_stdout("
@@ -977,6 +992,7 @@ test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
     assert_that(p.cargo("test"),
                 execs().with_status(0)
                        .with_stderr("\
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target[..]foo-[..]
 [RUNNING] target[..]test-[..]")
                        .with_stdout("
@@ -1015,6 +1031,7 @@ fn test_twice_with_build_cmd() {
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({dir})
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target[..]foo-[..]
 [DOCTEST] foo", dir = p.url()))
                        .with_stdout("
@@ -1033,6 +1050,7 @@ test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
     assert_that(p.cargo("test"),
                 execs().with_status(0)
                        .with_stderr("\
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target[..]foo-[..]
 [DOCTEST] foo")
                        .with_stdout("
@@ -1067,6 +1085,7 @@ fn test_then_build() {
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({dir})
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target[..]foo-[..]
 [DOCTEST] foo", dir = p.url()))
                        .with_stdout("
@@ -1105,6 +1124,7 @@ fn test_no_run() {
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({dir})
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 ",
                        dir = p.url())));
 }
@@ -1133,6 +1153,7 @@ fn test_run_specific_bin_target() {
                 execs().with_status(0)
                        .with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({dir})
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target[..]bin2-[..]", dir = prj.url()))
                        .with_stdout("
 running 1 test
@@ -1161,6 +1182,7 @@ fn test_run_specific_test_target() {
                 execs().with_status(0)
                        .with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({dir})
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target[..]b-[..]", dir = prj.url()))
                        .with_stdout("
 running 1 test
@@ -1196,6 +1218,7 @@ fn test_no_harness() {
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({dir})
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target[..]bar-[..]
 ",
                        dir = p.url())));
@@ -1251,6 +1274,7 @@ fn selective_testing() {
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] d1 v0.0.1 ({dir}/d1)
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target[..]d1-[..]
 [RUNNING] target[..]d1-[..]", dir = p.url()))
                        .with_stdout("
@@ -1270,6 +1294,7 @@ test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] d2 v0.0.1 ({dir}/d2)
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target[..]d2-[..]
 [RUNNING] target[..]d2-[..]", dir = p.url()))
                        .with_stdout("
@@ -1289,6 +1314,7 @@ test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({dir})
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target[..]foo-[..]", dir = p.url()))
                        .with_stdout("
 running 0 tests
@@ -1450,6 +1476,7 @@ fn selective_testing_with_docs() {
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] d1 v0.0.1 ({dir}/d1)
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target[..]deps[..]d1[..]
 [DOCTEST] d1", dir = p.url()))
                        .with_stdout("
@@ -1483,6 +1510,7 @@ fn example_bin_same_name() {
 [COMPILING] foo v0.0.1 ({dir})
 [RUNNING] `rustc [..]`
 [RUNNING] `rustc [..]`
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 ", dir = p.url())));
 
     assert_that(&p.bin("foo"), is_not(existing_file()));
@@ -1495,6 +1523,7 @@ fn example_bin_same_name() {
                 execs().with_status(0)
                        .with_stderr("\
 [COMPILING] foo v0.0.1 ([..])
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] [..]")
                        .with_stdout("\
 bin
@@ -1559,6 +1588,7 @@ fn example_with_dev_dep() {
 [..]
 [..]
 [RUNNING] `rustc [..] --crate-name ex [..] --extern a=[..]`
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 "));
 }
 
@@ -1628,6 +1658,7 @@ fn doctest_feature() {
                 execs().with_status(0)
                        .with_stderr("\
 [COMPILING] foo [..]
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target[..]foo[..]
 [DOCTEST] foo")
                        .with_stdout("
@@ -1714,6 +1745,7 @@ fn filter_no_doc_tests() {
     assert_that(p.cargo_process("test").arg("--test=foo"),
                 execs().with_stderr("\
 [COMPILING] foo v0.0.1 ([..])
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target[..]debug[..]foo[..]")
                        .with_stdout("
 running 0 tests
@@ -1747,6 +1779,7 @@ fn dylib_doctest() {
     assert_that(p.cargo_process("test"),
                 execs().with_stderr("\
 [COMPILING] foo v0.0.1 ([..])
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 [DOCTEST] foo")
                        .with_stdout("
 running 1 test
@@ -1816,6 +1849,7 @@ fn cyclic_dev_dep_doc_test() {
                 execs().with_stderr("\
 [COMPILING] foo v0.0.1 ([..])
 [COMPILING] bar v0.0.1 ([..])
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target[..]foo[..]
 [DOCTEST] foo")
                        .with_stdout("
@@ -1908,6 +1942,7 @@ fn no_fail_fast() {
                 execs().with_status(101)
                        .with_stderr_contains("\
 [COMPILING] foo v0.0.1 ([..])
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target[..]foo[..]
 [RUNNING] target[..]test_add_one[..]")
                        .with_stdout_contains("
@@ -2025,6 +2060,7 @@ fn bin_does_not_rebuild_tests() {
 [COMPILING] foo v0.0.1 ([..])
 [RUNNING] `rustc src[..]main.rs [..]`
 [RUNNING] `rustc src[..]main.rs [..]`
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 "));
 }
 
@@ -2086,6 +2122,7 @@ fn selective_test_optional_dep() {
 [COMPILING] a v0.0.1 ([..])
 [RUNNING] `rustc a[..]src[..]lib.rs [..]`
 [RUNNING] `rustc a[..]src[..]lib.rs [..]`
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 "));
 }
 
@@ -2117,6 +2154,7 @@ fn only_test_docs() {
                 execs().with_status(0)
                        .with_stderr("\
 [COMPILING] foo v0.0.1 ([..])
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 [DOCTEST] foo")
                        .with_stdout("
 running 1 test
@@ -2190,6 +2228,7 @@ fn cfg_test_even_with_no_harness() {
                        .with_stderr("\
 [COMPILING] foo v0.0.1 ([..])
 [RUNNING] `rustc [..]`
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `[..]`
 "));
 }

--- a/tests/tool-paths.rs
+++ b/tests/tool-paths.rs
@@ -30,6 +30,7 @@ fn pathless_tools() {
                 execs().with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({url})
 [RUNNING] `rustc [..] -C ar=nonexistent-ar -C linker=nonexistent-linker [..]`
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 ", url = foo.url())))
 }
 
@@ -71,6 +72,7 @@ fn absolute_tools() {
                 execs().with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({url})
 [RUNNING] `rustc [..] -C ar={ar} -C linker={linker} [..]`
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 ", url = foo.url(), ar = output.0, linker = output.1)))
 }
 
@@ -119,5 +121,6 @@ fn relative_tools() {
                 execs().with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({url})
 [RUNNING] `rustc [..] -C ar={ar} -C linker={linker} [..]`
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 ", url = foo_url, ar = output.0, linker = output.1)))
 }

--- a/tests/workspaces.rs
+++ b/tests/workspaces.rs
@@ -503,6 +503,7 @@ fn share_dependencies() {
 [DOWNLOADING] dep1 v0.1.3 ([..])
 [COMPILING] dep1 v0.1.3 ([..])
 [COMPILING] foo v0.1.0 ([..])
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 "));
 }
 
@@ -587,6 +588,7 @@ fn lock_works_for_everyone() {
 [DOWNLOADING] dep2 v0.1.0 ([..])
 [COMPILING] dep2 v0.1.0 ([..])
 [COMPILING] foo v0.1.0 ([..])
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 "));
 
     assert_that(p.cargo("build").cwd(p.root().join("bar")),
@@ -595,6 +597,7 @@ fn lock_works_for_everyone() {
 [DOWNLOADING] dep1 v0.1.0 ([..])
 [COMPILING] dep1 v0.1.0 ([..])
 [COMPILING] bar v0.1.0 ([..])
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 "));
 }
 


### PR DESCRIPTION
This is similar to https://github.com/rust-lang/cargo/pull/2896 but instead of inline, it puts an indicator at the bottom showing if it was a release or debug build.

```
jturner-23759:cargo jturner$ ./target/release/cargo build
Finished debug (unoptimized + debuginfo) build.
jturner-23759:cargo jturner$ ./target/release/cargo build --release
Finished release (optimized) build.
```