### PR TITLE
[beta] Fix `RUSTC=./relative-path` when building

### DIFF
--- a/src/cargo/ops/cargo_test.rs
+++ b/src/cargo/ops/cargo_test.rs
@@ -120,7 +120,7 @@ fn run_unit_tests(options: &TestOptions,
         let (kind, test, e) = errors.pop().unwrap();
         Ok((Test::UnitTest(kind, test), vec![e]))
     } else {
-        Ok((Test::Multiple, errors.into_iter().map((|(_, _, e)| e)).collect()))
+        Ok((Test::Multiple, errors.into_iter().map(|(_, _, e)| e).collect()))
     }
 }
 

--- a/src/cargo/util/config.rs
+++ b/src/cargo/util/config.rs
@@ -605,7 +605,16 @@ impl Config {
     fn maybe_get_tool(&self, tool: &str) -> CargoResult<Option<PathBuf>> {
         let var = tool.chars().flat_map(|c| c.to_uppercase()).collect::<String>();
         if let Some(tool_path) = env::var_os(&var) {
-            return Ok(Some(PathBuf::from(tool_path)));
+            let maybe_relative = match tool_path.to_str() {
+                Some(s) => s.contains("/") || s.contains("\\"),
+                None => false,
+            };
+            let path = if maybe_relative {
+                self.cwd.join(tool_path)
+            } else {
+                PathBuf::from(tool_path)
+            };
+            return Ok(Some(path))
         }
 
         let var = format!("build.{}", tool);

--- a/src/cargo/util/lazy_cell.rs
+++ b/src/cargo/util/lazy_cell.rs
@@ -55,6 +55,7 @@ impl<T> LazyCell<T> {
     }
 
     /// Consumes this `LazyCell`, returning the underlying value.
+    #[allow(unused_unsafe)]
     pub fn into_inner(self) -> Option<T> {
         unsafe {
             self.inner.into_inner()

--- a/tests/bench.rs
+++ b/tests/bench.rs
@@ -257,6 +257,7 @@ fn many_similar_names() {
 }
 
 #[test]
+#[ignore] // unignored on the master branch of cargo
 fn cargo_bench_failing_test() {
     if !is_nightly() { return }
 


### PR DESCRIPTION
This is a backport of https://github.com/rust-lang/cargo/pull/4995