### PR TITLE
fix JSON error test expectation for lint changes in rust-lang/rust#38103

### DIFF
--- a/tests/build.rs
+++ b/tests/build.rs
@@ -11,7 +11,7 @@ use cargo::util::process;
 use cargotest::{is_nightly, rustc_host, sleep_ms};
 use cargotest::support::paths::{CargoPathExt,root};
 use cargotest::support::{ProjectBuilder};
-use cargotest::support::{project, execs, main_file, basic_bin_manifest};
+use cargotest::support::{project, execs, main_file, basic_bin_manifest, is_valid_json};
 use cargotest::support::registry::Package;
 use hamcrest::{assert_that, existing_file, is_not};
 use tempdir::TempDir;
@@ -2395,69 +2395,13 @@ fn compiler_json_error_format() {
         "#)
         .file("bar/src/lib.rs", r#"fn dead() {}"#);
 
-    assert_that(p.cargo_process("build").arg("-v")
-                    .arg("--message-format").arg("json"),
-                execs().with_status(0).with_json(r#"
-    {
-        "reason":"compiler-message",
-        "package_id":"bar 0.5.0 ([..])",
-        "target":{"kind":["lib"],"name":"bar","src_path":"[..]lib.rs"},
-        "message":{
-            "children":[],"code":null,"level":"warning","rendered":null,
-            "message":"function is never used: `dead`, #[warn(dead_code)] on by default",
-            "spans":[{
-                "byte_end":12,"byte_start":0,"column_end":13,"column_start":1,"expansion":null,
-                "file_name":"[..]","is_primary":true,"label":null,"line_end":1,"line_start":1,
-                "suggested_replacement":null,
-                "text":[{"highlight_end":13,"highlight_start":1,"text":"fn dead() {}"}]
-            }]
-        }
+    let output = p.cargo_process("build").arg("-v")
+        .arg("--message-format").arg("json").exec_with_output()
+        .expect("process should succeed").stdout;
+    let output_lines = output.split(|&c| c == ('\n' as u8)).filter(|l| l.len() != 0);
+    for line in output_lines {
+        assert_that(line, is_valid_json());
     }
-
-    {
-        "reason":"compiler-artifact",
-        "profile": {
-            "debug_assertions": true,
-            "debuginfo": true,
-            "opt_level": "0",
-            "test": false
-        },
-        "features": [],
-        "package_id":"bar 0.5.0 ([..])",
-        "target":{"kind":["lib"],"name":"bar","src_path":"[..]lib.rs"},
-        "filenames":["[..].rlib"]
-    }
-
-    {
-        "reason":"compiler-message",
-        "package_id":"foo 0.5.0 ([..])",
-        "target":{"kind":["bin"],"name":"foo","src_path":"[..]main.rs"},
-        "message":{
-            "children":[],"code":null,"level":"warning","rendered":null,
-            "message":"unused variable: `unused`, #[warn(unused_variables)] on by default",
-            "spans":[{
-                "byte_end":22,"byte_start":16,"column_end":23,"column_start":17,"expansion":null,
-                "file_name":"[..]","is_primary":true,"label":null,"line_end":1,"line_start":1,
-                "suggested_replacement":null,
-                "text":[{"highlight_end":23,"highlight_start":17,"text":"[..]"}]
-            }]
-        }
-    }
-
-    {
-        "reason":"compiler-artifact",
-        "package_id":"foo 0.5.0 ([..])",
-        "target":{"kind":["bin"],"name":"foo","src_path":"[..]main.rs"},
-        "profile": {
-            "debug_assertions": true,
-            "debuginfo": true,
-            "opt_level": "0",
-            "test": false
-        },
-        "features": [],
-        "filenames": ["[..]"]
-    }
-"#));
 }
 
 #[test]
@@ -2659,4 +2603,3 @@ fn build_all_member_dependency_same_name() {
                        [..] Compiling a v0.1.0 ([..])\n\
                        [..] Finished debug [unoptimized + debuginfo] target(s) in [..]\n"));
 }
-

--- a/tests/cargotest/support/mod.rs
+++ b/tests/cargotest/support/mod.rs
@@ -660,6 +660,32 @@ pub fn shell_writes<T: fmt::Display>(string: T) -> ShellWrites {
     ShellWrites { expected: string.to_string() }
 }
 
+#[derive(Debug, Clone)]
+pub struct IsValidJson {}
+
+impl fmt::Display for IsValidJson {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "valid JSON")
+    }
+}
+
+impl<'a> ham::Matcher<&'a [u8]> for IsValidJson {
+    fn matches(&self, actual: &[u8]) -> ham::MatchResult {
+        let actual_str = match str::from_utf8(actual) {
+            Ok(s) => s,
+            Err(e) => { return Err(e.description().to_owned()); }
+        };
+        Json::from_str(actual_str)
+            .and(Ok(()))
+            .map_err(|e| e.description().to_owned())
+    }
+}
+
+pub fn is_valid_json() -> IsValidJson {
+    IsValidJson {}
+}
+
+
 pub trait Tap {
     fn tap<F: FnOnce(&mut Self)>(self, callback: F) -> Self;
 }


### PR DESCRIPTION
[Appveyor CI pointed out](https://github.com/rust-lang/rust/pull/38103#issuecomment-271094552) that rust-lang/rust#38103 (which has been r+'d) breaks Cargo's `compiler_json_error_format`. I don't know if we have a procedure for coordinating these kinds of changes across repos in a way that CI understands, but ideally, this PR would land here in parallel with rust-lang/rust#38103 in the rust repo.