### PR TITLE
Add --build-plan for 'cargo build'

### DIFF
--- a/src/bin/bench.rs
+++ b/src/bin/bench.rs
@@ -19,6 +19,7 @@ pub struct Options {
     flag_quiet: Option<bool>,
     flag_color: Option<String>,
     flag_message_format: MessageFormat,
+    flag_build_plan: bool,
     flag_lib: bool,
     flag_bin: Vec<String>,
     flag_bins: bool,
@@ -67,6 +68,7 @@ Options:
     -q, --quiet                  No output printed to stdout
     --color WHEN                 Coloring: auto, always, never
     --message-format FMT         Error format: human, json [default: human]
+    --build-plan                 Generate a build plan
     --no-fail-fast               Run all benchmarks regardless of failure
     --frozen                     Require Cargo.lock and cache are up to date
     --locked                     Require Cargo.lock is up to date
@@ -127,6 +129,7 @@ pub fn execute(options: Options, config: &Config) -> CliResult {
                                             &options.flag_example, options.flag_examples,
                                             &options.flag_bench, options.flag_benches,),
             message_format: options.flag_message_format,
+            build_plan: options.flag_build_plan,
             target_rustdoc_args: None,
             target_rustc_args: None,
         },

--- a/src/bin/build.rs
+++ b/src/bin/build.rs
@@ -18,6 +18,7 @@ pub struct Options {
     flag_quiet: Option<bool>,
     flag_color: Option<String>,
     flag_message_format: MessageFormat,
+    flag_build_plan: bool,
     flag_release: bool,
     flag_lib: bool,
     flag_bin: Vec<String>,
@@ -65,6 +66,7 @@ Options:
     -q, --quiet                  No output printed to stdout
     --color WHEN                 Coloring: auto, always, never
     --message-format FMT         Error format: human, json [default: human]
+    --build-plan                 Generate a build plan
     --frozen                     Require Cargo.lock and cache are up to date
     --locked                     Require Cargo.lock is up to date
 
@@ -115,6 +117,7 @@ pub fn execute(options: Options, config: &Config) -> CliResult {
                                         &options.flag_example, options.flag_examples,
                                         &options.flag_bench, options.flag_benches,),
         message_format: options.flag_message_format,
+        build_plan: options.flag_build_plan,
         target_rustdoc_args: None,
         target_rustc_args: None,
     };

--- a/src/bin/check.rs
+++ b/src/bin/check.rs
@@ -36,6 +36,7 @@ Options:
     -q, --quiet                  No output printed to stdout
     --color WHEN                 Coloring: auto, always, never
     --message-format FMT         Error format: human, json [default: human]
+    --build-plan                 Generate a build plan
     --frozen                     Require Cargo.lock and cache are up to date
     --locked                     Require Cargo.lock is up to date
 
@@ -62,6 +63,7 @@ pub struct Options {
     flag_quiet: Option<bool>,
     flag_color: Option<String>,
     flag_message_format: MessageFormat,
+    flag_build_plan: bool,
     flag_release: bool,
     flag_lib: bool,
     flag_bin: Vec<String>,
@@ -112,6 +114,7 @@ pub fn execute(options: Options, config: &Config) -> CliResult {
                                         &options.flag_example, options.flag_examples,
                                         &options.flag_bench, options.flag_benches,),
         message_format: options.flag_message_format,
+        build_plan: options.flag_build_plan,
         target_rustdoc_args: None,
         target_rustc_args: None,
     };

