### PR TITLE
Optimize a slew of Cargo internals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,6 +28,7 @@ dependencies = [
  "openssl 0.9.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "psapi-sys 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "scoped-tls 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -624,6 +625,11 @@ version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "scoped-tls"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "semver"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -921,6 +927,7 @@ dependencies = [
 "checksum regex-syntax 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ad890a5eef7953f55427c50575c680c42841653abd2b028b68cd223d157f62db"
 "checksum rustc-demangle 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "3058a43ada2c2d0b92b3ae38007a2d0fa5e9db971be260e0171408a4ff471c95"
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
+"checksum scoped-tls 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f417c22df063e9450888a7561788e9bd46d3bb3c1466435b4eccb903807f147d"
 "checksum semver 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3fdd61b85a0fa777f7fb7c454b9189b2941b110d1385ce84d7f76efdf1606a85"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 "checksum serde 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)" = "c2f530d36fb84ec48fb7146936881f026cdbf4892028835fd9398475f82c1bb4"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,7 +25,7 @@ dependencies = [
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl 0.9.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl 0.9.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "psapi-sys 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -34,11 +34,11 @@ dependencies = [
  "serde_ignored 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "shell-escape 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "tar 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tar 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "term 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -72,7 +72,7 @@ name = "backtrace"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "backtrace-sys 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "backtrace-sys 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "dbghelp-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -83,7 +83,7 @@ dependencies = [
 
 [[package]]
 name = "backtrace-sys"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "gcc 0.3.50 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -97,7 +97,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "bitflags"
-version = "0.8.2"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -121,10 +121,10 @@ dependencies = [
  "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tar 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tar 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "term 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -150,7 +150,7 @@ dependencies = [
  "serde 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -166,7 +166,7 @@ dependencies = [
  "curl-sys 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl-probe 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl-sys 0.9.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys 0.9.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -178,7 +178,7 @@ dependencies = [
  "gcc 0.3.50 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "libz-sys 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl-sys 0.9.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys 0.9.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -280,8 +280,8 @@ dependencies = [
  "libc 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "libgit2-sys 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl-probe 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl-sys 0.9.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys 0.9.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -292,7 +292,7 @@ dependencies = [
  "curl 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "git2 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -315,7 +315,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "matches 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-bidi 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-bidi 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-normalization 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -365,7 +365,7 @@ dependencies = [
  "libc 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "libssh2-sys 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "libz-sys 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl-sys 0.9.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys 0.9.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -377,7 +377,7 @@ dependencies = [
  "cmake 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "libz-sys 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl-sys 0.9.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys 0.9.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -525,14 +525,14 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.9.12"
+version = "0.9.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bitflags 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "foreign-types 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl-sys 0.9.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys 0.9.13 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -542,7 +542,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.12"
+version = "0.9.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "gcc 0.3.50 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -710,7 +710,7 @@ dependencies = [
 
 [[package]]
 name = "tar"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "filetime 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -779,7 +779,7 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "matches 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "idna 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -860,9 +860,9 @@ dependencies = [
 "checksum aho-corasick 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ca972c2ea5f742bfce5687b9aef75506a764f61d37f8f649047846a9686ddb66"
 "checksum aho-corasick 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "500909c4f87a9e52355b26626d890833e9e1d53ac566db76c36faa984b889699"
 "checksum backtrace 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "72f9b4182546f4b04ebc4ab7f84948953a118bd6021a1b6a6c909e3e94f6be76"
-"checksum backtrace-sys 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "d192fd129132fbc97497c1f2ec2c2c5174e376b95f535199ef4fe0a293d33842"
+"checksum backtrace-sys 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "3a0d842ea781ce92be2bf78a9b38883948542749640b8378b3b2f03d1fd9f1ff"
 "checksum bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aad18937a628ec6abcd26d1489012cc0e18c21798210f491af69ded9b881106d"
-"checksum bitflags 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1370e9fc2a6ae53aea8b7a5110edbd08836ed87c88736dfabccade1c2b44bff4"
+"checksum bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4efd02e230a02e18f92fc2735f44597385ed02ad8f831e7c1c1156ee5e1ab3a5"
 "checksum bufstream 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "f2f382711e76b9de6c744cc00d0497baba02fb00a787f088c879f01d09468e32"
 "checksum cfg-if 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "de1e760d7b6535af4241fca8bd8adf68e2e7edacc6b29f5d399050c5e48cf88c"
 "checksum cmake 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)" = "b8ebbb35d3dc9cd09497168f33de1acb79b265d350ab0ac34133b98f8509af1f"
@@ -908,9 +908,9 @@ dependencies = [
 "checksum num-rational 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)" = "c2dc5ea04020a8f18318ae485c751f8cfa1c0e69dcf465c29ddaaa64a313cc44"
 "checksum num-traits 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "e1cbfa3781f3fe73dc05321bed52a06d2d491eaa764c52335cf4399f046ece99"
 "checksum num_cpus 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f6e850c7f35c3de263e6094e819f6b4b9c09190ff4438fc6dec1aef1568547bc"
-"checksum openssl 0.9.12 (registry+https://github.com/rust-lang/crates.io-index)" = "bb5d1663b73d10c6a3eda53e2e9d0346f822394e7b858d7257718f65f61dfbe2"
+"checksum openssl 0.9.13 (registry+https://github.com/rust-lang/crates.io-index)" = "b34cd77cf91301fff3123fbd46b065c3b728b17a392835de34c397315dce5586"
 "checksum openssl-probe 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d98df0270d404ccd3c050a41d579c52d1db15375168bb3471e04ec0f5f378daf"
-"checksum openssl-sys 0.9.12 (registry+https://github.com/rust-lang/crates.io-index)" = "3a5886d87d3e2a0d890bf62dc8944f5e3769a405f7e1e9ef6e517e47fd7a0897"
+"checksum openssl-sys 0.9.13 (registry+https://github.com/rust-lang/crates.io-index)" = "e035022a50faa380bd7ccdbd184d946ce539ebdb0a358780de92a995882af97a"
 "checksum pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "3a8b4c6b8165cd1a1cd4b9b120978131389f64bdaf456435caa41e630edba903"
 "checksum psapi-sys 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "abcd5d1a07d360e29727f757a9decb3ce8bc6e0efa8969cfaad669a8317a2478"
 "checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
@@ -932,7 +932,7 @@ dependencies = [
 "checksum strsim 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b4d15c810519a91cf877e7e36e63fe068815c678181439f2f29e2562147c3694"
 "checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
 "checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
-"checksum tar 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)" = "ab0ef9ead2fe0aa9e18475a96a207bfd5143f4124779ef7429503a8665416ce8"
+"checksum tar 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)" = "281285b717926caa919ad905ef89c63d75805c7d89437fb873100925a53f2b1b"
 "checksum tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "87974a6f5c1dfb344d733055601650059a3363de2a6104819293baff662132d6"
 "checksum term 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "d168af3930b369cfe245132550579d47dfd873d69470755a19c2c6568dbbd989"
 "checksum thread-id 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a9539db560102d1cef46b8b78ce737ff0bb64e7e18d35b2a5688f7d097d0ff03"
@@ -940,11 +940,11 @@ dependencies = [
 "checksum thread_local 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "8576dbbfcaef9641452d5cf0df9b0e7eeab7694956dd33bb61515fb8f18cfdd5"
 "checksum thread_local 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c85048c6260d17cf486ceae3282d9fb6b90be220bf5b28c400f5485ffc29f0c7"
 "checksum toml 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4cc5dbfb20a481e64b99eb7ae280859ec76730c7191570ba5edaa962394edb0a"
-"checksum unicode-bidi 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "916219eb752dd865717c9b21064401c6ee843dc91ed659c144591e0c87c56d59"
+"checksum unicode-bidi 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a6a2c4e3710edd365cd7e78383153ed739fa31af19f9172f72d3575060f5a43a"
 "checksum unicode-normalization 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "e28fa37426fceeb5cf8f41ee273faa7c82c47dc8fba5853402841e665fcd86ff"
 "checksum unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
 "checksum unreachable 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1f2ae5ddb18e1c92664717616dd9549dde73f539f01bd7b77c2edb2446bdff91"
-"checksum url 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f5ba8a749fb4479b043733416c244fa9d1d3af3d7c23804944651c8a448cb87e"
+"checksum url 1.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3e2ba3456fbe5c0098cb877cf08b92b76c3e18e0be9e47c35b487220d377d24e"
 "checksum user32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4ef4711d107b21b410a3a974b1204d9accc8b10dad75d8324b5d755de1617d47"
 "checksum utf8-ranges 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a1ca13c08c41c9c3e04224ed9ff80461d97e121589ff27c753a16cb10830ae0f"
 "checksum utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "662fab6525a98beff2921d7f61a39e7d59e0b425ebc7d0d9e66d316e55124122"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ libgit2-sys = "0.6"
 log = "0.3"
 num_cpus = "1.0"
 rustc-serialize = "0.3"
+scoped-tls = "0.1"
 semver = { version = "0.7.0", features = ["serde"] }
 serde = "1.0"
 serde_derive = "1.0"

--- a/src/bin/cargo.rs
+++ b/src/bin/cargo.rs
@@ -337,7 +337,7 @@ fn execute_external_subcommand(config: &Config, cmd: &str, args: &[String]) -> C
             return Err(CliError::code(code));
         }
     }
-    Err(CliError::new(err, 101))    
+    Err(CliError::new(err, 101))
 }
 
 /// List all runnable commands

--- a/src/cargo/core/dependency.rs
+++ b/src/cargo/core/dependency.rs
@@ -180,49 +180,49 @@ this warning.
         self.platform.as_ref()
     }
 
-    pub fn set_kind(mut self, kind: Kind) -> DependencyInner {
+    pub fn set_kind(&mut self, kind: Kind) -> &mut DependencyInner {
         self.kind = kind;
         self
     }
 
     /// Sets the list of features requested for the package.
-    pub fn set_features(mut self, features: Vec<String>) -> DependencyInner {
+    pub fn set_features(&mut self, features: Vec<String>) -> &mut DependencyInner {
         self.features = features;
         self
     }
 
     /// Sets whether the dependency requests default features of the package.
-    pub fn set_default_features(mut self, default_features: bool) -> DependencyInner {
+    pub fn set_default_features(&mut self, default_features: bool) -> &mut DependencyInner {
         self.default_features = default_features;
         self
     }
 
     /// Sets whether the dependency is optional.
-    pub fn set_optional(mut self, optional: bool) -> DependencyInner {
+    pub fn set_optional(&mut self, optional: bool) -> &mut DependencyInner {
         self.optional = optional;
         self
     }
 
     /// Set the source id for this dependency
-    pub fn set_source_id(mut self, id: SourceId) -> DependencyInner {
+    pub fn set_source_id(&mut self, id: SourceId) -> &mut DependencyInner {
         self.source_id = id;
         self
     }
 
     /// Set the version requirement for this dependency
-    pub fn set_version_req(mut self, req: VersionReq) -> DependencyInner {
+    pub fn set_version_req(&mut self, req: VersionReq) -> &mut DependencyInner {
         self.req = req;
         self
     }
 
-    pub fn set_platform(mut self, platform: Option<Platform>)
-                        -> DependencyInner {
+    pub fn set_platform(&mut self, platform: Option<Platform>)
+                        -> &mut DependencyInner {
         self.platform = platform;
         self
     }
 
     /// Lock this dependency to depending on the specified package id
-    pub fn lock_to(self, id: &PackageId) -> DependencyInner {
+    pub fn lock_to(&mut self, id: &PackageId) -> &mut DependencyInner {
         assert_eq!(self.source_id, *id.source_id());
         assert!(self.req.matches(id.version()));
         self.set_version_req(VersionReq::exact(id.version()))
@@ -303,8 +303,20 @@ impl Dependency {
     }
 
     /// Lock this dependency to depending on the specified package id
-    pub fn lock_to(self, id: &PackageId) -> Dependency {
-        self.clone_inner().lock_to(id).into_dependency()
+    pub fn lock_to(mut self, id: &PackageId) -> Dependency {
+        Rc::make_mut(&mut self.inner).lock_to(id);
+        self
+    }
+
+    /// Set the version requirement for this dependency
+    pub fn set_version_req(&mut self, req: VersionReq) -> &mut Dependency {
+        Rc::make_mut(&mut self.inner).set_version_req(req);
+        self
+    }
+
+    pub fn set_kind(&mut self, kind: Kind) -> &mut Dependency {
+        Rc::make_mut(&mut self.inner).set_kind(kind);
+        self
     }
 
     /// Returns false if the dependency is only used to build the local package.
@@ -327,14 +339,14 @@ impl Dependency {
         self.inner.matches_id(id)
     }
 
-    pub fn map_source(self, to_replace: &SourceId, replace_with: &SourceId)
+    pub fn map_source(mut self, to_replace: &SourceId, replace_with: &SourceId)
                       -> Dependency {
         if self.source_id() != to_replace {
             self
         } else {
-            Rc::try_unwrap(self.inner).unwrap_or_else(|r| (*r).clone())
-               .set_source_id(replace_with.clone())
-               .into_dependency()
+            Rc::make_mut(&mut self.inner)
+                .set_source_id(replace_with.clone());
+            self
         }
     }
 }

--- a/src/cargo/core/dependency.rs
+++ b/src/cargo/core/dependency.rs
@@ -14,12 +14,12 @@ use util::errors::{CargoResult, CargoResultExt, CargoError};
 /// Cheap to copy.
 #[derive(PartialEq, Clone, Debug)]
 pub struct Dependency {
-    inner: Rc<DependencyInner>,
+    inner: Rc<Inner>,
 }
 
 /// The data underlying a Dependency.
 #[derive(PartialEq, Clone, Debug)]
-pub struct DependencyInner {
+struct Inner {
     name: String,
     source_id: SourceId,
     req: VersionReq,
@@ -79,6 +79,40 @@ pub enum Kind {
     Build,
 }
 
+fn parse_req_with_deprecated(req: &str,
+                             extra: Option<(&PackageId, &Config)>)
+                             -> CargoResult<VersionReq> {
+    match VersionReq::parse(req) {
+        Err(e) => {
+            let (inside, config) = match extra {
+                Some(pair) => pair,
+                None => return Err(e.into()),
+            };
+            match e {
+                ReqParseError::DeprecatedVersionRequirement(requirement) => {
+                    let msg = format!("\
+parsed version requirement `{}` is no longer valid
+
+Previous versions of Cargo accepted this malformed requirement,
+but it is being deprecated. This was found when parsing the manifest
+of {} {}, and the correct version requirement is `{}`.
+
+This will soon become a hard error, so it's either recommended to
+update to a fixed version or contact the upstream maintainer about
+this warning.
+",
+req, inside.name(), inside.version(), requirement);
+                    config.shell().warn(&msg)?;
+
+                    Ok(requirement)
+                }
+                e => Err(e.into()),
+            }
+        },
+        Ok(v) => Ok(v),
+    }
+}
+
 impl ser::Serialize for Kind {
     fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
         where S: ser::Serializer,
@@ -91,177 +125,6 @@ impl ser::Serialize for Kind {
     }
 }
 
-impl DependencyInner {
-    /// Attempt to create a `Dependency` from an entry in the manifest.
-    ///
-    /// The `deprecated_extra` information is set to `Some` when this method
-    /// should *also* parse historically deprecated semver requirements. This
-    /// information allows providing diagnostic information about what's going
-    /// on.
-    ///
-    /// If set to `None`, then historically deprecated semver requirements will
-    /// all be rejected.
-    pub fn parse(name: &str,
-                 version: Option<&str>,
-                 source_id: &SourceId,
-                 deprecated_extra: Option<(&PackageId, &Config)>)
-                 -> CargoResult<DependencyInner> {
-        let (specified_req, version_req) = match version {
-            Some(v) => (true, DependencyInner::parse_with_deprecated(v, deprecated_extra)?),
-            None => (false, VersionReq::any())
-        };
-
-        Ok(DependencyInner {
-            only_match_name: false,
-            req: version_req,
-            specified_req: specified_req,
-            .. DependencyInner::new_override(name, source_id)
-        })
-    }
-
-    fn parse_with_deprecated(req: &str,
-                             extra: Option<(&PackageId, &Config)>)
-                             -> CargoResult<VersionReq> {
-        match VersionReq::parse(req) {
-            Err(e) => {
-                let (inside, config) = match extra {
-                    Some(pair) => pair,
-                    None => return Err(e.into()),
-                };
-                match e {
-                    ReqParseError::DeprecatedVersionRequirement(requirement) => {
-                        let msg = format!("\
-parsed version requirement `{}` is no longer valid
-
-Previous versions of Cargo accepted this malformed requirement,
-but it is being deprecated. This was found when parsing the manifest
-of {} {}, and the correct version requirement is `{}`.
-
-This will soon become a hard error, so it's either recommended to
-update to a fixed version or contact the upstream maintainer about
-this warning.
-",
-    req, inside.name(), inside.version(), requirement);
-                        config.shell().warn(&msg)?;
-
-                        Ok(requirement)
-                    }
-                    e => Err(e.into()),
-                }
-            },
-            Ok(v) => Ok(v),
-        }
-    }
-
-    pub fn new_override(name: &str, source_id: &SourceId) -> DependencyInner {
-        DependencyInner {
-            name: name.to_string(),
-            source_id: source_id.clone(),
-            req: VersionReq::any(),
-            kind: Kind::Normal,
-            only_match_name: true,
-            optional: false,
-            features: Vec::new(),
-            default_features: true,
-            specified_req: false,
-            platform: None,
-        }
-    }
-
-    pub fn version_req(&self) -> &VersionReq { &self.req }
-    pub fn name(&self) -> &str { &self.name }
-    pub fn source_id(&self) -> &SourceId { &self.source_id }
-    pub fn kind(&self) -> Kind { self.kind }
-    pub fn specified_req(&self) -> bool { self.specified_req }
-
-    /// If none, this dependency must be built for all platforms.
-    /// If some, it must only be built for matching platforms.
-    pub fn platform(&self) -> Option<&Platform> {
-        self.platform.as_ref()
-    }
-
-    pub fn set_kind(&mut self, kind: Kind) -> &mut DependencyInner {
-        self.kind = kind;
-        self
-    }
-
-    /// Sets the list of features requested for the package.
-    pub fn set_features(&mut self, features: Vec<String>) -> &mut DependencyInner {
-        self.features = features;
-        self
-    }
-
-    /// Sets whether the dependency requests default features of the package.
-    pub fn set_default_features(&mut self, default_features: bool) -> &mut DependencyInner {
-        self.default_features = default_features;
-        self
-    }
-
-    /// Sets whether the dependency is optional.
-    pub fn set_optional(&mut self, optional: bool) -> &mut DependencyInner {
-        self.optional = optional;
-        self
-    }
-
-    /// Set the source id for this dependency
-    pub fn set_source_id(&mut self, id: SourceId) -> &mut DependencyInner {
-        self.source_id = id;
-        self
-    }
-
-    /// Set the version requirement for this dependency
-    pub fn set_version_req(&mut self, req: VersionReq) -> &mut DependencyInner {
-        self.req = req;
-        self
-    }
-
-    pub fn set_platform(&mut self, platform: Option<Platform>)
-                        -> &mut DependencyInner {
-        self.platform = platform;
-        self
-    }
-
-    /// Lock this dependency to depending on the specified package id
-    pub fn lock_to(&mut self, id: &PackageId) -> &mut DependencyInner {
-        assert_eq!(self.source_id, *id.source_id());
-        assert!(self.req.matches(id.version()));
-        self.set_version_req(VersionReq::exact(id.version()))
-            .set_source_id(id.source_id().clone())
-    }
-
-    /// Returns false if the dependency is only used to build the local package.
-    pub fn is_transitive(&self) -> bool {
-        match self.kind {
-            Kind::Normal | Kind::Build => true,
-            Kind::Development => false,
-        }
-    }
-    pub fn is_build(&self) -> bool {
-        match self.kind { Kind::Build => true, _ => false }
-    }
-    pub fn is_optional(&self) -> bool { self.optional }
-    /// Returns true if the default features of the dependency are requested.
-    pub fn uses_default_features(&self) -> bool { self.default_features }
-    /// Returns the list of features that are requested by the dependency.
-    pub fn features(&self) -> &[String] { &self.features }
-
-    /// Returns true if the package (`sum`) can fulfill this dependency request.
-    pub fn matches(&self, sum: &Summary) -> bool {
-        self.matches_id(sum.package_id())
-    }
-
-    /// Returns true if the package (`id`) can fulfill this dependency request.
-    pub fn matches_id(&self, id: &PackageId) -> bool {
-        self.name == id.name() &&
-            (self.only_match_name || (self.req.matches(id.version()) &&
-                                      &self.source_id == id.source_id()))
-    }
-
-    pub fn into_dependency(self) -> Dependency {
-        Dependency {inner: Rc::new(self)}
-    }
-}
-
 impl Dependency {
     /// Attempt to create a `Dependency` from an entry in the manifest.
     pub fn parse(name: &str,
@@ -270,73 +133,170 @@ impl Dependency {
                  inside: &PackageId,
                  config: &Config) -> CargoResult<Dependency> {
         let arg = Some((inside, config));
-        DependencyInner::parse(name, version, source_id, arg).map(|di| {
-            di.into_dependency()
-        })
+        let (specified_req, version_req) = match version {
+            Some(v) => (true, parse_req_with_deprecated(v, arg)?),
+            None => (false, VersionReq::any())
+        };
+
+        let mut ret = Dependency::new_override(name, source_id);
+        {
+            let ptr = Rc::make_mut(&mut ret.inner);
+            ptr.only_match_name = false;
+            ptr.req = version_req;
+            ptr.specified_req = specified_req;
+        }
+        Ok(ret)
     }
 
     /// Attempt to create a `Dependency` from an entry in the manifest.
     pub fn parse_no_deprecated(name: &str,
                                version: Option<&str>,
                                source_id: &SourceId) -> CargoResult<Dependency> {
-        DependencyInner::parse(name, version, source_id, None).map(|di| {
-            di.into_dependency()
-        })
+        let (specified_req, version_req) = match version {
+            Some(v) => (true, parse_req_with_deprecated(v, None)?),
+            None => (false, VersionReq::any())
+        };
+
+        let mut ret = Dependency::new_override(name, source_id);
+        {
+            let ptr = Rc::make_mut(&mut ret.inner);
+            ptr.only_match_name = false;
+            ptr.req = version_req;
+            ptr.specified_req = specified_req;
+        }
+        Ok(ret)
     }
 
     pub fn new_override(name: &str, source_id: &SourceId) -> Dependency {
-        DependencyInner::new_override(name, source_id).into_dependency()
+        Dependency {
+            inner: Rc::new(Inner {
+                name: name.to_string(),
+                source_id: source_id.clone(),
+                req: VersionReq::any(),
+                kind: Kind::Normal,
+                only_match_name: true,
+                optional: false,
+                features: Vec::new(),
+                default_features: true,
+                specified_req: false,
+                platform: None,
+            }),
+        }
     }
 
-    pub fn clone_inner(&self) -> DependencyInner { (*self.inner).clone() }
+    pub fn version_req(&self) -> &VersionReq {
+        &self.inner.req
+    }
 
-    pub fn version_req(&self) -> &VersionReq { self.inner.version_req() }
-    pub fn name(&self) -> &str { self.inner.name() }
-    pub fn source_id(&self) -> &SourceId { self.inner.source_id() }
-    pub fn kind(&self) -> Kind { self.inner.kind() }
-    pub fn specified_req(&self) -> bool { self.inner.specified_req() }
+    pub fn name(&self) -> &str {
+        &self.inner.name
+    }
+
+    pub fn source_id(&self) -> &SourceId {
+        &self.inner.source_id
+    }
+
+    pub fn kind(&self) -> Kind {
+        self.inner.kind
+    }
+
+    pub fn specified_req(&self) -> bool {
+        self.inner.specified_req
+    }
 
     /// If none, this dependencies must be built for all platforms.
     /// If some, it must only be built for the specified platform.
     pub fn platform(&self) -> Option<&Platform> {
-        self.inner.platform()
+        self.inner.platform.as_ref()
     }
 
-    /// Lock this dependency to depending on the specified package id
-    pub fn lock_to(mut self, id: &PackageId) -> Dependency {
-        Rc::make_mut(&mut self.inner).lock_to(id);
+    pub fn set_kind(&mut self, kind: Kind) -> &mut Dependency {
+        Rc::make_mut(&mut self.inner).kind = kind;
+        self
+    }
+
+    /// Sets the list of features requested for the package.
+    pub fn set_features(&mut self, features: Vec<String>) -> &mut Dependency {
+        Rc::make_mut(&mut self.inner).features = features;
+        self
+    }
+
+    /// Sets whether the dependency requests default features of the package.
+    pub fn set_default_features(&mut self, default_features: bool) -> &mut Dependency {
+        Rc::make_mut(&mut self.inner).default_features = default_features;
+        self
+    }
+
+    /// Sets whether the dependency is optional.
+    pub fn set_optional(&mut self, optional: bool) -> &mut Dependency {
+        Rc::make_mut(&mut self.inner).optional = optional;
+        self
+    }
+
+    /// Set the source id for this dependency
+    pub fn set_source_id(&mut self, id: SourceId) -> &mut Dependency {
+        Rc::make_mut(&mut self.inner).source_id = id;
         self
     }
 
     /// Set the version requirement for this dependency
     pub fn set_version_req(&mut self, req: VersionReq) -> &mut Dependency {
-        Rc::make_mut(&mut self.inner).set_version_req(req);
+        Rc::make_mut(&mut self.inner).req = req;
         self
     }
 
-    pub fn set_kind(&mut self, kind: Kind) -> &mut Dependency {
-        Rc::make_mut(&mut self.inner).set_kind(kind);
+    pub fn set_platform(&mut self, platform: Option<Platform>) -> &mut Dependency {
+        Rc::make_mut(&mut self.inner).platform = platform;
         self
     }
+
+    /// Lock this dependency to depending on the specified package id
+    pub fn lock_to(&mut self, id: &PackageId) -> &mut Dependency {
+        assert_eq!(self.inner.source_id, *id.source_id());
+        assert!(self.inner.req.matches(id.version()));
+        self.set_version_req(VersionReq::exact(id.version()))
+            .set_source_id(id.source_id().clone())
+    }
+
 
     /// Returns false if the dependency is only used to build the local package.
-    pub fn is_transitive(&self) -> bool { self.inner.is_transitive() }
-    pub fn is_build(&self) -> bool { self.inner.is_build() }
-    pub fn is_optional(&self) -> bool { self.inner.is_optional() }
+    pub fn is_transitive(&self) -> bool {
+        match self.inner.kind {
+            Kind::Normal | Kind::Build => true,
+            Kind::Development => false,
+        }
+    }
+
+    pub fn is_build(&self) -> bool {
+        match self.inner.kind {
+            Kind::Build => true,
+            _ => false,
+        }
+    }
+
+    pub fn is_optional(&self) -> bool {
+        self.inner.optional
+    }
 
     /// Returns true if the default features of the dependency are requested.
     pub fn uses_default_features(&self) -> bool {
-        self.inner.uses_default_features()
+        self.inner.default_features
     }
     /// Returns the list of features that are requested by the dependency.
-    pub fn features(&self) -> &[String] { self.inner.features() }
+    pub fn features(&self) -> &[String] {
+        &self.inner.features
+    }
 
     /// Returns true if the package (`sum`) can fulfill this dependency request.
-    pub fn matches(&self, sum: &Summary) -> bool { self.inner.matches(sum) }
+    pub fn matches(&self, sum: &Summary) -> bool {
+        self.matches_id(sum.package_id())
+    }
 
     /// Returns true if the package (`id`) can fulfill this dependency request.
     pub fn matches_id(&self, id: &PackageId) -> bool {
-        self.inner.matches_id(id)
+        self.inner.name == id.name() &&
+            (self.inner.only_match_name || (self.inner.req.matches(id.version()) &&
+                                      &self.inner.source_id == id.source_id()))
     }
 
     pub fn map_source(mut self, to_replace: &SourceId, replace_with: &SourceId)
@@ -344,8 +304,7 @@ impl Dependency {
         if self.source_id() != to_replace {
             self
         } else {
-            Rc::make_mut(&mut self.inner)
-                .set_source_id(replace_with.clone());
+            self.set_source_id(replace_with.clone());
             self
         }
     }

--- a/src/cargo/core/mod.rs
+++ b/src/cargo/core/mod.rs
@@ -1,4 +1,4 @@
-pub use self::dependency::{Dependency, DependencyInner};
+pub use self::dependency::Dependency;
 pub use self::manifest::{Manifest, Target, TargetKind, Profile, LibKind, Profiles};
 pub use self::manifest::{EitherManifest, VirtualManifest};
 pub use self::package::{Package, PackageSet};

--- a/src/cargo/core/package_id.rs
+++ b/src/cargo/core/package_id.rs
@@ -28,10 +28,10 @@ impl ser::Serialize for PackageId {
     fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
         where S: ser::Serializer
     {
-        let source = self.inner.source_id.to_url();
-        let encoded = format!("{} {} ({})", self.inner.name, self.inner.version,
-                              source);
-        encoded.serialize(s)
+        s.collect_str(&format_args!("{} {} ({})",
+                                    self.inner.name,
+                                    self.inner.version,
+                                    self.inner.source_id.to_url()))
     }
 }
 

--- a/src/cargo/core/registry.rs
+++ b/src/cargo/core/registry.rs
@@ -259,7 +259,7 @@ impl<'cfg> PackageRegistry<'cfg> {
             Some(&(ref precise, _)) => summary.override_id(precise.clone()),
             None => summary,
         };
-        summary.map_dependencies(|dep| {
+        summary.map_dependencies(|mut dep| {
             trace!("\t{}/{}/{}", dep.name(), dep.version_req(),
                    dep.source_id());
 
@@ -286,7 +286,8 @@ impl<'cfg> PackageRegistry<'cfg> {
                 let locked = locked_deps.iter().find(|id| dep.matches_id(id));
                 if let Some(locked) = locked {
                     trace!("\tfirst hit on {}", locked);
-                    return dep.lock_to(locked)
+                    dep.lock_to(locked);
+                    return dep
                 }
             }
 
@@ -301,7 +302,8 @@ impl<'cfg> PackageRegistry<'cfg> {
             match v {
                 Some(&(ref id, _)) => {
                     trace!("\tsecond hit on {}", id);
-                    dep.lock_to(id)
+                    dep.lock_to(id);
+                    return dep
                 }
                 None => {
                     trace!("\tremaining unlocked");

--- a/src/cargo/core/registry.rs
+++ b/src/cargo/core/registry.rs
@@ -1,7 +1,7 @@
 use std::cell::RefCell;
 use std::collections::HashMap;
 
-use core::{Source, SourceId, SourceMap, Summary, Dependency, PackageId, Package};
+use core::{Source, SourceId, SourceMap, Summary, Dependency, PackageId};
 use core::PackageSet;
 use util::{Config, profile};
 use util::errors::{CargoResult, CargoResultExt};
@@ -28,30 +28,6 @@ pub trait Registry {
     /// By default, registries do not support checksums.
     fn supports_checksums(&self) -> bool {
         false
-    }
-}
-
-impl Registry for Vec<Summary> {
-    fn query(&mut self,
-             dep: &Dependency,
-             f: &mut FnMut(Summary)) -> CargoResult<()> {
-        for summary in self.iter().filter(|summary| dep.matches(*summary)) {
-            f(summary.clone());
-        }
-        Ok(())
-    }
-}
-
-impl Registry for Vec<Package> {
-    fn query(&mut self,
-             dep: &Dependency,
-             f: &mut FnMut(Summary)) -> CargoResult<()> {
-        for summary in self.iter()
-                           .map(|p| p.summary())
-                           .filter(|summary| dep.matches(*summary)) {
-            f(summary.clone());
-        }
-        Ok(())
     }
 }
 

--- a/src/cargo/core/registry.rs
+++ b/src/cargo/core/registry.rs
@@ -441,7 +441,12 @@ pub mod test {
             let overrides = self.query_overrides(dep);
 
             if overrides.is_empty() {
-                self.summaries.query(dep, f)
+                for s in self.summaries.iter() {
+                    if dep.matches(s) {
+                        f(s.clone());
+                    }
+                }
+                Ok(())
             } else {
                 for s in overrides {
                     f(s);

--- a/src/cargo/core/resolver/encode.rs
+++ b/src/cargo/core/resolver/encode.rs
@@ -267,7 +267,7 @@ impl ser::Serialize for EncodablePackageId {
     fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
         where S: ser::Serializer,
     {
-        self.to_string().serialize(s)
+        s.collect_str(self)
     }
 }
 

--- a/src/cargo/core/resolver/mod.rs
+++ b/src/cargo/core/resolver/mod.rs
@@ -297,12 +297,14 @@ enum GraphNode {
 
 #[derive(Clone)]
 struct Context<'a> {
-    activations: HashMap<String, HashMap<SourceId, Vec<Summary>>>,
+    activations: Activations,
     resolve_graph: RcList<GraphNode>,
     resolve_features: HashMap<PackageId, HashSet<String>>,
     resolve_replacements: RcList<(PackageId, PackageId)>,
     replacements: &'a [(PackageIdSpec, Dependency)],
 }
+
+type Activations = HashMap<String, HashMap<SourceId, Vec<Summary>>>;
 
 /// Builds the list of all packages required to build the first argument.
 pub fn resolve(summaries: &[(Summary, Method)],
@@ -1115,8 +1117,7 @@ impl<'a> Context<'a> {
     }
 }
 
-fn check_cycles(resolve: &Resolve,
-                activations: &HashMap<String, HashMap<SourceId, Vec<Summary>>>)
+fn check_cycles(resolve: &Resolve, activations: &Activations)
                 -> CargoResult<()> {
     let summaries: HashMap<&PackageId, &Summary> = activations.values()
         .flat_map(|v| v.values())

--- a/src/cargo/core/resolver/mod.rs
+++ b/src/cargo/core/resolver/mod.rs
@@ -295,12 +295,24 @@ enum GraphNode {
     Link(PackageId, PackageId),
 }
 
+// A `Context` is basically a bunch of local resolution information which is
+// kept around for all `BacktrackFrame` instances. As a result, this runs the
+// risk of being cloned *a lot* so we want to make this as cheap to clone as
+// possible.
 #[derive(Clone)]
 struct Context<'a> {
+    // TODO: Both this and the map below are super expensive to clone. We should
+    //       switch to persistent hash maps if we can at some point or otherwise
+    //       make these much cheaper to clone in general.
     activations: Activations,
-    resolve_graph: RcList<GraphNode>,
     resolve_features: HashMap<PackageId, HashSet<String>>,
+
+    // These are two cheaply-cloneable lists (O(1) clone) which are effectively
+    // hash maps but are built up as "construction lists". We'll iterate these
+    // at the very end and actually construct the map that we're making.
+    resolve_graph: RcList<GraphNode>,
     resolve_replacements: RcList<(PackageId, PackageId)>,
+
     replacements: &'a [(PackageIdSpec, Dependency)],
 }
 

--- a/src/cargo/core/resolver/mod.rs
+++ b/src/cargo/core/resolver/mod.rs
@@ -72,7 +72,6 @@ mod encode;
 ///
 /// Each instance of `Resolve` also understands the full set of features used
 /// for each package.
-#[derive(Clone)]
 pub struct Resolve {
     graph: Graph<PackageId>,
     replacements: HashMap<PackageId, PackageId>,

--- a/src/cargo/lib.rs
+++ b/src/cargo/lib.rs
@@ -224,7 +224,7 @@ fn handle_cause<E, EKind>(cargo_err: E, shell: &mut MultiShell) -> bool
     //the borrow's actual lifetime for purposes of downcasting and
     //inspecting the error chain
     unsafe fn extend_lifetime(r: &Error) -> &(Error + 'static) {
-        std::mem::transmute::<&Error, &Error>(r)    
+        std::mem::transmute::<&Error, &Error>(r)
     }
 
     let verbose = shell.get_verbose();

--- a/src/cargo/lib.rs
+++ b/src/cargo/lib.rs
@@ -5,6 +5,7 @@
 #[cfg(test)] extern crate hamcrest;
 #[macro_use] extern crate error_chain;
 #[macro_use] extern crate log;
+#[macro_use] extern crate scoped_tls;
 #[macro_use] extern crate serde_derive;
 #[macro_use] extern crate serde_json;
 extern crate crates_io as registry;

--- a/src/cargo/ops/cargo_clean.rs
+++ b/src/cargo/ops/cargo_clean.rs
@@ -83,10 +83,10 @@ pub fn clean(ws: &Workspace, opts: &CleanOptions) -> CargoResult<()> {
             continue
         }
 
-        for (src, link_dst, _) in cx.target_filenames(unit)? {
-            rm_rf(&src)?;
-            if let Some(dst) = link_dst {
-                rm_rf(&dst)?;
+        for &(ref src, ref link_dst, _) in cx.target_filenames(unit)?.iter() {
+            rm_rf(src)?;
+            if let Some(ref dst) = *link_dst {
+                rm_rf(dst)?;
             }
         }
     }

--- a/src/cargo/ops/cargo_install.rs
+++ b/src/cargo/ops/cargo_install.rs
@@ -295,7 +295,7 @@ fn select_pkg<'a, T>(mut source: T,
             };
             let vers = vers.as_ref().map(|s| &**s);
             let dep = Dependency::parse_no_deprecated(name, vers, source.source_id())?;
-            let deps = source.query(&dep)?;
+            let deps = source.query_vec(&dep)?;
             match deps.iter().map(|p| p.package_id()).max() {
                 Some(pkgid) => {
                     let pkg = source.download(pkgid)?;

--- a/src/cargo/ops/cargo_rustc/fingerprint.rs
+++ b/src/cargo/ops/cargo_rustc/fingerprint.rs
@@ -85,9 +85,9 @@ pub fn prepare_target<'a, 'cfg>(cx: &mut Context<'a, 'cfg>,
         missing_outputs = !root.join(unit.target.crate_name())
                                .join("index.html").exists();
     } else {
-        for (src, link_dst, _) in cx.target_filenames(unit)? {
+        for &(ref src, ref link_dst, _) in cx.target_filenames(unit)?.iter() {
             missing_outputs |= !src.exists();
-            if let Some(link_dst) = link_dst {
+            if let Some(ref link_dst) = *link_dst {
                 missing_outputs |= !link_dst.exists();
             }
         }

--- a/src/cargo/ops/cargo_rustc/output_depinfo.rs
+++ b/src/cargo/ops/cargo_rustc/output_depinfo.rs
@@ -61,8 +61,8 @@ pub fn output_depinfo<'a, 'b>(context: &mut Context<'a, 'b>, unit: &Unit<'a>) ->
     let mut visited = HashSet::new();
     let success = add_deps_for_unit(&mut deps, context, unit, &mut visited).is_ok();
     let basedir = None; // TODO
-    for (_filename, link_dst, _linkable) in context.target_filenames(unit)? {
-        if let Some(link_dst) = link_dst {
+    for &(_, ref link_dst, _) in context.target_filenames(unit)?.iter() {
+        if let Some(ref link_dst) = *link_dst {
             let output_path = link_dst.with_extension("d");
             if success {
                 let mut outfile = BufWriter::new(File::create(output_path)?);

--- a/src/cargo/ops/resolve.rs
+++ b/src/cargo/ops/resolve.rs
@@ -217,7 +217,9 @@ pub fn resolve_with_previous<'a>(registry: &mut PackageRegistry,
                     if spec.matches(key) &&
                        dep.matches_id(val) &&
                        keep(&val, to_avoid, &to_avoid_sources) {
-                        return (spec.clone(), dep.clone().lock_to(val))
+                        let mut dep = dep.clone();
+                        dep.lock_to(val);
+                        return (spec.clone(), dep)
                     }
                 }
                 (spec.clone(), dep.clone())

--- a/src/cargo/sources/directory.rs
+++ b/src/cargo/sources/directory.rs
@@ -45,11 +45,15 @@ impl<'cfg> Debug for DirectorySource<'cfg> {
 }
 
 impl<'cfg> Registry for DirectorySource<'cfg> {
-    fn query(&mut self, dep: &Dependency) -> CargoResult<Vec<Summary>> {
+    fn query(&mut self,
+             dep: &Dependency,
+             f: &mut FnMut(Summary)) -> CargoResult<()> {
         let packages = self.packages.values().map(|p| &p.0);
         let matches = packages.filter(|pkg| dep.matches(pkg.summary()));
-        let summaries = matches.map(|pkg| pkg.summary().clone());
-        Ok(summaries.collect())
+        for summary in matches.map(|pkg| pkg.summary().clone()) {
+            f(summary);
+        }
+        Ok(())
     }
 
     fn supports_checksums(&self) -> bool {

--- a/src/cargo/sources/git/source.rs
+++ b/src/cargo/sources/git/source.rs
@@ -115,10 +115,12 @@ impl<'cfg> Debug for GitSource<'cfg> {
 }
 
 impl<'cfg> Registry for GitSource<'cfg> {
-    fn query(&mut self, dep: &Dependency) -> CargoResult<Vec<Summary>> {
+    fn query(&mut self,
+             dep: &Dependency,
+             f: &mut FnMut(Summary)) -> CargoResult<()> {
         let src = self.path_source.as_mut()
                       .expect("BUG: update() must be called before query()");
-        src.query(dep)
+        src.query(dep, f)
     }
 }
 

--- a/src/cargo/sources/git/source.rs
+++ b/src/cargo/sources/git/source.rs
@@ -107,7 +107,7 @@ impl<'cfg> Debug for GitSource<'cfg> {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "git repo at {}", self.remote.url())?;
 
-        match self.reference.to_ref_string() {
+        match self.reference.pretty_ref() {
             Some(s) => write!(f, " ({})", s),
             None => Ok(())
         }

--- a/src/cargo/sources/path.rs
+++ b/src/cargo/sources/path.rs
@@ -320,7 +320,12 @@ impl<'cfg> Registry for PathSource<'cfg> {
     fn query(&mut self,
              dep: &Dependency,
              f: &mut FnMut(Summary)) -> CargoResult<()> {
-        self.packages.query(dep, f)
+        for s in self.packages.iter().map(|p| p.summary()) {
+            if dep.matches(s) {
+                f(s.clone())
+            }
+        }
+        Ok(())
     }
 }
 

--- a/src/cargo/sources/path.rs
+++ b/src/cargo/sources/path.rs
@@ -317,8 +317,10 @@ impl<'cfg> Debug for PathSource<'cfg> {
 }
 
 impl<'cfg> Registry for PathSource<'cfg> {
-    fn query(&mut self, dep: &Dependency) -> CargoResult<Vec<Summary>> {
-        self.packages.query(dep)
+    fn query(&mut self,
+             dep: &Dependency,
+             f: &mut FnMut(Summary)) -> CargoResult<()> {
+        self.packages.query(dep, f)
     }
 }
 

--- a/src/cargo/sources/registry/index.rs
+++ b/src/cargo/sources/registry/index.rs
@@ -152,7 +152,7 @@ impl<'cfg> RegistryIndex<'cfg> {
             name, req, features, optional, default_features, target, kind
         } = dep;
 
-        let dep = DependencyInner::parse(&name, Some(&req), &self.source_id, None)?;
+        let mut dep = DependencyInner::parse(&name, Some(&req), &self.source_id, None)?;
         let kind = match kind.as_ref().map(|s| &s[..]).unwrap_or("") {
             "dev" => Kind::Development,
             "build" => Kind::Build,
@@ -171,12 +171,12 @@ impl<'cfg> RegistryIndex<'cfg> {
         // out here.
         let features = features.into_iter().filter(|s| !s.is_empty()).collect();
 
-        Ok(dep.set_optional(optional)
-              .set_default_features(default_features)
-              .set_features(features)
-              .set_platform(platform)
-              .set_kind(kind)
-              .into_dependency())
+        dep.set_optional(optional)
+           .set_default_features(default_features)
+           .set_features(features)
+           .set_platform(platform)
+           .set_kind(kind);
+        Ok(dep.into_dependency())
     }
 
     pub fn query(&mut self,

--- a/src/cargo/sources/registry/local.rs
+++ b/src/cargo/sources/registry/local.rs
@@ -36,8 +36,11 @@ impl<'cfg> RegistryData for LocalRegistry<'cfg> {
         &self.index_path
     }
 
-    fn load(&self, root: &Path, path: &Path) -> CargoResult<Vec<u8>> {
-        paths::read_bytes(&root.join(path))
+    fn load(&self,
+            root: &Path,
+            path: &Path,
+            data: &mut FnMut(&[u8]) -> CargoResult<()>) -> CargoResult<()> {
+        data(&paths::read_bytes(&root.join(path))?)
     }
 
     fn config(&mut self) -> CargoResult<Option<RegistryConfig>> {

--- a/src/cargo/sources/registry/mod.rs
+++ b/src/cargo/sources/registry/mod.rs
@@ -221,7 +221,10 @@ struct RegistryDependency<'a> {
 
 pub trait RegistryData {
     fn index_path(&self) -> &Filesystem;
-    fn load(&self, root: &Path, path: &Path) -> CargoResult<Vec<u8>>;
+    fn load(&self,
+            _root: &Path,
+            path: &Path,
+            data: &mut FnMut(&[u8]) -> CargoResult<()>) -> CargoResult<()>;
     fn config(&mut self) -> CargoResult<Option<RegistryConfig>>;
     fn update_index(&mut self) -> CargoResult<()>;
     fn download(&mut self,

--- a/src/cargo/sources/registry/mod.rs
+++ b/src/cargo/sources/registry/mod.rs
@@ -158,6 +158,7 @@
 //!         ...
 //! ```
 
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::fs::File;
 use std::path::{PathBuf, Path};
@@ -198,24 +199,24 @@ pub struct RegistryConfig {
 }
 
 #[derive(Deserialize)]
-struct RegistryPackage {
+struct RegistryPackage<'a> {
     name: String,
     vers: String,
-    deps: Vec<RegistryDependency>,
+    deps: Vec<RegistryDependency<'a>>,
     features: HashMap<String, Vec<String>>,
     cksum: String,
     yanked: Option<bool>,
 }
 
 #[derive(Deserialize)]
-struct RegistryDependency {
-    name: String,
-    req: String,
+struct RegistryDependency<'a> {
+    name: Cow<'a, str>,
+    req: Cow<'a, str>,
     features: Vec<String>,
     optional: bool,
     default_features: bool,
-    target: Option<String>,
-    kind: Option<String>,
+    target: Option<Cow<'a, str>>,
+    kind: Option<Cow<'a, str>>,
 }
 
 pub trait RegistryData {

--- a/src/cargo/sources/registry/mod.rs
+++ b/src/cargo/sources/registry/mod.rs
@@ -170,7 +170,7 @@ use serde::de;
 use tar::Archive;
 
 use core::{Source, SourceId, PackageId, Package, Summary, Registry};
-use core::dependency::{Dependency, DependencyInner, Kind};
+use core::dependency::{Dependency, Kind};
 use sources::PathSource;
 use util::{CargoResult, Config, internal, FileLock, Filesystem};
 use util::errors::CargoResultExt;
@@ -459,7 +459,7 @@ fn parse_registry_dependency(dep: RegistryDependency)
     } = dep;
 
     let mut dep = DEFAULT_ID.with(|id| {
-        DependencyInner::parse(&name, Some(&req), id, None)
+        Dependency::parse_no_deprecated(&name, Some(&req), id)
     })?;
     let kind = match kind.as_ref().map(|s| &s[..]).unwrap_or("") {
         "dev" => Kind::Development,
@@ -484,5 +484,5 @@ fn parse_registry_dependency(dep: RegistryDependency)
        .set_features(features)
        .set_platform(platform)
        .set_kind(kind);
-    Ok(dep.into_dependency())
+    Ok(dep)
 }

--- a/src/cargo/util/graph.rs
+++ b/src/cargo/util/graph.rs
@@ -21,7 +21,9 @@ impl<N: Eq + Hash + Clone> Graph<N> {
     }
 
     pub fn add(&mut self, node: N, children: &[N]) {
-        self.nodes.insert(node, children.iter().cloned().collect());
+        self.nodes.entry(node)
+            .or_insert_with(HashSet::new)
+            .extend(children.iter().cloned());
     }
 
     pub fn link(&mut self, node: N, child: N) {

--- a/src/cargo/util/toml.rs
+++ b/src/cargo/util/toml.rs
@@ -960,17 +960,15 @@ impl TomlManifest {
                        requirement, but found one for `{}`", spec);
             }
 
-            let dep = replacement.to_dependency(spec.name(), cx, None)?;
-            let dep = {
+            let mut dep = replacement.to_dependency(spec.name(), cx, None)?;
+            {
                 let version = spec.version().ok_or_else(|| {
                     CargoError::from(format!("replacements must specify a version \
                              to replace, but `{}` does not",
                             spec))
                 })?;
-                let req = VersionReq::exact(version);
-                dep.clone_inner().set_version_req(req)
-                   .into_dependency()
-            };
+                dep.set_version_req(VersionReq::exact(version));
+            }
             replace.push((spec, dep));
         }
         Ok(replace)
@@ -1118,14 +1116,14 @@ impl TomlDependency {
             }
             None => DependencyInner::parse(name, version, &new_source_id, None)?,
         };
-        dep = dep.set_features(details.features.unwrap_or(Vec::new()))
-                 .set_default_features(details.default_features
-                                              .or(details.default_features2)
-                                              .unwrap_or(true))
-                 .set_optional(details.optional.unwrap_or(false))
-                 .set_platform(cx.platform.clone());
+        dep.set_features(details.features.unwrap_or(Vec::new()))
+           .set_default_features(details.default_features
+                                        .or(details.default_features2)
+                                        .unwrap_or(true))
+           .set_optional(details.optional.unwrap_or(false))
+           .set_platform(cx.platform.clone());
         if let Some(kind) = kind {
-            dep = dep.set_kind(kind);
+            dep.set_kind(kind);
         }
         Ok(dep.into_dependency())
     }

--- a/src/cargo/util/toml.rs
+++ b/src/cargo/util/toml.rs
@@ -12,7 +12,7 @@ use serde::de::{self, Deserialize};
 use serde_ignored;
 
 use core::{SourceId, Profiles, PackageIdSpec, GitReference, WorkspaceConfig};
-use core::{Summary, Manifest, Target, Dependency, DependencyInner, PackageId};
+use core::{Summary, Manifest, Target, Dependency, PackageId};
 use core::{EitherManifest, VirtualManifest};
 use core::dependency::{Kind, Platform};
 use core::manifest::{LibKind, Profile, ManifestMetadata};
@@ -1111,10 +1111,10 @@ impl TomlDependency {
         let version = details.version.as_ref().map(|v| &v[..]);
         let mut dep = match cx.pkgid {
             Some(id) => {
-                DependencyInner::parse(name, version, &new_source_id,
-                                            Some((id, cx.config)))?
+                Dependency::parse(name, version, &new_source_id,
+                                  id, cx.config)?
             }
-            None => DependencyInner::parse(name, version, &new_source_id, None)?,
+            None => Dependency::parse_no_deprecated(name, version, &new_source_id)?,
         };
         dep.set_features(details.features.unwrap_or(Vec::new()))
            .set_default_features(details.default_features
@@ -1125,7 +1125,7 @@ impl TomlDependency {
         if let Some(kind) = kind {
             dep.set_kind(kind);
         }
-        Ok(dep.into_dependency())
+        Ok(dep)
     }
 }
 

--- a/tests/resolve.rs
+++ b/tests/resolve.rs
@@ -109,7 +109,7 @@ fn dep_loc(name: &str, location: &str) -> Dependency {
     Dependency::parse_no_deprecated(name, Some("1.0.0"), &source_id).unwrap()
 }
 fn dep_kind(name: &str, kind: Kind) -> Dependency {
-    dep(name).clone_inner().set_kind(kind).into_dependency()
+    dep(name).set_kind(kind).clone()
 }
 
 fn registry(pkgs: Vec<Summary>) -> Vec<Summary> {

--- a/tests/resolve.rs
+++ b/tests/resolve.rs
@@ -18,7 +18,9 @@ fn resolve<R: Registry>(pkg: PackageId, deps: Vec<Dependency>,
                         -> CargoResult<Vec<PackageId>> {
     let summary = Summary::new(pkg.clone(), deps, HashMap::new()).unwrap();
     let method = Method::Everything;
-    Ok(resolver::resolve(&[(summary, method)], &[], registry)?.iter().cloned().collect())
+    let resolve = resolver::resolve(&[(summary, method)], &[], registry)?;
+    let res = resolve.iter().cloned().collect();
+    Ok(res)
 }
 
 trait ToDep {

--- a/tests/resolve.rs
+++ b/tests/resolve.rs
@@ -13,12 +13,26 @@ use cargo::core::{Dependency, PackageId, Summary, Registry};
 use cargo::util::{CargoResult, ToUrl};
 use cargo::core::resolver::{self, Method};
 
-fn resolve<R: Registry>(pkg: PackageId, deps: Vec<Dependency>,
-                        registry: &mut R)
-                        -> CargoResult<Vec<PackageId>> {
+fn resolve(pkg: PackageId, deps: Vec<Dependency>, registry: &[Summary])
+    -> CargoResult<Vec<PackageId>>
+{
+    struct MyRegistry<'a>(&'a [Summary]);
+    impl<'a> Registry for MyRegistry<'a> {
+        fn query(&mut self,
+                 dep: &Dependency,
+                 f: &mut FnMut(Summary)) -> CargoResult<()> {
+            for summary in self.0.iter() {
+                if dep.matches(summary) {
+                    f(summary.clone());
+                }
+            }
+            Ok(())
+        }
+    }
+    let mut registry = MyRegistry(registry);
     let summary = Summary::new(pkg.clone(), deps, HashMap::new()).unwrap();
     let method = Method::Everything;
-    let resolve = resolver::resolve(&[(summary, method)], &[], registry)?;
+    let resolve = resolver::resolve(&[(summary, method)], &[], &mut registry)?;
     let res = resolve.iter().cloned().collect();
     Ok(res)
 }


### PR DESCRIPTION
Cargo has historically had very little optimization applied to it. Despite that it's pretty speedy today but there's always a desire to be faster! I've noticed Cargo being particularly sluggish on projects like Servo and rust-lang/rust, so I started profiling and found quite a few low-hanging fruit!

This PR is a slew of optimizations across Cargo for various things found here and there. The banner optimizations are:

* Resolution with a lock file should be basically a noop in terms of execution time now. An optimization was done to avoid cloning `Context` unless necessary, and that basically means it doesn't get cloned now! As the number 1 source of slowdown in Cargo this is the biggest improvement.
* Lots of pieces in `resolve` are now `Rc<T>` for being more easily cloneable.
* `Summary` now internally contains an `Rc` like `Dependency`, making it much more quickly cloneable.
* `Registry` as a trait no longer returns a `Vec` but rather takes a closure to yield summaries up, removing lots of intermediate arrays.
* We no longer spawn a thread for all units of "fresh work", only when we're about to spawn a process.

Almost everything here was guided through profiling `./x.py build` on rust-lang/rust or `cargo build -p log` on Servo. Both of these stress "noop resolution" and the former also stresses noop builds.

Runs of `./x.py build` dropped from 4 to 2 seconds (with lots of low-hanging fruit still remaining in Cargo itself) and `cargo build -p log` dropped from 1.5s to 0.3s. Massif graphs showing Cargo's memory usage also show that the peak memory usage of Cargo in a noop build of Servo dropped from 300MB to 30MB during resolution.

I'm hoping that none of these optimizations makes the code less readable and/or understandable. There are no algorithmic improvements in this PR other than those transitively picked up by making clones cheaper and/or allocating less.