### PR TITLE
cargo install multiple crates

### DIFF
--- a/src/bin/install.rs
+++ b/src/bin/install.rs
@@ -22,7 +22,7 @@ pub struct Options {
     flag_frozen: bool,
     flag_locked: bool,
 
-    arg_crate: Option<String>,
+    arg_crate: Vec<String>,
     flag_vers: Option<String>,
 
     flag_git: Option<String>,
@@ -37,7 +37,7 @@ pub const USAGE: &'static str = "
 Install a Rust binary
 
 Usage:
-    cargo install [options] [<crate>]
+    cargo install [options] [<crate>...]
     cargo install [options] --list
 
 Specifying what crate to install:
@@ -139,20 +139,20 @@ pub fn execute(options: Options, config: &Config) -> CliResult {
         SourceId::for_git(&url, gitref)
     } else if let Some(path) = options.flag_path {
         SourceId::for_path(&config.cwd().join(path))?
-    } else if options.arg_crate == None {
+    } else if options.arg_crate.is_empty() {
         SourceId::for_path(&config.cwd())?
     } else {
         SourceId::crates_io(config)?
     };
 
-    let krate = options.arg_crate.as_ref().map(|s| &s[..]);
+    let krates = options.arg_crate.iter().map(|s| &s[..]).collect::<Vec<_>>();
     let vers = options.flag_vers.as_ref().map(|s| &s[..]);
     let root = options.flag_root.as_ref().map(|s| &s[..]);
 
     if options.flag_list {
         ops::install_list(root, config)?;
     } else {
-        ops::install(root, krate, &source, vers, &compile_opts, options.flag_force)?;
+        ops::install(root, krates, &source, vers, &compile_opts, options.flag_force)?;
     }
     Ok(())
 }

