### PR TITLE
ops::search: suggest to use --limit only when all crates can be displayed

### DIFF
--- a/src/cargo/ops/registry.rs
+++ b/src/cargo/ops/registry.rs
@@ -604,12 +604,12 @@ pub fn search(
     }
 
     let search_max_limit = 100;
-    if total_crates > limit && limit < search_max_limit {
+    if total_crates > limit && total_crates <= search_max_limit {
         println!(
             "... and {} crates more (use --limit N to see more)",
             total_crates - limit
         );
-    } else if total_crates > limit && limit >= search_max_limit {
+    } else if total_crates > limit && total_crates > search_max_limit {
         println!(
             "... and {} crates more (go to http://crates.io/search?q={} to see more)",
             total_crates - limit,


### PR DESCRIPTION
The previous behaviour was suggesting to use `--limit` also
when the number of discovered crates was much higher than
the `search_max_limit`. This seems semantically incorrect, as
`--limit` in that case could not be used to show all search
results.

This changes the behaviour to sugges the use of `--limit` only
when all search result can be displayed.

Just to give an example `cargo search search` was displaying
```
search = "0.0.2"           # ...                                                
fd-find = "7.0.0"          # fd is a simple, fast and user-friendly alternative to find.
ripgrep = "0.8.1"          # Line oriented search tool using Rust's regex library. Combines the raw performance of grep with the …
ff-find = "0.16.4"         # ff is a simple and fast utility for file search on Unix commandline.
rat = "0.4.9"              # REST API tool - query various REST APIs comfortably
graph-search = "0.2.0"     # A simple graph search and representation library
rs-es = "0.10.0"           # Client for the ElasticSearch REST API
amber = "0.3.3"            # A code search and replace tool
sublime_fuzzy = "0.5.0"    # Fuzzy matching algorithm based on Sublime Text's string search. Check out the repository's releases …
suffix = "1.0.0"           # Suffix arrays.
... and 318 crates more (use --limit N to see more)
```
but the maximum `N` is 100.

As an aside, would it be useful or interesting to have the results
optionally ordered by number of downloads, so that the results
up in the list are the most used ones? It is often the case that the
most used crates are supported and have easy to find documentation
and help. 
In the output above, if the crates were ordered by downloads, we would
have gotten
```
ripgrep       = "0.8.1"    	(downloads: 35496)
suffix        = "1.0.0"    	(downloads: 12837)
rs-es         = "0.10.0"    	(downloads: 10070)
fd-find       = "7.0.0"    	(downloads: 5555)
graph-search  = "0.2.0"    	(downloads: 1286)
amber         = "0.3.3"    	(downloads: 1193)
search        = "0.0.2"    	(downloads: 986)
ff-find       = "0.16.4"    	(downloads: 754)
rat           = "0.4.9"    	(downloads: 541)
sublime_fuzzy = "0.5.0"    	(downloads: 265)
```
