### PR TITLE
Explain why caching is only done on $HOME/.cargo/bin/ in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,10 @@ dist: trusty
 git:
   depth: 1
 
+# Using 'cache: cargo' to cache target/ and all of $HOME/.cargo/
+# doesn't work well: the cache is large and it takes several minutes
+# to move it to and from S3. So instead we only cache the mdbook
+# binary.
 cache:
   directories:
     - $HOME/.cargo/bin/


### PR DESCRIPTION
After having experimented with the Travis and AppVeyor caches, I concluded that they don't really help here: they're large and take a very long time to both download when the build starts and upload after it is finished.