### PR TITLE
Remove CommandType struct

### DIFF
--- a/src/cargo/ops/cargo_rustc/context.rs
+++ b/src/cargo/ops/cargo_rustc/context.rs
@@ -110,6 +110,8 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
             None => {}
         }
 
+        self.compilation.plugins_dylib_path = self.host.deps().to_path_buf();
+
         let layout = self.target.as_ref().unwrap_or(&self.host);
         self.compilation.root_output = layout.dest().to_path_buf();
         self.compilation.deps_output = layout.deps().to_path_buf();
@@ -278,11 +280,6 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
                                                  .unwrap_or(&self.host),
                                              primary),
         }
-    }
-
-    /// Returns the path for plugin/dylib dependencies
-    pub fn host_dylib_path(&self) -> &Path {
-        self.host.deps()
     }
 
     /// Returns the appropriate output directory for the specified package and

--- a/src/cargo/ops/cargo_rustc/custom_build.rs
+++ b/src/cargo/ops/cargo_rustc/custom_build.rs
@@ -10,7 +10,6 @@ use util::{internal, ChainError, profile, paths};
 
 use super::job::Work;
 use super::{fingerprint, Kind, Context, Unit};
-use super::compilation::CommandType;
 
 /// Contains the parsed output of a custom build script.
 #[derive(Clone, Debug, Hash)]
