### PR TITLE
Document that cargo sets `CARGO` for build scripts

### DIFF
--- a/src/doc/book/src/reference/environment-variables.md
+++ b/src/doc/book/src/reference/environment-variables.md
@@ -73,6 +73,7 @@ let out_dir = env::var("OUT_DIR").unwrap();
 
 `out_dir` will now contain the value of `OUT_DIR`.
 
+* `CARGO` - Path to the `cargo` binary performing the build.
 * `CARGO_MANIFEST_DIR` - The directory containing the manifest for the package
                          being built (the package containing the build
                          script). Also note that this is the value of the

--- a/src/doc/environment-variables.md
+++ b/src/doc/environment-variables.md
@@ -73,6 +73,7 @@ let out_dir = env::var("OUT_DIR").unwrap();
 
 `out_dir` will now contain the value of `OUT_DIR`.
 
+* `CARGO` - Path to the `cargo` binary performing the build.
 * `CARGO_MANIFEST_DIR` - The directory containing the manifest for the package
                          being built (the package containing the build
                          script). Also note that this is the value of the

--- a/tests/build-script.rs
+++ b/tests/build-script.rs
@@ -103,6 +103,8 @@ fn custom_build_env_vars() {
 
                 let _feat = env::var("CARGO_FEATURE_FOO").unwrap();
 
+                let _cargo = env::var("CARGO").unwrap();
+
                 let rustc = env::var("RUSTC").unwrap();
                 assert_eq!(rustc, "rustc");
 


### PR DESCRIPTION
This documents and tests the current behavior. 

However, I have two questions: 

* Do we support recursively invoking Cargo from the build script?

* Do we support recursively invoking Cargo on the crate's own sources (ie, stuff inside `CARGO_HOME` which gets extracted from `.crate` files, and which in general is not byte-equal to the original sources).


Here's an interesting problem that Servo faced:

* Servo is a workspace.
* Servo's `CARGO_HOME` is inside sources.
* One of Servo's deps uses cbindgen from build.rs
* cbindgen [invokes](https://github.com/eqrion/cbindgen/blob/ef3bd8d307f01ad1171ab69cf911b712fbd73583/src/bindgen/cargo/cargo_metadata.rs#L106) Cargo to read Cargo.toml from a crate inside CARGO_HOME (which is inside worksapce).

This all failed to work as expected, because Cargo invoked by bindgen thought that workspace configuration was wrong. 

The problem was fixed on the Servo side by using `exclude` key for workspace. 

But do we actually guarantee that this is supposed to work? :) If we do, we might want to apply fix suggested by @nox and avoid looking for workspace root if we are inside `CARGO_HOME`.

Note that cbindgen will probably be broken for crates which are workspaces themselves, because we rewrite members to path dependencies, but, if you have an explicit `members` key, `cargo metadata` inside such workspace in `CARGO_HOME` will complain. 

Original IRC discussion: https://botbot.me/mozilla/cargo/2017-11-29/?msg=94061970&page=3

cc @nox
