### PR TITLE
cmdline args: switch -j description from "CPUs" to "threads".

### DIFF
--- a/src/bin/bench.rs
+++ b/src/bin/bench.rs
@@ -64,7 +64,7 @@ Options:
     -p SPEC, --package SPEC ...  Package to run benchmarks for
     --all                        Benchmark all packages in the workspace
     --exclude SPEC ...           Exclude packages from the benchmark
-    -j N, --jobs N               Number of parallel jobs, defaults to # of CPUs
+    -j N, --jobs N               Number of parallel jobs, defaults to # of threads
     --features FEATURES          Space-separated list of features to also build
     --all-features               Build all available features
     --no-default-features        Do not build the `default` feature

--- a/src/bin/build.rs
+++ b/src/bin/build.rs
@@ -48,7 +48,7 @@ Options:
     -p SPEC, --package SPEC ...  Package to build
     --all                        Build all packages in the workspace
     --exclude SPEC ...           Exclude packages from the build
-    -j N, --jobs N               Number of parallel jobs, defaults to # of CPUs
+    -j N, --jobs N               Number of parallel jobs, defaults to # of threads
     --lib                        Build only this package's library
     --bin NAME                   Build only the specified binary
     --bins                       Build all binaries

--- a/src/bin/check.rs
+++ b/src/bin/check.rs
@@ -16,7 +16,7 @@ Options:
     -p SPEC, --package SPEC ...  Package(s) to check
     --all                        Check all packages in the workspace
     --exclude SPEC ...           Exclude packages from the check
-    -j N, --jobs N               Number of parallel jobs, defaults to # of CPUs
+    -j N, --jobs N               Number of parallel jobs, defaults to # of threads
     --lib                        Check only this package's library
     --bin NAME                   Check only the specified binary
     --bins                       Check all binaries

--- a/src/bin/doc.rs
+++ b/src/bin/doc.rs
@@ -45,7 +45,7 @@ Options:
     --all                        Document all packages in the workspace
     --exclude SPEC ...           Exclude packages from the build
     --no-deps                    Don't build documentation for dependencies
-    -j N, --jobs N               Number of parallel jobs, defaults to # of CPUs
+    -j N, --jobs N               Number of parallel jobs, defaults to # of threads
     --lib                        Document only this package's library
     --bin NAME                   Document only the specified binary
     --bins                       Document all binaries

--- a/src/bin/install.rs
+++ b/src/bin/install.rs
@@ -54,7 +54,7 @@ Specifying what crate to install:
 
 Build and install options:
     -h, --help                Print this message
-    -j N, --jobs N            Number of parallel jobs, defaults to # of CPUs
+    -j N, --jobs N            Number of parallel jobs, defaults to # of threads
     -f, --force               Force overwriting existing crates or binaries
     --features FEATURES       Space-separated list of features to activate
     --all-features            Build all available features

--- a/src/bin/package.rs
+++ b/src/bin/package.rs
@@ -35,7 +35,7 @@ Options:
     --allow-dirty           Allow dirty working directories to be packaged
     --target TRIPLE         Build for the target triple
     --manifest-path PATH    Path to the manifest to compile
-    -j N, --jobs N          Number of parallel jobs, defaults to # of CPUs
+    -j N, --jobs N          Number of parallel jobs, defaults to # of threads
     -v, --verbose ...       Use verbose output (-vv very verbose/build.rs output)
     -q, --quiet             No output printed to stdout
     --color WHEN            Coloring: auto, always, never

--- a/src/bin/publish.rs
+++ b/src/bin/publish.rs
@@ -39,7 +39,7 @@ Options:
     --allow-dirty            Allow publishing with a dirty source directory
     --target TRIPLE          Build for the target triple
     --manifest-path PATH     Path to the manifest of the package to publish
-    -j N, --jobs N           Number of parallel jobs, defaults to # of CPUs
+    -j N, --jobs N           Number of parallel jobs, defaults to # of threads
     --dry-run                Perform all checks without uploading
     -v, --verbose ...        Use verbose output (-vv very verbose/build.rs output)
     -q, --quiet              No output printed to stdout

