### PR TITLE
Add support for fetching git refspecs

### DIFF
--- a/src/bin/install.rs
+++ b/src/bin/install.rs
@@ -30,6 +30,7 @@ pub struct Options {
     flag_branch: Option<String>,
     flag_tag: Option<String>,
     flag_rev: Option<String>,
+    flag_refspec: Option<String>,
 
     flag_path: Option<String>,
     #[serde(rename = "flag_Z")]
@@ -50,6 +51,7 @@ Specifying what crate to install:
     --branch BRANCH           Branch to use when installing from git
     --tag TAG                 Tag to use when installing from git
     --rev SHA                 Specific commit to use when installing from git
+    --refspec REFSPEC         Remote refspec to use when installing from git
     --path PATH               Filesystem path to local crate to install
 
 Build and install options:
@@ -146,6 +148,8 @@ pub fn execute(options: Options, config: &mut Config) -> CliResult {
             GitReference::Tag(tag)
         } else if let Some(rev) = options.flag_rev {
             GitReference::Rev(rev)
+        } else if let Some(refspec) = options.flag_refspec {
+            GitReference::Refspec(refspec)
         } else {
             GitReference::Branch("master".to_string())
         };

--- a/src/cargo/core/source/source_id.rs
+++ b/src/cargo/core/source/source_id.rs
@@ -61,6 +61,8 @@ pub enum GitReference {
     Branch(String),
     /// from a specific revision
     Rev(String),
+    /// from a specific refspec
+    Refspec(String),
 }
 
 impl SourceId {
@@ -107,6 +109,7 @@ impl SourceId {
 
                         "rev" => reference = GitReference::Rev(v.into_owned()),
                         "tag" => reference = GitReference::Tag(v.into_owned()),
+                        "refspec" => reference = GitReference::Refspec(v.into_owned()),
                         _ => {}
                     }
                 }
@@ -502,6 +505,7 @@ impl<'a> fmt::Display for PrettyRef<'a> {
             GitReference::Branch(ref b) => write!(f, "branch={}", b),
             GitReference::Tag(ref s) => write!(f, "tag={}", s),
             GitReference::Rev(ref s) => write!(f, "rev={}", s),
+            GitReference::Refspec(ref s) => write!(f, "refspec={}", s),
         }
     }
 }

--- a/src/cargo/sources/config.rs
+++ b/src/cargo/sources/config.rs
@@ -177,7 +177,12 @@ restore the source replacement configuration to continue the build
                         None => {
                             match try("rev")? {
                                 Some(b) => GitReference::Rev(b.0.to_string()),
-                                None => GitReference::Branch("master".to_string()),
+                                None => {
+                                    match try("refspec")? {
+                                        Some(b) => GitReference::Refspec(b.0.to_string()),
+                                        None => GitReference::Branch("master".to_string()),
+                                    }
+                                }
                             }
                         }
                     }

--- a/src/cargo/sources/git/source.rs
+++ b/src/cargo/sources/git/source.rs
@@ -165,7 +165,7 @@ impl<'cfg> Source for GitSource<'cfg> {
 
             trace!("updating git source `{:?}`", self.remote);
 
-            let repo = self.remote.checkout(&db_path, self.config)?;
+            let repo = self.remote.checkout(&db_path, &self.reference, self.config)?;
             let rev = repo.rev_for(&self.reference).map_err(Internal::new)?;
             (repo, rev)
         } else {

--- a/src/cargo/sources/git/utils.rs
+++ b/src/cargo/sources/git/utils.rs
@@ -30,6 +30,18 @@ fn serialize_str<T, S>(t: &T, s: S) -> Result<S::Ok, S::Error>
     t.to_string().serialize(s)
 }
 
