### PR TITLE
Defer bailing out workspace root probing

### DIFF
--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -333,9 +333,6 @@ impl<'cfg> Workspace<'cfg> {
         }
 
         for path in paths::ancestors(manifest_path).skip(2) {
-            if self.config.home() == path {
-                return Ok(None);
-            }
             let ances_manifest_path = path.join("Cargo.toml");
             debug!("find_root - trying {}", ances_manifest_path.display());
             if ances_manifest_path.exists() {
@@ -353,6 +350,15 @@ impl<'cfg> Workspace<'cfg> {
                     }
                     WorkspaceConfig::Member { .. } => {}
                 }
+            }
+
+            // Don't walk across `CARGO_HOME` when we're looking for the
+            // workspace root. Sometimes a project will be organized with
+            // `CARGO_HOME` pointing inside of the workspace root or in the
+            // current project, but we don't want to mistakenly try to put
+            // crates.io crates into the workspace by accident.
+            if self.config.home() == path {
+                break
             }
         }
 

--- a/tests/workspaces.rs
+++ b/tests/workspaces.rs
@@ -1782,3 +1782,28 @@ fn include_and_exclude() {
     assert_that(&p.root().join("foo/bar/target"), existing_dir());
 }
 */
+
+#[test]
+fn cargo_home_at_root_works() {
+    let p = project("lib")
+        .file("Cargo.toml", r#"
+            [package]
+            name = "lib"
+            version = "0.1.0"
+
+            [workspace]
+            members = ["a"]
+        "#)
+        .file("src/lib.rs", "")
+        .file("a/Cargo.toml", r#"
+            [package]
+            name = "a"
+            version = "0.1.0"
+        "#)
+        .file("a/src/lib.rs", "");
+    let p = p.build();
+
+    assert_that(p.cargo("build"), execs().with_status(0));
+    assert_that(p.cargo("build").arg("--frozen").env("CARGO_HOME", p.root()),
+                execs().with_status(0));
+}


### PR DESCRIPTION
This commit alters the logic to bail out on probing for `CARGO_HOME` to
do it a little later rather than early on in the loop iteration, notably
allowing members to reside in `CARGO_HOME` itself.

Closes #4815