### PR TITLE
Introduce FeatureValue type to represent features table values

### DIFF
--- a/src/cargo/core/interning.rs
+++ b/src/cargo/core/interning.rs
@@ -1,3 +1,5 @@
+use serde::{Serialize, Serializer};
+
 use std::fmt;
 use std::sync::RwLock;
 use std::collections::HashSet;
@@ -93,5 +95,14 @@ impl Ord for InternedString {
 impl PartialOrd for InternedString {
     fn partial_cmp(&self, other: &InternedString) -> Option<Ordering> {
         Some(self.cmp(other))
+    }
+}
+
+impl Serialize for InternedString {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(self.inner)
     }
 }

--- a/src/cargo/core/mod.rs
+++ b/src/cargo/core/mod.rs
@@ -9,7 +9,7 @@ pub use self::registry::Registry;
 pub use self::resolver::Resolve;
 pub use self::shell::{Shell, Verbosity};
 pub use self::source::{GitReference, Source, SourceId, SourceMap};
-pub use self::summary::{FeatureMap, Summary};
+pub use self::summary::{FeatureMap, FeatureValue, Summary};
 pub use self::workspace::{Members, Workspace, WorkspaceConfig, WorkspaceRootConfig};
 
 pub mod source;

--- a/src/cargo/core/mod.rs
+++ b/src/cargo/core/mod.rs
@@ -9,7 +9,7 @@ pub use self::registry::Registry;
 pub use self::resolver::Resolve;
 pub use self::shell::{Shell, Verbosity};
 pub use self::source::{GitReference, Source, SourceId, SourceMap};
-pub use self::summary::Summary;
+pub use self::summary::{FeatureMap, Summary};
 pub use self::workspace::{Members, Workspace, WorkspaceConfig, WorkspaceRootConfig};
 
 pub mod source;

--- a/src/cargo/core/package.rs
+++ b/src/cargo/core/package.rs
@@ -1,5 +1,5 @@
 use std::cell::{Ref, RefCell};
-use std::collections::{BTreeMap, HashMap};
+use std::collections::HashMap;
 use std::fmt;
 use std::hash;
 use std::path::{Path, PathBuf};
@@ -10,7 +10,7 @@ use toml;
 use lazycell::LazyCell;
 
 use core::{Dependency, Manifest, PackageId, SourceId, Target};
-use core::{SourceMap, Summary};
+use core::{FeatureMap, SourceMap, Summary};
 use core::interning::InternedString;
 use util::{internal, lev_distance, Config};
 use util::errors::{CargoResult, CargoResultExt};
@@ -39,7 +39,7 @@ struct SerializedPackage<'a> {
     source: &'a SourceId,
     dependencies: &'a [Dependency],
     targets: &'a [Target],
-    features: &'a BTreeMap<String, Vec<String>>,
+    features: &'a FeatureMap,
     manifest_path: &'a str,
 }
 

--- a/src/cargo/core/summary.rs
+++ b/src/cargo/core/summary.rs
@@ -48,47 +48,60 @@ impl Summary {
                 )
             }
         }
