### PR TITLE
Added '--deps-only' to {build, doc} subcommands

### DIFF
--- a/src/bin/bench.rs
+++ b/src/bin/bench.rs
@@ -91,6 +91,7 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
             spec: ops::Packages::Packages(&options.flag_package),
             release: true,
             mode: ops::CompileMode::Bench,
+            deps_only: false,
             filter: ops::CompileFilter::new(options.flag_lib,
                                             &options.flag_bin,
                                             &options.flag_test,

--- a/src/bin/build.rs
+++ b/src/bin/build.rs
@@ -27,6 +27,7 @@ pub struct Options {
     flag_locked: bool,
     flag_frozen: bool,
     flag_all: bool,
+    flag_deps_only: bool,
 }
 
 pub const USAGE: &'static str = "
@@ -39,6 +40,7 @@ Options:
     -h, --help                   Print this message
     -p SPEC, --package SPEC ...  Package to build
     --all                        Build all packages in the workspace
+    --deps-only                  Build only dependencies
     -j N, --jobs N               Number of parallel jobs, defaults to # of CPUs
     --lib                        Build only this package's library
     --bin NAME                   Build only the specified binary
@@ -97,6 +99,7 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
         no_default_features: options.flag_no_default_features,
         spec: spec,
         mode: ops::CompileMode::Build,
+        deps_only: options.flag_deps_only,
         release: options.flag_release,
         filter: ops::CompileFilter::new(options.flag_lib,
                                         &options.flag_bin,

--- a/src/bin/check.rs
+++ b/src/bin/check.rs
@@ -88,6 +88,7 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
         no_default_features: options.flag_no_default_features,
         spec: ops::Packages::Packages(&options.flag_package),
         mode: ops::CompileMode::Check,
+        deps_only: false,
         release: options.flag_release,
         filter: ops::CompileFilter::new(options.flag_lib,
                                         &options.flag_bin,

--- a/src/bin/doc.rs
+++ b/src/bin/doc.rs
@@ -12,6 +12,7 @@ pub struct Options {
     flag_manifest_path: Option<String>,
     flag_no_default_features: bool,
     flag_no_deps: bool,
+    flag_deps_only: bool,
     flag_open: bool,
     flag_release: bool,
     flag_verbose: u32,
@@ -38,6 +39,7 @@ Options:
     -p SPEC, --package SPEC ...  Package to document
     --all                        Document all packages in the workspace
     --no-deps                    Don't build documentation for dependencies
+    --deps-only                  Build documentation only for dependencies
     -j N, --jobs N               Number of parallel jobs, defaults to # of CPUs
     --lib                        Document only this package's library
     --bin NAME                   Document only the specified binary
@@ -102,6 +104,7 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
             mode: ops::CompileMode::Doc {
                 deps: !options.flag_no_deps,
             },
+            deps_only: options.flag_deps_only,
             target_rustc_args: None,
             target_rustdoc_args: None,
         },

--- a/src/bin/install.rs
+++ b/src/bin/install.rs
@@ -110,6 +110,7 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
         no_default_features: options.flag_no_default_features,
         spec: ops::Packages::Packages(&[]),
         mode: ops::CompileMode::Build,
+        deps_only: false,
         release: !options.flag_debug,
         filter: ops::CompileFilter::new(false, &options.flag_bin, &[],
                                         &options.flag_example, &[]),

--- a/src/bin/run.rs
+++ b/src/bin/run.rs
@@ -92,6 +92,7 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
                 bins: &bins, examples: &examples,
             }
         },
+        deps_only: false,
         message_format: options.flag_message_format,
         target_rustdoc_args: None,
         target_rustc_args: None,

--- a/src/bin/rustc.rs
+++ b/src/bin/rustc.rs
@@ -107,6 +107,7 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
         no_default_features: options.flag_no_default_features,
         spec: Packages::Packages(&spec),
         mode: mode,
+        deps_only: false,
         release: options.flag_release,
         filter: ops::CompileFilter::new(options.flag_lib,
                                         &options.flag_bin,

--- a/src/bin/rustdoc.rs
+++ b/src/bin/rustdoc.rs
@@ -100,6 +100,7 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
                                             &options.flag_bench),
             message_format: options.flag_message_format,
             mode: ops::CompileMode::Doc { deps: false },
+            deps_only: false,
             target_rustdoc_args: Some(&options.arg_opts),
             target_rustc_args: None,
         },

--- a/src/bin/test.rs
+++ b/src/bin/test.rs
@@ -136,6 +136,7 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
             spec: spec,
             release: options.flag_release,
             mode: mode,
+            deps_only: false,
             filter: filter,
             message_format: options.flag_message_format,
             target_rustdoc_args: None,

--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -54,6 +54,8 @@ pub struct CompileOptions<'a> {
     pub release: bool,
     /// Mode for this compile.
     pub mode: CompileMode,
