### PR TITLE
Improving the error message for when a patched dependency does not resolve to anything

### DIFF
--- a/src/cargo/core/registry.rs
+++ b/src/cargo/core/registry.rs
@@ -194,8 +194,9 @@ impl<'cfg> PackageRegistry<'cfg> {
             let summary = match summaries.next() {
                 Some(summary) => summary,
                 None => {
-                    bail!("patch for `{}` in `{}` did not resolve to any crates. Your patched \
-                           dependency may conflict with the version in Cargo.lock.",
+                    bail!("patch for `{}` in `{}` did not resolve to any crates. If this is \
+                           unexpected, you may wish to consult: \
+                           https://github.com/rust-lang/cargo/issues/4678",
                           dep.name(), url)
                 }
             };

--- a/src/cargo/core/registry.rs
+++ b/src/cargo/core/registry.rs
@@ -194,7 +194,8 @@ impl<'cfg> PackageRegistry<'cfg> {
             let summary = match summaries.next() {
                 Some(summary) => summary,
                 None => {
-                    bail!("patch for `{}` in `{}` did not resolve to any crates",
+                    bail!("patch for `{}` in `{}` did not resolve to any crates. Your patched \
+                           dependency may conflict with the version in Cargo.lock.",
                           dep.name(), url)
                 }
             };


### PR DESCRIPTION
Hi,
I just spent a long time debugging what this error message means and so I thought I would try to help improve it. Could someone who knows the codebase well look at this and see if this error message even makes sense here. I know this is the information I would have needed, but the error may occur in other cases where this message doesn't make sense. I'm open to any suggestions that would help make it more clear and maybe point people to where they should look for more information.

The specific problem that I ran into occurred when I was trying to upgrade the `rustfmt` submodule in the rust codebase. The `rustfmt-nightly` dependency changed version numbers and this conflicted with what was in the `Cargo.lock` file. After some detective work I was able to find the [documentation on `[patch]`](http://doc.crates.io/manifest.html#the-patch-section) which I had never read before and the following relevant paragraphs from [some other documentation](http://doc.crates.io/specifying-dependencies.html#testing-a-bugfix):

> Next up we need to ensure that our lock file is updated to use this new version of uuid so our project uses the locally checked out copy instead of one from crates.io. The way [patch] works is that it'll load the dependency at ../path/to/uuid and then whenever crates.io is queried for versions of uuid it'll also return the local version.
> 
> This means that the version number of the local checkout is significant and will affect whether the patch is used. Our manifest declared uuid = "1.0" which means we'll only resolve to >= 1.0.0, < 2.0.0, and Cargo's greedy resolution algorithm also means that we'll resolve to the maximum version within that range. Typically this doesn't matter as the version of the git repository will already be greater or match the maximum version published on crates.io, but it's important to keep this in mind!

If it was not for the person who wrote those docs, I would not have known what to do here!