### PR TITLE
Multiline assert

### DIFF
--- a/tests/bench.rs
+++ b/tests/bench.rs
@@ -242,8 +242,9 @@ fn cargo_bench_failing_test() {
 [FINISHED] release [optimized] target(s) in [..]
 [RUNNING] target[/]release[/]deps[/]foo-[..][EXE]
 thread '[..]' panicked at 'assertion failed: \
-    `(left == right)` (left: \
-    `\"hello\"`, right: `\"nope\"`)', src[/]foo.rs:14
+    `(left == right)`
+ left: `\"hello\"`,
+right: `\"nope\"`', src[/]foo.rs:14
 [..]
 ", p.url()))
                        .with_status(101));

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -215,10 +215,11 @@ test test_hello ... FAILED
 failures:
 
 ---- test_hello stdout ----
-<tab>thread 'test_hello' panicked at 'assertion failed: \
-    `(left == right)` (left: \
-    `\"hello\"`, right: `\"nope\"`)', src[/]foo.rs:12
-")
+<tab>thread 'test_hello' panicked at 'assertion failed:[..]")
+                       .with_stdout_contains("[..]`(left == right)`[..]")
+                       .with_stdout_contains("[..]left: `\"hello\"`,[..]")
+                       .with_stdout_contains("[..]right: `\"nope\"`[..]")
+                       .with_stdout_contains("[..]src[/]foo.rs:12[..]")
                        .with_stdout_contains("\
 failures:
     test_hello


### PR DESCRIPTION
Found a second location where multiline assert_eq failure breaks a test.
This is an extention of #4181.