### PR TITLE
re-enable previously nightly-only tests

### DIFF
--- a/tests/build-script.rs
+++ b/tests/build-script.rs
@@ -4,7 +4,7 @@ extern crate hamcrest;
 use std::fs::{self, File};
 use std::io::prelude::*;
 
-use cargotest::{rustc_host, is_nightly, sleep_ms};
+use cargotest::{rustc_host, sleep_ms};
 use cargotest::support::{project, execs};
 use cargotest::support::paths::CargoPathExt;
 use cargotest::support::registry::Package;
@@ -2094,9 +2094,6 @@ fn custom_target_dir() {
 
 #[test]
 fn panic_abort_with_build_scripts() {
-    if !is_nightly() {
-        return
-    }
     let p = project("foo")
         .file("Cargo.toml", r#"
             [project]

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -2442,9 +2442,6 @@ fn manifest_with_bom_is_ok() {
 
 #[test]
 fn panic_abort_compiles_with_panic_abort() {
-    if !is_nightly() {
-        return
-    }
     let p = project("foo")
         .file("Cargo.toml", r#"
             [package]
@@ -2489,8 +2486,6 @@ fn explicit_color_config_is_propagated_to_rustc() {
 
 #[test]
 fn compiler_json_error_format() {
-    if !is_nightly() { return }
-
     let p = project("foo")
         .file("Cargo.toml", r#"
             [project]

--- a/tests/cfg.rs
+++ b/tests/cfg.rs
@@ -6,7 +6,7 @@ use std::str::FromStr;
 use std::fmt;
 
 use cargo::util::{Cfg, CfgExpr};
-use cargotest::{is_nightly, rustc_host};
+use cargotest::rustc_host;
 use cargotest::support::registry::Package;
 use cargotest::support::{project, execs};
 use hamcrest::assert_that;
@@ -138,8 +138,6 @@ fn cfg_matches() {
 
 #[test]
 fn cfg_easy() {
-    if !is_nightly() { return }
-
     let p = project("foo")
         .file("Cargo.toml", r#"
             [package]
@@ -166,8 +164,6 @@ fn cfg_easy() {
 
 #[test]
 fn dont_include() {
-    if !is_nightly() { return }
-
     let other_family = if cfg!(unix) {"windows"} else {"unix"};
     let p = project("foo")
         .file("Cargo.toml", &format!(r#"
@@ -196,8 +192,6 @@ fn dont_include() {
 
 #[test]
 fn works_through_the_registry() {
-    if !is_nightly() { return }
-
     Package::new("foo", "0.1.0").publish();
     Package::new("bar", "0.1.0")
             .target_dep("foo", "0.1.0", "cfg(unix)")
@@ -314,8 +308,6 @@ Caused by:
 
 #[test]
 fn multiple_match_ok() {
-    if !is_nightly() { return }
-
     let p = project("foo")
         .file("Cargo.toml", &format!(r#"
             [package]
@@ -351,8 +343,6 @@ fn multiple_match_ok() {
 
 #[test]
 fn any_ok() {
-    if !is_nightly() { return }
-
     let p = project("foo")
         .file("Cargo.toml", r#"
             [package]

--- a/tests/check.rs
+++ b/tests/check.rs
@@ -8,9 +8,6 @@ use hamcrest::assert_that;
 
 #[test]
 fn check_success() {
-    if !is_nightly() {
-        return
-    }
     let foo = project("foo")
         .file("Cargo.toml", r#"
             [package]
@@ -45,9 +42,6 @@ fn check_success() {
 
 #[test]
 fn check_fail() {
-    if !is_nightly() {
-        return
-    }
     let foo = project("foo")
         .file("Cargo.toml", r#"
             [package]
@@ -143,10 +137,6 @@ pub fn derive(_input: TokenStream) -> TokenStream {
 
 #[test]
 fn check_build() {
-    if !is_nightly() {
-        return;
-    }
-
     let foo = project("foo")
         .file("Cargo.toml", r#"
             [package]
@@ -185,10 +175,6 @@ fn check_build() {
 
 #[test]
 fn build_check() {
-    if !is_nightly() {
-        return;
-    }
-
     let foo = project("foo")
         .file("Cargo.toml", r#"
             [package]
@@ -229,10 +215,6 @@ fn build_check() {
 // not built.
 #[test]
 fn issue_3418() {
-    if !is_nightly() {
-        return;
-    }
-
     let foo = project("foo")
         .file("Cargo.toml", r#"
             [package]
@@ -254,10 +236,6 @@ fn issue_3418() {
 // checked, but in this case with a proc macro too.
 #[test]
 fn issue_3419() {
-    if !is_nightly() {
-        return;
-    }
-
     let foo = project("foo")
         .file("Cargo.toml", r#"
             [package]
@@ -307,9 +285,6 @@ fn issue_3419() {
 // test `cargo rustc --profile check`
 #[test]
 fn rustc_check() {
-    if !is_nightly() {
-        return
-    }
     let foo = project("foo")
         .file("Cargo.toml", r#"
             [package]
@@ -348,9 +323,6 @@ fn rustc_check() {
 
 #[test]
 fn rustc_check_err() {
-    if !is_nightly() {
-        return
-    }
     let foo = project("foo")
         .file("Cargo.toml", r#"
             [package]
@@ -389,9 +361,6 @@ fn rustc_check_err() {
 
 #[test]
 fn check_all() {
-    if !is_nightly() {
-        return
-    }
     let foo = project("foo")
         .file("Cargo.toml", r#"
             [package]

--- a/tests/doc.rs
+++ b/tests/doc.rs
@@ -4,7 +4,7 @@ extern crate hamcrest;
 use std::str;
 use std::fs;
 
-use cargotest::{is_nightly, rustc_host};
+use cargotest::rustc_host;
 use cargotest::support::{project, execs, path2url};
 use cargotest::support::registry::Package;
 use hamcrest::{assert_that, existing_file, existing_dir, is_not};
@@ -283,8 +283,6 @@ fn doc_same_name() {
 #[test]
 fn doc_target() {
     const TARGET: &'static str = "arm-unknown-linux-gnueabihf";
-
-    if !is_nightly() { return }
 
     let p = project("foo")
         .file("Cargo.toml", r#"

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -2292,9 +2292,6 @@ test result: ok.[..]
 
 #[test]
 fn test_panic_abort_with_dep() {
-    if !is_nightly() {
-        return
-    }
     let p = project("foo")
         .file("Cargo.toml", r#"
             [package]
@@ -2327,9 +2324,6 @@ fn test_panic_abort_with_dep() {
 
 #[test]
 fn cfg_test_even_with_no_harness() {
-    if !is_nightly() {
-        return
-    }
     let p = project("foo")
         .file("Cargo.toml", r#"
             [package]


### PR DESCRIPTION
These tests all play nicely with Rust 1.16.