### PR TITLE
Add cargo-metadata crate.

### DIFF
--- a/src/metadata/Cargo.toml
+++ b/src/metadata/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "cargo-metadata"
+version = "0.1.0"
+authors = ["Alex Crichton <alex@alexcrichton.com>",
+           "Ahmed Charles <acharles@outlook.com>"]
+license = "MIT/Apache-2.0"
+repository = "https://github.com/rust-lang/cargo"
+description = """
+Helpers for interacting with 'cargo metadata'.
+"""
+
+[lib]
+name = "cargo_metadata"
+path = "lib.rs"
+
+[dependencies]
+regex = "0.1"
+rustc-serialize = "0.3"

--- a/src/metadata/deps.json
+++ b/src/metadata/deps.json
@@ -1,0 +1,99 @@
+{
+    "packages": [
+        {
+            "dependencies": [
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "rustc-serialize",
+                    "optional": false,
+                    "req": "^0.3",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "target": null,
+                    "uses_default_features": true
+                }
+            ],
+            "features": {},
+            "id": "cargo-metadata 0.1.0 (path+file:///home/user/cargo/src/metadata)",
+            "manifest_path": "/home/user/cargo/src/metadata/Cargo.toml",
+            "name": "cargo-metadata",
+            "source": null,
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "name": "cargo_metadata",
+                    "src_path": "lib.rs"
+                }
+            ],
+            "version": "0.1.0"
+        },
+        {
+            "dependencies": [
+                {
+                    "features": [],
+                    "kind": "dev",
+                    "name": "rand",
+                    "optional": false,
+                    "req": "^0.3",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "target": null,
+                    "uses_default_features": true
+                }
+            ],
+            "features": {},
+            "id": "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
+            "manifest_path": "/home/user/.cargo/registry/src/github.com-1ecc6299db9ec823/rustc-serialize-0.3.19/Cargo.toml",
+            "name": "rustc-serialize",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "name": "rustc-serialize",
+                    "src_path": "/home/user/.cargo/registry/src/github.com-1ecc6299db9ec823/rustc-serialize-0.3.19/src/lib.rs"
+                },
+                {
+                    "kind": [
+                        "bench"
+                    ],
+                    "name": "hex",
+                    "src_path": "/home/user/.cargo/registry/src/github.com-1ecc6299db9ec823/rustc-serialize-0.3.19/benches/hex.rs"
+                },
+                {
+                    "kind": [
+                        "bench"
+                    ],
+                    "name": "base64",
+                    "src_path": "/home/user/.cargo/registry/src/github.com-1ecc6299db9ec823/rustc-serialize-0.3.19/benches/base64.rs"
+                },
+                {
+                    "kind": [
+                        "bench"
+                    ],
+                    "name": "json",
+                    "src_path": "/home/user/.cargo/registry/src/github.com-1ecc6299db9ec823/rustc-serialize-0.3.19/benches/json.rs"
+                }
+            ],
+            "version": "0.3.19"
+        }
+    ],
+    "resolve": {
+        "nodes": [
+            {
+                "dependencies": [
+                    "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "id": "cargo-metadata 0.1.0 (path+file:///home/user/cargo/src/metadata)"
+            },
+            {
+                "dependencies": [],
+                "id": "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)"
+            }
+        ],
+        "root": "cargo-metadata 0.1.0 (path+file:///home/user/cargo/src/metadata)"
+    },
+    "version": 1
+}

--- a/src/metadata/lib.rs
+++ b/src/metadata/lib.rs
@@ -1,0 +1,378 @@
+extern crate regex;
+extern crate rustc_serialize;
+
+use std::collections::HashMap;
+use std::error::Error as StdError;
+use std::fmt;
+
+use regex::Regex;
+use rustc_serialize::{Decodable, Decoder};
+use rustc_serialize::json::{decode, DecoderError};
+
+#[derive(Debug, PartialEq)]
+enum InnerError {
+    DecoderError(DecoderError),
+    VersionError(u32),
+}
+
+#[derive(Debug, PartialEq)]
+pub struct Error {
+    error: InnerError,
+}
+
+impl StdError for Error {
+    fn description(&self) -> &str {
+        match self.error {
+            InnerError::DecoderError(ref e) => e.description(),
+            InnerError::VersionError(_) => "version error",
+        }
+    }
+
+    fn cause(&self) -> Option<&StdError> {
+        match self.error {
+            InnerError::DecoderError(ref e) => Some(e),
+            InnerError::VersionError(_) => None,
+        }
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Debug::fmt(&self, f)
+    }
+}
+
+impl From<DecoderError> for Error {
+    fn from(e: DecoderError) -> Error {
+        Error { error: InnerError::DecoderError(e) }
+    }
+}
+
+#[derive(Debug, Eq, PartialEq, RustcDecodable)]
+pub struct CargoMetadata {
+    packages: Vec<Package>,
+    workspace_members: Option<Vec<()>>,
+    resolve: Option<Resolve>,
+    version: u32,
+}
+
+impl CargoMetadata {
+    pub fn from_json(json: &str) -> Result<CargoMetadata, Error> {
+        #[derive(RustcDecodable)]
+        struct MetadataVersion {
+            version: u32,
+        }
+        let d: MetadataVersion = try!(decode(json));
+        if d.version != 1 {
+            return Err(Error { error: InnerError::VersionError(d.version) });
+        }
+        decode(json).map_err(|e| e.into())
+    }
+}
+
+#[derive(Debug, Eq, PartialEq, RustcDecodable)]
+pub struct Package {
+    dependencies: Vec<Dependency>,
+    features: HashMap<String, Vec<String>>,
+    id: PackageId,
+    manifest_path: String,
+    name: String,
+    source: Option<String>,
+    targets: Vec<Target>,
+    version: String,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct PackageId {
+    name: String,
+    version: String,
+    source_id: String,
+}
+
+impl Decodable for PackageId {
+    fn decode<D: Decoder>(d: &mut D) -> Result<PackageId, D::Error> {
+        let string: String = try!(Decodable::decode(d));
+        let regex = Regex::new(r"^([^ ]+) ([^ ]+) \(([^\)]+)\)$").unwrap();
+        let captures = try!(regex.captures(&string).ok_or_else(|| {
+            d.error("invalid serialized PackageId")
+        }));
+
+        let name = captures.at(1).unwrap();
+        let version = captures.at(2).unwrap();
+        let url = captures.at(3).unwrap();
+
+        Ok(PackageId {
+            name: name.to_string(),
+            version: version.to_string(),
+            source_id: url.to_string(),
+        })
+    }
+}
+
+#[derive(Debug, Eq, PartialEq, RustcDecodable)]
+pub struct Dependency {
+    features: Vec<()>,
+    kind: Option<String>,
+    name: String,
+    optional: bool,
+    req: String,
+    source: Option<String>,
+    target: (),
+    uses_default_features: bool,
+}
+
+#[derive(Debug, Eq, PartialEq, RustcDecodable)]
+pub struct Target {
+    kind: Vec<String>,
+    name: String,
+    src_path: String,
+}
+
+#[derive(Debug, Eq, PartialEq, RustcDecodable)]
+pub struct Resolve {
+    nodes: Vec<Node>,
+    root: PackageId,
+}
+
+#[derive(Debug, Eq, PartialEq, RustcDecodable)]
+pub struct Node {
+    dependencies: Vec<PackageId>,
+    id: PackageId,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::{HashMap, HashSet};
+
+    #[test]
+    fn test_no_deps() {
+        let json = include_str!("no-deps.json");
+        let decoded = CargoMetadata::from_json(json).unwrap();
+        assert_eq!(CargoMetadata {
+            packages: vec!(Package {
+                dependencies: vec!(Dependency {
+                    features: vec!(),
+                    kind: None,
+                    name: "rustc-serialize".to_string(),
+                    optional: false,
+                    req: "^0.3".to_string(),
+                    source: Some("registry+https://github.com/rust-lang/crates.io-index"
+                        .to_string()),
+                    target: (),
+                    uses_default_features: true,
+                }),
+                features: HashMap::new(),
+                id: PackageId {
+                    name: "cargo-metadata".to_string(),
+                    version: "0.1.0".to_string(),
+                    source_id: "path+file:///home/user/cargo/src/metadata".to_string(),
+                },
+                manifest_path: "/home/user/cargo/src/metadata/Cargo.toml".to_string(),
+                name: "cargo-metadata".to_string(),
+                source: None,
+                targets: vec!(Target {
+                    kind: vec!("lib".to_string()),
+                    name: "cargo_metadata".to_string(),
+                    src_path: "lib.rs".to_string(),
+                }),
+                version: "0.1.0".to_string(),
+            }),
+            workspace_members: None,
+            resolve: None,
+            version: 1,
+        }, decoded);
+    }
+
+    #[test]
+    fn test_deps() {
+        let json = include_str!("deps.json");
+        let decoded = CargoMetadata::from_json(json).unwrap();
+        assert_eq!(CargoMetadata {
+            packages: vec!(Package {
+                dependencies: vec!(Dependency {
+                    features: vec!(),
+                    kind: None,
+                    name: "rustc-serialize".to_string(),
+                    optional: false,
+                    req: "^0.3".to_string(),
+                    source: Some("registry+https://github.com/rust-lang/crates.io-index"
+                        .to_string()),
+                    target: (),
+                    uses_default_features: true,
+                }),
+                features: HashMap::new(),
+                id: PackageId {
+                    name: "cargo-metadata".to_string(),
+                    version: "0.1.0".to_string(),
+                    source_id: "path+file:///home/user/cargo/src/metadata".to_string(),
+                },
+                manifest_path: "/home/user/cargo/src/metadata/Cargo.toml".to_string(),
+                name: "cargo-metadata".to_string(),
+                source: None,
+                targets: vec!(Target {
+                    kind: vec!("lib".to_string()),
+                    name: "cargo_metadata".to_string(),
+                    src_path: "lib.rs".to_string(),
+                }),
+                version: "0.1.0".to_string(),
+            },
+            Package {
+                dependencies: vec!(Dependency {
+                    features: vec!(),
+                    kind: Some("dev".to_string()),
+                    name: "rand".to_string(),
+                    optional: false,
+                    req: "^0.3".to_string(),
+                    source: Some("registry+https://github.com/rust-lang/crates.io-index"
+                        .to_string()),
+                    target: (),
+                    uses_default_features: true,
+                }),
+                features: HashMap::new(),
+                id: PackageId {
+                    name: "rustc-serialize".to_string(),
+                    version: "0.3.19".to_string(),
+                    source_id: "registry+https://github.com/rust-lang/crates.io-index".to_string(),
+                },
+                manifest_path: "/home/user/.cargo/registry/src/github.com-1ecc6299db9ec823/\
+rustc-serialize-0.3.19/Cargo.toml".to_string(),
+                name: "rustc-serialize".to_string(),
+                source: Some("registry+https://github.com/rust-lang/crates.io-index".to_string()),
+                targets: vec!(Target {
+                    kind: vec!("lib".to_string()),
+                    name: "rustc-serialize".to_string(),
+                    src_path: "/home/user/.cargo/registry/src/github.com-1ecc6299db9ec823/\
+rustc-serialize-0.3.19/src/lib.rs".to_string(),
+                },
+                Target {
+                    kind: vec!("bench".to_string()),
+                    name: "hex".to_string(),
+                    src_path: "/home/user/.cargo/registry/src/github.com-1ecc6299db9ec823/\
+rustc-serialize-0.3.19/benches/hex.rs".to_string(),
+                },
+                Target {
+                    kind: vec!("bench".to_string()),
+                    name: "base64".to_string(),
+                    src_path: "/home/user/.cargo/registry/src/github.com-1ecc6299db9ec823/\
+rustc-serialize-0.3.19/benches/base64.rs".to_string(),
+                },
+                Target {
+                    kind: vec!("bench".to_string()),
+                    name: "json".to_string(),
+                    src_path: "/home/user/.cargo/registry/src/github.com-1ecc6299db9ec823/\
+rustc-serialize-0.3.19/benches/json.rs".to_string(),
+                }),
+                version: "0.3.19".to_string(),
+            }),
+            workspace_members: None,
+            resolve: Some(Resolve {
+                nodes: vec!(Node {
+                    dependencies: vec!(PackageId {
+                        name: "rustc-serialize".to_string(),
+                        version: "0.3.19".to_string(),
+                        source_id: "registry+https://github.com/rust-lang/crates.io-index"
+                            .to_string(),
+                    }),
+                    id: PackageId {
+                        name: "cargo-metadata".to_string(),
+                        version: "0.1.0".to_string(),
+                        source_id: "path+file:///home/user/cargo/src/metadata".to_string(),
+                    },
+                },
+                Node {
+                    dependencies: vec!(),
+                    id: PackageId {
+                        name: "rustc-serialize".to_string(),
+                        version: "0.3.19".to_string(),
+                        source_id: "registry+https://github.com/rust-lang/crates.io-index"
+                            .to_string(),
+                    },
+                }),
+                root: PackageId {
+                    name: "cargo-metadata".to_string(),
+                    version: "0.1.0".to_string(),
+                    source_id: "path+file:///home/user/cargo/src/metadata".to_string(),
+                },
+            }),
+            version: 1,
+        }, decoded);
+    }
+
+    #[test]
+    fn test_rustc() {
+        let json = include_str!("rustc.json");
+        let decoded = CargoMetadata::from_json(json).unwrap();
+        let resolve = decoded.resolve.as_ref().unwrap();
+        let root = resolve.root.name.as_str();
+        assert_eq!("rustc-main", root);
+        let mut todo = vec!(root);
+        let mut trans = HashSet::new();
+        trans.insert(root);
+        while let Some(next) = todo.pop() {
+            let node = resolve.nodes.iter().find(|x| x.id.name == next).unwrap();
+            todo.extend(node.dependencies.iter().map(|x| x.name.as_str()));
+            trans.extend(node.dependencies.iter().map(|x| x.name.as_str()));
+        }
+        let expected: HashSet<&str> = vec!(
+            "arena", "rustc_resolve", "log", "proc_macro", "rustc_privacy", "rustc_typeck",
+            "rustc_metadata", "rustc_borrowck", "rustc_passes", "rustc_plugin", "rustc_const_eval",
+            "rustc_macro", "graphviz", "rustc_driver", "rustc_llvm", "rustc_errors", "rustc",
+            "gcc", "rustc_mir", "rustc-main", "rustc_data_structures", "rustc_const_math",
+            "rustc_save_analysis", "build_helper", "rustc_back", "serialize", "rustc_trans",
+            "rustc_platform_intrinsics", "rustdoc", "flate", "syntax_ext", "rustc_lint",
+            "syntax_pos", "fmt_macros", "rustc_incremental", "syntax", "rustc_bitflags"
+        ).into_iter().collect();
+        assert_eq!(expected, trans);
+    }
+
+    #[test]
+    fn test_std_shim() {
+        let json = include_str!("std_shim.json");
+        let decoded = CargoMetadata::from_json(json).unwrap();
+        let resolve = decoded.resolve.as_ref().unwrap();
+        let root = resolve.root.name.as_str();
+        assert_eq!("std_shim", root);
+        let mut todo = vec!(root);
+        let mut trans = HashSet::new();
+        trans.insert(root);
+        while let Some(next) = todo.pop() {
+            let node = resolve.nodes.iter().find(|x| x.id.name == next).unwrap();
+            todo.extend(node.dependencies.iter().map(|x| x.name.as_str()));
+            trans.extend(node.dependencies.iter().map(|x| x.name.as_str()));
+        }
+        let expected: HashSet<&str> = vec!(
+            "std_shim", "rustc_unicode", "build_helper", "rand", "gcc", "libc", "panic_abort",
+            "std", "alloc_system", "collections", "compiler_builtins", "core", "unwind", "alloc",
+            "panic_unwind"
+        ).into_iter().collect();
+        assert_eq!(expected, trans);
+    }
+
+    #[test]
+    fn test_test_shim() {
+        let json = include_str!("test_shim.json");
+        let decoded = CargoMetadata::from_json(json).unwrap();
+        let resolve = decoded.resolve.as_ref().unwrap();
+        let root = resolve.root.name.as_str();
+        assert_eq!("test_shim", root);
+        let mut todo = vec!(root);
+        let mut trans = HashSet::new();
+        trans.insert(root);
+        while let Some(next) = todo.pop() {
+            let node = resolve.nodes.iter().find(|x| x.id.name == next).unwrap();
+            todo.extend(node.dependencies.iter().map(|x| x.name.as_str()));
+            trans.extend(node.dependencies.iter().map(|x| x.name.as_str()));
+        }
+        let expected: HashSet<&str> = vec!(
+            "test", "term", "getopts", "test_shim"
+        ).into_iter().collect();
+        assert_eq!(expected, trans);
+    }
+
+    #[test]
+    fn test_invalid_version() {
+        let json = r#"{ "version": 2 }"#;
+        assert!(CargoMetadata::from_json(json).is_err());
+    }
+}

--- a/src/metadata/no-deps.json
+++ b/src/metadata/no-deps.json
@@ -1,0 +1,35 @@
+{
+    "packages": [
+        {
+            "dependencies": [
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "rustc-serialize",
+                    "optional": false,
+                    "req": "^0.3",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "target": null,
+                    "uses_default_features": true
+                }
+            ],
+            "features": {},
+            "id": "cargo-metadata 0.1.0 (path+file:///home/user/cargo/src/metadata)",
+            "manifest_path": "/home/user/cargo/src/metadata/Cargo.toml",
+            "name": "cargo-metadata",
+            "source": null,
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "name": "cargo_metadata",
+                    "src_path": "lib.rs"
+                }
+            ],
+            "version": "0.1.0"
+        }
+    ],
+    "resolve": null,
+    "version": 1
+}

