### PR TITLE
RFC cargo: add "metadata" and "extra_filename" to cargo metadata output

### DIFF
--- a/src/cargo/ops/cargo_rustc/layout.rs
+++ b/src/cargo/ops/cargo_rustc/layout.rs
@@ -49,9 +49,8 @@ use std::fs;
 use std::io;
 use std::path::{PathBuf, Path};
 
-use core::{Package, Workspace};
+use core::{Package, Metadata, Workspace};
 use util::{Config, FileLock, CargoResult, Filesystem};
-use util::hex::short_hash;
 use super::Unit;
 
 pub struct Layout {
@@ -141,7 +140,8 @@ impl Layout {
     }
 
     fn pkg_dir(&self, pkg: &Package) -> String {
-        format!("{}-{}", pkg.name(), short_hash(pkg))
+        let Metadata { extra_filename, .. } = pkg.generate_metadata();
+        format!("{}{}", pkg.name(), extra_filename)
     }
 }
 

--- a/tests/cargotest/support/mod.rs
+++ b/tests/cargotest/support/mod.rs
@@ -115,18 +115,28 @@ impl ProjectBuilder {
     pub fn url(&self) -> Url { path2url(self.root()) }
 
     pub fn bin(&self, b: &str) -> PathBuf {
-        self.build_dir().join("debug").join(&format!("{}{}", b,
-                                                     env::consts::EXE_SUFFIX))
+        self.debug_dir().join(&format!("{}{}", b, env::consts::EXE_SUFFIX))
     }
 
     pub fn release_bin(&self, b: &str) -> PathBuf {
-        self.build_dir().join("release").join(&format!("{}{}", b,
-                                                       env::consts::EXE_SUFFIX))
+        self.release_dir().join(&format!("{}{}", b, env::consts::EXE_SUFFIX))
     }
 
     pub fn target_bin(&self, target: &str, b: &str) -> PathBuf {
         self.build_dir().join(target).join("debug")
                         .join(&format!("{}{}", b, env::consts::EXE_SUFFIX))
+    }
+
+    pub fn deps(&self) -> PathBuf {
+        self.debug_dir().join("deps")
+    }
+
+    pub fn debug_dir(&self) -> PathBuf {
+        self.build_dir().join("debug")
+    }
+
+    pub fn release_dir(&self) -> PathBuf {
+        self.build_dir().join("release")
     }
 
     pub fn build_dir(&self) -> PathBuf {

--- a/tests/metadata.rs
+++ b/tests/metadata.rs
@@ -1,7 +1,11 @@
 extern crate cargotest;
 extern crate hamcrest;
+extern crate rustc_serialize;
 
-use hamcrest::assert_that;
+use std::str;
+
+use rustc_serialize::json;
+use hamcrest::{assert_that, existing_file};
 use cargotest::support::registry::Package;
 use cargotest::support::{project, execs, basic_bin_manifest, basic_lib_manifest, main_file};
 
@@ -27,7 +31,9 @@ fn cargo_metadata_simple() {
                             "bin"
                         ],
                         "name": "foo",
-                        "src_path": "src[..]foo.rs"
+                        "src_path": "src[..]foo.rs",
+                        "metadata": null,
+                        "filename": "foo"
                     }
                 ],
                 "features": {},
@@ -90,7 +96,9 @@ fn cargo_metadata_with_deps_and_version() {
                             "lib"
                         ],
                         "name": "baz",
-                        "src_path": "[..]lib.rs"
+                        "src_path": "[..]lib.rs",
+                        "metadata": "[..]",
+                        "filename": "libbaz-[..].rlib"
                     }
                 ],
                 "version": "0.0.1"
@@ -121,7 +129,9 @@ fn cargo_metadata_with_deps_and_version() {
                             "lib"
                         ],
                         "name": "bar",
-                        "src_path": "[..]lib.rs"
+                        "src_path": "[..]lib.rs",
+                        "metadata": "[..]",
+                        "filename": "libbar-[..].rlib"
                     }
                 ],
                 "version": "0.0.1"
@@ -152,7 +162,9 @@ fn cargo_metadata_with_deps_and_version() {
                             "bin"
                         ],
                         "name": "foo",
-                        "src_path": "[..]foo.rs"
+                        "src_path": "[..]foo.rs",
+                        "metadata": null,
+                        "filename": "foo"
                     }
                 ],
                 "version": "0.5.0"
@@ -212,7 +224,9 @@ fn workspace_metadata() {
                     {
                         "kind": [ "lib" ],
                         "name": "bar",
-                        "src_path": "[..]bar[..]src[..]lib.rs"
+                        "src_path": "[..]bar[..]src[..]lib.rs",
+                        "metadata": "[..]",
+                        "filename": "libbar-[..].rlib"
                     }
                 ],
                 "features": {},
