### PR TITLE
cargo_new: remove redundant leading new lines from ignore files

### DIFF
--- a/src/cargo/ops/cargo_new.rs
+++ b/src/cargo/ops/cargo_new.rs
@@ -420,7 +420,6 @@ fn mk(config: &Config, opts: &MkOptions) -> CargoResult<()> {
     let cfg = global_config(config)?;
     // Please ensure that ignore and hgignore are in sync.
     let ignore = [
-        "\n",
         "/target\n",
         "**/*.rs.bk\n",
         if !opts.bin { "Cargo.lock\n" } else { "" },
@@ -429,7 +428,6 @@ fn mk(config: &Config, opts: &MkOptions) -> CargoResult<()> {
     // file will exclude too much. Instead, use regexp-based ignores. See 'hg help ignore' for
     // more.
     let hgignore = [
-        "\n",
         "^target/\n",
         "glob:*.rs.bk\n",
         if !opts.bin { "glob:Cargo.lock\n" } else { "" },
@@ -449,18 +447,30 @@ fn mk(config: &Config, opts: &MkOptions) -> CargoResult<()> {
             if !fs::metadata(&path.join(".git")).is_ok() {
                 GitRepo::init(path, config.cwd())?;
             }
+            let ignore = match fs::metadata(&path.join(".gitignore")) {
+                Ok(_) => format!("\n{}", ignore),
+                _ => ignore,
+            };
             paths::append(&path.join(".gitignore"), ignore.as_bytes())?;
         }
         VersionControl::Hg => {
             if !fs::metadata(&path.join(".hg")).is_ok() {
                 HgRepo::init(path, config.cwd())?;
             }
+            let hgignore = match fs::metadata(&path.join(".hgignore")) {
+                Ok(_) => format!("\n{}", hgignore),
+                _ => hgignore,
+            };
             paths::append(&path.join(".hgignore"), hgignore.as_bytes())?;
         }
         VersionControl::Pijul => {
             if !fs::metadata(&path.join(".pijul")).is_ok() {
                 PijulRepo::init(path, config.cwd())?;
             }
+            let ignore = match fs::metadata(&path.join(".ignore")) {
+                Ok(_) => format!("\n{}", ignore),
+                _ => ignore,
+            };
             paths::append(&path.join(".ignore"), ignore.as_bytes())?;
         }
         VersionControl::Fossil => {

--- a/tests/testsuite/init.rs
+++ b/tests/testsuite/init.rs
@@ -437,7 +437,7 @@ fn gitignore_appended_not_replaced() {
 }
 
 #[test]
-fn gitignore_added_newline_if_required() {
+fn gitignore_added_newline_in_existing() {
     fs::create_dir(&paths::root().join(".git")).unwrap();
 
     File::create(&paths::root().join(".gitignore"))
@@ -461,7 +461,26 @@ fn gitignore_added_newline_if_required() {
 }
 
 #[test]
-fn mercurial_added_newline_if_required() {
+fn gitignore_no_newline_in_new() {
+    fs::create_dir(&paths::root().join(".git")).unwrap();
+
+    assert_that(
+        cargo_process("init").arg("--lib").env("USER", "foo"),
+        execs().with_status(0),
+    );
+
+    assert_that(&paths::root().join(".gitignore"), existing_file());
+
+    let mut contents = String::new();
+    File::open(&paths::root().join(".gitignore"))
+        .unwrap()
+        .read_to_string(&mut contents)
+        .unwrap();
+    assert!(!contents.starts_with("\n"));
+}
+
+#[test]
+fn mercurial_added_newline_in_existing() {
     fs::create_dir(&paths::root().join(".hg")).unwrap();
 
     File::create(&paths::root().join(".hgignore"))
@@ -482,6 +501,25 @@ fn mercurial_added_newline_if_required() {
         .read_to_string(&mut contents)
         .unwrap();
     assert!(contents.starts_with("first\n"));
+}
+
+#[test]
+fn mercurial_no_newline_in_new() {
+    fs::create_dir(&paths::root().join(".hg")).unwrap();
+
+    assert_that(
+        cargo_process("init").arg("--lib").env("USER", "foo"),
+        execs().with_status(0),
+    );
+
+    assert_that(&paths::root().join(".hgignore"), existing_file());
+
+    let mut contents = String::new();
+    File::open(&paths::root().join(".hgignore"))
+        .unwrap()
+        .read_to_string(&mut contents)
+        .unwrap();
+    assert!(!contents.starts_with("\n"));
 }
 
 #[test]


### PR DESCRIPTION
Only add a leading new line in `.gitignore`/`.hgignore`/`.ignore` files when
the file existed before `cargo new`.

Fixes #5265.