### PR TITLE
Fix typo's in the cargo's output messages.

### DIFF
--- a/src/bin/search.rs
+++ b/src/bin/search.rs
@@ -28,7 +28,7 @@ Usage:
 Options:
     -h, --help               Print this message
     --index INDEX            Registry index to search in
-    --host HOST              DEPRICATED, renamed to '--index'
+    --host HOST              DEPRECATED, renamed to '--index'
     -v, --verbose ...        Use verbose output (-vv very verbose/build.rs output)
     -q, --quiet              No output printed to stdout
     --color WHEN             Coloring: auto, always, never

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -694,19 +694,19 @@ impl TomlManifest {
             bail!("virtual manifests do not define [package]");
         }
         if me.lib.is_some() {
-            bail!("virtual manifests do not specifiy [lib]");
+            bail!("virtual manifests do not specify [lib]");
         }
         if me.bin.is_some() {
-            bail!("virtual manifests do not specifiy [[bin]]");
+            bail!("virtual manifests do not specify [[bin]]");
         }
         if me.example.is_some() {
-            bail!("virtual manifests do not specifiy [[example]]");
+            bail!("virtual manifests do not specify [[example]]");
         }
         if me.test.is_some() {
-            bail!("virtual manifests do not specifiy [[test]]");
+            bail!("virtual manifests do not specify [[test]]");
         }
         if me.bench.is_some() {
-            bail!("virtual manifests do not specifiy [[bench]]");
+            bail!("virtual manifests do not specify [[bench]]");
         }
 
         let mut nested_paths = Vec::new();

--- a/src/etc/man/cargo-pkgid.1
+++ b/src/etc/man/cargo-pkgid.1
@@ -43,7 +43,7 @@ Coloring: auto, always, never.
 .RE
 .SH EXAMPLES
 .PP
-Retrive package specification for foo package
+Retrieve package specification for foo package
 .IP
 .nf
 \f[C]
@@ -59,7 +59,7 @@ $\ cargo\ pkgid\ foo:1.0.0
 \f[]
 .fi
 .PP
-Retrive package specification for foo from crates.io
+Retrieve package specification for foo from crates.io
 .IP
 .nf
 \f[C]


### PR DESCRIPTION
I'm forwarding  the patch we used in Debian to fix the typo's which were found in cargo's output messages.