### PR TITLE
Add a [/] macro expansion for tests

### DIFF
--- a/tests/bench.rs
+++ b/tests/bench.rs
@@ -43,7 +43,7 @@ fn cargo_bench_simple() {
                 execs().with_stderr(&format!("\
 [COMPILING] foo v0.5.0 ({})
 [FINISHED] release [optimized] target(s) in [..]
-[RUNNING] target[..]release[..]foo-[..][EXE]", p.url()))
+[RUNNING] target[/]release[/]foo-[..][EXE]", p.url()))
                        .with_stdout("
 running 1 test
 test bench_hello ... bench: [..] 0 ns/iter (+/- 0)
@@ -78,7 +78,7 @@ fn bench_tarname() {
                .with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({dir})
 [FINISHED] release [optimized] target(s) in [..]
-[RUNNING] target[..]release[..]bin2-[..][EXE]
+[RUNNING] target[/]release[/]bin2-[..][EXE]
 ", dir = prj.url()))
                .with_stdout("
 running 1 test
@@ -105,9 +105,9 @@ fn cargo_bench_verbose() {
     assert_that(p.cargo_process("bench").arg("-v").arg("hello"),
                 execs().with_stderr(&format!("\
 [COMPILING] foo v0.5.0 ({url})
-[RUNNING] `rustc src[..]foo.rs [..]`
+[RUNNING] `rustc src[/]foo.rs [..]`
 [FINISHED] release [optimized] target(s) in [..]
-[RUNNING] `[..]target[..]release[..]foo-[..][EXE] hello --bench`", url = p.url()))
+[RUNNING] `[..]target[/]release[/]foo-[..][EXE] hello --bench`", url = p.url()))
                        .with_stdout("
 running 1 test
 test bench_hello ... bench: [..] 0 ns/iter (+/- 0)
@@ -190,10 +190,10 @@ test bench_hello ... ")
                        .with_stderr_contains(format!("\
 [COMPILING] foo v0.5.0 ({})
 [FINISHED] release [optimized] target(s) in [..]
-[RUNNING] target[..]release[..]foo-[..][EXE]
+[RUNNING] target[/]release[/]foo-[..][EXE]
 thread '[..]' panicked at 'assertion failed: \
     `(left == right)` (left: \
-    `\"hello\"`, right: `\"nope\"`)', src[..]foo.rs:14
+    `\"hello\"`, right: `\"nope\"`)', src[/]foo.rs:14
 [..]
 ", p.url()))
                        .with_status(101));
@@ -243,8 +243,8 @@ fn bench_with_lib_dep() {
                 execs().with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({})
 [FINISHED] release [optimized] target(s) in [..]
-[RUNNING] target[..]release[..]baz-[..][EXE]
-[RUNNING] target[..]release[..]foo-[..][EXE]", p.url()))
+[RUNNING] target[/]release[/]baz-[..][EXE]
+[RUNNING] target[/]release[/]deps[/]foo-[..][EXE]", p.url()))
                        .with_stdout("
 running 1 test
 test bin_bench ... bench: [..] 0 ns/iter (+/- 0)
@@ -307,7 +307,7 @@ fn bench_with_deep_lib_dep() {
 [COMPILING] foo v0.0.1 ([..])
 [COMPILING] bar v0.0.1 ({dir})
 [FINISHED] release [optimized] target(s) in [..]
-[RUNNING] target[..]release[..]deps[..]bar-[..][EXE]", dir = p.url()))
+[RUNNING] target[/]release[/]deps[/]bar-[..][EXE]", dir = p.url()))
                        .with_stdout("
 running 1 test
 test bar_bench ... bench: [..] 0 ns/iter (+/- 0)
@@ -353,8 +353,8 @@ fn external_bench_explicit() {
                 execs().with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({})
 [FINISHED] release [optimized] target(s) in [..]
-[RUNNING] target[..]release[..]bench-[..][EXE]
-[RUNNING] target[..]release[..]foo-[..][EXE]", p.url()))
+[RUNNING] target[/]release[/]bench-[..][EXE]
+[RUNNING] target[/]release[/]deps[/]foo-[..][EXE]", p.url()))
                        .with_stdout("
 running 1 test
 test external_bench ... bench: [..] 0 ns/iter (+/- 0)
@@ -403,8 +403,8 @@ fn external_bench_implicit() {
                 execs().with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({})
 [FINISHED] release [optimized] target(s) in [..]
-[RUNNING] target[..]release[..]external-[..][EXE]
-[RUNNING] target[..]release[..]foo-[..][EXE]", p.url()))
+[RUNNING] target[/]release[/]external-[..][EXE]
+[RUNNING] target[/]release[/]deps[/]foo-[..][EXE]", p.url()))
                        .with_stdout("
 running 1 test
 test external_bench ... bench: [..] 0 ns/iter (+/- 0)
@@ -464,7 +464,7 @@ fn pass_through_command_line() {
                 .with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({dir})
 [FINISHED] release [optimized] target(s) in [..]
-[RUNNING] target[..]release[..]foo-[..][EXE]", dir = p.url()))
+[RUNNING] target[/]release[/]deps[/]foo-[..][EXE]", dir = p.url()))
                 .with_stdout("
 running 1 test
 test bar ... bench: [..] 0 ns/iter (+/- 0)
@@ -476,7 +476,7 @@ test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured
     assert_that(p.cargo("bench").arg("foo"),
                 execs().with_status(0)
                        .with_stderr("[FINISHED] release [optimized] target(s) in [..]
-[RUNNING] target[..]release[..]foo-[..][EXE]")
+[RUNNING] target[/]release[/]deps[/]foo-[..][EXE]")
                        .with_stdout("
 running 1 test
 test foo ... bench: [..] 0 ns/iter (+/- 0)
@@ -546,8 +546,8 @@ fn lib_bin_same_name() {
                 execs().with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({})
 [FINISHED] release [optimized] target(s) in [..]
-[RUNNING] target[..]release[..]foo-[..][EXE]
-[RUNNING] target[..]release[..]foo-[..][EXE]", p.url()))
+[RUNNING] target[/]release[/]deps[/]foo-[..][EXE]
+[RUNNING] target[/]release[/]foo-[..][EXE]", p.url()))
                        .with_stdout("
 running 1 test
 test [..] ... bench: [..] 0 ns/iter (+/- 0)
@@ -600,8 +600,8 @@ fn lib_with_standard_name() {
                        .with_stderr(&format!("\
 [COMPILING] syntax v0.0.1 ({dir})
 [FINISHED] release [optimized] target(s) in [..]
-[RUNNING] target[..]release[..]bench-[..][EXE]
-[RUNNING] target[..]release[..]syntax-[..][EXE]", dir = p.url()))
+[RUNNING] target[/]release[/]bench-[..][EXE]
+[RUNNING] target[/]release[/]deps[/]syntax-[..][EXE]", dir = p.url()))
                        .with_stdout("
 running 1 test
 test bench ... bench: [..] 0 ns/iter (+/- 0)
@@ -652,7 +652,7 @@ fn lib_with_standard_name2() {
                        .with_stderr(&format!("\
 [COMPILING] syntax v0.0.1 ({dir})
 [FINISHED] release [optimized] target(s) in [..]
-[RUNNING] target[..]release[..]syntax-[..][EXE]", dir = p.url()))
+[RUNNING] target[/]release[/]syntax-[..][EXE]", dir = p.url()))
                        .with_stdout("
 running 1 test
 test bench ... bench: [..] 0 ns/iter (+/- 0)
@@ -722,8 +722,8 @@ fn bench_dylib() {
 [RUNNING] [..] -C opt-level=3 [..]
 [RUNNING] [..] -C opt-level=3 [..]
 [FINISHED] release [optimized] target(s) in [..]
-[RUNNING] `[..]target[..]release[..]bench-[..][EXE] --bench`
-[RUNNING] `[..]target[..]release[..]foo-[..][EXE] --bench`", dir = p.url()))
+[RUNNING] `[..]target[/]release[/]bench-[..][EXE] --bench`
+[RUNNING] `[..]target[/]release[/]deps[/]foo-[..][EXE] --bench`", dir = p.url()))
                        .with_stdout("
 running 1 test
 test foo ... bench: [..] 0 ns/iter (+/- 0)
@@ -744,8 +744,8 @@ test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured
 [FRESH] bar v0.0.1 ({dir}/bar)
 [FRESH] foo v0.0.1 ({dir})
 [FINISHED] release [optimized] target(s) in [..]
-[RUNNING] `[..]target[..]release[..]bench-[..][EXE] --bench`
-[RUNNING] `[..]target[..]release[..]foo-[..][EXE] --bench`", dir = p.url()))
+[RUNNING] `[..]target[/]release[/]bench-[..][EXE] --bench`
+[RUNNING] `[..]target[/]release[/]deps[/]foo-[..][EXE] --bench`", dir = p.url()))
                        .with_stdout("
 running 1 test
 test foo ... bench: [..] 0 ns/iter (+/- 0)
@@ -786,7 +786,7 @@ fn bench_twice_with_build_cmd() {
                        .with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({dir})
 [FINISHED] release [optimized] target(s) in [..]
-[RUNNING] target[..]release[..]foo-[..][EXE]", dir = p.url()))
+[RUNNING] target[/]release[/]deps[/]foo-[..][EXE]", dir = p.url()))
                        .with_stdout("
 running 1 test
 test foo ... bench: [..] 0 ns/iter (+/- 0)
@@ -798,7 +798,7 @@ test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured
     assert_that(p.cargo("bench"),
                 execs().with_status(0)
                        .with_stderr("[FINISHED] release [optimized] target(s) in [..]
-[RUNNING] target[..]release[..]foo-[..][EXE]")
+[RUNNING] target[/]release[/]deps[/]foo-[..][EXE]")
                        .with_stdout("
 running 1 test
 test foo ... bench: [..] 0 ns/iter (+/- 0)
@@ -871,8 +871,8 @@ fn bench_with_examples() {
 [RUNNING] `rustc [..]`
 [RUNNING] `rustc [..]`
 [FINISHED] release [optimized] target(s) in [..]
-[RUNNING] `{dir}[..]target[..]release[..]testb1-[..][EXE] --bench`
-[RUNNING] `{dir}[..]target[..]release[..]testbench-[..][EXE] --bench`",
+[RUNNING] `{dir}[/]target[/]release[/]testb1-[..][EXE] --bench`
+[RUNNING] `{dir}[/]target[/]release[/]deps[/]testbench-[..][EXE] --bench`",
                 dir = p.root().display(), url = p.url()))
                        .with_stdout("
 running 1 test
@@ -920,7 +920,7 @@ fn test_a_bench() {
                        .with_stderr("\
 [COMPILING] foo v0.1.0 ([..])
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target[..]debug[..]b-[..][EXE]")
+[RUNNING] target[/]debug[/]b-[..][EXE]")
                        .with_stdout("
 running 1 test
 test foo ... ok
@@ -1030,7 +1030,7 @@ fn test_bench_multiple_packages() {
     assert_that(p.cargo_process("bench").arg("-p").arg("bar").arg("-p").arg("baz"),
                 execs().with_status(0)
                        .with_stderr_contains("\
-[RUNNING] target[..]release[..]bbaz-[..][EXE]")
+[RUNNING] target[/]release[/]deps[/]bbaz-[..][EXE]")
                        .with_stdout_contains("
 running 1 test
 test bench_baz ... bench:           0 ns/iter (+/- 0)
@@ -1038,7 +1038,7 @@ test bench_baz ... bench:           0 ns/iter (+/- 0)
 test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured
 ")
                        .with_stderr_contains("\
-[RUNNING] target[..]release[..]bbar-[..][EXE]")
+[RUNNING] target[/]release[/]deps[/]bbar-[..][EXE]")
                        .with_stdout_contains("
 running 1 test
 test bench_bar ... bench:           0 ns/iter (+/- 0)

--- a/tests/build-lib.rs
+++ b/tests/build-lib.rs
@@ -1,21 +1,19 @@
 extern crate cargotest;
 extern crate hamcrest;
 
-use std::path::MAIN_SEPARATOR as SEP;
-
 use cargotest::support::{basic_bin_manifest, execs, project, ProjectBuilder};
 use hamcrest::{assert_that};
 
 fn verbose_output_for_lib(p: &ProjectBuilder) -> String {
     format!("\
 [COMPILING] {name} v{version} ({url})
-[RUNNING] `rustc src{sep}lib.rs --crate-name {name} --crate-type lib -g \
+[RUNNING] `rustc src[/]lib.rs --crate-name {name} --crate-type lib -g \
         -C metadata=[..] \
         --out-dir [..] \
         --emit=dep-info,link \
-        -L dependency={dir}{sep}target{sep}debug{sep}deps`
+        -L dependency={dir}[/]target[/]debug[/]deps`
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
-", sep = SEP,
+",
             dir = p.root().display(), url = p.url(),
             name = "foo", version = "0.0.1")
 }

--- a/tests/build-script.rs
+++ b/tests/build-script.rs
@@ -36,7 +36,7 @@ fn custom_build_script_failed() {
 [RUNNING] `rustc build.rs --crate-name build_script_build --crate-type bin [..]`
 [RUNNING] `[..][/]build-script-build`
 [ERROR] failed to run custom build command for `foo v0.5.0 ({url})`
-process didn't exit successfully: `[..][/]build-script-build[EXE]` (exit code: 101)",
+process didn't exit successfully: `[..][/]build-script-build` (exit code: 101)",
 url = p.url())));
 }
 

--- a/tests/build-script.rs
+++ b/tests/build-script.rs
@@ -34,9 +34,9 @@ fn custom_build_script_failed() {
                        .with_stderr(&format!("\
 [COMPILING] foo v0.5.0 ({url})
 [RUNNING] `rustc build.rs --crate-name build_script_build --crate-type bin [..]`
-[RUNNING] `[..]build-script-build`
+[RUNNING] `[..][/]build-script-build`
 [ERROR] failed to run custom build command for `foo v0.5.0 ({url})`
-process didn't exit successfully: `[..]build-script-build[..]` (exit code: 101)",
+process didn't exit successfully: `[..][/]build-script-build[EXE]` (exit code: 101)",
 url = p.url())));
 }
 
@@ -407,7 +407,7 @@ fn only_rerun_build_script() {
                 execs().with_status(0)
                        .with_stderr("\
 [COMPILING] foo v0.5.0 (file://[..])
-[RUNNING] `[..]build-script-build`
+[RUNNING] `[..][/]build-script-build`
 [RUNNING] `rustc [..] --crate-name foo [..]`
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 "));
@@ -495,11 +495,11 @@ fn testing_and_such() {
                 execs().with_status(0)
                        .with_stderr("\
 [COMPILING] foo v0.5.0 (file://[..])
-[RUNNING] `[..]build-script-build`
+[RUNNING] `[..][/]build-script-build`
 [RUNNING] `rustc [..] --crate-name foo [..]`
 [RUNNING] `rustc [..] --crate-name foo [..]`
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] `[..]foo-[..][EXE]`
+[RUNNING] `[..][/]foo-[..][EXE]`
 [DOCTEST] foo
 [RUNNING] `rustdoc --test [..]`")
                        .with_stdout("
@@ -530,7 +530,7 @@ test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
                        .with_stderr("\
 [COMPILING] foo v0.5.0 (file://[..])
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] `target[..]foo[EXE]`
+[RUNNING] `target[/]debug[/]foo[EXE]`
 "));
 }
 
@@ -674,7 +674,7 @@ fn build_deps_simple() {
 [RUNNING] `rustc [..] --crate-name a [..]`
 [COMPILING] foo v0.5.0 (file://[..])
 [RUNNING] `rustc build.rs [..] --extern a=[..]`
-[RUNNING] `[..]foo-[..]build-script-build`
+[RUNNING] `[..][/]foo-[..][/]build-script-build`
 [RUNNING] `rustc [..] --crate-name foo [..]`
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 "));
@@ -763,22 +763,22 @@ fn build_cmd_with_a_build_cmd() {
 [COMPILING] b v0.5.0 (file://[..])
 [RUNNING] `rustc [..] --crate-name b [..]`
 [COMPILING] a v0.5.0 (file://[..])
-[RUNNING] `rustc a[..]build.rs [..] --extern b=[..]`
-[RUNNING] `[..]a-[..]build-script-build`
+[RUNNING] `rustc a[/]build.rs [..] --extern b=[..]`
+[RUNNING] `[..][/]a-[..][/]build-script-build`
 [RUNNING] `rustc [..]lib.rs --crate-name a --crate-type lib -g \
     -C metadata=[..] \
-    --out-dir [..]target[..]deps --emit=dep-info,link \
-    -L [..]target[..]deps`
+    --out-dir [..]target[/]debug[/]deps --emit=dep-info,link \
+    -L [..]target[/]debug[/]deps`
 [COMPILING] foo v0.5.0 (file://[..])
 [RUNNING] `rustc build.rs --crate-name build_script_build --crate-type bin \
     -g -C metadata=[..] --out-dir [..] --emit=dep-info,link \
-    -L [..]target[..]deps \
+    -L [..]target[/]debug[/]deps \
     --extern a=[..]liba[..].rlib`
-[RUNNING] `[..]foo-[..]build-script-build`
+[RUNNING] `[..][/]foo-[..][/]build-script-build`
 [RUNNING] `rustc [..]lib.rs --crate-name foo --crate-type lib -g \
     -C metadata=[..] \
     --out-dir [..] --emit=dep-info,link \
-    -L [..]target[..]deps`
+    -L [..]target[/]debug[/]deps`
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 "));
 }
@@ -854,7 +854,7 @@ fn output_separate_lines() {
                        .with_stderr_contains("\
 [COMPILING] foo v0.5.0 (file://[..])
 [RUNNING] `rustc build.rs [..]`
-[RUNNING] `[..]foo-[..]build-script-build`
+[RUNNING] `[..][/]foo-[..][/]build-script-build`
 [RUNNING] `rustc [..] --crate-name foo [..] -L foo -l static=foo`
 [ERROR] could not find native static library [..]
 "));
@@ -882,7 +882,7 @@ fn output_separate_lines_new() {
                        .with_stderr_contains("\
 [COMPILING] foo v0.5.0 (file://[..])
 [RUNNING] `rustc build.rs [..]`
-[RUNNING] `[..]foo-[..]build-script-build`
+[RUNNING] `[..][/]foo-[..][/]build-script-build`
 [RUNNING] `rustc [..] --crate-name foo [..] -L foo -l static=foo`
 [ERROR] could not find native static library [..]
 "));
@@ -927,7 +927,7 @@ fn code_generation() {
                        .with_stderr("\
 [COMPILING] foo v0.5.0 (file://[..])
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] `target[..]foo`")
+[RUNNING] `target[/]debug[/]foo`")
                        .with_stdout("\
 Hello, World!
 "));
@@ -1364,13 +1364,13 @@ fn cfg_test() {
                 execs().with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({dir})
 [RUNNING] [..] build.rs [..]
-[RUNNING] `[..]build-script-build`
+[RUNNING] `[..][/]build-script-build`
 [RUNNING] [..] --cfg foo[..]
 [RUNNING] [..] --cfg foo[..]
 [RUNNING] [..] --cfg foo[..]
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] `[..]foo-[..][EXE]`
-[RUNNING] `[..]test-[..][EXE]`
+[RUNNING] `[..][/]foo-[..][EXE]`
+[RUNNING] `[..][/]test-[..][EXE]`
 [DOCTEST] foo
 [RUNNING] [..] --cfg foo[..]", dir = p.url()))
                        .with_stdout("
@@ -1486,8 +1486,8 @@ fn cfg_override_test() {
 [RUNNING] `[..]`
 [RUNNING] `[..]`
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] `[..]foo-[..][EXE]`
-[RUNNING] `[..]test-[..][EXE]`
+[RUNNING] `[..][/]foo-[..][EXE]`
+[RUNNING] `[..][/]test-[..][EXE]`
 [DOCTEST] foo
 [RUNNING] [..] --cfg foo[..]", dir = p.url()))
                        .with_stdout("
@@ -1597,16 +1597,16 @@ fn flags_go_into_tests() {
                 execs().with_status(0)
                        .with_stderr("\
 [COMPILING] a v0.5.0 ([..]
-[RUNNING] `rustc a[..]build.rs [..]`
-[RUNNING] `[..]build-script-build`
-[RUNNING] `rustc a[..]src[..]lib.rs [..] -L test[..]`
+[RUNNING] `rustc a[/]build.rs [..]`
+[RUNNING] `[..][/]build-script-build`
+[RUNNING] `rustc a[/]src[/]lib.rs [..] -L test[..]`
 [COMPILING] b v0.5.0 ([..]
-[RUNNING] `rustc b[..]src[..]lib.rs [..] -L test[..]`
+[RUNNING] `rustc b[/]src[/]lib.rs [..] -L test[..]`
 [COMPILING] foo v0.5.0 ([..]
-[RUNNING] `rustc src[..]lib.rs [..] -L test[..]`
-[RUNNING] `rustc tests[..]foo.rs [..] -L test[..]`
+[RUNNING] `rustc src[/]lib.rs [..] -L test[..]`
+[RUNNING] `rustc tests[/]foo.rs [..] -L test[..]`
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] `[..]foo-[..][EXE]`")
+[RUNNING] `[..][/]foo-[..][EXE]`")
                        .with_stdout("
 running 0 tests
 
@@ -1619,9 +1619,9 @@ test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
                        .with_stderr("\
 [FRESH] a v0.5.0 ([..]
 [COMPILING] b v0.5.0 ([..]
-[RUNNING] `rustc b[..]src[..]lib.rs [..] -L test[..]`
+[RUNNING] `rustc b[/]src[/]lib.rs [..] -L test[..]`
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] `[..]b-[..][EXE]`")
+[RUNNING] `[..][/]b-[..][EXE]`")
                        .with_stdout("
 running 0 tests
 
@@ -1802,8 +1802,8 @@ fn rebuild_only_on_explicit_paths() {
     assert_that(p.cargo("build").arg("-v"),
                 execs().with_status(0).with_stderr("\
 [COMPILING] a v0.5.0 ([..])
-[RUNNING] `[..]build-script-build`
-[RUNNING] `rustc src[..]lib.rs [..]`
+[RUNNING] `[..][/]build-script-build`
+[RUNNING] `rustc src[/]lib.rs [..]`
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 "));
 
@@ -1816,8 +1816,8 @@ fn rebuild_only_on_explicit_paths() {
     assert_that(p.cargo("build").arg("-v"),
                 execs().with_status(0).with_stderr("\
 [COMPILING] a v0.5.0 ([..])
-[RUNNING] `[..]build-script-build`
-[RUNNING] `rustc src[..]lib.rs [..]`
+[RUNNING] `[..][/]build-script-build`
+[RUNNING] `rustc src[/]lib.rs [..]`
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 "));
 
@@ -1845,8 +1845,8 @@ fn rebuild_only_on_explicit_paths() {
     assert_that(p.cargo("build").arg("-v"),
                 execs().with_status(0).with_stderr("\
 [COMPILING] a v0.5.0 ([..])
-[RUNNING] `[..]build-script-build`
-[RUNNING] `rustc src[..]lib.rs [..]`
+[RUNNING] `[..][/]build-script-build`
+[RUNNING] `rustc src[/]lib.rs [..]`
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 "));
 
@@ -1856,8 +1856,8 @@ fn rebuild_only_on_explicit_paths() {
     assert_that(p.cargo("build").arg("-v"),
                 execs().with_status(0).with_stderr("\
 [COMPILING] a v0.5.0 ([..])
-[RUNNING] `[..]build-script-build`
-[RUNNING] `rustc src[..]lib.rs [..]`
+[RUNNING] `[..][/]build-script-build`
+[RUNNING] `rustc src[/]lib.rs [..]`
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 "));
 }

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -98,7 +98,7 @@ fn cargo_compile_with_invalid_manifest3() {
 
 Caused by:
   could not parse input as TOML\n\
-src[..]Cargo.toml:1:5-1:6 expected a value\n\n"))
+src[/]Cargo.toml:1:5-1:6 expected a value\n\n"))
 }
 
 #[test]
@@ -1051,13 +1051,13 @@ fn lto_build() {
     assert_that(p.cargo_process("build").arg("-v").arg("--release"),
                 execs().with_status(0).with_stderr(&format!("\
 [COMPILING] test v0.0.0 ({url})
-[RUNNING] `rustc src[..]main.rs --crate-name test --crate-type bin \
+[RUNNING] `rustc src[/]main.rs --crate-name test --crate-type bin \
         -C opt-level=3 \
         -C lto \
         -C metadata=[..] \
-        --out-dir {dir}[..]target[..]release \
+        --out-dir {dir}[/]target[/]release \
         --emit=dep-info,link \
-        -L dependency={dir}[..]target[..]release[..]deps`
+        -L dependency={dir}[/]target[/]release[/]deps`
 [FINISHED] release [optimized] target(s) in [..]
 ",
 dir = p.root().display(),
@@ -1080,11 +1080,11 @@ fn verbose_build() {
     assert_that(p.cargo_process("build").arg("-v"),
                 execs().with_status(0).with_stderr(&format!("\
 [COMPILING] test v0.0.0 ({url})
-[RUNNING] `rustc src[..]lib.rs --crate-name test --crate-type lib -g \
+[RUNNING] `rustc src[/]lib.rs --crate-name test --crate-type lib -g \
         -C metadata=[..] \
         --out-dir [..] \
         --emit=dep-info,link \
-        -L dependency={dir}[..]target[..]debug[..]deps`
+        -L dependency={dir}[/]target[/]debug[/]deps`
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 ",
 dir = p.root().display(),
@@ -1107,12 +1107,12 @@ fn verbose_release_build() {
     assert_that(p.cargo_process("build").arg("-v").arg("--release"),
                 execs().with_status(0).with_stderr(&format!("\
 [COMPILING] test v0.0.0 ({url})
-[RUNNING] `rustc src[..]lib.rs --crate-name test --crate-type lib \
+[RUNNING] `rustc src[/]lib.rs --crate-name test --crate-type lib \
         -C opt-level=3 \
         -C metadata=[..] \
         --out-dir [..] \
         --emit=dep-info,link \
-        -L dependency={dir}[..]target[..]release[..]deps`
+        -L dependency={dir}[/]target[/]release[/]deps`
 [FINISHED] release [optimized] target(s) in [..]
 ",
 dir = p.root().display(),
@@ -1150,23 +1150,22 @@ fn verbose_release_build_deps() {
     assert_that(p.cargo_process("build").arg("-v").arg("--release"),
                 execs().with_status(0).with_stderr(&format!("\
 [COMPILING] foo v0.0.0 ({url}/foo)
-[RUNNING] `rustc foo[..]src[..]lib.rs --crate-name foo \
+[RUNNING] `rustc foo[/]src[/]lib.rs --crate-name foo \
         --crate-type dylib --crate-type rlib -C prefer-dynamic \
         -C opt-level=3 \
         -C metadata=[..] \
         --out-dir [..] \
         --emit=dep-info,link \
-        -L dependency={dir}[..]target[..]release[..]deps`
+        -L dependency={dir}[/]target[/]release[/]deps`
 [COMPILING] test v0.0.0 ({url})
-[RUNNING] `rustc src[..]lib.rs --crate-name test --crate-type lib \
+[RUNNING] `rustc src[/]lib.rs --crate-name test --crate-type lib \
         -C opt-level=3 \
         -C metadata=[..] \
         --out-dir [..] \
         --emit=dep-info,link \
-        -L dependency={dir}[..]target[..]release[..]deps \
-        --extern foo={dir}[..]target[..]release[..]deps[..]\
-                     {prefix}foo{suffix} \
-        --extern foo={dir}[..]target[..]release[..]deps[..]libfoo.rlib`
+        -L dependency={dir}[/]target[/]release[/]deps \
+        --extern foo={dir}[/]target[/]release[/]deps[/]{prefix}foo{suffix} \
+        --extern foo={dir}[/]target[/]release[/]deps[/]libfoo.rlib`
 [FINISHED] release [optimized] target(s) in [..]
 ",
                     dir = p.root().display(),
@@ -2266,7 +2265,7 @@ fn explicit_color_config_is_propagated_to_rustc() {
 
     assert_that(p.cargo_process("build").arg("-v").arg("--color").arg("always"),
                 execs().with_status(0).with_stderr_contains(
-                    "[..]rustc src[..]lib.rs --color always[..]"));
+                    "[..]rustc src[/]lib.rs --color always[..]"));
 
     assert_that(p.cargo_process("build").arg("-v").arg("--color").arg("never"),
                 execs().with_status(0).with_stderr("\

--- a/tests/cargotest/support/mod.rs
+++ b/tests/cargotest/support/mod.rs
@@ -351,7 +351,7 @@ impl Execs {
                  description: &str, extra: &[u8],
                  partial: bool) -> ham::MatchResult {
         let out = match expected {
-            Some(out) => substitute_macros(out),
+            Some(out) => out,
             None => return ham::success(),
         };
         let actual = match str::from_utf8(actual) {
@@ -432,6 +432,7 @@ impl Execs {
 }
 
 pub fn lines_match(expected: &str, mut actual: &str) -> bool {
+    let expected = substitute_macros(expected);
     for (i, part) in expected.split("[..]").enumerate() {
         match actual.find(part) {
             Some(j) => {

--- a/tests/cargotest/support/mod.rs
+++ b/tests/cargotest/support/mod.rs
@@ -673,6 +673,7 @@ fn substitute_macros(input: &str) -> String {
         ("[REPLACING]",   "   Replacing"),
         ("[UNPACKING]",   "   Unpacking"),
         ("[EXE]", if cfg!(windows) {".exe"} else {""}),
+        ("[/]", if cfg!(windows) {"\\"} else {"/"}),
     ];
     let mut result = input.to_owned();
     for &(pat, subst) in macros.iter() {

--- a/tests/clean.rs
+++ b/tests/clean.rs
@@ -173,7 +173,7 @@ fn build_script() {
 [COMPILING] foo v0.0.1 ([..])
 [RUNNING] `rustc build.rs [..]`
 [RUNNING] `[..]build-script-build`
-[RUNNING] `rustc src[..]main.rs [..]`
+[RUNNING] `rustc src[/]main.rs [..]`
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 "));
 }

--- a/tests/cross-compile.rs
+++ b/tests/cross-compile.rs
@@ -357,13 +357,13 @@ fn linker_and_ar() {
                 execs().with_status(101)
                        .with_stderr_contains(&format!("\
 [COMPILING] foo v0.5.0 ({url})
-[RUNNING] `rustc src[..]foo.rs --crate-name foo --crate-type bin -g \
+[RUNNING] `rustc src[/]foo.rs --crate-name foo --crate-type bin -g \
     -C metadata=[..] \
-    --out-dir {dir}[..]target[..]{target}[..]debug \
+    --out-dir {dir}[/]target[/]{target}[/]debug \
     --emit=dep-info,link \
     --target {target} \
     -C ar=my-ar-tool -C linker=my-linker-tool \
-    -L dependency={dir}[..]target[..]{target}[..]debug[..]deps`
+    -L dependency={dir}[/]target[/]{target}[/]debug[/]deps`
 ",
                             dir = p.root().display(),
                             url = p.url(),
@@ -473,8 +473,8 @@ fn cross_tests() {
                        .with_stderr(&format!("\
 [COMPILING] foo v0.0.0 ({foo})
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target[..]{triple}[..]bar-[..][EXE]
-[RUNNING] target[..]{triple}[..]foo-[..][EXE]", foo = p.url(), triple = target))
+[RUNNING] target[/]{triple}[/]debug[/]bar-[..][EXE]
+[RUNNING] target[/]{triple}[/]debug[/]deps[/]foo-[..][EXE]", foo = p.url(), triple = target))
                        .with_stdout("
 running 1 test
 test test ... ok
@@ -511,7 +511,7 @@ fn no_cross_doctests() {
     let host_output = format!("\
 [COMPILING] foo v0.0.0 ({foo})
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target[..]foo-[..][EXE]
+[RUNNING] target[/]debug[/]deps[/]foo-[..][EXE]
 [DOCTEST] foo
 ", foo = p.url());
 
@@ -524,7 +524,12 @@ fn no_cross_doctests() {
     let target = host();
     assert_that(p.cargo_process("test").arg("--target").arg(&target),
                 execs().with_status(0)
-                       .with_stderr(&host_output));
+                       .with_stderr(&format!("\
+[COMPILING] foo v0.0.0 ({foo})
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[RUNNING] target[/]{triple}[/]debug[/]deps[/]foo-[..][EXE]
+[DOCTEST] foo
+", foo = p.url(), triple = target)));
 
     println!("c");
     let target = alternate();
@@ -533,7 +538,7 @@ fn no_cross_doctests() {
                        .with_stderr(&format!("\
 [COMPILING] foo v0.0.0 ({foo})
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target[..]{triple}[..]foo-[..][EXE]
+[RUNNING] target[/]{triple}[/]debug[/]deps[/]foo-[..][EXE]
 ", foo = p.url(), triple = target)));
 }
 
@@ -599,9 +604,9 @@ fn cross_with_a_build_script() {
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] foo v0.0.0 (file://[..])
-[RUNNING] `rustc build.rs [..] --out-dir {dir}[..]target[..]build[..]foo-[..]`
-[RUNNING] `{dir}[..]target[..]build[..]foo-[..]build-script-build`
-[RUNNING] `rustc src[..]main.rs [..] --target {target} [..]`
+[RUNNING] `rustc build.rs [..] --out-dir {dir}[/]target[/]debug[/]build[/]foo-[..]`
+[RUNNING] `{dir}[/]target[/]debug[/]build[/]foo-[..][/]build-script-build`
+[RUNNING] `rustc src[/]main.rs [..] --target {target} [..]`
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 ", target = target,
    dir = p.root().display())));
@@ -671,25 +676,25 @@ fn build_script_needed_for_host_and_target() {
                        .with_stderr_contains(&format!("\
 [COMPILING] d1 v0.0.0 ({url}/d1)", url = p.url()))
                        .with_stderr_contains(&format!("\
-[RUNNING] `rustc d1[..]build.rs [..] --out-dir {dir}[..]target[..]build[..]d1-[..]`",
+[RUNNING] `rustc d1[/]build.rs [..] --out-dir {dir}[/]target[/]debug[/]build[/]d1-[..]`",
     dir = p.root().display()))
                        .with_stderr_contains(&format!("\
-[RUNNING] `{dir}[..]target[..]build[..]d1-[..]build-script-build`",
+[RUNNING] `{dir}[/]target[/]debug[/]build[/]d1-[..][/]build-script-build`",
     dir = p.root().display()))
                        .with_stderr_contains("\
-[RUNNING] `rustc d1[..]src[..]lib.rs [..]`")
+[RUNNING] `rustc d1[/]src[/]lib.rs [..]`")
                        .with_stderr_contains(&format!("\
 [COMPILING] d2 v0.0.0 ({url}/d2)", url = p.url()))
                        .with_stderr_contains(&format!("\
-[RUNNING] `rustc d2[..]src[..]lib.rs [..] \
+[RUNNING] `rustc d2[/]src[/]lib.rs [..] \
            -L /path/to/{host}`", host = host))
                        .with_stderr_contains(&format!("\
 [COMPILING] foo v0.0.0 ({url})", url = p.url()))
                        .with_stderr_contains(&format!("\
-[RUNNING] `rustc build.rs [..] --out-dir {dir}[..]target[..]build[..]foo-[..] \
+[RUNNING] `rustc build.rs [..] --out-dir {dir}[/]target[/]debug[/]build[/]foo-[..] \
            -L /path/to/{host}`", dir = p.root().display(), host = host))
                        .with_stderr_contains(&format!("\
-[RUNNING] `rustc src[..]main.rs [..] --target {target} [..] \
+[RUNNING] `rustc src[/]main.rs [..] --target {target} [..] \
            -L /path/to/{target}`", target = target)));
 }
 
@@ -800,8 +805,8 @@ fn plugin_build_script_right_arch() {
                        .with_stderr("\
 [COMPILING] foo v0.0.1 ([..])
 [RUNNING] `rustc build.rs [..]`
-[RUNNING] `[..]build-script-build`
-[RUNNING] `rustc src[..]lib.rs [..]`
+[RUNNING] `[..][/]build-script-build`
+[RUNNING] `rustc src[/]lib.rs [..]`
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 "));
 }
@@ -847,13 +852,13 @@ fn build_script_with_platform_specific_dependencies() {
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] d2 v0.0.0 ([..])
-[RUNNING] `rustc d2[..]src[..]lib.rs [..]`
+[RUNNING] `rustc d2[/]src[/]lib.rs [..]`
 [COMPILING] d1 v0.0.0 ([..])
-[RUNNING] `rustc d1[..]src[..]lib.rs [..]`
+[RUNNING] `rustc d1[/]src[/]lib.rs [..]`
 [COMPILING] foo v0.0.1 ([..])
 [RUNNING] `rustc build.rs [..]`
-[RUNNING] `{dir}[..]target[..]build[..]foo-[..]build-script-build`
-[RUNNING] `rustc src[..]lib.rs [..] --target {target} [..]`
+[RUNNING] `{dir}[/]target[/]debug[/]build[/]foo-[..][/]build-script-build`
+[RUNNING] `rustc src[/]lib.rs [..] --target {target} [..]`
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 ", dir = p.root().display(), target = target)));
 }

--- a/tests/doc.rs
+++ b/tests/doc.rs
@@ -445,7 +445,7 @@ fn doc_release() {
                 execs().with_status(0)
                        .with_stderr("\
 [DOCUMENTING] foo v0.0.1 ([..])
-[RUNNING] `rustdoc src[..]lib.rs [..]`
+[RUNNING] `rustdoc src[/]lib.rs [..]`
 "));
 }
 

--- a/tests/git.rs
+++ b/tests/git.rs
@@ -936,7 +936,7 @@ fn dep_with_changed_submodule() {
                                       [COMPILING] foo v0.5.0 ([..])\n\
                                       [FINISHED] debug [unoptimized + debuginfo] target(s) in \
                                       [..]\n\
-                                      [RUNNING] `target[..]foo[EXE]`\n")
+                                      [RUNNING] `target[/]debug[/]foo[EXE]`\n")
                 .with_stdout("project2\n")
                 .with_status(0));
 
@@ -978,7 +978,7 @@ fn dep_with_changed_submodule() {
                                       [COMPILING] foo v0.5.0 ([..])\n\
                                       [FINISHED] debug [unoptimized + debuginfo] target(s) in \
                                       [..]\n\
-                                      [RUNNING] `target[..]foo[EXE]`\n")
+                                      [RUNNING] `target[/]debug[/]foo[EXE]`\n")
                 .with_stdout("project3\n")
                 .with_status(0));
 }
@@ -1035,7 +1035,7 @@ fn dev_deps_with_testing() {
 [COMPILING] [..] v0.5.0 ([..])
 [COMPILING] [..] v0.5.0 ([..]
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target[..]foo-[..][EXE]")
+[RUNNING] target[/]debug[/]foo-[..][EXE]")
                        .with_stdout("
 running 1 test
 test tests::foo ... ok

--- a/tests/metadata.rs
+++ b/tests/metadata.rs
@@ -27,7 +27,7 @@ fn cargo_metadata_simple() {
                             "bin"
                         ],
                         "name": "foo",
-                        "src_path": "src[..]foo.rs"
+                        "src_path": "src[/]foo.rs"
                     }
                 ],
                 "features": {},
@@ -212,11 +212,11 @@ fn workspace_metadata() {
                     {
                         "kind": [ "lib" ],
                         "name": "bar",
-                        "src_path": "[..]bar[..]src[..]lib.rs"
+                        "src_path": "[..]bar[/]src[/]lib.rs"
                     }
                 ],
                 "features": {},
-                "manifest_path": "[..]bar[..]Cargo.toml"
+                "manifest_path": "[..]bar[/]Cargo.toml"
             },
             {
                 "name": "baz",
@@ -230,11 +230,11 @@ fn workspace_metadata() {
                     {
                         "kind": [ "lib" ],
                         "name": "baz",
-                        "src_path": "[..]baz[..]src[..]lib.rs"
+                        "src_path": "[..]baz[/]src[/]lib.rs"
                     }
                 ],
                 "features": {},
-                "manifest_path": "[..]baz[..]Cargo.toml"
+                "manifest_path": "[..]baz[/]Cargo.toml"
             }
         ],
         "workspace_members": ["baz 0.5.0 (path+file:[..]baz)", "bar 0.5.0 (path+file:[..]bar)"],
@@ -283,11 +283,11 @@ fn workspace_metadata_no_deps() {
                     {
                         "kind": [ "lib" ],
                         "name": "bar",
-                        "src_path": "[..]bar[..]src[..]lib.rs"
+                        "src_path": "[..]bar[/]src[/]lib.rs"
                     }
                 ],
                 "features": {},
-                "manifest_path": "[..]bar[..]Cargo.toml"
+                "manifest_path": "[..]bar[/]Cargo.toml"
             },
             {
                 "name": "baz",
@@ -301,11 +301,11 @@ fn workspace_metadata_no_deps() {
                     {
                         "kind": [ "lib" ],
                         "name": "baz",
-                        "src_path": "[..]baz[..]src[..]lib.rs"
+                        "src_path": "[..]baz[/]src[/]lib.rs"
                     }
                 ],
                 "features": {},
-                "manifest_path": "[..]baz[..]Cargo.toml"
+                "manifest_path": "[..]baz[/]Cargo.toml"
             }
         ],
         "workspace_members": ["baz 0.5.0 (path+file:[..]baz)", "bar 0.5.0 (path+file:[..]bar)"],
@@ -341,7 +341,7 @@ const MANIFEST_OUTPUT: &'static str=
         "targets":[{
             "kind":["bin"],
             "name":"foo",
-            "src_path":"src[..]foo.rs"
+            "src_path":"src[/]foo.rs"
         }],
         "features":{},
         "manifest_path":"[..]Cargo.toml"

--- a/tests/package.rs
+++ b/tests/package.rs
@@ -48,7 +48,7 @@ See [..]
     assert_that(p.cargo("package").arg("-l"),
                 execs().with_status(0).with_stdout("\
 Cargo.toml
-src[..]main.rs
+src[/]main.rs
 "));
     assert_that(p.cargo("package"),
                 execs().with_status(0).with_stdout(""));

--- a/tests/path.rs
+++ b/tests/path.rs
@@ -189,7 +189,7 @@ fn cargo_compile_with_root_dev_deps_with_testing() {
 [COMPILING] [..] v0.5.0 ([..])
 [COMPILING] [..] v0.5.0 ([..])
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target[..]foo-[..][EXE]")
+[RUNNING] target[/]debug[/]foo-[..][EXE]")
                        .with_stdout("
 running 0 tests
 
@@ -555,7 +555,7 @@ Caused by:
   Unable to update file://[..]
 
 Caused by:
-  failed to read `[..]bar[..]Cargo.toml`
+  failed to read `[..]bar[/]Cargo.toml`
 
 Caused by:
   [..] (os error [..])
@@ -798,7 +798,7 @@ fn dev_deps_no_rebuild_lib() {
 [COMPILING] [..] v0.5.0 ({url}[..])
 [COMPILING] [..] v0.5.0 ({url}[..])
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target[..]foo-[..][EXE]", url = p.url()))
+[RUNNING] target[/]debug[/]deps[/]foo-[..][EXE]", url = p.url()))
                        .with_stdout("
 running 0 tests
 

--- a/tests/profiles.rs
+++ b/tests/profiles.rs
@@ -2,7 +2,6 @@ extern crate cargotest;
 extern crate hamcrest;
 
 use std::env;
-use std::path::MAIN_SEPARATOR as SEP;
 
 use cargotest::is_nightly;
 use cargotest::support::{project, execs};
@@ -28,16 +27,16 @@ fn profile_overrides() {
     assert_that(p.cargo_process("build").arg("-v"),
                 execs().with_status(0).with_stderr(&format!("\
 [COMPILING] test v0.0.0 ({url})
-[RUNNING] `rustc src{sep}lib.rs --crate-name test --crate-type lib \
+[RUNNING] `rustc src[/]lib.rs --crate-name test --crate-type lib \
         -C opt-level=1 \
         -C debug-assertions=on \
         -C metadata=[..] \
         -C rpath \
         --out-dir [..] \
         --emit=dep-info,link \
-        -L dependency={dir}{sep}target{sep}debug{sep}deps`
+        -L dependency={dir}[/]target[/]debug[/]deps`
 [FINISHED] debug [optimized] target(s) in [..]
-", sep = SEP,
+",
 dir = p.root().display(),
 url = p.url(),
 )));
@@ -61,14 +60,14 @@ fn opt_level_override_0() {
     assert_that(p.cargo_process("build").arg("-v"),
                 execs().with_status(0).with_stderr(&format!("\
 [COMPILING] test v0.0.0 ({url})
-[RUNNING] `rustc src{sep}lib.rs --crate-name test --crate-type lib \
+[RUNNING] `rustc src[/]lib.rs --crate-name test --crate-type lib \
         -g \
         -C metadata=[..] \
         --out-dir [..] \
         --emit=dep-info,link \
-        -L dependency={dir}{sep}target{sep}debug{sep}deps`
+        -L dependency={dir}[/]target[/]debug[/]deps`
 [FINISHED] [..] target(s) in [..]
-", sep = SEP,
+",
 dir = p.root().display(),
 url = p.url()
 )));
@@ -91,16 +90,16 @@ fn check_opt_level_override(profile_level: &str, rustc_level: &str) {
     assert_that(p.cargo_process("build").arg("-v"),
                 execs().with_status(0).with_stderr(&format!("\
 [COMPILING] test v0.0.0 ({url})
-[RUNNING] `rustc src{sep}lib.rs --crate-name test --crate-type lib \
+[RUNNING] `rustc src[/]lib.rs --crate-name test --crate-type lib \
         -C opt-level={level} \
         -g \
         -C debug-assertions=on \
         -C metadata=[..] \
         --out-dir [..] \
         --emit=dep-info,link \
-        -L dependency={dir}{sep}target{sep}debug{sep}deps`
+        -L dependency={dir}[/]target[/]debug[/]deps`
 [FINISHED] [..] target(s) in [..]
-", sep = SEP,
+",
 dir = p.root().display(),
 url = p.url(),
 level = rustc_level
@@ -160,30 +159,29 @@ fn top_level_overrides_deps() {
     assert_that(p.cargo_process("build").arg("-v").arg("--release"),
                 execs().with_status(0).with_stderr(&format!("\
 [COMPILING] foo v0.0.0 ({url}/foo)
-[RUNNING] `rustc foo{sep}src{sep}lib.rs --crate-name foo \
+[RUNNING] `rustc foo[/]src[/]lib.rs --crate-name foo \
         --crate-type dylib --crate-type rlib -C prefer-dynamic \
         -C opt-level=1 \
         -g \
         -C metadata=[..] \
-        --out-dir {dir}{sep}target{sep}release{sep}deps \
+        --out-dir {dir}[/]target[/]release[/]deps \
         --emit=dep-info,link \
-        -L dependency={dir}{sep}target{sep}release{sep}deps`
+        -L dependency={dir}[/]target[/]release[/]deps`
 [COMPILING] test v0.0.0 ({url})
-[RUNNING] `rustc src{sep}lib.rs --crate-name test --crate-type lib \
+[RUNNING] `rustc src[/]lib.rs --crate-name test --crate-type lib \
         -C opt-level=1 \
         -g \
         -C metadata=[..] \
         --out-dir [..] \
         --emit=dep-info,link \
-        -L dependency={dir}{sep}target{sep}release{sep}deps \
-        --extern foo={dir}{sep}target{sep}release{sep}deps{sep}\
+        -L dependency={dir}[/]target[/]release[/]deps \
+        --extern foo={dir}[/]target[/]release[/]deps[/]\
                      {prefix}foo[..]{suffix} \
-        --extern foo={dir}{sep}target{sep}release{sep}deps{sep}libfoo.rlib`
+        --extern foo={dir}[/]target[/]release[/]deps[/]libfoo.rlib`
 [FINISHED] release [optimized + debuginfo] target(s) in [..]
 ",
                     dir = p.root().display(),
                     url = p.url(),
-                    sep = SEP,
                     prefix = env::consts::DLL_PREFIX,
                     suffix = env::consts::DLL_SUFFIX)));
 }

--- a/tests/read-manifest.rs
+++ b/tests/read-manifest.rs
@@ -21,7 +21,7 @@ fn read_manifest_output() -> String {
     "targets":[{
         "kind":["bin"],
         "name":"foo",
-        "src_path":"src[/]foo.rs"
+        "src_path":"src[..]foo.rs"
     }],
     "features":{},
     "manifest_path":"[..]Cargo.toml"

--- a/tests/read-manifest.rs
+++ b/tests/read-manifest.rs
@@ -21,7 +21,7 @@ fn read_manifest_output() -> String {
     "targets":[{
         "kind":["bin"],
         "name":"foo",
-        "src_path":"src[..]foo.rs"
+        "src_path":"src[/]foo.rs"
     }],
     "features":{},
     "manifest_path":"[..]Cargo.toml"

--- a/tests/run.rs
+++ b/tests/run.rs
@@ -2,8 +2,6 @@ extern crate cargo;
 extern crate cargotest;
 extern crate hamcrest;
 
-use std::path::MAIN_SEPARATOR as SEP;
-
 use cargo::util::paths::dylib_path_envvar;
 use cargotest::support::{project, execs, path2url};
 use hamcrest::{assert_that, existing_file};
@@ -26,7 +24,7 @@ fn simple() {
                        .with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({dir})
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] `target{sep}debug{sep}foo[EXE]`", dir = path2url(p.root()), sep = SEP))
+[RUNNING] `target[/]debug[/]foo[EXE]`", dir = path2url(p.root())))
                        .with_stdout("\
 hello
 "));
@@ -232,18 +230,18 @@ fn specify_name() {
 [RUNNING] `rustc src[/]lib.rs [..]`
 [RUNNING] `rustc src[/]bin[/]a.rs [..]`
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] `target{sep}debug{sep}a[EXE]`", dir = path2url(p.root()), sep = SEP))
+[RUNNING] `target[/]debug[/]a[EXE]`", dir = path2url(p.root())))
                        .with_stdout("\
 hello a.rs
 "));
 
     assert_that(p.cargo("run").arg("--bin").arg("b").arg("-v"),
                 execs().with_status(0)
-                       .with_stderr(&format!("\
+                       .with_stderr("\
 [COMPILING] foo v0.0.1 ([..])
 [RUNNING] `rustc src[/]bin[/]b.rs [..]`
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] `target{sep}debug{sep}b[EXE]`", sep = SEP))
+[RUNNING] `target[/]debug[/]b[EXE]`")
                        .with_stdout("\
 hello b.rs
 "));
@@ -271,7 +269,7 @@ fn run_example() {
                        .with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({dir})
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] `target{sep}debug{sep}examples{sep}a[EXE]`", dir = path2url(p.root()), sep = SEP))
+[RUNNING] `target[/]debug[/]examples[/]a[EXE]`", dir = path2url(p.root())))
                        .with_stdout("\
 example
 "));
@@ -364,7 +362,7 @@ fn one_bin_multiple_examples() {
                        .with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({dir})
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] `target{sep}debug{sep}main[EXE]`", dir = path2url(p.root()), sep = SEP))
+[RUNNING] `target[/]debug[/]main[EXE]`", dir = path2url(p.root())))
                        .with_stdout("\
 hello main.rs
 "));
@@ -418,26 +416,26 @@ fn example_with_release_flag() {
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] bar v0.0.1 ({url}/bar)
-[RUNNING] `rustc bar{sep}src{sep}bar.rs --crate-name bar --crate-type lib \
+[RUNNING] `rustc bar[/]src[/]bar.rs --crate-name bar --crate-type lib \
         -C opt-level=3 \
         -C metadata=[..] \
-        --out-dir {dir}{sep}target{sep}release{sep}deps \
+        --out-dir {dir}[/]target[/]release[/]deps \
         --emit=dep-info,link \
-        -L dependency={dir}{sep}target{sep}release{sep}deps`
+        -L dependency={dir}[/]target[/]release[/]deps`
 [COMPILING] foo v0.0.1 ({url})
-[RUNNING] `rustc examples{sep}a.rs --crate-name a --crate-type bin \
+[RUNNING] `rustc examples[/]a.rs --crate-name a --crate-type bin \
         -C opt-level=3 \
         -C metadata=[..] \
-        --out-dir {dir}{sep}target{sep}release{sep}examples \
+        --out-dir {dir}[/]target[/]release[/]examples \
         --emit=dep-info,link \
-        -L dependency={dir}{sep}target{sep}release{sep}deps \
-         --extern bar={dir}{sep}target{sep}release{sep}deps{sep}libbar.rlib`
+        -L dependency={dir}[/]target[/]release[/]deps \
+         --extern bar={dir}[/]target[/]release[/]deps[/]libbar.rlib`
 [FINISHED] release [optimized] target(s) in [..]
-[RUNNING] `target{sep}release{sep}examples{sep}a[EXE]`
+[RUNNING] `target[/]release[/]examples[/]a[EXE]`
 ",
         dir = p.root().display(),
         url = path2url(p.root()),
-        sep = SEP))
+        ))
                        .with_stdout("\
 fast1
 fast2"));
@@ -446,26 +444,26 @@ fast2"));
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] bar v0.0.1 ({url}/bar)
-[RUNNING] `rustc bar{sep}src{sep}bar.rs --crate-name bar --crate-type lib \
+[RUNNING] `rustc bar[/]src[/]bar.rs --crate-name bar --crate-type lib \
         -g \
         -C metadata=[..] \
-        --out-dir {dir}{sep}target{sep}debug{sep}deps \
+        --out-dir {dir}[/]target[/]debug[/]deps \
         --emit=dep-info,link \
-        -L dependency={dir}{sep}target{sep}debug{sep}deps`
+        -L dependency={dir}[/]target[/]debug[/]deps`
 [COMPILING] foo v0.0.1 ({url})
-[RUNNING] `rustc examples{sep}a.rs --crate-name a --crate-type bin \
+[RUNNING] `rustc examples[/]a.rs --crate-name a --crate-type bin \
         -g \
         -C metadata=[..] \
-        --out-dir {dir}{sep}target{sep}debug{sep}examples \
+        --out-dir {dir}[/]target[/]debug[/]examples \
         --emit=dep-info,link \
-        -L dependency={dir}{sep}target{sep}debug{sep}deps \
-         --extern bar={dir}{sep}target{sep}debug{sep}deps{sep}libbar.rlib`
+        -L dependency={dir}[/]target[/]debug[/]deps \
+         --extern bar={dir}[/]target[/]debug[/]deps[/]libbar.rlib`
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] `target{sep}debug{sep}examples{sep}a[EXE]`
+[RUNNING] `target[/]debug[/]examples[/]a[EXE]`
 ",
         dir = p.root().display(),
         url = path2url(p.root()),
-        sep = SEP))
+        ))
                        .with_stdout("\
 slow1
 slow2"));
@@ -520,10 +518,10 @@ fn release_works() {
                 execs().with_status(0).with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({dir})
 [FINISHED] release [optimized] target(s) in [..]
-[RUNNING] `target{sep}release{sep}foo[EXE]`
+[RUNNING] `target[/]release[/]foo[EXE]`
 ",
         dir = path2url(p.root()),
-        sep = SEP)));
+        )));
     assert_that(&p.release_bin("foo"), existing_file());
 }
 
@@ -589,9 +587,9 @@ fn run_from_executable_folder() {
 
     assert_that(p.cargo("run").cwd(cwd),
                 execs().with_status(0)
-                       .with_stderr(&format!("\
+                       .with_stderr("\
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]\n\
-[RUNNING] `.{sep}foo[EXE]`", sep = SEP))
+[RUNNING] `.[/]foo[EXE]`")
                        .with_stdout("\
 hello
 "));

--- a/tests/run.rs
+++ b/tests/run.rs
@@ -229,8 +229,8 @@ fn specify_name() {
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({dir})
-[RUNNING] `rustc src[..]lib.rs [..]`
-[RUNNING] `rustc src[..]a.rs [..]`
+[RUNNING] `rustc src[/]lib.rs [..]`
+[RUNNING] `rustc src[/]bin[/]a.rs [..]`
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `target{sep}debug{sep}a[EXE]`", dir = path2url(p.root()), sep = SEP))
                        .with_stdout("\
@@ -241,7 +241,7 @@ hello a.rs
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ([..])
-[RUNNING] `rustc src[..]b.rs [..]`
+[RUNNING] `rustc src[/]bin[/]b.rs [..]`
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `target{sep}debug{sep}b[EXE]`", sep = SEP))
                        .with_stdout("\

--- a/tests/rustc.rs
+++ b/tests/rustc.rs
@@ -101,7 +101,7 @@ fn build_main_and_allow_unstable_options() {
         --out-dir [..] \
         --emit=dep-info,link \
         -L dependency={dir}{sep}target{sep}debug{sep}deps \
-        --extern {name}={dir}{sep}target[..]lib{name}.rlib`
+        --extern {name}={dir}{sep}target[/]debug[/]deps[/]lib{name}.rlib`
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 ", sep = SEP,
             dir = p.root().display(), url = p.url(),

--- a/tests/rustc.rs
+++ b/tests/rustc.rs
@@ -1,8 +1,6 @@
 extern crate cargotest;
 extern crate hamcrest;
 
-use std::path::MAIN_SEPARATOR as SEP;
-
 use cargotest::support::{execs, project};
 use hamcrest::assert_that;
 
@@ -29,14 +27,13 @@ fn build_lib_for_foo() {
                 .with_status(0)
                 .with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({url})
-[RUNNING] `rustc src{sep}lib.rs --crate-name foo --crate-type lib -g \
+[RUNNING] `rustc src[/]lib.rs --crate-name foo --crate-type lib -g \
         -C metadata=[..] \
         --out-dir [..] \
         --emit=dep-info,link \
-        -L dependency={dir}{sep}target{sep}debug{sep}deps`
+        -L dependency={dir}[/]target[/]debug[/]deps`
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
-", sep = SEP,
-            dir = p.root().display(), url = p.url())));
+", dir = p.root().display(), url = p.url())));
 }
 
 #[test]
@@ -59,15 +56,14 @@ fn lib() {
                 .with_status(0)
                 .with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({url})
-[RUNNING] `rustc src{sep}lib.rs --crate-name foo --crate-type lib -g \
+[RUNNING] `rustc src[/]lib.rs --crate-name foo --crate-type lib -g \
         -C debug-assertions=off \
         -C metadata=[..] \
         --out-dir [..] \
         --emit=dep-info,link \
-        -L dependency={dir}{sep}target{sep}debug{sep}deps`
+        -L dependency={dir}[/]target[/]debug[/]deps`
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
-", sep = SEP,
-            dir = p.root().display(), url = p.url())))
+", dir = p.root().display(), url = p.url())))
 }
 
 #[test]
@@ -90,20 +86,20 @@ fn build_main_and_allow_unstable_options() {
                 .with_status(0)
                 .with_stderr(&format!("\
 [COMPILING] {name} v{version} ({url})
-[RUNNING] `rustc src{sep}lib.rs --crate-name {name} --crate-type lib -g \
+[RUNNING] `rustc src[/]lib.rs --crate-name {name} --crate-type lib -g \
         -C metadata=[..] \
         --out-dir [..] \
         --emit=dep-info,link \
-        -L dependency={dir}{sep}target{sep}debug{sep}deps`
-[RUNNING] `rustc src{sep}main.rs --crate-name {name} --crate-type bin -g \
+        -L dependency={dir}[/]target[/]debug[/]deps`
+[RUNNING] `rustc src[/]main.rs --crate-name {name} --crate-type bin -g \
         -C debug-assertions \
         -C metadata=[..] \
         --out-dir [..] \
         --emit=dep-info,link \
-        -L dependency={dir}{sep}target{sep}debug{sep}deps \
-        --extern {name}={dir}{sep}target[/]debug[/]deps[/]lib{name}.rlib`
+        -L dependency={dir}[/]target[/]debug[/]deps \
+        --extern {name}={dir}[/]target[/]debug[/]deps[/]lib{name}.rlib`
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
-", sep = SEP,
+",
             dir = p.root().display(), url = p.url(),
             name = "foo", version = "0.0.1")));
 }
@@ -155,13 +151,13 @@ fn build_with_args_to_one_of_multiple_binaries() {
                 .with_status(0)
                 .with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({url})
-[RUNNING] `rustc src{sep}lib.rs --crate-name foo --crate-type lib -g \
+[RUNNING] `rustc src[/]lib.rs --crate-name foo --crate-type lib -g \
         -C metadata=[..] \
         --out-dir [..]`
-[RUNNING] `rustc src{sep}bin{sep}bar.rs --crate-name bar --crate-type bin -g \
+[RUNNING] `rustc src[/]bin[/]bar.rs --crate-name bar --crate-type bin -g \
         -C debug-assertions [..]`
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
-", sep = SEP, url = p.url())));
+", url = p.url())));
 }
 
 #[test]
@@ -211,13 +207,13 @@ fn build_with_args_to_one_of_multiple_tests() {
                 .with_status(0)
                 .with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({url})
-[RUNNING] `rustc src{sep}lib.rs --crate-name foo --crate-type lib -g \
+[RUNNING] `rustc src[/]lib.rs --crate-name foo --crate-type lib -g \
         -C metadata=[..] \
         --out-dir [..]`
-[RUNNING] `rustc tests{sep}bar.rs --crate-name bar -g \
+[RUNNING] `rustc tests[/]bar.rs --crate-name bar -g \
         -C debug-assertions [..]--test[..]`
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
-", sep = SEP, url = p.url())));
+", url = p.url())));
 }
 
 #[test]
@@ -259,8 +255,7 @@ fn build_foo_with_bar_dependency() {
 [COMPILING] foo v0.0.1 ({url})
 [RUNNING] `[..] -g -C debug-assertions [..]`
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
-",
-                url = foo.url())));
+", url = foo.url())));
 }
 
 #[test]

--- a/tests/rustdoc.rs
+++ b/tests/rustdoc.rs
@@ -1,8 +1,6 @@
 extern crate cargotest;
 extern crate hamcrest;
 
-use std::path::MAIN_SEPARATOR as SEP;
-
 use cargotest::support::{execs, project};
 use hamcrest::{assert_that};
 
@@ -22,12 +20,11 @@ fn rustdoc_simple() {
                 .with_status(0)
                 .with_stderr(format!("\
 [DOCUMENTING] foo v0.0.1 ({url})
-[RUNNING] `rustdoc src{sep}lib.rs --crate-name foo \
-        -o {dir}{sep}target{sep}doc \
-        -L dependency={dir}{sep}target{sep}debug{sep}deps`
+[RUNNING] `rustdoc src[/]lib.rs --crate-name foo \
+        -o {dir}[/]target[/]doc \
+        -L dependency={dir}[/]target[/]debug[/]deps`
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
-", sep = SEP,
-            dir = p.root().display(), url = p.url())));
+", dir = p.root().display(), url = p.url())));
 }
 
 #[test]
@@ -46,13 +43,12 @@ fn rustdoc_args() {
                 .with_status(0)
                 .with_stderr(format!("\
 [DOCUMENTING] foo v0.0.1 ({url})
-[RUNNING] `rustdoc src{sep}lib.rs --crate-name foo \
-        -o {dir}{sep}target{sep}doc \
+[RUNNING] `rustdoc src[/]lib.rs --crate-name foo \
+        -o {dir}[/]target[/]doc \
         --no-defaults \
-        -L dependency={dir}{sep}target{sep}debug{sep}deps`
+        -L dependency={dir}[/]target[/]debug[/]deps`
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
-", sep = SEP,
-            dir = p.root().display(), url = p.url())));
+", dir = p.root().display(), url = p.url())));
 }
 
 
@@ -90,16 +86,15 @@ fn rustdoc_foo_with_bar_dependency() {
                 .with_status(0)
                 .with_stderr(format!("\
 [COMPILING] bar v0.0.1 ([..])
-[RUNNING] `rustc [..]bar{sep}src{sep}lib.rs [..]`
+[RUNNING] `rustc [..]bar[/]src[/]lib.rs [..]`
 [DOCUMENTING] foo v0.0.1 ({url})
-[RUNNING] `rustdoc src{sep}lib.rs --crate-name foo \
-        -o {dir}{sep}target{sep}doc \
+[RUNNING] `rustdoc src[/]lib.rs --crate-name foo \
+        -o {dir}[/]target[/]doc \
         --no-defaults \
-        -L dependency={dir}{sep}target{sep}debug{sep}deps \
+        -L dependency={dir}[/]target[/]debug[/]deps \
         --extern [..]`
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
-", sep = SEP,
-            dir = foo.root().display(), url = foo.url())));
+", dir = foo.root().display(), url = foo.url())));
 }
 
 #[test]
@@ -138,13 +133,12 @@ fn rustdoc_only_bar_dependency() {
                 .with_status(0)
                 .with_stderr(format!("\
 [DOCUMENTING] bar v0.0.1 ([..])
-[RUNNING] `rustdoc [..]bar{sep}src{sep}lib.rs --crate-name bar \
-        -o {dir}{sep}target{sep}doc \
+[RUNNING] `rustdoc [..]bar[/]src[/]lib.rs --crate-name bar \
+        -o {dir}[/]target[/]doc \
         --no-defaults \
-        -L dependency={dir}{sep}target{sep}debug{sep}deps`
+        -L dependency={dir}[/]target[/]debug[/]deps`
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
-", sep = SEP,
-            dir = foo.root().display())));
+", dir = foo.root().display())));
 }
 
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -40,7 +40,7 @@ fn cargo_test_simple() {
                 execs().with_stderr(format!("\
 [COMPILING] foo v0.5.0 ({})
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target[..]foo-[..][EXE]", p.url()))
+[RUNNING] target[/]debug[/]foo-[..][EXE]", p.url()))
                        .with_stdout("
 running 1 test
 test test_hello ... ok
@@ -92,8 +92,8 @@ fn cargo_test_release() {
 [RUNNING] [..] -C opt-level=3 [..]
 [RUNNING] [..] -C opt-level=3 [..]
 [FINISHED] release [optimized] target(s) in [..]
-[RUNNING] `[..]target[..]foo-[..][EXE]`
-[RUNNING] `[..]target[..]test-[..][EXE]`
+[RUNNING] `[..]target[/]release[/]deps[/]foo-[..][EXE]`
+[RUNNING] `[..]target[/]release[/]test-[..][EXE]`
 [DOCTEST] foo
 [RUNNING] `rustdoc --test [..]lib.rs[..]`", dir = p.url()))
                        .with_stdout("
@@ -128,9 +128,9 @@ fn cargo_test_verbose() {
     assert_that(p.cargo_process("test").arg("-v").arg("hello"),
                 execs().with_stderr(format!("\
 [COMPILING] foo v0.5.0 ({url})
-[RUNNING] `rustc src[..]foo.rs [..]`
+[RUNNING] `rustc src[/]foo.rs [..]`
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] `[..]target[..]foo-[..][EXE] hello`", url = p.url()))
+[RUNNING] `[..]target[/]debug[/]foo-[..][EXE] hello`", url = p.url()))
                        .with_stdout("
 running 1 test
 test test_hello ... ok
@@ -198,7 +198,7 @@ fn cargo_test_failing_test() {
                 execs().with_stderr(format!("\
 [COMPILING] foo v0.5.0 ({url})
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target[..]foo-[..][EXE]
+[RUNNING] target[/]debug[/]foo-[..][EXE]
 [ERROR] test failed", url = p.url()))
                        .with_stdout_contains("
 running 1 test
@@ -209,7 +209,7 @@ failures:
 ---- test_hello stdout ----
 <tab>thread 'test_hello' panicked at 'assertion failed: \
     `(left == right)` (left: \
-    `\"hello\"`, right: `\"nope\"`)', src[..]foo.rs:12
+    `\"hello\"`, right: `\"nope\"`)', src[/]foo.rs:12
 ")
                        .with_stdout_contains("\
 failures:
@@ -258,8 +258,8 @@ fn test_with_lib_dep() {
                 execs().with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({})
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target[..]baz-[..][EXE]
-[RUNNING] target[..]foo-[..][EXE]
+[RUNNING] target[/]debug[/]baz-[..][EXE]
+[RUNNING] target[/]debug[/]deps[/]foo-[..][EXE]
 [DOCTEST] foo", p.url()))
                        .with_stdout("
 running 1 test
@@ -374,8 +374,8 @@ fn external_test_explicit() {
                 execs().with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({})
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target[..]foo-[..][EXE]
-[RUNNING] target[..]test-[..][EXE]
+[RUNNING] target[/]debug[/]deps[/]foo-[..][EXE]
+[RUNNING] target[/]debug[/]test-[..][EXE]
 [DOCTEST] foo", p.url()))
                        .with_stdout("
 running 1 test
@@ -423,8 +423,8 @@ fn external_test_implicit() {
                 execs().with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({})
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target[..]external-[..][EXE]
-[RUNNING] target[..]foo-[..][EXE]
+[RUNNING] target[/]debug[/]external-[..][EXE]
+[RUNNING] target[/]debug[/]deps[/]foo-[..][EXE]
 [DOCTEST] foo", p.url()))
                        .with_stdout("
 running 1 test
@@ -483,7 +483,7 @@ fn pass_through_command_line() {
                        .with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({dir})
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target[..]foo-[..][EXE]
+[RUNNING] target[/]debug[/]deps[/]foo-[..][EXE]
 [DOCTEST] foo", dir = p.url()))
                        .with_stdout("
 running 1 test
@@ -502,7 +502,7 @@ test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
                 execs().with_status(0)
                        .with_stderr("\
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target[..]foo-[..][EXE]
+[RUNNING] target[/]debug[/]deps[/]foo-[..][EXE]
 [DOCTEST] foo")
                        .with_stdout("
 running 1 test
@@ -567,8 +567,8 @@ fn lib_bin_same_name() {
                 execs().with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({})
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target[..]foo-[..][EXE]
-[RUNNING] target[..]foo-[..][EXE]
+[RUNNING] target[/]debug[/]deps[/]foo-[..][EXE]
+[RUNNING] target[/]debug[/]foo-[..][EXE]
 [DOCTEST] foo", p.url()))
                        .with_stdout("
 running 1 test
@@ -620,8 +620,8 @@ fn lib_with_standard_name() {
                        .with_stderr(&format!("\
 [COMPILING] syntax v0.0.1 ({dir})
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target[..]syntax-[..][EXE]
-[RUNNING] target[..]test-[..][EXE]
+[RUNNING] target[/]debug[/]deps[/]syntax-[..][EXE]
+[RUNNING] target[/]debug[/]test-[..][EXE]
 [DOCTEST] syntax", dir = p.url()))
                        .with_stdout("
 running 1 test
@@ -675,7 +675,7 @@ fn lib_with_standard_name2() {
                        .with_stderr(&format!("\
 [COMPILING] syntax v0.0.1 ({dir})
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target[..]syntax-[..][EXE]", dir = p.url()))
+[RUNNING] target[/]debug[/]syntax-[..][EXE]", dir = p.url()))
                        .with_stdout("
 running 1 test
 test test ... ok
@@ -715,7 +715,7 @@ fn lib_without_name() {
                        .with_stderr(&format!("\
 [COMPILING] syntax v0.0.1 ({dir})
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target[..]syntax-[..][EXE]", dir = p.url()))
+[RUNNING] target[/]debug[/]syntax-[..][EXE]", dir = p.url()))
                        .with_stdout("
 running 1 test
 test test ... ok
@@ -973,8 +973,8 @@ fn test_dylib() {
 [COMPILING] bar v0.0.1 ({dir}/bar)
 [COMPILING] foo v0.0.1 ({dir})
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target[..]foo-[..][EXE]
-[RUNNING] target[..]test-[..][EXE]", dir = p.url()))
+[RUNNING] target[/]debug[/]deps[/]foo-[..][EXE]
+[RUNNING] target[/]debug[/]test-[..][EXE]", dir = p.url()))
                        .with_stdout("
 running 1 test
 test foo ... ok
@@ -993,8 +993,8 @@ test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
                 execs().with_status(0)
                        .with_stderr("\
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target[..]foo-[..][EXE]
-[RUNNING] target[..]test-[..][EXE]")
+[RUNNING] target[/]debug[/]deps[/]foo-[..][EXE]
+[RUNNING] target[/]debug[/]test-[..][EXE]")
                        .with_stdout("
 running 1 test
 test foo ... ok
@@ -1032,7 +1032,7 @@ fn test_twice_with_build_cmd() {
                        .with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({dir})
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target[..]foo-[..][EXE]
+[RUNNING] target[/]debug[/]deps[/]foo-[..][EXE]
 [DOCTEST] foo", dir = p.url()))
                        .with_stdout("
 running 1 test
@@ -1051,7 +1051,7 @@ test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
                 execs().with_status(0)
                        .with_stderr("\
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target[..]foo-[..][EXE]
+[RUNNING] target[/]debug[/]deps[/]foo-[..][EXE]
 [DOCTEST] foo")
                        .with_stdout("
 running 1 test
@@ -1086,7 +1086,7 @@ fn test_then_build() {
                        .with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({dir})
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target[..]foo-[..][EXE]
+[RUNNING] target[/]debug[/]deps[/]foo-[..][EXE]
 [DOCTEST] foo", dir = p.url()))
                        .with_stdout("
 running 1 test
@@ -1154,7 +1154,7 @@ fn test_run_specific_bin_target() {
                        .with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({dir})
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target[..]bin2-[..][EXE]", dir = prj.url()))
+[RUNNING] target[/]debug[/]bin2-[..][EXE]", dir = prj.url()))
                        .with_stdout("
 running 1 test
 test test2 ... ok
@@ -1183,7 +1183,7 @@ fn test_run_specific_test_target() {
                        .with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({dir})
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target[..]b-[..][EXE]", dir = prj.url()))
+[RUNNING] target[/]debug[/]b-[..][EXE]", dir = prj.url()))
                        .with_stdout("
 running 1 test
 test test_b ... ok
@@ -1219,7 +1219,7 @@ fn test_no_harness() {
                        .with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({dir})
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target[..]bar-[..][EXE]
+[RUNNING] target[/]debug[/]bar-[..][EXE]
 ",
                        dir = p.url())));
 }
@@ -1275,8 +1275,8 @@ fn selective_testing() {
                        .with_stderr(&format!("\
 [COMPILING] d1 v0.0.1 ({dir}/d1)
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target[..]d1-[..][EXE]
-[RUNNING] target[..]d1-[..][EXE]", dir = p.url()))
+[RUNNING] target[/]debug[/]deps[/]d1-[..][EXE]
+[RUNNING] target[/]debug[/]deps[/]d1-[..][EXE]", dir = p.url()))
                        .with_stdout("
 running 0 tests
 
@@ -1295,8 +1295,8 @@ test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
                        .with_stderr(&format!("\
 [COMPILING] d2 v0.0.1 ({dir}/d2)
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target[..]d2-[..][EXE]
-[RUNNING] target[..]d2-[..][EXE]", dir = p.url()))
+[RUNNING] target[/]debug[/]deps[/]d2-[..][EXE]
+[RUNNING] target[/]debug[/]deps[/]d2-[..][EXE]", dir = p.url()))
                        .with_stdout("
 running 0 tests
 
@@ -1315,7 +1315,7 @@ test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
                        .with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({dir})
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target[..]foo-[..][EXE]", dir = p.url()))
+[RUNNING] target[/]debug[/]deps[/]foo-[..][EXE]", dir = p.url()))
                        .with_stdout("
 running 0 tests
 
@@ -1477,7 +1477,7 @@ fn selective_testing_with_docs() {
                        .with_stderr(&format!("\
 [COMPILING] d1 v0.0.1 ({dir}/d1)
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target[..]deps[..]d1[..][EXE]
+[RUNNING] target[/]debug[/]deps[/]d1[..][EXE]
 [DOCTEST] d1", dir = p.url()))
                        .with_stdout("
 running 0 tests
@@ -1659,7 +1659,7 @@ fn doctest_feature() {
                        .with_stderr("\
 [COMPILING] foo [..]
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target[..]foo[..][EXE]
+[RUNNING] target[/]debug[/]deps[/]foo[..][EXE]
 [DOCTEST] foo")
                        .with_stdout("
 running 0 tests
@@ -1746,7 +1746,7 @@ fn filter_no_doc_tests() {
                 execs().with_stderr("\
 [COMPILING] foo v0.0.1 ([..])
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target[..]debug[..]foo[..][EXE]")
+[RUNNING] target[/]debug[/]foo[..][EXE]")
                        .with_stdout("
 running 0 tests
 
@@ -1850,7 +1850,7 @@ fn cyclic_dev_dep_doc_test() {
 [COMPILING] foo v0.0.1 ([..])
 [COMPILING] bar v0.0.1 ([..])
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target[..]foo[..][EXE]
+[RUNNING] target[/]debug[/]deps[/]foo[..][EXE]
 [DOCTEST] foo")
                        .with_stdout("
 running 0 tests
@@ -1943,8 +1943,8 @@ fn no_fail_fast() {
                        .with_stderr_contains("\
 [COMPILING] foo v0.0.1 ([..])
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target[..]foo-[..][EXE]
-[RUNNING] target[..]test_add_one-[..][EXE]")
+[RUNNING] target[/]debug[/]deps[/]foo-[..][EXE]
+[RUNNING] target[/]debug[/]test_add_one-[..][EXE]")
                        .with_stdout_contains("
 running 0 tests
 
@@ -1952,7 +1952,7 @@ test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
 
 ")
                        .with_stderr_contains("\
-[RUNNING] target[..]test_sub_one-[..][EXE]
+[RUNNING] target[/]debug[/]test_sub_one-[..][EXE]
 [DOCTEST] foo")
                        .with_stdout_contains("\
 test result: FAILED. 1 passed; 1 failed; 0 ignored; 0 measured
@@ -2018,14 +2018,14 @@ fn test_multiple_packages() {
     assert_that(p.cargo("test").arg("-p").arg("d1").arg("-p").arg("d2"),
                 execs().with_status(0)
                        .with_stderr_contains("\
-[RUNNING] target[..]debug[..]d1-[..][EXE]")
+[RUNNING] target[/]debug[/]deps[/]d1-[..][EXE]")
                        .with_stdout_contains("
 running 0 tests
 
 test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
 ")
                        .with_stderr_contains("\
-[RUNNING] target[..]debug[..]d2-[..][EXE]")
+[RUNNING] target[/]debug[/]deps[/]d2-[..][EXE]")
                        .with_stdout_contains("
 running 0 tests
 
@@ -2058,8 +2058,8 @@ fn bin_does_not_rebuild_tests() {
                 execs().with_status(0)
                        .with_stderr("\
 [COMPILING] foo v0.0.1 ([..])
-[RUNNING] `rustc src[..]main.rs [..]`
-[RUNNING] `rustc src[..]main.rs [..]`
+[RUNNING] `rustc src[/]main.rs [..]`
+[RUNNING] `rustc src[/]main.rs [..]`
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 "));
 }
@@ -2120,8 +2120,8 @@ fn selective_test_optional_dep() {
                  .arg("--features").arg("a").arg("-p").arg("a"),
                 execs().with_status(0).with_stderr("\
 [COMPILING] a v0.0.1 ([..])
-[RUNNING] `rustc a[..]src[..]lib.rs [..]`
-[RUNNING] `rustc a[..]src[..]lib.rs [..]`
+[RUNNING] `rustc a[/]src[/]lib.rs [..]`
+[RUNNING] `rustc a[/]src[/]lib.rs [..]`
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 "));
 }


### PR DESCRIPTION
Converts to backslash on windows. Currently, we're using [..],
so this will tighten up the tests.