### PR TITLE
Fix dylib linking issues within the project

### DIFF
--- a/src/cargo/ops/cargo_rustc/mod.rs
+++ b/src/cargo/ops/cargo_rustc/mod.rs
@@ -568,8 +568,7 @@ fn build_base_args(cx: &mut Context,
 
     let prefer_dynamic = (unit.target.for_host() &&
                           !unit.target.is_custom_build()) ||
-                         (crate_types.contains(&"dylib") &&
-                          cx.ws.members().find(|&p| p != unit.pkg).is_some());
+                         crate_types.contains(&"dylib");
     if prefer_dynamic {
         cmd.arg("-C").arg("prefer-dynamic");
     }


### PR DESCRIPTION
While the name is equal to the root, we still should produce a dynamic one; otherwise the link will fail.
Close #3406 

Code sample:
```
[package]
name = "foo"
version = "0.1.0"
authors = []

[dependencies]
# cool stuffs

[lib]
crate-type = ["dylib"]
# [bin] is implicit
```