### PR TITLE
Don't filter deps before we have all info

### DIFF
--- a/src/cargo/ops/cargo_rustc/context.rs
+++ b/src/cargo/ops/cargo_rustc/context.rs
@@ -49,6 +49,7 @@ pub struct Context<'a, 'cfg: 'a> {
     host_info: TargetInfo,
     profiles: &'a Profiles,
     incremental_enabled: bool,
+    target_info_probed: bool,
 }
 
 #[derive(Clone, Default)]
@@ -87,6 +88,7 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
             resolve: resolve,
             packages: packages,
             config: config,
+            target_info_probed: false,
             target_info: TargetInfo::default(),
             host_info: TargetInfo::default(),
             compilation: Compilation::new(config),
@@ -146,6 +148,7 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
         } else {
             self.probe_target_info_kind(&crate_types, Kind::Host)?;
         }
+        self.target_info_probed = true;
         Ok(())
     }
 
@@ -782,6 +785,15 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
             Some(p) => p,
             None => return true,
         };
+
+        // If we haven't gotten around to probing target info yet then the
+        // `host_info` and `target_info` structures we'll read below are empty.
+        // This means we're in very early phases of the building the compilation
+        // graph so we just don't filter out dependencies.
+        if !self.target_info_probed {
+            return true
+        }
+
         let (name, info) = match kind {
             Kind::Host => (self.host_triple(), &self.host_info),
             Kind::Target => (self.target_triple(), &self.target_info),

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -2685,3 +2685,31 @@ fn build_all_member_dependency_same_name() {
                        [..] Finished debug [unoptimized + debuginfo] target(s) in [..]\n"));
 }
 
+#[test]
+fn target_specific_dylib_rlib() {
+    let p = project("workspace")
+        .file("Cargo.toml", r#"
+            [project]
+            name = "a"
+            version = "0.1.0"
+
+            [target.'cfg(unix)'.dependencies]
+            b = { path = "b" }
+            [target.'cfg(windows)'.dependencies]
+            b = { path = "b" }
+        "#)
+        .file("src/lib.rs", "")
+        .file("b/Cargo.toml", r#"
+            [project]
+            name = "b"
+            version = "0.1.0"
+
+            [lib]
+            crate-type = ["rlib", "dylib"]
+        "#)
+        .file("b/src/lib.rs", "");
+    p.build();
+
+    assert_that(p.cargo_process("build"),
+                execs().with_status(0));
+}


### PR DESCRIPTION
Previously we'd filter dependencies based on empty arrays for the `--print cfg`
output. Instead let's wait for the `--print cfg` output to get gathered before
we start filtering dependencies. This'll allow us to actually learn about
everything we may possibly need to execute.

Closes #3512