### PR TITLE
Fix rust-lang/rust#35203 warning/error

### DIFF
--- a/tests/cargotest/support/mod.rs
+++ b/tests/cargotest/support/mod.rs
@@ -608,7 +608,7 @@ pub fn shell_writes<T: fmt::Display>(string: T) -> ShellWrites {
 }
 
 pub trait Tap {
-    fn tap<F: FnOnce(&mut Self)>(mut self, callback: F) -> Self;
+    fn tap<F: FnOnce(&mut Self)>(self, callback: F) -> Self;
 }
 
 impl<T> Tap for T {


### PR DESCRIPTION
rust-lang/rust#35203 made patterns in functions without body into a warn by default lint (which is being `deny`ed here).

cc rust-lang/rust#37378, rust-lang/rust#37416