### PR TITLE
Explain why we need a `Vec<Dependency>` in `Resolve`.

### DIFF
--- a/src/cargo/core/resolver/resolve.rs
+++ b/src/cargo/core/resolver/resolve.rs
@@ -18,6 +18,9 @@ use super::encode::Metadata;
 /// for each package.
 #[derive(PartialEq)]
 pub struct Resolve {
+    /// A graph, whose vertices are packages and edges are dependency specifications
+    /// from Cargo.toml. We need a `Vec` here because the same package
+    /// might be present in both `[dependencies]` and `[build-dependencies]`.
     graph: Graph<PackageId, Vec<Dependency>>,
     replacements: HashMap<PackageId, PackageId>,
     reverse_replacements: HashMap<PackageId, PackageId>,


### PR DESCRIPTION
Looks like everyone, who sees it, asks the same question, so let's add an explanation!

cc https://github.com/rust-lang/cargo/pull/5428#issuecomment-385459845