### PR TITLE
Add workspace root to metadata command.

### DIFF
--- a/src/cargo/ops/cargo_output_metadata.rs
+++ b/src/cargo/ops/cargo_output_metadata.rs
@@ -39,6 +39,7 @@ fn metadata_no_deps(ws: &Workspace,
         resolve: None,
         target_directory: ws.target_dir().display().to_string(),
         version: VERSION,
+        workspace_root: ws.root().display().to_string(),
     })
 }
 
@@ -66,6 +67,7 @@ fn metadata_full(ws: &Workspace,
         }),
         target_directory: ws.target_dir().display().to_string(),
         version: VERSION,
+        workspace_root: ws.root().display().to_string(),
     })
 }
 
@@ -76,6 +78,7 @@ pub struct ExportInfo {
     resolve: Option<MetadataResolve>,
     target_directory: String,
     version: u32,
+    workspace_root: String,
 }
 
 /// Newtype wrapper to provide a custom `Serialize` implementation.

--- a/tests/metadata.rs
+++ b/tests/metadata.rs
@@ -51,7 +51,8 @@ fn cargo_metadata_simple() {
             "root": "foo 0.5.0 (path+file:[..]foo)"
         },
         "target_directory": "[..]foo[/]target",
-        "version": 1
+        "version": 1,
+        "workspace_root": "[..][/]foo"
     }"#));
 }
 
@@ -125,7 +126,8 @@ crate-type = ["lib", "staticlib"]
             "root": "foo 0.5.0 (path+file:[..]foo)"
         },
         "target_directory": "[..]foo[/]target",
-        "version": 1
+        "version": 1,
+        "workspace_root": "[..][/]foo"
     }"#));
 }
 
@@ -275,7 +277,8 @@ fn cargo_metadata_with_deps_and_version() {
             "root": "foo 0.5.0 (path+file:[..]foo)"
         },
         "target_directory": "[..]foo[/]target",
-        "version": 1
+        "version": 1,
+        "workspace_root": "[..][/]foo"
     }"#));
 }
 
@@ -337,7 +340,8 @@ name = "ex"
             ]
         },
         "target_directory": "[..]foo[/]target",
-        "version": 1
+        "version": 1,
+        "workspace_root": "[..][/]foo"
     }"#));
 }
 
@@ -400,7 +404,8 @@ crate-type = ["rlib", "dylib"]
             ]
         },
         "target_directory": "[..]foo[/]target",
-        "version": 1
+        "version": 1,
+        "workspace_root": "[..][/]foo"
     }"#));
 }
 
@@ -476,7 +481,8 @@ fn workspace_metadata() {
             "root": null
         },
         "target_directory": "[..]foo[/]target",
-        "version": 1
+        "version": 1,
+        "workspace_root": "[..][/]foo"
     }"#))
 }
 
@@ -540,7 +546,8 @@ fn workspace_metadata_no_deps() {
         "workspace_members": ["baz 0.5.0 (path+file:[..]baz)", "bar 0.5.0 (path+file:[..]bar)"],
         "resolve": null,
         "target_directory": "[..]foo[/]target",
-        "version": 1
+        "version": 1,
+        "workspace_root": "[..][/]foo"
     }"#))
 }
 
@@ -582,7 +589,8 @@ const MANIFEST_OUTPUT: &'static str=
     "workspace_members": [ "foo 0.5.0 (path+file:[..]foo)" ],
     "resolve": null,
     "target_directory": "[..]foo[/]target",
-    "version": 1
+    "version": 1,
+    "workspace_root": "[..][/]foo"
 }"#;
 
 #[test]


### PR DESCRIPTION
Fixes #4933 

@alexcrichton, you mentioned using `"workspace_manifest"`, but the `Workspace.root` function already strips off `Cargo.toml`.  It would be easy to append it back, though I'm uncertain if that's really necessary since I think for most use cases it will just need to be stripped off again.  Also, I feel like it might be confusing for non-workspace packages since `workspace_manifest` would be the same as the package `manifest_path` (and in that case it isn't really a workspace manifest).  I can easily change it, just let me know.