### PR TITLE
Don't rewrite dep-info files if they don't change

### DIFF
--- a/tests/testsuite/dep_info.rs
+++ b/tests/testsuite/dep_info.rs
@@ -1,4 +1,5 @@
 use cargotest::support::{basic_bin_manifest, main_file, execs, project};
+use filetime::FileTime;
 use hamcrest::{assert_that, existing_file};
 
 #[test]
@@ -78,4 +79,28 @@ fn build_dep_info_dylib() {
 
     assert_that(p.cargo("build").arg("--example=ex"), execs().with_status(0));
     assert_that(&p.example_lib("ex", "dylib").with_extension("d"), existing_file());
+}
+
+#[test]
+fn no_rewrite_if_no_change() {
+    let p = project("foo")
+        .file("Cargo.toml", r#"
+            [package]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+        "#)
+        .file("src/lib.rs", "")
+        .build();
+
+    assert_that(p.cargo("build"), execs().with_status(0));
+    let dep_info = p.root().join("target/debug/libfoo.d");
+    let metadata1 = dep_info.metadata().unwrap();
+    assert_that(p.cargo("build"), execs().with_status(0));
+    let metadata2 = dep_info.metadata().unwrap();
+
+    assert_eq!(
+        FileTime::from_last_modification_time(&metadata1),
+        FileTime::from_last_modification_time(&metadata2),
+    );
 }


### PR DESCRIPTION
Similar to how we treat lock files, read the contents, compare, and if they're
the same don't actually write the file.

Closes #5172