### PR TITLE
Ignore `panic` configuration for test/bench profiles

### DIFF
--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -245,7 +245,7 @@ pub fn compile_ws<'a>(ws: &Workspace<'a>,
         let _p = profile::start("compiling");
         let mut build_config = try!(scrape_build_config(config, jobs, target));
         build_config.release = release;
-        build_config.test = mode == CompileMode::Test;
+        build_config.test = mode == CompileMode::Test || mode == CompileMode::Bench;
         build_config.json_errors = message_format == MessageFormat::Json;
         if let CompileMode::Doc { deps } = mode {
             build_config.doc_all = deps;

--- a/src/cargo/util/toml.rs
+++ b/src/cargo/util/toml.rs
@@ -1239,6 +1239,10 @@ fn build_profiles(profiles: &Option<TomlProfiles>) -> Profiles {
                    profiles.and_then(|p| p.doc.as_ref())),
         custom_build: Profile::default_custom_build(),
     };
+    // The test/bench targets cannot have panic=abort because they'll all get
+    // compiled with --test which requires the unwind runtime currently
+    profiles.test.panic = None;
+    profiles.bench.panic = None;
     profiles.test_deps.panic = None;
     profiles.bench_deps.panic = None;
     return profiles;

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -2332,3 +2332,35 @@ fn pass_correct_cfgs_flags_to_rustdoc() {
 [DOCTEST] foo
 [RUNNING] `rustdoc --test [..]feature_a[..]`"));
 }
+
+#[test]
+fn test_release_ignore_panic() {
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [package]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+
+            [dependencies]
+            a = { path = "a" }
+
+            [profile.test]
+            panic = 'abort'
+            [profile.release]
+            panic = 'abort'
+        "#)
+        .file("src/lib.rs", "extern crate a;")
+        .file("a/Cargo.toml", r#"
+            [package]
+            name = "a"
+            version = "0.0.1"
+            authors = []
+        "#)
+        .file("a/src/lib.rs", "");
+    p.build();
+    println!("test");
+    assert_that(p.cargo("test").arg("-v"), execs().with_status(0));
+    println!("bench");
+    assert_that(p.cargo("bench").arg("-v"), execs().with_status(0));
+}


### PR DESCRIPTION
Both of these profiles link to libtest, so it's invalid to configure them with
`panic="abort"`. To prevent confusing errors just ignore the configuration for
now.

Closes #3166
