### PR TITLE
Add dep-info generation

### DIFF
--- a/src/cargo/ops/cargo_rustc/mod.rs
+++ b/src/cargo/ops/cargo_rustc/mod.rs
@@ -18,6 +18,8 @@ use util::Freshness;
 use self::job::{Job, Work};
 use self::job_queue::JobQueue;
 
+use self::output_depinfo::output_depinfo;
+
 pub use self::compilation::Compilation;
 pub use self::context::{Context, Unit};
 pub use self::custom_build::{BuildOutput, BuildMap, BuildScripts};
@@ -30,6 +32,7 @@ mod job;
 mod job_queue;
 mod layout;
 mod links;
+mod output_depinfo;
 
 #[derive(PartialEq, Eq, Hash, Debug, Clone, Copy, PartialOrd, Ord)]
 pub enum Kind { Host, Target }
@@ -184,6 +187,8 @@ pub fn compile_targets<'a, 'cfg: 'a>(ws: &Workspace<'cfg>,
                 .or_insert(HashSet::new())
                 .extend(feats.iter().map(|feat| format!("feature=\"{}\"", feat)));
         }
+
+        output_depinfo(&mut cx, unit)?;
     }
 
     for (&(ref pkg, _), output) in cx.build_state.outputs.lock().unwrap().iter() {

--- a/src/cargo/ops/cargo_rustc/output_depinfo.rs
+++ b/src/cargo/ops/cargo_rustc/output_depinfo.rs
@@ -1,0 +1,127 @@
+use std::borrow::ToOwned;
+use std::collections::HashSet;
+use std::io::{Read, Write};
+use std::fs::File;
+use std::path::{Path, PathBuf};
+
+use core::{TargetKind};
+use ops::{Context, Unit};
+use util::{CargoResult, internal, human};
+
+#[derive(Debug)]
+struct DepLine {
+    target: String,
+    deps: Vec<String>,
+}
+
+struct DepFile {
+    dir: String,
+    deps: Vec<DepLine>,
+}
+
+fn render_filename<P: AsRef<Path>>(path: P, basedir: Option<&str>) -> CargoResult<String> {
+    let path = path.as_ref();
+    let relpath = match basedir {
+        None => path,
+        Some(base) => match path.strip_prefix(base) {
+            Ok(relpath) => relpath,
+            _ => path,
+        }
+    };
+    relpath.to_str().ok_or(internal("path not utf-8")).map(ToOwned::to_owned)
+}
+
+fn read_dep_file<P: AsRef<Path>>(path: P) -> CargoResult<DepFile> {
+    let mut file = File::open(&path).map_err(|_|
+        human("error opening ".to_string() + path.as_ref().to_str().unwrap_or("(bad unicode")))?;
+    let mut contents = String::new();
+    let _ = file.read_to_string(&mut contents)?;
+    let mut spl = contents.split('\0');
+    let dir = spl.next().ok_or(internal("dependency file empty"))?;
+    let dep_txt = spl.next().ok_or(internal("dependency file missing null byte"))?;
+    let mut result = Vec::new();
+    for line in dep_txt.lines() {
+        let mut line_spl = line.split(": ");
+        if let Some(target) = line_spl.next() {
+            if let Some(deps) = line_spl.next() {
+                let deps = deps.split_whitespace().map(ToOwned::to_owned).collect();
+                result.push(DepLine {
+                    target: target.to_string(),
+                    deps: deps,
+                });
+            }
+        }
+    }
+    Ok(DepFile {
+        dir: dir.to_string(),
+        deps: result,
+    })
+}
+
+fn add_deps(depfile: &DepFile, deps: &mut HashSet<PathBuf>) {
+    let dep_dir = PathBuf::from(&depfile.dir);
+    for depline in &depfile.deps {
+        for dep in &depline.deps {
+            deps.insert(dep_dir.join(dep));
+        }
+    }
+}
+
+// TODO: probably better to use Context::target_filenames for this
+fn target_filename(context: &mut Context, unit: &Unit) -> CargoResult<PathBuf> {
+    let (dir, base) = context.link_stem(&unit).ok_or(internal("can't get link stem"))?;
+    if unit.target.is_lib() {
+        Ok(dir.join(["lib", &base, ".rlib"].concat()))
+    } else {
+        Ok(dir.join(base))
+    }
+}
+
+fn add_deps_for_unit(deps: &mut HashSet<PathBuf>, context: &mut Context, unit: &Unit)
+    -> CargoResult<()>
+{
+    // TODO: this is duplicated against filename in fingerprint.rs
+    let kind = match *unit.target.kind() {
+        TargetKind::Lib(..) => "lib",
+        TargetKind::Bin => "bin",
+        TargetKind::Test => "integration-test",
+        TargetKind::Example => "example",
+        TargetKind::Bench => "bench",
+        TargetKind::CustomBuild => "build-script",
+    };
+    let flavor = if unit.profile.test {
+        "test-"
+    } else if unit.profile.doc {
+        "doc-"
+    } else {
+        ""
+    };
+    let dep_filename = ["dep-", flavor, kind, "-", &context.file_stem(&unit)].concat();
+    let path = context.fingerprint_dir(&unit).join(&dep_filename);
+    let depfile = read_dep_file(&path)?;
+    add_deps(&depfile, deps);
+    Ok(())
+}
+
+pub fn output_depinfo(context: &mut Context, unit: &Unit) -> CargoResult<()> {
+    let mut deps = HashSet::new();
+    add_deps_for_unit(&mut deps, context, unit)?;
+    for dep_unit in &context.dep_targets(unit)? {
+        let source_id = dep_unit.pkg.package_id().source_id();
+        if source_id.is_path() {
+            add_deps_for_unit(&mut deps, context, dep_unit)?;
+        }
+    }
+    let filename = target_filename(context, unit)?;
+    let mut output_path = filename.clone().into_os_string();
+    output_path.push(".d");
+    let basedir = None; // TODO
+    let target_fn = render_filename(filename, basedir)?;
+    let mut outfile = File::create(output_path)?;
+    write!(outfile, "{}:", target_fn)?;
+    for dep in &deps {
+        write!(outfile, " {}", render_filename(dep, basedir)?)?;
+    }
+    writeln!(outfile, "")?;
+    Ok(())
+}

--- a/src/cargo/ops/cargo_rustc/output_depinfo.rs
+++ b/src/cargo/ops/cargo_rustc/output_depinfo.rs
@@ -1,5 +1,5 @@
 use std::collections::HashSet;
-use std::io::Write;
+use std::io::{Write, BufWriter};
 use std::fs::File;
 use std::path::{Path, PathBuf};
 
@@ -53,7 +53,7 @@ pub fn output_depinfo<'a, 'b>(context: &mut Context<'a, 'b>, unit: &Unit<'a>) ->
         if let Some(link_dst) = link_dst {
             let output_path = link_dst.with_extension("d");
             let target_fn = render_filename(link_dst, basedir)?;
-            let mut outfile = File::create(output_path)?;
+            let mut outfile = BufWriter::new(File::create(output_path)?);
             write!(outfile, "{}:", target_fn)?;
             for dep in &deps {
                 write!(outfile, " {}", render_filename(dep, basedir)?)?;

--- a/src/cargo/ops/cargo_rustc/output_depinfo.rs
+++ b/src/cargo/ops/cargo_rustc/output_depinfo.rs
@@ -85,7 +85,8 @@ fn add_deps_for_unit(deps: &mut HashSet<PathBuf>, context: &mut Context, unit: &
         TargetKind::Lib(..) => "lib",
         TargetKind::Bin => "bin",
         TargetKind::Test => "integration-test",
-        TargetKind::Example => "example",
+        TargetKind::ExampleBin |
+        TargetKind::ExampleLib(..) => "example",
         TargetKind::Bench => "bench",
         TargetKind::CustomBuild => "build-script",
     };

--- a/src/cargo/ops/cargo_rustc/output_depinfo.rs
+++ b/src/cargo/ops/cargo_rustc/output_depinfo.rs
@@ -1,23 +1,11 @@
-use std::borrow::ToOwned;
 use std::collections::HashSet;
-use std::io::{Read, Write};
+use std::io::Write;
 use std::fs::File;
 use std::path::{Path, PathBuf};
 
-use core::{TargetKind};
 use ops::{Context, Unit};
-use util::{CargoResult, internal, human};
-
-#[derive(Debug)]
-struct DepLine {
-    target: String,
-    deps: Vec<String>,
-}
-
-struct DepFile {
-    dir: String,
-    deps: Vec<DepLine>,
-}
+use util::{CargoResult, internal};
+use ops::cargo_rustc::fingerprint;
 
 fn render_filename<P: AsRef<Path>>(path: P, basedir: Option<&str>) -> CargoResult<String> {
     let path = path.as_ref();
@@ -28,101 +16,50 @@ fn render_filename<P: AsRef<Path>>(path: P, basedir: Option<&str>) -> CargoResul
             _ => path,
         }
     };
-    relpath.to_str().ok_or(internal("path not utf-8")).map(ToOwned::to_owned)
+    relpath.to_str().ok_or(internal("path not utf-8")).map(|f| f.replace(" ", "\\ "))
 }
 
-fn read_dep_file<P: AsRef<Path>>(path: P) -> CargoResult<DepFile> {
-    let mut file = File::open(&path).map_err(|_|
-        human("error opening ".to_string() + path.as_ref().to_str().unwrap_or("(bad unicode")))?;
-    let mut contents = String::new();
-    let _ = file.read_to_string(&mut contents)?;
-    let mut spl = contents.split('\0');
-    let dir = spl.next().ok_or(internal("dependency file empty"))?;
-    let dep_txt = spl.next().ok_or(internal("dependency file missing null byte"))?;
-    let mut result = Vec::new();
-    for line in dep_txt.lines() {
-        let mut line_spl = line.split(": ");
-        if let Some(target) = line_spl.next() {
-            if let Some(deps) = line_spl.next() {
-                let deps = deps.split_whitespace().map(ToOwned::to_owned).collect();
-                result.push(DepLine {
-                    target: target.to_string(),
-                    deps: deps,
-                });
-            }
-        }
-    }
-    Ok(DepFile {
-        dir: dir.to_string(),
-        deps: result,
-    })
-}
-
-fn add_deps(depfile: &DepFile, deps: &mut HashSet<PathBuf>) {
-    let dep_dir = PathBuf::from(&depfile.dir);
-    for depline in &depfile.deps {
-        for dep in &depline.deps {
-            deps.insert(dep_dir.join(dep));
-        }
-    }
-}
-
-// TODO: probably better to use Context::target_filenames for this
-fn target_filename(context: &mut Context, unit: &Unit) -> CargoResult<PathBuf> {
-    let (dir, base) = context.link_stem(&unit).ok_or(internal("can't get link stem"))?;
-    if unit.target.is_lib() {
-        Ok(dir.join(["lib", &base, ".rlib"].concat()))
-    } else {
-        Ok(dir.join(base))
-    }
-}
-
-fn add_deps_for_unit(deps: &mut HashSet<PathBuf>, context: &mut Context, unit: &Unit)
-    -> CargoResult<()>
+fn add_deps_for_unit<'a, 'b>(deps: &mut HashSet<PathBuf>, context: &mut Context<'a, 'b>,
+    unit: &Unit<'a>, visited: &mut HashSet<Unit<'a>>) -> CargoResult<()>
 {
-    // TODO: this is duplicated against filename in fingerprint.rs
-    let kind = match *unit.target.kind() {
-        TargetKind::Lib(..) => "lib",
-        TargetKind::Bin => "bin",
-        TargetKind::Test => "integration-test",
-        TargetKind::ExampleBin |
-        TargetKind::ExampleLib(..) => "example",
-        TargetKind::Bench => "bench",
-        TargetKind::CustomBuild => "build-script",
-    };
-    let flavor = if unit.profile.test {
-        "test-"
-    } else if unit.profile.doc {
-        "doc-"
-    } else {
-        ""
-    };
-    let dep_filename = ["dep-", flavor, kind, "-", &context.file_stem(&unit)].concat();
-    let path = context.fingerprint_dir(&unit).join(&dep_filename);
-    let depfile = read_dep_file(&path)?;
-    add_deps(&depfile, deps);
-    Ok(())
-}
+    if visited.contains(unit) {
+        return Ok(());
+    }
+    visited.insert(unit.clone());
 
-pub fn output_depinfo(context: &mut Context, unit: &Unit) -> CargoResult<()> {
-    let mut deps = HashSet::new();
-    add_deps_for_unit(&mut deps, context, unit)?;
+    let dep_info_loc = fingerprint::dep_info_loc(context, unit);
+    if let Some(paths) = fingerprint::parse_dep_info(&dep_info_loc)? {
+        for path in paths {
+            deps.insert(path);
+        }
+    }
+
+    // recursively traverse all transitive dependencies
     for dep_unit in &context.dep_targets(unit)? {
         let source_id = dep_unit.pkg.package_id().source_id();
         if source_id.is_path() {
-            add_deps_for_unit(&mut deps, context, dep_unit)?;
+            add_deps_for_unit(deps, context, dep_unit, visited)?;
         }
     }
-    let filename = target_filename(context, unit)?;
-    let mut output_path = filename.clone().into_os_string();
-    output_path.push(".d");
+    Ok(())
+}
+
+pub fn output_depinfo<'a, 'b>(context: &mut Context<'a, 'b>, unit: &Unit<'a>) -> CargoResult<()> {
+    let mut deps = HashSet::new();
+    let mut visited = HashSet::new();
+    add_deps_for_unit(&mut deps, context, unit, &mut visited)?;
     let basedir = None; // TODO
-    let target_fn = render_filename(filename, basedir)?;
-    let mut outfile = File::create(output_path)?;
-    write!(outfile, "{}:", target_fn)?;
-    for dep in &deps {
-        write!(outfile, " {}", render_filename(dep, basedir)?)?;
+    for (_filename, link_dst, _linkable) in context.target_filenames(unit)? {
+        if let Some(link_dst) = link_dst {
+            let output_path = link_dst.with_extension("d");
+            let target_fn = render_filename(link_dst, basedir)?;
+            let mut outfile = File::create(output_path)?;
+            write!(outfile, "{}:", target_fn)?;
+            for dep in &deps {
+                write!(outfile, " {}", render_filename(dep, basedir)?)?;
+            }
+            writeln!(outfile, "")?;
+        }
     }
-    writeln!(outfile, "")?;
     Ok(())
 }

--- a/tests/dep-info.rs
+++ b/tests/dep-info.rs
@@ -1,0 +1,79 @@
+extern crate cargotest;
+extern crate hamcrest;
+
+use cargotest::support::{basic_bin_manifest, main_file, execs, project};
+use hamcrest::{assert_that, existing_file};
+
+#[test]
+fn build_dep_info() {
+    let p = project("foo")
+        .file("Cargo.toml", &basic_bin_manifest("foo"))
+        .file("src/foo.rs", &main_file(r#""i am foo""#, &[]));
+
+    assert_that(p.cargo_process("build"), execs().with_status(0));
+
+    let depinfo_bin_path = &p.bin("foo").with_extension("d");
+
+    assert_that(depinfo_bin_path, existing_file());
+}
+
+#[test]
+fn build_dep_info_lib() {
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [package]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+
+            [[example]]
+            name = "ex"
+            crate-type = ["lib"]
+        "#)
+        .file("src/lib.rs", "")
+        .file("examples/ex.rs", "");
+
+    assert_that(p.cargo_process("build").arg("--example=ex"), execs().with_status(0));
+    assert_that(&p.example_lib("ex", "lib").with_extension("d"), existing_file());
+}
+
+
+#[test]
+fn build_dep_info_rlib() {
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [package]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+
+            [[example]]
+            name = "ex"
+            crate-type = ["rlib"]
+        "#)
+        .file("src/lib.rs", "")
+        .file("examples/ex.rs", "");
+
+    assert_that(p.cargo_process("build").arg("--example=ex"), execs().with_status(0));
+    assert_that(&p.example_lib("ex", "rlib").with_extension("d"), existing_file());
+}
+
+#[test]
+fn build_dep_info_dylib() {
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [package]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+
+            [[example]]
+            name = "ex"
+            crate-type = ["dylib"]
+        "#)
+        .file("src/lib.rs", "")
+        .file("examples/ex.rs", "");
+
+    assert_that(p.cargo_process("build").arg("--example=ex"), execs().with_status(0));
+    assert_that(&p.example_lib("ex", "dylib").with_extension("d"), existing_file());
+}


### PR DESCRIPTION
Work in progress: add a --dep-info flag to cargo build (and also
rustc) that outputs dependency information in a form compatible with
make and ninja, to a specified file. This will help in integrating
into other build systems.