### PR TITLE
Prevent rustc stderr/stdout from being duplicated.

### DIFF
--- a/src/cargo/ops/cargo_rustc/custom_build.rs
+++ b/src/cargo/ops/cargo_rustc/custom_build.rs
@@ -244,6 +244,7 @@ fn build_work<'a, 'cfg>(cx: &mut Context<'a, 'cfg>, unit: &Unit<'a>)
         let output = cmd.exec_with_streaming(
             &mut |out_line| { state.stdout(out_line); Ok(()) },
             &mut |err_line| { state.stderr(err_line); Ok(()) },
+            true,
         ).map_err(|e| {
             CargoError::from(
                 format!("failed to run custom build command for `{}`\n{}",

--- a/src/cargo/ops/cargo_rustc/mod.rs
+++ b/src/cargo/ops/cargo_rustc/mod.rs
@@ -80,7 +80,7 @@ pub trait Executor: Send + Sync + 'static {
                  handle_stdout: &mut FnMut(&str) -> CargoResult<()>,
                  handle_stderr: &mut FnMut(&str) -> CargoResult<()>)
                  -> CargoResult<()> {
-        cmd.exec_with_streaming(handle_stdout, handle_stderr)?;
+        cmd.exec_with_streaming(handle_stdout, handle_stderr, false)?;
         Ok(())
     }
 }

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -29,6 +29,16 @@ fn cargo_compile_simple() {
                 execs().with_status(0).with_stdout("i am foo\n"));
 }
 
+#[test]
+fn cargo_fail_with_no_stderr() {
+    let p = project("foo")
+        .file("Cargo.toml", &basic_bin_manifest("foo"))
+        .file("src/foo.rs", &String::from("refusal"));
+    let p = p.build();
+    assert_that(p.cargo("build").arg("--message-format=json"), execs().with_status(101)
+        .with_stderr_does_not_contain("--- stderr"));
+}
+
 /// Check that the `CARGO_INCREMENTAL` environment variable results in
 /// `rustc` getting `-Zincremental` passed to it.
 #[test]


### PR DESCRIPTION
Please review carefully. I've not submitted patches to Cargo before, I think, so this may be flawed in some way I haven't detected yet. Tests are green locally, though.

Fixes #4223