### PR TITLE
Add top level documentation comment template to cargo new

### DIFF
--- a/src/cargo/ops/cargo_new.rs
+++ b/src/cargo/ops/cargo_new.rs
@@ -504,17 +504,17 @@ authors = [{}]
         let default_file_content : &[u8] = if i.bin {
             b"\
 //! This is the top-level module documentation in src/main.rs.
+//!
 //! This text appears on the front page of your crate's documentation;
 //! preview it by running `cargo doc --open`.
 //!
-//! # Example
+//! # Examples
 //!
 //! This is a great place to add an example of how to use your crate!
 //!
 //! ```
 //! assert(true);
 //! ```
-
 fn main() {
     println!(\"Hello, world!\");
 }
@@ -522,17 +522,17 @@ fn main() {
         } else {
             b"\
 //! This is the top-level module documentation in src/lib.rs.
+//!
 //! This text appears on the front page of your crate's documentation;
 //! preview it by running `cargo doc --open`.
 //!
-//! # Example
+//! # Examples
 //!
 //! This is a great place to add an example of how to use your crate!
 //!
 //! ```
 //! assert(true);
 //! ```
-
 #[cfg(test)]
 mod tests {
     #[test]

--- a/src/cargo/ops/cargo_new.rs
+++ b/src/cargo/ops/cargo_new.rs
@@ -503,12 +503,36 @@ authors = [{}]
 
         let default_file_content : &[u8] = if i.bin {
             b"\
+//! This is the top-level module documentation in src/main.rs.
+//! This text appears on the front page of your crate's documentation;
+//! preview it by running `cargo doc --open`.
+//!
+//! # Example
+//!
+//! This is a great place to add an example of how to use your crate!
+//!
+//! ```
+//! assert(true);
+//! ```
+
 fn main() {
     println!(\"Hello, world!\");
 }
 "
         } else {
             b"\
+//! This is the top-level module documentation in src/lib.rs.
+//! This text appears on the front page of your crate's documentation;
+//! preview it by running `cargo doc --open`.
+//!
+//! # Example
+//!
+//! This is a great place to add an example of how to use your crate!
+//!
+//! ```
+//! assert(true);
+//! ```
+
 #[cfg(test)]
 mod tests {
     #[test]


### PR DESCRIPTION
Work on #3506. 

So the thing I'm not sure about is what the documentation comment template should look like with binary projects, since the way documentation is used for those projects may be different to a library. An example that comes to mind is perhaps prodding the user to list some sample commands the binary crate could run. 

@sanmai-NL @carols10cents 