### PR TITLE
Assert Dependency::name is never empty, prevent 'install ""' from crashing

### DIFF
--- a/src/bin/commands/install.rs
+++ b/src/bin/commands/install.rs
@@ -7,7 +7,7 @@ use cargo::util::ToUrl;
 pub fn cli() -> App {
     subcommand("install")
         .about("Install a Rust binary")
-        .arg(Arg::with_name("crate").multiple(true))
+        .arg(Arg::with_name("crate").empty_values(false).multiple(true))
         .arg(
             opt("version", "Specify a version to install from crates.io")
                 .alias("vers")

--- a/src/cargo/core/dependency.rs
+++ b/src/cargo/core/dependency.rs
@@ -185,6 +185,7 @@ impl Dependency {
     }
 
     pub fn new_override(name: &str, source_id: &SourceId) -> Dependency {
+        assert!(name.len() > 0);
         Dependency {
             inner: Rc::new(Inner {
                 name: InternedString::new(name),

--- a/tests/testsuite/install.rs
+++ b/tests/testsuite/install.rs
@@ -1476,3 +1476,14 @@ dependencies = [
 
     assert_that(cargo_process("install").arg("foo"), execs().with_status(0));
 }
+
+#[test]
+fn install_empty_argument() {
+    // Bug 5229
+    assert_that(
+        cargo_process("install").arg(""),
+        execs().with_status(1).with_stderr_contains(
+            "[ERROR] The argument '<crate>...' requires a value but none was supplied",
+        ),
+    );
+}

--- a/tests/testsuite/resolve.rs
+++ b/tests/testsuite/resolve.rs
@@ -173,6 +173,13 @@ fn loc_names(names: &[(&'static str, &'static str)]) -> Vec<PackageId> {
 }
 
 #[test]
+#[should_panic(expected = "assertion failed: name.len() > 0")]
+fn test_dependency_with_empty_name() {
+    // Bug 5229, dependency-names must not be empty
+    "".to_dep();
+}
+
+#[test]
 fn test_resolving_empty_dependency_list() {
     let res = resolve(&pkg_id("root"), Vec::new(), &registry(vec![])).unwrap();
 


### PR DESCRIPTION
An explicit `cargo install ""` would cause clap to pass an empty crate-name,
leading to a panic(). We now assert() that Dependency::name is never the
empty string and prevent the situation in the first place by not allowing
the crate-name to be empty for `install`.

Fixes #5229