### PR TITLE
Fix doc publishing: Remove $USER from the --user argument from pip install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -116,7 +116,7 @@ after_success: |
   [ $TRAVIS_BRANCH = master ] &&
   [ $TRAVIS_PULL_REQUEST = false ] &&
   [ $(uname -s) = Linux ] &&
-  pip install ghp-import --user $USER &&
+  pip install ghp-import --user &&
   $HOME/.local/bin/ghp-import -n target/doc &&
   git push -qf https://${GH_TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git gh-pages
 


### PR DESCRIPTION
[This looks to be the cause of why docs aren't publishing to gh-pages](https://travis-ci.org/rust-lang/cargo/jobs/193507734#L1059). I was able to publish the docs to [my repo's gh-pages](https://integer32llc.github.io/cargo/) with this change (and setting my own secure gh-token).

It looks like this problem got introduced [in this commit](https://github.com/rust-lang/cargo/commit/dc15ca5d202d6d10f6be45f388759a902723de6c). I don't really know python/pip, but `$USER` wasn't there before and [Travis' docs just say `--user`](https://docs.travis-ci.com/user/languages/python/#pip).