### PR TITLE
Clarify wording: this restriction is not just libraries

### DIFF
--- a/src/doc/faq.md
+++ b/src/doc/faq.md
@@ -130,10 +130,10 @@ picture to decide what versions of dependencies should be used.
 
 # Can libraries use `*` as a version for their dependencies?
 
-**Starting January 22nd, 2016, [crates.io] will begin rejecting packages with
-wildcard dependency constraints.**
+**As of January 22nd, 2016, [crates.io] rejects all packages (not just libraries)
+with wildcard dependency constraints.**
 
-While they _can_, strictly speaking, they should not. A version requirement
+While libraries _can_, strictly speaking, they should not. A version requirement
 of `*` says “This will work with every version ever,” which is never going
 to be true. Libraries should always specify the range that they do work with,
 even if it’s something as general as “every 1.x.y version.”


### PR DESCRIPTION
I found the previous wording a little confusing (see [discussion on users.rust-lang.org](https://users.rust-lang.org/t/uploading-binary-packages-not-libraries-to-crates-io/7072)).

Since the section heading specifically refers to libraries, I was puzzled that crates.io rejected my binary package with wildcard dependencies (plus a Cargo.lock file). I think this wording is clearer, let me know what you think.

Ideally we'd also say the reasoning behind rejecting wildcard dependencies for binary crates, but I don't know what the reasoning is.