### PR TITLE
tests/directory: Remove unnecessary dummy registry URL for crates.io

### DIFF
--- a/tests/directory.rs
+++ b/tests/directory.rs
@@ -20,7 +20,6 @@ fn setup() {
     t!(fs::create_dir(&root.join(".cargo")));
     t!(t!(File::create(root.join(".cargo/config"))).write_all(br#"
         [source.crates-io]
-        registry = 'https://wut'
         replace-with = 'my-awesome-local-registry'
 
         [source.my-awesome-local-registry]


### PR DESCRIPTION
Older versions of cargo required this; current versions do not.  All of
the tests still pass with it removed.