### PR TITLE
Use short IDs in git dependencies checkout path

### DIFF
--- a/src/cargo/sources/git/source.rs
+++ b/src/cargo/sources/git/source.rs
@@ -149,8 +149,13 @@ impl<'cfg> Source for GitSource<'cfg> {
             (self.remote.db_at(&db_path)?, actual_rev.unwrap())
         };
 
+        // Don’t use the full hash,
+        // to contribute less to reaching the path length limit on Windows:
+        // https://github.com/servo/servo/pull/14397
+        let short_id = repo.to_short_id(actual_rev.clone()).unwrap();
+
         let checkout_path = lock.parent().join("checkouts")
-            .join(&self.ident).join(actual_rev.to_string());
+            .join(&self.ident).join(short_id.as_str());
 
         // Copy the database to the checkout location. After this we could drop
         // the lock on the database as we no longer needed it, but we leave it

--- a/src/cargo/sources/git/utils.rs
+++ b/src/cargo/sources/git/utils.rs
@@ -19,6 +19,14 @@ impl fmt::Display for GitRevision {
     }
 }
 
+pub struct GitShortID(git2::Buf);
+
+impl GitShortID {
+    pub fn as_str(&self) -> &str {
+        self.0.as_str().unwrap()
+    }
+}
+
 /// GitRemote represents a remote repository. It gets cloned into a local
 /// GitDatabase.
 #[derive(PartialEq,Clone,Debug)]
@@ -213,6 +221,11 @@ impl GitDatabase {
             }
         };
         Ok(GitRevision(id))
+    }
+
+    pub fn to_short_id(&self, revision: GitRevision) -> CargoResult<GitShortID> {
+        let obj = self.repo.find_object(revision.0, None)?;
+        Ok(GitShortID(obj.short_id()?))
     }
 
     pub fn has_ref(&self, reference: &str) -> CargoResult<()> {


### PR DESCRIPTION
… in order to contribute less to the path length limit on Windows: https://github.com/servo/servo/pull/14397