### PR TITLE
Continuously publish Cargo builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,49 +1,149 @@
 language: rust
-rust:
-  - stable
-  - beta
-  - nightly
-sudo: false
-script:
-  - ./configure --prefix=$HOME/cargo-install --disable-cross-tests --disable-optimize
-  - make
-  - make test
-  - make distcheck
-  - make doc
-  - make install
-  - make uninstall
-after_success: |
-  [ $TRAVIS_BRANCH = master ] &&
-  [ $TRAVIS_PULL_REQUEST = false ] &&
-  [ $(uname -s) = Linux ] &&
-  pip install ghp-import --user $USER &&
-  $HOME/.local/bin/ghp-import -n target/doc &&
-  git push -qf https://${TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git gh-pages
-env:
-  global:
-    # apparently we use too much memory and if there's more than one rustc then
-    # when compiling Cargo's unit tests some compilers will be randomly kill
-    # -9'd
-    - CARGOFLAGS=-j1
-    - secure: scGpeetUfba5RWyuS4yt10bPoFAI9wpHEReIFqEx7eH5vr2Anajk6+70jW6GdrWVdUvdINiArlQ3An2DeB9vEUWcBjw8WvuPtOH0tDMoSsuVloPlFD8yn1Ac0Bx9getAO5ofxqtoNg+OV4MDVuGabEesqAOWqURNrBC7XK+ntC8=
+rust: stable
+sudo: required
+dist: trusty
+os: linux
+services:
+  - docker
 
 matrix:
   include:
-    - os: osx
-      rust: stable
+    # stable linux builds, tested
+    - env: TARGET=x86_64-unknown-linux-gnu
+           ALT=i686-unknown-linux-gnu
+           IMAGE=dist
+           MAKE_TARGETS="test distcheck doc install uninstall"
+    - env: TARGET=i686-unknown-linux-gnu
+           IMAGE=dist
+           MAKE_TARGETS=test-unit-i686-unknown-linux-gnu
+           CFG_DISABLE_CROSS_TESTS=1
+
+    # stable osx builds, tested
+    - env: TARGET=x86_64-apple-darwin
+           ALT=i686-apple-darwin
+           MAKE_TARGETS="test distcheck doc install uninstall"
+           MACOSX_DEPLOYMENT_TARGET=10.7
+      os: osx
       before_install:
         - export OPENSSL_INCLUDE_DIR=`brew --prefix openssl`/include
-        - export OPENSSL_LIB_DIR=`brew --prefix openssl`/lib
+        - export OPENSSL_LIB_DIR=`brew --prefix openssl`/include
+    - env: TARGET=i686-apple-darwin
+           MAKE_TARGETS=test
+           MACOSX_DEPLOYMENT_TARGET=10.7
+           CFG_DISABLE_CROSS_TESTS=1
+      os: osx
+      before_install:
+        - export OPENSSL_INCLUDE_DIR=`brew --prefix openssl`/include
+        - export OPENSSL_LIB_DIR=`brew --prefix openssl`/include
 
-branches:
-  only:
-    - master
+    # stable musl target, tested
+    - env: TARGET=x86_64-unknown-linux-musl
+           IMAGE=x86_64-musl
+           CFG_DISABLE_CROSS_TESTS=1
+           MAKE_TARGETS=test-unit-$TARGET
 
