### PR TITLE
Print new Cargo.lock on conflict when -vv --locked/--frozen is passed.

### DIFF
--- a/src/cargo/ops/lockfile.rs
+++ b/src/cargo/ops/lockfile.rs
@@ -77,6 +77,11 @@ pub fn write_pkg_lockfile(ws: &Workspace, resolve: &Resolve) -> CargoResult<()> 
 
     if !ws.config().lock_update_allowed() {
         let flag = if ws.config().network_allowed() {"--locked"} else {"--frozen"};
+        if ws.config().extra_verbose() {
+            eprintln!("Lock file needs to be updated. \
+                       The new Cargo.lock will be written to stdout");
+            println!("{}", out);
+        }
         bail!("the lock file needs to be updated but {} was passed to \
                prevent this", flag);
     }


### PR DESCRIPTION
Previously, when the lock file needs to be updated but --locked/--frozen is passed, cargo will simply fail without indicating what's wrong. This PR changes the behavior to also write out the new Cargo.lock when -vv (extra verbose) is passed. This allows the user to obtain a usable Cargo.lock with minimum change.

(Ideally this should print a colored diff, but adding a whole new dependency just for a -vv output is wasteful.)