### PR TITLE
Upgrade flate2 crate to 1.0 in cargotest

### DIFF
--- a/tests/cargotest/Cargo.toml
+++ b/tests/cargotest/Cargo.toml
@@ -9,7 +9,7 @@ path = "lib.rs"
 [dependencies]
 cargo = { path = "../.." }
 filetime = "0.1"
-flate2 = "0.2"
+flate2 = "1.0"
 git2 = { version = "0.6", default-features = false }
 hamcrest = "=0.1.1"
 hex = "0.2"

--- a/tests/cargotest/support/registry.rs
+++ b/tests/cargotest/support/registry.rs
@@ -3,7 +3,7 @@ use std::fs::{self, File};
 use std::io::prelude::*;
 use std::path::{PathBuf, Path};
 
-use flate2::Compression::Default;
+use flate2::Compression;
 use flate2::write::GzEncoder;
 use git2;
 use hex::ToHex;
@@ -273,7 +273,8 @@ impl Package {
         let dst = self.archive_dst();
         t!(fs::create_dir_all(dst.parent().unwrap()));
         let f = t!(File::create(&dst));
-        let mut a = Builder::new(GzEncoder::new(f, Default));
+        let mut a =
+            Builder::new(GzEncoder::new(f, Compression::default()));
         self.append(&mut a, "Cargo.toml", &manifest);
         if self.files.is_empty() {
             self.append(&mut a, "src/lib.rs", "");


### PR DESCRIPTION
I've missed this part in my previous PR, sorry.
Unblocks rust#46278.