### PR TITLE
New defaults to bin

### DIFF
--- a/src/bin/init.rs
+++ b/src/bin/init.rs
@@ -32,8 +32,8 @@ Options:
                         control system (git, hg, pijul, or fossil) or do not
                         initialize any version control at all (none), overriding
                         a global configuration.
-    --bin               Use a binary (application) template
-    --lib               Use a library template [default]
+    --bin               Use a binary (application) template [default]
+    --lib               Use a library template
     --name NAME         Set the resulting package name
     -v, --verbose ...   Use verbose output (-vv very verbose/build.rs output)
     -q, --quiet         No output printed to stdout

--- a/src/bin/init.rs
+++ b/src/bin/init.rs
@@ -56,17 +56,16 @@ pub fn execute(options: Options, config: &mut Config) -> CliResult {
 
     let path = &arg_path.unwrap_or_else(|| String::from("."));
     let opts = ops::NewOptions::new(flag_vcs,
-                                     flag_bin,
-                                     flag_lib,
-                                     path,
-                                     flag_name.as_ref().map(|s| s.as_ref()));
+                                    flag_bin,
+                                    flag_lib,
+                                    path,
+                                    flag_name.as_ref().map(|s| s.as_ref()));
 
     let opts_lib = opts.lib;
     ops::init(&opts, config)?;
 
-    config.shell().status("Created", format!("{} project",
-                                             if opts_lib { "library" }
-                                             else {"binary (application)"}))?;
+    let project_kind = if opts_lib { "library" } else { "binary (application)" };
+    config.shell().status("Created", format!("{} project", project_kind))?;
 
     Ok(())
 }

--- a/src/bin/init.rs
+++ b/src/bin/init.rs
@@ -59,13 +59,11 @@ pub fn execute(options: Options, config: &mut Config) -> CliResult {
                                     flag_bin,
                                     flag_lib,
                                     path,
-                                    flag_name.as_ref().map(|s| s.as_ref()));
+                                    flag_name.as_ref().map(|s| s.as_ref()))?;
 
-    let opts_lib = opts.lib;
     ops::init(&opts, config)?;
 
-    let project_kind = if opts_lib { "library" } else { "binary (application)" };
-    config.shell().status("Created", format!("{} project", project_kind))?;
+    config.shell().status("Created", format!("{} project", opts.kind))?;
 
     Ok(())
 }

--- a/src/bin/new.rs
+++ b/src/bin/new.rs
@@ -32,8 +32,8 @@ Options:
                         control system (git, hg, pijul, or fossil) or do not
                         initialize any version control at all (none), overriding
                         a global configuration.
-    --bin               Use a binary (application) template
-    --lib               Use a library template [default]
+    --bin               Use a binary (application) template [default]
+    --lib               Use a library template
     --name NAME         Set the resulting package name, defaults to the value of <path>
     -v, --verbose ...   Use verbose output (-vv very verbose/build.rs output)
     -q, --quiet         No output printed to stdout

--- a/src/bin/new.rs
+++ b/src/bin/new.rs
@@ -63,10 +63,8 @@ pub fn execute(options: Options, config: &mut Config) -> CliResult {
     let opts_lib = opts.lib;
     ops::new(&opts, config)?;
 
-    config.shell().status("Created", format!("{} `{}` project",
-                                             if opts_lib { "library" }
-                                             else {"binary (application)"},
-                                             arg_path))?;
+    let project_kind = if opts_lib { "library" } else { "binary (application)" };
+    config.shell().status("Created", format!("{} `{}` project", project_kind, arg_path))?;
 
     Ok(())
 }

--- a/src/bin/new.rs
+++ b/src/bin/new.rs
@@ -58,13 +58,11 @@ pub fn execute(options: Options, config: &mut Config) -> CliResult {
                                     flag_bin,
                                     flag_lib,
                                     &arg_path,
-                                    flag_name.as_ref().map(|s| s.as_ref()));
+                                    flag_name.as_ref().map(|s| s.as_ref()))?;
 
-    let opts_lib = opts.lib;
     ops::new(&opts, config)?;
 
-    let project_kind = if opts_lib { "library" } else { "binary (application)" };
-    config.shell().status("Created", format!("{} `{}` project", project_kind, arg_path))?;
+    config.shell().status("Created", format!("{} `{}` project", opts.kind, arg_path))?;
 
     Ok(())
 }

--- a/src/cargo/ops/cargo_new.rs
+++ b/src/cargo/ops/cargo_new.rs
@@ -62,25 +62,20 @@ impl<'de> Deserialize<'de> for VersionControl {
 
 impl<'a> NewOptions<'a> {
     pub fn new(version_control: Option<VersionControl>,
-           bin: bool,
-           lib: bool,
-           path: &'a str,
-           name: Option<&'a str>) -> NewOptions<'a> {
+               bin: bool,
+               lib: bool,
+               path: &'a str,
+               name: Option<&'a str>) -> NewOptions<'a> {
 
         // default to lib
-        let is_lib = if !bin {
-            true
-        }
-        else {
-            lib
-        };
+        let is_lib = !bin || lib;
 
         NewOptions {
-            version_control: version_control,
-            bin: bin,
+            version_control,
+            bin,
             lib: is_lib,
-            path: path,
-            name: name,
+            path,
+            name,
         }
     }
 }

--- a/src/cargo/ops/cargo_new.rs
+++ b/src/cargo/ops/cargo_new.rs
@@ -92,8 +92,8 @@ impl<'a> NewOptions<'a> {
             (true, true) => bail!("can't specify both lib and binary outputs"),
             (true, false) => NewProjectKind::Bin,
             (false, true) => NewProjectKind::Lib,
-            // default to lib
-            (false, false) => NewProjectKind::Lib,
+            // default to bin
+            (false, false) => NewProjectKind::Bin,
         };
 
         let opts = NewOptions { version_control, kind, path, name };

--- a/src/doc/src/getting-started/first-steps.md
+++ b/src/doc/src/getting-started/first-steps.md
@@ -7,7 +7,7 @@ $ cargo new hello_world --bin
 ```
 
 We’re passing `--bin` because we’re making a binary program: if we
-were making a library, we’d leave it off.
+were making a library, we’d pass `--lib`.
 
 Let’s check out what Cargo has generated for us:
 

--- a/src/doc/src/guide/creating-a-new-project.md
+++ b/src/doc/src/guide/creating-a-new-project.md
@@ -7,7 +7,7 @@ $ cargo new hello_world --bin
 ```
 
 We’re passing `--bin` because we’re making a binary program: if we
-were making a library, we’d leave it off. This also initializes a new `git`
+were making a library, we’d pass `--lib`. This also initializes a new `git`
 repository by default. If you don't want it to do that, pass `--vcs none`.
 
 Let’s check out what Cargo has generated for us:
@@ -23,9 +23,7 @@ $ tree .
 1 directory, 2 files
 ```
 
-If we had just used `cargo new hello_world` without the `--bin` flag, then
-we would have a `lib.rs` instead of a `main.rs`. For now, however, this is all
-we need to get started. First, let’s check out `Cargo.toml`:
+Let’s take a closer look at `Cargo.toml`:
 
 ```toml
 [package]


### PR DESCRIPTION
So this switches `cargo new` default from `--lib` to `--bin`, as discussed on IRC.

The first two commits are just refactorings, and the last one actually flips the switch. Surprisingly enough, no tests need to be modified it seems!

r? @withoutboats 
