### PR TITLE
Better error message when a package version is not found

### DIFF
--- a/tests/build.rs
+++ b/tests/build.rs
@@ -760,9 +760,8 @@ fn compile_path_dep_then_change_version() {
 
     assert_that(p.cargo("build"),
                 execs().with_status(101).with_stderr("\
-[ERROR] no matching package named `bar` found (required by `foo`)
+[ERROR] no matching version `= 0.0.1` found for package `bar` (required by `foo`)
 location searched: [..]
-version required: = 0.0.1
 versions found: 0.0.2
 consider running `cargo update` to update a path dependency's locked version
 "));

--- a/tests/registry.rs
+++ b/tests/registry.rs
@@ -134,9 +134,8 @@ fn wrong_version() {
 
     assert_that(p.cargo("build"),
                 execs().with_status(101).with_stderr_contains("\
-[ERROR] no matching package named `foo` found (required by `foo`)
+[ERROR] no matching version `>= 1.0.0` found for package `foo` (required by `foo`)
 location searched: registry [..]
-version required: >= 1.0.0
 versions found: 0.0.2, 0.0.1
 "));
 
@@ -145,9 +144,8 @@ versions found: 0.0.2, 0.0.1
 
     assert_that(p.cargo("build"),
                 execs().with_status(101).with_stderr_contains("\
-[ERROR] no matching package named `foo` found (required by `foo`)
+[ERROR] no matching version `>= 1.0.0` found for package `foo` (required by `foo`)
 location searched: registry [..]
-version required: >= 1.0.0
 versions found: 0.0.4, 0.0.3, 0.0.2, ...
 "));
 }
@@ -399,9 +397,8 @@ fn relying_on_a_yank_is_bad() {
 
     assert_that(p.cargo("build"),
                 execs().with_status(101).with_stderr_contains("\
-[ERROR] no matching package named `baz` found (required by `bar`)
+[ERROR] no matching version `= 0.0.2` found for package `baz` (required by `bar`)
 location searched: registry [..]
-version required: = 0.0.2
 versions found: 0.0.1
 "));
 }


### PR DESCRIPTION
This changes the error message when a package *is* found but there's no
matching version to be a little more helpful.

Old: "no matching package named `<dep name>`"
New: "no matching version `<version>` found for package `<dep name>`"

Fixes #2997