### PR TITLE
Fix overriding mixing with default features

### DIFF
--- a/src/cargo/core/resolver/mod.rs
+++ b/src/cargo/core/resolver/mod.rs
@@ -316,15 +316,13 @@ fn activate(cx: &mut Context,
                               candidate.summary.package_id().clone());
     }
 
-    if cx.flag_activated(&candidate.summary, method) {
-        return Ok(None);
-    }
+    let activated = cx.flag_activated(&candidate.summary, method);
 
     let candidate = match candidate.replace {
         Some(replace) => {
             cx.resolve_replacements.insert(candidate.summary.package_id().clone(),
                                            replace.package_id().clone());
-            if cx.flag_activated(&replace, method) {
+            if cx.flag_activated(&replace, method) && activated {
                 return Ok(None);
             }
             trace!("activating {} (replacing {})", replace.package_id(),
@@ -332,6 +330,9 @@ fn activate(cx: &mut Context,
             replace
         }
         None => {
+            if activated {
+                return Ok(None)
+            }
             trace!("activating {}", candidate.summary.package_id());
             candidate.summary
         }


### PR DESCRIPTION
Previously Cargo had a bug where if a crate *without* a default feature was
overridden with one that did indeed have a default feature then the default may
not end up getting activated by accident. The fix was to avoid returning too
quickly hen activating dependencies until after we've inspected and learned
about replacements.

Closes #3812