-addons:
-  apt:
-    sources:
-      - kalakris-cmake
-    packages:
-      - cmake
-      - g++-multilib
-      - lib32stdc++6
+    # cross compiled targets
+    - env: TARGET=arm-unknown-linux-gnueabi
+           IMAGE=cross
+    - env: TARGET=arm-unknown-linux-gnueabihf
+           IMAGE=cross
+    - env: TARGET=armv7-unknown-linux-gnueabihf
+           IMAGE=cross
+    - env: TARGET=aarch64-unknown-linux-gnu
+           IMAGE=cross
+    - env: TARGET=i686-unknown-freebsd
+           IMAGE=cross
+    - env: TARGET=x86_64-unknown-freebsd
+           IMAGE=cross
+    - env: TARGET=x86_64-unknown-netbsd
+           IMAGE=cross
+    - env: TARGET=mips-unknown-linux-gnu
+           IMAGE=cross
+    - env: TARGET=mipsel-unknown-linux-gnu
+           IMAGE=cross
+    - env: TARGET=mips64-unknown-linux-gnuabi64
+           IMAGE=cross
+      rust: nightly
+    - env: TARGET=mips64el-unknown-linux-gnuabi64
+           IMAGE=cross
+      rust: nightly
+    - env: TARGET=s390x-unknown-linux-gnu
+           IMAGE=cross
+      rust: nightly
+    - env: TARGET=powerpc-unknown-linux-gnu
+           IMAGE=cross
+      rust: beta
+    - env: TARGET=powerpc64-unknown-linux-gnu
+           IMAGE=cross
+      rust: beta
+    - env: TARGET=powerpc64le-unknown-linux-gnu
+           IMAGE=cross
+      rust: beta
+
+    # beta/nightly builds
+    - env: TARGET=x86_64-unknown-linux-gnu
+           ALT=i686-unknown-linux-gnu
+           IMAGE=dist
+           MAKE_TARGETS="test distcheck doc install uninstall"
+           DEPLOY=0
+      rust: beta
+    - env: TARGET=x86_64-unknown-linux-gnu
+           ALT=i686-unknown-linux-gnu
+           IMAGE=dist
+           MAKE_TARGETS="test distcheck doc install uninstall"
+           DEPLOY=0
+      rust: nightly
+
+  exclude:
+    - rust: stable
+
+before_script:
+  - pip install 'travis-cargo<0.2' --user && export PATH=$HOME/.local/bin:$PATH
+  - curl https://static.rust-lang.org/rustup.sh |
+    sh -s -- --add-target=$TARGET --disable-sudo -y --prefix=`rustc --print sysroot`
+  - if [ ! -z "$ALT" ]; then
+      curl https://static.rust-lang.org/rustup.sh |
+      sh -s -- --add-target=$ALT --disable-sudo -y --prefix=`rustc --print sysroot`;
+    fi
+script:
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then
+        SRC=. src/ci/run.sh $TARGET;
+    else
+        src/ci/docker/run.sh $IMAGE $TARGET;
+    fi
+after_success:
+  - travis-cargo --only nightly doc-upload
+
+env:
+  global:
+    - DEPLOY=1
+    - secure: LB2o9UL90Z4CVOLVQsTbZr7ZBLA1dCLxFODuCkPkbdqG3Kl5z1yMIPMRvSbjp9KwBlIgm+Mg0R1iqphKVq+rVP5zo96K4+kEQMG+zWsPb23ZKTxiL8MK5VgCZ7s9AONCvNeCTCNAG3EyeciFr5Zr9eygVCfo0WF6JsPujYYQZx0=
+
+notifications:
+  email:
+    on_success: never
+
+before_deploy:
+  - mkdir -p deploy/$TRAVIS_COMMIT
+  - cp target/$TARGET/release/dist/cargo-nightly-$TARGET.tar.gz
+    deploy/$TRAVIS_COMMIT
+
+deploy:
+  - provider: s3
+    bucket: rust-lang-cargo-dev
+    skip_cleanup: true
+    local_dir: deploy
+    upload_dir: cargo-master
+    acl: public_read
+    region: us-west-1
+    access_key_id: AKIAJYHGN72KKCN4DFBQ
+    secret_access_key:
+      secure: wKKDMYBVTdWLuc7+ffpjTqJs1EdM2pXpV6keUfZGv9RLRta+esh/r/cgc+UQ7+m9JHAliH8eWhlMm5ws6WDgkTvM0PTdqWBgwd24BRbAitsXX2kWfi9WgAeSJVSkIJdZ999TRpRIJu7Zc+1++fbfdD/tDv5XBirQGOJv1HynVWY=
+    on:
+      branch: auto
+      condition: $DEPLOY = 1
+
+cache:
+  directories:
+    - $HOME/.cargo
+    - target/openssl

