### PR TITLE
Adjust submodule updating failure reporting

### DIFF
--- a/src/cargo/sources/git/utils.rs
+++ b/src/cargo/sources/git/utils.rs
@@ -295,7 +295,7 @@ impl<'a> GitCheckout<'a> {
 
             for mut child in repo.submodules()?.into_iter() {
                 update_submodule(repo, &mut child, cargo_config).chain_error(|| {
-                    human(format!("Failed to update submodule `{}`",
+                    human(format!("failed to update submodule `{}`",
                                   child.name().unwrap_or("")))
                 })?;
             }

--- a/src/cargo/sources/git/utils.rs
+++ b/src/cargo/sources/git/utils.rs
@@ -296,52 +296,60 @@ impl<'a> GitCheckout<'a> {
             info!("update submodules for: {:?}", repo.workdir().unwrap());
 
             for mut child in repo.submodules()?.into_iter() {
-                child.init(false)?;
-                let url = child.url().chain_error(|| {
-                    internal("non-utf8 url for submodule")
-                })?;
-
-                // A submodule which is listed in .gitmodules but not actually
-                // checked out will not have a head id, so we should ignore it.
-                let head = match child.head_id() {
-                    Some(head) => head,
-                    None => continue,
-                };
-
-                // If the submodule hasn't been checked out yet, we need to
-                // clone it. If it has been checked out and the head is the same
-                // as the submodule's head, then we can bail out and go to the
-                // next submodule.
-                let head_and_repo = child.open().and_then(|repo| {
-                    let target = repo.head()?.target();
-                    Ok((target, repo))
-                });
-                let repo = match head_and_repo {
-                    Ok((head, repo)) => {
-                        if child.head_id() == head {
-                            continue
-                        }
-                        repo
-                    }
-                    Err(..) => {
-                        let path = repo.workdir().unwrap().join(child.path());
-                        let _ = fs::remove_dir_all(&path);
-                        git2::Repository::clone(url, &path)?
-                    }
-                };
-
-                // Fetch data from origin and reset to the head commit
-                let refspec = "refs/heads/*:refs/heads/*";
-                fetch(&repo, url, refspec, cargo_config).chain_error(|| {
-                    internal(format!("failed to fetch submodule `{}` from {}",
-                                     child.name().unwrap_or(""), url))
-                })?;
-
-                let obj = repo.find_object(head, None)?;
-                repo.reset(&obj, git2::ResetType::Hard, None)?;
-                update_submodules(&repo, cargo_config)?;
+                update_submodule(repo, &mut child, cargo_config).chain_error(||
+                    internal(
+                        format!("failed to update submodule `{}`",
+                            child.name().unwrap_or("")))
+                    )?;
             }
             Ok(())
+        }
+
+        fn update_submodule(parent: &git2::Repository, child: &mut git2::Submodule, cargo_config: &Config) -> CargoResult<()> {
+            child.init(false)?;
+            let url = child.url().chain_error(|| {
+                internal("non-utf8 url for submodule")
+            })?;
+
+            // A submodule which is listed in .gitmodules but not actually
+            // checked out will not have a head id, so we should ignore it.
+            let head = match child.head_id() {
+                Some(head) => head,
+                None => return Ok(()),
+            };
+
+            // If the submodule hasn't been checked out yet, we need to
+            // clone it. If it has been checked out and the head is the same
+            // as the submodule's head, then we can bail out and go to the
+            // next submodule.
+            let head_and_repo = child.open().and_then(|repo| {
+                let target = repo.head()?.target();
+                Ok((target, repo))
+            });
+            let repo = match head_and_repo {
+                Ok((head, repo)) => {
+                    if child.head_id() == head {
+                        return Ok(())
+                    }
+                    repo
+                }
+                Err(..) => {
+                    let path = parent.workdir().unwrap().join(child.path());
+                    let _ = fs::remove_dir_all(&path);
+                    git2::Repository::clone(url, &path)?
+                }
+            };
+
+            // Fetch data from origin and reset to the head commit
+            let refspec = "refs/heads/*:refs/heads/*";
+            fetch(&repo, url, refspec, cargo_config).chain_error(|| {
+                internal(format!("failed to fetch submodule `{}` from {}",
+                                 child.name().unwrap_or(""), url))
+            })?;
+
+            let obj = repo.find_object(head, None)?;
+            repo.reset(&obj, git2::ResetType::Hard, None)?;
+            update_submodules(&repo, cargo_config)
         }
     }
 }

--- a/src/cargo/sources/git/utils.rs
+++ b/src/cargo/sources/git/utils.rs
@@ -294,16 +294,17 @@ impl<'a> GitCheckout<'a> {
             info!("update submodules for: {:?}", repo.workdir().unwrap());
 
             for mut child in repo.submodules()?.into_iter() {
-                update_submodule(repo, &mut child, cargo_config).chain_error(||
-                    human(
-                        format!("Failed to update submodule `{}`",
-                            child.name().unwrap_or("")))
-                    )?;
+                update_submodule(repo, &mut child, cargo_config).chain_error(|| {
+                    human(format!("Failed to update submodule `{}`",
+                                  child.name().unwrap_or("")))
+                })?;
             }
             Ok(())
         }
 
-        fn update_submodule(parent: &git2::Repository, child: &mut git2::Submodule, cargo_config: &Config) -> CargoResult<()> {
+        fn update_submodule(parent: &git2::Repository,
+                            child: &mut git2::Submodule,
+                            cargo_config: &Config) -> CargoResult<()> {
             child.init(false)?;
             let url = child.url().chain_error(|| {
                 internal("non-utf8 url for submodule")

--- a/src/cargo/sources/git/utils.rs
+++ b/src/cargo/sources/git/utils.rs
@@ -156,9 +156,7 @@ impl GitDatabase {
             }
             Err(..) => GitCheckout::clone_into(dest, self, rev)?,
         };
-        checkout.update_submodules(cargo_config).chain_error(|| {
-            internal("failed to update submodules")
-        })?;
+        checkout.update_submodules(cargo_config)?;
         Ok(checkout)
     }
 
@@ -297,8 +295,8 @@ impl<'a> GitCheckout<'a> {
 
             for mut child in repo.submodules()?.into_iter() {
                 update_submodule(repo, &mut child, cargo_config).chain_error(||
-                    internal(
-                        format!("failed to update submodule `{}`",
+                    human(
+                        format!("Failed to update submodule `{}`",
                             child.name().unwrap_or("")))
                     )?;
             }

--- a/tests/git.rs
+++ b/tests/git.rs
@@ -796,17 +796,18 @@ fn dep_with_bad_submodule() {
             pub fn foo() { dep1::dep() }
         ");
 
-    assert_that(project.cargo_process("build").arg("--verbose"),
+    assert_that(project.cargo_process("build"),
                 execs().with_stderr(format!("\
 [UPDATING] git repository [..]
 [ERROR] failed to load source for a dependency on `dep1`
 
 Caused by:
-  Failed to update submodules of [..]
+  Unable to update {}
 
 Caused by:
-  [9/-3] object not found - no match for id ({})
-", original_submodule_ref)).with_status(101));
+  Failed to update submodule `src`
+
+To learn more, run the command again with --verbose.\n", path2url(git_project.root()))).with_status(101));
 }
 
 #[test]

--- a/tests/git.rs
+++ b/tests/git.rs
@@ -777,7 +777,13 @@ fn dep_with_bad_submodule() {
     let repo = git2::Repository::open(&git_project2.root()).unwrap();
     let original_submodule_ref = repo.refname_to_id("refs/heads/master").unwrap();
     let commit = repo.find_commit(original_submodule_ref).unwrap();
-    commit.amend(Some("refs/heads/master"), None, None, None, Some("something something"), None).unwrap();
+    commit.amend(
+        Some("refs/heads/master"),
+        None,
+        None,
+        None,
+        Some("something something"),
+        None).unwrap();
 
     let project = project
         .file("Cargo.toml", &format!(r#"
@@ -796,8 +802,7 @@ fn dep_with_bad_submodule() {
             pub fn foo() { dep1::dep() }
         ");
 
-    assert_that(project.cargo_process("build"),
-                execs().with_stderr(format!("\
+    let expected = format!("\
 [UPDATING] git repository [..]
 [ERROR] failed to load source for a dependency on `dep1`
 
@@ -807,7 +812,10 @@ Caused by:
 Caused by:
   Failed to update submodule `src`
 
-To learn more, run the command again with --verbose.\n", path2url(git_project.root()))).with_status(101));
+To learn more, run the command again with --verbose.\n", path2url(git_project.root()));
+
+    assert_that(project.cargo_process("build"),
+                execs().with_stderr(expected).with_status(101));
 }
 
 #[test]

--- a/tests/git.rs
+++ b/tests/git.rs
@@ -810,7 +810,7 @@ Caused by:
   Unable to update {}
 
 Caused by:
-  Failed to update submodule `src`
+  failed to update submodule `src`
 
 To learn more, run the command again with --verbose.\n", path2url(git_project.root()));
 

--- a/tests/git.rs
+++ b/tests/git.rs
@@ -752,6 +752,64 @@ fn dep_with_submodule() {
 }
 
 #[test]
+fn dep_with_bad_submodule() {
+    let project = project("foo");
+    let git_project = git::new("dep1", |project| {
+        project
+            .file("Cargo.toml", r#"
+                [package]
+                name = "dep1"
+                version = "0.5.0"
+                authors = ["carlhuda@example.com"]
+            "#)
+    }).unwrap();
+    let git_project2 = git::new("dep2", |project| {
+        project.file("lib.rs", "pub fn dep() {}")
+    }).unwrap();
+
+    let repo = git2::Repository::open(&git_project.root()).unwrap();
+    let url = path2url(git_project2.root()).to_string();
+    git::add_submodule(&repo, &url, Path::new("src"));
+    git::commit(&repo);
+
+    // now amend the first commit on git_project2 to make submodule ref point to not-found
+    // commit
+    let repo = git2::Repository::open(&git_project2.root()).unwrap();
+    let original_submodule_ref = repo.refname_to_id("refs/heads/master").unwrap();
+    let commit = repo.find_commit(original_submodule_ref).unwrap();
+    commit.amend(Some("refs/heads/master"), None, None, None, Some("something something"), None).unwrap();
+
+    let project = project
+        .file("Cargo.toml", &format!(r#"
+            [project]
+
+            name = "foo"
+            version = "0.5.0"
+            authors = ["wycats@example.com"]
+
+            [dependencies.dep1]
+
+            git = '{}'
+        "#, git_project.url()))
+        .file("src/lib.rs", "
+            extern crate dep1;
+            pub fn foo() { dep1::dep() }
+        ");
+
+    assert_that(project.cargo_process("build").arg("--verbose"),
+                execs().with_stderr(format!("\
+[UPDATING] git repository [..]
+[ERROR] failed to load source for a dependency on `dep1`
+
+Caused by:
+  Failed to update submodules of [..]
+
+Caused by:
+  [9/-3] object not found - no match for id ({})
+", original_submodule_ref)).with_status(101));
+}
+
+#[test]
 fn two_deps_only_update_one() {
     let project = project("foo");
     let git1 = git::new("dep1", |project| {


### PR DESCRIPTION
This PR changes output of cargo when updating a dependency fails because of it's submodules cannot be loaded. In my original example this was caused by submodule pointing to a revision which was deleted by force pushing. Fixes #3922.

Before:

```
$ cargo check
    Updating git repository `<foo-url>`
error: failed to load source for a dependency on `foo`
Caused by:
  Unable to update <foo-url>?rev=hash
To learn more, run the command again with --verbose.
```

After:

```
$ cargo check
    Updating git repository `<foo-url>`
error: failed to load source for a dependency on `foo`
Caused by:
  Unable to update <foo-url>?rev=hash
Caused by:
  Failed to update submodule `submodule`
To learn more, run the command again with --verbose.
```

`--verbose` showing an additional `[9/-3] object not found - no match for id (hash)` has not been changed.

@alexcrichton since we have this nice timezone difference there was no chance of mentoring so far but any comments/suggestions are highly welcome. I'll likely check back on this next week.