### PR TITLE
Add an "-Z offline" flag to Cargo, altering it's dependency resolution behavior

### DIFF
--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -232,6 +232,7 @@ impl Features {
 pub struct CliUnstable {
     pub print_im_a_teapot: bool,
     pub unstable_options: bool,
+    pub offline: bool,
 }
 
 impl CliUnstable {
@@ -262,6 +263,7 @@ impl CliUnstable {
         match k {
             "print-im-a-teapot" => self.print_im_a_teapot = parse_bool(v)?,
             "unstable-options" => self.unstable_options = true,
+            "offline" => self.offline = true,
             _ => bail!("unknown `-Z` flag specified: {}", k),
         }
 

--- a/src/cargo/core/resolver/mod.rs
+++ b/src/cargo/core/resolver/mod.rs
@@ -889,8 +889,10 @@ fn activation_error(cx: &Context,
 
     if let Some(config) = config {
         if config.cli_unstable().offline {
-            msg.push_str("\nperhaps an error occurred because you are using \
-                              the offline mode");
+            msg.push_str("\nAs a reminder, you're using offline mode (-Z offline) \
+            which can sometimes cause surprising resolution failures, \
+            if this error is too confusing you may with to retry \
+            without the offline flag.");
         }
     }
 

--- a/src/cargo/core/resolver/mod.rs
+++ b/src/cargo/core/resolver/mod.rs
@@ -722,7 +722,7 @@ fn activate_deps_loop<'a>(mut cx: Context<'a>,
                     None => return Err(activation_error(&cx, registry, &parent,
                                                         &dep,
                                                         cx.prev_active(&dep),
-                                                        &candidates)),
+                                                        &candidates, config)),
                     Some(candidate) => candidate,
                 }
             }
