### PR TITLE
Revert "Enable new behavior of `--feature`"

### DIFF
--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -299,6 +299,7 @@ pub struct CliUnstable {
     pub no_index_update: bool,
     pub avoid_dev_deps: bool,
     pub minimal_versions: bool,
+    pub package_features: bool,
 }
 
 impl CliUnstable {
@@ -332,6 +333,7 @@ impl CliUnstable {
             "no-index-update" => self.no_index_update = true,
             "avoid-dev-deps" => self.avoid_dev_deps = true,
             "minimal-versions" => self.minimal_versions = true,
+            "package-features" => self.package_features = true,
             _ => bail!("unknown `-Z` flag specified: {}", k),
         }
 

--- a/src/cargo/core/resolver/types.rs
+++ b/src/cargo/core/resolver/types.rs
@@ -155,7 +155,7 @@ impl<'a> RegistryQueryer<'a> {
     }
 }
 
-#[derive(Clone, Copy, Eq, PartialEq)]
+#[derive(Clone, Copy)]
 pub enum Method<'a> {
     Everything, // equivalent to Required { dev_deps: true, all_features: true, .. }
     Required {

--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -118,7 +118,6 @@ pub struct WorkspaceRootConfig {
 
 /// An iterator over the member packages of a workspace, returned by
 /// `Workspace::members`
-#[derive(Clone)]
 pub struct Members<'a, 'cfg: 'a> {
     ws: &'a Workspace<'cfg>,
     iter: slice::Iter<'a, PathBuf>,

--- a/tests/testsuite/features.rs
+++ b/tests/testsuite/features.rs
@@ -1674,42 +1674,46 @@ fn combining_features_and_package() {
         .build();
 
     assert_that(
-        p.cargo("build --all --features main")
-            .masquerade_as_nightly_cargo(),
-        execs()
-            .with_status(101)
-            .with_stderr_contains("[ERROR] cannot specify features for more than one package"),
-    );
-
-    assert_that(
-        p.cargo("build --package dep --features main")
+        p.cargo("build -Z package-features --all --features main")
             .masquerade_as_nightly_cargo(),
         execs().with_status(101).with_stderr_contains(
-            "[ERROR] cannot specify features for packages outside of workspace",
-        ),
-    );
-    assert_that(
-        p.cargo("build --package dep --all-features")
-            .masquerade_as_nightly_cargo(),
-        execs().with_status(101).with_stderr_contains(
-            "[ERROR] cannot specify features for packages outside of workspace",
-        ),
-    );
-    assert_that(
-        p.cargo("build --package dep --no-default-features")
-            .masquerade_as_nightly_cargo(),
-        execs().with_status(101).with_stderr_contains(
-            "[ERROR] cannot specify features for packages outside of workspace",
+            "\
+             [ERROR] cannot specify features for more than one package",
         ),
     );
 
     assert_that(
-        p.cargo("build --all --all-features")
+        p.cargo("build -Z package-features --package dep --features main")
+            .masquerade_as_nightly_cargo(),
+        execs().with_status(101).with_stderr_contains(
+            "\
+             [ERROR] cannot specify features for packages outside of workspace",
+        ),
+    );
+    assert_that(
+        p.cargo("build -Z package-features --package dep --all-features")
+            .masquerade_as_nightly_cargo(),
+        execs().with_status(101).with_stderr_contains(
+            "\
+             [ERROR] cannot specify features for packages outside of workspace",
+        ),
+    );
+    assert_that(
+        p.cargo("build -Z package-features --package dep --no-default-features")
+            .masquerade_as_nightly_cargo(),
+        execs().with_status(101).with_stderr_contains(
+            "\
+             [ERROR] cannot specify features for packages outside of workspace",
+        ),
+    );
+
+    assert_that(
+        p.cargo("build -Z package-features --all --all-features")
             .masquerade_as_nightly_cargo(),
         execs().with_status(0),
     );
     assert_that(
-        p.cargo("run --package foo --features main")
+        p.cargo("run -Z package-features --package foo --features main")
             .masquerade_as_nightly_cargo(),
         execs().with_status(0),
     );


### PR DESCRIPTION
This reverts commit 038eec5cb3bd25a0855b0be6ad2aeba5391c6c6e.

As discussed at https://github.com/rust-lang/cargo/issues/5364, the new behavior unfortunately causes real-life breakage, so we have to revert it. 

This is kinda sad, this is a part of the larger issue with feature selection, which, at the moment, has a behavior which I would classify (loosely speaking) as unsound:

* `cargo build -p foo` and `cargo build -p foo -p bar` might produce different artifacts for `foo` ([repro](https://github.com/matklad/workspace-vs-feaures))
* `cargo build -p foo` might produce different artifacts, depending on cwd ([repro](https://github.com/matklad/features-cwd))

The new feature behavior specifically addressed the second point. 

It is unclear what we could do with this... One option, instead of flatly erroring out, as the revreted commit does, is to print a warning, but change the set of activated features. It will still be a breaking change, but it at least has  a chance of working by accident. 

r? @alexcrichton 