### PR TITLE
Add a number of progress indicators to Cargo

### DIFF
--- a/src/cargo/ops/resolve.rs
+++ b/src/cargo/ops/resolve.rs
@@ -257,15 +257,11 @@ pub fn resolve_with_previous<'a>(registry: &mut PackageRegistry,
         None => root_replace.to_vec(),
     };
 
-    let config = if warn {
-        Some(ws.config())
-    } else {
-        None
-    };
     let mut resolved = resolver::resolve(&summaries,
                                          &replace,
                                          registry,
-                                         config)?;
+                                         Some(ws.config()),
+                                         warn)?;
     resolved.register_used_patches(registry.patches());
     if let Some(previous) = previous {
         resolved.merge_from(previous)?;

--- a/src/cargo/util/config.rs
+++ b/src/cargo/util/config.rs
@@ -630,9 +630,11 @@ impl Config {
     }
 
     pub fn http(&self) -> CargoResult<&RefCell<Easy>> {
-        self.easy.get_or_try_init(|| {
+        let http = self.easy.get_or_try_init(|| {
             ops::http_handle(self).map(RefCell::new)
-        })
+        })?;
+        http.borrow_mut().reset();
+        Ok(http)
     }
 }
 

--- a/src/cargo/util/mod.rs
+++ b/src/cargo/util/mod.rs
@@ -18,6 +18,7 @@ pub use self::to_semver::ToSemver;
 pub use self::to_url::ToUrl;
 pub use self::vcs::{GitRepo, HgRepo, PijulRepo, FossilRepo};
 pub use self::read2::read2;
+pub use self::progress::Progress;
 
 pub mod config;
 pub mod errors;
@@ -42,3 +43,4 @@ mod vcs;
 mod lazy_cell;
 mod flock;
 mod read2;
+mod progress;

