### PR TITLE
Ignore rustc-macro tests for now

### DIFF
--- a/tests/rustc-macro.rs
+++ b/tests/rustc-macro.rs
@@ -6,6 +6,7 @@ use cargotest::support::{project, execs};
 use hamcrest::assert_that;
 
 #[test]
+#[ignore]
 fn noop() {
     if !is_nightly() {
         return;
@@ -62,6 +63,7 @@ fn noop() {
 }
 
 #[test]
+#[ignore]
 fn impl_and_derive() {
     if !is_nightly() {
         return;
@@ -146,6 +148,7 @@ fn impl_and_derive() {
 }
 
 #[test]
+#[ignore]
 fn plugin_and_rustc_macro() {
     if !is_nightly() {
         return;


### PR DESCRIPTION
We need to ignore them to land rust-lang/rust#36945 and after that we'll shortly
re-enable them.