### PR TITLE
Add workspace root to metadata command.

### DIFF
--- a/src/cargo/ops/cargo_output_metadata.rs
+++ b/src/cargo/ops/cargo_output_metadata.rs
@@ -39,6 +39,7 @@ fn metadata_no_deps(ws: &Workspace,
         resolve: None,
         target_directory: ws.target_dir().display().to_string(),
         version: VERSION,
+        workspace_root: ws.root().display().to_string(),
     })
 }
 
@@ -66,6 +67,7 @@ fn metadata_full(ws: &Workspace,
         }),
         target_directory: ws.target_dir().display().to_string(),
         version: VERSION,
+        workspace_root: ws.root().display().to_string(),
     })
 }
 
@@ -76,6 +78,7 @@ pub struct ExportInfo {
     resolve: Option<MetadataResolve>,
     target_directory: String,
     version: u32,
+    workspace_root: String,
 }
 
 /// Newtype wrapper to provide a custom `Serialize` implementation.

--- a/tests/metadata.rs
+++ b/tests/metadata.rs
@@ -51,7 +51,8 @@ fn cargo_metadata_simple() {
             "root": "foo 0.5.0 (path+file:[..]foo)"
         },
         "target_directory": "[..]foo[/]target",
-        "version": 1
+        "version": 1,
+        "workspace_root": "[..][/]foo"
     }"#));
 }
 
@@ -125,7 +126,8 @@ crate-type = ["lib", "staticlib"]
             "root": "foo 0.5.0 (path+file:[..]foo)"
         },
         "target_directory": "[..]foo[/]target",
-        "version": 1
+        "version": 1,
+        "workspace_root": "[..][/]foo"
     }"#));
 }
 
@@ -275,7 +277,8 @@ fn cargo_metadata_with_deps_and_version() {
             "root": "foo 0.5.0 (path+file:[..]foo)"
         },
         "target_directory": "[..]foo[/]target",
-        "version": 1
+        "version": 1,
+        "workspace_root": "[..][/]foo"
     }"#));
 }
 
@@ -337,7 +340,8 @@ name = "ex"
             ]
         },
         "target_directory": "[..]foo[/]target",
-        "version": 1
+        "version": 1,
+        "workspace_root": "[..][/]foo"
     }"#));
 }
 
@@ -400,7 +404,8 @@ crate-type = ["rlib", "dylib"]
             ]
         },
         "target_directory": "[..]foo[/]target",
-        "version": 1
+        "version": 1,
+        "workspace_root": "[..][/]foo"
     }"#));
 }
 
@@ -476,7 +481,8 @@ fn workspace_metadata() {
             "root": null
         },
         "target_directory": "[..]foo[/]target",
-        "version": 1
+        "version": 1,
+        "workspace_root": "[..][/]foo"
     }"#))
 }
 
@@ -540,7 +546,8 @@ fn workspace_metadata_no_deps() {
         "workspace_members": ["baz 0.5.0 (path+file:[..]baz)", "bar 0.5.0 (path+file:[..]bar)"],
         "resolve": null,
         "target_directory": "[..]foo[/]target",
-        "version": 1
+        "version": 1,
+        "workspace_root": "[..][/]foo"
     }"#))
 }
 
@@ -582,7 +589,8 @@ const MANIFEST_OUTPUT: &'static str=
     "workspace_members": [ "foo 0.5.0 (path+file:[..]foo)" ],
     "resolve": null,
     "target_directory": "[..]foo[/]target",
-    "version": 1
+    "version": 1,
+    "workspace_root": "[..][/]foo"
 }"#;
 
 #[test]


### PR DESCRIPTION
Fixes #4933 

Merge of #4938 for rust 1.24 beta.

@alexcrichton I'm uncertain about the process for merging in beta.  I'm guessing after this I just need to open a PR on the rust beta branch to update the cargo submodule?