### PR TITLE
Remove overflow checks to eliminate rust build warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,3 @@ hamcrest = "=0.1.1"
 name = "cargo"
 test = false
 doc = false
-
-[profile.release]
-overflow-checks = true


### PR DESCRIPTION
Although the checks are desirable, they cause warnings in the rust build (due to workspaces) which could cause needless concern. The checks aren't too important, so just disable them.

r? @alexcrichton (as discussed)