### PR TITLE
Allow cargo install --version as well (preferred)

### DIFF
--- a/src/bin/install.rs
+++ b/src/bin/install.rs
@@ -1,6 +1,6 @@
 use cargo::ops;
 use cargo::core::{SourceId, GitReference};
-use cargo::util::{CliResult, Config, ToUrl};
+use cargo::util::{CargoError, CliResult, Config, ToUrl};
 
 #[derive(Deserialize)]
 pub struct Options {
@@ -153,7 +153,11 @@ pub fn execute(options: Options, config: &mut Config) -> CliResult {
     };
 
     let krates = options.arg_crate.iter().map(|s| &s[..]).collect::<Vec<_>>();
-    let vers = options.flag_version.as_ref().or(options.flag_vers.as_ref()).map(|s| &s[..]);
+    let vers = match (&options.flag_vers, &options.flag_version) {
+        (&Some(_), &Some(_)) => return Err(CargoError::from("Invalid arguments.").into()),
+        (&Some(ref v), _) | (_, &Some(ref v)) => Some(v.as_ref()),
+        _ => None,
+    };
     let root = options.flag_root.as_ref().map(|s| &s[..]);
 
     if options.flag_list {

--- a/src/bin/install.rs
+++ b/src/bin/install.rs
@@ -24,6 +24,7 @@ pub struct Options {
 
     arg_crate: Vec<String>,
     flag_vers: Option<String>,
+    flag_version: Option<String>,
 
     flag_git: Option<String>,
     flag_branch: Option<String>,
@@ -43,7 +44,8 @@ Usage:
     cargo install [options] --list
 
 Specifying what crate to install:
-    --vers VERS               Specify a version to install from crates.io
+    --vers VERSION            Specify a version to install from crates.io
+    --version VERSION
     --git URL                 Git URL to install the specified crate from
     --branch BRANCH           Branch to use when installing from git
     --tag TAG                 Tag to use when installing from git
@@ -151,7 +153,7 @@ pub fn execute(options: Options, config: &mut Config) -> CliResult {
     };
 
     let krates = options.arg_crate.iter().map(|s| &s[..]).collect::<Vec<_>>();
-    let vers = options.flag_vers.as_ref().map(|s| &s[..]);
+    let vers = options.flag_version.as_ref().or(options.flag_vers.as_ref()).map(|s| &s[..]);
     let root = options.flag_root.as_ref().map(|s| &s[..]);
 
     if options.flag_list {

--- a/tests/install.rs
+++ b/tests/install.rs
@@ -933,13 +933,13 @@ fn version_too() {
 }
 
 #[test]
-fn version_preferred() {
+fn not_both_vers_and_version() {
     pkg("foo", "0.1.1");
     pkg("foo", "0.1.2");
 
     assert_that(cargo_process("install").arg("foo").arg("--version").arg("0.1.1").arg("--vers").arg("0.1.2"),
-                execs().with_status(0).with_stderr_contains("\
-                    [DOWNLOADING] foo v0.1.1 (registry [..])
+                execs().with_status(101).with_stderr_contains("\
+error: Invalid arguments.
 "));
 }
 

--- a/tests/install.rs
+++ b/tests/install.rs
@@ -922,6 +922,28 @@ fn vers_precise() {
 }
 
 #[test]
+fn version_too() {
+    pkg("foo", "0.1.1");
+    pkg("foo", "0.1.2");
+
+    assert_that(cargo_process("install").arg("foo").arg("--version").arg("0.1.1"),
+                execs().with_status(0).with_stderr_contains("\
+                    [DOWNLOADING] foo v0.1.1 (registry [..])
+"));
+}
+
+#[test]
+fn version_preferred() {
+    pkg("foo", "0.1.1");
+    pkg("foo", "0.1.2");
+
+    assert_that(cargo_process("install").arg("foo").arg("--version").arg("0.1.1").arg("--vers").arg("0.1.2"),
+                execs().with_status(0).with_stderr_contains("\
+                    [DOWNLOADING] foo v0.1.1 (registry [..])
+"));
+}
+
+#[test]
 fn legacy_version_requirement() {
     pkg("foo", "0.1.1");
 


### PR DESCRIPTION
Fixes https://github.com/rust-lang/cargo/issues/4590.

The usage looks pretty ugly with this extra line in it, but it's not really avoidable with our docopt use.

We fail if both are provided; accepting both feels like a path to demons.