--- a/src/bin/run.rs
+++ b/src/bin/run.rs
@@ -39,7 +39,7 @@ Options:
     --bin NAME                   Name of the bin target to run
     --example NAME               Name of the example target to run
     -p SPEC, --package SPEC      Package with the target to run
-    -j N, --jobs N               Number of parallel jobs, defaults to # of CPUs
+    -j N, --jobs N               Number of parallel jobs, defaults to # of threads
     --release                    Build artifacts in release mode, with optimizations
     --features FEATURES          Space-separated list of features to also build
     --all-features               Build all available features

--- a/src/bin/rustc.rs
+++ b/src/bin/rustc.rs
@@ -46,7 +46,7 @@ Usage:
 Options:
     -h, --help               Print this message
     -p SPEC, --package SPEC  Package to build
-    -j N, --jobs N           Number of parallel jobs, defaults to # of CPUs
+    -j N, --jobs N           Number of parallel jobs, defaults to # of threads
     --lib                    Build only this package's library
     --bin NAME               Build only the specified binary
     --bins                   Build all binaries

--- a/src/bin/rustdoc.rs
+++ b/src/bin/rustdoc.rs
@@ -45,7 +45,7 @@ Options:
     -h, --help               Print this message
     --open                   Opens the docs in a browser after the operation
     -p SPEC, --package SPEC  Package to document
-    -j N, --jobs N           Number of parallel jobs, defaults to # of CPUs
+    -j N, --jobs N           Number of parallel jobs, defaults to # of threads
     --lib                    Build only this package's library
     --bin NAME               Build only the specified binary
     --bins                   Build all binaries

--- a/src/doc/src/reference/config.md
+++ b/src/doc/src/reference/config.md
@@ -97,7 +97,7 @@ cainfo = "cert.pem" # Path to Certificate Authority (CA) bundle (optional)
 check-revoke = true # Indicates whether SSL certs are checked for revocation
 
 [build]
-jobs = 1                  # number of parallel jobs, defaults to # of CPUs
+jobs = 1                  # number of parallel jobs, defaults to # of threads
 rustc = "rustc"           # the rust compiler tool
 rustdoc = "rustdoc"       # the doc generator tool
 target = "triple"         # build for the target triple

--- a/src/etc/_cargo
+++ b/src/etc/_cargo
@@ -39,7 +39,7 @@ case $state in
                     '--features=[space separated feature list]' \
                     '--all-features[enable all available features]' \
                     '(-h, --help)'{-h,--help}'[show help message]' \
-                    '(-j, --jobs)'{-j,--jobs}'[number of parallel jobs, defaults to # of CPUs]' \
+                    '(-j, --jobs)'{-j,--jobs}'[number of parallel jobs, defaults to # of threads]' \
                     "${command_scope_spec[@]}" \
                     '--manifest-path=[path to manifest]: :_files -/' \
                     '--no-default-features[do not build the default features]' \
@@ -56,7 +56,7 @@ case $state in
                     '--features=[space separated feature list]' \
                     '--all-features[enable all available features]' \
                     '(-h, --help)'{-h,--help}'[show help message]' \
-                    '(-j, --jobs)'{-j,--jobs}'[number of parallel jobs, defaults to # of CPUs]' \
+                    '(-j, --jobs)'{-j,--jobs}'[number of parallel jobs, defaults to # of threads]' \
                     "${command_scope_spec[@]}" \
                     '--manifest-path=[path to manifest]: :_files -/' \
                     '--no-default-features[do not build the default features]' \
@@ -73,7 +73,7 @@ case $state in
                     '--features=[space separated feature list]' \
                     '--all-features[enable all available features]' \
                     '(-h, --help)'{-h,--help}'[show help message]' \
-                    '(-j, --jobs)'{-j,--jobs}'[number of parallel jobs, defaults to # of CPUs]' \
+                    '(-j, --jobs)'{-j,--jobs}'[number of parallel jobs, defaults to # of threads]' \
                     "${command_scope_spec[@]}" \
                     '--manifest-path=[path to manifest]: :_files -/' \
                     '--no-default-features[do not check the default features]' \
