### PR TITLE
fix error message when --locked is passed but lockfile is outdated

### DIFF
--- a/src/cargo/ops/lockfile.rs
+++ b/src/cargo/ops/lockfile.rs
@@ -98,7 +98,7 @@ pub fn write_pkg_lockfile(ws: &Workspace, resolve: &Resolve) -> CargoResult<()> 
     }
 
     if !ws.config().lock_update_allowed() {
-        let flag = if ws.config().network_allowed() {"--frozen"} else {"--locked"};
+        let flag = if ws.config().network_allowed() {"--locked"} else {"--frozen"};
         bail!("the lock file needs to be updated but {} was passed to \
                prevent this", flag);
     }


### PR DESCRIPTION
The logic is currently the wrong way around, saying I passed `--frozen` when I really passed `--locked`.

I had no idea where to put the test...