### PR TITLE
Reduce flakiness of tests/concurrent on windows

### DIFF
--- a/tests/concurrent.rs
+++ b/tests/concurrent.rs
@@ -383,16 +383,15 @@ fn killing_cargo_releases_the_lock() {
     let mut a = a.spawn().unwrap();
     l.accept().unwrap();
     a.kill().unwrap();
+    let a = a.wait().unwrap();
 
     // Spawn `b`, then just finish the output of a/b the same way the above
     // tests does.
     let b = b.spawn().unwrap();
-    let a = thread::spawn(move || a.wait_with_output().unwrap());
     let b = b.wait_with_output().unwrap();
-    let a = a.join().unwrap();
 
     // We killed `a`, so it shouldn't succeed, but `b` should have succeeded.
-    assert!(!a.status.success());
+    assert!(!a.success());
     assert_that(b, execs().with_status(0));
 }
 


### PR DESCRIPTION
I believe that resources are not reclaimed until the process has
terminated, so trying to run the processes concurrently will likely
lead to failures on windows. Terminating a before starting b should
improve this.