### PR TITLE
transmit: send README filename as well as content

### DIFF
--- a/src/cargo/ops/registry.rs
+++ b/src/cargo/ops/registry.rs
@@ -119,7 +119,7 @@ fn transmit(config: &Config,
         ref keywords, ref readme, ref repository, ref license, ref license_file,
         ref categories, ref badges,
     } = *manifest.metadata();
-    let readme = match *readme {
+    let readme_content = match *readme {
         Some(ref readme) => Some(paths::read(&pkg.root().join(readme))?),
         None => None,
     };
@@ -146,7 +146,8 @@ fn transmit(config: &Config,
         documentation: documentation.clone(),
         keywords: keywords.clone(),
         categories: categories.clone(),
-        readme: readme,
+        readme: readme_content,
+        readme_file: readme.clone(),
         repository: repository.clone(),
         license: license.clone(),
         license_file: license_file.clone(),

--- a/src/crates-io/lib.rs
+++ b/src/crates-io/lib.rs
@@ -82,6 +82,7 @@ pub struct NewCrate {
     pub documentation: Option<String>,
     pub homepage: Option<String>,
     pub readme: Option<String>,
+    pub readme_file: Option<String>,
     pub keywords: Vec<String>,
     pub categories: Vec<String>,
     pub license: Option<String>,


### PR DESCRIPTION
This is required to solve https://github.com/rust-lang/crates.io/issues/995; we currently only send the README content, but not the name of the README itself, so it's not possible to determine how we should render it.

I've confirmed the existing crates.io server silently ignores the new field, so this should be safe to roll out whenever.