### PR TITLE
Expose rustc cfg values to build scripts

### DIFF
--- a/src/cargo/ops/cargo_rustc/context.rs
+++ b/src/cargo/ops/cargo_rustc/context.rs
@@ -678,6 +678,15 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
         self.target_config(kind).ar.as_ref().map(|s| s.as_ref())
     }
 
+    /// Get the list of cfg printed out from the compiler for the specified kind
+    pub fn cfg(&self, kind: Kind) -> &[Cfg] {
+        let info = match kind {
+            Kind::Host => &self.host_info,
+            Kind::Target => &self.target_info,
+        };
+        info.cfg.as_ref().map(|s| &s[..]).unwrap_or(&[])
+    }
+
     /// Get the target configuration for a particular host or target
     fn target_config(&self, kind: Kind) -> &TargetConfig {
         match kind {

--- a/tests/build-script.rs
+++ b/tests/build-script.rs
@@ -2259,3 +2259,30 @@ fn rustc_and_rustdoc_set_correctly() {
     assert_that(build.cargo_process("bench"),
                 execs().with_status(0));
 }
+
+#[test]
+fn cfg_env_vars_available() {
+    let build = project("builder")
+        .file("Cargo.toml", r#"
+            [package]
+            name = "builder"
+            version = "0.0.1"
+            authors = []
+            build = "build.rs"
+        "#)
+        .file("src/lib.rs", "")
+        .file("build.rs", r#"
+            use std::env;
+
+            fn main() {
+                let fam = env::var("CARGO_CFG_TARGET_FAMILY").unwrap();
+                if cfg!(unix) {
+                    assert_eq!(fam, "unix");
+                } else {
+                    assert_eq!(fam, "windows");
+                }
+            }
+        "#);
+    assert_that(build.cargo_process("bench"),
+                execs().with_status(0));
+}


### PR DESCRIPTION
This commit is Cargo's portion of the implementation of [RFC 1721] where it will
expose values printed by `rustc --print cfg` to build scripts.

[RFC 1721]: https://github.com/rust-lang/rfcs/blob/master/text/1721-crt-static.md

This will in turn be used to communicate features like `-C
target-feature=+crt-static` which can be used to compile objects for statically
linking against the msvcrt on MSVC.