### PR TITLE
Fix DocOpt deserialization type bounds

### DIFF
--- a/src/cargo/lib.rs
+++ b/src/cargo/lib.rs
@@ -40,7 +40,7 @@ extern crate core_foundation;
 
 use std::fmt;
 
-use serde::Deserialize;
+use serde::de::DeserializeOwned;
 use serde::ser;
 use docopt::Docopt;
 use failure::Error;
@@ -103,7 +103,7 @@ impl fmt::Display for VersionInfo {
     }
 }
 
-pub fn call_main_without_stdin<'de, Flags: Deserialize<'de>>(
+pub fn call_main_without_stdin<Flags: DeserializeOwned>(
             exec: fn(Flags, &mut Config) -> CliResult,
             config: &mut Config,
             usage: &str,


### PR DESCRIPTION
This is wrt https://github.com/docopt/docopt.rs/pull/222

DocOpt does not support deserializing borrowed types.

This change was reverted in
https://github.com/docopt/docopt.rs/commit/7292a374e69afb192bb7aaa00f9d9f4afebc200d
because it broke crates like Cargo etc.