### PR TITLE
cargo_new: drop the trailing slash for target exclusion in Git

### DIFF
--- a/src/cargo/ops/cargo_new.rs
+++ b/src/cargo/ops/cargo_new.rs
@@ -404,7 +404,7 @@ fn mk(config: &Config, opts: &MkOptions) -> CargoResult<()> {
     let name = opts.name;
     let cfg = global_config(config)?;
     // Please ensure that ignore and hgignore are in sync.
-    let ignore = ["\n", "/target/\n", "**/*.rs.bk\n",
+    let ignore = ["\n", "/target\n", "**/*.rs.bk\n",
         if !opts.bin { "Cargo.lock\n" } else { "" }]
         .concat();
     // Mercurial glob ignores can't be rooted, so just sticking a 'syntax: glob' at the top of the


### PR DESCRIPTION
When `target` is a symlink (e.g., to keep build outputs on a separate
partition), Git will not match the `/target/` ignore to the symlink
since it is not a directory. Drop the trailing slash to support ignoring
`target` as a symlink.