### PR TITLE
Fix an infinite loop in error reporting

### DIFF
--- a/src/cargo/core/resolver/mod.rs
+++ b/src/cargo/core/resolver/mod.rs
@@ -118,21 +118,26 @@ struct Candidate {
 impl Resolve {
     /// Resolves one of the paths from the given dependent package up to
     /// the root.
-    pub fn path_to_top(&self, pkg: &PackageId) -> Vec<&PackageId> {
-        let mut result = Vec::new();
-        let mut pkg = pkg;
-        while let Some(pulling) = self.graph
-                                    .get_nodes()
-                                    .iter()
-                                    .filter_map(|(pulling, pulled)|
-                                                if pulled.contains(pkg) {
-                                                    Some(pulling)
-                                                } else {
-                                                    None
-                                                })
-                                    .nth(0) {
-            result.push(pulling);
-            pkg = pulling;
+    pub fn path_to_top<'a>(&'a self, mut pkg: &'a PackageId) -> Vec<&'a PackageId> {
+        // Note that this implementation isn't the most robust per se, we'll
+        // likely have to tweak this over time. For now though it works for what
+        // it's used for!
+        let mut result = vec![pkg];
+        let first_pkg_depending_on = |pkg: &PackageId| {
+            self.graph.get_nodes()
+                .iter()
+                .filter(|&(_node, adjacent)| adjacent.contains(pkg))
+                .next()
+                .map(|p| p.0)
+        };
+        while let Some(p) = first_pkg_depending_on(pkg) {
+            // Note that we can have "cycles" introduced through dev-dependency
+            // edges, so make sure we don't loop infinitely.
+            if result.contains(&p) {
+                break
+            }
+            result.push(p);
+            pkg = p;
         }
         result
     }

--- a/src/cargo/ops/cargo_rustc/links.rs
+++ b/src/cargo/ops/cargo_rustc/links.rs
@@ -31,25 +31,21 @@ impl<'a> Links<'a> {
 
             let describe_path = |pkgid: &PackageId| -> String {
                 let dep_path = resolve.path_to_top(pkgid);
-                if dep_path.is_empty() {
-                    String::from("The root-package ")
-                } else {
-                    let mut dep_path_desc = format!("Package `{}`\n", pkgid);
-                    for dep in dep_path {
-                        write!(dep_path_desc,
-                               "    ... which is depended on by `{}`\n",
-                               dep).unwrap();
-                    }
-                    dep_path_desc
+                let mut dep_path_desc = format!("package `{}`", dep_path[0]);
+                for dep in dep_path.iter().skip(1) {
+                    write!(dep_path_desc,
+                           "\n    ... which is depended on by `{}`",
+                           dep).unwrap();
                 }
+                dep_path_desc
             };
 
-            bail!("Multiple packages link to native library `{}`. \
-                   A native library can be linked only once.\n\
+            bail!("multiple packages link to native library `{}`, \
+                   but a native library can be linked only once\n\
                    \n\
-                   {}links to native library `{}`.\n\
+                   {}\nlinks to native library `{}`\n\
                    \n\
-                   {}also links to native library `{}`.",
+                   {}\nalso links to native library `{}`",
                   lib,
                   describe_path(prev), lib,
                   describe_path(pkg), lib)


### PR DESCRIPTION
The `path_to_root` function unfortunately didn't account for cycles in the
dependency graph introduced through dev-dependencies, so if a cycle was present
then the function would infinitely loop pushing items onto a vector.

This commit fixes the infinite loop and also touches up the reporting to be a
little more consistent with the rest of Cargo