### PR TITLE
Be forward compat with rootless lock files

### DIFF
--- a/tests/bad-config.rs
+++ b/tests/bad-config.rs
@@ -224,7 +224,7 @@ fn bad_cargo_lock() {
         version = "0.0.0"
         authors = []
     "#)
-    .file("Cargo.lock", "")
+    .file("Cargo.lock", "[[package]]\nfoo = 92")
     .file("src/lib.rs", "");
 
     assert_that(foo.cargo_process("build").arg("-v"),
@@ -232,7 +232,7 @@ fn bad_cargo_lock() {
 [ERROR] failed to parse lock file at: [..]Cargo.lock
 
 Caused by:
-  expected a section for the key `root`
+  expected a value of type `string` for the key `package.name`
 "));
 }
 


### PR DESCRIPTION
Hi! So what is the plan regarding the `[root]` key in the lock file? 

With workspaces it is meaningless, but not immediately harmful.

I think it should be possible to remove it eventually if we teach `Cargo` to read rootless lockfiles now and switch to them several cycles later. Reading lockfiles with `[root]` should be supported forever of course.

This PR adds ability to read rootless lockfiles, but they are then replaced by the current format in `write_pkg_lockfile`. Should be easy to fix if we do want to evolve lockfile format. 