### PR TITLE
Add fossil VCS support to `cargo new`

### DIFF
--- a/src/bin/new.rs
+++ b/src/bin/new.rs
@@ -27,8 +27,9 @@ Usage:
 Options:
     -h, --help          Print this message
     --vcs VCS           Initialize a new repository for the given version
-                        control system (git, hg, or pijul) or do not initialize any version
-                        control at all (none) overriding a global configuration.
+                        control system (git, hg, pijul, or fossil) or do not
+                        initialize any version control at all (none), overriding
+                        a global configuration.
     --bin               Use a binary (application) template
     --lib               Use a library template [default]
     --name NAME         Set the resulting package name, defaults to the value of <path>

--- a/src/cargo/util/mod.rs
+++ b/src/cargo/util/mod.rs
@@ -16,7 +16,7 @@ pub use self::rustc::Rustc;
 pub use self::sha256::Sha256;
 pub use self::to_semver::ToSemver;
 pub use self::to_url::ToUrl;
-pub use self::vcs::{GitRepo, HgRepo, PijulRepo};
+pub use self::vcs::{GitRepo, HgRepo, PijulRepo, FossilRepo};
 pub use self::read2::read2;
 
 pub mod config;


### PR DESCRIPTION
Fossil is a simple, high-reliability, distributed software configuration management system <https://www.fossil-scm.org/>

I mostly followed https://github.com/rust-lang/cargo/pull/3842 as a template. Like that one, this only adds support for `cargo new`, not for pulling down fossil-hosted dependencies

A problem that i didn't tackle but I'd be willing to is a little more more `trait`ifying of the VCSs. I would need some guidance on that since it looks like git has some more thorough support than e.g. hg does but it looks pretty doable