### PR TITLE
Allow to substitute executed program in `ProcessBuilder`

### DIFF
--- a/src/cargo/util/process_builder.rs
+++ b/src/cargo/util/process_builder.rs
@@ -33,6 +33,11 @@ impl fmt::Display for ProcessBuilder {
 }
 
 impl ProcessBuilder {
+    pub fn program<T: AsRef<OsStr>>(&mut self, program: T) -> &mut ProcessBuilder {
+        self.program = program.as_ref().to_os_string();
+        self
+    }
+
     pub fn arg<T: AsRef<OsStr>>(&mut self, arg: T) -> &mut ProcessBuilder {
         self.args.push(arg.as_ref().to_os_string());
         self


### PR DESCRIPTION
Extends #4424. Sorry for the noise, turns out it'd also be useful to substite the executed program (e.g. for rls, which needs to use a rustc shim itself) without having to copy over manually all parts of the `ProcessBuilder`.

While I'm at it, do you think this needs even more functionality, like being able to specify `None` for the `cwd` or `jobserver` (currently API exposes only ability to specify `Some(...)` as values for those)?

r? @alexcrichton