### PR TITLE
Clarify that .cargo/config files are unified

### DIFF
--- a/src/doc/book/src/reference/config.md
+++ b/src/doc/book/src/reference/config.md
@@ -9,7 +9,7 @@ manifest, see the [manifest format](reference/manifest.html).
 Cargo allows to have local configuration for a particular project or global
 configuration (like git). Cargo also extends this ability to a hierarchical
 strategy. If, for example, Cargo were invoked in `/home/foo/bar/baz`, then the
-following configuration files would be probed for:
+following configuration files would be probed for and unified in this order:
 
 * `/home/foo/bar/baz/.cargo/config`
 * `/home/foo/bar/.cargo/config`

--- a/src/doc/config.md
+++ b/src/doc/config.md
@@ -9,7 +9,7 @@ manifest, see the [manifest format](manifest.html).
 Cargo allows to have local configuration for a particular project or global
 configuration (like git). Cargo also extends this ability to a hierarchical
 strategy. If, for example, Cargo were invoked in `/home/foo/bar/baz`, then the
-following configuration files would be probed for:
+following configuration files would be probed for and unified in this order:
 
 * `/home/foo/bar/baz/.cargo/config`
 * `/home/foo/bar/.cargo/config`


### PR DESCRIPTION
It wasn't immediately clear to me from the text on this page whether Cargo looks for these files and stops at the first one, or whether it looks for them all and puts them all together. I was pretty sure it was the latter, but I think these few more words would have made me feel more confident sooner :)