### PR TITLE
Emit Resolve.features_sorted in "cargo metadata"

### DIFF
--- a/src/cargo/ops/cargo_output_metadata.rs
+++ b/src/cargo/ops/cargo_output_metadata.rs
@@ -98,12 +98,14 @@ fn serialize_resolve<S>(resolve: &Resolve, s: S) -> Result<S::Ok, S::Error>
     struct Node<'a> {
         id: &'a PackageId,
         dependencies: Vec<&'a PackageId>,
+        features: Vec<&'a str>,
     }
 
     resolve.iter().map(|id| {
         Node {
             id,
             dependencies: resolve.deps(id).collect(),
+            features: resolve.features_sorted(id),
         }
     }).collect::<Vec<_>>().serialize(s)
 }

--- a/tests/testsuite/metadata.rs
+++ b/tests/testsuite/metadata.rs
@@ -129,6 +129,76 @@ crate-type = ["lib", "staticlib"]
 }
 
 #[test]
+fn library_with_features() {
+    let p = project("foo")
+        .file("src/lib.rs", "")
+        .file("Cargo.toml", r#"
+[package]
+name = "foo"
+version = "0.5.0"
+
+[features]
+default = ["default_feat"]
+default_feat = []
+optional_feat = []
+            "#)
+        .build();
+
+    assert_that(p.cargo("metadata"), execs().with_json(r#"
+    {
+        "packages": [
+            {
+                "name": "foo",
+                "version": "0.5.0",
+                "id": "foo[..]",
+                "source": null,
+                "dependencies": [],
+                "license": null,
+                "license_file": null,
+                "description": null,
+                "targets": [
+                    {
+                        "kind": [
+                            "lib"
+                        ],
+                        "crate_types": [
+                            "lib"
+                        ],
+                        "name": "foo",
+                        "src_path": "[..][/]foo[/]src[/]lib.rs"
+                    }
+                ],
+                "features": {
+                  "default": [
+                    "default_feat"
+                  ],
+                  "default_feat": [],
+                  "optional_feat": []
+                },
+                "manifest_path": "[..]Cargo.toml"
+            }
+        ],
+        "workspace_members": ["foo 0.5.0 (path+file:[..]foo)"],
+        "resolve": {
+            "nodes": [
+                {
+                    "dependencies": [],
+                    "features": [
+                      "default",
+                      "default_feat"
+                    ],
+                    "id": "foo 0.5.0 (path+file:[..]foo)"
+                }
+            ],
+            "root": "foo 0.5.0 (path+file:[..]foo)"
+        },
+        "target_directory": "[..]foo[/]target",
+        "version": 1,
+        "workspace_root": "[..][/]foo"
+    }"#));
+}
+
+#[test]
 fn cargo_metadata_with_deps_and_version() {
     let p = project("foo")
         .file("src/foo.rs", "")


### PR DESCRIPTION
This PR adds `features` to `metadata.resolve.nodes[*]` using the Resolve object's known features. This is different from the `features` fields that already exist elsewhere within metadata as this one is the actual features that need to be used in order to build the code.

Context: I'm currently using Cargo's internals to synthesize BUILD files for the Bazel build tool. `cargo metadata` currently provides almost everything I need in order to avoid using Cargo's internals -- *except* for this.

cc https://github.com/google/cargo-raze/issues/7
