### PR TITLE
Allow to configure colors using an environment variable

### DIFF
--- a/src/cargo/core/shell.rs
+++ b/src/cargo/core/shell.rs
@@ -83,6 +83,13 @@ impl Style {
         }
         Ok(())
     }
+
+    pub fn new(color: Color, attr: Option<Attr>) -> Self {
+        Style {
+            color: color,
+            attr: attr
+        }
+    }
 }
 
 #[derive(Clone, Copy, PartialEq)]

--- a/src/cargo/lib.rs
+++ b/src/cargo/lib.rs
@@ -38,7 +38,6 @@ use docopt::Docopt;
 
 use core::{Shell, MultiShell, ShellConfig, Verbosity, ColorConfig};
 use core::shell::Verbosity::{Verbose};
-use term::color::{BLACK};
 
 pub use util::{CargoError, CargoResult, CliError, CliResult, human, Config, ChainError};
 
@@ -185,12 +184,14 @@ pub fn exit_with_error(err: CliError, shell: &mut MultiShell) -> ! {
         } else if fatal {
             shell.error(&error)
         } else {
-            shell.say(&error, BLACK)
+            let color = shell.styles.default;
+            shell.say(&error, color)
         };
 
         if !handle_cause(&error, shell) || hide {
+            let color = shell.styles.default;
             let _ = shell.err().say("\nTo learn more, run the command again \
-                                     with --verbose.".to_string(), BLACK);
+                                     with --verbose.".to_string(), color);
         }
     }
 
@@ -223,8 +224,9 @@ fn handle_cause(mut cargo_err: &CargoError, shell: &mut MultiShell) -> bool {
     }
 
     fn print(error: String, shell: &mut MultiShell) {
-        let _ = shell.err().say("\nCaused by:", BLACK);
-        let _ = shell.err().say(format!("  {}", error), BLACK);
+        let color = shell.styles.default;
+        let _ = shell.err().say("\nCaused by:", color);
+        let _ = shell.err().say(format!("  {}", error), color);
     }
 }
 

--- a/src/cargo/ops/cargo_new.rs
+++ b/src/cargo/ops/cargo_new.rs
@@ -6,8 +6,6 @@ use rustc_serialize::{Decodable, Decoder};
 
 use git2::Config as GitConfig;
 
-use term::color::BLACK;
-
 use handlebars::{Handlebars, no_escape};
 use tempdir::TempDir;
 use time;
@@ -193,10 +191,11 @@ fn get_name<'a>(path: &'a Path, opts: &'a NewOptions, config: &Config) -> CargoR
     } else {
         let new_name = strip_rust_affixes(dir_name);
         if new_name != dir_name {
+            let color = config.shell().styles.default;
             let message = format!(
                 "note: package will be named `{}`; use --name to override",
                 new_name);
-            config.shell().say(&message, BLACK)?;
+            config.shell().say(&message, color)?;
         }
         Ok(new_name)
     }

--- a/src/cargo/ops/cargo_rustc/job_queue.rs
+++ b/src/cargo/ops/cargo_rustc/job_queue.rs
@@ -5,7 +5,6 @@ use std::io::Write;
 use std::sync::mpsc::{channel, Sender, Receiver};
 
 use crossbeam::{self, Scope};
-use term::color::YELLOW;
 
 use core::{PackageId, Target, Profile};
 use util::{Config, DependencyQueue, Fresh, Dirty, Freshness};
@@ -185,9 +184,10 @@ impl<'a> JobQueue<'a> {
                             if self.active > 0 {
                                 error = Some(human("build failed"));
                                 handle_error(&*e, &mut *cx.config.shell());
+                                let color = cx.config.shell().styles.warning;
                                 cx.config.shell().say(
                                             "Build failed, waiting for other \
-                                             jobs to finish...", YELLOW)?;
+                                             jobs to finish...", color)?;
                             }
                             if error.is_none() {
                                 error = Some(e);

--- a/src/cargo/ops/registry.rs
+++ b/src/cargo/ops/registry.rs
@@ -8,7 +8,6 @@ use std::time::Duration;
 use curl::easy::{Easy, SslOpt};
 use git2;
 use registry::{Registry, NewCrate, NewCrateDependency};
-use term::color::BLACK;
 
 use url::percent_encoding::{percent_encode, QUERY_ENCODE_SET};
 
@@ -419,6 +418,7 @@ pub fn search(query: &str,
         .max()
         .unwrap_or(0);
 
+    let color = config.shell().styles.default;
     for (name, description) in list_items.into_iter() {
         let line = match description {
             Some(desc) => {
@@ -428,24 +428,22 @@ pub fn search(query: &str,
             }
             None => name
         };
-        config.shell().say(line, BLACK)?;
+        config.shell().say(line, color)?;
     }
 
     let search_max_limit = 100;
     if total_crates > limit as u32 && limit < search_max_limit {
         config.shell().say(
             format!("... and {} crates more (use --limit N to see more)",
-                    total_crates - limit as u32),
-            BLACK)
+                    total_crates - limit as u32), color)
         ?;
-    } else if total_crates > limit as u32 && limit >= search_max_limit {
+    } else if total_crates > limit as u32 && limit >= search_max_limit {        
         config.shell().say(
             format!(
                 "... and {} crates more (go to http://crates.io/search?q={} to see more)",
                 total_crates - limit as u32,
                 percent_encode(query.as_bytes(), QUERY_ENCODE_SET)
-            ),
-            BLACK)
+            ), color)
         ?;
     }
 

