### PR TITLE
Refactor resolve_dependencies

### DIFF
--- a/src/cargo/core/registry.rs
+++ b/src/cargo/core/registry.rs
@@ -153,8 +153,7 @@ impl<'cfg> PackageRegistry<'cfg> {
         self.add_source(source, Kind::Locked);
     }
 
-    fn add_source(&mut self, source: Box<Source + 'cfg>,
-                  kind: Kind) {
+    fn add_source(&mut self, source: Box<Source + 'cfg>, kind: Kind) {
         let id = source.source_id().clone();
         self.sources.insert(source);
         self.source_ids.insert(id.clone(), (id, kind));

--- a/src/cargo/core/registry.rs
+++ b/src/cargo/core/registry.rs
@@ -149,19 +149,20 @@ impl<'cfg> PackageRegistry<'cfg> {
         Ok(())
     }
 
-    pub fn add_preloaded(&mut self, id: &SourceId, source: Box<Source + 'cfg>) {
-        self.add_source(id, source, Kind::Locked);
+    pub fn add_preloaded(&mut self, source: Box<Source + 'cfg>) {
+        self.add_source(source, Kind::Locked);
     }
 
-    fn add_source(&mut self, id: &SourceId, source: Box<Source + 'cfg>,
+    fn add_source(&mut self, source: Box<Source + 'cfg>,
                   kind: Kind) {
-        self.sources.insert(id, source);
-        self.source_ids.insert(id.clone(), (id.clone(), kind));
+        let id = source.source_id().clone();
+        self.sources.insert(source);
+        self.source_ids.insert(id.clone(), (id, kind));
     }
 
-    pub fn add_override(&mut self, id: &SourceId, source: Box<Source + 'cfg>) {
-        self.add_source(id, source, Kind::Override);
-        self.overrides.push(id.clone());
+    pub fn add_override(&mut self, source: Box<Source + 'cfg>) {
+        self.overrides.push(source.source_id().clone());
+        self.add_source(source, Kind::Override);
     }
 
     pub fn register_lock(&mut self, id: PackageId, deps: Vec<PackageId>) {
@@ -179,11 +180,12 @@ impl<'cfg> PackageRegistry<'cfg> {
     fn load(&mut self, source_id: &SourceId, kind: Kind) -> CargoResult<()> {
         (|| {
             let source = self.source_config.load(source_id)?;
+            assert_eq!(source.source_id(), source_id);
 
             if kind == Kind::Override {
                 self.overrides.push(source_id.clone());
             }
-            self.add_source(source_id, source, kind);
+            self.add_source(source, kind);
 
             // Ensure the source has fetched all necessary remote data.
             let _p = profile::start(format!("updating: {}", source_id));

--- a/src/cargo/core/source.rs
+++ b/src/cargo/core/source.rs
@@ -20,6 +20,8 @@ use util::{human, Config, CargoResult, ToUrl};
 /// A Source finds and downloads remote packages based on names and
 /// versions.
 pub trait Source: Registry {
+    fn source_id(&self) -> &SourceId;
+
     /// The update method performs any network operations required to
     /// get the entire list of all names, versions and dependencies of
     /// packages managed by the Source.
@@ -53,6 +55,10 @@ pub trait Source: Registry {
 }
 
 impl<'a, T: Source + ?Sized + 'a> Source for Box<T> {
+    fn source_id(&self) -> &SourceId {
+        (**self).source_id()
+    }
+
     fn update(&mut self) -> CargoResult<()> {
         (**self).update()
     }
@@ -505,8 +511,9 @@ impl<'src> SourceMap<'src> {
         self.get(pkg_id.source_id())
     }
 
-    pub fn insert(&mut self, id: &SourceId, source: Box<Source + 'src>) {
-        self.map.insert(id.clone(), source);
+    pub fn insert(&mut self, source: Box<Source + 'src>) {
+        let id = source.source_id().clone();
+        self.map.insert(id, source);
     }
 
     pub fn is_empty(&self) -> bool {

--- a/src/cargo/ops/cargo_clean.rs
+++ b/src/cargo/ops/cargo_clean.rs
@@ -3,7 +3,6 @@ use std::fs;
 use std::path::Path;
 
 use core::{Profiles, Workspace};
-use core::registry::PackageRegistry;
 use util::{CargoResult, human, ChainError, Config};
 use ops::{self, Context, BuildConfig, Kind, Unit};
 
@@ -28,9 +27,7 @@ pub fn clean(ws: &Workspace, opts: &CleanOptions) -> CargoResult<()> {
         return rm_rf(&target_dir);
     }
 
-    let mut registry = PackageRegistry::new(opts.config)?;
-    let resolve = ops::resolve_ws(&mut registry, ws)?;
-    let packages = ops::get_resolved_packages(&resolve, registry);
+    let (packages, resolve) = ops::resolve_ws(ws)?;
 
     let profiles = ws.profiles();
     let host_triple = opts.config.rustc()?.host.clone();

--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -141,7 +141,7 @@ pub fn compile_ws<'a>(ws: &Workspace<'a>,
     let profiles = ws.profiles();
 
     let specs = spec.into_package_id_specs(ws)?;
-    let resolve = ops::resolve_dependencies(ws,
+    let resolve = ops::resolve_ws_precisely(ws,
                                             source,
                                             features,
                                             all_features,

--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -25,14 +25,11 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
 
-use core::registry::PackageRegistry;
-use core::{Source, SourceId, PackageSet, Package, Target};
+use core::{Source, Package, Target};
 use core::{Profile, TargetKind, Profiles, Workspace, PackageIdSpec};
-use core::resolver::{Method, Resolve};
 use ops::{self, BuildOutput};
-use sources::PathSource;
 use util::config::Config;
-use util::{CargoResult, profile, human, ChainError};
+use util::{CargoResult, profile};
 
 /// Contains information about how a package should be compiled.
 pub struct CompileOptions<'a> {
@@ -124,65 +121,6 @@ pub fn compile<'a>(ws: &Workspace<'a>, options: &CompileOptions<'a>)
     compile_ws(ws, None, options)
 }
 
-pub fn resolve_dependencies<'a>(ws: &Workspace<'a>,
-                                source: Option<Box<Source + 'a>>,
-                                features: &[String],
-                                all_features: bool,
-                                no_default_features: bool,
-                                specs: &[PackageIdSpec])
-                                -> CargoResult<(PackageSet<'a>, Resolve)> {
-    let features = features.iter().flat_map(|s| {
-        s.split_whitespace()
-    }).map(|s| s.to_string()).collect::<Vec<String>>();
-
-    let mut registry = PackageRegistry::new(ws.config())?;
-
-    if let Some(source) = source {
-        if let Some(root_package) = ws.current_opt() {
-            registry.add_preloaded(root_package.package_id().source_id(), source);
-        }
-    }
-
-    // First, resolve the root_package's *listed* dependencies, as well as
-    // downloading and updating all remotes and such.
-    let resolve = ops::resolve_ws(&mut registry, ws)?;
-
-    // Second, resolve with precisely what we're doing. Filter out
-    // transitive dependencies if necessary, specify features, handle
-    // overrides, etc.
-    let _p = profile::start("resolving w/ overrides...");
-
-    add_overrides(&mut registry, ws)?;
-
-    let method = if all_features {
-        Method::Everything
-    } else {
-        Method::Required {
-            dev_deps: true, // TODO: remove this option?
-            features: &features,
-            uses_default_features: !no_default_features,
-        }
-    };
-
-    let resolved_with_overrides =
-            ops::resolve_with_previous(&mut registry, ws,
-                                            method, Some(&resolve), None,
-                                            &specs)?;
-
-    for &(ref replace_spec, _) in ws.root_replace() {
-        if !resolved_with_overrides.replacements().keys().any(|r| replace_spec.matches(r)) {
-            ws.config().shell().warn(
-                format!("package replacement is not used: {}", replace_spec)
-            )?
-        }
-    }
-
-    let packages = ops::get_resolved_packages(&resolved_with_overrides,
-                                              registry);
-
-    Ok((packages, resolved_with_overrides))
-}
-
 pub fn compile_ws<'a>(ws: &Workspace<'a>,
                       source: Option<Box<Source + 'a>>,
                       options: &CompileOptions<'a>)
@@ -203,12 +141,12 @@ pub fn compile_ws<'a>(ws: &Workspace<'a>,
     let profiles = ws.profiles();
 
     let specs = spec.into_package_id_specs(ws)?;
-    let resolve = resolve_dependencies(ws,
-                                       source,
-                                       features,
-                                       all_features,
-                                       no_default_features,
-                                       &specs)?;
+    let resolve = ops::resolve_dependencies(ws,
+                                            source,
+                                            features,
+                                            all_features,
+                                            no_default_features,
+                                            &specs)?;
     let (packages, resolve_with_overrides) = resolve;
 
     let mut pkgids = Vec::new();
@@ -437,35 +375,6 @@ fn generate_targets<'a>(pkg: &'a Package,
             Ok(targets)
         }
     }
-}
-
-/// Read the `paths` configuration variable to discover all path overrides that
-/// have been configured.
-fn add_overrides<'a>(registry: &mut PackageRegistry<'a>,
-                     ws: &Workspace<'a>) -> CargoResult<()> {
-    let paths = match ws.config().get_list("paths")? {
-        Some(list) => list,
-        None => return Ok(())
-    };
-
-    let paths = paths.val.iter().map(|&(ref s, ref p)| {
-        // The path listed next to the string is the config file in which the
-        // key was located, so we want to pop off the `.cargo/config` component
-        // to get the directory containing the `.cargo` folder.
-        (p.parent().unwrap().parent().unwrap().join(s), p)
-    });
-
-    for (path, definition) in paths {
-        let id = SourceId::for_path(&path)?;
-        let mut source = PathSource::new_recursive(&path, &id, ws.config());
-        source.update().chain_error(|| {
-            human(format!("failed to update path override `{}` \
-                           (defined in `{}`)", path.display(),
-                          definition.display()))
-        })?;
-        registry.add_override(&id, Box::new(source));
-    }
-    Ok(())
 }
 
 /// Parse all config files to learn about build configuration. Currently

--- a/src/cargo/ops/cargo_fetch.rs
+++ b/src/cargo/ops/cargo_fetch.rs
@@ -1,22 +1,12 @@
-use core::registry::PackageRegistry;
-use core::{PackageId, Resolve, PackageSet, Workspace};
+use core::{Resolve, PackageSet, Workspace};
 use ops;
 use util::CargoResult;
 
 /// Executes `cargo fetch`.
 pub fn fetch<'a>(ws: &Workspace<'a>) -> CargoResult<(Resolve, PackageSet<'a>)> {
-    let mut registry = PackageRegistry::new(ws.config())?;
-    let resolve = ops::resolve_ws(&mut registry, ws)?;
-    let packages = get_resolved_packages(&resolve, registry);
+    let (packages, resolve) = ops::resolve_ws(ws)?;
     for id in resolve.iter() {
         packages.get(id)?;
     }
     Ok((resolve, packages))
-}
-
-pub fn get_resolved_packages<'a>(resolve: &Resolve,
-                                 registry: PackageRegistry<'a>)
-                                 -> PackageSet<'a> {
-    let ids: Vec<PackageId> = resolve.iter().cloned().collect();
-    registry.get(&ids)
 }

--- a/src/cargo/ops/cargo_install.rs
+++ b/src/cargo/ops/cargo_install.rs
@@ -57,7 +57,7 @@ pub fn install(root: Option<&str>,
     let root = resolve_root(root, config)?;
     let map = SourceConfigMap::new(config)?;
     let (pkg, source) = if source_id.is_git() {
-        select_pkg(GitSource::new(source_id, config), source_id,
+        select_pkg(GitSource::new(source_id, config),
                    krate, vers, config, &mut |git| git.read_packages())?
     } else if source_id.is_path() {
         let path = source_id.url().to_file_path().ok()
@@ -69,11 +69,10 @@ pub fn install(root: Option<&str>,
                            specify an alternate source", path.display()))
         })?;
         select_pkg(PathSource::new(&path, source_id, config),
-                   source_id, krate, vers, config,
-                   &mut |path| path.read_packages())?
+                   krate, vers, config, &mut |path| path.read_packages())?
     } else {
         select_pkg(map.load(source_id)?,
-                   source_id, krate, vers, config,
+                   krate, vers, config,
                    &mut |_| Err(human("must specify a crate to install from \
                                        crates.io, or use --path or --git to \
                                        specify alternate source")))?
@@ -249,7 +248,6 @@ pub fn install(root: Option<&str>,
 }
 
 fn select_pkg<'a, T>(mut source: T,
-                     source_id: &SourceId,
                      name: Option<&str>,
                      vers: Option<&str>,
                      config: &Config,
@@ -280,7 +278,7 @@ fn select_pkg<'a, T>(mut source: T,
                 None => None,
             };
             let vers = vers.as_ref().map(|s| &**s);
-            let dep = Dependency::parse_no_deprecated(name, vers, source_id)?;
+            let dep = Dependency::parse_no_deprecated(name, vers, source.source_id())?;
             let deps = source.query(&dep)?;
             match deps.iter().map(|p| p.package_id()).max() {
                 Some(pkgid) => {
@@ -291,7 +289,7 @@ fn select_pkg<'a, T>(mut source: T,
                     let vers_info = vers.map(|v| format!(" with version `{}`", v))
                                         .unwrap_or(String::new());
                     Err(human(format!("could not find `{}` in `{}`{}", name,
-                                      source_id, vers_info)))
+                                      source.source_id(), vers_info)))
                 }
             }
         }

--- a/src/cargo/ops/cargo_install.rs
+++ b/src/cargo/ops/cargo_install.rs
@@ -92,7 +92,7 @@ pub fn install(root: Option<&str>,
     };
 
     let ws = match overidden_target_dir {
-        Some(dir) => Workspace::one(pkg, config, Some(dir))?,
+        Some(dir) => Workspace::ephemeral(pkg, config, Some(dir))?,
         None => Workspace::new(pkg.manifest_path(), config)?,
     };
     let pkg = ws.current()?;

--- a/src/cargo/ops/cargo_output_metadata.rs
+++ b/src/cargo/ops/cargo_output_metadata.rs
@@ -44,7 +44,7 @@ fn metadata_no_deps(ws: &Workspace,
 fn metadata_full(ws: &Workspace,
                  opt: &OutputMetadataOptions) -> CargoResult<ExportInfo> {
     let specs = Packages::All.into_package_id_specs(ws)?;
-    let deps = ops::resolve_dependencies(ws,
+    let deps = ops::resolve_ws_precisely(ws,
                                          None,
                                          &opt.features,
                                          opt.all_features,

--- a/src/cargo/ops/cargo_package.rs
+++ b/src/cargo/ops/cargo_package.rs
@@ -283,7 +283,7 @@ fn run_verify(ws: &Workspace, tar: &File, opts: &PackageOpts) -> CargoResult<()>
     let new_pkg = Package::new(new_manifest, &manifest_path);
 
     // Now that we've rewritten all our path dependencies, compile it!
-    let ws = Workspace::one(new_pkg, config, None)?;
+    let ws = Workspace::ephemeral(new_pkg, config, None)?;
     ops::compile_ws(&ws, None, &ops::CompileOptions {
         config: config,
         jobs: opts.jobs,

--- a/src/cargo/ops/mod.rs
+++ b/src/cargo/ops/mod.rs
@@ -20,7 +20,7 @@ pub use self::registry::{registry_login, search, http_proxy_exists, http_handle}
 pub use self::registry::{modify_owners, yank, OwnersOptions, PublishOpts};
 pub use self::cargo_fetch::fetch;
 pub use self::cargo_pkgid::pkgid;
-pub use self::resolve::{resolve_ws, resolve_dependencies, resolve_with_previous};
+pub use self::resolve::{resolve_ws, resolve_ws_precisely, resolve_with_previous};
 pub use self::cargo_output_metadata::{output_metadata, OutputMetadataOptions, ExportInfo};
 
 mod cargo_clean;

--- a/src/cargo/ops/mod.rs
+++ b/src/cargo/ops/mod.rs
@@ -18,7 +18,7 @@ pub use self::cargo_package::{package, PackageOpts};
 pub use self::registry::{publish, registry_configuration, RegistryConfig};
 pub use self::registry::{registry_login, search, http_proxy_exists, http_handle};
 pub use self::registry::{modify_owners, yank, OwnersOptions, PublishOpts};
-pub use self::cargo_fetch::{fetch, get_resolved_packages};
+pub use self::cargo_fetch::fetch;
 pub use self::cargo_pkgid::pkgid;
 pub use self::resolve::{resolve_ws, resolve_dependencies, resolve_with_previous};
 pub use self::cargo_output_metadata::{output_metadata, OutputMetadataOptions, ExportInfo};

--- a/src/cargo/ops/mod.rs
+++ b/src/cargo/ops/mod.rs
@@ -1,5 +1,5 @@
 pub use self::cargo_clean::{clean, CleanOptions};
-pub use self::cargo_compile::{compile, compile_ws, resolve_dependencies, CompileOptions};
+pub use self::cargo_compile::{compile, compile_ws, CompileOptions};
 pub use self::cargo_compile::{CompileFilter, CompileMode, MessageFormat, Packages};
 pub use self::cargo_read_manifest::{read_manifest,read_package,read_packages};
 pub use self::cargo_rustc::{compile_targets, Compilation, Kind, Unit};
@@ -20,7 +20,7 @@ pub use self::registry::{registry_login, search, http_proxy_exists, http_handle}
 pub use self::registry::{modify_owners, yank, OwnersOptions, PublishOpts};
 pub use self::cargo_fetch::{fetch, get_resolved_packages};
 pub use self::cargo_pkgid::pkgid;
-pub use self::resolve::{resolve_ws, resolve_with_previous};
+pub use self::resolve::{resolve_ws, resolve_dependencies, resolve_with_previous};
 pub use self::cargo_output_metadata::{output_metadata, OutputMetadataOptions, ExportInfo};
 
 mod cargo_clean;

--- a/src/cargo/ops/resolve.rs
+++ b/src/cargo/ops/resolve.rs
@@ -7,7 +7,7 @@ use sources::PathSource;
 use ops;
 use util::{profile, human, CargoResult, ChainError};
 
-/// Resolve all dependencies for the specified `package` using the previous
+/// Resolve all dependencies for the workspace using the previous
 /// lockfile as a guide if present.
 ///
 /// This function will also write the result of resolution as a new
@@ -19,7 +19,9 @@ pub fn resolve_ws<'a>(ws: &Workspace<'a>) -> CargoResult<(PackageSet<'a>, Resolv
     Ok((packages, resolve))
 }
 
-pub fn resolve_dependencies<'a>(ws: &Workspace<'a>,
+/// Resolves dependencies for some packages of the workspace,
+/// taking into account `paths` overrides and activated features.
+pub fn resolve_ws_precisely<'a>(ws: &Workspace<'a>,
                                 source: Option<Box<Source + 'a>>,
                                 features: &[String],
                                 all_features: bool,

--- a/src/cargo/ops/resolve.rs
+++ b/src/cargo/ops/resolve.rs
@@ -34,13 +34,11 @@ pub fn resolve_ws_precisely<'a>(ws: &Workspace<'a>,
 
     let mut registry = PackageRegistry::new(ws.config())?;
 
-    let mut write_lockfile = true;
+    // Avoid writing a lockfile if we are `cargo install`ing a non local package.
+    let write_lockfile = source.is_none() || ws.current_opt().is_none();
+
     if let Some(source) = source {
-        if let Some(root_package) = ws.current_opt() {
-            // Avoid writing a lockfile if we are `cargo install`ing a non local package.
-            write_lockfile = false;
-            registry.add_preloaded(root_package.package_id().source_id(), source);
-        }
+        registry.add_preloaded(source);
     }
 
     // First, resolve the root_package's *listed* dependencies, as well as
@@ -265,7 +263,7 @@ fn add_overrides<'a>(registry: &mut PackageRegistry<'a>,
                            (defined in `{}`)", path.display(),
                           definition.display()))
         })?;
-        registry.add_override(&id, Box::new(source));
+        registry.add_override(Box::new(source));
     }
     Ok(())
 }

--- a/src/cargo/sources/directory.rs
+++ b/src/cargo/sources/directory.rs
@@ -13,7 +13,7 @@ use util::{CargoResult, human, ChainError, Config, Sha256};
 use util::paths;
 
 pub struct DirectorySource<'cfg> {
-    id: SourceId,
+    source_id: SourceId,
     root: PathBuf,
     packages: HashMap<PackageId, (Package, Checksum)>,
     config: &'cfg Config,
@@ -29,7 +29,7 @@ impl<'cfg> DirectorySource<'cfg> {
     pub fn new(path: &Path, id: &SourceId, config: &'cfg Config)
                -> DirectorySource<'cfg> {
         DirectorySource {
-            id: id.clone(),
+            source_id: id.clone(),
             root: path.to_path_buf(),
             config: config,
             packages: HashMap::new(),
@@ -57,6 +57,10 @@ impl<'cfg> Registry for DirectorySource<'cfg> {
 }
 
 impl<'cfg> Source for DirectorySource<'cfg> {
+    fn source_id(&self) -> &SourceId {
+        &self.source_id
+    }
+
     fn update(&mut self) -> CargoResult<()> {
         self.packages.clear();
         let entries = self.root.read_dir().chain_error(|| {
@@ -67,9 +71,7 @@ impl<'cfg> Source for DirectorySource<'cfg> {
         for entry in entries {
             let entry = entry?;
             let path = entry.path();
-            let mut src = PathSource::new(&path,
-                                          &self.id,
-                                          self.config);
+            let mut src = PathSource::new(&path, &self.source_id, self.config);
             src.update()?;
             let pkg = src.root_package()?;
 

--- a/src/cargo/sources/git/source.rs
+++ b/src/cargo/sources/git/source.rs
@@ -122,6 +122,10 @@ impl<'cfg> Registry for GitSource<'cfg> {
 }
 
 impl<'cfg> Source for GitSource<'cfg> {
+    fn source_id(&self) -> &SourceId {
+        &self.source_id
+    }
+
     fn update(&mut self) -> CargoResult<()> {
         let lock = self.config.git_path()
             .open_rw(".cargo-lock-git", self.config, "the git checkouts")?;

--- a/src/cargo/sources/path.rs
+++ b/src/cargo/sources/path.rs
@@ -12,7 +12,7 @@ use util::{self, CargoResult, internal, internal_error, human, ChainError};
 use util::Config;
 
 pub struct PathSource<'cfg> {
-    id: SourceId,
+    source_id: SourceId,
     path: PathBuf,
     updated: bool,
     packages: Vec<Package>,
@@ -28,7 +28,7 @@ impl<'cfg> PathSource<'cfg> {
     pub fn new(path: &Path, id: &SourceId, config: &'cfg Config)
                -> PathSource<'cfg> {
         PathSource {
-            id: id.clone(),
+            source_id: id.clone(),
             path: path.to_path_buf(),
             updated: false,
             packages: Vec::new(),
@@ -68,11 +68,10 @@ impl<'cfg> PathSource<'cfg> {
         if self.updated {
             Ok(self.packages.clone())
         } else if self.recursive {
-            ops::read_packages(&self.path, &self.id, self.config)
+            ops::read_packages(&self.path, &self.source_id, self.config)
         } else {
             let path = self.path.join("Cargo.toml");
-            let (pkg, _) = ops::read_package(&path, &self.id,
-                                                  self.config)?;
+            let (pkg, _) = ops::read_package(&path, &self.source_id, self.config)?;
             Ok(vec![pkg])
         }
     }
@@ -324,6 +323,10 @@ impl<'cfg> Registry for PathSource<'cfg> {
 }
 
 impl<'cfg> Source for PathSource<'cfg> {
+    fn source_id(&self) -> &SourceId {
+        &self.source_id
+    }
+
     fn update(&mut self) -> CargoResult<()> {
         if !self.updated {
             let packages = self.read_packages()?;

--- a/src/cargo/sources/registry/mod.rs
+++ b/src/cargo/sources/registry/mod.rs
@@ -337,6 +337,10 @@ impl<'cfg> Registry for RegistrySource<'cfg> {
 }
 
 impl<'cfg> Source for RegistrySource<'cfg> {
+    fn source_id(&self) -> &SourceId {
+        &self.source_id
+    }
+
     fn update(&mut self) -> CargoResult<()> {
         // If we have an imprecise version then we don't know what we're going
         // to look for, so we always attempt to perform an update here.

--- a/src/cargo/sources/replaced.rs
+++ b/src/cargo/sources/replaced.rs
@@ -33,6 +33,10 @@ impl<'cfg> Registry for ReplacedSource<'cfg> {
 }
 
 impl<'cfg> Source for ReplacedSource<'cfg> {
+    fn source_id(&self) -> &SourceId {
+        &self.to_replace
+    }
+
     fn update(&mut self) -> CargoResult<()> {
         self.inner.update().chain_error(|| {
             human(format!("failed to update replaced source `{}`",


### PR DESCRIPTION
This moves `resolve_dependencies` function from `compile.rs` into the `resolve.rs`, where it more reasonably belongs. 