### PR TITLE
include version requirements in path for resolver error messages

### DIFF
--- a/src/bin/cargo/command_prelude.rs
+++ b/src/bin/cargo/command_prelude.rs
@@ -115,7 +115,9 @@ pub trait AppExt: Sized {
     }
 
     fn arg_target_dir(self) -> Self {
-        self._arg(opt("target-dir", "Directory for all generated artifacts").value_name("DIRECTORY"))
+        self._arg(
+            opt("target-dir", "Directory for all generated artifacts").value_name("DIRECTORY"),
+        )
     }
 
     fn arg_manifest_path(self) -> Self {

--- a/src/bin/cargo/commands/new.rs
+++ b/src/bin/cargo/commands/new.rs
@@ -19,8 +19,9 @@ pub fn exec(config: &mut Config, args: &ArgMatches) -> CliResult {
     } else {
         path
     };
-    config
-        .shell()
-        .status("Created", format!("{} `{}` project", opts.kind, project_name))?;
+    config.shell().status(
+        "Created",
+        format!("{} `{}` project", opts.kind, project_name),
+    )?;
     Ok(())
 }

--- a/src/cargo/core/compiler/build_context/mod.rs
+++ b/src/cargo/core/compiler/build_context/mod.rs
@@ -103,16 +103,18 @@ impl<'a, 'cfg> BuildContext<'a, 'cfg> {
         };
 
         let crate_name = dep.target.crate_name();
-        let mut names = deps.iter()
-            .map(|d| d.rename().unwrap_or(&crate_name));
+        let mut names = deps.iter().map(|d| d.rename().unwrap_or(&crate_name));
         let name = names.next().unwrap_or(&crate_name);
         for n in names {
             if n == name {
-                continue
+                continue;
             }
-            bail!("multiple dependencies listed for the same crate must \
-                   all have the same name, but the dependency on `{}` \
-                   is listed as having different names", dep.pkg.package_id());
+            bail!(
+                "multiple dependencies listed for the same crate must \
+                 all have the same name, but the dependency on `{}` \
+                 is listed as having different names",
+                dep.pkg.package_id()
+            );
         }
         Ok(name.to_string())
     }

