### PR TITLE
Make .cargo/credentials a subset of .cargo/config

### DIFF
--- a/src/cargo/ops/registry.rs
+++ b/src/cargo/ops/registry.rs
@@ -220,7 +220,7 @@ pub fn registry_configuration(config: &Config,
     let (index, token) = match registry {
         Some(registry) => {
             (Some(config.get_registry_index(&registry)?.to_string()),
-             config.get_string(&format!("registry.{}.token", registry))?.map(|p| p.val))
+             config.get_string(&format!("registries.{}.token", registry))?.map(|p| p.val))
         }
         None => {
             // Checking out for default index and token

--- a/tests/cargotest/support/publish.rs
+++ b/tests/cargotest/support/publish.rs
@@ -12,7 +12,7 @@ pub fn setup() -> Repository {
     t!(fs::create_dir_all(config.parent().unwrap()));
     t!(t!(File::create(&config)).write_all(format!(r#"
         [registry]
-            token = "api-token"
+        token = "api-token"
 
         [registries.alternative]
         index = "{registry}"
@@ -21,7 +21,7 @@ pub fn setup() -> Repository {
     let credentials = paths::root().join("home/.cargo/credentials");
     t!(fs::create_dir_all(credentials.parent().unwrap()));
     t!(t!(File::create(&credentials)).write_all(br#"
-        [alternative]
+        [registries.alternative]
         token = "api-token"
     "#));
 

--- a/tests/login.rs
+++ b/tests/login.rs
@@ -53,7 +53,9 @@ fn check_token(expected_token: &str, registry: Option<&str>) -> bool {
         // A registry has been provided, so check that the token exists in a
         // table for the registry.
         (Some(registry), toml::Value::Table(table)) => {
-            table.get(registry).and_then(|registry_table| {
+            table.get("registries")
+                    .and_then(|registries_table| registries_table.get(registry))
+                    .and_then(|registry_table| {
                 match registry_table.get("token") {
                     Some(&toml::Value::String(ref token)) => Some(token.as_str().to_string()),
                     _ => None,
@@ -62,7 +64,9 @@ fn check_token(expected_token: &str, registry: Option<&str>) -> bool {
         },
         // There is no registry provided, so check the global token instead.
         (None, toml::Value::Table(table)) => {
-            table.get("token").and_then(|v| {
+            table.get("registry")
+                    .and_then(|registry_table| registry_table.get("token"))
+                    .and_then(|v| {
                 match v {
                     &toml::Value::String(ref token) => Some(token.as_str().to_string()),
                     _ => None,


### PR DESCRIPTION
Previously, .cargo/credentials looked like

```toml
token = "..."

[my-registry]
token = "..."
```

And was simply merged into the `registry` block of .cargo/config. This
meant that custom registry tokens were under
`registry.my-registry.token` rather than `registries.my-registry.token`
which is where the index was located, and that you couldn't have a
custom registry named `token` or it'd conflict with the token for the
default registry.

This commit changes things such that .cargo/credentials has the same
layout as .cargo/config, but only contains token values. For backwards
compatibility, we move `token` to `registry.token` when parsing.