### PR TITLE
Added documentation blacklisting notes

### DIFF
--- a/src/doc/manifest.md
+++ b/src/doc/manifest.md
@@ -48,6 +48,11 @@ This field specifies a URL to a website hosting the crate's documentation.
 If no URL is specified in the manifest file, [crates.io][cratesio] will
 automatically link your crate to the corresponding [docs.rs][docsrs] page.
 
+Documentation links from specific domainss are blacklisted. Currently, any link
+from rust-ci.org will be blacklisted since this domain is no longer used for
+legitimate documentation hosting. URLs from this domain will have no reported
+documentation link on crates.io.
+
 [docsrs]: https://docs.rs/
 [cratesio]: https://crates.io/
 

--- a/src/doc/manifest.md
+++ b/src/doc/manifest.md
@@ -48,10 +48,14 @@ This field specifies a URL to a website hosting the crate's documentation.
 If no URL is specified in the manifest file, [crates.io][cratesio] will
 automatically link your crate to the corresponding [docs.rs][docsrs] page.
 
-Documentation links from specific domainss are blacklisted. Currently, any link
-from rust-ci.org will be blacklisted since this domain is no longer used for
-legitimate documentation hosting. URLs from this domain will have no reported
-documentation link on crates.io.
+Documentation links from specific hosts are blacklisted. Hosts are added 
+to the blacklist if they are known to not be hosting documentation and are 
+possibly of malicious intent e.g. ad tracking networks. URLs from the 
+following hosts are blacklisted:
+- rust-ci.org
+
+Documentation URLs from blacklisted hosts will not appear on crates.io, and
+may be replaced by docs.rs links.
 
 [docsrs]: https://docs.rs/
 [cratesio]: https://crates.io/


### PR DESCRIPTION
Added notes regarding [documentation domain blacklisting](https://github.com/rust-lang/crates.io/issues/626) on crates.io