### PR TITLE
Simplify lockfile tests

### DIFF
--- a/tests/cargotest/support/mod.rs
+++ b/tests/cargotest/support/mod.rs
@@ -181,6 +181,13 @@ impl ProjectBuilder {
         self
     }
 
+    pub fn read_lockfile(&self) -> String {
+        let mut buffer = String::new();
+        fs::File::open(self.root().join("Cargo.lock")).unwrap()
+            .read_to_string(&mut buffer).unwrap();
+        buffer
+    }
+
     fn rm_root(&self) {
         self.root.rm_rf()
     }


### PR DESCRIPTION
Use project builder to create a file and an extension function to read it.  