### PR TITLE
small improvements to interning

### DIFF
--- a/src/cargo/core/interning.rs
+++ b/src/cargo/core/interning.rs
@@ -39,12 +39,7 @@ impl InternedString {
         cache.insert(s);
         InternedString { ptr: s.as_ptr(), len: s.len() }
     }
-}
-
-impl Deref for InternedString {
-    type Target = str;
-
-    fn deref(&self) -> &'static str {
+    pub fn to_inner(&self) -> &'static str {
         unsafe {
             let slice = slice::from_raw_parts(self.ptr, self.len);
             &str::from_utf8_unchecked(slice)
@@ -52,17 +47,29 @@ impl Deref for InternedString {
     }
 }
 
+impl Deref for InternedString {
+    type Target = str;
+
+    fn deref(&self) -> &'static str {
+        self.to_inner()
+    }
+}
+
 impl fmt::Debug for InternedString {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let str: &str = &*self;
-        write!(f, "InternedString {{ {} }}", str)
+        write!(f, "InternedString {{ {} }}", self.to_inner())
+    }
+}
+
+impl fmt::Display for InternedString {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.to_inner())
     }
 }
 
 impl Ord for InternedString {
     fn cmp(&self, other: &InternedString) -> Ordering {
-        let str: &str = &*self;
-        str.cmp(&*other)
+        self.to_inner().cmp(&*other)
     }
 }
 

--- a/src/cargo/core/package_id.rs
+++ b/src/cargo/core/package_id.rs
@@ -11,6 +11,7 @@ use serde::ser;
 
 use util::{CargoResult, ToSemver};
 use core::source::SourceId;
+use core::interning::InternedString;
 
 /// Identifier for a specific version of a package in a specific source.
 #[derive(Clone)]
@@ -20,7 +21,7 @@ pub struct PackageId {
 
 #[derive(PartialEq, PartialOrd, Eq, Ord)]
 struct PackageIdInner {
-    name: String,
+    name: InternedString,
     version: semver::Version,
     source_id: SourceId,
 }
@@ -63,7 +64,7 @@ impl<'de> de::Deserialize<'de> for PackageId {
 
         Ok(PackageId {
             inner: Arc::new(PackageIdInner {
-                name: name.to_string(),
+                name: InternedString::new(name),
                 version,
                 source_id,
             }),
@@ -102,21 +103,21 @@ impl PackageId {
         let v = version.to_semver()?;
         Ok(PackageId {
             inner: Arc::new(PackageIdInner {
-                name: name.to_string(),
+                name: InternedString::new(name),
                 version: v,
                 source_id: sid.clone(),
             }),
         })
     }
 
-    pub fn name(&self) -> &str { &self.inner.name }
+    pub fn name(&self) -> &str { self.inner.name.to_inner() }
     pub fn version(&self) -> &semver::Version { &self.inner.version }
     pub fn source_id(&self) -> &SourceId { &self.inner.source_id }
 
     pub fn with_precise(&self, precise: Option<String>) -> PackageId {
         PackageId {
             inner: Arc::new(PackageIdInner {
-                name: self.inner.name.to_string(),
+                name: self.inner.name,
                 version: self.inner.version.clone(),
                 source_id: self.inner.source_id.with_precise(precise),
             }),
@@ -126,7 +127,7 @@ impl PackageId {
     pub fn with_source_id(&self, source: &SourceId) -> PackageId {
         PackageId {
             inner: Arc::new(PackageIdInner {
-                name: self.inner.name.to_string(),
+                name: self.inner.name,
                 version: self.inner.version.clone(),
                 source_id: source.clone(),
             }),


### PR DESCRIPTION
In #5121 https://github.com/Eh2406/cargo/commit/411355aca37fdd8b361481a350c3cb625beabd1a I tried to use the `InternedString` In more places, but test failed so that commit was backed out. This PR is an attempt to redo that in tiny steps, so as to track down exactly what caused the error.

The first commit hear, is just some housekeeping. This should still be green.