### PR TITLE
use more Rc in the part of resolver that gets cloned a lot 2

### DIFF
--- a/src/cargo/core/resolver/context.rs
+++ b/src/cargo/core/resolver/context.rs
@@ -68,9 +68,7 @@ impl Context {
                     &*link
                 );
             }
-            let mut inner: Vec<_> = (**prev).clone();
-            inner.push(summary.clone());
-            *prev = Rc::new(inner);
+            Rc::make_mut(prev).push(summary.clone());
             return Ok(false);
         }
         debug!("checking if {} is already activated", summary.package_id());
@@ -246,15 +244,13 @@ impl Context {
         if !reqs.used.is_empty() {
             let pkgid = s.package_id();
 
-            let set = self.resolve_features
+            let set = Rc::make_mut(self.resolve_features
                 .entry(pkgid.clone())
-                .or_insert_with(|| Rc::new(HashSet::new()));
+                .or_insert_with(|| Rc::new(HashSet::new())));
 
-            let mut inner: HashSet<_> = (**set).clone();
             for feature in reqs.used {
-                inner.insert(InternedString::new(feature));
+                set.insert(InternedString::new(feature));
             }
-            *set = Rc::new(inner);
         }
 
         Ok(ret)


### PR DESCRIPTION
This is the same idea as https://github.com/rust-lang/cargo/pull/5118, I was looking at a profile and noted that ~5% of our time was sent dropping `HashMap<PackageId, HashSet<InternedString>>`. A quick rg and I found the culprit, we are cloning the set of features for every new `Context`. With some Rc we are now just cloning for each time we insert.

To benchmark I commented out line https://github.com/rust-lang/cargo/blob/b9aa315158fe4d8d63672a49200401922ef7385d/src/cargo/core/resolver/mod.rs#L453 
the smallest change to get https://github.com/rust-lang/cargo/issues/4810#issuecomment-357553286 not to solve instantly.
Before 17000000 ticks, 90s, 188.889 ticks/ms
After 17000000 ticks, 73s, 232.877 ticks/ms