### PR TITLE
Pass linker path to build script

### DIFF
--- a/src/cargo/core/compiler/custom_build.rs
+++ b/src/cargo/core/compiler/custom_build.rs
@@ -146,8 +146,8 @@ fn build_work<'a, 'cfg>(cx: &mut Context<'a, 'cfg>, unit: &Unit<'a>) -> CargoRes
         .env("RUSTDOC", &*cx.config.rustdoc()?)
         .inherit_jobserver(&cx.jobserver);
 
-    if cx.build_config.target.linker.is_some() {
-        cmd.env("RUSTC_LINKER", &cx.build_config.target.linker.as_ref().unwrap());
+    if let Some(ref linker) = cx.build_config.target.linker {
+        cmd.env("RUSTC_LINKER", linker);
     }
 
     if let Some(links) = unit.pkg.manifest().links() {

--- a/src/cargo/core/compiler/custom_build.rs
+++ b/src/cargo/core/compiler/custom_build.rs
@@ -144,6 +144,7 @@ fn build_work<'a, 'cfg>(cx: &mut Context<'a, 'cfg>, unit: &Unit<'a>) -> CargoRes
         .env("HOST", &cx.build_config.host_triple())
         .env("RUSTC", &cx.build_config.rustc.path)
         .env("RUSTDOC", &*cx.config.rustdoc()?)
+        .env("LINKER", &cx.build_config.target.linker.as_ref().unwrap_or(&PathBuf::new()))
         .inherit_jobserver(&cx.jobserver);
 
     if let Some(links) = unit.pkg.manifest().links() {

--- a/src/cargo/core/compiler/custom_build.rs
+++ b/src/cargo/core/compiler/custom_build.rs
@@ -144,8 +144,11 @@ fn build_work<'a, 'cfg>(cx: &mut Context<'a, 'cfg>, unit: &Unit<'a>) -> CargoRes
         .env("HOST", &cx.build_config.host_triple())
         .env("RUSTC", &cx.build_config.rustc.path)
         .env("RUSTDOC", &*cx.config.rustdoc()?)
-        .env("LINKER", &cx.build_config.target.linker.as_ref().unwrap_or(&PathBuf::new()))
         .inherit_jobserver(&cx.jobserver);
+
+    if cx.build_config.target.linker.is_some() {
+        cmd.env("RUSTC_LINKER", &cx.build_config.target.linker.as_ref().unwrap());
+    }
 
     if let Some(links) = unit.pkg.manifest().links() {
         cmd.env("CARGO_MANIFEST_LINKS", links);

--- a/src/doc/src/reference/environment-variables.md
+++ b/src/doc/src/reference/environment-variables.md
@@ -123,14 +123,18 @@ let out_dir = env::var("OUT_DIR").unwrap();
 * `RUSTC`, `RUSTDOC` - the compiler and documentation generator that Cargo has
                        resolved to use, passed to the build script so it might
                        use it as well.
-* `LINKER` - The linker that rust has resolved to use for the current target,
-             passed to the build script so it might use it as well.
+* `RUSTC_LINKER` - The path to the linker binary that Cargo has resolved to use
+                   for the current target, if specified. The linker can be
+                   changed by editing `.cargo/config`; see the documentation
+                   about [cargo configuration][cargo-config] for more
+                   information.
 
 [links]: reference/build-scripts.html#the-links-manifest-key
 [profile]: reference/manifest.html#the-profile-sections
 [configuration]: https://doc.rust-lang.org/reference/attributes.html#conditional-compilation
 [clang]: http://clang.llvm.org/docs/CrossCompilation.html#target-triple
 [jobserver]: https://www.gnu.org/software/make/manual/html_node/Job-Slots.html
+[cargo-config]: reference/config
 
 ### Environment variables Cargo sets for 3rd party subcommands
 

--- a/src/doc/src/reference/environment-variables.md
+++ b/src/doc/src/reference/environment-variables.md
@@ -123,6 +123,8 @@ let out_dir = env::var("OUT_DIR").unwrap();
 * `RUSTC`, `RUSTDOC` - the compiler and documentation generator that Cargo has
                        resolved to use, passed to the build script so it might
                        use it as well.
+* `LINKER` - The linker that rust has resolved to use for the current target,
+             passed to the build script so it might use it as well.
 
 [links]: reference/build-scripts.html#the-links-manifest-key
 [profile]: reference/manifest.html#the-profile-sections

--- a/src/doc/src/reference/environment-variables.md
+++ b/src/doc/src/reference/environment-variables.md
@@ -134,7 +134,7 @@ let out_dir = env::var("OUT_DIR").unwrap();
 [configuration]: https://doc.rust-lang.org/reference/attributes.html#conditional-compilation
 [clang]: http://clang.llvm.org/docs/CrossCompilation.html#target-triple
 [jobserver]: https://www.gnu.org/software/make/manual/html_node/Job-Slots.html
-[cargo-config]: reference/config
+[cargo-config]: reference/config.html
 
 ### Environment variables Cargo sets for 3rd party subcommands
 

--- a/tests/testsuite/build_script.rs
+++ b/tests/testsuite/build_script.rs
@@ -179,7 +179,7 @@ fn custom_build_env_vars() {
             use std::env;
 
             fn main() {
-                assert_eq!(env::var("RUSTC_LINKER"), "/path/to/linker");
+                assert_eq!(env::var("RUSTC_LINKER").unwrap(), "/path/to/linker");
             }
         "#)
         .file("src/lib.rs", "")
@@ -188,7 +188,7 @@ fn custom_build_env_vars() {
     // no crate type set => linker never called => build succeeds if and
     // only if build.rs succeeds, despite linker binary not existing.
     assert_that(
-        p.cargo("build").arg("--target").arg(&target).arg("-v"),
+        p.cargo("build").arg("--target").arg(&target),
         execs().with_status(0),
     );
 }

--- a/tests/testsuite/build_script.rs
+++ b/tests/testsuite/build_script.rs
@@ -151,8 +151,11 @@ fn custom_build_env_vars() {
         p.cargo("build").arg("--features").arg("bar_feat"),
         execs().with_status(0),
     );
+}
 
-    // Test passing linker from .cargo/config to env var
+
+#[test]
+fn custom_build_env_var_rustc_linker() {
     if cross_compile::disabled() { return; }
     let target = cross_compile::alternate();
     let p = project("foo")
@@ -181,7 +184,8 @@ fn custom_build_env_vars() {
             fn main() {
                 assert!(env::var("RUSTC_LINKER").unwrap().ends_with("/path/to/linker"));
             }
-        "#)
+            "#
+        )
         .file("src/lib.rs", "")
         .build();
 

--- a/tests/testsuite/build_script.rs
+++ b/tests/testsuite/build_script.rs
@@ -179,7 +179,7 @@ fn custom_build_env_vars() {
             use std::env;
 
             fn main() {
-                assert_eq!(env::var("RUSTC_LINKER").unwrap(), "/path/to/linker");
+                assert!(env::var("RUSTC_LINKER").unwrap().ends_with("/path/to/linker"));
             }
         "#)
         .file("src/lib.rs", "")

--- a/tests/testsuite/build_script.rs
+++ b/tests/testsuite/build_script.rs
@@ -4,7 +4,7 @@ use std::io::prelude::*;
 use std::path::PathBuf;
 
 use cargotest::{rustc_host, sleep_ms};
-use cargotest::support::{execs, project};
+use cargotest::support::{cross_compile, execs, project};
 use cargotest::support::paths::CargoPathExt;
 use cargotest::support::registry::Package;
 use hamcrest::{assert_that, existing_dir, existing_file};
@@ -134,6 +134,8 @@ fn custom_build_env_vars() {
 
                 let rustdoc = env::var("RUSTDOC").unwrap();
                 assert_eq!(rustdoc, "rustdoc");
+
+                assert!(env::var("RUSTC_LINKER").is_err());
             }}
         "#,
         p.root()
@@ -147,6 +149,46 @@ fn custom_build_env_vars() {
 
     assert_that(
         p.cargo("build").arg("--features").arg("bar_feat"),
+        execs().with_status(0),
+    );
+
+    // Test passing linker from .cargo/config to env var
+    if cross_compile::disabled() { return; }
+    let target = cross_compile::alternate();
+    let p = project("foo")
+        .file("Cargo.toml",
+              r#"
+              [project]
+              name = "foo"
+              version = "0.0.1"
+              "#
+        )
+        .file(
+            ".cargo/config",
+            &format!(
+                r#"
+                [target.{}]
+                linker = "/path/to/linker"
+                "#,
+                target
+            )
+        )
+        .file(
+            "build.rs",
+            r#"
+            use std::env;
+
+            fn main() {
+                assert_eq!(env::var("RUSTC_LINKER"), "/path/to/linker");
+            }
+        "#)
+        .file("src/lib.rs", "")
+        .build();
+
+    // no crate type set => linker never called => build succeeds if and
+    // only if build.rs succeeds, despite linker binary not existing.
+    assert_that(
+        p.cargo("build").arg("--target").arg(&target).arg("-v"),
         execs().with_status(0),
     );
 }


### PR DESCRIPTION
This change adds the environment variable LINKER to pass the path of the linker used by cargo to the build script. This complements the variable RUSTC (the rustc binary used) to give the build script full knowledge of its environment.

A specific usage example would be automatically generating bindings to system headers in cross compilation, e.g. by locating jni.h for android targets.