--- a/Makefile.in
+++ b/Makefile.in
@@ -6,11 +6,6 @@ OPENSSL_SHA256=e7aff292be21c259c6af26469c7a9b3ba26e9abaaffd325e3dccc9785256c431
 
 include config.mk
 
-ifneq ($(CFG_LOCAL_RUST_ROOT),)
-export LD_LIBRARY_PATH := $(CFG_LOCAL_RUST_ROOT)/lib:$(LD_LIBRARY_PATH)
-export DYLD_LIBRARY_PATH := $(CFG_LOCAL_RUST_ROOT)/lib:$(DYLD_LIBRARY_PATH)
-endif
-
 export PATH := $(dir $(CFG_RUSTC)):$(PATH)
 
 ifdef CFG_ENABLE_NIGHTLY
@@ -84,44 +79,45 @@ $(foreach target,$(CFG_TARGET),$(eval $(call DIST_TARGET,$(target))))
 ifdef CFG_LOCAL_CARGO
 CARGO := $(CFG_LOCAL_CARGO)
 else
-CARGO := $(TARGET_ROOT)/snapshot/bin/cargo$(X)
+CARGO := $(CFG_CARGO)
 endif
 
 all: $(foreach target,$(CFG_TARGET),cargo-$(target))
 
 define CARGO_TARGET
-cargo-$(1): $$(CARGO) target/openssl/$(1).stamp
+cargo-$(1): target/openssl/$(1).stamp
 	$$(CFG_RUSTC) -V
 	$$(CARGO) --version
 	$$(CARGO) build --target $(1) \
 		--manifest-path $(S)Cargo.toml \
 		$$(OPT_FLAG) $$(CARGOFLAGS) $$(VERBOSE_FLAG) $$(ARGS)
 
-test-unit-$(1): $$(CARGO)
-	@mkdir -p target/$(1)/cit
-	$$(CARGO) test --target $(1) $$(CARGOFLAGS) $$(VERBOSE_FLAG) $$(only)
+test-unit-$(1): target/openssl/$(1).stamp cargo-$(1)
+	@mkdir -p $$(CFG_BUILD_DIR)/target/$(1)/cit
+	$$(CARGO) test --target $(1) \
+		--manifest-path $(S)Cargo.toml \
+		$$(OPT_FLAG) $$(CARGOFLAGS) $$(VERBOSE_FLAG) $$(only)
 endef
 $(foreach target,$(CFG_TARGET),$(eval $(call CARGO_TARGET,$(target))))
-
-$(TARGET_ROOT)/snapshot/bin/cargo$(X): $(S)src/snapshots.txt
-	$(CFG_PYTHON) $(S)src/etc/dl-snapshot.py $(CFG_BUILD)
-	touch $@
-
 
 # === Tests
 
 test: style no-exes $(foreach target,$(CFG_TARGET),test-unit-$(target))
 
 style:
-	sh tests/check-style.sh
+	(cd $(S) && sh tests/check-style.sh)
 
+ifeq ($(CFG_GIT),)
 no-exes:
-	find $$(git ls-files) -type f \
+else
+no-exes:
+	(cd $(S) && find $$($(CFG_GIT) ls-files) -type f \
 		\( -perm -u+x -or -perm -g+x -or -perm -o+x \) \
 		-not -name configure -not -name '*.sh' -not -name '*.rs' \
 		-not -name '*.py' -not -wholename "*/rust-installer/*" | \
 		grep '.*' \
-		&& exit 1 || exit 0
+		&& exit 1 || exit 0)
+endif
 
 # === Misc
 
