### PR TITLE
Detect cyclic dependencies through [replace]

### DIFF
--- a/src/cargo/core/resolver/mod.rs
+++ b/src/cargo/core/resolver/mod.rs
@@ -1023,13 +1023,17 @@ fn check_cycles(resolve: &Resolve,
         // dependencies.
         if checked.insert(id) {
             let summary = summaries[id];
-            for dep in resolve.deps(id) {
+            for dep in resolve.deps_not_replaced(id) {
                 let is_transitive = summary.dependencies().iter().any(|d| {
                     d.matches_id(dep) && d.is_transitive()
                 });
                 let mut empty = HashSet::new();
                 let visited = if is_transitive {&mut *visited} else {&mut empty};
                 visit(resolve, dep, summaries, visited, checked)?;
+
+                if let Some(id) = resolve.replacement(dep) {
+                    visit(resolve, id, summaries, visited, checked)?;
+                }
             }
         }
 


### PR DESCRIPTION
Previously this'd cause a stack overflow in Cargo later in the compilation
graph, but this is intended to get caught during resolution.

Closes #3831