### PR TITLE
Clarify dependencies documentation

### DIFF
--- a/src/doc/book/src/reference/specifying-dependencies.md
+++ b/src/doc/book/src/reference/specifying-dependencies.md
@@ -31,8 +31,8 @@ An update is allowed if the new version number does not modify the left-most
 non-zero digit in the major, minor, patch grouping. In this case, if we ran
 `cargo update -p time`, cargo would update us to version `0.1.13` if it was
 available, but would not update us to `0.2.0`. If instead we had specified the
-version string as `^1.0`, cargo would update to `1.1` but not `2.0`. `0.0.x` is
-not considered compatible with any other version.
+version string as `^1.0`, cargo would update to `1.1` but not `2.0`. The version
+`0.0.x` is not considered compatible with any other version.
 
 Here are some more examples of caret requirements and the versions that would
 be allowed with them:


### PR DESCRIPTION
The snippet:

```
... but not `2.0`. `0.0.x` is not considered ...
```
Looks very similar to `... but not 2.0.0.0.x is not considered ...`, when rendered, which is confusing.

This adds a couple words to clarify.