### PR TITLE
Allow deprecated use of SipHasher

### DIFF
--- a/src/cargo/sources/git/source.rs
+++ b/src/cargo/sources/git/source.rs
@@ -1,12 +1,12 @@
 use std::fmt::{self, Debug, Formatter};
-use std::hash::{Hash, Hasher, SipHasher};
 
 use url::Url;
 
 use core::source::{Source, SourceId};
 use core::GitReference;
 use core::{Package, PackageId, Summary, Registry, Dependency};
-use util::{CargoResult, Config, to_hex};
+use util::{CargoResult, Config};
+use util::hex::short_hash;
 use sources::PathSource;
 use sources::git::utils::{GitRemote, GitRevision};
 
@@ -57,8 +57,6 @@ impl<'cfg> GitSource<'cfg> {
 }
 
 fn ident(url: &Url) -> String {
-    let mut hasher = SipHasher::new_with_keys(0,0);
-
     let url = canonicalize_url(url);
     let ident = url.path_segments().and_then(|mut s| s.next_back()).unwrap_or("");
 
@@ -68,8 +66,7 @@ fn ident(url: &Url) -> String {
         ident
     };
 
-    url.hash(&mut hasher);
-    format!("{}-{}", ident, to_hex(hasher.finish()))
+    format!("{}-{}", ident, short_hash(&url))
 }
 
 // Some hacks and heuristics for making equivalent URLs hash the same

--- a/src/cargo/util/hex.rs
+++ b/src/cargo/util/hex.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use std::hash::{Hasher, Hash, SipHasher};
 
 use rustc_serialize::hex::ToHex;


### PR DESCRIPTION
This type is being deprecated in rust-lang/rust#36815, so allow use of the
deprecated type for now. We can fix this later once new APIs have landed.