### PR TITLE
Bring test of nightly in line with tests

### DIFF
--- a/src/cargo/ops/cargo_rustc/context.rs
+++ b/src/cargo/ops/cargo_rustc/context.rs
@@ -88,8 +88,10 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
         // ignore CARGO_INCREMENTAL on anything but nightly. This allows users
         // to always have CARGO_INCREMENTAL set without getting unexpected
         // errors on stable/beta builds.
-        let incremental_enabled = incremental_enabled
-            && config.rustc()?.verbose_version.contains("nightly");
+        let is_nightly =
+            config.rustc()?.verbose_version.contains("-nightly") ||
+            config.rustc()?.verbose_version.contains("-dev");
+        let incremental_enabled = incremental_enabled && is_nightly;
 
         Ok(Context {
             ws: ws,


### PR DESCRIPTION
#4000 passes `-Zincremental` to `rustc` only on nightly, but uses a different mechanism for detecting nightly than [cargotest does](https://github.com/rust-lang/cargo/blob/9bf9bddd9297cfb5098be6146d85be551c6d4eff/tests/cargotest/lib.rs#L37). This PR brings the two in line, which should hopefully fix the build failure observed in https://github.com/rust-lang/rust/pull/41830#issuecomment-300052969.