### PR TITLE
Add --build-plan for 'cargo build'

### DIFF
--- a/src/bin/cargo/command_prelude.rs
+++ b/src/bin/cargo/command_prelude.rs
@@ -132,6 +132,10 @@ pub trait AppExt: Sized {
         )
     }
 
+    fn arg_build_plan(self) -> Self {
+        self._arg(opt("build-plan", "Output the build plan in JSON"))
+    }
+
     fn arg_new_opts(self) -> Self {
         self._arg(
             opt(
@@ -275,6 +279,12 @@ pub trait ArgMatchesExt {
         let mut build_config = BuildConfig::new(config, self.jobs()?, &self.target(), mode)?;
         build_config.message_format = message_format;
         build_config.release = self._is_present("release");
+        build_config.build_plan = self._is_present("build-plan");
+        if build_config.build_plan && !config.cli_unstable().unstable_options {
+            Err(format_err!(
+                "`--build-plan` flag is unstable, pass `-Z unstable-options` to enable it"
+            ))?;
+        };
 
         let opts = CompileOptions {
             config,

--- a/src/bin/cargo/commands/build.rs
+++ b/src/bin/cargo/commands/build.rs
@@ -31,6 +31,7 @@ pub fn cli() -> App {
         .arg(opt("out-dir", "Copy final artifacts to this directory").value_name("PATH"))
         .arg_manifest_path()
         .arg_message_format()
+        .arg_build_plan()
         .after_help(
             "\
 If the --package argument is given, then SPEC is a package id specification

--- a/src/cargo/core/compiler/build_config.rs
+++ b/src/cargo/core/compiler/build_config.rs
@@ -14,6 +14,8 @@ pub struct BuildConfig {
     pub mode: CompileMode,
     /// Whether to print std output in json format (for machine reading)
     pub message_format: MessageFormat,
+    /// Output a build plan to stdout instead of actually compiling.
+    pub build_plan: bool,
 }
 
 impl BuildConfig {
@@ -87,6 +89,7 @@ impl BuildConfig {
             release: false,
             mode,
             message_format: MessageFormat::Human,
+            build_plan: false,
         })
     }
 

--- a/src/cargo/core/compiler/build_context/mod.rs
+++ b/src/cargo/core/compiler/build_context/mod.rs
@@ -229,6 +229,18 @@ impl<'a, 'cfg> BuildContext<'a, 'cfg> {
         }
         None
     }
+
+    /// Return the list of filenames read by cargo to generate the BuildContext
+    /// (all Cargo.toml, etc).
+    pub fn inputs(&self) -> CargoResult<Vec<PathBuf>> {
+        let mut inputs = Vec::new();
+        for id in self.packages.package_ids() {
+            let pkg = self.get_package(id)?;
+            inputs.push(pkg.manifest_path().to_path_buf());
+        }
+        inputs.sort();
+        Ok(inputs)
+    }
 }
 
 /// Information required to build for a target

--- a/src/cargo/core/compiler/build_plan.rs
+++ b/src/cargo/core/compiler/build_plan.rs
@@ -1,0 +1,158 @@
+//! A graph-like structure used to represent the rustc commands to build the project and the
+//! interdependencies between them.
+//!
+//! The BuildPlan structure is used to store the dependency graph of a dry run so that it can be
+//! shared with an external build system. Each Invocation in the BuildPlan comprises a single
+//! subprocess and defines the build environment, the outputs produced by the subprocess, and the
+//! dependencies on other Invocations.
+
+use std::collections::BTreeMap;
+
+use core::TargetKind;
+use super::{Context, Kind, Unit};
+use super::context::OutputFile;
+use util::{internal, CargoResult, ProcessBuilder};
+use std::sync::Arc;
+use std::path::PathBuf;
+use serde_json;
+use semver;
+
+#[derive(Debug, Serialize)]
+struct Invocation {
+    package_name: String,
+    package_version: semver::Version,
+    target_kind: TargetKind,
+    kind: Kind,
+    deps: Vec<usize>,
+    outputs: Vec<PathBuf>,
+    links: BTreeMap<PathBuf, PathBuf>,
+    program: String,
+    args: Vec<String>,
+    env: BTreeMap<String, String>,
+    cwd: Option<PathBuf>,
+}
+
+#[derive(Debug)]
+pub struct BuildPlan {
+    invocation_map: BTreeMap<String, usize>,
+    plan: SerializedBuildPlan,
+}
+
+#[derive(Debug, Serialize)]
+struct SerializedBuildPlan {
+    invocations: Vec<Invocation>,
+    inputs: Vec<PathBuf>,
+}
+
+impl Invocation {
+    pub fn new(unit: &Unit, deps: Vec<usize>) -> Invocation {
+        let id = unit.pkg.package_id();
+        Invocation {
+            package_name: id.name().to_string(),
+            package_version: id.version().clone(),
+            kind: unit.kind,
+            target_kind: unit.target.kind().clone(),
+            deps: deps,
+            outputs: Vec::new(),
+            links: BTreeMap::new(),
+            program: String::new(),
+            args: Vec::new(),
+            env: BTreeMap::new(),
+            cwd: None,
+        }
+    }
+
+    pub fn add_output(&mut self, path: &PathBuf, link: &Option<PathBuf>) {
+        self.outputs.push(path.clone());
+        if let Some(ref link) = *link {
+            self.links.insert(link.clone(), path.clone());
+        }
+    }
+
+    pub fn update_cmd(&mut self, cmd: ProcessBuilder) -> CargoResult<()> {
+        self.program = cmd.get_program()
+            .to_str()
+            .ok_or_else(|| format_err!("unicode program string required"))?
+            .to_string()
+            .clone();
+        self.cwd = Some(cmd.get_cwd().unwrap().to_path_buf());
+        for arg in cmd.get_args().iter() {
+            self.args.push(
+                arg.to_str()
+                    .ok_or_else(|| format_err!("unicode argument string required"))?
+                    .to_string()
+                    .clone(),
+            );
+        }
+        for var in cmd.get_envs().keys() {
+            let value = cmd.get_env(var).unwrap_or_default();
+            self.env.insert(
+                var.clone(),
+                value
+                    .to_str()
+                    .ok_or_else(|| format_err!("unicode environment value required"))?
+                    .to_string(),
+            );
+        }
+        Ok(())
+    }
+}
+
+impl BuildPlan {
+    pub fn new() -> BuildPlan {
+        BuildPlan {
+            invocation_map: BTreeMap::new(),
+            plan: SerializedBuildPlan::new(),
+        }
+    }
+
+    pub fn add(&mut self, cx: &Context, unit: &Unit) -> CargoResult<()> {
+        let id = self.plan.invocations.len();
+        self.invocation_map.insert(unit.buildkey(), id);
+        let deps = cx.dep_targets(&unit)
+            .iter()
+            .map(|dep| self.invocation_map[&dep.buildkey()])
+            .collect();
+        let invocation = Invocation::new(unit, deps);
+        self.plan.invocations.push(invocation);
+        Ok(())
+    }
+
+    pub fn update(
+        &mut self,
+        invocation_name: String,
+        cmd: ProcessBuilder,
+        outputs: Arc<Vec<OutputFile>>,
+    ) -> CargoResult<()> {
+        let id = self.invocation_map[&invocation_name];
+        let invocation = self.plan
+            .invocations
+            .get_mut(id)
+            .ok_or_else(|| internal(format!("couldn't find invocation for {}", invocation_name)))?;
+
+        invocation.update_cmd(cmd)?;
+        for output in outputs.iter() {
+            invocation.add_output(&output.path, &output.hardlink);
+        }
+
+        Ok(())
+    }
+
+    pub fn set_inputs(&mut self, inputs: Vec<PathBuf>) {
+        self.plan.inputs = inputs;
+    }
+
+    pub fn output_plan(self) {
+        let encoded = serde_json::to_string(&self.plan).unwrap();
+        println!("{}", encoded);
+    }
+}
+
+impl SerializedBuildPlan {
+    pub fn new() -> SerializedBuildPlan {
+        SerializedBuildPlan {
+            invocations: Vec::new(),
+            inputs: Vec::new(),
+        }
+    }
+}

--- a/src/cargo/core/compiler/build_plan.rs
+++ b/src/cargo/core/compiler/build_plan.rs
@@ -73,19 +73,20 @@ impl Invocation {
         self.program = cmd.get_program()
             .to_str()
             .ok_or_else(|| format_err!("unicode program string required"))?
-            .to_string()
-            .clone();
+            .to_string();
         self.cwd = Some(cmd.get_cwd().unwrap().to_path_buf());
         for arg in cmd.get_args().iter() {
             self.args.push(
                 arg.to_str()
                     .ok_or_else(|| format_err!("unicode argument string required"))?
-                    .to_string()
-                    .clone(),
+                    .to_string(),
             );
         }
-        for var in cmd.get_envs().keys() {
-            let value = cmd.get_env(var).unwrap_or_default();
+        for (var, value) in cmd.get_envs() {
+            let value = match value {
+                Some(s) => s,
+                None => continue,
+            };
             self.env.insert(
                 var.clone(),
                 value

--- a/src/cargo/core/compiler/job_queue.rs
+++ b/src/cargo/core/compiler/job_queue.rs
@@ -4,6 +4,7 @@ use std::fmt;
 use std::io;
 use std::mem;
 use std::sync::mpsc::{channel, Receiver, Sender};
+use std::sync::Arc;
 
 use crossbeam::{self, Scope};
 use jobserver::{Acquired, HelperThread};
@@ -15,7 +16,8 @@ use util::{internal, profile, CargoResult, CargoResultExt, ProcessBuilder};
 use util::{Config, DependencyQueue, Dirty, Fresh, Freshness};
 
 use super::job::Job;
-use super::{BuildContext, CompileMode, Context, Kind, Unit};
+use super::{BuildContext, BuildPlan, CompileMode, Context, Kind, Unit};
+use super::context::OutputFile;
 
 /// A management structure of the entire dependency graph to compile.
 ///
@@ -58,6 +60,7 @@ pub struct JobState<'a> {
 
 enum Message<'a> {
     Run(String),
+    BuildPlanMsg(String, ProcessBuilder, Arc<Vec<OutputFile>>),
     Stdout(String),
     Stderr(String),
     Token(io::Result<Acquired>),
@@ -67,6 +70,16 @@ enum Message<'a> {
 impl<'a> JobState<'a> {
     pub fn running(&self, cmd: &ProcessBuilder) {
         let _ = self.tx.send(Message::Run(cmd.to_string()));
+    }
+
+    pub fn build_plan(
+        &self,
+        module_name: String,
+        cmd: ProcessBuilder,
+        filenames: Arc<Vec<OutputFile>>,
+    ) {
+        let _ = self.tx
+            .send(Message::BuildPlanMsg(module_name, cmd, filenames));
     }
 
     pub fn stdout(&self, out: &str) {
@@ -115,7 +128,7 @@ impl<'a> JobQueue<'a> {
     /// This function will spawn off `config.jobs()` workers to build all of the
     /// necessary dependencies, in order. Freshness is propagated as far as
     /// possible along each dependency chain.
-    pub fn execute(&mut self, cx: &mut Context) -> CargoResult<()> {
+    pub fn execute(&mut self, cx: &mut Context, plan: &mut BuildPlan) -> CargoResult<()> {
         let _p = profile::start("executing the job graph");
         self.queue.queue_finished();
 
@@ -141,17 +154,19 @@ impl<'a> JobQueue<'a> {
             })
             .chain_err(|| "failed to create helper thread for jobserver management")?;
 
-        crossbeam::scope(|scope| self.drain_the_queue(cx, scope, &helper))
+        crossbeam::scope(|scope| self.drain_the_queue(cx, plan, scope, &helper))
     }
 
     fn drain_the_queue(
         &mut self,
         cx: &mut Context,
+        plan: &mut BuildPlan,
         scope: &Scope<'a>,
         jobserver_helper: &HelperThread,
     ) -> CargoResult<()> {
         let mut tokens = Vec::new();
         let mut queue = Vec::new();
+        let build_plan = cx.bcx.build_config.build_plan;
         trace!("queue: {:#?}", self.queue);
 
         // Iteratively execute the entire dependency graph. Each turn of the
@@ -192,7 +207,7 @@ impl<'a> JobQueue<'a> {
             // we're able to perform some parallel work.
             while error.is_none() && self.active < tokens.len() + 1 && !queue.is_empty() {
                 let (key, job, fresh) = queue.remove(0);
-                self.run(key, fresh, job, cx.bcx.config, scope)?;
+                self.run(key, fresh, job, cx.bcx.config, scope, build_plan)?;
             }
 
             // If after all that we're not actually running anything then we're
@@ -214,6 +229,9 @@ impl<'a> JobQueue<'a> {
                         .config
                         .shell()
                         .verbose(|c| c.status("Running", &cmd))?;
+                }
+                Message::BuildPlanMsg(module_name, cmd, filenames) => {
+                    plan.update(module_name, cmd, filenames)?;
                 }
                 Message::Stdout(out) => {
                     if cx.bcx.config.extra_verbose() {
@@ -303,7 +321,9 @@ impl<'a> JobQueue<'a> {
                 "{} [{}] target(s) in {}",
                 build_type, opt_type, time_elapsed
             );
-            cx.bcx.config.shell().status("Finished", message)?;
+            if !build_plan {
+                cx.bcx.config.shell().status("Finished", message)?;
+            }
             Ok(())
         } else if let Some(e) = error {
             Err(e)
@@ -322,6 +342,7 @@ impl<'a> JobQueue<'a> {
         job: Job,
         config: &Config,
         scope: &Scope<'a>,
+        build_plan: bool,
     ) -> CargoResult<()> {
         info!("start: {:?}", key);
 
@@ -340,8 +361,10 @@ impl<'a> JobQueue<'a> {
             }
         }
 
-        // Print out some nice progress information
-        self.note_working_on(config, &key, fresh)?;
+        if !build_plan {
+            // Print out some nice progress information
+            self.note_working_on(config, &key, fresh)?;
+        }
 
         Ok(())
     }

--- a/tests/testsuite/build_plan.rs
+++ b/tests/testsuite/build_plan.rs
@@ -1,0 +1,207 @@
+use cargotest::ChannelChanger;
+use cargotest::support::{basic_bin_manifest, execs, main_file, project};
+use hamcrest::{assert_that, existing_file, is_not};
+
+#[test]
+fn cargo_build_plan_simple() {
+    let p = project("foo")
+        .file("Cargo.toml", &basic_bin_manifest("foo"))
+        .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
+        .build();
+
+    assert_that(
+        p.cargo("build")
+            .masquerade_as_nightly_cargo()
+            .arg("--build-plan")
+            .arg("-Zunstable-options"),
+        execs().with_status(0).with_json(
+            r#"
+    {
+        "inputs": [
+            "[..][/]foo[/]Cargo.toml"
+        ],
+        "invocations": [
+            {
+                "args": "{...}",
+                "cwd": "[..][/]target[/]cit[/][..][/]foo",
+                "deps": [],
+                "env": "{...}",
+                "kind": "Host",
+                "links": "{...}",
+                "outputs": "{...}",
+                "package_name": "foo",
+                "package_version": "0.5.0",
+                "program": "rustc",
+                "target_kind": ["bin"]
+            }
+        ]
+    }
+    "#,
+        ),
+    );
+    assert_that(&p.bin("foo"), is_not(existing_file()));
+}
+
+#[test]
+fn cargo_build_plan_single_dep() {
+    let p = project("foo")
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "foo"
+            authors = []
+            version = "0.5.0"
+
+            [dependencies]
+            bar = { path = "bar" }
+        "#,
+        )
+        .file(
+            "src/lib.rs",
+            r#"
+            extern crate bar;
+            pub fn foo() { bar::bar(); }
+
+            #[test]
+            fn test() { foo(); }
+        "#,
+        )
+        .file(
+            "bar/Cargo.toml",
+            r#"
+            [package]
+            name = "bar"
+            version = "0.0.1"
+            authors = []
+        "#,
+        )
+        .file("bar/src/lib.rs", "pub fn bar() {}")
+        .build();
+    assert_that(
+        p.cargo("build")
+            .masquerade_as_nightly_cargo()
+            .arg("--build-plan")
+            .arg("-Zunstable-options"),
+        execs().with_status(0).with_json(
+            r#"
+    {
+        "inputs": [
+            "[..][/]foo[/]Cargo.toml",
+            "[..][/]foo[/]bar[/]Cargo.toml"
+        ],
+        "invocations": [
+            {
+                "args": "{...}",
+                "cwd": "[..][/]target[/]cit[/][..][/]foo",
+                "deps": [],
+                "env": "{...}",
+                "kind": "Host",
+                "links": "{...}",
+                "outputs": [
+                    "[..][/]foo[/]target[/]debug[/]deps[/]libbar-[..].rlib"
+                ],
+                "package_name": "bar",
+                "package_version": "0.0.1",
+                "program": "rustc",
+                "target_kind": ["lib"]
+            },
+            {
+                "args": "{...}",
+                "cwd": "[..][/]target[/]cit[/][..][/]foo",
+                "deps": [0],
+                "env": "{...}",
+                "kind": "Host",
+                "links": "{...}",
+                "outputs": [
+                    "[..][/]foo[/]target[/]debug[/]deps[/]libfoo-[..].rlib"
+                ],
+                "package_name": "foo",
+                "package_version": "0.5.0",
+                "program": "rustc",
+                "target_kind": ["lib"]
+            }
+        ]
+    }
+    "#,
+        ),
+    );
+}
+
+#[test]
+fn cargo_build_plan_build_script() {
+    let p = project("foo")
+        .file(
+            "Cargo.toml",
+            r#"
+            [project]
+
+            name = "foo"
+            version = "0.5.0"
+            authors = ["wycats@example.com"]
+            build = "build.rs"
+        "#,
+        )
+        .file("src/main.rs", r#"fn main() {}"#)
+        .file("build.rs", r#"fn main() {}"#)
+        .build();
+
+    assert_that(
+        p.cargo("build")
+            .masquerade_as_nightly_cargo()
+            .arg("--build-plan")
+            .arg("-Zunstable-options"),
+        execs().with_status(0).with_json(
+            r#"
+    {
+        "inputs": [
+            "[..][/]foo[/]Cargo.toml"
+        ],
+        "invocations": [
+            {
+                "args": "{...}",
+                "cwd": "[..][/]target[/]cit[/][..][/]foo",
+                "deps": [],
+                "env": "{...}",
+                "kind": "Host",
+                "links": "{...}",
+                "outputs": [
+                    "[..][/]foo[/]target[/]debug[/]build[/][..][/]build_script_build-[..]"
+                ],
+                "package_name": "foo",
+                "package_version": "0.5.0",
+                "program": "rustc",
+                "target_kind": ["custom-build"]
+            },
+            {
+                "args": "{...}",
+                "cwd": "[..][/]target[/]cit[/][..][/]foo",
+                "deps": [0],
+                "env": "{...}",
+                "kind": "Host",
+                "links": "{...}",
+                "outputs": [],
+                "package_name": "foo",
+                "package_version": "0.5.0",
+                "program": "[..][/]build-script-build",
+                "target_kind": ["custom-build"]
+            },
+            {
+                "args": "{...}",
+                "cwd": "[..][/]target[/]cit[/][..][/]foo",
+                "deps": [1],
+                "env": "{...}",
+                "kind": "Host",
+                "links": "{...}",
+                "outputs": "{...}",
+                "package_name": "foo",
+                "package_version": "0.5.0",
+                "program": "rustc",
+                "target_kind": ["bin"]
+            }
+        ]
+    }
+    "#,
+        ),
+    );
+}

--- a/tests/testsuite/main.rs
+++ b/tests/testsuite/main.rs
@@ -30,6 +30,7 @@ mod bench;
 mod build_auth;
 mod build_lib;
 mod build;
+mod build_plan;
 mod build_script_env;
 mod build_script;
 mod cargo_alias_config;


### PR DESCRIPTION
With 'cargo build --build-plan', cargo does not actually run any
commands, but instead prints out what it would have done in the form of
a JSON data structure.

Fixes #3815