### PR TITLE
add support for per-target rustflags in .cargo/config

### DIFF
--- a/src/cargo/ops/cargo_rustc/context.rs
+++ b/src/cargo/ops/cargo_rustc/context.rs
@@ -775,8 +775,16 @@ fn env_args(config: &Config,
         return Ok(args.collect());
     }
 
-    // Then the build.rustflags value
     let name = name.chars().flat_map(|c| c.to_lowercase()).collect::<String>();
+    // Then the target.*.rustflags value
+    let target = build_config.requested_target.as_ref().unwrap_or(&build_config.host_triple);
+    let key = format!("target.{}.{}", target, name);
+    if let Some(args) = try!(config.get_list(&key)) {
+        let args = args.val.into_iter().map(|a| a.0);
+        return Ok(args.collect());
+    }
+
+    // Then the build.rustflags value
     let key = format!("build.{}", name);
     if let Some(args) = try!(config.get_list(&key)) {
         let args = args.val.into_iter().map(|a| a.0);

--- a/src/doc/config.md
+++ b/src/doc/config.md
@@ -69,6 +69,9 @@ linker = ".."
 # Similar to the above linker configuration, but this only applies to
 # when the `$triple` is being compiled for.
 linker = ".."
+# custom flags to pass to all compiler invocations that target $triple
+# this value overrides build.rustflags when both are present
+rustflags = ["..", ".."]
 
 # Configuration keys related to the registry
 [registry]


### PR DESCRIPTION
you can now specify rustflags on a per-target basis in .cargo/config:

``` toml
[target.x86_64-unknown-linux-gnu]
rustflags = ["x86", "specific", "flags"]

[target.arm-unknown-linux-gnueabi]
rustflags = ["arm", "specific", "flags"]
```

If both build.rustflags and target.*.rustflags are specified, the
target.* ones will be used.

As before RUSTFLAGS overrides either set.

closes #3153

r? @alexcrichton I've only added a smoke test and a precedence test. Let me know if I should add more tests!