### PR TITLE
Intern more strings

### DIFF
--- a/src/cargo/core/resolver/mod.rs
+++ b/src/cargo/core/resolver/mod.rs
@@ -56,6 +56,7 @@ use semver;
 
 use core::{Dependency, PackageId, Registry, Summary};
 use core::PackageIdSpec;
+use core::interning::InternedString;
 use util::config::Config;
 use util::Graph;
 use util::errors::{CargoError, CargoResult};
@@ -670,7 +671,7 @@ struct BacktrackFrame {
     remaining_candidates: RemainingCandidates,
     parent: Summary,
     dep: Dependency,
-    features: Rc<Vec<String>>,
+    features: Rc<Vec<InternedString>>,
     conflicting_activations: HashMap<PackageId, ConflictReason>,
 }
 

--- a/src/cargo/core/resolver/types.rs
+++ b/src/cargo/core/resolver/types.rs
@@ -4,6 +4,7 @@ use std::ops::Range;
 use std::rc::Rc;
 
 use core::{Dependency, PackageId, PackageIdSpec, Registry, Summary};
+use core::interning::InternedString;
 use util::{CargoError, CargoResult};
 
 pub struct RegistryQueryer<'a> {
@@ -159,21 +160,21 @@ pub enum Method<'a> {
     Everything, // equivalent to Required { dev_deps: true, all_features: true, .. }
     Required {
         dev_deps: bool,
-        features: &'a [String],
+        features: &'a [InternedString],
         all_features: bool,
         uses_default_features: bool,
     },
 }
 
 impl<'r> Method<'r> {
-    pub fn split_features(features: &[String]) -> Vec<String> {
+    pub fn split_features(features: &[String]) -> Vec<InternedString> {
         features
             .iter()
             .flat_map(|s| s.split_whitespace())
             .flat_map(|s| s.split(','))
             .filter(|s| !s.is_empty())
-            .map(|s| s.to_string())
-            .collect::<Vec<String>>()
+            .map(|s| InternedString::new(s))
+            .collect::<Vec<InternedString>>()
     }
 }
 
@@ -245,7 +246,7 @@ impl Ord for DepsFrame {
 // Information about the dependencies for a crate, a tuple of:
 //
 // (dependency info, candidates, features activated)
-pub type DepInfo = (Dependency, Rc<Vec<Candidate>>, Rc<Vec<String>>);
+pub type DepInfo = (Dependency, Rc<Vec<Candidate>>, Rc<Vec<InternedString>>);
 
 pub type ActivateResult<T> = Result<T, ActivateError>;
 

--- a/src/cargo/ops/registry.rs
+++ b/src/cargo/ops/registry.rs
@@ -171,7 +171,7 @@ fn transmit(
                 optional: dep.is_optional(),
                 default_features: dep.uses_default_features(),
                 name: dep.name().to_string(),
-                features: dep.features().to_vec(),
+                features: dep.features().iter().map(|s| s.to_string()).collect(),
                 version_req: dep.version_req().to_string(),
                 target: dep.platform().map(|s| s.to_string()),
                 kind: match dep.kind() {

--- a/src/cargo/ops/resolve.rs
+++ b/src/cargo/ops/resolve.rs
@@ -472,9 +472,11 @@ fn register_previous_locks<'a>(
             //       dependency on that crate to enable the feature. For now
             //       this bug is better than the always updating registry
             //       though...
-            if !ws.members().any(|pkg| pkg.package_id() == member.package_id()) &&
-                (dep.is_optional() || !dep.is_transitive()) {
-                continue
+            if !ws.members()
+                .any(|pkg| pkg.package_id() == member.package_id())
+                && (dep.is_optional() || !dep.is_transitive())
+            {
+                continue;
             }
 
             // Ok if nothing matches, then we poison the source of this


### PR DESCRIPTION
As pointed out in https://github.com/rust-lang/cargo/pull/5270#issuecomment-378372147, that clean up adds the mildly expensive `InternedString::new` to the hot path in the resolver.

The process of this PR is:
1. Find a `InternedString::new` in the hot path.
2. replace the argument of type `&str` that is passed along to `InternedString::new` with the type `InternedString`
3. add an `InternedString::new` to the callers until it type checked.
4. Repeat from step 1.

This stop if:
- It was traced back to something that was already an `InternedString`
- It was traced back to a `.to_string()` call
- It was in a persistent object creation

cc:
- @djc this is building on your work, I don't want to get in your way.
- @alexcrichton is this making things clearer and do you want to see a performance check?