### PR TITLE
Add gitlab to the supported services for AppVeyor badges.

### DIFF
--- a/src/doc/manifest.md
+++ b/src/doc/manifest.md
@@ -148,7 +148,8 @@ license-file = "..."
 # Travis CI: `repository` is required. `branch` is optional; default is `master`
 travis-ci = { repository = "...", branch = "master" }
 # Appveyor: `repository` is required. `branch` is optional; default is `master`
-# `service` is optional; valid values are `github` (default) and `bitbucket`
+# `service` is optional; valid values are `github` (default), `bitbucket`, and
+# `gitlab`.
 appveyor = { repository = "...", branch = "master", service = "github" }
 ```
 


### PR DESCRIPTION
This is undocumented but supported behavior for AppVeyor. I have already done this with a crate I own and the badge works on both the AppVeyor and crates.io end.