### PR TITLE
Add profiling calls to stuff which is actually slow

### DIFF
--- a/src/cargo/ops/cargo_rustc/context/mod.rs
+++ b/src/cargo/ops/cargo_rustc/context/mod.rs
@@ -197,6 +197,7 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
     /// Ensure that we've collected all target-specific information to compile
     /// all the units mentioned in `units`.
     fn probe_target_info(&mut self) -> CargoResult<()> {
+        let _p = profile::start("Context::probe_target_info");
         debug!("probe_target_info");
         let host_target_same = match self.requested_target() {
             Some(s) if s != self.config.rustc()?.host => false,

--- a/src/cargo/util/rustc.rs
+++ b/src/cargo/util/rustc.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use util::{self, internal, CargoResult, ProcessBuilder};
+use util::{self, internal, profile, CargoResult, ProcessBuilder};
 
 /// Information on the `rustc` executable
 #[derive(Debug)]
@@ -23,6 +23,8 @@ impl Rustc {
     /// If successful this function returns a description of the compiler along
     /// with a list of its capabilities.
     pub fn new(path: PathBuf, wrapper: Option<PathBuf>) -> CargoResult<Rustc> {
+        let _p = profile::start("Rustc::new");
+
         let mut cmd = util::process(&path);
         cmd.arg("-vV");
 


### PR DESCRIPTION
So these two functions is what makes no-op build slow, so let's profile them to be able to track regressions better in the future. 