### PR TITLE
Faster resolver: clean code and the `backtrack_stack`

### DIFF
--- a/src/cargo/core/resolver/mod.rs
+++ b/src/cargo/core/resolver/mod.rs
@@ -1096,30 +1096,16 @@ fn activate_deps_loop(
                         }
                     }
                     if !has_another && has_past_conflicting_dep && !backtracked {
-                        // we have not activated ANY candidates and
-                        // we are out of choices so add it to the cache
-                        // so our parent will know that we don't work
-                        let past = past_conflicting_activations
-                            .entry(dep.clone())
-                            .or_insert_with(Vec::new);
-                        if !past.contains(&conflicting_activations) {
-                            trace!(
-                                "{}[{}]>{} adding a meta-skip {:?}",
-                                parent.name(),
-                                cur,
-                                dep.name(),
-                                conflicting_activations
-                            );
-                            past.push(conflicting_activations.clone());
-                            // also clean the `backtrack_stack` so we don't
-                            // backtrack to a place where we will try this again.
-                            backtrack_stack.retain(|bframe| {
-                                !bframe.context_backup.is_conflicting(
-                                    Some(parent.package_id()),
-                                    &conflicting_activations,
-                                )
-                            });
-                        }
+                        // we have not activated ANY candidates.
+                        // So clean the `backtrack_stack` so we don't
+                        // backtrack to a place where we will try this again.
+                        backtrack_stack.retain(|bframe| {
+                            // Maybe we could just not add them in the first place, but for now this works
+                            !bframe.context_backup.is_conflicting(
+                                Some(parent.package_id()),
+                                &conflicting_activations,
+                            )
+                        });
                     }
                     // if not has_another we we activate for the better error messages
                     frame.just_for_error_messages = has_past_conflicting_dep;

--- a/src/cargo/core/resolver/mod.rs
+++ b/src/cargo/core/resolver/mod.rs
@@ -1095,18 +1095,6 @@ fn activate_deps_loop(
                             has_past_conflicting_dep = true;
                         }
                     }
-                    if !has_another && has_past_conflicting_dep && !backtracked {
-                        // we have not activated ANY candidates.
-                        // So clean the `backtrack_stack` so we don't
-                        // backtrack to a place where we will try this again.
-                        backtrack_stack.retain(|bframe| {
-                            // Maybe we could just not add them in the first place, but for now this works
-                            !bframe.context_backup.is_conflicting(
-                                Some(parent.package_id()),
-                                &conflicting_activations,
-                            )
-                        });
-                    }
                     // if not has_another we we activate for the better error messages
                     frame.just_for_error_messages = has_past_conflicting_dep;
                     if !has_past_conflicting_dep

--- a/tests/testsuite/resolve.rs
+++ b/tests/testsuite/resolve.rs
@@ -642,7 +642,11 @@ fn resolving_with_deep_traps() {
 
     let reg = registry(reglist.clone());
 
-    let res = resolve(&pkg_id("root"), vec![dep_req("backtrack_trap0", "*"), dep_req("cloaking", "*")], &reg);
+    let res = resolve(
+        &pkg_id("root"),
+        vec![dep_req("backtrack_trap0", "*"), dep_req("cloaking", "*")],
+        &reg,
+    );
 
     assert!(res.is_err());
 }

--- a/tests/testsuite/resolve.rs
+++ b/tests/testsuite/resolve.rs
@@ -609,6 +609,45 @@ fn resolving_with_many_equivalent_backtracking() {
 }
 
 #[test]
+fn resolving_with_deep_traps() {
+    let mut reglist = Vec::new();
+
+    const DEPTH: usize = 200;
+    const BRANCHING_FACTOR: usize = 100;
+
+    // Each backtrack_trap depends on the next, and adds a backtrack frame.
+    // None of witch is going to help with `bad`.
+    for l in 0..DEPTH {
+        let name = format!("backtrack_trap{}", l);
+        let next = format!("backtrack_trap{}", l + 1);
+        for i in 1..BRANCHING_FACTOR {
+            let vsn = format!("1.0.{}", i);
+            reglist.push(pkg!((name.as_str(), vsn.as_str()) => [dep_req(next.as_str(), "*")]));
+        }
+    }
+    {
+        let name = format!("backtrack_trap{}", DEPTH);
+        for i in 1..BRANCHING_FACTOR {
+            let vsn = format!("1.0.{}", i);
+            reglist.push(pkg!((name.as_str(), vsn.as_str())));
+        }
+    }
+    {
+        // slightly less constrained to make sure `cloaking` gets picked last.
+        for i in 1..(BRANCHING_FACTOR + 10) {
+            let vsn = format!("1.0.{}", i);
+            reglist.push(pkg!(("cloaking", vsn.as_str()) => [dep_req("bad", "1.0.1")]));
+        }
+    }
+
+    let reg = registry(reglist.clone());
+
+    let res = resolve(&pkg_id("root"), vec![dep_req("backtrack_trap0", "*"), dep_req("cloaking", "*")], &reg);
+
+    assert!(res.is_err());
+}
+
+#[test]
 fn resolving_with_constrained_sibling_backtrack_activation() {
     // It makes sense to resolve most-constrained deps first, but
     // with that logic the backtrack traps here come between the two


### PR DESCRIPTION
This is a small extension to #5168 and is inspired by https://github.com/rust-lang/cargo/pull/4834#issuecomment-363518370

After #5168 these work (and don't on cargo from nightly.):
- `safe_core = "=0.22.4"`
- `safe_vault = "=0.13.2"`

But these don't work (and do on cargo from this PR.)
- `crust = "=0.24.0"`
- `elastic = "=0.3.0"`
- `elastic = "=0.4.0"`
- `elastic = "=0.5.0"`
- `safe_vault = "=0.14.0"`

It took some work to figure out why they are not working, and make a test case.

This PR remove use of `conflicting_activations` before it is extended with the conflicting from next.
https://github.com/rust-lang/cargo/pull/5187#issuecomment-373830919
However the `find_candidate(` is still needed so it now gets the conflicting from next before being called.

It often happens that the candidate whose child will fail leading to it's failure, will have older siblings that have already set up `backtrack_frame`s. The candidate knows that it's failure can not be saved by its siblings, but sometimes we activate the child anyway for the error messages. Unfortunately the child does not know that is uncles can't save it, so it backtracks to one of them. Leading to a combinatorial loop.

The solution is to clear the `backtrack_stack` if we are activating just for the error messages.

Edit original end of this message, no longer accurate.
#5168 means that when we find a permanent problem we will never **activate** its parent again. In practise there afften is a lot of work and `backtrack_frame`s between the problem and reactivating its parent. This PR removes `backtrack_frame`s where its parent and the problem are present. This means that when we find a permanent problem we will never **backtrack** into it again.

An alternative is to scan all cashed problems while backtracking, but this seemed more efficient.