### PR TITLE
Allow a client to override values in a config

### DIFF
--- a/src/cargo/util/config.rs
+++ b/src/cargo/util/config.rs
@@ -109,6 +109,16 @@ impl Config {
         self.values.get_or_try_init(|| self.load_values())
     }
 
+    pub fn set_values(&self, values: HashMap<String, ConfigValue>) -> CargoResult<()> {
+        if self.values.borrow().is_some() {
+            return Err(human("Config values already found"));
+        }
+        match self.values.fill(values) {
+            Ok(()) => Ok(()),
+            Err(_) => Err(human("Could not fill values")),
+        }
+    }
+
     pub fn cwd(&self) -> &Path { &self.cwd }
 
     pub fn target_dir(&self) -> CargoResult<Option<Filesystem>> {
@@ -378,7 +388,7 @@ impl Config {
         !self.frozen.get() && !self.locked.get()
     }
 
-    fn load_values(&self) -> CargoResult<HashMap<String, ConfigValue>> {
+    pub fn load_values(&self) -> CargoResult<HashMap<String, ConfigValue>> {
         let mut cfg = CV::Table(HashMap::new(), PathBuf::from("."));
 
         walk_tree(&self.cwd, |mut file, path| {

--- a/src/cargo/util/mod.rs
+++ b/src/cargo/util/mod.rs
@@ -1,5 +1,5 @@
 pub use self::cfg::{Cfg, CfgExpr};
-pub use self::config::{Config, homedir};
+pub use self::config::{Config, ConfigValue, homedir};
 pub use self::dependency_queue::{DependencyQueue, Fresh, Dirty, Freshness};
 pub use self::errors::{CargoResult, CargoError, Test, ChainError, CliResult};
 pub use self::errors::{CliError, ProcessError, CargoTestError};


### PR DESCRIPTION
The use case here is that the RLS wants to set a project's `target-dir`, but can't do this using a config file (since the user might have their own, and it's a bit hacky) or via an environment variable (because there might be multiple instances of Cargo running on different directories in different threads.

ISTM that the best way to accomplish this is to allow the RLS to override values in the config before we make a workspace from it. However, since the config uses a `LazyCell` for the config values, this is not very nice (if something tries to read a config value before we set them, then there will be an error when we try to set them). However, this meets our needs and is pretty low impact, so it seems like the best solution for now. I'm open to other ideas though.