### PR TITLE
Ignore summaries in downloaded crates

### DIFF
--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -185,7 +185,8 @@ impl Encodable for Target {
 }
 
 impl Manifest {
-    pub fn new(summary: Summary, targets: Vec<Target>,
+    pub fn new(summary: Summary,
+               targets: Vec<Target>,
                exclude: Vec<String>,
                include: Vec<String>,
                links: Option<String>,

--- a/tests/cargotest/support/registry.rs
+++ b/tests/cargotest/support/registry.rs
@@ -141,7 +141,7 @@ impl Package {
             map.insert("name".to_string(), dep.name.to_json());
             map.insert("req".to_string(), dep.vers.to_json());
             map.insert("features".to_string(), dep.features.to_json());
-            map.insert("default_features".to_string(), false.to_json());
+            map.insert("default_features".to_string(), true.to_json());
             map.insert("target".to_string(), dep.target.to_json());
             map.insert("optional".to_string(), false.to_json());
             map.insert("kind".to_string(), dep.kind.to_json());
@@ -211,7 +211,7 @@ impl Package {
         for dep in self.deps.iter() {
             let target = match dep.target {
                 None => String::new(),
-                Some(ref s) => format!("target.{}.", s),
+                Some(ref s) => format!("target.'{}'.", s),
             };
             let kind = match &dep.kind[..] {
                 "build" => "build-",

--- a/tests/cfg.rs
+++ b/tests/cfg.rs
@@ -200,8 +200,8 @@ fn works_through_the_registry() {
 
     Package::new("foo", "0.1.0").publish();
     Package::new("bar", "0.1.0")
-            .target_dep("foo", "0.1.0", "'cfg(unix)'")
-            .target_dep("foo", "0.1.0", "'cfg(windows)'")
+            .target_dep("foo", "0.1.0", "cfg(unix)")
+            .target_dep("foo", "0.1.0", "cfg(windows)")
             .publish();
 
     let p = project("a")


### PR DESCRIPTION
Unfortunately historical Cargo bugs have made it such that the index sometimes
differs from the actual crate we download. Let's respect the index, however,
which should be our source of truth.

Closes #3214