### PR TITLE
Always hash entire metadata

### DIFF
--- a/src/cargo/ops/cargo_rustc/context.rs
+++ b/src/cargo/ops/cargo_rustc/context.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 use core::{Package, PackageId, PackageSet, Resolve, Target, Profile};
 use core::{TargetKind, Profiles, Dependency, Workspace};
 use core::dependency::Kind as DepKind;
-use util::{self, CargoResult, ChainError, internal, Config, profile, Cfg, CfgExpr, human};
+use util::{CargoResult, ChainError, internal, Config, profile, Cfg, CfgExpr, human};
 
 use super::TargetConfig;
 use super::custom_build::{BuildState, BuildScripts};
@@ -383,10 +383,7 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
 
     fn pkg_dir(&mut self, unit: &Unit) -> String {
         let name = unit.pkg.package_id().name();
-        match self.target_metadata(unit) {
-            Some(meta) => format!("{}-{}", name, meta),
-            None => format!("{}-{}", name, util::short_hash(unit.pkg)),
-        }
+        format!("{}-{}", name, self.target_metadata(unit).0)
     }
 
     /// Return the host triple for this context
@@ -408,31 +405,7 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
     /// We build to the path: "{filename}-{target_metadata}"
     /// We use a linking step to link/copy to a predictable filename
     /// like `target/debug/libfoo.{a,so,rlib}` and such.
