### PR TITLE
Output hygiene: write to stderr by default

### DIFF
--- a/src/bin/cargo.rs
+++ b/src/bin/cargo.rs
@@ -161,16 +161,16 @@ fn execute(flags: Flags, config: &mut Config) -> CliResult {
 
     if flags.flag_version {
         let version = cargo::version();
-        println!("{}", version);
+        eprintln!("{}", version);
         if flags.flag_verbose > 0 {
-            println!("release: {}.{}.{}",
+            eprintln!("release: {}.{}.{}",
                      version.major,
                      version.minor,
                      version.patch);
             if let Some(ref cfg) = version.cfg_info {
                 if let Some(ref ci) = cfg.commit_info {
-                    println!("commit-hash: {}", ci.commit_hash);
-                    println!("commit-date: {}", ci.commit_date);
+                    eprintln!("commit-hash: {}", ci.commit_hash);
+                    eprintln!("commit-date: {}", ci.commit_date);
                 }
             }
         }
@@ -178,9 +178,9 @@ fn execute(flags: Flags, config: &mut Config) -> CliResult {
     }
 
     if flags.flag_list {
-        println!("Installed Commands:");
+        eprintln!("Installed Commands:");
         for command in list_commands(config) {
-            println!("    {}", command);
+            eprintln!("    {}", command);
         }
         return Ok(());
     }

--- a/src/bin/login.rs
+++ b/src/bin/login.rs
@@ -68,7 +68,7 @@ pub fn execute(options: Options, config: &mut Config) -> CliResult {
                     options.flag_host.clone().unwrap_or(config.api.unwrap())
                 }
             };
-            println!("please visit {}me and paste the API Token below", host);
+            eprintln!("please visit {}me and paste the API Token below", host);
             let mut line = String::new();
             let input = io::stdin();
             input.lock().read_line(&mut line).chain_err(|| {

--- a/src/bin/pkgid.rs
+++ b/src/bin/pkgid.rs
@@ -74,7 +74,7 @@ pub fn execute(options: Options, config: &mut Config) -> CliResult {
     };
     let spec = spec.as_ref().map(|s| &s[..]);
     let spec = ops::pkgid(&ws, spec)?;
-    println!("{}", spec);
+    eprintln!("{}", spec);
     Ok(())
 }
 

--- a/src/bin/version.rs
+++ b/src/bin/version.rs
@@ -21,7 +21,7 @@ Options:
 pub fn execute(_: Options, _: &mut Config) -> CliResult {
     debug!("executing; cmd=cargo-version; args={:?}", env::args().collect::<Vec<_>>());
 
-    println!("{}", cargo::version());
+    eprintln!("{}", cargo::version());
 
     Ok(())
 }

--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -355,7 +355,7 @@ impl Manifest {
     pub fn print_teapot(&self, config: &Config) {
         if let Some(teapot) = self.im_a_teapot {
             if config.cli_unstable().print_im_a_teapot {
-                println!("im-a-teapot = {}", teapot);
+                eprintln!("im-a-teapot = {}", teapot);
             }
         }
     }

--- a/src/cargo/lib.rs
+++ b/src/cargo/lib.rs
@@ -143,7 +143,7 @@ pub fn exit_with_error(err: CliError, shell: &mut Shell) -> ! {
         } else if fatal {
             drop(shell.error(&error))
         } else {
-            println!("{}", error);
+            eprintln!("{}", error);
         }
 
         if !handle_cause(&error, shell) || hide {

--- a/src/cargo/ops/cargo_install.rs
+++ b/src/cargo/ops/cargo_install.rs
@@ -558,9 +558,9 @@ pub fn install_list(dst: Option<&str>, config: &Config) -> CargoResult<()> {
     let dst = metadata(config, &dst)?;
     let list = read_crate_list(&dst)?;
     for (k, v) in list.v1.iter() {
-        println!("{}:", k);
+        eprintln!("{}:", k);
         for bin in v {
-            println!("    {}", bin);
+            eprintln!("    {}", bin);
         }
     }
     Ok(())

--- a/src/cargo/ops/cargo_new.rs
+++ b/src/cargo/ops/cargo_new.rs
@@ -493,7 +493,7 @@ authors = [{}]
         let default_file_content : &[u8] = if i.bin {
             b"\
 fn main() {
-    println!(\"Hello, world!\");
+    eprintln!(\"Hello, world!\");
 }
 "
         } else {

--- a/src/cargo/ops/cargo_package.rs
+++ b/src/cargo/ops/cargo_package.rs
@@ -49,7 +49,7 @@ pub fn package(ws: &Workspace,
         }).collect();
         list.sort();
         for file in list.iter() {
-            println!("{}", file.display());
+            eprintln!("{}", file.display());
         }
         return Ok(None)
     }

--- a/src/cargo/ops/cargo_rustc/mod.rs
+++ b/src/cargo/ops/cargo_rustc/mod.rs
@@ -2,7 +2,6 @@ use std::collections::{HashMap, HashSet};
 use std::env;
 use std::ffi::{OsStr, OsString};
 use std::fs;
-use std::io::{self, Write};
 use std::path::{self, PathBuf};
 use std::sync::Arc;
 
@@ -415,7 +414,7 @@ fn rustc<'a, 'cfg>(cx: &mut Context<'a, 'cfg>,
                         });
                     } else {
                         // Forward non-JSON to stderr
-                        writeln!(io::stderr(), "{}", line)?;
+                        eprintln!("{}", line);
                     }
                     Ok(())
                 }

--- a/src/cargo/ops/registry.rs
+++ b/src/cargo/ops/registry.rs
@@ -432,12 +432,12 @@ pub fn modify_owners(config: &Config, opts: &OwnersOptions) -> CargoResult<()> {
             format!("failed to list owners of crate {}", name)
         })?;
         for owner in owners.iter() {
-            print!("{}", owner.login);
+            eprint!("{}", owner.login);
             match (owner.name.as_ref(), owner.email.as_ref()) {
-                (Some(name), Some(email)) => println!(" ({} <{}>)", name, email),
+                (Some(name), Some(email)) => eprintln!(" ({} <{}>)", name, email),
                 (Some(s), None) |
-                (None, Some(s)) => println!(" ({})", s),
-                (None, None) => println!(),
+                (None, Some(s)) => eprintln!(" ({})", s),
+                (None, None) => eprintln!(),
             }
         }
     }
@@ -529,15 +529,15 @@ pub fn search(query: &str,
             }
             None => name
         };