@@ -788,7 +788,8 @@ fn activation_error(cx: &Context,
                     parent: &Summary,
                     dep: &Dependency,
                     prev_active: &[Summary],
-                    candidates: &[Candidate]) -> CargoError {
+                    candidates: &[Candidate],
+                    config: Option<&Config>) -> CargoError {
     if !candidates.is_empty() {
         let mut msg = format!("failed to select a version for `{}` \
                                (required by `{}`):\n\
@@ -843,7 +844,7 @@ fn activation_error(cx: &Context,
         b.version().cmp(a.version())
     });
 
-    let msg = if !candidates.is_empty() {
+    let mut msg = if !candidates.is_empty() {
         let versions = {
             let mut versions = candidates.iter().take(3).map(|cand| {
                 cand.version().to_string()
@@ -885,6 +886,13 @@ fn activation_error(cx: &Context,
                 dep.source_id(),
                 dep.version_req())
     };
+
+    if let Some(config) = config {
+        if config.cli_unstable().offline {
+            msg.push_str("\nperhaps an error occurred because you are using \
+                              the offline mode");
+        }
+    }
 
     format_err!("{}", msg)
 }

--- a/src/cargo/ops/cargo_generate_lockfile.rs
+++ b/src/cargo/ops/cargo_generate_lockfile.rs
@@ -37,6 +37,10 @@ pub fn update_lockfile(ws: &Workspace, opts: &UpdateOptions)
         bail!("you can't generate a lockfile for an empty workspace.")
     }
 
+    if opts.config.cli_unstable().offline {
+        bail!("you can't update in the offline mode");
+    }
+
     let previous_resolve = match ops::load_pkg_lockfile(ws)? {
         Some(resolve) => resolve,
         None => return generate_lockfile(ws),

--- a/src/cargo/ops/lockfile.rs
+++ b/src/cargo/ops/lockfile.rs
@@ -76,6 +76,10 @@ pub fn write_pkg_lockfile(ws: &Workspace, resolve: &Resolve) -> CargoResult<()> 
     }
 
     if !ws.config().lock_update_allowed() {
+        if ws.config().cli_unstable().offline {
+            bail!("can't update in the offline mode");
+        }
+
         let flag = if ws.config().network_allowed() {"--locked"} else {"--frozen"};
         bail!("the lock file needs to be updated but {} was passed to \
                prevent this", flag);

--- a/src/cargo/ops/registry.rs
+++ b/src/cargo/ops/registry.rs
@@ -263,9 +263,12 @@ pub fn registry(config: &Config,
 
 /// Create a new HTTP handle with appropriate global configuration for cargo.
 pub fn http_handle(config: &Config) -> CargoResult<Easy> {
-    if !config.network_allowed() {
+    if config.frozen() {
         bail!("attempting to make an HTTP request, but --frozen was \
                specified")
+    }
+    if !config.network_allowed() {
+        bail!("can't make HTTP request in the offline mode")
     }
 
     // The timeout option for libcurl by default times out the entire transfer,

--- a/src/cargo/sources/git/source.rs
+++ b/src/cargo/sources/git/source.rs
@@ -152,7 +152,8 @@ impl<'cfg> Source for GitSource<'cfg> {
         let db_path = lock.parent().join("db").join(&self.ident);
 
         if self.config.cli_unstable().offline && !db_path.exists() {
-            bail!("can't checkout from '{}': you are in the offline mode", self.remote.url());
+            bail!("can't checkout from '{}': you are in the offline mode (-Z offline)",
+                self.remote.url());
         }
 
         // Resolve our reference to an actual revision, and check if the

--- a/src/cargo/sources/git/source.rs
+++ b/src/cargo/sources/git/source.rs
@@ -151,6 +151,10 @@ impl<'cfg> Source for GitSource<'cfg> {
 
         let db_path = lock.parent().join("db").join(&self.ident);
 
+        if self.config.cli_unstable().offline && !db_path.exists() {
+            bail!("can't checkout from '{}': you are in the offline mode", self.remote.url());
+        }
+
         // Resolve our reference to an actual revision, and check if the
         // database already has that revision. If it does, we just load a
         // database pinned at that revision, and if we don't we issue an update
@@ -159,7 +163,7 @@ impl<'cfg> Source for GitSource<'cfg> {
         let should_update = actual_rev.is_err() ||
                             self.source_id.precise().is_none();
 
-        let (db, actual_rev) = if should_update {
+        let (db, actual_rev) = if should_update && !self.config.cli_unstable().offline {
             self.config.shell().status("Updating",
                 format!("git repository `{}`", self.remote.url()))?;
 

--- a/src/cargo/sources/git/utils.rs
+++ b/src/cargo/sources/git/utils.rs
@@ -615,9 +615,12 @@ pub fn fetch(repo: &mut git2::Repository,
              url: &Url,
              refspec: &str,
              config: &Config) -> CargoResult<()> {
-    if !config.network_allowed() {
+    if config.frozen() {
         bail!("attempting to update a git repository, but --frozen \
                was specified")
+    }
+    if !config.network_allowed() {
+        bail!("can't update a git repository in the offline mode")
     }
 
     // If we're fetching from github, attempt github's special fast path for

--- a/src/cargo/sources/registry/index.rs
+++ b/src/cargo/sources/registry/index.rs
@@ -110,13 +110,20 @@ impl<'cfg> RegistryIndex<'cfg> {
                                 .map(|s| s.trim())
                                 .filter(|l| !l.is_empty());
 
+            let online = !self.config.cli_unstable().offline;
             // Attempt forwards-compatibility on the index by ignoring
             // everything that we ourselves don't understand, that should
             // allow future cargo implementations to break the
             // interpretation of each line here and older cargo will simply
             // ignore the new lines.
             ret.extend(lines.filter_map(|line| {
-                self.parse_registry_package(line).ok()
+                self.parse_registry_package(line).ok().and_then(|v|{
+                    if online || load.is_crate_downloaded(v.0.package_id()) {
+                        Some(v)
+                    } else {
+                        None
+                    }
+                })
             }));
 
             Ok(())

--- a/src/cargo/sources/registry/mod.rs
+++ b/src/cargo/sources/registry/mod.rs
@@ -249,6 +249,8 @@ pub trait RegistryData {
     fn download(&mut self,
                 pkg: &PackageId,
                 checksum: &str) -> CargoResult<FileLock>;
+
+    fn is_crate_downloaded(&self, _pkg: &PackageId) -> bool { true }
 }
 
 mod index;

--- a/src/cargo/util/config.rs
+++ b/src/cargo/util/config.rs
@@ -504,7 +504,11 @@ impl Config {
     }
 
     pub fn network_allowed(&self) -> bool {
-        !self.frozen
+        !self.frozen() && !self.cli_unstable().offline
+    }
+
+    pub fn frozen(&self) -> bool {
+        self.frozen
     }
 
     pub fn lock_update_allowed(&self) -> bool {

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -897,13 +897,10 @@ fn cargo_compile_with_downloaded_dependency_with_offline() {
 
     assert_that(p2.cargo("build").masquerade_as_nightly_cargo().arg("-Zoffline"),
                 execs().with_status(0)
-                    .with_stderr_does_not_contain("Updating registry")
-                    .with_stderr_does_not_contain("Downloading")
                     .with_stderr(format!("\
 [COMPILING] present_dep v1.2.3
-[COMPILING] bar v0.1.0 ({url})
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]",
-                                         url = p2.url())));
+[COMPILING] bar v0.1.0 ([..])
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]")));
 
 }
 
@@ -923,13 +920,14 @@ fn cargo_compile_offline_not_try_update() {
 
     assert_that(p.cargo("build").masquerade_as_nightly_cargo().arg("-Zoffline"),
                 execs().with_status(101)
-                    .with_stderr_does_not_contain("Updating registry")
-                    .with_stderr_does_not_contain("Downloading")
                     .with_stderr("\
 error: no matching package named `not_cached_dep` found (required by `bar`)
 location searched: registry `[..]`
 version required: ^1.2.5
-perhaps an error occurred because you are using the offline mode"));
+As a reminder, you're using offline mode (-Z offline) \
+which can sometimes cause surprising resolution failures, \
+if this error is too confusing you may with to retry \
+without the offline flag."));
 }
 
 #[test]
@@ -987,16 +985,15 @@ fn main(){
 }")
         .build();
 
-    assert_that(p2.cargo("build").masquerade_as_nightly_cargo().arg("-Zoffline"),
+    assert_that(p2.cargo("run").masquerade_as_nightly_cargo().arg("-Zoffline"),
                 execs().with_status(0)
                     .with_stderr(format!("\
 [COMPILING] present_dep v1.2.3
 [COMPILING] foo v0.1.0 ({url})
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]",
-                                         url = p2.url())));
-
-    assert_that(process(&p2.bin("foo")),
-                execs().with_status(0).with_stdout("1.2.3"));
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+     Running `[..]`", url = p2.url()))
+                    .with_stdout("1.2.3")
+    );
 }
 
 #[test]
@@ -1033,13 +1030,14 @@ fn compile_offline_while_transitive_dep_not_cached() {
 
     assert_that(p.cargo("build").masquerade_as_nightly_cargo().arg("-Zoffline"),
         execs().with_status(101)
-            .with_stderr_does_not_contain("Updating registry")
-            .with_stderr_does_not_contain("Downloading")
             .with_stderr("\
 error: no matching package named `bar` found (required by `foo`)
 location searched: registry `[..]`
 version required: = 1.0.0
-perhaps an error occurred because you are using the offline mode"));
+As a reminder, you're using offline mode (-Z offline) \
+which can sometimes cause surprising resolution failures, \
+if this error is too confusing you may with to retry \
+without the offline flag."));
 }
 
 #[test]

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -15,6 +15,7 @@ use cargotest::support::paths::{CargoPathExt,root};
 use cargotest::support::{ProjectBuilder};
 use cargotest::support::{project, execs, main_file, basic_bin_manifest};
 use cargotest::support::registry::Package;
+use cargotest::ChannelChanger;
 use hamcrest::{assert_that, existing_file, existing_dir, is_not};
 use tempdir::TempDir;
 
@@ -827,6 +828,218 @@ Did you mean `a`?"));
 [ERROR] no example target named `a.rs`
 
 Did you mean `a`?"));
+}
+
+#[test]
+fn cargo_compile_path_with_offline() {
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [package]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+
+            [dependencies.bar]
+            path = "bar"
+        "#)
+        .file("src/lib.rs", "")
+        .file("bar/Cargo.toml", r#"
+            [package]
+            name = "bar"
+            version = "0.0.1"
+            authors = []
+        "#)
+        .file("bar/src/lib.rs", "")
+        .build();
+
+    assert_that(p.cargo("build").masquerade_as_nightly_cargo().arg("-Zoffline"),
+                execs().with_status(0));
+}
+
+#[test]
+fn cargo_compile_with_downloaded_dependency_with_offline() {
+    Package::new("present_dep", "1.2.3")
+        .file("Cargo.toml", r#"
+            [project]
+            name = "present_dep"
+            version = "1.2.3"
+        "#)
+        .file("src/lib.rs", "")
+        .publish();
+
+    {
+        // make package downloaded
+        let p = project("foo")
+            .file("Cargo.toml", r#"
+            [project]
+            name = "foo"
+            version = "0.1.0"
+
+            [dependencies]
+            present_dep = "1.2.3"
+        "#)
+            .file("src/lib.rs", "")
+            .build();
+        assert_that(p.cargo("build"),execs().with_status(0));
+    }
+
+    let p2 = project("bar")
+        .file("Cargo.toml", r#"
+            [project]
+            name = "bar"
+            version = "0.1.0"
+
+            [dependencies]
+            present_dep = "1.2.3"
+        "#)
+        .file("src/lib.rs", "")
+        .build();
+
+    assert_that(p2.cargo("build").masquerade_as_nightly_cargo().arg("-Zoffline"),
+                execs().with_status(0)
+                    .with_stderr_does_not_contain("Updating registry")
+                    .with_stderr_does_not_contain("Downloading")
+                    .with_stderr(format!("\
+[COMPILING] present_dep v1.2.3
+[COMPILING] bar v0.1.0 ({url})
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]",
+                                         url = p2.url())));
+
+}
+
+#[test]
+fn cargo_compile_offline_not_try_update() {
+    let p = project("bar")
+        .file("Cargo.toml", r#"
+            [project]
+            name = "bar"
+            version = "0.1.0"
+
+            [dependencies]
+            not_cached_dep = "1.2.5"
+        "#)
+        .file("src/lib.rs", "")
+        .build();
+
+    assert_that(p.cargo("build").masquerade_as_nightly_cargo().arg("-Zoffline"),
+                execs().with_status(101)
+                    .with_stderr_does_not_contain("Updating registry")
+                    .with_stderr_does_not_contain("Downloading")
+                    .with_stderr("\
+error: no matching package named `not_cached_dep` found (required by `bar`)
+location searched: registry `[..]`
+version required: ^1.2.5
+perhaps an error occurred because you are using the offline mode"));
+}
+
+#[test]
+fn compile_offline_without_maxvers_cached(){
+    Package::new("present_dep", "1.2.1").publish();
+    Package::new("present_dep", "1.2.2").publish();
+
+    Package::new("present_dep", "1.2.3")
+        .file("Cargo.toml", r#"
+            [project]
+            name = "present_dep"
+            version = "1.2.3"
+        "#)
+        .file("src/lib.rs", r#"pub fn get_version()->&'static str {"1.2.3"}"#)
+        .publish();
+
+    Package::new("present_dep", "1.2.5")
+        .file("Cargo.toml", r#"
+            [project]
+            name = "present_dep"
+            version = "1.2.5"
+        "#)
+        .file("src/lib.rs", r#"pub fn get_version(){"1.2.5"}"#)
+        .publish();
+
+    {
+        // make package cached
+        let p = project("foo")
+            .file("Cargo.toml", r#"
+            [project]
+            name = "foo"
+            version = "0.1.0"
+
+            [dependencies]
+            present_dep = "=1.2.3"
+        "#)
+            .file("src/lib.rs", "")
+            .build();
+        assert_that(p.cargo("build"),execs().with_status(0));
+    }
+
+    let p2 = project("foo")
+        .file("Cargo.toml", r#"
+            [project]
+            name = "foo"
+            version = "0.1.0"
+
+            [dependencies]
+            present_dep = "1.2"
+        "#)
+        .file("src/main.rs", "\
+extern crate present_dep;
+fn main(){
+    println!(\"{}\", present_dep::get_version());
+}")
+        .build();
+
+    assert_that(p2.cargo("build").masquerade_as_nightly_cargo().arg("-Zoffline"),
+                execs().with_status(0)
+                    .with_stderr(format!("\
+[COMPILING] present_dep v1.2.3
+[COMPILING] foo v0.1.0 ({url})
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]",
+                                         url = p2.url())));
+
+    assert_that(process(&p2.bin("foo")),
+                execs().with_status(0).with_stdout("1.2.3"));
+}
+
+#[test]
+fn compile_offline_while_transitive_dep_not_cached() {
+    let bar = Package::new("bar", "1.0.0");
+    let bar_path = bar.archive_dst();
+    bar.publish();
+
+    let mut content = Vec::new();
+
+    let mut file = File::open(bar_path.clone()).ok().unwrap();
+    let _ok = file.read_to_end(&mut content).ok().unwrap();
+    drop(file);
+    drop(File::create(bar_path.clone()).ok().unwrap() );
+
+    Package::new("foo", "0.1.0").dep("bar", "1.0.0").publish();
+
+    let p = project("transitive_load_test")
+        .file("Cargo.toml", r#"
+            [project]
+            name = "transitive_load_test"
+            version = "0.0.1"
+
+            [dependencies]
+            foo = "0.1.0"
+        "#)
+        .file("src/main.rs", "fn main(){}")
+        .build();
+
+    // simulate download foo, but fail to download bar
+    let _out = p.cargo("build").exec_with_output();
+
+    drop( File::create(bar_path).ok().unwrap().write_all(&content) );
+
+    assert_that(p.cargo("build").masquerade_as_nightly_cargo().arg("-Zoffline"),
+        execs().with_status(101)
+            .with_stderr_does_not_contain("Updating registry")
+            .with_stderr_does_not_contain("Downloading")
+            .with_stderr("\
+error: no matching package named `bar` found (required by `foo`)
+location searched: registry `[..]`
+version required: = 1.0.0
+perhaps an error occurred because you are using the offline mode"));
 }
 
 #[test]

--- a/tests/git.rs
+++ b/tests/git.rs
@@ -97,7 +97,6 @@ fn cargo_compile_forbird_git_httpsrepo_offline() {
 
     assert_that(p.cargo("build").masquerade_as_nightly_cargo().arg("-Zoffline"),
                 execs().with_status(101).
-                    with_stderr_does_not_contain("[UPDATING] git repository [..]").
                     with_stderr("\
 error: failed to load source for a dependency on `dep1`
 
@@ -105,7 +104,7 @@ Caused by:
   Unable to update https://github.com/some_user/dep1.git
 
 Caused by:
-  can't checkout from 'https://github.com/some_user/dep1.git': you are in the offline mode"));
+  can't checkout from 'https://github.com/some_user/dep1.git': you are in the offline mode (-Z offline)"));
 }
 
 

--- a/tests/registry.rs
+++ b/tests/registry.rs
@@ -553,6 +553,26 @@ fn update_lockfile() {
 }
 
 #[test]
+fn update_offline(){
+    use cargotest::ChannelChanger;
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [project]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+
+            [dependencies]
+            bar = "*"
+        "#)
+        .file("src/main.rs", "fn main() {}")
+        .build();
+    assert_that(p.cargo("update").masquerade_as_nightly_cargo().arg("-Zoffline"),
+    execs().with_status(101).
+        with_stderr("error: you can't update in the offline mode[..]"));
+}
+
+#[test]
 fn dev_dependency_not_used() {
     let p = project("foo")
         .file("Cargo.toml", r#"


### PR DESCRIPTION
This PR is implementation of the #4686 (without "Populating the global cache" feature)