### PR TITLE
Show an error messager for invalid semver spec for packages in the [replace] section.

### DIFF
--- a/src/cargo/core/package_id_spec.rs
+++ b/src/cargo/core/package_id_spec.rs
@@ -257,6 +257,7 @@ mod tests {
     #[test]
     fn bad_parsing() {
         assert!(PackageIdSpec::parse("baz:").is_err());
+        assert!(PackageIdSpec::parse("baz:*").is_err());
         assert!(PackageIdSpec::parse("baz:1.0").is_err());
         assert!(PackageIdSpec::parse("http://baz:1.0").is_err());
         assert!(PackageIdSpec::parse("http://#baz:1.0").is_err());

--- a/src/cargo/util/toml.rs
+++ b/src/cargo/util/toml.rs
@@ -737,7 +737,12 @@ impl TomlManifest {
                -> CargoResult<Vec<(PackageIdSpec, Dependency)>> {
         let mut replace = Vec::new();
         for (spec, replacement) in self.replace.iter().flat_map(|x| x) {
-            let spec = try!(PackageIdSpec::parse(spec));
+            let spec = match PackageIdSpec::parse(spec) {
+                Ok(spec) => spec,
+                Err(_)   => bail!("replacements must specify a \
+                                   valid semver version \
+                                   to replace, but `{}` does not", spec),
+            };
 
             let version_specified = match *replacement {
                 TomlDependency::Detailed(ref d) => d.version.is_some(),

--- a/src/cargo/util/toml.rs
+++ b/src/cargo/util/toml.rs
@@ -737,12 +737,11 @@ impl TomlManifest {
                -> CargoResult<Vec<(PackageIdSpec, Dependency)>> {
         let mut replace = Vec::new();
         for (spec, replacement) in self.replace.iter().flat_map(|x| x) {
-            let spec = match PackageIdSpec::parse(spec) {
-                Ok(spec) => spec,
-                Err(_)   => bail!("replacements must specify a \
-                                   valid semver version \
-                                   to replace, but `{}` does not", spec),
-            };
+            let spec = try!(PackageIdSpec::parse(spec).chain_error(|| {
+                human(format!("replacements must specify a valid semver \
+                               version to replace, but `{}` does not",
+                              spec))
+            }));
 
             let version_specified = match *replacement {
                 TomlDependency::Detailed(ref d) => d.version.is_some(),

--- a/tests/overrides.rs
+++ b/tests/overrides.rs
@@ -95,7 +95,7 @@ fn invalid_semver_version() {
         .file("src/lib.rs", "");
 
     assert_that(p.cargo_process("build"),
-                execs().with_status(101).with_stderr("\
+                execs().with_status(101).with_stderr_contains("\
 error: failed to parse manifest at `[..]`
 
 Caused by:

--- a/tests/overrides.rs
+++ b/tests/overrides.rs
@@ -78,6 +78,32 @@ Caused by:
 }
 
 #[test]
+fn invalid_semver_version() {
+    let p = project("local")
+        .file("Cargo.toml", r#"
+            [package]
+            name = "local"
+            version = "0.0.1"
+            authors = []
+
+            [dependencies]
+            foo = "*"
+
+            [replace]
+            "foo:*" = { git = 'https://example.com' }
+        "#)
+        .file("src/lib.rs", "");
+
+    assert_that(p.cargo_process("build"),
+                execs().with_status(101).with_stderr("\
+error: failed to parse manifest at `[..]`
+
+Caused by:
+  replacements must specify a valid semver version to replace, but `foo:*` does not
+"));
+}
+
+#[test]
 fn different_version() {
     Package::new("foo", "0.2.0").publish();
     Package::new("foo", "0.1.0").publish();


### PR DESCRIPTION
The `[replace]` section in the `Cargo.toml` file doesn't allow invalid semver specsfor packages, so something like this:

```toml
[dependencies]
foo = "*"

[replace]
"foo:*" = { git = 'https://example.com' }
```

It's not valid. In this case we will display an error message like this:

```
error: failed to parse manifest at `Cargo.toml`

Caused by:
  replacements must specify a valid semver version to replace, but `foo:*` does not

Caused by:
  Parse error
```

closes #3129 