### PR TITLE
cargo build --out-dir

### DIFF
--- a/src/bin/command_prelude.rs
+++ b/src/bin/command_prelude.rs
@@ -288,6 +288,7 @@ pub trait ArgMatchesExt {
             message_format,
             target_rustdoc_args: None,
             target_rustc_args: None,
+            export_dir: None,
         };
         Ok(opts)
     }

--- a/src/bin/commands/build.rs
+++ b/src/bin/commands/build.rs
@@ -27,6 +27,7 @@ pub fn cli() -> App {
         .arg_release("Build artifacts in release mode, with optimizations")
         .arg_features()
         .arg_target_triple("Build for the target triple")
+        .arg(opt("out-dir", "Copy final artifacts to this directory").value_name("PATH"))
         .arg_manifest_path()
         .arg_message_format()
         .after_help(
@@ -49,7 +50,8 @@ the --release flag will use the `release` profile instead.
 
 pub fn exec(config: &mut Config, args: &ArgMatches) -> CliResult {
     let ws = args.workspace(config)?;
-    let compile_opts = args.compile_options(config, CompileMode::Build)?;
+    let mut compile_opts = args.compile_options(config, CompileMode::Build)?;
+    compile_opts.export_dir = args.value_of_path("out-dir", config);
     ops::compile(&ws, &compile_opts)?;
     Ok(())
 }

--- a/src/bin/commands/build.rs
+++ b/src/bin/commands/build.rs
@@ -52,6 +52,11 @@ pub fn exec(config: &mut Config, args: &ArgMatches) -> CliResult {
     let ws = args.workspace(config)?;
     let mut compile_opts = args.compile_options(config, CompileMode::Build)?;
     compile_opts.export_dir = args.value_of_path("out-dir", config);
+    if compile_opts.export_dir.is_some() && !config.cli_unstable().out_dir {
+        Err(format_err!(
+            "`--out-dir` flag is unstable, pass `-Z out-dir` to enable it"
+        ))?;
+    };
     ops::compile(&ws, &compile_opts)?;
     Ok(())
 }

--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -286,6 +286,7 @@ pub struct CliUnstable {
     pub no_index_update: bool,
     pub avoid_dev_deps: bool,
     pub minimal_versions: bool,
+    pub out_dir: bool,
 }
 
 impl CliUnstable {
@@ -319,6 +320,7 @@ impl CliUnstable {
             "no-index-update" => self.no_index_update = true,
             "avoid-dev-deps" => self.avoid_dev_deps = true,
             "minimal-versions" => self.minimal_versions = true,
+            "out-dir" => self.out_dir = true,
             _ => bail!("unknown `-Z` flag specified: {}", k),
         }
 

--- a/src/cargo/ops/cargo_clean.rs
+++ b/src/cargo/ops/cargo_clean.rs
@@ -98,6 +98,7 @@ pub fn clean(ws: &Workspace, opts: &CleanOptions) -> CargoResult<()> {
             ..BuildConfig::default()
         },
         profiles,
+        None,
         &units,
     )?;
 

--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -64,6 +64,12 @@ pub struct CompileOptions<'a> {
     /// The specified target will be compiled with all the available arguments,
     /// note that this only accounts for the *final* invocation of rustc
     pub target_rustc_args: Option<Vec<String>>,
+    /// The directory to copy final artifacts to. Note that even if `out_dir` is
+    /// set, a copy of artifacts still could be found a `target/(debug\release)`
+    /// as usual.
+    // Note that, although the cmd-line flag name is `out-dir`, in code we use
+    // `export_dir`, to avoid confusion with out dir at `target/debug/deps`.
+    pub export_dir: Option<PathBuf>,
 }
 
 impl<'a> CompileOptions<'a> {
@@ -84,6 +90,7 @@ impl<'a> CompileOptions<'a> {
             message_format: MessageFormat::Human,
             target_rustdoc_args: None,
             target_rustc_args: None,
+            export_dir: None,
         }
     }
 }
@@ -233,6 +240,7 @@ pub fn compile_ws<'a>(
         ref filter,
         ref target_rustdoc_args,
         ref target_rustc_args,
