### PR TITLE
Lift up workspace rlibs while building

### DIFF
--- a/src/cargo/ops/cargo_rustc/context.rs
+++ b/src/cargo/ops/cargo_rustc/context.rs
@@ -224,7 +224,7 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
 
             map.insert(crate_type.to_string(), Some((prefix.to_string(), suffix.to_string())));
         }
- 
+
         let cfg = if has_cfg {
             Some(try!(lines.map(Cfg::from_str).collect()))
         } else {
@@ -448,7 +448,8 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
         // we don't want to link it up.
         if src_dir.ends_with("deps") {
             // Don't lift up library dependencies
-            if self.ws.members().find(|&p| p != unit.pkg).is_some() && !unit.target.is_bin() {
+            if self.ws.members().find(|&p| p == unit.pkg).is_none() &&
+               !unit.target.is_bin() {
                 None
             } else {
                 Some((

--- a/tests/path.rs
+++ b/tests/path.rs
@@ -979,3 +979,34 @@ location searched: [..]
 version required: *
 "));
 }
+
+#[test]
+fn workspace_produces_rlib() {
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [project]
+            name = "top"
+            version = "0.5.0"
+            authors = []
+
+            [workspace]
+
+            [dependencies]
+            foo = { path = "foo" }
+        "#)
+        .file("src/lib.rs", "")
+        .file("foo/Cargo.toml", r#"
+            [project]
+            name = "foo"
+            version = "0.5.0"
+            authors = []
+        "#)
+        .file("foo/src/lib.rs", "");
+    p.build();
+
+    assert_that(p.cargo("build"), execs().with_status(0));
+
+    assert_that(&p.root().join("target/debug/libtop.rlib"), existing_file());
+    assert_that(&p.root().join("target/debug/libfoo.rlib"), existing_file());
+
+}


### PR DESCRIPTION
I think the condition here was slightly off from before, so invert it subtly to
get what we want, lifting up anything in a workspace or binaries otherwise.

Closes #3432