### PR TITLE
Remove root from cargo lock

### DIFF
--- a/src/cargo/core/resolver/encode.rs
+++ b/src/cargo/core/resolver/encode.rs
@@ -14,8 +14,6 @@ use super::Resolve;
 #[derive(Serialize, Deserialize, Debug)]
 pub struct EncodableResolve {
     package: Option<Vec<EncodableDependency>>,
-    /// `root` is optional to allow forward compatibility.
-    root: Option<EncodableDependency>,
     metadata: Option<Metadata>,
 
     #[serde(default, skip_serializing_if = "Patch::is_empty")]
@@ -33,13 +31,7 @@ impl EncodableResolve {
     pub fn into_resolve(self, ws: &Workspace) -> CargoResult<Resolve> {
         let path_deps = build_path_deps(ws);
 
-        let packages = {
-            let mut packages = self.package.unwrap_or_default();
-            if let Some(root) = self.root {
-                packages.insert(0, root);
-            }
-            packages
-        };
+        let packages = self.package.unwrap_or_default();
 
         // `PackageId`s in the lock file don't include the `source` part
         // for workspace members, so we reconstruct proper ids.
@@ -311,7 +303,6 @@ impl<'de> de::Deserialize<'de> for EncodablePackageId {
 pub struct WorkspaceResolve<'a, 'cfg: 'a> {
     pub ws: &'a Workspace<'cfg>,
     pub resolve: &'a Resolve,
-    pub use_root_key: bool,
 }
 
 impl<'a, 'cfg> ser::Serialize for WorkspaceResolve<'a, 'cfg> {
@@ -321,15 +312,7 @@ impl<'a, 'cfg> ser::Serialize for WorkspaceResolve<'a, 'cfg> {
         let mut ids: Vec<&PackageId> = self.resolve.graph.iter().collect();
         ids.sort();
 
-        let root = self.ws.members().max_by_key(|member| {
-            member.name()
-        }).map(Package::package_id);
-
         let encodable = ids.iter().filter_map(|&id| {
-            if self.use_root_key && root.unwrap() == id {
-                return None
-            }
-
             Some(encodable_resolve_node(id, self.resolve))
         }).collect::<Vec<_>>();
 
@@ -347,11 +330,6 @@ impl<'a, 'cfg> ser::Serialize for WorkspaceResolve<'a, 'cfg> {
 
         let metadata = if metadata.is_empty() { None } else { Some(metadata) };
 
-        let root = match root {
-            Some(root) if self.use_root_key => Some(encodable_resolve_node(root, self.resolve)),
-            _ => None,
-        };
-
         let patch = Patch {
             unused: self.resolve.unused_patches().iter().map(|id| {
                 EncodableDependency {
@@ -365,7 +343,6 @@ impl<'a, 'cfg> ser::Serialize for WorkspaceResolve<'a, 'cfg> {
         };
         EncodableResolve {
             package: Some(encodable),
-            root: root,
             metadata: metadata,
             patch: patch,
         }.serialize(s)

--- a/src/cargo/ops/lockfile.rs
+++ b/src/cargo/ops/lockfile.rs
@@ -43,7 +43,6 @@ pub fn write_pkg_lockfile(ws: &Workspace, resolve: &Resolve) -> CargoResult<()> 
     let toml = toml::Value::try_from(WorkspaceResolve {
         ws: ws,
         resolve: resolve,
-        use_root_key: false,
     }).unwrap();
 
     let mut out = String::new();

--- a/src/cargo/ops/lockfile.rs
+++ b/src/cargo/ops/lockfile.rs
@@ -43,6 +43,7 @@ pub fn write_pkg_lockfile(ws: &Workspace, resolve: &Resolve) -> CargoResult<()> 
     let toml = toml::Value::try_from(WorkspaceResolve {
         ws: ws,
         resolve: resolve,
+        use_root_key: false,
     }).unwrap();
 
     let mut out = String::new();

--- a/src/cargo/ops/lockfile.rs
+++ b/src/cargo/ops/lockfile.rs
@@ -40,29 +40,13 @@ pub fn write_pkg_lockfile(ws: &Workspace, resolve: &Resolve) -> CargoResult<()> 
         Ok(s)
     });
 
-    // Forward compatibility: if `orig` uses rootless format
-    // from the future, do the same.
-    let use_root_key = if let Ok(ref orig) = orig {
-        !orig.starts_with("[[package]]")
-    } else {
-        true
-    };
-
     let toml = toml::Value::try_from(WorkspaceResolve {
         ws: ws,
         resolve: resolve,
-        use_root_key: use_root_key,
+        use_root_key: false,
     }).unwrap();
 
     let mut out = String::new();
-
-    // Note that we do not use e.toml.to_string() as we want to control the
-    // exact format the toml is in to ensure pretty diffs between updates to the
-    // lockfile.
-    if let Some(root) = toml.get("root") {
-        out.push_str("[root]\n");
-        emit_package(root.as_table().unwrap(), &mut out);
-    }
 
     let deps = toml["package"].as_array().unwrap();
     for dep in deps.iter() {

--- a/src/doc/book/src/guide/cargo-toml-vs-cargo-lock.md
+++ b/src/doc/book/src/guide/cargo-toml-vs-cargo-lock.md
@@ -71,7 +71,7 @@ Cargo will take the latest commit and write that information out into our
 `Cargo.lock` when we build for the first time. That file will look like this:
 
 ```toml
-[root]
+[[package]]
 name = "hello_world"
 version = "0.1.0"
 dependencies = [

--- a/src/doc/guide.md
+++ b/src/doc/guide.md
@@ -328,7 +328,7 @@ Cargo will take the latest commit and write that information out into our
 `Cargo.lock` when we build for the first time. That file will look like this:
 
 ```toml
-[root]
+[[package]]
 name = "hello_world"
 version = "0.1.0"
 dependencies = [

--- a/tests/bad-config.rs
+++ b/tests/bad-config.rs
@@ -256,7 +256,7 @@ fn duplicate_packages_in_cargo_lock() {
         "#)
         .file("src/lib.rs", "")
         .file("Cargo.lock", r#"
-            [root]
+            [[package]]
             name = "bar"
             version = "0.0.1"
             dependencies = [
@@ -300,7 +300,7 @@ fn bad_source_in_cargo_lock() {
         "#)
         .file("src/lib.rs", "")
         .file("Cargo.lock", r#"
-            [root]
+            [[package]]
             name = "bar"
             version = "0.0.1"
             dependencies = [
@@ -334,7 +334,7 @@ fn bad_dependency_in_lockfile() {
         "#)
         .file("src/lib.rs", "")
         .file("Cargo.lock", r#"
-            [root]
+            [[package]]
             name = "foo"
             version = "0.0.1"
             dependencies = [

--- a/tests/generate-lockfile.rs
+++ b/tests/generate-lockfile.rs
@@ -145,7 +145,7 @@ fn preserve_line_endings_issue_2076() {
 
     let lock0 = p.read_lockfile();
 
-    assert!(lock0.starts_with("[root]\n"));
+    assert!(lock0.starts_with("[[package]]\n"));
 
     let lock1 = lock0.replace("\n", "\r\n");
     {
@@ -157,7 +157,7 @@ fn preserve_line_endings_issue_2076() {
 
     let lock2 = p.read_lockfile();
 
-    assert!(lock2.starts_with("[root]\r\n"));
+    assert!(lock2.starts_with("[[package]]\r\n"));
     assert_eq!(lock1, lock2);
 }
 

--- a/tests/git.rs
+++ b/tests/git.rs
@@ -971,7 +971,7 @@ fn stale_cached_version() {
     let rev = repo.revparse_single("HEAD").unwrap().id();
 
     File::create(&foo.root().join("Cargo.lock")).unwrap().write_all(format!(r#"
-        [root]
+        [[package]]
         name = "foo"
         version = "0.0.0"
         dependencies = [

--- a/tests/install.rs
+++ b/tests/install.rs
@@ -829,7 +829,7 @@ fn git_with_lockfile() {
         "#)
         .file("bar/src/lib.rs", "fn main() {}")
         .file("Cargo.lock", r#"
-            [root]
+            [[package]]
             name = "foo"
             version = "0.1.0"
             dependencies = [ "bar 0.1.0" ]

--- a/tests/overrides.rs
+++ b/tests/overrides.rs
@@ -802,7 +802,7 @@ fn override_an_override() {
             "serde:0.8.0" = { path = "serde" }
         "#)
         .file("Cargo.lock", r#"
-            [root]
+            [[package]]
             name = "local"
             version = "0.0.1"
             dependencies = [

--- a/tests/workspaces.rs
+++ b/tests/workspaces.rs
@@ -961,7 +961,7 @@ fn lockfile_can_specify_nonexistant_members() {
         "#)
         .file("a/src/main.rs", "fn main() {}")
         .file("Cargo.lock", r#"
-            [root]
+            [[package]]
             name = "a"
             version = "0.1.0"
 


### PR DESCRIPTION
Removing [root] section from Cargo.lock for #4563 

Tests of interest has been updated accordingly, especially [tests/lockfile-compat.rs#oldest_lockfile_still_works](https://github.com/rust-lang/cargo/compare/master...raytung:remove-root-from-cargo-lock?expand=1#diff-48866d1891f97cb799dd0ca7148d1eefR10)