### PR TITLE
Allow to run several integration tests

### DIFF
--- a/src/bin/test.rs
+++ b/src/bin/test.rs
@@ -42,7 +42,7 @@ Options:
     --lib                        Test only this package's library
     --doc                        Test only this library's documentation
     --bin NAME ...               Test only the specified binaries
-    --example NAME ...           Test only the specified examples
+    --example NAME ...           Check that the specified examples compile
     --test NAME ...              Test only the specified integration test targets
     --bench NAME ...             Test only the specified benchmark targets
     --no-run                     Compile, but don't run tests

--- a/src/bin/test.rs
+++ b/src/bin/test.rs
@@ -41,10 +41,10 @@ Options:
     -h, --help                   Print this message
     --lib                        Test only this package's library
     --doc                        Test only this library's documentation
-    --bin NAME                   Test only the specified binary
-    --example NAME               Test only the specified example
-    --test NAME                  Test only the specified integration test target
-    --bench NAME                 Test only the specified benchmark target
+    --bin NAME ...               Test only the specified binaries
+    --example NAME ...           Test only the specified examples
+    --test NAME ...              Test only the specified integration test targets
+    --bench NAME ...             Test only the specified benchmark targets
     --no-run                     Compile, but don't run tests
     -p SPEC, --package SPEC ...  Package to run tests for
     --all                        Test all packages in the workspace

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -2571,3 +2571,79 @@ fn doctest_only_with_dev_dep() {
     assert_that(p.cargo_process("test").arg("--doc").arg("-v"),
                 execs().with_status(0));
 }
+
+#[test]
+fn test_can_test_example() {
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [project]
+            name = "foo"
+            version = "0.1.0"
+        "#)
+        .file("examples/ex.rs", r#"
+            fn main() {}
+            #[test] fn kaboom() { panic("KABOOM!") }
+        "#);
+    let _ = p;
+// FIXME: does not work
+//    assert_that(p.cargo_process("test").arg("--example").arg("ex"),
+//                execs().with_status(101).with_stdout_contains("KABOOM!"))
+
+}
+
+#[test]
+fn test_many_targets() {
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [project]
+            name = "foo"
+            version = "0.1.0"
+        "#)
+        .file("src/bin/a.rs", r#"
+            fn main() {}
+            #[test] fn bin_a() {}
+        "#)
+        .file("src/bin/b.rs", r#"
+            fn main() {}
+            #[test] fn bin_b() {}
+        "#)
+        .file("src/bin/c.rs", r#"
+            fn main() {}
+            #[test] fn bin_c() { panic!(); }
+        "#)
+        .file("examples/a.rs", r#"
+            fn main() {}
+            #[test] fn example_a() {}
+        "#)
+        .file("examples/b.rs", r#"
+            fn main() {}
+            #[test] fn example_b() {}
+        "#)
+        .file("examples/c.rs", r#"
+            #[test] fn example_c() { panic!(); }
+        "#)
+        .file("tests/a.rs", r#"
+            #[test] fn test_a() {}
+        "#)
+        .file("tests/b.rs", r#"
+            #[test] fn test_b() {}
+        "#)
+        .file("tests/c.rs", r#"
+            #[test] fn test_c() { panic!(); }
+        "#);
+
+    assert_that(p.cargo_process("test")
+                    .arg("--bin").arg("a").arg("--bin").arg("b")
+                    .arg("--example").arg("a").arg("--example").arg("b")
+                    .arg("--test").arg("a").arg("--test").arg("b"),
+                execs()
+                    .with_status(0)
+                    .with_stdout_contains("test bin_a ... ok")
+                    .with_stdout_contains("test bin_b ... ok")
+                    .with_stdout_contains("test test_a ... ok")
+                    .with_stdout_contains("test test_b ... ok")
+// FIXME: does not work
+//                  .with_stdout_contains("test example_a ... ok")
+//                  .with_stdout_contains("test example_b ... ok")
+    )
+}

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -2573,25 +2573,6 @@ fn doctest_only_with_dev_dep() {
 }
 
 #[test]
-fn test_can_test_example() {
-    let p = project("foo")
-        .file("Cargo.toml", r#"
-            [project]
-            name = "foo"
-            version = "0.1.0"
-        "#)
-        .file("examples/ex.rs", r#"
-            fn main() {}
-            #[test] fn kaboom() { panic("KABOOM!") }
-        "#);
-    let _ = p;
-// FIXME: does not work
-//    assert_that(p.cargo_process("test").arg("--example").arg("ex"),
-//                execs().with_status(101).with_stdout_contains("KABOOM!"))
-
-}
-
-#[test]
 fn test_many_targets() {
     let p = project("foo")
         .file("Cargo.toml", r#"
@@ -2629,10 +2610,10 @@ fn test_many_targets() {
             #[test] fn test_b() {}
         "#)
         .file("tests/c.rs", r#"
-            #[test] fn test_c() { panic!(); }
+            does not compile
         "#);
 
-    assert_that(p.cargo_process("test")
+    assert_that(p.cargo_process("test").arg("--verbose")
                     .arg("--bin").arg("a").arg("--bin").arg("b")
                     .arg("--example").arg("a").arg("--example").arg("b")
                     .arg("--test").arg("a").arg("--test").arg("b"),
@@ -2642,8 +2623,6 @@ fn test_many_targets() {
                     .with_stdout_contains("test bin_b ... ok")
                     .with_stdout_contains("test test_a ... ok")
                     .with_stdout_contains("test test_b ... ok")
-// FIXME: does not work
-//                  .with_stdout_contains("test example_a ... ok")
-//                  .with_stdout_contains("test example_b ... ok")
-    )
+                    .with_stderr_contains("[RUNNING] `rustc --crate-name a examples[/]a.rs [..]`")
+                    .with_stderr_contains("[RUNNING] `rustc --crate-name b examples[/]b.rs [..]`"))
 }


### PR DESCRIPTION
It's useful to be able to run several, but not all, test targets at once (especially in the IDE, where you want to select a bunch of files and command "run these!"). This seems to work, but obviously needs some tests. `Options` `struct` already supports several targets. 