### PR TITLE
[cargo_new] Hint to use `cargo init` on existing dir

### DIFF
--- a/src/bin/init.rs
+++ b/src/bin/init.rs
@@ -18,7 +18,7 @@ pub struct Options {
 }
 
 pub const USAGE: &'static str = "
-Create a new cargo package in current directory
+Create a new cargo package in an existing directory
 
 Usage:
     cargo init [options] [<path>]
@@ -27,8 +27,9 @@ Usage:
 Options:
     -h, --help          Print this message
     --vcs VCS           Initialize a new repository for the given version
-                        control system (git or hg) or do not initialize any version
-                        control at all (none) overriding a global configuration.
+                        control system (git, hg, pijul, or fossil) or do not
+                        initialize any version control at all (none), overriding
+                        a global configuration.
     --bin               Use a binary (application) template
     --lib               Use a library template [default]
     --name NAME         Set the resulting package name
@@ -49,11 +50,11 @@ pub fn execute(options: Options, config: &Config) -> CliResult {
 
     let Options { flag_bin, flag_lib, arg_path, flag_name, flag_vcs, .. } = options;
 
-    let tmp = &arg_path.unwrap_or(format!("."));
+    let path = &arg_path.unwrap_or(format!("."));
     let opts = ops::NewOptions::new(flag_vcs,
                                      flag_bin,
                                      flag_lib,
-                                     tmp,
+                                     path,
                                      flag_name.as_ref().map(|s| s.as_ref()));
 
     let opts_lib = opts.lib;

--- a/src/cargo/ops/cargo_new.rs
+++ b/src/cargo/ops/cargo_new.rs
@@ -268,12 +268,14 @@ fn plan_new_source_file(bin: bool, project_name: String) -> SourceFileInformatio
 pub fn new(opts: NewOptions, config: &Config) -> CargoResult<()> {
     let path = config.cwd().join(opts.path);
     if fs::metadata(&path).is_ok() {
-        bail!("destination `{}` already exists",
-              path.display())
+        bail!("destination `{}` already exists\n\n\
+            Use `cargo init` to initialize the directory\
+            ", path.display()
+        )
     }
 
     if opts.lib && opts.bin {
-        bail!("can't specify both lib and binary outputs");
+        bail!("can't specify both lib and binary outputs")
     }
 
     let name = get_name(&path, &opts, config)?;

--- a/tests/new.rs
+++ b/tests/new.rs
@@ -111,7 +111,8 @@ fn existing() {
     fs::create_dir(&dst).unwrap();
     assert_that(cargo_process("new").arg("foo"),
                 execs().with_status(101)
-                       .with_stderr(format!("[ERROR] destination `{}` already exists\n",
+                       .with_stderr(format!("[ERROR] destination `{}` already exists\n\n\
+                                            Use `cargo init` to initialize the directory",
                                             dst.display())));
 }
 


### PR DESCRIPTION
The `new` command always expects a non-existing path. The `init` command
always expects an existing path. Therefore, it makes sense to hint to
use `init` if the pre-condition to `new` is not satisfied.

Fixes <#4366>
