### PR TITLE
configure: Support --disable-option-checking

### DIFF
--- a/configure
+++ b/configure
@@ -296,6 +296,7 @@ opt debug 1 "build with extra debug fun"
 opt optimize 1 "build with optimizations"
 opt nightly 0 "build nightly packages"
 opt verify-install 1 "verify installed binaries work"
+opt option-checking 1 "complain about unrecognized options in this configure script"
 opt cross-tests 1 "run cross-compilation tests"
 valopt prefix "/usr/local" "set installation prefix"
 valopt local-rust-root "" "set prefix for local rust binary"
@@ -337,8 +338,11 @@ then
 fi
 
 # Validate Options
-step_msg "validating $CFG_SELF args"
-validate_opt
+if [ -z "$CFG_DISABLE_OPTION_CHECKING" ]
+then
+   step_msg "validating $CFG_SELF args"
+   validate_opt
+fi
 
 step_msg "looking for build programs"
 


### PR DESCRIPTION
This is mirroring rust-lang/rust#31169.  The RPM %configure macro sets a
lot of useful paths for typical configure scripts, but some of these
values are not recognized here in Cargo.  It's nice to have an option to
ignore those, rather than failing on `validate_opt`.