### PR TITLE
cargotest: Fix `with_*_does_not_contain` to support `[..]` and macro matching.

### DIFF
--- a/tests/testsuite/bench.rs
+++ b/tests/testsuite/bench.rs
@@ -267,7 +267,7 @@ fn bench_multiple_targets() {
             .with_status(0)
             .with_stdout_contains("test run1 ... bench: [..]")
             .with_stdout_contains("test run2 ... bench: [..]")
-            .with_stdout_does_not_contain("run3"),
+            .with_stdout_does_not_contain("[..]run3[..]"),
     );
 }
 

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -4509,7 +4509,7 @@ fn build_virtual_manifest_one_project() {
         p.cargo("build").arg("-p").arg("foo"),
         execs()
             .with_status(0)
-            .with_stderr_does_not_contain("bar")
+            .with_stderr_does_not_contain("[..]bar[..]")
             .with_stderr_contains("[..] Compiling foo v0.1.0 ([..])")
             .with_stderr(
                 "[..] Compiling [..] v0.1.0 ([..])\n\

--- a/tests/testsuite/cargotest/support/mod.rs
+++ b/tests/testsuite/cargotest/support/mod.rs
@@ -687,9 +687,17 @@ impl Execs {
                 }
             }
             MatchKind::NotPresent => {
-                if !actual.contains(out) {
-                    Ok(())
-                } else {
+                let mut a = actual.lines();
+                let e = out.lines();
+
+                let mut diffs = self.diff_lines(a.clone(), e.clone(), true);
+                while let Some(..) = a.next() {
+                    let a = self.diff_lines(a.clone(), e.clone(), true);
+                    if a.len() < diffs.len() {
+                        diffs = a;
+                    }
+                }
+                if diffs.is_empty() {
                     Err(format!(
                         "expected not to find:\n\
                          {}\n\n\
@@ -697,6 +705,8 @@ impl Execs {
                          {}",
                         out, actual
                     ))
+                } else {
+                    Ok(())
                 }
             }
         }

--- a/tests/testsuite/check.rs
+++ b/tests/testsuite/check.rs
@@ -743,10 +743,10 @@ fn check_filters() {
             .with_status(0)
             .with_stderr_contains("[..]unused_normal_lib[..]")
             .with_stderr_contains("[..]unused_normal_bin[..]")
-            .with_stderr_does_not_contain("unused_normal_t1")
-            .with_stderr_does_not_contain("unused_normal_ex1")
-            .with_stderr_does_not_contain("unused_normal_b1")
-            .with_stderr_does_not_contain("unused_unit_"),
+            .with_stderr_does_not_contain("[..]unused_normal_t1[..]")
+            .with_stderr_does_not_contain("[..]unused_normal_ex1[..]")
+            .with_stderr_does_not_contain("[..]unused_normal_b1[..]")
+            .with_stderr_does_not_contain("[..]unused_unit_[..]"),
     );
     p.root().join("target").rm_rf();
     assert_that(
@@ -764,8 +764,8 @@ fn check_filters() {
             .with_stderr_contains("[..]unused_unit_t1[..]")
             .with_stderr_contains("[..]unused_normal_ex1[..]")
             .with_stderr_contains("[..]unused_unit_ex1[..]")
-            .with_stderr_does_not_contain("unused_normal_b1")
-            .with_stderr_does_not_contain("unused_unit_b1"),
+            .with_stderr_does_not_contain("[..]unused_normal_b1[..]")
+            .with_stderr_does_not_contain("[..]unused_unit_b1[..]"),
     );
     p.root().join("target").rm_rf();
     assert_that(
@@ -775,12 +775,12 @@ fn check_filters() {
             .with_stderr_contains("[..]unused_normal_lib[..]")
             .with_stderr_contains("[..]unused_normal_bin[..]")
             .with_stderr_contains("[..]unused_unit_t1[..]")
-            .with_stderr_does_not_contain("unused_unit_lib")
-            .with_stderr_does_not_contain("unused_unit_bin")
-            .with_stderr_does_not_contain("unused_normal_ex1")
-            .with_stderr_does_not_contain("unused_normal_b1")
-            .with_stderr_does_not_contain("unused_unit_ex1")
-            .with_stderr_does_not_contain("unused_unit_b1"),
+            .with_stderr_does_not_contain("[..]unused_unit_lib[..]")
+            .with_stderr_does_not_contain("[..]unused_unit_bin[..]")
+            .with_stderr_does_not_contain("[..]unused_normal_ex1[..]")
+            .with_stderr_does_not_contain("[..]unused_normal_b1[..]")
+            .with_stderr_does_not_contain("[..]unused_unit_ex1[..]")
+            .with_stderr_does_not_contain("[..]unused_unit_b1[..]"),
     );
     p.root().join("target").rm_rf();
     assert_that(


### PR DESCRIPTION
I changed it so that it is essentially the opposite of `with_*_contains` to keep it symmetric.

Any in-flight PRs using the old style will need to be updated (else they will incorrectly silently pass).  Alternatively, we could rename the method to avoid that.

The following tests contained brackets, so they were not checking what they thought they were checking.  I did a cursory look at them, but perhaps someone else could double-check that they make sense.  Asserting what *doesn't* happen can be tricky since there is an infinite number of things that won't happen.  Preferably a test would assert that it appears in one scenario and not another (like `incremental_profile` does), but some of them don't or can't.

```
build::incremental_profile
build::incremental_config
build::cargo_compile_with_workspace_excluded
build::build_all_exclude
build::targets_selected_default
check::targets_selected_default
check::check_filters
rustc::targets_selected_default
rustc_info_cache::rustc_info_cache
warn_on_failure::no_warning_on_bin_failure
warn_on_failure::warning_on_lib_failure
```

BTW, would you be interested in a PR that adds some documentation to `cargotest`?
I've discovered things I didn't know where there.  I think some docstrings on some of the methods, and a short guide for new contributors would be helpful.
