### PR TITLE
Remove generic infrastrucure for printing json

### DIFF
--- a/src/bin/bench.rs
+++ b/src/bin/bench.rs
@@ -70,7 +70,7 @@ not affect how many jobs are used when running the benchmarks.
 Compilation can be customized with the `bench` profile in the manifest.
 ";
 
-pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
+pub fn execute(options: Options, config: &Config) -> CliResult {
     let root = find_root_manifest_for_wd(options.flag_manifest_path, config.cwd())?;
     config.configure(options.flag_verbose,
                      options.flag_quiet,
@@ -105,7 +105,7 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
     let ws = Workspace::new(&root, config)?;
     let err = ops::run_benches(&ws, &ops, &options.arg_args)?;
     match err {
-        None => Ok(None),
+        None => Ok(()),
         Some(err) => {
             Err(match err.exit.as_ref().and_then(|e| e.code()) {
                 Some(i) => CliError::new(human("bench failed"), i),

--- a/src/bin/build.rs
+++ b/src/bin/build.rs
@@ -71,7 +71,7 @@ the manifest. The default profile for this command is `dev`, but passing
 the --release flag will use the `release` profile instead.
 ";
 
-pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
+pub fn execute(options: Options, config: &Config) -> CliResult {
     debug!("executing; cmd=cargo-build; args={:?}",
            env::args().collect::<Vec<_>>());
     config.configure(options.flag_verbose,
@@ -110,5 +110,5 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
 
     let ws = Workspace::new(&root, config)?;
     ops::compile(&ws, &opts)?;
-    Ok(None)
+    Ok(())
 }

--- a/src/bin/cargo.rs
+++ b/src/bin/cargo.rs
@@ -89,8 +89,7 @@ fn main() {
 
     match result {
         Err(e) => cargo::handle_cli_error(e, &mut *config.shell()),
-        Ok(None) => {},
-        Ok(Some(())) => unreachable!(),
+        Ok(()) => {},
     }
 }
 
@@ -139,7 +138,7 @@ each_subcommand!(declare_mod);
   because they are fundamental (and intertwined). Other commands can rely
   on this top-level information.
 */
-fn execute(flags: Flags, config: &Config) -> CliResult<Option<()>> {
+fn execute(flags: Flags, config: &Config) -> CliResult {
     config.configure(flags.flag_verbose,
                      flags.flag_quiet,
                      &flags.flag_color,
@@ -162,7 +161,7 @@ fn execute(flags: Flags, config: &Config) -> CliResult<Option<()>> {
                 }
             }
         }
-        return Ok(None)
+        return Ok(())
     }
 
     if flags.flag_list {
@@ -170,13 +169,13 @@ fn execute(flags: Flags, config: &Config) -> CliResult<Option<()>> {
         for command in list_commands(config) {
             println!("    {}", command);
         };
-        return Ok(None)
+        return Ok(())
     }
 
     if let Some(ref code) = flags.flag_explain {
         let mut procss = config.rustc()?.process();
         procss.arg("--explain").arg(code).exec().map_err(human)?;
-        return Ok(None)
+        return Ok(())
     }
 
     let args = match &flags.arg_command[..] {
@@ -189,7 +188,7 @@ fn execute(flags: Flags, config: &Config) -> CliResult<Option<()>> {
             let r = cargo::call_main_without_stdin(execute, config, USAGE, args,
                                                    false);
             cargo::process_executed(r, &mut config.shell());
-            return Ok(None)
+            return Ok(())
         }
 
         // For `cargo help -h` and `cargo help --help`, print out the help
@@ -221,7 +220,7 @@ fn execute(flags: Flags, config: &Config) -> CliResult<Option<()>> {
     };
 
     if try_execute(&config, &args) {
-        return Ok(None)
+        return Ok(())
     }
 
     let alias_list = aliased_command(&config, &args[1])?;
@@ -233,7 +232,7 @@ fn execute(flags: Flags, config: &Config) -> CliResult<Option<()>> {
                 .map(|s| s.to_string())
                 .collect::<Vec<_>>();
             if try_execute(&config, &chain) {
-                return Ok(None)
+                return Ok(())
             } else {
                 chain
             }
@@ -241,7 +240,7 @@ fn execute(flags: Flags, config: &Config) -> CliResult<Option<()>> {
         None => args,
     };
     execute_subcommand(config, &args[1], &args)?;
-    Ok(None)
+    Ok(())
 }
 
 fn try_execute(config: &Config, args: &[String]) -> bool {
@@ -298,7 +297,7 @@ fn find_closest(config: &Config, cmd: &str) -> Option<String> {
 
 fn execute_subcommand(config: &Config,
                       cmd: &str,
-                      args: &[String]) -> CliResult<()> {
+                      args: &[String]) -> CliResult {
     let command_exe = format!("cargo-{}{}", cmd, env::consts::EXE_SUFFIX);
     let path = search_directories(config)
                     .iter()

--- a/src/bin/check.rs
+++ b/src/bin/check.rs
@@ -66,7 +66,7 @@ pub struct Options {
     flag_frozen: bool,
 }
 
-pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
+pub fn execute(options: Options, config: &Config) -> CliResult {
     debug!("executing; cmd=cargo-check; args={:?}",
            env::args().collect::<Vec<_>>());
 
@@ -100,5 +100,5 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
     };
 
     ops::compile(&ws, &opts)?;
-    Ok(None)
+    Ok(())
 }

--- a/src/bin/clean.rs
+++ b/src/bin/clean.rs
@@ -42,7 +42,7 @@ given, then all packages' artifacts are removed. For more information on SPEC
 and its format, see the `cargo help pkgid` command.
 ";
 
-pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
+pub fn execute(options: Options, config: &Config) -> CliResult {
     debug!("executing; cmd=cargo-clean; args={:?}", env::args().collect::<Vec<_>>());
     config.configure(options.flag_verbose,
                      options.flag_quiet,
@@ -59,5 +59,5 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
     };
     let ws = Workspace::new(&root, config)?;
     ops::clean(&ws, &opts)?;
-    Ok(None)
+    Ok(())
 }

--- a/src/bin/doc.rs
+++ b/src/bin/doc.rs
@@ -66,7 +66,7 @@ current package is documented. For more information on SPEC and its format, see
 the `cargo help pkgid` command.
 ";
 
-pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
+pub fn execute(options: Options, config: &Config) -> CliResult {
     config.configure(options.flag_verbose,
                      options.flag_quiet,
                      &options.flag_color,
@@ -109,5 +109,5 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
 
     let ws = Workspace::new(&root, config)?;
     ops::doc(&ws, &doc_opts)?;
-    Ok(None)
+    Ok(())
 }

--- a/src/bin/fetch.rs
+++ b/src/bin/fetch.rs
@@ -38,7 +38,7 @@ If the lockfile is not available, then this is the equivalent of
 all updated.
 ";
 
-pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
+pub fn execute(options: Options, config: &Config) -> CliResult {
     config.configure(options.flag_verbose,
                      options.flag_quiet,
                      &options.flag_color,
@@ -47,6 +47,6 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
     let root = find_root_manifest_for_wd(options.flag_manifest_path, config.cwd())?;
     let ws = Workspace::new(&root, config)?;
     ops::fetch(&ws)?;
-    Ok(None)
+    Ok(())
 }
 

--- a/src/bin/generate_lockfile.rs
+++ b/src/bin/generate_lockfile.rs
@@ -31,7 +31,7 @@ Options:
     --locked                 Require Cargo.lock is up to date
 ";
 
-pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
+pub fn execute(options: Options, config: &Config) -> CliResult {
     debug!("executing; cmd=cargo-generate-lockfile; args={:?}", env::args().collect::<Vec<_>>());
     config.configure(options.flag_verbose,
                      options.flag_quiet,
@@ -42,5 +42,5 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
 
     let ws = Workspace::new(&root, config)?;
     ops::generate_lockfile(&ws)?;
-    Ok(None)
+    Ok(())
 }

--- a/src/bin/git_checkout.rs
+++ b/src/bin/git_checkout.rs
@@ -29,7 +29,7 @@ Options:
     --locked                 Require Cargo.lock is up to date
 ";
 
-pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
+pub fn execute(options: Options, config: &Config) -> CliResult {
     config.configure(options.flag_verbose,
                      options.flag_quiet,
                      &options.flag_color,
@@ -46,5 +46,5 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
 
     source.update()?;
 
-    Ok(None)
+    Ok(())
 }

--- a/src/bin/help.rs
+++ b/src/bin/help.rs
@@ -14,7 +14,7 @@ Options:
     -h, --help          Print this message
 ";
 
-pub fn execute(_: Options, _: &Config) -> CliResult<Option<()>> {
+pub fn execute(_: Options, _: &Config) -> CliResult {
     // This is a dummy command just so that `cargo help help` works.
     // The actual delegation of help flag to subcommands is handled by the
     // cargo command.

--- a/src/bin/init.rs
+++ b/src/bin/init.rs
@@ -39,7 +39,7 @@ Options:
     --locked            Require Cargo.lock is up to date
 ";
 
-pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
+pub fn execute(options: Options, config: &Config) -> CliResult {
     debug!("executing; cmd=cargo-init; args={:?}", env::args().collect::<Vec<_>>());
     config.configure(options.flag_verbose,
                      options.flag_quiet,
@@ -63,6 +63,6 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
                                              if opts_lib { "library" }
                                              else {"binary (application)"}))?;
 
-    Ok(None)
+    Ok(())
 }
 

--- a/src/bin/install.rs
+++ b/src/bin/install.rs
@@ -94,7 +94,7 @@ the more explicit `install --path .`.
 The `--list` option will list all installed packages (and their versions).
 ";
 
-pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
+pub fn execute(options: Options, config: &Config) -> CliResult {
     config.configure(options.flag_verbose,
                      options.flag_quiet,
                      &options.flag_color,
@@ -147,5 +147,5 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
     } else {
         ops::install(root, krate, &source, vers, &compile_opts, options.flag_force)?;
     }
-    Ok(None)
+    Ok(())
 }

--- a/src/bin/locate_project.rs
+++ b/src/bin/locate_project.rs
@@ -1,3 +1,4 @@
+use cargo;
 use cargo::util::{CliResult, CliError, human, ChainError, Config};
 use cargo::util::important_paths::{find_root_manifest_for_wd};
 
@@ -23,7 +24,7 @@ pub struct ProjectLocation {
 }
 
 pub fn execute(flags: LocateProjectFlags,
-               config: &Config) -> CliResult<Option<ProjectLocation>> {
+               config: &Config) -> CliResult {
     let root = find_root_manifest_for_wd(flags.flag_manifest_path, config.cwd())?;
 
     let string = root.to_str()
@@ -32,5 +33,7 @@ pub fn execute(flags: LocateProjectFlags,
                                              Unicode"))
                       .map_err(|e| CliError::new(e, 1))?;
 
-    Ok(Some(ProjectLocation { root: string.to_string() }))
+    let location = ProjectLocation { root: string.to_string() };
+    cargo::print_json(&location);
+    Ok(())
 }

--- a/src/bin/login.rs
+++ b/src/bin/login.rs
@@ -34,7 +34,7 @@ Options:
 
 ";
 
-pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
+pub fn execute(options: Options, config: &Config) -> CliResult {
     config.configure(options.flag_verbose,
                      options.flag_quiet,
                      &options.flag_color,
@@ -60,6 +60,6 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
 
     let token = token.trim().to_string();
     ops::registry_login(config, token)?;
-    Ok(None)
+    Ok(())
 }
 

--- a/src/bin/metadata.rs
+++ b/src/bin/metadata.rs
@@ -1,5 +1,6 @@
+use cargo;
 use cargo::core::Workspace;
-use cargo::ops::{output_metadata, OutputMetadataOptions, ExportInfo};
+use cargo::ops::{output_metadata, OutputMetadataOptions};
 use cargo::util::important_paths::find_root_manifest_for_wd;
 use cargo::util::{CliResult, Config};
 
@@ -42,7 +43,7 @@ Options:
     --locked                   Require Cargo.lock is up to date
 ";
 
-pub fn execute(options: Options, config: &Config) -> CliResult<Option<ExportInfo>> {
+pub fn execute(options: Options, config: &Config) -> CliResult {
     config.configure(options.flag_verbose,
                      options.flag_quiet,
                      &options.flag_color,
@@ -60,5 +61,6 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<ExportInfo
 
     let ws = Workspace::new(&manifest, config)?;
     let result = output_metadata(&ws, &options)?;
-    Ok(Some(result))
+    cargo::print_json(&result);
+    Ok(())
 }

--- a/src/bin/new.rs
+++ b/src/bin/new.rs
@@ -39,7 +39,7 @@ Options:
     --locked            Require Cargo.lock is up to date
 ";
 
-pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
+pub fn execute(options: Options, config: &Config) -> CliResult {
     debug!("executing; cmd=cargo-new; args={:?}", env::args().collect::<Vec<_>>());
     config.configure(options.flag_verbose,
                      options.flag_quiet,
@@ -63,6 +63,6 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
                                              else {"binary (application)"},
                                              arg_path))?;
 
-    Ok(None)
+    Ok(())
 }
 

--- a/src/bin/owner.rs
+++ b/src/bin/owner.rs
@@ -44,7 +44,7 @@ See http://doc.crates.io/crates-io.html#cargo-owner for detailed documentation
 and troubleshooting.
 ";
 
-pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
+pub fn execute(options: Options, config: &Config) -> CliResult {
     config.configure(options.flag_verbose,
                      options.flag_quiet,
                      &options.flag_color,
@@ -59,6 +59,6 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
         list: options.flag_list,
     };
     ops::modify_owners(config, &opts)?;
-    Ok(None)
+    Ok(())
 }
 

--- a/src/bin/package.rs
+++ b/src/bin/package.rs
@@ -39,7 +39,7 @@ Options:
     --locked                Require Cargo.lock is up to date
 ";
 
-pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
+pub fn execute(options: Options, config: &Config) -> CliResult {
     config.configure(options.flag_verbose,
                      options.flag_quiet,
                      &options.flag_color,
@@ -55,5 +55,5 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
         allow_dirty: options.flag_allow_dirty,
         jobs: options.flag_jobs,
     })?;
-    Ok(None)
+    Ok(())
 }

--- a/src/bin/pkgid.rs
+++ b/src/bin/pkgid.rs
@@ -53,7 +53,7 @@ Example Package IDs
 ";
 
 pub fn execute(options: Options,
-               config: &Config) -> CliResult<Option<()>> {
+               config: &Config) -> CliResult {
     config.configure(options.flag_verbose,
                      options.flag_quiet,
                      &options.flag_color,
@@ -72,6 +72,6 @@ pub fn execute(options: Options,
     let spec = spec.as_ref().map(|s| &s[..]);
     let spec = ops::pkgid(&ws, spec)?;
     println!("{}", spec);
-    Ok(None)
+    Ok(())
 }
 

--- a/src/bin/publish.rs
+++ b/src/bin/publish.rs
@@ -42,7 +42,7 @@ Options:
 
 ";
 
-pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
+pub fn execute(options: Options, config: &Config) -> CliResult {
     config.configure(options.flag_verbose,
                      options.flag_quiet,
                      &options.flag_color,
@@ -70,5 +70,5 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
         jobs: jobs,
         dry_run: dry_run,
     })?;
-    Ok(None)
+    Ok(())
 }

--- a/src/bin/read_manifest.rs
+++ b/src/bin/read_manifest.rs
@@ -1,5 +1,6 @@
 use std::env;
 
+use cargo;
 use cargo::core::Package;
 use cargo::util::{CliResult, Config};
 use cargo::util::important_paths::{find_root_manifest_for_wd};
@@ -25,7 +26,7 @@ Options:
     --color WHEN             Coloring: auto, always, never
 ";
 
-pub fn execute(options: Options, config: &Config) -> CliResult<Option<Package>> {
+pub fn execute(options: Options, config: &Config) -> CliResult {
     debug!("executing; cmd=cargo-read-manifest; args={:?}",
            env::args().collect::<Vec<_>>());
     config.shell().set_color_config(options.flag_color.as_ref().map(|s| &s[..]))?;
@@ -33,5 +34,6 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<Package>> 
     let root = find_root_manifest_for_wd(options.flag_manifest_path, config.cwd())?;
 
     let pkg = Package::for_path(&root, config)?;
-    Ok(Some(pkg))
+    cargo::print_json(&pkg);
+    Ok(())
 }

--- a/src/bin/run.rs
+++ b/src/bin/run.rs
@@ -57,7 +57,7 @@ arguments to both Cargo and the binary, the ones after `--` go to the binary,
 the ones before go to Cargo.
 ";
 
-pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
+pub fn execute(options: Options, config: &Config) -> CliResult {
     config.configure(options.flag_verbose,
                      options.flag_quiet,
                      &options.flag_color,
@@ -99,7 +99,7 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
 
     let ws = Workspace::new(&root, config)?;
     match ops::run(&ws, &compile_opts, &options.arg_args)? {
-        None => Ok(None),
+        None => Ok(()),
         Some(err) => {
             // If we never actually spawned the process then that sounds pretty
             // bad and we always want to forward that up.

--- a/src/bin/rustc.rs
+++ b/src/bin/rustc.rs
@@ -73,7 +73,7 @@ processes spawned by Cargo, use the $RUSTFLAGS environment variable or the
 `build.rustflags` configuration option.
 ";
 
-pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
+pub fn execute(options: Options, config: &Config) -> CliResult {
     debug!("executing; cmd=cargo-rustc; args={:?}",
            env::args().collect::<Vec<_>>());
     config.configure(options.flag_verbose,
@@ -120,6 +120,6 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
 
     let ws = Workspace::new(&root, config)?;
     ops::compile(&ws, &opts)?;
-    Ok(None)
+    Ok(())
 }
 

--- a/src/bin/rustdoc.rs
+++ b/src/bin/rustdoc.rs
@@ -70,7 +70,7 @@ current package is documented. For more information on SPEC and its format, see
 the `cargo help pkgid` command.
 ";
 
-pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
+pub fn execute(options: Options, config: &Config) -> CliResult {
     config.configure(options.flag_verbose,
                      options.flag_quiet,
                      &options.flag_color,
@@ -108,5 +108,5 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
     let ws = Workspace::new(&root, config)?;
     ops::doc(&ws, &doc_opts)?;
 
-    Ok(None)
+    Ok(())
 }

--- a/src/bin/search.rs
+++ b/src/bin/search.rs
@@ -33,7 +33,7 @@ Options:
     --locked                 Require Cargo.lock is up to date
 ";
 
-pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
+pub fn execute(options: Options, config: &Config) -> CliResult {
     config.configure(options.flag_verbose,
                      options.flag_quiet,
                      &options.flag_color,
@@ -47,5 +47,5 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
     } = options;
 
     ops::search(&query.join("+"), config, host, cmp::min(100, limit.unwrap_or(10)) as u8)?;
-    Ok(None)
+    Ok(())
 }

--- a/src/bin/test.rs
+++ b/src/bin/test.rs
@@ -93,7 +93,7 @@ To get the list of all options available for the test binaries use this:
   cargo test -- --help
 ";
 
-pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
+pub fn execute(options: Options, config: &Config) -> CliResult {
     config.configure(options.flag_verbose,
                      options.flag_quiet,
                      &options.flag_color,
@@ -146,7 +146,7 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
     let ws = Workspace::new(&root, config)?;
     let err = ops::run_tests(&ws, &ops, &options.arg_args)?;
     match err {
-        None => Ok(None),
+        None => Ok(()),
         Some(err) => {
             Err(match err.exit.as_ref().and_then(|e| e.code()) {
                 Some(i) => CliError::new(human("test failed"), i),

--- a/src/bin/uninstall.rs
+++ b/src/bin/uninstall.rs
@@ -37,7 +37,7 @@ uninstalled for a crate but the `--bin` and `--example` flags can be used to
 only uninstall particular binaries.
 ";
 
-pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
+pub fn execute(options: Options, config: &Config) -> CliResult {
     config.configure(options.flag_verbose,
                      options.flag_quiet,
                      &options.flag_color,
@@ -46,6 +46,6 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
 
     let root = options.flag_root.as_ref().map(|s| &s[..]);
     ops::uninstall(root, &options.arg_spec, &options.flag_bin, config)?;
-    Ok(None)
+    Ok(())
 }
 

--- a/src/bin/update.rs
+++ b/src/bin/update.rs
@@ -57,7 +57,7 @@ updated.
 For more information about package id specifications, see `cargo help pkgid`.
 ";
 
-pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
+pub fn execute(options: Options, config: &Config) -> CliResult {
     debug!("executing; cmd=cargo-update; args={:?}", env::args().collect::<Vec<_>>());
     config.configure(options.flag_verbose,
                      options.flag_quiet,
@@ -75,5 +75,5 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
 
     let ws = Workspace::new(&root, config)?;
     ops::update_lockfile(&ws, &update_opts)?;
-    Ok(None)
+    Ok(())
 }

--- a/src/bin/verify_project.rs
+++ b/src/bin/verify_project.rs
@@ -3,12 +3,11 @@ use std::fs::File;
 use std::io::prelude::*;
 use std::process;
 
+use cargo;
 use cargo::util::important_paths::{find_root_manifest_for_wd};
 use cargo::util::{CliResult, Config};
 use rustc_serialize::json;
 use toml;
-
-pub type Error = HashMap<String, String>;
 
 #[derive(RustcDecodable)]
 pub struct Flags {
@@ -37,7 +36,7 @@ Options:
     --locked                Require Cargo.lock is up to date
 ";
 
-pub fn execute(args: Flags, config: &Config) -> CliResult<Option<Error>> {
+pub fn execute(args: Flags, config: &Config) -> CliResult {
     config.configure(args.flag_verbose,
                      args.flag_quiet,
                      &args.flag_color,
@@ -63,7 +62,8 @@ pub fn execute(args: Flags, config: &Config) -> CliResult<Option<Error>> {
 
     let mut h = HashMap::new();
     h.insert("success".to_string(), "true".to_string());
-    Ok(Some(h))
+    cargo::print_json(&h);
+    Ok(())
 }
 
 fn fail(reason: &str, value: &str) -> ! {

--- a/src/bin/version.rs
+++ b/src/bin/version.rs
@@ -18,10 +18,10 @@ Options:
     --color WHEN             Coloring: auto, always, never
 ";
 
-pub fn execute(_: Options, _: &Config) -> CliResult<Option<()>> {
+pub fn execute(_: Options, _: &Config) -> CliResult {
     debug!("executing; cmd=cargo-version; args={:?}", env::args().collect::<Vec<_>>());
 
     println!("{}", cargo::version());
 
-    Ok(None)
+    Ok(())
 }

--- a/src/bin/yank.rs
+++ b/src/bin/yank.rs
@@ -42,7 +42,7 @@ download the yanked version to use it. Cargo will, however, not allow any new
 crates to be locked to any yanked version.
 ";
 
-pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
+pub fn execute(options: Options, config: &Config) -> CliResult {
     config.configure(options.flag_verbose,
                      options.flag_quiet,
                      &options.flag_color,
@@ -54,6 +54,6 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
               options.flag_token,
               options.flag_index,
               options.flag_undo)?;
-    Ok(None)
+    Ok(())
 }
 

--- a/src/cargo/util/errors.rs
+++ b/src/cargo/util/errors.rs
@@ -243,7 +243,7 @@ impl<E: CargoError> CargoError for Human<E> {
 // =============================================================================
 // CLI errors
 
-pub type CliResult<T> = Result<T, CliError>;
+pub type CliResult = Result<(), CliError>;
 
 #[derive(Debug)]
 pub struct CliError {

--- a/tests/version.rs
+++ b/tests/version.rs
@@ -20,35 +20,6 @@ fn simple() {
 
 }
 
-#[derive(RustcDecodable)]
-struct FooFlags {
-    flag_version: bool,
-}
-
-fn real_main(flags: FooFlags, _config: &cargo::Config) ->
-        cargo::CliResult<Option<String>> {
-    if flags.flag_version {
-        Ok(Some("foo <version>".to_string()))
-    } else {
-        Ok(None)
-    }
-}
-
-#[test]
-fn subcommand_with_version_using_exec_main_without_stdin() {
-    let usage = "
-Usage: cargo foo [--version]
-
-Options:
-    -V, --version       Print version info
-";
-    let args: Vec<String> = vec!["cargo", "foo", "--version"]
-        .into_iter().map(|s| s.to_string()).collect();
-    let result = cargo::call_main_without_stdin(
-                real_main, &cargo::Config::default().unwrap(),
-                usage, &args, false);
-    assert_eq!(result.unwrap(), Some("foo <version>".to_string()));
-}
 
 #[test]
 #[cfg_attr(target_os = "windows", ignore)]


### PR DESCRIPTION
Only a couple of command really use this features, so it's clearer just to print json right on the spot rather then return it though the call stack.

`CliResult` is now just a `Result<(), CliError>`. 