### PR TITLE
Fix broken code block

### DIFF
--- a/src/doc/manifest.md
+++ b/src/doc/manifest.md
@@ -461,6 +461,7 @@ You can run individual executable examples with the command `cargo run --example
 <example-name>`.
 
 Specify `crate-type` to make an example be compiled as a library:
+
 ```toml
 [[example]]
 name = "foo"


### PR DESCRIPTION
It seems like the Markdown parser requires a blank line before a code block (otherwise it treats it like an inline span).