### PR TITLE
Write stderr output from build-scripts next to stdout output

### DIFF
--- a/src/cargo/ops/cargo_rustc/custom_build.rs
+++ b/src/cargo/ops/cargo_rustc/custom_build.rs
@@ -164,7 +164,12 @@ fn build_work<'a, 'cfg>(cx: &mut Context<'a, 'cfg>, unit: &Unit<'a>)
     let pkg_name = unit.pkg.to_string();
     let build_state = cx.build_state.clone();
     let id = unit.pkg.package_id().clone();
-    let output_file = build_output.parent().unwrap().join("output");
+    let (output_file, err_file) = {
+        let build_output_parent = build_output.parent().unwrap();
+        let output_file = build_output_parent.join("output");
+        let err_file = build_output_parent.join("stderr");
+        (output_file, err_file)
+    };
     let all = (id.clone(), pkg_name.clone(), build_state.clone(),
                output_file.clone());
     let build_scripts = super::load_build_deps(cx, unit);
@@ -237,7 +242,9 @@ fn build_work<'a, 'cfg>(cx: &mut Context<'a, 'cfg>, unit: &Unit<'a>)
                              pkg_name, e.desc);
             Human(e)
         })?;
+
         paths::write(&output_file, &output.stdout)?;
+        paths::write(&err_file, &output.stderr)?;
 
         // After the build command has finished running, we need to be sure to
         // remember all of its output so we can later discover precisely what it

--- a/src/doc/build-script.md
+++ b/src/doc/build-script.md
@@ -58,6 +58,9 @@ cargo:libdir=/path/to/foo/lib
 cargo:include=/path/to/foo/include
 ```
 
+On the other hand, lines printed to stderr are written to a file like
+`target/debug/build/<pkg>/stderr` but are not interpreted by cargo.
+
 There are a few special keys that Cargo recognizes, some affecting how the
 crate is built:
 


### PR DESCRIPTION
Closes #3462.

Please let me know if you want to change the file name for the error output. I originally thought that `stdout` and `stderr` would have been nice but I'm worried that changing `output` to `stdout` would cause breakage. So I choose the more conservative route.