### PR TITLE
Introduce autoXXX keys for target auto-discovery

### DIFF
--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -459,6 +459,10 @@ pub struct TomlProject {
     workspace: Option<String>,
     #[serde(rename = "im-a-teapot")]
     im_a_teapot: Option<bool>,
+    autobins: Option<bool>,
+    autoexamples: Option<bool>,
+    autotests: Option<bool>,
+    autobenches: Option<bool>,
 
     // package metadata
     description: Option<String>,
@@ -653,6 +657,7 @@ impl TomlManifest {
             me,
             package_name,
             package_root,
+            edition,
             &project.build,
             &mut warnings,
             &mut errors,

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -633,6 +633,19 @@ impl TomlManifest {
 
         let pkgid = project.to_package_id(source_id)?;
 
+        let edition = if let Some(ref edition) = project.rust {
+            features
+                .require(Feature::edition())
+                .chain_err(|| "editions are unstable")?;
+            if let Ok(edition) = edition.parse() {
+                edition
+            } else {
+                bail!("the `rust` key must be one of: `2015`, `2018`")
+            }
+        } else {
+            Edition::Edition2015
+        };
+
         // If we have no lib at all, use the inferred lib if available
         // If we have a lib with a path, we're done
         // If we have a lib with no path, use the inferred lib or_else package name
@@ -798,18 +811,6 @@ impl TomlManifest {
             None => false,
         };
 
-        let edition = if let Some(ref edition) = project.rust {
-            features
-                .require(Feature::edition())
-                .chain_err(|| "editiones are unstable")?;
-            if let Ok(edition) = edition.parse() {
-                edition
-            } else {
-                bail!("the `rust` key must be one of: `2015`, `2018`")
-            }
-        } else {
-            Edition::Edition2015
-        };
         let custom_metadata = project.metadata.clone();
         let mut manifest = Manifest::new(
             summary,

--- a/src/cargo/util/toml/targets.rs
+++ b/src/cargo/util/toml/targets.rs
@@ -595,18 +595,20 @@ fn toml_targets_and_inferred(
                             }
                             warnings.push(format!(
                                 "\
-An explicit [[{section}]] section is specified in Cargo.toml which currently disables Cargo from \
-automatically inferring other {target_kind_human} targets. This inference behavior will change in \
-the Rust 2018 edition and the following files will be included as a {target_kind_human} target:
+An explicit [[{section}]] section is specified in Cargo.toml which currently
+disables Cargo from automatically inferring other {target_kind_human} targets.
+This inference behavior will change in the Rust 2018 edition and the following
+files will be included as a {target_kind_human} target:
 
 {rem_targets_str}
-This is likely to break cargo build or cargo test as these files may not be ready to be compiled \
-as a {target_kind_human} target today. You can future-proof yourself and disable this warning by \
-adding {autodiscover_flag_name} = false to your [package] section. You may also move the files to \
-a location where Cargo would not automatically infer them to be a target, such as in subfolders.
+This is likely to break cargo build or cargo test as these files may not be
+ready to be compiled as a {target_kind_human} target today. You can future-proof yourself
+and disable this warning by adding {autodiscover_flag_name} = false to your [package]
+section. You may also move the files to a location where Cargo would not
+automatically infer them to be a target, such as in subfolders.
 
-For more information on this warning you can consult https://github.com/rust-lang/cargo/issues/5330\
-                            ",
+For more information on this warning you can consult
+https://github.com/rust-lang/cargo/issues/5330",
                                 section = target_kind,
                                 target_kind_human = target_kind_human,
                                 rem_targets_str = rem_targets_str,

--- a/src/cargo/util/toml/targets.rs
+++ b/src/cargo/util/toml/targets.rs
@@ -590,7 +590,7 @@ fn toml_targets_and_inferred(
                             let mut rem_targets_str = String::new();
                             for t in rem_targets.iter() {
                                 if let Some(p) = t.path.clone() {
-                                    rem_targets_str.push_str(&format!("* {:?}\n", p.0))
+                                    rem_targets_str.push_str(&format!("* {}\n", p.0.display()))
                                 }
                             }
                             warnings.push(format!(

--- a/src/cargo/util/toml/targets.rs
+++ b/src/cargo/util/toml/targets.rs
@@ -603,7 +603,7 @@ files will be included as a {target_kind_human} target:
 {rem_targets_str}
 This is likely to break cargo build or cargo test as these files may not be
 ready to be compiled as a {target_kind_human} target today. You can future-proof yourself
-and disable this warning by adding {autodiscover_flag_name} = false to your [package]
+and disable this warning by adding `{autodiscover_flag_name} = false` to your [package]
 section. You may also move the files to a location where Cargo would not
 automatically infer them to be a target, such as in subfolders.
 

--- a/src/doc/src/reference/manifest.md
+++ b/src/doc/src/reference/manifest.md
@@ -728,6 +728,10 @@ proc-macro = false
 harness = true
 ```
 
+The `[package]` also includes the optional `autobins`, `autoexamples`,
+`autotests`, and `autobenches` keys to explicitly opt-in or opt-out of
+auto-discovering specific target kinds.
+
 #### The `required-features` field (optional)
 
 The `required-features` field specifies which features the target needs in order

--- a/tests/testsuite/bench.rs
+++ b/tests/testsuite/bench.rs
@@ -762,7 +762,7 @@ files will be included as a benchmark target:
 
 This is likely to break cargo build or cargo test as these files may not be
 ready to be compiled as a benchmark target today. You can future-proof yourself
-and disable this warning by adding autobenches = false to your [package]
+and disable this warning by adding `autobenches = false` to your [package]
 section. You may also move the files to a location where Cargo would not
 automatically infer them to be a target, such as in subfolders.
 

--- a/tests/testsuite/bench.rs
+++ b/tests/testsuite/bench.rs
@@ -757,7 +757,7 @@ An explicit [[bench]] section is specified in Cargo.toml which currently disable
 automatically inferring other benchmark targets. This inference behavior will change in \
 the Rust 2018 edition and the following files will be included as a benchmark target:
 
-* \"[..]bench_basic.rs\"
+* [..]bench_basic.rs
 
 This is likely to break cargo build or cargo test as these files may not be ready to be compiled \
 as a benchmark target today. You can future-proof yourself and disable this warning by \

--- a/tests/testsuite/bench.rs
+++ b/tests/testsuite/bench.rs
@@ -757,7 +757,7 @@ An explicit [[bench]] section is specified in Cargo.toml which currently disable
 automatically inferring other benchmark targets. This inference behavior will change in \
 the Rust 2018 edition and the following files will be included as a benchmark target:
 
-* \"[..]foo[/]benches[/]bench_basic.rs\"
+* \"[..]bench_basic.rs\"
 
 This is likely to break cargo build or cargo test as these files may not be ready to be compiled \
 as a benchmark target today. You can future-proof yourself and disable this warning by \

--- a/tests/testsuite/bench.rs
+++ b/tests/testsuite/bench.rs
@@ -753,18 +753,21 @@ fn bench_autodiscover_2015() {
             .masquerade_as_nightly_cargo(),
         execs().with_stderr(&format!(
             "warning: \
-An explicit [[bench]] section is specified in Cargo.toml which currently disables Cargo from \
-automatically inferring other benchmark targets. This inference behavior will change in \
-the Rust 2018 edition and the following files will be included as a benchmark target:
+An explicit [[bench]] section is specified in Cargo.toml which currently
+disables Cargo from automatically inferring other benchmark targets.
+This inference behavior will change in the Rust 2018 edition and the following
+files will be included as a benchmark target:
 
 * [..]bench_basic.rs
 
-This is likely to break cargo build or cargo test as these files may not be ready to be compiled \
-as a benchmark target today. You can future-proof yourself and disable this warning by \
-adding autobenches = false to your [package] section. You may also move the files to \
-a location where Cargo would not automatically infer them to be a target, such as in subfolders.
+This is likely to break cargo build or cargo test as these files may not be
+ready to be compiled as a benchmark target today. You can future-proof yourself
+and disable this warning by adding autobenches = false to your [package]
+section. You may also move the files to a location where Cargo would not
+automatically infer them to be a target, such as in subfolders.
 
-For more information on this warning you can consult https://github.com/rust-lang/cargo/issues/5330
+For more information on this warning you can consult
+https://github.com/rust-lang/cargo/issues/5330
 [COMPILING] foo v0.0.1 ({})
 [FINISHED] release [optimized] target(s) in [..]
 [RUNNING] target[/]release[/]deps[/]foo-[..][EXE]

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -2264,7 +2264,6 @@ fn non_existing_example() {
         "#,
         )
         .file("src/lib.rs", "")
-        .file("examples/ehlo.rs", "")
         .build();
 
     assert_that(

--- a/tests/testsuite/package.rs
+++ b/tests/testsuite/package.rs
@@ -1220,7 +1220,7 @@ fn test_edition_nightly() {
 error: failed to parse manifest at `[..]`
 
 Caused by:
-  editiones are unstable
+  editions are unstable
 
 Caused by:
   feature `edition` is required

--- a/tests/testsuite/run.rs
+++ b/tests/testsuite/run.rs
@@ -1,5 +1,6 @@
 use cargo::util::paths::dylib_path_envvar;
-use cargotest::support::{execs, project, path2url};
+use cargotest::{self, ChannelChanger};
+use cargotest::support::{execs, project, Project, path2url};
 use hamcrest::{assert_that, existing_file};
 
 #[test]
@@ -373,6 +374,151 @@ fn run_example() {
 
     assert_that(
         p.cargo("run").arg("--example").arg("a"),
+        execs()
+            .with_status(0)
+            .with_stderr(&format!(
+                "\
+[COMPILING] foo v0.0.1 ({dir})
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[RUNNING] `target[/]debug[/]examples[/]a[EXE]`",
+                dir = path2url(p.root())
+            ))
+            .with_stdout("example"),
+    );
+}
+
+fn autodiscover_examples_project(rust_edition: &str, autoexamples: Option<bool>) -> Project {
+    let autoexamples = match autoexamples {
+        None => "".to_string(),
+        Some(bool) => format!("autoexamples = {}", bool),
+    };
+    project("foo")
+        .file(
+            "Cargo.toml",
+            &format!(
+                r#"
+            cargo-features = ["edition"]
+
+            [project]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+            rust = "{rust_edition}"
+            {autoexamples}
+
+            [features]
+            magic = []
+
+            [[example]]
+            name = "do_magic"
+            required-features = ["magic"]
+        "#,
+                rust_edition = rust_edition,
+                autoexamples = autoexamples
+            ),
+        )
+        .file(
+            "examples/a.rs",
+            r#"
+            fn main() { println!("example"); }
+        "#,
+        )
+        .file(
+            "examples/do_magic.rs",
+            r#"
+            fn main() { println!("magic example"); }
+        "#,
+        )
+        .build()
+}
+
+#[test]
+fn run_example_autodiscover_2015() {
+    if !cargotest::is_nightly() {
+        return;
+    }
+
+    let p = autodiscover_examples_project("2015", None);
+    assert_that(
+        p.cargo("run")
+            .arg("--example")
+            .arg("a")
+            .masquerade_as_nightly_cargo(),
+        execs().with_status(101).with_stderr(
+            "warning: \
+An explicit [[example]] section is specified in Cargo.toml which currently disables Cargo from \
+automatically inferring other example targets. This inference behavior will change in \
+the Rust 2018 edition and the following files will be included as a example target:
+
+* \"[..]foo[/]examples[/]a.rs\"
+
+This is likely to break cargo build or cargo test as these files may not be ready to be compiled \
+as a example target today. You can future-proof yourself and disable this warning by \
+adding autoexamples = false to your [package] section. You may also move the files to \
+a location where Cargo would not automatically infer them to be a target, such as in subfolders.
+
+For more information on this warning you can consult https://github.com/rust-lang/cargo/issues/5330
+error: no example target named `a`
+",
+        ),
+    );
+}
+
+#[test]
+fn run_example_autodiscover_2015_with_autoexamples_enabled() {
+    if !cargotest::is_nightly() {
+        return;
+    }
+
+    let p = autodiscover_examples_project("2015", Some(true));
+    assert_that(
+        p.cargo("run")
+            .arg("--example")
+            .arg("a")
+            .masquerade_as_nightly_cargo(),
+        execs()
+            .with_status(0)
+            .with_stderr(&format!(
+                "\
+[COMPILING] foo v0.0.1 ({dir})
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[RUNNING] `target[/]debug[/]examples[/]a[EXE]`",
+                dir = path2url(p.root())
+            ))
+            .with_stdout("example"),
+    );
+}
+
+#[test]
+fn run_example_autodiscover_2015_with_autoexamples_disabled() {
+    if !cargotest::is_nightly() {
+        return;
+    }
+
+    let p = autodiscover_examples_project("2015", Some(false));
+    assert_that(
+        p.cargo("run")
+            .arg("--example")
+            .arg("a")
+            .masquerade_as_nightly_cargo(),
+        execs()
+            .with_status(101)
+            .with_stderr("error: no example target named `a`\n"),
+    );
+}
+
+#[test]
+fn run_example_autodiscover_2018() {
+    if !cargotest::is_nightly() {
+        return;
+    }
+
+    let p = autodiscover_examples_project("2018", None);
+    assert_that(
+        p.cargo("run")
+            .arg("--example")
+            .arg("a")
+            .masquerade_as_nightly_cargo(),
         execs()
             .with_status(0)
             .with_stderr(&format!(

--- a/tests/testsuite/run.rs
+++ b/tests/testsuite/run.rs
@@ -450,7 +450,7 @@ An explicit [[example]] section is specified in Cargo.toml which currently disab
 automatically inferring other example targets. This inference behavior will change in \
 the Rust 2018 edition and the following files will be included as a example target:
 
-* \"[..]a.rs\"
+* [..]a.rs
 
 This is likely to break cargo build or cargo test as these files may not be ready to be compiled \
 as a example target today. You can future-proof yourself and disable this warning by \

--- a/tests/testsuite/run.rs
+++ b/tests/testsuite/run.rs
@@ -450,7 +450,7 @@ An explicit [[example]] section is specified in Cargo.toml which currently disab
 automatically inferring other example targets. This inference behavior will change in \
 the Rust 2018 edition and the following files will be included as a example target:
 
-* \"[..]foo[/]examples[/]a.rs\"
+* \"[..]a.rs\"
 
 This is likely to break cargo build or cargo test as these files may not be ready to be compiled \
 as a example target today. You can future-proof yourself and disable this warning by \

--- a/tests/testsuite/run.rs
+++ b/tests/testsuite/run.rs
@@ -446,18 +446,21 @@ fn run_example_autodiscover_2015() {
             .masquerade_as_nightly_cargo(),
         execs().with_status(101).with_stderr(
             "warning: \
-An explicit [[example]] section is specified in Cargo.toml which currently disables Cargo from \
-automatically inferring other example targets. This inference behavior will change in \
-the Rust 2018 edition and the following files will be included as a example target:
+An explicit [[example]] section is specified in Cargo.toml which currently
+disables Cargo from automatically inferring other example targets.
+This inference behavior will change in the Rust 2018 edition and the following
+files will be included as a example target:
 
 * [..]a.rs
 
-This is likely to break cargo build or cargo test as these files may not be ready to be compiled \
-as a example target today. You can future-proof yourself and disable this warning by \
-adding autoexamples = false to your [package] section. You may also move the files to \
-a location where Cargo would not automatically infer them to be a target, such as in subfolders.
+This is likely to break cargo build or cargo test as these files may not be
+ready to be compiled as a example target today. You can future-proof yourself
+and disable this warning by adding autoexamples = false to your [package]
+section. You may also move the files to a location where Cargo would not
+automatically infer them to be a target, such as in subfolders.
 
-For more information on this warning you can consult https://github.com/rust-lang/cargo/issues/5330
+For more information on this warning you can consult
+https://github.com/rust-lang/cargo/issues/5330
 error: no example target named `a`
 ",
         ),

--- a/tests/testsuite/run.rs
+++ b/tests/testsuite/run.rs
@@ -455,7 +455,7 @@ files will be included as a example target:
 
 This is likely to break cargo build or cargo test as these files may not be
 ready to be compiled as a example target today. You can future-proof yourself
-and disable this warning by adding autoexamples = false to your [package]
+and disable this warning by adding `autoexamples = false` to your [package]
 section. You may also move the files to a location where Cargo would not
 automatically infer them to be a target, such as in subfolders.
 


### PR DESCRIPTION
In Rust 2015 absence of the configuration makes it default to not
include auto-discovered targets (i.e false), with a warnings message.

In Rust 2018 absence makes it default to include auto-discovered
targets (i.e true).

Fixes #5330

---

_original_

Fixes #5330

submitted for early review. feedback very welcome, I'm happy to iterate (and learn).

in particular I require assistance with the borrowing of `warnings` in `clean_benches`.