### PR TITLE
[sources/path] Support leading slash in glob patterns

### DIFF
--- a/tests/package.rs
+++ b/tests/package.rs
@@ -321,8 +321,6 @@ See [..]
 See [..]
 [WARNING] [..] file `dir_root_3[/]some_dir[/]file` WILL be excluded [..]
 See [..]
-[WARNING] [..] file `file_root_2` WILL be excluded [..]
-See [..]
 [WARNING] [..] file `some_dir[/]dir_deep_1[/]some_dir[/]file` WILL be excluded [..]
 See [..]
 [WARNING] [..] file `some_dir[/]dir_deep_3[/]some_dir[/]file` WILL be excluded [..]
@@ -351,7 +349,6 @@ See [..]
 [ARCHIVING] [..]
 [ARCHIVING] [..]
 [ARCHIVING] [..]
-[ARCHIVING] [..]
 "));
 
     assert_that(&p.root().join("target/package/foo-0.0.1.crate"), existing_file());
@@ -362,7 +359,6 @@ Cargo.toml
 dir_root_1[/]some_dir[/]file
 dir_root_2[/]some_dir[/]file
 dir_root_3[/]some_dir[/]file
-file_root_2
 file_root_3
 file_root_4
 file_root_5


### PR DESCRIPTION
Background: https://github.com/rust-lang/cargo/issues/4268

This diff takes us to **Stage 1.1** of the migration plan by allowing
glob patterns to include a leading slash, so that glob patterns can be
updated, if needed, to start with a slash, closer to the future behavior
with gitignore-like matching.

Why is this stage needed?

It's common to have `package.include` set like this:
```
include = ["src/**"]
```
In old interpretation, this would only include all files under the `src`
directory under the package root. With the new interpretation, this
would match any path with some directory called `src`, even if it's not
directly under the package root.

After this patch, package owners can start marking glob patters with a
leading slash to fix the warning thrown, if any.

One thing to notice here is that there are no extra matchings, but, if
a manifest has already a pattern with a leading slash, this would
silently start matching it with the paths. I believe this is fine, since
the old behavior would have been for the pattern to not match anything,
therefore the item was useless.

See also <https://github.com/rust-lang/cargo/issues/4377> for suggestion
to throw warning on useless/invalid patterns in these fields.