### PR TITLE
Faster resolver: Cache past conflicting_activations, prevent doing the same work repeatedly.

### DIFF
--- a/tests/testsuite/resolve.rs
+++ b/tests/testsuite/resolve.rs
@@ -474,8 +474,8 @@ fn resolving_with_many_equivalent_backtracking() {
         pkg!(("level0", "1.0.0")),
     ];
 
-    const DEPTH: usize = 100;
-    const BRANCHING_FACTOR: usize = 10;
+    const DEPTH: usize = 200;
+    const BRANCHING_FACTOR: usize = 100;
 
     for l in 0..DEPTH {
         let name = format!("level{}", l);

--- a/tests/testsuite/resolve.rs
+++ b/tests/testsuite/resolve.rs
@@ -474,8 +474,8 @@ fn resolving_with_many_equivalent_backtracking() {
         pkg!(("level0", "1.0.0")),
     ];
 
-    const DEPTH: usize = 10;
-    const BRANCHING_FACTOR: usize = 5;
+    const DEPTH: usize = 100;
+    const BRANCHING_FACTOR: usize = 10;
 
     for l in 0..DEPTH {
         let name = format!("level{}", l);

--- a/tests/testsuite/resolve.rs
+++ b/tests/testsuite/resolve.rs
@@ -469,6 +469,34 @@ fn resolving_with_constrained_sibling_backtrack_parent() {
 }
 
 #[test]
+fn resolving_with_many_equivalent_backtracking() {
+    let mut reglist = vec![
+        pkg!(("level0", "1.0.0")),
+    ];
+
+    const DEPTH: usize = 10;
+    const BRANCHING_FACTOR: usize = 5;
+
+    for l in 0..DEPTH {
+        let name = format!("level{}", l);
+        let next = format!("level{}", l + 1);
+        for i in 1..BRANCHING_FACTOR {
+            let vsn = format!("1.0.{}", i);
+            reglist.push(pkg!((name.as_str(), vsn.as_str()) => [dep_req(next.as_str(), "*")]));
+        }
+    }
+
+    let reg = registry(reglist);
+
+    let res = resolve(&pkg_id("root"), vec![
+        dep_req("level0", "*"),
+    ], &reg).unwrap();
+
+    assert_that(&res, contains(names(&[("root", "1.0.0"),
+                                       ("level0", "1.0.0")])));
+}
+
+#[test]
 fn resolving_with_constrained_sibling_backtrack_activation() {
     // It makes sense to resolve most-constrained deps first, but
     // with that logic the backtrack traps here come between the two


### PR DESCRIPTION
This work is inspired by @alexcrichton's [comment](https://github.com/rust-lang/cargo/issues/4066#issuecomment-303912744) that a slow resolver can be caused by all versions of a dependency being yanked. Witch stuck in my brain as I did not understand why it would happen. If a dependency has no candidates then it will be the most constrained and will trigger backtracking in the next tick. Eventually I found a reproducible test case. If the bad dependency is deep in the tree of dependencies then we activate and backtrack `O(versions^depth)`  times. Even tho it is fast to identify the problem that is a lot of work.

**The set up:**
1. Every time we backtrack cache the (dep, `conflicting_activations`).
2. Build on the work in #5000, Fail to activate if any of its dependencies will just backtrack to this frame. I.E. for each dependency check if any of its cached `conflicting_activations` are already all activated. If so we can just skip to the next candidate. We also add that bad `conflicting_activations` to our set of  `conflicting_activations`, so that we can...

**The pay off:**
 If we fail to find any candidates that we can activate in lite of 2, then we cannot be activated in this context, add our (dep, `conflicting_activations`) to the cache so that next time our parent will not bother trying us.

I hear you saying "but the error messages, what about the error messages?" So if we are at the end `!has_another` then we disable this optimization. After we mark our dep as being not activatable then we activate anyway. It won't resolve but it will have the same error message as before this PR. If we have been activated for the error messages then skip straight to the last candidate, as that is the only backtrack that will end with the user.

I added a test in the vain of #4834. With the old code the time to run was `O(BRANCHING_FACTOR ^ DEPTH)` and took ~3min with DEPTH = 10; BRANCHING_FACTOR = 5; with the new code it runs almost instantly with 200 and 100.
