### PR TITLE
doc/guide/dependencies: Add a 'rust' language marker

### DIFF
--- a/src/doc/src/guide/dependencies.md
+++ b/src/doc/src/guide/dependencies.md
@@ -70,7 +70,7 @@ we choose to `cargo update`.
 
 You can now use the `regex` library using `extern crate` in `main.rs`.
 
-```
+```rust
 extern crate regex;
 
 use regex::Regex;


### PR DESCRIPTION
This had been added to the non-book docs in 2ad45a56 (#4455), despite the fact that the book didn't actually have that marker:


    $ git cat-file -p 2ad45a56:src/doc/book/src/guide/dependencies.md | grep -A2 'You can now use the'
    You can now use the `regex` library using `extern crate` in `main.rs`.

    ```

This is (along with the already-landed #4916), part of recovering from #4904.