### PR TITLE
Ensure `[target]` rustflags are deterministically passed

### DIFF
--- a/src/cargo/ops/cargo_rustc/context.rs
+++ b/src/cargo/ops/cargo_rustc/context.rs
@@ -1221,6 +1221,16 @@ fn env_args(config: &Config,
                     None
                 }
             });
+
+            // Note that we may have multiple matching `[target]` sections and
+            // because we're passing flags to the compiler this can affect
+            // cargo's caching and whether it rebuilds. Ensure a deterministic
+            // ordering through sorting for now. We may perhaps one day wish to
+            // ensure a deterministic ordering via the order keys were defined
+            // in files perhaps.
+            let mut cfgs = cfgs.collect::<Vec<_>>();
+            cfgs.sort();
+
             for n in cfgs {
                 let key = format!("target.{}.{}", n, name);
                 if let Some(args) = config.get_list_or_split_string(&key)? {


### PR DESCRIPTION
The usage of `HashMap` in the `Config` tables introduced some nondeterminism, so
reverse that with a sort right before we pass it down to rustc. One day we'll
probably want to sort by the position where these keys were defined, but for now
a blanket sort should do the trick.

Closes #4935