### PR TITLE
Link to crate type docs

### DIFF
--- a/src/doc/src/reference/manifest.md
+++ b/src/doc/src/reference/manifest.md
@@ -613,7 +613,9 @@ compiled when you run your tests to protect them from bitrotting.
 You can run individual executable examples with the command `cargo run --example
 <example-name>`.
 
-Specify `crate-type` to make an example be compiled as a library:
+Specify `crate-type` to make an example be compiled as a library (additional 
+information about crate types is available in 
+[the Cargo reference](https://doc.rust-lang.org/reference/linkage.html)):
 
 ```toml
 [[example]]


### PR DESCRIPTION
This page (served at https://doc.rust-lang.org/cargo/reference/manifest.html) is the first hit I get when searching "cargo crate-type". The doc which actually explains `crate-type`, https://doc.rust-lang.org/reference/linkage.html, does not appear in the first page of results. I hope that linking the reference doc here will make it easier for others to find instead of having to dig into closed GitHub issues like I did to find it.