### PR TITLE
Link to the category slugs page from the docs instead

### DIFF
--- a/src/doc/manifest.md
+++ b/src/doc/manifest.md
@@ -124,7 +124,7 @@ readme = "..."
 keywords = ["...", "..."]
 
 # This is a list of up to five categories where this crate would fit.
-# Categories are a fixed list available at crates.io/categories, and
+# Categories are a fixed list available at crates.io/category_slugs, and
 # they must match exactly.
 categories = ["...", "..."]
 


### PR DESCRIPTION
Oops, just noticed that I didn't change this link in the docs when we changed to specifying slugs for categories in `Cargo.toml` :-/