### PR TITLE
More interning

### DIFF
--- a/src/cargo/core/dependency.rs
+++ b/src/cargo/core/dependency.rs
@@ -329,13 +329,13 @@ impl Dependency {
 
     /// Returns true if the package (`sum`) can fulfill this dependency request.
     pub fn matches_ignoring_source(&self, sum: &Summary) -> bool {
-        self.name() == sum.package_id().name() &&
+        self.name() == &*sum.package_id().name() &&
             self.version_req().matches(sum.package_id().version())
     }
 
     /// Returns true if the package (`id`) can fulfill this dependency request.
     pub fn matches_id(&self, id: &PackageId) -> bool {
-        self.inner.name == id.name() &&
+        self.inner.name == &*id.name() &&
             (self.inner.only_match_name || (self.inner.req.matches(id.version()) &&
                                       &self.inner.source_id == id.source_id()))
     }

--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -301,7 +301,7 @@ impl Manifest {
     pub fn exclude(&self) -> &[String] { &self.exclude }
     pub fn include(&self) -> &[String] { &self.include }
     pub fn metadata(&self) -> &ManifestMetadata { &self.metadata }
-    pub fn name(&self) -> &str { self.package_id().name() }
+    pub fn name(&self) -> &str { self.package_id().name().to_inner() }
     pub fn package_id(&self) -> &PackageId { self.summary.package_id() }
     pub fn summary(&self) -> &Summary { &self.summary }
     pub fn targets(&self) -> &[Target] { &self.targets }

--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -10,6 +10,7 @@ use url::Url;
 
 use core::{Dependency, PackageId, Summary, SourceId, PackageIdSpec};
 use core::{WorkspaceConfig, Epoch, Features, Feature};
+use core::interning::InternedString;
 use util::Config;
 use util::toml::TomlManifest;
 use util::errors::*;
@@ -301,7 +302,7 @@ impl Manifest {
     pub fn exclude(&self) -> &[String] { &self.exclude }
     pub fn include(&self) -> &[String] { &self.include }
     pub fn metadata(&self) -> &ManifestMetadata { &self.metadata }
-    pub fn name(&self) -> &str { self.package_id().name().to_inner() }
+    pub fn name(&self) -> InternedString { self.package_id().name() }
     pub fn package_id(&self) -> &PackageId { self.summary.package_id() }
     pub fn summary(&self) -> &Summary { &self.summary }
     pub fn targets(&self) -> &[Target] { &self.targets }

--- a/src/cargo/core/package.rs
+++ b/src/cargo/core/package.rs
@@ -55,7 +55,7 @@ impl ser::Serialize for Package {
         let description = manmeta.description.as_ref().map(String::as_ref);
 
         SerializedPackage {
-            name: package_id.name(),
+            name: &*package_id.name(),
             version: &package_id.version().to_string(),
             id: package_id,
             license,
@@ -95,7 +95,7 @@ impl Package {
     /// Get the path to the manifest
     pub fn manifest_path(&self) -> &Path { &self.manifest_path }
     /// Get the name of the package
-    pub fn name(&self) -> &str { self.package_id().name() }
+    pub fn name(&self) -> &str { self.package_id().name().to_inner() }
     /// Get the PackageId object for the package (fully defines a package)
     pub fn package_id(&self) -> &PackageId { self.manifest.package_id() }
     /// Get the root folder of the package

--- a/src/cargo/core/package.rs
+++ b/src/cargo/core/package.rs
@@ -11,6 +11,7 @@ use lazycell::LazyCell;
 
 use core::{Dependency, Manifest, PackageId, SourceId, Target};
 use core::{Summary, SourceMap};
+use core::interning::InternedString;
 use ops;
 use util::{Config, internal, lev_distance};
 use util::errors::{CargoResult, CargoResultExt};
@@ -95,7 +96,7 @@ impl Package {
     /// Get the path to the manifest
     pub fn manifest_path(&self) -> &Path { &self.manifest_path }
     /// Get the name of the package
-    pub fn name(&self) -> &str { self.package_id().name().to_inner() }
+    pub fn name(&self) -> InternedString { self.package_id().name() }
     /// Get the PackageId object for the package (fully defines a package)
     pub fn package_id(&self) -> &PackageId { self.manifest.package_id() }
     /// Get the root folder of the package

--- a/src/cargo/core/package_id.rs
+++ b/src/cargo/core/package_id.rs
@@ -11,6 +11,7 @@ use serde::ser;
 
 use util::{CargoResult, ToSemver};
 use core::source::SourceId;
+use core::interning::InternedString;
 
 /// Identifier for a specific version of a package in a specific source.
 #[derive(Clone)]
@@ -20,7 +21,7 @@ pub struct PackageId {
 
 #[derive(PartialEq, PartialOrd, Eq, Ord)]
 struct PackageIdInner {
-    name: String,
+    name: InternedString,
     version: semver::Version,
     source_id: SourceId,
 }
@@ -63,7 +64,7 @@ impl<'de> de::Deserialize<'de> for PackageId {
 
         Ok(PackageId {
             inner: Arc::new(PackageIdInner {
-                name: name.to_string(),
+                name: InternedString::new(name),
                 version,
                 source_id,
             }),
@@ -102,21 +103,21 @@ impl PackageId {
         let v = version.to_semver()?;
         Ok(PackageId {
             inner: Arc::new(PackageIdInner {
-                name: name.to_string(),
+                name: InternedString::new(name),
                 version: v,
                 source_id: sid.clone(),
             }),
         })
     }
 
-    pub fn name(&self) -> &str { &self.inner.name }
+    pub fn name(&self) -> InternedString { self.inner.name }
     pub fn version(&self) -> &semver::Version { &self.inner.version }
     pub fn source_id(&self) -> &SourceId { &self.inner.source_id }
 
     pub fn with_precise(&self, precise: Option<String>) -> PackageId {
         PackageId {
             inner: Arc::new(PackageIdInner {
-                name: self.inner.name.to_string(),
+                name: self.inner.name,
                 version: self.inner.version.clone(),
                 source_id: self.inner.source_id.with_precise(precise),
             }),
@@ -126,7 +127,7 @@ impl PackageId {
     pub fn with_source_id(&self, source: &SourceId) -> PackageId {
         PackageId {
             inner: Arc::new(PackageIdInner {
-                name: self.inner.name.to_string(),
+                name: self.inner.name,
                 version: self.inner.version.clone(),
                 source_id: source.clone(),
             }),

--- a/src/cargo/core/package_id_spec.rs
+++ b/src/cargo/core/package_id_spec.rs
@@ -115,7 +115,7 @@ impl PackageIdSpec {
     }
 
     pub fn matches(&self, package_id: &PackageId) -> bool {
-        if self.name() != package_id.name() { return false }
+        if self.name() != &*package_id.name() { return false }
 
         if let Some(ref v) = self.version {
             if v != package_id.version() {

--- a/src/cargo/core/registry.rs
+++ b/src/cargo/core/registry.rs
@@ -317,7 +317,7 @@ impl<'cfg> PackageRegistry<'cfg> {
                        -> CargoResult<Option<Summary>> {
         for s in self.overrides.iter() {
             let src = self.sources.get_mut(s).unwrap();
-            let dep = Dependency::new_override(dep.name(), s);
+            let dep = Dependency::new_override(&*dep.name(), s);
             let mut results = src.query_vec(&dep)?;
             if !results.is_empty() {
                 return Ok(Some(results.remove(0)))
@@ -568,7 +568,7 @@ fn lock(locked: &LockedMap,
         // all known locked packages to see if they match this dependency.
         // If anything does then we lock it to that and move on.
         let v = locked.get(dep.source_id()).and_then(|map| {
-            map.get(dep.name())
+            map.get(&*dep.name())
         }).and_then(|vec| {
             vec.iter().find(|&&(ref id, _)| dep.matches_id(id))
         });
@@ -584,7 +584,7 @@ fn lock(locked: &LockedMap,
         let v = patches.get(dep.source_id().url()).map(|vec| {
             let dep2 = dep.clone();
             let mut iter = vec.iter().filter(move |p| {
-                dep2.name() == &*p.name() &&
+                dep2.name() == p.name() &&
                     dep2.version_req().matches(p.version())
             });
             (iter.next(), iter)

--- a/src/cargo/core/registry.rs
+++ b/src/cargo/core/registry.rs
@@ -584,7 +584,7 @@ fn lock(locked: &LockedMap,
         let v = patches.get(dep.source_id().url()).map(|vec| {
             let dep2 = dep.clone();
             let mut iter = vec.iter().filter(move |p| {
-                dep2.name() == p.name() &&
+                dep2.name() == &*p.name() &&
                     dep2.version_req().matches(p.version())
             });
             (iter.next(), iter)
@@ -593,7 +593,7 @@ fn lock(locked: &LockedMap,
             assert!(remaining.next().is_none());
             let patch_source = patch_id.source_id();
             let patch_locked = locked.get(patch_source).and_then(|m| {
-                m.get(patch_id.name())
+                m.get(&*patch_id.name())
             }).map(|list| {
                 list.iter().any(|&(ref id, _)| id == patch_id)
             }).unwrap_or(false);

--- a/src/cargo/core/registry.rs
+++ b/src/cargo/core/registry.rs
@@ -519,7 +519,7 @@ fn lock(locked: &LockedMap,
         patches: &HashMap<Url, Vec<PackageId>>,
         summary: Summary) -> Summary {
     let pair = locked.get(summary.source_id()).and_then(|map| {
-        map.get(summary.name())
+        map.get(&*summary.name())
     }).and_then(|vec| {
         vec.iter().find(|&&(ref id, _)| id == summary.package_id())
     });

--- a/src/cargo/core/resolver/mod.rs
+++ b/src/cargo/core/resolver/mod.rs
@@ -1059,7 +1059,7 @@ fn activation_error(cx: &Context,
         for &(p, r) in features_errors.iter() {
             if let ConflictReason::MissingFeatures(ref features) = *r {
                 msg.push_str("\n\nthe package `");
-                msg.push_str(p.name());
+                msg.push_str(&*p.name());
                 msg.push_str("` depends on `");
                 msg.push_str(dep.name());
                 msg.push_str("`, with features: `");
@@ -1304,7 +1304,7 @@ impl Context {
                       method: &Method) -> CargoResult<bool> {
         let id = summary.package_id();
         let prev = self.activations
-                       .entry((InternedString::new(id.name()), id.source_id().clone()))
+                       .entry((id.name(), id.source_id().clone()))
                        .or_insert_with(||Rc::new(Vec::new()));
         if !prev.iter().any(|c| c == summary) {
             self.resolve_graph.push(GraphNode::Add(id.clone()));
@@ -1371,7 +1371,7 @@ impl Context {
     }
 
     fn is_active(&self, id: &PackageId) -> bool {
-        self.activations.get(&(InternedString::new(id.name()), id.source_id().clone()))
+        self.activations.get(&(id.name(), id.source_id().clone()))
             .map(|v| v.iter().any(|s| s.package_id() == id))
             .unwrap_or(false)
     }

--- a/src/cargo/core/summary.rs
+++ b/src/cargo/core/summary.rs
@@ -78,7 +78,7 @@ impl Summary {
     }
 
     pub fn package_id(&self) -> &PackageId { &self.inner.package_id }
-    pub fn name(&self) -> &str { self.package_id().name().to_inner() }
+    pub fn name(&self) -> InternedString { self.package_id().name() }
     pub fn version(&self) -> &Version { self.package_id().version() }
     pub fn source_id(&self) -> &SourceId { self.package_id().source_id() }
     pub fn dependencies(&self) -> &[Dependency] { &self.inner.dependencies }

--- a/src/cargo/core/summary.rs
+++ b/src/cargo/core/summary.rs
@@ -78,7 +78,7 @@ impl Summary {
     }
 
     pub fn package_id(&self) -> &PackageId { &self.inner.package_id }
-    pub fn name(&self) -> &str { self.package_id().name() }
+    pub fn name(&self) -> &str { self.package_id().name().to_inner() }
     pub fn version(&self) -> &Version { self.package_id().version() }
     pub fn source_id(&self) -> &SourceId { self.package_id().source_id() }
     pub fn dependencies(&self) -> &[Dependency] { &self.inner.dependencies }

--- a/src/cargo/core/summary.rs
+++ b/src/cargo/core/summary.rs
@@ -32,7 +32,7 @@ impl Summary {
                features: BTreeMap<String, Vec<String>>,
                links: Option<String>) -> CargoResult<Summary> {
         for dep in dependencies.iter() {
-            if features.get(dep.name()).is_some() {
+            if features.get(&*dep.name()).is_some() {
                 bail!("Features and dependencies cannot have the \
                        same name: `{}`", dep.name())
             }
@@ -47,7 +47,7 @@ impl Summary {
                 let dep = parts.next().unwrap();
                 let is_reexport = parts.next().is_some();
                 if !is_reexport && features.get(dep).is_some() { continue }
-                match dependencies.iter().find(|d| d.name() == dep) {
+                match dependencies.iter().find(|d| &*d.name() == dep) {
                     Some(d) => {
                         if d.is_optional() || is_reexport { continue }
                         bail!("Feature `{}` depends on `{}` which is not an \

--- a/src/cargo/ops/cargo_doc.rs
+++ b/src/cargo/ops/cargo_doc.rs
@@ -54,7 +54,7 @@ pub fn doc(ws: &Workspace, options: &DocOptions) -> CargoResult<()> {
             bail!("Passing multiple packages and `open` is not supported.\n\
                    Please re-run this command with `-p <spec>` where `<spec>` \
                    is one of the following:\n  {}",
-                   pkgs.iter().map(|p| p.name()).collect::<Vec<_>>().join("\n  "));
+                   pkgs.iter().map(|p| p.name().to_inner()).collect::<Vec<_>>().join("\n  "));
         } else if pkgs.len() == 1 {
             pkgs[0].name().replace("-", "_")
         } else {

--- a/src/cargo/ops/cargo_generate_lockfile.rs
+++ b/src/cargo/ops/cargo_generate_lockfile.rs
@@ -136,7 +136,7 @@ pub fn update_lockfile(ws: &Workspace, opts: &UpdateOptions)
                                      resolve: &'a Resolve) ->
                                      Vec<(Vec<&'a PackageId>, Vec<&'a PackageId>)> {
         fn key(dep: &PackageId) -> (&str, &SourceId) {
-            (dep.name(), dep.source_id())
+            (dep.name().to_inner(), dep.source_id())
         }
 
         // Removes all package ids in `b` from `a`. Note that this is somewhat

--- a/src/cargo/ops/cargo_install.rs
+++ b/src/cargo/ops/cargo_install.rs
@@ -429,9 +429,9 @@ fn select_pkg<'a, T>(mut source: T,
             return Ok((pkg.clone(), Box::new(source)));
 
             fn multi_err(kind: &str, mut pkgs: Vec<&Package>) -> String {
-                pkgs.sort_by(|a, b| a.name().cmp(b.name()));
+                pkgs.sort_by(|a, b| a.name().cmp(&b.name()));
                 format!("multiple packages with {} found: {}", kind,
-                        pkgs.iter().map(|p| p.name()).collect::<Vec<_>>()
+                        pkgs.iter().map(|p| p.name().to_inner()).collect::<Vec<_>>()
                             .join(", "))
             }
         }

--- a/src/cargo/ops/cargo_run.rs
+++ b/src/cargo/ops/cargo_run.rs
@@ -16,7 +16,7 @@ pub fn run(ws: &Workspace,
         Packages::Packages(xs) => match xs.len() {
             0 => ws.current()?,
             1 => ws.members()
-                .find(|pkg| pkg.name() == xs[0])
+                .find(|pkg| &*pkg.name() == xs[0])
                 .ok_or_else(||
                     format_err!("package `{}` is not a member of the workspace", xs[0])
                 )?,

--- a/src/cargo/ops/cargo_rustc/compilation.rs
+++ b/src/cargo/ops/cargo_rustc/compilation.rs
@@ -170,7 +170,7 @@ impl<'cfg> Compilation<'cfg> {
            .env("CARGO_PKG_VERSION_PATCH", &pkg.version().patch.to_string())
            .env("CARGO_PKG_VERSION_PRE", &pre_version_component(pkg.version()))
            .env("CARGO_PKG_VERSION", &pkg.version().to_string())
-           .env("CARGO_PKG_NAME", &pkg.name())
+           .env("CARGO_PKG_NAME", &*pkg.name())
            .env("CARGO_PKG_DESCRIPTION", metadata.description.as_ref().unwrap_or(&String::new()))
            .env("CARGO_PKG_HOMEPAGE", metadata.homepage.as_ref().unwrap_or(&String::new()))
            .env("CARGO_PKG_AUTHORS", &pkg.authors().join(":"))

--- a/src/cargo/ops/cargo_rustc/context.rs
+++ b/src/cargo/ops/cargo_rustc/context.rs
@@ -782,7 +782,7 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
         let deps = self.resolve.deps(id);
         let mut ret = deps.filter(|dep| {
             unit.pkg.dependencies().iter().filter(|d| {
-                d.name() == dep.name() && d.version_req().matches(dep.version())
+                d.name() == &*dep.name() && d.version_req().matches(dep.version())
             }).any(|d| {
                 // If this target is a build command, then we only want build
                 // dependencies, otherwise we want everything *other than* build
@@ -915,7 +915,7 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
     fn doc_deps(&self, unit: &Unit<'a>) -> CargoResult<Vec<Unit<'a>>> {
         let deps = self.resolve.deps(unit.pkg.package_id()).filter(|dep| {
             unit.pkg.dependencies().iter().filter(|d| {
-                d.name() == dep.name()
+                d.name() == &*dep.name()
             }).any(|dep| {
                 match dep.kind() {
                     DepKind::Normal => self.dep_platform_activated(dep,

--- a/src/cargo/ops/cargo_rustc/context.rs
+++ b/src/cargo/ops/cargo_rustc/context.rs
@@ -782,7 +782,7 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
         let deps = self.resolve.deps(id);
         let mut ret = deps.filter(|dep| {
             unit.pkg.dependencies().iter().filter(|d| {
-                d.name() == &*dep.name() && d.version_req().matches(dep.version())
+                d.name() == dep.name() && d.version_req().matches(dep.version())
             }).any(|d| {
                 // If this target is a build command, then we only want build
                 // dependencies, otherwise we want everything *other than* build
@@ -806,7 +806,7 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
 
                 // If the dependency is optional, then we're only activating it
                 // if the corresponding feature was activated
-                if d.is_optional() && !self.resolve.features(id).contains(d.name()) {
+                if d.is_optional() && !self.resolve.features(id).contains(&*d.name()) {
                     return false;
                 }
 
@@ -915,7 +915,7 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
     fn doc_deps(&self, unit: &Unit<'a>) -> CargoResult<Vec<Unit<'a>>> {
         let deps = self.resolve.deps(unit.pkg.package_id()).filter(|dep| {
             unit.pkg.dependencies().iter().filter(|d| {
-                d.name() == &*dep.name()
+                d.name() == dep.name()
             }).any(|dep| {
                 match dep.kind() {
                     DepKind::Normal => self.dep_platform_activated(dep,

--- a/src/cargo/sources/registry/index.rs
+++ b/src/cargo/sources/registry/index.rs
@@ -41,7 +41,7 @@ impl<'cfg> RegistryIndex<'cfg> {
                 pkg: &PackageId,
                 load: &mut RegistryData)
                 -> CargoResult<String> {
-        let name = pkg.name();
+        let name = &*pkg.name();
         let version = pkg.version();
         if let Some(s) = self.hashes.get(name).and_then(|v| v.get(version)) {
             return Ok(s.clone())

--- a/src/cargo/sources/registry/index.rs
+++ b/src/cargo/sources/registry/index.rs
@@ -169,7 +169,7 @@ impl<'cfg> RegistryIndex<'cfg> {
                  f: &mut FnMut(Summary))
                  -> CargoResult<()> {
         let source_id = self.source_id.clone();
-        let summaries = self.summaries(dep.name(), load)?;
+        let summaries = self.summaries(&*dep.name(), load)?;
         let summaries = summaries.iter().filter(|&&(_, yanked)| {
             dep.source_id().precise().is_some() || !yanked
         }).map(|s| s.0.clone());
@@ -180,7 +180,7 @@ impl<'cfg> RegistryIndex<'cfg> {
         // version requested (argument to `--precise`).
         let summaries = summaries.filter(|s| {
             match source_id.precise() {
-                Some(p) if p.starts_with(dep.name()) &&
+                Some(p) if p.starts_with(&*dep.name()) &&
                            p[dep.name().len()..].starts_with('=') => {
                     let vers = &p[dep.name().len() + 1..];
                     s.version().to_string() == vers

--- a/src/cargo/sources/registry/mod.rs
+++ b/src/cargo/sources/registry/mod.rs
@@ -435,7 +435,7 @@ impl<'cfg> Source for RegistrySource<'cfg> {
         // differ due to historical Cargo bugs. To paper over these we trash the
         // *summary* loaded from the Cargo.toml we just downloaded with the one
         // we loaded from the index.
-        let summaries = self.index.summaries(package.name(), &mut *self.ops)?;
+        let summaries = self.index.summaries(&*package.name(), &mut *self.ops)?;
         let summary = summaries.iter().map(|s| &s.0).find(|s| {
             s.package_id() == package
         }).expect("summary not found");

--- a/src/cargo/sources/registry/remote.rs
+++ b/src/cargo/sources/registry/remote.rs
@@ -217,7 +217,7 @@ impl<'cfg> RegistryData for RemoteRegistry<'cfg> {
             write!(url, "/{}/{}/download", CRATE_TEMPLATE, VERSION_TEMPLATE).unwrap();
         }
         let url = url
-            .replace(CRATE_TEMPLATE, pkg.name())
+            .replace(CRATE_TEMPLATE, &*pkg.name())
             .replace(VERSION_TEMPLATE, &pkg.version().to_string())
             .to_url()?;
 


### PR DESCRIPTION
This is a forward approach to interning. Specifically `Dependency` and `PackageId` store their names as `InternedString`s and leave that value interned as long as possible. The alternative is to make a new `interned_name` function. The advantage of this approach is that a number of places in the code are doing `deb.name() == pid.name()` and are now using the fast pointer compare instead of the string compare, without the code needing to change. The disadvantage is that lots of places need to call `deref` with `&*` to convert to an `&str` and sum need to use `.to_inner()` to get a `&'static str`.

In a test on https://github.com/rust-lang/cargo/issues/4810#issuecomment-357553286
Before we got to 10000000 ticks in ~48 sec
After we got to 10000000 ticks in ~44 sec
