### PR TITLE
Make `cargo doc --open --target TARGET` work as expected.

### DIFF
--- a/src/cargo/ops/cargo_doc.rs
+++ b/src/cargo/ops/cargo_doc.rs
@@ -53,7 +53,10 @@ pub fn doc(ws: &Workspace,
         // Don't bother locking here as if this is getting deleted there's
         // nothing we can do about it and otherwise if it's getting overwritten
         // then that's also ok!
-        let target_dir = ws.target_dir();
+        let mut target_dir = ws.target_dir();
+        if let Some(triple) = options.compile_opts.target {
+            target_dir.push(Path::new(triple).file_stem().unwrap());
+        }
         let path = target_dir.join("doc").join(&name).join("index.html");
         let path = path.into_path_unlocked();
         if fs::metadata(&path).is_ok() {


### PR DESCRIPTION
Currently `cargo doc --open` opens `$TARGET/doc` unconditionally, but it is incorrect if the explicit target is specified.

The target directory should be same to what `Layout::new()` generates, and ideally it should use the same data source (it hadn't been so far), but I'm yet to find a good way to signal that. At least I'm pretty sure that `Compilation` is not a good position to put them (it assumes the bipartite "root"-"deps" separation which doesn't quite work in documentation).