--- a/src/bin/doc.rs
+++ b/src/bin/doc.rs
@@ -20,6 +20,7 @@ pub struct Options {
     flag_quiet: Option<bool>,
     flag_color: Option<String>,
     flag_message_format: MessageFormat,
+    flag_build_plan: bool,
     flag_package: Vec<String>,
     flag_lib: bool,
     flag_bin: Vec<String>,
@@ -55,6 +56,7 @@ Options:
     -q, --quiet                  No output printed to stdout
     --color WHEN                 Coloring: auto, always, never
     --message-format FMT         Error format: human, json [default: human]
+    --build-plan                 Generate a build plan
     --frozen                     Require Cargo.lock and cache are up to date
     --locked                     Require Cargo.lock is up to date
 
@@ -106,6 +108,7 @@ pub fn execute(options: Options, config: &Config) -> CliResult {
                                             &empty, false,
                                             &empty, false),
             message_format: options.flag_message_format,
+            build_plan: options.flag_build_plan,
             release: options.flag_release,
             mode: ops::CompileMode::Doc {
                 deps: !options.flag_no_deps,

--- a/src/bin/install.rs
+++ b/src/bin/install.rs
@@ -121,6 +121,7 @@ pub fn execute(options: Options, config: &Config) -> CliResult {
                                         &options.flag_example, options.flag_examples,
                                         &[], false),
         message_format: ops::MessageFormat::Human,
+        build_plan: false,
         target_rustc_args: None,
         target_rustdoc_args: None,
     };

--- a/src/bin/run.rs
+++ b/src/bin/run.rs
@@ -20,6 +20,7 @@ pub struct Options {
     flag_quiet: Option<bool>,
     flag_color: Option<String>,
     flag_message_format: MessageFormat,
+    flag_build_plan: bool,
     flag_release: bool,
     flag_frozen: bool,
     flag_locked: bool,
@@ -48,6 +49,7 @@ Options:
     -q, --quiet                  No output printed to stdout
     --color WHEN                 Coloring: auto, always, never
     --message-format FMT         Error format: human, json [default: human]
+    --build-plan                 Generate a build plan
     --frozen                     Require Cargo.lock and cache are up to date
     --locked                     Require Cargo.lock is up to date
 
@@ -101,6 +103,7 @@ pub fn execute(options: Options, config: &Config) -> CliResult {
                                     &[], false)
         },
         message_format: options.flag_message_format,
+        build_plan: options.flag_build_plan,
         target_rustdoc_args: None,
         target_rustc_args: None,
     };

--- a/src/bin/rustc.rs
+++ b/src/bin/rustc.rs
@@ -19,6 +19,7 @@ pub struct Options {
     flag_quiet: Option<bool>,
     flag_color: Option<String>,
     flag_message_format: MessageFormat,
+    flag_build_plan: bool,
     flag_release: bool,
     flag_lib: bool,
     flag_bin: Vec<String>,
@@ -64,6 +65,7 @@ Options:
     -q, --quiet              No output printed to stdout
     --color WHEN             Coloring: auto, always, never
     --message-format FMT     Error format: human, json [default: human]
+    --build-plan             Generate a build plan
     --frozen                 Require Cargo.lock and cache are up to date
     --locked                 Require Cargo.lock is up to date
 
@@ -122,6 +124,7 @@ pub fn execute(options: Options, config: &Config) -> CliResult {
                                         &options.flag_example, options.flag_examples,
                                         &options.flag_bench, options.flag_benches,),
         message_format: options.flag_message_format,
+        build_plan: options.flag_build_plan,
         target_rustdoc_args: None,
         target_rustc_args: options.arg_opts.as_ref().map(|a| &a[..]),
     };

