### PR TITLE
manifest reference: correct statement: codegen-units=x is not ignored if lto=true.

### DIFF
--- a/src/doc/src/reference/manifest.md
+++ b/src/doc/src/reference/manifest.md
@@ -189,7 +189,7 @@ license-file = "..."
 #   Appveyor, CircleCI, GitLab, and TravisCI.
 # - Available badges pertaining to code test coverage are Codecov and
 #   Coveralls.
-# - There are also maintenance-related badges basesed on isitmaintained.com
+# - There are also maintenance-related badges based on isitmaintained.com
 #   which state the issue resolution time, percent of open issues, and future
 #   maintenance intentions.
 #
@@ -301,7 +301,7 @@ debug-assertions = true # controls whether debug assertions are enabled
                    # (e.g. debug_assert!() and arithmetic overflow checks)
 codegen-units = 1  # if > 1 enables parallel code generation which improves
                    # compile times, but prevents some optimizations.
-                   # Passes `-C codegen-units`. Ignored when `lto = true`.
+                   # Passes `-C codegen-units`.
 panic = 'unwind'   # panic strategy (`-C panic=...`), can also be 'abort'
 incremental = true # whether or not incremental compilation is enabled
 overflow-checks = true # use overflow checks for integer arithmetic.


### PR DESCRIPTION
Also fix typo along the way.