### PR TITLE
Bump hamcrest to 0.1.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ winapi = "0.2"
 bufstream = "0.1"
 cargotest = { path = "tests/cargotest" }
 filetime = "0.1"
-hamcrest = "=0.1.1"
+hamcrest = "=0.1.5"
 
 [[bin]]
 name = "cargo"

--- a/tests/alt-registry.rs
+++ b/tests/alt-registry.rs
@@ -1,10 +1,11 @@
 extern crate cargotest;
+#[macro_use]
 extern crate hamcrest;
 
 use cargotest::ChannelChanger;
 use cargotest::support::registry::{self, Package, alt_api_path};
 use cargotest::support::{project, execs};
-use hamcrest::assert_that;
+use hamcrest::prelude::*;
 
 #[test]
 fn is_feature_gated() {
@@ -24,7 +25,7 @@ fn is_feature_gated() {
 
     Package::new("bar", "0.0.1").alternative(true).publish();
 
-    assert_that(p.cargo("build").masquerade_as_nightly_cargo(),
+    assert_that!(p.cargo("build").masquerade_as_nightly_cargo(),
                 execs().with_status(101)
                 .with_stderr_contains("  feature `alternative-registries` is required"));
 }
@@ -49,7 +50,7 @@ fn depend_on_alt_registry() {
 
     Package::new("bar", "0.0.1").alternative(true).publish();
 
-    assert_that(p.cargo("build").masquerade_as_nightly_cargo(),
+    assert_that!(p.cargo("build").masquerade_as_nightly_cargo(),
                 execs().with_status(0).with_stderr(&format!("\
 [UPDATING] registry `{reg}`
 [DOWNLOADING] bar v0.0.1 (registry `file://[..]`)
@@ -60,10 +61,10 @@ fn depend_on_alt_registry() {
         dir = p.url(),
         reg = registry::alt_registry())));
 
-    assert_that(p.cargo("clean").masquerade_as_nightly_cargo(), execs().with_status(0));
+    assert_that!(p.cargo("clean").masquerade_as_nightly_cargo(), execs().with_status(0));
 
     // Don't download a second time
-    assert_that(p.cargo("build").masquerade_as_nightly_cargo(),
+    assert_that!(p.cargo("build").masquerade_as_nightly_cargo(),
                 execs().with_status(0).with_stderr(&format!("\
 [COMPILING] bar v0.0.1 (registry `file://[..]`)
 [COMPILING] foo v0.0.1 ({dir})
@@ -93,7 +94,7 @@ fn depend_on_alt_registry_depends_on_same_registry_no_index() {
     Package::new("baz", "0.0.1").alternative(true).publish();
     Package::new("bar", "0.0.1").dep("baz", "0.0.1").alternative(true).publish();
 
-    assert_that(p.cargo("build").masquerade_as_nightly_cargo(),
+    assert_that!(p.cargo("build").masquerade_as_nightly_cargo(),
                 execs().with_status(0).with_stderr(&format!("\
 [UPDATING] registry `{reg}`
 [DOWNLOADING] [..] v0.0.1 (registry `file://[..]`)
@@ -128,7 +129,7 @@ fn depend_on_alt_registry_depends_on_same_registry() {
     Package::new("baz", "0.0.1").alternative(true).publish();
     Package::new("bar", "0.0.1").registry_dep("baz", "0.0.1", registry::alt_registry().as_str()).alternative(true).publish();
 
-    assert_that(p.cargo("build").masquerade_as_nightly_cargo(),
+    assert_that!(p.cargo("build").masquerade_as_nightly_cargo(),
                 execs().with_status(0).with_stderr(&format!("\
 [UPDATING] registry `{reg}`
 [DOWNLOADING] [..] v0.0.1 (registry `file://[..]`)
@@ -163,7 +164,7 @@ fn depend_on_alt_registry_depends_on_crates_io() {
     Package::new("baz", "0.0.1").publish();
     Package::new("bar", "0.0.1").registry_dep("baz", "0.0.1", registry::registry().as_str()).alternative(true).publish();
 
-    assert_that(p.cargo("build").masquerade_as_nightly_cargo(),
+    assert_that!(p.cargo("build").masquerade_as_nightly_cargo(),
                 execs().with_status(0).with_stderr(&format!("\
 [UPDATING] registry `{alt_reg}`
 [UPDATING] registry `{reg}`
@@ -197,7 +198,7 @@ fn registry_incompatible_with_path() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    assert_that(p.cargo("build").masquerade_as_nightly_cargo(),
+    assert_that!(p.cargo("build").masquerade_as_nightly_cargo(),
                 execs().with_status(101)
                 .with_stderr_contains("  dependency (bar) specification is ambiguous. Only one of `path` or `registry` is allowed."));
 }
@@ -220,7 +221,7 @@ fn registry_incompatible_with_git() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    assert_that(p.cargo("build").masquerade_as_nightly_cargo(),
+    assert_that!(p.cargo("build").masquerade_as_nightly_cargo(),
                 execs().with_status(101)
                 .with_stderr_contains("  dependency (bar) specification is ambiguous. Only one of `git` or `registry` is allowed."));
 }
@@ -243,7 +244,7 @@ fn cannot_publish_to_crates_io_with_registry_dependency() {
 
     Package::new("bar", "0.0.1").alternative(true).publish();
 
-    assert_that(p.cargo("publish").masquerade_as_nightly_cargo()
+    assert_that!(p.cargo("publish").masquerade_as_nightly_cargo()
                  .arg("--index").arg(registry::registry().to_string()),
                 execs().with_status(101));
 }
@@ -269,11 +270,11 @@ fn publish_with_registry_dependency() {
     Package::new("bar", "0.0.1").alternative(true).publish();
 
     // Login so that we have the token available
-    assert_that(p.cargo("login").masquerade_as_nightly_cargo()
+    assert_that!(p.cargo("login").masquerade_as_nightly_cargo()
                  .arg("--registry").arg("alternative").arg("TOKEN").arg("-Zunstable-options"),
                 execs().with_status(0));
 
-    assert_that(p.cargo("publish").masquerade_as_nightly_cargo()
+    assert_that!(p.cargo("publish").masquerade_as_nightly_cargo()
                  .arg("--registry").arg("alternative").arg("-Zunstable-options"),
                 execs().with_status(0));
 }
@@ -303,7 +304,7 @@ fn alt_registry_and_crates_io_deps() {
     Package::new("crates_io_dep", "0.0.1").publish();
     Package::new("alt_reg_dep", "0.1.0").alternative(true).publish();
 
-    assert_that(p.cargo("build").masquerade_as_nightly_cargo(),
+    assert_that!(p.cargo("build").masquerade_as_nightly_cargo(),
                 execs().with_status(0)
                        .with_stderr_contains(format!("\
 [UPDATING] registry `{}`", registry::alt_registry()))
@@ -340,7 +341,7 @@ fn block_publish_due_to_no_token() {
     Package::new("bar", "0.0.1").alternative(true).publish();
 
     // Now perform the actual publish
-    assert_that(p.cargo("publish").masquerade_as_nightly_cargo()
+    assert_that!(p.cargo("publish").masquerade_as_nightly_cargo()
                  .arg("--registry").arg("alternative").arg("-Zunstable-options"),
                 execs().with_status(101)
                 .with_stderr_contains("error: no upload token found, please run `cargo login`"));
@@ -364,12 +365,12 @@ fn publish_to_alt_registry() {
     Package::new("bar", "0.0.1").alternative(true).publish();
 
     // Login so that we have the token available
-    assert_that(p.cargo("login").masquerade_as_nightly_cargo()
+    assert_that!(p.cargo("login").masquerade_as_nightly_cargo()
                  .arg("--registry").arg("alternative").arg("TOKEN").arg("-Zunstable-options"),
                 execs().with_status(0));
 
     // Now perform the actual publish
-    assert_that(p.cargo("publish").masquerade_as_nightly_cargo()
+    assert_that!(p.cargo("publish").masquerade_as_nightly_cargo()
                  .arg("--registry").arg("alternative").arg("-Zunstable-options"),
                 execs().with_status(0));
 
@@ -399,11 +400,11 @@ fn publish_with_crates_io_dep() {
     Package::new("bar", "0.0.1").publish();
 
     // Login so that we have the token available
-    assert_that(p.cargo("login").masquerade_as_nightly_cargo()
+    assert_that!(p.cargo("login").masquerade_as_nightly_cargo()
                  .arg("--registry").arg("alternative").arg("TOKEN").arg("-Zunstable-options"),
                 execs().with_status(0));
 
-    assert_that(p.cargo("publish").masquerade_as_nightly_cargo()
+    assert_that!(p.cargo("publish").masquerade_as_nightly_cargo()
                  .arg("--registry").arg("alternative").arg("-Zunstable-options"),
                 execs().with_status(0));
 }

--- a/tests/bad-config.rs
+++ b/tests/bad-config.rs
@@ -1,9 +1,10 @@
 extern crate cargotest;
+#[macro_use]
 extern crate hamcrest;
 
 use cargotest::support::{project, execs};
 use cargotest::support::registry::Package;
-use hamcrest::assert_that;
+use hamcrest::prelude::*;
 
 #[test]
 fn bad1() {
@@ -20,7 +21,7 @@ fn bad1() {
               nonexistent-target = "foo"
         "#)
         .build();
-    assert_that(p.cargo("build").arg("-v")
+    assert_that!(p.cargo("build").arg("-v")
                    .arg("--target=nonexistent-target"),
                 execs().with_status(101).with_stderr("\
 [ERROR] expected table for configuration key `target.nonexistent-target`, \
@@ -43,7 +44,7 @@ fn bad2() {
                 proxy = 3.0
         "#)
         .build();
-    assert_that(p.cargo("publish").arg("-v"),
+    assert_that!(p.cargo("publish").arg("-v"),
                 execs().with_status(101).with_stderr("\
 [ERROR] Couldn't load Cargo configuration
 
@@ -78,7 +79,7 @@ fn bad3() {
         .build();
     Package::new("foo", "1.0.0").publish();
 
-    assert_that(p.cargo("publish").arg("-v"),
+    assert_that!(p.cargo("publish").arg("-v"),
                 execs().with_status(101).with_stderr("\
 error: failed to update registry [..]
 
@@ -96,7 +97,7 @@ fn bad4() {
               name = false
         "#)
         .build();
-    assert_that(p.cargo("new").arg("-v").arg("foo"),
+    assert_that!(p.cargo("new").arg("-v").arg("foo"),
                 execs().with_status(101).with_stderr("\
 [ERROR] Failed to create project `foo` at `[..]`
 
@@ -116,7 +117,7 @@ fn bad5() {
             foo = 2
         "#)
         .build();
-    assert_that(p.cargo("new")
+    assert_that!(p.cargo("new")
                    .arg("-v").arg("foo").cwd(&p.root().join("foo")),
                 execs().with_status(101).with_stderr("\
 [ERROR] Failed to create project `foo` at `[..]`
@@ -152,7 +153,7 @@ fn bad_cargo_config_jobs() {
             jobs = -1
         "#)
         .build();
-    assert_that(p.cargo("build").arg("-v"),
+    assert_that!(p.cargo("build").arg("-v"),
                 execs().with_status(101).with_stderr("\
 [ERROR] build.jobs must be positive, but found -1 in [..]
 "));
@@ -173,7 +174,7 @@ fn default_cargo_config_jobs() {
             jobs = 1
         "#)
         .build();
-    assert_that(p.cargo("build").arg("-v"),
+    assert_that!(p.cargo("build").arg("-v"),
                 execs().with_status(0));
 }
 
@@ -192,7 +193,7 @@ fn good_cargo_config_jobs() {
             jobs = 4
         "#)
         .build();
-    assert_that(p.cargo("build").arg("-v"),
+    assert_that!(p.cargo("build").arg("-v"),
                 execs().with_status(0));
 }
 
@@ -212,7 +213,7 @@ fn invalid_global_config() {
         .file("src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("build").arg("-v"),
+    assert_that!(p.cargo("build").arg("-v"),
                 execs().with_status(101).with_stderr("\
 [ERROR] Couldn't load Cargo configuration
 
@@ -240,7 +241,7 @@ fn bad_cargo_lock() {
         .file("src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("build").arg("-v"),
+    assert_that!(p.cargo("build").arg("-v"),
                 execs().with_status(101).with_stderr("\
 [ERROR] failed to parse lock file at: [..]Cargo.lock
 
@@ -284,7 +285,7 @@ fn duplicate_packages_in_cargo_lock() {
         "#)
         .build();
 
-    assert_that(p.cargo("build").arg("--verbose"),
+    assert_that!(p.cargo("build").arg("--verbose"),
                 execs().with_status(101).with_stderr("\
 [ERROR] failed to parse lock file at: [..]
 
@@ -323,7 +324,7 @@ fn bad_source_in_cargo_lock() {
         "#)
         .build();
 
-    assert_that(p.cargo("build").arg("--verbose"),
+    assert_that!(p.cargo("build").arg("--verbose"),
                 execs().with_status(101).with_stderr("\
 [ERROR] failed to parse lock file at: [..]
 
@@ -352,7 +353,7 @@ fn bad_dependency_in_lockfile() {
         "#)
         .build();
 
-    assert_that(p.cargo("build").arg("--verbose"),
+    assert_that!(p.cargo("build").arg("--verbose"),
                 execs().with_status(101).with_stderr("\
 [ERROR] failed to parse lock file at: [..]
 
@@ -377,7 +378,7 @@ fn bad_git_dependency() {
         .file("src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("build").arg("-v"),
+    assert_that!(p.cargo("build").arg("-v"),
                 execs().with_status(101).with_stderr("\
 [UPDATING] git repository `file:///`
 [ERROR] failed to load source for a dependency on `foo`
@@ -408,7 +409,7 @@ fn bad_crate_type() {
         .file("src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("build").arg("-v"),
+    assert_that!(p.cargo("build").arg("-v"),
                 execs().with_status(101).with_stderr_contains("\
 error: failed to run `rustc` to learn about target-specific information
 "));
@@ -431,7 +432,7 @@ fn malformed_override() {
         .file("src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(101).with_stderr("\
 [ERROR] failed to parse manifest at `[..]`
 
@@ -464,7 +465,7 @@ fn duplicate_binary_names() {
         .file("b.rs", r#"fn main() -> () {}"#)
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(101).with_stderr("\
 [ERROR] failed to parse manifest at `[..]`
 
@@ -494,7 +495,7 @@ fn duplicate_example_names() {
         .file("examples/ex2.rs", r#"fn main () -> () {}"#)
         .build();
 
-    assert_that(p.cargo("build").arg("--example").arg("ex"),
+    assert_that!(p.cargo("build").arg("--example").arg("ex"),
                 execs().with_status(101).with_stderr("\
 [ERROR] failed to parse manifest at `[..]`
 
@@ -524,7 +525,7 @@ fn duplicate_bench_names() {
         .file("benches/ex2.rs", r#"fn main () {}"#)
         .build();
 
-    assert_that(p.cargo("bench"),
+    assert_that!(p.cargo("bench"),
                 execs().with_status(101).with_stderr("\
 [ERROR] failed to parse manifest at `[..]`
 
@@ -569,7 +570,7 @@ fn duplicate_deps() {
         .file("src/main.rs", r#"fn main () {}"#)
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(101).with_stderr("\
 [ERROR] failed to parse manifest at `[..]`
 
@@ -615,7 +616,7 @@ fn duplicate_deps_diff_sources() {
         .file("src/main.rs", r#"fn main () {}"#)
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(101).with_stderr("\
 [ERROR] failed to parse manifest at `[..]`
 
@@ -640,7 +641,7 @@ fn unused_keys() {
         .file("src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0).with_stderr("\
 warning: unused manifest key: target.foo.bar
 [COMPILING] foo v0.1.0 (file:///[..])
@@ -660,7 +661,7 @@ warning: unused manifest key: target.foo.bar
             pub fn foo() {}
         "#)
         .build();
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0)
                     .with_stderr("\
 warning: unused manifest key: project.bulid
@@ -683,7 +684,7 @@ warning: unused manifest key: project.bulid
             pub fn foo() {}
         "#)
         .build();
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0)
                     .with_stderr("\
 warning: unused manifest key: lib.build
@@ -710,7 +711,7 @@ fn empty_dependencies() {
 
     Package::new("foo", "0.0.1").publish();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0).with_stderr_contains("\
 warning: dependency (foo) specified without providing a local path, Git repository, or version \
 to use. This will be considered an error in future versions
@@ -732,7 +733,7 @@ fn invalid_toml_historically_allowed_is_warned() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0).with_stderr("\
 warning: TOML file found which contains invalid syntax and will soon not parse
 at `[..]config`.
@@ -763,7 +764,7 @@ fn ambiguous_git_reference() {
         .file("src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("build").arg("-v"),
+    assert_that!(p.cargo("build").arg("-v"),
                 execs().with_stderr_contains("\
 [WARNING] dependency (bar) specification is ambiguous. \
 Only one of `branch`, `tag` or `rev` is allowed. \
@@ -786,7 +787,7 @@ fn bad_source_config1() {
         "#)
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(101).with_stderr("\
 error: no source URL specified for `source.foo`, need [..]
 "));
@@ -812,7 +813,7 @@ fn bad_source_config2() {
         "#)
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(101).with_stderr("\
 error: failed to load source for a dependency on `bar`
 
@@ -845,7 +846,7 @@ fn bad_source_config3() {
         "#)
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(101).with_stderr("\
 error: failed to load source for a dependency on `bar`
 
@@ -881,7 +882,7 @@ fn bad_source_config4() {
         "#)
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(101).with_stderr("\
 error: failed to load source for a dependency on `bar`
 
@@ -917,7 +918,7 @@ fn bad_source_config5() {
         "#)
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(101).with_stderr("\
 error: configuration key `source.bar.registry` specified an invalid URL (in [..])
 
@@ -942,7 +943,7 @@ fn both_git_and_path_specified() {
         .file("src/lib.rs", "")
         .build();
 
-    assert_that(foo.cargo("build").arg("-v"),
+    assert_that!(foo.cargo("build").arg("-v"),
                 execs().with_stderr_contains("\
 [WARNING] dependency (bar) specification is ambiguous. \
 Only one of `git` or `path` is allowed. \
@@ -970,7 +971,7 @@ fn bad_source_config6() {
         "#)
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(101).with_stderr("\
 error: expected a string, but found a array for `source.crates-io.replace-with` in [..]
 "));
@@ -992,7 +993,7 @@ fn ignored_git_revision() {
         .file("src/lib.rs", "")
         .build();
 
-    assert_that(foo.cargo("build").arg("-v"),
+    assert_that!(foo.cargo("build").arg("-v"),
                 execs().with_stderr_contains("\
 [WARNING] key `branch` is ignored for dependency (bar). \
 This will be considered an error in future versions"));
@@ -1020,7 +1021,7 @@ fn bad_source_config7() {
 
     Package::new("bar", "0.1.0").publish();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(101).with_stderr("\
 error: more than one source URL specified for `source.foo`
 "));
@@ -1041,7 +1042,7 @@ fn bad_dependency() {
         .file("src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(101).with_stderr("\
 error: failed to parse manifest at `[..]`
 
@@ -1065,7 +1066,7 @@ fn bad_debuginfo() {
         .file("src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(101).with_stderr("\
 error: failed to parse manifest at `[..]`
 
@@ -1087,7 +1088,7 @@ fn bad_opt_level() {
         .file("src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(101).with_stderr("\
 error: failed to parse manifest at `[..]`
 

--- a/tests/bad-manifest-path.rs
+++ b/tests/bad-manifest-path.rs
@@ -1,8 +1,9 @@
+#[macro_use]
 extern crate hamcrest;
 extern crate cargotest;
 
 use cargotest::support::{project, execs, main_file, basic_bin_manifest};
-use hamcrest::{assert_that};
+use hamcrest::prelude::*;
 
 fn assert_not_a_cargo_toml(command: &str, manifest_path_argument: &str) {
     let p = project("foo")
@@ -10,7 +11,7 @@ fn assert_not_a_cargo_toml(command: &str, manifest_path_argument: &str) {
         .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
         .build();
 
-    assert_that(p.cargo(command)
+    assert_that!(p.cargo(command)
                  .arg("--manifest-path").arg(manifest_path_argument)
                  .cwd(p.root().parent().unwrap()),
                 execs().with_status(101)
@@ -24,7 +25,7 @@ fn assert_cargo_toml_doesnt_exist(command: &str, manifest_path_argument: &str) {
     let expected_path = manifest_path_argument
         .split('/').collect::<Vec<_>>().join("[..]");
 
-    assert_that(p.cargo(command)
+    assert_that!(p.cargo(command)
                  .arg("--manifest-path").arg(manifest_path_argument)
                  .cwd(p.root().parent().unwrap()),
                 execs().with_status(101)
@@ -321,7 +322,7 @@ fn verify_project_dir_containing_cargo_toml() {
         .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
         .build();
 
-    assert_that(p.cargo("verify-project")
+    assert_that!(p.cargo("verify-project")
                  .arg("--manifest-path").arg("foo")
                  .cwd(p.root().parent().unwrap()),
                 execs().with_status(1)
@@ -337,7 +338,7 @@ fn verify_project_dir_plus_file() {
         .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
         .build();
 
-    assert_that(p.cargo("verify-project")
+    assert_that!(p.cargo("verify-project")
                  .arg("--manifest-path").arg("foo/bar")
                  .cwd(p.root().parent().unwrap()),
                 execs().with_status(1)
@@ -353,7 +354,7 @@ fn verify_project_dir_plus_path() {
         .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
         .build();
 
-    assert_that(p.cargo("verify-project")
+    assert_that!(p.cargo("verify-project")
                  .arg("--manifest-path").arg("foo/bar/baz")
                  .cwd(p.root().parent().unwrap()),
                 execs().with_status(1)
@@ -365,7 +366,7 @@ fn verify_project_dir_plus_path() {
 #[test]
 fn verify_project_dir_to_nonexistent_cargo_toml() {
     let p = project("foo").build();
-    assert_that(p.cargo("verify-project")
+    assert_that!(p.cargo("verify-project")
                  .arg("--manifest-path").arg("foo/bar/baz/Cargo.toml")
                  .cwd(p.root().parent().unwrap()),
                 execs().with_status(1)

--- a/tests/bench.rs
+++ b/tests/bench.rs
@@ -1,5 +1,6 @@
 extern crate cargotest;
 extern crate cargo;
+#[macro_use]
 extern crate hamcrest;
 
 use std::str;
@@ -8,7 +9,7 @@ use cargo::util::process;
 use cargotest::is_nightly;
 use cargotest::support::paths::CargoPathExt;
 use cargotest::support::{project, execs, basic_bin_manifest, basic_lib_manifest};
-use hamcrest::{assert_that, existing_file};
+use hamcrest::prelude::*;
 
 #[test]
 fn cargo_bench_simple() {
@@ -35,13 +36,13 @@ fn cargo_bench_simple() {
             }"#)
         .build();
 
-    assert_that(p.cargo("build"), execs());
-    assert_that(&p.bin("foo"), existing_file());
+    assert_that!(p.cargo("build"), execs());
+    assert_that!(&p.bin("foo"), existing_file());
 
-    assert_that(process(&p.bin("foo")),
+    assert_that!(process(&p.bin("foo")),
                 execs().with_stdout("hello\n"));
 
-    assert_that(p.cargo("bench"),
+    assert_that!(p.cargo("bench"),
                 execs().with_stderr(&format!("\
 [COMPILING] foo v0.5.0 ({})
 [FINISHED] release [optimized] target(s) in [..]
@@ -76,7 +77,7 @@ fn bench_bench_implicit() {
             #[bench] fn run2(_ben: &mut test::Bencher) { }"#)
         .build();
 
-    assert_that(p.cargo("bench").arg("--benches"),
+    assert_that!(p.cargo("bench").arg("--benches"),
         execs().with_status(0)
                .with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({dir})
@@ -114,7 +115,7 @@ fn bench_bin_implicit() {
             #[bench] fn run2(_ben: &mut test::Bencher) { }"#)
         .build();
 
-    assert_that(p.cargo("bench").arg("--bins"),
+    assert_that!(p.cargo("bench").arg("--bins"),
         execs().with_status(0)
                .with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({dir})
@@ -145,7 +146,7 @@ fn bench_tarname() {
             #[bench] fn run2(_ben: &mut test::Bencher) { }"#)
         .build();
 
-    assert_that(p.cargo("bench").arg("--bench").arg("bin2"),
+    assert_that!(p.cargo("bench").arg("--bench").arg("bin2"),
         execs().with_status(0)
                .with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({dir})
@@ -180,7 +181,7 @@ fn bench_multiple_targets() {
             #[bench] fn run3(_ben: &mut test::Bencher) { }"#)
         .build();
 
-    assert_that(p.cargo("bench")
+    assert_that!(p.cargo("bench")
                 .arg("--bench").arg("bin1")
                 .arg("--bench").arg("bin2"),
                 execs()
@@ -205,7 +206,7 @@ fn cargo_bench_verbose() {
         "#)
         .build();
 
-    assert_that(p.cargo("bench").arg("-v").arg("hello"),
+    assert_that!(p.cargo("bench").arg("-v").arg("hello"),
                 execs().with_stderr(&format!("\
 [COMPILING] foo v0.5.0 ({url})
 [RUNNING] `rustc [..] src[/]main.rs [..]`
@@ -280,13 +281,13 @@ fn cargo_bench_failing_test() {
             }"#)
         .build();
 
-    assert_that(p.cargo("build"), execs());
-    assert_that(&p.bin("foo"), existing_file());
+    assert_that!(p.cargo("build"), execs());
+    assert_that!(&p.bin("foo"), existing_file());
 
-    assert_that(process(&p.bin("foo")),
+    assert_that!(process(&p.bin("foo")),
                 execs().with_stdout("hello\n"));
 
-    assert_that(p.cargo("bench"),
+    assert_that!(p.cargo("bench"),
                 execs().with_stdout_contains("test bench_hello ... ")
                        .with_stderr_contains(format!("\
 [COMPILING] foo v0.5.0 ({})
@@ -344,7 +345,7 @@ fn bench_with_lib_dep() {
         ")
         .build();
 
-    assert_that(p.cargo("bench"),
+    assert_that!(p.cargo("bench"),
                 execs().with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({})
 [FINISHED] release [optimized] target(s) in [..]
@@ -399,7 +400,7 @@ fn bench_with_deep_lib_dep() {
         ")
         .build();
 
-    assert_that(p.cargo("bench"),
+    assert_that!(p.cargo("bench"),
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ([..])
@@ -444,7 +445,7 @@ fn external_bench_explicit() {
         "#)
         .build();
 
-    assert_that(p.cargo("bench"),
+    assert_that!(p.cargo("bench"),
                 execs().with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({})
 [FINISHED] release [optimized] target(s) in [..]
@@ -486,7 +487,7 @@ fn external_bench_implicit() {
         "#)
         .build();
 
-    assert_that(p.cargo("bench"),
+    assert_that!(p.cargo("bench"),
                 execs().with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({})
 [FINISHED] release [optimized] target(s) in [..]
@@ -512,7 +513,7 @@ fn dont_run_examples() {
             fn main() { panic!("Examples should not be run by 'cargo test'"); }
         "#)
         .build();
-    assert_that(p.cargo("bench"),
+    assert_that!(p.cargo("bench"),
                 execs().with_status(0));
 }
 
@@ -537,7 +538,7 @@ fn pass_through_command_line() {
         ")
         .build();
 
-    assert_that(p.cargo("bench").arg("bar"),
+    assert_that!(p.cargo("bench").arg("bar"),
                 execs().with_status(0)
                 .with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({dir})
@@ -545,7 +546,7 @@ fn pass_through_command_line() {
 [RUNNING] target[/]release[/]deps[/]foo-[..][EXE]", dir = p.url()))
                 .with_stdout_contains("test bar ... bench: [..]"));
 
-    assert_that(p.cargo("bench").arg("foo"),
+    assert_that!(p.cargo("bench").arg("foo"),
                 execs().with_status(0)
                        .with_stderr("[FINISHED] release [optimized] target(s) in [..]
 [RUNNING] target[/]release[/]deps[/]foo-[..][EXE]")
@@ -574,7 +575,7 @@ fn cargo_bench_twice() {
     p.cargo("build");
 
     for _ in 0..2 {
-        assert_that(p.cargo("bench"),
+        assert_that!(p.cargo("bench"),
                     execs().with_status(0));
     }
 }
@@ -613,7 +614,7 @@ fn lib_bin_same_name() {
         ")
         .build();
 
-    assert_that(p.cargo("bench"),
+    assert_that!(p.cargo("bench"),
                 execs().with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({})
 [FINISHED] release [optimized] target(s) in [..]
@@ -656,7 +657,7 @@ fn lib_with_standard_name() {
         ")
         .build();
 
-    assert_that(p.cargo("bench"),
+    assert_that!(p.cargo("bench"),
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] syntax v0.0.1 ({dir})
@@ -700,7 +701,7 @@ fn lib_with_standard_name2() {
         ")
         .build();
 
-    assert_that(p.cargo("bench"),
+    assert_that!(p.cargo("bench"),
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] syntax v0.0.1 ({dir})
@@ -761,7 +762,7 @@ fn bench_dylib() {
         ")
         .build();
 
-    assert_that(p.cargo("bench").arg("-v"),
+    assert_that!(p.cargo("bench").arg("-v"),
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] bar v0.0.1 ({dir}/bar)
@@ -776,7 +777,7 @@ fn bench_dylib() {
                        .with_stdout_contains_n("test foo ... bench: [..]", 2));
 
     p.root().move_into_the_past();
-    assert_that(p.cargo("bench").arg("-v"),
+    assert_that!(p.cargo("bench").arg("-v"),
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [FRESH] bar v0.0.1 ({dir}/bar)
@@ -809,7 +810,7 @@ fn bench_twice_with_build_cmd() {
         ")
         .build();
 
-    assert_that(p.cargo("bench"),
+    assert_that!(p.cargo("bench"),
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({dir})
@@ -817,7 +818,7 @@ fn bench_twice_with_build_cmd() {
 [RUNNING] target[/]release[/]deps[/]foo-[..][EXE]", dir = p.url()))
                        .with_stdout_contains("test foo ... bench: [..]"));
 
-    assert_that(p.cargo("bench"),
+    assert_that!(p.cargo("bench"),
                 execs().with_status(0)
                        .with_stderr("[FINISHED] release [optimized] target(s) in [..]
 [RUNNING] target[/]release[/]deps[/]foo-[..][EXE]")
@@ -881,7 +882,7 @@ fn bench_with_examples() {
         "#)
         .build();
 
-    assert_that(p.cargo("bench").arg("-v"),
+    assert_that!(p.cargo("bench").arg("-v"),
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] testbench v6.6.6 ({url})
@@ -923,7 +924,7 @@ fn test_a_bench() {
         "#)
         .build();
 
-    assert_that(p.cargo("test"),
+    assert_that!(p.cargo("test"),
                 execs().with_status(0)
                        .with_stderr("\
 [COMPILING] foo v0.1.0 ([..])
@@ -956,7 +957,7 @@ fn test_bench_no_run() {
         "#)
         .build();
 
-    assert_that(p.cargo("bench").arg("--no-run"),
+    assert_that!(p.cargo("bench").arg("--no-run"),
                 execs().with_status(0)
                        .with_stderr("\
 [COMPILING] foo v0.1.0 ([..])
@@ -993,7 +994,7 @@ fn test_bench_no_fail_fast() {
             }"#)
         .build();
 
-    assert_that(p.cargo("bench").arg("--no-fail-fast"),
+    assert_that!(p.cargo("bench").arg("--no-fail-fast"),
                 execs().with_status(101)
                     .with_stderr_contains("\
 [RUNNING] target[/]release[/]deps[/]foo-[..][EXE]")
@@ -1071,7 +1072,7 @@ fn test_bench_multiple_packages() {
         .build();
 
 
-    assert_that(p.cargo("bench").arg("-p").arg("bar").arg("-p").arg("baz"),
+    assert_that!(p.cargo("bench").arg("-p").arg("bar").arg("-p").arg("baz"),
                 execs().with_status(0)
                        .with_stderr_contains("\
 [RUNNING] target[/]release[/]deps[/]bbaz-[..][EXE]")
@@ -1127,7 +1128,7 @@ fn bench_all_workspace() {
         "#)
         .build();
 
-    assert_that(p.cargo("bench")
+    assert_that!(p.cargo("bench")
                  .arg("--all"),
                 execs().with_status(0)
                        .with_stderr_contains("\
@@ -1182,7 +1183,7 @@ fn bench_all_exclude() {
         "#)
         .build();
 
-    assert_that(p.cargo("bench")
+    assert_that!(p.cargo("bench")
                     .arg("--all")
                     .arg("--exclude")
                     .arg("baz"),
@@ -1238,7 +1239,7 @@ fn bench_all_virtual_manifest() {
         .build();
 
     // The order in which foo and bar are built is not guaranteed
-    assert_that(p.cargo("bench")
+    assert_that!(p.cargo("bench")
                  .arg("--all"),
                 execs().with_status(0)
                        .with_stderr_contains("\
@@ -1277,7 +1278,7 @@ fn legacy_bench_name() {
         "#)
         .build();
 
-    assert_that(p.cargo("bench"), execs().with_status(0).with_stderr_contains("\
+    assert_that!(p.cargo("bench"), execs().with_status(0).with_stderr_contains("\
 [WARNING] path `[..]src[/]bench.rs` was erroneously implicitly accepted for benchmark `bench`,
 please set bench.path in Cargo.toml"));
 }
@@ -1325,7 +1326,7 @@ fn bench_virtual_manifest_all_implied() {
 
     // The order in which foo and bar are built is not guaranteed
 
-    assert_that(p.cargo("bench"),
+    assert_that!(p.cargo("bench"),
                 execs().with_status(0)
                        .with_stderr_contains("\
 [RUNNING] target[/]release[/]deps[/]bar-[..][EXE]")

--- a/tests/build-auth.rs
+++ b/tests/build-auth.rs
@@ -1,6 +1,7 @@
 extern crate bufstream;
 extern crate git2;
 extern crate cargotest;
+#[macro_use]
 extern crate hamcrest;
 
 use std::collections::HashSet;
@@ -11,7 +12,7 @@ use std::thread;
 use bufstream::BufStream;
 use cargotest::support::paths;
 use cargotest::support::{project, execs};
-use hamcrest::assert_that;
+use hamcrest::prelude::*;
 
 // Test that HTTP auth is offered from `credential.helper`
 #[test]
@@ -80,7 +81,7 @@ fn http_auth_offered() {
         "#)
         .build();
 
-    assert_that(script.cargo("build").arg("-v"),
+    assert_that!(script.cargo("build").arg("-v"),
                 execs().with_status(0));
     let script = script.bin("script");
 
@@ -106,7 +107,7 @@ fn http_auth_offered() {
         ")
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(101).with_stderr(&format!("\
 [UPDATING] git repository `http://{addr}/foo/bar`
 [ERROR] failed to load source for a dependency on `bar`
@@ -157,7 +158,7 @@ fn https_something_happens() {
         ")
         .build();
 
-    assert_that(p.cargo("build").arg("-v"),
+    assert_that!(p.cargo("build").arg("-v"),
                 execs().with_status(101).with_stderr_contains(&format!("\
 [UPDATING] git repository `https://{addr}/foo/bar`
 ", addr = addr))
@@ -201,7 +202,7 @@ fn ssh_something_happens() {
         .file("src/main.rs", "")
         .build();
 
-    assert_that(p.cargo("build").arg("-v"),
+    assert_that!(p.cargo("build").arg("-v"),
                 execs().with_status(101).with_stderr_contains(&format!("\
 [UPDATING] git repository `ssh://{addr}/foo/bar`
 ", addr = addr))

--- a/tests/build-lib.rs
+++ b/tests/build-lib.rs
@@ -1,8 +1,9 @@
 extern crate cargotest;
+#[macro_use]
 extern crate hamcrest;
 
 use cargotest::support::{basic_bin_manifest, execs, project, Project};
-use hamcrest::{assert_that};
+use hamcrest::prelude::*;
 
 fn verbose_output_for_lib(p: &Project) -> String {
     format!("\
@@ -34,7 +35,7 @@ fn build_lib_only() {
         .file("src/lib.rs", r#" "#)
         .build();
 
-    assert_that(p.cargo("build").arg("--lib").arg("-v"),
+    assert_that!(p.cargo("build").arg("--lib").arg("-v"),
                 execs()
                 .with_status(0)
                 .with_stderr(verbose_output_for_lib(&p)));
@@ -50,7 +51,7 @@ fn build_with_no_lib() {
         "#)
         .build();
 
-    assert_that(p.cargo("build").arg("--lib"),
+    assert_that!(p.cargo("build").arg("--lib"),
                 execs().with_status(101)
                        .with_stderr("[ERROR] no library targets found"));
 }
@@ -82,7 +83,7 @@ fn build_with_relative_cargo_home_path() {
         "#)
         .build();
 
-    assert_that(p.cargo("build").env("CARGO_HOME", "./cargo_home/"),
+    assert_that!(p.cargo("build").env("CARGO_HOME", "./cargo_home/"),
                 execs()
                 .with_status(0));
 }

--- a/tests/build-script-env.rs
+++ b/tests/build-script-env.rs
@@ -1,11 +1,12 @@
 extern crate cargotest;
+#[macro_use]
 extern crate hamcrest;
 
 use std::fs::File;
 
 use cargotest::sleep_ms;
 use cargotest::support::{project, execs};
-use hamcrest::assert_that;
+use hamcrest::prelude::*;
 
 #[test]
 fn rerun_if_env_changes() {
@@ -26,30 +27,30 @@ fn rerun_if_env_changes() {
         "#)
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0)
                        .with_stderr("\
 [COMPILING] foo v0.5.0 ([..])
 [FINISHED] [..]
 "));
-    assert_that(p.cargo("build").env("FOO", "bar"),
+    assert_that!(p.cargo("build").env("FOO", "bar"),
                 execs().with_status(0)
                        .with_stderr("\
 [COMPILING] foo v0.5.0 ([..])
 [FINISHED] [..]
 "));
-    assert_that(p.cargo("build").env("FOO", "baz"),
+    assert_that!(p.cargo("build").env("FOO", "baz"),
                 execs().with_status(0)
                        .with_stderr("\
 [COMPILING] foo v0.5.0 ([..])
 [FINISHED] [..]
 "));
-    assert_that(p.cargo("build").env("FOO", "baz"),
+    assert_that!(p.cargo("build").env("FOO", "baz"),
                 execs().with_status(0)
                        .with_stderr("\
 [FINISHED] [..]
 "));
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0)
                        .with_stderr("\
 [COMPILING] foo v0.5.0 ([..])
@@ -78,26 +79,26 @@ fn rerun_if_env_or_file_changes() {
         .file("foo", "")
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0)
                        .with_stderr("\
 [COMPILING] foo v0.5.0 ([..])
 [FINISHED] [..]
 "));
-    assert_that(p.cargo("build").env("FOO", "bar"),
+    assert_that!(p.cargo("build").env("FOO", "bar"),
                 execs().with_status(0)
                        .with_stderr("\
 [COMPILING] foo v0.5.0 ([..])
 [FINISHED] [..]
 "));
-    assert_that(p.cargo("build").env("FOO", "bar"),
+    assert_that!(p.cargo("build").env("FOO", "bar"),
                 execs().with_status(0)
                        .with_stderr("\
 [FINISHED] [..]
 "));
     sleep_ms(1000);
     File::create(p.root().join("foo")).unwrap();
-    assert_that(p.cargo("build").env("FOO", "bar"),
+    assert_that!(p.cargo("build").env("FOO", "bar"),
                 execs().with_status(0)
                        .with_stderr("\
 [COMPILING] foo v0.5.0 ([..])

--- a/tests/build-script.rs
+++ b/tests/build-script.rs
@@ -1,4 +1,5 @@
 extern crate cargotest;
+#[macro_use]
 extern crate hamcrest;
 
 use std::env;
@@ -10,7 +11,7 @@ use cargotest::{rustc_host, sleep_ms};
 use cargotest::support::{project, execs};
 use cargotest::support::paths::CargoPathExt;
 use cargotest::support::registry::Package;
-use hamcrest::{assert_that, existing_file, existing_dir};
+use hamcrest::prelude::*;
 
 #[test]
 fn custom_build_script_failed() {
@@ -32,7 +33,7 @@ fn custom_build_script_failed() {
             }
         "#)
         .build();
-    assert_that(p.cargo("build").arg("-v"),
+    assert_that!(p.cargo("build").arg("-v"),
                 execs().with_status(101)
                        .with_stderr(&format!("\
 [COMPILING] foo v0.5.0 ({url})
@@ -118,7 +119,7 @@ fn custom_build_env_vars() {
 
     let p = p.file("bar/build.rs", &file_content).build();
 
-    assert_that(p.cargo("build").arg("--features").arg("bar_feat"),
+    assert_that!(p.cargo("build").arg("--features").arg("bar_feat"),
                 execs().with_status(0));
 }
 
@@ -143,7 +144,7 @@ fn custom_build_script_wrong_rustc_flags() {
         "#)
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(101)
                        .with_stderr_contains(&format!("\
 [ERROR] Only `-l` and `-L` flags are allowed in build script of `foo v0.5.0 ({})`: \
@@ -186,7 +187,7 @@ fn custom_build_script_rustc_flags() {
         .build();
 
     // TODO: TEST FAILS BECAUSE OF WRONG STDOUT (but otherwise, the build works)
-    assert_that(p.cargo("build").arg("--verbose"),
+    assert_that!(p.cargo("build").arg("--verbose"),
                 execs().with_status(101)
                        .with_stderr(&format!("\
 [COMPILING] bar v0.5.0 ({url})
@@ -217,7 +218,7 @@ fn links_no_build_cmd() {
         .file("src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(101)
                        .with_stderr("\
 [ERROR] package `foo v0.5.0 (file://[..])` specifies that it links to `a` but does \
@@ -253,7 +254,7 @@ fn links_duplicates() {
         .file("a-sys/build.rs", "")
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(101)
                        .with_stderr("\
 [ERROR] multiple packages link to native library `a`, but a native library can \
@@ -308,7 +309,7 @@ fn links_duplicates_deep_dependency() {
         .file("a/a-sys/build.rs", "")
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(101)
                        .with_stderr("\
 [ERROR] multiple packages link to native library `a`, but a native library can \
@@ -367,7 +368,7 @@ fn overrides_and_links() {
         .file("a/build.rs", "not valid rust code")
         .build();
 
-    assert_that(p.cargo("build").arg("-v"),
+    assert_that!(p.cargo("build").arg("-v"),
                 execs().with_status(0)
                        .with_stderr("\
 [..]
@@ -402,7 +403,7 @@ fn unused_overrides() {
         "#, target))
         .build();
 
-    assert_that(p.cargo("build").arg("-v"),
+    assert_that!(p.cargo("build").arg("-v"),
                 execs().with_status(0));
 }
 
@@ -448,7 +449,7 @@ fn links_passes_env_vars() {
         "#)
         .build();
 
-    assert_that(p.cargo("build").arg("-v"),
+    assert_that!(p.cargo("build").arg("-v"),
                 execs().with_status(0));
 }
 
@@ -468,14 +469,14 @@ fn only_rerun_build_script() {
         "#)
         .build();
 
-    assert_that(p.cargo("build").arg("-v"),
+    assert_that!(p.cargo("build").arg("-v"),
                 execs().with_status(0));
     p.root().move_into_the_past();
 
     File::create(&p.root().join("some-new-file")).unwrap();
     p.root().move_into_the_past();
 
-    assert_that(p.cargo("build").arg("-v"),
+    assert_that!(p.cargo("build").arg("-v"),
                 execs().with_status(0)
                        .with_stderr("\
 [COMPILING] foo v0.5.0 (file://[..])
@@ -529,14 +530,14 @@ fn rebuild_continues_to_pass_env_vars() {
         "#)
         .build();
 
-    assert_that(p.cargo("build").arg("-v"),
+    assert_that!(p.cargo("build").arg("-v"),
                 execs().with_status(0));
     p.root().move_into_the_past();
 
     File::create(&p.root().join("some-new-file")).unwrap();
     p.root().move_into_the_past();
 
-    assert_that(p.cargo("build").arg("-v"),
+    assert_that!(p.cargo("build").arg("-v"),
                 execs().with_status(0));
 }
 
@@ -557,7 +558,7 @@ fn testing_and_such() {
         .build();
 
     println!("build");
-    assert_that(p.cargo("build").arg("-v"),
+    assert_that!(p.cargo("build").arg("-v"),
                 execs().with_status(0));
     p.root().move_into_the_past();
 
@@ -565,7 +566,7 @@ fn testing_and_such() {
     p.root().move_into_the_past();
 
     println!("test");
-    assert_that(p.cargo("test").arg("-vj1"),
+    assert_that!(p.cargo("test").arg("-vj1"),
                 execs().with_status(0)
                        .with_stderr("\
 [COMPILING] foo v0.5.0 (file://[..])
@@ -579,7 +580,7 @@ fn testing_and_such() {
                        .with_stdout_contains_n("running 0 tests", 2));
 
     println!("doc");
-    assert_that(p.cargo("doc").arg("-v"),
+    assert_that!(p.cargo("doc").arg("-v"),
                 execs().with_status(0)
                        .with_stderr("\
 [DOCUMENTING] foo v0.5.0 (file://[..])
@@ -590,7 +591,7 @@ fn testing_and_such() {
     File::create(&p.root().join("src/main.rs")).unwrap()
          .write_all(b"fn main() {}").unwrap();
     println!("run");
-    assert_that(p.cargo("run"),
+    assert_that!(p.cargo("run"),
                 execs().with_status(0)
                        .with_stderr("\
 [COMPILING] foo v0.5.0 (file://[..])
@@ -645,7 +646,7 @@ fn propagation_of_l_flags() {
         "#, target))
         .build();
 
-    assert_that(p.cargo("build").arg("-v").arg("-j1"),
+    assert_that!(p.cargo("build").arg("-v").arg("-j1"),
                 execs().with_status(0)
                        .with_stderr_contains("\
 [RUNNING] `rustc --crate-name a [..] -L bar[..]-L foo[..]`
@@ -700,7 +701,7 @@ fn propagation_of_l_flags_new() {
         "#, target))
         .build();
 
-    assert_that(p.cargo("build").arg("-v").arg("-j1"),
+    assert_that!(p.cargo("build").arg("-v").arg("-j1"),
                 execs().with_status(0)
                        .with_stderr_contains("\
 [RUNNING] `rustc --crate-name a [..] -L bar[..]-L foo[..]`
@@ -736,7 +737,7 @@ fn build_deps_simple() {
         .file("a/src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("build").arg("-v"),
+    assert_that!(p.cargo("build").arg("-v"),
                 execs().with_status(0)
                        .with_stderr("\
 [COMPILING] a v0.5.0 (file://[..])
@@ -777,7 +778,7 @@ fn build_deps_not_for_normal() {
         .file("a/src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("build").arg("-v").arg("--target").arg(&target),
+    assert_that!(p.cargo("build").arg("-v").arg("--target").arg(&target),
                 execs().with_status(101)
                        .with_stderr_contains("\
 [..]can't find crate for `aaaaa`[..]
@@ -830,7 +831,7 @@ fn build_cmd_with_a_build_cmd() {
         .file("b/src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("build").arg("-v"),
+    assert_that!(p.cargo("build").arg("-v"),
                 execs().with_status(0)
                        .with_stderr("\
 [COMPILING] b v0.5.0 (file://[..])
@@ -882,7 +883,7 @@ fn out_dir_is_preserved() {
         .build();
 
     // Make the file
-    assert_that(p.cargo("build").arg("-v"),
+    assert_that!(p.cargo("build").arg("-v"),
                 execs().with_status(0));
     p.root().move_into_the_past();
 
@@ -896,16 +897,16 @@ fn out_dir_is_preserved() {
         }
     "#).unwrap();
     p.root().move_into_the_past();
-    assert_that(p.cargo("build").arg("-v"),
+    assert_that!(p.cargo("build").arg("-v"),
                 execs().with_status(0));
 
     // Run a fresh build where file should be preserved
-    assert_that(p.cargo("build").arg("-v"),
+    assert_that!(p.cargo("build").arg("-v"),
                 execs().with_status(0));
 
     // One last time to make sure it's still there.
     File::create(&p.root().join("foo")).unwrap();
-    assert_that(p.cargo("build").arg("-v"),
+    assert_that!(p.cargo("build").arg("-v"),
                 execs().with_status(0));
 }
 
@@ -927,7 +928,7 @@ fn output_separate_lines() {
             }
         "#)
         .build();
-    assert_that(p.cargo("build").arg("-v"),
+    assert_that!(p.cargo("build").arg("-v"),
                 execs().with_status(101)
                        .with_stderr_contains("\
 [COMPILING] foo v0.5.0 (file://[..])
@@ -956,7 +957,7 @@ fn output_separate_lines_new() {
             }
         "#)
         .build();
-    assert_that(p.cargo("build").arg("-v"),
+    assert_that!(p.cargo("build").arg("-v"),
                 execs().with_status(101)
                        .with_stderr_contains("\
 [COMPILING] foo v0.5.0 (file://[..])
@@ -1003,7 +1004,7 @@ fn code_generation() {
         "#)
         .build();
 
-    assert_that(p.cargo("run"),
+    assert_that!(p.cargo("run"),
                 execs().with_status(0)
                        .with_stderr("\
 [COMPILING] foo v0.5.0 (file://[..])
@@ -1013,7 +1014,7 @@ fn code_generation() {
 Hello, World!
 "));
 
-    assert_that(p.cargo("test"),
+    assert_that!(p.cargo("test"),
                 execs().with_status(0));
 }
 
@@ -1033,7 +1034,7 @@ fn release_with_build_script() {
         "#)
         .build();
 
-    assert_that(p.cargo("build").arg("-v").arg("--release"),
+    assert_that!(p.cargo("build").arg("-v").arg("--release"),
                 execs().with_status(0));
 }
 
@@ -1049,7 +1050,7 @@ fn build_script_only() {
         "#)
         .file("build.rs", r#"fn main() {}"#)
         .build();
-    assert_that(p.cargo("build").arg("-v"),
+    assert_that!(p.cargo("build").arg("-v"),
                 execs().with_status(101)
                        .with_stderr("\
 [ERROR] failed to parse manifest at `[..]`
@@ -1097,7 +1098,7 @@ fn shared_dep_with_a_build_script() {
         "#)
         .file("b/src/lib.rs", "")
         .build();
-    assert_that(p.cargo("build").arg("-v"),
+    assert_that!(p.cargo("build").arg("-v"),
                 execs().with_status(0));
 }
 
@@ -1141,7 +1142,7 @@ fn transitive_dep_host() {
         "#)
         .file("b/src/lib.rs", "")
         .build();
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0));
 }
 
@@ -1179,7 +1180,7 @@ fn test_a_lib_with_a_build_command() {
             }
         "#)
         .build();
-    assert_that(p.cargo("test"),
+    assert_that!(p.cargo("test"),
                 execs().with_status(0));
 }
 
@@ -1207,7 +1208,7 @@ fn test_dev_dep_build_script() {
         .file("a/src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("test"), execs().with_status(0));
+    assert_that!(p.cargo("test"), execs().with_status(0));
 }
 
 #[test]
@@ -1281,11 +1282,11 @@ fn build_script_with_dynamic_native_dependency() {
         "#)
         .build();
 
-    assert_that(build.cargo("build").arg("-v")
+    assert_that!(build.cargo("build").arg("-v")
                 .env("RUST_LOG", "cargo::ops::cargo_rustc"),
                 execs().with_status(0));
 
-    assert_that(foo.cargo("build").arg("-v").env("SRC", build.root())
+    assert_that!(foo.cargo("build").arg("-v").env("SRC", build.root())
                 .env("RUST_LOG", "cargo::ops::cargo_rustc"),
                 execs().with_status(0));
 }
@@ -1311,7 +1312,7 @@ fn profile_and_opt_level_set_correctly() {
               }
         "#)
         .build();
-    assert_that(build.cargo("bench"),
+    assert_that!(build.cargo("bench"),
                 execs().with_status(0));
 }
 
@@ -1334,7 +1335,7 @@ fn build_script_with_lto() {
               }
         "#)
         .build();
-    assert_that(build.cargo("build"),
+    assert_that!(build.cargo("build"),
                 execs().with_status(0));
 }
 
@@ -1371,7 +1372,7 @@ fn test_duplicate_deps() {
         .file("bar/src/lib.rs", "pub fn do_nothing() {}")
         .build();
 
-    assert_that(p.cargo("build"), execs().with_status(0));
+    assert_that!(p.cargo("build"), execs().with_status(0));
 }
 
 #[test]
@@ -1394,7 +1395,7 @@ fn cfg_feedback() {
             }
         "#)
         .build();
-    assert_that(build.cargo("build").arg("-v"),
+    assert_that!(build.cargo("build").arg("-v"),
                 execs().with_status(0));
 }
 
@@ -1422,7 +1423,7 @@ fn cfg_override() {
         "#, target))
         .build();
 
-    assert_that(p.cargo("build").arg("-v"),
+    assert_that!(p.cargo("build").arg("-v"),
                 execs().with_status(0));
 }
 
@@ -1466,7 +1467,7 @@ fn cfg_test() {
             fn test_bar() {}
         "#)
         .build();
-    assert_that(p.cargo("test").arg("-v"),
+    assert_that!(p.cargo("test").arg("-v"),
                 execs().with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({dir})
 [RUNNING] [..] build.rs [..]
@@ -1523,11 +1524,11 @@ fn cfg_doc() {
             pub fn bar() {}
         "#)
         .build();
-    assert_that(p.cargo("doc"),
+    assert_that!(p.cargo("doc"),
                 execs().with_status(0));
-    assert_that(&p.root().join("target/doc"), existing_dir());
-    assert_that(&p.root().join("target/doc/foo/fn.foo.html"), existing_file());
-    assert_that(&p.root().join("target/doc/bar/fn.bar.html"), existing_file());
+    assert_that!(&p.root().join("target/doc"), existing_dir());
+    assert_that!(&p.root().join("target/doc/foo/fn.foo.html"), existing_file());
+    assert_that!(&p.root().join("target/doc/bar/fn.bar.html"), existing_file());
 }
 
 #[test]
@@ -1571,7 +1572,7 @@ fn cfg_override_test() {
             fn test_bar() {}
         "#)
         .build();
-    assert_that(p.cargo("test").arg("-v"),
+    assert_that!(p.cargo("test").arg("-v"),
                 execs().with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({dir})
 [RUNNING] `[..]`
@@ -1626,11 +1627,11 @@ fn cfg_override_doc() {
             pub fn bar() {}
         "#)
         .build();
-    assert_that(p.cargo("doc"),
+    assert_that!(p.cargo("doc"),
                 execs().with_status(0));
-    assert_that(&p.root().join("target/doc"), existing_dir());
-    assert_that(&p.root().join("target/doc/foo/fn.foo.html"), existing_file());
-    assert_that(&p.root().join("target/doc/bar/fn.bar.html"), existing_file());
+    assert_that!(&p.root().join("target/doc"), existing_dir());
+    assert_that!(&p.root().join("target/doc/foo/fn.foo.html"), existing_file());
+    assert_that!(&p.root().join("target/doc/bar/fn.bar.html"), existing_file());
 }
 
 #[test]
@@ -1655,9 +1656,9 @@ fn env_build() {
             }
         "#)
         .build();
-    assert_that(p.cargo("build").arg("-v"),
+    assert_that!(p.cargo("build").arg("-v"),
                 execs().with_status(0));
-    assert_that(p.cargo("run").arg("-v"),
+    assert_that!(p.cargo("run").arg("-v"),
                 execs().with_status(0).with_stdout("foo\n"));
 }
 
@@ -1688,7 +1689,7 @@ fn env_test() {
             }
         "#)
         .build();
-    assert_that(p.cargo("test").arg("-v"),
+    assert_that!(p.cargo("test").arg("-v"),
                 execs().with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({dir})
 [RUNNING] [..] build.rs [..]
@@ -1725,7 +1726,7 @@ fn env_doc() {
             }
         "#)
         .build();
-    assert_that(p.cargo("doc").arg("-v"),
+    assert_that!(p.cargo("doc").arg("-v"),
                 execs().with_status(0));
 }
 
@@ -1767,7 +1768,7 @@ fn flags_go_into_tests() {
         "#)
         .build();
 
-    assert_that(p.cargo("test").arg("-v").arg("--test=foo"),
+    assert_that!(p.cargo("test").arg("-v").arg("--test=foo"),
                 execs().with_status(0)
                        .with_stderr("\
 [COMPILING] a v0.5.0 ([..]
@@ -1783,7 +1784,7 @@ fn flags_go_into_tests() {
 [RUNNING] `[..][/]foo-[..][EXE]`")
                        .with_stdout_contains("running 0 tests"));
 
-    assert_that(p.cargo("test").arg("-v").arg("-pb").arg("--lib"),
+    assert_that!(p.cargo("test").arg("-v").arg("-pb").arg("--lib"),
                 execs().with_status(0)
                        .with_stderr("\
 [FRESH] a v0.5.0 ([..]
@@ -1843,7 +1844,7 @@ fn diamond_passes_args_only_once() {
         .file("c/src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("build").arg("-v"),
+    assert_that!(p.cargo("build").arg("-v"),
                 execs().with_status(0).with_stderr("\
 [COMPILING] c v0.5.0 ([..]
 [RUNNING] `rustc [..]`
@@ -1880,7 +1881,7 @@ fn adding_an_override_invalidates() {
         "#)
         .build();
 
-    assert_that(p.cargo("build").arg("-v"),
+    assert_that!(p.cargo("build").arg("-v"),
                 execs().with_status(0).with_stderr("\
 [COMPILING] foo v0.5.0 ([..]
 [RUNNING] `rustc [..]`
@@ -1894,7 +1895,7 @@ fn adding_an_override_invalidates() {
         rustc-link-search = [\"native=bar\"]
     ", target).as_bytes()).unwrap();
 
-    assert_that(p.cargo("build").arg("-v"),
+    assert_that!(p.cargo("build").arg("-v"),
                 execs().with_status(0).with_stderr("\
 [COMPILING] foo v0.5.0 ([..]
 [RUNNING] `rustc [..] -L native=bar`
@@ -1922,7 +1923,7 @@ fn changing_an_override_invalidates() {
         .file("build.rs", "")
         .build();
 
-    assert_that(p.cargo("build").arg("-v"),
+    assert_that!(p.cargo("build").arg("-v"),
                 execs().with_status(0).with_stderr("\
 [COMPILING] foo v0.5.0 ([..]
 [RUNNING] `rustc [..] -L native=foo`
@@ -1934,7 +1935,7 @@ fn changing_an_override_invalidates() {
         rustc-link-search = [\"native=bar\"]
     ", target).as_bytes()).unwrap();
 
-    assert_that(p.cargo("build").arg("-v"),
+    assert_that!(p.cargo("build").arg("-v"),
                 execs().with_status(0).with_stderr("\
 [COMPILING] foo v0.5.0 ([..]
 [RUNNING] `rustc [..] -L native=bar`
@@ -1966,14 +1967,14 @@ fn fresh_builds_possible_with_link_libs() {
         .file("build.rs", "")
         .build();
 
-    assert_that(p.cargo("build").arg("-v"),
+    assert_that!(p.cargo("build").arg("-v"),
                 execs().with_status(0).with_stderr("\
 [COMPILING] foo v0.5.0 ([..]
 [RUNNING] `rustc [..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
 
-    assert_that(p.cargo("build")
+    assert_that!(p.cargo("build")
                  .arg("-v")
                  .env("RUST_LOG", "cargo::ops::cargo_rustc::fingerprint=info"),
                 execs().with_status(0).with_stderr("\
@@ -2008,14 +2009,14 @@ fn fresh_builds_possible_with_multiple_metadata_overrides() {
         .file("build.rs", "")
         .build();
 
-    assert_that(p.cargo("build").arg("-v"),
+    assert_that!(p.cargo("build").arg("-v"),
                 execs().with_status(0).with_stderr("\
 [COMPILING] foo v0.5.0 ([..]
 [RUNNING] `rustc [..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
 
-    assert_that(p.cargo("build")
+    assert_that!(p.cargo("build")
                  .arg("-v")
                  .env("RUST_LOG", "cargo::ops::cargo_rustc::fingerprint=info"),
                 execs().with_status(0).with_stderr("\
@@ -2044,12 +2045,12 @@ fn rebuild_only_on_explicit_paths() {
         "#)
         .build();
 
-    assert_that(p.cargo("build").arg("-v"),
+    assert_that!(p.cargo("build").arg("-v"),
                 execs().with_status(0));
 
     // files don't exist, so should always rerun if they don't exist
     println!("run without");
-    assert_that(p.cargo("build").arg("-v"),
+    assert_that!(p.cargo("build").arg("-v"),
                 execs().with_status(0).with_stderr("\
 [COMPILING] a v0.5.0 ([..])
 [RUNNING] `[..][/]build-script-build`
@@ -2063,7 +2064,7 @@ fn rebuild_only_on_explicit_paths() {
 
     // now the exist, so run once, catch the mtime, then shouldn't run again
     println!("run with");
-    assert_that(p.cargo("build").arg("-v"),
+    assert_that!(p.cargo("build").arg("-v"),
                 execs().with_status(0).with_stderr("\
 [COMPILING] a v0.5.0 ([..])
 [RUNNING] `[..][/]build-script-build`
@@ -2072,7 +2073,7 @@ fn rebuild_only_on_explicit_paths() {
 "));
 
     println!("run with2");
-    assert_that(p.cargo("build").arg("-v"),
+    assert_that!(p.cargo("build").arg("-v"),
                 execs().with_status(0).with_stderr("\
 [FRESH] a v0.5.0 ([..])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
@@ -2083,7 +2084,7 @@ fn rebuild_only_on_explicit_paths() {
     // random other files do not affect freshness
     println!("run baz");
     File::create(p.root().join("baz")).unwrap();
-    assert_that(p.cargo("build").arg("-v"),
+    assert_that!(p.cargo("build").arg("-v"),
                 execs().with_status(0).with_stderr("\
 [FRESH] a v0.5.0 ([..])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
@@ -2092,7 +2093,7 @@ fn rebuild_only_on_explicit_paths() {
     // but changing dependent files does
     println!("run foo change");
     File::create(p.root().join("foo")).unwrap();
-    assert_that(p.cargo("build").arg("-v"),
+    assert_that!(p.cargo("build").arg("-v"),
                 execs().with_status(0).with_stderr("\
 [COMPILING] a v0.5.0 ([..])
 [RUNNING] `[..][/]build-script-build`
@@ -2103,7 +2104,7 @@ fn rebuild_only_on_explicit_paths() {
     // .. as does deleting a file
     println!("run foo delete");
     fs::remove_file(p.root().join("bar")).unwrap();
-    assert_that(p.cargo("build").arg("-v"),
+    assert_that!(p.cargo("build").arg("-v"),
                 execs().with_status(0).with_stderr("\
 [COMPILING] a v0.5.0 ([..])
 [RUNNING] `[..][/]build-script-build`
@@ -2141,7 +2142,7 @@ fn doctest_recieves_build_link_args() {
         "#)
         .build();
 
-    assert_that(p.cargo("test").arg("-v"),
+    assert_that!(p.cargo("test").arg("-v"),
                 execs().with_status(0)
                        .with_stderr_contains("\
 [RUNNING] `rustdoc --test [..] --crate-name foo [..]-L native=bar[..]`
@@ -2183,7 +2184,7 @@ fn please_respect_the_dag() {
         "#)
         .build();
 
-    assert_that(p.cargo("build").arg("-v"),
+    assert_that!(p.cargo("build").arg("-v"),
                 execs().with_status(0)
                        .with_stderr_contains("\
 [RUNNING] `rustc [..] -L native=foo -L native=bar[..]`
@@ -2221,7 +2222,7 @@ fn non_utf8_output() {
         "#)
         .build();
 
-    assert_that(p.cargo("build").arg("-v"),
+    assert_that!(p.cargo("build").arg("-v"),
                 execs().with_status(0));
 }
 
@@ -2253,7 +2254,7 @@ fn custom_target_dir() {
         .file("a/src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("build").arg("-v"),
+    assert_that!(p.cargo("build").arg("-v"),
                 execs().with_status(0));
 }
 
@@ -2294,7 +2295,7 @@ fn panic_abort_with_build_scripts() {
         .file("b/src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("build").arg("-v").arg("--release"),
+    assert_that!(p.cargo("build").arg("-v").arg("--release"),
                 execs().with_status(0));
 }
 
@@ -2317,7 +2318,7 @@ fn warnings_emitted() {
         "#)
         .build();
 
-    assert_that(p.cargo("build").arg("-v"),
+    assert_that!(p.cargo("build").arg("-v"),
                 execs().with_status(0)
                        .with_stderr("\
 [COMPILING] foo v0.5.0 ([..])
@@ -2362,7 +2363,7 @@ fn warnings_hidden_for_upstream() {
         .file("src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("build").arg("-v"),
+    assert_that!(p.cargo("build").arg("-v"),
                 execs().with_status(0)
                        .with_stderr("\
 [UPDATING] registry `[..]`
@@ -2409,7 +2410,7 @@ fn warnings_printed_on_vv() {
         .file("src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("build").arg("-vv"),
+    assert_that!(p.cargo("build").arg("-vv"),
                 execs().with_status(0)
                        .with_stderr("\
 [UPDATING] registry `[..]`
@@ -2447,7 +2448,7 @@ fn output_shows_on_vv() {
         "#)
         .build();
 
-    assert_that(p.cargo("build").arg("-vv"),
+    assert_that!(p.cargo("build").arg("-vv"),
                 execs().with_status(0)
                        .with_stdout("\
 stdout
@@ -2487,7 +2488,7 @@ fn links_with_dots() {
         "#, target))
         .build();
 
-    assert_that(p.cargo("build").arg("-v"),
+    assert_that!(p.cargo("build").arg("-v"),
                 execs().with_status(0)
                        .with_stderr_contains("\
 [RUNNING] `rustc --crate-name foo [..] [..] -L foo[..]`
@@ -2514,7 +2515,7 @@ fn rustc_and_rustdoc_set_correctly() {
               }
         "#)
         .build();
-    assert_that(p.cargo("bench"),
+    assert_that!(p.cargo("bench"),
                 execs().with_status(0));
 }
 
@@ -2542,7 +2543,7 @@ fn cfg_env_vars_available() {
             }
         "#)
         .build();
-    assert_that(p.cargo("bench"),
+    assert_that!(p.cargo("bench"),
                 execs().with_status(0));
 }
 
@@ -2584,11 +2585,11 @@ fn switch_features_rerun() {
         "#)
         .build();
 
-    assert_that(p.cargo("run").arg("-v").arg("--features=foo"),
+    assert_that!(p.cargo("run").arg("-v").arg("--features=foo"),
                 execs().with_status(0).with_stdout("foo\n"));
-    assert_that(p.cargo("run").arg("-v"),
+    assert_that!(p.cargo("run").arg("-v"),
                 execs().with_status(0).with_stdout("bar\n"));
-    assert_that(p.cargo("run").arg("-v").arg("--features=foo"),
+    assert_that!(p.cargo("run").arg("-v").arg("--features=foo"),
                 execs().with_status(0).with_stdout("foo\n"));
 }
 
@@ -2615,7 +2616,7 @@ fn assume_build_script_when_build_rs_present() {
         "#)
         .build();
 
-    assert_that(p.cargo("run").arg("-v"),
+    assert_that!(p.cargo("run").arg("-v"),
                 execs().with_status(0));
 }
 
@@ -2643,7 +2644,7 @@ fn if_build_set_to_false_dont_treat_build_rs_as_build_script() {
         "#)
         .build();
 
-    assert_that(p.cargo("run").arg("-v"),
+    assert_that!(p.cargo("run").arg("-v"),
                 execs().with_status(0));
 }
 
@@ -2731,7 +2732,7 @@ fn deterministic_rustc_dependency_flags() {
         "#)
         .build();
 
-    assert_that(p.cargo("build").arg("-v"),
+    assert_that!(p.cargo("build").arg("-v"),
                 execs().with_status(0)
                     .with_stderr_contains("\
 [RUNNING] `rustc --crate-name foo [..] -L native=test1 -L native=test2 \
@@ -2780,7 +2781,7 @@ fn links_duplicates_with_cycle() {
         .file("b/src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(101)
                        .with_stderr("\
 [ERROR] multiple packages link to native library `a`, but a native library can \
@@ -2815,7 +2816,7 @@ fn rename_with_link_search_path() {
         ");
     let p = p.build();
 
-    assert_that(p.cargo("build"), execs().with_status(0));
+    assert_that!(p.cargo("build"), execs().with_status(0));
 
     let p2 = project("bar")
         .file("Cargo.toml", r#"
@@ -2883,7 +2884,7 @@ fn rename_with_link_search_path() {
     fs::remove_dir_all(p.root()).unwrap();
 
     // Everything should work the first time
-    assert_that(p2.cargo("run"),
+    assert_that!(p2.cargo("run"),
                 execs().with_status(0));
 
     // Now rename the root directory and rerun `cargo run`. Not only should we
@@ -2892,7 +2893,7 @@ fn rename_with_link_search_path() {
     new.pop();
     new.push("bar2");
     fs::rename(p2.root(), &new).unwrap();
-    assert_that(p2.cargo("run").cwd(&new),
+    assert_that!(p2.cargo("run").cwd(&new),
                 execs().with_status(0)
                        .with_stderr("\
 [FINISHED] [..]

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -1,6 +1,7 @@
 extern crate cargo;
 #[macro_use]
 extern crate cargotest;
+#[macro_use]
 extern crate hamcrest;
 extern crate tempdir;
 
@@ -15,7 +16,7 @@ use cargotest::support::paths::{CargoPathExt,root};
 use cargotest::support::{ProjectBuilder};
 use cargotest::support::{project, execs, main_file, basic_bin_manifest};
 use cargotest::support::registry::Package;
-use hamcrest::{assert_that, existing_file, existing_dir, is_not};
+use hamcrest::prelude::*;
 use tempdir::TempDir;
 
 #[test]
@@ -25,10 +26,10 @@ fn cargo_compile_simple() {
         .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
         .build();
 
-    assert_that(p.cargo("build"), execs().with_status(0));
-    assert_that(&p.bin("foo"), existing_file());
+    assert_that!(p.cargo("build"), execs().with_status(0));
+    assert_that!(&p.bin("foo"), existing_file());
 
-    assert_that(process(&p.bin("foo")),
+    assert_that!(process(&p.bin("foo")),
                 execs().with_status(0).with_stdout("i am foo\n"));
 }
 
@@ -38,7 +39,7 @@ fn cargo_fail_with_no_stderr() {
         .file("Cargo.toml", &basic_bin_manifest("foo"))
         .file("src/foo.rs", &String::from("refusal"))
         .build();
-    assert_that(p.cargo("build").arg("--message-format=json"), execs().with_status(101)
+    assert_that!(p.cargo("build").arg("--message-format=json"), execs().with_status(101)
         .with_stderr_does_not_contain("--- stderr"));
 }
 
@@ -55,13 +56,13 @@ fn cargo_compile_incremental() {
         .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
         .build();
 
-    assert_that(
+    assert_that!(
         p.cargo("build").arg("-v").env("CARGO_INCREMENTAL", "1"),
         execs().with_stderr_contains(
             "[RUNNING] `rustc [..] -C incremental=[..][/]target[/]debug[/]incremental[..]`\n")
             .with_status(0));
 
-    assert_that(
+    assert_that!(
         p.cargo("test").arg("-v").env("CARGO_INCREMENTAL", "1"),
         execs().with_stderr_contains(
             "[RUNNING] `rustc [..] -C incremental=[..][/]target[/]debug[/]incremental[..]`\n")
@@ -90,22 +91,22 @@ fn incremental_profile() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    assert_that(
+    assert_that!(
         p.cargo("build").arg("-v").env_remove("CARGO_INCREMENTAL"),
         execs().with_stderr_does_not_contain("[..]C incremental=[..]")
             .with_status(0));
 
-    assert_that(
+    assert_that!(
         p.cargo("build").arg("-v").env("CARGO_INCREMENTAL", "1"),
         execs().with_stderr_contains("[..]C incremental=[..]")
             .with_status(0));
 
-    assert_that(
+    assert_that!(
         p.cargo("build").arg("--release").arg("-v").env_remove("CARGO_INCREMENTAL"),
         execs().with_stderr_contains("[..]C incremental=[..]")
             .with_status(0));
 
-    assert_that(
+    assert_that!(
         p.cargo("build").arg("--release").arg("-v").env("CARGO_INCREMENTAL", "0"),
         execs().with_stderr_does_not_contain("[..]C incremental=[..]")
             .with_status(0));
@@ -131,12 +132,12 @@ fn incremental_config() {
         "#)
         .build();
 
-    assert_that(
+    assert_that!(
         p.cargo("build").arg("-v").env_remove("CARGO_INCREMENTAL"),
         execs().with_stderr_does_not_contain("[..]C incremental=[..]")
             .with_status(0));
 
-    assert_that(
+    assert_that!(
         p.cargo("build").arg("-v").env("CARGO_INCREMENTAL", "1"),
         execs().with_stderr_contains("[..]C incremental=[..]")
             .with_status(0));
@@ -149,11 +150,11 @@ fn cargo_compile_manifest_path() {
         .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
         .build();
 
-    assert_that(p.cargo("build")
+    assert_that!(p.cargo("build")
                  .arg("--manifest-path").arg("foo/Cargo.toml")
                  .cwd(p.root().parent().unwrap()),
                 execs().with_status(0));
-    assert_that(&p.bin("foo"), existing_file());
+    assert_that!(&p.bin("foo"), existing_file());
 }
 
 #[test]
@@ -162,7 +163,7 @@ fn cargo_compile_with_invalid_manifest() {
         .file("Cargo.toml", "")
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
         execs()
         .with_status(101)
         .with_stderr("\
@@ -182,7 +183,7 @@ fn cargo_compile_with_invalid_manifest2() {
         ")
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
         execs()
         .with_status(101)
         .with_stderr("\
@@ -208,7 +209,7 @@ fn cargo_compile_with_invalid_manifest3() {
         .file("src/Cargo.toml", "a = bar")
         .build();
 
-    assert_that(p.cargo("build").arg("--manifest-path")
+    assert_that!(p.cargo("build").arg("--manifest-path")
                  .arg("src/Cargo.toml"),
         execs()
         .with_status(101)
@@ -245,7 +246,7 @@ fn cargo_compile_duplicate_build_targets() {
         "#)
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs()
                 .with_status(0)
                 .with_stderr("\
@@ -266,7 +267,7 @@ fn cargo_compile_with_invalid_version() {
         "#)
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs()
                 .with_status(101)
                 .with_stderr("\
@@ -289,7 +290,7 @@ fn cargo_compile_with_invalid_package_name() {
         "#)
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs()
                 .with_status(101)
                 .with_stderr("\
@@ -314,7 +315,7 @@ fn cargo_compile_with_invalid_bin_target_name() {
         "#)
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs()
                 .with_status(101)
                 .with_stderr("\
@@ -339,7 +340,7 @@ fn cargo_compile_with_forbidden_bin_target_name() {
         "#)
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs()
                 .with_status(101)
                 .with_stderr("\
@@ -364,7 +365,7 @@ fn cargo_compile_with_invalid_lib_target_name() {
         "#)
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs()
                 .with_status(101)
                 .with_stderr("\
@@ -380,7 +381,7 @@ fn cargo_compile_without_manifest() {
     let tmpdir = TempDir::new("cargo").unwrap();
     let p = ProjectBuilder::new("foo", tmpdir.path().to_path_buf()).build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(101)
                        .with_stderr("\
 [ERROR] could not find `Cargo.toml` in `[..]` or any parent directory
@@ -394,14 +395,14 @@ fn cargo_compile_with_invalid_code() {
         .file("src/foo.rs", "invalid rust code!")
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
         execs()
         .with_status(101)
         .with_stderr_contains("\
 [ERROR] Could not compile `foo`.
 
 To learn more, run the command again with --verbose.\n"));
-    assert_that(&p.root().join("Cargo.lock"), existing_file());
+    assert_that!(&p.root().join("Cargo.lock"), existing_file());
 }
 
 #[test]
@@ -428,7 +429,7 @@ fn cargo_compile_with_invalid_code_in_deps() {
         .file("Cargo.toml", &basic_bin_manifest("baz"))
         .file("src/lib.rs", "invalid rust code!")
         .build();
-    assert_that(p.cargo("build"), execs().with_status(101));
+    assert_that!(p.cargo("build"), execs().with_status(101));
 }
 
 #[test]
@@ -438,7 +439,7 @@ fn cargo_compile_with_warnings_in_the_root_package() {
         .file("src/foo.rs", "fn main() {} fn dead() {}")
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0).with_stderr_contains("\
 [..]function is never used: `dead`[..]
 "));
@@ -483,14 +484,14 @@ fn cargo_compile_with_warnings_in_a_dep_package() {
         "#)
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
         execs().with_status(0).with_stderr_contains("\
 [..]function is never used: `dead`[..]
 "));
 
-    assert_that(&p.bin("foo"), existing_file());
+    assert_that!(&p.bin("foo"), existing_file());
 
-    assert_that(
+    assert_that!(
       process(&p.bin("foo")),
       execs().with_status(0).with_stdout("test passed\n"));
 }
@@ -548,11 +549,11 @@ fn cargo_compile_with_nested_deps_inferred() {
         .exec_with_output()
         .unwrap();
 
-    assert_that(&p.bin("foo"), existing_file());
-    assert_that(&p.bin("libbar.rlib"), is_not(existing_file()));
-    assert_that(&p.bin("libbaz.rlib"), is_not(existing_file()));
+    assert_that!(&p.bin("foo"), existing_file());
+    assert_that!(&p.bin("libbar.rlib"), is_not(existing_file()));
+    assert_that!(&p.bin("libbaz.rlib"), is_not(existing_file()));
 
-    assert_that(
+    assert_that!(
       process(&p.bin("foo")),
       execs().with_status(0).with_stdout("test passed\n"));
 }
@@ -610,11 +611,11 @@ fn cargo_compile_with_nested_deps_correct_bin() {
         .exec_with_output()
         .unwrap();
 
-    assert_that(&p.bin("foo"), existing_file());
-    assert_that(&p.bin("libbar.rlib"), is_not(existing_file()));
-    assert_that(&p.bin("libbaz.rlib"), is_not(existing_file()));
+    assert_that!(&p.bin("foo"), existing_file());
+    assert_that!(&p.bin("libbar.rlib"), is_not(existing_file()));
+    assert_that!(&p.bin("libbaz.rlib"), is_not(existing_file()));
 
-    assert_that(
+    assert_that!(
       process(&p.bin("foo")),
       execs().with_status(0).with_stdout("test passed\n"));
 }
@@ -677,11 +678,11 @@ fn cargo_compile_with_nested_deps_shorthand() {
         .exec_with_output()
         .unwrap();
 
-    assert_that(&p.bin("foo"), existing_file());
-    assert_that(&p.bin("libbar.rlib"), is_not(existing_file()));
-    assert_that(&p.bin("libbaz.rlib"), is_not(existing_file()));
+    assert_that!(&p.bin("foo"), existing_file());
+    assert_that!(&p.bin("libbar.rlib"), is_not(existing_file()));
+    assert_that!(&p.bin("libbaz.rlib"), is_not(existing_file()));
 
-    assert_that(
+    assert_that!(
       process(&p.bin("foo")),
       execs().with_status(0).with_stdout("test passed\n"));
 }
@@ -746,13 +747,13 @@ fn cargo_compile_with_nested_deps_longhand() {
         "#)
         .build();
 
-    assert_that(p.cargo("build"), execs());
+    assert_that!(p.cargo("build"), execs());
 
-    assert_that(&p.bin("foo"), existing_file());
-    assert_that(&p.bin("libbar.rlib"), is_not(existing_file()));
-    assert_that(&p.bin("libbaz.rlib"), is_not(existing_file()));
+    assert_that!(&p.bin("foo"), existing_file());
+    assert_that!(&p.bin("libbar.rlib"), is_not(existing_file()));
+    assert_that!(&p.bin("libbaz.rlib"), is_not(existing_file()));
 
-    assert_that(process(&p.bin("foo")),
+    assert_that!(process(&p.bin("foo")),
                 execs().with_status(0).with_stdout("test passed\n"));
 }
 
@@ -781,7 +782,7 @@ fn cargo_compile_with_dep_name_mismatch() {
         .file("bar/src/bar.rs", &main_file(r#""i am bar""#, &[]))
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(101).with_stderr(&format!(
 r#"[ERROR] no matching package named `notquitebar` found (required by `foo`)
 location searched: {proj_dir}/bar
@@ -808,21 +809,21 @@ fn cargo_compile_with_filename() {
         "#)
         .build();
 
-    assert_that(p.cargo("build").arg("--bin").arg("bin.rs"),
+    assert_that!(p.cargo("build").arg("--bin").arg("bin.rs"),
                 execs().with_status(101).with_stderr("\
 [ERROR] no bin target named `bin.rs`"));
 
-    assert_that(p.cargo("build").arg("--bin").arg("a.rs"),
+    assert_that!(p.cargo("build").arg("--bin").arg("a.rs"),
                 execs().with_status(101).with_stderr("\
 [ERROR] no bin target named `a.rs`
 
 Did you mean `a`?"));
 
-    assert_that(p.cargo("build").arg("--example").arg("example.rs"),
+    assert_that!(p.cargo("build").arg("--example").arg("example.rs"),
                 execs().with_status(101).with_stderr("\
 [ERROR] no example target named `example.rs`"));
 
-    assert_that(p.cargo("build").arg("--example").arg("a.rs"),
+    assert_that!(p.cargo("build").arg("--example").arg("a.rs"),
                 execs().with_status(101).with_stderr("\
 [ERROR] no example target named `a.rs`
 
@@ -851,7 +852,7 @@ fn compile_path_dep_then_change_version() {
         .file("bar/src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("build"), execs().with_status(0));
+    assert_that!(p.cargo("build"), execs().with_status(0));
 
     File::create(&p.root().join("bar/Cargo.toml")).unwrap().write_all(br#"
         [package]
@@ -860,7 +861,7 @@ fn compile_path_dep_then_change_version() {
         authors = []
     "#).unwrap();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(101).with_stderr("\
 [ERROR] no matching version `= 0.0.1` found for package `bar` (required by `foo`)
 location searched: [..]
@@ -884,7 +885,7 @@ fn ignores_carriage_return_in_lockfile() {
         .file("src/a.rs", "")
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0));
 
     let lockfile = p.root().join("Cargo.lock");
@@ -892,7 +893,7 @@ fn ignores_carriage_return_in_lockfile() {
     File::open(&lockfile).unwrap().read_to_string(&mut lock).unwrap();
     let lock = lock.replace("\n", "\r\n");
     File::create(&lockfile).unwrap().write_all(lock.as_bytes()).unwrap();
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0));
 }
 
@@ -925,7 +926,7 @@ fn cargo_default_env_metadata_env_var() {
         .build();
 
     // No metadata on libbar since it's a dylib path dependency
-    assert_that(p.cargo("build").arg("-v"),
+    assert_that!(p.cargo("build").arg("-v"),
                 execs().with_status(0).with_stderr(&format!("\
 [COMPILING] bar v0.0.1 ({url}/bar)
 [RUNNING] `rustc --crate-name bar bar[/]src[/]lib.rs --crate-type dylib \
@@ -949,10 +950,10 @@ prefix = env::consts::DLL_PREFIX,
 suffix = env::consts::DLL_SUFFIX,
 )));
 
-    assert_that(p.cargo("clean"), execs().with_status(0));
+    assert_that!(p.cargo("clean"), execs().with_status(0));
 
     // If you set the env-var, then we expect metadata on libbar
-    assert_that(p.cargo("build").arg("-v").env("__CARGO_DEFAULT_LIB_METADATA", "stable"),
+    assert_that!(p.cargo("build").arg("-v").env("__CARGO_DEFAULT_LIB_METADATA", "stable"),
                 execs().with_status(0).with_stderr(&format!("\
 [COMPILING] bar v0.0.1 ({url}/bar)
 [RUNNING] `rustc --crate-name bar bar[/]src[/]lib.rs --crate-type dylib \
@@ -1030,15 +1031,15 @@ fn crate_env_vars() {
         .build();
 
     println!("build");
-    assert_that(p.cargo("build").arg("-v"), execs().with_status(0));
+    assert_that!(p.cargo("build").arg("-v"), execs().with_status(0));
 
     println!("bin");
-    assert_that(process(&p.bin("foo")),
+    assert_that!(process(&p.bin("foo")),
                 execs().with_status(0).with_stdout(&format!("0-5-1 @ alpha.1 in {}\n",
                                                    p.root().display())));
 
     println!("test");
-    assert_that(p.cargo("test").arg("-v"),
+    assert_that!(p.cargo("test").arg("-v"),
                 execs().with_status(0));
 }
 
@@ -1071,14 +1072,14 @@ fn crate_authors_env_vars() {
         .build();
 
     println!("build");
-    assert_that(p.cargo("build").arg("-v"), execs().with_status(0));
+    assert_that!(p.cargo("build").arg("-v"), execs().with_status(0));
 
     println!("bin");
-    assert_that(process(&p.bin("foo")),
+    assert_that!(process(&p.bin("foo")),
                 execs().with_status(0).with_stdout("wycats@example.com:neikos@example.com"));
 
     println!("test");
-    assert_that(p.cargo("test").arg("-v"),
+    assert_that!(p.cargo("test").arg("-v"),
                 execs().with_status(0));
 }
 
@@ -1113,7 +1114,7 @@ fn crate_library_path_env_var() {
         "##, dylib_path_envvar()))
         .build();
 
-    assert_that(setenv_for_removing_empty_component(p.cargo("run")),
+    assert_that!(setenv_for_removing_empty_component(p.cargo("run")),
                 execs().with_status(0));
 }
 
@@ -1134,7 +1135,7 @@ fn build_with_fake_libc_not_loading() {
         .file("libc.so.6", r#""#)
         .build();
 
-    assert_that(setenv_for_removing_empty_component(p.cargo("build")),
+    assert_that!(setenv_for_removing_empty_component(p.cargo("build")),
                 execs().with_status(0));
 }
 
@@ -1158,14 +1159,14 @@ fn many_crate_types_old_style_lib_location() {
             pub fn foo() {}
         "#)
         .build();
-    assert_that(p.cargo("build"), execs().with_status(0).with_stderr_contains("\
+    assert_that!(p.cargo("build"), execs().with_status(0).with_stderr_contains("\
 [WARNING] path `[..]src[/]foo.rs` was erroneously implicitly accepted for library `foo`,
 please rename the file to `src/lib.rs` or set lib.path in Cargo.toml"));
 
-    assert_that(&p.root().join("target/debug/libfoo.rlib"), existing_file());
+    assert_that!(&p.root().join("target/debug/libfoo.rlib"), existing_file());
     let fname = format!("{}foo{}", env::consts::DLL_PREFIX,
                         env::consts::DLL_SUFFIX);
-    assert_that(&p.root().join("target/debug").join(&fname), existing_file());
+    assert_that!(&p.root().join("target/debug").join(&fname), existing_file());
 }
 
 #[test]
@@ -1187,13 +1188,13 @@ fn many_crate_types_correct() {
             pub fn foo() {}
         "#)
         .build();
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0));
 
-    assert_that(&p.root().join("target/debug/libfoo.rlib"), existing_file());
+    assert_that!(&p.root().join("target/debug/libfoo.rlib"), existing_file());
     let fname = format!("{}foo{}", env::consts::DLL_PREFIX,
                         env::consts::DLL_SUFFIX);
-    assert_that(&p.root().join("target/debug").join(&fname), existing_file());
+    assert_that!(&p.root().join("target/debug").join(&fname), existing_file());
 }
 
 #[test]
@@ -1216,7 +1217,7 @@ fn self_dependency() {
         "#)
         .file("src/test.rs", "fn main() {}")
         .build();
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(101)
                        .with_stderr("\
 [ERROR] cyclic package dependency: package `test v0.0.0 ([..])` depends on itself
@@ -1234,10 +1235,10 @@ fn ignore_broken_symlinks() {
         .symlink("Notafile", "bar")
         .build();
 
-    assert_that(p.cargo("build"), execs().with_status(0));
-    assert_that(&p.bin("foo"), existing_file());
+    assert_that!(p.cargo("build"), execs().with_status(0));
+    assert_that!(&p.bin("foo"), existing_file());
 
-    assert_that(process(&p.bin("foo")),
+    assert_that!(process(&p.bin("foo")),
                 execs().with_status(0).with_stdout("i am foo\n"));
 }
 
@@ -1252,7 +1253,7 @@ fn missing_lib_and_bin() {
             authors = []
         "#)
         .build();
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(101)
                        .with_stderr("\
 [ERROR] failed to parse manifest at `[..]Cargo.toml`
@@ -1282,7 +1283,7 @@ fn lto_build() {
         "#)
         .file("src/main.rs", "fn main() {}")
         .build();
-    assert_that(p.cargo("build").arg("-v").arg("--release"),
+    assert_that!(p.cargo("build").arg("-v").arg("--release"),
                 execs().with_status(0).with_stderr(&format!("\
 [COMPILING] test v0.0.0 ({url})
 [RUNNING] `rustc --crate-name test src[/]main.rs --crate-type bin \
@@ -1311,7 +1312,7 @@ fn verbose_build() {
         "#)
         .file("src/lib.rs", "")
         .build();
-    assert_that(p.cargo("build").arg("-v"),
+    assert_that!(p.cargo("build").arg("-v"),
                 execs().with_status(0).with_stderr(&format!("\
 [COMPILING] test v0.0.0 ({url})
 [RUNNING] `rustc --crate-name test src[/]lib.rs --crate-type lib \
@@ -1338,7 +1339,7 @@ fn verbose_release_build() {
         "#)
         .file("src/lib.rs", "")
         .build();
-    assert_that(p.cargo("build").arg("-v").arg("--release"),
+    assert_that!(p.cargo("build").arg("-v").arg("--release"),
                 execs().with_status(0).with_stderr(&format!("\
 [COMPILING] test v0.0.0 ({url})
 [RUNNING] `rustc --crate-name test src[/]lib.rs --crate-type lib \
@@ -1381,7 +1382,7 @@ fn verbose_release_build_deps() {
         "#)
         .file("foo/src/lib.rs", "")
         .build();
-    assert_that(p.cargo("build").arg("-v").arg("--release"),
+    assert_that!(p.cargo("build").arg("-v").arg("--release"),
                 execs().with_status(0).with_stderr(&format!("\
 [COMPILING] foo v0.0.0 ({url}/foo)
 [RUNNING] `rustc --crate-name foo foo[/]src[/]lib.rs \
@@ -1445,10 +1446,10 @@ fn explicit_examples() {
         "#)
         .build();
 
-    assert_that(p.cargo("test").arg("-v"), execs().with_status(0));
-    assert_that(process(&p.bin("examples/hello")),
+    assert_that!(p.cargo("test").arg("-v"), execs().with_status(0));
+    assert_that!(process(&p.bin("examples/hello")),
                         execs().with_status(0).with_stdout("Hello, World!\n"));
-    assert_that(process(&p.bin("examples/goodbye")),
+    assert_that!(process(&p.bin("examples/goodbye")),
                         execs().with_status(0).with_stdout("Goodbye, World!\n"));
 }
 
@@ -1472,7 +1473,7 @@ fn non_existing_example() {
         .file("examples/ehlo.rs", "")
         .build();
 
-    assert_that(p.cargo("test").arg("-v"), execs().with_status(101).with_stderr("\
+    assert_that!(p.cargo("test").arg("-v"), execs().with_status(101).with_stderr("\
 [ERROR] failed to parse manifest at `[..]`
 
 Caused by:
@@ -1495,7 +1496,7 @@ fn non_existing_binary() {
         .file("src/bin/ehlo.rs", "")
         .build();
 
-    assert_that(p.cargo("build").arg("-v"), execs().with_status(101).with_stderr("\
+    assert_that!(p.cargo("build").arg("-v"), execs().with_status(101).with_stderr("\
 [ERROR] failed to parse manifest at `[..]`
 
 Caused by:
@@ -1518,7 +1519,7 @@ fn legacy_binary_paths_warinigs() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    assert_that(p.cargo("build").arg("-v"), execs().with_status(0).with_stderr_contains("\
+    assert_that!(p.cargo("build").arg("-v"), execs().with_status(0).with_stderr_contains("\
 [WARNING] path `[..]src[/]main.rs` was erroneously implicitly accepted for binary `bar`,
 please set bin.path in Cargo.toml"));
 
@@ -1536,7 +1537,7 @@ please set bin.path in Cargo.toml"));
         .file("src/bin/main.rs", "fn main() {}")
         .build();
 
-    assert_that(p.cargo("build").arg("-v"), execs().with_status(0).with_stderr_contains("\
+    assert_that!(p.cargo("build").arg("-v"), execs().with_status(0).with_stderr_contains("\
 [WARNING] path `[..]src[/]bin[/]main.rs` was erroneously implicitly accepted for binary `bar`,
 please set bin.path in Cargo.toml"));
 
@@ -1553,7 +1554,7 @@ please set bin.path in Cargo.toml"));
         .file("src/bar.rs", "fn main() {}")
         .build();
 
-    assert_that(p.cargo("build").arg("-v"), execs().with_status(0).with_stderr_contains("\
+    assert_that!(p.cargo("build").arg("-v"), execs().with_status(0).with_stderr_contains("\
 [WARNING] path `[..]src[/]bar.rs` was erroneously implicitly accepted for binary `bar`,
 please set bin.path in Cargo.toml"));
 }
@@ -1586,10 +1587,10 @@ fn implicit_examples() {
         "#)
         .build();
 
-    assert_that(p.cargo("test"), execs().with_status(0));
-    assert_that(process(&p.bin("examples/hello")),
+    assert_that!(p.cargo("test"), execs().with_status(0));
+    assert_that!(process(&p.bin("examples/hello")),
                 execs().with_status(0).with_stdout("Hello, World!\n"));
-    assert_that(process(&p.bin("examples/goodbye")),
+    assert_that!(process(&p.bin("examples/goodbye")),
                 execs().with_status(0).with_stdout("Goodbye, World!\n"));
 }
 
@@ -1608,8 +1609,8 @@ fn standard_build_no_ndebug() {
         "#)
         .build();
 
-    assert_that(p.cargo("build"), execs().with_status(0));
-    assert_that(process(&p.bin("foo")),
+    assert_that!(p.cargo("build"), execs().with_status(0));
+    assert_that!(process(&p.bin("foo")),
                 execs().with_status(0).with_stdout("slow\n"));
 }
 
@@ -1628,9 +1629,9 @@ fn release_build_ndebug() {
         "#)
         .build();
 
-    assert_that(p.cargo("build").arg("--release"),
+    assert_that!(p.cargo("build").arg("--release"),
                 execs().with_status(0));
-    assert_that(process(&p.release_bin("foo")),
+    assert_that!(process(&p.release_bin("foo")),
                 execs().with_status(0).with_stdout("fast\n"));
 }
 
@@ -1648,8 +1649,8 @@ fn inferred_main_bin() {
         "#)
         .build();
 
-    assert_that(p.cargo("build"), execs().with_status(0));
-    assert_that(process(&p.bin("foo")), execs().with_status(0));
+    assert_that!(p.cargo("build"), execs().with_status(0));
+    assert_that!(process(&p.bin("foo")), execs().with_status(0));
 }
 
 #[test]
@@ -1677,14 +1678,14 @@ fn deletion_causes_failure() {
         .file("bar/src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("build"), execs().with_status(0));
+    assert_that!(p.cargo("build"), execs().with_status(0));
     p.change_file("Cargo.toml", r#"
         [package]
         name = "foo"
         version = "0.0.1"
         authors = []
     "#);
-    assert_that(p.cargo("build"), execs().with_status(101));
+    assert_that!(p.cargo("build"), execs().with_status(101));
 }
 
 #[test]
@@ -1702,8 +1703,8 @@ fn bad_cargo_toml_in_target_dir() {
         .file("target/Cargo.toml", "bad-toml")
         .build();
 
-    assert_that(p.cargo("build"), execs().with_status(0));
-    assert_that(process(&p.bin("foo")), execs().with_status(0));
+    assert_that!(p.cargo("build"), execs().with_status(0));
+    assert_that!(process(&p.bin("foo")), execs().with_status(0));
 }
 
 #[test]
@@ -1724,7 +1725,7 @@ fn lib_with_standard_name() {
         ")
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] syntax v0.0.1 ({dir})
@@ -1750,7 +1751,7 @@ fn simple_staticlib() {
         .build();
 
     // env var is a test for #1381
-    assert_that(p.cargo("build").env("RUST_LOG", "nekoneko=trace"),
+    assert_that!(p.cargo("build").env("RUST_LOG", "nekoneko=trace"),
                 execs().with_status(0));
 }
 
@@ -1776,7 +1777,7 @@ fn staticlib_rlib_and_bin() {
               }"#)
         .build();
 
-    assert_that(p.cargo("build").arg("-v"), execs().with_status(0));
+    assert_that!(p.cargo("build").arg("-v"), execs().with_status(0));
 }
 
 #[test]
@@ -1793,7 +1794,7 @@ fn opt_out_of_bin() {
         .file("src/lib.rs", "")
         .file("src/main.rs", "bad syntax")
         .build();
-    assert_that(p.cargo("build"), execs().with_status(0));
+    assert_that!(p.cargo("build"), execs().with_status(0));
 }
 
 #[test]
@@ -1811,7 +1812,7 @@ fn single_lib() {
         "#)
         .file("src/bar.rs", "")
         .build();
-    assert_that(p.cargo("build"), execs().with_status(0));
+    assert_that!(p.cargo("build"), execs().with_status(0));
 }
 
 #[test]
@@ -1830,7 +1831,7 @@ fn freshness_ignores_excluded() {
         .build();
     foo.root().move_into_the_past();
 
-    assert_that(foo.cargo("build"),
+    assert_that!(foo.cargo("build"),
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] foo v0.0.0 ({url})
@@ -1839,14 +1840,14 @@ fn freshness_ignores_excluded() {
 
     // Smoke test to make sure it doesn't compile again
     println!("first pass");
-    assert_that(foo.cargo("build"),
+    assert_that!(foo.cargo("build"),
                 execs().with_status(0)
                        .with_stdout(""));
 
     // Modify an ignored file and make sure we don't rebuild
     println!("second pass");
     File::create(&foo.root().join("src/bar.rs")).unwrap();
-    assert_that(foo.cargo("build"),
+    assert_that!(foo.cargo("build"),
                 execs().with_status(0)
                        .with_stdout(""));
 }
@@ -1879,7 +1880,7 @@ fn rebuild_preserves_out_dir() {
         .build();
     foo.root().move_into_the_past();
 
-    assert_that(foo.cargo("build").env("FIRST", "1"),
+    assert_that!(foo.cargo("build").env("FIRST", "1"),
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] foo v0.0.0 ({url})
@@ -1887,7 +1888,7 @@ fn rebuild_preserves_out_dir() {
 ", url = foo.url())));
 
     File::create(&foo.root().join("src/bar.rs")).unwrap();
-    assert_that(foo.cargo("build"),
+    assert_that!(foo.cargo("build"),
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] foo v0.0.0 ({url})
@@ -1916,7 +1917,7 @@ fn dep_no_libs() {
         "#)
         .file("bar/src/main.rs", "")
         .build();
-    assert_that(foo.cargo("build"),
+    assert_that!(foo.cargo("build"),
                 execs().with_status(0));
 }
 
@@ -1935,9 +1936,9 @@ fn recompile_space_in_name() {
         "#)
         .file("src/my lib.rs", "")
         .build();
-    assert_that(foo.cargo("build"), execs().with_status(0));
+    assert_that!(foo.cargo("build"), execs().with_status(0));
     foo.root().move_into_the_past();
-    assert_that(foo.cargo("build"),
+    assert_that!(foo.cargo("build"),
                 execs().with_status(0).with_stdout(""));
 }
 
@@ -1960,7 +1961,7 @@ fn ignore_bad_directories() {
     let mut perms = stat.permissions();
     perms.set_mode(0o644);
     fs::set_permissions(&dir, perms.clone()).unwrap();
-    assert_that(foo.cargo("build"),
+    assert_that!(foo.cargo("build"),
                 execs().with_status(0));
     perms.set_mode(0o755);
     fs::set_permissions(&dir, perms).unwrap();
@@ -1980,7 +1981,7 @@ fn bad_cargo_config() {
               this is not valid toml
         "#)
         .build();
-    assert_that(foo.cargo("build").arg("-v"),
+    assert_that!(foo.cargo("build").arg("-v"),
                 execs().with_status(101).with_stderr("\
 [ERROR] Couldn't load Cargo configuration
 
@@ -2049,11 +2050,11 @@ fn cargo_platform_specific_dependency() {
         .file("dev/src/lib.rs", "pub fn dev() {}")
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0));
 
-    assert_that(&p.bin("foo"), existing_file());
-    assert_that(p.cargo("test"),
+    assert_that!(&p.bin("foo"), existing_file());
+    assert_that!(p.cargo("test"),
                 execs().with_status(0));
 }
 
@@ -2088,7 +2089,7 @@ fn bad_platform_specific_dependency() {
         "#)
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(101));
 }
 
@@ -2122,8 +2123,8 @@ fn cargo_platform_specific_dependency_wrong_platform() {
 
     p.cargo("build").exec_with_output().unwrap();
 
-    assert_that(&p.bin("foo"), existing_file());
-    assert_that(process(&p.bin("foo")),
+    assert_that!(&p.bin("foo"), existing_file());
+    assert_that!(process(&p.bin("foo")),
                 execs().with_status(0));
 
     let loc = p.root().join("Cargo.lock");
@@ -2149,8 +2150,8 @@ fn example_as_lib() {
         .file("examples/ex.rs", "")
         .build();
 
-    assert_that(p.cargo("build").arg("--example=ex"), execs().with_status(0));
-    assert_that(&p.example_lib("ex", "lib"), existing_file());
+    assert_that!(p.cargo("build").arg("--example=ex"), execs().with_status(0));
+    assert_that!(&p.example_lib("ex", "lib"), existing_file());
 }
 
 #[test]
@@ -2170,8 +2171,8 @@ fn example_as_rlib() {
         .file("examples/ex.rs", "")
         .build();
 
-    assert_that(p.cargo("build").arg("--example=ex"), execs().with_status(0));
-    assert_that(&p.example_lib("ex", "rlib"), existing_file());
+    assert_that!(p.cargo("build").arg("--example=ex"), execs().with_status(0));
+    assert_that!(&p.example_lib("ex", "rlib"), existing_file());
 }
 
 #[test]
@@ -2191,8 +2192,8 @@ fn example_as_dylib() {
         .file("examples/ex.rs", "")
         .build();
 
-    assert_that(p.cargo("build").arg("--example=ex"), execs().with_status(0));
-    assert_that(&p.example_lib("ex", "dylib"), existing_file());
+    assert_that!(p.cargo("build").arg("--example=ex"), execs().with_status(0));
+    assert_that!(&p.example_lib("ex", "dylib"), existing_file());
 }
 
 #[test]
@@ -2216,8 +2217,8 @@ fn example_as_proc_macro() {
         .file("examples/ex.rs", "#![feature(proc_macro)]")
         .build();
 
-    assert_that(p.cargo("build").arg("--example=ex"), execs().with_status(0));
-    assert_that(&p.example_lib("ex", "proc-macro"), existing_file());
+    assert_that!(p.cargo("build").arg("--example=ex"), execs().with_status(0));
+    assert_that!(&p.example_lib("ex", "proc-macro"), existing_file());
 }
 
 #[test]
@@ -2237,17 +2238,17 @@ fn example_bin_same_name() {
         .exec_with_output()
         .unwrap();
 
-    assert_that(&p.bin("foo"), is_not(existing_file()));
+    assert_that!(&p.bin("foo"), is_not(existing_file()));
     // We expect a file of the form bin/foo-{metadata_hash}
-    assert_that(&p.bin("examples/foo"), existing_file());
+    assert_that!(&p.bin("examples/foo"), existing_file());
 
     p.cargo("test").arg("--no-run").arg("-v")
                    .exec_with_output()
                    .unwrap();
 
-    assert_that(&p.bin("foo"), is_not(existing_file()));
+    assert_that!(&p.bin("foo"), is_not(existing_file()));
     // We expect a file of the form bin/foo-{metadata_hash}
-    assert_that(&p.bin("examples/foo"), existing_file());
+    assert_that!(&p.bin("examples/foo"), existing_file());
 }
 
 #[test]
@@ -2262,14 +2263,14 @@ fn compile_then_delete() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    assert_that(p.cargo("run").arg("-v"), execs().with_status(0));
-    assert_that(&p.bin("foo"), existing_file());
+    assert_that!(p.cargo("run").arg("-v"), execs().with_status(0));
+    assert_that!(&p.bin("foo"), existing_file());
     if cfg!(windows) {
         // On windows unlinking immediately after running often fails, so sleep
         sleep_ms(100);
     }
     fs::remove_file(&p.bin("foo")).unwrap();
-    assert_that(p.cargo("run").arg("-v"),
+    assert_that!(p.cargo("run").arg("-v"),
                 execs().with_status(0));
 }
 
@@ -2305,7 +2306,7 @@ fn transitive_dependencies_not_available() {
         .file("b/src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("build").arg("-v"),
+    assert_that!(p.cargo("build").arg("-v"),
                 execs().with_status(101)
                        .with_stderr_contains("\
 [..] can't find crate for `bbbbb`[..]
@@ -2337,7 +2338,7 @@ fn cyclic_deps_rejected() {
         .file("a/src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("build").arg("-v"),
+    assert_that!(p.cargo("build").arg("-v"),
                 execs().with_status(101)
                        .with_stderr("\
 [ERROR] cyclic package dependency: package `a v0.0.1 ([..])` depends on itself
@@ -2360,12 +2361,12 @@ fn predictable_filenames() {
         .file("src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("build").arg("-v"),
+    assert_that!(p.cargo("build").arg("-v"),
                 execs().with_status(0));
-    assert_that(&p.root().join("target/debug/libfoo.rlib"), existing_file());
+    assert_that!(&p.root().join("target/debug/libfoo.rlib"), existing_file());
     let dylib_name = format!("{}foo{}", env::consts::DLL_PREFIX,
                              env::consts::DLL_SUFFIX);
-    assert_that(&p.root().join("target/debug").join(dylib_name),
+    assert_that!(&p.root().join("target/debug").join(dylib_name),
                 existing_file());
 }
 
@@ -2382,9 +2383,9 @@ fn dashes_to_underscores() {
         .file("src/main.rs", "extern crate foo_bar; fn main() {}")
         .build();
 
-    assert_that(p.cargo("build").arg("-v"),
+    assert_that!(p.cargo("build").arg("-v"),
                 execs().with_status(0));
-    assert_that(&p.bin("foo-bar"), existing_file());
+    assert_that!(&p.bin("foo-bar"), existing_file());
 }
 
 #[test]
@@ -2403,7 +2404,7 @@ fn dashes_in_crate_name_bad() {
         .file("src/main.rs", "extern crate foo_bar; fn main() {}")
         .build();
 
-    assert_that(p.cargo("build").arg("-v"),
+    assert_that!(p.cargo("build").arg("-v"),
                 execs().with_status(101));
 }
 
@@ -2419,7 +2420,7 @@ fn rustc_env_var() {
         .file("src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("build")
+    assert_that!(p.cargo("build")
                  .env("RUSTC", "rustc-that-does-not-exist").arg("-v"),
                 execs().with_status(101)
                        .with_stderr("\
@@ -2428,7 +2429,7 @@ fn rustc_env_var() {
 Caused by:
 [..]
 "));
-    assert_that(&p.bin("a"), is_not(existing_file()));
+    assert_that!(&p.bin("a"), is_not(existing_file()));
 }
 
 #[test]
@@ -2447,16 +2448,16 @@ fn filtering() {
         .file("examples/b.rs", "fn main() {}")
         .build();
 
-    assert_that(p.cargo("build").arg("--lib"),
+    assert_that!(p.cargo("build").arg("--lib"),
                 execs().with_status(0));
-    assert_that(&p.bin("a"), is_not(existing_file()));
+    assert_that!(&p.bin("a"), is_not(existing_file()));
 
-    assert_that(p.cargo("build").arg("--bin=a").arg("--example=a"),
+    assert_that!(p.cargo("build").arg("--bin=a").arg("--example=a"),
                 execs().with_status(0));
-    assert_that(&p.bin("a"), existing_file());
-    assert_that(&p.bin("b"), is_not(existing_file()));
-    assert_that(&p.bin("examples/a"), existing_file());
-    assert_that(&p.bin("examples/b"), is_not(existing_file()));
+    assert_that!(&p.bin("a"), existing_file());
+    assert_that!(&p.bin("b"), is_not(existing_file()));
+    assert_that!(&p.bin("examples/a"), existing_file());
+    assert_that!(&p.bin("examples/b"), is_not(existing_file()));
 }
 
 #[test]
@@ -2475,12 +2476,12 @@ fn filtering_implicit_bins() {
         .file("examples/b.rs", "fn main() {}")
         .build();
 
-    assert_that(p.cargo("build").arg("--bins"),
+    assert_that!(p.cargo("build").arg("--bins"),
                 execs().with_status(0));
-    assert_that(&p.bin("a"), existing_file());
-    assert_that(&p.bin("b"), existing_file());
-    assert_that(&p.bin("examples/a"), is_not(existing_file()));
-    assert_that(&p.bin("examples/b"), is_not(existing_file()));
+    assert_that!(&p.bin("a"), existing_file());
+    assert_that!(&p.bin("b"), existing_file());
+    assert_that!(&p.bin("examples/a"), is_not(existing_file()));
+    assert_that!(&p.bin("examples/b"), is_not(existing_file()));
 }
 
 #[test]
@@ -2499,12 +2500,12 @@ fn filtering_implicit_examples() {
         .file("examples/b.rs", "fn main() {}")
         .build();
 
-    assert_that(p.cargo("build").arg("--examples"),
+    assert_that!(p.cargo("build").arg("--examples"),
                 execs().with_status(0));
-    assert_that(&p.bin("a"), is_not(existing_file()));
-    assert_that(&p.bin("b"), is_not(existing_file()));
-    assert_that(&p.bin("examples/a"), existing_file());
-    assert_that(&p.bin("examples/b"), existing_file());
+    assert_that!(&p.bin("a"), is_not(existing_file()));
+    assert_that!(&p.bin("b"), is_not(existing_file()));
+    assert_that!(&p.bin("examples/a"), existing_file());
+    assert_that!(&p.bin("examples/b"), existing_file());
 }
 
 #[test]
@@ -2520,7 +2521,7 @@ fn ignore_dotfile() {
         .file("src/bin/a.rs", "fn main() {}")
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0));
 }
 
@@ -2538,7 +2539,7 @@ fn ignore_dotdirs() {
         .file(".pc/dummy-fix.patch/Cargo.toml", "")
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0));
 }
 
@@ -2553,7 +2554,7 @@ fn dotdir_root() {
         "#)
         .file("src/bin/a.rs", "fn main() {}")
         .build();
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0));
 }
 
@@ -2572,18 +2573,18 @@ fn custom_target_dir() {
 
     let exe_name = format!("foo{}", env::consts::EXE_SUFFIX);
 
-    assert_that(p.cargo("build").env("CARGO_TARGET_DIR", "foo/target"),
+    assert_that!(p.cargo("build").env("CARGO_TARGET_DIR", "foo/target"),
                 execs().with_status(0));
-    assert_that(&p.root().join("foo/target/debug").join(&exe_name),
+    assert_that!(&p.root().join("foo/target/debug").join(&exe_name),
                 existing_file());
-    assert_that(&p.root().join("target/debug").join(&exe_name),
+    assert_that!(&p.root().join("target/debug").join(&exe_name),
                 is_not(existing_file()));
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0));
-    assert_that(&p.root().join("foo/target/debug").join(&exe_name),
+    assert_that!(&p.root().join("foo/target/debug").join(&exe_name),
                 existing_file());
-    assert_that(&p.root().join("target/debug").join(&exe_name),
+    assert_that!(&p.root().join("target/debug").join(&exe_name),
                 existing_file());
 
     fs::create_dir(p.root().join(".cargo")).unwrap();
@@ -2591,13 +2592,13 @@ fn custom_target_dir() {
         [build]
         target-dir = "foo/target"
     "#).unwrap();
-    assert_that(p.cargo("build").env("CARGO_TARGET_DIR", "bar/target"),
+    assert_that!(p.cargo("build").env("CARGO_TARGET_DIR", "bar/target"),
                 execs().with_status(0));
-    assert_that(&p.root().join("bar/target/debug").join(&exe_name),
+    assert_that!(&p.root().join("bar/target/debug").join(&exe_name),
                 existing_file());
-    assert_that(&p.root().join("foo/target/debug").join(&exe_name),
+    assert_that!(&p.root().join("foo/target/debug").join(&exe_name),
                 existing_file());
-    assert_that(&p.root().join("target/debug").join(&exe_name),
+    assert_that!(&p.root().join("target/debug").join(&exe_name),
                 existing_file());
 }
 
@@ -2615,7 +2616,7 @@ fn rustc_no_trans() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    assert_that(p.cargo("rustc").arg("-v").arg("--").arg("-Zno-trans"),
+    assert_that!(p.cargo("rustc").arg("-v").arg("--").arg("-Zno-trans"),
                 execs().with_status(0));
 }
 
@@ -2661,12 +2662,12 @@ fn build_multiple_packages() {
         .file("d2/src/main.rs", "fn main() { println!(\"d2\"); }")
         .build();
 
-    assert_that(p.cargo("build").arg("-p").arg("d1").arg("-p").arg("d2")
+    assert_that!(p.cargo("build").arg("-p").arg("d1").arg("-p").arg("d2")
                                         .arg("-p").arg("foo"),
                 execs().with_status(0));
 
-    assert_that(&p.bin("foo"), existing_file());
-    assert_that(process(&p.bin("foo")),
+    assert_that!(&p.bin("foo"), existing_file());
+    assert_that!(process(&p.bin("foo")),
                 execs().with_status(0).with_stdout("i am foo\n"));
 
     let d1_path = &p.build_dir().join("debug")
@@ -2674,11 +2675,11 @@ fn build_multiple_packages() {
     let d2_path = &p.build_dir().join("debug")
                                 .join(format!("d2{}", env::consts::EXE_SUFFIX));
 
-    assert_that(d1_path, existing_file());
-    assert_that(process(d1_path), execs().with_status(0).with_stdout("d1"));
+    assert_that!(d1_path, existing_file());
+    assert_that!(process(d1_path), execs().with_status(0).with_stdout("d1"));
 
-    assert_that(d2_path, existing_file());
-    assert_that(process(d2_path),
+    assert_that!(d2_path, existing_file());
+    assert_that!(process(d2_path),
                 execs().with_status(0).with_stdout("d2"));
 }
 
@@ -2711,12 +2712,12 @@ fn invalid_spec() {
         .file("d1/src/main.rs", "fn main() { println!(\"d1\"); }")
         .build();
 
-    assert_that(p.cargo("build").arg("-p").arg("notAValidDep"),
+    assert_that!(p.cargo("build").arg("-p").arg("notAValidDep"),
                 execs().with_status(101).with_stderr("\
 [ERROR] package id specification `notAValidDep` matched no packages
 "));
 
-    assert_that(p.cargo("build").arg("-p").arg("d1").arg("-p").arg("notAValidDep"),
+    assert_that!(p.cargo("build").arg("-p").arg("d1").arg("-p").arg("notAValidDep"),
                 execs().with_status(101).with_stderr("\
 [ERROR] package id specification `notAValidDep` matched no packages
 "));
@@ -2733,7 +2734,7 @@ fn manifest_with_bom_is_ok() {
         ")
         .file("src/lib.rs", "")
         .build();
-    assert_that(p.cargo("build").arg("-v"),
+    assert_that!(p.cargo("build").arg("-v"),
                 execs().with_status(0));
 }
 
@@ -2751,7 +2752,7 @@ fn panic_abort_compiles_with_panic_abort() {
         "#)
         .file("src/lib.rs", "")
         .build();
-    assert_that(p.cargo("build").arg("-v"),
+    assert_that!(p.cargo("build").arg("-v"),
                 execs().with_status(0)
                        .with_stderr_contains("[..] -C panic=abort [..]"));
 }
@@ -2768,13 +2769,13 @@ fn explicit_color_config_is_propagated_to_rustc() {
             "#)
         .file("src/lib.rs", "")
         .build();
-    assert_that(p.cargo("build").arg("-v").arg("--color").arg("always"),
+    assert_that!(p.cargo("build").arg("-v").arg("--color").arg("always"),
                 execs().with_status(0).with_stderr_contains(
                     "[..]rustc [..] src[/]lib.rs --color always[..]"));
 
-    assert_that(p.cargo("clean"), execs().with_status(0));
+    assert_that!(p.cargo("clean"), execs().with_status(0));
 
-    assert_that(p.cargo("build").arg("-v").arg("--color").arg("never"),
+    assert_that!(p.cargo("build").arg("-v").arg("--color").arg("never"),
                 execs().with_status(0).with_stderr("\
 [COMPILING] test v0.0.0 ([..])
 [RUNNING] `rustc [..] --color never [..]`
@@ -2809,7 +2810,7 @@ fn compiler_json_error_format() {
         .file("bar/src/lib.rs", r#"fn dead() {}"#)
         .build();
 
-    assert_that(p.cargo("build").arg("-v")
+    assert_that!(p.cargo("build").arg("-v")
                     .arg("--message-format").arg("json"),
                 execs().with_status(0).with_json(r#"
     {
@@ -2881,7 +2882,7 @@ fn compiler_json_error_format() {
 
     // With fresh build, we should repeat the artifacts,
     // but omit compiler warnings.
-    assert_that(p.cargo("build").arg("-v")
+    assert_that!(p.cargo("build").arg("-v")
                     .arg("--message-format").arg("json"),
                 execs().with_status(0).with_json(r#"
     {
@@ -2935,7 +2936,7 @@ fn wrong_message_format_option() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    assert_that(p.cargo("build").arg("--message-format").arg("XML"),
+    assert_that!(p.cargo("build").arg("--message-format").arg("XML"),
                 execs().with_status(1)
                        .with_stderr_contains(
 r#"[ERROR] Could not match 'xml' with any of the allowed variants: ["Human", "Json"]"#));
@@ -2948,7 +2949,7 @@ fn message_format_json_forward_stderr() {
         .file("src/main.rs", "fn main() { let unused = 0; }")
         .build();
 
-    assert_that(p.cargo("rustc").arg("--release").arg("--bin").arg("foo")
+    assert_that!(p.cargo("rustc").arg("--release").arg("--bin").arg("foo")
                 .arg("--message-format").arg("JSON"),
                 execs().with_status(0)
                 .with_json(r#"
@@ -3006,7 +3007,7 @@ fn no_warn_about_package_metadata() {
         "#)
         .file("src/lib.rs", "")
         .build();
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0)
                        .with_stderr("[..] foo v0.0.1 ([..])\n\
                        [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]\n"));
@@ -3019,7 +3020,7 @@ fn cargo_build_empty_target() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    assert_that(p.cargo("build").arg("--target").arg(""),
+    assert_that!(p.cargo("build").arg("--target").arg(""),
                 execs().with_status(101)
                 .with_stderr_contains("[..] target was empty"));
 }
@@ -3050,7 +3051,7 @@ fn build_all_workspace() {
         "#)
         .build();
 
-    assert_that(p.cargo("build")
+    assert_that!(p.cargo("build")
                  .arg("--all"),
                 execs().with_status(0)
                        .with_stderr("[..] Compiling bar v0.1.0 ([..])\n\
@@ -3092,7 +3093,7 @@ fn build_all_exclude() {
         "#)
         .build();
 
-    assert_that(p.cargo("build")
+    assert_that!(p.cargo("build")
                  .arg("--all")
                  .arg("--exclude")
                  .arg("baz"),
@@ -3132,20 +3133,20 @@ fn build_all_workspace_implicit_examples() {
         .file("bar/examples/h.rs", "fn main() {}")
         .build();
 
-    assert_that(p.cargo("build")
+    assert_that!(p.cargo("build")
                  .arg("--all").arg("--examples"),
                 execs().with_status(0)
                        .with_stderr("[..] Compiling bar v0.1.0 ([..])\n\
                        [..] Compiling foo v0.1.0 ([..])\n\
                        [..] Finished dev [unoptimized + debuginfo] target(s) in [..]\n"));
-    assert_that(&p.bin("a"), is_not(existing_file()));
-    assert_that(&p.bin("b"), is_not(existing_file()));
-    assert_that(&p.bin("examples/c"), existing_file());
-    assert_that(&p.bin("examples/d"), existing_file());
-    assert_that(&p.bin("e"), is_not(existing_file()));
-    assert_that(&p.bin("f"), is_not(existing_file()));
-    assert_that(&p.bin("examples/g"), existing_file());
-    assert_that(&p.bin("examples/h"), existing_file());
+    assert_that!(&p.bin("a"), is_not(existing_file()));
+    assert_that!(&p.bin("b"), is_not(existing_file()));
+    assert_that!(&p.bin("examples/c"), existing_file());
+    assert_that!(&p.bin("examples/d"), existing_file());
+    assert_that!(&p.bin("e"), is_not(existing_file()));
+    assert_that!(&p.bin("f"), is_not(existing_file()));
+    assert_that!(&p.bin("examples/g"), existing_file());
+    assert_that!(&p.bin("examples/h"), existing_file());
 }
 
 #[test]
@@ -3174,7 +3175,7 @@ fn build_all_virtual_manifest() {
         .build();
 
     // The order in which foo and bar are built is not guaranteed
-    assert_that(p.cargo("build")
+    assert_that!(p.cargo("build")
                  .arg("--all"),
                 execs().with_status(0)
                        .with_stderr_contains("[..] Compiling bar v0.1.0 ([..])")
@@ -3210,7 +3211,7 @@ fn build_virtual_manifest_all_implied() {
         .build();
 
     // The order in which foo and bar are built is not guaranteed
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0)
                        .with_stderr_contains("[..] Compiling bar v0.1.0 ([..])")
                        .with_stderr_contains("[..] Compiling foo v0.1.0 ([..])")
@@ -3244,7 +3245,7 @@ fn build_virtual_manifest_one_project() {
         "#)
         .build();
 
-    assert_that(p.cargo("build")
+    assert_that!(p.cargo("build")
                  .arg("-p").arg("foo"),
                 execs().with_status(0)
                        .with_stderr_does_not_contain("bar")
@@ -3283,7 +3284,7 @@ fn build_all_virtual_manifest_implicit_examples() {
         .build();
 
     // The order in which foo and bar are built is not guaranteed
-    assert_that(p.cargo("build")
+    assert_that!(p.cargo("build")
                  .arg("--all").arg("--examples"),
                 execs().with_status(0)
                        .with_stderr_contains("[..] Compiling bar v0.1.0 ([..])")
@@ -3291,14 +3292,14 @@ fn build_all_virtual_manifest_implicit_examples() {
                        .with_stderr("[..] Compiling [..] v0.1.0 ([..])\n\
                        [..] Compiling [..] v0.1.0 ([..])\n\
                        [..] Finished dev [unoptimized + debuginfo] target(s) in [..]\n"));
-    assert_that(&p.bin("a"), is_not(existing_file()));
-    assert_that(&p.bin("b"), is_not(existing_file()));
-    assert_that(&p.bin("examples/c"), existing_file());
-    assert_that(&p.bin("examples/d"), existing_file());
-    assert_that(&p.bin("e"), is_not(existing_file()));
-    assert_that(&p.bin("f"), is_not(existing_file()));
-    assert_that(&p.bin("examples/g"), existing_file());
-    assert_that(&p.bin("examples/h"), existing_file());
+    assert_that!(&p.bin("a"), is_not(existing_file()));
+    assert_that!(&p.bin("b"), is_not(existing_file()));
+    assert_that!(&p.bin("examples/c"), existing_file());
+    assert_that!(&p.bin("examples/d"), existing_file());
+    assert_that!(&p.bin("e"), is_not(existing_file()));
+    assert_that!(&p.bin("f"), is_not(existing_file()));
+    assert_that!(&p.bin("examples/g"), existing_file());
+    assert_that!(&p.bin("examples/h"), existing_file());
 }
 
 #[test]
@@ -3323,7 +3324,7 @@ fn build_all_member_dependency_same_name() {
 
     Package::new("a", "0.1.0").publish();
 
-    assert_that(p.cargo("build")
+    assert_that!(p.cargo("build")
                  .arg("--all"),
                 execs().with_status(0)
                        .with_stderr("[..] Updating registry `[..]`\n\
@@ -3358,7 +3359,7 @@ fn run_proper_binary() {
         "#)
         .build();
 
-    assert_that(p.cargo("run").arg("--bin").arg("other"),
+    assert_that!(p.cargo("run").arg("--bin").arg("other"),
                 execs().with_status(0));
 }
 
@@ -3380,7 +3381,7 @@ fn run_proper_binary_main_rs() {
         "#)
         .build();
 
-    assert_that(p.cargo("run").arg("--bin").arg("foo"),
+    assert_that!(p.cargo("run").arg("--bin").arg("foo"),
                 execs().with_status(0));
 }
 
@@ -3408,13 +3409,13 @@ fn run_proper_alias_binary_from_src() {
         "#)
         .build();
 
-    assert_that(p.cargo("build")
+    assert_that!(p.cargo("build")
                  .arg("--all"),
                 execs().with_status(0)
                 );
-    assert_that(process(&p.bin("foo")),
+    assert_that!(process(&p.bin("foo")),
                 execs().with_status(0).with_stdout("foo\n"));
-    assert_that(process(&p.bin("bar")),
+    assert_that!(process(&p.bin("bar")),
                 execs().with_status(0).with_stdout("bar\n"));
 }
 
@@ -3438,13 +3439,13 @@ fn run_proper_alias_binary_main_rs() {
         "#)
         .build();
 
-    assert_that(p.cargo("build")
+    assert_that!(p.cargo("build")
                  .arg("--all"),
                 execs().with_status(0)
                 );
-    assert_that(process(&p.bin("foo")),
+    assert_that!(process(&p.bin("foo")),
                 execs().with_status(0).with_stdout("main\n"));
-    assert_that(process(&p.bin("bar")),
+    assert_that!(process(&p.bin("bar")),
                 execs().with_status(0).with_stdout("main\n"));
 }
 
@@ -3470,7 +3471,7 @@ fn run_proper_binary_main_rs_as_foo() {
         "#)
         .build();
 
-    assert_that(p.cargo("run").arg("--bin").arg("foo"),
+    assert_that!(p.cargo("run").arg("--bin").arg("foo"),
                 execs().with_status(0));
 }
 
@@ -3484,7 +3485,7 @@ fn rustc_wrapper() {
         .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
         .build();
 
-    assert_that(p.cargo("build").arg("-v").env("RUSTC_WRAPPER", "/usr/bin/env"),
+    assert_that!(p.cargo("build").arg("-v").env("RUSTC_WRAPPER", "/usr/bin/env"),
                 execs().with_stderr_contains(
                     "[RUNNING] `/usr/bin/env rustc --crate-name foo [..]")
                 .with_status(0));
@@ -3505,7 +3506,7 @@ fn cdylib_not_lifted() {
         .file("src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("build"), execs().with_status(0));
+    assert_that!(p.cargo("build"), execs().with_status(0));
 
     let files = if cfg!(windows) {
         vec!["foo.dll.lib", "foo.dll.exp", "foo.dll"]
@@ -3517,7 +3518,7 @@ fn cdylib_not_lifted() {
 
     for file in files {
         println!("checking: {}", file);
-        assert_that(&p.root().join("target/debug/deps").join(&file),
+        assert_that!(&p.root().join("target/debug/deps").join(&file),
                     existing_file());
     }
 }
@@ -3537,7 +3538,7 @@ fn cdylib_final_outputs() {
         .file("src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("build"), execs().with_status(0));
+    assert_that!(p.cargo("build"), execs().with_status(0));
 
     let files = if cfg!(windows) {
         vec!["foo_bar.dll.lib", "foo_bar.dll"]
@@ -3549,7 +3550,7 @@ fn cdylib_final_outputs() {
 
     for file in files {
         println!("checking: {}", file);
-        assert_that(&p.root().join("target/debug").join(&file), existing_file());
+        assert_that!(&p.root().join("target/debug").join(&file), existing_file());
     }
 }
 
@@ -3687,7 +3688,7 @@ fn deterministic_cfg_flags() {
         "#)
         .build();
 
-    assert_that(p.cargo("build").arg("-v"),
+    assert_that!(p.cargo("build").arg("-v"),
                 execs().with_status(0)
                     .with_stderr("\
 [COMPILING] foo v0.1.0 [..]
@@ -3720,7 +3721,7 @@ fn explicit_bins_without_paths() {
         .file("src/bin/bar.rs", "fn main() {}")
         .build();
 
-    assert_that(p.cargo("build"), execs().with_status(0));
+    assert_that!(p.cargo("build"), execs().with_status(0));
 }
 
 #[test]
@@ -3739,7 +3740,7 @@ fn no_bin_in_src_with_lib() {
         .file("src/foo.rs", "fn main() {}")
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(101)
                        .with_stderr_contains("\
 [ERROR] failed to parse manifest at `[..]`
@@ -3763,10 +3764,10 @@ fn inferred_bins() {
         .file("src/bin/baz/main.rs", "fn main() {}")
         .build();
 
-    assert_that(p.cargo("build"), execs().with_status(0));
-    assert_that(&p.bin("foo"), existing_file());
-    assert_that(&p.bin("bar"), existing_file());
-    assert_that(&p.bin("baz"), existing_file());
+    assert_that!(p.cargo("build"), execs().with_status(0));
+    assert_that!(&p.bin("foo"), existing_file());
+    assert_that!(&p.bin("bar"), existing_file());
+    assert_that!(&p.bin("baz"), existing_file());
 }
 
 #[test]
@@ -3784,7 +3785,7 @@ fn inferred_bins_duplicate_name() {
         .file("src/bin/foo/main.rs", "fn main() {}")
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(101)
                        .with_stderr_contains("\
 [..]found duplicate binary name foo, but all binary targets must have a unique name[..]
@@ -3807,8 +3808,8 @@ fn inferred_bin_path() {
         .file("src/bin/bar/main.rs", "fn main() {}")
         .build();
 
-    assert_that(p.cargo("build"), execs().with_status(0));
-    assert_that(&p.bin("bar"), existing_file());
+    assert_that!(p.cargo("build"), execs().with_status(0));
+    assert_that!(&p.bin("bar"), existing_file());
 }
 
 #[test]
@@ -3825,9 +3826,9 @@ fn inferred_examples() {
         .file("examples/baz/main.rs", "fn main() {}")
         .build();
 
-    assert_that(p.cargo("test"), execs().with_status(0));
-    assert_that(&p.bin("examples/bar"), existing_file());
-    assert_that(&p.bin("examples/baz"), existing_file());
+    assert_that!(p.cargo("test"), execs().with_status(0));
+    assert_that!(&p.bin("examples/bar"), existing_file());
+    assert_that!(&p.bin("examples/baz"), existing_file());
 }
 
 #[test]
@@ -3844,7 +3845,7 @@ fn inferred_tests() {
         .file("tests/baz/main.rs", "fn main() {}")
         .build();
 
-    assert_that(
+    assert_that!(
         p.cargo("test").arg("--test=bar").arg("--test=baz"),
         execs().with_status(0));
 }
@@ -3863,7 +3864,7 @@ fn inferred_benchmarks() {
         .file("benches/baz/main.rs", "fn main() {}")
         .build();
 
-    assert_that(
+    assert_that!(
         p.cargo("bench").arg("--bench=bar").arg("--bench=baz"),
         execs().with_status(0));
 }
@@ -3890,11 +3891,11 @@ fn same_metadata_different_directory() {
         .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
         .build();
 
-    assert_that(
+    assert_that!(
         p.cargo("build").arg("-v"),
         execs().with_status(0).with_stderr_contains(
             format!("[..]{}[..]", metadata),
-        ),
+        )
     );
 }
 
@@ -3924,7 +3925,7 @@ fn building_a_dependent_crate_witout_bin_should_fail() {
         .file("src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(101).with_stderr_contains(
                     "[..]can't find `a_bin` bin, specify bin.path"
                 ));
@@ -3947,12 +3948,12 @@ fn uplift_dsym_of_bin_on_mac() {
         .file("tests/d.rs", "fn main() { panic!(); }")
         .build();
 
-    assert_that(
+    assert_that!(
         p.cargo("build").arg("--bins").arg("--examples").arg("--tests"),
         execs().with_status(0)
     );
-    assert_that(&p.bin("foo.dSYM"), existing_dir());
-    assert_that(&p.bin("b.dSYM"), existing_dir());
+    assert_that!(&p.bin("foo.dSYM"), existing_dir());
+    assert_that!(&p.bin("b.dSYM"), existing_dir());
     assert!(
         p.bin("b.dSYM")
             .symlink_metadata()
@@ -3960,8 +3961,8 @@ fn uplift_dsym_of_bin_on_mac() {
             .file_type()
             .is_symlink()
     );
-    assert_that(&p.bin("c.dSYM"), is_not(existing_dir()));
-    assert_that(&p.bin("d.dSYM"), is_not(existing_dir()));
+    assert_that!(&p.bin("c.dSYM"), is_not(existing_dir()));
+    assert_that!(&p.bin("d.dSYM"), is_not(existing_dir()));
 }
 
 // Make sure that `cargo build` chooses the correct profile for building
@@ -3982,7 +3983,7 @@ fn build_filter_infer_profile() {
         .file("examples/ex1.rs", "fn main() {}")
         .build();
 
-    assert_that(p.cargo("build").arg("-v"),
+    assert_that!(p.cargo("build").arg("-v"),
         execs().with_status(0)
         .with_stderr_contains("\
             [RUNNING] `rustc --crate-name foo src[/]lib.rs --crate-type lib \
@@ -3993,7 +3994,7 @@ fn build_filter_infer_profile() {
         );
 
     p.root().join("target").rm_rf();
-    assert_that(p.cargo("build").arg("-v").arg("--test=t1"),
+    assert_that!(p.cargo("build").arg("-v").arg("--test=t1"),
         execs().with_status(0)
         .with_stderr_contains("\
             [RUNNING] `rustc --crate-name foo src[/]lib.rs --crate-type lib \
@@ -4006,7 +4007,7 @@ fn build_filter_infer_profile() {
         );
 
     p.root().join("target").rm_rf();
-    assert_that(p.cargo("build").arg("-v").arg("--bench=b1"),
+    assert_that!(p.cargo("build").arg("-v").arg("--bench=b1"),
         execs().with_status(0)
         .with_stderr_contains("\
             [RUNNING] `rustc --crate-name foo src[/]lib.rs --crate-type lib \
@@ -4031,7 +4032,7 @@ fn all_targets_no_lib() {
         "#)
         .file("src/main.rs", "fn main() {}")
         .build();
-    assert_that(p.cargo("build").arg("-v").arg("--all-targets"),
+    assert_that!(p.cargo("build").arg("-v").arg("--all-targets"),
         execs().with_status(0)
         // bin
         .with_stderr_contains("\
@@ -4071,7 +4072,7 @@ fn no_linkable_target() {
         "#)
         .file("the_lib/src/lib.rs", "pub fn foo() {}")
         .build();
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs()
                 .with_status(0)
                 .with_stderr_contains("\

--- a/tests/cargo-features.rs
+++ b/tests/cargo-features.rs
@@ -1,9 +1,10 @@
 extern crate cargotest;
+#[macro_use]
 extern crate hamcrest;
 
 use cargotest::ChannelChanger;
 use cargotest::support::{project, execs};
-use hamcrest::assert_that;
+use hamcrest::prelude::*;
 
 #[test]
 fn feature_required() {
@@ -17,7 +18,7 @@ fn feature_required() {
         "#)
         .file("src/lib.rs", "")
         .build();
-    assert_that(p.cargo("build")
+    assert_that!(p.cargo("build")
                  .masquerade_as_nightly_cargo(),
                 execs().with_status(101)
                        .with_stderr("\
@@ -32,7 +33,7 @@ Caused by:
 consider adding `cargo-features = [\"test-dummy-unstable\"]` to the manifest
 "));
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(101)
                        .with_stderr("\
 error: failed to parse manifest at `[..]`
@@ -62,7 +63,7 @@ fn unknown_feature() {
         "#)
         .file("src/lib.rs", "")
         .build();
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(101)
                        .with_stderr("\
 error: failed to parse manifest at `[..]`
@@ -85,7 +86,7 @@ fn stable_feature_warns() {
         "#)
         .file("src/lib.rs", "")
         .build();
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0)
                        .with_stderr("\
 warning: the cargo feature `test-dummy-stable` is now stable and is no longer \
@@ -109,7 +110,7 @@ fn nightly_feature_requires_nightly() {
         "#)
         .file("src/lib.rs", "")
         .build();
-    assert_that(p.cargo("build")
+    assert_that!(p.cargo("build")
                  .masquerade_as_nightly_cargo(),
                 execs().with_status(0)
                        .with_stderr("\
@@ -117,7 +118,7 @@ fn nightly_feature_requires_nightly() {
 [FINISHED] [..]
 "));
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(101)
                        .with_stderr("\
 error: failed to parse manifest at `[..]`
@@ -152,7 +153,7 @@ fn nightly_feature_requires_nightly_in_dep() {
         "#)
         .file("a/src/lib.rs", "")
         .build();
-    assert_that(p.cargo("build")
+    assert_that!(p.cargo("build")
                  .masquerade_as_nightly_cargo(),
                 execs().with_status(0)
                        .with_stderr("\
@@ -161,7 +162,7 @@ fn nightly_feature_requires_nightly_in_dep() {
 [FINISHED] [..]
 "));
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(101)
                        .with_stderr("\
 error: failed to load source for a dependency on `a`
@@ -192,7 +193,7 @@ fn cant_publish() {
         "#)
         .file("src/lib.rs", "")
         .build();
-    assert_that(p.cargo("build")
+    assert_that!(p.cargo("build")
                  .masquerade_as_nightly_cargo(),
                 execs().with_status(0)
                        .with_stderr("\
@@ -200,7 +201,7 @@ fn cant_publish() {
 [FINISHED] [..]
 "));
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(101)
                        .with_stderr("\
 error: failed to parse manifest at `[..]`
@@ -225,14 +226,14 @@ fn z_flags_rejected() {
         "#)
         .file("src/lib.rs", "")
         .build();
-    assert_that(p.cargo("build")
+    assert_that!(p.cargo("build")
                  .arg("-Zprint-im-a-teapot"),
                 execs().with_status(101)
                        .with_stderr("\
 error: the `-Z` flag is only accepted on the nightly channel of Cargo
 "));
 
-    assert_that(p.cargo("build")
+    assert_that!(p.cargo("build")
                  .masquerade_as_nightly_cargo()
                  .arg("-Zarg"),
                 execs().with_status(101)
@@ -240,7 +241,7 @@ error: the `-Z` flag is only accepted on the nightly channel of Cargo
 error: unknown `-Z` flag specified: arg
 "));
 
-    assert_that(p.cargo("build")
+    assert_that!(p.cargo("build")
                  .masquerade_as_nightly_cargo()
                  .arg("-Zprint-im-a-teapot"),
                 execs().with_status(0)
@@ -264,7 +265,7 @@ fn publish_rejected() {
         "#)
         .file("src/lib.rs", "")
         .build();
-    assert_that(p.cargo("package")
+    assert_that!(p.cargo("package")
                  .masquerade_as_nightly_cargo(),
                 execs().with_status(101)
                        .with_stderr("\

--- a/tests/cargo.rs
+++ b/tests/cargo.rs
@@ -1,5 +1,6 @@
 extern crate cargo;
 extern crate cargotest;
+#[macro_use]
 extern crate hamcrest;
 
 use std::env;
@@ -11,7 +12,7 @@ use std::str;
 use cargotest::cargo_process;
 use cargotest::support::paths::{self, CargoPathExt};
 use cargotest::support::{execs, project, Project, basic_bin_manifest};
-use hamcrest::{assert_that, existing_file};
+use hamcrest::prelude::*;
 
 #[cfg_attr(windows,allow(dead_code))]
 enum FakeKind<'a> {
@@ -103,7 +104,7 @@ fn find_closest_biuld_to_build() {
     let mut pr = cargo_process();
     pr.arg("biuld");
 
-    assert_that(pr,
+    assert_that!(pr,
                 execs().with_status(101)
                        .with_stderr("[ERROR] no such subcommand: `biuld`
 
@@ -119,7 +120,7 @@ fn find_closest_dont_correct_nonsense() {
     pr.arg("there-is-no-way-that-there-is-a-command-close-to-this")
       .cwd(&paths::root());
 
-    assert_that(pr,
+    assert_that!(pr,
                 execs().with_status(101)
                        .with_stderr("[ERROR] no such subcommand: \
                         `there-is-no-way-that-there-is-a-command-close-to-this`
@@ -131,7 +132,7 @@ fn displays_subcommand_on_error() {
     let mut pr = cargo_process();
     pr.arg("invalid-command");
 
-    assert_that(pr,
+    assert_that!(pr,
                 execs().with_status(101)
                        .with_stderr("[ERROR] no such subcommand: `invalid-command`
 "));
@@ -149,7 +150,7 @@ fn override_cargo_home() {
         git = false
     "#).unwrap();
 
-    assert_that(cargo_process()
+    assert_that!(cargo_process()
                     .arg("new").arg("foo")
                     .env("USER", "foo")
                     .env("CARGO_HOME", &my_home),
@@ -180,8 +181,8 @@ fn cargo_subcommand_env() {
 
     let target_dir = p.target_debug_dir();
 
-    assert_that(p.cargo("build"), execs().with_status(0));
-    assert_that(&p.bin("cargo-envtest"), existing_file());
+    assert_that!(p.cargo("build"), execs().with_status(0));
+    assert_that!(&p.bin("cargo-envtest"), existing_file());
 
     let mut pr = cargo_process();
     let cargo = cargo_exe().canonicalize().unwrap();
@@ -189,30 +190,30 @@ fn cargo_subcommand_env() {
     path.push(target_dir);
     let path = env::join_paths(path.iter()).unwrap();
 
-    assert_that(pr.arg("envtest").env("PATH", &path),
+    assert_that!(pr.arg("envtest").env("PATH", &path),
                 execs().with_status(0).with_stdout(cargo.to_str().unwrap()));
 }
 
 #[test]
 fn cargo_help() {
-    assert_that(cargo_process(),
+    assert_that!(cargo_process(),
                 execs().with_status(0));
-    assert_that(cargo_process().arg("help"),
+    assert_that!(cargo_process().arg("help"),
                 execs().with_status(0));
-    assert_that(cargo_process().arg("-h"),
+    assert_that!(cargo_process().arg("-h"),
                 execs().with_status(0));
-    assert_that(cargo_process().arg("help").arg("build"),
+    assert_that!(cargo_process().arg("help").arg("build"),
                 execs().with_status(0));
-    assert_that(cargo_process().arg("build").arg("-h"),
+    assert_that!(cargo_process().arg("build").arg("-h"),
                 execs().with_status(0));
-    assert_that(cargo_process().arg("help").arg("-h"),
+    assert_that!(cargo_process().arg("help").arg("-h"),
                 execs().with_status(0));
-    assert_that(cargo_process().arg("help").arg("help"),
+    assert_that!(cargo_process().arg("help").arg("help"),
                 execs().with_status(0));
 }
 
 #[test]
 fn explain() {
-    assert_that(cargo_process().arg("--explain").arg("E0001"),
+    assert_that!(cargo_process().arg("--explain").arg("E0001"),
                 execs().with_status(0));
 }

--- a/tests/cargo_alias_config.rs
+++ b/tests/cargo_alias_config.rs
@@ -1,7 +1,9 @@
 extern crate cargotest;
+#[macro_use]
 extern crate hamcrest;
+
 use cargotest::support::{project, execs, basic_bin_manifest};
-use hamcrest::{assert_that};
+use hamcrest::prelude::*;
 
 #[test]
 fn alias_incorrect_config_type() {
@@ -16,7 +18,7 @@ fn alias_incorrect_config_type() {
         "#)
         .build();
 
-    assert_that(p.cargo("b-cargo-test").arg("-v"),
+    assert_that!(p.cargo("b-cargo-test").arg("-v"),
                 execs().with_status(101).
                 with_stderr_contains("[ERROR] invalid configuration \
 for key `alias.b-cargo-test`
@@ -37,7 +39,7 @@ fn alias_default_config_overrides_config() {
         "#)
         .build();
 
-    assert_that(p.cargo("b").arg("-v"),
+    assert_that!(p.cargo("b").arg("-v"),
                 execs().with_status(0).
                 with_stderr_contains("[COMPILING] foo v0.5.0 [..]"));
 }
@@ -55,7 +57,7 @@ fn alias_config() {
         "#)
         .build();
 
-    assert_that(p.cargo("b-cargo-test").arg("-v"),
+    assert_that!(p.cargo("b-cargo-test").arg("-v"),
                 execs().with_status(0).
                 with_stderr_contains("[COMPILING] foo v0.5.0 [..]
 [RUNNING] `rustc --crate-name foo [..]"));
@@ -74,7 +76,7 @@ fn alias_list_test() {
          "#)
         .build();
 
-    assert_that(p.cargo("b-cargo-test").arg("-v"),
+    assert_that!(p.cargo("b-cargo-test").arg("-v"),
                 execs().with_status(0).
                 with_stderr_contains("[COMPILING] foo v0.5.0 [..]").
                 with_stderr_contains("[RUNNING] `rustc --crate-name [..]")
@@ -94,7 +96,7 @@ fn alias_with_flags_config() {
          "#)
         .build();
 
-    assert_that(p.cargo("b-cargo-test").arg("-v"),
+    assert_that!(p.cargo("b-cargo-test").arg("-v"),
                 execs().with_status(0).
                 with_stderr_contains("[COMPILING] foo v0.5.0 [..]").
                 with_stderr_contains("[RUNNING] `rustc --crate-name foo [..]")
@@ -114,7 +116,7 @@ fn cant_shadow_builtin() {
          "#)
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0)
                        .with_stderr("\
 [COMPILING] foo v0.5.0 ([..])

--- a/tests/cargotest/Cargo.toml
+++ b/tests/cargotest/Cargo.toml
@@ -11,7 +11,7 @@ cargo = { path = "../.." }
 filetime = "0.1"
 flate2 = "1.0"
 git2 = { version = "0.6", default-features = false }
-hamcrest = "=0.1.1"
+hamcrest = "0.1.5"
 hex = "0.2"
 log = "0.3"
 serde_json = "1.0"

--- a/tests/cargotest/install.rs
+++ b/tests/cargotest/install.rs
@@ -1,7 +1,8 @@
 use std::fmt;
 use std::path::{PathBuf, Path};
 
-use hamcrest::{Matcher, MatchResult, existing_file};
+use hamcrest::core::{Matcher, MatchResult};
+use hamcrest::existing_file;
 use support::paths;
 
 pub use self::InstalledExe as has_installed_exe;

--- a/tests/cargotest/support/mod.rs
+++ b/tests/cargotest/support/mod.rs
@@ -406,17 +406,17 @@ impl Execs {
         self
     }
 
-    fn match_output(&self, actual: &Output) -> ham::MatchResult {
+    fn match_output(&self, actual: &Output) -> ham::core::MatchResult {
         self.match_status(actual)
             .and(self.match_stdout(actual))
             .and(self.match_stderr(actual))
     }
 
-    fn match_status(&self, actual: &Output) -> ham::MatchResult {
+    fn match_status(&self, actual: &Output) -> ham::core::MatchResult {
         match self.expect_exit_code {
-            None => ham::success(),
+            None => ham::core::success(),
             Some(code) => {
-                ham::expect(
+                ham::core::expect(
                     actual.status.code() == Some(code),
                     format!("exited with {}\n--- stdout\n{}\n--- stderr\n{}",
                             actual.status,
@@ -426,7 +426,7 @@ impl Execs {
         }
     }
 
-    fn match_stdout(&self, actual: &Output) -> ham::MatchResult {
+    fn match_stdout(&self, actual: &Output) -> ham::core::MatchResult {
         self.match_std(self.expect_stdout.as_ref(), &actual.stdout,
                        "stdout", &actual.stderr, MatchKind::Exact)?;
         for expect in self.expect_stdout_contains.iter() {
@@ -465,17 +465,17 @@ impl Execs {
         Ok(())
     }
 
-    fn match_stderr(&self, actual: &Output) -> ham::MatchResult {
+    fn match_stderr(&self, actual: &Output) -> ham::core::MatchResult {
         self.match_std(self.expect_stderr.as_ref(), &actual.stderr,
                        "stderr", &actual.stdout, MatchKind::Exact)
     }
 
     fn match_std(&self, expected: Option<&String>, actual: &[u8],
                  description: &str, extra: &[u8],
-                 kind: MatchKind) -> ham::MatchResult {
+                 kind: MatchKind) -> ham::core::MatchResult {
         let out = match expected {
             Some(out) => out,
-            None => return ham::success(),
+            None => return ham::core::success(),
         };
         let actual = match str::from_utf8(actual) {
             Err(..) => return Err(format!("{} was not utf8 encoded",
@@ -492,7 +492,7 @@ impl Execs {
                 let e = out.lines();
 
                 let diffs = self.diff_lines(a, e, false);
-                ham::expect(diffs.is_empty(),
+                ham::core::expect(diffs.is_empty(),
                             format!("differences:\n\
                                     {}\n\n\
                                     other output:\n\
@@ -510,7 +510,7 @@ impl Execs {
                         diffs = a;
                     }
                 }
-                ham::expect(diffs.is_empty(),
+                ham::core::expect(diffs.is_empty(),
                             format!("expected to find:\n\
                                      {}\n\n\
                                      did not find in output:\n\
@@ -530,7 +530,7 @@ impl Execs {
                     a.next()
                 } {}
 
-                ham::expect(matches == number,
+                ham::core::expect(matches == number,
                             format!("expected to find {} occurences:\n\
                                      {}\n\n\
                                      did not find in output:\n\
@@ -538,7 +538,7 @@ impl Execs {
                                      actual))
             }
             MatchKind::NotPresent => {
-                ham::expect(!actual.contains(out),
+                ham::core::expect(!actual.contains(out),
                             format!("expected not to find:\n\
                                      {}\n\n\
                                      but found in output:\n\
@@ -548,7 +548,7 @@ impl Execs {
         }
     }
 
-    fn match_json(&self, expected: &Value, line: &str) -> ham::MatchResult {
+    fn match_json(&self, expected: &Value, line: &str) -> ham::core::MatchResult {
         let actual = match line.parse() {
              Err(e) => return Err(format!("invalid json, {}:\n`{}`", e, line)),
              Ok(actual) => actual,
@@ -720,14 +720,14 @@ impl fmt::Display for Execs {
     }
 }
 
-impl ham::Matcher<ProcessBuilder> for Execs {
-    fn matches(&self, mut process: ProcessBuilder) -> ham::MatchResult {
+impl ham::core::Matcher<ProcessBuilder> for Execs {
+    fn matches(&self, mut process: ProcessBuilder) -> ham::core::MatchResult {
         self.matches(&mut process)
     }
 }
 
-impl<'a> ham::Matcher<&'a mut ProcessBuilder> for Execs {
-    fn matches(&self, process: &'a mut ProcessBuilder) -> ham::MatchResult {
+impl<'a> ham::core::Matcher<&'a mut ProcessBuilder> for Execs {
+    fn matches(&self, process: &'a mut ProcessBuilder) -> ham::core::MatchResult {
         println!("running {}", process);
         let res = process.exec_with_output();
 
@@ -748,8 +748,8 @@ impl<'a> ham::Matcher<&'a mut ProcessBuilder> for Execs {
     }
 }
 
-impl ham::Matcher<Output> for Execs {
-    fn matches(&self, output: Output) -> ham::MatchResult {
+impl ham::core::Matcher<Output> for Execs {
+    fn matches(&self, output: Output) -> ham::core::MatchResult {
         self.match_output(&output)
     }
 }
@@ -780,13 +780,13 @@ impl fmt::Display for ShellWrites {
     }
 }
 
-impl<'a> ham::Matcher<&'a [u8]> for ShellWrites {
+impl<'a> ham::core::Matcher<&'a [u8]> for ShellWrites {
     fn matches(&self, actual: &[u8])
-        -> ham::MatchResult
+        -> ham::core::MatchResult
     {
         let actual = String::from_utf8_lossy(actual);
         let actual = actual.to_string();
-        ham::expect(actual == self.expected, actual)
+        ham::core::expect(actual == self.expected, actual)
     }
 }
 

--- a/tests/cfg.rs
+++ b/tests/cfg.rs
@@ -1,5 +1,6 @@
 extern crate cargo;
 extern crate cargotest;
+#[macro_use]
 extern crate hamcrest;
 
 use std::str::FromStr;
@@ -9,7 +10,7 @@ use cargo::util::{Cfg, CfgExpr};
 use cargotest::rustc_host;
 use cargotest::support::registry::Package;
 use cargotest::support::{project, execs};
-use hamcrest::assert_that;
+use hamcrest::prelude::*;
 
 macro_rules! c {
     ($a:ident) => (
@@ -159,7 +160,7 @@ fn cfg_easy() {
         "#)
         .file("b/src/lib.rs", "")
         .build();
-    assert_that(p.cargo("build").arg("-v"),
+    assert_that!(p.cargo("build").arg("-v"),
                 execs().with_status(0));
 }
 
@@ -185,7 +186,7 @@ fn dont_include() {
         "#)
         .file("b/src/lib.rs", "")
         .build();
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0).with_stderr("\
 [COMPILING] a v0.0.1 ([..])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
@@ -213,7 +214,7 @@ fn works_through_the_registry() {
         .file("src/lib.rs", "#[allow(unused_extern_crates)] extern crate bar;")
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0).with_stderr("\
 [UPDATING] registry [..]
 [DOWNLOADING] [..]
@@ -248,7 +249,7 @@ fn ignore_version_from_other_platform() {
         .file("src/lib.rs", "#[allow(unused_extern_crates)] extern crate foo;")
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0).with_stderr("\
 [UPDATING] registry [..]
 [DOWNLOADING] [..]
@@ -273,7 +274,7 @@ fn bad_target_spec() {
         .file("src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(101).with_stderr("\
 [ERROR] failed to parse manifest at `[..]`
 
@@ -300,7 +301,7 @@ fn bad_target_spec2() {
         .file("src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(101).with_stderr("\
 [ERROR] failed to parse manifest at `[..]`
 
@@ -344,7 +345,7 @@ fn multiple_match_ok() {
         "#)
         .file("b/src/lib.rs", "")
         .build();
-    assert_that(p.cargo("build").arg("-v"),
+    assert_that!(p.cargo("build").arg("-v"),
                 execs().with_status(0));
 }
 
@@ -369,6 +370,6 @@ fn any_ok() {
         "#)
         .file("b/src/lib.rs", "")
         .build();
-    assert_that(p.cargo("build").arg("-v"),
+    assert_that!(p.cargo("build").arg("-v"),
                 execs().with_status(0));
 }

--- a/tests/check.rs
+++ b/tests/check.rs
@@ -1,4 +1,5 @@
 extern crate cargotest;
+#[macro_use]
 extern crate hamcrest;
 extern crate glob;
 
@@ -48,7 +49,7 @@ fn check_success() {
         "#)
         .build();
 
-    assert_that(foo.cargo("check"),
+    assert_that!(foo.cargo("check"),
                 execs().with_status(0));
 }
 
@@ -83,7 +84,7 @@ fn check_fail() {
         "#)
         .build();
 
-    assert_that(foo.cargo("check"),
+    assert_that!(foo.cargo("check"),
                 execs().with_status(101));
 }
 
@@ -145,7 +146,7 @@ pub fn derive(_input: TokenStream) -> TokenStream {
 "#)
         .build();
 
-    assert_that(foo.cargo("check"),
+    assert_that!(foo.cargo("check"),
                 execs().with_status(0));
 }
 
@@ -181,9 +182,9 @@ fn check_build() {
         "#)
         .build();
 
-    assert_that(foo.cargo("check"),
+    assert_that!(foo.cargo("check"),
                 execs().with_status(0));
-    assert_that(foo.cargo("build"),
+    assert_that!(foo.cargo("build"),
                 execs().with_status(0));
 }
 
@@ -219,9 +220,9 @@ fn build_check() {
         "#)
         .build();
 
-    assert_that(foo.cargo("build"),
+    assert_that!(foo.cargo("build"),
                 execs().with_status(0));
-    assert_that(foo.cargo("check"),
+    assert_that!(foo.cargo("check"),
                 execs().with_status(0));
 }
 
@@ -242,7 +243,7 @@ fn issue_3418() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    assert_that(foo.cargo("check").arg("-v"),
+    assert_that!(foo.cargo("check").arg("-v"),
                 execs().with_status(0)
                        .with_stderr_contains("[..] --emit=dep-info,metadata [..]"));
 }
@@ -294,7 +295,7 @@ fn issue_3419() {
                     where F: FnOnce(&mut Self) -> Result<T, Self::Error>;
                  } "#).publish();
 
-    assert_that(p.cargo("check"),
+    assert_that!(p.cargo("check"),
                 execs().with_status(0));
 }
 
@@ -316,17 +317,17 @@ fn dylib_check_preserves_build_cache() {
         .file("src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0)
                 .with_stderr("\
 [..]Compiling foo v0.1.0 ([..])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
 
-    assert_that(p.cargo("check"),
+    assert_that!(p.cargo("check"),
                 execs().with_status(0));
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0)
                 .with_stderr("\
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
@@ -365,7 +366,7 @@ fn rustc_check() {
         "#)
         .build();
 
-    assert_that(foo.cargo("rustc")
+    assert_that!(foo.cargo("rustc")
                    .arg("--profile")
                    .arg("check")
                    .arg("--")
@@ -404,7 +405,7 @@ fn rustc_check_err() {
         "#)
         .build();
 
-    assert_that(foo.cargo("rustc")
+    assert_that!(foo.cargo("rustc")
                    .arg("--profile")
                    .arg("check")
                    .arg("--")
@@ -439,7 +440,7 @@ fn check_all() {
         .file("b/src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("check").arg("--all").arg("-v"),
+    assert_that!(p.cargo("check").arg("--all").arg("-v"),
                 execs().with_status(0)
         .with_stderr_contains("[..] --crate-name foo src[/]lib.rs [..]")
         .with_stderr_contains("[..] --crate-name foo src[/]main.rs [..]")
@@ -473,7 +474,7 @@ fn check_virtual_all_implied() {
         "#)
         .build();
 
-    assert_that(p.cargo("check").arg("-v"),
+    assert_that!(p.cargo("check").arg("-v"),
                 execs().with_status(0)
         .with_stderr_contains("[..] --crate-name foo foo[/]src[/]lib.rs [..]")
         .with_stderr_contains("[..] --crate-name bar bar[/]src[/]lib.rs [..]")
@@ -491,7 +492,7 @@ fn check_all_targets() {
         .file("benches/bench3.rs", "")
         .build();
 
-    assert_that(foo.cargo("check").arg("--all-targets").arg("-v"),
+    assert_that!(foo.cargo("check").arg("--all-targets").arg("-v"),
                 execs().with_status(0)
         .with_stderr_contains("[..] --crate-name foo src[/]lib.rs [..]")
         .with_stderr_contains("[..] --crate-name foo src[/]main.rs [..]")
@@ -516,9 +517,9 @@ fn check_unit_test_profile() {
         "#)
         .build();
 
-    assert_that(foo.cargo("check"),
+    assert_that!(foo.cargo("check"),
                 execs().with_status(0));
-    assert_that(foo.cargo("check").arg("--profile").arg("test"),
+    assert_that!(foo.cargo("check").arg("--profile").arg("test"),
                 execs().with_status(101)
                 .with_stderr_contains("[..]badtext[..]"));
 }
@@ -567,7 +568,7 @@ fn check_filters() {
         "#)
         .build();
 
-    assert_that(p.cargo("check"),
+    assert_that!(p.cargo("check"),
         execs().with_status(0)
         .with_stderr_contains("[..]unused_normal_lib[..]")
         .with_stderr_contains("[..]unused_normal_bin[..]")
@@ -576,7 +577,7 @@ fn check_filters() {
         .with_stderr_does_not_contain("unused_normal_b1")
         .with_stderr_does_not_contain("unused_unit_"));
     p.root().join("target").rm_rf();
-    assert_that(p.cargo("check").arg("--tests").arg("-v"),
+    assert_that!(p.cargo("check").arg("--tests").arg("-v"),
         execs().with_status(0)
         .with_stderr_contains("[..] --crate-name foo src[/]lib.rs [..] --test [..]")
         .with_stderr_contains("[..] --crate-name foo src[/]lib.rs --crate-type lib [..]")
@@ -592,7 +593,7 @@ fn check_filters() {
         .with_stderr_does_not_contain("unused_normal_b1")
         .with_stderr_does_not_contain("unused_unit_b1"));
     p.root().join("target").rm_rf();
-    assert_that(p.cargo("check").arg("--test").arg("t1").arg("-v"),
+    assert_that!(p.cargo("check").arg("--test").arg("t1").arg("-v"),
         execs().with_status(0)
         .with_stderr_contains("[..]unused_normal_lib[..]")
         .with_stderr_contains("[..]unused_normal_bin[..]")
@@ -604,7 +605,7 @@ fn check_filters() {
         .with_stderr_does_not_contain("unused_unit_ex1")
         .with_stderr_does_not_contain("unused_unit_b1"));
     p.root().join("target").rm_rf();
-    assert_that(p.cargo("check").arg("--all-targets").arg("-v"),
+    assert_that!(p.cargo("check").arg("--all-targets").arg("-v"),
         execs().with_status(0)
         .with_stderr_contains("[..]unused_normal_lib[..]")
         .with_stderr_contains("[..]unused_normal_bin[..]")
@@ -630,66 +631,66 @@ fn check_artifacts()
         .file("examples/ex1.rs", "fn main() {}")
         .file("benches/b1.rs", "")
         .build();
-    assert_that(p.cargo("check"), execs().with_status(0));
-    assert_that(&p.root().join("target/debug/libfoo.rmeta"),
+    assert_that!(p.cargo("check"), execs().with_status(0));
+    assert_that!(&p.root().join("target/debug/libfoo.rmeta"),
         existing_file());
-    assert_that(&p.root().join("target/debug/libfoo.rlib"),
+    assert_that!(&p.root().join("target/debug/libfoo.rlib"),
         is_not(existing_file()));
-    assert_that(&p.root().join("target/debug").join(exe("foo")),
+    assert_that!(&p.root().join("target/debug").join(exe("foo")),
         is_not(existing_file()));
 
     p.root().join("target").rm_rf();
-    assert_that(p.cargo("check").arg("--lib"), execs().with_status(0));
-    assert_that(&p.root().join("target/debug/libfoo.rmeta"),
+    assert_that!(p.cargo("check").arg("--lib"), execs().with_status(0));
+    assert_that!(&p.root().join("target/debug/libfoo.rmeta"),
         existing_file());
-    assert_that(&p.root().join("target/debug/libfoo.rlib"),
+    assert_that!(&p.root().join("target/debug/libfoo.rlib"),
         is_not(existing_file()));
-    assert_that(&p.root().join("target/debug").join(exe("foo")),
+    assert_that!(&p.root().join("target/debug").join(exe("foo")),
         is_not(existing_file()));
 
     p.root().join("target").rm_rf();
-    assert_that(p.cargo("check").arg("--bin").arg("foo"),
+    assert_that!(p.cargo("check").arg("--bin").arg("foo"),
         execs().with_status(0));
-    assert_that(&p.root().join("target/debug/libfoo.rmeta"),
+    assert_that!(&p.root().join("target/debug/libfoo.rmeta"),
         existing_file());
-    assert_that(&p.root().join("target/debug/libfoo.rlib"),
+    assert_that!(&p.root().join("target/debug/libfoo.rlib"),
         is_not(existing_file()));
-    assert_that(&p.root().join("target/debug").join(exe("foo")),
+    assert_that!(&p.root().join("target/debug").join(exe("foo")),
         is_not(existing_file()));
 
     p.root().join("target").rm_rf();
-    assert_that(p.cargo("check").arg("--test").arg("t1"),
+    assert_that!(p.cargo("check").arg("--test").arg("t1"),
         execs().with_status(0));
-    assert_that(&p.root().join("target/debug/libfoo.rmeta"),
+    assert_that!(&p.root().join("target/debug/libfoo.rmeta"),
         existing_file());
-    assert_that(&p.root().join("target/debug/libfoo.rlib"),
+    assert_that!(&p.root().join("target/debug/libfoo.rlib"),
         is_not(existing_file()));
-    assert_that(&p.root().join("target/debug").join(exe("foo")),
+    assert_that!(&p.root().join("target/debug").join(exe("foo")),
         is_not(existing_file()));
-    assert_that(glob(&p.root().join("target/debug/t1-*").to_str().unwrap())
+    assert_that!(glob(&p.root().join("target/debug/t1-*").to_str().unwrap())
             .unwrap().count(),
         is(equal_to(0)));
 
     p.root().join("target").rm_rf();
-    assert_that(p.cargo("check").arg("--example").arg("ex1"),
+    assert_that!(p.cargo("check").arg("--example").arg("ex1"),
         execs().with_status(0));
-    assert_that(&p.root().join("target/debug/libfoo.rmeta"),
+    assert_that!(&p.root().join("target/debug/libfoo.rmeta"),
         existing_file());
-    assert_that(&p.root().join("target/debug/libfoo.rlib"),
+    assert_that!(&p.root().join("target/debug/libfoo.rlib"),
         is_not(existing_file()));
-    assert_that(&p.root().join("target/debug/examples").join(exe("ex1")),
+    assert_that!(&p.root().join("target/debug/examples").join(exe("ex1")),
         is_not(existing_file()));
 
     p.root().join("target").rm_rf();
-    assert_that(p.cargo("check").arg("--bench").arg("b1"),
+    assert_that!(p.cargo("check").arg("--bench").arg("b1"),
         execs().with_status(0));
-    assert_that(&p.root().join("target/debug/libfoo.rmeta"),
+    assert_that!(&p.root().join("target/debug/libfoo.rmeta"),
         existing_file());
-    assert_that(&p.root().join("target/debug/libfoo.rlib"),
+    assert_that!(&p.root().join("target/debug/libfoo.rlib"),
         is_not(existing_file()));
-    assert_that(&p.root().join("target/debug").join(exe("foo")),
+    assert_that!(&p.root().join("target/debug").join(exe("foo")),
         is_not(existing_file()));
-    assert_that(glob(&p.root().join("target/debug/b1-*").to_str().unwrap())
+    assert_that!(glob(&p.root().join("target/debug/b1-*").to_str().unwrap())
             .unwrap().count(),
         is(equal_to(0)));
 }

--- a/tests/clean.rs
+++ b/tests/clean.rs
@@ -1,3 +1,4 @@
+#[macro_use]
 extern crate hamcrest;
 extern crate cargotest;
 
@@ -5,7 +6,7 @@ use std::env;
 
 use cargotest::support::{git, project, execs, main_file, basic_bin_manifest};
 use cargotest::support::registry::Package;
-use hamcrest::{assert_that, existing_dir, existing_file, is_not};
+use hamcrest::prelude::*;
 
 #[test]
 fn cargo_clean_simple() {
@@ -14,12 +15,12 @@ fn cargo_clean_simple() {
         .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
         .build();
 
-    assert_that(p.cargo("build"), execs().with_status(0));
-    assert_that(&p.build_dir(), existing_dir());
+    assert_that!(p.cargo("build"), execs().with_status(0));
+    assert_that!(&p.build_dir(), existing_dir());
 
-    assert_that(p.cargo("clean"),
+    assert_that!(p.cargo("clean"),
                 execs().with_status(0));
-    assert_that(&p.build_dir(), is_not(existing_dir()));
+    assert_that!(&p.build_dir(), is_not(existing_dir()));
 }
 
 #[test]
@@ -30,12 +31,12 @@ fn different_dir() {
         .file("src/bar/a.rs", "")
         .build();
 
-    assert_that(p.cargo("build"), execs().with_status(0));
-    assert_that(&p.build_dir(), existing_dir());
+    assert_that!(p.cargo("build"), execs().with_status(0));
+    assert_that!(&p.build_dir(), existing_dir());
 
-    assert_that(p.cargo("clean").cwd(&p.root().join("src")),
+    assert_that!(p.cargo("clean").cwd(&p.root().join("src")),
                 execs().with_status(0).with_stdout(""));
-    assert_that(&p.build_dir(), is_not(existing_dir()));
+    assert_that!(&p.build_dir(), is_not(existing_dir()));
 }
 
 #[test]
@@ -78,7 +79,7 @@ fn clean_multiple_packages() {
         .file("d2/src/main.rs", "fn main() { println!(\"d2\"); }")
         .build();
 
-    assert_that(p.cargo("build").arg("-p").arg("d1").arg("-p").arg("d2")
+    assert_that!(p.cargo("build").arg("-p").arg("d1").arg("-p").arg("d2")
                                         .arg("-p").arg("foo"),
                 execs().with_status(0));
 
@@ -88,16 +89,16 @@ fn clean_multiple_packages() {
                                 .join(format!("d2{}", env::consts::EXE_SUFFIX));
 
 
-    assert_that(&p.bin("foo"), existing_file());
-    assert_that(d1_path, existing_file());
-    assert_that(d2_path, existing_file());
+    assert_that!(&p.bin("foo"), existing_file());
+    assert_that!(d1_path, existing_file());
+    assert_that!(d2_path, existing_file());
 
-    assert_that(p.cargo("clean").arg("-p").arg("d1").arg("-p").arg("d2")
+    assert_that!(p.cargo("clean").arg("-p").arg("d1").arg("-p").arg("d2")
                                 .cwd(&p.root().join("src")),
                 execs().with_status(0).with_stdout(""));
-    assert_that(&p.bin("foo"), existing_file());
-    assert_that(d1_path, is_not(existing_file()));
-    assert_that(d2_path, is_not(existing_file()));
+    assert_that!(&p.bin("foo"), existing_file());
+    assert_that!(d1_path, is_not(existing_file()));
+    assert_that!(d2_path, is_not(existing_file()));
 }
 
 #[test]
@@ -122,17 +123,17 @@ fn clean_release() {
         .file("a/src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("build").arg("--release"),
+    assert_that!(p.cargo("build").arg("--release"),
                 execs().with_status(0));
 
-    assert_that(p.cargo("clean").arg("-p").arg("foo"),
+    assert_that!(p.cargo("clean").arg("-p").arg("foo"),
                 execs().with_status(0));
-    assert_that(p.cargo("build").arg("--release"),
+    assert_that!(p.cargo("build").arg("--release"),
                 execs().with_status(0).with_stdout(""));
 
-    assert_that(p.cargo("clean").arg("-p").arg("foo").arg("--release"),
+    assert_that!(p.cargo("clean").arg("-p").arg("foo").arg("--release"),
                 execs().with_status(0));
-    assert_that(p.cargo("build").arg("--release"),
+    assert_that!(p.cargo("build").arg("--release"),
                 execs().with_status(0).with_stderr("\
 [COMPILING] foo v0.0.1 ([..])
 [FINISHED] release [optimized] target(s) in [..]
@@ -166,11 +167,11 @@ fn build_script() {
         .file("a/src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("build").env("FIRST", "1"),
+    assert_that!(p.cargo("build").env("FIRST", "1"),
                 execs().with_status(0));
-    assert_that(p.cargo("clean").arg("-p").arg("foo"),
+    assert_that!(p.cargo("clean").arg("-p").arg("foo"),
                 execs().with_status(0));
-    assert_that(p.cargo("build").arg("-v"),
+    assert_that!(p.cargo("build").arg("-v"),
                 execs().with_status(0).with_stderr("\
 [COMPILING] foo v0.0.1 ([..])
 [RUNNING] `rustc [..] build.rs [..]`
@@ -205,11 +206,11 @@ fn clean_git() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0));
-    assert_that(p.cargo("clean").arg("-p").arg("dep"),
+    assert_that!(p.cargo("clean").arg("-p").arg("dep"),
                 execs().with_status(0).with_stdout(""));
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0));
 }
 
@@ -230,10 +231,10 @@ fn registry() {
 
     Package::new("bar", "0.1.0").publish();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0));
-    assert_that(p.cargo("clean").arg("-p").arg("bar"),
+    assert_that!(p.cargo("clean").arg("-p").arg("bar"),
                 execs().with_status(0).with_stdout(""));
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0));
 }

--- a/tests/concurrent.rs
+++ b/tests/concurrent.rs
@@ -1,5 +1,6 @@
 extern crate cargotest;
 extern crate git2;
+#[macro_use]
 extern crate hamcrest;
 
 use std::{env, str};
@@ -15,7 +16,7 @@ use cargotest::install::{has_installed_exe, cargo_home};
 use cargotest::support::git;
 use cargotest::support::registry::Package;
 use cargotest::support::{execs, project};
-use hamcrest::{assert_that, existing_file};
+use hamcrest::prelude::*;
 
 fn pkg(name: &str, vers: &str) {
     Package::new(name, vers)
@@ -54,11 +55,11 @@ fn multiple_installs() {
     let b = b.wait_with_output().unwrap();
     let a = a.join().unwrap();
 
-    assert_that(a, execs().with_status(0));
-    assert_that(b, execs().with_status(0));
+    assert_that!(a, execs().with_status(0));
+    assert_that!(b, execs().with_status(0));
 
-    assert_that(cargo_home(), has_installed_exe("foo"));
-    assert_that(cargo_home(), has_installed_exe("bar"));
+    assert_that!(cargo_home(), has_installed_exe("foo"));
+    assert_that!(cargo_home(), has_installed_exe("bar"));
 }
 
 #[test]
@@ -83,11 +84,11 @@ fn concurrent_installs() {
     assert!(!str::from_utf8(&a.stderr).unwrap().contains(LOCKED_BUILD));
     assert!(!str::from_utf8(&b.stderr).unwrap().contains(LOCKED_BUILD));
 
-    assert_that(a, execs().with_status(0));
-    assert_that(b, execs().with_status(0));
+    assert_that!(a, execs().with_status(0));
+    assert_that!(b, execs().with_status(0));
 
-    assert_that(cargo_home(), has_installed_exe("foo"));
-    assert_that(cargo_home(), has_installed_exe("bar"));
+    assert_that!(cargo_home(), has_installed_exe("foo"));
+    assert_that!(cargo_home(), has_installed_exe("bar"));
 }
 
 #[test]
@@ -122,14 +123,14 @@ fn one_install_should_be_bad() {
     let a = a.join().unwrap();
 
     let (bad, good) = if a.status.code() == Some(101) {(a, b)} else {(b, a)};
-    assert_that(bad, execs().with_status(101).with_stderr_contains("\
+    assert_that!(bad, execs().with_status(101).with_stderr_contains("\
 [ERROR] binary `foo[..]` already exists in destination as part of `[..]`
 "));
-    assert_that(good, execs().with_status(0).with_stderr_contains("\
+    assert_that!(good, execs().with_status(0).with_stderr_contains("\
 warning: be sure to add `[..]` to your PATH [..]
 "));
 
-    assert_that(cargo_home(), has_installed_exe("foo"));
+    assert_that!(cargo_home(), has_installed_exe("foo"));
 }
 
 #[test]
@@ -177,13 +178,13 @@ fn multiple_registry_fetches() {
     let b = b.wait_with_output().unwrap();
     let a = a.join().unwrap();
 
-    assert_that(a, execs().with_status(0));
-    assert_that(b, execs().with_status(0));
+    assert_that!(a, execs().with_status(0));
+    assert_that!(b, execs().with_status(0));
 
     let suffix = env::consts::EXE_SUFFIX;
-    assert_that(&p.root().join("a/target/debug").join(format!("foo{}", suffix)),
+    assert_that!(&p.root().join("a/target/debug").join(format!("foo{}", suffix)),
                 existing_file());
-    assert_that(&p.root().join("b/target/debug").join(format!("bar{}", suffix)),
+    assert_that!(&p.root().join("b/target/debug").join(format!("bar{}", suffix)),
                 existing_file());
 }
 
@@ -242,8 +243,8 @@ fn git_same_repo_different_tags() {
     let b = b.wait_with_output().unwrap();
     let a = a.join().unwrap();
 
-    assert_that(a, execs().with_status(0));
-    assert_that(b, execs().with_status(0));
+    assert_that!(a, execs().with_status(0));
+    assert_that!(b, execs().with_status(0));
 }
 
 #[test]
@@ -282,7 +283,7 @@ fn git_same_branch_different_revs() {
 
     // Generate a Cargo.lock pointing at the current rev, then clear out the
     // target directory
-    assert_that(p.cargo("build").cwd(p.root().join("a")),
+    assert_that!(p.cargo("build").cwd(p.root().join("a")),
                 execs().with_status(0));
     fs::remove_dir_all(p.root().join("a/target")).unwrap();
 
@@ -307,8 +308,8 @@ fn git_same_branch_different_revs() {
     let b = b.wait_with_output().unwrap();
     let a = a.join().unwrap();
 
-    assert_that(a, execs().with_status(0));
-    assert_that(b, execs().with_status(0));
+    assert_that!(a, execs().with_status(0));
+    assert_that!(b, execs().with_status(0));
 }
 
 #[test]
@@ -336,8 +337,8 @@ fn same_project() {
     let b = b.wait_with_output().unwrap();
     let a = a.join().unwrap();
 
-    assert_that(a, execs().with_status(0));
-    assert_that(b, execs().with_status(0));
+    assert_that!(a, execs().with_status(0));
+    assert_that!(b, execs().with_status(0));
 }
 
 // Make sure that if Cargo dies while holding a lock that it's released and the
@@ -394,7 +395,7 @@ fn killing_cargo_releases_the_lock() {
 
     // We killed `a`, so it shouldn't succeed, but `b` should have succeeded.
     assert!(!a.status.success());
-    assert_that(b, execs().with_status(0));
+    assert_that!(b, execs().with_status(0));
 }
 
 #[test]
@@ -409,7 +410,7 @@ fn debug_release_ok() {
         .file("src/main.rs", "fn main() {}");
     let p = p.build();
 
-    assert_that(p.cargo("build"), execs().with_status(0));
+    assert_that!(p.cargo("build"), execs().with_status(0));
     fs::remove_dir_all(p.root().join("target")).unwrap();
 
     let mut a = p.cargo("build").build_command();
@@ -422,11 +423,11 @@ fn debug_release_ok() {
     let b = b.wait_with_output().unwrap();
     let a = a.join().unwrap();
 
-    assert_that(a, execs().with_status(0).with_stderr("\
+    assert_that!(a, execs().with_status(0).with_stderr("\
 [COMPILING] foo v0.0.0 [..]
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
-    assert_that(b, execs().with_status(0).with_stderr("\
+    assert_that!(b, execs().with_status(0).with_stderr("\
 [COMPILING] foo v0.0.0 [..]
 [FINISHED] release [optimized] target(s) in [..]
 "));
@@ -494,7 +495,7 @@ fn no_deadlock_with_git_dependencies() {
 
     for _ in 0..n_concurrent_builds {
         let result = recv_timeout(&rx);
-        assert_that(result, execs().with_status(0))
+        assert_that!(result, execs().with_status(0))
     }
 
 }

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -1,8 +1,9 @@
+#[macro_use]
 extern crate hamcrest;
 extern crate cargotest;
 
 use cargotest::support::{project, execs};
-use hamcrest::assert_that;
+use hamcrest::prelude::*;
 
 #[test]
 fn read_env_vars_for_config() {
@@ -23,6 +24,6 @@ fn read_env_vars_for_config() {
         "#)
         .build();
 
-    assert_that(p.cargo("build").env("CARGO_BUILD_JOBS", "100"),
+    assert_that!(p.cargo("build").env("CARGO_BUILD_JOBS", "100"),
                 execs().with_status(0));
 }

--- a/tests/cross-compile.rs
+++ b/tests/cross-compile.rs
@@ -1,11 +1,12 @@
 extern crate cargo;
 extern crate cargotest;
+#[macro_use]
 extern crate hamcrest;
 
 use cargo::util::process;
 use cargotest::{is_nightly, rustc_host};
 use cargotest::support::{project, execs, basic_bin_manifest, cross_compile};
-use hamcrest::{assert_that, existing_file};
+use hamcrest::prelude::*;
 
 #[test]
 fn simple_cross() {
@@ -33,11 +34,11 @@ fn simple_cross() {
         .build();
 
     let target = cross_compile::alternate();
-    assert_that(p.cargo("build").arg("--target").arg(&target).arg("-v"),
+    assert_that!(p.cargo("build").arg("--target").arg(&target).arg("-v"),
                 execs().with_status(0));
-    assert_that(&p.target_bin(&target, "foo"), existing_file());
+    assert_that!(&p.target_bin(&target, "foo"), existing_file());
 
-    assert_that(process(&p.target_bin(&target, "foo")),
+    assert_that!(process(&p.target_bin(&target, "foo")),
                 execs().with_status(0));
 }
 
@@ -71,11 +72,11 @@ fn simple_cross_config() {
         .build();
 
     let target = cross_compile::alternate();
-    assert_that(p.cargo("build").arg("-v"),
+    assert_that!(p.cargo("build").arg("-v"),
                 execs().with_status(0));
-    assert_that(&p.target_bin(&target, "foo"), existing_file());
+    assert_that!(&p.target_bin(&target, "foo"), existing_file());
 
-    assert_that(process(&p.target_bin(&target, "foo")),
+    assert_that!(process(&p.target_bin(&target, "foo")),
                 execs().with_status(0));
 }
 
@@ -109,11 +110,11 @@ fn simple_deps() {
         .build();
 
     let target = cross_compile::alternate();
-    assert_that(p.cargo("build").arg("--target").arg(&target),
+    assert_that!(p.cargo("build").arg("--target").arg(&target),
                 execs().with_status(0));
-    assert_that(&p.target_bin(&target, "foo"), existing_file());
+    assert_that!(&p.target_bin(&target, "foo"), existing_file());
 
-    assert_that(process(&p.target_bin(&target, "foo")),
+    assert_that!(process(&p.target_bin(&target, "foo")),
                 execs().with_status(0));
 }
 
@@ -190,11 +191,11 @@ fn plugin_deps() {
         .build();
 
     let target = cross_compile::alternate();
-    assert_that(foo.cargo("build").arg("--target").arg(&target),
+    assert_that!(foo.cargo("build").arg("--target").arg(&target),
                 execs().with_status(0));
-    assert_that(&foo.target_bin(&target, "foo"), existing_file());
+    assert_that!(&foo.target_bin(&target, "foo"), existing_file());
 
-    assert_that(process(&foo.target_bin(&target, "foo")),
+    assert_that!(process(&foo.target_bin(&target, "foo")),
                 execs().with_status(0));
 }
 
@@ -278,15 +279,15 @@ fn plugin_to_the_max() {
         .build();
 
     let target = cross_compile::alternate();
-    assert_that(foo.cargo("build").arg("--target").arg(&target).arg("-v"),
+    assert_that!(foo.cargo("build").arg("--target").arg(&target).arg("-v"),
                 execs().with_status(0));
     println!("second");
-    assert_that(foo.cargo("build").arg("-v")
+    assert_that!(foo.cargo("build").arg("-v")
                    .arg("--target").arg(&target),
                 execs().with_status(0));
-    assert_that(&foo.target_bin(&target, "foo"), existing_file());
+    assert_that!(&foo.target_bin(&target, "foo"), existing_file());
 
-    assert_that(process(&foo.target_bin(&target, "foo")),
+    assert_that!(process(&foo.target_bin(&target, "foo")),
                 execs().with_status(0));
 }
 
@@ -310,7 +311,7 @@ fn linker_and_ar() {
         "#, cross_compile::alternate_arch()))
         .build();
 
-    assert_that(p.cargo("build").arg("--target").arg(&target)
+    assert_that!(p.cargo("build").arg("--target").arg(&target)
                                               .arg("-v"),
                 execs().with_status(101)
                        .with_stderr_contains(&format!("\
@@ -395,7 +396,7 @@ fn plugin_with_extra_dylib_dep() {
         .build();
 
     let target = cross_compile::alternate();
-    assert_that(foo.cargo("build").arg("--target").arg(&target),
+    assert_that!(foo.cargo("build").arg("--target").arg(&target),
                 execs().with_status(0));
 }
 
@@ -430,7 +431,7 @@ fn cross_tests() {
         .build();
 
     let target = cross_compile::alternate();
-    assert_that(p.cargo("test").arg("--target").arg(&target),
+    assert_that!(p.cargo("test").arg("--target").arg(&target),
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] foo v0.0.0 ({foo})
@@ -468,13 +469,13 @@ fn no_cross_doctests() {
 ", foo = p.url());
 
     println!("a");
-    assert_that(p.cargo("test"),
+    assert_that!(p.cargo("test"),
                 execs().with_status(0)
                        .with_stderr(&host_output));
 
     println!("b");
     let target = cross_compile::host();
-    assert_that(p.cargo("test").arg("--target").arg(&target),
+    assert_that!(p.cargo("test").arg("--target").arg(&target),
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] foo v0.0.0 ({foo})
@@ -485,7 +486,7 @@ fn no_cross_doctests() {
 
     println!("c");
     let target = cross_compile::alternate();
-    assert_that(p.cargo("test").arg("--target").arg(&target),
+    assert_that!(p.cargo("test").arg("--target").arg(&target),
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] foo v0.0.0 ({foo})
@@ -514,7 +515,7 @@ fn simple_cargo_run() {
         .build();
 
     let target = cross_compile::alternate();
-    assert_that(p.cargo("run").arg("--target").arg(&target),
+    assert_that!(p.cargo("run").arg("--target").arg(&target),
                 execs().with_status(0));
 }
 
@@ -554,7 +555,7 @@ fn cross_with_a_build_script() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    assert_that(p.cargo("build").arg("--target").arg(&target).arg("-v"),
+    assert_that!(p.cargo("build").arg("--target").arg(&target).arg("-v"),
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] foo v0.0.0 (file://[..])
@@ -629,7 +630,7 @@ fn build_script_needed_for_host_and_target() {
         ")
         .build();
 
-    assert_that(p.cargo("build").arg("--target").arg(&target).arg("-v"),
+    assert_that!(p.cargo("build").arg("--target").arg(&target).arg("-v"),
                 execs().with_status(0)
                        .with_stderr_contains(&format!("\
 [COMPILING] d1 v0.0.0 ({url}/d1)", url = p.url()))
@@ -695,7 +696,7 @@ fn build_deps_for_the_right_arch() {
         .build();
 
     let target = cross_compile::alternate();
-    assert_that(p.cargo("build").arg("--target").arg(&target).arg("-v"),
+    assert_that!(p.cargo("build").arg("--target").arg(&target).arg("-v"),
                 execs().with_status(0));
 }
 
@@ -738,7 +739,7 @@ fn build_script_only_host() {
         .build();
 
     let target = cross_compile::alternate();
-    assert_that(p.cargo("build").arg("--target").arg(&target).arg("-v"),
+    assert_that!(p.cargo("build").arg("--target").arg(&target).arg("-v"),
                 execs().with_status(0));
 }
 
@@ -761,7 +762,7 @@ fn plugin_build_script_right_arch() {
         .file("src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("build").arg("-v").arg("--target").arg(cross_compile::alternate()),
+    assert_that!(p.cargo("build").arg("-v").arg("--target").arg(cross_compile::alternate()),
                 execs().with_status(0)
                        .with_stderr("\
 [COMPILING] foo v0.0.1 ([..])
@@ -817,7 +818,7 @@ fn build_script_with_platform_specific_dependencies() {
         .file("d2/src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("build").arg("-v").arg("--target").arg(&target),
+    assert_that!(p.cargo("build").arg("-v").arg("--target").arg(&target),
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] d2 v0.0.0 ([..])
@@ -873,7 +874,7 @@ fn platform_specific_dependencies_do_not_leak() {
         .file("d2/src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("build").arg("-v").arg("--target").arg(&target),
+    assert_that!(p.cargo("build").arg("-v").arg("--target").arg(&target),
                 execs().with_status(101)
                        .with_stderr_contains("\
 [..] can't find crate for `d2`[..]"));
@@ -943,8 +944,8 @@ fn platform_specific_variables_reflected_in_build_scripts() {
         .file("d2/src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("build").arg("-v"), execs().with_status(0));
-    assert_that(p.cargo("build").arg("-v").arg("--target").arg(&target),
+    assert_that!(p.cargo("build").arg("-v"), execs().with_status(0));
+    assert_that!(p.cargo("build").arg("-v").arg("--target").arg(&target),
                 execs().with_status(0));
 }
 
@@ -1000,7 +1001,7 @@ fn cross_test_dylib() {
         "#, cross_compile::alternate_arch()))
         .build();
 
-    assert_that(p.cargo("test").arg("--target").arg(&target),
+    assert_that!(p.cargo("test").arg("--target").arg(&target),
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] bar v0.0.1 ({dir}/bar)

--- a/tests/cross-publish.rs
+++ b/tests/cross-publish.rs
@@ -1,5 +1,6 @@
 extern crate cargo;
 extern crate cargotest;
+#[macro_use]
 extern crate hamcrest;
 extern crate flate2;
 extern crate tar;
@@ -9,7 +10,7 @@ use std::path::PathBuf;
 use std::io::prelude::*;
 
 use cargotest::support::{project, execs, cross_compile, publish};
-use hamcrest::{assert_that, contains};
+use hamcrest::prelude::*;
 use flate2::read::GzDecoder;
 use tar::Archive;
 
@@ -37,7 +38,7 @@ fn simple_cross_package() {
 
     let target = cross_compile::alternate();
 
-    assert_that(p.cargo("package").arg("--target").arg(&target),
+    assert_that!(p.cargo("package").arg("--target").arg(&target),
                 execs().with_status(0).with_status(0).with_stderr(&format!(
 "   Packaging foo v0.0.0 ({dir})
    Verifying foo v0.0.0 ({dir})
@@ -55,9 +56,9 @@ fn simple_cross_package() {
     let entry_paths = entries.map(|entry| {
         entry.unwrap().path().unwrap().into_owned()
     }).collect::<Vec<PathBuf>>();
-    assert_that(&entry_paths, contains(vec![PathBuf::from("foo-0.0.0/Cargo.toml")]));
-    assert_that(&entry_paths, contains(vec![PathBuf::from("foo-0.0.0/Cargo.toml.orig")]));
-    assert_that(&entry_paths, contains(vec![PathBuf::from("foo-0.0.0/src/main.rs")]));
+    assert_that!(&entry_paths, contains(vec![PathBuf::from("foo-0.0.0/Cargo.toml")]));
+    assert_that!(&entry_paths, contains(vec![PathBuf::from("foo-0.0.0/Cargo.toml.orig")]));
+    assert_that!(&entry_paths, contains(vec![PathBuf::from("foo-0.0.0/src/main.rs")]));
 }
 
 #[test]
@@ -86,7 +87,7 @@ fn publish_with_target() {
 
     let target = cross_compile::alternate();
 
-    assert_that(p.cargo("publish")
+    assert_that!(p.cargo("publish")
                  .arg("--index").arg(publish::registry().to_string())
                  .arg("--target").arg(&target),
                 execs().with_status(0).with_stderr(&format!(

--- a/tests/dep-info.rs
+++ b/tests/dep-info.rs
@@ -1,8 +1,9 @@
 extern crate cargotest;
+#[macro_use]
 extern crate hamcrest;
 
 use cargotest::support::{basic_bin_manifest, main_file, execs, project};
-use hamcrest::{assert_that, existing_file};
+use hamcrest::prelude::*;
 
 #[test]
 fn build_dep_info() {
@@ -11,11 +12,11 @@ fn build_dep_info() {
         .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
         .build();
 
-    assert_that(p.cargo("build"), execs().with_status(0));
+    assert_that!(p.cargo("build"), execs().with_status(0));
 
     let depinfo_bin_path = &p.bin("foo").with_extension("d");
 
-    assert_that(depinfo_bin_path, existing_file());
+    assert_that!(depinfo_bin_path, existing_file());
 }
 
 #[test]
@@ -36,8 +37,8 @@ fn build_dep_info_lib() {
         .file("examples/ex.rs", "")
         .build();
 
-    assert_that(p.cargo("build").arg("--example=ex"), execs().with_status(0));
-    assert_that(&p.example_lib("ex", "lib").with_extension("d"), existing_file());
+    assert_that!(p.cargo("build").arg("--example=ex"), execs().with_status(0));
+    assert_that!(&p.example_lib("ex", "lib").with_extension("d"), existing_file());
 }
 
 
@@ -58,8 +59,8 @@ fn build_dep_info_rlib() {
         .file("examples/ex.rs", "")
         .build();
 
-    assert_that(p.cargo("build").arg("--example=ex"), execs().with_status(0));
-    assert_that(&p.example_lib("ex", "rlib").with_extension("d"), existing_file());
+    assert_that!(p.cargo("build").arg("--example=ex"), execs().with_status(0));
+    assert_that!(&p.example_lib("ex", "rlib").with_extension("d"), existing_file());
 }
 
 #[test]
@@ -79,6 +80,6 @@ fn build_dep_info_dylib() {
         .file("examples/ex.rs", "")
         .build();
 
-    assert_that(p.cargo("build").arg("--example=ex"), execs().with_status(0));
-    assert_that(&p.example_lib("ex", "dylib").with_extension("d"), existing_file());
+    assert_that!(p.cargo("build").arg("--example=ex"), execs().with_status(0));
+    assert_that!(&p.example_lib("ex", "dylib").with_extension("d"), existing_file());
 }

--- a/tests/directory.rs
+++ b/tests/directory.rs
@@ -1,5 +1,6 @@
 #[macro_use]
 extern crate cargotest;
+#[macro_use]
 extern crate hamcrest;
 #[macro_use]
 extern crate serde_derive;
@@ -15,7 +16,7 @@ use cargotest::support::git;
 use cargotest::support::paths;
 use cargotest::support::registry::{Package, cksum};
 use cargotest::support::{project, execs, ProjectBuilder};
-use hamcrest::assert_that;
+use hamcrest::prelude::*;
 
 fn setup() {
     let root = paths::root();
@@ -103,7 +104,7 @@ fn simple() {
         "#)
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0).with_stderr("\
 [COMPILING] foo v0.1.0
 [COMPILING] bar v0.1.0 ([..]bar)
@@ -144,7 +145,7 @@ fn simple_install() {
         "#)
         .build();
 
-    assert_that(cargo_process().arg("install").arg("bar"),
+    assert_that!(cargo_process().arg("install").arg("bar"),
                 execs().with_status(0).with_stderr(
 "  Installing bar v0.1.0
    Compiling foo v0.1.0
@@ -189,7 +190,7 @@ fn simple_install_fail() {
         "#)
         .build();
 
-    assert_that(cargo_process().arg("install").arg("bar"),
+    assert_that!(cargo_process().arg("install").arg("bar"),
                 execs().with_status(101).with_stderr(
 "  Installing bar v0.1.0
 error: failed to compile `bar v0.1.0`, intermediate artifacts can be found at `[..]`
@@ -238,7 +239,7 @@ fn install_without_feature_dep() {
         "#)
         .build();
 
-    assert_that(cargo_process().arg("install").arg("bar"),
+    assert_that!(cargo_process().arg("install").arg("bar"),
                 execs().with_status(0).with_stderr(
 "  Installing bar v0.1.0
    Compiling foo v0.1.0
@@ -274,7 +275,7 @@ fn not_there() {
         "#)
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(101).with_stderr("\
 error: no matching package named `foo` found (required by `bar`)
 location searched: [..]
@@ -327,7 +328,7 @@ fn multiple() {
         "#)
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0).with_stderr("\
 [COMPILING] foo v0.1.0
 [COMPILING] bar v0.1.0 ([..]bar)
@@ -360,7 +361,7 @@ fn crates_io_then_directory() {
                         .file("src/lib.rs", "pub fn foo() -> u32 { 0 }")
                         .publish();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0).with_stderr("\
 [UPDATING] registry `[..]`
 [DOWNLOADING] foo v0.1.0 ([..])
@@ -382,7 +383,7 @@ fn crates_io_then_directory() {
     v.cksum.package = Some(cksum);
     v.build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0).with_stderr("\
 [COMPILING] foo v0.1.0
 [COMPILING] bar v0.1.0 ([..]bar)
@@ -407,7 +408,7 @@ fn crates_io_then_bad_checksum() {
 
     Package::new("foo", "0.1.0").publish();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0));
     setup();
 
@@ -421,7 +422,7 @@ fn crates_io_then_bad_checksum() {
         .file("src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(101).with_stderr("\
 error: checksum for `foo v0.1.0` changed between lock files
 
@@ -466,7 +467,7 @@ fn bad_file_checksum() {
         .file("src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(101).with_stderr("\
 error: the listed checksum of `[..]lib.rs` has changed:
 expected: [..]
@@ -508,7 +509,7 @@ fn only_dot_files_ok() {
         .file("src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("build"), execs().with_status(0));
+    assert_that!(p.cargo("build"), execs().with_status(0));
 }
 
 #[test]
@@ -548,7 +549,7 @@ fn git_lock_file_doesnt_change() {
         .file("src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("build"), execs().with_status(0));
+    assert_that!(p.cargo("build"), execs().with_status(0));
 
     let mut lock1 = String::new();
     t!(t!(File::open(p.root().join("Cargo.lock"))).read_to_string(&mut lock1));
@@ -564,7 +565,7 @@ fn git_lock_file_doesnt_change() {
         directory = 'index'
     "#, git.url()).as_bytes()));
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0)
                        .with_stderr("\
 [COMPILING] [..]
@@ -614,7 +615,7 @@ fn git_override_requires_lockfile() {
         directory = 'index'
     "#));
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(101)
                        .with_stderr("\
 error: failed to load source for a dependency on `git`

--- a/tests/doc.rs
+++ b/tests/doc.rs
@@ -1,4 +1,5 @@
 extern crate cargotest;
+#[macro_use]
 extern crate hamcrest;
 extern crate cargo;
 
@@ -9,7 +10,7 @@ use std::io::Read;
 use cargotest::rustc_host;
 use cargotest::support::{project, execs, path2url};
 use cargotest::support::registry::Package;
-use hamcrest::{assert_that, existing_file, existing_dir, is_not};
+use hamcrest::prelude::*;
 use cargo::util::ProcessError;
 
 #[test]
@@ -28,15 +29,15 @@ fn simple() {
         "#)
         .build();
 
-    assert_that(p.cargo("doc"),
+    assert_that!(p.cargo("doc"),
                 execs().with_status(0).with_stderr(&format!("\
 [..] foo v0.0.1 ({dir})
 [..] foo v0.0.1 ({dir})
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         dir = path2url(p.root()))));
-    assert_that(&p.root().join("target/doc"), existing_dir());
-    assert_that(&p.root().join("target/doc/foo/index.html"), existing_file());
+    assert_that!(&p.root().join("target/doc"), existing_dir());
+    assert_that!(&p.root().join("target/doc/foo/index.html"), existing_file());
 }
 
 #[test]
@@ -57,7 +58,7 @@ fn doc_no_libs() {
         "#)
         .build();
 
-    assert_that(p.cargo("doc"),
+    assert_that!(p.cargo("doc"),
                 execs().with_status(0));
 }
 
@@ -75,14 +76,14 @@ fn doc_twice() {
         "#)
         .build();
 
-    assert_that(p.cargo("doc"),
+    assert_that!(p.cargo("doc"),
                 execs().with_status(0).with_stderr(&format!("\
 [DOCUMENTING] foo v0.0.1 ({dir})
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         dir = path2url(p.root()))));
 
-    assert_that(p.cargo("doc"),
+    assert_that!(p.cargo("doc"),
                 execs().with_status(0).with_stdout(""))
 }
 
@@ -113,7 +114,7 @@ fn doc_deps() {
         "#)
         .build();
 
-    assert_that(p.cargo("doc"),
+    assert_that!(p.cargo("doc"),
                 execs().with_status(0).with_stderr(&format!("\
 [..] bar v0.0.1 ({dir}/bar)
 [..] bar v0.0.1 ({dir}/bar)
@@ -122,17 +123,17 @@ fn doc_deps() {
 ",
         dir = path2url(p.root()))));
 
-    assert_that(&p.root().join("target/doc"), existing_dir());
-    assert_that(&p.root().join("target/doc/foo/index.html"), existing_file());
-    assert_that(&p.root().join("target/doc/bar/index.html"), existing_file());
+    assert_that!(&p.root().join("target/doc"), existing_dir());
+    assert_that!(&p.root().join("target/doc/foo/index.html"), existing_file());
+    assert_that!(&p.root().join("target/doc/bar/index.html"), existing_file());
 
-    assert_that(p.cargo("doc")
+    assert_that!(p.cargo("doc")
                  .env("RUST_LOG", "cargo::ops::cargo_rustc::fingerprint"),
                 execs().with_status(0).with_stdout(""));
 
-    assert_that(&p.root().join("target/doc"), existing_dir());
-    assert_that(&p.root().join("target/doc/foo/index.html"), existing_file());
-    assert_that(&p.root().join("target/doc/bar/index.html"), existing_file());
+    assert_that!(&p.root().join("target/doc"), existing_dir());
+    assert_that!(&p.root().join("target/doc/foo/index.html"), existing_file());
+    assert_that!(&p.root().join("target/doc/bar/index.html"), existing_file());
 }
 
 #[test]
@@ -162,7 +163,7 @@ fn doc_no_deps() {
         "#)
         .build();
 
-    assert_that(p.cargo("doc").arg("--no-deps"),
+    assert_that!(p.cargo("doc").arg("--no-deps"),
                 execs().with_status(0).with_stderr(&format!("\
 [COMPILING] bar v0.0.1 ({dir}/bar)
 [DOCUMENTING] foo v0.0.1 ({dir})
@@ -170,9 +171,9 @@ fn doc_no_deps() {
 ",
         dir = path2url(p.root()))));
 
-    assert_that(&p.root().join("target/doc"), existing_dir());
-    assert_that(&p.root().join("target/doc/foo/index.html"), existing_file());
-    assert_that(&p.root().join("target/doc/bar/index.html"), is_not(existing_file()));
+    assert_that!(&p.root().join("target/doc"), existing_dir());
+    assert_that!(&p.root().join("target/doc/foo/index.html"), existing_file());
+    assert_that!(&p.root().join("target/doc/bar/index.html"), is_not(existing_file()));
 }
 
 #[test]
@@ -202,12 +203,12 @@ fn doc_only_bin() {
         "#)
         .build();
 
-    assert_that(p.cargo("doc").arg("-v"),
+    assert_that!(p.cargo("doc").arg("-v"),
                 execs().with_status(0));
 
-    assert_that(&p.root().join("target/doc"), existing_dir());
-    assert_that(&p.root().join("target/doc/bar/index.html"), existing_file());
-    assert_that(&p.root().join("target/doc/foo/index.html"), existing_file());
+    assert_that!(&p.root().join("target/doc"), existing_dir());
+    assert_that!(&p.root().join("target/doc/bar/index.html"), existing_file());
+    assert_that!(&p.root().join("target/doc/foo/index.html"), existing_file());
 }
 
 #[test]
@@ -235,7 +236,7 @@ fn doc_multiple_targets_same_name_lib() {
         .file("bar/src/lib.rs", "")
         .build();
 
-        assert_that(p.cargo("doc").arg("--all"),
+        assert_that!(p.cargo("doc").arg("--all"),
                     execs()
                     .with_status(101)
                     .with_stderr_contains("[..] library `foo_lib` is specified [..]")
@@ -271,15 +272,15 @@ fn doc_multiple_targets_same_name() {
 
         let root = path2url(p.root());
 
-        assert_that(p.cargo("doc").arg("--all"),
+        assert_that!(p.cargo("doc").arg("--all"),
                     execs()
                     .with_status(0)
                     .with_stderr_contains(&format!("[DOCUMENTING] foo v0.1.0 ({}/foo)", root))
                     .with_stderr_contains(&format!("[DOCUMENTING] bar v0.1.0 ({}/bar)", root))
                     .with_stderr_contains("[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]"));
-        assert_that(&p.root().join("target/doc"), existing_dir());
+        assert_that!(&p.root().join("target/doc"), existing_dir());
         let doc_file = p.root().join("target/doc/foo_lib/index.html");
-        assert_that(&doc_file, existing_file());
+        assert_that!(&doc_file, existing_file());
 }
 
 #[test]
@@ -307,7 +308,7 @@ fn doc_multiple_targets_same_name_bin() {
         .file("bar/src/foo-cli.rs", "")
         .build();
 
-        assert_that(p.cargo("doc").arg("--all"),
+        assert_that!(p.cargo("doc").arg("--all"),
                     execs()
                     .with_status(101)
                     .with_stderr_contains("[..] binary `foo_cli` is specified [..]")
@@ -341,7 +342,7 @@ fn doc_multiple_targets_same_name_undoced() {
         .file("bar/src/foo-cli.rs", "")
         .build();
 
-        assert_that(p.cargo("doc").arg("--all"),
+        assert_that!(p.cargo("doc").arg("--all"),
                     execs().with_status(0));
 }
 
@@ -367,14 +368,14 @@ fn doc_lib_bin_same_name_documents_lib() {
         "#)
         .build();
 
-    assert_that(p.cargo("doc"),
+    assert_that!(p.cargo("doc"),
                 execs().with_status(0).with_stderr(&format!("\
 [DOCUMENTING] foo v0.0.1 ({dir})
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ", dir = path2url(p.root()))));
-    assert_that(&p.root().join("target/doc"), existing_dir());
+    assert_that!(&p.root().join("target/doc"), existing_dir());
     let doc_file = p.root().join("target/doc/foo/index.html");
-    assert_that(&doc_file, existing_file());
+    assert_that!(&doc_file, existing_file());
     let mut doc_html = String::new();
     File::open(&doc_file).unwrap().read_to_string(&mut doc_html).unwrap();
     assert!(doc_html.contains("Library"));
@@ -403,14 +404,14 @@ fn doc_lib_bin_same_name_documents_lib_when_requested() {
         "#)
         .build();
 
-    assert_that(p.cargo("doc").arg("--lib"),
+    assert_that!(p.cargo("doc").arg("--lib"),
                 execs().with_status(0).with_stderr(&format!("\
 [DOCUMENTING] foo v0.0.1 ({dir})
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ", dir = path2url(p.root()))));
-    assert_that(&p.root().join("target/doc"), existing_dir());
+    assert_that!(&p.root().join("target/doc"), existing_dir());
     let doc_file = p.root().join("target/doc/foo/index.html");
-    assert_that(&doc_file, existing_file());
+    assert_that!(&doc_file, existing_file());
     let mut doc_html = String::new();
     File::open(&doc_file).unwrap().read_to_string(&mut doc_html).unwrap();
     assert!(doc_html.contains("Library"));
@@ -439,15 +440,15 @@ fn doc_lib_bin_same_name_documents_named_bin_when_requested() {
         "#)
         .build();
 
-    assert_that(p.cargo("doc").arg("--bin").arg("foo"),
+    assert_that!(p.cargo("doc").arg("--bin").arg("foo"),
                 execs().with_status(0).with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({dir})
 [DOCUMENTING] foo v0.0.1 ({dir})
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ", dir = path2url(p.root()))));
-    assert_that(&p.root().join("target/doc"), existing_dir());
+    assert_that!(&p.root().join("target/doc"), existing_dir());
     let doc_file = p.root().join("target/doc/foo/index.html");
-    assert_that(&doc_file, existing_file());
+    assert_that!(&doc_file, existing_file());
     let mut doc_html = String::new();
     File::open(&doc_file).unwrap().read_to_string(&mut doc_html).unwrap();
     assert!(!doc_html.contains("Library"));
@@ -476,15 +477,15 @@ fn doc_lib_bin_same_name_documents_bins_when_requested() {
         "#)
         .build();
 
-    assert_that(p.cargo("doc").arg("--bins"),
+    assert_that!(p.cargo("doc").arg("--bins"),
                 execs().with_status(0).with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({dir})
 [DOCUMENTING] foo v0.0.1 ({dir})
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ", dir = path2url(p.root()))));
-    assert_that(&p.root().join("target/doc"), existing_dir());
+    assert_that!(&p.root().join("target/doc"), existing_dir());
     let doc_file = p.root().join("target/doc/foo/index.html");
-    assert_that(&doc_file, existing_file());
+    assert_that!(&doc_file, existing_file());
     let mut doc_html = String::new();
     File::open(&doc_file).unwrap().read_to_string(&mut doc_html).unwrap();
     assert!(!doc_html.contains("Library"));
@@ -523,7 +524,7 @@ fn doc_dash_p() {
         .file("b/src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("doc").arg("-p").arg("a"),
+    assert_that!(p.cargo("doc").arg("-p").arg("a"),
                 execs().with_status(0)
                        .with_stderr("\
 [..] b v0.0.1 (file://[..])
@@ -548,7 +549,7 @@ fn doc_same_name() {
         .file("tests/main.rs", "fn main() {}")
         .build();
 
-    assert_that(p.cargo("doc"),
+    assert_that!(p.cargo("doc"),
                 execs().with_status(0));
 }
 
@@ -573,10 +574,10 @@ fn doc_target() {
         "#)
         .build();
 
-    assert_that(p.cargo("doc").arg("--target").arg(TARGET).arg("--verbose"),
+    assert_that!(p.cargo("doc").arg("--target").arg(TARGET).arg("--verbose"),
                 execs().with_status(0));
-    assert_that(&p.root().join(&format!("target/{}/doc", TARGET)), existing_dir());
-    assert_that(&p.root().join(&format!("target/{}/doc/foo/index.html", TARGET)), existing_file());
+    assert_that!(&p.root().join(&format!("target/{}/doc", TARGET)), existing_dir());
+    assert_that!(&p.root().join(&format!("target/{}/doc/foo/index.html", TARGET)), existing_file());
 }
 
 #[test]
@@ -601,7 +602,7 @@ fn target_specific_not_documented() {
         .file("a/src/lib.rs", "not rust")
         .build();
 
-    assert_that(p.cargo("doc"),
+    assert_that!(p.cargo("doc"),
                 execs().with_status(0));
 }
 
@@ -676,7 +677,7 @@ fn target_specific_documented() {
         ")
         .build();
 
-    assert_that(p.cargo("doc"),
+    assert_that!(p.cargo("doc"),
                 execs().with_status(0));
 }
 
@@ -709,7 +710,7 @@ fn no_document_build_deps() {
         ")
         .build();
 
-    assert_that(p.cargo("doc"),
+    assert_that!(p.cargo("doc"),
                 execs().with_status(0));
 }
 
@@ -725,9 +726,9 @@ fn doc_release() {
         .file("src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("build").arg("--release"),
+    assert_that!(p.cargo("build").arg("--release"),
                 execs().with_status(0));
-    assert_that(p.cargo("doc").arg("--release").arg("-v"),
+    assert_that!(p.cargo("doc").arg("--release").arg("-v"),
                 execs().with_status(0)
                        .with_stderr("\
 [DOCUMENTING] foo v0.0.1 ([..])
@@ -775,15 +776,15 @@ fn doc_multiple_deps() {
         "#)
         .build();
 
-    assert_that(p.cargo("doc")
+    assert_that!(p.cargo("doc")
                   .arg("-p").arg("bar")
                   .arg("-p").arg("baz")
                   .arg("-v"),
                 execs().with_status(0));
 
-    assert_that(&p.root().join("target/doc"), existing_dir());
-    assert_that(&p.root().join("target/doc/bar/index.html"), existing_file());
-    assert_that(&p.root().join("target/doc/baz/index.html"), existing_file());
+    assert_that!(&p.root().join("target/doc"), existing_dir());
+    assert_that!(&p.root().join("target/doc/bar/index.html"), existing_file());
+    assert_that!(&p.root().join("target/doc/baz/index.html"), existing_file());
 }
 
 #[test]
@@ -824,11 +825,11 @@ fn features() {
             pub fn bar() {}
         "#)
         .build();
-    assert_that(p.cargo("doc").arg("--features").arg("foo"),
+    assert_that!(p.cargo("doc").arg("--features").arg("foo"),
                 execs().with_status(0));
-    assert_that(&p.root().join("target/doc"), existing_dir());
-    assert_that(&p.root().join("target/doc/foo/fn.foo.html"), existing_file());
-    assert_that(&p.root().join("target/doc/bar/fn.bar.html"), existing_file());
+    assert_that!(&p.root().join("target/doc"), existing_dir());
+    assert_that!(&p.root().join("target/doc/foo/fn.foo.html"), existing_file());
+    assert_that!(&p.root().join("target/doc/bar/fn.bar.html"), existing_file());
 }
 
 #[test]
@@ -846,15 +847,15 @@ fn rerun_when_dir_removed() {
         "#)
         .build();
 
-    assert_that(p.cargo("doc"),
+    assert_that!(p.cargo("doc"),
                 execs().with_status(0));
-    assert_that(&p.root().join("target/doc/foo/index.html"), existing_file());
+    assert_that!(&p.root().join("target/doc/foo/index.html"), existing_file());
 
     fs::remove_dir_all(p.root().join("target/doc/foo")).unwrap();
 
-    assert_that(p.cargo("doc"),
+    assert_that!(p.cargo("doc"),
                 execs().with_status(0));
-    assert_that(&p.root().join("target/doc/foo/index.html"), existing_file());
+    assert_that!(&p.root().join("target/doc/foo/index.html"), existing_file());
 }
 
 #[test]
@@ -878,9 +879,9 @@ fn document_only_lib() {
             fn main() { foo(); }
         "#)
         .build();
-    assert_that(p.cargo("doc").arg("--lib"),
+    assert_that!(p.cargo("doc").arg("--lib"),
                 execs().with_status(0));
-    assert_that(&p.root().join("target/doc/foo/index.html"), existing_file());
+    assert_that!(&p.root().join("target/doc/foo/index.html"), existing_file());
 }
 
 #[test]
@@ -900,7 +901,7 @@ fn plugins_no_use_target() {
         "#)
         .file("src/lib.rs", "")
         .build();
-    assert_that(p.cargo("doc")
+    assert_that!(p.cargo("doc")
                  .arg("--target=x86_64-unknown-openbsd")
                  .arg("-v"),
                 execs().with_status(0));
@@ -933,7 +934,7 @@ fn doc_all_workspace() {
         .build();
 
     // The order in which bar is compiled or documented is not deterministic
-    assert_that(p.cargo("doc")
+    assert_that!(p.cargo("doc")
                  .arg("--all"),
                 execs().with_status(0)
                        .with_stderr_contains("[..] Documenting bar v0.1.0 ([..])")
@@ -967,7 +968,7 @@ fn doc_all_virtual_manifest() {
         .build();
 
     // The order in which foo and bar are documented is not guaranteed
-    assert_that(p.cargo("doc")
+    assert_that!(p.cargo("doc")
                  .arg("--all"),
                 execs().with_status(0)
                        .with_stderr_contains("[..] Documenting bar v0.1.0 ([..])")
@@ -1000,7 +1001,7 @@ fn doc_virtual_manifest_all_implied() {
         .build();
 
     // The order in which foo and bar are documented is not guaranteed
-    assert_that(p.cargo("doc"),
+    assert_that!(p.cargo("doc"),
                 execs().with_status(0)
                        .with_stderr_contains("[..] Documenting bar v0.1.0 ([..])")
                        .with_stderr_contains("[..] Documenting foo v0.1.0 ([..])"));
@@ -1028,7 +1029,7 @@ fn doc_all_member_dependency_same_name() {
 
     Package::new("a", "0.1.0").publish();
 
-    assert_that(p.cargo("doc")
+    assert_that!(p.cargo("doc")
                  .arg("--all"),
                 execs().with_status(0)
                        .with_stderr_contains("[..] Updating registry `[..]`")

--- a/tests/features.rs
+++ b/tests/features.rs
@@ -1,5 +1,6 @@
 #[macro_use]
 extern crate cargotest;
+#[macro_use]
 extern crate hamcrest;
 
 use std::fs::File;
@@ -7,7 +8,7 @@ use std::io::prelude::*;
 
 use cargotest::support::paths::CargoPathExt;
 use cargotest::support::{project, execs};
-use hamcrest::assert_that;
+use hamcrest::prelude::*;
 
 #[test]
 fn invalid1() {
@@ -24,7 +25,7 @@ fn invalid1() {
         .file("src/main.rs", "")
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(101).with_stderr("\
 [ERROR] failed to parse manifest at `[..]`
 
@@ -51,7 +52,7 @@ fn invalid2() {
         .file("src/main.rs", "")
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(101).with_stderr("\
 [ERROR] failed to parse manifest at `[..]`
 
@@ -78,7 +79,7 @@ fn invalid3() {
         .file("src/main.rs", "")
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(101).with_stderr("\
 [ERROR] failed to parse manifest at `[..]`
 
@@ -111,7 +112,7 @@ fn invalid4() {
         .file("bar/src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(101).with_stderr("\
 [ERROR] Package `bar v0.0.1 ([..])` does not have these features: `bar`
 "));
@@ -123,7 +124,7 @@ fn invalid4() {
         authors = []
     "#);
 
-    assert_that(p.cargo("build").arg("--features").arg("test"),
+    assert_that!(p.cargo("build").arg("--features").arg("test"),
                 execs().with_status(101).with_stderr("\
 [ERROR] Package `foo v0.0.1 ([..])` does not have these features: `test`
 "));
@@ -145,7 +146,7 @@ fn invalid5() {
         .file("src/main.rs", "")
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(101).with_stderr("\
 [ERROR] failed to parse manifest at `[..]`
 
@@ -169,7 +170,7 @@ fn invalid6() {
         .file("src/main.rs", "")
         .build();
 
-    assert_that(p.cargo("build").arg("--features").arg("foo"),
+    assert_that!(p.cargo("build").arg("--features").arg("foo"),
                 execs().with_status(101).with_stderr("\
 [ERROR] failed to parse manifest at `[..]`
 
@@ -194,7 +195,7 @@ fn invalid7() {
         .file("src/main.rs", "")
         .build();
 
-    assert_that(p.cargo("build").arg("--features").arg("foo"),
+    assert_that!(p.cargo("build").arg("--features").arg("foo"),
                 execs().with_status(101).with_stderr("\
 [ERROR] failed to parse manifest at `[..]`
 
@@ -226,7 +227,7 @@ fn invalid8() {
         .file("bar/src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("build").arg("--features").arg("foo"),
+    assert_that!(p.cargo("build").arg("--features").arg("foo"),
                 execs().with_status(101).with_stderr("\
 [ERROR] feature names may not contain slashes: `foo/bar`
 "));
@@ -254,7 +255,7 @@ fn invalid9() {
         .file("bar/src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("build").arg("--features").arg("bar"),
+    assert_that!(p.cargo("build").arg("--features").arg("bar"),
                 execs().with_status(0).with_stderr("\
 warning: Package `foo v0.0.1 ([..])` does not have feature `bar`. It has a required dependency with \
 that name, but only optional dependencies can be used as features. [..]
@@ -297,7 +298,7 @@ fn invalid10() {
         .file("bar/baz/src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0).with_stderr("\
 warning: Package `bar v0.0.1 ([..])` does not have feature `baz`. It has a required dependency with \
 that name, but only optional dependencies can be used as features. [..]
@@ -354,7 +355,7 @@ fn no_transitive_dep_feature_requirement() {
             pub fn test() { print!("test"); }
         "#)
         .build();
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(101).with_stderr("\
 [ERROR] feature names may not contain slashes: `bar/qux`
 "));
@@ -390,21 +391,21 @@ fn no_feature_doesnt_build() {
         .file("bar/src/lib.rs", "pub fn bar() {}")
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0).with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({dir})
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ", dir = p.url())));
-    assert_that(p.process(&p.bin("foo")),
+    assert_that!(p.process(&p.bin("foo")),
                 execs().with_status(0).with_stdout(""));
 
-    assert_that(p.cargo("build").arg("--features").arg("bar"),
+    assert_that!(p.cargo("build").arg("--features").arg("bar"),
                 execs().with_status(0).with_stderr(format!("\
 [COMPILING] bar v0.0.1 ({dir}/bar)
 [COMPILING] foo v0.0.1 ({dir})
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ", dir = p.url())));
-    assert_that(p.process(&p.bin("foo")),
+    assert_that!(p.process(&p.bin("foo")),
                 execs().with_status(0).with_stdout("bar\n"));
 }
 
@@ -441,21 +442,21 @@ fn default_feature_pulled_in() {
         .file("bar/src/lib.rs", "pub fn bar() {}")
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0).with_stderr(format!("\
 [COMPILING] bar v0.0.1 ({dir}/bar)
 [COMPILING] foo v0.0.1 ({dir})
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ", dir = p.url())));
-    assert_that(p.process(&p.bin("foo")),
+    assert_that!(p.process(&p.bin("foo")),
                 execs().with_status(0).with_stdout("bar\n"));
 
-    assert_that(p.cargo("build").arg("--no-default-features"),
+    assert_that!(p.cargo("build").arg("--no-default-features"),
                 execs().with_status(0).with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({dir})
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ", dir = p.url())));
-    assert_that(p.process(&p.bin("foo")),
+    assert_that!(p.process(&p.bin("foo")),
                 execs().with_status(0).with_stdout(""));
 }
 
@@ -474,7 +475,7 @@ fn cyclic_feature() {
         .file("src/main.rs", "")
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(101).with_stderr("\
 [ERROR] Cyclic feature dependency: feature `default` depends on itself
 "));
@@ -496,7 +497,7 @@ fn cyclic_feature2() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0).with_stdout(""));
 }
 
@@ -550,7 +551,7 @@ fn groups_on_groups_on_groups() {
         .file("baz/src/lib.rs", "pub fn baz() {}")
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0).with_stderr(format!("\
 [COMPILING] ba[..] v0.0.1 ({dir}/ba[..])
 [COMPILING] ba[..] v0.0.1 ({dir}/ba[..])
@@ -599,7 +600,7 @@ fn many_cli_features() {
         .file("baz/src/lib.rs", "pub fn baz() {}")
         .build();
 
-    assert_that(p.cargo("build").arg("--features").arg("bar baz"),
+    assert_that!(p.cargo("build").arg("--features").arg("bar baz"),
                 execs().with_status(0).with_stderr(format!("\
 [COMPILING] ba[..] v0.0.1 ({dir}/ba[..])
 [COMPILING] ba[..] v0.0.1 ({dir}/ba[..])
@@ -664,7 +665,7 @@ fn union_features() {
         "#)
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0).with_stderr(format!("\
 [COMPILING] d2 v0.0.1 ({dir}/d2)
 [COMPILING] d1 v0.0.1 ({dir}/d1)
@@ -701,7 +702,7 @@ fn many_features_no_rebuilds() {
         .file("a/src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0).with_stderr(format!("\
 [COMPILING] a v0.1.0 ({dir}/a)
 [COMPILING] b v0.1.0 ({dir})
@@ -709,7 +710,7 @@ fn many_features_no_rebuilds() {
 ", dir = p.url())));
     p.root().move_into_the_past();
 
-    assert_that(p.cargo("build").arg("-v"),
+    assert_that!(p.cargo("build").arg("-v"),
                 execs().with_status(0).with_stderr("\
 [FRESH] a v0.1.0 ([..]/a)
 [FRESH] b v0.1.0 ([..])
@@ -730,7 +731,7 @@ fn empty_features() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    assert_that(p.cargo("build").arg("--features").arg(""),
+    assert_that!(p.cargo("build").arg("--features").arg(""),
                 execs().with_status(0));
 }
 
@@ -769,7 +770,7 @@ fn transitive_features() {
         "#)
         .build();
 
-    assert_that(p.cargo("build").arg("--features").arg("foo"),
+    assert_that!(p.cargo("build").arg("--features").arg("foo"),
                 execs().with_status(0));
 }
 
@@ -825,7 +826,7 @@ fn everything_in_the_lockfile() {
         .file("d3/src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("fetch"), execs().with_status(0));
+    assert_that!(p.cargo("fetch"), execs().with_status(0));
     let loc = p.root().join("Cargo.lock");
     let mut lockfile = String::new();
     t!(t!(File::open(&loc)).read_to_string(&mut lockfile));
@@ -871,9 +872,9 @@ fn no_rebuild_when_frobbing_default_feature() {
         .file("a/src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("build"), execs().with_status(0));
-    assert_that(p.cargo("build"), execs().with_status(0).with_stdout(""));
-    assert_that(p.cargo("build"), execs().with_status(0).with_stdout(""));
+    assert_that!(p.cargo("build"), execs().with_status(0));
+    assert_that!(p.cargo("build"), execs().with_status(0).with_stdout(""));
+    assert_that!(p.cargo("build"), execs().with_status(0).with_stdout(""));
 }
 
 #[test]
@@ -919,9 +920,9 @@ fn unions_work_with_no_default_features() {
         "#)
         .build();
 
-    assert_that(p.cargo("build"), execs().with_status(0));
-    assert_that(p.cargo("build"), execs().with_status(0).with_stdout(""));
-    assert_that(p.cargo("build"), execs().with_status(0).with_stdout(""));
+    assert_that!(p.cargo("build"), execs().with_status(0));
+    assert_that!(p.cargo("build"), execs().with_status(0).with_stdout(""));
+    assert_that!(p.cargo("build"), execs().with_status(0).with_stdout(""));
 }
 
 #[test]
@@ -948,7 +949,7 @@ fn optional_and_dev_dep() {
         .file("foo/src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0).with_stderr("\
 [COMPILING] test v0.1.0 ([..])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
@@ -991,7 +992,7 @@ fn activating_feature_activates_dep() {
         "#)
         .build();
 
-    assert_that(p.cargo("build").arg("--features").arg("a").arg("-v"),
+    assert_that!(p.cargo("build").arg("--features").arg("a").arg("-v"),
                 execs().with_status(0));
 }
 
@@ -1045,22 +1046,22 @@ fn dep_feature_in_cmd_line() {
 
     // The foo project requires that feature "some-feat" in "bar" is enabled.
     // Building without any features enabled should fail:
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(101));
 
     // We should be able to enable the feature "derived-feat", which enables "some-feat",
     // on the command line. The feature is enabled, thus building should be successful:
-    assert_that(p.cargo("build").arg("--features").arg("derived/derived-feat"),
+    assert_that!(p.cargo("build").arg("--features").arg("derived/derived-feat"),
                 execs().with_status(0));
 
     // Trying to enable features of transitive dependencies is an error
-    assert_that(p.cargo("build").arg("--features").arg("bar/some-feat"),
+    assert_that!(p.cargo("build").arg("--features").arg("bar/some-feat"),
                 execs().with_status(101).with_stderr("\
 [ERROR] Package `foo v0.0.1 ([..])` does not have these features: `bar`
 "));
 
     // Hierarchical feature specification should still be disallowed
-    assert_that(p.cargo("build").arg("--features").arg("derived/bar/some-feat"),
+    assert_that!(p.cargo("build").arg("--features").arg("derived/bar/some-feat"),
                 execs().with_status(101).with_stderr("\
 [ERROR] feature names may not contain slashes: `bar/some-feat`
 "));
@@ -1107,7 +1108,7 @@ fn all_features_flag_enables_all_features() {
         .file("baz/src/lib.rs", "pub fn baz() {}")
         .build();
 
-    assert_that(p.cargo("build").arg("--all-features"),
+    assert_that!(p.cargo("build").arg("--all-features"),
                 execs().with_status(0));
 }
 
@@ -1151,7 +1152,7 @@ fn many_cli_features_comma_delimited() {
         .file("baz/src/lib.rs", "pub fn baz() {}")
         .build();
 
-    assert_that(p.cargo("build").arg("--features").arg("bar,baz"),
+    assert_that!(p.cargo("build").arg("--features").arg("bar,baz"),
                 execs().with_status(0).with_stderr(format!("\
 [COMPILING] ba[..] v0.0.1 ({dir}/ba[..])
 [COMPILING] ba[..] v0.0.1 ({dir}/ba[..])
@@ -1226,7 +1227,7 @@ fn many_cli_features_comma_and_space_delimited() {
         .file("bap/src/lib.rs", "pub fn bap() {}")
         .build();
 
-    assert_that(p.cargo("build").arg("--features").arg("bar,baz bam bap"),
+    assert_that!(p.cargo("build").arg("--features").arg("bar,baz bam bap"),
                 execs().with_status(0).with_stderr(format!("\
 [COMPILING] ba[..] v0.0.1 ({dir}/ba[..])
 [COMPILING] ba[..] v0.0.1 ({dir}/ba[..])

--- a/tests/fetch.rs
+++ b/tests/fetch.rs
@@ -1,8 +1,9 @@
 extern crate cargotest;
+#[macro_use]
 extern crate hamcrest;
 
 use cargotest::support::{project, execs};
-use hamcrest::assert_that;
+use hamcrest::prelude::*;
 
 #[test]
 fn no_deps() {
@@ -19,6 +20,6 @@ fn no_deps() {
         .file("src/a.rs", "")
         .build();
 
-    assert_that(p.cargo("fetch"),
+    assert_that!(p.cargo("fetch"),
                 execs().with_status(0).with_stdout(""));
 }

--- a/tests/freshness.rs
+++ b/tests/freshness.rs
@@ -1,4 +1,5 @@
 extern crate cargotest;
+#[macro_use]
 extern crate hamcrest;
 
 use std::fs::{self, File};
@@ -7,7 +8,7 @@ use std::io::prelude::*;
 use cargotest::sleep_ms;
 use cargotest::support::{project, execs, path2url};
 use cargotest::support::paths::CargoPathExt;
-use hamcrest::{assert_that, existing_file};
+use hamcrest::prelude::*;
 
 #[test]
 fn modifying_and_moving() {
@@ -24,27 +25,27 @@ fn modifying_and_moving() {
         .file("src/a.rs", "")
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0).with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({dir})
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ", dir = path2url(p.root()))));
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0).with_stdout(""));
     p.root().move_into_the_past();
     p.root().join("target").move_into_the_past();
 
     File::create(&p.root().join("src/a.rs")).unwrap()
          .write_all(b"#[allow(unused)]fn main() {}").unwrap();
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0).with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({dir})
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ", dir = path2url(p.root()))));
 
     fs::rename(&p.root().join("src/a.rs"), &p.root().join("src/b.rs")).unwrap();
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(101));
 }
 
@@ -67,16 +68,16 @@ fn modify_only_some_files() {
         .file("tests/test.rs", "")
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0).with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({dir})
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ", dir = path2url(p.root()))));
-    assert_that(p.cargo("test"),
+    assert_that!(p.cargo("test"),
                 execs().with_status(0));
     sleep_ms(1000);
 
-    assert_that(&p.bin("foo"), existing_file());
+    assert_that!(&p.bin("foo"), existing_file());
 
     let lib = p.root().join("src/lib.rs");
     let bin = p.root().join("src/b.rs");
@@ -86,12 +87,12 @@ fn modify_only_some_files() {
     lib.move_into_the_past();
 
     // Make sure the binary is rebuilt, not the lib
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0).with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({dir})
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ", dir = path2url(p.root()))));
-    assert_that(&p.bin("foo"), existing_file());
+    assert_that!(&p.bin("foo"), existing_file());
 }
 
 #[test]
@@ -127,14 +128,14 @@ fn rebuild_sub_package_then_while_package() {
         .file("b/src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0));
 
     File::create(&p.root().join("b/src/lib.rs")).unwrap().write_all(br#"
         pub fn b() {}
     "#).unwrap();
 
-    assert_that(p.cargo("build").arg("-pb"),
+    assert_that!(p.cargo("build").arg("-pb"),
                 execs().with_status(0));
 
     File::create(&p.root().join("src/lib.rs")).unwrap().write_all(br#"
@@ -143,7 +144,7 @@ fn rebuild_sub_package_then_while_package() {
         pub fn toplevel() {}
     "#).unwrap();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0));
 }
 
@@ -162,14 +163,14 @@ fn changing_lib_features_caches_targets() {
         .file("src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0)
                        .with_stderr("\
 [..]Compiling foo v0.0.1 ([..])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
 
-    assert_that(p.cargo("build").arg("--features").arg("foo"),
+    assert_that!(p.cargo("build").arg("--features").arg("foo"),
                 execs().with_status(0)
                        .with_stderr("\
 [..]Compiling foo v0.0.1 ([..])
@@ -178,17 +179,17 @@ fn changing_lib_features_caches_targets() {
 
     /* Targets should be cached from the first build */
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0)
                        .with_stderr("\
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0)
                        .with_stdout(""));
 
-    assert_that(p.cargo("build").arg("--features").arg("foo"),
+    assert_that!(p.cargo("build").arg("--features").arg("foo"),
                 execs().with_status(0)
                        .with_stderr("\
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
@@ -213,14 +214,14 @@ fn changing_profiles_caches_targets() {
         .file("src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0)
                        .with_stderr("\
 [..]Compiling foo v0.0.1 ([..])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
 
-    assert_that(p.cargo("test"),
+    assert_that!(p.cargo("test"),
                 execs().with_status(0)
                        .with_stderr("\
 [..]Compiling foo v0.0.1 ([..])
@@ -231,13 +232,13 @@ fn changing_profiles_caches_targets() {
 
     /* Targets should be cached from the first build */
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0)
                        .with_stderr("\
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
 
-    assert_that(p.cargo("test").arg("foo"),
+    assert_that!(p.cargo("test").arg("foo"),
                 execs().with_status(0)
                        .with_stderr("\
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
@@ -310,7 +311,7 @@ fn changing_bin_paths_common_target_features_caches_targets() {
         .build();
 
     /* Build and rebuild a/. Ensure dep_crate only builds once */
-    assert_that(p.cargo("run").cwd(p.root().join("a")),
+    assert_that!(p.cargo("run").cwd(p.root().join("a")),
                 execs().with_status(0)
                        .with_stdout("ftest off")
                        .with_stderr("\
@@ -319,9 +320,9 @@ fn changing_bin_paths_common_target_features_caches_targets() {
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `[..]target[/]debug[/]a[EXE]`
 "));
-    assert_that(p.cargo("clean").arg("-p").arg("a").cwd(p.root().join("a")),
+    assert_that!(p.cargo("clean").arg("-p").arg("a").cwd(p.root().join("a")),
                 execs().with_status(0));
-    assert_that(p.cargo("run").cwd(p.root().join("a")),
+    assert_that!(p.cargo("run").cwd(p.root().join("a")),
                 execs().with_status(0)
                        .with_stdout("ftest off")
                        .with_stderr("\
@@ -331,7 +332,7 @@ fn changing_bin_paths_common_target_features_caches_targets() {
 "));
 
     /* Build and rebuild b/. Ensure dep_crate only builds once */
-    assert_that(p.cargo("run").cwd(p.root().join("b")),
+    assert_that!(p.cargo("run").cwd(p.root().join("b")),
                 execs().with_status(0)
                        .with_stdout("ftest on")
                        .with_stderr("\
@@ -340,9 +341,9 @@ fn changing_bin_paths_common_target_features_caches_targets() {
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `[..]target[/]debug[/]b[EXE]`
 "));
-    assert_that(p.cargo("clean").arg("-p").arg("b").cwd(p.root().join("b")),
+    assert_that!(p.cargo("clean").arg("-p").arg("b").cwd(p.root().join("b")),
                 execs().with_status(0));
-    assert_that(p.cargo("run").cwd(p.root().join("b")),
+    assert_that!(p.cargo("run").cwd(p.root().join("b")),
                 execs().with_status(0)
                        .with_stdout("ftest on")
                        .with_stderr("\
@@ -353,9 +354,9 @@ fn changing_bin_paths_common_target_features_caches_targets() {
 
     /* Build a/ package again. If we cache different feature dep builds correctly,
      * this should not cause a rebuild of dep_crate */
-    assert_that(p.cargo("clean").arg("-p").arg("a").cwd(p.root().join("a")),
+    assert_that!(p.cargo("clean").arg("-p").arg("a").cwd(p.root().join("a")),
                 execs().with_status(0));
-    assert_that(p.cargo("run").cwd(p.root().join("a")),
+    assert_that!(p.cargo("run").cwd(p.root().join("a")),
                 execs().with_status(0)
                        .with_stdout("ftest off")
                        .with_stderr("\
@@ -366,9 +367,9 @@ fn changing_bin_paths_common_target_features_caches_targets() {
 
     /* Build b/ package again. If we cache different feature dep builds correctly,
      * this should not cause a rebuild */
-    assert_that(p.cargo("clean").arg("-p").arg("b").cwd(p.root().join("b")),
+    assert_that!(p.cargo("clean").arg("-p").arg("b").cwd(p.root().join("b")),
                 execs().with_status(0));
-    assert_that(p.cargo("run").cwd(p.root().join("b")),
+    assert_that!(p.cargo("run").cwd(p.root().join("b")),
                 execs().with_status(0)
                        .with_stdout("ftest on")
                        .with_stderr("\
@@ -398,7 +399,7 @@ fn changing_bin_features_caches_targets() {
         "#)
         .build();
 
-    assert_that(p.cargo("run"),
+    assert_that!(p.cargo("run"),
                 execs().with_status(0)
                        .with_stdout("feature off")
                        .with_stderr("\
@@ -407,7 +408,7 @@ fn changing_bin_features_caches_targets() {
 [RUNNING] `target[/]debug[/]foo[EXE]`
 "));
 
-    assert_that(p.cargo("run").arg("--features").arg("foo"),
+    assert_that!(p.cargo("run").arg("--features").arg("foo"),
                 execs().with_status(0)
                        .with_stdout("feature on")
                        .with_stderr("\
@@ -418,7 +419,7 @@ fn changing_bin_features_caches_targets() {
 
     /* Targets should be cached from the first build */
 
-    assert_that(p.cargo("run"),
+    assert_that!(p.cargo("run"),
                 execs().with_status(0)
                        .with_stdout("feature off")
                        .with_stderr("\
@@ -426,7 +427,7 @@ fn changing_bin_features_caches_targets() {
 [RUNNING] `target[/]debug[/]foo[EXE]`
 "));
 
-    assert_that(p.cargo("run").arg("--features").arg("foo"),
+    assert_that!(p.cargo("run").arg("--features").arg("foo"),
                 execs().with_status(0)
                        .with_stdout("feature on")
                        .with_stderr("\
@@ -452,17 +453,17 @@ fn rebuild_tests_if_lib_changes() {
         "#)
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0));
-    assert_that(p.cargo("test"),
+    assert_that!(p.cargo("test"),
                 execs().with_status(0));
 
     sleep_ms(1000);
     File::create(&p.root().join("src/lib.rs")).unwrap();
 
-    assert_that(p.cargo("build").arg("-v"),
+    assert_that!(p.cargo("build").arg("-v"),
                 execs().with_status(0));
-    assert_that(p.cargo("test").arg("-v"),
+    assert_that!(p.cargo("test").arg("-v"),
                 execs().with_status(101));
 }
 
@@ -511,9 +512,9 @@ fn no_rebuild_transitive_target_deps() {
         .file("c/src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0));
-    assert_that(p.cargo("test").arg("--no-run"),
+    assert_that!(p.cargo("test").arg("--no-run"),
                 execs().with_status(0)
                        .with_stderr("\
 [COMPILING] c v0.0.1 ([..])
@@ -551,9 +552,9 @@ fn rerun_if_changed_in_dep() {
         .file("a/src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0));
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0).with_stdout(""));
 }
 
@@ -609,7 +610,7 @@ fn same_build_dir_cached_packages() {
         "#)
         .build();
 
-    assert_that(p.cargo("build").cwd(p.root().join("a1")),
+    assert_that!(p.cargo("build").cwd(p.root().join("a1")),
                 execs().with_status(0).with_stderr(&format!("\
 [COMPILING] d v0.0.1 ({dir}/d)
 [COMPILING] c v0.0.1 ({dir}/c)
@@ -617,7 +618,7 @@ fn same_build_dir_cached_packages() {
 [COMPILING] a1 v0.0.1 ({dir}/a1)
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ", dir = p.url())));
-    assert_that(p.cargo("build").cwd(p.root().join("a2")),
+    assert_that!(p.cargo("build").cwd(p.root().join("a2")),
                 execs().with_status(0).with_stderr(&format!("\
 [COMPILING] a2 v0.0.1 ({dir}/a2)
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
@@ -646,12 +647,12 @@ fn no_rebuild_if_build_artifacts_move_backwards_in_time() {
         .file("a/src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0));
 
     p.root().move_into_the_past();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0).with_stdout("").with_stderr("\
 [FINISHED] [..]
 "));
@@ -679,12 +680,12 @@ fn rebuild_if_build_artifacts_move_forward_in_time() {
         .file("a/src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0));
 
     p.root().move_into_the_future();
 
-    assert_that(p.cargo("build").env("RUST_LOG", ""),
+    assert_that!(p.cargo("build").env("RUST_LOG", ""),
                 execs().with_status(0).with_stdout("").with_stderr("\
 [COMPILING] a v0.0.1 ([..])
 [COMPILING] forwards_in_time v0.0.1 ([..])
@@ -709,7 +710,7 @@ fn rebuild_if_environment_changes() {
         "#)
         .build();
 
-    assert_that(p.cargo("run"),
+    assert_that!(p.cargo("run"),
                 execs().with_status(0)
                 .with_stdout("old desc").with_stderr(&format!("\
 [COMPILING] env_change v0.0.1 ({dir})
@@ -725,7 +726,7 @@ fn rebuild_if_environment_changes() {
         authors = []
     "#).unwrap();
 
-    assert_that(p.cargo("run"),
+    assert_that!(p.cargo("run"),
                 execs().with_status(0)
                 .with_stdout("new desc").with_stderr(&format!("\
 [COMPILING] env_change v0.0.1 ({dir})
@@ -756,13 +757,13 @@ fn no_rebuild_when_rename_dir() {
         .file("foo/src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("build"), execs().with_status(0));
+    assert_that!(p.cargo("build"), execs().with_status(0));
     let mut new = p.root();
     new.pop();
     new.push("bar");
     fs::rename(p.root(), &new).unwrap();
 
-    assert_that(p.cargo("build").cwd(&new),
+    assert_that!(p.cargo("build").cwd(&new),
                 execs().with_status(0)
                 .with_stderr("\
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]

--- a/tests/generate-lockfile.rs
+++ b/tests/generate-lockfile.rs
@@ -1,11 +1,12 @@
 extern crate cargotest;
+#[macro_use]
 extern crate hamcrest;
 
 use std::fs::{self, File};
 use std::io::prelude::*;
 
 use cargotest::support::{project, execs};
-use hamcrest::{assert_that, existing_file, is_not};
+use hamcrest::prelude::*;
 
 #[test]
 fn adding_and_removing_packages() {
@@ -26,7 +27,7 @@ fn adding_and_removing_packages() {
         .file("bar/src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("generate-lockfile"),
+    assert_that!(p.cargo("generate-lockfile"),
                 execs().with_status(0));
 
     let toml = p.root().join("Cargo.toml");
@@ -42,7 +43,7 @@ fn adding_and_removing_packages() {
         [dependencies.bar]
         path = "bar"
     "#).unwrap();
-    assert_that(p.cargo("generate-lockfile"),
+    assert_that!(p.cargo("generate-lockfile"),
                 execs().with_status(0));
     let lock2 = p.read_lockfile();
     assert!(lock1 != lock2);
@@ -54,7 +55,7 @@ fn adding_and_removing_packages() {
         authors = []
         version = "0.0.2"
     "#).unwrap();
-    assert_that(p.cargo("generate-lockfile"),
+    assert_that!(p.cargo("generate-lockfile"),
                 execs().with_status(0));
     let lock3 = p.read_lockfile();
     assert!(lock1 != lock3);
@@ -68,7 +69,7 @@ fn adding_and_removing_packages() {
         authors = []
         version = "0.0.1"
     "#).unwrap();
-    assert_that(p.cargo("generate-lockfile"),
+    assert_that!(p.cargo("generate-lockfile"),
                 execs().with_status(0));
     let lock4 = p.read_lockfile();
     assert_eq!(lock1, lock4);
@@ -93,7 +94,7 @@ fn preserve_metadata() {
         .file("bar/src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("generate-lockfile"),
+    assert_that!(p.cargo("generate-lockfile"),
                 execs().with_status(0));
 
     let metadata = r#"
@@ -107,13 +108,13 @@ foo = "bar"
     File::create(&lockfile).unwrap().write_all(data.as_bytes()).unwrap();
 
     // Build and make sure the metadata is still there
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0));
     let lock = p.read_lockfile();
     assert!(lock.contains(metadata.trim()), "{}", lock);
 
     // Update and make sure the metadata is still there
-    assert_that(p.cargo("update"),
+    assert_that!(p.cargo("update"),
                 execs().with_status(0));
     let lock = p.read_lockfile();
     assert!(lock.contains(metadata.trim()), "{}", lock);
@@ -139,11 +140,11 @@ fn preserve_line_endings_issue_2076() {
         .build();
 
     let lockfile = p.root().join("Cargo.lock");
-    assert_that(p.cargo("generate-lockfile"),
+    assert_that!(p.cargo("generate-lockfile"),
                 execs().with_status(0));
-    assert_that(&lockfile,
+    assert_that!(&lockfile,
                 existing_file());
-    assert_that(p.cargo("generate-lockfile"),
+    assert_that!(p.cargo("generate-lockfile"),
                 execs().with_status(0));
 
     let lock0 = p.read_lockfile();
@@ -155,7 +156,7 @@ fn preserve_line_endings_issue_2076() {
         File::create(&lockfile).unwrap().write_all(lock1.as_bytes()).unwrap();
     }
 
-    assert_that(p.cargo("generate-lockfile"),
+    assert_that!(p.cargo("generate-lockfile"),
                 execs().with_status(0));
 
     let lock2 = p.read_lockfile();
@@ -177,14 +178,14 @@ fn cargo_update_generate_lockfile() {
         .build();
 
     let lockfile = p.root().join("Cargo.lock");
-    assert_that(&lockfile, is_not(existing_file()));
-    assert_that(p.cargo("update"), execs().with_status(0).with_stdout(""));
-    assert_that(&lockfile, existing_file());
+    assert_that!(&lockfile, is_not(existing_file()));
+    assert_that!(p.cargo("update"), execs().with_status(0).with_stdout(""));
+    assert_that!(&lockfile, existing_file());
 
     fs::remove_file(p.root().join("Cargo.lock")).unwrap();
 
-    assert_that(&lockfile, is_not(existing_file()));
-    assert_that(p.cargo("update"), execs().with_status(0).with_stdout(""));
-    assert_that(&lockfile, existing_file());
+    assert_that!(&lockfile, is_not(existing_file()));
+    assert_that!(p.cargo("update"), execs().with_status(0).with_stdout(""));
+    assert_that!(&lockfile, existing_file());
 
 }

--- a/tests/git.rs
+++ b/tests/git.rs
@@ -1,6 +1,7 @@
 extern crate cargo;
 extern crate cargotest;
 extern crate git2;
+#[macro_use]
 extern crate hamcrest;
 
 use std::fs::{self, File};
@@ -15,7 +16,7 @@ use cargo::util::process;
 use cargotest::sleep_ms;
 use cargotest::support::paths::{self, CargoPathExt};
 use cargotest::support::{git, project, execs, main_file, path2url};
-use hamcrest::{assert_that,existing_file};
+use hamcrest::prelude::*;
 
 #[test]
 fn cargo_compile_simple_git_dep() {
@@ -58,7 +59,7 @@ fn cargo_compile_simple_git_dep() {
     let root = project.root();
     let git_root = git_project.root();
 
-    assert_that(project.cargo("build"),
+    assert_that!(project.cargo("build"),
         execs()
         .with_stderr(&format!("[UPDATING] git repository `{}`\n\
                               [COMPILING] dep1 v0.5.0 ({}#[..])\n\
@@ -68,9 +69,9 @@ fn cargo_compile_simple_git_dep() {
                              path2url(git_root),
                              path2url(root))));
 
-    assert_that(&project.bin("foo"), existing_file());
+    assert_that!(&project.bin("foo"), existing_file());
 
-    assert_that(
+    assert_that!(
       process(&project.bin("foo")),
       execs().with_stdout("hello world\n"));
 }
@@ -124,7 +125,7 @@ fn cargo_compile_git_dep_branch() {
     let root = project.root();
     let git_root = git_project.root();
 
-    assert_that(project.cargo("build"),
+    assert_that!(project.cargo("build"),
         execs()
         .with_stderr(&format!("[UPDATING] git repository `{}`\n\
                               [COMPILING] dep1 v0.5.0 ({}?branch=branchy#[..])\n\
@@ -134,9 +135,9 @@ fn cargo_compile_git_dep_branch() {
                              path2url(git_root),
                              path2url(root))));
 
-    assert_that(&project.bin("foo"), existing_file());
+    assert_that!(&project.bin("foo"), existing_file());
 
-    assert_that(
+    assert_that!(
       process(&project.bin("foo")),
       execs().with_stdout("hello world\n"));
 }
@@ -192,7 +193,7 @@ fn cargo_compile_git_dep_tag() {
     let root = project.root();
     let git_root = git_project.root();
 
-    assert_that(project.cargo("build"),
+    assert_that!(project.cargo("build"),
         execs()
         .with_stderr(&format!("[UPDATING] git repository `{}`\n\
                               [COMPILING] dep1 v0.5.0 ({}?tag=v0.1.0#[..])\n\
@@ -202,12 +203,12 @@ fn cargo_compile_git_dep_tag() {
                              path2url(git_root),
                              path2url(root))));
 
-    assert_that(&project.bin("foo"), existing_file());
+    assert_that!(&project.bin("foo"), existing_file());
 
-    assert_that(process(&project.bin("foo")),
+    assert_that!(process(&project.bin("foo")),
                 execs().with_stdout("hello world\n"));
 
-    assert_that(project.cargo("build"),
+    assert_that!(project.cargo("build"),
                 execs().with_status(0));
 }
 
@@ -281,9 +282,9 @@ fn cargo_compile_with_nested_paths() {
         .exec_with_output()
         .unwrap();
 
-    assert_that(&p.bin("parent"), existing_file());
+    assert_that!(&p.bin("parent"), existing_file());
 
-    assert_that(process(&p.bin("parent")),
+    assert_that!(process(&p.bin("parent")),
                 execs().with_stdout("hello world\n"));
 }
 
@@ -337,9 +338,9 @@ fn cargo_compile_with_malformed_nested_paths() {
         .exec_with_output()
         .unwrap();
 
-    assert_that(&p.bin("parent"), existing_file());
+    assert_that!(&p.bin("parent"), existing_file());
 
-    assert_that(process(&p.bin("parent")),
+    assert_that!(process(&p.bin("parent")),
                 execs().with_stdout("hello world\n"));
 }
 
@@ -411,9 +412,9 @@ fn cargo_compile_with_meta_package() {
         .exec_with_output()
         .unwrap();
 
-    assert_that(&p.bin("parent"), existing_file());
+    assert_that!(&p.bin("parent"), existing_file());
 
-    assert_that(process(&p.bin("parent")),
+    assert_that!(process(&p.bin("parent")),
                 execs().with_stdout("this is dep1 this is dep2\n"));
 }
 
@@ -440,7 +441,7 @@ fn cargo_compile_with_short_ssh_git() {
         .file("src/foo.rs", &main_file(r#""{}", dep1::hello()"#, &["dep1"]))
         .build();
 
-    assert_that(project.cargo("build"),
+    assert_that!(project.cargo("build"),
         execs()
         .with_stdout("")
         .with_stderr(&format!("\
@@ -515,10 +516,10 @@ fn two_revs_same_deps() {
         "#)
         .build();
 
-    assert_that(foo.cargo("build").arg("-v"),
+    assert_that!(foo.cargo("build").arg("-v"),
                 execs().with_status(0));
-    assert_that(&foo.bin("foo"), existing_file());
-    assert_that(foo.process(&foo.bin("foo")), execs().with_status(0));
+    assert_that!(&foo.bin("foo"), existing_file());
+    assert_that!(foo.process(&foo.bin("foo")), execs().with_status(0));
 }
 
 #[test]
@@ -558,7 +559,7 @@ fn recompilation() {
         .build();
 
     // First time around we should compile both foo and bar
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_stderr(&format!("[UPDATING] git repository `{}`\n\
                                              [COMPILING] bar v0.5.0 ({}#[..])\n\
                                              [COMPILING] foo v0.5.0 ({})\n\
@@ -569,7 +570,7 @@ fn recompilation() {
                                             p.url())));
 
     // Don't recompile the second time
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_stdout(""));
 
     // Modify a file manually, shouldn't trigger a recompile
@@ -577,14 +578,14 @@ fn recompilation() {
         pub fn bar() { println!("hello!"); }
     "#).unwrap();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_stdout(""));
 
-    assert_that(p.cargo("update"),
+    assert_that!(p.cargo("update"),
                 execs().with_stderr(&format!("[UPDATING] git repository `{}`",
                                             git_project.url())));
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_stdout(""));
 
     // Commit the changes and make sure we don't trigger a recompile because the
@@ -594,18 +595,18 @@ fn recompilation() {
     git::commit(&repo);
 
     println!("compile after commit");
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_stdout(""));
     p.root().move_into_the_past();
 
     // Update the dependency and carry on!
-    assert_that(p.cargo("update"),
+    assert_that!(p.cargo("update"),
                 execs().with_stderr(&format!("[UPDATING] git repository `{}`\n\
                                               [UPDATING] bar v0.5.0 ([..]) -> #[..]\n\
                                              ",
                                             git_project.url())));
     println!("going for the last compile");
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_stderr(&format!("[COMPILING] bar v0.5.0 ({}#[..])\n\
                                              [COMPILING] foo v0.5.0 ({})\n\
                                              [FINISHED] dev [unoptimized + debuginfo] target(s) \
@@ -614,10 +615,10 @@ fn recompilation() {
                                             p.url())));
 
     // Make sure clean only cleans one dep
-    assert_that(p.cargo("clean")
+    assert_that!(p.cargo("clean")
                  .arg("-p").arg("foo"),
                 execs().with_stdout(""));
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_stderr(&format!("[COMPILING] foo v0.5.0 ({})\n\
                                               [FINISHED] dev [unoptimized + debuginfo] target(s) \
                                               in [..]\n",
@@ -687,7 +688,7 @@ fn update_with_shared_deps() {
         .build();
 
     // First time around we should compile both foo and bar
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_stderr(&format!("\
 [UPDATING] git repository `{git}`
 [COMPILING] bar v0.5.0 ({git}#[..])
@@ -710,13 +711,13 @@ git = git_project.url(), dir = p.url())));
 
     // By default, not transitive updates
     println!("dep1 update");
-    assert_that(p.cargo("update")
+    assert_that!(p.cargo("update")
                  .arg("-p").arg("dep1"),
                 execs().with_stdout(""));
 
     // Don't do anything bad on a weird --precise argument
     println!("bar bad precise update");
-    assert_that(p.cargo("update")
+    assert_that!(p.cargo("update")
                  .arg("-p").arg("bar")
                  .arg("--precise").arg("0.1.2"),
                 execs().with_status(101).with_stderr("\
@@ -729,14 +730,14 @@ To learn more, run the command again with --verbose.
     // Specifying a precise rev to the old rev shouldn't actually update
     // anything because we already have the rev in the db.
     println!("bar precise update");
-    assert_that(p.cargo("update")
+    assert_that!(p.cargo("update")
                  .arg("-p").arg("bar")
                  .arg("--precise").arg(&old_head.to_string()),
                 execs().with_stdout(""));
 
     // Updating aggressively should, however, update the repo.
     println!("dep1 aggressive update");
-    assert_that(p.cargo("update")
+    assert_that!(p.cargo("update")
                  .arg("-p").arg("dep1")
                  .arg("--aggressive"),
                 execs().with_stderr(&format!("[UPDATING] git repository `{}`\n\
@@ -745,7 +746,7 @@ To learn more, run the command again with --verbose.
 
     // Make sure we still only compile one version of the git repo
     println!("build");
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_stderr(&format!("\
 [COMPILING] bar v0.5.0 ({git}#[..])
 [COMPILING] [..] v0.5.0 ({dir}[..]dep[..])
@@ -755,7 +756,7 @@ To learn more, run the command again with --verbose.
                     git = git_project.url(), dir = p.url())));
 
     // We should be able to update transitive deps
-    assert_that(p.cargo("update").arg("-p").arg("bar"),
+    assert_that!(p.cargo("update").arg("-p").arg("bar"),
                 execs().with_stderr(&format!("[UPDATING] git repository `{}`",
                                             git_project.url())));
 }
@@ -799,7 +800,7 @@ fn dep_with_submodule() {
         ")
         .build();
 
-    assert_that(project.cargo("build"),
+    assert_that!(project.cargo("build"),
                 execs().with_stderr("\
 [UPDATING] git repository [..]
 [COMPILING] dep1 [..]
@@ -873,7 +874,7 @@ Caused by:
   object not found - no match for id [..]
 ", path2url(git_project.root()));
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_stderr(expected).with_status(101));
 }
 
@@ -917,7 +918,7 @@ fn two_deps_only_update_one() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
         execs()
         .with_stderr(&format!("[UPDATING] git repository `[..]`\n\
                               [UPDATING] git repository `[..]`\n\
@@ -934,7 +935,7 @@ fn two_deps_only_update_one() {
     git::add(&repo);
     git::commit(&repo);
 
-    assert_that(p.cargo("update")
+    assert_that!(p.cargo("update")
                        .arg("-p").arg("dep1"),
         execs()
         .with_stderr(&format!("[UPDATING] git repository `{}`\n\
@@ -973,8 +974,8 @@ fn stale_cached_version() {
         "#)
         .build();
 
-    assert_that(foo.cargo("build"), execs().with_status(0));
-    assert_that(foo.process(&foo.bin("foo")), execs().with_status(0));
+    assert_that!(foo.cargo("build"), execs().with_status(0));
+    assert_that!(foo.process(&foo.bin("foo")), execs().with_status(0));
 
     // Update the repo, and simulate someone else updating the lockfile and then
     // us pulling it down.
@@ -1004,7 +1005,7 @@ fn stale_cached_version() {
     "#, url = bar.url(), hash = rev).as_bytes()).unwrap();
 
     // Now build!
-    assert_that(foo.cargo("build"),
+    assert_that!(foo.cargo("build"),
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [UPDATING] git repository `{bar}`
@@ -1012,7 +1013,7 @@ fn stale_cached_version() {
 [COMPILING] foo v0.0.0 ({foo})
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ", bar = bar.url(), foo = foo.url())));
-    assert_that(foo.process(&foo.bin("foo")), execs().with_status(0));
+    assert_that!(foo.process(&foo.bin("foo")), execs().with_status(0));
 }
 
 #[test]
@@ -1059,7 +1060,7 @@ fn dep_with_changed_submodule() {
         .build();
 
     println!("first run");
-    assert_that(p.cargo("run"), execs()
+    assert_that!(p.cargo("run"), execs()
                 .with_stderr("[UPDATING] git repository `[..]`\n\
                                       [COMPILING] dep1 v0.5.0 ([..])\n\
                                       [COMPILING] foo v0.5.0 ([..])\n\
@@ -1094,7 +1095,7 @@ fn dep_with_changed_submodule() {
     sleep_ms(1000);
     // Update the dependency and carry on!
     println!("update");
-    assert_that(p.cargo("update").arg("-v"),
+    assert_that!(p.cargo("update").arg("-v"),
                 execs()
                 .with_stderr("")
                 .with_stderr(&format!("[UPDATING] git repository `{}`\n\
@@ -1102,7 +1103,7 @@ fn dep_with_changed_submodule() {
                                       ", git_project.url())));
 
     println!("last run");
-    assert_that(p.cargo("run"), execs()
+    assert_that!(p.cargo("run"), execs()
                 .with_stderr("[COMPILING] dep1 v0.5.0 ([..])\n\
                                       [COMPILING] foo v0.5.0 ([..])\n\
                                       [FINISHED] dev [unoptimized + debuginfo] target(s) in \
@@ -1151,7 +1152,7 @@ fn dev_deps_with_testing() {
 
     // Generate a lockfile which did not use `bar` to compile, but had to update
     // `bar` to generate the lockfile
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
         execs().with_stderr(&format!("\
 [UPDATING] git repository `{bar}`
 [COMPILING] foo v0.5.0 ({url})
@@ -1160,7 +1161,7 @@ fn dev_deps_with_testing() {
 
     // Make sure we use the previous resolution of `bar` instead of updating it
     // a second time.
-    assert_that(p.cargo("test"),
+    assert_that!(p.cargo("test"),
                 execs().with_stderr("\
 [COMPILING] [..] v0.5.0 ([..])
 [COMPILING] [..] v0.5.0 ([..]
@@ -1189,7 +1190,7 @@ fn git_build_cmd_freshness() {
 
     sleep_ms(1000);
 
-    assert_that(foo.cargo("build"),
+    assert_that!(foo.cargo("build"),
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] foo v0.0.0 ({url})
@@ -1198,14 +1199,14 @@ fn git_build_cmd_freshness() {
 
     // Smoke test to make sure it doesn't compile again
     println!("first pass");
-    assert_that(foo.cargo("build"),
+    assert_that!(foo.cargo("build"),
                 execs().with_status(0)
                        .with_stdout(""));
 
     // Modify an ignored file and make sure we don't rebuild
     println!("second pass");
     File::create(&foo.root().join("src/bar.rs")).unwrap();
-    assert_that(foo.cargo("build"),
+    assert_that!(foo.cargo("build"),
                 execs().with_status(0)
                        .with_stdout(""));
 }
@@ -1244,7 +1245,7 @@ fn git_name_not_always_needed() {
 
     // Generate a lockfile which did not use `bar` to compile, but had to update
     // `bar` to generate the lockfile
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
         execs().with_stderr(&format!("\
 [UPDATING] git repository `{bar}`
 [COMPILING] foo v0.5.0 ({url})
@@ -1279,7 +1280,7 @@ fn git_repo_changing_no_rebuild() {
         .file("build.rs", "fn main() {}")
         .build();
     p1.root().move_into_the_past();
-    assert_that(p1.cargo("build"),
+    assert_that!(p1.cargo("build"),
                 execs().with_stderr(&format!("\
 [UPDATING] git repository `{bar}`
 [COMPILING] [..]
@@ -1307,7 +1308,7 @@ fn git_repo_changing_no_rebuild() {
         "#, bar.url()))
         .file("src/main.rs", "fn main() {}")
         .build();
-    assert_that(p2.cargo("build"),
+    assert_that!(p2.cargo("build"),
                 execs().with_stderr(&format!("\
 [UPDATING] git repository `{bar}`
 [COMPILING] [..]
@@ -1317,7 +1318,7 @@ fn git_repo_changing_no_rebuild() {
 
     // And now for the real test! Make sure that p1 doesn't get rebuilt
     // even though the git repo has changed.
-    assert_that(p1.cargo("build"),
+    assert_that!(p1.cargo("build"),
                 execs().with_stdout(""));
 }
 
@@ -1367,20 +1368,20 @@ fn git_dep_build_cmd() {
 
     p.root().join("bar").move_into_the_past();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0));
 
-    assert_that(process(&p.bin("foo")),
+    assert_that!(process(&p.bin("foo")),
                 execs().with_stdout("0\n"));
 
     // Touching bar.rs.in should cause the `build` command to run again.
     fs::File::create(&p.root().join("bar/src/bar.rs.in")).unwrap()
              .write_all(b"pub fn gimme() -> i32 { 1 }").unwrap();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0));
 
-    assert_that(process(&p.bin("foo")),
+    assert_that!(process(&p.bin("foo")),
                 execs().with_stdout("1\n"));
 }
 
@@ -1407,12 +1408,12 @@ fn fetch_downloads() {
         "#, bar.url()))
         .file("src/main.rs", "fn main() {}")
         .build();
-    assert_that(p.cargo("fetch"),
+    assert_that!(p.cargo("fetch"),
                 execs().with_status(0).with_stderr(&format!("\
 [UPDATING] git repository `{url}`
 ", url = bar.url())));
 
-    assert_that(p.cargo("fetch"),
+    assert_that!(p.cargo("fetch"),
                 execs().with_status(0).with_stdout(""));
 }
 
@@ -1440,7 +1441,7 @@ fn warnings_in_git_dep() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
         execs()
         .with_stderr(&format!("[UPDATING] git repository `{}`\n\
                               [COMPILING] bar v0.5.0 ({}#[..])\n\
@@ -1498,8 +1499,8 @@ fn update_ambiguous() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    assert_that(p.cargo("generate-lockfile"), execs().with_status(0));
-    assert_that(p.cargo("update")
+    assert_that!(p.cargo("generate-lockfile"), execs().with_status(0));
+    assert_that!(p.cargo("update")
                  .arg("-p").arg("foo"),
                 execs().with_status(101)
                        .with_stderr("\
@@ -1545,8 +1546,8 @@ fn update_one_dep_in_repo_with_many_deps() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    assert_that(p.cargo("generate-lockfile"), execs().with_status(0));
-    assert_that(p.cargo("update")
+    assert_that!(p.cargo("generate-lockfile"), execs().with_status(0));
+    assert_that!(p.cargo("update")
                  .arg("-p").arg("foo"),
                 execs().with_status(0)
                        .with_stderr(&format!("\
@@ -1602,7 +1603,7 @@ fn switch_deps_does_not_update_transitive() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [UPDATING] git repository `{}`
@@ -1624,7 +1625,7 @@ fn switch_deps_does_not_update_transitive() {
             git = '{}'
     "#, dep2.url()).as_bytes()).unwrap();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [UPDATING] git repository `{}`
@@ -1668,7 +1669,7 @@ fn update_one_source_updates_all_packages_in_that_git_source() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0));
 
     let repo = git2::Repository::open(&dep.root()).unwrap();
@@ -1681,7 +1682,7 @@ fn update_one_source_updates_all_packages_in_that_git_source() {
     git::add(&repo);
     git::commit(&repo);
 
-    assert_that(p.cargo("update").arg("-p").arg("dep"),
+    assert_that!(p.cargo("update").arg("-p").arg("dep"),
                 execs().with_status(0));
     let mut lockfile = String::new();
     File::open(&p.root().join("Cargo.lock")).unwrap()
@@ -1732,7 +1733,7 @@ fn switch_sources() {
         .file("b/src/lib.rs", "pub fn main() {}")
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0)
                        .with_stderr("\
 [UPDATING] git repository `file://[..]a1`
@@ -1751,7 +1752,7 @@ fn switch_sources() {
         git = '{}'
     "#, a2.url()).as_bytes()).unwrap();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0)
                        .with_stderr("\
 [UPDATING] git repository `file://[..]a2`
@@ -1789,7 +1790,7 @@ fn dont_require_submodules_are_checked_out() {
     let dst = paths::home().join("foo");
     git2::Repository::clone(&url, &dst).unwrap();
 
-    assert_that(git1.cargo("build").arg("-v").cwd(&dst),
+    assert_that!(git1.cargo("build").arg("-v").cwd(&dst),
                 execs().with_status(0));
 }
 
@@ -1833,7 +1834,7 @@ fn doctest_same_name() {
         "#)
         .build();
 
-    assert_that(p.cargo("test").arg("-v"),
+    assert_that!(p.cargo("test").arg("-v"),
                 execs().with_status(0));
 }
 
@@ -1864,7 +1865,7 @@ fn lints_are_suppressed() {
         .file("src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0).with_stderr("\
 [UPDATING] git repository `[..]`
 [COMPILING] a v0.5.0 ([..])
@@ -1901,7 +1902,7 @@ fn denied_lints_are_allowed() {
         .file("src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0).with_stderr("\
 [UPDATING] git repository `[..]`
 [COMPILING] a v0.5.0 ([..])
@@ -1943,7 +1944,7 @@ fn add_a_git_dep() {
         .file("a/src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("build"), execs().with_status(0));
+    assert_that!(p.cargo("build"), execs().with_status(0));
 
     File::create(p.root().join("a/Cargo.toml")).unwrap().write_all(format!(r#"
         [package]
@@ -1955,7 +1956,7 @@ fn add_a_git_dep() {
         git = {{ git = '{}' }}
     "#, git.url()).as_bytes()).unwrap();
 
-    assert_that(p.cargo("build"), execs().with_status(0));
+    assert_that!(p.cargo("build"), execs().with_status(0));
 }
 
 #[test]
@@ -2000,8 +2001,8 @@ fn two_at_rev_instead_of_tag() {
         .file("src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("generate-lockfile"), execs().with_status(0));
-    assert_that(p.cargo("build").arg("-v"), execs().with_status(0));
+    assert_that!(p.cargo("generate-lockfile"), execs().with_status(0));
+    assert_that!(p.cargo("build").arg("-v"), execs().with_status(0));
 }
 
 #[test]
@@ -2058,7 +2059,7 @@ fn include_overrides_gitignore() {
     }).unwrap();
 
     println!("build 1: all is new");
-    assert_that(p.cargo("build").arg("-v"),
+    assert_that!(p.cargo("build").arg("-v"),
                 execs().with_status(0)
                        .with_stderr("\
 [UPDATING] registry `[..]`
@@ -2076,7 +2077,7 @@ fn include_overrides_gitignore() {
 "));
 
     println!("build 2: nothing changed; file timestamps reset by build script");
-    assert_that(p.cargo("build").arg("-v"),
+    assert_that!(p.cargo("build").arg("-v"),
                 execs().with_status(0)
                        .with_stderr("\
 [FRESH] libc [..]
@@ -2089,7 +2090,7 @@ fn include_overrides_gitignore() {
     sleep_ms(1000);
     File::create(p.root().join("src").join("not_incl.rs")).unwrap();
 
-    assert_that(p.cargo("build").arg("-v"),
+    assert_that!(p.cargo("build").arg("-v"),
                 execs().with_status(0)
                        .with_stderr("\
 [FRESH] libc [..]
@@ -2106,7 +2107,7 @@ fn include_overrides_gitignore() {
     sleep_ms(1000);
     File::create(p.root().join("src").join("incl.rs")).unwrap();
 
-    assert_that(p.cargo("build").arg("-v"),
+    assert_that!(p.cargo("build").arg("-v"),
                 execs().with_status(0)
                        .with_stderr("\
 [FRESH] libc [..]
@@ -2160,7 +2161,7 @@ fn invalid_git_dependency_manifest() {
 
     let git_root = git_project.root();
 
-    assert_that(project.cargo("build"),
+    assert_that!(project.cargo("build"),
         execs()
         .with_stderr(&format!("[UPDATING] git repository `{}`\n\
                               error: failed to load source for a dependency on `dep1`\n\
@@ -2244,11 +2245,11 @@ fn failed_submodule_checkout() {
         .file("src/lib.rs", "")
         .build();
 
-    assert_that(project.cargo("build"),
+    assert_that!(project.cargo("build"),
                 execs().with_status(101)
                        .with_stderr_contains("  failed to update submodule `src`")
                        .with_stderr_contains("  failed to update submodule `bar`"));
-    assert_that(project.cargo("build"),
+    assert_that!(project.cargo("build"),
                 execs().with_status(101)
                        .with_stderr_contains("  failed to update submodule `src`")
                        .with_stderr_contains("  failed to update submodule `bar`"));

--- a/tests/init.rs
+++ b/tests/init.rs
@@ -1,6 +1,7 @@
 extern crate cargotest;
 extern crate cargo;
 extern crate tempdir;
+#[macro_use]
 extern crate hamcrest;
 
 use std::fs::{self, File};
@@ -9,7 +10,7 @@ use std::env;
 
 use cargo::util::ProcessBuilder;
 use cargotest::support::{execs, paths, cargo_exe};
-use hamcrest::{assert_that, existing_file, existing_dir, is_not};
+use hamcrest::prelude::*;
 use tempdir::TempDir;
 
 fn cargo_process(s: &str) -> ProcessBuilder {
@@ -20,17 +21,17 @@ fn cargo_process(s: &str) -> ProcessBuilder {
 
 #[test]
 fn simple_lib() {
-    assert_that(cargo_process("init").arg("--lib").arg("--vcs").arg("none")
+    assert_that!(cargo_process("init").arg("--lib").arg("--vcs").arg("none")
                                     .env("USER", "foo"),
                 execs().with_status(0).with_stderr("\
 [CREATED] library project
 "));
 
-    assert_that(&paths::root().join("Cargo.toml"), existing_file());
-    assert_that(&paths::root().join("src/lib.rs"), existing_file());
-    assert_that(&paths::root().join(".gitignore"), is_not(existing_file()));
+    assert_that!(&paths::root().join("Cargo.toml"), existing_file());
+    assert_that!(&paths::root().join("src/lib.rs"), existing_file());
+    assert_that!(&paths::root().join(".gitignore"), is_not(existing_file()));
 
-    assert_that(cargo_process("build"),
+    assert_that!(cargo_process("build"),
                 execs().with_status(0));
 }
 
@@ -38,18 +39,18 @@ fn simple_lib() {
 fn simple_bin() {
     let path = paths::root().join("foo");
     fs::create_dir(&path).unwrap();
-    assert_that(cargo_process("init").arg("--bin").arg("--vcs").arg("none")
+    assert_that!(cargo_process("init").arg("--bin").arg("--vcs").arg("none")
                                     .env("USER", "foo").cwd(&path),
                 execs().with_status(0).with_stderr("\
 [CREATED] binary (application) project
 "));
 
-    assert_that(&paths::root().join("foo/Cargo.toml"), existing_file());
-    assert_that(&paths::root().join("foo/src/main.rs"), existing_file());
+    assert_that!(&paths::root().join("foo/Cargo.toml"), existing_file());
+    assert_that!(&paths::root().join("foo/src/main.rs"), existing_file());
 
-    assert_that(cargo_process("build").cwd(&path),
+    assert_that!(cargo_process("build").cwd(&path),
                 execs().with_status(0));
-    assert_that(&paths::root().join(&format!("foo/target/debug/foo{}",
+    assert_that!(&paths::root().join(&format!("foo/target/debug/foo{}",
                                              env::consts::EXE_SUFFIX)),
                 existing_file());
 }
@@ -57,7 +58,7 @@ fn simple_bin() {
 #[test]
 fn both_lib_and_bin() {
     let td = TempDir::new("cargo").unwrap();
-    assert_that(cargo_process("init").arg("--lib").arg("--bin").cwd(td.path())
+    assert_that!(cargo_process("init").arg("--lib").arg("--bin").cwd(td.path())
                                     .env("USER", "foo"),
                 execs().with_status(101).with_stderr(
                     "[ERROR] can't specify both lib and binary outputs"));
@@ -78,17 +79,17 @@ fn bin_already_exists(explicit: bool, rellocation: &str) {
     File::create(&sourcefile_path).unwrap().write_all(content).unwrap();
 
     if explicit {
-        assert_that(cargo_process("init").arg("--bin").arg("--vcs").arg("none")
+        assert_that!(cargo_process("init").arg("--bin").arg("--vcs").arg("none")
                                         .env("USER", "foo").cwd(&path),
                     execs().with_status(0));
     } else {
-        assert_that(cargo_process("init").arg("--vcs").arg("none")
+        assert_that!(cargo_process("init").arg("--vcs").arg("none")
                                         .env("USER", "foo").cwd(&path),
                     execs().with_status(0));
     }
 
-    assert_that(&paths::root().join("foo/Cargo.toml"), existing_file());
-    assert_that(&paths::root().join("foo/src/lib.rs"), is_not(existing_file()));
+    assert_that!(&paths::root().join("foo/Cargo.toml"), existing_file());
+    assert_that!(&paths::root().join("foo/src/lib.rs"), is_not(existing_file()));
 
     // Check that our file is not overwritten
     let mut new_content = Vec::new();
@@ -147,13 +148,13 @@ fn confused_by_multiple_lib_files() {
         }
     "#).unwrap();
 
-    assert_that(cargo_process("init").arg("--vcs").arg("none")
+    assert_that!(cargo_process("init").arg("--vcs").arg("none")
                                     .env("USER", "foo").cwd(&path),
                 execs().with_status(101).with_stderr("\
 [ERROR] cannot have a project with multiple libraries, found both `src/lib.rs` and `lib.rs`
 "));
 
-    assert_that(&paths::root().join("foo/Cargo.toml"), is_not(existing_file()));
+    assert_that!(&paths::root().join("foo/Cargo.toml"), is_not(existing_file()));
 }
 
 
@@ -178,7 +179,7 @@ fn multibin_project_name_clash() {
         }
     "#).unwrap();
 
-    assert_that(cargo_process("init").arg("--lib").arg("--vcs").arg("none")
+    assert_that!(cargo_process("init").arg("--lib").arg("--vcs").arg("none")
                                     .env("USER", "foo").cwd(&path),
                 execs().with_status(101).with_stderr("\
 [ERROR] multiple possible binary sources found:
@@ -187,7 +188,7 @@ fn multibin_project_name_clash() {
 cannot automatically generate Cargo.toml as the main target would be ambiguous
 "));
 
-    assert_that(&paths::root().join("foo/Cargo.toml"), is_not(existing_file()));
+    assert_that!(&paths::root().join("foo/Cargo.toml"), is_not(existing_file()));
 }
 
 fn lib_already_exists(rellocation: &str) {
@@ -202,12 +203,12 @@ fn lib_already_exists(rellocation: &str) {
 
     File::create(&sourcefile_path).unwrap().write_all(content).unwrap();
 
-    assert_that(cargo_process("init").arg("--vcs").arg("none")
+    assert_that!(cargo_process("init").arg("--vcs").arg("none")
                                     .env("USER", "foo").cwd(&path),
                 execs().with_status(0));
 
-    assert_that(&paths::root().join("foo/Cargo.toml"), existing_file());
-    assert_that(&paths::root().join("foo/src/main.rs"), is_not(existing_file()));
+    assert_that!(&paths::root().join("foo/Cargo.toml"), existing_file());
+    assert_that!(&paths::root().join("foo/src/main.rs"), is_not(existing_file()));
 
     // Check that our file is not overwritten
     let mut new_content = Vec::new();
@@ -227,16 +228,16 @@ fn lib_already_exists_nosrc() {
 
 #[test]
 fn simple_git() {
-    assert_that(cargo_process("init").arg("--lib")
+    assert_that!(cargo_process("init").arg("--lib")
                                      .arg("--vcs")
                                      .arg("git")
                                      .env("USER", "foo"),
                 execs().with_status(0));
 
-    assert_that(&paths::root().join("Cargo.toml"), existing_file());
-    assert_that(&paths::root().join("src/lib.rs"), existing_file());
-    assert_that(&paths::root().join(".git"), existing_dir());
-    assert_that(&paths::root().join(".gitignore"), existing_file());
+    assert_that!(&paths::root().join("Cargo.toml"), existing_file());
+    assert_that!(&paths::root().join("src/lib.rs"), existing_file());
+    assert_that!(&paths::root().join(".git"), existing_dir());
+    assert_that!(&paths::root().join(".gitignore"), existing_file());
 }
 
 #[test]
@@ -244,58 +245,58 @@ fn auto_git() {
     let td = TempDir::new("cargo").unwrap();
     let foo = &td.path().join("foo");
     fs::create_dir_all(&foo).unwrap();
-    assert_that(cargo_process("init").arg("--lib")
+    assert_that!(cargo_process("init").arg("--lib")
                                      .cwd(foo.clone())
                                      .env("USER", "foo"),
                 execs().with_status(0));
 
-    assert_that(&foo.join("Cargo.toml"), existing_file());
-    assert_that(&foo.join("src/lib.rs"), existing_file());
-    assert_that(&foo.join(".git"), existing_dir());
-    assert_that(&foo.join(".gitignore"), existing_file());
+    assert_that!(&foo.join("Cargo.toml"), existing_file());
+    assert_that!(&foo.join("src/lib.rs"), existing_file());
+    assert_that!(&foo.join(".git"), existing_dir());
+    assert_that!(&foo.join(".gitignore"), existing_file());
 }
 
 #[test]
 fn invalid_dir_name() {
     let foo = &paths::root().join("foo.bar");
     fs::create_dir_all(&foo).unwrap();
-    assert_that(cargo_process("init").cwd(foo.clone())
+    assert_that!(cargo_process("init").cwd(foo.clone())
                                      .env("USER", "foo"),
                 execs().with_status(101).with_stderr("\
 [ERROR] Invalid character `.` in crate name: `foo.bar`
 use --name to override crate name
 "));
 
-    assert_that(&foo.join("Cargo.toml"), is_not(existing_file()));
+    assert_that!(&foo.join("Cargo.toml"), is_not(existing_file()));
 }
 
 #[test]
 fn reserved_name() {
     let test = &paths::root().join("test");
     fs::create_dir_all(&test).unwrap();
-    assert_that(cargo_process("init").cwd(test.clone())
+    assert_that!(cargo_process("init").cwd(test.clone())
                                      .env("USER", "foo"),
                 execs().with_status(101).with_stderr("\
 [ERROR] The name `test` cannot be used as a crate name\n\
 use --name to override crate name
 "));
 
-    assert_that(&test.join("Cargo.toml"), is_not(existing_file()));
+    assert_that!(&test.join("Cargo.toml"), is_not(existing_file()));
 }
 
 #[test]
 fn git_autodetect() {
     fs::create_dir(&paths::root().join(".git")).unwrap();
 
-    assert_that(cargo_process("init").arg("--lib")
+    assert_that!(cargo_process("init").arg("--lib")
                                     .env("USER", "foo"),
                 execs().with_status(0));
 
 
-    assert_that(&paths::root().join("Cargo.toml"), existing_file());
-    assert_that(&paths::root().join("src/lib.rs"), existing_file());
-    assert_that(&paths::root().join(".git"), existing_dir());
-    assert_that(&paths::root().join(".gitignore"), existing_file());
+    assert_that!(&paths::root().join("Cargo.toml"), existing_file());
+    assert_that!(&paths::root().join("src/lib.rs"), existing_file());
+    assert_that!(&paths::root().join(".git"), existing_dir());
+    assert_that!(&paths::root().join(".gitignore"), existing_file());
 }
 
 
@@ -303,15 +304,15 @@ fn git_autodetect() {
 fn mercurial_autodetect() {
     fs::create_dir(&paths::root().join(".hg")).unwrap();
 
-    assert_that(cargo_process("init").arg("--lib")
+    assert_that!(cargo_process("init").arg("--lib")
                                     .env("USER", "foo"),
                 execs().with_status(0));
 
 
-    assert_that(&paths::root().join("Cargo.toml"), existing_file());
-    assert_that(&paths::root().join("src/lib.rs"), existing_file());
-    assert_that(&paths::root().join(".git"), is_not(existing_dir()));
-    assert_that(&paths::root().join(".hgignore"), existing_file());
+    assert_that!(&paths::root().join("Cargo.toml"), existing_file());
+    assert_that!(&paths::root().join("src/lib.rs"), existing_file());
+    assert_that!(&paths::root().join(".git"), is_not(existing_dir()));
+    assert_that!(&paths::root().join(".hgignore"), existing_file());
 }
 
 #[test]
@@ -320,15 +321,15 @@ fn gitignore_appended_not_replaced() {
 
     File::create(&paths::root().join(".gitignore")).unwrap().write_all(b"qqqqqq\n").unwrap();
 
-    assert_that(cargo_process("init").arg("--lib")
+    assert_that!(cargo_process("init").arg("--lib")
                                      .env("USER", "foo"),
                 execs().with_status(0));
 
 
-    assert_that(&paths::root().join("Cargo.toml"), existing_file());
-    assert_that(&paths::root().join("src/lib.rs"), existing_file());
-    assert_that(&paths::root().join(".git"), existing_dir());
-    assert_that(&paths::root().join(".gitignore"), existing_file());
+    assert_that!(&paths::root().join("Cargo.toml"), existing_file());
+    assert_that!(&paths::root().join("src/lib.rs"), existing_file());
+    assert_that!(&paths::root().join(".git"), existing_dir());
+    assert_that!(&paths::root().join(".gitignore"), existing_file());
 
     let mut contents = String::new();
     File::open(&paths::root().join(".gitignore")).unwrap().read_to_string(&mut contents).unwrap();
@@ -341,11 +342,11 @@ fn gitignore_added_newline_if_required() {
 
     File::create(&paths::root().join(".gitignore")).unwrap().write_all(b"first").unwrap();
 
-    assert_that(cargo_process("init").arg("--lib")
+    assert_that!(cargo_process("init").arg("--lib")
                                      .env("USER", "foo"),
                 execs().with_status(0));
 
-    assert_that(&paths::root().join(".gitignore"), existing_file());
+    assert_that!(&paths::root().join(".gitignore"), existing_file());
 
     let mut contents = String::new();
     File::open(&paths::root().join(".gitignore")).unwrap().read_to_string(&mut contents).unwrap();
@@ -358,11 +359,11 @@ fn mercurial_added_newline_if_required() {
 
     File::create(&paths::root().join(".hgignore")).unwrap().write_all(b"first").unwrap();
 
-    assert_that(cargo_process("init").arg("--lib")
+    assert_that!(cargo_process("init").arg("--lib")
                                      .env("USER", "foo"),
                 execs().with_status(0));
 
-    assert_that(&paths::root().join(".hgignore"), existing_file());
+    assert_that!(&paths::root().join(".hgignore"), existing_file());
 
     let mut contents = String::new();
     File::open(&paths::root().join(".hgignore")).unwrap().read_to_string(&mut contents).unwrap();
@@ -373,11 +374,11 @@ fn mercurial_added_newline_if_required() {
 fn cargo_lock_gitignored_if_lib1() {
     fs::create_dir(&paths::root().join(".git")).unwrap();
 
-    assert_that(cargo_process("init").arg("--lib").arg("--vcs").arg("git")
+    assert_that!(cargo_process("init").arg("--lib").arg("--vcs").arg("git")
                                      .env("USER", "foo"),
                 execs().with_status(0));
 
-    assert_that(&paths::root().join(".gitignore"), existing_file());
+    assert_that!(&paths::root().join(".gitignore"), existing_file());
 
     let mut contents = String::new();
     File::open(&paths::root().join(".gitignore")).unwrap().read_to_string(&mut contents).unwrap();
@@ -390,11 +391,11 @@ fn cargo_lock_gitignored_if_lib2() {
 
     File::create(&paths::root().join("lib.rs")).unwrap().write_all(br#""#).unwrap();
 
-    assert_that(cargo_process("init").arg("--vcs").arg("git")
+    assert_that!(cargo_process("init").arg("--vcs").arg("git")
                                      .env("USER", "foo"),
                 execs().with_status(0));
 
-    assert_that(&paths::root().join(".gitignore"), existing_file());
+    assert_that!(&paths::root().join(".gitignore"), existing_file());
 
     let mut contents = String::new();
     File::open(&paths::root().join(".gitignore")).unwrap().read_to_string(&mut contents).unwrap();
@@ -405,12 +406,12 @@ fn cargo_lock_gitignored_if_lib2() {
 fn cargo_lock_not_gitignored_if_bin1() {
     fs::create_dir(&paths::root().join(".git")).unwrap();
 
-    assert_that(cargo_process("init").arg("--vcs").arg("git")
+    assert_that!(cargo_process("init").arg("--vcs").arg("git")
                                      .arg("--bin")
                                      .env("USER", "foo"),
                 execs().with_status(0));
 
-    assert_that(&paths::root().join(".gitignore"), existing_file());
+    assert_that!(&paths::root().join(".gitignore"), existing_file());
 
     let mut contents = String::new();
     File::open(&paths::root().join(".gitignore")).unwrap().read_to_string(&mut contents).unwrap();
@@ -423,11 +424,11 @@ fn cargo_lock_not_gitignored_if_bin2() {
 
     File::create(&paths::root().join("main.rs")).unwrap().write_all(br#""#).unwrap();
 
-    assert_that(cargo_process("init").arg("--vcs").arg("git")
+    assert_that!(cargo_process("init").arg("--vcs").arg("git")
                                      .env("USER", "foo"),
                 execs().with_status(0));
 
-    assert_that(&paths::root().join(".gitignore"), existing_file());
+    assert_that!(&paths::root().join(".gitignore"), existing_file());
 
     let mut contents = String::new();
     File::open(&paths::root().join(".gitignore")).unwrap().read_to_string(&mut contents).unwrap();
@@ -436,16 +437,16 @@ fn cargo_lock_not_gitignored_if_bin2() {
 
 #[test]
 fn with_argument() {
-    assert_that(cargo_process("init").arg("foo").arg("--vcs").arg("none")
+    assert_that!(cargo_process("init").arg("foo").arg("--vcs").arg("none")
                                      .env("USER", "foo"),
                 execs().with_status(0));
-    assert_that(&paths::root().join("foo/Cargo.toml"), existing_file());
+    assert_that!(&paths::root().join("foo/Cargo.toml"), existing_file());
 }
 
 
 #[test]
 fn unknown_flags() {
-    assert_that(cargo_process("init").arg("foo").arg("--flag"),
+    assert_that!(cargo_process("init").arg("foo").arg("--flag"),
                 execs().with_status(1)
                        .with_stderr("\
 [ERROR] Unknown flag: '--flag'
@@ -459,7 +460,7 @@ Usage:
 #[cfg(not(windows))]
 #[test]
 fn no_filename() {
-    assert_that(cargo_process("init").arg("/"),
+    assert_that!(cargo_process("init").arg("/"),
                 execs().with_status(101)
                        .with_stderr("\
 [ERROR] cannot auto-detect project name from path \"/\" ; use --name to override

--- a/tests/jobserver.rs
+++ b/tests/jobserver.rs
@@ -1,4 +1,5 @@
 extern crate cargotest;
+#[macro_use]
 extern crate hamcrest;
 
 use std::net::TcpListener;
@@ -6,7 +7,7 @@ use std::thread;
 use std::process::Command;
 
 use cargotest::support::{project, execs, cargo_exe};
-use hamcrest::assert_that;
+use hamcrest::prelude::*;
 
 #[test]
 fn jobserver_exists() {
@@ -56,7 +57,7 @@ fn jobserver_exists() {
         .file("src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0));
 }
 
@@ -142,7 +143,7 @@ all:
         drop((a2, a3));
     });
 
-    assert_that(p.process(make)
+    assert_that!(p.process(make)
                  .env("CARGO", cargo_exe())
                  .env("ADDR", addr.to_string())
                  .arg("-j2"),
@@ -171,7 +172,7 @@ all:
 ")
         .build();
 
-    assert_that(p.process(make)
+    assert_that!(p.process(make)
                  .env("CARGO", cargo_exe())
                  .arg("-j2"),
                 execs().with_status(0).with_stderr("\

--- a/tests/local-registry.rs
+++ b/tests/local-registry.rs
@@ -1,5 +1,6 @@
 #[macro_use]
 extern crate cargotest;
+#[macro_use]
 extern crate hamcrest;
 
 use std::fs::{self, File};
@@ -8,7 +9,7 @@ use std::io::prelude::*;
 use cargotest::support::paths::{self, CargoPathExt};
 use cargotest::support::registry::Package;
 use cargotest::support::{project, execs};
-use hamcrest::assert_that;
+use hamcrest::prelude::*;
 
 fn setup() {
     let root = paths::root();
@@ -49,7 +50,7 @@ fn simple() {
         "#)
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0).with_stderr(&format!("\
 [UNPACKING] foo v0.0.1 ([..])
 [COMPILING] foo v0.0.1
@@ -57,10 +58,10 @@ fn simple() {
 [FINISHED] [..]
 ",
         dir = p.url())));
-    assert_that(p.cargo("build"), execs().with_status(0).with_stderr("\
+    assert_that!(p.cargo("build"), execs().with_status(0).with_stderr("\
 [FINISHED] [..]
 "));
-    assert_that(p.cargo("test"), execs().with_status(0));
+    assert_that!(p.cargo("test"), execs().with_status(0));
 }
 
 #[test]
@@ -90,7 +91,7 @@ fn multiple_versions() {
         "#)
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0).with_stderr(&format!("\
 [UNPACKING] foo v0.1.0 ([..])
 [COMPILING] foo v0.1.0
@@ -104,7 +105,7 @@ fn multiple_versions() {
             .file("src/lib.rs", "pub fn foo() {}")
             .publish();
 
-    assert_that(p.cargo("update").arg("-v"),
+    assert_that!(p.cargo("update").arg("-v"),
                 execs().with_status(0).with_stderr("\
 [UPDATING] foo v0.1.0 -> v0.2.0
 "));
@@ -143,7 +144,7 @@ fn multiple_names() {
         "#)
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0).with_stderr(&format!("\
 [UNPACKING] [..]
 [UNPACKING] [..]
@@ -189,7 +190,7 @@ fn interdependent() {
         "#)
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0).with_stderr(&format!("\
 [UNPACKING] [..]
 [UNPACKING] [..]
@@ -251,7 +252,7 @@ fn path_dep_rewritten() {
         "#)
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0).with_stderr(&format!("\
 [UNPACKING] [..]
 [UNPACKING] [..]
@@ -287,7 +288,7 @@ fn invalid_dir_bad() {
         "#)
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(101).with_stderr("\
 [ERROR] failed to load source for a dependency on `foo`
 
@@ -327,7 +328,7 @@ fn different_directory_replacing_the_registry_is_bad() {
 
     // Generate a lock file against the crates.io registry
     Package::new("foo", "0.0.1").publish();
-    assert_that(p.cargo("build"), execs().with_status(0));
+    assert_that!(p.cargo("build"), execs().with_status(0));
 
     // Switch back to our directory source, and now that we're replacing
     // crates.io make sure that this fails because we're replacing with a
@@ -339,7 +340,7 @@ fn different_directory_replacing_the_registry_is_bad() {
             .local(true)
             .publish();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(101).with_stderr("\
 [ERROR] checksum for `foo v0.0.1` changed between lock files
 
@@ -389,7 +390,7 @@ fn crates_io_registry_url_is_optional() {
         "#)
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0).with_stderr(&format!("\
 [UNPACKING] foo v0.0.1 ([..])
 [COMPILING] foo v0.0.1
@@ -397,8 +398,8 @@ fn crates_io_registry_url_is_optional() {
 [FINISHED] [..]
 ",
         dir = p.url())));
-    assert_that(p.cargo("build"), execs().with_status(0).with_stderr("\
+    assert_that!(p.cargo("build"), execs().with_status(0).with_stderr("\
 [FINISHED] [..]
 "));
-    assert_that(p.cargo("test"), execs().with_status(0));
+    assert_that!(p.cargo("test"), execs().with_status(0));
 }

--- a/tests/lockfile-compat.rs
+++ b/tests/lockfile-compat.rs
@@ -1,10 +1,11 @@
 extern crate cargotest;
+#[macro_use]
 extern crate hamcrest;
 
 use cargotest::support::git;
 use cargotest::support::registry::Package;
 use cargotest::support::{execs, project, lines_match};
-use hamcrest::assert_that;
+use hamcrest::prelude::*;
 
 #[test]
 fn oldest_lockfile_still_works() {
@@ -65,7 +66,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
         .file("Cargo.lock", old_lockfile)
         .build();
 
-    assert_that(p.cargo(cargo_command),
+    assert_that!(p.cargo(cargo_command),
                 execs().with_status(0));
 
     let lock = p.read_lockfile();
@@ -114,7 +115,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
         .file("Cargo.lock", &old_lockfile)
         .build();
 
-    assert_that(p.cargo("build").arg("--locked"),
+    assert_that!(p.cargo("build").arg("--locked"),
                 execs().with_status(0));
 
     let lock = p.read_lockfile();
@@ -161,7 +162,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
     let p = p.build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0));
 
     let lock = p.read_lockfile();
@@ -216,7 +217,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
     let p = p.build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(101).with_stderr("\
 [UPDATING] registry `[..]`
 error: checksum for `foo v0.1.0` changed between lock files
@@ -268,7 +269,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "#);
     let p = p.build();
 
-    assert_that(p.cargo("fetch"),
+    assert_that!(p.cargo("fetch"),
                 execs().with_status(101).with_stderr("\
 [UPDATING] registry `[..]`
 error: checksum for `foo v0.1.0` was not previously calculated, but a checksum \
@@ -329,7 +330,7 @@ source = "git+{0}"
 
     let p = p.build();
 
-    assert_that(p.cargo("fetch"),
+    assert_that!(p.cargo("fetch"),
                 execs().with_status(101).with_stderr("\
 [UPDATING] git repository `[..]`
 error: checksum for `foo v0.1.0 ([..])` could not be calculated, but a \
@@ -363,7 +364,7 @@ fn current_lockfile_format() {
         .file("src/lib.rs", "");
     let p = p.build();
 
-    assert_that(p.cargo("build"), execs().with_status(0));
+    assert_that!(p.cargo("build"), execs().with_status(0));
 
     let actual = p.read_lockfile();
 
@@ -422,7 +423,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
     let p = p.build();
 
-    assert_that(p.cargo("build"), execs().with_status(0));
+    assert_that!(p.cargo("build"), execs().with_status(0));
 
     let lock = p.read_lockfile();
     assert!(lock.starts_with(lockfile.trim()));
@@ -445,7 +446,7 @@ fn locked_correct_error() {
         .file("src/lib.rs", "");
     let p = p.build();
 
-    assert_that(p.cargo("build").arg("--locked"),
+    assert_that!(p.cargo("build").arg("--locked"),
                 execs().with_status(101).with_stderr("\
 [UPDATING] registry `[..]`
 error: the lock file needs to be updated but --locked was passed to prevent this

--- a/tests/login.rs
+++ b/tests/login.rs
@@ -1,6 +1,7 @@
 #[macro_use]
 extern crate cargotest;
 extern crate cargo;
+#[macro_use]
 extern crate hamcrest;
 extern crate toml;
 
@@ -13,7 +14,7 @@ use cargotest::support::registry::registry;
 use cargotest::install::cargo_home;
 use cargo::util::config::Config;
 use cargo::core::Shell;
-use hamcrest::{assert_that, existing_file, is_not};
+use hamcrest::prelude::*;
 
 const TOKEN: &str = "test-token";
 const ORIGINAL_TOKEN: &str = "api-token";
@@ -43,7 +44,7 @@ fn setup_new_credentials() {
 fn check_token(expected_token: &str, registry: Option<&str>) -> bool {
 
     let credentials = cargo_home().join("credentials");
-    assert_that(&credentials, existing_file());
+    assert_that!(&credentials, existing_file());
 
     let mut contents = String::new();
     File::open(&credentials).unwrap().read_to_string(&mut contents).unwrap();
@@ -83,12 +84,12 @@ fn check_token(expected_token: &str, registry: Option<&str>) -> bool {
 fn login_with_old_credentials() {
     setup_old_credentials();
 
-    assert_that(cargo_process().arg("login")
+    assert_that!(cargo_process().arg("login")
                 .arg("--host").arg(registry().to_string()).arg(TOKEN),
                 execs().with_status(0));
 
     let config = cargo_home().join("config");
-    assert_that(&config, existing_file());
+    assert_that!(&config, existing_file());
 
     let mut contents = String::new();
     File::open(&config).unwrap().read_to_string(&mut contents).unwrap();
@@ -102,12 +103,12 @@ fn login_with_old_credentials() {
 fn login_with_new_credentials() {
     setup_new_credentials();
 
-    assert_that(cargo_process().arg("login")
+    assert_that!(cargo_process().arg("login")
                 .arg("--host").arg(registry().to_string()).arg(TOKEN),
                 execs().with_status(0));
 
     let config = cargo_home().join("config");
-    assert_that(&config, is_not(existing_file()));
+    assert_that!(&config, is_not(existing_file()));
 
     // Ensure that we get the new token for the registry
     assert!(check_token(TOKEN, None));
@@ -121,12 +122,12 @@ fn login_with_old_and_new_credentials() {
 
 #[test]
 fn login_without_credentials() {
-    assert_that(cargo_process().arg("login")
+    assert_that!(cargo_process().arg("login")
                 .arg("--host").arg(registry().to_string()).arg(TOKEN),
                 execs().with_status(0));
 
     let config = cargo_home().join("config");
-    assert_that(&config, is_not(existing_file()));
+    assert_that!(&config, is_not(existing_file()));
 
     // Ensure that we get the new token for the registry
     assert!(check_token(TOKEN, None));
@@ -137,7 +138,7 @@ fn new_credentials_is_used_instead_old() {
     setup_old_credentials();
     setup_new_credentials();
 
-    assert_that(cargo_process().arg("login")
+    assert_that!(cargo_process().arg("login")
                 .arg("--host").arg(registry().to_string()).arg(TOKEN),
                 execs().with_status(0));
 
@@ -154,7 +155,7 @@ fn registry_credentials() {
 
     let reg = "test-reg";
 
-    assert_that(cargo_process().arg("login").masquerade_as_nightly_cargo()
+    assert_that!(cargo_process().arg("login").masquerade_as_nightly_cargo()
                 .arg("--registry").arg(reg).arg(TOKEN).arg("-Zunstable-options"),
                 execs().with_status(0));
 

--- a/tests/metadata.rs
+++ b/tests/metadata.rs
@@ -1,9 +1,10 @@
 extern crate cargotest;
+#[macro_use]
 extern crate hamcrest;
 
-use hamcrest::assert_that;
 use cargotest::support::registry::Package;
 use cargotest::support::{project, execs, basic_bin_manifest, basic_lib_manifest, main_file};
+use hamcrest::prelude::*;
 
 #[test]
 fn cargo_metadata_simple() {
@@ -12,7 +13,7 @@ fn cargo_metadata_simple() {
         .file("Cargo.toml", &basic_bin_manifest("foo"))
         .build();
 
-    assert_that(p.cargo("metadata"), execs().with_json(r#"
+    assert_that!(p.cargo("metadata"), execs().with_json(r#"
     {
         "packages": [
             {
@@ -62,11 +63,11 @@ fn cargo_metadata_warns_on_implicit_version() {
         .file("Cargo.toml", &basic_bin_manifest("foo"))
         .build();
 
-    assert_that(p.cargo("metadata"),
+    assert_that!(p.cargo("metadata"),
                 execs().with_stderr("\
 [WARNING] please specify `--format-version` flag explicitly to avoid compatibility problems"));
 
-    assert_that(p.cargo("metadata").arg("--format-version").arg("1"),
+    assert_that!(p.cargo("metadata").arg("--format-version").arg("1"),
                 execs().with_stderr(""));
 }
 
@@ -84,7 +85,7 @@ crate-type = ["lib", "staticlib"]
             "#)
         .build();
 
-    assert_that(p.cargo("metadata"), execs().with_json(r#"
+    assert_that!(p.cargo("metadata"), execs().with_json(r#"
     {
         "packages": [
             {
@@ -151,7 +152,7 @@ fn cargo_metadata_with_deps_and_version() {
     Package::new("baz", "0.0.1").publish();
     Package::new("bar", "0.0.1").dep("baz", "0.0.1").publish();
 
-    assert_that(p.cargo("metadata")
+    assert_that!(p.cargo("metadata")
                  .arg("-q")
                  .arg("--format-version").arg("1"),
                 execs().with_json(r#"
@@ -294,7 +295,7 @@ name = "ex"
             "#)
         .build();
 
-    assert_that(p.cargo("metadata"), execs().with_json(r#"
+    assert_that!(p.cargo("metadata"), execs().with_json(r#"
     {
         "packages": [
             {
@@ -357,7 +358,7 @@ crate-type = ["rlib", "dylib"]
             "#)
         .build();
 
-    assert_that(p.cargo("metadata"), execs().with_json(r#"
+    assert_that!(p.cargo("metadata"), execs().with_json(r#"
     {
         "packages": [
             {
@@ -417,7 +418,7 @@ fn workspace_metadata() {
         .file("baz/src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("metadata"), execs().with_status(0).with_json(r#"
+    assert_that!(p.cargo("metadata"), execs().with_status(0).with_json(r#"
     {
         "packages": [
             {
@@ -493,7 +494,7 @@ fn workspace_metadata_no_deps() {
         .file("baz/src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("metadata").arg("--no-deps"), execs().with_status(0).with_json(r#"
+    assert_that!(p.cargo("metadata").arg("--no-deps"), execs().with_status(0).with_json(r#"
     {
         "packages": [
             {
@@ -550,7 +551,7 @@ fn cargo_metadata_with_invalid_manifest() {
         .file("Cargo.toml", "")
         .build();
 
-    assert_that(p.cargo("metadata").arg("--format-version").arg("1"),
+    assert_that!(p.cargo("metadata").arg("--format-version").arg("1"),
                 execs().with_status(101).with_stderr("\
 [ERROR] failed to parse manifest at `[..]`
 
@@ -592,7 +593,7 @@ fn cargo_metadata_no_deps_path_to_cargo_toml_relative() {
         .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
         .build();
 
-        assert_that(p.cargo("metadata").arg("--no-deps")
+        assert_that!(p.cargo("metadata").arg("--no-deps")
                      .arg("--manifest-path").arg("foo/Cargo.toml")
                      .cwd(p.root().parent().unwrap()),
                     execs().with_status(0)
@@ -606,7 +607,7 @@ fn cargo_metadata_no_deps_path_to_cargo_toml_absolute() {
         .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
         .build();
 
-    assert_that(p.cargo("metadata").arg("--no-deps")
+    assert_that!(p.cargo("metadata").arg("--no-deps")
                  .arg("--manifest-path").arg(p.root().join("Cargo.toml"))
                  .cwd(p.root().parent().unwrap()),
                 execs().with_status(0)
@@ -620,7 +621,7 @@ fn cargo_metadata_no_deps_path_to_cargo_toml_parent_relative() {
         .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
         .build();
 
-    assert_that(p.cargo("metadata").arg("--no-deps")
+    assert_that!(p.cargo("metadata").arg("--no-deps")
                  .arg("--manifest-path").arg("foo")
                  .cwd(p.root().parent().unwrap()),
                 execs().with_status(101)
@@ -635,7 +636,7 @@ fn cargo_metadata_no_deps_path_to_cargo_toml_parent_absolute() {
         .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
         .build();
 
-    assert_that(p.cargo("metadata").arg("--no-deps")
+    assert_that!(p.cargo("metadata").arg("--no-deps")
                  .arg("--manifest-path").arg(p.root())
                  .cwd(p.root().parent().unwrap()),
                 execs().with_status(101)
@@ -650,7 +651,7 @@ fn cargo_metadata_no_deps_cwd() {
         .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
         .build();
 
-    assert_that(p.cargo("metadata").arg("--no-deps")
+    assert_that!(p.cargo("metadata").arg("--no-deps")
                  .cwd(p.root()),
                 execs().with_status(0)
                        .with_json(MANIFEST_OUTPUT));
@@ -663,7 +664,7 @@ fn cargo_metadata_bad_version() {
         .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
         .build();
 
-    assert_that(p.cargo("metadata").arg("--no-deps")
+    assert_that!(p.cargo("metadata").arg("--no-deps")
                  .arg("--format-version").arg("2")
                  .cwd(p.root()),
                 execs().with_status(101)
@@ -686,7 +687,7 @@ fn multiple_features() {
         .file("src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("metadata")
+    assert_that!(p.cargo("metadata")
                  .arg("--features").arg("a b"),
                 execs().with_status(0));
 }

--- a/tests/net-config.rs
+++ b/tests/net-config.rs
@@ -1,8 +1,9 @@
 extern crate cargotest;
+#[macro_use]
 extern crate hamcrest;
 
 use cargotest::support::{project, execs};
-use hamcrest::assert_that;
+use hamcrest::prelude::*;
 
 #[test]
 fn net_retry_loads_from_config() {
@@ -24,7 +25,7 @@ fn net_retry_loads_from_config() {
          "#)
         .build();
 
-    assert_that(p.cargo("build").arg("-v"),
+    assert_that!(p.cargo("build").arg("-v"),
                 execs().with_status(101)
                 .with_stderr_contains("[WARNING] spurious network error \
 (1 tries remaining): [..]"));
@@ -49,7 +50,7 @@ fn net_retry_git_outputs_warning() {
         .file("src/main.rs", "")
         .build();
 
-    assert_that(p.cargo("build").arg("-v").arg("-j").arg("1"),
+    assert_that!(p.cargo("build").arg("-v").arg("-j").arg("1"),
                 execs().with_status(101)
                 .with_stderr_contains("[WARNING] spurious network error \
 (2 tries remaining): [..]")

--- a/tests/new.rs
+++ b/tests/new.rs
@@ -1,5 +1,6 @@
 extern crate cargo;
 extern crate cargotest;
+#[macro_use]
 extern crate hamcrest;
 extern crate tempdir;
 
@@ -10,7 +11,7 @@ use std::env;
 use cargo::util::ProcessBuilder;
 use cargotest::process;
 use cargotest::support::{execs, paths};
-use hamcrest::{assert_that, existing_file, existing_dir, is_not};
+use hamcrest::prelude::*;
 use tempdir::TempDir;
 
 fn cargo_process(s: &str) -> ProcessBuilder {
@@ -29,16 +30,16 @@ fn create_empty_gitconfig() {
 
 #[test]
 fn simple_lib() {
-    assert_that(cargo_process("new").arg("--lib").arg("foo").arg("--vcs").arg("none")
+    assert_that!(cargo_process("new").arg("--lib").arg("foo").arg("--vcs").arg("none")
                                     .env("USER", "foo"),
                 execs().with_status(0).with_stderr("\
 [CREATED] library `foo` project
 "));
 
-    assert_that(&paths::root().join("foo"), existing_dir());
-    assert_that(&paths::root().join("foo/Cargo.toml"), existing_file());
-    assert_that(&paths::root().join("foo/src/lib.rs"), existing_file());
-    assert_that(&paths::root().join("foo/.gitignore"), is_not(existing_file()));
+    assert_that!(&paths::root().join("foo"), existing_dir());
+    assert_that!(&paths::root().join("foo/Cargo.toml"), existing_file());
+    assert_that!(&paths::root().join("foo/src/lib.rs"), existing_file());
+    assert_that!(&paths::root().join("foo/.gitignore"), is_not(existing_file()));
 
     let lib = paths::root().join("foo/src/lib.rs");
     let mut contents = String::new();
@@ -52,32 +53,32 @@ mod tests {
 }
 "#);
 
-    assert_that(cargo_process("build").cwd(&paths::root().join("foo")),
+    assert_that!(cargo_process("build").cwd(&paths::root().join("foo")),
                 execs().with_status(0));
 }
 
 #[test]
 fn simple_bin() {
-    assert_that(cargo_process("new").arg("--bin").arg("foo")
+    assert_that!(cargo_process("new").arg("--bin").arg("foo")
                                     .env("USER", "foo"),
                 execs().with_status(0).with_stderr("\
 [CREATED] binary (application) `foo` project
 "));
 
-    assert_that(&paths::root().join("foo"), existing_dir());
-    assert_that(&paths::root().join("foo/Cargo.toml"), existing_file());
-    assert_that(&paths::root().join("foo/src/main.rs"), existing_file());
+    assert_that!(&paths::root().join("foo"), existing_dir());
+    assert_that!(&paths::root().join("foo/Cargo.toml"), existing_file());
+    assert_that!(&paths::root().join("foo/src/main.rs"), existing_file());
 
-    assert_that(cargo_process("build").cwd(&paths::root().join("foo")),
+    assert_that!(cargo_process("build").cwd(&paths::root().join("foo")),
                 execs().with_status(0));
-    assert_that(&paths::root().join(&format!("foo/target/debug/foo{}",
+    assert_that!(&paths::root().join(&format!("foo/target/debug/foo{}",
                                              env::consts::EXE_SUFFIX)),
                 existing_file());
 }
 
 #[test]
 fn both_lib_and_bin() {
-    assert_that(cargo_process("new").arg("--lib").arg("--bin").arg("foo")
+    assert_that!(cargo_process("new").arg("--lib").arg("--bin").arg("foo")
                                     .env("USER", "foo"),
                 execs().with_status(101).with_stderr(
                     "[ERROR] can't specify both lib and binary outputs"));
@@ -89,23 +90,23 @@ fn simple_git() {
     // If this ran inside paths::root() it would detect that we are already
     // inside a git repo and skip the initialization.
     let td = TempDir::new("cargo").unwrap();
-    assert_that(cargo_process("new").arg("--lib").arg("foo").cwd(td.path())
+    assert_that!(cargo_process("new").arg("--lib").arg("foo").cwd(td.path())
                                     .env("USER", "foo"),
                 execs().with_status(0));
 
-    assert_that(td.path(), existing_dir());
-    assert_that(&td.path().join("foo/Cargo.toml"), existing_file());
-    assert_that(&td.path().join("foo/src/lib.rs"), existing_file());
-    assert_that(&td.path().join("foo/.git"), existing_dir());
-    assert_that(&td.path().join("foo/.gitignore"), existing_file());
+    assert_that!(td.path(), existing_dir());
+    assert_that!(&td.path().join("foo/Cargo.toml"), existing_file());
+    assert_that!(&td.path().join("foo/src/lib.rs"), existing_file());
+    assert_that!(&td.path().join("foo/.git"), existing_dir());
+    assert_that!(&td.path().join("foo/.gitignore"), existing_file());
 
-    assert_that(cargo_process("build").cwd(&td.path().join("foo")),
+    assert_that!(cargo_process("build").cwd(&td.path().join("foo")),
                 execs().with_status(0));
 }
 
 #[test]
 fn no_argument() {
-    assert_that(cargo_process("new"),
+    assert_that!(cargo_process("new"),
                 execs().with_status(1)
                        .with_stderr("\
 [ERROR] Invalid arguments.
@@ -120,7 +121,7 @@ Usage:
 fn existing() {
     let dst = paths::root().join("foo");
     fs::create_dir(&dst).unwrap();
-    assert_that(cargo_process("new").arg("foo"),
+    assert_that!(cargo_process("new").arg("foo"),
                 execs().with_status(101)
                        .with_stderr(format!("[ERROR] destination `{}` already exists\n\n\
                                             Use `cargo init` to initialize the directory",
@@ -129,7 +130,7 @@ fn existing() {
 
 #[test]
 fn invalid_characters() {
-    assert_that(cargo_process("new").arg("foo.rs"),
+    assert_that!(cargo_process("new").arg("foo.rs"),
                 execs().with_status(101)
                        .with_stderr("\
 [ERROR] Invalid character `.` in crate name: `foo.rs`
@@ -138,7 +139,7 @@ use --name to override crate name"));
 
 #[test]
 fn reserved_name() {
-    assert_that(cargo_process("new").arg("test"),
+    assert_that!(cargo_process("new").arg("test"),
                 execs().with_status(101)
                        .with_stderr("\
 [ERROR] The name `test` cannot be used as a crate name\n\
@@ -147,7 +148,7 @@ use --name to override crate name"));
 
 #[test]
 fn reserved_binary_name() {
-    assert_that(cargo_process("new").arg("--bin").arg("incremental"),
+    assert_that!(cargo_process("new").arg("--bin").arg("incremental"),
                 execs().with_status(101)
                        .with_stderr("\
 [ERROR] The name `incremental` cannot be used as a crate name\n\
@@ -156,7 +157,7 @@ use --name to override crate name"));
 
 #[test]
 fn keyword_name() {
-    assert_that(cargo_process("new").arg("pub"),
+    assert_that!(cargo_process("new").arg("pub"),
                 execs().with_status(101)
                        .with_stderr("\
 [ERROR] The name `pub` cannot be used as a crate name\n\
@@ -165,7 +166,7 @@ use --name to override crate name"));
 
 #[test]
 fn rust_prefix_stripped() {
-    assert_that(cargo_process("new").arg("--lib").arg("rust-foo").env("USER", "foo"),
+    assert_that!(cargo_process("new").arg("--lib").arg("rust-foo").env("USER", "foo"),
                 execs().with_status(0)
                        .with_stderr_contains("note: package will be named `foo`; use --name to override"));
     let toml = paths::root().join("rust-foo/Cargo.toml");
@@ -176,7 +177,7 @@ fn rust_prefix_stripped() {
 
 #[test]
 fn bin_disables_stripping() {
-    assert_that(cargo_process("new").arg("rust-foo").arg("--bin").env("USER", "foo"),
+    assert_that!(cargo_process("new").arg("rust-foo").arg("--bin").env("USER", "foo"),
                 execs().with_status(0));
     let toml = paths::root().join("rust-foo/Cargo.toml");
     let mut contents = String::new();
@@ -186,7 +187,7 @@ fn bin_disables_stripping() {
 
 #[test]
 fn explicit_name_not_stripped() {
-    assert_that(cargo_process("new").arg("foo").arg("--name").arg("rust-bar").env("USER", "foo"),
+    assert_that!(cargo_process("new").arg("foo").arg("--name").arg("rust-bar").env("USER", "foo"),
                 execs().with_status(0));
     let toml = paths::root().join("foo/Cargo.toml");
     let mut contents = String::new();
@@ -197,7 +198,7 @@ fn explicit_name_not_stripped() {
 #[test]
 fn finds_author_user() {
     create_empty_gitconfig();
-    assert_that(cargo_process("new").arg("foo").env("USER", "foo"),
+    assert_that!(cargo_process("new").arg("foo").env("USER", "foo"),
                 execs().with_status(0));
 
     let toml = paths::root().join("foo/Cargo.toml");
@@ -209,7 +210,7 @@ fn finds_author_user() {
 #[test]
 fn finds_author_user_escaped() {
     create_empty_gitconfig();
-    assert_that(cargo_process("new").arg("foo").env("USER", "foo \"bar\""),
+    assert_that!(cargo_process("new").arg("foo").env("USER", "foo \"bar\""),
                 execs().with_status(0));
 
     let toml = paths::root().join("foo/Cargo.toml");
@@ -221,7 +222,7 @@ fn finds_author_user_escaped() {
 #[test]
 fn finds_author_username() {
     create_empty_gitconfig();
-    assert_that(cargo_process("new").arg("foo")
+    assert_that!(cargo_process("new").arg("foo")
                                     .env_remove("USER")
                                     .env("USERNAME", "foo"),
                 execs().with_status(0));
@@ -234,7 +235,7 @@ fn finds_author_username() {
 
 #[test]
 fn finds_author_priority() {
-    assert_that(cargo_process("new").arg("foo")
+    assert_that!(cargo_process("new").arg("foo")
                                     .env("USER", "bar2")
                                     .env("EMAIL", "baz2")
                                     .env("CARGO_NAME", "bar")
@@ -250,7 +251,7 @@ fn finds_author_priority() {
 #[test]
 fn finds_author_email() {
     create_empty_gitconfig();
-    assert_that(cargo_process("new").arg("foo")
+    assert_that!(cargo_process("new").arg("foo")
                                     .env("USER", "bar")
                                     .env("EMAIL", "baz"),
                 execs().with_status(0));
@@ -267,7 +268,7 @@ fn finds_author_git() {
                   .exec().unwrap();
     process("git").args(&["config", "--global", "user.email", "baz"])
                   .exec().unwrap();
-    assert_that(cargo_process("new").arg("foo").env("USER", "foo"),
+    assert_that!(cargo_process("new").arg("foo").env("USER", "foo"),
                 execs().with_status(0));
 
     let toml = paths::root().join("foo/Cargo.toml");
@@ -290,7 +291,7 @@ fn finds_local_author_git() {
                   .exec().unwrap();
     process("git").args(&["config", "user.email", "baz"])
                   .exec().unwrap();
-    assert_that(cargo_process("init").env("USER", "foo"),
+    assert_that!(cargo_process("init").env("USER", "foo"),
                 execs().with_status(0));
 
     let toml = paths::root().join("Cargo.toml");
@@ -301,7 +302,7 @@ fn finds_local_author_git() {
 
 #[test]
 fn finds_git_email() {
-    assert_that(cargo_process("new").arg("foo")
+    assert_that!(cargo_process("new").arg("foo")
                                     .env("GIT_AUTHOR_NAME", "foo")
                                     .env("GIT_AUTHOR_EMAIL", "gitfoo"),
                 execs().with_status(0));
@@ -316,7 +317,7 @@ fn finds_git_email() {
 #[test]
 fn finds_git_author() {
     create_empty_gitconfig();
-    assert_that(cargo_process("new").arg("foo")
+    assert_that!(cargo_process("new").arg("foo")
                                     .env_remove("USER")
                                     .env("GIT_COMMITTER_NAME", "gitfoo"),
                 execs().with_status(0));
@@ -342,7 +343,7 @@ fn author_prefers_cargo() {
         vcs = "none"
     "#).unwrap();
 
-    assert_that(cargo_process("new").arg("foo").env("USER", "foo"),
+    assert_that!(cargo_process("new").arg("foo").env("USER", "foo"),
                 execs().with_status(0));
 
     let toml = paths::root().join("foo/Cargo.toml");
@@ -363,7 +364,7 @@ fn git_prefers_command_line() {
         email = "bar"
     "#).unwrap();
 
-    assert_that(cargo_process("new").arg("foo").arg("--vcs").arg("git")
+    assert_that!(cargo_process("new").arg("foo").arg("--vcs").arg("git")
                                     .env("USER", "foo"),
                 execs().with_status(0));
     assert!(paths::root().join("foo/.gitignore").exists());
@@ -371,42 +372,42 @@ fn git_prefers_command_line() {
 
 #[test]
 fn subpackage_no_git() {
-    assert_that(cargo_process("new").arg("foo").env("USER", "foo"),
+    assert_that!(cargo_process("new").arg("foo").env("USER", "foo"),
                 execs().with_status(0));
 
     let subpackage = paths::root().join("foo").join("components");
     fs::create_dir(&subpackage).unwrap();
-    assert_that(cargo_process("new").arg("foo/components/subcomponent")
+    assert_that!(cargo_process("new").arg("foo/components/subcomponent")
                                     .env("USER", "foo"),
                 execs().with_status(0));
 
-    assert_that(&paths::root().join("foo/components/subcomponent/.git"),
+    assert_that!(&paths::root().join("foo/components/subcomponent/.git"),
                  is_not(existing_file()));
-    assert_that(&paths::root().join("foo/components/subcomponent/.gitignore"),
+    assert_that!(&paths::root().join("foo/components/subcomponent/.gitignore"),
                  is_not(existing_file()));
 }
 
 #[test]
 fn subpackage_git_with_vcs_arg() {
-    assert_that(cargo_process("new").arg("foo").env("USER", "foo"),
+    assert_that!(cargo_process("new").arg("foo").env("USER", "foo"),
                 execs().with_status(0));
 
     let subpackage = paths::root().join("foo").join("components");
     fs::create_dir(&subpackage).unwrap();
-    assert_that(cargo_process("new").arg("foo/components/subcomponent")
+    assert_that!(cargo_process("new").arg("foo/components/subcomponent")
                                     .arg("--vcs").arg("git")
                                     .env("USER", "foo"),
                 execs().with_status(0));
 
-    assert_that(&paths::root().join("foo/components/subcomponent/.git"),
+    assert_that!(&paths::root().join("foo/components/subcomponent/.git"),
                  existing_dir());
-    assert_that(&paths::root().join("foo/components/subcomponent/.gitignore"),
+    assert_that!(&paths::root().join("foo/components/subcomponent/.gitignore"),
                  existing_file());
 }
 
 #[test]
 fn unknown_flags() {
-    assert_that(cargo_process("new").arg("foo").arg("--flag"),
+    assert_that!(cargo_process("new").arg("foo").arg("--flag"),
                 execs().with_status(1)
                        .with_stderr("\
 [ERROR] Unknown flag: '--flag'

--- a/tests/overrides.rs
+++ b/tests/overrides.rs
@@ -1,11 +1,12 @@
 extern crate cargotest;
+#[macro_use]
 extern crate hamcrest;
 
 use cargotest::support::git;
 use cargotest::support::paths;
 use cargotest::support::registry::Package;
 use cargotest::support::{execs, project};
-use hamcrest::assert_that;
+use hamcrest::prelude::*;
 
 #[test]
 fn override_simple() {
@@ -42,7 +43,7 @@ fn override_simple() {
         ")
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0).with_stderr("\
 [UPDATING] registry `file://[..]`
 [UPDATING] git repository `[..]`
@@ -70,7 +71,7 @@ fn missing_version() {
         .file("src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(101).with_stderr("\
 error: failed to parse manifest at `[..]`
 
@@ -97,7 +98,7 @@ fn invalid_semver_version() {
         .file("src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(101).with_stderr_contains("\
 error: failed to parse manifest at `[..]`
 
@@ -127,7 +128,7 @@ fn different_version() {
         .file("src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(101).with_stderr("\
 error: failed to parse manifest at `[..]`
 
@@ -170,7 +171,7 @@ fn transitive() {
         .file("src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0).with_stderr("\
 [UPDATING] registry `file://[..]`
 [UPDATING] git repository `[..]`
@@ -181,7 +182,7 @@ fn transitive() {
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
 
-    assert_that(p.cargo("build"), execs().with_status(0).with_stdout(""));
+    assert_that!(p.cargo("build"), execs().with_status(0).with_stdout(""));
 }
 
 #[test]
@@ -219,7 +220,7 @@ fn persists_across_rebuilds() {
         ")
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0).with_stderr("\
 [UPDATING] registry `file://[..]`
 [UPDATING] git repository `file://[..]`
@@ -228,7 +229,7 @@ fn persists_across_rebuilds() {
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0).with_stdout(""));
 }
 
@@ -267,7 +268,7 @@ fn replace_registry_with_path() {
         ")
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0).with_stderr("\
 [UPDATING] registry `file://[..]`
 [COMPILING] foo v0.1.0 (file://[..])
@@ -325,7 +326,7 @@ fn use_a_spec_to_select() {
         ")
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0).with_stderr("\
 [UPDATING] registry `file://[..]`
 [UPDATING] git repository `[..]`
@@ -373,7 +374,7 @@ fn override_adds_some_deps() {
         .file("src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0).with_stderr("\
 [UPDATING] registry `file://[..]`
 [UPDATING] git repository `[..]`
@@ -384,21 +385,21 @@ fn override_adds_some_deps() {
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
 
-    assert_that(p.cargo("build"), execs().with_status(0).with_stdout(""));
+    assert_that!(p.cargo("build"), execs().with_status(0).with_stdout(""));
 
     Package::new("foo", "0.1.2").publish();
-    assert_that(p.cargo("update").arg("-p").arg(&format!("{}#bar", foo.url())),
+    assert_that!(p.cargo("update").arg("-p").arg(&format!("{}#bar", foo.url())),
                 execs().with_status(0).with_stderr("\
 [UPDATING] git repository `file://[..]`
 "));
-    assert_that(p.cargo("update")
+    assert_that!(p.cargo("update")
                  .arg("-p")
                  .arg("https://github.com/rust-lang/crates.io-index#bar"),
                 execs().with_status(0).with_stderr("\
 [UPDATING] registry `file://[..]`
 "));
 
-    assert_that(p.cargo("build"), execs().with_status(0).with_stdout(""));
+    assert_that!(p.cargo("build"), execs().with_status(0).with_stdout(""));
 }
 
 #[test]
@@ -438,11 +439,11 @@ fn locked_means_locked_yes_no_seriously_i_mean_locked() {
         .file("src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0));
 
-    assert_that(p.cargo("build"), execs().with_status(0).with_stdout(""));
-    assert_that(p.cargo("build"), execs().with_status(0).with_stdout(""));
+    assert_that!(p.cargo("build"), execs().with_status(0).with_stdout(""));
+    assert_that!(p.cargo("build"), execs().with_status(0).with_stdout(""));
 }
 
 #[test]
@@ -475,7 +476,7 @@ fn override_wrong_name() {
         .file("src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(101).with_stderr("\
 [UPDATING] registry [..]
 [UPDATING] git repository [..]
@@ -509,7 +510,7 @@ fn override_with_nothing() {
         .file("src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(101).with_stderr("\
 [UPDATING] registry [..]
 [UPDATING] git repository [..]
@@ -538,7 +539,7 @@ fn override_wrong_version() {
         .file("src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(101).with_stderr("\
 error: failed to parse manifest at `[..]`
 
@@ -580,7 +581,7 @@ fn multiple_specs() {
         .file("src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(101).with_stderr("\
 [UPDATING] registry [..]
 [UPDATING] git repository [..]
@@ -623,7 +624,7 @@ fn test_override_dep() {
         .file("src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("test").arg("-p").arg("foo"),
+    assert_that!(p.cargo("test").arg("-p").arg("foo"),
                 execs().with_status(101)
                        .with_stderr_contains("\
 error: There are multiple `foo` packages in your project, and the [..]
@@ -663,9 +664,9 @@ fn update() {
         .file("src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("generate-lockfile"),
+    assert_that!(p.cargo("generate-lockfile"),
                 execs().with_status(0));
-    assert_that(p.cargo("update"),
+    assert_that!(p.cargo("update"),
                 execs().with_status(0)
                        .with_stderr("\
 [UPDATING] registry `[..]`
@@ -721,7 +722,7 @@ fn no_override_self() {
         "#)
         .build();
 
-    assert_that(p.cargo("build").arg("--verbose"),
+    assert_that!(p.cargo("build").arg("--verbose"),
                 execs().with_status(0));
 }
 
@@ -766,7 +767,7 @@ fn broken_path_override_warns() {
         "#)
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0)
                        .with_stderr("\
 [UPDATING] [..]
@@ -890,7 +891,7 @@ fn override_an_override() {
         ")
         .build();
 
-    assert_that(p.cargo("build").arg("-v"),
+    assert_that!(p.cargo("build").arg("-v"),
                 execs().with_status(0));
 }
 
@@ -937,9 +938,9 @@ fn overriding_nonexistent_no_spurious() {
         .file("src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0));
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0).with_stderr("\
 [WARNING] package replacement is not used: [..]bar:0.1.0
 [FINISHED] [..]
@@ -981,7 +982,7 @@ fn no_warnings_when_replace_is_used_in_another_workspace_member() {
         .file("local_foo/src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("build").cwd(p.root().join("first_crate")),
+    assert_that!(p.cargo("build").cwd(p.root().join("first_crate")),
                 execs().with_status(0)
                     .with_stdout("")
                     .with_stderr("\
@@ -990,7 +991,7 @@ fn no_warnings_when_replace_is_used_in_another_workspace_member() {
 [COMPILING] first_crate v0.1.0 ([..])
 [FINISHED] [..]"));
 
-    assert_that(p.cargo("build").cwd(p.root().join("second_crate")),
+    assert_that!(p.cargo("build").cwd(p.root().join("second_crate")),
                 execs().with_status(0)
                     .with_stdout("")
                     .with_stderr("\
@@ -1037,7 +1038,7 @@ fn override_to_path_dep() {
         "#)
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0));
 }
 
@@ -1085,7 +1086,7 @@ fn replace_to_path_dep() {
         .file("foo/bar/src/lib.rs", "pub fn bar() {}")
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0));
 }
 
@@ -1129,7 +1130,7 @@ fn paths_ok_with_optional() {
         "#)
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0).with_stderr("\
 [COMPILING] foo v0.1.0 ([..]foo2)
 [COMPILING] local v0.0.1 ([..])
@@ -1174,7 +1175,7 @@ fn paths_add_optional_bad() {
         "#)
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0).with_stderr_contains("\
 warning: path override for crate `foo` has altered the original list of
 dependencies; the dependency on `bar` was either added or\
@@ -1236,7 +1237,7 @@ fn override_with_default_feature() {
         .file("another2/src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("run"),
+    assert_that!(p.cargo("run"),
                 execs().with_status(0));
 }
 
@@ -1270,7 +1271,7 @@ fn override_plus_dep() {
         .file("bar/src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(101).with_stderr_contains("\
 error: cyclic package dependency: [..]
 "));

--- a/tests/package.rs
+++ b/tests/package.rs
@@ -2,6 +2,7 @@
 extern crate cargotest;
 extern crate flate2;
 extern crate git2;
+#[macro_use]
 extern crate hamcrest;
 extern crate tar;
 
@@ -13,7 +14,7 @@ use cargotest::{cargo_process, process};
 use cargotest::support::{project, execs, paths, git, path2url, cargo_exe};
 use cargotest::support::registry::Package;
 use flate2::read::GzDecoder;
-use hamcrest::{assert_that, existing_file, contains, equal_to};
+use hamcrest::prelude::*;
 use tar::Archive;
 
 #[test]
@@ -34,7 +35,7 @@ fn simple() {
         .file("src/bar.txt", "") // should be ignored when packaging
         .build();
 
-    assert_that(p.cargo("package"),
+    assert_that!(p.cargo("package"),
                 execs().with_status(0).with_stderr(&format!("\
 [WARNING] manifest has no documentation[..]
 See [..]
@@ -44,13 +45,13 @@ See [..]
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         dir = p.url())));
-    assert_that(&p.root().join("target/package/foo-0.0.1.crate"), existing_file());
-    assert_that(p.cargo("package").arg("-l"),
+    assert_that!(&p.root().join("target/package/foo-0.0.1.crate"), existing_file());
+    assert_that!(p.cargo("package").arg("-l"),
                 execs().with_status(0).with_stdout("\
 Cargo.toml
 src[/]main.rs
 "));
-    assert_that(p.cargo("package"),
+    assert_that!(p.cargo("package"),
                 execs().with_status(0).with_stdout(""));
 
     let f = File::open(&p.root().join("target/package/foo-0.0.1.crate")).unwrap();
@@ -82,7 +83,7 @@ fn metadata_warning() {
             fn main() {}
         "#)
         .build();
-    assert_that(p.cargo("package"),
+    assert_that!(p.cargo("package"),
                 execs().with_status(0).with_stderr(&format!("\
 warning: manifest has no description, license, license-file, documentation, \
 homepage or repository.
@@ -106,7 +107,7 @@ See http://doc.crates.io/manifest.html#package-metadata for more info.
             fn main() {}
         "#)
         .build();
-    assert_that(p.cargo("package"),
+    assert_that!(p.cargo("package"),
                 execs().with_status(0).with_stderr(&format!("\
 warning: manifest has no description, documentation, homepage or repository.
 See http://doc.crates.io/manifest.html#package-metadata for more info.
@@ -131,7 +132,7 @@ See http://doc.crates.io/manifest.html#package-metadata for more info.
             fn main() {}
         "#)
         .build();
-    assert_that(p.cargo("package"),
+    assert_that!(p.cargo("package"),
                 execs().with_status(0).with_stderr(&format!("\
 [PACKAGING] foo v0.0.1 ({dir})
 [VERIFYING] foo v0.0.1 ({dir})
@@ -164,10 +165,10 @@ fn package_verbose() {
         .build();
     let mut cargo = cargo_process();
     cargo.cwd(p.root());
-    assert_that(cargo.clone().arg("build"), execs().with_status(0));
+    assert_that!(cargo.clone().arg("build"), execs().with_status(0));
 
     println!("package main repo");
-    assert_that(cargo.clone().arg("package").arg("-v").arg("--no-verify"),
+    assert_that!(cargo.clone().arg("package").arg("-v").arg("--no-verify"),
                 execs().with_status(0).with_stderr("\
 [WARNING] manifest has no description[..]
 See http://doc.crates.io/manifest.html#package-metadata for more info.
@@ -177,7 +178,7 @@ See http://doc.crates.io/manifest.html#package-metadata for more info.
 "));
 
     println!("package sub-repo");
-    assert_that(cargo.arg("package").arg("-v").arg("--no-verify")
+    assert_that!(cargo.arg("package").arg("-v").arg("--no-verify")
                      .cwd(p.root().join("a")),
                 execs().with_status(0).with_stderr("\
 [WARNING] manifest has no description[..]
@@ -201,9 +202,9 @@ fn package_verification() {
             fn main() {}
         "#)
         .build();
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0));
-    assert_that(p.cargo("package"),
+    assert_that!(p.cargo("package"),
                 execs().with_status(0).with_stderr(&format!("\
 [WARNING] manifest has no description[..]
 See http://doc.crates.io/manifest.html#package-metadata for more info.
@@ -239,7 +240,7 @@ fn path_dependency_no_version() {
         .file("bar/src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("package"),
+    assert_that!(p.cargo("package"),
                 execs().with_status(101).with_stderr("\
 [WARNING] manifest has no documentation, homepage or repository.
 See http://doc.crates.io/manifest.html#package-metadata for more info.
@@ -315,7 +316,7 @@ fn exclude() {
         .file("some_dir/dir_deep_5/some_dir/file", "")
         .build();
 
-    assert_that(p.cargo("package").arg("--no-verify").arg("-v"),
+    assert_that!(p.cargo("package").arg("--no-verify").arg("-v"),
                 execs().with_status(0).with_stdout("").with_stderr("\
 [WARNING] manifest has no description[..]
 See http://doc.crates.io/manifest.html#package-metadata for more info.
@@ -356,9 +357,9 @@ See [..]
 [ARCHIVING] [..]
 "));
 
-    assert_that(&p.root().join("target/package/foo-0.0.1.crate"), existing_file());
+    assert_that!(&p.root().join("target/package/foo-0.0.1.crate"), existing_file());
 
-    assert_that(p.cargo("package").arg("-l"),
+    assert_that!(p.cargo("package").arg("-l"),
                 execs().with_status(0).with_stdout("\
 Cargo.toml
 dir_root_1[/]some_dir[/]file
@@ -399,7 +400,7 @@ fn include() {
         .file("src/bar.txt", "") // should be ignored when packaging
         .build();
 
-    assert_that(p.cargo("package").arg("--no-verify").arg("-v"),
+    assert_that!(p.cargo("package").arg("--no-verify").arg("-v"),
                 execs().with_status(0).with_stderr("\
 [WARNING] manifest has no description[..]
 See http://doc.crates.io/manifest.html#package-metadata for more info.
@@ -426,7 +427,7 @@ fn package_lib_with_bin() {
         .file("src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("package").arg("-v"),
+    assert_that!(p.cargo("package").arg("-v"),
                 execs().with_status(0));
 }
 
@@ -457,7 +458,7 @@ fn package_git_submodule() {
     repository.reset(&repository.revparse_single("HEAD").unwrap(),
                      git2::ResetType::Hard, None).unwrap();
 
-    assert_that(cargo_process().arg("package").cwd(project.root())
+    assert_that!(cargo_process().arg("package").cwd(project.root())
                  .arg("--no-verify").arg("-v"),
                 execs().with_status(0).with_stderr_contains("[ARCHIVING] bar/Makefile"));
 }
@@ -481,8 +482,8 @@ fn no_duplicates_from_modified_tracked_files() {
         "#).unwrap();
     let mut cargo = cargo_process();
     cargo.cwd(p.root());
-    assert_that(cargo.clone().arg("build"), execs().with_status(0));
-    assert_that(cargo.arg("package").arg("--list"),
+    assert_that!(cargo.clone().arg("build"), execs().with_status(0));
+    assert_that!(cargo.arg("package").arg("--list"),
                 execs().with_status(0).with_stdout("\
 Cargo.toml
 src/main.rs
@@ -511,7 +512,7 @@ fn ignore_nested() {
         .file("a_dir/nested/src/main.rs", main_rs)
         .build();
 
-    assert_that(p.cargo("package"),
+    assert_that!(p.cargo("package"),
                 execs().with_status(0).with_stderr(&format!("\
 [WARNING] manifest has no documentation[..]
 See http://doc.crates.io/manifest.html#package-metadata for more info.
@@ -521,13 +522,13 @@ See http://doc.crates.io/manifest.html#package-metadata for more info.
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         dir = p.url())));
-    assert_that(&p.root().join("target/package/nested-0.0.1.crate"), existing_file());
-    assert_that(p.cargo("package").arg("-l"),
+    assert_that!(&p.root().join("target/package/nested-0.0.1.crate"), existing_file());
+    assert_that!(p.cargo("package").arg("-l"),
                 execs().with_status(0).with_stdout("\
 Cargo.toml
 src[..]main.rs
 "));
-    assert_that(p.cargo("package"),
+    assert_that!(p.cargo("package"),
                 execs().with_status(0).with_stdout(""));
 
     let f = File::open(&p.root().join("target/package/nested-0.0.1.crate")).unwrap();
@@ -562,7 +563,7 @@ fn package_weird_characters() {
         .file("src/:foo", "")
         .build();
 
-    assert_that(p.cargo("package"),
+    assert_that!(p.cargo("package"),
                 execs().with_status(101).with_stderr("\
 warning: [..]
 See [..]
@@ -588,7 +589,7 @@ fn repackage_on_source_change() {
         "#)
         .build();
 
-    assert_that(p.cargo("package"),
+    assert_that!(p.cargo("package"),
                 execs().with_status(0));
 
     // Add another source file
@@ -605,7 +606,7 @@ fn repackage_on_source_change() {
     pro.arg("package").cwd(p.root());
 
     // Check that cargo rebuilds the tarball
-    assert_that(pro, execs().with_status(0).with_stderr(&format!("\
+    assert_that!(pro, execs().with_status(0).with_stderr(&format!("\
 [WARNING] [..]
 See [..]
 [PACKAGING] foo v0.0.1 ({dir})
@@ -625,7 +626,7 @@ See [..]
     let entry_paths = entries.map(|entry| {
         entry.unwrap().path().unwrap().into_owned()
     }).collect::<Vec<PathBuf>>();
-    assert_that(&entry_paths, contains(vec![PathBuf::from("foo-0.0.1/src/foo.rs")]));
+    assert_that!(&entry_paths, contains(vec![PathBuf::from("foo-0.0.1/src/foo.rs")]));
 }
 
 #[test]
@@ -651,7 +652,7 @@ fn broken_symlink() {
         .build();
     t!(fs::symlink("nowhere", &p.root().join("src/foo.rs")));
 
-    assert_that(p.cargo("package").arg("-v"),
+    assert_that!(p.cargo("package").arg("-v"),
                 execs().with_status(101)
                        .with_stderr_contains("\
 error: failed to prepare local package for uploading
@@ -696,7 +697,7 @@ fn do_not_package_if_repository_is_dirty() {
             # change
     "#);
 
-    assert_that(p.cargo("package"),
+    assert_that!(p.cargo("package"),
                 execs().with_status(101)
                        .with_stderr("\
 error: 1 files in the working directory contain changes that were not yet \
@@ -744,7 +745,7 @@ fn generated_manifest() {
         .file("bar/src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("package").arg("--no-verify"),
+    assert_that!(p.cargo("package").arg("--no-verify"),
                 execs().with_status(0));
 
     let f = File::open(&p.root().join("target/package/foo-0.0.1.crate")).unwrap();
@@ -760,7 +761,7 @@ fn generated_manifest() {
     entry.read_to_string(&mut contents).unwrap();
     // BTreeMap makes the order of dependencies in the generated file deterministic
     // by sorting alphabetically
-    assert_that(&contents[..], equal_to(
+    assert_that!(&contents[..], equal_to(
 r#"# THIS FILE IS AUTOMATICALLY GENERATED BY CARGO
 #
 # When uploading crates to the registry Cargo will automatically
@@ -823,7 +824,7 @@ fn ignore_workspace_specifier() {
         .file("bar/src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("package").arg("--no-verify").cwd(p.root().join("bar")),
+    assert_that!(p.cargo("package").arg("--no-verify").cwd(p.root().join("bar")),
                 execs().with_status(0));
 
     let f = File::open(&p.root().join("target/package/bar-0.1.0.crate")).unwrap();
@@ -837,7 +838,7 @@ fn ignore_workspace_specifier() {
                         .unwrap();
     let mut contents = String::new();
     entry.read_to_string(&mut contents).unwrap();
-    assert_that(&contents[..], equal_to(
+    assert_that!(&contents[..], equal_to(
 r#"# THIS FILE IS AUTOMATICALLY GENERATED BY CARGO
 #
 # When uploading crates to the registry Cargo will automatically
@@ -875,6 +876,6 @@ fn package_two_kinds_of_deps() {
         .file("src/main.rs", "")
         .build();
 
-    assert_that(p.cargo("package").arg("--no-verify"),
+    assert_that!(p.cargo("package").arg("--no-verify"),
                 execs().with_status(0));
 }

--- a/tests/patch.rs
+++ b/tests/patch.rs
@@ -1,5 +1,6 @@
 #[macro_use]
 extern crate cargotest;
+#[macro_use]
 extern crate hamcrest;
 extern crate toml;
 
@@ -10,7 +11,7 @@ use cargotest::support::git;
 use cargotest::support::paths;
 use cargotest::support::registry::Package;
 use cargotest::support::{execs, project};
-use hamcrest::assert_that;
+use hamcrest::prelude::*;
 
 #[test]
 fn replace() {
@@ -58,7 +59,7 @@ fn replace() {
         "#)
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0).with_stderr("\
 [UPDATING] registry `file://[..]`
 [DOWNLOADING] deep-foo v0.1.0 ([..])
@@ -68,7 +69,7 @@ fn replace() {
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
 
-    assert_that(p.cargo("build"),//.env("RUST_LOG", "trace"),
+    assert_that!(p.cargo("build"),//.env("RUST_LOG", "trace"),
                 execs().with_status(0).with_stderr("[FINISHED] [..]"));
 }
 
@@ -106,14 +107,14 @@ fn nonexistent() {
         "#)
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0).with_stderr("\
 [UPDATING] registry `file://[..]`
 [COMPILING] foo v0.1.0 (file://[..])
 [COMPILING] bar v0.0.1 (file://[..])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0).with_stderr("[FINISHED] [..]"));
 }
 
@@ -159,14 +160,14 @@ fn patch_git() {
         "#)
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0).with_stderr("\
 [UPDATING] git repository `file://[..]`
 [COMPILING] foo v0.1.0 (file://[..])
 [COMPILING] bar v0.0.1 (file://[..])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0).with_stderr("[FINISHED] [..]"));
 }
 
@@ -205,7 +206,7 @@ fn patch_to_git() {
         ")
         .build();
 
-    assert_that(p.cargo("build"),//.env("RUST_LOG", "cargo=trace"),
+    assert_that!(p.cargo("build"),//.env("RUST_LOG", "cargo=trace"),
                 execs().with_status(0).with_stderr("\
 [UPDATING] git repository `file://[..]`
 [UPDATING] registry `file://[..]`
@@ -213,7 +214,7 @@ fn patch_to_git() {
 [COMPILING] bar v0.0.1 (file://[..])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0).with_stderr("[FINISHED] [..]"));
 }
 
@@ -246,7 +247,7 @@ fn unused() {
         "#)
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0).with_stderr("\
 [UPDATING] registry `file://[..]`
 [DOWNLOADING] foo v0.1.0 [..]
@@ -254,7 +255,7 @@ fn unused() {
 [COMPILING] bar v0.0.1 (file://[..])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0).with_stderr("[FINISHED] [..]"));
 
     // unused patch should be in the lock file
@@ -297,7 +298,7 @@ fn unused_git() {
         .file("src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0).with_stderr("\
 [UPDATING] git repository `file://[..]`
 [UPDATING] registry `file://[..]`
@@ -306,7 +307,7 @@ fn unused_git() {
 [COMPILING] bar v0.0.1 (file://[..])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0).with_stderr("[FINISHED] [..]"));
 }
 
@@ -334,7 +335,7 @@ fn add_patch() {
         .file("foo/src/lib.rs", r#""#)
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0).with_stderr("\
 [UPDATING] registry `file://[..]`
 [DOWNLOADING] foo v0.1.0 [..]
@@ -342,7 +343,7 @@ fn add_patch() {
 [COMPILING] bar v0.0.1 (file://[..])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0).with_stderr("[FINISHED] [..]"));
 
     t!(t!(File::create(p.root().join("Cargo.toml"))).write_all(br#"
@@ -358,13 +359,13 @@ fn add_patch() {
             foo = { path = 'foo' }
     "#));
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0).with_stderr("\
 [COMPILING] foo v0.1.0 (file://[..])
 [COMPILING] bar v0.0.1 (file://[..])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0).with_stderr("[FINISHED] [..]"));
 }
 
@@ -392,7 +393,7 @@ fn add_ignored_patch() {
         .file("foo/src/lib.rs", r#""#)
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0).with_stderr("\
 [UPDATING] registry `file://[..]`
 [DOWNLOADING] foo v0.1.0 [..]
@@ -400,7 +401,7 @@ fn add_ignored_patch() {
 [COMPILING] bar v0.0.1 (file://[..])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0).with_stderr("[FINISHED] [..]"));
 
     t!(t!(File::create(p.root().join("Cargo.toml"))).write_all(br#"
@@ -416,11 +417,11 @@ fn add_ignored_patch() {
             foo = { path = 'foo' }
     "#));
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0).with_stderr("\
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0).with_stderr("[FINISHED] [..]"));
 }
 
@@ -451,7 +452,7 @@ fn new_minor() {
         .file("foo/src/lib.rs", r#""#)
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0).with_stderr("\
 [UPDATING] registry `file://[..]`
 [COMPILING] foo v0.1.1 [..]
@@ -497,7 +498,7 @@ fn transitive_new_minor() {
         .file("foo/src/lib.rs", r#""#)
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0).with_stderr("\
 [UPDATING] registry `file://[..]`
 [COMPILING] foo v0.1.1 [..]
@@ -534,7 +535,7 @@ fn new_major() {
         .file("foo/src/lib.rs", r#""#)
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0).with_stderr("\
 [UPDATING] registry `file://[..]`
 [COMPILING] foo v0.2.0 [..]
@@ -543,9 +544,9 @@ fn new_major() {
 "));
 
     Package::new("foo", "0.2.0").publish();
-    assert_that(p.cargo("update"),
+    assert_that!(p.cargo("update"),
                 execs().with_status(0));
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0).with_stderr("\
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
@@ -559,7 +560,7 @@ fn new_major() {
             [dependencies]
             foo = "0.2.0"
     "#));
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0).with_stderr("\
 [UPDATING] registry `file://[..]`
 [DOWNLOADING] foo v0.2.0 [..]
@@ -606,7 +607,7 @@ fn transitive_new_major() {
         .file("foo/src/lib.rs", r#""#)
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0).with_stderr("\
 [UPDATING] registry `file://[..]`
 [COMPILING] foo v0.2.0 [..]
@@ -653,7 +654,7 @@ fn remove_patch() {
         .build();
 
     // Generate a lock file where `bar` is unused
-    assert_that(p.cargo("build"), execs().with_status(0));
+    assert_that!(p.cargo("build"), execs().with_status(0));
     let mut lock_file1 = String::new();
     File::open(p.root().join("Cargo.lock")).unwrap()
         .read_to_string(&mut lock_file1).unwrap();
@@ -671,14 +672,14 @@ fn remove_patch() {
         [patch.crates-io]
         foo = { path = 'foo' }
     "#.as_bytes()).unwrap();
-    assert_that(p.cargo("build"), execs().with_status(0));
+    assert_that!(p.cargo("build"), execs().with_status(0));
     let mut lock_file2 = String::new();
     File::open(p.root().join("Cargo.lock")).unwrap()
         .read_to_string(&mut lock_file2).unwrap();
 
     // Remove the lock file and build from scratch
     fs::remove_file(p.root().join("Cargo.lock")).unwrap();
-    assert_that(p.cargo("build"), execs().with_status(0));
+    assert_that!(p.cargo("build"), execs().with_status(0));
     let mut lock_file3 = String::new();
     File::open(p.root().join("Cargo.lock")).unwrap()
         .read_to_string(&mut lock_file3).unwrap();
@@ -712,7 +713,7 @@ fn non_crates_io() {
         .file("foo/src/lib.rs", r#""#)
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(101)
                        .with_stderr("\
 error: failed to parse manifest at `[..]`
@@ -746,7 +747,7 @@ fn replace_with_crates_io() {
         .file("foo/src/lib.rs", r#""#)
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(101)
                        .with_stderr("\
 [UPDATING] [..]
@@ -789,9 +790,9 @@ fn patch_in_virtual() {
         .file("bar/src/lib.rs", r#""#)
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0));
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0).with_stderr("\
 [FINISHED] [..]
 "));

--- a/tests/path.rs
+++ b/tests/path.rs
@@ -1,6 +1,7 @@
 extern crate cargo;
 #[macro_use]
 extern crate cargotest;
+#[macro_use]
 extern crate hamcrest;
 
 use std::fs::{self, File};
@@ -11,7 +12,7 @@ use cargotest::sleep_ms;
 use cargotest::support::paths::{self, CargoPathExt};
 use cargotest::support::{project, execs, main_file};
 use cargotest::support::registry::Package;
-use hamcrest::{assert_that, existing_file};
+use hamcrest::prelude::*;
 
 #[test]
 #[cfg(not(windows))] // I have no idea why this is failing spuriously on
@@ -73,7 +74,7 @@ fn cargo_compile_with_nested_deps_shorthand() {
         "#)
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
         execs().with_status(0)
                .with_stderr(&format!("[COMPILING] baz v0.5.0 ({}/bar/baz)\n\
                                      [COMPILING] bar v0.5.0 ({}/bar)\n\
@@ -84,23 +85,23 @@ fn cargo_compile_with_nested_deps_shorthand() {
                                     p.url(),
                                     p.url())));
 
-    assert_that(&p.bin("foo"), existing_file());
+    assert_that!(&p.bin("foo"), existing_file());
 
-    assert_that(process(&p.bin("foo")),
+    assert_that!(process(&p.bin("foo")),
                 execs().with_stdout("test passed\n").with_status(0));
 
     println!("cleaning");
-    assert_that(p.cargo("clean").arg("-v"),
+    assert_that!(p.cargo("clean").arg("-v"),
                 execs().with_stdout("").with_status(0));
     println!("building baz");
-    assert_that(p.cargo("build").arg("-p").arg("baz"),
+    assert_that!(p.cargo("build").arg("-p").arg("baz"),
                 execs().with_status(0)
                        .with_stderr(&format!("[COMPILING] baz v0.5.0 ({}/bar/baz)\n\
                                               [FINISHED] dev [unoptimized + debuginfo] target(s) \
                                               in [..]\n",
                                             p.url())));
     println!("building foo");
-    assert_that(p.cargo("build")
+    assert_that!(p.cargo("build")
                  .arg("-p").arg("foo"),
                 execs().with_status(0)
                        .with_stderr(&format!("[COMPILING] bar v0.5.0 ({}/bar)\n\
@@ -147,7 +148,7 @@ fn cargo_compile_with_root_dev_deps() {
         "#)
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(101))
 }
 
@@ -187,7 +188,7 @@ fn cargo_compile_with_root_dev_deps_with_testing() {
         "#)
         .build();
 
-    assert_that(p.cargo("test"),
+    assert_that!(p.cargo("test"),
                 execs().with_stderr("\
 [COMPILING] [..] v0.5.0 ([..])
 [COMPILING] [..] v0.5.0 ([..])
@@ -235,7 +236,7 @@ fn cargo_compile_with_transitive_dev_deps() {
         "#)
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
         execs().with_stderr(&format!("[COMPILING] bar v0.5.0 ({}/bar)\n\
                                      [COMPILING] foo v0.5.0 ({})\n\
                                      [FINISHED] dev [unoptimized + debuginfo] target(s) in \
@@ -243,9 +244,9 @@ fn cargo_compile_with_transitive_dev_deps() {
                                     p.url(),
                                     p.url())));
 
-    assert_that(&p.bin("foo"), existing_file());
+    assert_that!(&p.bin("foo"), existing_file());
 
-    assert_that(process(&p.bin("foo")),
+    assert_that!(process(&p.bin("foo")),
                 execs().with_stdout("zoidberg\n"));
 }
 
@@ -281,7 +282,7 @@ fn no_rebuild_dependency() {
         "#)
         .build();
     // First time around we should compile both foo and bar
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_stderr(&format!("[COMPILING] bar v0.5.0 ({}/bar)\n\
                                              [COMPILING] foo v0.5.0 ({})\n\
                                              [FINISHED] dev [unoptimized + debuginfo] target(s) \
@@ -295,7 +296,7 @@ fn no_rebuild_dependency() {
         fn main() { bar::bar(); }
     "#);
     // Don't compile bar, but do recompile foo.
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_stderr("\
                      [COMPILING] foo v0.5.0 ([..])\n\
                      [FINISHED] dev [unoptimized + debuginfo] target(s) \
@@ -349,7 +350,7 @@ fn deep_dependencies_trigger_rebuild() {
             pub fn baz() {}
         "#)
         .build();
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_stderr(&format!("[COMPILING] baz v0.5.0 ({}/baz)\n\
                                              [COMPILING] bar v0.5.0 ({}/bar)\n\
                                              [COMPILING] foo v0.5.0 ({})\n\
@@ -358,7 +359,7 @@ fn deep_dependencies_trigger_rebuild() {
                                             p.url(),
                                             p.url(),
                                             p.url())));
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_stdout(""));
 
     // Make sure an update to baz triggers a rebuild of bar
@@ -369,7 +370,7 @@ fn deep_dependencies_trigger_rebuild() {
     File::create(&p.root().join("baz/src/baz.rs")).unwrap().write_all(br#"
         pub fn baz() { println!("hello!"); }
     "#).unwrap();
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_stderr(&format!("[COMPILING] baz v0.5.0 ({}/baz)\n\
                                              [COMPILING] bar v0.5.0 ({}/bar)\n\
                                              [COMPILING] foo v0.5.0 ({})\n\
@@ -385,7 +386,7 @@ fn deep_dependencies_trigger_rebuild() {
         extern crate baz;
         pub fn bar() { println!("hello!"); baz::baz(); }
     "#).unwrap();
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_stderr(&format!("[COMPILING] bar v0.5.0 ({}/bar)\n\
                                              [COMPILING] foo v0.5.0 ({})\n\
                                              [FINISHED] dev [unoptimized + debuginfo] target(s) \
@@ -443,7 +444,7 @@ fn no_rebuild_two_deps() {
             pub fn baz() {}
         "#)
         .build();
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_stderr(&format!("[COMPILING] baz v0.5.0 ({}/baz)\n\
                                              [COMPILING] bar v0.5.0 ({}/bar)\n\
                                              [COMPILING] foo v0.5.0 ({})\n\
@@ -452,10 +453,10 @@ fn no_rebuild_two_deps() {
                                             p.url(),
                                             p.url(),
                                             p.url())));
-    assert_that(&p.bin("foo"), existing_file());
-    assert_that(p.cargo("build"),
+    assert_that!(&p.bin("foo"), existing_file());
+    assert_that!(p.cargo("build"),
                 execs().with_stdout(""));
-    assert_that(&p.bin("foo"), existing_file());
+    assert_that!(&p.bin("foo"), existing_file());
 }
 
 #[test]
@@ -490,7 +491,7 @@ fn nested_deps_recompile() {
         .build();
     let bar = p.url();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_stderr(&format!("[COMPILING] bar v0.5.0 ({}/src/bar)\n\
                                              [COMPILING] foo v0.5.0 ({})\n\
                                              [FINISHED] dev [unoptimized + debuginfo] target(s) \
@@ -504,7 +505,7 @@ fn nested_deps_recompile() {
     "#).unwrap();
 
     // This shouldn't recompile `bar`
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_stderr(&format!("[COMPILING] foo v0.5.0 ({})\n\
                                               [FINISHED] dev [unoptimized + debuginfo] target(s) \
                                               in [..]\n",
@@ -529,7 +530,7 @@ fn error_message_for_missing_manifest() {
         .file("src/bar/not-a-manifest", "")
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(101)
                        .with_stderr("\
 [ERROR] failed to load source for a dependency on `bar`
@@ -576,7 +577,7 @@ fn override_relative() {
         "#, bar.root().display()))
        .file("src/lib.rs", "")
        .build();
-    assert_that(p.cargo("build").arg("-v"), execs().with_status(0));
+    assert_that!(p.cargo("build").arg("-v"), execs().with_status(0));
 
 }
 
@@ -614,7 +615,7 @@ fn override_self() {
        .file("src/main.rs", "fn main() {}")
        .build();
 
-    assert_that(p.cargo("build"), execs().with_status(0));
+    assert_that!(p.cargo("build"), execs().with_status(0));
 }
 
 #[test]
@@ -658,7 +659,7 @@ fn override_path_dep() {
        .file("src/lib.rs", "")
        .build();
 
-    assert_that(p.cargo("build").arg("-v"),
+    assert_that!(p.cargo("build").arg("-v"),
                 execs().with_status(0));
 
 }
@@ -703,7 +704,7 @@ fn path_dep_build_cmd() {
         "#).build();
     p.root().join("bar").move_into_the_past();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
         execs().with_stderr(&format!("[COMPILING] bar v0.5.0 ({}/bar)\n\
                                      [COMPILING] foo v0.5.0 ({})\n\
                                      [FINISHED] dev [unoptimized + debuginfo] target(s) in \
@@ -711,9 +712,9 @@ fn path_dep_build_cmd() {
                                     p.url(),
                                     p.url())));
 
-    assert_that(&p.bin("foo"), existing_file());
+    assert_that!(&p.bin("foo"), existing_file());
 
-    assert_that(process(&p.bin("foo")),
+    assert_that!(process(&p.bin("foo")),
                 execs().with_stdout("0\n"));
 
     // Touching bar.rs.in should cause the `build` command to run again.
@@ -722,7 +723,7 @@ fn path_dep_build_cmd() {
         file.unwrap().write_all(br#"pub fn gimme() -> i32 { 1 }"#).unwrap();
     }
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
         execs().with_stderr(&format!("[COMPILING] bar v0.5.0 ({}/bar)\n\
                                      [COMPILING] foo v0.5.0 ({})\n\
                                      [FINISHED] dev [unoptimized + debuginfo] target(s) in \
@@ -730,7 +731,7 @@ fn path_dep_build_cmd() {
                                     p.url(),
                                     p.url())));
 
-    assert_that(process(&p.bin("foo")),
+    assert_that!(process(&p.bin("foo")),
                 execs().with_stdout("1\n"));
 }
 
@@ -763,7 +764,7 @@ fn dev_deps_no_rebuild_lib() {
         "#)
         .file("bar/src/lib.rs", "pub fn bar() {}")
         .build();
-    assert_that(p.cargo("build")
+    assert_that!(p.cargo("build")
                  .env("FOO", "bar"),
                 execs().with_status(0)
                        .with_stderr(&format!("[COMPILING] foo v0.5.0 ({})\n\
@@ -771,7 +772,7 @@ fn dev_deps_no_rebuild_lib() {
                                               in [..]\n",
                                               p.url())));
 
-    assert_that(p.cargo("test"),
+    assert_that!(p.cargo("test"),
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] [..] v0.5.0 ({url}[..])
@@ -812,7 +813,7 @@ fn custom_target_no_rebuild() {
         "#)
         .file("b/src/lib.rs", "")
         .build();
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0)
                        .with_stderr("\
 [COMPILING] a v0.5.0 ([..])
@@ -821,7 +822,7 @@ fn custom_target_no_rebuild() {
 "));
 
     t!(fs::rename(p.root().join("target"), p.root().join("target_moved")));
-    assert_that(p.cargo("build")
+    assert_that!(p.cargo("build")
                  .arg("--manifest-path=b/Cargo.toml")
                  .env("CARGO_TARGET_DIR", "target_moved"),
                 execs().with_status(0)
@@ -864,7 +865,7 @@ fn override_and_depend() {
             paths = ["../a"]
         "#)
         .build();
-    assert_that(p.cargo("build").cwd(p.root().join("b")),
+    assert_that!(p.cargo("build").cwd(p.root().join("b")),
                 execs().with_status(0)
                        .with_stderr("\
 [COMPILING] a2 v0.5.0 ([..])
@@ -888,7 +889,7 @@ fn missing_path_dependency() {
             paths = ["../whoa-this-does-not-exist"]
         "#)
         .build();
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(101)
                        .with_stderr("\
 [ERROR] failed to update path override `[..]../whoa-this-does-not-exist` \
@@ -932,7 +933,7 @@ fn invalid_path_dep_in_workspace_with_lockfile() {
         .build();
 
     // Generate a lock file
-    assert_that(p.cargo("build"), execs().with_status(0));
+    assert_that!(p.cargo("build"), execs().with_status(0));
 
     // Change the dependency on `bar` to an invalid path
     File::create(&p.root().join("foo/Cargo.toml")).unwrap().write_all(br#"
@@ -947,7 +948,7 @@ fn invalid_path_dep_in_workspace_with_lockfile() {
 
     // Make sure we get a nice error. In the past this actually stack
     // overflowed!
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(101)
                        .with_stderr("\
 error: no matching package named `bar` found (required by `foo`)
@@ -980,9 +981,9 @@ fn workspace_produces_rlib() {
         .file("foo/src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("build"), execs().with_status(0));
+    assert_that!(p.cargo("build"), execs().with_status(0));
 
-    assert_that(&p.root().join("target/debug/libtop.rlib"), existing_file());
-    assert_that(&p.root().join("target/debug/libfoo.rlib"), existing_file());
+    assert_that!(&p.root().join("target/debug/libtop.rlib"), existing_file());
+    assert_that!(&p.root().join("target/debug/libfoo.rlib"), existing_file());
 
 }

--- a/tests/plugins.rs
+++ b/tests/plugins.rs
@@ -1,4 +1,5 @@
 extern crate cargotest;
+#[macro_use]
 extern crate hamcrest;
 
 use std::fs;
@@ -6,7 +7,7 @@ use std::env;
 
 use cargotest::{is_nightly, rustc_host};
 use cargotest::support::{project, execs};
-use hamcrest::assert_that;
+use hamcrest::prelude::*;
 
 #[test]
 fn plugin_to_the_max() {
@@ -81,9 +82,9 @@ fn plugin_to_the_max() {
         .file("src/lib.rs", "pub fn baz() -> i32 { 1 }")
         .build();
 
-    assert_that(foo.cargo("build"),
+    assert_that!(foo.cargo("build"),
                 execs().with_status(0));
-    assert_that(foo.cargo("doc"),
+    assert_that!(foo.cargo("doc"),
                 execs().with_status(0));
 }
 
@@ -168,7 +169,7 @@ fn plugin_with_dynamic_native_dependency() {
         "#)
         .build();
 
-    assert_that(build.cargo("build"),
+    assert_that!(build.cargo("build"),
                 execs().with_status(0));
 
     let src = workspace.root().join("target/debug");
@@ -178,7 +179,7 @@ fn plugin_with_dynamic_native_dependency() {
             lib.ends_with(env::consts::DLL_SUFFIX)
     }).unwrap();
 
-    assert_that(foo.cargo("build").env("SRC", &lib).arg("-v"),
+    assert_that!(foo.cargo("build").env("SRC", &lib).arg("-v"),
                 execs().with_status(0));
 }
 
@@ -202,7 +203,7 @@ fn plugin_integration() {
         .file("tests/it_works.rs", "")
         .build();
 
-    assert_that(p.cargo("test").arg("-v"),
+    assert_that!(p.cargo("test").arg("-v"),
                 execs().with_status(0));
 }
 
@@ -237,7 +238,7 @@ fn doctest_a_plugin() {
         "#)
         .build();
 
-    assert_that(p.cargo("test").arg("-v"),
+    assert_that!(p.cargo("test").arg("-v"),
                 execs().with_status(0));
 }
 
@@ -277,7 +278,7 @@ fn native_plugin_dependency_with_custom_ar_linker() {
         "#, target))
         .build();
 
-    assert_that(bar.cargo("build").arg("--verbose"),
+    assert_that!(bar.cargo("build").arg("--verbose"),
                 execs().with_stderr_contains("\
 [COMPILING] foo v0.0.1 ([..])
 [RUNNING] `rustc [..] -C ar=nonexistent-ar -C linker=nonexistent-linker [..]`
@@ -320,7 +321,7 @@ fn panic_abort_plugins() {
         "#)
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0));
 }
 
@@ -373,6 +374,6 @@ fn shared_panic_abort_plugins() {
         .file("bar/src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0));
 }

--- a/tests/proc-macro.rs
+++ b/tests/proc-macro.rs
@@ -1,9 +1,10 @@
 extern crate cargotest;
+#[macro_use]
 extern crate hamcrest;
 
 use cargotest::is_nightly;
 use cargotest::support::{project, execs};
-use hamcrest::assert_that;
+use hamcrest::prelude::*;
 
 #[test]
 fn probe_cfg_before_crate_type_discovery() {
@@ -56,7 +57,7 @@ fn probe_cfg_before_crate_type_discovery() {
         "#)
         .build();
 
-    assert_that(client.cargo("build"),
+    assert_that!(client.cargo("build"),
                 execs().with_status(0));
 }
 
@@ -111,9 +112,9 @@ fn noop() {
         "#)
         .build();
 
-    assert_that(client.cargo("build"),
+    assert_that!(client.cargo("build"),
                 execs().with_status(0));
-    assert_that(client.cargo("build"),
+    assert_that!(client.cargo("build"),
                 execs().with_status(0));
 }
 
@@ -189,9 +190,9 @@ fn impl_and_derive() {
         "#)
         .build();
 
-    assert_that(client.cargo("build"),
+    assert_that!(client.cargo("build"),
                 execs().with_status(0));
-    assert_that(client.cargo("run"),
+    assert_that!(client.cargo("run"),
                 execs().with_status(0).with_stdout("X { success: true }"));
 }
 
@@ -233,7 +234,7 @@ fn plugin_and_proc_macro() {
         .build();
 
     let msg = "  lib.plugin and lib.proc-macro cannot both be true";
-    assert_that(questionable.cargo("build"),
+    assert_that!(questionable.cargo("build"),
                 execs().with_status(101).with_stderr_contains(msg));
 }
 
@@ -274,7 +275,7 @@ fn a() {
 "#)
         .build();
 
-    assert_that(foo.cargo("test"),
+    assert_that!(foo.cargo("test"),
                 execs().with_status(0)
                        .with_stdout_contains("test a ... ok")
                        .with_stdout_contains_n("test [..] ... ok", 2));

--- a/tests/profiles.rs
+++ b/tests/profiles.rs
@@ -1,11 +1,12 @@
 extern crate cargotest;
+#[macro_use]
 extern crate hamcrest;
 
 use std::env;
 
 use cargotest::is_nightly;
 use cargotest::support::{project, execs};
-use hamcrest::assert_that;
+use hamcrest::prelude::*;
 
 #[test]
 fn profile_overrides() {
@@ -24,7 +25,7 @@ fn profile_overrides() {
         "#)
         .file("src/lib.rs", "")
         .build();
-    assert_that(p.cargo("build").arg("-v"),
+    assert_that!(p.cargo("build").arg("-v"),
                 execs().with_status(0).with_stderr(&format!("\
 [COMPILING] test v0.0.0 ({url})
 [RUNNING] `rustc --crate-name test src[/]lib.rs --crate-type lib \
@@ -57,7 +58,7 @@ fn opt_level_override_0() {
         "#)
         .file("src/lib.rs", "")
         .build();
-    assert_that(p.cargo("build").arg("-v"),
+    assert_that!(p.cargo("build").arg("-v"),
                 execs().with_status(0).with_stderr(&format!("\
 [COMPILING] test v0.0.0 ({url})
 [RUNNING] `rustc --crate-name test src[/]lib.rs --crate-type lib \
@@ -87,7 +88,7 @@ fn debug_override_1() {
         "#)
         .file("src/lib.rs", "")
         .build();
-    assert_that(p.cargo("build").arg("-v"),
+    assert_that!(p.cargo("build").arg("-v"),
                 execs().with_status(0).with_stderr(&format!("\
 [COMPILING] test v0.0.0 ({url})
 [RUNNING] `rustc --crate-name test src[/]lib.rs --crate-type lib \
@@ -117,7 +118,7 @@ fn check_opt_level_override(profile_level: &str, rustc_level: &str) {
         "#, level = profile_level))
         .file("src/lib.rs", "")
         .build();
-    assert_that(p.cargo("build").arg("-v"),
+    assert_that!(p.cargo("build").arg("-v"),
                 execs().with_status(0).with_stderr(&format!("\
 [COMPILING] test v0.0.0 ({url})
 [RUNNING] `rustc --crate-name test src[/]lib.rs --crate-type lib \
@@ -186,7 +187,7 @@ fn top_level_overrides_deps() {
         "#)
         .file("foo/src/lib.rs", "")
         .build();
-    assert_that(p.cargo("build").arg("-v").arg("--release"),
+    assert_that!(p.cargo("build").arg("-v").arg("--release"),
                 execs().with_status(0).with_stderr(&format!("\
 [COMPILING] foo v0.0.0 ({url}/foo)
 [RUNNING] `rustc --crate-name foo foo[/]src[/]lib.rs \
@@ -246,7 +247,7 @@ fn profile_in_non_root_manifest_triggers_a_warning() {
         .file("bar/src/main.rs", "fn main() {}")
         .build();
 
-    assert_that(p.cargo("build").cwd(p.root().join("bar")).arg("-v"),
+    assert_that!(p.cargo("build").cwd(p.root().join("bar")).arg("-v"),
                 execs().with_status(0).with_stderr("\
 [WARNING] profiles for the non root package will be ignored, specify profiles at the workspace root:
 package:   [..]
@@ -278,7 +279,7 @@ fn profile_in_virtual_manifest_works() {
         .file("bar/src/main.rs", "fn main() {}")
         .build();
 
-    assert_that(p.cargo("build").cwd(p.root().join("bar")).arg("-v"),
+    assert_that!(p.cargo("build").cwd(p.root().join("bar")).arg("-v"),
                 execs().with_status(0).with_stderr("\
 [COMPILING] bar v0.1.0 ([..])
 [RUNNING] `rustc [..]`

--- a/tests/publish.rs
+++ b/tests/publish.rs
@@ -1,5 +1,6 @@
 extern crate cargotest;
 extern crate flate2;
+#[macro_use]
 extern crate hamcrest;
 extern crate tar;
 
@@ -11,8 +12,8 @@ use cargotest::ChannelChanger;
 use cargotest::support::git::repo;
 use cargotest::support::paths;
 use cargotest::support::{project, execs, publish};
+use hamcrest::prelude::*;
 use flate2::read::GzDecoder;
-use hamcrest::assert_that;
 use tar::Archive;
 
 #[test]
@@ -31,7 +32,7 @@ fn simple() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    assert_that(p.cargo("publish").arg("--no-verify")
+    assert_that!(p.cargo("publish").arg("--no-verify")
                  .arg("--index").arg(publish::registry().to_string()),
                 execs().with_status(0).with_stderr(&format!("\
 [UPDATING] registry `{reg}`
@@ -88,7 +89,7 @@ fn simple_with_host() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    assert_that(p.cargo("publish").arg("--no-verify")
+    assert_that!(p.cargo("publish").arg("--no-verify")
                  .arg("--host").arg(publish::registry().to_string()),
                 execs().with_status(0).with_stderr(&format!("\
 [WARNING] The flag '--host' is no longer valid.
@@ -155,7 +156,7 @@ fn simple_with_index_and_host() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    assert_that(p.cargo("publish").arg("--no-verify")
+    assert_that!(p.cargo("publish").arg("--no-verify")
                  .arg("--index").arg(publish::registry().to_string())
                  .arg("--host").arg(publish::registry().to_string()),
                 execs().with_status(0).with_stderr(&format!("\
@@ -224,7 +225,7 @@ fn git_deps() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    assert_that(p.cargo("publish").arg("-v").arg("--no-verify")
+    assert_that!(p.cargo("publish").arg("-v").arg("--no-verify")
                  .arg("--index").arg(publish::registry().to_string()),
                 execs().with_status(101).with_stderr("\
 [UPDATING] registry [..]
@@ -262,7 +263,7 @@ fn path_dependency_no_version() {
         .file("bar/src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("publish")
+    assert_that!(p.cargo("publish")
                  .arg("--index").arg(publish::registry().to_string()),
                 execs().with_status(101).with_stderr("\
 [UPDATING] registry [..]
@@ -288,7 +289,7 @@ fn unpublishable_crate() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    assert_that(p.cargo("publish")
+    assert_that!(p.cargo("publish")
                  .arg("--index").arg(publish::registry().to_string()),
                 execs().with_status(101).with_stderr("\
 [ERROR] some crates cannot be published.
@@ -318,7 +319,7 @@ fn dont_publish_dirty() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    assert_that(p.cargo("publish")
+    assert_that!(p.cargo("publish")
                  .arg("--index").arg(publish::registry().to_string()),
                 execs().with_status(101).with_stderr("\
 [UPDATING] registry `[..]`
@@ -352,7 +353,7 @@ fn publish_clean() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    assert_that(p.cargo("publish")
+    assert_that!(p.cargo("publish")
                  .arg("--index").arg(publish::registry().to_string()),
                 execs().with_status(0));
 }
@@ -380,7 +381,7 @@ fn publish_in_sub_repo() {
         .file("bar/src/main.rs", "fn main() {}")
         .build();
 
-    assert_that(p.cargo("publish").cwd(p.root().join("bar"))
+    assert_that!(p.cargo("publish").cwd(p.root().join("bar"))
                  .arg("--index").arg(publish::registry().to_string()),
                 execs().with_status(0));
 }
@@ -409,7 +410,7 @@ fn publish_when_ignored() {
         .file(".gitignore", "baz")
         .build();
 
-    assert_that(p.cargo("publish")
+    assert_that!(p.cargo("publish")
                  .arg("--index").arg(publish::registry().to_string()),
                 execs().with_status(0));
 }
@@ -436,7 +437,7 @@ fn ignore_when_crate_ignored() {
             repository = "foo"
         "#)
         .nocommit_file("bar/src/main.rs", "fn main() {}");
-    assert_that(p.cargo("publish").cwd(p.root().join("bar"))
+    assert_that!(p.cargo("publish").cwd(p.root().join("bar"))
                  .arg("--index").arg(publish::registry().to_string()),
                 execs().with_status(0));
 }
@@ -462,7 +463,7 @@ fn new_crate_rejected() {
             repository = "foo"
         "#)
         .nocommit_file("src/main.rs", "fn main() {}");
-    assert_that(p.cargo("publish")
+    assert_that!(p.cargo("publish")
                  .arg("--index").arg(publish::registry().to_string()),
                 execs().with_status(101));
 }
@@ -483,7 +484,7 @@ fn dry_run() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    assert_that(p.cargo("publish").arg("--dry-run")
+    assert_that!(p.cargo("publish").arg("--dry-run")
                  .arg("--index").arg(publish::registry().to_string()),
                 execs().with_status(0).with_stderr(&format!("\
 [UPDATING] registry `[..]`
@@ -521,7 +522,7 @@ fn block_publish_feature_not_enabled() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    assert_that(p.cargo("publish").masquerade_as_nightly_cargo()
+    assert_that!(p.cargo("publish").masquerade_as_nightly_cargo()
                  .arg("--registry").arg("alternative").arg("-Zunstable-options"),
                 execs().with_status(101).with_stderr("\
 error: failed to parse manifest at `[..]`
@@ -557,7 +558,7 @@ fn registry_not_in_publish_list() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    assert_that(p.cargo("publish").masquerade_as_nightly_cargo()
+    assert_that!(p.cargo("publish").masquerade_as_nightly_cargo()
                  .arg("--registry").arg("alternative").arg("-Zunstable-options"),
                 execs().with_status(101).with_stderr("\
 [ERROR] some crates cannot be published.
@@ -584,7 +585,7 @@ fn publish_empty_list() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    assert_that(p.cargo("publish").masquerade_as_nightly_cargo()
+    assert_that!(p.cargo("publish").masquerade_as_nightly_cargo()
                  .arg("--registry").arg("alternative").arg("-Zunstable-options"),
                 execs().with_status(101).with_stderr("\
 [ERROR] some crates cannot be published.
@@ -615,7 +616,7 @@ fn publish_allowed_registry() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    assert_that(p.cargo("publish").masquerade_as_nightly_cargo()
+    assert_that!(p.cargo("publish").masquerade_as_nightly_cargo()
                  .arg("--registry").arg("alternative").arg("-Zunstable-options"),
                 execs().with_status(0));
 }
@@ -639,7 +640,7 @@ fn block_publish_no_registry() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    assert_that(p.cargo("publish").masquerade_as_nightly_cargo()
+    assert_that!(p.cargo("publish").masquerade_as_nightly_cargo()
                  .arg("--index").arg(publish::registry().to_string()),
                 execs().with_status(101).with_stderr("\
 [ERROR] some crates cannot be published.

--- a/tests/read-manifest.rs
+++ b/tests/read-manifest.rs
@@ -1,8 +1,9 @@
 extern crate cargotest;
+#[macro_use]
 extern crate hamcrest;
 
 use cargotest::support::{project, execs, main_file, basic_bin_manifest};
-use hamcrest::{assert_that};
+use hamcrest::prelude::*;
 
 static MANIFEST_OUTPUT: &'static str = r#"
 {
@@ -31,7 +32,7 @@ fn cargo_read_manifest_path_to_cargo_toml_relative() {
         .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
         .build();
 
-    assert_that(p.cargo("read-manifest")
+    assert_that!(p.cargo("read-manifest")
                  .arg("--manifest-path").arg("foo/Cargo.toml")
                  .cwd(p.root().parent().unwrap()),
                 execs().with_status(0)
@@ -45,7 +46,7 @@ fn cargo_read_manifest_path_to_cargo_toml_absolute() {
         .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
         .build();
 
-    assert_that(p.cargo("read-manifest")
+    assert_that!(p.cargo("read-manifest")
                  .arg("--manifest-path").arg(p.root().join("Cargo.toml"))
                  .cwd(p.root().parent().unwrap()),
                 execs().with_status(0)
@@ -59,7 +60,7 @@ fn cargo_read_manifest_path_to_cargo_toml_parent_relative() {
         .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
         .build();
 
-    assert_that(p.cargo("read-manifest")
+    assert_that!(p.cargo("read-manifest")
                  .arg("--manifest-path").arg("foo")
                  .cwd(p.root().parent().unwrap()),
                 execs().with_status(101)
@@ -74,7 +75,7 @@ fn cargo_read_manifest_path_to_cargo_toml_parent_absolute() {
         .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
         .build();
 
-    assert_that(p.cargo("read-manifest")
+    assert_that!(p.cargo("read-manifest")
                  .arg("--manifest-path").arg(p.root())
                  .cwd(p.root().parent().unwrap()),
                 execs().with_status(101)
@@ -89,7 +90,7 @@ fn cargo_read_manifest_cwd() {
         .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
         .build();
 
-    assert_that(p.cargo("read-manifest")
+    assert_that!(p.cargo("read-manifest")
                  .cwd(p.root()),
                 execs().with_status(0)
                        .with_json(MANIFEST_OUTPUT));

--- a/tests/registry.rs
+++ b/tests/registry.rs
@@ -1,5 +1,6 @@
 #[macro_use]
 extern crate cargotest;
+#[macro_use]
 extern crate hamcrest;
 extern crate url;
 
@@ -12,7 +13,7 @@ use cargotest::support::git;
 use cargotest::support::paths::{self, CargoPathExt};
 use cargotest::support::registry::{self, Package};
 use cargotest::support::{project, execs};
-use hamcrest::assert_that;
+use hamcrest::prelude::*;
 use url::Url;
 
 fn registry_path() -> PathBuf { paths::root().join("registry") }
@@ -35,7 +36,7 @@ fn simple() {
 
     Package::new("bar", "0.0.1").publish();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0).with_stderr(&format!("\
 [UPDATING] registry `{reg}`
 [DOWNLOADING] bar v0.0.1 (registry `file://[..]`)
@@ -46,10 +47,10 @@ fn simple() {
         dir = p.url(),
         reg = registry::registry())));
 
-    assert_that(p.cargo("clean"), execs().with_status(0));
+    assert_that!(p.cargo("clean"), execs().with_status(0));
 
     // Don't download a second time
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0).with_stderr(&format!("\
 [COMPILING] bar v0.0.1
 [COMPILING] foo v0.0.1 ({dir})
@@ -76,7 +77,7 @@ fn deps() {
     Package::new("baz", "0.0.1").publish();
     Package::new("bar", "0.0.1").dep("baz", "*").publish();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0).with_stderr(&format!("\
 [UPDATING] registry `{reg}`
 [DOWNLOADING] [..] v0.0.1 (registry `file://[..]`)
@@ -107,7 +108,7 @@ fn nonexistent() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(101).with_stderr("\
 [UPDATING] registry [..]
 [ERROR] no matching package named `nonexistent` found (required by `foo`)
@@ -134,7 +135,7 @@ fn wrong_version() {
     Package::new("foo", "0.0.1").publish();
     Package::new("foo", "0.0.2").publish();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(101).with_stderr_contains("\
 [ERROR] no matching version `>= 1.0.0` found for package `foo` (required by `foo`)
 location searched: registry [..]
@@ -144,7 +145,7 @@ versions found: 0.0.2, 0.0.1
     Package::new("foo", "0.0.3").publish();
     Package::new("foo", "0.0.4").publish();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(101).with_stderr_contains("\
 [ERROR] no matching version `>= 1.0.0` found for package `foo` (required by `foo`)
 location searched: registry [..]
@@ -171,7 +172,7 @@ fn bad_cksum() {
     pkg.publish();
     t!(File::create(&pkg.archive_dst()));
 
-    assert_that(p.cargo("build").arg("-v"),
+    assert_that!(p.cargo("build").arg("-v"),
                 execs().with_status(101).with_stderr("\
 [UPDATING] registry [..]
 [DOWNLOADING] bad-cksum [..]
@@ -202,7 +203,7 @@ fn update_registry() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(101).with_stderr_contains("\
 [ERROR] no matching package named `notyet` found (required by `foo`)
 location searched: registry [..]
@@ -211,7 +212,7 @@ version required: >= 0.0.0
 
     Package::new("notyet", "0.0.1").publish();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0).with_stderr(&format!("\
 [UPDATING] registry `{reg}`
 [DOWNLOADING] notyet v0.0.1 (registry `file://[..]`)
@@ -251,7 +252,7 @@ fn package_with_path_deps() {
         .file("notyet/src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("package").arg("-v"),
+    assert_that!(p.cargo("package").arg("-v"),
                 execs().with_status(101).with_stderr_contains("\
 [ERROR] failed to verify package tarball
 
@@ -263,7 +264,7 @@ version required: ^0.0.1
 
     Package::new("notyet", "0.0.1").publish();
 
-    assert_that(p.cargo("package"),
+    assert_that!(p.cargo("package"),
                 execs().with_status(0).with_stderr(format!("\
 [PACKAGING] foo v0.0.1 ({dir})
 [VERIFYING] foo v0.0.1 ({dir})
@@ -292,7 +293,7 @@ fn lockfile_locks() {
 
     Package::new("bar", "0.0.1").publish();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0).with_stderr(&format!("\
 [UPDATING] registry `[..]`
 [DOWNLOADING] bar v0.0.1 (registry `file://[..]`)
@@ -305,7 +306,7 @@ fn lockfile_locks() {
     p.root().move_into_the_past();
     Package::new("bar", "0.0.2").publish();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0).with_stdout(""));
 }
 
@@ -327,7 +328,7 @@ fn lockfile_locks_transitively() {
     Package::new("baz", "0.0.1").publish();
     Package::new("bar", "0.0.1").dep("baz", "*").publish();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0).with_stderr(&format!("\
 [UPDATING] registry `[..]`
 [DOWNLOADING] [..] v0.0.1 (registry `file://[..]`)
@@ -343,7 +344,7 @@ fn lockfile_locks_transitively() {
     Package::new("baz", "0.0.2").publish();
     Package::new("bar", "0.0.2").dep("baz", "*").publish();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0).with_stdout(""));
 }
 
@@ -367,7 +368,7 @@ fn yanks_are_not_used() {
     Package::new("bar", "0.0.1").dep("baz", "*").publish();
     Package::new("bar", "0.0.2").dep("baz", "*").yanked(true).publish();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0).with_stderr(&format!("\
 [UPDATING] registry `[..]`
 [DOWNLOADING] [..] v0.0.1 (registry `file://[..]`)
@@ -399,7 +400,7 @@ fn relying_on_a_yank_is_bad() {
     Package::new("baz", "0.0.2").yanked(true).publish();
     Package::new("bar", "0.0.1").dep("baz", "=0.0.2").publish();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(101).with_stderr_contains("\
 [ERROR] no matching version `= 0.0.2` found for package `baz` (required by `bar`)
 location searched: registry [..]
@@ -424,17 +425,17 @@ fn yanks_in_lockfiles_are_ok() {
 
     Package::new("bar", "0.0.1").publish();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0));
 
     registry::registry_path().join("3").rm_rf();
 
     Package::new("bar", "0.0.1").yanked(true).publish();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0).with_stdout(""));
 
-    assert_that(p.cargo("update"),
+    assert_that!(p.cargo("update"),
                 execs().with_status(101).with_stderr_contains("\
 [ERROR] no matching package named `bar` found (required by `foo`)
 location searched: registry [..]
@@ -458,12 +459,12 @@ fn update_with_lockfile_if_packages_missing() {
         .build();
 
     Package::new("bar", "0.0.1").publish();
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0));
     p.root().move_into_the_past();
 
     paths::home().join(".cargo/registry").rm_rf();
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0).with_stderr("\
 [UPDATING] registry `[..]`
 [DOWNLOADING] bar v0.0.1 (registry `file://[..]`)
@@ -488,14 +489,14 @@ fn update_lockfile() {
 
     println!("0.0.1");
     Package::new("bar", "0.0.1").publish();
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0));
 
     Package::new("bar", "0.0.2").publish();
     Package::new("bar", "0.0.3").publish();
     paths::home().join(".cargo/registry").rm_rf();
     println!("0.0.2 update");
-    assert_that(p.cargo("update")
+    assert_that!(p.cargo("update")
                  .arg("-p").arg("bar").arg("--precise").arg("0.0.2"),
                 execs().with_status(0).with_stderr("\
 [UPDATING] registry `[..]`
@@ -503,7 +504,7 @@ fn update_lockfile() {
 "));
 
     println!("0.0.2 build");
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0).with_stderr(&format!("\
 [DOWNLOADING] [..] v0.0.2 (registry `file://[..]`)
 [COMPILING] bar v0.0.2
@@ -513,7 +514,7 @@ fn update_lockfile() {
    dir = p.url())));
 
     println!("0.0.3 update");
-    assert_that(p.cargo("update")
+    assert_that!(p.cargo("update")
                  .arg("-p").arg("bar"),
                 execs().with_status(0).with_stderr("\
 [UPDATING] registry `[..]`
@@ -521,7 +522,7 @@ fn update_lockfile() {
 "));
 
     println!("0.0.3 build");
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0).with_stderr(&format!("\
 [DOWNLOADING] [..] v0.0.3 (registry `file://[..]`)
 [COMPILING] bar v0.0.3
@@ -533,7 +534,7 @@ fn update_lockfile() {
    println!("new dependencies update");
    Package::new("bar", "0.0.4").dep("spam", "0.2.5").publish();
    Package::new("spam", "0.2.5").publish();
-   assert_that(p.cargo("update")
+   assert_that!(p.cargo("update")
                 .arg("-p").arg("bar"),
                execs().with_status(0).with_stderr("\
 [UPDATING] registry `[..]`
@@ -543,7 +544,7 @@ fn update_lockfile() {
 
    println!("new dependencies update");
    Package::new("bar", "0.0.5").publish();
-   assert_that(p.cargo("update")
+   assert_that!(p.cargo("update")
                 .arg("-p").arg("bar"),
                execs().with_status(0).with_stderr("\
 [UPDATING] registry `[..]`
@@ -570,7 +571,7 @@ fn dev_dependency_not_used() {
     Package::new("baz", "0.0.1").publish();
     Package::new("bar", "0.0.1").dev_dep("baz", "*").publish();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0).with_stderr(&format!("\
 [UPDATING] registry `[..]`
 [DOWNLOADING] [..] v0.0.1 (registry `file://[..]`)
@@ -585,7 +586,7 @@ fn dev_dependency_not_used() {
 fn login_with_no_cargo_dir() {
     let home = paths::home().join("new-home");
     t!(fs::create_dir(&home));
-    assert_that(cargo_process().arg("login").arg("foo").arg("-v"),
+    assert_that!(cargo_process().arg("login").arg("foo").arg("-v"),
                 execs().with_status(0));
 }
 
@@ -594,11 +595,11 @@ fn login_with_differently_sized_token() {
     // Verify that the configuration file gets properly trunchated.
     let home = paths::home().join("new-home");
     t!(fs::create_dir(&home));
-    assert_that(cargo_process().arg("login").arg("lmaolmaolmao").arg("-v"),
+    assert_that!(cargo_process().arg("login").arg("lmaolmaolmao").arg("-v"),
                 execs().with_status(0));
-    assert_that(cargo_process().arg("login").arg("lmao").arg("-v"),
+    assert_that!(cargo_process().arg("login").arg("lmao").arg("-v"),
                 execs().with_status(0));
-    assert_that(cargo_process().arg("login").arg("lmaolmaolmao").arg("-v"),
+    assert_that!(cargo_process().arg("login").arg("lmaolmaolmao").arg("-v"),
                 execs().with_status(0));
 }
 
@@ -619,7 +620,7 @@ fn bad_license_file() {
             fn main() {}
         "#)
         .build();
-    assert_that(p.cargo("publish")
+    assert_that!(p.cargo("publish")
                  .arg("-v")
                  .arg("--index").arg(registry().to_string()),
                 execs().with_status(101)
@@ -654,7 +655,7 @@ fn updating_a_dep() {
 
     Package::new("bar", "0.0.1").publish();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0).with_stderr(&format!("\
 [UPDATING] registry `[..]`
 [DOWNLOADING] bar v0.0.1 (registry `file://[..]`)
@@ -677,7 +678,7 @@ fn updating_a_dep() {
     Package::new("bar", "0.1.0").publish();
 
     println!("second");
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0).with_stderr(&format!("\
 [UPDATING] registry `[..]`
 [DOWNLOADING] bar v0.1.0 (registry `file://[..]`)
@@ -722,7 +723,7 @@ fn git_and_registry_dep() {
     Package::new("a", "0.0.1").publish();
 
     p.root().move_into_the_past();
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0).with_stderr(&format!("\
 [UPDATING] [..]
 [UPDATING] [..]
@@ -736,7 +737,7 @@ fn git_and_registry_dep() {
     p.root().move_into_the_past();
 
     println!("second");
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0).with_stdout(""));
 }
 
@@ -757,7 +758,7 @@ fn update_publish_then_update() {
         .file("src/main.rs", "fn main() {}")
         .build();
     Package::new("a", "0.1.0").publish();
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0));
 
     // Next, publish a new package and back up the copy of the registry we just
@@ -781,7 +782,7 @@ fn update_publish_then_update() {
         "#)
         .file("src/main.rs", "fn main() {}")
         .build();
-    assert_that(p2.cargo("build"),
+    assert_that!(p2.cargo("build"),
                 execs().with_status(0));
     registry.rm_rf();
     t!(fs::rename(&backup, &registry));
@@ -790,7 +791,7 @@ fn update_publish_then_update() {
     // Finally, build the first project again (with our newer Cargo.lock) which
     // should force an update of the old registry, download the new crate, and
     // then build everything again.
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0).with_stderr(&format!("\
 [UPDATING] [..]
 [DOWNLOADING] a v0.1.1 (registry `file://[..]`)
@@ -819,7 +820,7 @@ fn fetch_downloads() {
 
     Package::new("a", "0.1.0").publish();
 
-    assert_that(p.cargo("fetch"),
+    assert_that!(p.cargo("fetch"),
                 execs().with_status(0)
                        .with_stderr("\
 [UPDATING] registry `[..]`
@@ -845,19 +846,19 @@ fn update_transitive_dependency() {
     Package::new("a", "0.1.0").dep("b", "*").publish();
     Package::new("b", "0.1.0").publish();
 
-    assert_that(p.cargo("fetch"),
+    assert_that!(p.cargo("fetch"),
                 execs().with_status(0));
 
     Package::new("b", "0.1.1").publish();
 
-    assert_that(p.cargo("update").arg("-pb"),
+    assert_that!(p.cargo("update").arg("-pb"),
                 execs().with_status(0)
                        .with_stderr("\
 [UPDATING] registry `[..]`
 [UPDATING] b v0.1.0 -> v0.1.1
 "));
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0)
                        .with_stderr("\
 [DOWNLOADING] b v0.1.1 (registry `file://[..]`)
@@ -890,7 +891,7 @@ fn update_backtracking_ok() {
     Package::new("cookie", "0.1.0").dep("openssl", "0.1").publish();
     Package::new("openssl", "0.1.0").publish();
 
-    assert_that(p.cargo("generate-lockfile"),
+    assert_that!(p.cargo("generate-lockfile"),
                 execs().with_status(0));
 
     Package::new("openssl", "0.1.1").publish();
@@ -898,7 +899,7 @@ fn update_backtracking_ok() {
                                   .dep("cookie", "0.1.0")
                                   .publish();
 
-    assert_that(p.cargo("update").arg("-p").arg("hyper"),
+    assert_that!(p.cargo("update").arg("-p").arg("hyper"),
                 execs().with_status(0)
                        .with_stderr("\
 [UPDATING] registry `[..]`
@@ -926,14 +927,14 @@ fn update_multiple_packages() {
     Package::new("b", "0.1.0").publish();
     Package::new("c", "0.1.0").publish();
 
-    assert_that(p.cargo("fetch"),
+    assert_that!(p.cargo("fetch"),
                 execs().with_status(0));
 
     Package::new("a", "0.1.1").publish();
     Package::new("b", "0.1.1").publish();
     Package::new("c", "0.1.1").publish();
 
-    assert_that(p.cargo("update").arg("-pa").arg("-pb"),
+    assert_that!(p.cargo("update").arg("-pa").arg("-pb"),
                 execs().with_status(0)
                        .with_stderr("\
 [UPDATING] registry `[..]`
@@ -941,14 +942,14 @@ fn update_multiple_packages() {
 [UPDATING] b v0.1.0 -> v0.1.1
 "));
 
-    assert_that(p.cargo("update").arg("-pb").arg("-pc"),
+    assert_that!(p.cargo("update").arg("-pb").arg("-pc"),
                 execs().with_status(0)
                        .with_stderr("\
 [UPDATING] registry `[..]`
 [UPDATING] c v0.1.0 -> v0.1.1
 "));
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0)
                        .with_stderr_contains("\
 [DOWNLOADING] a v0.1.1 (registry `file://[..]`)")
@@ -1004,7 +1005,7 @@ fn bundled_crate_in_registry() {
         .file("bar/src/lib.rs", "")
         .publish();
 
-    assert_that(p.cargo("run"), execs().with_status(0));
+    assert_that!(p.cargo("run"), execs().with_status(0));
 }
 
 #[test]
@@ -1027,8 +1028,8 @@ fn update_same_prefix_oh_my_how_was_this_a_bug() {
         .dep("foobar", "0.2.0")
         .publish();
 
-    assert_that(p.cargo("generate-lockfile"), execs().with_status(0));
-    assert_that(p.cargo("update").arg("-pfoobar").arg("--precise=0.2.0"),
+    assert_that!(p.cargo("generate-lockfile"), execs().with_status(0));
+    assert_that!(p.cargo("update").arg("-pfoobar").arg("--precise=0.2.0"),
                 execs().with_status(0));
 }
 
@@ -1049,7 +1050,7 @@ fn use_semver() {
 
     Package::new("foo", "1.2.3-alpha.0").publish();
 
-    assert_that(p.cargo("build"), execs().with_status(0));
+    assert_that!(p.cargo("build"), execs().with_status(0));
 }
 
 #[test]
@@ -1075,7 +1076,7 @@ fn only_download_relevant() {
     Package::new("bar", "0.1.0").publish();
     Package::new("baz", "0.1.0").publish();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0).with_stderr("\
 [UPDATING] registry `[..]`
 [DOWNLOADING] baz v0.1.0 ([..])
@@ -1105,7 +1106,7 @@ fn resolve_and_backtracking() {
             .publish();
     Package::new("foo", "0.1.0").publish();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0));
 }
 
@@ -1128,7 +1129,7 @@ fn upstream_warnings_on_extra_verbose() {
             .file("src/lib.rs", "fn unused() {}")
             .publish();
 
-    assert_that(p.cargo("build").arg("-vv"),
+    assert_that!(p.cargo("build").arg("-vv"),
                 execs().with_status(0).with_stderr_contains("\
 [..]warning: function is never used[..]
 "));
@@ -1149,7 +1150,7 @@ fn disallow_network() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    assert_that(p.cargo("build").arg("--frozen"),
+    assert_that!(p.cargo("build").arg("--frozen"),
                 execs().with_status(101).with_stderr("\
 error: failed to load source for a dependency on `foo`
 
@@ -1188,7 +1189,7 @@ fn add_dep_dont_update_registry() {
 
     Package::new("remote", "0.3.4").publish();
 
-    assert_that(p.cargo("build"), execs().with_status(0));
+    assert_that!(p.cargo("build"), execs().with_status(0));
 
     t!(t!(File::create(p.root().join("Cargo.toml"))).write_all(br#"
         [project]
@@ -1201,7 +1202,7 @@ fn add_dep_dont_update_registry() {
         remote = "0.3"
     "#));
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0)
                        .with_stderr("\
 [COMPILING] bar v0.5.0 ([..])
@@ -1236,7 +1237,7 @@ fn bump_version_dont_update_registry() {
 
     Package::new("remote", "0.3.4").publish();
 
-    assert_that(p.cargo("build"), execs().with_status(0));
+    assert_that!(p.cargo("build"), execs().with_status(0));
 
     t!(t!(File::create(p.root().join("Cargo.toml"))).write_all(br#"
         [project]
@@ -1248,7 +1249,7 @@ fn bump_version_dont_update_registry() {
         baz = { path = "baz" }
     "#));
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0)
                        .with_stderr("\
 [COMPILING] bar v0.6.0 ([..])
@@ -1273,7 +1274,7 @@ fn old_version_req() {
 
     Package::new("remote", "0.2.0").publish();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0)
                        .with_stderr("\
 warning: parsed version requirement `0.2*` is no longer valid
@@ -1333,7 +1334,7 @@ fn old_version_req_upstream() {
             .publish();
     Package::new("bar", "0.2.0").publish();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0)
                        .with_stderr("\
 [UPDATING] [..]
@@ -1384,7 +1385,7 @@ fn toml_lies_but_index_is_truth() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    assert_that(p.cargo("build").arg("-v"),
+    assert_that!(p.cargo("build").arg("-v"),
                 execs().with_status(0));
 }
 
@@ -1411,7 +1412,7 @@ fn vv_prints_warnings() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    assert_that(p.cargo("build").arg("-vv"),
+    assert_that!(p.cargo("build").arg("-vv"),
                 execs().with_status(0));
 }
 
@@ -1434,7 +1435,7 @@ fn bad_and_or_malicious_packages_rejected() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    assert_that(p.cargo("build").arg("-vv"),
+    assert_that!(p.cargo("build").arg("-vv"),
                 execs().with_status(101)
                        .with_stderr("\
 [UPDATING] [..]

--- a/tests/required-features.rs
+++ b/tests/required-features.rs
@@ -1,10 +1,11 @@
 extern crate cargotest;
+#[macro_use]
 extern crate hamcrest;
 
 use cargotest::is_nightly;
 use cargotest::install::{cargo_home, has_installed_exe};
 use cargotest::support::{project, execs};
-use hamcrest::{assert_that, existing_file, not};
+use hamcrest::prelude::*;
 
 #[test]
 fn build_bin_default_features() {
@@ -39,18 +40,18 @@ fn build_bin_default_features() {
         "#)
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0));
-    assert_that(&p.bin("foo"), existing_file());
+    assert_that!(&p.bin("foo"), existing_file());
 
-    assert_that(p.cargo("build").arg("--no-default-features"),
+    assert_that!(p.cargo("build").arg("--no-default-features"),
                 execs().with_status(0));
 
-    assert_that(p.cargo("build").arg("--bin=foo"),
+    assert_that!(p.cargo("build").arg("--bin=foo"),
                 execs().with_status(0));
-    assert_that(&p.bin("foo"), existing_file());
+    assert_that!(&p.bin("foo"), existing_file());
 
-    assert_that(p.cargo("build").arg("--bin=foo").arg("--no-default-features"),
+    assert_that!(p.cargo("build").arg("--bin=foo").arg("--no-default-features"),
                 execs().with_status(101).with_stderr("\
 error: target `foo` requires the features: `a`
 Consider enabling them by passing e.g. `--features=\"a\"`
@@ -76,9 +77,9 @@ fn build_bin_arg_features() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    assert_that(p.cargo("build").arg("--features").arg("a"),
+    assert_that!(p.cargo("build").arg("--features").arg("a"),
                 execs().with_status(0));
-    assert_that(&p.bin("foo"), existing_file());
+    assert_that!(&p.bin("foo"), existing_file());
 }
 
 #[test]
@@ -110,19 +111,19 @@ fn build_bin_multiple_required_features() {
         .file("src/foo_2.rs", "fn main() {}")
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0));
 
-    assert_that(&p.bin("foo_1"), not(existing_file()));
-    assert_that(&p.bin("foo_2"), existing_file());
+    assert_that!(&p.bin("foo_1"), not(existing_file()));
+    assert_that!(&p.bin("foo_2"), existing_file());
 
-    assert_that(p.cargo("build").arg("--features").arg("c"),
+    assert_that!(p.cargo("build").arg("--features").arg("c"),
                 execs().with_status(0));
 
-    assert_that(&p.bin("foo_1"), existing_file());
-    assert_that(&p.bin("foo_2"), existing_file());
+    assert_that!(&p.bin("foo_1"), existing_file());
+    assert_that!(&p.bin("foo_2"), existing_file());
 
-    assert_that(p.cargo("build").arg("--no-default-features"),
+    assert_that!(p.cargo("build").arg("--no-default-features"),
                 execs().with_status(0));
 }
 
@@ -146,11 +147,11 @@ fn build_example_default_features() {
         .file("examples/foo.rs", "fn main() {}")
         .build();
 
-    assert_that(p.cargo("build").arg("--example=foo"),
+    assert_that!(p.cargo("build").arg("--example=foo"),
                 execs().with_status(0));
-    assert_that(&p.bin("examples/foo"), existing_file());
+    assert_that!(&p.bin("examples/foo"), existing_file());
 
-    assert_that(p.cargo("build").arg("--example=foo").arg("--no-default-features"),
+    assert_that!(p.cargo("build").arg("--example=foo").arg("--no-default-features"),
                 execs().with_status(101).with_stderr("\
 error: target `foo` requires the features: `a`
 Consider enabling them by passing e.g. `--features=\"a\"`
@@ -176,9 +177,9 @@ fn build_example_arg_features() {
         .file("examples/foo.rs", "fn main() {}")
         .build();
 
-    assert_that(p.cargo("build").arg("--example=foo").arg("--features").arg("a"),
+    assert_that!(p.cargo("build").arg("--example=foo").arg("--features").arg("a"),
                 execs().with_status(0));
-    assert_that(&p.bin("examples/foo"), existing_file());
+    assert_that!(&p.bin("examples/foo"), existing_file());
 }
 
 #[test]
@@ -208,34 +209,34 @@ fn build_example_multiple_required_features() {
         .file("examples/foo_2.rs", "fn main() {}")
         .build();
 
-    assert_that(p.cargo("build").arg("--example=foo_1"),
+    assert_that!(p.cargo("build").arg("--example=foo_1"),
                 execs().with_status(101).with_stderr("\
 error: target `foo_1` requires the features: `b`, `c`
 Consider enabling them by passing e.g. `--features=\"b c\"`
 "));
-    assert_that(p.cargo("build").arg("--example=foo_2"),
+    assert_that!(p.cargo("build").arg("--example=foo_2"),
                 execs().with_status(0));
 
-    assert_that(&p.bin("examples/foo_1"), not(existing_file()));
-    assert_that(&p.bin("examples/foo_2"), existing_file());
+    assert_that!(&p.bin("examples/foo_1"), not(existing_file()));
+    assert_that!(&p.bin("examples/foo_2"), existing_file());
 
-    assert_that(p.cargo("build").arg("--example=foo_1")
+    assert_that!(p.cargo("build").arg("--example=foo_1")
                 .arg("--features").arg("c"),
                 execs().with_status(0));
-    assert_that(p.cargo("build").arg("--example=foo_2")
+    assert_that!(p.cargo("build").arg("--example=foo_2")
                 .arg("--features").arg("c"),
                 execs().with_status(0));
 
-    assert_that(&p.bin("examples/foo_1"), existing_file());
-    assert_that(&p.bin("examples/foo_2"), existing_file());
+    assert_that!(&p.bin("examples/foo_1"), existing_file());
+    assert_that!(&p.bin("examples/foo_2"), existing_file());
 
-    assert_that(p.cargo("build").arg("--example=foo_1")
+    assert_that!(p.cargo("build").arg("--example=foo_1")
                 .arg("--no-default-features"),
                 execs().with_status(101).with_stderr("\
 error: target `foo_1` requires the features: `b`, `c`
 Consider enabling them by passing e.g. `--features=\"b c\"`
 "));
-    assert_that(p.cargo("build").arg("--example=foo_2")
+    assert_that!(p.cargo("build").arg("--example=foo_2")
                 .arg("--no-default-features"),
                 execs().with_status(101).with_stderr("\
 error: target `foo_2` requires the features: `a`
@@ -263,25 +264,25 @@ fn test_default_features() {
         .file("tests/foo.rs", "#[test]\nfn test() {}")
         .build();
 
-    assert_that(p.cargo("test"),
+    assert_that!(p.cargo("test"),
                 execs().with_status(0).with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({})
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target[/]debug[/]deps[/]foo-[..][EXE]", p.url()))
                 .with_stdout_contains("test test ... ok"));
 
-    assert_that(p.cargo("test").arg("--no-default-features"),
+    assert_that!(p.cargo("test").arg("--no-default-features"),
                 execs().with_status(0).with_stderr(format!("\
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]"))
                 .with_stdout(""));
 
-    assert_that(p.cargo("test").arg("--test=foo"),
+    assert_that!(p.cargo("test").arg("--test=foo"),
                 execs().with_status(0).with_stderr(format!("\
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target[/]debug[/]deps[/]foo-[..][EXE]"))
                 .with_stdout_contains("test test ... ok"));
 
-    assert_that(p.cargo("test").arg("--test=foo").arg("--no-default-features"),
+    assert_that!(p.cargo("test").arg("--test=foo").arg("--no-default-features"),
                 execs().with_status(101).with_stderr("\
 error: target `foo` requires the features: `a`
 Consider enabling them by passing e.g. `--features=\"a\"`
@@ -307,7 +308,7 @@ fn test_arg_features() {
         .file("tests/foo.rs", "#[test]\nfn test() {}")
         .build();
 
-    assert_that(p.cargo("test").arg("--features").arg("a"),
+    assert_that!(p.cargo("test").arg("--features").arg("a"),
                 execs().with_status(0).with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({})
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
@@ -342,14 +343,14 @@ fn test_multiple_required_features() {
         .file("tests/foo_2.rs", "#[test]\nfn test() {}")
         .build();
 
-    assert_that(p.cargo("test"),
+    assert_that!(p.cargo("test"),
                 execs().with_status(0).with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({})
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target[/]debug[/]deps[/]foo_2-[..][EXE]", p.url()))
                 .with_stdout_contains("test test ... ok"));
 
-    assert_that(p.cargo("test").arg("--features").arg("c"),
+    assert_that!(p.cargo("test").arg("--features").arg("c"),
                 execs().with_status(0).with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({})
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
@@ -357,7 +358,7 @@ fn test_multiple_required_features() {
 [RUNNING] target[/]debug[/]deps[/]foo_2-[..][EXE]", p.url()))
                 .with_stdout_contains_n("test test ... ok", 2));
 
-    assert_that(p.cargo("test").arg("--no-default-features"),
+    assert_that!(p.cargo("test").arg("--no-default-features"),
                 execs().with_status(0).with_stderr(format!("\
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]"))
                 .with_stdout(""));
@@ -393,25 +394,25 @@ fn bench_default_features() {
             }"#)
         .build();
 
-    assert_that(p.cargo("bench"),
+    assert_that!(p.cargo("bench"),
                 execs().with_status(0).with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({})
 [FINISHED] release [optimized] target(s) in [..]
 [RUNNING] target[/]release[/]deps[/]foo-[..][EXE]", p.url()))
                 .with_stdout_contains("test bench ... bench: [..]"));
 
-    assert_that(p.cargo("bench").arg("--no-default-features"),
+    assert_that!(p.cargo("bench").arg("--no-default-features"),
                 execs().with_status(0).with_stderr(format!("\
 [FINISHED] release [optimized] target(s) in [..]"))
                 .with_stdout(""));
 
-    assert_that(p.cargo("bench").arg("--bench=foo"),
+    assert_that!(p.cargo("bench").arg("--bench=foo"),
                 execs().with_status(0).with_stderr(format!("\
 [FINISHED] release [optimized] target(s) in [..]
 [RUNNING] target[/]release[/]deps[/]foo-[..][EXE]"))
                 .with_stdout_contains("test bench ... bench: [..]"));
 
-    assert_that(p.cargo("bench").arg("--bench=foo").arg("--no-default-features"),
+    assert_that!(p.cargo("bench").arg("--bench=foo").arg("--no-default-features"),
                 execs().with_status(101).with_stderr("\
 error: target `foo` requires the features: `a`
 Consider enabling them by passing e.g. `--features=\"a\"`
@@ -447,7 +448,7 @@ fn bench_arg_features() {
             }"#)
         .build();
 
-    assert_that(p.cargo("bench").arg("--features").arg("a"),
+    assert_that!(p.cargo("bench").arg("--features").arg("a"),
                 execs().with_status(0).with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({})
 [FINISHED] release [optimized] target(s) in [..]
@@ -498,14 +499,14 @@ fn bench_multiple_required_features() {
             }"#)
         .build();
 
-    assert_that(p.cargo("bench"),
+    assert_that!(p.cargo("bench"),
                 execs().with_status(0).with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({})
 [FINISHED] release [optimized] target(s) in [..]
 [RUNNING] target[/]release[/]deps[/]foo_2-[..][EXE]", p.url()))
                 .with_stdout_contains("test bench ... bench: [..]"));
 
-    assert_that(p.cargo("bench").arg("--features").arg("c"),
+    assert_that!(p.cargo("bench").arg("--features").arg("c"),
                 execs().with_status(0).with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({})
 [FINISHED] release [optimized] target(s) in [..]
@@ -513,7 +514,7 @@ fn bench_multiple_required_features() {
 [RUNNING] target[/]release[/]deps[/]foo_2-[..][EXE]", p.url()))
                 .with_stdout_contains_n("test bench ... bench: [..]", 2));
 
-    assert_that(p.cargo("bench").arg("--no-default-features"),
+    assert_that!(p.cargo("bench").arg("--no-default-features"),
                 execs().with_status(0).with_stderr(format!("\
 [FINISHED] release [optimized] target(s) in [..]"))
                 .with_stdout(""));
@@ -544,27 +545,27 @@ fn install_default_features() {
         .file("examples/foo.rs", "fn main() {}")
         .build();
 
-    assert_that(p.cargo("install"),
+    assert_that!(p.cargo("install"),
                 execs().with_status(0));
-    assert_that(cargo_home(), has_installed_exe("foo"));
-    assert_that(p.cargo("uninstall").arg("foo"),
+    assert_that!(cargo_home(), has_installed_exe("foo"));
+    assert_that!(p.cargo("uninstall").arg("foo"),
                 execs().with_status(0));
 
-    assert_that(p.cargo("install").arg("--no-default-features"),
+    assert_that!(p.cargo("install").arg("--no-default-features"),
                 execs().with_status(101).with_stderr(format!("\
 [INSTALLING] foo v0.0.1 ([..])
 [FINISHED] release [optimized] target(s) in [..]
 [ERROR] no binaries are available for install using the selected features
 ")));
-    assert_that(cargo_home(), not(has_installed_exe("foo")));
+    assert_that!(cargo_home(), not(has_installed_exe("foo")));
 
-    assert_that(p.cargo("install").arg("--bin=foo"),
+    assert_that!(p.cargo("install").arg("--bin=foo"),
                 execs().with_status(0));
-    assert_that(cargo_home(), has_installed_exe("foo"));
-    assert_that(p.cargo("uninstall").arg("foo"),
+    assert_that!(cargo_home(), has_installed_exe("foo"));
+    assert_that!(p.cargo("uninstall").arg("foo"),
                 execs().with_status(0));
 
-    assert_that(p.cargo("install").arg("--bin=foo").arg("--no-default-features"),
+    assert_that!(p.cargo("install").arg("--bin=foo").arg("--no-default-features"),
                 execs().with_status(101).with_stderr(format!("\
 [INSTALLING] foo v0.0.1 ([..])
 [ERROR] failed to compile `foo v0.0.1 ([..])`, intermediate artifacts can be found at \
@@ -574,15 +575,15 @@ Caused by:
   target `foo` requires the features: `a`
 Consider enabling them by passing e.g. `--features=\"a\"`
 ")));
-    assert_that(cargo_home(), not(has_installed_exe("foo")));
+    assert_that!(cargo_home(), not(has_installed_exe("foo")));
 
-    assert_that(p.cargo("install").arg("--example=foo"),
+    assert_that!(p.cargo("install").arg("--example=foo"),
                 execs().with_status(0));
-    assert_that(cargo_home(), has_installed_exe("foo"));
-    assert_that(p.cargo("uninstall").arg("foo"),
+    assert_that!(cargo_home(), has_installed_exe("foo"));
+    assert_that!(p.cargo("uninstall").arg("foo"),
                 execs().with_status(0));
 
-    assert_that(p.cargo("install").arg("--example=foo").arg("--no-default-features"),
+    assert_that!(p.cargo("install").arg("--example=foo").arg("--no-default-features"),
                 execs().with_status(101).with_stderr(format!("\
 [INSTALLING] foo v0.0.1 ([..])
 [ERROR] failed to compile `foo v0.0.1 ([..])`, intermediate artifacts can be found at \
@@ -592,7 +593,7 @@ Caused by:
   target `foo` requires the features: `a`
 Consider enabling them by passing e.g. `--features=\"a\"`
 ")));
-    assert_that(cargo_home(), not(has_installed_exe("foo")));
+    assert_that!(cargo_home(), not(has_installed_exe("foo")));
 }
 
 #[test]
@@ -614,10 +615,10 @@ fn install_arg_features() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    assert_that(p.cargo("install").arg("--features").arg("a"),
+    assert_that!(p.cargo("install").arg("--features").arg("a"),
                 execs().with_status(0));
-    assert_that(cargo_home(), has_installed_exe("foo"));
-    assert_that(p.cargo("uninstall").arg("foo"),
+    assert_that!(cargo_home(), has_installed_exe("foo"));
+    assert_that!(p.cargo("uninstall").arg("foo"),
                 execs().with_status(0));
 }
 
@@ -650,28 +651,28 @@ fn install_multiple_required_features() {
         .file("src/foo_2.rs", "fn main() {}")
         .build();
 
-    assert_that(p.cargo("install"),
+    assert_that!(p.cargo("install"),
                 execs().with_status(0));
-    assert_that(cargo_home(), not(has_installed_exe("foo_1")));
-    assert_that(cargo_home(), has_installed_exe("foo_2"));
-    assert_that(p.cargo("uninstall").arg("foo"),
-                execs().with_status(0));
-
-    assert_that(p.cargo("install").arg("--features").arg("c"),
-                execs().with_status(0));
-    assert_that(cargo_home(), has_installed_exe("foo_1"));
-    assert_that(cargo_home(), has_installed_exe("foo_2"));
-    assert_that(p.cargo("uninstall").arg("foo"),
+    assert_that!(cargo_home(), not(has_installed_exe("foo_1")));
+    assert_that!(cargo_home(), has_installed_exe("foo_2"));
+    assert_that!(p.cargo("uninstall").arg("foo"),
                 execs().with_status(0));
 
-    assert_that(p.cargo("install").arg("--no-default-features"),
+    assert_that!(p.cargo("install").arg("--features").arg("c"),
+                execs().with_status(0));
+    assert_that!(cargo_home(), has_installed_exe("foo_1"));
+    assert_that!(cargo_home(), has_installed_exe("foo_2"));
+    assert_that!(p.cargo("uninstall").arg("foo"),
+                execs().with_status(0));
+
+    assert_that!(p.cargo("install").arg("--no-default-features"),
                 execs().with_status(101).with_stderr("\
 [INSTALLING] foo v0.0.1 ([..])
 [FINISHED] release [optimized] target(s) in [..]
 [ERROR] no binaries are available for install using the selected features
 "));
-    assert_that(cargo_home(), not(has_installed_exe("foo_1")));
-    assert_that(cargo_home(), not(has_installed_exe("foo_2")));
+    assert_that!(cargo_home(), not(has_installed_exe("foo_1")));
+    assert_that!(cargo_home(), not(has_installed_exe("foo_2")));
 }
 
 #[test]
@@ -724,21 +725,21 @@ fn dep_feature_in_toml() {
         .file("bar/src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0));
 
     // bin
-    assert_that(p.cargo("build").arg("--bin=foo"),
+    assert_that!(p.cargo("build").arg("--bin=foo"),
                 execs().with_status(0));
-    assert_that(&p.bin("foo"), existing_file());
+    assert_that!(&p.bin("foo"), existing_file());
 
     // example
-    assert_that(p.cargo("build").arg("--example=foo"),
+    assert_that!(p.cargo("build").arg("--example=foo"),
                 execs().with_status(0));
-    assert_that(&p.bin("examples/foo"), existing_file());
+    assert_that!(&p.bin("examples/foo"), existing_file());
 
     // test
-    assert_that(p.cargo("test").arg("--test=foo"),
+    assert_that!(p.cargo("test").arg("--test=foo"),
                 execs().with_status(0).with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({})
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
@@ -747,7 +748,7 @@ fn dep_feature_in_toml() {
 
     // bench
     if is_nightly() {
-        assert_that(p.cargo("bench").arg("--bench=foo"),
+        assert_that!(p.cargo("bench").arg("--bench=foo"),
                     execs().with_status(0).with_stderr(format!("\
 [COMPILING] bar v0.0.1 ({0}/bar)
 [COMPILING] foo v0.0.1 ({0})
@@ -757,10 +758,10 @@ fn dep_feature_in_toml() {
     }
 
     // install
-    assert_that(p.cargo("install"),
+    assert_that!(p.cargo("install"),
                 execs().with_status(0));
-    assert_that(cargo_home(), has_installed_exe("foo"));
-    assert_that(p.cargo("uninstall").arg("foo"),
+    assert_that!(cargo_home(), has_installed_exe("foo"));
+    assert_that!(p.cargo("uninstall").arg("foo"),
                 execs().with_status(0));
 }
 
@@ -814,38 +815,38 @@ fn dep_feature_in_cmd_line() {
         .file("bar/src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0));
 
     // bin
-    assert_that(p.cargo("build").arg("--bin=foo"),
+    assert_that!(p.cargo("build").arg("--bin=foo"),
                 execs().with_status(101).with_stderr("\
 error: target `foo` requires the features: `bar/a`
 Consider enabling them by passing e.g. `--features=\"bar/a\"`
 "));
 
-    assert_that(p.cargo("build").arg("--bin=foo").arg("--features").arg("bar/a"),
+    assert_that!(p.cargo("build").arg("--bin=foo").arg("--features").arg("bar/a"),
                 execs().with_status(0));
-    assert_that(&p.bin("foo"), existing_file());
+    assert_that!(&p.bin("foo"), existing_file());
 
     // example
-    assert_that(p.cargo("build").arg("--example=foo"),
+    assert_that!(p.cargo("build").arg("--example=foo"),
                 execs().with_status(101).with_stderr("\
 error: target `foo` requires the features: `bar/a`
 Consider enabling them by passing e.g. `--features=\"bar/a\"`
 "));
 
-    assert_that(p.cargo("build").arg("--example=foo").arg("--features").arg("bar/a"),
+    assert_that!(p.cargo("build").arg("--example=foo").arg("--features").arg("bar/a"),
                 execs().with_status(0));
-    assert_that(&p.bin("examples/foo"), existing_file());
+    assert_that!(&p.bin("examples/foo"), existing_file());
 
     // test
-    assert_that(p.cargo("test"),
+    assert_that!(p.cargo("test"),
                 execs().with_status(0).with_stderr(format!("\
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]"))
                 .with_stdout(""));
 
-    assert_that(p.cargo("test").arg("--test=foo").arg("--features").arg("bar/a"),
+    assert_that!(p.cargo("test").arg("--test=foo").arg("--features").arg("bar/a"),
                 execs().with_status(0).with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({})
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
@@ -854,12 +855,12 @@ Consider enabling them by passing e.g. `--features=\"bar/a\"`
 
     // bench
     if is_nightly() {
-        assert_that(p.cargo("bench"),
+        assert_that!(p.cargo("bench"),
                     execs().with_status(0).with_stderr(format!("\
 [FINISHED] release [optimized] target(s) in [..]"))
                     .with_stdout(""));
 
-        assert_that(p.cargo("bench").arg("--bench=foo").arg("--features").arg("bar/a"),
+        assert_that!(p.cargo("bench").arg("--bench=foo").arg("--features").arg("bar/a"),
                     execs().with_status(0).with_stderr(format!("\
 [COMPILING] bar v0.0.1 ({0}/bar)
 [COMPILING] foo v0.0.1 ({0})
@@ -869,18 +870,18 @@ Consider enabling them by passing e.g. `--features=\"bar/a\"`
     }
 
     // install
-    assert_that(p.cargo("install"),
+    assert_that!(p.cargo("install"),
                 execs().with_status(101).with_stderr(format!("\
 [INSTALLING] foo v0.0.1 ([..])
 [FINISHED] release [optimized] target(s) in [..]
 [ERROR] no binaries are available for install using the selected features
 ")));
-    assert_that(cargo_home(), not(has_installed_exe("foo")));
+    assert_that!(cargo_home(), not(has_installed_exe("foo")));
 
-    assert_that(p.cargo("install").arg("--features").arg("bar/a"),
+    assert_that!(p.cargo("install").arg("--features").arg("bar/a"),
                 execs().with_status(0));
-    assert_that(cargo_home(), has_installed_exe("foo"));
-    assert_that(p.cargo("uninstall").arg("foo"),
+    assert_that!(cargo_home(), has_installed_exe("foo"));
+    assert_that!(p.cargo("uninstall").arg("foo"),
                 execs().with_status(0));
 }
 
@@ -906,27 +907,27 @@ fn test_skips_compiling_bin_with_missing_required_features() {
         .file("benches/foo.rs", "")
         .build();
 
-    assert_that(p.cargo("test"),
+    assert_that!(p.cargo("test"),
                 execs().with_status(0).with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({})
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target[/]debug[/]deps[/]foo-[..][EXE]", p.url()))
                 .with_stdout_contains("running 0 tests"));
 
-    assert_that(p.cargo("test").arg("--features").arg("a").arg("-j").arg("1"),
+    assert_that!(p.cargo("test").arg("--features").arg("a").arg("-j").arg("1"),
                 execs().with_status(101).with_stderr_contains(format!("\
 [COMPILING] foo v0.0.1 ({})
 error[E0463]: can't find crate for `bar`", p.url())));
 
     if is_nightly() {
-        assert_that(p.cargo("bench"),
+        assert_that!(p.cargo("bench"),
                     execs().with_status(0).with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({})
 [FINISHED] release [optimized] target(s) in [..]
 [RUNNING] target[/]release[/]deps[/]foo-[..][EXE]", p.url()))
                     .with_stdout_contains("running 0 tests"));
 
-        assert_that(p.cargo("bench").arg("--features").arg("a").arg("-j").arg("1"),
+        assert_that!(p.cargo("bench").arg("--features").arg("a").arg("-j").arg("1"),
                     execs().with_status(101).with_stderr_contains(format!("\
 [COMPILING] foo v0.0.1 ({})
 error[E0463]: can't find crate for `bar`", p.url())));
@@ -954,13 +955,13 @@ fn run_default() {
         .file("src/main.rs", "extern crate foo; fn main() {}")
         .build();
 
-    assert_that(p.cargo("run"),
+    assert_that!(p.cargo("run"),
                 execs().with_status(101).with_stderr("\
 error: target `foo` requires the features: `a`
 Consider enabling them by passing e.g. `--features=\"a\"`
 "));
 
-    assert_that(p.cargo("run").arg("--features").arg("a"),
+    assert_that!(p.cargo("run").arg("--features").arg("a"),
                 execs().with_status(0));
 }
 
@@ -993,7 +994,7 @@ fn run_default_multiple_required_features() {
         .file("src/foo2.rs", "extern crate foo; fn main() {}")
         .build();
 
-    assert_that(p.cargo("run"),
+    assert_that!(p.cargo("run"),
                 execs().with_status(101).with_stderr("\
 error: `cargo run` requires that a project only have one executable; \
 use the `--bin` option to specify which one to run\navailable binaries: foo1, foo2"));

--- a/tests/resolve.rs
+++ b/tests/resolve.rs
@@ -1,11 +1,12 @@
 #![deny(warnings)]
 
+#[macro_use]
 extern crate hamcrest;
 extern crate cargo;
 
 use std::collections::BTreeMap;
 
-use hamcrest::{assert_that, equal_to, contains, not};
+use hamcrest::prelude::*;
 
 use cargo::core::source::{SourceId, GitReference};
 use cargo::core::dependency::Kind::{self, Development};
@@ -146,7 +147,8 @@ fn test_resolving_empty_dependency_list() {
     let res = resolve(&pkg_id("root"), Vec::new(),
                       &registry(vec![])).unwrap();
 
-    assert_that(&res, equal_to(&names(&["root"])));
+    let names = names(&["root"]);
+    assert_that!(&res, equal_to(&names));
 }
 
 #[test]
@@ -154,7 +156,7 @@ fn test_resolving_only_package() {
     let reg = registry(vec![pkg("foo")]);
     let res = resolve(&pkg_id("root"), vec![dep("foo")], &reg);
 
-    assert_that(&res.unwrap(), contains(names(&["root", "foo"])).exactly());
+    assert_that!(&res.unwrap(), contains(names(&["root", "foo"])).exactly());
 }
 
 #[test]
@@ -162,7 +164,7 @@ fn test_resolving_one_dep() {
     let reg = registry(vec![pkg("foo"), pkg("bar")]);
     let res = resolve(&pkg_id("root"), vec![dep("foo")], &reg);
 
-    assert_that(&res.unwrap(), contains(names(&["root", "foo"])).exactly());
+    assert_that!(&res.unwrap(), contains(names(&["root", "foo"])).exactly());
 }
 
 #[test]
@@ -171,7 +173,7 @@ fn test_resolving_multiple_deps() {
     let res = resolve(&pkg_id("root"), vec![dep("foo"), dep("baz")],
                       &reg).unwrap();
 
-    assert_that(&res, contains(names(&["root", "foo", "baz"])).exactly());
+    assert_that!(&res, contains(names(&["root", "foo", "baz"])).exactly());
 }
 
 #[test]
@@ -179,7 +181,7 @@ fn test_resolving_transitive_deps() {
     let reg = registry(vec![pkg!("foo"), pkg!("bar" => ["foo"])]);
     let res = resolve(&pkg_id("root"), vec![dep("bar")], &reg).unwrap();
 
-    assert_that(&res, contains(names(&["root", "foo", "bar"])));
+    assert_that!(&res, contains(names(&["root", "foo", "bar"])));
 }
 
 #[test]
@@ -188,7 +190,7 @@ fn test_resolving_common_transitive_deps() {
     let res = resolve(&pkg_id("root"), vec![dep("foo"), dep("bar")],
                       &reg).unwrap();
 
-    assert_that(&res, contains(names(&["root", "foo", "bar"])));
+    assert_that!(&res, contains(names(&["root", "foo", "bar"])));
 }
 
 #[test]
@@ -207,7 +209,7 @@ fn test_resolving_with_same_name() {
 
     names.push(pkg_id("root"));
 
-    assert_that(&res.unwrap(), contains(names).exactly());
+    assert_that!(&res.unwrap(), contains(names).exactly());
 }
 
 #[test]
@@ -223,7 +225,7 @@ fn test_resolving_with_dev_deps() {
                       vec![dep("foo"), dep_kind("baz", Development)],
                       &reg).unwrap();
 
-    assert_that(&res, contains(names(&["root", "foo", "bar", "baz"])));
+    assert_that!(&res, contains(names(&["root", "foo", "bar", "baz"])));
 }
 
 #[test]
@@ -235,7 +237,7 @@ fn resolving_with_many_versions() {
 
     let res = resolve(&pkg_id("root"), vec![dep("foo")], &reg).unwrap();
 
-    assert_that(&res, contains(names(&[("root", "1.0.0"),
+    assert_that!(&res, contains(names(&[("root", "1.0.0"),
                                        ("foo", "1.0.2")])));
 }
 
@@ -249,7 +251,7 @@ fn resolving_with_specific_version() {
     let res = resolve(&pkg_id("root"), vec![dep_req("foo", "=1.0.1")],
                       &reg).unwrap();
 
-    assert_that(&res, contains(names(&[("root", "1.0.0"),
+    assert_that!(&res, contains(names(&[("root", "1.0.0"),
                                        ("foo", "1.0.1")])));
 }
 
@@ -266,12 +268,12 @@ fn test_resolving_maximum_version_with_transitive_deps() {
     let res = resolve(&pkg_id("root"), vec![dep_req("foo", "1.0.0"), dep_req("bar", "1.0.0")],
                       &reg).unwrap();
 
-    assert_that(&res, contains(names(&[("root", "1.0.0"),
+    assert_that!(&res, contains(names(&[("root", "1.0.0"),
                                        ("foo", "1.0.0"),
                                        ("bar", "1.0.0"),
                                        ("util", "1.2.2")])));
-    assert_that(&res, not(contains(names(&[("util", "1.0.1")]))));
-    assert_that(&res, not(contains(names(&[("util", "1.1.1")]))));
+    assert_that!(&res, not(contains(names(&[("util", "1.0.1")]))));
+    assert_that!(&res, not(contains(names(&[("util", "1.1.1")]))));
 }
 
 #[test]
@@ -301,7 +303,7 @@ fn resolving_backtrack() {
         dep_req("foo", "^1"),
     ], &reg).unwrap();
 
-    assert_that(&res, contains(names(&[("root", "1.0.0"),
+    assert_that!(&res, contains(names(&[("root", "1.0.0"),
                                        ("foo", "1.0.1"),
                                        ("baz", "1.0.0")])));
 }
@@ -325,7 +327,7 @@ fn resolving_allows_multiple_compatible_versions() {
         dep("bar"),
     ], &reg).unwrap();
 
-    assert_that(&res, contains(names(&[("root", "1.0.0"),
+    assert_that!(&res, contains(names(&[("root", "1.0.0"),
                                        ("foo", "1.0.0"),
                                        ("foo", "2.0.0"),
                                        ("foo", "0.1.0"),
@@ -358,7 +360,7 @@ fn resolving_with_deep_backtracking() {
         dep_req("foo", "1"),
     ], &reg).unwrap();
 
-    assert_that(&res, contains(names(&[("root", "1.0.0"),
+    assert_that!(&res, contains(names(&[("root", "1.0.0"),
                                        ("foo", "1.0.0"),
                                        ("bar", "2.0.0"),
                                        ("baz", "1.0.1")])));
@@ -406,7 +408,7 @@ fn hard_equality() {
         dep_req("foo", "=1.0.0"),
     ], &reg).unwrap();
 
-    assert_that(&res, contains(names(&[("root", "1.0.0"),
+    assert_that!(&res, contains(names(&[("root", "1.0.0"),
                                        ("foo", "1.0.0"),
                                        ("bar", "1.0.0")])));
 }

--- a/tests/run.rs
+++ b/tests/run.rs
@@ -1,10 +1,11 @@
 extern crate cargo;
 extern crate cargotest;
+#[macro_use]
 extern crate hamcrest;
 
 use cargo::util::paths::dylib_path_envvar;
 use cargotest::support::{project, execs, path2url};
-use hamcrest::{assert_that, existing_file};
+use hamcrest::prelude::*;
 
 #[test]
 fn simple() {
@@ -20,7 +21,7 @@ fn simple() {
         "#)
         .build();
 
-    assert_that(p.cargo("run"),
+    assert_that!(p.cargo("run"),
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({dir})
@@ -29,7 +30,7 @@ fn simple() {
                        .with_stdout("\
 hello
 "));
-    assert_that(&p.bin("foo"), existing_file());
+    assert_that!(&p.bin("foo"), existing_file());
 }
 
 #[test]
@@ -47,7 +48,7 @@ fn simple_implicit_main() {
         "#)
         .build();
 
-    assert_that(p.cargo("run").arg("--bins"),
+    assert_that!(p.cargo("run").arg("--bins"),
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({dir})
@@ -56,7 +57,7 @@ fn simple_implicit_main() {
                        .with_stdout("\
 hello
 "));
-    assert_that(&p.bin("foo"), existing_file());
+    assert_that!(&p.bin("foo"), existing_file());
 }
 
 #[test]
@@ -73,7 +74,7 @@ fn simple_quiet() {
         "#)
         .build();
 
-    assert_that(p.cargo("run").arg("-q"),
+    assert_that!(p.cargo("run").arg("-q"),
                 execs().with_status(0).with_stdout("\
 hello
 ")
@@ -94,7 +95,7 @@ fn simple_quiet_and_verbose() {
         "#)
         .build();
 
-    assert_that(p.cargo("run").arg("-q").arg("-v"),
+    assert_that!(p.cargo("run").arg("-q").arg("-v"),
                 execs().with_status(101).with_stderr("\
 [ERROR] cannot set both --verbose and --quiet
 "));
@@ -118,7 +119,7 @@ fn quiet_and_verbose_config() {
         "#)
         .build();
 
-    assert_that(p.cargo("run").arg("-q"),
+    assert_that!(p.cargo("run").arg("-q"),
                 execs().with_status(0));
 }
 
@@ -139,7 +140,7 @@ fn simple_with_args() {
         "#)
         .build();
 
-    assert_that(p.cargo("run").arg("hello").arg("world"),
+    assert_that!(p.cargo("run").arg("hello").arg("world"),
                 execs().with_status(0));
 }
 
@@ -167,7 +168,7 @@ fn exit_code() {
 [ERROR] process didn't exit successfully: `target[..]foo[..]` (exit code: 2)
 ");
     }
-    assert_that(p.cargo("run"),
+    assert_that!(p.cargo("run"),
                 execs().with_status(2).with_stderr(output));
 }
 
@@ -197,7 +198,7 @@ fn exit_code_verbose() {
 ");
     }
 
-    assert_that(p.cargo("run").arg("-v"),
+    assert_that!(p.cargo("run").arg("-v"),
                 execs().with_status(2).with_stderr(output));
 }
 
@@ -213,7 +214,7 @@ fn no_main_file() {
         .file("src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("run"),
+    assert_that!(p.cargo("run"),
                 execs().with_status(101)
                        .with_stderr("[ERROR] a bin target must be available \
                                      for `cargo run`\n"));
@@ -232,7 +233,7 @@ fn no_main_file_implicit() {
         .file("src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("run").arg("--bins"),
+    assert_that!(p.cargo("run").arg("--bins"),
                 execs().with_status(101)
                        .with_stderr("[ERROR] a bin target must be available \
                                      for `cargo run`\n"));
@@ -252,7 +253,7 @@ fn too_many_bins() {
         .file("src/bin/b.rs", "")
         .build();
 
-    assert_that(p.cargo("run"),
+    assert_that!(p.cargo("run"),
                 execs().with_status(101)
                        .with_stderr("[ERROR] `cargo run` requires that a project only \
                                      have one executable; use the `--bin` option \
@@ -274,7 +275,7 @@ fn too_many_bins_implicit() {
         .file("src/bin/b.rs", "")
         .build();
 
-    assert_that(p.cargo("run").arg("--bins"),
+    assert_that!(p.cargo("run").arg("--bins"),
                 execs().with_status(101)
                        .with_stderr("[ERROR] `cargo run` requires that a project only \
                                      have one executable; use the `--bin` option \
@@ -303,7 +304,7 @@ fn specify_name() {
         "#)
         .build();
 
-    assert_that(p.cargo("run").arg("--bin").arg("a").arg("-v"),
+    assert_that!(p.cargo("run").arg("--bin").arg("a").arg("-v"),
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({dir})
@@ -315,7 +316,7 @@ fn specify_name() {
 hello a.rs
 "));
 
-    assert_that(p.cargo("run").arg("--bin").arg("b").arg("-v"),
+    assert_that!(p.cargo("run").arg("--bin").arg("b").arg("-v"),
                 execs().with_status(0)
                        .with_stderr("\
 [COMPILING] foo v0.0.1 ([..])
@@ -345,7 +346,7 @@ fn run_example() {
         "#)
         .build();
 
-    assert_that(p.cargo("run").arg("--example").arg("a"),
+    assert_that!(p.cargo("run").arg("--example").arg("a"),
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({dir})
@@ -375,7 +376,7 @@ fn run_bin_implicit() {
         "#)
         .build();
 
-    assert_that(p.cargo("run").arg("--bins"),
+    assert_that!(p.cargo("run").arg("--bins"),
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({dir})
@@ -405,7 +406,7 @@ fn run_example_implicit() {
         "#)
         .build();
 
-    assert_that(p.cargo("run").arg("--examples"),
+    assert_that!(p.cargo("run").arg("--examples"),
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({dir})
@@ -435,21 +436,21 @@ fn run_with_filename() {
         "#)
         .build();
 
-    assert_that(p.cargo("run").arg("--bin").arg("bin.rs"),
+    assert_that!(p.cargo("run").arg("--bin").arg("bin.rs"),
                 execs().with_status(101).with_stderr("\
 [ERROR] no bin target named `bin.rs`"));
 
-    assert_that(p.cargo("run").arg("--bin").arg("a.rs"),
+    assert_that!(p.cargo("run").arg("--bin").arg("a.rs"),
                 execs().with_status(101).with_stderr("\
 [ERROR] no bin target named `a.rs`
 
 Did you mean `a`?"));
 
-    assert_that(p.cargo("run").arg("--example").arg("example.rs"),
+    assert_that!(p.cargo("run").arg("--example").arg("example.rs"),
                 execs().with_status(101).with_stderr("\
 [ERROR] no example target named `example.rs`"));
 
-    assert_that(p.cargo("run").arg("--example").arg("a.rs"),
+    assert_that!(p.cargo("run").arg("--example").arg("a.rs"),
                 execs().with_status(101).with_stderr("\
 [ERROR] no example target named `a.rs`
 
@@ -473,7 +474,7 @@ fn either_name_or_example() {
         "#)
         .build();
 
-    assert_that(p.cargo("run").arg("--bin").arg("a").arg("--example").arg("b"),
+    assert_that!(p.cargo("run").arg("--bin").arg("a").arg("--example").arg("b"),
                 execs().with_status(101)
                        .with_stderr("[ERROR] `cargo run` can run at most one \
                                      executable, but multiple were \
@@ -501,7 +502,7 @@ fn one_bin_multiple_examples() {
         "#)
         .build();
 
-    assert_that(p.cargo("run"),
+    assert_that!(p.cargo("run"),
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({dir})
@@ -557,7 +558,7 @@ fn example_with_release_flag() {
         "#)
         .build();
 
-    assert_that(p.cargo("run").arg("-v").arg("--release").arg("--example").arg("a"),
+    assert_that!(p.cargo("run").arg("-v").arg("--release").arg("--example").arg("a"),
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] bar v0.0.1 ({url}/bar)
@@ -585,7 +586,7 @@ fn example_with_release_flag() {
 fast1
 fast2"));
 
-    assert_that(p.cargo("run").arg("-v").arg("--example").arg("a"),
+    assert_that!(p.cargo("run").arg("-v").arg("--example").arg("a"),
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] bar v0.0.1 ({url}/bar)
@@ -643,7 +644,7 @@ fn run_dylib_dep() {
         .file("bar/src/lib.rs", "pub fn bar() {}")
         .build();
 
-    assert_that(p.cargo("run").arg("hello").arg("world"),
+    assert_that!(p.cargo("run").arg("hello").arg("world"),
                 execs().with_status(0));
 }
 
@@ -661,7 +662,7 @@ fn release_works() {
         "#)
         .build();
 
-    assert_that(p.cargo("run").arg("--release"),
+    assert_that!(p.cargo("run").arg("--release"),
                 execs().with_status(0).with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({dir})
 [FINISHED] release [optimized] target(s) in [..]
@@ -669,7 +670,7 @@ fn release_works() {
 ",
         dir = path2url(p.root()),
         )));
-    assert_that(&p.release_bin("foo"), existing_file());
+    assert_that!(&p.release_bin("foo"), existing_file());
 }
 
 #[test]
@@ -689,7 +690,7 @@ fn run_bin_different_name() {
         "#)
         .build();
 
-    assert_that(p.cargo("run"), execs().with_status(0));
+    assert_that!(p.cargo("run"), execs().with_status(0));
 }
 
 #[test]
@@ -714,7 +715,7 @@ fn dashes_are_forwarded() {
         "#)
         .build();
 
-    assert_that(p.cargo("run").arg("--").arg("a").arg("--").arg("b"),
+    assert_that!(p.cargo("run").arg("--").arg("a").arg("--").arg("b"),
                 execs().with_status(0));
 }
 
@@ -735,7 +736,7 @@ fn run_from_executable_folder() {
     let cwd = p.root().join("target").join("debug");
     p.cargo("build").exec_with_output().unwrap();
 
-    assert_that(p.cargo("run").cwd(cwd),
+    assert_that!(p.cargo("run").cwd(cwd),
                 execs().with_status(0)
                        .with_stderr("\
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]\n\
@@ -781,7 +782,7 @@ fn run_with_library_paths() {
         "##, dylib_path_envvar(), dir1.display(), dir2.display()))
         .build();
 
-    assert_that(p.cargo("run"), execs().with_status(0));
+    assert_that!(p.cargo("run"), execs().with_status(0));
 }
 
 #[test]
@@ -800,7 +801,7 @@ fn fail_no_extra_verbose() {
         "#)
         .build();
 
-    assert_that(p.cargo("run").arg("-q"),
+    assert_that!(p.cargo("run").arg("-q"),
                 execs().with_status(1)
                        .with_stdout("")
                        .with_stderr(""));
@@ -862,21 +863,21 @@ fn run_multiple_packages() {
         process_builder
     };
 
-    assert_that(cargo().arg("-p").arg("d1"),
+    assert_that!(cargo().arg("-p").arg("d1"),
                 execs().with_status(0).with_stdout("d1"));
 
-    assert_that(cargo().arg("-p").arg("d2").arg("--bin").arg("d2"),
+    assert_that!(cargo().arg("-p").arg("d2").arg("--bin").arg("d2"),
                 execs().with_status(0).with_stdout("d2"));
 
-    assert_that(cargo(),
+    assert_that!(cargo(),
                 execs().with_status(0).with_stdout("foo"));
 
-    assert_that(cargo().arg("-p").arg("d1").arg("-p").arg("d2"),
+    assert_that!(cargo().arg("-p").arg("d1").arg("-p").arg("d2"),
                 execs()
                     .with_status(1)
                     .with_stderr_contains("[ERROR] Invalid arguments."));
 
-    assert_that(cargo().arg("-p").arg("d3"),
+    assert_that!(cargo().arg("-p").arg("d3"),
                 execs()
                     .with_status(101)
                     .with_stderr_contains("[ERROR] package `d3` is not a member of the workspace"));

--- a/tests/rustc.rs
+++ b/tests/rustc.rs
@@ -1,8 +1,9 @@
 extern crate cargotest;
+#[macro_use]
 extern crate hamcrest;
 
 use cargotest::support::{execs, project};
-use hamcrest::assert_that;
+use hamcrest::prelude::*;
 
 const CARGO_RUSTC_ERROR: &'static str =
 "[ERROR] extra arguments to `rustc` can only be passed to one target, consider filtering
@@ -23,7 +24,7 @@ fn build_lib_for_foo() {
         .file("src/lib.rs", r#" "#)
         .build();
 
-    assert_that(p.cargo("rustc").arg("--lib").arg("-v"),
+    assert_that!(p.cargo("rustc").arg("--lib").arg("-v"),
                 execs()
                 .with_status(0)
                 .with_stderr(format!("\
@@ -52,7 +53,7 @@ fn lib() {
         .file("src/lib.rs", r#" "#)
         .build();
 
-    assert_that(p.cargo("rustc").arg("--lib").arg("-v")
+    assert_that!(p.cargo("rustc").arg("--lib").arg("-v")
                 .arg("--").arg("-C").arg("debug-assertions=off"),
                 execs()
                 .with_status(0)
@@ -83,7 +84,7 @@ fn build_main_and_allow_unstable_options() {
         .file("src/lib.rs", r#" "#)
         .build();
 
-    assert_that(p.cargo("rustc").arg("-v").arg("--bin").arg("foo")
+    assert_that!(p.cargo("rustc").arg("-v").arg("--bin").arg("foo")
                 .arg("--").arg("-C").arg("debug-assertions"),
                 execs()
                 .with_status(0)
@@ -122,7 +123,7 @@ fn fails_when_trying_to_build_main_and_lib_with_args() {
         .file("src/lib.rs", r#" "#)
         .build();
 
-    assert_that(p.cargo("rustc").arg("-v")
+    assert_that!(p.cargo("rustc").arg("-v")
                 .arg("--").arg("-C").arg("debug-assertions"),
                 execs()
                 .with_status(101)
@@ -150,7 +151,7 @@ fn build_with_args_to_one_of_multiple_binaries() {
         .file("src/lib.rs", r#" "#)
         .build();
 
-    assert_that(p.cargo("rustc").arg("-v").arg("--bin").arg("bar")
+    assert_that!(p.cargo("rustc").arg("-v").arg("--bin").arg("bar")
                 .arg("--").arg("-C").arg("debug-assertions"),
                 execs()
                 .with_status(0)
@@ -186,7 +187,7 @@ fn fails_with_args_to_all_binaries() {
         .file("src/lib.rs", r#" "#)
         .build();
 
-    assert_that(p.cargo("rustc").arg("-v")
+    assert_that!(p.cargo("rustc").arg("-v")
                 .arg("--").arg("-C").arg("debug-assertions"),
                 execs()
                 .with_status(101)
@@ -208,7 +209,7 @@ fn build_with_args_to_one_of_multiple_tests() {
         .file("src/lib.rs", r#" "#)
         .build();
 
-    assert_that(p.cargo("rustc").arg("-v").arg("--test").arg("bar")
+    assert_that!(p.cargo("rustc").arg("-v").arg("--test").arg("bar")
                 .arg("--").arg("-C").arg("debug-assertions"),
                 execs()
                 .with_status(0)
@@ -254,7 +255,7 @@ fn build_foo_with_bar_dependency() {
         "#)
         .build();
 
-    assert_that(foo.cargo("rustc").arg("-v").arg("--").arg("-C").arg("debug-assertions"),
+    assert_that!(foo.cargo("rustc").arg("-v").arg("--").arg("-C").arg("debug-assertions"),
                 execs()
                 .with_status(0)
                 .with_stderr(format!("\
@@ -297,7 +298,7 @@ fn build_only_bar_dependency() {
         "#)
         .build();
 
-    assert_that(foo.cargo("rustc").arg("-v").arg("-p").arg("bar")
+    assert_that!(foo.cargo("rustc").arg("-v").arg("-p").arg("bar")
                 .arg("--").arg("-C").arg("debug-assertions"),
                 execs()
                 .with_status(0)
@@ -356,7 +357,7 @@ fn fail_with_multiple_packages() {
         "#)
         .build();
 
-    assert_that(foo.cargo("rustc").arg("-v").arg("-p").arg("bar")
+    assert_that!(foo.cargo("rustc").arg("-v").arg("-p").arg("bar")
                                           .arg("-p").arg("baz"),
                 execs().with_status(1).with_stderr("\
 [ERROR] Invalid arguments.
@@ -392,6 +393,6 @@ fn rustc_with_other_profile() {
         .file("a/src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("rustc").arg("--profile").arg("test"),
+    assert_that!(p.cargo("rustc").arg("--profile").arg("test"),
                 execs().with_status(0));
 }

--- a/tests/rustdoc.rs
+++ b/tests/rustdoc.rs
@@ -1,8 +1,9 @@
 extern crate cargotest;
+#[macro_use]
 extern crate hamcrest;
 
 use cargotest::support::{execs, project};
-use hamcrest::{assert_that};
+use hamcrest::prelude::*;
 
 #[test]
 fn rustdoc_simple() {
@@ -16,7 +17,7 @@ fn rustdoc_simple() {
         .file("src/lib.rs", r#" "#)
         .build();
 
-    assert_that(p.cargo("rustdoc").arg("-v"),
+    assert_that!(p.cargo("rustdoc").arg("-v"),
                 execs()
                 .with_status(0)
                 .with_stderr(format!("\
@@ -40,7 +41,7 @@ fn rustdoc_args() {
         .file("src/lib.rs", r#" "#)
         .build();
 
-    assert_that(p.cargo("rustdoc").arg("-v").arg("--").arg("--cfg=foo"),
+    assert_that!(p.cargo("rustdoc").arg("-v").arg("--").arg("--cfg=foo"),
                 execs()
                 .with_status(0)
                 .with_stderr(format!("\
@@ -84,7 +85,7 @@ fn rustdoc_foo_with_bar_dependency() {
         "#)
         .build();
 
-    assert_that(foo.cargo("rustdoc").arg("-v").arg("--").arg("--cfg=foo"),
+    assert_that!(foo.cargo("rustdoc").arg("-v").arg("--").arg("--cfg=foo"),
                 execs()
                 .with_status(0)
                 .with_stderr(format!("\
@@ -131,7 +132,7 @@ fn rustdoc_only_bar_dependency() {
         "#)
         .build();
 
-    assert_that(foo.cargo("rustdoc").arg("-v").arg("-p").arg("bar")
+    assert_that!(foo.cargo("rustdoc").arg("-v").arg("-p").arg("bar")
                                             .arg("--").arg("--cfg=foo"),
                 execs()
                 .with_status(0)
@@ -161,7 +162,7 @@ fn rustdoc_same_name_documents_lib() {
         .file("src/lib.rs", r#" "#)
         .build();
 
-    assert_that(p.cargo("rustdoc").arg("-v")
+    assert_that!(p.cargo("rustdoc").arg("-v")
                  .arg("--").arg("--cfg=foo"),
                 execs()
                 .with_status(0)

--- a/tests/rustdocflags.rs
+++ b/tests/rustdocflags.rs
@@ -1,8 +1,9 @@
 extern crate cargotest;
+#[macro_use]
 extern crate hamcrest;
 
 use cargotest::support::{project, execs};
-use hamcrest::assert_that;
+use hamcrest::prelude::*;
 
 #[test]
 fn parses_env() {
@@ -16,7 +17,7 @@ fn parses_env() {
         .file("src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("doc").env("RUSTDOCFLAGS", "--cfg=foo").arg("-v"),
+    assert_that!(p.cargo("doc").env("RUSTDOCFLAGS", "--cfg=foo").arg("-v"),
                 execs().with_status(0)
                        .with_stderr_contains("\
 [RUNNING] `rustdoc [..] --cfg=foo[..]`
@@ -39,7 +40,7 @@ fn parses_config() {
         "#)
         .build();
 
-    assert_that(p.cargo("doc").arg("-v"),
+    assert_that!(p.cargo("doc").arg("-v"),
                 execs().with_status(0)
                        .with_stderr_contains("\
 [RUNNING] `rustdoc [..] --cfg foo[..]`
@@ -58,7 +59,7 @@ fn bad_flags() {
         .file("src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("doc").env("RUSTDOCFLAGS", "--bogus"),
+    assert_that!(p.cargo("doc").env("RUSTDOCFLAGS", "--bogus"),
                 execs().with_status(101));
 }
 
@@ -74,13 +75,13 @@ fn rerun() {
         .file("src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("doc").env("RUSTDOCFLAGS", "--cfg=foo"),
+    assert_that!(p.cargo("doc").env("RUSTDOCFLAGS", "--cfg=foo"),
                 execs().with_status(0));
-    assert_that(p.cargo("doc").env("RUSTDOCFLAGS", "--cfg=foo"),
+    assert_that!(p.cargo("doc").env("RUSTDOCFLAGS", "--cfg=foo"),
                 execs().with_status(0).with_stderr("\
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
-    assert_that(p.cargo("doc").env("RUSTDOCFLAGS", "--cfg=bar"),
+    assert_that!(p.cargo("doc").env("RUSTDOCFLAGS", "--cfg=bar"),
                 execs().with_status(0).with_stderr("\
 [DOCUMENTING] foo v0.0.1 ([..])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
@@ -102,7 +103,7 @@ fn rustdocflags_passed_to_rustdoc_through_cargo_test() {
         "#)
         .build();
 
-    assert_that(p.cargo("test").arg("--doc").env("RUSTDOCFLAGS", "--cfg do_not_choke"),
+    assert_that!(p.cargo("test").arg("--doc").env("RUSTDOCFLAGS", "--cfg do_not_choke"),
                 execs().with_status(0));
 }
 
@@ -117,6 +118,6 @@ fn rustdocflags_passed_to_rustdoc_through_cargo_test_only_once() {
         .file("src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("test").arg("--doc").env("RUSTDOCFLAGS", "--markdown-no-toc"),
+    assert_that!(p.cargo("test").arg("--doc").env("RUSTDOCFLAGS", "--markdown-no-toc"),
                 execs().with_status(0));
 }

--- a/tests/rustflags.rs
+++ b/tests/rustflags.rs
@@ -1,4 +1,5 @@
 extern crate cargotest;
+#[macro_use]
 extern crate hamcrest;
 
 use std::io::Write;
@@ -6,7 +7,7 @@ use std::fs::{self, File};
 
 use cargotest::rustc_host;
 use cargotest::support::{project, project_in_home, execs, paths};
-use hamcrest::assert_that;
+use hamcrest::prelude::*;
 
 #[test]
 fn env_rustflags_normal_source() {
@@ -27,18 +28,18 @@ fn env_rustflags_normal_source() {
         .build();
 
     // Use RUSTFLAGS to pass an argument that will generate an error
-    assert_that(p.cargo("build").env("RUSTFLAGS", "-Z bogus")
+    assert_that!(p.cargo("build").env("RUSTFLAGS", "-Z bogus")
                 .arg("--lib"),
                 execs().with_status(101));
-    assert_that(p.cargo("build").env("RUSTFLAGS", "-Z bogus")
+    assert_that!(p.cargo("build").env("RUSTFLAGS", "-Z bogus")
                 .arg("--bin=a"),
                 execs().with_status(101));
-    assert_that(p.cargo("build").env("RUSTFLAGS", "-Z bogus")
+    assert_that!(p.cargo("build").env("RUSTFLAGS", "-Z bogus")
                 .arg("--example=b"),
                 execs().with_status(101));
-    assert_that(p.cargo("test").env("RUSTFLAGS", "-Z bogus"),
+    assert_that!(p.cargo("test").env("RUSTFLAGS", "-Z bogus"),
                 execs().with_status(101));
-    assert_that(p.cargo("bench").env("RUSTFLAGS", "-Z bogus"),
+    assert_that!(p.cargo("bench").env("RUSTFLAGS", "-Z bogus"),
                 execs().with_status(101));
 }
 
@@ -62,7 +63,7 @@ fn env_rustflags_build_script() {
         "#)
         .build();
 
-    assert_that(p.cargo("build").env("RUSTFLAGS", "--cfg foo"),
+    assert_that!(p.cargo("build").env("RUSTFLAGS", "--cfg foo"),
                 execs().with_status(0));
 }
 
@@ -99,7 +100,7 @@ fn env_rustflags_build_script_dep() {
         "#)
         .build();
 
-    assert_that(foo.cargo("build").env("RUSTFLAGS", "--cfg foo"),
+    assert_that!(foo.cargo("build").env("RUSTFLAGS", "--cfg foo"),
                 execs().with_status(0));
 }
 
@@ -125,7 +126,7 @@ fn env_rustflags_plugin() {
         "#)
         .build();
 
-    assert_that(p.cargo("build").env("RUSTFLAGS", "--cfg foo"),
+    assert_that!(p.cargo("build").env("RUSTFLAGS", "--cfg foo"),
                 execs().with_status(0));
 }
 
@@ -167,7 +168,7 @@ fn env_rustflags_plugin_dep() {
         "#)
         .build();
 
-    assert_that(foo.cargo("build").env("RUSTFLAGS", "--cfg foo"),
+    assert_that!(foo.cargo("build").env("RUSTFLAGS", "--cfg foo"),
                 execs().with_status(0));
 }
 
@@ -192,19 +193,19 @@ fn env_rustflags_normal_source_with_target() {
     let host = &rustc_host();
 
     // Use RUSTFLAGS to pass an argument that will generate an error
-    assert_that(p.cargo("build").env("RUSTFLAGS", "-Z bogus")
+    assert_that!(p.cargo("build").env("RUSTFLAGS", "-Z bogus")
                 .arg("--lib").arg("--target").arg(host),
                 execs().with_status(101));
-    assert_that(p.cargo("build").env("RUSTFLAGS", "-Z bogus")
+    assert_that!(p.cargo("build").env("RUSTFLAGS", "-Z bogus")
                 .arg("--bin=a").arg("--target").arg(host),
                 execs().with_status(101));
-    assert_that(p.cargo("build").env("RUSTFLAGS", "-Z bogus")
+    assert_that!(p.cargo("build").env("RUSTFLAGS", "-Z bogus")
                 .arg("--example=b").arg("--target").arg(host),
                 execs().with_status(101));
-    assert_that(p.cargo("test").env("RUSTFLAGS", "-Z bogus")
+    assert_that!(p.cargo("test").env("RUSTFLAGS", "-Z bogus")
                 .arg("--target").arg(host),
                 execs().with_status(101));
-    assert_that(p.cargo("bench").env("RUSTFLAGS", "-Z bogus")
+    assert_that!(p.cargo("bench").env("RUSTFLAGS", "-Z bogus")
                 .arg("--target").arg(host),
                 execs().with_status(101));
 }
@@ -230,7 +231,7 @@ fn env_rustflags_build_script_with_target() {
         .build();
 
     let host = rustc_host();
-    assert_that(p.cargo("build").env("RUSTFLAGS", "--cfg foo")
+    assert_that!(p.cargo("build").env("RUSTFLAGS", "--cfg foo")
                 .arg("--target").arg(host),
                 execs().with_status(0));
 }
@@ -269,7 +270,7 @@ fn env_rustflags_build_script_dep_with_target() {
         .build();
 
     let host = rustc_host();
-    assert_that(foo.cargo("build").env("RUSTFLAGS", "--cfg foo")
+    assert_that!(foo.cargo("build").env("RUSTFLAGS", "--cfg foo")
                 .arg("--target").arg(host),
                 execs().with_status(0));
 }
@@ -297,7 +298,7 @@ fn env_rustflags_plugin_with_target() {
         .build();
 
     let host = rustc_host();
-    assert_that(p.cargo("build").env("RUSTFLAGS", "--cfg foo")
+    assert_that!(p.cargo("build").env("RUSTFLAGS", "--cfg foo")
                 .arg("--target").arg(host),
                 execs().with_status(0));
 }
@@ -341,7 +342,7 @@ fn env_rustflags_plugin_dep_with_target() {
         .build();
 
     let host = rustc_host();
-    assert_that(foo.cargo("build").env("RUSTFLAGS", "--cfg foo")
+    assert_that!(foo.cargo("build").env("RUSTFLAGS", "--cfg foo")
                 .arg("--target").arg(host),
                 execs().with_status(0));
 }
@@ -357,10 +358,10 @@ fn env_rustflags_recompile() {
         .file("src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0));
     // Setting RUSTFLAGS forces a recompile
-    assert_that(p.cargo("build").env("RUSTFLAGS", "-Z bogus"),
+    assert_that!(p.cargo("build").env("RUSTFLAGS", "-Z bogus"),
                 execs().with_status(101));
 }
 
@@ -375,10 +376,10 @@ fn env_rustflags_recompile2() {
         .file("src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("build").env("RUSTFLAGS", "--cfg foo"),
+    assert_that!(p.cargo("build").env("RUSTFLAGS", "--cfg foo"),
                 execs().with_status(0));
     // Setting RUSTFLAGS forces a recompile
-    assert_that(p.cargo("build").env("RUSTFLAGS", "-Z bogus"),
+    assert_that!(p.cargo("build").env("RUSTFLAGS", "-Z bogus"),
                 execs().with_status(101));
 }
 
@@ -393,9 +394,9 @@ fn env_rustflags_no_recompile() {
         .file("src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("build").env("RUSTFLAGS", "--cfg foo"),
+    assert_that!(p.cargo("build").env("RUSTFLAGS", "--cfg foo"),
                 execs().with_status(0));
-    assert_that(p.cargo("build").env("RUSTFLAGS", "--cfg foo"),
+    assert_that!(p.cargo("build").env("RUSTFLAGS", "--cfg foo"),
                 execs().with_stdout("").with_status(0));
 }
 
@@ -421,18 +422,18 @@ fn build_rustflags_normal_source() {
             "#)
         .build();
 
-    assert_that(p.cargo("build")
+    assert_that!(p.cargo("build")
                 .arg("--lib"),
                 execs().with_status(101));
-    assert_that(p.cargo("build")
+    assert_that!(p.cargo("build")
                 .arg("--bin=a"),
                 execs().with_status(101));
-    assert_that(p.cargo("build")
+    assert_that!(p.cargo("build")
                 .arg("--example=b"),
                 execs().with_status(101));
-    assert_that(p.cargo("test"),
+    assert_that!(p.cargo("test"),
                 execs().with_status(101));
-    assert_that(p.cargo("bench"),
+    assert_that!(p.cargo("bench"),
                 execs().with_status(101));
 }
 
@@ -460,7 +461,7 @@ fn build_rustflags_build_script() {
             "#)
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0));
 }
 
@@ -501,7 +502,7 @@ fn build_rustflags_build_script_dep() {
         "#)
         .build();
 
-    assert_that(foo.cargo("build"),
+    assert_that!(foo.cargo("build"),
                 execs().with_status(0));
 }
 
@@ -531,7 +532,7 @@ fn build_rustflags_plugin() {
             "#)
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0));
 }
 
@@ -577,7 +578,7 @@ fn build_rustflags_plugin_dep() {
         "#)
         .build();
 
-    assert_that(foo.cargo("build"),
+    assert_that!(foo.cargo("build"),
                 execs().with_status(0));
 }
 
@@ -606,19 +607,19 @@ fn build_rustflags_normal_source_with_target() {
     let ref host = rustc_host();
 
     // Use RUSTFLAGS to pass an argument that will generate an error
-    assert_that(p.cargo("build")
+    assert_that!(p.cargo("build")
                 .arg("--lib").arg("--target").arg(host),
                 execs().with_status(101));
-    assert_that(p.cargo("build")
+    assert_that!(p.cargo("build")
                 .arg("--bin=a").arg("--target").arg(host),
                 execs().with_status(101));
-    assert_that(p.cargo("build")
+    assert_that!(p.cargo("build")
                 .arg("--example=b").arg("--target").arg(host),
                 execs().with_status(101));
-    assert_that(p.cargo("test")
+    assert_that!(p.cargo("test")
                 .arg("--target").arg(host),
                 execs().with_status(101));
-    assert_that(p.cargo("bench")
+    assert_that!(p.cargo("bench")
                 .arg("--target").arg(host),
                 execs().with_status(101));
 }
@@ -648,7 +649,7 @@ fn build_rustflags_build_script_with_target() {
         .build();
 
     let host = rustc_host();
-    assert_that(p.cargo("build")
+    assert_that!(p.cargo("build")
                 .arg("--target").arg(host),
                 execs().with_status(0));
 }
@@ -691,7 +692,7 @@ fn build_rustflags_build_script_dep_with_target() {
         .build();
 
     let host = rustc_host();
-    assert_that(foo.cargo("build")
+    assert_that!(foo.cargo("build")
                 .arg("--target").arg(host),
                 execs().with_status(0));
 }
@@ -723,7 +724,7 @@ fn build_rustflags_plugin_with_target() {
         .build();
 
     let host = rustc_host();
-    assert_that(p.cargo("build")
+    assert_that!(p.cargo("build")
                 .arg("--target").arg(host),
                 execs().with_status(0));
 }
@@ -771,7 +772,7 @@ fn build_rustflags_plugin_dep_with_target() {
         .build();
 
     let host = rustc_host();
-    assert_that(foo.cargo("build")
+    assert_that!(foo.cargo("build")
                 .arg("--target").arg(host),
                 execs().with_status(0));
 }
@@ -787,7 +788,7 @@ fn build_rustflags_recompile() {
         .file("src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0));
 
     // Setting RUSTFLAGS forces a recompile
@@ -800,7 +801,7 @@ fn build_rustflags_recompile() {
     let mut config_file = File::create(config_file).unwrap();
     config_file.write_all(config.as_bytes()).unwrap();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(101));
 }
 
@@ -815,7 +816,7 @@ fn build_rustflags_recompile2() {
         .file("src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("build").env("RUSTFLAGS", "--cfg foo"),
+    assert_that!(p.cargo("build").env("RUSTFLAGS", "--cfg foo"),
                 execs().with_status(0));
 
     // Setting RUSTFLAGS forces a recompile
@@ -828,7 +829,7 @@ fn build_rustflags_recompile2() {
     let mut config_file = File::create(config_file).unwrap();
     config_file.write_all(config.as_bytes()).unwrap();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(101));
 }
 
@@ -847,9 +848,9 @@ fn build_rustflags_no_recompile() {
             "#)
         .build();
 
-    assert_that(p.cargo("build").env("RUSTFLAGS", "--cfg foo"),
+    assert_that!(p.cargo("build").env("RUSTFLAGS", "--cfg foo"),
                 execs().with_status(0));
-    assert_that(p.cargo("build").env("RUSTFLAGS", "--cfg foo"),
+    assert_that!(p.cargo("build").env("RUSTFLAGS", "--cfg foo"),
                 execs().with_stdout("").with_status(0));
 }
 
@@ -875,7 +876,7 @@ fn build_rustflags_with_home_config() {
         .file("src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("build").arg("-v"),
+    assert_that!(p.cargo("build").arg("-v"),
                 execs().with_status(0));
 }
 
@@ -901,18 +902,18 @@ fn target_rustflags_normal_source() {
             ", rustc_host()))
         .build();
 
-    assert_that(p.cargo("build")
+    assert_that!(p.cargo("build")
                 .arg("--lib"),
                 execs().with_status(101));
-    assert_that(p.cargo("build")
+    assert_that!(p.cargo("build")
                 .arg("--bin=a"),
                 execs().with_status(101));
-    assert_that(p.cargo("build")
+    assert_that!(p.cargo("build")
                 .arg("--example=b"),
                 execs().with_status(101));
-    assert_that(p.cargo("test"),
+    assert_that!(p.cargo("test"),
                 execs().with_status(101));
-    assert_that(p.cargo("bench"),
+    assert_that!(p.cargo("bench"),
                 execs().with_status(101));
 }
 
@@ -935,18 +936,18 @@ fn target_rustflags_precedence() {
             ", rustc_host()))
         .build();
 
-    assert_that(p.cargo("build")
+    assert_that!(p.cargo("build")
                 .arg("--lib"),
                 execs().with_status(101));
-    assert_that(p.cargo("build")
+    assert_that!(p.cargo("build")
                 .arg("--bin=a"),
                 execs().with_status(101));
-    assert_that(p.cargo("build")
+    assert_that!(p.cargo("build")
                 .arg("--example=b"),
                 execs().with_status(101));
-    assert_that(p.cargo("test"),
+    assert_that!(p.cargo("test"),
                 execs().with_status(101));
-    assert_that(p.cargo("bench"),
+    assert_that!(p.cargo("bench"),
                 execs().with_status(101));
 }
 
@@ -968,28 +969,28 @@ fn cfg_rustflags_normal_source() {
             "#, if rustc_host().contains("-windows-") {"windows"} else {"not(windows)"}))
         .build();
 
-    assert_that(p.cargo("build").arg("--lib").arg("-v"),
+    assert_that!(p.cargo("build").arg("--lib").arg("-v"),
                 execs().with_status(0).with_stderr("\
 [COMPILING] foo v0.0.1 ([..])
 [RUNNING] `rustc [..] --cfg bar[..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
     
-    assert_that(p.cargo("build").arg("--bin=a").arg("-v"),
+    assert_that!(p.cargo("build").arg("--bin=a").arg("-v"),
                 execs().with_status(0).with_stderr("\
 [COMPILING] foo v0.0.1 ([..])
 [RUNNING] `rustc [..] --cfg bar[..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
     
-    assert_that(p.cargo("build").arg("--example=b").arg("-v"),
+    assert_that!(p.cargo("build").arg("--example=b").arg("-v"),
                 execs().with_status(0).with_stderr("\
 [COMPILING] foo v0.0.1 ([..])
 [RUNNING] `rustc [..] --cfg bar[..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
     
-    assert_that(p.cargo("test").arg("--no-run").arg("-v"),
+    assert_that!(p.cargo("test").arg("--no-run").arg("-v"),
                 execs().with_status(0).with_stderr("\
 [COMPILING] foo v0.0.1 ([..])
 [RUNNING] `rustc [..] --cfg bar[..]`
@@ -998,7 +999,7 @@ fn cfg_rustflags_normal_source() {
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
     
-    assert_that(p.cargo("bench").arg("--no-run").arg("-v"),
+    assert_that!(p.cargo("bench").arg("--no-run").arg("-v"),
                 execs().with_status(0).with_stderr("\
 [COMPILING] foo v0.0.1 ([..])
 [RUNNING] `rustc [..] --cfg bar[..]`
@@ -1031,28 +1032,28 @@ fn cfg_rustflags_precedence() {
             "#, if rustc_host().contains("-windows-") { "windows" } else { "not(windows)" }))
         .build();
 
-    assert_that(p.cargo("build").arg("--lib").arg("-v"),
+    assert_that!(p.cargo("build").arg("--lib").arg("-v"),
                 execs().with_status(0).with_stderr("\
 [COMPILING] foo v0.0.1 ([..])
 [RUNNING] `rustc [..] --cfg bar[..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
 
-    assert_that(p.cargo("build").arg("--bin=a").arg("-v"),
+    assert_that!(p.cargo("build").arg("--bin=a").arg("-v"),
                 execs().with_status(0).with_stderr("\
 [COMPILING] foo v0.0.1 ([..])
 [RUNNING] `rustc [..] --cfg bar[..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
 
-    assert_that(p.cargo("build").arg("--example=b").arg("-v"),
+    assert_that!(p.cargo("build").arg("--example=b").arg("-v"),
                 execs().with_status(0).with_stderr("\
 [COMPILING] foo v0.0.1 ([..])
 [RUNNING] `rustc [..] --cfg bar[..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
 
-    assert_that(p.cargo("test").arg("--no-run").arg("-v"),
+    assert_that!(p.cargo("test").arg("--no-run").arg("-v"),
                 execs().with_status(0).with_stderr("\
 [COMPILING] foo v0.0.1 ([..])
 [RUNNING] `rustc [..] --cfg bar[..]`
@@ -1061,7 +1062,7 @@ fn cfg_rustflags_precedence() {
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
 
-    assert_that(p.cargo("bench").arg("--no-run").arg("-v"),
+    assert_that!(p.cargo("bench").arg("--no-run").arg("-v"),
                 execs().with_status(0).with_stderr("\
 [COMPILING] foo v0.0.1 ([..])
 [RUNNING] `rustc [..] --cfg bar[..]`
@@ -1087,7 +1088,7 @@ fn target_rustflags_string_and_array_form1() {
             "#)
         .build();
 
-    assert_that(p1.cargo("build").arg("-v"),
+    assert_that!(p1.cargo("build").arg("-v"),
         execs().with_status(0).with_stderr("\
 [COMPILING] foo v0.0.1 ([..])
 [RUNNING] `rustc [..] --cfg foo[..]`
@@ -1107,7 +1108,7 @@ fn target_rustflags_string_and_array_form1() {
             "#)
         .build();
 
-    assert_that(p2.cargo("build").arg("-v"),
+    assert_that!(p2.cargo("build").arg("-v"),
         execs().with_status(0).with_stderr("\
 [COMPILING] foo v0.0.1 ([..])
 [RUNNING] `rustc [..] --cfg foo[..]`
@@ -1131,7 +1132,7 @@ fn target_rustflags_string_and_array_form2() {
         .file("src/lib.rs", "")
         .build();
 
-    assert_that(p1.cargo("build").arg("-v"),
+    assert_that!(p1.cargo("build").arg("-v"),
         execs().with_status(0).with_stderr("\
 [COMPILING] foo v0.0.1 ([..])
 [RUNNING] `rustc [..] --cfg foo[..]`
@@ -1151,7 +1152,7 @@ fn target_rustflags_string_and_array_form2() {
         .file("src/lib.rs", "")
         .build();
 
-    assert_that(p2.cargo("build").arg("-v"),
+    assert_that!(p2.cargo("build").arg("-v"),
         execs().with_status(0).with_stderr("\
 [COMPILING] foo v0.0.1 ([..])
 [RUNNING] `rustc [..] --cfg foo[..]`

--- a/tests/search.rs
+++ b/tests/search.rs
@@ -1,5 +1,6 @@
 extern crate cargo;
 extern crate cargotest;
+#[macro_use]
 extern crate hamcrest;
 extern crate url;
 
@@ -11,7 +12,7 @@ use cargo::util::ProcessBuilder;
 use cargotest::support::execs;
 use cargotest::support::git::repo;
 use cargotest::support::paths;
-use hamcrest::assert_that;
+use hamcrest::prelude::*;
 use url::Url;
 
 fn registry_path() -> PathBuf { paths::root().join("registry") }
@@ -81,7 +82,7 @@ fn simple() {
              .write_all(contents.as_bytes()).unwrap();
     }
 
-    assert_that(cargo_process("search").arg("postgres")
+    assert_that!(cargo_process("search").arg("postgres")
                     .arg("--index").arg(registry().to_string()),
                 execs().with_status(0)
                        .with_stdout_contains("\
@@ -133,7 +134,7 @@ fn simple_with_host() {
              .write_all(contents.as_bytes()).unwrap();
     }
 
-    assert_that(cargo_process("search").arg("postgres")
+    assert_that!(cargo_process("search").arg("postgres")
                     .arg("--host").arg(registry().to_string()),
                 execs().with_status(0)
                        .with_stderr(&format!("\
@@ -199,7 +200,7 @@ fn simple_with_index_and_host() {
              .write_all(contents.as_bytes()).unwrap();
     }
 
-    assert_that(cargo_process("search").arg("postgres")
+    assert_that!(cargo_process("search").arg("postgres")
                     .arg("--index").arg(registry().to_string())
                     .arg("--host").arg(registry().to_string()),
                 execs().with_status(0)
@@ -264,7 +265,7 @@ fn multiple_query_params() {
              .write_all(contents.as_bytes()).unwrap();
     }
 
-    assert_that(cargo_process("search").arg("postgres").arg("sql")
+    assert_that!(cargo_process("search").arg("postgres").arg("sql")
                     .arg("--index").arg(registry().to_string()),
                 execs().with_status(0)
                        .with_stdout_contains("\
@@ -273,8 +274,8 @@ hoare = \"0.1.1\"    # Design by contract style assertions for Rust"));
 
 #[test]
 fn help() {
-    assert_that(cargo_process("search").arg("-h"),
+    assert_that!(cargo_process("search").arg("-h"),
                 execs().with_status(0));
-    assert_that(cargo_process("help").arg("search"),
+    assert_that!(cargo_process("help").arg("search"),
                 execs().with_status(0));
 }

--- a/tests/small-fd-limits.rs
+++ b/tests/small-fd-limits.rs
@@ -1,5 +1,6 @@
 extern crate cargotest;
 extern crate git2;
+#[macro_use]
 extern crate hamcrest;
 extern crate url;
 
@@ -12,7 +13,7 @@ use cargotest::support::{execs, project};
 use cargotest::support::registry::Package;
 use cargotest::support::paths;
 use cargotest::support::git;
-use hamcrest::assert_that;
+use hamcrest::prelude::*;
 
 use url::Url;
 
@@ -38,7 +39,7 @@ fn run_test(path_env: Option<&OsStr>) {
         .build();
     Package::new("bar", "0.1.0").publish();
 
-    assert_that(foo.cargo("build"),
+    assert_that!(foo.cargo("build"),
                 execs().with_status(0));
 
     let index = find_index();
@@ -74,7 +75,7 @@ fn run_test(path_env: Option<&OsStr>) {
         cmd.env("PATH", path);
     }
     cmd.env("RUST_LOG", "trace");
-    assert_that(cmd, execs().with_status(0));
+    assert_that!(cmd, execs().with_status(0));
     let after = find_index().join(".git/objects/pack")
                     .read_dir().unwrap()
                     .count();

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,5 +1,6 @@
 extern crate cargo;
 extern crate cargotest;
+#[macro_use]
 extern crate hamcrest;
 
 use std::fs::File;
@@ -10,7 +11,7 @@ use cargotest::{sleep_ms, is_nightly, rustc_host};
 use cargotest::support::{project, execs, basic_bin_manifest, basic_lib_manifest, cargo_exe};
 use cargotest::support::paths::CargoPathExt;
 use cargotest::support::registry::Package;
-use hamcrest::{assert_that, existing_file, is_not};
+use hamcrest::prelude::*;
 use cargo::util::process;
 
 #[test]
@@ -32,13 +33,13 @@ fn cargo_test_simple() {
             }"#)
         .build();
 
-    assert_that(p.cargo("build"), execs().with_status(0));
-    assert_that(&p.bin("foo"), existing_file());
+    assert_that!(p.cargo("build"), execs().with_status(0));
+    assert_that!(&p.bin("foo"), existing_file());
 
-    assert_that(process(&p.bin("foo")),
+    assert_that!(process(&p.bin("foo")),
                 execs().with_status(0).with_stdout("hello\n"));
 
-    assert_that(p.cargo("test"),
+    assert_that!(p.cargo("test"),
                 execs().with_status(0).with_stderr(format!("\
 [COMPILING] foo v0.5.0 ({})
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
@@ -80,7 +81,7 @@ fn cargo_test_release() {
         .file("bar/src/lib.rs", "pub fn bar() {}")
         .build();
 
-    assert_that(p.cargo("test").arg("-v").arg("--release"),
+    assert_that!(p.cargo("test").arg("-v").arg("--release"),
                 execs().with_status(0).with_stderr(format!("\
 [COMPILING] bar v0.0.1 ({dir}/bar)
 [RUNNING] [..] -C opt-level=3 [..]
@@ -125,11 +126,11 @@ fn cargo_test_overflow_checks() {
             }"#)
         .build();
 
-    assert_that(p.cargo("build").arg("--release"),
+    assert_that!(p.cargo("build").arg("--release"),
                 execs().with_status(0));
-    assert_that(&p.release_bin("foo"), existing_file());
+    assert_that!(&p.release_bin("foo"), existing_file());
 
-    assert_that(process(&p.release_bin("foo")),
+    assert_that!(process(&p.release_bin("foo")),
                 execs().with_status(0).with_stdout(""));
 }
 
@@ -143,7 +144,7 @@ fn cargo_test_verbose() {
         "#)
         .build();
 
-    assert_that(p.cargo("test").arg("-v").arg("hello"),
+    assert_that!(p.cargo("test").arg("-v").arg("hello"),
                 execs().with_status(0).with_stderr(format!("\
 [COMPILING] foo v0.5.0 ({url})
 [RUNNING] `rustc [..] src[/]main.rs [..]`
@@ -202,13 +203,13 @@ fn cargo_test_failing_test_in_bin() {
             }"#)
         .build();
 
-    assert_that(p.cargo("build"), execs().with_status(0));
-    assert_that(&p.bin("foo"), existing_file());
+    assert_that!(p.cargo("build"), execs().with_status(0));
+    assert_that!(&p.bin("foo"), existing_file());
 
-    assert_that(process(&p.bin("foo")),
+    assert_that!(process(&p.bin("foo")),
                 execs().with_status(0).with_stdout("hello\n"));
 
-    assert_that(p.cargo("test"),
+    assert_that!(p.cargo("test"),
                 execs().with_stderr(format!("\
 [COMPILING] foo v0.5.0 ({url})
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
@@ -248,13 +249,13 @@ fn cargo_test_failing_test_in_test() {
             }"#)
         .build();
 
-    assert_that(p.cargo("build"), execs().with_status(0));
-    assert_that(&p.bin("foo"), existing_file());
+    assert_that!(p.cargo("build"), execs().with_status(0));
+    assert_that!(&p.bin("foo"), existing_file());
 
-    assert_that(process(&p.bin("foo")),
+    assert_that!(process(&p.bin("foo")),
                 execs().with_status(0).with_stdout("hello\n"));
 
-    assert_that(p.cargo("test"),
+    assert_that!(p.cargo("test"),
                 execs().with_stderr(format!("\
 [COMPILING] foo v0.5.0 ({url})
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
@@ -290,7 +291,7 @@ fn cargo_test_failing_test_in_lib() {
             }"#)
         .build();
 
-    assert_that(p.cargo("test"),
+    assert_that!(p.cargo("test"),
                 execs().with_stderr(format!("\
 [COMPILING] foo v0.5.0 ({url})
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
@@ -349,7 +350,7 @@ fn test_with_lib_dep() {
         ")
         .build();
 
-    assert_that(p.cargo("test"),
+    assert_that!(p.cargo("test"),
                 execs().with_status(0).with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({})
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
@@ -402,7 +403,7 @@ fn test_with_deep_lib_dep() {
         ")
         .build();
 
-    assert_that(p.cargo("test"),
+    assert_that!(p.cargo("test"),
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ([..])
@@ -441,7 +442,7 @@ fn external_test_explicit() {
         "#)
         .build();
 
-    assert_that(p.cargo("test"),
+    assert_that!(p.cargo("test"),
                 execs().with_status(0).with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({})
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
@@ -472,7 +473,7 @@ fn external_test_named_test() {
         "#)
         .build();
 
-    assert_that(p.cargo("test"),
+    assert_that!(p.cargo("test"),
                 execs().with_status(0))
 }
 
@@ -499,7 +500,7 @@ fn external_test_implicit() {
         "#)
         .build();
 
-    assert_that(p.cargo("test"),
+    assert_that!(p.cargo("test"),
                 execs().with_status(0).with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({})
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
@@ -526,7 +527,7 @@ fn dont_run_examples() {
             fn main() { panic!("Examples should not be run by 'cargo test'"); }
         "#)
         .build();
-    assert_that(p.cargo("test"),
+    assert_that!(p.cargo("test"),
                 execs().with_status(0));
 }
 
@@ -545,7 +546,7 @@ fn pass_through_command_line() {
         ")
         .build();
 
-    assert_that(p.cargo("test").arg("bar"),
+    assert_that!(p.cargo("test").arg("bar"),
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({dir})
@@ -555,7 +556,7 @@ fn pass_through_command_line() {
                        .with_stdout_contains("test bar ... ok")
                        .with_stdout_contains("running 0 tests"));
 
-    assert_that(p.cargo("test").arg("foo"),
+    assert_that!(p.cargo("test").arg("foo"),
                 execs().with_status(0)
                        .with_stderr("\
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
@@ -582,7 +583,7 @@ fn cargo_test_twice() {
     p.cargo("build");
 
     for _ in 0..2 {
-        assert_that(p.cargo("test"),
+        assert_that!(p.cargo("test"),
                     execs().with_status(0));
     }
 }
@@ -613,7 +614,7 @@ fn lib_bin_same_name() {
         ")
         .build();
 
-    assert_that(p.cargo("test"),
+    assert_that!(p.cargo("test"),
                 execs().with_status(0).with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({})
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
@@ -650,7 +651,7 @@ fn lib_with_standard_name() {
         ")
         .build();
 
-    assert_that(p.cargo("test"),
+    assert_that!(p.cargo("test"),
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] syntax v0.0.1 ({dir})
@@ -690,7 +691,7 @@ fn lib_with_standard_name2() {
         ")
         .build();
 
-    assert_that(p.cargo("test"),
+    assert_that!(p.cargo("test"),
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] syntax v0.0.1 ({dir})
@@ -725,7 +726,7 @@ fn lib_without_name() {
         ")
         .build();
 
-    assert_that(p.cargo("test"),
+    assert_that!(p.cargo("test"),
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] syntax v0.0.1 ({dir})
@@ -763,7 +764,7 @@ fn bin_without_name() {
         ")
         .build();
 
-    assert_that(p.cargo("test"),
+    assert_that!(p.cargo("test"),
                 execs().with_status(101)
                        .with_stderr("\
 [ERROR] failed to parse manifest at `[..]`
@@ -809,7 +810,7 @@ fn bench_without_name() {
         ")
         .build();
 
-    assert_that(p.cargo("test"),
+    assert_that!(p.cargo("test"),
                 execs().with_status(101)
                        .with_stderr("\
 [ERROR] failed to parse manifest at `[..]`
@@ -854,7 +855,7 @@ fn test_without_name() {
         "#)
         .build();
 
-    assert_that(p.cargo("test"),
+    assert_that!(p.cargo("test"),
                 execs().with_status(101)
                        .with_stderr("\
 [ERROR] failed to parse manifest at `[..]`
@@ -899,7 +900,7 @@ fn example_without_name() {
         "#)
         .build();
 
-    assert_that(p.cargo("test"),
+    assert_that!(p.cargo("test"),
                 execs().with_status(101)
                        .with_stderr("\
 [ERROR] failed to parse manifest at `[..]`
@@ -982,7 +983,7 @@ fn test_dylib() {
         ")
         .build();
 
-    assert_that(p.cargo("test"),
+    assert_that!(p.cargo("test"),
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] bar v0.0.1 ({dir}/bar)
@@ -993,7 +994,7 @@ fn test_dylib() {
                        .with_stdout_contains_n("test foo ... ok", 2));
 
     p.root().move_into_the_past();
-    assert_that(p.cargo("test"),
+    assert_that!(p.cargo("test"),
                 execs().with_status(0)
                        .with_stderr("\
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
@@ -1019,7 +1020,7 @@ fn test_twice_with_build_cmd() {
         ")
         .build();
 
-    assert_that(p.cargo("test"),
+    assert_that!(p.cargo("test"),
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({dir})
@@ -1029,7 +1030,7 @@ fn test_twice_with_build_cmd() {
                        .with_stdout_contains("test foo ... ok")
                        .with_stdout_contains("running 0 tests"));
 
-    assert_that(p.cargo("test"),
+    assert_that!(p.cargo("test"),
                 execs().with_status(0)
                        .with_stderr("\
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
@@ -1054,7 +1055,7 @@ fn test_then_build() {
         ")
         .build();
 
-    assert_that(p.cargo("test"),
+    assert_that!(p.cargo("test"),
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({dir})
@@ -1064,7 +1065,7 @@ fn test_then_build() {
                        .with_stdout_contains("test foo ... ok")
                        .with_stdout_contains("running 0 tests"));
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0)
                        .with_stdout(""));
 }
@@ -1084,7 +1085,7 @@ fn test_no_run() {
         ")
         .build();
 
-    assert_that(p.cargo("test").arg("--no-run"),
+    assert_that!(p.cargo("test").arg("--no-run"),
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({dir})
@@ -1114,7 +1115,7 @@ fn test_run_specific_bin_target() {
         .file("src/bin2.rs", "#[test] fn test2() { }")
         .build();
 
-    assert_that(prj.cargo("test").arg("--bin").arg("bin2"),
+    assert_that!(prj.cargo("test").arg("--bin").arg("bin2"),
                 execs().with_status(0)
                        .with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({dir})
@@ -1144,7 +1145,7 @@ fn test_run_implicit_bin_target() {
                fn main() { panic!(\"Don't execute me!\"); }")
         .build();
 
-    assert_that(prj.cargo("test").arg("--bins"),
+    assert_that!(prj.cargo("test").arg("--bins"),
                 execs().with_status(0)
                        .with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({dir})
@@ -1168,7 +1169,7 @@ fn test_run_specific_test_target() {
         .file("tests/b.rs", "#[test] fn test_b() { }")
         .build();
 
-    assert_that(prj.cargo("test").arg("--test").arg("b"),
+    assert_that!(prj.cargo("test").arg("--test").arg("b"),
                 execs().with_status(0)
                        .with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({dir})
@@ -1198,7 +1199,7 @@ fn test_run_implicit_test_target() {
                fn main() { panic!(\"Don't execute me!\"); }")
         .build();
 
-    assert_that(prj.cargo("test").arg("--tests"),
+    assert_that!(prj.cargo("test").arg("--tests"),
                 execs().with_status(0)
                        .with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({dir})
@@ -1230,7 +1231,7 @@ fn test_run_implicit_bench_target() {
                fn main() { panic!(\"Don't execute me!\"); }")
         .build();
 
-    assert_that(prj.cargo("test").arg("--benches"),
+    assert_that!(prj.cargo("test").arg("--benches"),
                 execs().with_status(0)
                        .with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({dir})
@@ -1261,7 +1262,7 @@ fn test_run_implicit_example_target() {
                fn main() { panic!(\"Don't execute me!\"); }")
         .build();
 
-    assert_that(prj.cargo("test").arg("--examples"),
+    assert_that!(prj.cargo("test").arg("--examples"),
                 execs().with_status(0)
                        .with_stderr(format!("\
 [COMPILING] foo v0.0.1 ({dir})
@@ -1291,7 +1292,7 @@ fn test_no_harness() {
         .file("foo.rs", "fn main() {}")
         .build();
 
-    assert_that(p.cargo("test").arg("--").arg("--nocapture"),
+    assert_that!(p.cargo("test").arg("--").arg("--nocapture"),
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({dir})
@@ -1347,7 +1348,7 @@ fn selective_testing() {
     let p = p.build();
 
     println!("d1");
-    assert_that(p.cargo("test").arg("-p").arg("d1"),
+    assert_that!(p.cargo("test").arg("-p").arg("d1"),
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] d1 v0.0.1 ({dir}/d1)
@@ -1357,7 +1358,7 @@ fn selective_testing() {
                        .with_stdout_contains_n("running 0 tests", 2));
 
     println!("d2");
-    assert_that(p.cargo("test").arg("-p").arg("d2"),
+    assert_that!(p.cargo("test").arg("-p").arg("d2"),
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] d2 v0.0.1 ({dir}/d2)
@@ -1367,7 +1368,7 @@ fn selective_testing() {
                        .with_stdout_contains_n("running 0 tests", 2));
 
     println!("whole");
-    assert_that(p.cargo("test"),
+    assert_that!(p.cargo("test"),
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({dir})
@@ -1416,8 +1417,8 @@ fn almost_cyclic_but_not_quite() {
         .file("c/src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("build"), execs().with_status(0));
-    assert_that(p.cargo("test"),
+    assert_that!(p.cargo("build"), execs().with_status(0));
+    assert_that!(p.cargo("test"),
                 execs().with_status(0));
 }
 
@@ -1450,9 +1451,9 @@ fn build_then_selective_test() {
         .file("b/src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("build"), execs().with_status(0));
+    assert_that!(p.cargo("build"), execs().with_status(0));
     p.root().move_into_the_past();
-    assert_that(p.cargo("test").arg("-p").arg("b"),
+    assert_that!(p.cargo("test").arg("-p").arg("b"),
                 execs().with_status(0));
 }
 
@@ -1496,9 +1497,9 @@ fn example_dev_dep() {
             }
         "#)
         .build();
-    assert_that(p.cargo("test"),
+    assert_that!(p.cargo("test"),
                 execs().with_status(0));
-    assert_that(p.cargo("run")
+    assert_that!(p.cargo("run")
                  .arg("--example").arg("e1").arg("--release").arg("-v"),
                 execs().with_status(0));
 }
@@ -1534,7 +1535,7 @@ fn selective_testing_with_docs() {
         .file("d1/d1.rs", "");
     let p = p.build();
 
-    assert_that(p.cargo("test").arg("-p").arg("d1"),
+    assert_that!(p.cargo("test").arg("-p").arg("d1"),
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] d1 v0.0.1 ({dir}/d1)
@@ -1557,7 +1558,7 @@ fn example_bin_same_name() {
         .file("examples/foo.rs", r#"fn main() { println!("example"); }"#)
         .build();
 
-    assert_that(p.cargo("test").arg("--no-run").arg("-v"),
+    assert_that!(p.cargo("test").arg("--no-run").arg("-v"),
                 execs().with_status(0)
                        .with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({dir})
@@ -1566,13 +1567,13 @@ fn example_bin_same_name() {
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ", dir = p.url())));
 
-    assert_that(&p.bin("foo"), is_not(existing_file()));
-    assert_that(&p.bin("examples/foo"), existing_file());
+    assert_that!(&p.bin("foo"), is_not(existing_file()));
+    assert_that!(&p.bin("examples/foo"), existing_file());
 
-    assert_that(p.process(&p.bin("examples/foo")),
+    assert_that!(p.process(&p.bin("examples/foo")),
                 execs().with_status(0).with_stdout("example\n"));
 
-    assert_that(p.cargo("run"),
+    assert_that!(p.cargo("run"),
                 execs().with_status(0)
                        .with_stderr("\
 [COMPILING] foo v0.0.1 ([..])
@@ -1581,7 +1582,7 @@ fn example_bin_same_name() {
                        .with_stdout("\
 bin
 "));
-    assert_that(&p.bin("foo"), existing_file());
+    assert_that!(&p.bin("foo"), existing_file());
 }
 
 #[test]
@@ -1598,13 +1599,13 @@ fn test_with_example_twice() {
         .build();
 
     println!("first");
-    assert_that(p.cargo("test").arg("-v"),
+    assert_that!(p.cargo("test").arg("-v"),
                 execs().with_status(0));
-    assert_that(&p.bin("examples/foo"), existing_file());
+    assert_that!(&p.bin("examples/foo"), existing_file());
     println!("second");
-    assert_that(p.cargo("test").arg("-v"),
+    assert_that!(p.cargo("test").arg("-v"),
                 execs().with_status(0));
-    assert_that(&p.bin("examples/foo"), existing_file());
+    assert_that!(&p.bin("examples/foo"), existing_file());
 }
 
 #[test]
@@ -1635,7 +1636,7 @@ fn example_with_dev_dep() {
         .file("a/src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("test").arg("-v"),
+    assert_that!(p.cargo("test").arg("-v"),
                 execs().with_status(0)
                        .with_stderr("\
 [..]
@@ -1660,14 +1661,14 @@ fn bin_is_preserved() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    assert_that(p.cargo("build").arg("-v"),
+    assert_that!(p.cargo("build").arg("-v"),
                 execs().with_status(0));
-    assert_that(&p.bin("foo"), existing_file());
+    assert_that!(&p.bin("foo"), existing_file());
 
     println!("testing");
-    assert_that(p.cargo("test").arg("-v"),
+    assert_that!(p.cargo("test").arg("-v"),
                 execs().with_status(0));
-    assert_that(&p.bin("foo"), existing_file());
+    assert_that!(&p.bin("foo"), existing_file());
 }
 
 #[test]
@@ -1682,11 +1683,11 @@ fn bad_example() {
         .file("src/lib.rs", "");
     let p = p.build();
 
-    assert_that(p.cargo("run").arg("--example").arg("foo"),
+    assert_that!(p.cargo("run").arg("--example").arg("foo"),
                 execs().with_status(101).with_stderr("\
 [ERROR] no example target named `foo`
 "));
-    assert_that(p.cargo("run").arg("--bin").arg("foo"),
+    assert_that!(p.cargo("run").arg("--bin").arg("foo"),
                 execs().with_status(101).with_stderr("\
 [ERROR] no bin target named `foo`
 "));
@@ -1712,7 +1713,7 @@ fn doctest_feature() {
         "#)
         .build();
 
-    assert_that(p.cargo("test").arg("--features").arg("bar"),
+    assert_that!(p.cargo("test").arg("--features").arg("bar"),
                 execs().with_status(0)
                        .with_stderr("\
 [COMPILING] foo [..]
@@ -1740,7 +1741,7 @@ fn dashes_to_underscores() {
         "#)
         .build();
 
-    assert_that(p.cargo("test").arg("-v"),
+    assert_that!(p.cargo("test").arg("-v"),
                 execs().with_status(0));
 }
 
@@ -1771,7 +1772,7 @@ fn doctest_dev_dep() {
         .file("b/src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("test").arg("-v"),
+    assert_that!(p.cargo("test").arg("-v"),
                 execs().with_status(0));
 }
 
@@ -1793,7 +1794,7 @@ fn filter_no_doc_tests() {
         .file("tests/foo.rs", "")
         .build();
 
-    assert_that(p.cargo("test").arg("--test=foo"),
+    assert_that!(p.cargo("test").arg("--test=foo"),
                 execs().with_status(0).with_stderr("\
 [COMPILING] foo v0.0.1 ([..])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
@@ -1823,7 +1824,7 @@ fn dylib_doctest() {
         "#)
         .build();
 
-    assert_that(p.cargo("test"),
+    assert_that!(p.cargo("test"),
                 execs().with_status(0).with_stderr("\
 [COMPILING] foo v0.0.1 ([..])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
@@ -1854,7 +1855,7 @@ fn dylib_doctest2() {
         "#)
         .build();
 
-    assert_that(p.cargo("test"),
+    assert_that!(p.cargo("test"),
                 execs().with_status(0).with_stdout(""));
 }
 
@@ -1889,7 +1890,7 @@ fn cyclic_dev_dep_doc_test() {
             extern crate foo;
         "#)
         .build();
-    assert_that(p.cargo("test"),
+    assert_that!(p.cargo("test"),
                 execs().with_status(0).with_stderr("\
 [COMPILING] foo v0.0.1 ([..])
 [COMPILING] bar v0.0.1 ([..])
@@ -1924,7 +1925,7 @@ fn dev_dep_with_build_script() {
         .file("bar/src/lib.rs", "")
         .file("bar/build.rs", "fn main() {}")
         .build();
-    assert_that(p.cargo("test"),
+    assert_that!(p.cargo("test"),
                 execs().with_status(0));
 }
 
@@ -1974,7 +1975,7 @@ fn no_fail_fast() {
         }
         "#)
         .build();
-    assert_that(p.cargo("test").arg("--no-fail-fast"),
+    assert_that!(p.cargo("test").arg("--no-fail-fast"),
                 execs().with_status(101)
                        .with_stderr_contains("\
 [COMPILING] foo v0.0.1 ([..])
@@ -2033,7 +2034,7 @@ fn test_multiple_packages() {
         .file("d2/src/lib.rs", "");
     let p = p.build();
 
-    assert_that(p.cargo("test").arg("-p").arg("d1").arg("-p").arg("d2"),
+    assert_that!(p.cargo("test").arg("-p").arg("d1").arg("-p").arg("d2"),
                 execs().with_status(0)
                        .with_stderr_contains("\
 [RUNNING] target[/]debug[/]deps[/]d1-[..][EXE]")
@@ -2056,14 +2057,14 @@ fn bin_does_not_rebuild_tests() {
         .file("tests/foo.rs", "");
     let p = p.build();
 
-    assert_that(p.cargo("test").arg("-v"),
+    assert_that!(p.cargo("test").arg("-v"),
                 execs().with_status(0));
 
     sleep_ms(1000);
     File::create(&p.root().join("src/main.rs")).unwrap()
          .write_all(b"fn main() { 3; }").unwrap();
 
-    assert_that(p.cargo("test").arg("-v").arg("--no-run"),
+    assert_that!(p.cargo("test").arg("-v").arg("--no-run"),
                 execs().with_status(0)
                        .with_stderr("\
 [COMPILING] foo v0.0.1 ([..])
@@ -2098,7 +2099,7 @@ fn selective_test_wonky_profile() {
         .file("a/src/lib.rs", "");
     let p = p.build();
 
-    assert_that(p.cargo("test").arg("-v").arg("--no-run").arg("--release")
+    assert_that!(p.cargo("test").arg("-v").arg("--no-run").arg("--release")
                  .arg("-p").arg("foo").arg("-p").arg("a"),
                 execs().with_status(0));
 }
@@ -2125,7 +2126,7 @@ fn selective_test_optional_dep() {
         .file("a/src/lib.rs", "");
     let p = p.build();
 
-    assert_that(p.cargo("test").arg("-v").arg("--no-run")
+    assert_that!(p.cargo("test").arg("-v").arg("--no-run")
                  .arg("--features").arg("a").arg("-p").arg("a"),
                 execs().with_status(0).with_stderr("\
 [COMPILING] a v0.0.1 ([..])
@@ -2160,7 +2161,7 @@ fn only_test_docs() {
         .file("tests/foo.rs", "this is not rust");
     let p = p.build();
 
-    assert_that(p.cargo("test").arg("--doc"),
+    assert_that!(p.cargo("test").arg("--doc"),
                 execs().with_status(0)
                        .with_stderr("\
 [COMPILING] foo v0.0.1 ([..])
@@ -2198,7 +2199,7 @@ fn test_panic_abort_with_dep() {
         "#)
         .file("bar/src/lib.rs", "")
         .build();
-    assert_that(p.cargo("test").arg("-v"),
+    assert_that!(p.cargo("test").arg("-v"),
                 execs().with_status(0));
 }
 
@@ -2222,7 +2223,7 @@ fn cfg_test_even_with_no_harness() {
             }
         "#)
         .build();
-    assert_that(p.cargo("test").arg("-v"),
+    assert_that!(p.cargo("test").arg("-v"),
                 execs().with_status(0)
                        .with_stdout("hello!\n")
                        .with_stderr("\
@@ -2257,7 +2258,7 @@ fn panic_abort_multiple() {
         "#)
         .file("a/src/lib.rs", "")
         .build();
-    assert_that(p.cargo("test")
+    assert_that!(p.cargo("test")
                  .arg("--release").arg("-v")
                  .arg("-p").arg("foo")
                  .arg("-p").arg("a"),
@@ -2333,7 +2334,7 @@ fn pass_correct_cfgs_flags_to_rustdoc() {
         .file("libs/mock_serde_codegen/src/lib.rs", "");
     let p = p.build();
 
-    assert_that(p.cargo("test")
+    assert_that!(p.cargo("test")
                 .arg("--package").arg("feature_a")
                 .arg("--verbose"),
                 execs().with_status(0)
@@ -2341,7 +2342,7 @@ fn pass_correct_cfgs_flags_to_rustdoc() {
 [DOCTEST] feature_a
 [RUNNING] `rustdoc --test [..]mock_serde_codegen[..]`"));
 
-    assert_that(p.cargo("test")
+    assert_that!(p.cargo("test")
                 .arg("--verbose"),
                 execs().with_status(0)
                        .with_stderr_contains("\
@@ -2376,9 +2377,9 @@ fn test_release_ignore_panic() {
         .file("a/src/lib.rs", "");
     let p = p.build();
     println!("test");
-    assert_that(p.cargo("test").arg("-v"), execs().with_status(0));
+    assert_that!(p.cargo("test").arg("-v"), execs().with_status(0));
     println!("bench");
-    assert_that(p.cargo("bench").arg("-v"), execs().with_status(0));
+    assert_that!(p.cargo("bench").arg("-v"), execs().with_status(0));
 }
 
 #[test]
@@ -2408,7 +2409,7 @@ fn test_many_with_features() {
         .file("a/src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("test").arg("-v")
+    assert_that!(p.cargo("test").arg("-v")
                  .arg("-p").arg("a")
                  .arg("-p").arg("foo")
                  .arg("--features").arg("foo"),
@@ -2443,7 +2444,7 @@ fn test_all_workspace() {
         "#)
         .build();
 
-    assert_that(p.cargo("test")
+    assert_that!(p.cargo("test")
                  .arg("--all"),
                 execs().with_status(0)
                        .with_stdout_contains("test foo_test ... ok")
@@ -2486,7 +2487,7 @@ fn test_all_exclude() {
         "#)
         .build();
 
-    assert_that(p.cargo("test")
+    assert_that!(p.cargo("test")
                     .arg("--all")
                     .arg("--exclude")
                     .arg("baz"),
@@ -2522,7 +2523,7 @@ fn test_all_virtual_manifest() {
         "#)
         .build();
 
-    assert_that(p.cargo("test")
+    assert_that!(p.cargo("test")
                  .arg("--all"),
                 execs().with_status(0)
                        .with_stdout_contains("test a ... ok")
@@ -2556,7 +2557,7 @@ fn test_virtual_manifest_all_implied() {
         "#)
         .build();
 
-    assert_that(p.cargo("test"),
+    assert_that!(p.cargo("test"),
                 execs().with_status(0)
                        .with_stdout_contains("test a ... ok")
                        .with_stdout_contains("test b ... ok"));
@@ -2585,7 +2586,7 @@ fn test_all_member_dependency_same_name() {
 
     Package::new("a", "0.1.0").publish();
 
-    assert_that(p.cargo("test")
+    assert_that!(p.cargo("test")
                  .arg("--all"),
                 execs().with_status(0)
                        .with_stdout_contains("test a ... ok"));
@@ -2620,7 +2621,7 @@ fn doctest_only_with_dev_dep() {
         "#)
         .build();
 
-    assert_that(p.cargo("test").arg("--doc").arg("-v"),
+    assert_that!(p.cargo("test").arg("--doc").arg("-v"),
                 execs().with_status(0));
 }
 
@@ -2666,7 +2667,7 @@ fn test_many_targets() {
         "#)
         .build();
 
-    assert_that(p.cargo("test").arg("--verbose")
+    assert_that!(p.cargo("test").arg("--verbose")
                     .arg("--bin").arg("a").arg("--bin").arg("b")
                     .arg("--example").arg("a").arg("--example").arg("b")
                     .arg("--test").arg("a").arg("--test").arg("b"),
@@ -2719,7 +2720,7 @@ fn doctest_and_registry() {
 
     Package::new("b", "0.1.0").publish();
 
-    assert_that(p.cargo("test").arg("--all").arg("-v"),
+    assert_that!(p.cargo("test").arg("--all").arg("-v"),
                 execs().with_status(0));
 }
 
@@ -2742,7 +2743,7 @@ fn cargo_test_env() {
 
     let mut pr = p.cargo("test");
     let cargo = cargo_exe().canonicalize().unwrap();
-    assert_that(pr.args(&["--lib", "--", "--nocapture"]),
+    assert_that!(pr.args(&["--lib", "--", "--nocapture"]),
                 execs().with_status(0)
                        .with_stdout_contains(format!("\
 {}
@@ -2769,7 +2770,7 @@ fn test_order() {
         "#)
         .build();
 
-        assert_that(p.cargo("test").arg("--all"),
+        assert_that!(p.cargo("test").arg("--all"),
             execs().with_status(0)
                    .with_stdout_contains("
 running 1 test
@@ -2811,7 +2812,7 @@ fn cyclic_dev() {
         "#)
         .build();
 
-    assert_that(p.cargo("test").arg("--all"),
+    assert_that!(p.cargo("test").arg("--all"),
                 execs().with_status(0));
 }
 
@@ -2849,8 +2850,8 @@ fn publish_a_crate_without_tests() {
         .file("src/lib.rs", "")
         .build();
 
-    assert_that(p.cargo("test"), execs().with_status(0));
-    assert_that(p.cargo("test").arg("--package").arg("testless"),
+    assert_that!(p.cargo("test"), execs().with_status(0));
+    assert_that!(p.cargo("test").arg("--package").arg("testless"),
                 execs().with_status(0));
 }
 
@@ -2905,7 +2906,7 @@ fn find_dependency_of_proc_macro_dependency_with_target() {
         .dep("foo", "0.1")
         .file("src/lib.rs", "extern crate foo;")
         .publish();
-    assert_that(workspace.cargo("test").arg("--all").arg("--target").arg(rustc_host()),
+    assert_that!(workspace.cargo("test").arg("--all").arg("--target").arg(rustc_host()),
                 execs().with_status(0));
 }
 
@@ -2930,7 +2931,7 @@ fn test_hint_not_masked_by_doctest() {
             }
         "#)
         .build();
-    assert_that(p.cargo("test")
+    assert_that!(p.cargo("test")
                  .arg("--no-fail-fast"),
                 execs()
                 .with_status(101)

--- a/tests/tool-paths.rs
+++ b/tests/tool-paths.rs
@@ -1,9 +1,10 @@
 extern crate cargotest;
+#[macro_use]
 extern crate hamcrest;
 
 use cargotest::rustc_host;
 use cargotest::support::{path2url, project, execs};
-use hamcrest::assert_that;
+use hamcrest::prelude::*;
 
 #[test]
 fn pathless_tools() {
@@ -27,7 +28,7 @@ fn pathless_tools() {
         "#, target))
         .build();
 
-    assert_that(foo.cargo("build").arg("--verbose"),
+    assert_that!(foo.cargo("build").arg("--verbose"),
                 execs().with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({url})
 [RUNNING] `rustc [..] -C ar=nonexistent-ar -C linker=nonexistent-linker [..]`
@@ -70,7 +71,7 @@ fn absolute_tools() {
         (r#"/bogus/nonexistent-ar"#, r#"/bogus/nonexistent-linker"#)
     };
 
-    assert_that(foo.cargo("build").arg("--verbose"),
+    assert_that!(foo.cargo("build").arg("--verbose"),
                 execs().with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({url})
 [RUNNING] `rustc [..] -C ar={ar} -C linker={linker} [..]`
@@ -120,7 +121,7 @@ fn relative_tools() {
          format!(r#"{}/./tools/nonexistent-linker"#, prefix))
     };
 
-    assert_that(origin.cargo("build").cwd(foo_path).arg("--verbose"),
+    assert_that!(origin.cargo("build").cwd(foo_path).arg("--verbose"),
                 execs().with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({url})
 [RUNNING] `rustc [..] -C ar={ar} -C linker={linker} [..]`
@@ -147,14 +148,14 @@ fn custom_runner() {
         "#, target))
         .build();
 
-    assert_that(p.cargo("run").args(&["--", "--param"]),
+    assert_that!(p.cargo("run").args(&["--", "--param"]),
                 execs().with_stderr_contains(&format!("\
 [COMPILING] foo v0.0.1 ({url})
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `nonexistent-runner -r target[/]debug[/]foo[EXE] --param`
 ", url = p.url())));
 
-    assert_that(p.cargo("test").args(&["--test", "test", "--verbose", "--", "--param"]),
+    assert_that!(p.cargo("test").args(&["--test", "test", "--verbose", "--", "--param"]),
                 execs().with_stderr_contains(&format!("\
 [COMPILING] foo v0.0.1 ({url})
 [RUNNING] `rustc [..]`
@@ -162,7 +163,7 @@ fn custom_runner() {
 [RUNNING] `nonexistent-runner -r [..][/]target[/]debug[/]deps[/]test-[..][EXE] --param`
 ", url = p.url())));
 
-    assert_that(p.cargo("bench").args(&["--bench", "bench", "--verbose", "--", "--param"]),
+    assert_that!(p.cargo("bench").args(&["--bench", "bench", "--verbose", "--", "--param"]),
                 execs().with_stderr_contains(&format!("\
 [COMPILING] foo v0.0.1 ({url})
 [RUNNING] `rustc [..]`

--- a/tests/verify-project.rs
+++ b/tests/verify-project.rs
@@ -1,8 +1,9 @@
 extern crate cargotest;
+#[macro_use]
 extern crate hamcrest;
 
 use cargotest::support::{project, execs, main_file, basic_bin_manifest};
-use hamcrest::{assert_that};
+use hamcrest::prelude::*;
 
 fn verify_project_success_output() -> String {
     r#"{"success":"true"}"#.into()
@@ -15,7 +16,7 @@ fn cargo_verify_project_path_to_cargo_toml_relative() {
         .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
         .build();
 
-    assert_that(p.cargo("verify-project")
+    assert_that!(p.cargo("verify-project")
                  .arg("--manifest-path").arg("foo/Cargo.toml")
                  .cwd(p.root().parent().unwrap()),
                 execs().with_status(0)
@@ -29,7 +30,7 @@ fn cargo_verify_project_path_to_cargo_toml_absolute() {
         .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
         .build();
 
-    assert_that(p.cargo("verify-project")
+    assert_that!(p.cargo("verify-project")
                  .arg("--manifest-path").arg(p.root().join("Cargo.toml"))
                  .cwd(p.root().parent().unwrap()),
                 execs().with_status(0)
@@ -43,7 +44,7 @@ fn cargo_verify_project_cwd() {
         .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
         .build();
 
-    assert_that(p.cargo("verify-project")
+    assert_that!(p.cargo("verify-project")
                  .cwd(p.root()),
                 execs().with_status(0)
                        .with_stdout(verify_project_success_output()));

--- a/tests/version.rs
+++ b/tests/version.rs
@@ -1,19 +1,20 @@
 extern crate cargo;
 extern crate cargotest;
+#[macro_use]
 extern crate hamcrest;
 
 use cargotest::support::{project, execs};
-use hamcrest::assert_that;
+use hamcrest::prelude::*;
 
 #[test]
 fn simple() {
     let p = project("foo").build();
 
-    assert_that(p.cargo("version"),
+    assert_that!(p.cargo("version"),
                 execs().with_status(0).with_stdout(&format!("{}\n",
                                                             cargo::version())));
 
-    assert_that(p.cargo("--version"),
+    assert_that!(p.cargo("--version"),
                 execs().with_status(0).with_stdout(&format!("{}\n",
                                                             cargo::version())));
 
@@ -24,7 +25,7 @@ fn simple() {
 #[cfg_attr(target_os = "windows", ignore)]
 fn version_works_without_rustc() {
     let p = project("foo").build();
-    assert_that(p.cargo("version").env("PATH", ""),
+    assert_that!(p.cargo("version").env("PATH", ""),
                 execs().with_status(0));
 }
 
@@ -33,7 +34,7 @@ fn version_works_with_bad_config() {
     let p = project("foo")
         .file(".cargo/config", "this is not toml")
         .build();
-    assert_that(p.cargo("version"),
+    assert_that!(p.cargo("version"),
                 execs().with_status(0));
 }
 
@@ -45,6 +46,6 @@ fn version_works_with_bad_target_dir() {
             target-dir = 4
         "#)
         .build();
-    assert_that(p.cargo("version"),
+    assert_that!(p.cargo("version"),
                 execs().with_status(0));
 }

--- a/tests/warn-on-failure.rs
+++ b/tests/warn-on-failure.rs
@@ -1,9 +1,10 @@
 extern crate cargotest;
+#[macro_use]
 extern crate hamcrest;
 
 use cargotest::support::{project, execs, Project};
 use cargotest::support::registry::Package;
-use hamcrest::assert_that;
+use hamcrest::prelude::*;
 
 static WARNING1: &'static str = "Hello! I'm a warning. :)";
 static WARNING2: &'static str = "And one more!";
@@ -49,7 +50,7 @@ fn make_upstream(main_src: &str) -> Project {
 fn no_warning_on_success() {
     make_lib("");
     let upstream = make_upstream("");
-    assert_that(upstream.cargo("build"),
+    assert_that!(upstream.cargo("build"),
                 execs().with_status(0)
                        .with_stderr("\
 [UPDATING] registry `[..]`
@@ -64,7 +65,7 @@ fn no_warning_on_success() {
 fn no_warning_on_bin_failure() {
     make_lib("");
     let upstream = make_upstream("hi()");
-    assert_that(upstream.cargo("build"),
+    assert_that!(upstream.cargo("build"),
                 execs().with_status(101)
                        .with_stdout_does_not_contain("hidden stdout")
                        .with_stderr_does_not_contain("hidden stderr")
@@ -80,7 +81,7 @@ fn no_warning_on_bin_failure() {
 fn warning_on_lib_failure() {
     make_lib("err()");
     let upstream = make_upstream("");
-    assert_that(upstream.cargo("build"),
+    assert_that!(upstream.cargo("build"),
                 execs().with_status(101)
                        .with_stdout_does_not_contain("hidden stdout")
                        .with_stderr_does_not_contain("hidden stderr")

--- a/tests/workspaces.rs
+++ b/tests/workspaces.rs
@@ -1,5 +1,6 @@
 #[macro_use]
 extern crate cargotest;
+#[macro_use]
 extern crate hamcrest;
 
 use std::io::{Read, Write};
@@ -8,7 +9,7 @@ use std::fs::File;
 use cargotest::sleep_ms;
 use cargotest::support::{project, execs, git};
 use cargotest::support::registry::Package;
-use hamcrest::{assert_that, existing_file, existing_dir, is_not};
+use hamcrest::prelude::*;
 
 #[test]
 fn simple_explicit() {
@@ -33,17 +34,17 @@ fn simple_explicit() {
         .file("bar/src/main.rs", "fn main() {}");
     let p = p.build();
 
-    assert_that(p.cargo("build"), execs().with_status(0));
-    assert_that(&p.bin("foo"), existing_file());
-    assert_that(&p.bin("bar"), is_not(existing_file()));
+    assert_that!(p.cargo("build"), execs().with_status(0));
+    assert_that!(&p.bin("foo"), existing_file());
+    assert_that!(&p.bin("bar"), is_not(existing_file()));
 
-    assert_that(p.cargo("build").cwd(p.root().join("bar")),
+    assert_that!(p.cargo("build").cwd(p.root().join("bar")),
                 execs().with_status(0));
-    assert_that(&p.bin("foo"), existing_file());
-    assert_that(&p.bin("bar"), existing_file());
+    assert_that!(&p.bin("foo"), existing_file());
+    assert_that!(&p.bin("bar"), existing_file());
 
-    assert_that(&p.root().join("Cargo.lock"), existing_file());
-    assert_that(&p.root().join("bar/Cargo.lock"), is_not(existing_file()));
+    assert_that!(&p.root().join("Cargo.lock"), existing_file());
+    assert_that!(&p.root().join("bar/Cargo.lock"), is_not(existing_file()));
 }
 
 #[test]
@@ -70,9 +71,9 @@ fn simple_explicit_default_members() {
         .file("bar/src/main.rs", "fn main() {}");
     let p = p.build();
 
-    assert_that(p.cargo("build"), execs().with_status(0));
-    assert_that(&p.bin("bar"), existing_file());
-    assert_that(&p.bin("foo"), is_not(existing_file()));
+    assert_that!(p.cargo("build"), execs().with_status(0));
+    assert_that!(&p.bin("bar"), existing_file());
+    assert_that!(&p.bin("foo"), is_not(existing_file()));
 }
 
 #[test]
@@ -97,17 +98,17 @@ fn inferred_root() {
         .file("bar/src/main.rs", "fn main() {}");
     let p = p.build();
 
-    assert_that(p.cargo("build"), execs().with_status(0));
-    assert_that(&p.bin("foo"), existing_file());
-    assert_that(&p.bin("bar"), is_not(existing_file()));
+    assert_that!(p.cargo("build"), execs().with_status(0));
+    assert_that!(&p.bin("foo"), existing_file());
+    assert_that!(&p.bin("bar"), is_not(existing_file()));
 
-    assert_that(p.cargo("build").cwd(p.root().join("bar")),
+    assert_that!(p.cargo("build").cwd(p.root().join("bar")),
                 execs().with_status(0));
-    assert_that(&p.bin("foo"), existing_file());
-    assert_that(&p.bin("bar"), existing_file());
+    assert_that!(&p.bin("foo"), existing_file());
+    assert_that!(&p.bin("bar"), existing_file());
 
-    assert_that(&p.root().join("Cargo.lock"), existing_file());
-    assert_that(&p.root().join("bar/Cargo.lock"), is_not(existing_file()));
+    assert_that!(&p.root().join("Cargo.lock"), existing_file());
+    assert_that!(&p.root().join("bar/Cargo.lock"), is_not(existing_file()));
 }
 
 #[test]
@@ -135,17 +136,17 @@ fn inferred_path_dep() {
         .file("bar/src/lib.rs", "");
     let p = p.build();
 
-    assert_that(p.cargo("build"), execs().with_status(0));
-    assert_that(&p.bin("foo"), existing_file());
-    assert_that(&p.bin("bar"), is_not(existing_file()));
+    assert_that!(p.cargo("build"), execs().with_status(0));
+    assert_that!(&p.bin("foo"), existing_file());
+    assert_that!(&p.bin("bar"), is_not(existing_file()));
 
-    assert_that(p.cargo("build").cwd(p.root().join("bar")),
+    assert_that!(p.cargo("build").cwd(p.root().join("bar")),
                 execs().with_status(0));
-    assert_that(&p.bin("foo"), existing_file());
-    assert_that(&p.bin("bar"), existing_file());
+    assert_that!(&p.bin("foo"), existing_file());
+    assert_that!(&p.bin("bar"), existing_file());
 
-    assert_that(&p.root().join("Cargo.lock"), existing_file());
-    assert_that(&p.root().join("bar/Cargo.lock"), is_not(existing_file()));
+    assert_that!(&p.root().join("Cargo.lock"), existing_file());
+    assert_that!(&p.root().join("bar/Cargo.lock"), is_not(existing_file()));
 }
 
 #[test]
@@ -184,26 +185,26 @@ fn transitive_path_dep() {
         .file("baz/src/lib.rs", "");
     let p = p.build();
 
-    assert_that(p.cargo("build"), execs().with_status(0));
-    assert_that(&p.bin("foo"), existing_file());
-    assert_that(&p.bin("bar"), is_not(existing_file()));
-    assert_that(&p.bin("baz"), is_not(existing_file()));
+    assert_that!(p.cargo("build"), execs().with_status(0));
+    assert_that!(&p.bin("foo"), existing_file());
+    assert_that!(&p.bin("bar"), is_not(existing_file()));
+    assert_that!(&p.bin("baz"), is_not(existing_file()));
 
-    assert_that(p.cargo("build").cwd(p.root().join("bar")),
+    assert_that!(p.cargo("build").cwd(p.root().join("bar")),
                 execs().with_status(0));
-    assert_that(&p.bin("foo"), existing_file());
-    assert_that(&p.bin("bar"), existing_file());
-    assert_that(&p.bin("baz"), is_not(existing_file()));
+    assert_that!(&p.bin("foo"), existing_file());
+    assert_that!(&p.bin("bar"), existing_file());
+    assert_that!(&p.bin("baz"), is_not(existing_file()));
 
-    assert_that(p.cargo("build").cwd(p.root().join("baz")),
+    assert_that!(p.cargo("build").cwd(p.root().join("baz")),
                 execs().with_status(0));
-    assert_that(&p.bin("foo"), existing_file());
-    assert_that(&p.bin("bar"), existing_file());
-    assert_that(&p.bin("baz"), existing_file());
+    assert_that!(&p.bin("foo"), existing_file());
+    assert_that!(&p.bin("bar"), existing_file());
+    assert_that!(&p.bin("baz"), existing_file());
 
-    assert_that(&p.root().join("Cargo.lock"), existing_file());
-    assert_that(&p.root().join("bar/Cargo.lock"), is_not(existing_file()));
-    assert_that(&p.root().join("baz/Cargo.lock"), is_not(existing_file()));
+    assert_that!(&p.root().join("Cargo.lock"), existing_file());
+    assert_that!(&p.root().join("bar/Cargo.lock"), is_not(existing_file()));
+    assert_that!(&p.root().join("baz/Cargo.lock"), is_not(existing_file()));
 }
 
 #[test]
@@ -232,12 +233,12 @@ fn parent_pointer_works() {
         .file("bar/src/lib.rs", "");
     let p = p.build();
 
-    assert_that(p.cargo("build").cwd(p.root().join("foo")),
+    assert_that!(p.cargo("build").cwd(p.root().join("foo")),
                 execs().with_status(0));
-    assert_that(p.cargo("build").cwd(p.root().join("bar")),
+    assert_that!(p.cargo("build").cwd(p.root().join("bar")),
                 execs().with_status(0));
-    assert_that(&p.root().join("foo/Cargo.lock"), existing_file());
-    assert_that(&p.root().join("bar/Cargo.lock"), is_not(existing_file()));
+    assert_that!(&p.root().join("foo/Cargo.lock"), existing_file());
+    assert_that!(&p.root().join("bar/Cargo.lock"), is_not(existing_file()));
 }
 
 #[test]
@@ -263,7 +264,7 @@ fn same_names_in_workspace() {
         .file("bar/src/main.rs", "fn main() {}");
     let p = p.build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(101)
                        .with_stderr("\
 error: two packages named `foo` in this workspace:
@@ -293,7 +294,7 @@ fn parent_doesnt_point_to_child() {
         .file("bar/src/main.rs", "fn main() {}");
     let p = p.build();
 
-    assert_that(p.cargo("build").cwd(p.root().join("bar")),
+    assert_that!(p.cargo("build").cwd(p.root().join("bar")),
                 execs().with_status(101)
                        .with_stderr("\
 error: current package believes it's in a workspace when it's not:
@@ -317,7 +318,7 @@ fn invalid_parent_pointer() {
         .file("src/main.rs", "fn main() {}");
     let p = p.build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(101)
                        .with_stderr("\
 error: failed to read `[..]Cargo.toml`
@@ -342,7 +343,7 @@ fn invalid_members() {
         .file("src/main.rs", "fn main() {}");
     let p = p.build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(101)
                        .with_stderr("\
 error: failed to read `[..]Cargo.toml`
@@ -366,7 +367,7 @@ fn bare_workspace_ok() {
         .file("src/main.rs", "fn main() {}");
     let p = p.build();
 
-    assert_that(p.cargo("build"), execs().with_status(0));
+    assert_that!(p.cargo("build"), execs().with_status(0));
 }
 
 #[test]
@@ -394,7 +395,7 @@ fn two_roots() {
         .file("bar/src/main.rs", "fn main() {}");
     let p = p.build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(101)
                        .with_stderr("\
 error: multiple workspace roots found in the same workspace:
@@ -423,7 +424,7 @@ fn workspace_isnt_root() {
         .file("bar/src/main.rs", "fn main() {}");
     let p = p.build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(101)
                        .with_stderr("\
 error: root of a workspace inferred but wasn't a root: [..]
@@ -461,7 +462,7 @@ fn dangling_member() {
         .file("baz/src/main.rs", "fn main() {}");
     let p = p.build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(101)
                        .with_stderr("\
 error: package `[..]` is a member of the wrong workspace
@@ -491,7 +492,7 @@ fn cycle() {
         .file("bar/src/main.rs", "fn main() {}");
     let p = p.build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(101));
 }
 
@@ -526,7 +527,7 @@ fn share_dependencies() {
     Package::new("dep1", "0.1.3").publish();
     Package::new("dep1", "0.1.8").publish();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0)
                        .with_stderr("\
 [UPDATING] registry `[..]`
@@ -564,7 +565,7 @@ fn fetch_fetches_all() {
 
     Package::new("dep1", "0.1.3").publish();
 
-    assert_that(p.cargo("fetch"),
+    assert_that!(p.cargo("fetch"),
                 execs().with_status(0)
                        .with_stderr("\
 [UPDATING] registry `[..]`
@@ -603,7 +604,7 @@ fn lock_works_for_everyone() {
     Package::new("dep1", "0.1.0").publish();
     Package::new("dep2", "0.1.0").publish();
 
-    assert_that(p.cargo("generate-lockfile"),
+    assert_that!(p.cargo("generate-lockfile"),
                 execs().with_status(0)
                        .with_stderr("\
 [UPDATING] registry `[..]`
@@ -612,7 +613,7 @@ fn lock_works_for_everyone() {
     Package::new("dep1", "0.1.1").publish();
     Package::new("dep2", "0.1.1").publish();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0)
                        .with_stderr("\
 [DOWNLOADING] dep2 v0.1.0 ([..])
@@ -621,7 +622,7 @@ fn lock_works_for_everyone() {
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
 
-    assert_that(p.cargo("build").cwd(p.root().join("bar")),
+    assert_that!(p.cargo("build").cwd(p.root().join("bar")),
                 execs().with_status(0)
                        .with_stderr("\
 [DOWNLOADING] dep1 v0.1.0 ([..])
@@ -646,11 +647,11 @@ fn virtual_works() {
         "#)
         .file("bar/src/main.rs", "fn main() {}");
     let p = p.build();
-    assert_that(p.cargo("build").cwd(p.root().join("bar")),
+    assert_that!(p.cargo("build").cwd(p.root().join("bar")),
                 execs().with_status(0));
-    assert_that(&p.root().join("Cargo.lock"), existing_file());
-    assert_that(&p.bin("bar"), existing_file());
-    assert_that(&p.root().join("bar/Cargo.lock"), is_not(existing_file()));
+    assert_that!(&p.root().join("Cargo.lock"), existing_file());
+    assert_that!(&p.bin("bar"), existing_file());
+    assert_that!(&p.root().join("bar/Cargo.lock"), is_not(existing_file()));
 }
 
 #[test]
@@ -668,11 +669,11 @@ fn explicit_package_argument_works_with_virtual_manifest() {
         "#)
         .file("bar/src/main.rs", "fn main() {}");
     let p = p.build();
-    assert_that(p.cargo("build").cwd(p.root()).args(&["--package", "bar"]),
+    assert_that!(p.cargo("build").cwd(p.root()).args(&["--package", "bar"]),
                 execs().with_status(0));
-    assert_that(&p.root().join("Cargo.lock"), existing_file());
-    assert_that(&p.bin("bar"), existing_file());
-    assert_that(&p.root().join("bar/Cargo.lock"), is_not(existing_file()));
+    assert_that!(&p.root().join("Cargo.lock"), existing_file());
+    assert_that!(&p.bin("bar"), existing_file());
+    assert_that!(&p.root().join("bar/Cargo.lock"), is_not(existing_file()));
 }
 
 #[test]
@@ -689,7 +690,7 @@ fn virtual_misconfigure() {
         "#)
         .file("bar/src/main.rs", "fn main() {}");
     let p = p.build();
-    assert_that(p.cargo("build").cwd(p.root().join("bar")),
+    assert_that!(p.cargo("build").cwd(p.root().join("bar")),
                 execs().with_status(101)
                        .with_stderr("\
 error: current package believes it's in a workspace when it's not:
@@ -716,7 +717,7 @@ fn virtual_build_all_implied() {
         "#)
         .file("bar/src/main.rs", "fn main() {}");
     let p = p.build();
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0));
 }
 
@@ -743,10 +744,10 @@ fn virtual_default_members() {
         .file("bar/src/main.rs", "fn main() {}")
         .file("baz/src/main.rs", "fn main() {}");
     let p = p.build();
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0));
-    assert_that(&p.bin("bar"), existing_file());
-    assert_that(&p.bin("baz"), is_not(existing_file()));
+    assert_that!(&p.bin("bar"), existing_file());
+    assert_that!(&p.bin("baz"), is_not(existing_file()));
 }
 
 #[test]
@@ -765,7 +766,7 @@ fn virtual_default_member_is_not_a_member() {
         "#)
         .file("bar/src/main.rs", "fn main() {}");
     let p = p.build();
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(101)
                        .with_stderr("\
 error: package `[..]something-else` is listed in workspace’s default-members \
@@ -780,7 +781,7 @@ fn virtual_build_no_members() {
             [workspace]
         "#);
     let p = p.build();
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(101)
                        .with_stderr("\
 error: manifest path `[..]` contains no package: The manifest is virtual, \
@@ -804,7 +805,7 @@ fn include_virtual() {
             [workspace]
         "#);
     let p = p.build();
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(101)
                        .with_stderr("\
 error: multiple workspace roots found in the same workspace:
@@ -855,19 +856,19 @@ fn members_include_path_deps() {
         .file("p3/src/lib.rs", "");
     let p = p.build();
 
-    assert_that(p.cargo("build").cwd(p.root().join("p1")),
+    assert_that!(p.cargo("build").cwd(p.root().join("p1")),
                 execs().with_status(0));
-    assert_that(p.cargo("build").cwd(p.root().join("p2")),
+    assert_that!(p.cargo("build").cwd(p.root().join("p2")),
                 execs().with_status(0));
-    assert_that(p.cargo("build").cwd(p.root().join("p3")),
+    assert_that!(p.cargo("build").cwd(p.root().join("p3")),
                 execs().with_status(0));
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0));
 
-    assert_that(&p.root().join("target"), existing_dir());
-    assert_that(&p.root().join("p1/target"), is_not(existing_dir()));
-    assert_that(&p.root().join("p2/target"), is_not(existing_dir()));
-    assert_that(&p.root().join("p3/target"), is_not(existing_dir()));
+    assert_that!(&p.root().join("target"), existing_dir());
+    assert_that!(&p.root().join("p1/target"), is_not(existing_dir()));
+    assert_that!(&p.root().join("p2/target"), is_not(existing_dir()));
+    assert_that!(&p.root().join("p3/target"), is_not(existing_dir()));
 }
 
 #[test]
@@ -884,7 +885,7 @@ fn new_warns_you_this_will_not_work() {
         .file("src/lib.rs", "");
     let p = p.build();
 
-    assert_that(p.cargo("new").arg("--lib").arg("bar").env("USER", "foo"),
+    assert_that!(p.cargo("new").arg("--lib").arg("bar").env("USER", "foo"),
                 execs().with_status(0)
                        .with_stderr("\
 warning: compiling this new crate may not work due to invalid workspace \
@@ -931,13 +932,13 @@ fn lock_doesnt_change_depending_on_crate() {
     Package::new("foo", "1.0.0").publish();
     Package::new("bar", "1.0.0").publish();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0));
 
     let mut lockfile = String::new();
     t!(t!(File::open(p.root().join("Cargo.lock"))).read_to_string(&mut lockfile));
 
-    assert_that(p.cargo("build").cwd(p.root().join("baz")),
+    assert_that!(p.cargo("build").cwd(p.root().join("baz")),
                 execs().with_status(0));
 
     let mut lockfile2 = String::new();
@@ -978,7 +979,7 @@ fn rebuild_please() {
         "#);
     let p = p.build();
 
-    assert_that(p.cargo("run").cwd(p.root().join("bin")),
+    assert_that!(p.cargo("run").cwd(p.root().join("bin")),
                 execs().with_status(0));
 
     sleep_ms(1000);
@@ -987,10 +988,10 @@ fn rebuild_please() {
         pub fn foo() -> u32 { 1 }
     "#));
 
-    assert_that(p.cargo("build").cwd(p.root().join("lib")),
+    assert_that!(p.cargo("build").cwd(p.root().join("lib")),
                 execs().with_status(0));
 
-    assert_that(p.cargo("run").cwd(p.root().join("bin")),
+    assert_that!(p.cargo("run").cwd(p.root().join("bin")),
                 execs().with_status(101));
 }
 
@@ -1023,7 +1024,7 @@ fn workspace_in_git() {
         "#);
     let p = p.build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0));
 }
 
@@ -1054,7 +1055,7 @@ fn lockfile_can_specify_nonexistant_members() {
 
     let p = p.build();
 
-    assert_that(p.cargo("build").cwd(p.root().join("a")), execs().with_status(0));
+    assert_that!(p.cargo("build").cwd(p.root().join("a")), execs().with_status(0));
 }
 
 #[test]
@@ -1072,7 +1073,7 @@ fn you_cannot_generate_lockfile_for_empty_workspaces() {
         .file("bar/src/main.rs", "fn main() {}");
     let p = p.build();
 
-    assert_that(p.cargo("update"),
+    assert_that!(p.cargo("update"),
                 execs().with_status(101)
                        .with_stderr("\
 error: you can't generate a lockfile for an empty workspace.
@@ -1123,7 +1124,7 @@ fn workspace_with_transitive_dev_deps() {
         .file("baz/src/lib.rs", r#"pub fn do_stuff() {}"#);
     let p = p.build();
 
-    assert_that(p.cargo("test").args(&["-p", "bar"]),
+    assert_that!(p.cargo("test").args(&["-p", "bar"]),
                 execs().with_status(0));
 }
 
@@ -1140,7 +1141,7 @@ fn error_if_parent_cargo_toml_is_invalid() {
         .file("bar/src/main.rs", "fn main() {}");
     let p = p.build();
 
-    assert_that(p.cargo("build").cwd(p.root().join("bar")),
+    assert_that!(p.cargo("build").cwd(p.root().join("bar")),
                 execs().with_status(101)
                        .with_stderr_contains("\
 [ERROR] failed to parse manifest at `[..]`"));
@@ -1169,8 +1170,8 @@ fn relative_path_for_member_works() {
         .file("bar/src/main.rs", "fn main() {}");
     let p = p.build();
 
-    assert_that(p.cargo("build").cwd(p.root().join("foo")), execs().with_status(0));
-    assert_that(p.cargo("build").cwd(p.root().join("bar")), execs().with_status(0));
+    assert_that!(p.cargo("build").cwd(p.root().join("foo")), execs().with_status(0));
+    assert_that!(p.cargo("build").cwd(p.root().join("bar")), execs().with_status(0));
 }
 
 #[test]
@@ -1197,11 +1198,11 @@ fn relative_path_for_root_works() {
         .file("subproj/src/main.rs", "fn main() {}");
     let p = p.build();
 
-    assert_that(p.cargo("build").cwd(p.root())
+    assert_that!(p.cargo("build").cwd(p.root())
                     .arg("--manifest-path").arg("./Cargo.toml"),
                 execs().with_status(0));
 
-    assert_that(p.cargo("build").cwd(p.root().join("subproj"))
+    assert_that!(p.cargo("build").cwd(p.root().join("subproj"))
                     .arg("--manifest-path").arg("../Cargo.toml"),
                 execs().with_status(0));
 }
@@ -1230,7 +1231,7 @@ fn path_dep_outside_workspace_is_not_member() {
         .file("foo/src/lib.rs", "");
     let p = p.build();
 
-    assert_that(p.cargo("build").cwd(p.root().join("ws")),
+    assert_that!(p.cargo("build").cwd(p.root().join("ws")),
                 execs().with_status(0));
 }
 
@@ -1270,22 +1271,22 @@ fn test_in_and_out_of_workspace() {
         .file("bar/src/lib.rs", "pub fn f() { }");
     let p = p.build();
 
-    assert_that(p.cargo("build").cwd(p.root().join("ws")),
+    assert_that!(p.cargo("build").cwd(p.root().join("ws")),
                 execs().with_status(0));
 
-    assert_that(&p.root().join("ws/Cargo.lock"), existing_file());
-    assert_that(&p.root().join("ws/target"), existing_dir());
-    assert_that(&p.root().join("foo/Cargo.lock"), is_not(existing_file()));
-    assert_that(&p.root().join("foo/target"), is_not(existing_dir()));
-    assert_that(&p.root().join("bar/Cargo.lock"), is_not(existing_file()));
-    assert_that(&p.root().join("bar/target"), is_not(existing_dir()));
+    assert_that!(&p.root().join("ws/Cargo.lock"), existing_file());
+    assert_that!(&p.root().join("ws/target"), existing_dir());
+    assert_that!(&p.root().join("foo/Cargo.lock"), is_not(existing_file()));
+    assert_that!(&p.root().join("foo/target"), is_not(existing_dir()));
+    assert_that!(&p.root().join("bar/Cargo.lock"), is_not(existing_file()));
+    assert_that!(&p.root().join("bar/target"), is_not(existing_dir()));
 
-    assert_that(p.cargo("build").cwd(p.root().join("foo")),
+    assert_that!(p.cargo("build").cwd(p.root().join("foo")),
                 execs().with_status(0));
-    assert_that(&p.root().join("foo/Cargo.lock"), existing_file());
-    assert_that(&p.root().join("foo/target"), existing_dir());
-    assert_that(&p.root().join("bar/Cargo.lock"), is_not(existing_file()));
-    assert_that(&p.root().join("bar/target"), is_not(existing_dir()));
+    assert_that!(&p.root().join("foo/Cargo.lock"), existing_file());
+    assert_that!(&p.root().join("foo/target"), existing_dir());
+    assert_that!(&p.root().join("bar/Cargo.lock"), is_not(existing_file()));
+    assert_that!(&p.root().join("bar/target"), is_not(existing_dir()));
 }
 
 #[test]
@@ -1323,17 +1324,17 @@ fn test_path_dependency_under_member() {
         .file("foo/bar/src/lib.rs", "pub fn f() { }");
     let p = p.build();
 
-    assert_that(p.cargo("build").cwd(p.root().join("ws")),
+    assert_that!(p.cargo("build").cwd(p.root().join("ws")),
                 execs().with_status(0));
 
-    assert_that(&p.root().join("foo/bar/Cargo.lock"), is_not(existing_file()));
-    assert_that(&p.root().join("foo/bar/target"), is_not(existing_dir()));
+    assert_that!(&p.root().join("foo/bar/Cargo.lock"), is_not(existing_file()));
+    assert_that!(&p.root().join("foo/bar/target"), is_not(existing_dir()));
 
-    assert_that(p.cargo("build").cwd(p.root().join("foo/bar")),
+    assert_that!(p.cargo("build").cwd(p.root().join("foo/bar")),
                 execs().with_status(0));
 
-    assert_that(&p.root().join("foo/bar/Cargo.lock"), is_not(existing_file()));
-    assert_that(&p.root().join("foo/bar/target"), is_not(existing_dir()));
+    assert_that!(&p.root().join("foo/bar/Cargo.lock"), is_not(existing_file()));
+    assert_that!(&p.root().join("foo/bar/target"), is_not(existing_dir()));
 }
 
 #[test]
@@ -1358,12 +1359,12 @@ fn excluded_simple() {
         .file("foo/src/lib.rs", "");
     let p = p.build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0));
-    assert_that(&p.root().join("target"), existing_dir());
-    assert_that(p.cargo("build").cwd(p.root().join("foo")),
+    assert_that!(&p.root().join("target"), existing_dir());
+    assert_that!(p.cargo("build").cwd(p.root().join("foo")),
                 execs().with_status(0));
-    assert_that(&p.root().join("foo/target"), existing_dir());
+    assert_that!(&p.root().join("foo/target"), existing_dir());
 }
 
 #[test]
@@ -1396,15 +1397,15 @@ fn exclude_members_preferred() {
         .file("foo/bar/src/lib.rs", "");
     let p = p.build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0));
-    assert_that(&p.root().join("target"), existing_dir());
-    assert_that(p.cargo("build").cwd(p.root().join("foo")),
+    assert_that!(&p.root().join("target"), existing_dir());
+    assert_that!(p.cargo("build").cwd(p.root().join("foo")),
                 execs().with_status(0));
-    assert_that(&p.root().join("foo/target"), existing_dir());
-    assert_that(p.cargo("build").cwd(p.root().join("foo/bar")),
+    assert_that!(&p.root().join("foo/target"), existing_dir());
+    assert_that!(p.cargo("build").cwd(p.root().join("foo/bar")),
                 execs().with_status(0));
-    assert_that(&p.root().join("foo/bar/target"), is_not(existing_dir()));
+    assert_that!(&p.root().join("foo/bar/target"), is_not(existing_dir()));
 }
 
 #[test]
@@ -1439,15 +1440,15 @@ fn exclude_but_also_depend() {
         .file("foo/bar/src/lib.rs", "");
     let p = p.build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(0));
-    assert_that(&p.root().join("target"), existing_dir());
-    assert_that(p.cargo("build").cwd(p.root().join("foo")),
+    assert_that!(&p.root().join("target"), existing_dir());
+    assert_that!(p.cargo("build").cwd(p.root().join("foo")),
                 execs().with_status(0));
-    assert_that(&p.root().join("foo/target"), existing_dir());
-    assert_that(p.cargo("build").cwd(p.root().join("foo/bar")),
+    assert_that!(&p.root().join("foo/target"), existing_dir());
+    assert_that!(p.cargo("build").cwd(p.root().join("foo/bar")),
                 execs().with_status(0));
-    assert_that(&p.root().join("foo/bar/target"), existing_dir());
+    assert_that!(&p.root().join("foo/bar/target"), existing_dir());
 }
 
 #[test]
@@ -1489,29 +1490,29 @@ fn glob_syntax() {
         .file("crates/qux/src/main.rs", "fn main() {}");
     let p = p.build();
 
-    assert_that(p.cargo("build"), execs().with_status(0));
-    assert_that(&p.bin("foo"), existing_file());
-    assert_that(&p.bin("bar"), is_not(existing_file()));
-    assert_that(&p.bin("baz"), is_not(existing_file()));
+    assert_that!(p.cargo("build"), execs().with_status(0));
+    assert_that!(&p.bin("foo"), existing_file());
+    assert_that!(&p.bin("bar"), is_not(existing_file()));
+    assert_that!(&p.bin("baz"), is_not(existing_file()));
 
-    assert_that(p.cargo("build").cwd(p.root().join("crates/bar")),
+    assert_that!(p.cargo("build").cwd(p.root().join("crates/bar")),
                 execs().with_status(0));
-    assert_that(&p.bin("foo"), existing_file());
-    assert_that(&p.bin("bar"), existing_file());
+    assert_that!(&p.bin("foo"), existing_file());
+    assert_that!(&p.bin("bar"), existing_file());
 
-    assert_that(p.cargo("build").cwd(p.root().join("crates/baz")),
+    assert_that!(p.cargo("build").cwd(p.root().join("crates/baz")),
                 execs().with_status(0));
-    assert_that(&p.bin("foo"), existing_file());
-    assert_that(&p.bin("baz"), existing_file());
+    assert_that!(&p.bin("foo"), existing_file());
+    assert_that!(&p.bin("baz"), existing_file());
 
-    assert_that(p.cargo("build").cwd(p.root().join("crates/qux")),
+    assert_that!(p.cargo("build").cwd(p.root().join("crates/qux")),
                 execs().with_status(0));
-    assert_that(&p.bin("qux"), is_not(existing_file()));
+    assert_that!(&p.bin("qux"), is_not(existing_file()));
 
-    assert_that(&p.root().join("Cargo.lock"), existing_file());
-    assert_that(&p.root().join("crates/bar/Cargo.lock"), is_not(existing_file()));
-    assert_that(&p.root().join("crates/baz/Cargo.lock"), is_not(existing_file()));
-    assert_that(&p.root().join("crates/qux/Cargo.lock"), existing_file());
+    assert_that!(&p.root().join("Cargo.lock"), existing_file());
+    assert_that!(&p.root().join("crates/bar/Cargo.lock"), is_not(existing_file()));
+    assert_that!(&p.root().join("crates/baz/Cargo.lock"), is_not(existing_file()));
+    assert_that!(&p.root().join("crates/qux/Cargo.lock"), existing_file());
 }
 
 /*FIXME: This fails because of how workspace.exclude and workspace.members are working.
@@ -1554,29 +1555,29 @@ fn glob_syntax_2() {
         .file("crates/qux/src/main.rs", "fn main() {}");
     p.build();
 
-    assert_that(p.cargo("build"), execs().with_status(0));
-    assert_that(&p.bin("foo"), existing_file());
-    assert_that(&p.bin("bar"), is_not(existing_file()));
-    assert_that(&p.bin("baz"), is_not(existing_file()));
+    assert_that!(p.cargo("build"), execs().with_status(0));
+    assert_that!(&p.bin("foo"), existing_file());
+    assert_that!(&p.bin("bar"), is_not(existing_file()));
+    assert_that!(&p.bin("baz"), is_not(existing_file()));
 
-    assert_that(p.cargo("build").cwd(p.root().join("crates/bar")),
+    assert_that!(p.cargo("build").cwd(p.root().join("crates/bar")),
                 execs().with_status(0));
-    assert_that(&p.bin("foo"), existing_file());
-    assert_that(&p.bin("bar"), existing_file());
+    assert_that!(&p.bin("foo"), existing_file());
+    assert_that!(&p.bin("bar"), existing_file());
 
-    assert_that(p.cargo("build").cwd(p.root().join("crates/baz")),
+    assert_that!(p.cargo("build").cwd(p.root().join("crates/baz")),
                 execs().with_status(0));
-    assert_that(&p.bin("foo"), existing_file());
-    assert_that(&p.bin("baz"), existing_file());
+    assert_that!(&p.bin("foo"), existing_file());
+    assert_that!(&p.bin("baz"), existing_file());
 
-    assert_that(p.cargo("build").cwd(p.root().join("crates/qux")),
+    assert_that!(p.cargo("build").cwd(p.root().join("crates/qux")),
                 execs().with_status(0));
-    assert_that(&p.bin("qux"), is_not(existing_file()));
+    assert_that!(&p.bin("qux"), is_not(existing_file()));
 
-    assert_that(&p.root().join("Cargo.lock"), existing_file());
-    assert_that(&p.root().join("crates/bar/Cargo.lock"), is_not(existing_file()));
-    assert_that(&p.root().join("crates/baz/Cargo.lock"), is_not(existing_file()));
-    assert_that(&p.root().join("crates/qux/Cargo.lock"), existing_file());
+    assert_that!(&p.root().join("Cargo.lock"), existing_file());
+    assert_that!(&p.root().join("crates/bar/Cargo.lock"), is_not(existing_file()));
+    assert_that!(&p.root().join("crates/baz/Cargo.lock"), is_not(existing_file()));
+    assert_that!(&p.root().join("crates/qux/Cargo.lock"), existing_file());
 }
 */
 
@@ -1596,7 +1597,7 @@ fn glob_syntax_invalid_members() {
         .file("crates/bar/src/main.rs", "fn main() {}");
     let p = p.build();
 
-    assert_that(p.cargo("build"),
+    assert_that!(p.cargo("build"),
                 execs().with_status(101)
                        .with_stderr("\
 error: failed to read `[..]Cargo.toml`
@@ -1657,7 +1658,7 @@ fn dep_used_with_separate_features() {
     let p = p.build();
 
     // Build the entire workspace
-    assert_that(p.cargo("build").arg("--all"),
+    assert_that!(p.cargo("build").arg("--all"),
                 execs().with_status(0)
                        .with_stderr("\
 [..]Compiling feat_lib v0.1.0 ([..])
@@ -1665,15 +1666,15 @@ fn dep_used_with_separate_features() {
 [..]Compiling caller2 v0.1.0 ([..])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
-    assert_that(&p.bin("caller1"), existing_file());
-    assert_that(&p.bin("caller2"), existing_file());
+    assert_that!(&p.bin("caller1"), existing_file());
+    assert_that!(&p.bin("caller2"), existing_file());
 
 
     // Build caller1. should build the dep library. Because the features
     // are different than the full workspace, it rebuilds.
     // Ideally once we solve https://github.com/rust-lang/cargo/issues/3620, then
     // a single cargo build at the top level will be enough.
-    assert_that(p.cargo("build").cwd(p.root().join("caller1")),
+    assert_that!(p.cargo("build").cwd(p.root().join("caller1")),
                 execs().with_status(0)
                        .with_stderr("\
 [..]Compiling feat_lib v0.1.0 ([..])
@@ -1683,17 +1684,17 @@ fn dep_used_with_separate_features() {
 
     // Alternate building caller2/caller1 a few times, just to make sure
     // features are being built separately.  Should not rebuild anything
-    assert_that(p.cargo("build").cwd(p.root().join("caller2")),
+    assert_that!(p.cargo("build").cwd(p.root().join("caller2")),
                 execs().with_status(0)
                        .with_stderr("\
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
-    assert_that(p.cargo("build").cwd(p.root().join("caller1")),
+    assert_that!(p.cargo("build").cwd(p.root().join("caller1")),
                 execs().with_status(0)
                        .with_stderr("\
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
-    assert_that(p.cargo("build").cwd(p.root().join("caller2")),
+    assert_that!(p.cargo("build").cwd(p.root().join("caller2")),
                 execs().with_status(0)
                        .with_stderr("\
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
@@ -1744,7 +1745,7 @@ fn dont_recurse_out_of_cargo_home() {
         .file("src/lib.rs", "");
     let p = p.build();
 
-    assert_that(p.cargo("build").env("CARGO_HOME", p.root().join(".cargo")),
+    assert_that!(p.cargo("build").env("CARGO_HOME", p.root().join(".cargo")),
                 execs().with_status(0));
 }
 
@@ -1773,13 +1774,13 @@ fn include_and_exclude() {
         .file("foo/bar/src/lib.rs", "");
     p.build();
 
-    assert_that(p.cargo("build").cwd(p.root().join("foo")),
+    assert_that!(p.cargo("build").cwd(p.root().join("foo")),
     execs().with_status(0));
-    assert_that(&p.root().join("target"), existing_dir());
-    assert_that(&p.root().join("foo/target"), is_not(existing_dir()));
-    assert_that(p.cargo("build").cwd(p.root().join("foo/bar")),
+    assert_that!(&p.root().join("target"), existing_dir());
+    assert_that!(&p.root().join("foo/target"), is_not(existing_dir()));
+    assert_that!(p.cargo("build").cwd(p.root().join("foo/bar")),
     execs().with_status(0));
-    assert_that(&p.root().join("foo/bar/target"), existing_dir());
+    assert_that!(&p.root().join("foo/bar/target"), existing_dir());
 }
 */
 
@@ -1803,7 +1804,7 @@ fn cargo_home_at_root_works() {
         .file("a/src/lib.rs", "");
     let p = p.build();
 
-    assert_that(p.cargo("build"), execs().with_status(0));
-    assert_that(p.cargo("build").arg("--frozen").env("CARGO_HOME", p.root()),
+    assert_that!(p.cargo("build"), execs().with_status(0));
+    assert_that!(p.cargo("build").arg("--frozen").env("CARGO_HOME", p.root()),
                 execs().with_status(0));
 }


### PR DESCRIPTION
The main change is that the `assert_that` function is now deprecated and
is replaced by the `assert_that!` macro hence the size of that patch.
Since that macro needs some traits to be in scope, I changed every
hamcrest import to be just `use hamcrest::prelude::*`.