### PR TITLE
Drop an old visible doc TODO

### DIFF
--- a/src/doc/src/reference/manifest.md
+++ b/src/doc/src/reference/manifest.md
@@ -578,7 +578,6 @@ When `default-members` is not specified, the default is the root manifest
 if it is a package, or every member manifest (as if `--all` were specified
 on the command-line) for virtual workspaces.
 
-#TODO: move this to a more appropriate place
 ### The project layout
 
 If your project is an executable, name the main source file `src/main.rs`. If it


### PR DESCRIPTION
Looks like this originates from
https://github.com/istankovic/cargo-book/commit/418611304daac22e3590aee9322355ae159802fe

But it's even visible in the render docs:
https://doc.rust-lang.org/cargo/reference/manifest.html#package-selection
:-O