### PR TITLE
Track which commands a registry supports in its config.json

### DIFF
--- a/src/cargo/ops/registry.rs
+++ b/src/cargo/ops/registry.rs
@@ -226,15 +226,16 @@ pub fn registry(config: &Config,
         (Some(index), _) | (None, Some(index)) => SourceId::for_registry(&index.to_url()?)?,
         (None, None) => SourceId::crates_io(config)?,
     };
-    let api_host = {
+    let (api_host, commands) = {
         let mut src = RegistrySource::remote(&sid, config);
         src.update().chain_err(|| {
             format!("failed to update {}", sid)
         })?;
-        (src.config()?).unwrap().api.unwrap()
+        let cfg = src.config()?.unwrap();
+        (cfg.api.unwrap(), cfg.commands)
     };
     let handle = http_handle(config)?;
-    Ok((Registry::new_handle(api_host, token, handle), sid))
+    Ok((Registry::new_handle(api_host, commands, token, handle), sid))
 }
 
 /// Create a new HTTP handle with appropriate global configuration for cargo.

--- a/src/cargo/sources/registry/mod.rs
+++ b/src/cargo/sources/registry/mod.rs
@@ -200,6 +200,9 @@ pub struct RegistryConfig {
     /// API endpoint for the registry. This is what's actually hit to perform
     /// operations like yanks, owner modifications, publish new crates, etc.
     pub api: Option<String>,
+
+    #[serde(default)]
+    pub commands: BTreeMap<String, Vec<String>>,
 }
 
 #[derive(Deserialize)]

--- a/src/crates-io/lib.rs
+++ b/src/crates-io/lib.rs
@@ -49,11 +49,16 @@ body:
             NotFound {
                 display("cannot find crate")
             }
+            UnsupportedCommand(command: String) {
+                description("unsupported command")
+                display("unsupported command: {}", command)
+            }
         }
     }
 
 pub struct Registry {
     host: String,
+    commands: BTreeMap<String, Vec<String>>,
     token: Option<String>,
     handle: Easy,
 }
