### PR TITLE
Rename debug target to dev in build output

### DIFF
--- a/src/cargo/ops/cargo_rustc/job_queue.rs
+++ b/src/cargo/ops/cargo_rustc/job_queue.rs
@@ -197,7 +197,7 @@ impl<'a> JobQueue<'a> {
             }
         }
 
-        let build_type = if self.is_release { "release" } else { "debug" };
+        let build_type = if self.is_release { "release" } else { "dev" };
         let profile = cx.lib_profile();
         let mut opt_type = String::from(if profile.opt_level == "0" { "unoptimized" }
                                         else { "optimized" });

--- a/tests/bad-config.rs
+++ b/tests/bad-config.rs
@@ -575,7 +575,7 @@ fn unused_keys() {
                 execs().with_status(0).with_stderr("\
 warning: unused manifest key: target.foo.bar
 [COMPILING] foo v0.1.0 (file:///[..])
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
 }
 
@@ -626,7 +626,7 @@ invalid), but this file has a table header which does not have a newline after
 it. A newline needs to be added and this warning will soon become a hard error
 in the future.
 [COMPILING] empty_deps v0.0.0 ([..])
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
 }
 

--- a/tests/bench.rs
+++ b/tests/bench.rs
@@ -919,7 +919,7 @@ fn test_a_bench() {
                 execs().with_status(0)
                        .with_stderr("\
 [COMPILING] foo v0.1.0 ([..])
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target[/]debug[/]deps[/]b-[..][EXE]")
                        .with_stdout("
 running 1 test

--- a/tests/build-lib.rs
+++ b/tests/build-lib.rs
@@ -12,7 +12,7 @@ fn verbose_output_for_lib(p: &ProjectBuilder) -> String {
         -C metadata=[..] \
         --out-dir [..] \
         -L dependency={dir}[/]target[/]debug[/]deps`
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
             dir = p.root().display(), url = p.url(),
             name = "foo", version = "0.0.1")

--- a/tests/build-script.rs
+++ b/tests/build-script.rs
@@ -307,7 +307,7 @@ fn overrides_and_links() {
 [..]
 [..]
 [RUNNING] `rustc --crate-name foo [..] -L foo -L bar[..]`
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
 }
 
@@ -409,7 +409,7 @@ fn only_rerun_build_script() {
 [COMPILING] foo v0.5.0 (file://[..])
 [RUNNING] `[..][/]build-script-build`
 [RUNNING] `rustc --crate-name foo [..]`
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
 }
 
@@ -498,7 +498,7 @@ fn testing_and_such() {
 [RUNNING] `[..][/]build-script-build`
 [RUNNING] `rustc --crate-name foo [..]`
 [RUNNING] `rustc --crate-name foo [..]`
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `[..][/]foo-[..][EXE]`
 [DOCTEST] foo
 [RUNNING] `rustdoc --test [..]`")
@@ -529,7 +529,7 @@ test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
                 execs().with_status(0)
                        .with_stderr("\
 [COMPILING] foo v0.5.0 (file://[..])
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `target[/]debug[/]foo[EXE]`
 "));
 }
@@ -676,7 +676,7 @@ fn build_deps_simple() {
 [RUNNING] `rustc [..] build.rs [..] --extern a=[..]`
 [RUNNING] `[..][/]foo-[..][/]build-script-build`
 [RUNNING] `rustc --crate-name foo [..]`
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
 }
 
@@ -782,7 +782,7 @@ fn build_cmd_with_a_build_cmd() {
     -C metadata=[..] \
     --out-dir [..] \
     -L [..]target[/]debug[/]deps`
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
 }
 
@@ -929,7 +929,7 @@ fn code_generation() {
                 execs().with_status(0)
                        .with_stderr("\
 [COMPILING] foo v0.5.0 (file://[..])
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `target[/]debug[/]foo`")
                        .with_stdout("\
 Hello, World!
@@ -1373,7 +1373,7 @@ fn cfg_test() {
 [RUNNING] [..] --cfg foo[..]
 [RUNNING] [..] --cfg foo[..]
 [RUNNING] [..] --cfg foo[..]
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `[..][/]foo-[..][EXE]`
 [RUNNING] `[..][/]test-[..][EXE]`
 [DOCTEST] foo
@@ -1490,7 +1490,7 @@ fn cfg_override_test() {
 [RUNNING] `[..]`
 [RUNNING] `[..]`
 [RUNNING] `[..]`
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `[..][/]foo-[..][EXE]`
 [RUNNING] `[..][/]test-[..][EXE]`
 [DOCTEST] foo
@@ -1610,7 +1610,7 @@ fn flags_go_into_tests() {
 [COMPILING] foo v0.5.0 ([..]
 [RUNNING] `rustc [..] src[/]lib.rs [..] -L test[..]`
 [RUNNING] `rustc [..] tests[/]foo.rs [..] -L test[..]`
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `[..][/]foo-[..][EXE]`")
                        .with_stdout("
 running 0 tests
@@ -1625,7 +1625,7 @@ test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
 [FRESH] a v0.5.0 ([..]
 [COMPILING] b v0.5.0 ([..]
 [RUNNING] `rustc [..] b[/]src[/]lib.rs [..] -L test[..]`
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `[..][/]b-[..][EXE]`")
                        .with_stdout("
 running 0 tests
@@ -1695,7 +1695,7 @@ fn diamond_passes_args_only_once() {
 [RUNNING] `rustc [..]`
 [COMPILING] foo v0.5.0 ([..]
 [RUNNING] `[..]rlib -L native=test`
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
 }
 
@@ -1725,7 +1725,7 @@ fn adding_an_override_invalidates() {
 [RUNNING] `rustc [..]`
 [RUNNING] `[..]`
 [RUNNING] `rustc [..] -L native=foo`
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
 
     File::create(p.root().join(".cargo/config")).unwrap().write_all(format!("
@@ -1737,7 +1737,7 @@ fn adding_an_override_invalidates() {
                 execs().with_status(0).with_stderr("\
 [COMPILING] foo v0.5.0 ([..]
 [RUNNING] `rustc [..] -L native=bar`
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
 }
 
@@ -1764,7 +1764,7 @@ fn changing_an_override_invalidates() {
                 execs().with_status(0).with_stderr("\
 [COMPILING] foo v0.5.0 ([..]
 [RUNNING] `rustc [..] -L native=foo`
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
 
     File::create(p.root().join(".cargo/config")).unwrap().write_all(format!("
@@ -1776,7 +1776,7 @@ fn changing_an_override_invalidates() {
                 execs().with_status(0).with_stderr("\
 [COMPILING] foo v0.5.0 ([..]
 [RUNNING] `rustc [..] -L native=bar`
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
 }
 
@@ -1809,7 +1809,7 @@ fn rebuild_only_on_explicit_paths() {
 [COMPILING] a v0.5.0 ([..])
 [RUNNING] `[..][/]build-script-build`
 [RUNNING] `rustc [..] src[/]lib.rs [..]`
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
 
     sleep_ms(1000);
@@ -1823,14 +1823,14 @@ fn rebuild_only_on_explicit_paths() {
 [COMPILING] a v0.5.0 ([..])
 [RUNNING] `[..][/]build-script-build`
 [RUNNING] `rustc [..] src[/]lib.rs [..]`
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
 
     println!("run with2");
     assert_that(p.cargo("build").arg("-v"),
                 execs().with_status(0).with_stderr("\
 [FRESH] a v0.5.0 ([..])
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
 
     sleep_ms(1000);
@@ -1841,7 +1841,7 @@ fn rebuild_only_on_explicit_paths() {
     assert_that(p.cargo("build").arg("-v"),
                 execs().with_status(0).with_stderr("\
 [FRESH] a v0.5.0 ([..])
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
 
     // but changing dependent files does
@@ -1852,7 +1852,7 @@ fn rebuild_only_on_explicit_paths() {
 [COMPILING] a v0.5.0 ([..])
 [RUNNING] `[..][/]build-script-build`
 [RUNNING] `rustc [..] src[/]lib.rs [..]`
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
 
     // .. as does deleting a file
@@ -1863,7 +1863,7 @@ fn rebuild_only_on_explicit_paths() {
 [COMPILING] a v0.5.0 ([..])
 [RUNNING] `[..][/]build-script-build`
 [RUNNING] `rustc [..] src[/]lib.rs [..]`
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
 }
 
@@ -2078,7 +2078,7 @@ fn warnings_emitted() {
 warning: foo
 warning: bar
 [RUNNING] `rustc [..]`
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
 }
 
@@ -2124,7 +2124,7 @@ fn warnings_hidden_for_upstream() {
 [RUNNING] `rustc [..]`
 [COMPILING] foo v0.5.0 ([..])
 [RUNNING] `rustc [..]`
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
 }
 
@@ -2172,7 +2172,7 @@ warning: bar
 [RUNNING] `rustc [..]`
 [COMPILING] foo v0.5.0 ([..])
 [RUNNING] `rustc [..]`
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
 }
 
@@ -2207,7 +2207,7 @@ stdout
 [RUNNING] `[..]`
 stderr
 [RUNNING] `rustc [..]`
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
 }
 

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -808,7 +808,7 @@ fn cargo_default_env_metadata_env_var() {
         --out-dir [..] \
         -L dependency={dir}[/]target[/]debug[/]deps \
         --extern bar={dir}[/]target[/]debug[/]deps[/]{prefix}bar{suffix}`
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]",
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]",
 dir = p.root().display(),
 url = p.url(),
 prefix = env::consts::DLL_PREFIX,
@@ -835,7 +835,7 @@ suffix = env::consts::DLL_SUFFIX,
         --out-dir [..] \
         -L dependency={dir}[/]target[/]debug[/]deps \
         --extern bar={dir}[/]target[/]debug[/]deps[/]{prefix}bar-[..]{suffix}`
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
 dir = p.root().display(),
 url = p.url(),
@@ -1026,7 +1026,7 @@ fn unused_keys() {
                        .with_stderr("\
 warning: unused manifest key: project.bulid
 [COMPILING] foo [..]
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
 
     let mut p = project("bar");
@@ -1051,7 +1051,7 @@ warning: unused manifest key: project.bulid
                        .with_stderr("\
 warning: unused manifest key: lib.build
 [COMPILING] foo [..]
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
 }
 
@@ -1177,7 +1177,7 @@ fn verbose_build() {
         -C metadata=[..] \
         --out-dir [..] \
         -L dependency={dir}[/]target[/]debug[/]deps`
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
 dir = p.root().display(),
 url = p.url(),
@@ -1472,7 +1472,7 @@ fn lib_with_standard_name() {
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] syntax v0.0.1 ({dir})
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
                        dir = p.url())));
 }
@@ -1574,7 +1574,7 @@ fn freshness_ignores_excluded() {
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] foo v0.0.0 ({url})
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ", url = foo.url())));
 
     // Smoke test to make sure it doesn't compile again
@@ -1623,7 +1623,7 @@ fn rebuild_preserves_out_dir() {
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] foo v0.0.0 ({url})
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ", url = foo.url())));
 
     File::create(&foo.root().join("src/bar.rs")).unwrap();
@@ -1631,7 +1631,7 @@ fn rebuild_preserves_out_dir() {
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] foo v0.0.0 ({url})
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ", url = foo.url())));
 }
 
@@ -2366,7 +2366,7 @@ fn explicit_color_config_is_propagated_to_rustc() {
                 execs().with_status(0).with_stderr("\
 [COMPILING] test v0.0.0 ([..])
 [RUNNING] `rustc [..] --color never [..]`
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
 }
 
@@ -2543,7 +2543,7 @@ fn no_warn_about_package_metadata() {
     assert_that(p.cargo_process("build"),
                 execs().with_status(0)
                        .with_stderr("[..] foo v0.0.1 ([..])\n\
-                       [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]\n"));
+                       [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]\n"));
 }
 
 #[test]
@@ -2589,7 +2589,7 @@ fn build_all_workspace() {
                 execs().with_status(0)
                        .with_stderr("[..] Compiling bar v0.1.0 ([..])\n\
                        [..] Compiling foo v0.1.0 ([..])\n\
-                       [..] Finished debug [unoptimized + debuginfo] target(s) in [..]\n"));
+                       [..] Finished dev [unoptimized + debuginfo] target(s) in [..]\n"));
 }
 
 #[test]
@@ -2625,7 +2625,7 @@ fn build_all_virtual_manifest() {
                        .with_stderr_contains("[..] Compiling foo v0.1.0 ([..])")
                        .with_stderr("[..] Compiling [..] v0.1.0 ([..])\n\
                        [..] Compiling [..] v0.1.0 ([..])\n\
-                       [..] Finished debug [unoptimized + debuginfo] target(s) in [..]\n"));
+                       [..] Finished dev [unoptimized + debuginfo] target(s) in [..]\n"));
 }
 
 #[test]
@@ -2657,6 +2657,6 @@ fn build_all_member_dependency_same_name() {
                        [..] Downloading a v0.1.0 ([..])\n\
                        [..] Compiling a v0.1.0\n\
                        [..] Compiling a v0.1.0 ([..])\n\
-                       [..] Finished debug [unoptimized + debuginfo] target(s) in [..]\n"));
+                       [..] Finished dev [unoptimized + debuginfo] target(s) in [..]\n"));
 }
 

--- a/tests/cargo_alias_config.rs
+++ b/tests/cargo_alias_config.rs
@@ -112,6 +112,6 @@ fn cant_shadow_builtin() {
                 execs().with_status(0)
                        .with_stderr("\
 [COMPILING] foo v0.5.0 ([..])
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
 }

--- a/tests/cfg.rs
+++ b/tests/cfg.rs
@@ -190,7 +190,7 @@ fn dont_include() {
     assert_that(p.cargo_process("build"),
                 execs().with_status(0).with_stderr("\
 [COMPILING] a v0.0.1 ([..])
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
 }
 
@@ -224,7 +224,7 @@ fn works_through_the_registry() {
 [COMPILING] foo v0.1.0
 [COMPILING] bar v0.1.0
 [COMPILING] a v0.0.1 ([..])
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
 }
 
@@ -256,7 +256,7 @@ fn ignore_version_from_other_platform() {
 [DOWNLOADING] [..]
 [COMPILING] foo v0.1.0
 [COMPILING] a v0.0.1 ([..])
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
 }
 

--- a/tests/clean.rs
+++ b/tests/clean.rs
@@ -174,7 +174,7 @@ fn build_script() {
 [RUNNING] `rustc [..] build.rs [..]`
 [RUNNING] `[..]build-script-build`
 [RUNNING] `rustc [..] src[/]main.rs [..]`
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
 }
 

--- a/tests/concurrent.rs
+++ b/tests/concurrent.rs
@@ -425,7 +425,7 @@ fn debug_release_ok() {
 
     assert_that(a, execs().with_status(0).with_stderr("\
 [COMPILING] foo v0.0.0 [..]
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
     assert_that(b, execs().with_status(0).with_stderr("\
 [COMPILING] foo v0.0.0 [..]

--- a/tests/cross-compile.rs
+++ b/tests/cross-compile.rs
@@ -547,7 +547,7 @@ fn cross_tests() {
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] foo v0.0.0 ({foo})
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target[/]{triple}[/]debug[/]deps[/]bar-[..][EXE]
 [RUNNING] target[/]{triple}[/]debug[/]deps[/]foo-[..][EXE]", foo = p.url(), triple = target))
                        .with_stdout("
@@ -585,7 +585,7 @@ fn no_cross_doctests() {
 
     let host_output = format!("\
 [COMPILING] foo v0.0.0 ({foo})
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target[/]debug[/]deps[/]foo-[..][EXE]
 [DOCTEST] foo
 ", foo = p.url());
@@ -601,7 +601,7 @@ fn no_cross_doctests() {
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] foo v0.0.0 ({foo})
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target[/]{triple}[/]debug[/]deps[/]foo-[..][EXE]
 [DOCTEST] foo
 ", foo = p.url(), triple = target)));
@@ -612,7 +612,7 @@ fn no_cross_doctests() {
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] foo v0.0.0 ({foo})
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target[/]{triple}[/]debug[/]deps[/]foo-[..][EXE]
 ", foo = p.url(), triple = target)));
 }
@@ -682,7 +682,7 @@ fn cross_with_a_build_script() {
 [RUNNING] `rustc [..] build.rs [..] --out-dir {dir}[/]target[/]debug[/]build[/]foo-[..]`
 [RUNNING] `{dir}[/]target[/]debug[/]build[/]foo-[..][/]build-script-build`
 [RUNNING] `rustc [..] src[/]main.rs [..] --target {target} [..]`
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ", target = target,
    dir = p.root().display())));
 }
@@ -882,7 +882,7 @@ fn plugin_build_script_right_arch() {
 [RUNNING] `rustc [..] build.rs [..]`
 [RUNNING] `[..][/]build-script-build`
 [RUNNING] `rustc [..] src[/]lib.rs [..]`
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
 }
 
@@ -934,7 +934,7 @@ fn build_script_with_platform_specific_dependencies() {
 [RUNNING] `rustc [..] build.rs [..]`
 [RUNNING] `{dir}[/]target[/]debug[/]build[/]foo-[..][/]build-script-build`
 [RUNNING] `rustc [..] src[/]lib.rs [..] --target {target} [..]`
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ", dir = p.root().display(), target = target)));
 }
 

--- a/tests/doc.rs
+++ b/tests/doc.rs
@@ -155,7 +155,7 @@ fn doc_no_deps() {
                 execs().with_status(0).with_stderr(&format!("\
 [COMPILING] bar v0.0.1 ({dir}/bar)
 [DOCUMENTING] foo v0.0.1 ({dir})
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         dir = path2url(p.root()))));
 

--- a/tests/features.rs
+++ b/tests/features.rs
@@ -307,7 +307,7 @@ fn no_feature_doesnt_build() {
     assert_that(p.cargo_process("build"),
                 execs().with_status(0).with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({dir})
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ", dir = p.url())));
     assert_that(p.process(&p.bin("foo")),
                 execs().with_status(0).with_stdout(""));
@@ -316,7 +316,7 @@ fn no_feature_doesnt_build() {
                 execs().with_status(0).with_stderr(format!("\
 [COMPILING] bar v0.0.1 ({dir}/bar)
 [COMPILING] foo v0.0.1 ({dir})
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ", dir = p.url())));
     assert_that(p.process(&p.bin("foo")),
                 execs().with_status(0).with_stdout("bar\n"));
@@ -358,7 +358,7 @@ fn default_feature_pulled_in() {
                 execs().with_status(0).with_stderr(format!("\
 [COMPILING] bar v0.0.1 ({dir}/bar)
 [COMPILING] foo v0.0.1 ({dir})
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ", dir = p.url())));
     assert_that(p.process(&p.bin("foo")),
                 execs().with_status(0).with_stdout("bar\n"));
@@ -366,7 +366,7 @@ fn default_feature_pulled_in() {
     assert_that(p.cargo("build").arg("--no-default-features"),
                 execs().with_status(0).with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({dir})
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ", dir = p.url())));
     assert_that(p.process(&p.bin("foo")),
                 execs().with_status(0).with_stdout(""));
@@ -465,7 +465,7 @@ fn groups_on_groups_on_groups() {
 [COMPILING] ba[..] v0.0.1 ({dir}/ba[..])
 [COMPILING] ba[..] v0.0.1 ({dir}/ba[..])
 [COMPILING] foo v0.0.1 ({dir})
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ", dir = p.url())));
 }
 
@@ -511,7 +511,7 @@ fn many_cli_features() {
 [COMPILING] ba[..] v0.0.1 ({dir}/ba[..])
 [COMPILING] ba[..] v0.0.1 ({dir}/ba[..])
 [COMPILING] foo v0.0.1 ({dir})
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ", dir = p.url())));
 }
 
@@ -574,7 +574,7 @@ fn union_features() {
 [COMPILING] d2 v0.0.1 ({dir}/d2)
 [COMPILING] d1 v0.0.1 ({dir}/d1)
 [COMPILING] foo v0.0.1 ({dir})
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ", dir = p.url())));
 }
 
@@ -609,7 +609,7 @@ fn many_features_no_rebuilds() {
                 execs().with_status(0).with_stderr(format!("\
 [COMPILING] a v0.1.0 ({dir}/a)
 [COMPILING] b v0.1.0 ({dir})
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ", dir = p.url())));
     p.root().move_into_the_past();
 
@@ -617,7 +617,7 @@ fn many_features_no_rebuilds() {
                 execs().with_status(0).with_stderr("\
 [FRESH] a v0.1.0 ([..]/a)
 [FRESH] b v0.1.0 ([..])
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
 }
 
@@ -849,7 +849,7 @@ fn optional_and_dev_dep() {
     assert_that(p.cargo_process("build"),
                 execs().with_status(0).with_stderr("\
 [COMPILING] test v0.1.0 ([..])
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
 }
 

--- a/tests/freshness.rs
+++ b/tests/freshness.rs
@@ -26,7 +26,7 @@ fn modifying_and_moving() {
     assert_that(p.cargo_process("build"),
                 execs().with_status(0).with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({dir})
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ", dir = path2url(p.root()))));
 
     assert_that(p.cargo("build"),
@@ -39,7 +39,7 @@ fn modifying_and_moving() {
     assert_that(p.cargo("build"),
                 execs().with_status(0).with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({dir})
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ", dir = path2url(p.root()))));
 
     fs::rename(&p.root().join("src/a.rs"), &p.root().join("src/b.rs")).unwrap();
@@ -68,7 +68,7 @@ fn modify_only_some_files() {
     assert_that(p.cargo_process("build"),
                 execs().with_status(0).with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({dir})
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ", dir = path2url(p.root()))));
     assert_that(p.cargo("test"),
                 execs().with_status(0));
@@ -87,7 +87,7 @@ fn modify_only_some_files() {
     assert_that(p.cargo("build"),
                 execs().with_status(0).with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({dir})
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ", dir = path2url(p.root()))));
     assert_that(&p.bin("foo"), existing_file());
 }
@@ -162,14 +162,14 @@ fn changing_lib_features_caches_targets() {
                 execs().with_status(0)
                        .with_stderr("\
 [..]Compiling foo v0.0.1 ([..])
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
 
     assert_that(p.cargo("build").arg("--features").arg("foo"),
                 execs().with_status(0)
                        .with_stderr("\
 [..]Compiling foo v0.0.1 ([..])
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
 
     /* Targets should be cached from the first build */
@@ -177,7 +177,7 @@ fn changing_lib_features_caches_targets() {
     assert_that(p.cargo("build"),
                 execs().with_status(0)
                        .with_stderr("\
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
 
     assert_that(p.cargo("build"),
@@ -187,7 +187,7 @@ fn changing_lib_features_caches_targets() {
     assert_that(p.cargo("build").arg("--features").arg("foo"),
                 execs().with_status(0)
                        .with_stderr("\
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
 }
 
@@ -212,14 +212,14 @@ fn changing_profiles_caches_targets() {
                 execs().with_status(0)
                        .with_stderr("\
 [..]Compiling foo v0.0.1 ([..])
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
 
     assert_that(p.cargo("test"),
                 execs().with_status(0)
                        .with_stderr("\
 [..]Compiling foo v0.0.1 ([..])
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target[..]debug[..]deps[..]foo-[..][EXE]
 [DOCTEST] foo
 "));
@@ -229,13 +229,13 @@ fn changing_profiles_caches_targets() {
     assert_that(p.cargo("build"),
                 execs().with_status(0)
                        .with_stderr("\
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
 
     assert_that(p.cargo("test").arg("foo"),
                 execs().with_status(0)
                        .with_stderr("\
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target[..]debug[..]deps[..]foo-[..][EXE]
 [DOCTEST] foo
 "));
@@ -310,7 +310,7 @@ fn changing_bin_paths_common_target_features_caches_targets() {
                        .with_stderr("\
 [..]Compiling dep_crate v0.0.1 ([..])
 [..]Compiling a v0.0.1 ([..])
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `[..]target[/]debug[/]a[EXE]`
 "));
     assert_that(p.cargo("clean").arg("-p").arg("a").cwd(p.root().join("a")),
@@ -320,7 +320,7 @@ fn changing_bin_paths_common_target_features_caches_targets() {
                        .with_stdout("ftest off")
                        .with_stderr("\
 [..]Compiling a v0.0.1 ([..])
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `[..]target[/]debug[/]a[EXE]`
 "));
 
@@ -331,7 +331,7 @@ fn changing_bin_paths_common_target_features_caches_targets() {
                        .with_stderr("\
 [..]Compiling dep_crate v0.0.1 ([..])
 [..]Compiling b v0.0.1 ([..])
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `[..]target[/]debug[/]b[EXE]`
 "));
     assert_that(p.cargo("clean").arg("-p").arg("b").cwd(p.root().join("b")),
@@ -341,7 +341,7 @@ fn changing_bin_paths_common_target_features_caches_targets() {
                        .with_stdout("ftest on")
                        .with_stderr("\
 [..]Compiling b v0.0.1 ([..])
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `[..]target[/]debug[/]b[EXE]`
 "));
 
@@ -354,7 +354,7 @@ fn changing_bin_paths_common_target_features_caches_targets() {
                        .with_stdout("ftest off")
                        .with_stderr("\
 [..]Compiling a v0.0.1 ([..])
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `[..]target[/]debug[/]a[EXE]`
 "));
 
@@ -367,7 +367,7 @@ fn changing_bin_paths_common_target_features_caches_targets() {
                        .with_stdout("ftest on")
                        .with_stderr("\
 [..]Compiling b v0.0.1 ([..])
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `[..]target[/]debug[/]b[EXE]`
 "));
 }
@@ -396,7 +396,7 @@ fn changing_bin_features_caches_targets() {
                        .with_stdout("feature off")
                        .with_stderr("\
 [..]Compiling foo v0.0.1 ([..])
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `target[/]debug[/]foo[EXE]`
 "));
 
@@ -405,7 +405,7 @@ fn changing_bin_features_caches_targets() {
                        .with_stdout("feature on")
                        .with_stderr("\
 [..]Compiling foo v0.0.1 ([..])
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `target[/]debug[/]foo[EXE]`
 "));
 
@@ -415,7 +415,7 @@ fn changing_bin_features_caches_targets() {
                 execs().with_status(0)
                        .with_stdout("feature off")
                        .with_stderr("\
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `target[/]debug[/]foo[EXE]`
 "));
 
@@ -423,7 +423,7 @@ fn changing_bin_features_caches_targets() {
                 execs().with_status(0)
                        .with_stdout("feature on")
                        .with_stderr("\
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `target[/]debug[/]foo[EXE]`
 "));
 }
@@ -511,7 +511,7 @@ fn no_rebuild_transitive_target_deps() {
 [COMPILING] c v0.0.1 ([..])
 [COMPILING] b v0.0.1 ([..])
 [COMPILING] foo v0.0.1 ([..])
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
 }
 
@@ -606,12 +606,12 @@ fn same_build_dir_cached_packages() {
 [COMPILING] c v0.0.1 ({dir}/c)
 [COMPILING] b v0.0.1 ({dir}/b)
 [COMPILING] a1 v0.0.1 ({dir}/a1)
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ", dir = p.url())));
     assert_that(p.cargo("build").cwd(p.root().join("a2")),
                 execs().with_status(0).with_stderr(&format!("\
 [COMPILING] a2 v0.0.1 ({dir}/a2)
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ", dir = p.url())));
 }
 

--- a/tests/git.rs
+++ b/tests/git.rs
@@ -62,7 +62,7 @@ fn cargo_compile_simple_git_dep() {
         .with_stderr(&format!("[UPDATING] git repository `{}`\n\
                               [COMPILING] dep1 v0.5.0 ({}#[..])\n\
                               [COMPILING] foo v0.5.0 ({})\n\
-                              [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]\n",
+                              [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]\n",
                              path2url(git_root.clone()),
                              path2url(git_root),
                              path2url(root))));
@@ -130,7 +130,7 @@ fn cargo_compile_git_dep_branch() {
         .with_stderr(&format!("[UPDATING] git repository `{}`\n\
                               [COMPILING] dep1 v0.5.0 ({}?branch=branchy#[..])\n\
                               [COMPILING] foo v0.5.0 ({})\n\
-                              [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]\n",
+                              [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]\n",
                              path2url(git_root.clone()),
                              path2url(git_root),
                              path2url(root))));
@@ -201,7 +201,7 @@ fn cargo_compile_git_dep_tag() {
         .with_stderr(&format!("[UPDATING] git repository `{}`\n\
                               [COMPILING] dep1 v0.5.0 ({}?tag=v0.1.0#[..])\n\
                               [COMPILING] foo v0.5.0 ({})\n\
-                              [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]\n",
+                              [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]\n",
                              path2url(git_root.clone()),
                              path2url(git_root),
                              path2url(root))));
@@ -510,7 +510,7 @@ fn recompilation() {
                 execs().with_stderr(&format!("[UPDATING] git repository `{}`\n\
                                              [COMPILING] bar v0.5.0 ({}#[..])\n\
                                              [COMPILING] foo v0.5.0 ({})\n\
-                                             [FINISHED] debug [unoptimized + debuginfo] target(s) \
+                                             [FINISHED] dev [unoptimized + debuginfo] target(s) \
                                              in [..]\n",
                                             git_project.url(),
                                             git_project.url(),
@@ -556,7 +556,7 @@ fn recompilation() {
     assert_that(p.cargo("build"),
                 execs().with_stderr(&format!("[COMPILING] bar v0.5.0 ({}#[..])\n\
                                              [COMPILING] foo v0.5.0 ({})\n\
-                                             [FINISHED] debug [unoptimized + debuginfo] target(s) \
+                                             [FINISHED] dev [unoptimized + debuginfo] target(s) \
                                              in [..]\n",
                                             git_project.url(),
                                             p.url())));
@@ -567,7 +567,7 @@ fn recompilation() {
                 execs().with_stdout(""));
     assert_that(p.cargo("build"),
                 execs().with_stderr(&format!("[COMPILING] foo v0.5.0 ({})\n\
-                                              [FINISHED] debug [unoptimized + debuginfo] target(s) \
+                                              [FINISHED] dev [unoptimized + debuginfo] target(s) \
                                               in [..]\n",
                                             p.url())));
 }
@@ -639,7 +639,7 @@ fn update_with_shared_deps() {
 [COMPILING] [..] v0.5.0 ([..])
 [COMPILING] [..] v0.5.0 ([..])
 [COMPILING] foo v0.5.0 ({dir})
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]\n",
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]\n",
 git = git_project.url(), dir = p.url())));
 
     // Modify a file manually, and commit it
@@ -696,7 +696,7 @@ To learn more, run the command again with --verbose.
 [COMPILING] [..] v0.5.0 ({dir}[..]dep[..])
 [COMPILING] [..] v0.5.0 ({dir}[..]dep[..])
 [COMPILING] foo v0.5.0 ({dir})
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]\n",
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]\n",
                     git = git_project.url(), dir = p.url())));
 
     // We should be able to update transitive deps
@@ -748,7 +748,7 @@ fn dep_with_submodule() {
 [UPDATING] git repository [..]
 [COMPILING] dep1 [..]
 [COMPILING] foo [..]
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]\n").with_status(0));
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]\n").with_status(0));
 }
 
 #[test]
@@ -797,7 +797,7 @@ fn two_deps_only_update_one() {
                               [COMPILING] [..] v0.5.0 ([..])\n\
                               [COMPILING] [..] v0.5.0 ([..])\n\
                               [COMPILING] foo v0.5.0 ({})\n\
-                              [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]\n",
+                              [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]\n",
                              project.url())));
 
     File::create(&git1.root().join("src/lib.rs")).unwrap().write_all(br#"
@@ -882,7 +882,7 @@ fn stale_cached_version() {
 [UPDATING] git repository `{bar}`
 [COMPILING] bar v0.0.0 ({bar}#[..])
 [COMPILING] foo v0.0.0 ({foo})
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ", bar = bar.url(), foo = foo.url())));
     assert_that(foo.process(&foo.bin("foo")), execs().with_status(0));
 }
@@ -934,7 +934,7 @@ fn dep_with_changed_submodule() {
                 .with_stderr("[UPDATING] git repository `[..]`\n\
                                       [COMPILING] dep1 v0.5.0 ([..])\n\
                                       [COMPILING] foo v0.5.0 ([..])\n\
-                                      [FINISHED] debug [unoptimized + debuginfo] target(s) in \
+                                      [FINISHED] dev [unoptimized + debuginfo] target(s) in \
                                       [..]\n\
                                       [RUNNING] `target[/]debug[/]foo[EXE]`\n")
                 .with_stdout("project2\n")
@@ -976,7 +976,7 @@ fn dep_with_changed_submodule() {
     assert_that(project.cargo("run"), execs()
                 .with_stderr("[COMPILING] dep1 v0.5.0 ([..])\n\
                                       [COMPILING] foo v0.5.0 ([..])\n\
-                                      [FINISHED] debug [unoptimized + debuginfo] target(s) in \
+                                      [FINISHED] dev [unoptimized + debuginfo] target(s) in \
                                       [..]\n\
                                       [RUNNING] `target[/]debug[/]foo[EXE]`\n")
                 .with_stdout("project3\n")
@@ -1025,7 +1025,7 @@ fn dev_deps_with_testing() {
         execs().with_stderr(&format!("\
 [UPDATING] git repository `{bar}`
 [COMPILING] foo v0.5.0 ({url})
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ", url = p.url(), bar = p2.url())));
 
     // Make sure we use the previous resolution of `bar` instead of updating it
@@ -1034,7 +1034,7 @@ fn dev_deps_with_testing() {
                 execs().with_stderr("\
 [COMPILING] [..] v0.5.0 ([..])
 [COMPILING] [..] v0.5.0 ([..]
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target[/]debug[/]deps[/]foo-[..][EXE]")
                        .with_stdout("
 running 1 test
@@ -1069,7 +1069,7 @@ fn git_build_cmd_freshness() {
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] foo v0.0.0 ({url})
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ", url = foo.url())));
 
     // Smoke test to make sure it doesn't compile again
@@ -1123,7 +1123,7 @@ fn git_name_not_always_needed() {
         execs().with_stderr(&format!("\
 [UPDATING] git repository `{bar}`
 [COMPILING] foo v0.5.0 ({url})
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ", url = p.url(), bar = p2.url())));
 }
 
@@ -1159,7 +1159,7 @@ fn git_repo_changing_no_rebuild() {
 [UPDATING] git repository `{bar}`
 [COMPILING] [..]
 [COMPILING] [..]
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ", bar = bar.url())));
 
     // Make a commit to lock p2 to a different rev
@@ -1186,7 +1186,7 @@ fn git_repo_changing_no_rebuild() {
 [UPDATING] git repository `{bar}`
 [COMPILING] [..]
 [COMPILING] [..]
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ", bar = bar.url())));
 
     // And now for the real test! Make sure that p1 doesn't get rebuilt
@@ -1317,7 +1317,7 @@ fn warnings_in_git_dep() {
         .with_stderr(&format!("[UPDATING] git repository `{}`\n\
                               [COMPILING] bar v0.5.0 ({}#[..])\n\
                               [COMPILING] foo v0.5.0 ({})\n\
-                              [FINISHED] debug [unoptimized + debuginfo] target(s) in [..]\n",
+                              [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]\n",
                              bar.url(),
                              bar.url(),
                              p.url())));
@@ -1480,7 +1480,7 @@ fn switch_deps_does_not_update_transitive() {
 [COMPILING] transitive [..]
 [COMPILING] dep [..]
 [COMPILING] project [..]
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ", dep1.url(), transitive.url())));
 
     // Update the dependency to point to the second repository, but this
@@ -1500,7 +1500,7 @@ fn switch_deps_does_not_update_transitive() {
 [UPDATING] git repository `{}`
 [COMPILING] dep [..]
 [COMPILING] project [..]
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ", dep2.url())));
 }
 
@@ -1609,7 +1609,7 @@ fn switch_sources() {
 [COMPILING] a v0.5.0 ([..]a1#[..]
 [COMPILING] b v0.5.0 ([..])
 [COMPILING] project v0.5.0 ([..])
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
 
     File::create(&p.root().join("b/Cargo.toml")).unwrap().write_all(format!(r#"
@@ -1628,7 +1628,7 @@ fn switch_sources() {
 [COMPILING] a v0.5.1 ([..]a2#[..]
 [COMPILING] b v0.5.0 ([..])
 [COMPILING] project v0.5.0 ([..])
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
 }
 
@@ -1737,7 +1737,7 @@ fn lints_are_suppressed() {
 [UPDATING] git repository `[..]`
 [COMPILING] a v0.5.0 ([..])
 [COMPILING] foo v0.0.1 ([..])
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
 }
 
@@ -1776,7 +1776,7 @@ fn denied_lints_are_allowed() {
 [UPDATING] git repository `[..]`
 [COMPILING] a v0.5.0 ([..])
 [COMPILING] foo v0.0.1 ([..])
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
 }
 

--- a/tests/overrides.rs
+++ b/tests/overrides.rs
@@ -47,7 +47,7 @@ fn override_simple() {
 [UPDATING] git repository `[..]`
 [COMPILING] foo v0.1.0 (file://[..])
 [COMPILING] local v0.0.1 (file://[..])
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
 }
 
@@ -173,7 +173,7 @@ fn transitive() {
 [COMPILING] foo v0.1.0 (file://[..])
 [COMPILING] bar v0.2.0
 [COMPILING] local v0.0.1 (file://[..])
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
 
     assert_that(p.cargo("build"), execs().with_status(0).with_stdout(""));
@@ -219,7 +219,7 @@ fn persists_across_rebuilds() {
 [UPDATING] git repository `file://[..]`
 [COMPILING] foo v0.1.0 (file://[..])
 [COMPILING] local v0.0.1 (file://[..])
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
 
     assert_that(p.cargo("build"),
@@ -265,7 +265,7 @@ fn replace_registry_with_path() {
 [UPDATING] registry `file://[..]`
 [COMPILING] foo v0.1.0 (file://[..])
 [COMPILING] local v0.0.1 (file://[..])
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
 }
 
@@ -327,7 +327,7 @@ fn use_a_spec_to_select() {
 [COMPILING] [..]
 [COMPILING] [..]
 [COMPILING] local v0.0.1 (file://[..])
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
 }
 
@@ -372,7 +372,7 @@ fn override_adds_some_deps() {
 [COMPILING] foo v0.1.1
 [COMPILING] bar v0.1.0 ([..])
 [COMPILING] local v0.0.1 (file://[..])
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
 
     assert_that(p.cargo("build"), execs().with_status(0).with_stdout(""));

--- a/tests/package.rs
+++ b/tests/package.rs
@@ -40,7 +40,7 @@ See [..]
 [PACKAGING] foo v0.0.1 ({dir})
 [VERIFYING] foo v0.0.1 ({dir})
 [COMPILING] foo v0.0.1 ({dir}[..])
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         dir = p.url())));
     assert_that(&p.root().join("target/package/foo-0.0.1.crate"), existing_file());
@@ -87,7 +87,7 @@ See http://doc.crates.io/manifest.html#package-metadata for more info.
 [PACKAGING] foo v0.0.1 ({dir})
 [VERIFYING] foo v0.0.1 ({dir})
 [COMPILING] foo v0.0.1 ({dir}[..])
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         dir = p.url())));
 
@@ -109,7 +109,7 @@ See http://doc.crates.io/manifest.html#package-metadata for more info.
 [PACKAGING] foo v0.0.1 ({dir})
 [VERIFYING] foo v0.0.1 ({dir})
 [COMPILING] foo v0.0.1 ({dir}[..])
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         dir = p.url())));
 
@@ -131,7 +131,7 @@ See http://doc.crates.io/manifest.html#package-metadata for more info.
 [PACKAGING] foo v0.0.1 ({dir})
 [VERIFYING] foo v0.0.1 ({dir})
 [COMPILING] foo v0.0.1 ({dir}[..])
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         dir = p.url())));
 }
@@ -204,7 +204,7 @@ See http://doc.crates.io/manifest.html#package-metadata for more info.
 [PACKAGING] foo v0.0.1 ({dir})
 [VERIFYING] foo v0.0.1 ({dir})
 [COMPILING] foo v0.0.1 ({dir}[..])
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         dir = p.url())));
 }
@@ -401,7 +401,7 @@ See http://doc.crates.io/manifest.html#package-metadata for more info.
 [PACKAGING] nested v0.0.1 ({dir})
 [VERIFYING] nested v0.0.1 ({dir})
 [COMPILING] nested v0.0.1 ({dir}[..])
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         dir = p.url())));
     assert_that(&p.root().join("target/package/nested-0.0.1.crate"), existing_file());
@@ -491,7 +491,7 @@ See [..]
 [PACKAGING] foo v0.0.1 ({dir})
 [VERIFYING] foo v0.0.1 ({dir})
 [COMPILING] foo v0.0.1 ({dir}[..])
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         dir = p.url())));
 

--- a/tests/path.rs
+++ b/tests/path.rs
@@ -78,7 +78,7 @@ fn cargo_compile_with_nested_deps_shorthand() {
                .with_stderr(&format!("[COMPILING] baz v0.5.0 ({}/bar/baz)\n\
                                      [COMPILING] bar v0.5.0 ({}/bar)\n\
                                      [COMPILING] foo v0.5.0 ({})\n\
-                                     [FINISHED] debug [unoptimized + debuginfo] target(s) \
+                                     [FINISHED] dev [unoptimized + debuginfo] target(s) \
                                      in [..]\n",
                                     p.url(),
                                     p.url(),
@@ -96,7 +96,7 @@ fn cargo_compile_with_nested_deps_shorthand() {
     assert_that(p.cargo("build").arg("-p").arg("baz"),
                 execs().with_status(0)
                        .with_stderr(&format!("[COMPILING] baz v0.5.0 ({}/bar/baz)\n\
-                                              [FINISHED] debug [unoptimized + debuginfo] target(s) \
+                                              [FINISHED] dev [unoptimized + debuginfo] target(s) \
                                               in [..]\n",
                                             p.url())));
     println!("building foo");
@@ -105,7 +105,7 @@ fn cargo_compile_with_nested_deps_shorthand() {
                 execs().with_status(0)
                        .with_stderr(&format!("[COMPILING] bar v0.5.0 ({}/bar)\n\
                                              [COMPILING] foo v0.5.0 ({})\n\
-                                             [FINISHED] debug [unoptimized + debuginfo] target(s) \
+                                             [FINISHED] dev [unoptimized + debuginfo] target(s) \
                                              in [..]\n",
                                             p.url(),
                                             p.url())));
@@ -189,7 +189,7 @@ fn cargo_compile_with_root_dev_deps_with_testing() {
                 execs().with_stderr("\
 [COMPILING] [..] v0.5.0 ([..])
 [COMPILING] [..] v0.5.0 ([..])
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target[/]debug[/]deps[/]foo-[..][EXE]")
                        .with_stdout("
 running 0 tests
@@ -244,7 +244,7 @@ fn cargo_compile_with_transitive_dev_deps() {
     assert_that(p.cargo_process("build"),
         execs().with_stderr(&format!("[COMPILING] bar v0.5.0 ({}/bar)\n\
                                      [COMPILING] foo v0.5.0 ({})\n\
-                                     [FINISHED] debug [unoptimized + debuginfo] target(s) in \
+                                     [FINISHED] dev [unoptimized + debuginfo] target(s) in \
                                      [..]\n",
                                     p.url(),
                                     p.url())));
@@ -292,7 +292,7 @@ fn no_rebuild_dependency() {
     assert_that(p.cargo_process("build"),
                 execs().with_stderr(&format!("[COMPILING] bar v0.5.0 ({}/bar)\n\
                                              [COMPILING] foo v0.5.0 ({})\n\
-                                             [FINISHED] debug [unoptimized + debuginfo] target(s) \
+                                             [FINISHED] dev [unoptimized + debuginfo] target(s) \
                                              in [..]\n",
                                             p.url(),
                                             p.url())));
@@ -305,7 +305,7 @@ fn no_rebuild_dependency() {
     assert_that(p.cargo("build"),
                 execs().with_stderr(&format!("[COMPILING] bar v0.5.0 ({}/bar)\n\
                                              [COMPILING] foo v0.5.0 ({})\n\
-                                             [FINISHED] debug [unoptimized + debuginfo] target(s) \
+                                             [FINISHED] dev [unoptimized + debuginfo] target(s) \
                                              in [..]\n",
                                             p.url(),
                                             p.url())));
@@ -364,7 +364,7 @@ fn deep_dependencies_trigger_rebuild() {
                 execs().with_stderr(&format!("[COMPILING] baz v0.5.0 ({}/baz)\n\
                                              [COMPILING] bar v0.5.0 ({}/bar)\n\
                                              [COMPILING] foo v0.5.0 ({})\n\
-                                             [FINISHED] debug [unoptimized + debuginfo] target(s) \
+                                             [FINISHED] dev [unoptimized + debuginfo] target(s) \
                                              in [..]\n",
                                             p.url(),
                                             p.url(),
@@ -384,7 +384,7 @@ fn deep_dependencies_trigger_rebuild() {
                 execs().with_stderr(&format!("[COMPILING] baz v0.5.0 ({}/baz)\n\
                                              [COMPILING] bar v0.5.0 ({}/bar)\n\
                                              [COMPILING] foo v0.5.0 ({})\n\
-                                             [FINISHED] debug [unoptimized + debuginfo] target(s) \
+                                             [FINISHED] dev [unoptimized + debuginfo] target(s) \
                                              in [..]\n",
                                             p.url(),
                                             p.url(),
@@ -399,7 +399,7 @@ fn deep_dependencies_trigger_rebuild() {
     assert_that(p.cargo("build"),
                 execs().with_stderr(&format!("[COMPILING] bar v0.5.0 ({}/bar)\n\
                                              [COMPILING] foo v0.5.0 ({})\n\
-                                             [FINISHED] debug [unoptimized + debuginfo] target(s) \
+                                             [FINISHED] dev [unoptimized + debuginfo] target(s) \
                                              in [..]\n",
                                             p.url(),
                                             p.url())));
@@ -460,7 +460,7 @@ fn no_rebuild_two_deps() {
                 execs().with_stderr(&format!("[COMPILING] baz v0.5.0 ({}/baz)\n\
                                              [COMPILING] bar v0.5.0 ({}/bar)\n\
                                              [COMPILING] foo v0.5.0 ({})\n\
-                                             [FINISHED] debug [unoptimized + debuginfo] target(s) \
+                                             [FINISHED] dev [unoptimized + debuginfo] target(s) \
                                              in [..]\n",
                                             p.url(),
                                             p.url(),
@@ -509,7 +509,7 @@ fn nested_deps_recompile() {
     assert_that(p.cargo_process("build"),
                 execs().with_stderr(&format!("[COMPILING] bar v0.5.0 ({}/src/bar)\n\
                                              [COMPILING] foo v0.5.0 ({})\n\
-                                             [FINISHED] debug [unoptimized + debuginfo] target(s) \
+                                             [FINISHED] dev [unoptimized + debuginfo] target(s) \
                                              in [..]\n",
                                             bar,
                                             p.url())));
@@ -522,7 +522,7 @@ fn nested_deps_recompile() {
     // This shouldn't recompile `bar`
     assert_that(p.cargo("build"),
                 execs().with_stderr(&format!("[COMPILING] foo v0.5.0 ({})\n\
-                                              [FINISHED] debug [unoptimized + debuginfo] target(s) \
+                                              [FINISHED] dev [unoptimized + debuginfo] target(s) \
                                               in [..]\n",
                                             p.url())));
 }
@@ -728,7 +728,7 @@ fn path_dep_build_cmd() {
     assert_that(p.cargo("build"),
         execs().with_stderr(&format!("[COMPILING] bar v0.5.0 ({}/bar)\n\
                                      [COMPILING] foo v0.5.0 ({})\n\
-                                     [FINISHED] debug [unoptimized + debuginfo] target(s) in \
+                                     [FINISHED] dev [unoptimized + debuginfo] target(s) in \
                                      [..]\n",
                                     p.url(),
                                     p.url())));
@@ -747,7 +747,7 @@ fn path_dep_build_cmd() {
     assert_that(p.cargo("build"),
         execs().with_stderr(&format!("[COMPILING] bar v0.5.0 ({}/bar)\n\
                                      [COMPILING] foo v0.5.0 ({})\n\
-                                     [FINISHED] debug [unoptimized + debuginfo] target(s) in \
+                                     [FINISHED] dev [unoptimized + debuginfo] target(s) in \
                                      [..]\n",
                                     p.url(),
                                     p.url())));
@@ -789,7 +789,7 @@ fn dev_deps_no_rebuild_lib() {
                  .env("FOO", "bar"),
                 execs().with_status(0)
                        .with_stderr(&format!("[COMPILING] foo v0.5.0 ({})\n\
-                                              [FINISHED] debug [unoptimized + debuginfo] target(s) \
+                                              [FINISHED] dev [unoptimized + debuginfo] target(s) \
                                               in [..]\n",
                                               p.url())));
 
@@ -798,7 +798,7 @@ fn dev_deps_no_rebuild_lib() {
                        .with_stderr(&format!("\
 [COMPILING] [..] v0.5.0 ({url}[..])
 [COMPILING] [..] v0.5.0 ({url}[..])
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target[/]debug[/]deps[/]foo-[..][EXE]", url = p.url()))
                        .with_stdout("
 running 0 tests
@@ -842,7 +842,7 @@ fn custom_target_no_rebuild() {
                        .with_stderr("\
 [COMPILING] a v0.5.0 ([..])
 [COMPILING] foo v0.5.0 ([..])
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
 
     assert_that(p.cargo("build")
@@ -851,7 +851,7 @@ fn custom_target_no_rebuild() {
                 execs().with_status(0)
                        .with_stderr("\
 [COMPILING] b v0.5.0 ([..])
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
 }
 
@@ -894,7 +894,7 @@ fn override_and_depend() {
 [COMPILING] a2 v0.5.0 ([..])
 [COMPILING] a1 v0.5.0 ([..])
 [COMPILING] b v0.5.0 ([..])
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
 }
 

--- a/tests/profiles.rs
+++ b/tests/profiles.rs
@@ -35,7 +35,7 @@ fn profile_overrides() {
         -C rpath \
         --out-dir [..] \
         -L dependency={dir}[/]target[/]debug[/]deps`
-[FINISHED] debug [optimized] target(s) in [..]
+[FINISHED] dev [optimized] target(s) in [..]
 ",
 dir = p.root().display(),
 url = p.url(),
@@ -223,7 +223,7 @@ package:   [..]
 workspace: [..]
 [COMPILING] bar v0.1.0 ([..])
 [RUNNING] `rustc [..]`
-[FINISHED] debug [unoptimized] target(s) in [..]"));
+[FINISHED] dev [unoptimized] target(s) in [..]"));
 }
 
 #[test]
@@ -252,5 +252,5 @@ fn profile_in_virtual_manifest_works() {
                 execs().with_status(0).with_stderr("\
 [COMPILING] bar v0.1.0 ([..])
 [RUNNING] `rustc [..]`
-[FINISHED] debug [optimized] target(s) in [..]"));
+[FINISHED] dev [optimized] target(s) in [..]"));
 }

--- a/tests/publish.rs
+++ b/tests/publish.rs
@@ -362,7 +362,7 @@ See [..]
 [PACKAGING] foo v0.0.1 ({dir})
 [VERIFYING] foo v0.0.1 ({dir})
 [COMPILING] foo v0.0.1 [..]
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [UPLOADING] foo v0.0.1 ({dir})
 [WARNING] aborting upload due to dry run
 ",

--- a/tests/registry.rs
+++ b/tests/registry.rs
@@ -40,7 +40,7 @@ fn simple() {
 [DOWNLOADING] bar v0.0.1 (registry file://[..])
 [COMPILING] bar v0.0.1
 [COMPILING] foo v0.0.1 ({dir})
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..] secs
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..] secs
 ",
         dir = p.url(),
         reg = registry::registry())));
@@ -51,7 +51,7 @@ fn simple() {
 [UPDATING] registry `{reg}`
 [COMPILING] bar v0.0.1
 [COMPILING] foo v0.0.1 ({dir})
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..] secs
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..] secs
 ",
         dir = p.url(),
         reg = registry::registry())));
@@ -82,7 +82,7 @@ fn deps() {
 [COMPILING] baz v0.0.1
 [COMPILING] bar v0.0.1
 [COMPILING] foo v0.0.1 ({dir})
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..] secs
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..] secs
 ",
         dir = p.url(),
         reg = registry::registry())));
@@ -213,7 +213,7 @@ version required: >= 0.0.0
 [DOWNLOADING] notyet v0.0.1 (registry file://[..])
 [COMPILING] notyet v0.0.1
 [COMPILING] foo v0.0.1 ({dir})
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..] secs
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..] secs
 ",
         dir = p.url(),
         reg = registry::registry())));
@@ -267,7 +267,7 @@ version required: ^0.0.1
 [DOWNLOADING] notyet v0.0.1 (registry file://[..])
 [COMPILING] notyet v0.0.1
 [COMPILING] foo v0.0.1 ({dir}[..])
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..] secs
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..] secs
 ", dir = p.url())));
 }
 
@@ -294,7 +294,7 @@ fn lockfile_locks() {
 [DOWNLOADING] bar v0.0.1 (registry file://[..])
 [COMPILING] bar v0.0.1
 [COMPILING] foo v0.0.1 ({dir})
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..] secs
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..] secs
 ",
    dir = p.url())));
 
@@ -331,7 +331,7 @@ fn lockfile_locks_transitively() {
 [COMPILING] baz v0.0.1
 [COMPILING] bar v0.0.1
 [COMPILING] foo v0.0.1 ({dir})
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..] secs
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..] secs
 ",
    dir = p.url())));
 
@@ -371,7 +371,7 @@ fn yanks_are_not_used() {
 [COMPILING] baz v0.0.1
 [COMPILING] bar v0.0.1
 [COMPILING] foo v0.0.1 ({dir})
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..] secs
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..] secs
 ",
    dir = p.url())));
 }
@@ -464,7 +464,7 @@ fn update_with_lockfile_if_packages_missing() {
                 execs().with_status(0).with_stderr("\
 [UPDATING] registry `[..]`
 [DOWNLOADING] bar v0.0.1 (registry file://[..])
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..] secs
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..] secs
 "));
 }
 
@@ -505,7 +505,7 @@ fn update_lockfile() {
 [DOWNLOADING] [..] v0.0.2 (registry file://[..])
 [COMPILING] bar v0.0.2
 [COMPILING] foo v0.0.1 ({dir})
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..] secs
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..] secs
 ",
    dir = p.url())));
 
@@ -523,7 +523,7 @@ fn update_lockfile() {
 [DOWNLOADING] [..] v0.0.3 (registry file://[..])
 [COMPILING] bar v0.0.3
 [COMPILING] foo v0.0.1 ({dir})
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..] secs
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..] secs
 ",
    dir = p.url())));
 
@@ -573,7 +573,7 @@ fn dev_dependency_not_used() {
 [DOWNLOADING] [..] v0.0.1 (registry file://[..])
 [COMPILING] bar v0.0.1
 [COMPILING] foo v0.0.1 ({dir})
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..] secs
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..] secs
 ",
    dir = p.url())));
 }
@@ -657,7 +657,7 @@ fn updating_a_dep() {
 [COMPILING] bar v0.0.1
 [COMPILING] a v0.0.1 ({dir}/a)
 [COMPILING] foo v0.0.1 ({dir})
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..] secs
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..] secs
 ",
    dir = p.url())));
 
@@ -680,7 +680,7 @@ fn updating_a_dep() {
 [COMPILING] bar v0.1.0
 [COMPILING] a v0.0.1 ({dir}/a)
 [COMPILING] foo v0.0.1 ({dir})
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..] secs
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..] secs
 ",
    dir = p.url())));
 }
@@ -726,7 +726,7 @@ fn git_and_registry_dep() {
 [COMPILING] a v0.0.1
 [COMPILING] b v0.0.1 ([..])
 [COMPILING] foo v0.0.1 ({dir})
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..] secs
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..] secs
 ",
    dir = p.url())));
     p.root().move_into_the_past();
@@ -791,7 +791,7 @@ fn update_publish_then_update() {
 [DOWNLOADING] a v0.1.1 (registry file://[..])
 [COMPILING] a v0.1.1
 [COMPILING] foo v0.5.0 ({dir})
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..] secs
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..] secs
 ",
    dir = p.url())));
 
@@ -859,7 +859,7 @@ fn update_transitive_dependency() {
 [COMPILING] b v0.1.1
 [COMPILING] a v0.1.0
 [COMPILING] foo v0.5.0 ([..])
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..] secs
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..] secs
 "));
 }
 
@@ -1076,7 +1076,7 @@ fn only_download_relevant() {
 [DOWNLOADING] baz v0.1.0 ([..])
 [COMPILING] baz v0.1.0
 [COMPILING] bar v0.5.0 ([..])
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..] secs
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..] secs
 "));
 }
 

--- a/tests/run.rs
+++ b/tests/run.rs
@@ -23,7 +23,7 @@ fn simple() {
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({dir})
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `target[/]debug[/]foo[EXE]`", dir = path2url(p.root())))
                        .with_stdout("\
 hello
@@ -126,7 +126,7 @@ fn exit_code() {
 
     let mut output = String::from("\
 [COMPILING] foo v0.0.1 (file[..])
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `target[..]`
 ");
     if !cfg!(unix) {
@@ -154,7 +154,7 @@ fn exit_code_verbose() {
     let mut output = String::from("\
 [COMPILING] foo v0.0.1 (file[..])
 [RUNNING] `rustc [..]`
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `target[..]`
 ");
     if !cfg!(unix) {
@@ -229,7 +229,7 @@ fn specify_name() {
 [COMPILING] foo v0.0.1 ({dir})
 [RUNNING] `rustc [..] src[/]lib.rs [..]`
 [RUNNING] `rustc [..] src[/]bin[/]a.rs [..]`
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `target[/]debug[/]a[EXE]`", dir = path2url(p.root())))
                        .with_stdout("\
 hello a.rs
@@ -240,7 +240,7 @@ hello a.rs
                        .with_stderr("\
 [COMPILING] foo v0.0.1 ([..])
 [RUNNING] `rustc [..] src[/]bin[/]b.rs [..]`
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `target[/]debug[/]b[EXE]`")
                        .with_stdout("\
 hello b.rs
@@ -268,7 +268,7 @@ fn run_example() {
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({dir})
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `target[/]debug[/]examples[/]a[EXE]`", dir = path2url(p.root())))
                        .with_stdout("\
 example
@@ -361,7 +361,7 @@ fn one_bin_multiple_examples() {
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({dir})
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `target[/]debug[/]main[EXE]`", dir = path2url(p.root())))
                        .with_stdout("\
 hello main.rs
@@ -458,7 +458,7 @@ fast2"));
         --out-dir {dir}[/]target[/]debug[/]examples \
         -L dependency={dir}[/]target[/]debug[/]deps \
          --extern bar={dir}[/]target[/]debug[/]deps[/]libbar-[..].rlib`
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `target[/]debug[/]examples[/]a[EXE]`
 ",
         dir = p.root().display(),
@@ -588,7 +588,7 @@ fn run_from_executable_folder() {
     assert_that(p.cargo("run").cwd(cwd),
                 execs().with_status(0)
                        .with_stderr("\
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]\n\
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]\n\
 [RUNNING] `.[/]foo[EXE]`")
                        .with_stdout("\
 hello

--- a/tests/rustc.rs
+++ b/tests/rustc.rs
@@ -32,7 +32,7 @@ fn build_lib_for_foo() {
         -C metadata=[..] \
         --out-dir [..] \
         -L dependency={dir}[/]target[/]debug[/]deps`
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ", dir = p.root().display(), url = p.url())));
 }
 
@@ -62,7 +62,7 @@ fn lib() {
         -C metadata=[..] \
         --out-dir [..] \
         -L dependency={dir}[/]target[/]debug[/]deps`
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ", dir = p.root().display(), url = p.url())))
 }
 
@@ -98,7 +98,7 @@ fn build_main_and_allow_unstable_options() {
         --out-dir [..] \
         -L dependency={dir}[/]target[/]debug[/]deps \
         --extern {name}={dir}[/]target[/]debug[/]deps[/]lib{name}-[..].rlib`
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
             dir = p.root().display(), url = p.url(),
             name = "foo", version = "0.0.1")));
@@ -156,7 +156,7 @@ fn build_with_args_to_one_of_multiple_binaries() {
         --out-dir [..]`
 [RUNNING] `rustc --crate-name bar src[/]bin[/]bar.rs --crate-type bin --emit=dep-info,link -g \
         -C debug-assertions [..]`
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ", url = p.url())));
 }
 
@@ -212,7 +212,7 @@ fn build_with_args_to_one_of_multiple_tests() {
         --out-dir [..]`
 [RUNNING] `rustc --crate-name bar tests[/]bar.rs --emit=dep-info,link -g \
         -C debug-assertions [..]--test[..]`
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ", url = p.url())));
 }
 
@@ -254,7 +254,7 @@ fn build_foo_with_bar_dependency() {
 [RUNNING] `[..] -g [..]`
 [COMPILING] foo v0.0.1 ({url})
 [RUNNING] `[..] -g -C debug-assertions [..]`
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ", url = foo.url())));
 }
 
@@ -295,7 +295,7 @@ fn build_only_bar_dependency() {
                 .with_stderr("\
 [COMPILING] bar v0.1.0 ([..])
 [RUNNING] `rustc --crate-name bar [..] --crate-type lib [..] -C debug-assertions [..]`
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
 }
 

--- a/tests/rustdoc.rs
+++ b/tests/rustdoc.rs
@@ -23,7 +23,7 @@ fn rustdoc_simple() {
 [RUNNING] `rustdoc --crate-name foo src[/]lib.rs \
         -o {dir}[/]target[/]doc \
         -L dependency={dir}[/]target[/]debug[/]deps`
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ", dir = p.root().display(), url = p.url())));
 }
 
@@ -47,7 +47,7 @@ fn rustdoc_args() {
         -o {dir}[/]target[/]doc \
         --no-defaults \
         -L dependency={dir}[/]target[/]debug[/]deps`
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ", dir = p.root().display(), url = p.url())));
 }
 
@@ -93,7 +93,7 @@ fn rustdoc_foo_with_bar_dependency() {
         --no-defaults \
         -L dependency={dir}[/]target[/]debug[/]deps \
         --extern [..]`
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ", dir = foo.root().display(), url = foo.url())));
 }
 
@@ -137,7 +137,7 @@ fn rustdoc_only_bar_dependency() {
         -o {dir}[/]target[/]doc \
         --no-defaults \
         -L dependency={dir}[/]target[/]debug[/]deps`
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ", dir = foo.root().display())));
 }
 

--- a/tests/rustflags.rs
+++ b/tests/rustflags.rs
@@ -969,7 +969,7 @@ fn target_rustflags_string_and_array_form1() {
         execs().with_status(0).with_stderr("\
 [COMPILING] foo v0.0.1 ([..])
 [RUNNING] `rustc [..] --cfg foo[..]`
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
 
     let p2 = project("foo")
@@ -989,7 +989,7 @@ fn target_rustflags_string_and_array_form1() {
         execs().with_status(0).with_stderr("\
 [COMPILING] foo v0.0.1 ([..])
 [RUNNING] `rustc [..] --cfg foo[..]`
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
 
 }
@@ -1013,7 +1013,7 @@ fn target_rustflags_string_and_array_form2() {
         execs().with_status(0).with_stderr("\
 [COMPILING] foo v0.0.1 ([..])
 [RUNNING] `rustc [..] --cfg foo[..]`
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
 
     let p2 = project("foo")
@@ -1033,7 +1033,7 @@ fn target_rustflags_string_and_array_form2() {
         execs().with_status(0).with_stderr("\
 [COMPILING] foo v0.0.1 ([..])
 [RUNNING] `rustc [..] --cfg foo[..]`
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
 
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -40,7 +40,7 @@ fn cargo_test_simple() {
     assert_that(p.cargo("test"),
                 execs().with_status(0).with_stderr(format!("\
 [COMPILING] foo v0.5.0 ({})
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target[/]debug[/]deps[/]foo-[..][EXE]", p.url()))
                        .with_stdout("
 running 1 test
@@ -130,7 +130,7 @@ fn cargo_test_verbose() {
                 execs().with_status(0).with_stderr(format!("\
 [COMPILING] foo v0.5.0 ({url})
 [RUNNING] `rustc [..] src[/]foo.rs [..]`
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `[..]target[/]debug[/]deps[/]foo-[..][EXE] hello`", url = p.url()))
                        .with_stdout("
 running 1 test
@@ -198,7 +198,7 @@ fn cargo_test_failing_test() {
     assert_that(p.cargo("test"),
                 execs().with_stderr(format!("\
 [COMPILING] foo v0.5.0 ({url})
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target[/]debug[/]deps[/]foo-[..][EXE]
 [ERROR] test failed", url = p.url()))
                        .with_stdout_contains("
@@ -258,7 +258,7 @@ fn test_with_lib_dep() {
     assert_that(p.cargo_process("test"),
                 execs().with_status(0).with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({})
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target[/]debug[/]deps[/]baz-[..][EXE]
 [RUNNING] target[/]debug[/]deps[/]foo-[..][EXE]
 [DOCTEST] foo", p.url()))
@@ -327,7 +327,7 @@ fn test_with_deep_lib_dep() {
                        .with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ([..])
 [COMPILING] bar v0.0.1 ({dir})
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target[..]
 [DOCTEST] bar", dir = p.url()))
                        .with_stdout("
@@ -374,7 +374,7 @@ fn external_test_explicit() {
     assert_that(p.cargo_process("test"),
                 execs().with_status(0).with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({})
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target[/]debug[/]deps[/]foo-[..][EXE]
 [RUNNING] target[/]debug[/]deps[/]test-[..][EXE]
 [DOCTEST] foo", p.url()))
@@ -423,7 +423,7 @@ fn external_test_implicit() {
     assert_that(p.cargo_process("test"),
                 execs().with_status(0).with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({})
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target[/]debug[/]deps[/]external-[..][EXE]
 [RUNNING] target[/]debug[/]deps[/]foo-[..][EXE]
 [DOCTEST] foo", p.url()))
@@ -483,7 +483,7 @@ fn pass_through_command_line() {
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({dir})
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target[/]debug[/]deps[/]foo-[..][EXE]
 [DOCTEST] foo", dir = p.url()))
                        .with_stdout("
@@ -502,7 +502,7 @@ test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
     assert_that(p.cargo("test").arg("foo"),
                 execs().with_status(0)
                        .with_stderr("\
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target[/]debug[/]deps[/]foo-[..][EXE]
 [DOCTEST] foo")
                        .with_stdout("
@@ -567,7 +567,7 @@ fn lib_bin_same_name() {
     assert_that(p.cargo_process("test"),
                 execs().with_status(0).with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({})
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target[/]debug[/]deps[/]foo-[..][EXE]
 [RUNNING] target[/]debug[/]deps[/]foo-[..][EXE]
 [DOCTEST] foo", p.url()))
@@ -620,7 +620,7 @@ fn lib_with_standard_name() {
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] syntax v0.0.1 ({dir})
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target[/]debug[/]deps[/]syntax-[..][EXE]
 [RUNNING] target[/]debug[/]deps[/]test-[..][EXE]
 [DOCTEST] syntax", dir = p.url()))
@@ -675,7 +675,7 @@ fn lib_with_standard_name2() {
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] syntax v0.0.1 ({dir})
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target[/]debug[/]deps[/]syntax-[..][EXE]", dir = p.url()))
                        .with_stdout("
 running 1 test
@@ -715,7 +715,7 @@ fn lib_without_name() {
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] syntax v0.0.1 ({dir})
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target[/]debug[/]deps[/]syntax-[..][EXE]", dir = p.url()))
                        .with_stdout("
 running 1 test
@@ -973,7 +973,7 @@ fn test_dylib() {
                        .with_stderr(&format!("\
 [COMPILING] bar v0.0.1 ({dir}/bar)
 [COMPILING] foo v0.0.1 ({dir})
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target[/]debug[/]deps[/]foo-[..][EXE]
 [RUNNING] target[/]debug[/]deps[/]test-[..][EXE]", dir = p.url()))
                        .with_stdout("
@@ -993,7 +993,7 @@ test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
     assert_that(p.cargo("test"),
                 execs().with_status(0)
                        .with_stderr("\
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target[/]debug[/]deps[/]foo-[..][EXE]
 [RUNNING] target[/]debug[/]deps[/]test-[..][EXE]")
                        .with_stdout("
@@ -1032,7 +1032,7 @@ fn test_twice_with_build_cmd() {
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({dir})
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target[/]debug[/]deps[/]foo-[..][EXE]
 [DOCTEST] foo", dir = p.url()))
                        .with_stdout("
@@ -1051,7 +1051,7 @@ test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
     assert_that(p.cargo("test"),
                 execs().with_status(0)
                        .with_stderr("\
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target[/]debug[/]deps[/]foo-[..][EXE]
 [DOCTEST] foo")
                        .with_stdout("
@@ -1086,7 +1086,7 @@ fn test_then_build() {
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({dir})
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target[/]debug[/]deps[/]foo-[..][EXE]
 [DOCTEST] foo", dir = p.url()))
                        .with_stdout("
@@ -1125,7 +1125,7 @@ fn test_no_run() {
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({dir})
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
                        dir = p.url())));
 }
@@ -1154,7 +1154,7 @@ fn test_run_specific_bin_target() {
                 execs().with_status(0)
                        .with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({dir})
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target[/]debug[/]deps[/]bin2-[..][EXE]", dir = prj.url()))
                        .with_stdout("
 running 1 test
@@ -1183,7 +1183,7 @@ fn test_run_specific_test_target() {
                 execs().with_status(0)
                        .with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({dir})
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target[/]debug[/]deps[/]b-[..][EXE]", dir = prj.url()))
                        .with_stdout("
 running 1 test
@@ -1219,7 +1219,7 @@ fn test_no_harness() {
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({dir})
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target[/]debug[/]deps[/]bar-[..][EXE]
 ",
                        dir = p.url())));
@@ -1275,7 +1275,7 @@ fn selective_testing() {
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] d1 v0.0.1 ({dir}/d1)
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target[/]debug[/]deps[/]d1-[..][EXE]
 [RUNNING] target[/]debug[/]deps[/]d1-[..][EXE]", dir = p.url()))
                        .with_stdout("
@@ -1295,7 +1295,7 @@ test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] d2 v0.0.1 ({dir}/d2)
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target[/]debug[/]deps[/]d2-[..][EXE]
 [RUNNING] target[/]debug[/]deps[/]d2-[..][EXE]", dir = p.url()))
                        .with_stdout("
@@ -1315,7 +1315,7 @@ test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({dir})
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target[/]debug[/]deps[/]foo-[..][EXE]", dir = p.url()))
                        .with_stdout("
 running 0 tests
@@ -1477,7 +1477,7 @@ fn selective_testing_with_docs() {
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] d1 v0.0.1 ({dir}/d1)
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target[/]debug[/]deps[/]d1[..][EXE]
 [DOCTEST] d1", dir = p.url()))
                        .with_stdout("
@@ -1511,7 +1511,7 @@ fn example_bin_same_name() {
 [COMPILING] foo v0.0.1 ({dir})
 [RUNNING] `rustc [..]`
 [RUNNING] `rustc [..]`
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ", dir = p.url())));
 
     assert_that(&p.bin("foo"), is_not(existing_file()));
@@ -1524,7 +1524,7 @@ fn example_bin_same_name() {
                 execs().with_status(0)
                        .with_stderr("\
 [COMPILING] foo v0.0.1 ([..])
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] [..]")
                        .with_stdout("\
 bin
@@ -1589,7 +1589,7 @@ fn example_with_dev_dep() {
 [..]
 [..]
 [RUNNING] `rustc --crate-name ex [..] --extern a=[..]`
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
 }
 
@@ -1659,7 +1659,7 @@ fn doctest_feature() {
                 execs().with_status(0)
                        .with_stderr("\
 [COMPILING] foo [..]
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target[/]debug[/]deps[/]foo[..][EXE]
 [DOCTEST] foo")
                        .with_stdout("
@@ -1746,7 +1746,7 @@ fn filter_no_doc_tests() {
     assert_that(p.cargo_process("test").arg("--test=foo"),
                 execs().with_status(0).with_stderr("\
 [COMPILING] foo v0.0.1 ([..])
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target[/]debug[/]deps[/]foo[..][EXE]")
                        .with_stdout("
 running 0 tests
@@ -1780,7 +1780,7 @@ fn dylib_doctest() {
     assert_that(p.cargo_process("test"),
                 execs().with_status(0).with_stderr("\
 [COMPILING] foo v0.0.1 ([..])
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [DOCTEST] foo")
                        .with_stdout("
 running 1 test
@@ -1850,7 +1850,7 @@ fn cyclic_dev_dep_doc_test() {
                 execs().with_status(0).with_stderr("\
 [COMPILING] foo v0.0.1 ([..])
 [COMPILING] bar v0.0.1 ([..])
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target[/]debug[/]deps[/]foo[..][EXE]
 [DOCTEST] foo")
                        .with_stdout("
@@ -1943,7 +1943,7 @@ fn no_fail_fast() {
                 execs().with_status(101)
                        .with_stderr_contains("\
 [COMPILING] foo v0.0.1 ([..])
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target[/]debug[/]deps[/]foo-[..][EXE]
 [RUNNING] target[/]debug[/]deps[/]test_add_one-[..][EXE]")
                        .with_stdout_contains("
@@ -2061,7 +2061,7 @@ fn bin_does_not_rebuild_tests() {
 [COMPILING] foo v0.0.1 ([..])
 [RUNNING] `rustc [..] src[/]main.rs [..]`
 [RUNNING] `rustc [..] src[/]main.rs [..]`
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
 }
 
@@ -2123,7 +2123,7 @@ fn selective_test_optional_dep() {
 [COMPILING] a v0.0.1 ([..])
 [RUNNING] `rustc [..] a[/]src[/]lib.rs [..]`
 [RUNNING] `rustc [..] a[/]src[/]lib.rs [..]`
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
 }
 
@@ -2155,7 +2155,7 @@ fn only_test_docs() {
                 execs().with_status(0)
                        .with_stderr("\
 [COMPILING] foo v0.0.1 ([..])
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [DOCTEST] foo")
                        .with_stdout("
 running 1 test
@@ -2229,7 +2229,7 @@ fn cfg_test_even_with_no_harness() {
                        .with_stderr("\
 [COMPILING] foo v0.0.1 ([..])
 [RUNNING] `rustc [..]`
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `[..]`
 "));
 }

--- a/tests/tool-paths.rs
+++ b/tests/tool-paths.rs
@@ -30,7 +30,7 @@ fn pathless_tools() {
                 execs().with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({url})
 [RUNNING] `rustc [..] -C ar=nonexistent-ar -C linker=nonexistent-linker [..]`
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ", url = foo.url())))
 }
 
@@ -72,7 +72,7 @@ fn absolute_tools() {
                 execs().with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({url})
 [RUNNING] `rustc [..] -C ar={ar} -C linker={linker} [..]`
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ", url = foo.url(), ar = output.0, linker = output.1)))
 }
 
@@ -121,6 +121,6 @@ fn relative_tools() {
                 execs().with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({url})
 [RUNNING] `rustc [..] -C ar={ar} -C linker={linker} [..]`
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ", url = foo_url, ar = output.0, linker = output.1)))
 }

--- a/tests/workspaces.rs
+++ b/tests/workspaces.rs
@@ -504,7 +504,7 @@ fn share_dependencies() {
 [DOWNLOADING] dep1 v0.1.3 ([..])
 [COMPILING] dep1 v0.1.3
 [COMPILING] foo v0.1.0 ([..])
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
 }
 
@@ -589,7 +589,7 @@ fn lock_works_for_everyone() {
 [DOWNLOADING] dep2 v0.1.0 ([..])
 [COMPILING] dep2 v0.1.0
 [COMPILING] foo v0.1.0 ([..])
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
 
     assert_that(p.cargo("build").cwd(p.root().join("bar")),
@@ -598,7 +598,7 @@ fn lock_works_for_everyone() {
 [DOWNLOADING] dep1 v0.1.0 ([..])
 [COMPILING] dep1 v0.1.0
 [COMPILING] bar v0.1.0 ([..])
-[FINISHED] debug [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
 }
 


### PR DESCRIPTION
This renames the debug target to dev in the build output for non-release
builds.  This includes the output of commands such as `cargo build`,
`cargo test`, and `cargo doc`.

Closes #3519