### PR TITLE
util/progress: no progress reporting in dumb terminals

### DIFF
--- a/src/cargo/util/progress.rs
+++ b/src/cargo/util/progress.rs
@@ -1,4 +1,5 @@
 use std::cmp;
+use std::env;
 use std::iter;
 use std::time::{Instant, Duration};
 
@@ -20,8 +21,12 @@ struct State<'cfg> {
 
 impl<'cfg> Progress<'cfg> {
     pub fn new(name: &str, cfg: &'cfg Config) -> Progress<'cfg> {
-        // no progress if `-q` is passed as, well, we're supposed to be quiet
-        if cfg.shell().verbosity() == Verbosity::Quiet {
+        // report no progress when -q (for quiet) or TERM=dumb are set
+        let dumb = match env::var("TERM") {
+            Ok(term) => term == "dumb",
+            Err(_) => false,
+        };
+        if cfg.shell().verbosity() == Verbosity::Quiet || dumb {
             return Progress { state: None }
         }
 


### PR DESCRIPTION
cargo should not assume that all terminals have direct access to
the terminal.  Dumb terminals are those that can interpret only a
limited number of control codes (CR, LF, &c.) and the escape codes
used by the progress bar breaks output in these by asserting control
over the cursor position to draw a bar.

A dumb terminal is identified by the TERM output variable being set to
"dumb".  This adds a direct check for this in src/cargo/util/progress.rs
because TERM=dumb does not imply the same as the -q flag.