### PR TITLE
Separate licenses with a `/` instead of ` OR `

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.26.0"
 authors = ["Yehuda Katz <wycats@gmail.com>",
            "Carl Lerche <me@carllerche.com>",
            "Alex Crichton <alex@alexcrichton.com>"]
-license = "MIT OR Apache-2.0"
+license = "MIT/Apache-2.0"
 homepage = "https://crates.io"
 repository = "https://github.com/rust-lang/cargo"
 documentation = "https://docs.rs/cargo"


### PR DESCRIPTION
It's what we tell others to do.

https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata

> ```toml
> # This is a string description of the license for this package. Currently
> # crates.io will validate the license provided against a whitelist of known
> # license identifiers from http://spdx.org/licenses/. Multiple licenses can be
> # separated with a `/`.
> license = "..."
> ```

Noted [here](https://github.com/TeXitoi/structopt/pull/71#discussion_r170423582).

This should either use `/` or a note should be added that ` OR ` is allowed as a combination operator.