### PR TITLE
Add --reinstall argument to the install option

### DIFF
--- a/src/bin/install.rs
+++ b/src/bin/install.rs
@@ -19,6 +19,7 @@ pub struct Options {
     flag_root: Option<String>,
     flag_list: bool,
     flag_force: bool,
+    flag_reinstall: bool,
     flag_frozen: bool,
     flag_locked: bool,
 
@@ -55,6 +56,7 @@ Specifying what crate to install:
 Build and install options:
     -h, --help                Print this message
     -j N, --jobs N            Number of parallel jobs, defaults to # of CPUs
+    -r, --reinstall           Reinstall the package
     -f, --force               Force overwriting existing crates or binaries
     --features FEATURES       Space-separated list of features to activate
     --all-features            Build all available features
@@ -93,8 +95,9 @@ one of them, and if you'd rather install examples the `--example` argument can
 be used as well.
 
 By default cargo will refuse to overwrite existing binaries. The `--force` flag
-enables overwriting existing binaries. Thus you can reinstall a crate with
-`cargo install --force <crate>`.
+enables overwriting existing binaries. Thus you can install new crate with
+overwriting old one with `cargo install --force <crate>`. However, if you want
+just to reinstall the crate, you `cargo install --reinstall <crate>`.
 
 As a special convenience, omitting the <crate> specification entirely will
 install the crate in the current directory. That is, `install` is equivalent to
@@ -169,7 +172,7 @@ pub fn execute(options: Options, config: &mut Config) -> CliResult {
     if options.flag_list {
         ops::install_list(root, config)?;
     } else {
-        ops::install(root, krates, &source, vers, &compile_opts, options.flag_force)?;
+        ops::install(root, krates, &source, vers, &compile_opts, options.flag_force, options.flag_reinstall)?;
     }
     Ok(())
 }

--- a/tests/cargotest/support/mod.rs
+++ b/tests/cargotest/support/mod.rs
@@ -890,6 +890,7 @@ fn substitute_macros(input: &str) -> String {
         ("[UPLOADING]",   "   Uploading"),
         ("[VERIFYING]",   "   Verifying"),
         ("[ARCHIVING]",   "   Archiving"),
+        ("[CHECKING]",    "    Checking"),
         ("[INSTALLING]",  "  Installing"),
         ("[REPLACING]",   "   Replacing"),
         ("[UNPACKING]",   "   Unpacking"),

--- a/tests/directory.rs
+++ b/tests/directory.rs
@@ -146,7 +146,8 @@ fn simple_install() {
 
     assert_that(cargo_process().arg("install").arg("bar"),
                 execs().with_status(0).with_stderr(
-"  Installing bar v0.1.0
+"    Checking bar v0.1.0
+  Installing bar v0.1.0
    Compiling foo v0.1.0
    Compiling bar v0.1.0
     Finished release [optimized] target(s) in [..] secs
@@ -191,7 +192,8 @@ fn simple_install_fail() {
 
     assert_that(cargo_process().arg("install").arg("bar"),
                 execs().with_status(101).with_stderr(
-"  Installing bar v0.1.0
+"    Checking bar v0.1.0
+  Installing bar v0.1.0
 error: failed to compile `bar v0.1.0`, intermediate artifacts can be found at `[..]`
 
 Caused by:
@@ -240,7 +242,8 @@ fn install_without_feature_dep() {
 
     assert_that(cargo_process().arg("install").arg("bar"),
                 execs().with_status(0).with_stderr(
-"  Installing bar v0.1.0
+"    Checking bar v0.1.0
+  Installing bar v0.1.0
    Compiling foo v0.1.0
    Compiling bar v0.1.0
     Finished release [optimized] target(s) in [..] secs

--- a/tests/required-features.rs
+++ b/tests/required-features.rs
@@ -552,6 +552,7 @@ fn install_default_features() {
 
     assert_that(p.cargo("install").arg("--no-default-features"),
                 execs().with_status(101).with_stderr(format!("\
+[CHECKING] foo v0.0.1 ([..])
 [INSTALLING] foo v0.0.1 ([..])
 [FINISHED] release [optimized] target(s) in [..]
 [ERROR] no binaries are available for install using the selected features
@@ -566,6 +567,7 @@ fn install_default_features() {
 
     assert_that(p.cargo("install").arg("--bin=foo").arg("--no-default-features"),
                 execs().with_status(101).with_stderr(format!("\
+[CHECKING] foo v0.0.1 ([..])
 [INSTALLING] foo v0.0.1 ([..])
 [ERROR] failed to compile `foo v0.0.1 ([..])`, intermediate artifacts can be found at \
     `[..]target`
@@ -584,6 +586,7 @@ Consider enabling them by passing e.g. `--features=\"a\"`
 
     assert_that(p.cargo("install").arg("--example=foo").arg("--no-default-features"),
                 execs().with_status(101).with_stderr(format!("\
+[CHECKING] foo v0.0.1 ([..])
 [INSTALLING] foo v0.0.1 ([..])
 [ERROR] failed to compile `foo v0.0.1 ([..])`, intermediate artifacts can be found at \
     `[..]target`
@@ -666,6 +669,7 @@ fn install_multiple_required_features() {
 
     assert_that(p.cargo("install").arg("--no-default-features"),
                 execs().with_status(101).with_stderr("\
+[CHECKING] foo v0.0.1 ([..])
 [INSTALLING] foo v0.0.1 ([..])
 [FINISHED] release [optimized] target(s) in [..]
 [ERROR] no binaries are available for install using the selected features
@@ -871,6 +875,7 @@ Consider enabling them by passing e.g. `--features=\"bar/a\"`
     // install
     assert_that(p.cargo("install"),
                 execs().with_status(101).with_stderr(format!("\
+[CHECKING] foo v0.0.1 ([..])
 [INSTALLING] foo v0.0.1 ([..])
 [FINISHED] release [optimized] target(s) in [..]
 [ERROR] no binaries are available for install using the selected features


### PR DESCRIPTION
The --reinstall option simply uninstalls the package before installing
it so the user need not run uninstall and then install. This also updates the
package since install always look for a new version.