### PR TITLE
[beta] Do not update semantically equivalent lockfiles with --frozen/--locked.

### DIFF
--- a/src/cargo/core/resolver/mod.rs
+++ b/src/cargo/core/resolver/mod.rs
@@ -73,6 +73,7 @@ mod encode;
 ///
 /// Each instance of `Resolve` also understands the full set of features used
 /// for each package.
+#[derive(PartialEq)]
 pub struct Resolve {
     graph: Graph<PackageId>,
     replacements: HashMap<PackageId, PackageId>,

--- a/tests/lockfile-compat.rs
+++ b/tests/lockfile-compat.rs
@@ -22,16 +22,16 @@ fn oldest_lockfile_still_works_with_command(cargo_command: &str) {
 
     let expected_lockfile =
 r#"[[package]]
-name = "bar"
+name = "foo"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "zzz"
 version = "0.0.1"
 dependencies = [
  "foo 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "foo"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
 "checksum foo 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "[..]"
@@ -39,7 +39,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
     let old_lockfile =
 r#"[root]
-name = "bar"
+name = "zzz"
 version = "0.0.1"
 dependencies = [
  "foo 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -54,7 +54,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
     let p = project("bar")
         .file("Cargo.toml", r#"
             [project]
-            name = "bar"
+            name = "zzz"
             version = "0.0.1"
             authors = []
 
@@ -83,7 +83,7 @@ fn frozen_flag_preserves_old_lockfile() {
 
     let old_lockfile =
         r#"[root]
-name = "bar"
+name = "zzz"
 version = "0.0.1"
 dependencies = [
  "foo 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -101,7 +101,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
     let p = project("bar")
         .file("Cargo.toml", r#"
             [project]
-            name = "bar"
+            name = "zzz"
             version = "0.0.1"
             authors = []
 


### PR DESCRIPTION
A previous patch in #4684 attempted to fix this, but didn't work for the
case where the [root] crate wasn't the first crate in the sorted package
array.

Backport of https://github.com/rust-lang/cargo/pull/4714.