### PR TITLE
Find workspace root via encompassing member

### DIFF
--- a/src/doc/manifest.md
+++ b/src/doc/manifest.md
@@ -384,11 +384,11 @@ properties:
 
 [RFC 1525]: https://github.com/rust-lang/rfcs/blob/master/text/1525-cargo-workspace.md
 
-The root crate of a workspace, indicated by the presence of `[workspace]` in
-its manifest, is responsible for defining the entire workspace (listing all
-members). This can be done through the `members` key, and if it is omitted then
-members are implicitly included through all `path` dependencies. Note that
-members of the workspaces listed explicitly will also have their path
+The root crate of a workspace, indicated by the presence of `[workspace]` in its
+manifest, is responsible for defining the entire workspace. All `path`
+dependencies residing in the workspace directory become members. You can add
+additional packages to the workspace by listing them in the `members` key. Note
+that members of the workspaces listed explicitly will also have their path
 dependencies included in the workspace.
 
 The `package.workspace` manifest key (described above) is used in member crates

--- a/tests/workspaces.rs
+++ b/tests/workspaces.rs
@@ -1196,6 +1196,7 @@ fn test_path_dependency_under_member() {
             [dependencies]
             foo = { path = "../foo" }
 
+            [workspace]
         "#)
         .file("ws/src/lib.rs", r"extern crate foo; pub fn f() { foo::f() }")
         .file("foo/Cargo.toml", r#"

--- a/tests/workspaces.rs
+++ b/tests/workspaces.rs
@@ -1101,3 +1101,31 @@ fn relative_path_for_member_works() {
     assert_that(p.cargo("build").cwd(p.root().join("foo")), execs().with_status(0));
     assert_that(p.cargo("build").cwd(p.root().join("bar")), execs().with_status(0));
 }
+
+#[test]
+fn path_dep_outside_workspace_is_not_member() {
+    let p = project("foo")
+        .file("ws/Cargo.toml", r#"
+            [project]
+            name = "ws"
+            version = "0.1.0"
+            authors = []
+
+            [dependencies]
+            foo = { path = "../foo" }
+
+            [workspace]
+        "#)
+        .file("ws/src/lib.rs", r"extern crate foo;")
+        .file("foo/Cargo.toml", r#"
+            [project]
+            name = "foo"
+            version = "0.1.0"
+            authors = []
+        "#)
+        .file("foo/src/lib.rs", "");
+    p.build();
+
+    assert_that(p.cargo("build").cwd(p.root().join("ws")),
+                execs().with_status(0));
+}

--- a/tests/workspaces.rs
+++ b/tests/workspaces.rs
@@ -1226,8 +1226,7 @@ fn test_path_dependency_under_member() {
 
     assert_that(p.cargo("build").cwd(p.root().join("foo/bar")),
                 execs().with_status(0));
-    // Ideally, `foo/bar` should be a member of the workspace,
-    // because it is hierarchically under the workspace member.
-    assert_that(&p.root().join("foo/bar/Cargo.lock"), existing_file());
-    assert_that(&p.root().join("foo/bar/target"), existing_dir());
+
+    assert_that(&p.root().join("foo/bar/Cargo.lock"), is_not(existing_file()));
+    assert_that(&p.root().join("foo/bar/target"), is_not(existing_dir()));
 }


### PR DESCRIPTION
Expand #3443 to also find workspace root via member. Also fixes the test from https://github.com/rust-lang/cargo/pull/3443#issuecomment-272981716