### PR TITLE
tweak test/bench's help around filtering & libtest

### DIFF
--- a/src/bin/commands/bench.rs
+++ b/src/bin/commands/bench.rs
@@ -45,9 +45,12 @@ pub fn cli() -> App {
         ))
         .after_help(
             "\
-All of the trailing arguments are passed to the benchmark binaries generated
-for filtering benchmarks and generally providing options configuring how they
-run.
+The benchmark filtering argument `BENCHNAME` and all the arguments following the
+two dashes (`--`) are passed to the benchmark binaries and thus to libtest
+(rustc's built in unit-test and micro-benchmarking framework).  If you're
+passing arguments to both Cargo and the binary, the ones after `--` go to the
+binary, the ones before go to Cargo.  For details about libtest's arguments see
+the output of `cargo bench -- --help`.
 
 If the --package argument is given, then SPEC is a package id specification
 which indicates which package should be benchmarked. If it is not given, then

--- a/src/bin/commands/run.rs
+++ b/src/bin/commands/run.rs
@@ -27,9 +27,9 @@ bin target it will be run. Otherwise `--bin` specifies the bin target to run,
 and `--example` specifies the example target to run. At most one of `--bin` or
 `--example` can be provided.
 
-All of the trailing arguments are passed to the binary to run. If you're passing
-arguments to both Cargo and the binary, the ones after `--` go to the binary,
-the ones before go to Cargo.
+All the arguments following the two dashes (`--`) are passed to the binary to
+run. If you're passing arguments to both Cargo and the binary, the ones after
+`--` go to the binary, the ones before go to Cargo.
 ",
         )
 }

--- a/src/bin/commands/test.rs
+++ b/src/bin/commands/test.rs
@@ -45,11 +45,15 @@ pub fn cli() -> App {
         .arg_message_format()
         .after_help(
             "\
-All of the trailing arguments are passed to the test binaries generated for
-filtering tests and generally providing options configuring how they run. For
-example, this will run all tests with the name `foo` in their name:
+The test filtering argument `TESTNAME` and all the arguments following the
+two dashes (`--`) are passed to the test binaries and thus to libtest
+(rustc's built in unit-test and micro-benchmarking framework).  If you're
+passing arguments to both Cargo and the binary, the ones after `--` go to the
+binary, the ones before go to Cargo.  For details about libtest's arguments see
+the output of `cargo test -- --help`.  As an example, this will run all
+tests with `foo` in their name on 3 threads in parallel:
 
-    cargo test foo
+    cargo test foo -- --test-threads 3
 
 If the --package argument is given, then SPEC is a package id specification
 which indicates which package should be tested. If it is not given, then the


### PR DESCRIPTION
Attempt to bring more clarity about test/bench's filtering arg by
detailing the distinction and integration between cargo's test/bench and
libtest.

Also make sure to mention how to see libtest's help/usage message.

Fixes #5337

Feedback welcome.  Also, how do I auto-generate the man pages in
src/etc/man/?  I'm wasn't sure about the escaping to attempt manually
editing.