### PR TITLE
Replace home-grown create_dir_all with std::fs::create_dir_all

### DIFF
--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -14,7 +14,7 @@ use url::Url;
 
 use core::{GitReference, PackageIdSpec, Profiles, SourceId, WorkspaceConfig, WorkspaceRootConfig};
 use core::{Dependency, Manifest, PackageId, Summary, Target};
-use core::{EitherManifest, Edition, Feature, Features, VirtualManifest};
+use core::{Edition, EitherManifest, Feature, Features, VirtualManifest};
 use core::dependency::{Kind, Platform};
 use core::manifest::{LibKind, Lto, ManifestMetadata, Profile};
 use sources::CRATES_IO;


### PR DESCRIPTION
The old one is just the historical artifact, right?