### PR TITLE
Always pass `-C metadata` to the compiler

### DIFF
--- a/src/cargo/ops/cargo_rustc/mod.rs
+++ b/src/cargo/ops/cargo_rustc/mod.rs
@@ -9,7 +9,7 @@ use core::{Package, PackageId, PackageSet, Target, Resolve};
 use core::{Profile, Profiles, Workspace};
 use core::shell::ColorConfig;
 use util::{self, CargoResult, human};
-use util::{Config, internal, ChainError, profile, join_paths};
+use util::{Config, internal, ChainError, profile, join_paths, short_hash};
 
 use self::job::{Job, Work};
 use self::job_queue::JobQueue;
@@ -554,9 +554,14 @@ fn build_base_args(cx: &Context,
         }
     }
 
-    if let Some(m) = cx.target_metadata(unit) {
-        cmd.arg("-C").arg(&format!("metadata={}", m.metadata));
-        cmd.arg("-C").arg(&format!("extra-filename={}", m.extra_filename));
+    match cx.target_metadata(unit) {
+        Some(m) => {
+            cmd.arg("-C").arg(&format!("metadata={}", m.metadata));
+            cmd.arg("-C").arg(&format!("extra-filename={}", m.extra_filename));
+        }
+        None => {
+            cmd.arg("-C").arg(&format!("metadata={}", short_hash(unit.pkg)));
+        }
     }
 
     if rpath {

--- a/tests/build-lib.rs
+++ b/tests/build-lib.rs
@@ -10,6 +10,7 @@ fn verbose_output_for_lib(p: &ProjectBuilder) -> String {
     format!("\
 [COMPILING] {name} v{version} ({url})
 [RUNNING] `rustc src{sep}lib.rs --crate-name {name} --crate-type lib -g \
+        -C metadata=[..] \
         --out-dir [..] \
         --emit=dep-info,link \
         -L dependency={dir}{sep}target{sep}debug{sep}deps`

--- a/tests/build-script.rs
+++ b/tests/build-script.rs
@@ -766,15 +766,17 @@ fn build_cmd_with_a_build_cmd() {
 [RUNNING] `rustc a[..]build.rs [..] --extern b=[..]`
 [RUNNING] `[..]a-[..]build-script-build[..]`
 [RUNNING] `rustc [..]lib.rs --crate-name a --crate-type lib -g \
+    -C metadata=[..] \
     --out-dir [..]target[..]deps --emit=dep-info,link \
     -L [..]target[..]deps`
 [COMPILING] foo v0.5.0 (file://[..])
 [RUNNING] `rustc build.rs --crate-name build_script_build --crate-type bin \
-    -g --out-dir [..] --emit=dep-info,link \
+    -g -C metadata=[..] --out-dir [..] --emit=dep-info,link \
     -L [..]target[..]deps \
     --extern a=[..]liba[..].rlib`
 [RUNNING] `[..]foo-[..]build-script-build[..]`
 [RUNNING] `rustc [..]lib.rs --crate-name foo --crate-type lib -g \
+    -C metadata=[..] \
     --out-dir [..] --emit=dep-info,link \
     -L [..]target[..]deps`
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -1024,6 +1024,7 @@ fn lto_build() {
 [RUNNING] `rustc src[..]main.rs --crate-name test --crate-type bin \
         -C opt-level=3 \
         -C lto \
+        -C metadata=[..] \
         --out-dir {dir}[..]target[..]release \
         --emit=dep-info,link \
         -L dependency={dir}[..]target[..]release[..]deps`
@@ -1050,6 +1051,7 @@ fn verbose_build() {
                 execs().with_status(0).with_stderr(&format!("\
 [COMPILING] test v0.0.0 ({url})
 [RUNNING] `rustc src[..]lib.rs --crate-name test --crate-type lib -g \
+        -C metadata=[..] \
         --out-dir [..] \
         --emit=dep-info,link \
         -L dependency={dir}[..]target[..]debug[..]deps`
@@ -1077,6 +1079,7 @@ fn verbose_release_build() {
 [COMPILING] test v0.0.0 ({url})
 [RUNNING] `rustc src[..]lib.rs --crate-name test --crate-type lib \
         -C opt-level=3 \
+        -C metadata=[..] \
         --out-dir [..] \
         --emit=dep-info,link \
         -L dependency={dir}[..]target[..]release[..]deps`
@@ -1120,12 +1123,14 @@ fn verbose_release_build_deps() {
 [RUNNING] `rustc foo[..]src[..]lib.rs --crate-name foo \
         --crate-type dylib --crate-type rlib -C prefer-dynamic \
         -C opt-level=3 \
+        -C metadata=[..] \
         --out-dir [..] \
         --emit=dep-info,link \
         -L dependency={dir}[..]target[..]release[..]deps`
 [COMPILING] test v0.0.0 ({url})
 [RUNNING] `rustc src[..]lib.rs --crate-name test --crate-type lib \
         -C opt-level=3 \
+        -C metadata=[..] \
         --out-dir [..] \
         --emit=dep-info,link \
         -L dependency={dir}[..]target[..]release[..]deps \

--- a/tests/cargo_alias_config.rs
+++ b/tests/cargo_alias_config.rs
@@ -55,8 +55,7 @@ fn alias_config() {
     assert_that(p.cargo_process("b-cargo-test").arg("-v"),
                 execs().with_status(0).
                 with_stderr_contains("[COMPILING] foo v0.5.0 [..]
-[RUNNING] `rustc [..] --crate-name foo --crate-type \
-bin -g --out-dir [..] --emit=dep-info,link -L dependency=[..]"));
+[RUNNING] `rustc [..] --crate-name foo [..]"));
 }
 
 #[test]
@@ -74,9 +73,7 @@ fn alias_list_test() {
     assert_that(p.cargo_process("b-cargo-test").arg("-v"),
                 execs().with_status(0).
                 with_stderr_contains("[COMPILING] foo v0.5.0 [..]").
-                with_stderr_contains("[RUNNING] `rustc [..] --crate-name foo \
-                                     --crate-type bin -C opt-level=3 --out-dir [..]\
-                                     --emit=dep-info,link -L dependency=[..]")
+                with_stderr_contains("[RUNNING] `rustc [..] --crate-name [..]")
                 );
 }
 
@@ -95,9 +92,7 @@ fn alias_with_flags_config() {
     assert_that(p.cargo_process("b-cargo-test").arg("-v"),
                 execs().with_status(0).
                 with_stderr_contains("[COMPILING] foo v0.5.0 [..]").
-                with_stderr_contains("[RUNNING] `rustc [..] --crate-name foo \
-                                     --crate-type bin -C opt-level=3 --out-dir [..]\
-                                     --emit=dep-info,link -L dependency=[..]")
+                with_stderr_contains("[RUNNING] `rustc [..] --crate-name foo [..]")
                 );
 }
 

--- a/tests/cross-compile.rs
+++ b/tests/cross-compile.rs
@@ -358,6 +358,7 @@ fn linker_and_ar() {
                        .with_stderr_contains(&format!("\
 [COMPILING] foo v0.5.0 ({url})
 [RUNNING] `rustc src[..]foo.rs --crate-name foo --crate-type bin -g \
+    -C metadata=[..] \
     --out-dir {dir}[..]target[..]{target}[..]debug \
     --emit=dep-info,link \
     --target {target} \

--- a/tests/profiles.rs
+++ b/tests/profiles.rs
@@ -30,6 +30,7 @@ fn profile_overrides() {
 [RUNNING] `rustc src{sep}lib.rs --crate-name test --crate-type lib \
         -C opt-level=1 \
         -C debug-assertions=on \
+        -C metadata=[..] \
         -C rpath \
         --out-dir [..] \
         --emit=dep-info,link \
@@ -83,6 +84,7 @@ fn top_level_overrides_deps() {
         --crate-type dylib --crate-type rlib -C prefer-dynamic \
         -C opt-level=1 \
         -g \
+        -C metadata=[..] \
         --out-dir {dir}{sep}target{sep}release{sep}deps \
         --emit=dep-info,link \
         -L dependency={dir}{sep}target{sep}release{sep}deps`
@@ -90,6 +92,7 @@ fn top_level_overrides_deps() {
 [RUNNING] `rustc src{sep}lib.rs --crate-name test --crate-type lib \
         -C opt-level=1 \
         -g \
+        -C metadata=[..] \
         --out-dir [..] \
         --emit=dep-info,link \
         -L dependency={dir}{sep}target{sep}release{sep}deps \

--- a/tests/run.rs
+++ b/tests/run.rs
@@ -411,12 +411,14 @@ fn example_with_release_flag() {
 [COMPILING] bar v0.0.1 ({url}/bar)
 [RUNNING] `rustc bar{sep}src{sep}bar.rs --crate-name bar --crate-type lib \
         -C opt-level=3 \
+        -C metadata=[..] \
         --out-dir {dir}{sep}target{sep}release{sep}deps \
         --emit=dep-info,link \
         -L dependency={dir}{sep}target{sep}release{sep}deps`
 [COMPILING] foo v0.0.1 ({url})
 [RUNNING] `rustc examples{sep}a.rs --crate-name a --crate-type bin \
         -C opt-level=3 \
+        -C metadata=[..] \
         --out-dir {dir}{sep}target{sep}release{sep}examples \
         --emit=dep-info,link \
         -L dependency={dir}{sep}target{sep}release{sep}deps \
@@ -437,12 +439,14 @@ fast2"));
 [COMPILING] bar v0.0.1 ({url}/bar)
 [RUNNING] `rustc bar{sep}src{sep}bar.rs --crate-name bar --crate-type lib \
         -g \
+        -C metadata=[..] \
         --out-dir {dir}{sep}target{sep}debug{sep}deps \
         --emit=dep-info,link \
         -L dependency={dir}{sep}target{sep}debug{sep}deps`
 [COMPILING] foo v0.0.1 ({url})
 [RUNNING] `rustc examples{sep}a.rs --crate-name a --crate-type bin \
         -g \
+        -C metadata=[..] \
         --out-dir {dir}{sep}target{sep}debug{sep}examples \
         --emit=dep-info,link \
         -L dependency={dir}{sep}target{sep}debug{sep}deps \

--- a/tests/rustc.rs
+++ b/tests/rustc.rs
@@ -30,6 +30,7 @@ fn build_lib_for_foo() {
                 .with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({url})
 [RUNNING] `rustc src{sep}lib.rs --crate-name foo --crate-type lib -g \
+        -C metadata=[..] \
         --out-dir [..] \
         --emit=dep-info,link \
         -L dependency={dir}{sep}target{sep}debug{sep}deps`
@@ -60,6 +61,7 @@ fn lib() {
 [COMPILING] foo v0.0.1 ({url})
 [RUNNING] `rustc src{sep}lib.rs --crate-name foo --crate-type lib -g \
         -C debug-assertions=off \
+        -C metadata=[..] \
         --out-dir [..] \
         --emit=dep-info,link \
         -L dependency={dir}{sep}target{sep}debug{sep}deps`
@@ -89,11 +91,13 @@ fn build_main_and_allow_unstable_options() {
                 .with_stderr(&format!("\
 [COMPILING] {name} v{version} ({url})
 [RUNNING] `rustc src{sep}lib.rs --crate-name {name} --crate-type lib -g \
+        -C metadata=[..] \
         --out-dir [..] \
         --emit=dep-info,link \
         -L dependency={dir}{sep}target{sep}debug{sep}deps`
 [RUNNING] `rustc src{sep}main.rs --crate-name {name} --crate-type bin -g \
         -C debug-assertions \
+        -C metadata=[..] \
         --out-dir [..] \
         --emit=dep-info,link \
         -L dependency={dir}{sep}target{sep}debug{sep}deps \
@@ -152,6 +156,7 @@ fn build_with_args_to_one_of_multiple_binaries() {
                 .with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({url})
 [RUNNING] `rustc src{sep}lib.rs --crate-name foo --crate-type lib -g \
+        -C metadata=[..] \
         --out-dir [..]`
 [RUNNING] `rustc src{sep}bin{sep}bar.rs --crate-name bar --crate-type bin -g \
         -C debug-assertions [..]`
@@ -207,6 +212,7 @@ fn build_with_args_to_one_of_multiple_tests() {
                 .with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({url})
 [RUNNING] `rustc src{sep}lib.rs --crate-name foo --crate-type lib -g \
+        -C metadata=[..] \
         --out-dir [..]`
 [RUNNING] `rustc tests{sep}bar.rs --crate-name bar -g \
         -C debug-assertions [..]--test[..]`


### PR DESCRIPTION
If it's not otherwise available we just key it off the pkgid which should be
unique enough across compilations. This should help incremental compilation
efforts be "more incremental" across projects.

Closes #2943