### PR TITLE
Pinpoint hamcrest-dependency in cargotest to 0.1.1

### DIFF
--- a/tests/cargotest/Cargo.toml
+++ b/tests/cargotest/Cargo.toml
@@ -12,7 +12,7 @@ cargo = { path = "../.." }
 filetime = "0.1"
 flate2 = "0.2"
 git2 = { version = "0.6", default-features = false }
-hamcrest = "0.1"
+hamcrest = "=0.1.1"
 kernel32-sys = "0.2"
 libc = "0.2"
 log = "0.3"


### PR DESCRIPTION
hamcrest 0.1 currently resolves to 0.1.3, which cargotest can't actually build with. Cargo's own dependency on =0.1.1 used to shadow the problem.