### PR TITLE
only deny warnings when building with nightly

### DIFF
--- a/tests/testsuite/main.rs
+++ b/tests/testsuite/main.rs
@@ -1,4 +1,4 @@
-#![deny(warnings)]
+#![cfg_attr(feature = "nightly", deny(warnings))]
 
 extern crate bufstream;
 extern crate cargo;


### PR DESCRIPTION
copied from the human-panic crate

this is just an idea: it's annoying to be developing in the test suite and not be able to run tests because, for example, you have some unused code. wdyt?