### PR TITLE
Rustc cache

### DIFF
--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -47,7 +47,7 @@ Run with 'cargo -Z [FLAG] [SUBCOMMAND]'"
     }
 
     if let Some(ref code) = args.value_of("explain") {
-        let mut procss = config.rustc()?.process();
+        let mut procss = config.new_rustc()?.process();
         procss.arg("--explain").arg(code).exec()?;
         return Ok(());
     }

--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -47,7 +47,7 @@ Run with 'cargo -Z [FLAG] [SUBCOMMAND]'"
     }
 
     if let Some(ref code) = args.value_of("explain") {
-        let mut procss = config.new_rustc()?.process();
+        let mut procss = config.rustc(None)?.process();
         procss.arg("--explain").arg(code).exec()?;
         return Ok(());
     }

--- a/src/cargo/core/compiler/compilation.rs
+++ b/src/cargo/core/compiler/compilation.rs
@@ -57,15 +57,17 @@ pub struct Compilation<'cfg> {
     /// Flags to pass to rustdoc when invoked from cargo test, per package.
     pub rustdocflags: HashMap<PackageId, Vec<String>>,
 
+    pub host: String,
     pub target: String,
 
     config: &'cfg Config,
+    rustc_process: ProcessBuilder,
 
     target_runner: LazyCell<Option<(PathBuf, Vec<String>)>>,
 }
 
 impl<'cfg> Compilation<'cfg> {
-    pub fn new(config: &'cfg Config) -> Compilation<'cfg> {
+    pub fn new(config: &'cfg Config, rustc_process: ProcessBuilder) -> Compilation<'cfg> {
         Compilation {
             libraries: HashMap::new(),
             native_dirs: BTreeSet::new(), // TODO: deprecated, remove
@@ -81,6 +83,8 @@ impl<'cfg> Compilation<'cfg> {
             cfgs: HashMap::new(),
             rustdocflags: HashMap::new(),
             config,
+            rustc_process,
+            host: String::new(),
             target: String::new(),
             target_runner: LazyCell::new(),
         }
@@ -88,7 +92,7 @@ impl<'cfg> Compilation<'cfg> {
 
     /// See `process`.
     pub fn rustc_process(&self, pkg: &Package) -> CargoResult<ProcessBuilder> {
-        self.fill_env(self.config.rustc()?.process(), pkg, true)
+        self.fill_env(self.rustc_process.clone(), pkg, true)
     }
 
     /// See `process`.

--- a/src/cargo/core/compiler/context/compilation_files.rs
+++ b/src/cargo/core/compiler/context/compilation_files.rs
@@ -434,9 +434,7 @@ fn compute_metadata<'a, 'cfg>(
     unit.target.name().hash(&mut hasher);
     unit.target.kind().hash(&mut hasher);
 
-    if let Ok(rustc) = cx.config.rustc() {
-        rustc.verbose_version.hash(&mut hasher);
-    }
+    cx.build_config.rustc.verbose_version.hash(&mut hasher);
 
     // Seed the contents of __CARGO_DEFAULT_LIB_METADATA to the hasher if present.
     // This should be the release channel, to get a different hash for each channel.

--- a/src/cargo/core/compiler/context/mod.rs
+++ b/src/cargo/core/compiler/context/mod.rs
@@ -130,7 +130,7 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
             let _p = profile::start("Context::probe_target_info");
             debug!("probe_target_info");
             let host_target_same = match build_config.requested_target {
-                Some(ref s) if s != &config.rustc()?.host => false,
+                Some(ref s) if s != &build_config.host_triple => false,
                 _ => true,
             };
 
@@ -150,7 +150,7 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
             config,
             target_info,
             host_info,
-            compilation: Compilation::new(config),
+            compilation: Compilation::new(config, build_config.rustc.process()),
             build_state: Arc::new(BuildState::new(&build_config)),
             build_config,
             fingerprints: HashMap::new(),
@@ -302,6 +302,7 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
                 self.compilation.native_dirs.insert(dir.clone());
             }
         }
+        self.compilation.host = self.build_config.host_triple.clone();
         self.compilation.target = self.build_config.target_triple().to_string();
         Ok(self.compilation)
     }

--- a/src/cargo/core/compiler/context/mod.rs
+++ b/src/cargo/core/compiler/context/mod.rs
@@ -130,7 +130,7 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
             let _p = profile::start("Context::probe_target_info");
             debug!("probe_target_info");
             let host_target_same = match build_config.requested_target {
-                Some(ref s) if s != &build_config.host_triple => false,
+                Some(ref s) if s != &build_config.host_triple() => false,
                 _ => true,
             };
 
@@ -302,7 +302,7 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
                 self.compilation.native_dirs.insert(dir.clone());
             }
         }
-        self.compilation.host = self.build_config.host_triple.clone();
+        self.compilation.host = self.build_config.host_triple().to_string();
         self.compilation.target = self.build_config.target_triple().to_string();
         Ok(self.compilation)
     }
@@ -441,7 +441,7 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
             None => return true,
         };
         let (name, info) = match kind {
-            Kind::Host => (self.build_config.host_triple.as_ref(), &self.host_info),
+            Kind::Host => (self.build_config.host_triple(), &self.host_info),
             Kind::Target => (self.build_config.target_triple(), &self.target_info),
         };
         platform.matches(name, info.cfg())
@@ -653,7 +653,8 @@ fn env_args(
     let target = build_config
         .requested_target
         .as_ref()
-        .unwrap_or(&build_config.host_triple);
+        .map(|s| s.as_str())
+        .unwrap_or(build_config.host_triple());
     let key = format!("target.{}.{}", target, name);
     if let Some(args) = config.get_list_or_split_string(&key)? {
         let args = args.val.into_iter();

--- a/src/cargo/core/compiler/context/target_info.rs
+++ b/src/cargo/core/compiler/context/target_info.rs
@@ -53,7 +53,7 @@ impl FileType {
 impl TargetInfo {
     pub fn new(config: &Config, build_config: &BuildConfig, kind: Kind) -> CargoResult<TargetInfo> {
         let rustflags = env_args(config, build_config, None, kind, "RUSTFLAGS")?;
-        let mut process = config.rustc()?.process();
+        let mut process = build_config.rustc.process();
         process
             .arg("-")
             .arg("--crate-name")

--- a/src/cargo/core/compiler/context/target_info.rs
+++ b/src/cargo/core/compiler/context/target_info.rs
@@ -78,20 +78,19 @@ impl TargetInfo {
         with_cfg.arg("--print=cfg");
 
         let mut has_cfg_and_sysroot = true;
-        let output = with_cfg
-            .exec_with_output()
+        let (output, error) = build_config
+            .rustc
+            .cached_output(&with_cfg)
             .or_else(|_| {
                 has_cfg_and_sysroot = false;
-                process.exec_with_output()
+                build_config.rustc.cached_output(&process)
             })
             .chain_err(|| "failed to run `rustc` to learn about target-specific information")?;
 
-        let error = str::from_utf8(&output.stderr).unwrap();
-        let output = str::from_utf8(&output.stdout).unwrap();
         let mut lines = output.lines();
         let mut map = HashMap::new();
         for crate_type in KNOWN_CRATE_TYPES {
-            let out = parse_crate_type(crate_type, error, &mut lines)?;
+            let out = parse_crate_type(crate_type, &error, &mut lines)?;
             map.insert(crate_type.to_string(), out);
         }
 

--- a/src/cargo/core/compiler/custom_build.rs
+++ b/src/cargo/core/compiler/custom_build.rs
@@ -142,7 +142,7 @@ fn build_work<'a, 'cfg>(cx: &mut Context<'a, 'cfg>, unit: &Unit<'a>) -> CargoRes
             },
         )
         .env("HOST", &cx.build_config.host_triple)
-        .env("RUSTC", &cx.config.rustc()?.path)
+        .env("RUSTC", &cx.build_config.rustc.path)
         .env("RUSTDOC", &*cx.config.rustdoc()?)
         .inherit_jobserver(&cx.jobserver);
 

--- a/src/cargo/core/compiler/custom_build.rs
+++ b/src/cargo/core/compiler/custom_build.rs
@@ -127,7 +127,7 @@ fn build_work<'a, 'cfg>(cx: &mut Context<'a, 'cfg>, unit: &Unit<'a>) -> CargoRes
         .env(
             "TARGET",
             &match unit.kind {
-                Kind::Host => &cx.build_config.host_triple,
+                Kind::Host => &cx.build_config.host_triple(),
                 Kind::Target => cx.build_config.target_triple(),
             },
         )
@@ -141,7 +141,7 @@ fn build_work<'a, 'cfg>(cx: &mut Context<'a, 'cfg>, unit: &Unit<'a>) -> CargoRes
                 "debug"
             },
         )
-        .env("HOST", &cx.build_config.host_triple)
+        .env("HOST", &cx.build_config.host_triple())
         .env("RUSTC", &cx.build_config.rustc.path)
         .env("RUSTDOC", &*cx.config.rustdoc()?)
         .inherit_jobserver(&cx.jobserver);

--- a/src/cargo/core/compiler/fingerprint.rs
+++ b/src/cargo/core/compiler/fingerprint.rs
@@ -455,7 +455,7 @@ fn calculate<'a, 'cfg>(
         cx.rustflags_args(unit)?
     };
     let fingerprint = Arc::new(Fingerprint {
-        rustc: util::hash_u64(&cx.config.rustc()?.verbose_version),
+        rustc: util::hash_u64(&cx.build_config.rustc.verbose_version),
         target: util::hash_u64(&unit.target),
         profile: util::hash_u64(&(&unit.profile, cx.incremental_args(unit)?)),
         // Note that .0 is hashed here, not .1 which is the cwd. That doesn't

--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -80,6 +80,7 @@ impl BuildConfig {
         config: &Config,
         jobs: Option<u32>,
         requested_target: &Option<String>,
+        rustc_info_cache: Option<PathBuf>,
     ) -> CargoResult<BuildConfig> {
         if let &Some(ref s) = requested_target {
             if s.trim().is_empty() {
@@ -117,7 +118,7 @@ impl BuildConfig {
             None => None,
         };
         let jobs = jobs.or(cfg_jobs).unwrap_or(::num_cpus::get() as u32);
-        let rustc = config.new_rustc()?;
+        let rustc = config.rustc(rustc_info_cache)?;
         let host_config = TargetConfig::new(config, &rustc.host)?;
         let target_config = match target.as_ref() {
             Some(triple) => TargetConfig::new(config, triple)?,

--- a/src/cargo/ops/cargo_clean.rs
+++ b/src/cargo/ops/cargo_clean.rs
@@ -84,7 +84,7 @@ pub fn clean(ws: &Workspace, opts: &CleanOptions) -> CargoResult<()> {
         }
     }
 
-    let mut build_config = BuildConfig::new(config, Some(1), &opts.target)?;
+    let mut build_config = BuildConfig::new(config, Some(1), &opts.target, None)?;
     build_config.release = opts.release;
     let mut cx = Context::new(ws, &resolve, &packages, opts.config, build_config, profiles)?;
     cx.prepare_units(None, &units)?;

--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -260,7 +260,8 @@ pub fn compile_ws<'a>(
         bail!("jobs must be at least 1")
     }
 
-    let mut build_config = BuildConfig::new(config, jobs, &target)?;
+    let rustc_info_cache = ws.target_dir().join("rustc_info.json").into_path_unlocked();
+    let mut build_config = BuildConfig::new(config, jobs, &target, Some(rustc_info_cache))?;
     build_config.release = release;
     build_config.test = mode == CompileMode::Test || mode == CompileMode::Bench;
     build_config.json_messages = message_format == MessageFormat::Json;

--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -260,7 +260,7 @@ pub fn compile_ws<'a>(
         bail!("jobs must be at least 1")
     }
 
-    let rustc_info_cache = ws.target_dir().join("rustc_info.json").into_path_unlocked();
+    let rustc_info_cache = ws.target_dir().join(".rustc_info.json").into_path_unlocked();
     let mut build_config = BuildConfig::new(config, jobs, &target, Some(rustc_info_cache))?;
     build_config.release = release;
     build_config.test = mode == CompileMode::Test || mode == CompileMode::Bench;

--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -260,7 +260,9 @@ pub fn compile_ws<'a>(
         bail!("jobs must be at least 1")
     }
 
-    let rustc_info_cache = ws.target_dir().join(".rustc_info.json").into_path_unlocked();
+    let rustc_info_cache = ws.target_dir()
+        .join(".rustc_info.json")
+        .into_path_unlocked();
     let mut build_config = BuildConfig::new(config, jobs, &target, Some(rustc_info_cache))?;
     build_config.release = release;
     build_config.test = mode == CompileMode::Test || mode == CompileMode::Bench;

--- a/src/cargo/ops/cargo_test.rs
+++ b/src/cargo/ops/cargo_test.rs
@@ -150,7 +150,7 @@ fn run_doc_tests(
     let config = options.compile_opts.config;
 
     // We don't build/rust doctests if target != host
-    if config.rustc()?.host != compilation.target {
+    if compilation.host != compilation.target {
         return Ok((Test::Doc, errors));
     }
 

--- a/src/cargo/sources/path.rs
+++ b/src/cargo/sources/path.rs
@@ -11,6 +11,7 @@ use ignore::gitignore::GitignoreBuilder;
 use core::{Dependency, Package, PackageId, Registry, Source, SourceId, Summary};
 use ops;
 use util::{self, internal, CargoResult};
+use util::paths;
 use util::Config;
 
 pub struct PathSource<'cfg> {
@@ -529,9 +530,7 @@ impl<'cfg> Source for PathSource<'cfg> {
             // condition where this path was rm'ed - either way,
             // we can ignore the error and treat the path's mtime
             // as 0.
-            let mtime = fs::metadata(&file)
-                .map(|meta| FileTime::from_last_modification_time(&meta))
-                .unwrap_or(FileTime::zero());
+            let mtime = paths::mtime(&file).unwrap_or(FileTime::zero());
             warn!("{} {}", mtime, file.display());
             if mtime > max {
                 max = mtime;

--- a/src/cargo/util/config.rs
+++ b/src/cargo/util/config.rs
@@ -171,6 +171,7 @@ impl Config {
         Rustc::new(
             self.get_tool("rustc")?,
             self.maybe_get_tool("rustc_wrapper")?,
+            &self.home().join("bin").join("rustc").into_path_unlocked(),
             if self.cache_rustc_info {
                 cache_location
             } else {

--- a/src/cargo/util/config.rs
+++ b/src/cargo/util/config.rs
@@ -171,7 +171,11 @@ impl Config {
         Rustc::new(
             self.get_tool("rustc")?,
             self.maybe_get_tool("rustc_wrapper")?,
-            &self.home().join("bin").join("rustc").into_path_unlocked(),
+            &self.home()
+                .join("bin")
+                .join("rustc")
+                .into_path_unlocked()
+                .with_extension(env::consts::EXE_EXTENSION),
             if self.cache_rustc_info {
                 cache_location
             } else {

--- a/src/cargo/util/config.rs
+++ b/src/cargo/util/config.rs
@@ -158,13 +158,11 @@ impl Config {
     }
 
     /// Get the path to the `rustc` executable
-    pub fn rustc(&self) -> CargoResult<&Rustc> {
-        self.rustc.try_borrow_with(|| {
-            Rustc::new(
-                self.get_tool("rustc")?,
-                self.maybe_get_tool("rustc_wrapper")?,
-            )
-        })
+    pub fn new_rustc(&self) -> CargoResult<Rustc> {
+        Rustc::new(
+            self.get_tool("rustc")?,
+            self.maybe_get_tool("rustc_wrapper")?,
+        )
     }
 
     /// Get the path to the `cargo` executable

--- a/src/cargo/util/paths.rs
+++ b/src/cargo/util/paths.rs
@@ -158,8 +158,7 @@ pub fn append(path: &Path, contents: &[u8]) -> CargoResult<()> {
 }
 
 pub fn mtime(path: &Path) -> CargoResult<FileTime> {
-    let meta =
-        fs::metadata(path).chain_err(|| format!("failed to stat `{}`", path.display()))?;
+    let meta = fs::metadata(path).chain_err(|| format!("failed to stat `{}`", path.display()))?;
     Ok(FileTime::from_last_modification_time(&meta))
 }
 

--- a/src/cargo/util/paths.rs
+++ b/src/cargo/util/paths.rs
@@ -8,8 +8,7 @@ use std::iter;
 
 use filetime::FileTime;
 
-use util::{internal, CargoResult};
-use util::errors::{CargoError, CargoResultExt, Internal};
+use util::errors::{CargoError, CargoResult, CargoResultExt, Internal};
 
 pub fn join_paths<T: AsRef<OsStr>>(paths: &[T], env: &str) -> CargoResult<OsString> {
     let err = match env::join_paths(paths.iter()) {
@@ -154,13 +153,13 @@ pub fn append(path: &Path, contents: &[u8]) -> CargoResult<()> {
         f.write_all(contents)?;
         Ok(())
     })()
-        .chain_err(|| internal(format!("failed to write `{}`", path.display())))?;
+        .chain_err(|| format!("failed to write `{}`", path.display()))?;
     Ok(())
 }
 
 pub fn mtime(path: &Path) -> CargoResult<FileTime> {
     let meta =
-        fs::metadata(path).chain_err(|| internal(format!("failed to stat `{}`", path.display())))?;
+        fs::metadata(path).chain_err(|| format!("failed to stat `{}`", path.display()))?;
     Ok(FileTime::from_last_modification_time(&meta))
 }
 

--- a/src/cargo/util/paths.rs
+++ b/src/cargo/util/paths.rs
@@ -132,8 +132,8 @@ pub fn append(path: &Path, contents: &[u8]) -> CargoResult<()> {
 }
 
 pub fn mtime(path: &Path) -> CargoResult<FileTime> {
-    let meta = fs::metadata(path)
-        .chain_err(|| internal(format!("failed to stat `{}`", path.display())))?;
+    let meta =
+        fs::metadata(path).chain_err(|| internal(format!("failed to stat `{}`", path.display())))?;
     Ok(FileTime::from_last_modification_time(&meta))
 }
 

--- a/src/cargo/util/paths.rs
+++ b/src/cargo/util/paths.rs
@@ -5,6 +5,8 @@ use std::io;
 use std::io::prelude::*;
 use std::path::{Component, Path, PathBuf};
 
+use filetime::FileTime;
+
 use util::{internal, CargoResult};
 use util::errors::{CargoError, CargoResultExt, Internal};
 
@@ -127,6 +129,12 @@ pub fn append(path: &Path, contents: &[u8]) -> CargoResult<()> {
     })()
         .chain_err(|| internal(format!("failed to write `{}`", path.display())))?;
     Ok(())
+}
+
+pub fn mtime(path: &Path) -> CargoResult<FileTime> {
+    let meta = fs::metadata(path)
+        .chain_err(|| internal(format!("failed to stat `{}`", path.display())))?;
+    Ok(FileTime::from_last_modification_time(&meta))
 }
 
 #[cfg(unix)]

--- a/src/cargo/util/rustc.rs
+++ b/src/cargo/util/rustc.rs
@@ -1,6 +1,15 @@
-use std::path::PathBuf;
+#![allow(deprecated)] // for SipHasher
+
+use std::path::{Path, PathBuf};
+use std::hash::{Hash, Hasher, SipHasher};
+use std::collections::hash_map::{Entry, HashMap};
+use std::sync::Mutex;
+use std::env;
+
+use serde_json;
 
 use util::{self, internal, profile, CargoResult, ProcessBuilder};
+use util::paths;
 
 /// Information on the `rustc` executable
 #[derive(Debug)]
@@ -14,6 +23,7 @@ pub struct Rustc {
     pub verbose_version: String,
     /// The host triple (arch-platform-OS), this comes from verbose_version.
     pub host: String,
+    cache: Mutex<Cache>,
 }
 
 impl Rustc {
@@ -22,16 +32,18 @@ impl Rustc {
     ///
     /// If successful this function returns a description of the compiler along
     /// with a list of its capabilities.
-    pub fn new(path: PathBuf, wrapper: Option<PathBuf>) -> CargoResult<Rustc> {
+    pub fn new(
+        path: PathBuf,
+        wrapper: Option<PathBuf>,
+        cache_location: Option<PathBuf>,
+    ) -> CargoResult<Rustc> {
         let _p = profile::start("Rustc::new");
+
+        let mut cache = Cache::load(&path, cache_location);
 
         let mut cmd = util::process(&path);
         cmd.arg("-vV");
-
-        let output = cmd.exec_with_output()?;
-
-        let verbose_version = String::from_utf8(output.stdout)
-            .map_err(|_| internal("rustc -v didn't return utf8 output"))?;
+        let verbose_version = cache.cached_output(&cmd)?.0;
 
         let host = {
             let triple = verbose_version
@@ -47,6 +59,7 @@ impl Rustc {
             wrapper,
             verbose_version,
             host,
+            cache: Mutex::new(cache),
         })
     }
 
@@ -62,4 +75,157 @@ impl Rustc {
             util::process(&self.path)
         }
     }
+
+    pub fn cached_output(&self, cmd: &ProcessBuilder) -> CargoResult<(String, String)> {
+        self.cache.lock().unwrap().cached_output(cmd)
+    }
+}
+
+/// It is a well known that `rustc` is not the fastest compiler in the world.
+/// What is less known is that even `rustc --version --verbose` takes about a
+/// hundred milliseconds! Because we need compiler version info even for no-op
+/// builds, we cache it here, based on compiler's mtime and rustup's current
+/// toolchain.
+#[derive(Debug)]
+struct Cache {
+    cache_location: Option<PathBuf>,
+    dirty: bool,
+    data: CacheData,
+}
+
+#[derive(Serialize, Deserialize, Debug, Default)]
+struct CacheData {
+    rustc_fingerprint: u64,
+    outputs: HashMap<u64, (String, String)>,
+}
+
+impl Cache {
+    fn load(rustc: &Path, cache_location: Option<PathBuf>) -> Cache {
+        match (cache_location, rustc_fingerprint(rustc)) {
+            (Some(cache_location), Ok(rustc_fingerprint)) => {
+                let empty = CacheData {
+                    rustc_fingerprint,
+                    outputs: HashMap::new(),
+                };
+                let mut dirty = true;
+                let data = match read(&cache_location) {
+                    Ok(data) => {
+                        if data.rustc_fingerprint == rustc_fingerprint {
+                            info!("reusing existing rustc info cache");
+                            dirty = false;
+                            data
+                        } else {
+                            info!("different compiler, creating new rustc info cache");
+                            empty
+                        }
+                    }
+                    Err(e) => {
+                        info!("failed to read rustc info cache: {}", e);
+                        empty
+                    }
+                };
+                return Cache {
+                    cache_location: Some(cache_location),
+                    dirty,
+                    data,
+                };
+
+                fn read(path: &Path) -> CargoResult<CacheData> {
+                    let json = paths::read(path)?;
+                    Ok(serde_json::from_str(&json)?)
+                }
+            }
+            (_, fingerprint) => {
+                if let Err(e) = fingerprint {
+                    warn!("failed to calculate rustc fingerprint: {}", e);
+                }
+                info!("rustc info cache disabled");
+                Cache {
+                    cache_location: None,
+                    dirty: false,
+                    data: CacheData::default(),
+                }
+            }
+        }
+    }
+
+    fn cached_output(&mut self, cmd: &ProcessBuilder) -> CargoResult<(String, String)> {
+        let calculate = || {
+            let output = cmd.exec_with_output()?;
+            let stdout = String::from_utf8(output.stdout)
+                .map_err(|_| internal("rustc didn't return utf8 output"))?;
+            let stderr = String::from_utf8(output.stderr)
+                .map_err(|_| internal("rustc didn't return utf8 output"))?;
+            Ok((stdout, stderr))
+        };
+        if self.cache_location.is_none() {
+            info!("rustc info uncached");
+            return calculate();
+        }
+
+        let key = process_fingerprint(cmd);
+        match self.data.outputs.entry(key) {
+            Entry::Occupied(entry) => {
+                info!("rustc info cache hit");
+                Ok(entry.get().clone())
+            }
+            Entry::Vacant(entry) => {
+                info!("rustc info cache miss");
+                let output = calculate()?;
+                entry.insert(output.clone());
+                self.dirty = true;
+                Ok(output)
+            }
+        }
+    }
+}
+
+impl Drop for Cache {
+    fn drop(&mut self) {
+        match (&self.cache_location, self.dirty) {
+            (&Some(ref path), true) => {
+                let json = serde_json::to_string(&self.data).unwrap();
+                match paths::write(path, json.as_bytes()) {
+                    Ok(()) => info!("updated rustc info cache"),
+                    Err(e) => warn!("failed to update rustc info cache: {}", e),
+                }
+            }
+            _ => (),
+        }
+    }
+}
+
+fn rustc_fingerprint(path: &Path) -> CargoResult<u64> {
+    let mut hasher = SipHasher::new_with_keys(0, 0);
+
+    let path = paths::resolve_executable(path)?;
+    path.hash(&mut hasher);
+
+    paths::mtime(&path)?.hash(&mut hasher);
+
+    match (env::var("RUSTUP_HOME"), env::var("RUSTUP_TOOLCHAIN")) {
+        (Ok(rustup_home), Ok(rustup_toolchain)) => {
+            debug!("adding rustup info to rustc fingerprint");
+            rustup_toolchain.hash(&mut hasher);
+            rustup_home.hash(&mut hasher);
+            let rustup_rustc = Path::new(&rustup_home)
+                .join("toolchains")
+                .join(rustup_toolchain)
+                .join("bin")
+                .join("rustc");
+            paths::mtime(&rustup_rustc)?.hash(&mut hasher);
+        }
+        _ => (),
+    }
+
+    Ok(hasher.finish())
+}
+
+fn process_fingerprint(cmd: &ProcessBuilder) -> u64 {
+    let mut hasher = SipHasher::new_with_keys(0, 0);
+    cmd.get_args().hash(&mut hasher);
+    let mut env = cmd.get_envs().iter().collect::<Vec<_>>();
+    env.sort();
+    env.hash(&mut hasher);
+    hasher.finish()
 }

--- a/src/cargo/util/rustc.rs
+++ b/src/cargo/util/rustc.rs
@@ -186,15 +186,15 @@ impl Cache {
 
 impl Drop for Cache {
     fn drop(&mut self) {
-        match (&self.cache_location, self.dirty) {
-            (&Some(ref path), true) => {
-                let json = serde_json::to_string(&self.data).unwrap();
-                match paths::write(path, json.as_bytes()) {
-                    Ok(()) => info!("updated rustc info cache"),
-                    Err(e) => warn!("failed to update rustc info cache: {}", e),
-                }
+        if !self.dirty {
+            return;
+        }
+        if let Some(ref path) = self.cache_location {
+            let json = serde_json::to_string(&self.data).unwrap();
+            match paths::write(path, json.as_bytes()) {
+                Ok(()) => info!("updated rustc info cache"),
+                Err(e) => warn!("failed to update rustc info cache: {}", e),
             }
-            _ => (),
         }
     }
 }

--- a/src/doc/src/reference/environment-variables.md
+++ b/src/doc/src/reference/environment-variables.md
@@ -9,29 +9,31 @@ with them:
 You can override these environment variables to change Cargo's behavior on your
 system:
 
-* `CARGO_HOME` - Cargo maintains a local cache of the registry index and of git
+* `CARGO_HOME` — Cargo maintains a local cache of the registry index and of git
   checkouts of crates.  By default these are stored under `$HOME/.cargo`, but
   this variable overrides the location of this directory. Once a crate is cached
   it is not removed by the clean command.
-* `CARGO_TARGET_DIR` - Location of where to place all generated artifacts,
+* `CARGO_TARGET_DIR` — Location of where to place all generated artifacts,
   relative to the current working directory.
-* `RUSTC` - Instead of running `rustc`, Cargo will execute this specified
+* `RUSTC` — Instead of running `rustc`, Cargo will execute this specified
   compiler instead.
-* `RUSTC_WRAPPER` - Instead of simply running `rustc`, Cargo will execute this
+* `RUSTC_WRAPPER` — Instead of simply running `rustc`, Cargo will execute this
   specified wrapper instead, passing as its commandline arguments the rustc
   invocation, with the first argument being rustc.
-* `RUSTDOC` - Instead of running `rustdoc`, Cargo will execute this specified
+* `RUSTDOC` — Instead of running `rustdoc`, Cargo will execute this specified
   `rustdoc` instance instead.
-* `RUSTDOCFLAGS` - A space-separated list of custom flags to pass to all `rustdoc`
+* `RUSTDOCFLAGS` — A space-separated list of custom flags to pass to all `rustdoc`
   invocations that Cargo performs. In contrast with `cargo rustdoc`, this is
   useful for passing a flag to *all* `rustdoc` instances.
-* `RUSTFLAGS` - A space-separated list of custom flags to pass to all compiler
+* `RUSTFLAGS` — A space-separated list of custom flags to pass to all compiler
   invocations that Cargo performs. In contrast with `cargo rustc`, this is
   useful for passing a flag to *all* compiler instances.
-* `CARGO_INCREMENTAL` - If this is set to 1 then Cargo will force incremental
+* `CARGO_INCREMENTAL` — If this is set to 1 then Cargo will force incremental
   compilation to be enabled for the current compilation, and when set to 0 it
   will force disabling it. If this env var isn't present then cargo's defaults
   will otherwise be used.
+* `CARGO_CACHE_RUSTC_INFO` — If this is set to 0 then Cargo will not try to cache 
+  compiler version information.
 
 Note that Cargo will also read environment variables for `.cargo/config`
 configuration values, as described in [that documentation][config-env]

--- a/tests/testsuite/cargotest/mod.rs
+++ b/tests/testsuite/cargotest/mod.rs
@@ -10,7 +10,7 @@ pub mod support;
 
 pub mod install;
 
-thread_local!(pub static RUSTC: Rustc = Rustc::new(PathBuf::from("rustc"), None).unwrap());
+thread_local!(pub static RUSTC: Rustc = Rustc::new(PathBuf::from("rustc"), None, None).unwrap());
 
 pub fn rustc_host() -> String {
     RUSTC.with(|r| r.host.clone())

--- a/tests/testsuite/cargotest/mod.rs
+++ b/tests/testsuite/cargotest/mod.rs
@@ -3,14 +3,21 @@ use std::time::Duration;
 
 use cargo::util::Rustc;
 use cargo;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 #[macro_use]
 pub mod support;
 
 pub mod install;
 
-thread_local!(pub static RUSTC: Rustc = Rustc::new(PathBuf::from("rustc"), None, None).unwrap());
+thread_local!(
+pub static RUSTC: Rustc = Rustc::new(
+    PathBuf::from("rustc"),
+    None,
+    Path::new("should be path to rustup rustc, but we don't care in tests"),
+    None,
+).unwrap()
+);
 
 pub fn rustc_host() -> String {
     RUSTC.with(|r| r.host.clone())

--- a/tests/testsuite/main.rs
+++ b/tests/testsuite/main.rs
@@ -78,6 +78,7 @@ mod required_features;
 mod resolve;
 mod run;
 mod rustc;
+mod rustc_info_cache;
 mod rustdocflags;
 mod rustdoc;
 mod rustflags;

--- a/tests/testsuite/rustc_info_cache.rs
+++ b/tests/testsuite/rustc_info_cache.rs
@@ -19,7 +19,9 @@ fn rustc_info_cache() {
         .build();
 
     let miss = "[..] rustc info cache miss[..]";
-    let hit = "[..] rustc info cache hit[..]";
+    let hit = "[..]rustc info cache hit[..]";
+    let uncached = "[..]rustc info uncached[..]";
+    let update = "[..]updated rustc info cache[..]";
 
     assert_that(
         p.cargo("build").env("RUST_LOG", "cargo::util::rustc=info"),
@@ -27,7 +29,8 @@ fn rustc_info_cache() {
             .with_status(0)
             .with_stderr_contains("[..]failed to read rustc info cache[..]")
             .with_stderr_contains(miss)
-            .with_stderr_does_not_contain(hit),
+            .with_stderr_does_not_contain(hit)
+            .with_stderr_contains(update),
     );
 
     assert_that(
@@ -36,7 +39,19 @@ fn rustc_info_cache() {
             .with_status(0)
             .with_stderr_contains("[..]reusing existing rustc info cache[..]")
             .with_stderr_contains(hit)
-            .with_stderr_does_not_contain(miss),
+            .with_stderr_does_not_contain(miss)
+            .with_stderr_does_not_contain(update),
+    );
+
+    assert_that(
+        p.cargo("build")
+            .env("RUST_LOG", "cargo::util::rustc=info")
+            .env("CARGO_CACHE_RUSTC_INFO", "0"),
+        execs()
+            .with_status(0)
+            .with_stderr_contains("[..]rustc info cache disabled[..]")
+            .with_stderr_contains(uncached)
+            .with_stderr_does_not_contain(update),
     );
 
     let other_rustc = {
@@ -80,7 +95,8 @@ fn rustc_info_cache() {
             .with_status(0)
             .with_stderr_contains("[..]different compiler, creating new rustc info cache[..]")
             .with_stderr_contains(miss)
-            .with_stderr_does_not_contain(hit),
+            .with_stderr_does_not_contain(hit)
+            .with_stderr_contains(update),
     );
 
     assert_that(
@@ -91,7 +107,8 @@ fn rustc_info_cache() {
             .with_status(0)
             .with_stderr_contains("[..]reusing existing rustc info cache[..]")
             .with_stderr_contains(hit)
-            .with_stderr_does_not_contain(miss),
+            .with_stderr_does_not_contain(miss)
+            .with_stderr_does_not_contain(update),
     );
 
     other_rustc.move_into_the_future();
@@ -104,7 +121,8 @@ fn rustc_info_cache() {
             .with_status(0)
             .with_stderr_contains("[..]different compiler, creating new rustc info cache[..]")
             .with_stderr_contains(miss)
-            .with_stderr_does_not_contain(hit),
+            .with_stderr_does_not_contain(hit)
+            .with_stderr_contains(update),
     );
 
     assert_that(
@@ -115,6 +133,7 @@ fn rustc_info_cache() {
             .with_status(0)
             .with_stderr_contains("[..]reusing existing rustc info cache[..]")
             .with_stderr_contains(hit)
-            .with_stderr_does_not_contain(miss),
+            .with_stderr_does_not_contain(miss)
+            .with_stderr_does_not_contain(update),
     );
 }


### PR DESCRIPTION
This implements rustc caching, to speed-up no-op builds. 

The cache is per-project, and stored in `target` directory. To implement this, I had to move `rustc` from `Config` down to `BuildConfig`. 

closes https://github.com/rust-lang/cargo/issues/5315