### PR TITLE
Allow cargo:rustc-env in build scripts

### DIFF
--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -709,6 +709,12 @@ fn scrape_target_config(config: &Config, triple: &str)
                     let list = value.list(&k)?;
                     output.cfgs.extend(list.iter().map(|v| v.0.clone()));
                 }
+                "rustc-env" => {
+                    for (name, val) in value.table(&k)?.0 {
+                        let val = val.string(name)?.0;
+                        output.env.push((name.clone(), val.to_string()));
+                    }
+                }
                 "warning" | "rerun-if-changed" => {
                     bail!("`{}` is not supported in build script overrides", k);
                 }

--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -670,6 +670,7 @@ fn scrape_target_config(config: &Config, triple: &str)
             library_paths: Vec::new(),
             library_links: Vec::new(),
             cfgs: Vec::new(),
+            env: Vec::new(),
             metadata: Vec::new(),
             rerun_if_changed: Vec::new(),
             warnings: Vec::new(),

--- a/src/cargo/ops/cargo_rustc/mod.rs
+++ b/src/cargo/ops/cargo_rustc/mod.rs
@@ -428,17 +428,12 @@ fn rustc(cx: &mut Context, unit: &Unit, exec: Arc<Executor>) -> CargoResult<Work
     // been put there by one of the `build_scripts`) to the command provided.
     fn add_custom_env(rustc: &mut ProcessBuilder,
                       build_state: &BuildMap,
-                      build_scripts: &BuildScripts,
+                      _: &BuildScripts,
                       current_id: &PackageId) -> CargoResult<()> {
-        for key in build_scripts.to_link.iter() {
-            let output = build_state.get(key).chain_error(|| {
-                internal(format!("couldn't find build state for {}/{:?}",
-                                 key.0, key.1))
-            })?;
-            if key.0 == *current_id {
-                for &(ref name, ref value) in output.env.iter() {
-                    rustc.env(name, value);
-                }
+        let key = (current_id.clone(), Kind::Host);
+        if let Some(output) = build_state.get(&key) {
+            for &(ref name, ref value) in output.env.iter() {
+                rustc.env(name, value);
             }
         }
         Ok(())

--- a/src/cargo/util/machine_message.rs
+++ b/src/cargo/util/machine_message.rs
@@ -48,6 +48,7 @@ pub struct BuildScript<'a> {
     pub linked_libs: &'a [String],
     pub linked_paths: &'a [String],
     pub cfgs: &'a [String],
+    pub env: &'a [(String, String)],
 }
 
 impl<'a> Message for BuildScript<'a> {

--- a/src/doc/build-script.md
+++ b/src/doc/build-script.md
@@ -51,6 +51,7 @@ All the lines printed to stdout by a build script are written to a file like `ta
 cargo:rustc-link-lib=static=foo
 cargo:rustc-link-search=native=/path/to/foo
 cargo:rustc-cfg=foo
+cargo:rustc-env=FOO=bar
 # arbitrary user-defined metadata
 cargo:root=/path/to/foo
 cargo:libdir=/path/to/foo/lib
@@ -73,6 +74,12 @@ crate is built:
 * `rustc-cfg=FEATURE` indicates that the specified feature will be passed as a
   `--cfg` flag to the compiler. This is often useful for performing compile-time
   detection of various features.
+* `rustc-env=VAR=VALUE` indicates that the specified environment variable
+  will be added to the environment which the compiler is run within.
+  The value can be then retrieved by the `env!` macro in the compiled crate.
+  This is useful for embedding additional metadata in crate's code,
+  such as the hash of Git HEAD or the unique identifier of a continuous
+  integration server.
 * `rerun-if-changed=PATH` is a path to a file or directory which indicates that
   the build script should be re-run if it changes (detected by a more-recent
   last-modified timestamp on the file). Normally build scripts are re-run if

--- a/tests/build-script.rs
+++ b/tests/build-script.rs
@@ -1577,10 +1577,10 @@ fn cfg_override_doc() {
 
 #[test]
 fn env_build() {
-    let build = project("builder")
+    let p = project("foo")
         .file("Cargo.toml", r#"
             [package]
-            name = "builder"
+            name = "foo"
             version = "0.0.1"
             authors = []
             build = "build.rs"
@@ -1596,9 +1596,9 @@ fn env_build() {
                 println!("cargo:rustc-env=FOO=foo");
             }
         "#);
-    assert_that(build.cargo_process("build").arg("-v"),
+    assert_that(p.cargo_process("build").arg("-v"),
                 execs().with_status(0));
-    assert_that(build.cargo("run").arg("-v"),
+    assert_that(p.cargo("run").arg("-v"),
                 execs().with_status(0).with_stdout("foo\n"));
 }
 
@@ -1633,14 +1633,14 @@ fn env_test() {
 [COMPILING] foo v0.0.1 ({dir})
 [RUNNING] [..] build.rs [..]
 [RUNNING] `[..][/]build-script-build`
-[RUNNING] [..] --cfg foo[..]
-[RUNNING] [..] --cfg foo[..]
-[RUNNING] [..] --cfg foo[..]
+[RUNNING] [..] --crate-name foo[..]
+[RUNNING] [..] --crate-name foo[..]
+[RUNNING] [..] --crate-name test[..]
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `[..][/]foo-[..][EXE]`
 [RUNNING] `[..][/]test-[..][EXE]`
 [DOCTEST] foo
-[RUNNING] [..] --cfg foo[..]", dir = p.url()))
+[RUNNING] [..] --crate-name foo[..]", dir = p.url()))
                        .with_stdout("
 running 0 tests
 
@@ -1652,7 +1652,35 @@ test test_foo ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
 
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
+
 "));
+}
+
+#[test]
+fn env_doc() {
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [package]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+            build = "build.rs"
+        "#)
+        .file("src/main.rs", r#"
+            const FOO: &'static str = env!("FOO");
+            fn main() {}
+        "#)
+        .file("build.rs", r#"
+            fn main() {
+                println!("cargo:rustc-env=FOO=foo");
+            }
+        "#);
+    assert_that(p.cargo_process("doc").arg("-v"),
+                execs().with_status(0));
 }
 
 #[test]

--- a/tests/build-script.rs
+++ b/tests/build-script.rs
@@ -1587,7 +1587,9 @@ fn env_build() {
         "#)
         .file("src/main.rs", r#"
             const FOO: &'static str = env!("FOO");
-            fn main() {}
+            fn main() {
+                println!("{}", FOO);
+            }
         "#)
         .file("build.rs", r#"
             fn main() {
@@ -1596,6 +1598,8 @@ fn env_build() {
         "#);
     assert_that(build.cargo_process("build").arg("-v"),
                 execs().with_status(0));
+    assert_that(build.cargo("run").arg("-v"),
+                execs().with_status(0).with_stdout("foo\n"));
 }
 
 #[test]


### PR DESCRIPTION
This is an attempt to address issue #2875. Basically, I'm trying to allow build scripts to produce`cargo:rustc-env=FOO=foo` lines in their output. These are then translated to `env!()`-friendly env. vars that rustc is run with.