### PR TITLE
Fix: Don't parse the home directory more than once

### DIFF
--- a/src/cargo/util/config.rs
+++ b/src/cargo/util/config.rs
@@ -22,30 +22,6 @@ use util::toml as cargo_toml;
 
 use self::ConfigValue as CV;
 
-#[derive(PartialEq, Eq, Hash)]
-struct ConfigFile {
-    path: Option<PathBuf>,
-}
-
-impl ConfigFile {
-    pub fn new(path: PathBuf) -> ConfigFile {
-        let canonical = match fs::canonicalize(path) {
-            Ok(p) => Some(p),
-            Err(_) => None,
-        };
-
-        ConfigFile { path: canonical }
-    }
-
-    pub fn exist(&self) -> bool {
-        self.path.is_some()
-    }
-
-    pub fn as_path_buf(&self) -> Option<PathBuf> {
-        self.path.clone()
-    }
-}
-
 pub struct Config {
     home_path: Filesystem,
     shell: RefCell<MultiShell>,
@@ -700,15 +676,14 @@ fn walk_tree<F>(pwd: &Path, mut walk: F) -> CargoResult<()>
     where F: FnMut(File, &Path) -> CargoResult<()>
 {
     let mut current = pwd;
-    let mut stash: HashSet<ConfigFile> = HashSet::new();
+    let mut stash: HashSet<PathBuf> = HashSet::new();
 
     loop {
-        let possible = ConfigFile::new(current.join(".cargo").join("config"));
-        if possible.exist() && stash.get(&possible).is_none() {
-            let name = possible.as_path_buf().unwrap();
-            let file = try!(File::open(&name));
+        let possible = current.join(".cargo").join("config");
+        if fs::metadata(&possible).is_ok() {
+            let file = try!(File::open(&possible));
 
-            try!(walk(file, &name));
+            try!(walk(file, &possible));
 
             stash.insert(possible);
         }
@@ -726,11 +701,10 @@ fn walk_tree<F>(pwd: &Path, mut walk: F) -> CargoResult<()>
         human("Cargo couldn't find your home directory. \
               This probably means that $HOME was not set.")
     }));
-    let config = ConfigFile::new(home.join("config"));
-    if config.exist() && stash.get(&config).is_none() {
-        let name = config.as_path_buf().unwrap();
-        let file = try!(File::open(&name));
-        try!(walk(file, &name));
+    let config = home.join("config");
+    if !stash.contains(&config) && fs::metadata(&config).is_ok() {
+        let file = try!(File::open(&config));
+        try!(walk(file, &config));
     }
 
     Ok(())

--- a/tests/cargotest/support/mod.rs
+++ b/tests/cargotest/support/mod.rs
@@ -198,6 +198,11 @@ pub fn project(name: &str) -> ProjectBuilder {
     ProjectBuilder::new(name, paths::root().join(name))
 }
 
+// Generates a project layout inside our fake home dir
+pub fn project_in_home(name: &str) -> ProjectBuilder {
+    ProjectBuilder::new(name, paths::home().join(name))
+}
+
 // === Helpers ===
 
 pub fn main_file(println: &str, deps: &[&str]) -> String {


### PR DESCRIPTION
This PR tries to resolve this issue https://github.com/rust-lang/cargo/issues/3070. The problem is that the `walk_tree` method in the `src/util/config.rs` module was parsing more than once the contents of the config file in the home directory (the file `~/.cargo/config`). The biggest problem with this is with options that can accept multiple values, like `build.rustflags`. If you parse the file twice, the same option can end with duplicated values (e.g: `rustflags=["-Z", "foo", "-Z", "foo"]`).

I made the fix following the comments in the issue. In the fix I keep track of all the parsed config files in a `HashSet` so I can know if a file has been parsed already. ~~I'm also using `std::fs::canonicalize`, as suggested in the issue, to prevent parsing files behind symbolic links more than once.~~

**UPDATE:** I removed the call to `fs::canonicalize` as suggested in the comments. Now the fix is way simpler, which means less code and less possibilities to add a new bug.