### PR TITLE
Add information about Cargo releases going with Rust releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,9 +102,33 @@ make doc
 open target/doc/index.html
 ```
 
-## Release notes
+## Releases
 
-High level release notes are available as part of [Rust's release notes](https://github.com/rust-lang/rust/blob/master/RELEASES.md).
+High level release notes are available as part of [Rust's release notes][rel].
+Cargo releases coincide with Rust releases.
+
+[rel]: https://github.com/rust-lang/rust/blob/master/RELEASES.md
+
+<details>
+    <summary>Table of Rust versions with their Cargo versions</summary>
+
+Rust version | Cargo version
+-------------|--------------|
+   1.12.0    |    0.13.0    |
+   1.11.0    |    0.12.0    |
+   1.10.0    |    0.11.0    |
+   1.9.0     |    0.10.0    |
+   1.8.0     |    0.9.0     |
+   1.7.0     |    0.8.0     |
+   1.6.0     |    0.7.0     |
+   1.5.0     |    0.6.0     |
+   1.4.0     |    0.5.0     |
+   1.3.0     |    0.4.0     |
+   1.2.0     |    0.3.0     |
+   1.1.0     |    0.2.0     |
+   1.0.0     |    0.1.0     |
+
+</details>
 
 ## Reporting Issues
 


### PR DESCRIPTION
Closes #3101.

This just adds a table of rust release numbers to cargo release numbers, and some text that clarifies that they happen together. 

I put the table behind a details tag, which Chrome renders really nicely with a little toggle triangle... Firefox will do the toggling *functionality* but doesn't have much of an indication that you can click on the text, but I think they're working on it. Servo has a little triangle but nothing happens when you click on it ;)