### PR TITLE
List available binary names

### DIFF
--- a/src/cargo/ops/cargo_run.rs
+++ b/src/cargo/ops/cargo_run.rs
@@ -25,25 +25,28 @@ pub fn run(ws: &Workspace,
         }
     };
 
-    let mut bins = pkg.manifest().targets().iter().filter(|a| {
+    let bins: Vec<_> = pkg.manifest().targets().iter().filter(|a| {
         !a.is_lib() && !a.is_custom_build() && if !options.filter.is_specific() {
             a.is_bin()
         } else {
             options.filter.matches(a)
         }
-    });
-    if bins.next().is_none() {
+    })
+    .map(|bin| bin.name())
+    .collect();
+
+    if bins.len() == 0 {
         if !options.filter.is_specific() {
             bail!("a bin target must be available for `cargo run`")
         } else {
             // this will be verified in cargo_compile
         }
     }
-    if bins.next().is_some() {
+    if bins.len() > 1 {
         if !options.filter.is_specific() {
             bail!("`cargo run` requires that a project only have one \
                    executable; use the `--bin` option to specify which one \
-                   to run")
+                   to run ({})", bins.join(", "))
         } else {
             bail!("`cargo run` can run at most one executable, but \
                    multiple were specified")

--- a/src/cargo/ops/cargo_run.rs
+++ b/src/cargo/ops/cargo_run.rs
@@ -17,7 +17,7 @@ pub fn run(ws: &Workspace,
             0 => ws.current()?,
             1 => ws.members()
                 .find(|pkg| pkg.name() == xs[0])
-                .ok_or_else(|| 
+                .ok_or_else(||
                     CargoError::from(
                         format!("package `{}` is not a member of the workspace", xs[0]))
                 )?,
@@ -46,7 +46,7 @@ pub fn run(ws: &Workspace,
         if !options.filter.is_specific() {
             bail!("`cargo run` requires that a project only have one \
                    executable; use the `--bin` option to specify which one \
-                   to run ({})", bins.join(", "))
+                   to run\navailable binaries: {}", bins.join(", "))
         } else {
             bail!("`cargo run` can run at most one executable, but \
                    multiple were specified")

--- a/tests/required-features.rs
+++ b/tests/required-features.rs
@@ -996,5 +996,5 @@ fn run_default_multiple_required_features() {
     assert_that(p.cargo("run"),
                 execs().with_status(101).with_stderr("\
 error: `cargo run` requires that a project only have one executable; \
-use the `--bin` option to specify which one to run (foo1, foo2)"));
+use the `--bin` option to specify which one to run\navailable binaries: foo1, foo2"));
 }

--- a/tests/required-features.rs
+++ b/tests/required-features.rs
@@ -996,5 +996,5 @@ fn run_default_multiple_required_features() {
     assert_that(p.cargo("run"),
                 execs().with_status(101).with_stderr("\
 error: `cargo run` requires that a project only have one executable; \
-use the `--bin` option to specify which one to run"));
+use the `--bin` option to specify which one to run (foo1, foo2)"));
 }

--- a/tests/run.rs
+++ b/tests/run.rs
@@ -256,7 +256,7 @@ fn too_many_bins() {
                 execs().with_status(101)
                        .with_stderr("[ERROR] `cargo run` requires that a project only \
                                      have one executable; use the `--bin` option \
-                                     to specify which one to run ([..])\n"));
+                                     to specify which one to run\navailable binaries: [..]\n"));
 }
 
 #[test]
@@ -278,7 +278,7 @@ fn too_many_bins_implicit() {
                 execs().with_status(101)
                        .with_stderr("[ERROR] `cargo run` requires that a project only \
                                      have one executable; use the `--bin` option \
-                                     to specify which one to run ([..])\n"));
+                                     to specify which one to run\navailable binaries: [..]\n"));
 }
 
 #[test]

--- a/tests/run.rs
+++ b/tests/run.rs
@@ -256,7 +256,7 @@ fn too_many_bins() {
                 execs().with_status(101)
                        .with_stderr("[ERROR] `cargo run` requires that a project only \
                                      have one executable; use the `--bin` option \
-                                     to specify which one to run\n"));
+                                     to specify which one to run ([..])\n"));
 }
 
 #[test]
@@ -278,7 +278,7 @@ fn too_many_bins_implicit() {
                 execs().with_status(101)
                        .with_stderr("[ERROR] `cargo run` requires that a project only \
                                      have one executable; use the `--bin` option \
-                                     to specify which one to run\n"));
+                                     to specify which one to run ([..])\n"));
 }
 
 #[test]


### PR DESCRIPTION
When a project has multiple executables `cargo run` fails, but offers an incomplete solution (suggests `--bin`, but not its arguments.)

This PR adds a list of available binary names to the error message.