### PR TITLE
Don't recurse out of CARGO_HOME when looking for workspace root

### DIFF
--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -333,6 +333,9 @@ impl<'cfg> Workspace<'cfg> {
         }
 
         for path in paths::ancestors(manifest_path).skip(2) {
+            if self.config.home() == path {
+                return Ok(None);
+            }
             let ances_manifest_path = path.join("Cargo.toml");
             debug!("find_root - trying {}", ances_manifest_path.display());
             if ances_manifest_path.exists() {

--- a/src/cargo/util/flock.rs
+++ b/src/cargo/util/flock.rs
@@ -233,6 +233,18 @@ impl Filesystem {
     }
 }
 
+impl PartialEq<Path> for Filesystem {
+    fn eq(&self, other: &Path) -> bool {
+        self.root == other
+    }
+}
+
+impl PartialEq<Filesystem> for Path {
+    fn eq(&self, other: &Filesystem) -> bool {
+        self == other.root
+    }
+}
+
 /// Acquires a lock on a file in a "nice" manner.
 ///
 /// Almost all long-running blocking actions in Cargo have a status message


### PR DESCRIPTION
This fixes #4765.