### PR TITLE
Relax overly strict asserts in dependency queue

### DIFF
--- a/src/cargo/util/dependency_queue.rs
+++ b/src/cargo/util/dependency_queue.rs
@@ -83,10 +83,10 @@ impl<K: Hash + Eq + Clone, V> DependencyQueue<K, V> {
 
         let mut my_dependencies = HashSet::new();
         for dep in dependencies {
-            assert!(my_dependencies.insert(dep.clone()));
+            my_dependencies.insert(dep.clone());
             let rev = self.reverse_dep_map.entry(dep.clone())
                                           .or_insert_with(HashSet::new);
-            assert!(rev.insert(key.clone()));
+            rev.insert(key.clone());
         }
         &mut slot.insert((my_dependencies, value)).1
     }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -3005,3 +3005,25 @@ test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
 "));
 
 }
+
+#[test]
+fn cyclic_dev() {
+   let p = project("foo")
+        .file("Cargo.toml", r#"
+            [project]
+            name = "foo"
+            version = "0.1.0"
+
+            [dev-dependencies]
+            foo = { path = "." }
+        "#)
+        .file("src/lib.rs", r#"
+            #[test] fn test_lib() {}
+        "#)
+        .file("tests/foo.rs", r#"
+            extern crate foo;
+        "#);
+
+    assert_that(p.cargo_process("test").arg("--all"),
+                execs().with_status(0));
+}


### PR DESCRIPTION
Don't actually need to assert that these are unique, it works both ways and we
can have flavorful dependency graphs which otherwise trigger the assertions.

Closes #3902