### PR TITLE
Include package props with corresponding env vars into target metadata

### DIFF
--- a/src/cargo/ops/cargo_rustc/compilation.rs
+++ b/src/cargo/ops/cargo_rustc/compilation.rs
@@ -146,6 +146,10 @@ impl<'cfg> Compilation<'cfg> {
         let cargo_exe = self.config.cargo_exe()?;
         cmd.env(::CARGO_ENV, cargo_exe);
 
+        // When adding new environment variables depending on
+        // crate properties which might require rebuild upon change
+        // consider adding the corresponding properties to the hash
+        // in Context::target_metadata()
         cmd.env("CARGO_MANIFEST_DIR", pkg.root())
            .env("CARGO_PKG_VERSION_MAJOR", &pkg.version().major.to_string())
            .env("CARGO_PKG_VERSION_MINOR", &pkg.version().minor.to_string())

--- a/src/cargo/ops/cargo_rustc/context.rs
+++ b/src/cargo/ops/cargo_rustc/context.rs
@@ -399,6 +399,13 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
         // to pull crates from anywhere w/o worrying about conflicts
         unit.pkg.package_id().hash(&mut hasher);
 
+        // Add package properties which map to environment variables
+        // exposed by Cargo
+        let manifest_metadata = unit.pkg.manifest().metadata();
+        manifest_metadata.authors.hash(&mut hasher);
+        manifest_metadata.description.hash(&mut hasher);
+        manifest_metadata.homepage.hash(&mut hasher);
+
         // Also mix in enabled features to our metadata. This'll ensure that
         // when changing feature sets each lib is separately cached.
         self.resolve.features_sorted(unit.pkg.package_id()).hash(&mut hasher);


### PR DESCRIPTION
Previously, when changing package properties with corresponding environment variables (such as authors, which has CARGO_PKG_AUTHORS), it didn't invalidate the build, even though there could have been a dependency on such variables in the source code.

This commit includes 3 such properties: authors list, description and homepage in the target metadata.

I've added a test only for description change, can add more if necessary.
Fixes #3696.