### PR TITLE
quote the binary name in the warning

### DIFF
--- a/src/cargo/util/toml/targets.rs
+++ b/src/cargo/util/toml/targets.rs
@@ -182,7 +182,7 @@ fn clean_bins(toml_bins: Option<&Vec<TomlBinTarget>>,
                         .unwrap_or(&legacy_path);
 
                     warnings.push(format!(
-                        "path `{}` was erroneously implicitly accepted for binary {},\n\
+                        "path `{}` was erroneously implicitly accepted for binary `{}`,\n\
                          please set bin.path in Cargo.toml",
                         short_path.display(), bin.name()
                     ));

--- a/src/cargo/util/toml/targets.rs
+++ b/src/cargo/util/toml/targets.rs
@@ -110,7 +110,7 @@ fn clean_lib(toml_lib: Option<&TomlLibTarget>,
                         .unwrap_or(&legacy_path);
 
                     warnings.push(format!(
-                        "path `{}` was erroneously implicitly accepted for library {},\n\
+                        "path `{}` was erroneously implicitly accepted for library `{}`,\n\
                          please rename the file to `src/lib.rs` or set lib.path in Cargo.toml",
                         short_path.display(), lib.name()
                     ));
@@ -272,7 +272,7 @@ fn clean_benches(toml_benches: Option<&Vec<TomlBenchTarget>>,
                 .unwrap_or(&legacy_path);
 
             warnings.push(format!(
-                "path `{}` was erroneously implicitly accepted for benchmark {},\n\
+                "path `{}` was erroneously implicitly accepted for benchmark `{}`,\n\
                  please set bench.path in Cargo.toml",
                 short_path.display(), bench.name()
             ));

--- a/tests/bench.rs
+++ b/tests/bench.rs
@@ -1186,6 +1186,6 @@ fn legacy_bench_name() {
         "#);
 
     assert_that(p.cargo_process("bench"), execs().with_status(0).with_stderr_contains("\
-[WARNING] path `src[/]bench.rs` was erroneously implicitly accepted for benchmark bench,
+[WARNING] path `src[/]bench.rs` was erroneously implicitly accepted for benchmark `bench`,
 please set bench.path in Cargo.toml"));
 }

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -1047,7 +1047,7 @@ fn many_crate_types_old_style_lib_location() {
             pub fn foo() {}
         "#);
     assert_that(p.cargo_process("build"), execs().with_status(0).with_stderr_contains("\
-[WARNING] path `src[/]foo.rs` was erroneously implicitly accepted for library foo,
+[WARNING] path `src[/]foo.rs` was erroneously implicitly accepted for library `foo`,
 please rename the file to `src/lib.rs` or set lib.path in Cargo.toml"));
 
     assert_that(&p.root().join("target/debug/libfoo.rlib"), existing_file());

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -1402,7 +1402,7 @@ fn legacy_binary_paths_warinigs() {
         .file("src/main.rs", "fn main() {}");
 
     assert_that(p.cargo_process("build").arg("-v"), execs().with_status(0).with_stderr_contains("\
-[WARNING] path `src[/]main.rs` was erroneously implicitly accepted for binary bar,
+[WARNING] path `src[/]main.rs` was erroneously implicitly accepted for binary `bar`,
 please set bin.path in Cargo.toml"));
 
     let mut p = project("world");
@@ -1419,7 +1419,7 @@ please set bin.path in Cargo.toml"));
         .file("src/bin/main.rs", "fn main() {}");
 
     assert_that(p.cargo_process("build").arg("-v"), execs().with_status(0).with_stderr_contains("\
-[WARNING] path `src[/]bin[/]main.rs` was erroneously implicitly accepted for binary bar,
+[WARNING] path `src[/]bin[/]main.rs` was erroneously implicitly accepted for binary `bar`,
 please set bin.path in Cargo.toml"));
 
     let mut p = project("world");
@@ -1435,7 +1435,7 @@ please set bin.path in Cargo.toml"));
         .file("src/bar.rs", "fn main() {}");
 
     assert_that(p.cargo_process("build").arg("-v"), execs().with_status(0).with_stderr_contains("\
-[WARNING] path `src[/]bar.rs` was erroneously implicitly accepted for binary bar,
+[WARNING] path `src[/]bar.rs` was erroneously implicitly accepted for binary `bar`,
 please set bin.path in Cargo.toml"));
 }
 


### PR DESCRIPTION
to avoid confusion when the warning happens inside a workspace, example:
pwd is rustlearnage/rust_books/1_first_edition/closures/
and `cargo run` shows:
```
warning: path `src/main.rs` was erroneously implicitly accepted for binary match,
please set bin.path in Cargo.toml
```
(note that 'match' is not quoted, so it's confusing)

the 'match' project that it's referring to is in rustlearnage/rust_books/1_first_edition/match/
(note: Cargo.toml [workspace] is in rustlearnage/ )