### PR TITLE
add support for rustc's --error-format short

### DIFF
--- a/src/bin/bench.rs
+++ b/src/bin/bench.rs
@@ -70,7 +70,7 @@ Options:
     -v, --verbose ...            Use verbose output (-vv very verbose/build.rs output)
     -q, --quiet                  No output printed to stdout
     --color WHEN                 Coloring: auto, always, never
-    --message-format FMT         Error format: human, json [default: human]
+    --message-format FMT         Error format: human, json, short [default: human]
     --no-fail-fast               Run all benchmarks regardless of failure
     --frozen                     Require Cargo.lock and cache are up to date
     --locked                     Require Cargo.lock is up to date

--- a/src/bin/build.rs
+++ b/src/bin/build.rs
@@ -68,7 +68,7 @@ Options:
     -v, --verbose ...            Use verbose output (-vv very verbose/build.rs output)
     -q, --quiet                  No output printed to stdout
     --color WHEN                 Coloring: auto, always, never
-    --message-format FMT         Error format: human, json [default: human]
+    --message-format FMT         Error format: human, json, short [default: human]
     --frozen                     Require Cargo.lock and cache are up to date
     --locked                     Require Cargo.lock is up to date
     -Z FLAG ...                  Unstable (nightly-only) flags to Cargo

--- a/src/bin/check.rs
+++ b/src/bin/check.rs
@@ -37,7 +37,7 @@ Options:
     -v, --verbose ...            Use verbose output
     -q, --quiet                  No output printed to stdout
     --color WHEN                 Coloring: auto, always, never
-    --message-format FMT         Error format: human, json [default: human]
+    --message-format FMT         Error format: human, json, short [default: human]
     --frozen                     Require Cargo.lock and cache are up to date
     --locked                     Require Cargo.lock is up to date
     -Z FLAG ...                  Unstable (nightly-only) flags to Cargo

--- a/src/bin/doc.rs
+++ b/src/bin/doc.rs
@@ -56,7 +56,7 @@ Options:
     -v, --verbose ...            Use verbose output (-vv very verbose/build.rs output)
     -q, --quiet                  No output printed to stdout
     --color WHEN                 Coloring: auto, always, never
-    --message-format FMT         Error format: human, json [default: human]
+    --message-format FMT         Error format: human, json, short [default: human]
     --frozen                     Require Cargo.lock and cache are up to date
     --locked                     Require Cargo.lock is up to date
     -Z FLAG ...                  Unstable (nightly-only) flags to Cargo

--- a/src/bin/run.rs
+++ b/src/bin/run.rs
@@ -49,7 +49,7 @@ Options:
     -v, --verbose ...            Use verbose output (-vv very verbose/build.rs output)
     -q, --quiet                  No output printed to stdout
     --color WHEN                 Coloring: auto, always, never
-    --message-format FMT         Error format: human, json [default: human]
+    --message-format FMT         Error format: human, json, short [default: human]
     --frozen                     Require Cargo.lock and cache are up to date
     --locked                     Require Cargo.lock is up to date
     -Z FLAG ...                  Unstable (nightly-only) flags to Cargo

--- a/src/bin/rustc.rs
+++ b/src/bin/rustc.rs
@@ -67,7 +67,7 @@ Options:
     -v, --verbose ...        Use verbose output (-vv very verbose/build.rs output)
     -q, --quiet              No output printed to stdout
     --color WHEN             Coloring: auto, always, never
-    --message-format FMT     Error format: human, json [default: human]
+    --message-format FMT     Error format: human, json, short [default: human]
     --frozen                 Require Cargo.lock and cache are up to date
     --locked                 Require Cargo.lock is up to date
     -Z FLAG ...              Unstable (nightly-only) flags to Cargo

--- a/src/bin/rustdoc.rs
+++ b/src/bin/rustdoc.rs
@@ -65,7 +65,7 @@ Options:
     -v, --verbose ...        Use verbose output (-vv very verbose/build.rs output)
     -q, --quiet              No output printed to stdout
     --color WHEN             Coloring: auto, always, never
-    --message-format FMT     Error format: human, json [default: human]
+    --message-format FMT     Error format: human, json, short [default: human]
     --frozen                 Require Cargo.lock and cache are up to date
     --locked                 Require Cargo.lock is up to date
     -Z FLAG ...              Unstable (nightly-only) flags to Cargo

--- a/src/bin/test.rs
+++ b/src/bin/test.rs
@@ -74,7 +74,7 @@ Options:
     -v, --verbose ...            Use verbose output (-vv very verbose/build.rs output)
     -q, --quiet                  No output printed to stdout
     --color WHEN                 Coloring: auto, always, never
-    --message-format FMT         Error format: human, json [default: human]
+    --message-format FMT         Error format: human, json, short [default: human]
     --no-fail-fast               Run all tests regardless of failure
     --frozen                     Require Cargo.lock and cache are up to date
     --locked                     Require Cargo.lock is up to date

--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -101,7 +101,14 @@ pub enum CompileMode {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Deserialize)]
 pub enum MessageFormat {
     Human,
-    Json
+    Json,
+    Short,
+}
+
+impl Default for MessageFormat {
+    fn default() -> Self {
+        MessageFormat::Human
+    }
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
@@ -306,7 +313,7 @@ pub fn compile_ws<'a>(ws: &Workspace<'a>,
         let mut build_config = scrape_build_config(config, jobs, target)?;
         build_config.release = release;
         build_config.test = mode == CompileMode::Test || mode == CompileMode::Bench;
-        build_config.json_messages = message_format == MessageFormat::Json;
+        build_config.message_format = message_format;
         if let CompileMode::Doc { deps } = mode {
             build_config.doc_all = deps;
         }

--- a/src/cargo/ops/cargo_rustc/custom_build.rs
+++ b/src/cargo/ops/cargo_rustc/custom_build.rs
@@ -5,6 +5,7 @@ use std::str;
 use std::sync::{Mutex, Arc};
 
 use core::PackageId;
+use ops::MessageFormat;
 use util::{Freshness, Cfg};
 use util::errors::{CargoResult, CargoResultExt, CargoError};
 use util::{internal, profile, paths};
@@ -188,7 +189,7 @@ fn build_work<'a, 'cfg>(cx: &mut Context<'a, 'cfg>, unit: &Unit<'a>)
                output_file.clone());
     let build_scripts = super::load_build_deps(cx, unit);
     let kind = unit.kind;
-    let json_messages = cx.build_config.json_messages;
+    let json_messages = cx.build_config.message_format == MessageFormat::Json;
 
     // Check to see if the build script has already run, and if it has keep
     // track of whether it has told us about some explicit dependencies

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -2864,7 +2864,7 @@ fn wrong_message_format_option() {
     assert_that(p.cargo("build").arg("--message-format").arg("XML"),
                 execs().with_status(1)
                        .with_stderr_contains(
-r#"[ERROR] Could not match 'xml' with any of the allowed variants: ["Human", "Json"]"#));
+r#"[ERROR] Could not match 'xml' with any of the allowed variants: ["Human", "Json", "Short"]"#));
 }
 
 #[test]


### PR DESCRIPTION
As implemented in https://github.com/rust-lang/rust/pull/44636, this exposes the `--error-format short` in Cargo's `--message-format` flag.