### PR TITLE
Ignore a test that accesses crates.io for now

### DIFF
--- a/tests/git.rs
+++ b/tests/git.rs
@@ -1986,6 +1986,7 @@ fn two_at_rev_instead_of_tag() {
 }
 
 #[test]
+#[ignore] // accesses crates.io
 fn include_overrides_gitignore() {
     let p = git::new("reduction", |repo| {
         repo.file("Cargo.toml", r#"


### PR DESCRIPTION
Tests in general shouldn't hit the network, but this one requires a crate from
crates.io :(