### PR TITLE
Always build libraries into the same location

### DIFF
--- a/src/cargo/ops/cargo_clean.rs
+++ b/src/cargo/ops/cargo_clean.rs
@@ -73,7 +73,7 @@ pub fn clean(ws: &Workspace, opts: &CleanOptions) -> CargoResult<()> {
     try!(cx.probe_target_info(&units));
 
     for unit in units.iter() {
-        let layout = cx.layout(&unit.pkg, unit.kind);
+        let layout = cx.layout(unit);
         try!(rm_rf(&layout.proxy().fingerprint(&unit.pkg)));
         try!(rm_rf(&layout.build(&unit.pkg)));
 

--- a/src/cargo/ops/cargo_rustc/custom_build.rs
+++ b/src/cargo/ops/cargo_rustc/custom_build.rs
@@ -87,9 +87,10 @@ pub fn prepare<'a, 'cfg>(cx: &mut Context<'a, 'cfg>, unit: &Unit<'a>)
 
 fn build_work<'a, 'cfg>(cx: &mut Context<'a, 'cfg>, unit: &Unit<'a>)
                         -> CargoResult<(Work, Work)> {
+    let host_unit = Unit { kind: Kind::Host, ..*unit };
     let (script_output, build_output) = {
-        (cx.layout(unit.pkg, Kind::Host).build(unit.pkg),
-         cx.layout(unit.pkg, unit.kind).build_out(unit.pkg))
+        (cx.layout(&host_unit).build(unit.pkg),
+         cx.layout(unit).build_out(unit.pkg))
     };
 
     // Building the command to execute
@@ -161,8 +162,8 @@ fn build_work<'a, 'cfg>(cx: &mut Context<'a, 'cfg>, unit: &Unit<'a>)
     };
     cx.build_explicit_deps.insert(*unit, (output_file.clone(), rerun_if_changed));
 
-    try!(fs::create_dir_all(&cx.layout(unit.pkg, Kind::Host).build(unit.pkg)));
-    try!(fs::create_dir_all(&cx.layout(unit.pkg, unit.kind).build(unit.pkg)));
+    try!(fs::create_dir_all(&cx.layout(&host_unit).build(unit.pkg)));
+    try!(fs::create_dir_all(&cx.layout(unit).build(unit.pkg)));
 
     // Prepare the unit of "dirty work" which will actually run the custom build
     // command.

--- a/src/cargo/ops/cargo_rustc/fingerprint.rs
+++ b/src/cargo/ops/cargo_rustc/fingerprint.rs
@@ -497,7 +497,7 @@ pub fn prepare_init(cx: &mut Context, unit: &Unit) -> CargoResult<()> {
 
 /// Return the (old, new) location for fingerprints for a package
 pub fn dir(cx: &Context, unit: &Unit) -> PathBuf {
-    cx.layout(unit.pkg, unit.kind).proxy().fingerprint(unit.pkg)
+    cx.layout(unit).proxy().fingerprint(unit.pkg)
 }
 
 /// Returns the (old, new) location for the dep info file of a target.

--- a/src/cargo/ops/cargo_rustc/layout.rs
+++ b/src/cargo/ops/cargo_rustc/layout.rs
@@ -49,9 +49,10 @@ use std::fs;
 use std::io;
 use std::path::{PathBuf, Path};
 
-use core::{Package, Target, Workspace};
+use core::{Package, Workspace};
 use util::{Config, FileLock, CargoResult, Filesystem};
 use util::hex::short_hash;
+use super::Unit;
 
 pub struct Layout {
     root: PathBuf,
@@ -165,11 +166,13 @@ impl<'a> LayoutProxy<'a> {
 
     pub fn proxy(&self) -> &'a Layout { self.root }
 
-    pub fn out_dir(&self, pkg: &Package, target: &Target) -> PathBuf {
-        if target.is_custom_build() {
-            self.build(pkg)
-        } else if target.is_example() {
+    pub fn out_dir(&self, unit: &Unit) -> PathBuf {
+        if unit.target.is_custom_build() {
+            self.build(unit.pkg)
+        } else if unit.target.is_example() {
             self.examples().to_path_buf()
+        } else if unit.target.is_lib() {
+            self.deps().to_path_buf()
         } else {
             self.root().to_path_buf()
         }

--- a/src/cargo/ops/cargo_test.rs
+++ b/src/cargo/ops/cargo_test.rs
@@ -134,7 +134,7 @@ fn run_doc_tests(options: &TestOptions,
             p.arg("--test").arg(lib)
              .arg("--crate-name").arg(&crate_name);
 
-            for &rust_dep in &[&compilation.deps_output, &compilation.root_output] {
+            for &rust_dep in &[&compilation.deps_output] {
                 let mut arg = OsString::from("dependency=");
                 arg.push(rust_dep);
                 p.arg("-L").arg(arg);

--- a/tests/build-lib.rs
+++ b/tests/build-lib.rs
@@ -10,9 +10,8 @@ fn verbose_output_for_lib(p: &ProjectBuilder) -> String {
     format!("\
 [COMPILING] {name} v{version} ({url})
 [RUNNING] `rustc src{sep}lib.rs --crate-name {name} --crate-type lib -g \
-        --out-dir {dir}{sep}target{sep}debug \
+        --out-dir [..] \
         --emit=dep-info,link \
-        -L dependency={dir}{sep}target{sep}debug \
         -L dependency={dir}{sep}target{sep}debug{sep}deps`
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 ", sep = SEP,

--- a/tests/build-script.rs
+++ b/tests/build-script.rs
@@ -766,19 +766,17 @@ fn build_cmd_with_a_build_cmd() {
 [RUNNING] `rustc a[..]build.rs [..] --extern b=[..]`
 [RUNNING] `[..]a-[..]build-script-build[..]`
 [RUNNING] `rustc [..]lib.rs --crate-name a --crate-type lib -g \
-    -C metadata=[..] -C extra-filename=-[..] \
     --out-dir [..]target[..]deps --emit=dep-info,link \
-    -L [..]target[..]deps -L [..]target[..]deps`
+    -L [..]target[..]deps`
 [COMPILING] foo v0.5.0 (file://[..])
 [RUNNING] `rustc build.rs --crate-name build_script_build --crate-type bin \
-    -g \
-    --out-dir [..]build[..]foo-[..] --emit=dep-info,link \
-    -L [..]target[..]debug -L [..]target[..]deps \
-    --extern a=[..]liba-[..].rlib`
+    -g --out-dir [..] --emit=dep-info,link \
+    -L [..]target[..]deps \
+    --extern a=[..]liba[..].rlib`
 [RUNNING] `[..]foo-[..]build-script-build[..]`
 [RUNNING] `rustc [..]lib.rs --crate-name foo --crate-type lib -g \
-    --out-dir [..]target[..]debug --emit=dep-info,link \
-    -L [..]target[..]debug -L [..]target[..]deps`
+    --out-dir [..] --emit=dep-info,link \
+    -L [..]target[..]deps`
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 "));
 }
@@ -1175,7 +1173,7 @@ fn build_script_with_dynamic_native_dependency() {
 
             fn main() {
                 let src = PathBuf::from(env::var("SRC").unwrap());
-                println!("cargo:rustc-link-search={}/target/debug",
+                println!("cargo:rustc-link-search={}/target/debug/deps",
                          src.display());
             }
         "#)

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -1026,7 +1026,6 @@ fn lto_build() {
         -C lto \
         --out-dir {dir}[..]target[..]release \
         --emit=dep-info,link \
-        -L dependency={dir}[..]target[..]release \
         -L dependency={dir}[..]target[..]release[..]deps`
 [FINISHED] release [optimized] target(s) in [..]
 ",
@@ -1051,9 +1050,8 @@ fn verbose_build() {
                 execs().with_status(0).with_stderr(&format!("\
 [COMPILING] test v0.0.0 ({url})
 [RUNNING] `rustc src[..]lib.rs --crate-name test --crate-type lib -g \
-        --out-dir {dir}[..]target[..]debug \
+        --out-dir [..] \
         --emit=dep-info,link \
-        -L dependency={dir}[..]target[..]debug \
         -L dependency={dir}[..]target[..]debug[..]deps`
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 ",
@@ -1079,9 +1077,8 @@ fn verbose_release_build() {
 [COMPILING] test v0.0.0 ({url})
 [RUNNING] `rustc src[..]lib.rs --crate-name test --crate-type lib \
         -C opt-level=3 \
-        --out-dir {dir}[..]target[..]release \
+        --out-dir [..] \
         --emit=dep-info,link \
-        -L dependency={dir}[..]target[..]release \
         -L dependency={dir}[..]target[..]release[..]deps`
 [FINISHED] release [optimized] target(s) in [..]
 ",
@@ -1123,22 +1120,18 @@ fn verbose_release_build_deps() {
 [RUNNING] `rustc foo[..]src[..]lib.rs --crate-name foo \
         --crate-type dylib --crate-type rlib -C prefer-dynamic \
         -C opt-level=3 \
-        -C metadata=[..] \
-        -C extra-filename=-[..] \
-        --out-dir {dir}[..]target[..]release[..]deps \
+        --out-dir [..] \
         --emit=dep-info,link \
-        -L dependency={dir}[..]target[..]release[..]deps \
         -L dependency={dir}[..]target[..]release[..]deps`
 [COMPILING] test v0.0.0 ({url})
 [RUNNING] `rustc src[..]lib.rs --crate-name test --crate-type lib \
         -C opt-level=3 \
-        --out-dir {dir}[..]target[..]release \
+        --out-dir [..] \
         --emit=dep-info,link \
-        -L dependency={dir}[..]target[..]release \
         -L dependency={dir}[..]target[..]release[..]deps \
         --extern foo={dir}[..]target[..]release[..]deps[..]\
-                     {prefix}foo-[..]{suffix} \
-        --extern foo={dir}[..]target[..]release[..]deps[..]libfoo-[..].rlib`
+                     {prefix}foo{suffix} \
+        --extern foo={dir}[..]target[..]release[..]deps[..]libfoo.rlib`
 [FINISHED] release [optimized] target(s) in [..]
 ",
                     dir = p.root().display(),
@@ -1783,14 +1776,14 @@ fn compile_then_delete() {
         "#)
         .file("src/main.rs", "fn main() {}");
 
-    assert_that(p.cargo_process("run"), execs().with_status(0));
+    assert_that(p.cargo_process("run").arg("-v"), execs().with_status(0));
     assert_that(&p.bin("foo"), existing_file());
     if cfg!(windows) {
         // On windows unlinking immediately after running often fails, so sleep
         sleep_ms(100);
     }
     fs::remove_file(&p.bin("foo")).unwrap();
-    assert_that(p.cargo("run"),
+    assert_that(p.cargo("run").arg("-v"),
                 execs().with_status(0));
 }
 
@@ -2243,11 +2236,7 @@ fn explicit_color_config_is_propagated_to_rustc() {
     assert_that(p.cargo_process("build").arg("-v").arg("--color").arg("never"),
                 execs().with_status(0).with_stderr("\
 [COMPILING] test v0.0.0 ([..])
-[RUNNING] `rustc src[..]lib.rs --color never --crate-name test --crate-type lib -g \
-        --out-dir [..]target[..]debug \
-        --emit=dep-info,link \
-        -L dependency=[..]target[..]debug \
-        -L dependency=[..]target[..]debug[..]deps`
+[RUNNING] `rustc [..] --color never [..]`
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 "));
 }

--- a/tests/cargo_alias_config.rs
+++ b/tests/cargo_alias_config.rs
@@ -56,8 +56,7 @@ fn alias_config() {
                 execs().with_status(0).
                 with_stderr_contains("[COMPILING] foo v0.5.0 [..]
 [RUNNING] `rustc [..] --crate-name foo --crate-type \
-bin -g --out-dir [..] --emit=dep-info,link -L dependency=[..]\
--L dependency=[..]"));
+bin -g --out-dir [..] --emit=dep-info,link -L dependency=[..]"));
 }
 
 #[test]

--- a/tests/cross-compile.rs
+++ b/tests/cross-compile.rs
@@ -362,7 +362,6 @@ fn linker_and_ar() {
     --emit=dep-info,link \
     --target {target} \
     -C ar=my-ar-tool -C linker=my-linker-tool \
-    -L dependency={dir}[..]target[..]{target}[..]debug \
     -L dependency={dir}[..]target[..]{target}[..]debug[..]deps`
 ",
                             dir = p.root().display(),

--- a/tests/plugins.rs
+++ b/tests/plugins.rs
@@ -147,7 +147,7 @@ fn plugin_with_dynamic_native_dependency() {
 
             fn main() {
                 let src = PathBuf::from(env::var("SRC").unwrap());
-                println!("cargo:rustc-flags=-L {}", src.parent().unwrap()
+                println!("cargo:rustc-flags=-L {}/deps", src.parent().unwrap()
                                                        .display());
             }
         "#)

--- a/tests/profiles.rs
+++ b/tests/profiles.rs
@@ -31,9 +31,8 @@ fn profile_overrides() {
         -C opt-level=1 \
         -C debug-assertions=on \
         -C rpath \
-        --out-dir {dir}{sep}target{sep}debug \
+        --out-dir [..] \
         --emit=dep-info,link \
-        -L dependency={dir}{sep}target{sep}debug \
         -L dependency={dir}{sep}target{sep}debug{sep}deps`
 [FINISHED] debug [optimized] target(s) in [..]
 ", sep = SEP,
@@ -84,23 +83,19 @@ fn top_level_overrides_deps() {
         --crate-type dylib --crate-type rlib -C prefer-dynamic \
         -C opt-level=1 \
         -g \
-        -C metadata=[..] \
-        -C extra-filename=-[..] \
         --out-dir {dir}{sep}target{sep}release{sep}deps \
         --emit=dep-info,link \
-        -L dependency={dir}{sep}target{sep}release{sep}deps \
         -L dependency={dir}{sep}target{sep}release{sep}deps`
 [COMPILING] test v0.0.0 ({url})
 [RUNNING] `rustc src{sep}lib.rs --crate-name test --crate-type lib \
         -C opt-level=1 \
         -g \
-        --out-dir {dir}{sep}target{sep}release \
+        --out-dir [..] \
         --emit=dep-info,link \
-        -L dependency={dir}{sep}target{sep}release \
         -L dependency={dir}{sep}target{sep}release{sep}deps \
         --extern foo={dir}{sep}target{sep}release{sep}deps{sep}\
-                     {prefix}foo-[..]{suffix} \
-        --extern foo={dir}{sep}target{sep}release{sep}deps{sep}libfoo-[..].rlib`
+                     {prefix}foo[..]{suffix} \
+        --extern foo={dir}{sep}target{sep}release{sep}deps{sep}libfoo.rlib`
 [FINISHED] release [optimized + debuginfo] target(s) in [..]
 ",
                     dir = p.root().display(),

--- a/tests/run.rs
+++ b/tests/run.rs
@@ -411,20 +411,16 @@ fn example_with_release_flag() {
 [COMPILING] bar v0.0.1 ({url}/bar)
 [RUNNING] `rustc bar{sep}src{sep}bar.rs --crate-name bar --crate-type lib \
         -C opt-level=3 \
-        -C metadata=[..] \
-        -C extra-filename=[..] \
         --out-dir {dir}{sep}target{sep}release{sep}deps \
         --emit=dep-info,link \
-        -L dependency={dir}{sep}target{sep}release{sep}deps \
         -L dependency={dir}{sep}target{sep}release{sep}deps`
 [COMPILING] foo v0.0.1 ({url})
 [RUNNING] `rustc examples{sep}a.rs --crate-name a --crate-type bin \
         -C opt-level=3 \
         --out-dir {dir}{sep}target{sep}release{sep}examples \
         --emit=dep-info,link \
-        -L dependency={dir}{sep}target{sep}release \
         -L dependency={dir}{sep}target{sep}release{sep}deps \
-         --extern bar={dir}{sep}target{sep}release{sep}deps{sep}libbar-[..].rlib`
+         --extern bar={dir}{sep}target{sep}release{sep}deps{sep}libbar.rlib`
 [FINISHED] release [optimized] target(s) in [..]
 [RUNNING] `target{sep}release{sep}examples{sep}a[..]`
 ",
@@ -441,20 +437,16 @@ fast2"));
 [COMPILING] bar v0.0.1 ({url}/bar)
 [RUNNING] `rustc bar{sep}src{sep}bar.rs --crate-name bar --crate-type lib \
         -g \
-        -C metadata=[..] \
-        -C extra-filename=[..] \
         --out-dir {dir}{sep}target{sep}debug{sep}deps \
         --emit=dep-info,link \
-        -L dependency={dir}{sep}target{sep}debug{sep}deps \
         -L dependency={dir}{sep}target{sep}debug{sep}deps`
 [COMPILING] foo v0.0.1 ({url})
 [RUNNING] `rustc examples{sep}a.rs --crate-name a --crate-type bin \
         -g \
         --out-dir {dir}{sep}target{sep}debug{sep}examples \
         --emit=dep-info,link \
-        -L dependency={dir}{sep}target{sep}debug \
         -L dependency={dir}{sep}target{sep}debug{sep}deps \
-         --extern bar={dir}{sep}target{sep}debug{sep}deps{sep}libbar-[..].rlib`
+         --extern bar={dir}{sep}target{sep}debug{sep}deps{sep}libbar.rlib`
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `target{sep}debug{sep}examples{sep}a[..]`
 ",

--- a/tests/rustc.rs
+++ b/tests/rustc.rs
@@ -30,9 +30,8 @@ fn build_lib_for_foo() {
                 .with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({url})
 [RUNNING] `rustc src{sep}lib.rs --crate-name foo --crate-type lib -g \
-        --out-dir {dir}{sep}target{sep}debug \
+        --out-dir [..] \
         --emit=dep-info,link \
-        -L dependency={dir}{sep}target{sep}debug \
         -L dependency={dir}{sep}target{sep}debug{sep}deps`
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 ", sep = SEP,
@@ -61,9 +60,8 @@ fn lib() {
 [COMPILING] foo v0.0.1 ({url})
 [RUNNING] `rustc src{sep}lib.rs --crate-name foo --crate-type lib -g \
         -C debug-assertions=off \
-        --out-dir {dir}{sep}target{sep}debug \
+        --out-dir [..] \
         --emit=dep-info,link \
-        -L dependency={dir}{sep}target{sep}debug \
         -L dependency={dir}{sep}target{sep}debug{sep}deps`
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 ", sep = SEP,
@@ -91,17 +89,15 @@ fn build_main_and_allow_unstable_options() {
                 .with_stderr(&format!("\
 [COMPILING] {name} v{version} ({url})
 [RUNNING] `rustc src{sep}lib.rs --crate-name {name} --crate-type lib -g \
-        --out-dir {dir}{sep}target{sep}debug \
+        --out-dir [..] \
         --emit=dep-info,link \
-        -L dependency={dir}{sep}target{sep}debug \
         -L dependency={dir}{sep}target{sep}debug{sep}deps`
 [RUNNING] `rustc src{sep}main.rs --crate-name {name} --crate-type bin -g \
         -C debug-assertions \
-        --out-dir {dir}{sep}target{sep}debug \
+        --out-dir [..] \
         --emit=dep-info,link \
-        -L dependency={dir}{sep}target{sep}debug \
         -L dependency={dir}{sep}target{sep}debug{sep}deps \
-        --extern {name}={dir}{sep}target{sep}debug{sep}lib{name}.rlib`
+        --extern {name}={dir}{sep}target[..]lib{name}.rlib`
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 ", sep = SEP,
             dir = p.root().display(), url = p.url(),
@@ -156,12 +152,11 @@ fn build_with_args_to_one_of_multiple_binaries() {
                 .with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({url})
 [RUNNING] `rustc src{sep}lib.rs --crate-name foo --crate-type lib -g \
-        --out-dir {dir}{sep}target{sep}debug [..]`
+        --out-dir [..]`
 [RUNNING] `rustc src{sep}bin{sep}bar.rs --crate-name bar --crate-type bin -g \
         -C debug-assertions [..]`
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
-", sep = SEP,
-                dir = p.root().display(), url = p.url())));
+", sep = SEP, url = p.url())));
 }
 
 #[test]
@@ -212,12 +207,11 @@ fn build_with_args_to_one_of_multiple_tests() {
                 .with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({url})
 [RUNNING] `rustc src{sep}lib.rs --crate-name foo --crate-type lib -g \
-        --out-dir {dir}{sep}target{sep}debug [..]`
+        --out-dir [..]`
 [RUNNING] `rustc tests{sep}bar.rs --crate-name bar -g \
         -C debug-assertions [..]--test[..]`
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
-", sep = SEP,
-                dir = p.root().display(), url = p.url())));
+", sep = SEP, url = p.url())));
 }
 
 #[test]
@@ -255,7 +249,7 @@ fn build_foo_with_bar_dependency() {
                 .with_status(0)
                 .with_stderr(format!("\
 [COMPILING] bar v0.1.0 ([..])
-[RUNNING] `[..] -g -C [..]`
+[RUNNING] `[..] -g [..]`
 [COMPILING] foo v0.0.1 ({url})
 [RUNNING] `[..] -g -C debug-assertions [..]`
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]

--- a/tests/rustdoc.rs
+++ b/tests/rustdoc.rs
@@ -24,7 +24,6 @@ fn rustdoc_simple() {
 [DOCUMENTING] foo v0.0.1 ({url})
 [RUNNING] `rustdoc src{sep}lib.rs --crate-name foo \
         -o {dir}{sep}target{sep}doc \
-        -L dependency={dir}{sep}target{sep}debug \
         -L dependency={dir}{sep}target{sep}debug{sep}deps`
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 ", sep = SEP,
@@ -50,7 +49,6 @@ fn rustdoc_args() {
 [RUNNING] `rustdoc src{sep}lib.rs --crate-name foo \
         -o {dir}{sep}target{sep}doc \
         --no-defaults \
-        -L dependency={dir}{sep}target{sep}debug \
         -L dependency={dir}{sep}target{sep}debug{sep}deps`
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 ", sep = SEP,
@@ -97,7 +95,6 @@ fn rustdoc_foo_with_bar_dependency() {
 [RUNNING] `rustdoc src{sep}lib.rs --crate-name foo \
         -o {dir}{sep}target{sep}doc \
         --no-defaults \
-        -L dependency={dir}{sep}target{sep}debug \
         -L dependency={dir}{sep}target{sep}debug{sep}deps \
         --extern [..]`
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
@@ -144,7 +141,6 @@ fn rustdoc_only_bar_dependency() {
 [RUNNING] `rustdoc [..]bar{sep}src{sep}lib.rs --crate-name bar \
         -o {dir}{sep}target{sep}doc \
         --no-defaults \
-        -L dependency={dir}{sep}target{sep}debug{sep}deps \
         -L dependency={dir}{sep}target{sep}debug{sep}deps`
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 ", sep = SEP,

--- a/tests/workspaces.rs
+++ b/tests/workspaces.rs
@@ -2,7 +2,7 @@
 extern crate cargotest;
 extern crate hamcrest;
 
-use std::io::Read;
+use std::io::{Read, Write};
 use std::fs::File;
 
 use cargotest::support::{project, execs};
@@ -826,4 +826,50 @@ fn lock_doesnt_change_depending_on_crate() {
     t!(t!(File::open(p.root().join("Cargo.lock"))).read_to_string(&mut lockfile2));
 
     assert_eq!(lockfile, lockfile2);
+}
+
+#[test]
+fn rebuild_please() {
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [workspace]
+            members = ['lib', 'bin']
+        "#)
+        .file("lib/Cargo.toml", r#"
+            [package]
+            name = "lib"
+            version = "0.1.0"
+        "#)
+        .file("lib/src/lib.rs", r#"
+            pub fn foo() -> u32 { 0 }
+        "#)
+        .file("bin/Cargo.toml", r#"
+            [package]
+            name = "bin"
+            version = "0.1.0"
+
+            [dependencies]
+            lib = { path = "../lib" }
+        "#)
+        .file("bin/src/main.rs", r#"
+            extern crate lib;
+
+            fn main() {
+                assert_eq!(lib::foo(), 0);
+            }
+        "#);
+    p.build();
+
+    assert_that(p.cargo("run").cwd(p.root().join("bin")),
+                execs().with_status(0));
+
+    t!(t!(File::create(p.root().join("lib/src/lib.rs"))).write_all(br#"
+        pub fn foo() -> u32 { 1 }
+    "#));
+
+    assert_that(p.cargo("build").cwd(p.root().join("lib")),
+                execs().with_status(0));
+
+    assert_that(p.cargo("run").cwd(p.root().join("bin")),
+                execs().with_status(101));
 }


### PR DESCRIPTION
Previously Cargo would compile a library into a different location depending on
whether it was the "root crate" or not. In the ongoing saga of reducing Cargo's
reliance on the idea of a "root crate" this PR is the next step. With workspaces
the root crate of a compliation changes all the time, so the output needs to be
the same whether a crate is at the root or not.

Fixing this inconsistence in turn fixes bugs like #2855 and #2897 which arise
due to this discrepancy. Additionally, Cargo will no longer recompile a library
when it's used as a "root crate" or not.

This is fixed by taking a few steps:

* Everything is now compiled into the `deps` directory, regardless of whether
  it's a root output or not.
* If a "root crate" is being compiled, then the relevant outputs are hard-linked
  up one level to where they are today. This means that your binaries, dylibs,
  staticlibs, etc, will all show up where they used to.
* The `-C metadata` flag is always omitted for path dependencies now. These
  dependencies are always path dependencies and already all have unique crate
  names. Additionally, they're the only crates in the DAG without metadata, so
  there's no need to provide additional metadata. This in turn means that none
  of the file names of the generated crates are mangled.

Closes #2855