### PR TITLE
Remove rustfmt from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,9 +36,6 @@ matrix:
         - cargo doc --no-deps
         - (cd src/doc && mdbook build --dest-dir ../../target/doc)
 
-    - before_script: rustup component add rustfmt-preview
-      script: cargo fmt -- --write-mode diff
-
   exclude:
     - rust: stable
 


### PR DESCRIPTION
As discussed at the recent work week this is probably a bit too zealous at this
time, so let's hold off on it until it's either more stable or we figure out a
better way to deal with changes in rustfmt.

For now though it'll hopefully be easy to continue running rustfmt every so
often!