### PR TITLE
Add a publish-build-info command for reporting build results to crates.io

### DIFF
--- a/src/bin/cargo.rs
+++ b/src/bin/cargo.rs
@@ -124,6 +124,7 @@ macro_rules! each_subcommand{
         $mac!(package);
         $mac!(pkgid);
         $mac!(publish);
+        $mac!(publish_build_info);
         $mac!(read_manifest);
         $mac!(run);
         $mac!(rustc);

--- a/src/bin/publish_build_info.rs
+++ b/src/bin/publish_build_info.rs
@@ -1,0 +1,74 @@
+use cargo::core::Workspace;
+use cargo::ops;
+use cargo::util::{CliResult, Config};
+use cargo::util::important_paths::find_root_manifest_for_wd;
+
+#[derive(Deserialize)]
+pub struct Options {
+    flag_target: Option<String>,
+    flag_host: Option<String>,
+    flag_token: Option<String>,
+    flag_manifest_path: Option<String>,
+    flag_verbose: u32,
+    flag_quiet: Option<bool>,
+    flag_color: Option<String>,
+    flag_dry_run: bool,
+    flag_frozen: bool,
+    flag_locked: bool,
+    cmd_pass: bool,
+    #[allow(dead_code)] // Pass and fail are mutually exclusive
+    cmd_fail: bool,
+}
+
+pub const USAGE: &'static str = "
+Upload a package's build info to the registry: whether the crate built
+successfully on a particular target with a particular version of Rust.
+
+Usage:
+    cargo publish-build-info [options] (pass|fail)
+
+Options:
+    -h, --help               Print this message
+    --target TRIPLE          Build for the target triple
+    --host HOST              Host to upload the package to
+    --token TOKEN            Token to use when uploading
+    --manifest-path PATH     Path to the manifest of the package to publish
+    --dry-run                Perform all checks without uploading
+    -v, --verbose ...        Use verbose output (-vv very verbose/build.rs output)
+    -q, --quiet              No output printed to stdout
+    --color WHEN             Coloring: auto, always, never
+    --frozen                 Require Cargo.lock and cache are up to date
+    --locked                 Require Cargo.lock is up to date
+
+";
+
+pub fn execute(options: Options, config: &Config) -> CliResult {
+    config.configure(options.flag_verbose,
+                     options.flag_quiet,
+                     &options.flag_color,
+                     options.flag_frozen,
+                     options.flag_locked)?;
+
+    let Options {
+        flag_token: token,
+        flag_host: host,
+        flag_manifest_path,
+        flag_dry_run: dry_run,
+        flag_target: target,
+        cmd_pass,
+        ..
+    } = options;
+
+    let root = find_root_manifest_for_wd(flag_manifest_path.clone(), config.cwd())?;
+    let ws = Workspace::new(&root, config)?;
+    ops::publish_build_info(&ws, ops::PublishBuildInfoOpts {
+        config: config,
+        token: token,
+        index: host,
+        dry_run: dry_run,
+        rust_version: config.rustc()?.version_channel_date()?.to_string(),
+        target: target,
+        passed: cmd_pass,
+    })?;
+    Ok(())
+}

--- a/src/bin/publish_build_info.rs
+++ b/src/bin/publish_build_info.rs
@@ -6,7 +6,7 @@ use cargo::util::important_paths::find_root_manifest_for_wd;
 #[derive(Deserialize)]
 pub struct Options {
     flag_target: Option<String>,
-    flag_host: Option<String>,
+    flag_index: Option<String>,
     flag_token: Option<String>,
     flag_manifest_path: Option<String>,
     flag_verbose: u32,
@@ -15,6 +15,9 @@ pub struct Options {
     flag_dry_run: bool,
     flag_frozen: bool,
     flag_locked: bool,
+    #[serde(rename = "flag_Z")]
+    flag_z: Vec<String>,
+    flag_registry: Option<String>,
     cmd_pass: bool,
     #[allow(dead_code)] // Pass and fail are mutually exclusive
     cmd_fail: bool,
@@ -30,7 +33,7 @@ Usage:
 Options:
     -h, --help               Print this message
     --target TRIPLE          Build for the target triple
-    --host HOST              Host to upload the package to
+    --index INDEX            Registry index to publish build info to
     --token TOKEN            Token to use when uploading
     --manifest-path PATH     Path to the manifest of the package to publish
     --dry-run                Perform all checks without uploading
@@ -39,22 +42,26 @@ Options:
     --color WHEN             Coloring: auto, always, never
     --frozen                 Require Cargo.lock and cache are up to date
     --locked                 Require Cargo.lock is up to date
+    -Z FLAG ...              Unstable (nightly-only) flags to Cargo
+    --registry REGISTRY      Registry to use
 
 ";
 
-pub fn execute(options: Options, config: &Config) -> CliResult {
+pub fn execute(options: Options, config: &mut Config) -> CliResult {
     config.configure(options.flag_verbose,
                      options.flag_quiet,
                      &options.flag_color,
                      options.flag_frozen,
-                     options.flag_locked)?;
+                     options.flag_locked,
+                     &options.flag_z)?;
 
     let Options {
         flag_token: token,
-        flag_host: host,
+        flag_index: index,
         flag_manifest_path,
         flag_dry_run: dry_run,
         flag_target: target,
+        flag_registry: registry,
         cmd_pass,
         ..
     } = options;
@@ -62,12 +69,13 @@ pub fn execute(options: Options, config: &Config) -> CliResult {
     let root = find_root_manifest_for_wd(flag_manifest_path.clone(), config.cwd())?;
     let ws = Workspace::new(&root, config)?;
     ops::publish_build_info(&ws, ops::PublishBuildInfoOpts {
-        config: config,
-        token: token,
-        index: host,
-        dry_run: dry_run,
+        config,
+        token,
+        index,
+        dry_run,
         rust_version: config.rustc()?.version_channel_date()?.to_string(),
-        target: target,
+        registry,
+        target,
         passed: cmd_pass,
     })?;
     Ok(())

--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -716,7 +716,7 @@ fn scrape_build_config(config: &Config,
         None => None,
     };
     let jobs = jobs.or(cfg_jobs).unwrap_or(::num_cpus::get() as u32);
-    let cfg_target = config.get_string("build.target")?.map(|s| s.val);
+    let cfg_target = config.build_target_triple()?;
     let target = target.or(cfg_target);
     let mut base = ops::BuildConfig {
         host_triple: config.rustc()?.host.clone(),

--- a/src/cargo/ops/mod.rs
+++ b/src/cargo/ops/mod.rs
@@ -20,6 +20,7 @@ pub use self::registry::{publish, registry_configuration, RegistryConfig};
 pub use self::registry::{registry_login, search, needs_custom_http_transport, http_handle};
 pub use self::registry::{modify_owners, yank, OwnersOptions, PublishOpts};
 pub use self::registry::configure_http_handle;
+pub use self::registry::{publish_build_info, PublishBuildInfoOpts};
 pub use self::cargo_fetch::fetch;
 pub use self::cargo_pkgid::pkgid;
 pub use self::resolve::{resolve_ws, resolve_ws_precisely, resolve_with_previous};

--- a/src/cargo/ops/registry.rs
+++ b/src/cargo/ops/registry.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 
 use curl::easy::{Easy, SslOpt};
 use git2;
-use registry::{Registry, NewCrate, NewCrateDependency};
+use registry::{Registry, NewCrate, NewCrateDependency, NewVersionBuildInfo};
 
 use url::percent_encoding::{percent_encode, QUERY_ENCODE_SET};
 
@@ -223,6 +223,61 @@ fn transmit(config: &Config,
         },
         Err(e) => Err(e),
     }
+}
+
+pub struct PublishBuildInfoOpts<'cfg> {
+    pub config: &'cfg Config,
+    pub token: Option<String>,
+    pub index: Option<String>,
+    pub dry_run: bool,
+    pub rust_version: String,
+    pub target: Option<String>,
+    pub passed: bool,
+}
+
+pub fn publish_build_info(ws: &Workspace, opts: PublishBuildInfoOpts) -> CargoResult<()> {
+    let pkg = ws.current()?;
+
+    let (mut registry, _reg_id) = registry(opts.config, opts.token, opts.index)?;
+
+    // Upload build info to the specified destination
+    opts.config.shell().status("Uploading build info", pkg.package_id().to_string())?;
+
+    let target = opts.target;
+    let cfg_target = opts.config.build_target_triple()?;
+    let target = target.or(cfg_target);
+    let target = target.unwrap_or(opts.config.rustc()?.host.clone());
+
+    transmit_build_info(
+        opts.config, &pkg, &mut registry, opts.dry_run,
+        &opts.rust_version, &target, opts.passed)?;
+
+    Ok(())
+}
+
+fn transmit_build_info(config: &Config,
+            pkg: &Package,
+            registry: &mut Registry,
+            dry_run: bool,
+            rust_version: &str,
+            target: &str,
+            passed: bool) -> CargoResult<()> {
+
+    // Do not upload if performing a dry run
+    if dry_run {
+        config.shell().warn("aborting upload due to dry run")?;
+        return Ok(());
+    }
+
+    registry.publish_build_info(&NewVersionBuildInfo {
+        name: pkg.name().to_string(),
+        vers: pkg.version().to_string(),
+        rust_version: rust_version.to_string(),
+        target: target.to_string(),
+        passed: passed,
+    }).map_err(|e| {
+        CargoError::from(e.to_string())
+    })
 }
 
 pub fn registry_configuration(config: &Config,

--- a/src/cargo/ops/registry.rs
+++ b/src/cargo/ops/registry.rs
@@ -233,12 +233,13 @@ pub struct PublishBuildInfoOpts<'cfg> {
     pub rust_version: String,
     pub target: Option<String>,
     pub passed: bool,
+    pub registry: Option<String>,
 }
 
 pub fn publish_build_info(ws: &Workspace, opts: PublishBuildInfoOpts) -> CargoResult<()> {
     let pkg = ws.current()?;
 
-    let (mut registry, _reg_id) = registry(opts.config, opts.token, opts.index)?;
+    let (mut registry, _reg_id) = registry(opts.config, opts.token, opts.index, opts.registry)?;
 
     // Upload build info to the specified destination
     opts.config.shell().status("Uploading build info", pkg.package_id().to_string())?;
@@ -275,8 +276,6 @@ fn transmit_build_info(config: &Config,
         rust_version: rust_version.to_string(),
         target: target.to_string(),
         passed: passed,
-    }).map_err(|e| {
-        CargoError::from(e.to_string())
     })
 }
 

--- a/src/cargo/util/config.rs
+++ b/src/cargo/util/config.rs
@@ -223,6 +223,10 @@ impl Config {
 
     pub fn cwd(&self) -> &Path { &self.cwd }
 
+    pub fn build_target_triple(&self) -> CargoResult<Option<String>> {
+        self.get_string("build.target").map(|r| r.map(|s| s.val))
+    }
+
     pub fn target_dir(&self) -> CargoResult<Option<Filesystem>> {
         if let Some(dir) = env::var_os("CARGO_TARGET_DIR") {
             Ok(Some(Filesystem::new(self.cwd.join(dir))))

--- a/src/cargo/util/rustc.rs
+++ b/src/cargo/util/rustc.rs
@@ -60,7 +60,7 @@ impl Rustc {
         }
     }
 
-    pub fn medium_version(&self) -> Option<&str> {
-        self.verbose_version.lines().next()
+    pub fn version_channel_date(&self) -> CargoResult<&str> {
+        self.verbose_version.lines().next().ok_or(internal("rustc -v didn't have any lines"))
     }
 }

--- a/src/cargo/util/rustc.rs
+++ b/src/cargo/util/rustc.rs
@@ -59,4 +59,8 @@ impl Rustc {
             util::process(&self.path)
         }
     }
+
+    pub fn medium_version(&self) -> Option<&str> {
+        self.verbose_version.lines().next()
+    }
 }

--- a/src/crates-io/lib.rs
+++ b/src/crates-io/lib.rs
@@ -72,6 +72,15 @@ pub struct NewCrateDependency {
     pub registry: Option<String>,
 }
 
+#[derive(Serialize)]
+pub struct NewVersionBuildInfo {
+    pub name: String,
+    pub vers: String,
+    pub rust_version: String,
+    pub target: String,
+    pub passed: bool,
+}
+
 #[derive(Deserialize)]
 pub struct User {
     pub id: u32,
@@ -200,6 +209,18 @@ impl Registry {
             invalid_categories: invalid_categories,
             invalid_badges: invalid_badges,
         })
+    }
+
+    pub fn publish_build_info(&mut self, build_info: &NewVersionBuildInfo)
+                   -> Result<()> {
+        let body = serde_json::to_string(build_info)?;
+        let url = format!("/crates/{}/{}/build_info", build_info.name, build_info.vers);
+
+        let body = self.put(url, body.as_bytes())?;
+
+        assert!(serde_json::from_str::<R>(&body)?.ok);
+
+        Ok(())
     }
 
     pub fn search(&mut self, query: &str, limit: u8) -> Result<(Vec<Crate>, u32)> {


### PR DESCRIPTION
We're working on reviving this old thing :) The [associated crates.io PR](https://github.com/rust-lang/crates.io/pull/764) should go in first.

This goes with https://github.com/rust-lang/crates.io/pull/764. @shepmaster worked on these too :)

This PR adds a cargo command, `publish-build-info`, which allows crate owners to report crate version, rust version, target, and pass/fail to crates.io.

The purpose is to enable crate authors to automatically report to potential crate users on the Rust version and platform compatibility of each version of the crate.

The idea is that this command would be added to CI, and an example of configuration for Travis is in the documentation we added. We haven't actually tested that configuration out yet; we wanted to get these PRs in for feedback before we set up crates.io instances that weren't local but that we could publish to :) We want to add Appveyor too, but we want to test the travis configuration first.

We also thought about, but didn't implement:

- ~~An `--overwrite` flag to allow editing of an already-reported-on crate version+rust version+target combination, to allow for correcting errors if reporting manually~~ Overwriting is now the default behavior.
- Adding flags to enable manual specification of rust version and crate version, right now cargo just detects what it's running with. Target can be overridden with `--target` since there was already support for that flag :)
