### PR TITLE
Make crates-io registry URL optional in config; ignore all changes to source.crates-io

### DIFF
--- a/src/cargo/sources/config.rs
+++ b/src/cargo/sources/config.rs
@@ -146,6 +146,9 @@ a lock file compatible with `{orig}` cannot be generated in this situation
             path.push(s);
             srcs.push(try!(SourceId::for_directory(&path)));
         }
+        if name == "crates-io" && srcs.is_empty() {
+            srcs.push(try!(SourceId::crates_io(self.config)));
+        }
 
         let mut srcs = srcs.into_iter();
         let src = try!(srcs.next().chain_error(|| {


### PR DESCRIPTION
Hi! When I was working on the instructions for source replacement [in this crates.io PR](https://github.com/rust-lang/crates.io/pull/440), I found that when I'm replacing `source.crates-io`, [I still have to specify some value for `registry`](https://github.com/rust-lang/crates.io/pull/440/files#diff-04c6e90faac2675aa89e2176d2eec7d8R177), or else I get this:

```
error: no source URL specified for `source.crates-io`, need either `registry` or `local-registry` defined
```

This seems weird and annoying to me: cargo definitely knows the registry URL for crates-io, and I'm trying to replace it anyway.

So the first commit in this PR makes it optional, so that you don't have to specify a registry url for crates-io: it uses `SourceId::crates_io`, like it would if we didn't have any source configs at all.

~~The second commit in this PR might go too far, and/or might break existing uses of cargo, I'm not sure. In my opinion, `source.crates-io` should only be able to be replaced and never changed directly-- crates-io should always be crates-io, and I should be able to assume that in any project. So the second commit ignores all modifications to `source.crates-io`'s `registry`, `local-registry`, and `directory`, and warns that they're being ignored.~~

~~I tried to search github to see if anyone was using these keys with `source.crates-io`, but since github's search ignores `.` (ARE YOU LISTENING GITHUB? I WOULD LIKE TO SEARCH WITH PUNCTUATION PLEASE), there's a lot of false positives to wade through. I didn't see anything in the first few pages though.~~

I'm happy to make whatever modifications to this!