@@ -142,9 +138,9 @@ DOC_OPTS := --markdown-no-toc \
 		--markdown-css stylesheets/normalize.css \
 		--markdown-css stylesheets/all.css \
 		--markdown-css stylesheets/prism.css \
-		--html-in-header src/doc/html-headers.html \
-		--html-before-content src/doc/header.html \
-		--html-after-content src/doc/footer.html
+		--html-in-header $(S)src/doc/html-headers.html \
+		--html-before-content $(S)src/doc/header.html \
+		--html-after-content $(S)src/doc/footer.html
 ASSETS := CNAME images/noise.png images/forkme.png images/Cargo-Logo-Small.png \
 	stylesheets/all.css stylesheets/normalize.css javascripts/prism.js \
 	javascripts/all.js stylesheets/prism.css images/circle-with-i.png \
@@ -155,14 +151,19 @@ doc: $(foreach doc,$(DOCS),target/doc/$(doc).html) \
 	$(foreach asset,$(ASSETS),target/doc/$(asset)) \
 	target/doc/cargo/index.html
 
-target/doc/cargo/index.html:
-	$(CARGO) doc --no-deps
+target/doc/cargo/index.html: target/openssl/$(CFG_BUILD).stamp cargo-$(CFG_BUILD)
+	$(CARGO) doc --no-deps --target $(CFG_BUILD) \
+		--manifest-path $(S)Cargo.toml $(OPT_FLAG)
 
-$(DOC_DIR)/%.html: src/doc/%.md src/doc/html-headers.html src/doc/header.html src/doc/footer.html
+$(DOC_DIR)/%.html: \
+		$(S)src/doc/%.md \
+		$(S)src/doc/html-headers.html \
+		$(S)src/doc/header.html \
+		$(S)src/doc/footer.html
 	@mkdir -p $(@D)
 	$(CFG_RUSTDOC) $< -o $(@D) $(DOC_OPTS)
 
-$(DOC_DIR)/%: src/doc/%
+$(DOC_DIR)/%: $(S)src/doc/%
 	@mkdir -p $(@D)
 	cp $< $@
 
@@ -172,6 +173,7 @@ OPENSSL_OS_arm-unknown-linux-gnueabihf := linux-armv4
 OPENSSL_OS_armv7-unknown-linux-gnueabihf := linux-armv4
 OPENSSL_OS_i686-unknown-freebsd := BSD-x86-elf
 OPENSSL_OS_i686-unknown-linux-gnu := linux-elf
+OPENSSL_OS_i686-unknown-linux-musl := linux-elf
 OPENSSL_OS_mips-unknown-linux-gnu := linux-mips32
 OPENSSL_OS_mipsel-unknown-linux-gnu := linux-mips32
 OPENSSL_OS_mips64-unknown-linux-gnuabi64 := linux64-mips64
@@ -191,6 +193,7 @@ OPENSSL_AR_arm-unknown-linux-gnueabihf := arm-linux-gnueabihf-ar
 OPENSSL_AR_armv7-unknown-linux-gnueabihf := armv7-linux-gnueabihf-ar
 OPENSSL_AR_i686-unknown-freebsd := i686-unknown-freebsd10-ar
 OPENSSL_AR_i686-unknown-linux-gnu := ar
+OPENSSL_AR_i686-unknown-linux-musl := ar
 OPENSSL_AR_mips-unknown-linux-gnu := mips-linux-gnu-ar
 OPENSSL_AR_mips64-unknown-linux-gnuabi64 := mips64-linux-gnuabi64-ar
 OPENSSL_AR_mips64el-unknown-linux-gnuabi64 := mips64el-linux-gnuabi64-ar
@@ -209,6 +212,7 @@ OPENSSL_CC_arm-unknown-linux-gnueabihf := arm-linux-gnueabihf-gcc
 OPENSSL_CC_armv7-unknown-linux-gnueabihf := armv7-linux-gnueabihf-gcc
 OPENSSL_CC_i686-unknown-freebsd := i686-unknown-freebsd10-gcc
 OPENSSL_CC_i686-unknown-linux-gnu := gcc
