### PR TITLE
Add `[target.'cfg(...)']` syntax for rustc(doc)flags in .cargo/config

### DIFF
--- a/src/doc/config.md
+++ b/src/doc/config.md
@@ -58,7 +58,8 @@ vcs = "none"
 
 # For the following sections, $triple refers to any valid target triple, not the
 # literal string "$triple", and it will apply whenever that target triple is
-# being compiled to.
+# being compiled to. 'cfg(...)' refers to the Rust-like `#[cfg]` syntax for 
+# conditional compilation.
 [target]
 # For Cargo builds which do not mention --target, this is the linker
 # which is passed to rustc (via `-C linker=`). By default this flag is not
@@ -71,6 +72,13 @@ linker = ".."
 linker = ".."
 # custom flags to pass to all compiler invocations that target $triple
 # this value overrides build.rustflags when both are present
+rustflags = ["..", ".."]
+
+[target.'cfg(...)']
+# Similar for the $triple configuration, but using the `cfg` syntax.
+# If several `cfg` and $triple targets are candidates, then the rustflags
+# are concatenated. The `cfg` syntax only applies to rustflags, and not to
+# linker.
 rustflags = ["..", ".."]
 
 # Configuration keys related to the registry

--- a/tests/rustflags.rs
+++ b/tests/rustflags.rs
@@ -951,6 +951,79 @@ fn target_rustflags_precedence() {
 }
 
 #[test]
+fn cfg_rustflags_normal_source() {
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [package]
+            name = "foo"
+            version = "0.0.1"
+        "#)
+        .file("src/lib.rs", "")
+        .file("src/bin/a.rs", "fn main() {}")
+        .file("examples/b.rs", "fn main() {}")
+        .file("tests/c.rs", "#[test] fn f() { }")
+        .file("benches/d.rs", r#"
+            #![feature(test)]
+            extern crate test;
+            #[bench] fn run1(_ben: &mut test::Bencher) { }"#)
+        .file(".cargo/config", "
+            [target.'cfg(feature=\"feat\")']
+            rustflags = [\"-Z\", \"bogus\"]
+            ");
+    p.build();
+
+    assert_that(p.cargo("build").arg("--features").arg("\"feat\"")
+                .arg("--lib"),
+                execs().with_status(101));
+    assert_that(p.cargo("build").arg("--features").arg("\"feat\"")
+                .arg("--bin=a"),
+                execs().with_status(101));
+    assert_that(p.cargo("build").arg("--features").arg("\"feat\"")
+                .arg("--example=b"),
+                execs().with_status(101));
+    assert_that(p.cargo("test").arg("--features").arg("\"feat\""),
+                execs().with_status(101));
+    assert_that(p.cargo("bench").arg("--features").arg("\"feat\""),
+                execs().with_status(101));
+}
+
+// target.'cfg(...)'.rustflags takes precedence over build.rustflags
+#[test]
+fn cfg_rustflags_precedence() {
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [package]
+            name = "foo"
+            version = "0.0.1"
+        "#)
+        .file("src/lib.rs", "")
+        .file(".cargo/config", "
+            [build]
+            rustflags = [\"--cfg\", \"foo\"]
+
+            [target.'cfg(feature = \"feat\"')]
+            rustflags = [\"-Z\", \"bogus\"]
+            ");
+    p.build();
+
+    assert_that(p.cargo("build").arg("--features").arg("\"feat\"")
+                .arg("--lib"),
+                execs().with_status(101));
+    assert_that(p.cargo("build").arg("--features").arg("\"feat\"")
+                .arg("--bin=a"),
+                execs().with_status(101));
+    assert_that(p.cargo("build").arg("--features").arg("\"feat\"")
+                .arg("--example=b"),
+                execs().with_status(101));
+    assert_that(p.cargo("test").arg("--features").arg("\"feat\""),
+                execs().with_status(101));
+    assert_that(p.cargo("bench").arg("--features").arg("\"feat\""),
+                execs().with_status(101));
+}
+
+
+
+#[test]
 fn target_rustflags_string_and_array_form1() {
     let p1 = project("foo")
         .file("Cargo.toml", r#"


### PR DESCRIPTION
Allow to use the Rust `cfg(...)` syntax to configure rust(doc)flags.
The flags are concatenated when a build matches several `cfg`, or
several `cfg` and a $triple.

Fix #3499.