### PR TITLE
Fixed some variables being unnecessarily mutable

### DIFF
--- a/src/cargo/core/resolver/mod.rs
+++ b/src/cargo/core/resolver/mod.rs
@@ -1109,7 +1109,7 @@ impl<'a> Context<'a> {
         if !used_features.is_empty() {
             let pkgid = candidate.package_id();
 
-            let mut set = self.resolve_features.entry(pkgid.clone())
+            let set = self.resolve_features.entry(pkgid.clone())
                               .or_insert_with(HashSet::new);
             for feature in used_features {
                 if !set.contains(feature) {

--- a/src/cargo/util/config.rs
+++ b/src/cargo/util/config.rs
@@ -482,7 +482,7 @@ impl Config {
             format!("failed to load TOML configuration from `{}`", credentials.display())
         })?;
 
-        let mut cfg = match *cfg {
+        let cfg = match *cfg {
             CV::Table(ref mut map, _) => map,
             _ => unreachable!(),
         };

--- a/src/cargo/util/read2.rs
+++ b/src/cargo/util/read2.rs
@@ -12,7 +12,7 @@ mod imp {
 
     pub fn read2(mut out_pipe: ChildStdout,
                  mut err_pipe: ChildStderr,
-                 mut data: &mut FnMut(bool, &mut Vec<u8>, bool)) -> io::Result<()> {
+                 data: &mut FnMut(bool, &mut Vec<u8>, bool)) -> io::Result<()> {
         unsafe {
             libc::fcntl(out_pipe.as_raw_fd(), libc::F_SETFL, libc::O_NONBLOCK);
             libc::fcntl(err_pipe.as_raw_fd(), libc::F_SETFL, libc::O_NONBLOCK);

--- a/src/cargo/util/read2.rs
+++ b/src/cargo/util/read2.rs
@@ -102,7 +102,7 @@ mod imp {
 
     pub fn read2(out_pipe: ChildStdout,
                  err_pipe: ChildStderr,
-                 mut data: &mut FnMut(bool, &mut Vec<u8>, bool)) -> io::Result<()> {
+                 data: &mut FnMut(bool, &mut Vec<u8>, bool)) -> io::Result<()> {
         let mut out = Vec::new();
         let mut err = Vec::new();
 


### PR DESCRIPTION
### Changes

Some variables are marked `mut` when they don't need to be. This PR changes those variables to no longer be `mut`.

### Context

PR on https://github.com/rust-lang/rust/pull/43582

tl:dr; There's a bug with the mutability checker that sometimes marks mutable ref variables as being used when they're not.