@@ -98,7 +97,7 @@ fn build_work<'a, 'cfg>(cx: &mut Context<'a, 'cfg>, unit: &Unit<'a>)
     // package's library profile.
     let profile = cx.lib_profile(unit.pkg.package_id());
     let to_exec = to_exec.into_os_string();
-    let mut cmd = try!(super::process(CommandType::Host(to_exec), unit.pkg, cx));
+    let mut cmd = try!(cx.compilation.host_process(to_exec, unit.pkg, cx.host_dylib_path()));
     cmd.env("OUT_DIR", &build_output)
        .env("CARGO_MANIFEST_DIR", unit.pkg.root())
        .env("NUM_JOBS", &cx.jobs().to_string())

--- a/src/cargo/ops/cargo_rustc/custom_build.rs
+++ b/src/cargo/ops/cargo_rustc/custom_build.rs
@@ -97,7 +97,7 @@ fn build_work<'a, 'cfg>(cx: &mut Context<'a, 'cfg>, unit: &Unit<'a>)
     // package's library profile.
     let profile = cx.lib_profile(unit.pkg.package_id());
     let to_exec = to_exec.into_os_string();
-    let mut cmd = try!(cx.compilation.host_process(to_exec, unit.pkg, cx.host_dylib_path()));
+    let mut cmd = try!(cx.compilation.host_process(to_exec, unit.pkg));
     cmd.env("OUT_DIR", &build_output)
        .env("CARGO_MANIFEST_DIR", unit.pkg.root())
        .env("NUM_JOBS", &cx.jobs().to_string())

--- a/src/cargo/ops/cargo_rustc/mod.rs
+++ b/src/cargo/ops/cargo_rustc/mod.rs
@@ -16,7 +16,7 @@ use util::{Config, internal, ChainError, profile, join_paths, short_hash};
 use self::job::{Job, Work};
 use self::job_queue::JobQueue;
 
-pub use self::compilation::{Compilation, CommandType};
+pub use self::compilation::Compilation;
 pub use self::context::{Context, Unit};
 pub use self::layout::{Layout, LayoutProxy};
 pub use self::custom_build::{BuildOutput, BuildMap, BuildScripts};
@@ -415,7 +415,7 @@ fn add_plugin_deps(rustc: &mut ProcessBuilder,
 fn prepare_rustc(cx: &Context,
                  crate_types: Vec<&str>,
                  unit: &Unit) -> CargoResult<ProcessBuilder> {
-    let mut base = try!(process(CommandType::Rustc, unit.pkg, cx));
+    let mut base = try!(cx.compilation.rustc_process(unit.pkg, cx.host_dylib_path()));
     build_base_args(cx, &mut base, unit, &crate_types);
     build_plugin_args(&mut base, cx, unit);
     try!(build_deps_args(&mut base, cx, unit));
@@ -424,7 +424,7 @@ fn prepare_rustc(cx: &Context,
 
 
 fn rustdoc(cx: &mut Context, unit: &Unit) -> CargoResult<Work> {
-    let mut rustdoc = try!(process(CommandType::Rustdoc, unit.pkg, cx));
+    let mut rustdoc = try!(cx.compilation.rustdoc_process(unit.pkg, Some(cx.host_dylib_path())));
     rustdoc.arg(&root_path(cx, unit))
            .cwd(cx.config.cwd())
            .arg("--crate-name").arg(&unit.target.crate_name());
@@ -671,21 +671,6 @@ fn build_deps_args(cmd: &mut ProcessBuilder, cx: &Context, unit: &Unit)
         }
         Ok(())
     }
-}
-
-pub fn process(cmd: CommandType, pkg: &Package,
-               cx: &Context) -> CargoResult<ProcessBuilder> {
-    // When invoking a tool, we need the *host* deps directory in the dynamic
-    // library search path for plugins and such which have dynamic dependencies.
-    let mut search_path = util::dylib_path();
-    search_path.push(cx.host_dylib_path().to_path_buf());
-
-    // We want to use the same environment and such as normal processes, but we
-    // want to override the dylib search path with the one we just calculated.
-    let search_path = try!(join_paths(&search_path, util::dylib_path_envvar()));
-    let mut cmd = try!(cx.compilation.process(cmd, pkg));
-    cmd.env(util::dylib_path_envvar(), &search_path);
-    Ok(cmd)
 }
 
 fn envify(s: &str) -> String {

--- a/src/cargo/ops/cargo_rustc/mod.rs
+++ b/src/cargo/ops/cargo_rustc/mod.rs
@@ -415,7 +415,7 @@ fn add_plugin_deps(rustc: &mut ProcessBuilder,
 fn prepare_rustc(cx: &Context,
                  crate_types: Vec<&str>,
                  unit: &Unit) -> CargoResult<ProcessBuilder> {
-    let mut base = try!(cx.compilation.rustc_process(unit.pkg, cx.host_dylib_path()));
+    let mut base = try!(cx.compilation.rustc_process(unit.pkg));
     build_base_args(cx, &mut base, unit, &crate_types);
     build_plugin_args(&mut base, cx, unit);
     try!(build_deps_args(&mut base, cx, unit));
@@ -424,7 +424,7 @@ fn prepare_rustc(cx: &Context,
 
 
 fn rustdoc(cx: &mut Context, unit: &Unit) -> CargoResult<Work> {
-    let mut rustdoc = try!(cx.compilation.rustdoc_process(unit.pkg, Some(cx.host_dylib_path())));
+    let mut rustdoc = try!(cx.compilation.rustdoc_process(unit.pkg));
     rustdoc.arg(&root_path(cx, unit))
            .cwd(cx.config.cwd())
            .arg("--crate-name").arg(&unit.target.crate_name());

--- a/src/cargo/ops/cargo_test.rs
+++ b/src/cargo/ops/cargo_test.rs
@@ -128,7 +128,7 @@ fn run_doc_tests(options: &TestOptions,
     for (package, tests) in libs {
         for (lib, name, crate_name) in tests {
             try!(config.shell().status("Doc-tests", name));
-            let mut p = try!(compilation.rustdoc_process(package));
+            let mut p = try!(compilation.rustdoc_process(package, None));
             p.arg("--test").arg(lib)
              .arg("--crate-name").arg(&crate_name);
 

--- a/src/cargo/ops/cargo_test.rs
+++ b/src/cargo/ops/cargo_test.rs
@@ -128,7 +128,7 @@ fn run_doc_tests(options: &TestOptions,
     for (package, tests) in libs {
         for (lib, name, crate_name) in tests {
             try!(config.shell().status("Doc-tests", name));
-            let mut p = try!(compilation.rustdoc_process(package, None));
+            let mut p = try!(compilation.rustdoc_process(package));
             p.arg("--test").arg(lib)
              .arg("--crate-name").arg(&crate_name);
 


### PR DESCRIPTION
This removes `CommandType` struct as well as `cargo_rustc::process` function. So now all process creation goes thorough methods of `Compilation`. 

This does change search path order from `util::dylib_path(), host_dylib_path()` to `host_dylib_path(), util::dylib_path()`, but I hope this is not a problem.

This also uncovers the fact that `rustdoc` is run sometimes with and sometimes without `host_dylib_path`. Is this intentional? 