### PR TITLE
Do not output "Blocking - waiting for lock" with -q

### DIFF
--- a/src/cargo/core/shell.rs
+++ b/src/cargo/core/shell.rs
@@ -90,13 +90,20 @@ impl MultiShell {
         }
     }
 
-    pub fn status<T, U>(&mut self, status: T, message: U) -> CargoResult<()>
+    pub fn status_with_color<T, U>(&mut self, status: T, message: U, color: Color)
+                                   -> CargoResult<()>
         where T: fmt::Display, U: fmt::Display
     {
         match self.verbosity {
             Quiet => Ok(()),
-            _ => self.err().say_status(status, message, GREEN, true)
+            _ => self.err().say_status(status, message, color, true)
         }
+    }
+
+    pub fn status<T, U>(&mut self, status: T, message: U) -> CargoResult<()>
+        where T: fmt::Display, U: fmt::Display
+    {
+        self.status_with_color(status, message, GREEN)
     }
 
     pub fn verbose<F>(&mut self, mut callback: F) -> CargoResult<()>

--- a/src/cargo/util/flock.rs
+++ b/src/cargo/util/flock.rs
@@ -288,7 +288,7 @@ fn acquire(config: &Config,
         }
     }
     let msg = format!("waiting for file lock on {}", msg);
-    config.shell().err().say_status("Blocking", &msg, CYAN, true)?;
+    config.shell().status_with_color("Blocking", &msg, CYAN)?;
 
     return block().chain_error(|| {
         human(format!("failed to lock file: {}", path.display()))


### PR DESCRIPTION
This is not an error, so it should not be printed unconditionally
to stderr.  Since it can appear intermittently (e.g. due to editor
integration calling build every now and then) it will disturb
things that expect exact output from cargo (e.g. test suites).