### PR TITLE
Allow unused_unsafe in LazyCell in preparation for lib change

### DIFF
--- a/src/cargo/util/lazy_cell.rs
+++ b/src/cargo/util/lazy_cell.rs
@@ -55,6 +55,7 @@ impl<T> LazyCell<T> {
     }
 
     /// Consumes this `LazyCell`, returning the underlying value.
+    #[allow(unused_unsafe)]
     pub fn into_inner(self) -> Option<T> {
         unsafe {
             self.inner.into_inner()


### PR DESCRIPTION
https://github.com/rust-lang/rust/pull/47204 makes `UnsafeCell::into_inner` safe, which means `LazyCell::into_inner` will no longer need an `unsafe` block. `LazyCell` is a blocker for the change in Rust: this fix should allow the change to take place.