### PR TITLE
Added information about examples as libraries to the documentation

### DIFF
--- a/src/doc/guide.md
+++ b/src/doc/guide.md
@@ -238,7 +238,7 @@ Cargo project:
 * The default executable file is `src/main.rs`.
 * Other executables can be placed in `src/bin/*.rs`.
 * Integration tests go in the `tests` directory (unit tests go in each file they're testing).
-* Example executable files go in the `examples` directory.
+* Examples go in the `examples` directory.
 * Benchmarks go in the `benches` directory.
 
 These are explained in more detail in the [manifest

--- a/src/doc/manifest.md
+++ b/src/doc/manifest.md
@@ -451,8 +451,7 @@ To structure your code after you've created the files and folders for your proje
 Files located under `examples` are example uses of the functionality provided by
 the library. When compiled, they are placed in the `target/examples` directory.
 
-They may compile either as executables (with a `main()` function) or as libraries.
-They load in the library by using `extern crate <library-name>`. They are compiled when you run
+They can compile either as executables (with a `main()` function) or libraries and pull in the library by using `extern crate <library-name>`. They are compiled when you run
 your tests to protect them from bitrotting.
 
 You can run individual executable examples with the command `cargo run --example
@@ -460,7 +459,7 @@ You can run individual executable examples with the command `cargo run --example
 
 Specify `crate-type` to make an example be compiled as a library:
 ```toml
-[[example.example]]
+[[example.foo]]
 crate-type = ["staticlib"]
 ```
 

--- a/src/doc/manifest.md
+++ b/src/doc/manifest.md
@@ -459,9 +459,12 @@ You can run individual executable examples with the command `cargo run --example
 
 Specify `crate-type` to make an example be compiled as a library:
 ```toml
-[[example.foo]]
+[[example]]
+name = "foo"
 crate-type = ["staticlib"]
 ```
+
+You can build individual library examples with the command `cargo build --example <example-name>`.
 
 # Tests
 

--- a/src/doc/manifest.md
+++ b/src/doc/manifest.md
@@ -427,7 +427,7 @@ is a library, name the main source file `src/lib.rs`.
 Cargo will also treat any files located in `src/bin/*.rs` as executables.
 
 Your project can optionally contain folders named `examples`, `tests`, and
-`benches`, which Cargo will treat as containing example executable files,
+`benches`, which Cargo will treat as containing examples,
 integration tests, and benchmarks respectively.
 
 ```notrust
@@ -451,12 +451,18 @@ To structure your code after you've created the files and folders for your proje
 Files located under `examples` are example uses of the functionality provided by
 the library. When compiled, they are placed in the `target/examples` directory.
 
-They must compile as executables (with a `main()` function) and load in the
-library by using `extern crate <library-name>`. They are compiled when you run
+They may compile either as executables (with a `main()` function) or as libraries.
+They load in the library by using `extern crate <library-name>`. They are compiled when you run
 your tests to protect them from bitrotting.
 
-You can run individual examples with the command `cargo run --example
+You can run individual executable examples with the command `cargo run --example
 <example-name>`.
+
+Specify `crate-type` to make an example be compiled as a library:
+```toml
+[[example.example]]
+crate-type = ["staticlib"]
+```
 
 # Tests
 


### PR DESCRIPTION
[Allow examples to be library](https://github.com/rust-lang/cargo/pull/3556) has been committed.
The PR adds information to the documentation.