### PR TITLE
More intuitive CARGO_INCREMENTAL semantics

### DIFF
--- a/src/cargo/ops/cargo_rustc/context.rs
+++ b/src/cargo/ops/cargo_rustc/context.rs
@@ -78,7 +78,10 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
         // Enable incremental builds if the user opts in. For now,
         // this is an environment variable until things stabilize a
         // bit more.
-        let incremental_enabled = env::var("CARGO_INCREMENTAL").is_ok();
+        let incremental_enabled = match env::var("CARGO_INCREMENTAL") {
+            Ok(v) => v == "1",
+            Err(_) => false,
+        };
 
         Ok(Context {
             ws: ws,


### PR DESCRIPTION
Currently, the mere presence of a `CARGO_INCREMENTAL` variable in the environment causes incremental compilation to be enabled. This has the very counterintuitive effect that `CARGO_INCREMENTAL=0` and even `CARGO_INCREMENTAL=` mean incremental compilation is *on*.

This PR brings the semantics in line with how they are defined in the tests (cf. [tests/build.rs:45](https://github.com/rust-lang/cargo/blob/master/tests/build.rs#L45)), and in [public-facing documentation](https://internals.rust-lang.org/t/incremental-compilation-beta/4721).

See also [rust#39773](https://github.com/rust-lang/rust/issues/39773) for an example of this causing confusion in the wild.