### PR TITLE
Auto-disable incremental on CI builds

### DIFF
--- a/src/cargo/ops/cargo_rustc/fingerprint.rs
+++ b/src/cargo/ops/cargo_rustc/fingerprint.rs
@@ -414,7 +414,7 @@ fn calculate<'a, 'cfg>(cx: &mut Context<'a, 'cfg>, unit: &Unit<'a>)
     let fingerprint = Arc::new(Fingerprint {
         rustc: util::hash_u64(&cx.config.rustc()?.verbose_version),
         target: util::hash_u64(&unit.target),
-        profile: util::hash_u64(&(&unit.profile, cx.incremental_args(unit)?)),
+        profile: util::hash_u64(&(&unit.profile, cx.incremental_enabled()?)),
         // Note that .0 is hashed here, not .1 which is the cwd. That doesn't
         // actually affect the output artifact so there's no need to hash it.
         path: util::hash_u64(&super::path_args(cx, unit).0),

--- a/src/cargo/ops/cargo_rustc/job_queue.rs
+++ b/src/cargo/ops/cargo_rustc/job_queue.rs
@@ -260,6 +260,11 @@ impl<'a> JobQueue<'a> {
         if profile.debuginfo.is_some() {
             opt_type += " + debuginfo";
         }
+        match (profile.incremental, cx.incremental_enabled()?) {
+            (true, false) => opt_type += " + non-incremental",
+            (false, true) => opt_type += " + incremental",
+            (false, false) | (true, true) => {}
+        }
         let duration = start_time.elapsed();
         let time_elapsed = format!("{}.{1:.2} secs",
                                    duration.as_secs(),

--- a/tests/testsuite/build_script.rs
+++ b/tests/testsuite/build_script.rs
@@ -839,6 +839,7 @@ fn build_cmd_with_a_build_cmd() {
     --emit=dep-info,link -C debuginfo=2 \
     -C metadata=[..] \
     --out-dir [..]target[/]debug[/]deps \
+    -C incremental=[..] \
     -L [..]target[/]debug[/]deps`
 [COMPILING] foo v0.5.0 (file://[..])
 [RUNNING] `rustc --crate-name build_script_build build.rs --crate-type bin \

--- a/tests/testsuite/cargotest/mod.rs
+++ b/tests/testsuite/cargotest/mod.rs
@@ -40,11 +40,6 @@ fn _process(t: &OsStr) -> cargo::util::ProcessBuilder {
      // cargo rides the trains.
      .env("__CARGO_TEST_CHANNEL_OVERRIDE_DO_NOT_USE_THIS", "stable")
 
-     // For now disable incremental by default as support hasn't ridden to the
-     // stable channel yet. Once incremental support hits the stable compiler we
-     // can switch this to one and then fix the tests.
-     .env("CARGO_INCREMENTAL", "0")
-
      // This env var can switch the git backend from libgit2 to git2-curl, which
      // can tweak error messages and cause some tests to fail, so let's forcibly
      // remove it.
@@ -66,7 +61,9 @@ fn _process(t: &OsStr) -> cargo::util::ProcessBuilder {
      .env_remove("GIT_COMMITTER_NAME")
      .env_remove("GIT_COMMITTER_EMAIL")
      .env_remove("CARGO_TARGET_DIR")     // we assume 'target'
-     .env_remove("MSYSTEM");             // assume cmd.exe everywhere on windows
+     .env_remove("MSYSTEM")              // assume cmd.exe everywhere on windows
+     .env_remove("CI")
+     .env_remove("CARGO_INCREMENTAL");
     return p
 }
 

--- a/tests/testsuite/cross_compile.rs
+++ b/tests/testsuite/cross_compile.rs
@@ -298,7 +298,7 @@ fn linker_and_ar() {
             linker = "my-linker-tool"
         "#, target))
         .file("Cargo.toml", &basic_bin_manifest("foo"))
-        .file("src/foo.rs", &format!(r#"
+        .file("src/main.rs", &format!(r#"
             use std::env;
             fn main() {{
                 assert_eq!(env::consts::ARCH, "{}");
@@ -311,12 +311,13 @@ fn linker_and_ar() {
                 execs().with_status(101)
                        .with_stderr_contains(&format!("\
 [COMPILING] foo v0.5.0 ({url})
-[RUNNING] `rustc --crate-name foo src[/]foo.rs --crate-type bin \
+[RUNNING] `rustc --crate-name foo src[/]main.rs --crate-type bin \
     --emit=dep-info,link -C debuginfo=2 \
     -C metadata=[..] \
     --out-dir {dir}[/]target[/]{target}[/]debug[/]deps \
     --target {target} \
     -C ar=my-ar-tool -C linker=my-linker-tool \
+    -C incremental=[..] \
     -L dependency={dir}[/]target[/]{target}[/]debug[/]deps \
     -L dependency={dir}[/]target[/]debug[/]deps`
 ",

--- a/tests/testsuite/run.rs
+++ b/tests/testsuite/run.rs
@@ -561,6 +561,7 @@ fn example_with_release_flag() {
         --emit=dep-info,link \
         -C opt-level=3 \
         -C metadata=[..] \
+        -C extra-filename=[..] \
         --out-dir {dir}[/]target[/]release[/]deps \
         -L dependency={dir}[/]target[/]release[/]deps`
 [COMPILING] foo v0.0.1 ({url})
@@ -568,6 +569,7 @@ fn example_with_release_flag() {
         --emit=dep-info,link \
         -C opt-level=3 \
         -C metadata=[..] \
+        -C extra-filename=[..] \
         --out-dir {dir}[/]target[/]release[/]examples \
         -L dependency={dir}[/]target[/]release[/]deps \
          --extern bar={dir}[/]target[/]release[/]deps[/]libbar-[..].rlib`
@@ -590,6 +592,7 @@ fast2"));
         -C debuginfo=2 \
         -C metadata=[..] \
         --out-dir {dir}[/]target[/]debug[/]deps \
+        -C incremental=[..] \
         -L dependency={dir}[/]target[/]debug[/]deps`
 [COMPILING] foo v0.0.1 ({url})
 [RUNNING] `rustc --crate-name a examples[/]a.rs --crate-type bin \
@@ -597,6 +600,7 @@ fast2"));
         -C debuginfo=2 \
         -C metadata=[..] \
         --out-dir {dir}[/]target[/]debug[/]examples \
+        -C incremental=[..] \
         -L dependency={dir}[/]target[/]debug[/]deps \
          --extern bar={dir}[/]target[/]debug[/]deps[/]libbar-[..].rlib`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]


### PR DESCRIPTION
Most CI systems seem to export an environment variable named `CI` to indicate
such. Incremental compilation is also known to slow down development builds due
to the extra tracking necessary. As a result the *fastest* dev build currently
involves disabling incremental compilation (so long as you're not actually
incrementall compiling). In CI it's typically pretty rare that artifacts are
cached as well (or so it seems).

As a result this commit is a stab at automatically disabling incremental
compilation on CI to see if we can improve the compile time of projects in these
situations.