### PR TITLE
Add *.rs.bk files to vcs ignore files

### DIFF
--- a/src/cargo/ops/cargo_new.rs
+++ b/src/cargo/ops/cargo_new.rs
@@ -375,6 +375,9 @@ fn mk(config: &Config, opts: &MkOptions) -> CargoResult<()> {
     if !opts.bin {
         ignore.push_str("Cargo.lock\n");
     }
+    // Add a rule to ignore rustfmt backup files in the vcs ignore file
+    ignore.push_str("# Ignore rustfmt backup files\n");
+    ignore.push_str("*.rs.bk\n");
 
     let vcs = match (opts.version_control, cfg.version_control, in_existing_vcs_repo) {
         (None, None, false) => VersionControl::Git,


### PR DESCRIPTION
Implements #2949 

This adds the following lines to the vcs ignore files when a new project is created

```bash
# Ignore rustfmt backup files
*.rs.bk
```