### PR TITLE
cargo_compile: iterate packages once, not three times

### DIFF
--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -231,21 +231,16 @@ pub fn compile_ws<'a>(ws: &Workspace<'a>,
                                             &specs)?;
     let (packages, resolve_with_overrides) = resolve;
 
-    let mut pkgids = Vec::new();
-    if specs.len() > 0 {
-        for p in specs.iter() {
-            pkgids.push(p.query(resolve_with_overrides.iter())?);
-        }
-    } else {
+    if specs.is_empty() {
         return Err(format!("manifest path `{}` contains no package: The manifest is virtual, \
                      and the workspace has no members.", ws.current_manifest().display()).into());
     };
 
-    let to_builds = pkgids.iter().map(|id| {
-        packages.get(id)
-    }).collect::<CargoResult<Vec<_>>>()?;
-    for p in to_builds.iter() {
+    let mut to_builds = Vec::new();
+    for p in specs.iter() {
+        let p = packages.get(p.query(resolve_with_overrides.iter())?)?;
         p.manifest().print_teapot(ws.config());
+        to_builds.push(p);
     }
 
     let mut general_targets = Vec::new();

--- a/src/cargo/ops/cargo_doc.rs
+++ b/src/cargo/ops/cargo_doc.rs
@@ -22,15 +22,15 @@ pub fn doc(ws: &Workspace, options: &DocOptions) -> CargoResult<()> {
                                             &specs)?;
     let (packages, resolve_with_overrides) = resolve;
 
-    let mut pkgs = Vec::new();
-    if specs.len() > 0 {
-        for p in specs.iter() {
-            pkgs.push(packages.get(p.query(resolve_with_overrides.iter())?)?);
-        }
-    } else {
+    if specs.is_empty() {
         return Err(format!("manifest path `{}` contains no package: The manifest is virtual, \
                      and the workspace has no members.", ws.current_manifest().display()).into());
     };
+
+    let mut pkgs = Vec::new();
+    for p in specs.iter() {
+        pkgs.push(packages.get(p.query(resolve_with_overrides.iter())?)?);
+    }
 
     let mut lib_names = HashSet::new();
     let mut bin_names = HashSet::new();


### PR DESCRIPTION
I forgot to push this into <https://github.com/rust-lang/cargo/pull/4492>

r? @matklad
