### PR TITLE
doc/reference/index: Remove "Now that you have an overview" paragraph

### DIFF
--- a/src/doc/src/reference/index.md
+++ b/src/doc/src/reference/index.md
@@ -1,8 +1,5 @@
 ## Cargo Reference
 
-Now that you have an overview of how to use Cargo and have created your first
-crate, you may be interested in more details in the following areas.
-
 The reference covers the details of various areas of Cargo.
 
 * [Specifying Dependencies](reference/specifying-dependencies.html)


### PR DESCRIPTION
This wording was originally from 58a1804f (#2688), which added it to the end of the guide (where telling readers what they know makes some sense).  It was moved to a "Cargo in Depth" section with 01aa9e3c (#4453), where it makes a bit less sense.  When that section became the reference index in 3f2d93e3 (#4455) the context assumed by the paragraph was completely missing.

This commit removes the paragraph, which doesn't reduce the usefulness of the reference index.  And the removal avoids confusing readers who start with the reference docs and may now have the assumed overview.