-        println!("{}", line);
+        eprintln!("{}", line);
     }
 
     let search_max_limit = 100;
     if total_crates > u32::from(limit) && limit < search_max_limit {
-        println!("... and {} crates more (use --limit N to see more)",
+        eprintln!("... and {} crates more (use --limit N to see more)",
                  total_crates - u32::from(limit));
     } else if total_crates > u32::from(limit) && limit >= search_max_limit {
-        println!("... and {} crates more (go to http://crates.io/search?q={} to see more)",
+        eprintln!("... and {} crates more (go to http://crates.io/search?q={} to see more)",
                  total_crates - u32::from(limit),
                  percent_encode(query.as_bytes(), QUERY_ENCODE_SET));
     }

--- a/src/cargo/util/profile.rs
+++ b/src/cargo/util/profile.rs
@@ -46,7 +46,7 @@ impl Drop for Profiler {
                 let mut last = 0;
                 for (i, &(l, time, ref msg)) in msgs.iter().enumerate() {
                     if l != lvl { continue }
-                    println!("{} {:6}ms - {}",
+                    eprintln!("{} {:6}ms - {}",
                              repeat("    ").take(lvl + 1).collect::<String>(),
                              time, msg);
 

--- a/src/doc/src/getting-started/first-steps.md
+++ b/src/doc/src/getting-started/first-steps.md
@@ -38,7 +38,7 @@ Here’s what’s in `src/main.rs`:
 
 ```rust
 fn main() {
-    println!("Hello, world!");
+    eprintln!("Hello, world!");
 }
 ```
 

--- a/src/doc/src/guide/creating-a-new-project.md
+++ b/src/doc/src/guide/creating-a-new-project.md
@@ -39,7 +39,7 @@ Here’s what’s in `src/main.rs`:
 
 ```rust
 fn main() {
-    println!("Hello, world!");
+    eprintln!("Hello, world!");
 }
 ```
 

--- a/src/doc/src/guide/dependencies.md
+++ b/src/doc/src/guide/dependencies.md
@@ -77,7 +77,7 @@ use regex::Regex;
 
 fn main() {
     let re = Regex::new(r"^\d{4}-\d{2}-\d{2}$").unwrap();
-    println!("Did our date match? {}", re.is_match("2014-01-01"));
+    eprintln!("Did our date match? {}", re.is_match("2014-01-01"));
 }
 ```
 

--- a/src/doc/src/reference/build-scripts.md
+++ b/src/doc/src/reference/build-scripts.md
@@ -285,7 +285,7 @@ Next, let’s peek at the library itself:
 include!(concat!(env!("OUT_DIR"), "/hello.rs"));
 
 fn main() {
-    println!("{}", message());
+    eprintln!("{}", message());
 }
 ```
 

--- a/tests/build-script.rs
+++ b/tests/build-script.rs
@@ -2561,7 +2561,7 @@ fn switch_features_rerun() {
         "#)
         .file("src/main.rs", r#"
             fn main() {
-                println!(include_str!(concat!(env!("OUT_DIR"), "/output")));
+                eprintln!(include_str!(concat!(env!("OUT_DIR"), "/output")));
             }
         "#)
         .file("build.rs", r#"
@@ -2585,11 +2585,11 @@ fn switch_features_rerun() {
         .build();
 
     assert_that(p.cargo("run").arg("-v").arg("--features=foo"),
-                execs().with_status(0).with_stdout("foo\n"));
+                execs().with_status(0).with_stderr_contains("foo\n"));
     assert_that(p.cargo("run").arg("-v"),
-                execs().with_status(0).with_stdout("bar\n"));
+                execs().with_status(0).with_stderr_contains("bar\n"));
     assert_that(p.cargo("run").arg("-v").arg("--features=foo"),
-                execs().with_status(0).with_stdout("foo\n"));
+                execs().with_status(0).with_stderr_contains("foo\n"));
 }
 
 #[test]

--- a/tests/cargo-features.rs
+++ b/tests/cargo-features.rs
@@ -244,11 +244,7 @@ error: unknown `-Z` flag specified: arg
                  .masquerade_as_nightly_cargo()
                  .arg("-Zprint-im-a-teapot"),
                 execs().with_status(0)
-                       .with_stdout("im-a-teapot = true\n")
-                       .with_stderr("\
-[COMPILING] a [..]
-[FINISHED] [..]
-"));
+                       .with_stderr_contains("im-a-teapot = true\n"));
 }
 
 #[test]

--- a/tests/cargo.rs
+++ b/tests/cargo.rs
@@ -73,7 +73,7 @@ fn list_command_looks_at_path() {
     let output = pr.arg("-v").arg("--list")
                    .env("PATH", &path);
     let output = output.exec_with_output().unwrap();
-    let output = str::from_utf8(&output.stdout).unwrap();
+    let output = str::from_utf8(&output.stderr).unwrap();
     assert!(output.contains("\n    1\n"), "missing 1: {}", output);
 }
 
@@ -94,7 +94,7 @@ fn list_command_resolves_symlinks() {
     let output = pr.arg("-v").arg("--list")
                    .env("PATH", &path);
     let output = output.exec_with_output().unwrap();
-    let output = str::from_utf8(&output.stdout).unwrap();
+    let output = str::from_utf8(&output.stderr).unwrap();
     assert!(output.contains("\n    2\n"), "missing 2: {}", output);
 }
 

--- a/tests/cargotest/support/mod.rs
+++ b/tests/cargotest/support/mod.rs
@@ -760,7 +760,7 @@ impl ham::Matcher<ProcessBuilder> for Execs {
 
 impl<'a> ham::Matcher<&'a mut ProcessBuilder> for Execs {
     fn matches(&self, process: &'a mut ProcessBuilder) -> ham::MatchResult {
-        println!("running {}", process);
+        eprintln!("running {}", process);
         let res = process.exec_with_output();
 
         match res {

--- a/tests/cross-compile.rs
+++ b/tests/cross-compile.rs
@@ -436,9 +436,9 @@ fn cross_tests() {
 [COMPILING] foo v0.0.0 ({foo})
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target[/]{triple}[/]debug[/]deps[/]foo-[..][EXE]
-[RUNNING] target[/]{triple}[/]debug[/]deps[/]bar-[..][EXE]", foo = p.url(), triple = target))
-                       .with_stdout_contains("test test_foo ... ok")
-                       .with_stdout_contains("test test ... ok"));
+test test_foo ... ok
+[RUNNING] target[/]{triple}[/]debug[/]deps[/]bar-[..][EXE]
+test test ... ok", foo = p.url(), triple = target)));
 }
 
 #[test]

--- a/tests/features.rs
+++ b/tests/features.rs
@@ -377,7 +377,7 @@ fn no_feature_doesnt_build() {
             #[cfg(feature = "bar")]
             extern crate bar;
             #[cfg(feature = "bar")]
-            fn main() { bar::bar(); println!("bar") }
+            fn main() { bar::bar(); eprintln!("bar") }
             #[cfg(not(feature = "bar"))]
             fn main() {}
         "#)
@@ -405,7 +405,7 @@ fn no_feature_doesnt_build() {
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ", dir = p.url())));
     assert_that(p.process(&p.bin("foo")),
-                execs().with_status(0).with_stdout("bar\n"));
+                execs().with_status(0).with_stderr("bar\n"));
 }
 
 #[test]

--- a/tests/install.rs
+++ b/tests/install.rs
@@ -462,7 +462,7 @@ warning: be sure to add `[..]` to your PATH to be able to run the installed bina
         home = cargo_home().display())));
 
     assert_that(cargo_process("install").arg("--list"),
-                execs().with_status(0).with_stdout("\
+                execs().with_status(0).with_stderr("\
 foo v0.2.0 ([..]):
     foo[..]
 "));
@@ -507,7 +507,7 @@ warning: be sure to add `[..]` to your PATH to be able to run the installed bina
         home = cargo_home().display())));
 
     assert_that(cargo_process("install").arg("--list"),
-                execs().with_status(0).with_stdout("\
+                execs().with_status(0).with_stderr("\
 foo v0.1.0 ([..]):
     foo-bin1[..]
 foo v0.2.0 ([..]):
@@ -558,7 +558,7 @@ warning: be sure to add `[..]` to your PATH to be able to run the installed bina
         home = cargo_home().display())));
 
     assert_that(cargo_process("install").arg("--list"),
-                execs().with_status(0).with_stdout("\
+                execs().with_status(0).with_stderr("\
 foo v0.1.0 ([..]):
     foo-bin1[..]
 foo v0.2.0 ([..]):
@@ -631,7 +631,7 @@ fn list() {
     assert_that(cargo_process("install").arg("foo"),
                 execs().with_status(0));
     assert_that(cargo_process("install").arg("--list"),
-                execs().with_status(0).with_stdout("\
+                execs().with_status(0).with_stderr("\
 bar v0.2.1:
     bar[..]
 foo v0.0.1:
@@ -645,7 +645,7 @@ fn list_error() {
     assert_that(cargo_process("install").arg("foo"),
                 execs().with_status(0));
     assert_that(cargo_process("install").arg("--list"),
-                execs().with_status(0).with_stdout("\
+                execs().with_status(0).with_stderr("\
 foo v0.0.1:
     foo[..]
 "));
@@ -732,16 +732,16 @@ fn subcommand_works_out_of_the_box() {
     Package::new("cargo-foo", "1.0.0")
         .file("src/main.rs", r#"
             fn main() {
-                println!("bar");
+                eprintln!("bar");
             }
         "#)
         .publish();
     assert_that(cargo_process("install").arg("cargo-foo"),
                 execs().with_status(0));
     assert_that(cargo_process("foo"),
-                execs().with_status(0).with_stdout("bar\n"));
+                execs().with_status(0).with_stderr("bar\n"));
     assert_that(cargo_process("--list"),
-                execs().with_status(0).with_stdout_contains("    foo\n"));
+                execs().with_status(0).with_stderr_contains("    foo\n"));
 }
 
 #[test]
@@ -799,7 +799,7 @@ fn reports_unsuccessful_subcommand_result() {
     assert_that(cargo_process("install").arg("cargo-fail"),
                 execs().with_status(0));
     assert_that(cargo_process("--list"),
-                execs().with_status(0).with_stdout_contains("    fail\n"));
+                execs().with_status(0).with_stderr_contains("    fail\n"));
     assert_that(cargo_process("fail"),
                 execs().with_status(101).with_stderr_contains("\
 thread '[..]' panicked at 'explicit panic', [..]

--- a/tests/package.rs
+++ b/tests/package.rs
@@ -29,7 +29,7 @@ fn simple() {
             description = "foo"
         "#)
         .file("src/main.rs", r#"
-            fn main() { println!("hello"); }
+            fn main() { eprintln!("hello"); }
         "#)
         .file("src/bar.txt", "") // should be ignored when packaging
         .build();
@@ -46,7 +46,7 @@ See [..]
         dir = p.url())));
     assert_that(&p.root().join("target/package/foo-0.0.1.crate"), existing_file());
     assert_that(p.cargo("package").arg("-l"),
-                execs().with_status(0).with_stdout("\
+                execs().with_status(0).with_stderr_contains("\
 Cargo.toml
 src[/]main.rs
 "));
@@ -316,7 +316,7 @@ fn exclude() {
         .build();
 
     assert_that(p.cargo("package").arg("--no-verify").arg("-v"),
-                execs().with_status(0).with_stdout("").with_stderr("\
+                execs().with_status(0).with_stdout("").with_stderr_contains("\
 [WARNING] manifest has no description[..]
 See http://doc.crates.io/manifest.html#package-metadata for more info.
 [PACKAGING] foo v0.0.1 ([..])
@@ -355,7 +355,7 @@ See [..]
     assert_that(&p.root().join("target/package/foo-0.0.1.crate"), existing_file());
 
     assert_that(p.cargo("package").arg("-l"),
-                execs().with_status(0).with_stdout("\
+                execs().with_status(0).with_stderr_contains("\
 Cargo.toml
 dir_root_1[/]some_dir[/]file
 dir_root_2[/]some_dir[/]file
@@ -473,13 +473,13 @@ fn no_duplicates_from_modified_tracked_files() {
         "#)
         .build();
     File::create(p.root().join("src/main.rs")).unwrap().write_all(br#"
-            fn main() { println!("A change!"); }
+            fn main() { eprintln!("A change!"); }
         "#).unwrap();
     let mut cargo = cargo_process();
     cargo.cwd(p.root());
     assert_that(cargo.clone().arg("build"), execs().with_status(0));
     assert_that(cargo.arg("package").arg("--list"),
-                execs().with_status(0).with_stdout("\
+                execs().with_status(0).with_stderr_contains("\
 Cargo.toml
 src/main.rs
 "));
@@ -496,7 +496,7 @@ fn ignore_nested() {
             description = "nested"
         "#;
     let main_rs = r#"
-            fn main() { println!("hello"); }
+            fn main() { eprintln!("hello"); }
         "#;
     let p = project("nested")
         .file("Cargo.toml", cargo_toml)
@@ -508,7 +508,7 @@ fn ignore_nested() {
         .build();
 
     assert_that(p.cargo("package"),
-                execs().with_status(0).with_stderr(&format!("\
+                execs().with_status(0).with_stderr_contains(&format!("\
 [WARNING] manifest has no documentation[..]
 See http://doc.crates.io/manifest.html#package-metadata for more info.
 [PACKAGING] nested v0.0.1 ({dir})
@@ -519,7 +519,7 @@ See http://doc.crates.io/manifest.html#package-metadata for more info.
         dir = p.url())));
     assert_that(&p.root().join("target/package/nested-0.0.1.crate"), existing_file());
     assert_that(p.cargo("package").arg("-l"),
-                execs().with_status(0).with_stdout("\
+                execs().with_status(0).with_stderr_contains("\
 Cargo.toml
 src[..]main.rs
 "));

--- a/tests/publish.rs
+++ b/tests/publish.rs
@@ -224,7 +224,7 @@ fn simple_with_index_and_host() {
     assert_that(p.cargo("publish").arg("--no-verify")
                  .arg("--index").arg(publish::registry().to_string())
                  .arg("--host").arg(publish::registry().to_string()),
-                execs().with_status(0).with_stderr(&format!("\
+                execs().with_status(0).with_stderr_contains(&format!("\
 [WARNING] The flag '--host' is no longer valid.
 
 Previous versions of Cargo accepted this flag, but it is being

--- a/tests/run.rs
+++ b/tests/run.rs
@@ -16,7 +16,7 @@ fn simple() {
             authors = []
         "#)
         .file("src/main.rs", r#"
-            fn main() { println!("hello"); }
+            fn main() { eprintln!("hello"); }
         "#)
         .build();
 
@@ -25,10 +25,8 @@ fn simple() {
                        .with_stderr(&format!("\
 [COMPILING] foo v0.0.1 ({dir})
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] `target[/]debug[/]foo[EXE]`", dir = path2url(p.root())))
-                       .with_stdout("\
-hello
-"));
+[RUNNING] `target[/]debug[/]foo[EXE]`
+hello", dir = path2url(p.root()))));
     assert_that(&p.bin("foo"), existing_file());
 }
 

--- a/tests/search.rs
+++ b/tests/search.rs
@@ -84,7 +84,7 @@ fn simple() {
     assert_that(cargo_process("search").arg("postgres")
                     .arg("--index").arg(registry().to_string()),
                 execs().with_status(0)
-                       .with_stdout_contains("\
+                       .with_stderr_contains("\
 hoare = \"0.1.1\"    # Design by contract style assertions for Rust"));
 }
 
@@ -136,7 +136,7 @@ fn simple_with_host() {
     assert_that(cargo_process("search").arg("postgres")
                     .arg("--host").arg(registry().to_string()),
                 execs().with_status(0)
-                       .with_stderr(&format!("\
+                       .with_stderr_contains(&format!("\
 [WARNING] The flag '--host' is no longer valid.
 
 Previous versions of Cargo accepted this flag, but it is being
@@ -150,7 +150,7 @@ about this warning.
 [UPDATING] registry `{reg}`
 ",
     reg = registry()))
-                       .with_stdout_contains("\
+                       .with_stderr_contains("\
 hoare = \"0.1.1\"    # Design by contract style assertions for Rust"));
 }
 
@@ -203,7 +203,7 @@ fn simple_with_index_and_host() {
                     .arg("--index").arg(registry().to_string())
                     .arg("--host").arg(registry().to_string()),
                 execs().with_status(0)
-                        .with_stderr(&format!("\
+                        .with_stderr_contains(&format!("\
 [WARNING] The flag '--host' is no longer valid.
 
 Previous versions of Cargo accepted this flag, but it is being
@@ -217,7 +217,7 @@ about this warning.
 [UPDATING] registry `{reg}`
 ",
     reg = registry()))
-                       .with_stdout_contains("\
+                       .with_stderr_contains("\
 hoare = \"0.1.1\"    # Design by contract style assertions for Rust"));
 }
 
@@ -267,7 +267,7 @@ fn multiple_query_params() {
     assert_that(cargo_process("search").arg("postgres").arg("sql")
                     .arg("--index").arg(registry().to_string()),
                 execs().with_status(0)
-                       .with_stdout_contains("\
+                       .with_stderr_contains("\
 hoare = \"0.1.1\"    # Design by contract style assertions for Rust"));
 }
 
@@ -277,9 +277,9 @@ fn help() {
                 execs().with_status(0));
     assert_that(cargo_process("help").arg("search"),
                 execs().with_status(0));
-    // Ensure that help output goes to stdout, not stderr.
+    // Ensure that help output goes to stderr, not stdout.
     assert_that(cargo_process("search").arg("--help"),
-                execs().with_stderr(""));
+                execs().with_stdout(""));
     assert_that(cargo_process("search").arg("--help"),
-                execs().with_stdout_contains("[..] --frozen [..]"));
+                execs().with_stderr_contains("[..] --frozen [..]"));
 }

--- a/tests/version.rs
+++ b/tests/version.rs
@@ -10,11 +10,11 @@ fn simple() {
     let p = project("foo").build();
 
     assert_that(p.cargo("version"),
-                execs().with_status(0).with_stdout(&format!("{}\n",
+                execs().with_status(0).with_stderr(&format!("{}\n",
                                                             cargo::version())));
 
     assert_that(p.cargo("--version"),
-                execs().with_status(0).with_stdout(&format!("{}\n",
+                execs().with_status(0).with_stderr(&format!("{}\n",
                                                             cargo::version())));
 
 }


### PR DESCRIPTION
Only proper machine readable output should be written to stdout. This would be JSON for Cargo and `rustc`. This is only one slight patch toward this requirement, there are still other instances of writing various stuff to stdout in `rustc`.