### PR TITLE
Print "Checking" for cargo check

### DIFF
--- a/src/cargo/core/compiler/job_queue.rs
+++ b/src/cargo/core/compiler/job_queue.rs
@@ -383,7 +383,11 @@ impl<'a> JobQueue<'a> {
                     }
                 } else {
                     self.compiled.insert(key.pkg);
-                    config.shell().status("Compiling", key.pkg)?;
+                    if key.profile.check {
+                        config.shell().status("Checking", key.pkg)?;
+                    } else {
+                        config.shell().status("Compiling", key.pkg)?;
+                    }
                 }
             }
             Fresh if self.counts[key.pkg] == 0 => {

--- a/tests/testsuite/cargotest/support/mod.rs
+++ b/tests/testsuite/cargotest/support/mod.rs
@@ -992,6 +992,7 @@ fn substitute_macros(input: &str) -> String {
     let macros = [
         ("[RUNNING]", "     Running"),
         ("[COMPILING]", "   Compiling"),
+        ("[CHECKING]", "    Checking"),
         ("[CREATED]", "     Created"),
         ("[FINISHED]", "    Finished"),
         ("[ERROR]", "error:"),

--- a/tests/testsuite/doc.rs
+++ b/tests/testsuite/doc.rs
@@ -217,7 +217,7 @@ fn doc_no_deps() {
         p.cargo("doc").arg("--no-deps"),
         execs().with_status(0).with_stderr(&format!(
             "\
-[COMPILING] bar v0.0.1 ({dir}/bar)
+[CHECKING] bar v0.0.1 ({dir}/bar)
 [DOCUMENTING] foo v0.0.1 ({dir})
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
@@ -596,7 +596,7 @@ fn doc_lib_bin_same_name_documents_named_bin_when_requested() {
         p.cargo("doc").arg("--bin").arg("foo"),
         execs().with_status(0).with_stderr(&format!(
             "\
-[COMPILING] foo v0.0.1 ({dir})
+[CHECKING] foo v0.0.1 ({dir})
 [DOCUMENTING] foo v0.0.1 ({dir})
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
@@ -650,7 +650,7 @@ fn doc_lib_bin_same_name_documents_bins_when_requested() {
         p.cargo("doc").arg("--bins"),
         execs().with_status(0).with_stderr(&format!(
             "\
-[COMPILING] foo v0.0.1 ({dir})
+[CHECKING] foo v0.0.1 ({dir})
 [DOCUMENTING] foo v0.0.1 ({dir})
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
@@ -1270,7 +1270,7 @@ fn doc_all_workspace() {
         execs()
             .with_status(0)
             .with_stderr_contains("[..] Documenting bar v0.1.0 ([..])")
-            .with_stderr_contains("[..] Compiling bar v0.1.0 ([..])")
+            .with_stderr_contains("[..] Checking bar v0.1.0 ([..])")
             .with_stderr_contains("[..] Documenting foo v0.1.0 ([..])"),
     );
 }

--- a/tests/testsuite/rustdoc.rs
+++ b/tests/testsuite/rustdoc.rs
@@ -109,7 +109,7 @@ fn rustdoc_foo_with_bar_dependency() {
         foo.cargo("rustdoc").arg("-v").arg("--").arg("--cfg=foo"),
         execs().with_status(0).with_stderr(format!(
             "\
-[COMPILING] bar v0.0.1 ([..])
+[CHECKING] bar v0.0.1 ([..])
 [RUNNING] `rustc [..]bar[/]src[/]lib.rs [..]`
 [DOCUMENTING] foo v0.0.1 ({url})
 [RUNNING] `rustdoc --crate-name foo src[/]lib.rs \


### PR DESCRIPTION
I often alternate between `check` and `build` and I'd like to be able to tell which is currently happening (short-term memory being what it is, and "compiling" implying to me that codegen is occurring). Changing the message to "Checking" seemed to be reasonable (and there was precedent for `doc` with "Documenting").