### PR TITLE
Don't download dependencies from other platforms

### DIFF
--- a/src/cargo/ops/cargo_rustc/context.rs
+++ b/src/cargo/ops/cargo_rustc/context.rs
@@ -454,7 +454,7 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
         let deps = self.resolve.deps(id);
         let mut ret = try!(deps.filter(|dep| {
             unit.pkg.dependencies().iter().filter(|d| {
-                d.name() == dep.name()
+                d.name() == dep.name() && d.version_req().matches(dep.version())
             }).any(|d| {
                 // If this target is a build command, then we only want build
                 // dependencies, otherwise we want everything *other than* build


### PR DESCRIPTION
Having a Cargo.toml which looks like this:

            [package]
            name = "a"
            version = "0.0.1"
            authors = []

            [target.'cfg(unix)'.dependencies]
            foo = "0.1.0"

            [target.'cfg(windows)'.dependencies]
            foo = "0.2.0"

This would still download foo version 0.2.0 on unix. I think there is no need to do that, but please correct me if I'm wrong.

This was triggered by [this](http://stackoverflow.com/questions/39709542/why-does-the-last-platform-specific-dependency-take-precedence-in-cargo) stackoverflow question, but that situation is more complicated, as the version is the same, just the features are different. This PR will not solve that bug. If you want me to include that too, I would have to debug a bit more first....
