### PR TITLE
Required dependencies are not features

### DIFF
--- a/src/cargo/core/resolver/mod.rs
+++ b/src/cargo/core/resolver/mod.rs
@@ -57,7 +57,7 @@ use url::Url;
 
 use core::{PackageId, Registry, SourceId, Summary, Dependency};
 use core::PackageIdSpec;
-use core::shell::Shell;
+use util::config::Config;
 use util::Graph;
 use util::errors::{CargoResult, CargoError};
 use util::profile;
@@ -342,7 +342,7 @@ type Activations = HashMap<String, HashMap<SourceId, Vec<Summary>>>;
 pub fn resolve(summaries: &[(Summary, Method)],
                replacements: &[(PackageIdSpec, Dependency)],
                registry: &mut Registry,
-               shell: Option<&mut Shell>) -> CargoResult<Resolve> {
+               config: Option<&Config>) -> CargoResult<Resolve> {
     let cx = Context {
         resolve_graph: RcList::new(),
         resolve_features: HashMap::new(),
@@ -377,7 +377,8 @@ pub fn resolve(summaries: &[(Summary, Method)],
     trace!("resolved: {:?}", resolve);
 
     // If we have a shell, emit warnings about required deps used as feature.
-    if let Some(shell) = shell {
+    if let Some(config) = config {
+        let mut shell = config.shell();
         let mut warnings = &cx.warnings;
         while let Some(ref head) = warnings.head {
             shell.warn(&head.0)?;

--- a/src/cargo/core/summary.rs
+++ b/src/cargo/core/summary.rs
@@ -53,8 +53,8 @@ impl Summary {
                                feature, dep)
                     }
                     None if is_reexport => {
-                        bail!("Feature `{}` requires `{}` which is not an \
-                               optional dependency", feature, dep)
+                        bail!("Feature `{}` requires a feature of `{}` which is not a \
+                               dependency", feature, dep)
                     }
                     None => {
                         bail!("Feature `{}` includes `{}` which is neither \

--- a/src/cargo/ops/cargo_generate_lockfile.rs
+++ b/src/cargo/ops/cargo_generate_lockfile.rs
@@ -19,7 +19,7 @@ pub fn generate_lockfile(ws: &Workspace) -> CargoResult<()> {
     let mut registry = PackageRegistry::new(ws.config())?;
     let resolve = ops::resolve_with_previous(&mut registry, ws,
                                              Method::Everything,
-                                             None, None, &[])?;
+                                             None, None, &[], true)?;
     ops::write_pkg_lockfile(ws, &resolve)?;
     Ok(())
 }
@@ -79,7 +79,8 @@ pub fn update_lockfile(ws: &Workspace, opts: &UpdateOptions)
                                                   Method::Everything,
                                                   Some(&previous_resolve),
                                                   Some(&to_avoid),
-                                                  &[])?;
+                                                  &[],
+                                                  true)?;
 
     // Summarize what is changing for the user.
     let print_change = |status: &str, msg: String| {

--- a/src/cargo/ops/resolve.rs
+++ b/src/cargo/ops/resolve.rs
@@ -257,17 +257,15 @@ pub fn resolve_with_previous<'a>(registry: &mut PackageRegistry,
         None => root_replace.to_vec(),
     };
 
-    let mut shell;
-    let opt_shell = if warn {
-        shell = ws.config().shell();
-        Some(&mut *shell)
+    let config = if warn {
+        Some(ws.config())
     } else {
         None
     };
     let mut resolved = resolver::resolve(&summaries,
                                          &replace,
                                          registry,
-                                         opt_shell)?;
+                                         config)?;
     resolved.register_used_patches(registry.patches());
     if let Some(previous) = previous {
         resolved.merge_from(previous)?;

--- a/tests/features.rs
+++ b/tests/features.rs
@@ -248,7 +248,8 @@ fn invalid9() {
 
     assert_that(p.cargo_process("build").arg("--features").arg("bar"),
                 execs().with_status(101).with_stderr("\
-[ERROR] Package `foo v0.0.1 ([..])` does not have these features: `bar`
+[ERROR] Package `foo v0.0.1 ([..])` does not have feature `bar`. It has a required dependency with \
+that name, but only optional dependencies can be used as features.
 "));
 }
 
@@ -286,7 +287,8 @@ fn invalid10() {
 
     assert_that(p.cargo_process("build"),
                 execs().with_status(101).with_stderr("\
-[ERROR] Package `bar v0.0.1 ([..])` does not have these features: `baz`
+[ERROR] Package `bar v0.0.1 ([..])` does not have feature `baz`. It has a required dependency with \
+that name, but only optional dependencies can be used as features.
 "));
 }
 

--- a/tests/features.rs
+++ b/tests/features.rs
@@ -237,7 +237,7 @@ fn invalid9() {
             [dependencies.bar]
             path = "bar"
         "#)
-        .file("src/main.rs", "")
+        .file("src/main.rs", "fn main() {}")
         .file("bar/Cargo.toml", r#"
             [package]
             name = "bar"
@@ -247,9 +247,12 @@ fn invalid9() {
         .file("bar/src/lib.rs", "");
 
     assert_that(p.cargo_process("build").arg("--features").arg("bar"),
-                execs().with_status(101).with_stderr("\
-[ERROR] Package `foo v0.0.1 ([..])` does not have feature `bar`. It has a required dependency with \
-that name, but only optional dependencies can be used as features.
+                execs().with_status(0).with_stderr("\
+warning: Package `foo v0.0.1 ([..])` does not have feature `bar`. It has a required dependency with \
+that name, but only optional dependencies can be used as features. [..]
+   Compiling bar v0.0.1 ([..])
+   Compiling foo v0.0.1 ([..])
+    Finished dev [unoptimized + debuginfo] target(s) in [..] secs
 "));
 }
 
@@ -266,7 +269,7 @@ fn invalid10() {
             path = "bar"
             features = ["baz"]
         "#)
-        .file("src/main.rs", "")
+        .file("src/main.rs", "fn main() {}")
         .file("bar/Cargo.toml", r#"
             [package]
             name = "bar"
@@ -286,9 +289,13 @@ fn invalid10() {
         .file("bar/baz/src/lib.rs", "");
 
     assert_that(p.cargo_process("build"),
-                execs().with_status(101).with_stderr("\
-[ERROR] Package `bar v0.0.1 ([..])` does not have feature `baz`. It has a required dependency with \
-that name, but only optional dependencies can be used as features.
+                execs().with_status(0).with_stderr("\
+warning: Package `bar v0.0.1 ([..])` does not have feature `baz`. It has a required dependency with \
+that name, but only optional dependencies can be used as features. [..]
+   Compiling baz v0.0.1 ([..])
+   Compiling bar v0.0.1 ([..])
+   Compiling foo v0.0.1 ([..])
+    Finished dev [unoptimized + debuginfo] target(s) in [..] secs
 "));
 }
 

--- a/tests/features.rs
+++ b/tests/features.rs
@@ -169,7 +169,7 @@ fn invalid6() {
 [ERROR] failed to parse manifest at `[..]`
 
 Caused by:
-  Feature `foo` requires `bar` which is not an optional dependency
+  Feature `foo` requires a feature of `bar` which is not a dependency
 "));
 }
 
@@ -193,7 +193,7 @@ fn invalid7() {
 [ERROR] failed to parse manifest at `[..]`
 
 Caused by:
-  Feature `foo` requires `bar` which is not an optional dependency
+  Feature `foo` requires a feature of `bar` which is not a dependency
 "));
 }
 

--- a/tests/resolve.rs
+++ b/tests/resolve.rs
@@ -32,7 +32,7 @@ fn resolve(pkg: PackageId, deps: Vec<Dependency>, registry: &[Summary])
     let mut registry = MyRegistry(registry);
     let summary = Summary::new(pkg.clone(), deps, HashMap::new()).unwrap();
     let method = Method::Everything;
-    let resolve = resolver::resolve(&[(summary, method)], &[], &mut registry)?;
+    let resolve = resolver::resolve(&[(summary, method)], &[], &mut registry, None)?;
     let res = resolve.iter().cloned().collect();
     Ok(res)
 }


### PR DESCRIPTION
Also, while I was at it, I fixed an error message which complained about something not being an optional dependency, when really what mattered was that it was not a dependency at all.

I made a bunch of guesses about how things work. These guesses ended up as comments in the commit (so hopefully, the next reader of these files has to guess less). I am not totally certain these comments are all correct, so please yell if not. :)

In particular, for resolve_features, I observed that dependencies get compiled even when they are not returned from that function. But judging from how the function used to behave, it actually returns all dependencies, even those that have nothing to do with any features. (Making the name rather misleading, TBH...)

Fixes #4363