### PR TITLE
Credentials for multiple hosts.

### DIFF
--- a/src/bin/login.rs
+++ b/src/bin/login.rs
@@ -40,26 +40,29 @@ pub fn execute(options: Options, config: &Config) -> CliResult {
                      &options.flag_color,
                      options.flag_frozen,
                      options.flag_locked)?;
-    let token = match options.arg_token.clone() {
+    let token = match options.arg_token {
         Some(token) => token,
         None => {
-            let src = SourceId::crates_io(config)?;
-            let mut src = RegistrySource::remote(&src, config);
-            src.update()?;
-            let config = src.config()?.unwrap();
-            let host = options.flag_host.clone().unwrap_or(config.api);
+            let host = match options.flag_host {
+                Some(ref host) => host.clone(),
+                None => {
+                    let src = SourceId::crates_io(config)?;
+                    let mut src = RegistrySource::remote(&src, config);
+                    src.update()?;
+                    src.config()?.unwrap().api
+                }
+            };
+
             println!("please visit {}me and paste the API Token below", host);
             let mut line = String::new();
             let input = io::stdin();
             input.lock().read_line(&mut line).chain_err(|| {
                 "failed to read stdin"
             })?;
-            line
+            line.trim().to_string()
         }
     };
 
-    let token = token.trim().to_string();
-    ops::registry_login(config, token)?;
+    ops::registry_login(config, token, options.flag_host)?;
     Ok(())
 }
-

