### PR TITLE
Prepare to align Cargo and Rust version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo"
-version = "0.27.0"
+version = "0.27.5" # Bump to "0.28.0" next time and fix `cargo::version`
 authors = ["Yehuda Katz <wycats@gmail.com>",
            "Carl Lerche <me@carllerche.com>",
            "Alex Crichton <alex@alexcrichton.com>"]

--- a/src/cargo/lib.rs
+++ b/src/cargo/lib.rs
@@ -206,8 +206,8 @@ pub fn version() -> VersionInfo {
     // We continue to use this scheme for the library, but transform it to 1.x.w for the purposes
     // of `cargo --version`.
     let major = 1;
-    let minor = env!("CARGO_PKG_VERSION_MINOR").parse::<u8>().unwrap() - 1;
-    let patch = env!("CARGO_PKG_VERSION_PATCH").parse::<u8>().unwrap();
+    let minor = env!("CARGO_PKG_VERSION_MINOR").parse::<u8>().unwrap();
+    let patch = env!("CARGO_PKG_VERSION_PATCH").parse::<u8>().unwrap() - 5;
 
     match option_env!("CFG_RELEASE_CHANNEL") {
         // We have environment variables set up from configure/make.


### PR DESCRIPTION
We'll be bumping Cargo version soon, right? Let's bump it half-way perhaps, so that we'll have Rust 1.28.0 and Cargo 0.28.0 in the future? 