### PR TITLE
apply clippy suggestions

### DIFF
--- a/src/cargo/ops/registry.rs
+++ b/src/cargo/ops/registry.rs
@@ -220,7 +220,7 @@ fn transmit(config: &Config,
 
             Ok(())
         },
-        Err(e) => Err(e.into()),
+        Err(e) => Err(e),
     }
 }
 
@@ -437,7 +437,7 @@ pub fn modify_owners(config: &Config, opts: &OwnersOptions) -> CargoResult<()> {
                 (Some(name), Some(email)) => println!(" ({} <{}>)", name, email),
                 (Some(s), None) |
                 (None, Some(s)) => println!(" ({})", s),
-                (None, None) => println!(""),
+                (None, None) => println!(),
             }
         }
     }


### PR DESCRIPTION
I want to try if this actually works =)

There are many other clippy suggestions. I wonder if I can take them for granted or if some of them would be refused. 

For example:
```
warning: Constants have by default a `'static` lifetime
  --> src/cargo/lib.rs:53:23
   |
53 | pub const CARGO_ENV: &'static str = "CARGO";
   |                      -^^^^^^^---- help: consider removing `'static`: `&str`
   |
   = note: #[warn(const_static_lifetime)] on by default
   = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.185/index.html#const_static_lifetime
```