### PR TITLE
Remove build date from version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,22 +61,22 @@ matrix:
            IMAGE=cross
     - env: TARGET=mips64-unknown-linux-gnuabi64
            IMAGE=cross
-      rust: beta
+      rust: beta-2017-03-03
     - env: TARGET=mips64el-unknown-linux-gnuabi64
            IMAGE=cross
-      rust: beta
+      rust: beta-2017-03-03
     - env: TARGET=s390x-unknown-linux-gnu
            IMAGE=cross
-      rust: beta
+      rust: beta-2017-03-03
     - env: TARGET=powerpc-unknown-linux-gnu
            IMAGE=cross
-      rust: beta
+      rust: beta-2017-03-03
     - env: TARGET=powerpc64-unknown-linux-gnu
            IMAGE=cross
-      rust: beta
+      rust: beta-2017-03-03
     - env: TARGET=powerpc64le-unknown-linux-gnu
            IMAGE=cross
-      rust: beta
+      rust: beta-2017-03-03
 
     # beta/nightly builds
     - env: TARGET=x86_64-unknown-linux-gnu
@@ -84,13 +84,13 @@ matrix:
            IMAGE=dist
            MAKE_TARGETS="test distcheck doc install uninstall"
            DEPLOY=0
-      rust: beta
+      rust: beta-2017-03-03
     - env: TARGET=x86_64-unknown-linux-gnu
            ALT=i686-unknown-linux-gnu
            IMAGE=dist
            MAKE_TARGETS="test distcheck doc install uninstall"
            DEPLOY=0
-      rust: nightly
+      rust: nightly-2017-03-03
 
   exclude:
     - rust: stable

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,7 +30,7 @@ install:
 
   # FIXME(#3394) use master rustup
   - curl -sSfO https://static.rust-lang.org/rustup/archive/0.6.5/x86_64-pc-windows-msvc/rustup-init.exe
-  - rustup-init.exe -y --default-host x86_64-pc-windows-msvc --default-toolchain nightly
+  - rustup-init.exe -y --default-host x86_64-pc-windows-msvc --default-toolchain nightly-2017-03-03
   - set PATH=%PATH%;C:\Users\appveyor\.cargo\bin
   - if NOT "%TARGET%" == "x86_64-pc-windows-msvc" rustup target add %TARGET%
   - if defined OTHER_TARGET rustup target add %OTHER_TARGET%

--- a/src/cargo/lib.rs
+++ b/src/cargo/lib.rs
@@ -64,8 +64,6 @@ pub struct CommitInfo {
 pub struct CfgInfo {
     // Information about the git repository we may have been built from.
     pub commit_info: Option<CommitInfo>,
-    // The date that the build was performed.
-    pub build_date: String,
     // The release channel we were built for.
     pub release_channel: String,
 }
@@ -93,15 +91,9 @@ impl fmt::Display for VersionInfo {
         };
 
         if let Some(ref cfg) = self.cfg_info {
-            match cfg.commit_info {
-                Some(ref ci) => {
-                    write!(f, " ({} {})",
-                           ci.short_commit_hash, ci.commit_date)?;
-                },
-                None => {
-                    write!(f, " (built {})",
-                           cfg.build_date)?;
-                }
+            if let Some(ref ci) = cfg.commit_info {
+                write!(f, " ({} {})",
+                       ci.short_commit_hash, ci.commit_date)?;
             }
         };
         Ok(())
@@ -260,7 +252,6 @@ pub fn version() -> VersionInfo {
                 patch: env_str!("CARGO_PKG_VERSION_PATCH"),
                 pre_release: option_env_str!("CARGO_PKG_VERSION_PRE"),
                 cfg_info: Some(CfgInfo {
-                    build_date: option_env_str!("CFG_BUILD_DATE").unwrap(),
                     release_channel: option_env_str!("CFG_RELEASE_CHANNEL").unwrap(),
                     commit_info: commit_info,
                 }),


### PR DESCRIPTION
This was done by rustc awhile ago anyway and the rustc build system isn't
exporting it.