### PR TITLE
[WIP] print status message when linking binary

### DIFF
--- a/tests/alt-registry.rs
+++ b/tests/alt-registry.rs
@@ -56,10 +56,9 @@ fn depend_on_alt_registry() {
 [UPDATING] registry `{reg}`
 [DOWNLOADING] bar v0.0.1 (registry `file://[..]`)
 [COMPILING] bar v0.0.1 (registry `file://[..]`)
-[COMPILING] foo v0.0.1 ({dir})
+[LINKING] foo
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..] secs
 ",
-        dir = p.url(),
         reg = registry::alt_registry())));
 
     assert_that(p.cargo("clean").masquerade_as_nightly_cargo(), execs().with_status(0));
@@ -68,11 +67,10 @@ fn depend_on_alt_registry() {
     assert_that(p.cargo("build").masquerade_as_nightly_cargo(),
                 execs().with_status(0).with_stderr(&format!("\
 [COMPILING] bar v0.0.1 (registry `file://[..]`)
-[COMPILING] foo v0.0.1 ({dir})
+[LINKING] foo
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..] secs
 ",
-        dir = p.url())));
-}
+)))}
 
 #[test]
 fn depend_on_alt_registry_depends_on_same_registry_no_index() {
@@ -102,10 +100,9 @@ fn depend_on_alt_registry_depends_on_same_registry_no_index() {
 [DOWNLOADING] [..] v0.0.1 (registry `file://[..]`)
 [COMPILING] baz v0.0.1 (registry `file://[..]`)
 [COMPILING] bar v0.0.1 (registry `file://[..]`)
-[COMPILING] foo v0.0.1 ({dir})
+[LINKING] foo
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..] secs
 ",
-        dir = p.url(),
         reg = registry::alt_registry())));
 }
 
@@ -137,10 +134,9 @@ fn depend_on_alt_registry_depends_on_same_registry() {
 [DOWNLOADING] [..] v0.0.1 (registry `file://[..]`)
 [COMPILING] baz v0.0.1 (registry `file://[..]`)
 [COMPILING] bar v0.0.1 (registry `file://[..]`)
-[COMPILING] foo v0.0.1 ({dir})
+[LINKING] foo
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..] secs
 ",
-        dir = p.url(),
         reg = registry::alt_registry())));
 }
 
@@ -173,10 +169,9 @@ fn depend_on_alt_registry_depends_on_crates_io() {
 [DOWNLOADING] [..] v0.0.1 (registry `file://[..]`)
 [COMPILING] baz v0.0.1 (registry `file://[..]`)
 [COMPILING] bar v0.0.1 (registry `file://[..]`)
-[COMPILING] foo v0.0.1 ({dir})
+[LINKING] foo
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..] secs
 ",
-        dir = p.url(),
         alt_reg = registry::alt_registry(),
         reg = registry::registry())));
 }
@@ -212,7 +207,7 @@ fn registry_and_path_dep_works() {
                 execs().with_status(0)
                 .with_stderr(&format!("\
 [COMPILING] bar v0.0.1 ({dir}/bar)
-[COMPILING] foo v0.0.1 ({dir})
+[LINKING] foo
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..] secs
 ",
         dir = p.url())));
@@ -336,7 +331,7 @@ fn alt_registry_and_crates_io_deps() {
                        .with_stderr_contains("\
 [COMPILING] crates_io_dep v0.0.1")
                        .with_stderr_contains(&format!("\
-[COMPILING] foo v0.0.1 ({})", p.url()))
+[LINKING] foo"))
                        .with_stderr_contains("\
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..] secs"))
 

--- a/tests/bad-config.rs
+++ b/tests/bad-config.rs
@@ -741,7 +741,7 @@ The TOML spec requires newlines after table definitions (e.g. `[a] b = 1` is
 invalid), but this file has a table header which does not have a newline after
 it. A newline needs to be added and this warning will soon become a hard error
 in the future.
-[COMPILING] empty_deps v0.0.0 ([..])
+[LINKING] empty_deps
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "));
 }

--- a/tests/cargotest/support/mod.rs
+++ b/tests/cargotest/support/mod.rs
@@ -875,6 +875,7 @@ fn substitute_macros(input: &str) -> String {
     let macros = [
         ("[RUNNING]",     "     Running"),
         ("[COMPILING]",   "   Compiling"),
+        ("[LINKING]",     "     Linking"),
         ("[CREATED]",     "     Created"),
         ("[FINISHED]",    "    Finished"),
         ("[ERROR]",       "error:"),


### PR DESCRIPTION
This adds a status print when linking binaries.

Linking can take quite some time when using lto so this adds some additional information.

I also had situations where the base/root crate was actually not build last in the dependecy chain which looked a bit strange because in most cases buiding the base crate also builds its binaries right after.

I started updating some of the tests but wanted to have some comments on the idea before I update the rest.
![linking](https://user-images.githubusercontent.com/476013/36131746-ad78b2be-1073-11e8-9a85-d23ab1d352aa.png)


