### PR TITLE
Package lock files in published crates

### DIFF
--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -162,6 +162,9 @@ features! {
 
         // Renaming a package in the manifest via the `package` key
         [unstable] rename_dependency: bool,
+
+        // Whether a lock file is published with this crate
+        [unstable] publish_lockfile: bool,
     }
 }
 

--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -31,6 +31,7 @@ pub struct Manifest {
     metadata: ManifestMetadata,
     profiles: Profiles,
     publish: Option<Vec<String>>,
+    publish_lockfile: bool,
     replace: Vec<(PackageIdSpec, Dependency)>,
     patch: HashMap<Url, Vec<Dependency>>,
     workspace: WorkspaceConfig,
@@ -267,6 +268,7 @@ impl Manifest {
                metadata: ManifestMetadata,
                profiles: Profiles,
                publish: Option<Vec<String>>,
+               publish_lockfile: bool,
                replace: Vec<(PackageIdSpec, Dependency)>,
                patch: HashMap<Url, Vec<Dependency>>,
                workspace: WorkspaceConfig,
@@ -291,6 +293,7 @@ impl Manifest {
             epoch,
             original,
             im_a_teapot,
+            publish_lockfile,
         }
     }
 
@@ -306,6 +309,7 @@ impl Manifest {
     pub fn warnings(&self) -> &[DelayedWarning] { &self.warnings }
     pub fn profiles(&self) -> &Profiles { &self.profiles }
     pub fn publish(&self) -> &Option<Vec<String>> { &self.publish }
+    pub fn publish_lockfile(&self) -> bool { self.publish_lockfile }
     pub fn replace(&self) -> &[(PackageIdSpec, Dependency)] { &self.replace }
     pub fn original(&self) -> &TomlManifest { &self.original }
     pub fn patch(&self) -> &HashMap<Url, Vec<Dependency>> { &self.patch }

--- a/src/cargo/ops/resolve.rs
+++ b/src/cargo/ops/resolve.rs
@@ -65,7 +65,7 @@ pub fn resolve_ws_precisely<'a>(ws: &Workspace<'a>,
 
         Some(resolve)
     } else {
-        None
+        ops::load_pkg_lockfile(ws)?
     };
 
     let method = if all_features {

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -426,6 +426,8 @@ pub struct TomlProject {
     exclude: Option<Vec<String>>,
     include: Option<Vec<String>>,
     publish: Option<VecStringOrBool>,
+    #[serde(rename = "publish-lockfile")]
+    publish_lockfile: Option<bool>,
     workspace: Option<String>,
     #[serde(rename = "im-a-teapot")]
     im_a_teapot: Option<bool>,
@@ -719,6 +721,14 @@ impl TomlManifest {
             None | Some(VecStringOrBool::Bool(true)) => None,
         };
 
+        let publish_lockfile = match project.publish_lockfile {
+            Some(b) => {
+                features.require(Feature::publish_lockfile())?;
+                b
+            }
+            None => false,
+        };
+
         let epoch = if let Some(ref epoch) = project.rust {
             features.require(Feature::epoch()).chain_err(|| {
                 "epoches are unstable"
@@ -739,6 +749,7 @@ impl TomlManifest {
                                          metadata,
                                          profiles,
                                          publish,
+                                         publish_lockfile,
                                          replace,
                                          patch,
                                          workspace_config,

--- a/tests/testsuite/install.rs
+++ b/tests/testsuite/install.rs
@@ -1044,3 +1044,33 @@ dependencies = [
     assert_that(cargo_process("install").arg("foo"),
                 execs().with_status(0));
 }
+
+#[test]
+fn lock_file_path_deps_ok() {
+    Package::new("bar", "0.1.0").publish();
+
+    Package::new("foo", "0.1.0")
+        .dep("bar", "0.1")
+        .file("src/lib.rs", "")
+        .file("src/main.rs", "
+            extern crate foo;
+            extern crate bar;
+            fn main() {}
+        ")
+        .file("Cargo.lock", r#"
+[[package]]
+name = "bar"
+version = "0.1.0"
+
+[[package]]
+name = "foo"
+version = "0.1.0"
+dependencies = [
+ "bar 0.1.0",
+]
+"#)
+        .publish();
+
+    assert_that(cargo_process("install").arg("foo"),
+                execs().with_status(0));
+}

--- a/tests/testsuite/install.rs
+++ b/tests/testsuite/install.rs
@@ -1011,3 +1011,36 @@ fn custom_target_dir_for_git_source() {
     assert_that(&paths::root().join("target/release"),
                 existing_dir());
 }
+
+#[test]
+fn install_respects_lock_file() {
+    Package::new("bar", "0.1.0").publish();
+    Package::new("bar", "0.1.1")
+        .file("src/lib.rs", "not rust")
+        .publish();
+    Package::new("foo", "0.1.0")
+        .dep("bar", "0.1")
+        .file("src/lib.rs", "")
+        .file("src/main.rs", "
+            extern crate foo;
+            extern crate bar;
+            fn main() {}
+        ")
+        .file("Cargo.lock", r#"
+[[package]]
+name = "bar"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "foo"
+version = "0.1.0"
+dependencies = [
+ "bar 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+"#)
+        .publish();
+
+    assert_that(cargo_process("install").arg("foo"),
+                execs().with_status(0));
+}


### PR DESCRIPTION
Previously we had logic to explicitly skip lock files but there's actually a
good case to read these from crates.io (#2263) so let's do so!

Closes #2263