### PR TITLE
Initial addition of airplane mode #4686

### DIFF
--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -232,6 +232,7 @@ impl Features {
 pub struct CliUnstable {
     pub print_im_a_teapot: bool,
     pub unstable_options: bool,
+    pub airplane: bool,
 }
 
 impl CliUnstable {
@@ -262,6 +263,7 @@ impl CliUnstable {
         match k {
             "print-im-a-teapot" => self.print_im_a_teapot = parse_bool(v)?,
             "unstable-options" => self.unstable_options = true,
+            "airplane" => self.airplane = parse_bool(v)?,
             _ => bail!("unknown `-Z` flag specified: {}", k),
         }
 

--- a/src/cargo/core/resolver/mod.rs
+++ b/src/cargo/core/resolver/mod.rs
@@ -380,7 +380,7 @@ pub fn resolve(summaries: &[(Summary, Method)],
         warnings: RcList::new(),
     };
     let _p = profile::start("resolving");
-    let cx = activate_deps_loop(cx, registry, summaries, config)?;
+    let cx = activate_deps_loop(cx, registry, summaries, &config)?;
 
     let mut resolve = Resolve {
         graph: cx.graph(),
@@ -589,7 +589,7 @@ impl RemainingCandidates {
 fn activate_deps_loop<'a>(mut cx: Context<'a>,
                           registry: &mut Registry,
                           summaries: &[(Summary, Method)],
-                          config: Option<&Config>)
+                          config: &Option<&Config>)
                           -> CargoResult<Context<'a>> {
     // Note that a `BinaryHeap` is used for the remaining dependencies that need
     // activation. This heap is sorted such that the "largest value" is the most
@@ -640,7 +640,7 @@ fn activate_deps_loop<'a>(mut cx: Context<'a>,
         // like `Instant::now` by only checking every N iterations of this loop
         // to amortize the cost of the current time lookup.
         ticks += 1;
-        if let Some(config) = config {
+        if let &Some(config) = config {
             if config.shell().is_err_tty() &&
                 !printed &&
                 ticks % 1000 == 0 &&
@@ -722,7 +722,8 @@ fn activate_deps_loop<'a>(mut cx: Context<'a>,
                     None => return Err(activation_error(&cx, registry, &parent,
                                                         &dep,
                                                         cx.prev_active(&dep),
-                                                        &candidates)),
+                                                        &candidates,
+                                                        config)),
                     Some(candidate) => candidate,
                 }
             }
@@ -788,7 +789,8 @@ fn activation_error(cx: &Context,
                     parent: &Summary,
                     dep: &Dependency,
                     prev_active: &[Summary],
-                    candidates: &[Candidate]) -> CargoError {
+                    candidates: &[Candidate],
+                    config: &Option<&Config>) -> CargoError {
     if !candidates.is_empty() {
         let mut msg = format!("failed to select a version for `{}` \
                                (required by `{}`):\n\
@@ -843,7 +845,7 @@ fn activation_error(cx: &Context,
         b.version().cmp(a.version())
     });
 
-    let msg = if !candidates.is_empty() {
+    let mut msg = if !candidates.is_empty() {
         let versions = {
             let mut versions = candidates.iter().take(3).map(|cand| {
                 cand.version().to_string()
@@ -885,6 +887,13 @@ fn activation_error(cx: &Context,
                 dep.source_id(),
                 dep.version_req())
     };
+    // If airplane mode is enabled, then this probably just means that we
+    // haven't downloaded the package yet
+    if let &Some(conf) = config {
+        if conf.cli_unstable().airplane {
+            msg.push_str("\nthis may be failing due to the -Zairplane flag");
+        }
+    }
 
     format_err!("{}", msg)
 }

--- a/src/cargo/ops/cargo_generate_lockfile.rs
+++ b/src/cargo/ops/cargo_generate_lockfile.rs
@@ -37,6 +37,10 @@ pub fn update_lockfile(ws: &Workspace, opts: &UpdateOptions)
         bail!("you can't generate a lockfile for an empty workspace.")
     }
 
+    if !ws.config().network_allowed() {
+        bail!("cannot update when network operations are not allowed.");
+    }
+
     let previous_resolve = match ops::load_pkg_lockfile(ws)? {
         Some(resolve) => resolve,
         None => return generate_lockfile(ws),

--- a/src/cargo/ops/resolve.rs
+++ b/src/cargo/ops/resolve.rs
@@ -44,7 +44,7 @@ pub fn resolve_ws_precisely<'a>(ws: &Workspace<'a>,
     let resolve = if ws.require_optional_deps() {
         // First, resolve the root_package's *listed* dependencies, as well as
         // downloading and updating all remotes and such.
-        let resolve = resolve_with_registry(ws, &mut registry, false)?;
+        let resolve = resolve_with_registry(ws, &mut registry, true)?;
 
         // Second, resolve with precisely what we're doing. Filter out
         // transitive dependencies if necessary, specify features, handle

--- a/src/cargo/sources/git/source.rs
+++ b/src/cargo/sources/git/source.rs
@@ -159,7 +159,7 @@ impl<'cfg> Source for GitSource<'cfg> {
         let should_update = actual_rev.is_err() ||
                             self.source_id.precise().is_none();
 
-        let (repo, actual_rev) = if should_update {
+        let (repo, actual_rev) = if should_update && self.config.network_allowed() {
             self.config.shell().status("Updating",
                 format!("git repository `{}`", self.remote.url()))?;
 

--- a/src/cargo/sources/git/utils.rs
+++ b/src/cargo/sources/git/utils.rs
@@ -145,7 +145,7 @@ impl GitDatabase {
         let checkout = match git2::Repository::open(dest) {
             Ok(repo) => {
                 let mut checkout = GitCheckout::new(dest, self, rev, repo);
-                if !checkout.is_fresh() {
+                if !checkout.is_fresh() && cargo_config.network_allowed() {
                     checkout.fetch(cargo_config)?;
                     checkout.reset(cargo_config)?;
                     assert!(checkout.is_fresh());

--- a/src/cargo/sources/registry/local.rs
+++ b/src/cargo/sources/registry/local.rs
@@ -102,4 +102,9 @@ impl<'cfg> RegistryData for LocalRegistry<'cfg> {
 
         Ok(crate_file)
     }
+
+    fn is_crate_downloaded(&self, pkg: &PackageId) -> bool {
+        let crate_file = format!("{}-{}.crate", pkg.name(), pkg.version());
+        self.root.open_ro(&crate_file, self.config, "crate file").is_ok()
+    }
 }

--- a/src/cargo/sources/registry/mod.rs
+++ b/src/cargo/sources/registry/mod.rs
@@ -249,6 +249,7 @@ pub trait RegistryData {
     fn download(&mut self,
                 pkg: &PackageId,
                 checksum: &str) -> CargoResult<FileLock>;
+    fn is_crate_downloaded(&self, pkg: &PackageId) -> bool;
 }
 
 mod index;

--- a/src/cargo/util/config.rs
+++ b/src/cargo/util/config.rs
@@ -504,7 +504,7 @@ impl Config {
     }
 
     pub fn network_allowed(&self) -> bool {
-        !self.frozen
+        !(self.frozen || self.cli_unstable().airplane)
     }
 
     pub fn lock_update_allowed(&self) -> bool {

--- a/src/cargo/util/network.rs
+++ b/src/cargo/util/network.rs
@@ -6,7 +6,7 @@ use failure::Error;
 use util::Config;
 use util::errors::{CargoResult, HttpNot200};
 
-fn maybe_spurious(err: &Error) -> bool {
+pub fn maybe_spurious(err: &Error) -> bool {
     for e in err.causes() {
         if let Some(git_err) = e.downcast_ref::<git2::Error>() {
             match git_err.class() {

--- a/tests/cargo-features.rs
+++ b/tests/cargo-features.rs
@@ -242,11 +242,20 @@ error: unknown `-Z` flag specified: arg
 
     assert_that(p.cargo("build")
                  .masquerade_as_nightly_cargo()
+                 .arg("-Zairplane"),
+                execs().with_status(0)
+                       .with_stdout("")
+                       .with_stderr("\
+[COMPILING] a [..]
+[FINISHED] [..]
+"));
+
+    assert_that(p.cargo("build")
+                 .masquerade_as_nightly_cargo()
                  .arg("-Zprint-im-a-teapot"),
                 execs().with_status(0)
                        .with_stdout("im-a-teapot = true\n")
                        .with_stderr("\
-[COMPILING] a [..]
 [FINISHED] [..]
 "));
 }


### PR DESCRIPTION
https://github.com/rust-lang/cargo/issues/4686
Hi all, sorry for the delay in getting this implemented. @alexcrichton thanks again for the amazing write up. I have a lot more time now to go back on forth on this, so I wanted to get the first version of airplane mode up for review. I've implemented everything except for the subcommand for populating the offline cache, which I've wanted to discuss some. There's already been some work in this space:

- https://github.com/est31/cargo-local-serve/blob/master/src/bin/download-all-crates.rs
- https://github.com/C4K3/crates-ectype
- https://github.com/Xion/cargo-download

Additionally, one can already download the crates they want by setting up a cargo project with their desired dependencies, and running something like `cargo update && cargo build`.

We could take the approach of trying to make all of crates accessible offline via some clever caching (@est31 mentioned it's possible to reduce the size of crates to only 3GB), or try to make a better user interface for choosing crates to download. Maybe something like `cargo download --popular 100` to download the 100 most popular crates, or `cargo download $crate` to download the dependencies needed to build a certain crate? 

Also, Happy Holidays 🎅🎉!