### PR TITLE
Add `-e` to `run`, setting environment variables

### DIFF
--- a/src/bin/run.rs
+++ b/src/bin/run.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::iter::FromIterator;
 
 use cargo::core::Workspace;
@@ -23,6 +24,7 @@ pub struct Options {
     flag_release: bool,
     flag_frozen: bool,
     flag_locked: bool,
+    flag_env: Vec<String>,
     arg_args: Vec<String>,
     #[serde(rename = "flag_Z")]
     flag_z: Vec<String>,
@@ -46,6 +48,7 @@ Options:
     --no-default-features        Do not build the `default` feature
     --target TRIPLE              Build for the target triple
     --manifest-path PATH         Path to the manifest to execute
+    -e ENVVAR, --env ENVVAR ...  Set environment variable
     -v, --verbose ...            Use verbose output (-vv very verbose/build.rs output)
     -q, --quiet                  No output printed to stdout
     --color WHEN                 Coloring: auto, always, never
@@ -58,6 +61,11 @@ If neither `--bin` nor `--example` are given, then if the project only has one
 bin target it will be run. Otherwise `--bin` specifies the bin target to run,
 and `--example` specifies the example target to run. At most one of `--bin` or
 `--example` can be provided.
+
+Environment variables can be set using one or more `-e` options. The argument
+to `-e` takes the form `KEY=VALUE`, causing the environment variable `KEY`
+to be set to `VALUE` for the target process. Environment variables set this
+way are not visible during compilation.
 
 All of the trailing arguments are passed to the binary to run. If you're passing
 arguments to both Cargo and the binary, the ones after `--` go to the binary,
@@ -85,6 +93,25 @@ pub fn execute(options: Options, config: &Config) -> CliResult {
     let packages = Vec::from_iter(options.flag_package.iter().cloned());
     let spec = Packages::Packages(&packages);
 
+    let mut envmap = HashMap::new();
+    for env_arg in options.flag_env {
+        let mut env_arg = env_arg.splitn(2, '=');
+        let key = match env_arg.next() {
+            Some(k) => k,
+            None => return Err(CliError::new("Environment variables take the \
+                                             form KEY=VALUE".into(), 101))
+        };
+        let value = match env_arg.next() {
+            Some(k) => k,
+            None => return Err(CliError::new("Environment variables take the \
+                                             form KEY=VALUE".into(), 101))
+        };
+        if envmap.insert(key.to_owned(), value.to_owned()).is_some() {
+            config.shell().warn(format!("Environment variable `{}` is set \
+                                         multiple times.", key))?;
+        }
+    }
+
     let compile_opts = ops::CompileOptions {
         config: config,
         jobs: options.flag_jobs,
@@ -111,7 +138,7 @@ pub fn execute(options: Options, config: &Config) -> CliResult {
     };
 
     let ws = Workspace::new(&root, config)?;
-    match ops::run(&ws, &compile_opts, &options.arg_args)? {
+    match ops::run(&ws, &compile_opts, &options.arg_args, &envmap)? {
         None => Ok(()),
         Some(err) => {
             // If we never actually spawned the process then that sounds pretty

--- a/src/cargo/ops/cargo_run.rs
+++ b/src/cargo/ops/cargo_run.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::path::Path;
 
 use ops::{self, Packages};
@@ -7,7 +8,8 @@ use core::Workspace;
 
 pub fn run(ws: &Workspace,
            options: &ops::CompileOptions,
-           args: &[String]) -> CargoResult<Option<ProcessError>> {
+           args: &[String],
+           env: &HashMap<String, String>) -> CargoResult<Option<ProcessError>> {
     let config = ws.config();
 
     let pkg = match options.spec {
@@ -59,8 +61,12 @@ pub fn run(ws: &Workspace,
         Some(path) => path.to_path_buf(),
         None => exe.to_path_buf(),
     };
+
     let mut process = compile.target_process(exe, pkg)?;
     process.args(args).cwd(config.cwd());
+    for (key, value) in env.iter() {
+        process.env(key, value);
+    }
 
     config.shell().status("Running", process.to_string())?;
 

--- a/src/cargo/ops/cargo_run.rs
+++ b/src/cargo/ops/cargo_run.rs
@@ -65,7 +65,11 @@ pub fn run(ws: &Workspace,
     let mut process = compile.target_process(exe, pkg)?;
     process.args(args).cwd(config.cwd());
     for (key, value) in env.iter() {
-        process.env(key, value);
+        if value == "" {
+            process.env_remove(key);
+        } else {
+            process.env(key, value);
+        }
     }
 
     config.shell().status("Running", process.to_string())?;


### PR DESCRIPTION
Implement #4505 

A new option `-e` or `--env` is provided to `cargo run`. The process ultimately started has the given environment variables added to it. These environment variables are not visible to Cargo or rustc (think `LD_PRELOAD`). They are also not visible to `build.rs`, for which people may have a use-case. Personally, I'd rather wait until this comes up.

There may be a use-case for `cargo test`. Any thoughts?