### PR TITLE
Slightly improve ergonomics of writing Cargo tests

### DIFF
--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -3705,16 +3705,7 @@ fn build_multiple_packages() {
         .file("d2/src/main.rs", "fn main() { println!(\"d2\"); }")
         .build();
 
-    assert_that(
-        p.cargo("build")
-            .arg("-p")
-            .arg("d1")
-            .arg("-p")
-            .arg("d2")
-            .arg("-p")
-            .arg("foo"),
-        execs().with_status(0),
-    );
+    assert_that(p.cargo("build -p d1 -p d2 -p foo"), execs().with_status(0));
 
     assert_that(&p.bin("foo"), existing_file());
     assert_that(

--- a/tests/testsuite/cargotest/support/mod.rs
+++ b/tests/testsuite/cargotest/support/mod.rs
@@ -233,7 +233,12 @@ impl Project {
 
     pub fn cargo(&self, cmd: &str) -> ProcessBuilder {
         let mut p = self.process(&cargo_exe());
-        p.arg(cmd);
+        for arg in cmd.split_whitespace() {
+            if arg.contains('"') || arg.contains('\'') {
+                panic!("shell-style argument parsing is not supported")
+            }
+            p.arg(arg);
+        }
         return p;
     }
 

--- a/tests/testsuite/clean.rs
+++ b/tests/testsuite/clean.rs
@@ -85,16 +85,7 @@ fn clean_multiple_packages() {
         .file("d2/src/main.rs", "fn main() { println!(\"d2\"); }")
         .build();
 
-    assert_that(
-        p.cargo("build")
-            .arg("-p")
-            .arg("d1")
-            .arg("-p")
-            .arg("d2")
-            .arg("-p")
-            .arg("foo"),
-        execs().with_status(0),
-    );
+    assert_that(p.cargo("build -p d1 -p d2 -p foo"), execs().with_status(0));
 
     let d1_path = &p.build_dir()
         .join("debug")
@@ -108,12 +99,7 @@ fn clean_multiple_packages() {
     assert_that(d2_path, existing_file());
 
     assert_that(
-        p.cargo("clean")
-            .arg("-p")
-            .arg("d1")
-            .arg("-p")
-            .arg("d2")
-            .cwd(&p.root().join("src")),
+        p.cargo("clean -p d1 -p d2").cwd(&p.root().join("src")),
         execs().with_status(0).with_stdout(""),
     );
     assert_that(&p.bin("foo"), existing_file());

--- a/tests/testsuite/run.rs
+++ b/tests/testsuite/run.rs
@@ -59,12 +59,12 @@ fn simple_quiet() {
         .build();
 
     assert_that(
-        p.cargo("run").arg("-q"),
+        p.cargo("run -q"),
         execs().with_status(0).with_stdout("hello"),
     );
 
     assert_that(
-        p.cargo("run").arg("--quiet"),
+        p.cargo("run --quiet"),
         execs().with_status(0).with_stdout("hello"),
     );
 }
@@ -1133,12 +1133,5 @@ fn explicit_bin_with_args() {
         )
         .build();
 
-    assert_that(
-        p.cargo("run")
-            .arg("--bin")
-            .arg("foo")
-            .arg("hello")
-            .arg("world"),
-        execs().with_status(0),
-    );
+    assert_that(p.cargo("run --bin foo hello world"), execs().with_status(0));
 }

--- a/tests/testsuite/rustc.rs
+++ b/tests/testsuite/rustc.rs
@@ -111,13 +111,7 @@ fn build_main_and_allow_unstable_options() {
         .build();
 
     assert_that(
-        p.cargo("rustc")
-            .arg("-v")
-            .arg("--bin")
-            .arg("foo")
-            .arg("--")
-            .arg("-C")
-            .arg("debug-assertions"),
+        p.cargo("rustc -v --bin foo -- -C debug-assertions"),
         execs().with_status(0).with_stderr(&format!(
             "\
 [COMPILING] {name} v{version} ({url})
@@ -208,13 +202,7 @@ fn build_with_args_to_one_of_multiple_binaries() {
         .build();
 
     assert_that(
-        p.cargo("rustc")
-            .arg("-v")
-            .arg("--bin")
-            .arg("bar")
-            .arg("--")
-            .arg("-C")
-            .arg("debug-assertions"),
+        p.cargo("rustc -v --bin bar -- -C debug-assertions"),
         execs().with_status(0).with_stderr(format!(
             "\
 [COMPILING] foo v0.0.1 ({url})
@@ -292,13 +280,7 @@ fn build_with_args_to_one_of_multiple_tests() {
         .build();
 
     assert_that(
-        p.cargo("rustc")
-            .arg("-v")
-            .arg("--test")
-            .arg("bar")
-            .arg("--")
-            .arg("-C")
-            .arg("debug-assertions"),
+        p.cargo("rustc -v --test bar -- -C debug-assertions"),
         execs().with_status(0).with_stderr(format!(
             "\
 [COMPILING] foo v0.0.1 ({url})
@@ -420,13 +402,7 @@ fn build_only_bar_dependency() {
         .build();
 
     assert_that(
-        foo.cargo("rustc")
-            .arg("-v")
-            .arg("-p")
-            .arg("bar")
-            .arg("--")
-            .arg("-C")
-            .arg("debug-assertions"),
+        foo.cargo("rustc -v -p bar -- -C debug-assertions"),
         execs().with_status(0).with_stderr(
             "\
 [COMPILING] bar v0.1.0 ([..])
@@ -504,12 +480,7 @@ fn fail_with_multiple_packages() {
         .build();
 
     assert_that(
-        foo.cargo("rustc")
-            .arg("-v")
-            .arg("-p")
-            .arg("bar")
-            .arg("-p")
-            .arg("baz"),
+        foo.cargo("rustc -v -p bar -p baz"),
         execs().with_status(1).with_stderr_contains(
             "\
 error: The argument '--package <SPEC>' was provided more than once, \

--- a/tests/testsuite/test.rs
+++ b/tests/testsuite/test.rs
@@ -2833,14 +2833,7 @@ fn selective_test_wonky_profile() {
     let p = p.build();
 
     assert_that(
-        p.cargo("test")
-            .arg("-v")
-            .arg("--no-run")
-            .arg("--release")
-            .arg("-p")
-            .arg("foo")
-            .arg("-p")
-            .arg("a"),
+        p.cargo("test -v --no-run --release -p foo -p a"),
         execs().with_status(0),
     );
 }
@@ -3051,13 +3044,7 @@ fn panic_abort_multiple() {
         .file("a/src/lib.rs", "")
         .build();
     assert_that(
-        p.cargo("test")
-            .arg("--release")
-            .arg("-v")
-            .arg("-p")
-            .arg("foo")
-            .arg("-p")
-            .arg("a"),
+        p.cargo("test --release -v -p foo -p a"),
         execs().with_status(0),
     );
 }
@@ -3246,14 +3233,7 @@ fn test_many_with_features() {
         .build();
 
     assert_that(
-        p.cargo("test")
-            .arg("-v")
-            .arg("-p")
-            .arg("a")
-            .arg("-p")
-            .arg("foo")
-            .arg("--features")
-            .arg("foo"),
+        p.cargo("test -v -p a -p foo --features foo"),
         execs().with_status(0),
     );
 }


### PR DESCRIPTION
As discussed in https://github.com/rust-lang/cargo/pull/5196#discussion_r175110557

I've also employed this to some of the longer command-lines in our test suite :)