@@ -230,7 +244,9 @@ fn workspace_metadata() {
                     {
                         "kind": [ "lib" ],
                         "name": "baz",
-                        "src_path": "[..]baz[..]src[..]lib.rs"
+                        "src_path": "[..]baz[..]src[..]lib.rs",
+                        "metadata": "[..]",
+                        "filename": "libbaz-[..].rlib"
                     }
                 ],
                 "features": {},
@@ -283,7 +299,9 @@ fn workspace_metadata_no_deps() {
                     {
                         "kind": [ "lib" ],
                         "name": "bar",
-                        "src_path": "[..]bar[..]src[..]lib.rs"
+                        "src_path": "[..]bar[..]src[..]lib.rs",
+                        "metadata": "[..]",
+                        "filename": "libbar-[..].rlib"
                     }
                 ],
                 "features": {},
@@ -301,7 +319,9 @@ fn workspace_metadata_no_deps() {
                     {
                         "kind": [ "lib" ],
                         "name": "baz",
-                        "src_path": "[..]baz[..]src[..]lib.rs"
+                        "src_path": "[..]baz[..]src[..]lib.rs",
+                        "metadata": "[..]",
+                        "filename": "libbaz-[..].rlib"
                     }
                 ],
                 "features": {},
@@ -341,7 +361,9 @@ const MANIFEST_OUTPUT: &'static str=
         "targets":[{
             "kind":["bin"],
             "name":"foo",
-            "src_path":"src[..]foo.rs"
+            "src_path":"src[..]foo.rs",
+            "metadata": null,
+            "filename": "foo"
         }],
         "features":{},
         "manifest_path":"[..]Cargo.toml"
@@ -428,4 +450,363 @@ fn carg_metadata_bad_version() {
                  .cwd(p.root()),
                 execs().with_status(101)
     .with_stderr("[ERROR] metadata version 2 not supported, only 1 is currently supported"));
