### PR TITLE
Cap lints for upstream deps with `-vv`

### DIFF
--- a/src/cargo/ops/cargo_rustc/mod.rs
+++ b/src/cargo/ops/cargo_rustc/mod.rs
@@ -249,11 +249,23 @@ fn rustc(cx: &mut Context, unit: &Unit, exec: Arc<Executor>) -> CargoResult<Work
     let mut rustc = prepare_rustc(cx, crate_types, unit)?;
 
     let name = unit.pkg.name().to_string();
+
+    // If this is an upstream dep we don't want warnings from, turn off all
+    // lints.
     if !cx.show_warnings(unit.pkg.package_id()) {
         if cx.config.rustc()?.cap_lints {
             rustc.arg("--cap-lints").arg("allow");
         } else {
             rustc.arg("-Awarnings");
+        }
+
+    // If this is an upstream dep but we *do* want warnings, make sure that they
+    // don't fail compilation.
+    } else if !unit.pkg.package_id().source_id().is_path() {
+        if cx.config.rustc()?.cap_lints {
+            rustc.arg("--cap-lints").arg("warn");
+        } else {
+            rustc.arg("-Awarnings"); // not much to do on older compilers
         }
     }
 

--- a/tests/registry.rs
+++ b/tests/registry.rs
@@ -1384,3 +1384,30 @@ fn toml_lies_but_index_is_truth() {
     assert_that(p.cargo("build").arg("-v"),
                 execs().with_status(0));
 }
+
+#[test]
+fn vv_prints_warnings() {
+    Package::new("foo", "0.2.0")
+            .file("src/lib.rs", r#"
+                #![deny(warnings)]
+
+                fn foo() {} // unused function
+            "#)
+            .publish();
+
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [project]
+            name = "fo"
+            version = "0.5.0"
+            authors = []
+
+            [dependencies]
+            foo = "0.2"
+        "#)
+        .file("src/main.rs", "fn main() {}");
+    p.build();
+
+    assert_that(p.cargo("build").arg("-vv"),
+                execs().with_status(0));
+}


### PR DESCRIPTION
Previously with `-vv` Cargo didn't pass `--cap-lints` at all, but with upstream
dependencies we still want to pass at least `--cap-lints warn` to make sure that
they're all still compiling.

Closes #3823