### PR TITLE
[beta] When uplifting directories, symlink them instead of hard-link them.

### DIFF
--- a/tests/build.rs
+++ b/tests/build.rs
@@ -3899,6 +3899,13 @@ fn uplift_dsym_of_bin_on_mac() {
     );
     assert_that(&p.bin("foo.dSYM"), existing_dir());
     assert_that(&p.bin("b.dSYM"), existing_dir());
+    assert!(
+        p.bin("b.dSYM")
+            .symlink_metadata()
+            .expect("read metadata from b.dSYM")
+            .file_type()
+            .is_symlink()
+    );
     assert_that(&p.bin("c.dSYM"), is_not(existing_dir()));
     assert_that(&p.bin("d.dSYM"), is_not(existing_dir()));
 }

--- a/tests/cargotest/support/paths.rs
+++ b/tests/cargotest/support/paths.rs
@@ -81,15 +81,14 @@ impl CargoPathExt for Path {
         }
 
         for file in t!(fs::read_dir(self)) {
-            let file = t!(file).path();
-
-            if file.is_dir() {
-                file.rm_rf();
+            let file = t!(file);
+            if file.file_type().map(|m| m.is_dir()).unwrap_or(false) {
+                file.path().rm_rf();
             } else {
                 // On windows we can't remove a readonly file, and git will
                 // often clone files as readonly. As a result, we have some
                 // special logic to remove readonly files on windows.
-                do_op(&file, "remove file", |p| fs::remove_file(p));
+                do_op(&file.path(), "remove file", |p| fs::remove_file(p));
             }
         }
         do_op(self, "remove dir", |p| fs::remove_dir(p));


### PR DESCRIPTION
Backport of #4672 to 1.22 (cargo 0.23)

The current stable RC (cee38cd30) contains #4616 *but not* #4672. Without the latter it is known to cause #4671 on APFS (enabled by default on macOS 10.13 "High Sierra"). 

The issue was found by kpy3 on https://internals.rust-lang.org/t/rust-1-22-0-prerelease-testing/6282/2. 