### PR TITLE
Use serde type system for handlebars

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -272,7 +272,7 @@ dependencies = [
  "pest 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "quick-error 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ fs2 = "0.4"
 git2 = "0.6"
 git2-curl = "0.7"
 glob = "0.2"
-handlebars = "0.25"
+handlebars = { version = "0.25", features = ["serde_type", "partial4"], default-features = false }
 libc = "0.2"
 libgit2-sys = "0.6"
 log = "0.3"

--- a/src/cargo/util/template.rs
+++ b/src/cargo/util/template.rs
@@ -18,7 +18,7 @@ pub fn toml_escape_helper(h: &Helper,
                           _: &Handlebars,
                           rc: &mut RenderContext) -> Result<(), RenderError> {
     if let Some(param) = h.param(0) {
-        let txt = param.value().as_string().unwrap_or("").to_owned();
+        let txt = param.value().as_str().unwrap_or("").to_owned();
         let rendered = format!("{}", toml::Value::String(txt));
         try!(rc.writer.write_all(rendered.into_bytes().as_ref()));
     }
@@ -30,7 +30,7 @@ pub fn html_escape_helper(h: &Helper,
                           _: &Handlebars,
                           rc: &mut RenderContext) -> Result<(), RenderError> {
     if let Some(param) = h.param(0) {
-        let rendered = html_escape(param.value().as_string().unwrap_or(""));
+        let rendered = html_escape(param.value().as_str().unwrap_or(""));
         try!(rc.writer.write_all(rendered.into_bytes().as_ref()));
     }
     Ok(())


### PR DESCRIPTION
This will help cargo to drop rustc_serialize as dependency (#3682). Handlebars actually supports using serde_json as its type system instead of rustc_serialize. And I'm planning to drop rustc_serialize in future releases. 