### PR TITLE
Reordered rustc arguments.

### DIFF
--- a/src/cargo/ops/cargo_rustc/mod.rs
+++ b/src/cargo/ops/cargo_rustc/mod.rs
@@ -434,9 +434,9 @@ fn prepare_rustc(cx: &Context,
 
 fn rustdoc(cx: &mut Context, unit: &Unit) -> CargoResult<Work> {
     let mut rustdoc = cx.compilation.rustdoc_process(unit.pkg)?;
-    rustdoc.arg(&root_path(cx, unit))
+    rustdoc.arg("--crate-name").arg(&unit.target.crate_name())
            .cwd(cx.config.cwd())
-           .arg("--crate-name").arg(&unit.target.crate_name());
+           .arg(&root_path(cx, unit));
 
     if unit.kind != Kind::Host {
         if let Some(target) = cx.requested_target() {
@@ -523,6 +523,8 @@ fn build_base_args(cx: &Context,
     // Move to cwd so the root_path() passed below is actually correct
     cmd.cwd(cx.config.cwd());
 
+    cmd.arg("--crate-name").arg(&unit.target.crate_name());
+
     cmd.arg(&root_path(cx, unit));
 
     let color_config = cx.config.shell().color_config();
@@ -533,8 +535,6 @@ fn build_base_args(cx: &Context,
     if cx.build_config.json_errors {
         cmd.arg("--error-format").arg("json");
     }
-
-    cmd.arg("--crate-name").arg(&unit.target.crate_name());
 
     if !test {
         for crate_type in crate_types.iter() {

--- a/tests/bench.rs
+++ b/tests/bench.rs
@@ -105,7 +105,7 @@ fn cargo_bench_verbose() {
     assert_that(p.cargo_process("bench").arg("-v").arg("hello"),
                 execs().with_stderr(&format!("\
 [COMPILING] foo v0.5.0 ({url})
-[RUNNING] `rustc src[/]foo.rs [..]`
+[RUNNING] `rustc [..] src[/]foo.rs [..]`
 [FINISHED] release [optimized] target(s) in [..]
 [RUNNING] `[..]target[/]release[/]deps[/]foo-[..][EXE] hello --bench`", url = p.url()))
                        .with_stdout("

--- a/tests/build-lib.rs
+++ b/tests/build-lib.rs
@@ -7,7 +7,7 @@ use hamcrest::{assert_that};
 fn verbose_output_for_lib(p: &ProjectBuilder) -> String {
     format!("\
 [COMPILING] {name} v{version} ({url})
-[RUNNING] `rustc src[/]lib.rs --crate-name {name} --crate-type lib -g \
+[RUNNING] `rustc --crate-name {name} src[/]lib.rs --crate-type lib -g \
         -C metadata=[..] \
         --out-dir [..] \
         --emit=dep-info,link \

--- a/tests/build-script.rs
+++ b/tests/build-script.rs
@@ -33,7 +33,7 @@ fn custom_build_script_failed() {
                 execs().with_status(101)
                        .with_stderr(&format!("\
 [COMPILING] foo v0.5.0 ({url})
-[RUNNING] `rustc build.rs --crate-name build_script_build --crate-type bin [..]`
+[RUNNING] `rustc --crate-name build_script_build build.rs --crate-type bin [..]`
 [RUNNING] `[..][/]build-script-build`
 [ERROR] failed to run custom build command for `foo v0.5.0 ({url})`
 process didn't exit successfully: `[..][/]build-script-build` (exit code: 101)",
@@ -184,7 +184,7 @@ fn custom_build_script_rustc_flags() {
                 execs().with_status(101)
                        .with_stderr(&format!("\
 [COMPILING] bar v0.5.0 ({url})
-[RUNNING] `rustc {dir}{sep}src{sep}lib.rs --crate-name test --crate-type lib -g \
+[RUNNING] `rustc --crate-name test {dir}{sep}src{sep}lib.rs --crate-type lib -g \
         -C metadata=[..] \
         -C extra-filename=-[..] \
         --out-dir {dir}{sep}target \
@@ -306,7 +306,7 @@ fn overrides_and_links() {
 [..]
 [..]
 [..]
-[RUNNING] `rustc [..] --crate-name foo [..] -L foo -L bar[..]`
+[RUNNING] `rustc --crate-name foo [..] -L foo -L bar[..]`
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 "));
 }
@@ -408,7 +408,7 @@ fn only_rerun_build_script() {
                        .with_stderr("\
 [COMPILING] foo v0.5.0 (file://[..])
 [RUNNING] `[..][/]build-script-build`
-[RUNNING] `rustc [..] --crate-name foo [..]`
+[RUNNING] `rustc --crate-name foo [..]`
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 "));
 }
@@ -496,8 +496,8 @@ fn testing_and_such() {
                        .with_stderr("\
 [COMPILING] foo v0.5.0 (file://[..])
 [RUNNING] `[..][/]build-script-build`
-[RUNNING] `rustc [..] --crate-name foo [..]`
-[RUNNING] `rustc [..] --crate-name foo [..]`
+[RUNNING] `rustc --crate-name foo [..]`
+[RUNNING] `rustc --crate-name foo [..]`
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `[..][/]foo-[..][EXE]`
 [DOCTEST] foo
@@ -582,9 +582,9 @@ fn propagation_of_l_flags() {
     assert_that(p.cargo_process("build").arg("-v").arg("-j1"),
                 execs().with_status(0)
                        .with_stderr_contains("\
-[RUNNING] `rustc [..] --crate-name a [..]-L bar[..]-L foo[..]`
+[RUNNING] `rustc --crate-name a [..] -L bar[..]-L foo[..]`
 [COMPILING] foo v0.5.0 (file://[..])
-[RUNNING] `rustc [..] --crate-name foo [..] -L bar -L foo`
+[RUNNING] `rustc --crate-name foo [..] -L bar -L foo`
 "));
 }
 
@@ -636,9 +636,9 @@ fn propagation_of_l_flags_new() {
     assert_that(p.cargo_process("build").arg("-v").arg("-j1"),
                 execs().with_status(0)
                        .with_stderr_contains("\
-[RUNNING] `rustc [..] --crate-name a [..]-L bar[..]-L foo[..]`
+[RUNNING] `rustc --crate-name a [..] -L bar[..]-L foo[..]`
 [COMPILING] foo v0.5.0 (file://[..])
-[RUNNING] `rustc [..] --crate-name foo [..] -L bar -L foo`
+[RUNNING] `rustc --crate-name foo [..] -L bar -L foo`
 "));
 }
 
@@ -671,11 +671,11 @@ fn build_deps_simple() {
                 execs().with_status(0)
                        .with_stderr("\
 [COMPILING] a v0.5.0 (file://[..])
-[RUNNING] `rustc [..] --crate-name a [..]`
+[RUNNING] `rustc --crate-name a [..]`
 [COMPILING] foo v0.5.0 (file://[..])
-[RUNNING] `rustc build.rs [..] --extern a=[..]`
+[RUNNING] `rustc [..] build.rs [..] --extern a=[..]`
 [RUNNING] `[..][/]foo-[..][/]build-script-build`
-[RUNNING] `rustc [..] --crate-name foo [..]`
+[RUNNING] `rustc --crate-name foo [..]`
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 "));
 }
@@ -761,21 +761,21 @@ fn build_cmd_with_a_build_cmd() {
                 execs().with_status(0)
                        .with_stderr("\
 [COMPILING] b v0.5.0 (file://[..])
-[RUNNING] `rustc [..] --crate-name b [..]`
+[RUNNING] `rustc --crate-name b [..]`
 [COMPILING] a v0.5.0 (file://[..])
-[RUNNING] `rustc a[/]build.rs [..] --extern b=[..]`
+[RUNNING] `rustc [..] a[/]build.rs [..] --extern b=[..]`
 [RUNNING] `[..][/]a-[..][/]build-script-build`
-[RUNNING] `rustc [..]lib.rs --crate-name a --crate-type lib -g \
+[RUNNING] `rustc --crate-name a [..]lib.rs --crate-type lib -g \
     -C metadata=[..] \
     --out-dir [..]target[/]debug[/]deps --emit=dep-info,link \
     -L [..]target[/]debug[/]deps`
 [COMPILING] foo v0.5.0 (file://[..])
-[RUNNING] `rustc build.rs --crate-name build_script_build --crate-type bin \
+[RUNNING] `rustc --crate-name build_script_build build.rs --crate-type bin \
     -g -C metadata=[..] --out-dir [..] --emit=dep-info,link \
     -L [..]target[/]debug[/]deps \
     --extern a=[..]liba[..].rlib`
 [RUNNING] `[..][/]foo-[..][/]build-script-build`
-[RUNNING] `rustc [..]lib.rs --crate-name foo --crate-type lib -g \
+[RUNNING] `rustc --crate-name foo [..]lib.rs --crate-type lib -g \
     -C metadata=[..] \
     --out-dir [..] --emit=dep-info,link \
     -L [..]target[/]debug[/]deps`
@@ -853,9 +853,9 @@ fn output_separate_lines() {
                 execs().with_status(101)
                        .with_stderr_contains("\
 [COMPILING] foo v0.5.0 (file://[..])
-[RUNNING] `rustc build.rs [..]`
+[RUNNING] `rustc [..] build.rs [..]`
 [RUNNING] `[..][/]foo-[..][/]build-script-build`
-[RUNNING] `rustc [..] --crate-name foo [..] -L foo -l static=foo`
+[RUNNING] `rustc --crate-name foo [..] -L foo -l static=foo`
 [ERROR] could not find native static library [..]
 "));
 }
@@ -881,9 +881,9 @@ fn output_separate_lines_new() {
                 execs().with_status(101)
                        .with_stderr_contains("\
 [COMPILING] foo v0.5.0 (file://[..])
-[RUNNING] `rustc build.rs [..]`
+[RUNNING] `rustc [..] build.rs [..]`
 [RUNNING] `[..][/]foo-[..][/]build-script-build`
-[RUNNING] `rustc [..] --crate-name foo [..] -L foo -l static=foo`
+[RUNNING] `rustc --crate-name foo [..] -L foo -l static=foo`
 [ERROR] could not find native static library [..]
 "));
 }
@@ -1599,14 +1599,14 @@ fn flags_go_into_tests() {
                 execs().with_status(0)
                        .with_stderr("\
 [COMPILING] a v0.5.0 ([..]
-[RUNNING] `rustc a[/]build.rs [..]`
+[RUNNING] `rustc [..] a[/]build.rs [..]`
 [RUNNING] `[..][/]build-script-build`
-[RUNNING] `rustc a[/]src[/]lib.rs [..] -L test[..]`
+[RUNNING] `rustc [..] a[/]src[/]lib.rs [..] -L test[..]`
 [COMPILING] b v0.5.0 ([..]
-[RUNNING] `rustc b[/]src[/]lib.rs [..] -L test[..]`
+[RUNNING] `rustc [..] b[/]src[/]lib.rs [..] -L test[..]`
 [COMPILING] foo v0.5.0 ([..]
-[RUNNING] `rustc src[/]lib.rs [..] -L test[..]`
-[RUNNING] `rustc tests[/]foo.rs [..] -L test[..]`
+[RUNNING] `rustc [..] src[/]lib.rs [..] -L test[..]`
+[RUNNING] `rustc [..] tests[/]foo.rs [..] -L test[..]`
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `[..][/]foo-[..][EXE]`")
                        .with_stdout("
@@ -1621,7 +1621,7 @@ test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
                        .with_stderr("\
 [FRESH] a v0.5.0 ([..]
 [COMPILING] b v0.5.0 ([..]
-[RUNNING] `rustc b[/]src[/]lib.rs [..] -L test[..]`
+[RUNNING] `rustc [..] b[/]src[/]lib.rs [..] -L test[..]`
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `[..][/]b-[..][EXE]`")
                        .with_stdout("
@@ -1805,7 +1805,7 @@ fn rebuild_only_on_explicit_paths() {
                 execs().with_status(0).with_stderr("\
 [COMPILING] a v0.5.0 ([..])
 [RUNNING] `[..][/]build-script-build`
-[RUNNING] `rustc src[/]lib.rs [..]`
+[RUNNING] `rustc [..] src[/]lib.rs [..]`
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 "));
 
@@ -1819,7 +1819,7 @@ fn rebuild_only_on_explicit_paths() {
                 execs().with_status(0).with_stderr("\
 [COMPILING] a v0.5.0 ([..])
 [RUNNING] `[..][/]build-script-build`
-[RUNNING] `rustc src[/]lib.rs [..]`
+[RUNNING] `rustc [..] src[/]lib.rs [..]`
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 "));
 
@@ -1848,7 +1848,7 @@ fn rebuild_only_on_explicit_paths() {
                 execs().with_status(0).with_stderr("\
 [COMPILING] a v0.5.0 ([..])
 [RUNNING] `[..][/]build-script-build`
-[RUNNING] `rustc src[/]lib.rs [..]`
+[RUNNING] `rustc [..] src[/]lib.rs [..]`
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 "));
 
@@ -1859,7 +1859,7 @@ fn rebuild_only_on_explicit_paths() {
                 execs().with_status(0).with_stderr("\
 [COMPILING] a v0.5.0 ([..])
 [RUNNING] `[..][/]build-script-build`
-[RUNNING] `rustc src[/]lib.rs [..]`
+[RUNNING] `rustc [..] src[/]lib.rs [..]`
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 "));
 }
@@ -2235,7 +2235,7 @@ fn links_with_dots() {
     assert_that(p.cargo_process("build").arg("-v"),
                 execs().with_status(0)
                        .with_stderr_contains("\
-[RUNNING] `rustc [..] --crate-name foo [..] -L foo[..]`
+[RUNNING] `rustc --crate-name foo [..] [..] -L foo[..]`
 "));
 }
 

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -793,14 +793,14 @@ fn cargo_default_env_metadata_env_var() {
     assert_that(p.cargo_process("build").arg("-v"),
                 execs().with_status(0).with_stderr(&format!("\
 [COMPILING] bar v0.0.1 ({url}/bar)
-[RUNNING] `rustc bar[/]src[/]lib.rs --crate-name bar --crate-type dylib \
+[RUNNING] `rustc --crate-name bar bar[/]src[/]lib.rs --crate-type dylib \
         -C prefer-dynamic -g \
         -C metadata=[..] \
         --out-dir [..] \
         --emit=dep-info,link \
         -L dependency={dir}[/]target[/]debug[/]deps`
 [COMPILING] foo v0.0.1 ({url})
-[RUNNING] `rustc src[/]lib.rs --crate-name foo --crate-type lib -g \
+[RUNNING] `rustc --crate-name foo src[/]lib.rs --crate-type lib -g \
         -C metadata=[..] \
         -C extra-filename=[..] \
         --out-dir [..] \
@@ -821,14 +821,14 @@ suffix = env::consts::DLL_SUFFIX,
     assert_that(p.cargo_process("build").arg("-v").env("__CARGO_DEFAULT_LIB_METADATA", "1"),
                 execs().with_status(0).with_stderr(&format!("\
 [COMPILING] bar v0.0.1 ({url}/bar)
-[RUNNING] `rustc bar[/]src[/]lib.rs --crate-name bar --crate-type dylib \
+[RUNNING] `rustc --crate-name bar bar[/]src[/]lib.rs --crate-type dylib \
         -C prefer-dynamic -g \
         -C metadata=[..] \
         --out-dir [..] \
         --emit=dep-info,link \
         -L dependency={dir}[/]target[/]debug[/]deps`
 [COMPILING] foo v0.0.1 ({url})
-[RUNNING] `rustc src[/]lib.rs --crate-name foo --crate-type lib -g \
+[RUNNING] `rustc --crate-name foo src[/]lib.rs --crate-type lib -g \
         -C metadata=[..] \
         -C extra-filename=[..] \
         --out-dir [..] \
@@ -1141,7 +1141,7 @@ fn lto_build() {
     assert_that(p.cargo_process("build").arg("-v").arg("--release"),
                 execs().with_status(0).with_stderr(&format!("\
 [COMPILING] test v0.0.0 ({url})
-[RUNNING] `rustc src[/]main.rs --crate-name test --crate-type bin \
+[RUNNING] `rustc --crate-name test src[/]main.rs --crate-type bin \
         -C opt-level=3 \
         -C lto \
         -C metadata=[..] \
@@ -1170,7 +1170,7 @@ fn verbose_build() {
     assert_that(p.cargo_process("build").arg("-v"),
                 execs().with_status(0).with_stderr(&format!("\
 [COMPILING] test v0.0.0 ({url})
-[RUNNING] `rustc src[/]lib.rs --crate-name test --crate-type lib -g \
+[RUNNING] `rustc --crate-name test src[/]lib.rs --crate-type lib -g \
         -C metadata=[..] \
         --out-dir [..] \
         --emit=dep-info,link \
@@ -1197,7 +1197,7 @@ fn verbose_release_build() {
     assert_that(p.cargo_process("build").arg("-v").arg("--release"),
                 execs().with_status(0).with_stderr(&format!("\
 [COMPILING] test v0.0.0 ({url})
-[RUNNING] `rustc src[/]lib.rs --crate-name test --crate-type lib \
+[RUNNING] `rustc --crate-name test src[/]lib.rs --crate-type lib \
         -C opt-level=3 \
         -C metadata=[..] \
         --out-dir [..] \
@@ -1240,7 +1240,7 @@ fn verbose_release_build_deps() {
     assert_that(p.cargo_process("build").arg("-v").arg("--release"),
                 execs().with_status(0).with_stderr(&format!("\
 [COMPILING] foo v0.0.0 ({url}/foo)
-[RUNNING] `rustc foo[/]src[/]lib.rs --crate-name foo \
+[RUNNING] `rustc --crate-name foo foo[/]src[/]lib.rs \
         --crate-type dylib --crate-type rlib -C prefer-dynamic \
         -C opt-level=3 \
         -C metadata=[..] \
@@ -1248,7 +1248,7 @@ fn verbose_release_build_deps() {
         --emit=dep-info,link \
         -L dependency={dir}[/]target[/]release[/]deps`
 [COMPILING] test v0.0.0 ({url})
-[RUNNING] `rustc src[/]lib.rs --crate-name test --crate-type lib \
+[RUNNING] `rustc --crate-name test src[/]lib.rs --crate-type lib \
         -C opt-level=3 \
         -C metadata=[..] \
         --out-dir [..] \
@@ -2357,7 +2357,7 @@ fn explicit_color_config_is_propagated_to_rustc() {
 
     assert_that(p.cargo_process("build").arg("-v").arg("--color").arg("always"),
                 execs().with_status(0).with_stderr_contains(
-                    "[..]rustc src[/]lib.rs --color always[..]"));
+                    "[..]rustc [..] src[/]lib.rs --color always[..]"));
 
     assert_that(p.cargo_process("build").arg("-v").arg("--color").arg("never"),
                 execs().with_status(0).with_stderr("\

--- a/tests/cargo_alias_config.rs
+++ b/tests/cargo_alias_config.rs
@@ -55,7 +55,7 @@ fn alias_config() {
     assert_that(p.cargo_process("b-cargo-test").arg("-v"),
                 execs().with_status(0).
                 with_stderr_contains("[COMPILING] foo v0.5.0 [..]
-[RUNNING] `rustc [..] --crate-name foo [..]"));
+[RUNNING] `rustc --crate-name foo [..]"));
 }
 
 #[test]
@@ -73,7 +73,7 @@ fn alias_list_test() {
     assert_that(p.cargo_process("b-cargo-test").arg("-v"),
                 execs().with_status(0).
                 with_stderr_contains("[COMPILING] foo v0.5.0 [..]").
-                with_stderr_contains("[RUNNING] `rustc [..] --crate-name [..]")
+                with_stderr_contains("[RUNNING] `rustc --crate-name [..]")
                 );
 }
 
@@ -92,7 +92,7 @@ fn alias_with_flags_config() {
     assert_that(p.cargo_process("b-cargo-test").arg("-v"),
                 execs().with_status(0).
                 with_stderr_contains("[COMPILING] foo v0.5.0 [..]").
-                with_stderr_contains("[RUNNING] `rustc [..] --crate-name foo [..]")
+                with_stderr_contains("[RUNNING] `rustc --crate-name foo [..]")
                 );
 }
 

--- a/tests/clean.rs
+++ b/tests/clean.rs
@@ -171,9 +171,9 @@ fn build_script() {
     assert_that(p.cargo("build").arg("-v"),
                 execs().with_status(0).with_stderr("\
 [COMPILING] foo v0.0.1 ([..])
-[RUNNING] `rustc build.rs [..]`
+[RUNNING] `rustc [..] build.rs [..]`
 [RUNNING] `[..]build-script-build`
-[RUNNING] `rustc src[/]main.rs [..]`
+[RUNNING] `rustc [..] src[/]main.rs [..]`
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 "));
 }

--- a/tests/cross-compile.rs
+++ b/tests/cross-compile.rs
@@ -804,9 +804,9 @@ fn plugin_build_script_right_arch() {
                 execs().with_status(0)
                        .with_stderr("\
 [COMPILING] foo v0.0.1 ([..])
-[RUNNING] `rustc build.rs [..]`
+[RUNNING] `rustc [..] build.rs [..]`
 [RUNNING] `[..][/]build-script-build`
-[RUNNING] `rustc src[/]lib.rs [..]`
+[RUNNING] `rustc [..] src[/]lib.rs [..]`
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 "));
 }

--- a/tests/cross-compile.rs
+++ b/tests/cross-compile.rs
@@ -357,7 +357,7 @@ fn linker_and_ar() {
                 execs().with_status(101)
                        .with_stderr_contains(&format!("\
 [COMPILING] foo v0.5.0 ({url})
-[RUNNING] `rustc src[/]foo.rs --crate-name foo --crate-type bin -g \
+[RUNNING] `rustc --crate-name foo src[/]foo.rs --crate-type bin -g \
     -C metadata=[..] \
     --out-dir {dir}[/]target[/]{target}[/]debug[/]deps \
     --emit=dep-info,link \
@@ -604,9 +604,9 @@ fn cross_with_a_build_script() {
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] foo v0.0.0 (file://[..])
-[RUNNING] `rustc build.rs [..] --out-dir {dir}[/]target[/]debug[/]build[/]foo-[..]`
+[RUNNING] `rustc [..] build.rs [..] --out-dir {dir}[/]target[/]debug[/]build[/]foo-[..]`
 [RUNNING] `{dir}[/]target[/]debug[/]build[/]foo-[..][/]build-script-build`
-[RUNNING] `rustc src[/]main.rs [..] --target {target} [..]`
+[RUNNING] `rustc [..] src[/]main.rs [..] --target {target} [..]`
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 ", target = target,
    dir = p.root().display())));
@@ -676,25 +676,25 @@ fn build_script_needed_for_host_and_target() {
                        .with_stderr_contains(&format!("\
 [COMPILING] d1 v0.0.0 ({url}/d1)", url = p.url()))
                        .with_stderr_contains(&format!("\
-[RUNNING] `rustc d1[/]build.rs [..] --out-dir {dir}[/]target[/]debug[/]build[/]d1-[..]`",
+[RUNNING] `rustc [..] d1[/]build.rs [..] --out-dir {dir}[/]target[/]debug[/]build[/]d1-[..]`",
     dir = p.root().display()))
                        .with_stderr_contains(&format!("\
 [RUNNING] `{dir}[/]target[/]debug[/]build[/]d1-[..][/]build-script-build`",
     dir = p.root().display()))
                        .with_stderr_contains("\
-[RUNNING] `rustc d1[/]src[/]lib.rs [..]`")
+[RUNNING] `rustc [..] d1[/]src[/]lib.rs [..]`")
                        .with_stderr_contains(&format!("\
 [COMPILING] d2 v0.0.0 ({url}/d2)", url = p.url()))
                        .with_stderr_contains(&format!("\
-[RUNNING] `rustc d2[/]src[/]lib.rs [..] \
+[RUNNING] `rustc [..] d2[/]src[/]lib.rs [..] \
            -L /path/to/{host}`", host = host))
                        .with_stderr_contains(&format!("\
 [COMPILING] foo v0.0.0 ({url})", url = p.url()))
                        .with_stderr_contains(&format!("\
-[RUNNING] `rustc build.rs [..] --out-dir {dir}[/]target[/]debug[/]build[/]foo-[..] \
+[RUNNING] `rustc [..] build.rs [..] --out-dir {dir}[/]target[/]debug[/]build[/]foo-[..] \
            -L /path/to/{host}`", dir = p.root().display(), host = host))
                        .with_stderr_contains(&format!("\
-[RUNNING] `rustc src[/]main.rs [..] --target {target} [..] \
+[RUNNING] `rustc [..] src[/]main.rs [..] --target {target} [..] \
            -L /path/to/{target}`", target = target)));
 }
 
@@ -852,13 +852,13 @@ fn build_script_with_platform_specific_dependencies() {
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] d2 v0.0.0 ([..])
-[RUNNING] `rustc d2[/]src[/]lib.rs [..]`
+[RUNNING] `rustc [..] d2[/]src[/]lib.rs [..]`
 [COMPILING] d1 v0.0.0 ([..])
-[RUNNING] `rustc d1[/]src[/]lib.rs [..]`
+[RUNNING] `rustc [..] d1[/]src[/]lib.rs [..]`
 [COMPILING] foo v0.0.1 ([..])
-[RUNNING] `rustc build.rs [..]`
+[RUNNING] `rustc [..] build.rs [..]`
 [RUNNING] `{dir}[/]target[/]debug[/]build[/]foo-[..][/]build-script-build`
-[RUNNING] `rustc src[/]lib.rs [..] --target {target} [..]`
+[RUNNING] `rustc [..] src[/]lib.rs [..] --target {target} [..]`
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 ", dir = p.root().display(), target = target)));
 }

--- a/tests/doc.rs
+++ b/tests/doc.rs
@@ -445,7 +445,7 @@ fn doc_release() {
                 execs().with_status(0)
                        .with_stderr("\
 [DOCUMENTING] foo v0.0.1 ([..])
-[RUNNING] `rustdoc src[/]lib.rs [..]`
+[RUNNING] `rustdoc [..] src[/]lib.rs [..]`
 "));
 }
 

--- a/tests/profiles.rs
+++ b/tests/profiles.rs
@@ -27,7 +27,7 @@ fn profile_overrides() {
     assert_that(p.cargo_process("build").arg("-v"),
                 execs().with_status(0).with_stderr(&format!("\
 [COMPILING] test v0.0.0 ({url})
-[RUNNING] `rustc src[/]lib.rs --crate-name test --crate-type lib \
+[RUNNING] `rustc --crate-name test src[/]lib.rs --crate-type lib \
         -C opt-level=1 \
         -C debug-assertions=on \
         -C metadata=[..] \
@@ -60,7 +60,7 @@ fn opt_level_override_0() {
     assert_that(p.cargo_process("build").arg("-v"),
                 execs().with_status(0).with_stderr(&format!("\
 [COMPILING] test v0.0.0 ({url})
-[RUNNING] `rustc src[/]lib.rs --crate-name test --crate-type lib \
+[RUNNING] `rustc --crate-name test src[/]lib.rs --crate-type lib \
         -g \
         -C metadata=[..] \
         --out-dir [..] \
@@ -90,7 +90,7 @@ fn check_opt_level_override(profile_level: &str, rustc_level: &str) {
     assert_that(p.cargo_process("build").arg("-v"),
                 execs().with_status(0).with_stderr(&format!("\
 [COMPILING] test v0.0.0 ({url})
-[RUNNING] `rustc src[/]lib.rs --crate-name test --crate-type lib \
+[RUNNING] `rustc --crate-name test src[/]lib.rs --crate-type lib \
         -C opt-level={level} \
         -g \
         -C debug-assertions=on \
@@ -159,7 +159,7 @@ fn top_level_overrides_deps() {
     assert_that(p.cargo_process("build").arg("-v").arg("--release"),
                 execs().with_status(0).with_stderr(&format!("\
 [COMPILING] foo v0.0.0 ({url}/foo)
-[RUNNING] `rustc foo[/]src[/]lib.rs --crate-name foo \
+[RUNNING] `rustc --crate-name foo foo[/]src[/]lib.rs \
         --crate-type dylib --crate-type rlib -C prefer-dynamic \
         -C opt-level=1 \
         -g \
@@ -168,7 +168,7 @@ fn top_level_overrides_deps() {
         --emit=dep-info,link \
         -L dependency={dir}[/]target[/]release[/]deps`
 [COMPILING] test v0.0.0 ({url})
-[RUNNING] `rustc src[/]lib.rs --crate-name test --crate-type lib \
+[RUNNING] `rustc --crate-name test src[/]lib.rs --crate-type lib \
         -C opt-level=1 \
         -g \
         -C metadata=[..] \

--- a/tests/run.rs
+++ b/tests/run.rs
@@ -227,8 +227,8 @@ fn specify_name() {
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({dir})
-[RUNNING] `rustc src[/]lib.rs [..]`
-[RUNNING] `rustc src[/]bin[/]a.rs [..]`
+[RUNNING] `rustc [..] src[/]lib.rs [..]`
+[RUNNING] `rustc [..] src[/]bin[/]a.rs [..]`
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `target[/]debug[/]a[EXE]`", dir = path2url(p.root())))
                        .with_stdout("\
@@ -239,7 +239,7 @@ hello a.rs
                 execs().with_status(0)
                        .with_stderr("\
 [COMPILING] foo v0.0.1 ([..])
-[RUNNING] `rustc src[/]bin[/]b.rs [..]`
+[RUNNING] `rustc [..] src[/]bin[/]b.rs [..]`
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `target[/]debug[/]b[EXE]`")
                        .with_stdout("\
@@ -416,14 +416,14 @@ fn example_with_release_flag() {
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] bar v0.0.1 ({url}/bar)
-[RUNNING] `rustc bar[/]src[/]bar.rs --crate-name bar --crate-type lib \
+[RUNNING] `rustc --crate-name bar bar[/]src[/]bar.rs --crate-type lib \
         -C opt-level=3 \
         -C metadata=[..] \
         --out-dir {dir}[/]target[/]release[/]deps \
         --emit=dep-info,link \
         -L dependency={dir}[/]target[/]release[/]deps`
 [COMPILING] foo v0.0.1 ({url})
-[RUNNING] `rustc examples[/]a.rs --crate-name a --crate-type bin \
+[RUNNING] `rustc --crate-name a examples[/]a.rs  --crate-type bin \
         -C opt-level=3 \
         -C metadata=[..] \
         --out-dir {dir}[/]target[/]release[/]examples \
@@ -444,14 +444,14 @@ fast2"));
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] bar v0.0.1 ({url}/bar)
-[RUNNING] `rustc bar[/]src[/]bar.rs --crate-name bar --crate-type lib \
+[RUNNING] `rustc --crate-name bar bar[/]src[/]bar.rs --crate-type lib \
         -g \
         -C metadata=[..] \
         --out-dir {dir}[/]target[/]debug[/]deps \
         --emit=dep-info,link \
         -L dependency={dir}[/]target[/]debug[/]deps`
 [COMPILING] foo v0.0.1 ({url})
-[RUNNING] `rustc examples[/]a.rs --crate-name a --crate-type bin \
+[RUNNING] `rustc --crate-name a examples[/]a.rs --crate-type bin \
         -g \
         -C metadata=[..] \
         --out-dir {dir}[/]target[/]debug[/]examples \

--- a/tests/run.rs
+++ b/tests/run.rs
@@ -423,7 +423,7 @@ fn example_with_release_flag() {
         --emit=dep-info,link \
         -L dependency={dir}[/]target[/]release[/]deps`
 [COMPILING] foo v0.0.1 ({url})
-[RUNNING] `rustc --crate-name a examples[/]a.rs  --crate-type bin \
+[RUNNING] `rustc --crate-name a examples[/]a.rs --crate-type bin \
         -C opt-level=3 \
         -C metadata=[..] \
         --out-dir {dir}[/]target[/]release[/]examples \

--- a/tests/rustc.rs
+++ b/tests/rustc.rs
@@ -27,7 +27,7 @@ fn build_lib_for_foo() {
                 .with_status(0)
                 .with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({url})
-[RUNNING] `rustc src[/]lib.rs --crate-name foo --crate-type lib -g \
+[RUNNING] `rustc --crate-name foo src[/]lib.rs --crate-type lib -g \
         -C metadata=[..] \
         --out-dir [..] \
         --emit=dep-info,link \
@@ -56,7 +56,7 @@ fn lib() {
                 .with_status(0)
                 .with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({url})
-[RUNNING] `rustc src[/]lib.rs --crate-name foo --crate-type lib -g \
+[RUNNING] `rustc --crate-name foo src[/]lib.rs --crate-type lib -g \
         -C debug-assertions=off \
         -C metadata=[..] \
         --out-dir [..] \
@@ -86,12 +86,12 @@ fn build_main_and_allow_unstable_options() {
                 .with_status(0)
                 .with_stderr(&format!("\
 [COMPILING] {name} v{version} ({url})
-[RUNNING] `rustc src[/]lib.rs --crate-name {name} --crate-type lib -g \
+[RUNNING] `rustc --crate-name {name} src[/]lib.rs --crate-type lib -g \
         -C metadata=[..] \
         --out-dir [..] \
         --emit=dep-info,link \
         -L dependency={dir}[/]target[/]debug[/]deps`
-[RUNNING] `rustc src[/]main.rs --crate-name {name} --crate-type bin -g \
+[RUNNING] `rustc --crate-name {name} src[/]main.rs --crate-type bin -g \
         -C debug-assertions \
         -C metadata=[..] \
         --out-dir [..] \
@@ -151,10 +151,10 @@ fn build_with_args_to_one_of_multiple_binaries() {
                 .with_status(0)
                 .with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({url})
-[RUNNING] `rustc src[/]lib.rs --crate-name foo --crate-type lib -g \
+[RUNNING] `rustc --crate-name foo src[/]lib.rs --crate-type lib -g \
         -C metadata=[..] \
         --out-dir [..]`
-[RUNNING] `rustc src[/]bin[/]bar.rs --crate-name bar --crate-type bin -g \
+[RUNNING] `rustc --crate-name bar src[/]bin[/]bar.rs --crate-type bin -g \
         -C debug-assertions [..]`
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 ", url = p.url())));
@@ -207,10 +207,10 @@ fn build_with_args_to_one_of_multiple_tests() {
                 .with_status(0)
                 .with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({url})
-[RUNNING] `rustc src[/]lib.rs --crate-name foo --crate-type lib -g \
+[RUNNING] `rustc --crate-name foo src[/]lib.rs --crate-type lib -g \
         -C metadata=[..] \
         --out-dir [..]`
-[RUNNING] `rustc tests[/]bar.rs --crate-name bar -g \
+[RUNNING] `rustc --crate-name bar tests[/]bar.rs -g \
         -C debug-assertions [..]--test[..]`
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 ", url = p.url())));

--- a/tests/rustc.rs
+++ b/tests/rustc.rs
@@ -294,7 +294,7 @@ fn build_only_bar_dependency() {
                 .with_status(0)
                 .with_stderr("\
 [COMPILING] bar v0.1.0 ([..])
-[RUNNING] `[..]--crate-name bar --crate-type lib [..] -C debug-assertions [..]`
+[RUNNING] `rustc --crate-name bar [..] --crate-type lib [..] -C debug-assertions [..]`
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 "));
 }

--- a/tests/rustdoc.rs
+++ b/tests/rustdoc.rs
@@ -20,7 +20,7 @@ fn rustdoc_simple() {
                 .with_status(0)
                 .with_stderr(format!("\
 [DOCUMENTING] foo v0.0.1 ({url})
-[RUNNING] `rustdoc src[/]lib.rs --crate-name foo \
+[RUNNING] `rustdoc --crate-name foo src[/]lib.rs \
         -o {dir}[/]target[/]doc \
         -L dependency={dir}[/]target[/]debug[/]deps`
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
@@ -43,7 +43,7 @@ fn rustdoc_args() {
                 .with_status(0)
                 .with_stderr(format!("\
 [DOCUMENTING] foo v0.0.1 ({url})
-[RUNNING] `rustdoc src[/]lib.rs --crate-name foo \
+[RUNNING] `rustdoc --crate-name foo src[/]lib.rs \
         -o {dir}[/]target[/]doc \
         --no-defaults \
         -L dependency={dir}[/]target[/]debug[/]deps`
@@ -88,7 +88,7 @@ fn rustdoc_foo_with_bar_dependency() {
 [COMPILING] bar v0.0.1 ([..])
 [RUNNING] `rustc [..]bar[/]src[/]lib.rs [..]`
 [DOCUMENTING] foo v0.0.1 ({url})
-[RUNNING] `rustdoc src[/]lib.rs --crate-name foo \
+[RUNNING] `rustdoc --crate-name foo src[/]lib.rs \
         -o {dir}[/]target[/]doc \
         --no-defaults \
         -L dependency={dir}[/]target[/]debug[/]deps \
@@ -133,7 +133,7 @@ fn rustdoc_only_bar_dependency() {
                 .with_status(0)
                 .with_stderr(format!("\
 [DOCUMENTING] bar v0.0.1 ([..])
-[RUNNING] `rustdoc [..]bar[/]src[/]lib.rs --crate-name bar \
+[RUNNING] `rustdoc --crate-name bar [..]bar[/]src[/]lib.rs \
         -o {dir}[/]target[/]doc \
         --no-defaults \
         -L dependency={dir}[/]target[/]debug[/]deps`

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -128,7 +128,7 @@ fn cargo_test_verbose() {
     assert_that(p.cargo_process("test").arg("-v").arg("hello"),
                 execs().with_stderr(format!("\
 [COMPILING] foo v0.5.0 ({url})
-[RUNNING] `rustc src[/]foo.rs [..]`
+[RUNNING] `rustc [..] src[/]foo.rs [..]`
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `[..]target[/]debug[/]deps[/]foo-[..][EXE] hello`", url = p.url()))
                        .with_stdout("
@@ -1587,7 +1587,7 @@ fn example_with_dev_dep() {
 [..]
 [..]
 [..]
-[RUNNING] `rustc [..] --crate-name ex [..] --extern a=[..]`
+[RUNNING] `rustc --crate-name ex [..] --extern a=[..]`
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 "));
 }
@@ -2058,8 +2058,8 @@ fn bin_does_not_rebuild_tests() {
                 execs().with_status(0)
                        .with_stderr("\
 [COMPILING] foo v0.0.1 ([..])
-[RUNNING] `rustc src[/]main.rs [..]`
-[RUNNING] `rustc src[/]main.rs [..]`
+[RUNNING] `rustc [..] src[/]main.rs [..]`
+[RUNNING] `rustc [..] src[/]main.rs [..]`
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 "));
 }
@@ -2120,8 +2120,8 @@ fn selective_test_optional_dep() {
                  .arg("--features").arg("a").arg("-p").arg("a"),
                 execs().with_status(0).with_stderr("\
 [COMPILING] a v0.0.1 ([..])
-[RUNNING] `rustc a[/]src[/]lib.rs [..]`
-[RUNNING] `rustc a[/]src[/]lib.rs [..]`
+[RUNNING] `rustc [..] a[/]src[/]lib.rs [..]`
+[RUNNING] `rustc [..] a[/]src[/]lib.rs [..]`
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 "));
 }


### PR DESCRIPTION
This adresses #3276 .

Some tests I can't run locally might still fail, I'm fixing those.

The core change is rather trivial, simply reorder some existing code, and update tests to match the new results.