### PR TITLE
Fix renaming crates as they come from 2 sources

### DIFF
--- a/src/cargo/core/resolver/context.rs
+++ b/src/cargo/core/resolver/context.rs
@@ -269,17 +269,25 @@ impl Context {
         replacements
     }
 
-    pub fn graph(&self) -> Graph<PackageId> {
+    pub fn graph(&self)
+        -> (Graph<PackageId>, HashMap<(PackageId, PackageId), Vec<Dependency>>)
+    {
         let mut graph = Graph::new();
+        let mut deps = HashMap::new();
         let mut cur = &self.resolve_graph;
         while let Some(ref node) = cur.head {
             match node.0 {
-                GraphNode::Add(ref p) => graph.add(p.clone(), &[]),
-                GraphNode::Link(ref a, ref b) => graph.link(a.clone(), b.clone()),
+                GraphNode::Add(ref p) => graph.add(p.clone()),
+                GraphNode::Link(ref a, ref b, ref dep) => {
+                    graph.link(a.clone(), b.clone());
+                    deps.entry((a.clone(), b.clone()))
+                        .or_insert(Vec::new())
+                        .push(dep.clone());
+                }
             }
             cur = &node.1;
         }
-        graph
+        (graph, deps)
     }
 }
 

--- a/src/cargo/core/resolver/types.rs
+++ b/src/cargo/core/resolver/types.rs
@@ -394,5 +394,5 @@ impl<T> Drop for RcList<T> {
 
 pub enum GraphNode {
     Add(PackageId),
-    Link(PackageId, PackageId),
+    Link(PackageId, PackageId, Dependency),
 }

--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -397,8 +397,7 @@ pub fn compile_ws<'a>(
 
         // Include features enabled for use by dependencies so targets can also use them with the
         // required-features field when deciding whether to be built or skipped.
-        let deps = resolve_with_overrides.deps(package_id);
-        for dep in deps {
+        for (dep, _) in resolve_with_overrides.deps(package_id) {
             for feature in resolve_with_overrides.features(dep) {
                 features.insert(dep.name().to_string() + "/" + feature);
             }

--- a/src/cargo/ops/cargo_fetch.rs
+++ b/src/cargo/ops/cargo_fetch.rs
@@ -1,5 +1,5 @@
 use core::compiler::{BuildConfig, Kind, TargetInfo};
-use core::{Package, PackageId, PackageSet, Resolve, Workspace};
+use core::{PackageSet, Resolve, Workspace};
 use ops;
 use std::collections::HashSet;
 use util::CargoResult;
@@ -18,57 +18,45 @@ pub fn fetch<'a>(
 ) -> CargoResult<(Resolve, PackageSet<'a>)> {
     let (packages, resolve) = ops::resolve_ws(ws)?;
 
-    fetch_for_target(ws, options.config, &options.target, &resolve, &packages)?;
-
-    Ok((resolve, packages))
-}
-
-fn fetch_for_target<'a, 'cfg: 'a>(
-    ws: &'a Workspace<'cfg>,
-    config: &'cfg Config,
-    target: &Option<String>,
-    resolve: &'a Resolve,
-    packages: &'a PackageSet<'cfg>,
-) -> CargoResult<HashSet<&'a PackageId>> {
-    let mut fetched_packages = HashSet::new();
-    let mut deps_to_fetch = Vec::new();
     let jobs = Some(1);
-    let build_config = BuildConfig::new(config, jobs, target, None)?;
-    let target_info = TargetInfo::new(config, &build_config, Kind::Target)?;
-    let root_package_ids = ws.members().map(Package::package_id).collect::<Vec<_>>();
+    let build_config = BuildConfig::new(ws.config(), jobs, &options.target, None)?;
+    let target_info = TargetInfo::new(ws.config(), &build_config, Kind::Target)?;
+    {
+        let mut fetched_packages = HashSet::new();
+        let mut deps_to_fetch = ws.members()
+            .map(|p| p.package_id())
+            .collect::<Vec<_>>();
 
-    deps_to_fetch.extend(root_package_ids);
+        while let Some(id) = deps_to_fetch.pop() {
+            if !fetched_packages.insert(id) {
+                continue;
+            }
 
-    while let Some(id) = deps_to_fetch.pop() {
-        if !fetched_packages.insert(id) {
-            continue;
-        }
-
-        let package = packages.get(id)?;
-        let deps = resolve.deps(id);
-        let dependency_ids = deps.filter(|dep| {
-            package
-                .dependencies()
-                .iter()
-                .filter(|d| d.name() == dep.name() && d.version_req().matches(dep.version()))
-                .any(|d| {
-                    // If no target was specified then all dependencies can be fetched.
-                    let target = match *target {
-                        Some(ref t) => t,
-                        None => return true,
-                    };
-                    // If this dependency is only available for certain platforms,
-                    // make sure we're only fetching it for that platform.
-                    let platform = match d.platform() {
-                        Some(p) => p,
-                        None => return true,
-                    };
-                    platform.matches(target, target_info.cfg())
+            packages.get(id)?;
+            let deps = resolve.deps(id)
+                .filter(|&(_id, deps)| {
+                    deps.iter()
+                        .any(|d| {
+                            // If no target was specified then all dependencies can
+                            // be fetched.
+                            let target = match options.target {
+                                Some(ref t) => t,
+                                None => return true,
+                            };
+                            // If this dependency is only available for certain
+                            // platforms, make sure we're only fetching it for that
+                            // platform.
+                            let platform = match d.platform() {
+                                Some(p) => p,
+                                None => return true,
+                            };
+                            platform.matches(target, target_info.cfg())
+                        })
                 })
-        }).collect::<Vec<_>>();
-
-        deps_to_fetch.extend(dependency_ids);
+                .map(|(id, _deps)| id);
+            deps_to_fetch.extend(deps);
+        }
     }
 
-    Ok(fetched_packages)
+    Ok((resolve, packages))
 }

--- a/src/cargo/ops/cargo_generate_lockfile.rs
+++ b/src/cargo/ops/cargo_generate_lockfile.rs
@@ -132,7 +132,7 @@ pub fn update_lockfile(ws: &Workspace, opts: &UpdateOptions) -> CargoResult<()> 
             return;
         }
         set.insert(dep);
-        for dep in resolve.deps(dep) {
+        for dep in resolve.deps_not_replaced(dep) {
             fill_with_deps(resolve, dep, set, visited);
         }
     }

--- a/src/cargo/ops/cargo_output_metadata.rs
+++ b/src/cargo/ops/cargo_output_metadata.rs
@@ -109,7 +109,7 @@ where
         .iter()
         .map(|id| Node {
             id,
-            dependencies: resolve.deps(id).collect(),
+            dependencies: resolve.deps(id).map(|p| p.0).collect(),
             features: resolve.features_sorted(id),
         })
         .collect::<Vec<_>>()

--- a/src/cargo/util/graph.rs
+++ b/src/cargo/util/graph.rs
@@ -22,11 +22,10 @@ impl<N: Eq + Hash + Clone> Graph<N> {
         }
     }
 
-    pub fn add(&mut self, node: N, children: &[N]) {
+    pub fn add(&mut self, node: N) {
         self.nodes
             .entry(node)
-            .or_insert_with(HashSet::new)
-            .extend(children.iter().cloned());
+            .or_insert_with(HashSet::new);
     }
 
     pub fn link(&mut self, node: N, child: N) {

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -742,8 +742,8 @@ impl TomlManifest {
         {
             let mut names_sources = BTreeMap::new();
             for dep in &deps {
-                let name = dep.name();
-                let prev = names_sources.insert(name, dep.source_id());
+                let name = dep.rename().unwrap_or(dep.name().as_str());
+                let prev = names_sources.insert(name.to_string(), dep.source_id());
                 if prev.is_some() && prev != Some(dep.source_id()) {
                     bail!(
                         "Dependency '{}' has different source paths depending on the build \

--- a/tests/testsuite/rename_deps.rs
+++ b/tests/testsuite/rename_deps.rs
@@ -1,6 +1,8 @@
-use cargotest::support::{execs, project};
-use cargotest::support::registry::Package;
 use cargotest::ChannelChanger;
+use cargotest::support::git;
+use cargotest::support::paths;
+use cargotest::support::registry::Package;
+use cargotest::support::{execs, project};
 use hamcrest::assert_that;
 
 #[test]
@@ -143,5 +145,173 @@ fn rename_with_different_names() {
     assert_that(
         p.cargo("build").masquerade_as_nightly_cargo(),
         execs().with_status(0),
+    );
+}
+
+#[test]
+fn lots_of_names() {
+    Package::new("foo", "0.1.0")
+        .file("src/lib.rs", "pub fn foo1() {}")
+        .publish();
+    Package::new("foo", "0.2.0")
+        .file("src/lib.rs", "pub fn foo() {}")
+        .publish();
+    Package::new("foo", "0.1.0")
+        .file("src/lib.rs", "pub fn foo2() {}")
+        .alternative(true)
+        .publish();
+
+    let g = git::repo(&paths::root().join("another"))
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.1.0"
+                authors = []
+            "#,
+        )
+        .file("src/lib.rs", "pub fn foo3() {}")
+        .build();
+
+    let p = project("foo")
+        .file(
+            "Cargo.toml",
+            &format!(r#"
+                cargo-features = ["alternative-registries", "rename-dependency"]
+
+                [package]
+                name = "test"
+                version = "0.1.0"
+                authors = []
+
+                [dependencies]
+                foo = "0.2"
+                foo1 = {{ version = "0.1", package = "foo" }}
+                foo2 = {{ version = "0.1", registry = "alternative", package = "foo" }}
+                foo3 = {{ git = '{}', package = "foo" }}
+                foo4 = {{ path = "foo", package = "foo" }}
+            "#,
+            g.url())
+        )
+        .file(
+            "src/lib.rs",
+            "
+                extern crate foo;
+                extern crate foo1;
+                extern crate foo2;
+                extern crate foo3;
+                extern crate foo4;
+
+                pub fn foo() {
+                    foo::foo();
+                    foo1::foo1();
+                    foo2::foo2();
+                    foo3::foo3();
+                    foo4::foo4();
+                }
+            ",
+        )
+        .file(
+            "foo/Cargo.toml",
+            r#"
+                [project]
+                name = "foo"
+                version = "0.1.0"
+                authors = []
+            "#,
+        )
+        .file("foo/src/lib.rs", "pub fn foo4() {}")
+        .build();
+
+    assert_that(
+        p.cargo("build -v").masquerade_as_nightly_cargo(),
+        execs().with_status(0),
+    );
+}
+
+#[test]
+fn rename_and_patch() {
+    Package::new("foo", "0.1.0").publish();
+
+    let p = project("foo")
+        .file(
+            "Cargo.toml",
+            r#"
+                cargo-features = ["rename-dependency"]
+
+                [package]
+                name = "test"
+                version = "0.1.0"
+                authors = []
+
+                [dependencies]
+                bar = { version = "0.1", package = "foo" }
+
+                [patch.crates-io]
+                foo = { path = "foo" }
+            "#,
+        )
+        .file(
+            "src/lib.rs",
+            "
+                extern crate bar;
+
+                pub fn foo() {
+                    bar::foo();
+                }
+            ",
+        )
+        .file(
+            "foo/Cargo.toml",
+            r#"
+                [project]
+                name = "foo"
+                version = "0.1.0"
+                authors = []
+            "#,
+        )
+        .file("foo/src/lib.rs", "pub fn foo() {}")
+        .build();
+
+    assert_that(
+        p.cargo("build -v").masquerade_as_nightly_cargo(),
+        execs().with_status(0),
+    );
+}
+
+#[test]
+fn rename_twice() {
+    Package::new("foo", "0.1.0").publish();
+
+    let p = project("foo")
+        .file(
+            "Cargo.toml",
+            r#"
+                cargo-features = ["rename-dependency"]
+
+                [package]
+                name = "test"
+                version = "0.1.0"
+                authors = []
+
+                [dependencies]
+                bar = { version = "0.1", package = "foo" }
+                [build-dependencies]
+                foo = { version = "0.1" }
+            "#,
+        )
+        .file("src/lib.rs", "",)
+        .build();
+
+    assert_that(
+        p.cargo("build -v").masquerade_as_nightly_cargo(),
+        execs().with_status(101)
+            .with_stderr("\
+[UPDATING] registry `[..]`
+[DOWNLOADING] foo v0.1.0 (registry [..])
+error: multiple dependencies listed for the same crate must all have the same \
+name, but the dependency on `foo v0.1.0` is listed as having different names
+")
     );
 }


### PR DESCRIPTION
Previously there was a verification in manifest parsing that the same dependency
must come from the same source, but this erroneously triggered an error to get
emitted when the `package` key was used to rename crates. The first change here
was to update that clause to key off the `rename` field rather than the `name`
field.

Afterwards, though, this exposed an existing bug in the implementation. During
compilation we have a `Resolve` which is a graph of crates, but we don't know
*why* each edge in the dependency graph exists. In other words we don't know,
when looking at an edge of the graph, what `Dependency` caused that edge to be
drawn. We need to know this when passing `--extern` flags because the
`Dependency` is what lists what's being renamed.

This commit then primarily refactors `Resolve::deps` from an iterator of package
ids to an iterator of a tuples. The first element is the package id from before
and the second element is a list of `Dependency` directives which caused the
edge to ber driven.

This refactoring cleaned up a few places in the backend where we had to work
around the lack of this knowledge. Namely this also fixes the extra test added
here.

Closes #5413