### PR TITLE
Migrate from rustc-serialize to Serde

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,11 +28,15 @@ dependencies = [
  "psapi-sys 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_ignored 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "shell-escape 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tar 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "term 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "toml 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -86,6 +90,8 @@ dependencies = [
  "libc 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tar 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "term 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -111,7 +117,9 @@ name = "crates-io"
 version = "0.7.0"
 dependencies = [
  "curl 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -155,6 +163,11 @@ dependencies = [
  "rustc-serialize 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "strsim 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "dtoa"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "env_logger"
@@ -271,6 +284,11 @@ dependencies = [
  "unicode-bidi 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-normalization 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "itoa"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "kernel32-sys"
@@ -522,6 +540,11 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "quote"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "rand"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -582,6 +605,48 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "serde"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "serde_codegen_internals"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "syn 0.11.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "serde_derive"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "quote 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_codegen_internals 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.11.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "serde_ignored"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "serde 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "serde_json"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "dtoa 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itoa 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "shell-escape"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -590,6 +655,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "strsim"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "syn"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "quote 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "tar"
@@ -656,8 +730,13 @@ dependencies = [
 name = "toml"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "toml"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rustc-serialize 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -671,6 +750,11 @@ dependencies = [
 [[package]]
 name = "unicode-normalization"
 version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "unicode-xid"
+version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -745,6 +829,7 @@ dependencies = [
 "checksum curl 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "654c5b772f9e62a46a99cc9ee7442e80a139027889a6305cdd59bc1e5eb3e3e8"
 "checksum curl-sys 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "a89415561199ca2ac6de2519674739159c1583bc0a9b46ec30fd3814999d5ef5"
 "checksum docopt 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ab32ea6e284d87987066f21a9e809a73c14720571ef34516f0890b3d355ccfd8"
+"checksum dtoa 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "80c8b71fd71146990a9742fc06dcbbde19161a267e0ad4e572c35162f4578c90"
 "checksum env_logger 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "99971fb1b635fe7a0ee3c4d065845bb93cca80a23b5613b5613391ece5de4144"
 "checksum error-chain 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "318cb3c71ee4cdea69fdc9e15c173b245ed6063e1709029e8fd32525a881120f"
 "checksum filetime 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "5363ab8e4139b8568a6237db5248646e5a8a2f89bd5ccb02092182b11fd3e922"
@@ -758,6 +843,7 @@ dependencies = [
 "checksum hamcrest 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bf088f042a467089e9baa4972f57f9247e42a0cc549ba264c7a04fbb8ecb89d4"
 "checksum handlebars 0.25.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b930077f1422bf853008047b55896efc1409744bfc9903f1eec1a58fcc7edeff"
 "checksum idna 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1053236e00ce4f668aeca4a769a09b3bf5a682d802abd6f3cb39374f6b162c11"
+"checksum itoa 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "eb2f404fbc66fd9aac13e998248505e7ecb2ad8e44ab6388684c5fb11c6c251c"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6abe0ee2e758cd6bc8a2cd56726359007748fbf4128da998b65d0b70f881e19b"
 "checksum libc 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)" = "684f330624d8c3784fb9558ca46c4ce488073a8d22450415c5eb4f4cfb0d11b5"
@@ -787,6 +873,7 @@ dependencies = [
 "checksum pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "3a8b4c6b8165cd1a1cd4b9b120978131389f64bdaf456435caa41e630edba903"
 "checksum psapi-sys 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "abcd5d1a07d360e29727f757a9decb3ce8bc6e0efa8969cfaad669a8317a2478"
 "checksum quick-error 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0aad603e8d7fb67da22dbdf1f4b826ce8829e406124109e73cf1b2454b93a71c"
+"checksum quote 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)" = "e7b44fd83db28b83c1c58187159934906e5e955c812e211df413b76b03c909a5"
 "checksum rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "022e0636ec2519ddae48154b028864bdce4eaf7d35226ab8e65c611be97b189d"
 "checksum regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)" = "4fd4ace6a8cf7860714a2c2280d6c1f7e6a413486c13298bbc86fd3da019402f"
 "checksum regex 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4278c17d0f6d62dfef0ab00028feb45bd7d2102843f80763474eeb1be8a10c01"
@@ -795,8 +882,14 @@ dependencies = [
 "checksum rustc-serialize 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)" = "237546c689f20bb44980270c73c3b9edd0891c1be49cc1274406134a66d3957b"
 "checksum semver 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a3186ec9e65071a2095434b1f5bb24838d4e8e130f584c790f6033c79943537"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
+"checksum serde 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0ae9a3c8b07c09dbe43022486d55a18c629a0618d2241e49829aaef9b6d862f9"
+"checksum serde_codegen_internals 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c3172bf2940b975c0e4f6ab42a511c0a4407d4f46ccef87a9d3615db5c26fa96"
+"checksum serde_derive 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ecc6e0379ca933ece58302d2d3034443f06fbf38fd535857c1dc516195cbc3bf"
+"checksum serde_ignored 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d4b3f5576874721d14690657e9f0ed286e72a52be2f6fdc0cf2f024182bd8f64"
+"checksum serde_json 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)" = "e095e4e94e7382b76f48e93bd845ffddda62df8dfd4c163b1bfa93d40e22e13a"
 "checksum shell-escape 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "dd5cc96481d54583947bfe88bf30c23d53f883c6cd0145368b69989d97b84ef8"
 "checksum strsim 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b4d15c810519a91cf877e7e36e63fe068815c678181439f2f29e2562147c3694"
+"checksum syn 0.11.4 (registry+https://github.com/rust-lang/crates.io-index)" = "f4f94368aae82bb29656c98443a7026ca931a659e8d19dcdc41d6e273054e820"
 "checksum tar 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "1eb3bf6ec92843ca93f4fcfb5fc6dfe30534815b147885db4b5759b8e2ff7d52"
 "checksum tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "87974a6f5c1dfb344d733055601650059a3363de2a6104819293baff662132d6"
 "checksum term 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "3deff8a2b3b6607d6d7cc32ac25c0b33709453ca9cceac006caac51e963cf94a"
@@ -805,8 +898,10 @@ dependencies = [
 "checksum thread_local 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "8576dbbfcaef9641452d5cf0df9b0e7eeab7694956dd33bb61515fb8f18cfdd5"
 "checksum thread_local 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7793b722f0f77ce716e7f1acf416359ca32ff24d04ffbac4269f44a4a83be05d"
 "checksum toml 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "736b60249cb25337bc196faa43ee12c705e426f3d55c214d73a4e7be06f92cb4"
+"checksum toml 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "08272367dd2e766db3fa38f068067d17aa6a9dfd7259af24b3927db92f1e0c2f"
 "checksum unicode-bidi 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b61814f3e7fd0e0f15370f767c7c943e08bc2e3214233ae8f88522b334ceb778"
 "checksum unicode-normalization 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "e28fa37426fceeb5cf8f41ee273faa7c82c47dc8fba5853402841e665fcd86ff"
+"checksum unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
 "checksum unreachable 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1f2ae5ddb18e1c92664717616dd9549dde73f539f01bd7b77c2edb2446bdff91"
 "checksum url 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f5ba8a749fb4479b043733416c244fa9d1d3af3d7c23804944651c8a448cb87e"
 "checksum user32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4ef4711d107b21b410a3a974b1204d9accc8b10dad75d8324b5d755de1617d47"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,11 +35,15 @@ log = "0.3"
 num_cpus = "1.0"
 rustc-serialize = "0.3"
 semver = "0.6.0"
+serde = "0.9"
+serde_derive = "0.9"
+serde_json = "0.9"
+serde_ignored = "0.0.2"
 shell-escape = "0.1"
 tar = { version = "0.4", default-features = false }
 tempdir = "0.3"
 term = "0.4.4"
-toml = "0.2"
+toml = "0.3"
 url = "1.1"
 
 [target.'cfg(unix)'.dependencies]

--- a/src/bin/cargo.rs
+++ b/src/bin/cargo.rs
@@ -6,6 +6,9 @@ extern crate rustc_serialize;
 extern crate toml;
 #[macro_use]
 extern crate log;
+#[macro_use]
+extern crate serde_derive;
+extern crate serde_json;
 
 use std::collections::BTreeSet;
 use std::collections::HashMap;

--- a/src/bin/locate_project.rs
+++ b/src/bin/locate_project.rs
@@ -18,7 +18,7 @@ Options:
     -h, --help              Print this message
 ";
 
-#[derive(RustcEncodable)]
+#[derive(Serialize)]
 pub struct ProjectLocation {
     root: String
 }

--- a/src/bin/verify_project.rs
+++ b/src/bin/verify_project.rs
@@ -6,7 +6,7 @@ use std::process;
 use cargo;
 use cargo::util::important_paths::{find_root_manifest_for_wd};
 use cargo::util::{CliResult, Config};
-use rustc_serialize::json;
+use serde_json;
 use toml;
 
 #[derive(RustcDecodable)]
@@ -55,10 +55,9 @@ pub fn execute(args: Flags, config: &Config) -> CliResult {
         Ok(_) => {},
         Err(e) => fail("invalid", &format!("error reading file: {}", e))
     };
-    match toml::Parser::new(&contents).parse() {
-        None => fail("invalid", "invalid-format"),
-        Some(..) => {}
-    };
+    if contents.parse::<toml::Value>().is_err() {
+        fail("invalid", "invalid-format");
+    }
 
     let mut h = HashMap::new();
     h.insert("success".to_string(), "true".to_string());
@@ -69,6 +68,6 @@ pub fn execute(args: Flags, config: &Config) -> CliResult {
 fn fail(reason: &str, value: &str) -> ! {
     let mut h = HashMap::new();
     h.insert(reason.to_string(), value.to_string());
-    println!("{}", json::encode(&h).unwrap());
+    println!("{}", serde_json::to_string(&h).unwrap());
     process::exit(1)
 }

--- a/src/cargo/lib.rs
+++ b/src/cargo/lib.rs
@@ -3,6 +3,8 @@
 
 #[cfg(test)] extern crate hamcrest;
 #[macro_use] extern crate log;
+#[macro_use] extern crate serde_derive;
+#[macro_use] extern crate serde_json;
 extern crate crates_io as registry;
 extern crate crossbeam;
 extern crate curl;
@@ -18,6 +20,8 @@ extern crate libgit2_sys;
 extern crate num_cpus;
 extern crate rustc_serialize;
 extern crate semver;
+extern crate serde;
+extern crate serde_ignored;
 extern crate shell_escape;
 extern crate tar;
 extern crate tempdir;
@@ -27,8 +31,8 @@ extern crate url;
 
 use std::io;
 use std::fmt;
-use rustc_serialize::{Decodable, Encodable};
-use rustc_serialize::json;
+use rustc_serialize::Decodable;
+use serde::ser;
 use docopt::Docopt;
 
 use core::{Shell, MultiShell, ShellConfig, Verbosity, ColorConfig};
@@ -121,8 +125,8 @@ pub fn call_main_without_stdin<Flags: Decodable>(
     exec(flags, config)
 }
 
-pub fn print_json<T: Encodable>(obj: &T) {
-    let encoded = json::encode(&obj).unwrap();
+pub fn print_json<T: ser::Serialize>(obj: &T) {
+    let encoded = serde_json::to_string(&obj).unwrap();
     println!("{}", encoded);
 }
 

--- a/src/cargo/ops/cargo_rustc/mod.rs
+++ b/src/cargo/ops/cargo_rustc/mod.rs
@@ -6,7 +6,7 @@ use std::io::{self, Write};
 use std::path::{self, PathBuf};
 use std::sync::Arc;
 
-use rustc_serialize::json;
+use serde_json;
 
 use core::{Package, PackageId, PackageSet, Target, Resolve};
 use core::{Profile, Profiles, Workspace};
@@ -346,7 +346,7 @@ fn rustc(cx: &mut Context, unit: &Unit, exec: Arc<Executor>) -> CargoResult<Work
                     // stderr from rustc can have a mix of JSON and non-JSON output
                     if line.starts_with('{') {
                         // Handle JSON lines
-                        let compiler_message = json::Json::from_str(line).map_err(|_| {
+                        let compiler_message = serde_json::from_str(line).map_err(|_| {
                             internal(&format!("compiler produced invalid json: `{}`", line))
                         })?;
 

--- a/src/cargo/sources/directory.rs
+++ b/src/cargo/sources/directory.rs
@@ -5,7 +5,7 @@ use std::io::Read;
 use std::path::{Path, PathBuf};
 
 use rustc_serialize::hex::ToHex;
-use rustc_serialize::json;
+use serde_json;
 
 use core::{Package, PackageId, Summary, SourceId, Source, Dependency, Registry};
 use sources::PathSource;
@@ -19,7 +19,7 @@ pub struct DirectorySource<'cfg> {
     config: &'cfg Config,
 }
 
-#[derive(RustcDecodable)]
+#[derive(Deserialize)]
 struct Checksum {
     package: String,
     files: HashMap<String, String>,
@@ -93,7 +93,7 @@ impl<'cfg> Source for DirectorySource<'cfg> {
                               pkg.package_id().version()))
 
             })?;
-            let cksum: Checksum = json::decode(&cksum).chain_error(|| {
+            let cksum: Checksum = serde_json::from_str(&cksum).chain_error(|| {
                 human(format!("failed to decode `.cargo-checksum.json` of \
                                {} v{}",
                               pkg.package_id().name(),

--- a/src/cargo/sources/registry/index.rs
+++ b/src/cargo/sources/registry/index.rs
@@ -3,7 +3,7 @@ use std::io::prelude::*;
 use std::fs::File;
 use std::path::Path;
 
-use rustc_serialize::json;
+use serde_json;
 
 use core::dependency::{Dependency, DependencyInner, Kind};
 use core::{SourceId, Summary, PackageId, Registry};
@@ -116,7 +116,7 @@ impl<'cfg> RegistryIndex<'cfg> {
                               -> CargoResult<(Summary, bool)> {
         let RegistryPackage {
             name, vers, cksum, deps, features, yanked
-        } = json::decode::<RegistryPackage>(line)?;
+        } = serde_json::from_str::<RegistryPackage>(line)?;
         let pkgid = PackageId::new(&name, &vers, &self.source_id)?;
         let deps: CargoResult<Vec<Dependency>> = deps.into_iter().map(|dep| {
             self.parse_registry_dependency(dep)

--- a/src/cargo/sources/registry/mod.rs
+++ b/src/cargo/sources/registry/mod.rs
@@ -184,7 +184,7 @@ pub struct RegistrySource<'cfg> {
     index_locked: bool,
 }
 
-#[derive(RustcDecodable)]
+#[derive(Deserialize)]
 pub struct RegistryConfig {
     /// Download endpoint for all crates. This will be appended with
     /// `/<crate>/<version>/download` and then will be hit with an HTTP GET
@@ -196,7 +196,7 @@ pub struct RegistryConfig {
     pub api: String,
 }
 
-#[derive(RustcDecodable)]
+#[derive(Deserialize)]
 struct RegistryPackage {
     name: String,
     vers: String,
@@ -206,7 +206,7 @@ struct RegistryPackage {
     yanked: Option<bool>,
 }
 
-#[derive(RustcDecodable)]
+#[derive(Deserialize)]
 struct RegistryDependency {
     name: String,
     req: String,

--- a/src/cargo/sources/registry/remote.rs
+++ b/src/cargo/sources/registry/remote.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 use curl::easy::{Easy, List};
 use git2;
 use rustc_serialize::hex::ToHex;
-use rustc_serialize::json;
+use serde_json;
 use url::Url;
 
 use core::{PackageId, SourceId};
@@ -49,7 +49,7 @@ impl<'cfg> RegistryData for RemoteRegistry<'cfg> {
                                            "the registry index")?;
         let path = lock.path().parent().unwrap();
         let contents = paths::read(&path.join("config.json"))?;
-        let config = json::decode(&contents)?;
+        let config = serde_json::from_str(&contents)?;
         Ok(Some(config))
     }
 

--- a/src/cargo/util/errors.rs
+++ b/src/cargo/util/errors.rs
@@ -11,8 +11,8 @@ use std::string;
 use curl;
 use git2;
 use handlebars;
-use rustc_serialize::json;
 use semver;
+use serde_json;
 use term;
 use toml;
 use url;
@@ -334,13 +334,12 @@ from_error! {
     io::Error,
     ProcessError,
     git2::Error,
-    json::DecoderError,
-    json::EncoderError,
+    serde_json::Error,
     curl::Error,
     CliError,
-    toml::Error,
     url::ParseError,
-    toml::DecodeError,
+    toml::ser::Error,
+    toml::de::Error,
     ffi::NulError,
     term::Error,
     num::ParseIntError,
@@ -363,14 +362,17 @@ impl<E: CargoError> From<Human<E>> for Box<CargoError> {
 impl CargoError for semver::ReqParseError {}
 impl CargoError for io::Error {}
 impl CargoError for git2::Error {}
-impl CargoError for json::DecoderError {}
-impl CargoError for json::EncoderError {}
+impl CargoError for serde_json::Error {}
 impl CargoError for curl::Error {}
 impl CargoError for ProcessError {}
 impl CargoError for CargoTestError {}
 impl CargoError for CliError {}
-impl CargoError for toml::Error {}
-impl CargoError for toml::DecodeError {}
+impl CargoError for toml::ser::Error {
+    fn is_human(&self) -> bool { true }
+}
+impl CargoError for toml::de::Error {
+    fn is_human(&self) -> bool { true }
+}
 impl CargoError for url::ParseError {}
 impl CargoError for ffi::NulError {}
 impl CargoError for term::Error {}

--- a/src/crates-io/Cargo.toml
+++ b/src/crates-io/Cargo.toml
@@ -14,5 +14,7 @@ path = "lib.rs"
 
 [dependencies]
 curl = "0.4"
+serde = "0.9"
+serde_derive = "0.9"
+serde_json = "0.9"
 url = "1.0"
-rustc-serialize = "0.3"

--- a/src/crates-io/lib.rs
+++ b/src/crates-io/lib.rs
@@ -1,6 +1,8 @@
 extern crate curl;
 extern crate url;
-extern crate rustc_serialize;
+extern crate serde_json;
+#[macro_use]
+extern crate serde_derive;
 
 use std::collections::HashMap;
 use std::fmt;
@@ -10,7 +12,6 @@ use std::io::{self, Cursor};
 use std::result;
 
 use curl::easy::{Easy, List};
-use rustc_serialize::json::{self, Json};
 
 use url::percent_encoding::{percent_encode, QUERY_ENCODE_SET};
 
@@ -37,26 +38,12 @@ pub enum Error {
     TokenMissing,
     Io(io::Error),
     NotFound,
-    JsonEncodeError(json::EncoderError),
-    JsonDecodeError(json::DecoderError),
-    JsonParseError(json::ParserError),
+    Json(serde_json::Error),
 }
 
-impl From<json::EncoderError> for Error {
-    fn from(err: json::EncoderError) -> Error {
-        Error::JsonEncodeError(err)
-    }
-}
-
-impl From<json::DecoderError> for Error {
-    fn from(err: json::DecoderError) -> Error {
-        Error::JsonDecodeError(err)
-    }
-}
-
-impl From<json::ParserError> for Error {
-    fn from(err: json::ParserError) -> Error {
-        Error::JsonParseError(err)
+impl From<serde_json::Error> for Error {
+    fn from(err: serde_json::Error) -> Error {
+        Error::Json(err)
     }
 }
 
@@ -66,14 +53,14 @@ impl From<curl::Error> for Error {
     }
 }
 
-#[derive(RustcDecodable)]
+#[derive(Deserialize)]
 pub struct Crate {
     pub name: String,
     pub description: Option<String>,
     pub max_version: String
 }
 
-#[derive(RustcEncodable)]
+#[derive(Serialize)]
 pub struct NewCrate {
     pub name: String,
     pub vers: String,
@@ -92,7 +79,7 @@ pub struct NewCrate {
     pub badges: HashMap<String, HashMap<String, String>>,
 }
 
-#[derive(RustcEncodable)]
+#[derive(Serialize)]
 pub struct NewCrateDependency {
     pub optional: bool,
     pub default_features: bool,
@@ -103,7 +90,7 @@ pub struct NewCrateDependency {
     pub kind: String,
 }
 
-#[derive(RustcDecodable)]
+#[derive(Deserialize)]
 pub struct User {
     pub id: u32,
     pub login: String,
@@ -117,13 +104,13 @@ pub struct Warnings {
     pub invalid_badges: Vec<String>,
 }
 
-#[derive(RustcDecodable)] struct R { ok: bool }
-#[derive(RustcDecodable)] struct ApiErrorList { errors: Vec<ApiError> }
-#[derive(RustcDecodable)] struct ApiError { detail: String }
-#[derive(RustcEncodable)] struct OwnersReq<'a> { users: &'a [&'a str] }
-#[derive(RustcDecodable)] struct Users { users: Vec<User> }
-#[derive(RustcDecodable)] struct TotalCrates { total: u32 }
-#[derive(RustcDecodable)] struct Crates { crates: Vec<Crate>, meta: TotalCrates }
+#[derive(Deserialize)] struct R { ok: bool }
+#[derive(Deserialize)] struct ApiErrorList { errors: Vec<ApiError> }
+#[derive(Deserialize)] struct ApiError { detail: String }
+#[derive(Serialize)] struct OwnersReq<'a> { users: &'a [&'a str] }
+#[derive(Deserialize)] struct Users { users: Vec<User> }
+#[derive(Deserialize)] struct TotalCrates { total: u32 }
+#[derive(Deserialize)] struct Crates { crates: Vec<Crate>, meta: TotalCrates }
 impl Registry {
     pub fn new(host: String, token: Option<String>) -> Registry {
         Registry::new_handle(host, token, Easy::new())
@@ -140,29 +127,29 @@ impl Registry {
     }
 
     pub fn add_owners(&mut self, krate: &str, owners: &[&str]) -> Result<()> {
-        let body = json::encode(&OwnersReq { users: owners })?;
+        let body = serde_json::to_string(&OwnersReq { users: owners })?;
         let body = self.put(format!("/crates/{}/owners", krate),
                                  body.as_bytes())?;
-        assert!(json::decode::<R>(&body)?.ok);
+        assert!(serde_json::from_str::<R>(&body)?.ok);
         Ok(())
     }
 
     pub fn remove_owners(&mut self, krate: &str, owners: &[&str]) -> Result<()> {
-        let body = json::encode(&OwnersReq { users: owners })?;
+        let body = serde_json::to_string(&OwnersReq { users: owners })?;
         let body = self.delete(format!("/crates/{}/owners", krate),
                                     Some(body.as_bytes()))?;
-        assert!(json::decode::<R>(&body)?.ok);
+        assert!(serde_json::from_str::<R>(&body)?.ok);
         Ok(())
     }
 
     pub fn list_owners(&mut self, krate: &str) -> Result<Vec<User>> {
         let body = self.get(format!("/crates/{}/owners", krate))?;
-        Ok(json::decode::<Users>(&body)?.users)
+        Ok(serde_json::from_str::<Users>(&body)?.users)
     }
 
     pub fn publish(&mut self, krate: &NewCrate, tarball: &File)
                    -> Result<Warnings> {
-        let json = json::encode(krate)?;
+        let json = serde_json::to_string(krate)?;
         // Prepare the body. The format of the upload request is:
         //
         //      <le u32 of json>
@@ -208,28 +195,27 @@ impl Registry {
             body.read(buf).unwrap_or(0)
         })?;
 
-        // Can't derive RustcDecodable because JSON has a key named "crate" :(
         let response = if body.len() > 0 {
-            Json::from_str(&body)?
+            body.parse::<serde_json::Value>()?
         } else {
-            Json::from_str("{}")?
+            "{}".parse()?
         };
 
         let invalid_categories: Vec<String> =
-            response
-                .find_path(&["warnings", "invalid_categories"])
-                .and_then(Json::as_array)
+            response.get("warnings")
+                .and_then(|j| j.get("invalid_categories"))
+                .and_then(|j| j.as_array())
                 .map(|x| {
-                    x.iter().flat_map(Json::as_string).map(Into::into).collect()
+                    x.iter().flat_map(|j| j.as_str()).map(Into::into).collect()
                 })
                 .unwrap_or_else(Vec::new);
 
         let invalid_badges: Vec<String> =
-            response
-                .find_path(&["warnings", "invalid_badges"])
-                .and_then(Json::as_array)
+            response.get("warnings")
+                .and_then(|j| j.get("invalid_badges"))
+                .and_then(|j| j.as_array())
                 .map(|x| {
-                    x.iter().flat_map(Json::as_string).map(Into::into).collect()
+                    x.iter().flat_map(|j| j.as_str()).map(Into::into).collect()
                 })
                 .unwrap_or_else(Vec::new);
 
@@ -246,21 +232,21 @@ impl Registry {
             None, Auth::Unauthorized
         )?;
 
-        let crates = json::decode::<Crates>(&body)?;
+        let crates = serde_json::from_str::<Crates>(&body)?;
         Ok((crates.crates, crates.meta.total))
     }
 
     pub fn yank(&mut self, krate: &str, version: &str) -> Result<()> {
         let body = self.delete(format!("/crates/{}/{}/yank", krate, version),
                                     None)?;
-        assert!(json::decode::<R>(&body)?.ok);
+        assert!(serde_json::from_str::<R>(&body)?.ok);
         Ok(())
     }
 
     pub fn unyank(&mut self, krate: &str, version: &str) -> Result<()> {
         let body = self.put(format!("/crates/{}/{}/unyank", krate, version),
                                  &[])?;
-        assert!(json::decode::<R>(&body)?.ok);
+        assert!(serde_json::from_str::<R>(&body)?.ok);
         Ok(())
     }
 
@@ -337,7 +323,7 @@ fn handle(handle: &mut Easy,
         Ok(body) => body,
         Err(..) => return Err(Error::NonUtf8Body),
     };
-    match json::decode::<ApiErrorList>(&body) {
+    match serde_json::from_str::<ApiErrorList>(&body) {
         Ok(errors) => {
             return Err(Error::Api(errors.errors.into_iter().map(|s| s.detail)
                                         .collect()))
@@ -369,9 +355,7 @@ impl fmt::Display for Error {
             Error::TokenMissing => write!(f, "no upload token found, please run `cargo login`"),
             Error::Io(ref e) => write!(f, "io error: {}", e),
             Error::NotFound => write!(f, "cannot find crate"),
-            Error::JsonEncodeError(ref e) => write!(f, "json encode error: {}", e),
-            Error::JsonDecodeError(ref e) => write!(f, "json decode error: {}", e),
-            Error::JsonParseError(ref e) => write!(f, "json parse error: {}", e),
+            Error::Json(ref e) => write!(f, "json error: {}", e),
         }
     }
 }

--- a/tests/bad-config.rs
+++ b/tests/bad-config.rs
@@ -206,12 +206,13 @@ fn invalid_global_config() {
 [ERROR] Couldn't load Cargo configuration
 
 Caused by:
-  could not parse TOML configuration in `[..]config`
+  could not parse TOML configuration in `[..]`
 
 Caused by:
   could not parse input as TOML
-[..]config:1:2 expected `=`, but found eof
 
+Caused by:
+  expected an equals, found eof at line 1
 "));
 }
 
@@ -232,7 +233,7 @@ fn bad_cargo_lock() {
 [ERROR] failed to parse lock file at: [..]Cargo.lock
 
 Caused by:
-  expected a value of type `string` for the key `package.name`
+  missing field `name` for key `package`
 "));
 }
 
@@ -315,7 +316,7 @@ fn bad_source_in_cargo_lock() {
 [ERROR] failed to parse lock file at: [..]
 
 Caused by:
-  invalid source `You shall not parse` for the key `package.source`
+  invalid source `You shall not parse` for key `package.source`
 "));
 }
 
@@ -421,8 +422,9 @@ fn malformed_override() {
 
 Caused by:
   could not parse input as TOML
-Cargo.toml:[..]
 
+Caused by:
+  expected a table key, found a newline at line 8
 "));
 }
 

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -100,8 +100,9 @@ fn cargo_compile_with_invalid_manifest2() {
 
 Caused by:
   could not parse input as TOML
-Cargo.toml:3:19-3:20 expected a value
 
+Caused by:
+  invalid number at line 3
 "))
 }
 
@@ -124,8 +125,11 @@ fn cargo_compile_with_invalid_manifest3() {
 [ERROR] failed to parse manifest at `[..]`
 
 Caused by:
-  could not parse input as TOML\n\
-src[/]Cargo.toml:1:5-1:6 expected a value\n\n"))
+  could not parse input as TOML
+
+Caused by:
+  invalid number at line 1
+"))
 }
 
 #[test]
@@ -175,7 +179,7 @@ fn cargo_compile_with_invalid_version() {
 [ERROR] failed to parse manifest at `[..]`
 
 Caused by:
-  cannot parse '1.0' as a semver for the key `project.version`
+  cannot parse '1.0' as a semver for key `project.version`
 "))
 
 }
@@ -876,39 +880,39 @@ suffix = env::consts::DLL_SUFFIX,
 fn crate_env_vars() {
     let p = project("foo")
         .file("Cargo.toml", r#"
-	    [project]
-	    name = "foo"
-	    version = "0.5.1-alpha.1"
-	    description = "This is foo"
-	    homepage = "http://example.com"
-	    authors = ["wycats@example.com"]
+        [project]
+        name = "foo"
+        version = "0.5.1-alpha.1"
+        description = "This is foo"
+        homepage = "http://example.com"
+        authors = ["wycats@example.com"]
         "#)
         .file("src/main.rs", r#"
             extern crate foo;
 
 
-	    static VERSION_MAJOR: &'static str = env!("CARGO_PKG_VERSION_MAJOR");
-	    static VERSION_MINOR: &'static str = env!("CARGO_PKG_VERSION_MINOR");
-	    static VERSION_PATCH: &'static str = env!("CARGO_PKG_VERSION_PATCH");
-	    static VERSION_PRE: &'static str = env!("CARGO_PKG_VERSION_PRE");
-	    static VERSION: &'static str = env!("CARGO_PKG_VERSION");
-	    static CARGO_MANIFEST_DIR: &'static str = env!("CARGO_MANIFEST_DIR");
-	    static PKG_NAME: &'static str = env!("CARGO_PKG_NAME");
-	    static HOMEPAGE: &'static str = env!("CARGO_PKG_HOMEPAGE");
-	    static DESCRIPTION: &'static str = env!("CARGO_PKG_DESCRIPTION");
+            static VERSION_MAJOR: &'static str = env!("CARGO_PKG_VERSION_MAJOR");
+            static VERSION_MINOR: &'static str = env!("CARGO_PKG_VERSION_MINOR");
+            static VERSION_PATCH: &'static str = env!("CARGO_PKG_VERSION_PATCH");
+            static VERSION_PRE: &'static str = env!("CARGO_PKG_VERSION_PRE");
+            static VERSION: &'static str = env!("CARGO_PKG_VERSION");
+            static CARGO_MANIFEST_DIR: &'static str = env!("CARGO_MANIFEST_DIR");
+            static PKG_NAME: &'static str = env!("CARGO_PKG_NAME");
+            static HOMEPAGE: &'static str = env!("CARGO_PKG_HOMEPAGE");
+            static DESCRIPTION: &'static str = env!("CARGO_PKG_DESCRIPTION");
 
             fn main() {
                 let s = format!("{}-{}-{} @ {} in {}", VERSION_MAJOR,
                                 VERSION_MINOR, VERSION_PATCH, VERSION_PRE,
                                 CARGO_MANIFEST_DIR);
-		 assert_eq!(s, foo::version());
-		 println!("{}", s);
-		 assert_eq!("foo", PKG_NAME);
-		 assert_eq!("http://example.com", HOMEPAGE);
-		 assert_eq!("This is foo", DESCRIPTION);
+                 assert_eq!(s, foo::version());
+                 println!("{}", s);
+                 assert_eq!("foo", PKG_NAME);
+                 assert_eq!("http://example.com", HOMEPAGE);
+                 assert_eq!("This is foo", DESCRIPTION);
                 let s = format!("{}.{}.{}-{}", VERSION_MAJOR,
                                 VERSION_MINOR, VERSION_PATCH, VERSION_PRE);
-		 assert_eq!(s, VERSION);
+                assert_eq!(s, VERSION);
             }
         "#)
         .file("src/lib.rs", r#"
@@ -1755,8 +1759,9 @@ Caused by:
 
 Caused by:
   could not parse input as TOML
-[..].cargo[..]config:2:20-2:21 expected `=`, but found `i`
 
+Caused by:
+  expected an equals, found an identifier at line 2
 "));
 }
 

--- a/tests/cargotest/Cargo.toml
+++ b/tests/cargotest/Cargo.toml
@@ -17,6 +17,8 @@ kernel32-sys = "0.2"
 libc = "0.2"
 log = "0.3"
 rustc-serialize = "0.3"
+serde = "0.9"
+serde_json = "0.9"
 tar = { version = "0.4", default-features = false }
 tempdir = "0.3"
 term = "0.4.4"

--- a/tests/cargotest/lib.rs
+++ b/tests/cargotest/lib.rs
@@ -8,6 +8,9 @@ extern crate git2;
 extern crate hamcrest;
 extern crate libc;
 extern crate rustc_serialize;
+extern crate serde;
+#[macro_use]
+extern crate serde_json;
 extern crate tar;
 extern crate tempdir;
 extern crate term;
@@ -49,6 +52,7 @@ fn _process(t: &OsStr) -> cargo::util::ProcessBuilder {
      .env("CARGO_HOME", support::paths::home().join(".cargo"))
      .env_remove("RUSTC")
      .env_remove("RUSTFLAGS")
+     .env_remove("CARGO_INCREMENTAL")
      .env_remove("XDG_CONFIG_HOME")      // see #2345
      .env("GIT_CONFIG_NOSYSTEM", "1")    // keep trying to sandbox ourselves
      .env_remove("CARGO_TARGET_DIR")     // we assume 'target'

--- a/tests/registry.rs
+++ b/tests/registry.rs
@@ -1317,17 +1317,17 @@ fn old_version_req_upstream() {
     p.build();
 
     Package::new("remote", "0.3.0")
-			.file("Cargo.toml", r#"
-				[project]
+            .file("Cargo.toml", r#"
+                [project]
                 name = "remote"
                 version = "0.3.0"
                 authors = []
 
                 [dependencies]
                 bar = "0.2*"
-			"#)
+            "#)
             .file("src/lib.rs", "")
-			.publish();
+            .publish();
     Package::new("bar", "0.2.0").publish();
 
     assert_that(p.cargo("build"),
@@ -1356,17 +1356,17 @@ fn toml_lies_but_index_is_truth() {
     Package::new("foo", "0.2.0").publish();
     Package::new("bar", "0.3.0")
             .dep("foo", "0.2.0")
-			.file("Cargo.toml", r#"
-				[project]
+            .file("Cargo.toml", r#"
+                [project]
                 name = "bar"
                 version = "0.3.0"
                 authors = []
 
                 [dependencies]
                 foo = "0.1.0"
-			"#)
+            "#)
             .file("src/lib.rs", "extern crate foo;")
-			.publish();
+            .publish();
 
     let p = project("foo")
         .file("Cargo.toml", r#"


### PR DESCRIPTION
This commit migrates Cargo as much as possible from rustc-serialize to
Serde. This not only provides an excellent testing ground for the toml
0.3 release but it also is a big boost to the speed of parsing the JSON
bits of the registry.

This doesn't completely excise the dependency just yet as docopt still
requires it along with handlebars. I'm sure though that in time those
crates will migrate to serde!