### PR TITLE
Fix `[patch]` sections depending on one another

### DIFF
--- a/src/cargo/core/dependency.rs
+++ b/src/cargo/core/dependency.rs
@@ -254,6 +254,11 @@ impl Dependency {
     pub fn lock_to(&mut self, id: &PackageId) -> &mut Dependency {
         assert_eq!(self.inner.source_id, *id.source_id());
         assert!(self.inner.req.matches(id.version()));
+        trace!("locking dep from `{}` with `{}` at {} to {}",
+               self.name(),
+               self.version_req(),
+               self.source_id(),
+               id);
         self.set_version_req(VersionReq::exact(id.version()))
             .set_source_id(id.source_id().clone())
     }

--- a/src/cargo/ops/cargo_generate_lockfile.rs
+++ b/src/cargo/ops/cargo_generate_lockfile.rs
@@ -19,9 +19,14 @@ pub struct UpdateOptions<'a> {
 
 pub fn generate_lockfile(ws: &Workspace) -> CargoResult<()> {
     let mut registry = PackageRegistry::new(ws.config())?;
-    let resolve = ops::resolve_with_previous(&mut registry, ws,
+    let resolve = ops::resolve_with_previous(&mut registry,
+                                             ws,
                                              Method::Everything,
-                                             None, None, &[], true)?;
+                                             None,
+                                             None,
+                                             &[],
+                                             true,
+                                             true)?;
     ops::write_pkg_lockfile(ws, &resolve)?;
     Ok(())
 }
@@ -77,12 +82,13 @@ pub fn update_lockfile(ws: &Workspace, opts: &UpdateOptions)
     }
 
     let resolve = ops::resolve_with_previous(&mut registry,
-                                                  ws,
-                                                  Method::Everything,
-                                                  Some(&previous_resolve),
-                                                  Some(&to_avoid),
-                                                  &[],
-                                                  true)?;
+                                             ws,
+                                             Method::Everything,
+                                             Some(&previous_resolve),
+                                             Some(&to_avoid),
+                                             &[],
+                                             true,
+                                             true)?;
 
     // Summarize what is changing for the user.
     let print_change = |status: &str, msg: String, color: Color| {


### PR DESCRIPTION
This commit fixes a bug in `[patch]` where the original source is updated too
often (for example `Updating ...` being printed too much). This bug occurred
when patches depended on each other (for example the dependencies of a resolved
`[patch]` would actually resolve to a `[patch]` that hadn't been resolved yet).
The ordering of resolution/locking wasn't happening correctly and wasn't ready
to break these cycles!

The process of adding `[patch]` sections to a registry has been updated to
account for this bug. Instead of add-and-lock all in one go this commit instead
splits the addition of `[patch]` into two phases. In the first we collect a
bunch of unlocked patch summaries but record all the `PackageId` instances for
each url we've scraped. After all `[patch]` sections have been processed in this
manner we go back and lock all the summaries that were previously unlocked. The
`lock` function was updated to *only* need the map of patches from URL to
`PackageId` as it doesn't actually have access to the full `Summary` of patches
during the `lock_patches` method.

All in all this should correctly resolve dependencies here which means that
processing of patches should proceed as usual, avoiding updating the registry
too much!

Closes #4941