### PR TITLE
Some small optimizations

### DIFF
--- a/src/cargo/core/source/source_id.rs
+++ b/src/cargo/core/source/source_id.rs
@@ -168,21 +168,23 @@ impl SourceId {
     /// This is the main cargo registry by default, but it can be overridden in
     /// a `.cargo/config`.
     pub fn crates_io(config: &Config) -> CargoResult<SourceId> {
-        let cfg = ops::registry_configuration(config, None)?;
-        let url = if let Some(ref index) = cfg.index {
-            static WARNED: AtomicBool = ATOMIC_BOOL_INIT;
-            if !WARNED.swap(true, SeqCst) {
-                config.shell().warn("custom registry support via \
-                                     the `registry.index` configuration is \
-                                     being removed, this functionality \
-                                     will not work in the future")?;
-            }
-            &index[..]
-        } else {
-            CRATES_IO
-        };
-        let url = url.to_url()?;
-        SourceId::for_registry(&url)
+        config.crates_io_source_id(|| {
+            let cfg = ops::registry_configuration(config, None)?;
+            let url = if let Some(ref index) = cfg.index {
+                static WARNED: AtomicBool = ATOMIC_BOOL_INIT;
+                if !WARNED.swap(true, SeqCst) {
+                    config.shell().warn("custom registry support via \
+                                         the `registry.index` configuration is \
+                                         being removed, this functionality \
+                                         will not work in the future")?;
+                }
+                &index[..]
+            } else {
+                CRATES_IO
+            };
+            let url = url.to_url()?;
+            SourceId::for_registry(&url)
+        })
     }
 
     pub fn alt_registry(config: &Config, key: &str) -> CargoResult<SourceId> {

--- a/src/cargo/sources/registry/mod.rs
+++ b/src/cargo/sources/registry/mod.rs
@@ -499,7 +499,7 @@ impl<'de> de::Deserialize<'de> for DependencyList {
 fn parse_registry_dependency(dep: RegistryDependency)
                              -> CargoResult<Dependency> {
     let RegistryDependency {
-        name, req, features, optional, default_features, target, kind, registry
+        name, req, mut features, optional, default_features, target, kind, registry
     } = dep;
 
     let id = if let Some(registry) = registry {
@@ -527,7 +527,7 @@ fn parse_registry_dependency(dep: RegistryDependency)
     // empty feature, "", inside. This confuses the resolution process much
     // later on and these features aren't actually valid, so filter them all
     // out here.
-    let features = features.into_iter().filter(|s| !s.is_empty()).collect();
+    features.retain(|s| !s.is_empty());
 
     dep.set_optional(optional)
        .set_default_features(default_features)


### PR DESCRIPTION
Found an easy hot spot or two when profiling `./x.py build` in rust-lang/rust, although certainly still lots remaining.