### PR TITLE
Convert Options struct into unit struct

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ atty = "0.2"
 crates-io = { path = "src/crates-io", version = "0.11" }
 crossbeam = "0.2"
 curl = "0.4.6"
-docopt = "0.8"
+docopt = "0.8.1"
 env_logger = "0.4"
 error-chain = "0.10.0"
 filetime = "0.1"

--- a/src/bin/version.rs
+++ b/src/bin/version.rs
@@ -4,7 +4,7 @@ use cargo;
 use cargo::util::{CliResult, Config};
 
 #[derive(Deserialize)]
-pub struct Options {}
+pub struct Options;
 
 pub const USAGE: &'static str = "
 Show version information


### PR DESCRIPTION
Unit struct support was added in Docopt 0.8.1 via docopt/docopt.rs#217. Fixes #4174.