### PR TITLE
Allow doc tests to run on proc macro crates

### DIFF
--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -382,7 +382,11 @@ impl Target {
     pub fn doctested(&self) -> bool {
         self.doctest && match self.kind {
             TargetKind::Lib(ref kinds) => {
-                kinds.contains(&LibKind::Rlib) || kinds.contains(&LibKind::Lib)
+                kinds.iter().find(|k| {
+                  *k == &LibKind::Rlib ||
+                  *k == &LibKind::Lib ||
+                  *k == &LibKind::ProcMacro
+                }).is_some()
             }
             _ => false,
         }


### PR DESCRIPTION
Fixes https://github.com/rust-lang/cargo/issues/3545

Since `--test` works for rustc, doctests should also work. Currently cargo isn't setup to run doctests for proc macro crates, this PR adds them to the list.

Currently rustdoc can run doctests for proc-macro crates, but the `phase_2_configure_and_expand` call` triggers the following warning:

```
the `#[proc_macro_derive]` attribute is only usable with crates of the `proc-macro` crate type
```

So perhaps this PR should wait until I've finished creating/testing the PR for rustc.