### PR TITLE
docs(manifest): Update crate-types with `cdylib`

### DIFF
--- a/src/doc/manifest.md
+++ b/src/doc/manifest.md
@@ -527,9 +527,13 @@ name = "..."
 crate-type = ["dylib"] # could be `staticlib` as well
 ```
 
-The available options are `dylib`, `rlib`, and `staticlib`. You should only use
-this option in a project. Cargo will always compile packages (dependencies)
-based on the requirements of the project that includes them.
+The available options are `dylib`, `rlib`, `staticlib`, and, as of Rust 1.11, 
+`cdylib`. You should only use this option in a project. Cargo will always 
+compile packages (dependencies) based on the requirements of the project that
+includes them.
+
+You can read more about the different crate types in the 
+[Rust Reference Manual](https://doc.rust-lang.org/reference.html#linkage)
 
 # The `[replace]` Section
 

--- a/src/doc/manifest.md
+++ b/src/doc/manifest.md
@@ -527,10 +527,9 @@ name = "..."
 crate-type = ["dylib"] # could be `staticlib` as well
 ```
 
-The available options are `dylib`, `rlib`, `staticlib`, and, as of Rust 1.11, 
-`cdylib`. You should only use this option in a project. Cargo will always 
-compile packages (dependencies) based on the requirements of the project that
-includes them.
+The available options are `dylib`, `rlib`, `staticlib`, and `cdylib`. You
+should only use this option in a project. Cargo will always compile packages
+(dependencies) based on the requirements of the project that includes them.
 
 You can read more about the different crate types in the 
 [Rust Reference Manual](https://doc.rust-lang.org/reference.html#linkage)


### PR DESCRIPTION
Rust 1.11 now supports the `cdylib` crate-type, so added it to the list of options.

Also added a link to the [Linkage](https://doc.rust-lang.org/reference.html#linkage) section in the Rust Reference manual which explains what the different crate types actually mean in practice....though right now it actually doesn't explain what a `cdylib` is, specifically. ;)