### PR TITLE
workspace: export Members as part of the public interface

### DIFF
--- a/src/cargo/core/mod.rs
+++ b/src/cargo/core/mod.rs
@@ -9,7 +9,7 @@ pub use self::resolver::Resolve;
 pub use self::shell::{Shell, Verbosity};
 pub use self::source::{Source, SourceId, SourceMap, GitReference};
 pub use self::summary::Summary;
-pub use self::workspace::{Workspace, WorkspaceConfig};
+pub use self::workspace::{Members, Workspace, WorkspaceConfig};
 
 pub mod source;
 pub mod package;


### PR DESCRIPTION
This struct is returned by `Workspace::members`, but there's no way to
refer to it since it's not exported.