### PR TITLE
Allow examples to be library

### DIFF
--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -113,7 +113,6 @@ impl Encodable for TargetKind {
     fn encode<S: Encoder>(&self, s: &mut S) -> Result<(), S::Error> {
         match *self {
             TargetKind::Lib(ref kinds) |
-            // TODO: I am not sure whether it should be encoded like a library or like an example
             TargetKind::ExampleLib(ref kinds) => {
                 kinds.iter().map(LibKind::crate_type).collect()
             }

--- a/src/cargo/core/package.rs
+++ b/src/cargo/core/package.rs
@@ -6,7 +6,7 @@ use std::path::{Path, PathBuf};
 
 use semver::Version;
 
-use core::{Dependency, Manifest, PackageId, SourceId, Target, TargetKind};
+use core::{Dependency, Manifest, PackageId, SourceId, Target};
 use core::{Summary, SourceMap};
 use ops;
 use util::{CargoResult, Config, LazyCell, ChainError, internal, human, lev_distance};
@@ -94,10 +94,10 @@ impl Package {
         self.targets().iter().any(|t| t.is_custom_build())
     }
 
-    pub fn find_closest_target(&self, target: &str, kind: TargetKind) -> Option<&Target> {
+    pub fn find_closest_target(&self, target: &str, is_expected_kind: fn(&Target)-> bool) -> Option<&Target> {
         let targets = self.targets();
 
-        let matches = targets.iter().filter(|t| *t.kind() == kind)
+        let matches = targets.iter().filter(|t| is_expected_kind(t))
                                     .map(|t| (lev_distance(target, t.name()), t))
                                     .filter(|&(d, _)| d < 4);
         matches.min_by_key(|t| t.0).map(|t| t.1)

--- a/src/cargo/core/package.rs
+++ b/src/cargo/core/package.rs
@@ -94,7 +94,9 @@ impl Package {
         self.targets().iter().any(|t| t.is_custom_build())
     }
 
-    pub fn find_closest_target(&self, target: &str, is_expected_kind: fn(&Target)-> bool) -> Option<&Target> {
+    pub fn find_closest_target(&self,
+                               target: &str,
+                               is_expected_kind: fn(&Target)-> bool) -> Option<&Target> {
         let targets = self.targets();
 
         let matches = targets.iter().filter(|t| is_expected_kind(t))

--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -386,7 +386,10 @@ fn generate_targets<'a>(pkg: &'a Package,
             }
 
             {
-                let mut find = |names: &[String], desc, is_expected_kind: fn(&Target) -> bool, profile| {
+                let mut find = |names: &[String],
+                                desc,
+                                is_expected_kind: fn(&Target) -> bool,
+                                profile| {
                     for name in names {
                         let target = pkg.targets().iter().find(|t| {
                             t.name() == *name && is_expected_kind(t)

--- a/src/cargo/ops/cargo_rustc/context.rs
+++ b/src/cargo/ops/cargo_rustc/context.rs
@@ -133,6 +133,7 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
         for unit in units {
             self.visit_crate_type(unit, &mut crate_types)?;
         }
+        debug!("probe_target_info: crate_types={:?}", crate_types);
         self.probe_target_info_kind(&crate_types, Kind::Target)?;
         if self.requested_target().is_none() {
             self.host_info = self.target_info.clone();
@@ -517,19 +518,22 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
                 };
 
                 match *unit.target.kind() {
-                    TargetKind::Example |
                     TargetKind::Bin |
                     TargetKind::CustomBuild |
+                    TargetKind::ExampleBin |
                     TargetKind::Bench |
                     TargetKind::Test => {
                         add("bin", false)?;
                     }
-                    TargetKind::Lib(..) if unit.profile.test => {
+                    TargetKind::Lib(..) |
+                    TargetKind::ExampleLib(..)
+                    if unit.profile.test => {
                         add("bin", false)?;
                     }
-                    TargetKind::Lib(ref libs) => {
-                        for lib in libs {
-                            add(lib.crate_type(), lib.linkable())?;
+                    TargetKind::ExampleLib(ref kinds) |
+                    TargetKind::Lib(ref kinds) => {
+                        for kind in kinds {
+                            add(kind.crate_type(), kind.linkable())?;
                         }
                     }
                 }

--- a/src/cargo/ops/cargo_rustc/fingerprint.rs
+++ b/src/cargo/ops/cargo_rustc/fingerprint.rs
@@ -657,7 +657,8 @@ fn filename(cx: &mut Context, unit: &Unit) -> String {
         TargetKind::Lib(..) => "lib",
         TargetKind::Bin => "bin",
         TargetKind::Test => "integration-test",
-        TargetKind::Example => "example",
+        TargetKind::ExampleBin |
+        TargetKind::ExampleLib(..) => "example",
         TargetKind::Bench => "bench",
         TargetKind::CustomBuild => "build-script",
     };

--- a/src/cargo/util/toml.rs
+++ b/src/cargo/util/toml.rs
@@ -1159,7 +1159,16 @@ fn normalize(package_root: &Path,
                 PathValue::Path(default(ex))
             });
 
-            let mut target = Target::example_target(&ex.name(), package_root.join(path.to_path()));
+            let crate_types = match ex.crate_type {
+                Some(ref kinds) => kinds.iter().map(|s| LibKind::from_str(s)).collect(),
+                None => Vec::new()
+            };
+
+            let mut target = Target::example_target(
+                &ex.name(),
+                crate_types,
+                package_root.join(path.to_path())
+            );
             configure(ex, &mut target);
             dst.push(target);
         }

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -1952,6 +1952,10 @@ fn example_as_dylib() {
 
 #[test]
 fn example_as_proc_macro() {
+    if !is_nightly() {
+        return;
+    }
+
     let p = project("foo")
         .file("Cargo.toml", r#"
             [package]

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -1924,7 +1924,7 @@ fn example_as_rlib() {
             crate-type = ["rlib"]
         "#)
         .file("src/lib.rs", "")
-        .file("examples/ex.rs", "fn a() {}");
+        .file("examples/ex.rs", "");
 
     assert_that(p.cargo_process("build").arg("--example=ex"), execs().with_status(0));
     assert_that(&p.example_lib("ex", "rlib"), existing_file());
@@ -1964,7 +1964,7 @@ fn example_as_proc_macro() {
             crate-type = ["proc-macro"]
         "#)
         .file("src/lib.rs", "")
-        .file("examples/ex.rs", "");
+        .file("examples/ex.rs", "#![feature(proc_macro)]");
 
     assert_that(p.cargo_process("build").arg("--example=ex"), execs().with_status(0));
     assert_that(&p.example_lib("ex", "proc-macro"), existing_file());

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -1891,6 +1891,82 @@ fn cargo_platform_specific_dependency_wrong_platform() {
 }
 
 #[test]
+fn example_as_lib() {
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [package]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+
+            [[example]]
+            name = "ex"
+            crate-type = ["lib"]
+        "#)
+        .file("src/lib.rs", "")
+        .file("examples/ex.rs", "");
+
+    assert_that(p.cargo_process("build"), execs().with_status(0));
+}
+
+#[test]
+fn example_as_rlib() {
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [package]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+
+            [[example]]
+            name = "ex"
+            crate-type = ["rlib"]
+        "#)
+        .file("src/lib.rs", "")
+        .file("examples/ex.rs", "");
+
+    assert_that(p.cargo_process("build"), execs().with_status(0));
+}
+
+#[test]
+fn example_as_dylib() {
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [package]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+
+            [[example]]
+            name = "ex"
+            crate-type = ["dylib"]
+        "#)
+        .file("src/lib.rs", "")
+        .file("examples/ex.rs", "");
+
+    assert_that(p.cargo_process("build"), execs().with_status(0));
+}
+
+#[test]
+fn example_as_proc_macro() {
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [package]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+
+            [[example]]
+            name = "ex"
+            crate-type = ["proc-macro"]
+        "#)
+        .file("src/lib.rs", "")
+        .file("examples/ex.rs", "");
+
+    assert_that(p.cargo_process("build"), execs().with_status(0));
+}
+
+#[test]
 fn example_bin_same_name() {
     let p = project("foo")
         .file("Cargo.toml", r#"

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -1906,7 +1906,8 @@ fn example_as_lib() {
         .file("src/lib.rs", "")
         .file("examples/ex.rs", "");
 
-    assert_that(p.cargo_process("build"), execs().with_status(0));
+    assert_that(p.cargo_process("build").arg("--example=ex"), execs().with_status(0));
+    assert_that(&p.example_lib("ex", "lib"), existing_file());
 }
 
 #[test]
@@ -1923,9 +1924,10 @@ fn example_as_rlib() {
             crate-type = ["rlib"]
         "#)
         .file("src/lib.rs", "")
-        .file("examples/ex.rs", "");
+        .file("examples/ex.rs", "fn a() {}");
 
-    assert_that(p.cargo_process("build"), execs().with_status(0));
+    assert_that(p.cargo_process("build").arg("--example=ex"), execs().with_status(0));
+    assert_that(&p.example_lib("ex", "rlib"), existing_file());
 }
 
 #[test]
@@ -1944,7 +1946,8 @@ fn example_as_dylib() {
         .file("src/lib.rs", "")
         .file("examples/ex.rs", "");
 
-    assert_that(p.cargo_process("build"), execs().with_status(0));
+    assert_that(p.cargo_process("build").arg("--example=ex"), execs().with_status(0));
+    assert_that(&p.example_lib("ex", "dylib"), existing_file());
 }
 
 #[test]
@@ -1963,7 +1966,8 @@ fn example_as_proc_macro() {
         .file("src/lib.rs", "")
         .file("examples/ex.rs", "");
 
-    assert_that(p.cargo_process("build"), execs().with_status(0));
+    assert_that(p.cargo_process("build").arg("--example=ex"), execs().with_status(0));
+    assert_that(&p.example_lib("ex", "proc-macro"), existing_file());
 }
 
 #[test]


### PR DESCRIPTION
This PR allows to specify **crate-type** to an example in **Cargo.toml**.
After this PR an example's **crate-type** can be:

* lib
* rlib
* dylib
* proc-macro

Please look at src/cargo/core/manifest.rs:116 because I am not sure whether I done it right.

I haven't added any tests.
I'd like to add them if someone says me how to do that.

Fixes #2358.