### PR TITLE
Generalize error message used by both `cargo package` and `cargo publish`.

### DIFF
--- a/src/cargo/ops/cargo_package.rs
+++ b/src/cargo/ops/cargo_package.rs
@@ -173,8 +173,7 @@ fn check_not_dirty(p: &Package, src: &PathSource) -> CargoResult<()> {
             Ok(())
         } else {
             bail!("{} dirty files found in the working directory:\n\n{}\n\n\
-                   to publish despite this, pass `--allow-dirty` to \
-                   `cargo publish`",
+                   to proceed despite this, pass the `--allow-dirty` flag",
                   dirty.len(), dirty.join("\n"))
         }
     }

--- a/tests/publish.rs
+++ b/tests/publish.rs
@@ -207,7 +207,7 @@ error: 1 dirty files found in the working directory:
 
 bar
 
-to publish despite this, pass `--allow-dirty` to `cargo publish`
+to proceed despite this, pass the `--allow-dirty` flag
 "));
 }
 


### PR DESCRIPTION
Resolves issue #3061.

This pull request updates the wording of the error message in question to be applicable to both `cargo package` and `cargo publish`, and adds a test case for the example in the issue description.
