### PR TITLE
Fix transitive doctests panic=abort

### DIFF
--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -308,17 +308,22 @@ fn generate_targets<'a>(pkg: &'a Package,
                     }).collect::<Vec<_>>())
                 }
                 CompileMode::Test => {
+                    let deps = if release {
+                        &profiles.bench_deps
+                    } else {
+                        &profiles.test_deps
+                    };
                     let mut base = pkg.targets().iter().filter(|t| {
                         t.tested()
                     }).map(|t| {
-                        (t, if t.is_example() {build} else {profile})
+                        (t, if t.is_example() {deps} else {profile})
                     }).collect::<Vec<_>>();
 
                     // Always compile the library if we're testing everything as
                     // it'll be needed for doctests
                     if let Some(t) = pkg.targets().iter().find(|t| t.is_lib()) {
                         if t.doctested() {
-                            base.push((t, build));
+                            base.push((t, deps));
                         }
                     }
                     Ok(base)

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -2232,3 +2232,33 @@ fn cfg_test_even_with_no_harness() {
 [RUNNING] `[..]`
 "));
 }
+
+#[test]
+fn panic_abort_multiple() {
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [package]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+
+            [dependencies]
+            a = { path = "a" }
+
+            [profile.release]
+            panic = 'abort'
+        "#)
+        .file("src/lib.rs", "extern crate a;")
+        .file("a/Cargo.toml", r#"
+            [package]
+            name = "a"
+            version = "0.0.1"
+            authors = []
+        "#)
+        .file("a/src/lib.rs", "");
+    assert_that(p.cargo_process("test")
+                 .arg("--release").arg("-v")
+                 .arg("-p").arg("foo")
+                 .arg("-p").arg("a"),
+                execs().with_status(0));
+}


### PR DESCRIPTION
Ensure that when we compile doctested libraries or examples we use the same
panic mode as the rest of the tests, namely ignoring panic=abort b/c libtest
isn't compiled with panic=abort.

Closes #3017