+        ref export_dir,
     } = *options;
 
     let target = match target {
@@ -330,7 +338,6 @@ pub fn compile_ws<'a>(
             package_targets.push((to_build, vec![(target, profile)]));
         }
     }
-
     let mut ret = {
         let _p = profile::start("compiling");
         let mut build_config = scrape_build_config(config, jobs, target)?;
@@ -349,6 +356,7 @@ pub fn compile_ws<'a>(
             config,
             build_config,
             profiles,
+            export_dir.clone(),
             &exec,
         )?
     };

--- a/src/cargo/ops/cargo_package.rs
+++ b/src/cargo/ops/cargo_package.rs
@@ -350,6 +350,7 @@ fn run_verify(ws: &Workspace, tar: &FileLock, opts: &PackageOpts) -> CargoResult
             mode: ops::CompileMode::Build,
             target_rustdoc_args: None,
             target_rustc_args: None,
+            export_dir: None,
         },
         Arc::new(DefaultExecutor),
     )?;

--- a/src/cargo/ops/cargo_rustc/context/compilation_files.rs
+++ b/src/cargo/ops/cargo_rustc/context/compilation_files.rs
@@ -27,6 +27,7 @@ pub struct CompilationFiles<'a, 'cfg: 'a> {
     pub(super) host: Layout,
     /// The target directory layout for the target (if different from then host)
     pub(super) target: Option<Layout>,
+    export_dir: Option<(PathBuf, Vec<Unit<'a>>)>,
     ws: &'a Workspace<'cfg>,
     metas: HashMap<Unit<'a>, Option<Metadata>>,
     /// For each Unit, a list all files produced.
@@ -49,6 +50,7 @@ impl<'a, 'cfg: 'a> CompilationFiles<'a, 'cfg> {
         roots: &[Unit<'a>],
         host: Layout,
         target: Option<Layout>,
+        export_dir: Option<PathBuf>,
         ws: &'a Workspace<'cfg>,
         cx: &Context<'a, 'cfg>,
     ) -> CompilationFiles<'a, 'cfg> {
@@ -65,6 +67,7 @@ impl<'a, 'cfg: 'a> CompilationFiles<'a, 'cfg> {
             ws,
             host,
             target,
+            export_dir: export_dir.map(|dir| (dir, roots.to_vec())),
             metas,
             outputs,
         }
@@ -104,6 +107,15 @@ impl<'a, 'cfg: 'a> CompilationFiles<'a, 'cfg> {
             self.layout(unit.kind).examples().to_path_buf()
         } else {
             self.deps_dir(unit).to_path_buf()
+        }
+    }
+
+    pub fn export_dir(&self, unit: &Unit<'a>) -> Option<PathBuf> {
+        let &(ref dir, ref roots) = self.export_dir.as_ref()?;
+        if roots.contains(unit) {
+            Some(dir.clone())
+        } else {
+            None
         }
     }
 

--- a/src/cargo/ops/cargo_rustc/context/mod.rs
+++ b/src/cargo/ops/cargo_rustc/context/mod.rs
@@ -2,7 +2,7 @@
 
 use std::collections::{HashMap, HashSet};
 use std::env;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::str::{self, FromStr};
 use std::sync::Arc;
 
@@ -105,6 +105,7 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
         config: &'cfg Config,
         build_config: BuildConfig,
         profiles: &'a Profiles,
