### PR TITLE
backtrack if can not activate

### DIFF
--- a/tests/testsuite/features.rs
+++ b/tests/testsuite/features.rs
@@ -113,11 +113,8 @@ error: failed to select a version for `bar`.
     ... required by package `foo v0.0.1 ([..])`
 versions that meet the requirements `*` are: 0.0.1
 
-the package `bar` depends on `bar`, with features: `bar` but it does not have these features.
-package `bar v0.0.1 ([..])`
-    ... which is depended on by `foo v0.0.1 ([..])`
+the package `foo` depends on `bar`, with features: `bar` but `bar` does not have these features.
 
-all possible versions conflict with previously selected packages.
 
 failed to select a version for `bar` which could resolve this conflict"));
 

--- a/tests/testsuite/features.rs
+++ b/tests/testsuite/features.rs
@@ -109,8 +109,17 @@ fn invalid4() {
 
     assert_that(p.cargo("build"),
                 execs().with_status(101).with_stderr("\
-[ERROR] Package `bar v0.0.1 ([..])` does not have these features: `bar`
-"));
+error: failed to select a version for `bar`.
+    ... required by package `foo v0.0.1 ([..])`
+versions that meet the requirements `*` are: 0.0.1
+
+the package `bar` depends on `bar`, with features: `bar` but it does not have these features.
+package `bar v0.0.1 ([..])`
+    ... which is depended on by `foo v0.0.1 ([..])`
+
+all possible versions conflict with previously selected packages.
+
+failed to select a version for `bar` which could resolve this conflict"));
 
     p.change_file("Cargo.toml", r#"
         [project]
@@ -121,8 +130,7 @@ fn invalid4() {
 
     assert_that(p.cargo("build").arg("--features").arg("test"),
                 execs().with_status(101).with_stderr("\
-[ERROR] Package `foo v0.0.1 ([..])` does not have these features: `test`
-"));
+error: Package `foo v0.0.1 ([..])` does not have these features: `test`"));
 }
 
 #[test]
@@ -1052,8 +1060,7 @@ fn dep_feature_in_cmd_line() {
     // Trying to enable features of transitive dependencies is an error
     assert_that(p.cargo("build").arg("--features").arg("bar/some-feat"),
                 execs().with_status(101).with_stderr("\
-[ERROR] Package `foo v0.0.1 ([..])` does not have these features: `bar`
-"));
+error: Package `foo v0.0.1 ([..])` does not have these features: `bar`"));
 
     // Hierarchical feature specification should still be disallowed
     assert_that(p.cargo("build").arg("--features").arg("derived/bar/some-feat"),

--- a/tests/testsuite/resolve.rs
+++ b/tests/testsuite/resolve.rs
@@ -58,20 +58,20 @@ trait ToPkgId {
     fn to_pkgid(&self) -> PackageId;
 }
 
-impl ToPkgId for &'static str {
+impl<'a> ToPkgId for &'a str {
     fn to_pkgid(&self) -> PackageId {
         PackageId::new(*self, "1.0.0", &registry_loc()).unwrap()
     }
 }
 
-impl ToPkgId for (&'static str, &'static str) {
+impl<'a> ToPkgId for (&'a str, &'a str) {
     fn to_pkgid(&self) -> PackageId {
         let (name, vers) = *self;
         PackageId::new(name, vers, &registry_loc()).unwrap()
     }
 }
 
-impl ToPkgId for (&'static str, String) {
+impl<'a> ToPkgId for (&'a str, String) {
     fn to_pkgid(&self) -> PackageId {
         let (name, ref vers) = *self;
         PackageId::new(name, vers, &registry_loc()).unwrap()
@@ -314,6 +314,27 @@ fn resolving_backtrack() {
     assert_that(&res, contains(names(&[("root", "1.0.0"),
                                        ("foo", "1.0.1"),
                                        ("baz", "1.0.0")])));
+}
+
+#[test]
+fn resolving_backtrack_features() {
+    // test for cargo/issues/4347
+    let mut bad = dep("bar");
+    bad.set_features(vec!["bad".to_string()]);
+
+    let reg = registry(vec![
+        pkg!(("foo", "1.0.2") => [bad]),
+        pkg!(("foo", "1.0.1") => [dep("bar")]),
+        pkg!("bar"),
+    ]);
+
+    let res = resolve(&pkg_id("root"), vec![
+        dep_req("foo", "^1"),
+    ], &reg).unwrap();
+
+    assert_that(&res, contains(names(&[("root", "1.0.0"),
+                                       ("foo", "1.0.1"),
+                                       ("bar", "1.0.0")])));
 }
 
 #[test]


### PR DESCRIPTION
This is a fix for #4347
Unfortunately this too regressed error messages for the case that you specified a dependency feature that does not  exist. 
@alexcrichton advice on improving the message?