### PR TITLE
Simplify cli-handling functions

### DIFF
--- a/tests/lockfile-compat.rs
+++ b/tests/lockfile-compat.rs
@@ -1,4 +1,3 @@
-#[macro_use]
 extern crate cargotest;
 extern crate hamcrest;
 


### PR DESCRIPTION
This simplifies somewhat roundabout `main` in `bin/cargo.rs`. 