### PR TITLE
Add support for absolute target.json paths

### DIFF
--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -24,7 +24,7 @@
 
 use std::collections::{HashMap, HashSet};
 use std::default::Default;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use core::{Package, Source, Target};
@@ -32,7 +32,7 @@ use core::{PackageId, PackageIdSpec, Profile, Profiles, TargetKind, Workspace};
 use core::resolver::{Method, Resolve};
 use ops::{self, BuildOutput, DefaultExecutor, Executor};
 use util::config::Config;
-use util::{profile, CargoResult};
+use util::{profile, CargoResult, CargoResultExt};
 
 /// Contains information about how a package should be compiled.
 #[derive(Debug)]
@@ -235,7 +235,17 @@ pub fn compile_ws<'a>(
         ref target_rustc_args,
     } = *options;
 
-    let target = target.clone();
+    let target = match target {
+        &Some(ref target) if target.ends_with(".json") => {
+            let path = Path::new(target)
+                .canonicalize()
+                .chain_err(|| format_err!("Target path {:?} is not a valid file", target))?;
+            Some(path.into_os_string()
+                .into_string()
+                .map_err(|_| format_err!("Target path is not valid unicode"))?)
+        }
+        other => other.clone(),
+    };
 
     if jobs == Some(0) {
         bail!("jobs must be at least 1")

--- a/tests/testsuite/main.rs
+++ b/tests/testsuite/main.rs
@@ -43,6 +43,7 @@ mod config;
 mod corrupt_git;
 mod cross_compile;
 mod cross_publish;
+mod custom_target;
 mod death;
 mod dep_info;
 mod directory;


### PR DESCRIPTION
Builds upon https://github.com/rust-lang/rust/pull/49019 with the goal to provide a solution to https://github.com/rust-lang/cargo/issues/4905.

This PR does two things:

~~1. It appends a hash of the target path to the target folder name if a `*.json` path is passed as `--target`, like it's done in https://github.com/rust-lang/rust/pull/49019. This helps differentiating targets with the same JSON file name and avoids sysroot clashes in `xargo`.~~ See https://github.com/rust-lang/cargo/pull/5228#discussion_r176827531
2. It canonicalizes the passed target path (if it's a `*.json` path), so that the path stays valid when building dependencies and setting the `RUST_TARGET_PATH` environment variable is no longer necessary.