### PR TITLE
use full path to rustdoc as for rustc

### DIFF
--- a/src/cargo/ops/cargo_rustc/custom_build.rs
+++ b/src/cargo/ops/cargo_rustc/custom_build.rs
@@ -123,7 +123,7 @@ fn build_work<'a, 'cfg>(cx: &mut Context<'a, 'cfg>, unit: &Unit<'a>)
        .env("PROFILE", if cx.build_config.release { "release" } else { "debug" })
        .env("HOST", cx.host_triple())
        .env("RUSTC", &cx.config.rustc()?.path)
-       .env("RUSTDOC", &*cx.config.rustdoc()?)
+       .env("RUSTDOC", &cx.config.rustdoc()?.path)
        .inherit_jobserver(&cx.jobserver);
 
     if let Some(links) = unit.pkg.manifest().links() {


### PR DESCRIPTION
If user is using system-wide rust/cargo and rustup'ed one and tries to run
`cargo test`, rustc is executed through /usr/bin/rustc, but rustdoc
is executed without full path which leads to:

error[E0514]: found crate `XXX` compiled by an incompatible version of rustc

Fixes: a4c0c06275889ea4231a4fccd1180e6ab5907428
Reported-by: Martin Sehnoutka <msehnout@rehdat.com>
Signed-off-by: Igor Gnatenko <ignatenkobrain@fedoraproject.org>