### PR TITLE
Add a synthetic dependency on num-traits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,10 @@ toml = "0.4"
 url = "1.1"
 clap = "2.27.0"
 
+# Not actually needed right now but required to make sure that rls/cargo build
+# with the same set of features in rust-lang/rust
+num-traits = "0.2" # enable the default feature
+
 [target.'cfg(target_os = "macos")'.dependencies]
 core-foundation = { version = "0.5.1", features = ["mac_os_10_7_support"] }
 


### PR DESCRIPTION
Right now the rust-lang/rust integration is compiling Cargo twice on dist
builds, once for Cargo and once for the RLS. This is due to a dependency of
Cargo being recompiled with different features when used from the RLS or not.
For now paper over this problem with a synthetic dependency to prevent Cargo
from being compiled twice.