### PR TITLE
Add Pijul support to Cargo

### DIFF
--- a/src/bin/new.rs
+++ b/src/bin/new.rs
@@ -27,7 +27,7 @@ Usage:
 Options:
     -h, --help          Print this message
     --vcs VCS           Initialize a new repository for the given version
-                        control system (git or hg) or do not initialize any version
+                        control system (git, hg, or pijul) or do not initialize any version
                         control at all (none) overriding a global configuration.
     --bin               Use a binary (application) template
     --lib               Use a library template

--- a/src/cargo/util/mod.rs
+++ b/src/cargo/util/mod.rs
@@ -17,7 +17,7 @@ pub use self::rustc::Rustc;
 pub use self::sha256::Sha256;
 pub use self::to_semver::ToSemver;
 pub use self::to_url::ToUrl;
-pub use self::vcs::{GitRepo, HgRepo};
+pub use self::vcs::{GitRepo, HgRepo, PijulRepo};
 pub use self::read2::read2;
 
 pub mod config;

--- a/src/cargo/util/vcs.rs
+++ b/src/cargo/util/vcs.rs
@@ -6,6 +6,7 @@ use util::{CargoResult, process};
 
 pub struct HgRepo;
 pub struct GitRepo;
+pub struct PijulRepo;
 
 impl GitRepo {
     pub fn init(path: &Path, _: &Path) -> CargoResult<GitRepo> {
@@ -28,3 +29,9 @@ impl HgRepo {
     }
 }
 
+impl PijulRepo {
+    pub fn init(path: &Path, cwd: &Path) -> CargoResult<PijulRepo> {
+        process("pijul").cwd(cwd).arg("init").arg(path).exec()?;
+        Ok(PijulRepo)
+    }
+}


### PR DESCRIPTION
[Pijul](https://pijul.org) is a version control system written in Rust. This commit adds the ability to create a cargo project using pijul as the vcs for the project.

To use it, run `cargo new my-awesome-project --vcs=pijul`