### PR TITLE
Write invalid data when cloning to force an abort

### DIFF
--- a/tests/git.rs
+++ b/tests/git.rs
@@ -2205,7 +2205,9 @@ fn failed_submodule_checkout() {
 
     let t = thread::spawn(move || {
         while !done2.load(Ordering::SeqCst) {
-            drop(listener.accept());
+            if let Ok((mut socket, _)) = listener.accept() {
+                drop(socket.write_all(b"foo\r\n"));
+            }
         }
     });
 


### PR DESCRIPTION
Otherwise it seems libgit2 isn't ready to handle premature eof? Unclear...