### PR TITLE
Use valid error number in test

### DIFF
--- a/tests/cargo.rs
+++ b/tests/cargo.rs
@@ -181,6 +181,6 @@ fn cargo_help() {
 
 #[test]
 fn explain() {
-    assert_that(cargo_process().arg("--explain").arg("E0001"),
+    assert_that(cargo_process().arg("--explain").arg("E0002"),
                 execs().with_status(0));
 }


### PR DESCRIPTION
This is needed to get https://github.com/rust-lang/rust/pull/38069 passing tests.