### PR TITLE
Move `target_dir` to Workspace and fix #2848

### DIFF
--- a/src/cargo/ops/cargo_clean.rs
+++ b/src/cargo/ops/cargo_clean.rs
@@ -16,7 +16,7 @@ pub struct CleanOptions<'a> {
 
 /// Cleans the project from build artifacts.
 pub fn clean(ws: &Workspace, opts: &CleanOptions) -> CargoResult<()> {
-    let target_dir = opts.config.target_dir(&ws);
+    let target_dir = ws.target_dir();
 
     // If we have a spec, then we need to delete some packages, otherwise, just
     // remove the whole target directory and be done with it!

--- a/src/cargo/ops/cargo_doc.rs
+++ b/src/cargo/ops/cargo_doc.rs
@@ -53,7 +53,7 @@ pub fn doc(ws: &Workspace,
         // Don't bother locking here as if this is getting deleted there's
         // nothing we can do about it and otherwise if it's getting overwritten
         // then that's also ok!
-        let target_dir = options.compile_opts.config.target_dir(ws);
+        let target_dir = ws.target_dir();
         let path = target_dir.join("doc").join(&name).join("index.html");
         let path = path.into_path_unlocked();
         if fs::metadata(&path).is_ok() {

--- a/src/cargo/ops/cargo_install.rs
+++ b/src/cargo/ops/cargo_install.rs
@@ -89,7 +89,7 @@ pub fn install(root: Option<&str>,
         Some(Filesystem::new(config.cwd().join("target-install")))
     };
 
-    let ws = Workspace::one(pkg, config, overidden_target_dir);
+    let ws = try!(Workspace::one(pkg, config, overidden_target_dir));
     let pkg = try!(ws.current());
 
     // Preflight checks to check up front whether we'll overwrite something.

--- a/src/cargo/ops/cargo_package.rs
+++ b/src/cargo/ops/cargo_package.rs
@@ -52,7 +52,7 @@ pub fn package(ws: &Workspace,
     }
 
     let filename = format!("{}-{}.crate", pkg.name(), pkg.version());
-    let dir = config.target_dir(ws).join("package");
+    let dir = ws.target_dir().join("package");
     let mut dst = {
         let tmp = format!(".{}", filename);
         try!(dir.open_rw(&tmp, config, "package scratch space"))
@@ -266,7 +266,7 @@ fn run_verify(ws: &Workspace, tar: &File, opts: &PackageOpts) -> CargoResult<()>
     let new_pkg = Package::new(new_manifest, &manifest_path);
 
     // Now that we've rewritten all our path dependencies, compile it!
-    let ws = Workspace::one(new_pkg, config);
+    let ws = Workspace::one(new_pkg, config, None);
     try!(ops::compile_ws(&ws, None, &ops::CompileOptions {
         config: config,
         jobs: opts.jobs,

--- a/src/cargo/ops/cargo_package.rs
+++ b/src/cargo/ops/cargo_package.rs
@@ -266,7 +266,7 @@ fn run_verify(ws: &Workspace, tar: &File, opts: &PackageOpts) -> CargoResult<()>
     let new_pkg = Package::new(new_manifest, &manifest_path);
 
     // Now that we've rewritten all our path dependencies, compile it!
-    let ws = Workspace::one(new_pkg, config, None);
+    let ws = try!(Workspace::one(new_pkg, config, None));
     try!(ops::compile_ws(&ws, None, &ops::CompileOptions {
         config: config,
         jobs: opts.jobs,

--- a/src/cargo/ops/cargo_rustc/layout.rs
+++ b/src/cargo/ops/cargo_rustc/layout.rs
@@ -72,7 +72,7 @@ impl Layout {
     pub fn new(ws: &Workspace,
                triple: Option<&str>,
                dest: &str) -> CargoResult<Layout> {
-        let mut path = ws.config().target_dir(ws);
+        let mut path = ws.target_dir();
         // Flexible target specifications often point at filenames, so interpret
         // the target triple as a Path and then just use the file stem as the
         // component for the directory name.

--- a/src/cargo/util/config.rs
+++ b/src/cargo/util/config.rs
@@ -287,8 +287,11 @@ impl Config {
                      locked: bool) -> CargoResult<()> {
         let extra_verbose = verbose >= 2;
         let verbose = if verbose == 0 {None} else {Some(true)};
-        let cfg_verbose = try!(self.get_bool("term.verbose")).map(|v| v.val);
-        let cfg_color = try!(self.get_string("term.color")).map(|v| v.val);
+
+        // Ignore errors in the configuration files.
+        let cfg_verbose = self.get_bool("term.verbose").unwrap_or(None).map(|v| v.val);
+        let cfg_color = self.get_string("term.color").unwrap_or(None).map(|v| v.val);
+
         let color = color.as_ref().or(cfg_color.as_ref());
 
         let verbosity = match (verbose, cfg_verbose, quiet) {

--- a/tests/bad-config.rs
+++ b/tests/bad-config.rs
@@ -112,7 +112,10 @@ fn bad5() {
     assert_that(foo.cargo("new")
                    .arg("-v").arg("foo").cwd(&foo.root().join("foo")),
                 execs().with_status(101).with_stderr("\
-[ERROR] Couldn't load Cargo configuration
+[ERROR] Failed to create project `foo` at `[..]`
+
+Caused by:
+  Couldn't load Cargo configuration
 
 Caused by:
   failed to merge key `foo` between files:

--- a/tests/version.rs
+++ b/tests/version.rs
@@ -56,3 +56,22 @@ fn version_works_without_rustc() {
     assert_that(p.cargo_process("version").env("PATH", ""),
                 execs().with_status(0));
 }
+
+#[test]
+fn version_works_with_bad_config() {
+    let p = project("foo")
+        .file(".cargo/config", "this is not toml");
+    assert_that(p.cargo_process("version"),
+                execs().with_status(0));
+}
+
+#[test]
+fn version_works_with_bad_target_dir() {
+    let p = project("foo")
+        .file(".cargo/config", r#"
+            [build]
+            target-dir = 4
+        "#);
+    assert_that(p.cargo_process("version"),
+                execs().with_status(0));
+}


### PR DESCRIPTION
Target dir is now an API of Workspace. It is still initialized eagerly, just later. 

I also had to errors in the config file when retrieving `verbose` and `color` config. Seems fishy, but is probably OK. 