--- a/src/cargo/util/progress.rs
+++ b/src/cargo/util/progress.rs
@@ -1,0 +1,127 @@
+use std::cmp;
+use std::iter;
+use std::time::{Instant, Duration};
+
+use util::{Config, CargoResult};
+
+pub struct Progress<'cfg> {
+    state: Option<State<'cfg>>,
+}
+
+struct State<'cfg> {
+    config: &'cfg Config,
+    width: usize,
+    first: bool,
+    last_update: Instant,
+    name: String,
+    done: bool,
+}
+
+impl<'cfg> Progress<'cfg> {
+    pub fn new(name: &str, cfg: &'cfg Config) -> Progress<'cfg> {
+        Progress {
+            state: cfg.shell().err_width().map(|n| {
+                State {
+                    config: cfg,
+                    width: cmp::min(n, 80),
+                    first: true,
+                    last_update: Instant::now(),
+                    name: name.to_string(),
+                    done: false,
+                }
+            }),
+        }
+    }
+
+    pub fn tick(&mut self, cur: usize, max: usize) -> CargoResult<()> {
+        match self.state {
+            Some(ref mut s) => s.tick(cur, max),
+            None => Ok(())
+        }
+    }
+}
+
+impl<'cfg> State<'cfg> {
+    fn tick(&mut self, cur: usize, max: usize) -> CargoResult<()> {
+        if self.done {
+            return Ok(())
+        }
+
+        // Don't update too often as it can cause excessive performance loss
+        // just putting stuff onto the terminal. We also want to avoid
+        // flickering by not drawing anything that goes away too quickly. As a
+        // result we've got two branches here:
+        //
+        // 1. If we haven't drawn anything, we wait for a period of time to
+        //    actually start drawing to the console. This ensures that
+        //    short-lived operations don't flicker on the console. Currently
+        //    there's a 500ms delay to when we first draw something.
+        // 2. If we've drawn something, then we rate limit ourselves to only
+        //    draw to the console every so often. Currently there's a 100ms
+        //    delay between updates.
+        if self.first {
+            let delay = Duration::from_millis(500);
+            if self.last_update.elapsed() < delay {
+                return Ok(())
+            }
+            self.first = false;
+        } else {
+            let interval = Duration::from_millis(100);
+            if self.last_update.elapsed() < interval {
+                return Ok(())
+            }
+        }
+        self.last_update = Instant::now();
+
+        // Render the percentage at the far right and then figure how long the
+        // progress bar is
+        let pct = (cur as f64) / (max as f64);
+        let pct = if !pct.is_finite() { 0.0 } else { pct };
+        let stats = format!(" {:6.02}%", pct * 100.0);
+        let extra_len = stats.len() + 2 /* [ and ] */ + 15 /* status header */;
+        let display_width = match self.width.checked_sub(extra_len) {
+            Some(n) => n,
+            None => return Ok(()),
+        };
+        let mut string = String::from("[");
+        let hashes = display_width as f64 * pct;
+        let hashes = hashes as usize;
+
+        // Draw the `===>`
+        if hashes > 0 {
+            for _ in 0..hashes-1 {
+                string.push_str("=");
+            }
+            if cur == max {
+                self.done = true;
+                string.push_str("=");
+            } else {
+                string.push_str(">");
+            }
+        }
+
+        // Draw the empty space we have left to do
+        for _ in 0..(display_width - hashes) {
+            string.push_str(" ");
+        }
+        string.push_str("]");
+        string.push_str(&stats);
+
+        // Write out a pretty header, then the progress bar itself, and then
+        // return back to the beginning of the line for the next print.
+        self.config.shell().status_header(&self.name)?;
+        write!(self.config.shell().err(), "{}\r", string)?;
+        Ok(())
+    }
+}
+
+fn clear(width: usize, config: &Config) {
+    let blank = iter::repeat(" ").take(width).collect::<String>();
+    drop(write!(config.shell().err(), "{}\r", blank));
+}
+
+impl<'cfg> Drop for State<'cfg> {
+    fn drop(&mut self) {
+        clear(self.width, self.config);
+    }
+}

--- a/tests/resolve.rs
+++ b/tests/resolve.rs
@@ -34,7 +34,7 @@ fn resolve(pkg: &PackageId, deps: Vec<Dependency>, registry: &[Summary])
     let mut registry = MyRegistry(registry);
     let summary = Summary::new(pkg.clone(), deps, BTreeMap::new()).unwrap();
     let method = Method::Everything;
-    let resolve = resolver::resolve(&[(summary, method)], &[], &mut registry, None)?;
+    let resolve = resolver::resolve(&[(summary, method)], &[], &mut registry, None, false)?;
     let res = resolve.iter().cloned().collect();
     Ok(res)
 }


### PR DESCRIPTION
This commit is an attempt to stem the tide of "cargo is stuck updating the
registry" issues by giving a better indication as to what's happening in
long-running steps. The primary addition here is a `Progress` helper module
which prints and manages a progress bar for long-running operations like git
fetches, git checkouts, HTTP downloads, etc.

The second addition here is to print out when we've been stuck in resolve for
some time. We never really have a progress indicator for crate graph resolution
nor do we know when we're done updating sources. Instead we make a naive
assumption that when you've spent 0.5s in the resolution loop itself (not
updating deps) you're probably done updating dependencies and on to acutal
resolution. This will print out `Resolving crate graph...` and help inform that
Cargo is indeed not stuck looking at the registry, but rather it's churning away
in resolution.

**Downloading all Servo's dependencies**

[![asciicast](https://asciinema.org/a/JX9yQZtyFo5ED0Pwg45barBco.png)](https://asciinema.org/a/JX9yQZtyFo5ED0Pwg45barBco)

**Long running resolution**

[![asciicast](https://asciinema.org/a/p7xAkSVeMlkyvgcI6Gx7DZjAV.png)](https://asciinema.org/a/p7xAkSVeMlkyvgcI6Gx7DZjAV)