### PR TITLE
Add `fn args_replace` and `fn get_program` to `ProcessBuilder`

### DIFF
--- a/src/cargo/util/process_builder.rs
+++ b/src/cargo/util/process_builder.rs
@@ -45,6 +45,13 @@ impl ProcessBuilder {
         self
     }
 
+    pub fn args_replace<T: AsRef<OsStr>>(&mut self, arguments: &[T]) -> &mut ProcessBuilder {
+        self.args = arguments.iter().map(|t| {
+            t.as_ref().to_os_string()
+        }).collect();
+        self
+    }
+
     pub fn cwd<T: AsRef<OsStr>>(&mut self, path: T) -> &mut ProcessBuilder {
         self.cwd = Some(path.as_ref().to_os_string());
         self
@@ -59,6 +66,10 @@ impl ProcessBuilder {
     pub fn env_remove(&mut self, key: &str) -> &mut ProcessBuilder {
         self.env.insert(key.to_string(), None);
         self
+    }
+
+    pub fn get_program(&self) -> &OsString {
+        &self.program
     }
 
     pub fn get_args(&self) -> &[OsString] {


### PR DESCRIPTION
`Executor::exec()` provides a `ProcessBuilder` argument representing compiler call and if someone wants to use it or modify it for their own purposes, they have to (partially) recreate it themselves.

This:
* makes the argument modification possible (via `args_replace`, analogous to `env_remove`)
* exposes the program that will be run (via `get_program`, in case `rustc` is overriden via wrapper etc.).

r? @alexcrichton 