### PR TITLE
cargotest/support: remove internal mutability in favor of switching types

### DIFF
--- a/tests/bad-config.rs
+++ b/tests/bad-config.rs
@@ -7,7 +7,7 @@ use hamcrest::assert_that;
 
 #[test]
 fn bad1() {
-    let foo = project("foo")
+    let p = project("foo")
         .file("Cargo.toml", r#"
             [package]
             name = "foo"
@@ -18,8 +18,9 @@ fn bad1() {
         .file(".cargo/config", r#"
               [target]
               nonexistent-target = "foo"
-        "#);
-    assert_that(foo.cargo_process("build").arg("-v")
+        "#)
+        .build();
+    assert_that(p.cargo("build").arg("-v")
                    .arg("--target=nonexistent-target"),
                 execs().with_status(101).with_stderr("\
 [ERROR] expected table for configuration key `target.nonexistent-target`, \
@@ -29,7 +30,7 @@ but found string in [..]config
 
 #[test]
 fn bad2() {
-    let foo = project("foo")
+    let p = project("foo")
         .file("Cargo.toml", r#"
             [package]
             name = "foo"
@@ -40,8 +41,9 @@ fn bad2() {
         .file(".cargo/config", r#"
               [http]
                 proxy = 3.0
-        "#);
-    assert_that(foo.cargo_process("publish").arg("-v"),
+        "#)
+        .build();
+    assert_that(p.cargo("publish").arg("-v"),
                 execs().with_status(101).with_stderr("\
 [ERROR] Couldn't load Cargo configuration
 
@@ -61,7 +63,7 @@ Caused by:
 
 #[test]
 fn bad3() {
-    let foo = project("foo")
+    let p = project("foo")
         .file("Cargo.toml", r#"
             [package]
             name = "foo"
@@ -72,10 +74,11 @@ fn bad3() {
         .file(".cargo/config", r#"
             [http]
               proxy = true
-        "#);
+        "#)
+        .build();
     Package::new("foo", "1.0.0").publish();
 
-    assert_that(foo.cargo_process("publish").arg("-v"),
+    assert_that(p.cargo("publish").arg("-v"),
                 execs().with_status(101).with_stderr("\
 error: failed to update registry [..]
 
@@ -87,12 +90,13 @@ expected a string, but found a boolean for `http.proxy` in [..]config
 
 #[test]
 fn bad4() {
-    let foo = project("foo")
+    let p = project("foo")
         .file(".cargo/config", r#"
             [cargo-new]
               name = false
-        "#);
-    assert_that(foo.cargo_process("new").arg("-v").arg("foo"),
+        "#)
+        .build();
+    assert_that(p.cargo("new").arg("-v").arg("foo"),
                 execs().with_status(101).with_stderr("\
 [ERROR] Failed to create project `foo` at `[..]`
 
@@ -104,16 +108,16 @@ expected a string, but found a boolean for `cargo-new.name` in [..]config
 
 #[test]
 fn bad5() {
-    let foo = project("foo")
+    let p = project("foo")
         .file(".cargo/config", r#"
             foo = ""
         "#)
         .file("foo/.cargo/config", r#"
             foo = 2
-        "#);
-    foo.build();
-    assert_that(foo.cargo("new")
-                   .arg("-v").arg("foo").cwd(&foo.root().join("foo")),
+        "#)
+        .build();
+    assert_that(p.cargo("new")
+                   .arg("-v").arg("foo").cwd(&p.root().join("foo")),
                 execs().with_status(101).with_stderr("\
 [ERROR] Failed to create project `foo` at `[..]`
 
@@ -135,19 +139,20 @@ Caused by:
 
 #[test]
 fn bad_cargo_config_jobs() {
-    let foo = project("foo")
-    .file("Cargo.toml", r#"
-        [package]
-        name = "foo"
-        version = "0.0.0"
-        authors = []
-    "#)
-    .file("src/lib.rs", "")
-    .file(".cargo/config", r#"
-        [build]
-        jobs = -1
-    "#);
-    assert_that(foo.cargo_process("build").arg("-v"),
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [package]
+            name = "foo"
+            version = "0.0.0"
+            authors = []
+        "#)
+        .file("src/lib.rs", "")
+        .file(".cargo/config", r#"
+            [build]
+            jobs = -1
+        "#)
+        .build();
+    assert_that(p.cargo("build").arg("-v"),
                 execs().with_status(101).with_stderr("\
 [ERROR] build.jobs must be positive, but found -1 in [..]
 "));
@@ -155,56 +160,59 @@ fn bad_cargo_config_jobs() {
 
 #[test]
 fn default_cargo_config_jobs() {
-    let foo = project("foo")
-    .file("Cargo.toml", r#"
-        [package]
-        name = "foo"
-        version = "0.0.0"
-        authors = []
-    "#)
-    .file("src/lib.rs", "")
-    .file(".cargo/config", r#"
-        [build]
-        jobs = 1
-    "#);
-    assert_that(foo.cargo_process("build").arg("-v"),
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [package]
+            name = "foo"
+            version = "0.0.0"
+            authors = []
+        "#)
+        .file("src/lib.rs", "")
+        .file(".cargo/config", r#"
+            [build]
+            jobs = 1
+        "#)
+        .build();
+    assert_that(p.cargo("build").arg("-v"),
                 execs().with_status(0));
 }
 
 #[test]
 fn good_cargo_config_jobs() {
-    let foo = project("foo")
-    .file("Cargo.toml", r#"
-        [package]
-        name = "foo"
-        version = "0.0.0"
-        authors = []
-    "#)
-    .file("src/lib.rs", "")
-    .file(".cargo/config", r#"
-        [build]
-        jobs = 4
-    "#);
-    assert_that(foo.cargo_process("build").arg("-v"),
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [package]
+            name = "foo"
+            version = "0.0.0"
+            authors = []
+        "#)
+        .file("src/lib.rs", "")
+        .file(".cargo/config", r#"
+            [build]
+            jobs = 4
+        "#)
+        .build();
+    assert_that(p.cargo("build").arg("-v"),
                 execs().with_status(0));
 }
 
 #[test]
 fn invalid_global_config() {
-    let foo = project("foo")
-    .file("Cargo.toml", r#"
-        [package]
-        name = "foo"
-        version = "0.0.0"
-        authors = []
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [package]
+            name = "foo"
+            version = "0.0.0"
+            authors = []
 
-        [dependencies]
-        foo = "0.1.0"
-    "#)
-    .file(".cargo/config", "4")
-    .file("src/lib.rs", "");
+            [dependencies]
+            foo = "0.1.0"
+        "#)
+        .file(".cargo/config", "4")
+        .file("src/lib.rs", "")
+        .build();
 
-    assert_that(foo.cargo_process("build").arg("-v"),
+    assert_that(p.cargo("build").arg("-v"),
                 execs().with_status(101).with_stderr("\
 [ERROR] Couldn't load Cargo configuration
 
@@ -221,17 +229,18 @@ Caused by:
 
 #[test]
 fn bad_cargo_lock() {
-    let foo = project("foo")
-    .file("Cargo.toml", r#"
-        [package]
-        name = "foo"
-        version = "0.0.0"
-        authors = []
-    "#)
-    .file("Cargo.lock", "[[package]]\nfoo = 92")
-    .file("src/lib.rs", "");
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [package]
+            name = "foo"
+            version = "0.0.0"
+            authors = []
+        "#)
+        .file("Cargo.lock", "[[package]]\nfoo = 92")
+        .file("src/lib.rs", "")
+        .build();
 
-    assert_that(foo.cargo_process("build").arg("-v"),
+    assert_that(p.cargo("build").arg("-v"),
                 execs().with_status(101).with_stderr("\
 [ERROR] failed to parse lock file at: [..]Cargo.lock
 
@@ -272,8 +281,8 @@ fn duplicate_packages_in_cargo_lock() {
             name = "foo"
             version = "0.1.0"
             source = "registry+https://github.com/rust-lang/crates.io-index"
-        "#);
-    p.build();
+        "#)
+        .build();
 
     assert_that(p.cargo("build").arg("--verbose"),
                 execs().with_status(101).with_stderr("\
@@ -311,8 +320,8 @@ fn bad_source_in_cargo_lock() {
             name = "foo"
             version = "0.1.0"
             source = "You shall not parse"
-        "#);
-    p.build();
+        "#)
+        .build();
 
     assert_that(p.cargo("build").arg("--verbose"),
                 execs().with_status(101).with_stderr("\
@@ -340,8 +349,8 @@ fn bad_dependency_in_lockfile() {
             dependencies = [
              "bar 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
             ]
-        "#);
-    p.build();
+        "#)
+        .build();
 
     assert_that(p.cargo("build").arg("--verbose"),
                 execs().with_status(101).with_stderr("\
@@ -355,19 +364,20 @@ Caused by:
 
 #[test]
 fn bad_git_dependency() {
-    let foo = project("foo")
-    .file("Cargo.toml", r#"
-        [package]
-        name = "foo"
-        version = "0.0.0"
-        authors = []
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [package]
+            name = "foo"
+            version = "0.0.0"
+            authors = []
 
-        [dependencies]
-        foo = { git = "file:.." }
-    "#)
-    .file("src/lib.rs", "");
+            [dependencies]
+            foo = { git = "file:.." }
+        "#)
+        .file("src/lib.rs", "")
+        .build();
 
-    assert_that(foo.cargo_process("build").arg("-v"),
+    assert_that(p.cargo("build").arg("-v"),
                 execs().with_status(101).with_stderr("\
 [UPDATING] git repository `file:///`
 [ERROR] failed to load source for a dependency on `foo`
@@ -385,19 +395,20 @@ Caused by:
 
 #[test]
 fn bad_crate_type() {
-    let foo = project("foo")
-    .file("Cargo.toml", r#"
-        [package]
-        name = "foo"
-        version = "0.0.0"
-        authors = []
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [package]
+            name = "foo"
+            version = "0.0.0"
+            authors = []
 
-        [lib]
-        crate-type = ["bad_type", "rlib"]
-    "#)
-    .file("src/lib.rs", "");
+            [lib]
+            crate-type = ["bad_type", "rlib"]
+        "#)
+        .file("src/lib.rs", "")
+        .build();
 
-    assert_that(foo.cargo_process("build").arg("-v"),
+    assert_that(p.cargo("build").arg("-v"),
                 execs().with_status(101).with_stderr_contains("\
 error: failed to run `rustc` to learn about target-specific information
 "));
@@ -405,21 +416,22 @@ error: failed to run `rustc` to learn about target-specific information
 
 #[test]
 fn malformed_override() {
-    let foo = project("foo")
-    .file("Cargo.toml", r#"
-        [package]
-        name = "foo"
-        version = "0.0.0"
-        authors = []
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [package]
+            name = "foo"
+            version = "0.0.0"
+            authors = []
 
-        [target.x86_64-apple-darwin.freetype]
-        native = {
-          foo: "bar"
-        }
-    "#)
-    .file("src/lib.rs", "");
+            [target.x86_64-apple-darwin.freetype]
+            native = {
+              foo: "bar"
+            }
+        "#)
+        .file("src/lib.rs", "")
+        .build();
 
-    assert_that(foo.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(101).with_stderr("\
 [ERROR] failed to parse manifest at `[..]`
 
@@ -433,25 +445,26 @@ Caused by:
 
 #[test]
 fn duplicate_binary_names() {
-    let foo = project("foo")
-    .file("Cargo.toml", r#"
-       [package]
-       name = "qqq"
-       version = "0.1.0"
-       authors = ["A <a@a.a>"]
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+           [package]
+           name = "qqq"
+           version = "0.1.0"
+           authors = ["A <a@a.a>"]
 
-       [[bin]]
-       name = "e"
-       path = "a.rs"
+           [[bin]]
+           name = "e"
+           path = "a.rs"
 
-       [[bin]]
-       name = "e"
-       path = "b.rs"
-    "#)
-    .file("a.rs", r#"fn main() -> () {}"#)
-    .file("b.rs", r#"fn main() -> () {}"#);
+           [[bin]]
+           name = "e"
+           path = "b.rs"
+        "#)
+        .file("a.rs", r#"fn main() -> () {}"#)
+        .file("b.rs", r#"fn main() -> () {}"#)
+        .build();
 
-    assert_that(foo.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(101).with_stderr("\
 [ERROR] failed to parse manifest at `[..]`
 
@@ -462,25 +475,26 @@ Caused by:
 
 #[test]
 fn duplicate_example_names() {
-    let foo = project("foo")
-    .file("Cargo.toml", r#"
-       [package]
-       name = "qqq"
-       version = "0.1.0"
-       authors = ["A <a@a.a>"]
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+           [package]
+           name = "qqq"
+           version = "0.1.0"
+           authors = ["A <a@a.a>"]
 
-       [[example]]
-       name = "ex"
-       path = "examples/ex.rs"
+           [[example]]
+           name = "ex"
+           path = "examples/ex.rs"
 
-       [[example]]
-       name = "ex"
-       path = "examples/ex2.rs"
-    "#)
-    .file("examples/ex.rs", r#"fn main () -> () {}"#)
-    .file("examples/ex2.rs", r#"fn main () -> () {}"#);
+           [[example]]
+           name = "ex"
+           path = "examples/ex2.rs"
+        "#)
+        .file("examples/ex.rs", r#"fn main () -> () {}"#)
+        .file("examples/ex2.rs", r#"fn main () -> () {}"#)
+        .build();
 
-    assert_that(foo.cargo_process("build").arg("--example").arg("ex"),
+    assert_that(p.cargo("build").arg("--example").arg("ex"),
                 execs().with_status(101).with_stderr("\
 [ERROR] failed to parse manifest at `[..]`
 
@@ -491,25 +505,26 @@ Caused by:
 
 #[test]
 fn duplicate_bench_names() {
-    let foo = project("foo")
-    .file("Cargo.toml", r#"
-       [package]
-       name = "qqq"
-       version = "0.1.0"
-       authors = ["A <a@a.a>"]
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+           [package]
+           name = "qqq"
+           version = "0.1.0"
+           authors = ["A <a@a.a>"]
 
-       [[bench]]
-       name = "ex"
-       path = "benches/ex.rs"
+           [[bench]]
+           name = "ex"
+           path = "benches/ex.rs"
 
-       [[bench]]
-       name = "ex"
-       path = "benches/ex2.rs"
-    "#)
-    .file("benches/ex.rs", r#"fn main () {}"#)
-    .file("benches/ex2.rs", r#"fn main () {}"#);
+           [[bench]]
+           name = "ex"
+           path = "benches/ex2.rs"
+        "#)
+        .file("benches/ex.rs", r#"fn main () {}"#)
+        .file("benches/ex2.rs", r#"fn main () {}"#)
+        .build();
 
-    assert_that(foo.cargo_process("bench"),
+    assert_that(p.cargo("bench"),
                 execs().with_status(101).with_stderr("\
 [ERROR] failed to parse manifest at `[..]`
 
@@ -520,40 +535,41 @@ Caused by:
 
 #[test]
 fn duplicate_deps() {
-    let foo = project("foo")
-    .file("shim-bar/Cargo.toml", r#"
-       [package]
-       name = "bar"
-       version = "0.0.1"
-       authors = []
-    "#)
-    .file("shim-bar/src/lib.rs", r#"
-            pub fn a() {}
-    "#)
-    .file("linux-bar/Cargo.toml", r#"
-       [package]
-       name = "bar"
-       version = "0.0.1"
-       authors = []
-    "#)
-    .file("linux-bar/src/lib.rs", r#"
-            pub fn a() {}
-    "#)
-    .file("Cargo.toml", r#"
-       [package]
-       name = "qqq"
-       version = "0.0.1"
-       authors = []
+    let p = project("foo")
+        .file("shim-bar/Cargo.toml", r#"
+           [package]
+           name = "bar"
+           version = "0.0.1"
+           authors = []
+        "#)
+        .file("shim-bar/src/lib.rs", r#"
+                pub fn a() {}
+        "#)
+        .file("linux-bar/Cargo.toml", r#"
+           [package]
+           name = "bar"
+           version = "0.0.1"
+           authors = []
+        "#)
+        .file("linux-bar/src/lib.rs", r#"
+                pub fn a() {}
+        "#)
+        .file("Cargo.toml", r#"
+           [package]
+           name = "qqq"
+           version = "0.0.1"
+           authors = []
 
-       [dependencies]
-       bar = { path = "shim-bar" }
+           [dependencies]
+           bar = { path = "shim-bar" }
 
-       [target.x86_64-unknown-linux-gnu.dependencies]
-       bar = { path = "linux-bar" }
-    "#)
-    .file("src/main.rs", r#"fn main () {}"#);
+           [target.x86_64-unknown-linux-gnu.dependencies]
+           bar = { path = "linux-bar" }
+        "#)
+        .file("src/main.rs", r#"fn main () {}"#)
+        .build();
 
-    assert_that(foo.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(101).with_stderr("\
 [ERROR] failed to parse manifest at `[..]`
 
@@ -565,40 +581,41 @@ have a single canonical source path irrespective of build target.
 
 #[test]
 fn duplicate_deps_diff_sources() {
-    let foo = project("foo")
-    .file("shim-bar/Cargo.toml", r#"
-       [package]
-       name = "bar"
-       version = "0.0.1"
-       authors = []
-    "#)
-    .file("shim-bar/src/lib.rs", r#"
-            pub fn a() {}
-    "#)
-    .file("linux-bar/Cargo.toml", r#"
-       [package]
-       name = "bar"
-       version = "0.0.1"
-       authors = []
-    "#)
-    .file("linux-bar/src/lib.rs", r#"
-            pub fn a() {}
-    "#)
-    .file("Cargo.toml", r#"
-       [package]
-       name = "qqq"
-       version = "0.0.1"
-       authors = []
+    let p = project("foo")
+        .file("shim-bar/Cargo.toml", r#"
+           [package]
+           name = "bar"
+           version = "0.0.1"
+           authors = []
+        "#)
+        .file("shim-bar/src/lib.rs", r#"
+                pub fn a() {}
+        "#)
+        .file("linux-bar/Cargo.toml", r#"
+           [package]
+           name = "bar"
+           version = "0.0.1"
+           authors = []
+        "#)
+        .file("linux-bar/src/lib.rs", r#"
+                pub fn a() {}
+        "#)
+        .file("Cargo.toml", r#"
+           [package]
+           name = "qqq"
+           version = "0.0.1"
+           authors = []
 
-       [target.i686-unknown-linux-gnu.dependencies]
-       bar = { path = "shim-bar" }
+           [target.i686-unknown-linux-gnu.dependencies]
+           bar = { path = "shim-bar" }
 
-       [target.x86_64-unknown-linux-gnu.dependencies]
-       bar = { path = "linux-bar" }
-    "#)
-    .file("src/main.rs", r#"fn main () {}"#);
+           [target.x86_64-unknown-linux-gnu.dependencies]
+           bar = { path = "linux-bar" }
+        "#)
+        .file("src/main.rs", r#"fn main () {}"#)
+        .build();
 
-    assert_that(foo.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(101).with_stderr("\
 [ERROR] failed to parse manifest at `[..]`
 
@@ -620,17 +637,17 @@ fn unused_keys() {
            [target.foo]
            bar = "3"
         "#)
-        .file("src/lib.rs", "");
+        .file("src/lib.rs", "")
+        .build();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(0).with_stderr("\
 warning: unused manifest key: target.foo.bar
 [COMPILING] foo v0.1.0 (file:///[..])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
 
-    let mut p = project("foo");
-    p = p
+    let p = project("foo")
         .file("Cargo.toml", r#"
             [project]
 
@@ -641,8 +658,9 @@ warning: unused manifest key: target.foo.bar
         "#)
         .file("src/lib.rs", r#"
             pub fn foo() {}
-        "#);
-    assert_that(p.cargo_process("build"),
+        "#)
+        .build();
+    assert_that(p.cargo("build"),
                 execs().with_status(0)
                     .with_stderr("\
 warning: unused manifest key: project.bulid
@@ -650,8 +668,7 @@ warning: unused manifest key: project.bulid
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
 
-    let mut p = project("bar");
-    p = p
+    let p = project("bar")
         .file("Cargo.toml", r#"
             [project]
 
@@ -664,8 +681,9 @@ warning: unused manifest key: project.bulid
         "#)
         .file("src/lib.rs", r#"
             pub fn foo() {}
-        "#);
-    assert_that(p.cargo_process("build"),
+        "#)
+        .build();
+    assert_that(p.cargo("build"),
                 execs().with_status(0)
                     .with_stderr("\
 warning: unused manifest key: lib.build
@@ -678,20 +696,21 @@ warning: unused manifest key: lib.build
 #[test]
 fn empty_dependencies() {
     let p = project("empty_deps")
-    .file("Cargo.toml", r#"
-        [package]
-        name = "empty_deps"
-        version = "0.0.0"
-        authors = []
+        .file("Cargo.toml", r#"
+            [package]
+            name = "empty_deps"
+            version = "0.0.0"
+            authors = []
 
-        [dependencies]
-        foo = {}
-    "#)
-    .file("src/main.rs", "fn main() {}");
+            [dependencies]
+            foo = {}
+        "#)
+        .file("src/main.rs", "fn main() {}")
+        .build();
 
     Package::new("foo", "0.0.1").publish();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(0).with_stderr_contains("\
 warning: dependency (foo) specified without providing a local path, Git repository, or version \
 to use. This will be considered an error in future versions
@@ -701,18 +720,19 @@ to use. This will be considered an error in future versions
 #[test]
 fn invalid_toml_historically_allowed_is_warned() {
     let p = project("empty_deps")
-    .file("Cargo.toml", r#"
-        [package]
-        name = "empty_deps"
-        version = "0.0.0"
-        authors = []
-    "#)
-    .file(".cargo/config", r#"
-        [foo] bar = 2
-    "#)
-    .file("src/main.rs", "fn main() {}");
+        .file("Cargo.toml", r#"
+            [package]
+            name = "empty_deps"
+            version = "0.0.0"
+            authors = []
+        "#)
+        .file(".cargo/config", r#"
+            [foo] bar = 2
+        "#)
+        .file("src/main.rs", "fn main() {}")
+        .build();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(0).with_stderr("\
 warning: TOML file found which contains invalid syntax and will soon not parse
 at `[..]config`.
@@ -728,21 +748,22 @@ in the future.
 
 #[test]
 fn ambiguous_git_reference() {
-    let foo = project("foo")
-    .file("Cargo.toml", r#"
-        [package]
-        name = "foo"
-        version = "0.0.0"
-        authors = []
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [package]
+            name = "foo"
+            version = "0.0.0"
+            authors = []
 
-        [dependencies.bar]
-        git = "https://127.0.0.1"
-        branch = "master"
-        tag = "some-tag"
-    "#)
-    .file("src/lib.rs", "");
+            [dependencies.bar]
+            git = "https://127.0.0.1"
+            branch = "master"
+            tag = "some-tag"
+        "#)
+        .file("src/lib.rs", "")
+        .build();
 
-    assert_that(foo.cargo_process("build").arg("-v"),
+    assert_that(p.cargo("build").arg("-v"),
                 execs().with_stderr_contains("\
 [WARNING] dependency (bar) specification is ambiguous. \
 Only one of `branch`, `tag` or `rev` is allowed. \
@@ -762,9 +783,10 @@ fn bad_source_config1() {
         .file("src/lib.rs", "")
         .file(".cargo/config", r#"
             [source.foo]
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(101).with_stderr("\
 error: no source URL specified for `source.foo`, need [..]
 "));
@@ -787,9 +809,10 @@ fn bad_source_config2() {
             [source.crates-io]
             registry = 'http://example.com'
             replace-with = 'bar'
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(101).with_stderr("\
 error: failed to load source for a dependency on `bar`
 
@@ -819,9 +842,10 @@ fn bad_source_config3() {
             [source.crates-io]
             registry = 'http://example.com'
             replace-with = 'crates-io'
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(101).with_stderr("\
 error: failed to load source for a dependency on `bar`
 
@@ -854,9 +878,10 @@ fn bad_source_config4() {
             [source.bar]
             registry = 'http://example.com'
             replace-with = 'crates-io'
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(101).with_stderr("\
 error: failed to load source for a dependency on `bar`
 
@@ -889,9 +914,10 @@ fn bad_source_config5() {
 
             [source.bar]
             registry = 'not a url'
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(101).with_stderr("\
 error: configuration key `source.bar.registry` specified an invalid URL (in [..])
 
@@ -913,9 +939,10 @@ fn both_git_and_path_specified() {
         git = "https://127.0.0.1"
         path = "bar"
     "#)
-        .file("src/lib.rs", "");
+        .file("src/lib.rs", "")
+        .build();
 
-    assert_that(foo.cargo_process("build").arg("-v"),
+    assert_that(foo.cargo("build").arg("-v"),
                 execs().with_stderr_contains("\
 [WARNING] dependency (bar) specification is ambiguous. \
 Only one of `git` or `path` is allowed. \
@@ -940,9 +967,10 @@ fn bad_source_config6() {
             [source.crates-io]
             registry = 'http://example.com'
             replace-with = ['not', 'a', 'string']
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(101).with_stderr("\
 error: expected a string, but found a array for `source.crates-io.replace-with` in [..]
 "));
@@ -961,9 +989,10 @@ fn ignored_git_revision() {
         path = "bar"
         branch = "spam"
     "#)
-        .file("src/lib.rs", "");
+        .file("src/lib.rs", "")
+        .build();
 
-    assert_that(foo.cargo_process("build").arg("-v"),
+    assert_that(foo.cargo("build").arg("-v"),
                 execs().with_stderr_contains("\
 [WARNING] key `branch` is ignored for dependency (bar). \
 This will be considered an error in future versions"));
@@ -986,11 +1015,12 @@ fn bad_source_config7() {
             [source.foo]
             registry = 'http://example.com'
             local-registry = 'file:///another/file'
-        "#);
+        "#)
+        .build();
 
     Package::new("bar", "0.1.0").publish();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(101).with_stderr("\
 error: more than one source URL specified for `source.foo`
 "));
@@ -1008,9 +1038,10 @@ fn bad_dependency() {
             [dependencies]
             bar = 3
         "#)
-        .file("src/lib.rs", "");
+        .file("src/lib.rs", "")
+        .build();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(101).with_stderr("\
 error: failed to parse manifest at `[..]`
 
@@ -1031,9 +1062,10 @@ fn bad_debuginfo() {
             [profile.dev]
             debug = 'a'
         "#)
-        .file("src/lib.rs", "");
+        .file("src/lib.rs", "")
+        .build();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(101).with_stderr("\
 error: failed to parse manifest at `[..]`
 
@@ -1052,9 +1084,10 @@ fn bad_opt_level() {
             authors = []
             build = 3
         "#)
-        .file("src/lib.rs", "");
+        .file("src/lib.rs", "")
+        .build();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(101).with_stderr("\
 error: failed to parse manifest at `[..]`
 

--- a/tests/bad-manifest-path.rs
+++ b/tests/bad-manifest-path.rs
@@ -7,9 +7,10 @@ use hamcrest::{assert_that};
 fn assert_not_a_cargo_toml(command: &str, manifest_path_argument: &str) {
     let p = project("foo")
         .file("Cargo.toml", &basic_bin_manifest("foo"))
-        .file("src/foo.rs", &main_file(r#""i am foo""#, &[]));
+        .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
+        .build();
 
-    assert_that(p.cargo_process(command)
+    assert_that(p.cargo(command)
                  .arg("--manifest-path").arg(manifest_path_argument)
                  .cwd(p.root().parent().unwrap()),
                 execs().with_status(101)
@@ -19,11 +20,11 @@ fn assert_not_a_cargo_toml(command: &str, manifest_path_argument: &str) {
 
 
 fn assert_cargo_toml_doesnt_exist(command: &str, manifest_path_argument: &str) {
-    let p = project("foo");
+    let p = project("foo").build();
     let expected_path = manifest_path_argument
         .split('/').collect::<Vec<_>>().join("[..]");
 
-    assert_that(p.cargo_process(command)
+    assert_that(p.cargo(command)
                  .arg("--manifest-path").arg(manifest_path_argument)
                  .cwd(p.root().parent().unwrap()),
                 execs().with_status(101)
@@ -317,9 +318,10 @@ fn update_dir_to_nonexistent_cargo_toml() {
 fn verify_project_dir_containing_cargo_toml() {
     let p = project("foo")
         .file("Cargo.toml", &basic_bin_manifest("foo"))
-        .file("src/foo.rs", &main_file(r#""i am foo""#, &[]));
+        .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
+        .build();
 
-    assert_that(p.cargo_process("verify-project")
+    assert_that(p.cargo("verify-project")
                  .arg("--manifest-path").arg("foo")
                  .cwd(p.root().parent().unwrap()),
                 execs().with_status(1)
@@ -332,9 +334,10 @@ fn verify_project_dir_containing_cargo_toml() {
 fn verify_project_dir_plus_file() {
     let p = project("foo")
         .file("Cargo.toml", &basic_bin_manifest("foo"))
-        .file("src/foo.rs", &main_file(r#""i am foo""#, &[]));
+        .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
+        .build();
 
-    assert_that(p.cargo_process("verify-project")
+    assert_that(p.cargo("verify-project")
                  .arg("--manifest-path").arg("foo/bar")
                  .cwd(p.root().parent().unwrap()),
                 execs().with_status(1)
@@ -347,9 +350,10 @@ fn verify_project_dir_plus_file() {
 fn verify_project_dir_plus_path() {
     let p = project("foo")
         .file("Cargo.toml", &basic_bin_manifest("foo"))
-        .file("src/foo.rs", &main_file(r#""i am foo""#, &[]));
+        .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
+        .build();
 
-    assert_that(p.cargo_process("verify-project")
+    assert_that(p.cargo("verify-project")
                  .arg("--manifest-path").arg("foo/bar/baz")
                  .cwd(p.root().parent().unwrap()),
                 execs().with_status(1)
@@ -360,8 +364,8 @@ fn verify_project_dir_plus_path() {
 
 #[test]
 fn verify_project_dir_to_nonexistent_cargo_toml() {
-    let p = project("foo");
-    assert_that(p.cargo_process("verify-project")
+    let p = project("foo").build();
+    assert_that(p.cargo("verify-project")
                  .arg("--manifest-path").arg("foo/bar/baz/Cargo.toml")
                  .cwd(p.root().parent().unwrap()),
                 execs().with_status(1)

--- a/tests/bench.rs
+++ b/tests/bench.rs
@@ -32,9 +32,10 @@ fn cargo_bench_simple() {
             #[bench]
             fn bench_hello(_b: &mut test::Bencher) {
                 assert_eq!(hello(), "hello")
-            }"#);
+            }"#)
+        .build();
 
-    assert_that(p.cargo_process("build"), execs());
+    assert_that(p.cargo("build"), execs());
     assert_that(&p.bin("foo"), existing_file());
 
     assert_that(process(&p.bin("foo")),
@@ -52,7 +53,7 @@ fn cargo_bench_simple() {
 fn bench_bench_implicit() {
     if !is_nightly() { return }
 
-    let prj = project("foo")
+    let p = project("foo")
         .file("Cargo.toml" , r#"
             [package]
             name = "foo"
@@ -72,15 +73,16 @@ fn bench_bench_implicit() {
         .file("benches/mybench.rs", r#"
             #![feature(test)]
             extern crate test;
-            #[bench] fn run2(_ben: &mut test::Bencher) { }"#);
+            #[bench] fn run2(_ben: &mut test::Bencher) { }"#)
+        .build();
 
-    assert_that(prj.cargo_process("bench").arg("--benches"),
+    assert_that(p.cargo("bench").arg("--benches"),
         execs().with_status(0)
                .with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({dir})
 [FINISHED] release [optimized] target(s) in [..]
 [RUNNING] target[/]release[/]deps[/]mybench-[..][EXE]
-", dir = prj.url()))
+", dir = p.url()))
                .with_stdout_contains("test run2 ... bench: [..]"));
 }
 
@@ -88,7 +90,7 @@ fn bench_bench_implicit() {
 fn bench_bin_implicit() {
     if !is_nightly() { return }
 
-    let prj = project("foo")
+    let p = project("foo")
         .file("Cargo.toml" , r#"
             [package]
             name = "foo"
@@ -108,15 +110,16 @@ fn bench_bin_implicit() {
         .file("benches/mybench.rs", r#"
             #![feature(test)]
             extern crate test;
-            #[bench] fn run2(_ben: &mut test::Bencher) { }"#);
+            #[bench] fn run2(_ben: &mut test::Bencher) { }"#)
+        .build();
 
-    assert_that(prj.cargo_process("bench").arg("--bins"),
+    assert_that(p.cargo("bench").arg("--bins"),
         execs().with_status(0)
                .with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({dir})
 [FINISHED] release [optimized] target(s) in [..]
 [RUNNING] target[/]release[/]deps[/]foo-[..][EXE]
-", dir = prj.url()))
+", dir = p.url()))
                .with_stdout_contains("test run1 ... bench: [..]"));
 }
 
@@ -124,7 +127,7 @@ fn bench_bin_implicit() {
 fn bench_tarname() {
     if !is_nightly() { return }
 
-    let prj = project("foo")
+    let p = project("foo")
         .file("Cargo.toml" , r#"
             [package]
             name = "foo"
@@ -138,15 +141,16 @@ fn bench_tarname() {
         .file("benches/bin2.rs", r#"
             #![feature(test)]
             extern crate test;
-            #[bench] fn run2(_ben: &mut test::Bencher) { }"#);
+            #[bench] fn run2(_ben: &mut test::Bencher) { }"#)
+        .build();
 
-    assert_that(prj.cargo_process("bench").arg("--bench").arg("bin2"),
+    assert_that(p.cargo("bench").arg("--bench").arg("bin2"),
         execs().with_status(0)
                .with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({dir})
 [FINISHED] release [optimized] target(s) in [..]
 [RUNNING] target[/]release[/]deps[/]bin2-[..][EXE]
-", dir = prj.url()))
+", dir = p.url()))
                .with_stdout_contains("test run2 ... bench: [..]"));
 }
 
@@ -154,7 +158,7 @@ fn bench_tarname() {
 fn bench_multiple_targets() {
     if !is_nightly() { return }
 
-    let prj = project("foo")
+    let p = project("foo")
         .file("Cargo.toml" , r#"
             [package]
             name = "foo"
@@ -172,9 +176,10 @@ fn bench_multiple_targets() {
         .file("benches/bin3.rs", r#"
             #![feature(test)]
             extern crate test;
-            #[bench] fn run3(_ben: &mut test::Bencher) { }"#);
+            #[bench] fn run3(_ben: &mut test::Bencher) { }"#)
+        .build();
 
-    assert_that(prj.cargo_process("bench")
+    assert_that(p.cargo("bench")
                 .arg("--bench").arg("bin1")
                 .arg("--bench").arg("bin2"),
                 execs()
@@ -196,9 +201,10 @@ fn cargo_bench_verbose() {
             extern crate test;
             fn main() {}
             #[bench] fn bench_hello(_b: &mut test::Bencher) {}
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("bench").arg("-v").arg("hello"),
+    assert_that(p.cargo("bench").arg("-v").arg("hello"),
                 execs().with_stderr(&format!("\
 [COMPILING] foo v0.5.0 ({url})
 [RUNNING] `rustc [..] src[/]main.rs [..]`
@@ -239,9 +245,10 @@ fn many_similar_names() {
             extern crate foo;
             extern crate test;
             #[bench] fn bench_bench(_b: &mut test::Bencher) { foo::foo() }
-        "#);
+        "#)
+        .build();
 
-    let output = p.cargo_process("bench").exec_with_output().unwrap();
+    let output = p.cargo("bench").exec_with_output().unwrap();
     let output = str::from_utf8(&output.stdout).unwrap();
     assert!(output.contains("test bin_bench"), "bin_bench missing\n{}", output);
     assert!(output.contains("test lib_bench"), "lib_bench missing\n{}", output);
@@ -269,9 +276,10 @@ fn cargo_bench_failing_test() {
             #[bench]
             fn bench_hello(_b: &mut test::Bencher) {
                 assert_eq!(hello(), "nope")
-            }"#);
+            }"#)
+        .build();
 
-    assert_that(p.cargo_process("build"), execs());
+    assert_that(p.cargo("build"), execs());
     assert_that(&p.bin("foo"), existing_file());
 
     assert_that(process(&p.bin("foo")),
@@ -332,9 +340,10 @@ fn bench_with_lib_dep() {
 
             #[bench]
             fn bin_bench(_b: &mut test::Bencher) {}
-        ");
+        ")
+        .build();
 
-    assert_that(p.cargo_process("bench"),
+    assert_that(p.cargo("bench"),
                 execs().with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({})
 [FINISHED] release [optimized] target(s) in [..]
@@ -368,8 +377,9 @@ fn bench_with_deep_lib_dep() {
             fn bar_bench(_b: &mut test::Bencher) {
                 foo::foo();
             }
-        ");
-    let p2 = project("foo")
+        ")
+        .build();
+    let _p2 = project("foo")
         .file("Cargo.toml", r#"
             [package]
             name = "foo"
@@ -385,10 +395,10 @@ fn bench_with_deep_lib_dep() {
 
             #[bench]
             fn foo_bench(_b: &mut test::Bencher) {}
-        ");
+        ")
+        .build();
 
-    p2.build();
-    assert_that(p.cargo_process("bench"),
+    assert_that(p.cargo("bench"),
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ([..])
@@ -430,9 +440,10 @@ fn external_bench_explicit() {
 
             #[bench]
             fn external_bench(_b: &mut test::Bencher) {}
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("bench"),
+    assert_that(p.cargo("bench"),
                 execs().with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({})
 [FINISHED] release [optimized] target(s) in [..]
@@ -471,9 +482,10 @@ fn external_bench_implicit() {
 
             #[bench]
             fn external_bench(_b: &mut test::Bencher) {}
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("bench"),
+    assert_that(p.cargo("bench"),
                 execs().with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({})
 [FINISHED] release [optimized] target(s) in [..]
@@ -497,8 +509,9 @@ fn dont_run_examples() {
         .file("src/lib.rs", r"")
         .file("examples/dont-run-me-i-will-fail.rs", r#"
             fn main() { panic!("Examples should not be run by 'cargo test'"); }
-        "#);
-    assert_that(p.cargo_process("bench"),
+        "#)
+        .build();
+    assert_that(p.cargo("bench"),
                 execs().with_status(0));
 }
 
@@ -520,9 +533,10 @@ fn pass_through_command_line() {
 
             #[bench] fn foo(_b: &mut test::Bencher) {}
             #[bench] fn bar(_b: &mut test::Bencher) {}
-        ");
+        ")
+        .build();
 
-    assert_that(p.cargo_process("bench").arg("bar"),
+    assert_that(p.cargo("bench").arg("bar"),
                 execs().with_status(0)
                 .with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({dir})
@@ -553,9 +567,10 @@ fn cargo_bench_twice() {
 
             #[bench]
             fn dummy_bench(b: &mut test::Bencher) { }
-            "#);
+            "#)
+        .build();
 
-    p.cargo_process("build");
+    p.cargo("build");
 
     for _ in 0..2 {
         assert_that(p.cargo("bench"),
@@ -594,9 +609,10 @@ fn lib_bin_same_name() {
 
             #[bench]
             fn bin_bench(_b: &mut test::Bencher) {}
-        ");
+        ")
+        .build();
 
-    assert_that(p.cargo_process("bench"),
+    assert_that(p.cargo("bench"),
                 execs().with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({})
 [FINISHED] release [optimized] target(s) in [..]
@@ -636,9 +652,10 @@ fn lib_with_standard_name() {
 
             #[bench]
             fn bench(_b: &mut test::Bencher) { syntax::foo() }
-        ");
+        ")
+        .build();
 
-    assert_that(p.cargo_process("bench"),
+    assert_that(p.cargo("bench"),
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] syntax v0.0.1 ({dir})
@@ -679,9 +696,10 @@ fn lib_with_standard_name2() {
 
             #[bench]
             fn bench(_b: &mut test::Bencher) { syntax::foo() }
-        ");
+        ")
+        .build();
 
-    assert_that(p.cargo_process("bench"),
+    assert_that(p.cargo("bench"),
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] syntax v0.0.1 ({dir})
@@ -739,9 +757,10 @@ fn bench_dylib() {
         "#)
         .file("bar/src/lib.rs", "
              pub fn baz() {}
-        ");
+        ")
+        .build();
 
-    assert_that(p.cargo_process("bench").arg("-v"),
+    assert_that(p.cargo("bench").arg("-v"),
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] bar v0.0.1 ({dir}/bar)
@@ -786,9 +805,10 @@ fn bench_twice_with_build_cmd() {
             extern crate test;
             #[bench]
             fn foo(_b: &mut test::Bencher) {}
-        ");
+        ")
+        .build();
 
-    assert_that(p.cargo_process("bench"),
+    assert_that(p.cargo("bench"),
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({dir})
@@ -857,9 +877,10 @@ fn bench_with_examples() {
                 println!("example1");
                 testbench::f1();
             }
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("bench").arg("-v"),
+    assert_that(p.cargo("bench").arg("-v"),
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] testbench v6.6.6 ({url})
@@ -898,9 +919,10 @@ fn test_a_bench() {
         .file("benches/b.rs", r#"
             #[test]
             fn foo() {}
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("test"),
+    assert_that(p.cargo("test"),
                 execs().with_status(0)
                        .with_stderr("\
 [COMPILING] foo v0.1.0 ([..])
@@ -930,9 +952,10 @@ fn test_bench_no_run() {
 
             #[bench]
             fn bench_baz(_: &mut Bencher) {}
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("bench").arg("--no-run"),
+    assert_that(p.cargo("bench").arg("--no-run"),
                 execs().with_status(0)
                        .with_stderr("\
 [COMPILING] foo v0.1.0 ([..])
@@ -966,9 +989,10 @@ fn test_bench_no_fail_fast() {
             #[bench]
             fn bench_nope(_b: &mut test::Bencher) {
                 assert_eq!("nope", hello())
-            }"#);
+            }"#)
+        .build();
 
-    assert_that(p.cargo_process("bench").arg("--no-fail-fast"),
+    assert_that(p.cargo("bench").arg("--no-fail-fast"),
                 execs().with_status(101)
                     .with_stderr_contains("\
 [RUNNING] target[/]release[/]deps[/]foo-[..][EXE]")
@@ -996,9 +1020,10 @@ fn test_bench_multiple_packages() {
             [dependencies.baz]
             path = "../baz"
         "#)
-        .file("src/lib.rs", "");
+        .file("src/lib.rs", "")
+        .build();
 
-    let bar = project("bar")
+    let _bar = project("bar")
         .file("Cargo.toml", r#"
             [project]
             name = "bar"
@@ -1018,10 +1043,10 @@ fn test_bench_multiple_packages() {
 
             #[bench]
             fn bench_bar(_b: &mut Bencher) {}
-        "#);
-    bar.build();
+        "#)
+        .build();
 
-    let baz = project("baz")
+    let _baz = project("baz")
         .file("Cargo.toml", r#"
             [project]
             name = "baz"
@@ -1041,11 +1066,11 @@ fn test_bench_multiple_packages() {
 
             #[bench]
             fn bench_baz(_b: &mut Bencher) {}
-        "#);
-    baz.build();
+        "#)
+        .build();
 
 
-    assert_that(p.cargo_process("bench").arg("-p").arg("bar").arg("-p").arg("baz"),
+    assert_that(p.cargo("bench").arg("-p").arg("bar").arg("-p").arg("baz"),
                 execs().with_status(0)
                        .with_stderr_contains("\
 [RUNNING] target[/]release[/]deps[/]bbaz-[..][EXE]")
@@ -1098,9 +1123,10 @@ fn bench_all_workspace() {
 
             #[bench]
             fn bench_bar(_: &mut Bencher) -> () { () }
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("bench")
+    assert_that(p.cargo("bench")
                  .arg("--all"),
                 execs().with_status(0)
                        .with_stderr_contains("\
@@ -1152,9 +1178,10 @@ fn bench_all_exclude() {
             pub fn baz() {
                 break_the_build();
             }
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("bench")
+    assert_that(p.cargo("bench")
                     .arg("--all")
                     .arg("--exclude")
                     .arg("baz"),
@@ -1206,10 +1233,11 @@ fn bench_all_virtual_manifest() {
 
             #[bench]
             fn bench_bar(_: &mut Bencher) -> () { () }
-        "#);
+        "#)
+        .build();
 
     // The order in which foo and bar are built is not guaranteed
-    assert_that(p.cargo_process("bench")
+    assert_that(p.cargo("bench")
                  .arg("--all"),
                 execs().with_status(0)
                        .with_stderr_contains("\
@@ -1245,9 +1273,10 @@ fn legacy_bench_name() {
 
             #[bench]
             fn bench_foo(_: &mut Bencher) -> () { () }
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("bench"), execs().with_status(0).with_stderr_contains("\
+    assert_that(p.cargo("bench"), execs().with_status(0).with_stderr_contains("\
 [WARNING] path `[..]src[/]bench.rs` was erroneously implicitly accepted for benchmark `bench`,
 please set bench.path in Cargo.toml"));
 }
@@ -1290,11 +1319,12 @@ fn bench_virtual_manifest_all_implied() {
             use test::Bencher;
             #[bench]
             fn bench_bar(_: &mut Bencher) -> () { () }
-        "#);
+        "#)
+        .build();
 
     // The order in which foo and bar are built is not guaranteed
     
-    assert_that(p.cargo_process("bench"),
+    assert_that(p.cargo("bench"),
                 execs().with_status(0)
                        .with_stderr_contains("\
 [RUNNING] target[/]release[/]deps[/]bar-[..][EXE]")

--- a/tests/build-auth.rs
+++ b/tests/build-auth.rs
@@ -77,9 +77,10 @@ fn http_auth_offered() {
                 println!("username=foo");
                 println!("password=bar");
             }
-        "#);
+        "#)
+        .build();
 
-    assert_that(script.cargo_process("build").arg("-v"),
+    assert_that(script.cargo("build").arg("-v"),
                 execs().with_status(0));
     let script = script.bin("script");
 
@@ -102,9 +103,10 @@ fn http_auth_offered() {
         .file(".cargo/config","\
         [net]
         retry = 0
-        ");
+        ")
+        .build();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(101).with_stderr(&format!("\
 [UPDATING] git repository `http://{addr}/foo/bar`
 [ERROR] failed to load source for a dependency on `bar`
@@ -152,9 +154,10 @@ fn https_something_happens() {
         .file(".cargo/config","\
         [net]
         retry = 0
-        ");
+        ")
+        .build();
 
-    assert_that(p.cargo_process("build").arg("-v"),
+    assert_that(p.cargo("build").arg("-v"),
                 execs().with_status(101).with_stderr_contains(&format!("\
 [UPDATING] git repository `https://{addr}/foo/bar`
 ", addr = addr))
@@ -195,9 +198,10 @@ fn ssh_something_happens() {
             [dependencies.bar]
             git = "ssh://127.0.0.1:{}/foo/bar"
         "#, addr.port()))
-        .file("src/main.rs", "");
+        .file("src/main.rs", "")
+        .build();
 
-    assert_that(p.cargo_process("build").arg("-v"),
+    assert_that(p.cargo("build").arg("-v"),
                 execs().with_status(101).with_stderr_contains(&format!("\
 [UPDATING] git repository `ssh://{addr}/foo/bar`
 ", addr = addr))

--- a/tests/build-lib.rs
+++ b/tests/build-lib.rs
@@ -1,10 +1,10 @@
 extern crate cargotest;
 extern crate hamcrest;
 
-use cargotest::support::{basic_bin_manifest, execs, project, ProjectBuilder};
+use cargotest::support::{basic_bin_manifest, execs, project, Project};
 use hamcrest::{assert_that};
 
-fn verbose_output_for_lib(p: &ProjectBuilder) -> String {
+fn verbose_output_for_lib(p: &Project) -> String {
     format!("\
 [COMPILING] {name} v{version} ({url})
 [RUNNING] `rustc --crate-name {name} src[/]lib.rs --crate-type lib \
@@ -31,9 +31,10 @@ fn build_lib_only() {
         .file("src/main.rs", r#"
             fn main() {}
         "#)
-        .file("src/lib.rs", r#" "#);
+        .file("src/lib.rs", r#" "#)
+        .build();
 
-    assert_that(p.cargo_process("build").arg("--lib").arg("-v"),
+    assert_that(p.cargo("build").arg("--lib").arg("-v"),
                 execs()
                 .with_status(0)
                 .with_stderr(verbose_output_for_lib(&p)));
@@ -46,9 +47,10 @@ fn build_with_no_lib() {
         .file("Cargo.toml", &basic_bin_manifest("foo"))
         .file("src/main.rs", r#"
             fn main() {}
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("build").arg("--lib"),
+    assert_that(p.cargo("build").arg("--lib"),
                 execs().with_status(101)
                        .with_stderr("[ERROR] no library targets found"));
 }
@@ -77,9 +79,10 @@ fn build_with_relative_cargo_home_path() {
             name = "test-dependency"
             version = "0.0.1"
             authors = ["wycats@example.com"]
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("build").env("CARGO_HOME", "./cargo_home/"),
+    assert_that(p.cargo("build").env("CARGO_HOME", "./cargo_home/"),
                 execs()
                 .with_status(0));
 }

--- a/tests/build-script-env.rs
+++ b/tests/build-script-env.rs
@@ -23,8 +23,8 @@ fn rerun_if_env_changes() {
             fn main() {
                 println!("cargo:rerun-if-env-changed=FOO");
             }
-        "#);
-    p.build();
+        "#)
+        .build();
 
     assert_that(p.cargo("build"),
                 execs().with_status(0)
@@ -75,8 +75,8 @@ fn rerun_if_env_or_file_changes() {
                 println!("cargo:rerun-if-changed=foo");
             }
         "#)
-        .file("foo", "");
-    p.build();
+        .file("foo", "")
+        .build();
 
     assert_that(p.cargo("build"),
                 execs().with_status(0)

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -22,9 +22,10 @@ use tempdir::TempDir;
 fn cargo_compile_simple() {
     let p = project("foo")
         .file("Cargo.toml", &basic_bin_manifest("foo"))
-        .file("src/foo.rs", &main_file(r#""i am foo""#, &[]));
+        .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
+        .build();
 
-    assert_that(p.cargo_process("build"), execs().with_status(0));
+    assert_that(p.cargo("build"), execs().with_status(0));
     assert_that(&p.bin("foo"), existing_file());
 
     assert_that(process(&p.bin("foo")),
@@ -35,8 +36,8 @@ fn cargo_compile_simple() {
 fn cargo_fail_with_no_stderr() {
     let p = project("foo")
         .file("Cargo.toml", &basic_bin_manifest("foo"))
-        .file("src/foo.rs", &String::from("refusal"));
-    let p = p.build();
+        .file("src/foo.rs", &String::from("refusal"))
+        .build();
     assert_that(p.cargo("build").arg("--message-format=json"), execs().with_status(101)
         .with_stderr_does_not_contain("--- stderr"));
 }
@@ -51,8 +52,8 @@ fn cargo_compile_incremental() {
 
     let p = project("foo")
         .file("Cargo.toml", &basic_bin_manifest("foo"))
-        .file("src/foo.rs", &main_file(r#""i am foo""#, &[]));
-    p.build();
+        .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
+        .build();
 
     assert_that(
         p.cargo("build").arg("-v").env("CARGO_INCREMENTAL", "1"),
@@ -71,9 +72,10 @@ fn cargo_compile_incremental() {
 fn cargo_compile_manifest_path() {
     let p = project("foo")
         .file("Cargo.toml", &basic_bin_manifest("foo"))
-        .file("src/foo.rs", &main_file(r#""i am foo""#, &[]));
+        .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
+        .build();
 
-    assert_that(p.cargo_process("build")
+    assert_that(p.cargo("build")
                  .arg("--manifest-path").arg("foo/Cargo.toml")
                  .cwd(p.root().parent().unwrap()),
                 execs().with_status(0));
@@ -83,9 +85,10 @@ fn cargo_compile_manifest_path() {
 #[test]
 fn cargo_compile_with_invalid_manifest() {
     let p = project("foo")
-        .file("Cargo.toml", "");
+        .file("Cargo.toml", "")
+        .build();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
         execs()
         .with_status(101)
         .with_stderr("\
@@ -102,9 +105,10 @@ fn cargo_compile_with_invalid_manifest2() {
         .file("Cargo.toml", r"
             [project]
             foo = bar
-        ");
+        ")
+        .build();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
         execs()
         .with_status(101)
         .with_stderr("\
@@ -127,9 +131,10 @@ fn cargo_compile_with_invalid_manifest3() {
             version = "0.0.1"
             authors = []
         "#)
-        .file("src/Cargo.toml", "a = bar");
+        .file("src/Cargo.toml", "a = bar")
+        .build();
 
-    assert_that(p.cargo_process("build").arg("--manifest-path")
+    assert_that(p.cargo("build").arg("--manifest-path")
                  .arg("src/Cargo.toml"),
         execs()
         .with_status(101)
@@ -163,9 +168,10 @@ fn cargo_compile_duplicate_build_targets() {
         .file("src/main.rs", r#"
             #![allow(warnings)]
             fn main() {}
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs()
                 .with_status(0)
                 .with_stderr("\
@@ -183,9 +189,10 @@ fn cargo_compile_with_invalid_version() {
             name = "foo"
             authors = []
             version = "1.0"
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs()
                 .with_status(101)
                 .with_stderr("\
@@ -205,9 +212,10 @@ fn cargo_compile_with_invalid_package_name() {
             name = ""
             authors = []
             version = "0.0.0"
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs()
                 .with_status(101)
                 .with_stderr("\
@@ -229,9 +237,10 @@ fn cargo_compile_with_invalid_bin_target_name() {
 
             [[bin]]
             name = ""
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs()
                 .with_status(101)
                 .with_stderr("\
@@ -253,9 +262,10 @@ fn cargo_compile_with_forbidden_bin_target_name() {
 
             [[bin]]
             name = "build"
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs()
                 .with_status(101)
                 .with_stderr("\
@@ -277,9 +287,10 @@ fn cargo_compile_with_invalid_lib_target_name() {
 
             [lib]
             name = ""
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs()
                 .with_status(101)
                 .with_stderr("\
@@ -293,9 +304,9 @@ Caused by:
 #[test]
 fn cargo_compile_without_manifest() {
     let tmpdir = TempDir::new("cargo").unwrap();
-    let p = ProjectBuilder::new("foo", tmpdir.path().to_path_buf());
+    let p = ProjectBuilder::new("foo", tmpdir.path().to_path_buf()).build();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(101)
                        .with_stderr("\
 [ERROR] could not find `Cargo.toml` in `[..]` or any parent directory
@@ -306,9 +317,10 @@ fn cargo_compile_without_manifest() {
 fn cargo_compile_with_invalid_code() {
     let p = project("foo")
         .file("Cargo.toml", &basic_bin_manifest("foo"))
-        .file("src/foo.rs", "invalid rust code!");
+        .file("src/foo.rs", "invalid rust code!")
+        .build();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
         execs()
         .with_status(101)
         .with_stderr_contains("\
@@ -332,25 +344,27 @@ fn cargo_compile_with_invalid_code_in_deps() {
             [dependencies.baz]
             path = "../baz"
         "#)
-        .file("src/main.rs", "invalid rust code!");
-    let bar = project("bar")
+        .file("src/main.rs", "invalid rust code!")
+        .build();
+    let _bar = project("bar")
         .file("Cargo.toml", &basic_bin_manifest("bar"))
-        .file("src/lib.rs", "invalid rust code!");
-    let baz = project("baz")
+        .file("src/lib.rs", "invalid rust code!")
+        .build();
+    let _baz = project("baz")
         .file("Cargo.toml", &basic_bin_manifest("baz"))
-        .file("src/lib.rs", "invalid rust code!");
-    bar.build();
-    baz.build();
-    assert_that(p.cargo_process("build"), execs().with_status(101));
+        .file("src/lib.rs", "invalid rust code!")
+        .build();
+    assert_that(p.cargo("build"), execs().with_status(101));
 }
 
 #[test]
 fn cargo_compile_with_warnings_in_the_root_package() {
     let p = project("foo")
         .file("Cargo.toml", &basic_bin_manifest("foo"))
-        .file("src/foo.rs", "fn main() {} fn dead() {}");
+        .file("src/foo.rs", "fn main() {} fn dead() {}")
+        .build();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(0).with_stderr_contains("\
 [..]function is never used: `dead`[..]
 "));
@@ -358,9 +372,7 @@ fn cargo_compile_with_warnings_in_the_root_package() {
 
 #[test]
 fn cargo_compile_with_warnings_in_a_dep_package() {
-    let mut p = project("foo");
-
-    p = p
+    let p = project("foo")
         .file("Cargo.toml", r#"
             [project]
 
@@ -394,9 +406,10 @@ fn cargo_compile_with_warnings_in_a_dep_package() {
             }
 
             fn dead() {}
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
         execs().with_status(0).with_stderr_contains("\
 [..]function is never used: `dead`[..]
 "));
@@ -454,9 +467,10 @@ fn cargo_compile_with_nested_deps_inferred() {
             pub fn gimme() -> String {
                 "test passed".to_string()
             }
-        "#);
+        "#)
+        .build();
 
-    p.cargo_process("build")
+    p.cargo("build")
         .exec_with_output()
         .unwrap();
 
@@ -515,9 +529,10 @@ fn cargo_compile_with_nested_deps_correct_bin() {
             pub fn gimme() -> String {
                 "test passed".to_string()
             }
-        "#);
+        "#)
+        .build();
 
-    p.cargo_process("build")
+    p.cargo("build")
         .exec_with_output()
         .unwrap();
 
@@ -581,9 +596,10 @@ fn cargo_compile_with_nested_deps_shorthand() {
             pub fn gimme() -> String {
                 "test passed".to_string()
             }
-        "#);
+        "#)
+        .build();
 
-    p.cargo_process("build")
+    p.cargo("build")
         .exec_with_output()
         .unwrap();
 
@@ -653,9 +669,10 @@ fn cargo_compile_with_nested_deps_longhand() {
             pub fn gimme() -> String {
                 "test passed".to_string()
             }
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("build"), execs());
+    assert_that(p.cargo("build"), execs());
 
     assert_that(&p.bin("foo"), existing_file());
     assert_that(&p.bin("libbar.rlib"), is_not(existing_file()));
@@ -687,9 +704,10 @@ fn cargo_compile_with_dep_name_mismatch() {
         "#)
         .file("src/bin/foo.rs", &main_file(r#""i am foo""#, &["bar"]))
         .file("bar/Cargo.toml", &basic_bin_manifest("bar"))
-        .file("bar/src/bar.rs", &main_file(r#""i am bar""#, &[]));
+        .file("bar/src/bar.rs", &main_file(r#""i am bar""#, &[]))
+        .build();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(101).with_stderr(&format!(
 r#"[ERROR] no matching package named `notquitebar` found (required by `foo`)
 location searched: {proj_dir}/bar
@@ -713,8 +731,8 @@ fn cargo_compile_with_filename() {
         "#)
         .file("examples/a.rs", r#"
             fn main() { println!("example"); }
-        "#);
-    p.build();
+        "#)
+        .build();
 
     assert_that(p.cargo("build").arg("--bin").arg("bin.rs"),
                 execs().with_status(101).with_stderr("\
@@ -756,9 +774,10 @@ fn compile_path_dep_then_change_version() {
             version = "0.0.1"
             authors = []
         "#)
-        .file("bar/src/lib.rs", "");
+        .file("bar/src/lib.rs", "")
+        .build();
 
-    assert_that(p.cargo_process("build"), execs().with_status(0));
+    assert_that(p.cargo("build"), execs().with_status(0));
 
     File::create(&p.root().join("bar/Cargo.toml")).unwrap().write_all(br#"
         [package]
@@ -788,9 +807,10 @@ fn ignores_carriage_return_in_lockfile() {
         .file("src/main.rs", r#"
             mod a; fn main() {}
         "#)
-        .file("src/a.rs", "");
+        .file("src/a.rs", "")
+        .build();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(0));
 
     let lockfile = p.root().join("Cargo.lock");
@@ -827,8 +847,8 @@ fn cargo_default_env_metadata_env_var() {
             name = "bar"
             crate_type = ["dylib"]
         "#)
-        .file("bar/src/lib.rs", "// hello");
-    p.build();
+        .file("bar/src/lib.rs", "// hello")
+        .build();
 
     // No metadata on libbar since it's a dylib path dependency
     assert_that(p.cargo("build").arg("-v"),
@@ -932,10 +952,11 @@ fn crate_env_vars() {
                         env!("CARGO_PKG_VERSION_PRE"),
                         env!("CARGO_MANIFEST_DIR"))
             }
-        "#);
+        "#)
+        .build();
 
     println!("build");
-    assert_that(p.cargo_process("build").arg("-v"), execs().with_status(0));
+    assert_that(p.cargo("build").arg("-v"), execs().with_status(0));
 
     println!("bin");
     assert_that(process(&p.bin("foo")),
@@ -972,10 +993,11 @@ fn crate_authors_env_vars() {
             pub fn authors() -> String {
                 format!("{}", env!("CARGO_PKG_AUTHORS"))
             }
-        "#);
+        "#)
+        .build();
 
     println!("build");
-    assert_that(p.cargo_process("build").arg("-v"), execs().with_status(0));
+    assert_that(p.cargo("build").arg("-v"), execs().with_status(0));
 
     println!("bin");
     assert_that(process(&p.bin("foo")),
@@ -1001,9 +1023,8 @@ fn setenv_for_removing_empty_component(mut p: ProcessBuilder) -> ProcessBuilder 
 // Regression test for #4277
 #[test]
 fn crate_library_path_env_var() {
-    let mut p = project("foo");
-
-    p = p.file("Cargo.toml", r#"
+    let p = project("foo")
+        .file("Cargo.toml", r#"
             [project]
             name = "foo"
             version = "0.0.1"
@@ -1015,9 +1036,10 @@ fn crate_library_path_env_var() {
                 let paths = std::env::split_paths(&search_path).collect::<Vec<_>>();
                 assert!(!paths.contains(&"".into()));
             }}
-        "##, dylib_path_envvar()));
+        "##, dylib_path_envvar()))
+        .build();
 
-    assert_that(setenv_for_removing_empty_component(p.cargo_process("run")),
+    assert_that(setenv_for_removing_empty_component(p.cargo("run")),
                 execs().with_status(0));
 }
 
@@ -1035,17 +1057,17 @@ fn build_with_fake_libc_not_loading() {
             fn main() {}
         "#)
         .file("src/lib.rs", r#" "#)
-        .file("libc.so.6", r#""#);
+        .file("libc.so.6", r#""#)
+        .build();
 
-    assert_that(setenv_for_removing_empty_component(p.cargo_process("build")),
+    assert_that(setenv_for_removing_empty_component(p.cargo("build")),
                 execs().with_status(0));
 }
 
 // this is testing that src/<pkg-name>.rs still works (for now)
 #[test]
 fn many_crate_types_old_style_lib_location() {
-    let mut p = project("foo");
-    p = p
+    let p = project("foo")
         .file("Cargo.toml", r#"
             [project]
 
@@ -1060,8 +1082,9 @@ fn many_crate_types_old_style_lib_location() {
         "#)
         .file("src/foo.rs", r#"
             pub fn foo() {}
-        "#);
-    assert_that(p.cargo_process("build"), execs().with_status(0).with_stderr_contains("\
+        "#)
+        .build();
+    assert_that(p.cargo("build"), execs().with_status(0).with_stderr_contains("\
 [WARNING] path `[..]src[/]foo.rs` was erroneously implicitly accepted for library `foo`,
 please rename the file to `src/lib.rs` or set lib.path in Cargo.toml"));
 
@@ -1073,8 +1096,7 @@ please rename the file to `src/lib.rs` or set lib.path in Cargo.toml"));
 
 #[test]
 fn many_crate_types_correct() {
-    let mut p = project("foo");
-    p = p
+    let p = project("foo")
         .file("Cargo.toml", r#"
             [project]
 
@@ -1089,8 +1111,9 @@ fn many_crate_types_correct() {
         "#)
         .file("src/lib.rs", r#"
             pub fn foo() {}
-        "#);
-    assert_that(p.cargo_process("build"),
+        "#)
+        .build();
+    assert_that(p.cargo("build"),
                 execs().with_status(0));
 
     assert_that(&p.root().join("target/debug/libfoo.rlib"), existing_file());
@@ -1101,8 +1124,7 @@ fn many_crate_types_correct() {
 
 #[test]
 fn self_dependency() {
-    let mut p = project("foo");
-    p = p
+    let p = project("foo")
         .file("Cargo.toml", r#"
             [package]
 
@@ -1118,8 +1140,9 @@ fn self_dependency() {
             name = "test"
             path = "src/test.rs"
         "#)
-        .file("src/test.rs", "fn main() {}");
-    assert_that(p.cargo_process("build"),
+        .file("src/test.rs", "fn main() {}")
+        .build();
+    assert_that(p.cargo("build"),
                 execs().with_status(101)
                        .with_stderr("\
 [ERROR] cyclic package dependency: package `test v0.0.0 ([..])` depends on itself
@@ -1134,9 +1157,10 @@ fn ignore_broken_symlinks() {
     let p = project("foo")
         .file("Cargo.toml", &basic_bin_manifest("foo"))
         .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
-        .symlink("Notafile", "bar");
+        .symlink("Notafile", "bar")
+        .build();
 
-    assert_that(p.cargo_process("build"), execs().with_status(0));
+    assert_that(p.cargo("build"), execs().with_status(0));
     assert_that(&p.bin("foo"), existing_file());
 
     assert_that(process(&p.bin("foo")),
@@ -1145,16 +1169,16 @@ fn ignore_broken_symlinks() {
 
 #[test]
 fn missing_lib_and_bin() {
-    let mut p = project("foo");
-    p = p
+    let p = project("foo")
         .file("Cargo.toml", r#"
             [package]
 
             name = "test"
             version = "0.0.0"
             authors = []
-        "#);
-    assert_that(p.cargo_process("build"),
+        "#)
+        .build();
+    assert_that(p.cargo("build"),
                 execs().with_status(101)
                        .with_stderr("\
 [ERROR] failed to parse manifest at `[..]Cargo.toml`
@@ -1171,8 +1195,7 @@ fn lto_build() {
         return
     }
 
-    let mut p = project("foo");
-    p = p
+    let p = project("foo")
         .file("Cargo.toml", r#"
             [package]
 
@@ -1183,8 +1206,9 @@ fn lto_build() {
             [profile.release]
             lto = true
         "#)
-        .file("src/main.rs", "fn main() {}");
-    assert_that(p.cargo_process("build").arg("-v").arg("--release"),
+        .file("src/main.rs", "fn main() {}")
+        .build();
+    assert_that(p.cargo("build").arg("-v").arg("--release"),
                 execs().with_status(0).with_stderr(&format!("\
 [COMPILING] test v0.0.0 ({url})
 [RUNNING] `rustc --crate-name test src[/]main.rs --crate-type bin \
@@ -1203,8 +1227,7 @@ url = p.url(),
 
 #[test]
 fn verbose_build() {
-    let mut p = project("foo");
-    p = p
+    let p = project("foo")
         .file("Cargo.toml", r#"
             [package]
 
@@ -1212,8 +1235,9 @@ fn verbose_build() {
             version = "0.0.0"
             authors = []
         "#)
-        .file("src/lib.rs", "");
-    assert_that(p.cargo_process("build").arg("-v"),
+        .file("src/lib.rs", "")
+        .build();
+    assert_that(p.cargo("build").arg("-v"),
                 execs().with_status(0).with_stderr(&format!("\
 [COMPILING] test v0.0.0 ({url})
 [RUNNING] `rustc --crate-name test src[/]lib.rs --crate-type lib \
@@ -1230,8 +1254,7 @@ url = p.url(),
 
 #[test]
 fn verbose_release_build() {
-    let mut p = project("foo");
-    p = p
+    let p = project("foo")
         .file("Cargo.toml", r#"
             [package]
 
@@ -1239,8 +1262,9 @@ fn verbose_release_build() {
             version = "0.0.0"
             authors = []
         "#)
-        .file("src/lib.rs", "");
-    assert_that(p.cargo_process("build").arg("-v").arg("--release"),
+        .file("src/lib.rs", "")
+        .build();
+    assert_that(p.cargo("build").arg("-v").arg("--release"),
                 execs().with_status(0).with_stderr(&format!("\
 [COMPILING] test v0.0.0 ({url})
 [RUNNING] `rustc --crate-name test src[/]lib.rs --crate-type lib \
@@ -1258,8 +1282,7 @@ url = p.url(),
 
 #[test]
 fn verbose_release_build_deps() {
-    let mut p = project("foo");
-    p = p
+    let p = project("foo")
         .file("Cargo.toml", r#"
             [package]
 
@@ -1282,8 +1305,9 @@ fn verbose_release_build_deps() {
             name = "foo"
             crate_type = ["dylib", "rlib"]
         "#)
-        .file("foo/src/lib.rs", "");
-    assert_that(p.cargo_process("build").arg("-v").arg("--release"),
+        .file("foo/src/lib.rs", "")
+        .build();
+    assert_that(p.cargo("build").arg("-v").arg("--release"),
                 execs().with_status(0).with_stderr(&format!("\
 [COMPILING] foo v0.0.0 ({url}/foo)
 [RUNNING] `rustc --crate-name foo foo[/]src[/]lib.rs \
@@ -1313,8 +1337,8 @@ fn verbose_release_build_deps() {
 
 #[test]
 fn explicit_examples() {
-    let mut p = project("world");
-    p = p.file("Cargo.toml", r#"
+    let p = project("world")
+        .file("Cargo.toml", r#"
             [package]
             name = "world"
             version = "1.0.0"
@@ -1344,9 +1368,10 @@ fn explicit_examples() {
         .file("examples/ex-goodbye.rs", r#"
             extern crate world;
             fn main() { println!("{}, {}!", world::get_goodbye(), world::get_world()); }
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("test").arg("-v"), execs().with_status(0));
+    assert_that(p.cargo("test").arg("-v"), execs().with_status(0));
     assert_that(process(&p.bin("examples/hello")),
                         execs().with_status(0).with_stdout("Hello, World!\n"));
     assert_that(process(&p.bin("examples/goodbye")),
@@ -1355,8 +1380,8 @@ fn explicit_examples() {
 
 #[test]
 fn non_existing_example() {
-    let mut p = project("world");
-    p = p.file("Cargo.toml", r#"
+    let p = project("world")
+        .file("Cargo.toml", r#"
             [package]
             name = "world"
             version = "1.0.0"
@@ -1370,9 +1395,10 @@ fn non_existing_example() {
             name = "hello"
         "#)
         .file("src/lib.rs", "")
-        .file("examples/ehlo.rs", "");
+        .file("examples/ehlo.rs", "")
+        .build();
 
-    assert_that(p.cargo_process("test").arg("-v"), execs().with_status(101).with_stderr("\
+    assert_that(p.cargo("test").arg("-v"), execs().with_status(101).with_stderr("\
 [ERROR] failed to parse manifest at `[..]`
 
 Caused by:
@@ -1381,8 +1407,8 @@ Caused by:
 
 #[test]
 fn non_existing_binary() {
-    let mut p = project("world");
-    p = p.file("Cargo.toml", r#"
+    let p = project("world")
+        .file("Cargo.toml", r#"
             [package]
             name = "world"
             version = "1.0.0"
@@ -1392,9 +1418,10 @@ fn non_existing_binary() {
             name = "hello"
         "#)
         .file("src/lib.rs", "")
-        .file("src/bin/ehlo.rs", "");
+        .file("src/bin/ehlo.rs", "")
+        .build();
 
-    assert_that(p.cargo_process("build").arg("-v"), execs().with_status(101).with_stderr("\
+    assert_that(p.cargo("build").arg("-v"), execs().with_status(101).with_stderr("\
 [ERROR] failed to parse manifest at `[..]`
 
 Caused by:
@@ -1403,8 +1430,8 @@ Caused by:
 
 #[test]
 fn legacy_binary_paths_warinigs() {
-    let mut p = project("world");
-    p = p.file("Cargo.toml", r#"
+    let p = project("world")
+        .file("Cargo.toml", r#"
             [package]
             name = "foo"
             version = "1.0.0"
@@ -1414,14 +1441,15 @@ fn legacy_binary_paths_warinigs() {
             name = "bar"
         "#)
         .file("src/lib.rs", "")
-        .file("src/main.rs", "fn main() {}");
+        .file("src/main.rs", "fn main() {}")
+        .build();
 
-    assert_that(p.cargo_process("build").arg("-v"), execs().with_status(0).with_stderr_contains("\
+    assert_that(p.cargo("build").arg("-v"), execs().with_status(0).with_stderr_contains("\
 [WARNING] path `[..]src[/]main.rs` was erroneously implicitly accepted for binary `bar`,
 please set bin.path in Cargo.toml"));
 
-    let mut p = project("world");
-    p = p.file("Cargo.toml", r#"
+    let p = project("world")
+        .file("Cargo.toml", r#"
             [package]
             name = "foo"
             version = "1.0.0"
@@ -1431,14 +1459,15 @@ please set bin.path in Cargo.toml"));
             name = "bar"
         "#)
         .file("src/lib.rs", "")
-        .file("src/bin/main.rs", "fn main() {}");
+        .file("src/bin/main.rs", "fn main() {}")
+        .build();
 
-    assert_that(p.cargo_process("build").arg("-v"), execs().with_status(0).with_stderr_contains("\
+    assert_that(p.cargo("build").arg("-v"), execs().with_status(0).with_stderr_contains("\
 [WARNING] path `[..]src[/]bin[/]main.rs` was erroneously implicitly accepted for binary `bar`,
 please set bin.path in Cargo.toml"));
 
-    let mut p = project("world");
-    p = p.file("Cargo.toml", r#"
+    let p = project("world")
+        .file("Cargo.toml", r#"
             [package]
             name = "foo"
             version = "1.0.0"
@@ -1447,17 +1476,18 @@ please set bin.path in Cargo.toml"));
             [[bin]]
             name = "bar"
         "#)
-        .file("src/bar.rs", "fn main() {}");
+        .file("src/bar.rs", "fn main() {}")
+        .build();
 
-    assert_that(p.cargo_process("build").arg("-v"), execs().with_status(0).with_stderr_contains("\
+    assert_that(p.cargo("build").arg("-v"), execs().with_status(0).with_stderr_contains("\
 [WARNING] path `[..]src[/]bar.rs` was erroneously implicitly accepted for binary `bar`,
 please set bin.path in Cargo.toml"));
 }
 
 #[test]
 fn implicit_examples() {
-    let mut p = project("world");
-    p = p.file("Cargo.toml", r#"
+    let p = project("world")
+        .file("Cargo.toml", r#"
             [package]
             name = "world"
             version = "1.0.0"
@@ -1479,9 +1509,10 @@ fn implicit_examples() {
             fn main() {
                 println!("{}, {}!", world::get_goodbye(), world::get_world());
             }
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("test"), execs().with_status(0));
+    assert_that(p.cargo("test"), execs().with_status(0));
     assert_that(process(&p.bin("examples/hello")),
                 execs().with_status(0).with_stdout("Hello, World!\n"));
     assert_that(process(&p.bin("examples/goodbye")),
@@ -1500,9 +1531,10 @@ fn standard_build_no_ndebug() {
                     println!("fast")
                 }
             }
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("build"), execs().with_status(0));
+    assert_that(p.cargo("build"), execs().with_status(0));
     assert_that(process(&p.bin("foo")),
                 execs().with_status(0).with_stdout("slow\n"));
 }
@@ -1519,9 +1551,10 @@ fn release_build_ndebug() {
                     println!("fast")
                 }
             }
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("build").arg("--release"),
+    assert_that(p.cargo("build").arg("--release"),
                 execs().with_status(0));
     assert_that(process(&p.release_bin("foo")),
                 execs().with_status(0).with_stdout("fast\n"));
@@ -1538,9 +1571,10 @@ fn inferred_main_bin() {
         "#)
         .file("src/main.rs", r#"
             fn main() {}
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("build"), execs().with_status(0));
+    assert_that(p.cargo("build"), execs().with_status(0));
     assert_that(process(&p.bin("foo")), execs().with_status(0));
 }
 
@@ -1566,8 +1600,8 @@ fn deletion_causes_failure() {
             version = "0.0.1"
             authors = []
         "#)
-        .file("bar/src/lib.rs", "");
-    p.build();
+        .file("bar/src/lib.rs", "")
+        .build();
 
     assert_that(p.cargo("build"), execs().with_status(0));
     p.change_file("Cargo.toml", r#"
@@ -1591,9 +1625,10 @@ fn bad_cargo_toml_in_target_dir() {
         .file("src/main.rs", r#"
             fn main() {}
         "#)
-        .file("target/Cargo.toml", "bad-toml");
+        .file("target/Cargo.toml", "bad-toml")
+        .build();
 
-    assert_that(p.cargo_process("build"), execs().with_status(0));
+    assert_that(p.cargo("build"), execs().with_status(0));
     assert_that(process(&p.bin("foo")), execs().with_status(0));
 }
 
@@ -1612,9 +1647,10 @@ fn lib_with_standard_name() {
         .file("src/main.rs", "
             extern crate syntax;
             fn main() { syntax::foo() }
-        ");
+        ")
+        .build();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] syntax v0.0.1 ({dir})
@@ -1636,10 +1672,11 @@ fn simple_staticlib() {
               name = "foo"
               crate-type = ["staticlib"]
         "#)
-        .file("src/lib.rs", "pub fn foo() {}");
+        .file("src/lib.rs", "pub fn foo() {}")
+        .build();
 
     // env var is a test for #1381
-    assert_that(p.cargo_process("build").env("RUST_LOG", "nekoneko=trace"),
+    assert_that(p.cargo("build").env("RUST_LOG", "nekoneko=trace"),
                 execs().with_status(0));
 }
 
@@ -1662,9 +1699,10 @@ fn staticlib_rlib_and_bin() {
 
               fn main() {
                   foo::foo();
-              }"#);
+              }"#)
+        .build();
 
-    assert_that(p.cargo_process("build").arg("-v"), execs().with_status(0));
+    assert_that(p.cargo("build").arg("-v"), execs().with_status(0));
 }
 
 #[test]
@@ -1679,8 +1717,9 @@ fn opt_out_of_bin() {
               version = "0.0.1"
         "#)
         .file("src/lib.rs", "")
-        .file("src/main.rs", "bad syntax");
-    assert_that(p.cargo_process("build"), execs().with_status(0));
+        .file("src/main.rs", "bad syntax")
+        .build();
+    assert_that(p.cargo("build"), execs().with_status(0));
 }
 
 #[test]
@@ -1696,8 +1735,9 @@ fn single_lib() {
               name = "foo"
               path = "src/bar.rs"
         "#)
-        .file("src/bar.rs", "");
-    assert_that(p.cargo_process("build"), execs().with_status(0));
+        .file("src/bar.rs", "")
+        .build();
+    assert_that(p.cargo("build"), execs().with_status(0));
 }
 
 #[test]
@@ -1712,8 +1752,8 @@ fn freshness_ignores_excluded() {
             exclude = ["src/b*.rs"]
         "#)
         .file("build.rs", "fn main() {}")
-        .file("src/lib.rs", "pub fn bar() -> i32 { 1 }");
-    foo.build();
+        .file("src/lib.rs", "pub fn bar() -> i32 { 1 }")
+        .build();
     foo.root().move_into_the_past();
 
     assert_that(foo.cargo("build"),
@@ -1761,8 +1801,8 @@ fn rebuild_preserves_out_dir() {
                 }
             }
         "#)
-        .file("src/lib.rs", "pub fn bar() -> i32 { 1 }");
-    foo.build();
+        .file("src/lib.rs", "pub fn bar() -> i32 { 1 }")
+        .build();
     foo.root().move_into_the_past();
 
     assert_that(foo.cargo("build").env("FIRST", "1"),
@@ -1800,8 +1840,9 @@ fn dep_no_libs() {
             version = "0.0.0"
             authors = []
         "#)
-        .file("bar/src/main.rs", "");
-    assert_that(foo.cargo_process("build"),
+        .file("bar/src/main.rs", "")
+        .build();
+    assert_that(foo.cargo("build"),
                 execs().with_status(0));
 }
 
@@ -1818,8 +1859,9 @@ fn recompile_space_in_name() {
             name = "foo"
             path = "src/my lib.rs"
         "#)
-        .file("src/my lib.rs", "");
-    assert_that(foo.cargo_process("build"), execs().with_status(0));
+        .file("src/my lib.rs", "")
+        .build();
+    assert_that(foo.cargo("build"), execs().with_status(0));
     foo.root().move_into_the_past();
     assert_that(foo.cargo("build"),
                 execs().with_status(0).with_stdout(""));
@@ -1836,8 +1878,8 @@ fn ignore_bad_directories() {
             version = "0.0.0"
             authors = []
         "#)
-        .file("src/lib.rs", "");
-    foo.build();
+        .file("src/lib.rs", "")
+        .build();
     let dir = foo.root().join("tmp");
     fs::create_dir(&dir).unwrap();
     let stat = fs::metadata(&dir).unwrap();
@@ -1862,8 +1904,9 @@ fn bad_cargo_config() {
         .file("src/lib.rs", "")
         .file(".cargo/config", r#"
               this is not valid toml
-        "#);
-    assert_that(foo.cargo_process("build").arg("-v"),
+        "#)
+        .build();
+    assert_that(foo.cargo("build").arg("-v"),
                 execs().with_status(101).with_stderr("\
 [ERROR] Couldn't load Cargo configuration
 
@@ -1929,9 +1972,10 @@ fn cargo_platform_specific_dependency() {
             version = "0.5.0"
             authors = ["wycats@example.com"]
         "#)
-        .file("dev/src/lib.rs", "pub fn dev() {}");
+        .file("dev/src/lib.rs", "pub fn dev() {}")
+        .build();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(0));
 
     assert_that(&p.bin("foo"), existing_file());
@@ -1967,9 +2011,10 @@ fn bad_platform_specific_dependency() {
             pub fn gimme() -> String {
                 format!("")
             }
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(101));
 }
 
@@ -1998,9 +2043,10 @@ fn cargo_platform_specific_dependency_wrong_platform() {
         "#)
         .file("bar/src/lib.rs", r#"
             invalid rust file, should not be compiled
-        "#);
+        "#)
+        .build();
 
-    p.cargo_process("build").exec_with_output().unwrap();
+    p.cargo("build").exec_with_output().unwrap();
 
     assert_that(&p.bin("foo"), existing_file());
     assert_that(process(&p.bin("foo")),
@@ -2026,9 +2072,10 @@ fn example_as_lib() {
             crate-type = ["lib"]
         "#)
         .file("src/lib.rs", "")
-        .file("examples/ex.rs", "");
+        .file("examples/ex.rs", "")
+        .build();
 
-    assert_that(p.cargo_process("build").arg("--example=ex"), execs().with_status(0));
+    assert_that(p.cargo("build").arg("--example=ex"), execs().with_status(0));
     assert_that(&p.example_lib("ex", "lib"), existing_file());
 }
 
@@ -2046,9 +2093,10 @@ fn example_as_rlib() {
             crate-type = ["rlib"]
         "#)
         .file("src/lib.rs", "")
-        .file("examples/ex.rs", "");
+        .file("examples/ex.rs", "")
+        .build();
 
-    assert_that(p.cargo_process("build").arg("--example=ex"), execs().with_status(0));
+    assert_that(p.cargo("build").arg("--example=ex"), execs().with_status(0));
     assert_that(&p.example_lib("ex", "rlib"), existing_file());
 }
 
@@ -2066,9 +2114,10 @@ fn example_as_dylib() {
             crate-type = ["dylib"]
         "#)
         .file("src/lib.rs", "")
-        .file("examples/ex.rs", "");
+        .file("examples/ex.rs", "")
+        .build();
 
-    assert_that(p.cargo_process("build").arg("--example=ex"), execs().with_status(0));
+    assert_that(p.cargo("build").arg("--example=ex"), execs().with_status(0));
     assert_that(&p.example_lib("ex", "dylib"), existing_file());
 }
 
@@ -2090,9 +2139,10 @@ fn example_as_proc_macro() {
             crate-type = ["proc-macro"]
         "#)
         .file("src/lib.rs", "")
-        .file("examples/ex.rs", "#![feature(proc_macro)]");
+        .file("examples/ex.rs", "#![feature(proc_macro)]")
+        .build();
 
-    assert_that(p.cargo_process("build").arg("--example=ex"), execs().with_status(0));
+    assert_that(p.cargo("build").arg("--example=ex"), execs().with_status(0));
     assert_that(&p.example_lib("ex", "proc-macro"), existing_file());
 }
 
@@ -2106,9 +2156,10 @@ fn example_bin_same_name() {
             authors = []
         "#)
         .file("src/main.rs", "fn main() {}")
-        .file("examples/foo.rs", "fn main() {}");
+        .file("examples/foo.rs", "fn main() {}")
+        .build();
 
-    p.cargo_process("test").arg("--no-run").arg("-v")
+    p.cargo("test").arg("--no-run").arg("-v")
         .exec_with_output()
         .unwrap();
 
@@ -2134,9 +2185,10 @@ fn compile_then_delete() {
             version = "0.0.1"
             authors = []
         "#)
-        .file("src/main.rs", "fn main() {}");
+        .file("src/main.rs", "fn main() {}")
+        .build();
 
-    assert_that(p.cargo_process("run").arg("-v"), execs().with_status(0));
+    assert_that(p.cargo("run").arg("-v"), execs().with_status(0));
     assert_that(&p.bin("foo"), existing_file());
     if cfg!(windows) {
         // On windows unlinking immediately after running often fails, so sleep
@@ -2176,9 +2228,10 @@ fn transitive_dependencies_not_available() {
             version = "0.0.1"
             authors = []
         "#)
-        .file("b/src/lib.rs", "");
+        .file("b/src/lib.rs", "")
+        .build();
 
-    assert_that(p.cargo_process("build").arg("-v"),
+    assert_that(p.cargo("build").arg("-v"),
                 execs().with_status(101)
                        .with_stderr_contains("\
 [..] can't find crate for `bbbbb`[..]
@@ -2207,9 +2260,10 @@ fn cyclic_deps_rejected() {
             [dependencies.foo]
             path = ".."
         "#)
-        .file("a/src/lib.rs", "");
+        .file("a/src/lib.rs", "")
+        .build();
 
-    assert_that(p.cargo_process("build").arg("-v"),
+    assert_that(p.cargo("build").arg("-v"),
                 execs().with_status(101)
                        .with_stderr("\
 [ERROR] cyclic package dependency: package `a v0.0.1 ([..])` depends on itself
@@ -2229,9 +2283,10 @@ fn predictable_filenames() {
             name = "foo"
             crate-type = ["dylib", "rlib"]
         "#)
-        .file("src/lib.rs", "");
+        .file("src/lib.rs", "")
+        .build();
 
-    assert_that(p.cargo_process("build").arg("-v"),
+    assert_that(p.cargo("build").arg("-v"),
                 execs().with_status(0));
     assert_that(&p.root().join("target/debug/libfoo.rlib"), existing_file());
     let dylib_name = format!("{}foo{}", env::consts::DLL_PREFIX,
@@ -2250,9 +2305,10 @@ fn dashes_to_underscores() {
             authors = []
         "#)
         .file("src/lib.rs", "")
-        .file("src/main.rs", "extern crate foo_bar; fn main() {}");
+        .file("src/main.rs", "extern crate foo_bar; fn main() {}")
+        .build();
 
-    assert_that(p.cargo_process("build").arg("-v"),
+    assert_that(p.cargo("build").arg("-v"),
                 execs().with_status(0));
     assert_that(&p.bin("foo-bar"), existing_file());
 }
@@ -2270,9 +2326,10 @@ fn dashes_in_crate_name_bad() {
             name = "foo-bar"
         "#)
         .file("src/lib.rs", "")
-        .file("src/main.rs", "extern crate foo_bar; fn main() {}");
+        .file("src/main.rs", "extern crate foo_bar; fn main() {}")
+        .build();
 
-    assert_that(p.cargo_process("build").arg("-v"),
+    assert_that(p.cargo("build").arg("-v"),
                 execs().with_status(101));
 }
 
@@ -2285,8 +2342,8 @@ fn rustc_env_var() {
             version = "0.0.1"
             authors = []
         "#)
-        .file("src/lib.rs", "");
-    p.build();
+        .file("src/lib.rs", "")
+        .build();
 
     assert_that(p.cargo("build")
                  .env("RUSTC", "rustc-that-does-not-exist").arg("-v"),
@@ -2313,8 +2370,8 @@ fn filtering() {
         .file("src/bin/a.rs", "fn main() {}")
         .file("src/bin/b.rs", "fn main() {}")
         .file("examples/a.rs", "fn main() {}")
-        .file("examples/b.rs", "fn main() {}");
-    p.build();
+        .file("examples/b.rs", "fn main() {}")
+        .build();
 
     assert_that(p.cargo("build").arg("--lib"),
                 execs().with_status(0));
@@ -2341,8 +2398,8 @@ fn filtering_implicit_bins() {
         .file("src/bin/a.rs", "fn main() {}")
         .file("src/bin/b.rs", "fn main() {}")
         .file("examples/a.rs", "fn main() {}")
-        .file("examples/b.rs", "fn main() {}");
-    p.build();
+        .file("examples/b.rs", "fn main() {}")
+        .build();
 
     assert_that(p.cargo("build").arg("--bins"),
                 execs().with_status(0));
@@ -2365,8 +2422,8 @@ fn filtering_implicit_examples() {
         .file("src/bin/a.rs", "fn main() {}")
         .file("src/bin/b.rs", "fn main() {}")
         .file("examples/a.rs", "fn main() {}")
-        .file("examples/b.rs", "fn main() {}");
-    p.build();
+        .file("examples/b.rs", "fn main() {}")
+        .build();
 
     assert_that(p.cargo("build").arg("--examples"),
                 execs().with_status(0));
@@ -2386,8 +2443,8 @@ fn ignore_dotfile() {
             authors = []
         "#)
         .file("src/bin/.a.rs", "")
-        .file("src/bin/a.rs", "fn main() {}");
-    p.build();
+        .file("src/bin/a.rs", "fn main() {}")
+        .build();
 
     assert_that(p.cargo("build"),
                 execs().with_status(0));
@@ -2404,8 +2461,8 @@ fn ignore_dotdirs() {
         "#)
         .file("src/bin/a.rs", "fn main() {}")
         .file(".git/Cargo.toml", "")
-        .file(".pc/dummy-fix.patch/Cargo.toml", "");
-    p.build();
+        .file(".pc/dummy-fix.patch/Cargo.toml", "")
+        .build();
 
     assert_that(p.cargo("build"),
                 execs().with_status(0));
@@ -2420,8 +2477,8 @@ fn dotdir_root() {
             version = "0.0.1"
             authors = []
         "#)
-        .file("src/bin/a.rs", "fn main() {}");
-    p.build();
+        .file("src/bin/a.rs", "fn main() {}")
+        .build();
     assert_that(p.cargo("build"),
                 execs().with_status(0));
 }
@@ -2436,8 +2493,8 @@ fn custom_target_dir() {
             version = "0.0.1"
             authors = []
         "#)
-        .file("src/main.rs", "fn main() {}");
-    p.build();
+        .file("src/main.rs", "fn main() {}")
+        .build();
 
     let exe_name = format!("foo{}", env::consts::EXE_SUFFIX);
 
@@ -2481,8 +2538,8 @@ fn rustc_no_trans() {
             version = "0.0.1"
             authors = []
         "#)
-        .file("src/main.rs", "fn main() {}");
-    p.build();
+        .file("src/main.rs", "fn main() {}")
+        .build();
 
     assert_that(p.cargo("rustc").arg("-v").arg("--").arg("-Zno-trans"),
                 execs().with_status(0));
@@ -2527,9 +2584,10 @@ fn build_multiple_packages() {
                 name = "d2"
                 doctest = false
         "#)
-        .file("d2/src/main.rs", "fn main() { println!(\"d2\"); }");
+        .file("d2/src/main.rs", "fn main() { println!(\"d2\"); }")
+        .build();
 
-    assert_that(p.cargo_process("build").arg("-p").arg("d1").arg("-p").arg("d2")
+    assert_that(p.cargo("build").arg("-p").arg("d1").arg("-p").arg("d2")
                                         .arg("-p").arg("foo"),
                 execs().with_status(0));
 
@@ -2576,8 +2634,8 @@ fn invalid_spec() {
                 name = "d1"
         "#)
         .file("d1/src/lib.rs", "")
-        .file("d1/src/main.rs", "fn main() { println!(\"d1\"); }");
-    p.build();
+        .file("d1/src/main.rs", "fn main() { println!(\"d1\"); }")
+        .build();
 
     assert_that(p.cargo("build").arg("-p").arg("notAValidDep"),
                 execs().with_status(101).with_stderr("\
@@ -2599,8 +2657,9 @@ fn manifest_with_bom_is_ok() {
             version = \"0.0.1\"
             authors = []
         ")
-        .file("src/lib.rs", "");
-    assert_that(p.cargo_process("build").arg("-v"),
+        .file("src/lib.rs", "")
+        .build();
+    assert_that(p.cargo("build").arg("-v"),
                 execs().with_status(0));
 }
 
@@ -2616,8 +2675,9 @@ fn panic_abort_compiles_with_panic_abort() {
             [profile.dev]
             panic = 'abort'
         "#)
-        .file("src/lib.rs", "");
-    assert_that(p.cargo_process("build").arg("-v"),
+        .file("src/lib.rs", "")
+        .build();
+    assert_that(p.cargo("build").arg("-v"),
                 execs().with_status(0)
                        .with_stderr_contains("[..] -C panic=abort [..]"));
 }
@@ -2632,8 +2692,8 @@ fn explicit_color_config_is_propagated_to_rustc() {
                 version = "0.0.0"
                 authors = []
             "#)
-        .file("src/lib.rs", "");
-    p.build();
+        .file("src/lib.rs", "")
+        .build();
     assert_that(p.cargo("build").arg("-v").arg("--color").arg("always"),
                 execs().with_status(0).with_stderr_contains(
                     "[..]rustc [..] src[/]lib.rs --color always[..]"));
@@ -2669,8 +2729,8 @@ fn compiler_json_error_format() {
             version = "0.5.0"
             authors = ["wycats@example.com"]
         "#)
-        .file("bar/src/lib.rs", r#"fn dead() {}"#);
-    p.build();
+        .file("bar/src/lib.rs", r#"fn dead() {}"#)
+        .build();
 
     assert_that(p.cargo("build").arg("-v")
                     .arg("--message-format").arg("json"),
@@ -2795,9 +2855,10 @@ fn compiler_json_error_format() {
 fn wrong_message_format_option() {
     let p = project("foo")
         .file("Cargo.toml", &basic_bin_manifest("foo"))
-        .file("src/main.rs", "fn main() {}");
+        .file("src/main.rs", "fn main() {}")
+        .build();
 
-    assert_that(p.cargo_process("build").arg("--message-format").arg("XML"),
+    assert_that(p.cargo("build").arg("--message-format").arg("XML"),
                 execs().with_status(1)
                        .with_stderr_contains(
 r#"[ERROR] Could not match 'xml' with any of the allowed variants: ["Human", "Json"]"#));
@@ -2807,9 +2868,10 @@ r#"[ERROR] Could not match 'xml' with any of the allowed variants: ["Human", "Js
 fn message_format_json_forward_stderr() {
     let p = project("foo")
         .file("Cargo.toml", &basic_bin_manifest("foo"))
-        .file("src/main.rs", "fn main() { let unused = 0; }");
+        .file("src/main.rs", "fn main() { let unused = 0; }")
+        .build();
 
-    assert_that(p.cargo_process("rustc").arg("--bin").arg("foo")
+    assert_that(p.cargo("rustc").arg("--bin").arg("foo")
                 .arg("--message-format").arg("JSON"),
                 execs().with_status(0)
                 .with_json(r#"
@@ -2865,8 +2927,9 @@ fn no_warn_about_package_metadata() {
             [package.metadata.another]
             bar = 3
         "#)
-        .file("src/lib.rs", "");
-    assert_that(p.cargo_process("build"),
+        .file("src/lib.rs", "")
+        .build();
+    assert_that(p.cargo("build"),
                 execs().with_status(0)
                        .with_stderr("[..] foo v0.0.1 ([..])\n\
                        [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]\n"));
@@ -2876,9 +2939,10 @@ fn no_warn_about_package_metadata() {
 fn cargo_build_empty_target() {
     let p = project("foo")
         .file("Cargo.toml", &basic_bin_manifest("foo"))
-        .file("src/main.rs", "fn main() {}");
+        .file("src/main.rs", "fn main() {}")
+        .build();
 
-    assert_that(p.cargo_process("build").arg("--target").arg(""),
+    assert_that(p.cargo("build").arg("--target").arg(""),
                 execs().with_status(101)
                 .with_stderr_contains("[..] target was empty"));
 }
@@ -2906,9 +2970,10 @@ fn build_all_workspace() {
         "#)
         .file("bar/src/lib.rs", r#"
             pub fn bar() {}
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("build")
+    assert_that(p.cargo("build")
                  .arg("--all"),
                 execs().with_status(0)
                        .with_stderr("[..] Compiling bar v0.1.0 ([..])\n\
@@ -2947,9 +3012,10 @@ fn build_all_exclude() {
             pub fn baz() {
                 break_the_build();
             }
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("build")
+    assert_that(p.cargo("build")
                  .arg("--all")
                  .arg("--exclude")
                  .arg("baz"),
@@ -2986,9 +3052,10 @@ fn build_all_workspace_implicit_examples() {
         .file("bar/src/bin/e.rs", "fn main() {}")
         .file("bar/src/bin/f.rs", "fn main() {}")
         .file("bar/examples/g.rs", "fn main() {}")
-        .file("bar/examples/h.rs", "fn main() {}");
+        .file("bar/examples/h.rs", "fn main() {}")
+        .build();
 
-    assert_that(p.cargo_process("build")
+    assert_that(p.cargo("build")
                  .arg("--all").arg("--examples"),
                 execs().with_status(0)
                        .with_stderr("[..] Compiling bar v0.1.0 ([..])\n\
@@ -3026,10 +3093,11 @@ fn build_all_virtual_manifest() {
         "#)
         .file("bar/src/lib.rs", r#"
             pub fn bar() {}
-        "#);
+        "#)
+        .build();
 
     // The order in which foo and bar are built is not guaranteed
-    assert_that(p.cargo_process("build")
+    assert_that(p.cargo("build")
                  .arg("--all"),
                 execs().with_status(0)
                        .with_stderr_contains("[..] Compiling bar v0.1.0 ([..])")
@@ -3061,10 +3129,11 @@ fn build_virtual_manifest_all_implied() {
         "#)
         .file("bar/src/lib.rs", r#"
             pub fn bar() {}
-        "#);
+        "#)
+        .build();
 
     // The order in which foo and bar are built is not guaranteed
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(0)
                        .with_stderr_contains("[..] Compiling bar v0.1.0 ([..])")
                        .with_stderr_contains("[..] Compiling foo v0.1.0 ([..])")
@@ -3095,9 +3164,10 @@ fn build_virtual_manifest_one_project() {
         "#)
         .file("bar/src/lib.rs", r#"
             pub fn bar() {}
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("build")
+    assert_that(p.cargo("build")
                  .arg("-p").arg("foo"),
                 execs().with_status(0)
                        .with_stderr_does_not_contain("bar")
@@ -3132,10 +3202,11 @@ fn build_all_virtual_manifest_implicit_examples() {
         .file("bar/src/bin/e.rs", "fn main() {}")
         .file("bar/src/bin/f.rs", "fn main() {}")
         .file("bar/examples/g.rs", "fn main() {}")
-        .file("bar/examples/h.rs", "fn main() {}");
+        .file("bar/examples/h.rs", "fn main() {}")
+        .build();
 
     // The order in which foo and bar are built is not guaranteed
-    assert_that(p.cargo_process("build")
+    assert_that(p.cargo("build")
                  .arg("--all").arg("--examples"),
                 execs().with_status(0)
                        .with_stderr_contains("[..] Compiling bar v0.1.0 ([..])")
@@ -3170,11 +3241,12 @@ fn build_all_member_dependency_same_name() {
         "#)
         .file("a/src/lib.rs", r#"
             pub fn a() {}
-        "#);
+        "#)
+        .build();
 
     Package::new("a", "0.1.0").publish();
 
-    assert_that(p.cargo_process("build")
+    assert_that(p.cargo("build")
                  .arg("--all"),
                 execs().with_status(0)
                        .with_stderr("[..] Updating registry `[..]`\n\
@@ -3206,9 +3278,10 @@ fn run_proper_binary() {
         .file("src/bin/other.rs", r#"
             fn main() {
             }
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("run").arg("--bin").arg("other"),
+    assert_that(p.cargo("run").arg("--bin").arg("other"),
                 execs().with_status(0));
 }
 
@@ -3227,9 +3300,10 @@ fn run_proper_binary_main_rs() {
         .file("src/bin/main.rs", r#"
             fn main() {
             }
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("run").arg("--bin").arg("foo"),
+    assert_that(p.cargo("run").arg("--bin").arg("foo"),
                 execs().with_status(0));
 }
 
@@ -3254,9 +3328,10 @@ fn run_proper_alias_binary_from_src() {
             fn main() {
               println!("bar");
             }
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("build")
+    assert_that(p.cargo("build")
                  .arg("--all"),
                 execs().with_status(0)
                 );
@@ -3283,9 +3358,10 @@ fn run_proper_alias_binary_main_rs() {
             fn main() {
               println!("main");
             }
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("build")
+    assert_that(p.cargo("build")
                  .arg("--all"),
                 execs().with_status(0)
                 );
@@ -3314,9 +3390,10 @@ fn run_proper_binary_main_rs_as_foo() {
         .file("src/main.rs", r#"
             fn main() {
             }
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("run").arg("--bin").arg("foo"),
+    assert_that(p.cargo("run").arg("--bin").arg("foo"),
                 execs().with_status(0));
 }
 
@@ -3327,9 +3404,10 @@ fn rustc_wrapper() {
 
     let p = project("foo")
         .file("Cargo.toml", &basic_bin_manifest("foo"))
-        .file("src/foo.rs", &main_file(r#""i am foo""#, &[]));
+        .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
+        .build();
 
-    assert_that(p.cargo_process("build").arg("-v").env("RUSTC_WRAPPER", "/usr/bin/env"),
+    assert_that(p.cargo("build").arg("-v").env("RUSTC_WRAPPER", "/usr/bin/env"),
                 execs().with_stderr_contains(
                     "[RUNNING] `/usr/bin/env rustc --crate-name foo [..]")
                 .with_status(0));
@@ -3347,9 +3425,10 @@ fn cdylib_not_lifted() {
             [lib]
             crate-type = ["cdylib"]
         "#)
-        .file("src/lib.rs", "");
+        .file("src/lib.rs", "")
+        .build();
 
-    assert_that(p.cargo_process("build"), execs().with_status(0));
+    assert_that(p.cargo("build"), execs().with_status(0));
 
     let files = if cfg!(windows) {
         vec!["foo.dll.lib", "foo.dll.exp", "foo.dll"]
@@ -3378,9 +3457,10 @@ fn cdylib_final_outputs() {
             [lib]
             crate-type = ["cdylib"]
         "#)
-        .file("src/lib.rs", "");
+        .file("src/lib.rs", "")
+        .build();
 
-    assert_that(p.cargo_process("build"), execs().with_status(0));
+    assert_that(p.cargo("build"), execs().with_status(0));
 
     let files = if cfg!(windows) {
         vec!["foo_bar.dll.lib", "foo_bar.dll"]
@@ -3412,8 +3492,8 @@ fn wasm32_final_outputs() {
             authors = []
             version = "0.1.0"
         "#)
-        .file("src/main.rs", "fn main() {}");
-    p.build();
+        .file("src/main.rs", "fn main() {}")
+        .build();
 
     // We can't cross-compile the project to wasm target unless we have emscripten installed.
     // So here we will not run `cargo build`, but just create cargo_rustc::Context and ask it
@@ -3527,9 +3607,10 @@ fn deterministic_cfg_flags() {
             "#)
         .file("src/main.rs", r#"
             fn main() {}
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("build").arg("-v"),
+    assert_that(p.cargo("build").arg("-v"),
                 execs().with_status(0)
                     .with_stderr("\
 [COMPILING] foo v0.1.0 [..]
@@ -3559,9 +3640,10 @@ fn explicit_bins_without_paths() {
         "#)
         .file("src/lib.rs", "")
         .file("src/main.rs", "fn main() {}")
-        .file("src/bin/bar.rs", "fn main() {}");
+        .file("src/bin/bar.rs", "fn main() {}")
+        .build();
 
-    assert_that(p.cargo_process("build"), execs().with_status(0));
+    assert_that(p.cargo("build"), execs().with_status(0));
 }
 
 #[test]
@@ -3577,9 +3659,10 @@ fn no_bin_in_src_with_lib() {
             name = "foo"
         "#)
         .file("src/lib.rs", "")
-        .file("src/foo.rs", "fn main() {}");
+        .file("src/foo.rs", "fn main() {}")
+        .build();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(101)
                        .with_stderr_contains("\
 [ERROR] failed to parse manifest at `[..]`
@@ -3602,9 +3685,10 @@ fn dirs_in_bin_dir_with_main_rs() {
         .file("src/bin/bar.rs", "fn main() {}")
         .file("src/bin/bar2.rs", "fn main() {}")
         .file("src/bin/bar3/main.rs", "fn main() {}")
-        .file("src/bin/bar4/main.rs", "fn main() {}");
+        .file("src/bin/bar4/main.rs", "fn main() {}")
+        .build();
 
-    assert_that(p.cargo_process("build"), execs().with_status(0));
+    assert_that(p.cargo("build"), execs().with_status(0));
     assert_that(&p.bin("foo"), existing_file());
     assert_that(&p.bin("bar"), existing_file());
     assert_that(&p.bin("bar2"), existing_file());
@@ -3624,9 +3708,10 @@ fn dir_and_file_with_same_name_in_bin() {
         "#)
         .file("src/main.rs", "fn main() {}")
         .file("src/bin/foo.rs", "fn main() {}")
-        .file("src/bin/foo/main.rs", "fn main() {}");
+        .file("src/bin/foo/main.rs", "fn main() {}")
+        .build();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(101)
                        .with_stderr_contains("\
 [..]found duplicate binary name foo, but all binary targets must have a unique name[..]
@@ -3646,9 +3731,10 @@ fn inferred_path_in_src_bin_foo() {
         name = "bar"
         # Note, no `path` key!
         "#)
-        .file("src/bin/bar/main.rs", "fn main() {}");
+        .file("src/bin/bar/main.rs", "fn main() {}")
+        .build();
 
-    assert_that(p.cargo_process("build"), execs().with_status(0));
+    assert_that(p.cargo("build"), execs().with_status(0));
     assert_that(&p.bin("bar"), existing_file());
 }
 
@@ -3663,9 +3749,10 @@ fn inferred_examples() {
         "#)
         .file("src/lib.rs", "fn main() {}")
         .file("examples/bar.rs", "fn main() {}")
-        .file("examples/baz/main.rs", "fn main() {}");
+        .file("examples/baz/main.rs", "fn main() {}")
+        .build();
 
-    assert_that(p.cargo_process("test"), execs().with_status(0));
+    assert_that(p.cargo("test"), execs().with_status(0));
     assert_that(&p.bin("examples/bar"), existing_file());
     assert_that(&p.bin("examples/baz"), existing_file());
 }
@@ -3681,10 +3768,11 @@ fn inferred_tests() {
         "#)
         .file("src/lib.rs", "fn main() {}")
         .file("tests/bar.rs", "fn main() {}")
-        .file("tests/baz/main.rs", "fn main() {}");
+        .file("tests/baz/main.rs", "fn main() {}")
+        .build();
 
     assert_that(
-        p.cargo_process("test").arg("--test=bar").arg("--test=baz"),
+        p.cargo("test").arg("--test=bar").arg("--test=baz"),
         execs().with_status(0));
 }
 
@@ -3698,10 +3786,11 @@ fn inferred_benchmark() {
             authors = []
         "#)
         .file("src/lib.rs", "fn main() {}")
-        .file("benches/bar.rs", "fn main() {}");
+        .file("benches/bar.rs", "fn main() {}")
+        .build();
 
     assert_that(
-        p.cargo_process("bench").arg("--bench=bar"),
+        p.cargo("bench").arg("--bench=bar"),
         execs().with_status(0));
 }
 
@@ -3716,10 +3805,11 @@ fn inferred_benchmark_from_directory() {
             authors = []
         "#)
         .file("src/lib.rs", "fn main() {}")
-        .file("benches/bar/main.rs", "fn main() {}");
+        .file("benches/bar/main.rs", "fn main() {}")
+        .build();
 
     assert_that(
-        p.cargo_process("bench").arg("--bench=bar"),
+        p.cargo("bench").arg("--bench=bar"),
         execs().with_status(0));
 }
 
@@ -3729,9 +3819,10 @@ fn same_metadata_different_directory() {
     // same metadata hash.
     let p = project("foo1")
         .file("Cargo.toml", &basic_bin_manifest("foo"))
-        .file("src/foo.rs", &main_file(r#""i am foo""#, &[]));
+        .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
+        .build();
     let output = t!(String::from_utf8(
-        t!(p.cargo_process("build").arg("-v").exec_with_output())
+        t!(p.cargo("build").arg("-v").exec_with_output())
             .stderr,
     ));
     let metadata = output
@@ -3741,10 +3832,11 @@ fn same_metadata_different_directory() {
 
     let p = project("foo2")
         .file("Cargo.toml", &basic_bin_manifest("foo"))
-        .file("src/foo.rs", &main_file(r#""i am foo""#, &[]));
+        .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
+        .build();
 
     assert_that(
-        p.cargo_process("build").arg("-v"),
+        p.cargo("build").arg("-v"),
         execs().with_status(0).with_stderr_contains(
             format!("[..]{}[..]", metadata),
         ),
@@ -3774,8 +3866,8 @@ fn building_a_dependent_crate_witout_bin_should_fail() {
             [dependencies]
             testless = "0.1.0"
         "#)
-        .file("src/lib.rs", "");
-    p.build();
+        .file("src/lib.rs", "")
+        .build();
 
     assert_that(p.cargo("build"),
                 execs().with_status(101).with_stderr_contains(

--- a/tests/cargo-features.rs
+++ b/tests/cargo-features.rs
@@ -15,8 +15,9 @@ fn feature_required() {
             authors = []
             im-a-teapot = true
         "#)
-        .file("src/lib.rs", "");
-    assert_that(p.cargo_process("build")
+        .file("src/lib.rs", "")
+        .build();
+    assert_that(p.cargo("build")
                  .masquerade_as_nightly_cargo(),
                 execs().with_status(101)
                        .with_stderr("\
@@ -59,8 +60,9 @@ fn unknown_feature() {
             version = "0.0.1"
             authors = []
         "#)
-        .file("src/lib.rs", "");
-    assert_that(p.cargo_process("build"),
+        .file("src/lib.rs", "")
+        .build();
+    assert_that(p.cargo("build"),
                 execs().with_status(101)
                        .with_stderr("\
 error: failed to parse manifest at `[..]`
@@ -81,8 +83,9 @@ fn stable_feature_warns() {
             version = "0.0.1"
             authors = []
         "#)
-        .file("src/lib.rs", "");
-    assert_that(p.cargo_process("build"),
+        .file("src/lib.rs", "")
+        .build();
+    assert_that(p.cargo("build"),
                 execs().with_status(0)
                        .with_stderr("\
 warning: the cargo feature `test-dummy-stable` is now stable and is no longer \
@@ -104,8 +107,9 @@ fn nightly_feature_requires_nightly() {
             authors = []
             im-a-teapot = true
         "#)
-        .file("src/lib.rs", "");
-    assert_that(p.cargo_process("build")
+        .file("src/lib.rs", "")
+        .build();
+    assert_that(p.cargo("build")
                  .masquerade_as_nightly_cargo(),
                 execs().with_status(0)
                        .with_stderr("\
@@ -146,8 +150,9 @@ fn nightly_feature_requires_nightly_in_dep() {
             authors = []
             im-a-teapot = true
         "#)
-        .file("a/src/lib.rs", "");
-    assert_that(p.cargo_process("build")
+        .file("a/src/lib.rs", "")
+        .build();
+    assert_that(p.cargo("build")
                  .masquerade_as_nightly_cargo(),
                 execs().with_status(0)
                        .with_stderr("\
@@ -185,8 +190,9 @@ fn cant_publish() {
             authors = []
             im-a-teapot = true
         "#)
-        .file("src/lib.rs", "");
-    assert_that(p.cargo_process("build")
+        .file("src/lib.rs", "")
+        .build();
+    assert_that(p.cargo("build")
                  .masquerade_as_nightly_cargo(),
                 execs().with_status(0)
                        .with_stderr("\
@@ -217,8 +223,9 @@ fn z_flags_rejected() {
             authors = []
             im-a-teapot = true
         "#)
-        .file("src/lib.rs", "");
-    assert_that(p.cargo_process("build")
+        .file("src/lib.rs", "")
+        .build();
+    assert_that(p.cargo("build")
                  .arg("-Zprint-im-a-teapot"),
                 execs().with_status(101)
                        .with_stderr("\
@@ -255,8 +262,9 @@ fn publish_rejected() {
             version = "0.0.1"
             authors = []
         "#)
-        .file("src/lib.rs", "");
-    assert_that(p.cargo_process("package")
+        .file("src/lib.rs", "")
+        .build();
+    assert_that(p.cargo("package")
                  .masquerade_as_nightly_cargo(),
                 execs().with_status(101)
                        .with_stderr("\

--- a/tests/cargo.rs
+++ b/tests/cargo.rs
@@ -10,7 +10,7 @@ use std::str;
 
 use cargotest::cargo_process;
 use cargotest::support::paths::{self, CargoPathExt};
-use cargotest::support::{execs, project, ProjectBuilder, basic_bin_manifest};
+use cargotest::support::{execs, project, Project, basic_bin_manifest};
 use hamcrest::{assert_that, existing_file};
 
 #[cfg_attr(windows,allow(dead_code))]
@@ -20,8 +20,8 @@ enum FakeKind<'a> {
 }
 
 /// Add an empty file with executable flags (and platform-dependent suffix).
-/// TODO: move this to `ProjectBuilder` if other cases using this emerge.
-fn fake_file(proj: ProjectBuilder, dir: &Path, name: &str, kind: &FakeKind) -> ProjectBuilder {
+/// TODO: move this to `Project` if other cases using this emerge.
+fn fake_file(proj: Project, dir: &Path, name: &str, kind: &FakeKind) -> Project {
     let path = proj.root().join(dir).join(&format!("{}{}", name,
                                                    env::consts::EXE_SUFFIX));
     path.parent().unwrap().mkdir_p();
@@ -63,7 +63,7 @@ fn path() -> Vec<PathBuf> {
 
 #[test]
 fn list_command_looks_at_path() {
-    let proj = project("list-non-overlapping");
+    let proj = project("list-non-overlapping").build();
     let proj = fake_file(proj, Path::new("path-test"), "cargo-1", &FakeKind::Executable);
     let mut pr = cargo_process();
 
@@ -83,7 +83,7 @@ fn list_command_looks_at_path() {
 fn list_command_resolves_symlinks() {
     use cargotest::support::cargo_exe;
 
-    let proj = project("list-non-overlapping");
+    let proj = project("list-non-overlapping").build();
     let proj = fake_file(proj, Path::new("path-test"), "cargo-2",
                          &FakeKind::Symlink{target:&cargo_exe()});
     let mut pr = cargo_process();
@@ -175,11 +175,12 @@ fn cargo_subcommand_env() {
 
     let p = project("cargo-envtest")
         .file("Cargo.toml", &basic_bin_manifest("cargo-envtest"))
-        .file("src/main.rs", &src);
+        .file("src/main.rs", &src)
+        .build();
 
     let target_dir = p.target_debug_dir();
 
-    assert_that(p.cargo_process("build"), execs().with_status(0));
+    assert_that(p.cargo("build"), execs().with_status(0));
     assert_that(&p.bin("cargo-envtest"), existing_file());
 
     let mut pr = cargo_process();

--- a/tests/cargo_alias_config.rs
+++ b/tests/cargo_alias_config.rs
@@ -13,9 +13,10 @@ fn alias_incorrect_config_type() {
         .file(".cargo/config",r#"
             [alias]
             b-cargo-test = 5
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("b-cargo-test").arg("-v"),
+    assert_that(p.cargo("b-cargo-test").arg("-v"),
                 execs().with_status(101).
                 with_stderr_contains("[ERROR] invalid configuration \
 for key `alias.b-cargo-test`
@@ -33,9 +34,10 @@ fn alias_default_config_overrides_config() {
         .file(".cargo/config",r#"
             [alias]
             b = "not_build"
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("b").arg("-v"),
+    assert_that(p.cargo("b").arg("-v"),
                 execs().with_status(0).
                 with_stderr_contains("[COMPILING] foo v0.5.0 [..]"));
 }
@@ -50,9 +52,10 @@ fn alias_config() {
         .file(".cargo/config",r#"
             [alias]
             b-cargo-test = "build"
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("b-cargo-test").arg("-v"),
+    assert_that(p.cargo("b-cargo-test").arg("-v"),
                 execs().with_status(0).
                 with_stderr_contains("[COMPILING] foo v0.5.0 [..]
 [RUNNING] `rustc --crate-name foo [..]"));
@@ -68,9 +71,10 @@ fn alias_list_test() {
         .file(".cargo/config",r#"
             [alias]
             b-cargo-test = ["build", "--release"]
-         "#);
+         "#)
+        .build();
 
-    assert_that(p.cargo_process("b-cargo-test").arg("-v"),
+    assert_that(p.cargo("b-cargo-test").arg("-v"),
                 execs().with_status(0).
                 with_stderr_contains("[COMPILING] foo v0.5.0 [..]").
                 with_stderr_contains("[RUNNING] `rustc --crate-name [..]")
@@ -87,9 +91,10 @@ fn alias_with_flags_config() {
         .file(".cargo/config",r#"
             [alias]
             b-cargo-test = "build --release"
-         "#);
+         "#)
+        .build();
 
-    assert_that(p.cargo_process("b-cargo-test").arg("-v"),
+    assert_that(p.cargo("b-cargo-test").arg("-v"),
                 execs().with_status(0).
                 with_stderr_contains("[COMPILING] foo v0.5.0 [..]").
                 with_stderr_contains("[RUNNING] `rustc --crate-name foo [..]")
@@ -106,9 +111,10 @@ fn cant_shadow_builtin() {
         .file(".cargo/config",r#"
             [alias]
             build = "fetch"
-         "#);
+         "#)
+        .build();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(0)
                        .with_stderr("\
 [COMPILING] foo v0.5.0 ([..])

--- a/tests/cargotest/support/cross_compile.rs
+++ b/tests/cargotest/support/cross_compile.rs
@@ -32,9 +32,10 @@ pub fn disabled() -> bool {
     CHECK.call_once(|| {
         let p = project("cross_test")
             .file("Cargo.toml", &basic_bin_manifest("cross_test"))
-            .file("src/cross_test.rs", &main_file(r#""testing!""#, &[]));
+            .file("src/cross_test.rs", &main_file(r#""testing!""#, &[]))
+            .build();
 
-        let result = p.cargo_process("build")
+        let result = p.cargo("build")
             .arg("--target").arg(&cross_target)
             .exec_with_output();
 

--- a/tests/cargotest/support/publish.rs
+++ b/tests/cargotest/support/publish.rs
@@ -3,11 +3,11 @@ use std::io::prelude::*;
 use std::fs::{self, File};
 
 use support::paths;
-use support::git::repo;
+use support::git::{repo, Repository};
 
 use url::Url;
 
-pub fn setup() {
+pub fn setup() -> Repository {
     let config = paths::root().join(".cargo/config");
     t!(fs::create_dir_all(config.parent().unwrap()));
     t!(t!(File::create(&config)).write_all(br#"
@@ -21,7 +21,7 @@ pub fn setup() {
             "dl": "{0}",
             "api": "{0}"
         }}"#, upload()))
-        .build();
+        .build()
 }
 
 fn registry_path() -> PathBuf { paths::root().join("registry") }

--- a/tests/cargotest/support/registry.rs
+++ b/tests/cargotest/support/registry.rs
@@ -57,7 +57,7 @@ pub fn init() {
     "#, reg = registry()).as_bytes()));
 
     // Init a new registry
-    repo(&registry_path())
+    let _ = repo(&registry_path())
         .file("config.json", &format!(r#"
             {{"dl":"{0}","api":"{0}"}}
         "#, dl_url()))

--- a/tests/cfg.rs
+++ b/tests/cfg.rs
@@ -157,8 +157,9 @@ fn cfg_easy() {
             version = "0.0.1"
             authors = []
         "#)
-        .file("b/src/lib.rs", "");
-    assert_that(p.cargo_process("build").arg("-v"),
+        .file("b/src/lib.rs", "")
+        .build();
+    assert_that(p.cargo("build").arg("-v"),
                 execs().with_status(0));
 }
 
@@ -182,8 +183,9 @@ fn dont_include() {
             version = "0.0.1"
             authors = []
         "#)
-        .file("b/src/lib.rs", "");
-    assert_that(p.cargo_process("build"),
+        .file("b/src/lib.rs", "")
+        .build();
+    assert_that(p.cargo("build"),
                 execs().with_status(0).with_stderr("\
 [COMPILING] a v0.0.1 ([..])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
@@ -208,9 +210,10 @@ fn works_through_the_registry() {
             [dependencies]
             bar = "0.1.0"
         "#)
-        .file("src/lib.rs", "#[allow(unused_extern_crates)] extern crate bar;");
+        .file("src/lib.rs", "#[allow(unused_extern_crates)] extern crate bar;")
+        .build();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(0).with_stderr("\
 [UPDATING] registry [..]
 [DOWNLOADING] [..]
@@ -242,9 +245,10 @@ fn ignore_version_from_other_platform() {
             [target.'cfg({})'.dependencies]
             foo = "0.2.0"
         "#, this_family, other_family))
-        .file("src/lib.rs", "#[allow(unused_extern_crates)] extern crate foo;");
+        .file("src/lib.rs", "#[allow(unused_extern_crates)] extern crate foo;")
+        .build();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(0).with_stderr("\
 [UPDATING] registry [..]
 [DOWNLOADING] [..]
@@ -266,9 +270,10 @@ fn bad_target_spec() {
             [target.'cfg(4)'.dependencies]
             bar = "0.1.0"
         "#)
-        .file("src/lib.rs", "");
+        .file("src/lib.rs", "")
+        .build();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(101).with_stderr("\
 [ERROR] failed to parse manifest at `[..]`
 
@@ -292,9 +297,10 @@ fn bad_target_spec2() {
             [target.'cfg(foo =)'.dependencies]
             bar = "0.1.0"
         "#)
-        .file("src/lib.rs", "");
+        .file("src/lib.rs", "")
+        .build();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(101).with_stderr("\
 [ERROR] failed to parse manifest at `[..]`
 
@@ -336,8 +342,9 @@ fn multiple_match_ok() {
             version = "0.0.1"
             authors = []
         "#)
-        .file("b/src/lib.rs", "");
-    assert_that(p.cargo_process("build").arg("-v"),
+        .file("b/src/lib.rs", "")
+        .build();
+    assert_that(p.cargo("build").arg("-v"),
                 execs().with_status(0));
 }
 
@@ -360,7 +367,8 @@ fn any_ok() {
             version = "0.0.1"
             authors = []
         "#)
-        .file("b/src/lib.rs", "");
-    assert_that(p.cargo_process("build").arg("-v"),
+        .file("b/src/lib.rs", "")
+        .build();
+    assert_that(p.cargo("build").arg("-v"),
                 execs().with_status(0));
 }

--- a/tests/check.rs
+++ b/tests/check.rs
@@ -23,8 +23,9 @@ fn check_success() {
             fn main() {
                 ::bar::baz();
             }
-        "#);
-    let bar = project("bar")
+        "#)
+        .build();
+    let _bar = project("bar")
         .file("Cargo.toml", r#"
             [package]
             name = "bar"
@@ -33,10 +34,10 @@ fn check_success() {
         "#)
         .file("src/lib.rs", r#"
             pub fn baz() {}
-        "#);
-    bar.build();
+        "#)
+        .build();
 
-    assert_that(foo.cargo_process("check"),
+    assert_that(foo.cargo("check"),
                 execs().with_status(0));
 }
 
@@ -57,8 +58,9 @@ fn check_fail() {
             fn main() {
                 ::bar::baz(42);
             }
-        "#);
-    let bar = project("bar")
+        "#)
+        .build();
+    let _bar = project("bar")
         .file("Cargo.toml", r#"
             [package]
             name = "bar"
@@ -67,10 +69,10 @@ fn check_fail() {
         "#)
         .file("src/lib.rs", r#"
             pub fn baz() {}
-        "#);
-    bar.build();
+        "#)
+        .build();
 
-    assert_that(foo.cargo_process("check"),
+    assert_that(foo.cargo("check"),
                 execs().with_status(101));
 }
 
@@ -106,8 +108,9 @@ fn main() {
     let a = A;
     a.b();
 }
-"#);
-    let bar = project("bar")
+"#)
+        .build();
+    let _bar = project("bar")
         .file("Cargo.toml", r#"
             [package]
             name = "bar"
@@ -128,10 +131,10 @@ use proc_macro::TokenStream;
 pub fn derive(_input: TokenStream) -> TokenStream {
     format!("impl B for A {{ fn b(&self) {{}} }}").parse().unwrap()
 }
-"#);
-    bar.build();
+"#)
+        .build();
 
-    assert_that(foo.cargo_process("check"),
+    assert_that(foo.cargo("check"),
                 execs().with_status(0));
 }
 
@@ -152,10 +155,10 @@ fn check_build() {
             fn main() {
                 ::bar::baz();
             }
-        "#);
-    foo.build();
+        "#)
+        .build();
 
-    let bar = project("bar")
+    let _bar = project("bar")
         .file("Cargo.toml", r#"
             [package]
             name = "bar"
@@ -164,8 +167,8 @@ fn check_build() {
         "#)
         .file("src/lib.rs", r#"
             pub fn baz() {}
-        "#);
-    bar.build();
+        "#)
+        .build();
 
     assert_that(foo.cargo("check"),
                 execs().with_status(0));
@@ -190,10 +193,10 @@ fn build_check() {
             fn main() {
                 ::bar::baz();
             }
-        "#);
-    foo.build();
+        "#)
+        .build();
 
-    let bar = project("bar")
+    let _bar = project("bar")
         .file("Cargo.toml", r#"
             [package]
             name = "bar"
@@ -202,8 +205,8 @@ fn build_check() {
         "#)
         .file("src/lib.rs", r#"
             pub fn baz() {}
-        "#);
-    bar.build();
+        "#)
+        .build();
 
     assert_that(foo.cargo("build"),
                 execs().with_status(0));
@@ -225,9 +228,10 @@ fn issue_3418() {
             [dependencies]
         "#)
         .file("src/lib.rs", "")
-        .file("src/main.rs", "fn main() {}");
+        .file("src/main.rs", "fn main() {}")
+        .build();
 
-    assert_that(foo.cargo_process("check").arg("-v"),
+    assert_that(foo.cargo("check").arg("-v"),
                 execs().with_status(0)
                        .with_stderr_contains("[..] --emit=dep-info,metadata [..]"));
 }
@@ -236,7 +240,7 @@ fn issue_3418() {
 // checked, but in this case with a proc macro too.
 #[test]
 fn issue_3419() {
-    let foo = project("foo")
+    let p = project("foo")
         .file("Cargo.toml", r#"
             [package]
             name = "foo"
@@ -264,7 +268,8 @@ fn issue_3419() {
             fn main() {
                 foo::take::<Foo>();
             }
-        "#);
+        "#)
+        .build();
 
     Package::new("rustc-serialize", "1.0.0")
         .file("src/lib.rs",
@@ -278,7 +283,7 @@ fn issue_3419() {
                     where F: FnOnce(&mut Self) -> Result<T, Self::Error>;
                  } "#).publish();
 
-    assert_that(foo.cargo_process("check"),
+    assert_that(p.cargo("check"),
                 execs().with_status(0));
 }
 
@@ -300,8 +305,9 @@ fn rustc_check() {
             fn main() {
                 ::bar::baz();
             }
-        "#);
-    let bar = project("bar")
+        "#)
+        .build();
+    let _bar = project("bar")
         .file("Cargo.toml", r#"
             [package]
             name = "bar"
@@ -310,10 +316,10 @@ fn rustc_check() {
         "#)
         .file("src/lib.rs", r#"
             pub fn baz() {}
-        "#);
-    bar.build();
+        "#)
+        .build();
 
-    assert_that(foo.cargo_process("rustc")
+    assert_that(foo.cargo("rustc")
                    .arg("--profile")
                    .arg("check")
                    .arg("--")
@@ -338,8 +344,9 @@ fn rustc_check_err() {
             fn main() {
                 ::bar::qux();
             }
-        "#);
-    let bar = project("bar")
+        "#)
+        .build();
+    let _bar = project("bar")
         .file("Cargo.toml", r#"
             [package]
             name = "bar"
@@ -348,10 +355,10 @@ fn rustc_check_err() {
         "#)
         .file("src/lib.rs", r#"
             pub fn baz() {}
-        "#);
-    bar.build();
+        "#)
+        .build();
 
-    assert_that(foo.cargo_process("rustc")
+    assert_that(foo.cargo("rustc")
                    .arg("--profile")
                    .arg("check")
                    .arg("--")
@@ -361,7 +368,7 @@ fn rustc_check_err() {
 
 #[test]
 fn check_all() {
-    let foo = project("foo")
+    let p = project("foo")
         .file("Cargo.toml", r#"
             [package]
             name = "foo"
@@ -383,9 +390,10 @@ fn check_all() {
             authors = []
         "#)
         .file("b/src/main.rs", "fn main() {}")
-        .file("b/src/lib.rs", "");
+        .file("b/src/lib.rs", "")
+        .build();
 
-    assert_that(foo.cargo_process("check").arg("--all").arg("-v"),
+    assert_that(p.cargo("check").arg("--all").arg("-v"),
                 execs().with_status(0)
         .with_stderr_contains("[..] --crate-name foo src[/]lib.rs [..]")
         .with_stderr_contains("[..] --crate-name foo src[/]main.rs [..]")
@@ -416,9 +424,10 @@ fn check_virtual_all_implied() {
         "#)
         .file("bar/src/lib.rs", r#"
             pub fn bar() {}
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("check").arg("-v"),
+    assert_that(p.cargo("check").arg("-v"),
                 execs().with_status(0)
         .with_stderr_contains("[..] --crate-name foo foo[/]src[/]lib.rs [..]")
         .with_stderr_contains("[..] --crate-name bar bar[/]src[/]lib.rs [..]")
@@ -439,9 +448,9 @@ fn check_all_targets() {
         .file("examples/example1.rs", "fn main() {}")
         .file("tests/test2.rs", "#[test] fn t() {}")
         .file("benches/bench3.rs", "")
-    ;
+        .build();
 
-    assert_that(foo.cargo_process("check").arg("--all-targets").arg("-v"),
+    assert_that(foo.cargo("check").arg("--all-targets").arg("-v"),
                 execs().with_status(0)
         .with_stderr_contains("[..] --crate-name foo src[/]lib.rs [..]")
         .with_stderr_contains("[..] --crate-name foo src[/]main.rs [..]")

--- a/tests/clean.rs
+++ b/tests/clean.rs
@@ -10,10 +10,11 @@ use hamcrest::{assert_that, existing_dir, existing_file, is_not};
 #[test]
 fn cargo_clean_simple() {
     let p = project("foo")
-              .file("Cargo.toml", &basic_bin_manifest("foo"))
-              .file("src/foo.rs", &main_file(r#""i am foo""#, &[]));
+        .file("Cargo.toml", &basic_bin_manifest("foo"))
+        .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
+        .build();
 
-    assert_that(p.cargo_process("build"), execs().with_status(0));
+    assert_that(p.cargo("build"), execs().with_status(0));
     assert_that(&p.build_dir(), existing_dir());
 
     assert_that(p.cargo("clean"),
@@ -24,11 +25,12 @@ fn cargo_clean_simple() {
 #[test]
 fn different_dir() {
     let p = project("foo")
-              .file("Cargo.toml", &basic_bin_manifest("foo"))
-              .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
-              .file("src/bar/a.rs", "");
+        .file("Cargo.toml", &basic_bin_manifest("foo"))
+        .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
+        .file("src/bar/a.rs", "")
+        .build();
 
-    assert_that(p.cargo_process("build"), execs().with_status(0));
+    assert_that(p.cargo("build"), execs().with_status(0));
     assert_that(&p.build_dir(), existing_dir());
 
     assert_that(p.cargo("clean").cwd(&p.root().join("src")),
@@ -73,9 +75,10 @@ fn clean_multiple_packages() {
             [[bin]]
                 name = "d2"
         "#)
-        .file("d2/src/main.rs", "fn main() { println!(\"d2\"); }");
+        .file("d2/src/main.rs", "fn main() { println!(\"d2\"); }")
+        .build();
 
-    assert_that(p.cargo_process("build").arg("-p").arg("d1").arg("-p").arg("d2")
+    assert_that(p.cargo("build").arg("-p").arg("d1").arg("-p").arg("d2")
                                         .arg("-p").arg("foo"),
                 execs().with_status(0));
 
@@ -116,8 +119,8 @@ fn clean_release() {
             version = "0.0.1"
             authors = []
         "#)
-        .file("a/src/lib.rs", "");
-    p.build();
+        .file("a/src/lib.rs", "")
+        .build();
 
     assert_that(p.cargo("build").arg("--release"),
                 execs().with_status(0));
@@ -160,8 +163,8 @@ fn build_script() {
                 }
             }
         "#)
-        .file("a/src/lib.rs", "");
-    p.build();
+        .file("a/src/lib.rs", "")
+        .build();
 
     assert_that(p.cargo("build").env("FIRST", "1"),
                 execs().with_status(0));
@@ -199,8 +202,8 @@ fn clean_git() {
             [dependencies]
             dep = {{ git = '{}' }}
         "#, git.url()))
-        .file("src/main.rs", "fn main() {}");
-    p.build();
+        .file("src/main.rs", "fn main() {}")
+        .build();
 
     assert_that(p.cargo("build"),
                 execs().with_status(0));
@@ -222,8 +225,8 @@ fn registry() {
             [dependencies]
             bar = "0.1"
         "#)
-        .file("src/main.rs", "fn main() {}");
-    p.build();
+        .file("src/main.rs", "fn main() {}")
+        .build();
 
     Package::new("bar", "0.1.0").publish();
 

--- a/tests/concurrent.rs
+++ b/tests/concurrent.rs
@@ -40,7 +40,7 @@ fn multiple_installs() {
             version = "0.0.0"
         "#)
         .file("b/src/main.rs", "fn main() {}");
-    p.build();
+    let p = p.build();
 
     let mut a = p.cargo("install").cwd(p.root().join("a")).build_command();
     let mut b = p.cargo("install").cwd(p.root().join("b")).build_command();
@@ -107,7 +107,7 @@ fn one_install_should_be_bad() {
             version = "0.0.0"
         "#)
         .file("b/src/main.rs", "fn main() {}");
-    p.build();
+    let p = p.build();
 
     let mut a = p.cargo("install").cwd(p.root().join("a")).build_command();
     let mut b = p.cargo("install").cwd(p.root().join("b")).build_command();
@@ -163,7 +163,7 @@ fn multiple_registry_fetches() {
             bar = "*"
         "#)
         .file("b/src/main.rs", "fn main() {}");
-    p.build();
+    let p = p.build();
 
     let mut a = p.cargo("build").cwd(p.root().join("a")).build_command();
     let mut b = p.cargo("build").cwd(p.root().join("b")).build_command();
@@ -228,7 +228,7 @@ fn git_same_repo_different_tags() {
             dep = {{ git = '{}', tag = 'tag2' }}
         "#, a.url()))
         .file("b/src/main.rs", "extern crate dep; fn main() { dep::tag2(); }");
-    p.build();
+    let p = p.build();
 
     let mut a = p.cargo("build").arg("-v").cwd(p.root().join("a")).build_command();
     let mut b = p.cargo("build").arg("-v").cwd(p.root().join("b")).build_command();
@@ -278,7 +278,7 @@ fn git_same_branch_different_revs() {
             dep = {{ git = '{}' }}
         "#, a.url()))
         .file("b/src/main.rs", "extern crate dep; fn main() { dep::f2(); }");
-    p.build();
+    let p = p.build();
 
     // Generate a Cargo.lock pointing at the current rev, then clear out the
     // target directory
@@ -322,7 +322,7 @@ fn same_project() {
         "#)
         .file("src/main.rs", "fn main() {}")
         .file("src/lib.rs", "");
-    p.build();
+    let p = p.build();
 
     let mut a = p.cargo("build").build_command();
     let mut b = p.cargo("build").build_command();
@@ -366,7 +366,7 @@ fn killing_cargo_releases_the_lock() {
                 }
             }
         "#);
-    p.build();
+    let p = p.build();
 
     // Our build script will connect to our local TCP socket to inform us that
     // it's started  and that's how we know that `a` will have the lock
@@ -407,7 +407,7 @@ fn debug_release_ok() {
             version = "0.0.0"
         "#)
         .file("src/main.rs", "fn main() {}");
-    p.build();
+    let p = p.build();
 
     assert_that(p.cargo("build"), execs().with_status(0));
     fs::remove_dir_all(p.root().join("target")).unwrap();
@@ -464,7 +464,7 @@ fn no_deadlock_with_git_dependencies() {
             dep2 = {{ git = '{}' }}
         "#, dep1.url(), dep2.url()))
         .file("src/main.rs", "fn main() { }");
-    p.build();
+    let p = p.build();
 
     let n_concurrent_builds = 5;
 

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -20,8 +20,9 @@ fn read_env_vars_for_config() {
             fn main() {
                 assert_eq!(env::var("NUM_JOBS").unwrap(), "100");
             }
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("build").env("CARGO_BUILD_JOBS", "100"),
+    assert_that(p.cargo("build").env("CARGO_BUILD_JOBS", "100"),
                 execs().with_status(0));
 }

--- a/tests/cross-compile.rs
+++ b/tests/cross-compile.rs
@@ -29,10 +29,11 @@ fn simple_cross() {
             fn main() {{
                 assert_eq!(env::consts::ARCH, "{}");
             }}
-        "#, cross_compile::alternate_arch()));
+        "#, cross_compile::alternate_arch()))
+        .build();
 
     let target = cross_compile::alternate();
-    assert_that(p.cargo_process("build").arg("--target").arg(&target).arg("-v"),
+    assert_that(p.cargo("build").arg("--target").arg(&target).arg("-v"),
                 execs().with_status(0));
     assert_that(&p.target_bin(&target, "foo"), existing_file());
 
@@ -66,10 +67,11 @@ fn simple_cross_config() {
             fn main() {{
                 assert_eq!(env::consts::ARCH, "{}");
             }}
-        "#, cross_compile::alternate_arch()));
+        "#, cross_compile::alternate_arch()))
+        .build();
 
     let target = cross_compile::alternate();
-    assert_that(p.cargo_process("build").arg("-v"),
+    assert_that(p.cargo("build").arg("-v"),
                 execs().with_status(0));
     assert_that(&p.target_bin(&target, "foo"), existing_file());
 
@@ -94,19 +96,20 @@ fn simple_deps() {
         .file("src/main.rs", r#"
             extern crate bar;
             fn main() { bar::bar(); }
-        "#);
-    let p2 = project("bar")
+        "#)
+        .build();
+    let _p2 = project("bar")
         .file("Cargo.toml", r#"
             [package]
             name = "bar"
             version = "0.0.1"
             authors = []
         "#)
-        .file("src/lib.rs", "pub fn bar() {}");
-    p2.build();
+        .file("src/lib.rs", "pub fn bar() {}")
+        .build();
 
     let target = cross_compile::alternate();
-    assert_that(p.cargo_process("build").arg("--target").arg(&target),
+    assert_that(p.cargo("build").arg("--target").arg(&target),
                 execs().with_status(0));
     assert_that(&p.target_bin(&target, "foo"), existing_file());
 
@@ -139,8 +142,9 @@ fn plugin_deps() {
             fn main() {
                 assert_eq!(bar!(), baz::baz());
             }
-        "#);
-    let bar = project("bar")
+        "#)
+        .build();
+    let _bar = project("bar")
         .file("Cargo.toml", r#"
             [package]
             name = "bar"
@@ -171,20 +175,20 @@ fn plugin_deps() {
                           -> Box<MacResult + 'static> {
                 MacEager::expr(quote_expr!(cx, 1))
             }
-        "#);
-    let baz = project("baz")
+        "#)
+        .build();
+    let _baz = project("baz")
         .file("Cargo.toml", r#"
             [package]
             name = "baz"
             version = "0.0.1"
             authors = []
         "#)
-        .file("src/lib.rs", "pub fn baz() -> i32 { 1 }");
-    bar.build();
-    baz.build();
+        .file("src/lib.rs", "pub fn baz() -> i32 { 1 }")
+        .build();
 
     let target = cross_compile::alternate();
-    assert_that(foo.cargo_process("build").arg("--target").arg(&target),
+    assert_that(foo.cargo("build").arg("--target").arg(&target),
                 execs().with_status(0));
     assert_that(&foo.target_bin(&target, "foo"), existing_file());
 
@@ -217,8 +221,9 @@ fn plugin_to_the_max() {
             fn main() {
                 assert_eq!(bar!(), baz::baz());
             }
-        "#);
-    let bar = project("bar")
+        "#)
+        .build();
+    let _bar = project("bar")
         .file("Cargo.toml", r#"
             [package]
             name = "bar"
@@ -253,20 +258,20 @@ fn plugin_to_the_max() {
                           -> Box<MacResult + 'static> {
                 MacEager::expr(quote_expr!(cx, baz::baz()))
             }
-        "#);
-    let baz = project("baz")
+        "#)
+        .build();
+    let _baz = project("baz")
         .file("Cargo.toml", r#"
             [package]
             name = "baz"
             version = "0.0.1"
             authors = []
         "#)
-        .file("src/lib.rs", "pub fn baz() -> i32 { 1 }");
-    bar.build();
-    baz.build();
+        .file("src/lib.rs", "pub fn baz() -> i32 { 1 }")
+        .build();
 
     let target = cross_compile::alternate();
-    assert_that(foo.cargo_process("build").arg("--target").arg(&target).arg("-v"),
+    assert_that(foo.cargo("build").arg("--target").arg(&target).arg("-v"),
                 execs().with_status(0));
     println!("second");
     assert_that(foo.cargo("build").arg("-v")
@@ -295,9 +300,10 @@ fn linker_and_ar() {
             fn main() {{
                 assert_eq!(env::consts::ARCH, "{}");
             }}
-        "#, cross_compile::alternate_arch()));
+        "#, cross_compile::alternate_arch()))
+        .build();
 
-    assert_that(p.cargo_process("build").arg("--target").arg(&target)
+    assert_that(p.cargo("build").arg("--target").arg(&target)
                                               .arg("-v"),
                 execs().with_status(101)
                        .with_stderr_contains(&format!("\
@@ -337,8 +343,9 @@ fn plugin_with_extra_dylib_dep() {
             #![plugin(bar)]
 
             fn main() {}
-        "#);
-    let bar = project("bar")
+        "#)
+        .build();
+    let _bar = project("bar")
         .file("Cargo.toml", r#"
             [package]
             name = "bar"
@@ -364,8 +371,9 @@ fn plugin_with_extra_dylib_dep() {
             pub fn foo(reg: &mut Registry) {
                 println!("{}", baz::baz());
             }
-        "#);
-    let baz = project("baz")
+        "#)
+        .build();
+    let _baz = project("baz")
         .file("Cargo.toml", r#"
             [package]
             name = "baz"
@@ -376,12 +384,11 @@ fn plugin_with_extra_dylib_dep() {
             name = "baz"
             crate_type = ["dylib"]
         "#)
-        .file("src/lib.rs", "pub fn baz() -> i32 { 1 }");
-    bar.build();
-    baz.build();
+        .file("src/lib.rs", "pub fn baz() -> i32 { 1 }")
+        .build();
 
     let target = cross_compile::alternate();
-    assert_that(foo.cargo_process("build").arg("--target").arg(&target),
+    assert_that(foo.cargo("build").arg("--target").arg(&target),
                 execs().with_status(0));
 }
 
@@ -412,10 +419,11 @@ fn cross_tests() {
             use std::env;
             pub fn foo() {{ assert_eq!(env::consts::ARCH, "{}"); }}
             #[test] fn test_foo() {{ foo() }}
-        "#, cross_compile::alternate_arch()));
+        "#, cross_compile::alternate_arch()))
+        .build();
 
     let target = cross_compile::alternate();
-    assert_that(p.cargo_process("test").arg("--target").arg(&target),
+    assert_that(p.cargo("test").arg("--target").arg(&target),
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] foo v0.0.0 ({foo})
@@ -442,8 +450,8 @@ fn no_cross_doctests() {
             //! extern crate foo;
             //! assert!(true);
             //! ```
-        "#);
-    p.build();
+        "#)
+        .build();
 
     let host_output = format!("\
 [COMPILING] foo v0.0.0 ({foo})
@@ -495,10 +503,11 @@ fn simple_cargo_run() {
             fn main() {{
                 assert_eq!(env::consts::ARCH, "{}");
             }}
-        "#, cross_compile::alternate_arch()));
+        "#, cross_compile::alternate_arch()))
+        .build();
 
     let target = cross_compile::alternate();
-    assert_that(p.cargo_process("run").arg("--target").arg(&target),
+    assert_that(p.cargo("run").arg("--target").arg(&target),
                 execs().with_status(0));
 }
 
@@ -535,9 +544,10 @@ fn cross_with_a_build_script() {
                 assert_eq!(path.file_name().unwrap().to_str().unwrap(), "target");
             }}
         "#, target))
-        .file("src/main.rs", "fn main() {}");
+        .file("src/main.rs", "fn main() {}")
+        .build();
 
-    assert_that(p.cargo_process("build").arg("--target").arg(&target).arg("-v"),
+    assert_that(p.cargo("build").arg("--target").arg(&target).arg("-v"),
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] foo v0.0.0 (file://[..])
@@ -609,9 +619,10 @@ fn build_script_needed_for_host_and_target() {
             #[allow(unused_extern_crates)]
             extern crate d1;
             pub fn d2() { d1::d1(); }
-        ");
+        ")
+        .build();
 
-    assert_that(p.cargo_process("build").arg("--target").arg(&target).arg("-v"),
+    assert_that(p.cargo("build").arg("--target").arg(&target).arg("-v"),
                 execs().with_status(0)
                        .with_stderr_contains(&format!("\
 [COMPILING] d1 v0.0.0 ({url}/d1)", url = p.url()))
@@ -673,10 +684,11 @@ fn build_deps_for_the_right_arch() {
             path = "../d1"
         "#)
         .file("d2/build.rs", "extern crate d1; fn main() {}")
-        .file("d2/src/lib.rs", "");
+        .file("d2/src/lib.rs", "")
+        .build();
 
     let target = cross_compile::alternate();
-    assert_that(p.cargo_process("build").arg("--target").arg(&target).arg("-v"),
+    assert_that(p.cargo("build").arg("--target").arg(&target).arg("-v"),
                 execs().with_status(0));
 }
 
@@ -715,10 +727,11 @@ fn build_script_only_host() {
                                            .contains("target/debug/build/d1-"),
                         "bad: {:?}", env::var("OUT_DIR"));
             }
-        "#);
+        "#)
+        .build();
 
     let target = cross_compile::alternate();
-    assert_that(p.cargo_process("build").arg("--target").arg(&target).arg("-v"),
+    assert_that(p.cargo("build").arg("--target").arg(&target).arg("-v"),
                 execs().with_status(0));
 }
 
@@ -738,9 +751,10 @@ fn plugin_build_script_right_arch() {
             plugin = true
         "#)
         .file("build.rs", "fn main() {}")
-        .file("src/lib.rs", "");
+        .file("src/lib.rs", "")
+        .build();
 
-    assert_that(p.cargo_process("build").arg("-v").arg("--target").arg(cross_compile::alternate()),
+    assert_that(p.cargo("build").arg("-v").arg("--target").arg(cross_compile::alternate()),
                 execs().with_status(0)
                        .with_stderr("\
 [COMPILING] foo v0.0.1 ([..])
@@ -793,9 +807,10 @@ fn build_script_with_platform_specific_dependencies() {
             version = "0.0.0"
             authors = []
         "#)
-        .file("d2/src/lib.rs", "");
+        .file("d2/src/lib.rs", "")
+        .build();
 
-    assert_that(p.cargo_process("build").arg("-v").arg("--target").arg(&target),
+    assert_that(p.cargo("build").arg("-v").arg("--target").arg(&target),
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] d2 v0.0.0 ([..])
@@ -848,9 +863,10 @@ fn platform_specific_dependencies_do_not_leak() {
             version = "0.0.0"
             authors = []
         "#)
-        .file("d2/src/lib.rs", "");
+        .file("d2/src/lib.rs", "")
+        .build();
 
-    assert_that(p.cargo_process("build").arg("-v").arg("--target").arg(&target),
+    assert_that(p.cargo("build").arg("-v").arg("--target").arg(&target),
                 execs().with_status(101)
                        .with_stderr_contains("\
 [..] can't find crate for `d2`[..]"));
@@ -917,8 +933,8 @@ fn platform_specific_variables_reflected_in_build_scripts() {
         .file("d2/build.rs", r#"
             fn main() { println!("cargo:val=1") }
         "#)
-        .file("d2/src/lib.rs", "");
-    p.build();
+        .file("d2/src/lib.rs", "")
+        .build();
 
     assert_that(p.cargo("build").arg("-v"), execs().with_status(0));
     assert_that(p.cargo("build").arg("-v").arg("--target").arg(&target),
@@ -974,9 +990,10 @@ fn cross_test_dylib() {
              pub fn baz() {{
                 assert_eq!(env::consts::ARCH, "{}");
             }}
-        "#, cross_compile::alternate_arch()));
+        "#, cross_compile::alternate_arch()))
+        .build();
 
-    assert_that(p.cargo_process("test").arg("--target").arg(&target),
+    assert_that(p.cargo("test").arg("--target").arg(&target),
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] bar v0.0.1 ({dir}/bar)

--- a/tests/cross-publish.rs
+++ b/tests/cross-publish.rs
@@ -32,11 +32,12 @@ fn simple_cross_package() {
             fn main() {{
                 assert_eq!(env::consts::ARCH, "{}");
             }}
-        "#, cross_compile::alternate_arch()));
+        "#, cross_compile::alternate_arch()))
+        .build();
 
     let target = cross_compile::alternate();
 
-    assert_that(p.cargo_process("package").arg("--target").arg(&target),
+    assert_that(p.cargo("package").arg("--target").arg(&target),
                 execs().with_status(0).with_status(0).with_stderr(&format!(
 "   Packaging foo v0.0.0 ({dir})
    Verifying foo v0.0.0 ({dir})
@@ -80,9 +81,8 @@ fn publish_with_target() {
             fn main() {{
                 assert_eq!(env::consts::ARCH, "{}");
             }}
-        "#, cross_compile::alternate_arch()));
-
-    p.build();
+        "#, cross_compile::alternate_arch()))
+        .build();
 
     let target = cross_compile::alternate();
 

--- a/tests/death.rs
+++ b/tests/death.rs
@@ -77,8 +77,8 @@ fn ctrl_c_kills_everyone() {
                 let _ = socket.read(&mut [0; 10]);
                 panic!("that read should never return");
             }}
-        "#, addr));
-    p.build();
+        "#, addr))
+        .build();
 
     let mut cargo = p.cargo("build").build_command();
     cargo.stdin(Stdio::piped())

--- a/tests/dep-info.rs
+++ b/tests/dep-info.rs
@@ -8,9 +8,10 @@ use hamcrest::{assert_that, existing_file};
 fn build_dep_info() {
     let p = project("foo")
         .file("Cargo.toml", &basic_bin_manifest("foo"))
-        .file("src/foo.rs", &main_file(r#""i am foo""#, &[]));
+        .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
+        .build();
 
-    assert_that(p.cargo_process("build"), execs().with_status(0));
+    assert_that(p.cargo("build"), execs().with_status(0));
 
     let depinfo_bin_path = &p.bin("foo").with_extension("d");
 
@@ -31,9 +32,10 @@ fn build_dep_info_lib() {
             crate-type = ["lib"]
         "#)
         .file("src/lib.rs", "")
-        .file("examples/ex.rs", "");
+        .file("examples/ex.rs", "")
+        .build();
 
-    assert_that(p.cargo_process("build").arg("--example=ex"), execs().with_status(0));
+    assert_that(p.cargo("build").arg("--example=ex"), execs().with_status(0));
     assert_that(&p.example_lib("ex", "lib").with_extension("d"), existing_file());
 }
 
@@ -52,9 +54,10 @@ fn build_dep_info_rlib() {
             crate-type = ["rlib"]
         "#)
         .file("src/lib.rs", "")
-        .file("examples/ex.rs", "");
+        .file("examples/ex.rs", "")
+        .build();
 
-    assert_that(p.cargo_process("build").arg("--example=ex"), execs().with_status(0));
+    assert_that(p.cargo("build").arg("--example=ex"), execs().with_status(0));
     assert_that(&p.example_lib("ex", "rlib").with_extension("d"), existing_file());
 }
 
@@ -72,8 +75,9 @@ fn build_dep_info_dylib() {
             crate-type = ["dylib"]
         "#)
         .file("src/lib.rs", "")
-        .file("examples/ex.rs", "");
+        .file("examples/ex.rs", "")
+        .build();
 
-    assert_that(p.cargo_process("build").arg("--example=ex"), execs().with_status(0));
+    assert_that(p.cargo("build").arg("--example=ex"), execs().with_status(0));
     assert_that(&p.example_lib("ex", "dylib").with_extension("d"), existing_file());
 }

--- a/tests/directory.rs
+++ b/tests/directory.rs
@@ -66,7 +66,7 @@ impl VendorPackage {
         let p = self.p.take().unwrap();
         let json = serde_json::to_string(&self.cksum).unwrap();
         let p = p.file(".cargo-checksum.json", &json);
-        p.build();
+        let _ = p.build();
     }
 }
 
@@ -100,8 +100,8 @@ fn simple() {
             pub fn bar() {
                 foo::foo();
             }
-        "#);
-    p.build();
+        "#)
+        .build();
 
     assert_that(p.cargo("build"),
                 execs().with_status(0).with_stderr("\
@@ -253,7 +253,7 @@ warning: be sure to add `[..]` to your PATH to be able to run the installed bina
 fn not_there() {
     setup();
 
-    project("index").build();
+    let _ = project("index").build();
 
     let p = project("bar")
         .file("Cargo.toml", r#"
@@ -271,8 +271,8 @@ fn not_there() {
             pub fn bar() {
                 foo::foo();
             }
-        "#);
-    p.build();
+        "#)
+        .build();
 
     assert_that(p.cargo("build"),
                 execs().with_status(101).with_stderr("\
@@ -324,8 +324,8 @@ fn multiple() {
             pub fn bar() {
                 foo::foo();
             }
-        "#);
-    p.build();
+        "#)
+        .build();
 
     assert_that(p.cargo("build"),
                 execs().with_status(0).with_stderr("\
@@ -353,8 +353,8 @@ fn crates_io_then_directory() {
             pub fn bar() {
                 foo::foo();
             }
-        "#);
-    p.build();
+        "#)
+        .build();
 
     let cksum = Package::new("foo", "0.1.0")
                         .file("src/lib.rs", "pub fn foo() -> u32 { 0 }")
@@ -402,8 +402,8 @@ fn crates_io_then_bad_checksum() {
             [dependencies]
             foo = "0.1.0"
         "#)
-        .file("src/lib.rs", "");
-    p.build();
+        .file("src/lib.rs", "")
+        .build();
 
     Package::new("foo", "0.1.0").publish();
 
@@ -463,8 +463,8 @@ fn bad_file_checksum() {
             [dependencies]
             foo = "0.1.0"
         "#)
-        .file("src/lib.rs", "");
-    p.build();
+        .file("src/lib.rs", "")
+        .build();
 
     assert_that(p.cargo("build"),
                 execs().with_status(101).with_stderr("\
@@ -505,8 +505,8 @@ fn only_dot_files_ok() {
             [dependencies]
             foo = "0.1.0"
         "#)
-        .file("src/lib.rs", "");
-    p.build();
+        .file("src/lib.rs", "")
+        .build();
 
     assert_that(p.cargo("build"), execs().with_status(0));
 }
@@ -545,8 +545,8 @@ fn git_lock_file_doesnt_change() {
             [dependencies]
             git = {{ git = '{0}' }}
         "#, git.url()))
-        .file("src/lib.rs", "");
-    p.build();
+        .file("src/lib.rs", "")
+        .build();
 
     assert_that(p.cargo("build"), execs().with_status(0));
 
@@ -600,8 +600,8 @@ fn git_override_requires_lockfile() {
             [dependencies]
             git = { git = 'https://example.com/' }
         "#)
-        .file("src/lib.rs", "");
-    p.build();
+        .file("src/lib.rs", "")
+        .build();
 
     let root = paths::root();
     t!(fs::create_dir(&root.join(".cargo")));

--- a/tests/doc.rs
+++ b/tests/doc.rs
@@ -24,9 +24,10 @@ fn simple() {
         .file("build.rs", "fn main() {}")
         .file("src/lib.rs", r#"
             pub fn foo() {}
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("doc"),
+    assert_that(p.cargo("doc"),
                 execs().with_status(0).with_stderr(&format!("\
 [..] foo v0.0.1 ({dir})
 [..] foo v0.0.1 ({dir})
@@ -52,9 +53,10 @@ fn doc_no_libs() {
         "#)
         .file("src/main.rs", r#"
             bad code
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("doc"),
+    assert_that(p.cargo("doc"),
                 execs().with_status(0));
 }
 
@@ -69,9 +71,10 @@ fn doc_twice() {
         "#)
         .file("src/lib.rs", r#"
             pub fn foo() {}
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("doc"),
+    assert_that(p.cargo("doc"),
                 execs().with_status(0).with_stderr(&format!("\
 [DOCUMENTING] foo v0.0.1 ({dir})
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
@@ -106,9 +109,10 @@ fn doc_deps() {
         "#)
         .file("bar/src/lib.rs", r#"
             pub fn bar() {}
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("doc"),
+    assert_that(p.cargo("doc"),
                 execs().with_status(0).with_stderr(&format!("\
 [..] bar v0.0.1 ({dir}/bar)
 [..] bar v0.0.1 ({dir}/bar)
@@ -154,9 +158,10 @@ fn doc_no_deps() {
         "#)
         .file("bar/src/lib.rs", r#"
             pub fn bar() {}
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("doc").arg("--no-deps"),
+    assert_that(p.cargo("doc").arg("--no-deps"),
                 execs().with_status(0).with_stderr(&format!("\
 [COMPILING] bar v0.0.1 ({dir}/bar)
 [DOCUMENTING] foo v0.0.1 ({dir})
@@ -193,9 +198,10 @@ fn doc_only_bin() {
         "#)
         .file("bar/src/lib.rs", r#"
             pub fn bar() {}
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("doc").arg("-v"),
+    assert_that(p.cargo("doc").arg("-v"),
                 execs().with_status(0));
 
     assert_that(&p.root().join("target/doc"), existing_dir());
@@ -225,9 +231,10 @@ fn doc_multiple_targets_same_name_lib() {
             [lib]
             name = "foo_lib"
         "#)
-        .file("bar/src/lib.rs", "");
+        .file("bar/src/lib.rs", "")
+        .build();
 
-        assert_that(p.cargo_process("doc").arg("--all"),
+        assert_that(p.cargo("doc").arg("--all"),
                     execs()
                     .with_status(101)
                     .with_stderr_contains("[..] library `foo_lib` is specified [..]")
@@ -257,9 +264,10 @@ fn doc_multiple_targets_same_name() {
             [lib]
             name = "foo_lib"
         "#)
-        .file("bar/src/lib.rs", "");
+        .file("bar/src/lib.rs", "")
+        .build();
 
-        assert_that(p.cargo_process("doc").arg("--all"),
+        assert_that(p.cargo("doc").arg("--all"),
                     execs()
                     .with_status(101)
                     .with_stderr_contains("[..] target `foo_lib` [..]")
@@ -289,9 +297,10 @@ fn doc_multiple_targets_same_name_bin() {
             [[bin]]
             name = "foo-cli"
         "#)
-        .file("bar/src/foo-cli.rs", "");
+        .file("bar/src/foo-cli.rs", "")
+        .build();
 
-        assert_that(p.cargo_process("doc").arg("--all"),
+        assert_that(p.cargo("doc").arg("--all"),
                     execs()
                     .with_status(101)
                     .with_stderr_contains("[..] binary `foo_cli` is specified [..]")
@@ -322,9 +331,10 @@ fn doc_multiple_targets_same_name_undoced() {
             name = "foo-cli"
             doc = false
         "#)
-        .file("bar/src/foo-cli.rs", "");
+        .file("bar/src/foo-cli.rs", "")
+        .build();
 
-        assert_that(p.cargo_process("doc").arg("--all"),
+        assert_that(p.cargo("doc").arg("--all"),
                     execs().with_status(0));
 }
 
@@ -338,9 +348,10 @@ fn doc_lib_bin_same_name() {
             authors = []
         "#)
         .file("src/main.rs", "fn main() {}")
-        .file("src/lib.rs", "fn foo() {}");
+        .file("src/lib.rs", "fn foo() {}")
+        .build();
 
-    assert_that(p.cargo_process("doc"),
+    assert_that(p.cargo("doc"),
                 execs().with_status(101)
                        .with_stderr("\
 [ERROR] The target `foo` is specified as a library and as a binary by package \
@@ -376,9 +387,10 @@ fn doc_dash_p() {
             version = "0.0.1"
             authors = []
         "#)
-        .file("b/src/lib.rs", "");
+        .file("b/src/lib.rs", "")
+        .build();
 
-    assert_that(p.cargo_process("doc").arg("-p").arg("a"),
+    assert_that(p.cargo("doc").arg("-p").arg("a"),
                 execs().with_status(0)
                        .with_stderr("\
 [..] b v0.0.1 (file://[..])
@@ -400,9 +412,10 @@ fn doc_same_name() {
         .file("src/lib.rs", "")
         .file("src/bin/main.rs", "fn main() {}")
         .file("examples/main.rs", "fn main() {}")
-        .file("tests/main.rs", "fn main() {}");
+        .file("tests/main.rs", "fn main() {}")
+        .build();
 
-    assert_that(p.cargo_process("doc"),
+    assert_that(p.cargo("doc"),
                 execs().with_status(0));
 }
 
@@ -424,9 +437,10 @@ fn doc_target() {
             extern {
                 pub static A: u32;
             }
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("doc").arg("--target").arg(TARGET).arg("--verbose"),
+    assert_that(p.cargo("doc").arg("--target").arg(TARGET).arg("--verbose"),
                 execs().with_status(0));
     assert_that(&p.root().join(&format!("target/{}/doc", TARGET)), existing_dir());
     assert_that(&p.root().join(&format!("target/{}/doc/foo/index.html", TARGET)), existing_file());
@@ -451,9 +465,10 @@ fn target_specific_not_documented() {
             version = "0.0.1"
             authors = []
         "#)
-        .file("a/src/lib.rs", "not rust");
+        .file("a/src/lib.rs", "not rust")
+        .build();
 
-    assert_that(p.cargo_process("doc"),
+    assert_that(p.cargo("doc"),
                 execs().with_status(0));
 }
 
@@ -481,9 +496,10 @@ fn output_not_captured() {
             /// ☃
             /// ```
             pub fn foo() {}
-        ");
+        ")
+        .build();
 
-    let error = p.cargo_process("doc").exec_with_output().err().unwrap();
+    let error = p.cargo("doc").exec_with_output().err().unwrap();
     if let CargoError(CargoErrorKind::ProcessErrorKind(perr), ..) = error {
         let output = perr.output.unwrap();
         let stderr = str::from_utf8(&output.stderr).unwrap();
@@ -524,9 +540,10 @@ fn target_specific_documented() {
         .file("a/src/lib.rs", "
             /// test
             pub fn foo() {}
-        ");
+        ")
+        .build();
 
-    assert_that(p.cargo_process("doc"),
+    assert_that(p.cargo("doc"),
                 execs().with_status(0));
 }
 
@@ -556,9 +573,10 @@ fn no_document_build_deps() {
             /// ☃
             /// ```
             pub fn foo() {}
-        ");
+        ")
+        .build();
 
-    assert_that(p.cargo_process("doc"),
+    assert_that(p.cargo("doc"),
                 execs().with_status(0));
 }
 
@@ -571,9 +589,10 @@ fn doc_release() {
             version = "0.0.1"
             authors = []
         "#)
-        .file("src/lib.rs", "");
+        .file("src/lib.rs", "")
+        .build();
 
-    assert_that(p.cargo_process("build").arg("--release"),
+    assert_that(p.cargo("build").arg("--release"),
                 execs().with_status(0));
     assert_that(p.cargo("doc").arg("--release").arg("-v"),
                 execs().with_status(0)
@@ -620,9 +639,10 @@ fn doc_multiple_deps() {
         "#)
         .file("baz/src/lib.rs", r#"
             pub fn baz() {}
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("doc")
+    assert_that(p.cargo("doc")
                   .arg("-p").arg("bar")
                   .arg("-p").arg("baz")
                   .arg("-v"),
@@ -669,8 +689,9 @@ fn features() {
         .file("bar/src/lib.rs", r#"
             #[cfg(feature = "bar")]
             pub fn bar() {}
-        "#);
-    assert_that(p.cargo_process("doc").arg("--features").arg("foo"),
+        "#)
+        .build();
+    assert_that(p.cargo("doc").arg("--features").arg("foo"),
                 execs().with_status(0));
     assert_that(&p.root().join("target/doc"), existing_dir());
     assert_that(&p.root().join("target/doc/foo/fn.foo.html"), existing_file());
@@ -689,8 +710,8 @@ fn rerun_when_dir_removed() {
         .file("src/lib.rs", r#"
             /// dox
             pub fn foo() {}
-        "#);
-    p.build();
+        "#)
+        .build();
 
     assert_that(p.cargo("doc"),
                 execs().with_status(0));
@@ -722,8 +743,9 @@ fn document_only_lib() {
             /// ```
             pub fn foo() {}
             fn main() { foo(); }
-        "#);
-    assert_that(p.cargo_process("doc").arg("--lib"),
+        "#)
+        .build();
+    assert_that(p.cargo("doc").arg("--lib"),
                 execs().with_status(0));
     assert_that(&p.root().join("target/doc/foo/index.html"), existing_file());
 }
@@ -743,8 +765,9 @@ fn plugins_no_use_target() {
             [lib]
             proc-macro = true
         "#)
-        .file("src/lib.rs", "");
-    assert_that(p.cargo_process("doc")
+        .file("src/lib.rs", "")
+        .build();
+    assert_that(p.cargo("doc")
                  .arg("--target=x86_64-unknown-openbsd")
                  .arg("-v"),
                 execs().with_status(0));
@@ -773,10 +796,11 @@ fn doc_all_workspace() {
         "#)
         .file("bar/src/lib.rs", r#"
             pub fn bar() {}
-        "#);
+        "#)
+        .build();
 
     // The order in which bar is compiled or documented is not deterministic
-    assert_that(p.cargo_process("doc")
+    assert_that(p.cargo("doc")
                  .arg("--all"),
                 execs().with_status(0)
                        .with_stderr_contains("[..] Documenting bar v0.1.0 ([..])")
@@ -806,10 +830,11 @@ fn doc_all_virtual_manifest() {
         "#)
         .file("bar/src/lib.rs", r#"
             pub fn bar() {}
-        "#);
+        "#)
+        .build();
 
     // The order in which foo and bar are documented is not guaranteed
-    assert_that(p.cargo_process("doc")
+    assert_that(p.cargo("doc")
                  .arg("--all"),
                 execs().with_status(0)
                        .with_stderr_contains("[..] Documenting bar v0.1.0 ([..])")
@@ -838,10 +863,11 @@ fn doc_virtual_manifest_all_implied() {
         "#)
         .file("bar/src/lib.rs", r#"
             pub fn bar() {}
-        "#);
+        "#)
+        .build();
 
     // The order in which foo and bar are documented is not guaranteed
-    assert_that(p.cargo_process("doc"),
+    assert_that(p.cargo("doc"),
                 execs().with_status(0)
                        .with_stderr_contains("[..] Documenting bar v0.1.0 ([..])")
                        .with_stderr_contains("[..] Documenting foo v0.1.0 ([..])"));
@@ -864,11 +890,12 @@ fn doc_all_member_dependency_same_name() {
         "#)
         .file("a/src/lib.rs", r#"
             pub fn a() {}
-        "#);
+        "#)
+        .build();
 
     Package::new("a", "0.1.0").publish();
 
-    assert_that(p.cargo_process("doc")
+    assert_that(p.cargo("doc")
                  .arg("--all"),
                 execs().with_status(0)
                        .with_stderr_contains("[..] Updating registry `[..]`")

--- a/tests/features.rs
+++ b/tests/features.rs
@@ -21,9 +21,10 @@ fn invalid1() {
             [features]
             bar = ["baz"]
         "#)
-        .file("src/main.rs", "");
+        .file("src/main.rs", "")
+        .build();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(101).with_stderr("\
 [ERROR] failed to parse manifest at `[..]`
 
@@ -47,9 +48,10 @@ fn invalid2() {
             [dependencies.bar]
             path = "foo"
         "#)
-        .file("src/main.rs", "");
+        .file("src/main.rs", "")
+        .build();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(101).with_stderr("\
 [ERROR] failed to parse manifest at `[..]`
 
@@ -73,9 +75,10 @@ fn invalid3() {
             [dependencies.baz]
             path = "foo"
         "#)
-        .file("src/main.rs", "");
+        .file("src/main.rs", "")
+        .build();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(101).with_stderr("\
 [ERROR] failed to parse manifest at `[..]`
 
@@ -105,8 +108,8 @@ fn invalid4() {
             version = "0.0.1"
             authors = []
         "#)
-        .file("bar/src/lib.rs", "");
-    p.build();
+        .file("bar/src/lib.rs", "")
+        .build();
 
     assert_that(p.cargo("build"),
                 execs().with_status(101).with_stderr("\
@@ -139,9 +142,10 @@ fn invalid5() {
             path = "bar"
             optional = true
         "#)
-        .file("src/main.rs", "");
+        .file("src/main.rs", "")
+        .build();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(101).with_stderr("\
 [ERROR] failed to parse manifest at `[..]`
 
@@ -162,9 +166,10 @@ fn invalid6() {
             [features]
             foo = ["bar/baz"]
         "#)
-        .file("src/main.rs", "");
+        .file("src/main.rs", "")
+        .build();
 
-    assert_that(p.cargo_process("build").arg("--features").arg("foo"),
+    assert_that(p.cargo("build").arg("--features").arg("foo"),
                 execs().with_status(101).with_stderr("\
 [ERROR] failed to parse manifest at `[..]`
 
@@ -186,9 +191,10 @@ fn invalid7() {
             foo = ["bar/baz"]
             bar = []
         "#)
-        .file("src/main.rs", "");
+        .file("src/main.rs", "")
+        .build();
 
-    assert_that(p.cargo_process("build").arg("--features").arg("foo"),
+    assert_that(p.cargo("build").arg("--features").arg("foo"),
                 execs().with_status(101).with_stderr("\
 [ERROR] failed to parse manifest at `[..]`
 
@@ -217,9 +223,10 @@ fn invalid8() {
             version = "0.0.1"
             authors = []
         "#)
-        .file("bar/src/lib.rs", "");
+        .file("bar/src/lib.rs", "")
+        .build();
 
-    assert_that(p.cargo_process("build").arg("--features").arg("foo"),
+    assert_that(p.cargo("build").arg("--features").arg("foo"),
                 execs().with_status(101).with_stderr("\
 [ERROR] feature names may not contain slashes: `foo/bar`
 "));
@@ -244,9 +251,10 @@ fn invalid9() {
             version = "0.0.1"
             authors = []
         "#)
-        .file("bar/src/lib.rs", "");
+        .file("bar/src/lib.rs", "")
+        .build();
 
-    assert_that(p.cargo_process("build").arg("--features").arg("bar"),
+    assert_that(p.cargo("build").arg("--features").arg("bar"),
                 execs().with_status(0).with_stderr("\
 warning: Package `foo v0.0.1 ([..])` does not have feature `bar`. It has a required dependency with \
 that name, but only optional dependencies can be used as features. [..]
@@ -286,9 +294,10 @@ fn invalid10() {
             version = "0.0.1"
             authors = []
         "#)
-        .file("bar/baz/src/lib.rs", "");
+        .file("bar/baz/src/lib.rs", "")
+        .build();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(0).with_stderr("\
 warning: Package `bar v0.0.1 ([..])` does not have feature `baz`. It has a required dependency with \
 that name, but only optional dependencies can be used as features. [..]
@@ -343,8 +352,9 @@ fn no_transitive_dep_feature_requirement() {
         .file("bar/src/lib.rs", r#"
             #[cfg(feature = "qux")]
             pub fn test() { print!("test"); }
-        "#);
-    assert_that(p.cargo_process("build"),
+        "#)
+        .build();
+    assert_that(p.cargo("build"),
                 execs().with_status(101).with_stderr("\
 [ERROR] feature names may not contain slashes: `bar/qux`
 "));
@@ -377,9 +387,10 @@ fn no_feature_doesnt_build() {
             version = "0.0.1"
             authors = []
         "#)
-        .file("bar/src/lib.rs", "pub fn bar() {}");
+        .file("bar/src/lib.rs", "pub fn bar() {}")
+        .build();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(0).with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({dir})
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
@@ -427,9 +438,10 @@ fn default_feature_pulled_in() {
             version = "0.0.1"
             authors = []
         "#)
-        .file("bar/src/lib.rs", "pub fn bar() {}");
+        .file("bar/src/lib.rs", "pub fn bar() {}")
+        .build();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(0).with_stderr(format!("\
 [COMPILING] bar v0.0.1 ({dir}/bar)
 [COMPILING] foo v0.0.1 ({dir})
@@ -459,9 +471,10 @@ fn cyclic_feature() {
             [features]
             default = ["default"]
         "#)
-        .file("src/main.rs", "");
+        .file("src/main.rs", "")
+        .build();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(101).with_stderr("\
 [ERROR] Cyclic feature dependency: feature `default` depends on itself
 "));
@@ -480,9 +493,10 @@ fn cyclic_feature2() {
             foo = ["bar"]
             bar = ["foo"]
         "#)
-        .file("src/main.rs", "fn main() {}");
+        .file("src/main.rs", "fn main() {}")
+        .build();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(0).with_stdout(""));
 }
 
@@ -533,9 +547,10 @@ fn groups_on_groups_on_groups() {
             version = "0.0.1"
             authors = []
         "#)
-        .file("baz/src/lib.rs", "pub fn baz() {}");
+        .file("baz/src/lib.rs", "pub fn baz() {}")
+        .build();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(0).with_stderr(format!("\
 [COMPILING] ba[..] v0.0.1 ({dir}/ba[..])
 [COMPILING] ba[..] v0.0.1 ({dir}/ba[..])
@@ -581,9 +596,10 @@ fn many_cli_features() {
             version = "0.0.1"
             authors = []
         "#)
-        .file("baz/src/lib.rs", "pub fn baz() {}");
+        .file("baz/src/lib.rs", "pub fn baz() {}")
+        .build();
 
-    assert_that(p.cargo_process("build").arg("--features").arg("bar baz"),
+    assert_that(p.cargo("build").arg("--features").arg("bar baz"),
                 execs().with_status(0).with_stderr(format!("\
 [COMPILING] ba[..] v0.0.1 ({dir}/ba[..])
 [COMPILING] ba[..] v0.0.1 ({dir}/ba[..])
@@ -645,9 +661,10 @@ fn union_features() {
         .file("d2/src/lib.rs", r#"
             #[cfg(feature = "f1")] pub fn f1() {}
             #[cfg(feature = "f2")] pub fn f2() {}
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(0).with_stderr(format!("\
 [COMPILING] d2 v0.0.1 ({dir}/d2)
 [COMPILING] d1 v0.0.1 ({dir}/d1)
@@ -681,9 +698,10 @@ fn many_features_no_rebuilds() {
             ftest2 = []
             fall   = ["ftest", "ftest2"]
         "#)
-        .file("a/src/lib.rs", "");
+        .file("a/src/lib.rs", "")
+        .build();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(0).with_stderr(format!("\
 [COMPILING] a v0.1.0 ({dir}/a)
 [COMPILING] b v0.1.0 ({dir})
@@ -709,9 +727,10 @@ fn empty_features() {
             version = "0.0.1"
             authors = []
         "#)
-        .file("src/main.rs", "fn main() {}");
+        .file("src/main.rs", "fn main() {}")
+        .build();
 
-    assert_that(p.cargo_process("build").arg("--features").arg(""),
+    assert_that(p.cargo("build").arg("--features").arg(""),
                 execs().with_status(0));
 }
 
@@ -747,9 +766,10 @@ fn transitive_features() {
         .file("bar/src/lib.rs", r#"
             #[cfg(feature = "baz")]
             pub fn baz() {}
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("build").arg("--features").arg("foo"),
+    assert_that(p.cargo("build").arg("--features").arg("foo"),
                 execs().with_status(0));
 }
 
@@ -802,9 +822,10 @@ fn everything_in_the_lockfile() {
             [features]
             f3 = []
         "#)
-        .file("d3/src/lib.rs", "");
+        .file("d3/src/lib.rs", "")
+        .build();
 
-    assert_that(p.cargo_process("fetch"), execs().with_status(0));
+    assert_that(p.cargo("fetch"), execs().with_status(0));
     let loc = p.root().join("Cargo.lock");
     let mut lockfile = String::new();
     t!(t!(File::open(&loc)).read_to_string(&mut lockfile));
@@ -847,9 +868,10 @@ fn no_rebuild_when_frobbing_default_feature() {
             default = ["f1"]
             f1 = []
         "#)
-        .file("a/src/lib.rs", "");
+        .file("a/src/lib.rs", "")
+        .build();
 
-    assert_that(p.cargo_process("build"), execs().with_status(0));
+    assert_that(p.cargo("build"), execs().with_status(0));
     assert_that(p.cargo("build"), execs().with_status(0).with_stdout(""));
     assert_that(p.cargo("build"), execs().with_status(0).with_stdout(""));
 }
@@ -894,9 +916,10 @@ fn unions_work_with_no_default_features() {
         .file("a/src/lib.rs", r#"
             #[cfg(feature = "f1")]
             pub fn a() {}
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("build"), execs().with_status(0));
+    assert_that(p.cargo("build"), execs().with_status(0));
     assert_that(p.cargo("build"), execs().with_status(0).with_stdout(""));
     assert_that(p.cargo("build"), execs().with_status(0).with_stdout(""));
 }
@@ -922,9 +945,10 @@ fn optional_and_dev_dep() {
             version = "0.1.0"
             authors = []
         "#)
-        .file("foo/src/lib.rs", "");
+        .file("foo/src/lib.rs", "")
+        .build();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(0).with_stderr("\
 [COMPILING] test v0.1.0 ([..])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
@@ -964,9 +988,10 @@ fn activating_feature_activates_dep() {
         .file("foo/src/lib.rs", r#"
             #[cfg(feature = "a")]
             pub fn bar() {}
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("build").arg("--features").arg("a").arg("-v"),
+    assert_that(p.cargo("build").arg("--features").arg("a").arg("-v"),
                 execs().with_status(0));
 }
 
@@ -1015,8 +1040,8 @@ fn dep_feature_in_cmd_line() {
         .file("bar/src/lib.rs", r#"
             #[cfg(feature = "some-feat")]
             pub fn test() { print!("test"); }
-        "#);
-    p.build();
+        "#)
+        .build();
 
     // The foo project requires that feature "some-feat" in "bar" is enabled.
     // Building without any features enabled should fail:
@@ -1079,9 +1104,10 @@ fn all_features_flag_enables_all_features() {
             version = "0.0.1"
             authors = []
         "#)
-        .file("baz/src/lib.rs", "pub fn baz() {}");
+        .file("baz/src/lib.rs", "pub fn baz() {}")
+        .build();
 
-    assert_that(p.cargo_process("build").arg("--all-features"),
+    assert_that(p.cargo("build").arg("--all-features"),
                 execs().with_status(0));
 }
 
@@ -1122,9 +1148,10 @@ fn many_cli_features_comma_delimited() {
             version = "0.0.1"
             authors = []
         "#)
-        .file("baz/src/lib.rs", "pub fn baz() {}");
+        .file("baz/src/lib.rs", "pub fn baz() {}")
+        .build();
 
-    assert_that(p.cargo_process("build").arg("--features").arg("bar,baz"),
+    assert_that(p.cargo("build").arg("--features").arg("bar,baz"),
                 execs().with_status(0).with_stderr(format!("\
 [COMPILING] ba[..] v0.0.1 ({dir}/ba[..])
 [COMPILING] ba[..] v0.0.1 ({dir}/ba[..])
@@ -1196,9 +1223,10 @@ fn many_cli_features_comma_and_space_delimited() {
             version = "0.0.1"
             authors = []
         "#)
-        .file("bap/src/lib.rs", "pub fn bap() {}");
+        .file("bap/src/lib.rs", "pub fn bap() {}")
+        .build();
 
-    assert_that(p.cargo_process("build").arg("--features").arg("bar,baz bam bap"),
+    assert_that(p.cargo("build").arg("--features").arg("bar,baz bam bap"),
                 execs().with_status(0).with_stderr(format!("\
 [COMPILING] ba[..] v0.0.1 ({dir}/ba[..])
 [COMPILING] ba[..] v0.0.1 ({dir}/ba[..])

--- a/tests/fetch.rs
+++ b/tests/fetch.rs
@@ -16,8 +16,9 @@ fn no_deps() {
         .file("src/main.rs", r#"
             mod a; fn main() {}
         "#)
-        .file("src/a.rs", "");
+        .file("src/a.rs", "")
+        .build();
 
-    assert_that(p.cargo_process("fetch"),
+    assert_that(p.cargo("fetch"),
                 execs().with_status(0).with_stdout(""));
 }

--- a/tests/freshness.rs
+++ b/tests/freshness.rs
@@ -21,9 +21,10 @@ fn modifying_and_moving() {
         .file("src/main.rs", r#"
             mod a; fn main() {}
         "#)
-        .file("src/a.rs", "");
+        .file("src/a.rs", "")
+        .build();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(0).with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({dir})
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
@@ -63,9 +64,10 @@ fn modify_only_some_files() {
             fn main() {}
         "#)
         .file("src/b.rs", "")
-        .file("tests/test.rs", "");
+        .file("tests/test.rs", "")
+        .build();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(0).with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({dir})
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
@@ -122,9 +124,10 @@ fn rebuild_sub_package_then_while_package() {
             authors = []
             version = "0.0.1"
         "#)
-        .file("b/src/lib.rs", "");
+        .file("b/src/lib.rs", "")
+        .build();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(0));
 
     File::create(&p.root().join("b/src/lib.rs")).unwrap().write_all(br#"
@@ -156,9 +159,10 @@ fn changing_lib_features_caches_targets() {
             [features]
             foo = []
         "#)
-        .file("src/lib.rs", "");
+        .file("src/lib.rs", "")
+        .build();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(0)
                        .with_stderr("\
 [..]Compiling foo v0.0.1 ([..])
@@ -206,9 +210,10 @@ fn changing_profiles_caches_targets() {
             [profile.test]
             panic = "unwind"
         "#)
-        .file("src/lib.rs", "");
+        .file("src/lib.rs", "")
+        .build();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(0)
                        .with_stderr("\
 [..]Compiling foo v0.0.1 ([..])
@@ -301,10 +306,11 @@ fn changing_bin_paths_common_target_features_caches_targets() {
             fn main() {
                 yo();
             }
-        "#);
+        "#)
+        .build();
 
     /* Build and rebuild a/. Ensure dep_crate only builds once */
-    assert_that(p.cargo_process("run").cwd(p.root().join("a")),
+    assert_that(p.cargo("run").cwd(p.root().join("a")),
                 execs().with_status(0)
                        .with_stdout("ftest off")
                        .with_stderr("\
@@ -389,9 +395,10 @@ fn changing_bin_features_caches_targets() {
                 let msg = if cfg!(feature = "foo") { "feature on" } else { "feature off" };
                 println!("{}", msg);
             }
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("run"),
+    assert_that(p.cargo("run"),
                 execs().with_status(0)
                        .with_stdout("feature off")
                        .with_stderr("\
@@ -442,8 +449,8 @@ fn rebuild_tests_if_lib_changes() {
             extern crate foo;
             #[test]
             fn test() { foo::foo(); }
-        "#);
-    p.build();
+        "#)
+        .build();
 
     assert_that(p.cargo("build"),
                 execs().with_status(0));
@@ -501,9 +508,10 @@ fn no_rebuild_transitive_target_deps() {
             version = "0.0.1"
             authors = []
         "#)
-        .file("c/src/lib.rs", "");
+        .file("c/src/lib.rs", "")
+        .build();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(0));
     assert_that(p.cargo("test").arg("--no-run"),
                 execs().with_status(0)
@@ -540,9 +548,10 @@ fn rerun_if_changed_in_dep() {
                 println!("cargo:rerun-if-changed=build.rs");
             }
         "#)
-        .file("a/src/lib.rs", "");
+        .file("a/src/lib.rs", "")
+        .build();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(0));
     assert_that(p.cargo("build"),
                 execs().with_status(0).with_stdout(""));
@@ -597,8 +606,8 @@ fn same_build_dir_cached_packages() {
         .file(".cargo/config", r#"
             [build]
             target-dir = "./target"
-        "#);
-    p.build();
+        "#)
+        .build();
 
     assert_that(p.cargo("build").cwd(p.root().join("a1")),
                 execs().with_status(0).with_stderr(&format!("\
@@ -634,9 +643,10 @@ fn no_rebuild_if_build_artifacts_move_backwards_in_time() {
             version = "0.0.1"
             authors = []
         "#)
-        .file("a/src/lib.rs", "");
+        .file("a/src/lib.rs", "")
+        .build();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(0));
 
     p.root().move_into_the_past();
@@ -666,9 +676,10 @@ fn rebuild_if_build_artifacts_move_forward_in_time() {
             version = "0.0.1"
             authors = []
         "#)
-        .file("a/src/lib.rs", "");
+        .file("a/src/lib.rs", "")
+        .build();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(0));
 
     p.root().move_into_the_future();
@@ -695,9 +706,10 @@ fn rebuild_if_environment_changes() {
             fn main() {
                 println!("{}", env!("CARGO_PKG_DESCRIPTION"));
             }
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("run"),
+    assert_that(p.cargo("run"),
                 execs().with_status(0)
                 .with_stdout("old desc").with_stderr(&format!("\
 [COMPILING] env_change v0.0.1 ({dir})

--- a/tests/generate-lockfile.rs
+++ b/tests/generate-lockfile.rs
@@ -23,9 +23,10 @@ fn adding_and_removing_packages() {
             authors = []
             version = "0.0.1"
         "#)
-        .file("bar/src/lib.rs", "");
+        .file("bar/src/lib.rs", "")
+        .build();
 
-    assert_that(p.cargo_process("generate-lockfile"),
+    assert_that(p.cargo("generate-lockfile"),
                 execs().with_status(0));
 
     let toml = p.root().join("Cargo.toml");
@@ -89,9 +90,10 @@ fn preserve_metadata() {
             authors = []
             version = "0.0.1"
         "#)
-        .file("bar/src/lib.rs", "");
+        .file("bar/src/lib.rs", "")
+        .build();
 
-    assert_that(p.cargo_process("generate-lockfile"),
+    assert_that(p.cargo("generate-lockfile"),
                 execs().with_status(0));
 
     let metadata = r#"
@@ -133,10 +135,11 @@ fn preserve_line_endings_issue_2076() {
             authors = []
             version = "0.0.1"
         "#)
-        .file("bar/src/lib.rs", "");
+        .file("bar/src/lib.rs", "")
+        .build();
 
     let lockfile = p.root().join("Cargo.lock");
-    assert_that(p.cargo_process("generate-lockfile"),
+    assert_that(p.cargo("generate-lockfile"),
                 execs().with_status(0));
     assert_that(&lockfile,
                 existing_file());
@@ -170,11 +173,12 @@ fn cargo_update_generate_lockfile() {
             authors = []
             version = "0.0.1"
         "#)
-        .file("src/main.rs", "fn main() {}");
+        .file("src/main.rs", "fn main() {}")
+        .build();
 
     let lockfile = p.root().join("Cargo.lock");
     assert_that(&lockfile, is_not(existing_file()));
-    assert_that(p.cargo_process("update"), execs().with_status(0).with_stdout(""));
+    assert_that(p.cargo("update"), execs().with_status(0).with_stdout(""));
     assert_that(&lockfile, existing_file());
 
     fs::remove_file(p.root().join("Cargo.lock")).unwrap();

--- a/tests/git.rs
+++ b/tests/git.rs
@@ -48,12 +48,13 @@ fn cargo_compile_simple_git_dep() {
 
             git = '{}'
         "#, git_project.url()))
-        .file("src/main.rs", &main_file(r#""{}", dep1::hello()"#, &["dep1"]));
+        .file("src/main.rs", &main_file(r#""{}", dep1::hello()"#, &["dep1"]))
+        .build();
 
     let root = project.root();
     let git_root = git_project.root();
 
-    assert_that(project.cargo_process("build"),
+    assert_that(project.cargo("build"),
         execs()
         .with_stderr(&format!("[UPDATING] git repository `{}`\n\
                               [COMPILING] dep1 v0.5.0 ({}#[..])\n\
@@ -113,12 +114,13 @@ fn cargo_compile_git_dep_branch() {
             branch = "branchy"
 
         "#, git_project.url()))
-        .file("src/main.rs", &main_file(r#""{}", dep1::hello()"#, &["dep1"]));
+        .file("src/main.rs", &main_file(r#""{}", dep1::hello()"#, &["dep1"]))
+        .build();
 
     let root = project.root();
     let git_root = git_project.root();
 
-    assert_that(project.cargo_process("build"),
+    assert_that(project.cargo("build"),
         execs()
         .with_stderr(&format!("[UPDATING] git repository `{}`\n\
                               [COMPILING] dep1 v0.5.0 ({}?branch=branchy#[..])\n\
@@ -180,12 +182,13 @@ fn cargo_compile_git_dep_tag() {
             git = '{}'
             tag = "v0.1.0"
         "#, git_project.url()))
-        .file("src/main.rs", &main_file(r#""{}", dep1::hello()"#, &["dep1"]));
+        .file("src/main.rs", &main_file(r#""{}", dep1::hello()"#, &["dep1"]))
+        .build();
 
     let root = project.root();
     let git_root = git_project.root();
 
-    assert_that(project.cargo_process("build"),
+    assert_that(project.cargo("build"),
         execs()
         .with_stderr(&format!("[UPDATING] git repository `{}`\n\
                               [COMPILING] dep1 v0.5.0 ({}?tag=v0.1.0#[..])\n\
@@ -267,9 +270,10 @@ fn cargo_compile_with_nested_paths() {
             name = "parent"
         "#, git_project.url()))
         .file("src/parent.rs",
-              &main_file(r#""{}", dep1::hello()"#, &["dep1"]));
+              &main_file(r#""{}", dep1::hello()"#, &["dep1"]))
+        .build();
 
-    p.cargo_process("build")
+    p.cargo("build")
         .exec_with_output()
         .unwrap();
 
@@ -322,9 +326,10 @@ fn cargo_compile_with_malformed_nested_paths() {
             name = "parent"
         "#, git_project.url()))
         .file("src/parent.rs",
-              &main_file(r#""{}", dep1::hello()"#, &["dep1"]));
+              &main_file(r#""{}", dep1::hello()"#, &["dep1"]))
+        .build();
 
-    p.cargo_process("build")
+    p.cargo("build")
         .exec_with_output()
         .unwrap();
 
@@ -395,9 +400,10 @@ fn cargo_compile_with_meta_package() {
             name = "parent"
         "#, git_project.url(), git_project.url()))
         .file("src/parent.rs",
-              &main_file(r#""{} {}", dep1::hello(), dep2::hello()"#, &["dep1", "dep2"]));
+              &main_file(r#""{} {}", dep1::hello(), dep2::hello()"#, &["dep1", "dep2"]))
+        .build();
 
-    p.cargo_process("build")
+    p.cargo("build")
         .exec_with_output()
         .unwrap();
 
@@ -427,9 +433,10 @@ fn cargo_compile_with_short_ssh_git() {
 
             name = "foo"
         "#, url))
-        .file("src/foo.rs", &main_file(r#""{}", dep1::hello()"#, &["dep1"]));
+        .file("src/foo.rs", &main_file(r#""{}", dep1::hello()"#, &["dep1"]))
+        .build();
 
-    assert_that(project.cargo_process("build"),
+    assert_that(project.cargo("build"),
         execs()
         .with_stdout("")
         .with_stderr(&format!("\
@@ -484,9 +491,10 @@ fn two_revs_same_deps() {
                 assert_eq!(bar::bar(), 1);
                 assert_eq!(baz::baz(), 2);
             }
-        "#);
+        "#)
+        .build();
 
-    let baz = project("baz")
+    let _baz = project("baz")
         .file("Cargo.toml", &format!(r#"
             [package]
             name = "baz"
@@ -500,11 +508,10 @@ fn two_revs_same_deps() {
         .file("src/lib.rs", r#"
             extern crate bar;
             pub fn baz() -> i32 { bar::bar() }
-        "#);
+        "#)
+        .build();
 
-    baz.build();
-
-    assert_that(foo.cargo_process("build").arg("-v"),
+    assert_that(foo.cargo("build").arg("-v"),
                 execs().with_status(0));
     assert_that(&foo.bin("foo"), existing_file());
     assert_that(foo.process(&foo.bin("foo")), execs().with_status(0));
@@ -543,10 +550,11 @@ fn recompilation() {
             git = '{}'
         "#, git_project.url()))
         .file("src/main.rs",
-              &main_file(r#""{:?}", bar::bar()"#, &["bar"]));
+              &main_file(r#""{:?}", bar::bar()"#, &["bar"]))
+        .build();
 
     // First time around we should compile both foo and bar
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_stderr(&format!("[UPDATING] git repository `{}`\n\
                                              [COMPILING] bar v0.5.0 ({}#[..])\n\
                                              [COMPILING] foo v0.5.0 ({})\n\
@@ -671,10 +679,11 @@ fn update_with_shared_deps() {
             version = "0.5.0"
             git = '{}'
         "#, git_project.url()))
-        .file("dep2/src/lib.rs", "");
+        .file("dep2/src/lib.rs", "")
+        .build();
 
     // First time around we should compile both foo and bar
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_stderr(&format!("\
 [UPDATING] git repository `{git}`
 [COMPILING] bar v0.5.0 ({git}#[..])
@@ -783,9 +792,10 @@ fn dep_with_submodule() {
         .file("src/lib.rs", "
             extern crate dep1;
             pub fn foo() { dep1::dep() }
-        ");
+        ")
+        .build();
 
-    assert_that(project.cargo_process("build"),
+    assert_that(project.cargo("build"),
                 execs().with_stderr("\
 [UPDATING] git repository [..]
 [COMPILING] dep1 [..]
@@ -827,7 +837,7 @@ fn dep_with_bad_submodule() {
         Some("something something"),
         None).unwrap();
 
-    let project = project
+    let p = project
         .file("Cargo.toml", &format!(r#"
             [project]
 
@@ -842,7 +852,8 @@ fn dep_with_bad_submodule() {
         .file("src/lib.rs", "
             extern crate dep1;
             pub fn foo() { dep1::dep() }
-        ");
+        ")
+        .build();
 
     let expected = format!("\
 [UPDATING] git repository [..]
@@ -856,7 +867,7 @@ Caused by:
 
 To learn more, run the command again with --verbose.\n", path2url(git_project.root()));
 
-    assert_that(project.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_stderr(expected).with_status(101));
 }
 
@@ -884,7 +895,7 @@ fn two_deps_only_update_one() {
             .file("src/lib.rs", "")
     }).unwrap();
 
-    let project = project
+    let p = project
         .file("Cargo.toml", &format!(r#"
             [project]
 
@@ -897,9 +908,10 @@ fn two_deps_only_update_one() {
             [dependencies.dep2]
             git = '{}'
         "#, git1.url(), git2.url()))
-        .file("src/main.rs", "fn main() {}");
+        .file("src/main.rs", "fn main() {}")
+        .build();
 
-    assert_that(project.cargo_process("build"),
+    assert_that(p.cargo("build"),
         execs()
         .with_stderr(&format!("[UPDATING] git repository `[..]`\n\
                               [UPDATING] git repository `[..]`\n\
@@ -907,7 +919,7 @@ fn two_deps_only_update_one() {
                               [COMPILING] [..] v0.5.0 ([..])\n\
                               [COMPILING] foo v0.5.0 ({})\n\
                               [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]\n",
-                             project.url())));
+                             p.url())));
 
     File::create(&git1.root().join("src/lib.rs")).unwrap().write_all(br#"
         pub fn foo() {}
@@ -916,7 +928,7 @@ fn two_deps_only_update_one() {
     git::add(&repo);
     git::commit(&repo);
 
-    assert_that(project.cargo("update")
+    assert_that(p.cargo("update")
                        .arg("-p").arg("dep1"),
         execs()
         .with_stderr(&format!("[UPDATING] git repository `{}`\n\
@@ -952,9 +964,10 @@ fn stale_cached_version() {
             extern crate bar;
 
             fn main() { assert_eq!(bar::bar(), 1) }
-        "#);
+        "#)
+        .build();
 
-    assert_that(foo.cargo_process("build"), execs().with_status(0));
+    assert_that(foo.cargo("build"), execs().with_status(0));
     assert_that(foo.process(&foo.bin("foo")), execs().with_status(0));
 
     // Update the repo, and simulate someone else updating the lockfile and then
@@ -1024,7 +1037,7 @@ fn dep_with_changed_submodule() {
                                      Path::new("src"));
     git::commit(&repo);
 
-    let project = project
+    let p = project
         .file("Cargo.toml", &format!(r#"
             [project]
             name = "foo"
@@ -1036,10 +1049,11 @@ fn dep_with_changed_submodule() {
         .file("src/main.rs", "
             extern crate dep1;
             pub fn main() { println!(\"{}\", dep1::dep()) }
-        ");
+        ")
+        .build();
 
     println!("first run");
-    assert_that(project.cargo_process("run"), execs()
+    assert_that(p.cargo("run"), execs()
                 .with_stderr("[UPDATING] git repository `[..]`\n\
                                       [COMPILING] dep1 v0.5.0 ([..])\n\
                                       [COMPILING] foo v0.5.0 ([..])\n\
@@ -1074,7 +1088,7 @@ fn dep_with_changed_submodule() {
     sleep_ms(1000);
     // Update the dependency and carry on!
     println!("update");
-    assert_that(project.cargo("update").arg("-v"),
+    assert_that(p.cargo("update").arg("-v"),
                 execs()
                 .with_stderr("")
                 .with_stderr(&format!("[UPDATING] git repository `{}`\n\
@@ -1082,7 +1096,7 @@ fn dep_with_changed_submodule() {
                                       ", git_project.url())));
 
     println!("last run");
-    assert_that(project.cargo("run"), execs()
+    assert_that(p.cargo("run"), execs()
                 .with_stderr("[COMPILING] dep1 v0.5.0 ([..])\n\
                                       [COMPILING] foo v0.5.0 ([..])\n\
                                       [FINISHED] dev [unoptimized + debuginfo] target(s) in \
@@ -1126,11 +1140,12 @@ fn dev_deps_with_testing() {
                 extern crate bar;
                 #[test] fn foo() { bar::gimme(); }
             }
-        "#);
+        "#)
+        .build();
 
     // Generate a lockfile which did not use `bar` to compile, but had to update
     // `bar` to generate the lockfile
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
         execs().with_stderr(&format!("\
 [UPDATING] git repository `{bar}`
 [COMPILING] foo v0.5.0 ({url})
@@ -1218,11 +1233,12 @@ fn git_name_not_always_needed() {
             [dev-dependencies.bar]
             git = '{}'
         "#, p2.url()))
-        .file("src/main.rs", "fn main() {}");
+        .file("src/main.rs", "fn main() {}")
+        .build();
 
     // Generate a lockfile which did not use `bar` to compile, but had to update
     // `bar` to generate the lockfile
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
         execs().with_stderr(&format!("\
 [UPDATING] git repository `{bar}`
 [COMPILING] foo v0.5.0 ({url})
@@ -1254,8 +1270,8 @@ fn git_repo_changing_no_rebuild() {
             git = '{}'
         "#, bar.url()))
         .file("src/main.rs", "fn main() {}")
-        .file("build.rs", "fn main() {}");
-    p1.build();
+        .file("build.rs", "fn main() {}")
+        .build();
     p1.root().move_into_the_past();
     assert_that(p1.cargo("build"),
                 execs().with_stderr(&format!("\
@@ -1283,8 +1299,9 @@ fn git_repo_changing_no_rebuild() {
             [dependencies.bar]
             git = '{}'
         "#, bar.url()))
-        .file("src/main.rs", "fn main() {}");
-    assert_that(p2.cargo_process("build"),
+        .file("src/main.rs", "fn main() {}")
+        .build();
+    assert_that(p2.cargo("build"),
                 execs().with_stderr(&format!("\
 [UPDATING] git repository `{bar}`
 [COMPILING] [..]
@@ -1382,8 +1399,9 @@ fn fetch_downloads() {
             [dependencies.bar]
             git = '{}'
         "#, bar.url()))
-        .file("src/main.rs", "fn main() {}");
-    assert_that(p.cargo_process("fetch"),
+        .file("src/main.rs", "fn main() {}")
+        .build();
+    assert_that(p.cargo("fetch"),
                 execs().with_status(0).with_stderr(&format!("\
 [UPDATING] git repository `{url}`
 ", url = bar.url())));
@@ -1413,9 +1431,10 @@ fn warnings_in_git_dep() {
             [dependencies.bar]
             git = '{}'
         "#, bar.url()))
-        .file("src/main.rs", "fn main() {}");
+        .file("src/main.rs", "fn main() {}")
+        .build();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
         execs()
         .with_stderr(&format!("[UPDATING] git repository `{}`\n\
                               [COMPILING] bar v0.5.0 ({}#[..])\n\
@@ -1470,9 +1489,10 @@ fn update_ambiguous() {
             [dependencies.bar]
             git = '{}'
         "#, foo1.url(), bar.url()))
-        .file("src/main.rs", "fn main() {}");
+        .file("src/main.rs", "fn main() {}")
+        .build();
 
-    assert_that(p.cargo_process("generate-lockfile"), execs().with_status(0));
+    assert_that(p.cargo("generate-lockfile"), execs().with_status(0));
     assert_that(p.cargo("update")
                  .arg("-p").arg("foo"),
                 execs().with_status(101)
@@ -1516,9 +1536,10 @@ fn update_one_dep_in_repo_with_many_deps() {
             [dependencies.a]
             git = '{}'
         "#, foo.url(), foo.url()))
-        .file("src/main.rs", "fn main() {}");
+        .file("src/main.rs", "fn main() {}")
+        .build();
 
-    assert_that(p.cargo_process("generate-lockfile"), execs().with_status(0));
+    assert_that(p.cargo("generate-lockfile"), execs().with_status(0));
     assert_that(p.cargo("update")
                  .arg("-p").arg("foo"),
                 execs().with_status(0)
@@ -1572,9 +1593,9 @@ fn switch_deps_does_not_update_transitive() {
             [dependencies.dep]
             git = '{}'
         "#, dep1.url()))
-        .file("src/main.rs", "fn main() {}");
+        .file("src/main.rs", "fn main() {}")
+        .build();
 
-    p.build();
     assert_that(p.cargo("build"),
                 execs().with_status(0)
                        .with_stderr(&format!("\
@@ -1638,9 +1659,9 @@ fn update_one_source_updates_all_packages_in_that_git_source() {
             [dependencies.dep]
             git = '{}'
         "#, dep.url()))
-        .file("src/main.rs", "fn main() {}");
+        .file("src/main.rs", "fn main() {}")
+        .build();
 
-    p.build();
     assert_that(p.cargo("build"),
                 execs().with_status(0));
 
@@ -1702,9 +1723,9 @@ fn switch_sources() {
             [dependencies.a]
             git = '{}'
         "#, a1.url()))
-        .file("b/src/lib.rs", "pub fn main() {}");
+        .file("b/src/lib.rs", "pub fn main() {}")
+        .build();
 
-    p.build();
     assert_that(p.cargo("build"),
                 execs().with_status(0)
                        .with_stderr("\
@@ -1737,7 +1758,7 @@ fn switch_sources() {
 
 #[test]
 fn dont_require_submodules_are_checked_out() {
-    let project = project("foo");
+    let p = project("foo").build();
     let git1 = git::new("dep1", |p| {
         p.file("Cargo.toml", r#"
             [project]
@@ -1757,7 +1778,7 @@ fn dont_require_submodules_are_checked_out() {
     git::add_submodule(&repo, &url, Path::new("a/submodule"));
     git::commit(&repo);
 
-    git2::Repository::init(&project.root()).unwrap();
+    git2::Repository::init(&p.root()).unwrap();
     let url = path2url(git1.root()).to_string();
     let dst = paths::home().join("foo");
     git2::Repository::clone(&url, &dst).unwrap();
@@ -1803,9 +1824,10 @@ fn doctest_same_name() {
         .file("src/lib.rs", r#"
             #[macro_use]
             extern crate a;
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("test").arg("-v"),
+    assert_that(p.cargo("test").arg("-v"),
                 execs().with_status(0));
 }
 
@@ -1833,9 +1855,10 @@ fn lints_are_suppressed() {
             [dependencies]
             a = {{ git = '{}' }}
         "#, a.url()))
-        .file("src/lib.rs", "");
+        .file("src/lib.rs", "")
+        .build();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(0).with_stderr("\
 [UPDATING] git repository `[..]`
 [COMPILING] a v0.5.0 ([..])
@@ -1869,9 +1892,10 @@ fn denied_lints_are_allowed() {
             [dependencies]
             a = {{ git = '{}' }}
         "#, a.url()))
-        .file("src/lib.rs", "");
+        .file("src/lib.rs", "")
+        .build();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(0).with_stderr("\
 [UPDATING] git repository `[..]`
 [COMPILING] a v0.5.0 ([..])
@@ -1910,9 +1934,10 @@ fn add_a_git_dep() {
             version = "0.0.1"
             authors = []
         "#)
-        .file("a/src/lib.rs", "");
+        .file("a/src/lib.rs", "")
+        .build();
 
-    assert_that(p.cargo_process("build"), execs().with_status(0));
+    assert_that(p.cargo("build"), execs().with_status(0));
 
     File::create(p.root().join("a/Cargo.toml")).unwrap().write_all(format!(r#"
         [package]
@@ -1966,9 +1991,10 @@ fn two_at_rev_instead_of_tag() {
             git1 = {{ git = '{0}', rev = 'v0.1.0' }}
             git2 = {{ git = '{0}', rev = 'v0.1.0' }}
         "#, git.url()))
-        .file("src/lib.rs", "");
+        .file("src/lib.rs", "")
+        .build();
 
-    assert_that(p.cargo_process("generate-lockfile"), execs().with_status(0));
+    assert_that(p.cargo("generate-lockfile"), execs().with_status(0));
     assert_that(p.cargo("build").arg("-v"), execs().with_status(0));
 }
 
@@ -2123,11 +2149,12 @@ fn invalid_git_dependency_manifest() {
 
             git = '{}'
         "#, git_project.url()))
-        .file("src/main.rs", &main_file(r#""{}", dep1::hello()"#, &["dep1"]));
+        .file("src/main.rs", &main_file(r#""{}", dep1::hello()"#, &["dep1"]))
+        .build();
 
     let git_root = git_project.root();
 
-    assert_that(project.cargo_process("build"),
+    assert_that(project.cargo("build"),
         execs()
         .with_stderr(&format!("[UPDATING] git repository `{}`\n\
                               error: failed to load source for a dependency on `dep1`\n\

--- a/tests/install.rs
+++ b/tests/install.rs
@@ -207,8 +207,8 @@ fn install_path() {
             version = "0.1.0"
             authors = []
         "#)
-        .file("src/main.rs", "fn main() {}");
-    p.build();
+        .file("src/main.rs", "fn main() {}")
+        .build();
 
     assert_that(cargo_process("install").arg("--path").arg(p.root()),
                 execs().with_status(0));
@@ -237,8 +237,8 @@ fn multiple_crates_error() {
             version = "0.1.0"
             authors = []
         "#)
-        .file("a/src/main.rs", "fn main() {}");
-    p.build();
+        .file("a/src/main.rs", "fn main() {}")
+        .build();
 
     assert_that(cargo_process("install").arg("--git").arg(p.url().to_string()),
                 execs().with_status(101).with_stderr("\
@@ -263,8 +263,8 @@ fn multiple_crates_select() {
             version = "0.1.0"
             authors = []
         "#)
-        .file("a/src/main.rs", "fn main() {}");
-    p.build();
+        .file("a/src/main.rs", "fn main() {}")
+        .build();
 
     assert_that(cargo_process("install").arg("--git").arg(p.url().to_string())
                                         .arg("foo"),
@@ -297,8 +297,8 @@ fn multiple_crates_auto_binaries() {
             version = "0.1.0"
             authors = []
         "#)
-        .file("a/src/lib.rs", "");
-    p.build();
+        .file("a/src/lib.rs", "")
+        .build();
 
     assert_that(cargo_process("install").arg("--path").arg(p.root()),
                 execs().with_status(0));
@@ -329,8 +329,8 @@ fn multiple_crates_auto_examples() {
             version = "0.1.0"
             authors = []
         "#)
-        .file("a/src/lib.rs", "");
-    p.build();
+        .file("a/src/lib.rs", "")
+        .build();
 
     assert_that(cargo_process("install").arg("--path").arg(p.root())
                                         .arg("--example=foo"),
@@ -357,8 +357,8 @@ fn no_binaries_or_examples() {
             version = "0.1.0"
             authors = []
         "#)
-        .file("a/src/lib.rs", "");
-    p.build();
+        .file("a/src/lib.rs", "")
+        .build();
 
     assert_that(cargo_process("install").arg("--path").arg(p.root()),
                 execs().with_status(101).with_stderr("\
@@ -376,8 +376,8 @@ fn no_binaries() {
             authors = []
         "#)
         .file("src/lib.rs", "")
-        .file("examples/foo.rs", "fn main() {}");
-    p.build();
+        .file("examples/foo.rs", "fn main() {}")
+        .build();
 
     assert_that(cargo_process("install").arg("--path").arg(p.root()).arg("foo"),
                 execs().with_status(101).with_stderr("\
@@ -396,8 +396,8 @@ fn examples() {
             authors = []
         "#)
         .file("src/lib.rs", "")
-        .file("examples/foo.rs", "extern crate foo; fn main() {}");
-    p.build();
+        .file("examples/foo.rs", "extern crate foo; fn main() {}")
+        .build();
 
     assert_that(cargo_process("install").arg("--path").arg(p.root())
                                         .arg("--example=foo"),
@@ -415,8 +415,8 @@ fn install_twice() {
             authors = []
         "#)
         .file("src/bin/foo-bin1.rs", "fn main() {}")
-        .file("src/bin/foo-bin2.rs", "fn main() {}");
-    p.build();
+        .file("src/bin/foo-bin2.rs", "fn main() {}")
+        .build();
 
     assert_that(cargo_process("install").arg("--path").arg(p.root()),
                 execs().with_status(0));
@@ -438,8 +438,8 @@ fn install_force() {
             version = "0.1.0"
             authors = []
         "#)
-        .file("src/main.rs", "fn main() {}");
-    p.build();
+        .file("src/main.rs", "fn main() {}")
+        .build();
 
     assert_that(cargo_process("install").arg("--path").arg(p.root()),
                 execs().with_status(0));
@@ -451,8 +451,8 @@ fn install_force() {
             version = "0.2.0"
             authors = []
         "#)
-        .file("src/main.rs", "fn main() {}");
-    p.build();
+        .file("src/main.rs", "fn main() {}")
+        .build();
 
     assert_that(cargo_process("install").arg("--force").arg("--path").arg(p.root()),
                 execs().with_status(0).with_stderr(&format!("\
@@ -481,8 +481,8 @@ fn install_force_partial_overlap() {
             authors = []
         "#)
         .file("src/bin/foo-bin1.rs", "fn main() {}")
-        .file("src/bin/foo-bin2.rs", "fn main() {}");
-    p.build();
+        .file("src/bin/foo-bin2.rs", "fn main() {}")
+        .build();
 
     assert_that(cargo_process("install").arg("--path").arg(p.root()),
                 execs().with_status(0));
@@ -495,8 +495,8 @@ fn install_force_partial_overlap() {
             authors = []
         "#)
         .file("src/bin/foo-bin2.rs", "fn main() {}")
-        .file("src/bin/foo-bin3.rs", "fn main() {}");
-    p.build();
+        .file("src/bin/foo-bin3.rs", "fn main() {}")
+        .build();
 
     assert_that(cargo_process("install").arg("--force").arg("--path").arg(p.root()),
                 execs().with_status(0).with_stderr(&format!("\
@@ -529,8 +529,8 @@ fn install_force_bin() {
             authors = []
         "#)
         .file("src/bin/foo-bin1.rs", "fn main() {}")
-        .file("src/bin/foo-bin2.rs", "fn main() {}");
-    p.build();
+        .file("src/bin/foo-bin2.rs", "fn main() {}")
+        .build();
 
     assert_that(cargo_process("install").arg("--path").arg(p.root()),
                 execs().with_status(0));
@@ -543,8 +543,8 @@ fn install_force_bin() {
             authors = []
         "#)
         .file("src/bin/foo-bin1.rs", "fn main() {}")
-        .file("src/bin/foo-bin2.rs", "fn main() {}");
-    p.build();
+        .file("src/bin/foo-bin2.rs", "fn main() {}")
+        .build();
 
     assert_that(cargo_process("install").arg("--force")
                     .arg("--bin")
@@ -578,8 +578,8 @@ fn compile_failure() {
             version = "0.1.0"
             authors = []
         "#)
-        .file("src/main.rs", "");
-    p.build();
+        .file("src/main.rs", "")
+        .build();
 
     assert_that(cargo_process("install").arg("--path").arg(p.root()),
                 execs().with_status(101).with_stderr_contains("\
@@ -602,8 +602,8 @@ fn git_repo() {
             version = "0.1.0"
             authors = []
         "#)
-        .file("src/main.rs", "fn main() {}");
-    p.build();
+        .file("src/main.rs", "fn main() {}")
+        .build();
 
     // use `--locked` to test that we don't even try to write a lockfile
     assert_that(cargo_process("install").arg("--locked").arg("--git").arg(p.url().to_string()),
@@ -702,8 +702,8 @@ fn uninstall_piecemeal() {
             authors = []
         "#)
         .file("src/bin/foo.rs", "fn main() {}")
-        .file("src/bin/bar.rs", "fn main() {}");
-    p.build();
+        .file("src/bin/bar.rs", "fn main() {}")
+        .build();
 
     assert_that(cargo_process("install").arg("--path").arg(p.root()),
                 execs().with_status(0));
@@ -756,8 +756,8 @@ fn installs_from_cwd_by_default() {
             version = "0.1.0"
             authors = []
         "#)
-        .file("src/main.rs", "fn main() {}");
-    p.build();
+        .file("src/main.rs", "fn main() {}")
+        .build();
 
     assert_that(cargo_process("install").cwd(p.root()),
                 execs().with_status(0));
@@ -773,9 +773,10 @@ fn do_not_rebuilds_on_local_install() {
             version = "0.1.0"
             authors = []
         "#)
-        .file("src/main.rs", "fn main() {}");
+        .file("src/main.rs", "fn main() {}")
+        .build();
 
-    assert_that(p.cargo_process("build").arg("--release"),
+    assert_that(p.cargo("build").arg("--release"),
                 execs().with_status(0));
     assert_that(cargo_process("install").arg("--path").arg(p.root()),
                 execs().with_status(0).with_stderr("[INSTALLING] [..]
@@ -837,8 +838,8 @@ fn git_with_lockfile() {
             [[package]]
             name = "bar"
             version = "0.1.0"
-        "#);
-    p.build();
+        "#)
+        .build();
 
     assert_that(cargo_process("install").arg("--git").arg(p.url().to_string()),
                 execs().with_status(0));
@@ -853,8 +854,8 @@ fn q_silences_warnings() {
             version = "0.1.0"
             authors = []
         "#)
-        .file("src/main.rs", "fn main() {}");
-    p.build();
+        .file("src/main.rs", "fn main() {}")
+        .build();
 
     assert_that(cargo_process("install").arg("-q").arg("--path").arg(p.root()),
                 execs().with_status(0).with_stderr(""));
@@ -899,8 +900,8 @@ fn use_path_workspace() {
             [dependencies]
             foo = "1"
         "#)
-        .file("baz/src/lib.rs", "");
-    p.build();
+        .file("baz/src/lib.rs", "")
+        .build();
 
     assert_that(p.cargo("build"), execs().with_status(0));
     let lock = p.read_lockfile();

--- a/tests/jobserver.rs
+++ b/tests/jobserver.rs
@@ -53,9 +53,10 @@ fn jobserver_exists() {
                 // a little too complicated for a test...
             }
         "#)
-        .file("src/lib.rs", "");
+        .file("src/lib.rs", "")
+        .build();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(0));
 }
 
@@ -114,12 +115,12 @@ fn makes_jobserver_used() {
                 let mut v = Vec::new();
                 stream.read_to_end(&mut v).unwrap();
             }
-       "#)
-       .file("Makefile", "\
+        "#)
+        .file("Makefile", "\
 all:
 \t+$(CARGO) build
-");
-    p.build();
+")
+        .build();
 
     let l = TcpListener::bind("127.0.0.1:0").unwrap();
     let addr = l.local_addr().unwrap();
@@ -163,12 +164,12 @@ fn jobserver_and_j() {
             version = "0.0.1"
             authors = []
         "#)
-       .file("src/lib.rs", "")
-       .file("Makefile", "\
+        .file("src/lib.rs", "")
+        .file("Makefile", "\
 all:
 \t+$(CARGO) build -j2
-");
-    p.build();
+")
+        .build();
 
     assert_that(p.process(make)
                  .env("CARGO", cargo_exe())

--- a/tests/local-registry.rs
+++ b/tests/local-registry.rs
@@ -46,9 +46,10 @@ fn simple() {
             pub fn bar() {
                 foo::foo();
             }
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(0).with_stderr(&format!("\
 [UNPACKING] foo v0.0.1 ([..])
 [COMPILING] foo v0.0.1
@@ -86,9 +87,10 @@ fn multiple_versions() {
             pub fn bar() {
                 foo::foo();
             }
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(0).with_stderr(&format!("\
 [UNPACKING] foo v0.1.0 ([..])
 [COMPILING] foo v0.1.0
@@ -138,9 +140,10 @@ fn multiple_names() {
                 foo::foo();
                 bar::bar();
             }
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(0).with_stderr(&format!("\
 [UNPACKING] [..]
 [UNPACKING] [..]
@@ -183,9 +186,10 @@ fn interdependent() {
                 foo::foo();
                 bar::bar();
             }
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(0).with_stderr(&format!("\
 [UNPACKING] [..]
 [UNPACKING] [..]
@@ -244,9 +248,10 @@ fn path_dep_rewritten() {
                 foo::foo();
                 bar::bar();
             }
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(0).with_stderr(&format!("\
 [UNPACKING] [..]
 [UNPACKING] [..]
@@ -279,10 +284,10 @@ fn invalid_dir_bad() {
 
             [source.my-awesome-local-directory]
             local-registry = '/path/to/nowhere'
-        "#);
+        "#)
+        .build();
 
-
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(101).with_stderr("\
 [ERROR] failed to load source for a dependency on `foo`
 
@@ -317,8 +322,8 @@ fn different_directory_replacing_the_registry_is_bad() {
             [dependencies]
             foo = "*"
         "#)
-        .file("src/lib.rs", "");
-    p.build();
+        .file("src/lib.rs", "")
+        .build();
 
     // Generate a lock file against the crates.io registry
     Package::new("foo", "0.0.1").publish();
@@ -381,9 +386,10 @@ fn crates_io_registry_url_is_optional() {
             pub fn bar() {
                 foo::foo();
             }
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(0).with_stderr(&format!("\
 [UNPACKING] foo v0.0.1 ([..])
 [COMPILING] foo v0.0.1

--- a/tests/lockfile-compat.rs
+++ b/tests/lockfile-compat.rs
@@ -64,7 +64,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
         .file("src/lib.rs", "")
         .file("Cargo.lock", old_lockfile);
 
-    p.build();
+    let p = p.build();
 
     assert_that(p.cargo(cargo_command),
                 execs().with_status(0));
@@ -110,7 +110,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum foo 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "checksum"
 "#);
 
-    p.build();
+    let p = p.build();
 
     assert_that(p.cargo("build"),
                 execs().with_status(0));
@@ -165,7 +165,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum foo 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "checksum"
 "#);
 
-    p.build();
+    let p = p.build();
 
     assert_that(p.cargo("build"),
                 execs().with_status(101).with_stderr("\
@@ -217,7 +217,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [metadata]
 "checksum foo 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "<none>"
 "#);
-    p.build();
+    let p = p.build();
 
     assert_that(p.cargo("fetch"),
                 execs().with_status(101).with_stderr("\
@@ -278,7 +278,7 @@ source = "git+{0}"
 "checksum foo 0.1.0 (git+{0})" = "checksum"
 "#, git.url()));
 
-    p.build();
+    let p = p.build();
 
     assert_that(p.cargo("fetch"),
                 execs().with_status(101).with_stderr("\
@@ -312,7 +312,7 @@ fn current_lockfile_format() {
             foo = "0.1.0"
         "#)
         .file("src/lib.rs", "");
-    p.build();
+    let p = p.build();
 
     assert_that(p.cargo("build"), execs().with_status(0));
 
@@ -371,7 +371,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
         .file("src/lib.rs", "")
         .file("Cargo.lock", lockfile);
 
-    p.build();
+    let p = p.build();
 
     assert_that(p.cargo("build"), execs().with_status(0));
 
@@ -394,7 +394,7 @@ fn locked_correct_error() {
             foo = "0.1.0"
         "#)
         .file("src/lib.rs", "");
-    p.build();
+    let p = p.build();
 
     assert_that(p.cargo("build").arg("--locked"),
                 execs().with_status(101).with_stderr("\

--- a/tests/metadata.rs
+++ b/tests/metadata.rs
@@ -8,10 +8,11 @@ use cargotest::support::{project, execs, basic_bin_manifest, basic_lib_manifest,
 #[test]
 fn cargo_metadata_simple() {
     let p = project("foo")
-            .file("src/foo.rs", "")
-            .file("Cargo.toml", &basic_bin_manifest("foo"));
+        .file("src/foo.rs", "")
+        .file("Cargo.toml", &basic_bin_manifest("foo"))
+        .build();
 
-    assert_that(p.cargo_process("metadata"), execs().with_json(r#"
+    assert_that(p.cargo("metadata"), execs().with_json(r#"
     {
         "packages": [
             {
@@ -58,8 +59,8 @@ fn cargo_metadata_simple() {
 fn cargo_metadata_warns_on_implicit_version() {
     let p = project("foo")
         .file("src/foo.rs", "")
-        .file("Cargo.toml", &basic_bin_manifest("foo"));
-    p.build();
+        .file("Cargo.toml", &basic_bin_manifest("foo"))
+        .build();
 
     assert_that(p.cargo("metadata"),
                 execs().with_stderr("\
@@ -72,17 +73,18 @@ fn cargo_metadata_warns_on_implicit_version() {
 #[test]
 fn library_with_several_crate_types() {
     let p = project("foo")
-            .file("src/lib.rs", "")
-            .file("Cargo.toml", r#"
+        .file("src/lib.rs", "")
+        .file("Cargo.toml", r#"
 [package]
 name = "foo"
 version = "0.5.0"
 
 [lib]
 crate-type = ["lib", "staticlib"]
-            "#);
+            "#)
+        .build();
 
-    assert_that(p.cargo_process("metadata"), execs().with_json(r#"
+    assert_that(p.cargo("metadata"), execs().with_json(r#"
     {
         "packages": [
             {
@@ -144,11 +146,12 @@ fn cargo_metadata_with_deps_and_version() {
 
             [dependencies]
             bar = "*"
-        "#);
+        "#)
+        .build();
     Package::new("baz", "0.0.1").publish();
     Package::new("bar", "0.0.1").dep("baz", "0.0.1").publish();
 
-    assert_that(p.cargo_process("metadata")
+    assert_that(p.cargo("metadata")
                  .arg("-q")
                  .arg("--format-version").arg("1"),
                 execs().with_json(r#"
@@ -279,18 +282,19 @@ fn cargo_metadata_with_deps_and_version() {
 #[test]
 fn example() {
     let p = project("foo")
-            .file("src/lib.rs", "")
-            .file("examples/ex.rs", "")
-            .file("Cargo.toml", r#"
+        .file("src/lib.rs", "")
+        .file("examples/ex.rs", "")
+        .file("Cargo.toml", r#"
 [package]
 name = "foo"
 version = "0.1.0"
 
 [[example]]
 name = "ex"
-            "#);
+            "#)
+        .build();
 
-    assert_that(p.cargo_process("metadata"), execs().with_json(r#"
+    assert_that(p.cargo("metadata"), execs().with_json(r#"
     {
         "packages": [
             {
@@ -340,9 +344,9 @@ name = "ex"
 #[test]
 fn example_lib() {
     let p = project("foo")
-            .file("src/lib.rs", "")
-            .file("examples/ex.rs", "")
-            .file("Cargo.toml", r#"
+        .file("src/lib.rs", "")
+        .file("examples/ex.rs", "")
+        .file("Cargo.toml", r#"
 [package]
 name = "foo"
 version = "0.1.0"
@@ -350,9 +354,10 @@ version = "0.1.0"
 [[example]]
 name = "ex"
 crate-type = ["rlib", "dylib"]
-            "#);
+            "#)
+        .build();
 
-    assert_that(p.cargo_process("metadata"), execs().with_json(r#"
+    assert_that(p.cargo("metadata"), execs().with_json(r#"
     {
         "packages": [
             {
@@ -409,9 +414,10 @@ fn workspace_metadata() {
         .file("bar/Cargo.toml", &basic_lib_manifest("bar"))
         .file("bar/src/lib.rs", "")
         .file("baz/Cargo.toml", &basic_lib_manifest("baz"))
-        .file("baz/src/lib.rs", "");
+        .file("baz/src/lib.rs", "")
+        .build();
 
-    assert_that(p.cargo_process("metadata"), execs().with_status(0).with_json(r#"
+    assert_that(p.cargo("metadata"), execs().with_status(0).with_json(r#"
     {
         "packages": [
             {
@@ -484,9 +490,10 @@ fn workspace_metadata_no_deps() {
         .file("bar/Cargo.toml", &basic_lib_manifest("bar"))
         .file("bar/src/lib.rs", "")
         .file("baz/Cargo.toml", &basic_lib_manifest("baz"))
-        .file("baz/src/lib.rs", "");
+        .file("baz/src/lib.rs", "")
+        .build();
 
-    assert_that(p.cargo_process("metadata").arg("--no-deps"), execs().with_status(0).with_json(r#"
+    assert_that(p.cargo("metadata").arg("--no-deps"), execs().with_status(0).with_json(r#"
     {
         "packages": [
             {
@@ -540,9 +547,10 @@ fn workspace_metadata_no_deps() {
 #[test]
 fn cargo_metadata_with_invalid_manifest() {
     let p = project("foo")
-            .file("Cargo.toml", "");
+        .file("Cargo.toml", "")
+        .build();
 
-    assert_that(p.cargo_process("metadata").arg("--format-version").arg("1"),
+    assert_that(p.cargo("metadata").arg("--format-version").arg("1"),
                 execs().with_status(101).with_stderr("\
 [ERROR] failed to parse manifest at `[..]`
 
@@ -581,9 +589,10 @@ const MANIFEST_OUTPUT: &'static str=
 fn cargo_metadata_no_deps_path_to_cargo_toml_relative() {
     let p = project("foo")
         .file("Cargo.toml", &basic_bin_manifest("foo"))
-        .file("src/foo.rs", &main_file(r#""i am foo""#, &[]));
+        .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
+        .build();
 
-        assert_that(p.cargo_process("metadata").arg("--no-deps")
+        assert_that(p.cargo("metadata").arg("--no-deps")
                      .arg("--manifest-path").arg("foo/Cargo.toml")
                      .cwd(p.root().parent().unwrap()),
                     execs().with_status(0)
@@ -594,9 +603,10 @@ fn cargo_metadata_no_deps_path_to_cargo_toml_relative() {
 fn cargo_metadata_no_deps_path_to_cargo_toml_absolute() {
     let p = project("foo")
         .file("Cargo.toml", &basic_bin_manifest("foo"))
-        .file("src/foo.rs", &main_file(r#""i am foo""#, &[]));
+        .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
+        .build();
 
-    assert_that(p.cargo_process("metadata").arg("--no-deps")
+    assert_that(p.cargo("metadata").arg("--no-deps")
                  .arg("--manifest-path").arg(p.root().join("Cargo.toml"))
                  .cwd(p.root().parent().unwrap()),
                 execs().with_status(0)
@@ -607,9 +617,10 @@ fn cargo_metadata_no_deps_path_to_cargo_toml_absolute() {
 fn cargo_metadata_no_deps_path_to_cargo_toml_parent_relative() {
     let p = project("foo")
         .file("Cargo.toml", &basic_bin_manifest("foo"))
-        .file("src/foo.rs", &main_file(r#""i am foo""#, &[]));
+        .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
+        .build();
 
-    assert_that(p.cargo_process("metadata").arg("--no-deps")
+    assert_that(p.cargo("metadata").arg("--no-deps")
                  .arg("--manifest-path").arg("foo")
                  .cwd(p.root().parent().unwrap()),
                 execs().with_status(101)
@@ -621,9 +632,10 @@ fn cargo_metadata_no_deps_path_to_cargo_toml_parent_relative() {
 fn cargo_metadata_no_deps_path_to_cargo_toml_parent_absolute() {
     let p = project("foo")
         .file("Cargo.toml", &basic_bin_manifest("foo"))
-        .file("src/foo.rs", &main_file(r#""i am foo""#, &[]));
+        .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
+        .build();
 
-    assert_that(p.cargo_process("metadata").arg("--no-deps")
+    assert_that(p.cargo("metadata").arg("--no-deps")
                  .arg("--manifest-path").arg(p.root())
                  .cwd(p.root().parent().unwrap()),
                 execs().with_status(101)
@@ -635,9 +647,10 @@ fn cargo_metadata_no_deps_path_to_cargo_toml_parent_absolute() {
 fn cargo_metadata_no_deps_cwd() {
     let p = project("foo")
         .file("Cargo.toml", &basic_bin_manifest("foo"))
-        .file("src/foo.rs", &main_file(r#""i am foo""#, &[]));
+        .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
+        .build();
 
-    assert_that(p.cargo_process("metadata").arg("--no-deps")
+    assert_that(p.cargo("metadata").arg("--no-deps")
                  .cwd(p.root()),
                 execs().with_status(0)
                        .with_json(MANIFEST_OUTPUT));
@@ -647,9 +660,10 @@ fn cargo_metadata_no_deps_cwd() {
 fn cargo_metadata_bad_version() {
     let p = project("foo")
         .file("Cargo.toml", &basic_bin_manifest("foo"))
-        .file("src/foo.rs", &main_file(r#""i am foo""#, &[]));
+        .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
+        .build();
 
-    assert_that(p.cargo_process("metadata").arg("--no-deps")
+    assert_that(p.cargo("metadata").arg("--no-deps")
                  .arg("--format-version").arg("2")
                  .cwd(p.root()),
                 execs().with_status(101)
@@ -669,9 +683,10 @@ fn multiple_features() {
             a = []
             b = []
         "#)
-        .file("src/lib.rs", "");
+        .file("src/lib.rs", "")
+        .build();
 
-    assert_that(p.cargo_process("metadata")
+    assert_that(p.cargo("metadata")
                  .arg("--features").arg("a b"),
                 execs().with_status(0));
 }

--- a/tests/net-config.rs
+++ b/tests/net-config.rs
@@ -21,9 +21,10 @@ fn net_retry_loads_from_config() {
         retry=1
         [http]
         timeout=1
-         "#);
+         "#)
+        .build();
 
-    assert_that(p.cargo_process("build").arg("-v"),
+    assert_that(p.cargo("build").arg("-v"),
                 execs().with_status(101)
                 .with_stderr_contains("[WARNING] spurious network error \
 (1 tries remaining): [..]"));
@@ -45,9 +46,10 @@ fn net_retry_git_outputs_warning() {
         [http]
         timeout=1
          "#)
-        .file("src/main.rs", "");
+        .file("src/main.rs", "")
+        .build();
 
-    assert_that(p.cargo_process("build").arg("-v").arg("-j").arg("1"),
+    assert_that(p.cargo("build").arg("-v").arg("-j").arg("1"),
                 execs().with_status(101)
                 .with_stderr_contains("[WARNING] spurious network error \
 (2 tries remaining): [..]")

--- a/tests/overrides.rs
+++ b/tests/overrides.rs
@@ -18,8 +18,8 @@ fn override_simple() {
             version = "0.1.0"
             authors = []
         "#)
-        .file("src/lib.rs", "pub fn foo() {}");
-    foo.build();
+        .file("src/lib.rs", "pub fn foo() {}")
+        .build();
 
     let p = project("local")
         .file("Cargo.toml", &format!(r#"
@@ -39,9 +39,10 @@ fn override_simple() {
             pub fn bar() {
                 foo::foo();
             }
-        ");
+        ")
+        .build();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(0).with_stderr("\
 [UPDATING] registry `file://[..]`
 [UPDATING] git repository `[..]`
@@ -66,9 +67,10 @@ fn missing_version() {
             [replace]
             foo = { git = 'https://example.com' }
         "#)
-        .file("src/lib.rs", "");
+        .file("src/lib.rs", "")
+        .build();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(101).with_stderr("\
 error: failed to parse manifest at `[..]`
 
@@ -92,9 +94,10 @@ fn invalid_semver_version() {
             [replace]
             "foo:*" = { git = 'https://example.com' }
         "#)
-        .file("src/lib.rs", "");
+        .file("src/lib.rs", "")
+        .build();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(101).with_stderr_contains("\
 error: failed to parse manifest at `[..]`
 
@@ -121,9 +124,10 @@ fn different_version() {
             [replace]
             "foo:0.1.0" = "0.2.0"
         "#)
-        .file("src/lib.rs", "");
+        .file("src/lib.rs", "")
+        .build();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(101).with_stderr("\
 error: failed to parse manifest at `[..]`
 
@@ -147,8 +151,8 @@ fn transitive() {
             version = "0.1.0"
             authors = []
         "#)
-        .file("src/lib.rs", "pub fn foo() {}");
-    foo.build();
+        .file("src/lib.rs", "pub fn foo() {}")
+        .build();
 
     let p = project("local")
         .file("Cargo.toml", &format!(r#"
@@ -163,9 +167,10 @@ fn transitive() {
             [replace]
             "foo:0.1.0" = {{ git = '{}' }}
         "#, foo.url()))
-        .file("src/lib.rs", "");
+        .file("src/lib.rs", "")
+        .build();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(0).with_stderr("\
 [UPDATING] registry `file://[..]`
 [UPDATING] git repository `[..]`
@@ -190,8 +195,8 @@ fn persists_across_rebuilds() {
             version = "0.1.0"
             authors = []
         "#)
-        .file("src/lib.rs", "pub fn foo() {}");
-    foo.build();
+        .file("src/lib.rs", "pub fn foo() {}")
+        .build();
 
     let p = project("local")
         .file("Cargo.toml", &format!(r#"
@@ -211,9 +216,10 @@ fn persists_across_rebuilds() {
             pub fn bar() {
                 foo::foo();
             }
-        ");
+        ")
+        .build();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(0).with_stderr("\
 [UPDATING] registry `file://[..]`
 [UPDATING] git repository `file://[..]`
@@ -230,7 +236,7 @@ fn persists_across_rebuilds() {
 fn replace_registry_with_path() {
     Package::new("foo", "0.1.0").publish();
 
-    project("foo")
+    let _ = project("foo")
         .file("Cargo.toml", r#"
             [package]
             name = "foo"
@@ -258,9 +264,10 @@ fn replace_registry_with_path() {
             pub fn bar() {
                 foo::foo();
             }
-        ");
+        ")
+        .build();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(0).with_stderr("\
 [UPDATING] registry `file://[..]`
 [COMPILING] foo v0.1.0 (file://[..])
@@ -290,8 +297,8 @@ fn use_a_spec_to_select() {
             version = "0.2.0"
             authors = []
         "#)
-        .file("src/lib.rs", "pub fn foo3() {}");
-    foo.build();
+        .file("src/lib.rs", "pub fn foo3() {}")
+        .build();
 
     let p = project("local")
         .file("Cargo.toml", &format!(r#"
@@ -315,9 +322,10 @@ fn use_a_spec_to_select() {
                 foo::foo1();
                 bar::bar();
             }
-        ");
+        ")
+        .build();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(0).with_stderr("\
 [UPDATING] registry `file://[..]`
 [UPDATING] git repository `[..]`
@@ -346,8 +354,8 @@ fn override_adds_some_deps() {
             [dependencies]
             foo = "0.1"
         "#)
-        .file("src/lib.rs", "");
-    foo.build();
+        .file("src/lib.rs", "")
+        .build();
 
     let p = project("local")
         .file("Cargo.toml", &format!(r#"
@@ -362,9 +370,10 @@ fn override_adds_some_deps() {
             [replace]
             "bar:0.1.0" = {{ git = '{}' }}
         "#, foo.url()))
-        .file("src/lib.rs", "");
+        .file("src/lib.rs", "")
+        .build();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(0).with_stderr("\
 [UPDATING] registry `file://[..]`
 [UPDATING] git repository `[..]`
@@ -409,8 +418,8 @@ fn locked_means_locked_yes_no_seriously_i_mean_locked() {
             [dependencies]
             foo = "*"
         "#)
-        .file("src/lib.rs", "");
-    foo.build();
+        .file("src/lib.rs", "")
+        .build();
 
     let p = project("local")
         .file("Cargo.toml", &format!(r#"
@@ -426,9 +435,10 @@ fn locked_means_locked_yes_no_seriously_i_mean_locked() {
             [replace]
             "bar:0.1.0" = {{ git = '{}' }}
         "#, foo.url()))
-        .file("src/lib.rs", "");
+        .file("src/lib.rs", "")
+        .build();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(0));
 
     assert_that(p.cargo("build"), execs().with_status(0).with_stdout(""));
@@ -446,8 +456,8 @@ fn override_wrong_name() {
             version = "0.1.0"
             authors = []
         "#)
-        .file("src/lib.rs", "");
-    foo.build();
+        .file("src/lib.rs", "")
+        .build();
 
     let p = project("local")
         .file("Cargo.toml", &format!(r#"
@@ -462,9 +472,10 @@ fn override_wrong_name() {
             [replace]
             "foo:0.1.0" = {{ git = '{}' }}
         "#, foo.url()))
-        .file("src/lib.rs", "");
+        .file("src/lib.rs", "")
+        .build();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(101).with_stderr("\
 [UPDATING] registry [..]
 [UPDATING] git repository [..]
@@ -479,8 +490,8 @@ fn override_with_nothing() {
     Package::new("foo", "0.1.0").publish();
 
     let foo = git::repo(&paths::root().join("override"))
-        .file("src/lib.rs", "");
-    foo.build();
+        .file("src/lib.rs", "")
+        .build();
 
     let p = project("local")
         .file("Cargo.toml", &format!(r#"
@@ -495,9 +506,10 @@ fn override_with_nothing() {
             [replace]
             "foo:0.1.0" = {{ git = '{}' }}
         "#, foo.url()))
-        .file("src/lib.rs", "");
+        .file("src/lib.rs", "")
+        .build();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(101).with_stderr("\
 [UPDATING] registry [..]
 [UPDATING] git repository [..]
@@ -523,9 +535,10 @@ fn override_wrong_version() {
             [replace]
             "foo:0.1.0" = { git = 'https://example.com', version = '0.2.0' }
         "#)
-        .file("src/lib.rs", "");
+        .file("src/lib.rs", "")
+        .build();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(101).with_stderr("\
 error: failed to parse manifest at `[..]`
 
@@ -545,8 +558,8 @@ fn multiple_specs() {
             version = "0.1.0"
             authors = []
         "#)
-        .file("src/lib.rs", "pub fn foo() {}");
-    foo.build();
+        .file("src/lib.rs", "pub fn foo() {}")
+        .build();
 
     let p = project("local")
         .file("Cargo.toml", &format!(r#"
@@ -564,9 +577,10 @@ fn multiple_specs() {
             [replace."https://github.com/rust-lang/crates.io-index#foo:0.1.0"]
             git = '{0}'
         "#, foo.url()))
-        .file("src/lib.rs", "");
+        .file("src/lib.rs", "")
+        .build();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(101).with_stderr("\
 [UPDATING] registry [..]
 [UPDATING] git repository [..]
@@ -590,8 +604,8 @@ fn test_override_dep() {
             version = "0.1.0"
             authors = []
         "#)
-        .file("src/lib.rs", "pub fn foo() {}");
-    foo.build();
+        .file("src/lib.rs", "pub fn foo() {}")
+        .build();
 
     let p = project("local")
         .file("Cargo.toml", &format!(r#"
@@ -606,9 +620,10 @@ fn test_override_dep() {
             [replace]
             "foo:0.1.0" = {{ git = '{0}' }}
         "#, foo.url()))
-        .file("src/lib.rs", "");
+        .file("src/lib.rs", "")
+        .build();
 
-    assert_that(p.cargo_process("test").arg("-p").arg("foo"),
+    assert_that(p.cargo("test").arg("-p").arg("foo"),
                 execs().with_status(101)
                        .with_stderr_contains("\
 error: There are multiple `foo` packages in your project, and the [..]
@@ -629,8 +644,8 @@ fn update() {
             version = "0.1.0"
             authors = []
         "#)
-        .file("src/lib.rs", "pub fn foo() {}");
-    foo.build();
+        .file("src/lib.rs", "pub fn foo() {}")
+        .build();
 
     let p = project("local")
         .file("Cargo.toml", &format!(r#"
@@ -645,9 +660,10 @@ fn update() {
             [replace]
             "foo:0.1.0" = {{ git = '{0}' }}
         "#, foo.url()))
-        .file("src/lib.rs", "");
+        .file("src/lib.rs", "")
+        .build();
 
-    assert_that(p.cargo_process("generate-lockfile"),
+    assert_that(p.cargo("generate-lockfile"),
                 execs().with_status(0));
     assert_that(p.cargo("update"),
                 execs().with_status(0)
@@ -683,9 +699,8 @@ fn no_override_self() {
         .file("near/src/lib.rs", r#"
             #![no_std]
             pub extern crate far;
-        "#);
-
-    deps.build();
+        "#)
+        .build();
 
     let p = project("local")
         .file("Cargo.toml", &format!(r#"
@@ -703,9 +718,10 @@ fn no_override_self() {
         .file("src/lib.rs", r#"
             #![no_std]
             pub extern crate near;
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("build").arg("--verbose"),
+    assert_that(p.cargo("build").arg("--verbose"),
                 execs().with_status(0));
 }
 
@@ -747,9 +763,10 @@ fn broken_path_override_warns() {
         .file("a2/src/lib.rs", "")
         .file(".cargo/config", r#"
             paths = ["a2"]
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(0)
                        .with_stderr("\
 [UPDATING] [..]
@@ -870,9 +887,10 @@ fn override_an_override() {
         "#)
         .file("serde/src/lib.rs", "
             pub fn serde08_override() {}
-        ");
+        ")
+        .build();
 
-    assert_that(p.cargo_process("build").arg("-v"),
+    assert_that(p.cargo("build").arg("-v"),
                 execs().with_status(0));
 }
 
@@ -898,8 +916,8 @@ fn overriding_nonexistent_no_spurious() {
             version = "0.1.0"
             authors = []
         "#)
-        .file("bar/src/lib.rs", "pub fn foo() {}");
-    foo.build();
+        .file("bar/src/lib.rs", "pub fn foo() {}")
+        .build();
 
 
     let p = project("local")
@@ -916,9 +934,10 @@ fn overriding_nonexistent_no_spurious() {
             "foo:0.1.0" = {{ git = '{url}' }}
             "bar:0.1.0" = {{ git = '{url}' }}
         "#, url = foo.url()))
-        .file("src/lib.rs", "");
+        .file("src/lib.rs", "")
+        .build();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(0));
     assert_that(p.cargo("build"),
                 execs().with_status(0).with_stderr("\
@@ -959,8 +978,8 @@ fn no_warnings_when_replace_is_used_in_another_workspace_member() {
             name = "foo"
             version = "0.1.0"
         "#)
-        .file("local_foo/src/lib.rs", "");
-    p.build();
+        .file("local_foo/src/lib.rs", "")
+        .build();
 
     assert_that(p.cargo("build").cwd(p.root().join("first_crate")),
                 execs().with_status(0)
@@ -1015,9 +1034,10 @@ fn override_to_path_dep() {
         .file("foo/bar/src/lib.rs", "")
         .file(".cargo/config", r#"
             paths = ["foo"]
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(0));
 }
 
@@ -1062,9 +1082,10 @@ fn replace_to_path_dep() {
             version = "0.1.0"
             authors = []
         "#)
-        .file("foo/bar/src/lib.rs", "pub fn bar() {}");
+        .file("foo/bar/src/lib.rs", "pub fn bar() {}")
+        .build();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(0));
 }
 
@@ -1105,9 +1126,10 @@ fn paths_ok_with_optional() {
         .file("foo2/src/lib.rs", "")
         .file(".cargo/config", r#"
             paths = ["foo2"]
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(0).with_stderr("\
 [COMPILING] foo v0.1.0 ([..]foo2)
 [COMPILING] local v0.0.1 ([..])
@@ -1149,9 +1171,10 @@ fn paths_add_optional_bad() {
         .file("foo2/src/lib.rs", "")
         .file(".cargo/config", r#"
             paths = ["foo2"]
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(0).with_stderr_contains("\
 warning: path override for crate `foo` has altered the original list of
 dependencies; the dependency on `bar` was either added or\
@@ -1210,9 +1233,10 @@ fn override_with_default_feature() {
             [dependencies]
             bar = { version = "0.1", default-features = false }
         "#)
-        .file("another2/src/lib.rs", "");
+        .file("another2/src/lib.rs", "")
+        .build();
 
-    assert_that(p.cargo_process("run"),
+    assert_that(p.cargo("run"),
                 execs().with_status(0));
 }
 
@@ -1243,9 +1267,10 @@ fn override_plus_dep() {
             [dependencies]
             foo = { path = ".." }
         "#)
-        .file("bar/src/lib.rs", "");
+        .file("bar/src/lib.rs", "")
+        .build();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(101).with_stderr_contains("\
 error: cyclic package dependency: [..]
 "));

--- a/tests/package.rs
+++ b/tests/package.rs
@@ -31,9 +31,10 @@ fn simple() {
         .file("src/main.rs", r#"
             fn main() { println!("hello"); }
         "#)
-        .file("src/bar.txt", ""); // should be ignored when packaging
+        .file("src/bar.txt", "") // should be ignored when packaging
+        .build();
 
-    assert_that(p.cargo_process("package"),
+    assert_that(p.cargo("package"),
                 execs().with_status(0).with_stderr(&format!("\
 [WARNING] manifest has no documentation[..]
 See [..]
@@ -79,8 +80,9 @@ fn metadata_warning() {
         "#)
         .file("src/main.rs", r#"
             fn main() {}
-        "#);
-    assert_that(p.cargo_process("package"),
+        "#)
+        .build();
+    assert_that(p.cargo("package"),
                 execs().with_status(0).with_stderr(&format!("\
 warning: manifest has no description, license, license-file, documentation, \
 homepage or repository.
@@ -102,8 +104,9 @@ See http://doc.crates.io/manifest.html#package-metadata for more info.
         "#)
         .file("src/main.rs", r#"
             fn main() {}
-        "#);
-    assert_that(p.cargo_process("package"),
+        "#)
+        .build();
+    assert_that(p.cargo("package"),
                 execs().with_status(0).with_stderr(&format!("\
 warning: manifest has no description, documentation, homepage or repository.
 See http://doc.crates.io/manifest.html#package-metadata for more info.
@@ -126,8 +129,9 @@ See http://doc.crates.io/manifest.html#package-metadata for more info.
         "#)
         .file("src/main.rs", r#"
             fn main() {}
-        "#);
-    assert_that(p.cargo_process("package"),
+        "#)
+        .build();
+    assert_that(p.cargo("package"),
                 execs().with_status(0).with_stderr(&format!("\
 [PACKAGING] foo v0.0.1 ({dir})
 [VERIFYING] foo v0.0.1 ({dir})
@@ -156,8 +160,8 @@ fn package_verbose() {
             version = "0.0.1"
             authors = []
         "#)
-        .file("a/src/lib.rs", "");
-    p.build();
+        .file("a/src/lib.rs", "")
+        .build();
     let mut cargo = cargo_process();
     cargo.cwd(p.root());
     assert_that(cargo.clone().arg("build"), execs().with_status(0));
@@ -195,8 +199,9 @@ fn package_verification() {
         "#)
         .file("src/main.rs", r#"
             fn main() {}
-        "#);
-    assert_that(p.cargo_process("build"),
+        "#)
+        .build();
+    assert_that(p.cargo("build"),
                 execs().with_status(0));
     assert_that(p.cargo("package"),
                 execs().with_status(0).with_stderr(&format!("\
@@ -231,9 +236,10 @@ fn path_dependency_no_version() {
             version = "0.0.1"
             authors = []
         "#)
-        .file("bar/src/lib.rs", "");
+        .file("bar/src/lib.rs", "")
+        .build();
 
-    assert_that(p.cargo_process("package"),
+    assert_that(p.cargo("package"),
                 execs().with_status(101).with_stderr("\
 [WARNING] manifest has no documentation, homepage or repository.
 See http://doc.crates.io/manifest.html#package-metadata for more info.
@@ -307,9 +313,9 @@ fn exclude() {
         .file("some_dir/dir_deep_3/some_dir/file", "")
         .file("some_dir/dir_deep_4/some_dir/file", "")
         .file("some_dir/dir_deep_5/some_dir/file", "")
-        ;
+        .build();
 
-    assert_that(p.cargo_process("package").arg("--no-verify").arg("-v"),
+    assert_that(p.cargo("package").arg("--no-verify").arg("-v"),
                 execs().with_status(0).with_stdout("").with_stderr("\
 [WARNING] manifest has no description[..]
 See http://doc.crates.io/manifest.html#package-metadata for more info.
@@ -390,9 +396,10 @@ fn include() {
         .file("src/main.rs", r#"
             fn main() { println!("hello"); }
         "#)
-        .file("src/bar.txt", ""); // should be ignored when packaging
+        .file("src/bar.txt", "") // should be ignored when packaging
+        .build();
 
-    assert_that(p.cargo_process("package").arg("--no-verify").arg("-v"),
+    assert_that(p.cargo("package").arg("--no-verify").arg("-v"),
                 execs().with_status(0).with_stderr("\
 [WARNING] manifest has no description[..]
 See http://doc.crates.io/manifest.html#package-metadata for more info.
@@ -416,9 +423,10 @@ fn package_lib_with_bin() {
             extern crate foo;
             fn main() {}
         "#)
-        .file("src/lib.rs", "");
+        .file("src/lib.rs", "")
+        .build();
 
-    assert_that(p.cargo_process("package").arg("-v"),
+    assert_that(p.cargo("package").arg("-v"),
                 execs().with_status(0));
 }
 
@@ -466,8 +474,8 @@ fn no_duplicates_from_modified_tracked_files() {
         "#)
         .file("src/main.rs", r#"
             fn main() {}
-        "#);
-    p.build();
+        "#)
+        .build();
     File::create(p.root().join("src/main.rs")).unwrap().write_all(br#"
             fn main() { println!("A change!"); }
         "#).unwrap();
@@ -500,9 +508,10 @@ fn ignore_nested() {
         // If a project happens to contain a copy of itself, we should
         // ignore it.
         .file("a_dir/nested/Cargo.toml", cargo_toml)
-        .file("a_dir/nested/src/main.rs", main_rs);
+        .file("a_dir/nested/src/main.rs", main_rs)
+        .build();
 
-    assert_that(p.cargo_process("package"),
+    assert_that(p.cargo("package"),
                 execs().with_status(0).with_stderr(&format!("\
 [WARNING] manifest has no documentation[..]
 See http://doc.crates.io/manifest.html#package-metadata for more info.
@@ -550,9 +559,10 @@ fn package_weird_characters() {
         .file("src/main.rs", r#"
             fn main() { println!("hello"); }
         "#)
-        .file("src/:foo", "");
+        .file("src/:foo", "")
+        .build();
 
-    assert_that(p.cargo_process("package"),
+    assert_that(p.cargo("package"),
                 execs().with_status(101).with_stderr("\
 warning: [..]
 See [..]
@@ -575,9 +585,10 @@ fn repackage_on_source_change() {
         "#)
         .file("src/main.rs", r#"
             fn main() { println!("hello"); }
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("package"),
+    assert_that(p.cargo("package"),
                 execs().with_status(0));
 
     // Add another source file
@@ -636,8 +647,8 @@ fn broken_symlink() {
         "#)
         .file("src/main.rs", r#"
             fn main() { println!("hello"); }
-        "#);
-    p.build();
+        "#)
+        .build();
     t!(fs::symlink("nowhere", &p.root().join("src/foo.rs")));
 
     assert_that(p.cargo("package").arg("-v"),
@@ -655,11 +666,10 @@ Caused by:
 
 #[test]
 fn do_not_package_if_repository_is_dirty() {
-    let p = project("foo");
-    p.build();
+    let p = project("foo").build();
 
     // Create a Git repository containing a minimal Rust project.
-    git::repo(&paths::root().join("foo"))
+    let _ = git::repo(&paths::root().join("foo"))
         .file("Cargo.toml", r#"
             [project]
             name = "foo"
@@ -731,9 +741,10 @@ fn generated_manifest() {
             version = "0.1.0"
             authors = []
         "#)
-        .file("bar/src/lib.rs", "");
+        .file("bar/src/lib.rs", "")
+        .build();
 
-    assert_that(p.cargo_process("package").arg("--no-verify"),
+    assert_that(p.cargo("package").arg("--no-verify"),
                 execs().with_status(0));
 
     let f = File::open(&p.root().join("target/package/foo-0.0.1.crate")).unwrap();
@@ -809,8 +820,8 @@ fn ignore_workspace_specifier() {
             authors = []
             workspace = ".."
         "#)
-        .file("bar/src/lib.rs", "");
-    p.build();
+        .file("bar/src/lib.rs", "")
+        .build();
 
     assert_that(p.cargo("package").arg("--no-verify").cwd(p.root().join("bar")),
                 execs().with_status(0));
@@ -861,8 +872,9 @@ fn package_two_kinds_of_deps() {
             other = "1.0"
             other1 = { version = "1.0" }
         "#)
-        .file("src/main.rs", "");
+        .file("src/main.rs", "")
+        .build();
 
-    assert_that(p.cargo_process("package").arg("--no-verify"),
+    assert_that(p.cargo("package").arg("--no-verify"),
                 execs().with_status(0));
 }

--- a/tests/patch.rs
+++ b/tests/patch.rs
@@ -55,9 +55,10 @@ fn replace() {
         "#)
         .file("foo/src/lib.rs", r#"
             pub fn foo() {}
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(0).with_stderr("\
 [UPDATING] registry `file://[..]`
 [DOWNLOADING] deep-foo v0.1.0 ([..])
@@ -102,9 +103,10 @@ fn nonexistent() {
         "#)
         .file("foo/src/lib.rs", r#"
             pub fn foo() {}
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(0).with_stderr("\
 [UPDATING] registry `file://[..]`
 [COMPILING] foo v0.1.0 (file://[..])
@@ -124,8 +126,8 @@ fn patch_git() {
             version = "0.1.0"
             authors = []
         "#)
-        .file("src/lib.rs", "");
-    foo.build();
+        .file("src/lib.rs", "")
+        .build();
 
     let p = project("bar")
         .file("Cargo.toml", &format!(r#"
@@ -154,9 +156,10 @@ fn patch_git() {
         "#)
         .file("foo/src/lib.rs", r#"
             pub fn foo() {}
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(0).with_stderr("\
 [UPDATING] git repository `file://[..]`
 [COMPILING] foo v0.1.0 (file://[..])
@@ -176,8 +179,8 @@ fn patch_to_git() {
             version = "0.1.0"
             authors = []
         "#)
-        .file("src/lib.rs", "pub fn foo() {}");
-    foo.build();
+        .file("src/lib.rs", "pub fn foo() {}")
+        .build();
 
     Package::new("foo", "0.1.0").publish();
 
@@ -199,9 +202,10 @@ fn patch_to_git() {
             pub fn bar() {
                 foo::foo();
             }
-        ");
+        ")
+        .build();
 
-    assert_that(p.cargo_process("build"),//.env("RUST_LOG", "cargo=trace"),
+    assert_that(p.cargo("build"),//.env("RUST_LOG", "cargo=trace"),
                 execs().with_status(0).with_stderr("\
 [UPDATING] git repository `file://[..]`
 [UPDATING] registry `file://[..]`
@@ -239,9 +243,10 @@ fn unused() {
         "#)
         .file("foo/src/lib.rs", r#"
             not rust code
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(0).with_stderr("\
 [UPDATING] registry `file://[..]`
 [DOWNLOADING] foo v0.1.0 [..]
@@ -273,8 +278,8 @@ fn unused_git() {
             version = "0.2.0"
             authors = []
         "#)
-        .file("src/lib.rs", "");
-    foo.build();
+        .file("src/lib.rs", "")
+        .build();
 
     let p = project("bar")
         .file("Cargo.toml", &format!(r#"
@@ -289,9 +294,10 @@ fn unused_git() {
             [patch.crates-io]
             foo = {{ git = '{}' }}
         "#, foo.url()))
-        .file("src/lib.rs", "");
+        .file("src/lib.rs", "")
+        .build();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(0).with_stderr("\
 [UPDATING] git repository `file://[..]`
 [UPDATING] registry `file://[..]`
@@ -325,9 +331,10 @@ fn add_patch() {
             version = "0.1.0"
             authors = []
         "#)
-        .file("foo/src/lib.rs", r#""#);
+        .file("foo/src/lib.rs", r#""#)
+        .build();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(0).with_stderr("\
 [UPDATING] registry `file://[..]`
 [DOWNLOADING] foo v0.1.0 [..]
@@ -382,9 +389,10 @@ fn add_ignored_patch() {
             version = "0.1.1"
             authors = []
         "#)
-        .file("foo/src/lib.rs", r#""#);
+        .file("foo/src/lib.rs", r#""#)
+        .build();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(0).with_stderr("\
 [UPDATING] registry `file://[..]`
 [DOWNLOADING] foo v0.1.0 [..]
@@ -440,9 +448,10 @@ fn new_minor() {
             version = "0.1.1"
             authors = []
         "#)
-        .file("foo/src/lib.rs", r#""#);
+        .file("foo/src/lib.rs", r#""#)
+        .build();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(0).with_stderr("\
 [UPDATING] registry `file://[..]`
 [COMPILING] foo v0.1.1 [..]
@@ -485,9 +494,10 @@ fn transitive_new_minor() {
             version = "0.1.1"
             authors = []
         "#)
-        .file("foo/src/lib.rs", r#""#);
+        .file("foo/src/lib.rs", r#""#)
+        .build();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(0).with_stderr("\
 [UPDATING] registry `file://[..]`
 [COMPILING] foo v0.1.1 [..]
@@ -521,9 +531,10 @@ fn new_major() {
             version = "0.2.0"
             authors = []
         "#)
-        .file("foo/src/lib.rs", r#""#);
+        .file("foo/src/lib.rs", r#""#)
+        .build();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(0).with_stderr("\
 [UPDATING] registry `file://[..]`
 [COMPILING] foo v0.2.0 [..]
@@ -592,9 +603,10 @@ fn transitive_new_major() {
             version = "0.2.0"
             authors = []
         "#)
-        .file("foo/src/lib.rs", r#""#);
+        .file("foo/src/lib.rs", r#""#)
+        .build();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(0).with_stderr("\
 [UPDATING] registry `file://[..]`
 [COMPILING] foo v0.2.0 [..]
@@ -637,10 +649,11 @@ fn remove_patch() {
             version = "0.1.0"
             authors = []
         "#)
-        .file("bar/src/lib.rs", r#""#);
+        .file("bar/src/lib.rs", r#""#)
+        .build();
 
     // Generate a lock file where `bar` is unused
-    assert_that(p.cargo_process("build"), execs().with_status(0));
+    assert_that(p.cargo("build"), execs().with_status(0));
     let mut lock_file1 = String::new();
     File::open(p.root().join("Cargo.lock")).unwrap()
         .read_to_string(&mut lock_file1).unwrap();
@@ -696,9 +709,10 @@ fn non_crates_io() {
             version = "0.1.0"
             authors = []
         "#)
-        .file("foo/src/lib.rs", r#""#);
+        .file("foo/src/lib.rs", r#""#)
+        .build();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(101)
                        .with_stderr("\
 error: failed to parse manifest at `[..]`
@@ -729,9 +743,10 @@ fn replace_with_crates_io() {
             version = "0.1.0"
             authors = []
         "#)
-        .file("foo/src/lib.rs", r#""#);
+        .file("foo/src/lib.rs", r#""#)
+        .build();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(101)
                        .with_stderr("\
 [UPDATING] [..]
@@ -771,9 +786,10 @@ fn patch_in_virtual() {
             [dependencies]
             foo = "0.1"
         "#)
-        .file("bar/src/lib.rs", r#""#);
+        .file("bar/src/lib.rs", r#""#)
+        .build();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(0));
     assert_that(p.cargo("build"),
                 execs().with_status(0).with_stderr("\

--- a/tests/path.rs
+++ b/tests/path.rs
@@ -70,9 +70,10 @@ fn cargo_compile_with_nested_deps_shorthand() {
             pub fn gimme() -> String {
                 "test passed".to_string()
             }
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
         execs().with_status(0)
                .with_stderr(&format!("[COMPILING] baz v0.5.0 ({}/bar/baz)\n\
                                      [COMPILING] bar v0.5.0 ({}/bar)\n\
@@ -129,8 +130,9 @@ fn cargo_compile_with_root_dev_deps() {
             name = "foo"
         "#)
         .file("src/main.rs",
-              &main_file(r#""{}", bar::gimme()"#, &["bar"]));
-    let p2 = project("bar")
+              &main_file(r#""{}", bar::gimme()"#, &["bar"]))
+        .build();
+    let _p2 = project("bar")
         .file("Cargo.toml", r#"
             [package]
 
@@ -142,10 +144,10 @@ fn cargo_compile_with_root_dev_deps() {
             pub fn gimme() -> &'static str {
                 "zoidberg"
             }
-        "#);
+        "#)
+        .build();
 
-    p2.build();
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(101))
 }
 
@@ -168,8 +170,9 @@ fn cargo_compile_with_root_dev_deps_with_testing() {
             name = "foo"
         "#)
         .file("src/main.rs",
-              &main_file(r#""{}", bar::gimme()"#, &["bar"]));
-    let p2 = project("bar")
+              &main_file(r#""{}", bar::gimme()"#, &["bar"]))
+        .build();
+    let _p2 = project("bar")
         .file("Cargo.toml", r#"
             [package]
 
@@ -181,10 +184,10 @@ fn cargo_compile_with_root_dev_deps_with_testing() {
             pub fn gimme() -> &'static str {
                 "zoidberg"
             }
-        "#);
+        "#)
+        .build();
 
-    p2.build();
-    assert_that(p.cargo_process("test"),
+    assert_that(p.cargo("test"),
                 execs().with_stderr("\
 [COMPILING] [..] v0.5.0 ([..])
 [COMPILING] [..] v0.5.0 ([..])
@@ -229,9 +232,10 @@ fn cargo_compile_with_transitive_dev_deps() {
             pub fn gimme() -> &'static str {
                 "zoidberg"
             }
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
         execs().with_stderr(&format!("[COMPILING] bar v0.5.0 ({}/bar)\n\
                                      [COMPILING] foo v0.5.0 ({})\n\
                                      [FINISHED] dev [unoptimized + debuginfo] target(s) in \
@@ -274,9 +278,10 @@ fn no_rebuild_dependency() {
         "#)
         .file("bar/src/bar.rs", r#"
             pub fn bar() {}
-        "#);
+        "#)
+        .build();
     // First time around we should compile both foo and bar
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_stderr(&format!("[COMPILING] bar v0.5.0 ({}/bar)\n\
                                              [COMPILING] foo v0.5.0 ({})\n\
                                              [FINISHED] dev [unoptimized + debuginfo] target(s) \
@@ -299,8 +304,7 @@ fn no_rebuild_dependency() {
 
 #[test]
 fn deep_dependencies_trigger_rebuild() {
-    let mut p = project("foo");
-    p = p
+    let p = project("foo")
         .file("Cargo.toml", r#"
             [project]
 
@@ -343,8 +347,9 @@ fn deep_dependencies_trigger_rebuild() {
         "#)
         .file("baz/src/baz.rs", r#"
             pub fn baz() {}
-        "#);
-    assert_that(p.cargo_process("build"),
+        "#)
+        .build();
+    assert_that(p.cargo("build"),
                 execs().with_stderr(&format!("[COMPILING] baz v0.5.0 ({}/baz)\n\
                                              [COMPILING] bar v0.5.0 ({}/bar)\n\
                                              [COMPILING] foo v0.5.0 ({})\n\
@@ -392,8 +397,7 @@ fn deep_dependencies_trigger_rebuild() {
 
 #[test]
 fn no_rebuild_two_deps() {
-    let mut p = project("foo");
-    p = p
+    let p = project("foo")
         .file("Cargo.toml", r#"
             [project]
 
@@ -437,8 +441,9 @@ fn no_rebuild_two_deps() {
         "#)
         .file("baz/src/baz.rs", r#"
             pub fn baz() {}
-        "#);
-    assert_that(p.cargo_process("build"),
+        "#)
+        .build();
+    assert_that(p.cargo("build"),
                 execs().with_stderr(&format!("[COMPILING] baz v0.5.0 ({}/baz)\n\
                                              [COMPILING] bar v0.5.0 ({}/bar)\n\
                                              [COMPILING] foo v0.5.0 ({})\n\
@@ -481,10 +486,11 @@ fn nested_deps_recompile() {
 
             name = "bar"
         "#)
-        .file("src/bar/src/bar.rs", "pub fn gimme() -> i32 { 92 }");
+        .file("src/bar/src/bar.rs", "pub fn gimme() -> i32 { 92 }")
+        .build();
     let bar = p.url();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_stderr(&format!("[COMPILING] bar v0.5.0 ({}/src/bar)\n\
                                              [COMPILING] foo v0.5.0 ({})\n\
                                              [FINISHED] dev [unoptimized + debuginfo] target(s) \
@@ -520,9 +526,10 @@ fn error_message_for_missing_manifest() {
             path = "src/bar"
         "#)
         .file("src/lib.rs", "")
-        .file("src/bar/not-a-manifest", "");
+        .file("src/bar/not-a-manifest", "")
+        .build();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(101)
                        .with_stderr("\
 [ERROR] failed to load source for a dependency on `bar`
@@ -549,7 +556,8 @@ fn override_relative() {
             version = "0.5.0"
             authors = ["wycats@example.com"]
         "#)
-       .file("src/lib.rs", "");
+       .file("src/lib.rs", "")
+        .build();
 
     fs::create_dir(&paths::root().join(".cargo")).unwrap();
     File::create(&paths::root().join(".cargo/config")).unwrap()
@@ -566,9 +574,9 @@ fn override_relative() {
             [dependencies.bar]
             path = '{}'
         "#, bar.root().display()))
-       .file("src/lib.rs", "");
-    bar.build();
-    assert_that(p.cargo_process("build").arg("-v"), execs().with_status(0));
+       .file("src/lib.rs", "")
+       .build();
+    assert_that(p.cargo("build").arg("-v"), execs().with_status(0));
 
 }
 
@@ -582,7 +590,8 @@ fn override_self() {
             version = "0.5.0"
             authors = ["wycats@example.com"]
         "#)
-       .file("src/lib.rs", "");
+        .file("src/lib.rs", "")
+        .build();
 
     let p = project("foo");
     let root = p.root().clone();
@@ -602,11 +611,10 @@ fn override_self() {
 
         "#, bar.root().display()))
        .file("src/lib.rs", "")
-       .file("src/main.rs", "fn main() {}");
+       .file("src/main.rs", "fn main() {}")
+       .build();
 
-    bar.build();
-    assert_that(p.cargo_process("build"), execs().with_status(0));
-
+    assert_that(p.cargo("build"), execs().with_status(0));
 }
 
 #[test]
@@ -628,7 +636,8 @@ fn override_path_dep() {
             version = "0.5.0"
             authors = []
        "#)
-       .file("p2/src/lib.rs", "");
+        .file("p2/src/lib.rs", "")
+        .build();
 
     let p = project("foo")
         .file(".cargo/config", &format!(r#"
@@ -646,10 +655,10 @@ fn override_path_dep() {
             path = '{}'
 
         "#, bar.root().join("p2").display()))
-       .file("src/lib.rs", "");
+       .file("src/lib.rs", "")
+       .build();
 
-    bar.build();
-    assert_that(p.cargo_process("build").arg("-v"),
+    assert_that(p.cargo("build").arg("-v"),
                 execs().with_status(0));
 
 }
@@ -691,9 +700,7 @@ fn path_dep_build_cmd() {
         "#)
         .file("bar/src/bar.rs.in", r#"
             pub fn gimme() -> i32 { 0 }
-        "#);
-
-    p.build();
+        "#).build();
     p.root().join("bar").move_into_the_past();
 
     assert_that(p.cargo("build"),
@@ -754,8 +761,8 @@ fn dev_deps_no_rebuild_lib() {
             version = "0.5.0"
             authors = ["wycats@example.com"]
         "#)
-        .file("bar/src/lib.rs", "pub fn bar() {}");
-    p.build();
+        .file("bar/src/lib.rs", "pub fn bar() {}")
+        .build();
     assert_that(p.cargo("build")
                  .env("FOO", "bar"),
                 execs().with_status(0)
@@ -803,8 +810,8 @@ fn custom_target_no_rebuild() {
             [dependencies]
             a = { path = "../a" }
         "#)
-        .file("b/src/lib.rs", "");
-    p.build();
+        .file("b/src/lib.rs", "")
+        .build();
     assert_that(p.cargo("build"),
                 execs().with_status(0)
                        .with_stderr("\
@@ -855,8 +862,8 @@ fn override_and_depend() {
         .file("b/src/lib.rs", "")
         .file("b/.cargo/config", r#"
             paths = ["../a"]
-        "#);
-    p.build();
+        "#)
+        .build();
     assert_that(p.cargo("build").cwd(p.root().join("b")),
                 execs().with_status(0)
                        .with_stderr("\
@@ -879,8 +886,8 @@ fn missing_path_dependency() {
         .file("src/lib.rs", "")
         .file(".cargo/config", r#"
             paths = ["../whoa-this-does-not-exist"]
-        "#);
-    p.build();
+        "#)
+        .build();
     assert_that(p.cargo("build"),
                 execs().with_status(101)
                        .with_stderr("\
@@ -921,8 +928,8 @@ fn invalid_path_dep_in_workspace_with_lockfile() {
             [dependencies]
             bar = "*"
         "#)
-        .file("foo/src/lib.rs", "");
-    p.build();
+        .file("foo/src/lib.rs", "")
+        .build();
 
     // Generate a lock file
     assert_that(p.cargo("build"), execs().with_status(0));
@@ -970,8 +977,8 @@ fn workspace_produces_rlib() {
             version = "0.5.0"
             authors = []
         "#)
-        .file("foo/src/lib.rs", "");
-    p.build();
+        .file("foo/src/lib.rs", "")
+        .build();
 
     assert_that(p.cargo("build"), execs().with_status(0));
 

--- a/tests/plugins.rs
+++ b/tests/plugins.rs
@@ -37,8 +37,9 @@ fn plugin_to_the_max() {
             #![plugin(bar)]
 
             pub fn foo() {}
-        "#);
-    let bar = project("bar")
+        "#)
+        .build();
+    let _bar = project("bar")
         .file("Cargo.toml", r#"
             [package]
             name = "bar"
@@ -64,8 +65,9 @@ fn plugin_to_the_max() {
             pub fn foo(_reg: &mut Registry) {
                 println!("{}", baz::baz());
             }
-        "#);
-    let baz = project("baz")
+        "#)
+        .build();
+    let _baz = project("baz")
         .file("Cargo.toml", r#"
             [package]
             name = "baz"
@@ -76,11 +78,10 @@ fn plugin_to_the_max() {
             name = "baz"
             crate_type = ["dylib"]
         "#)
-        .file("src/lib.rs", "pub fn baz() -> i32 { 1 }");
-    bar.build();
-    baz.build();
+        .file("src/lib.rs", "pub fn baz() -> i32 { 1 }")
+        .build();
 
-    assert_that(foo.cargo_process("build"),
+    assert_that(foo.cargo("build"),
                 execs().with_status(0));
     assert_that(foo.cargo("doc"),
                 execs().with_status(0));
@@ -94,8 +95,8 @@ fn plugin_with_dynamic_native_dependency() {
         .file("Cargo.toml", r#"
             [workspace]
             members = ["builder", "foo"]
-        "#);
-    workspace.build();
+        "#)
+        .build();
 
     let build = project("ws/builder")
         .file("Cargo.toml", r#"
@@ -111,8 +112,8 @@ fn plugin_with_dynamic_native_dependency() {
         .file("src/lib.rs", r#"
             #[no_mangle]
             pub extern fn foo() {}
-        "#);
-    build.build();
+        "#)
+        .build();
 
     let foo = project("ws/foo")
         .file("Cargo.toml", r#"
@@ -164,8 +165,8 @@ fn plugin_with_dynamic_native_dependency() {
             pub fn bar(_reg: &mut Registry) {
                 unsafe { foo() }
             }
-        "#);
-    foo.build();
+        "#)
+        .build();
 
     assert_that(build.cargo("build"),
                 execs().with_status(0));
@@ -198,9 +199,10 @@ fn plugin_integration() {
         "#)
         .file("build.rs", "fn main() {}")
         .file("src/lib.rs", "")
-        .file("tests/it_works.rs", "");
+        .file("tests/it_works.rs", "")
+        .build();
 
-    assert_that(p.cargo_process("test").arg("-v"),
+    assert_that(p.cargo("test").arg("-v"),
                 execs().with_status(0));
 }
 
@@ -232,9 +234,10 @@ fn doctest_a_plugin() {
         "#)
         .file("bar/src/lib.rs", r#"
             pub fn bar() {}
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("test").arg("-v"),
+    assert_that(p.cargo("test").arg("-v"),
                 execs().with_status(0));
 }
 
@@ -243,7 +246,7 @@ fn doctest_a_plugin() {
 fn native_plugin_dependency_with_custom_ar_linker() {
     let target = rustc_host();
 
-    let foo = project("foo")
+    let _foo = project("foo")
         .file("Cargo.toml", r#"
             [package]
             name = "foo"
@@ -253,7 +256,8 @@ fn native_plugin_dependency_with_custom_ar_linker() {
             [lib]
             plugin = true
         "#)
-        .file("src/lib.rs", "");
+        .file("src/lib.rs", "")
+        .build();
 
     let bar = project("bar")
         .file("Cargo.toml", r#"
@@ -270,10 +274,10 @@ fn native_plugin_dependency_with_custom_ar_linker() {
             [target.{}]
             ar = "nonexistent-ar"
             linker = "nonexistent-linker"
-        "#, target));
+        "#, target))
+        .build();
 
-    foo.build();
-    assert_that(bar.cargo_process("build").arg("--verbose"),
+    assert_that(bar.cargo("build").arg("--verbose"),
                 execs().with_stderr_contains("\
 [COMPILING] foo v0.0.1 ([..])
 [RUNNING] `rustc [..] -C ar=nonexistent-ar -C linker=nonexistent-linker [..]`
@@ -287,7 +291,7 @@ fn panic_abort_plugins() {
         return
     }
 
-    let bar = project("bar")
+    let p = project("bar")
         .file("Cargo.toml", r#"
             [package]
             name = "bar"
@@ -313,9 +317,10 @@ fn panic_abort_plugins() {
         .file("foo/src/lib.rs", r#"
             #![feature(rustc_private)]
             extern crate syntax;
-        "#);
+        "#)
+        .build();
 
-    assert_that(bar.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(0));
 }
 
@@ -325,7 +330,7 @@ fn shared_panic_abort_plugins() {
         return
     }
 
-    let bar = project("top")
+    let p = project("top")
         .file("Cargo.toml", r#"
             [package]
             name = "top"
@@ -365,8 +370,9 @@ fn shared_panic_abort_plugins() {
             version = "0.0.1"
             authors = []
         "#)
-        .file("bar/src/lib.rs", "");
+        .file("bar/src/lib.rs", "")
+        .build();
 
-    assert_that(bar.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(0));
 }

--- a/tests/proc-macro.rs
+++ b/tests/proc-macro.rs
@@ -31,8 +31,9 @@ fn probe_cfg_before_crate_type_discovery() {
             struct X;
 
             fn main() {}
-        "#);
-    let noop = project("noop")
+        "#)
+        .build();
+    let _noop = project("noop")
         .file("Cargo.toml", r#"
             [package]
             name = "noop"
@@ -52,10 +53,10 @@ fn probe_cfg_before_crate_type_discovery() {
             pub fn noop(_input: TokenStream) -> TokenStream {
                 "".parse().unwrap()
             }
-        "#);
-    noop.build();
+        "#)
+        .build();
 
-    assert_that(client.cargo_process("build"),
+    assert_that(client.cargo("build"),
                 execs().with_status(0));
 }
 
@@ -85,8 +86,9 @@ fn noop() {
             struct X;
 
             fn main() {}
-        "#);
-    let noop = project("noop")
+        "#)
+        .build();
+    let _noop = project("noop")
         .file("Cargo.toml", r#"
             [package]
             name = "noop"
@@ -106,10 +108,10 @@ fn noop() {
             pub fn noop(_input: TokenStream) -> TokenStream {
                 "".parse().unwrap()
             }
-        "#);
-    noop.build();
+        "#)
+        .build();
 
-    assert_that(client.cargo_process("build"),
+    assert_that(client.cargo("build"),
                 execs().with_status(0));
     assert_that(client.cargo("build"),
                 execs().with_status(0));
@@ -149,8 +151,9 @@ fn impl_and_derive() {
                 assert!(x.impl_by_transmogrify());
                 println!("{:?}", x);
             }
-        "#);
-    let transmogrify = project("transmogrify")
+        "#)
+        .build();
+    let _transmogrify = project("transmogrify")
         .file("Cargo.toml", r#"
             [package]
             name = "transmogrify"
@@ -183,10 +186,10 @@ fn impl_and_derive() {
                     }
                 ".parse().unwrap()
             }
-        "#);
-    transmogrify.build();
+        "#)
+        .build();
 
-    assert_that(client.cargo_process("build"),
+    assert_that(client.cargo("build"),
                 execs().with_status(0));
     assert_that(client.cargo("run"),
                 execs().with_status(0).with_stdout("X { success: true }"));
@@ -226,10 +229,11 @@ fn plugin_and_proc_macro() {
             pub fn questionable(input: TokenStream) -> TokenStream {
                 input
             }
-        "#);
+        "#)
+        .build();
 
     let msg = "  lib.plugin and lib.proc-macro cannot both be true";
-    assert_that(questionable.cargo_process("build"),
+    assert_that(questionable.cargo("build"),
                 execs().with_status(101).with_stderr_contains(msg));
 }
 
@@ -267,9 +271,10 @@ pub fn derive(_input: TokenStream) -> TokenStream {
 fn a() {
   assert!(true);
 }
-"#);
+"#)
+        .build();
 
-    assert_that(foo.cargo_process("test"),
+    assert_that(foo.cargo("test"),
                 execs().with_status(0)
                        .with_stdout_contains("test a ... ok")
                        .with_stdout_contains_n("test [..] ... ok", 2));

--- a/tests/profiles.rs
+++ b/tests/profiles.rs
@@ -9,8 +9,7 @@ use hamcrest::assert_that;
 
 #[test]
 fn profile_overrides() {
-    let mut p = project("foo");
-    p = p
+    let p = project("foo")
         .file("Cargo.toml", r#"
             [package]
 
@@ -23,8 +22,9 @@ fn profile_overrides() {
             debug = false
             rpath = true
         "#)
-        .file("src/lib.rs", "");
-    assert_that(p.cargo_process("build").arg("-v"),
+        .file("src/lib.rs", "")
+        .build();
+    assert_that(p.cargo("build").arg("-v"),
                 execs().with_status(0).with_stderr(&format!("\
 [COMPILING] test v0.0.0 ({url})
 [RUNNING] `rustc --crate-name test src[/]lib.rs --crate-type lib \
@@ -44,8 +44,7 @@ url = p.url(),
 
 #[test]
 fn opt_level_override_0() {
-    let mut p = project("foo");
-    p = p
+    let p = project("foo")
         .file("Cargo.toml", r#"
             [package]
 
@@ -56,8 +55,9 @@ fn opt_level_override_0() {
             [profile.dev]
             opt-level = 0
         "#)
-        .file("src/lib.rs", "");
-    assert_that(p.cargo_process("build").arg("-v"),
+        .file("src/lib.rs", "")
+        .build();
+    assert_that(p.cargo("build").arg("-v"),
                 execs().with_status(0).with_stderr(&format!("\
 [COMPILING] test v0.0.0 ({url})
 [RUNNING] `rustc --crate-name test src[/]lib.rs --crate-type lib \
@@ -75,9 +75,7 @@ url = p.url()
 
 #[test]
 fn debug_override_1() {
-    let mut p = project("foo");
-
-    p = p
+    let p = project("foo")
         .file("Cargo.toml", r#"
             [package]
             name = "test"
@@ -87,8 +85,9 @@ fn debug_override_1() {
             [profile.dev]
             debug = 1
         "#)
-        .file("src/lib.rs", "");
-    assert_that(p.cargo_process("build").arg("-v"),
+        .file("src/lib.rs", "")
+        .build();
+    assert_that(p.cargo("build").arg("-v"),
                 execs().with_status(0).with_stderr(&format!("\
 [COMPILING] test v0.0.0 ({url})
 [RUNNING] `rustc --crate-name test src[/]lib.rs --crate-type lib \
@@ -105,8 +104,7 @@ url = p.url()
 }
 
 fn check_opt_level_override(profile_level: &str, rustc_level: &str) {
-    let mut p = project("foo");
-    p = p
+    let p = project("foo")
         .file("Cargo.toml", &format!(r#"
             [package]
 
@@ -117,8 +115,9 @@ fn check_opt_level_override(profile_level: &str, rustc_level: &str) {
             [profile.dev]
             opt-level = {level}
         "#, level = profile_level))
-        .file("src/lib.rs", "");
-    assert_that(p.cargo_process("build").arg("-v"),
+        .file("src/lib.rs", "")
+        .build();
+    assert_that(p.cargo("build").arg("-v"),
                 execs().with_status(0).with_stderr(&format!("\
 [COMPILING] test v0.0.0 ({url})
 [RUNNING] `rustc --crate-name test src[/]lib.rs --crate-type lib \
@@ -154,8 +153,7 @@ fn opt_level_overrides() {
 
 #[test]
 fn top_level_overrides_deps() {
-    let mut p = project("foo");
-    p = p
+    let p = project("foo")
         .file("Cargo.toml", r#"
             [package]
 
@@ -186,8 +184,9 @@ fn top_level_overrides_deps() {
             name = "foo"
             crate_type = ["dylib", "rlib"]
         "#)
-        .file("foo/src/lib.rs", "");
-    assert_that(p.cargo_process("build").arg("-v").arg("--release"),
+        .file("foo/src/lib.rs", "")
+        .build();
+    assert_that(p.cargo("build").arg("-v").arg("--release"),
                 execs().with_status(0).with_stderr(&format!("\
 [COMPILING] foo v0.0.0 ({url}/foo)
 [RUNNING] `rustc --crate-name foo foo[/]src[/]lib.rs \
@@ -244,9 +243,10 @@ fn profile_in_non_root_manifest_triggers_a_warning() {
             [profile.dev]
             opt-level = 1
         "#)
-        .file("bar/src/main.rs", "fn main() {}");
+        .file("bar/src/main.rs", "fn main() {}")
+        .build();
 
-    assert_that(p.cargo_process("build").cwd(p.root().join("bar")).arg("-v"),
+    assert_that(p.cargo("build").cwd(p.root().join("bar")).arg("-v"),
                 execs().with_status(0).with_stderr("\
 [WARNING] profiles for the non root package will be ignored, specify profiles at the workspace root:
 package:   [..]
@@ -275,9 +275,10 @@ fn profile_in_virtual_manifest_works() {
             authors = []
             workspace = ".."
         "#)
-        .file("bar/src/main.rs", "fn main() {}");
+        .file("bar/src/main.rs", "fn main() {}")
+        .build();
 
-    assert_that(p.cargo_process("build").cwd(p.root().join("bar")).arg("-v"),
+    assert_that(p.cargo("build").cwd(p.root().join("bar")).arg("-v"),
                 execs().with_status(0).with_stderr("\
 [COMPILING] bar v0.1.0 ([..])
 [RUNNING] `rustc [..]`

--- a/tests/publish.rs
+++ b/tests/publish.rs
@@ -27,9 +27,10 @@ fn simple() {
             license = "MIT"
             description = "foo"
         "#)
-        .file("src/main.rs", "fn main() {}");
+        .file("src/main.rs", "fn main() {}")
+        .build();
 
-    assert_that(p.cargo_process("publish").arg("--no-verify")
+    assert_that(p.cargo("publish").arg("--no-verify")
                  .arg("--index").arg(publish::registry().to_string()),
                 execs().with_status(0).with_stderr(&format!("\
 [UPDATING] registry `{reg}`
@@ -83,9 +84,10 @@ fn simple_with_host() {
             license = "MIT"
             description = "foo"
         "#)
-        .file("src/main.rs", "fn main() {}");
+        .file("src/main.rs", "fn main() {}")
+        .build();
 
-    assert_that(p.cargo_process("publish").arg("--no-verify")
+    assert_that(p.cargo("publish").arg("--no-verify")
                  .arg("--host").arg(publish::registry().to_string()),
                 execs().with_status(0).with_stderr(&format!("\
 [WARNING] The flag '--host' is no longer valid.
@@ -149,9 +151,10 @@ fn simple_with_index_and_host() {
             license = "MIT"
             description = "foo"
         "#)
-        .file("src/main.rs", "fn main() {}");
+        .file("src/main.rs", "fn main() {}")
+        .build();
 
-    assert_that(p.cargo_process("publish").arg("--no-verify")
+    assert_that(p.cargo("publish").arg("--no-verify")
                  .arg("--index").arg(publish::registry().to_string())
                  .arg("--host").arg(publish::registry().to_string()),
                 execs().with_status(0).with_stderr(&format!("\
@@ -217,9 +220,10 @@ fn git_deps() {
             [dependencies.foo]
             git = "git://path/to/nowhere"
         "#)
-        .file("src/main.rs", "fn main() {}");
+        .file("src/main.rs", "fn main() {}")
+        .build();
 
-    assert_that(p.cargo_process("publish").arg("-v").arg("--no-verify")
+    assert_that(p.cargo("publish").arg("-v").arg("--no-verify")
                  .arg("--index").arg(publish::registry().to_string()),
                 execs().with_status(101).with_stderr("\
 [UPDATING] registry [..]
@@ -254,9 +258,10 @@ fn path_dependency_no_version() {
             version = "0.0.1"
             authors = []
         "#)
-        .file("bar/src/lib.rs", "");
+        .file("bar/src/lib.rs", "")
+        .build();
 
-    assert_that(p.cargo_process("publish")
+    assert_that(p.cargo("publish")
                  .arg("--index").arg(publish::registry().to_string()),
                 execs().with_status(101).with_stderr("\
 [UPDATING] registry [..]
@@ -279,9 +284,10 @@ fn unpublishable_crate() {
             description = "foo"
             publish = false
         "#)
-        .file("src/main.rs", "fn main() {}");
+        .file("src/main.rs", "fn main() {}")
+        .build();
 
-    assert_that(p.cargo_process("publish")
+    assert_that(p.cargo("publish")
                  .arg("--index").arg(publish::registry().to_string()),
                 execs().with_status(101).with_stderr("\
 [ERROR] some crates cannot be published.
@@ -293,10 +299,10 @@ fn unpublishable_crate() {
 fn dont_publish_dirty() {
     publish::setup();
     let p = project("foo")
-        .file("bar", "");
-    p.build();
+        .file("bar", "")
+        .build();
 
-    repo(&paths::root().join("foo"))
+    let _ = repo(&paths::root().join("foo"))
         .file("Cargo.toml", r#"
             [project]
             name = "foo"
@@ -328,10 +334,9 @@ to proceed despite this, pass the `--allow-dirty` flag
 fn publish_clean() {
     publish::setup();
 
-    let p = project("foo");
-    p.build();
+    let p = project("foo").build();
 
-    repo(&paths::root().join("foo"))
+    let _ = repo(&paths::root().join("foo"))
         .file("Cargo.toml", r#"
             [project]
             name = "foo"
@@ -356,10 +361,10 @@ fn publish_in_sub_repo() {
     publish::setup();
 
     let p = project("foo")
-        .file("baz", "");
-    p.build();
+        .file("baz", "")
+        .build();
 
-    repo(&paths::root().join("foo"))
+    let _ = repo(&paths::root().join("foo"))
         .file("bar/Cargo.toml", r#"
             [project]
             name = "foo"
@@ -384,10 +389,10 @@ fn publish_when_ignored() {
     publish::setup();
 
     let p = project("foo")
-        .file("baz", "");
-    p.build();
+        .file("baz", "")
+        .build();
 
-    repo(&paths::root().join("foo"))
+    let _ = repo(&paths::root().join("foo"))
         .file("Cargo.toml", r#"
             [project]
             name = "foo"
@@ -413,10 +418,10 @@ fn ignore_when_crate_ignored() {
     publish::setup();
 
     let p = project("foo")
-        .file("bar/baz", "");
-    p.build();
+        .file("bar/baz", "")
+        .build();
 
-    repo(&paths::root().join("foo"))
+    let _ = repo(&paths::root().join("foo"))
         .file(".gitignore", "bar")
         .nocommit_file("bar/Cargo.toml", r#"
             [project]
@@ -440,10 +445,10 @@ fn new_crate_rejected() {
     publish::setup();
 
     let p = project("foo")
-        .file("baz", "");
-    p.build();
+        .file("baz", "")
+        .build();
 
-    repo(&paths::root().join("foo"))
+    let _ = repo(&paths::root().join("foo"))
         .nocommit_file("Cargo.toml", r#"
             [project]
             name = "foo"
@@ -474,9 +479,10 @@ fn dry_run() {
             license = "MIT"
             description = "foo"
         "#)
-        .file("src/main.rs", "fn main() {}");
+        .file("src/main.rs", "fn main() {}")
+        .build();
 
-    assert_that(p.cargo_process("publish").arg("--dry-run")
+    assert_that(p.cargo("publish").arg("--dry-run")
                  .arg("--index").arg(publish::registry().to_string()),
                 execs().with_status(0).with_stderr(&format!("\
 [UPDATING] registry `[..]`

--- a/tests/read-manifest.rs
+++ b/tests/read-manifest.rs
@@ -28,9 +28,10 @@ static MANIFEST_OUTPUT: &'static str = r#"
 fn cargo_read_manifest_path_to_cargo_toml_relative() {
     let p = project("foo")
         .file("Cargo.toml", &basic_bin_manifest("foo"))
-        .file("src/foo.rs", &main_file(r#""i am foo""#, &[]));
+        .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
+        .build();
 
-    assert_that(p.cargo_process("read-manifest")
+    assert_that(p.cargo("read-manifest")
                  .arg("--manifest-path").arg("foo/Cargo.toml")
                  .cwd(p.root().parent().unwrap()),
                 execs().with_status(0)
@@ -41,9 +42,10 @@ fn cargo_read_manifest_path_to_cargo_toml_relative() {
 fn cargo_read_manifest_path_to_cargo_toml_absolute() {
     let p = project("foo")
         .file("Cargo.toml", &basic_bin_manifest("foo"))
-        .file("src/foo.rs", &main_file(r#""i am foo""#, &[]));
+        .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
+        .build();
 
-    assert_that(p.cargo_process("read-manifest")
+    assert_that(p.cargo("read-manifest")
                  .arg("--manifest-path").arg(p.root().join("Cargo.toml"))
                  .cwd(p.root().parent().unwrap()),
                 execs().with_status(0)
@@ -54,9 +56,10 @@ fn cargo_read_manifest_path_to_cargo_toml_absolute() {
 fn cargo_read_manifest_path_to_cargo_toml_parent_relative() {
     let p = project("foo")
         .file("Cargo.toml", &basic_bin_manifest("foo"))
-        .file("src/foo.rs", &main_file(r#""i am foo""#, &[]));
+        .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
+        .build();
 
-    assert_that(p.cargo_process("read-manifest")
+    assert_that(p.cargo("read-manifest")
                  .arg("--manifest-path").arg("foo")
                  .cwd(p.root().parent().unwrap()),
                 execs().with_status(101)
@@ -68,9 +71,10 @@ fn cargo_read_manifest_path_to_cargo_toml_parent_relative() {
 fn cargo_read_manifest_path_to_cargo_toml_parent_absolute() {
     let p = project("foo")
         .file("Cargo.toml", &basic_bin_manifest("foo"))
-        .file("src/foo.rs", &main_file(r#""i am foo""#, &[]));
+        .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
+        .build();
 
-    assert_that(p.cargo_process("read-manifest")
+    assert_that(p.cargo("read-manifest")
                  .arg("--manifest-path").arg(p.root())
                  .cwd(p.root().parent().unwrap()),
                 execs().with_status(101)
@@ -82,9 +86,10 @@ fn cargo_read_manifest_path_to_cargo_toml_parent_absolute() {
 fn cargo_read_manifest_cwd() {
     let p = project("foo")
         .file("Cargo.toml", &basic_bin_manifest("foo"))
-        .file("src/foo.rs", &main_file(r#""i am foo""#, &[]));
+        .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
+        .build();
 
-    assert_that(p.cargo_process("read-manifest")
+    assert_that(p.cargo("read-manifest")
                  .cwd(p.root()),
                 execs().with_status(0)
                        .with_json(MANIFEST_OUTPUT));

--- a/tests/registry.rs
+++ b/tests/registry.rs
@@ -30,8 +30,8 @@ fn simple() {
             [dependencies]
             bar = ">= 0.0.0"
         "#)
-        .file("src/main.rs", "fn main() {}");
-    p.build();
+        .file("src/main.rs", "fn main() {}")
+        .build();
 
     Package::new("bar", "0.0.1").publish();
 
@@ -70,12 +70,13 @@ fn deps() {
             [dependencies]
             bar = ">= 0.0.0"
         "#)
-        .file("src/main.rs", "fn main() {}");
+        .file("src/main.rs", "fn main() {}")
+        .build();
 
     Package::new("baz", "0.0.1").publish();
     Package::new("bar", "0.0.1").dep("baz", "*").publish();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(0).with_stderr(&format!("\
 [UPDATING] registry `{reg}`
 [DOWNLOADING] [..] v0.0.1 (registry file://[..])
@@ -103,9 +104,10 @@ fn nonexistent() {
             [dependencies]
             nonexistent = ">= 0.0.0"
         "#)
-        .file("src/main.rs", "fn main() {}");
+        .file("src/main.rs", "fn main() {}")
+        .build();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(101).with_stderr("\
 [UPDATING] registry [..]
 [ERROR] no matching package named `nonexistent` found (required by `foo`)
@@ -126,8 +128,8 @@ fn wrong_version() {
             [dependencies]
             foo = ">= 1.0.0"
         "#)
-        .file("src/main.rs", "fn main() {}");
-    p.build();
+        .file("src/main.rs", "fn main() {}")
+        .build();
 
     Package::new("foo", "0.0.1").publish();
     Package::new("foo", "0.0.2").publish();
@@ -162,13 +164,14 @@ fn bad_cksum() {
             [dependencies]
             bad-cksum = ">= 0.0.0"
         "#)
-        .file("src/main.rs", "fn main() {}");
+        .file("src/main.rs", "fn main() {}")
+        .build();
 
     let pkg = Package::new("bad-cksum", "0.0.1");
     pkg.publish();
     t!(File::create(&pkg.archive_dst()));
 
-    assert_that(p.cargo_process("build").arg("-v"),
+    assert_that(p.cargo("build").arg("-v"),
                 execs().with_status(101).with_stderr("\
 [UPDATING] registry [..]
 [DOWNLOADING] bad-cksum [..]
@@ -196,9 +199,10 @@ fn update_registry() {
             [dependencies]
             notyet = ">= 0.0.0"
         "#)
-        .file("src/main.rs", "fn main() {}");
+        .file("src/main.rs", "fn main() {}")
+        .build();
 
-    assert_that(p.cargo_process("build"),
+    assert_that(p.cargo("build"),
                 execs().with_status(101).with_stderr_contains("\
 [ERROR] no matching package named `notyet` found (required by `foo`)
 location searched: registry [..]
@@ -244,8 +248,8 @@ fn package_with_path_deps() {
             version = "0.0.1"
             authors = []
         "#)
-        .file("notyet/src/lib.rs", "");
-    p.build();
+        .file("notyet/src/lib.rs", "")
+        .build();
 
     assert_that(p.cargo("package").arg("-v"),
                 execs().with_status(101).with_stderr_contains("\
@@ -283,8 +287,8 @@ fn lockfile_locks() {
             [dependencies]
             bar = "*"
         "#)
-        .file("src/main.rs", "fn main() {}");
-    p.build();
+        .file("src/main.rs", "fn main() {}")
+        .build();
 
     Package::new("bar", "0.0.1").publish();
 
@@ -317,8 +321,8 @@ fn lockfile_locks_transitively() {
             [dependencies]
             bar = "*"
         "#)
-        .file("src/main.rs", "fn main() {}");
-    p.build();
+        .file("src/main.rs", "fn main() {}")
+        .build();
 
     Package::new("baz", "0.0.1").publish();
     Package::new("bar", "0.0.1").dep("baz", "*").publish();
@@ -355,8 +359,8 @@ fn yanks_are_not_used() {
             [dependencies]
             bar = "*"
         "#)
-        .file("src/main.rs", "fn main() {}");
-    p.build();
+        .file("src/main.rs", "fn main() {}")
+        .build();
 
     Package::new("baz", "0.0.1").publish();
     Package::new("baz", "0.0.2").yanked(true).publish();
@@ -388,8 +392,8 @@ fn relying_on_a_yank_is_bad() {
             [dependencies]
             bar = "*"
         "#)
-        .file("src/main.rs", "fn main() {}");
-    p.build();
+        .file("src/main.rs", "fn main() {}")
+        .build();
 
     Package::new("baz", "0.0.1").publish();
     Package::new("baz", "0.0.2").yanked(true).publish();
@@ -415,8 +419,8 @@ fn yanks_in_lockfiles_are_ok() {
             [dependencies]
             bar = "*"
         "#)
-        .file("src/main.rs", "fn main() {}");
-    p.build();
+        .file("src/main.rs", "fn main() {}")
+        .build();
 
     Package::new("bar", "0.0.1").publish();
 
@@ -450,8 +454,8 @@ fn update_with_lockfile_if_packages_missing() {
             [dependencies]
             bar = "*"
         "#)
-        .file("src/main.rs", "fn main() {}");
-    p.build();
+        .file("src/main.rs", "fn main() {}")
+        .build();
 
     Package::new("bar", "0.0.1").publish();
     assert_that(p.cargo("build"),
@@ -479,8 +483,8 @@ fn update_lockfile() {
             [dependencies]
             bar = "*"
         "#)
-        .file("src/main.rs", "fn main() {}");
-    p.build();
+        .file("src/main.rs", "fn main() {}")
+        .build();
 
     println!("0.0.1");
     Package::new("bar", "0.0.1").publish();
@@ -560,8 +564,8 @@ fn dev_dependency_not_used() {
             [dependencies]
             bar = "*"
         "#)
-        .file("src/main.rs", "fn main() {}");
-    p.build();
+        .file("src/main.rs", "fn main() {}")
+        .build();
 
     Package::new("baz", "0.0.1").publish();
     Package::new("bar", "0.0.1").dev_dep("baz", "*").publish();
@@ -613,8 +617,9 @@ fn bad_license_file() {
         "#)
         .file("src/main.rs", r#"
             fn main() {}
-        "#);
-    assert_that(p.cargo_process("publish")
+        "#)
+        .build();
+    assert_that(p.cargo("publish")
                  .arg("-v")
                  .arg("--index").arg(registry().to_string()),
                 execs().with_status(101)
@@ -644,8 +649,8 @@ fn updating_a_dep() {
             [dependencies]
             bar = "*"
         "#)
-        .file("a/src/lib.rs", "");
-    p.build();
+        .file("a/src/lib.rs", "")
+        .build();
 
     Package::new("bar", "0.0.1").publish();
 
@@ -696,8 +701,8 @@ fn git_and_registry_dep() {
             [dependencies]
             a = "0.0.1"
         "#)
-        .file("src/lib.rs", "");
-    b.build();
+        .file("src/lib.rs", "")
+        .build();
     let p = project("foo")
         .file("Cargo.toml", &format!(r#"
             [project]
@@ -711,8 +716,8 @@ fn git_and_registry_dep() {
             [dependencies.b]
             git = '{}'
         "#, b.url()))
-        .file("src/main.rs", "fn main() {}");
-    p.build();
+        .file("src/main.rs", "fn main() {}")
+        .build();
 
     Package::new("a", "0.0.1").publish();
 
@@ -749,8 +754,8 @@ fn update_publish_then_update() {
             [dependencies]
             a = "0.1.0"
         "#)
-        .file("src/main.rs", "fn main() {}");
-    p.build();
+        .file("src/main.rs", "fn main() {}")
+        .build();
     Package::new("a", "0.1.0").publish();
     assert_that(p.cargo("build"),
                 execs().with_status(0));
@@ -774,8 +779,9 @@ fn update_publish_then_update() {
             [dependencies]
             a = "0.1.1"
         "#)
-        .file("src/main.rs", "fn main() {}");
-    assert_that(p2.cargo_process("build"),
+        .file("src/main.rs", "fn main() {}")
+        .build();
+    assert_that(p2.cargo("build"),
                 execs().with_status(0));
     registry.rm_rf();
     t!(fs::rename(&backup, &registry));
@@ -808,8 +814,8 @@ fn fetch_downloads() {
             [dependencies]
             a = "0.1.0"
         "#)
-        .file("src/main.rs", "fn main() {}");
-    p.build();
+        .file("src/main.rs", "fn main() {}")
+        .build();
 
     Package::new("a", "0.1.0").publish();
 
@@ -833,8 +839,8 @@ fn update_transitive_dependency() {
             [dependencies]
             a = "0.1.0"
         "#)
-        .file("src/main.rs", "fn main() {}");
-    p.build();
+        .file("src/main.rs", "fn main() {}")
+        .build();
 
     Package::new("a", "0.1.0").dep("b", "*").publish();
     Package::new("b", "0.1.0").publish();
@@ -874,8 +880,8 @@ fn update_backtracking_ok() {
             [dependencies]
             webdriver = "0.1"
         "#)
-        .file("src/main.rs", "fn main() {}");
-    p.build();
+        .file("src/main.rs", "fn main() {}")
+        .build();
 
     Package::new("webdriver", "0.1.0").dep("hyper", "0.6").publish();
     Package::new("hyper", "0.6.5").dep("openssl", "0.1")
@@ -913,8 +919,8 @@ fn update_multiple_packages() {
             b = "*"
             c = "*"
         "#)
-        .file("src/main.rs", "fn main() {}");
-    p.build();
+        .file("src/main.rs", "fn main() {}")
+        .build();
 
     Package::new("a", "0.1.0").publish();
     Package::new("b", "0.1.0").publish();
@@ -973,8 +979,8 @@ fn bundled_crate_in_registry() {
             bar = "0.1"
             baz = "0.1"
         "#)
-        .file("src/main.rs", "fn main() {}");
-    p.build();
+        .file("src/main.rs", "fn main() {}")
+        .build();
 
     Package::new("bar", "0.1.0").publish();
     Package::new("baz", "0.1.0")
@@ -1013,8 +1019,8 @@ fn update_same_prefix_oh_my_how_was_this_a_bug() {
             [dependencies]
             foo = "0.1"
         "#)
-        .file("src/main.rs", "fn main() {}");
-    p.build();
+        .file("src/main.rs", "fn main() {}")
+        .build();
 
     Package::new("foobar", "0.2.0").publish();
     Package::new("foo", "0.1.0")
@@ -1038,8 +1044,8 @@ fn use_semver() {
             [dependencies]
             foo = "1.2.3-alpha.0"
         "#)
-        .file("src/main.rs", "fn main() {}");
-    p.build();
+        .file("src/main.rs", "fn main() {}")
+        .build();
 
     Package::new("foo", "1.2.3-alpha.0").publish();
 
@@ -1062,8 +1068,8 @@ fn only_download_relevant() {
             [dependencies]
             baz = "*"
         "#)
-        .file("src/main.rs", "fn main() {}");
-    p.build();
+        .file("src/main.rs", "fn main() {}")
+        .build();
 
     Package::new("foo", "0.1.0").publish();
     Package::new("bar", "0.1.0").publish();
@@ -1091,8 +1097,8 @@ fn resolve_and_backtracking() {
             [dependencies]
             foo = "*"
         "#)
-        .file("src/main.rs", "fn main() {}");
-    p.build();
+        .file("src/main.rs", "fn main() {}")
+        .build();
 
     Package::new("foo", "0.1.1")
             .feature_dep("bar", "0.1", &["a", "b"])
@@ -1115,8 +1121,8 @@ fn upstream_warnings_on_extra_verbose() {
             [dependencies]
             foo = "*"
         "#)
-        .file("src/main.rs", "fn main() {}");
-    p.build();
+        .file("src/main.rs", "fn main() {}")
+        .build();
 
     Package::new("foo", "0.1.0")
             .file("src/lib.rs", "fn unused() {}")
@@ -1140,8 +1146,8 @@ fn disallow_network() {
             [dependencies]
             foo = "*"
         "#)
-        .file("src/main.rs", "fn main() {}");
-    p.build();
+        .file("src/main.rs", "fn main() {}")
+        .build();
 
     assert_that(p.cargo("build").arg("--frozen"),
                 execs().with_status(101).with_stderr("\
@@ -1177,8 +1183,8 @@ fn add_dep_dont_update_registry() {
             [dependencies]
             remote = "0.3"
         "#)
-        .file("baz/src/lib.rs", "");
-    p.build();
+        .file("baz/src/lib.rs", "")
+        .build();
 
     Package::new("remote", "0.3.4").publish();
 
@@ -1225,8 +1231,8 @@ fn bump_version_dont_update_registry() {
             [dependencies]
             remote = "0.3"
         "#)
-        .file("baz/src/lib.rs", "");
-    p.build();
+        .file("baz/src/lib.rs", "")
+        .build();
 
     Package::new("remote", "0.3.4").publish();
 
@@ -1262,8 +1268,8 @@ fn old_version_req() {
             [dependencies]
             remote = "0.2*"
         "#)
-        .file("src/main.rs", "fn main() {}");
-    p.build();
+        .file("src/main.rs", "fn main() {}")
+        .build();
 
     Package::new("remote", "0.2.0").publish();
 
@@ -1310,8 +1316,8 @@ fn old_version_req_upstream() {
             [dependencies]
             remote = "0.3"
         "#)
-        .file("src/main.rs", "fn main() {}");
-    p.build();
+        .file("src/main.rs", "fn main() {}")
+        .build();
 
     Package::new("remote", "0.3.0")
             .file("Cargo.toml", r#"
@@ -1375,8 +1381,8 @@ fn toml_lies_but_index_is_truth() {
             [dependencies]
             bar = "0.3"
         "#)
-        .file("src/main.rs", "fn main() {}");
-    p.build();
+        .file("src/main.rs", "fn main() {}")
+        .build();
 
     assert_that(p.cargo("build").arg("-v"),
                 execs().with_status(0));
@@ -1402,8 +1408,8 @@ fn vv_prints_warnings() {
             [dependencies]
             foo = "0.2"
         "#)
-        .file("src/main.rs", "fn main() {}");
-    p.build();
+        .file("src/main.rs", "fn main() {}")
+        .build();
 
     assert_that(p.cargo("build").arg("-vv"),
                 execs().with_status(0));
@@ -1425,8 +1431,8 @@ fn bad_and_or_malicious_packages_rejected() {
             [dependencies]
             foo = "0.2"
         "#)
-        .file("src/main.rs", "fn main() {}");
-    p.build();
+        .file("src/main.rs", "fn main() {}")
+        .build();
 
     assert_that(p.cargo("build").arg("-vv"),
                 execs().with_status(101)

--- a/tests/required-features.rs
+++ b/tests/required-features.rs
@@ -36,8 +36,8 @@ fn build_bin_default_features() {
         .file("src/lib.rs", r#"
             #[cfg(feature = "a")]
             pub fn foo() {}
-        "#);
-    p.build();
+        "#)
+        .build();
 
     assert_that(p.cargo("build"),
                 execs().with_status(0));
@@ -73,8 +73,8 @@ fn build_bin_arg_features() {
             name = "foo"
             required-features = ["a"]
         "#)
-        .file("src/main.rs", "fn main() {}");
-    p.build();
+        .file("src/main.rs", "fn main() {}")
+        .build();
 
     assert_that(p.cargo("build").arg("--features").arg("a"),
                 execs().with_status(0));
@@ -107,8 +107,8 @@ fn build_bin_multiple_required_features() {
             required-features = ["a"]
         "#)
         .file("src/foo_1.rs", "fn main() {}")
-        .file("src/foo_2.rs", "fn main() {}");
-    p.build();
+        .file("src/foo_2.rs", "fn main() {}")
+        .build();
 
     assert_that(p.cargo("build"),
                 execs().with_status(0));
@@ -143,8 +143,8 @@ fn build_example_default_features() {
             name = "foo"
             required-features = ["a"]
         "#)
-        .file("examples/foo.rs", "fn main() {}");
-    p.build();
+        .file("examples/foo.rs", "fn main() {}")
+        .build();
 
     assert_that(p.cargo("build").arg("--example=foo"),
                 execs().with_status(0));
@@ -173,8 +173,8 @@ fn build_example_arg_features() {
             name = "foo"
             required-features = ["a"]
         "#)
-        .file("examples/foo.rs", "fn main() {}");
-    p.build();
+        .file("examples/foo.rs", "fn main() {}")
+        .build();
 
     assert_that(p.cargo("build").arg("--example=foo").arg("--features").arg("a"),
                 execs().with_status(0));
@@ -205,8 +205,8 @@ fn build_example_multiple_required_features() {
             required-features = ["a"]
         "#)
         .file("examples/foo_1.rs", "fn main() {}")
-        .file("examples/foo_2.rs", "fn main() {}");
-    p.build();
+        .file("examples/foo_2.rs", "fn main() {}")
+        .build();
 
     assert_that(p.cargo("build").arg("--example=foo_1"),
                 execs().with_status(101).with_stderr("\
@@ -260,8 +260,8 @@ fn test_default_features() {
             name = "foo"
             required-features = ["a"]
         "#)
-        .file("tests/foo.rs", "#[test]\nfn test() {}");
-    p.build();
+        .file("tests/foo.rs", "#[test]\nfn test() {}")
+        .build();
 
     assert_that(p.cargo("test"),
                 execs().with_status(0).with_stderr(format!("\
@@ -304,8 +304,8 @@ fn test_arg_features() {
             name = "foo"
             required-features = ["a"]
         "#)
-        .file("tests/foo.rs", "#[test]\nfn test() {}");
-    p.build();
+        .file("tests/foo.rs", "#[test]\nfn test() {}")
+        .build();
 
     assert_that(p.cargo("test").arg("--features").arg("a"),
                 execs().with_status(0).with_stderr(format!("\
@@ -339,8 +339,8 @@ fn test_multiple_required_features() {
             required-features = ["a"]
         "#)
         .file("tests/foo_1.rs", "#[test]\nfn test() {}")
-        .file("tests/foo_2.rs", "#[test]\nfn test() {}");
-    p.build();
+        .file("tests/foo_2.rs", "#[test]\nfn test() {}")
+        .build();
 
     assert_that(p.cargo("test"),
                 execs().with_status(0).with_stderr(format!("\
@@ -390,8 +390,8 @@ fn bench_default_features() {
 
             #[bench]
             fn bench(_: &mut test::Bencher) {
-            }"#);
-    p.build();
+            }"#)
+        .build();
 
     assert_that(p.cargo("bench"),
                 execs().with_status(0).with_stderr(format!("\
@@ -444,8 +444,8 @@ fn bench_arg_features() {
 
             #[bench]
             fn bench(_: &mut test::Bencher) {
-            }"#);
-    p.build();
+            }"#)
+        .build();
 
     assert_that(p.cargo("bench").arg("--features").arg("a"),
                 execs().with_status(0).with_stderr(format!("\
@@ -495,8 +495,8 @@ fn bench_multiple_required_features() {
 
             #[bench]
             fn bench(_: &mut test::Bencher) {
-            }"#);
-    p.build();
+            }"#)
+        .build();
 
     assert_that(p.cargo("bench"),
                 execs().with_status(0).with_stderr(format!("\
@@ -541,8 +541,8 @@ fn install_default_features() {
             required-features = ["a"]
         "#)
         .file("src/main.rs", "fn main() {}")
-        .file("examples/foo.rs", "fn main() {}");
-    p.build();
+        .file("examples/foo.rs", "fn main() {}")
+        .build();
 
     assert_that(p.cargo("install"),
                 execs().with_status(0));
@@ -611,8 +611,8 @@ fn install_arg_features() {
             name = "foo"
             required-features = ["a"]
         "#)
-        .file("src/main.rs", "fn main() {}");
-    p.build();
+        .file("src/main.rs", "fn main() {}")
+        .build();
 
     assert_that(p.cargo("install").arg("--features").arg("a"),
                 execs().with_status(0));
@@ -647,8 +647,8 @@ fn install_multiple_required_features() {
             required-features = ["a"]
         "#)
         .file("src/foo_1.rs", "fn main() {}")
-        .file("src/foo_2.rs", "fn main() {}");
-    p.build();
+        .file("src/foo_2.rs", "fn main() {}")
+        .build();
 
     assert_that(p.cargo("install"),
                 execs().with_status(0));
@@ -721,8 +721,8 @@ fn dep_feature_in_toml() {
             [features]
             a = []
         "#)
-        .file("bar/src/lib.rs", "");
-    p.build();
+        .file("bar/src/lib.rs", "")
+        .build();
 
     assert_that(p.cargo("build"),
                 execs().with_status(0));
@@ -811,8 +811,8 @@ fn dep_feature_in_cmd_line() {
             [features]
             a = []
         "#)
-        .file("bar/src/lib.rs", "");
-    p.build();
+        .file("bar/src/lib.rs", "")
+        .build();
 
     assert_that(p.cargo("build"),
                 execs().with_status(0));
@@ -903,8 +903,8 @@ fn test_skips_compiling_bin_with_missing_required_features() {
         "#)
         .file("src/bin/foo.rs", "extern crate bar; fn main() {}")
         .file("tests/foo.rs", "")
-        .file("benches/foo.rs", "");
-    p.build();
+        .file("benches/foo.rs", "")
+        .build();
 
     assert_that(p.cargo("test"),
                 execs().with_status(0).with_stderr(format!("\
@@ -951,8 +951,8 @@ fn run_default() {
             required-features = ["a"]
         "#)
         .file("src/lib.rs", "")
-        .file("src/main.rs", "extern crate foo; fn main() {}");
-    p.build();
+        .file("src/main.rs", "extern crate foo; fn main() {}")
+        .build();
 
     assert_that(p.cargo("run"),
                 execs().with_status(101).with_stderr("\
@@ -990,8 +990,8 @@ fn run_default_multiple_required_features() {
         "#)
         .file("src/lib.rs", "")
         .file("src/foo1.rs", "extern crate foo; fn main() {}")
-        .file("src/foo2.rs", "extern crate foo; fn main() {}");
-    p.build();
+        .file("src/foo2.rs", "extern crate foo; fn main() {}")
+        .build();
 
     assert_that(p.cargo("run"),
                 execs().with_status(101).with_stderr("\

--- a/tests/run.rs
+++ b/tests/run.rs
@@ -17,9 +17,10 @@ fn simple() {
         "#)
         .file("src/main.rs", r#"
             fn main() { println!("hello"); }
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("run"),
+    assert_that(p.cargo("run"),
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({dir})
@@ -43,9 +44,10 @@ fn simple_implicit_main() {
         "#)
         .file("src/main.rs", r#"
             fn main() { println!("hello world"); }
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("run").arg("--bins"),
+    assert_that(p.cargo("run").arg("--bins"),
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({dir})
@@ -68,9 +70,10 @@ fn simple_quiet() {
         "#)
         .file("src/main.rs", r#"
             fn main() { println!("hello"); }
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("run").arg("-q"),
+    assert_that(p.cargo("run").arg("-q"),
                 execs().with_status(0).with_stdout("\
 hello
 ")
@@ -88,9 +91,10 @@ fn simple_quiet_and_verbose() {
         "#)
         .file("src/main.rs", r#"
             fn main() { println!("hello"); }
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("run").arg("-q").arg("-v"),
+    assert_that(p.cargo("run").arg("-q").arg("-v"),
                 execs().with_status(101).with_stderr("\
 [ERROR] cannot set both --verbose and --quiet
 "));
@@ -111,9 +115,10 @@ fn quiet_and_verbose_config() {
         "#)
         .file("src/main.rs", r#"
             fn main() { println!("hello"); }
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("run").arg("-q"),
+    assert_that(p.cargo("run").arg("-q"),
                 execs().with_status(0));
 }
 
@@ -131,9 +136,10 @@ fn simple_with_args() {
                 assert_eq!(std::env::args().nth(1).unwrap(), "hello");
                 assert_eq!(std::env::args().nth(2).unwrap(), "world");
             }
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("run").arg("hello").arg("world"),
+    assert_that(p.cargo("run").arg("hello").arg("world"),
                 execs().with_status(0));
 }
 
@@ -148,7 +154,8 @@ fn exit_code() {
         "#)
         .file("src/main.rs", r#"
             fn main() { std::process::exit(2); }
-        "#);
+        "#)
+        .build();
 
     let mut output = String::from("\
 [COMPILING] foo v0.0.1 (file[..])
@@ -160,7 +167,7 @@ fn exit_code() {
 [ERROR] process didn't exit successfully: `target[..]foo[..]` (exit code: 2)
 ");
     }
-    assert_that(p.cargo_process("run"),
+    assert_that(p.cargo("run"),
                 execs().with_status(2).with_stderr(output));
 }
 
@@ -175,7 +182,8 @@ fn exit_code_verbose() {
         "#)
         .file("src/main.rs", r#"
             fn main() { std::process::exit(2); }
-        "#);
+        "#)
+        .build();
 
     let mut output = String::from("\
 [COMPILING] foo v0.0.1 (file[..])
@@ -189,7 +197,7 @@ fn exit_code_verbose() {
 ");
     }
 
-    assert_that(p.cargo_process("run").arg("-v"),
+    assert_that(p.cargo("run").arg("-v"),
                 execs().with_status(2).with_stderr(output));
 }
 
@@ -202,9 +210,10 @@ fn no_main_file() {
             version = "0.0.1"
             authors = []
         "#)
-        .file("src/lib.rs", "");
+        .file("src/lib.rs", "")
+        .build();
 
-    assert_that(p.cargo_process("run"),
+    assert_that(p.cargo("run"),
                 execs().with_status(101)
                        .with_stderr("[ERROR] a bin target must be available \
                                      for `cargo run`\n"));
@@ -220,9 +229,10 @@ fn no_main_file_implicit() {
             version = "0.0.1"
             authors = []
         "#)
-        .file("src/lib.rs", "");
+        .file("src/lib.rs", "")
+        .build();
 
-    assert_that(p.cargo_process("run").arg("--bins"),
+    assert_that(p.cargo("run").arg("--bins"),
                 execs().with_status(101)
                        .with_stderr("[ERROR] a bin target must be available \
                                      for `cargo run`\n"));
@@ -239,9 +249,10 @@ fn too_many_bins() {
         "#)
         .file("src/lib.rs", "")
         .file("src/bin/a.rs", "")
-        .file("src/bin/b.rs", "");
+        .file("src/bin/b.rs", "")
+        .build();
 
-    assert_that(p.cargo_process("run"),
+    assert_that(p.cargo("run"),
                 execs().with_status(101)
                        .with_stderr("[ERROR] `cargo run` requires that a project only \
                                      have one executable; use the `--bin` option \
@@ -260,9 +271,10 @@ fn too_many_bins_implicit() {
         "#)
         .file("src/lib.rs", "")
         .file("src/bin/a.rs", "")
-        .file("src/bin/b.rs", "");
+        .file("src/bin/b.rs", "")
+        .build();
 
-    assert_that(p.cargo_process("run").arg("--bins"),
+    assert_that(p.cargo("run").arg("--bins"),
                 execs().with_status(101)
                        .with_stderr("[ERROR] `cargo run` requires that a project only \
                                      have one executable; use the `--bin` option \
@@ -288,9 +300,10 @@ fn specify_name() {
             #[allow(unused_extern_crates)]
             extern crate foo;
             fn main() { println!("hello b.rs"); }
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("run").arg("--bin").arg("a").arg("-v"),
+    assert_that(p.cargo("run").arg("--bin").arg("a").arg("-v"),
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({dir})
@@ -329,9 +342,10 @@ fn run_example() {
         "#)
         .file("src/bin/a.rs", r#"
             fn main() { println!("bin"); }
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("run").arg("--example").arg("a"),
+    assert_that(p.cargo("run").arg("--example").arg("a"),
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({dir})
@@ -358,9 +372,10 @@ fn run_bin_implicit() {
         "#)
         .file("src/bin/a.rs", r#"
             fn main() { println!("bin"); }
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("run").arg("--bins"),
+    assert_that(p.cargo("run").arg("--bins"),
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({dir})
@@ -387,9 +402,10 @@ fn run_example_implicit() {
         "#)
         .file("src/bin/a.rs", r#"
             fn main() { println!("bin"); }
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("run").arg("--examples"),
+    assert_that(p.cargo("run").arg("--examples"),
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({dir})
@@ -416,8 +432,8 @@ fn run_with_filename() {
         "#)
         .file("examples/a.rs", r#"
             fn main() { println!("example"); }
-        "#);
-    p.build();
+        "#)
+        .build();
 
     assert_that(p.cargo("run").arg("--bin").arg("bin.rs"),
                 execs().with_status(101).with_stderr("\
@@ -454,9 +470,10 @@ fn either_name_or_example() {
         "#)
         .file("examples/b.rs", r#"
             fn main() { println!("hello b.rs"); }
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("run").arg("--bin").arg("a").arg("--example").arg("b"),
+    assert_that(p.cargo("run").arg("--bin").arg("a").arg("--example").arg("b"),
                 execs().with_status(101)
                        .with_stderr("[ERROR] `cargo run` can run at most one \
                                      executable, but multiple were \
@@ -481,9 +498,10 @@ fn one_bin_multiple_examples() {
         "#)
         .file("examples/b.rs", r#"
             fn main() { println!("hello b.rs"); }
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("run"),
+    assert_that(p.cargo("run"),
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({dir})
@@ -536,9 +554,10 @@ fn example_with_release_flag() {
                     println!("fast2")
                 }
             }
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("run").arg("-v").arg("--release").arg("--example").arg("a"),
+    assert_that(p.cargo("run").arg("-v").arg("--release").arg("--example").arg("a"),
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] bar v0.0.1 ({url}/bar)
@@ -621,9 +640,10 @@ fn run_dylib_dep() {
             name = "bar"
             crate-type = ["dylib"]
         "#)
-        .file("bar/src/lib.rs", "pub fn bar() {}");
+        .file("bar/src/lib.rs", "pub fn bar() {}")
+        .build();
 
-    assert_that(p.cargo_process("run").arg("hello").arg("world"),
+    assert_that(p.cargo("run").arg("hello").arg("world"),
                 execs().with_status(0));
 }
 
@@ -638,9 +658,10 @@ fn release_works() {
         "#)
         .file("src/main.rs", r#"
             fn main() { if cfg!(debug_assertions) { panic!() } }
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("run").arg("--release"),
+    assert_that(p.cargo("run").arg("--release"),
                 execs().with_status(0).with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({dir})
 [FINISHED] release [optimized] target(s) in [..]
@@ -665,9 +686,10 @@ fn run_bin_different_name() {
         "#)
         .file("src/bar.rs", r#"
             fn main() { }
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("run"), execs().with_status(0));
+    assert_that(p.cargo("run"), execs().with_status(0));
 }
 
 #[test]
@@ -689,9 +711,10 @@ fn dashes_are_forwarded() {
                 assert_eq!(s[2], "--");
                 assert_eq!(s[3], "b");
             }
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("run").arg("--").arg("a").arg("--").arg("b"),
+    assert_that(p.cargo("run").arg("--").arg("a").arg("--").arg("b"),
                 execs().with_status(0));
 }
 
@@ -706,10 +729,11 @@ fn run_from_executable_folder() {
         "#)
         .file("src/main.rs", r#"
             fn main() { println!("hello"); }
-        "#);
+        "#)
+        .build();
 
     let cwd = p.root().join("target").join("debug");
-    p.cargo_process("build").exec_with_output().unwrap();
+    p.cargo("build").exec_with_output().unwrap();
 
     assert_that(p.cargo("run").cwd(cwd),
                 execs().with_status(0)
@@ -723,7 +747,7 @@ hello
 
 #[test]
 fn run_with_library_paths() {
-    let mut p = project("foo");
+    let p = project("foo");
 
     // Only link search directories within the target output directory are
     // propagated through to dylib_path_envvar() (see #3366).
@@ -733,7 +757,8 @@ fn run_with_library_paths() {
     let mut dir2 = p.target_debug_dir();
     dir2.push("dir=containing=equal=signs");
 
-    p = p.file("Cargo.toml", r#"
+    let p = p
+        .file("Cargo.toml", r#"
             [project]
             name = "foo"
             version = "0.0.1"
@@ -753,9 +778,10 @@ fn run_with_library_paths() {
                 assert!(paths.contains(&r#"{}"#.into()));
                 assert!(paths.contains(&r#"{}"#.into()));
             }}
-        "##, dylib_path_envvar(), dir1.display(), dir2.display()));
+        "##, dylib_path_envvar(), dir1.display(), dir2.display()))
+        .build();
 
-    assert_that(p.cargo_process("run"), execs().with_status(0));
+    assert_that(p.cargo("run"), execs().with_status(0));
 }
 
 #[test]
@@ -771,9 +797,10 @@ fn fail_no_extra_verbose() {
             fn main() {
                 std::process::exit(1);
             }
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("run").arg("-q"),
+    assert_that(p.cargo("run").arg("-q"),
                 execs().with_status(1)
                        .with_stdout("")
                        .with_stderr(""));
@@ -826,9 +853,8 @@ fn run_multiple_packages() {
             version = "0.0.1"
             authors = []
         "#)
-        .file("d3/src/main.rs", "fn main() { println!(\"d2\"); }");
-
-    let p = p.build();
+        .file("d3/src/main.rs", "fn main() { println!(\"d2\"); }")
+        .build();
 
     let cargo = || {
         let mut process_builder = p.cargo("run");

--- a/tests/rustc.rs
+++ b/tests/rustc.rs
@@ -20,9 +20,10 @@ fn build_lib_for_foo() {
         .file("src/main.rs", r#"
             fn main() {}
         "#)
-        .file("src/lib.rs", r#" "#);
+        .file("src/lib.rs", r#" "#)
+        .build();
 
-    assert_that(p.cargo_process("rustc").arg("--lib").arg("-v"),
+    assert_that(p.cargo("rustc").arg("--lib").arg("-v"),
                 execs()
                 .with_status(0)
                 .with_stderr(format!("\
@@ -48,9 +49,10 @@ fn lib() {
         .file("src/main.rs", r#"
             fn main() {}
         "#)
-        .file("src/lib.rs", r#" "#);
+        .file("src/lib.rs", r#" "#)
+        .build();
 
-    assert_that(p.cargo_process("rustc").arg("--lib").arg("-v")
+    assert_that(p.cargo("rustc").arg("--lib").arg("-v")
                 .arg("--").arg("-C").arg("debug-assertions=off"),
                 execs()
                 .with_status(0)
@@ -78,9 +80,10 @@ fn build_main_and_allow_unstable_options() {
         .file("src/main.rs", r#"
             fn main() {}
         "#)
-        .file("src/lib.rs", r#" "#);
+        .file("src/lib.rs", r#" "#)
+        .build();
 
-    assert_that(p.cargo_process("rustc").arg("-v").arg("--bin").arg("foo")
+    assert_that(p.cargo("rustc").arg("-v").arg("--bin").arg("foo")
                 .arg("--").arg("-C").arg("debug-assertions"),
                 execs()
                 .with_status(0)
@@ -116,9 +119,10 @@ fn fails_when_trying_to_build_main_and_lib_with_args() {
         .file("src/main.rs", r#"
             fn main() {}
         "#)
-        .file("src/lib.rs", r#" "#);
+        .file("src/lib.rs", r#" "#)
+        .build();
 
-    assert_that(p.cargo_process("rustc").arg("-v")
+    assert_that(p.cargo("rustc").arg("-v")
                 .arg("--").arg("-C").arg("debug-assertions"),
                 execs()
                 .with_status(101)
@@ -143,9 +147,10 @@ fn build_with_args_to_one_of_multiple_binaries() {
         .file("src/bin/baz.rs", r#"
             fn main() {}
         "#)
-        .file("src/lib.rs", r#" "#);
+        .file("src/lib.rs", r#" "#)
+        .build();
 
-    assert_that(p.cargo_process("rustc").arg("-v").arg("--bin").arg("bar")
+    assert_that(p.cargo("rustc").arg("-v").arg("--bin").arg("bar")
                 .arg("--").arg("-C").arg("debug-assertions"),
                 execs()
                 .with_status(0)
@@ -178,9 +183,10 @@ fn fails_with_args_to_all_binaries() {
         .file("src/bin/baz.rs", r#"
             fn main() {}
         "#)
-        .file("src/lib.rs", r#" "#);
+        .file("src/lib.rs", r#" "#)
+        .build();
 
-    assert_that(p.cargo_process("rustc").arg("-v")
+    assert_that(p.cargo("rustc").arg("-v")
                 .arg("--").arg("-C").arg("debug-assertions"),
                 execs()
                 .with_status(101)
@@ -199,9 +205,10 @@ fn build_with_args_to_one_of_multiple_tests() {
         .file("tests/foo.rs", r#" "#)
         .file("tests/bar.rs", r#" "#)
         .file("tests/baz.rs", r#" "#)
-        .file("src/lib.rs", r#" "#);
+        .file("src/lib.rs", r#" "#)
+        .build();
 
-    assert_that(p.cargo_process("rustc").arg("-v").arg("--test").arg("bar")
+    assert_that(p.cargo("rustc").arg("-v").arg("--test").arg("bar")
                 .arg("--").arg("-C").arg("debug-assertions"),
                 execs()
                 .with_status(0)
@@ -233,8 +240,9 @@ fn build_foo_with_bar_dependency() {
             fn main() {
                 bar::baz()
             }
-        "#);
-    let bar = project("bar")
+        "#)
+        .build();
+    let _bar = project("bar")
         .file("Cargo.toml", r#"
             [package]
             name = "bar"
@@ -243,10 +251,10 @@ fn build_foo_with_bar_dependency() {
         "#)
         .file("src/lib.rs", r#"
             pub fn baz() {}
-        "#);
-    bar.build();
+        "#)
+        .build();
 
-    assert_that(foo.cargo_process("rustc").arg("-v").arg("--").arg("-C").arg("debug-assertions"),
+    assert_that(foo.cargo("rustc").arg("-v").arg("--").arg("-C").arg("debug-assertions"),
                 execs()
                 .with_status(0)
                 .with_stderr(format!("\
@@ -275,8 +283,9 @@ fn build_only_bar_dependency() {
             fn main() {
                 bar::baz()
             }
-        "#);
-    let bar = project("bar")
+        "#)
+        .build();
+    let _bar = project("bar")
         .file("Cargo.toml", r#"
             [package]
             name = "bar"
@@ -285,10 +294,10 @@ fn build_only_bar_dependency() {
         "#)
         .file("src/lib.rs", r#"
             pub fn baz() {}
-        "#);
-    bar.build();
+        "#)
+        .build();
 
-    assert_that(foo.cargo_process("rustc").arg("-v").arg("-p").arg("bar")
+    assert_that(foo.cargo("rustc").arg("-v").arg("-p").arg("bar")
                 .arg("--").arg("-C").arg("debug-assertions"),
                 execs()
                 .with_status(0)
@@ -316,10 +325,10 @@ fn fail_with_multiple_packages() {
         "#)
         .file("src/main.rs", r#"
             fn main() {}
-        "#);
-    foo.build();
+        "#)
+        .build();
 
-    let bar = project("bar")
+    let _bar = project("bar")
         .file("Cargo.toml", r#"
             [package]
             name = "bar"
@@ -330,10 +339,10 @@ fn fail_with_multiple_packages() {
             fn main() {
                 if cfg!(flag = "1") { println!("Yeah from bar!"); }
             }
-        "#);
-    bar.build();
+        "#)
+        .build();
 
-    let baz = project("baz")
+    let _baz = project("baz")
         .file("Cargo.toml", r#"
             [package]
             name = "baz"
@@ -344,8 +353,8 @@ fn fail_with_multiple_packages() {
             fn main() {
                 if cfg!(flag = "1") { println!("Yeah from baz!"); }
             }
-        "#);
-    baz.build();
+        "#)
+        .build();
 
     assert_that(foo.cargo("rustc").arg("-v").arg("-p").arg("bar")
                                           .arg("-p").arg("baz"),
@@ -358,7 +367,7 @@ Usage:
 
 #[test]
 fn rustc_with_other_profile() {
-    let foo = project("foo")
+    let p = project("foo")
         .file("Cargo.toml", r#"
             [package]
             name = "foo"
@@ -380,9 +389,9 @@ fn rustc_with_other_profile() {
             version = "0.1.0"
             authors = []
         "#)
-        .file("a/src/lib.rs", "");
-    foo.build();
+        .file("a/src/lib.rs", "")
+        .build();
 
-    assert_that(foo.cargo("rustc").arg("--profile").arg("test"),
+    assert_that(p.cargo("rustc").arg("--profile").arg("test"),
                 execs().with_status(0));
 }

--- a/tests/rustdoc.rs
+++ b/tests/rustdoc.rs
@@ -13,9 +13,10 @@ fn rustdoc_simple() {
             version = "0.0.1"
             authors = []
         "#)
-        .file("src/lib.rs", r#" "#);
+        .file("src/lib.rs", r#" "#)
+        .build();
 
-    assert_that(p.cargo_process("rustdoc").arg("-v"),
+    assert_that(p.cargo("rustdoc").arg("-v"),
                 execs()
                 .with_status(0)
                 .with_stderr(format!("\
@@ -36,9 +37,10 @@ fn rustdoc_args() {
             version = "0.0.1"
             authors = []
         "#)
-        .file("src/lib.rs", r#" "#);
+        .file("src/lib.rs", r#" "#)
+        .build();
 
-    assert_that(p.cargo_process("rustdoc").arg("-v").arg("--").arg("--cfg=foo"),
+    assert_that(p.cargo("rustdoc").arg("-v").arg("--").arg("--cfg=foo"),
                 execs()
                 .with_status(0)
                 .with_stderr(format!("\
@@ -68,8 +70,9 @@ fn rustdoc_foo_with_bar_dependency() {
         .file("src/lib.rs", r#"
             extern crate bar;
             pub fn foo() {}
-        "#);
-    let bar = project("bar")
+        "#)
+        .build();
+    let _bar = project("bar")
         .file("Cargo.toml", r#"
             [package]
             name = "bar"
@@ -78,10 +81,10 @@ fn rustdoc_foo_with_bar_dependency() {
         "#)
         .file("src/lib.rs", r#"
             pub fn baz() {}
-        "#);
-    bar.build();
+        "#)
+        .build();
 
-    assert_that(foo.cargo_process("rustdoc").arg("-v").arg("--").arg("--cfg=foo"),
+    assert_that(foo.cargo("rustdoc").arg("-v").arg("--").arg("--cfg=foo"),
                 execs()
                 .with_status(0)
                 .with_stderr(format!("\
@@ -114,8 +117,9 @@ fn rustdoc_only_bar_dependency() {
             fn main() {
                 bar::baz()
             }
-        "#);
-    let bar = project("bar")
+        "#)
+        .build();
+    let _bar = project("bar")
         .file("Cargo.toml", r#"
             [package]
             name = "bar"
@@ -124,10 +128,10 @@ fn rustdoc_only_bar_dependency() {
         "#)
         .file("src/lib.rs", r#"
             pub fn baz() {}
-        "#);
-    bar.build();
+        "#)
+        .build();
 
-    assert_that(foo.cargo_process("rustdoc").arg("-v").arg("-p").arg("bar")
+    assert_that(foo.cargo("rustdoc").arg("-v").arg("-p").arg("bar")
                                             .arg("--").arg("--cfg=foo"),
                 execs()
                 .with_status(0)
@@ -154,9 +158,10 @@ fn rustdoc_same_name_err() {
         .file("src/main.rs", r#"
             fn main() {}
         "#)
-        .file("src/lib.rs", r#" "#);
+        .file("src/lib.rs", r#" "#)
+        .build();
 
-    assert_that(p.cargo_process("rustdoc").arg("-v")
+    assert_that(p.cargo("rustdoc").arg("-v")
                  .arg("--").arg("--cfg=foo"),
                 execs()
                 .with_status(101)

--- a/tests/rustdocflags.rs
+++ b/tests/rustdocflags.rs
@@ -13,8 +13,8 @@ fn parses_env() {
             version = "0.0.1"
             authors = []
         "#)
-        .file("src/lib.rs", "");
-    p.build();
+        .file("src/lib.rs", "")
+        .build();
 
     assert_that(p.cargo("doc").env("RUSTDOCFLAGS", "--cfg=foo").arg("-v"),
                 execs().with_status(0)
@@ -36,8 +36,8 @@ fn parses_config() {
         .file(".cargo/config", r#"
             [build]
             rustdocflags = ["--cfg", "foo"]
-        "#);
-    p.build();
+        "#)
+        .build();
 
     assert_that(p.cargo("doc").arg("-v"),
                 execs().with_status(0)
@@ -55,8 +55,8 @@ fn bad_flags() {
             version = "0.0.1"
             authors = []
         "#)
-        .file("src/lib.rs", "");
-    p.build();
+        .file("src/lib.rs", "")
+        .build();
 
     assert_that(p.cargo("doc").env("RUSTDOCFLAGS", "--bogus"),
                 execs().with_status(101));
@@ -71,8 +71,8 @@ fn rerun() {
             version = "0.0.1"
             authors = []
         "#)
-        .file("src/lib.rs", "");
-    p.build();
+        .file("src/lib.rs", "")
+        .build();
 
     assert_that(p.cargo("doc").env("RUSTDOCFLAGS", "--cfg=foo"),
                 execs().with_status(0));

--- a/tests/rustflags.rs
+++ b/tests/rustflags.rs
@@ -23,8 +23,8 @@ fn env_rustflags_normal_source() {
         .file("benches/d.rs", r#"
             #![feature(test)]
             extern crate test;
-            #[bench] fn run1(_ben: &mut test::Bencher) { }"#);
-    p.build();
+            #[bench] fn run1(_ben: &mut test::Bencher) { }"#)
+        .build();
 
     // Use RUSTFLAGS to pass an argument that will generate an error
     assert_that(p.cargo("build").env("RUSTFLAGS", "-Z bogus")
@@ -59,8 +59,8 @@ fn env_rustflags_build_script() {
             fn main() { }
             #[cfg(not(foo))]
             fn main() { }
-        "#);
-    p.build();
+        "#)
+        .build();
 
     assert_that(p.cargo("build").env("RUSTFLAGS", "--cfg foo"),
                 execs().with_status(0));
@@ -84,8 +84,9 @@ fn env_rustflags_build_script_dep() {
         .file("src/lib.rs", "")
         .file("build.rs", r#"
             fn main() { }
-        "#);
-    let bar = project("bar")
+        "#)
+        .build();
+    let _bar = project("bar")
         .file("Cargo.toml", r#"
             [package]
             name = "bar"
@@ -95,9 +96,8 @@ fn env_rustflags_build_script_dep() {
             fn bar() { }
             #[cfg(not(foo))]
             fn bar() { }
-        "#);
-    foo.build();
-    bar.build();
+        "#)
+        .build();
 
     assert_that(foo.cargo("build").env("RUSTFLAGS", "--cfg foo"),
                 execs().with_status(0));
@@ -122,8 +122,8 @@ fn env_rustflags_plugin() {
             fn main() { }
             #[cfg(not(foo))]
             fn main() { }
-        "#);
-    p.build();
+        "#)
+        .build();
 
     assert_that(p.cargo("build").env("RUSTFLAGS", "--cfg foo"),
                 execs().with_status(0));
@@ -149,8 +149,9 @@ fn env_rustflags_plugin_dep() {
         "#)
         .file("src/lib.rs", r#"
             fn foo() { }
-        "#);
-    let bar = project("bar")
+        "#)
+        .build();
+    let _bar = project("bar")
         .file("Cargo.toml", r#"
             [package]
             name = "bar"
@@ -163,9 +164,8 @@ fn env_rustflags_plugin_dep() {
             fn bar() { }
             #[cfg(not(foo))]
             fn bar() { }
-        "#);
-    foo.build();
-    bar.build();
+        "#)
+        .build();
 
     assert_that(foo.cargo("build").env("RUSTFLAGS", "--cfg foo"),
                 execs().with_status(0));
@@ -186,8 +186,8 @@ fn env_rustflags_normal_source_with_target() {
         .file("benches/d.rs", r#"
             #![feature(test)]
             extern crate test;
-            #[bench] fn run1(_ben: &mut test::Bencher) { }"#);
-    p.build();
+            #[bench] fn run1(_ben: &mut test::Bencher) { }"#)
+        .build();
 
     let host = &rustc_host();
 
@@ -226,8 +226,8 @@ fn env_rustflags_build_script_with_target() {
             fn main() { }
             #[cfg(foo)]
             fn main() { }
-        "#);
-    p.build();
+        "#)
+        .build();
 
     let host = rustc_host();
     assert_that(p.cargo("build").env("RUSTFLAGS", "--cfg foo")
@@ -253,8 +253,9 @@ fn env_rustflags_build_script_dep_with_target() {
         .file("src/lib.rs", "")
         .file("build.rs", r#"
             fn main() { }
-        "#);
-    let bar = project("bar")
+        "#)
+        .build();
+    let _bar = project("bar")
         .file("Cargo.toml", r#"
             [package]
             name = "bar"
@@ -264,9 +265,8 @@ fn env_rustflags_build_script_dep_with_target() {
             fn bar() { }
             #[cfg(foo)]
             fn bar() { }
-        "#);
-    foo.build();
-    bar.build();
+        "#)
+        .build();
 
     let host = rustc_host();
     assert_that(foo.cargo("build").env("RUSTFLAGS", "--cfg foo")
@@ -293,8 +293,8 @@ fn env_rustflags_plugin_with_target() {
             fn main() { }
             #[cfg(foo)]
             fn main() { }
-        "#);
-    p.build();
+        "#)
+        .build();
 
     let host = rustc_host();
     assert_that(p.cargo("build").env("RUSTFLAGS", "--cfg foo")
@@ -322,8 +322,9 @@ fn env_rustflags_plugin_dep_with_target() {
         "#)
         .file("src/lib.rs", r#"
             fn foo() { }
-        "#);
-    let bar = project("bar")
+        "#)
+        .build();
+    let _bar = project("bar")
         .file("Cargo.toml", r#"
             [package]
             name = "bar"
@@ -336,9 +337,8 @@ fn env_rustflags_plugin_dep_with_target() {
             fn bar() { }
             #[cfg(foo)]
             fn bar() { }
-        "#);
-    foo.build();
-    bar.build();
+        "#)
+        .build();
 
     let host = rustc_host();
     assert_that(foo.cargo("build").env("RUSTFLAGS", "--cfg foo")
@@ -354,8 +354,8 @@ fn env_rustflags_recompile() {
             name = "foo"
             version = "0.0.1"
         "#)
-        .file("src/lib.rs", "");
-    p.build();
+        .file("src/lib.rs", "")
+        .build();
 
     assert_that(p.cargo("build"),
                 execs().with_status(0));
@@ -372,8 +372,8 @@ fn env_rustflags_recompile2() {
             name = "foo"
             version = "0.0.1"
         "#)
-        .file("src/lib.rs", "");
-    p.build();
+        .file("src/lib.rs", "")
+        .build();
 
     assert_that(p.cargo("build").env("RUSTFLAGS", "--cfg foo"),
                 execs().with_status(0));
@@ -390,8 +390,8 @@ fn env_rustflags_no_recompile() {
             name = "foo"
             version = "0.0.1"
         "#)
-        .file("src/lib.rs", "");
-    p.build();
+        .file("src/lib.rs", "")
+        .build();
 
     assert_that(p.cargo("build").env("RUSTFLAGS", "--cfg foo"),
                 execs().with_status(0));
@@ -418,8 +418,8 @@ fn build_rustflags_normal_source() {
         .file(".cargo/config", r#"
             [build]
             rustflags = ["-Z", "bogus"]
-            "#);
-    p.build();
+            "#)
+        .build();
 
     assert_that(p.cargo("build")
                 .arg("--lib"),
@@ -457,8 +457,8 @@ fn build_rustflags_build_script() {
         .file(".cargo/config", r#"
             [build]
             rustflags = ["--cfg", "foo"]
-            "#);
-    p.build();
+            "#)
+        .build();
 
     assert_that(p.cargo("build"),
                 execs().with_status(0));
@@ -486,8 +486,9 @@ fn build_rustflags_build_script_dep() {
         .file(".cargo/config", r#"
             [build]
             rustflags = ["--cfg", "foo"]
-            "#);
-    let bar = project("bar")
+            "#)
+        .build();
+    let _bar = project("bar")
         .file("Cargo.toml", r#"
             [package]
             name = "bar"
@@ -497,9 +498,8 @@ fn build_rustflags_build_script_dep() {
             fn bar() { }
             #[cfg(not(foo))]
             fn bar() { }
-        "#);
-    foo.build();
-    bar.build();
+        "#)
+        .build();
 
     assert_that(foo.cargo("build"),
                 execs().with_status(0));
@@ -528,8 +528,8 @@ fn build_rustflags_plugin() {
         .file(".cargo/config", r#"
             [build]
             rustflags = ["--cfg", "foo"]
-            "#);
-    p.build();
+            "#)
+        .build();
 
     assert_that(p.cargo("build"),
                 execs().with_status(0));
@@ -559,8 +559,9 @@ fn build_rustflags_plugin_dep() {
         .file(".cargo/config", r#"
             [build]
             rustflags = ["--cfg", "foo"]
-            "#);
-    let bar = project("bar")
+            "#)
+        .build();
+    let _bar = project("bar")
         .file("Cargo.toml", r#"
             [package]
             name = "bar"
@@ -573,9 +574,8 @@ fn build_rustflags_plugin_dep() {
             fn bar() { }
             #[cfg(not(foo))]
             fn bar() { }
-        "#);
-    foo.build();
-    bar.build();
+        "#)
+        .build();
 
     assert_that(foo.cargo("build"),
                 execs().with_status(0));
@@ -600,8 +600,8 @@ fn build_rustflags_normal_source_with_target() {
         .file(".cargo/config", r#"
             [build]
             rustflags = ["-Z", "bogus"]
-            "#);
-    p.build();
+            "#)
+        .build();
 
     let ref host = rustc_host();
 
@@ -644,8 +644,8 @@ fn build_rustflags_build_script_with_target() {
         .file(".cargo/config", r#"
             [build]
             rustflags = ["--cfg", "foo"]
-            "#);
-    p.build();
+            "#)
+        .build();
 
     let host = rustc_host();
     assert_that(p.cargo("build")
@@ -675,8 +675,9 @@ fn build_rustflags_build_script_dep_with_target() {
         .file(".cargo/config", r#"
             [build]
             rustflags = ["--cfg", "foo"]
-            "#);
-    let bar = project("bar")
+            "#)
+        .build();
+    let _bar = project("bar")
         .file("Cargo.toml", r#"
             [package]
             name = "bar"
@@ -686,9 +687,8 @@ fn build_rustflags_build_script_dep_with_target() {
             fn bar() { }
             #[cfg(foo)]
             fn bar() { }
-        "#);
-    foo.build();
-    bar.build();
+        "#)
+        .build();
 
     let host = rustc_host();
     assert_that(foo.cargo("build")
@@ -719,8 +719,8 @@ fn build_rustflags_plugin_with_target() {
         .file(".cargo/config", r#"
             [build]
             rustflags = ["--cfg", "foo"]
-            "#);
-    p.build();
+            "#)
+        .build();
 
     let host = rustc_host();
     assert_that(p.cargo("build")
@@ -752,8 +752,9 @@ fn build_rustflags_plugin_dep_with_target() {
         .file(".cargo/config", r#"
             [build]
             rustflags = ["--cfg", "foo"]
-            "#);
-    let bar = project("bar")
+            "#)
+        .build();
+    let _bar = project("bar")
         .file("Cargo.toml", r#"
             [package]
             name = "bar"
@@ -766,9 +767,8 @@ fn build_rustflags_plugin_dep_with_target() {
             fn bar() { }
             #[cfg(foo)]
             fn bar() { }
-        "#);
-    foo.build();
-    bar.build();
+        "#)
+        .build();
 
     let host = rustc_host();
     assert_that(foo.cargo("build")
@@ -784,8 +784,8 @@ fn build_rustflags_recompile() {
             name = "foo"
             version = "0.0.1"
         "#)
-        .file("src/lib.rs", "");
-    p.build();
+        .file("src/lib.rs", "")
+        .build();
 
     assert_that(p.cargo("build"),
                 execs().with_status(0));
@@ -812,8 +812,8 @@ fn build_rustflags_recompile2() {
             name = "foo"
             version = "0.0.1"
         "#)
-        .file("src/lib.rs", "");
-    p.build();
+        .file("src/lib.rs", "")
+        .build();
 
     assert_that(p.cargo("build").env("RUSTFLAGS", "--cfg foo"),
                 execs().with_status(0));
@@ -844,8 +844,8 @@ fn build_rustflags_no_recompile() {
         .file(".cargo/config", r#"
             [build]
             rustflags = ["--cfg", "foo"]
-            "#);
-    p.build();
+            "#)
+        .build();
 
     assert_that(p.cargo("build").env("RUSTFLAGS", "--cfg foo"),
                 execs().with_status(0));
@@ -872,8 +872,8 @@ fn build_rustflags_with_home_config() {
             name = "foo"
             version = "0.0.1"
         "#)
-        .file("src/lib.rs", "");
-    p.build();
+        .file("src/lib.rs", "")
+        .build();
 
     assert_that(p.cargo("build").arg("-v"),
                 execs().with_status(0));
@@ -898,8 +898,8 @@ fn target_rustflags_normal_source() {
         .file(".cargo/config", &format!("
             [target.{}]
             rustflags = [\"-Z\", \"bogus\"]
-            ", rustc_host()));
-    p.build();
+            ", rustc_host()))
+        .build();
 
     assert_that(p.cargo("build")
                 .arg("--lib"),
@@ -932,8 +932,8 @@ fn target_rustflags_precedence() {
 
             [target.{}]
             rustflags = [\"-Z\", \"bogus\"]
-            ", rustc_host()));
-    p.build();
+            ", rustc_host()))
+        .build();
 
     assert_that(p.cargo("build")
                 .arg("--lib"),
@@ -965,9 +965,9 @@ fn cfg_rustflags_normal_source() {
         .file(".cargo/config", &format!(r#"
             [target.'cfg({})']
             rustflags = ["--cfg", "bar"]
-            "#, if rustc_host().contains("-windows-") {"windows"} else {"not(windows)"}));
-    p.build();
-    
+            "#, if rustc_host().contains("-windows-") {"windows"} else {"not(windows)"}))
+        .build();
+
     assert_that(p.cargo("build").arg("--lib").arg("-v"),
                 execs().with_status(0).with_stderr("\
 [COMPILING] foo v0.0.1 ([..])
@@ -1028,8 +1028,8 @@ fn cfg_rustflags_precedence() {
 
             [target.'cfg({})']
             rustflags = ["--cfg", "bar"]
-            "#, if rustc_host().contains("-windows-") { "windows" } else { "not(windows)" }));
-    p.build();
+            "#, if rustc_host().contains("-windows-") { "windows" } else { "not(windows)" }))
+        .build();
 
     assert_that(p.cargo("build").arg("--lib").arg("-v"),
                 execs().with_status(0).with_stderr("\
@@ -1084,8 +1084,8 @@ fn target_rustflags_string_and_array_form1() {
         .file(".cargo/config", r#"
             [build]
             rustflags = ["--cfg", "foo"]
-            "#);
-    p1.build();
+            "#)
+        .build();
 
     assert_that(p1.cargo("build").arg("-v"),
         execs().with_status(0).with_stderr("\
@@ -1104,8 +1104,8 @@ fn target_rustflags_string_and_array_form1() {
         .file(".cargo/config", r#"
             [build]
             rustflags = "--cfg foo"
-            "#);
-    p2.build();
+            "#)
+        .build();
 
     assert_that(p2.cargo("build").arg("-v"),
         execs().with_status(0).with_stderr("\
@@ -1128,8 +1128,8 @@ fn target_rustflags_string_and_array_form2() {
             [target.{}]
             rustflags = ["--cfg", "foo"]
         "#, rustc_host()))
-        .file("src/lib.rs", "");
-    p1.build();
+        .file("src/lib.rs", "")
+        .build();
 
     assert_that(p1.cargo("build").arg("-v"),
         execs().with_status(0).with_stderr("\
@@ -1148,8 +1148,8 @@ fn target_rustflags_string_and_array_form2() {
             [target.{}]
             rustflags = "--cfg foo"
         "#, rustc_host()))
-        .file("src/lib.rs", "");
-    p2.build();
+        .file("src/lib.rs", "")
+        .build();
 
     assert_that(p2.cargo("build").arg("-v"),
         execs().with_status(0).with_stderr("\

--- a/tests/search.rs
+++ b/tests/search.rs
@@ -24,7 +24,7 @@ fn setup() {
     fs::create_dir_all(config.parent().unwrap()).unwrap();
     fs::create_dir_all(&api_path().join("api/v1")).unwrap();
 
-    repo(&registry_path())
+    let _ = repo(&registry_path())
         .file("config.json", &format!(r#"{{
             "dl": "{0}",
             "api": "{0}"

--- a/tests/small-fd-limits.rs
+++ b/tests/small-fd-limits.rs
@@ -34,10 +34,11 @@ fn run_test(path_env: Option<&OsStr>) {
             [dependencies]
             bar = "*"
         "#)
-        .file("src/lib.rs", "");
+        .file("src/lib.rs", "")
+        .build();
     Package::new("bar", "0.1.0").publish();
 
-    assert_that(foo.cargo_process("build"),
+    assert_that(foo.cargo("build"),
                 execs().with_status(0));
 
     let index = find_index();

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -29,9 +29,10 @@ fn cargo_test_simple() {
             #[test]
             fn test_hello() {
                 assert_eq!(hello(), "hello")
-            }"#);
+            }"#)
+        .build();
 
-    assert_that(p.cargo_process("build"), execs().with_status(0));
+    assert_that(p.cargo("build"), execs().with_status(0));
     assert_that(&p.bin("foo"), existing_file());
 
     assert_that(process(&p.bin("foo")),
@@ -76,9 +77,10 @@ fn cargo_test_release() {
             version = "0.0.1"
             authors = []
         "#)
-        .file("bar/src/lib.rs", "pub fn bar() {}");
+        .file("bar/src/lib.rs", "pub fn bar() {}")
+        .build();
 
-    assert_that(p.cargo_process("test").arg("-v").arg("--release"),
+    assert_that(p.cargo("test").arg("-v").arg("--release"),
                 execs().with_status(0).with_stderr(format!("\
 [COMPILING] bar v0.0.1 ({dir}/bar)
 [RUNNING] [..] -C opt-level=3 [..]
@@ -120,9 +122,10 @@ fn cargo_test_overflow_checks() {
                     [1, i32::max_value()].iter().sum::<i32>();
                 });
                 assert!(r.is_err());
-            }"#);
+            }"#)
+        .build();
 
-    assert_that(p.cargo_process("build").arg("--release"),
+    assert_that(p.cargo("build").arg("--release"),
                 execs().with_status(0));
     assert_that(&p.release_bin("foo"), existing_file());
 
@@ -137,9 +140,10 @@ fn cargo_test_verbose() {
         .file("src/main.rs", r#"
             fn main() {}
             #[test] fn test_hello() {}
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("test").arg("-v").arg("hello"),
+    assert_that(p.cargo("test").arg("-v").arg("hello"),
                 execs().with_status(0).with_stderr(format!("\
 [COMPILING] foo v0.5.0 ({url})
 [RUNNING] `rustc [..] src[/]main.rs [..]`
@@ -169,9 +173,10 @@ fn many_similar_names() {
         .file("tests/foo.rs", r#"
             extern crate foo;
             #[test] fn test_test() { foo::foo() }
-        "#);
+        "#)
+        .build();
 
-    let output = p.cargo_process("test").arg("-v").exec_with_output().unwrap();
+    let output = p.cargo("test").arg("-v").exec_with_output().unwrap();
     let output = str::from_utf8(&output.stdout).unwrap();
     assert!(output.contains("test bin_test"), "bin_test missing\n{}", output);
     assert!(output.contains("test lib_test"), "lib_test missing\n{}", output);
@@ -194,9 +199,10 @@ fn cargo_test_failing_test_in_bin() {
             #[test]
             fn test_hello() {
                 assert_eq!(hello(), "nope")
-            }"#);
+            }"#)
+        .build();
 
-    assert_that(p.cargo_process("build"), execs().with_status(0));
+    assert_that(p.cargo("build"), execs().with_status(0));
     assert_that(&p.bin("foo"), existing_file());
 
     assert_that(process(&p.bin("foo")),
@@ -239,9 +245,10 @@ fn cargo_test_failing_test_in_test() {
             #[test]
             fn test_hello() {
                 assert!(false)
-            }"#);
+            }"#)
+        .build();
 
-    assert_that(p.cargo_process("build"), execs().with_status(0));
+    assert_that(p.cargo("build"), execs().with_status(0));
     assert_that(&p.bin("foo"), existing_file());
 
     assert_that(process(&p.bin("foo")),
@@ -280,9 +287,10 @@ fn cargo_test_failing_test_in_lib() {
             #[test]
             fn test_hello() {
                 assert!(false)
-            }"#);
+            }"#)
+        .build();
 
-    assert_that(p.cargo_process("test"),
+    assert_that(p.cargo("test"),
                 execs().with_stderr(format!("\
 [COMPILING] foo v0.5.0 ({url})
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
@@ -338,9 +346,10 @@ fn test_with_lib_dep() {
 
             #[test]
             fn bin_test() {}
-        ");
+        ")
+        .build();
 
-    assert_that(p.cargo_process("test"),
+    assert_that(p.cargo("test"),
                 execs().with_status(0).with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({})
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
@@ -376,8 +385,9 @@ fn test_with_deep_lib_dep() {
             fn bar_test() {
                 foo::foo();
             }
-        ");
-    let p2 = project("foo")
+        ")
+        .build();
+    let _p2 = project("foo")
         .file("Cargo.toml", r#"
             [package]
             name = "foo"
@@ -389,10 +399,10 @@ fn test_with_deep_lib_dep() {
 
             #[test]
             fn foo_test() {}
-        ");
+        ")
+        .build();
 
-    p2.build();
-    assert_that(p.cargo_process("test"),
+    assert_that(p.cargo("test"),
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ([..])
@@ -428,9 +438,10 @@ fn external_test_explicit() {
 
             #[test]
             fn external_test() { assert_eq!(foo::get_hello(), "Hello") }
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("test"),
+    assert_that(p.cargo("test"),
                 execs().with_status(0).with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({})
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
@@ -458,9 +469,10 @@ fn external_test_named_test() {
         .file("tests/test.rs", r#"
             #[test]
             fn foo() { }
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("test"),
+    assert_that(p.cargo("test"),
                 execs().with_status(0))
 }
 
@@ -484,9 +496,10 @@ fn external_test_implicit() {
 
             #[test]
             fn external_test() { assert_eq!(foo::get_hello(), "Hello") }
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("test"),
+    assert_that(p.cargo("test"),
                 execs().with_status(0).with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({})
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
@@ -511,8 +524,9 @@ fn dont_run_examples() {
         "#)
         .file("examples/dont-run-me-i-will-fail.rs", r#"
             fn main() { panic!("Examples should not be run by 'cargo test'"); }
-        "#);
-    assert_that(p.cargo_process("test"),
+        "#)
+        .build();
+    assert_that(p.cargo("test"),
                 execs().with_status(0));
 }
 
@@ -528,9 +542,10 @@ fn pass_through_command_line() {
         .file("src/lib.rs", "
             #[test] fn foo() {}
             #[test] fn bar() {}
-        ");
+        ")
+        .build();
 
-    assert_that(p.cargo_process("test").arg("bar"),
+    assert_that(p.cargo("test").arg("bar"),
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({dir})
@@ -561,9 +576,10 @@ fn cargo_test_twice() {
 
             #[test]
             fn dummy_test() { }
-            "#);
+            "#)
+        .build();
 
-    p.cargo_process("build");
+    p.cargo("build");
 
     for _ in 0..2 {
         assert_that(p.cargo("test"),
@@ -594,9 +610,10 @@ fn lib_bin_same_name() {
 
             #[test]
             fn bin_test() {}
-        ");
+        ")
+        .build();
 
-    assert_that(p.cargo_process("test"),
+    assert_that(p.cargo("test"),
                 execs().with_status(0).with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({})
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
@@ -630,9 +647,10 @@ fn lib_with_standard_name() {
 
             #[test]
             fn test() { syntax::foo() }
-        ");
+        ")
+        .build();
 
-    assert_that(p.cargo_process("test"),
+    assert_that(p.cargo("test"),
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] syntax v0.0.1 ({dir})
@@ -669,9 +687,10 @@ fn lib_with_standard_name2() {
 
             #[test]
             fn test() { syntax::foo() }
-        ");
+        ")
+        .build();
 
-    assert_that(p.cargo_process("test"),
+    assert_that(p.cargo("test"),
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] syntax v0.0.1 ({dir})
@@ -703,9 +722,10 @@ fn lib_without_name() {
 
             #[test]
             fn test() { syntax::foo() }
-        ");
+        ")
+        .build();
 
-    assert_that(p.cargo_process("test"),
+    assert_that(p.cargo("test"),
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] syntax v0.0.1 ({dir})
@@ -740,9 +760,10 @@ fn bin_without_name() {
 
             #[test]
             fn test() { syntax::foo() }
-        ");
+        ")
+        .build();
 
-    assert_that(p.cargo_process("test"),
+    assert_that(p.cargo("test"),
                 execs().with_status(101)
                        .with_stderr("\
 [ERROR] failed to parse manifest at `[..]`
@@ -785,9 +806,10 @@ fn bench_without_name() {
 
             #[bench]
             fn external_bench(_b: &mut test::Bencher) {}
-        ");
+        ")
+        .build();
 
-    assert_that(p.cargo_process("test"),
+    assert_that(p.cargo("test"),
                 execs().with_status(101)
                        .with_stderr("\
 [ERROR] failed to parse manifest at `[..]`
@@ -829,9 +851,10 @@ fn test_without_name() {
 
             #[test]
             fn external_test() { assert_eq!(syntax::get_hello(), "Hello") }
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("test"),
+    assert_that(p.cargo("test"),
                 execs().with_status(101)
                        .with_stderr("\
 [ERROR] failed to parse manifest at `[..]`
@@ -873,9 +896,10 @@ fn example_without_name() {
             fn main() {
                 println!("example1");
             }
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("test"),
+    assert_that(p.cargo("test"),
                 execs().with_status(101)
                        .with_stderr("\
 [ERROR] failed to parse manifest at `[..]`
@@ -904,9 +928,10 @@ fn bin_there_for_integration() {
                 let status = Command::new("target/debug/foo").status().unwrap();
                 assert_eq!(status.code(), Some(101));
             }
-        "#);
+        "#)
+        .build();
 
-    let output = p.cargo_process("test").arg("-v").exec_with_output().unwrap();
+    let output = p.cargo("test").arg("-v").exec_with_output().unwrap();
     let output = str::from_utf8(&output.stdout).unwrap();
     assert!(output.contains("main_test ... ok"), "no main_test\n{}", output);
     assert!(output.contains("test_test ... ok"), "no test_test\n{}", output);
@@ -954,9 +979,10 @@ fn test_dylib() {
         "#)
         .file("bar/src/lib.rs", "
              pub fn baz() {}
-        ");
+        ")
+        .build();
 
-    assert_that(p.cargo_process("test"),
+    assert_that(p.cargo("test"),
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] bar v0.0.1 ({dir}/bar)
@@ -990,9 +1016,10 @@ fn test_twice_with_build_cmd() {
         .file("src/lib.rs", "
             #[test]
             fn foo() {}
-        ");
+        ")
+        .build();
 
-    assert_that(p.cargo_process("test"),
+    assert_that(p.cargo("test"),
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({dir})
@@ -1024,9 +1051,10 @@ fn test_then_build() {
         .file("src/lib.rs", "
             #[test]
             fn foo() {}
-        ");
+        ")
+        .build();
 
-    assert_that(p.cargo_process("test"),
+    assert_that(p.cargo("test"),
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({dir})
@@ -1053,9 +1081,10 @@ fn test_no_run() {
         .file("src/lib.rs", "
             #[test]
             fn foo() { panic!() }
-        ");
+        ")
+        .build();
 
-    assert_that(p.cargo_process("test").arg("--no-run"),
+    assert_that(p.cargo("test").arg("--no-run"),
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({dir})
@@ -1082,9 +1111,10 @@ fn test_run_specific_bin_target() {
             path="src/bin2.rs"
         "#)
         .file("src/bin1.rs", "#[test] fn test1() { }")
-        .file("src/bin2.rs", "#[test] fn test2() { }");
+        .file("src/bin2.rs", "#[test] fn test2() { }")
+        .build();
 
-    assert_that(prj.cargo_process("test").arg("--bin").arg("bin2"),
+    assert_that(prj.cargo("test").arg("--bin").arg("bin2"),
                 execs().with_status(0)
                        .with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({dir})
@@ -1111,9 +1141,10 @@ fn test_run_implicit_bin_target() {
         .file("tests/mytest.rs", "#[test] fn test_in_test() { }")
         .file("benches/mybench.rs", "#[test] fn test_in_bench() { }")
         .file("examples/myexm.rs", "#[test] fn test_in_exm() { }
-               fn main() { panic!(\"Don't execute me!\"); }");
+               fn main() { panic!(\"Don't execute me!\"); }")
+        .build();
 
-    assert_that(prj.cargo_process("test").arg("--bins"),
+    assert_that(prj.cargo("test").arg("--bins"),
                 execs().with_status(0)
                        .with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({dir})
@@ -1134,9 +1165,10 @@ fn test_run_specific_test_target() {
         .file("src/bin/a.rs", "fn main() { }")
         .file("src/bin/b.rs", "#[test] fn test_b() { } fn main() { }")
         .file("tests/a.rs", "#[test] fn test_a() { }")
-        .file("tests/b.rs", "#[test] fn test_b() { }");
+        .file("tests/b.rs", "#[test] fn test_b() { }")
+        .build();
 
-    assert_that(prj.cargo_process("test").arg("--test").arg("b"),
+    assert_that(prj.cargo("test").arg("--test").arg("b"),
                 execs().with_status(0)
                        .with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({dir})
@@ -1163,9 +1195,10 @@ fn test_run_implicit_test_target() {
         .file("tests/mytest.rs", "#[test] fn test_in_test() { }")
         .file("benches/mybench.rs", "#[test] fn test_in_bench() { }")
         .file("examples/myexm.rs", "#[test] fn test_in_exm() { }
-               fn main() { panic!(\"Don't execute me!\"); }");
+               fn main() { panic!(\"Don't execute me!\"); }")
+        .build();
 
-    assert_that(prj.cargo_process("test").arg("--tests"),
+    assert_that(prj.cargo("test").arg("--tests"),
                 execs().with_status(0)
                        .with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({dir})
@@ -1192,9 +1225,10 @@ fn test_run_implicit_bench_target() {
         .file("tests/mytest.rs", "#[test] fn test_in_test() { }")
         .file("benches/mybench.rs", "#[test] fn test_in_bench() { }")
         .file("examples/myexm.rs", "#[test] fn test_in_exm() { }
-               fn main() { panic!(\"Don't execute me!\"); }");
+               fn main() { panic!(\"Don't execute me!\"); }")
+        .build();
 
-    assert_that(prj.cargo_process("test").arg("--benches"),
+    assert_that(prj.cargo("test").arg("--benches"),
                 execs().with_status(0)
                        .with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({dir})
@@ -1221,9 +1255,10 @@ fn test_run_implicit_example_target() {
         .file("tests/mytest.rs", "#[test] fn test_in_test() { }")
         .file("benches/mybench.rs", "#[test] fn test_in_bench() { }")
         .file("examples/myexm.rs", "#[test] fn test_in_exm() { }
-               fn main() { panic!(\"Don't execute me!\"); }");
+               fn main() { panic!(\"Don't execute me!\"); }")
+        .build();
 
-    assert_that(prj.cargo_process("test").arg("--examples"),
+    assert_that(prj.cargo("test").arg("--examples"),
                 execs().with_status(0)
                        .with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({dir})
@@ -1249,9 +1284,10 @@ fn test_no_harness() {
             harness = false
         "#)
         .file("src/main.rs", "fn main() {}")
-        .file("foo.rs", "fn main() {}");
+        .file("foo.rs", "fn main() {}")
+        .build();
 
-    assert_that(p.cargo_process("test").arg("--").arg("--nocapture"),
+    assert_that(p.cargo("test").arg("--").arg("--nocapture"),
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({dir})
@@ -1304,7 +1340,7 @@ fn selective_testing() {
         "#)
         .file("d2/src/lib.rs", "")
         .file("d2/src/main.rs", "#[allow(unused_extern_crates)] extern crate d2; fn main() {}");
-    p.build();
+    let p = p.build();
 
     println!("d1");
     assert_that(p.cargo("test").arg("-p").arg("d1"),
@@ -1373,9 +1409,10 @@ fn almost_cyclic_but_not_quite() {
             version = "0.0.1"
             authors = []
         "#)
-        .file("c/src/lib.rs", "");
+        .file("c/src/lib.rs", "")
+        .build();
 
-    assert_that(p.cargo_process("build"), execs().with_status(0));
+    assert_that(p.cargo("build"), execs().with_status(0));
     assert_that(p.cargo("test"),
                 execs().with_status(0));
 }
@@ -1406,9 +1443,10 @@ fn build_then_selective_test() {
             version = "0.0.1"
             authors = []
         "#)
-        .file("b/src/lib.rs", "");
+        .file("b/src/lib.rs", "")
+        .build();
 
-    assert_that(p.cargo_process("build"), execs().with_status(0));
+    assert_that(p.cargo("build"), execs().with_status(0));
     p.root().move_into_the_past();
     assert_that(p.cargo("test").arg("-p").arg("b"),
                 execs().with_status(0));
@@ -1452,8 +1490,9 @@ fn example_dev_dep() {
             pub fn bar() {
                 f8!();
             }
-        "#);
-    assert_that(p.cargo_process("test"),
+        "#)
+        .build();
+    assert_that(p.cargo("test"),
                 execs().with_status(0));
     assert_that(p.cargo("run")
                  .arg("--example").arg("e1").arg("--release").arg("-v"),
@@ -1489,7 +1528,7 @@ fn selective_testing_with_docs() {
             path = "d1.rs"
         "#)
         .file("d1/d1.rs", "");
-    p.build();
+    let p = p.build();
 
     assert_that(p.cargo("test").arg("-p").arg("d1"),
                 execs().with_status(0)
@@ -1511,9 +1550,10 @@ fn example_bin_same_name() {
             authors = []
         "#)
         .file("src/bin/foo.rs", r#"fn main() { println!("bin"); }"#)
-        .file("examples/foo.rs", r#"fn main() { println!("example"); }"#);
+        .file("examples/foo.rs", r#"fn main() { println!("example"); }"#)
+        .build();
 
-    assert_that(p.cargo_process("test").arg("--no-run").arg("-v"),
+    assert_that(p.cargo("test").arg("--no-run").arg("-v"),
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({dir})
@@ -1550,10 +1590,11 @@ fn test_with_example_twice() {
             authors = []
         "#)
         .file("src/bin/foo.rs", r#"fn main() { println!("bin"); }"#)
-        .file("examples/foo.rs", r#"fn main() { println!("example"); }"#);
+        .file("examples/foo.rs", r#"fn main() { println!("example"); }"#)
+        .build();
 
     println!("first");
-    assert_that(p.cargo_process("test").arg("-v"),
+    assert_that(p.cargo("test").arg("-v"),
                 execs().with_status(0));
     assert_that(&p.bin("examples/foo"), existing_file());
     println!("second");
@@ -1587,9 +1628,10 @@ fn example_with_dev_dep() {
             version = "0.0.1"
             authors = []
         "#)
-        .file("a/src/lib.rs", "");
+        .file("a/src/lib.rs", "")
+        .build();
 
-    assert_that(p.cargo_process("test").arg("-v"),
+    assert_that(p.cargo("test").arg("-v"),
                 execs().with_status(0)
                        .with_stderr("\
 [..]
@@ -1611,9 +1653,10 @@ fn bin_is_preserved() {
             authors = []
         "#)
         .file("src/lib.rs", "")
-        .file("src/main.rs", "fn main() {}");
+        .file("src/main.rs", "fn main() {}")
+        .build();
 
-    assert_that(p.cargo_process("build").arg("-v"),
+    assert_that(p.cargo("build").arg("-v"),
                 execs().with_status(0));
     assert_that(&p.bin("foo"), existing_file());
 
@@ -1633,7 +1676,7 @@ fn bad_example() {
             authors = []
         "#)
         .file("src/lib.rs", "");
-    p.build();
+    let p = p.build();
 
     assert_that(p.cargo("run").arg("--example").arg("foo"),
                 execs().with_status(101).with_stderr("\
@@ -1662,9 +1705,10 @@ fn doctest_feature() {
             /// ```
             #[cfg(feature = "bar")]
             pub fn foo() -> i32 { 1 }
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("test").arg("--features").arg("bar"),
+    assert_that(p.cargo("test").arg("--features").arg("bar"),
                 execs().with_status(0)
                        .with_stderr("\
 [COMPILING] foo [..]
@@ -1689,9 +1733,10 @@ fn dashes_to_underscores() {
             /// assert_eq!(foo_bar::foo(), 1);
             /// ```
             pub fn foo() -> i32 { 1 }
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("test").arg("-v"),
+    assert_that(p.cargo("test").arg("-v"),
                 execs().with_status(0));
 }
 
@@ -1719,9 +1764,10 @@ fn doctest_dev_dep() {
             version = "0.0.1"
             authors = []
         "#)
-        .file("b/src/lib.rs", "");
+        .file("b/src/lib.rs", "")
+        .build();
 
-    assert_that(p.cargo_process("test").arg("-v"),
+    assert_that(p.cargo("test").arg("-v"),
                 execs().with_status(0));
 }
 
@@ -1740,9 +1786,10 @@ fn filter_no_doc_tests() {
             /// ```
             pub fn foo() {}
         "#)
-        .file("tests/foo.rs", "");
+        .file("tests/foo.rs", "")
+        .build();
 
-    assert_that(p.cargo_process("test").arg("--test=foo"),
+    assert_that(p.cargo("test").arg("--test=foo"),
                 execs().with_status(0).with_stderr("\
 [COMPILING] foo v0.0.1 ([..])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
@@ -1769,9 +1816,10 @@ fn dylib_doctest() {
             /// foo::foo();
             /// ```
             pub fn foo() {}
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("test"),
+    assert_that(p.cargo("test"),
                 execs().with_status(0).with_stderr("\
 [COMPILING] foo v0.0.1 ([..])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
@@ -1799,9 +1847,10 @@ fn dylib_doctest2() {
             /// foo::foo();
             /// ```
             pub fn foo() {}
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("test"),
+    assert_that(p.cargo("test"),
                 execs().with_status(0).with_stdout(""));
 }
 
@@ -1834,8 +1883,9 @@ fn cyclic_dev_dep_doc_test() {
         .file("bar/src/lib.rs", r#"
             #[allow(unused_extern_crates)]
             extern crate foo;
-        "#);
-    assert_that(p.cargo_process("test"),
+        "#)
+        .build();
+    assert_that(p.cargo("test"),
                 execs().with_status(0).with_stderr("\
 [COMPILING] foo v0.0.1 ([..])
 [COMPILING] bar v0.0.1 ([..])
@@ -1868,8 +1918,9 @@ fn dev_dep_with_build_script() {
             build = "build.rs"
         "#)
         .file("bar/src/lib.rs", "")
-        .file("bar/build.rs", "fn main() {}");
-    assert_that(p.cargo_process("test"),
+        .file("bar/build.rs", "fn main() {}")
+        .build();
+    assert_that(p.cargo("test"),
                 execs().with_status(0));
 }
 
@@ -1917,8 +1968,9 @@ fn no_fail_fast() {
         fn sub_one_test() {
             assert_eq!(sub_one(1), 0);
         }
-        "#);
-    assert_that(p.cargo_process("test").arg("--no-fail-fast"),
+        "#)
+        .build();
+    assert_that(p.cargo("test").arg("--no-fail-fast"),
                 execs().with_status(101)
                        .with_stderr_contains("\
 [COMPILING] foo v0.0.1 ([..])
@@ -1975,7 +2027,7 @@ fn test_multiple_packages() {
                 doctest = false
         "#)
         .file("d2/src/lib.rs", "");
-    p.build();
+    let p = p.build();
 
     assert_that(p.cargo("test").arg("-p").arg("d1").arg("-p").arg("d2"),
                 execs().with_status(0)
@@ -1998,7 +2050,7 @@ fn bin_does_not_rebuild_tests() {
         .file("src/lib.rs", "")
         .file("src/main.rs", "fn main() {}")
         .file("tests/foo.rs", "");
-    p.build();
+    let p = p.build();
 
     assert_that(p.cargo("test").arg("-v"),
                 execs().with_status(0));
@@ -2040,7 +2092,7 @@ fn selective_test_wonky_profile() {
             authors = []
         "#)
         .file("a/src/lib.rs", "");
-    p.build();
+    let p = p.build();
 
     assert_that(p.cargo("test").arg("-v").arg("--no-run").arg("--release")
                  .arg("-p").arg("foo").arg("-p").arg("a"),
@@ -2067,7 +2119,7 @@ fn selective_test_optional_dep() {
             authors = []
         "#)
         .file("a/src/lib.rs", "");
-    p.build();
+    let p = p.build();
 
     assert_that(p.cargo("test").arg("-v").arg("--no-run")
                  .arg("--features").arg("a").arg("-p").arg("a"),
@@ -2102,7 +2154,7 @@ fn only_test_docs() {
             }
         "#)
         .file("tests/foo.rs", "this is not rust");
-    p.build();
+    let p = p.build();
 
     assert_that(p.cargo("test").arg("--doc"),
                 execs().with_status(0)
@@ -2140,8 +2192,9 @@ fn test_panic_abort_with_dep() {
             version = "0.0.1"
             authors = []
         "#)
-        .file("bar/src/lib.rs", "");
-    assert_that(p.cargo_process("test").arg("-v"),
+        .file("bar/src/lib.rs", "")
+        .build();
+    assert_that(p.cargo("test").arg("-v"),
                 execs().with_status(0));
 }
 
@@ -2163,8 +2216,9 @@ fn cfg_test_even_with_no_harness() {
             fn main() {
                 println!("hello!");
             }
-        "#);
-    assert_that(p.cargo_process("test").arg("-v"),
+        "#)
+        .build();
+    assert_that(p.cargo("test").arg("-v"),
                 execs().with_status(0)
                        .with_stdout("hello!\n")
                        .with_stderr("\
@@ -2197,8 +2251,9 @@ fn panic_abort_multiple() {
             version = "0.0.1"
             authors = []
         "#)
-        .file("a/src/lib.rs", "");
-    assert_that(p.cargo_process("test")
+        .file("a/src/lib.rs", "")
+        .build();
+    assert_that(p.cargo("test")
                  .arg("--release").arg("-v")
                  .arg("-p").arg("foo")
                  .arg("-p").arg("a"),
@@ -2272,7 +2327,7 @@ fn pass_correct_cfgs_flags_to_rustdoc() {
                 authors = []
             "#)
         .file("libs/mock_serde_codegen/src/lib.rs", "");
-    p.build();
+    let p = p.build();
 
     assert_that(p.cargo("test")
                 .arg("--package").arg("feature_a")
@@ -2315,7 +2370,7 @@ fn test_release_ignore_panic() {
             authors = []
         "#)
         .file("a/src/lib.rs", "");
-    p.build();
+    let p = p.build();
     println!("test");
     assert_that(p.cargo("test").arg("-v"), execs().with_status(0));
     println!("bench");
@@ -2346,9 +2401,10 @@ fn test_many_with_features() {
             version = "0.0.1"
             authors = []
         "#)
-        .file("a/src/lib.rs", "");
+        .file("a/src/lib.rs", "")
+        .build();
 
-    assert_that(p.cargo_process("test").arg("-v")
+    assert_that(p.cargo("test").arg("-v")
                  .arg("-p").arg("a")
                  .arg("-p").arg("foo")
                  .arg("--features").arg("foo"),
@@ -2380,9 +2436,10 @@ fn test_all_workspace() {
         .file("bar/src/lib.rs", r#"
             #[test]
             fn bar_test() {}
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("test")
+    assert_that(p.cargo("test")
                  .arg("--all"),
                 execs().with_status(0)
                        .with_stdout_contains("test foo_test ... ok")
@@ -2422,9 +2479,10 @@ fn test_all_exclude() {
             pub fn baz() {
                 assert!(false);
             }
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("test")
+    assert_that(p.cargo("test")
                     .arg("--all")
                     .arg("--exclude")
                     .arg("baz"),
@@ -2457,9 +2515,10 @@ fn test_all_virtual_manifest() {
         .file("b/src/lib.rs", r#"
             #[test]
             fn b() {}
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("test")
+    assert_that(p.cargo("test")
                  .arg("--all"),
                 execs().with_status(0)
                        .with_stdout_contains("test a ... ok")
@@ -2490,9 +2549,10 @@ fn test_virtual_manifest_all_implied() {
         .file("b/src/lib.rs", r#"
             #[test]
             fn b() {}
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("test"),
+    assert_that(p.cargo("test"),
                 execs().with_status(0)
                        .with_stdout_contains("test a ... ok")
                        .with_stdout_contains("test b ... ok"));
@@ -2516,11 +2576,12 @@ fn test_all_member_dependency_same_name() {
         .file("a/src/lib.rs", r#"
             #[test]
             fn a() {}
-        "#);
+        "#)
+        .build();
 
     Package::new("a", "0.1.0").publish();
 
-    assert_that(p.cargo_process("test")
+    assert_that(p.cargo("test")
                  .arg("--all"),
                 execs().with_status(0)
                        .with_stdout_contains("test a ... ok"));
@@ -2552,9 +2613,10 @@ fn doctest_only_with_dev_dep() {
         "#)
         .file("b/src/lib.rs", r#"
             pub fn b() {}
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("test").arg("--doc").arg("-v"),
+    assert_that(p.cargo("test").arg("--doc").arg("-v"),
                 execs().with_status(0));
 }
 
@@ -2597,9 +2659,10 @@ fn test_many_targets() {
         "#)
         .file("tests/c.rs", r#"
             does not compile
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("test").arg("--verbose")
+    assert_that(p.cargo("test").arg("--verbose")
                     .arg("--bin").arg("a").arg("--bin").arg("b")
                     .arg("--example").arg("a").arg("--example").arg("b")
                     .arg("--test").arg("a").arg("--test").arg("b"),
@@ -2647,11 +2710,12 @@ fn doctest_and_registry() {
             [dependencies]
             b = "0.1"
         "#)
-        .file("c/src/lib.rs", "");
+        .file("c/src/lib.rs", "")
+        .build();
 
     Package::new("b", "0.1.0").publish();
 
-    assert_that(p.cargo_process("test").arg("--all").arg("-v"),
+    assert_that(p.cargo("test").arg("--all").arg("-v"),
                 execs().with_status(0));
 }
 
@@ -2669,9 +2733,10 @@ fn cargo_test_env() {
 
     let p = project("env_test")
         .file("Cargo.toml", &basic_lib_manifest("env_test"))
-        .file("src/lib.rs", &src);
+        .file("src/lib.rs", &src)
+        .build();
 
-    let mut pr = p.cargo_process("test");
+    let mut pr = p.cargo("test");
     let cargo = cargo_exe().canonicalize().unwrap();
     assert_that(pr.args(&["--lib", "--", "--nocapture"]),
                 execs().with_status(0)
@@ -2697,9 +2762,10 @@ fn test_order() {
         "#)
         .file("tests/z.rs", r#"
             #[test] fn test_z() {}
-        "#);
+        "#)
+        .build();
 
-        assert_that(p.cargo_process("test").arg("--all"),
+        assert_that(p.cargo("test").arg("--all"),
             execs().with_status(0)
                    .with_stdout_contains("
 running 1 test
@@ -2738,9 +2804,10 @@ fn cyclic_dev() {
         "#)
         .file("tests/foo.rs", r#"
             extern crate foo;
-        "#);
+        "#)
+        .build();
 
-    assert_that(p.cargo_process("test").arg("--all"),
+    assert_that(p.cargo("test").arg("--all"),
                 execs().with_status(0));
 }
 
@@ -2775,8 +2842,8 @@ fn publish_a_crate_without_tests() {
             [dependencies]
             testless = "0.1.0"
         "#)
-        .file("src/lib.rs", "");
-    p.build();
+        .file("src/lib.rs", "")
+        .build();
 
     assert_that(p.cargo("test"), execs().with_status(0));
     assert_that(p.cargo("test").arg("--package").arg("testless"),
@@ -2827,13 +2894,13 @@ fn find_dependency_of_proc_macro_dependency_with_target() {
             pub fn noop(_input: TokenStream) -> TokenStream {
                 "".parse().unwrap()
             }
-        "#);
+        "#)
+        .build();
     Package::new("foo", "0.1.0").publish();
     Package::new("bar", "0.1.0")
         .dep("foo", "0.1")
         .file("src/lib.rs", "extern crate foo;")
         .publish();
-    workspace.build();
     assert_that(workspace.cargo("test").arg("--all").arg("--target").arg(rustc_host()),
                 execs().with_status(0));
 }
@@ -2857,8 +2924,9 @@ fn test_hint_not_masked_by_doctest() {
             fn this_fails() {
                 panic!();
             }
-        "#);
-    assert_that(p.cargo_process("test")
+        "#)
+        .build();
+    assert_that(p.cargo("test")
                  .arg("--no-fail-fast"),
                 execs()
                 .with_status(101)

--- a/tests/verify-project.rs
+++ b/tests/verify-project.rs
@@ -12,9 +12,10 @@ fn verify_project_success_output() -> String {
 fn cargo_verify_project_path_to_cargo_toml_relative() {
     let p = project("foo")
         .file("Cargo.toml", &basic_bin_manifest("foo"))
-        .file("src/foo.rs", &main_file(r#""i am foo""#, &[]));
+        .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
+        .build();
 
-    assert_that(p.cargo_process("verify-project")
+    assert_that(p.cargo("verify-project")
                  .arg("--manifest-path").arg("foo/Cargo.toml")
                  .cwd(p.root().parent().unwrap()),
                 execs().with_status(0)
@@ -25,9 +26,10 @@ fn cargo_verify_project_path_to_cargo_toml_relative() {
 fn cargo_verify_project_path_to_cargo_toml_absolute() {
     let p = project("foo")
         .file("Cargo.toml", &basic_bin_manifest("foo"))
-        .file("src/foo.rs", &main_file(r#""i am foo""#, &[]));
+        .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
+        .build();
 
-    assert_that(p.cargo_process("verify-project")
+    assert_that(p.cargo("verify-project")
                  .arg("--manifest-path").arg(p.root().join("Cargo.toml"))
                  .cwd(p.root().parent().unwrap()),
                 execs().with_status(0)
@@ -38,9 +40,10 @@ fn cargo_verify_project_path_to_cargo_toml_absolute() {
 fn cargo_verify_project_cwd() {
     let p = project("foo")
         .file("Cargo.toml", &basic_bin_manifest("foo"))
-        .file("src/foo.rs", &main_file(r#""i am foo""#, &[]));
+        .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
+        .build();
 
-    assert_that(p.cargo_process("verify-project")
+    assert_that(p.cargo("verify-project")
                  .cwd(p.root()),
                 execs().with_status(0)
                        .with_stdout(verify_project_success_output()));

--- a/tests/version.rs
+++ b/tests/version.rs
@@ -7,8 +7,7 @@ use hamcrest::assert_that;
 
 #[test]
 fn simple() {
-    let p = project("foo");
-    p.build();
+    let p = project("foo").build();
 
     assert_that(p.cargo("version"),
                 execs().with_status(0).with_stdout(&format!("{}\n",
@@ -24,16 +23,17 @@ fn simple() {
 #[test]
 #[cfg_attr(target_os = "windows", ignore)]
 fn version_works_without_rustc() {
-    let p = project("foo");
-    assert_that(p.cargo_process("version").env("PATH", ""),
+    let p = project("foo").build();
+    assert_that(p.cargo("version").env("PATH", ""),
                 execs().with_status(0));
 }
 
 #[test]
 fn version_works_with_bad_config() {
     let p = project("foo")
-        .file(".cargo/config", "this is not toml");
-    assert_that(p.cargo_process("version"),
+        .file(".cargo/config", "this is not toml")
+        .build();
+    assert_that(p.cargo("version"),
                 execs().with_status(0));
 }
 
@@ -43,7 +43,8 @@ fn version_works_with_bad_target_dir() {
         .file(".cargo/config", r#"
             [build]
             target-dir = 4
-        "#);
-    assert_that(p.cargo_process("version"),
+        "#)
+        .build();
+    assert_that(p.cargo("version"),
                 execs().with_status(0));
 }

--- a/tests/warn-on-failure.rs
+++ b/tests/warn-on-failure.rs
@@ -1,7 +1,7 @@
 extern crate cargotest;
 extern crate hamcrest;
 
-use cargotest::support::{project, execs, ProjectBuilder};
+use cargotest::support::{project, execs, Project};
 use cargotest::support::registry::Package;
 use hamcrest::assert_that;
 
@@ -30,7 +30,7 @@ fn make_lib(lib_src: &str) {
         .publish();
 }
 
-fn make_upstream(main_src: &str) -> ProjectBuilder {
+fn make_upstream(main_src: &str) -> Project {
     project("bar")
         .file("Cargo.toml", r#"
             [package]
@@ -42,13 +42,14 @@ fn make_upstream(main_src: &str) -> ProjectBuilder {
             foo = "*"
         "#)
         .file("src/main.rs", &format!("fn main() {{ {} }}", main_src))
+        .build()
 }
 
 #[test]
 fn no_warning_on_success() {
     make_lib("");
     let upstream = make_upstream("");
-    assert_that(upstream.cargo_process("build"),
+    assert_that(upstream.cargo("build"),
                 execs().with_status(0)
                        .with_stderr("\
 [UPDATING] registry `[..]`
@@ -63,7 +64,7 @@ fn no_warning_on_success() {
 fn no_warning_on_bin_failure() {
     make_lib("");
     let upstream = make_upstream("hi()");
-    assert_that(upstream.cargo_process("build"),
+    assert_that(upstream.cargo("build"),
                 execs().with_status(101)
                        .with_stdout_does_not_contain("hidden stdout")
                        .with_stderr_does_not_contain("hidden stderr")
@@ -79,7 +80,7 @@ fn no_warning_on_bin_failure() {
 fn warning_on_lib_failure() {
     make_lib("err()");
     let upstream = make_upstream("");
-    assert_that(upstream.cargo_process("build"),
+    assert_that(upstream.cargo("build"),
                 execs().with_status(101)
                        .with_stdout_does_not_contain("hidden stdout")
                        .with_stderr_does_not_contain("hidden stderr")

--- a/tests/workspaces.rs
+++ b/tests/workspaces.rs
@@ -31,7 +31,7 @@ fn simple_explicit() {
             workspace = ".."
         "#)
         .file("bar/src/main.rs", "fn main() {}");
-    p.build();
+    let p = p.build();
 
     assert_that(p.cargo("build"), execs().with_status(0));
     assert_that(&p.bin("foo"), existing_file());
@@ -66,7 +66,7 @@ fn inferred_root() {
             authors = []
         "#)
         .file("bar/src/main.rs", "fn main() {}");
-    p.build();
+    let p = p.build();
 
     assert_that(p.cargo("build"), execs().with_status(0));
     assert_that(&p.bin("foo"), existing_file());
@@ -104,7 +104,7 @@ fn inferred_path_dep() {
         "#)
         .file("bar/src/main.rs", "fn main() {}")
         .file("bar/src/lib.rs", "");
-    p.build();
+    let p = p.build();
 
     assert_that(p.cargo("build"), execs().with_status(0));
     assert_that(&p.bin("foo"), existing_file());
@@ -153,7 +153,7 @@ fn transitive_path_dep() {
         "#)
         .file("baz/src/main.rs", "fn main() {}")
         .file("baz/src/lib.rs", "");
-    p.build();
+    let p = p.build();
 
     assert_that(p.cargo("build"), execs().with_status(0));
     assert_that(&p.bin("foo"), existing_file());
@@ -201,7 +201,7 @@ fn parent_pointer_works() {
         "#)
         .file("bar/src/main.rs", "fn main() {}")
         .file("bar/src/lib.rs", "");
-    p.build();
+    let p = p.build();
 
     assert_that(p.cargo("build").cwd(p.root().join("foo")),
                 execs().with_status(0));
@@ -232,7 +232,7 @@ fn same_names_in_workspace() {
             workspace = ".."
         "#)
         .file("bar/src/main.rs", "fn main() {}");
-    p.build();
+    let p = p.build();
 
     assert_that(p.cargo("build"),
                 execs().with_status(101)
@@ -262,7 +262,7 @@ fn parent_doesnt_point_to_child() {
             authors = []
         "#)
         .file("bar/src/main.rs", "fn main() {}");
-    p.build();
+    let p = p.build();
 
     assert_that(p.cargo("build").cwd(p.root().join("bar")),
                 execs().with_status(101)
@@ -286,7 +286,7 @@ fn invalid_parent_pointer() {
             workspace = "foo"
         "#)
         .file("src/main.rs", "fn main() {}");
-    p.build();
+    let p = p.build();
 
     assert_that(p.cargo("build"),
                 execs().with_status(101)
@@ -311,7 +311,7 @@ fn invalid_members() {
             members = ["foo"]
         "#)
         .file("src/main.rs", "fn main() {}");
-    p.build();
+    let p = p.build();
 
     assert_that(p.cargo("build"),
                 execs().with_status(101)
@@ -335,7 +335,7 @@ fn bare_workspace_ok() {
             [workspace]
         "#)
         .file("src/main.rs", "fn main() {}");
-    p.build();
+    let p = p.build();
 
     assert_that(p.cargo("build"), execs().with_status(0));
 }
@@ -363,7 +363,7 @@ fn two_roots() {
             members = [".."]
         "#)
         .file("bar/src/main.rs", "fn main() {}");
-    p.build();
+    let p = p.build();
 
     assert_that(p.cargo("build"),
                 execs().with_status(101)
@@ -392,7 +392,7 @@ fn workspace_isnt_root() {
             authors = []
         "#)
         .file("bar/src/main.rs", "fn main() {}");
-    p.build();
+    let p = p.build();
 
     assert_that(p.cargo("build"),
                 execs().with_status(101)
@@ -430,7 +430,7 @@ fn dangling_member() {
             workspace = "../baz"
         "#)
         .file("baz/src/main.rs", "fn main() {}");
-    p.build();
+    let p = p.build();
 
     assert_that(p.cargo("build"),
                 execs().with_status(101)
@@ -460,7 +460,7 @@ fn cycle() {
             workspace = ".."
         "#)
         .file("bar/src/main.rs", "fn main() {}");
-    p.build();
+    let p = p.build();
 
     assert_that(p.cargo("build"),
                 execs().with_status(101));
@@ -492,7 +492,7 @@ fn share_dependencies() {
             dep1 = "< 0.1.5"
         "#)
         .file("bar/src/main.rs", "fn main() {}");
-    p.build();
+    let p = p.build();
 
     Package::new("dep1", "0.1.3").publish();
     Package::new("dep1", "0.1.8").publish();
@@ -531,7 +531,7 @@ fn fetch_fetches_all() {
             dep1 = "*"
         "#)
         .file("bar/src/main.rs", "fn main() {}");
-    p.build();
+    let p = p.build();
 
     Package::new("dep1", "0.1.3").publish();
 
@@ -569,7 +569,7 @@ fn lock_works_for_everyone() {
             dep1 = "0.1"
         "#)
         .file("bar/src/main.rs", "fn main() {}");
-    p.build();
+    let p = p.build();
 
     Package::new("dep1", "0.1.0").publish();
     Package::new("dep2", "0.1.0").publish();
@@ -616,7 +616,7 @@ fn virtual_works() {
             authors = []
         "#)
         .file("bar/src/main.rs", "fn main() {}");
-    p.build();
+    let p = p.build();
     assert_that(p.cargo("build").cwd(p.root().join("bar")),
                 execs().with_status(0));
     assert_that(&p.root().join("Cargo.lock"), existing_file());
@@ -638,7 +638,7 @@ fn explicit_package_argument_works_with_virtual_manifest() {
             authors = []
         "#)
         .file("bar/src/main.rs", "fn main() {}");
-    p.build();
+    let p = p.build();
     assert_that(p.cargo("build").cwd(p.root()).args(&["--package", "bar"]),
                 execs().with_status(0));
     assert_that(&p.root().join("Cargo.lock"), existing_file());
@@ -659,7 +659,7 @@ fn virtual_misconfigure() {
             authors = []
         "#)
         .file("bar/src/main.rs", "fn main() {}");
-    p.build();
+    let p = p.build();
     assert_that(p.cargo("build").cwd(p.root().join("bar")),
                 execs().with_status(101)
                        .with_stderr("\
@@ -686,7 +686,7 @@ fn virtual_build_all_implied() {
             authors = []
         "#)
         .file("bar/src/main.rs", "fn main() {}");
-    p.build();
+    let p = p.build();
     assert_that(p.cargo("build"),
                 execs().with_status(0));
 }
@@ -697,7 +697,7 @@ fn virtual_build_no_members() {
         .file("Cargo.toml", r#"
             [workspace]
         "#);
-    p.build();
+    let p = p.build();
     assert_that(p.cargo("build"),
                 execs().with_status(101)
                        .with_stderr("\
@@ -721,7 +721,7 @@ fn include_virtual() {
         .file("bar/Cargo.toml", r#"
             [workspace]
         "#);
-    p.build();
+    let p = p.build();
     assert_that(p.cargo("build"),
                 execs().with_status(101)
                        .with_stderr("\
@@ -771,7 +771,7 @@ fn members_include_path_deps() {
             authors = []
         "#)
         .file("p3/src/lib.rs", "");
-    p.build();
+    let p = p.build();
 
     assert_that(p.cargo("build").cwd(p.root().join("p1")),
                 execs().with_status(0));
@@ -800,7 +800,7 @@ fn new_warns_you_this_will_not_work() {
             [workspace]
         "#)
         .file("src/lib.rs", "");
-    p.build();
+    let p = p.build();
 
     assert_that(p.cargo("new").arg("--lib").arg("bar").env("USER", "foo"),
                 execs().with_status(0)
@@ -844,7 +844,7 @@ fn lock_doesnt_change_depending_on_crate() {
             bar = "*"
         "#)
         .file("baz/src/lib.rs", "");
-    p.build();
+    let p = p.build();
 
     Package::new("foo", "1.0.0").publish();
     Package::new("bar", "1.0.0").publish();
@@ -894,7 +894,7 @@ fn rebuild_please() {
                 assert_eq!(lib::foo(), 0);
             }
         "#);
-    p.build();
+    let p = p.build();
 
     assert_that(p.cargo("run").cwd(p.root().join("bin")),
                 execs().with_status(0));
@@ -939,7 +939,7 @@ fn workspace_in_git() {
         .file("src/lib.rs", r#"
             pub fn foo() -> u32 { 0 }
         "#);
-    p.build();
+    let p = p.build();
 
     assert_that(p.cargo("build"),
                 execs().with_status(0));
@@ -970,7 +970,7 @@ fn lockfile_can_specify_nonexistant_members() {
             version = "0.1.0"
         "#);
 
-    p.build();
+    let p = p.build();
 
     assert_that(p.cargo("build").cwd(p.root().join("a")), execs().with_status(0));
 }
@@ -988,7 +988,7 @@ fn you_cannot_generate_lockfile_for_empty_workspaces() {
             authors = []
         "#)
         .file("bar/src/main.rs", "fn main() {}");
-    p.build();
+    let p = p.build();
 
     assert_that(p.cargo("update"),
                 execs().with_status(101)
@@ -1039,7 +1039,7 @@ fn workspace_with_transitive_dev_deps() {
             authors = ["mbrubeck@example.com"]
         "#)
         .file("baz/src/lib.rs", r#"pub fn do_stuff() {}"#);
-    p.build();
+    let p = p.build();
 
     assert_that(p.cargo("test").args(&["-p", "bar"]),
                 execs().with_status(0));
@@ -1056,7 +1056,7 @@ fn error_if_parent_cargo_toml_is_invalid() {
             authors = []
         "#)
         .file("bar/src/main.rs", "fn main() {}");
-    p.build();
+    let p = p.build();
 
     assert_that(p.cargo("build").cwd(p.root().join("bar")),
                 execs().with_status(101)
@@ -1085,7 +1085,7 @@ fn relative_path_for_member_works() {
         workspace = "../foo"
     "#)
         .file("bar/src/main.rs", "fn main() {}");
-    p.build();
+    let p = p.build();
 
     assert_that(p.cargo("build").cwd(p.root().join("foo")), execs().with_status(0));
     assert_that(p.cargo("build").cwd(p.root().join("bar")), execs().with_status(0));
@@ -1113,7 +1113,7 @@ fn relative_path_for_root_works() {
         authors = []
     "#)
         .file("subproj/src/main.rs", "fn main() {}");
-    p.build();
+    let p = p.build();
 
     assert_that(p.cargo("build").cwd(p.root())
                     .arg("--manifest-path").arg("./Cargo.toml"),
@@ -1146,7 +1146,7 @@ fn path_dep_outside_workspace_is_not_member() {
             authors = []
         "#)
         .file("foo/src/lib.rs", "");
-    p.build();
+    let p = p.build();
 
     assert_that(p.cargo("build").cwd(p.root().join("ws")),
                 execs().with_status(0));
@@ -1186,7 +1186,7 @@ fn test_in_and_out_of_workspace() {
             authors = []
         "#)
         .file("bar/src/lib.rs", "pub fn f() { }");
-    p.build();
+    let p = p.build();
 
     assert_that(p.cargo("build").cwd(p.root().join("ws")),
                 execs().with_status(0));
@@ -1239,7 +1239,7 @@ fn test_path_dependency_under_member() {
             authors = []
         "#)
         .file("foo/bar/src/lib.rs", "pub fn f() { }");
-    p.build();
+    let p = p.build();
 
     assert_that(p.cargo("build").cwd(p.root().join("ws")),
                 execs().with_status(0));
@@ -1274,7 +1274,7 @@ fn excluded_simple() {
             authors = []
         "#)
         .file("foo/src/lib.rs", "");
-    p.build();
+    let p = p.build();
 
     assert_that(p.cargo("build"),
                 execs().with_status(0));
@@ -1312,7 +1312,7 @@ fn exclude_members_preferred() {
             authors = []
         "#)
         .file("foo/bar/src/lib.rs", "");
-    p.build();
+    let p = p.build();
 
     assert_that(p.cargo("build"),
                 execs().with_status(0));
@@ -1355,7 +1355,7 @@ fn exclude_but_also_depend() {
             authors = []
         "#)
         .file("foo/bar/src/lib.rs", "");
-    p.build();
+    let p = p.build();
 
     assert_that(p.cargo("build"),
                 execs().with_status(0));
@@ -1405,7 +1405,7 @@ fn glob_syntax() {
             authors = []
         "#)
         .file("crates/qux/src/main.rs", "fn main() {}");
-    p.build();
+    let p = p.build();
 
     assert_that(p.cargo("build"), execs().with_status(0));
     assert_that(&p.bin("foo"), existing_file());
@@ -1446,7 +1446,7 @@ fn glob_syntax_invalid_members() {
         "#)
         .file("src/main.rs", "fn main() {}")
         .file("crates/bar/src/main.rs", "fn main() {}");
-    p.build();
+    let p = p.build();
 
     assert_that(p.cargo("build"),
                 execs().with_status(101)
@@ -1506,7 +1506,7 @@ fn dep_used_with_separate_features() {
         "#)
         .file("caller2/src/main.rs", "fn main() {}")
         .file("caller2/src/lib.rs", "");
-    p.build();
+    let p = p.build();
 
     // Build the entire workspace
     assert_that(p.cargo("build").arg("--all"),


### PR DESCRIPTION
`Cell<bool>` was removed from `ProjectBuilder`. Instead `PhantomData<T>` was added to it (and `RepoBuilder`) to manage state transition in the type level (`T` is either `Configuring` or `Done`.)
`ProjectBuilder::cargo_process()` was removed as its design heavily depended on the internal mutability.

Also added `#[must_use]` to `ProjectBuilder` and `RepoBuilder` to check for call sites of their `build()` method.