### PR TITLE
Slightly improve InternedString

### DIFF
--- a/src/cargo/core/resolver/context.rs
+++ b/src/cargo/core/resolver/context.rs
@@ -280,7 +280,7 @@ fn build_requirements<'a, 'b: 'a>(
                 reqs.require_feature(key)?;
             }
             for dep in s.dependencies().iter().filter(|d| d.is_optional()) {
-                reqs.require_dependency(dep.name().to_inner());
+                reqs.require_dependency(dep.name().as_str());
             }
         }
         Method::Required {

--- a/src/cargo/ops/cargo_doc.rs
+++ b/src/cargo/ops/cargo_doc.rs
@@ -69,7 +69,7 @@ pub fn doc(ws: &Workspace, options: &DocOptions) -> CargoResult<()> {
                  Please re-run this command with `-p <spec>` where `<spec>` \
                  is one of the following:\n  {}",
                 pkgs.iter()
-                    .map(|p| p.name().to_inner())
+                    .map(|p| p.name().as_str())
                     .collect::<Vec<_>>()
                     .join("\n  ")
             );

--- a/src/cargo/ops/cargo_generate_lockfile.rs
+++ b/src/cargo/ops/cargo_generate_lockfile.rs
@@ -142,7 +142,7 @@ pub fn update_lockfile(ws: &Workspace, opts: &UpdateOptions) -> CargoResult<()> 
         resolve: &'a Resolve,
     ) -> Vec<(Vec<&'a PackageId>, Vec<&'a PackageId>)> {
         fn key(dep: &PackageId) -> (&str, &SourceId) {
-            (dep.name().to_inner(), dep.source_id())
+            (dep.name().as_str(), dep.source_id())
         }
 
         // Removes all package ids in `b` from `a`. Note that this is somewhat

--- a/src/cargo/ops/cargo_install.rs
+++ b/src/cargo/ops/cargo_install.rs
@@ -506,7 +506,7 @@ where
                     "multiple packages with {} found: {}",
                     kind,
                     pkgs.iter()
-                        .map(|p| p.name().to_inner())
+                        .map(|p| p.name().as_str())
                         .collect::<Vec<_>>()
                         .join(", ")
                 )


### PR DESCRIPTION
* Use `&'static str` instead of (ptr, len) pair to reduce unsafety.
* try make hash calculation O(1) instead of O(n), fail miserably,
  document findings.
* Rename `to_inner` -> `as_str()`.