### PR TITLE
Fix #3658 .cargo/config prevents freshness (sort after HashMap)

### DIFF
--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -492,7 +492,13 @@ fn scrape_target_config(config: &Config, triple: &str)
             rerun_if_changed: Vec::new(),
             warnings: Vec::new(),
         };
+        // We require deterministic order of evaluation, so we must sort the pairs by key first.
+        let mut pairs = Vec::new();
         for (k, value) in value.table(&lib_name)?.0 {
+            pairs.push((k,value));
+        }
+        pairs.sort_by_key( |p| p.0 );
+        for (k,value) in pairs{
             let key = format!("{}.{}", key, k);
             match &k[..] {
                 "rustc-flags" => {
@@ -528,10 +534,6 @@ fn scrape_target_config(config: &Config, triple: &str)
                     output.metadata.push((k.clone(), val.to_string()));
                 }
             }
-
-            // We randomized the data source with HashMaps, so we must sort the resulting vectors
-            // to produce a deterministic result
-            output.sort();
         }
         ret.overrides.insert(lib_name, output);
     }

--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -528,6 +528,10 @@ fn scrape_target_config(config: &Config, triple: &str)
                     output.metadata.push((k.clone(), val.to_string()));
                 }
             }
+
+            // We randomized the data source with HashMaps, so we must sort the resulting vectors
+            // to produce a deterministic result
+            output.sort();
         }
         ret.overrides.insert(lib_name, output);
     }

--- a/src/cargo/ops/cargo_rustc/custom_build.rs
+++ b/src/cargo/ops/cargo_rustc/custom_build.rs
@@ -406,6 +406,17 @@ impl BuildOutput {
         }
         Ok((library_paths, library_links))
     }
+
+    /// Sort the contents of the struct for consistent hashing. 
+    /// Suggested if populated from a HashMap instead of a order-preserving data source
+    pub fn sort(&mut self){
+        self.library_paths.sort();
+        self.library_links.sort();
+        self.cfgs.sort();
+        self.metadata.sort();
+        self.rerun_if_changed.sort();
+        self.warnings.sort();
+    }   
 }
 
 /// Compute the `build_scripts` map in the `Context` which tracks what build

--- a/src/cargo/ops/cargo_rustc/custom_build.rs
+++ b/src/cargo/ops/cargo_rustc/custom_build.rs
@@ -406,17 +406,6 @@ impl BuildOutput {
         }
         Ok((library_paths, library_links))
     }
-
-    /// Sort the contents of the struct for consistent hashing. 
-    /// Suggested if populated from a HashMap instead of an order-preserving data source
-    pub fn sort(&mut self){
-        self.library_paths.sort();
-        self.library_links.sort();
-        self.cfgs.sort();
-        self.metadata.sort();
-        self.rerun_if_changed.sort();
-        self.warnings.sort();
-    }   
 }
 
 /// Compute the `build_scripts` map in the `Context` which tracks what build

--- a/src/cargo/ops/cargo_rustc/custom_build.rs
+++ b/src/cargo/ops/cargo_rustc/custom_build.rs
@@ -408,7 +408,7 @@ impl BuildOutput {
     }
 
     /// Sort the contents of the struct for consistent hashing. 