+    /// Whether only dependencies of the package should be compiled
+    pub deps_only: bool,
     /// `--error_format` flag for the compiler.
     pub message_format: MessageFormat,
     /// Extra arguments to be passed to rustdoc (for main crate and dependencies)
@@ -75,6 +77,7 @@ impl<'a> CompileOptions<'a> {
             no_default_features: false,
             spec: ops::Packages::Packages(&[]),
             mode: mode,
+            deps_only: false,
             release: false,
             filter: ops::CompileFilter::new(false, &[], &[], &[], &[]),
             message_format: MessageFormat::Human,
@@ -158,7 +161,7 @@ pub fn compile_ws<'a>(ws: &Workspace<'a>,
                       -> CargoResult<ops::Compilation<'a>> {
     let CompileOptions { config, jobs, target, spec, features,
                          all_features, no_default_features,
-                         release, mode, message_format,
+                         release, mode, deps_only, message_format,
                          ref filter,
                          ref target_rustdoc_args,
                          ref target_rustc_args } = *options;
@@ -253,8 +256,9 @@ pub fn compile_ws<'a>(ws: &Workspace<'a>,
         build_config.test = mode == CompileMode::Test || mode == CompileMode::Bench;
         build_config.json_messages = message_format == MessageFormat::Json;
         if let CompileMode::Doc { deps } = mode {
-            build_config.doc_all = deps;
+            build_config.doc_deps = deps;
         }
+        build_config.deps_only = deps_only;
 
         ops::compile_targets(ws,
                              &package_targets,

--- a/src/cargo/ops/cargo_package.rs
+++ b/src/cargo/ops/cargo_package.rs
@@ -295,6 +295,7 @@ fn run_verify(ws: &Workspace, tar: &File, opts: &PackageOpts) -> CargoResult<()>
         spec: ops::Packages::Packages(&[]),
         filter: ops::CompileFilter::Everything,
         release: false,
+        deps_only: false,
         message_format: ops::MessageFormat::Human,
         mode: ops::CompileMode::Build,
         target_rustdoc_args: None,

--- a/src/cargo/ops/cargo_rustc/context.rs
+++ b/src/cargo/ops/cargo_rustc/context.rs
@@ -726,7 +726,7 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
                 profile: self.lib_profile(),
                 kind: unit.kind.for_target(lib),
             });
-            if self.build_config.doc_all {
+            if self.build_config.doc_deps {
                 ret.push(Unit {
                     pkg: dep,
                     target: lib,

--- a/src/cargo/ops/cargo_rustc/mod.rs
+++ b/src/cargo/ops/cargo_rustc/mod.rs
@@ -43,7 +43,10 @@ pub struct BuildConfig {
     pub jobs: u32,
     pub release: bool,
     pub test: bool,
-    pub doc_all: bool,
+    /// If set no action is taken for the main units only for their dependencies
+    pub deps_only: bool,
+    /// If set and units are documented, their dependencies are documented also
+    pub doc_deps: bool,
     pub json_messages: bool,
 }
 
@@ -113,6 +116,8 @@ pub fn compile_targets<'a, 'cfg: 'a>(ws: &Workspace<'cfg>,
         })
     }).collect::<Vec<_>>();
 
+    let deps_only = build_config.deps_only;
+
     let mut cx = Context::new(ws, resolve, packages, config,
                                    build_config, profiles)?;
 
@@ -123,13 +128,21 @@ pub fn compile_targets<'a, 'cfg: 'a>(ws: &Workspace<'cfg>,
     cx.build_used_in_plugin_map(&units)?;
     custom_build::build_map(&mut cx, &units)?;
 
-    for unit in units.iter() {
-        // Build up a list of pending jobs, each of which represent
-        // compiling a particular package. No actual work is executed as
-        // part of this, that's all done next as part of the `execute`
-        // function which will run everything in order with proper
-        // parallelism.
-        compile(&mut cx, &mut queue, unit, exec.clone())?;
+    if deps_only {
+        for unit in &units {
+            for dep in &cx.dep_targets(unit)? {
+                compile(&mut cx, &mut queue, dep, exec.clone())?;
+            }
+        }
+    } else {
+        for unit in units.iter() {
+            // Build up a list of pending jobs, each of which represent
+            // compiling a particular package. No actual work is executed as
+            // part of this, that's all done next as part of the `execute`
+            // function which will run everything in order with proper
+            // parallelism.
+            compile(&mut cx, &mut queue, unit, exec.clone())?;
+        }
     }
 
     // Now that we've figured out everything that we're going to do, do it!


### PR DESCRIPTION
Please don't merge it.
I haven't added tests.

It works, I just want to hear opinions.
Which subcommands can support "--deps-only"?

How can I prevent the bot from building?

Soon I will describe my changes.

### Unresolved questions
#### What to do if `--deps-only` is passed but there are no dependencies?
#### What to do if both `--deps-only` and `--no-deps` are passed to `cargo doc`?