### PR TITLE
Add a workspace.exclude key

### DIFF
--- a/src/cargo/util/toml.rs
+++ b/src/cargo/util/toml.rs
@@ -437,6 +437,7 @@ pub struct TomlProject {
 #[derive(Deserialize)]
 pub struct TomlWorkspace {
     members: Option<Vec<String>>,
+    exclude: Option<Vec<String>>,
 }
 
 pub struct TomlVersion {
@@ -784,7 +785,10 @@ impl TomlManifest {
         let workspace_config = match (self.workspace.as_ref(),
                                       project.workspace.as_ref()) {
             (Some(config), None) => {
-                WorkspaceConfig::Root { members: config.members.clone() }
+                WorkspaceConfig::Root {
+                    members: config.members.clone(),
+                    exclude: config.exclude.clone().unwrap_or(Vec::new()),
+                }
             }
             (None, root) => {
                 WorkspaceConfig::Member { root: root.cloned() }
@@ -860,7 +864,10 @@ impl TomlManifest {
         let profiles = build_profiles(&self.profile);
         let workspace_config = match self.workspace {
             Some(ref config) => {
-                WorkspaceConfig::Root { members: config.members.clone() }
+                WorkspaceConfig::Root {
+                    members: config.members.clone(),
+                    exclude: config.exclude.clone().unwrap_or(Vec::new()),
+                }
             }
             None => {
                 bail!("virtual manifests must be configured with [workspace]");

--- a/src/doc/manifest.md
+++ b/src/doc/manifest.md
@@ -388,6 +388,9 @@ as:
 
 # Optional key, inferred if not present
 members = ["path/to/member1", "path/to/member2"]
+
+# Optional key, empty if not present
+exclude = ["path1", "path/to/dir2"]
 ```
 
 Workspaces were added to Cargo as part [RFC 1525] and have a number of
@@ -410,7 +413,9 @@ manifest, is responsible for defining the entire workspace. All `path`
 dependencies residing in the workspace directory become members. You can add
 additional packages to the workspace by listing them in the `members` key. Note
 that members of the workspaces listed explicitly will also have their path
-dependencies included in the workspace.
+dependencies included in the workspace. Finally, the `exclude` key can be used
+to blacklist paths from being included in a workspace. This can be useful if
+some path dependencies aren't desired to be in the workspace at all.
 
 The `package.workspace` manifest key (described above) is used in member crates
 to point at a workspace's root crate. If this key is omitted then it is inferred


### PR DESCRIPTION
This commit adds a new key to the `Cargo.toml` manifest, `workspace.exclude`.
This new key is a list of strings which is an array of directories that are
excluded from the workspace explicitly. This is intended for use cases such as
vendoring where path dependencies into a vendored directory don't want to pull
in the workspace dependencies.

There's a number of use cases mentioned on #3192 which I believe should all be
covered with this strategy. At a bare minimum it should suffice to `exclude`
every directory and then just explicitly whitelist crates through `members`
through inclusion, and that should give precise control over the structure of a
workspace.

Closes #3192