### PR TITLE
Adding Workspace DIR functionality

### DIFF
--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -201,6 +201,17 @@ impl<'cfg> Workspace<'cfg> {
         }.parent().unwrap()
     }
 
+    /// Returns the root path of this workspace.
+    ///
+    /// That is, this returns the path of the directory containing the
+    /// `Cargo.toml` which is the root of this workspace.
+    pub fn workspace_dir(&self) -> Option<&Path> {
+        match self.root_manifest {
+            Some(ref p) => p.parent(),
+            None => None
+        }
+    }
+
     pub fn target_dir(&self) -> Filesystem {
         self.target_dir.clone().unwrap_or_else(|| {
             Filesystem::new(self.root().join("target"))

--- a/src/cargo/ops/cargo_rustc/custom_build.rs
+++ b/src/cargo/ops/cargo_rustc/custom_build.rs
@@ -120,6 +120,10 @@ fn build_work<'a, 'cfg>(cx: &mut Context<'a, 'cfg>, unit: &Unit<'a>)
         cmd.env("CARGO_MANIFEST_LINKS", links);
     }
 
+    if let Some(ws_dir) = cx.ws.workspace_dir() {
+        cmd.env("CARGO_WORKSPACE_DIR", ws_dir);
+    }
+
     // Be sure to pass along all enabled features for this package, this is the
     // last piece of statically known information that we have.
     for feat in cx.resolve.features(unit.pkg.package_id()).iter() {

--- a/src/doc/environment-variables.md
+++ b/src/doc/environment-variables.md
@@ -75,6 +75,8 @@ let out_dir = env::var("OUT_DIR").unwrap();
                          script). Also note that this is the value of the
                          current working directory of the build script when it
                          starts.
+* `CARGO_WORKSPACE_DIR` - The directory containing the manifest of the workspace,
+                          for the package being built.
 * `CARGO_MANIFEST_LINKS` - the manifest `links` value.
 * `CARGO_FEATURE_<name>` - For each activated feature of the package being
                            built, this environment variable will be present


### PR DESCRIPTION
This is the basic code I did to get #3946 fixed.

The functionality is about allowing `build.rs` custom build script to find Workspace directory, so it could extract some data, etc. It's possible, it makes sense for this environment variable to be present even during regular `cargo build`.

Workspace directory variable is called `CARGO_WORKSPACE_DIR` and points to workspace directory (one with `Cargo.toml` that declares members), regardless of which crate from workspace called it. If the crate built doesn't have a workspace there will be no value in `CARGO_WORKSPACE_DIR`, i.e. `env!("CARGO_WORKSPACE_DIR")` will be `Err(NotPresent)`.