### PR TITLE
add `overflow-checks` field to profiles

### DIFF
--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -145,6 +145,7 @@ pub struct Profile {
     pub rustdoc_args: Option<Vec<String>>,
     pub debuginfo: Option<u32>,
     pub debug_assertions: bool,
+    pub overflow_checks: bool,
     #[serde(skip_serializing)]
     pub rpath: bool,
     pub test: bool,
@@ -528,6 +529,7 @@ impl Profile {
         Profile {
             debuginfo: Some(2),
             debug_assertions: true,
+            overflow_checks: true,
             ..Profile::default()
         }
     }
@@ -594,6 +596,7 @@ impl Default for Profile {
             rustdoc_args: None,
             debuginfo: None,
             debug_assertions: false,
+            overflow_checks: false,
             rpath: false,
             test: false,
             doc: false,

--- a/src/cargo/util/toml.rs
+++ b/src/cargo/util/toml.rs
@@ -371,6 +371,8 @@ pub struct TomlProfile {
     debug_assertions: Option<bool>,
     rpath: Option<bool>,
     panic: Option<String>,
+    #[serde(rename = "overflow-checks")]
+    overflow_checks: Option<bool>,
 }
 
 #[derive(Clone, Debug)]
@@ -1469,7 +1471,7 @@ fn build_profiles(profiles: &Option<TomlProfiles>) -> Profiles {
     fn merge(profile: Profile, toml: Option<&TomlProfile>) -> Profile {
         let &TomlProfile {
             ref opt_level, lto, codegen_units, ref debug, debug_assertions, rpath,
-            ref panic
+            ref panic, ref overflow_checks,
         } = match toml {
             Some(toml) => toml,
             None => return profile,
@@ -1488,6 +1490,7 @@ fn build_profiles(profiles: &Option<TomlProfiles>) -> Profiles {
             rustdoc_args: None,
             debuginfo: debug.unwrap_or(profile.debuginfo),
             debug_assertions: debug_assertions.unwrap_or(profile.debug_assertions),
+            overflow_checks: overflow_checks.unwrap_or(profile.overflow_checks),
             rpath: rpath.unwrap_or(profile.rpath),
             test: profile.test,
             doc: profile.doc,

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -2535,6 +2535,7 @@ fn compiler_json_error_format() {
             "debug_assertions": true,
             "debuginfo": 2,
             "opt_level": "0",
+            "overflow_checks": true,
             "test": false
         },
         "features": [],
@@ -2574,6 +2575,7 @@ fn compiler_json_error_format() {
             "debug_assertions": true,
             "debuginfo": 2,
             "opt_level": "0",
+            "overflow_checks": true,
             "test": false
         },
         "features": [],
@@ -2593,6 +2595,7 @@ fn compiler_json_error_format() {
             "debug_assertions": true,
             "debuginfo": 2,
             "opt_level": "0",
+            "overflow_checks": true,
             "test": false
         },
         "features": [],
@@ -2620,6 +2623,7 @@ fn compiler_json_error_format() {
             "debug_assertions": true,
             "debuginfo": 2,
             "opt_level": "0",
+            "overflow_checks": true,
             "test": false
         },
         "features": [],
@@ -2679,6 +2683,7 @@ fn message_format_json_forward_stderr() {
             "debug_assertions":true,
             "debuginfo":2,
             "opt_level":"0",
+            "overflow_checks": true,
             "test":false
         },
         "features":[],


### PR DESCRIPTION
...and pass `-C overflow-checks` to the compiler when necessary.

Fixes #2262.