### PR TITLE
[beta] Hash `Kind` in metadata for crates

### DIFF
--- a/src/cargo/ops/cargo_rustc/context.rs
+++ b/src/cargo/ops/cargo_rustc/context.rs
@@ -477,6 +477,11 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
         // settings like debuginfo and whatnot.
         unit.profile.hash(&mut hasher);
 
+        // Artifacts compiled for the host should have a different metadata
+        // piece than those compiled for the target, so make sure we throw in
+        // the unit's `kind` as well
+        unit.kind.hash(&mut hasher);
+
         // Finally throw in the target name/kind. This ensures that concurrent
         // compiles of targets in the same crate don't collide.
         unit.target.name().hash(&mut hasher);


### PR DESCRIPTION
This fixes what is now a bug in Cargo discovered when attempting to land
rust-lang/rust#42495 where Cargo will compile both host and target artifacts
with the same `-C metadata` flag. This means that the compile can load two
crates with the same SVH that are supposed to be distinct, which causes weird
bugs with crate loading and whatnot.

This commit throws in the `Kind` into the metadata calculation to resolve this
to ensure that host/target artifacts always have a different `-C metadata`