### PR TITLE
Mention Cargo.toml in manifest help description

### DIFF
--- a/src/etc/man/cargo-bench.1
+++ b/src/etc/man/cargo-bench.1
@@ -99,7 +99,7 @@ Build for the target triple.
 .RE
 .TP
 .B \-\-manifest\-path \f[I]PATH\f[]
-Path to the manifest (Cargo.toml) to compile.
+Path to the Cargo.toml to compile.
 .RS
 .RE
 .TP

--- a/src/etc/man/cargo-bench.1
+++ b/src/etc/man/cargo-bench.1
@@ -99,7 +99,7 @@ Build for the target triple.
 .RE
 .TP
 .B \-\-manifest\-path \f[I]PATH\f[]
-Path to the manifest to compile.
+Path to the manifest (Cargo.toml) to compile.
 .RS
 .RE
 .TP

--- a/src/etc/man/cargo-build.1
+++ b/src/etc/man/cargo-build.1
@@ -88,7 +88,7 @@ Build for the target triple.
 .RE
 .TP
 .B \-\-manifest\-path \f[I]PATH\f[]
-Path to the manifest to compile.
+Path to the Cargo.toml to compile.
 .RS
 .RE
 .TP

--- a/src/etc/man/cargo-check.1
+++ b/src/etc/man/cargo-check.1
@@ -88,7 +88,7 @@ Check for the target triple.
 .RE
 .TP
 .B \-\-manifest\-path \f[I]PATH\f[]
-Path to the manifest (Cargo.toml) to compile.
+Path to the Cargo.toml to compile.
 .RS
 .RE
 .TP

--- a/src/etc/man/cargo-check.1
+++ b/src/etc/man/cargo-check.1
@@ -88,7 +88,7 @@ Check for the target triple.
 .RE
 .TP
 .B \-\-manifest\-path \f[I]PATH\f[]
-Path to the manifest to compile.
+Path to the manifest (Cargo.toml) to compile.
 .RS
 .RE
 .TP

--- a/src/etc/man/cargo-doc.1
+++ b/src/etc/man/cargo-doc.1
@@ -73,7 +73,7 @@ Build for the target triple.
 .RE
 .TP
 .B \-\-manifest\-path \f[I]PATH\f[]
-Path to the manifest to compile.
+Path to the manifestsrc/etc/man/cargo-doc.1 to compile.
 .RS
 .RE
 .TP

--- a/src/etc/man/cargo-doc.1
+++ b/src/etc/man/cargo-doc.1
@@ -73,7 +73,7 @@ Build for the target triple.
 .RE
 .TP
 .B \-\-manifest\-path \f[I]PATH\f[]
-Path to the manifestsrc/etc/man/cargo-doc.1 to compile.
+Path to the Cargo.toml to compile.
 .RS
 .RE
 .TP

--- a/src/etc/man/cargo-package.1
+++ b/src/etc/man/cargo-package.1
@@ -32,7 +32,7 @@ Ignore warnings about a lack of human\-usable metadata.
 .RE
 .TP
 .B \-\-manifest\-path \f[I]PATH\f[]
-Path to the manifest (Cargo.toml) to compile.
+Path to the Cargo.toml to compile.
 .RS
 .RE
 .TP

--- a/src/etc/man/cargo-package.1
+++ b/src/etc/man/cargo-package.1
@@ -32,7 +32,7 @@ Ignore warnings about a lack of human\-usable metadata.
 .RE
 .TP
 .B \-\-manifest\-path \f[I]PATH\f[]
-Path to the manifest to compile.
+Path to the manifest (Cargo.toml) to compile.
 .RS
 .RE
 .TP

--- a/src/etc/man/cargo-run.1
+++ b/src/etc/man/cargo-run.1
@@ -67,7 +67,7 @@ Build for the target triple.
 .RE
 .TP
 .B \-\-manifest\-path \f[I]PATH\f[]
-Path to the manifest to compile.
+Path to the manifest (Cargo.toml) to compile.
 .RS
 .RE
 .TP

--- a/src/etc/man/cargo-run.1
+++ b/src/etc/man/cargo-run.1
@@ -67,7 +67,7 @@ Build for the target triple.
 .RE
 .TP
 .B \-\-manifest\-path \f[I]PATH\f[]
-Path to the manifest (Cargo.toml) to compile.
+Path to the Cargo.toml to compile.
 .RS
 .RE
 .TP

--- a/src/etc/man/cargo-test.1
+++ b/src/etc/man/cargo-test.1
@@ -123,7 +123,7 @@ Build for the target triple.
 .RE
 .TP
 .B \-\-manifest\-path \f[I]PATH\f[]
-Path to the manifest to compile.
+Path to the manifest (Cargo.toml) to compile.
 .RS
 .RE
 .TP

--- a/src/etc/man/cargo-test.1
+++ b/src/etc/man/cargo-test.1
@@ -123,7 +123,7 @@ Build for the target triple.
 .RE
 .TP
 .B \-\-manifest\-path \f[I]PATH\f[]
-Path to the manifest (Cargo.toml) to compile.
+Path to the Cargo.toml to compile.
 .RS
 .RE
 .TP


### PR DESCRIPTION
I was looking for a CLI flag to pass a different TOML to cargo, but didn’t realize it’s called “manifest” from reading the help.