### PR TITLE
Remove a stray character from the Zsh completion script

### DIFF
--- a/src/etc/_cargo
+++ b/src/etc/_cargo
@@ -136,7 +136,7 @@ case $state in
             git-checkout)
                 _arguments \
                     '(-h, --help)'{-h,--help}'[show help message]' \
-                    'q(-q, --quiet)'{-q,--quiet}'[no output printed to stdout]' \
+                    '(-q, --quiet)'{-q,--quiet}'[no output printed to stdout]' \
                     '--reference=[REF]' \
                     '--url=[URL]' \
                     '(-v, --verbose)'{-v,--verbose}'[use verbose output]' \


### PR DESCRIPTION
That's not a command that people normally use, found it by accident...