### PR TITLE
Remove redundant recursion_limit

### DIFF
--- a/src/cargo/lib.rs
+++ b/src/cargo/lib.rs
@@ -1,5 +1,4 @@
 #![cfg_attr(test, deny(warnings))]
-#![recursion_limit="128"]
 
 // Currently, Cargo does not use clippy for its source code.
 // But if someone runs it they should know that


### PR DESCRIPTION
Now that we have migrate from error-chain to failure, we no longer need to extend it.