+OPENSSL_CC_i686-unknown-linux-musl := musl-gcc
 OPENSSL_CC_mips-unknown-linux-gnu := mips-linux-gnu-gcc
 OPENSSL_CC_mips64-unknown-linux-gnuabi64 := mips64-linux-gnuabi64-gcc
 OPENSSL_CC_mips64el-unknown-linux-gnuabi64 := mips64el-linux-gnuabi64-gcc
@@ -224,6 +228,7 @@ OPENSSL_CC_x86_64-unknown-netbsd := x86_64-unknown-netbsd-gcc
 
 SETARCH_i686-unknown-linux-gnu := setarch i386
 OPENSSL_CFLAGS_i686-unknown-linux-gnu := -m32
+OPENSSL_CFLAGS_i686-unknown-linux-musl := -m32
 
 define BUILD_OPENSSL
 ifdef OPENSSL_OS_$(1)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,37 +1,71 @@
 environment:
-  CFG_DISABLE_CROSS_TESTS: 1
   matrix:
-  - TARGET: i686-pc-windows-msvc
-    MSVC: 1
-    BITS: 32
-    ARCH: x86
-  - TARGET: x86_64-pc-windows-msvc
-    MSVC: 1
-    BITS: 64
-    ARCH: amd64
   - TARGET: x86_64-pc-windows-gnu
     ARCH: amd64
     BITS: 64
+    CFG_DISABLE_CROSS_TESTS: 1
+    MAKE_TARGETS: test-unit-x86_64-pc-windows-gnu
   - TARGET: i686-pc-windows-gnu
     ARCH: x86
     BITS: 32
     MINGW_URL: https://s3.amazonaws.com/rust-lang-ci
     MINGW_ARCHIVE: i686-4.9.2-release-win32-dwarf-rt_v4-rev4.7z
     MINGW_DIR: mingw32
+    CFG_DISABLE_CROSS_TESTS: 1
+    MAKE_TARGETS: test-unit-i686-pc-windows-gnu
+  - TARGET: i686-pc-windows-msvc
+    BITS: 32
+    ARCH: x86
+    MAKE_TARGETS: test-unit-i686-pc-windows-msvc
+    CFG_DISABLE_CROSS_TESTS: 1
+  - TARGET: x86_64-pc-windows-msvc
+    OTHER_TARGET: i686-pc-windows-msvc
+    BITS: 64
+    ARCH: amd64
+    MAKE_TARGETS: test-unit-x86_64-pc-windows-msvc
 
 install:
-  - IF "%MSVC%"=="" set PATH=C:\msys64\mingw%BITS%\bin;C:\msys64\usr\bin;%PATH%
+  - set PATH=C:\msys64\mingw%BITS%\bin;C:\msys64\usr\bin;%PATH%
   - if defined MINGW_URL appveyor DownloadFile %MINGW_URL%/%MINGW_ARCHIVE%
   - if defined MINGW_URL 7z x -y %MINGW_ARCHIVE% > nul
   - if defined MINGW_URL set PATH=%CD%\%MINGW_DIR%\bin;C:\msys64\usr\bin;%PATH%
-  - python src/etc/install-deps.py
-  - python src/etc/dl-snapshot.py %TARGET%
-  - SET PATH=%PATH%;%cd%/rustc/bin
-  - SET PATH=%PATH%;%cd%/target/snapshot/bin
+  - curl -sSf -o rustup-init.exe https://win.rustup.rs/
+  - rustup-init.exe -y --default-host x86_64-pc-windows-msvc
+  - set PATH=%PATH%;C:\Users\appveyor\.cargo\bin
+  - if NOT "%TARGET%" == "x86_64-pc-windows-msvc" rustup target add %TARGET%
+  - if defined OTHER_TARGET rustup target add %OTHER_TARGET%
   - rustc -V
   - cargo -V
