### PR TITLE
Fix python detection

### DIFF
--- a/configure
+++ b/configure
@@ -343,7 +343,7 @@ validate_opt
 step_msg "looking for build programs"
 
 probe_need CFG_CURLORWGET  curl wget
-probe_need CFG_PYTHON      python
+probe_need CFG_PYTHON      python2.7 python2 python
 probe_need CFG_CC          cc gcc clang
 
 if [ ! -z "${CFG_LOCAL_RUST_ROOT}" ]; then


### PR DESCRIPTION
Some platform, like ArchLinux, may not have python in the PATH, but can still have python2. So we should add some fallback option to detect python correctly. This detection order is copy from [rust-lang/rust](https://github.com/rust-lang/rust/blob/master/configure#L742).