### PR TITLE
cargo doc: Generate rmeta files for dependencies instead of compiling rlibs

### DIFF
--- a/src/cargo/ops/cargo_rustc/context.rs
+++ b/src/cargo/ops/cargo_rustc/context.rs
@@ -940,7 +940,7 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
             ret.push(Unit {
                 pkg: dep,
                 target: lib,
-                profile: self.lib_profile(),
+                profile: self.lib_or_check_profile(unit, lib),
                 kind: unit.kind.for_target(lib),
             });
             if self.build_config.doc_all {
@@ -1056,6 +1056,9 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
 
     pub fn lib_or_check_profile(&self, unit: &Unit, target: &Target) -> &'a Profile {
         if unit.profile.check && !target.is_custom_build() && !target.for_host() {
+            &self.profiles.check
+        } else if unit.profile.doc && !unit.profile.test &&
+                !target.is_custom_build() && !target.for_host() {
             &self.profiles.check
         } else {
             self.lib_profile()

--- a/src/cargo/ops/cargo_rustc/context.rs
+++ b/src/cargo/ops/cargo_rustc/context.rs
@@ -1055,14 +1055,12 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
     }
 
     pub fn lib_or_check_profile(&self, unit: &Unit, target: &Target) -> &'a Profile {
-        if unit.profile.check && !target.is_custom_build() && !target.for_host() {
-            &self.profiles.check
-        } else if unit.profile.doc && !unit.profile.test &&
-                !target.is_custom_build() && !target.for_host() {
-            &self.profiles.check
-        } else {
-            self.lib_profile()
+        if !target.is_custom_build() && !target.for_host() {
+            if unit.profile.check || (unit.profile.doc && !unit.profile.test) {
+                return &self.profiles.check
+            }
         }
+        self.lib_profile()
     }
 
     pub fn build_script_profile(&self, _pkg: &PackageId) -> &'a Profile {


### PR DESCRIPTION
This makes `cargo doc` require only metadata (`.rmeta` files) instead of compiled libraries (`.rlib` files) for dependencies.  This makes `cargo doc` faster in cases where rlibs are not already built and/or metadata is already available.

Unfortunately, this is not a win for every workflow.  In the case where the user has already compiled but has not generated metadata, it makes `cargo doc` do extra work.  This is probably a common case, though tools like RLS and `cargo check` mean that many developers *will* have up-to-date metadata available.

It would become an unequivocal win if `cargo build` and `cargo check` re-used shared metadata (#3501). For now, starting from a clean working directory, the following sequences of commands will become:

* `cargo doc`: faster
* `cargo build; cargo doc`: slower
* `cargo check; cargo doc`: faster
* `cargo build --release; cargo doc`: faster
* `cargo check; cargo build; cargo doc`: no change