--- a/src/metadata/rustc.json
+++ b/src/metadata/rustc.json
@@ -1,0 +1,3196 @@
+{
+    "packages": [
+        {
+            "dependencies": [
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "rustc_borrowck",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "rustc_passes",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "rustc",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "rustc_trans",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "graphviz",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "rustc_privacy",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "rustc_resolve",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "serialize",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "rustc_metadata",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "rustc_typeck",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "rustc_lint",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "flate",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "arena",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "syntax_pos",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "syntax",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "proc_macro",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "rustc_incremental",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "log",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "rustc_mir",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "rustc_llvm",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "rustc_save_analysis",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "syntax_ext",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "rustc_plugin",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "rustc_back",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "rustc_errors",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "rustc_const_eval",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                }
+            ],
+            "features": {},
+            "id": "rustc_driver 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_driver)",
+            "manifest_path": "/Users/acharles/rust/rustc/src/src/librustc_driver/Cargo.toml",
+            "name": "rustc_driver",
+            "source": null,
+            "targets": [
+                {
+                    "kind": [
+                        "dylib"
+                    ],
+                    "name": "rustc_driver",
+                    "src_path": "lib.rs"
+                }
+            ],
+            "version": "0.0.0"
+        },
+        {
+            "dependencies": [
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "serialize",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "syntax",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "log",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                }
+            ],
+            "features": {
+                "jemalloc": []
+            },
+            "id": "rustc_back 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_back)",
+            "manifest_path": "/Users/acharles/rust/rustc/src/src/librustc_back/Cargo.toml",
+            "name": "rustc_back",
+            "source": null,
+            "targets": [
+                {
+                    "kind": [
+                        "dylib"
+                    ],
+                    "name": "rustc_back",
+                    "src_path": "lib.rs"
+                }
+            ],
+            "version": "0.0.0"
+        },
+        {
+            "dependencies": [
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "serialize",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "syntax_pos",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "log",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                }
+            ],
+            "features": {},
+            "id": "rustc_errors 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_errors)",
+            "manifest_path": "/Users/acharles/rust/rustc/src/src/librustc_errors/Cargo.toml",
+            "name": "rustc_errors",
+            "source": null,
+            "targets": [
+                {
+                    "kind": [
+                        "dylib"
+                    ],
+                    "name": "rustc_errors",
+                    "src_path": "lib.rs"
+                }
+            ],
+            "version": "0.0.0"
+        },
+        {
+            "dependencies": [
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "serialize",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "log",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                }
+            ],
+            "features": {},
+            "id": "rustc_data_structures 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_data_structures)",
+            "manifest_path": "/Users/acharles/rust/rustc/src/src/librustc_data_structures/Cargo.toml",
+            "name": "rustc_data_structures",
+            "source": null,
+            "targets": [
+                {
+                    "kind": [
+                        "dylib"
+                    ],
+                    "name": "rustc_data_structures",
+                    "src_path": "lib.rs"
+                }
+            ],
+            "version": "0.0.0"
+        },
+        {
+            "dependencies": [
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "rustc",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "fmt_macros",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "arena",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "syntax_pos",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "syntax",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "rustc_platform_intrinsics",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "log",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "rustc_back",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "rustc_errors",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "rustc_const_eval",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "rustc_const_math",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                }
+            ],
+            "features": {},
+            "id": "rustc_typeck 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_typeck)",
+            "manifest_path": "/Users/acharles/rust/rustc/src/src/librustc_typeck/Cargo.toml",
+            "name": "rustc_typeck",
+            "source": null,
+            "targets": [
+                {
+                    "kind": [
+                        "dylib"
+                    ],
+                    "name": "rustc_typeck",
+                    "src_path": "lib.rs"
+                }
+            ],
+            "version": "0.0.0"
+        },
+        {
+            "dependencies": [
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "rustc_bitflags",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "serialize",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "syntax_pos",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "log",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "rustc_errors",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                }
+            ],
+            "features": {},
+            "id": "syntax 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libsyntax)",
+            "manifest_path": "/Users/acharles/rust/rustc/src/src/libsyntax/Cargo.toml",
+            "name": "syntax",
+            "source": null,
+            "targets": [
+                {
+                    "kind": [
+                        "dylib"
+                    ],
+                    "name": "syntax",
+                    "src_path": "lib.rs"
+                }
+            ],
+            "version": "0.0.0"
+        },
+        {
+            "dependencies": [
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "rustc",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "serialize",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "rustc_data_structures",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "flate",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "syntax_pos",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "syntax",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "rustc_macro",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "log",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "rustc_llvm",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "syntax_ext",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "rustc_errors",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "rustc_back",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "rustc_const_math",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                }
+            ],
+            "features": {},
+            "id": "rustc_metadata 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_metadata)",
+            "manifest_path": "/Users/acharles/rust/rustc/src/src/librustc_metadata/Cargo.toml",
+            "name": "rustc_metadata",
+            "source": null,
+            "targets": [
+                {
+                    "kind": [
+                        "dylib"
+                    ],
+                    "name": "rustc_metadata",
+                    "src_path": "lib.rs"
+                }
+            ],
+            "version": "0.0.0"
+        },
+        {
+            "dependencies": [
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "syntax",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                }
+            ],
+            "features": {},
+            "id": "rustc_macro 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_macro)",
+            "manifest_path": "/Users/acharles/rust/rustc/src/src/librustc_macro/Cargo.toml",
+            "name": "rustc_macro",
+            "source": null,
+            "targets": [
+                {
+                    "kind": [
+                        "dylib"
+                    ],
+                    "name": "rustc_macro",
+                    "src_path": "lib.rs"
+                }
+            ],
+            "version": "0.0.0"
+        },
+        {
+            "dependencies": [
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "rustc",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "syntax_pos",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "syntax",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "log",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "rustc_errors",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "rustc_const_eval",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "rustc_const_math",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                }
+            ],
+            "features": {},
+            "id": "rustc_passes 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_passes)",
+            "manifest_path": "/Users/acharles/rust/rustc/src/src/librustc_passes/Cargo.toml",
+            "name": "rustc_passes",
+            "source": null,
+            "targets": [
+                {
+                    "kind": [
+                        "dylib"
+                    ],
+                    "name": "rustc_passes",
+                    "src_path": "lib.rs"
+                }
+            ],
+            "version": "0.0.0"
+        },
+        {
+            "dependencies": [
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "serialize",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "syntax",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "log",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                }
+            ],
+            "features": {},
+            "id": "rustc_const_math 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_const_math)",
+            "manifest_path": "/Users/acharles/rust/rustc/src/src/librustc_const_math/Cargo.toml",
+            "name": "rustc_const_math",
+            "source": null,
+            "targets": [
+                {
+                    "kind": [
+                        "dylib"
+                    ],
+                    "name": "rustc_const_math",
+                    "src_path": "lib.rs"
+                }
+            ],
+            "version": "0.0.0"
+        },
+        {
+            "dependencies": [
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "rustc_bitflags",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "graphviz",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "serialize",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "fmt_macros",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "rustc_data_structures",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "flate",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "arena",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "syntax_pos",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "syntax",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "log",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "rustc_llvm",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "rustc_back",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "rustc_errors",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "rustc_const_math",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                }
+            ],
+            "features": {},
+            "id": "rustc 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc)",
+            "manifest_path": "/Users/acharles/rust/rustc/src/src/librustc/Cargo.toml",
+            "name": "rustc",
+            "source": null,
+            "targets": [
+                {
+                    "kind": [
+                        "dylib"
+                    ],
+                    "name": "rustc",
+                    "src_path": "lib.rs"
+                }
+            ],
+            "version": "0.0.0"
+        },
+        {
+            "dependencies": [],
+            "features": {},
+            "id": "fmt_macros 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libfmt_macros)",
+            "manifest_path": "/Users/acharles/rust/rustc/src/src/libfmt_macros/Cargo.toml",
+            "name": "fmt_macros",
+            "source": null,
+            "targets": [
+                {
+                    "kind": [
+                        "dylib"
+                    ],
+                    "name": "fmt_macros",
+                    "src_path": "lib.rs"
+                }
+            ],
+            "version": "0.0.0"
+        },
+        {
+            "dependencies": [
+                {
+                    "features": [],
+                    "kind": "dev",
+                    "name": "tempdir",
+                    "optional": false,
+                    "req": "^0.3",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "target": null,
+                    "uses_default_features": true
+                }
+            ],
+            "features": {},
+            "id": "gcc 0.3.28 (registry+https://github.com/rust-lang/crates.io-index)",
+            "manifest_path": "/Users/acharles/.cargo/registry/src/github.com-1ecc6299db9ec823/gcc-0.3.28/Cargo.toml",
+            "name": "gcc",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "name": "gcc",
+                    "src_path": "/Users/acharles/.cargo/registry/src/github.com-1ecc6299db9ec823/gcc-0.3.28/src/lib.rs"
+                },
+                {
+                    "kind": [
+                        "bin"
+                    ],
+                    "name": "gcc-shim",
+                    "src_path": "/Users/acharles/.cargo/registry/src/github.com-1ecc6299db9ec823/gcc-0.3.28/src/bin/gcc-shim.rs"
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "name": "cc_env",
+                    "src_path": "/Users/acharles/.cargo/registry/src/github.com-1ecc6299db9ec823/gcc-0.3.28/tests/cc_env.rs"
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "name": "test",
+                    "src_path": "/Users/acharles/.cargo/registry/src/github.com-1ecc6299db9ec823/gcc-0.3.28/tests/test.rs"
+                }
+            ],
+            "version": "0.3.28"
+        },
+        {
+            "dependencies": [],
+            "features": {},
+            "id": "graphviz 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libgraphviz)",
+            "manifest_path": "/Users/acharles/rust/rustc/src/src/libgraphviz/Cargo.toml",
+            "name": "graphviz",
+            "source": null,
+            "targets": [
+                {
+                    "kind": [
+                        "dylib"
+                    ],
+                    "name": "graphviz",
+                    "src_path": "lib.rs"
+                }
+            ],
+            "version": "0.0.0"
+        },
+        {
+            "dependencies": [
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "rustc",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "rustc_trans",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "rustc_resolve",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "serialize",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "rustc_metadata",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "rustc_data_structures",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "rustc_lint",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "arena",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "syntax_pos",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "syntax",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "log",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "rustc_driver",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "rustc_back",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "rustc_errors",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "rustc_const_eval",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "rustc_const_math",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": "build",
+                    "name": "build_helper",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": "build",
+                    "name": "gcc",
+                    "optional": false,
+                    "req": "^0.3.27",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "target": null,
+                    "uses_default_features": true
+                }
+            ],
+            "features": {},
+            "id": "rustdoc 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustdoc)",
+            "manifest_path": "/Users/acharles/rust/rustc/src/src/librustdoc/Cargo.toml",
+            "name": "rustdoc",
+            "source": null,
+            "targets": [
+                {
+                    "kind": [
+                        "dylib"
+                    ],
+                    "name": "rustdoc",
+                    "src_path": "lib.rs"
+                },
+                {
+                    "kind": [
+                        "custom-build"
+                    ],
+                    "name": "build-script-build",
+                    "src_path": "build.rs"
+                }
+            ],
+            "version": "0.0.0"
+        },
+        {
+            "dependencies": [
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "rustc_bitflags",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": "build",
+                    "name": "build_helper",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": "build",
+                    "name": "gcc",
+                    "optional": false,
+                    "req": "^0.3.27",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "target": null,
+                    "uses_default_features": true
+                }
+            ],
+            "features": {
+                "static-libstdcpp": []
+            },
+            "id": "rustc_llvm 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_llvm)",
+            "manifest_path": "/Users/acharles/rust/rustc/src/src/librustc_llvm/Cargo.toml",
+            "name": "rustc_llvm",
+            "source": null,
+            "targets": [
+                {
+                    "kind": [
+                        "dylib"
+                    ],
+                    "name": "rustc_llvm",
+                    "src_path": "lib.rs"
+                },
+                {
+                    "kind": [
+                        "custom-build"
+                    ],
+                    "name": "build-script-build",
+                    "src_path": "build.rs"
+                }
+            ],
+            "version": "0.0.0"
+        },
+        {
+            "dependencies": [],
+            "features": {},
+            "id": "rustc_platform_intrinsics 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_platform_intrinsics)",
+            "manifest_path": "/Users/acharles/rust/rustc/src/src/librustc_platform_intrinsics/Cargo.toml",
+            "name": "rustc_platform_intrinsics",
+            "source": null,
+            "targets": [
+                {
+                    "kind": [
+                        "dylib"
+                    ],
+                    "name": "rustc_platform_intrinsics",
+                    "src_path": "lib.rs"
+                }
+            ],
+            "version": "0.0.0"
+        },
+        {
+            "dependencies": [
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "rustc",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "graphviz",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "serialize",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "rustc_data_structures",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "flate",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "arena",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "syntax_pos",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "syntax",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "rustc_platform_intrinsics",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "rustc_incremental",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "log",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "rustc_llvm",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "rustc_back",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "rustc_errors",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "rustc_const_eval",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "rustc_const_math",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                }
+            ],
+            "features": {},
+            "id": "rustc_trans 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_trans)",
+            "manifest_path": "/Users/acharles/rust/rustc/src/src/librustc_trans/Cargo.toml",
+            "name": "rustc_trans",
+            "source": null,
+            "targets": [
+                {
+                    "kind": [
+                        "dylib"
+                    ],
+                    "name": "rustc_trans",
+                    "src_path": "lib.rs"
+                }
+            ],
+            "version": "0.0.0"
+        },
+        {
+            "dependencies": [
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "syntax_pos",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "syntax",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "log",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "rustc_plugin",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                }
+            ],
+            "features": {},
+            "id": "proc_macro 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libproc_macro)",
+            "manifest_path": "/Users/acharles/rust/rustc/src/src/libproc_macro/Cargo.toml",
+            "name": "proc_macro",
+            "source": null,
+            "targets": [
+                {
+                    "kind": [
+                        "dylib"
+                    ],
+                    "name": "proc_macro",
+                    "src_path": "lib.rs"
+                }
+            ],
+            "version": "0.0.0"
+        },
+        {
+            "dependencies": [],
+            "features": {},
+            "id": "log 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/liblog)",
+            "manifest_path": "/Users/acharles/rust/rustc/src/src/liblog/Cargo.toml",
+            "name": "log",
+            "source": null,
+            "targets": [
+                {
+                    "kind": [
+                        "dylib",
+                        "rlib"
+                    ],
+                    "name": "log",
+                    "src_path": "lib.rs"
+                }
+            ],
+            "version": "0.0.0"
+        },
+        {
+            "dependencies": [
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "rustc_bitflags",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "rustc",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "graphviz",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "rustc_data_structures",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "syntax_pos",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "syntax",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "log",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "rustc_back",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "rustc_const_eval",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "rustc_const_math",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                }
+            ],
+            "features": {},
+            "id": "rustc_mir 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_mir)",
+            "manifest_path": "/Users/acharles/rust/rustc/src/src/librustc_mir/Cargo.toml",
+            "name": "rustc_mir",
+            "source": null,
+            "targets": [
+                {
+                    "kind": [
+                        "dylib"
+                    ],
+                    "name": "rustc_mir",
+                    "src_path": "lib.rs"
+                }
+            ],
+            "version": "0.0.0"
+        },
+        {
+            "dependencies": [
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "serialize",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                }
+            ],
+            "features": {},
+            "id": "syntax_pos 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libsyntax_pos)",
+            "manifest_path": "/Users/acharles/rust/rustc/src/src/libsyntax_pos/Cargo.toml",
+            "name": "syntax_pos",
+            "source": null,
+            "targets": [
+                {
+                    "kind": [
+                        "dylib"
+                    ],
+                    "name": "syntax_pos",
+                    "src_path": "lib.rs"
+                }
+            ],
+            "version": "0.0.0"
+        },
+        {
+            "dependencies": [
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "rustc_bitflags",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "rustc",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "rustc_metadata",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "syntax_pos",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "syntax",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "log",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "rustc_back",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "rustc_errors",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                }
+            ],
+            "features": {},
+            "id": "rustc_plugin 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_plugin)",
+            "manifest_path": "/Users/acharles/rust/rustc/src/src/librustc_plugin/Cargo.toml",
+            "name": "rustc_plugin",
+            "source": null,
+            "targets": [
+                {
+                    "kind": [
+                        "dylib"
+                    ],
+                    "name": "rustc_plugin",
+                    "src_path": "lib.rs"
+                }
+            ],
+            "version": "0.0.0"
+        },
+        {
+            "dependencies": [
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "rustc",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "serialize",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "syntax_pos",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "syntax",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "log",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                }
+            ],
+            "features": {},
+            "id": "rustc_save_analysis 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_save_analysis)",
+            "manifest_path": "/Users/acharles/rust/rustc/src/src/librustc_save_analysis/Cargo.toml",
+            "name": "rustc_save_analysis",
+            "source": null,
+            "targets": [
+                {
+                    "kind": [
+                        "dylib"
+                    ],
+                    "name": "rustc_save_analysis",
+                    "src_path": "lib.rs"
+                }
+            ],
+            "version": "0.0.0"
+        },
+        {
+            "dependencies": [
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "log",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                }
+            ],
+            "features": {},
+            "id": "serialize 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libserialize)",
+            "manifest_path": "/Users/acharles/rust/rustc/src/src/libserialize/Cargo.toml",
+            "name": "serialize",
+            "source": null,
+            "targets": [
+                {
+                    "kind": [
+                        "dylib",
+                        "rlib"
+                    ],
+                    "name": "serialize",
+                    "src_path": "lib.rs"
+                }
+            ],
+            "version": "0.0.0"
+        },
+        {
+            "dependencies": [
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "rustc",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "arena",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "syntax_pos",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "syntax",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "log",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "rustc_errors",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                }
+            ],
+            "features": {},
+            "id": "rustc_resolve 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_resolve)",
+            "manifest_path": "/Users/acharles/rust/rustc/src/src/librustc_resolve/Cargo.toml",
+            "name": "rustc_resolve",
+            "source": null,
+            "targets": [
+                {
+                    "kind": [
+                        "dylib"
+                    ],
+                    "name": "rustc_resolve",
+                    "src_path": "lib.rs"
+                }
+            ],
+            "version": "0.0.0"
+        },
+        {
+            "dependencies": [
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "rustc",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "syntax_pos",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "syntax",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "log",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "rustc_back",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "rustc_const_eval",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                }
+            ],
+            "features": {},
+            "id": "rustc_lint 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_lint)",
+            "manifest_path": "/Users/acharles/rust/rustc/src/src/librustc_lint/Cargo.toml",
+            "name": "rustc_lint",
+            "source": null,
+            "targets": [
+                {
+                    "kind": [
+                        "dylib"
+                    ],
+                    "name": "rustc_lint",
+                    "src_path": "lib.rs"
+                }
+            ],
+            "version": "0.0.0"
+        },
+        {
+            "dependencies": [
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "rustc",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "graphviz",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "serialize",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "rustc_data_structures",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "syntax_pos",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "syntax",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "log",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                }
+            ],
+            "features": {},
+            "id": "rustc_incremental 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_incremental)",
+            "manifest_path": "/Users/acharles/rust/rustc/src/src/librustc_incremental/Cargo.toml",
+            "name": "rustc_incremental",
+            "source": null,
+            "targets": [
+                {
+                    "kind": [
+                        "dylib"
+                    ],
+                    "name": "rustc_incremental",
+                    "src_path": "lib.rs"
+                }
+            ],
+            "version": "0.0.0"
+        },
+        {
+            "dependencies": [
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "rustdoc",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "rustc_driver",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "rustc_back",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                }
+            ],
+            "features": {
+                "jemalloc": [
+                    "rustc_back/jemalloc"
+                ]
+            },
+            "id": "rustc-main 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/rustc)",
+            "manifest_path": "/Users/acharles/rust/rustc/src/src/rustc/Cargo.toml",
+            "name": "rustc-main",
+            "source": null,
+            "targets": [
+                {
+                    "kind": [
+                        "bin"
+                    ],
+                    "name": "rustc",
+                    "src_path": "rustc.rs"
+                },
+                {
+                    "kind": [
+                        "bin"
+                    ],
+                    "name": "rustdoc",
+                    "src_path": "rustdoc.rs"
+                }
+            ],
+            "version": "0.0.0"
+        },
+        {
+            "dependencies": [
+                {
+                    "features": [],
+                    "kind": "build",
+                    "name": "build_helper",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": "build",
+                    "name": "gcc",
+                    "optional": false,
+                    "req": "^0.3.27",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "target": null,
+                    "uses_default_features": true
+                }
+            ],
+            "features": {},
+            "id": "flate 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libflate)",
+            "manifest_path": "/Users/acharles/rust/rustc/src/src/libflate/Cargo.toml",
+            "name": "flate",
+            "source": null,
+            "targets": [
+                {
+                    "kind": [
+                        "dylib"
+                    ],
+                    "name": "flate",
+                    "src_path": "lib.rs"
+                },
+                {
+                    "kind": [
+                        "custom-build"
+                    ],
+                    "name": "build-script-build",
+                    "src_path": "build.rs"
+                }
+            ],
+            "version": "0.0.0"
+        },
+        {
+            "dependencies": [],
+            "features": {},
+            "id": "arena 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libarena)",
+            "manifest_path": "/Users/acharles/rust/rustc/src/src/libarena/Cargo.toml",
+            "name": "arena",
+            "source": null,
+            "targets": [
+                {
+                    "kind": [
+                        "dylib"
+                    ],
+                    "name": "arena",
+                    "src_path": "lib.rs"
+                }
+            ],
+            "version": "0.0.0"
+        },
+        {
+            "dependencies": [
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "rustc",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "graphviz",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "rustc_data_structures",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "syntax_pos",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "syntax",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "log",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "rustc_mir",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "rustc_errors",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                }
+            ],
+            "features": {},
+            "id": "rustc_borrowck 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_borrowck)",
+            "manifest_path": "/Users/acharles/rust/rustc/src/src/librustc_borrowck/Cargo.toml",
+            "name": "rustc_borrowck",
+            "source": null,
+            "targets": [
+                {
+                    "kind": [
+                        "dylib"
+                    ],
+                    "name": "rustc_borrowck",
+                    "src_path": "lib.rs"
+                }
+            ],
+            "version": "0.0.0"
+        },
+        {
+            "dependencies": [
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "rustc",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "graphviz",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "serialize",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "syntax_pos",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "syntax",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "log",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "rustc_back",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "rustc_errors",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "rustc_const_math",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                }
+            ],
+            "features": {},
+            "id": "rustc_const_eval 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_const_eval)",
+            "manifest_path": "/Users/acharles/rust/rustc/src/src/librustc_const_eval/Cargo.toml",
+            "name": "rustc_const_eval",
+            "source": null,
+            "targets": [
+                {
+                    "kind": [
+                        "dylib"
+                    ],
+                    "name": "rustc_const_eval",
+                    "src_path": "lib.rs"
+                }
+            ],
+            "version": "0.0.0"
+        },
+        {
+            "dependencies": [],
+            "features": {},
+            "id": "rustc_bitflags 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_bitflags)",
+            "manifest_path": "/Users/acharles/rust/rustc/src/src/librustc_bitflags/Cargo.toml",
+            "name": "rustc_bitflags",
+            "source": null,
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "name": "rustc_bitflags",
+                    "src_path": "lib.rs"
+                }
+            ],
+            "version": "0.0.0"
+        },
+        {
+            "dependencies": [],
+            "features": {},
+            "id": "build_helper 0.1.0 (path+file:///Users/acharles/rust/rustc/src/src/build_helper)",
+            "manifest_path": "/Users/acharles/rust/rustc/src/src/build_helper/Cargo.toml",
+            "name": "build_helper",
+            "source": null,
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "name": "build_helper",
+                    "src_path": "lib.rs"
+                }
+            ],
+            "version": "0.1.0"
+        },
+        {
+            "dependencies": [
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "rustc",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "syntax_pos",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "syntax",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                }
+            ],
+            "features": {},
+            "id": "rustc_privacy 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_privacy)",
+            "manifest_path": "/Users/acharles/rust/rustc/src/src/librustc_privacy/Cargo.toml",
+            "name": "rustc_privacy",
+            "source": null,
+            "targets": [
+                {
+                    "kind": [
+                        "dylib"
+                    ],
+                    "name": "rustc_privacy",
+                    "src_path": "lib.rs"
+                }
+            ],
+            "version": "0.0.0"
+        },
+        {
+            "dependencies": [
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "fmt_macros",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "syntax_pos",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "syntax",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "rustc_macro",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "log",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "rustc_errors",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                }
+            ],
+            "features": {},
+            "id": "syntax_ext 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libsyntax_ext)",
+            "manifest_path": "/Users/acharles/rust/rustc/src/src/libsyntax_ext/Cargo.toml",
+            "name": "syntax_ext",
+            "source": null,
+            "targets": [
+                {
+                    "kind": [
+                        "dylib"
+                    ],
+                    "name": "syntax_ext",
+                    "src_path": "lib.rs"
+                }
+            ],
+            "version": "0.0.0"
+        }
+    ],
+    "resolve": {
+        "nodes": [
+            {
+                "dependencies": [
+                    "log 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/liblog)",
+                    "rustc_mir 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_mir)",
+                    "rustc_back 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_back)",
+                    "rustc_errors 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_errors)",
+                    "syntax_pos 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libsyntax_pos)",
+                    "rustc_save_analysis 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_save_analysis)",
+                    "rustc_plugin 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_plugin)",
+                    "rustc_typeck 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_typeck)",
+                    "serialize 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libserialize)",
+                    "rustc_metadata 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_metadata)",
+                    "syntax 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libsyntax)",
+                    "rustc_resolve 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_resolve)",
+                    "rustc_lint 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_lint)",
+                    "rustc_passes 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_passes)",
+                    "rustc 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc)",
+                    "graphviz 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libgraphviz)",
+                    "rustc_incremental 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_incremental)",
+                    "flate 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libflate)",
+                    "rustc_llvm 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_llvm)",
+                    "arena 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libarena)",
+                    "rustc_borrowck 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_borrowck)",
+                    "rustc_const_eval 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_const_eval)",
+                    "rustc_trans 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_trans)",
+                    "rustc_privacy 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_privacy)",
+                    "proc_macro 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libproc_macro)",
+                    "syntax_ext 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libsyntax_ext)"
+                ],
+                "id": "rustc_driver 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_driver)"
+            },
+            {
+                "dependencies": [
+                    "serialize 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libserialize)",
+                    "syntax 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libsyntax)",
+                    "log 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/liblog)"
+                ],
+                "id": "rustc_back 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_back)"
+            },
+            {
+                "dependencies": [
+                    "syntax_pos 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libsyntax_pos)",
+                    "serialize 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libserialize)",
+                    "log 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/liblog)"
+                ],
+                "id": "rustc_errors 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_errors)"
+            },
+            {
+                "dependencies": [
+                    "serialize 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libserialize)",
+                    "log 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/liblog)"
+                ],
+                "id": "rustc_data_structures 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_data_structures)"
+            },
+            {
+                "dependencies": [
+                    "rustc_back 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_back)",
+                    "rustc_errors 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_errors)",
+                    "syntax_pos 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libsyntax_pos)",
+                    "syntax 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libsyntax)",
+                    "rustc 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc)",
+                    "rustc_const_math 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_const_math)",
+                    "fmt_macros 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libfmt_macros)",
+                    "rustc_platform_intrinsics 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_platform_intrinsics)",
+                    "arena 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libarena)",
+                    "rustc_const_eval 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_const_eval)",
+                    "log 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/liblog)"
+                ],
+                "id": "rustc_typeck 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_typeck)"
+            },
+            {
+                "dependencies": [
+                    "rustc_errors 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_errors)",
+                    "syntax_pos 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libsyntax_pos)",
+                    "serialize 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libserialize)",
+                    "rustc_bitflags 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_bitflags)",
+                    "log 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/liblog)"
+                ],
+                "id": "syntax 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libsyntax)"
+            },
+            {
+                "dependencies": [
+                    "rustc_back 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_back)",
+                    "rustc_errors 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_errors)",
+                    "syntax_pos 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libsyntax_pos)",
+                    "serialize 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libserialize)",
+                    "rustc_data_structures 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_data_structures)",
+                    "syntax 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libsyntax)",
+                    "rustc_macro 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_macro)",
+                    "rustc 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc)",
+                    "rustc_const_math 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_const_math)",
+                    "flate 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libflate)",
+                    "rustc_llvm 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_llvm)",
+                    "syntax_ext 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libsyntax_ext)",
+                    "log 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/liblog)"
+                ],
+                "id": "rustc_metadata 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_metadata)"
+            },
+            {
+                "dependencies": [
+                    "syntax 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libsyntax)"
+                ],
+                "id": "rustc_macro 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_macro)"
+            },
+            {
+                "dependencies": [
+                    "rustc_errors 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_errors)",
+                    "syntax_pos 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libsyntax_pos)",
+                    "syntax 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libsyntax)",
+                    "rustc 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc)",
+                    "rustc_const_math 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_const_math)",
+                    "rustc_const_eval 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_const_eval)",
+                    "log 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/liblog)"
+                ],
+                "id": "rustc_passes 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_passes)"
+            },
+            {
+                "dependencies": [
+                    "serialize 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libserialize)",
+                    "syntax 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libsyntax)",
+                    "log 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/liblog)"
+                ],
+                "id": "rustc_const_math 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_const_math)"
+            },
+            {
+                "dependencies": [
+                    "rustc_back 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_back)",
+                    "rustc_errors 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_errors)",
+                    "syntax_pos 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libsyntax_pos)",
+                    "serialize 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libserialize)",
+                    "rustc_data_structures 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_data_structures)",
+                    "syntax 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libsyntax)",
+                    "rustc_const_math 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_const_math)",
+                    "fmt_macros 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libfmt_macros)",
+                    "graphviz 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libgraphviz)",
+                    "flate 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libflate)",
+                    "rustc_llvm 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_llvm)",
+                    "arena 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libarena)",
+                    "rustc_bitflags 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_bitflags)",
+                    "log 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/liblog)"
+                ],
+                "id": "rustc 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc)"
+            },
+            {
+                "dependencies": [],
+                "id": "fmt_macros 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libfmt_macros)"
+            },
+            {
+                "dependencies": [],
+                "id": "gcc 0.3.28 (registry+https://github.com/rust-lang/crates.io-index)"
+            },
+            {
+                "dependencies": [],
+                "id": "graphviz 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libgraphviz)"
+            },
+            {
+                "dependencies": [
+                    "rustc_driver 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_driver)",
+                    "rustc_back 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_back)",
+                    "rustc_errors 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_errors)",
+                    "syntax_pos 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libsyntax_pos)",
+                    "serialize 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libserialize)",
+                    "rustc_data_structures 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_data_structures)",
+                    "rustc_resolve 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_resolve)",
+                    "rustc_metadata 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_metadata)",
+                    "syntax 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libsyntax)",
+                    "rustc_lint 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_lint)",
+                    "rustc 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc)",
+                    "rustc_const_math 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_const_math)",
+                    "gcc 0.3.28 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "arena 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libarena)",
+                    "rustc_const_eval 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_const_eval)",
+                    "rustc_trans 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_trans)",
+                    "build_helper 0.1.0 (path+file:///Users/acharles/rust/rustc/src/src/build_helper)",
+                    "log 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/liblog)"
+                ],
+                "id": "rustdoc 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustdoc)"
+            },
+            {
+                "dependencies": [
+                    "gcc 0.3.28 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "rustc_bitflags 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_bitflags)",
+                    "build_helper 0.1.0 (path+file:///Users/acharles/rust/rustc/src/src/build_helper)"
+                ],
+                "id": "rustc_llvm 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_llvm)"
+            },
+            {
+                "dependencies": [],
+                "id": "rustc_platform_intrinsics 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_platform_intrinsics)"
+            },
+            {
+                "dependencies": [
+                    "rustc_back 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_back)",
+                    "rustc_errors 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_errors)",
+                    "syntax_pos 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libsyntax_pos)",
+                    "serialize 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libserialize)",
+                    "rustc_data_structures 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_data_structures)",
+                    "syntax 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libsyntax)",
+                    "rustc 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc)",
+                    "rustc_const_math 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_const_math)",
+                    "graphviz 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libgraphviz)",
+                    "rustc_incremental 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_incremental)",
+                    "flate 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libflate)",
+                    "rustc_platform_intrinsics 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_platform_intrinsics)",
+                    "rustc_llvm 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_llvm)",
+                    "arena 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libarena)",
+                    "rustc_const_eval 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_const_eval)",
+                    "log 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/liblog)"
+                ],
+                "id": "rustc_trans 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_trans)"
+            },
+            {
+                "dependencies": [
+                    "syntax_pos 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libsyntax_pos)",
+                    "rustc_plugin 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_plugin)",
+                    "syntax 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libsyntax)",
+                    "log 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/liblog)"
+                ],
+                "id": "proc_macro 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libproc_macro)"
+            },
+            {
+                "dependencies": [],
+                "id": "log 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/liblog)"
+            },
+            {
+                "dependencies": [
+                    "rustc_back 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_back)",
+                    "syntax_pos 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libsyntax_pos)",
+                    "rustc_data_structures 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_data_structures)",
+                    "syntax 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libsyntax)",
+                    "rustc 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc)",
+                    "rustc_const_math 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_const_math)",
+                    "graphviz 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libgraphviz)",
+                    "rustc_const_eval 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_const_eval)",
+                    "rustc_bitflags 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_bitflags)",
+                    "log 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/liblog)"
+                ],
+                "id": "rustc_mir 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_mir)"
+            },
+            {
+                "dependencies": [
+                    "serialize 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libserialize)"
+                ],
+                "id": "syntax_pos 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libsyntax_pos)"
+            },
+            {
+                "dependencies": [
+                    "rustc_back 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_back)",
+                    "rustc_errors 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_errors)",
+                    "syntax_pos 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libsyntax_pos)",
+                    "rustc_metadata 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_metadata)",
+                    "syntax 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libsyntax)",
+                    "rustc 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc)",
+                    "rustc_bitflags 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_bitflags)",
+                    "log 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/liblog)"
+                ],
+                "id": "rustc_plugin 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_plugin)"
+            },
+            {
+                "dependencies": [
+                    "syntax_pos 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libsyntax_pos)",
+                    "serialize 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libserialize)",
+                    "syntax 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libsyntax)",
+                    "rustc 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc)",
+                    "log 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/liblog)"
+                ],
+                "id": "rustc_save_analysis 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_save_analysis)"
+            },
+            {
+                "dependencies": [
+                    "log 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/liblog)"
+                ],
+                "id": "serialize 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libserialize)"
+            },
+            {
+                "dependencies": [
+                    "rustc_errors 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_errors)",
+                    "syntax_pos 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libsyntax_pos)",
+                    "syntax 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libsyntax)",
+                    "rustc 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc)",
+                    "arena 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libarena)",
+                    "log 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/liblog)"
+                ],
+                "id": "rustc_resolve 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_resolve)"
+            },
+            {
+                "dependencies": [
+                    "rustc_back 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_back)",
+                    "syntax_pos 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libsyntax_pos)",
+                    "syntax 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libsyntax)",
+                    "rustc 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc)",
+                    "rustc_const_eval 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_const_eval)",
+                    "log 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/liblog)"
+                ],
+                "id": "rustc_lint 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_lint)"
+            },
+            {
+                "dependencies": [
+                    "syntax_pos 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libsyntax_pos)",
+                    "serialize 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libserialize)",
+                    "rustc_data_structures 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_data_structures)",
+                    "syntax 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libsyntax)",
+                    "rustc 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc)",
+                    "graphviz 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libgraphviz)",
+                    "log 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/liblog)"
+                ],
+                "id": "rustc_incremental 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_incremental)"
+            },
+            {
+                "dependencies": [
+                    "rustc_driver 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_driver)",
+                    "rustc_back 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_back)",
+                    "rustdoc 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustdoc)"
+                ],
+                "id": "rustc-main 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/rustc)"
+            },
+            {
+                "dependencies": [
+                    "gcc 0.3.28 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "build_helper 0.1.0 (path+file:///Users/acharles/rust/rustc/src/src/build_helper)"
+                ],
+                "id": "flate 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libflate)"
+            },
+            {
+                "dependencies": [],
+                "id": "arena 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libarena)"
+            },
+            {
+                "dependencies": [
+                    "rustc_mir 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_mir)",
+                    "rustc_errors 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_errors)",
+                    "syntax_pos 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libsyntax_pos)",
+                    "rustc_data_structures 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_data_structures)",
+                    "syntax 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libsyntax)",
+                    "rustc 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc)",
+                    "graphviz 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libgraphviz)",
+                    "log 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/liblog)"
+                ],
+                "id": "rustc_borrowck 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_borrowck)"
+            },
+            {
+                "dependencies": [
+                    "rustc_back 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_back)",
+                    "rustc_errors 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_errors)",
+                    "syntax_pos 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libsyntax_pos)",
+                    "serialize 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libserialize)",
+                    "syntax 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libsyntax)",
+                    "rustc 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc)",
+                    "rustc_const_math 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_const_math)",
+                    "graphviz 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libgraphviz)",
+                    "log 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/liblog)"
+                ],
+                "id": "rustc_const_eval 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_const_eval)"
+            },
+            {
+                "dependencies": [],
+                "id": "rustc_bitflags 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_bitflags)"
+            },
+            {
+                "dependencies": [],
+                "id": "build_helper 0.1.0 (path+file:///Users/acharles/rust/rustc/src/src/build_helper)"
+            },
+            {
+                "dependencies": [
+                    "syntax_pos 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libsyntax_pos)",
+                    "syntax 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libsyntax)",
+                    "rustc 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc)"
+                ],
+                "id": "rustc_privacy 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_privacy)"
+            },
+            {
+                "dependencies": [
+                    "rustc_errors 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_errors)",
+                    "syntax_pos 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libsyntax_pos)",
+                    "syntax 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libsyntax)",
+                    "rustc_macro 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_macro)",
+                    "fmt_macros 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libfmt_macros)",
+                    "log 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/liblog)"
+                ],
+                "id": "syntax_ext 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libsyntax_ext)"
+            }
+        ],
+        "root": "rustc-main 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/rustc)"
+    },
+    "version": 1
+}

