### PR TITLE
Improve message for multiple links to native lib

### DIFF
--- a/src/cargo/core/resolver/mod.rs
+++ b/src/cargo/core/resolver/mod.rs
@@ -114,6 +114,31 @@ struct Candidate {
 }
 
 impl Resolve {
+    /// Resolves one of the paths from the given dependent package up to
+    /// the root.
+    pub fn path_to_top(&self, pkg: &PackageId) -> Vec<&PackageId> {
+        let mut result = Vec::new();
+        let mut pkg = pkg;
+        loop {
+            match self.graph
+                  .get_nodes()
+                  .iter()
+                  .filter_map(|(pulling, pulled)|
+                              if pulled.contains(pkg) {
+                                  Some(pulling)
+                              } else {
+                                  None
+                              })
+                  .nth(0) {
+                Some(pulling) => {
+                    result.push(pulling);
+                    pkg = pulling;
+                },
+                None => break
+            }
+        }
+        result
+    }
     pub fn register_used_patches(&mut self,
                                  patches: &HashMap<Url, Vec<Summary>>) {
         for summary in patches.values().flat_map(|v| v) {

--- a/src/cargo/ops/cargo_rustc/links.rs
+++ b/src/cargo/ops/cargo_rustc/links.rs
@@ -32,37 +32,27 @@ impl<'a> Links<'a> {
             let describe_path = |pkgid: &PackageId| -> String {
                 let dep_path = resolve.path_to_top(pkgid);
                 if dep_path.is_empty() {
-                    String::from("(This is the root-package)")
+                    String::from("The root-package ")
                 } else {
-                    let mut pkg_path_desc = String::from("(Dependency via ");
-                    let mut dep_path_iter = dep_path.into_iter().peekable();
-                    while let Some(dep) = dep_path_iter.next() {
-                        write!(pkg_path_desc, "{}", dep).unwrap();
-                        if dep_path_iter.peek().is_some() {
-                            pkg_path_desc.push_str(" => ");
-                        }
+                    let mut dep_path_desc = format!("Package `{}`\n", pkgid);
+                    for dep in dep_path {
+                        write!(dep_path_desc,
+                               "    ... which is depended on by `{}`\n",
+                               dep).unwrap();
                     }
-                    pkg_path_desc.push(')');
-                    pkg_path_desc
+                    dep_path_desc
                 }
             };
 
-            bail!("More than one package links to native library `{}`, \
-                   which can only be linked once.\n\n\
-                   Package {} links to native library `{}`.\n\
-                   {}\n\
+            bail!("Multiple packages link to native library `{}`. \
+                   A native library can be linked only once.\n\
                    \n\
-                   Package {} also links to native library `{}`.\n\
-                   {}\n\
+                   {}links to native library `{}`.\n\
                    \n\
-                   Try updating or pinning your dependencies to ensure that \
-                   native library `{}` is only linked once.",
+                   {}also links to native library `{}`.",
                   lib,
-                  prev, lib,
-                  describe_path(prev),
-                  pkg, lib,
-                  describe_path(pkg),
-                  lib)
+                  describe_path(prev), lib,
+                  describe_path(pkg), lib)
         }
         if !unit.pkg.manifest().targets().iter().any(|t| t.is_custom_build()) {
             bail!("package `{}` specifies that it links to `{}` but does not \

--- a/src/cargo/ops/cargo_rustc/mod.rs
+++ b/src/cargo/ops/cargo_rustc/mod.rs
@@ -237,7 +237,7 @@ fn compile<'a, 'cfg: 'a>(cx: &mut Context<'a, 'cfg>,
     let p = profile::start(format!("preparing: {}/{}", unit.pkg,
                                    unit.target.name()));
     fingerprint::prepare_init(cx, unit)?;
-    cx.links.validate(unit)?;
+    cx.links.validate(&cx.resolve, unit)?;
 
     let (dirty, fresh, freshness) = if unit.profile.run_custom_build {
         custom_build::prepare(cx, unit)?

--- a/tests/build-script.rs
+++ b/tests/build-script.rs
@@ -248,16 +248,14 @@ fn links_duplicates() {
     assert_that(p.cargo_process("build"),
                 execs().with_status(101)
                        .with_stderr("\
-error: More than one package links to native library `a`, which can only be \
-linked once.
+[ERROR] Multiple packages link to native library `a`. A native library can be \
+linked only once.
 
-Package foo v0.5.0 (file://[..]) links to native library `a`.
-(This is the root-package)
+The root-package links to native library `a`.
 
-Package a-sys v0.5.0 (file://[..]) also links to native library `a`.
-(Dependency via foo v0.5.0 (file://[..]))
-
-Try updating[..]
+Package `a-sys v0.5.0 (file://[..])`
+    ... which is depended on by `foo v0.5.0 (file://[..])`
+also links to native library `a`.
 "));
 }
 
@@ -303,16 +301,15 @@ fn links_duplicates_deep_dependency() {
     assert_that(p.cargo_process("build"),
                 execs().with_status(101)
                        .with_stderr("\
-error: More than one package links to native library `a`, which can only be \
-linked once.
+[ERROR] Multiple packages link to native library `a`. A native library can be \
+linked only once.
 
-Package foo v0.5.0 (file://[..]) links to native library `a`.
-(This is the root-package)
+The root-package links to native library `a`.
 
-Package a-sys v0.5.0 (file://[..]) also links to native library `a`.
-(Dependency via a v0.5.0 (file://[..]) => foo v0.5.0 (file://[..]))
-
-Try updating[..]
+Package `a-sys v0.5.0 (file://[..])`
+    ... which is depended on by `a v0.5.0 (file://[..])`
+    ... which is depended on by `foo v0.5.0 (file://[..])`
+also links to native library `a`.
 "));
 }
 


### PR DESCRIPTION
Proposal for a fix to #1006, as advertised in my comment; as discussed briefly with alexcrichton on IRC.

In case multiple packages link to the same library, the error message is now

> error: More than one package links to native library `a`, which can only be linked once.
> 
> Package a-sys v0.5.0 (file:///home/lukas/dev/issue1006test/a) links to native library `a`.
> (Dependency via foo v0.5.0 (file:///home/lukas/dev/issue1006test))
> 
> Package b-sys v0.5.0 (file:///home/lukas/dev/issue1006test/a/b) also links to native library `a`.
> (Dependency via a-sys v0.5.0 (file:///home/lukas/dev/issue1006test/a) => foo v0.5.0 (file:///home/lukas/dev/issue1006test))
> 
> Try updating or pinning your dependencies to ensure that native library `a` is only linked once.
> 

In case the root-package itself is an offender:

> Package foo v0.5.0 (file:///home/lukas/dev/issue1006test) links to native library `a`.
> (This is the root-package)
> 

IMHO the wording is much clearer now (the term "native library" and "package" are repeated on purpose); printing the whole dependency-chain from the offending package up to the root allows the user to at least figure out where the native library actually comes in.

Added a unit-test, which all pass. Please scrutinize this carefully, it's my first PR for cargo.