### PR TITLE
Remove duplicate option in cargo-publish man page

### DIFF
--- a/src/etc/man/cargo-publish.1
+++ b/src/etc/man/cargo-publish.1
@@ -21,11 +21,6 @@ Host to upload the package to.
 .RS
 .RE
 .TP
-.B \-\-host \f[I]HOST\f[]
-Host to upload the package to.
-.RS
-.RE
-.TP
 .B \-\-token \f[I]TOKEN\f[]
 Token to use when uploading.
 .RS


### PR DESCRIPTION
The `--host` option was listed twice; this commit removes one of the duplicates.