### PR TITLE
Supply units to the context at the point of creation

### DIFF
--- a/src/cargo/ops/cargo_clean.rs
+++ b/src/cargo/ops/cargo_clean.rs
@@ -37,20 +37,6 @@ pub fn clean(ws: &Workspace, opts: &CleanOptions) -> CargoResult<()> {
 
     let profiles = ws.profiles();
     let host_triple = opts.config.rustc()?.host.clone();
-    let mut cx = Context::new(
-        ws,
-        &resolve,
-        &packages,
-        opts.config,
-        BuildConfig {
-            host_triple,
-            requested_target: opts.target.clone(),
-            release: opts.release,
-            jobs: 1,
-            ..BuildConfig::default()
-        },
-        profiles,
-    )?;
     let mut units = Vec::new();
 
     for spec in opts.spec.iter() {
@@ -99,8 +85,21 @@ pub fn clean(ws: &Workspace, opts: &CleanOptions) -> CargoResult<()> {
         }
     }
 
-    cx.probe_target_info()?;
-    cx.build_unit_dependencies(&units)?;
+    let mut cx = Context::new(
+        ws,
+        &resolve,
+        &packages,
+        opts.config,
+        BuildConfig {
+            host_triple,
+            requested_target: opts.target.clone(),
+            release: opts.release,
+            jobs: 1,
+            ..BuildConfig::default()
+        },
+        profiles,
+        &units,
+    )?;
 
     for unit in units.iter() {
         rm_rf(&cx.fingerprint_dir(unit), config)?;

--- a/src/cargo/ops/cargo_rustc/mod.rs
+++ b/src/cargo/ops/cargo_rustc/mod.rs
@@ -164,13 +164,19 @@ pub fn compile_targets<'a, 'cfg: 'a>(
         })
         .collect::<Vec<_>>();
 
-    let mut cx = Context::new(ws, resolve, packages, config, build_config, profiles)?;
+    let mut cx = Context::new(
+        ws,
+        resolve,
+        packages,
+        config,
+        build_config,
+        profiles,
+        &units,
+    )?;
 
     let mut queue = JobQueue::new(&cx);
 
     cx.prepare()?;
-    cx.probe_target_info()?;
-    cx.build_unit_dependencies(&units)?;
     cx.build_used_in_plugin_map(&units)?;
     custom_build::build_map(&mut cx, &units)?;
 


### PR DESCRIPTION
This slightly reshuffles `Context` creation. The main benefit is that we know the set of units when we do `Context::new`, so we could use it to precalculate more things.