### PR TITLE
switch to using the --edition flag

### DIFF
--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -911,7 +911,7 @@ fn build_base_args<'a, 'cfg>(
     let manifest = unit.pkg.manifest();
 
     if manifest.features().is_enabled(Feature::edition()) {
-        cmd.arg(format!("-Zedition={}", manifest.edition()));
+        cmd.arg(format!("--edition={}", manifest.edition()));
     }
 
     // Disable LTO for host builds as prefer_dynamic and it are mutually

--- a/tests/testsuite/package.rs
+++ b/tests/testsuite/package.rs
@@ -1119,13 +1119,13 @@ fn test_edition() {
     assert_that(
         p.cargo("build").arg("-v").masquerade_as_nightly_cargo(),
         execs()
-                // -Zedition is still in flux and we're not passing -Zunstable-options
+                // --edition is still in flux and we're not passing -Zunstable-options
                 // from Cargo so it will probably error. Only partially match the output
                 // until stuff stabilizes
                 .with_stderr_contains(format!("\
 [COMPILING] foo v0.0.1 ({url})
 [RUNNING] `rustc --crate-name foo src[/]lib.rs --crate-type lib \
-        --emit=dep-info,link -Zedition=2018 -C debuginfo=2 \
+        --emit=dep-info,link --edition=2018 -C debuginfo=2 \
         -C metadata=[..] \
         --out-dir [..] \
         -L dependency={dir}[/]target[/]debug[/]deps`
@@ -1153,13 +1153,13 @@ fn test_edition_missing() {
     assert_that(
         p.cargo("build").arg("-v").masquerade_as_nightly_cargo(),
         execs()
-                // -Zedition is still in flux and we're not passing -Zunstable-options
+                // --edition is still in flux and we're not passing -Zunstable-options
                 // from Cargo so it will probably error. Only partially match the output
                 // until stuff stabilizes
                 .with_stderr_contains(format!("\
 [COMPILING] foo v0.0.1 ({url})
 [RUNNING] `rustc --crate-name foo src[/]lib.rs --crate-type lib \
-        --emit=dep-info,link -Zedition=2015 -C debuginfo=2 \
+        --emit=dep-info,link --edition=2015 -C debuginfo=2 \
         -C metadata=[..] \
         --out-dir [..] \
         -L dependency={dir}[/]target[/]debug[/]deps`


### PR DESCRIPTION
Now that we have an `--edition` flag in the rust compiler, let's switch to using it.

fixes #5406 