### PR TITLE
Allow using opt-level="s"/"z" in profile overrides

### DIFF
--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -121,7 +121,7 @@ impl Encodable for TargetKind {
 
 #[derive(RustcEncodable, RustcDecodable, Clone, PartialEq, Eq, Debug, Hash)]
 pub struct Profile {
-    pub opt_level: u32,
+    pub opt_level: String,
     pub lto: bool,
     pub codegen_units: Option<u32>,    // None = use rustc default
     pub rustc_args: Option<Vec<String>>,
@@ -473,7 +473,7 @@ impl Profile {
 
     pub fn default_release() -> Profile {
         Profile {
-            opt_level: 3,
+            opt_level: "3".to_string(),
             debuginfo: false,
             ..Profile::default()
         }
@@ -511,7 +511,7 @@ impl Profile {
 impl Default for Profile {
     fn default() -> Profile {
         Profile {
-            opt_level: 0,
+            opt_level: "0".to_string(),
             lto: false,
             codegen_units: None,
             rustc_args: None,

--- a/src/cargo/ops/cargo_rustc/custom_build.rs
+++ b/src/cargo/ops/cargo_rustc/custom_build.rs
@@ -111,7 +111,7 @@ fn build_work<'a, 'cfg>(cx: &mut Context<'a, 'cfg>, unit: &Unit<'a>)
          Kind::Target => cx.target_triple(),
      })
      .env("DEBUG", &profile.debuginfo.to_string())
-     .env("OPT_LEVEL", &profile.opt_level.to_string())
+     .env("OPT_LEVEL", &profile.opt_level)
      .env("PROFILE", if cx.build_config.release {"release"} else {"debug"})
      .env("HOST", cx.host_triple())
      .env("RUSTC", &try!(cx.config.rustc()).path)

--- a/src/cargo/ops/cargo_rustc/job_queue.rs
+++ b/src/cargo/ops/cargo_rustc/job_queue.rs
@@ -200,8 +200,8 @@ impl<'a> JobQueue<'a> {
 
         let build_type = if self.is_release { "release" } else { "debug" };
         let profile = cx.lib_profile(cx.resolve.root());
-        let mut opt_type = String::from(if profile.opt_level > 0 { "optimized" }
-                                        else { "unoptimized" });
+        let mut opt_type = String::from(if profile.opt_level == "0" { "unoptimized" }
+                                        else { "optimized" });
         if profile.debuginfo {
             opt_type = opt_type + " + debuginfo";
         }

--- a/src/cargo/ops/cargo_rustc/mod.rs
+++ b/src/cargo/ops/cargo_rustc/mod.rs
@@ -477,7 +477,7 @@ fn build_base_args(cx: &Context,
                    unit: &Unit,
                    crate_types: &[&str]) {
     let Profile {
-        opt_level, lto, codegen_units, ref rustc_args, debuginfo,
+        ref opt_level, lto, codegen_units, ref rustc_args, debuginfo,
         debug_assertions, rpath, test, doc: _doc, run_custom_build,
         ref panic, rustdoc_args: _,
     } = *unit.profile;
@@ -509,7 +509,7 @@ fn build_base_args(cx: &Context,
         cmd.arg("-C").arg("prefer-dynamic");
     }
 
-    if opt_level != 0 {
+    if opt_level != "0" {
         cmd.arg("-C").arg(&format!("opt-level={}", opt_level));
     }
 
@@ -549,9 +549,9 @@ fn build_base_args(cx: &Context,
         cmd.args(args);
     }
 
-    if debug_assertions && opt_level > 0 {
+    if debug_assertions && opt_level != "0" {
         cmd.args(&["-C", "debug-assertions=on"]);
-    } else if !debug_assertions && opt_level == 0 {
+    } else if !debug_assertions && opt_level == "0" {
         cmd.args(&["-C", "debug-assertions=off"]);
     }
 


### PR DESCRIPTION
Initially, I've considered making a dedicated `OptLevel` enum, but this appeared to bring no practical benefit, only boilerplate, so I've used a String instead, which is also in line with the `u32` that was there before, not even checked for being in range `0...3`.