### PR TITLE
Load [replace] sections from lock files

### DIFF
--- a/src/cargo/core/resolver/encode.rs
+++ b/src/cargo/core/resolver/encode.rs
@@ -185,8 +185,10 @@ fn build_path_deps(ws: &Workspace) -> HashMap<String, SourceId> {
     fn build(pkg: &Package,
              config: &Config,
              ret: &mut HashMap<String, SourceId>) {
+        let replace = pkg.manifest().replace();
         let deps = pkg.dependencies()
                       .iter()
+                      .chain(replace.iter().map(|p| &p.1))
                       .filter(|d| !ret.contains_key(d.name()))
                       .map(|d| d.source_id())
                       .filter(|id| id.is_path())

--- a/src/cargo/core/resolver/mod.rs
+++ b/src/cargo/core/resolver/mod.rs
@@ -864,6 +864,7 @@ impl<'a> Context<'a> {
                 None => return Ok(Candidate { summary: summary, replace: None }),
                 Some(replacement) => replacement,
             };
+            debug!("found an override for {} {}", dep.name(), dep.version_req());
 
             let mut summaries = try!(registry.query(dep)).into_iter();
             let s = try!(summaries.next().chain_error(|| {
@@ -901,6 +902,10 @@ impl<'a> Context<'a> {
                 bail!("overlapping replacement specifications found:\n\n  \
                        * {}\n  * {}\n\nboth specifications match: {}",
                       matched_spec, spec, summary.package_id());
+            }
+
+            for dep in summary.dependencies() {
+                debug!("\t{} => {}", dep.name(), dep.version_req());
             }
 
             Ok(Candidate { summary: summary, replace: replace })

--- a/src/cargo/ops/resolve.rs
+++ b/src/cargo/ops/resolve.rs
@@ -77,6 +77,7 @@ pub fn resolve_with_previous<'a>(registry: &mut PackageRegistry,
     //    to the previously resolved version if the dependency listed
     //    still matches the locked version.
     if let Some(r) = previous {
+        trace!("previous: {:?}", r);
         for node in r.iter().filter(|p| keep(p, to_avoid, &to_avoid_sources)) {
             let deps = r.deps_not_replaced(node)
                         .filter(|p| keep(p, to_avoid, &to_avoid_sources))


### PR DESCRIPTION
This commit fixes a bug in Cargo where path-based [replace] dependencies were
accidentally not loaded from lock files. This meant that even with a lock
file some compilations could accidentally become nondeterministic. The fix here
is to just look at all path dependencies, even those specified through [replace]

Closes #3216
