### PR TITLE
Support --exclude option for `cargo doc`

### DIFF
--- a/src/bin/doc.rs
+++ b/src/bin/doc.rs
@@ -27,6 +27,7 @@ pub struct Options {
     flag_frozen: bool,
     flag_locked: bool,
     flag_all: bool,
+    flag_exclude: Vec<String>,
     #[serde(rename = "flag_Z")]
     flag_z: Vec<String>,
 }
@@ -42,6 +43,7 @@ Options:
     --open                       Opens the docs in a browser after the operation
     -p SPEC, --package SPEC ...  Package to document
     --all                        Document all packages in the workspace
+    --exclude SPEC ...           Exclude packages from the build
     --no-deps                    Don't build documentation for dependencies
     -j N, --jobs N               Number of parallel jobs, defaults to # of CPUs
     --lib                        Document only this package's library
@@ -88,11 +90,9 @@ pub fn execute(options: Options, config: &mut Config) -> CliResult {
     let root = find_root_manifest_for_wd(options.flag_manifest_path, config.cwd())?;
     let ws = Workspace::new(&root, config)?;
 
-    let spec = if options.flag_all || (ws.is_virtual() && options.flag_package.is_empty()) {
-        Packages::All
-    } else {
-        Packages::Packages(&options.flag_package)
-    };
+    let spec = Packages::from_flags(options.flag_all,
+                                    &options.flag_exclude,
+                                    &options.flag_package)?;
 
     let empty = Vec::new();
     let doc_opts = ops::DocOptions {


### PR DESCRIPTION
I think this should have been implemented when the feature was added for
other commands. Probably just an oversight.

cc https://github.com/rust-lang/cargo/pull/4031

r? @alexcrichton 