### PR TITLE
Allow to intercept binaries invoked by Cargo

### DIFF
--- a/src/cargo/ops/cargo_run.rs
+++ b/src/cargo/ops/cargo_run.rs
@@ -65,7 +65,7 @@ pub fn run(ws: &Workspace,
     let mut process = compile.target_process(exe, &pkg)?;
     process.args(args).cwd(config.cwd());
 
-    if config.wrap_exe() {
+    if config.print_run() {
         machine_message::emit(RunProfile::new(&process));
         Ok(None)
     } else {

--- a/src/cargo/ops/cargo_run.rs
+++ b/src/cargo/ops/cargo_run.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use ops::{self, CompileFilter, Packages};
+use ops::{self, CompileFilter, Packages, MessageFormat};
 use util::{self, human, CargoResult, ProcessError};
 use util::machine_message::{self, RunProfile};
 use core::Workspace;
@@ -66,6 +66,9 @@ pub fn run(ws: &Workspace,
     process.args(args).cwd(config.cwd());
 
     if config.print_run() {
+        if options.message_format != MessageFormat::Json {
+            bail!("CARGO_PRINT_RUN requires --message-format=json")
+        }
         machine_message::emit(RunProfile::new(&process));
         Ok(None)
     } else {

--- a/src/cargo/ops/cargo_run.rs
+++ b/src/cargo/ops/cargo_run.rs
@@ -2,6 +2,7 @@ use std::path::Path;
 
 use ops::{self, CompileFilter, Packages};
 use util::{self, human, CargoResult, ProcessError};
+use util::machine_message::{self, RunProfile};
 use core::Workspace;
 
 pub fn run(ws: &Workspace,
@@ -64,6 +65,11 @@ pub fn run(ws: &Workspace,
     let mut process = compile.target_process(exe, &pkg)?;
     process.args(args).cwd(config.cwd());
 
-    config.shell().status("Running", process.to_string())?;
-    Ok(process.exec_replace().err())
+    if config.wrap_exe() {
+        machine_message::emit(RunProfile::new(&process));
+        Ok(None)
+    } else {
+        config.shell().status("Running", process.to_string())?;
+        Ok(process.exec_replace().err())
+    }
 }

--- a/src/cargo/ops/cargo_test.rs
+++ b/src/cargo/ops/cargo_test.rs
@@ -1,6 +1,6 @@
 use std::ffi::{OsString, OsStr};
 
-use ops::{self, Compilation};
+use ops::{self, Compilation, MessageFormat};
 use util::{self, CargoResult, CargoTestError, Test, ProcessError};
 use util::machine_message::{self, RunProfile};
 use core::Workspace;
@@ -98,6 +98,9 @@ fn run_unit_tests(options: &TestOptions,
         })?;
 
         if config.print_run() {
+            if options.compile_opts.message_format != MessageFormat::Json {
+                bail!("CARGO_PRINT_RUN requires --message-format=json")
+            }
             machine_message::emit(RunProfile::new(&cmd));
         } else {
             config.shell().verbose(|shell| {

--- a/src/cargo/ops/cargo_test.rs
+++ b/src/cargo/ops/cargo_test.rs
@@ -97,7 +97,7 @@ fn run_unit_tests(options: &TestOptions,
             shell.status("Running", to_display.display().to_string())
         })?;
 
-        if config.wrap_exe() {
+        if config.print_run() {
             machine_message::emit(RunProfile::new(&cmd));
         } else {
             config.shell().verbose(|shell| {
@@ -124,7 +124,7 @@ fn run_doc_tests(options: &TestOptions,
 
     // We don't build/rust doctests if target != host or
     // if we are not supposed to run binaries.
-    if config.rustc()?.host != compilation.target || config.wrap_exe()  {
+    if config.rustc()?.host != compilation.target || config.print_run()  {
         return Ok((Test::Doc, errors));
     }
 

--- a/src/cargo/util/config.rs
+++ b/src/cargo/util/config.rs
@@ -33,6 +33,7 @@ pub struct Config {
     extra_verbose: Cell<bool>,
     frozen: Cell<bool>,
     locked: Cell<bool>,
+    wrap_exe: Cell<bool>,
 }
 
 impl Config {
@@ -50,6 +51,7 @@ impl Config {
             extra_verbose: Cell::new(false),
             frozen: Cell::new(false),
             locked: Cell::new(false),
+            wrap_exe: Cell::new(false),
         }
     }
 
@@ -361,6 +363,7 @@ impl Config {
         self.extra_verbose.set(extra_verbose);
         self.frozen.set(frozen);
         self.locked.set(locked);
+        self.wrap_exe.set(env::var("CARGO_WRAP").is_ok());
 
         Ok(())
     }
@@ -375,6 +378,10 @@ impl Config {
 
     pub fn lock_update_allowed(&self) -> bool {
         !self.frozen.get() && !self.locked.get()
+    }
+
+    pub fn wrap_exe(&self) -> bool {
+        self.wrap_exe.get()
     }
 
     fn load_values(&self) -> CargoResult<HashMap<String, ConfigValue>> {

--- a/src/cargo/util/config.rs
+++ b/src/cargo/util/config.rs
@@ -33,7 +33,10 @@ pub struct Config {
     extra_verbose: Cell<bool>,
     frozen: Cell<bool>,
     locked: Cell<bool>,
-    wrap_exe: Cell<bool>,
+    /// When this is set, Cargo does not run binaries
+    /// during `cargo run`/`cargo test`. Instead it
+    /// prints what it should have run otherwise.
+    print_run: Cell<bool>,
 }
 
 impl Config {
@@ -51,7 +54,7 @@ impl Config {
             extra_verbose: Cell::new(false),
             frozen: Cell::new(false),
             locked: Cell::new(false),
-            wrap_exe: Cell::new(false),
+            print_run: Cell::new(false),
         }
     }
 
@@ -363,7 +366,7 @@ impl Config {
         self.extra_verbose.set(extra_verbose);
         self.frozen.set(frozen);
         self.locked.set(locked);
-        self.wrap_exe.set(env::var("CARGO_WRAP").is_ok());
+        self.print_run.set(env::var("CARGO_PRINT_RUN").is_ok());
 
         Ok(())
     }
@@ -380,8 +383,8 @@ impl Config {
         !self.frozen.get() && !self.locked.get()
     }
 
-    pub fn wrap_exe(&self) -> bool {
-        self.wrap_exe.get()
+    pub fn print_run(&self) -> bool {
+        self.print_run.get()
     }
 
     fn load_values(&self) -> CargoResult<HashMap<String, ConfigValue>> {

--- a/src/cargo/util/process_builder.rs
+++ b/src/cargo/util/process_builder.rs
@@ -57,6 +57,10 @@ impl ProcessBuilder {
         self
     }
 
+    pub fn get_program(&self) -> &OsString {
+        &self.program
+    }
+
     pub fn get_args(&self) -> &[OsString] {
         &self.args
     }

--- a/src/doc/environment-variables.md
+++ b/src/doc/environment-variables.md
@@ -28,6 +28,13 @@ configuration values, as described in [that documentation][config-env]
 
 [config-env]: config.html#environment-variables
 
+There are special environmental variables which are not read from `.cargo/config`:
+
+* `CARGO_PRINT_RUN` - If set, Cargo print information about binaries it is about to
+  run during `cargo test` and `cargo run`, without actually executing the binaries.
+  This is intended for integration with tools wrapping Cargo and IDEs.
+
+
 # Environment variables Cargo sets for crates
 
 Cargo exposes these environment variables to your crate when it is compiled.

--- a/tests/cargotest/support/mod.rs
+++ b/tests/cargotest/support/mod.rs
@@ -426,13 +426,14 @@ impl Execs {
         }
 
         if let Some(ref objects) = self.expect_json {
-            let lines = match str::from_utf8(&actual.stdout) {
+            let stdout = match str::from_utf8(&actual.stdout) {
                 Err(..) => return Err("stdout was not utf8 encoded".to_owned()),
-                Ok(stdout) => stdout.lines().collect::<Vec<_>>(),
+                Ok(stdout) => stdout,
             };
+            let lines = stdout.lines().collect::<Vec<_>>();;
             if lines.len() != objects.len() {
-                return Err(format!("expected {} json lines, got {}",
-                                   objects.len(), lines.len()));
+                return Err(format!("expected {} json lines, got {}:\n {}",
+                                   objects.len(), lines.len(), stdout));
             }
             for (obj, line) in objects.iter().zip(lines) {
                 self.match_json(obj, line)?;

--- a/tests/intercept_exe.rs
+++ b/tests/intercept_exe.rs
@@ -1,0 +1,118 @@
+extern crate cargo;
+extern crate cargotest;
+extern crate hamcrest;
+
+use cargotest::support::{project, execs};
+use hamcrest::{assert_that, existing_file};
+
+#[test]
+fn single_bin() {
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [project]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+        "#)
+        .file("src/main.rs", r#"
+            fn main() { println!("hello"); }
+        "#);
+
+    assert_that(p.cargo_process("run").env("CARGO_WRAP", "1"),
+                execs().with_status(0)
+                       .with_stderr(&"\
+[COMPILING] foo v0.0.1 ([..])
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]")
+                       .with_json(r#"
+{
+  "reason": "run-profile",
+  "program": "target\/debug\/foo",
+  "env": {
+    "LD_LIBRARY_PATH": "[..]",
+    "CARGO_PKG_VERSION_PRE": "",
+    "CARGO_PKG_VERSION_PATCH": "1",
+    "CARGO_PKG_VERSION_MINOR": "0",
+    "CARGO_PKG_VERSION_MAJOR": "0",
+    "CARGO_PKG_VERSION": "0.0.1",
+    "CARGO_PKG_NAME": "foo",
+    "CARGO_PKG_HOMEPAGE": "",
+    "CARGO_PKG_DESCRIPTION": "",
+    "CARGO_PKG_AUTHORS": "",
+    "CARGO_MANIFEST_DIR": "[..]",
+    "CARGO": "[..]"
+  },
+  "cwd": "[..]",
+  "args": []
+}
+"#));
+    assert_that(&p.bin("foo"), existing_file());
+}
+
+#[test]
+fn several_tests() {
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [project]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+        "#)
+        .file("src/lib.rs", r#"
+            /// Doctest are not executed with wrap
+            /// ```
+            /// assert!(false);
+            /// ```
+            pub fn f() {  }
+
+            #[test] fn test_in_lib() {}
+        "#)
+        .file("tests/bar.rs", r#"
+            #[test] fn test_bar() {}
+        "#)
+        .file("tests/baz.rs", r#"
+            #[test] fn test_baz() {}
+        "#);
+
+    let env = r#"{
+        "LD_LIBRARY_PATH": "[..]",
+        "CARGO_PKG_VERSION_PRE": "",
+        "CARGO_PKG_VERSION_PATCH": "1",
+        "CARGO_PKG_VERSION_MINOR": "0",
+        "CARGO_PKG_VERSION_MAJOR": "0",
+        "CARGO_PKG_VERSION": "0.0.1",
+        "CARGO_PKG_NAME": "foo",
+        "CARGO_PKG_HOMEPAGE": "",
+        "CARGO_PKG_DESCRIPTION": "",
+        "CARGO_PKG_AUTHORS": "",
+        "CARGO_MANIFEST_DIR": "[..]",
+        "CARGO": "[..]"
+    }"#;
+    assert_that(p.cargo_process("test").env("CARGO_WRAP", "1"),
+                execs().with_status(0)
+                       .with_json(&format!(r#"
+{{
+  "reason": "run-profile",
+  "program": "[..]bar-[..]",
+  "env": {env},
+  "cwd": "[..]",
+  "args": []
+}}
+
+{{
+  "reason": "run-profile",
+  "program": "[..]baz-[..]",
+  "env": {env},
+  "cwd": "[..]",
+  "args": []
+}}
+
+{{
+  "reason": "run-profile",
+  "program": "[..]foo-[..]",
+  "env": {env},
+  "cwd": "[..]",
+  "args": []
+}}
+"#, env=env)));
+}
+

--- a/tests/print_run.rs
+++ b/tests/print_run.rs
@@ -26,7 +26,7 @@ fn single_bin() {
                        .with_json(r#"
 {
   "reason": "run-profile",
-  "program": "target\/debug\/foo",
+  "program": "[..][/]foo[/]target[/]debug[/]foo",
   "env": {
     "LD_LIBRARY_PATH": "[..]",
     "CARGO_PKG_VERSION_PRE": "",

--- a/tests/print_run.rs
+++ b/tests/print_run.rs
@@ -18,7 +18,7 @@ fn single_bin() {
             fn main() { println!("hello"); }
         "#);
 
-    assert_that(p.cargo_process("run").env("CARGO_WRAP", "1"),
+    assert_that(p.cargo_process("run").env("CARGO_PRINT_RUN", "1"),
                 execs().with_status(0)
                        .with_stderr(&"\
 [COMPILING] foo v0.0.1 ([..])
@@ -87,7 +87,7 @@ fn several_tests() {
         "CARGO_MANIFEST_DIR": "[..]",
         "CARGO": "[..]"
     }"#;
-    assert_that(p.cargo_process("test").env("CARGO_WRAP", "1"),
+    assert_that(p.cargo_process("test").env("CARGO_PRINT_RUN", "1"),
                 execs().with_status(0)
                        .with_json(&format!(r#"
 {{


### PR DESCRIPTION
Fix #3670.

This adds an environmental variable `CARGO_WRAP`, which prevents cargo from running binaries and allows IDEs and such to take over the wheel. 

Question: how this should interract with `--message-format=json`? What should Cargo do, if it sees `CARGO_WRAP`, but `--message_format` is human? 