### PR TITLE
Support vendoring git repositories

### DIFF
--- a/src/cargo/core/registry.rs
+++ b/src/cargo/core/registry.rs
@@ -26,11 +26,11 @@ pub trait Registry {
 
     /// Returns whether or not this registry will return summaries with
     /// checksums listed.
-    ///
-    /// By default, registries do not support checksums.
-    fn supports_checksums(&self) -> bool {
-        false
-    }
+    fn supports_checksums(&self) -> bool;
+
+    /// Returns whether or not this registry will return summaries with
+    /// the `precise` field in the source id listed.
+    fn requires_precise(&self) -> bool;
 }
 
 impl<'a, T: ?Sized + Registry + 'a> Registry for Box<T> {
@@ -38,6 +38,14 @@ impl<'a, T: ?Sized + Registry + 'a> Registry for Box<T> {
              dep: &Dependency,
              f: &mut FnMut(Summary)) -> CargoResult<()> {
         (**self).query(dep, f)
+    }
+
+    fn supports_checksums(&self) -> bool {
+        (**self).supports_checksums()
+    }
+
+    fn requires_precise(&self) -> bool {
+        (**self).requires_precise()
     }
 }
 
@@ -415,6 +423,14 @@ impl<'cfg> Registry for PackageRegistry<'cfg> {
         f(self.lock(override_summary));
         Ok(())
     }
+
+    fn supports_checksums(&self) -> bool {
+        false
+    }
+
+    fn requires_precise(&self) -> bool {
+        false
+    }
 }
 
 fn lock(locked: &LockedMap,
@@ -578,6 +594,14 @@ pub mod test {
                 }
                 Ok(())
             }
+        }
+
+        fn supports_checksums(&self) -> bool {
+            false
+        }
+
+        fn requires_precise(&self) -> bool {
+            false
         }
     }
 }

--- a/src/cargo/sources/directory.rs
+++ b/src/cargo/sources/directory.rs
@@ -23,7 +23,7 @@ pub struct DirectorySource<'cfg> {
 
 #[derive(Deserialize)]
 struct Checksum {
-    package: String,
+    package: Option<String>,
     files: HashMap<String, String>,
 }
 
@@ -58,6 +58,10 @@ impl<'cfg> Registry for DirectorySource<'cfg> {
     }
 
     fn supports_checksums(&self) -> bool {
+        true
+    }
+
+    fn requires_precise(&self) -> bool {
         true
     }
 }
@@ -133,8 +137,11 @@ impl<'cfg> Source for DirectorySource<'cfg> {
             })?;
 
             let mut manifest = pkg.manifest().clone();
-            let summary = manifest.summary().clone();
-            manifest.set_summary(summary.set_checksum(cksum.package.clone()));
+            let mut summary = manifest.summary().clone();
+            if let Some(ref package) = cksum.package {
+                summary = summary.set_checksum(package.clone());
+            }
+            manifest.set_summary(summary);
             let pkg = Package::new(manifest, pkg.manifest_path());
             self.packages.insert(pkg.package_id().clone(), (pkg, cksum));
         }

--- a/src/cargo/sources/git/source.rs
+++ b/src/cargo/sources/git/source.rs
@@ -130,6 +130,14 @@ impl<'cfg> Registry for GitSource<'cfg> {
                       .expect("BUG: update() must be called before query()");
         src.query(dep, f)
     }
+
+    fn supports_checksums(&self) -> bool {
+        false
+    }
+
+    fn requires_precise(&self) -> bool {
+        true
+    }
 }
 
 impl<'cfg> Source for GitSource<'cfg> {

--- a/src/cargo/sources/path.rs
+++ b/src/cargo/sources/path.rs
@@ -484,6 +484,14 @@ impl<'cfg> Registry for PathSource<'cfg> {
         }
         Ok(())
     }
+
+    fn supports_checksums(&self) -> bool {
+        false
+    }
+
+    fn requires_precise(&self) -> bool {
+        false
+    }
 }
 
 impl<'cfg> Source for PathSource<'cfg> {

--- a/src/cargo/sources/registry/mod.rs
+++ b/src/cargo/sources/registry/mod.rs
@@ -356,6 +356,10 @@ impl<'cfg> Registry for RegistrySource<'cfg> {
     fn supports_checksums(&self) -> bool {
         true
     }
+
+    fn requires_precise(&self) -> bool {
+        false
+    }
 }
 
 impl<'cfg> Source for RegistrySource<'cfg> {

--- a/src/cargo/sources/replaced.rs
+++ b/src/cargo/sources/replaced.rs
@@ -33,6 +33,14 @@ impl<'cfg> Registry for ReplacedSource<'cfg> {
                     self.to_replace)
         })
     }
+
+    fn supports_checksums(&self) -> bool {
+        self.inner.supports_checksums()
+    }
+
+    fn requires_precise(&self) -> bool {
+        self.inner.requires_precise()
+    }
 }
 
 impl<'cfg> Source for ReplacedSource<'cfg> {

--- a/src/doc/source-replacement.md
+++ b/src/doc/source-replacement.md
@@ -68,6 +68,12 @@ replace-with = "another-source"
 registry = "https://example.com/path/to/index"
 local-registry = "path/to/registry"
 directory = "path/to/vendor"
+
+# Git sources can optionally specify a branch/tag/rev as well
+git = "https://example.com/path/to/repo"
+# branch = "master"
+# tag = "v1.0.1"
+# rev = "313f44e8"
 ```
 
 The `crates-io` represents the crates.io online registry (default source of

--- a/tests/resolve.rs
+++ b/tests/resolve.rs
@@ -28,6 +28,8 @@ fn resolve(pkg: PackageId, deps: Vec<Dependency>, registry: &[Summary])
             }
             Ok(())
         }
+        fn supports_checksums(&self) -> bool { false }
+        fn requires_precise(&self) -> bool { false }
     }
     let mut registry = MyRegistry(registry);
     let summary = Summary::new(pkg.clone(), deps, HashMap::new()).unwrap();


### PR DESCRIPTION
Currently the vendoring support in Cargo primarily only allows replacing
registry sources, e.g. crates.io. Other networked sources of code, such as git
repositories, cannot currently be replaced. The purpose of this commit is to
support vendoring of git dependencies to eventually have support implemented in
the `cargo-vendor` subcommand.

Support for vendoring git repositories required a few subtle changes:

* First and foremost, configuration for source replacement of a git repository
  was added. This looks similar to the `Cargo.toml` configuration of a git
  source.

* The restriction around checksum providing sources was relaxed. If a
  replacement source provides checksums but the replaced source doesn't then
  that's now considered ok unlike it being an error before.

* Lock files can be generated for crates.io crates against vendored sources, but
  lock files cannot be generated against git sources. A lock file must
  previously exist to make use of a vendored git source.

* The `package` field of `.cargo-checksum.json` is now optional, and it is
  intended to be omitted for git sources that are vendored.