### PR TITLE
Display git errors during authentication.

### DIFF
--- a/src/cargo/sources/git/utils.rs
+++ b/src/cargo/sources/git/utils.rs
@@ -12,7 +12,7 @@ use url::Url;
 
 use core::GitReference;
 use util::{ToUrl, internal, Config, network, Progress};
-use util::errors::{CargoResult, CargoResultExt, Internal};
+use util::errors::{CargoResult, CargoResultExt, CargoError};
 
 #[derive(PartialEq, Clone, Debug)]
 pub struct GitRevision(git2::Oid);
@@ -546,7 +546,7 @@ fn with_authentication<T, F>(url: &str, cfg: &git2::Config, mut f: F)
     // In the case of an authentication failure (where we tried something) then
     // we try to give a more helpful error message about precisely what we
     // tried.
-    let res = res.map_err(Internal::new).chain_err(|| {
+    let res = res.map_err(CargoError::from).chain_err(|| {
         let mut msg = "failed to authenticate when downloading \
                        repository".to_string();
         if !ssh_agent_attempts.is_empty() {

--- a/tests/testsuite/build_auth.rs
+++ b/tests/testsuite/build_auth.rs
@@ -118,7 +118,9 @@ Caused by:
   failed to authenticate when downloading repository
 attempted to find username/password via `credential.helper`, but [..]
 
-To learn more, run the command again with --verbose.
+Caused by:
+  curl error: Failed to connect to 127.0.0.1 port [..]: Connection refused
+; class=Net (12)
 ",
         addr = addr)));
 

--- a/tests/testsuite/build_auth.rs
+++ b/tests/testsuite/build_auth.rs
@@ -103,8 +103,10 @@ fn http_auth_offered() {
         ")
         .build();
 
+    // This is a "contains" check because the last error differs by platform,
+    // may span multiple lines, and isn't relevant to this test.
     assert_that(p.cargo("build"),
-                execs().with_status(101).with_stderr(&format!("\
+                execs().with_status(101).with_stderr_contains(&format!("\
 [UPDATING] git repository `http://{addr}/foo/bar`
 [ERROR] failed to load source for a dependency on `bar`
 
@@ -119,8 +121,6 @@ Caused by:
 attempted to find username/password via `credential.helper`, but [..]
 
 Caused by:
-  curl error: Failed to connect to 127.0.0.1 port [..]: Connection refused
-; class=Net (12)
 ",
         addr = addr)));
 


### PR DESCRIPTION
Certain git errors during authentication were being converted to internal errors which meant that they are only seen if you pass `--verbose`.  This may not be obvious, and many of these messages are helpful for diagnosing git errors.  This change makes these errors always be displayed.

Fixes #5035.

Note: Some of the git errors are currently unhelpful.  Once Cargo has updated git2-rs to include alexcrichton/git2-rs#298, these errors will improve.  (@alexcrichton, I can make a PR to update Cargo for the changes in git2 if you'd like).

I'm uncertain if this is a good solution, since the error messages in some cases are a little verbose (such as showing `class=...`).  Here is a sample of what some of the messages look like:

<details><summary>Error Message Examples</summary>
<p>
Example of the git message shown below the "attempted yadda yadda" message.

Scenario | Message
---------|--------
No ssh-agent, multiple usernames | `error authenticating: ; class=Ssh (23)`
| | †`error authenticating: no auth sock variable; class=Ssh (23)`
No ssh-agent, one username | `an unknown git error occurred`
| | †`error authenticating: no auth sock variable; class=Ssh (23)`
Incorrect ssh-agent setup | `error authenticating: failed connecting with agent; class=Ssh (23)`
ssh-agent no keys, one username | `an unknown git error occurred`
| | †`failed to acquire username/password from local configuration`
ssh-agent no keys, multiple usernames | `error authenticating: ; class=Ssh (23)`
| | †`no authentication available`
auth success, bad path | `fatal: '/path/to/repo/' does not appear to be a git repository; class=Ssh (23); code=Eof (-20)`
| | ‡`ERROR: Repository not found.; class=Ssh (23); code=Eof (-20)`
bad username | `an unknown git error occurred`
| | †`failed to acquire username/password from local configuration`
| | ‡`error authenticating: Username/PublicKey combination invalid; class=Ssh (23)`


† - Messages once git2-rs is updated.
‡ - Github message

</p>
</details>
