### PR TITLE
hash 'CFG_RELEASE_CHANNEL' in metadata for crates

### DIFF
--- a/src/cargo/ops/cargo_rustc/context.rs
+++ b/src/cargo/ops/cargo_rustc/context.rs
@@ -491,6 +491,10 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
             rustc.verbose_version.hash(&mut hasher);
         }
 
+        if let Ok(ref channel) = env::var("CFG_RELEASE_CHANNEL") {
+            channel.hash(&mut hasher);
+        }
+
         Some(Metadata(hasher.finish()))
     }
 


### PR DESCRIPTION
This avoids having conflicting hashes between two rustc channels when a
library has not changed

This requires https://github.com/rust-lang/rust/pull/42696 to work properly as part of rustbuild, otherwise the build system can get confused and try to access libraries with a wrong hash.