### PR TITLE
Improve error for dependencies that don't have the same source paths

### DIFF
--- a/src/cargo/util/toml.rs
+++ b/src/cargo/util/toml.rs
@@ -636,8 +636,9 @@ impl TomlManifest {
                 let name = dep.name();
                 let prev = names_sources.insert(name, dep.source_id());
                 if prev.is_some() && prev != Some(dep.source_id()) {
-                    bail!("found duplicate dependency name {}, but all \
-                           dependencies must have a unique name", name);
+                    bail!("Dependency '{}' has different source paths depending on the build \
+                           target. Each dependency must have a single canonical source path \
+                           irrespective of build target.", name);
                 }
             }
         }

--- a/tests/bad-config.rs
+++ b/tests/bad-config.rs
@@ -553,7 +553,53 @@ fn duplicate_deps() {
 [ERROR] failed to parse manifest at `[..]`
 
 Caused by:
-  found duplicate dependency name bar, but all dependencies must have a unique name
+  Dependency 'bar' has different source paths depending on the build target. Each dependency must \
+have a single canonical source path irrespective of build target.
+"));
+}
+
+#[test]
+fn duplicate_deps_diff_sources() {
+    let foo = project("foo")
+    .file("shim-bar/Cargo.toml", r#"
+       [package]
+       name = "bar"
+       version = "0.0.1"
+       authors = []
+    "#)
+    .file("shim-bar/src/lib.rs", r#"
+            pub fn a() {}
+    "#)
+    .file("linux-bar/Cargo.toml", r#"
+       [package]
+       name = "bar"
+       version = "0.0.1"
+       authors = []
+    "#)
+    .file("linux-bar/src/lib.rs", r#"
+            pub fn a() {}
+    "#)
+    .file("Cargo.toml", r#"
+       [package]
+       name = "qqq"
+       version = "0.0.1"
+       authors = []
+
+       [target.i686-unknown-linux-gnu.dependencies]
+       bar = { path = "shim-bar" }
+
+       [target.x86_64-unknown-linux-gnu.dependencies]
+       bar = { path = "linux-bar" }
+    "#)
+    .file("src/main.rs", r#"fn main () {}"#);
+
+    assert_that(foo.cargo_process("build"),
+                execs().with_status(101).with_stderr("\
+[ERROR] failed to parse manifest at `[..]`
+
+Caused by:
+  Dependency 'bar' has different source paths depending on the build target. Each dependency must \
+have a single canonical source path irrespective of build target.
 "));
 }
 


### PR DESCRIPTION
I've added an additional test case which is how my project compiled. Part of the issue was that I didn't know that each dependency needs to use the same path for all build targets. The previous error message was unclear both in what was going on and how to resolve it. The new error message should be more clear.

This is tied to #3592.