### PR TITLE
Add year to project template variables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,6 @@ dependencies = [
  "advapi32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bufstream 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "cargotest 0.1.0",
- "chrono 0.2.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "crates-io 0.7.0",
  "crossbeam 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "curl 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -37,6 +36,7 @@ dependencies = [
  "tar 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "term 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -104,15 +104,6 @@ dependencies = [
 name = "cfg-if"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "chrono"
-version = "0.2.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "num 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "cmake"
@@ -850,7 +841,6 @@ dependencies = [
 "checksum bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aad18937a628ec6abcd26d1489012cc0e18c21798210f491af69ded9b881106d"
 "checksum bufstream 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7b48dbe2ff0e98fa2f03377d204a9637d3c9816cd431bfe05a8abbd0ea11d074"
 "checksum cfg-if 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "de1e760d7b6535af4241fca8bd8adf68e2e7edacc6b29f5d399050c5e48cf88c"
-"checksum chrono 0.2.25 (registry+https://github.com/rust-lang/crates.io-index)" = "9213f7cd7c27e95c2b57c49f0e69b1ea65b27138da84a170133fd21b07659c00"
 "checksum cmake 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)" = "a3a6805df695087e7c1bcd9a82e03ad6fb864c8e67ac41b1348229ce5b7f0407"
 "checksum crossbeam 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)" = "0c5ea215664ca264da8a9d9c3be80d2eaf30923c259d03e870388eb927508f97"
 "checksum curl 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c90e1240ef340dd4027ade439e5c7c2064dd9dc652682117bd50d1486a3add7b"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,6 +5,7 @@ dependencies = [
  "advapi32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bufstream 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "cargotest 0.1.0",
+ "chrono 0.2.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "crates-io 0.7.0",
  "crossbeam 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "curl 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -103,6 +104,15 @@ dependencies = [
 name = "cfg-if"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "chrono"
+version = "0.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "cmake"
@@ -553,6 +563,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "regex"
 version = "0.1.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -727,6 +742,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "toml"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -824,6 +850,7 @@ dependencies = [
 "checksum bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aad18937a628ec6abcd26d1489012cc0e18c21798210f491af69ded9b881106d"
 "checksum bufstream 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7b48dbe2ff0e98fa2f03377d204a9637d3c9816cd431bfe05a8abbd0ea11d074"
 "checksum cfg-if 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "de1e760d7b6535af4241fca8bd8adf68e2e7edacc6b29f5d399050c5e48cf88c"
+"checksum chrono 0.2.25 (registry+https://github.com/rust-lang/crates.io-index)" = "9213f7cd7c27e95c2b57c49f0e69b1ea65b27138da84a170133fd21b07659c00"
 "checksum cmake 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)" = "a3a6805df695087e7c1bcd9a82e03ad6fb864c8e67ac41b1348229ce5b7f0407"
 "checksum crossbeam 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)" = "0c5ea215664ca264da8a9d9c3be80d2eaf30923c259d03e870388eb927508f97"
 "checksum curl 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c90e1240ef340dd4027ade439e5c7c2064dd9dc652682117bd50d1486a3add7b"
@@ -875,6 +902,7 @@ dependencies = [
 "checksum quick-error 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0aad603e8d7fb67da22dbdf1f4b826ce8829e406124109e73cf1b2454b93a71c"
 "checksum quote 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)" = "e7b44fd83db28b83c1c58187159934906e5e955c812e211df413b76b03c909a5"
 "checksum rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "022e0636ec2519ddae48154b028864bdce4eaf7d35226ab8e65c611be97b189d"
+"checksum redox_syscall 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "8dd35cc9a8bdec562c757e3d43c1526b5c6d2653e23e2315065bc25556550753"
 "checksum regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)" = "4fd4ace6a8cf7860714a2c2280d6c1f7e6a413486c13298bbc86fd3da019402f"
 "checksum regex 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4278c17d0f6d62dfef0ab00028feb45bd7d2102843f80763474eeb1be8a10c01"
 "checksum regex-syntax 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "f9ec002c35e86791825ed294b50008eea9ddfc8def4420124fbc6b08db834957"
@@ -897,6 +925,7 @@ dependencies = [
 "checksum thread-id 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4437c97558c70d129e40629a5b385b3fb1ffac301e63941335e4d354081ec14a"
 "checksum thread_local 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "8576dbbfcaef9641452d5cf0df9b0e7eeab7694956dd33bb61515fb8f18cfdd5"
 "checksum thread_local 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7793b722f0f77ce716e7f1acf416359ca32ff24d04ffbac4269f44a4a83be05d"
+"checksum time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)" = "211b63c112206356ef1ff9b19355f43740fc3f85960c598a93d3a3d3ba7beade"
 "checksum toml 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "736b60249cb25337bc196faa43ee12c705e426f3d55c214d73a4e7be06f92cb4"
 "checksum toml 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "08272367dd2e766db3fa38f068067d17aa6a9dfd7259af24b3927db92f1e0c2f"
 "checksum unicode-bidi 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b61814f3e7fd0e0f15370f767c7c943e08bc2e3214233ae8f88522b334ceb778"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ name = "cargo"
 path = "src/cargo/lib.rs"
 
 [dependencies]
+chrono = "0.2.25"
 crates-io = { path = "src/crates-io", version = "0.7" }
 crossbeam = "0.2"
 curl = "0.4.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ name = "cargo"
 path = "src/cargo/lib.rs"
 
 [dependencies]
-chrono = "0.2.25"
 crates-io = { path = "src/crates-io", version = "0.7" }
 crossbeam = "0.2"
 curl = "0.4.6"
@@ -44,6 +43,7 @@ shell-escape = "0.1"
 tar = { version = "0.4", default-features = false }
 tempdir = "0.3"
 term = "0.4.4"
+time = "0.1.36"
 toml = "0.3"
 url = "1.1"
 

--- a/src/cargo/lib.rs
+++ b/src/cargo/lib.rs
@@ -5,6 +5,7 @@
 #[macro_use] extern crate log;
 #[macro_use] extern crate serde_derive;
 #[macro_use] extern crate serde_json;
+extern crate chrono;
 extern crate crates_io as registry;
 extern crate crossbeam;
 extern crate curl;

--- a/src/cargo/lib.rs
+++ b/src/cargo/lib.rs
@@ -5,7 +5,6 @@
 #[macro_use] extern crate log;
 #[macro_use] extern crate serde_derive;
 #[macro_use] extern crate serde_json;
-extern crate chrono;
 extern crate crates_io as registry;
 extern crate crossbeam;
 extern crate curl;
@@ -27,6 +26,7 @@ extern crate shell_escape;
 extern crate tar;
 extern crate tempdir;
 extern crate term;
+extern crate time;
 extern crate toml;
 extern crate url;
 

--- a/src/cargo/ops/cargo_new.rs
+++ b/src/cargo/ops/cargo_new.rs
@@ -8,6 +8,7 @@ use git2::Config as GitConfig;
 
 use term::color::BLACK;
 
+use chrono::{Datelike,Local};
 use handlebars::{Handlebars, no_escape};
 use tempdir::TempDir;
 use toml;
@@ -520,6 +521,7 @@ fn mk(config: &Config, opts: &MkOptions) -> CargoResult<()> {
     let mut data = BTreeMap::new();
     data.insert("name".to_owned(), name.to_owned());
     data.insert("author".to_owned(), author);
+    data.insert("year".to_owned(), Local::now().year().to_string());
 
     let template_set = try!(get_input_template(config, opts));
     for template in template_set.template_files.iter() {
@@ -582,7 +584,7 @@ fn collect_template_dir(template_path: &PathBuf, _: &Path) -> CargoResult<Vec<Bo
                                       human(format!("entry is somehow not a subpath \
                                                      of the directory being walked."))
                                   })));
-        templates.push(Box::new(InputFileTemplateFile::new(entry_path, 
+        templates.push(Box::new(InputFileTemplateFile::new(entry_path,
                                                            dest_file_name.to_path_buf())));
         Ok(())
     }));

--- a/src/cargo/ops/cargo_new.rs
+++ b/src/cargo/ops/cargo_new.rs
@@ -8,9 +8,9 @@ use git2::Config as GitConfig;
 
 use term::color::BLACK;
 
-use chrono::{Datelike,Local};
 use handlebars::{Handlebars, no_escape};
 use tempdir::TempDir;
+use time;
 use toml;
 
 use core::Workspace;
@@ -521,7 +521,7 @@ fn mk(config: &Config, opts: &MkOptions) -> CargoResult<()> {
     let mut data = BTreeMap::new();
     data.insert("name".to_owned(), name.to_owned());
     data.insert("author".to_owned(), author);
-    data.insert("year".to_owned(), Local::now().year().to_string());
+    data.insert("year".to_owned(), (time::now().tm_year + 1900).to_string());
 
     let template_set = try!(get_input_template(config, opts));
     for template in template_set.template_files.iter() {

--- a/src/doc/guide.md
+++ b/src/doc/guide.md
@@ -29,7 +29,7 @@ repository by default. If you don't want it to do that, pass `--vcs none`.
 
 You can also use your own template to scaffold cargo projects! See the
 [Templates](#templates) section for more details.
-  
+
 Let’s check out what Cargo has generated for us:
 
 ```shell
@@ -480,7 +480,8 @@ $ cargo new proj --template http://your/project/repo
 The variables available for use are:
 
 - `name`: the name of the project
-- `authors`: the toml formatted name of the project author
+- `author`: the toml formatted name of the project author
+- `year`: the current year
 
 In the future, more variables may be added. Suggestions welcome!
 

--- a/tests/new.rs
+++ b/tests/new.rs
@@ -1,8 +1,8 @@
 extern crate cargo;
 extern crate cargotest;
-extern crate chrono;
 extern crate hamcrest;
 extern crate tempdir;
+extern crate time;
 
 use std::fs::{self, File};
 use std::io::prelude::*;
@@ -11,7 +11,6 @@ use std::env;
 use cargo::util::ProcessBuilder;
 use cargotest::process;
 use cargotest::support::{execs, git, paths};
-use chrono::{Datelike,Local};
 use hamcrest::{assert_that, existing_file, existing_dir, is_not};
 use tempdir::TempDir;
 
@@ -95,7 +94,8 @@ fn main () {
     let license = paths::root().join("foo/LICENSE");
     let mut contents = String::new();
     File::open(&license).unwrap().read_to_string(&mut contents).unwrap();
-    assert!(contents.contains(&format!("(c) {} {}", Local::now().year(), "foo")));
+    let expected = format!("(c) {} {}", (time::now().tm_year + 1900).to_string(), "foo");
+    assert!(contents.contains(&expected));
 
     assert_that(cargo_process("build").cwd(&paths::root().join("foo")),
                 execs().with_status(0));


### PR DESCRIPTION
This adds the current year as a `year` variable for project templates. Some license files / headers include the year, so this should make it easier to include those in a template.