### PR TITLE
Add helpful message when running cargo doc --open

### DIFF
--- a/src/cargo/ops/cargo_doc.rs
+++ b/src/cargo/ops/cargo_doc.rs
@@ -59,7 +59,10 @@ pub fn doc(ws: &Workspace, options: &DocOptions) -> CargoResult<()> {
 
     if options.open_result {
         let name = if pkgs.len() > 1 {
-            bail!("Passing multiple packages and `open` is not supported")
+            bail!("Passing multiple packages and `open` is not supported.\n\
+                   Please re-run this command with `-p <spec>` where `<spec>` \
+                   is one of the following:\n  {}",
+                   pkgs.iter().map(|p| p.name()).collect::<Vec<_>>().join("\n  "));
         } else if pkgs.len() == 1 {
             pkgs[0].name().replace("-", "_")
         } else {


### PR DESCRIPTION
Add helpful message when running cargo doc --open in the root of the workspace.

closes #4962 

old output:

```
 Documenting foo v0.1.0 (file:///Users/marek/projects/ethcore/tmp/dupa/foo)
 Documenting bar v0.1.0 (file:///Users/marek/projects/ethcore/tmp/dupa/bar)
    Finished dev [unoptimized + debuginfo] target(s) in 0.78 secs
error: Passing multiple packages and `open` is not supported
```

new output:

```
 Documenting foo v0.1.0 (file:///Users/marek/projects/ethcore/tmp/dupa/foo)
 Documenting bar v0.1.0 (file:///Users/marek/projects/ethcore/tmp/dupa/bar)
    Finished dev [unoptimized + debuginfo] target(s) in 0.81 secs
error: Passing multiple packages and `open` is not supported.
Please re-run this command with `-p <spec>` where `<spec>` is one of the following:
  foo
  bar
```