### PR TITLE
cargo run --set-env=RUST_LOG=debug

### DIFF
--- a/src/bin/bench.rs
+++ b/src/bin/bench.rs
@@ -2,6 +2,7 @@ use cargo::core::Workspace;
 use cargo::ops::{self, MessageFormat, Packages};
 use cargo::util::{CliResult, CliError, Config, CargoErrorKind};
 use cargo::util::important_paths::{find_root_manifest_for_wd};
+use cargo::util::parse_set_env;
 
 #[derive(Deserialize)]
 pub struct Options {
@@ -26,6 +27,7 @@ pub struct Options {
     flag_tests: bool,
     flag_bench: Vec<String>,
     flag_benches: bool,
+    flag_set_env: Vec<String>,
     flag_frozen: bool,
     flag_locked: bool,
     arg_args: Vec<String>,
@@ -50,6 +52,7 @@ Options:
     --tests                      Benchmark all tests
     --bench NAME                 Benchmark only the specified bench target
     --benches                    Benchmark all benches
+    -e NV, --set-env NV ...      Set environment variable (NAME=VALUE) when running executable
     --no-run                     Compile, but don't run benchmarks
     -p SPEC, --package SPEC ...  Package to run benchmarks for
     --all                        Benchmark all packages in the workspace
@@ -122,8 +125,10 @@ pub fn execute(options: Options, config: &Config) -> CliResult {
         },
     };
 
+    let env_vars = parse_set_env(&options.flag_set_env)?;
+
     let ws = Workspace::new(&root, config)?;
-    let err = ops::run_benches(&ws, &ops, &options.arg_args)?;
+    let err = ops::run_benches(&ws, &ops, &options.arg_args, &env_vars)?;
     match err {
         None => Ok(()),
         Some(err) => {

--- a/src/bin/test.rs
+++ b/src/bin/test.rs
@@ -2,6 +2,7 @@ use cargo::core::Workspace;
 use cargo::ops::{self, MessageFormat, Packages};
 use cargo::util::{CliResult, CliError, Config, CargoErrorKind};
 use cargo::util::important_paths::find_root_manifest_for_wd;
+use cargo::util::parse_set_env;
 
 #[derive(Deserialize)]
 pub struct Options {
@@ -24,6 +25,7 @@ pub struct Options {
     flag_tests: bool,
     flag_bench: Vec<String>,
     flag_benches: bool,
+    flag_set_env: Vec<String>,
     flag_verbose: u32,
     flag_quiet: Option<bool>,
     flag_color: Option<String>,
@@ -54,6 +56,7 @@ Options:
     --tests                      Test all tests
     --bench NAME ...             Test only the specified bench target
     --benches                    Test all benches
+    -e NV, --set-env NV ...      Set environment variable (NAME=VALUE) when running executable
     --no-run                     Compile, but don't run tests
     -p SPEC, --package SPEC ...  Package to run tests for
     --all                        Test all packages in the workspace
@@ -157,8 +160,10 @@ pub fn execute(options: Options, config: &Config) -> CliResult {
         },
     };
 
+    let env_vars = parse_set_env(&options.flag_set_env)?;
+
     let ws = Workspace::new(&root, config)?;
-    let err = ops::run_tests(&ws, &ops, &options.arg_args)?;
+    let err = ops::run_tests(&ws, &ops, &options.arg_args, &env_vars)?;
     match err {
         None => Ok(()),
         Some(err) => {

--- a/src/cargo/ops/cargo_run.rs
+++ b/src/cargo/ops/cargo_run.rs
@@ -7,7 +7,8 @@ use core::Workspace;
 
 pub fn run(ws: &Workspace,
            options: &ops::CompileOptions,
-           args: &[String]) -> CargoResult<Option<ProcessError>> {
+           args: &[String],
+           env_vars: &[(String, String)]) -> CargoResult<Option<ProcessError>> {
     let config = ws.config();
 
     let pkg = match options.spec {
@@ -61,6 +62,8 @@ pub fn run(ws: &Workspace,
     };
     let mut process = compile.target_process(exe, &pkg)?;
     process.args(args).cwd(config.cwd());
+
+    process.env_all(env_vars);
 
     config.shell().status("Running", process.to_string())?;
 

--- a/src/cargo/util/mod.rs
+++ b/src/cargo/util/mod.rs
@@ -18,6 +18,7 @@ pub use self::to_semver::ToSemver;
 pub use self::to_url::ToUrl;
 pub use self::vcs::{GitRepo, HgRepo, PijulRepo, FossilRepo};
 pub use self::read2::read2;
+pub use self::parse_set_env::parse_set_env;
 
 pub mod config;
 pub mod errors;
@@ -42,3 +43,4 @@ mod vcs;
 mod lazy_cell;
 mod flock;
 mod read2;
+mod parse_set_env;

--- a/src/cargo/util/parse_set_env.rs
+++ b/src/cargo/util/parse_set_env.rs
@@ -1,0 +1,16 @@
+use super::{CargoError, CargoResult};
+
+/// Parse `flag_set_env` field in options.
+pub fn parse_set_env(args: &[String]) -> CargoResult<Vec<(String, String)>> {
+    let mut env_vars = Vec::new();
+    for nv in args {
+        let eq = nv.find('=');
+        if let Some(eq) = eq {
+            env_vars.push((nv[..eq].to_owned(), nv[eq+1..].to_owned()));
+        } else {
+            return Err(CargoError::from(
+                format!("--set-env param: `{}` is is not NAME=VALUE", nv)));
+        }
+    }
+    Ok(env_vars)
+}

--- a/src/cargo/util/process_builder.rs
+++ b/src/cargo/util/process_builder.rs
@@ -56,6 +56,15 @@ impl ProcessBuilder {
         self
     }
 
+    pub fn env_all<K: AsRef<str>, V: AsRef<OsStr>>(&mut self,
+                                                   env_vars: &[(K, V)]) -> &mut ProcessBuilder {
+        for &(ref n, ref v) in env_vars {
+            self.env(n.as_ref(), v);
+        }
+        self
+    }
+
+
     pub fn env_remove(&mut self, key: &str) -> &mut ProcessBuilder {
         self.env.insert(key.to_string(), None);
         self

--- a/tests/run.rs
+++ b/tests/run.rs
@@ -138,6 +138,27 @@ fn simple_with_args() {
 }
 
 #[test]
+fn set_env() {
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [project]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+        "#)
+        .file("src/main.rs", r#"
+            fn main() {
+                println!("{}", std::env::var("PONIES").expect("env::var"));
+                println!("{}", std::env::var("UNICORNS").expect("env::var"));
+            }
+        "#);
+
+    assert_that(p.cargo_process("run")
+                    .arg("--set-env=PONIES=pink").arg("-e").arg("UNICORNS=rainbow"),
+                execs().with_status(0).with_stdout("pink\nrainbow\n"));
+}
+
+#[test]
 fn exit_code() {
     let p = project("foo")
         .file("Cargo.toml", r#"


### PR DESCRIPTION
Set env variable when running program, test or bench.

Useful with `RUST_LOG=debug` environment variable to avoid displaying
log output of cargo itself.