### PR TITLE
Improve docs for build badges

### DIFF
--- a/src/doc/book/src/reference/manifest.md
+++ b/src/doc/book/src/reference/manifest.md
@@ -191,7 +191,7 @@ license-file = "..."
 # `gitlab`.
 appveyor = { repository = "...", branch = "master", service = "github" }
 
-# Circle CI: `repository` is required. `branch` is optiona; default is `master`
+# Circle CI: `repository` is required. `branch` is optional; default is `master`
 circle-ci = { repository = "...", branch = "master" }
 
 # GitLab: `repository` is required. `branch` is optional; default is `master`

--- a/src/doc/book/src/reference/manifest.md
+++ b/src/doc/book/src/reference/manifest.md
@@ -178,12 +178,15 @@ license = "..."
 # (similar to the readme key).
 license-file = "..."
 
-# Optional specification of badges to be displayed on crates.io. The badges
-# pertaining to build status that are currently available are Appveyor, CircleCI,
-# GitLab, and TravisCI. Available badges pertaining to code test coverage are
-# Codecov and Coveralls. There are also maintenance-related badges which state
-# the issue resolution time, percent of open issues, and future maintenance
-# intentions.
+# Optional specification of badges to be displayed on crates.io.
+#
+# - The badges pertaining to build status that are currently available are
+#   Appveyor, CircleCI, GitLab, and TravisCI.
+# - Available badges pertaining to code test coverage are Codecov and
+#   Coveralls.
+# - There are also maintenance-related badges basesed on isitmaintained.com
+#   which state the issue resolution time, percent of open issues, and future
+#   maintenance intentions.
 [badges]
 
 # Appveyor: `repository` is required. `branch` is optional; default is `master`

--- a/src/doc/book/src/reference/manifest.md
+++ b/src/doc/book/src/reference/manifest.md
@@ -187,6 +187,9 @@ license-file = "..."
 # - There are also maintenance-related badges basesed on isitmaintained.com
 #   which state the issue resolution time, percent of open issues, and future
 #   maintenance intentions.
+#
+# If a `repository` key is required, this refers to a Github repository in
+# `user/repo` format.
 [badges]
 
 # Appveyor: `repository` is required. `branch` is optional; default is `master`

--- a/src/doc/book/src/reference/manifest.md
+++ b/src/doc/book/src/reference/manifest.md
@@ -188,7 +188,7 @@ license-file = "..."
 #   which state the issue resolution time, percent of open issues, and future
 #   maintenance intentions.
 #
-# If a `repository` key is required, this refers to a Github repository in
+# If a `repository` key is required, this refers to a repository in
 # `user/repo` format.
 [badges]
 

--- a/src/doc/manifest.md
+++ b/src/doc/manifest.md
@@ -184,6 +184,9 @@ license-file = "..."
 # - There are also maintenance-related badges basesed on isitmaintained.com
 #   which state the issue resolution time, percent of open issues, and future
 #   maintenance intentions.
+#
+# If a `repository` key is required, this refers to a Github repository in
+# `user/repo` format.
 [badges]
 
 # Appveyor: `repository` is required. `branch` is optional; default is `master`

--- a/src/doc/manifest.md
+++ b/src/doc/manifest.md
@@ -189,7 +189,7 @@ license-file = "..."
 # want to use that instead.
 appveyor = { repository = "...", branch = "master", service = "github" }
 
-# Circle CI: `repository` is required. `branch` is optiona; default is `master`
+# Circle CI: `repository` is required. `branch` is optional; default is `master`
 circle-ci = { repository = "...", branch = "master" }
 
 # GitLab: `repository` is required. `branch` is optional; default is `master`

--- a/src/doc/manifest.md
+++ b/src/doc/manifest.md
@@ -175,12 +175,15 @@ license = "..."
 # (similar to the readme key).
 license-file = "..."
 
-# Optional specification of badges to be displayed on crates.io. The badges
-# pertaining to build status that are currently available are Appveyor, CircleCI,
-# GitLab, and TravisCI. Available badges pertaining to code test coverage are
-# Codecov and Coveralls. There are also maintenance-related badges which state
-# the issue resolution time, percent of open issues, and future maintenance
-# intentions.
+# Optional specification of badges to be displayed on crates.io.
+#
+# - The badges pertaining to build status that are currently available are
+#   Appveyor, CircleCI, GitLab, and TravisCI.
+# - Available badges pertaining to code test coverage are Codecov and
+#   Coveralls.
+# - There are also maintenance-related badges basesed on isitmaintained.com
+#   which state the issue resolution time, percent of open issues, and future
+#   maintenance intentions.
 [badges]
 
 # Appveyor: `repository` is required. `branch` is optional; default is `master`

--- a/src/doc/manifest.md
+++ b/src/doc/manifest.md
@@ -185,7 +185,7 @@ license-file = "..."
 #   which state the issue resolution time, percent of open issues, and future
 #   maintenance intentions.
 #
-# If a `repository` key is required, this refers to a Github repository in
+# If a `repository` key is required, this refers to a repository in
 # `user/repo` format.
 [badges]
 


### PR DESCRIPTION
The `repo` format wasn't clear to me. I also fixed a typo and clarified how the is-it-maintained badges are generated