### PR TITLE
Ignore files in sources::DirectorySource's root

### DIFF
--- a/src/cargo/sources/directory.rs
+++ b/src/cargo/sources/directory.rs
@@ -82,6 +82,10 @@ impl<'cfg> Source for DirectorySource<'cfg> {
             let entry = entry?;
             let path = entry.path();
 
+            if !path.is_dir() {
+                continue
+            }
+
             // Ignore hidden/dot directories as they typically don't contain
             // crates and otherwise may conflict with a VCS
             // (rust-lang/cargo#3414).


### PR DESCRIPTION
We assume that a DirectorySource's root only contains further
directories. While trying to explore those, Cargo would trip
and crash over innocent files. Ignore regular files to fix that.

Fixes #4811