### PR TITLE
Emit more info on --message-format=json

### DIFF
--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -123,7 +123,7 @@ impl Encodable for TargetKind {
     }
 }
 
-#[derive(RustcEncodable, RustcDecodable, Clone, PartialEq, Eq, Debug, Hash)]
+#[derive(Clone, PartialEq, Eq, Debug, Hash)]
 pub struct Profile {
     pub opt_level: String,
     pub lto: bool,
@@ -137,6 +137,25 @@ pub struct Profile {
     pub doc: bool,
     pub run_custom_build: bool,
     pub panic: Option<String>,
+}
+
+#[derive(RustcEncodable)]
+struct SerializedProfile<'a> {
+    opt_level: &'a str,
+    debuginfo: bool,
+    debug_assertions: bool,
+    test: bool,
+}
+
+impl Encodable for Profile {
+    fn encode<S: Encoder>(&self, s: &mut S) -> Result<(), S::Error> {
+        SerializedProfile {
+            opt_level: &self.opt_level,
+            debuginfo: self.debuginfo,
+            debug_assertions: self.debug_assertions,
+            test: self.test,
+        }.encode(s)
+    }
 }
 
 #[derive(Default, Clone, Debug, PartialEq, Eq)]

--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -251,7 +251,7 @@ pub fn compile_ws<'a>(ws: &Workspace<'a>,
         let mut build_config = scrape_build_config(config, jobs, target)?;
         build_config.release = release;
         build_config.test = mode == CompileMode::Test || mode == CompileMode::Bench;
-        build_config.json_errors = message_format == MessageFormat::Json;
+        build_config.json_messages = message_format == MessageFormat::Json;
         if let CompileMode::Doc { deps } = mode {
             build_config.doc_all = deps;
         }
@@ -512,7 +512,7 @@ fn scrape_target_config(config: &Config, triple: &str)
                     let (flags, definition) = value.string(&k)?;
                     let whence = format!("in `{}` (in {})", key,
                                          definition.display());
-                    let (paths, links) = 
+                    let (paths, links) =
                         BuildOutput::parse_rustc_flags(&flags, &whence)
                     ?;
                     output.library_paths.extend(paths);

--- a/src/cargo/util/machine_message.rs
+++ b/src/cargo/util/machine_message.rs
@@ -1,30 +1,60 @@
-use rustc_serialize::json;
-use core::{PackageId, Target};
+use rustc_serialize::Encodable;
+use rustc_serialize::json::{self, Json};
+
+use core::{PackageId, Target, Profile};
+
+pub trait Message: Encodable {
+    fn reason(&self) -> &str;
+}
+
+pub fn emit<T: Message>(t: T) {
+    let json = json::encode(&t).unwrap();
+    let mut map = match json.parse().unwrap() {
+        Json::Object(obj) => obj,
+        _ => panic!("not a json object"),
+    };
+    map.insert("reason".to_string(), Json::String(t.reason().to_string()));
+    println!("{}", Json::Object(map));
+}
 
 #[derive(RustcEncodable)]
 pub struct FromCompiler<'a> {
-    reason: &'static str,
-    package_id: &'a PackageId,
-    target: &'a Target,
-    message: json::Json,
+    pub package_id: &'a PackageId,
+    pub target: &'a Target,
+    pub message: json::Json,
 }
 
-impl<'a> FromCompiler<'a> {
-    pub fn new(package_id: &'a PackageId,
-               target: &'a Target,
-               message: json::Json)
-               -> FromCompiler<'a> {
-        FromCompiler {
-            reason: "compiler-message",
-            package_id: package_id,
-            target: target,
-            message: message,
-        }
-    }
-
-    pub fn emit(self) {
-        let json = json::encode(&self).unwrap();
-        println!("{}", json);
+impl<'a> Message for FromCompiler<'a> {
+    fn reason(&self) -> &str {
+        "compiler-message"
     }
 }
 
+#[derive(RustcEncodable)]
+pub struct Artifact<'a> {
+    pub package_id: &'a PackageId,
+    pub target: &'a Target,
+    pub profile: &'a Profile,
+    pub features: Vec<String>,
+    pub filenames: Vec<String>,
+}
+
+impl<'a> Message for Artifact<'a> {
+    fn reason(&self) -> &str {
+        "compiler-artifact"
+    }
+}
+
+#[derive(RustcEncodable)]
+pub struct BuildScript<'a> {
+    pub package_id: &'a PackageId,
+    pub linked_libs: &'a [String],
+    pub linked_paths: &'a [String],
+    pub cfgs: &'a [String],
+}
+
+impl<'a> Message for BuildScript<'a> {
+    fn reason(&self) -> &str {
+        "build-script-executed"
+    }
+}

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -2412,6 +2412,20 @@ fn compiler_json_error_format() {
     }
 
     {
+        "reason":"compiler-artifact",
+        "profile": {
+            "debug_assertions": true,
+            "debuginfo": true,
+            "opt_level": "0",
+            "test": false
+        },
+        "features": [],
+        "package_id":"bar 0.5.0 ([..])",
+        "target":{"kind":["lib"],"name":"bar","src_path":"[..]lib.rs"},
+        "filenames":["[..].rlib"]
+    }
+
+    {
         "reason":"compiler-message",
         "package_id":"foo 0.5.0 ([..])",
         "target":{"kind":["bin"],"name":"foo","src_path":"[..]main.rs"},
@@ -2425,6 +2439,20 @@ fn compiler_json_error_format() {
                 "text":[{"highlight_end":23,"highlight_start":17,"text":"[..]"}]
             }]
         }
+    }
+
+    {
+        "reason":"compiler-artifact",
+        "package_id":"foo 0.5.0 ([..])",
+        "target":{"kind":["bin"],"name":"foo","src_path":"[..]main.rs"},
+        "profile": {
+            "debug_assertions": true,
+            "debuginfo": true,
+            "opt_level": "0",
+            "test": false
+        },
+        "features": [],
+        "filenames": ["[..]"]
     }
 "#));
 }


### PR DESCRIPTION
This adds more output on Cargo's behalf to the output of
`--message-format=json`. Cargo will now emit a message when a crate is finished
compiling with a list of all files that were just generated along with a message
when a build script finishes executing with linked libraries and linked library
paths.

Closes #3212