### PR TITLE
Drop Option wrapper on Manifest target vecs

### DIFF
--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -215,10 +215,10 @@ pub struct TomlManifest {
     project: Option<Box<TomlProject>>,
     profile: Option<TomlProfiles>,
     lib: Option<TomlLibTarget>,
-    bin: Option<Vec<TomlBinTarget>>,
-    example: Option<Vec<TomlExampleTarget>>,
-    test: Option<Vec<TomlTestTarget>>,
-    bench: Option<Vec<TomlTestTarget>>,
+    bin: Vec<TomlBinTarget>,
+    example: Vec<TomlExampleTarget>,
+    test: Vec<TomlTestTarget>,
+    bench: Vec<TomlTestTarget>,
     dependencies: Option<BTreeMap<String, TomlDependency>>,
     dev_dependencies: Option<BTreeMap<String, TomlDependency>>,
     #[serde(rename = "dev_dependencies")]
@@ -862,16 +862,16 @@ impl TomlManifest {
         if me.lib.is_some() {
             bail!("virtual manifests do not specify [lib]");
         }
-        if me.bin.is_some() {
+        if !me.bin.is_empty() {
             bail!("virtual manifests do not specify [[bin]]");
         }
-        if me.example.is_some() {
+        if !me.example.is_empty() {
             bail!("virtual manifests do not specify [[example]]");
         }
-        if me.test.is_some() {
+        if !me.test.is_empty() {
             bail!("virtual manifests do not specify [[test]]");
         }
-        if me.bench.is_some() {
+        if !me.bench.is_empty() {
             bail!("virtual manifests do not specify [[bench]]");
         }
 

--- a/src/cargo/util/toml/targets.rs
+++ b/src/cargo/util/toml/targets.rs
@@ -40,7 +40,7 @@ pub fn targets(
     }
 
     targets.extend(clean_bins(
-        manifest.bin.as_ref(),
+        &manifest.bin,
         package_root,
         package_name,
         warnings,
@@ -48,16 +48,12 @@ pub fn targets(
         has_lib,
     )?);
 
-    targets.extend(clean_examples(
-        manifest.example.as_ref(),
-        package_root,
-        errors,
-    )?);
+    targets.extend(clean_examples(&manifest.example, package_root, errors)?);
 
-    targets.extend(clean_tests(manifest.test.as_ref(), package_root, errors)?);
+    targets.extend(clean_tests(&manifest.test, package_root, errors)?);
 
     targets.extend(clean_benches(
-        manifest.bench.as_ref(),
+        &manifest.bench,
         package_root,
         warnings,
         errors,

--- a/src/cargo/util/toml/targets.rs
+++ b/src/cargo/util/toml/targets.rs
@@ -161,7 +161,7 @@ fn clean_lib(
 }
 
 fn clean_bins(
-    toml_bins: Option<&Vec<TomlBinTarget>>,
+    toml_bins: &Vec<TomlBinTarget>,
     package_root: &Path,
     package_name: &str,
     warnings: &mut Vec<String>,
@@ -169,16 +169,17 @@ fn clean_bins(
     has_lib: bool,
 ) -> CargoResult<Vec<Target>> {
     let inferred = inferred_bins(package_root, package_name);
-    let bins = match toml_bins {
-        Some(bins) => bins.clone(),
-        None => inferred
+    let bins = if toml_bins.is_empty() {
+        inferred
             .iter()
             .map(|&(ref name, ref path)| TomlTarget {
                 name: Some(name.clone()),
                 path: Some(PathValue(path.clone())),
                 ..TomlTarget::new()
             })
-            .collect(),
+            .collect()
+    } else {
+        toml_bins.clone()
     };
 
     for bin in &bins {
@@ -259,7 +260,7 @@ fn clean_bins(
 }
 
 fn clean_examples(
-    toml_examples: Option<&Vec<TomlExampleTarget>>,
+    toml_examples: &Vec<TomlExampleTarget>,
     package_root: &Path,
     errors: &mut Vec<String>,
 ) -> CargoResult<Vec<Target>> {
@@ -295,7 +296,7 @@ fn clean_examples(
 }
 
 fn clean_tests(
-    toml_tests: Option<&Vec<TomlTestTarget>>,
+    toml_tests: &Vec<TomlTestTarget>,
     package_root: &Path,
     errors: &mut Vec<String>,
 ) -> CargoResult<Vec<Target>> {
@@ -313,7 +314,7 @@ fn clean_tests(
 }
 
 fn clean_benches(
-    toml_benches: Option<&Vec<TomlBenchTarget>>,
+    toml_benches: &Vec<TomlBenchTarget>,
     package_root: &Path,
     warnings: &mut Vec<String>,
     errors: &mut Vec<String>,
@@ -357,7 +358,7 @@ fn clean_benches(
 fn clean_targets(
     target_kind_human: &str,
     target_kind: &str,
-    toml_targets: Option<&Vec<TomlTarget>>,
+    toml_targets: &Vec<TomlTarget>,
     inferred: &[(String, PathBuf)],
     package_root: &Path,
     errors: &mut Vec<String>,
@@ -376,22 +377,23 @@ fn clean_targets(
 fn clean_targets_with_legacy_path(
     target_kind_human: &str,
     target_kind: &str,
-    toml_targets: Option<&Vec<TomlTarget>>,
+    toml_targets: &Vec<TomlTarget>,
     inferred: &[(String, PathBuf)],
     package_root: &Path,
     errors: &mut Vec<String>,
     legacy_path: &mut FnMut(&TomlTarget) -> Option<PathBuf>,
 ) -> CargoResult<Vec<(PathBuf, TomlTarget)>> {
-    let toml_targets = match toml_targets {
-        Some(targets) => targets.clone(),
-        None => inferred
+    let toml_targets = if toml_targets.is_empty() {
+        inferred
             .iter()
             .map(|&(ref name, ref path)| TomlTarget {
                 name: Some(name.clone()),
                 path: Some(PathValue(path.clone())),
                 ..TomlTarget::new()
             })
-            .collect(),
+            .collect()
+    } else {
+        toml_targets.clone()
     };
 
     for target in &toml_targets {


### PR DESCRIPTION
As opposed to other manifest keys, such as `authors`, where a difference
may be drawn between:

    authors = []

and the complete absence of the `authors` key the same cannot be said
for the target keys which are TOML [Array of Tables][1] types for which
the only way to define an empty array is by never defining any element
in it.

[1]: https://github.com/toml-lang/toml#array-of-tables