### PR TITLE
docs(Z-flags): Add description for each -Z flag in cargo help

### DIFF
--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -16,12 +16,11 @@ pub fn main(config: &mut Config) -> CliResult {
             "
 Available unstable (nightly-only) flags:
 
-    -Z avoid-dev-deps    -- Avoid installing dev-dependencies if possible
-    -Z minimal-versions  -- Install minimal dependency versions instead of maximum
-    -Z no-index-update   -- Do not update the registry, avoids a network request for benchmarking
-    -Z offline           -- Offline mode that does not perform network requests
-    -Z print-im-a-teapot -- Example option for demonstration purposes
-    -Z unstable-options  -- Allow the usage of unstable options such as --registry
+    -Z avoid-dev-deps   -- Avoid installing dev-dependencies if possible
+    -Z minimal-versions -- Install minimal dependency versions instead of maximum
+    -Z no-index-update  -- Do not update the registry, avoids a network request for benchmarking
+    -Z offline          -- Offline mode that does not perform network requests
+    -Z unstable-options -- Allow the usage of unstable options such as --registry
 
 Run with 'cargo -Z [FLAG] [SUBCOMMAND]'"
         );

--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -10,6 +10,24 @@ use command_prelude::*;
 
 pub fn main(config: &mut Config) -> CliResult {
     let args = cli().get_matches_safe()?;
+
+    if args.value_of("unstable-features") == Some("help") {
+        println!(
+            "
+Available unstable (nightly-only) flags:
+
+    -Z avoid-dev-deps    -- Avoid installing dev-dependencies if possible
+    -Z minimal-versions  -- Install minimal dependency versions instead of maximum
+    -Z no-index-update   -- Do not update the registry, avoids a network request for benchmarking
+    -Z offline           -- Offline mode that does not perform network requests
+    -Z print-im-a-teapot -- Example option for demonstration purposes
+    -Z unstable-options  -- Allow the usage of unstable options such as --registry
+
+Run with 'cargo -Z [FLAG] [SUBCOMMAND]'"
+        );
+        return Ok(());
+    }
+
     let is_verbose = args.occurrences_of("verbose") > 0;
     if args.is_present("version") {
         let version = cargo::version();
@@ -161,7 +179,7 @@ See 'cargo help <command>' for more information on a specific command.\n",
         .arg(opt("locked", "Require Cargo.lock is up to date").global(true))
         .arg(
             Arg::with_name("unstable-features")
-                .help("Unstable (nightly-only) flags to Cargo")
+                .help("Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details")
                 .short("Z")
                 .value_name("FLAG")
                 .multiple(true)

--- a/tests/testsuite/cargo_command.rs
+++ b/tests/testsuite/cargo_command.rs
@@ -338,8 +338,8 @@ fn explain() {
 fn z_flags_help() {
     assert_that(
         cargo_process().arg("-Z").arg("help"),
-        execs()
-            .with_status(0)
-            .with_stdout_contains("-Z unstable-options"),
+        execs().with_status(0).with_stdout_contains(
+            "    -Z unstable-options -- Allow the usage of unstable options such as --registry",
+        ),
     );
 }

--- a/tests/testsuite/cargo_command.rs
+++ b/tests/testsuite/cargo_command.rs
@@ -331,3 +331,15 @@ fn explain() {
         ),
     );
 }
+
+// Test that the output of 'cargo -Z help' shows a different help screen with
+// all the -Z flags.
+#[test]
+fn z_flags_help() {
+    assert_that(
+        cargo_process().arg("-Z").arg("help"),
+        execs()
+            .with_status(0)
+            .with_stdout_contains("-Z unstable-options"),
+    );
+}


### PR DESCRIPTION
Fixes #5155 

There might be a more elaborate way of adding descriptions to available options and generating help text automatically. For now I think some static text is a good start.