### PR TITLE
Add `--all` flag to `cargo test`

### DIFF
--- a/src/bin/bench.rs
+++ b/src/bin/bench.rs
@@ -88,7 +88,7 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
             features: &options.flag_features,
             all_features: options.flag_all_features,
             no_default_features: options.flag_no_default_features,
-            spec: &options.flag_package,
+            spec: ops::Packages::Packages(&options.flag_package),
             release: true,
             mode: ops::CompileMode::Bench,
             filter: ops::CompileFilter::new(options.flag_lib,

--- a/src/bin/build.rs
+++ b/src/bin/build.rs
@@ -84,7 +84,7 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
         features: &options.flag_features,
         all_features: options.flag_all_features,
         no_default_features: options.flag_no_default_features,
-        spec: &options.flag_package,
+        spec: ops::Packages::Packages(&options.flag_package),
         mode: ops::CompileMode::Build,
         release: options.flag_release,
         filter: ops::CompileFilter::new(options.flag_lib,

--- a/src/bin/doc.rs
+++ b/src/bin/doc.rs
@@ -1,5 +1,5 @@
 use cargo::core::Workspace;
-use cargo::ops::{self, MessageFormat};
+use cargo::ops::{self, MessageFormat, Packages};
 use cargo::util::{CliResult, Config};
 use cargo::util::important_paths::{find_root_manifest_for_wd};
 
@@ -80,7 +80,7 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
             features: &options.flag_features,
             all_features: options.flag_all_features,
             no_default_features: options.flag_no_default_features,
-            spec: &options.flag_package,
+            spec: Packages::Packages(&options.flag_package),
             filter: ops::CompileFilter::new(options.flag_lib,
                                             &options.flag_bin,
                                             &empty,

--- a/src/bin/install.rs
+++ b/src/bin/install.rs
@@ -108,7 +108,7 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
         features: &options.flag_features,
         all_features: options.flag_all_features,
         no_default_features: options.flag_no_default_features,
-        spec: &[],
+        spec: ops::Packages::Packages(&[]),
         mode: ops::CompileMode::Build,
         release: !options.flag_debug,
         filter: ops::CompileFilter::new(false, &options.flag_bin, &[],

--- a/src/bin/run.rs
+++ b/src/bin/run.rs
@@ -1,5 +1,5 @@
 use cargo::core::Workspace;
-use cargo::ops::{self, MessageFormat};
+use cargo::ops::{self, MessageFormat, Packages};
 use cargo::util::{CliResult, CliError, Config, Human};
 use cargo::util::important_paths::{find_root_manifest_for_wd};
 
@@ -81,7 +81,7 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
         features: &options.flag_features,
         all_features: options.flag_all_features,
         no_default_features: options.flag_no_default_features,
-        spec: &[],
+        spec: Packages::Packages(&[]),
         release: options.flag_release,
         mode: ops::CompileMode::Build,
         filter: if examples.is_empty() && bins.is_empty() {

--- a/src/bin/rustc.rs
+++ b/src/bin/rustc.rs
@@ -1,7 +1,7 @@
 use std::env;
 
 use cargo::core::Workspace;
-use cargo::ops::{self, CompileOptions, CompileMode, MessageFormat};
+use cargo::ops::{self, CompileOptions, CompileMode, MessageFormat, Packages};
 use cargo::util::important_paths::{find_root_manifest_for_wd};
 use cargo::util::{CliResult, CliError, Config, human};
 
@@ -95,6 +95,8 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
         }
     };
 
+    let spec = options.flag_package.map_or_else(Vec::new, |s| vec![s]);
+
     let opts = CompileOptions {
         config: config,
         jobs: options.flag_jobs,
@@ -102,7 +104,7 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
         features: &options.flag_features,
         all_features: options.flag_all_features,
         no_default_features: options.flag_no_default_features,
-        spec: &options.flag_package.map_or(Vec::new(), |s| vec![s]),
+        spec: Packages::Packages(&spec),
         mode: mode,
         release: options.flag_release,
         filter: ops::CompileFilter::new(options.flag_lib,

--- a/src/bin/rustdoc.rs
+++ b/src/bin/rustdoc.rs
@@ -1,5 +1,5 @@
 use cargo::core::Workspace;
-use cargo::ops::{self, MessageFormat};
+use cargo::ops::{self, MessageFormat, Packages};
 use cargo::util::{CliResult, Config};
 use cargo::util::important_paths::{find_root_manifest_for_wd};
 
@@ -80,6 +80,8 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
     let root = find_root_manifest_for_wd(options.flag_manifest_path,
                                          config.cwd())?;
 
+    let spec = options.flag_package.map_or_else(Vec::new, |s| vec![s]);
+
     let doc_opts = ops::DocOptions {
         open_result: options.flag_open,
         compile_opts: ops::CompileOptions {
@@ -89,7 +91,7 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
             features: &options.flag_features,
             all_features: options.flag_all_features,
             no_default_features: options.flag_no_default_features,
-            spec: &options.flag_package.map_or(Vec::new(), |s| vec![s]),
+            spec: Packages::Packages(&spec),
             release: options.flag_release,
             filter: ops::CompileFilter::new(options.flag_lib,
                                             &options.flag_bin,

--- a/src/bin/test.rs
+++ b/src/bin/test.rs
@@ -1,7 +1,7 @@
 use cargo::core::Workspace;
-use cargo::ops::{self, MessageFormat};
+use cargo::ops::{self, MessageFormat, Packages};
 use cargo::util::{CliResult, CliError, Human, human, Config};
-use cargo::util::important_paths::{find_root_manifest_for_wd};
+use cargo::util::important_paths::find_root_manifest_for_wd;
 
 #[derive(RustcDecodable)]
 pub struct Options {
@@ -28,6 +28,7 @@ pub struct Options {
     flag_no_fail_fast: bool,
     flag_frozen: bool,
     flag_locked: bool,
+    flag_all: bool,
 }
 
 pub const USAGE: &'static str = "
@@ -46,6 +47,7 @@ Options:
     --bench NAME                 Test only the specified benchmark target
     --no-run                     Compile, but don't run tests
     -p SPEC, --package SPEC ...  Package to run tests for
+    --all                        Test all packages in the workspace
     -j N, --jobs N               Number of parallel jobs, defaults to # of CPUs
     --release                    Build artifacts in release mode, with optimizations
     --features FEATURES          Space-separated list of features to also build
@@ -71,6 +73,9 @@ If the --package argument is given, then SPEC is a package id specification
 which indicates which package should be tested. If it is not given, then the
 current package is tested. For more information on SPEC and its format, see the
 `cargo help pkgid` command.
+
+All packages in the workspace are tested if the `--all` flag is supplied. The
+`--all` flag may be supplied in the presence of a virtual manifest.
 
 The --jobs argument affects the building of the test executable but does
 not affect how many jobs are used when running the tests.
@@ -111,6 +116,12 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
                                          &options.flag_bench);
     }
 
+    let spec = if options.flag_all {
+        Packages::All
+    } else {
+        Packages::Packages(&options.flag_package)
+    };
+
     let ops = ops::TestOptions {
         no_run: options.flag_no_run,
         no_fail_fast: options.flag_no_fail_fast,
@@ -122,7 +133,7 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
             features: &options.flag_features,
             all_features: options.flag_all_features,
             no_default_features: options.flag_no_default_features,
-            spec: &options.flag_package,
+            spec: spec,
             release: options.flag_release,
             mode: mode,
             filter: filter,
@@ -139,7 +150,7 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
         Some(err) => {
             Err(match err.exit.as_ref().and_then(|e| e.code()) {
                 Some(i) => CliError::new(human("test failed"), i),
-                None => CliError::new(Box::new(Human(err)), 101)
+                None => CliError::new(Box::new(Human(err)), 101),
             })
         }
     }

--- a/src/cargo/core/resolver/encode.rs
+++ b/src/cargo/core/resolver/encode.rs
@@ -286,12 +286,11 @@ impl<'a, 'cfg> Encodable for WorkspaceResolve<'a, 'cfg> {
         }).map(Package::package_id);
 
         let encodable = ids.iter().filter_map(|&id| {
-            match root {
-                Some(ref root) if !(self.use_root_key && *root == id) => {
-                    Some(encodable_resolve_node(id, self.resolve))
-                },
-                _ => None,
+            if self.use_root_key && root.unwrap() == id {
+                return None
             }
+
+            Some(encodable_resolve_node(id, self.resolve))
         }).collect::<Vec<_>>();
 
         let mut metadata = self.resolve.metadata.clone();

--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -199,7 +199,7 @@ pub fn compile_ws<'a>(ws: &Workspace<'a>,
     let mut pkgids = Vec::new();
     if spec.len() > 0 {
         for p in spec.iter() {
-            pkgids.push(resolve_with_overrides.query(&p.to_string())?);
+            pkgids.push(p.query(resolve_with_overrides.iter())?);
         }
     } else {
         let root_package = ws.current()?;

--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -152,7 +152,7 @@ pub fn resolve_dependencies<'a>(ws: &Workspace<'a>,
                 .map(Package::package_id)
                 .map(PackageIdSpec::from_package_id)
                 .collect()
-        },
+        }
         Packages::Packages(packages) => {
             packages.iter().map(|p| PackageIdSpec::parse(&p)).collect::<CargoResult<Vec<_>>>()?
         }
@@ -189,11 +189,11 @@ pub fn compile_ws<'a>(ws: &Workspace<'a>,
     let profiles = ws.profiles();
 
     let resolve = resolve_dependencies(ws,
-                                         source,
-                                         features,
-                                         all_features,
-                                         no_default_features,
-                                         &spec)?;
+                                       source,
+                                       features,
+                                       all_features,
+                                       no_default_features,
+                                       &spec)?;
     let (spec, packages, resolve_with_overrides) = resolve;
 
     let mut pkgids = Vec::new();

--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -98,8 +98,8 @@ pub enum CompileFilter<'a> {
 
 pub fn compile<'a>(ws: &Workspace<'a>, options: &CompileOptions<'a>)
                    -> CargoResult<ops::Compilation<'a>> {
-    if let Some(root_package) = ws.current_opt() {
-        for key in root_package.manifest().warnings().iter() {
+    for member in ws.members() {
+        for key in member.manifest().warnings().iter() {
             options.config.shell().warn(key)?
         }
     }

--- a/src/cargo/ops/cargo_doc.rs
+++ b/src/cargo/ops/cargo_doc.rs
@@ -15,9 +15,18 @@ pub struct DocOptions<'a> {
 pub fn doc(ws: &Workspace, options: &DocOptions) -> CargoResult<()> {
     let package = ws.current()?;
 
+    let spec = match options.compile_opts.spec {
+        ops::Packages::Packages(packages) => packages,
+        _ => {
+            // This should not happen, because the `doc` binary is hard-coded to pass
+            // the `Packages::Packages` variant.
+            bail!("`cargo doc` does not support the `--all` flag")
+        },
+    };
+
     let mut lib_names = HashSet::new();
     let mut bin_names = HashSet::new();
-    if options.compile_opts.spec.is_empty() {
+    if spec.is_empty() {
         for target in package.targets().iter().filter(|t| t.documented()) {
             if target.is_lib() {
                 assert!(lib_names.insert(target.crate_name()));
@@ -37,10 +46,10 @@ pub fn doc(ws: &Workspace, options: &DocOptions) -> CargoResult<()> {
     ops::compile(ws, &options.compile_opts)?;
 
     if options.open_result {
-        let name = if options.compile_opts.spec.len() > 1 {
+        let name = if spec.len() > 1 {
             bail!("Passing multiple packages and `open` is not supported")
-        } else if options.compile_opts.spec.len() == 1 {
-            PackageIdSpec::parse(&options.compile_opts.spec[0])?
+        } else if spec.len() == 1 {
+            PackageIdSpec::parse(&spec[0])?
                 .name()
                 .replace("-", "_")
         } else {

--- a/src/cargo/ops/cargo_output_metadata.rs
+++ b/src/cargo/ops/cargo_output_metadata.rs
@@ -1,8 +1,8 @@
 use rustc_serialize::{Encodable, Encoder};
 
 use core::resolver::Resolve;
-use core::{Package, PackageId, PackageIdSpec, Workspace};
-use ops;
+use core::{Package, PackageId, Workspace};
+use ops::{self, Packages};
 use util::CargoResult;
 
 const VERSION: u32 = 1;
@@ -43,16 +43,13 @@ fn metadata_no_deps(ws: &Workspace,
 
 fn metadata_full(ws: &Workspace,
                  opt: &OutputMetadataOptions) -> CargoResult<ExportInfo> {
-    let specs = ws.members().map(|pkg| {
-        PackageIdSpec::from_package_id(pkg.package_id())
-    }).collect::<Vec<_>>();
     let deps = ops::resolve_dependencies(ws,
                                          None,
                                          &opt.features,
                                          opt.all_features,
                                          opt.no_default_features,
-                                         &specs)?;
-    let (packages, resolve) = deps;
+                                         &Packages::All)?;
+    let (_, packages, resolve) = deps;
 
     let packages = try!(packages.package_ids()
                                 .map(|i| packages.get(i).map(|p| p.clone()))

--- a/src/cargo/ops/cargo_package.rs
+++ b/src/cargo/ops/cargo_package.rs
@@ -291,7 +291,7 @@ fn run_verify(ws: &Workspace, tar: &File, opts: &PackageOpts) -> CargoResult<()>
         features: &[],
         no_default_features: false,
         all_features: false,
-        spec: &[],
+        spec: ops::Packages::Packages(&[]),
         filter: ops::CompileFilter::Everything,
         release: false,
         message_format: ops::MessageFormat::Human,

--- a/src/cargo/ops/cargo_rustc/context.rs
+++ b/src/cargo/ops/cargo_rustc/context.rs
@@ -597,7 +597,7 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
                         Ok(Unit {
                             pkg: pkg,
                             target: t,
-                            profile: self.lib_profile(id),
+                            profile: self.lib_profile(),
                             kind: unit.kind.for_target(t),
                         })
                     })
@@ -630,7 +630,7 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
                 Unit {
                     pkg: unit.pkg,
                     target: t,
-                    profile: self.lib_profile(id),
+                    profile: self.lib_profile(),
                     kind: unit.kind.for_target(t),
                 }
             }));
@@ -707,7 +707,7 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
             ret.push(Unit {
                 pkg: dep,
                 target: lib,
-                profile: self.lib_profile(dep.package_id()),
+                profile: self.lib_profile(),
                 kind: unit.kind.for_target(lib),
             });
             if self.build_config.doc_all {
@@ -753,7 +753,7 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
             Unit {
                 pkg: unit.pkg,
                 target: t,
-                profile: self.lib_profile(unit.pkg.package_id()),
+                profile: self.lib_profile(),
                 kind: unit.kind.for_target(t),
             }
         })
@@ -808,7 +808,7 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
     /// Number of jobs specified for this build
     pub fn jobs(&self) -> u32 { self.build_config.jobs }
 
-    pub fn lib_profile(&self, _pkg: &PackageId) -> &'a Profile {
+    pub fn lib_profile(&self) -> &'a Profile {
         let (normal, test) = if self.build_config.release {
             (&self.profiles.release, &self.profiles.bench_deps)
         } else {
@@ -821,10 +821,10 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
         }
     }
 
-    pub fn build_script_profile(&self, pkg: &PackageId) -> &'a Profile {
+    pub fn build_script_profile(&self, _pkg: &PackageId) -> &'a Profile {
         // TODO: should build scripts always be built with the same library
         //       profile? How is this controlled at the CLI layer?
-        self.lib_profile(pkg)
+        self.lib_profile()
     }
 
     pub fn rustflags_args(&self, unit: &Unit) -> CargoResult<Vec<String>> {

--- a/src/cargo/ops/cargo_rustc/context.rs
+++ b/src/cargo/ops/cargo_rustc/context.rs
@@ -449,8 +449,7 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
         // we don't want to link it up.
         if src_dir.ends_with("deps") {
             // Don't lift up library dependencies
-            if self.ws.current_opt().map_or(false, |p| unit.pkg.package_id() != p.package_id())
-                    && !unit.target.is_bin() {
+            if self.ws.members().find(|&p| p != unit.pkg).is_some() && !unit.target.is_bin() {
                 None
             } else {
                 Some((

--- a/src/cargo/ops/cargo_rustc/context.rs
+++ b/src/cargo/ops/cargo_rustc/context.rs
@@ -836,9 +836,7 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
     }
 
     pub fn show_warnings(&self, pkg: &PackageId) -> bool {
-        self.ws.current_opt().map_or(false, |p| *pkg == *p.package_id())
-            || pkg.source_id().is_path()
-            || self.config.extra_verbose()
+        pkg.source_id().is_path() || self.config.extra_verbose()
     }
 }
 

--- a/src/cargo/ops/cargo_rustc/custom_build.rs
+++ b/src/cargo/ops/cargo_rustc/custom_build.rs
@@ -97,7 +97,7 @@ fn build_work<'a, 'cfg>(cx: &mut Context<'a, 'cfg>, unit: &Unit<'a>)
     // environment variables. Note that the profile-related environment
     // variables are not set with this the build script's profile but rather the
     // package's library profile.
-    let profile = cx.lib_profile(unit.pkg.package_id());
+    let profile = cx.lib_profile();
     let to_exec = to_exec.into_os_string();
     let mut cmd = cx.compilation.host_process(to_exec, unit.pkg)?;
     cmd.env("OUT_DIR", &build_output)

--- a/src/cargo/ops/cargo_rustc/job_queue.rs
+++ b/src/cargo/ops/cargo_rustc/job_queue.rs
@@ -198,9 +198,7 @@ impl<'a> JobQueue<'a> {
         }
 
         let build_type = if self.is_release { "release" } else { "debug" };
-        let profile = cx.ws.current_opt().map_or_else(Profile::default, |p| {
-            cx.lib_profile(p.package_id()).to_owned()
-        });
+        let profile = cx.lib_profile();
         let mut opt_type = String::from(if profile.opt_level == "0" { "unoptimized" }
                                         else { "optimized" });
         if profile.debuginfo {

--- a/src/cargo/ops/cargo_rustc/job_queue.rs
+++ b/src/cargo/ops/cargo_rustc/job_queue.rs
@@ -198,8 +198,8 @@ impl<'a> JobQueue<'a> {
         }
 
         let build_type = if self.is_release { "release" } else { "debug" };
-        let profile = cx.current_package.as_ref().map_or_else(Profile::default, |p| {
-            cx.lib_profile(p).to_owned()
+        let profile = cx.ws.current_opt().map_or_else(Profile::default, |p| {
+            cx.lib_profile(p.package_id()).to_owned()
         });
         let mut opt_type = String::from(if profile.opt_level == "0" { "unoptimized" }
                                         else { "optimized" });

--- a/src/cargo/ops/cargo_rustc/job_queue.rs
+++ b/src/cargo/ops/cargo_rustc/job_queue.rs
@@ -198,7 +198,9 @@ impl<'a> JobQueue<'a> {
         }
 
         let build_type = if self.is_release { "release" } else { "debug" };
-        let profile = cx.lib_profile(&cx.current_package);
+        let profile = cx.current_package.as_ref().map_or_else(Profile::default, |p| {
+            cx.lib_profile(p).to_owned()
+        });
         let mut opt_type = String::from(if profile.opt_level == "0" { "unoptimized" }
                                         else { "optimized" });
         if profile.debuginfo {

--- a/src/cargo/ops/cargo_rustc/mod.rs
+++ b/src/cargo/ops/cargo_rustc/mod.rs
@@ -557,8 +557,8 @@ fn build_base_args(cx: &mut Context,
     let prefer_dynamic = (unit.target.for_host() &&
                           !unit.target.is_custom_build()) ||
                          (crate_types.contains(&"dylib") &&
-                          cx.current_package.as_ref().map_or(false, |p| {
-                              *p != *unit.pkg.package_id()
+                          cx.ws.current_opt().map_or(false, |p| {
+                              *p.package_id() != *unit.pkg.package_id()
                           }));
     if prefer_dynamic {
         cmd.arg("-C").arg("prefer-dynamic");

--- a/src/cargo/ops/cargo_rustc/mod.rs
+++ b/src/cargo/ops/cargo_rustc/mod.rs
@@ -557,7 +557,9 @@ fn build_base_args(cx: &mut Context,
     let prefer_dynamic = (unit.target.for_host() &&
                           !unit.target.is_custom_build()) ||
                          (crate_types.contains(&"dylib") &&
-                          unit.pkg.package_id() != &cx.current_package);
+                          cx.current_package.as_ref().map_or(false, |p| {
+                              *p != *unit.pkg.package_id()
+                          }));
     if prefer_dynamic {
         cmd.arg("-C").arg("prefer-dynamic");
     }

--- a/src/cargo/ops/cargo_rustc/mod.rs
+++ b/src/cargo/ops/cargo_rustc/mod.rs
@@ -557,9 +557,7 @@ fn build_base_args(cx: &mut Context,
     let prefer_dynamic = (unit.target.for_host() &&
                           !unit.target.is_custom_build()) ||
                          (crate_types.contains(&"dylib") &&
-                          cx.ws.current_opt().map_or(false, |p| {
-                              *p.package_id() != *unit.pkg.package_id()
-                          }));
+                          cx.ws.members().find(|&p| p != unit.pkg).is_some());
     if prefer_dynamic {
         cmd.arg("-C").arg("prefer-dynamic");
     }

--- a/src/cargo/ops/mod.rs
+++ b/src/cargo/ops/mod.rs
@@ -1,6 +1,6 @@
 pub use self::cargo_clean::{clean, CleanOptions};
 pub use self::cargo_compile::{compile, compile_ws, resolve_dependencies, CompileOptions};
-pub use self::cargo_compile::{CompileFilter, CompileMode, MessageFormat};
+pub use self::cargo_compile::{CompileFilter, CompileMode, MessageFormat, Packages};
 pub use self::cargo_read_manifest::{read_manifest,read_package,read_packages};
 pub use self::cargo_rustc::{compile_targets, Compilation, Kind, Unit};
 pub use self::cargo_rustc::Context;

--- a/tests/workspaces.rs
+++ b/tests/workspaces.rs
@@ -655,6 +655,29 @@ fn virtual_build() {
     let p = project("foo")
         .file("Cargo.toml", r#"
             [workspace]
+            members = ["bar"]
+        "#)
+        .file("bar/Cargo.toml", r#"
+            [project]
+            name = "bar"
+            version = "0.1.0"
+            authors = []
+        "#)
+        .file("bar/src/main.rs", "fn main() {}");
+    p.build();
+    assert_that(p.cargo("build"),
+                execs().with_status(101)
+                       .with_stderr("\
+error: manifest path `[..]` is a virtual manifest, but this command \
+requires running against an actual package in this workspace
+"));
+}
+
+#[test]
+fn virtual_build_no_members() {
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [workspace]
         "#)
         .file("bar/Cargo.toml", r#"
             [project]


### PR DESCRIPTION
Work towards #2878.

This flag allows a user to test all members of a workspace by using `cargo test --all`. The command is also supported when using a virtual workspace manifest.
