### PR TITLE
Rootless resolve

### DIFF
--- a/src/cargo/core/resolver/encode.rs
+++ b/src/cargo/core/resolver/encode.rs
@@ -140,7 +140,6 @@ impl EncodableResolve {
 
         Ok(Resolve {
             graph: g,
-            root: root,
             features: HashMap::new(),
             replacements: replacements,
             checksums: checksums,

--- a/src/cargo/ops/cargo_output_metadata.rs
+++ b/src/cargo/ops/cargo_output_metadata.rs
@@ -53,7 +53,7 @@ fn metadata_full(ws: &Workspace,
 
     Ok(ExportInfo {
         packages: packages,
-        resolve: Some(MetadataResolve(resolve)),
+        resolve: Some(MetadataResolve(resolve, try!(ws.current()).package_id().clone())),
         version: VERSION,
     })
 }
@@ -68,7 +68,7 @@ pub struct ExportInfo {
 /// Newtype wrapper to provide a custom `Encodable` implementation.
 /// The one from lockfile does not fit because it uses a non-standard
 /// format for `PackageId`s
-struct MetadataResolve(Resolve);
+struct MetadataResolve(Resolve, PackageId);
 
 impl Encodable for MetadataResolve {
     fn encode<S: Encoder>(&self, s: &mut S) -> Result<(), S::Error> {
@@ -85,8 +85,9 @@ impl Encodable for MetadataResolve {
         }
 
         let resolve = &self.0;
+        let root = &self.1;
         let encodable = EncodableResolve {
-            root: resolve.root(),
+            root: root,
             nodes: resolve.iter().map(|id| {
                 Node {
                     id: id,

--- a/src/cargo/ops/cargo_rustc/context.rs
+++ b/src/cargo/ops/cargo_rustc/context.rs
@@ -76,7 +76,6 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
             Arc::new(Box::new(ProcessEngine))
         });
         let current_package = try!(ws.current()).package_id().clone();
-        assert_eq!(&current_package, resolve.root());
         Ok(Context {
             host: host_layout,
             target: target_layout,

--- a/src/cargo/ops/cargo_rustc/job_queue.rs
+++ b/src/cargo/ops/cargo_rustc/job_queue.rs
@@ -199,7 +199,7 @@ impl<'a> JobQueue<'a> {
         }
 
         let build_type = if self.is_release { "release" } else { "debug" };
-        let profile = cx.lib_profile(cx.resolve.root());
+        let profile = cx.lib_profile(&cx.current_package);
         let mut opt_type = String::from(if profile.opt_level == "0" { "unoptimized" }
                                         else { "optimized" });
         if profile.debuginfo {

--- a/src/cargo/ops/cargo_rustc/mod.rs
+++ b/src/cargo/ops/cargo_rustc/mod.rs
@@ -81,7 +81,7 @@ pub fn compile_targets<'a, 'cfg: 'a>(ws: &Workspace<'cfg>,
         })
     }).collect::<Vec<_>>();
 
-    let root = try!(packages.get(resolve.root()));
+    let root = try!(ws.current());
     let mut cx = try!(Context::new(ws, resolve, packages, config,
                                    build_config, profiles));
 
@@ -229,7 +229,7 @@ fn rustc(cx: &mut Context, unit: &Unit) -> CargoResult<Work> {
     let do_rename = unit.target.allows_underscores() && !unit.profile.test;
     let real_name = unit.target.name().to_string();
     let crate_name = unit.target.crate_name();
-    let move_outputs_up = unit.pkg.package_id() == cx.resolve.root();
+    let move_outputs_up = unit.pkg.package_id() == &cx.current_package;
 
     let rustc_dep_info_loc = if do_rename {
         root.join(&crate_name)
@@ -504,7 +504,7 @@ fn build_base_args(cx: &Context,
     let prefer_dynamic = (unit.target.for_host() &&
                           !unit.target.is_custom_build()) ||
                          (crate_types.contains(&"dylib") &&
-                          unit.pkg.package_id() != cx.resolve.root());
+                          unit.pkg.package_id() != &cx.current_package);
     if prefer_dynamic {
         cmd.arg("-C").arg("prefer-dynamic");
     }

--- a/src/cargo/ops/resolve.rs
+++ b/src/cargo/ops/resolve.rs
@@ -148,10 +148,7 @@ pub fn resolve_with_previous<'a>(registry: &mut PackageRegistry,
         None => root_replace.to_vec(),
     };
 
-    let mut resolved = try!(resolver::resolve(try!(ws.current()).package_id(),
-                                              &summaries,
-                                              &replace,
-                                              registry));
+    let mut resolved = try!(resolver::resolve(&summaries, &replace, registry));
     if let Some(previous) = previous {
         try!(resolved.merge_from(previous));
     }

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -1887,7 +1887,7 @@ fn cyclic_deps_rejected() {
     assert_that(p.cargo_process("build").arg("-v"),
                 execs().with_status(101)
                        .with_stderr("\
-[ERROR] cyclic package dependency: package `foo v0.0.1 ([..])` depends on itself
+[ERROR] cyclic package dependency: package `a v0.0.1 ([..])` depends on itself
 "));
 }
 

--- a/tests/resolve.rs
+++ b/tests/resolve.rs
@@ -18,8 +18,7 @@ fn resolve<R: Registry>(pkg: PackageId, deps: Vec<Dependency>,
                         -> CargoResult<Vec<PackageId>> {
     let summary = Summary::new(pkg.clone(), deps, HashMap::new()).unwrap();
     let method = Method::Everything;
-    Ok(try!(resolver::resolve(&pkg,
-                              &[(summary, method)],
+    Ok(try!(resolver::resolve(&[(summary, method)],
                               &[],
                               registry)).iter().map(|p| {
         p.clone()


### PR DESCRIPTION
This should help to make more commands applicable to the whole workspace. Though there is apparently a ton of work to make `cargo metadata` work with workspaces.

This does not support rootless lockfiles. Will do this in a separate PR. 