### PR TITLE
Don't use `-C metadata` cdylibs like we do with dylibs

### DIFF
--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -435,6 +435,19 @@ impl Target {
         }
     }
 
+    pub fn is_cdylib(&self) -> bool {
+        let libs = match self.kind {
+            TargetKind::Lib(ref libs) => libs,
+            _ => return false
+        };
+        libs.iter().any(|l| {
+            match *l {
+                LibKind::Other(ref s) => s == "cdylib",
+                _ => false,
+            }
+        })
+    }
+
     pub fn linkable(&self) -> bool {
         match self.kind {
             TargetKind::Lib(ref kinds) => {

--- a/src/cargo/ops/cargo_rustc/context.rs
+++ b/src/cargo/ops/cargo_rustc/context.rs
@@ -388,7 +388,7 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
         // just here for rustbuild. We need a more principled method
         // doing this eventually.
         if !unit.profile.test &&
-            unit.target.is_dylib() &&
+            (unit.target.is_dylib() || unit.target.is_cdylib()) &&
             unit.pkg.package_id().source_id().is_path() &&
             !env::var("__CARGO_DEFAULT_LIB_METADATA").is_ok() {
             return None;
@@ -940,7 +940,7 @@ fn env_args(config: &Config,
     let mut rustflags = Vec::new();
 
     let name = name.chars().flat_map(|c| c.to_lowercase()).collect::<String>();
-    // Then the target.*.rustflags value... 
+    // Then the target.*.rustflags value...
     let target = build_config.requested_target.as_ref().unwrap_or(&build_config.host_triple);
     let key = format!("target.{}.{}", target, name);
     if let Some(args) = config.get_list_or_split_string(&key)? {

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -2909,3 +2909,34 @@ fn rustc_wrapper() {
                     "[RUNNING] `/usr/bin/env rustc --crate-name foo [..]")
                 .with_status(0));
 }
+
+#[test]
+fn cdylib_not_lifted() {
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [project]
+            name = "foo"
+            authors = []
+            version = "0.1.0"
+
+            [lib]
+            crate-type = ["cdylib"]
+        "#)
+        .file("src/lib.rs", "");
+
+    assert_that(p.cargo_process("build"), execs().with_status(0));
+
+    let files = if cfg!(windows) {
+        vec!["foo.dll.lib", "foo.dll.exp", "foo.dll"]
+    } else if cfg!(target_os = "macos") {
+        vec!["libfoo.dylib"]
+    } else {
+        vec!["libfoo.so"]
+    };
+
+    for file in files {
+        println!("checking: {}", file);
+        assert_that(&p.root().join("target/debug/deps").join(&file),
+                    existing_file());
+    }
+}


### PR DESCRIPTION
Dylibs don't get any metadata/extra filename info applied to them as "final
targets" because it can mess with system-specific information (e.g. on OSX) so
this just applies the same logic to cdylibs which need similar treatment on more
platforms (like Windows).

Closes #3934