--- a/src/bin/rustdoc.rs
+++ b/src/bin/rustdoc.rs
@@ -18,6 +18,7 @@ pub struct Options {
     flag_quiet: Option<bool>,
     flag_color: Option<String>,
     flag_message_format: MessageFormat,
+    flag_build_plan: bool,
     flag_package: Option<String>,
     flag_lib: bool,
     flag_bin: Vec<String>,
@@ -62,6 +63,7 @@ Options:
     -q, --quiet              No output printed to stdout
     --color WHEN             Coloring: auto, always, never
     --message-format FMT     Error format: human, json [default: human]
+    --build-plan             Generate a build plan
     --frozen                 Require Cargo.lock and cache are up to date
     --locked                 Require Cargo.lock is up to date
 
@@ -107,6 +109,7 @@ pub fn execute(options: Options, config: &Config) -> CliResult {
                                             &options.flag_example, options.flag_examples,
                                             &options.flag_bench, options.flag_benches,),
             message_format: options.flag_message_format,
+            build_plan: options.flag_build_plan,
             mode: ops::CompileMode::Doc { deps: false },
             target_rustdoc_args: Some(&options.arg_opts),
             target_rustc_args: None,

--- a/src/bin/test.rs
+++ b/src/bin/test.rs
@@ -30,6 +30,7 @@ pub struct Options {
     flag_quiet: Option<bool>,
     flag_color: Option<String>,
     flag_message_format: MessageFormat,
+    flag_build_plan: bool,
     flag_release: bool,
     flag_no_fail_fast: bool,
     flag_frozen: bool,
@@ -71,6 +72,7 @@ Options:
     -q, --quiet                  No output printed to stdout
     --color WHEN                 Coloring: auto, always, never
     --message-format FMT         Error format: human, json [default: human]
+    --build-plan                 Generate a build plan
     --no-fail-fast               Run all tests regardless of failure
     --frozen                     Require Cargo.lock and cache are up to date
     --locked                     Require Cargo.lock is up to date
@@ -159,6 +161,7 @@ pub fn execute(options: Options, config: &Config) -> CliResult {
             mode: mode,
             filter: filter,
             message_format: options.flag_message_format,
+            build_plan: options.flag_build_plan,
             target_rustdoc_args: None,
             target_rustc_args: None,
         },

--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -59,6 +59,8 @@ pub struct CompileOptions<'a> {
     pub mode: CompileMode,
     /// `--error_format` flag for the compiler.
     pub message_format: MessageFormat,
+    /// Output a build plan to stdout instead of actually compiling.
+    pub build_plan: bool,
     /// Extra arguments to be passed to rustdoc (for main crate and dependencies)
     pub target_rustdoc_args: Option<&'a [String]>,
     /// The specified target will be compiled with all the available arguments,
@@ -81,6 +83,7 @@ impl<'a> CompileOptions<'a> {
             release: false,
             filter: CompileFilter::Everything { required_features_filterable: false },
             message_format: MessageFormat::Human,
+            build_plan: false,
             target_rustdoc_args: None,
             target_rustc_args: None,
         }
@@ -196,6 +199,7 @@ pub fn compile_ws<'a>(ws: &Workspace<'a>,
     let CompileOptions { config, jobs, target, spec, features,
                          all_features, no_default_features,
                          release, mode, message_format,
+                         build_plan,
                          ref filter,
                          ref target_rustdoc_args,
                          ref target_rustc_args } = *options;
@@ -297,6 +301,7 @@ pub fn compile_ws<'a>(ws: &Workspace<'a>,
         build_config.release = release;
         build_config.test = mode == CompileMode::Test || mode == CompileMode::Bench;
         build_config.json_messages = message_format == MessageFormat::Json;
+        build_config.build_plan = build_plan;
         if let CompileMode::Doc { deps } = mode {
             build_config.doc_all = deps;
         }

--- a/src/cargo/ops/cargo_package.rs
+++ b/src/cargo/ops/cargo_package.rs
@@ -302,6 +302,7 @@ fn run_verify(ws: &Workspace, tar: &File, opts: &PackageOpts) -> CargoResult<()>
         filter: ops::CompileFilter::Everything { required_features_filterable: true },
         release: false,
         message_format: ops::MessageFormat::Human,
+        build_plan: false,
         mode: ops::CompileMode::Build,
         target_rustdoc_args: None,
         target_rustc_args: None,

--- a/src/cargo/util/dependency_queue.rs
+++ b/src/cargo/util/dependency_queue.rs
@@ -135,4 +135,8 @@ impl<K: Hash + Eq + Clone, V> DependencyQueue<K, V> {
             assert!(self.dep_map.get_mut(dep).unwrap().0.remove(key));
         }
     }
+
+    pub fn get_dep_map(&self) -> &HashMap<K, (HashSet<K>, V)> {
+        return &self.dep_map;
+    }
 }

--- a/src/cargo/util/process_builder.rs
+++ b/src/cargo/util/process_builder.rs
@@ -230,6 +230,16 @@ impl ProcessBuilder {
         command
     }
 
+    pub fn output_build_plan(&self) -> () {
+        println!("        'program': {:?},", self.program);
+        println!("        'cwd': {:?},", self.get_cwd().unwrap());
+        println!("        'args': [");
+        for arg in self.args.iter() {
+            println!("            '{}',", escape(arg.to_string_lossy()));
+        }
+        println!("        ],");
+    }
+
     fn debug_string(&self) -> String {
         let mut program = format!("{}", self.program.to_string_lossy());
         for arg in self.args.iter() {


### PR DESCRIPTION
With 'cargo build --build-plan', cargo does not actually run any
commands, but instead prints out what it would have done in the form of
Python data structures. The 'dependencies' structure lists the
dependencies between steps, and the 'commands' structure lists the
information required to run the commands from an external build system.

Fixes #3815