-    pub fn target_metadata(&mut self, unit: &Unit) -> Option<Metadata> {
-        // No metadata for dylibs because of a couple issues
-        // - OSX encodes the dylib name in the executable
-        // - Windows rustc multiple files of which we can't easily link all of them
-        //
-        // Two expeptions
-        // 1) Upstream dependencies (we aren't exporting + need to resolve name conflict)
-        // 2) __CARGO_DEFAULT_LIB_METADATA env var
-        //
-        // Note, though, that the compiler's build system at least wants
-        // path dependencies (eg libstd) to have hashes in filenames. To account for
-        // that we have an extra hack here which reads the
-        // `__CARGO_DEFAULT_METADATA` environment variable and creates a
-        // hash in the filename if that's present.
-        //
-        // This environment variable should not be relied on! It's
-        // just here for rustbuild. We need a more principled method
-        // doing this eventually.
-        if !unit.profile.test &&
-            (unit.target.is_dylib() || unit.target.is_cdylib()) &&
-            unit.pkg.package_id().source_id().is_path() &&
-            !env::var("__CARGO_DEFAULT_LIB_METADATA").is_ok() {
-            return None;
-        }
-
+    pub fn target_metadata(&mut self, unit: &Unit) -> (Metadata, bool) {
         let mut hasher = SipHasher::new_with_keys(0, 0);
 
         // Unique metadata per (name, source, version) triple. This'll allow us
@@ -460,15 +433,36 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
         unit.target.name().hash(&mut hasher);
         unit.target.kind().hash(&mut hasher);
 
-        Some(Metadata(hasher.finish()))
+        // No metadata suffix for dylibs because of a couple issues
+        // - OSX encodes the dylib name in the executable
+        // - Windows rustc multiple files of which we can't easily link all of them
+        //
+        // Two expeptions
+        // 1) Upstream dependencies (we aren't exporting + need to resolve name conflict)
+        // 2) __CARGO_DEFAULT_LIB_METADATA env var
+        //
+        // Note, though, that the compiler's build system at least wants
+        // path dependencies (eg libstd) to have hashes in filenames. To account for
+        // that we have an extra hack here which reads the
+        // `__CARGO_DEFAULT_METADATA` environment variable and creates a
+        // hash in the filename if that's present.
+        //
+        // This environment variable should not be relied on! It's
+        // just here for rustbuild. We need a more principled method
+        // doing this eventually.
+        let extra_filename = unit.profile.test ||
+            !(unit.target.is_dylib() || unit.target.is_cdylib()) ||
+            !unit.pkg.package_id().source_id().is_path() ||
+            env::var("__CARGO_DEFAULT_LIB_METADATA").is_ok();
+        (Metadata(hasher.finish()), extra_filename)
     }
 
     /// Returns the file stem for a given target/profile combo (with metadata)
     pub fn file_stem(&mut self, unit: &Unit) -> String {
         match self.target_metadata(unit) {
-            Some(ref metadata) => format!("{}-{}", unit.target.crate_name(),
+            (ref metadata, true) => format!("{}-{}", unit.target.crate_name(),
                                           metadata),
-            None => self.bin_stem(unit),
+            (_, false) => self.bin_stem(unit),
         }
     }
 

--- a/src/cargo/ops/cargo_rustc/context.rs
+++ b/src/cargo/ops/cargo_rustc/context.rs
@@ -437,23 +437,11 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
         // - OSX encodes the dylib name in the executable
         // - Windows rustc multiple files of which we can't easily link all of them
         //
-        // Two expeptions
-        // 1) Upstream dependencies (we aren't exporting + need to resolve name conflict)
-        // 2) __CARGO_DEFAULT_LIB_METADATA env var
-        //
-        // Note, though, that the compiler's build system at least wants
-        // path dependencies (eg libstd) to have hashes in filenames. To account for
-        // that we have an extra hack here which reads the
-        // `__CARGO_DEFAULT_METADATA` environment variable and creates a
-        // hash in the filename if that's present.
-        //
-        // This environment variable should not be relied on! It's
-        // just here for rustbuild. We need a more principled method
-        // doing this eventually.
+        // Exceptions:
+        // Upstream dependencies (we aren't exporting + need to resolve name conflict)
         let extra_filename = unit.profile.test ||
             !(unit.target.is_dylib() || unit.target.is_cdylib()) ||
-            !unit.pkg.package_id().source_id().is_path() ||
-            env::var("__CARGO_DEFAULT_LIB_METADATA").is_ok();
+            !unit.pkg.package_id().source_id().is_path();
         (Metadata(hasher.finish()), extra_filename)
     }
 

--- a/src/cargo/ops/cargo_rustc/mod.rs
+++ b/src/cargo/ops/cargo_rustc/mod.rs
@@ -12,7 +12,7 @@ use core::{Package, PackageId, PackageSet, Target, Resolve};
 use core::{Profile, Profiles, Workspace};
 use core::shell::ColorConfig;
 use util::{self, CargoResult, ProcessBuilder, ProcessError, human, machine_message};
-use util::{Config, internal, ChainError, profile, join_paths, short_hash};
+use util::{Config, internal, ChainError, profile, join_paths};
 use util::Freshness;
 
 use self::job::{Job, Work};
@@ -280,7 +280,7 @@ fn rustc(cx: &mut Context, unit: &Unit, exec: Arc<Executor>) -> CargoResult<Work
     let crate_name = unit.target.crate_name();
 
     // XXX(Rely on target_filenames iterator as source of truth rather than rederiving filestem)
-    let rustc_dep_info_loc = if do_rename && cx.target_metadata(unit).is_none() {
+    let rustc_dep_info_loc = if do_rename && !cx.target_metadata(unit).1 {
         root.join(&crate_name)
     } else {
         root.join(&cx.file_stem(unit))
@@ -749,12 +749,12 @@ fn build_base_args(cx: &mut Context,
     }
 
     match cx.target_metadata(unit) {
-        Some(m) => {
+        (m, true) => {
             cmd.arg("-C").arg(&format!("metadata={}", m));
             cmd.arg("-C").arg(&format!("extra-filename=-{}", m));
         }
-        None => {
-            cmd.arg("-C").arg(&format!("metadata={}", short_hash(unit.pkg)));
+        (m, false) => {
+            cmd.arg("-C").arg(&format!("metadata={}", m));
         }
     }
 

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -845,34 +845,6 @@ url = p.url(),
 prefix = env::consts::DLL_PREFIX,
 suffix = env::consts::DLL_SUFFIX,
 )));
-
-    assert_that(p.cargo("clean"), execs().with_status(0));
-
-    // If you set the env-var, then we expect metadata on libbar
-    assert_that(p.cargo("build").arg("-v").env("__CARGO_DEFAULT_LIB_METADATA", "1"),
-                execs().with_status(0).with_stderr(&format!("\
-[COMPILING] bar v0.0.1 ({url}/bar)
-[RUNNING] `rustc --crate-name bar bar[/]src[/]lib.rs --crate-type dylib \
-        --emit=dep-info,link \
-        -C prefer-dynamic -C debuginfo=2 \
-        -C metadata=[..] \
-        --out-dir [..] \
-        -L dependency={dir}[/]target[/]debug[/]deps`
-[COMPILING] foo v0.0.1 ({url})
-[RUNNING] `rustc --crate-name foo src[/]lib.rs --crate-type lib \
-        --emit=dep-info,link -C debuginfo=2 \
-        -C metadata=[..] \
-        -C extra-filename=[..] \
-        --out-dir [..] \
-        -L dependency={dir}[/]target[/]debug[/]deps \
-        --extern bar={dir}[/]target[/]debug[/]deps[/]{prefix}bar-[..]{suffix}`
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
-",
-dir = p.root().display(),
-url = p.url(),
-prefix = env::consts::DLL_PREFIX,
-suffix = env::consts::DLL_SUFFIX,
-)));
 }
 
 #[test]

--- a/tests/cargotest/lib.rs
+++ b/tests/cargotest/lib.rs
@@ -51,7 +51,6 @@ fn _process(t: &OsStr) -> cargo::util::ProcessBuilder {
      .env("HOME", support::paths::home())
      .env("CARGO_HOME", support::paths::home().join(".cargo"))
      .env("__CARGO_TEST_ROOT", support::paths::root())
-     .env_remove("__CARGO_DEFAULT_LIB_METADATA")
      .env_remove("RUSTC")
      .env_remove("RUSTDOC")
      .env_remove("RUSTC_WRAPPER")


### PR DESCRIPTION
Why are we hashing the filename while there are other factors that contributes
to binary difference?

BREAKING CHANGE: backward incompatible public API modification