### PR TITLE
[WIP, do not commit] set Cargo.toml configuration from the command line

### DIFF
--- a/src/bin/build.rs
+++ b/src/bin/build.rs
@@ -42,33 +42,33 @@ Usage:
     cargo build [options]
 
 Options:
-    -h, --help                   Print this message
-    -p SPEC, --package SPEC ...  Package to build
-    --all                        Build all packages in the workspace
-    --exclude SPEC ...           Exclude packages from the build
-    -j N, --jobs N               Number of parallel jobs, defaults to # of CPUs
-    --lib                        Build only this package's library
-    --bin NAME                   Build only the specified binary
-    --bins                       Build all binaries
-    --example NAME               Build only the specified example
-    --examples                   Build all examples
-    --test NAME                  Build only the specified test target
-    --tests                      Build all tests
-    --bench NAME                 Build only the specified bench target
-    --benches                    Build all benches
-    --release                    Build artifacts in release mode, with optimizations
-    --features FEATURES          Space-separated list of features to also build
-    --all-features               Build all available features
-    --no-default-features        Do not build the `default` feature
-    --target TRIPLE              Build for the target triple
-    --manifest-path PATH         Path to the manifest to compile
-    -c CONFIG, --config CONFIG   Set/override values specified in Cargo.toml
-    -v, --verbose ...            Use verbose output (-vv very verbose/build.rs output)
-    -q, --quiet                  No output printed to stdout
-    --color WHEN                 Coloring: auto, always, never
-    --message-format FMT         Error format: human, json [default: human]
-    --frozen                     Require Cargo.lock and cache are up to date
-    --locked                     Require Cargo.lock is up to date
+    -h, --help                       Print this message
+    -p SPEC, --package SPEC ...      Package to build
+    --all                            Build all packages in the workspace
+    --exclude SPEC ...               Exclude packages from the build
+    -j N, --jobs N                   Number of parallel jobs, defaults to # of CPUs
+    --lib                            Build only this package's library
+    --bin NAME                       Build only the specified binary
+    --bins                           Build all binaries
+    --example NAME                   Build only the specified example
+    --examples                       Build all examples
+    --test NAME                      Build only the specified test target
+    --tests                          Build all tests
+    --bench NAME                     Build only the specified bench target
+    --benches                        Build all benches
+    --release                        Build artifacts in release mode, with optimizations
+    --features FEATURES              Space-separated list of features to also build
+    --all-features                   Build all available features
+    --no-default-features            Do not build the `default` feature
+    --target TRIPLE                  Build for the target triple
+    --manifest-path PATH             Path to the manifest to compile
+    -c CONFIG, --config CONFIG ...   Set/override values specified in Cargo.toml
+    -v, --verbose ...                Use verbose output (-vv very verbose/build.rs output)
+    -q, --quiet                      No output printed to stdout
+    --color WHEN                     Coloring: auto, always, never
+    --message-format FMT             Error format: human, json [default: human]
+    --frozen                         Require Cargo.lock and cache are up to date
+    --locked                         Require Cargo.lock is up to date
 
 If the --package argument is given, then SPEC is a package id specification
 which indicates which package should be built. If it is not given, then the
@@ -94,7 +94,7 @@ pub fn execute(options: Options, config: &Config) -> CliResult {
                      options.flag_locked)?;
 
     let root = find_root_manifest_for_wd(options.flag_manifest_path, config.cwd())?;
-    let ws = Workspace::new(&root, config)?;
+    let ws = Workspace::new_with_overrides(&root, config, &options.flag_config)?;
 
     let spec = Packages::from_flags(ws.is_virtual(),
                                     options.flag_all,

--- a/src/bin/build.rs
+++ b/src/bin/build.rs
@@ -32,6 +32,7 @@ pub struct Options {
     flag_frozen: bool,
     flag_all: bool,
     flag_exclude: Vec<String>,
+    flag_config: Vec<String>,
 }
 
 pub const USAGE: &'static str = "
@@ -61,6 +62,7 @@ Options:
     --no-default-features        Do not build the `default` feature
     --target TRIPLE              Build for the target triple
     --manifest-path PATH         Path to the manifest to compile
+    -c CONFIG, --config CONFIG   Set/override values specified in Cargo.toml
     -v, --verbose ...            Use verbose output (-vv very verbose/build.rs output)
     -q, --quiet                  No output printed to stdout
     --color WHEN                 Coloring: auto, always, never

--- a/src/cargo/ops/cargo_read_manifest.rs
+++ b/src/cargo/ops/cargo_read_manifest.rs
@@ -12,7 +12,8 @@ use util::toml::read_manifest;
 pub fn read_package(path: &Path, source_id: &SourceId, config: &Config)
                     -> CargoResult<(Package, Vec<PathBuf>)> {
     trace!("read_package; path={}; source-id={}", path.display(), source_id);
-    let (manifest, nested) = read_manifest(path, source_id, config)?;
+    let unused = vec!();
+    let (manifest, nested) = read_manifest(path, source_id, &unused, config)?;
     let manifest = match manifest {
         EitherManifest::Real(manifest) => manifest,
         EitherManifest::Virtual(..) => {
@@ -114,7 +115,8 @@ fn read_nested_packages(path: &Path,
 
     let manifest_path = find_project_manifest_exact(path, "Cargo.toml")?;
 
-    let (manifest, nested) = match read_manifest(&manifest_path, source_id, config) {
+    let unused = vec!();
+    let (manifest, nested) = match read_manifest(&manifest_path, source_id, &unused, config) {
         Err(err) => {
             // Ignore malformed manifests found on git repositories
             //


### PR DESCRIPTION
This pull request introduces `cargo build -c CONFIG` for setting `Cargo.toml` key-value pairs from the command line, suggested in #4349.  Any config settings provided on the command line override those set in `Cargo.toml`.  This sort of thing is probably most useful for setting `profile.$PROFILE.$X` options, but there are a number of other possibilities.

It's not complete--there are a few XXX comments, tests are needed, and it's an open question how many commands should support this--but it is at least in a state where I thought feedback could be provided.  @alexcrichton WDYT?  Is this heading in the right direction?