### PR TITLE
Expose ops::cargo_compile::FilterRule

### DIFF
--- a/src/cargo/ops/mod.rs
+++ b/src/cargo/ops/mod.rs
@@ -1,6 +1,6 @@
 pub use self::cargo_clean::{clean, CleanOptions};
 pub use self::cargo_compile::{compile, compile_with_exec, compile_ws, CompileOptions};
-pub use self::cargo_compile::{CompileFilter, CompileMode, MessageFormat, Packages};
+pub use self::cargo_compile::{CompileFilter, CompileMode, FilterRule, MessageFormat, Packages};
 pub use self::cargo_read_manifest::{read_package, read_packages};
 pub use self::cargo_rustc::{compile_targets, Compilation, Kind, Unit};
 pub use self::cargo_rustc::{Context, is_bad_artifact_name};


### PR DESCRIPTION
I've been mindlessly copying and consuming the Cargo API to work on the build plan prototype for RLS and I noticed that, it seems, pub `ops::cargo_compile::CompileFilter` is exported, but not the `ops::cargo_compile::FilterRule`, which `CompileFilter` uses, as a part of a public API.

If I'm wrong and missing something, feel free to ignore/close it. It was possible to match/destructure `CompileFilter` before, but with this change it's possible to use the underlying type.