### PR TITLE
Allow to generate lockfile without registry update

### DIFF
--- a/src/bin/generate_lockfile.rs
+++ b/src/bin/generate_lockfile.rs
@@ -13,6 +13,7 @@ pub struct Options {
     flag_color: Option<String>,
     flag_frozen: bool,
     flag_locked: bool,
+    flag_offline: bool,
 }
 
 pub const USAGE: &'static str = "
@@ -29,6 +30,8 @@ Options:
     --color WHEN             Coloring: auto, always, never
     --frozen                 Require Cargo.lock and cache are up to date
     --locked                 Require Cargo.lock is up to date
+    --offline                Do not download crates.io registry and use
+                             a potentially stale local copy
 ";
 
 pub fn execute(options: Options, config: &Config) -> CliResult {
@@ -38,6 +41,9 @@ pub fn execute(options: Options, config: &Config) -> CliResult {
                      &options.flag_color,
                      options.flag_frozen,
                      options.flag_locked)?;
+    if options.flag_offline {
+        config.disable_registry_update();
+    }
     let root = find_root_manifest_for_wd(options.flag_manifest_path, config.cwd())?;
 
     let ws = Workspace::new(&root, config)?;

--- a/src/cargo/util/config.rs
+++ b/src/cargo/util/config.rs
@@ -33,6 +33,7 @@ pub struct Config {
     extra_verbose: Cell<bool>,
     frozen: Cell<bool>,
     locked: Cell<bool>,
+    disable_registry_update: Cell<bool>,
 }
 
 impl Config {
@@ -50,6 +51,7 @@ impl Config {
             extra_verbose: Cell::new(false),
             frozen: Cell::new(false),
             locked: Cell::new(false),
+            disable_registry_update: Cell::new(false),
         }
     }
 
@@ -375,6 +377,14 @@ impl Config {
 
     pub fn lock_update_allowed(&self) -> bool {
         !self.frozen.get() && !self.locked.get()
+    }
+
+    pub fn registry_update_allowed(&self) -> bool {
+        !self.disable_registry_update.get()
+    }
+
+    pub fn disable_registry_update(&self) {
+        self.disable_registry_update.set(true)
     }
 
     fn load_values(&self) -> CargoResult<HashMap<String, ConfigValue>> {


### PR DESCRIPTION
Attempt to fix #3479.

This particular implementation is quite probably broken, because there are no tests yet, I am planning to add them later :) 

I really like how this features solves #1882 nicely: if you don't have internet connection, you can still add new dependencies, but you need to be super explicit about it.