@@ -102,7 +102,7 @@ case $state in
                     '--features=[space separated feature list]' \
                     '--all-features[enable all available features]' \
                     '(-h, --help)'{-h,--help}'[show help message]' \
-                    '(-j, --jobs)'{-j,--jobs}'[number of parallel jobs, defaults to # of CPUs]' \
+                    '(-j, --jobs)'{-j,--jobs}'[number of parallel jobs, defaults to # of threads]' \
                     '--manifest-path=[path to manifest]: :_files -/' \
                     '--no-deps[do not build docs for dependencies]' \
                     '--no-default-features[do not build the default features]' \
@@ -171,7 +171,7 @@ case $state in
                     '--all-features[enable all available features]' \
                     '--git=[URL from which to install the crate]' \
                     '(-h, --help)'{-h,--help}'[show help message]' \
-                    '(-j, --jobs)'{-j,--jobs}'[number of parallel jobs, defaults to # of CPUs]' \
+                    '(-j, --jobs)'{-j,--jobs}'[number of parallel jobs, defaults to # of threads]' \
                     '--no-default-features[do not build the default features]' \
                     '--path=[local filesystem path to crate to install]: :_files -/' \
                     '(-q, --quiet)'{-q,--quiet}'[no output printed to stdout]' \
@@ -282,7 +282,7 @@ case $state in
                     '--features=[space separated feature list]' \
                     '--all-features[enable all available features]' \
                     '(-h, --help)'{-h,--help}'[show help message]' \
-                    '(-j, --jobs)'{-j,--jobs}'[number of parallel jobs, defaults to # of CPUs]' \
+                    '(-j, --jobs)'{-j,--jobs}'[number of parallel jobs, defaults to # of threads]' \
                     '--manifest-path=[path to manifest]: :_files -/' \
                     '--bin=[name of the bin target]' \
                     '--no-default-features[do not build the default features]' \
@@ -300,7 +300,7 @@ case $state in
                     '--features=[features to compile for the package]' \
                     '--all-features[enable all available features]' \
                     '(-h, --help)'{-h,--help}'[show help message]' \
-                    '(-j, --jobs)'{-j,--jobs}'=[number of parallel jobs, defaults to # of CPUs]' \
+                    '(-j, --jobs)'{-j,--jobs}'=[number of parallel jobs, defaults to # of threads]' \
                     '--manifest-path=[path to the manifest to fetch dependencies for]: :_files -/' \
                     '--no-default-features[do not compile default features for the package]' \
                     '(-p, --package)'{-p,--package}'=[profile to compile for]' \
@@ -318,7 +318,7 @@ case $state in
                     '--features=[space-separated list of features to also build]' \
                     '--all-features[enable all available features]' \
                     '(-h, --help)'{-h,--help}'[show help message]' \
-                    '(-j, --jobs)'{-j,--jobs}'=[number of parallel jobs, defaults to # of CPUs]' \
+                    '(-j, --jobs)'{-j,--jobs}'=[number of parallel jobs, defaults to # of threads]' \
                     '--manifest-path=[path to the manifest to document]: :_files -/' \
                     '--no-default-features[do not build the `default` feature]' \
                     '--open[open the docs in a browser after the operation]' \
@@ -345,7 +345,7 @@ case $state in
                     '--features=[space separated feature list]' \
                     '--all-features[enable all available features]' \
                     '(-h, --help)'{-h,--help}'[show help message]' \
-                    '(-j, --jobs)'{-j,--jobs}'[number of parallel jobs, defaults to # of CPUs]' \
+                    '(-j, --jobs)'{-j,--jobs}'[number of parallel jobs, defaults to # of threads]' \
                     '--manifest-path=[path to manifest]: :_files -/' \
                     '--test=[test name]: :_test_names' \
                     '--no-default-features[do not build the default features]' \

