### PR TITLE
Use a single profile set per workspace

### DIFF
--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -33,6 +33,7 @@ pub struct Manifest {
 pub struct VirtualManifest {
     replace: Vec<(PackageIdSpec, Dependency)>,
     workspace: WorkspaceConfig,
+    profiles: Profiles,
 }
 
 /// General metadata about a package which is just blindly uploaded to the
@@ -139,7 +140,7 @@ pub struct Profile {
     pub panic: Option<String>,
 }
 
-#[derive(Default, Clone, Debug)]
+#[derive(Default, Clone, Debug, PartialEq, Eq)]
 pub struct Profiles {
     pub release: Profile,
     pub dev: Profile,
@@ -250,10 +251,12 @@ impl Manifest {
 
 impl VirtualManifest {
     pub fn new(replace: Vec<(PackageIdSpec, Dependency)>,
-               workspace: WorkspaceConfig) -> VirtualManifest {
+               workspace: WorkspaceConfig,
+               profiles: Profiles) -> VirtualManifest {
         VirtualManifest {
             replace: replace,
             workspace: workspace,
+            profiles: profiles,
         }
     }
 
@@ -263,6 +266,10 @@ impl VirtualManifest {
 
     pub fn workspace_config(&self) -> &WorkspaceConfig {
         &self.workspace
+    }
+
+    pub fn profiles(&self) -> &Profiles {
+        &self.profiles
     }
 }
 

--- a/src/cargo/ops/cargo_clean.rs
+++ b/src/cargo/ops/cargo_clean.rs
@@ -32,7 +32,7 @@ pub fn clean(ws: &Workspace, opts: &CleanOptions) -> CargoResult<()> {
     let resolve = try!(ops::resolve_ws(&mut registry, ws));
     let packages = ops::get_resolved_packages(&resolve, registry);
 
-    let profiles = try!(ws.current()).manifest().profiles();
+    let profiles = ws.profiles();
     let host_triple = try!(opts.config.rustc()).host.clone();
     let mut cx = try!(Context::new(ws, &resolve, &packages, opts.config,
                                    BuildConfig {

--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -169,7 +169,7 @@ pub fn compile_ws<'a>(ws: &Workspace<'a>,
         bail!("jobs must be at least 1")
     }
 
-    let profiles = root_package.manifest().profiles();
+    let profiles = ws.profiles();
     if spec.len() == 0 {
         try!(generate_targets(root_package, profiles, mode, filter, release));
     }

--- a/src/cargo/util/toml.rs
+++ b/src/cargo/util/toml.rs
@@ -725,6 +725,7 @@ impl TomlManifest {
             platform: None,
             layout: layout,
         }));
+        let profiles = build_profiles(&self.profile);
         let workspace_config = match self.workspace {
             Some(ref config) => {
                 WorkspaceConfig::Root { members: config.members.clone() }
@@ -733,7 +734,7 @@ impl TomlManifest {
                 bail!("virtual manifests must be configured with [workspace]");
             }
         };
-        Ok((VirtualManifest::new(replace, workspace_config), nested_paths))
+        Ok((VirtualManifest::new(replace, workspace_config, profiles), nested_paths))
     }
 
     fn replace(&self, cx: &mut Context)


### PR DESCRIPTION
This aims to close #3206. 

I have not figured out how to do this 100% backward compatibly, that's why I want to discuss this separately, although a related PR (#3221) is already in flight. 

The problem is this: suppose that you have a workspace with two members, A and B and that A includes a profiles section and B does not. Now, mentally `cd` inside B and run `cargo build`. Today, Cargo will use a default profile. We want it to use a profile from A. So here the silent behavior switch will inevitably occur :( Looks like we can't detect this situation. 


So this PR just switches the behavior to always use root profiles, and to print a warning if a non-root package specifies profiles. Feel free to reuse it in any form for #3221 if that's convenient! 