### PR TITLE
Replace maintenance status with ellipses

### DIFF
--- a/src/doc/manifest.md
+++ b/src/doc/manifest.md
@@ -216,7 +216,7 @@ is-it-maintained-open-issues = { repository = "..." }
 # Maintenance: `status` is required Available options are `actively-developed`,
 # `passively-maintained`, `as-is`, `none`, `experimental`, `looking-for-maintainer`
 # and `deprecated`.
-maintenance = { status = "none" }
+maintenance = { status = "..." }
 
 ```
 


### PR DESCRIPTION
Since the default maintenance status isn't set to none if it isn't set, feel it'd be more appropriate to have ellipses instead like the other badge docs.