### PR TITLE
Fix a serialization error on publish

### DIFF
--- a/src/cargo/util/toml.rs
+++ b/src/cargo/util/toml.rs
@@ -656,7 +656,10 @@ impl TomlManifest {
                     TomlDependency::Detailed(d)
                 }
                 TomlDependency::Simple(ref s) => {
-                    TomlDependency::Simple(s.clone())
+                    TomlDependency::Detailed(DetailedTomlDependency {
+                        version: Some(s.clone()),
+                        ..Default::default()
+                    })
                 }
             }
         }

--- a/tests/package.rs
+++ b/tests/package.rs
@@ -12,6 +12,7 @@ use std::path::{Path, PathBuf};
 
 use cargotest::{cargo_process, process};
 use cargotest::support::{project, execs, paths, git, path2url, cargo_exe};
+use cargotest::support::registry::Package;
 use flate2::read::GzDecoder;
 use hamcrest::{assert_that, existing_file, contains, equal_to};
 use tar::Archive;
@@ -663,6 +664,7 @@ fn ignore_workspace_specifier() {
             [project]
             name = "foo"
             version = "0.0.1"
+
             authors = []
 
             [workspace]
@@ -713,4 +715,25 @@ name = "bar"
 version = "0.1.0"
 authors = []
 "#));
+}
+
+#[test]
+fn package_two_kinds_of_deps() {
+    Package::new("other", "1.0.0").publish();
+    Package::new("other1", "1.0.0").publish();
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [project]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+
+            [dependencies]
+            other = "1.0"
+            other1 = { version = "1.0" }
+        "#)
+        .file("src/main.rs", "");
+
+    assert_that(p.cargo_process("package").arg("--no-verify"),
+                execs().with_status(0));
 }


### PR DESCRIPTION
In TOML we have to emit all keys before we emit all sub-tables, so to handle
that for dependencies just transform everything to an elaborated version.

Closes #4081