### PR TITLE
unblock rust-lang/rust#46980 by cleaning up an unused pair of parentheses

### DIFF
--- a/src/cargo/ops/cargo_test.rs
+++ b/src/cargo/ops/cargo_test.rs
@@ -120,7 +120,7 @@ fn run_unit_tests(options: &TestOptions,
         let (kind, test, e) = errors.pop().unwrap();
         Ok((Test::UnitTest(kind, test), vec![e]))
     } else {
-        Ok((Test::Multiple, errors.into_iter().map((|(_, _, e)| e)).collect()))
+        Ok((Test::Multiple, errors.into_iter().map(|(_, _, e)| e).collect()))
     }
 }
 


### PR DESCRIPTION
While this might seem like too trivial of a stylistic nitpick to deserve
its own commit, this [is needed to unblock](https://github.com/rust-lang/rust/pull/46980#issuecomment-355565906) the PR rust-lang/rust#46980 (which makes
the unused-parens lint look at function arguments, which it previously didn't).
  