+  - git submodule update --init
 
 build: false
 
 test_script:
-  - cargo test
+  - sh src/ci/run.sh %TARGET%
+
+cache:
+  - target
+  - C:\Users\appveyor\.cargo\registry
+
+after_test:
+  - mkdir %APPVEYOR_REPO_COMMIT%
+  - copy target\%TARGET%\release\dist\cargo-nightly-%TARGET%.tar.gz
+         %APPVEYOR_REPO_COMMIT%
+
+artifacts:
+  - path: $(APPVEYOR_REPO_COMMIT)\cargo-nightly-$(TARGET).tar.gz
+    name: cargo
+
+deploy:
+  - provider: S3
+    skip_cleanup: true
+    access_key_id: AKIAIIBSE766REJRCHEA
+    secret_access_key:
+      secure: S3MCw/gXyWBuq8cW+eFQjbfjccxrH1koYqQxsYDvCDkM7D2PLqd88yv8lND7dVt0
+    bucket: rust-lang-cargo-dev
+    set_public: true
+    region: us-west-1
+    artifact: cargo
+    folder: cargo-master
+    on:
+      branch: auto

--- a/configure
+++ b/configure
@@ -270,9 +270,7 @@ need_cmd date
 need_cmd tr
 need_cmd sed
 need_cmd cmake
-if [ "${OS}" != "Windows_NT" ]; then
-    need_cmd curl
-fi
+need_cmd make
 
 CFG_SRC_DIR="$(cd $(dirname $0) && pwd)/"
 CFG_BUILD_DIR="$(pwd)/"
@@ -309,20 +307,20 @@ opt cross-tests 1 "run cross-compilation tests"
 valopt prefix "/usr/local" "set installation prefix"
 valopt local-rust-root "" "set prefix for local rust binary"
 
+if [ ! -z "${CFG_LOCAL_RUST_ROOT}" ]; then
+    export LD_LIBRARY_PATH="${CFG_LOCAL_RUST_ROOT}/lib:$LD_LIBRARY_PATH"
+    export DYLD_LIBRARY_PATH="${CFG_LOCAL_RUST_ROOT}/lib:$DYLD_LIBRARY_PATH"
+    export PATH="${CFG_LOCAL_RUST_ROOT}/bin:$PATH"
+fi
+
+valopt cargo "cargo" "cargo to bootstrap from"
+valopt rustc "rustc" "rustc to compile with"
+valopt rustdoc "rustdoc" "rustdoc to document with"
+
 if [ $HELP -eq 0 ]; then
-    if [ ! -z "${CFG_LOCAL_RUST_ROOT}" ]; then
-        export LD_LIBRARY_PATH="${CFG_LOCAL_RUST_ROOT}/lib:$LD_LIBRARY_PATH"
-        export DYLD_LIBRARY_PATH="${CFG_LOCAL_RUST_ROOT}/lib:$DYLD_LIBRARY_PATH"
-        LRV=`${CFG_LOCAL_RUST_ROOT}/bin/rustc --version`
-        if [ $? -eq 0 ]; then
-            step_msg "using rustc at: ${CFG_LOCAL_RUST_ROOT} with version: $LRV"
-        else
-            err "failed to run rustc at: ${CFG_LOCAL_RUST_ROOT}"
-        fi
-        CFG_RUSTC="${CFG_LOCAL_RUST_ROOT}/bin/rustc"
-    else
-        probe_need CFG_RUSTC        rustc
-    fi
+    probe_need CFG_CARGO $CFG_CARGO
+    probe_need CFG_RUSTC $CFG_RUSTC
+    probe_need CFG_RUSTDOC $CFG_RUSTDOC
     DEFAULT_BUILD=$("${CFG_RUSTC}" -vV | grep 'host: ' | sed 's/host: //')
 fi
 
