### PR TITLE
Allow debuginfo level to be specified

### DIFF
--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -130,7 +130,7 @@ pub struct Profile {
     pub codegen_units: Option<u32>,    // None = use rustc default
     pub rustc_args: Option<Vec<String>>,
     pub rustdoc_args: Option<Vec<String>>,
-    pub debuginfo: bool,
+    pub debuginfo: Option<u32>,
     pub debug_assertions: bool,
     pub rpath: bool,
     pub test: bool,
@@ -143,7 +143,7 @@ pub struct Profile {
 #[derive(RustcEncodable)]
 struct SerializedProfile<'a> {
     opt_level: &'a str,
-    debuginfo: bool,
+    debuginfo: Option<u32>,
     debug_assertions: bool,
     test: bool,
 }
@@ -488,7 +488,7 @@ impl fmt::Display for Target {
 impl Profile {
     pub fn default_dev() -> Profile {
         Profile {
-            debuginfo: true,
+            debuginfo: Some(2),
             debug_assertions: true,
             ..Profile::default()
         }
@@ -497,7 +497,7 @@ impl Profile {
     pub fn default_release() -> Profile {
         Profile {
             opt_level: "3".to_string(),
-            debuginfo: false,
+            debuginfo: None,
             ..Profile::default()
         }
     }
@@ -554,7 +554,7 @@ impl Default for Profile {
             codegen_units: None,
             rustc_args: None,
             rustdoc_args: None,
-            debuginfo: false,
+            debuginfo: None,
             debug_assertions: false,
             rpath: false,
             test: false,

--- a/src/cargo/ops/cargo_rustc/custom_build.rs
+++ b/src/cargo/ops/cargo_rustc/custom_build.rs
@@ -107,7 +107,7 @@ fn build_work<'a, 'cfg>(cx: &mut Context<'a, 'cfg>, unit: &Unit<'a>)
            Kind::Host => cx.host_triple(),
            Kind::Target => cx.target_triple(),
        })
-       .env("DEBUG", &profile.debuginfo.to_string())
+       .env("DEBUG", &profile.debuginfo.is_some().to_string())
        .env("OPT_LEVEL", &profile.opt_level)
        .env("PROFILE", if cx.build_config.release { "release" } else { "debug" })
        .env("HOST", cx.host_triple())

--- a/src/cargo/ops/cargo_rustc/job_queue.rs
+++ b/src/cargo/ops/cargo_rustc/job_queue.rs
@@ -201,7 +201,7 @@ impl<'a> JobQueue<'a> {
         let profile = cx.lib_profile();
         let mut opt_type = String::from(if profile.opt_level == "0" { "unoptimized" }
                                         else { "optimized" });
-        if profile.debuginfo {
+        if profile.debuginfo.is_some() {
             opt_type = opt_type + " + debuginfo";
         }
         let duration = start_time.elapsed();

--- a/src/cargo/ops/cargo_rustc/mod.rs
+++ b/src/cargo/ops/cargo_rustc/mod.rs
@@ -94,7 +94,7 @@ pub fn compile_targets<'a, 'cfg: 'a>(ws: &Workspace<'cfg>,
                                      resolve: &'a Resolve,
                                      config: &'cfg Config,
                                      build_config: BuildConfig,
-                                     profiles: &'a Profiles, 
+                                     profiles: &'a Profiles,
                                      exec: Arc<Executor>)
                                      -> CargoResult<Compilation<'cfg>> {
     let units = pkg_targets.iter().flat_map(|&(pkg, ref targets)| {
@@ -659,8 +659,8 @@ fn build_base_args(cx: &mut Context,
         }
     }
 
-    if debuginfo {
-        cmd.arg("-g");
+    if let Some(debuginfo) = debuginfo {
+        cmd.arg("-C").arg(format!("debuginfo={}", debuginfo));
     }
 
     if let Some(ref args) = *rustc_args {

--- a/src/doc/manifest.md
+++ b/src/doc/manifest.md
@@ -181,7 +181,8 @@ along with the defaults for each profile.
 # The development profile, used for `cargo build`.
 [profile.dev]
 opt-level = 0      # controls the `--opt-level` the compiler builds with
-debug = true       # controls whether the compiler passes `-g`
+debug = true       # controls whether the compiler passes `-C debuginfo`
+                   # a value of `true` is equivalent to `2`
 rpath = false      # controls whether the compiler passes `-C rpath`
 lto = false        # controls `-C lto` for binaries and staticlibs
 debug-assertions = true # controls whether debug assertions are enabled
@@ -202,7 +203,7 @@ panic = 'unwind'
 # The testing profile, used for `cargo test`.
 [profile.test]
 opt-level = 0
-debug = true
+debug = 2
 rpath = false
 lto = false
 debug-assertions = true
@@ -222,7 +223,7 @@ panic = 'unwind'
 # The documentation profile, used for `cargo doc`.
 [profile.doc]
 opt-level = 0
-debug = true
+debug = 2
 rpath = false
 lto = false
 debug-assertions = true

--- a/tests/build-lib.rs
+++ b/tests/build-lib.rs
@@ -8,7 +8,7 @@ fn verbose_output_for_lib(p: &ProjectBuilder) -> String {
     format!("\
 [COMPILING] {name} v{version} ({url})
 [RUNNING] `rustc --crate-name {name} src[/]lib.rs --crate-type lib \
-        --emit=dep-info,link -g \
+        --emit=dep-info,link -C debuginfo=2 \
         -C metadata=[..] \
         --out-dir [..] \
         -L dependency={dir}[/]target[/]debug[/]deps`

--- a/tests/build-script.rs
+++ b/tests/build-script.rs
@@ -184,7 +184,7 @@ fn custom_build_script_rustc_flags() {
                 execs().with_status(101)
                        .with_stderr(&format!("\
 [COMPILING] bar v0.5.0 ({url})
-[RUNNING] `rustc --crate-name test {dir}{sep}src{sep}lib.rs --crate-type lib -g \
+[RUNNING] `rustc --crate-name test {dir}{sep}src{sep}lib.rs --crate-type lib -C debuginfo=2 \
         -C metadata=[..] \
         -C extra-filename=-[..] \
         --out-dir {dir}{sep}target \
@@ -766,19 +766,19 @@ fn build_cmd_with_a_build_cmd() {
 [RUNNING] `rustc [..] a[/]build.rs [..] --extern b=[..]`
 [RUNNING] `[..][/]a-[..][/]build-script-build`
 [RUNNING] `rustc --crate-name a [..]lib.rs --crate-type lib \
-    --emit=dep-info,link -g \
+    --emit=dep-info,link -C debuginfo=2 \
     -C metadata=[..] \
     --out-dir [..]target[/]debug[/]deps \
     -L [..]target[/]debug[/]deps`
 [COMPILING] foo v0.5.0 (file://[..])
 [RUNNING] `rustc --crate-name build_script_build build.rs --crate-type bin \
     --emit=dep-info,link \
-    -g -C metadata=[..] --out-dir [..] \
+    -C debuginfo=2 -C metadata=[..] --out-dir [..] \
     -L [..]target[/]debug[/]deps \
     --extern a=[..]liba[..].rlib`
 [RUNNING] `[..][/]foo-[..][/]build-script-build`
 [RUNNING] `rustc --crate-name foo [..]lib.rs --crate-type lib \
-    --emit=dep-info,link -g \
+    --emit=dep-info,link -C debuginfo=2 \
     -C metadata=[..] \
     --out-dir [..] \
     -L [..]target[/]debug[/]deps`

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -821,13 +821,13 @@ fn cargo_default_env_metadata_env_var() {
 [COMPILING] bar v0.0.1 ({url}/bar)
 [RUNNING] `rustc --crate-name bar bar[/]src[/]lib.rs --crate-type dylib \
         --emit=dep-info,link \
-        -C prefer-dynamic -g \
+        -C prefer-dynamic -C debuginfo=2 \
         -C metadata=[..] \
         --out-dir [..] \
         -L dependency={dir}[/]target[/]debug[/]deps`
 [COMPILING] foo v0.0.1 ({url})
 [RUNNING] `rustc --crate-name foo src[/]lib.rs --crate-type lib \
-        --emit=dep-info,link -g \
+        --emit=dep-info,link -C debuginfo=2 \
         -C metadata=[..] \
         -C extra-filename=[..] \
         --out-dir [..] \
@@ -848,13 +848,13 @@ suffix = env::consts::DLL_SUFFIX,
 [COMPILING] bar v0.0.1 ({url}/bar)
 [RUNNING] `rustc --crate-name bar bar[/]src[/]lib.rs --crate-type dylib \
         --emit=dep-info,link \
-        -C prefer-dynamic -g \
+        -C prefer-dynamic -C debuginfo=2 \
         -C metadata=[..] \
         --out-dir [..] \
         -L dependency={dir}[/]target[/]debug[/]deps`
 [COMPILING] foo v0.0.1 ({url})
 [RUNNING] `rustc --crate-name foo src[/]lib.rs --crate-type lib \
-        --emit=dep-info,link -g \
+        --emit=dep-info,link -C debuginfo=2 \
         -C metadata=[..] \
         -C extra-filename=[..] \
         --out-dir [..] \
@@ -1198,7 +1198,7 @@ fn verbose_build() {
                 execs().with_status(0).with_stderr(&format!("\
 [COMPILING] test v0.0.0 ({url})
 [RUNNING] `rustc --crate-name test src[/]lib.rs --crate-type lib \
-        --emit=dep-info,link -g \
+        --emit=dep-info,link -C debuginfo=2 \
         -C metadata=[..] \
         --out-dir [..] \
         -L dependency={dir}[/]target[/]debug[/]deps`
@@ -2443,7 +2443,7 @@ fn compiler_json_error_format() {
         "reason":"compiler-artifact",
         "profile": {
             "debug_assertions": true,
-            "debuginfo": true,
+            "debuginfo": 2,
             "opt_level": "0",
             "test": false
         },
@@ -2475,7 +2475,7 @@ fn compiler_json_error_format() {
         "target":{"kind":["bin"],"name":"foo","src_path":"[..]main.rs"},
         "profile": {
             "debug_assertions": true,
-            "debuginfo": true,
+            "debuginfo": 2,
             "opt_level": "0",
             "test": false
         },
@@ -2537,7 +2537,7 @@ fn message_format_json_forward_stderr() {
         "target":{"kind":["bin"],"name":"foo","src_path":"[..]"},
         "profile":{
             "debug_assertions":true,
-            "debuginfo":true,
+            "debuginfo":2,
             "opt_level":"0",
             "test":false
         },

--- a/tests/cross-compile.rs
+++ b/tests/cross-compile.rs
@@ -432,7 +432,7 @@ fn linker_and_ar() {
                        .with_stderr_contains(&format!("\
 [COMPILING] foo v0.5.0 ({url})
 [RUNNING] `rustc --crate-name foo src[/]foo.rs --crate-type bin \
-    --emit=dep-info,link -g \
+    --emit=dep-info,link -C debuginfo=2 \
     -C metadata=[..] \
     --out-dir {dir}[/]target[/]{target}[/]debug[/]deps \
     --target {target} \

--- a/tests/profiles.rs
+++ b/tests/profiles.rs
@@ -62,7 +62,38 @@ fn opt_level_override_0() {
 [COMPILING] test v0.0.0 ({url})
 [RUNNING] `rustc --crate-name test src[/]lib.rs --crate-type lib \
         --emit=dep-info,link \
-        -g \
+        -C debuginfo=2 \
+        -C metadata=[..] \
+        --out-dir [..] \
+        -L dependency={dir}[/]target[/]debug[/]deps`
+[FINISHED] [..] target(s) in [..]
+",
+dir = p.root().display(),
+url = p.url()
+)));
+}
+
+#[test]
+fn debug_override_1() {
+    let mut p = project("foo");
+
+    p = p
+        .file("Cargo.toml", r#"
+            [package]
+            name = "test"
+            version = "0.0.0"
+            authors = []
+
+            [profile.dev]
+            debug = 1
+        "#)
+        .file("src/lib.rs", "");
+    assert_that(p.cargo_process("build").arg("-v"),
+                execs().with_status(0).with_stderr(&format!("\
+[COMPILING] test v0.0.0 ({url})
+[RUNNING] `rustc --crate-name test src[/]lib.rs --crate-type lib \
+        --emit=dep-info,link \
+        -C debuginfo=1 \
         -C metadata=[..] \
         --out-dir [..] \
         -L dependency={dir}[/]target[/]debug[/]deps`
@@ -93,7 +124,7 @@ fn check_opt_level_override(profile_level: &str, rustc_level: &str) {
 [RUNNING] `rustc --crate-name test src[/]lib.rs --crate-type lib \
         --emit=dep-info,link \
         -C opt-level={level} \
-        -g \
+        -C debuginfo=2 \
         -C debug-assertions=on \
         -C metadata=[..] \
         --out-dir [..] \
@@ -164,7 +195,7 @@ fn top_level_overrides_deps() {
         --emit=dep-info,link \
         -C prefer-dynamic \
         -C opt-level=1 \
-        -g \
+        -C debuginfo=2 \
         -C metadata=[..] \
         --out-dir {dir}[/]target[/]release[/]deps \
         -L dependency={dir}[/]target[/]release[/]deps`
@@ -172,7 +203,7 @@ fn top_level_overrides_deps() {
 [RUNNING] `rustc --crate-name test src[/]lib.rs --crate-type lib \
         --emit=dep-info,link \
         -C opt-level=1 \
-        -g \
+        -C debuginfo=2 \
         -C metadata=[..] \
         --out-dir [..] \
         -L dependency={dir}[/]target[/]release[/]deps \

--- a/tests/run.rs
+++ b/tests/run.rs
@@ -446,14 +446,14 @@ fast2"));
 [COMPILING] bar v0.0.1 ({url}/bar)
 [RUNNING] `rustc --crate-name bar bar[/]src[/]bar.rs --crate-type lib \
         --emit=dep-info,link \
-        -g \
+        -C debuginfo=2 \
         -C metadata=[..] \
         --out-dir {dir}[/]target[/]debug[/]deps \
         -L dependency={dir}[/]target[/]debug[/]deps`
 [COMPILING] foo v0.0.1 ({url})
 [RUNNING] `rustc --crate-name a examples[/]a.rs --crate-type bin \
         --emit=dep-info,link \
-        -g \
+        -C debuginfo=2 \
         -C metadata=[..] \
         --out-dir {dir}[/]target[/]debug[/]examples \
         -L dependency={dir}[/]target[/]debug[/]deps \

--- a/tests/rustc.rs
+++ b/tests/rustc.rs
@@ -28,7 +28,7 @@ fn build_lib_for_foo() {
                 .with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({url})
 [RUNNING] `rustc --crate-name foo src[/]lib.rs --crate-type lib \
-        --emit=dep-info,link -g \
+        --emit=dep-info,link -C debuginfo=2 \
         -C metadata=[..] \
         --out-dir [..] \
         -L dependency={dir}[/]target[/]debug[/]deps`
@@ -57,7 +57,7 @@ fn lib() {
                 .with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({url})
 [RUNNING] `rustc --crate-name foo src[/]lib.rs --crate-type lib \
-        --emit=dep-info,link -g \
+        --emit=dep-info,link -C debuginfo=2 \
         -C debug-assertions=off \
         -C metadata=[..] \
         --out-dir [..] \
@@ -87,12 +87,12 @@ fn build_main_and_allow_unstable_options() {
                 .with_stderr(&format!("\
 [COMPILING] {name} v{version} ({url})
 [RUNNING] `rustc --crate-name {name} src[/]lib.rs --crate-type lib \
-        --emit=dep-info,link -g \
+        --emit=dep-info,link -C debuginfo=2 \
         -C metadata=[..] \
         --out-dir [..] \
         -L dependency={dir}[/]target[/]debug[/]deps`
 [RUNNING] `rustc --crate-name {name} src[/]main.rs --crate-type bin \
-        --emit=dep-info,link -g \
+        --emit=dep-info,link -C debuginfo=2 \
         -C debug-assertions \
         -C metadata=[..] \
         --out-dir [..] \
@@ -151,11 +151,11 @@ fn build_with_args_to_one_of_multiple_binaries() {
                 .with_status(0)
                 .with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({url})
-[RUNNING] `rustc --crate-name foo src[/]lib.rs --crate-type lib --emit=dep-info,link -g \
-        -C metadata=[..] \
+[RUNNING] `rustc --crate-name foo src[/]lib.rs --crate-type lib --emit=dep-info,link \
+        -C debuginfo=2 -C metadata=[..] \
         --out-dir [..]`
-[RUNNING] `rustc --crate-name bar src[/]bin[/]bar.rs --crate-type bin --emit=dep-info,link -g \
-        -C debug-assertions [..]`
+[RUNNING] `rustc --crate-name bar src[/]bin[/]bar.rs --crate-type bin --emit=dep-info,link \
+        -C debuginfo=2 -C debug-assertions [..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ", url = p.url())));
 }
@@ -207,10 +207,10 @@ fn build_with_args_to_one_of_multiple_tests() {
                 .with_status(0)
                 .with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({url})
-[RUNNING] `rustc --crate-name foo src[/]lib.rs --crate-type lib --emit=dep-info,link -g \
-        -C metadata=[..] \
+[RUNNING] `rustc --crate-name foo src[/]lib.rs --crate-type lib --emit=dep-info,link \
+        -C debuginfo=2 -C metadata=[..] \
         --out-dir [..]`
-[RUNNING] `rustc --crate-name bar tests[/]bar.rs --emit=dep-info,link -g \
+[RUNNING] `rustc --crate-name bar tests[/]bar.rs --emit=dep-info,link -C debuginfo=2 \
         -C debug-assertions [..]--test[..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ", url = p.url())));
@@ -251,9 +251,9 @@ fn build_foo_with_bar_dependency() {
                 .with_status(0)
                 .with_stderr(format!("\
 [COMPILING] bar v0.1.0 ([..])
-[RUNNING] `[..] -g [..]`
+[RUNNING] `[..] -C debuginfo=2 [..]`
 [COMPILING] foo v0.0.1 ({url})
-[RUNNING] `[..] -g -C debug-assertions [..]`
+[RUNNING] `[..] -C debuginfo=2 -C debug-assertions [..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ", url = foo.url())));
 }


### PR DESCRIPTION
`true` is mapped to `2`, which matches current behavior.

r? @alexcrichton 