### PR TITLE
Allow metadata hash to be computed when checking dylibs

### DIFF
--- a/src/cargo/ops/cargo_rustc/context.rs
+++ b/src/cargo/ops/cargo_rustc/context.rs
@@ -535,7 +535,7 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
         // just here for rustbuild. We need a more principled method
         // doing this eventually.
         let __cargo_default_lib_metadata = env::var("__CARGO_DEFAULT_LIB_METADATA");
-        if !unit.profile.test &&
+        if !(unit.profile.test || unit.profile.check) &&
             (unit.target.is_dylib() || unit.target.is_cdylib() ||
                  (unit.target.is_bin() && self.target_triple().starts_with("wasm32-"))) &&
             unit.pkg.package_id().source_id().is_path() &&

--- a/tests/check.rs
+++ b/tests/check.rs
@@ -1,4 +1,3 @@
-#[macro_use]
 extern crate cargotest;
 extern crate hamcrest;
 extern crate glob;

--- a/tests/check.rs
+++ b/tests/check.rs
@@ -301,7 +301,7 @@ fn issue_3419() {
 
 // Check on a dylib should have a different metadata hash than build.
 #[test]
-fn check_dylib() {
+fn dylib_check_preserves_build_cache() {
     let p = project("foo")
         .file("Cargo.toml", r#"
             [package]
@@ -317,25 +317,21 @@ fn check_dylib() {
         .file("src/lib.rs", "")
         .build();
 
-    let build_output = t!(String::from_utf8(
-        t!(p.cargo("build").arg("-v").exec_with_output())
-            .stderr,
-    ));
-    let build_metadata = build_output
-        .split_whitespace()
-        .find(|arg| arg.starts_with("metadata="))
-        .unwrap();
+    assert_that(p.cargo("build"),
+                execs().with_status(0)
+                .with_stderr("\
+[..]Compiling foo v0.1.0 ([..])
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+"));
 
-    let check_output = t!(String::from_utf8(
-        t!(p.cargo("check").arg("-v").exec_with_output())
-            .stderr,
-    ));
-    let check_metadata = check_output
-        .split_whitespace()
-        .find(|arg| arg.starts_with("metadata="))
-        .unwrap();
+    assert_that(p.cargo("check"),
+                execs().with_status(0));
 
-    assert_ne!(build_metadata, check_metadata);
+    assert_that(p.cargo("build"),
+                execs().with_status(0)
+                .with_stderr("\
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+"));
 }
 
 // test `cargo rustc --profile check`


### PR DESCRIPTION
Currently, `cargo check` on a dylib crate will use the same fingerprint files as `build`, resulting in `build`s often having to re-do unnecessary work as previous `build`s fingerprints have been clobbered (specifically, the `profile` hash in the fingerprint will be wrong since `check` runs with a different profile than `build`).