### PR TITLE
Add temporary vim files to .gitignore

### DIFF
--- a/src/cargo/ops/cargo_new.rs
+++ b/src/cargo/ops/cargo_new.rs
@@ -384,7 +384,7 @@ fn mk(config: &Config, opts: &MkOptions) -> CargoResult<()> {
     let path = opts.path;
     let name = opts.name;
     let cfg = global_config(config)?;
-    let ignore = ["target/\n", "**/*.rs.bk\n",
+    let ignore = ["target/\n", "**/*.rs.bk\n", "*.sw[op]\n",
         if !opts.bin { "Cargo.lock\n" } else { "" }]
         .concat();
 


### PR DESCRIPTION
The first thing I do when creating a new project is editing the .gitignore to ignore temporary vim files. This patch would make git ignore `*.swp` and `*.swo` directly after cargo new, similar to `*.rs.bk`.