### PR TITLE
when cross-compiling, look for RUSTFLAGS_HOST for rustc flags of build scripts

### DIFF
--- a/src/cargo/ops/cargo_rustc/context.rs
+++ b/src/cargo/ops/cargo_rustc/context.rs
@@ -1066,15 +1066,16 @@ fn env_args(config: &Config,
     let compiling_with_target = build_config.requested_target.is_some();
     let is_target_kind = kind == Kind::Target;
 
+    let mut name = name.to_owned();
     if compiling_with_target && !is_target_kind {
         // This is probably a build script or plugin and we're
-        // compiling with --target. In this scenario there are
-        // no rustflags we can apply.
-        return Ok(Vec::new());
+        // compiling with --target. In this scenario we apply the _HOST
+        // version of the flags.
+        name.push_str("_HOST");
     }
 
     // First try RUSTFLAGS from the environment
-    if let Ok(a) = env::var(name) {
+    if let Ok(a) = env::var(&name[..]) {
         let args = a.split(' ')
             .map(str::trim)
             .filter(|s| !s.is_empty())

--- a/tests/cross-compile.rs
+++ b/tests/cross-compile.rs
@@ -611,31 +611,32 @@ fn build_script_needed_for_host_and_target() {
             pub fn d2() { d1::d1(); }
         ");
 
-    assert_that(p.cargo_process("build").arg("--target").arg(&target).arg("-v"),
+    assert_that(p.cargo_process("build").arg("--target").arg(&target).arg("-v")
+                .env("RUSTFLAGS", "--cap-lints=forbid").env("RUSTFLAGS_HOST", "--cap-lints=warn"),
                 execs().with_status(0)
                        .with_stderr_contains(&format!("\
 [COMPILING] d1 v0.0.0 ({url}/d1)", url = p.url()))
                        .with_stderr_contains(&format!("\
-[RUNNING] `rustc [..] d1[/]build.rs [..] --out-dir {dir}[/]target[/]debug[/]build[/]d1-[..]`",
-    dir = p.root().display()))
+[RUNNING] `rustc [..] d1[/]build.rs [..] --out-dir {dir}[/]target[/]debug[/]build[/]d1-[..] \
+           --cap-lints=warn`",  dir = p.root().display()))
                        .with_stderr_contains(&format!("\
 [RUNNING] `{dir}[/]target[/]debug[/]build[/]d1-[..][/]build-script-build`",
-    dir = p.root().display()))
+           dir = p.root().display()))
                        .with_stderr_contains("\
-[RUNNING] `rustc [..] d1[/]src[/]lib.rs [..]`")
+[RUNNING] `rustc [..] d1[/]src[/]lib.rs [..] --cap-lints=warn [..]`")
                        .with_stderr_contains(&format!("\
 [COMPILING] d2 v0.0.0 ({url}/d2)", url = p.url()))
                        .with_stderr_contains(&format!("\
-[RUNNING] `rustc [..] d2[/]src[/]lib.rs [..] \
+[RUNNING] `rustc [..] d2[/]src[/]lib.rs [..] --cap-lints=warn \
            -L /path/to/{host}`", host = host))
                        .with_stderr_contains(&format!("\
 [COMPILING] foo v0.0.0 ({url})", url = p.url()))
                        .with_stderr_contains(&format!("\
 [RUNNING] `rustc [..] build.rs [..] --out-dir {dir}[/]target[/]debug[/]build[/]foo-[..] \
-           -L /path/to/{host}`", dir = p.root().display(), host = host))
+           --cap-lints=warn -L /path/to/{host}`", dir = p.root().display(), host = host))
                        .with_stderr_contains(&format!("\
 [RUNNING] `rustc [..] src[/]main.rs [..] --target {target} [..] \
-           -L /path/to/{target}`", target = target)));
+           --cap-lints=forbid -L /path/to/{target}`", target = target)));
 }
 
 #[test]


### PR DESCRIPTION
Fixes #4423

This does not fix the inconsistency around what is considered a host vs. target build, but instead just uses the existing classification and makes it possible to still set flags for all compiler invocations.

If this approach is acceptable, I can edit environment-variables.md to mention the new variables. Also, if setting `target.*.rustflags` in `~/.cargo/...` is documented anywhere, that documentation should also be amended.