### PR TITLE
Update cargo tests in prep for new errors

### DIFF
--- a/tests/build-script.rs
+++ b/tests/build-script.rs
@@ -857,7 +857,6 @@ fn output_separate_lines() {
 [RUNNING] `[..]foo-[..]build-script-build[..]`
 [RUNNING] `rustc [..] --crate-name foo [..] -L foo -l static=foo`
 [ERROR] could not find native static library [..]
-[ERROR] Could not compile [..]
 "));
 }
 
@@ -886,7 +885,6 @@ fn output_separate_lines_new() {
 [RUNNING] `[..]foo-[..]build-script-build[..]`
 [RUNNING] `rustc [..] --crate-name foo [..] -L foo -l static=foo`
 [ERROR] could not find native static library [..]
-[ERROR] Could not compile [..]
 "));
 }
 


### PR DESCRIPTION
This updates a couple tests so that we can upgrade rustc to new error format.

r? @alexcrichton 