### PR TITLE
Fix regression when passing arguments to subcommands

### DIFF
--- a/src/bin/cargo.rs
+++ b/src/bin/cargo.rs
@@ -144,7 +144,7 @@ fn execute_external_subcommand(config: &Config, cmd: &str, args: &[&str]) -> Cli
     let cargo_exe = config.cargo_exe()?;
     let err = match util::process(&command)
         .env(cargo::CARGO_ENV, cargo_exe)
-        .args(&args[1..])
+        .args(args)
         .exec_replace()
     {
         Ok(()) => return Ok(()),


### PR DESCRIPTION
closes https://github.com/rust-lang/cargo/issues/5208

`.args(&args[1..])` was copied directly from the docopt implementation, but there, `args[0]` was the path to `cargo` and not the name of subcommand, ie, `args` were *original* arguments for Cargo as a whole. 