### PR TITLE
Add a check for names starting with a digit

### DIFF
--- a/src/cargo/ops/cargo_new.rs
+++ b/src/cargo/ops/cargo_new.rs
@@ -135,6 +135,13 @@ fn check_name(name: &str) -> CargoResult<()> {
                name)
     }
 
+    if let Some(ref c) = name.chars().nth(0) {
+        if c.is_digit(10) {
+            bail!("Package names starting with a digit cannot be used as a crate name\n\
+               use --name to override crate name")
+        }
+    }
+
     for c in name.chars() {
         if c.is_alphanumeric() { continue }
         if c == '_' || c == '-' { continue }


### PR DESCRIPTION
According to Rust grammer https://doc.rust-lang.org/grammar.html#extern-crate-declarations for extern crate declarations, a crate name cannot start with a digit.

But, currently this rule is not upheld by `cargo new` as creating a project like:

`cargo new 2048` would create a project named 2048 which obviously won't compile with crate declaration like `extern crate 2048` by a consumer.

This obviously is a rare case in practice, but its always good to check i guess.

This PR adds a check to the `new` method and `bail`s out with a message for any names starting with a digit.

PS: I noticed it while making a 2048 puzzle game as a library so thought it would be nice to add this check :)

