### PR TITLE
More interning

### DIFF
--- a/src/cargo/core/interning.rs
+++ b/src/cargo/core/interning.rs
@@ -1,3 +1,4 @@
+use std::fmt;
 use std::sync::RwLock;
 use std::collections::HashSet;
 use std::slice;
@@ -48,6 +49,13 @@ impl Deref for InternedString {
             let slice = slice::from_raw_parts(self.ptr, self.len);
             &str::from_utf8_unchecked(slice)
         }
+    }
+}
+
+impl fmt::Debug for InternedString {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let str: &str = &*self;
+        write!(f, "InternedString {{ {} }}", str)
     }
 }
 

--- a/src/cargo/core/resolver/mod.rs
+++ b/src/cargo/core/resolver/mod.rs
@@ -734,11 +734,11 @@ impl RemainingCandidates {
         use std::mem::replace;
         for (_, b) in self.remaining.by_ref() {
             if let Some(link) = b.summary.links() {
-                if let Some(a) = links.get(&InternedString::new(link)) {
+                if let Some(a) = links.get(&link) {
                     if a != b.summary.package_id() {
                         self.conflicting_prev_active
                             .entry(a.clone())
-                            .or_insert_with(|| ConflictReason::Links(link.to_owned()));
+                            .or_insert_with(|| ConflictReason::Links(link.to_string()));
                         continue;
                     }
                 }
@@ -1309,9 +1309,9 @@ impl Context {
         if !prev.iter().any(|c| c == summary) {
             self.resolve_graph.push(GraphNode::Add(id.clone()));
             if let Some(link) = summary.links() {
-                ensure!(self.links.insert(InternedString::new(link), id.clone()).is_none(),
+                ensure!(self.links.insert(link, id.clone()).is_none(),
                 "Attempting to resolve a with more then one crate with the links={}. \n\
-                 This will not build as is. Consider rebuilding the .lock file.", link);
+                 This will not build as is. Consider rebuilding the .lock file.", &*link);
             }
             let mut inner: Vec<_> = (**prev).clone();
             inner.push(summary.clone());

--- a/src/cargo/core/summary.rs
+++ b/src/cargo/core/summary.rs
@@ -4,6 +4,7 @@ use std::rc::Rc;
 
 use semver::Version;
 use core::{Dependency, PackageId, SourceId};
+use core::interning::InternedString;
 
 use util::CargoResult;
 
@@ -22,7 +23,7 @@ struct Inner {
     dependencies: Vec<Dependency>,
     features: BTreeMap<String, Vec<String>>,
     checksum: Option<String>,
-    links: Option<String>,
+    links: Option<InternedString>,
 }
 
 impl Summary {
@@ -71,7 +72,7 @@ impl Summary {
                 dependencies,
                 features,
                 checksum: None,
-                links,
+                links: links.map(|l| InternedString::new(&l)),
             }),
         })
     }
@@ -85,8 +86,8 @@ impl Summary {
     pub fn checksum(&self) -> Option<&str> {
         self.inner.checksum.as_ref().map(|s| &s[..])
     }
-    pub fn links(&self) -> Option<&str> {
-        self.inner.links.as_ref().map(|s| &s[..])
+    pub fn links(&self) -> Option<InternedString> {
+        self.inner.links
     }
 
     pub fn override_id(mut self, id: PackageId) -> Summary {


### PR DESCRIPTION
This is a small part of the unsuccessful last commit of #5121, this part removes `InternedString::new` from the innerest of loops.

This is mostly a resubmission of #5147, that I accidentally deleted while bors was testing. This one has new commits, so github will take the resubition.