### PR TITLE
Add support for custom target-specific runners

### DIFF
--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -662,8 +662,11 @@ fn scrape_target_config(config: &Config, triple: &str)
         None => return Ok(ret),
     };
     for (lib_name, value) in table {
-        if lib_name == "ar" || lib_name == "linker" || lib_name == "rustflags" {
-            continue
+        match lib_name.as_str() {
+            "ar" | "linker" | "runner" | "rustflags" => {
+                continue
+            },
+            _ => {}
         }
 
         let mut output = BuildOutput {

--- a/src/cargo/util/config.rs
+++ b/src/cargo/util/config.rs
@@ -237,7 +237,8 @@ impl Config {
         }
     }
 
-    pub fn get_path_and_args(&self, key: &str) -> CargoResult<Option<Value<(PathBuf, Vec<String>)>>> {
+    pub fn get_path_and_args(&self, key: &str)
+                             -> CargoResult<Option<Value<(PathBuf, Vec<String>)>>> {
         if let Some(mut val) = self.get_list_or_split_string(key)? {
             if !val.val.is_empty() {
                 return Ok(Some(Value {

--- a/src/doc/config.md
+++ b/src/doc/config.md
@@ -66,6 +66,11 @@ vcs = "none"
 linker = ".."
 # Same but for the library archiver which is passed to rustc via `-C ar=`.
 ar = ".."
+# If a runner is provided, compiled targets for the `$triple` will be executed
+# by invoking the specified runner executable with actual target as first argument.
+# This applies to `cargo run`, `cargo test` and `cargo bench` commands.
+# By default compiled targets are executed directly.
+runner = ".."
 # custom flags to pass to all compiler invocations that target $triple
 # this value overrides build.rustflags when both are present
 rustflags = ["..", ".."]

--- a/tests/tool-paths.rs
+++ b/tests/tool-paths.rs
@@ -140,7 +140,7 @@ fn custom_runner() {
         .file("benches/bench.rs", "")
         .file(".cargo/config", &format!(r#"
             [target.{}]
-            runner = "nonexistent-runner"
+            runner = "nonexistent-runner -r"
         "#, target));
 
     foo.build();
@@ -149,7 +149,7 @@ fn custom_runner() {
                 execs().with_stderr_contains(&format!("\
 [COMPILING] foo v0.0.1 ({url})
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] `nonexistent-runner target[/]debug[/]foo[EXE] --param`
+[RUNNING] `nonexistent-runner -r target[/]debug[/]foo[EXE] --param`
 ", url = foo.url())));
 
     assert_that(foo.cargo("test").args(&["--test", "test", "--verbose", "--", "--param"]),
@@ -157,7 +157,7 @@ fn custom_runner() {
 [COMPILING] foo v0.0.1 ({url})
 [RUNNING] `rustc [..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] `nonexistent-runner [..][/]target[/]debug[/]deps[/]test-[..][EXE] --param`
+[RUNNING] `nonexistent-runner -r [..][/]target[/]debug[/]deps[/]test-[..][EXE] --param`
 ", url = foo.url())));
 
     assert_that(foo.cargo("bench").args(&["--bench", "bench", "--verbose", "--", "--param"]),
@@ -166,6 +166,6 @@ fn custom_runner() {
 [RUNNING] `rustc [..]`
 [RUNNING] `rustc [..]`
 [FINISHED] release [optimized] target(s) in [..]
-[RUNNING] `nonexistent-runner [..][/]target[/]release[/]deps[/]bench-[..][EXE] --param --bench`
+[RUNNING] `nonexistent-runner -r [..][/]target[/]release[/]deps[/]bench-[..][EXE] --param --bench`
 ", url = foo.url())));
 }


### PR DESCRIPTION
When `target.$triple.runner` is specified, it will be used for any execution commands by cargo including `cargo run`, `cargo test` and `cargo bench`. The original file is passed to the runner executable as a first argument.

This allows to run tests when cross-comping Rust projects.

This is not a complete solution and might be extended in future for better ergonomics to support passing extra arguments to the runner itself or overriding runner from the command line, but it should already unlock major existing use cases.

Fixes #1411
Resolves #3626