### PR TITLE
Try a lot harder to recover corrupt git repos

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ matrix:
       script:
         - cargo test
         - cargo doc --no-deps
-        - (cd src/doc && mdbook build --no-create --dest-dir ../../target/doc)
+        - (cd src/doc && mdbook build --dest-dir ../../target/doc)
 
   exclude:
     - rust: stable

--- a/src/cargo/ops/cargo_clean.rs
+++ b/src/cargo/ops/cargo_clean.rs
@@ -5,6 +5,7 @@ use std::path::Path;
 use core::{Profiles, Workspace};
 use util::Config;
 use util::errors::{CargoResult, CargoResultExt};
+use util::paths;
 use ops::{self, Context, BuildConfig, Kind, Unit};
 
 pub struct CleanOptions<'a> {
@@ -99,12 +100,12 @@ fn rm_rf(path: &Path, config: &Config) -> CargoResult<()> {
     let m = fs::metadata(path);
     if m.as_ref().map(|s| s.is_dir()).unwrap_or(false) {
         config.shell().verbose(|shell| {shell.status("Removing", path.display())})?;
-        fs::remove_dir_all(path).chain_err(|| {
+        paths::remove_dir_all(path).chain_err(|| {
             format_err!("could not remove build directory")
         })?;
     } else if m.is_ok() {
         config.shell().verbose(|shell| {shell.status("Removing", path.display())})?;
-        fs::remove_file(path).chain_err(|| {
+        paths::remove_file(path).chain_err(|| {
             format_err!("failed to remove build artifact")
         })?;
     }

--- a/src/cargo/ops/cargo_install.rs
+++ b/src/cargo/ops/cargo_install.rs
@@ -17,6 +17,7 @@ use sources::{GitSource, PathSource, SourceConfigMap};
 use util::{Config, internal};
 use util::{Filesystem, FileLock};
 use util::errors::{CargoResult, CargoResultExt};
+use util::paths;
 
 #[derive(Deserialize, Serialize)]
 #[serde(untagged)]
@@ -47,7 +48,7 @@ impl Transaction {
 impl Drop for Transaction {
     fn drop(&mut self) {
         for bin in self.bins.iter() {
-            let _ = fs::remove_file(bin);
+            let _ = paths::remove_file(bin);
         }
     }
 }
@@ -319,7 +320,7 @@ fn install_one(root: &Filesystem,
         // Don't bother grabbing a lock as we're going to blow it all away
         // anyway.
         let target_dir = ws.target_dir().into_path_unlocked();
-        fs::remove_dir_all(&target_dir)?;
+        paths::remove_dir_all(&target_dir)?;
     }
 
     Ok(())
@@ -667,7 +668,7 @@ pub fn uninstall_one(root: &Filesystem,
     write_crate_list(&crate_metadata, metadata)?;
     for bin in to_remove {
         config.shell().status("Removing", bin.display())?;
-        fs::remove_file(bin)?;
+        paths::remove_file(bin)?;
     }
 
     Ok(())

--- a/src/cargo/ops/cargo_package.rs
+++ b/src/cargo/ops/cargo_package.rs
@@ -304,8 +304,8 @@ fn run_verify(ws: &Workspace, tar: &FileLock, opts: &PackageOpts) -> CargoResult
 
     let f = GzDecoder::new(tar.file());
     let dst = tar.parent().join(&format!("{}-{}", pkg.name(), pkg.version()));
-    if fs::metadata(&dst).is_ok() {
-        fs::remove_dir_all(&dst)?;
+    if dst.exists() {
+        paths::remove_dir_all(&dst)?;
     }
     let mut archive = Archive::new(f);
     archive.unpack(dst.parent().unwrap())?;

--- a/src/cargo/ops/cargo_rustc/mod.rs
+++ b/src/cargo/ops/cargo_rustc/mod.rs
@@ -15,6 +15,7 @@ use core::manifest::Lto;
 use core::shell::ColorChoice;
 use util::{self, ProcessBuilder, machine_message};
 use util::{Config, internal, profile, join_paths};
+use util::paths;
 use util::errors::{CargoResult, CargoResultExt, Internal};
 use util::Freshness;
 
@@ -385,9 +386,7 @@ fn rustc<'a, 'cfg>(cx: &mut Context<'a, 'cfg>,
             if filename.extension() == Some(OsStr::new("rmeta")) {
                 let dst = root.join(filename).with_extension("rlib");
                 if dst.exists() {
-                    fs::remove_file(&dst).chain_err(|| {
-                        format!("Could not remove file: {}.", dst.display())
-                    })?;
+                    paths::remove_file(&dst)?;
                 }
             }
         }
@@ -541,9 +540,7 @@ fn link_targets<'a, 'cfg>(cx: &mut Context<'a, 'cfg>,
                 continue
             }
             if dst.exists() {
-                fs::remove_file(&dst).chain_err(|| {
-                    format!("failed to remove: {}", dst.display())
-                })?;
+                paths::remove_file(&dst)?;
             }
 
             let link_result = if src.is_dir() {

--- a/src/cargo/sources/git/source.rs
+++ b/src/cargo/sources/git/source.rs
@@ -6,7 +6,7 @@ use core::source::{Source, SourceId};
 use core::GitReference;
 use core::{Package, PackageId, Summary, Registry, Dependency};
 use util::Config;
-use util::errors::{CargoResult, Internal};
+use util::errors::CargoResult;
 use util::hex::short_hash;
 use sources::PathSource;
 use sources::git::utils::{GitRemote, GitRevision};
@@ -170,9 +170,7 @@ impl<'cfg> Source for GitSource<'cfg> {
 
             trace!("updating git source `{:?}`", self.remote);
 
-            let repo = self.remote.checkout(&db_path, self.config)?;
-            let rev = repo.rev_for(&self.reference).map_err(Internal::new)?;
-            (repo, rev)
+            self.remote.checkout(&db_path, &self.reference, self.config)?
         } else {
             (self.remote.db_at(&db_path)?, actual_rev.unwrap())
         };

--- a/src/cargo/util/flock.rs
+++ b/src/cargo/util/flock.rs
@@ -9,6 +9,7 @@ use fs2::{FileExt, lock_contended_error};
 use libc;
 
 use util::Config;
+use util::paths;
 use util::errors::{CargoResult, CargoResultExt, CargoError};
 
 pub struct FileLock {
@@ -49,7 +50,7 @@ impl FileLock {
     ///
     /// This can be useful if a directory is locked with a sentinel file but it
     /// needs to be cleared out as it may be corrupt.
-    pub fn remove_siblings(&self) -> io::Result<()> {
+    pub fn remove_siblings(&self) -> CargoResult<()> {
         let path = self.path();
         for entry in path.parent().unwrap().read_dir()? {
             let entry = entry?;
@@ -58,9 +59,9 @@ impl FileLock {
             }
             let kind = entry.file_type()?;
             if kind.is_dir() {
-                fs::remove_dir_all(entry.path())?;
+                paths::remove_dir_all(entry.path())?;
             } else {
-                fs::remove_file(entry.path())?;
+                paths::remove_file(entry.path())?;
             }
         }
         Ok(())

--- a/src/cargo/util/paths.rs
+++ b/src/cargo/util/paths.rs
@@ -1,7 +1,7 @@
 use std::env;
 use std::ffi::{OsStr, OsString};
-use std::fs::File;
-use std::fs::OpenOptions;
+use std::fs::{self, File, OpenOptions};
+use std::io;
 use std::io::prelude::*;
 use std::path::{Path, PathBuf, Component};
 
@@ -187,4 +187,73 @@ impl<'a> Iterator for PathAncestors<'a> {
             None
         }
     }
+}
+
+pub fn remove_dir_all<P: AsRef<Path>>(p: P) -> CargoResult<()> {
+    _remove_dir_all(p.as_ref())
+}
+
+fn _remove_dir_all(p: &Path) -> CargoResult<()> {
+    if p.symlink_metadata()?.file_type().is_symlink() {
+        return remove_file(p)
+    }
+    let entries = p.read_dir().chain_err(|| {
+        format!("failed to read directory `{}`", p.display())
+    })?;
+    for entry in entries {
+        let entry = entry?;
+        let path = entry.path();
+        if entry.file_type()?.is_dir() {
+            remove_dir_all(&path)?;
+        } else {
+            remove_file(&path)?;
+        }
+    }
+    remove_dir(&p)
+}
+
+pub fn remove_dir<P: AsRef<Path>>(p: P) -> CargoResult<()> {
+    _remove_dir(p.as_ref())
+}
+
+fn _remove_dir(p: &Path) -> CargoResult<()> {
+    fs::remove_dir(p).chain_err(|| {
+        format!("failed to remove directory `{}`", p.display())
+    })?;
+    Ok(())
+}
+
+pub fn remove_file<P: AsRef<Path>>(p: P) -> CargoResult<()> {
+    _remove_file(p.as_ref())
+}
+
+fn _remove_file(p: &Path) -> CargoResult<()> {
+    let mut err = match fs::remove_file(p) {
+        Ok(()) => return Ok(()),
+        Err(e) => e,
+    };
+
+    if err.kind() == io::ErrorKind::PermissionDenied {
+        if set_not_readonly(p).unwrap_or(false) {
+            match fs::remove_file(p) {
+                Ok(()) => return Ok(()),
+                Err(e) => err = e,
+            }
+        }
+    }
+
+    Err(err).chain_err(|| {
+        format!("failed to remove file `{}`", p.display())
+    })?;
+    Ok(())
+}
+
+fn set_not_readonly(p: &Path) -> io::Result<bool> {
+    let mut perms = p.metadata()?.permissions();
+    if !perms.readonly() {
+        return Ok(false)
+    }
+    perms.set_readonly(false);
+    fs::set_permissions(p, perms)?;
+    Ok(true)
 }

--- a/tests/testsuite/corrupt_git.rs
+++ b/tests/testsuite/corrupt_git.rs
@@ -1,0 +1,161 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use cargo::util::paths as cargopaths;
+use cargotest::support::paths;
+use cargotest::support::{git, project, execs};
+use hamcrest::assert_that;
+
+#[test]
+fn deleting_database_files() {
+    let project = project("foo");
+    let git_project = git::new("bar", |project| {
+        project
+            .file("Cargo.toml", r#"
+                [project]
+                name = "bar"
+                version = "0.5.0"
+                authors = []
+            "#)
+            .file("src/lib.rs", "")
+    }).unwrap();
+
+    let project = project
+        .file("Cargo.toml", &format!(r#"
+            [project]
+            name = "foo"
+            version = "0.5.0"
+            authors = []
+
+            [dependencies]
+            bar = {{ git = '{}' }}
+        "#, git_project.url()))
+        .file("src/lib.rs", "")
+        .build();
+
+    assert_that(project.cargo("build"), execs().with_status(0));
+
+    let mut files = Vec::new();
+    find_files(&paths::home().join(".cargo/git/db"), &mut files);
+    assert!(files.len() > 0);
+
+    let log = "cargo::sources::git=trace";
+    for file in files {
+        if !file.exists() {
+            continue
+        }
+        println!("deleting {}", file.display());
+        cargopaths::remove_file(&file).unwrap();
+        assert_that(project.cargo("build").env("RUST_LOG", log).arg("-v"),
+                    execs().with_status(0));
+
+        if !file.exists() {
+            continue
+        }
+        println!("truncating {}", file.display());
+        make_writable(&file);
+        fs::OpenOptions::new()
+            .write(true)
+            .open(&file)
+            .unwrap()
+            .set_len(2)
+            .unwrap();
+        assert_that(project.cargo("build").env("RUST_LOG", log).arg("-v"),
+                    execs().with_status(0));
+    }
+}
+
+#[test]
+fn deleting_checkout_files() {
+    let project = project("foo");
+    let git_project = git::new("bar", |project| {
+        project
+            .file("Cargo.toml", r#"
+                [project]
+                name = "bar"
+                version = "0.5.0"
+                authors = []
+            "#)
+            .file("src/lib.rs", "")
+    }).unwrap();
+
+    let project = project
+        .file("Cargo.toml", &format!(r#"
+            [project]
+            name = "foo"
+            version = "0.5.0"
+            authors = []
+
+            [dependencies]
+            bar = {{ git = '{}' }}
+        "#, git_project.url()))
+        .file("src/lib.rs", "")
+        .build();
+
+    assert_that(project.cargo("build"), execs().with_status(0));
+
+    let dir = paths::home()
+        .join(".cargo/git/checkouts")
+        // get the first entry in the checkouts dir for the package's location
+        .read_dir()
+        .unwrap()
+        .next()
+        .unwrap()
+        .unwrap()
+        .path()
+        // get the first child of that checkout dir for our checkout
+        .read_dir()
+        .unwrap()
+        .next()
+        .unwrap()
+        .unwrap()
+        .path()
+        // and throw on .git to corrupt things
+        .join(".git");
+    let mut files = Vec::new();
+    find_files(&dir, &mut files);
+    assert!(files.len() > 0);
+
+    let log = "cargo::sources::git=trace";
+    for file in files {
+        if !file.exists() {
+            continue
+        }
+        println!("deleting {}", file.display());
+        cargopaths::remove_file(&file).unwrap();
+        assert_that(project.cargo("build").env("RUST_LOG", log).arg("-v"),
+                    execs().with_status(0));
+
+        if !file.exists() {
+            continue
+        }
+        println!("truncating {}", file.display());
+        make_writable(&file);
+        fs::OpenOptions::new()
+            .write(true)
+            .open(&file)
+            .unwrap()
+            .set_len(2)
+            .unwrap();
+        assert_that(project.cargo("build").env("RUST_LOG", log).arg("-v"),
+                    execs().with_status(0));
+    }
+}
+
+fn make_writable(path: &Path) {
+    let mut p = path.metadata().unwrap().permissions();
+    p.set_readonly(false);
+    fs::set_permissions(path, p).unwrap();
+}
+
+fn find_files(path: &Path, dst: &mut Vec<PathBuf>) {
+    for e in path.read_dir().unwrap() {
+        let e = e.unwrap();
+        let path = e.path();
+        if e.file_type().unwrap().is_dir() {
+            find_files(&path, dst);
+        } else {
+            dst.push(path);
+        }
+    }
+}

--- a/tests/testsuite/git.rs
+++ b/tests/testsuite/git.rs
@@ -855,7 +855,8 @@ git = git_project.url(), dir = p.url())));
 [UPDATING] git repository [..]
 [ERROR] Unable to update [..]
 
-To learn more, run the command again with --verbose.
+Caused by:
+  revspec '0.1.2' not found; [..]
 "));
 
     // Specifying a precise rev to the old rev shouldn't actually update

--- a/tests/testsuite/lib.rs
+++ b/tests/testsuite/lib.rs
@@ -38,6 +38,7 @@ mod check;
 mod clean;
 mod concurrent;
 mod config;
+mod corrupt_git;
 mod cross_compile;
 mod cross_publish;
 mod death;


### PR DESCRIPTION
We've received a lot of intermittent bug reports historically about corrupt git
repositories. These inevitably happens as Cargo is ctrl-c'd or for whatever
other reason, and to provide a better user experience Cargo strives to
automatically handle these situations by blowing away the old checkout for a new
update.

This commit adds a new test which attempts to pathologically corrupt a git
database and checkout in an attempt to expose bugs in Cargo. Sure enough there
were some more locations that we needed to handle gracefully for corrupt git
checkouts. Notable inclusions were:

* The `fetch` operation in libgit2 would fail due to corrupt references. This
  starts by adding an explicit whitelist for classes of errors coming out of
  `fetch` to auto-retry by blowing away the repository. We need to be super
  careful here as network errors commonly come out of this function and we don't
  want to too aggressively re-clone.

* After a `fetch` succeeded a repository could fail to actual resolve a
  git reference to the actual revision we want. This indicated that we indeed
  needed to blow everything away and re-clone entirely again.

* When creating a checkout from a database the `reset` operation might fail due
  to a corrupt local database of the checkout itself. If this happens we needed
  to just blow it away and try again.

There's likely more lurking situations where we need to re-clone but I figure we
can discover those over time.