### PR TITLE
Use workspaces during `cargo install`

### DIFF
--- a/src/cargo/ops/cargo_install.rs
+++ b/src/cargo/ops/cargo_install.rs
@@ -90,7 +90,10 @@ pub fn install(root: Option<&str>,
         Some(Filesystem::new(config.cwd().join("target-install")))
     };
 
-    let ws = try!(Workspace::one(pkg, config, overidden_target_dir));
+    let ws = match overidden_target_dir {
+        Some(dir) => try!(Workspace::one(pkg, config, Some(dir))),
+        None => try!(Workspace::new(pkg.manifest_path(), config)),
+    };
     let pkg = try!(ws.current());
 
     // Preflight checks to check up front whether we'll overwrite something.


### PR DESCRIPTION
Prevent lock files from oscillating.

Closes #3133