--- a/src/metadata/std_shim.json
+++ b/src/metadata/std_shim.json
@@ -1,0 +1,841 @@
+{
+    "packages": [
+        {
+            "dependencies": [
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "core",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": "build",
+                    "name": "gcc",
+                    "optional": false,
+                    "req": "^0.3.27",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "target": null,
+                    "uses_default_features": true
+                }
+            ],
+            "features": {},
+            "id": "compiler_builtins 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libcompiler_builtins)",
+            "manifest_path": "/Users/acharles/rust/rustc/src/src/libcompiler_builtins/Cargo.toml",
+            "name": "compiler_builtins",
+            "source": null,
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "name": "compiler_builtins",
+                    "src_path": "lib.rs"
+                },
+                {
+                    "kind": [
+                        "custom-build"
+                    ],
+                    "name": "build-script-build",
+                    "src_path": "build.rs"
+                }
+            ],
+            "version": "0.0.0"
+        },
+        {
+            "dependencies": [
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "core",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                }
+            ],
+            "features": {},
+            "id": "alloc 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/liballoc)",
+            "manifest_path": "/Users/acharles/rust/rustc/src/src/liballoc/Cargo.toml",
+            "name": "alloc",
+            "source": null,
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "name": "alloc",
+                    "src_path": "lib.rs"
+                }
+            ],
+            "version": "0.0.0"
+        },
+        {
+            "dependencies": [
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "core",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "alloc",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "unwind",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "libc",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                }
+            ],
+            "features": {},
+            "id": "panic_unwind 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libpanic_unwind)",
+            "manifest_path": "/Users/acharles/rust/rustc/src/src/libpanic_unwind/Cargo.toml",
+            "name": "panic_unwind",
+            "source": null,
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "name": "panic_unwind",
+                    "src_path": "lib.rs"
+                }
+            ],
+            "version": "0.0.0"
+        },
+        {
+            "dependencies": [
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "panic_abort",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "core",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "collections",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "alloc",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "rand",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "rustc_unicode",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "unwind",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "alloc_system",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "panic_unwind",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "alloc_jemalloc",
+                    "optional": true,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "compiler_builtins",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "libc",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": "build",
+                    "name": "build_helper",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": "build",
+                    "name": "gcc",
+                    "optional": false,
+                    "req": "^0.3.27",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "target": null,
+                    "uses_default_features": true
+                }
+            ],
+            "features": {
+                "backtrace": [],
+                "debug-jemalloc": [
+                    "alloc_jemalloc/debug"
+                ],
+                "jemalloc": [
+                    "alloc_jemalloc"
+                ]
+            },
+            "id": "std 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libstd)",
+            "manifest_path": "/Users/acharles/rust/rustc/src/src/libstd/Cargo.toml",
+            "name": "std",
+            "source": null,
+            "targets": [
+                {
+                    "kind": [
+                        "dylib",
+                        "rlib"
+                    ],
+                    "name": "std",
+                    "src_path": "lib.rs"
+                },
+                {
+                    "kind": [
+                        "custom-build"
+                    ],
+                    "name": "build-script-build",
+                    "src_path": "build.rs"
+                }
+            ],
+            "version": "0.0.0"
+        },
+        {
+            "dependencies": [
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "core",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "libc",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                }
+            ],
+            "features": {},
+            "id": "unwind 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libunwind)",
+            "manifest_path": "/Users/acharles/rust/rustc/src/src/libunwind/Cargo.toml",
+            "name": "unwind",
+            "source": null,
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "name": "unwind",
+                    "src_path": "lib.rs"
+                },
+                {
+                    "kind": [
+                        "custom-build"
+                    ],
+                    "name": "build-script-build",
+                    "src_path": "build.rs"
+                }
+            ],
+            "version": "0.0.0"
+        },
+        {
+            "dependencies": [
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "core",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "std",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                }
+            ],
+            "features": {
+                "backtrace": [
+                    "std/backtrace"
+                ],
+                "debug-jemalloc": [
+                    "std/debug-jemalloc"
+                ],
+                "jemalloc": [
+                    "std/jemalloc"
+                ]
+            },
+            "id": "std_shim 0.1.0 (path+file:///Users/acharles/rust/rustc/src/src/rustc/std_shim)",
+            "manifest_path": "/Users/acharles/rust/rustc/src/src/rustc/std_shim/Cargo.toml",
+            "name": "std_shim",
+            "source": null,
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "name": "std_shim",
+                    "src_path": "lib.rs"
+                }
+            ],
+            "version": "0.1.0"
+        },
+        {
+            "dependencies": [
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "core",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                }
+            ],
+            "features": {},
+            "id": "rand 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librand)",
+            "manifest_path": "/Users/acharles/rust/rustc/src/src/librand/Cargo.toml",
+            "name": "rand",
+            "source": null,
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "name": "rand",
+                    "src_path": "lib.rs"
+                }
+            ],
+            "version": "0.0.0"
+        },
+        {
+            "dependencies": [
+                {
+                    "features": [],
+                    "kind": "dev",
+                    "name": "tempdir",
+                    "optional": false,
+                    "req": "^0.3",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "target": null,
+                    "uses_default_features": true
+                }
+            ],
+            "features": {},
+            "id": "gcc 0.3.27 (registry+https://github.com/rust-lang/crates.io-index)",
+            "manifest_path": "/Users/acharles/.cargo/registry/src/github.com-1ecc6299db9ec823/gcc-0.3.27/Cargo.toml",
+            "name": "gcc",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "name": "gcc",
+                    "src_path": "/Users/acharles/.cargo/registry/src/github.com-1ecc6299db9ec823/gcc-0.3.27/src/lib.rs"
+                },
+                {
+                    "kind": [
+                        "bin"
+                    ],
+                    "name": "gcc-shim",
+                    "src_path": "/Users/acharles/.cargo/registry/src/github.com-1ecc6299db9ec823/gcc-0.3.27/src/bin/gcc-shim.rs"
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "name": "cc_env",
+                    "src_path": "/Users/acharles/.cargo/registry/src/github.com-1ecc6299db9ec823/gcc-0.3.27/tests/cc_env.rs"
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "name": "test",
+                    "src_path": "/Users/acharles/.cargo/registry/src/github.com-1ecc6299db9ec823/gcc-0.3.27/tests/test.rs"
+                }
+            ],
+            "version": "0.3.27"
+        },
+        {
+            "dependencies": [],
+            "features": {},
+            "id": "build_helper 0.1.0 (path+file:///Users/acharles/rust/rustc/src/src/build_helper)",
+            "manifest_path": "/Users/acharles/rust/rustc/src/src/build_helper/Cargo.toml",
+            "name": "build_helper",
+            "source": null,
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "name": "build_helper",
+                    "src_path": "lib.rs"
+                }
+            ],
+            "version": "0.1.0"
+        },
+        {
+            "dependencies": [
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "core",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                }
+            ],
+            "features": {},
+            "id": "rustc_unicode 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_unicode)",
+            "manifest_path": "/Users/acharles/rust/rustc/src/src/librustc_unicode/Cargo.toml",
+            "name": "rustc_unicode",
+            "source": null,
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "name": "rustc_unicode",
+                    "src_path": "lib.rs"
+                }
+            ],
+            "version": "0.0.0"
+        },
+        {
+            "dependencies": [
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "core",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                }
+            ],
+            "features": {},
+            "id": "libc 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/rustc/libc_shim)",
+            "manifest_path": "/Users/acharles/rust/rustc/src/src/rustc/libc_shim/Cargo.toml",
+            "name": "libc",
+            "source": null,
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "name": "libc",
+                    "src_path": "../../liblibc/src/lib.rs"
+                },
+                {
+                    "kind": [
+                        "custom-build"
+                    ],
+                    "name": "build-script-build",
+                    "src_path": "build.rs"
+                }
+            ],
+            "version": "0.0.0"
+        },
+        {
+            "dependencies": [
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "core",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "libc",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                }
+            ],
+            "features": {},
+            "id": "panic_abort 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libpanic_abort)",
+            "manifest_path": "/Users/acharles/rust/rustc/src/src/libpanic_abort/Cargo.toml",
+            "name": "panic_abort",
+            "source": null,
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "name": "panic_abort",
+                    "src_path": "lib.rs"
+                }
+            ],
+            "version": "0.0.0"
+        },
+        {
+            "dependencies": [
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "core",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "libc",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                }
+            ],
+            "features": {},
+            "id": "alloc_system 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/liballoc_system)",
+            "manifest_path": "/Users/acharles/rust/rustc/src/src/liballoc_system/Cargo.toml",
+            "name": "alloc_system",
+            "source": null,
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "name": "alloc_system",
+                    "src_path": "lib.rs"
+                }
+            ],
+            "version": "0.0.0"
+        },
+        {
+            "dependencies": [
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "core",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "alloc",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "rustc_unicode",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                }
+            ],
+            "features": {},
+            "id": "collections 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libcollections)",
+            "manifest_path": "/Users/acharles/rust/rustc/src/src/libcollections/Cargo.toml",
+            "name": "collections",
+            "source": null,
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "name": "collections",
+                    "src_path": "lib.rs"
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "name": "collectionstest",
+                    "src_path": "../libcollectionstest/lib.rs"
+                }
+            ],
+            "version": "0.0.0"
+        },
+        {
+            "dependencies": [],
+            "features": {},
+            "id": "core 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libcore)",
+            "manifest_path": "/Users/acharles/rust/rustc/src/src/libcore/Cargo.toml",
+            "name": "core",
+            "source": null,
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "name": "core",
+                    "src_path": "lib.rs"
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "name": "coretest",
+                    "src_path": "../libcoretest/lib.rs"
+                }
+            ],
+            "version": "0.0.0"
+        }
+    ],
+    "resolve": {
+        "nodes": [
+            {
+                "dependencies": [
+                    "gcc 0.3.27 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "core 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libcore)"
+                ],
+                "id": "compiler_builtins 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libcompiler_builtins)"
+            },
+            {
+                "dependencies": [
+                    "core 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libcore)"
+                ],
+                "id": "alloc 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/liballoc)"
+            },
+            {
+                "dependencies": [
+                    "alloc 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/liballoc)",
+                    "unwind 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libunwind)",
+                    "libc 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/rustc/libc_shim)",
+                    "core 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libcore)"
+                ],
+                "id": "panic_unwind 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libpanic_unwind)"
+            },
+            {
+                "dependencies": [
+                    "compiler_builtins 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libcompiler_builtins)",
+                    "alloc 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/liballoc)",
+                    "panic_unwind 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libpanic_unwind)",
+                    "unwind 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libunwind)",
+                    "rand 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librand)",
+                    "gcc 0.3.27 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "build_helper 0.1.0 (path+file:///Users/acharles/rust/rustc/src/src/build_helper)",
+                    "rustc_unicode 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_unicode)",
+                    "libc 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/rustc/libc_shim)",
+                    "panic_abort 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libpanic_abort)",
+                    "alloc_system 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/liballoc_system)",
+                    "collections 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libcollections)",
+                    "core 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libcore)"
+                ],
+                "id": "std 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libstd)"
+            },
+            {
+                "dependencies": [
+                    "libc 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/rustc/libc_shim)",
+                    "core 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libcore)"
+                ],
+                "id": "unwind 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libunwind)"
+            },
+            {
+                "dependencies": [
+                    "std 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libstd)",
+                    "core 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libcore)"
+                ],
+                "id": "std_shim 0.1.0 (path+file:///Users/acharles/rust/rustc/src/src/rustc/std_shim)"
+            },
+            {
+                "dependencies": [
+                    "core 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libcore)"
+                ],
+                "id": "rand 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librand)"
+            },
+            {
+                "dependencies": [],
+                "id": "gcc 0.3.27 (registry+https://github.com/rust-lang/crates.io-index)"
+            },
+            {
+                "dependencies": [],
+                "id": "build_helper 0.1.0 (path+file:///Users/acharles/rust/rustc/src/src/build_helper)"
+            },
+            {
+                "dependencies": [
+                    "core 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libcore)"
+                ],
+                "id": "rustc_unicode 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_unicode)"
+            },
+            {
+                "dependencies": [
+                    "core 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libcore)"
+                ],
+                "id": "libc 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/rustc/libc_shim)"
+            },
+            {
+                "dependencies": [
+                    "libc 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/rustc/libc_shim)",
+                    "core 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libcore)"
+                ],
+                "id": "panic_abort 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libpanic_abort)"
+            },
+            {
+                "dependencies": [
+                    "libc 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/rustc/libc_shim)",
+                    "core 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libcore)"
+                ],
+                "id": "alloc_system 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/liballoc_system)"
+            },
+            {
+                "dependencies": [
+                    "alloc 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/liballoc)",
+                    "rustc_unicode 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/librustc_unicode)",
+                    "core 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libcore)"
+                ],
+                "id": "collections 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libcollections)"
+            },
+            {
+                "dependencies": [],
+                "id": "core 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libcore)"
+            }
+        ],
+        "root": "std_shim 0.1.0 (path+file:///Users/acharles/rust/rustc/src/src/rustc/std_shim)"
+    },
+    "version": 1
+}

