### PR TITLE
Make it possible for windows-gnu tests to pass

### DIFF
--- a/tests/version.rs
+++ b/tests/version.rs
@@ -51,6 +51,7 @@ Options:
 }
 
 #[test]
+#[cfg_attr(target_os = "windows", ignore)]
 fn version_works_without_rustc() {
     let p = project("foo");
     assert_that(p.cargo_process("version").env("PATH", ""),


### PR DESCRIPTION
Skip test that uses empty path on Windows, because Windows doesn't do the empty path thing.