### PR TITLE
Remove inaccurate (misattributed) copyright notices

### DIFF
--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,5 +1,3 @@
-Copyright (c) 2014 The Rust Project Developers
-
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated
 documentation files (the "Software"), to deal in the

--- a/src/cargo/util/lev_distance.rs
+++ b/src/cargo/util/lev_distance.rs
@@ -1,13 +1,3 @@
-// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
-// file at the top-level directory of this distribution and at
-// http://rust-lang.org/COPYRIGHT.
-//
-// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
-// option. This file may not be copied, modified, or distributed
-// except according to those terms.
-
 use std::cmp;
 
 pub fn lev_distance(me: &str, t: &str) -> usize {


### PR DESCRIPTION
As discussed with @aturon, who took it to @rust-lang/core.

LICENSE-MIT and one source file contain inaccurate copyright notices of
the form "Copyright (c) (years) The Rust Project Developers", which
implies that an entity called "The Rust Project Developers" holds
copyrights in Rust. Rust contributors retain their copyrights, and do
not assign them to anyone by contributing.  Remove the inaccurate
notices.