### PR TITLE
Allow multiple arguments in `cargo bench`

### DIFF
--- a/src/bin/bench.rs
+++ b/src/bin/bench.rs
@@ -48,13 +48,13 @@ Usage:
 Options:
     -h, --help                   Print this message
     --lib                        Benchmark only this package's library
-    --bin NAME                   Benchmark only the specified binary
+    --bin NAME ...               Benchmark only the specified binary
     --bins                       Benchmark all binaries
-    --example NAME               Benchmark only the specified example
+    --example NAME ...           Benchmark only the specified example
     --examples                   Benchmark all examples
-    --test NAME                  Benchmark only the specified test target
+    --test NAME ...              Benchmark only the specified test target
     --tests                      Benchmark all tests
-    --bench NAME                 Benchmark only the specified bench target
+    --bench NAME ...             Benchmark only the specified bench target
     --benches                    Benchmark all benches
     --all-targets                Benchmark all targets (default)
     --no-run                     Compile, but don't run benchmarks

--- a/tests/bench.rs
+++ b/tests/bench.rs
@@ -151,6 +151,40 @@ fn bench_tarname() {
 }
 
 #[test]
+fn bench_multiple_targets() {
+    if !is_nightly() { return }
+
+    let prj = project("foo")
+        .file("Cargo.toml" , r#"
+            [package]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+        "#)
+        .file("benches/bin1.rs", r#"
+            #![feature(test)]
+            extern crate test;
+            #[bench] fn run1(_ben: &mut test::Bencher) { }"#)
+        .file("benches/bin2.rs", r#"
+            #![feature(test)]
+            extern crate test;
+            #[bench] fn run2(_ben: &mut test::Bencher) { }"#)
+        .file("benches/bin3.rs", r#"
+            #![feature(test)]
+            extern crate test;
+            #[bench] fn run3(_ben: &mut test::Bencher) { }"#);
+
+    assert_that(prj.cargo_process("bench")
+                .arg("--bench").arg("bin1")
+                .arg("--bench").arg("bin2"),
+                execs()
+                .with_status(0)
+                .with_stdout_contains("test run1 ... bench: [..]")
+                .with_stdout_contains("test run2 ... bench: [..]")
+                .with_stdout_does_not_contain("run3"));
+}
+
+#[test]
 fn cargo_bench_verbose() {
     if !is_nightly() { return }
 


### PR DESCRIPTION
It seems the docopt DSL was simply lacking.