+        let mut features_new = BTreeMap::new();
         for (feature, list) in features.iter() {
-            for dep in list.iter() {
-                let mut parts = dep.splitn(2, '/');
-                let dep = parts.next().unwrap();
-                let is_reexport = parts.next().is_some();
-                if !is_reexport && features.get(dep).is_some() {
+            let mut values = vec![];
+            for dep in list {
+                use self::FeatureValue::*;
+                let val = FeatureValue::build(dep, |fs| (&features).get(fs).is_some());
+                if let &Feature(_) = &val {
+                    // Return early to avoid doing unnecessary work
+                    values.push(val);
                     continue;
                 }
-                match dependencies.iter().find(|d| &*d.name() == dep) {
-                    Some(d) => {
-                        if d.is_optional() || is_reexport {
-                            continue;
+                // Find data for the referenced dependency...
+                let dep_data = {
+                    let dep_name = match &val {
+                        &Feature(_) => "",
+                        &Crate(ref dep_name) | &CrateFeature(ref dep_name, _) => dep_name,
+                    };
+                    dependencies.iter().find(|d| *d.name() == *dep_name)
+                };
+                match (&val, dep_data) {
+                    (&Crate(ref dep), Some(d)) => {
+                        if !d.is_optional() {
+                            bail!(
+                                "Feature `{}` depends on `{}` which is not an \
+                                 optional dependency.\nConsider adding \
+                                 `optional = true` to the dependency",
+                                feature,
+                                dep
+                            )
                         }
-                        bail!(
-                            "Feature `{}` depends on `{}` which is not an \
-                             optional dependency.\nConsider adding \
-                             `optional = true` to the dependency",
-                            feature,
-                            dep
-                        )
                     }
-                    None if is_reexport => bail!(
+                    (&CrateFeature(ref dep_name, _), None) => bail!(
                         "Feature `{}` requires a feature of `{}` which is not a \
                          dependency",
                         feature,
-                        dep
+                        dep_name
                     ),
-                    None => bail!(
+                    (&Crate(ref dep), None) => bail!(
                         "Feature `{}` includes `{}` which is neither \
                          a dependency nor another feature",
                         feature,
                         dep
                     ),
+                    (&CrateFeature(_, _), Some(_)) | (&Feature(_), _) => {}
                 }
+                values.push(val);
             }
+            features_new.insert(feature.clone(), values);
         }
         Ok(Summary {
             inner: Rc::new(Inner {
                 package_id: pkg_id,
                 dependencies,
-                features,
+                features: features_new,
                 checksum: None,
                 links: links.map(|l| InternedString::new(&l)),
             }),
@@ -159,4 +172,48 @@ impl PartialEq for Summary {
     }
 }
 
-pub type FeatureMap = BTreeMap<String, Vec<String>>;
+/// FeatureValue represents the types of dependencies a feature can have:
+///
+/// * Another feature
+/// * An optional dependency
+/// * A feature in a depedency
+///
+/// The selection between these 3 things happens as part of the construction of the FeatureValue.
+#[derive(Clone, Debug, Serialize)]
+pub enum FeatureValue {
+    Feature(InternedString),
+    Crate(InternedString),
+    CrateFeature(InternedString, InternedString),
+}
+
+impl FeatureValue {
+    fn build<T>(feature: &str, is_feature: T) -> FeatureValue
+    where
+        T: Fn(&str) -> bool,
+    {
+        match feature.find('/') {
+            Some(pos) => {
+                let (dep, dep_feat) = feature.split_at(pos);
+                let dep_feat = &dep_feat[1..];
+                FeatureValue::CrateFeature(InternedString::new(dep), InternedString::new(dep_feat))
+            }
+            None if is_feature(&feature) => FeatureValue::Feature(InternedString::new(feature)),
+            None => FeatureValue::Crate(InternedString::new(feature)),
+        }
+    }
+
+    pub fn new(feature: &str, s: &Summary) -> FeatureValue {
+        Self::build(feature, |fs| s.features().get(fs).is_some())
+    }
+
+    pub fn to_string(&self) -> String {
+        use self::FeatureValue::*;
+        match *self {
+            Feature(ref f) => f.to_string(),
+            Crate(ref c) => c.to_string(),
+            CrateFeature(ref c, ref f) => [c.as_ref(), f.as_ref()].join("/"),
+        }
+    }
+}
+
+pub type FeatureMap = BTreeMap<String, Vec<FeatureValue>>;

--- a/src/cargo/core/summary.rs
+++ b/src/cargo/core/summary.rs
@@ -21,7 +21,7 @@ pub struct Summary {
 struct Inner {
     package_id: PackageId,
     dependencies: Vec<Dependency>,
-    features: BTreeMap<String, Vec<String>>,
+    features: FeatureMap,
     checksum: Option<String>,
     links: Option<InternedString>,
 }
@@ -110,7 +110,7 @@ impl Summary {
     pub fn dependencies(&self) -> &[Dependency] {
         &self.inner.dependencies
     }
-    pub fn features(&self) -> &BTreeMap<String, Vec<String>> {
+    pub fn features(&self) -> &FeatureMap {
         &self.inner.features
     }
     pub fn checksum(&self) -> Option<&str> {
@@ -158,3 +158,5 @@ impl PartialEq for Summary {
         self.inner.package_id == other.inner.package_id
     }
 }
+
+pub type FeatureMap = BTreeMap<String, Vec<String>>;

--- a/src/cargo/ops/registry.rs
+++ b/src/cargo/ops/registry.rs
@@ -1,4 +1,5 @@
 use std::{cmp, env};
+use std::collections::BTreeMap;
 use std::fs::{self, File};
 use std::iter::repeat;
 use std::time::Duration;
@@ -213,12 +214,23 @@ fn transmit(
         return Ok(());
     }
 
+    let string_features = pkg.summary()
+        .features()
+        .iter()
+        .map(|(feat, values)| {
+            (
+                feat.clone(),
+                values.iter().map(|fv| fv.to_string()).collect(),
+            )
+        })
+        .collect::<BTreeMap<String, Vec<String>>>();
+
     let publish = registry.publish(
         &NewCrate {
             name: pkg.name().to_string(),
             vers: pkg.version().to_string(),
             deps,
-            features: pkg.summary().features().clone(),
+            features: string_features,
             authors: authors.clone(),
             description: description.clone(),
             homepage: homepage.clone(),

--- a/tests/testsuite/metadata.rs
+++ b/tests/testsuite/metadata.rs
@@ -192,7 +192,9 @@ optional_feat = []
                 ],
                 "features": {
                   "default": [
-                    "default_feat"
+                    {
+                       "Feature": "default_feat"
+                    }
                   ],
                   "default_feat": [],
                   "optional_feat": []


### PR DESCRIPTION
This is the next step towards #1286 (after #5258). The goal here is to have a central place in the code where feature strings are interpreted as (a) a feature, (b) a dependency or (c) a dependency/feature combo, and anchor that interpretation in the type system as an enum.

I've spent quite a bit of effort avoiding extra string allocations, complicating the code a bit; notice in particular the use of `Cow<str>` in `FeatureValue` variants, and the slight workaround in `Context::resolve_features()` and `build_requirements()`. I hope this is all okay.

cc @Eh2406 