### PR TITLE
One hard cs problem

### DIFF
--- a/src/cargo/core/compiler/context/mod.rs
+++ b/src/cargo/core/compiler/context/mod.rs
@@ -129,17 +129,8 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
         let (host_info, target_info) = {
             let _p = profile::start("Context::probe_target_info");
             debug!("probe_target_info");
-            let host_target_same = match build_config.requested_target {
-                Some(ref s) if s != &build_config.host_triple() => false,
-                _ => true,
-            };
-
             let host_info = TargetInfo::new(config, &build_config, Kind::Host)?;
-            let target_info = if host_target_same {
-                host_info.clone()
-            } else {
-                TargetInfo::new(config, &build_config, Kind::Target)?
-            };
+            let target_info = TargetInfo::new(config, &build_config, Kind::Target)?;
             (host_info, target_info)
         };
 

--- a/src/cargo/core/package.rs
+++ b/src/cargo/core/package.rs
@@ -46,7 +46,7 @@ struct SerializedPackage<'a> {
     categories: &'a [String],
     keywords: &'a [String],
     readme: Option<&'a str>,
-    repository: Option<&'a str>
+    repository: Option<&'a str>,
 }
 
 impl ser::Serialize for Package {

--- a/src/cargo/core/resolver/mod.rs
+++ b/src/cargo/core/resolver/mod.rs
@@ -68,7 +68,7 @@ use self::types::{RcVecIter, RegistryQueryer};
 
 pub use self::encode::{EncodableDependency, EncodablePackageId, EncodableResolve};
 pub use self::encode::{Metadata, WorkspaceResolve};
-pub use self::resolve::{Resolve, Deps, DepsNotReplaced};
+pub use self::resolve::{Deps, DepsNotReplaced, Resolve};
 pub use self::types::Method;
 
 mod context;

--- a/src/cargo/sources/registry/index.rs
+++ b/src/cargo/sources/registry/index.rs
@@ -150,7 +150,8 @@ impl<'cfg> RegistryIndex<'cfg> {
             links,
         } = serde_json::from_str(line)?;
         let pkgid = PackageId::new(&name, &vers, &self.source_id)?;
-        let deps = deps.into_iter().map(|dep| dep.into_dep(&self.source_id))
+        let deps = deps.into_iter()
+            .map(|dep| dep.into_dep(&self.source_id))
             .collect::<CargoResult<Vec<_>>>()?;
         let summary = Summary::new(pkgid, deps, features, links)?;
         let summary = summary.set_checksum(cksum.clone());

--- a/tests/testsuite/rustc_info_cache.rs
+++ b/tests/testsuite/rustc_info_cache.rs
@@ -20,7 +20,6 @@ fn rustc_info_cache() {
 
     let miss = "[..] rustc info cache miss[..]";
     let hit = "[..]rustc info cache hit[..]";
-    let uncached = "[..]rustc info uncached[..]";
     let update = "[..]updated rustc info cache[..]";
 
     assert_that(
@@ -50,7 +49,6 @@ fn rustc_info_cache() {
         execs()
             .with_status(0)
             .with_stderr_contains("[..]rustc info cache disabled[..]")
-            .with_stderr_contains(uncached)
             .with_stderr_does_not_contain(update),
     );
 


### PR DESCRIPTION
Closes https://github.com/rust-lang/cargo/issues/5313

r? @alexcrichton 

Note that, due to the first commit, this still gives us all the benefits of #5249: if RUSTFLAGS is empty, we will run only a single rustc process, even if we can't cache it across different cargo invocations. 