### PR TITLE
Reverted the "kind" field to the previous value.

### DIFF
--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -113,18 +113,21 @@ pub enum TargetKind {
 }
 
 impl TargetKind {
-    pub fn name(&self) -> &'static str {
+    /// Returns a vector of crate types as specified in a manifest with one difference.
+    /// For ExampleLib it returns "example" instead of crate types
+    pub fn kinds(&self) -> Vec<&str> {
         use self::TargetKind::*;
         match *self {
-            Lib(_) => "lib",
-            Bin => "bin",
-            ExampleBin | ExampleLib(_) => "example",
-            Test => "test",
-            CustomBuild => "custom-build",
-            Bench => "bench"
+            Lib(ref kinds) => kinds.iter().map(LibKind::crate_type).collect(),
+            Bin => vec!["bin"],
+            ExampleBin | ExampleLib(_) => vec!["example"],
+            Test => vec!["test"],
+            CustomBuild => vec!["custom-build"],
+            Bench => vec!["bench"]
         }
     }
 
+    /// Returns a vector of crate types as specified in a manifest
     pub fn crate_types(&self) -> Vec<&str> {
         use self::TargetKind::*;
         match *self {
@@ -216,7 +219,7 @@ struct SerializedTarget<'a> {
 impl Encodable for Target {
     fn encode<S: Encoder>(&self, s: &mut S) -> Result<(), S::Error> {
         SerializedTarget {
-            kind: vec![self.kind.name()],
+            kind: self.kind.kinds(),
             crate_types: self.kind.crate_types(),
             name: &self.name,
             src_path: &self.src_path.display().to_string(),

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -2600,14 +2600,24 @@ fn message_format_json_forward_stderr() {
     {
         "reason":"compiler-message",
         "package_id":"foo 0.5.0 ([..])",
-        "target":{"kind":["bin"],"name":"foo","src_path":"[..]"},
+        "target":{
+            "kind":["bin"],
+            "crate_types":["bin"],
+            "name":"foo",
+            "src_path":"[..]"
+        },
         "message":"{...}"
     }
 
     {
         "reason":"compiler-artifact",
         "package_id":"foo 0.5.0 ([..])",
-        "target":{"kind":["bin"],"name":"foo","src_path":"[..]"},
+        "target":{
+            "kind":["bin"],
+            "crate_types":["bin"],
+            "name":"foo",
+            "src_path":"[..]"
+        },
         "profile":{
             "debug_assertions":true,
             "debuginfo":2,

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -2510,7 +2510,12 @@ fn compiler_json_error_format() {
     {
         "reason":"compiler-message",
         "package_id":"bar 0.5.0 ([..])",
-        "target":{"kind":["lib"],"name":"bar","src_path":"[..]lib.rs"},
+        "target":{
+            "kind":["lib"],
+            "crate_types":["lib"],
+            "name":"bar",
+            "src_path":"[..]lib.rs"
+        },
         "message":"{...}"
     }
 
@@ -2524,21 +2529,36 @@ fn compiler_json_error_format() {
         },
         "features": [],
         "package_id":"bar 0.5.0 ([..])",
-        "target":{"kind":["lib"],"name":"bar","src_path":"[..]lib.rs"},
+        "target":{
+            "kind":["lib"],
+            "crate_types":["lib"],
+            "name":"bar",
+            "src_path":"[..]lib.rs"
+        },
         "filenames":["[..].rlib"]
     }
 
     {
         "reason":"compiler-message",
         "package_id":"foo 0.5.0 ([..])",
-        "target":{"kind":["bin"],"name":"foo","src_path":"[..]main.rs"},
+        "target":{
+            "kind":["bin"],
+            "crate_types":["bin"],
+            "name":"foo",
+            "src_path":"[..]main.rs"
+        },
         "message":"{...}"
     }
 
     {
         "reason":"compiler-artifact",
         "package_id":"foo 0.5.0 ([..])",
-        "target":{"kind":["bin"],"name":"foo","src_path":"[..]main.rs"},
+        "target":{
+            "kind":["bin"],
+            "crate_types":["bin"],
+            "name":"foo",
+            "src_path":"[..]main.rs"
+        },
         "profile": {
             "debug_assertions": true,
             "debuginfo": 2,

--- a/tests/metadata.rs
+++ b/tests/metadata.rs
@@ -274,7 +274,7 @@ version = "0.1.0"
 
 [[example]]
 name = "ex"
-crate-type = ["staticlib"]
+crate-type = ["rlib", "dylib"]
             "#);
 
     assert_that(p.cargo_process("metadata"), execs().with_json(r#"
@@ -298,7 +298,7 @@ crate-type = ["staticlib"]
                     },
                     {
                         "kind": [ "example" ],
-                        "crate_types": [ "staticlib" ],
+                        "crate_types": [ "rlib", "dylib" ],
                         "name": "ex",
                         "src_path": "[..][/]foo[/]examples[/]ex.rs"
                     }

--- a/tests/metadata.rs
+++ b/tests/metadata.rs
@@ -28,6 +28,9 @@ fn cargo_metadata_simple() {
                         "kind": [
                             "bin"
                         ],
+                        "crate_types": [
+                            "bin"
+                        ],
                         "name": "foo",
                         "src_path": "[..][/]foo[/]src[/]foo.rs"
                     }
@@ -93,6 +96,9 @@ fn cargo_metadata_with_deps_and_version() {
                         "kind": [
                             "lib"
                         ],
+                        "crate_types": [
+                            "lib"
+                        ],
                         "name": "baz",
                         "src_path": "[..]lib.rs"
                     }
@@ -125,6 +131,9 @@ fn cargo_metadata_with_deps_and_version() {
                         "kind": [
                             "lib"
                         ],
+                        "crate_types": [
+                            "lib"
+                        ],
                         "name": "bar",
                         "src_path": "[..]lib.rs"
                     }
@@ -155,6 +164,9 @@ fn cargo_metadata_with_deps_and_version() {
                 "targets": [
                     {
                         "kind": [
+                            "bin"
+                        ],
+                        "crate_types": [
                             "bin"
                         ],
                         "name": "foo",
@@ -218,6 +230,7 @@ fn workspace_metadata() {
                 "targets": [
                     {
                         "kind": [ "lib" ],
+                        "crate_types": [ "lib" ],
                         "name": "bar",
                         "src_path": "[..]bar[/]src[/]lib.rs"
                     }
@@ -237,6 +250,7 @@ fn workspace_metadata() {
                 "targets": [
                     {
                         "kind": [ "lib" ],
+                        "crate_types": [ "lib" ],
                         "name": "baz",
                         "src_path": "[..]baz[/]src[/]lib.rs"
                     }
@@ -291,6 +305,7 @@ fn workspace_metadata_no_deps() {
                 "targets": [
                     {
                         "kind": [ "lib" ],
+                        "crate_types": [ "lib" ],
                         "name": "bar",
                         "src_path": "[..]bar[/]src[/]lib.rs"
                     }
@@ -310,6 +325,7 @@ fn workspace_metadata_no_deps() {
                 "targets": [
                     {
                         "kind": [ "lib" ],
+                        "crate_types": ["lib"],
                         "name": "baz",
                         "src_path": "[..]baz[/]src[/]lib.rs"
                     }
@@ -351,6 +367,7 @@ const MANIFEST_OUTPUT: &'static str=
         "description": null,
         "targets":[{
             "kind":["bin"],
+            "crate_types":["bin"],
             "name":"foo",
             "src_path":"[..][/]foo[/]src[/]foo.rs"
         }],

--- a/tests/metadata.rs
+++ b/tests/metadata.rs
@@ -53,6 +53,62 @@ fn cargo_metadata_simple() {
     }"#));
 }
 
+#[test]
+fn library_with_several_crate_types() {
+    let p = project("foo")
+            .file("src/lib.rs", "")
+            .file("Cargo.toml", r#"
+[package]
+name = "foo"
+version = "0.5.0"
+
+[lib]
+crate-type = ["lib", "staticlib"]
+            "#);
+
+    assert_that(p.cargo_process("metadata"), execs().with_json(r#"
+    {
+        "packages": [
+            {
+                "name": "foo",
+                "version": "0.5.0",
+                "id": "foo[..]",
+                "source": null,
+                "dependencies": [],
+                "license": null,
+                "license_file": null,
+                "description": null,
+                "targets": [
+                    {
+                        "kind": [
+                            "lib",
+                            "staticlib"
+                        ],
+                        "crate_types": [
+                            "lib",
+                            "staticlib"
+                        ],
+                        "name": "foo",
+                        "src_path": "[..][/]foo[/]src[/]lib.rs"
+                    }
+                ],
+                "features": {},
+                "manifest_path": "[..]Cargo.toml"
+            }
+        ],
+        "workspace_members": ["foo 0.5.0 (path+file:[..]foo)"],
+        "resolve": {
+            "nodes": [
+                {
+                    "dependencies": [],
+                    "id": "foo 0.5.0 (path+file:[..]foo)"
+                }
+            ],
+            "root": "foo 0.5.0 (path+file:[..]foo)"
+        },
+        "version": 1
+    }"#));
+}
 
 #[test]
 fn cargo_metadata_with_deps_and_version() {
@@ -567,7 +623,7 @@ fn cargo_metadata_no_deps_cwd() {
 }
 
 #[test]
-fn carg_metadata_bad_version() {
+fn cargo_metadata_bad_version() {
     let p = project("foo")
         .file("Cargo.toml", &basic_bin_manifest("foo"))
         .file("src/foo.rs", &main_file(r#""i am foo""#, &[]));

--- a/tests/metadata.rs
+++ b/tests/metadata.rs
@@ -203,6 +203,127 @@ fn cargo_metadata_with_deps_and_version() {
 }
 
 #[test]
+fn example() {
+    let p = project("foo")
+            .file("src/lib.rs", "")
+            .file("examples/ex.rs", "")
+            .file("Cargo.toml", r#"
+[package]
+name = "foo"
+version = "0.1.0"
+
+[[example]]
+name = "ex"
+            "#);
+
+    assert_that(p.cargo_process("metadata"), execs().with_json(r#"
+    {
+        "packages": [
+            {
+                "name": "foo",
+                "version": "0.1.0",
+                "id": "foo[..]",
+                "license": null,
+                "license_file": null,
+                "description": null,
+                "source": null,
+                "dependencies": [],
+                "targets": [
+                    {
+                        "kind": [ "lib" ],
+                        "crate_types": [ "lib" ],
+                        "name": "foo",
+                        "src_path": "[..][/]foo[/]src[/]lib.rs"
+                    },
+                    {
+                        "kind": [ "example" ],
+                        "crate_types": [ "example" ],
+                        "name": "ex",
+                        "src_path": "[..][/]foo[/]examples[/]ex.rs"
+                    }
+                ],
+                "features": {},
+                "manifest_path": "[..]Cargo.toml"
+            }
+        ],
+        "workspace_members": [
+            "foo 0.1.0 (path+file:[..]foo)"
+        ],
+        "resolve": {
+            "root": "foo 0.1.0 (path+file://[..]foo)",
+            "nodes": [
+                {
+                    "id": "foo 0.1.0 (path+file:[..]foo)",
+                    "dependencies": []
+                }
+            ]
+        },
+        "version": 1
+    }"#));
+}
+
+#[test]
+fn example_lib() {
+    let p = project("foo")
+            .file("src/lib.rs", "")
+            .file("examples/ex.rs", "")
+            .file("Cargo.toml", r#"
+[package]
+name = "foo"
+version = "0.1.0"
+
+[[example]]
+name = "ex"
+crate-type = ["staticlib"]
+            "#);
+
+    assert_that(p.cargo_process("metadata"), execs().with_json(r#"
+    {
+        "packages": [
+            {
+                "name": "foo",
+                "version": "0.1.0",
+                "id": "foo[..]",
+                "license": null,
+                "license_file": null,
+                "description": null,
+                "source": null,
+                "dependencies": [],
+                "targets": [
+                    {
+                        "kind": [ "lib" ],
+                        "crate_types": [ "lib" ],
+                        "name": "foo",
+                        "src_path": "[..][/]foo[/]src[/]lib.rs"
+                    },
+                    {
+                        "kind": [ "example" ],
+                        "crate_types": [ "staticlib" ],
+                        "name": "ex",
+                        "src_path": "[..][/]foo[/]examples[/]ex.rs"
+                    }
+                ],
+                "features": {},
+                "manifest_path": "[..]Cargo.toml"
+            }
+        ],
+        "workspace_members": [
+            "foo 0.1.0 (path+file:[..]foo)"
+        ],
+        "resolve": {
+            "root": "foo 0.1.0 (path+file://[..]foo)",
+            "nodes": [
+                {
+                    "id": "foo 0.1.0 (path+file:[..]foo)",
+                    "dependencies": []
+                }
+            ]
+        },
+        "version": 1
+    }"#));
+}
+
+#[test]
 fn workspace_metadata() {
     let p = project("foo")
         .file("Cargo.toml", r#"

--- a/tests/read-manifest.rs
+++ b/tests/read-manifest.rs
@@ -16,6 +16,7 @@ static MANIFEST_OUTPUT: &'static str = r#"
     "dependencies":[],
     "targets":[{
         "kind":["bin"],
+        "crate_types":["bin"],
         "name":"foo",
         "src_path":"[..][/]foo[/]src[/]foo.rs"
     }],


### PR DESCRIPTION
Added a new field named "crate_types".
Fixes https://github.com/rust-lang/cargo/issues/3654
After this PR `cargo metadata` would output:
```json
{
    "packages": [
        {
            "targets": [
                {
                    "kind": ["lib"],
                    "crate_types": ["lib"]
                },
                {
                    "kind": ["example"],
                    "crate_types": ["staticlib"]
                }
            ]
        }
    ]
}
```

I have added tests.