### PR TITLE
Add `http.cainfo` config for custom certs

### DIFF
--- a/src/cargo/ops/registry.rs
+++ b/src/cargo/ops/registry.rs
@@ -198,6 +198,9 @@ pub fn http_handle(config: &Config) -> CargoResult<Easy> {
     if let Some(proxy) = try!(http_proxy(config)) {
         try!(handle.proxy(&proxy));
     }
+    if let Some(cainfo) = try!(config.get_path("http.cainfo")) {
+        try!(handle.cainfo(&cainfo.val));
+    }
     if let Some(timeout) = try!(http_timeout(config)) {
         try!(handle.connect_timeout(Duration::new(timeout as u64, 0)));
         try!(handle.low_speed_time(Duration::new(timeout as u64, 0)));

--- a/src/doc/config.md
+++ b/src/doc/config.md
@@ -75,8 +75,9 @@ index = "..."   # URL of the registry index (defaults to the central repository)
 token = "..."   # Access token (found on the central repo’s website)
 
 [http]
-proxy = "..."     # HTTP proxy to use for HTTP requests (defaults to none)
-timeout = 60000   # Timeout for each HTTP request, in milliseconds
+proxy = "..."       # HTTP proxy to use for HTTP requests (defaults to none)
+timeout = 60000     # Timeout for each HTTP request, in milliseconds
+cainfo = "cert.pem" # Path to Certificate Authority (CA) bundle (optional)
 
 [build]
 jobs = 1                  # number of parallel jobs, defaults to # of CPUs


### PR DESCRIPTION
This adds a `http.cainfo` option to Cargo which reads CA information from a
bundle to pass through to the underlying SSL implementation. This should allow
configuration of Cargo in situations where the default certificate store doesn't
contain the relevant certificates, such as behind corporate proxies.

cc #1180