### PR TITLE
Warn if replace is not actually used

### DIFF
--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -163,6 +163,14 @@ pub fn resolve_dependencies<'a>(ws: &Workspace<'a>,
                                             method, Some(&resolve), None,
                                             &specs)?;
 
+    for &(ref replace_spec, _) in ws.root_replace() {
+        if !resolved_with_overrides.replacements().keys().any(|r| replace_spec.matches(r)) {
+            ws.config().shell().warn(
+                format!("package replacement is not used: {}", replace_spec)
+            )?
+        }
+    }
+
     let packages = ops::get_resolved_packages(&resolved_with_overrides,
                                               registry);
 

--- a/tests/overrides.rs
+++ b/tests/overrides.rs
@@ -922,6 +922,7 @@ fn overriding_nonexistent_no_spurious() {
                 execs().with_status(0));
     assert_that(p.cargo("build"),
                 execs().with_status(0).with_stderr("\
+[WARNING] package replacement is not used: [..]bar:0.1.0
 [FINISHED] [..]
 ").with_stdout(""));
 }


### PR DESCRIPTION
closes #3324 

I've added warnings to `resolve_dependencies` inside `cargo_compile.rs`. Adding them to `resolve_with_previous` does not work because that method is called several times.

Perhaps the best idea is to refactor resolve facade, such that we have only `ops::resolve`  and not `ops::resolve_ws`, `ops::resolve_with_previous` and `ops::resolve_dependencies`. IIRC, there were some bugs because of logic mismatch between `compile` and `metadata` commands. 