@@ -337,7 +335,6 @@ valopt infodir "${CFG_PREFIX}/share/info" "install additional info"
 valopt docdir "${CFG_PREFIX}/share/doc/cargo" "install extra docs"
 valopt mandir "${CFG_PREFIX}/share/man" "install man pages in PATH"
 valopt libdir "${CFG_PREFIX}/lib" "install libraries"
-valopt local-cargo "" "local cargo to bootstrap from"
 
 if [ $HELP -eq 1 ]
 then
@@ -354,15 +351,8 @@ fi
 
 step_msg "looking for build programs"
 
-probe_need CFG_CURLORWGET  curl wget
-probe_need CFG_PYTHON      python2.7 python2 python
 probe_need CFG_CC          cc gcc clang
-
-if [ ! -z "${CFG_LOCAL_RUST_ROOT}" ]; then
-    CFG_RUSTDOC="${CFG_LOCAL_RUST_ROOT}/bin/rustdoc"
-else
-    probe_need CFG_RUSTDOC        rustdoc
-fi
+probe GIT git
 
 # a little post-processing of various config values
 CFG_PREFIX=${CFG_PREFIX%/}
@@ -396,6 +386,7 @@ if [ "$CFG_SRC_DIR" != "$CFG_BUILD_DIR" ]; then
 fi
 
 if [ ! -z "$CFG_ENABLE_NIGHTLY" ]; then
+    need_cmd curl
     if [ ! -f .cargo/config ]; then
         mkdir -p .cargo
         cat > .cargo/config <<-EOF
@@ -449,6 +440,8 @@ putvar CFG_MANDIR
 putvar CFG_LIBDIR
 putvar CFG_RUSTC
 putvar CFG_RUSTDOC
+putvar CFG_CARGO
+putvar CFG_GIT
 
 msg
 copy_if_changed ${CFG_SRC_DIR}Makefile.in ./Makefile

--- a/src/ci/docker/cross/Dockerfile
+++ b/src/ci/docker/cross/Dockerfile
@@ -1,0 +1,2 @@
+FROM alexcrichton/rust-slave-linux-cross:2016-10-11c
+ENTRYPOINT []

--- a/src/ci/docker/dist/Dockerfile
+++ b/src/ci/docker/dist/Dockerfile
@@ -1,0 +1,2 @@
+FROM alexcrichton/rust-slave-dist:2016-09-26
+ENTRYPOINT []

--- a/src/ci/docker/run.sh
+++ b/src/ci/docker/run.sh
@@ -1,0 +1,49 @@
+#!/bin/sh
+# Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+# file at the top-level directory of this distribution and at
+# http://rust-lang.org/COPYRIGHT.
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+set -e
+
+script=`cd $(dirname $0) && pwd`/`basename $0`
+image=$1
+TARGET=$2
+
+docker_dir="`dirname $script`"
+ci_dir="`dirname $docker_dir`"
+src_dir="`dirname $ci_dir`"
+root_dir="`dirname $src_dir`"
+
+docker build \
+  --rm \
+  -t rust-ci \
+  "`dirname "$script"`/$image"
+
+mkdir -p $HOME/.cargo
+mkdir -p target
+
+exec docker run \
+  --user `id -u`:`id -g` \
+  --volume "$root_dir:/checkout:ro" \
+  --workdir /tmp \
+  --env CFG_DISABLE_CROSS_TESTS=$CFG_DISABLE_CROSS_TESTS \
+  --env MAKE_TARGETS="$MAKE_TARGETS" \
+  --env SRC=/checkout \
+  --env CARGO_HOME=/cargo \
+  --volume "$HOME/.cargo:/cargo" \
+  --volume `rustc --print sysroot`:/rust:ro \
+  --volume `pwd`/target:/tmp/target \
+  --interactive \
+  --tty \
+  rust-ci \
+  sh -c "\
+    PATH=\$PATH:/rust/bin \
+    LD_LIBRARY_PATH=/rust/lib:\$LD_LIBRARY_PATH \
+    /checkout/src/ci/run.sh $TARGET"
+

