### PR TITLE
Let two further tests tolerate col info in panics

### DIFF
--- a/tests/test.rs
+++ b/tests/test.rs
@@ -263,7 +263,7 @@ failures:
 
 ---- test_hello stdout ----
 <tab>thread 'test_hello' panicked at 'assertion failed: false', \
-      tests[/]footest.rs:4
+      tests[/]footest.rs:4[..]
 ")
                        .with_stdout_contains("\
 failures:
@@ -295,7 +295,7 @@ failures:
 
 ---- test_hello stdout ----
 <tab>thread 'test_hello' panicked at 'assertion failed: false', \
-      src[/]lib.rs:4
+      src[/]lib.rs:4[..]
 ")
                        .with_stdout_contains("\
 failures:


### PR DESCRIPTION
Needed by https://github.com/rust-lang/rust/pull/42938

I've now ripgrepped for "panicked at" and found no further
test that hardcodes the "filename:line$" format.