### PR TITLE
Preprobe info for known crate type

### DIFF
--- a/src/cargo/ops/cargo_clean.rs
+++ b/src/cargo/ops/cargo_clean.rs
@@ -96,7 +96,7 @@ pub fn clean(ws: &Workspace, opts: &CleanOptions) -> CargoResult<()> {
         }
     }
 
-    cx.probe_target_info(&units)?;
+    cx.probe_target_info()?;
 
     for unit in units.iter() {
         rm_rf(&cx.fingerprint_dir(unit), config)?;

--- a/src/cargo/ops/cargo_rustc/mod.rs
+++ b/src/cargo/ops/cargo_rustc/mod.rs
@@ -169,7 +169,7 @@ pub fn compile_targets<'a, 'cfg: 'a>(
     let mut queue = JobQueue::new(&cx);
 
     cx.prepare()?;
-    cx.probe_target_info(&units)?;
+    cx.probe_target_info()?;
     cx.build_used_in_plugin_map(&units)?;
     custom_build::build_map(&mut cx, &units)?;
 

--- a/tests/testsuite/bad_config.rs
+++ b/tests/testsuite/bad_config.rs
@@ -529,7 +529,7 @@ fn bad_crate_type() {
     assert_that(
         p.cargo("build").arg("-v"),
         execs().with_status(101).with_stderr_contains(
-            "error: failed to run `rustc` to learn about target-specific information",
+            "error: failed to run `rustc` to learn about crate-type bad_type information",
         ),
     );
 }


### PR DESCRIPTION
Previously, we've calculated the set of crate types to learn about by
recursively walking the graph of units. However, to actually know
dependencies of a unit exactly, we must know target specific info, and
we don't know it at this moment (in fact, we are trying calculating it).

Note that crate-type calculation is already lazy, we don't have to calc
all crate-types upfront. So, let's just scrape this info once for
well-known crate types, and fill whatever is left lazily.


@alexcrichton would this approach work at all? I think it would, if `KNOWN_CRATE_TYPES` are all available for all target-tripples we support. Is it a valid assumption? 

The larger picture is that I am trying to make unit dependency resolution eager and move it into the separate file. I even got something working, but I have to run dependency resolution three times, because it is not exactly idempotent for various reasons, including this target-info stuff :) 

```
    cx.prepare()?;
    cx.build_unit_map(units.clone())?; // resolve dependencies
    cx.probe_target_info(&units)?;
    cx.build_unit_map(units.clone())?; // resolve again
    cx.build_used_in_plugin_map(&units)?;
    custom_build::build_map(&mut cx, &units)?;
    cx.build_unit_map(units.clone())?; // and resolve one final time :) 
```