### PR TITLE
Print a more useful error message when the target binary can't be removed

### DIFF
--- a/src/cargo/ops/cargo_rustc/mod.rs
+++ b/src/cargo/ops/cargo_rustc/mod.rs
@@ -258,7 +258,9 @@ fn rustc(cx: &mut Context, unit: &Unit) -> CargoResult<Work> {
         for &(ref filename, _linkable) in filenames.iter() {
             let dst = root.join(filename);
             if fs::metadata(&dst).is_ok() {
-                try!(fs::remove_file(&dst));
+                try!(fs::remove_file(&dst).chain_error(|| {
+                    human(format!("Could not remove file: {}.", dst.display()))
+                }));
             }
         }
 


### PR DESCRIPTION
This happens sometimes on Windows if the target is still running, and right
now cargo prints a very cryptic message:
```
$ cargo build
   Compiling sccache v0.1.0 (file:///C:/build/sccache2)
An unknown error occurred
```

With this patch we get a much more useful error:
```
$ ../cargo/target/debug/cargo build
   Compiling sccache v0.1.0 (file:///C:/build/sccache2)
error: Could not remove file: c:\build\sccache2\target\debug\sccache.exe.

To learn more, run the command again with --verbose.
```