### PR TITLE
doc: fix platform-specific definitions section

### DIFF
--- a/src/doc/specifying-dependencies.md
+++ b/src/doc/specifying-dependencies.md
@@ -307,10 +307,10 @@ winhttp = "0.4.0"
 [target.'cfg(unix)'.dependencies]
 openssl = "1.0.1"
 
-[target.'cfg(target_pointer_width = "32")'.dependencies]
+[target.'cfg(target_arch = "x86)'.dependencies]
 native = { path = "native/i686" }
 
-[target.'cfg(target_pointer_width = "64")'.dependencies]
+[target.'cfg(target_arch = "x86_64")'.dependencies]
 native = { path = "native/x86_64" }
 ```
 


### PR DESCRIPTION
Right now the section seems to imply that using cfg(target_pointer_width = "32")
is an acceptable way to detect whether the crate should be built for x86.