### PR TITLE
Update cargo tests for https://github.com/rust-lang/rust/pull/47052

### DIFF
--- a/tests/plugins.rs
+++ b/tests/plugins.rs
@@ -281,7 +281,7 @@ fn native_plugin_dependency_with_custom_ar_linker() {
                 execs().with_stderr_contains("\
 [COMPILING] foo v0.0.1 ([..])
 [RUNNING] `rustc [..] -C ar=nonexistent-ar -C linker=nonexistent-linker [..]`
-[ERROR] could not exec the linker [..]
+[ERROR] [..]linker[..]
 "));
 }
 


### PR DESCRIPTION
This test message currently breaks the build. The old error message was:

```
error: could not exec the linker `cc`: No such file or directory (os error 2)
  |
  = note: "cc" "-Wl,--as-needed" "-Wl,-z,noexecstack" "-m64" "-L" "/home/felix/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib" "hello.hello0.rcgu.o" "hello.hello1.rcgu.o" "-o" "hello" "hello.crate.allocator.rcgu.o" "-Wl,--gc-sections" "-pie" "-Wl,-z,relro,-z,now" "-nodefaultlibs" "-L" "/home/felix/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib" "-Wl,-Bstatic" "/home/felix/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/libstd-d3700976135c3f09.rlib" "/home/felix/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/liballoc_jemalloc-8a207564cfc9f224.rlib" "/home/felix/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/libpanic_unwind-4712d699ce2d50e5.rlib" "/home/felix/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/libunwind-7224935811a361fe.rlib" "/home/felix/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/liballoc_system-3343c92f30e63266.rlib" "/home/felix/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/liblibc-6e8aafa8bd1a67de.rlib" "/home/felix/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/liballoc-a8b7c0565b6366c3.rlib" "/home/felix/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/libstd_unicode-512049fc390dec2e.rlib" "/home/felix/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/libcore-ba1f12eb6cef9a1a.rlib" "/home/felix/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/libcompiler_builtins-53aab67ab6317c59.rlib" "-Wl,-Bdynamic" "-l" "dl" "-l" "rt" "-l" "pthread" "-l" "pthread" "-l" "gcc_s" "-l" "c" "-l" "m" "-l" "rt" "-l" "pthread" "-l" "util" "-l" "util"

error: aborting due to previous error
```

The new error message is:

```
error: linker `cc` not found
  |
  = note: No such file or directory (os error 2)

error: aborting due to previous error
```

This currently breaks https://github.com/rust-lang/rust/pull/47052.

**NOTE:** I don't know if I handled the "ticks" around the linker name correctly (if cargo test is smart enough to see that the ticks are part of the omitted part). My reasoning was that in the rustc code the ticks are in the source and not part of the linkers name - so if rustc changes, this will probably break again.

EDIT: fixed error message