### PR TITLE
hash '__CARGO_DEFAULT_LIB_METADATA' in metadata for rustc

### DIFF
--- a/tests/build.rs
+++ b/tests/build.rs
@@ -859,7 +859,7 @@ suffix = env::consts::DLL_SUFFIX,
     assert_that(p.cargo("clean"), execs().with_status(0));
 
     // If you set the env-var, then we expect metadata on libbar
-    assert_that(p.cargo("build").arg("-v").env("__CARGO_DEFAULT_LIB_METADATA", "1"),
+    assert_that(p.cargo("build").arg("-v").env("__CARGO_DEFAULT_LIB_METADATA", "stable"),
                 execs().with_status(0).with_stderr(&format!("\
 [COMPILING] bar v0.0.1 ({url}/bar)
 [RUNNING] `rustc --crate-name bar bar[/]src[/]lib.rs --crate-type dylib \


### PR DESCRIPTION
We already have __CARGO_DEFAULT_LIB_METADATA to force adding the hash of some metadata in the libraries file name when building rust.
For now, we only check if it is set or not.
This patch makes also use of its value to compute the hash. This way we'll be able to pass in the channel we're building to avoid hash collisions between channels.
