### PR TITLE
restructure `Activations` for better clone

### DIFF
--- a/src/cargo/core/resolver/mod.rs
+++ b/src/cargo/core/resolver/mod.rs
@@ -357,7 +357,7 @@ struct Context {
     warnings: RcList<String>,
 }
 
-type Activations = HashMap<InternedString, HashMap<SourceId, Rc<Vec<Summary>>>>;
+type Activations = HashMap<(InternedString, SourceId), Rc<Vec<Summary>>>;
 
 /// Builds the list of all packages required to build the first argument.
 pub fn resolve(summaries: &[(Summary, Method)],
@@ -389,7 +389,6 @@ pub fn resolve(summaries: &[(Summary, Method)],
     };
 
     for summary in cx.activations.values()
-                                 .flat_map(|v| v.values())
                                  .flat_map(|v| v.iter()) {
         let cksum = summary.checksum().map(|s| s.to_string());
         resolve.checksums.insert(summary.package_id().clone(), cksum);
@@ -1305,9 +1304,7 @@ impl Context {
                       method: &Method) -> CargoResult<bool> {
         let id = summary.package_id();
         let prev = self.activations
-                       .entry(InternedString::new(id.name()))
-                       .or_insert_with(HashMap::new)
-                       .entry(id.source_id().clone())
+                       .entry((InternedString::new(id.name()), id.source_id().clone()))
                        .or_insert_with(||Rc::new(Vec::new()));
         if !prev.iter().any(|c| c == summary) {
             self.resolve_graph.push(GraphNode::Add(id.clone()));
@@ -1368,15 +1365,13 @@ impl Context {
     }
 
     fn prev_active(&self, dep: &Dependency) -> &[Summary] {
-        self.activations.get(&InternedString::new(dep.name()))
-            .and_then(|v| v.get(dep.source_id()))
+        self.activations.get(&(InternedString::new(dep.name()), dep.source_id().clone()))
             .map(|v| &v[..])
             .unwrap_or(&[])
     }
 
     fn is_active(&self, id: &PackageId) -> bool {
-        self.activations.get(&InternedString::new(id.name()))
-            .and_then(|v| v.get(id.source_id()))
+        self.activations.get(&(InternedString::new(id.name()), id.source_id().clone()))
             .map(|v| v.iter().any(|s| s.package_id() == id))
             .unwrap_or(false)
     }
@@ -1484,7 +1479,6 @@ impl Context {
 fn check_cycles(resolve: &Resolve, activations: &Activations)
                 -> CargoResult<()> {
     let summaries: HashMap<&PackageId, &Summary> = activations.values()
-        .flat_map(|v| v.values())
         .flat_map(|v| v.iter())
         .map(|s| (s.package_id(), s))
         .collect();


### PR DESCRIPTION
This builds on the work in #5121 When we last met we had:
5000000 ticks in ~48 sec, 0r 104k ticks/sec
This small change brings us to:
5000000 ticks in ~21 sec, 0r 238k ticks/sec
Edit: sorry for the large diff only the last commit is new. The rest are from #5121