### PR TITLE
Cargo.toml: Replace '/' with 'OR' in 'license'

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.26.0"
 authors = ["Yehuda Katz <wycats@gmail.com>",
            "Carl Lerche <me@carllerche.com>",
            "Alex Crichton <alex@alexcrichton.com>"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 homepage = "https://crates.io"
 repository = "https://github.com/rust-lang/cargo"
 documentation = "https://docs.rs/cargo"

--- a/src/crates-io/Cargo.toml
+++ b/src/crates-io/Cargo.toml
@@ -2,7 +2,7 @@
 name = "crates-io"
 version = "0.15.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/cargo"
 description = """
 Helpers for interacting with crates.io


### PR DESCRIPTION
Catch up with our recommendations from 7dee65fe (#4898), which deprecated `/` in favor of vanilla SPDX license expressions.

I've gone with the disjunctive `OR`, because the README has:

> Cargo is primarily distributed under the terms of both the MIT license and the Apache License (Version 2.0).