### PR TITLE
Move stream_output to ProcessBuilder

### DIFF
--- a/src/cargo/ops/cargo_rustc/job_queue.rs
+++ b/src/cargo/ops/cargo_rustc/job_queue.rs
@@ -170,12 +170,12 @@ impl<'a> JobQueue<'a> {
                 }
                 Message::Stdout(out) => {
                     if cx.config.extra_verbose() {
-                        try!(write!(cx.config.shell().out(), "{}", out));
+                        try!(writeln!(cx.config.shell().out(), "{}", out));
                     }
                 }
                 Message::Stderr(err) => {
                     if cx.config.extra_verbose() {
-                        try!(write!(cx.config.shell().err(), "{}", err));
+                        try!(writeln!(cx.config.shell().err(), "{}", err));
                     }
                 }
                 Message::Finish(result) => {

--- a/tests/build-script.rs
+++ b/tests/build-script.rs
@@ -715,7 +715,7 @@ fn build_deps_not_for_normal() {
 [ERROR] Could not compile `foo`.
 
 Caused by:
-  Process didn't exit successfully: [..]
+  process didn't exit successfully: [..]
 "));
 }
 

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -1967,7 +1967,7 @@ fn rustc_env_var() {
                  .env("RUSTC", "rustc-that-does-not-exist").arg("-v"),
                 execs().with_status(101)
                        .with_stderr("\
-[ERROR] Could not execute process `rustc-that-does-not-exist -vV` ([..])
+[ERROR] could not execute process `rustc-that-does-not-exist -vV` ([..])
 
 Caused by:
 [..]

--- a/tests/run.rs
+++ b/tests/run.rs
@@ -132,7 +132,7 @@ fn exit_code() {
 [COMPILING] foo v0.0.1 (file[..])
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `target[..]`
-[ERROR] Process didn't exit successfully: `target[..]foo[..]` (exit code: 2)
+[ERROR] process didn't exit successfully: `target[..]foo[..]` (exit code: 2)
 "));
 }
 
@@ -156,7 +156,7 @@ fn exit_code_verbose() {
 [RUNNING] `rustc [..]`
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `target[..]`
-[ERROR] Process didn't exit successfully: `target[..]foo[..]` (exit code: 2)
+[ERROR] process didn't exit successfully: `target[..]foo[..]` (exit code: 2)
 "));
 }
 


### PR DESCRIPTION
Make `stream_output` method more reusable (I intend to use it in #3000). 

Unrelated question: what is that `ExecEngine` thing? Looks like it does nothing at the moment and can be removed. 