--- a/src/cargo/util/flock.rs
+++ b/src/cargo/util/flock.rs
@@ -3,7 +3,6 @@ use std::io::*;
 use std::io;
 use std::path::{Path, PathBuf, Display};
 
-use term::color::CYAN;
 use fs2::{FileExt, lock_contended_error};
 #[allow(unused_imports)]
 use libc;
@@ -288,7 +287,8 @@ fn acquire(config: &Config,
         }
     }
     let msg = format!("waiting for file lock on {}", msg);
-    config.shell().err().say_status("Blocking", &msg, CYAN, true)?;
+    let color = config.shell().styles.blocked;
+    config.shell().err().say_status("Blocking", &msg, color, true)?;
 
     return block().chain_error(|| {
         human(format!("failed to lock file: {}", path.display()))
@@ -299,7 +299,7 @@ fn acquire(config: &Config,
         use std::ffi::CString;
         use std::mem;
         use std::os::unix::prelude::*;
-
+        
         let path = match CString::new(path.as_os_str().as_bytes()) {
             Ok(path) => path,
             Err(_) => return false,

--- a/tests/shell.rs
+++ b/tests/shell.rs
@@ -8,7 +8,7 @@ use std::io;
 use std::sync::{Arc, Mutex};
 
 use cargo::core::shell::ColorConfig::{Auto,Always, Never};
-use cargo::core::shell::{Shell, ShellConfig};
+use cargo::core::shell::{Shell, ShellConfig, Style};
 use cargo::util::CargoResult;
 use cargotest::support::{Tap, execs, shell_writes};
 use hamcrest::{assert_that};
@@ -29,7 +29,7 @@ fn non_tty() {
     let a = Arc::new(Mutex::new(Vec::new()));
 
     Shell::create(|| Box::new(Sink(a.clone())), config).tap(|shell| {
-        shell.say("Hey Alex", color::RED).unwrap();
+        shell.say("Hey Alex", Style::default()).unwrap();
     });
     let buf = a.lock().unwrap().clone();
     assert_that(&buf[..], shell_writes("Hey Alex\n"));
@@ -44,7 +44,7 @@ fn color_explicitly_disabled() {
     let a = Arc::new(Mutex::new(Vec::new()));
 
     Shell::create(|| Box::new(Sink(a.clone())), config).tap(|shell| {
-        shell.say("Hey Alex", color::RED).unwrap();
+        shell.say("Hey Alex", Style::default()).unwrap();
     });
     let buf = a.lock().unwrap().clone();
     assert_that(&buf[..], shell_writes("Hey Alex\n"));
@@ -59,7 +59,7 @@ fn colored_shell() {
     let a = Arc::new(Mutex::new(Vec::new()));
 
     Shell::create(|| Box::new(Sink(a.clone())), config).tap(|shell| {
-        shell.say("Hey Alex", color::RED).unwrap();
+        shell.say("Hey Alex", Style::new(color::RED, None)).unwrap();
     });
     let buf = a.lock().unwrap().clone();
     let expected_output = if term.unwrap().supports_color() {
@@ -80,7 +80,7 @@ fn color_explicitly_enabled() {
     let a = Arc::new(Mutex::new(Vec::new()));
 
     Shell::create(|| Box::new(Sink(a.clone())), config).tap(|shell| {
-        shell.say("Hey Alex", color::RED).unwrap();
+        shell.say("Hey Alex", Style::new(color::RED, None)).unwrap();
     });
     let buf = a.lock().unwrap().clone();
     assert_that(&buf[..],


### PR DESCRIPTION
This commit add support for configuring colors used by cargo through a
environment variable (CARGO_COLORS). The used syntax for the environment
variable is similar to that one used by gcc (GCC_COLORS).

Example: CARGO_COLORS="status=01;2:warn=01;3:error=01;1:default:01;231:blocked=01;4"

The current state should be seen as a proof of concept and demo to see if this functionality is wanted. I've only tested the code on linux so far. 
For a final implementation the interpretation of the escape codes may be improved.