### PR TITLE
Add exclude option to the cargo doc

### DIFF
--- a/src/bin/doc.rs
+++ b/src/bin/doc.rs
@@ -14,6 +14,7 @@ pub struct Options {
     flag_manifest_path: Option<String>,
     flag_no_default_features: bool,
     flag_no_deps: bool,
+    flag_excludes: String,
     flag_open: bool,
     flag_release: bool,
     flag_verbose: u32,
@@ -42,6 +43,7 @@ Options:
     --open                       Opens the docs in a browser after the operation
     -p SPEC, --package SPEC ...  Package to document
     --all                        Document all packages in the workspace
+    --excludes SPECS             Document all packages except specified
     --no-deps                    Don't build documentation for dependencies
     -j N, --jobs N               Number of parallel jobs, defaults to # of CPUs
     --lib                        Document only this package's library
@@ -97,6 +99,7 @@ pub fn execute(options: Options, config: &mut Config) -> CliResult {
     let empty = Vec::new();
     let doc_opts = ops::DocOptions {
         open_result: options.flag_open,
+        excludes: &options.flag_excludes,
         compile_opts: ops::CompileOptions {
             config: config,
             jobs: options.flag_jobs,

--- a/src/bin/rustdoc.rs
+++ b/src/bin/rustdoc.rs
@@ -98,6 +98,7 @@ pub fn execute(options: Options, config: &mut Config) -> CliResult {
 
     let doc_opts = ops::DocOptions {
         open_result: options.flag_open,
+        excludes: "",
         compile_opts: ops::CompileOptions {
             config: config,
             jobs: options.flag_jobs,

--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -231,7 +231,8 @@ pub fn compile_ws<'a>(ws: &Workspace<'a>,
                                             features,
                                             all_features,
                                             no_default_features,
-                                            &specs)?;
+                                            &specs,
+                                            "")?;
     let (packages, resolve_with_overrides) = resolve;
 
     if specs.is_empty() {

--- a/src/cargo/ops/cargo_doc.rs
+++ b/src/cargo/ops/cargo_doc.rs
@@ -9,6 +9,7 @@ use util::CargoResult;
 
 pub struct DocOptions<'a> {
     pub open_result: bool,
+    pub excludes: &'a str,
     pub compile_opts: ops::CompileOptions<'a>,
 }
 
@@ -19,7 +20,8 @@ pub fn doc(ws: &Workspace, options: &DocOptions) -> CargoResult<()> {
                                             options.compile_opts.features,
                                             options.compile_opts.all_features,
                                             options.compile_opts.no_default_features,
-                                            &specs)?;
+                                            &specs,
+                                            options.excludes)?;
     let (packages, resolve_with_overrides) = resolve;
 
     if specs.is_empty() {

--- a/src/cargo/ops/cargo_output_metadata.rs
+++ b/src/cargo/ops/cargo_output_metadata.rs
@@ -51,7 +51,8 @@ fn metadata_full(ws: &Workspace,
                                          &opt.features,
                                          opt.all_features,
                                          opt.no_default_features,
-                                         &specs)?;
+                                         &specs,
+                                         "")?;
     let (packages, resolve) = deps;
 
     let packages = packages.package_ids()


### PR DESCRIPTION
Adds the `--exclude` option to the `cargo doc` so we can specify what packages we want to exclude from generating docs.