### PR TITLE
Improve error messages for cargo publish

### DIFF
--- a/src/cargo/ops/registry.rs
+++ b/src/cargo/ops/registry.rs
@@ -81,9 +81,10 @@ fn verify_dependencies(pkg: &Package, registry_src: &SourceId)
                        a version", dep.name())
             }
         } else if dep.source_id() != registry_src {
-            bail!("all dependencies must come from the same source.\n\
-                   dependency `{}` comes from {} instead",
-                  dep.name(), dep.source_id())
+            bail!("Crates published to crates.io cannot have dependencies sourced from \
+                   repositories. Either publish `{}` as its own crate on crates.io and \
+                   specify a crates.io version as a dependency or pull it into this \
+                   repository and specify it with a path and version.", dep.name());
         }
     }
     Ok(())

--- a/src/cargo/util/toml.rs
+++ b/src/cargo/util/toml.rs
@@ -636,8 +636,9 @@ impl TomlManifest {
                 let name = dep.name();
                 let prev = names_sources.insert(name, dep.source_id());
                 if prev.is_some() && prev != Some(dep.source_id()) {
-                    bail!("found duplicate dependency name {}, but all \
-                           dependencies must have a unique name", name);
+                    bail!("Dependency '{}' has different source paths depending on the build \
+                           target. Each dependency must have a single canonical source path \
+                           irrespective of build target.", name);
                 }
             }
         }

--- a/tests/bad-config.rs
+++ b/tests/bad-config.rs
@@ -553,7 +553,53 @@ fn duplicate_deps() {
 [ERROR] failed to parse manifest at `[..]`
 
 Caused by:
-  found duplicate dependency name bar, but all dependencies must have a unique name
+  Dependency 'bar' has different source paths depending on the build target. Each dependency must \
+have a single canonical source path irrespective of build target.
+"));
+}
+
+#[test]
+fn duplicate_deps_diff_sources() {
+    let foo = project("foo")
+    .file("shim-bar/Cargo.toml", r#"
+       [package]
+       name = "bar"
+       version = "0.0.1"
+       authors = []
+    "#)
+    .file("shim-bar/src/lib.rs", r#"
+            pub fn a() {}
+    "#)
+    .file("linux-bar/Cargo.toml", r#"
+       [package]
+       name = "bar"
+       version = "0.0.1"
+       authors = []
+    "#)
+    .file("linux-bar/src/lib.rs", r#"
+            pub fn a() {}
+    "#)
+    .file("Cargo.toml", r#"
+       [package]
+       name = "qqq"
+       version = "0.0.1"
+       authors = []
+
+       [target.i686-unknown-linux-gnu.dependencies]
+       bar = { path = "shim-bar" }
+
+       [target.x86_64-unknown-linux-gnu.dependencies]
+       bar = { path = "linux-bar" }
+    "#)
+    .file("src/main.rs", r#"fn main () {}"#);
+
+    assert_that(foo.cargo_process("build"),
+                execs().with_status(101).with_stderr("\
+[ERROR] failed to parse manifest at `[..]`
+
+Caused by:
+  Dependency 'bar' has different source paths depending on the build target. Each dependency must \
+have a single canonical source path irrespective of build target.
 "));
 }
 

--- a/tests/publish.rs
+++ b/tests/publish.rs
@@ -115,8 +115,10 @@ fn git_deps() {
                  .arg("--host").arg(registry().to_string()),
                 execs().with_status(101).with_stderr("\
 [UPDATING] registry [..]
-[ERROR] all dependencies must come from the same source.
-dependency `foo` comes from git://path/to/nowhere instead
+[ERROR] Crates published to crates.io cannot have dependencies sourced from \
+repositories. Either publish `foo` as its own crate on crates.io and \
+specify a crates.io version as a dependency or pull it into this \
+repository and specify it with a path and version.
 "));
 }
 


### PR DESCRIPTION
Improves the error when trying to publish a crate that has dependencies on git repos. This both clarifies the error and tells the user how they can resolve it. A big usability improvement.

Resolves #2947.