--- a/src/cargo/ops/cargo_install.rs
+++ b/src/cargo/ops/cargo_install.rs
@@ -77,7 +77,7 @@ pub fn install(root: Option<&str>,
             match install_one(root, map, Some(krate), source_id, vers, opts, force, first) {
                 Ok(()) => succeeded.push(krate),
                 Err(e) => {
-                    opts.config.shell().error(e)?;
+                    ::handle_error(e, &mut opts.config.shell());
                     failed.push(krate)
                 }
             }

--- a/src/cargo/ops/cargo_install.rs
+++ b/src/cargo/ops/cargo_install.rs
@@ -65,7 +65,8 @@ pub fn install(root: Option<&str>,
 
     let installed_anything = if krates.len() <= 1 {
         install_one(root.clone(), map, krates.into_iter().next(), source_id, vers, opts,
-                    force, true).is_ok()
+                    force, true)?;
+        true
     } else {
         let mut succeeded = vec![];
         let mut failed = vec![];

--- a/src/cargo/ops/cargo_install.rs
+++ b/src/cargo/ops/cargo_install.rs
@@ -64,8 +64,8 @@ pub fn install(root: Option<&str>,
     let root = resolve_root(root, opts.config)?;
     let map = SourceConfigMap::new(opts.config)?;
 
-    if krates.is_empty() {
-        install_one(root, map, None, source_id, vers, opts, force)
+    if krates.len() <= 1 {
+        install_one(root, map, krates.into_iter().next(), source_id, vers, opts, force)
     } else {
         let mut success = vec![];
         let mut errors = vec![];
@@ -97,6 +97,7 @@ fn install_one(root: Filesystem,
 
     static ALREADY_UPDATED: AtomicBool = ATOMIC_BOOL_INIT;
     let needs_update = !ALREADY_UPDATED.load(Ordering::SeqCst);
+    ALREADY_UPDATED.store(true, Ordering::SeqCst);
 
     let config = opts.config;
 
@@ -123,8 +124,6 @@ fn install_one(root: Filesystem,
                                  crates.io, or use --path or --git to \
                                  specify alternate source".into()))?
     };
-
-    ALREADY_UPDATED.store(true, Ordering::SeqCst);
 
     let mut td_opt = None;
     let overidden_target_dir = if source_id.is_path() {

--- a/src/cargo/sources/config.rs
+++ b/src/cargo/sources/config.rs
@@ -15,6 +15,7 @@ use util::{Config, ToUrl};
 use util::config::ConfigValue;
 use util::errors::{CargoError, CargoResult, CargoResultExt};
 
+#[derive(Clone)]
 pub struct SourceConfigMap<'cfg> {
     cfgs: HashMap<String, SourceConfig>,
     id2name: HashMap<SourceId, String>,
@@ -28,6 +29,7 @@ pub struct SourceConfigMap<'cfg> {
 /// registry = 'https://github.com/rust-lang/crates.io-index'
 /// replace-with = 'foo'    # optional
 /// ```
+#[derive(Clone)]
 struct SourceConfig {
     // id this source corresponds to, inferred from the various defined keys in
     // the configuration

--- a/tests/install.rs
+++ b/tests/install.rs
@@ -67,13 +67,11 @@ fn multiple_pkgs() {
 [COMPILING] foo v0.0.1
 [FINISHED] release [optimized] target(s) in [..]
 [INSTALLING] {home}[..]bin[..]foo[..]
-warning: be sure to add `[..]` to your PATH to be able to run the installed binaries
 [DOWNLOADING] bar v0.0.1 (registry file://[..])
 [INSTALLING] bar v0.0.1
 [COMPILING] bar v0.0.1
 [FINISHED] release [optimized] target(s) in [..]
 [INSTALLING] {home}[..]bin[..]bar[..]
-warning: be sure to add `[..]` to your PATH to be able to run the installed binaries
 
 
 SUMMARY
@@ -82,6 +80,7 @@ Successfully installed: foo, bar
 
 Errors:
 <tab>
+warning: be sure to add `[..]` to your PATH to be able to run the installed binaries
 ",
         home = cargo_home().display())));
     assert_that(cargo_home(), has_installed_exe("foo"));

--- a/tests/install.rs
+++ b/tests/install.rs
@@ -55,45 +55,54 @@ warning: be sure to add `[..]` to your PATH to be able to run the installed bina
 }
 
 #[test]
-test!(multiple_pkgs {
+fn multiple_pkgs() {
     pkg("foo", "0.0.1");
     pkg("bar", "0.0.1");
 
     assert_that(cargo_process("install").arg("foo").arg("bar"),
-                execs().with_status(0).with_stdout(&format!("\
-{updating} registry `[..]`
-{downloading} foo v0.0.1 (registry file://[..])
-{compiling} foo v0.0.1 (registry file://[..])
-{installing} {home}[..]bin[..]foo[..]
-{downloading} bar v0.0.1 (registry file://[..])
-{compiling} bar v0.0.1 (registry file://[..])
-{installing} {home}[..]bin[..]bar[..]
+                execs().with_status(0).with_stderr(&format!("\
+[UPDATING] registry `[..]`
+[DOWNLOADING] foo v0.0.1 (registry file://[..])
+[INSTALLING] foo v0.0.1
+[COMPILING] foo v0.0.1
+[FINISHED] release [optimized] target(s) in [..]
+[INSTALLING] {home}[..]bin[..]foo[..]
+warning: be sure to add `[..]` to your PATH to be able to run the installed binaries
+[DOWNLOADING] bar v0.0.1 (registry file://[..])
+[INSTALLING] bar v0.0.1
+[COMPILING] bar v0.0.1
+[FINISHED] release [optimized] target(s) in [..]
+[INSTALLING] {home}[..]bin[..]bar[..]
+warning: be sure to add `[..]` to your PATH to be able to run the installed binaries
+
+
+SUMMARY
+
+Successfully installed: foo, bar
+
+Errors:
+<tab>
 ",
-        updating = UPDATING,
-        downloading = DOWNLOADING,
-        compiling = COMPILING,
-        installing = INSTALLING,
         home = cargo_home().display())));
     assert_that(cargo_home(), has_installed_exe("foo"));
     assert_that(cargo_home(), has_installed_exe("bar"));
 
     assert_that(cargo_process("uninstall").arg("foo"),
-                execs().with_status(0).with_stdout(&format!("\
-{removing} {home}[..]bin[..]foo[..]
+                execs().with_status(0).with_stderr(&format!("\
+[REMOVING] {home}[..]bin[..]foo[..]
 ",
-        removing = REMOVING,
         home = cargo_home().display())));
     assert_that(cargo_process("uninstall").arg("bar"),
-                execs().with_status(0).with_stdout(&format!("\
-{removing} {home}[..]bin[..]bar[..]
+                execs().with_status(0).with_stderr(&format!("\
+[REMOVING] {home}[..]bin[..]bar[..]
 ",
-        removing = REMOVING,
         home = cargo_home().display())));
     assert_that(cargo_home(), is_not(has_installed_exe("foo")));
     assert_that(cargo_home(), is_not(has_installed_exe("bar")));
-});
+}
 
-test!(pick_max_version {
+#[test]
+fn pick_max_version() {
     pkg("foo", "0.0.1");
     pkg("foo", "0.0.2");
 

--- a/tests/install.rs
+++ b/tests/install.rs
@@ -60,7 +60,7 @@ fn multiple_pkgs() {
     pkg("bar", "0.0.2");
 
     assert_that(cargo_process("install").args(&["foo", "bar", "baz"]),
-                execs().with_status(0).with_stderr(&format!("\
+                execs().with_status(101).with_stderr(&format!("\
 [UPDATING] registry `[..]`
 [DOWNLOADING] foo v0.0.1 (registry file://[..])
 [INSTALLING] foo v0.0.1
@@ -76,6 +76,7 @@ error: could not find `baz` in `registry [..]`
    
 Summary: Successfully installed foo, bar! Failed to install baz (see error(s) above).
 warning: be sure to add `[..]` to your PATH to be able to run the installed binaries
+error: some crates failed to install
 ",
         home = cargo_home().display())));
     assert_that(cargo_home(), has_installed_exe("foo"));

--- a/tests/install.rs
+++ b/tests/install.rs
@@ -57,9 +57,9 @@ warning: be sure to add `[..]` to your PATH to be able to run the installed bina
 #[test]
 fn multiple_pkgs() {
     pkg("foo", "0.0.1");
-    pkg("bar", "0.0.1");
+    pkg("bar", "0.0.2");
 
-    assert_that(cargo_process("install").arg("foo").arg("bar"),
+    assert_that(cargo_process("install").args(&["foo", "bar", "baz"]),
                 execs().with_status(0).with_stderr(&format!("\
 [UPDATING] registry `[..]`
 [DOWNLOADING] foo v0.0.1 (registry file://[..])
@@ -67,12 +67,14 @@ fn multiple_pkgs() {
 [COMPILING] foo v0.0.1
 [FINISHED] release [optimized] target(s) in [..]
 [INSTALLING] {home}[..]bin[..]foo[..]
-[DOWNLOADING] bar v0.0.1 (registry file://[..])
-[INSTALLING] bar v0.0.1
-[COMPILING] bar v0.0.1
+[DOWNLOADING] bar v0.0.2 (registry file://[..])
+[INSTALLING] bar v0.0.2
+[COMPILING] bar v0.0.2
 [FINISHED] release [optimized] target(s) in [..]
 [INSTALLING] {home}[..]bin[..]bar[..]
-Successfully installed foo, bar
+error: could not find `baz` in `registry [..]`
+   
+Summary: Successfully installed foo, bar! Failed to install baz (see error(s) above).
 warning: be sure to add `[..]` to your PATH to be able to run the installed binaries
 ",
         home = cargo_home().display())));

--- a/tests/install.rs
+++ b/tests/install.rs
@@ -72,14 +72,7 @@ fn multiple_pkgs() {
 [COMPILING] bar v0.0.1
 [FINISHED] release [optimized] target(s) in [..]
 [INSTALLING] {home}[..]bin[..]bar[..]
-
-
-SUMMARY
-
-Successfully installed: foo, bar
-
-Errors:
-<tab>
+Successfully installed foo, bar
 warning: be sure to add `[..]` to your PATH to be able to run the installed binaries
 ",
         home = cargo_home().display())));


### PR DESCRIPTION
rust-lang-nursery/rustup.rs#986 for `cargo install`

Revives #2601 @pwoolcoc, replaces #3075 @esclear, closes #2585 @kindlychung @cyplo

Avoids the sticking point of the previous two PRs (multiple registry updates) by threading through a first-run boolean flag to decide whether `select_pkg` needs to call `source.update()`.

There is still the issue that flags such as `--git` and `--vers` are "global" to the multiple packages you may be installing. The workaround is just to run `cargo install` separately. In the future we could add syntax like `cargo install foo=1.0 bar=2.5 quux=git://github.com/durka/quux#dev-branch` or something.