### PR TITLE
Allow packaging of crates with unstable features

### DIFF
--- a/src/cargo/ops/cargo_package.rs
+++ b/src/cargo/ops/cargo_package.rs
@@ -31,12 +31,6 @@ pub fn package(ws: &Workspace,
     let pkg = ws.current()?;
     let config = ws.config();
 
-    // Allow packaging if a registry has been provided, or if there are no nightly
-    // features enabled.
-    if opts.registry.is_none() && !pkg.manifest().features().activated().is_empty() {
-        bail!("cannot package or publish crates which activate nightly-only \
-               cargo features")
-    }
     let mut src = PathSource::new(pkg.root(),
                                   pkg.package_id().source_id(),
                                   config);

--- a/src/cargo/ops/registry.rs
+++ b/src/cargo/ops/registry.rs
@@ -42,6 +42,12 @@ pub struct PublishOpts<'cfg> {
 pub fn publish(ws: &Workspace, opts: &PublishOpts) -> CargoResult<()> {
     let pkg = ws.current()?;
 
+    // Allow publishing if a registry has been provided, or if there are no nightly
+    // features enabled.
+    if opts.registry.is_none() && !pkg.manifest().features().activated().is_empty() {
+        bail!("cannot publish crates which activate nightly-only cargo features to crates.io")
+    }
+
     if let &Some(ref allowed_registries) = pkg.publish() {
         if !match opts.registry {
             Some(ref registry) => allowed_registries.contains(registry),

--- a/tests/cargo-features.rs
+++ b/tests/cargo-features.rs
@@ -264,10 +264,10 @@ fn publish_rejected() {
         "#)
         .file("src/lib.rs", "")
         .build();
-    assert_that(p.cargo("package")
+    assert_that(p.cargo("publish")
                  .masquerade_as_nightly_cargo(),
                 execs().with_status(101)
                        .with_stderr("\
-error: cannot package or publish crates which activate nightly-only cargo features
+error: cannot publish crates which activate nightly-only cargo features to crates.io
 "));
 }

--- a/tests/publish.rs
+++ b/tests/publish.rs
@@ -706,7 +706,8 @@ fn block_publish_no_registry() {
         .build();
 
     assert_that(p.cargo("publish").masquerade_as_nightly_cargo()
-                 .arg("--index").arg(publish::registry().to_string()),
+                 .arg("--registry").arg("alternative")
+                 .arg("-Zunstable-options"),
                 execs().with_status(101).with_stderr("\
 [ERROR] some crates cannot be published.
 `foo` is marked as unpublishable


### PR DESCRIPTION
We don't want them to land on crates.io, but it's fine to make a .crate
file.

Closes #4954