### PR TITLE
Cache the query result.

### DIFF
--- a/src/cargo/core/dependency.rs
+++ b/src/cargo/core/dependency.rs
@@ -12,13 +12,13 @@ use util::errors::{CargoResult, CargoResultExt, CargoError};
 
 /// Information about a dependency requested by a Cargo manifest.
 /// Cheap to copy.
-#[derive(PartialEq, Eq, Ord, PartialOrd, Clone, Debug)]
+#[derive(PartialEq, Eq, Hash, Ord, PartialOrd, Clone, Debug)]
 pub struct Dependency {
     inner: Rc<Inner>,
 }
 
 /// The data underlying a Dependency.
-#[derive(PartialEq, Eq, Ord, PartialOrd, Clone, Debug)]
+#[derive(PartialEq, Eq, Hash, Ord, PartialOrd, Clone, Debug)]
 struct Inner {
     name: String,
     source_id: SourceId,
@@ -38,7 +38,7 @@ struct Inner {
     platform: Option<Platform>,
 }
 
-#[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Debug)]
+#[derive(Eq, PartialEq, Hash, Ord, PartialOrd, Clone, Debug)]
 pub enum Platform {
     Name(String),
     Cfg(CfgExpr),
@@ -76,7 +76,7 @@ impl ser::Serialize for Dependency {
     }
 }
 
-#[derive(PartialEq, Eq, Ord, PartialOrd, Clone, Debug, Copy)]
+#[derive(PartialEq, Eq, Hash, Ord, PartialOrd, Clone, Debug, Copy)]
 pub enum Kind {
     Normal,
     Development,

--- a/src/cargo/core/dependency.rs
+++ b/src/cargo/core/dependency.rs
@@ -12,13 +12,13 @@ use util::errors::{CargoResult, CargoResultExt, CargoError};
 
 /// Information about a dependency requested by a Cargo manifest.
 /// Cheap to copy.
-#[derive(PartialEq, Clone, Debug)]
+#[derive(PartialEq, Eq, Ord, PartialOrd, Clone, Debug)]
 pub struct Dependency {
     inner: Rc<Inner>,
 }
 
 /// The data underlying a Dependency.
-#[derive(PartialEq, Clone, Debug)]
+#[derive(PartialEq, Eq, Ord, PartialOrd, Clone, Debug)]
 struct Inner {
     name: String,
     source_id: SourceId,
@@ -38,7 +38,7 @@ struct Inner {
     platform: Option<Platform>,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Debug)]
 pub enum Platform {
     Name(String),
     Cfg(CfgExpr),
@@ -76,7 +76,7 @@ impl ser::Serialize for Dependency {
     }
 }
 
-#[derive(PartialEq, Clone, Debug, Copy)]
+#[derive(PartialEq, Eq, Ord, PartialOrd, Clone, Debug, Copy)]
 pub enum Kind {
     Normal,
     Development,

--- a/src/cargo/core/resolver/mod.rs
+++ b/src/cargo/core/resolver/mod.rs
@@ -574,7 +574,7 @@ struct RegistryQueryer<'a> {
     registry: &'a mut (Registry + 'a),
     replacements: &'a [(PackageIdSpec, Dependency)],
     // TODO: with nll the Rc can be removed
-    cache: BTreeMap<Dependency, Rc<Vec<Candidate>>>,
+    cache: HashMap<Dependency, Rc<Vec<Candidate>>>,
 }
 
 impl<'a> RegistryQueryer<'a> {
@@ -582,7 +582,7 @@ impl<'a> RegistryQueryer<'a> {
         RegistryQueryer {
             registry,
             replacements,
-            cache: BTreeMap::new(),
+            cache: HashMap::new(),
         }
     }
 

--- a/src/cargo/util/cfg.rs
+++ b/src/cargo/util/cfg.rs
@@ -4,13 +4,13 @@ use std::fmt;
 
 use util::{CargoError, CargoResult};
 
-#[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Debug)]
+#[derive(Eq, PartialEq, Hash, Ord, PartialOrd, Clone, Debug)]
 pub enum Cfg {
     Name(String),
     KeyPair(String, String),
 }
 
-#[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Debug)]
+#[derive(Eq, PartialEq, Hash, Ord, PartialOrd, Clone, Debug)]
 pub enum CfgExpr {
     Not(Box<CfgExpr>),
     All(Vec<CfgExpr>),

--- a/src/cargo/util/cfg.rs
+++ b/src/cargo/util/cfg.rs
@@ -4,13 +4,13 @@ use std::fmt;
 
 use util::{CargoError, CargoResult};
 
-#[derive(Clone, PartialEq, Debug)]
+#[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Debug)]
 pub enum Cfg {
     Name(String),
     KeyPair(String, String),
 }
 
-#[derive(Clone, PartialEq, Debug)]
+#[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Debug)]
 pub enum CfgExpr {
     Not(Box<CfgExpr>),
     All(Vec<CfgExpr>),


### PR DESCRIPTION
Small performance gain.

In a test on https://github.com/rust-lang/cargo/issues/4810#issuecomment-357553286
Before we got to 1700000 ticks in ~97 sec
After we got to 1700000 ticks in ~92 sec. I just reran and got ~82, so it seems to be unstable.
And query disappears from the flame graph