### PR TITLE
Faster resolver: use a inverse-index to not activate the causes of conflict

### DIFF
--- a/src/cargo/core/resolver/conflict_cache.rs
+++ b/src/cargo/core/resolver/conflict_cache.rs
@@ -1,0 +1,91 @@
+use std::collections::{HashMap, HashSet};
+
+use core::{Dependency, PackageId};
+use core::resolver::{ConflictReason, Context};
+
+pub(super) struct ConflictCache {
+    // `con_from_dep` is a cache of the reasons for each time we
+    // backtrack. For example after several backtracks we may have:
+    //
+    //  con_from_dep[`foo = "^1.0.2"`] = vec![
+    //      map!{`foo=1.0.1`: Semver},
+    //      map!{`foo=1.0.0`: Semver},
+    //  ];
+    //
+    // This can be read as "we cannot find a candidate for dep `foo = "^1.0.2"`
+    // if either `foo=1.0.1` OR `foo=1.0.0` are activated".
+    //
+    // Another example after several backtracks we may have:
+    //
+    //  con_from_dep[`foo = ">=0.8.2, <=0.9.3"`] = vec![
+    //      map!{`foo=0.8.1`: Semver, `foo=0.9.4`: Semver},
+    //  ];
+    //
+    // This can be read as "we cannot find a candidate for dep `foo = ">=0.8.2,
+    // <=0.9.3"` if both `foo=0.8.1` AND `foo=0.9.4` are activated".
+    //
+    // This is used to make sure we don't queue work we know will fail. See the
+    // discussion in https://github.com/rust-lang/cargo/pull/5168 for why this
+    // is so important, and there can probably be a better data structure here
+    // but for now this works well enough!
+    //
+    // Also, as a final note, this map is *not* ever removed from. This remains
+    // as a global cache which we never delete from. Any entry in this map is
+    // unconditionally true regardless of our resolution history of how we got
+    // here.
+    con_from_dep: HashMap<Dependency, Vec<HashMap<PackageId, ConflictReason>>>,
+    // `past_conflict_triggers` is an
+    // of `past_conflicting_activations`.
+    // For every `PackageId` this lists the `Dependency`s that mention it in `past_conflicting_activations`.
+    dep_from_pid: HashMap<PackageId, HashSet<Dependency>>,
+}
+
+impl ConflictCache {
+    pub(super) fn new() -> ConflictCache {
+        ConflictCache {
+            con_from_dep: HashMap::new(),
+            dep_from_pid: HashMap::new(),
+        }
+    }
+    pub(super) fn filter_conflicting<F>(
+        &self,
+        cx: &Context,
+        dep: &Dependency,
+        filter: F,
+    ) -> Option<&HashMap<PackageId, ConflictReason>>
+    where
+        for<'r> F: FnMut(&'r &HashMap<PackageId, ConflictReason>) -> bool,
+    {
+        self.con_from_dep.get(dep).and_then(|past_bad| {
+            past_bad
+                .iter()
+                .filter(filter)
+                .find(|conflicting| cx.is_conflicting(None, conflicting))
+        })
+    }
+    pub(super) fn conflicting(
+        &self,
+        cx: &Context,
+        dep: &Dependency,
+    ) -> Option<&HashMap<PackageId, ConflictReason>> {
+        self.filter_conflicting(cx, dep, |_| true)
+    }
+    pub(super) fn insert(&mut self, dep: &Dependency, con: &HashMap<PackageId, ConflictReason>) {
+        let past = self.con_from_dep
+            .entry(dep.clone())
+            .or_insert_with(Vec::new);
+        if !past.contains(con) {
+            trace!("{} adding a skip {:?}", dep.name(), con);
+            past.push(con.clone());
+            for c in con.keys() {
+                self.dep_from_pid
+                    .entry(c.clone())
+                    .or_insert_with(HashSet::new)
+                    .insert(dep.clone());
+            }
+        }
+    }
+    pub(super) fn get_dep_from_pid(&self, pid: &PackageId) -> Option<&HashSet<Dependency>> {
+        self.dep_from_pid.get(pid)
+    }
+}

