### PR TITLE
Only build master as a branch on appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,6 +33,10 @@ install:
   - cargo -V
   - git submodule update --init
 
+branches:
+  only:
+    - master
+
 clone_depth: 1
 
 build: false


### PR DESCRIPTION
An attempt to not have the annoying 2 appveyor builds on cargo PRs, one of which never starts? This might block both of them though, let's find out