### PR TITLE
exec (replace the current process) external subcommands instead of running them as child processes.

### DIFF
--- a/src/bin/cargo.rs
+++ b/src/bin/cargo.rs
@@ -325,7 +325,7 @@ fn execute_external_subcommand(config: &Config, cmd: &str, args: &[String]) -> C
     let err = match util::process(&command)
         .env(cargo::CARGO_ENV, cargo_exe)
         .args(&args[1..])
-        .exec() {
+        .exec_replace() {
         Ok(()) => return Ok(()),
         Err(e) => e,
     };


### PR DESCRIPTION
This fixes https://github.com/rust-lang/cargo/issues/3959 (tested to be working with my yet-to-be-published subcommand, and tested not to break things with `cargo tree` and `cargo outdated`).