### PR TITLE
Add a `whoami` command to display the logged in user

### DIFF
--- a/src/bin/cargo.rs
+++ b/src/bin/cargo.rs
@@ -132,6 +132,7 @@ macro_rules! each_subcommand{
         $mac!(update);
         $mac!(verify_project);
         $mac!(version);
+        $mac!(whoami);
         $mac!(yank);
     }
 }

--- a/src/bin/whoami.rs
+++ b/src/bin/whoami.rs
@@ -1,0 +1,51 @@
+use cargo::ops;
+use cargo::util::{CliResult, Config};
+
+#[derive(Deserialize)]
+pub struct Options {
+    flag_index: Option<String>,
+    flag_verbose: u32,
+    flag_quiet: Option<bool>,
+    flag_color: Option<String>,
+    flag_frozen: bool,
+    flag_locked: bool,
+    #[serde(rename = "flag_Z")]
+    flag_z: Vec<String>,
+}
+
+pub const USAGE: &'static str = "
+Check if an api token exists locally and who it belongs to
+
+Usage:
+    cargo whoami [options] [<token>]
+
+Options:
+    -h, --help               Print this message
+    --index INDEX            Registry index to search in
+    -v, --verbose ...        Use verbose output (-vv very verbose/build.rs output)
+    -q, --quiet              No output printed to stdout
+    --color WHEN             Coloring: auto, always, never
+    --frozen                 Require Cargo.lock and cache are up to date
+    --locked                 Require Cargo.lock is up to date
+    -Z FLAG ...              Unstable (nightly-only) flags to Cargo
+
+";
+
+pub fn execute(options: Options, config: &mut Config) -> CliResult {
+    config.configure(
+        options.flag_verbose,
+        options.flag_quiet,
+        &options.flag_color,
+        options.flag_frozen,
+        options.flag_locked,
+        &options.flag_z,
+    )?;
+
+    let Options {
+        flag_index: index,
+        ..
+    } = options;
+
+    ops::registry_whoami(config, index)?;
+    Ok(())
+}

--- a/src/cargo/ops/mod.rs
+++ b/src/cargo/ops/mod.rs
@@ -17,7 +17,7 @@ pub use self::lockfile::{load_pkg_lockfile, write_pkg_lockfile};
 pub use self::cargo_test::{run_tests, run_benches, TestOptions};
 pub use self::cargo_package::{package, PackageOpts};
 pub use self::registry::{publish, registry_configuration, RegistryConfig};
-pub use self::registry::{registry_login, search, http_proxy_exists, http_handle};
+pub use self::registry::{registry_login, registry_whoami, search, http_proxy_exists, http_handle};
 pub use self::registry::{modify_owners, yank, OwnersOptions, PublishOpts};
 pub use self::cargo_fetch::fetch;
 pub use self::cargo_pkgid::pkgid;

--- a/src/cargo/ops/registry.rs
+++ b/src/cargo/ops/registry.rs
@@ -296,6 +296,18 @@ pub fn registry_login(config: &Config, token: String) -> CargoResult<()> {
     config::save_credentials(config, token)
 }
 
+pub fn registry_whoami(config: &Config, index: Option<String>) -> CargoResult<()> {
+    let RegistryConfig { token, .. } = registry_configuration(config)?;
+    let (mut registry, _) = registry(config, token.clone(), index)?;
+
+    match registry.whoami() {
+        Ok(user) => config.shell().status("Whoami", format!("Currently logged in as `{}`", user.login))?,
+        Err(e) => config.shell().status("Whoami", format!("{}", e))?,
+    };
+
+    Ok(())
+}
+
 pub struct OwnersOptions {
     pub krate: Option<String>,
     pub token: Option<String>,

--- a/src/crates-io/lib.rs
+++ b/src/crates-io/lib.rs
@@ -116,6 +116,7 @@ pub struct Warnings {
 }
 
 #[derive(Deserialize)] struct R { ok: bool }
+#[derive(Deserialize)] struct MeResponse { user: Option<User> }
 #[derive(Deserialize)] struct OwnerResponse { ok: bool, msg: String }
 #[derive(Deserialize)] struct ApiErrorList { errors: Vec<ApiError> }
 #[derive(Deserialize)] struct ApiError { detail: String }
@@ -254,6 +255,15 @@ impl Registry {
                                  &[])?;
         assert!(serde_json::from_str::<R>(&body)?.ok);
         Ok(())
+    }
+
+    pub fn whoami(&mut self) -> Result<User> {
+        let body = self.get(String::from("/me"))?;
+
+        match serde_json::from_str::<MeResponse>(&body)?.user {
+            Some(user) => Ok(user),
+            _ => Err(Error::from_kind(ErrorKind::TokenMissing))
+        }
     }
 
     fn put(&mut self, path: String, b: &[u8]) -> Result<String> {


### PR DESCRIPTION
This adds a new command to cargo called `whoami`, which will display the `login` name of the user that belongs to the saved credential.

I realize I did this without making an issue first to discuss it—sorry about that. I'm also aware that cargo has a built in plugin system, but a `whoami` command felt like it should be in cargo itself. If y'all feel differently, feel free to close this PR and I'll create a cargo plugin.

I also attempted to write some integration tests, but wasn't able to successfully. It seems like most commands are covered by tests but I might have been searching wrong. If tests are desired, let me know and I can take another stab at it.

Finally, if there is anything I should change, add, remove, etc, please let me know and I'll be happy to do that!