### PR TITLE
Assume that a `build.rs` file is a build script

### DIFF
--- a/tests/build-script.rs
+++ b/tests/build-script.rs
@@ -2350,8 +2350,8 @@ fn assume_build_script_when_build_rs_present() {
         "#)
         .file("src/main.rs", r#"
             fn main() {
-                if cfg!(foo) {
-                    panic!("the build script was run");
+                if ! cfg!(foo) {
+                    panic!("the build script was not run");
                 }
             }
         "#)
@@ -2363,14 +2363,7 @@ fn assume_build_script_when_build_rs_present() {
     p.build();
 
     assert_that(p.cargo("run").arg("-v"),
-                execs().with_status(0).with_stderr("\
-warning: `build.rs` files in the same directory as your `Cargo.toml` will soon be treated \
-as build scripts. Add `build = false` to your `Cargo.toml` to prevent this
-   Compiling builder v0.0.1 ([..])
-     Running [..]
-    Finished [..]
-     Running [..]
-"));
+                execs().with_status(0));
 }
 
 #[test]


### PR DESCRIPTION
If cargo sees a `build.rs` file in the same directory as the current
`Cargo.toml`, it will assume that the `build.rs` file is a build script,
unless there is `build = false` in the  `Cargo.toml` file.

Closes #3391