### PR TITLE
Fix #4370 - init panic in C:\ or /

### DIFF
--- a/src/cargo/ops/cargo_new.rs
+++ b/src/cargo/ops/cargo_new.rs
@@ -403,7 +403,7 @@ fn mk(config: &Config, opts: &MkOptions) -> CargoResult<()> {
         if !opts.bin { "glob:Cargo.lock\n" } else { "" }]
         .concat();
 
-    let in_existing_vcs_repo = existing_vcs_repo(path.parent().unwrap(), config.cwd());
+    let in_existing_vcs_repo = existing_vcs_repo(path.parent().unwrap_or(path), config.cwd());
     let vcs = match (opts.version_control, cfg.version_control, in_existing_vcs_repo) {
         (None, None, false) => VersionControl::Git,
         (None, Some(option), false) => option,


### PR DESCRIPTION
This fixes the crash in this issue, but the error message is strange - unable to create directory 'C:\\.'. I don't have write permissions there without becoming admin, so I suspect it's just a permission issue, but the weird error can be fixed by calling Path::canonicalize on line 300.