### PR TITLE
Add --all-features flag to cargo

### DIFF
--- a/src/bin/bench.rs
+++ b/src/bin/bench.rs
@@ -9,6 +9,7 @@ pub struct Options {
     flag_package: Vec<String>,
     flag_jobs: Option<u32>,
     flag_features: Vec<String>,
+    flag_all_features: bool,
     flag_no_default_features: bool,
     flag_target: Option<String>,
     flag_manifest_path: Option<String>,
@@ -42,6 +43,7 @@ Options:
     -p SPEC, --package SPEC ...  Package to run benchmarks for
     -j N, --jobs N               Number of parallel jobs, defaults to # of CPUs
     --features FEATURES          Space-separated list of features to also build
+    --all-features               Build all available features
     --no-default-features        Do not build the `default` feature
     --target TRIPLE              Build for the target triple
     --manifest-path PATH         Path to the manifest to build benchmarks for
@@ -83,6 +85,7 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
             jobs: options.flag_jobs,
             target: options.flag_target.as_ref().map(|s| &s[..]),
             features: &options.flag_features,
+            all_features: options.flag_all_features,
             no_default_features: options.flag_no_default_features,
             spec: &options.flag_package,
             exec_engine: None,

--- a/src/bin/build.rs
+++ b/src/bin/build.rs
@@ -11,6 +11,7 @@ pub struct Options {
     flag_package: Vec<String>,
     flag_jobs: Option<u32>,
     flag_features: Vec<String>,
+    flag_all_features: bool,
     flag_no_default_features: bool,
     flag_target: Option<String>,
     flag_manifest_path: Option<String>,
@@ -44,6 +45,7 @@ Options:
     --bench NAME                 Build only the specified benchmark target
     --release                    Build artifacts in release mode, with optimizations
     --features FEATURES          Space-separated list of features to also build
+    --all-features               Build all available features
     --no-default-features        Do not build the `default` feature
     --target TRIPLE              Build for the target triple
     --manifest-path PATH         Path to the manifest to compile
@@ -79,6 +81,7 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
         jobs: options.flag_jobs,
         target: options.flag_target.as_ref().map(|t| &t[..]),
         features: &options.flag_features,
+        all_features: options.flag_all_features,
         no_default_features: options.flag_no_default_features,
         spec: &options.flag_package,
         exec_engine: None,

--- a/src/bin/doc.rs
+++ b/src/bin/doc.rs
@@ -7,6 +7,7 @@ use cargo::util::important_paths::{find_root_manifest_for_wd};
 pub struct Options {
     flag_target: Option<String>,
     flag_features: Vec<String>,
+    flag_all_features: bool,
     flag_jobs: Option<u32>,
     flag_manifest_path: Option<String>,
     flag_no_default_features: bool,
@@ -39,6 +40,7 @@ Options:
     --bin NAME                   Document only the specified binary
     --release                    Build artifacts in release mode, with optimizations
     --features FEATURES          Space-separated list of features to also build
+    --all-features               Build all available features
     --no-default-features        Do not build the `default` feature
     --target TRIPLE              Build for the target triple
     --manifest-path PATH         Path to the manifest to document
@@ -74,6 +76,7 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
             jobs: options.flag_jobs,
             target: options.flag_target.as_ref().map(|t| &t[..]),
             features: &options.flag_features,
+            all_features: options.flag_all_features,
             no_default_features: options.flag_no_default_features,
             spec: &options.flag_package,
             exec_engine: None,

--- a/src/bin/install.rs
+++ b/src/bin/install.rs
@@ -6,6 +6,7 @@ use cargo::util::{CliResult, Config, ToUrl};
 pub struct Options {
     flag_jobs: Option<u32>,
     flag_features: Vec<String>,
+    flag_all_features: bool,
     flag_no_default_features: bool,
     flag_debug: bool,
     flag_bin: Vec<String>,
@@ -48,8 +49,9 @@ Specifying what crate to install:
 Build and install options:
     -h, --help                Print this message
     -j N, --jobs N            Number of parallel jobs, defaults to # of CPUs
-    --features FEATURES       Space-separated list of features to activate
     -f, --force               Force overwriting existing crates or binaries
+    --features FEATURES       Space-separated list of features to activate
+    --all-features            Build all available features
     --no-default-features     Do not build the `default` feature
     --debug                   Build in debug mode instead of release mode
     --bin NAME                Only install the binary NAME
@@ -104,6 +106,7 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
         jobs: options.flag_jobs,
         target: None,
         features: &options.flag_features,
+        all_features: options.flag_all_features,
         no_default_features: options.flag_no_default_features,
         spec: &[],
         exec_engine: None,

--- a/src/bin/metadata.rs
+++ b/src/bin/metadata.rs
@@ -7,6 +7,7 @@ use cargo::util::{CliResult, Config};
 pub struct Options {
     flag_color: Option<String>,
     flag_features: Vec<String>,
+    flag_all_features: bool,
     flag_format_version: u32,
     flag_manifest_path: Option<String>,
     flag_no_default_features: bool,
@@ -27,6 +28,7 @@ Usage:
 Options:
     -h, --help                 Print this message
     --features FEATURES        Space-separated list of features
+    --all-features             Build all available features
     --no-default-features      Do not include the `default` feature
     --no-deps                  Output information only about the root package
                                and don't fetch dependencies.
@@ -50,6 +52,7 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<ExportInfo
 
     let options = OutputMetadataOptions {
         features: options.flag_features,
+        all_features: options.flag_all_features,
         no_default_features: options.flag_no_default_features,
         no_deps: options.flag_no_deps,
         version: options.flag_format_version,

--- a/src/bin/run.rs
+++ b/src/bin/run.rs
@@ -9,6 +9,7 @@ pub struct Options {
     flag_example: Option<String>,
     flag_jobs: Option<u32>,
     flag_features: Vec<String>,
+    flag_all_features: bool,
     flag_no_default_features: bool,
     flag_target: Option<String>,
     flag_manifest_path: Option<String>,
@@ -34,6 +35,7 @@ Options:
     -j N, --jobs N          Number of parallel jobs, defaults to # of CPUs
     --release               Build artifacts in release mode, with optimizations
     --features FEATURES     Space-separated list of features to also build
+    --all-features          Build all available features
     --no-default-features   Do not build the `default` feature
     --target TRIPLE         Build for the target triple
     --manifest-path PATH    Path to the manifest to execute
@@ -75,6 +77,7 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
         jobs: options.flag_jobs,
         target: options.flag_target.as_ref().map(|t| &t[..]),
         features: &options.flag_features,
+        all_features: options.flag_all_features,
         no_default_features: options.flag_no_default_features,
         spec: &[],
         exec_engine: None,

--- a/src/bin/rustc.rs
+++ b/src/bin/rustc.rs
@@ -12,6 +12,7 @@ pub struct Options {
     flag_package: Option<String>,
     flag_jobs: Option<u32>,
     flag_features: Vec<String>,
+    flag_all_features: bool,
     flag_no_default_features: bool,
     flag_target: Option<String>,
     flag_manifest_path: Option<String>,
@@ -47,6 +48,7 @@ Options:
     --release                Build artifacts in release mode, with optimizations
     --profile PROFILE        Profile to build the selected target for
     --features FEATURES      Features to compile for the package
+    --all-features           Build all available features
     --no-default-features    Do not compile default features for the package
     --target TRIPLE          Target triple which compiles will be for
     --manifest-path PATH     Path to the manifest to fetch dependencies for
@@ -97,6 +99,7 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
         jobs: options.flag_jobs,
         target: options.flag_target.as_ref().map(|t| &t[..]),
         features: &options.flag_features,
+        all_features: options.flag_all_features,
         no_default_features: options.flag_no_default_features,
         spec: &options.flag_package.map_or(Vec::new(), |s| vec![s]),
         exec_engine: None,

--- a/src/bin/rustdoc.rs
+++ b/src/bin/rustdoc.rs
@@ -8,6 +8,7 @@ pub struct Options {
     arg_opts: Vec<String>,
     flag_target: Option<String>,
     flag_features: Vec<String>,
+    flag_all_features: bool,
     flag_jobs: Option<u32>,
     flag_manifest_path: Option<String>,
     flag_no_default_features: bool,
@@ -44,6 +45,7 @@ Options:
     --bench NAME             Build only the specified benchmark target
     --release                Build artifacts in release mode, with optimizations
     --features FEATURES      Space-separated list of features to also build
+    --all-features           Build all available features
     --no-default-features    Do not build the `default` feature
     --target TRIPLE          Build for the target triple
     --manifest-path PATH     Path to the manifest to document
@@ -83,6 +85,7 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
             jobs: options.flag_jobs,
             target: options.flag_target.as_ref().map(|t| &t[..]),
             features: &options.flag_features,
+            all_features: options.flag_all_features,
             no_default_features: options.flag_no_default_features,
             spec: &options.flag_package.map_or(Vec::new(), |s| vec![s]),
             exec_engine: None,

--- a/src/bin/test.rs
+++ b/src/bin/test.rs
@@ -7,6 +7,7 @@ use cargo::util::important_paths::{find_root_manifest_for_wd};
 pub struct Options {
     arg_args: Vec<String>,
     flag_features: Vec<String>,
+    flag_all_features: bool,
     flag_jobs: Option<u32>,
     flag_manifest_path: Option<String>,
     flag_no_default_features: bool,
@@ -47,6 +48,7 @@ Options:
     -j N, --jobs N               Number of parallel jobs, defaults to # of CPUs
     --release                    Build artifacts in release mode, with optimizations
     --features FEATURES          Space-separated list of features to also build
+    --all-features               Build all available features
     --no-default-features        Do not build the `default` feature
     --target TRIPLE              Build for the target triple
     --manifest-path PATH         Path to the manifest to build tests for
@@ -115,6 +117,7 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
             jobs: options.flag_jobs,
             target: options.flag_target.as_ref().map(|s| &s[..]),
             features: &options.flag_features,
+            all_features: options.flag_all_features,
             no_default_features: options.flag_no_default_features,
             spec: &options.flag_package,
             exec_engine: None,

--- a/src/cargo/core/package.rs
+++ b/src/cargo/core/package.rs
@@ -78,7 +78,7 @@ impl Package {
     pub fn package_id(&self) -> &PackageId { self.manifest.package_id() }
     pub fn root(&self) -> &Path { self.manifest_path.parent().unwrap() }
     pub fn summary(&self) -> &Summary { self.manifest.summary() }
-    pub fn targets(&self) -> &[Target] { self.manifest().targets() }
+    pub fn targets(&self) -> &[Target] { self.manifest.targets() }
     pub fn version(&self) -> &Version { self.package_id().version() }
     pub fn authors(&self) -> &Vec<String> { &self.manifest.metadata().authors }
     pub fn publish(&self) -> bool { self.manifest.publish() }

--- a/src/cargo/ops/cargo_output_metadata.rs
+++ b/src/cargo/ops/cargo_output_metadata.rs
@@ -10,6 +10,7 @@ const VERSION: u32 = 1;
 pub struct OutputMetadataOptions {
     pub features: Vec<String>,
     pub no_default_features: bool,
+    pub all_features: bool,
     pub no_deps: bool,
     pub version: u32,
 }
@@ -45,6 +46,7 @@ fn metadata_full(ws: &Workspace,
     let deps = try!(ops::resolve_dependencies(ws,
                                               None,
                                               opt.features.clone(),
+                                              opt.all_features,
                                               opt.no_default_features));
     let (packages, resolve) = deps;
 

--- a/src/cargo/ops/cargo_package.rs
+++ b/src/cargo/ops/cargo_package.rs
@@ -275,6 +275,7 @@ fn run_verify(ws: &Workspace, tar: &File, opts: &PackageOpts) -> CargoResult<()>
         target: None,
         features: &[],
         no_default_features: false,
+        all_features: false,
         spec: &[],
         filter: ops::CompileFilter::Everything,
         exec_engine: None,

--- a/src/etc/_cargo
+++ b/src/etc/_cargo
@@ -20,6 +20,7 @@ case $state in
             bench)
                 _arguments \
                     '--features=[space separated feature list]' \
+                    '--all-features[enable all available features]' \
                     '(-h, --help)'{-h,--help}'[show help message]' \
                     '(-j, --jobs)'{-j,--jobs}'[number of parallel jobs, defaults to # of CPUs]' \
                     "${command_scope_spec[@]}" \
@@ -36,6 +37,7 @@ case $state in
             build)
                 _arguments \
                     '--features=[space separated feature list]' \
+                    '--all-features[enable all available features]' \
                     '(-h, --help)'{-h,--help}'[show help message]' \
                     '(-j, --jobs)'{-j,--jobs}'[number of parallel jobs, defaults to # of CPUs]' \
                     "${command_scope_spec[@]}" \
@@ -64,6 +66,7 @@ case $state in
             doc)
                 _arguments \
                     '--features=[space separated feature list]' \
+                    '--all-features[enable all available features]' \
                     '(-h, --help)'{-h,--help}'[show help message]' \
                     '(-j, --jobs)'{-j,--jobs}'[number of parallel jobs, defaults to # of CPUs]' \
                     '--manifest-path=[path to manifest]: :_files -/' \
@@ -131,6 +134,7 @@ case $state in
                     '--debug[build in debug mode instead of release mode]' \
                     '--example[install the specified example instead of binaries]' \
                     '--features=[space separated feature list]' \
+                    '--all-features[enable all available features]' \
                     '--git=[URL from which to install the crate]' \
                     '(-h, --help)'{-h,--help}'[show help message]' \
                     '(-j, --jobs)'{-j,--jobs}'[number of parallel jobs, defaults to # of CPUs]' \
@@ -168,6 +172,7 @@ case $state in
                     '--no-default-features[do not include the default feature]' \
                     '--manifest-path=[path to manifest]: :_files -/' \
                     '--features=[space separated feature list]' \
+                    '--all-features[enable all available features]' \
                     '--format-version=[format version(default: 1)]' \
                     '--color=:colorization option:(auto always never)' \
                     ;;
@@ -241,6 +246,7 @@ case $state in
                 _arguments \
                     '--example=[name of the bin target]' \
                     '--features=[space separated feature list]' \
+                    '--all-features[enable all available features]' \
                     '(-h, --help)'{-h,--help}'[show help message]' \
                     '(-j, --jobs)'{-j,--jobs}'[number of parallel jobs, defaults to # of CPUs]' \
                     '--manifest-path=[path to manifest]: :_files -/' \
@@ -258,6 +264,7 @@ case $state in
                 _arguments \
                     '--color=:colorization option:(auto always never)' \
                     '--features=[features to compile for the package]' \
+                    '--all-features[enable all available features]' \
                     '(-h, --help)'{-h,--help}'[show help message]' \
                     '(-j, --jobs)'{-j,--jobs}'=[number of parallel jobs, defaults to # of CPUs]' \
                     '--manifest-path=[path to the manifest to fetch dependencies for]' \
@@ -275,6 +282,7 @@ case $state in
                 _arguments \
                     '--color=:colorization option:(auto always never)' \
                     '--features=[space-separated list of features to also build]' \
+                    '--all-features[enable all available features]' \
                     '(-h, --help)'{-h,--help}'[show help message]' \
                     '(-j, --jobs)'{-j,--jobs}'=[number of parallel jobs, defaults to # of CPUs]' \
                     '--manifest-path=[path to the manifest to document]' \
@@ -301,6 +309,7 @@ case $state in
             test)
                 _arguments \
                     '--features=[space separated feature list]' \
+                    '--all-features[enable all available features]' \
                     '(-h, --help)'{-h,--help}'[show help message]' \
                     '(-j, --jobs)'{-j,--jobs}'[number of parallel jobs, defaults to # of CPUs]' \
                     '--manifest-path=[path to manifest]: :_files -/' \

--- a/src/etc/cargo.bashcomp.sh
+++ b/src/etc/cargo.bashcomp.sh
@@ -17,7 +17,7 @@ _cargo()
 	local opt_color='--color'
 	local opt_common="$opt_help $opt_verbose $opt_quiet $opt_color"
 	local opt_pkg='-p --package'
-	local opt_feat='--features --no-default-features'
+	local opt_feat='--features --all-features --no-default-features'
 	local opt_mani='--manifest-path'
 	local opt_jobs='-j --jobs'
 

--- a/src/etc/man/cargo-bench.1
+++ b/src/etc/man/cargo-bench.1
@@ -83,6 +83,11 @@ Space\-separated list of features to also build.
 .RS
 .RE
 .TP
+.B \-\-all\-features
+Build all available features.
+.RS
+.RE
+.TP
 .B \-\-no\-default\-features
 Do not build the \f[C]default\f[] feature.
 .RS

--- a/src/etc/man/cargo-build.1
+++ b/src/etc/man/cargo-build.1
@@ -67,6 +67,11 @@ Build artifacts in release mode, with optimizations.
 .RS
 .RE
 .TP
+.B \-\-all\-features
+Build all available features.
+.RS
+.RE
+.TP
 .B \-\-features \f[I]FEATURES\f[]
 Space\-separated list of features to also build.
 .RS

--- a/src/etc/man/cargo-doc.1
+++ b/src/etc/man/cargo-doc.1
@@ -57,6 +57,11 @@ Space\-separated list of features to also build.
 .RS
 .RE
 .TP
+.B \-\-all\-features
+Build all available features.
+.RS
+.RE
+.TP
 .B \-\-no\-default\-features
 Do not build the \f[C]default\f[] feature.
 .RS

--- a/src/etc/man/cargo-install.1
+++ b/src/etc/man/cargo-install.1
@@ -98,6 +98,11 @@ Space\-separated list of features to activate.
 .RS
 .RE
 .TP
+.B \-\-all\-features
+Build all available features.
+.RS
+.RE
+.TP
 .B \-f, \-\-force
 Force overwriting existing crates or binaries
 .RS

--- a/src/etc/man/cargo-metadata.1
+++ b/src/etc/man/cargo-metadata.1
@@ -22,6 +22,11 @@ Space-separated list of features.
 .RS
 .RE
 .TP
+.B \-\-all\-features
+Build all available features.
+.RS
+.RE
+.TP
 .B \-\-no\-default\-features
 Do not include the \f[C]default\f[] feature.
 .RS

--- a/src/etc/man/cargo-run.1
+++ b/src/etc/man/cargo-run.1
@@ -51,6 +51,11 @@ Space\-separated list of features to also build.
 .RS
 .RE
 .TP
+.B \-\-all\-features
+Build all available features.
+.RS
+.RE
+.TP
 .B \-\-no\-default\-features
 Do not build the \f[C]default\f[] feature.
 .RS

--- a/src/etc/man/cargo-rustc.1
+++ b/src/etc/man/cargo-rustc.1
@@ -83,6 +83,11 @@ The version to yank or un\-yank.
 .RS
 .RE
 .TP
+.B \-\-all\-features
+Build all available features.
+.RS
+.RE
+.TP
 .B \-\-no\-default\-features
 Do not compile default features for the package.
 .RS

--- a/src/etc/man/cargo-rustdoc.1
+++ b/src/etc/man/cargo-rustdoc.1
@@ -81,6 +81,11 @@ Space-separated list of features to also build.
 .RS
 .RE
 .TP
+.B \-\-all\-features
+Build all available features.
+.RS
+.RE
+.TP
 .B \-\-no\-default\-features
 Do not build the \f[C]default\f[] feature.
 .RS

--- a/src/etc/man/cargo-test.1
+++ b/src/etc/man/cargo-test.1
@@ -107,6 +107,11 @@ Space\-separated list of features to also build.
 .RS
 .RE
 .TP
+.B \-\-all\-features
+Build all available features.
+.RS
+.RE
+.TP
 .B \-\-no\-default\-features
 Do not build the \f[C]default\f[] feature.
 .RS


### PR DESCRIPTION
As (more or less) requested in #1173 I added a `--all-features` flag to cargo that builds all available features.

I hope I documented it in all the right places.

If there's something weird or wrong, please give me a heads up.