### PR TITLE
Update documentation on overrides

### DIFF
--- a/src/doc/config.md
+++ b/src/doc/config.md
@@ -58,18 +58,14 @@ vcs = "none"
 
 # For the following sections, $triple refers to any valid target triple, not the
 # literal string "$triple", and it will apply whenever that target triple is
-# being compiled to. 'cfg(...)' refers to the Rust-like `#[cfg]` syntax for 
+# being compiled to. 'cfg(...)' refers to the Rust-like `#[cfg]` syntax for
 # conditional compilation.
-[target]
-# For Cargo builds which do not mention --target, this is the linker
-# which is passed to rustc (via `-C linker=`). By default this flag is not
-# passed to the compiler.
-linker = ".."
-
 [target.$triple]
-# Similar to the above linker configuration, but this only applies to
-# when the `$triple` is being compiled for.
+# This is the linker which is passed to rustc (via `-C linker=`) when the `$triple`
+# is being compiled for. By default this flag is not passed to the compiler.
 linker = ".."
+# Same but for the library archiver which is passed to rustc via `-C ar=`.
+ar = ".."
 # custom flags to pass to all compiler invocations that target $triple
 # this value overrides build.rustflags when both are present
 rustflags = ["..", ".."]


### PR DESCRIPTION
 - `target.linker` does not seem to be supported anymore, only `target.$triple.linker` works, so merged these sections.
 - Added note about supported `target.$triple.ar`