### PR TITLE
Add cargo clean --doc

### DIFF
--- a/src/bin/command_prelude.rs
+++ b/src/bin/command_prelude.rs
@@ -105,6 +105,10 @@ pub trait AppExt: Sized {
         self._arg(opt("release", release))
     }
 
+    fn arg_doc(self, doc: &'static str) -> Self {
+        self._arg(opt("doc", doc))
+    }
+
     fn arg_target_triple(self, target: &'static str) -> Self {
         self._arg(opt("target", target).value_name("TRIPLE"))
     }

--- a/src/bin/commands/clean.rs
+++ b/src/bin/commands/clean.rs
@@ -10,6 +10,7 @@ pub fn cli() -> App {
         .arg_target_triple("Target triple to clean output for (default all)")
         .arg_target_dir()
         .arg_release("Whether or not to clean release artifacts")
+        .arg_doc("Whether or not to clean just the documentation directory")
         .after_help(
             "\
 If the --package argument is given, then SPEC is a package id specification
@@ -27,6 +28,7 @@ pub fn exec(config: &mut Config, args: &ArgMatches) -> CliResult {
         spec: values(args, "package"),
         target: args.target(),
         release: args.is_present("release"),
+        doc: args.is_present("doc"),
     };
     ops::clean(&ws, &opts)?;
     Ok(())

--- a/src/cargo/ops/cargo_clean.rs
+++ b/src/cargo/ops/cargo_clean.rs
@@ -17,12 +17,21 @@ pub struct CleanOptions<'a> {
     pub target: Option<String>,
     /// Whether to clean the release directory
     pub release: bool,
+    /// Whether to just clean the doc directory
+    pub doc: bool,
 }
 
 /// Cleans the project from build artifacts.
 pub fn clean(ws: &Workspace, opts: &CleanOptions) -> CargoResult<()> {
     let target_dir = ws.target_dir();
     let config = ws.config();
+
+    // If the doc option is set, we just want to delete the doc directory.
+    if opts.doc {
+        let target_dir = target_dir.join("doc");
+        let target_dir = target_dir.into_path_unlocked();
+        return rm_rf(&target_dir, config);
+    }
 
     // If we have a spec, then we need to delete some packages, otherwise, just
     // remove the whole target directory and be done with it!

--- a/tests/testsuite/clean.rs
+++ b/tests/testsuite/clean.rs
@@ -162,6 +162,46 @@ fn clean_release() {
 }
 
 #[test]
+fn clean_doc() {
+    let p = project("foo")
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+
+            [dependencies]
+            a = { path = "a" }
+        "#,
+        )
+        .file("src/main.rs", "fn main() {}")
+        .file(
+            "a/Cargo.toml",
+            r#"
+            [package]
+            name = "a"
+            version = "0.0.1"
+            authors = []
+        "#,
+        )
+        .file("a/src/lib.rs", "")
+        .build();
+
+    assert_that(p.cargo("doc"), execs().with_status(0));
+
+    let doc_path = &p.build_dir().join("doc");
+
+    assert_that(doc_path, existing_dir());
+
+    assert_that(p.cargo("clean").arg("--doc"), execs().with_status(0));
+
+    assert_that(doc_path, is_not(existing_dir()));
+    assert_that(p.build_dir(), existing_dir());
+}
+
+#[test]
 fn build_script() {
     let p = project("foo")
         .file(


### PR DESCRIPTION
Implements #5449.
It only removes the doc directory and therefore keeps all other build artifacts intact.
When `--doc` is used all other options are ignored.

My test case is mostly copy&paste from `clean_release` so maybe the `.toml`s can be simplified.