### PR TITLE
Fix POSIX shell in configure script (support Illumos & Solaris)

### DIFF
--- a/configure
+++ b/configure
@@ -1,5 +1,13 @@
 #!/bin/sh
 
+# /bin/sh on Solaris is not a POSIX compatible shell, but /usr/bin/bash is.
+if [ `uname -s` = 'SunOS' -a "${POSIX_SHELL}" != "true" ]; then
+    POSIX_SHELL="true"
+    export POSIX_SHELL
+    exec /usr/bin/env bash $0 "$@"
+fi
+unset POSIX_SHELL # clear it so if we invoke other scripts, they run as bash as well
+
 msg() {
     echo "configure: $1"
 }


### PR DESCRIPTION
This patch provides the same fix that is applied for the `configure` script in rustc:
https://github.com/rust-lang/rust/blob/master/configure#L3-L9. It is required because `#!/bin/sh` is not Bash/POSIX-compatible on Solaris and its derivatives by default.

This change was previously discussed there: https://github.com/rust-lang/rust/pull/28589.