### PR TITLE
check for `CARGO_INCREMENTAL` and pass `-Zincremental` if present

### DIFF
--- a/src/cargo/ops/cargo_rustc/context.rs
+++ b/src/cargo/ops/cargo_rustc/context.rs
@@ -850,9 +850,9 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
         self.lib_profile()
     }
 
-    pub fn incremental_args(&self, _unit: &Unit) -> CargoResult<Vec<String>> {
+    pub fn incremental_args(&self, unit: &Unit) -> CargoResult<Vec<String>> {
         if self.incremental_enabled {
-            Ok(vec![format!("-Zincremental={}", self.host.incremental().display())])
+            Ok(vec![format!("-Zincremental={}", self.layout(unit.kind).incremental().display())])
         } else {
             Ok(vec![])
         }

--- a/src/cargo/ops/cargo_rustc/layout.rs
+++ b/src/cargo/ops/cargo_rustc/layout.rs
@@ -40,6 +40,10 @@
 //!         $pkg2/
 //!         $pkg3/
 //!
+//!     # Directory used to store incremental data for the compiler (when
+//!     # incremental is enabled.
+//!     incremental/
+//!
 //!     # Hidden directory that holds all of the fingerprint files for all
 //!     # packages
 //!     .fingerprint/
@@ -57,6 +61,7 @@ pub struct Layout {
     deps: PathBuf,
     native: PathBuf,
     build: PathBuf,
+    incremental: PathBuf,
     fingerprint: PathBuf,
     examples: PathBuf,
     _lock: FileLock,
@@ -88,6 +93,7 @@ impl Layout {
             deps: root.join("deps"),
             native: root.join("native"),
             build: root.join("build"),
+            incremental: root.join("incremental"),
             fingerprint: root.join(".fingerprint"),
             examples: root.join("examples"),
             root: root,
@@ -102,6 +108,7 @@ impl Layout {
 
         mkdir(&self.deps)?;
         mkdir(&self.native)?;
+        mkdir(&self.incremental)?;
         mkdir(&self.fingerprint)?;
         mkdir(&self.examples)?;
         mkdir(&self.build)?;
@@ -120,6 +127,7 @@ impl Layout {
     pub fn deps(&self) -> &Path { &self.deps }
     pub fn examples(&self) -> &Path { &self.examples }
     pub fn root(&self) -> &Path { &self.root }
+    pub fn incremental(&self) -> &Path { &self.incremental }
     pub fn fingerprint(&self) -> &Path { &self.fingerprint }
     pub fn build(&self) -> &Path { &self.build }
 }

--- a/src/cargo/ops/cargo_rustc/mod.rs
+++ b/src/cargo/ops/cargo_rustc/mod.rs
@@ -278,6 +278,7 @@ fn rustc(cx: &mut Context, unit: &Unit, exec: Arc<Executor>) -> CargoResult<Work
     let dep_info_loc = fingerprint::dep_info_loc(cx, unit);
     let cwd = cx.config.cwd().to_path_buf();
 
+    rustc.args(&cx.incremental_args(unit)?);
     rustc.args(&cx.rustflags_args(unit)?);
     let json_messages = cx.build_config.json_messages;
     let package_id = unit.pkg.package_id().clone();

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -44,12 +44,14 @@ fn cargo_compile_incremental() {
     assert_that(
         p.cargo_process("build").arg("-v").env("CARGO_INCREMENTAL", "1"),
         execs().with_stderr_contains(
-            "     Running `rustc [..] -Zincremental=[..]/target/debug/incremental`\n"));
+            "[RUNNING] `rustc [..] -Zincremental=[..][/]target[/]debug[/]incremental`\n")
+            .with_status(0));
 
     assert_that(
         p.cargo_process("test").arg("-v").env("CARGO_INCREMENTAL", "1"),
         execs().with_stderr_contains(
-            "     Running `rustc [..] -Zincremental=[..]/target/debug/incremental`\n"));
+            "[RUNNING] `rustc [..] -Zincremental=[..][/]target[/]debug[/]incremental`\n")
+               .with_status(0));
 }
 
 #[test]

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -29,6 +29,24 @@ fn cargo_compile_simple() {
                 execs().with_status(0).with_stdout("i am foo\n"));
 }
 
+/// Check that the `CARGO_INCREMENTAL` environment variable results in
+/// `rustc` getting `-Zincremental` passed to it.
+#[test]
+fn cargo_compile_incremental() {
+    if !is_nightly() {
+        return
+    }
+
+    let p = project("foo")
+        .file("Cargo.toml", &basic_bin_manifest("foo"))
+        .file("src/foo.rs", &main_file(r#""i am foo""#, &[]));
+
+    assert_that(
+        p.cargo_process("build").arg("-v").env("CARGO_INCREMENTAL", "1"),
+        execs().with_stderr_contains(
+            "     Running `rustc [..] -Zincremental=[..]/target/debug/incremental`\n"));
+}
+
 #[test]
 fn cargo_compile_manifest_path() {
     let p = project("foo")

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -45,6 +45,11 @@ fn cargo_compile_incremental() {
         p.cargo_process("build").arg("-v").env("CARGO_INCREMENTAL", "1"),
         execs().with_stderr_contains(
             "     Running `rustc [..] -Zincremental=[..]/target/debug/incremental`\n"));
+
+    assert_that(
+        p.cargo_process("test").arg("-v").env("CARGO_INCREMENTAL", "1"),
+        execs().with_stderr_contains(
+            "     Running `rustc [..] -Zincremental=[..]/target/debug/incremental`\n"));
 }
 
 #[test]


### PR DESCRIPTION
Per the discussion on IRC, this adds a very simple way for cargo users to opt into incremental compilation by setting the `CARGO_INCREMENTAL` environment variable (i.e., `CARGO_INCREMENTAL=1 cargo build`). This will result in incremental data being stored into the `target/incremental` directory. Since it supplies `-Z`, this option is only intended for use on nightly compilers, though cargo makes no effort to check.

The plan is to keep incremental compilation optional until we are feeling more confident it's not going to cause problems for people. At that point, it should become part of the compilation profile. It will be the default when building in debug builds, and opt-in for release builds.