### PR TITLE
Document that read_manifest command is deprecated

### DIFF
--- a/src/bin/read_manifest.rs
+++ b/src/bin/read_manifest.rs
@@ -11,7 +11,8 @@ pub struct Options {
 }
 
 pub const USAGE: &'static str = "
-Print a JSON representation of a Cargo.toml manifest
+Deprecated, use `cargo metadata --no-deps` instead.
+Print a JSON representation of a Cargo.toml manifest.
 
 Usage:
     cargo read-manifest [options]


### PR DESCRIPTION
I believe we intended to deprecate read_manifest command. I am not sure what a deprecation process for Cargo commands should be, but I guess it should involve mentioning somewhere that the command is deprecated :) 