### PR TITLE
Only gitignore the top level target directory for 'cargo new'

### DIFF
--- a/src/cargo/ops/cargo_new.rs
+++ b/src/cargo/ops/cargo_new.rs
@@ -370,7 +370,7 @@ fn mk(config: &Config, opts: &MkOptions) -> CargoResult<()> {
     let path = opts.path;
     let name = opts.name;
     let cfg = global_config(config)?;
-    let mut ignore = "target\n".to_string();
+    let mut ignore = "/target\n".to_string();
     let in_existing_vcs_repo = existing_vcs_repo(path.parent().unwrap(), config.cwd());
     if !opts.bin {
         ignore.push_str("Cargo.lock\n");


### PR DESCRIPTION
This modifies the default `.gitignore` for new projects to ignore only the `target` folder in the crate root.

Without this, you cannot have a `target/mod.rs` module.

This will also mean that projects with crate dependencies in the same repository will have their `target` directories recognised by version control. In these cases, the projects should be using workspaces.