### PR TITLE
Add an [EXE] hamcrest substitution for file extension

### DIFF
--- a/tests/bench.rs
+++ b/tests/bench.rs
@@ -43,7 +43,7 @@ fn cargo_bench_simple() {
                 execs().with_stderr(&format!("\
 [COMPILING] foo v0.5.0 ({})
 [FINISHED] release [optimized] target(s) in [..]
-[RUNNING] target[..]release[..]foo-[..]", p.url()))
+[RUNNING] target[..]release[..]foo-[..][EXE]", p.url()))
                        .with_stdout("
 running 1 test
 test bench_hello ... bench: [..] 0 ns/iter (+/- 0)
@@ -78,7 +78,7 @@ fn bench_tarname() {
                .with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({dir})
 [FINISHED] release [optimized] target(s) in [..]
-[RUNNING] target[..]release[..]bin2[..]
+[RUNNING] target[..]release[..]bin2-[..][EXE]
 ", dir = prj.url()))
                .with_stdout("
 running 1 test
@@ -107,7 +107,7 @@ fn cargo_bench_verbose() {
 [COMPILING] foo v0.5.0 ({url})
 [RUNNING] `rustc src[..]foo.rs [..]`
 [FINISHED] release [optimized] target(s) in [..]
-[RUNNING] `[..]target[..]release[..]foo-[..] hello --bench`", url = p.url()))
+[RUNNING] `[..]target[..]release[..]foo-[..][EXE] hello --bench`", url = p.url()))
                        .with_stdout("
 running 1 test
 test bench_hello ... bench: [..] 0 ns/iter (+/- 0)
@@ -190,7 +190,7 @@ test bench_hello ... ")
                        .with_stderr_contains(format!("\
 [COMPILING] foo v0.5.0 ({})
 [FINISHED] release [optimized] target(s) in [..]
-[RUNNING] target[..]release[..]foo-[..]
+[RUNNING] target[..]release[..]foo-[..][EXE]
 thread '[..]' panicked at 'assertion failed: \
     `(left == right)` (left: \
     `\"hello\"`, right: `\"nope\"`)', src[..]foo.rs:14
@@ -243,8 +243,8 @@ fn bench_with_lib_dep() {
                 execs().with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({})
 [FINISHED] release [optimized] target(s) in [..]
-[RUNNING] target[..]release[..]baz-[..]
-[RUNNING] target[..]release[..]foo-[..]", p.url()))
+[RUNNING] target[..]release[..]baz-[..][EXE]
+[RUNNING] target[..]release[..]foo-[..][EXE]", p.url()))
                        .with_stdout("
 running 1 test
 test bin_bench ... bench: [..] 0 ns/iter (+/- 0)
@@ -307,7 +307,7 @@ fn bench_with_deep_lib_dep() {
 [COMPILING] foo v0.0.1 ([..])
 [COMPILING] bar v0.0.1 ({dir})
 [FINISHED] release [optimized] target(s) in [..]
-[RUNNING] target[..]", dir = p.url()))
+[RUNNING] target[..]release[..]deps[..]bar-[..][EXE]", dir = p.url()))
                        .with_stdout("
 running 1 test
 test bar_bench ... bench: [..] 0 ns/iter (+/- 0)
@@ -353,8 +353,8 @@ fn external_bench_explicit() {
                 execs().with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({})
 [FINISHED] release [optimized] target(s) in [..]
-[RUNNING] target[..]release[..]bench-[..]
-[RUNNING] target[..]release[..]foo-[..]", p.url()))
+[RUNNING] target[..]release[..]bench-[..][EXE]
+[RUNNING] target[..]release[..]foo-[..][EXE]", p.url()))
                        .with_stdout("
 running 1 test
 test external_bench ... bench: [..] 0 ns/iter (+/- 0)
@@ -403,8 +403,8 @@ fn external_bench_implicit() {
                 execs().with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({})
 [FINISHED] release [optimized] target(s) in [..]
-[RUNNING] target[..]release[..]external-[..]
-[RUNNING] target[..]release[..]foo-[..]", p.url()))
+[RUNNING] target[..]release[..]external-[..][EXE]
+[RUNNING] target[..]release[..]foo-[..][EXE]", p.url()))
                        .with_stdout("
 running 1 test
 test external_bench ... bench: [..] 0 ns/iter (+/- 0)
@@ -464,7 +464,7 @@ fn pass_through_command_line() {
                 .with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({dir})
 [FINISHED] release [optimized] target(s) in [..]
-[RUNNING] target[..]release[..]foo-[..]", dir = p.url()))
+[RUNNING] target[..]release[..]foo-[..][EXE]", dir = p.url()))
                 .with_stdout("
 running 1 test
 test bar ... bench: [..] 0 ns/iter (+/- 0)
@@ -476,7 +476,7 @@ test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured
     assert_that(p.cargo("bench").arg("foo"),
                 execs().with_status(0)
                        .with_stderr("[FINISHED] release [optimized] target(s) in [..]
-[RUNNING] target[..]release[..]foo-[..]")
+[RUNNING] target[..]release[..]foo-[..][EXE]")
                        .with_stdout("
 running 1 test
 test foo ... bench: [..] 0 ns/iter (+/- 0)
@@ -546,8 +546,8 @@ fn lib_bin_same_name() {
                 execs().with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({})
 [FINISHED] release [optimized] target(s) in [..]
-[RUNNING] target[..]release[..]foo-[..]
-[RUNNING] target[..]release[..]foo-[..]", p.url()))
+[RUNNING] target[..]release[..]foo-[..][EXE]
+[RUNNING] target[..]release[..]foo-[..][EXE]", p.url()))
                        .with_stdout("
 running 1 test
 test [..] ... bench: [..] 0 ns/iter (+/- 0)
@@ -600,8 +600,8 @@ fn lib_with_standard_name() {
                        .with_stderr(&format!("\
 [COMPILING] syntax v0.0.1 ({dir})
 [FINISHED] release [optimized] target(s) in [..]
-[RUNNING] target[..]release[..]bench-[..]
-[RUNNING] target[..]release[..]syntax-[..]", dir = p.url()))
+[RUNNING] target[..]release[..]bench-[..][EXE]
+[RUNNING] target[..]release[..]syntax-[..][EXE]", dir = p.url()))
                        .with_stdout("
 running 1 test
 test bench ... bench: [..] 0 ns/iter (+/- 0)
@@ -652,7 +652,7 @@ fn lib_with_standard_name2() {
                        .with_stderr(&format!("\
 [COMPILING] syntax v0.0.1 ({dir})
 [FINISHED] release [optimized] target(s) in [..]
-[RUNNING] target[..]release[..]syntax-[..]", dir = p.url()))
+[RUNNING] target[..]release[..]syntax-[..][EXE]", dir = p.url()))
                        .with_stdout("
 running 1 test
 test bench ... bench: [..] 0 ns/iter (+/- 0)
@@ -722,8 +722,8 @@ fn bench_dylib() {
 [RUNNING] [..] -C opt-level=3 [..]
 [RUNNING] [..] -C opt-level=3 [..]
 [FINISHED] release [optimized] target(s) in [..]
-[RUNNING] [..]target[..]release[..]bench-[..]
-[RUNNING] [..]target[..]release[..]foo-[..]", dir = p.url()))
+[RUNNING] [..]target[..]release[..]bench-[..][EXE]
+[RUNNING] [..]target[..]release[..]foo-[..][EXE]", dir = p.url()))
                        .with_stdout("
 running 1 test
 test foo ... bench: [..] 0 ns/iter (+/- 0)
@@ -744,8 +744,8 @@ test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured
 [FRESH] bar v0.0.1 ({dir}/bar)
 [FRESH] foo v0.0.1 ({dir})
 [FINISHED] release [optimized] target(s) in [..]
-[RUNNING] [..]target[..]release[..]bench-[..]
-[RUNNING] [..]target[..]release[..]foo-[..]", dir = p.url()))
+[RUNNING] [..]target[..]release[..]bench-[..][EXE]
+[RUNNING] [..]target[..]release[..]foo-[..][EXE]", dir = p.url()))
                        .with_stdout("
 running 1 test
 test foo ... bench: [..] 0 ns/iter (+/- 0)
@@ -786,7 +786,7 @@ fn bench_twice_with_build_cmd() {
                        .with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({dir})
 [FINISHED] release [optimized] target(s) in [..]
-[RUNNING] target[..]release[..]foo-[..]", dir = p.url()))
+[RUNNING] target[..]release[..]foo-[..][EXE]", dir = p.url()))
                        .with_stdout("
 running 1 test
 test foo ... bench: [..] 0 ns/iter (+/- 0)
@@ -798,7 +798,7 @@ test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured
     assert_that(p.cargo("bench"),
                 execs().with_status(0)
                        .with_stderr("[FINISHED] release [optimized] target(s) in [..]
-[RUNNING] target[..]release[..]foo-[..]")
+[RUNNING] target[..]release[..]foo-[..][EXE]")
                        .with_stdout("
 running 1 test
 test foo ... bench: [..] 0 ns/iter (+/- 0)
@@ -871,8 +871,8 @@ fn bench_with_examples() {
 [RUNNING] `rustc [..]`
 [RUNNING] `rustc [..]`
 [FINISHED] release [optimized] target(s) in [..]
-[RUNNING] `{dir}[..]target[..]release[..]testb1-[..] --bench`
-[RUNNING] `{dir}[..]target[..]release[..]testbench-[..] --bench`",
+[RUNNING] `{dir}[..]target[..]release[..]testb1-[..][EXE] --bench`
+[RUNNING] `{dir}[..]target[..]release[..]testbench-[..][EXE] --bench`",
                 dir = p.root().display(), url = p.url()))
                        .with_stdout("
 running 1 test
@@ -920,7 +920,7 @@ fn test_a_bench() {
                        .with_stderr("\
 [COMPILING] foo v0.1.0 ([..])
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target[..]debug[..]b-[..]")
+[RUNNING] target[..]debug[..]b-[..][EXE]")
                        .with_stdout("
 running 1 test
 test foo ... ok
@@ -1030,7 +1030,7 @@ fn test_bench_multiple_packages() {
     assert_that(p.cargo_process("bench").arg("-p").arg("bar").arg("-p").arg("baz"),
                 execs().with_status(0)
                        .with_stderr_contains("\
-[RUNNING] target[..]release[..]bbaz-[..]")
+[RUNNING] target[..]release[..]bbaz-[..][EXE]")
                        .with_stdout_contains("
 running 1 test
 test bench_baz ... bench:           0 ns/iter (+/- 0)
@@ -1038,7 +1038,7 @@ test bench_baz ... bench:           0 ns/iter (+/- 0)
 test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured
 ")
                        .with_stderr_contains("\
-[RUNNING] target[..]release[..]bbar-[..]")
+[RUNNING] target[..]release[..]bbar-[..][EXE]")
                        .with_stdout_contains("
 running 1 test
 test bench_bar ... bench:           0 ns/iter (+/- 0)

--- a/tests/build-script.rs
+++ b/tests/build-script.rs
@@ -34,7 +34,7 @@ fn custom_build_script_failed() {
                        .with_stderr(&format!("\
 [COMPILING] foo v0.5.0 ({url})
 [RUNNING] `rustc build.rs --crate-name build_script_build --crate-type bin [..]`
-[RUNNING] `[..]build-script-build[..]`
+[RUNNING] `[..]build-script-build[EXE]`
 [ERROR] failed to run custom build command for `foo v0.5.0 ({url})`
 process didn't exit successfully: `[..]build-script-build[..]` (exit code: 101)",
 url = p.url())));
@@ -407,7 +407,7 @@ fn only_rerun_build_script() {
                 execs().with_status(0)
                        .with_stderr("\
 [COMPILING] foo v0.5.0 (file://[..])
-[RUNNING] `[..]build-script-build[..]`
+[RUNNING] `[..]build-script-build[EXE]`
 [RUNNING] `rustc [..] --crate-name foo [..]`
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 "));
@@ -495,11 +495,11 @@ fn testing_and_such() {
                 execs().with_status(0)
                        .with_stderr("\
 [COMPILING] foo v0.5.0 (file://[..])
-[RUNNING] `[..]build-script-build[..]`
+[RUNNING] `[..]build-script-build[EXE]`
 [RUNNING] `rustc [..] --crate-name foo [..]`
 [RUNNING] `rustc [..] --crate-name foo [..]`
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] `[..]foo-[..][..]`
+[RUNNING] `[..]foo-[..][EXE]`
 [DOCTEST] foo
 [RUNNING] `rustdoc --test [..]`")
                        .with_stdout("
@@ -530,7 +530,7 @@ test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
                        .with_stderr("\
 [COMPILING] foo v0.5.0 (file://[..])
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] `target[..]foo[..]`
+[RUNNING] `target[..]foo[EXE]`
 "));
 }
 
@@ -674,7 +674,7 @@ fn build_deps_simple() {
 [RUNNING] `rustc [..] --crate-name a [..]`
 [COMPILING] foo v0.5.0 (file://[..])
 [RUNNING] `rustc build.rs [..] --extern a=[..]`
-[RUNNING] `[..]foo-[..]build-script-build[..]`
+[RUNNING] `[..]foo-[..]build-script-build[EXE]`
 [RUNNING] `rustc [..] --crate-name foo [..]`
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 "));
@@ -764,7 +764,7 @@ fn build_cmd_with_a_build_cmd() {
 [RUNNING] `rustc [..] --crate-name b [..]`
 [COMPILING] a v0.5.0 (file://[..])
 [RUNNING] `rustc a[..]build.rs [..] --extern b=[..]`
-[RUNNING] `[..]a-[..]build-script-build[..]`
+[RUNNING] `[..]a-[..]build-script-build[EXE]`
 [RUNNING] `rustc [..]lib.rs --crate-name a --crate-type lib -g \
     -C metadata=[..] \
     --out-dir [..]target[..]deps --emit=dep-info,link \
@@ -774,7 +774,7 @@ fn build_cmd_with_a_build_cmd() {
     -g -C metadata=[..] --out-dir [..] --emit=dep-info,link \
     -L [..]target[..]deps \
     --extern a=[..]liba[..].rlib`
-[RUNNING] `[..]foo-[..]build-script-build[..]`
+[RUNNING] `[..]foo-[..]build-script-build[EXE]`
 [RUNNING] `rustc [..]lib.rs --crate-name foo --crate-type lib -g \
     -C metadata=[..] \
     --out-dir [..] --emit=dep-info,link \
@@ -854,7 +854,7 @@ fn output_separate_lines() {
                        .with_stderr_contains("\
 [COMPILING] foo v0.5.0 (file://[..])
 [RUNNING] `rustc build.rs [..]`
-[RUNNING] `[..]foo-[..]build-script-build[..]`
+[RUNNING] `[..]foo-[..]build-script-build[EXE]`
 [RUNNING] `rustc [..] --crate-name foo [..] -L foo -l static=foo`
 [ERROR] could not find native static library [..]
 "));
@@ -882,7 +882,7 @@ fn output_separate_lines_new() {
                        .with_stderr_contains("\
 [COMPILING] foo v0.5.0 (file://[..])
 [RUNNING] `rustc build.rs [..]`
-[RUNNING] `[..]foo-[..]build-script-build[..]`
+[RUNNING] `[..]foo-[..]build-script-build[EXE]`
 [RUNNING] `rustc [..] --crate-name foo [..] -L foo -l static=foo`
 [ERROR] could not find native static library [..]
 "));
@@ -1364,13 +1364,13 @@ fn cfg_test() {
                 execs().with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({dir})
 [RUNNING] [..] build.rs [..]
-[RUNNING] [..]build-script-build[..]
+[RUNNING] `[..]build-script-build[EXE]`
 [RUNNING] [..] --cfg foo[..]
 [RUNNING] [..] --cfg foo[..]
 [RUNNING] [..] --cfg foo[..]
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] [..]foo-[..]
-[RUNNING] [..]test-[..]
+[RUNNING] [..]foo-[..][EXE]
+[RUNNING] [..]test-[..][EXE]
 [DOCTEST] foo
 [RUNNING] [..] --cfg foo[..]", dir = p.url()))
                        .with_stdout("
@@ -1486,8 +1486,8 @@ fn cfg_override_test() {
 [RUNNING] `[..]`
 [RUNNING] `[..]`
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] [..]foo-[..]
-[RUNNING] [..]test-[..]
+[RUNNING] [..]foo-[..][EXE]
+[RUNNING] [..]test-[..][EXE]
 [DOCTEST] foo
 [RUNNING] [..] --cfg foo[..]", dir = p.url()))
                        .with_stdout("
@@ -1598,7 +1598,7 @@ fn flags_go_into_tests() {
                        .with_stderr("\
 [COMPILING] a v0.5.0 ([..]
 [RUNNING] `rustc a[..]build.rs [..]`
-[RUNNING] `[..]build-script-build[..]`
+[RUNNING] `[..]build-script-build[EXE]`
 [RUNNING] `rustc a[..]src[..]lib.rs [..] -L test[..]`
 [COMPILING] b v0.5.0 ([..]
 [RUNNING] `rustc b[..]src[..]lib.rs [..] -L test[..]`
@@ -1606,7 +1606,7 @@ fn flags_go_into_tests() {
 [RUNNING] `rustc src[..]lib.rs [..] -L test[..]`
 [RUNNING] `rustc tests[..]foo.rs [..] -L test[..]`
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] `[..]foo-[..]`")
+[RUNNING] `[..]foo-[..][EXE]`")
                        .with_stdout("
 running 0 tests
 
@@ -1621,7 +1621,7 @@ test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
 [COMPILING] b v0.5.0 ([..]
 [RUNNING] `rustc b[..]src[..]lib.rs [..] -L test[..]`
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] `[..]b-[..]`")
+[RUNNING] `[..]b-[..][EXE]`")
                        .with_stdout("
 running 0 tests
 
@@ -1802,7 +1802,7 @@ fn rebuild_only_on_explicit_paths() {
     assert_that(p.cargo("build").arg("-v"),
                 execs().with_status(0).with_stderr("\
 [COMPILING] a v0.5.0 ([..])
-[RUNNING] `[..]build-script-build[..]`
+[RUNNING] `[..]build-script-build[EXE]`
 [RUNNING] `rustc src[..]lib.rs [..]`
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 "));
@@ -1816,7 +1816,7 @@ fn rebuild_only_on_explicit_paths() {
     assert_that(p.cargo("build").arg("-v"),
                 execs().with_status(0).with_stderr("\
 [COMPILING] a v0.5.0 ([..])
-[RUNNING] `[..]build-script-build[..]`
+[RUNNING] `[..]build-script-build[EXE]`
 [RUNNING] `rustc src[..]lib.rs [..]`
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 "));
@@ -1845,7 +1845,7 @@ fn rebuild_only_on_explicit_paths() {
     assert_that(p.cargo("build").arg("-v"),
                 execs().with_status(0).with_stderr("\
 [COMPILING] a v0.5.0 ([..])
-[RUNNING] `[..]build-script-build[..]`
+[RUNNING] `[..]build-script-build[EXE]`
 [RUNNING] `rustc src[..]lib.rs [..]`
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 "));
@@ -1856,7 +1856,7 @@ fn rebuild_only_on_explicit_paths() {
     assert_that(p.cargo("build").arg("-v"),
                 execs().with_status(0).with_stderr("\
 [COMPILING] a v0.5.0 ([..])
-[RUNNING] `[..]build-script-build[..]`
+[RUNNING] `[..]build-script-build[EXE]`
 [RUNNING] `rustc src[..]lib.rs [..]`
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 "));

--- a/tests/cargotest/support/mod.rs
+++ b/tests/cargotest/support/mod.rs
@@ -672,6 +672,7 @@ fn substitute_macros(input: &str) -> String {
         ("[INSTALLING]",  "  Installing"),
         ("[REPLACING]",   "   Replacing"),
         ("[UNPACKING]",   "   Unpacking"),
+        ("[EXE]", if cfg!(windows) {".exe"} else {""}),
     ];
     let mut result = input.to_owned();
     for &(pat, subst) in macros.iter() {

--- a/tests/clean.rs
+++ b/tests/clean.rs
@@ -172,7 +172,7 @@ fn build_script() {
                 execs().with_status(0).with_stderr("\
 [COMPILING] foo v0.0.1 ([..])
 [RUNNING] `rustc build.rs [..]`
-[RUNNING] `[..]build-script-build[..]`
+[RUNNING] `[..]build-script-build[EXE]`
 [RUNNING] `rustc src[..]main.rs [..]`
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 "));

--- a/tests/cross-compile.rs
+++ b/tests/cross-compile.rs
@@ -473,8 +473,8 @@ fn cross_tests() {
                        .with_stderr(&format!("\
 [COMPILING] foo v0.0.0 ({foo})
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target[..]{triple}[..]bar-[..]
-[RUNNING] target[..]{triple}[..]foo-[..]", foo = p.url(), triple = target))
+[RUNNING] target[..]{triple}[..]bar-[..][EXE]
+[RUNNING] target[..]{triple}[..]foo-[..][EXE]", foo = p.url(), triple = target))
                        .with_stdout("
 running 1 test
 test test ... ok
@@ -511,7 +511,7 @@ fn no_cross_doctests() {
     let host_output = format!("\
 [COMPILING] foo v0.0.0 ({foo})
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target[..]foo-[..]
+[RUNNING] target[..]foo-[..][EXE]
 [DOCTEST] foo
 ", foo = p.url());
 
@@ -533,7 +533,7 @@ fn no_cross_doctests() {
                        .with_stderr(&format!("\
 [COMPILING] foo v0.0.0 ({foo})
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target[..]{triple}[..]foo-[..]
+[RUNNING] target[..]{triple}[..]foo-[..][EXE]
 ", foo = p.url(), triple = target)));
 }
 
@@ -674,7 +674,7 @@ fn build_script_needed_for_host_and_target() {
 [RUNNING] `rustc d1[..]build.rs [..] --out-dir {dir}[..]target[..]build[..]d1-[..]`",
     dir = p.root().display()))
                        .with_stderr_contains(&format!("\
-[RUNNING] `{dir}[..]target[..]build[..]d1-[..]build-script-build`",
+[RUNNING] `{dir}[..]target[..]build[..]d1-[..]build-script-build[EXE]`",
     dir = p.root().display()))
                        .with_stderr_contains("\
 [RUNNING] `rustc d1[..]src[..]lib.rs [..]`")
@@ -800,7 +800,7 @@ fn plugin_build_script_right_arch() {
                        .with_stderr("\
 [COMPILING] foo v0.0.1 ([..])
 [RUNNING] `rustc build.rs [..]`
-[RUNNING] `[..]build-script-build[..]`
+[RUNNING] `[..]build-script-build[EXE]`
 [RUNNING] `rustc src[..]lib.rs [..]`
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 "));
@@ -852,7 +852,7 @@ fn build_script_with_platform_specific_dependencies() {
 [RUNNING] `rustc d1[..]src[..]lib.rs [..]`
 [COMPILING] foo v0.0.1 ([..])
 [RUNNING] `rustc build.rs [..]`
-[RUNNING] `{dir}[..]target[..]build[..]foo-[..]build-script-build`
+[RUNNING] `{dir}[..]target[..]build[..]foo-[..]build-script-build[EXE]`
 [RUNNING] `rustc src[..]lib.rs [..] --target {target} [..]`
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 ", dir = p.root().display(), target = target)));

--- a/tests/git.rs
+++ b/tests/git.rs
@@ -936,7 +936,7 @@ fn dep_with_changed_submodule() {
                                       [COMPILING] foo v0.5.0 ([..])\n\
                                       [FINISHED] debug [unoptimized + debuginfo] target(s) in \
                                       [..]\n\
-                                      [RUNNING] `target[..]foo[..]`\n")
+                                      [RUNNING] `target[..]foo[EXE]`\n")
                 .with_stdout("project2\n")
                 .with_status(0));
 
@@ -978,7 +978,7 @@ fn dep_with_changed_submodule() {
                                       [COMPILING] foo v0.5.0 ([..])\n\
                                       [FINISHED] debug [unoptimized + debuginfo] target(s) in \
                                       [..]\n\
-                                      [RUNNING] `target[..]foo[..]`\n")
+                                      [RUNNING] `target[..]foo[EXE]`\n")
                 .with_stdout("project3\n")
                 .with_status(0));
 }
@@ -1035,7 +1035,7 @@ fn dev_deps_with_testing() {
 [COMPILING] [..] v0.5.0 ([..])
 [COMPILING] [..] v0.5.0 ([..]
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target[..]foo-[..]")
+[RUNNING] target[..]foo-[..][EXE]")
                        .with_stdout("
 running 1 test
 test tests::foo ... ok

--- a/tests/path.rs
+++ b/tests/path.rs
@@ -189,7 +189,7 @@ fn cargo_compile_with_root_dev_deps_with_testing() {
 [COMPILING] [..] v0.5.0 ([..])
 [COMPILING] [..] v0.5.0 ([..])
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target[..]foo-[..]")
+[RUNNING] target[..]foo-[..][EXE]")
                        .with_stdout("
 running 0 tests
 
@@ -798,7 +798,7 @@ fn dev_deps_no_rebuild_lib() {
 [COMPILING] [..] v0.5.0 ({url}[..])
 [COMPILING] [..] v0.5.0 ({url}[..])
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target[..]foo-[..]", url = p.url()))
+[RUNNING] target[..]foo-[..][EXE]", url = p.url()))
                        .with_stdout("
 running 0 tests
 

--- a/tests/run.rs
+++ b/tests/run.rs
@@ -26,7 +26,7 @@ fn simple() {
                        .with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({dir})
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] `target{sep}debug{sep}foo[..]`", dir = path2url(p.root()), sep = SEP))
+[RUNNING] `target{sep}debug{sep}foo[EXE]`", dir = path2url(p.root()), sep = SEP))
                        .with_stdout("\
 hello
 "));
@@ -232,7 +232,7 @@ fn specify_name() {
 [RUNNING] `rustc src[..]lib.rs [..]`
 [RUNNING] `rustc src[..]a.rs [..]`
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] `target{sep}debug{sep}a[..]`", dir = path2url(p.root()), sep = SEP))
+[RUNNING] `target{sep}debug{sep}a[EXE]`", dir = path2url(p.root()), sep = SEP))
                        .with_stdout("\
 hello a.rs
 "));
@@ -243,7 +243,7 @@ hello a.rs
 [COMPILING] foo v0.0.1 ([..])
 [RUNNING] `rustc src[..]b.rs [..]`
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] `target{sep}debug{sep}b[..]`", sep = SEP))
+[RUNNING] `target{sep}debug{sep}b[EXE]`", sep = SEP))
                        .with_stdout("\
 hello b.rs
 "));
@@ -271,7 +271,7 @@ fn run_example() {
                        .with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({dir})
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] `target{sep}debug{sep}examples{sep}a[..]`", dir = path2url(p.root()), sep = SEP))
+[RUNNING] `target{sep}debug{sep}examples{sep}a[EXE]`", dir = path2url(p.root()), sep = SEP))
                        .with_stdout("\
 example
 "));
@@ -364,7 +364,7 @@ fn one_bin_multiple_examples() {
                        .with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({dir})
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] `target{sep}debug{sep}main[..]`", dir = path2url(p.root()), sep = SEP))
+[RUNNING] `target{sep}debug{sep}main[EXE]`", dir = path2url(p.root()), sep = SEP))
                        .with_stdout("\
 hello main.rs
 "));
@@ -433,7 +433,7 @@ fn example_with_release_flag() {
         -L dependency={dir}{sep}target{sep}release{sep}deps \
          --extern bar={dir}{sep}target{sep}release{sep}deps{sep}libbar.rlib`
 [FINISHED] release [optimized] target(s) in [..]
-[RUNNING] `target{sep}release{sep}examples{sep}a[..]`
+[RUNNING] `target{sep}release{sep}examples{sep}a[EXE]`
 ",
         dir = p.root().display(),
         url = path2url(p.root()),
@@ -461,7 +461,7 @@ fast2"));
         -L dependency={dir}{sep}target{sep}debug{sep}deps \
          --extern bar={dir}{sep}target{sep}debug{sep}deps{sep}libbar.rlib`
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] `target{sep}debug{sep}examples{sep}a[..]`
+[RUNNING] `target{sep}debug{sep}examples{sep}a[EXE]`
 ",
         dir = p.root().display(),
         url = path2url(p.root()),
@@ -520,7 +520,7 @@ fn release_works() {
                 execs().with_status(0).with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({dir})
 [FINISHED] release [optimized] target(s) in [..]
-[RUNNING] `target{sep}release{sep}foo[..]`
+[RUNNING] `target{sep}release{sep}foo[EXE]`
 ",
         dir = path2url(p.root()),
         sep = SEP)));
@@ -591,7 +591,7 @@ fn run_from_executable_folder() {
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]\n\
-[RUNNING] `.{sep}foo[..]`", sep = SEP))
+[RUNNING] `.{sep}foo[EXE]`", sep = SEP))
                        .with_stdout("\
 hello
 "));

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -40,7 +40,7 @@ fn cargo_test_simple() {
                 execs().with_stderr(format!("\
 [COMPILING] foo v0.5.0 ({})
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target[..]foo-[..]", p.url()))
+[RUNNING] target[..]foo-[..][EXE]", p.url()))
                        .with_stdout("
 running 1 test
 test test_hello ... ok
@@ -92,8 +92,8 @@ fn cargo_test_release() {
 [RUNNING] [..] -C opt-level=3 [..]
 [RUNNING] [..] -C opt-level=3 [..]
 [FINISHED] release [optimized] target(s) in [..]
-[RUNNING] `[..]target[..]foo-[..]`
-[RUNNING] `[..]target[..]test-[..]`
+[RUNNING] `[..]target[..]foo-[..][EXE]`
+[RUNNING] `[..]target[..]test-[..][EXE]`
 [DOCTEST] foo
 [RUNNING] `rustdoc --test [..]lib.rs[..]`", dir = p.url()))
                        .with_stdout("
@@ -130,7 +130,7 @@ fn cargo_test_verbose() {
 [COMPILING] foo v0.5.0 ({url})
 [RUNNING] `rustc src[..]foo.rs [..]`
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] `[..]target[..]foo-[..] hello`", url = p.url()))
+[RUNNING] `[..]target[..]foo-[..][EXE] hello`", url = p.url()))
                        .with_stdout("
 running 1 test
 test test_hello ... ok
@@ -198,7 +198,7 @@ fn cargo_test_failing_test() {
                 execs().with_stderr(format!("\
 [COMPILING] foo v0.5.0 ({url})
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target[..]foo-[..]
+[RUNNING] target[..]foo-[..][EXE]
 [ERROR] test failed", url = p.url()))
                        .with_stdout_contains("
 running 1 test
@@ -258,8 +258,8 @@ fn test_with_lib_dep() {
                 execs().with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({})
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target[..]baz-[..]
-[RUNNING] target[..]foo[..]
+[RUNNING] target[..]baz-[..][EXE]
+[RUNNING] target[..]foo-[..][EXE]
 [DOCTEST] foo", p.url()))
                        .with_stdout("
 running 1 test
@@ -374,8 +374,8 @@ fn external_test_explicit() {
                 execs().with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({})
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target[..]foo-[..]
-[RUNNING] target[..]test-[..]
+[RUNNING] target[..]foo-[..][EXE]
+[RUNNING] target[..]test-[..][EXE]
 [DOCTEST] foo", p.url()))
                        .with_stdout("
 running 1 test
@@ -423,8 +423,8 @@ fn external_test_implicit() {
                 execs().with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({})
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target[..]external-[..]
-[RUNNING] target[..]foo-[..]
+[RUNNING] target[..]external-[..][EXE]
+[RUNNING] target[..]foo-[..][EXE]
 [DOCTEST] foo", p.url()))
                        .with_stdout("
 running 1 test
@@ -483,7 +483,7 @@ fn pass_through_command_line() {
                        .with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({dir})
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target[..]foo-[..]
+[RUNNING] target[..]foo-[..][EXE]
 [DOCTEST] foo", dir = p.url()))
                        .with_stdout("
 running 1 test
@@ -502,7 +502,7 @@ test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
                 execs().with_status(0)
                        .with_stderr("\
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target[..]foo-[..]
+[RUNNING] target[..]foo-[..][EXE]
 [DOCTEST] foo")
                        .with_stdout("
 running 1 test
@@ -567,8 +567,8 @@ fn lib_bin_same_name() {
                 execs().with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({})
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target[..]foo-[..]
-[RUNNING] target[..]foo-[..]
+[RUNNING] target[..]foo-[..][EXE]
+[RUNNING] target[..]foo-[..][EXE]
 [DOCTEST] foo", p.url()))
                        .with_stdout("
 running 1 test
@@ -620,8 +620,8 @@ fn lib_with_standard_name() {
                        .with_stderr(&format!("\
 [COMPILING] syntax v0.0.1 ({dir})
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target[..]syntax-[..]
-[RUNNING] target[..]test-[..]
+[RUNNING] target[..]syntax-[..][EXE]
+[RUNNING] target[..]test-[..][EXE]
 [DOCTEST] syntax", dir = p.url()))
                        .with_stdout("
 running 1 test
@@ -675,7 +675,7 @@ fn lib_with_standard_name2() {
                        .with_stderr(&format!("\
 [COMPILING] syntax v0.0.1 ({dir})
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target[..]syntax-[..]", dir = p.url()))
+[RUNNING] target[..]syntax-[..][EXE]", dir = p.url()))
                        .with_stdout("
 running 1 test
 test test ... ok
@@ -715,7 +715,7 @@ fn lib_without_name() {
                        .with_stderr(&format!("\
 [COMPILING] syntax v0.0.1 ({dir})
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target[..]syntax-[..]", dir = p.url()))
+[RUNNING] target[..]syntax-[..][EXE]", dir = p.url()))
                        .with_stdout("
 running 1 test
 test test ... ok
@@ -973,8 +973,8 @@ fn test_dylib() {
 [COMPILING] bar v0.0.1 ({dir}/bar)
 [COMPILING] foo v0.0.1 ({dir})
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target[..]foo-[..]
-[RUNNING] target[..]test-[..]", dir = p.url()))
+[RUNNING] target[..]foo-[..][EXE]
+[RUNNING] target[..]test-[..][EXE]", dir = p.url()))
                        .with_stdout("
 running 1 test
 test foo ... ok
@@ -993,8 +993,8 @@ test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
                 execs().with_status(0)
                        .with_stderr("\
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target[..]foo-[..]
-[RUNNING] target[..]test-[..]")
+[RUNNING] target[..]foo-[..][EXE]
+[RUNNING] target[..]test-[..][EXE]")
                        .with_stdout("
 running 1 test
 test foo ... ok
@@ -1032,7 +1032,7 @@ fn test_twice_with_build_cmd() {
                        .with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({dir})
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target[..]foo-[..]
+[RUNNING] target[..]foo-[..][EXE]
 [DOCTEST] foo", dir = p.url()))
                        .with_stdout("
 running 1 test
@@ -1051,7 +1051,7 @@ test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
                 execs().with_status(0)
                        .with_stderr("\
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target[..]foo-[..]
+[RUNNING] target[..]foo-[..][EXE]
 [DOCTEST] foo")
                        .with_stdout("
 running 1 test
@@ -1086,7 +1086,7 @@ fn test_then_build() {
                        .with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({dir})
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target[..]foo-[..]
+[RUNNING] target[..]foo-[..][EXE]
 [DOCTEST] foo", dir = p.url()))
                        .with_stdout("
 running 1 test
@@ -1154,7 +1154,7 @@ fn test_run_specific_bin_target() {
                        .with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({dir})
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target[..]bin2-[..]", dir = prj.url()))
+[RUNNING] target[..]bin2-[..][EXE]", dir = prj.url()))
                        .with_stdout("
 running 1 test
 test test2 ... ok
@@ -1183,7 +1183,7 @@ fn test_run_specific_test_target() {
                        .with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({dir})
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target[..]b-[..]", dir = prj.url()))
+[RUNNING] target[..]b-[..][EXE]", dir = prj.url()))
                        .with_stdout("
 running 1 test
 test test_b ... ok
@@ -1219,7 +1219,7 @@ fn test_no_harness() {
                        .with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({dir})
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target[..]bar-[..]
+[RUNNING] target[..]bar-[..][EXE]
 ",
                        dir = p.url())));
 }
@@ -1275,8 +1275,8 @@ fn selective_testing() {
                        .with_stderr(&format!("\
 [COMPILING] d1 v0.0.1 ({dir}/d1)
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target[..]d1-[..]
-[RUNNING] target[..]d1-[..]", dir = p.url()))
+[RUNNING] target[..]d1-[..][EXE]
+[RUNNING] target[..]d1-[..][EXE]", dir = p.url()))
                        .with_stdout("
 running 0 tests
 
@@ -1295,8 +1295,8 @@ test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
                        .with_stderr(&format!("\
 [COMPILING] d2 v0.0.1 ({dir}/d2)
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target[..]d2-[..]
-[RUNNING] target[..]d2-[..]", dir = p.url()))
+[RUNNING] target[..]d2-[..][EXE]
+[RUNNING] target[..]d2-[..][EXE]", dir = p.url()))
                        .with_stdout("
 running 0 tests
 
@@ -1315,7 +1315,7 @@ test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
                        .with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({dir})
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target[..]foo-[..]", dir = p.url()))
+[RUNNING] target[..]foo-[..][EXE]", dir = p.url()))
                        .with_stdout("
 running 0 tests
 
@@ -1477,7 +1477,7 @@ fn selective_testing_with_docs() {
                        .with_stderr(&format!("\
 [COMPILING] d1 v0.0.1 ({dir}/d1)
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target[..]deps[..]d1[..]
+[RUNNING] target[..]deps[..]d1[..][EXE]
 [DOCTEST] d1", dir = p.url()))
                        .with_stdout("
 running 0 tests
@@ -1659,7 +1659,7 @@ fn doctest_feature() {
                        .with_stderr("\
 [COMPILING] foo [..]
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target[..]foo[..]
+[RUNNING] target[..]foo[..][EXE]
 [DOCTEST] foo")
                        .with_stdout("
 running 0 tests
@@ -1746,7 +1746,7 @@ fn filter_no_doc_tests() {
                 execs().with_stderr("\
 [COMPILING] foo v0.0.1 ([..])
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target[..]debug[..]foo[..]")
+[RUNNING] target[..]debug[..]foo[..][EXE]")
                        .with_stdout("
 running 0 tests
 
@@ -1850,7 +1850,7 @@ fn cyclic_dev_dep_doc_test() {
 [COMPILING] foo v0.0.1 ([..])
 [COMPILING] bar v0.0.1 ([..])
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target[..]foo[..]
+[RUNNING] target[..]foo[..][EXE]
 [DOCTEST] foo")
                        .with_stdout("
 running 0 tests
@@ -1943,8 +1943,8 @@ fn no_fail_fast() {
                        .with_stderr_contains("\
 [COMPILING] foo v0.0.1 ([..])
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target[..]foo[..]
-[RUNNING] target[..]test_add_one[..]")
+[RUNNING] target[..]foo-[..][EXE]
+[RUNNING] target[..]test_add_one-[..][EXE]")
                        .with_stdout_contains("
 running 0 tests
 
@@ -1952,7 +1952,7 @@ test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
 
 ")
                        .with_stderr_contains("\
-[RUNNING] target[..]test_sub_one[..]
+[RUNNING] target[..]test_sub_one-[..][EXE]
 [DOCTEST] foo")
                        .with_stdout_contains("\
 test result: FAILED. 1 passed; 1 failed; 0 ignored; 0 measured
@@ -2018,14 +2018,14 @@ fn test_multiple_packages() {
     assert_that(p.cargo("test").arg("-p").arg("d1").arg("-p").arg("d2"),
                 execs().with_status(0)
                        .with_stderr_contains("\
-[RUNNING] target[..]debug[..]d1-[..]")
+[RUNNING] target[..]debug[..]d1-[..][EXE]")
                        .with_stdout_contains("
 running 0 tests
 
 test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
 ")
                        .with_stderr_contains("\
-[RUNNING] target[..]debug[..]d2-[..]")
+[RUNNING] target[..]debug[..]d2-[..][EXE]")
                        .with_stdout_contains("
 running 0 tests
 


### PR DESCRIPTION
This should make the testing a bit more precise as to whether
we expect targets of the form foo.exe vs foo-abc123.exe. I
was also considering adding a [/] substitution for the fwd
slash vs backslash [..], but thought I would leave that to another PR
if we thought that was a good idea.