### PR TITLE
Conflict tracking

### DIFF
--- a/src/cargo/core/resolver/mod.rs
+++ b/src/cargo/core/resolver/mod.rs
@@ -536,7 +536,6 @@ struct BacktrackFrame<'a> {
     parent: Summary,
     dep: Dependency,
     features: Rc<Vec<String>>,
-    conflicting_activations: HashSet<PackageId>,
 }
 
 #[derive(Clone)]
@@ -591,7 +590,6 @@ fn activate_deps_loop<'a>(mut cx: Context<'a>,
     // use (those with more candidates).
     let mut backtrack_stack = Vec::new();
     let mut remaining_deps = BinaryHeap::new();
-    let mut conflicting_activations;
     for &(ref summary, ref method) in summaries {
         debug!("initial activation: {}", summary.package_id());
         let candidate = Candidate { summary: summary.clone(), replace: None };
@@ -664,7 +662,6 @@ fn activate_deps_loop<'a>(mut cx: Context<'a>,
                 remaining: RcVecIter::new(Rc::clone(&candidates)),
                 conflicting_prev_active: HashSet::new(),
             };
-            conflicting_activations = HashSet::new();
             (candidates.next(prev_active),
              candidates.clone().next(prev_active).is_ok(),
              candidates)
@@ -695,13 +692,11 @@ fn activate_deps_loop<'a>(mut cx: Context<'a>,
                         parent: Summary::clone(&parent),
                         dep: Dependency::clone(&dep),
                         features: Rc::clone(&features),
-                        conflicting_activations: conflicting_activations.clone(),
                     });
                 }
                 candidate
             }
             Err(mut conflicting) => {
-                conflicting_activations.extend(conflicting.drain());
                 // This dependency has no valid candidate. Backtrack until we
                 // find a dependency that does have a candidate to try, and try
                 // to activate that one.  This resets the `remaining_deps` to
@@ -715,10 +710,10 @@ fn activate_deps_loop<'a>(mut cx: Context<'a>,
                                      &mut cur,
                                      &mut dep,
                                      &mut features,
-                                     &mut conflicting_activations) {
+                                     &mut conflicting) {
                     None => return Err(activation_error(&cx, registry, &parent,
                                                         &dep,
-                                                        conflicting_activations,
+                                                        conflicting,
                                                         &candidates, config)),
                     Some(candidate) => candidate,
                 }
@@ -787,7 +782,6 @@ fn find_candidate<'a>(
                 *parent = frame.parent.clone();
                 *dep = frame.dep.clone();
                 *features = Rc::clone(&frame.features);
-                *conflicting_activations = frame.conflicting_activations.clone();
                 backtrack_stack.push(frame);
             } else {
                 *cx = frame.context_backup;
@@ -795,7 +789,6 @@ fn find_candidate<'a>(
                 *parent = frame.parent;
                 *dep = frame.dep;
                 *features = frame.features;
-                *conflicting_activations = frame.conflicting_activations
             }
             return Some(candidate);
         }


### PR DESCRIPTION
This is an alternative implementation of #4834. This is slower but hopefully more flexible and clearer. The idea is to keep a list of `PackageId`'s that have caused us to skip a `Candidate`. Then we can use the list when we are backtracking if any items in our list have not been activated then we will have new `Candidate`'s to try so we should stop backtracking. Or to say that another way; We can continue backtracking as long as all the items in our list is still activated.

Next this new framework was used to make the error messages more focused. We only need to list the versions that conflict, as opposed to all previously activated versions.

Why is this more flexible?
1. It is not limited to conflicts within the same package. If `RemainingCandidates.next` skips something  because of a links attribute, that is easy to record, just add the `PackageId` to the set `conflicting_prev_active`.
2. Arbitrary things can add conflicts to the backtracking. If we fail to activate because some dependency needs a feature that does not exist, that is easy to record, just add the `PackageId` to the set `conflicting_activations`.
3. All things that could cause use to fail will be in the error messages, as the error messages loop over the set.
4. With a simple extension, replacing the `HashSet` with a `HashMap<_, Reason>`, we can customize the error messages to show the nature of the conflict.

@alexcrichton, @aidanhs, Does the logic look right? Does this seem clearer to you?