### PR TITLE
Assert that we don't build test project twice.

### DIFF
--- a/tests/build-script.rs
+++ b/tests/build-script.rs
@@ -926,7 +926,9 @@ fn code_generation() {
                 ").unwrap();
             }
         "#);
-    assert_that(p.cargo_process("run"),
+    p.build();
+
+    assert_that(p.cargo("run"),
                 execs().with_status(0)
                        .with_stderr("\
 [COMPILING] foo v0.5.0 (file://[..])
@@ -936,7 +938,7 @@ fn code_generation() {
 Hello, World!
 "));
 
-    assert_that(p.cargo_process("test"),
+    assert_that(p.cargo("test"),
                 execs().with_status(0));
 }
 

--- a/tests/check.rs
+++ b/tests/check.rs
@@ -163,6 +163,8 @@ fn check_build() {
                 ::bar::baz();
             }
         "#);
+    foo.build();
+
     let bar = project("bar")
         .file("Cargo.toml", r#"
             [package]
@@ -175,9 +177,9 @@ fn check_build() {
         "#);
     bar.build();
 
-    assert_that(foo.cargo_process("check"),
+    assert_that(foo.cargo("check"),
                 execs().with_status(0));
-    assert_that(foo.cargo_process("build"),
+    assert_that(foo.cargo("build"),
                 execs().with_status(0));
 }
 
@@ -203,6 +205,8 @@ fn build_check() {
                 ::bar::baz();
             }
         "#);
+    foo.build();
+
     let bar = project("bar")
         .file("Cargo.toml", r#"
             [package]
@@ -215,9 +219,9 @@ fn build_check() {
         "#);
     bar.build();
 
-    assert_that(foo.cargo_process("build"),
+    assert_that(foo.cargo("build"),
                 execs().with_status(0));
-    assert_that(foo.cargo_process("check"),
+    assert_that(foo.cargo("check"),
                 execs().with_status(0));
 }
 
@@ -240,7 +244,6 @@ fn issue_3418() {
         "#)
         .file("src/lib.rs", "")
         .file("src/main.rs", "fn main() {}");
-    foo.build();
 
     assert_that(foo.cargo_process("check").arg("-v"),
                 execs().with_status(0)

--- a/tests/clean.rs
+++ b/tests/clean.rs
@@ -74,7 +74,6 @@ fn clean_multiple_packages() {
                 name = "d2"
         "#)
         .file("d2/src/main.rs", "fn main() { println!(\"d2\"); }");
-    p.build();
 
     assert_that(p.cargo_process("build").arg("-p").arg("d1").arg("-p").arg("d2")
                                         .arg("-p").arg("foo"),
@@ -120,7 +119,7 @@ fn clean_release() {
         .file("a/src/lib.rs", "");
     p.build();
 
-    assert_that(p.cargo_process("build").arg("--release"),
+    assert_that(p.cargo("build").arg("--release"),
                 execs().with_status(0));
 
     assert_that(p.cargo("clean").arg("-p").arg("foo"),
@@ -164,7 +163,7 @@ fn build_script() {
         .file("a/src/lib.rs", "");
     p.build();
 
-    assert_that(p.cargo_process("build").env("FIRST", "1"),
+    assert_that(p.cargo("build").env("FIRST", "1"),
                 execs().with_status(0));
     assert_that(p.cargo("clean").arg("-p").arg("foo"),
                 execs().with_status(0));
@@ -203,7 +202,7 @@ fn clean_git() {
         .file("src/main.rs", "fn main() {}");
     p.build();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(0));
     assert_that(p.cargo("clean").arg("-p").arg("dep"),
                 execs().with_status(0).with_stdout(""));
@@ -228,7 +227,7 @@ fn registry() {
 
     Package::new("bar", "0.1.0").publish();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(0));
     assert_that(p.cargo("clean").arg("-p").arg("bar"),
                 execs().with_status(0).with_stdout(""));

--- a/tests/cross-compile.rs
+++ b/tests/cross-compile.rs
@@ -582,6 +582,7 @@ fn no_cross_doctests() {
             //! assert!(true);
             //! ```
         "#);
+    p.build();
 
     let host_output = format!("\
 [COMPILING] foo v0.0.0 ({foo})
@@ -591,13 +592,13 @@ fn no_cross_doctests() {
 ", foo = p.url());
 
     println!("a");
-    assert_that(p.cargo_process("test"),
+    assert_that(p.cargo("test"),
                 execs().with_status(0)
                        .with_stderr(&host_output));
 
     println!("b");
     let target = host();
-    assert_that(p.cargo_process("test").arg("--target").arg(&target),
+    assert_that(p.cargo("test").arg("--target").arg(&target),
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] foo v0.0.0 ({foo})
@@ -608,7 +609,7 @@ fn no_cross_doctests() {
 
     println!("c");
     let target = alternate();
-    assert_that(p.cargo_process("test").arg("--target").arg(&target),
+    assert_that(p.cargo("test").arg("--target").arg(&target),
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] foo v0.0.0 ({foo})
@@ -1046,8 +1047,9 @@ fn platform_specific_variables_reflected_in_build_scripts() {
             fn main() { println!("cargo:val=1") }
         "#)
         .file("d2/src/lib.rs", "");
+    p.build();
 
-    assert_that(p.cargo_process("build").arg("-v"), execs().with_status(0));
-    assert_that(p.cargo_process("build").arg("-v").arg("--target").arg(&target),
+    assert_that(p.cargo("build").arg("-v"), execs().with_status(0));
+    assert_that(p.cargo("build").arg("-v").arg("--target").arg(&target),
                 execs().with_status(0));
 }

--- a/tests/doc.rs
+++ b/tests/doc.rs
@@ -561,13 +561,15 @@ fn rerun_when_dir_removed() {
             /// dox
             pub fn foo() {}
         "#);
-    assert_that(p.cargo_process("doc"),
+    p.build();
+
+    assert_that(p.cargo("doc"),
                 execs().with_status(0));
     assert_that(&p.root().join("target/doc/foo/index.html"), existing_file());
 
     fs::remove_dir_all(p.root().join("target/doc/foo")).unwrap();
 
-    assert_that(p.cargo_process("doc"),
+    assert_that(p.cargo("doc"),
                 execs().with_status(0));
     assert_that(&p.root().join("target/doc/foo/index.html"), existing_file());
 }
@@ -643,7 +645,6 @@ fn doc_all_workspace() {
         .file("bar/src/lib.rs", r#"
             pub fn bar() {}
         "#);
-    p.build();
 
     // The order in which bar is compiled or documented is not deterministic
     assert_that(p.cargo_process("doc")
@@ -677,7 +678,6 @@ fn doc_all_virtual_manifest() {
         .file("bar/src/lib.rs", r#"
             pub fn bar() {}
         "#);
-    p.build();
 
     // The order in which foo and bar are documented is not guaranteed
     assert_that(p.cargo_process("doc")
@@ -705,7 +705,6 @@ fn doc_all_member_dependency_same_name() {
         .file("a/src/lib.rs", r#"
             pub fn a() {}
         "#);
-    p.build();
 
     Package::new("a", "0.1.0").publish();
 

--- a/tests/features.rs
+++ b/tests/features.rs
@@ -106,20 +106,21 @@ fn invalid4() {
             authors = []
         "#)
         .file("bar/src/lib.rs", "");
+    p.build();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(101).with_stderr("\
 [ERROR] Package `bar v0.0.1 ([..])` does not have these features: `bar`
 "));
 
-    let p = p.file("Cargo.toml", r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-        "#);
+    p.change_file("Cargo.toml", r#"
+        [project]
+        name = "foo"
+        version = "0.0.1"
+        authors = []
+    "#);
 
-    assert_that(p.cargo_process("build").arg("--features").arg("test"),
+    assert_that(p.cargo("build").arg("--features").arg("test"),
                 execs().with_status(101).with_stderr("\
 [ERROR] Package `foo v0.0.1 ([..])` does not have these features: `test`
 "));
@@ -938,25 +939,26 @@ fn dep_feature_in_cmd_line() {
             #[cfg(feature = "some-feat")]
             pub fn test() { print!("test"); }
         "#);
+    p.build();
 
     // The foo project requires that feature "some-feat" in "bar" is enabled.
     // Building without any features enabled should fail:
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(101));
 
     // We should be able to enable the feature "derived-feat", which enables "some-feat",
     // on the command line. The feature is enabled, thus building should be successful:
-    assert_that(p.cargo_process("build").arg("--features").arg("derived/derived-feat"),
+    assert_that(p.cargo("build").arg("--features").arg("derived/derived-feat"),
                 execs().with_status(0));
 
     // Trying to enable features of transitive dependencies is an error
-    assert_that(p.cargo_process("build").arg("--features").arg("bar/some-feat"),
+    assert_that(p.cargo("build").arg("--features").arg("bar/some-feat"),
                 execs().with_status(101).with_stderr("\
 [ERROR] Package `foo v0.0.1 ([..])` does not have these features: `bar`
 "));
 
     // Hierarchical feature specification should still be disallowed
-    assert_that(p.cargo_process("build").arg("--features").arg("derived/bar/some-feat"),
+    assert_that(p.cargo("build").arg("--features").arg("derived/bar/some-feat"),
                 execs().with_status(101).with_stderr("\
 [ERROR] feature names may not contain slashes: `bar/some-feat`
 "));

--- a/tests/metadata.rs
+++ b/tests/metadata.rs
@@ -390,7 +390,6 @@ fn workspace_metadata() {
         .file("bar/src/lib.rs", "")
         .file("baz/Cargo.toml", &basic_lib_manifest("baz"))
         .file("baz/src/lib.rs", "");
-    p.build();
 
     assert_that(p.cargo_process("metadata"), execs().with_status(0).with_json(r#"
     {
@@ -465,7 +464,6 @@ fn workspace_metadata_no_deps() {
         .file("bar/src/lib.rs", "")
         .file("baz/Cargo.toml", &basic_lib_manifest("baz"))
         .file("baz/src/lib.rs", "");
-    p.build();
 
     assert_that(p.cargo_process("metadata").arg("--no-deps"), execs().with_status(0).with_json(r#"
     {

--- a/tests/path.rs
+++ b/tests/path.rs
@@ -259,8 +259,7 @@ fn cargo_compile_with_transitive_dev_deps() {
 
 #[test]
 fn no_rebuild_dependency() {
-    let mut p = project("foo");
-    p = p
+    let p = project("foo")
         .file("Cargo.toml", r#"
             [project]
 
@@ -301,16 +300,6 @@ fn no_rebuild_dependency() {
     // This time we shouldn't compile bar
     assert_that(p.cargo("build"),
                 execs().with_stdout(""));
-    p.root().move_into_the_past();
-
-    p.build(); // rebuild the files (rewriting them in the process)
-    assert_that(p.cargo("build"),
-                execs().with_stderr(&format!("[COMPILING] bar v0.5.0 ({}/bar)\n\
-                                             [COMPILING] foo v0.5.0 ({})\n\
-                                             [FINISHED] dev [unoptimized + debuginfo] target(s) \
-                                             in [..]\n",
-                                            p.url(),
-                                            p.url())));
 }
 
 #[test]

--- a/tests/path.rs
+++ b/tests/path.rs
@@ -298,6 +298,7 @@ fn no_rebuild_dependency() {
                                             p.url(),
                                             p.url())));
 
+    sleep_ms(1000);
     p.change_file("src/foo.rs", r#"
         extern crate bar;
         fn main() { bar::bar(); }

--- a/tests/path.rs
+++ b/tests/path.rs
@@ -297,9 +297,17 @@ fn no_rebuild_dependency() {
                                              in [..]\n",
                                             p.url(),
                                             p.url())));
-    // This time we shouldn't compile bar
+
+    p.change_file("src/foo.rs", r#"
+        extern crate bar;
+        fn main() { bar::bar(); }
+    "#);
+    // Don't compile bar, but do recompile foo.
     assert_that(p.cargo("build"),
-                execs().with_stdout(""));
+                execs().with_stderr("\
+                     [COMPILING] foo v0.5.0 ([..])\n\
+                     [FINISHED] dev [unoptimized + debuginfo] target(s) \
+                     in [..]\n"));
 }
 
 #[test]

--- a/tests/proc-macro.rs
+++ b/tests/proc-macro.rs
@@ -214,7 +214,6 @@ fn a() {
   assert!(true);
 }
 "#);
-    foo.build();
 
     assert_that(foo.cargo_process("test"),
                 execs().with_status(0)

--- a/tests/profiles.rs
+++ b/tests/profiles.rs
@@ -245,7 +245,6 @@ fn profile_in_non_root_manifest_triggers_a_warning() {
             opt-level = 1
         "#)
         .file("bar/src/main.rs", "fn main() {}");
-    p.build();
 
     assert_that(p.cargo_process("build").cwd(p.root().join("bar")).arg("-v"),
                 execs().with_status(0).with_stderr("\
@@ -277,7 +276,6 @@ fn profile_in_virtual_manifest_works() {
             workspace = ".."
         "#)
         .file("bar/src/main.rs", "fn main() {}");
-    p.build();
 
     assert_that(p.cargo_process("build").cwd(p.root().join("bar")).arg("-v"),
                 execs().with_status(0).with_stderr("\

--- a/tests/publish.rs
+++ b/tests/publish.rs
@@ -184,6 +184,9 @@ fn unpublishable_crate() {
 #[test]
 fn dont_publish_dirty() {
     setup();
+    let p = project("foo")
+        .file("bar", "");
+    p.build();
 
     repo(&paths::root().join("foo"))
         .file("Cargo.toml", r#"
@@ -200,8 +203,6 @@ fn dont_publish_dirty() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    let p = project("foo");
-    t!(File::create(p.root().join("bar")));
     assert_that(p.cargo("publish")
                  .arg("--host").arg(registry().to_string()),
                 execs().with_status(101).with_stderr("\
@@ -218,6 +219,9 @@ to proceed despite this, pass the `--allow-dirty` flag
 fn publish_clean() {
     setup();
 
+    let p = project("foo");
+    p.build();
+
     repo(&paths::root().join("foo"))
         .file("Cargo.toml", r#"
             [project]
@@ -233,7 +237,6 @@ fn publish_clean() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    let p = project("foo");
     assert_that(p.cargo("publish")
                  .arg("--host").arg(registry().to_string()),
                 execs().with_status(0));
@@ -242,6 +245,10 @@ fn publish_clean() {
 #[test]
 fn publish_in_sub_repo() {
     setup();
+
+    let p = project("foo")
+        .file("baz", "");
+    p.build();
 
     repo(&paths::root().join("foo"))
         .file("bar/Cargo.toml", r#"
@@ -258,8 +265,6 @@ fn publish_in_sub_repo() {
         .file("bar/src/main.rs", "fn main() {}")
         .build();
 
-    let p = project("foo");
-    t!(File::create(p.root().join("baz")));
     assert_that(p.cargo("publish").cwd(p.root().join("bar"))
                  .arg("--host").arg(registry().to_string()),
                 execs().with_status(0));
@@ -268,6 +273,10 @@ fn publish_in_sub_repo() {
 #[test]
 fn publish_when_ignored() {
     setup();
+
+    let p = project("foo")
+        .file("baz", "");
+    p.build();
 
     repo(&paths::root().join("foo"))
         .file("Cargo.toml", r#"
@@ -285,8 +294,6 @@ fn publish_when_ignored() {
         .file(".gitignore", "baz")
         .build();
 
-    let p = project("foo");
-    t!(File::create(p.root().join("baz")));
     assert_that(p.cargo("publish")
                  .arg("--host").arg(registry().to_string()),
                 execs().with_status(0));
@@ -295,6 +302,10 @@ fn publish_when_ignored() {
 #[test]
 fn ignore_when_crate_ignored() {
     setup();
+
+    let p = project("foo")
+        .file("bar/baz", "");
+    p.build();
 
     repo(&paths::root().join("foo"))
         .file(".gitignore", "bar")
@@ -310,8 +321,6 @@ fn ignore_when_crate_ignored() {
             repository = "foo"
         "#)
         .nocommit_file("bar/src/main.rs", "fn main() {}");
-    let p = project("foo");
-    t!(File::create(p.root().join("bar/baz")));
     assert_that(p.cargo("publish").cwd(p.root().join("bar"))
                  .arg("--host").arg(registry().to_string()),
                 execs().with_status(0));
@@ -320,6 +329,10 @@ fn ignore_when_crate_ignored() {
 #[test]
 fn new_crate_rejected() {
     setup();
+
+    let p = project("foo")
+        .file("baz", "");
+    p.build();
 
     repo(&paths::root().join("foo"))
         .nocommit_file("Cargo.toml", r#"
@@ -334,8 +347,6 @@ fn new_crate_rejected() {
             repository = "foo"
         "#)
         .nocommit_file("src/main.rs", "fn main() {}");
-    let p = project("foo");
-    t!(File::create(p.root().join("baz")));
     assert_that(p.cargo("publish")
                  .arg("--host").arg(registry().to_string()),
                 execs().with_status(101));

--- a/tests/registry.rs
+++ b/tests/registry.rs
@@ -31,10 +31,11 @@ fn simple() {
             bar = ">= 0.0.0"
         "#)
         .file("src/main.rs", "fn main() {}");
+    p.build();
 
     Package::new("bar", "0.0.1").publish();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(0).with_stderr(&format!("\
 [UPDATING] registry `{reg}`
 [DOWNLOADING] bar v0.0.1 (registry file://[..])
@@ -45,16 +46,16 @@ fn simple() {
         dir = p.url(),
         reg = registry::registry())));
 
+    assert_that(p.cargo("clean"), execs().with_status(0));
+
     // Don't download a second time
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(0).with_stderr(&format!("\
-[UPDATING] registry `{reg}`
 [COMPILING] bar v0.0.1
 [COMPILING] foo v0.0.1 ({dir})
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..] secs
 ",
-        dir = p.url(),
-        reg = registry::registry())));
+        dir = p.url())));
 }
 
 #[test]
@@ -126,11 +127,12 @@ fn wrong_version() {
             foo = ">= 1.0.0"
         "#)
         .file("src/main.rs", "fn main() {}");
+    p.build();
 
     Package::new("foo", "0.0.1").publish();
     Package::new("foo", "0.0.2").publish();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(101).with_stderr_contains("\
 [ERROR] no matching package named `foo` found (required by `foo`)
 location searched: registry [..]
@@ -141,7 +143,7 @@ versions found: 0.0.2, 0.0.1
     Package::new("foo", "0.0.3").publish();
     Package::new("foo", "0.0.4").publish();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(101).with_stderr_contains("\
 [ERROR] no matching package named `foo` found (required by `foo`)
 location searched: registry [..]

--- a/tests/run.rs
+++ b/tests/run.rs
@@ -292,22 +292,23 @@ fn run_with_filename() {
         .file("examples/a.rs", r#"
             fn main() { println!("example"); }
         "#);
+    p.build();
 
-    assert_that(p.cargo_process("run").arg("--bin").arg("bin.rs"),
+    assert_that(p.cargo("run").arg("--bin").arg("bin.rs"),
                 execs().with_status(101).with_stderr("\
 [ERROR] no bin target named `bin.rs`"));
 
-    assert_that(p.cargo_process("run").arg("--bin").arg("a.rs"),
+    assert_that(p.cargo("run").arg("--bin").arg("a.rs"),
                 execs().with_status(101).with_stderr("\
 [ERROR] no bin target named `a.rs`
 
 Did you mean `a`?"));
 
-    assert_that(p.cargo_process("run").arg("--example").arg("example.rs"),
+    assert_that(p.cargo("run").arg("--example").arg("example.rs"),
                 execs().with_status(101).with_stderr("\
 [ERROR] no example target named `example.rs`"));
 
-    assert_that(p.cargo_process("run").arg("--example").arg("a.rs"),
+    assert_that(p.cargo("run").arg("--example").arg("a.rs"),
                 execs().with_status(101).with_stderr("\
 [ERROR] no example target named `a.rs`
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1625,12 +1625,13 @@ fn bad_example() {
             authors = []
         "#)
         .file("src/lib.rs", "");
+    p.build();
 
-    assert_that(p.cargo_process("run").arg("--example").arg("foo"),
+    assert_that(p.cargo("run").arg("--example").arg("foo"),
                 execs().with_status(101).with_stderr("\
 [ERROR] no example target named `foo`
 "));
-    assert_that(p.cargo_process("run").arg("--bin").arg("foo"),
+    assert_that(p.cargo("run").arg("--bin").arg("foo"),
                 execs().with_status(101).with_stderr("\
 [ERROR] no bin target named `foo`
 "));
@@ -2332,8 +2333,9 @@ fn pass_correct_cfgs_flags_to_rustdoc() {
                 authors = []
             "#)
         .file("libs/mock_serde_codegen/src/lib.rs", "");
+    p.build();
 
-    assert_that(p.cargo_process("test")
+    assert_that(p.cargo("test")
                 .arg("--package").arg("feature_a")
                 .arg("--verbose"),
                 execs().with_status(0)
@@ -2341,7 +2343,7 @@ fn pass_correct_cfgs_flags_to_rustdoc() {
 [DOCTEST] feature_a
 [RUNNING] `rustdoc --test [..]mock_serde_codegen[..]`"));
 
-    assert_that(p.cargo_process("test")
+    assert_that(p.cargo("test")
                 .arg("--verbose"),
                 execs().with_status(0)
                        .with_stderr_contains("\
@@ -2406,9 +2408,8 @@ fn test_many_with_features() {
             authors = []
         "#)
         .file("a/src/lib.rs", "");
-    p.build();
 
-    assert_that(p.cargo("test").arg("-v")
+    assert_that(p.cargo_process("test").arg("-v")
                  .arg("-p").arg("a")
                  .arg("-p").arg("foo")
                  .arg("--features").arg("foo"),
@@ -2441,7 +2442,6 @@ fn test_all_workspace() {
             #[test]
             fn bar_test() {}
         "#);
-    p.build();
 
     assert_that(p.cargo_process("test")
                  .arg("--all"),
@@ -2486,7 +2486,6 @@ fn test_all_virtual_manifest() {
             #[test]
             fn b() {}
         "#);
-    p.build();
 
     assert_that(p.cargo_process("test")
                  .arg("--all"),
@@ -2525,7 +2524,6 @@ fn test_all_member_dependency_same_name() {
             #[test]
             fn a() {}
         "#);
-    p.build();
 
     Package::new("a", "0.1.0").publish();
 

--- a/tests/version.rs
+++ b/tests/version.rs
@@ -9,12 +9,13 @@ use hamcrest::assert_that;
 #[test]
 fn simple() {
     let p = project("foo");
+    p.build();
 
-    assert_that(p.cargo_process("version"),
+    assert_that(p.cargo("version"),
                 execs().with_status(0).with_stdout(&format!("{}\n",
                                                             cargo::version())));
 
-    assert_that(p.cargo_process("--version"),
+    assert_that(p.cargo("--version"),
                 execs().with_status(0).with_stdout(&format!("{}\n",
                                                             cargo::version())));
 


### PR DESCRIPTION
Discussed in https://github.com/rust-lang/cargo/pull/3691#discussion_r100878827.

I've modify the offending tests to be more explicit about recreating projects.