@@ -125,21 +130,24 @@ pub struct Warnings {
 #[derive(Deserialize)] struct TotalCrates { total: u32 }
 #[derive(Deserialize)] struct Crates { crates: Vec<Crate>, meta: TotalCrates }
 impl Registry {
-    pub fn new(host: String, token: Option<String>) -> Registry {
-        Registry::new_handle(host, token, Easy::new())
+    pub fn new(host: String, commands: BTreeMap<String, Vec<String>>, token: Option<String>) -> Registry {
+        Registry::new_handle(host, commands, token, Easy::new())
     }
 
     pub fn new_handle(host: String,
+                      commands: BTreeMap<String, Vec<String>>,
                       token: Option<String>,
                       handle: Easy) -> Registry {
         Registry {
             host: host,
+            commands: commands,
             token: token,
             handle: handle,
         }
     }
 
     pub fn add_owners(&mut self, krate: &str, owners: &[&str]) -> Result<String> {
+        self.supports_command("owner", "v1")?;
         let body = serde_json::to_string(&OwnersReq { users: owners })?;
         let body = self.put(format!("/crates/{}/owners", krate),
                                  body.as_bytes())?;
@@ -148,6 +156,7 @@ impl Registry {
     }
 
     pub fn remove_owners(&mut self, krate: &str, owners: &[&str]) -> Result<()> {
+        self.supports_command("owner", "v1")?;
         let body = serde_json::to_string(&OwnersReq { users: owners })?;
         let body = self.delete(format!("/crates/{}/owners", krate),
                                     Some(body.as_bytes()))?;
@@ -156,12 +165,14 @@ impl Registry {
     }
 
     pub fn list_owners(&mut self, krate: &str) -> Result<Vec<User>> {
+        self.supports_command("owner", "v1")?;
         let body = self.get(format!("/crates/{}/owners", krate))?;
         Ok(serde_json::from_str::<Users>(&body)?.users)
     }
 
     pub fn publish(&mut self, krate: &NewCrate, tarball: &File)
                    -> Result<Warnings> {
+        self.supports_command("publish", "v1")?;
         let json = serde_json::to_string(krate)?;
         // Prepare the body. The format of the upload request is:
         //
@@ -233,6 +244,7 @@ impl Registry {
     }
 
     pub fn search(&mut self, query: &str, limit: u8) -> Result<(Vec<Crate>, u32)> {
+        self.supports_command("search", "v1")?;
         let formated_query = percent_encode(query.as_bytes(), QUERY_ENCODE_SET);
         let body = self.req(
             format!("/crates?q={}&per_page={}", formated_query, limit),
@@ -244,6 +256,7 @@ impl Registry {
     }
 
     pub fn yank(&mut self, krate: &str, version: &str) -> Result<()> {
+        self.supports_command("yank", "v1")?;
         let body = self.delete(format!("/crates/{}/{}/yank", krate, version),
                                     None)?;
         assert!(serde_json::from_str::<R>(&body)?.ok);
@@ -251,10 +264,19 @@ impl Registry {
     }
 
     pub fn unyank(&mut self, krate: &str, version: &str) -> Result<()> {
+        self.supports_command("yank", "v1")?;
         let body = self.put(format!("/crates/{}/{}/unyank", krate, version),
                                  &[])?;
         assert!(serde_json::from_str::<R>(&body)?.ok);
         Ok(())
+    }
+
+    fn supports_command(&self, cmd: &str, vers: &str) -> Result<()> {
+        if self.commands.get(cmd).map_or(false, |vs| vs.iter().any(|v| v == vers)) {
+            Ok(())
+        } else {
+            Err(Error::from_kind(ErrorKind::UnsupportedCommand(cmd.to_string())))
+        }
     }
 
     fn put(&mut self, path: String, b: &[u8]) -> Result<String> {

--- a/tests/cargotest/support/publish.rs
+++ b/tests/cargotest/support/publish.rs
@@ -3,6 +3,7 @@ use std::io::prelude::*;
 use std::fs::{self, File};
 
 use support::paths;
+use support::registry;
 use support::git::{repo, Repository};
 
 use url::Url;
@@ -19,8 +20,9 @@ pub fn setup() -> Repository {
     repo(&registry_path())
         .file("config.json", &format!(r#"{{
             "dl": "{0}",
-            "api": "{0}"
-        }}"#, upload()))
+            "api": "{0}",
+            "commands": {1}
+        }}"#, upload(), registry::COMMANDS))
         .build()
 }
 

--- a/tests/cargotest/support/registry.rs
+++ b/tests/cargotest/support/registry.rs
@@ -23,6 +23,14 @@ pub fn alt_registry() -> Url { Url::from_file_path(&*alt_registry_path()).ok().u
 pub fn alt_dl_path() -> PathBuf { paths::root().join("alt_dl") }
 pub fn alt_dl_url() -> Url { Url::from_file_path(&*alt_dl_path()).ok().unwrap() }
 
+pub const COMMANDS: &str = r#"{
+    "publish":  ["v1"],
+    "yank":     ["v1"],
+    "search":   ["v1"],
+    "owner":    ["v1"],
+    "login":    ["v1"]
+}"#;
+
 pub struct Package {
     name: String,
     vers: String,
@@ -68,16 +76,16 @@ pub fn init() {
     // Init a new registry
     let _ = repo(&registry_path())
         .file("config.json", &format!(r#"
-            {{"dl":"{0}","api":"{0}"}}
-        "#, dl_url()))
+            {{"dl":"{0}","api":"{0}","commands":{1}}}
+        "#, dl_url(), COMMANDS))
         .build();
     fs::create_dir_all(dl_path().join("api/v1/crates")).unwrap();
 
     // Init an alt registry
     repo(&alt_registry_path())
         .file("config.json", &format!(r#"
-            {{"dl":"{0}","api":"{0}"}}
-        "#, alt_dl_url()))
+            {{"dl":"{0}","api":"{0}","commands":{1}}}
+        "#, alt_dl_url(), COMMANDS))
         .build();
     fs::create_dir_all(alt_dl_path().join("api/v1/crates")).unwrap();
 }

--- a/tests/search.rs
+++ b/tests/search.rs
@@ -11,6 +11,7 @@ use cargo::util::ProcessBuilder;
 use cargotest::support::execs;
 use cargotest::support::git::repo;
 use cargotest::support::paths;
+use cargotest::support::registry::COMMANDS;
 use hamcrest::assert_that;
 use url::Url;
 
@@ -27,8 +28,9 @@ fn setup() {
     let _ = repo(&registry_path())
         .file("config.json", &format!(r#"{{
             "dl": "{0}",
-            "api": "{0}"
-        }}"#, api()))
+            "api": "{0}",
+            "commands": {1}
+        }}"#, api(), COMMANDS))
         .build();
 }
 


### PR DESCRIPTION
This arose out of #4574. The idea is for cargo to only perform an action if the registry supports that command.

The 5 existing commands that interact with registries are:

1. publish
2. yank
3. owner
4. search
5. login (technically never makes a direct request, but is clearly an interaction with the registry semantically)

This proposes to track each command as an array of supported versions:

```json
{
    "api": "https://crates.io/",
    "dl": "https://crates.io/api/v1/crates",
    "commands": {
        "publish": ["v1"],
        "yank": ["v1"],
        "owner": ["v1"],
        "search": ["v1"],
        "login": ["v1"]
    }
}
```

(On the issue it was discussed having an "api" string for each command, but the actual APIs of the commands are not conducive to this because parts of the query are in the path.)

Before merging, this commands object would need to be added to the config.json of the crates.io index.

@cswindle @carols10cents @rust-lang/cargo