### PR TITLE
add final linebreak to cargo default help message.

### DIFF
--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -134,7 +134,7 @@ Some common cargo commands are (see all commands with --list):
     install     Install a Rust binary
     uninstall   Uninstall a Rust binary
 
-See 'cargo help <command>' for more information on a specific command.",
+See 'cargo help <command>' for more information on a specific command.\n",
         )
         .arg(opt("version", "Print version info and exit").short("V"))
         .arg(opt("list", "List installed commands"))


### PR DESCRIPTION
before:
![cargo_before](https://user-images.githubusercontent.com/476013/37807125-16809ec8-2e44-11e8-9606-f37c1a97caf2.png)
patch: 
![cargo_after](https://user-images.githubusercontent.com/476013/37807134-227b658c-2e44-11e8-8f4b-d430414e69dc.png)

I assume this is some kind of leftover from the clap transition. cc @matklad 