### PR TITLE
Revert "Warn Windows 7 users about old TLS"

### DIFF
--- a/src/cargo/sources/git/utils.rs
+++ b/src/cargo/sources/git/utils.rs
@@ -591,7 +591,7 @@ pub fn with_fetch_options(git_config: &git2::Config,
     -> CargoResult<()>
 {
     let mut progress = Progress::new("Fetch", config);
-    network::with_retry(config, url, || {
+    network::with_retry(config, || {
         with_authentication(url.as_str(), git_config, |f| {
             let mut rcb = git2::RemoteCallbacks::new();
             rcb.credentials(f);

--- a/src/cargo/util/network.rs
+++ b/src/cargo/util/network.rs
@@ -1,6 +1,5 @@
 use curl;
 use git2;
-use url::Url;
 
 use failure::Error;
 
@@ -34,35 +33,6 @@ fn maybe_spurious(err: &Error) -> bool {
     false
 }
 
-
-/// Suggest the user to update their windows 7 to support modern TLS versions.
-/// See https://github.com/rust-lang/cargo/issues/5066 for details.
-#[cfg(windows)]
-fn should_warn_about_old_tls_for_win7(url: &Url, err: &Error) -> bool {
-    let is_github = url.host_str() == Some("github.com");
-    let is_cert_error = err.causes()
-        .filter_map(|e| e.downcast_ref::<git2::Error>())
-        .find(|e| e.class() == git2::ErrorClass::Net && e.code() == git2::ErrorCode::Certificate)
-        .is_some();
-    is_github && is_cert_error
-}
-
-#[cfg(not(windows))]
-fn should_warn_about_old_tls_for_win7(_url: &Url, _err: &Error) -> bool {
-    false
-}
-
-const WIN7_TLS_WARNING: &str = "\
-Certificate check failure might be caused by outdated TLS on older versions of Windows.
-If you are using Windows 7, Windows Server 2008 R2 or Windows Server 2012,
-please follow these instructions to enable more secure TLS:
-
-    https://support.microsoft.com/en-us/help/3140245/
-
-See https://github.com/rust-lang/cargo/issues/5066 for details.
-";
-
-
 /// Wrapper method for network call retry logic.
 ///
 /// Retry counts provided by Config object `net.retry`. Config shell outputs
@@ -76,7 +46,7 @@ See https://github.com/rust-lang/cargo/issues/5066 for details.
 /// use util::network;
 /// cargo_result = network::with_retry(&config, || something.download());
 /// ```
-pub fn with_retry<T, F>(config: &Config, url: &Url, mut callback: F) -> CargoResult<T>
+pub fn with_retry<T, F>(config: &Config, mut callback: F) -> CargoResult<T>
     where F: FnMut() -> CargoResult<T>
 {
     let mut remaining = config.net_retry()?;
@@ -84,14 +54,9 @@ pub fn with_retry<T, F>(config: &Config, url: &Url, mut callback: F) -> CargoRes
         match callback() {
             Ok(ret) => return Ok(ret),
             Err(ref e) if maybe_spurious(e) && remaining > 0 => {
-                config.shell().warn(
-                    format!("spurious network error ({} tries remaining): {}", remaining, e)
-                )?;
-
-                if should_warn_about_old_tls_for_win7(url, e) {
-                    config.shell().warn(WIN7_TLS_WARNING)?;
-                }
-
+                let msg = format!("spurious network error ({} tries \
+                          remaining): {}", remaining, e);
+                config.shell().warn(msg)?;
                 remaining -= 1;
             }
             //todo impl from
@@ -106,8 +71,7 @@ fn with_retry_repeats_the_call_then_works() {
     let error2 = HttpNot200 { code: 502, url: "Uri".to_string() }.into();
     let mut results: Vec<CargoResult<()>> = vec![Ok(()), Err(error1), Err(error2)];
     let config = Config::default().unwrap();
-    let url = "http://example.com".parse().unwrap();
-    let result = with_retry(&config, &url, || results.pop().unwrap());
+    let result = with_retry(&config, || results.pop().unwrap());
     assert_eq!(result.unwrap(), ())
 }
 
@@ -123,7 +87,6 @@ fn with_retry_finds_nested_spurious_errors() {
     let error2 = CargoError::from(error2.context("A second chained error"));
     let mut results: Vec<CargoResult<()>> = vec![Ok(()), Err(error1), Err(error2)];
     let config = Config::default().unwrap();
-    let url = "http://example.com".parse().unwrap();
-    let result = with_retry(&config, &url, || results.pop().unwrap());
+    let result = with_retry(&config, || results.pop().unwrap());
     assert_eq!(result.unwrap(), ())
 }


### PR DESCRIPTION
We now have upgraded libgit2 version, so Cargo would use TLS 1.2
on windows unconditionally. Note that even *unpatched* windows 7
supports TLS 1.2.

@retep998, you've originally written that

>TLS 1.2 support for Windows 7 still requires a rather recent patch and so even if we do fix that, we should still keep this error message because some people use Windows 7 with automatic updates disabled.

However, it looks like Windows 7 **does** support TLS 1.2 out of the box, and the update is required to enable the use of TLS 1.2 by default:

https://github.com/libgit2/libgit2/issues/4546#issuecomment-368909158

My own testing on a random win 7 virtual box confirms this. 


closes https://github.com/rust-lang/cargo/issues/5066