### PR TITLE
Implement size_hint for some iterators

### DIFF
--- a/src/cargo/core/resolver/resolve.rs
+++ b/src/cargo/core/resolver/resolve.rs
@@ -203,7 +203,18 @@ impl<'a> Iterator for Deps<'a> {
             .and_then(|e| e.next())
             .map(|id| self.resolve.replacement(id).unwrap_or(id))
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        match self.edges {
+            // Note: Edges is actually a std::collections::hash_set::Iter, which
+            // is an ExactSizeIterator.
+            Some(ref iter) => iter.size_hint(),
+            None => (0, Some(0))
+        }
+    }
 }
+
+impl<'a> ExactSizeIterator for Deps<'a> {}
 
 pub struct DepsNotReplaced<'a> {
     edges: Option<Edges<'a, PackageId>>,
@@ -215,4 +226,15 @@ impl<'a> Iterator for DepsNotReplaced<'a> {
     fn next(&mut self) -> Option<&'a PackageId> {
         self.edges.as_mut().and_then(|e| e.next())
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        match self.edges {
+            // Note: Edges is actually a std::collections::hash_set::Iter, which
+            // is an ExactSizeIterator.
+            Some(ref iter) => iter.size_hint(),
+            None => (0, Some(0))
+        }
+    }
 }
+
+impl<'a> ExactSizeIterator for DepsNotReplaced<'a> {}

--- a/src/cargo/core/resolver/resolve.rs
+++ b/src/cargo/core/resolver/resolve.rs
@@ -4,8 +4,8 @@ use std::iter::FromIterator;
 
 use url::Url;
 
-use core::{PackageId, Summary};
 use core::PackageIdSpec;
+use core::{PackageId, Summary};
 use util::Graph;
 use util::errors::CargoResult;
 use util::graph::{Edges, Nodes};
@@ -209,7 +209,7 @@ impl<'a> Iterator for Deps<'a> {
             // Note: Edges is actually a std::collections::hash_set::Iter, which
             // is an ExactSizeIterator.
             Some(ref iter) => iter.size_hint(),
-            None => (0, Some(0))
+            None => (0, Some(0)),
         }
     }
 }
@@ -232,7 +232,7 @@ impl<'a> Iterator for DepsNotReplaced<'a> {
             // Note: Edges is actually a std::collections::hash_set::Iter, which
             // is an ExactSizeIterator.
             Some(ref iter) => iter.size_hint(),
-            None => (0, Some(0))
+            None => (0, Some(0)),
         }
     }
 }

--- a/src/cargo/core/resolver/resolve.rs
+++ b/src/cargo/core/resolver/resolve.rs
@@ -205,12 +205,10 @@ impl<'a> Iterator for Deps<'a> {
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        match self.edges {
-            // Note: Edges is actually a std::collections::hash_set::Iter, which
-            // is an ExactSizeIterator.
-            Some(ref iter) => iter.size_hint(),
-            None => (0, Some(0)),
-        }
+        // Note: Edges is actually a std::collections::hash_set::Iter, which
+        // is an ExactSizeIterator.
+        let len = self.edges.as_ref().map(ExactSizeIterator::len).unwrap_or(0);
+        (len, Some(len))
     }
 }
 
@@ -228,12 +226,10 @@ impl<'a> Iterator for DepsNotReplaced<'a> {
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        match self.edges {
-            // Note: Edges is actually a std::collections::hash_set::Iter, which
-            // is an ExactSizeIterator.
-            Some(ref iter) => iter.size_hint(),
-            None => (0, Some(0)),
-        }
+        // Note: Edges is actually a std::collections::hash_set::Iter, which
+        // is an ExactSizeIterator.
+        let len = self.edges.as_ref().map(ExactSizeIterator::len).unwrap_or(0);
+        (len, Some(len))
     }
 }
 

--- a/src/cargo/core/resolver/types.rs
+++ b/src/cargo/core/resolver/types.rs
@@ -342,9 +342,12 @@ where
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
+        // rest is a std::ops::Range, which is an ExactSizeIterator.
         self.rest.size_hint()
     }
 }
+
+impl<T> ExactSizeIterator for RcVecIter<T> {}
 
 pub struct RcList<T> {
     pub head: Option<Rc<(T, RcList<T>)>>,

--- a/src/cargo/core/resolver/types.rs
+++ b/src/cargo/core/resolver/types.rs
@@ -347,7 +347,7 @@ where
     }
 }
 
-impl<T> ExactSizeIterator for RcVecIter<T> {}
+impl<T: Clone> ExactSizeIterator for RcVecIter<T> {}
 
 pub struct RcList<T> {
     pub head: Option<Rc<(T, RcList<T>)>>,

--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -776,6 +776,11 @@ impl<'a, 'cfg> Iterator for Members<'a, 'cfg> {
             }
         }
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let (_, upper) = self.iter.size_hint();
+        (0, upper)
+    }
 }
 
 impl MaybePackage {

--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -8,8 +8,8 @@ use glob::glob;
 use url::Url;
 
 use core::registry::PackageRegistry;
-use core::{EitherManifest, Package, SourceId, VirtualManifest};
 use core::{Dependency, PackageIdSpec, Profile, Profiles};
+use core::{EitherManifest, Package, SourceId, VirtualManifest};
 use ops;
 use sources::PathSource;
 use util::errors::{CargoResult, CargoResultExt};


### PR DESCRIPTION
This PR implements size_hints for `Deps`, `DepsNotReplaced`, and `Members`.
These size_hints are used extensively by cargo to allocate Vecs.

`Deps`, `DepsNotReplaced`, and `RcVecIter` also now implement `ExactSizeIterator`.

Closes #5211 