### PR TITLE
Fix the lockfile-compat test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,8 @@ matrix:
 
     - env: TARGET=x86_64-unknown-linux-gnu
            ALT=i686-unknown-linux-gnu
-      rust: nightly
+      # FIXME(rust-lang/rust#46271) should use just `nightly`
+      rust: nightly-2017-11-20
       install:
         - mdbook --help || cargo install mdbook --force
       script:

--- a/tests/lockfile-compat.rs
+++ b/tests/lockfile-compat.rs
@@ -79,9 +79,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 #[test]
 fn frozen_flag_preserves_old_lockfile() {
-    Package::new("foo", "0.1.0").publish();
+    let cksum = Package::new("foo", "0.1.0").publish();
 
-    let old_lockfile =
+    let old_lockfile = format!(
         r#"[root]
 name = "zzz"
 version = "0.0.1"
@@ -95,8 +95,10 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
-"checksum foo 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f9e0a16bdf5c05435698fa27192d89e331b22a26a972c34984f560662544453b"
-"#;
+"checksum foo 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "{}"
+"#,
+    cksum,
+    );
 
     let p = project("bar")
         .file("Cargo.toml", r#"
@@ -109,7 +111,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
             foo = "0.1.0"
         "#)
         .file("src/lib.rs", "")
-        .file("Cargo.lock", old_lockfile)
+        .file("Cargo.lock", &old_lockfile)
         .build();
 
     assert_that(p.cargo("build").arg("--locked"),


### PR DESCRIPTION
The newest version of `tar` tweaks the checksum here slightly as the tarball is
slightly different, so this just updates the test to pull the checksum from the
publication rather than hardcoding it.