### PR TITLE
Correctly print fractional part of a second

### DIFF
--- a/src/cargo/core/compiler/job_queue.rs
+++ b/src/cargo/core/compiler/job_queue.rs
@@ -264,7 +264,7 @@ impl<'a> JobQueue<'a> {
         }
         let duration = cx.config.creation_time().elapsed();
         let time_elapsed = format!(
-            "{}.{1:.2} secs",
+            "{}.{:02} secs",
             duration.as_secs(),
             duration.subsec_nanos() / 10_000_000
         );


### PR DESCRIPTION
So my experiments with `rustc -vV` caching bring no-op build times to around 50ms, and this actually exposes a bug in our time-printing code :-)