### PR TITLE
Upload Travis CI and Appveyor badge metadata specified in the manifest

### DIFF
--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::fmt;
 use std::path::{PathBuf, Path};
 
@@ -55,6 +56,7 @@ pub struct ManifestMetadata {
     pub homepage: Option<String>,       // url
     pub repository: Option<String>,     // url
     pub documentation: Option<String>,  // url
+    pub badges: HashMap<String, HashMap<String, String>>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]

--- a/src/cargo/ops/registry.rs
+++ b/src/cargo/ops/registry.rs
@@ -113,7 +113,7 @@ fn transmit(config: &Config,
     let ManifestMetadata {
         ref authors, ref description, ref homepage, ref documentation,
         ref keywords, ref readme, ref repository, ref license, ref license_file,
-        ref categories,
+        ref categories, ref badges,
     } = *manifest.metadata();
     let readme = match *readme {
         Some(ref readme) => Some(paths::read(&pkg.root().join(readme))?),
@@ -149,6 +149,7 @@ fn transmit(config: &Config,
         repository: repository.clone(),
         license: license.clone(),
         license_file: license_file.clone(),
+        badges: badges.clone(),
     }, tarball);
 
     match publish {
@@ -161,6 +162,18 @@ fn transmit(config: &Config,
                     ", warnings.invalid_categories.join(", "));
                 config.shell().warn(&msg)?;
             }
+
+            if !warnings.invalid_badges.is_empty() {
+                let msg = format!("\
+                    the following are not valid badges and were ignored: {}. \
+                    Either the badge type specified is unknown or a required \
+                    attribute is missing. Please see \
+                    http://doc.crates.io/manifest.html#package-metadata \
+                    for valid badge types and their required attributes.",
+                    warnings.invalid_badges.join(", "));
+                config.shell().warn(&msg)?;
+            }
+
             Ok(())
         },
         Err(e) => Err(human(e.to_string())),

--- a/src/cargo/util/toml.rs
+++ b/src/cargo/util/toml.rs
@@ -246,6 +246,7 @@ pub struct TomlManifest {
     target: Option<HashMap<String, TomlPlatform>>,
     replace: Option<HashMap<String, TomlDependency>>,
     workspace: Option<TomlWorkspace>,
+    badges: Option<HashMap<String, HashMap<String, String>>>,
 }
 
 #[derive(RustcDecodable, Clone, Default)]
@@ -656,6 +657,7 @@ impl TomlManifest {
             repository: project.repository.clone(),
             keywords: project.keywords.clone().unwrap_or(Vec::new()),
             categories: project.categories.clone().unwrap_or(Vec::new()),
+            badges: self.badges.clone().unwrap_or_else(HashMap::new),
         };
 
         let workspace_config = match (self.workspace.as_ref(),

--- a/src/doc/manifest.md
+++ b/src/doc/manifest.md
@@ -138,6 +138,16 @@ license = "..."
 # lieu of the above key and must point to a file relative to this manifest
 # (similar to the readme key).
 license-file = "..."
+
+# Optional specificaion of badges to be displayed on crates.io. The badges
+# currently available are Travis CI and Appveyor latest build status, specified
+# using the following parameters:
+[badges]
+# Travis CI: `repository` is required. `branch` is optional; default is `master`
+travis-ci = { repository = "...", branch = "master" }
+# Appveyor: `repository` is required. `branch` is optional; default is `master`
+# `service` is optional; valid values are `github` (default) and `bitbucket`
+appveyor = { repository = "...", branch = "master", service = "github" }
 ```
 
 The [crates.io](https://crates.io) registry will render the description, display


### PR DESCRIPTION
This goes with rust-lang/crates.io#504. This has cargo upload badge metadata to crates.io on publish, and will print any warnings it gets back from crates.io about unknown badges or missing required badge attributes!

This will definitely cause some merge conflicts with #3301, I'll watch and fix whichever one gets merged 2nd :)

