### PR TITLE
FIX: Call rustdoc test with the correct cfg flags of a package.

### DIFF
--- a/src/cargo/ops/cargo_rustc/compilation.rs
+++ b/src/cargo/ops/cargo_rustc/compilation.rs
@@ -43,8 +43,8 @@ pub struct Compilation<'cfg> {
 
     pub to_doc_test: Vec<Package>,
 
-    /// Features enabled during this compilation.
-    pub cfgs: HashSet<String>,
+    /// Features per package enabled during this compilation.
+    pub cfgs: HashMap<PackageId, HashSet<String>>,
 
     pub target: String,
 
@@ -63,7 +63,7 @@ impl<'cfg> Compilation<'cfg> {
             binaries: Vec::new(),
             extra_env: HashMap::new(),
             to_doc_test: Vec::new(),
-            cfgs: HashSet::new(),
+            cfgs: HashMap::new(),
             config: config,
             target: String::new(),
         }

--- a/src/cargo/ops/cargo_rustc/mod.rs
+++ b/src/cargo/ops/cargo_rustc/mod.rs
@@ -143,11 +143,9 @@ pub fn compile_targets<'a, 'cfg: 'a>(ws: &Workspace<'cfg>,
         }
 
         if let Some(feats) = cx.resolve.features(&unit.pkg.package_id()) {
-            for feat in feats.iter() {
-                cx.compilation.cfgs.entry(unit.pkg.package_id().clone())
-                    .or_insert(HashSet::new())
-                    .insert(format!("feature=\"{}\"", feat));
-            }
+            cx.compilation.cfgs.entry(unit.pkg.package_id().clone())
+                .or_insert(HashSet::new())
+                .extend(feats.iter().map(|feat| format!("feature=\"{}\"", feat)));
         }
     }
 

--- a/src/cargo/ops/cargo_test.rs
+++ b/src/cargo/ops/cargo_test.rs
@@ -145,8 +145,10 @@ fn run_doc_tests(options: &TestOptions,
                 p.arg("--test-args").arg(&test_args.join(" "));
             }
 
-            for cfg in compilation.cfgs.iter() {
-                p.arg("--cfg").arg(cfg);
+            if let Some(cfgs) = compilation.cfgs.get(&package.package_id()) {
+                for cfg in cfgs.iter() {
+                    p.arg("--cfg").arg(cfg);
+                }
             }
 
             for (_, libs) in compilation.libraries.iter() {

--- a/src/doc/machine-readable-output.md
+++ b/src/doc/machine-readable-output.md
@@ -7,7 +7,7 @@ Cargo can output information about project and build in JSON format.
 You can use `cargo metadata` command to get information about project structure
 and dependencies. The output of the command looks like this:
 
-```
+```text
 {
   // Integer version number of the format.
   "version": integer,
@@ -59,7 +59,7 @@ without waiting for the whole build to finish.
 
 The message format looks like this:
 
-```
+```text
 {
   // Type of the message.
   "reason": "compiler-message",

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -2273,11 +2273,11 @@ fn pass_correct_cfgs_flags_to_rustdoc() {
             authors = []
 
             [features]
-            default = ["a/default"]
-            nightly = ["a/nightly"]
+            default = ["feature_a/default"]
+            nightly = ["feature_a/nightly"]
 
-            [dependencies.a]
-            path = "libs/a"
+            [dependencies.feature_a]
+            path = "libs/feature_a"
             default-features = false
         "#)
         .file("src/lib.rs", r#"
@@ -2289,9 +2289,9 @@ fn pass_correct_cfgs_flags_to_rustdoc() {
                 }
             }
         "#)
-        .file("libs/a/Cargo.toml", r#"
+        .file("libs/feature_a/Cargo.toml", r#"
             [package]
-            name = "a"
+            name = "feature_a"
             version = "0.1.0"
             authors = []
 
@@ -2305,7 +2305,7 @@ fn pass_correct_cfgs_flags_to_rustdoc() {
             [build-dependencies]
             serde_codegen = { version = "0.8", optional = true }
         "#)
-        .file("libs/a/src/lib.rs", r#"
+        .file("libs/feature_a/src/lib.rs", r#"
             #[cfg(feature = "serde_derive")]
             const MSG: &'static str = "This is safe";
 
@@ -2318,17 +2318,17 @@ fn pass_correct_cfgs_flags_to_rustdoc() {
         "#);
 
     assert_that(p.cargo_process("test")
-                .arg("--package").arg("a")
+                .arg("--package").arg("feature_a")
                 .arg("--verbose"),
                 execs().with_status(0)
                        .with_stderr_contains("\
-[DOCTEST] a
-[RUNNING] `rustdoc --test [..]--cfg feature=\\\"serde_codegen\\\"[..]`"));
+[DOCTEST] feature_a
+[RUNNING] `rustdoc --test [..]serde_codegen[..]`"));
 
     assert_that(p.cargo_process("test")
                 .arg("--verbose"),
                 execs().with_status(0)
                        .with_stderr_contains("\
 [DOCTEST] foo
-[RUNNING] `rustdoc --test [..]--cfg feature=\\\"a\\\"[..]`"));
+[RUNNING] `rustdoc --test [..]feature_a[..]`"));
 }


### PR DESCRIPTION
There was a situation in which if you you had a lib that depends on a package with features, whenever you ran the tests for the package the `rustdoc test` call was failing because it was called with the root `cfg` flags, not the package `cfg` flags.

This fix solves the issue by keeping track of the `cfg` flags per package, so the `rustdoc` command will be generated with the correct `cfg` flags.

Closes #3172 