### PR TITLE
Allow test named `test`

### DIFF
--- a/src/cargo/util/toml.rs
+++ b/src/cargo/util/toml.rs
@@ -1367,19 +1367,11 @@ fn normalize(package_root: &Path,
                                    .join(&format!("{}.rs", ex.name())));
 
     test_targets(&mut ret, tests, &mut |test| {
-        if test.name() == "test" {
-            Path::new("src").join("test.rs")
-        } else {
-            Path::new("tests").join(&format!("{}.rs", test.name()))
-        }
+        Path::new("tests").join(&format!("{}.rs", test.name()))
     });
 
     bench_targets(&mut ret, benches, &mut |bench| {
-        if bench.name() == "bench" {
-            Path::new("src").join("bench.rs")
-        } else {
-            Path::new("benches").join(&format!("{}.rs", bench.name()))
-        }
+        Path::new("benches").join(&format!("{}.rs", bench.name()))
     });
 
     ret

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -521,6 +521,28 @@ test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
 }
 
 #[test]
+fn external_test_named_test() {
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [project]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+
+            [[test]]
+            name = "test"
+        "#)
+        .file("src/lib.rs", "")
+        .file("tests/test.rs", r#"
+            #[test]
+            fn foo() { }
+        "#);
+
+    assert_that(p.cargo_process("test"),
+                execs().with_status(0))
+}
+
+#[test]
 fn external_test_implicit() {
     let p = project("foo")
         .file("Cargo.toml", r#"
@@ -2849,5 +2871,5 @@ test test_z ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
 "));
-    
+
 }


### PR DESCRIPTION
Looks like `srt/test.rs` and `src/bench.rs` used to be default
integraion test and benchmark, but they no longer are.

closes #3932