### PR TITLE
Add templates for Cargo.toml

### DIFF
--- a/src/bin/init.rs
+++ b/src/bin/init.rs
@@ -38,6 +38,7 @@ Options:
     --color WHEN        Coloring: auto, always, never
     --frozen            Require Cargo.lock and cache are up to date
     --locked            Require Cargo.lock is up to date
+    --template NAME     Specify a template for Cargo.toml
 ";
 
 pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {

--- a/src/bin/init.rs
+++ b/src/bin/init.rs
@@ -13,6 +13,7 @@ pub struct Options {
     arg_path: Option<String>,
     flag_name: Option<String>,
     flag_vcs: Option<ops::VersionControl>,
+    flag_template: Option<String>,
     flag_frozen: bool,
     flag_locked: bool,
 }
@@ -47,14 +48,15 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
                      options.flag_frozen,
                      options.flag_locked)?;
 
-    let Options { flag_bin, flag_lib, arg_path, flag_name, flag_vcs, .. } = options;
+    let Options { flag_bin, flag_lib, arg_path, flag_name, flag_vcs, flag_template, .. } = options;
 
     let tmp = &arg_path.unwrap_or(format!("."));
     let opts = ops::NewOptions::new(flag_vcs,
                                      flag_bin,
                                      flag_lib,
                                      tmp,
-                                     flag_name.as_ref().map(|s| s.as_ref()));
+                                     flag_name.as_ref().map(|s| s.as_ref()),
+                                     flag_template.as_ref().map(|s| s.as_ref()));
 
     let opts_lib = opts.lib;
     ops::init(opts, config)?;

--- a/src/bin/new.rs
+++ b/src/bin/new.rs
@@ -12,6 +12,7 @@ pub struct Options {
     flag_lib: bool,
     arg_path: String,
     flag_name: Option<String>,
+    flag_template: Option<String>,
     flag_vcs: Option<ops::VersionControl>,
     flag_frozen: bool,
     flag_locked: bool,
@@ -37,6 +38,7 @@ Options:
     --color WHEN        Coloring: auto, always, never
     --frozen            Require Cargo.lock and cache are up to date
     --locked            Require Cargo.lock is up to date
+    --template NAME     Specify a template for Cargo.toml
 ";
 
 pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
@@ -47,13 +49,14 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
                      options.flag_frozen,
                      options.flag_locked)?;
 
-    let Options { flag_bin, flag_lib, arg_path, flag_name, flag_vcs, .. } = options;
+    let Options { flag_bin, flag_lib, arg_path, flag_name, flag_vcs, flag_template, .. } = options;
 
     let opts = ops::NewOptions::new(flag_vcs,
                                     flag_bin,
                                     flag_lib,
                                     &arg_path,
-                                    flag_name.as_ref().map(|s| s.as_ref()));
+                                    flag_name.as_ref().map(|s| s.as_ref()),
+                                    flag_template.as_ref().map(|s| s.as_ref()));
 
     let opts_lib = opts.lib;
     ops::new(opts, config)?;

--- a/src/cargo/ops/cargo_new.rs
+++ b/src/cargo/ops/cargo_new.rs
@@ -288,13 +288,6 @@ pub fn new(opts: NewOptions, config: &Config) -> CargoResult<()> {
     let name = get_name(&path, &opts, config)?;
     check_name(name)?;
 
-    //let template_string: Result<&str> = opts.template.map_or(Ok(&""), |path| {
-    //    File::open(path).map(|file| {
-    //        let s = String::new();
-    //        file.read_to_string(&mut s).map(|_| &s)
-    //    })
-    //});
-
     let template_string = resolve_template_content(opts.template)?;
 
     let mkopts = MkOptions {


### PR DESCRIPTION
This PR addresses issue #3459.

## New features

This change would add a `--template NAME` option to the `new` and the `init` subcommand where you can specify some template, say `optimized`. Cargo then looks for a file `templates/optimized.toml` in your `.cargo` folder.

These may be the contents of a template file:

```toml
[dependencies]

[profile.release]
lto = true
```

This would create the following `Cargo.toml` file:

```rust
[package]
name = "helloworld"
version = "0.1.0"
authors = ["My Name", "Some other name"]

[dependencies]

[profile.release]
lto = true
```

If you don't specify a the template flag, the `Cargo.toml` stays the same as before.

## What was done already

* I've already managed to add this flag to the USAGE string (I didn't know about docopt so it took me a while to figure out how cargo does the parsing).
* A `resolve_template_content` function has been added
* The template content will be inserted in the `Cargo.toml`

## What has to be done

I'd need some help because I'm not very familiar with how cargo works internally.
Also, please tell me if my code is not idiomatic, I'm using Rust since a month :). 

I think there is still documentation that has to be updated (including the manpages).
Also, is there a string containing the path to the `.cargo` folder?
When the template file does not exist, I get `An unknown error occured`. Is there a simple way to just display the error without getting rid of the nice `?`-Syntax?
