### PR TITLE
Infer multi-file binaries like `src/bin/server/main.rs` by convention

### DIFF
--- a/src/cargo/util/toml.rs
+++ b/src/cargo/util/toml.rs
@@ -526,16 +526,10 @@ fn inferred_bin_targets(name: &str, layout: &Layout) -> Vec<TomlTarget> {
             Some(name.to_string())
         } else {
             // bin is either a source file or a directory with main.rs inside.
-            if bin.ends_with("main.rs") {
+            if bin.ends_with("main.rs") && !bin.ends_with("src/bin/main.rs") {
                 if let Some(parent) = bin.parent() {
-                    // if the path ends with main.rs it is probably a directory, but it can also be
-                    // a file directly inside src/bin
-                    if parent.ends_with("src/bin") {
-                        // This will always return name "main"
-                        bin.file_stem().and_then(|s| s.to_str()).map(|f| f.to_string())
-                    } else {
-                        parent.file_stem().and_then(|s| s.to_str()).map(|f| f.to_string())
-                    }
+                    // Use a name of this directory as a name for binary
+                    parent.file_stem().and_then(|s| s.to_str()).map(|f| f.to_string())
                 } else {
                     None
                 }
@@ -1483,7 +1477,7 @@ fn inferred_bin_path(bin: &TomlBinTarget,
     // here we have a single bin, so it may be located in src/main.rs, src/foo.rs,
     // src/bin/foo.rs, src/bin/foo/main.rs or src/bin/main.rs
     if bin_len == 1 {
-        let path = Path::new("src").join(&format!("main.rs"));
+        let path = Path::new("src").join("main.rs");
         if package_root.join(&path).exists() {
             return path.to_path_buf()
         }
@@ -1501,12 +1495,12 @@ fn inferred_bin_path(bin: &TomlBinTarget,
         }
 
         // check for the case where src/bin/foo/main.rs is present
-        let path = Path::new("src").join("bin").join(bin.name()).join(&format!("main.rs"));
+        let path = Path::new("src").join("bin").join(bin.name()).join("main.rs");
         if package_root.join(&path).exists() {
             return path.to_path_buf()
         }
 
-        return Path::new("src").join("bin").join(&format!("main.rs")).to_path_buf()
+        return Path::new("src").join("bin").join("main.rs").to_path_buf()
     }
 
     // bin_len > 1
@@ -1516,7 +1510,7 @@ fn inferred_bin_path(bin: &TomlBinTarget,
     }
 
     // we can also have src/bin/foo/main.rs, but the former one is preferred
-    let path = Path::new("src").join("bin").join(bin.name()).join(&format!("main.rs"));
+    let path = Path::new("src").join("bin").join(bin.name()).join("main.rs");
     if package_root.join(&path).exists() {
         return path.to_path_buf()
     }
@@ -1528,12 +1522,12 @@ fn inferred_bin_path(bin: &TomlBinTarget,
         }
     }
 
-    let path = Path::new("src").join("bin").join(&format!("main.rs"));
+    let path = Path::new("src").join("bin").join("main.rs");
     if package_root.join(&path).exists() {
         return path.to_path_buf()
     }
 
-    return Path::new("src").join(&format!("main.rs")).to_path_buf()
+    return Path::new("src").join("main.rs").to_path_buf()
 }
 
 fn build_profiles(profiles: &Option<TomlProfiles>) -> Profiles {

--- a/src/cargo/util/toml.rs
+++ b/src/cargo/util/toml.rs
@@ -531,12 +531,8 @@ fn inferred_bin_targets(name: &str, layout: &Layout) -> Vec<TomlTarget> {
                     // if the path ends with main.rs it is probably a directory, but it can also be
                     // a file directly inside src/bin
                     if parent.ends_with("src/bin") {
-                        // This would always return name "main"
-                        // Fixme: Is this what we want? based on what @matklad said, I don't think so
-                        // bin.file_stem().and_then(|s| s.to_str()).map(|f| f.to_string())
-
-                        // This seems to be the right solution based on the inferred_bin_paths function
-                        Some(name.to_string())
+                        // This will always return name "main"
+                        bin.file_stem().and_then(|s| s.to_str()).map(|f| f.to_string())
                     } else {
                         parent.file_stem().and_then(|s| s.to_str()).map(|f| f.to_string())
                     }

--- a/src/doc/manifest.md
+++ b/src/doc/manifest.md
@@ -457,8 +457,11 @@ Most of the time workspaces will not need to be dealt with as `cargo new` and
 If your project is an executable, name the main source file `src/main.rs`. If it
 is a library, name the main source file `src/lib.rs`.
 
-Cargo will also treat any files located in `src/bin/*.rs` as executables.  Do
-note, however, once you add a `[[bin]]` section ([see
+Cargo will also treat any files located in `src/bin/*.rs` as executables. If your
+executable consist of more than just one source file, you might also use a directory
+inside `src/bin` containing a `main.rs` file which will be treated as an executable
+with a name of the parent directory.
+Do note, however, once you add a `[[bin]]` section ([see
 below](#configuring-a-target)), Cargo will no longer automatically build files
 located in `src/bin/*.rs`.  Instead you must create a `[[bin]]` section for
 each file you want to build.
@@ -473,6 +476,8 @@ integration tests, and benchmarks respectively.
   main.rs        # the main entry point for projects producing executables
   ▾ bin/         # (optional) directory containing additional executables
     *.rs
+  ▾ */           # (optional) directories containing multi-file executables
+    main.rs
 ▾ examples/      # (optional) examples
   *.rs
 ▾ tests/         # (optional) integration tests

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -3310,8 +3310,11 @@ fn dir_and_file_with_same_name_in_bin() {
         .file("src/bin/foo.rs", "fn main() {}")
         .file("src/bin/foo/main.rs", "fn main() {}");
 
-    // TODO: This should output the error from toml.rs:756
-    assert_that(p.cargo_process("build"), execs().with_status(101));
+    assert_that(p.cargo_process("build"), 
+                execs().with_status(101)
+                       .with_stderr_contains("\
+[..]found duplicate binary name foo, but all binary targets must have a unique name[..]
+"));
 }
 
 #[test]

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -3271,3 +3271,29 @@ fn no_bin_in_src_with_lib() {
                 execs().with_status(101)
                        .with_stderr_contains(r#"[ERROR] couldn't read "[..]main.rs"[..]"#));
 }
+
+
+#[test]
+fn dirs_in_bin_dir_with_main_rs() {
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [package]
+            name = "foo"
+            version = "0.1.0"
+            authors = []
+        "#)
+        .file("src/main.rs", "fn main() {}")
+        .file("src/bin/bar.rs", "fn main() {}")
+        .file("src/bin/bar2.rs", "fn main() {}")
+        .file("src/bin/main.rs", "fn main() {}")
+        .file("src/bin/bar3/main.rs", "fn main() {}")
+        .file("src/bin/bar4/main.rs", "fn main() {}");
+
+    assert_that(p.cargo_process("build"), execs().with_status(0));
+    assert_that(&p.bin("foo"), existing_file());
+    assert_that(&p.bin("bar"), existing_file());
+    assert_that(&p.bin("bar2"), existing_file());
+    assert_that(&p.bin("bar3"), existing_file());
+    assert_that(&p.bin("bar4"), existing_file());
+    assert_that(&p.bin("main"), existing_file());
+}


### PR DESCRIPTION
This feature is described in issue #4086