### PR TITLE
Upload categories specified in the manifest

### DIFF
--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -47,6 +47,7 @@ pub struct VirtualManifest {
 pub struct ManifestMetadata {
     pub authors: Vec<String>,
     pub keywords: Vec<String>,
+    pub categories: Vec<String>,
     pub license: Option<String>,
     pub license_file: Option<String>,
     pub description: Option<String>,    // not markdown

--- a/src/cargo/ops/registry.rs
+++ b/src/cargo/ops/registry.rs
@@ -151,13 +151,13 @@ fn transmit(config: &Config,
     }, tarball);
 
     match publish {
-        Ok(invalid_categories) => {
-            if !invalid_categories.is_empty() {
+        Ok(warnings) => {
+            if !warnings.invalid_categories.is_empty() {
                 let msg = format!("\
                     the following are not valid category slugs and were \
                     ignored: {}. Please see https://crates.io/category_slugs \
                     for the list of all category slugs. \
-                    ", invalid_categories.join(", "));
+                    ", warnings.invalid_categories.join(", "));
                 config.shell().warn(&msg)?;
             }
             Ok(())

--- a/src/cargo/ops/registry.rs
+++ b/src/cargo/ops/registry.rs
@@ -112,6 +112,7 @@ fn transmit(config: &Config,
     let ManifestMetadata {
         ref authors, ref description, ref homepage, ref documentation,
         ref keywords, ref readme, ref repository, ref license, ref license_file,
+        ref categories,
     } = *manifest.metadata();
     let readme = match *readme {
         Some(ref readme) => Some(paths::read(&pkg.root().join(readme))?),
@@ -142,6 +143,7 @@ fn transmit(config: &Config,
         homepage: homepage.clone(),
         documentation: documentation.clone(),
         keywords: keywords.clone(),
+        categories: categories.clone(),
         readme: readme,
         repository: repository.clone(),
         license: license.clone(),

--- a/src/cargo/util/toml.rs
+++ b/src/cargo/util/toml.rs
@@ -304,6 +304,7 @@ pub struct TomlProject {
     documentation: Option<String>,
     readme: Option<String>,
     keywords: Option<Vec<String>>,
+    categories: Option<Vec<String>>,
     license: Option<String>,
     license_file: Option<String>,
     repository: Option<String>,
@@ -640,6 +641,7 @@ impl TomlManifest {
             license_file: project.license_file.clone(),
             repository: project.repository.clone(),
             keywords: project.keywords.clone().unwrap_or(Vec::new()),
+            categories: project.categories.clone().unwrap_or(Vec::new()),
         };
 
         let workspace_config = match (self.workspace.as_ref(),

--- a/src/crates-io/lib.rs
+++ b/src/crates-io/lib.rs
@@ -78,6 +78,7 @@ pub struct NewCrate {
     pub homepage: Option<String>,
     pub readme: Option<String>,
     pub keywords: Vec<String>,
+    pub categories: Vec<String>,
     pub license: Option<String>,
     pub license_file: Option<String>,
     pub repository: Option<String>,

--- a/src/crates-io/lib.rs
+++ b/src/crates-io/lib.rs
@@ -202,7 +202,11 @@ impl Registry {
             body.read(buf).unwrap_or(0)
         })?;
         // Can't derive RustcDecodable because JSON has a key named "crate" :(
-        let response = Json::from_str(&body)?;
+        let response = if body.len() > 0 {
+            Json::from_str(&body)?
+        } else {
+            Json::from_str("{}")?
+        };
         let invalid_categories: Vec<String> =
             response
                 .find_path(&["warnings", "invalid_categories"])

--- a/src/crates-io/lib.rs
+++ b/src/crates-io/lib.rs
@@ -111,6 +111,10 @@ pub struct User {
     pub name: Option<String>,
 }
 
+pub struct Warnings {
+    pub invalid_categories: Vec<String>,
+}
+
 #[derive(RustcDecodable)] struct R { ok: bool }
 #[derive(RustcDecodable)] struct ApiErrorList { errors: Vec<ApiError> }
 #[derive(RustcDecodable)] struct ApiError { detail: String }
@@ -155,7 +159,7 @@ impl Registry {
     }
 
     pub fn publish(&mut self, krate: &NewCrate, tarball: &File)
-                   -> Result<Vec<String>> {
+                   -> Result<Warnings> {
         let json = json::encode(krate)?;
         // Prepare the body. The format of the upload request is:
         //
@@ -215,7 +219,7 @@ impl Registry {
                     x.iter().flat_map(Json::as_string).map(Into::into).collect()
                 })
                 .unwrap_or_else(Vec::new);
-        Ok(invalid_categories)
+        Ok(Warnings { invalid_categories: invalid_categories })
     }
 
     pub fn search(&mut self, query: &str, limit: u8) -> Result<(Vec<Crate>, u32)> {

--- a/src/doc/manifest.md
+++ b/src/doc/manifest.md
@@ -118,9 +118,15 @@ repository = "..."
 # contents of this file are stored and indexed in the registry.
 readme = "..."
 
-# This is a small list of keywords used to categorize and search for this
-# package.
+# This is a list of up to five keywords that describe this crate. Keywords
+# are searchable on crates.io, and you may choose any words that would
+# help someone find this crate.
 keywords = ["...", "..."]
+
+# This is a list of up to five categories where this crate would fit.
+# Categories are a fixed list available at crates.io/categories, and
+# they must match exactly.
+categories = ["...", "..."]
 
 # This is a string description of the license for this package. Currently
 # crates.io will validate the license provided against a whitelist of known


### PR DESCRIPTION
This adds support for uploading categories to crates.io, if they are specified in the manifest.

This goes with rust-lang/crates.io#473. It should be fine to merge this PR either before or after that one; crates.io master doesn't care if the categories are in the metadata or not. With that PR, I was able to use this patch with cargo to add categories to a crate!