### PR TITLE
Support having a generic writer instead of a termcolor StandardStream

### DIFF
--- a/src/cargo/lib.rs
+++ b/src/cargo/lib.rs
@@ -33,7 +33,6 @@ extern crate termcolor;
 extern crate toml;
 extern crate url;
 
-use std::io::Write;
 use std::fmt;
 use std::error::Error;
 

--- a/src/cargo/ops/cargo_new.rs
+++ b/src/cargo/ops/cargo_new.rs
@@ -1,7 +1,6 @@
 use std::collections::BTreeMap;
 use std::env;
 use std::fs;
-use std::io::Write;
 use std::path::Path;
 
 use serde::{Deserialize, Deserializer};

--- a/src/cargo/ops/cargo_rustc/job_queue.rs
+++ b/src/cargo/ops/cargo_rustc/job_queue.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 use std::collections::hash_map::HashMap;
 use std::fmt;
-use std::io::{self, Write};
+use std::io;
 use std::mem;
 use std::sync::mpsc::{channel, Sender, Receiver};
 

--- a/src/cargo/ops/registry.rs
+++ b/src/cargo/ops/registry.rs
@@ -1,6 +1,5 @@
 use std::env;
 use std::fs::{self, File};
-use std::io::Write;
 use std::iter::repeat;
 use std::time::Duration;
 


### PR DESCRIPTION
This is requied by the RLS (and presumably any other client who wants to use Cargo as a lib and redirect output)

r? @alexcrichton 