### PR TITLE
cargo check: use --emit=metadata rather than --crate-type=metadata

### DIFF
--- a/src/cargo/util/cfg.rs
+++ b/src/cargo/util/cfg.rs
@@ -44,7 +44,7 @@ impl FromStr for Cfg {
         let mut p = Parser::new(s);
         let e = p.cfg()?;
         if p.t.next().is_some() {
-            bail!("malformed cfg value or key/value pair")
+            bail!("malformed cfg value or key/value pair: `{}`", s)
         }
         Ok(e)
     }

--- a/tests/build-lib.rs
+++ b/tests/build-lib.rs
@@ -7,10 +7,10 @@ use hamcrest::{assert_that};
 fn verbose_output_for_lib(p: &ProjectBuilder) -> String {
     format!("\
 [COMPILING] {name} v{version} ({url})
-[RUNNING] `rustc --crate-name {name} src[/]lib.rs --crate-type lib -g \
+[RUNNING] `rustc --crate-name {name} src[/]lib.rs --crate-type lib \
+        --emit=dep-info,link -g \
         -C metadata=[..] \
         --out-dir [..] \
-        --emit=dep-info,link \
         -L dependency={dir}[/]target[/]debug[/]deps`
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 ",

--- a/tests/build-script.rs
+++ b/tests/build-script.rs
@@ -765,19 +765,22 @@ fn build_cmd_with_a_build_cmd() {
 [COMPILING] a v0.5.0 (file://[..])
 [RUNNING] `rustc [..] a[/]build.rs [..] --extern b=[..]`
 [RUNNING] `[..][/]a-[..][/]build-script-build`
-[RUNNING] `rustc --crate-name a [..]lib.rs --crate-type lib -g \
+[RUNNING] `rustc --crate-name a [..]lib.rs --crate-type lib \
+    --emit=dep-info,link -g \
     -C metadata=[..] \
-    --out-dir [..]target[/]debug[/]deps --emit=dep-info,link \
+    --out-dir [..]target[/]debug[/]deps \
     -L [..]target[/]debug[/]deps`
 [COMPILING] foo v0.5.0 (file://[..])
 [RUNNING] `rustc --crate-name build_script_build build.rs --crate-type bin \
-    -g -C metadata=[..] --out-dir [..] --emit=dep-info,link \
+    --emit=dep-info,link \
+    -g -C metadata=[..] --out-dir [..] \
     -L [..]target[/]debug[/]deps \
     --extern a=[..]liba[..].rlib`
 [RUNNING] `[..][/]foo-[..][/]build-script-build`
-[RUNNING] `rustc --crate-name foo [..]lib.rs --crate-type lib -g \
+[RUNNING] `rustc --crate-name foo [..]lib.rs --crate-type lib \
+    --emit=dep-info,link -g \
     -C metadata=[..] \
-    --out-dir [..] --emit=dep-info,link \
+    --out-dir [..] \
     -L [..]target[/]debug[/]deps`
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 "));

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -794,21 +794,20 @@ fn cargo_default_env_metadata_env_var() {
                 execs().with_status(0).with_stderr(&format!("\
 [COMPILING] bar v0.0.1 ({url}/bar)
 [RUNNING] `rustc --crate-name bar bar[/]src[/]lib.rs --crate-type dylib \
+        --emit=dep-info,link \
         -C prefer-dynamic -g \
         -C metadata=[..] \
         --out-dir [..] \
-        --emit=dep-info,link \
         -L dependency={dir}[/]target[/]debug[/]deps`
 [COMPILING] foo v0.0.1 ({url})
-[RUNNING] `rustc --crate-name foo src[/]lib.rs --crate-type lib -g \
+[RUNNING] `rustc --crate-name foo src[/]lib.rs --crate-type lib \
+        --emit=dep-info,link -g \
         -C metadata=[..] \
         -C extra-filename=[..] \
         --out-dir [..] \
-        --emit=dep-info,link \
         -L dependency={dir}[/]target[/]debug[/]deps \
         --extern bar={dir}[/]target[/]debug[/]deps[/]{prefix}bar{suffix}`
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
-",
+[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]",
 dir = p.root().display(),
 url = p.url(),
 prefix = env::consts::DLL_PREFIX,
@@ -822,17 +821,17 @@ suffix = env::consts::DLL_SUFFIX,
                 execs().with_status(0).with_stderr(&format!("\
 [COMPILING] bar v0.0.1 ({url}/bar)
 [RUNNING] `rustc --crate-name bar bar[/]src[/]lib.rs --crate-type dylib \
+        --emit=dep-info,link \
         -C prefer-dynamic -g \
         -C metadata=[..] \
         --out-dir [..] \
-        --emit=dep-info,link \
         -L dependency={dir}[/]target[/]debug[/]deps`
 [COMPILING] foo v0.0.1 ({url})
-[RUNNING] `rustc --crate-name foo src[/]lib.rs --crate-type lib -g \
+[RUNNING] `rustc --crate-name foo src[/]lib.rs --crate-type lib \
+        --emit=dep-info,link -g \
         -C metadata=[..] \
         -C extra-filename=[..] \
         --out-dir [..] \
-        --emit=dep-info,link \
         -L dependency={dir}[/]target[/]debug[/]deps \
         --extern bar={dir}[/]target[/]debug[/]deps[/]{prefix}bar-[..]{suffix}`
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
@@ -1142,11 +1141,11 @@ fn lto_build() {
                 execs().with_status(0).with_stderr(&format!("\
 [COMPILING] test v0.0.0 ({url})
 [RUNNING] `rustc --crate-name test src[/]main.rs --crate-type bin \
+        --emit=dep-info,link \
         -C opt-level=3 \
         -C lto \
         -C metadata=[..] \
         --out-dir {dir}[/]target[/]release[/]deps \
-        --emit=dep-info,link \
         -L dependency={dir}[/]target[/]release[/]deps`
 [FINISHED] release [optimized] target(s) in [..]
 ",
@@ -1170,10 +1169,10 @@ fn verbose_build() {
     assert_that(p.cargo_process("build").arg("-v"),
                 execs().with_status(0).with_stderr(&format!("\
 [COMPILING] test v0.0.0 ({url})
-[RUNNING] `rustc --crate-name test src[/]lib.rs --crate-type lib -g \
+[RUNNING] `rustc --crate-name test src[/]lib.rs --crate-type lib \
+        --emit=dep-info,link -g \
         -C metadata=[..] \
         --out-dir [..] \
-        --emit=dep-info,link \
         -L dependency={dir}[/]target[/]debug[/]deps`
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 ",
@@ -1198,10 +1197,10 @@ fn verbose_release_build() {
                 execs().with_status(0).with_stderr(&format!("\
 [COMPILING] test v0.0.0 ({url})
 [RUNNING] `rustc --crate-name test src[/]lib.rs --crate-type lib \
+        --emit=dep-info,link \
         -C opt-level=3 \
         -C metadata=[..] \
         --out-dir [..] \
-        --emit=dep-info,link \
         -L dependency={dir}[/]target[/]release[/]deps`
 [FINISHED] release [optimized] target(s) in [..]
 ",
@@ -1241,18 +1240,19 @@ fn verbose_release_build_deps() {
                 execs().with_status(0).with_stderr(&format!("\
 [COMPILING] foo v0.0.0 ({url}/foo)
 [RUNNING] `rustc --crate-name foo foo[/]src[/]lib.rs \
-        --crate-type dylib --crate-type rlib -C prefer-dynamic \
+        --crate-type dylib --crate-type rlib \
+        --emit=dep-info,link \
+        -C prefer-dynamic \
         -C opt-level=3 \
         -C metadata=[..] \
         --out-dir [..] \
-        --emit=dep-info,link \
         -L dependency={dir}[/]target[/]release[/]deps`
 [COMPILING] test v0.0.0 ({url})
 [RUNNING] `rustc --crate-name test src[/]lib.rs --crate-type lib \
+        --emit=dep-info,link \
         -C opt-level=3 \
         -C metadata=[..] \
         --out-dir [..] \
-        --emit=dep-info,link \
         -L dependency={dir}[/]target[/]release[/]deps \
         --extern foo={dir}[/]target[/]release[/]deps[/]{prefix}foo{suffix} \
         --extern foo={dir}[/]target[/]release[/]deps[/]libfoo.rlib`

--- a/tests/check.rs
+++ b/tests/check.rs
@@ -244,7 +244,7 @@ fn issue_3418() {
 
     assert_that(foo.cargo_process("check").arg("-v"),
                 execs().with_status(0)
-                       .with_stderr_does_not_contain("--crate-type lib"));
+                       .with_stderr_contains("[..] --emit=dep-info,metadata [..]"));
 }
 
 // Some weirdness that seems to be caused by a crate being built as well as

--- a/tests/cross-compile.rs
+++ b/tests/cross-compile.rs
@@ -357,10 +357,10 @@ fn linker_and_ar() {
                 execs().with_status(101)
                        .with_stderr_contains(&format!("\
 [COMPILING] foo v0.5.0 ({url})
-[RUNNING] `rustc --crate-name foo src[/]foo.rs --crate-type bin -g \
+[RUNNING] `rustc --crate-name foo src[/]foo.rs --crate-type bin \
+    --emit=dep-info,link -g \
     -C metadata=[..] \
     --out-dir {dir}[/]target[/]{target}[/]debug[/]deps \
-    --emit=dep-info,link \
     --target {target} \
     -C ar=my-ar-tool -C linker=my-linker-tool \
     -L dependency={dir}[/]target[/]{target}[/]debug[/]deps \

--- a/tests/profiles.rs
+++ b/tests/profiles.rs
@@ -28,12 +28,12 @@ fn profile_overrides() {
                 execs().with_status(0).with_stderr(&format!("\
 [COMPILING] test v0.0.0 ({url})
 [RUNNING] `rustc --crate-name test src[/]lib.rs --crate-type lib \
+        --emit=dep-info,link \
         -C opt-level=1 \
         -C debug-assertions=on \
         -C metadata=[..] \
         -C rpath \
         --out-dir [..] \
-        --emit=dep-info,link \
         -L dependency={dir}[/]target[/]debug[/]deps`
 [FINISHED] debug [optimized] target(s) in [..]
 ",
@@ -61,10 +61,10 @@ fn opt_level_override_0() {
                 execs().with_status(0).with_stderr(&format!("\
 [COMPILING] test v0.0.0 ({url})
 [RUNNING] `rustc --crate-name test src[/]lib.rs --crate-type lib \
+        --emit=dep-info,link \
         -g \
         -C metadata=[..] \
         --out-dir [..] \
-        --emit=dep-info,link \
         -L dependency={dir}[/]target[/]debug[/]deps`
 [FINISHED] [..] target(s) in [..]
 ",
@@ -91,12 +91,12 @@ fn check_opt_level_override(profile_level: &str, rustc_level: &str) {
                 execs().with_status(0).with_stderr(&format!("\
 [COMPILING] test v0.0.0 ({url})
 [RUNNING] `rustc --crate-name test src[/]lib.rs --crate-type lib \
+        --emit=dep-info,link \
         -C opt-level={level} \
         -g \
         -C debug-assertions=on \
         -C metadata=[..] \
         --out-dir [..] \
-        --emit=dep-info,link \
         -L dependency={dir}[/]target[/]debug[/]deps`
 [FINISHED] [..] target(s) in [..]
 ",
@@ -160,20 +160,21 @@ fn top_level_overrides_deps() {
                 execs().with_status(0).with_stderr(&format!("\
 [COMPILING] foo v0.0.0 ({url}/foo)
 [RUNNING] `rustc --crate-name foo foo[/]src[/]lib.rs \
-        --crate-type dylib --crate-type rlib -C prefer-dynamic \
+        --crate-type dylib --crate-type rlib \
+        --emit=dep-info,link \
+        -C prefer-dynamic \
         -C opt-level=1 \
         -g \
         -C metadata=[..] \
         --out-dir {dir}[/]target[/]release[/]deps \
-        --emit=dep-info,link \
         -L dependency={dir}[/]target[/]release[/]deps`
 [COMPILING] test v0.0.0 ({url})
 [RUNNING] `rustc --crate-name test src[/]lib.rs --crate-type lib \
+        --emit=dep-info,link \
         -C opt-level=1 \
         -g \
         -C metadata=[..] \
         --out-dir [..] \
-        --emit=dep-info,link \
         -L dependency={dir}[/]target[/]release[/]deps \
         --extern foo={dir}[/]target[/]release[/]deps[/]\
                      {prefix}foo[..]{suffix} \

--- a/tests/run.rs
+++ b/tests/run.rs
@@ -417,17 +417,17 @@ fn example_with_release_flag() {
                        .with_stderr(&format!("\
 [COMPILING] bar v0.0.1 ({url}/bar)
 [RUNNING] `rustc --crate-name bar bar[/]src[/]bar.rs --crate-type lib \
+        --emit=dep-info,link \
         -C opt-level=3 \
         -C metadata=[..] \
         --out-dir {dir}[/]target[/]release[/]deps \
-        --emit=dep-info,link \
         -L dependency={dir}[/]target[/]release[/]deps`
 [COMPILING] foo v0.0.1 ({url})
 [RUNNING] `rustc --crate-name a examples[/]a.rs --crate-type bin \
+        --emit=dep-info,link \
         -C opt-level=3 \
         -C metadata=[..] \
         --out-dir {dir}[/]target[/]release[/]examples \
-        --emit=dep-info,link \
         -L dependency={dir}[/]target[/]release[/]deps \
          --extern bar={dir}[/]target[/]release[/]deps[/]libbar-[..].rlib`
 [FINISHED] release [optimized] target(s) in [..]
@@ -445,17 +445,17 @@ fast2"));
                        .with_stderr(&format!("\
 [COMPILING] bar v0.0.1 ({url}/bar)
 [RUNNING] `rustc --crate-name bar bar[/]src[/]bar.rs --crate-type lib \
+        --emit=dep-info,link \
         -g \
         -C metadata=[..] \
         --out-dir {dir}[/]target[/]debug[/]deps \
-        --emit=dep-info,link \
         -L dependency={dir}[/]target[/]debug[/]deps`
 [COMPILING] foo v0.0.1 ({url})
 [RUNNING] `rustc --crate-name a examples[/]a.rs --crate-type bin \
+        --emit=dep-info,link \
         -g \
         -C metadata=[..] \
         --out-dir {dir}[/]target[/]debug[/]examples \
-        --emit=dep-info,link \
         -L dependency={dir}[/]target[/]debug[/]deps \
          --extern bar={dir}[/]target[/]debug[/]deps[/]libbar-[..].rlib`
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]

--- a/tests/rustc.rs
+++ b/tests/rustc.rs
@@ -27,10 +27,10 @@ fn build_lib_for_foo() {
                 .with_status(0)
                 .with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({url})
-[RUNNING] `rustc --crate-name foo src[/]lib.rs --crate-type lib -g \
+[RUNNING] `rustc --crate-name foo src[/]lib.rs --crate-type lib \
+        --emit=dep-info,link -g \
         -C metadata=[..] \
         --out-dir [..] \
-        --emit=dep-info,link \
         -L dependency={dir}[/]target[/]debug[/]deps`
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 ", dir = p.root().display(), url = p.url())));
@@ -56,11 +56,11 @@ fn lib() {
                 .with_status(0)
                 .with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({url})
-[RUNNING] `rustc --crate-name foo src[/]lib.rs --crate-type lib -g \
+[RUNNING] `rustc --crate-name foo src[/]lib.rs --crate-type lib \
+        --emit=dep-info,link -g \
         -C debug-assertions=off \
         -C metadata=[..] \
         --out-dir [..] \
-        --emit=dep-info,link \
         -L dependency={dir}[/]target[/]debug[/]deps`
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 ", dir = p.root().display(), url = p.url())))
@@ -86,16 +86,16 @@ fn build_main_and_allow_unstable_options() {
                 .with_status(0)
                 .with_stderr(&format!("\
 [COMPILING] {name} v{version} ({url})
-[RUNNING] `rustc --crate-name {name} src[/]lib.rs --crate-type lib -g \
+[RUNNING] `rustc --crate-name {name} src[/]lib.rs --crate-type lib \
+        --emit=dep-info,link -g \
         -C metadata=[..] \
         --out-dir [..] \
-        --emit=dep-info,link \
         -L dependency={dir}[/]target[/]debug[/]deps`
-[RUNNING] `rustc --crate-name {name} src[/]main.rs --crate-type bin -g \
+[RUNNING] `rustc --crate-name {name} src[/]main.rs --crate-type bin \
+        --emit=dep-info,link -g \
         -C debug-assertions \
         -C metadata=[..] \
         --out-dir [..] \
-        --emit=dep-info,link \
         -L dependency={dir}[/]target[/]debug[/]deps \
         --extern {name}={dir}[/]target[/]debug[/]deps[/]lib{name}-[..].rlib`
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
@@ -151,10 +151,10 @@ fn build_with_args_to_one_of_multiple_binaries() {
                 .with_status(0)
                 .with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({url})
-[RUNNING] `rustc --crate-name foo src[/]lib.rs --crate-type lib -g \
+[RUNNING] `rustc --crate-name foo src[/]lib.rs --crate-type lib --emit=dep-info,link -g \
         -C metadata=[..] \
         --out-dir [..]`
-[RUNNING] `rustc --crate-name bar src[/]bin[/]bar.rs --crate-type bin -g \
+[RUNNING] `rustc --crate-name bar src[/]bin[/]bar.rs --crate-type bin --emit=dep-info,link -g \
         -C debug-assertions [..]`
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 ", url = p.url())));
@@ -207,10 +207,10 @@ fn build_with_args_to_one_of_multiple_tests() {
                 .with_status(0)
                 .with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({url})
-[RUNNING] `rustc --crate-name foo src[/]lib.rs --crate-type lib -g \
+[RUNNING] `rustc --crate-name foo src[/]lib.rs --crate-type lib --emit=dep-info,link -g \
         -C metadata=[..] \
         --out-dir [..]`
-[RUNNING] `rustc --crate-name bar tests[/]bar.rs -g \
+[RUNNING] `rustc --crate-name bar tests[/]bar.rs --emit=dep-info,link -g \
         -C debug-assertions [..]--test[..]`
 [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
 ", url = p.url())));


### PR DESCRIPTION
Requires https://github.com/rust-lang/rust/pull/38571 (don't land before that does)

r? @alexcrichton 