### PR TITLE
Don't special case root package for overrides

### DIFF
--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -388,17 +388,12 @@ fn add_overrides<'a>(registry: &mut PackageRegistry<'a>,
         Some(list) => list,
         None => return Ok(())
     };
-    let current = try!(ws.current());
 
     let paths = paths.val.iter().map(|&(ref s, ref p)| {
         // The path listed next to the string is the config file in which the
         // key was located, so we want to pop off the `.cargo/config` component
         // to get the directory containing the `.cargo` folder.
         (p.parent().unwrap().parent().unwrap().join(s), p)
-    }).filter(|&(ref p, _)| {
-        // Make sure we don't override the local package, even if it's in the
-        // list of override paths.
-        current.root() != &**p
     });
 
     for (path, definition) in paths {


### PR DESCRIPTION
Hi! What is the expected behavior of path overrides and workspaces? There are some [tests] for this, but looks like they don't actually test the behavior: this commit removes special casing of the root package, but `override_self` still passes. I see two options:

1. Allow overriding of the workspace members as usual. This amounts to removing that `filter`

2. Ignore overriding of the workspace members.

In any case, I think it would be nice to add a test which overrides local package to some other package to make sure that test does not pass simply because the package and its override are in fact the same. 

[tests]: https://github.com/rust-lang/cargo/blob/master/tests/path.rs#L599-L679