### PR TITLE
[doc/manifest] Add build-dependencies to Dependency sections list

### DIFF
--- a/src/doc/manifest.md
+++ b/src/doc/manifest.md
@@ -220,8 +220,8 @@ assets = "path/to/static"
 # Dependency sections
 
 See the [specifying dependencies page](specifying-dependencies.html) for
-information on the `[dependencies]`, `[dev-dependencies]`, and target-specific
-`[target.*.dependencies]` sections.
+information on the `[dependencies]`, `[dev-dependencies]`,
+`[build-dependencies]`, and target-specific `[target.*.dependencies]` sections.
 
 # The `[profile.*]` sections
 


### PR DESCRIPTION
The `[build-dependencies]` section was missing from the Dependency
sections list, making it hard to find its existence and link to
`specifying-dependencies` page. This puts the section title in the list,
so a normal find works.

Background: https://github.com/rust-lang/cargo/issues/4309#issuecomment-317965620