### PR TITLE
FIX: Properly close dep_feature_in_cmd_line test.

### DIFF
--- a/tests/features.rs
+++ b/tests/features.rs
@@ -960,6 +960,7 @@ fn dep_feature_in_cmd_line() {
                 execs().with_status(101).with_stderr("\
 [ERROR] feature names may not contain slashes: `bar/some-feat`
 "));
+}
 
 #[test]
 fn all_features_flag_enables_all_features() {
@@ -1003,5 +1004,4 @@ fn all_features_flag_enables_all_features() {
 
     assert_that(p.cargo_process("build").arg("--all-features"),
                 execs().with_status(0));
-}
 }


### PR DESCRIPTION
It was including the test `all_features_flag_enables_all_features` inside its function body and it was causing this warning when executing `cargo test`:

```
   Compiling cargo v0.13.0 (file:///home/jhbabon/Code/cargo)
tests/features.rs:965:1: 1006:2 warning: function is never used: `all_features_flag_enables_all_features`, #[warn(dead_code)] on by default
tests/features.rs:965 fn all_features_flag_enables_all_features() {
                      ^
tests/features.rs:964:1: 964:8 warning: unused attribute, #[warn(unused_attributes)] on by default
tests/features.rs:964 #[test]
                      ^~~~~~~
     Running target/debug/features-e37991fdf417989c
```