### PR TITLE
Always produce artifact messages

### DIFF
--- a/src/cargo/util/machine_message.rs
+++ b/src/cargo/util/machine_message.rs
@@ -33,6 +33,7 @@ pub struct Artifact<'a> {
     pub profile: &'a Profile,
     pub features: Vec<String>,
     pub filenames: Vec<String>,
+    pub fresh: bool,
 }
 
 impl<'a> Message for Artifact<'a> {

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -2512,8 +2512,9 @@ fn compiler_json_error_format() {
             authors = ["wycats@example.com"]
         "#)
         .file("bar/src/lib.rs", r#"fn dead() {}"#);
+    p.build();
 
-    assert_that(p.cargo_process("build").arg("-v")
+    assert_that(p.cargo("build").arg("-v")
                     .arg("--message-format").arg("json"),
                 execs().with_status(0).with_json(r#"
     {
@@ -2544,7 +2545,8 @@ fn compiler_json_error_format() {
             "name":"bar",
             "src_path":"[..]lib.rs"
         },
-        "filenames":["[..].rlib"]
+        "filenames":["[..].rlib"],
+        "fresh": false
     }
 
     {
@@ -2575,7 +2577,54 @@ fn compiler_json_error_format() {
             "test": false
         },
         "features": [],
-        "filenames": ["[..]"]
+        "filenames": ["[..]"],
+        "fresh": false
+    }
+"#));
+
+    // With fresh build, we should repeat the artifacts,
+    // but omit compiler warnings.
+    assert_that(p.cargo("build").arg("-v")
+                    .arg("--message-format").arg("json"),
+                execs().with_status(0).with_json(r#"
+    {
+        "reason":"compiler-artifact",
+        "profile": {
+            "debug_assertions": true,
+            "debuginfo": 2,
+            "opt_level": "0",
+            "test": false
+        },
+        "features": [],
+        "package_id":"bar 0.5.0 ([..])",
+        "target":{
+            "kind":["lib"],
+            "crate_types":["lib"],
+            "name":"bar",
+            "src_path":"[..]lib.rs"
+        },
+        "filenames":["[..].rlib"],
+        "fresh": true
+    }
+
+    {
+        "reason":"compiler-artifact",
+        "package_id":"foo 0.5.0 ([..])",
+        "target":{
+            "kind":["bin"],
+            "crate_types":["bin"],
+            "name":"foo",
+            "src_path":"[..]main.rs"
+        },
+        "profile": {
+            "debug_assertions": true,
+            "debuginfo": 2,
+            "opt_level": "0",
+            "test": false
+        },
+        "features": [],
+        "filenames": ["[..]"],
+        "fresh": true
     }
 "#));
 }
@@ -2633,7 +2682,8 @@ fn message_format_json_forward_stderr() {
             "test":false
         },
         "features":[],
-        "filenames":["[..]"]
+        "filenames":[],
+        "fresh": false
     }
 "#));
 }


### PR DESCRIPTION
This changes `artifact` messages in several ways:

* They are produced even for fresh builds

* They used the path after hard linking (@jsgf talked about it in the end of https://github.com/rust-lang/cargo/pull/3319#issuecomment-263975431)

* Don't produce filenames if the compiler has not actually produced the binaries (`-Z-no-trans`). 