--- a/src/ci/docker/x86_64-musl/Dockerfile
+++ b/src/ci/docker/x86_64-musl/Dockerfile
@@ -1,0 +1,11 @@
+FROM ubuntu:16.04
+
+RUN apt-get update -y && apt-get install -y --no-install-recommends \
+  cmake \
+  make \
+  gcc \
+  musl-tools \
+  curl \
+  ca-certificates \
+  libc6-dev \
+  git

--- a/src/ci/run.sh
+++ b/src/ci/run.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+# Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+# file at the top-level directory of this distribution and at
+# http://rust-lang.org/COPYRIGHT.
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+set -ex
+
+TARGET=$1
+
+if [ -z "$SRC" ]; then
+    SRC=.
+fi
+
+$SRC/configure \
+    --prefix=/tmp/obj/install \
+    --target=$TARGET \
+    --enable-nightly
+
+make cargo-$TARGET
+make dist-$TARGET
+
+if [ ! -z "$MAKE_TARGETS" ]; then
+  for target in "$MAKE_TARGETS"; do
+    make $target
+  done
+fi

--- a/src/etc/install-deps.py
+++ b/src/etc/install-deps.py
@@ -55,11 +55,18 @@ else:
 
 rust_date = open('src/rustversion.txt').read().strip()
 url = 'https://static.rust-lang.org/dist/' + rust_date
+cargo_url = 'https://static.rust-lang.org/cargo-dist/2016-03-21'
 
 
 def install_via_tarballs():
     if os.path.isdir("rustc-install"):
         shutil.rmtree("rustc-install")
+
+    # Download cargo
+    host_fname = 'cargo-nightly-' + host + '.tar.gz'
+    download.get(cargo_url + '/' + host_fname, host_fname)
+    download.unpack(host_fname, "rustc-install", quiet=True, strip=2)
+    os.remove(host_fname)
 
     # Download the compiler
     host_fname = 'rustc-nightly-' + host + '.tar.gz'

--- a/tests/init.rs
+++ b/tests/init.rs
@@ -7,13 +7,13 @@ use std::fs::{self, File};
 use std::io::prelude::*;
 use std::env;
 
-use cargo::util::{process, ProcessBuilder};
+use cargo::util::ProcessBuilder;
 use cargotest::support::{execs, paths, cargo_dir};
 use hamcrest::{assert_that, existing_file, existing_dir, is_not};
 use tempdir::TempDir;
 
 fn cargo_process(s: &str) -> ProcessBuilder {
-    let mut p = process(&cargo_dir().join("cargo"));
+    let mut p = cargotest::process(&cargo_dir().join("cargo"));
     p.arg(s).cwd(&paths::root()).env("HOME", &paths::home());
     return p;
 }

--- a/tests/package.rs
+++ b/tests/package.rs
@@ -10,8 +10,7 @@ use std::fs::{File, OpenOptions};
 use std::io::prelude::*;
 use std::path::{Path, PathBuf};
 
-use cargo::util::process;
-use cargotest::cargo_process;
+use cargotest::{cargo_process, process};
 use cargotest::support::{project, execs, paths, git, path2url, cargo_dir};
 use flate2::read::GzDecoder;
 use hamcrest::{assert_that, existing_file, contains};


### PR DESCRIPTION
This commit tweaks Cargo's automation to continuously publish builds on Travis
an AppVeyor. Once this is merged we can hopefully turn off all buildbot
automation related to Cargo and purely rely on Travis and AppVeyor for this
repository. All CI matrices are ported over to Travis and AppVeyor and a new
musl build of Cargo is even added just to test out adding that for a spin.

Currently Cargo will upload the final artifact for each target to a directory
keyed by the commit hash to a new bucket on S3, rust-lang-cargo-dev. Once we're
happy with the builds then we can change this to `rust-lang-cargo` or anything
else at that point.