### PR TITLE
[patch] slipped to 1.21, mark 2

### DIFF
--- a/src/doc/book/src/reference/manifest.md
+++ b/src/doc/book/src/reference/manifest.md
@@ -727,8 +727,8 @@ source's original crate is replaced.
 
 More information about overriding dependencies can be found in the [overriding
 dependencies][replace] section of the documentation and [RFC 1969] for the
-technical specification of this feature. Note that the `[patch]` feature will
-first become available in Rust 1.20, set to be released on 2017-08-31.
+technical specification of this feature. (Note that the `[patch]` feature will
+first become available in Rust 1.21, set to be released on 2017-10-12.)
 
 [RFC 1969]: https://github.com/rust-lang/rfcs/pull/1969
 [replace]: reference/specifying-dependencies.html#overriding-dependencies

--- a/src/doc/specifying-dependencies.md
+++ b/src/doc/specifying-dependencies.md
@@ -189,10 +189,10 @@ example:
   of the crate to avoid blocking on the bug fix getting merged.
 
 These scenarios are currently all solved with the [`[patch]` manifest
-section][patch-section]. Note that the `[patch]` feature is not yet currently
-stable and will be released on 2017-08-31. Historically some of these scenarios
-have been solved with [the `[replace]` section][replace-section], but we'll
-document the `[patch]` section here.
+section][patch-section]. (Note that the `[patch]` feature will first become
+available in Rust 1.21, set to be released on 2017-10-12.) Historically some of
+these scenarios have been solved with [the `[replace]` section][replace-section],
+but we'll document the `[patch]` section here.
 
 [patch-section]: manifest.html#the-patch-section
 [replace-section]: manifest.html#the-replace-section


### PR DESCRIPTION
Same as #4513, apparently it showed up in a few places.