### PR TITLE
Test for bad path overrides with summaries

### DIFF
--- a/src/cargo/core/dependency.rs
+++ b/src/cargo/core/dependency.rs
@@ -11,7 +11,7 @@ use util::{CargoError, CargoResult, Cfg, CfgExpr, ChainError, human, Config};
 
 /// Information about a dependency requested by a Cargo manifest.
 /// Cheap to copy.
-#[derive(PartialEq, Clone ,Debug)]
+#[derive(PartialEq, Clone, Debug)]
 pub struct Dependency {
     inner: Rc<DependencyInner>,
 }


### PR DESCRIPTION
Bad path overrides are currently detected to issue warnings in cases where path
overrides are not suitable and have exhibited buggy behavior in the past.
Unfortunately though it looks like some false positives are being issued,
causing unnecessary confusion about `paths` overrides.

This commit fixes the detection of these "bad path overrides" by comparing
`Summary` dependencies (what's written down in `Cargo.toml`) rather than
comparing the `Cargo.toml` of the override with `Cargo.lock`. We're guaranteed
that the package we're overridding has already been resolved into `Cargo.lock`,
so we know that if the two `Cargo.toml` files are equivalent we'll continue
with the same crate graph.

I'm not actually entirely sure why I originally thought it'd be better to go
through the `Cargo.lock` comparison route. Unfortunately that doesn't take into
account optional deps which aren't in `Cargo.lock` but are in `Cargo.toml` of
the override, causing the false positive. This method, however, simply ensures
that the two dependency lists are the same.

Closes #3313