### PR TITLE
Improve error ico doc-targets with same name

### DIFF
--- a/src/cargo/ops/cargo_doc.rs
+++ b/src/cargo/ops/cargo_doc.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::HashMap;
 use std::fs;
 use std::path::Path;
 use std::process::Command;
@@ -32,21 +32,38 @@ pub fn doc(ws: &Workspace, options: &DocOptions) -> CargoResult<()> {
         packages.get(pkgid)
     }).collect::<CargoResult<Vec<_>>>()?;
 
-    let mut lib_names = HashSet::new();
-    let mut bin_names = HashSet::new();
+    let mut lib_names = HashMap::new();
+    let mut bin_names = HashMap::new();
     for package in &pkgs {
         for target in package.targets().iter().filter(|t| t.documented()) {
             if target.is_lib() {
-                assert!(lib_names.insert(target.crate_name()));
+                if let Some(prev) = lib_names.insert(target.crate_name(), package) {
+                    bail!("The library `{}` is specified by packages `{}` and \
+                          `{}` but can only be documented once. Consider renaming \
+                          or marking one of the targets as `doc = false`.",
+                          target.crate_name(), prev, package);
+                }
             } else {
-                assert!(bin_names.insert(target.crate_name()));
+                if let Some(prev) = bin_names.insert(target.crate_name(), package) {
+                    bail!("The binary `{}` is specified by packages `{}` and \
+                          `{}` but can be documented only once. Consider renaming \
+                          or marking one of the targets as `doc = false`.",
+                          target.crate_name(), prev, package);
+                }
             }
         }
-        for bin in bin_names.iter() {
-            if lib_names.contains(bin) {
-                bail!("cannot document a package where a library and a binary \
-                       have the same name. Consider renaming one or marking \
-                       the target as `doc = false`")
+        for (bin, bin_package) in bin_names.iter() {
+            if let Some(lib_package) = lib_names.get(bin) {
+                bail!("The target `{}` is specified as a library {}. It can be \
+                       documented only once. Consider renaming or marking one \
+                       of the targets as `doc = false`.",
+                       bin,
+                       if lib_package == bin_package {
+                           format!("and as a binary by package `{}`", lib_package)
+                       } else {
+                           format!("by package `{}` and as a binary by \
+                                    package `{}`", lib_package, bin_package)
+                       });
             }
         }
     }
@@ -59,7 +76,7 @@ pub fn doc(ws: &Workspace, options: &DocOptions) -> CargoResult<()> {
         } else if pkgs.len() == 1 {
             pkgs[0].name().replace("-", "_")
         } else {
-            match lib_names.iter().chain(bin_names.iter()).nth(0) {
+            match lib_names.keys().chain(bin_names.keys()).nth(0) {
                 Some(s) => s.to_string(),
                 None => return Ok(()),
             }

--- a/tests/rustdoc.rs
+++ b/tests/rustdoc.rs
@@ -160,7 +160,6 @@ fn rustdoc_same_name_err() {
                  .arg("--").arg("--cfg=foo"),
                 execs()
                 .with_status(101)
-                .with_stderr("[ERROR] cannot document a package where a library and a \
-                              binary have the same name. Consider renaming one \
-                              or marking the target as `doc = false`"));
+                .with_stderr("[ERROR] The target `foo` is specified as a \
+library and as a binary by package `foo [..]`. It can be documented[..]"));
 }


### PR DESCRIPTION
Replace the `assert!` that was triggered in #4539 with a `bail!`, giving the user a clear error that points to the offending packages. The error message now looks like

> The binary `foo_cli` is specified by packages `foo (file://...)` and `bar (file://...)` but can be documented only once. Consider renaming or marking one of the targets as `doc = false`. 

or

> The library `foo_cli` is specified by packages `foo (file://...)` and `bar (file://...)` ...

or

> The target `foo_cli` is specified as a library and as a binary by package `foo (file://...)`. It can be documented only once. Consider...

or

> The target `foo_cli` is specified as a library by package `foo (file://...)` and as a binary by package `bar (file://...)`. It can be ...

Add unit-test for all cases, including one that ensures the advertised mitigation `doc = false` actually works.