### PR TITLE
Warn about path overrides that won't work

### DIFF
--- a/src/cargo/sources/config.rs
+++ b/src/cargo/sources/config.rs
@@ -62,6 +62,10 @@ impl<'cfg> SourceConfigMap<'cfg> {
         Ok(base)
     }
 
+    pub fn config(&self) -> &'cfg Config {
+        self.config
+    }
+
     pub fn load(&self, id: &SourceId) -> CargoResult<Box<Source + 'cfg>> {
         debug!("loading: {}", id);
         let mut name = match self.id2name.get(id) {

--- a/tests/overrides.rs
+++ b/tests/overrides.rs
@@ -682,3 +682,70 @@ fn no_override_self() {
     assert_that(p.cargo_process("build").arg("--verbose"),
                 execs().with_status(0));
 }
+
+#[test]
+fn broken_path_override_warns() {
+    Package::new("foo", "0.1.0").publish();
+    Package::new("foo", "0.2.0").publish();
+
+    let p = project("local")
+        .file("Cargo.toml", r#"
+            [package]
+            name = "local"
+            version = "0.0.1"
+            authors = []
+
+            [dependencies]
+            a = { path = "a1" }
+        "#)
+        .file("src/lib.rs", "")
+        .file("a1/Cargo.toml", r#"
+            [package]
+            name = "a"
+            version = "0.0.1"
+            authors = []
+
+            [dependencies]
+            foo = "0.1"
+        "#)
+        .file("a1/src/lib.rs", "")
+        .file("a2/Cargo.toml", r#"
+            [package]
+            name = "a"
+            version = "0.0.1"
+            authors = []
+
+            [dependencies]
+            foo = "0.2"
+        "#)
+        .file("a2/src/lib.rs", "")
+        .file(".cargo/config", r#"
+            paths = ["a2"]
+        "#);
+
+    assert_that(p.cargo_process("build"),
+                execs().with_status(0)
+                       .with_stderr("\
+[UPDATING] [..]
+warning: path override for crate `a` has altered the original list of
+dependencies; the dependency on `foo` was either added or
+modified to not match the previously resolved version
+
+This is currently allowed but is known to produce buggy behavior with spurious
+recompiles and changes to the crate graph. Path overrides unfortunately were
+never intended to support this feature, so for now this message is just a
+warning. In the future, however, this message will become a hard error.
+
+To change the dependency graph via an override it's recommended to use the
+`[replace]` feature of Cargo instead of the path override feature. This is
+documented online at the url below for more information.
+
+http://doc.crates.io/specifying-dependencies.html#overriding-dependencies
+
+[DOWNLOADING] [..]
+[COMPILING] [..]
+[COMPILING] [..]
+[COMPILING] [..]
+[FINISHED] [..]
+"));
+}


### PR DESCRIPTION
Cargo has a long-standing [bug] in path overrides where they will cause spurious
rebuilds of crates in the crate graph. This can be very difficult to diagnose
and be incredibly frustrating as well. Unfortunately, though, it's behavior that
fundamentally can't be fixed in Cargo.

The crux of the problem happens when a `path` replacement changes something
about the list of dependencies of the crate that it's replacing. This alteration
to the list of dependencies *cannot be tracked by Cargo* as the lock file was
previously emitted. In the best case this ends up causing random recompiles. In
the worst case it cause infinite registry updates that always result in
recompiles.

A solution to this intention, changing the dependency graph of an overridden
dependency, was [implemented] with the `[replace]` feature in Cargo awhile back.
With that in mind, this commit implements a *warning* whenever a bad dependency
replacement is detected. The message here is pretty wordy, but it's intended to
convey that you should switch to using `[replace]` for a more robust
impelmentation, and it can also give security to anyone using `path` overrides
that if they get past this warning everything should work as intended.

[bug]: https://github.com/rust-lang/cargo/issues/2041
[implemented]: http://doc.crates.io/specifying-dependencies.html#overriding-dependencies

Closes #2041