### PR TITLE
Parse --features in `cargo metadata` the same

### DIFF
--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -100,11 +100,14 @@ pub fn compile<'a>(ws: &Workspace<'a>, options: &CompileOptions<'a>)
 
 pub fn resolve_dependencies<'a>(ws: &Workspace<'a>,
                                 source: Option<Box<Source + 'a>>,
-                                features: Vec<String>,
+                                features: &[String],
                                 all_features: bool,
                                 no_default_features: bool,
                                 spec: &'a [String])
                                 -> CargoResult<(PackageSet<'a>, Resolve)> {
+    let features = features.iter().flat_map(|s| {
+        s.split_whitespace()
+    }).map(|s| s.to_string()).collect::<Vec<String>>();
 
     let mut registry = try!(PackageRegistry::new(ws.config()));
 
@@ -161,9 +164,6 @@ pub fn compile_ws<'a>(ws: &Workspace<'a>,
                          ref target_rustc_args } = *options;
 
     let target = target.map(|s| s.to_string());
-    let features = features.iter().flat_map(|s| {
-        s.split(' ')
-    }).map(|s| s.to_string()).collect::<Vec<String>>();
 
     if jobs == Some(0) {
         bail!("jobs must be at least 1")

--- a/src/cargo/ops/cargo_output_metadata.rs
+++ b/src/cargo/ops/cargo_output_metadata.rs
@@ -45,7 +45,7 @@ fn metadata_full(ws: &Workspace,
                  opt: &OutputMetadataOptions) -> CargoResult<ExportInfo> {
     let deps = try!(ops::resolve_dependencies(ws,
                                               None,
-                                              opt.features.clone(),
+                                              &opt.features,
                                               opt.all_features,
                                               opt.no_default_features,
                                               &[]));

--- a/tests/metadata.rs
+++ b/tests/metadata.rs
@@ -429,3 +429,23 @@ fn carg_metadata_bad_version() {
                 execs().with_status(101)
     .with_stderr("[ERROR] metadata version 2 not supported, only 1 is currently supported"));
 }
+
+#[test]
+fn multiple_features() {
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [package]
+            name = "foo"
+            version = "0.1.0"
+            authors = []
+
+            [features]
+            a = []
+            b = []
+        "#)
+        .file("src/lib.rs", "");
+
+    assert_that(p.cargo_process("metadata")
+                 .arg("--features").arg("a b"),
+                execs().with_status(0));
+}


### PR DESCRIPTION
This accidentally didn't accept space-separated features passed through
`--features` as the logic for doing the splitting wasn't shared. Let's share it!