### PR TITLE
Warn Windows 7 users about old TLS

### DIFF
--- a/src/cargo/sources/git/utils.rs
+++ b/src/cargo/sources/git/utils.rs
@@ -591,7 +591,7 @@ pub fn with_fetch_options(git_config: &git2::Config,
     -> CargoResult<()>
 {
     let mut progress = Progress::new("Fetch", config);
-    network::with_retry(config, || {
+    network::with_retry(config, url, || {
         with_authentication(url.as_str(), git_config, |f| {
             let mut rcb = git2::RemoteCallbacks::new();
             rcb.credentials(f);

--- a/src/cargo/sources/registry/remote.rs
+++ b/src/cargo/sources/registry/remote.rs
@@ -224,14 +224,13 @@ impl<'cfg> RegistryData for RemoteRegistry<'cfg> {
         // TODO: don't download into memory, but ensure that if we ctrl-c a
         //       download we should resume either from the start or the middle
         //       on the next time
-        let url = url.to_string();
         let mut handle = self.config.http()?.borrow_mut();
         handle.get(true)?;
-        handle.url(&url)?;
+        handle.url(&url.to_string())?;
         handle.follow_location(true)?;
         let mut state = Sha256::new();
         let mut body = Vec::new();
-        network::with_retry(self.config, || {
+        network::with_retry(self.config, &url, || {
             state = Sha256::new();
             body = Vec::new();
             let mut pb = Progress::new("Fetch", self.config);
@@ -250,8 +249,10 @@ impl<'cfg> RegistryData for RemoteRegistry<'cfg> {
             }
             let code = handle.response_code()?;
             if code != 200 && code != 0 {
-                let url = handle.effective_url()?.unwrap_or(&url);
-                Err(HttpNot200 { code, url: url.to_string() }.into())
+                let url = handle.effective_url()?
+                    .map(|url| url.to_string())
+                    .unwrap_or_else(|| url.to_string());
+                Err(HttpNot200 { code, url }.into())
             } else {
                 Ok(())
             }


### PR DESCRIPTION
An eyepatch for https://github.com/rust-lang/cargo/issues/5066.

@retep998 what would the best way to check for windows 7 specifically? Currently I use just `#[cfg(windows)]`, which might give false positives on 8 and 10.