### PR TITLE
readme: add link to the cargo documentation on docs.rs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Learn more at https://doc.rust-lang.org/cargo/
 [![Build Status](https://travis-ci.org/rust-lang/cargo.svg?branch=master)](https://travis-ci.org/rust-lang/cargo)
 [![Build Status](https://ci.appveyor.com/api/projects/status/github/rust-lang/cargo?branch=master&svg=true)](https://ci.appveyor.com/project/rust-lang-libs/cargo)
 
+Code documentation: https://docs.rs/cargo/
+
 ## Installing Cargo
 
 Cargo is distributed by default with Rust, so if you've got `rustc` installed


### PR DESCRIPTION
[Rendered](https://github.com/matthiaskrgr/cargo/blob/readme_docs/README.md)

Background: I was searching for cargo source code doc a while back, found the cargo book and crates.io doc relatively quickly but not the actual source code doc which I only found (after way to much time had passed)  when I looked up the cargo crate on crates.io and found the "Documentation" link :/

Hope this improves the situation a bit in the future.