### PR TITLE
Build transitive dev-dependencies when needed

### DIFF
--- a/src/cargo/ops/cargo_generate_lockfile.rs
+++ b/src/cargo/ops/cargo_generate_lockfile.rs
@@ -19,7 +19,7 @@ pub fn generate_lockfile(ws: &Workspace) -> CargoResult<()> {
     let mut registry = try!(PackageRegistry::new(ws.config()));
     let resolve = try!(ops::resolve_with_previous(&mut registry, ws,
                                                   Method::Everything,
-                                                  None, None));
+                                                  None, None, &[]));
     try!(ops::write_pkg_lockfile(ws, &resolve));
     Ok(())
 }
@@ -78,7 +78,8 @@ pub fn update_lockfile(ws: &Workspace, opts: &UpdateOptions)
                                                   ws,
                                                   Method::Everything,
                                                   Some(&previous_resolve),
-                                                  Some(&to_avoid)));
+                                                  Some(&to_avoid),
+                                                  &[]));
 
     // Summarize what is changing for the user.
     let print_change = |status: &str, msg: String| {

--- a/src/cargo/ops/cargo_output_metadata.rs
+++ b/src/cargo/ops/cargo_output_metadata.rs
@@ -47,7 +47,8 @@ fn metadata_full(ws: &Workspace,
                                               None,
                                               opt.features.clone(),
                                               opt.all_features,
-                                              opt.no_default_features));
+                                              opt.no_default_features,
+                                              &[]));
     let (packages, resolve) = deps;
 
     let packages = try!(packages.package_ids()


### PR DESCRIPTION
When running `cargo test -p foo` where `foo` is a crate in the current workspace, build and link `foo`'s dev-dependencies. Fixes #860.