### PR TITLE
Made doc subcommand print duration

### DIFF
--- a/src/cargo/ops/cargo_rustc/job_queue.rs
+++ b/src/cargo/ops/cargo_rustc/job_queue.rs
@@ -30,7 +30,6 @@ pub struct JobQueue<'a> {
     documented: HashSet<&'a PackageId>,
     counts: HashMap<&'a PackageId, usize>,
     is_release: bool,
-    is_doc_all: bool,
 }
 
 /// A helper structure for metadata about the state of a building package.
@@ -90,7 +89,6 @@ impl<'a> JobQueue<'a> {
             documented: HashSet::new(),
             counts: HashMap::new(),
             is_release: cx.build_config.release,
-            is_doc_all: cx.build_config.doc_all,
         }
     }
 
@@ -209,12 +207,11 @@ impl<'a> JobQueue<'a> {
                                    duration.as_secs(),
                                    duration.subsec_nanos() / 10000000);
         if self.queue.is_empty() {
-            if !self.is_doc_all {
-                cx.config.shell().status("Finished", format!("{} [{}] target(s) in {}",
-                                                                  build_type,
-                                                                  opt_type,
-                                                                  time_elapsed))?;
-            }
+            let message = format!("{} [{}] target(s) in {}",
+                                  build_type,
+                                  opt_type,
+                                  time_elapsed);
+            cx.config.shell().status("Finished", message)?;
             Ok(())
         } else if let Some(e) = error {
             Err(e)

--- a/tests/build-script.rs
+++ b/tests/build-script.rs
@@ -520,6 +520,7 @@ test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
                        .with_stderr("\
 [DOCUMENTING] foo v0.5.0 (file://[..])
 [RUNNING] `rustdoc [..]`
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
 
     File::create(&p.root().join("src/main.rs")).unwrap()

--- a/tests/doc.rs
+++ b/tests/doc.rs
@@ -28,6 +28,7 @@ fn simple() {
                 execs().with_status(0).with_stderr(&format!("\
 [..] foo v0.0.1 ({dir})
 [..] foo v0.0.1 ({dir})
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         dir = path2url(p.root()))));
     assert_that(&p.root().join("target/doc"), existing_dir());
@@ -71,6 +72,7 @@ fn doc_twice() {
     assert_that(p.cargo_process("doc"),
                 execs().with_status(0).with_stderr(&format!("\
 [DOCUMENTING] foo v0.0.1 ({dir})
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         dir = path2url(p.root()))));
 
@@ -109,6 +111,7 @@ fn doc_deps() {
 [..] bar v0.0.1 ({dir}/bar)
 [..] bar v0.0.1 ({dir}/bar)
 [DOCUMENTING] foo v0.0.1 ({dir})
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         dir = path2url(p.root()))));
 
@@ -255,6 +258,7 @@ fn doc_dash_p() {
 [..] b v0.0.1 (file://[..])
 [..] b v0.0.1 (file://[..])
 [DOCUMENTING] a v0.0.1 (file://[..])
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
 }
 
@@ -447,6 +451,7 @@ fn doc_release() {
                        .with_stderr("\
 [DOCUMENTING] foo v0.0.1 ([..])
 [RUNNING] `rustdoc [..] src[/]lib.rs [..]`
+[FINISHED] release [optimized] target(s) in [..]
 "));
 }
 

--- a/tests/rustdocflags.rs
+++ b/tests/rustdocflags.rs
@@ -77,9 +77,12 @@ fn rerun() {
     assert_that(p.cargo("doc").env("RUSTDOCFLAGS", "--cfg=foo"),
                 execs().with_status(0));
     assert_that(p.cargo("doc").env("RUSTDOCFLAGS", "--cfg=foo"),
-                execs().with_status(0).with_stderr(""));
+                execs().with_status(0).with_stderr("\
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+"));
     assert_that(p.cargo("doc").env("RUSTDOCFLAGS", "--cfg=bar"),
                 execs().with_status(0).with_stderr("\
 [DOCUMENTING] foo v0.0.1 ([..])
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
 }


### PR DESCRIPTION
This PR makes `cargo doc` print duration.
Fixes #3016.