### PR TITLE
Simplify feature-handling code

### DIFF
--- a/src/cargo/core/resolver/encode.rs
+++ b/src/cargo/core/resolver/encode.rs
@@ -154,6 +154,7 @@ impl EncodableResolve {
 
         Ok(Resolve {
             graph: g,
+            empty_features: HashSet::new(),
             features: HashMap::new(),
             replacements: replacements,
             checksums: checksums,

--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -283,19 +283,14 @@ pub fn compile_ws<'a>(ws: &Workspace<'a>,
     fn resolve_all_features(resolve_with_overrides: &Resolve,
                             package_id: &PackageId)
                             -> HashSet<String> {
-        let mut features = match resolve_with_overrides.features(package_id) {
-            Some(all_features) => all_features.clone(),
-            None => HashSet::new(),
-        };
+        let mut features = resolve_with_overrides.features(package_id).clone();
 
         // Include features enabled for use by dependencies so targets can also use them with the
         // required-features field when deciding whether to be built or skipped.
         let deps = resolve_with_overrides.deps(package_id);
         for dep in deps {
-            if let Some(dep_features) = resolve_with_overrides.features(dep) {
-                for feature in dep_features {
-                    features.insert(dep.name().to_string() + "/" + feature);
-                }
+            for feature in resolve_with_overrides.features(dep) {
+                features.insert(dep.name().to_string() + "/" + feature);
             }
         }
 

--- a/src/cargo/ops/cargo_rustc/custom_build.rs
+++ b/src/cargo/ops/cargo_rustc/custom_build.rs
@@ -120,10 +120,8 @@ fn build_work<'a, 'cfg>(cx: &mut Context<'a, 'cfg>, unit: &Unit<'a>)
 
     // Be sure to pass along all enabled features for this package, this is the
     // last piece of statically known information that we have.
-    if let Some(features) = cx.resolve.features(unit.pkg.package_id()) {
-        for feat in features.iter() {
-            cmd.env(&format!("CARGO_FEATURE_{}", super::envify(feat)), "1");
-        }
+    for feat in cx.resolve.features(unit.pkg.package_id()).iter() {
+        cmd.env(&format!("CARGO_FEATURE_{}", super::envify(feat)), "1");
     }
 
     let mut cfg_map = HashMap::new();

--- a/src/cargo/ops/cargo_rustc/fingerprint.rs
+++ b/src/cargo/ops/cargo_rustc/fingerprint.rs
@@ -319,16 +319,6 @@ fn calculate<'a, 'cfg>(cx: &mut Context<'a, 'cfg>, unit: &Unit<'a>)
         return Ok(s.clone())
     }
 
-    // First, calculate all statically known "salt data" such as the profile
-    // information (compiler flags), the compiler version, activated features,
-    // and target configuration.
-    let features = cx.resolve.features(unit.pkg.package_id());
-    let features = features.map(|s| {
-        let mut v = s.iter().collect::<Vec<_>>();
-        v.sort();
-        v
-    });
-
     // Next, recursively calculate the fingerprint for all of our dependencies.
     //
     // Skip the fingerprints of build scripts as they may not always be
@@ -365,7 +355,7 @@ fn calculate<'a, 'cfg>(cx: &mut Context<'a, 'cfg>, unit: &Unit<'a>)
         rustc: util::hash_u64(&cx.config.rustc()?.verbose_version),
         target: util::hash_u64(&unit.target),
         profile: util::hash_u64(&unit.profile),
-        features: format!("{:?}", features),
+        features: format!("{:?}", cx.resolve.features_sorted(unit.pkg.package_id())),
         deps: deps,
         local: local,
         memoized_hash: Mutex::new(None),


### PR DESCRIPTION
A neat (imo :) ) hack to use an empty `&HashSet` instead of `Option<&HashSet>`. 