### PR TITLE
Replace `cargo search --host` with `cargo search --index`

### DIFF
--- a/tests/search.rs
+++ b/tests/search.rs
@@ -82,8 +82,141 @@ fn simple() {
     }
 
     assert_that(cargo_process("search").arg("postgres")
+                    .arg("--index").arg(registry().to_string()),
+                execs().with_status(0)
+                       .with_stdout_contains("\
+hoare = \"0.1.1\"    # Design by contract style assertions for Rust"));
+}
+
+// TODO: Depricated
+// remove once it has been decided '--host' can be safely removed
+#[test]
+fn simple_with_host() {
+    setup();
+
+    let contents = r#"{
+        "crates": [{
+            "created_at": "2014-11-16T20:17:35Z",
+            "description": "Design by contract style assertions for Rust",
+            "documentation": null,
+            "downloads": 2,
+            "homepage": null,
+            "id": "hoare",
+            "keywords": [],
+            "license": null,
+            "links": {
+                "owners": "/api/v1/crates/hoare/owners",
+                "reverse_dependencies": "/api/v1/crates/hoare/reverse_dependencies",
+                "version_downloads": "/api/v1/crates/hoare/downloads",
+                "versions": "/api/v1/crates/hoare/versions"
+            },
+            "max_version": "0.1.1",
+            "name": "hoare",
+            "repository": "https://github.com/nick29581/libhoare",
+            "updated_at": "2014-11-20T21:49:21Z",
+            "versions": null
+        }],
+        "meta": {
+            "total": 1
+        }
+    }"#;
+    let base = api_path().join("api/v1/crates");
+
+    // Older versions of curl don't peel off query parameters when looking for
+    // filenames, so just make both files.
+    //
+    // On windows, though, `?` is an invalid character, but we always build curl
+    // from source there anyway!
+    File::create(&base).unwrap().write_all(contents.as_bytes()).unwrap();
+    if !cfg!(windows) {
+        File::create(&base.with_file_name("crates?q=postgres&per_page=10")).unwrap()
+             .write_all(contents.as_bytes()).unwrap();
+    }
+
+    assert_that(cargo_process("search").arg("postgres")
                     .arg("--host").arg(registry().to_string()),
                 execs().with_status(0)
+                       .with_stderr(&format!("\
+[WARNING] The flag '--host' is no longer valid.
+
+Previous versions of Cargo accepted this flag, but it is being
+depricated. The flag is being renamed to 'index', as the flag
+wants the location of the index in which to search. Please
+use '--index' instead.
+
+This will soon become a hard error, so it's either recommended
+to update to a fixed version or contact the upstream maintainer
+about this warning.
+[UPDATING] registry `{reg}`
+",
+    reg = registry()))
+                       .with_stdout_contains("\
+hoare = \"0.1.1\"    # Design by contract style assertions for Rust"));
+}
+
+// TODO: Depricated
+// remove once it has been decided '--host' can be safely removed
+#[test]
+fn simple_with_index_and_host() {
+    setup();
+
+    let contents = r#"{
+        "crates": [{
+            "created_at": "2014-11-16T20:17:35Z",
+            "description": "Design by contract style assertions for Rust",
+            "documentation": null,
+            "downloads": 2,
+            "homepage": null,
+            "id": "hoare",
+            "keywords": [],
+            "license": null,
+            "links": {
+                "owners": "/api/v1/crates/hoare/owners",
+                "reverse_dependencies": "/api/v1/crates/hoare/reverse_dependencies",
+                "version_downloads": "/api/v1/crates/hoare/downloads",
+                "versions": "/api/v1/crates/hoare/versions"
+            },
+            "max_version": "0.1.1",
+            "name": "hoare",
+            "repository": "https://github.com/nick29581/libhoare",
+            "updated_at": "2014-11-20T21:49:21Z",
+            "versions": null
+        }],
+        "meta": {
+            "total": 1
+        }
+    }"#;
+    let base = api_path().join("api/v1/crates");
+
+    // Older versions of curl don't peel off query parameters when looking for
+    // filenames, so just make both files.
+    //
+    // On windows, though, `?` is an invalid character, but we always build curl
+    // from source there anyway!
+    File::create(&base).unwrap().write_all(contents.as_bytes()).unwrap();
+    if !cfg!(windows) {
+        File::create(&base.with_file_name("crates?q=postgres&per_page=10")).unwrap()
+             .write_all(contents.as_bytes()).unwrap();
+    }
+
+    assert_that(cargo_process("search").arg("postgres")
+                    .arg("--index").arg(registry().to_string())
+                    .arg("--host").arg(registry().to_string()),
+                execs().with_status(0)
+                        .with_stderr(&format!("\
+[WARNING] The flag '--host' is no longer valid.
+
+Previous versions of Cargo accepted this flag, but it is being
+depricated. The flag is being renamed to 'index', as the flag
+wants the location of the index in which to search. Please
+use '--index' instead.
+
+This will soon become a hard error, so it's either recommended
+to update to a fixed version or contact the upstream maintainer
+about this warning.
+[UPDATING] registry `{reg}`
+",
+    reg = registry()))
                        .with_stdout_contains("\
 hoare = \"0.1.1\"    # Design by contract style assertions for Rust"));
 }
@@ -132,7 +265,7 @@ fn multiple_query_params() {
     }
 
     assert_that(cargo_process("search").arg("postgres").arg("sql")
-                    .arg("--host").arg(registry().to_string()),
+                    .arg("--index").arg(registry().to_string()),
                 execs().with_status(0)
                        .with_stdout_contains("\
 hoare = \"0.1.1\"    # Design by contract style assertions for Rust"));


### PR DESCRIPTION
This change makes the command consistent with other versions of the same flag. `cargo search --host` is still supported, as well as `cargo search --index <index> --host <host>` in case of confusion. The three commands currently supported should produce the same behavior. All instances of `--host` are currently marked as deprecated, or for reuse as mentioned in issue #4208.

Fixes #4219 