### PR TITLE
Document that cargo test --release uses profile.bench

### DIFF
--- a/src/doc/book/src/reference/manifest.md
+++ b/src/doc/book/src/reference/manifest.md
@@ -310,7 +310,7 @@ debug-assertions = true
 codegen-units = 1
 panic = 'unwind'
 
-# The benchmarking profile, used for `cargo bench`.
+# The benchmarking profile, used for `cargo bench` and `cargo test --release`.
 [profile.bench]
 opt-level = 3
 debug = false

--- a/src/doc/manifest.md
+++ b/src/doc/manifest.md
@@ -309,7 +309,7 @@ debug-assertions = true
 codegen-units = 1
 panic = 'unwind'
 
-# The benchmarking profile, used for `cargo bench`.
+# The benchmarking profile, used for `cargo bench` and `cargo test --release`.
 [profile.bench]
 opt-level = 3
 debug = false


### PR DESCRIPTION
It certainly makes sense but it's still surprising behavior when the docs clearly state `cargo bench` = `profile.bench`, `cargo test` = `profile.test`. Had to dive into the code to figure this out.