### PR TITLE
Update lib template for `cargo new` so that the placeholder test contains an assertion

### DIFF
--- a/src/cargo/ops/cargo_new.rs
+++ b/src/cargo/ops/cargo_new.rs
@@ -507,8 +507,7 @@ fn main() {
 #[cfg(test)]
 mod tests {
     #[test]
-    fn it_works() {
-    }
+    fn it_works() {}
 }
 "
         };

--- a/src/cargo/ops/cargo_new.rs
+++ b/src/cargo/ops/cargo_new.rs
@@ -507,7 +507,9 @@ fn main() {
 #[cfg(test)]
 mod tests {
     #[test]
-    fn it_works() {}
+    fn it_works() {
+        assert_eq!(2 + 2, 4);
+    }
 }
 "
         };

--- a/tests/new.rs
+++ b/tests/new.rs
@@ -38,7 +38,9 @@ fn simple_lib() {
     assert_eq!(contents, r#"#[cfg(test)]
 mod tests {
     #[test]
-    fn it_works() {}
+    fn it_works() {
+        assert_eq!(2 + 2, 4);
+    }
 }
 "#);
 

--- a/tests/new.rs
+++ b/tests/new.rs
@@ -38,8 +38,7 @@ fn simple_lib() {
     assert_eq!(contents, r#"#[cfg(test)]
 mod tests {
     #[test]
-    fn it_works() {
-    }
+    fn it_works() {}
 }
 "#);
 


### PR DESCRIPTION
When you run `rustfmt` on the default generated lib template, it modifies it as shown [here](https://play.rust-lang.org/?gist=bd44610731e26e76719e75d47e598990&version=undefined)
