### PR TITLE
Add support for using a proxy for crate downloads

### DIFF
--- a/src/cargo/core/source/source_id.rs
+++ b/src/cargo/core/source/source_id.rs
@@ -32,6 +32,8 @@ struct SourceIdInner {
     kind: Kind,
     // e.g. the exact git revision of the specified branch for a Git Source
     precise: Option<String>,
+    /// Optional name to associate with the source
+    name: Option<String>,
 }
 
 /// The possible kinds of code source. Along with a URL, this fully defines the
@@ -72,6 +74,7 @@ impl SourceId {
                 canonical_url: git::canonicalize_url(&url)?,
                 url: url,
                 precise: None,
+                name: None,
             }),
         };
         Ok(source_id)
@@ -190,8 +193,14 @@ impl SourceId {
                 canonical_url: git::canonicalize_url(&url)?,
                 url: url,
                 precise: None,
+                name: Some(key.to_string()),
             }),
         })
+    }
+
+    /// Get the optional name associated with the source
+    pub fn name(&self) -> &Option<String> {
+        &self.inner.name
     }
 
     /// Get this source URL

--- a/src/cargo/sources/registry/remote.rs
+++ b/src/cargo/sources/registry/remote.rs
@@ -209,10 +209,20 @@ impl<'cfg> RegistryData for RemoteRegistry<'cfg> {
             .push(&pkg.version().to_string())
             .push("download");
 
+        let proxy_key = match self.source_id.name() {
+            &None => "registry.proxy".to_string(),
+            &Some(ref registry) => format!("registries.{}.proxy", registry),
+        };
+
+        if let Some(cache) = self.config.get_string(&proxy_key)? {
+            url = cache.val.to_url()?.join(url.path())?;
+        }
+
         // TODO: don't download into memory, but ensure that if we ctrl-c a
         //       download we should resume either from the start or the middle
         //       on the next time
         let url = url.to_string();
+
         let mut handle = self.config.http()?.borrow_mut();
         handle.get(true)?;
         handle.url(&url)?;

--- a/src/cargo/util/errors.rs
+++ b/src/cargo/util/errors.rs
@@ -17,6 +17,7 @@ use serde_json;
 use toml;
 use registry;
 use ignore;
+use url;
 
 error_chain! {
     types {
@@ -40,6 +41,7 @@ error_chain! {
         Parse(string::ParseError);
         Git(git2::Error);
         Curl(curl::Error);
+        UrlParse(url::ParseError);
     }
 
     errors {
@@ -87,6 +89,7 @@ impl CargoError {
             CargoErrorKind::Git(_) |
             CargoErrorKind::Internal(_) |
             CargoErrorKind::CargoTestErrorKind(_) |
+            CargoErrorKind::UrlParse(_) |
             CargoErrorKind::__Nonexhaustive { .. } => false
         }
     }


### PR DESCRIPTION
This pull request adds support for using a proxy to cache downloads of crates from crates.io, it is expected that a lot of the time this will be used in conjunction with source replacement to allow full mirroring of crates.io. This has the advantages that:

 - If there is an issue with crates.io you are still able to build using any crate anyone using the cache has previously downloaded
 - Reduces bandwidth to crates.io as normally the binaries will be served from the cache

This works by adding the following new config:

```
[registry]
proxy = "http://a.b.c.d/path/"
```

or 

```
[registries.cool-private-server]
proxy = http://d.c.b.a/path/"
```

When this is used any request to download files from crates.io is sent to the server provided with the original path, so for example a request to download the following file:

http://crates.io/api/v1/new -> http://a.b.c.d/path/api/v1/new

This then allows setting up a registry cache in artifactory by performing the following:

 * Create a new remote repository
 * Set to a generic repository type
 * Set a key for this repository (this will form part of the URL that is used in the proxy config)
 * Set the URL to "https://crates.io/"

Once that is done any cargo download will be cached in artifactory and future requests will not go to crates.io.

Note that currently I have not written any docs on how to do this and I have also not written any unit tests for the function, as I wanted to ensure that people were happy with the general approach.