### PR TITLE
Use `same-file` to avoid unnecessary hard links

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,6 +31,7 @@ dependencies = [
  "num_cpus 1.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl 0.9.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "psapi-sys 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "same-file 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "scoped-tls 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ libc = "0.2"
 libgit2-sys = "0.6"
 log = "0.3"
 num_cpus = "1.0"
+same-file = "0.1"
 scoped-tls = "0.1"
 semver = { version = "0.7.0", features = ["serde"] }
 serde = "1.0"

--- a/src/cargo/lib.rs
+++ b/src/cargo/lib.rs
@@ -25,6 +25,7 @@ extern crate jobserver;
 extern crate libc;
 extern crate libgit2_sys;
 extern crate num_cpus;
+extern crate same_file;
 extern crate semver;
 extern crate serde;
 extern crate serde_ignored;

--- a/src/cargo/ops/cargo_rustc/mod.rs
+++ b/src/cargo/ops/cargo_rustc/mod.rs
@@ -6,6 +6,7 @@ use std::io::{self, Write};
 use std::path::{self, PathBuf};
 use std::sync::Arc;
 
+use same_file::is_same_file;
 use serde_json;
 
 use core::{Package, PackageId, PackageSet, Target, Resolve};
@@ -496,6 +497,9 @@ fn link_targets<'a, 'cfg>(cx: &mut Context<'a, 'cfg>,
             destinations.push(dst.display().to_string());
 
             debug!("linking {} to {}", src.display(), dst.display());
+            if is_same_file(src, dst).unwrap_or(false) {
+                continue
+            }
             if dst.exists() {
                 fs::remove_file(&dst).chain_err(|| {
                     format!("failed to remove: {}", dst.display())


### PR DESCRIPTION
This is targeted at removing the need for a workaround in rust-lang/rust#39518,
allowing the main rust build system to move back to hard links which should be
much more efficient.