### PR TITLE
Test requested --target from source of truth

### DIFF
--- a/src/cargo/ops/cargo_rustc/compilation.rs
+++ b/src/cargo/ops/cargo_rustc/compilation.rs
@@ -44,6 +44,8 @@ pub struct Compilation<'cfg> {
     /// Features enabled during this compilation.
     pub cfgs: HashSet<String>,
 
+    pub target: String,
+
     config: &'cfg Config,
 }
 
@@ -60,6 +62,7 @@ impl<'cfg> Compilation<'cfg> {
             to_doc_test: Vec::new(),
             cfgs: HashSet::new(),
             config: config,
+            target: String::new(),
         }
     }
 

--- a/src/cargo/ops/cargo_rustc/mod.rs
+++ b/src/cargo/ops/cargo_rustc/mod.rs
@@ -159,6 +159,7 @@ pub fn compile_targets<'a, 'cfg: 'a>(ws: &Workspace<'cfg>,
             cx.compilation.native_dirs.insert(dir.clone());
         }
     }
+    cx.compilation.target = cx.target_triple().to_string();
     Ok(cx.compilation)
 }
 

--- a/src/cargo/ops/cargo_test.rs
+++ b/src/cargo/ops/cargo_test.rs
@@ -116,10 +116,8 @@ fn run_doc_tests(options: &TestOptions,
     let config = options.compile_opts.config;
 
     // We don't build/rust doctests if target != host
-    if let Some(target) = options.compile_opts.target {
-        if try!(config.rustc()).host != target {
-            return Ok(errors);
-        }
+    if try!(config.rustc()).host != compilation.target {
+        return Ok(errors);
     }
 
     let libs = compilation.to_doc_test.iter().map(|package| {


### PR DESCRIPTION
We skip doc tests for any cross compiles (as they don't work) but to detect a
cross compile we checked `--target` but forgot to check other locations like
`CARGO_BUILD_TARGET` or `[build.target]`. This alters the check to ensure that
it verifies from the source of truth whether a cross compilation happened or
not.

Closes #3143