+}
+
+#[test]
+fn cargo_metadata_filename_bin_test_dash() {
+    let p = project("foo")
+            .file("Cargo.toml", &basic_bin_manifest("foo-bar"))
+            .file("tests/foo-test.rs", "#[test]fn isok() {}");
+
+    assert_that(p.cargo_process("metadata"), execs().with_json(r#"
+    {
+        "packages": [
+            {
+                "name": "foo-bar",
+                "version": "0.5.0",
+                "id": "foo-bar[..]",
+                "source": null,
+                "dependencies": [],
+                "license": null,
+                "license_file": null,
+                "targets": [
+                    {
+                        "kind": [
+                            "bin"
+                        ],
+                        "name": "foo-bar",
+                        "src_path": "src/foo-bar.rs",
+                        "metadata": null,
+                        "filename": "foo_bar"
+                    },
+                    {
+                        "filename": "foo_test-[..]",
+                        "kind": [
+                            "test"
+                        ],
+                        "metadata": "[..]",
+                        "name": "foo-test",
+                        "src_path": "[..]/foo/tests/foo-test.rs"
+                    }
+                ],
+                "features": {},
+                "manifest_path": "[..]Cargo.toml"
+            }
+        ],
+        "workspace_members": [
+            "foo-bar 0.5.0 (path+file:[..]foo)"
+        ],
+        "resolve": {
+            "nodes": [
+                {
+                    "dependencies": [],
+                    "id": "foo-bar 0.5.0 (path+file:[..]foo)"
+                }
+            ],
+            "root": "foo-bar 0.5.0 (path+file:[..]foo)"
+        },
+        "version": 1
+    }"#));
+}
+
+#[test]
+fn cargo_metadata_filename_bin_test_underbar() {
+    let p = project("foo")
+            .file("Cargo.toml", &basic_bin_manifest("foo_underbar"))
+            .file("tests/foo_underbartest.rs", "#[test]fn isok() {}");
+
+    assert_that(p.cargo_process("metadata"), execs().with_json(r#"
+    {
+        "packages": [
+            {
+                "name": "foo_underbar",
+                "version": "0.5.0",
+                "id": "foo_underbar[..]",
+                "source": null,
+                "dependencies": [],
+                "license": null,
+                "license_file": null,
+                "targets": [
+                    {
+                        "kind": [
+                            "bin"
+                        ],
+                        "name": "foo_underbar",
+                        "src_path": "src[..]foo_underbar.rs",
+                        "metadata": null,
+                        "filename": "foo_underbar"
+                    },
+                    {
+                        "filename": "foo_underbartest-[..]",
+                        "kind": [
+                            "test"
+                        ],
+                        "metadata": "[..]",
+                        "name": "foo_underbartest",
+                        "src_path": "[..]/foo/tests/foo_underbartest.rs"
+                    }
+                ],
+                "features": {},
+                "manifest_path": "[..]Cargo.toml"
+            }
+        ],
+        "workspace_members": [
+            "foo_underbar 0.5.0 (path+file:[..]foo)"
+        ],
+        "resolve": {
+            "nodes": [
+                {
+                    "dependencies": [],
+                    "id": "foo_underbar 0.5.0 (path+file:[..]foo)"
+                }
+            ],
+            "root": "foo_underbar 0.5.0 (path+file:[..]foo)"
+        },
+        "version": 1
+    }"#));
+}
+
+#[test]
+fn cargo_metadata_filename_lib_dash() {
+    let p = project("foo")
+            .file("Cargo.toml", r#"
+                [package]
+                name = "foo-bar"
+                version = "0.5.0"
+                authors = ["wycats@example.com"]
+            "#)
+            .file("src/lib.rs", "pub fn foo() {}");
+
+    assert_that(p.cargo_process("metadata"), execs().with_json(r#"
+    {
+        "packages": [
+            {
+                "name": "foo-bar",
+                "version": "0.5.0",
+                "id": "foo-bar[..]",
+                "source": null,
+                "dependencies": [],
+                "license": null,
+                "license_file": null,
+                "targets": [
+                    {
+                        "kind": [
+                            "lib"
+                        ],
+                        "name": "foo-bar",
+                        "src_path": "[..]src/lib.rs",
+                        "metadata": "[..]",
+                        "filename": "libfoo_bar-[..].rlib"
+                    }
+                ],
+                "features": {},
+                "manifest_path": "[..]Cargo.toml"
+            }
+        ],
+        "workspace_members": [
+            "foo-bar 0.5.0 (path+file:[..]foo)"
+        ],
+        "resolve": {
+            "nodes": [
+                {
+                    "dependencies": [],
+                    "id": "foo-bar 0.5.0 (path+file:[..]foo)"
+                }
+            ],
+            "root": "foo-bar 0.5.0 (path+file:[..]foo)"
+        },
+        "version": 1
+    }"#));
+}
+
+#[test]
+fn cargo_metadata_filename_lib_underbar() {
+    let p = project("foo")
+            .file("Cargo.toml", &basic_lib_manifest("foo_underbar"));
+
+    assert_that(p.cargo_process("metadata"), execs().with_json(r#"
+    {
+        "packages": [
+            {
+                "name": "foo_underbar",
+                "version": "0.5.0",
+                "id": "foo_underbar[..]",
+                "source": null,
+                "dependencies": [],
+                "license": null,
+                "license_file": null,
+                "targets": [
+                    {
+                        "kind": [
+                            "lib"
+                        ],
+                        "name": "foo_underbar",
+                        "src_path": "src[..]foo_underbar.rs",
+                        "metadata": "[..]",
+                        "filename": "libfoo_underbar-[..].rlib"
+                    }
+                ],
+                "features": {},
+                "manifest_path": "[..]Cargo.toml"
+            }
+        ],
+        "workspace_members": [
+            "foo_underbar 0.5.0 (path+file:[..]foo)"
+        ],
+        "resolve": {
+            "nodes": [
+                {
+                    "dependencies": [],
+                    "id": "foo_underbar 0.5.0 (path+file:[..]foo)"
+                }
+            ],
+            "root": "foo_underbar 0.5.0 (path+file:[..]foo)"
+        },
+        "version": 1
+    }"#));
+}
+
+#[test]
+fn cargo_metadata_filename_lib_pathdep_namematch() {
+    // Construct a binary which depends on a library, so we can check the library
+    // is built with the expected extra_filename
+    let p = project("foo")
+            .file("Cargo.toml", r#"
+                [package]
+                name = "foo"
+                version = "0.5.0"
+                authors = ["wycats@example.com"]
+
+                [dependencies]
+                foo-bar = { path = "foo-bar" }
+            "#)
+            .file("src/main.rs", &main_file(r#""calling dep""#, &["foo_bar"]))
+            .file("foo-bar/Cargo.toml", r#"
+                [project]
+                name = "foo-bar"
+                version = "0.1.0"
+            "#)
+            .file("foo-bar/src/lib.rs", "pub fn foo() {}");
+
+    // get metadata
+    let out = p.cargo_process("metadata").exec_with_output();
+    let metadata: &str = match &out {
+        &Ok(ref out) => str::from_utf8(&out.stdout).expect("bad output"),
+        &Err(ref err) => panic!("cargo metadata failed {:?}", err),
+    };
+
+    // build things
+    assert_that(p.cargo_process("build"), execs().with_status(0));
+    assert_that(&p.bin("foo"), existing_file());
+
+    // Check the build matched the metadata
+    #[derive(RustcDecodable)]
+    struct DecodableTarget {
+        name: String,
+        filename: String,
+    }
+
+    #[derive(RustcDecodable)]
+    struct DecodablePackage {
+        name: String,
+        targets: Vec<DecodableTarget>,
+    }
+
+    #[derive(RustcDecodable)]
+    struct DecodableMetadata {
+        packages: Vec<DecodablePackage>,
+    }
+
+    let metadata: DecodableMetadata = json::decode(&metadata).expect("can't decode metadata json");
+    let pkg = metadata.packages.iter().find(|p| p.name == "foo-bar").expect("package not found");
+    let target = pkg.targets.iter().find(|t| t.name == "foo-bar").expect("target not found");
+    let dir = p.deps();
+    let path = dir.join(&target.filename);
+
+    println!("Dir {:?} path {:?}", p.debug_dir(), path);
+    for f in p.debug_dir().read_dir().expect("read_dir") {
+        let f = f.expect("dirent");
+        println!("Found {:?}", f.path())
+    }
+
+    println!("Dir {:?} path {:?}", dir, path);
+    for f in dir.read_dir().expect("read_dir") {
+        let f = f.expect("dirent");
+        println!("Found {:?}", f.path())
+    }
+    assert_that(&path, existing_file());
+}
+
+#[test]
+fn cargo_metadata_filename_lib_registry_namematch() {
+    // Construct a binary which depends on a library, so we can check the library
+    // is built with the expected extra_filename
+    let p = project("foo")
+            .file("Cargo.toml", r#"
+                [package]
+                name = "foo"
+                version = "0.5.0"
+                authors = ["wycats@example.com"]
+
+                [dependencies]
+                foo-bar = { path = "foo-bar" }
+                far = "*"
+            "#)
+            .file("src/main.rs", &main_file(r#""calling dep""#, &["foo_bar"]))
+            .file("foo-bar/Cargo.toml", r#"
+                [project]
+                name = "foo-bar"
+                version = "0.1.0"
+            "#)
+            .file("foo-bar/src/lib.rs", "pub fn foo() {}");
+
+    Package::new("far", "0.0.1").publish();
+
+    // get metadata
+    let out = p.cargo_process("metadata").exec_with_output();
+    let metadata: &str = match &out {
+        &Ok(ref out) => str::from_utf8(&out.stdout).expect("bad output"),
+        &Err(ref err) => panic!("cargo metadata failed {:?}", err),
+    };
+
+    // build things
+    assert_that(p.cargo_process("build"), execs().with_status(0));
+    assert_that(&p.bin("foo"), existing_file());
+
+    // Check the build matched the metadata
+    #[derive(RustcDecodable)]
+    struct DecodableTarget {
+        name: String,
+        filename: String,
+    }
+
+    #[derive(RustcDecodable)]
+    struct DecodablePackage {
+        name: String,
+        targets: Vec<DecodableTarget>,
+    }
+
+    #[derive(RustcDecodable)]
+    struct DecodableMetadata {
+        packages: Vec<DecodablePackage>,
+    }
+
+    let metadata: DecodableMetadata = json::decode(&metadata).expect("can't decode metadata json");
+    let pkg = metadata.packages.iter().find(|p| p.name == "far").expect("package not found");
+    let target = pkg.targets.iter().find(|t| t.name == "far").expect("target not found");
+    let dir = p.deps();
+    let path = dir.join(&target.filename);
+
+    println!("Dir {:?} path {:?}", p.debug_dir(), path);
+    for f in p.debug_dir().read_dir().expect("read_dir") {
+        let f = f.expect("dirent");
+        println!("Found {:?}", f.path())
+    }
+
+    println!("Dir {:?} path {:?}", dir, path);
+    for f in dir.read_dir().expect("read_dir") {
+        let f = f.expect("dirent");
+        println!("Found {:?}", f.path())
+    }
+    assert_that(&path, existing_file());
 }

--- a/tests/read-manifest.rs
+++ b/tests/read-manifest.rs
@@ -21,7 +21,9 @@ fn read_manifest_output() -> String {
     "targets":[{
         "kind":["bin"],
         "name":"foo",
-        "src_path":"src[..]foo.rs"
+        "src_path":"src[..]foo.rs",
+        "metadata": null,
+        "filename": "foo"
     }],
     "features":{},
     "manifest_path":"[..]Cargo.toml"


### PR DESCRIPTION
This is useful for determining the filename of a generated .rlib file
for a given version of a package.