--- a/src/cargo/core/compiler/context/mod.rs
+++ b/src/cargo/core/compiler/context/mod.rs
@@ -480,9 +480,17 @@ impl<'a> Links<'a> {
 
             let describe_path = |pkgid: &PackageId| -> String {
                 let dep_path = resolve.path_to_top(pkgid);
-                let mut dep_path_desc = format!("package `{}`", dep_path[0]);
-                for dep in dep_path.iter().skip(1) {
-                    write!(dep_path_desc, "\n    ... which is depended on by `{}`", dep).unwrap();
+                let mut dep_path_desc = format!("package `{}`", pkgid);
+                for &(dep, req) in dep_path.iter() {
+                    let req = req.first().unwrap();
+                    write!(
+                        dep_path_desc,
+                        "\n    ... selected to fulfill the requirement \
+                         `{} = \"{}\"` from package `{}`",
+                        req.name(),
+                        req.version_req(),
+                        dep
+                    ).unwrap();
                 }
                 dep_path_desc
             };

--- a/src/cargo/core/compiler/context/mod.rs
+++ b/src/cargo/core/compiler/context/mod.rs
@@ -479,7 +479,7 @@ impl<'a> Links<'a> {
             let pkg = unit.pkg.package_id();
 
             let describe_path = |pkgid: &PackageId| -> String {
-                let dep_path = resolve.path_to_top(pkgid);
+                let dep_path = resolve.graph().path_to_top(pkgid);
                 let mut dep_path_desc = format!("package `{}`", pkgid);
                 for &(dep, req) in dep_path.iter() {
                     let req = req.first().unwrap();

--- a/src/cargo/core/compiler/context/mod.rs
+++ b/src/cargo/core/compiler/context/mod.rs
@@ -486,8 +486,7 @@ impl<'a> Links<'a> {
                     write!(
                         dep_path_desc,
                         "\n    ... selected to fulfill the requirement \
-                         `{} = \"{}\"` from package `{}`",
-                        req.name(),
+                         \"{}\" from package `{}`",
                         req.version_req(),
                         dep
                     ).unwrap();

--- a/src/cargo/core/compiler/fingerprint.rs
+++ b/src/cargo/core/compiler/fingerprint.rs
@@ -15,7 +15,7 @@ use util::errors::{CargoResult, CargoResultExt};
 use util::paths;
 use util::{internal, profile, Dirty, Fresh, Freshness};
 
-use super::{Context, BuildContext, FileFlavor, Unit};
+use super::{BuildContext, Context, FileFlavor, Unit};
 use super::custom_build::BuildDeps;
 use super::job::Work;
 
@@ -355,7 +355,14 @@ impl hash::Hash for Fingerprint {
             ..
         } = *self;
         (
-            rustc, features, target, path, profile, local, edition, rustflags,
+            rustc,
+            features,
+            target,
+            path,
+            profile,
+            local,
+            edition,
+            rustflags,
         ).hash(h);
 
         h.write_usize(deps.len());

--- a/src/cargo/core/resolver/mod.rs
+++ b/src/cargo/core/resolver/mod.rs
@@ -1028,8 +1028,7 @@ fn describe_path(
         let req = req.first().unwrap();
         write!(
             dep_path_desc,
-            "\n    ... selected to fulfill the requirement `{} = \"{}\"` from package `{}`",
-            req.name(),
+            "\n    ... selected to fulfill the requirement \"{}\" from package `{}`",
             req.version_req(),
             dep
         ).unwrap();

--- a/src/cargo/core/resolver/mod.rs
+++ b/src/cargo/core/resolver/mod.rs
@@ -401,13 +401,7 @@ fn activate_deps_loop(
                 dep.name(),
                 candidate.summary.version()
             );
-            let res = activate(
-                &mut cx,
-                registry,
-                Some((&parent, &dep)),
-                candidate,
-                &method,
-            );
+            let res = activate(&mut cx, registry, Some((&parent, &dep)), candidate, &method);
 
             let successfully_activated = match res {
                 // Success! We've now activated our `candidate` in our context

--- a/src/cargo/core/resolver/mod.rs
+++ b/src/cargo/core/resolver/mod.rs
@@ -865,7 +865,10 @@ fn activation_error(
     if !candidates.is_empty() {
         let mut msg = format!("failed to select a version for `{}`.", dep.name());
         msg.push_str("\n    ... required by ");
-        msg.push_str(&describe_path(&graph.path_to_top(parent.package_id())));
+        msg.push_str(&describe_path(
+            parent.package_id(),
+            &graph.path_to_top(parent.package_id()),
+        ));
 
         msg.push_str("\nversions that meet the requirements `");
         msg.push_str(&dep.version_req().to_string());
@@ -894,7 +897,7 @@ fn activation_error(
                 msg.push_str(link);
                 msg.push_str("` as well:\n");
             }
-            msg.push_str(&describe_path(&graph.path_to_top(p)));
+            msg.push_str(&describe_path(p, &graph.path_to_top(p)));
         }
 
         let (features_errors, other_errors): (Vec<_>, Vec<_>) = other_errors
@@ -925,7 +928,7 @@ fn activation_error(
 
         for &(p, _) in other_errors.iter() {
             msg.push_str("\n\n  previously selected ");
-            msg.push_str(&describe_path(&graph.path_to_top(p)));
+            msg.push_str(&describe_path(p, &graph.path_to_top(p)));
         }
 
         msg.push_str("\n\nfailed to select a version for `");
@@ -976,7 +979,10 @@ fn activation_error(
             versions
         );
         msg.push_str("required by ");
-        msg.push_str(&describe_path(&graph.path_to_top(parent.package_id())));
+        msg.push_str(&describe_path(
+            parent.package_id(),
+            &graph.path_to_top(parent.package_id()),
+        ));
 
         // If we have a path dependency with a locked version, then this may
         // indicate that we updated a sub-package and forgot to run `cargo
@@ -997,7 +1003,10 @@ fn activation_error(
             dep.source_id()
         );
         msg.push_str("required by ");
-        msg.push_str(&describe_path(&graph.path_to_top(parent.package_id())));
+        msg.push_str(&describe_path(
+            parent.package_id(),
+            &graph.path_to_top(parent.package_id()),
+        ));
 
         msg
     };
@@ -1017,11 +1026,18 @@ fn activation_error(
 }
 
 /// Returns String representation of dependency chain for a particular `pkgid`.
-fn describe_path(path: &[&PackageId]) -> String {
+fn describe_path(this: &PackageId, path: &[(&PackageId, &Vec<Dependency>)]) -> String {
     use std::fmt::Write;
-    let mut dep_path_desc = format!("package `{}`", path[0]);
-    for dep in path[1..].iter() {
-        write!(dep_path_desc, "\n    ... which is depended on by `{}`", dep).unwrap();
+    let mut dep_path_desc = format!("package `{}`", this);
+    for &(dep, req) in path.iter() {
+        let req = req.first().unwrap();
+        write!(
+            dep_path_desc,
+            "\n    ... selected to fulfill the requirement `{} = \"{}\"` from package `{}`",
+            req.name(),
+            req.version_req(),
+            dep
+        ).unwrap();
     }
     dep_path_desc
 }
@@ -1055,7 +1071,7 @@ fn check_cycles(resolve: &Resolve, activations: &Activations) -> CargoResult<()>
             bail!(
                 "cyclic package dependency: package `{}` depends on itself. Cycle:\n{}",
                 id,
-                describe_path(&resolve.path_to_top(id))
+                describe_path(id, &resolve.path_to_top(id))
             );
         }
 

--- a/src/cargo/core/resolver/mod.rs
+++ b/src/cargo/core/resolver/mod.rs
@@ -865,10 +865,7 @@ fn activation_error(
     if !candidates.is_empty() {
         let mut msg = format!("failed to select a version for `{}`.", dep.name());
         msg.push_str("\n    ... required by ");
-        msg.push_str(&describe_path(
-            parent.package_id(),
-            &graph.path_to_top(parent.package_id()),
-        ));
+        msg.push_str(&describe_path(&graph, parent.package_id()));
 
         msg.push_str("\nversions that meet the requirements `");
         msg.push_str(&dep.version_req().to_string());
@@ -897,7 +894,7 @@ fn activation_error(
                 msg.push_str(link);
                 msg.push_str("` as well:\n");
             }
-            msg.push_str(&describe_path(p, &graph.path_to_top(p)));
+            msg.push_str(&describe_path(&graph, p));
         }
 
         let (features_errors, other_errors): (Vec<_>, Vec<_>) = other_errors
@@ -928,7 +925,7 @@ fn activation_error(
 
         for &(p, _) in other_errors.iter() {
             msg.push_str("\n\n  previously selected ");
-            msg.push_str(&describe_path(p, &graph.path_to_top(p)));
+            msg.push_str(&describe_path(&graph, p));
         }
 
         msg.push_str("\n\nfailed to select a version for `");
@@ -979,10 +976,7 @@ fn activation_error(
             versions
         );
         msg.push_str("required by ");
-        msg.push_str(&describe_path(
-            parent.package_id(),
-            &graph.path_to_top(parent.package_id()),
-        ));
+        msg.push_str(&describe_path(&graph, parent.package_id()));
 
         // If we have a path dependency with a locked version, then this may
         // indicate that we updated a sub-package and forgot to run `cargo
@@ -1003,10 +997,7 @@ fn activation_error(
             dep.source_id()
         );
         msg.push_str("required by ");
-        msg.push_str(&describe_path(
-            parent.package_id(),
-            &graph.path_to_top(parent.package_id()),
-        ));
+        msg.push_str(&describe_path(&graph, parent.package_id()));
 
         msg
     };
@@ -1026,8 +1017,12 @@ fn activation_error(
 }
 
 /// Returns String representation of dependency chain for a particular `pkgid`.
-fn describe_path(this: &PackageId, path: &[(&PackageId, &Vec<Dependency>)]) -> String {
+fn describe_path(
+    graph: &::util::graph::Graph<PackageId, Vec<Dependency>>,
+    this: &PackageId,
+) -> String {
     use std::fmt::Write;
+    let path: &[(&PackageId, &Vec<Dependency>)] = &graph.path_to_top(this);
     let mut dep_path_desc = format!("package `{}`", this);
     for &(dep, req) in path.iter() {
         let req = req.first().unwrap();
@@ -1071,7 +1066,7 @@ fn check_cycles(resolve: &Resolve, activations: &Activations) -> CargoResult<()>
             bail!(
                 "cyclic package dependency: package `{}` depends on itself. Cycle:\n{}",
                 id,
-                describe_path(id, &resolve.path_to_top(id))
+                describe_path(&resolve.graph(), id)
             );
         }
 

--- a/src/cargo/core/resolver/resolve.rs
+++ b/src/cargo/core/resolver/resolve.rs
@@ -58,7 +58,10 @@ impl Resolve {
 
     /// Resolves one of the paths from the given dependent package up to
     /// the root.
-    pub fn path_to_top<'a>(&'a self, pkg: &'a PackageId) -> Vec<&'a PackageId> {
+    pub fn path_to_top<'a>(
+        &'a self,
+        pkg: &'a PackageId,
+    ) -> Vec<(&'a PackageId, &'a Vec<Dependency>)> {
         self.graph.path_to_top(pkg)
     }
 

--- a/src/cargo/core/resolver/resolve.rs
+++ b/src/cargo/core/resolver/resolve.rs
@@ -56,15 +56,6 @@ impl Resolve {
         }
     }
 
-    /// Resolves one of the paths from the given dependent package up to
-    /// the root.
-    pub fn path_to_top<'a>(
-        &'a self,
-        pkg: &'a PackageId,
-    ) -> Vec<(&'a PackageId, &'a Vec<Dependency>)> {
-        self.graph.path_to_top(pkg)
-    }
-
     pub fn register_used_patches(&mut self, patches: &HashMap<Url, Vec<Summary>>) {
         for summary in patches.values().flat_map(|v| v) {
             if self.iter().any(|id| id == summary.package_id()) {
@@ -188,6 +179,10 @@ unable to verify that `{0}` is the same as when the lockfile was generated
 
     pub fn replacements(&self) -> &HashMap<PackageId, PackageId> {
         &self.replacements
+    }
+
+    pub fn graph(&self) -> &Graph<PackageId, Vec<Dependency>> {
+        &self.graph
     }
 
     pub fn features(&self, pkg: &PackageId) -> &HashSet<String> {

--- a/src/cargo/core/summary.rs
+++ b/src/cargo/core/summary.rs
@@ -142,7 +142,8 @@ fn build_feature_map(
     use self::FeatureValue::*;
     let mut dep_map = HashMap::new();
     for dep in dependencies.iter() {
-        dep_map.entry(dep.name().as_str())
+        dep_map
+            .entry(dep.name().as_str())
             .or_insert(Vec::new())
             .push(dep);
     }
@@ -198,7 +199,8 @@ fn build_feature_map(
                     }
                 }
             };
-            let is_optional_dep = dep_data.iter()
+            let is_optional_dep = dep_data
+                .iter()
                 .flat_map(|d| d.iter())
                 .any(|d| d.is_optional());
             if let FeatureValue::Crate(ref dep_name) = val {

--- a/src/cargo/ops/cargo_fetch.rs
+++ b/src/cargo/ops/cargo_fetch.rs
@@ -34,25 +34,25 @@ pub fn fetch<'a>(
             }
 
             packages.get(id)?;
-            let deps = resolve.deps(id)
+            let deps = resolve
+                .deps(id)
                 .filter(|&(_id, deps)| {
-                    deps.iter()
-                        .any(|d| {
-                            // If no target was specified then all dependencies can
-                            // be fetched.
-                            let target = match options.target {
-                                Some(ref t) => t,
-                                None => return true,
-                            };
-                            // If this dependency is only available for certain
-                            // platforms, make sure we're only fetching it for that
-                            // platform.
-                            let platform = match d.platform() {
-                                Some(p) => p,
-                                None => return true,
-                            };
-                            platform.matches(target, target_info.cfg())
-                        })
+                    deps.iter().any(|d| {
+                        // If no target was specified then all dependencies can
+                        // be fetched.
+                        let target = match options.target {
+                            Some(ref t) => t,
+                            None => return true,
+                        };
+                        // If this dependency is only available for certain
+                        // platforms, make sure we're only fetching it for that
+                        // platform.
+                        let platform = match d.platform() {
+                            Some(p) => p,
+                            None => return true,
+                        };
+                        platform.matches(target, target_info.cfg())
+                    })
                 })
                 .map(|(id, _deps)| id);
             deps_to_fetch.extend(deps);

--- a/src/cargo/sources/registry/index.rs
+++ b/src/cargo/sources/registry/index.rs
@@ -118,7 +118,7 @@ impl<'cfg> RegistryIndex<'cfg> {
                     Err(e) => {
                         info!("failed to parse `{}` registry package: {}", name, e);
                         trace!("line: {}", line);
-                        return None
+                        return None;
                     }
                 };
                 if online || load.is_crate_downloaded(summary.package_id()) {

--- a/src/cargo/util/graph.rs
+++ b/src/cargo/util/graph.rs
@@ -73,24 +73,25 @@ impl<N: Eq + Hash + Clone, E: Default> Graph<N, E> {
 
     /// Resolves one of the paths from the given dependent package up to
     /// the root.
-    pub fn path_to_top<'a>(&'a self, mut pkg: &'a N) -> Vec<&'a N> {
+    pub fn path_to_top<'a>(&'a self, mut pkg: &'a N) -> Vec<(&'a N, &'a E)> {
         // Note that this implementation isn't the most robust per se, we'll
         // likely have to tweak this over time. For now though it works for what
         // it's used for!
-        let mut result = vec![pkg];
-        let first_pkg_depending_on = |pkg: &N, res: &[&N]| {
+        let mut result: Vec<(&'a N, &'a E)> = vec![];
+        let first_pkg_depending_on = |pkg: &N, res: &[(&'a N, &'a E)]| {
             self.nodes
                 .iter()
                 .filter(|&(_node, adjacent)| adjacent.contains_key(pkg))
                 // Note that we can have "cycles" introduced through dev-dependency
                 // edges, so make sure we don't loop infinitely.
-                .filter(|&(node, _)| !res.contains(&node))
+                .filter(|&(node, _)| res.iter().find(|p| p.0 == node).is_none())
+                // TODO: find_map would be clearer
                 .next()
-                .map(|p| p.0)
+                .map(|(node, adjacent)| (node, adjacent.get(pkg).unwrap()))
         };
         while let Some(p) = first_pkg_depending_on(pkg, &result) {
             result.push(p);
-            pkg = p;
+            pkg = p.0;
         }
         result
     }

--- a/src/cargo/util/toml/targets.rs
+++ b/src/cargo/util/toml/targets.rs
@@ -476,7 +476,14 @@ fn clean_targets_with_legacy_path(
     validate_unique_names(&toml_targets, target_kind)?;
     let mut result = Vec::new();
     for target in toml_targets {
-        let path = target_path(&target, inferred, target_kind, package_root, edition, legacy_path);
+        let path = target_path(
+            &target,
+            inferred,
+            target_kind,
+            package_root,
+            edition,
+            legacy_path,
+        );
         let path = match path {
             Ok(path) => path,
             Err(e) => {

--- a/tests/testsuite/alt_registry.rs
+++ b/tests/testsuite/alt_registry.rs
@@ -419,9 +419,7 @@ fn alt_registry_and_crates_io_deps() {
             .with_stderr_contains("[COMPILING] alt_reg_dep v0.1.0 (registry `file://[..]`)")
             .with_stderr_contains("[COMPILING] crates_io_dep v0.0.1")
             .with_stderr_contains(&format!("[COMPILING] foo v0.0.1 ({})", p.url()))
-            .with_stderr_contains(
-                "[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s",
-            ),
+            .with_stderr_contains("[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s"),
     )
 }
 

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -1348,14 +1348,14 @@ fn incompatible_dependencies() {
             "\
 error: failed to select a version for `bad`.
     ... required by package `baz v0.1.0`
-    ... selected to fulfill the requirement `baz = \"^0.1.0\"` from package `incompatible_dependencies v0.0.1 ([..])`
+    ... selected to fulfill the requirement \"^0.1.0\" from package `incompatible_dependencies v0.0.1 ([..])`
 versions that meet the requirements `>= 1.0.1` are: 1.0.2, 1.0.1
 
 all possible versions conflict with previously selected packages.
 
   previously selected package `bad v1.0.0`
-    ... selected to fulfill the requirement `bad = \"= 1.0.0\"` from package `bar v0.1.0`
-    ... selected to fulfill the requirement `bar = \"^0.1.0\"` from package `incompatible_dependencies v0.0.1 ([..])`
+    ... selected to fulfill the requirement \"= 1.0.0\" from package `bar v0.1.0`
+    ... selected to fulfill the requirement \"^0.1.0\" from package `incompatible_dependencies v0.0.1 ([..])`
 
 failed to select a version for `bad` which could resolve this conflict",
         ),
@@ -1399,12 +1399,12 @@ versions that meet the requirements `>= 1.0.1, <= 2.0.0` are: 2.0.0, 1.0.1
 all possible versions conflict with previously selected packages.
 
   previously selected package `bad v2.0.1`
-    ... selected to fulfill the requirement `bad = \">= 2.0.1\"` from package `baz v0.1.0`
-    ... selected to fulfill the requirement `baz = \"^0.1.0\"` from package `incompatible_dependencies v0.0.1 ([..])`
+    ... selected to fulfill the requirement \">= 2.0.1\" from package `baz v0.1.0`
+    ... selected to fulfill the requirement \"^0.1.0\" from package `incompatible_dependencies v0.0.1 ([..])`
 
   previously selected package `bad v1.0.0`
-    ... selected to fulfill the requirement `bad = \"= 1.0.0\"` from package `bar v0.1.0`
-    ... selected to fulfill the requirement `bar = \"^0.1.0\"` from package `incompatible_dependencies v0.0.1 ([..])`
+    ... selected to fulfill the requirement \"= 1.0.0\" from package `bar v0.1.0`
+    ... selected to fulfill the requirement \"^0.1.0\" from package `incompatible_dependencies v0.0.1 ([..])`
 
 failed to select a version for `bad` which could resolve this conflict",
         ),
@@ -1455,7 +1455,7 @@ fn compile_offline_while_transitive_dep_not_cached() {
 error: no matching package named `bar` found
 location searched: registry `[..]`
 required by package `foo v0.1.0`
-    ... selected to fulfill the requirement `foo = \"= 0.1.0\"` \
+    ... selected to fulfill the requirement \"= 0.1.0\" \
 from package `transitive_load_test v0.0.1 ([..]/transitive_load_test)`
 As a reminder, you're using offline mode (-Z offline) \
 which can sometimes cause surprising resolution failures, \
@@ -3360,8 +3360,8 @@ fn cyclic_deps_rejected() {
                        .with_stderr(
 r#"[ERROR] cyclic package dependency: package `a v0.0.1 ([..])` depends on itself. Cycle:
 package `a v0.0.1 ([..]a)`
-    ... selected to fulfill the requirement `a = "*"` from package `foo v0.0.1 ([..]foo)`
-    ... selected to fulfill the requirement `foo = "*"` from package `a v0.0.1 ([..]a)`"#));
+    ... selected to fulfill the requirement "*" from package `foo v0.0.1 ([..]foo)`
+    ... selected to fulfill the requirement "*" from package `a v0.0.1 ([..]a)`"#));
 }
 
 #[test]

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -1348,14 +1348,14 @@ fn incompatible_dependencies() {
             "\
 error: failed to select a version for `bad`.
     ... required by package `baz v0.1.0`
-    ... which is depended on by `incompatible_dependencies v0.0.1 ([..])`
+    ... selected to fulfill the requirement `baz = \"^0.1.0\"` from package `incompatible_dependencies v0.0.1 ([..])`
 versions that meet the requirements `>= 1.0.1` are: 1.0.2, 1.0.1
 
 all possible versions conflict with previously selected packages.
 
   previously selected package `bad v1.0.0`
-    ... which is depended on by `bar v0.1.0`
-    ... which is depended on by `incompatible_dependencies v0.0.1 ([..])`
+    ... selected to fulfill the requirement `bad = \"= 1.0.0\"` from package `bar v0.1.0`
+    ... selected to fulfill the requirement `bar = \"^0.1.0\"` from package `incompatible_dependencies v0.0.1 ([..])`
 
 failed to select a version for `bad` which could resolve this conflict",
         ),
@@ -1399,12 +1399,12 @@ versions that meet the requirements `>= 1.0.1, <= 2.0.0` are: 2.0.0, 1.0.1
 all possible versions conflict with previously selected packages.
 
   previously selected package `bad v2.0.1`
-    ... which is depended on by `baz v0.1.0`
-    ... which is depended on by `incompatible_dependencies v0.0.1 ([..])`
+    ... selected to fulfill the requirement `bad = \">= 2.0.1\"` from package `baz v0.1.0`
+    ... selected to fulfill the requirement `baz = \"^0.1.0\"` from package `incompatible_dependencies v0.0.1 ([..])`
 
   previously selected package `bad v1.0.0`
-    ... which is depended on by `bar v0.1.0`
-    ... which is depended on by `incompatible_dependencies v0.0.1 ([..])`
+    ... selected to fulfill the requirement `bad = \"= 1.0.0\"` from package `bar v0.1.0`
+    ... selected to fulfill the requirement `bar = \"^0.1.0\"` from package `incompatible_dependencies v0.0.1 ([..])`
 
 failed to select a version for `bad` which could resolve this conflict",
         ),
@@ -1455,7 +1455,8 @@ fn compile_offline_while_transitive_dep_not_cached() {
 error: no matching package named `bar` found
 location searched: registry `[..]`
 required by package `foo v0.1.0`
-    ... which is depended on by `transitive_load_test v0.0.1 ([..]/transitive_load_test)`
+    ... selected to fulfill the requirement `foo = \"= 0.1.0\"` \
+from package `transitive_load_test v0.0.1 ([..]/transitive_load_test)`
 As a reminder, you're using offline mode (-Z offline) \
 which can sometimes cause surprising resolution failures, \
 if this error is too confusing you may with to retry \
@@ -1944,7 +1945,8 @@ fn self_dependency() {
         execs().with_status(101).with_stderr(
             "\
 [ERROR] cyclic package dependency: package `test v0.0.0 ([..])` depends on itself. Cycle:
-package `test v0.0.0 ([..]foo)`",
+package `test v0.0.0 ([..]foo)`
+    ... selected to fulfill the requirement \"*\" from package `test v0.0.0 ([..]foo)`",
         ),
     );
 }
@@ -3358,7 +3360,8 @@ fn cyclic_deps_rejected() {
                        .with_stderr(
 r#"[ERROR] cyclic package dependency: package `a v0.0.1 ([..])` depends on itself. Cycle:
 package `a v0.0.1 ([..]a)`
-    ... which is depended on by `foo v0.0.1 ([..]foo)`[..]"#));
+    ... selected to fulfill the requirement `a = "*"` from package `foo v0.0.1 ([..]foo)`
+    ... selected to fulfill the requirement `foo = "*"` from package `a v0.0.1 ([..]a)`"#));
 }
 
 #[test]

--- a/tests/testsuite/build_script.rs
+++ b/tests/testsuite/build_script.rs
@@ -428,7 +428,7 @@ fn links_duplicates_deep_dependency() {
                        .with_stderr("\
 error: failed to select a version for `a-sys`.
     ... required by package `a v0.5.0 ([..])`
-    ... selected to fulfill the requirement `a = \"*\"` from package `foo v0.5.0 ([..])`
+    ... selected to fulfill the requirement \"*\" from package `foo v0.5.0 ([..])`
 versions that meet the requirements `*` are: 0.5.0
 
 the package `a-sys` links to the native library `a`, but it conflicts with a previous package which links to `a` as well:

--- a/tests/testsuite/build_script.rs
+++ b/tests/testsuite/build_script.rs
@@ -157,18 +157,20 @@ fn custom_build_env_vars() {
     );
 }
 
-
 #[test]
 fn custom_build_env_var_rustc_linker() {
-    if cross_compile::disabled() { return; }
+    if cross_compile::disabled() {
+        return;
+    }
     let target = cross_compile::alternate();
     let p = project("foo")
-        .file("Cargo.toml",
-              r#"
+        .file(
+            "Cargo.toml",
+            r#"
               [project]
               name = "foo"
               version = "0.0.1"
-              "#
+              "#,
         )
         .file(
             ".cargo/config",
@@ -178,7 +180,7 @@ fn custom_build_env_var_rustc_linker() {
                 linker = "/path/to/linker"
                 "#,
                 target
-            )
+            ),
         )
         .file(
             "build.rs",
@@ -188,7 +190,7 @@ fn custom_build_env_var_rustc_linker() {
             fn main() {
                 assert!(env::var("RUSTC_LINKER").unwrap().ends_with("/path/to/linker"));
             }
-            "#
+            "#,
         )
         .file("src/lib.rs", "")
         .build();

--- a/tests/testsuite/build_script.rs
+++ b/tests/testsuite/build_script.rs
@@ -428,7 +428,7 @@ fn links_duplicates_deep_dependency() {
                        .with_stderr("\
 error: failed to select a version for `a-sys`.
     ... required by package `a v0.5.0 ([..])`
-    ... which is depended on by `foo v0.5.0 ([..])`
+    ... selected to fulfill the requirement `a = \"*\"` from package `foo v0.5.0 ([..])`
 versions that meet the requirements `*` are: 0.5.0
 
 the package `a-sys` links to the native library `a`, but it conflicts with a previous package which links to `a` as well:

--- a/tests/testsuite/doc.rs
+++ b/tests/testsuite/doc.rs
@@ -172,7 +172,10 @@ fn doc_deps() {
         0
     );
     assert_eq!(
-        glob(&p.root().join("target/debug/deps/libbar-*.rmeta").to_str().unwrap())
+        glob(&p.root()
+            .join("target/debug/deps/libbar-*.rmeta")
+            .to_str()
+            .unwrap())
             .unwrap()
             .count(),
         1

--- a/tests/testsuite/features.rs
+++ b/tests/testsuite/features.rs
@@ -2026,8 +2026,5 @@ fn only_dep_is_optional() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    assert_that(
-        p.cargo("build"),
-        execs().with_status(0),
-    );
+    assert_that(p.cargo("build"), execs().with_status(0));
 }

--- a/tests/testsuite/rename_deps.rs
+++ b/tests/testsuite/rename_deps.rs
@@ -177,7 +177,8 @@ fn lots_of_names() {
     let p = project("foo")
         .file(
             "Cargo.toml",
-            &format!(r#"
+            &format!(
+                r#"
                 cargo-features = ["alternative-registries", "rename-dependency"]
 
                 [package]
@@ -192,7 +193,8 @@ fn lots_of_names() {
                 foo3 = {{ git = '{}', package = "foo" }}
                 foo4 = {{ path = "foo", package = "foo" }}
             "#,
-            g.url())
+                g.url()
+            ),
         )
         .file(
             "src/lib.rs",
@@ -301,18 +303,19 @@ fn rename_twice() {
                 foo = { version = "0.1" }
             "#,
         )
-        .file("src/lib.rs", "",)
+        .file("src/lib.rs", "")
         .build();
 
     assert_that(
         p.cargo("build -v").masquerade_as_nightly_cargo(),
-        execs().with_status(101)
-            .with_stderr("\
+        execs().with_status(101).with_stderr(
+            "\
 [UPDATING] registry `[..]`
 [DOWNLOADING] foo v0.1.0 (registry [..])
 error: multiple dependencies listed for the same crate must all have the same \
 name, but the dependency on `foo v0.1.0` is listed as having different names
-")
+",
+        ),
     );
 }
 

--- a/tests/testsuite/run.rs
+++ b/tests/testsuite/run.rs
@@ -1013,10 +1013,7 @@ fn dashes_are_forwarded() {
         )
         .build();
 
-    assert_that(
-        p.cargo("run -- -- a -- b"),
-        execs().with_status(0),
-    );
+    assert_that(p.cargo("run -- -- a -- b"), execs().with_status(0));
 }
 
 #[test]

--- a/tests/testsuite/workspaces.rs
+++ b/tests/testsuite/workspaces.rs
@@ -2339,7 +2339,6 @@ fn relative_rustc() {
     assert_that(p.cargo("build").env("RUSTC", &file), execs().with_status(0));
 }
 
-
 #[test]
 fn ws_rustc_err() {
     let p = project("ws")


### PR DESCRIPTION
This is a follow up to https://github.com/rust-lang/cargo/pull/5428#issuecomment-385477365. It changes the error messages from:

https://github.com/rust-lang/cargo/blob/0b530c30867da26a4b59146f490c9f1d5377c20a/tests/testsuite/build.rs#L1356-L1358

to:

https://github.com/rust-lang/cargo/blob/499340a81624eaef77d969a3e9fd2cf94f933a2e/tests/testsuite/build.rs#L1356-L1358

Sorry for the big diff, this includes a `cargo +stable fmt` commit before my changes.