--- a/src/metadata/test_shim.json
+++ b/src/metadata/test_shim.json
@@ -1,0 +1,138 @@
+{
+    "packages": [
+        {
+            "dependencies": [
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "test",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                }
+            ],
+            "features": {},
+            "id": "test_shim 0.1.0 (path+file:///Users/acharles/rust/rustc/src/src/rustc/test_shim)",
+            "manifest_path": "/Users/acharles/rust/rustc/src/src/rustc/test_shim/Cargo.toml",
+            "name": "test_shim",
+            "source": null,
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "name": "test_shim",
+                    "src_path": "lib.rs"
+                }
+            ],
+            "version": "0.1.0"
+        },
+        {
+            "dependencies": [],
+            "features": {},
+            "id": "getopts 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libgetopts)",
+            "manifest_path": "/Users/acharles/rust/rustc/src/src/libgetopts/Cargo.toml",
+            "name": "getopts",
+            "source": null,
+            "targets": [
+                {
+                    "kind": [
+                        "dylib",
+                        "rlib"
+                    ],
+                    "name": "getopts",
+                    "src_path": "lib.rs"
+                }
+            ],
+            "version": "0.0.0"
+        },
+        {
+            "dependencies": [
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "term",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "getopts",
+                    "optional": false,
+                    "req": "*",
+                    "source": null,
+                    "target": null,
+                    "uses_default_features": true
+                }
+            ],
+            "features": {},
+            "id": "test 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libtest)",
+            "manifest_path": "/Users/acharles/rust/rustc/src/src/libtest/Cargo.toml",
+            "name": "test",
+            "source": null,
+            "targets": [
+                {
+                    "kind": [
+                        "dylib",
+                        "rlib"
+                    ],
+                    "name": "test",
+                    "src_path": "lib.rs"
+                }
+            ],
+            "version": "0.0.0"
+        },
+        {
+            "dependencies": [],
+            "features": {},
+            "id": "term 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libterm)",
+            "manifest_path": "/Users/acharles/rust/rustc/src/src/libterm/Cargo.toml",
+            "name": "term",
+            "source": null,
+            "targets": [
+                {
+                    "kind": [
+                        "dylib",
+                        "rlib"
+                    ],
+                    "name": "term",
+                    "src_path": "lib.rs"
+                }
+            ],
+            "version": "0.0.0"
+        }
+    ],
+    "resolve": {
+        "nodes": [
+            {
+                "dependencies": [
+                    "test 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libtest)"
+                ],
+                "id": "test_shim 0.1.0 (path+file:///Users/acharles/rust/rustc/src/src/rustc/test_shim)"
+            },
+            {
+                "dependencies": [],
+                "id": "getopts 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libgetopts)"
+            },
+            {
+                "dependencies": [
+                    "getopts 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libgetopts)",
+                    "term 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libterm)"
+                ],
+                "id": "test 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libtest)"
+            },
+            {
+                "dependencies": [],
+                "id": "term 0.0.0 (path+file:///Users/acharles/rust/rustc/src/src/libterm)"
+            }
+        ],
+        "root": "test_shim 0.1.0 (path+file:///Users/acharles/rust/rustc/src/src/rustc/test_shim)"
+    },
+    "version": 1
+}


### PR DESCRIPTION
This allows parsing the result of `cargo metadata` without having to
implement the json serialization in each caller, independently.

This is intended to be used by: https://github.com/rust-lang/rust/pull/36032

This is the bare minimum required to implement the functionality required by rustc's bootstrap to determine the transitive dependency closure. Obviously, it would be nice if this were more fully featured. I initially tried copying the implementations from cargo with the intent of having cargo depend on this crate through a path dependency, just like it does with crates-io. However, this ended up being non-trivial, so I decided to limit the scope and start from scratch. Any thoughts on whether that would be a worthwhile approach (likely longer term)?
