### PR TITLE
Remove some cells from Config

### DIFF
--- a/src/bin/bench.rs
+++ b/src/bin/bench.rs
@@ -95,7 +95,7 @@ not affect how many jobs are used when running the benchmarks.
 Compilation can be customized with the `bench` profile in the manifest.
 ";
 
-pub fn execute(options: Options, config: &Config) -> CliResult {
+pub fn execute(options: Options, config: &mut Config) -> CliResult {
     debug!("executing; cmd=cargo-bench; args={:?}",
            env::args().collect::<Vec<_>>());
 

--- a/src/bin/build.rs
+++ b/src/bin/build.rs
@@ -87,7 +87,7 @@ the manifest. The default profile for this command is `dev`, but passing
 the --release flag will use the `release` profile instead.
 ";
 
-pub fn execute(options: Options, config: &Config) -> CliResult {
+pub fn execute(options: Options, config: &mut Config) -> CliResult {
     debug!("executing; cmd=cargo-build; args={:?}",
            env::args().collect::<Vec<_>>());
     config.configure(options.flag_verbose,

--- a/src/bin/cargo.rs
+++ b/src/bin/cargo.rs
@@ -75,7 +75,7 @@ See 'cargo help <command>' for more information on a specific command.
 fn main() {
     env_logger::init().unwrap();
 
-    let config = match Config::default() {
+    let mut config = match Config::default() {
         Ok(cfg) => cfg,
         Err(e) => {
             let mut shell = Shell::new();
@@ -92,7 +92,7 @@ fn main() {
             })
             .collect());
         let rest = &args;
-        cargo::call_main_without_stdin(execute, &config, USAGE, rest, true)
+        cargo::call_main_without_stdin(execute, &mut config, USAGE, rest, true)
     })();
 
     match result {
@@ -146,7 +146,7 @@ each_subcommand!(declare_mod);
   because they are fundamental (and intertwined). Other commands can rely
   on this top-level information.
 */
-fn execute(flags: Flags, config: &Config) -> CliResult {
+fn execute(flags: Flags, config: &mut Config) -> CliResult {
     config.configure(flags.flag_verbose,
                    flags.flag_quiet,
                    &flags.flag_color,
@@ -250,11 +250,12 @@ fn execute(flags: Flags, config: &Config) -> CliResult {
     execute_external_subcommand(config, &args[1], &args)
 }
 
-fn try_execute_builtin_command(config: &Config, args: &[String]) -> Option<CliResult> {
+fn try_execute_builtin_command(config: &mut Config, args: &[String]) -> Option<CliResult> {
     macro_rules! cmd {
         ($name:ident) => (if args[1] == stringify!($name).replace("_", "-") {
             config.shell().set_verbosity(Verbosity::Verbose);
-            let r = cargo::call_main_without_stdin($name::execute, config,
+            let r = cargo::call_main_without_stdin($name::execute,
+                                                   config,
                                                    $name::USAGE,
                                                    &args,
                                                    false);

--- a/src/bin/check.rs
+++ b/src/bin/check.rs
@@ -87,7 +87,7 @@ pub struct Options {
     flag_z: Vec<String>,
 }
 
-pub fn execute(options: Options, config: &Config) -> CliResult {
+pub fn execute(options: Options, config: &mut Config) -> CliResult {
     debug!("executing; cmd=cargo-check; args={:?}",
            env::args().collect::<Vec<_>>());
 

--- a/src/bin/clean.rs
+++ b/src/bin/clean.rs
@@ -45,7 +45,7 @@ given, then all packages' artifacts are removed. For more information on SPEC
 and its format, see the `cargo help pkgid` command.
 ";
 
-pub fn execute(options: Options, config: &Config) -> CliResult {
+pub fn execute(options: Options, config: &mut Config) -> CliResult {
     debug!("executing; cmd=cargo-clean; args={:?}", env::args().collect::<Vec<_>>());
     config.configure(options.flag_verbose,
                      options.flag_quiet,

--- a/src/bin/doc.rs
+++ b/src/bin/doc.rs
@@ -74,7 +74,7 @@ current package is documented. For more information on SPEC and its format, see
 the `cargo help pkgid` command.
 ";
 
-pub fn execute(options: Options, config: &Config) -> CliResult {
+pub fn execute(options: Options, config: &mut Config) -> CliResult {
     debug!("executing; cmd=cargo-check; args={:?}",
            env::args().collect::<Vec<_>>());
 

--- a/src/bin/fetch.rs
+++ b/src/bin/fetch.rs
@@ -41,7 +41,7 @@ If the lockfile is not available, then this is the equivalent of
 all updated.
 ";
 
-pub fn execute(options: Options, config: &Config) -> CliResult {
+pub fn execute(options: Options, config: &mut Config) -> CliResult {
     config.configure(options.flag_verbose,
                      options.flag_quiet,
                      &options.flag_color,

--- a/src/bin/generate_lockfile.rs
+++ b/src/bin/generate_lockfile.rs
@@ -34,7 +34,7 @@ Options:
     -Z FLAG ...              Unstable (nightly-only) flags to Cargo
 ";
 
-pub fn execute(options: Options, config: &Config) -> CliResult {
+pub fn execute(options: Options, config: &mut Config) -> CliResult {
     debug!("executing; cmd=cargo-generate-lockfile; args={:?}", env::args().collect::<Vec<_>>());
     config.configure(options.flag_verbose,
                      options.flag_quiet,

--- a/src/bin/git_checkout.rs
+++ b/src/bin/git_checkout.rs
@@ -32,7 +32,7 @@ Options:
     -Z FLAG ...              Unstable (nightly-only) flags to Cargo
 ";
 
-pub fn execute(options: Options, config: &Config) -> CliResult {
+pub fn execute(options: Options, config: &mut Config) -> CliResult {
     config.configure(options.flag_verbose,
                      options.flag_quiet,
                      &options.flag_color,

--- a/src/bin/help.rs
+++ b/src/bin/help.rs
@@ -14,7 +14,7 @@ Options:
     -h, --help          Print this message
 ";
 
-pub fn execute(_: Options, _: &Config) -> CliResult {
+pub fn execute(_: Options, _: &mut Config) -> CliResult {
     // This is a dummy command just so that `cargo help help` works.
     // The actual delegation of help flag to subcommands is handled by the
     // cargo command.

--- a/src/bin/init.rs
+++ b/src/bin/init.rs
@@ -43,7 +43,7 @@ Options:
     -Z FLAG ...         Unstable (nightly-only) flags to Cargo
 ";
 
-pub fn execute(options: Options, config: &Config) -> CliResult {
+pub fn execute(options: Options, config: &mut Config) -> CliResult {
     debug!("executing; cmd=cargo-init; args={:?}", env::args().collect::<Vec<_>>());
     config.configure(options.flag_verbose,
                      options.flag_quiet,

--- a/src/bin/install.rs
+++ b/src/bin/install.rs
@@ -101,7 +101,7 @@ the more explicit `install --path .`.
 The `--list` option will list all installed packages (and their versions).
 ";
 
-pub fn execute(options: Options, config: &Config) -> CliResult {
+pub fn execute(options: Options, config: &mut Config) -> CliResult {
     config.configure(options.flag_verbose,
                      options.flag_quiet,
                      &options.flag_color,

--- a/src/bin/locate_project.rs
+++ b/src/bin/locate_project.rs
@@ -23,8 +23,7 @@ pub struct ProjectLocation {
     root: String
 }
 
-pub fn execute(flags: LocateProjectFlags,
-               config: &Config) -> CliResult {
+pub fn execute(flags: LocateProjectFlags, config: &mut Config) -> CliResult {
     let root = find_root_manifest_for_wd(flags.flag_manifest_path, config.cwd())?;
 
     let string = root.to_str()

--- a/src/bin/login.rs
+++ b/src/bin/login.rs
@@ -37,7 +37,7 @@ Options:
 
 ";
 
-pub fn execute(options: Options, config: &Config) -> CliResult {
+pub fn execute(options: Options, config: &mut Config) -> CliResult {
     config.configure(options.flag_verbose,
                      options.flag_quiet,
                      &options.flag_color,

--- a/src/bin/metadata.rs
+++ b/src/bin/metadata.rs
@@ -46,7 +46,7 @@ Options:
     -Z FLAG ...                Unstable (nightly-only) flags to Cargo
 ";
 
-pub fn execute(options: Options, config: &Config) -> CliResult {
+pub fn execute(options: Options, config: &mut Config) -> CliResult {
     config.configure(options.flag_verbose,
                      options.flag_quiet,
                      &options.flag_color,

--- a/src/bin/new.rs
+++ b/src/bin/new.rs
@@ -43,7 +43,7 @@ Options:
     -Z FLAG ...         Unstable (nightly-only) flags to Cargo
 ";
 
-pub fn execute(options: Options, config: &Config) -> CliResult {
+pub fn execute(options: Options, config: &mut Config) -> CliResult {
     debug!("executing; cmd=cargo-new; args={:?}", env::args().collect::<Vec<_>>());
     config.configure(options.flag_verbose,
                      options.flag_quiet,

--- a/src/bin/owner.rs
+++ b/src/bin/owner.rs
@@ -47,7 +47,7 @@ See http://doc.crates.io/crates-io.html#cargo-owner for detailed documentation
 and troubleshooting.
 ";
 
-pub fn execute(options: Options, config: &Config) -> CliResult {
+pub fn execute(options: Options, config: &mut Config) -> CliResult {
     config.configure(options.flag_verbose,
                      options.flag_quiet,
                      &options.flag_color,

--- a/src/bin/package.rs
+++ b/src/bin/package.rs
@@ -44,7 +44,7 @@ Options:
     -Z FLAG ...             Unstable (nightly-only) flags to Cargo
 ";
 
-pub fn execute(options: Options, config: &Config) -> CliResult {
+pub fn execute(options: Options, config: &mut Config) -> CliResult {
     config.configure(options.flag_verbose,
                      options.flag_quiet,
                      &options.flag_color,

--- a/src/bin/pkgid.rs
+++ b/src/bin/pkgid.rs
@@ -55,8 +55,7 @@ Example Package IDs
 
 ";
 
-pub fn execute(options: Options,
-               config: &Config) -> CliResult {
+pub fn execute(options: Options, config: &mut Config) -> CliResult {
     config.configure(options.flag_verbose,
                      options.flag_quiet,
                      &options.flag_color,

--- a/src/bin/publish.rs
+++ b/src/bin/publish.rs
@@ -49,7 +49,7 @@ Options:
 
 ";
 
-pub fn execute(options: Options, config: &Config) -> CliResult {
+pub fn execute(options: Options, config: &mut Config) -> CliResult {
     config.configure(options.flag_verbose,
                      options.flag_quiet,
                      &options.flag_color,

--- a/src/bin/read_manifest.rs
+++ b/src/bin/read_manifest.rs
@@ -26,7 +26,7 @@ Options:
     --color WHEN             Coloring: auto, always, never
 ";
 
-pub fn execute(options: Options, config: &Config) -> CliResult {
+pub fn execute(options: Options, config: &mut Config) -> CliResult {
     debug!("executing; cmd=cargo-read-manifest; args={:?}",
            env::args().collect::<Vec<_>>());
     config.shell().set_color_choice(options.flag_color.as_ref().map(|s| &s[..]))?;

--- a/src/bin/run.rs
+++ b/src/bin/run.rs
@@ -64,7 +64,7 @@ arguments to both Cargo and the binary, the ones after `--` go to the binary,
 the ones before go to Cargo.
 ";
 
-pub fn execute(options: Options, config: &Config) -> CliResult {
+pub fn execute(options: Options, config: &mut Config) -> CliResult {
     config.configure(options.flag_verbose,
                      options.flag_quiet,
                      &options.flag_color,

--- a/src/bin/rustc.rs
+++ b/src/bin/rustc.rs
@@ -86,7 +86,7 @@ processes spawned by Cargo, use the $RUSTFLAGS environment variable or the
 `build.rustflags` configuration option.
 ";
 
-pub fn execute(options: Options, config: &Config) -> CliResult {
+pub fn execute(options: Options, config: &mut Config) -> CliResult {
     debug!("executing; cmd=cargo-rustc; args={:?}",
            env::args().collect::<Vec<_>>());
     config.configure(options.flag_verbose,

--- a/src/bin/rustdoc.rs
+++ b/src/bin/rustdoc.rs
@@ -83,7 +83,7 @@ current package is documented. For more information on SPEC and its format, see
 the `cargo help pkgid` command.
 ";
 
-pub fn execute(options: Options, config: &Config) -> CliResult {
+pub fn execute(options: Options, config: &mut Config) -> CliResult {
     config.configure(options.flag_verbose,
                      options.flag_quiet,
                      &options.flag_color,

--- a/src/bin/search.rs
+++ b/src/bin/search.rs
@@ -38,7 +38,7 @@ Options:
     -Z FLAG ...              Unstable (nightly-only) flags to Cargo
 ";
 
-pub fn execute(options: Options, config: &Config) -> CliResult {
+pub fn execute(options: Options, config: &mut Config) -> CliResult {
     config.configure(options.flag_verbose,
                      options.flag_quiet,
                      &options.flag_color,

--- a/src/bin/test.rs
+++ b/src/bin/test.rs
@@ -116,7 +116,7 @@ To get the list of all options available for the test binaries use this:
   cargo test -- --help
 ";
 
-pub fn execute(options: Options, config: &Config) -> CliResult {
+pub fn execute(options: Options, config: &mut Config) -> CliResult {
     debug!("executing; cmd=cargo-test; args={:?}",
            env::args().collect::<Vec<_>>());
 

--- a/src/bin/uninstall.rs
+++ b/src/bin/uninstall.rs
@@ -40,7 +40,7 @@ uninstalled for a crate but the `--bin` and `--example` flags can be used to
 only uninstall particular binaries.
 ";
 
-pub fn execute(options: Options, config: &Config) -> CliResult {
+pub fn execute(options: Options, config: &mut Config) -> CliResult {
     config.configure(options.flag_verbose,
                      options.flag_quiet,
                      &options.flag_color,

--- a/src/bin/update.rs
+++ b/src/bin/update.rs
@@ -60,7 +60,7 @@ updated.
 For more information about package id specifications, see `cargo help pkgid`.
 ";
 
-pub fn execute(options: Options, config: &Config) -> CliResult {
+pub fn execute(options: Options, config: &mut Config) -> CliResult {
     debug!("executing; cmd=cargo-update; args={:?}", env::args().collect::<Vec<_>>());
     config.configure(options.flag_verbose,
                      options.flag_quiet,

--- a/src/bin/verify_project.rs
+++ b/src/bin/verify_project.rs
@@ -39,7 +39,7 @@ Options:
     -Z FLAG ...             Unstable (nightly-only) flags to Cargo
 ";
 
-pub fn execute(args: Flags, config: &Config) -> CliResult {
+pub fn execute(args: Flags, config: &mut Config) -> CliResult {
     config.configure(args.flag_verbose,
                      args.flag_quiet,
                      &args.flag_color,

--- a/src/bin/version.rs
+++ b/src/bin/version.rs
@@ -18,7 +18,7 @@ Options:
     --color WHEN             Coloring: auto, always, never
 ";
 
-pub fn execute(_: Options, _: &Config) -> CliResult {
+pub fn execute(_: Options, _: &mut Config) -> CliResult {
     debug!("executing; cmd=cargo-version; args={:?}", env::args().collect::<Vec<_>>());
 
     println!("{}", cargo::version());

--- a/src/bin/yank.rs
+++ b/src/bin/yank.rs
@@ -45,7 +45,7 @@ download the yanked version to use it. Cargo will, however, not allow any new
 crates to be locked to any yanked version.
 ";
 
-pub fn execute(options: Options, config: &Config) -> CliResult {
+pub fn execute(options: Options, config: &mut Config) -> CliResult {
     config.configure(options.flag_verbose,
                      options.flag_quiet,
                      &options.flag_color,

--- a/src/cargo/lib.rs
+++ b/src/cargo/lib.rs
@@ -109,8 +109,8 @@ impl fmt::Display for VersionInfo {
 }
 
 pub fn call_main_without_stdin<'de, Flags: Deserialize<'de>>(
-            exec: fn(Flags, &Config) -> CliResult,
-            config: &Config,
+            exec: fn(Flags, &mut Config) -> CliResult,
+            config: &mut Config,
             usage: &str,
             args: &[String],
             options_first: bool) -> CliResult

--- a/src/cargo/util/config.rs
+++ b/src/cargo/util/config.rs
@@ -50,9 +50,9 @@ pub struct Config {
     rustdoc: LazyCell<PathBuf>,
     /// Whether we are printing extra verbose messages
     extra_verbose: bool,
-    /// TODO to do with Cargo.lock
+    /// `frozen` is set if we shouldn't access the network
     frozen: bool,
-    /// TODO to do with Cargo.lock
+    /// `locked` is set if we should not update lock files
     locked: bool,
     /// A global static IPC control mechanism (used for managing parallel builds)
     jobserver: Option<jobserver::Client>,


### PR DESCRIPTION
In most cases it makes sense to not use interior mutability in Config, so that mutability is more transparent. This PR removes Cells in these cases. It leaves those cases where parameters are only initialized on first access (LazyCell).