### PR TITLE
[doc/book] Change title to The Cargo Book

### DIFF
--- a/src/doc/book/book.toml
+++ b/src/doc/book/book.toml
@@ -1,2 +1,2 @@
-title = "The Cargo Manual"
+title = "The Cargo Book"
 author = "Alex Crichton, Steve Klabnik and Carol Nichols, with Contributions from the Rust Community"

--- a/src/doc/book/src/index.md
+++ b/src/doc/book/src/index.md
@@ -1,10 +1,10 @@
-# The Cargo Manual
+# The Cargo Book
 
 ![Cargo Logo](images/Cargo-Logo-Small.png)
 
 Cargo is the [Rust] *package manager*. Cargo downloads your Rust project’s
 dependencies, compiles your project, makes packages, and upload them to
-[crates.io], the Rust *package registry*.
+[crates.io], the Rust community’s *package registry*.
 
 
 ### Sections


### PR DESCRIPTION
Also add "community’s" to description of crates.io, as Cargo now
supports multiple registries.