### PR TITLE
Add a newline before appended VCS ignore lines

### DIFF
--- a/src/cargo/ops/cargo_new.rs
+++ b/src/cargo/ops/cargo_new.rs
@@ -393,13 +393,13 @@ fn mk(config: &Config, opts: &MkOptions) -> CargoResult<()> {
     let name = opts.name;
     let cfg = global_config(config)?;
     // Please ensure that ignore and hgignore are in sync.
-    let ignore = ["/target/\n", "**/*.rs.bk\n",
+    let ignore = ["\n", "/target/\n", "**/*.rs.bk\n",
         if !opts.bin { "Cargo.lock\n" } else { "" }]
         .concat();
     // Mercurial glob ignores can't be rooted, so just sticking a 'syntax: glob' at the top of the
     // file will exclude too much. Instead, use regexp-based ignores. See 'hg help ignore' for
     // more.
-    let hgignore = ["^target/\n", "glob:*.rs.bk\n",
+    let hgignore = ["\n", "^target/\n", "glob:*.rs.bk\n",
         if !opts.bin { "glob:Cargo.lock\n" } else { "" }]
         .concat();
 

--- a/tests/init.rs
+++ b/tests/init.rs
@@ -336,6 +336,40 @@ fn gitignore_appended_not_replaced() {
 }
 
 #[test]
+fn gitignore_added_newline_if_required() {
+    fs::create_dir(&paths::root().join(".git")).unwrap();
+
+    File::create(&paths::root().join(".gitignore")).unwrap().write_all(b"first").unwrap();
+
+    assert_that(cargo_process("init").arg("--lib")
+                                     .env("USER", "foo"),
+                execs().with_status(0));
+
+    assert_that(&paths::root().join(".gitignore"), existing_file());
+
+    let mut contents = String::new();
+    File::open(&paths::root().join(".gitignore")).unwrap().read_to_string(&mut contents).unwrap();
+    assert!(contents.starts_with("first\n"));
+}
+
+#[test]
+fn mercurial_added_newline_if_required() {
+    fs::create_dir(&paths::root().join(".hg")).unwrap();
+
+    File::create(&paths::root().join(".hgignore")).unwrap().write_all(b"first").unwrap();
+
+    assert_that(cargo_process("init").arg("--lib")
+                                     .env("USER", "foo"),
+                execs().with_status(0));
+
+    assert_that(&paths::root().join(".hgignore"), existing_file());
+
+    let mut contents = String::new();
+    File::open(&paths::root().join(".hgignore")).unwrap().read_to_string(&mut contents).unwrap();
+    assert!(contents.starts_with("first\n"));
+}
+
+#[test]
 fn cargo_lock_gitignored_if_lib1() {
     fs::create_dir(&paths::root().join(".git")).unwrap();
 


### PR DESCRIPTION
The `cargo init` command appends to `.gitignore` or `.hgignore` without checking if the last line of the existing file ends with a newline.

This change will insert a newline before the appended lines. If the last line has no newline, this will ensure the lines are kept separated. If the newline is present, this will insert a blank line. Both Git and Mercurial ignore blank lines in these files.