--- a/src/etc/man/cargo-bench.1
+++ b/src/etc/man/cargo-bench.1
@@ -69,7 +69,7 @@ Package to benchmarks for.
 .RE
 .TP
 .B \-j \f[I]IN\f[], \-\-jobs \f[I]IN\f[]
-Number of parallel jobs, defaults to # of CPUs.
+Number of parallel jobs, defaults to # of threads.
 .RS
 .RE
 .TP

--- a/src/etc/man/cargo-build.1
+++ b/src/etc/man/cargo-build.1
@@ -33,7 +33,7 @@ Package to build.
 .RE
 .TP
 .B \-j \f[I]IN\f[], \-\-jobs \f[I]IN\f[]
-Number of parallel jobs, defaults to # of CPUs.
+Number of parallel jobs, defaults to # of threads.
 .RS
 .RE
 .TP

--- a/src/etc/man/cargo-check.1
+++ b/src/etc/man/cargo-check.1
@@ -33,7 +33,7 @@ Package to check.
 .RE
 .TP
 .B \-j \f[I]IN\f[], \-\-jobs \f[I]IN\f[]
-Number of parallel jobs, defaults to # of CPUs.
+Number of parallel jobs, defaults to # of threads.
 .RS
 .RE
 .TP

--- a/src/etc/man/cargo-doc.1
+++ b/src/etc/man/cargo-doc.1
@@ -43,7 +43,7 @@ Don\[aq]t build documentation for dependencies.
 .RE
 .TP
 .B \-j \f[I]N\f[], \-\-jobs \f[I]N\f[]
-Number of parallel jobs, defaults to # of CPUs.
+Number of parallel jobs, defaults to # of threads.
 .RS
 .RE
 .TP

--- a/src/etc/man/cargo-install.1
+++ b/src/etc/man/cargo-install.1
@@ -94,7 +94,7 @@ Print this message.
 .RE
 .TP
 .B \-j \f[I]N\f[], \-\-jobs \f[I]N\f[]
-Number of parallel jobs, defaults to # of CPUs.
+Number of parallel jobs, defaults to # of threads.
 .RS
 .RE
 .TP

--- a/src/etc/man/cargo-run.1
+++ b/src/etc/man/cargo-run.1
@@ -37,7 +37,7 @@ Name of the example target to run.
 .RE
 .TP
 .B \-j \f[I]IN\f[], \-\-jobs \f[I]IN\f[]
-Number of parallel jobs, defaults to # of CPUs.
+Number of parallel jobs, defaults to # of threads.
 .RS
 .RE
 .TP

--- a/src/etc/man/cargo-rustc.1
+++ b/src/etc/man/cargo-rustc.1
@@ -39,7 +39,7 @@ The profile to compiler for.
 .RE
 .TP
 .B \-j \f[I]N\f[], \-\-jobs \f[I]N\f[]
-Number of parallel jobs, defaults to # of CPUs.
+Number of parallel jobs, defaults to # of threads.
 .RS
 .RE
 .TP

--- a/src/etc/man/cargo-rustdoc.1
+++ b/src/etc/man/cargo-rustdoc.1
@@ -42,7 +42,7 @@ Package to document.
 .RE
 .TP
 .B \-j \f[I]N\f[], \-\-jobs \f[I]N\f[]
-Number of parallel jobs, defaults to # of CPUs.
+Number of parallel jobs, defaults to # of threads.
 .RS
 .RE
 .TP

--- a/src/etc/man/cargo-test.1
+++ b/src/etc/man/cargo-test.1
@@ -93,7 +93,7 @@ Package to run tests for.
 .RE
 .TP
 .B \-j \f[I]IN\f[], \-\-jobs \f[I]IN\f[]
-Number of parallel jobs, defaults to # of CPUs.
+Number of parallel jobs, defaults to # of threads.
 .RS
 .RE
 .TP


### PR DESCRIPTION
My system has a single cpu, with 2 cores and 2 threads each and cargo will launch 4 jobs automatically.
IMO "defaults to # of threads" is a bit clearer.