### PR TITLE
Fix `cargo check --lib` not emitting warnings on subsequent runs

### DIFF
--- a/src/cargo/ops/cargo_rustc/mod.rs
+++ b/src/cargo/ops/cargo_rustc/mod.rs
@@ -250,6 +250,12 @@ fn compile<'a, 'cfg: 'a>(cx: &mut Context<'a, 'cfg>,
             freshness = Freshness::Dirty;
         }
 
+        // Force recompilation for top-level targets when running the `check`
+        // command, so we can always emit warnings even if the files haven't changed.
+        if unit.profile.check && unit.pkg.package_id() == cx.ws.current()?.package_id() {
+            freshness = Freshness::Dirty;
+        }
+
         (dirty, fresh, freshness)
     };
     jobs.enqueue(cx, unit, Job::new(dirty, fresh), freshness)?;


### PR DESCRIPTION
`cargo check` for binaries will always emit warnings, even when the files in the
project haven't changed.

For `cargo check --lib`, warnings were emitted on the first run, but subsequent
runs would not trigger a recompilation of the library when no files have
changed, hence preventing warnings to appear.

This commit forces a recompilation of the library top-level target (*not*
library dependencies) when using the `check` command.

Closes GH-3624.