+fn git_ref_to_fetch_refspec(reference: &GitReference) -> String {
+    if let GitReference::Refspec(ref s) = *reference {
+        if s.starts_with("refs/") {
+            format!("{}:{}", s, s)
+        } else {
+            format!("refs/{}:refs/{}", s, s)
+        }
+    } else {
+        "refs/heads/*:refs/heads/*".to_string()
+    }
+}
+
 impl fmt::Display for GitRevision {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::Display::fmt(&self.0, f)
@@ -91,16 +103,17 @@ impl GitRemote {
         db.rev_for(reference)
     }
 
-    pub fn checkout(&self, into: &Path, cargo_config: &Config) -> CargoResult<GitDatabase> {
+    pub fn checkout(&self, into: &Path, reference: &GitReference, cargo_config: &Config)
+                    -> CargoResult<GitDatabase> {
         let repo = match git2::Repository::open(into) {
             Ok(mut repo) => {
-                self.fetch_into(&mut repo, cargo_config).chain_err(|| {
+                self.fetch_into(&mut repo, reference, cargo_config).chain_err(|| {
                     format!("failed to fetch into {}", into.display())
                 })?;
                 repo
             }
             Err(..) => {
-                self.clone_into(into, cargo_config).chain_err(|| {
+                self.clone_into(into, reference, cargo_config).chain_err(|| {
                     format!("failed to clone into: {}", into.display())
                 })?
             }
@@ -122,19 +135,20 @@ impl GitRemote {
         })
     }
 
-    fn fetch_into(&self, dst: &mut git2::Repository, cargo_config: &Config) -> CargoResult<()> {
+    fn fetch_into(&self, dst: &mut git2::Repository, reference: &GitReference, cargo_config: &Config) -> CargoResult<()> {
         // Create a local anonymous remote in the repository to fetch the url
-        let refspec = "refs/heads/*:refs/heads/*";
-        fetch(dst, &self.url, refspec, cargo_config)
+        let refspec = git_ref_to_fetch_refspec(reference);
+        fetch(dst, &self.url, &refspec, cargo_config)
     }
 
-    fn clone_into(&self, dst: &Path, cargo_config: &Config) -> CargoResult<git2::Repository> {
+    fn clone_into(&self, dst: &Path, reference: &GitReference, cargo_config: &Config) -> CargoResult<git2::Repository> {
         if fs::metadata(&dst).is_ok() {
             fs::remove_dir_all(dst)?;
         }
         fs::create_dir_all(dst)?;
         let mut repo = git2::Repository::init_bare(dst)?;
-        fetch(&mut repo, &self.url, "refs/heads/*:refs/heads/*", cargo_config)?;
+        let refspec = git_ref_to_fetch_refspec(reference);
+        fetch(&mut repo, &self.url, &refspec, cargo_config)?;
         Ok(repo)
     }
 }
@@ -183,6 +197,21 @@ impl GitDatabase {
             }
             GitReference::Rev(ref s) => {
                 let obj = self.repo.revparse_single(s)?;
+                match obj.as_tag() {
+                    Some(tag) => tag.target_id(),
+                    None => obj.id(),
+                }
+            }
+            GitReference::Refspec(ref s) => {
+                if s.contains(':') {
+                    Err(format_err!("refspec `{}` should not contain colon", s))?;
+                }
+                let obj = if s.starts_with("refs/") {
+                    self.repo.revparse_single(s)?
+                } else {
+                    let canon = format!("refs/{}", s);
+                    self.repo.revparse_single(&canon)?
+                };
                 match obj.as_tag() {
                     Some(tag) => tag.target_id(),
                     None => obj.id(),
@@ -251,7 +280,7 @@ impl<'a> GitCheckout<'a> {
     fn fetch(&mut self, cargo_config: &Config) -> CargoResult<()> {
         info!("fetch {}", self.repo.path().display());
         let url = self.database.path.to_url()?;
-        let refspec = "refs/heads/*:refs/heads/*";
+        let refspec = "refs/*:refs/*";
         fetch(&mut self.repo, &url, refspec, cargo_config)?;
         Ok(())
     }
@@ -328,7 +357,7 @@ impl<'a> GitCheckout<'a> {
             };
 
             // Fetch data from origin and reset to the head commit
-            let refspec = "refs/heads/*:refs/heads/*";
+            let refspec = "refs/*:refs/*";
             let url = url.to_url()?;
             fetch(&mut repo, &url, refspec, cargo_config).chain_err(|| {
                 internal(format!("failed to fetch submodule `{}` from {}",

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -186,6 +186,7 @@ pub struct DetailedTomlDependency {
     branch: Option<String>,
     tag: Option<String>,
     rev: Option<String>,
+    refspec: Option<String>,
     features: Option<Vec<String>>,
     optional: Option<bool>,
     #[serde(rename = "default-features")]
@@ -938,14 +939,14 @@ impl TomlDependency {
                     cx.warnings.push(msg)
                 }
 
-                let n_details = [&details.branch, &details.tag, &details.rev]
+                let n_details = [&details.branch, &details.tag, &details.rev, &details.refspec]
                     .iter()
                     .filter(|d| d.is_some())
                     .count();
 
                 if n_details > 1 {
                     let msg = format!("dependency ({}) specification is ambiguous. \
-                                       Only one of `branch`, `tag` or `rev` is allowed. \
+                                       Only one of `branch`, `tag`, `rev`, or `refspec` is allowed. \
                                        This will be considered an error in future versions", name);
                     cx.warnings.push(msg)
                 }
@@ -953,6 +954,7 @@ impl TomlDependency {
                 let reference = details.branch.clone().map(GitReference::Branch)
                     .or_else(|| details.tag.clone().map(GitReference::Tag))
                     .or_else(|| details.rev.clone().map(GitReference::Rev))
+                    .or_else(|| details.refspec.clone().map(GitReference::Refspec))
                     .unwrap_or_else(|| GitReference::Branch("master".to_string()));
                 let loc = git.to_url()?;
                 SourceId::for_git(&loc, reference)?

--- a/tests/bad-config.rs
+++ b/tests/bad-config.rs
@@ -766,7 +766,7 @@ fn ambiguous_git_reference() {
     assert_that(p.cargo("build").arg("-v"),
                 execs().with_stderr_contains("\
 [WARNING] dependency (bar) specification is ambiguous. \
-Only one of `branch`, `tag` or `rev` is allowed. \
+Only one of `branch`, `tag`, `rev`, or `refspec` is allowed. \
 This will be considered an error in future versions
 "));
 }


### PR DESCRIPTION
This would allow e.g. fetching pull requests directly from Github:

```
[dependencies.foo]
git = "https://github.com/user/foo"
refspec = "refs/pull/42/head"
```

The "refs/" prefix is optional.