### PR TITLE
Cleaning lints

### DIFF
--- a/src/cargo/ops/cargo_rustc/custom_build.rs
+++ b/src/cargo/ops/cargo_rustc/custom_build.rs
@@ -270,7 +270,7 @@ fn build_work<'a, 'cfg>(cx: &mut Context<'a, 'cfg>, unit: &Unit<'a>)
             let library_paths = parsed_output.library_paths.iter().map(|l| {
                 l.display().to_string()
             }).collect::<Vec<_>>();
-            machine_message::emit(machine_message::BuildScript {
+            machine_message::emit(&machine_message::BuildScript {
                 package_id: &id,
                 linked_libs: &parsed_output.library_links,
                 linked_paths: &library_paths,

--- a/src/cargo/ops/cargo_rustc/mod.rs
+++ b/src/cargo/ops/cargo_rustc/mod.rs
@@ -380,7 +380,7 @@ fn rustc<'a, 'cfg>(cx: &mut Context<'a, 'cfg>,
                             internal(&format!("compiler produced invalid json: `{}`", line))
                         })?;
 
-                        machine_message::emit(machine_message::FromCompiler {
+                        machine_message::emit(&machine_message::FromCompiler {
                             package_id: &package_id,
                             target: &target,
                             message: compiler_message,
@@ -525,7 +525,7 @@ fn link_targets<'a, 'cfg>(cx: &mut Context<'a, 'cfg>,
         }
 
         if json_messages {
-            machine_message::emit(machine_message::Artifact {
+            machine_message::emit(&machine_message::Artifact {
                 package_id: &package_id,
                 target: &target,
                 profile: &profile,

--- a/src/cargo/util/dependency_queue.rs
+++ b/src/cargo/util/dependency_queue.rs
@@ -52,6 +52,12 @@ impl Freshness {
     }
 }
 
+impl<K: Hash + Eq + Clone, V> Default for DependencyQueue<K, V> {
+    fn default() -> DependencyQueue<K, V> {
+        DependencyQueue::new()
+    }
+}
+
 impl<K: Hash + Eq + Clone, V> DependencyQueue<K, V> {
     /// Creates a new dependency queue with 0 packages.
     pub fn new() -> DependencyQueue<K, V> {

--- a/src/cargo/util/errors.rs
+++ b/src/cargo/util/errors.rs
@@ -68,26 +68,26 @@ impl CargoError {
     }
 
     fn is_human(&self) -> bool {
-        match &self.0 {
-            &CargoErrorKind::Msg(_) => true,
-            &CargoErrorKind::TomlSer(_) => true,
-            &CargoErrorKind::TomlDe(_) => true,
-            &CargoErrorKind::Curl(_) => true,
-            &CargoErrorKind::HttpNot200(..) => true,
-            &CargoErrorKind::ProcessErrorKind(_) => true,
-            &CargoErrorKind::CrateRegistry(_) => true,
-            &CargoErrorKind::ParseSemver(_) |
-            &CargoErrorKind::Semver(_) |
-            &CargoErrorKind::Ignore(_) |
-            &CargoErrorKind::Io(_) |
-            &CargoErrorKind::SerdeJson(_) |
-            &CargoErrorKind::ParseInt(_) |
-            &CargoErrorKind::ParseBool(_) |
-            &CargoErrorKind::Parse(_) |
-            &CargoErrorKind::Git(_) |
-            &CargoErrorKind::Internal(_) |
-            &CargoErrorKind::CargoTestErrorKind(_) |
-            &CargoErrorKind::__Nonexhaustive { .. } => false
+        match self.0 {
+            CargoErrorKind::Msg(_) |
+            CargoErrorKind::TomlSer(_) |
+            CargoErrorKind::TomlDe(_) |
+            CargoErrorKind::Curl(_) |
+            CargoErrorKind::HttpNot200(..) |
+            CargoErrorKind::ProcessErrorKind(_) |
+            CargoErrorKind::CrateRegistry(_) => true,
+            CargoErrorKind::ParseSemver(_) |
+            CargoErrorKind::Semver(_) |
+            CargoErrorKind::Ignore(_) |
+            CargoErrorKind::Io(_) |
+            CargoErrorKind::SerdeJson(_) |
+            CargoErrorKind::ParseInt(_) |
+            CargoErrorKind::ParseBool(_) |
+            CargoErrorKind::Parse(_) |
+            CargoErrorKind::Git(_) |
+            CargoErrorKind::Internal(_) |
+            CargoErrorKind::CargoTestErrorKind(_) |
+            CargoErrorKind::__Nonexhaustive { .. } => false
         }
     }
 }
@@ -138,8 +138,8 @@ impl CargoTestError {
     }
 
     pub fn hint(&self) -> String {
-        match &self.test {
-            &Test::UnitTest(ref kind, ref name) => {
+        match self.test {
+            Test::UnitTest(ref kind, ref name) => {
                 match *kind {
                     TargetKind::Bench => format!("test failed, to rerun pass '--bench {}'", name),
                     TargetKind::Bin => format!("test failed, to rerun pass '--bin {}'", name),
@@ -150,7 +150,7 @@ impl CargoTestError {
                     _ => "test failed.".into()
                 }
             },
-            &Test::Doc => "test failed, to rerun pass '--doc'".into(),
+            Test::Doc => "test failed, to rerun pass '--doc'".into(),
             _ => "test failed.".into()
         }
     }

--- a/src/cargo/util/flock.rs
+++ b/src/cargo/util/flock.rs
@@ -140,7 +140,7 @@ impl Filesystem {
     /// Handles errors where other Cargo processes are also attempting to
     /// concurrently create this directory.
     pub fn create_dir(&self) -> io::Result<()> {
-        return create_dir_all(&self.root);
+        create_dir_all(&self.root)
     }
 
     /// Returns an adaptor that can be used to print the path of this
@@ -323,7 +323,7 @@ fn acquire(config: &Config,
 
 fn create_dir_all(path: &Path) -> io::Result<()> {
     match create_dir(path) {
-        Ok(()) => return Ok(()),
+        Ok(()) => Ok(()),
         Err(e) => {
             if e.kind() == io::ErrorKind::NotFound {
                 if let Some(p) = path.parent() {

--- a/src/cargo/util/graph.rs
+++ b/src/cargo/util/graph.rs
@@ -56,7 +56,7 @@ impl<N: Eq + Hash + Clone> Graph<N> {
 
         marks.insert(node.clone(), Mark::InProgress);
 
-        for child in self.nodes[node].iter() {
+        for child in &self.nodes[node] {
             self.visit(child, dst, marks);
         }
 
@@ -69,11 +69,17 @@ impl<N: Eq + Hash + Clone> Graph<N> {
     }
 }
 
+impl<N: Eq + Hash + Clone> Default for Graph<N> {
+    fn default() -> Graph<N> {
+        Graph::new()
+    }
+}
+
 impl<N: fmt::Display + Eq + Hash> fmt::Debug for Graph<N> {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         writeln!(fmt, "Graph {{")?;
 
-        for (n, e) in self.nodes.iter() {
+        for (n, e) in &self.nodes {
             writeln!(fmt, "  - {}", n)?;
 
             for n in e.iter() {

--- a/src/cargo/util/lazy_cell.rs
+++ b/src/cargo/util/lazy_cell.rs
@@ -65,10 +65,8 @@ impl<T> LazyCell<T> {
     pub fn get_or_try_init<Error, F>(&self, init: F) -> Result<&T, Error>
         where F: FnOnce() -> Result<T, Error>
     {
-        if self.borrow().is_none() {
-            if self.fill(init()?).is_err() {
-                unreachable!();
-            }
+        if self.borrow().is_none() && self.fill(init()?).is_err() {
+            unreachable!();
         }
         Ok(self.borrow().unwrap())
     }

--- a/src/cargo/util/machine_message.rs
+++ b/src/cargo/util/machine_message.rs
@@ -7,8 +7,8 @@ pub trait Message: ser::Serialize {
     fn reason(&self) -> &str;
 }
 
-pub fn emit<T: Message>(t: T) {
-    let mut json: Value = serde_json::to_value(&t).unwrap();
+pub fn emit<T: Message>(t: &T) {
+    let mut json: Value = serde_json::to_value(t).unwrap();
     json["reason"] = json!(t.reason());
     println!("{}", json);
 }

--- a/src/cargo/util/network.rs
+++ b/src/cargo/util/network.rs
@@ -2,11 +2,10 @@ use std;
 use std::error::Error;
 
 use error_chain::ChainedError;
-
 use util::Config;
 use util::errors::{CargoError, CargoErrorKind, CargoResult};
-
 use git2;
+
 fn maybe_spurious<E, EKind>(err: &E) -> bool
     where E: ChainedError<ErrorKind=EKind> + 'static {
     //Error inspection in non-verbose mode requires inspecting the
@@ -18,7 +17,7 @@ fn maybe_spurious<E, EKind>(err: &E) -> bool
     //the borrow's actual lifetime for purposes of downcasting and
     //inspecting the error chain
     unsafe fn extend_lifetime(r: &Error) -> &(Error + 'static) {
-        std::mem::transmute::<&Error, &Error>(r)    
+        std::mem::transmute::<&Error, &Error>(r)
     }
 
     for e in err.iter() {
@@ -32,7 +31,7 @@ fn maybe_spurious<E, EKind>(err: &E) -> bool
                         _ => ()
                     }
                 }
-                &CargoErrorKind::Curl(ref curl_err) 
+                &CargoErrorKind::Curl(ref curl_err)
                     if curl_err.is_couldnt_connect() ||
                         curl_err.is_couldnt_resolve_proxy() ||
                         curl_err.is_couldnt_resolve_host() ||
@@ -55,7 +54,7 @@ fn maybe_spurious<E, EKind>(err: &E) -> bool
 /// Retry counts provided by Config object `net.retry`. Config shell outputs
 /// a warning on per retry.
 ///
-/// Closure must return a CargoResult.
+/// Closure must return a `CargoResult`.
 ///
 /// # Examples
 ///

--- a/src/cargo/util/process_builder.rs
+++ b/src/cargo/util/process_builder.rs
@@ -24,7 +24,7 @@ impl fmt::Display for ProcessBuilder {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "`{}", self.program.to_string_lossy())?;
 
-        for arg in self.args.iter() {
+        for arg in &self.args {
             write!(f, " {}", escape(arg.to_string_lossy()))?;
         }
 
@@ -231,10 +231,10 @@ impl ProcessBuilder {
         if let Some(cwd) = self.get_cwd() {
             command.current_dir(cwd);
         }
-        for arg in self.args.iter() {
+        for arg in &self.args {
             command.arg(arg);
         }
-        for (k, v) in self.env.iter() {
+        for (k, v) in &self.env {
             match *v {
                 Some(ref v) => { command.env(k, v); }
                 None => { command.env_remove(k); }
@@ -248,7 +248,7 @@ impl ProcessBuilder {
 
     fn debug_string(&self) -> String {
         let mut program = format!("{}", self.program.to_string_lossy());
-        for arg in self.args.iter() {
+        for arg in &self.args {
             program.push(' ');
             program.push_str(&format!("{}", arg.to_string_lossy()));
         }

--- a/src/cargo/util/profile.rs
+++ b/src/cargo/util/profile.rs
@@ -37,7 +37,7 @@ impl Drop for Profiler {
 
         let start = PROFILE_STACK.with(|stack| stack.borrow_mut().pop().unwrap());
         let duration = start.elapsed();
-        let duration_ms = duration.as_secs() * 1000 + (duration.subsec_nanos() / 1000000) as u64;
+        let duration_ms = duration.as_secs() * 1000 + u64::from(duration.subsec_nanos() / 1_000_000);
 
         let stack_len = PROFILE_STACK.with(|stack| stack.borrow().len());
         if stack_len == 0 {

--- a/src/cargo/util/rustc.rs
+++ b/src/cargo/util/rustc.rs
@@ -29,7 +29,7 @@ impl Rustc {
         let host = {
             let triple = verbose_version.lines().find(|l| {
                 l.starts_with("host: ")
-            }).map(|l| &l[6..]).ok_or(internal("rustc -v didn't have a line for `host:`"))?;
+            }).map(|l| &l[6..]).ok_or_else(|| internal("rustc -v didn't have a line for `host:`"))?;
             triple.to_string()
         };
 


### PR DESCRIPTION
I've started to clean some minor defects in cargo. This is the first commit of possibly many.

Requesting advice if this is actually wanted; #cargo was positive.

Some things raise the minimum version of rust required to compile cargo. E.g. `assert_ne!(foo, bar)` instead of `assert!(foo != bar)` requires (iirc) rust 1.13. Any advice on that in particular?