### PR TITLE
Sort native library paths for deterministic builds

### DIFF
--- a/src/cargo/ops/cargo_rustc/compilation.rs
+++ b/src/cargo/ops/cargo_rustc/compilation.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::{HashMap, HashSet, BTreeSet};
 use std::ffi::OsStr;
 use std::path::PathBuf;
 use semver::Version;
@@ -22,8 +22,10 @@ pub struct Compilation<'cfg> {
     ///
     /// This is currently used to drive some entries which are added to the
     /// LD_LIBRARY_PATH as appropriate.
+    ///
+    /// The order should be deterministic.
     // TODO: deprecated, remove
-    pub native_dirs: HashSet<PathBuf>,
+    pub native_dirs: BTreeSet<PathBuf>,
 
     /// Root output directory (for the local package's artifacts)
     pub root_output: PathBuf,
@@ -61,7 +63,7 @@ impl<'cfg> Compilation<'cfg> {
     pub fn new(config: &'cfg Config) -> Compilation<'cfg> {
         Compilation {
             libraries: HashMap::new(),
-            native_dirs: HashSet::new(),  // TODO: deprecated, remove
+            native_dirs: BTreeSet::new(),  // TODO: deprecated, remove
             root_output: PathBuf::from("/"),
             deps_output: PathBuf::from("/"),
             host_deps_output: PathBuf::from("/"),


### PR DESCRIPTION
Fixes #3800 by using a `BTreeSet`, which guarantees a deterministic iteration order. 

Since the order was previously arbitrary, a sorted order is just as good. The list is so small, that any performance difference between `BTreeSet` and `HashSet` is negligible.