### PR TITLE
Break crate-descriptions at char-, not byte-boundary, avoiding a panic

### DIFF
--- a/src/cargo/ops/registry.rs
+++ b/src/cargo/ops/registry.rs
@@ -1,4 +1,4 @@
-use std::env;
+use std::{cmp, env};
 use std::fs::{self, File};
 use std::iter::repeat;
 use std::time::Duration;
@@ -455,12 +455,16 @@ pub fn search(query: &str,
               index: Option<String>,
               limit: u8,
               reg: Option<String>) -> CargoResult<()> {
-    fn truncate_with_ellipsis(s: &str, max_length: usize) -> String {
-        if s.len() < max_length {
-            s.to_string()
-        } else {
-            format!("{}…", &s[..max_length - 1])
+    fn truncate_with_ellipsis(s: &str, max_width: usize) -> String {
+        // We should truncate at grapheme-boundary and compute character-widths,
+        // yet the dependencies on unicode-segmentation and unicode-width are
+        // not worth it.
+        let mut chars = s.chars();
+        let mut prefix = (&mut chars).take(max_width - 1).collect::<String>();
+        if chars.next().is_some() {
+            prefix.push('…');
         }
+        prefix
     }
 
     let (mut registry, _) = registry(config, None, index, reg)?;
@@ -468,19 +472,23 @@ pub fn search(query: &str,
         CargoError::from(format!("failed to retrieve search results from the registry: {}", e))
     })?;
 
-    let list_items = crates.iter()
-        .map(|krate| (
-            format!("{} = \"{}\"", krate.name, krate.max_version),
-            krate.description.as_ref().map(|desc|
-                truncate_with_ellipsis(&desc.replace("\n", " "), 128))
-        ))
-        .collect::<Vec<_>>();
-    let description_margin = list_items.iter()
-        .map(|&(ref left, _)| left.len() + 4)
-        .max()
-        .unwrap_or(0);
+    let names = crates.iter()
+        .map(|krate| format!("{} = \"{}\"", krate.name, krate.max_version))
+        .collect::<Vec<String>>();
 
-    for (name, description) in list_items.into_iter() {
+    let description_margin = names.iter()
+        .map(|s| s.len() + 4)
+        .max()
+        .unwrap_or_default();
+
+    let description_length = cmp::max(80, 128 - description_margin);
+
+    let descriptions = crates.iter()
+        .map(|krate|
+            krate.description.as_ref().map(|desc|
+                truncate_with_ellipsis(&desc.replace("\n", " "), description_length)));
+
+    for (name, description) in names.into_iter().zip(descriptions) {
         let line = match description {
             Some(desc) => {
                 let space = repeat(' ').take(description_margin - name.len())


### PR DESCRIPTION
Fixes #4771. The basic panicking-problem could be fixed by truncating at `char`- instead of `byte`-boundary. This PR takes the long route and uses the unicode-width to always truncate at grapheme-boundary, which should be visually correct in more cases. It adds two extra (extremely common) dependencies to Cargo, though. I have no strong opinions if this is worth it.

While truncating the descriptions, we now also take the length of the names-column into account, including margin, run a little shorter, and have them all of the same total true length.

Before
```
$ cargo search serde
serde = "1.0.23"                      # A generic serialization/deserialization framework
serde_json = "1.0.7"                  # A JSON serialization file format
serde_derive_internals = "0.17.0"     # AST representation used by Serde derive macros. Unstable.
serde_yaml = "0.7.3"                  # YAML support for Serde
serde_derive = "1.0.23"               # Macros 1.1 implementation of #[derive(Serialize, Deserialize)]
serde_test = "1.0.23"                 # Token De/Serializer for testing De/Serialize implementations
serde_bytes = "0.10.2"                # Optimized handling of `&[u8]` and `Vec<u8>` for Serde
serde_millis = "0.1.1"                #     A serde wrapper that stores integer millisecond value for timestamps     and durations (used similarly to serde_bytes) 
serde_codegen_internals = "0.14.2"    # AST representation used by Serde codegen. Unstable.
courier = "0.3.1"                     # Utility to make it easier to send and receive data when using the Rocket framework.
... and 275 crates more (use --limit N to see more)
```

After
```
$ cargo search serde
serde = "1.0.23"                      # A generic serialization/deserialization framework
serde_json = "1.0.7"                  # A JSON serialization file format
serde_derive_internals = "0.17.0"     # AST representation used by Serde derive macros. Unstable.
serde_yaml = "0.7.3"                  # YAML support for Serde
serde_derive = "1.0.23"               # Macros 1.1 implementation of #[derive(Serialize, Deserialize)]
serde_test = "1.0.23"                 # Token De/Serializer for testing De/Serialize implementations
serde_bytes = "0.10.2"                # Optimized handling of `&[u8]` and `Vec<u8>` for Serde
serde_millis = "0.1.1"                #     A serde wrapper that stores integer millisecond value for …
serde_codegen_internals = "0.14.2"    # AST representation used by Serde codegen. Unstable.
courier = "0.3.1"                     # Utility to make it easier to send and receive data when using …
... and 275 crates more (use --limit N to see more)
```