### PR TITLE
Update documentation on config via environment variables

### DIFF
--- a/src/doc/src/reference/config.md
+++ b/src/doc/src/reference/config.md
@@ -133,9 +133,11 @@ example the `build.jobs` key can also be defined by `CARGO_BUILD_JOBS`.
 
 Environment variables will take precedent over TOML configuration, and currently
 only integer, boolean, and string keys are supported to be defined by
-environment variables.
+environment variables. This means that [source replacement][source], which is expressed by
+tables, cannot be configured through environment variables.
 
 In addition to the system above, Cargo recognizes a few other specific
 [environment variables][env].
 
 [env]: reference/environment-variables.html
+[source]: (reference/source-replacement.html)


### PR DESCRIPTION
Use source replacement as a specific example of the kind
of configuration feature that cannot currently be set by
environmental variables.