### PR TITLE
Track panic mode in fingerprint

### DIFF
--- a/src/cargo/core/compiler/fingerprint.rs
+++ b/src/cargo/core/compiler/fingerprint.rs
@@ -457,6 +457,7 @@ fn calculate<'a, 'cfg>(
         unit.mode,
         cx.extra_args_for(unit),
         cx.incremental_args(unit)?,
+        cx.used_in_plugin.contains(unit), // used when passing panic=abort
     ));
     let fingerprint = Arc::new(Fingerprint {
         rustc: util::hash_u64(&cx.build_config.rustc.verbose_version),


### PR DESCRIPTION
Ensure that if we've previously compiled a crate with panic=abort and we later
need it for panic=unwind we correctly recompile it.

Closes #5445