### PR TITLE
Don't use a bare checkout of the index

### DIFF
--- a/src/cargo/sources/registry/remote.rs
+++ b/src/cargo/sources/registry/remote.rs
@@ -63,7 +63,19 @@ impl<'cfg> RemoteRegistry<'cfg> {
                                                        self.config,
                                                        "the registry index")?;
                     let _ = lock.remove_siblings();
-                    Ok(git2::Repository::init_bare(&path)?)
+
+                    // Note that we'd actually prefer to use a bare repository
+                    // here as we're not actually going to check anything out.
+                    // All versions of Cargo, though, share the same CARGO_HOME,
+                    // so for compatibility with older Cargo which *does* do
+                    // checkouts we make sure to initialize a new full
+                    // repository (not a bare one).
+                    //
+                    // We should change this to `init_bare` whenever we feel
+                    // like enough time has passed or if we change the directory
+                    // that the folder is located in, such as by changing the
+                    // hash at the end of the directory.
+                    Ok(git2::Repository::init(&path)?)
                 }
             }
         })


### PR DESCRIPTION
Both old and new Cargo share the same index, so be sure to maintain
compatibility by initializing a non-bare repository for the index. Note that
a nightly Cargo still won't check out the index, but when an older Cargo comes
along and tries to check it out then it'll work.

Closes #4058