### PR TITLE
Make test less brittle prior to assert_eq failure message format change

### DIFF
--- a/tests/bench.rs
+++ b/tests/bench.rs
@@ -242,10 +242,10 @@ fn cargo_bench_failing_test() {
 [FINISHED] release [optimized] target(s) in [..]
 [RUNNING] target[/]release[/]deps[/]foo-[..][EXE]
 thread '[..]' panicked at 'assertion failed: \
-    `(left == right)` (left: \
-    `\"hello\"`, right: `\"nope\"`)', src[/]foo.rs:14
-[..]
-", p.url()))
+    `(left == right)`", p.url()))
+                       .with_stderr_contains("left: `\"hello\"`")
+                       .with_stderr_contains("right: `\"nope\"`")
+                       .with_stderr_contains("src[/]foo.rs:14")
                        .with_status(101));
 }
 

--- a/tests/bench.rs
+++ b/tests/bench.rs
@@ -242,10 +242,10 @@ fn cargo_bench_failing_test() {
 [FINISHED] release [optimized] target(s) in [..]
 [RUNNING] target[/]release[/]deps[/]foo-[..][EXE]
 thread '[..]' panicked at 'assertion failed: \
-    `(left == right)`", p.url()))
-                       .with_stderr_contains("left: `\"hello\"`")
-                       .with_stderr_contains("right: `\"nope\"`")
-                       .with_stderr_contains("src[/]foo.rs:14")
+    `(left == right)`[..]", p.url()))
+                       .with_stderr_contains("[..]left: `\"hello\"`[..]")
+                       .with_stderr_contains("[..]right: `\"nope\"`[..]")
+                       .with_stderr_contains("[..]src[/]foo.rs:14")
                        .with_status(101));
 }
 


### PR DESCRIPTION
PR required for rust-lang/rust#42541 to make assert_eq error message be multi-line. Before implementing this we need to make the current test less brittle.
Not 100% clear on if I need the final [...] or not.