### PR TITLE
Added "pijul" as a config key for cargo-new.vcs in .cargo/config

### DIFF
--- a/src/cargo/ops/cargo_new.rs
+++ b/src/cargo/ops/cargo_new.rs
@@ -590,6 +590,7 @@ fn global_config(config: &Config) -> CargoResult<CargoNewConfig> {
     let vcs = match vcs.as_ref().map(|p| (&p.val[..], &p.definition)) {
         Some(("git", _)) => Some(VersionControl::Git),
         Some(("hg", _)) => Some(VersionControl::Hg),
+        Some(("pijul", _)) => Some(VersionControl::Pijul),
         Some(("none", _)) => Some(VersionControl::NoVcs),
         Some((s, p)) => {
             return Err(internal(format!("invalid configuration for key \


### PR DESCRIPTION
Currently Pijul can only be set as a version control from the command-line but not from the cargo-new.vcs key in .cargo/config