### PR TITLE
Use an older visual studio for 1.14

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,6 +4,7 @@ environment:
     BITS: 64
     CFG_DISABLE_CROSS_TESTS: 1
     MAKE_TARGETS: test-unit-x86_64-pc-windows-gnu
+    RUSTUP_TARGET: x86_64-pc-windows-msvc
   - TARGET: i686-pc-windows-gnu
     BITS: 32
     MINGW_URL: https://s3.amazonaws.com/rust-lang-ci
@@ -11,17 +12,20 @@ environment:
     MINGW_DIR: mingw32
     CFG_DISABLE_CROSS_TESTS: 1
     MAKE_TARGETS: test-unit-i686-pc-windows-gnu
+    RUSTUP_TARGET: x86_64-pc-windows-msvc
   - TARGET: i686-pc-windows-msvc
     BITS: 32
     MAKE_TARGETS: test-unit-i686-pc-windows-msvc
     CFG_DISABLE_CROSS_TESTS: 1
     ALLOW_PR: 1
     ARCH: x86
+    RUSTUP_TARGET: i686-pc-windows-msvc
   - TARGET: x86_64-pc-windows-msvc
-    OTHER_TARGET: i686-pc-windows-msvc
+    CFG_DISABLE_CROSS_TESTS: 1
     BITS: 64
     MAKE_TARGETS: test-unit-x86_64-pc-windows-msvc
     ARCH: amd64
+    RUSTUP_TARGET: x86_64-pc-windows-msvc
 
 install:
   - set PATH=C:\msys64\mingw%BITS%\bin;C:\msys64\usr\bin;%PATH%
@@ -33,10 +37,9 @@ install:
 
   # FIXME(#3394) use master rustup
   - curl -sSfO https://static.rust-lang.org/rustup/archive/0.6.5/x86_64-pc-windows-msvc/rustup-init.exe
-  - rustup-init.exe -y --default-host x86_64-pc-windows-msvc
+  - rustup-init.exe -y --default-host %RUSTUP_TARGET%
   - set PATH=%PATH%;C:\Users\appveyor\.cargo\bin
-  - if NOT "%TARGET%" == "x86_64-pc-windows-msvc" rustup target add %TARGET%
-  - if defined OTHER_TARGET rustup target add %OTHER_TARGET%
+  - if NOT "%TARGET%" == "%RUSTUP_TARGET%" rustup target add %TARGET%
   - rustc -V
   - cargo -V
   - git submodule update --init

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,16 +16,20 @@ environment:
     MAKE_TARGETS: test-unit-i686-pc-windows-msvc
     CFG_DISABLE_CROSS_TESTS: 1
     ALLOW_PR: 1
+    ARCH: x86
   - TARGET: x86_64-pc-windows-msvc
     OTHER_TARGET: i686-pc-windows-msvc
     BITS: 64
     MAKE_TARGETS: test-unit-x86_64-pc-windows-msvc
+    ARCH: amd64
 
 install:
   - set PATH=C:\msys64\mingw%BITS%\bin;C:\msys64\usr\bin;%PATH%
   - if defined MINGW_URL appveyor DownloadFile %MINGW_URL%/%MINGW_ARCHIVE%
   - if defined MINGW_URL 7z x -y %MINGW_ARCHIVE% > nul
   - if defined MINGW_URL set PATH=%CD%\%MINGW_DIR%\bin;C:\msys64\usr\bin;%PATH%
+
+  - if defined ARCH call "C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\vcvarsall.bat" %ARCH%
 
   # FIXME(#3394) use master rustup
   - curl -sSfO https://static.rust-lang.org/rustup/archive/0.6.5/x86_64-pc-windows-msvc/rustup-init.exe


### PR DESCRIPTION
Cargo built for Rust 1.13.0 was linked with Visual Studio 2012. Cargo was also
compiled against `msvcrt.dll`, with C code compiling with `/MD`. In Rust 1.14.0
C code is compiled with the same flags and Cargo's also linked against
`msvcrt.dll`. In 1.14.0, however, Cargo is linked with Visual Studio 2015,
presumably the default on AppVeyor. This introduced a dependency on the VS
redistributables which was not intended.

This dependency will be fixed in Rust 1.15.0 where cargo links to `libcmt` and
compiles C code with `/MT`. For the 1.14.0 branch this is taking the strategy of
reverting the build environment to where it previously was, using Visual Studio
2012 instead of Visual Studio 2015. This will hopefully drop the dependency on
the redistributables and restore the same list of dependencies as before.