### PR TITLE
call out that `cargo install` != `npm install`

### DIFF
--- a/src/bin/install.rs
+++ b/src/bin/install.rs
@@ -37,7 +37,9 @@ pub struct Options {
 }
 
 pub const USAGE: &'static str = "
-Install a Rust binary
+Install a Rust binary, for example, additional Cargo commands
+
+(If you're an npm user, please note this is completely unrelated to `npm install`. Please see `cargo build --help`.)
 
 Usage:
     cargo install [options] [<crate>...]


### PR DESCRIPTION
I have seen several people assume that `cargo install` is `npm install`. Given that JavaScript programmers are one of our big audiences, I think this deserves an explicit call-out above the fold.