### PR TITLE
Implement renaming dependencies in the manifest

### DIFF
--- a/src/cargo/core/dependency.rs
+++ b/src/cargo/core/dependency.rs
@@ -27,6 +27,7 @@ struct Inner {
     specified_req: bool,
     kind: Kind,
     only_match_name: bool,
+    rename: Option<String>,
 
     optional: bool,
     default_features: bool,
@@ -49,6 +50,7 @@ struct SerializedDependency<'a> {
     source: &'a SourceId,
     req: String,
     kind: Kind,
+    rename: Option<&'a str>,
 
     optional: bool,
     uses_default_features: bool,
@@ -69,6 +71,7 @@ impl ser::Serialize for Dependency {
             uses_default_features: self.uses_default_features(),
             features: self.features(),
             target: self.platform(),
+            rename: self.rename(),
         }.serialize(s)
     }
 }
@@ -182,6 +185,7 @@ impl Dependency {
                 default_features: true,
                 specified_req: false,
                 platform: None,
+                rename: None,
             }),
         }
     }
@@ -221,6 +225,10 @@ impl Dependency {
         self.inner.platform.as_ref()
     }
 
+    pub fn rename(&self) -> Option<&str> {
+        self.inner.rename.as_ref().map(|s| &**s)
+    }
+
     pub fn set_kind(&mut self, kind: Kind) -> &mut Dependency {
         Rc::make_mut(&mut self.inner).kind = kind;
         self
@@ -258,6 +266,11 @@ impl Dependency {
 
     pub fn set_platform(&mut self, platform: Option<Platform>) -> &mut Dependency {
         Rc::make_mut(&mut self.inner).platform = platform;
+        self
+    }
+
+    pub fn set_rename(&mut self, rename: &str) -> &mut Dependency {
+        Rc::make_mut(&mut self.inner).rename = Some(rename.to_string());
         self
     }
 

--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -159,6 +159,9 @@ features! {
 
         // Using epochs
         [unstable] epoch: bool,
+
+        // Renaming a package in the manifest via the `package` key
+        [unstable] rename_dependency: bool,
     }
 }
 

--- a/tests/metadata.rs
+++ b/tests/metadata.rs
@@ -193,7 +193,8 @@ fn cargo_metadata_with_deps_and_version() {
                         "req": "^0.0.1",
                         "source": "registry+[..]",
                         "target": null,
-                        "uses_default_features": true
+                        "uses_default_features": true,
+                        "rename": null
                     }
                 ],
                 "features": {},
@@ -228,7 +229,8 @@ fn cargo_metadata_with_deps_and_version() {
                         "req": "*",
                         "source": "registry+[..]",
                         "target": null,
-                        "uses_default_features": true
+                        "uses_default_features": true,
+                        "rename": null
                     }
                 ],
                 "features": {},

--- a/tests/rename-deps.rs
+++ b/tests/rename-deps.rs
@@ -1,0 +1,120 @@
+extern crate cargo;
+extern crate cargotest;
+extern crate hamcrest;
+
+use cargotest::support::{project, execs};
+use cargotest::support::registry::Package;
+use cargotest::ChannelChanger;
+use hamcrest::assert_that;
+
+#[test]
+fn gated() {
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [project]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+
+            [dependencies]
+            bar = { package = "foo", version = "0.1" }
+        "#)
+        .file("src/lib.rs", "")
+        .build();
+
+    assert_that(p.cargo("build").masquerade_as_nightly_cargo(),
+                execs().with_status(101)
+                       .with_stderr("\
+error: failed to parse manifest at `[..]`
+
+Caused by:
+  feature `rename-dependency` is required
+
+consider adding `cargo-features = [\"rename-dependency\"]` to the manifest
+"));
+
+    let p = project("bar")
+        .file("Cargo.toml", r#"
+            [project]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+
+            [dependencies]
+            bar = { version = "0.1", package = "baz" }
+        "#)
+        .file("src/lib.rs", "")
+        .build();
+
+    assert_that(p.cargo("build").masquerade_as_nightly_cargo(),
+                execs().with_status(101)
+                       .with_stderr("\
+error: failed to parse manifest at `[..]`
+
+Caused by:
+  feature `rename-dependency` is required
+
+consider adding `cargo-features = [\"rename-dependency\"]` to the manifest
+"));
+}
+
+#[test]
+fn rename_dependency() {
+    Package::new("bar", "0.1.0").publish();
+    Package::new("bar", "0.2.0").publish();
+
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            cargo-features = ["rename-dependency"]
+
+            [project]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+
+            [dependencies]
+            bar = { version = "0.1.0" }
+            baz = { version = "0.2.0", package = "bar" }
+        "#)
+        .file("src/lib.rs", "
+            extern crate bar;
+            extern crate baz;
+        ")
+        .build();
+
+    assert_that(p.cargo("build").masquerade_as_nightly_cargo(),
+                execs().with_status(0));
+}
+
+#[test]
+fn rename_with_different_names() {
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            cargo-features = ["rename-dependency"]
+
+            [project]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+
+            [dependencies]
+            baz = { path = "bar", package = "bar" }
+        "#)
+        .file("src/lib.rs", "
+            extern crate baz;
+        ")
+        .file("bar/Cargo.toml", r#"
+            [project]
+            name = "bar"
+            version = "0.0.1"
+            authors = []
+
+            [lib]
+            name = "random_name"
+        "#)
+        .file("bar/src/lib.rs", "")
+        .build();
+
+    assert_that(p.cargo("build").masquerade_as_nightly_cargo(),
+                execs().with_status(0));
+}


### PR DESCRIPTION
This commit implements a new unstable feature for manifests which allows
renaming a crate when depending on it. For example you can do:

```toml
cargo-features = ["dependencies-as"]

...

[dependencies]
foo = "0.1"
bar = { version = "0.1", registry = "custom", package = "foo" }
baz = { git = "https://github.com/foo/bar", package = "foo" }
```

Here three crates will be imported but they'll be made available to the Rust
source code via the names `foo` (crates.io), `bar` (the custom registry), and
`baz` (the git dependency). The *package* name, however, will be `foo` for all
of them. In other words the git repository here would be searched for a crate
called `foo`. For example:

```rust
extern crate foo; // crates.io
extern crate bar; // registry `custom`
extern crate baz; // git repository
```

The intention here is to enable a few use cases:

* Enable depending on the same named crate from different registries
* Allow depending on multiple versions of a crate from one registry
* Removing the need for `extern crate foo as bar` syntactically in Rust source

Currently I don't think we're ready to stabilize this so it's just a nightly
feature, but I'm hoping we can continue to iterate on it!

cc #1311