--- a/src/cargo/core/resolver/mod.rs
+++ b/src/cargo/core/resolver/mod.rs
@@ -72,6 +72,7 @@ pub use self::encode::{EncodableDependency, EncodablePackageId, EncodableResolve
 pub use self::encode::{Metadata, WorkspaceResolve};
 
 mod encode;
+mod conflict_cache;
 
 /// Represents a fully resolved package dependency graph. Each node in the graph
 /// is a package and edges represent dependencies between packages.
@@ -594,6 +595,15 @@ impl DepsFrame {
             .map(|(_, (_, candidates, _))| candidates.len())
             .unwrap_or(0)
     }
+
+    fn flatten<'s>(&'s self) -> Box<Iterator<Item = (PackageId, Dependency)> + 's> {
+        // TODO: with impl Trait the Box can be removed
+        Box::new(
+            self.remaining_siblings
+                .clone()
+                .map(move |(_, (d, _, _))| (self.parent.package_id().clone(), d)),
+        )
+    }
 }
 
 impl PartialEq for DepsFrame {
@@ -975,42 +985,8 @@ fn activate_deps_loop(
     let mut remaining_deps = BinaryHeap::new();
 
     // `past_conflicting_activations` is a cache of the reasons for each time we
-    // backtrack. For example after several backtracks we may have:
-    //
-    //  past_conflicting_activations[`foo = "^1.0.2"`] = vec![
-    //      map!{`foo=1.0.1`: Semver},
-    //      map!{`foo=1.0.0`: Semver},
-    //  ];
-    //
-    // This can be read as "we cannot find a candidate for dep `foo = "^1.0.2"`
-    // if either `foo=1.0.1` OR `foo=1.0.0` are activated".
-    //
-    // Another example after several backtracks we may have:
-    //
-    //  past_conflicting_activations[`foo = ">=0.8.2, <=0.9.3"`] = vec![
-    //      map!{`foo=0.8.1`: Semver, `foo=0.9.4`: Semver},
-    //  ];
-    //
-    // This can be read as "we cannot find a candidate for dep `foo = ">=0.8.2,
-    // <=0.9.3"` if both `foo=0.8.1` AND `foo=0.9.4` are activated".
-    //
-    // This is used to make sure we don't queue work we know will fail. See the
-    // discussion in https://github.com/rust-lang/cargo/pull/5168 for why this
-    // is so important, and there can probably be a better data structure here
-    // but for now this works well enough!
-    //
-    // Also, as a final note, this map is *not* ever removed from. This remains
-    // as a global cache which we never delete from. Any entry in this map is
-    // unconditionally true regardless of our resolution history of how we got
-    // here.
-    let mut past_conflicting_activations: HashMap<
-        Dependency,
-        Vec<HashMap<PackageId, ConflictReason>>,
-    > = HashMap::new();
-
-    // `past_conflict_triggers` is an inverse-index of `past_conflicting_activations`.
-    // For every `PackageId` this lists the `Dependency`s that mention it in `past_conflicting_activations`.
-    let mut past_conflict_triggers: HashMap<PackageId, HashSet<Dependency>> = HashMap::new();
+    // backtrack.
+    let mut past_conflicting_activations = conflict_cache::ConflictCache::new();
 
     // Activate all the initial summaries to kick off some work.
     for &(ref summary, ref method) in summaries {
@@ -1100,12 +1076,7 @@ fn activate_deps_loop(
 
         let just_here_for_the_error_messages = just_here_for_the_error_messages
             && past_conflicting_activations
-                .get(&dep)
-                .and_then(|past_bad| {
-                    past_bad
-                        .iter()
-                        .find(|conflicting| cx.is_conflicting(None, conflicting))
-                })
+                .conflicting(&cx, &dep)
                 .is_some();
 
         let mut remaining_candidates = RemainingCandidates::new(&candidates);
@@ -1157,25 +1128,7 @@ fn activate_deps_loop(
                 // local is set to `true` then our `conflicting_activations` may
                 // not be right, so we can't push into our global cache.
                 if !just_here_for_the_error_messages && !backtracked {
-                    let past = past_conflicting_activations
-                        .entry(dep.clone())
-                        .or_insert_with(Vec::new);
-                    if !past.contains(&conflicting_activations) {
-                        trace!(
-                            "{}[{}]>{} adding a skip {:?}",
-                            parent.name(),
-                            cur,
-                            dep.name(),
-                            conflicting_activations
-                        );
-                        past.push(conflicting_activations.clone());
-                        for c in conflicting_activations.keys() {
-                            past_conflict_triggers
-                                .entry(c.clone())
-                                .or_insert_with(HashSet::new)
-                                .insert(dep.clone());
-                        }
-                    }
+                    past_conflicting_activations.insert(&dep, &conflicting_activations);
                 }
 
                 match find_candidate(&mut backtrack_stack, &parent, &conflicting_activations) {
@@ -1280,11 +1233,10 @@ fn activate_deps_loop(
                         if let Some(conflicting) = frame
                             .remaining_siblings
                             .clone()
-                            .filter_map(|(_, (new_dep, _, _))| {
-                                past_conflicting_activations.get(&new_dep)
+                            .filter_map(|(_, (ref new_dep, _, _))| {
+                                past_conflicting_activations.conflicting(&cx, &new_dep)
                             })
-                            .flat_map(|x| x)
-                            .find(|con| cx.is_conflicting(None, con))
+                            .next()
                         {
                             let mut conflicting = conflicting.clone();
 
@@ -1309,33 +1261,23 @@ fn activate_deps_loop(
                     // ourselves are incompatible with that dep, so we know that deps
                     // parent conflict with us.
                     if !has_past_conflicting_dep {
-                        if let Some(rel_deps) = past_conflict_triggers.get(&pid) {
+                        if let Some(rel_deps) = past_conflicting_activations.get_dep_from_pid(&pid)
+                        {
                             if let Some((other_parent, conflict)) = remaining_deps
                                 .iter()
-                                .flat_map(|other| {
-                                    other
-                                        .remaining_siblings
-                                        // search thru all `remaining_deps`
-                                        .clone()
-                                        // for deps related to us
-                                        .filter(|&(_, (ref d, _, _))| rel_deps.contains(d))
-                                        .map(move |(_, (d, _, _))| {
-                                            (other.parent.package_id().clone(), d)
-                                        })
-                                })
-                                .filter_map(|(other_parent, other_deps)| {
+                                .flat_map(|other| other.flatten())
+                                // for deps related to us
+                                .filter(|&(_, ref other_dep)| rel_deps.contains(other_dep))
+                                .filter_map(|(other_parent, other_dep)| {
                                     past_conflicting_activations
-                                        .get(&other_deps)
-                                        .map(|v| (other_parent, v))
+                                        .filter_conflicting(
+                                            &cx,
+                                            &other_dep,
+                                            |con| con.contains_key(&pid)
+                                        )
+                                        .map(|con| (other_parent, con))
                                 })
-                                .flat_map(|(other_parent, past_bad)| {
-                                    past_bad
-                                        .iter()
-                                        // for deps that refer to us
-                                        .filter(|con| con.contains_key(&pid))
-                                        .map(move |c| (other_parent.clone(), c))
-                                })
-                                .find(|&(_, ref con)| cx.is_conflicting(None, con))
+                                .next()
                             {
                                 let mut conflict = conflict.clone();
                                 let rel = conflict.get(&pid).unwrap().clone();

--- a/src/cargo/core/resolver/mod.rs
+++ b/src/cargo/core/resolver/mod.rs
@@ -1307,10 +1307,12 @@ fn activate_deps_loop(
                                                         && cx.is_conflicting(None, con)
                                                 })
                                             }) {
-                                            conflicting_activations.insert(
-                                                debs.parent.package_id().clone(),
-                                                conflict.get(&pid).unwrap().clone(),
-                                            );
+                                            let mut conflict = conflict.clone();
+                                            let rel = conflict.get(&pid).unwrap().clone();
+                                            conflict.insert(debs.parent.package_id().clone(), rel);
+                                            conflict.remove(&pid);
+
+                                            conflicting_activations.extend(conflict);
                                             has_past_conflicting_dep = true;
                                             break 'deps;
                                         }

--- a/src/cargo/core/resolver/mod.rs
+++ b/src/cargo/core/resolver/mod.rs
@@ -1276,11 +1276,15 @@ fn activate_deps_loop(
                             .flat_map(|x| x)
                             .find(|con| cx.is_conflicting(None, con))
                         {
-                            conflicting_activations.extend(conflicting.clone());
+                            let mut conflicting = conflicting.clone();
+                            conflicting.remove(&pid);
+
+                            conflicting_activations.extend(conflicting);
                             has_past_conflicting_dep = true;
                         }
                     }
                     if !has_past_conflicting_dep {
+                        // TODO: this is ugly and slow, replace!
                         'deps: for debs in remaining_deps.iter() {
                             for (_, (other_dep, _, _)) in debs.remaining_siblings.clone() {
                                 if let Some(conflict) = past_conflicting_activations

--- a/src/cargo/core/resolver/mod.rs
+++ b/src/cargo/core/resolver/mod.rs
@@ -1280,6 +1280,26 @@ fn activate_deps_loop(
                             has_past_conflicting_dep = true;
                         }
                     }
+                    if !has_past_conflicting_dep {
+                        'deps: for debs in remaining_deps.iter() {
+                            for (_, (other_dep, _, _)) in debs.remaining_siblings.clone() {
+                                if let Some(conflict) = past_conflicting_activations
+                                    .get(&other_dep)
+                                    .and_then(|past_bad| {
+                                        past_bad
+                                            .iter()
+                                            .find(|conflicting| conflicting.get(&pid).is_some())
+                                    }) {
+                                    conflicting_activations.insert(
+                                        debs.parent.package_id().clone(),
+                                        conflict.get(&pid).unwrap().clone(),
+                                    );
+                                    has_past_conflicting_dep = true;
+                                    break 'deps;
+                                }
+                            }
+                        }
+                    }
 
                     // Ok if we're in a "known failure" state for this frame we
                     // may want to skip it altogether though. We don't want to

--- a/tests/testsuite/resolve.rs
+++ b/tests/testsuite/resolve.rs
@@ -758,6 +758,55 @@ fn resolving_with_deep_traps() {
 }
 
 #[test]
+fn resolving_with_constrained_cousins_backtrack_s1() {
+    // ToDo: Remove when the longer version below passes! DON'T merge
+    let mut reglist = Vec::new();
+
+    const DEPTH: usize = 200;
+    const BRANCHING_FACTOR: usize = 100;
+
+    // Each backtrack_trap depends on the next.
+    // The last depends on a specific ver of constrained.
+    for l in 0..DEPTH {
+        let name = format!("backtrack_trap{}", l);
+        let next = format!("backtrack_trap{}", l + 1);
+        for i in 1..BRANCHING_FACTOR {
+            let vsn = format!("1.0.{}", i);
+            reglist.push(pkg!((name.as_str(), vsn.as_str()) => [dep_req(next.as_str(), "*")]));
+        }
+    }
+    {
+        let name = format!("backtrack_trap{}", DEPTH);
+        for i in 1..BRANCHING_FACTOR {
+            let vsn = format!("1.0.{}", i);
+            reglist.push(pkg!((name.as_str(), vsn.as_str()) => [dep_req("constrained", "=1.0.0")]));
+        }
+    }
+    {
+        // slightly less constrained to make sure `constrained` gets picked last.
+        for i in 0..(BRANCHING_FACTOR + 10) {
+            let vsn = format!("1.0.{}", i);
+            reglist.push(pkg!(("constrained", vsn.as_str())));
+        }
+    }
+
+    let reg = registry(reglist.clone());
+
+    // `backtrack_trap0 = "*"` is a lot of ways of saying `constrained = "=1.0.0"`
+    // Only then to try and solve `constrained= "1.0.1"` which is incompatible.
+    let res = resolve(
+        &pkg_id("root"),
+        vec![
+            dep_req("backtrack_trap0", "*"),
+            dep_req("constrained", "1.0.1"),
+        ],
+        &reg,
+    );
+
+    assert!(res.is_err());
+}
+
+#[test]
 fn resolving_with_constrained_cousins_backtrack() {
     let mut reglist = Vec::new();
 
@@ -798,6 +847,33 @@ fn resolving_with_constrained_cousins_backtrack() {
         vec![
             dep_req("backtrack_trap0", "*"),
             dep_req("constrained", "1.0.1"),
+        ],
+        &reg,
+    );
+
+    assert!(res.is_err());
+
+    // Each level depends on the next but the last depends on incompatible deps.
+    // Let's make sure that we can cache that a dep has incompatible deps.
+    for l in 0..DEPTH {
+        let name = format!("level{}", l);
+        let next = format!("level{}", l + 1);
+        for i in 1..BRANCHING_FACTOR {
+            let vsn = format!("1.0.{}", i);
+            reglist.push(pkg!((name.as_str(), vsn.as_str()) => [dep_req(next.as_str(), "*")]));
+        }
+    }
+    reglist.push(pkg!((format!("level{}", DEPTH).as_str(), "1.0.0") => [dep_req("backtrack_trap0", "*"),
+            dep_req("constrained", "1.0.1")]));
+
+    let reg = registry(reglist.clone());
+
+    // `backtrack_trap0 = "*"` is a lot of ways of saying `constrained = "=1.0.0"`
+    // Only then to try and solve `constrained= "1.0.1"` which is incompatible.
+    let res = resolve(
+        &pkg_id("root"),
+        vec![
+            dep_req("level0", "*"),
         ],
         &reg,
     );

--- a/tests/testsuite/resolve.rs
+++ b/tests/testsuite/resolve.rs
@@ -758,60 +758,11 @@ fn resolving_with_deep_traps() {
 }
 
 #[test]
-fn resolving_with_constrained_cousins_backtrack_s1() {
-    // ToDo: Remove when the longer version below passes! DON'T merge
-    let mut reglist = Vec::new();
-
-    const DEPTH: usize = 200;
-    const BRANCHING_FACTOR: usize = 100;
-
-    // Each backtrack_trap depends on the next.
-    // The last depends on a specific ver of constrained.
-    for l in 0..DEPTH {
-        let name = format!("backtrack_trap{}", l);
-        let next = format!("backtrack_trap{}", l + 1);
-        for i in 1..BRANCHING_FACTOR {
-            let vsn = format!("1.0.{}", i);
-            reglist.push(pkg!((name.as_str(), vsn.as_str()) => [dep_req(next.as_str(), "*")]));
-        }
-    }
-    {
-        let name = format!("backtrack_trap{}", DEPTH);
-        for i in 1..BRANCHING_FACTOR {
-            let vsn = format!("1.0.{}", i);
-            reglist.push(pkg!((name.as_str(), vsn.as_str()) => [dep_req("constrained", "=1.0.0")]));
-        }
-    }
-    {
-        // slightly less constrained to make sure `constrained` gets picked last.
-        for i in 0..(BRANCHING_FACTOR + 10) {
-            let vsn = format!("1.0.{}", i);
-            reglist.push(pkg!(("constrained", vsn.as_str())));
-        }
-    }
-
-    let reg = registry(reglist.clone());
-
-    // `backtrack_trap0 = "*"` is a lot of ways of saying `constrained = "=1.0.0"`
-    // Only then to try and solve `constrained= "1.0.1"` which is incompatible.
-    let res = resolve(
-        &pkg_id("root"),
-        vec![
-            dep_req("backtrack_trap0", "*"),
-            dep_req("constrained", "1.0.1"),
-        ],
-        &reg,
-    );
-
-    assert!(res.is_err());
-}
-
-#[test]
 fn resolving_with_constrained_cousins_backtrack() {
     let mut reglist = Vec::new();
 
-    const DEPTH: usize = 200;
-    const BRANCHING_FACTOR: usize = 100;
+    const DEPTH: usize = 100;
+    const BRANCHING_FACTOR: usize = 50;
 
     // Each backtrack_trap depends on the next.
     // The last depends on a specific ver of constrained.
@@ -827,7 +778,9 @@ fn resolving_with_constrained_cousins_backtrack() {
         let name = format!("backtrack_trap{}", DEPTH);
         for i in 1..BRANCHING_FACTOR {
             let vsn = format!("1.0.{}", i);
-            reglist.push(pkg!((name.as_str(), vsn.as_str()) => [dep_req("constrained", "=1.0.0")]));
+            reglist.push(
+                pkg!((name.as_str(), vsn.as_str()) => [dep_req("constrained", ">=1.1.0, <=2.0.0")]),
+            );
         }
     }
     {
@@ -836,17 +789,23 @@ fn resolving_with_constrained_cousins_backtrack() {
             let vsn = format!("1.0.{}", i);
             reglist.push(pkg!(("constrained", vsn.as_str())));
         }
+        reglist.push(pkg!(("constrained", "1.1.0")));
+        reglist.push(pkg!(("constrained", "2.0.0")));
+        reglist.push(pkg!(("constrained", "2.0.1")));
     }
+    reglist.push(pkg!(("cloaking", "1.0.0") => [dep_req("constrained", "~1.0.0")]));
 
     let reg = registry(reglist.clone());
 
-    // `backtrack_trap0 = "*"` is a lot of ways of saying `constrained = "=1.0.0"`
-    // Only then to try and solve `constrained= "1.0.1"` which is incompatible.
+    // `backtrack_trap0 = "*"` is a lot of ways of saying `constrained = ">=1.1.0, <=2.0.0"`
+    // but `constrained= "2.0.1"` is already picked.
+    // Only then to try and solve `constrained= "~1.0.0"` which is incompatible.
     let res = resolve(
         &pkg_id("root"),
         vec![
             dep_req("backtrack_trap0", "*"),
-            dep_req("constrained", "1.0.1"),
+            dep_req("constrained", "2.0.1"),
+            dep_req("cloaking", "*"),
         ],
         &reg,
     );
@@ -863,22 +822,32 @@ fn resolving_with_constrained_cousins_backtrack() {
             reglist.push(pkg!((name.as_str(), vsn.as_str()) => [dep_req(next.as_str(), "*")]));
         }
     }
-    reglist.push(pkg!((format!("level{}", DEPTH).as_str(), "1.0.0") => [dep_req("backtrack_trap0", "*"),
-            dep_req("constrained", "1.0.1")]));
+    reglist.push(
+        pkg!((format!("level{}", DEPTH).as_str(), "1.0.0") => [dep_req("backtrack_trap0", "*"),
+            dep_req("cloaking", "*")
+            ]),
+    );
 
     let reg = registry(reglist.clone());
 
-    // `backtrack_trap0 = "*"` is a lot of ways of saying `constrained = "=1.0.0"`
-    // Only then to try and solve `constrained= "1.0.1"` which is incompatible.
     let res = resolve(
         &pkg_id("root"),
-        vec![
-            dep_req("level0", "*"),
-        ],
+        vec![dep_req("level0", "*"), dep_req("constrained", "2.0.1")],
         &reg,
     );
 
     assert!(res.is_err());
+
+    let res = resolve(
+        &pkg_id("root"),
+        vec![dep_req("level0", "*"), dep_req("constrained", "2.0.0")],
+        &reg,
+    ).unwrap();
+
+    assert_that(
+        &res,
+        contains(names(&[("constrained", "2.0.0"), ("cloaking", "1.0.0")])),
+    );
 }
 
 #[test]

--- a/tests/testsuite/resolve.rs
+++ b/tests/testsuite/resolve.rs
@@ -825,7 +825,7 @@ fn resolving_with_constrained_cousins_backtrack() {
     reglist.push(
         pkg!((format!("level{}", DEPTH).as_str(), "1.0.0") => [dep_req("backtrack_trap0", "*"),
             dep_req("cloaking", "*")
-            ]),
+        ]),
     );
 
     let reg = registry(reglist.clone());


### PR DESCRIPTION
This adds a test for https://github.com/rust-lang/cargo/issues/4810#issuecomment-357553286 with two extensions that make it harder. It is the last reproducible and in the wild exponentially slow resolution (that I have found).

The problem in the test is `backtrack_trap0 = "*"` is a lot of ways of saying `constrained = ">=1.1.0, <=2.0.0"` but `constrained= "2.0.1"` is already picked. Only then to try and solve `constrained= "~1.0.0"` which is incompatible. Our parent knows that we have been poisoned, and wont try to activate us again.  Because of the order we evaluate deps we end up backtracking to where `constrained: 1.1.0` is set instead of our parent. And so the poisoning does not help. This is harder then https://github.com/rust-lang/cargo/issues/4810#issuecomment-357553286 because:

1. Having multiple semver compatible versions of constrained in play makes for a lot more bookkeeping. Specifically bookkeeping I forgot when I first submitted this PR.
2. The problematic dependencies are added deep in a combinatorial explosion of possibilities. So if we don't correctly handle caching that `backtrack_trap0 = "*"` is doomed then we will never finish looking thru the different possibilities for `level0 = "*"`

This PR also includes a proof of concept solution for the test, which proves that it does solve https://github.com/rust-lang/cargo/issues/4810#issuecomment-357553286. The added code is tricky to read. It also adds a `O(remaining_deps)` job to every activation on the happy path, slower if the `past_conflicting_activations` is not empty.

I'd like some brainstorming on better solutions.