### PR TITLE
Assume `build.rs` in the same directory as `Cargo.toml` is a build script (unless explicitly told not to)

### DIFF
--- a/src/cargo/util/toml.rs
+++ b/src/cargo/util/toml.rs
@@ -286,12 +286,18 @@ pub struct TomlProfile {
     panic: Option<String>,
 }
 
+#[derive(RustcDecodable, Clone, Debug)]
+pub enum StringOrBool {
+    String(String),
+    Bool(bool),
+}
+
 #[derive(RustcDecodable)]
 pub struct TomlProject {
     name: String,
     version: TomlVersion,
     authors: Vec<String>,
-    build: Option<String>,
+    build: Option<StringOrBool>,
     links: Option<String>,
     exclude: Option<Vec<String>>,
     include: Option<Vec<String>>,
@@ -540,7 +546,11 @@ impl TomlManifest {
         }
 
         // processing the custom build script
-        let new_build = project.build.as_ref().map(PathBuf::from);
+        let manifest_file = util::important_paths::find_root_manifest_for_wd(None, &layout.root)
+                                 .chain_error(|| human("Could not find root manifest location"))?;
+        let base_dir = manifest_file.parent()
+                                    .ok_or(human("Could not get parent directory of manifest"))?;
+        let new_build = self.maybe_custom_build(&project.build, &base_dir);
 
         // Get targets
         let targets = normalize(&lib,
@@ -766,6 +776,23 @@ impl TomlManifest {
             replace.push((spec, dep));
         }
         Ok(replace)
+    }
+
+    fn maybe_custom_build(&self, build: &Option<StringOrBool>, project_dir: &Path)
+                          -> Option<PathBuf> {
+        let build_rs = project_dir.join("build.rs");
+        match *build {
+            Some(StringOrBool::Bool(false)) => None,        // explicitly no build script
+            Some(StringOrBool::Bool(true)) => Some(build_rs.into()),
+            Some(StringOrBool::String(ref s)) => Some(PathBuf::from(s)),
+            None => {
+                match fs::metadata(&build_rs) {
+                    Ok(ref e) if e.is_file() => Some(build_rs.into()),
+                    Ok(_) => None,
+                    Err(_) => None,
+                }
+            }
+        }
     }
 }
 

--- a/src/cargo/util/toml.rs
+++ b/src/cargo/util/toml.rs
@@ -546,11 +546,7 @@ impl TomlManifest {
         }
 
         // processing the custom build script
-        let manifest_file = util::important_paths::find_root_manifest_for_wd(None, &layout.root)
-                                 .chain_error(|| human("Could not find root manifest location"))?;
-        let base_dir = manifest_file.parent()
-                                    .ok_or(human("Could not get parent directory of manifest"))?;
-        let new_build = self.maybe_custom_build(&project.build, &base_dir);
+        let new_build = self.maybe_custom_build(&project.build, &layout.root);
 
         // Get targets
         let targets = normalize(&lib,

--- a/tests/build-script.rs
+++ b/tests/build-script.rs
@@ -2345,8 +2345,12 @@ fn assume_build_script_when_build_rs_present() {
             authors = []
         "#)
         .file("src/main.rs", r#"
+            use std::path::Path;
             fn main() {
-                println!(include_str!(concat!(env!("OUT_DIR"), "/output")));
+                let f = env!("OUT_DIR");
+                assert!(
+                    ! Path::new(f).join("output").exists()
+                );
             }
         "#)
         .file("build.rs", r#"
@@ -2365,7 +2369,14 @@ fn assume_build_script_when_build_rs_present() {
     p.build();
 
     assert_that(p.cargo("run").arg("-v"),
-                execs().with_status(0).with_stdout("foo\n"));
+                execs().with_status(0).with_stderr("\
+warning: `build.rs` files in the same directory as your `Cargo.toml` will soon be treated \
+as build scripts. Add `build = false` to your `Cargo.toml` to prevent this
+   Compiling builder v0.0.1 ([..])
+     Running [..]
+    Finished [..]
+     Running [..]
+"));
 }
 
 #[test]

--- a/tests/build-script.rs
+++ b/tests/build-script.rs
@@ -2369,7 +2369,7 @@ fn assume_build_script_when_build_rs_present() {
 }
 
 #[test]
-fn if_build_set_to_false_dont_tread_build_rs_as_build_script() {
+fn if_build_set_to_false_dont_treat_build_rs_as_build_script() {
     let p = project("builder")
         .file("Cargo.toml", r#"
             [package]


### PR DESCRIPTION
So, in May I posted a question in the #cargo IRC room: https://botbot.me/mozilla/cargo/2016-05-26/?msg=66770068&page=1

This PR does what was discussed there. If `cargo` sees a `build.rs` in the same directory as the `Cargo.toml`, it will assume `build.rs` is a build script unless `package.build = false`. Just for completeness I also made `build = true` mean the same as `build = "build.rs"` but I'm not sure if that is okay or not.