### PR TITLE
Clean up inferred* tests

### DIFF
--- a/tests/build.rs
+++ b/tests/build.rs
@@ -3676,7 +3676,7 @@ Caused by:
 
 
 #[test]
-fn dirs_in_bin_dir_with_main_rs() {
+fn inferred_bins() {
     let p = project("foo")
         .file("Cargo.toml", r#"
             [package]
@@ -3686,21 +3686,17 @@ fn dirs_in_bin_dir_with_main_rs() {
         "#)
         .file("src/main.rs", "fn main() {}")
         .file("src/bin/bar.rs", "fn main() {}")
-        .file("src/bin/bar2.rs", "fn main() {}")
-        .file("src/bin/bar3/main.rs", "fn main() {}")
-        .file("src/bin/bar4/main.rs", "fn main() {}")
+        .file("src/bin/baz/main.rs", "fn main() {}")
         .build();
 
     assert_that(p.cargo("build"), execs().with_status(0));
     assert_that(&p.bin("foo"), existing_file());
     assert_that(&p.bin("bar"), existing_file());
-    assert_that(&p.bin("bar2"), existing_file());
-    assert_that(&p.bin("bar3"), existing_file());
-    assert_that(&p.bin("bar4"), existing_file());
+    assert_that(&p.bin("baz"), existing_file());
 }
 
 #[test]
-fn dir_and_file_with_same_name_in_bin() {
+fn inferred_bins_duplicate_name() {
     // this should fail, because we have two binaries with the same name
     let p = project("bar")
         .file("Cargo.toml", r#"
@@ -3722,7 +3718,7 @@ fn dir_and_file_with_same_name_in_bin() {
 }
 
 #[test]
-fn inferred_path_in_src_bin_foo() {
+fn inferred_bin_path() {
     let p = project("foo")
         .file("Cargo.toml", r#"
         [package]
@@ -3780,7 +3776,7 @@ fn inferred_tests() {
 }
 
 #[test]
-fn inferred_benchmark() {
+fn inferred_benchmarks() {
     let p = project("foo")
         .file("Cargo.toml", r#"
             [package]
@@ -3790,29 +3786,11 @@ fn inferred_benchmark() {
         "#)
         .file("src/lib.rs", "fn main() {}")
         .file("benches/bar.rs", "fn main() {}")
+        .file("benches/baz/main.rs", "fn main() {}")
         .build();
 
     assert_that(
-        p.cargo("bench").arg("--bench=bar"),
-        execs().with_status(0));
-}
-
-#[test]
-fn inferred_benchmark_from_directory() {
-    //FIXME: merge with `inferred_benchmark` after fixing #4504
-    let p = project("foo")
-        .file("Cargo.toml", r#"
-            [package]
-            name = "foo"
-            version = "0.1.0"
-            authors = []
-        "#)
-        .file("src/lib.rs", "fn main() {}")
-        .file("benches/bar/main.rs", "fn main() {}")
-        .build();
-
-    assert_that(
-        p.cargo("bench").arg("--bench=bar"),
+        p.cargo("bench").arg("--bench=bar").arg("--bench=baz"),
         execs().with_status(0));
 }
 


### PR DESCRIPTION
Deduplicate, simplify and rename interred_* tests.
Follow up to #4496 
@matklad 