### PR TITLE
Fix optional dependencies and required dev-deps

### DIFF
--- a/src/cargo/core/resolver/mod.rs
+++ b/src/cargo/core/resolver/mod.rs
@@ -340,15 +340,18 @@ fn activate_deps_loop(
                         backtracked = true;
                         Ok((candidate, has_another))
                     }
-                    None => Err(activation_error(
-                        &cx,
-                        registry.registry,
-                        &parent,
-                        &dep,
-                        &conflicting_activations,
-                        &candidates,
-                        config,
-                    )),
+                    None => {
+                        debug!("no candidates found");
+                        Err(activation_error(
+                            &cx,
+                            registry.registry,
+                            &parent,
+                            &dep,
+                            &conflicting_activations,
+                            &candidates,
+                            config,
+                        ))
+                    }
                 }
             })?;
 

--- a/tests/testsuite/features.rs
+++ b/tests/testsuite/features.rs
@@ -1999,3 +1999,35 @@ fn namespaced_same_name() {
         execs().with_status(0),
     );
 }
+
+#[test]
+fn only_dep_is_optional() {
+    Package::new("bar", "0.1.0").publish();
+
+    let p = project("foo")
+        .file(
+            "Cargo.toml",
+            r#"
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+
+                [features]
+                foo = ['bar']
+
+                [dependencies]
+                bar = { version = "0.1", optional = true }
+
+                [dev-dependencies]
+                bar = "0.1"
+            "#,
+        )
+        .file("src/main.rs", "fn main() {}")
+        .build();
+
+    assert_that(
+        p.cargo("build"),
+        execs().with_status(0),
+    );
+}


### PR DESCRIPTION
This fixes an accidental bug introduced in #5300 by ensuring a local map keeps
track of the fact that there can be multiple dependencies for one name

Closes #5453