### PR TITLE
[travis] Enable cache for $HOME/.cargo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,10 @@ dist: trusty
 git:
   depth: 1
 
+cache:
+  directories:
+    - $HOME/.cargo/bin/
+
 matrix:
   include:
     - env: TARGET=x86_64-unknown-linux-gnu
@@ -22,7 +26,7 @@ matrix:
            ALT=i686-unknown-linux-gnu
       rust: nightly
       install:
-        - cargo install mdbook
+        - mdbook --help || cargo install mdbook --force
       script:
         - cargo test
         - cargo doc --no-deps


### PR DESCRIPTION
This should accelerate the `cargo install mdbook` step under `install`,
which is currently called on all linux+nightly setups.

https://github.com/rust-lang/cargo/blob/36ddeff03a31f710095cfbe49287503bb60e294d/.travis.yml#L24-L25