### PR TITLE
Preserve `package.metadata` when packaging

### DIFF
--- a/src/cargo/util/toml.rs
+++ b/src/cargo/util/toml.rs
@@ -109,9 +109,7 @@ pub fn to_manifest(contents: &str,
     let manifest: TomlManifest = serde_ignored::deserialize(root, |path| {
         let mut key = String::new();
         stringify(&mut key, &path);
-        if !key.starts_with("package.metadata") {
-            unused.insert(key);
-        }
+        unused.insert(key);
     })?;
 
     let manifest = Rc::new(manifest);
@@ -459,6 +457,7 @@ pub struct TomlProject {
     #[serde(rename = "license-file")]
     license_file: Option<String>,
     repository: Option<String>,
+    metadata: Option<toml::Value>,
 }
 
 #[derive(Deserialize, Serialize)]

--- a/tests/package.rs
+++ b/tests/package.rs
@@ -604,6 +604,9 @@ fn generated_manifest() {
             license = "MIT"
             description = "foo"
 
+            [project.metadata]
+            foo = 'bar'
+
             [workspace]
 
             [dependencies]
@@ -652,6 +655,9 @@ authors = []
 exclude = ["*.txt"]
 description = "foo"
 license = "MIT"
+
+[package.metadata]
+foo = "bar"
 [dependencies.bar]
 version = "0.1"
 "#));


### PR DESCRIPTION
Now that we use Serde this is actually trivial to implement!

Closes #4142