### PR TITLE
tests: Insulate from user git environment

### DIFF
--- a/tests/cargotest/lib.rs
+++ b/tests/cargotest/lib.rs
@@ -55,6 +55,11 @@ fn _process(t: &OsStr) -> cargo::util::ProcessBuilder {
      .env_remove("CARGO_INCREMENTAL")
      .env_remove("XDG_CONFIG_HOME")      // see #2345
      .env("GIT_CONFIG_NOSYSTEM", "1")    // keep trying to sandbox ourselves
+     .env_remove("EMAIL")
+     .env_remove("GIT_AUTHOR_NAME")
+     .env_remove("GIT_AUTHOR_EMAIL")
+     .env_remove("GIT_COMMITTER_NAME")
+     .env_remove("GIT_COMMITTER_EMAIL")
      .env_remove("CARGO_TARGET_DIR")     // we assume 'target'
      .env_remove("MSYSTEM");             // assume cmd.exe everywhere on windows
 


### PR DESCRIPTION
Several tests in "cargo test" would fail if the user had any of the Git
environment variables set for name or email address, because those
environment variables would override the tested configuration.  Filter
out those environment variables.