### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,6 +81,10 @@ of helpers to minimize boilerplate.
 installed locally, ignore the cross-compile test failures or disable them by
 using `CFG_DISABLE_CROSS_TESTS=1 cargo test`. Note that some tests are enabled
 only on `nightly` toolchain. If you can, test both toolchains.
+* All code is expected to comply with the formatting suggested by `rustfmt`;
+discrepancy is considered an error by CI, so a pull request with unsound
+formatting will not be accepted. You can use `rustup component add rustfmt-preview`
+to install `rustfmt` and use `cargo fmt` to automatically format your code.
 * Push your commits to GitHub and create a pull request against Cargo's
 `master` branch.
 


### PR DESCRIPTION
Since a13a33c33b049a7b412f0cc80a7b166b0d58345c code is rejected during CI if `rustfmt` complains. Update the docs regarding that fact.