### PR TITLE
Demote duplicate build target error to a warning

### DIFF
--- a/src/cargo/util/toml.rs
+++ b/src/cargo/util/toml.rs
@@ -536,7 +536,8 @@ impl TomlManifest {
         }
 
         if let Err(e) = unique_build_targets(&targets, layout) {
-            bail!("duplicate build target found: `{}`", e);
+            warnings.push(format!("file found to be present in multiple \
+                                   build targets: {}", e));
         }
 
         let mut deps = Vec::new();

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -117,21 +117,18 @@ fn cargo_compile_duplicate_build_targets() {
             [dependencies]
         "#)
         .file("src/main.rs", r#"
+            #![allow(warnings)]
             fn main() {}
         "#);
 
-    let error_message = format!("\
-[ERROR] failed to parse manifest at `[..]`
-
-Caused by:
-  duplicate build target found: `{}`",
-                     p.root().join("src[..]main.rs").display());
-
     assert_that(p.cargo_process("build"),
                 execs()
-                .with_status(101)
-                .with_stderr(error_message)
-    )
+                .with_status(0)
+                .with_stderr("\
+warning: file found to be present in multiple build targets: [..]main.rs
+[COMPILING] foo v0.0.1 ([..])
+[FINISHED] [..]
+"));
 }
 
 #[test]


### PR DESCRIPTION
Added in #2847 this ended up unfortunately breaking the `regex` crate on
nightly, so let's just issue a warning for awhile first. Eventually we can
promote this to an error if it becomes a problem.