-    /// Suggested if populated from a HashMap instead of a order-preserving data source
+    /// Suggested if populated from a HashMap instead of an order-preserving data source
     pub fn sort(&mut self){
         self.library_paths.sort();
         self.library_links.sort();

--- a/tests/build-script.rs
+++ b/tests/build-script.rs
@@ -1812,7 +1812,9 @@ fn fresh_builds_possible_with_multiple_metadata_overrides() {
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
 
-    assert_that(p.cargo("build").arg("-v").env("RUST_LOG", "cargo::ops::cargo_rustc::fingerprint=info"),
+    assert_that(p.cargo("build")
+                 .arg("-v")
+                 .env("RUST_LOG", "cargo::ops::cargo_rustc::fingerprint=info"),
                 execs().with_status(0).with_stderr("\
 [FRESH] foo v0.5.0 ([..])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]

--- a/tests/build-script.rs
+++ b/tests/build-script.rs
@@ -1812,8 +1812,6 @@ fn fresh_builds_possible_with_multiple_metadata_overrides() {
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
 
-    sleep_ms(2000);
-
     assert_that(p.cargo("build").arg("-v").env("RUST_LOG", "cargo::ops::cargo_rustc::fingerprint=info"),
                 execs().with_status(0).with_stderr("\
 [FRESH] foo v0.5.0 ([..])

--- a/tests/build-script.rs
+++ b/tests/build-script.rs
@@ -306,7 +306,7 @@ fn overrides_and_links() {
 [..]
 [..]
 [..]
-[RUNNING] `rustc --crate-name foo [..] -L bar -L foo`
+[RUNNING] `rustc --crate-name foo [..] -L foo -L bar`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
 }

--- a/tests/build-script.rs
+++ b/tests/build-script.rs
@@ -306,7 +306,7 @@ fn overrides_and_links() {
 [..]
 [..]
 [..]
-[RUNNING] `rustc --crate-name foo [..] -L foo -L bar[..]`
+[RUNNING] `rustc --crate-name foo [..] -L bar -L foo`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
 }

--- a/tests/build-script.rs
+++ b/tests/build-script.rs
@@ -1781,6 +1781,46 @@ fn changing_an_override_invalidates() {
 "));
 }
 
+
+#[test]
+fn fresh_builds_possible_with_link_libs() {
+    // The bug is non-deterministic. Sometimes you can get a fresh build
+    let target = rustc_host();
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [project]
+            name = "foo"
+            version = "0.5.0"
+            authors = []
+            links = "nativefoo"
+            build = "build.rs"
+        "#)
+        .file("src/lib.rs", "")
+        .file(".cargo/config", &format!("
+            [target.{}.nativefoo]
+            rustc-link-lib = [\"a\"]
+            rustc-link-search = [\"./b\"]
+            rustc-flags = \"-l z -L ./\"
+        ", target))
+        .file("build.rs", "");
+ 
+    assert_that(p.cargo_process("build").arg("-v"),
+                execs().with_status(0).with_stderr("\
+[COMPILING] foo v0.5.0 ([..]
+[RUNNING] `rustc [..]`
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+"));
+
+    assert_that(p.cargo("build")
+                 .arg("-v")
+                 .env("RUST_LOG", "cargo::ops::cargo_rustc::fingerprint=info"),
+                execs().with_status(0).with_stderr("\
+[FRESH] foo v0.5.0 ([..])
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+"));
+}
+
+
 #[test]
 fn fresh_builds_possible_with_multiple_metadata_overrides() {
     // The bug is non-deterministic. Sometimes you can get a fresh build

--- a/tests/build-script.rs
+++ b/tests/build-script.rs
@@ -1782,7 +1782,7 @@ fn changing_an_override_invalidates() {
 }
 
 #[test]
-fn fresh_builds_possible_with_overrides() {
+fn fresh_builds_possible_with_multiple_metadata_overrides() {
     // The bug is non-deterministic. Sometimes you can get a fresh build
     let target = rustc_host();
     let p = project("foo")
@@ -1797,23 +1797,24 @@ fn fresh_builds_possible_with_overrides() {
         .file("src/lib.rs", "")
         .file(".cargo/config", &format!("
             [target.{}.foo]
-            rustc-link-lib = [\"foo\"]
-            rustc-cfg=[\"ossl102\"]
-            version = \"102\"
-            conf = \"\"
+            a = \"\"
+            b = \"\"
+            c = \"\"
+            d = \"\"
+            e = \"\"
         ", target))
         .file("build.rs", "");
  
     assert_that(p.cargo_process("build").arg("-v"),
                 execs().with_status(0).with_stderr("\
 [COMPILING] foo v0.5.0 ([..]
-[RUNNING] `rustc [..] -l foo`
+[RUNNING] `rustc [..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
 
     sleep_ms(2000);
 
-    assert_that(p.cargo("build").arg("-v"),
+    assert_that(p.cargo("build").arg("-v").env("RUST_LOG", "cargo::ops::cargo_rustc::fingerprint=info"),
                 execs().with_status(0).with_stderr("\
 [FRESH] foo v0.5.0 ([..])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]


### PR DESCRIPTION
The many vectors of BuildOutput are populated from a HashMap in cargo_compile... and later these vectors are hashed.

HashMaps are the bane of Cargo's existence. 

But for now, we sort. 