### PR TITLE
Delegate debug implementation for InternedString

### DIFF
--- a/src/cargo/core/interning.rs
+++ b/src/cargo/core/interning.rs
@@ -70,13 +70,13 @@ impl Hash for InternedString {
 
 impl fmt::Debug for InternedString {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "InternedString {{ {} }}", self.to_inner())
+        fmt::Debug::fmt(self.to_inner(), f)
     }
 }
 
 impl fmt::Display for InternedString {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.to_inner())
+        fmt::Display::fmt(self.to_inner(), f)
     }
 }
 


### PR DESCRIPTION
Let's make `InternedString` debug implementation the same as for `String` / `str`? It's more concise, which helps when you debug printing other stuff, like `eprintln!("id = {:?}", a_package_id)`.