### PR TITLE
fix #2773 with new precise encode

### DIFF
--- a/src/cargo/ops/cargo_generate_lockfile.rs
+++ b/src/cargo/ops/cargo_generate_lockfile.rs
@@ -69,7 +69,7 @@ pub fn update_lockfile(ws: &Workspace, opts: &UpdateOptions) -> CargoResult<()> 
                         //       seems like a pretty hokey reason to single out
                         //       the registry as well.
                         let precise = if dep.source_id().is_registry() {
-                            format!("{}={}", dep.name(), precise)
+                            format!("{}={}->{}", dep.name(), dep.version(), precise)
                         } else {
                             precise.to_string()
                         };

--- a/src/cargo/sources/registry/index.rs
+++ b/src/cargo/sources/registry/index.rs
@@ -179,13 +179,18 @@ impl<'cfg> RegistryIndex<'cfg> {
             .map(|s| s.0.clone());
 
         // Handle `cargo update --precise` here. If specified, our own source
-        // will have a precise version listed of the form `<pkg>=<req>` where
-        // `<pkg>` is the name of a crate on this source and `<req>` is the
+        // will have a precise version listed of the form
+        // `<pkg>=<p_req>o-><f_req>` where `<pkg>` is the name of a crate on
+        // this source, `<p_req>` is the version installed and `<f_req> is the
         // version requested (argument to `--precise`).
         let summaries = summaries.filter(|s| match source_id.precise() {
             Some(p) if p.starts_with(&*dep.name()) && p[dep.name().len()..].starts_with('=') => {
-                let vers = &p[dep.name().len() + 1..];
-                s.version().to_string() == vers
+                let vers: Vec<&str> = p[dep.name().len() + 1..].split("->").collect();
+                    if dep.version_req().matches(&Version::parse(vers[0]).unwrap()) {
+                        return vers[1] == s.version().to_string()
+                    }
+
+                    true
             }
             _ => true,
         });

--- a/src/cargo/sources/registry/index.rs
+++ b/src/cargo/sources/registry/index.rs
@@ -186,11 +186,11 @@ impl<'cfg> RegistryIndex<'cfg> {
         let summaries = summaries.filter(|s| match source_id.precise() {
             Some(p) if p.starts_with(&*dep.name()) && p[dep.name().len()..].starts_with('=') => {
                 let vers: Vec<&str> = p[dep.name().len() + 1..].split("->").collect();
-                    if dep.version_req().matches(&Version::parse(vers[0]).unwrap()) {
-                        return vers[1] == s.version().to_string()
-                    }
-
+                if dep.version_req().matches(&Version::parse(vers[0]).unwrap()) {
+                    return vers[1] == s.version().to_string()
+                } {
                     true
+                }
             }
             _ => true,
         });

--- a/src/cargo/sources/registry/index.rs
+++ b/src/cargo/sources/registry/index.rs
@@ -185,10 +185,10 @@ impl<'cfg> RegistryIndex<'cfg> {
         // version requested (argument to `--precise`).
         let summaries = summaries.filter(|s| match source_id.precise() {
             Some(p) if p.starts_with(&*dep.name()) && p[dep.name().len()..].starts_with('=') => {
-                let vers: Vec<&str> = p[dep.name().len() + 1..].split("->").collect();
-                if dep.version_req().matches(&Version::parse(vers[0]).unwrap()) {
-                    return vers[1] == s.version().to_string()
-                } {
+                let mut vers = p[dep.name().len() + 1..].splitn(2, "->");
+                if dep.version_req().matches(&Version::parse(vers.next().unwrap()).unwrap()) {
+                    vers.next().unwrap() == s.version().to_string()
+                } else {
                     true
                 }
             }

--- a/src/cargo/sources/registry/index.rs
+++ b/src/cargo/sources/registry/index.rs
@@ -186,7 +186,9 @@ impl<'cfg> RegistryIndex<'cfg> {
         let summaries = summaries.filter(|s| match source_id.precise() {
             Some(p) if p.starts_with(&*dep.name()) && p[dep.name().len()..].starts_with('=') => {
                 let mut vers = p[dep.name().len() + 1..].splitn(2, "->");
-                if dep.version_req().matches(&Version::parse(vers.next().unwrap()).unwrap()) {
+                if dep.version_req()
+                    .matches(&Version::parse(vers.next().unwrap()).unwrap())
+                {
                     vers.next().unwrap() == s.version().to_string()
                 } else {
                     true


### PR DESCRIPTION
Changed the precise encode from <pkg>=<precise> to <pkg>=<present_version>-><future_version> in order to check the correct requirements.

cc @lu-zero