### PR TITLE
cargo: add license and license_file to cargo metadata output

### DIFF
--- a/src/cargo/core/package.rs
+++ b/src/cargo/core/package.rs
@@ -29,6 +29,8 @@ struct SerializedPackage<'a> {
     name: &'a str,
     version: &'a str,
     id: &'a PackageId,
+    license: Option<&'a str>,
+    license_file: Option<&'a str>,
     source: &'a SourceId,
     dependencies: &'a [Dependency],
     targets: &'a [Target],
@@ -40,11 +42,16 @@ impl Encodable for Package {
     fn encode<S: Encoder>(&self, s: &mut S) -> Result<(), S::Error> {
         let summary = self.manifest.summary();
         let package_id = summary.package_id();
+        let manmeta = self.manifest.metadata();
+        let license = manmeta.license.as_ref().map(String::as_ref);
+        let license_file = manmeta.license_file.as_ref().map(String::as_ref);
 
         SerializedPackage {
             name: &package_id.name(),
             version: &package_id.version().to_string(),
             id: package_id,
+            license: license,
+            license_file: license_file,
             source: summary.source_id(),
             dependencies: summary.dependencies(),
             targets: &self.manifest.targets(),

--- a/tests/metadata.rs
+++ b/tests/metadata.rs
@@ -19,6 +19,8 @@ fn cargo_metadata_simple() {
                 "id": "foo[..]",
                 "source": null,
                 "dependencies": [],
+                "license": null,
+                "license_file": null,
                 "targets": [
                     {
                         "kind": [
@@ -80,6 +82,8 @@ fn cargo_metadata_with_deps_and_version() {
                 "manifest_path": "[..]Cargo.toml",
                 "name": "baz",
                 "source": "registry+[..]",
+                "license": null,
+                "license_file": null,
                 "targets": [
                     {
                         "kind": [
@@ -109,6 +113,8 @@ fn cargo_metadata_with_deps_and_version() {
                 "manifest_path": "[..]Cargo.toml",
                 "name": "bar",
                 "source": "registry+[..]",
+                "license": null,
+                "license_file": null,
                 "targets": [
                     {
                         "kind": [
@@ -138,6 +144,8 @@ fn cargo_metadata_with_deps_and_version() {
                 "manifest_path": "[..]Cargo.toml",
                 "name": "foo",
                 "source": null,
+                "license": "MIT",
+                "license_file": null,
                 "targets": [
                     {
                         "kind": [
@@ -198,6 +206,8 @@ fn workspace_metadata() {
                 "id": "bar[..]",
                 "source": null,
                 "dependencies": [],
+                "license": null,
+                "license_file": null,
                 "targets": [
                     {
                         "kind": [ "lib" ],
@@ -214,6 +224,8 @@ fn workspace_metadata() {
                 "id": "baz[..]",
                 "source": null,
                 "dependencies": [],
+                "license": null,
+                "license_file": null,
                 "targets": [
                     {
                         "kind": [ "lib" ],
@@ -265,6 +277,8 @@ fn workspace_metadata_no_deps() {
                 "id": "bar[..]",
                 "source": null,
                 "dependencies": [],
+                "license": null,
+                "license_file": null,
                 "targets": [
                     {
                         "kind": [ "lib" ],
@@ -281,6 +295,8 @@ fn workspace_metadata_no_deps() {
                 "id": "baz[..]",
                 "source": null,
                 "dependencies": [],
+                "license": null,
+                "license_file": null,
                 "targets": [
                     {
                         "kind": [ "lib" ],
@@ -320,6 +336,8 @@ const MANIFEST_OUTPUT: &'static str=
         "id":"foo[..]0.5.0[..](path+file://[..]/foo)",
         "source":null,
         "dependencies":[],
+        "license": null,
+        "license_file": null,
         "targets":[{
             "kind":["bin"],
             "name":"foo",

--- a/tests/read-manifest.rs
+++ b/tests/read-manifest.rs
@@ -14,6 +14,8 @@ fn read_manifest_output() -> String {
     "name":"foo",
     "version":"0.5.0",
     "id":"foo[..]0.5.0[..](path+file://[..]/foo)",
+    "license": null,
+    "license_file": null,
     "source":null,
     "dependencies":[],
     "targets":[{


### PR DESCRIPTION
Proposed fix for #3108 