### PR TITLE
Fixed panic when canonicalizing not-a-base-url, fixes #4394

### DIFF
--- a/src/bin/git_checkout.rs
+++ b/src/bin/git_checkout.rs
@@ -40,9 +40,9 @@ pub fn execute(options: Options, config: &Config) -> CliResult {
     let url = url.to_url()?;
 
     let reference = GitReference::Branch(reference.clone());
-    let source_id = SourceId::for_git(&url, reference);
+    let source_id = SourceId::for_git(&url, reference)?;
 
-    let mut source = GitSource::new(&source_id, config);
+    let mut source = GitSource::new(&source_id, config)?;
 
     source.update()?;
 

--- a/src/bin/install.rs
+++ b/src/bin/install.rs
@@ -136,7 +136,7 @@ pub fn execute(options: Options, config: &Config) -> CliResult {
         } else {
             GitReference::Branch("master".to_string())
         };
-        SourceId::for_git(&url, gitref)
+        SourceId::for_git(&url, gitref)?
     } else if let Some(path) = options.flag_path {
         SourceId::for_path(&config.cwd().join(path))?
     } else if options.arg_crate.is_empty() {

--- a/src/cargo/core/package_id.rs
+++ b/src/cargo/core/package_id.rs
@@ -180,7 +180,7 @@ mod tests {
     #[test]
     fn invalid_version_handled_nicely() {
         let loc = CRATES_IO.to_url().unwrap();
-        let repo = SourceId::for_registry(&loc);
+        let repo = SourceId::for_registry(&loc).unwrap();
 
         assert!(PackageId::new("foo", "1.0", &repo).is_err());
         assert!(PackageId::new("foo", "1", &repo).is_err());

--- a/src/cargo/core/package_id_spec.rs
+++ b/src/cargo/core/package_id_spec.rs
@@ -270,7 +270,7 @@ mod tests {
     #[test]
     fn matching() {
         let url = Url::parse("http://example.com").unwrap();
-        let sid = SourceId::for_registry(&url);
+        let sid = SourceId::for_registry(&url).unwrap();
         let foo = PackageId::new("foo", "1.2.3", &sid).unwrap();
         let bar = PackageId::new("bar", "1.2.3", &sid).unwrap();
 

--- a/src/cargo/ops/cargo_install.rs
+++ b/src/cargo/ops/cargo_install.rs
@@ -133,7 +133,7 @@ fn install_one(root: Filesystem,
     let config = opts.config;
 
     let (pkg, source) = if source_id.is_git() {
-        select_pkg(GitSource::new(source_id, config),
+        select_pkg(GitSource::new(source_id, config)?,
                    krate, vers, config, is_first_install,
                    &mut |git| git.read_packages())?
     } else if source_id.is_path() {

--- a/src/cargo/ops/registry.rs
+++ b/src/cargo/ops/registry.rs
@@ -195,7 +195,7 @@ pub fn registry(config: &Config,
     } = registry_configuration(config)?;
     let token = token.or(token_config);
     let sid = match index {
-        Some(index) => SourceId::for_registry(&index.to_url()?),
+        Some(index) => SourceId::for_registry(&index.to_url()?)?,
         None => SourceId::crates_io(config)?,
     };
     let api_host = {

--- a/src/cargo/sources/config.rs
+++ b/src/cargo/sources/config.rs
@@ -73,7 +73,7 @@ impl<'cfg> SourceConfigMap<'cfg> {
         debug!("loading: {}", id);
         let mut name = match self.id2name.get(id) {
             Some(name) => name,
-            None => return Ok(id.load(self.config)),
+            None => return Ok(id.load(self.config)?),
         };
         let mut path = Path::new("/");
         let orig_name = name;
@@ -91,7 +91,7 @@ impl<'cfg> SourceConfigMap<'cfg> {
                     name = s;
                     path = p;
                 }
-                None if *id == cfg.id => return Ok(id.load(self.config)),
+                None if *id == cfg.id => return Ok(id.load(self.config)?),
                 None => {
                     new_id = cfg.id.with_precise(id.precise()
                                                  .map(|s| s.to_string()));
@@ -105,8 +105,8 @@ impl<'cfg> SourceConfigMap<'cfg> {
                        (configuration in `{}`)", name, path.display())
             }
         }
-        let new_src = new_id.load(self.config);
-        let old_src = id.load(self.config);
+        let new_src = new_id.load(self.config)?;
+        let old_src = id.load(self.config)?;
         if new_src.supports_checksums() != old_src.supports_checksums() {
             let (supports, no_support) = if new_src.supports_checksums() {
                 (name, orig_name)
@@ -133,7 +133,7 @@ a lock file compatible with `{orig}` cannot be generated in this situation
         let mut srcs = Vec::new();
         if let Some(val) = table.get("registry") {
             let url = url(val, &format!("source.{}.registry", name))?;
-            srcs.push(SourceId::for_registry(&url));
+            srcs.push(SourceId::for_registry(&url)?);
         }
         if let Some(val) = table.get("local-registry") {
             let (s, path) = val.string(&format!("source.{}.local-registry",

--- a/src/cargo/sources/git/source.rs
+++ b/src/cargo/sources/git/source.rs
@@ -76,13 +76,10 @@ fn ident(url: &Url) -> CargoResult<String> {
 pub fn canonicalize_url(url: &Url) -> CargoResult<Url> {
     let mut url = url.clone();
 
+    // cannot-be-a-base-urls are not supported 
+    // eg. github.com:rust-lang-nursery/rustfmt.git
     if url.cannot_be_a_base() {
-        if url.scheme() != "github.com" {
-            return Err(format!("invalid url `{}`: cannot-be-a-base-URLs are not supported", url).into());
-        }
-        // it's most likely an attempt to fetch github repo
-        // https://github.com/rust-lang/cargo/issues/4394
-        url = Url::parse(&format!("https://github.com/{}", url.path())).unwrap();
+        return Err(format!("invalid url `{}`: cannot-be-a-base-URLs are not supported", url).into());
     }
 
     // Strip a trailing slash
@@ -245,22 +242,15 @@ mod test {
     }
 
     #[test]
-    fn test_canonicalize_idents_different_protocls() {
+    fn test_canonicalize_idents_different_protocols() {
         let ident1 = ident(&url("https://github.com/PistonDevelopers/piston")).unwrap();
         let ident2 = ident(&url("git://github.com/PistonDevelopers/piston")).unwrap();
         assert_eq!(ident1, ident2);
     }
 
     #[test]
-    fn test_canonicalize_github_not_a_base_urls() {
-        let ident1 = ident(&url("github.com:PistonDevelopers/piston")).unwrap();
-        let ident2 = ident(&url("https://github.com/PistonDevelopers/piston")).unwrap();
-        assert_eq!(ident1, ident2);
-    }
-
-    #[test]
-    fn test_canonicalize_not_a_base_urls() {
-        assert!(ident(&url("github.com:PistonDevelopers/piston")).is_ok());
+    fn test_canonicalize_cannot_be_a_base_urls() {
+        assert!(ident(&url("github.com:PistonDevelopers/piston")).is_err());
         assert!(ident(&url("google.com:PistonDevelopers/piston")).is_err());
     }
 

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -876,7 +876,7 @@ impl TomlDependency {
                     .or_else(|| details.rev.clone().map(GitReference::Rev))
                     .unwrap_or_else(|| GitReference::Branch("master".to_string()));
                 let loc = git.to_url()?;
-                SourceId::for_git(&loc, reference)
+                SourceId::for_git(&loc, reference)?
             },
             (None, Some(path)) => {
                 cx.nested_paths.push(PathBuf::from(path));

--- a/tests/install.rs
+++ b/tests/install.rs
@@ -902,3 +902,11 @@ historically Cargo treated this as a semver version requirement accidentally
 and will continue to do so, but this behavior will be removed eventually
 "));
 }
+
+#[test]
+fn test_install_git_cannot_be_a_base_url() {
+    assert_that(cargo_process("install").arg("--git").arg("github.com:rust-lang-nursery/rustfmt.git"),
+                execs().with_status(101).with_stderr("\
+error: invalid url `github.com:rust-lang-nursery/rustfmt.git`: cannot-be-a-base-URLs are not supported
+"));
+}

--- a/tests/resolve.rs
+++ b/tests/resolve.rs
@@ -44,7 +44,7 @@ trait ToDep {
 impl ToDep for &'static str {
     fn to_dep(self) -> Dependency {
         let url = "http://example.com".to_url().unwrap();
-        let source_id = SourceId::for_registry(&url);
+        let source_id = SourceId::for_registry(&url).unwrap();
         Dependency::parse_no_deprecated(self, Some("1.0.0"), &source_id).unwrap()
     }
 }
@@ -86,7 +86,7 @@ macro_rules! pkg {
 
 fn registry_loc() -> SourceId {
     let remote = "http://example.com".to_url().unwrap();
-    SourceId::for_registry(&remote)
+    SourceId::for_registry(&remote).unwrap()
 }
 
 fn pkg(name: &str) -> Summary {
@@ -100,7 +100,7 @@ fn pkg_id(name: &str) -> PackageId {
 fn pkg_id_loc(name: &str, loc: &str) -> PackageId {
     let remote = loc.to_url();
     let master = GitReference::Branch("master".to_string());
-    let source_id = SourceId::for_git(&remote.unwrap(), master);
+    let source_id = SourceId::for_git(&remote.unwrap(), master).unwrap();
 
     PackageId::new(name, "1.0.0", &source_id).unwrap()
 }
@@ -112,14 +112,14 @@ fn pkg_loc(name: &str, loc: &str) -> Summary {
 fn dep(name: &str) -> Dependency { dep_req(name, "1.0.0") }
 fn dep_req(name: &str, req: &str) -> Dependency {
     let url = "http://example.com".to_url().unwrap();
-    let source_id = SourceId::for_registry(&url);
+    let source_id = SourceId::for_registry(&url).unwrap();
     Dependency::parse_no_deprecated(name, Some(req), &source_id).unwrap()
 }
 
 fn dep_loc(name: &str, location: &str) -> Dependency {
     let url = location.to_url().unwrap();
     let master = GitReference::Branch("master".to_string());
-    let source_id = SourceId::for_git(&url, master);
+    let source_id = SourceId::for_git(&url, master).unwrap();
     Dependency::parse_no_deprecated(name, Some("1.0.0"), &source_id).unwrap()
 }
 fn dep_kind(name: &str, kind: Kind) -> Dependency {


### PR DESCRIPTION
Fixes #4394. Majority of the changes are caused by propagating error upstream to `SourceId` and `GitSource`.