### PR TITLE
Restore the generated tests module created by `cargo new`

### DIFF
--- a/src/cargo/ops/cargo_new.rs
+++ b/src/cargo/ops/cargo_new.rs
@@ -582,7 +582,7 @@ fn collect_template_dir(template_path: &PathBuf, _: &Path) -> CargoResult<Vec<Bo
                                       human(format!("entry is somehow not a subpath \
                                                      of the directory being walked."))
                                   })));
-        templates.push(Box::new(InputFileTemplateFile::new(entry_path, 
+        templates.push(Box::new(InputFileTemplateFile::new(entry_path,
                                                            dest_file_name.to_path_buf())));
         Ok(())
     }));
@@ -707,8 +707,11 @@ authors = [{{toml-escape author}}]
 /// Create a new "lib" project
 fn create_lib_template() -> Vec<Box<TemplateFile>> {
     let lib_file = Box::new(InMemoryTemplateFile::new(PathBuf::from("src/lib.rs"),
-    String::from(r#"#[test]
-fn it_works() {
+    String::from(r#"#[cfg(test)]
+mod tests {
+    #[test]
+    fn it_works() {
+    }
 }
 "#)));
     vec![lib_file]

--- a/tests/new.rs
+++ b/tests/new.rs
@@ -32,6 +32,17 @@ fn simple_lib() {
     assert_that(&paths::root().join("foo/src/lib.rs"), existing_file());
     assert_that(&paths::root().join("foo/.gitignore"), is_not(existing_file()));
 
+    let lib = paths::root().join("foo/src/lib.rs");
+    let mut contents = String::new();
+    File::open(&lib).unwrap().read_to_string(&mut contents).unwrap();
+    assert_eq!(contents, r#"#[cfg(test)]
+mod tests {
+    #[test]
+    fn it_works() {
+    }
+}
+"#);
+
     assert_that(cargo_process("build").cwd(&paths::root().join("foo")),
                 execs().with_status(0));
 }


### PR DESCRIPTION
Appears to have been removed unintentionally in #3004.

Was just working on the book, ran `cargo new adder` with cargo-0.18.0-nightly (6f1b860 2017-02-11), and got this in `src/lib.rs`:

```rust
#[test]
fn it_works() {
}
```

when I expected to get this:

```rust
#[cfg(test)]
mod tests {
    #[test]
    fn it_works() {
    }
}
```

It looks like this was changed as part of #3004 ([removed](https://github.com/rust-lang/cargo/commit/875a8aba7916b63c3c8464008a271f6082e23779#diff-149dd4362a3b0dc13b113762713119dfL477), [added](https://github.com/rust-lang/cargo/commit/875a8aba7916b63c3c8464008a271f6082e23779#diff-149dd4362a3b0dc13b113762713119dfR678)), I'm assuming unintentionally?

The regression has not yet hit the beta channel; `cargo-0.17.0-nightly (0bb8047 2017-02-06)` generates the src/lib.rs I expect.