### PR TITLE
Add host dependency path via -L for cargo_test.

### DIFF
--- a/src/cargo/ops/cargo_rustc/compilation.rs
+++ b/src/cargo/ops/cargo_rustc/compilation.rs
@@ -35,10 +35,6 @@ pub struct Compilation<'cfg> {
     /// Output directory for the rust host dependencies.
     pub host_deps_output: PathBuf,
 
-    /// Library search path for compiler plugins and build scripts
-    /// which have dynamic dependencies.
-    pub plugins_dylib_path: PathBuf,
-
     /// The path to rustc's own libstd
     pub host_dylib_path: Option<PathBuf>,
 
@@ -69,7 +65,6 @@ impl<'cfg> Compilation<'cfg> {
             root_output: PathBuf::from("/"),
             deps_output: PathBuf::from("/"),
             host_deps_output: PathBuf::from("/"),
-            plugins_dylib_path: PathBuf::from("/"),
             host_dylib_path: None,
             target_dylib_path: None,
             tests: Vec::new(),
@@ -129,7 +124,7 @@ impl<'cfg> Compilation<'cfg> {
                 -> CargoResult<ProcessBuilder> {
 
         let mut search_path = if is_host {
-            let mut search_path = vec![self.plugins_dylib_path.clone()];
+            let mut search_path = vec![self.host_deps_output.clone()];
             search_path.extend(self.host_dylib_path.clone());
             search_path
         } else {

--- a/src/cargo/ops/cargo_rustc/compilation.rs
+++ b/src/cargo/ops/cargo_rustc/compilation.rs
@@ -28,8 +28,12 @@ pub struct Compilation<'cfg> {
     /// Root output directory (for the local package's artifacts)
     pub root_output: PathBuf,
 
-    /// Output directory for rust dependencies
+    /// Output directory for rust dependencies.
+    /// May be for the host or for a specific target.
     pub deps_output: PathBuf,
+
+    /// Output directory for the rust host dependencies.
+    pub host_deps_output: PathBuf,
 
     /// Library search path for compiler plugins and build scripts
     /// which have dynamic dependencies.
@@ -64,6 +68,7 @@ impl<'cfg> Compilation<'cfg> {
             native_dirs: HashSet::new(),  // TODO: deprecated, remove
             root_output: PathBuf::from("/"),
             deps_output: PathBuf::from("/"),
+            host_deps_output: PathBuf::from("/"),
             plugins_dylib_path: PathBuf::from("/"),
             host_dylib_path: None,
             target_dylib_path: None,

--- a/src/cargo/ops/cargo_rustc/context.rs
+++ b/src/cargo/ops/cargo_rustc/context.rs
@@ -176,6 +176,7 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
         }
 
         self.compilation.plugins_dylib_path = self.host.deps().to_path_buf();
+        self.compilation.host_deps_output = self.host.deps().to_path_buf();
 
         let layout = self.target.as_ref().unwrap_or(&self.host);
         self.compilation.root_output = layout.dest().to_path_buf();

--- a/src/cargo/ops/cargo_rustc/context.rs
+++ b/src/cargo/ops/cargo_rustc/context.rs
@@ -175,7 +175,6 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
             None => {}
         }
 
-        self.compilation.plugins_dylib_path = self.host.deps().to_path_buf();
         self.compilation.host_deps_output = self.host.deps().to_path_buf();
 
         let layout = self.target.as_ref().unwrap_or(&self.host);

--- a/src/cargo/ops/cargo_test.rs
+++ b/src/cargo/ops/cargo_test.rs
@@ -126,6 +126,7 @@ fn run_doc_tests(options: &TestOptions,
                  -> CargoResult<(Test, Vec<ProcessError>)> {
     let mut errors = Vec::new();
     let config = options.compile_opts.config;
+    let host_deps = find_host_deps(options, compilation);
 
     // We don't build/rust doctests if target != host
     if config.rustc()?.host != compilation.target {
@@ -143,6 +144,8 @@ fn run_doc_tests(options: &TestOptions,
             let mut p = compilation.rustdoc_process(package)?;
             p.arg("--test").arg(lib)
              .arg("--crate-name").arg(&crate_name);
+
+            p.arg("-L").arg(&host_deps);
 
             for &rust_dep in &[&compilation.deps_output] {
                 let mut arg = OsString::from("dependency=");
@@ -197,4 +200,25 @@ fn run_doc_tests(options: &TestOptions,
         }
     }
     Ok((Test::Doc, errors))
+}
+
+fn find_host_deps(options: &TestOptions, compilation: &Compilation) -> OsString {
+    let build_type = if options.compile_opts.release { "release" } else { "debug" };
+    let mut dir = compilation.root_output.clone();
+
+    // first pop off the build_type
+    dir.pop();
+    // if we see the target next, pop it off
+    let target: &OsStr = compilation.target.as_ref();
+    if dir.file_name().unwrap() == target {
+        dir.pop();
+    }
+    // push the build_type back on
+    dir.push(build_type);
+    // and we are looking for the deps directory
+    dir.push("deps");
+
+    let mut host_deps = OsString::from("dependency=");
+    host_deps.push(dir);
+    host_deps
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -2816,10 +2816,10 @@ fn find_dependency_of_proc_macro_dependency_with_target() {
             proc-macro = true
 
             [dependencies]
-            base64 = "^0.6"
+            dep_of_proc_macro_dep = "^0.1"
         "#)
         .file("proc_macro_dep/src/lib.rs", r#"
-            extern crate base64;
+            extern crate dep_of_proc_macro_dep;
             extern crate proc_macro;
             use proc_macro::TokenStream;
 
@@ -2828,6 +2828,7 @@ fn find_dependency_of_proc_macro_dependency_with_target() {
                 "".parse().unwrap()
             }
         "#);
+        Package::new("dep_of_proc_macro_dep", "0.1.0").publish();
         workspace.build();
     assert_that(workspace.cargo("test").arg("--all").arg("--target").arg(rustc_host()),
                 execs().with_status(0));

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -2816,10 +2816,10 @@ fn find_dependency_of_proc_macro_dependency_with_target() {
             proc-macro = true
 
             [dependencies]
-            dep_of_proc_macro_dep = "^0.1"
+            bar = "^0.1"
         "#)
         .file("proc_macro_dep/src/lib.rs", r#"
-            extern crate dep_of_proc_macro_dep;
+            extern crate bar;
             extern crate proc_macro;
             use proc_macro::TokenStream;
 
@@ -2828,7 +2828,11 @@ fn find_dependency_of_proc_macro_dependency_with_target() {
                 "".parse().unwrap()
             }
         "#);
-    Package::new("dep_of_proc_macro_dep", "0.1.0").publish();
+    Package::new("foo", "0.1.0").publish();
+    Package::new("bar", "0.1.0")
+        .dep("foo", "0.1")
+        .file("src/lib.rs", "extern crate foo;")
+        .publish();
     workspace.build();
     assert_that(workspace.cargo("test").arg("--all").arg("--target").arg(rustc_host()),
                 execs().with_status(0));

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -2828,8 +2828,8 @@ fn find_dependency_of_proc_macro_dependency_with_target() {
                 "".parse().unwrap()
             }
         "#);
-        Package::new("dep_of_proc_macro_dep", "0.1.0").publish();
-        workspace.build();
+    Package::new("dep_of_proc_macro_dep", "0.1.0").publish();
+    workspace.build();
     assert_that(workspace.cargo("test").arg("--all").arg("--target").arg(rustc_host()),
                 execs().with_status(0));
 }


### PR DESCRIPTION
Proc-macro crates' dependencies in the host dependency directory cannot
be found when running `cargo test` with the `--target {target}` flag
set as reported in #4224. This adds the host dependency directory to the
search path to find those missing dependencies with -L when building tests
and adds a test case that fails before and passes after this patch.

A new function `find_host_deps(..)` is added to accomplish this which can
determine the path of the host dependencies directory from within
`run_doc_tests(..)` where the missing library search path is needed.

Fixes #4224
Fixes #4254 

Modeled after a similar patch: a298346d6e8862992be3fd93dd8a6c833cc72719

**Concerns**

The test case seems to require a non-local crate from crates.io to example the failure before this patch. Couldn't make it fail with simply another local subcrate, but if others think it's possible that'd be great. This means that during tests for the cargo project itself that this test case actually downloads and compiles a crate, which I don't think any other tests do and is obviously not ideal and is perhaps even unacceptable. I've used the base64 crate pretty arbitrarily, but which crate it is really doesn't matter to test the case's content. So if anyone knows a tiny or empty crate on crates.io to use instead that'd speed this up and if someone can figure out how to make it fail before this patch is applied without downloading an external crate that would help as well.

Also, I'm not 100% confident about the `find_host_deps(..)` style and whether it's the best way to find the host dependencies directory with just the `TestOptions` and `Compilation` structs available since I'm new to this project. Any comments are appreciated.