### PR TITLE
Minor build tweaks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ matrix:
            MACOSX_DEPLOYMENT_TARGET=10.7
       os: osx
     - env: TARGET=i686-apple-darwin
-           MAKE_TARGETS=test
+           MAKE_TARGETS=test-unit-i686-apple-darwin
            MACOSX_DEPLOYMENT_TARGET=10.7
            CFG_DISABLE_CROSS_TESTS=1
       os: osx

--- a/Makefile.in
+++ b/Makefile.in
@@ -259,6 +259,7 @@ ifdef OPENSSL_OS_$(1)
 
 target/openssl/$(1).stamp: target/openssl/openssl-$$(OPENSSL_VERS).tar.gz \
 		| target/openssl/
+	rm -rf target/openssl/$(1)
 	mkdir -p target/openssl/$(1)
 	tar xf $$< -C target/openssl/$(1) --strip-components 1
 	(cd target/openssl/$(1) && \


### PR DESCRIPTION
* Clean out OpenSSL when building
* Test 32-bit Cargo on OSX, not the 64-bit version on the 32-bit builder