### PR TITLE
Move cargo features to top-level

### DIFF
--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -222,6 +222,8 @@ pub struct TomlManifest {
     patch: Option<HashMap<String, HashMap<String, TomlDependency>>>,
     workspace: Option<TomlWorkspace>,
     badges: Option<HashMap<String, HashMap<String, String>>>,
+    #[serde(rename = "cargo-features")]
+    cargo_features: Option<Vec<String>>,
 }
 
 #[derive(Deserialize, Serialize, Clone, Debug, Default)]
@@ -389,8 +391,6 @@ pub struct TomlProject {
     include: Option<Vec<String>>,
     publish: Option<bool>,
     workspace: Option<String>,
-    #[serde(rename = "cargo-features")]
-    cargo_features: Option<Vec<String>>,
     #[serde(rename = "im-a-teapot")]
     im_a_teapot: Option<bool>,
 
@@ -472,6 +472,7 @@ impl TomlManifest {
             patch: None,
             workspace: None,
             badges: self.badges.clone(),
+            cargo_features: self.cargo_features.clone(),
         };
 
         fn map_deps(deps: Option<&HashMap<String, TomlDependency>>)
@@ -649,7 +650,7 @@ impl TomlManifest {
         let profiles = build_profiles(&me.profile);
         let publish = project.publish.unwrap_or(true);
         let empty = Vec::new();
-        let cargo_features = project.cargo_features.as_ref().unwrap_or(&empty);
+        let cargo_features = me.cargo_features.as_ref().unwrap_or(&empty);
         let features = Features::new(&cargo_features, &mut warnings)?;
         let mut manifest = Manifest::new(summary,
                                          targets,

--- a/tests/cargo-features.rs
+++ b/tests/cargo-features.rs
@@ -52,11 +52,12 @@ switch to nightly channel you can add
 fn unknown_feature() {
     let p = project("foo")
         .file("Cargo.toml", r#"
+            cargo-features = ["foo"]
+
             [package]
             name = "a"
             version = "0.0.1"
             authors = []
-            cargo-features = ["foo"]
         "#)
         .file("src/lib.rs", "");
     assert_that(p.cargo_process("build"),
@@ -73,11 +74,12 @@ Caused by:
 fn stable_feature_warns() {
     let p = project("foo")
         .file("Cargo.toml", r#"
+            cargo-features = ["test-dummy-stable"]
+
             [package]
             name = "a"
             version = "0.0.1"
             authors = []
-            cargo-features = ["test-dummy-stable"]
         "#)
         .file("src/lib.rs", "");
     assert_that(p.cargo_process("build"),
@@ -94,12 +96,13 @@ necessary to be listed in the manifest
 fn nightly_feature_requires_nightly() {
     let p = project("foo")
         .file("Cargo.toml", r#"
+            cargo-features = ["test-dummy-unstable"]
+
             [package]
             name = "a"
             version = "0.0.1"
             authors = []
             im-a-teapot = true
-            cargo-features = ["test-dummy-unstable"]
         "#)
         .file("src/lib.rs", "");
     assert_that(p.cargo_process("build")
@@ -135,12 +138,13 @@ fn nightly_feature_requires_nightly_in_dep() {
         "#)
         .file("src/lib.rs", "")
         .file("a/Cargo.toml", r#"
+            cargo-features = ["test-dummy-unstable"]
+
             [package]
             name = "a"
             version = "0.0.1"
             authors = []
             im-a-teapot = true
-            cargo-features = ["test-dummy-unstable"]
         "#)
         .file("a/src/lib.rs", "");
     assert_that(p.cargo_process("build")
@@ -173,12 +177,13 @@ Caused by:
 fn cant_publish() {
     let p = project("foo")
         .file("Cargo.toml", r#"
+            cargo-features = ["test-dummy-unstable"]
+
             [package]
             name = "a"
             version = "0.0.1"
             authors = []
             im-a-teapot = true
-            cargo-features = ["test-dummy-unstable"]
         "#)
         .file("src/lib.rs", "");
     assert_that(p.cargo_process("build")
@@ -204,12 +209,13 @@ Caused by:
 fn z_flags_rejected() {
     let p = project("foo")
         .file("Cargo.toml", r#"
+            cargo-features = ["test-dummy-unstable"]
+
             [package]
             name = "a"
             version = "0.0.1"
             authors = []
             im-a-teapot = true
-            cargo-features = ["test-dummy-unstable"]
         "#)
         .file("src/lib.rs", "");
     assert_that(p.cargo_process("build")
@@ -242,11 +248,12 @@ error: unknown `-Z` flag specified: arg
 fn publish_rejected() {
     let p = project("foo")
         .file("Cargo.toml", r#"
+            cargo-features = ["test-dummy-unstable"]
+
             [package]
             name = "a"
             version = "0.0.1"
             authors = []
-            cargo-features = ["test-dummy-unstable"]
         "#)
         .file("src/lib.rs", "");
     assert_that(p.cargo_process("package")


### PR DESCRIPTION
This should allow to add Cargo-features to virtual manifest as well.

I've not actually added support for features in virtual manifests just yet, because that will probably require some refactoring to avoid duplicating feature-related code between virtual and usual manifests.

r? @alexcrichton 