+        export_dir: Option<PathBuf>,
         units: &[Unit<'a>],
     ) -> CargoResult<Context<'a, 'cfg>> {
         let dest = if build_config.release {
@@ -164,7 +165,7 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
         cx.probe_target_info()?;
         let deps = build_unit_dependencies(units, &cx)?;
         cx.unit_dependencies = deps;
-        let files = CompilationFiles::new(units, host_layout, target_layout, ws, &cx);
+        let files = CompilationFiles::new(units, host_layout, target_layout, export_dir, ws, &cx);
         cx.files = Some(files);
         Ok(cx)
     }

--- a/src/cargo/ops/cargo_rustc/mod.rs
+++ b/src/cargo/ops/cargo_rustc/mod.rs
@@ -645,8 +645,12 @@ fn hardlink_or_copy(src: &Path, dst: &Path) -> CargoResult<()> {
         use std::os::windows::fs::symlink_dir as symlink;
 
         let dst_dir = dst.parent().unwrap();
-        assert!(src.starts_with(dst_dir));
-        symlink(src.strip_prefix(dst_dir).unwrap(), dst)
+        let src = if src.starts_with(dst_dir) {
+            src.strip_prefix(dst_dir).unwrap()
+        } else {
+            src
+        };
+        symlink(src, dst)
     } else {
         fs::hard_link(src, dst)
     };

--- a/src/cargo/ops/cargo_rustc/mod.rs
+++ b/src/cargo/ops/cargo_rustc/mod.rs
@@ -605,9 +605,8 @@ fn link_targets<'a, 'cfg>(
             destinations.push(dst.display().to_string());
             hardlink_or_copy(&src, &dst)?;
             if let Some(ref path) = export_dir {
-                //TODO: check if dir
                 if !path.exists() {
-                    fs::create_dir(path)?;
+                    fs::create_dir_all(path)?;
                 }
 
                 hardlink_or_copy(&src, &path.join(dst.file_name().unwrap()))?;

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -14,7 +14,7 @@ use url::Url;
 
 use core::{GitReference, PackageIdSpec, Profiles, SourceId, WorkspaceConfig, WorkspaceRootConfig};
 use core::{Dependency, Manifest, PackageId, Summary, Target};
-use core::{EitherManifest, Edition, Feature, Features, VirtualManifest};
+use core::{Edition, EitherManifest, Feature, Features, VirtualManifest};
 use core::dependency::{Kind, Platform};
 use core::manifest::{LibKind, Lto, ManifestMetadata, Profile};
 use sources::CRATES_IO;

--- a/tests/testsuite/main.rs
+++ b/tests/testsuite/main.rs
@@ -62,6 +62,7 @@ mod login;
 mod metadata;
 mod net_config;
 mod new;
+mod out_dir;
 mod overrides;
 mod package;
 mod patch;

--- a/tests/testsuite/out_dir.rs
+++ b/tests/testsuite/out_dir.rs
@@ -1,0 +1,208 @@
+use cargotest::support::{execs, project};
+use hamcrest::assert_that;
+use std::path::Path;
+use std::fs;
+
+#[test]
+fn binary_with_debug() {
+    let p = project("foo")
+        .file(
+            "Cargo.toml",
+            r#"
+            [project]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+        "#,
+        )
+        .file("src/main.rs", r#"fn main() { println!("Hello, World!") }"#)
+        .build();
+
+    assert_that(p.cargo("build --out-dir out"), execs().with_status(0));
+    check_dir_contents(
+        &p.root().join("out"),
+        &["foo"],
+        &["foo"],
+        &["foo.exe", "foo.pdb"],
+    );
+}
+
+#[test]
+fn static_library_with_debug() {
+    let p = project("foo")
+        .file(
+            "Cargo.toml",
+            r#"
+            [project]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+
+            [lib]
+            crate-type = ["staticlib"]
+        "#,
+        )
+        .file(
+            "src/lib.rs",
+            r#"
+            #[no_mangle]
+            pub extern "C" fn foo() { println!("Hello, World!") }
+        "#,
+        )
+        .build();
+
+    assert_that(p.cargo("build --out-dir out"), execs().with_status(0));
+    check_dir_contents(
+        &p.root().join("out"),
+        &["libfoo.a"],
+        &["libfoo.a"],
+        &["foo.lib"],
+    );
+}
+
+#[test]
+fn dynamic_library_with_debug() {
+    let p = project("foo")
+        .file(
+            "Cargo.toml",
+            r#"
+            [project]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+
+            [lib]
+            crate-type = ["cdylib"]
+        "#,
+        )
+        .file(
+            "src/lib.rs",
+            r#"
+            #[no_mangle]
+            pub extern "C" fn foo() { println!("Hello, World!") }
+        "#,
+        )
+        .build();
+
+    assert_that(p.cargo("build --out-dir out"), execs().with_status(0));
+    check_dir_contents(
+        &p.root().join("out"),
+        &["libfoo.so"],
+        &["libfoo.so"],
+        &["foo.dll", "foo.dll.lib"],
+    );
+}
+
+#[test]
+fn rlib_with_debug() {
+    let p = project("foo")
+        .file(
+            "Cargo.toml",
+            r#"
+            [project]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+
+            [lib]
+            crate-type = ["rlib"]
+        "#,
+        )
+        .file(
+            "src/lib.rs",
+            r#"
+            pub fn foo() { println!("Hello, World!") }
+        "#,
+        )
+        .build();
+
+    assert_that(p.cargo("build --out-dir out"), execs().with_status(0));
+    check_dir_contents(
+        &p.root().join("out"),
+        &["libfoo.rlib"],
+        &["libfoo.rlib"],
+        &["libfoo.rlib"],
+    );
+}
+
+#[test]
+fn include_only_the_binary_from_the_current_package() {
+    let p = project("foo")
+        .file(
+            "Cargo.toml",
+            r#"
+            [project]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+
+            [workspace]
+
+            [dependencies]
+            utils = { path = "./utils" }
+        "#,
+        )
+        .file("src/lib.rs", "extern crate utils;")
+        .file(
+            "src/main.rs",
+            r#"
+            extern crate foo;
+            extern crate utils;
+            fn main() {
+                println!("Hello, World!")
+            }
+        "#,
+        )
+        .file(
+            "utils/Cargo.toml",
+            r#"
+            [project]
+            name = "utils"
+            version = "0.0.1"
+            authors = []
+        "#,
+        )
+        .file("utils/src/lib.rs", "")
+        .build();
+
+    assert_that(
+        p.cargo("build --bin foo --out-dir out"),
+        execs().with_status(0),
+    );
+    check_dir_contents(
+        &p.root().join("out"),
+        &["foo"],
+        &["foo"],
+        &["foo.exe", "foo.pdb"],
+    );
+}
+
+fn check_dir_contents(
+    out_dir: &Path,
+    expected_linux: &[&str],
+    expected_mac: &[&str],
+    expected_win: &[&str],
+) {
+    let expected = if cfg!(target_os = "windows") {
+        expected_win
+    } else if cfg!(target_os = "macos") {
+        expected_mac
+    } else {
+        expected_linux
+    };
+
+    let actual = list_dir(out_dir);
+    let mut expected = expected.iter().map(|s| s.to_string()).collect::<Vec<_>>();
+    expected.sort();
+    assert_eq!(actual, expected);
+}
+
+fn list_dir(dir: &Path) -> Vec<String> {
+    let mut res = Vec::new();
+    for entry in fs::read_dir(dir).unwrap() {
+        let entry = entry.unwrap();
+        res.push(entry.file_name().into_string().unwrap());
+    }
+    res.sort();
+    res
+}

--- a/tests/testsuite/out_dir.rs
+++ b/tests/testsuite/out_dir.rs
@@ -1,3 +1,4 @@
+use cargotest::ChannelChanger;
 use cargotest::support::{execs, project};
 use hamcrest::assert_that;
 use std::path::Path;
@@ -18,7 +19,11 @@ fn binary_with_debug() {
         .file("src/main.rs", r#"fn main() { println!("Hello, World!") }"#)
         .build();
 
-    assert_that(p.cargo("build --out-dir out"), execs().with_status(0));
+    assert_that(
+        p.cargo("build -Z out-dir --out-dir out")
+            .masquerade_as_nightly_cargo(),
+        execs().with_status(0),
+    );
     check_dir_contents(
         &p.root().join("out"),
         &["foo"],
@@ -51,7 +56,11 @@ fn static_library_with_debug() {
         )
         .build();
 
-    assert_that(p.cargo("build --out-dir out"), execs().with_status(0));
+    assert_that(
+        p.cargo("build -Z out-dir --out-dir out")
+            .masquerade_as_nightly_cargo(),
+        execs().with_status(0),
+    );
     check_dir_contents(
         &p.root().join("out"),
         &["libfoo.a"],
@@ -84,7 +93,11 @@ fn dynamic_library_with_debug() {
         )
         .build();
 
-    assert_that(p.cargo("build --out-dir out"), execs().with_status(0));
+    assert_that(
+        p.cargo("build -Z out-dir --out-dir out")
+            .masquerade_as_nightly_cargo(),
+        execs().with_status(0),
+    );
     check_dir_contents(
         &p.root().join("out"),
         &["libfoo.so"],
@@ -116,7 +129,11 @@ fn rlib_with_debug() {
         )
         .build();
 
-    assert_that(p.cargo("build --out-dir out"), execs().with_status(0));
+    assert_that(
+        p.cargo("build -Z out-dir --out-dir out")
+            .masquerade_as_nightly_cargo(),
+        execs().with_status(0),
+    );
     check_dir_contents(
         &p.root().join("out"),
         &["libfoo.rlib"],
@@ -166,7 +183,8 @@ fn include_only_the_binary_from_the_current_package() {
         .build();
 
     assert_that(
-        p.cargo("build --bin foo --out-dir out"),
+        p.cargo("build -Z out-dir --bin foo --out-dir out")
+            .masquerade_as_nightly_cargo(),
         execs().with_status(0),
     );
     check_dir_contents(

--- a/tests/testsuite/out_dir.rs
+++ b/tests/testsuite/out_dir.rs
@@ -1,11 +1,10 @@
 use std::path::Path;
 use std::fs::{self, File};
 use std::env;
-use std::io::Write;
 
 use hamcrest::assert_that;
 
-use cargotest::{process, ChannelChanger};
+use cargotest::{process, sleep_ms, ChannelChanger};
 use cargotest::support::{execs, project};
 
 #[test]
@@ -31,7 +30,7 @@ fn binary_with_debug() {
     check_dir_contents(
         &p.root().join("out"),
         &["foo"],
-        &["foo"],
+        &["foo", "foo.dSYM"],
         &["foo.exe", "foo.pdb"],
     );
 }
@@ -105,7 +104,7 @@ fn dynamic_library_with_debug() {
     check_dir_contents(
         &p.root().join("out"),
         &["libfoo.so"],
-        &["libfoo.so"],
+        &["libfoo.dylib"],
         &["foo.dll", "foo.dll.lib"],
     );
 }
@@ -194,7 +193,7 @@ fn include_only_the_binary_from_the_current_package() {
     check_dir_contents(
         &p.root().join("out"),
         &["foo"],
-        &["foo"],
+        &["foo", "foo.dSYM"],
         &["foo.exe", "foo.pdb"],
     );
 }
@@ -250,10 +249,8 @@ fn replaces_artifacts() {
         execs().with_stdout("foo"),
     );
 
-    fs::File::create(p.root().join("src/main.rs"))
-        .unwrap()
-        .write_all(br#"fn main() { println!("bar") }"#)
-        .unwrap();
+    sleep_ms(1000);
+    p.change_file("src/main.rs", r#"fn main() { println!("bar") }"#);
 
     assert_that(
         p.cargo("build -Z out-dir --out-dir out")


### PR DESCRIPTION
This is intended to fix https://github.com/rust-lang/cargo/issues/4875. Very much work in progress, just to figure out how exactly `--out-dir` should work :) 

The path of least resistance for implementing `out-dir` would be to just link everything from `target/debug` to the `out-dir`. However, the problem with this approach is that we link *too much* to the `target/debug`. For example, if you run `cargo build --bin foo`, you'll find not only the `foo` itself there, but also rlibs from the same workspace. 

I think it's rather important not to copy extra stuff to out-dir, so it is implemented as a completely new parameter, which is threaded through various config structs and applies *only* to the top-level units (i.e, to the stuff user explicitly requested to compile on the command line).

I also plan to add platform specific tests here, to check that we get .pdb on windows and .dSYM on macs for various crate-types. 

Because, in general, a single target may produce multiple files, `out-dir` has to be a directory, you can't directly specify the output *file*. 

Note that artifacts are still generated to the `target` dir as well. 

Also cc @nirbheek, I hope that this might be useful for Meson integration, because `--out-dir` should be more straightforward to use than `--message-format=json`. 

The end result, for `cargo build --bin rustraytracer --out-dir out` on windows looks like this:

![image](https://user-images.githubusercontent.com/1711539/37605115-941c0b22-2ba3-11e8-9685-9756a10fdfac.png)

Note how we have fewer files in the `out` :) 

r? @alexcrichton 
