### PR TITLE
Support for alternative crates.io registries in cargo

### DIFF
--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -27,6 +27,7 @@ pub struct Manifest {
     publish: bool,
     replace: Vec<(PackageIdSpec, Dependency)>,
     workspace: WorkspaceConfig,
+    registry: Option<String>,
 }
 
 #[derive(Clone, Debug)]
@@ -222,7 +223,8 @@ impl Manifest {
                profiles: Profiles,
                publish: bool,
                replace: Vec<(PackageIdSpec, Dependency)>,
-               workspace: WorkspaceConfig) -> Manifest {
+               workspace: WorkspaceConfig,
+               registry: Option<String>) -> Manifest {
         Manifest {
             summary: summary,
             targets: targets,
@@ -235,6 +237,7 @@ impl Manifest {
             publish: publish,
             replace: replace,
             workspace: workspace,
+            registry: registry,
         }
     }
 
@@ -251,6 +254,7 @@ impl Manifest {
     pub fn profiles(&self) -> &Profiles { &self.profiles }
     pub fn publish(&self) -> bool { self.publish }
     pub fn replace(&self) -> &[(PackageIdSpec, Dependency)] { &self.replace }
+    pub fn registry(&self) -> &Option<String> { &self.registry }
     pub fn links(&self) -> Option<&str> {
         self.links.as_ref().map(|s| &s[..])
     }

--- a/src/cargo/core/package.rs
+++ b/src/cargo/core/package.rs
@@ -37,6 +37,7 @@ struct SerializedPackage<'a> {
     targets: &'a [Target],
     features: &'a HashMap<String, Vec<String>>,
     manifest_path: &'a str,
+    registry: &'a Option<String>,
 }
 
 impl ser::Serialize for Package {
@@ -49,6 +50,7 @@ impl ser::Serialize for Package {
         let license = manmeta.license.as_ref().map(String::as_ref);
         let license_file = manmeta.license_file.as_ref().map(String::as_ref);
         let description = manmeta.description.as_ref().map(String::as_ref);
+        let registry = self.manifest.registry();
 
         SerializedPackage {
             name: &package_id.name(),
@@ -62,6 +64,7 @@ impl ser::Serialize for Package {
             targets: &self.manifest.targets(),
             features: summary.features(),
             manifest_path: &self.manifest_path.display().to_string(),
+            registry: registry,
         }.serialize(s)
     }
 }
@@ -94,6 +97,7 @@ impl Package {
     pub fn version(&self) -> &Version { self.package_id().version() }
     pub fn authors(&self) -> &Vec<String> { &self.manifest.metadata().authors }
     pub fn publish(&self) -> bool { self.manifest.publish() }
+    pub fn registry(&self) -> &Option<String> { &self.manifest.registry() }
 
     pub fn has_custom_build(&self) -> bool {
         self.targets().iter().any(|t| t.is_custom_build())

--- a/src/doc/manifest.md
+++ b/src/doc/manifest.md
@@ -150,6 +150,11 @@ license = "..."
 # (similar to the readme key).
 license-file = "..."
 
+# This optional URL points to a registry index. The package will then be
+# published to the registry specified rather than the default. When publishing,
+# this index must be given as the host.
+registry = "..."
+
 # Optional specification of badges to be displayed on crates.io. The badges
 # currently available are Travis CI, Appveyor, and GitLab latest build status,
 # specified using the following parameters:

--- a/src/doc/specifying-dependencies.md
+++ b/src/doc/specifying-dependencies.md
@@ -99,6 +99,17 @@ Here are some examples of inequality requirements:
 Multiple version requirements can also be separated with a comma, e.g. `>= 1.2,
 < 1.5`.
 
+# Specifying dependencies from a custom registry
+
+To use a custom registry (rather than crates.io) for a dependency, specify the
+url of the index:
+
+```toml
+[dependencies.rand]
+version = "0.1.11"
+registry = "https://github.com/my_awesome_fork/crates.io-index"
+```
+
 # Specifying dependencies from `git` repositories
 
 To depend on a library located in a `git` repository, the minimum information

--- a/tests/metadata.rs
+++ b/tests/metadata.rs
@@ -23,6 +23,7 @@ fn cargo_metadata_simple() {
                 "license": null,
                 "license_file": null,
                 "description": null,
+                "registry": null,
                 "targets": [
                     {
                         "kind": [
@@ -94,6 +95,7 @@ crate-type = ["lib", "staticlib"]
                 "license": null,
                 "license_file": null,
                 "description": null,
+                "registry": null,
                 "targets": [
                     {
                         "kind": [
@@ -164,6 +166,7 @@ fn cargo_metadata_with_deps_and_version() {
                 "license": null,
                 "license_file": null,
                 "description": null,
+                "registry": null,
                 "targets": [
                     {
                         "kind": [
@@ -199,6 +202,7 @@ fn cargo_metadata_with_deps_and_version() {
                 "license": null,
                 "license_file": null,
                 "description": null,
+                "registry": null,
                 "targets": [
                     {
                         "kind": [
@@ -234,6 +238,7 @@ fn cargo_metadata_with_deps_and_version() {
                 "license": "MIT",
                 "license_file": null,
                 "description": "foo",
+                "registry": null,
                 "targets": [
                     {
                         "kind": [
@@ -302,6 +307,7 @@ name = "ex"
                 "description": null,
                 "source": null,
                 "dependencies": [],
+                "registry": null,
                 "targets": [
                     {
                         "kind": [ "lib" ],
@@ -364,6 +370,7 @@ crate-type = ["rlib", "dylib"]
                 "description": null,
                 "source": null,
                 "dependencies": [],
+                "registry": null,
                 "targets": [
                     {
                         "kind": [ "lib" ],
@@ -423,6 +430,7 @@ fn workspace_metadata() {
                 "license": null,
                 "license_file": null,
                 "description": null,
+                "registry": null,
                 "targets": [
                     {
                         "kind": [ "lib" ],
@@ -443,6 +451,7 @@ fn workspace_metadata() {
                 "license": null,
                 "license_file": null,
                 "description": null,
+                "registry": null,
                 "targets": [
                     {
                         "kind": [ "lib" ],
@@ -498,6 +507,7 @@ fn workspace_metadata_no_deps() {
                 "license": null,
                 "license_file": null,
                 "description": null,
+                "registry": null,
                 "targets": [
                     {
                         "kind": [ "lib" ],
@@ -518,6 +528,7 @@ fn workspace_metadata_no_deps() {
                 "license": null,
                 "license_file": null,
                 "description": null,
+                "registry": null,
                 "targets": [
                     {
                         "kind": [ "lib" ],
@@ -562,6 +573,7 @@ const MANIFEST_OUTPUT: &'static str=
         "license": null,
         "license_file": null,
         "description": null,
+        "registry": null,
         "targets":[{
             "kind":["bin"],
             "crate_types":["bin"],

--- a/tests/read-manifest.rs
+++ b/tests/read-manifest.rs
@@ -14,6 +14,7 @@ static MANIFEST_OUTPUT: &'static str = r#"
     "description": null,
     "source":null,
     "dependencies":[],
+    "registry": null,
     "targets":[{
         "kind":["bin"],
         "crate_types":["bin"],


### PR DESCRIPTION
Currently, cargo supports crates.io and local registries, but not non-local non-crates.io registries (e.g. https://github.com/my_awesome_fork/crates.io-index) - see #3917. This PR adds support for such registries to cargo.

There are two main changes: 
 
1. You can now specify a registry index using the `registry` key in the `packages` section of `Cargo.toml`. When `cargo publish`ing, cargo verifies that the host being published to matches the specified registry index. 
2. Dependencies can now have a `registry` specified. Cargo will look in that registry rather than crates.io for the dependencies with that key set. 
 
A `Cargo.toml` using these features might look like: 
 
```toml 
[package] 
name = "registry-test" 
version = "0.1.0" 
authors = ["Christopher Swindle <christopher.swindle@metaswitch.com>"] 
registry = "https://github.com/my_awesome_fork/crates.io-index" 
 
[dependencies] 
libc = { version = "*", registry = "https://github.com/my_second_awesome_fork/crates.io-index" } 
```

We are also planning on pushing changes to the crates.io repo to allow setting up a private registry, but that requires tidying before we do so.