### PR TITLE
cargo_generate_lockfile: use color to also indicate the change

### DIFF
--- a/src/cargo/ops/cargo_generate_lockfile.rs
+++ b/src/cargo/ops/cargo_generate_lockfile.rs
@@ -1,5 +1,7 @@
 use std::collections::{BTreeMap, HashSet};
 
+use termcolor::Color::{self, Cyan, Green, Red};
+
 use core::PackageId;
 use core::registry::PackageRegistry;
 use core::{Resolve, SourceId, Workspace};
@@ -83,8 +85,8 @@ pub fn update_lockfile(ws: &Workspace, opts: &UpdateOptions)
                                                   true)?;
 
     // Summarize what is changing for the user.
-    let print_change = |status: &str, msg: String| {
-        opts.config.shell().status(status, msg)
+    let print_change = |status: &str, msg: String, color: Color| {
+        opts.config.shell().status_with_color(status, msg, color)
     };
     for (removed, added) in compare_dependency_graphs(&previous_resolve, &resolve) {
         if removed.len() == 1 && added.len() == 1 {
@@ -94,13 +96,13 @@ pub fn update_lockfile(ws: &Workspace, opts: &UpdateOptions)
             } else {
                 format!("{} -> v{}", removed[0], added[0].version())
             };
-            print_change("Updating", msg)?;
+            print_change("Updating", msg, Cyan)?;
         } else {
             for package in removed.iter() {
-                print_change("Removing", format!("{}", package))?;
+                print_change("Removing", format!("{}", package), Red)?;
             }
             for package in added.iter() {
-                print_change("Adding", format!("{}", package))?;
+                print_change("Adding", format!("{}", package), Green)?;
             }
         }
     }


### PR DESCRIPTION
In English, `Updating` and `Removing` are the same length and scanning
the list for changes is hard. Use color to help indicate the kind of
change that is occurring.