### PR TITLE
Bail if targets require nonexistent feature.

### DIFF
--- a/src/cargo/util/toml/targets.rs
+++ b/src/cargo/util/toml/targets.rs
@@ -62,6 +62,19 @@ pub fn targets(manifest: &TomlManifest,
         targets.push(Target::custom_build_target(&name, package_root.join(custom_build)));
     }
 
+    if let Some(ref features) = manifest.features {
+        for t in targets.iter() {
+            if let Some(req_features) = t.required_features() {
+                for req_feature in req_features {
+                    if !features.contains_key(req_feature) {
+                        bail!("Target `{}` requires feature `{}`, which is \
+not specified in the manifest's `[features]`-section.", t.name(), req_feature);
+                    }
+                }
+            }
+        }
+    }
+
     Ok(targets)
 }
 

--- a/tests/features.rs
+++ b/tests/features.rs
@@ -1236,3 +1236,33 @@ fn many_cli_features_comma_and_space_delimited() {
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ", dir = p.url())));
 }
+
+#[test]
+fn nonexistent_feature_in_target() {
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [project]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+
+            [features]
+            foo = []
+
+            [[example]]
+            name = "bar"
+            required-features = ["baz"]
+        "#)
+        .file("src/main.rs", "fn main() {}")
+        .file("examples/bar.rs", "fn main() {}")
+        .build();
+
+    assert_that(p.cargo("build"),
+                execs()
+                .with_status(101)
+                .with_stderr("\
+[ERROR] failed to parse manifest at `[..]`
+
+Caused by:
+  Target `bar` requires feature `baz`[..]"));
+}


### PR DESCRIPTION
Bin-, bench-, test- and example-targets may specify a set of required
features. Before this commit, it was possible to specify features not
declared in [features], which could be confusing in case of typos. This
is now a hard error during manifest-parsing.

Fixes #4854