### PR TITLE
use space, not dash, in `cargo --version` output

### DIFF
--- a/src/cargo/lib.rs
+++ b/src/cargo/lib.rs
@@ -75,7 +75,7 @@ pub struct VersionInfo {
 
 impl fmt::Display for VersionInfo {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "cargo-{}.{}.{}",
+        write!(f, "cargo {}.{}.{}",
                self.major, self.minor, self.patch)?;
         match self.cfg_info.as_ref().map(|ci| &ci.release_channel) {
             Some(channel) => {


### PR DESCRIPTION
 #3604 inadvertently changed the output format of `cargo --version`:

```
froydnj@hawkeye:~/src/cargo.git$ ./target/x86_64-unknown-linux-gnu/release/cargo --version
cargo-0.17.0-dev (ae4a4d8 2017-01-27)
froydnj@hawkeye:~/src/cargo.git$ cargo --version
cargo 0.16.0-nightly (6e0c18c 2017-01-27)
```

Note the dash between cargo and the version number in the newer version.

Let's put the space back to not break things that might depend on the
`--version` output.