### PR TITLE
removing return false causing links to break

### DIFF
--- a/src/doc/javascripts/all.js
+++ b/src/doc/javascripts/all.js
@@ -35,7 +35,6 @@ $(function() {
             var toggles = $('button.dropdown.active, a.dropdown.active');
             toggles.toggleClass('active').siblings('ul').toggleClass('open');
 
-            return false;
         }
     });
 });


### PR DESCRIPTION
Gah! Sorry about that.

fixes #3182 

I added a `return false` to the function above to prevent it from toggling itself back off but for some reason put one here as well which stopped the event before the link could fire.