### PR TITLE
Implementation and CLI-support for `--all-$KIND` flags

### DIFF
--- a/src/bin/bench.rs
+++ b/src/bin/bench.rs
@@ -19,9 +19,13 @@ pub struct Options {
     flag_message_format: MessageFormat,
     flag_lib: bool,
     flag_bin: Vec<String>,
+    flag_bins: bool,
     flag_example: Vec<String>,
+    flag_examples: bool,
     flag_test: Vec<String>,
+    flag_tests: bool,
     flag_bench: Vec<String>,
+    flag_benches: bool,
     flag_frozen: bool,
     flag_locked: bool,
     arg_args: Vec<String>,
@@ -37,9 +41,13 @@ Options:
     -h, --help                   Print this message
     --lib                        Benchmark only this package's library
     --bin NAME                   Benchmark only the specified binary
+    --bins                       Benchmark all binaries
     --example NAME               Benchmark only the specified example
+    --examples                   Benchmark all examples
     --test NAME                  Benchmark only the specified test target
+    --tests                      Benchmark all tests
     --bench NAME                 Benchmark only the specified bench target
+    --benches                    Benchmark all benches
     --no-run                     Compile, but don't run benchmarks
     -p SPEC, --package SPEC ...  Package to run benchmarks for
     -j N, --jobs N               Number of parallel jobs, defaults to # of CPUs
@@ -92,10 +100,10 @@ pub fn execute(options: Options, config: &Config) -> CliResult {
             release: true,
             mode: ops::CompileMode::Bench,
             filter: ops::CompileFilter::new(options.flag_lib,
-                                            &options.flag_bin,
-                                            &options.flag_test,
-                                            &options.flag_example,
-                                            &options.flag_bench),
+                                            &options.flag_bin, options.flag_bins,
+                                            &options.flag_test, options.flag_tests,
+                                            &options.flag_example, options.flag_examples,
+                                            &options.flag_bench, options.flag_benches,),
             message_format: options.flag_message_format,
             target_rustdoc_args: None,
             target_rustc_args: None,

--- a/src/bin/build.rs
+++ b/src/bin/build.rs
@@ -21,9 +21,13 @@ pub struct Options {
     flag_release: bool,
     flag_lib: bool,
     flag_bin: Vec<String>,
+    flag_bins: bool,
     flag_example: Vec<String>,
+    flag_examples: bool,
     flag_test: Vec<String>,
+    flag_tests: bool,
     flag_bench: Vec<String>,
+    flag_benches: bool,
     flag_locked: bool,
     flag_frozen: bool,
     flag_all: bool,
@@ -42,9 +46,13 @@ Options:
     -j N, --jobs N               Number of parallel jobs, defaults to # of CPUs
     --lib                        Build only this package's library
     --bin NAME                   Build only the specified binary
+    --bins                       Build all binaries
     --example NAME               Build only the specified example
+    --examples                   Build all examples
     --test NAME                  Build only the specified test target
-    --bench NAME                 Build only the specified benchmark target
+    --tests                      Build all tests
+    --bench NAME                 Build only the specified bench target
+    --benches                    Build all benches
     --release                    Build artifacts in release mode, with optimizations
     --features FEATURES          Space-separated list of features to also build
     --all-features               Build all available features
@@ -99,10 +107,10 @@ pub fn execute(options: Options, config: &Config) -> CliResult {
         mode: ops::CompileMode::Build,
         release: options.flag_release,
         filter: ops::CompileFilter::new(options.flag_lib,
-                                        &options.flag_bin,
-                                        &options.flag_test,
-                                        &options.flag_example,
-                                        &options.flag_bench),
+                                        &options.flag_bin, options.flag_bins,
+                                        &options.flag_test, options.flag_tests,
+                                        &options.flag_example, options.flag_examples,
+                                        &options.flag_bench, options.flag_benches,),
         message_format: options.flag_message_format,
         target_rustdoc_args: None,
         target_rustc_args: None,

--- a/src/bin/check.rs
+++ b/src/bin/check.rs
@@ -18,9 +18,13 @@ Options:
     -j N, --jobs N               Number of parallel jobs, defaults to # of CPUs
     --lib                        Check only this package's library
     --bin NAME                   Check only the specified binary
+    --bins                       Check all binaries
     --example NAME               Check only the specified example
+    --examples                   Check all examples
     --test NAME                  Check only the specified test target
-    --bench NAME                 Check only the specified benchmark target
+    --tests                      Check all tests
+    --bench NAME                 Check only the specified bench target
+    --benches                    Check all benches
     --release                    Check artifacts in release mode, with optimizations
     --features FEATURES          Space-separated list of features to also check
     --all-features               Check all available features
@@ -60,9 +64,13 @@ pub struct Options {
     flag_release: bool,
     flag_lib: bool,
     flag_bin: Vec<String>,
+    flag_bins: bool,
     flag_example: Vec<String>,
+    flag_examples: bool,
     flag_test: Vec<String>,
+    flag_tests: bool,
     flag_bench: Vec<String>,
+    flag_benches: bool,
     flag_locked: bool,
     flag_frozen: bool,
     flag_all: bool,
@@ -98,10 +106,10 @@ pub fn execute(options: Options, config: &Config) -> CliResult {
         mode: ops::CompileMode::Check,
         release: options.flag_release,
         filter: ops::CompileFilter::new(options.flag_lib,
-                                        &options.flag_bin,
-                                        &options.flag_test,
-                                        &options.flag_example,
-                                        &options.flag_bench),
+                                        &options.flag_bin, options.flag_bins,
+                                        &options.flag_test, options.flag_tests,
+                                        &options.flag_example, options.flag_examples,
+                                        &options.flag_bench, options.flag_benches,),
         message_format: options.flag_message_format,
         target_rustdoc_args: None,
         target_rustc_args: None,

--- a/src/bin/doc.rs
+++ b/src/bin/doc.rs
@@ -21,6 +21,7 @@ pub struct Options {
     flag_package: Vec<String>,
     flag_lib: bool,
     flag_bin: Vec<String>,
+    flag_bins: bool,
     flag_frozen: bool,
     flag_locked: bool,
     flag_all: bool,
@@ -41,6 +42,7 @@ Options:
     -j N, --jobs N               Number of parallel jobs, defaults to # of CPUs
     --lib                        Document only this package's library
     --bin NAME                   Document only the specified binary
+    --bins                       Document all binaries
     --release                    Build artifacts in release mode, with optimizations
     --features FEATURES          Space-separated list of features to also build
     --all-features               Build all available features
@@ -93,10 +95,10 @@ pub fn execute(options: Options, config: &Config) -> CliResult {
             no_default_features: options.flag_no_default_features,
             spec: spec,
             filter: ops::CompileFilter::new(options.flag_lib,
-                                            &options.flag_bin,
-                                            &empty,
-                                            &empty,
-                                            &empty),
+                                            &options.flag_bin, options.flag_bins,
+                                            &empty, false,
+                                            &empty, false,
+                                            &empty, false),
             message_format: options.flag_message_format,
             release: options.flag_release,
             mode: ops::CompileMode::Doc {

--- a/src/bin/install.rs
+++ b/src/bin/install.rs
@@ -10,7 +10,9 @@ pub struct Options {
     flag_no_default_features: bool,
     flag_debug: bool,
     flag_bin: Vec<String>,
+    flag_bins: bool,
     flag_example: Vec<String>,
+    flag_examples: bool,
     flag_verbose: u32,
     flag_quiet: Option<bool>,
     flag_color: Option<String>,
@@ -54,8 +56,10 @@ Build and install options:
     --all-features            Build all available features
     --no-default-features     Do not build the `default` feature
     --debug                   Build in debug mode instead of release mode
-    --bin NAME                Only install the binary NAME
-    --example EXAMPLE         Install the example EXAMPLE instead of binaries
+    --bin NAME                Install only the specified binary
+    --bins                    Install all binaries
+    --example NAME            Install only the specified example
+    --examples                Install all examples
     --root DIR                Directory to install packages into
     -v, --verbose ...         Use verbose output (-vv very verbose/build.rs output)
     -q, --quiet               Less output printed to stdout
@@ -111,8 +115,11 @@ pub fn execute(options: Options, config: &Config) -> CliResult {
         spec: ops::Packages::Packages(&[]),
         mode: ops::CompileMode::Build,
         release: !options.flag_debug,
-        filter: ops::CompileFilter::new(false, &options.flag_bin, &[],
-                                        &options.flag_example, &[]),
+        filter: ops::CompileFilter::new(false,
+                                        &options.flag_bin, options.flag_bins,
+                                        &[], false,
+                                        &options.flag_example, options.flag_examples,
+                                        &[], false),
         message_format: ops::MessageFormat::Human,
         target_rustc_args: None,
         target_rustdoc_args: None,

--- a/src/bin/run.rs
+++ b/src/bin/run.rs
@@ -94,10 +94,11 @@ pub fn execute(options: Options, config: &Config) -> CliResult {
         filter: if examples.is_empty() && bins.is_empty() {
             ops::CompileFilter::Everything { required_features_filterable: false, }
         } else {
-            ops::CompileFilter::Only {
-                lib: false, tests: &[], benches: &[],
-                bins: &bins, examples: &examples,
-            }
+            ops::CompileFilter::new(false,
+                                    &bins, false,
+                                    &[], false,
+                                    &examples, false,
+                                    &[], false)
         },
         message_format: options.flag_message_format,
         target_rustdoc_args: None,

--- a/src/bin/rustc.rs
+++ b/src/bin/rustc.rs
@@ -22,9 +22,13 @@ pub struct Options {
     flag_release: bool,
     flag_lib: bool,
     flag_bin: Vec<String>,
+    flag_bins: bool,
     flag_example: Vec<String>,
+    flag_examples: bool,
     flag_test: Vec<String>,
+    flag_tests: bool,
     flag_bench: Vec<String>,
+    flag_benches: bool,
     flag_profile: Option<String>,
     flag_frozen: bool,
     flag_locked: bool,
@@ -42,9 +46,13 @@ Options:
     -j N, --jobs N           Number of parallel jobs, defaults to # of CPUs
     --lib                    Build only this package's library
     --bin NAME               Build only the specified binary
+    --bins                   Build all binaries
     --example NAME           Build only the specified example
+    --examples               Build all examples
     --test NAME              Build only the specified test target
-    --bench NAME             Build only the specified benchmark target
+    --tests                  Build all tests
+    --bench NAME             Build only the specified bench target
+    --benches                Build all benches
     --release                Build artifacts in release mode, with optimizations
     --profile PROFILE        Profile to build the selected target for
     --features FEATURES      Features to compile for the package
@@ -109,10 +117,10 @@ pub fn execute(options: Options, config: &Config) -> CliResult {
         mode: mode,
         release: options.flag_release,
         filter: ops::CompileFilter::new(options.flag_lib,
-                                        &options.flag_bin,
-                                        &options.flag_test,
-                                        &options.flag_example,
-                                        &options.flag_bench),
+                                        &options.flag_bin, options.flag_bins,
+                                        &options.flag_test, options.flag_tests,
+                                        &options.flag_example, options.flag_examples,
+                                        &options.flag_bench, options.flag_benches,),
         message_format: options.flag_message_format,
         target_rustdoc_args: None,
         target_rustc_args: options.arg_opts.as_ref().map(|a| &a[..]),

--- a/src/bin/rustdoc.rs
+++ b/src/bin/rustdoc.rs
@@ -21,9 +21,13 @@ pub struct Options {
     flag_package: Option<String>,
     flag_lib: bool,
     flag_bin: Vec<String>,
+    flag_bins: bool,
     flag_example: Vec<String>,
+    flag_examples: bool,
     flag_test: Vec<String>,
+    flag_tests: bool,
     flag_bench: Vec<String>,
+    flag_benches: bool,
     flag_frozen: bool,
     flag_locked: bool,
 }
@@ -41,9 +45,13 @@ Options:
     -j N, --jobs N           Number of parallel jobs, defaults to # of CPUs
     --lib                    Build only this package's library
     --bin NAME               Build only the specified binary
+    --bins                   Build all binaries
     --example NAME           Build only the specified example
+    --examples               Build all examples
     --test NAME              Build only the specified test target
-    --bench NAME             Build only the specified benchmark target
+    --tests                  Build all tests
+    --bench NAME             Build only the specified bench target
+    --benches                Build all benches
     --release                Build artifacts in release mode, with optimizations
     --features FEATURES      Space-separated list of features to also build
     --all-features           Build all available features
@@ -94,10 +102,10 @@ pub fn execute(options: Options, config: &Config) -> CliResult {
             spec: Packages::Packages(&spec),
             release: options.flag_release,
             filter: ops::CompileFilter::new(options.flag_lib,
-                                            &options.flag_bin,
-                                            &options.flag_test,
-                                            &options.flag_example,
-                                            &options.flag_bench),
+                                            &options.flag_bin, options.flag_bins,
+                                            &options.flag_test, options.flag_tests,
+                                            &options.flag_example, options.flag_examples,
+                                            &options.flag_bench, options.flag_benches,),
             message_format: options.flag_message_format,
             mode: ops::CompileMode::Doc { deps: false },
             target_rustdoc_args: Some(&options.arg_opts),

--- a/src/bin/test.rs
+++ b/src/bin/test.rs
@@ -17,9 +17,13 @@ pub struct Options {
     flag_lib: bool,
     flag_doc: bool,
     flag_bin: Vec<String>,
+    flag_bins: bool,
     flag_example: Vec<String>,
+    flag_examples: bool,
     flag_test: Vec<String>,
+    flag_tests: bool,
     flag_bench: Vec<String>,
+    flag_benches: bool,
     flag_verbose: u32,
     flag_quiet: Option<bool>,
     flag_color: Option<String>,
@@ -41,10 +45,14 @@ Options:
     -h, --help                   Print this message
     --lib                        Test only this package's library
     --doc                        Test only this library's documentation
-    --bin NAME ...               Test only the specified binaries
+    --bin NAME ...               Test only the specified binary
+    --bins                       Test all binaries
     --example NAME ...           Check that the specified examples compile
-    --test NAME ...              Test only the specified integration test targets
-    --bench NAME ...             Test only the specified benchmark targets
+    --examples                   Check that all examples compile
+    --test NAME ...              Test only the specified test target
+    --tests                      Test all tests
+    --bench NAME ...             Test only the specified bench target
+    --benches                    Test all benches
     --no-run                     Compile, but don't run tests
     -p SPEC, --package SPEC ...  Package to run tests for
     --all                        Test all packages in the workspace
@@ -106,14 +114,15 @@ pub fn execute(options: Options, config: &Config) -> CliResult {
     let (mode, filter);
     if options.flag_doc {
         mode = ops::CompileMode::Doctest;
-        filter = ops::CompileFilter::new(true, &empty, &empty, &empty, &empty);
+        filter = ops::CompileFilter::new(true, &empty, false, &empty, false,
+                                               &empty, false, &empty, false);
     } else {
         mode = ops::CompileMode::Test;
         filter = ops::CompileFilter::new(options.flag_lib,
-                                         &options.flag_bin,
-                                         &options.flag_test,
-                                         &options.flag_example,
-                                         &options.flag_bench);
+                                         &options.flag_bin, options.flag_bins,
+                                         &options.flag_test, options.flag_tests,
+                                         &options.flag_example, options.flag_examples,
+                                         &options.flag_bench, options.flag_benches);
     }
 
     let spec = if options.flag_all {

--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -453,6 +453,14 @@ impl Target {
         }
     }
 
+    pub fn is_bin_example(&self) -> bool {
+        // Needed for --all-examples in contexts where only runnable examples make sense
+        match self.kind {
+            TargetKind::ExampleBin => true,
+            _ => false
+        }
+    }
+
     pub fn is_test(&self) -> bool { self.kind == TargetKind::Test }
     pub fn is_bench(&self) -> bool { self.kind == TargetKind::Bench }
     pub fn is_custom_build(&self) -> bool { self.kind == TargetKind::CustomBuild }

--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -382,6 +382,13 @@ impl<'a> CompileFilter<'a> {
             }
         }
     }
+
+    pub fn is_specific(&self) -> bool {
+        match *self {
+            CompileFilter::Everything { .. } => false,
+            CompileFilter::Only { .. } => true,
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug)]

--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -78,7 +78,7 @@ impl<'a> CompileOptions<'a> {
             spec: ops::Packages::Packages(&[]),
             mode: mode,
             release: false,
-            filter: ops::CompileFilter::new(false, &[], &[], &[], &[]),
+            filter: CompileFilter::Everything { required_features_filterable: false },
             message_format: MessageFormat::Human,
             target_rustdoc_args: None,
             target_rustc_args: None,
@@ -125,6 +125,12 @@ impl<'a> Packages<'a> {
     }
 }
 
+#[derive(Clone, Copy)]
+pub enum FilterRule<'a> {
+    All,
+    Just (&'a [String]),
+}
+
 pub enum CompileFilter<'a> {
     Everything {
         /// Flag whether targets can be safely skipped when required-features are not satisfied.
@@ -132,10 +138,10 @@ pub enum CompileFilter<'a> {
     },
     Only {
         lib: bool,
-        bins: &'a [String],
-        examples: &'a [String],
-        tests: &'a [String],
-        benches: &'a [String],
+        bins: FilterRule<'a>,
+        examples: FilterRule<'a>,
+        tests: FilterRule<'a>,
+        benches: FilterRule<'a>,
     }
 }
 
@@ -301,17 +307,56 @@ pub fn compile_ws<'a>(ws: &Workspace<'a>,
     }
 }
 
+impl<'a> FilterRule<'a> {
+    pub fn new(targets: &'a [String], all: bool) -> FilterRule<'a> {
+        if all {
+            FilterRule::All
+        } else {
+            FilterRule::Just(targets)
+        }
+    }
+
+    fn matches(&self, target: &Target) -> bool {
+        match *self {
+            FilterRule::All => true,
+            FilterRule::Just(targets) => {
+                targets.iter().any(|x| *x == target.name())
+            },
+        }
+    }
+
+    fn is_specific(&self) -> bool {
+        match *self {
+            FilterRule::All => true,
+            FilterRule::Just(targets) => !targets.is_empty(),
+        }
+    }
+
+    pub fn try_collect(&self) -> Option<Vec<String>> {
+        match *self {
+            FilterRule::All => None,
+            FilterRule::Just(targets) => Some(targets.iter().map(|t| t.clone()).collect()),
+        }
+    }
+}
+
 impl<'a> CompileFilter<'a> {
     pub fn new(lib_only: bool,
-               bins: &'a [String],
-               tests: &'a [String],
-               examples: &'a [String],
-               benches: &'a [String]) -> CompileFilter<'a> {
-        if lib_only || !bins.is_empty() || !tests.is_empty() ||
-           !examples.is_empty() || !benches.is_empty() {
+               bins: &'a [String], all_bins: bool,
+               tsts: &'a [String], all_tsts: bool,
+               exms: &'a [String], all_exms: bool,
+               bens: &'a [String], all_bens: bool) -> CompileFilter<'a> {
+        let rule_bins = FilterRule::new(bins, all_bins);
+        let rule_tsts = FilterRule::new(tsts, all_tsts);
+        let rule_exms = FilterRule::new(exms, all_exms);
+        let rule_bens = FilterRule::new(bens, all_bens);
+
+        if lib_only || rule_bins.is_specific() || rule_tsts.is_specific()
+                    || rule_exms.is_specific() || rule_bens.is_specific() {
             CompileFilter::Only {
-                lib: lib_only, bins: bins, examples: examples, benches: benches,
-                tests: tests,
+                lib: lib_only, bins: rule_bins,
+                examples: rule_exms, benches: rule_bens,
+                tests: rule_tsts,
             }
         } else {
             CompileFilter::Everything {
@@ -324,7 +369,7 @@ impl<'a> CompileFilter<'a> {
         match *self {
             CompileFilter::Everything { .. } => true,
             CompileFilter::Only { lib, bins, examples, tests, benches } => {
-                let list = match *target.kind() {
+                let rule = match *target.kind() {
                     TargetKind::Bin => bins,
                     TargetKind::Test => tests,
                     TargetKind::Bench => benches,
@@ -333,10 +378,165 @@ impl<'a> CompileFilter<'a> {
                     TargetKind::Lib(..) => return lib,
                     TargetKind::CustomBuild => return false,
                 };
-                list.iter().any(|x| *x == target.name())
+                rule.matches(target)
             }
         }
     }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct BuildProposal<'a> {
+    target: &'a Target,
+    profile: &'a Profile,
+    required: bool,
+}
+
+fn generate_auto_targets<'a>(mode: CompileMode, targets: &'a [Target],
+                             profile: &'a Profile,
+                             dep: &'a Profile,
+                             required_features_filterable: bool) -> Vec<BuildProposal<'a>> {
+    match mode {
+        CompileMode::Bench => {
+            targets.iter().filter(|t| t.benched()).map(|t| {
+                BuildProposal {
+                    target: t,
+                    profile: profile,
+                    required: !required_features_filterable,
+                }
+            }).collect::<Vec<_>>()
+        }
+        CompileMode::Test => {
+            let mut base = targets.iter().filter(|t| {
+                t.tested()
+            }).map(|t| {
+                BuildProposal {
+                    target: t,
+                    profile: if t.is_example() {dep} else {profile},
+                    required: !required_features_filterable,
+                }
+            }).collect::<Vec<_>>();
+
+            // Always compile the library if we're testing everything as
+            // it'll be needed for doctests
+            if let Some(t) = targets.iter().find(|t| t.is_lib()) {
+                if t.doctested() {
+                    base.push(BuildProposal {
+                        target: t,
+                        profile: dep,
+                        required: !required_features_filterable,
+                    });
+                }
+            }
+            base
+        }
+        CompileMode::Build | CompileMode::Check => {
+            targets.iter().filter(|t| {
+                t.is_bin() || t.is_lib()
+            }).map(|t| BuildProposal {
+                target: t,
+                profile: profile,
+                required: !required_features_filterable,
+            }).collect()
+        }
+        CompileMode::Doc { .. } => {
+            targets.iter().filter(|t| {
+                t.documented()
+            }).map(|t| BuildProposal {
+                target: t,
+                profile: profile,
+                required: !required_features_filterable,
+            }).collect()
+        }
+        CompileMode::Doctest => {
+            if let Some(t) = targets.iter().find(|t| t.is_lib()) {
+                if t.doctested() {
+                    return vec![BuildProposal {
+                        target: t,
+                        profile: profile,
+                        required: !required_features_filterable,
+                    }];
+                }
+            }
+
+            Vec::new()
+        }
+    }
+}
+
+/// Given a filter rule and some context, propose a list of targets
+fn propose_indicated_targets<'a>(pkg: &'a Package,
+                                 rule: FilterRule,
+                                 desc: &'static str,
+                                 is_expected_kind: fn(&Target) -> bool,
+                                 profile: &'a Profile) -> CargoResult<Vec<BuildProposal<'a>>> {
+    match rule {
+        FilterRule::All => {
+            let result = pkg.targets().iter().filter(|t| is_expected_kind(t)).map(|t| {
+                BuildProposal {
+                    target: t,
+                    profile: profile,
+                    required: false,
+                }
+            });
+            return Ok(result.collect());
+        }
+        FilterRule::Just(names) => {
+            let mut targets = Vec::new();
+            for name in names {
+                let target = pkg.targets().iter().find(|t| {
+                    t.name() == *name && is_expected_kind(t)
+                });
+                let t = match target {
+                    Some(t) => t,
+                    None => {
+                        let suggestion = pkg.find_closest_target(name, is_expected_kind);
+                        match suggestion {
+                            Some(s) => {
+                                let suggested_name = s.name();
+                                bail!("no {} target named `{}`\n\nDid you mean `{}`?",
+                                      desc, name, suggested_name)
+                            }
+                            None => bail!("no {} target named `{}`", desc, name),
+                        }
+                    }
+                };
+                debug!("found {} `{}`", desc, name);
+                targets.push(BuildProposal {
+                    target: t,
+                    profile: profile,
+                    required: true,
+                });
+            }
+            return Ok(targets);
+        }
+    }
+}
+
+/// Collect the targets that are libraries or have all required features available.
+fn filter_compatible_targets<'a>(mut proposals: Vec<BuildProposal<'a>>,
+                                 features: &HashSet<String>)
+        -> CargoResult<Vec<(&'a Target, &'a Profile)>> {
+    let mut compatible = Vec::with_capacity(proposals.len());
+    for proposal in proposals.drain(..) {
+        let unavailable_features = match proposal.target.required_features() {
+            Some(rf) => rf.iter().filter(|f| !features.contains(*f)).collect(),
+            None => Vec::new(),
+        };
+        if proposal.target.is_lib() || unavailable_features.is_empty() {
+            compatible.push((proposal.target, proposal.profile));
+        } else if proposal.required {
+            let required_features = proposal.target.required_features().unwrap();
+            let quoted_required_features: Vec<String> = required_features.iter()
+                                                                         .map(|s| format!("`{}`",s))
+                                                                         .collect();
+            bail!("target `{}` requires the features: {}\n\
+                  Consider enabling them by passing e.g. `--features=\"{}\"`",
+                  proposal.target.name(),
+                  quoted_required_features.join(", "),
+                  required_features.join(" "));
+        }
+    }
+    Ok(compatible)
 }
 
 /// Given the configuration for a build, this function will generate all
@@ -358,133 +558,44 @@ fn generate_targets<'a>(pkg: &'a Package,
         CompileMode::Doc { .. } => &profiles.doc,
         CompileMode::Doctest => &profiles.doctest,
     };
-    let mut targets = match *filter {
-        CompileFilter::Everything { .. } => {
-            match mode {
-                CompileMode::Bench => {
-                    pkg.targets().iter().filter(|t| t.benched()).map(|t| {
-                        (t, profile)
-                    }).collect::<Vec<_>>()
-                }
-                CompileMode::Test => {
-                    let deps = if release {
-                        &profiles.bench_deps
-                    } else {
-                        &profiles.test_deps
-                    };
-                    let mut base = pkg.targets().iter().filter(|t| {
-                        t.tested()
-                    }).map(|t| {
-                        (t, if t.is_example() {deps} else {profile})
-                    }).collect::<Vec<_>>();
 
-                    // Always compile the library if we're testing everything as
-                    // it'll be needed for doctests
-                    if let Some(t) = pkg.targets().iter().find(|t| t.is_lib()) {
-                        if t.doctested() {
-                            base.push((t, deps));
-                        }
-                    }
-                    base
-                }
-                CompileMode::Build | CompileMode::Check => {
-                    pkg.targets().iter().filter(|t| {
-                        t.is_bin() || t.is_lib()
-                    }).map(|t| (t, profile)).collect()
-                }
-                CompileMode::Doc { .. } => {
-                    pkg.targets().iter().filter(|t| t.documented())
-                       .map(|t| (t, profile)).collect()
-                }
-                CompileMode::Doctest => {
-                    if let Some(t) = pkg.targets().iter().find(|t| t.is_lib()) {
-                        if t.doctested() {
-                            return Ok(vec![(t, profile)])
-                        }
-                    }
-
-                    Vec::new()
-                }
-            }
+    let targets = match *filter {
+        CompileFilter::Everything { required_features_filterable } => {
+            let deps = if release {
+                &profiles.bench_deps
+            } else {
+                &profiles.test_deps
+            };
+            generate_auto_targets(mode, pkg.targets(), profile, deps, required_features_filterable)
         }
         CompileFilter::Only { lib, bins, examples, tests, benches } => {
             let mut targets = Vec::new();
 
             if lib {
                 if let Some(t) = pkg.targets().iter().find(|t| t.is_lib()) {
-                    targets.push((t, profile));
+                    targets.push(BuildProposal {
+                        target: t,
+                        profile: profile,
+                        required: true,
+                    });
                 } else {
                     bail!("no library targets found")
                 }
             }
 
-            {
-                let mut find = |names: &[String],
-                                desc,
-                                is_expected_kind: fn(&Target) -> bool,
-                                profile| {
-                    for name in names {
-                        let target = pkg.targets().iter().find(|t| {
-                            t.name() == *name && is_expected_kind(t)
-                        });
-                        let t = match target {
-                            Some(t) => t,
-                            None => {
-                                let suggestion = pkg.find_closest_target(name, is_expected_kind);
-                                match suggestion {
-                                    Some(s) => {
-                                        let suggested_name = s.name();
-                                        bail!("no {} target named `{}`\n\nDid you mean `{}`?",
-                                              desc, name, suggested_name)
-                                    }
-                                    None => bail!("no {} target named `{}`", desc, name),
-                                }
-                            }
-                        };
-                        debug!("found {} `{}`", desc, name);
-
-                        targets.push((t, profile));
-                    }
-                    Ok(())
-                };
-                find(bins, "bin", Target::is_bin, profile)?;
-                find(examples, "example", Target::is_example, build)?;
-                find(tests, "test", Target::is_test, test)?;
-                find(benches, "bench", Target::is_bench, &profiles.bench)?;
-            }
+            targets.append(&mut propose_indicated_targets(
+                pkg, bins, "bin", Target::is_bin, profile)?);
+            targets.append(&mut propose_indicated_targets(
+                pkg, examples, "example", Target::is_example, build)?);
+            targets.append(&mut propose_indicated_targets(
+                pkg, tests, "test", Target::is_test, test)?);
+            targets.append(&mut propose_indicated_targets(
+                pkg, benches, "bench", Target::is_bench, &profiles.bench)?);
             targets
         }
     };
 
-    //Collect the targets that are libraries or have all required features available.
-    let mut compatible_targets = Vec::with_capacity(targets.len());
-    for (target, profile) in targets.drain(0..) {
-        if target.is_lib() || match target.required_features() {
-            Some(f) => f.iter().all(|f| features.contains(f)),
-            None => true,
-        } {
-            compatible_targets.push((target, profile));
-            continue;
-        }
-
-        if match *filter {
-            CompileFilter::Everything { required_features_filterable } =>
-                !required_features_filterable,
-            CompileFilter::Only { .. } => true,
-        } {
-            let required_features = target.required_features().unwrap();
-            let quoted_required_features: Vec<String> = required_features.iter()
-                                                                         .map(|s| format!("`{}`",s))
-                                                                         .collect();
-            bail!("target `{}` requires the features: {}\n\
-                  Consider enabling them by passing e.g. `--features=\"{}\"`",
-                  target.name(),
-                  quoted_required_features.join(", "),
-                  required_features.join(" "));
-        }
-    }
-
-    Ok(compatible_targets)
+    filter_compatible_targets(targets, features)
 }
 
 /// Parse all config files to learn about build configuration. Currently

--- a/src/cargo/ops/cargo_install.rs
+++ b/src/cargo/ops/cargo_install.rs
@@ -388,7 +388,8 @@ fn find_duplicates(dst: &Path,
                    pkg: &Package,
                    filter: &ops::CompileFilter,
                    prev: &CrateListingV1) -> BTreeMap<String, Option<PackageId>> {
-    let check = |name| {
+    let check = |name: String| {
+        // Need to provide type, works around Rust Issue #93349
         let name = format!("{}{}", name, env::consts::EXE_SUFFIX);
         if fs::metadata(dst.join(&name)).is_err() {
             None
@@ -402,13 +403,24 @@ fn find_duplicates(dst: &Path,
         CompileFilter::Everything { .. } => {
             pkg.targets().iter()
                          .filter(|t| t.is_bin())
-                         .filter_map(|t| check(t.name()))
+                         .filter_map(|t| check(t.name().to_string()))
                          .collect()
         }
         CompileFilter::Only { bins, examples, .. } => {
-            bins.iter().chain(examples)
-                       .filter_map(|t| check(t))
-                       .collect()
+            let all_bins: Vec<String> = bins.try_collect().unwrap_or_else(|| {
+                pkg.targets().iter().filter(|t| t.is_bin())
+                                    .map(|t| t.name().to_string())
+                                    .collect()
+            });
+            let all_examples: Vec<String> = examples.try_collect().unwrap_or_else(|| {
+                pkg.targets().iter().filter(|t| t.is_bin_example())
+                                    .map(|t| t.name().to_string())
+                                    .collect()
+            });
+
+            all_bins.iter().chain(all_examples.iter())
+                           .filter_map(|t| check(t.clone()))
+                           .collect::<BTreeMap<String, Option<PackageId>>>()
         }
     }
 }

--- a/src/cargo/ops/cargo_install.rs
+++ b/src/cargo/ops/cargo_install.rs
@@ -358,7 +358,7 @@ fn check_overwrites(dst: &Path,
                     filter: &ops::CompileFilter,
                     prev: &CrateListingV1,
                     force: bool) -> CargoResult<BTreeMap<String, Option<PackageId>>> {
-    if let CompileFilter::Everything { .. } = *filter {
+    if !filter.is_specific() {
         // If explicit --bin or --example flags were passed then those'll
         // get checked during cargo_compile, we only care about the "build
         // everything" case here

--- a/src/cargo/ops/cargo_run.rs
+++ b/src/cargo/ops/cargo_run.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use ops::{self, CompileFilter, Packages};
+use ops::{self, Packages};
 use util::{self, human, CargoResult, ProcessError};
 use core::Workspace;
 
@@ -23,32 +23,27 @@ pub fn run(ws: &Workspace,
     };
 
     let mut bins = pkg.manifest().targets().iter().filter(|a| {
-        !a.is_lib() && !a.is_custom_build() && match options.filter {
-            CompileFilter::Everything { .. } => a.is_bin(),
-            CompileFilter::Only { .. } => options.filter.matches(a),
+        !a.is_lib() && !a.is_custom_build() && if !options.filter.is_specific() {
+            a.is_bin()
+        } else {
+            options.filter.matches(a)
         }
     });
     if bins.next().is_none() {
-        match options.filter {
-            CompileFilter::Everything { .. } => {
-                bail!("a bin target must be available for `cargo run`")
-            }
-            CompileFilter::Only { .. } => {
-                // this will be verified in cargo_compile
-            }
+        if !options.filter.is_specific() {
+            bail!("a bin target must be available for `cargo run`")
+        } else {
+            // this will be verified in cargo_compile
         }
     }
     if bins.next().is_some() {
-        match options.filter {
-            CompileFilter::Everything { .. } => {
-                bail!("`cargo run` requires that a project only have one \
-                       executable; use the `--bin` option to specify which one \
-                       to run")
-            }
-            CompileFilter::Only { .. } => {
-                bail!("`cargo run` can run at most one executable, but \
-                       multiple were specified")
-            }
+        if !options.filter.is_specific() {
+            bail!("`cargo run` requires that a project only have one \
+                   executable; use the `--bin` option to specify which one \
+                   to run")
+        } else {
+            bail!("`cargo run` can run at most one executable, but \
+                   multiple were specified")
         }
     }
 

--- a/src/cargo/ops/cargo_test.rs
+++ b/src/cargo/ops/cargo_test.rs
@@ -20,6 +20,7 @@ pub fn run_tests(ws: &Workspace,
         return Ok(None)
     }
     let (test, mut errors) = if options.only_doc {
+        assert!(options.compile_opts.filter.is_specific());
         run_doc_tests(options, test_args, &compilation)?
     } else {
         run_unit_tests(options, test_args, &compilation)?
@@ -32,7 +33,7 @@ pub fn run_tests(ws: &Workspace,
 
     // If a specific test was requested or we're not running any tests at all,
     // don't run any doc tests.
-    if let ops::CompileFilter::Only { .. } = options.compile_opts.filter {
+    if options.compile_opts.filter.is_specific() {
         match errors.len() {
             0 => return Ok(None),
             _ => return Ok(Some(CargoTestError::new(test, errors)))

--- a/tests/bench.rs
+++ b/tests/bench.rs
@@ -54,6 +54,88 @@ test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured
 }
 
 #[test]
+fn bench_bench_implicit() {
+    if !is_nightly() { return }
+
+    let prj = project("foo")
+        .file("Cargo.toml" , r#"
+            [package]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+        "#)
+        .file("src/main.rs", r#"
+            #![feature(test)]
+            extern crate test;
+            #[bench] fn run1(_ben: &mut test::Bencher) { }
+            fn main() { println!("Hello main!"); }"#)
+        .file("tests/other.rs", r#"
+            #![feature(test)]
+            extern crate test;
+            #[bench] fn run3(_ben: &mut test::Bencher) { }"#)
+        .file("benches/mybench.rs", r#"
+            #![feature(test)]
+            extern crate test;
+            #[bench] fn run2(_ben: &mut test::Bencher) { }"#);
+
+    assert_that(prj.cargo_process("bench").arg("--benches"),
+        execs().with_status(0)
+               .with_stderr(format!("\
+[COMPILING] foo v0.0.1 ({dir})
+[FINISHED] release [optimized] target(s) in [..]
+[RUNNING] target[/]release[/]deps[/]mybench-[..][EXE]
+", dir = prj.url()))
+               .with_stdout("
+running 1 test
+test run2 ... bench: [..] 0 ns/iter (+/- 0)
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured
+
+"));
+}
+
+#[test]
+fn bench_bin_implicit() {
+    if !is_nightly() { return }
+
+    let prj = project("foo")
+        .file("Cargo.toml" , r#"
+            [package]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+        "#)
+        .file("src/main.rs", r#"
+            #![feature(test)]
+            extern crate test;
+            #[bench] fn run1(_ben: &mut test::Bencher) { }
+            fn main() { println!("Hello main!"); }"#)
+        .file("tests/other.rs", r#"
+            #![feature(test)]
+            extern crate test;
+            #[bench] fn run3(_ben: &mut test::Bencher) { }"#)
+        .file("benches/mybench.rs", r#"
+            #![feature(test)]
+            extern crate test;
+            #[bench] fn run2(_ben: &mut test::Bencher) { }"#);
+
+    assert_that(prj.cargo_process("bench").arg("--bins"),
+        execs().with_status(0)
+               .with_stderr(format!("\
+[COMPILING] foo v0.0.1 ({dir})
+[FINISHED] release [optimized] target(s) in [..]
+[RUNNING] target[/]release[/]deps[/]foo-[..][EXE]
+", dir = prj.url()))
+               .with_stdout("
+running 1 test
+test run1 ... bench: [..] 0 ns/iter (+/- 0)
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured
+
+"));
+}
+
+#[test]
 fn bench_tarname() {
     if !is_nightly() { return }
 

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -2216,6 +2216,54 @@ fn filtering() {
 }
 
 #[test]
+fn filtering_implicit_bins() {
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [package]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+        "#)
+        .file("src/lib.rs", "")
+        .file("src/bin/a.rs", "fn main() {}")
+        .file("src/bin/b.rs", "fn main() {}")
+        .file("examples/a.rs", "fn main() {}")
+        .file("examples/b.rs", "fn main() {}");
+    p.build();
+
+    assert_that(p.cargo("build").arg("--bins"),
+                execs().with_status(0));
+    assert_that(&p.bin("a"), existing_file());
+    assert_that(&p.bin("b"), existing_file());
+    assert_that(&p.bin("examples/a"), is_not(existing_file()));
+    assert_that(&p.bin("examples/b"), is_not(existing_file()));
+}
+
+#[test]
+fn filtering_implicit_examples() {
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [package]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+        "#)
+        .file("src/lib.rs", "")
+        .file("src/bin/a.rs", "fn main() {}")
+        .file("src/bin/b.rs", "fn main() {}")
+        .file("examples/a.rs", "fn main() {}")
+        .file("examples/b.rs", "fn main() {}");
+    p.build();
+
+    assert_that(p.cargo("build").arg("--examples"),
+                execs().with_status(0));
+    assert_that(&p.bin("a"), is_not(existing_file()));
+    assert_that(&p.bin("b"), is_not(existing_file()));
+    assert_that(&p.bin("examples/a"), existing_file());
+    assert_that(&p.bin("examples/b"), existing_file());
+}
+
+#[test]
 fn ignore_dotfile() {
     let p = project("foo")
         .file("Cargo.toml", r#"

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1253,6 +1253,41 @@ test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
 }
 
 #[test]
+fn test_run_implicit_bin_target() {
+    let prj = project("foo")
+        .file("Cargo.toml" , r#"
+            [package]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+
+            [[bin]]
+            name="mybin"
+            path="src/mybin.rs"
+        "#)
+        .file("src/mybin.rs", "#[test] fn test_in_bin() { }
+               fn main() { panic!(\"Don't execute me!\"); }")
+        .file("tests/mytest.rs", "#[test] fn test_in_test() { }")
+        .file("benches/mybench.rs", "#[test] fn test_in_bench() { }")
+        .file("examples/myexm.rs", "#[test] fn test_in_exm() { }
+               fn main() { panic!(\"Don't execute me!\"); }");
+
+    assert_that(prj.cargo_process("test").arg("--bins"),
+                execs().with_status(0)
+                       .with_stderr(format!("\
+[COMPILING] foo v0.0.1 ({dir})
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[RUNNING] target[/]debug[/]deps[/]mybin-[..][EXE]", dir = prj.url()))
+                       .with_stdout("
+running 1 test
+test test_in_bin ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
+
+"));
+}
+
+#[test]
 fn test_run_specific_test_target() {
     let prj = project("foo")
         .file("Cargo.toml" , r#"
@@ -1279,6 +1314,103 @@ test test_b ... ok
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
 
 "));
+}
+
+#[test]
+fn test_run_implicit_test_target() {
+    let prj = project("foo")
+        .file("Cargo.toml" , r#"
+            [package]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+
+            [[bin]]
+            name="mybin"
+            path="src/mybin.rs"
+        "#)
+        .file("src/mybin.rs", "#[test] fn test_in_bin() { }
+               fn main() { panic!(\"Don't execute me!\"); }")
+        .file("tests/mytest.rs", "#[test] fn test_in_test() { }")
+        .file("benches/mybench.rs", "#[test] fn test_in_bench() { }")
+        .file("examples/myexm.rs", "#[test] fn test_in_exm() { }
+               fn main() { panic!(\"Don't execute me!\"); }");
+
+    assert_that(prj.cargo_process("test").arg("--tests"),
+                execs().with_status(0)
+                       .with_stderr(format!("\
+[COMPILING] foo v0.0.1 ({dir})
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[RUNNING] target[/]debug[/]deps[/]mytest-[..][EXE]", dir = prj.url()))
+                       .with_stdout("
+running 1 test
+test test_in_test ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
+
+"));
+}
+
+#[test]
+fn test_run_implicit_bench_target() {
+    let prj = project("foo")
+        .file("Cargo.toml" , r#"
+            [package]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+
+            [[bin]]
+            name="mybin"
+            path="src/mybin.rs"
+        "#)
+        .file("src/mybin.rs", "#[test] fn test_in_bin() { }
+               fn main() { panic!(\"Don't execute me!\"); }")
+        .file("tests/mytest.rs", "#[test] fn test_in_test() { }")
+        .file("benches/mybench.rs", "#[test] fn test_in_bench() { }")
+        .file("examples/myexm.rs", "#[test] fn test_in_exm() { }
+               fn main() { panic!(\"Don't execute me!\"); }");
+
+    assert_that(prj.cargo_process("test").arg("--benches"),
+                execs().with_status(0)
+                       .with_stderr(format!("\
+[COMPILING] foo v0.0.1 ({dir})
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[RUNNING] target[/]debug[/]deps[/]mybench-[..][EXE]", dir = prj.url()))
+                       .with_stdout("
+running 1 test
+test test_in_bench ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
+
+"));
+}
+
+#[test]
+fn test_run_implicit_example_target() {
+    let prj = project("foo")
+        .file("Cargo.toml" , r#"
+            [package]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+
+            [[bin]]
+            name="mybin"
+            path="src/mybin.rs"
+        "#)
+        .file("src/mybin.rs", "#[test] fn test_in_bin() { }
+               fn main() { panic!(\"Don't execute me!\"); }")
+        .file("tests/mytest.rs", "#[test] fn test_in_test() { }")
+        .file("benches/mybench.rs", "#[test] fn test_in_bench() { }")
+        .file("examples/myexm.rs", "#[test] fn test_in_exm() { }
+               fn main() { panic!(\"Don't execute me!\"); }");
+
+    assert_that(prj.cargo_process("test").arg("--examples"),
+                execs().with_status(0)
+                       .with_stderr(format!("\
+[COMPILING] foo v0.0.1 ({dir})
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]", dir = prj.url())));
 }
 
 #[test]


### PR DESCRIPTION
This implements #3112.

This means all of the following commands are now possible and meaningful:
```
cargo build --all-bins
cargo build --all-tests
cargo test --all-tests
cargo test --all-bins
cargo check --all-bins --all-examples --all-tests --all-benches
```

The commits try to represent the incremental "propagation" of the new feature:
- core functionality (`cargo check --lib` passes)
- CLI suport (`cargo build` passes)
- additional tests (`cargo test` covers new functionality)

Note that `--all` is already reserved to mean "all packages of the workspace", so it can't be used to mean `--all-bins --all-examples --all-tests --all-benches`.

I intend to follow this up by some other PRs, so please do tell me where I could improve.