### PR TITLE
Add rustfmt.toml with formatting disabled

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,1 @@
+disable_all_formatting = true


### PR DESCRIPTION
Currently, Cargo does not use rustfmt for its source code. By adding a rustfmt.toml that simply disables all formatting rules, editors which use rustfmt by default for all Rust code will do the right thing and leave the source code unchanged,.

This makes life a little bit easier for developers who no longer need to explicitly disable automatic rustfmt formatting when working on Cargo to avoid code unrelated to a change being reformatted.