### PR TITLE
Add *.rs.bk to .gitignore file by default.

### DIFF
--- a/src/cargo/ops/cargo_new.rs
+++ b/src/cargo/ops/cargo_new.rs
@@ -336,7 +336,7 @@ fn mk(config: &Config, opts: &MkOptions) -> CargoResult<()> {
     let path = opts.path;
     let name = opts.name;
     let cfg = try!(global_config(config));
-    let mut ignore = "target\n".to_string();
+    let mut ignore = "target\n*.rs.bk".to_string();
     let in_existing_vcs_repo = existing_vcs_repo(path.parent().unwrap(), config.cwd());
     if !opts.bin {
         ignore.push_str("Cargo.lock\n");

--- a/src/cargo/ops/cargo_new.rs
+++ b/src/cargo/ops/cargo_new.rs
@@ -336,7 +336,7 @@ fn mk(config: &Config, opts: &MkOptions) -> CargoResult<()> {
     let path = opts.path;
     let name = opts.name;
     let cfg = try!(global_config(config));
-    let mut ignore = "target\n*.rs.bk".to_string();
+    let mut ignore = "target\n*.rs.bk\n".to_string();
     let in_existing_vcs_repo = existing_vcs_repo(path.parent().unwrap(), config.cwd());
     if !opts.bin {
         ignore.push_str("Cargo.lock\n");


### PR DESCRIPTION
Rustfmt creates a backup of changed files with the file extension .rs.bk. Since the old files are already present in the vcs they should not be commited.