### PR TITLE
Improve "dirty" error message

### DIFF
--- a/src/cargo/ops/cargo_package.rs
+++ b/src/cargo/ops/cargo_package.rs
@@ -173,7 +173,8 @@ fn check_not_dirty(p: &Package, src: &PathSource) -> CargoResult<()> {
         if dirty.is_empty() {
             Ok(())
         } else {
-            bail!("{} dirty files found in the working directory:\n\n{}\n\n\
+            bail!("{} files in the working directory contain changes that were \
+                   not yet committed into git:\n\n{}\n\n\
                    to proceed despite this, pass the `--allow-dirty` flag",
                   dirty.len(), dirty.join("\n"))
         }

--- a/tests/package.rs
+++ b/tests/package.rs
@@ -580,7 +580,8 @@ fn do_not_package_if_repository_is_dirty() {
     assert_that(p.cargo("package"),
                 execs().with_status(101)
                        .with_stderr("\
-error: 1 dirty files found in the working directory:
+error: 1 files in the working directory contain changes that were not yet \
+committed into git:
 
 Cargo.toml
 

--- a/tests/publish.rs
+++ b/tests/publish.rs
@@ -207,7 +207,8 @@ fn dont_publish_dirty() {
                  .arg("--host").arg(registry().to_string()),
                 execs().with_status(101).with_stderr("\
 [UPDATING] registry `[..]`
-error: 1 dirty files found in the working directory:
+error: 1 files in the working directory contain changes that were not yet \
+committed into git:
 
 bar
 


### PR DESCRIPTION
Improve the error message stating the working directory has dirty files (files not yet committed).

Fix #3876.