### PR TITLE
Reorganize, warn ab. panic=abort with test/bench

### DIFF
--- a/src/cargo/util/toml.rs
+++ b/src/cargo/util/toml.rs
@@ -951,8 +951,8 @@ impl TomlManifest {
             }).collect()
         }
 
-        /// Will check a list of toml targets, and make sure the target names are unique within a vector.
-        /// If not, the name of the offending binary target is returned.
+        /// Will check a list of toml targets, and make sure the target names are unique within a
+        /// vector. If not, the name of the offending binary target is returned.
         fn unique_names_in_targets(targets: &[TomlTarget]) -> Result<(), String> {
             let mut seen = HashSet::new();
             for v in targets.iter().map(|e| e.name()) {
@@ -963,8 +963,8 @@ impl TomlManifest {
             Ok(())
         }
 
-        /// Will check a list of build targets, and make sure the target names are unique within a vector.
-        /// If not, the name of the offending build target is returned.
+        /// Will check a list of build targets, and make sure the target names are unique within a
+        /// vector. If not, the name of the offending build target is returned.
         fn unique_build_targets(targets: &[Target], layout: &Layout) -> Result<(), String> {
             let mut seen = HashSet::new();
             for v in targets.iter().map(|e| layout.root.join(e.src_path())) {

--- a/tests/freshness.rs
+++ b/tests/freshness.rs
@@ -211,18 +211,18 @@ fn changing_profiles_caches_targets() {
     assert_that(p.cargo_process("build"),
                 execs().with_status(0)
                        .with_stderr("\
-[..]Compiling foo v0.0.1 ([..])
 warning: The test/bench targets cannot have panic=abort because they'll all get compiled with \
---test which requires the unwind runtime currently.
+--test which requires the unwind runtime currently. \n\
+[..]Compiling foo v0.0.1 ([..])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
 
     assert_that(p.cargo("test"),
                 execs().with_status(0)
                        .with_stderr("\
-[..]Compiling foo v0.0.1 ([..])
 warning: The test/bench targets cannot have panic=abort because they'll all get compiled with \
---test which requires the unwind runtime currently.
+--test which requires the unwind runtime currently. \n\
+[..]Compiling foo v0.0.1 ([..])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target[..]debug[..]deps[..]foo-[..][EXE]
 [DOCTEST] foo
@@ -233,12 +233,16 @@ warning: The test/bench targets cannot have panic=abort because they'll all get 
     assert_that(p.cargo("build"),
                 execs().with_status(0)
                        .with_stderr("\
+warning: The test/bench targets cannot have panic=abort because they'll all get compiled with \
+--test which requires the unwind runtime currently. \n\
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
 
     assert_that(p.cargo("test").arg("foo"),
                 execs().with_status(0)
                        .with_stderr("\
+warning: The test/bench targets cannot have panic=abort because they'll all get compiled with \
+--test which requires the unwind runtime currently. \n\
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target[..]debug[..]deps[..]foo-[..][EXE]
 [DOCTEST] foo

--- a/tests/freshness.rs
+++ b/tests/freshness.rs
@@ -212,6 +212,8 @@ fn changing_profiles_caches_targets() {
                 execs().with_status(0)
                        .with_stderr("\
 [..]Compiling foo v0.0.1 ([..])
+warning: The test/bench targets cannot have panic=abort because they'll all get compiled with \
+--test which requires the unwind runtime currently.
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
 
@@ -219,6 +221,8 @@ fn changing_profiles_caches_targets() {
                 execs().with_status(0)
                        .with_stderr("\
 [..]Compiling foo v0.0.1 ([..])
+warning: The test/bench targets cannot have panic=abort because they'll all get compiled with \
+--test which requires the unwind runtime currently.
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target[..]debug[..]deps[..]foo-[..][EXE]
 [DOCTEST] foo


### PR DESCRIPTION
This PR resolves https://github.com/rust-lang/cargo/issues/3166#issuecomment-301579136 a bit more thoroughly.

* Was partially using information hiding by using nested functions. Apply this more consistently.
* Add warning when panic runtime parameter shall be ignored since set in test or bench profile.

The new stuff is only a few lines down here https://github.com/rust-lang/cargo/compare/master...sanmai-NL:Reorganize_toml.rs_warn_about_panic_runtime#diff-f4550ee862e63b97b52a09a7f644ac7bR651 .