### PR TITLE
Indicate that --lib is default for new, init.

### DIFF
--- a/src/bin/init.rs
+++ b/src/bin/init.rs
@@ -30,7 +30,7 @@ Options:
                         control system (git or hg) or do not initialize any version
                         control at all (none) overriding a global configuration.
     --bin               Use a binary (application) template
-    --lib               Use a library template
+    --lib               Use a library template [default]
     --name NAME         Set the resulting package name
     -v, --verbose ...   Use verbose output (-vv very verbose/build.rs output)
     -q, --quiet         No output printed to stdout

--- a/src/bin/new.rs
+++ b/src/bin/new.rs
@@ -30,7 +30,7 @@ Options:
                         control system (git, hg, or pijul) or do not initialize any version
                         control at all (none) overriding a global configuration.
     --bin               Use a binary (application) template
-    --lib               Use a library template
+    --lib               Use a library template [default]
     --name NAME         Set the resulting package name, defaults to the value of <path>
     -v, --verbose ...   Use verbose output (-vv very verbose/build.rs output)
     -q, --quiet         No output printed to stdout


### PR DESCRIPTION
I often forget for a moment which is the default behavior: `--bin` or `--lib`. This makes it clear in the usage text.