--- a/src/cargo/core/source.rs
+++ b/src/cargo/core/source.rs
@@ -206,7 +206,7 @@ impl SourceId {
     /// This is the main cargo registry by default, but it can be overridden in
     /// a `.cargo/config`.
     pub fn crates_io(config: &Config) -> CargoResult<SourceId> {
-        let cfg = ops::registry_configuration(config)?;
+        let cfg = ops::registry_configuration(config, None)?;
         let url = if let Some(ref index) = cfg.index {
             static WARNED: AtomicBool = ATOMIC_BOOL_INIT;
             if !WARNED.swap(true, SeqCst) {

--- a/src/cargo/util/config.rs
+++ b/src/cargo/util/config.rs
@@ -835,23 +835,36 @@ fn walk_tree<F>(pwd: &Path, mut walk: F) -> CargoResult<()>
 }
 
 pub fn save_credentials(cfg: &Config,
-                       token: String) -> CargoResult<()> {
+                        token: String,
+                        host: Option<String>) -> CargoResult<()> {
     let mut file = {
         cfg.home_path.create_dir()?;
         cfg.home_path.open_rw(Path::new("credentials"), cfg,
-                                   "credentials' config file")?
+                              "credentials' config file")?
+    };
+
+    let (key, value) = {
+        let key = "token".to_string();
+        let value = ConfigValue::String(token, file.path().to_path_buf());
+
+        if let Some(host) = host {
+            let mut map = HashMap::new();
+            map.insert(key, value);
+            (host, CV::Table(map, file.path().to_path_buf()))
+        } else {
+            (key, value)
+        }
     };
 
     let mut contents = String::new();
     file.read_to_string(&mut contents).chain_err(|| {
-        format!("failed to read configuration file `{}`",
-                      file.path().display())
+        format!("failed to read configuration file `{}`", file.path().display())
     })?;
+
     let mut toml = cargo_toml::parse(&contents, file.path(), cfg)?;
     toml.as_table_mut()
         .unwrap()
-        .insert("token".to_string(),
-                ConfigValue::String(token, file.path().to_path_buf()).into_toml());
+        .insert(key, value.into_toml());
 
     let contents = toml.to_string();
     file.seek(SeekFrom::Start(0))?;

--- a/tests/login.rs
+++ b/tests/login.rs
@@ -30,20 +30,35 @@ fn setup_old_credentials() {
 fn setup_new_credentials() {
     let config = cargo_home().join("credentials");
     t!(fs::create_dir_all(config.parent().unwrap()));
-    t!(t!(File::create(&config)).write_all(br#"
+    t!(t!(File::create(&config)).write_all(format!(r#"
         token = "api-token"
-    "#));
+
+        ["{registry}"]
+        token = "api-token"
+    "#, registry = registry().to_string())
+    .as_bytes()));
 }
 
-fn check_host_token(toml: toml::Value) -> bool {
+fn check_host_token(mut toml: toml::Value, host_key: &str) -> bool {
+    for &key in [host_key, "token"].into_iter() {
+        if key.is_empty() {
+            continue
+        }
+
+        match toml {
+            toml::Value::Table(table) => {
+                if let Some(v) = table.get(key) {
+                    toml = v.clone();
+                } else {
+                    return false;
+                }
+            }
+            _ => break,
+        }
+    }
+
     match toml {
-        toml::Value::Table(table) => match table.get("token") {
-            Some(v) => match v {
-                &toml::Value::String(ref token) => (token.as_str() == TOKEN),
-                _ => false,
-            },
-            None => false,
-        },
+        toml::Value::String(token) => (&token == TOKEN),
         _ => false,
     }
 }
@@ -68,7 +83,7 @@ fn login_with_old_credentials() {
 
     contents.clear();
     File::open(&credentials).unwrap().read_to_string(&mut contents).unwrap();
-    assert!(check_host_token(contents.parse().unwrap()));
+    assert!(check_host_token(contents.parse().unwrap(), &registry().to_string()));
 }
 
 #[test]
@@ -87,7 +102,7 @@ fn login_with_new_credentials() {
 
     let mut contents = String::new();
     File::open(&credentials).unwrap().read_to_string(&mut contents).unwrap();
-    assert!(check_host_token(contents.parse().unwrap()));
+    assert!(check_host_token(contents.parse().unwrap(), &registry().to_string()));
 }
 
 #[test]
@@ -101,6 +116,8 @@ fn login_without_credentials() {
     assert_that(cargo_process().arg("login")
                 .arg("--host").arg(registry().to_string()).arg(TOKEN),
                 execs().with_status(0));
+    assert_that(cargo_process().arg("login").arg(TOKEN),
+                execs().with_status(0));
 
     let config = cargo_home().join("config");
     assert_that(&config, is_not(existing_file()));
@@ -110,7 +127,9 @@ fn login_without_credentials() {
 
     let mut contents = String::new();
     File::open(&credentials).unwrap().read_to_string(&mut contents).unwrap();
-    assert!(check_host_token(contents.parse().unwrap()));
+    let toml: toml::Value = contents.parse().unwrap();
+    assert!(check_host_token(toml.clone(), &registry().to_string()));
+    assert!(check_host_token(toml, ""));
 }
 
 #[test]
@@ -118,11 +137,19 @@ fn new_credentials_is_used_instead_old() {
     setup_old_credentials();
     setup_new_credentials();
 
+    assert_that(cargo_process().arg("login").arg(TOKEN),
+                execs().with_status(0));
+
     assert_that(cargo_process().arg("login")
                 .arg("--host").arg(registry().to_string()).arg(TOKEN),
                 execs().with_status(0));
 
     let config = Config::new(Shell::new(), cargo_home(), cargo_home());
+
     let token = config.get_string("registry.token").unwrap().map(|p| p.val);
     assert!(token.unwrap() == TOKEN);
+
+    let token_host = config.get_string(&format!(r#"registry.{}.token"#, registry().to_string()))
+                       .unwrap().map(|p| p.val);
+    assert!(token_host.unwrap() == TOKEN);
 }


### PR DESCRIPTION
Now `cargo login` stores a token per host.
If the host parameter is omitted cargo stores a token as default, i.e. as a token for crates.io.

Resolves #3365. 
Implemented based on the conversation in #3978.
This RP could be postponed until the cargo team decides which format for registry we should use. Currently, it's a URL.