### PR TITLE
Remove cargo-only downloads from installation docs

### DIFF
--- a/src/doc/src/getting-started/installation.md
+++ b/src/doc/src/getting-started/installation.md
@@ -1,38 +1,37 @@
 ## Installation
 
-### Install Stable Rust and Cargo
+### Install Rust and Cargo
 
-The easiest way to get Cargo is to get the current stable release of [Rust] by
-using the `rustup` script:
+The easiest way to get Cargo is to install the current stable release of [Rust]
+by using `rustup`.
+
+On Linux and macOS systems, this is done as follows:
 
 ```console
 $ curl -sSf https://static.rust-lang.org/rustup.sh | sh
 ```
 
+It will download a script, and start the installation. If everything goes well,
+you’ll see this appear:
+
+```console
+Rust is installed now. Great! 
+```
+
+On Windows, download and run [rustup-init.exe]. It will start the installation
+in a console and present the above message on success.
+
 After this, you can use the `rustup` command to also install `beta` or `nightly`
 channels for Rust and Cargo.
 
-### Install Nightly Cargo
-
-To install just Cargo, the current recommended installation method is through
-the official nightly builds. Note that Cargo will also require that [Rust] is
-already installed on the system.
-
-| Platform         | 64-bit            | 32-bit            |
-|------------------|-------------------|-------------------|
-| Linux binaries   | [tar.gz][linux64] | [tar.gz][linux32] |
-| MacOS binaries   | [tar.gz][mac64]   | [tar.gz][mac32]   |
-| Windows binaries | [tar.gz][win64]   | [tar.gz][win32]   |
+For other installation options and information, visit the
+[install][install-rust] page of the Rust website.
 
 ### Build and Install Cargo from Source
 
 Alternatively, you can [build Cargo from source][compiling-from-source].
 
 [rust]: https://www.rust-lang.org/
-[linux64]: https://static.rust-lang.org/cargo-dist/cargo-nightly-x86_64-unknown-linux-gnu.tar.gz
-[linux32]: https://static.rust-lang.org/cargo-dist/cargo-nightly-i686-unknown-linux-gnu.tar.gz
-[mac64]: https://static.rust-lang.org/cargo-dist/cargo-nightly-x86_64-apple-darwin.tar.gz
-[mac32]: https://static.rust-lang.org/cargo-dist/cargo-nightly-i686-apple-darwin.tar.gz
-[win64]: https://static.rust-lang.org/cargo-dist/cargo-nightly-x86_64-pc-windows-gnu.tar.gz
-[win32]: https://static.rust-lang.org/cargo-dist/cargo-nightly-i686-pc-windows-gnu.tar.gz
+[rustup-init.exe]: https://win.rustup.rs/
+[install-rust]: https://www.rust-lang.org/install.html
 [compiling-from-source]: https://github.com/rust-lang/cargo#compiling-from-source


### PR DESCRIPTION
This also copies extra instructions for installing rust from https://doc.rust-lang.org/book/first-edition/getting-started.html#installing-rust-1.

I wasn't able to test the changes locally, but they're fairly minimal, so I trust they will render alright.

Fixes #5027.