### PR TITLE
Add host dependency path via -L for cross compiles

### DIFF
--- a/src/cargo/ops/cargo_rustc/context.rs
+++ b/src/cargo/ops/cargo_rustc/context.rs
@@ -314,6 +314,10 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
         self.layout(unit.kind).build().join(dir).join("out")
     }
 
+    pub fn host_deps(&self) -> &Path {
+        self.host.deps()
+    }
+
     /// Returns the appropriate output directory for the specified package and
     /// target.
     pub fn out_dir(&mut self, unit: &Unit) -> PathBuf {

--- a/src/cargo/ops/cargo_rustc/mod.rs
+++ b/src/cargo/ops/cargo_rustc/mod.rs
@@ -648,6 +648,16 @@ fn build_deps_args(cmd: &mut ProcessBuilder, cx: &mut Context, unit: &Unit)
         deps
     });
 
+    // Be sure that the host path is also listed. This'll ensure that proc-macro
+    // dependencies are correctly found (for reexported macros).
+    if let Kind::Target = unit.kind {
+        cmd.arg("-L").arg(&{
+            let mut deps = OsString::from("dependency=");
+            deps.push(cx.host_deps());
+            deps
+        });
+    }
+
     for unit in cx.dep_targets(unit)?.iter() {
         if unit.profile.run_custom_build {
             cmd.env("OUT_DIR", &cx.build_script_out_dir(unit));

--- a/tests/cross-compile.rs
+++ b/tests/cross-compile.rs
@@ -363,7 +363,8 @@ fn linker_and_ar() {
     --emit=dep-info,link \
     --target {target} \
     -C ar=my-ar-tool -C linker=my-linker-tool \
-    -L dependency={dir}[/]target[/]{target}[/]debug[/]deps`
+    -L dependency={dir}[/]target[/]{target}[/]debug[/]deps \
+    -L dependency={dir}[/]target[/]debug[/]deps`
 ",
                             dir = p.root().display(),
                             url = p.url(),


### PR DESCRIPTION
Now that proc-macro crates can reexport from their dependencies we need to be
able to find the other crates, so ensure that we pass an appropriate -L flag.

Closes #3334