### PR TITLE
Update Appveyor badge docs

### DIFF
--- a/src/doc/manifest.md
+++ b/src/doc/manifest.md
@@ -185,7 +185,8 @@ license-file = "..."
 
 # Appveyor: `repository` is required. `branch` is optional; default is `master`
 # `service` is optional; valid values are `github` (default), `bitbucket`, and
-# `gitlab`.
+# `gitlab`; `id` is optional; you can specify the appveyor project id if you 
+# want to use that instead.
 appveyor = { repository = "...", branch = "master", service = "github" }
 
 # Circle CI: `repository` is required. `branch` is optiona; default is `master`


### PR DESCRIPTION
* indicate you can specify the appveyor project id if you want to use that instead

This PR is part of: https://github.com/rust-lang/crates.io/issues/693