### PR TITLE
relax rustdoc tests

### DIFF
--- a/tests/rustdoc.rs
+++ b/tests/rustdoc.rs
@@ -38,14 +38,14 @@ fn rustdoc_args() {
         "#)
         .file("src/lib.rs", r#" "#);
 
-    assert_that(p.cargo_process("rustdoc").arg("-v").arg("--").arg("--no-defaults"),
+    assert_that(p.cargo_process("rustdoc").arg("-v").arg("--").arg("--cfg=foo"),
                 execs()
                 .with_status(0)
                 .with_stderr(format!("\
 [DOCUMENTING] foo v0.0.1 ({url})
 [RUNNING] `rustdoc --crate-name foo src[/]lib.rs \
         -o {dir}[/]target[/]doc \
-        --no-defaults \
+        --cfg=foo \
         -L dependency={dir}[/]target[/]debug[/]deps`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ", dir = p.root().display(), url = p.url())));
@@ -81,7 +81,7 @@ fn rustdoc_foo_with_bar_dependency() {
         "#);
     bar.build();
 
-    assert_that(foo.cargo_process("rustdoc").arg("-v").arg("--").arg("--no-defaults"),
+    assert_that(foo.cargo_process("rustdoc").arg("-v").arg("--").arg("--cfg=foo"),
                 execs()
                 .with_status(0)
                 .with_stderr(format!("\
@@ -90,7 +90,7 @@ fn rustdoc_foo_with_bar_dependency() {
 [DOCUMENTING] foo v0.0.1 ({url})
 [RUNNING] `rustdoc --crate-name foo src[/]lib.rs \
         -o {dir}[/]target[/]doc \
-        --no-defaults \
+        --cfg=foo \
         -L dependency={dir}[/]target[/]debug[/]deps \
         --extern [..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
@@ -128,14 +128,14 @@ fn rustdoc_only_bar_dependency() {
     bar.build();
 
     assert_that(foo.cargo_process("rustdoc").arg("-v").arg("-p").arg("bar")
-                                            .arg("--").arg("--no-defaults"),
+                                            .arg("--").arg("--cfg=foo"),
                 execs()
                 .with_status(0)
                 .with_stderr(format!("\
 [DOCUMENTING] bar v0.0.1 ([..])
 [RUNNING] `rustdoc --crate-name bar [..]bar[/]src[/]lib.rs \
         -o {dir}[/]target[/]doc \
-        --no-defaults \
+        --cfg=foo \
         -L dependency={dir}[/]target[/]debug[/]deps`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ", dir = foo.root().display())));
@@ -157,7 +157,7 @@ fn rustdoc_same_name_err() {
         .file("src/lib.rs", r#" "#);
 
     assert_that(p.cargo_process("rustdoc").arg("-v")
-                 .arg("--").arg("--no-defaults"),
+                 .arg("--").arg("--cfg=foo"),
                 execs()
                 .with_status(101)
                 .with_stderr("[ERROR] cannot document a package where a library and a \


### PR DESCRIPTION
This was asserting on the output directly, rather than just what it contains.

In https://github.com/rust-lang/rust/pull/44138 we are adding deprecations, and so it
breaks these tests.