### PR TITLE
Properly use unstable options for out-dir

### DIFF
--- a/src/bin/commands/build.rs
+++ b/src/bin/commands/build.rs
@@ -52,9 +52,9 @@ pub fn exec(config: &mut Config, args: &ArgMatches) -> CliResult {
     let ws = args.workspace(config)?;
     let mut compile_opts = args.compile_options(config, CompileMode::Build)?;
     compile_opts.export_dir = args.value_of_path("out-dir", config);
-    if compile_opts.export_dir.is_some() && !config.cli_unstable().out_dir {
+    if compile_opts.export_dir.is_some() && !config.cli_unstable().unstable_options {
         Err(format_err!(
-            "`--out-dir` flag is unstable, pass `-Z out-dir` to enable it"
+            "`--out-dir` flag is unstable, pass `-Z unstable-options` to enable it"
         ))?;
     };
     ops::compile(&ws, &compile_opts)?;

--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -286,7 +286,6 @@ pub struct CliUnstable {
     pub no_index_update: bool,
     pub avoid_dev_deps: bool,
     pub minimal_versions: bool,
-    pub out_dir: bool,
 }
 
 impl CliUnstable {
@@ -320,7 +319,6 @@ impl CliUnstable {
             "no-index-update" => self.no_index_update = true,
             "avoid-dev-deps" => self.avoid_dev_deps = true,
             "minimal-versions" => self.minimal_versions = true,
-            "out-dir" => self.out_dir = true,
             _ => bail!("unknown `-Z` flag specified: {}", k),
         }
 

--- a/tests/testsuite/out_dir.rs
+++ b/tests/testsuite/out_dir.rs
@@ -23,7 +23,7 @@ fn binary_with_debug() {
         .build();
 
     assert_that(
-        p.cargo("build -Z out-dir --out-dir out")
+        p.cargo("build -Z unstable-options --out-dir out")
             .masquerade_as_nightly_cargo(),
         execs().with_status(0),
     );
@@ -60,7 +60,7 @@ fn static_library_with_debug() {
         .build();
 
     assert_that(
-        p.cargo("build -Z out-dir --out-dir out")
+        p.cargo("build -Z unstable-options --out-dir out")
             .masquerade_as_nightly_cargo(),
         execs().with_status(0),
     );
@@ -97,7 +97,7 @@ fn dynamic_library_with_debug() {
         .build();
 
     assert_that(
-        p.cargo("build -Z out-dir --out-dir out")
+        p.cargo("build -Z unstable-options --out-dir out")
             .masquerade_as_nightly_cargo(),
         execs().with_status(0),
     );
@@ -133,7 +133,7 @@ fn rlib_with_debug() {
         .build();
 
     assert_that(
-        p.cargo("build -Z out-dir --out-dir out")
+        p.cargo("build -Z unstable-options --out-dir out")
             .masquerade_as_nightly_cargo(),
         execs().with_status(0),
     );
@@ -186,7 +186,7 @@ fn include_only_the_binary_from_the_current_package() {
         .build();
 
     assert_that(
-        p.cargo("build -Z out-dir --bin foo --out-dir out")
+        p.cargo("build -Z unstable-options --bin foo --out-dir out")
             .masquerade_as_nightly_cargo(),
         execs().with_status(0),
     );
@@ -215,7 +215,7 @@ fn out_dir_is_a_file() {
     File::create(p.root().join("out")).unwrap();
 
     assert_that(
-        p.cargo("build -Z out-dir --out-dir out")
+        p.cargo("build -Z unstable-options --out-dir out")
             .masquerade_as_nightly_cargo(),
         execs()
             .with_status(101)
@@ -239,7 +239,7 @@ fn replaces_artifacts() {
         .build();
 
     assert_that(
-        p.cargo("build -Z out-dir --out-dir out")
+        p.cargo("build -Z unstable-options --out-dir out")
             .masquerade_as_nightly_cargo(),
         execs().with_status(0),
     );
@@ -253,7 +253,7 @@ fn replaces_artifacts() {
     p.change_file("src/main.rs", r#"fn main() { println!("bar") }"#);
 
     assert_that(
-        p.cargo("build -Z out-dir --out-dir out")
+        p.cargo("build -Z unstable-options --out-dir out")
             .masquerade_as_nightly_cargo(),
         execs().with_status(0),
     );


### PR DESCRIPTION
@alexcrichton how exactly are unstable CLI options supposed to be handled? 

One can do `-Z unstable-options my-opt` (this is done for `registry`, and this pr uses the same approach for `out-dir`). Once can also do `-Z my-opt`. Doc comments say that `-Z my-opt=val` is also possible, but in reality it does not work.

This infra was inherited from `rustc`, which is a slightly different use-case, because it does not have subcommands. That is, if you do `-Z my-opt`, it is available for all subcommands, but does not show up in the help... 

What do you think about having only `-Z unstable-options` to unlock all cli options? Or do we require a finer-graind granularity?


Somewhat related, we have a bunch of unstable options already... Do we have tracking issues for them, to know when the time comes to graduate them to stable?