### PR TITLE
Increase copypastafication of `cargo search`

### DIFF
--- a/src/cargo/ops/registry.rs
+++ b/src/cargo/ops/registry.rs
@@ -424,7 +424,7 @@ pub fn search(query: &str,
 
     let list_items = crates.iter()
         .map(|krate| (
-            format!("{} ({})", krate.name, krate.max_version),
+            format!("{} = \"^{}\"", krate.name, krate.max_version),
             krate.description.as_ref().map(|desc|
                 truncate_with_ellipsis(&desc.replace("\n", " "), 128))
         ))
@@ -439,7 +439,7 @@ pub fn search(query: &str,
             Some(desc) => {
                 let space = repeat(' ').take(description_margin - name.len())
                                        .collect::<String>();
-                name + &space + &desc
+                name + &space + "# " + &desc
             }
             None => name
         };

--- a/src/cargo/ops/registry.rs
+++ b/src/cargo/ops/registry.rs
@@ -424,7 +424,7 @@ pub fn search(query: &str,
 
     let list_items = crates.iter()
         .map(|krate| (
-            format!("{} = \"^{}\"", krate.name, krate.max_version),
+            format!("{} = \"{}\"", krate.name, krate.max_version),
             krate.description.as_ref().map(|desc|
                 truncate_with_ellipsis(&desc.replace("\n", " "), 128))
         ))

--- a/tests/search.rs
+++ b/tests/search.rs
@@ -87,7 +87,7 @@ fn simple() {
                        .with_stderr("\
 [UPDATING] registry `[..]`")
                        .with_stdout("\
-hoare = \"^0.1.1\"    # Design by contract style assertions for Rust"));
+hoare = \"0.1.1\"    # Design by contract style assertions for Rust"));
 }
 
 #[test]
@@ -139,7 +139,7 @@ fn multiple_query_params() {
                        .with_stderr("\
 [UPDATING] registry `[..]`")
                        .with_stdout("\
-hoare = \"^0.1.1\"    # Design by contract style assertions for Rust"));
+hoare = \"0.1.1\"    # Design by contract style assertions for Rust"));
 }
 
 #[test]

--- a/tests/search.rs
+++ b/tests/search.rs
@@ -87,7 +87,7 @@ fn simple() {
                        .with_stderr("\
 [UPDATING] registry `[..]`")
                        .with_stdout("\
-hoare (0.1.1)    Design by contract style assertions for Rust"));
+hoare = \"^0.1.1\"    # Design by contract style assertions for Rust"));
 }
 
 #[test]
@@ -139,7 +139,7 @@ fn multiple_query_params() {
                        .with_stderr("\
 [UPDATING] registry `[..]`")
                        .with_stdout("\
-hoare (0.1.1)    Design by contract style assertions for Rust"));
+hoare = \"^0.1.1\"    # Design by contract style assertions for Rust"));
 }
 
 #[test]


### PR DESCRIPTION
Formats the search results printed by `cargo search` so that they can be
copied directly into a `Cargo.toml` file.

I used `^`, since I like being explicit, although that seems not to be the convention, so I'd be happy to remote it.

I also added a `#` in front of the description, so that that can be copy pastaed as well. I'm not super attached to this idea, but I think it's interesting, since it would serve to document what the various dependencies of a crate are for new contributors.

For example:

```
$ cargo search clap
clap = "^2.20.3"               # A simple to use, efficient, and full featured  Command Line ArgumentParser
please-clap = "^0.1.0"         # Pattern-match against Clap subcommands and arguments.
clapcomp = "^0.1.5"            # clap completion generator as command
clap-test = "^0.1.1"           # functions and macros to assist in testing clap
structopt = "^0.0.2"           # Parse command line argument by defining a struct.
capgun = "^0.1.1"              # fire when ready file watcher
structopt-derive = "^0.0.2"    # Parse command line argument by defining a struct, derive crate.
cargo-outdated = "^0.3.0"      # Cargo subcommand for displaying when dependencies are out of date
wesers = "^0.4.1"              # a simple HTTP/HTTPS server in Rust
cargo-arch = "^0.1.0"          # Rust Arch Linux package packer
... and 6 crates more (use --limit N to see more)
```