### PR TITLE
Don’t swallow virtual manifest parsing errors

### DIFF
--- a/tests/build.rs
+++ b/tests/build.rs
@@ -95,7 +95,7 @@ fn cargo_compile_with_invalid_manifest() {
 [ERROR] failed to parse manifest at `[..]`
 
 Caused by:
-  no `package` section found.
+  virtual manifests must be configured with [workspace]
 "))
 }
 

--- a/tests/metadata.rs
+++ b/tests/metadata.rs
@@ -555,7 +555,7 @@ fn cargo_metadata_with_invalid_manifest() {
 [ERROR] failed to parse manifest at `[..]`
 
 Caused by:
-  no `package` section found."))
+  virtual manifests must be configured with [workspace]"))
 }
 
 const MANIFEST_OUTPUT: &'static str=


### PR DESCRIPTION
Before this change, `cargo::util::toml::do_read_manifest` ended like this:

```rust
    return match TomlManifest::to_real_manifest(/* … */) {
        Ok(/* … */) => /* … */,
        Err(e) => match TomlManifest::to_virtual_manifest(/* … */) {
            Ok(/* … */) => /* … */,
            Err(..) => Err(e),
        }
    };
```

Errors returned by `to_virtual_manifest` were always ignored. As a result, when something was wrong in a virtual manifest, Cargo would unhelpfully exit with no more output than:

```
error: failed to parse manifest at `/tmp/a/Cargo.toml`

Caused by:
  no `package` section found.
```

http://doc.crates.io/manifest.html#virtual-manifest defines a virtual manifest as “the `package` table is not present”, so let’s first determine if a manifest is virtual based on that criteria, and then only call one of the two methods.

Although it is not mentioned in the documentation, `[project]` seems to be in the code an alias for `[package]`. So let’s preserve that here too.