### PR TITLE
Tell subprocesses the path to self in an env variable #3778

### DIFF
--- a/src/bin/cargo.rs
+++ b/src/bin/cargo.rs
@@ -320,7 +320,12 @@ fn execute_external_subcommand(config: &Config, cmd: &str, args: &[String]) -> C
                 .into())
         }
     };
-    let err = match util::process(&command).args(&args[1..]).exec() {
+
+    let cargo_exe = config.cargo_exe()?;
+    let err = match util::process(&command)
+        .env(cargo::CARGO_ENV, cargo_exe)
+        .args(&args[1..])
+        .exec() {
         Ok(()) => return Ok(()),
         Err(e) => e,
     };

--- a/src/cargo/lib.rs
+++ b/src/cargo/lib.rs
@@ -41,6 +41,8 @@ use term::color::{BLACK};
 
 pub use util::{CargoError, CargoResult, CliError, CliResult, human, Config, ChainError};
 
+pub const CARGO_ENV: &'static str = "CARGO";
+
 macro_rules! bail {
     ($($fmt:tt)*) => (
         return Err(::util::human(&format_args!($($fmt)*)))

--- a/src/cargo/ops/cargo_rustc/compilation.rs
+++ b/src/cargo/ops/cargo_rustc/compilation.rs
@@ -143,6 +143,9 @@ impl<'cfg> Compilation<'cfg> {
 
         let metadata = pkg.manifest().metadata();
 
+        let cargo_exe = self.config.cargo_exe()?;
+        cmd.env(::CARGO_ENV, cargo_exe);
+
         cmd.env("CARGO_MANIFEST_DIR", pkg.root())
            .env("CARGO_PKG_VERSION_MAJOR", &pkg.version().major.to_string())
            .env("CARGO_PKG_VERSION_MINOR", &pkg.version().minor.to_string())

--- a/src/cargo/util/config.rs
+++ b/src/cargo/util/config.rs
@@ -28,6 +28,7 @@ pub struct Config {
     rustc: LazyCell<Rustc>,
     values: LazyCell<HashMap<String, ConfigValue>>,
     cwd: PathBuf,
+    cargo_exe: LazyCell<PathBuf>,
     rustdoc: LazyCell<PathBuf>,
     extra_verbose: Cell<bool>,
     frozen: Cell<bool>,
@@ -44,6 +45,7 @@ impl Config {
             rustc: LazyCell::new(),
             cwd: cwd,
             values: LazyCell::new(),
+            cargo_exe: LazyCell::new(),
             rustdoc: LazyCell::new(),
             extra_verbose: Cell::new(false),
             frozen: Cell::new(false),
@@ -91,6 +93,15 @@ impl Config {
 
     pub fn rustc(&self) -> CargoResult<&Rustc> {
         self.rustc.get_or_try_init(|| Rustc::new(self.get_tool("rustc")?))
+    }
+
+    pub fn cargo_exe(&self) -> CargoResult<&Path> {
+        self.cargo_exe.get_or_try_init(||
+            env::current_exe().and_then(|path| path.canonicalize())
+            .chain_error(|| {
+                human("couldn't get the path to cargo executable")
+            })
+        ).map(AsRef::as_ref)
     }
 
     pub fn values(&self) -> CargoResult<&HashMap<String, ConfigValue>> {

--- a/src/doc/environment-variables.md
+++ b/src/doc/environment-variables.md
@@ -30,8 +30,9 @@ configuration values, as described in [that documentation][config-env]
 
 # Environment variables Cargo sets for crates
 
-Cargo exposes these environment variables to your crate when it is compiled. To get the
-value of any of these variables in a Rust program, do this:
+Cargo exposes these environment variables to your crate when it is compiled.
+Note that this applies for test binaries as well.
+To get the value of any of these variables in a Rust program, do this:
 
 ```
 let version = env!("CARGO_PKG_VERSION");
@@ -39,6 +40,7 @@ let version = env!("CARGO_PKG_VERSION");
 
 `version` will now contain the value of `CARGO_PKG_VERSION`.
 
+* `CARGO` - Path to the `cargo` binary performing the build.
 * `CARGO_MANIFEST_DIR` - The directory containing the manifest of your package.
 * `CARGO_PKG_VERSION` - The full version of your package.
 * `CARGO_PKG_VERSION_MAJOR` - The major version of your package.
@@ -96,3 +98,10 @@ let out_dir = env::var("OUT_DIR").unwrap();
 [links]: build-script.html#the-links-manifest-key
 [profile]: manifest.html#the-profile-sections
 [clang]:http://clang.llvm.org/docs/CrossCompilation.html#target-triple
+
+# Environment variables Cargo sets for 3rd party subcommands
+
+Cargo exposes this environment variable to 3rd party subcommands
+(ie. programs named `cargo-foobar` placed in `$PATH`):
+
+* `CARGO` - Path to the `cargo` binary performing the build.

--- a/tests/cargotest/lib.rs
+++ b/tests/cargotest/lib.rs
@@ -90,7 +90,7 @@ fn _process(t: &OsStr) -> cargo::util::ProcessBuilder {
 }
 
 pub fn cargo_process() -> cargo::util::ProcessBuilder {
-    process(&support::cargo_dir().join("cargo"))
+    process(&support::cargo_exe())
 }
 
 pub fn sleep_ms(ms: u64) {

--- a/tests/cargotest/support/mod.rs
+++ b/tests/cargotest/support/mod.rs
@@ -165,7 +165,7 @@ impl ProjectBuilder {
         assert!(self.is_build.get(),
                 "call `.build()` before calling `.cargo()`, \
                  or use `.cargo_process()`");
-        let mut p = self.process(&cargo_dir().join("cargo"));
+        let mut p = self.process(&cargo_exe());
         p.arg(cmd);
         return p;
     }
@@ -315,6 +315,10 @@ pub fn cargo_dir() -> PathBuf {
     }).unwrap_or_else(|| {
         panic!("CARGO_BIN_PATH wasn't set. Cannot continue running test")
     })
+}
+
+pub fn cargo_exe() -> PathBuf {
+    cargo_dir().join(format!("cargo{}", env::consts::EXE_SUFFIX))
 }
 
 /// Returns an absolute path in the filesystem that `path` points to. The

--- a/tests/init.rs
+++ b/tests/init.rs
@@ -8,12 +8,12 @@ use std::io::prelude::*;
 use std::env;
 
 use cargo::util::ProcessBuilder;
-use cargotest::support::{execs, paths, cargo_dir};
+use cargotest::support::{execs, paths, cargo_exe};
 use hamcrest::{assert_that, existing_file, existing_dir, is_not};
 use tempdir::TempDir;
 
 fn cargo_process(s: &str) -> ProcessBuilder {
-    let mut p = cargotest::process(&cargo_dir().join("cargo"));
+    let mut p = cargotest::process(&cargo_exe());
     p.arg(s).cwd(&paths::root()).env("HOME", &paths::home());
     p
 }

--- a/tests/package.rs
+++ b/tests/package.rs
@@ -11,7 +11,7 @@ use std::io::prelude::*;
 use std::path::{Path, PathBuf};
 
 use cargotest::{cargo_process, process};
-use cargotest::support::{project, execs, paths, git, path2url, cargo_dir};
+use cargotest::support::{project, execs, paths, git, path2url, cargo_exe};
 use flate2::read::GzDecoder;
 use hamcrest::{assert_that, existing_file, contains};
 use tar::Archive;
@@ -481,7 +481,7 @@ fn repackage_on_source_change() {
     "#).unwrap();
     std::mem::drop(file);
 
-    let mut pro = process(&cargo_dir().join("cargo"));
+    let mut pro = process(&cargo_exe());
     pro.arg("package").cwd(p.root());
 
     // Check that cargo rebuilds the tarball


### PR DESCRIPTION
I'm just setting the env var on the process itself, letting subprocesses inherit that, as it's easier than setting for each subprocess individually. I'm not entirely sure this is the right spot though.

Also, I should probably document this somewhere - what would be the best place?
