### PR TITLE
Support for custom Cargo profiles

### DIFF
--- a/src/bin/command_prelude.rs
+++ b/src/bin/command_prelude.rs
@@ -109,6 +109,10 @@ pub trait AppExt: Sized {
         self._arg(opt("target", target).value_name("TRIPLE"))
     }
 
+    fn arg_profile(self, profile: &'static str) -> Self {
+        self._arg(opt("profile", profile).value_name("PROFILE-NAME"))
+    }
+
     fn arg_manifest_path(self) -> Self {
         self._arg(opt("manifest-path", "Path to Cargo.toml").value_name("PATH"))
     }
@@ -272,6 +276,7 @@ pub trait ArgMatchesExt {
             no_default_features: self._is_present("no-default-features"),
             spec,
             mode,
+            profile: self._value_of("profile").map(|s| s.to_string()),
             release: self._is_present("release"),
             filter: CompileFilter::new(
                 self._is_present("lib"),

--- a/src/bin/commands/build.rs
+++ b/src/bin/commands/build.rs
@@ -27,6 +27,7 @@ pub fn cli() -> App {
         .arg_release("Build artifacts in release mode, with optimizations")
         .arg_features()
         .arg_target_triple("Build for the target triple")
+        .arg_profile("Build artifacts with the specified custom profile")
         .arg(opt("out-dir", "Copy final artifacts to this directory").value_name("PATH"))
         .arg_manifest_path()
         .arg_message_format()

--- a/src/bin/commands/run.rs
+++ b/src/bin/commands/run.rs
@@ -18,6 +18,7 @@ pub fn cli() -> App {
         .arg_release("Build artifacts in release mode, with optimizations")
         .arg_features()
         .arg_target_triple("Build for the target triple")
+        .arg_profile("Build artifacts with the specified custom profile")
         .arg_manifest_path()
         .arg_message_format()
         .after_help(

--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -201,6 +201,7 @@ pub struct Profiles {
     pub check: Profile,
     pub check_test: Profile,
     pub doctest: Profile,
+    pub custom: HashMap<String, Profile>,
 }
 
 /// Information about a binary, a library, an example, etc. that is part of the

--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -656,6 +656,7 @@ impl<'cfg> Workspace<'cfg> {
                 check: Profile::default_check(),
                 check_test: Profile::default_check_test(),
                 doctest: Profile::default_doctest(),
+                custom: HashMap::new(),
             };
 
             for pkg in self.members()

--- a/src/cargo/ops/cargo_clean.rs
+++ b/src/cargo/ops/cargo_clean.rs
@@ -59,6 +59,7 @@ pub fn clean(ws: &Workspace, opts: &CleanOptions) -> CargoResult<()> {
                     ref check,
                     ref check_test,
                     ref doctest,
+                    ref custom,
                 } = *profiles;
                 let profiles = [
                     release,
@@ -73,13 +74,19 @@ pub fn clean(ws: &Workspace, opts: &CleanOptions) -> CargoResult<()> {
                     check_test,
                     doctest,
                 ];
-                for profile in profiles.iter() {
+                let mut add = |profile| {
                     units.push(Unit {
                         pkg,
                         target,
                         profile,
                         kind: *kind,
                     });
+                };
+                for profile in profiles.iter() {
+                    add(profile);
+                }
+                for profile in custom.values() {
+                    add(profile);
                 }
             }
         }
@@ -98,6 +105,7 @@ pub fn clean(ws: &Workspace, opts: &CleanOptions) -> CargoResult<()> {
             ..BuildConfig::default()
         },
         profiles,
+        &None,
         None,
         &units,
     )?;

--- a/src/cargo/ops/cargo_package.rs
+++ b/src/cargo/ops/cargo_package.rs
@@ -346,6 +346,7 @@ fn run_verify(ws: &Workspace, tar: &FileLock, opts: &PackageOpts) -> CargoResult
                 required_features_filterable: true,
             },
             release: false,
+            profile: None,
             message_format: ops::MessageFormat::Human,
             mode: ops::CompileMode::Build,
             target_rustdoc_args: None,

--- a/src/cargo/ops/cargo_rustc/mod.rs
+++ b/src/cargo/ops/cargo_rustc/mod.rs
@@ -142,6 +142,7 @@ pub fn compile_targets<'a, 'cfg: 'a>(
     build_config: BuildConfig,
     profiles: &'a Profiles,
     export_dir: Option<PathBuf>,
+    profile_name: &Option<String>,
     exec: &Arc<Executor>,
 ) -> CargoResult<Compilation<'cfg>> {
     let units = pkg_targets
@@ -172,6 +173,7 @@ pub fn compile_targets<'a, 'cfg: 'a>(
         config,
         build_config,
         profiles,
+        profile_name,
         export_dir,
         &units,
     )?;

--- a/src/doc/src/reference/manifest.md
+++ b/src/doc/src/reference/manifest.md
@@ -279,9 +279,12 @@ project’s profiles are actually read. All dependencies’ profiles will be
 overridden. This is done so the top-level project has control over how its
 dependencies are compiled.
 
-There are five currently supported profile names, all of which have the same
-configuration available to them. Listed below is the configuration available,
-along with the defaults for each profile.
+There are five currently supported predefined profile names, all of which have
+the same configuration scheme available to them. It is possible to override the
+configuration for these profile, and it is also possible to define custom
+profiles under new names that derive from the predefined profiles.
+
+Listed below are the predefined profiles with their default configuration.
 
 ```toml
 # The development profile, used for `cargo build`.
@@ -355,6 +358,19 @@ panic = 'unwind'
 incremental = true
 overflow-checks = true
 ```
+
+Defining custom profiles is done by specifing new sections prefixed with
+`profile.custom.`. For example, we can define a new profile named `release-lto`
+that inherits from the `release` profile above:
+
+```toml
+[profile.custom.release-lto]
+inherits = "release"
+lto = true
+```
+
+To use the profile, pass it to `build` via `--profile`, e.g. `--profile release-lto`.
+
 
 ### The `[features]` section
 


### PR DESCRIPTION
This allows creating custom profiles that inherit from other profiles.

For example, one can have a release-lto profile that looks like this:

    [profile.custom.release-lto]
    inherits = "release"
    lto = true

The profile name will also carry itself into the output directory name so that the different build outputs can be cached independently from one another.

So in effect, at the `target` directory, a name will be created for the new profile, in addition to the 'debug' and 'release' builds:

```
    $ cargo build --profile release-lto
    $ ls -l target
    debug release release-lto
```