### PR TITLE
Be more conservative about which files are linked to the output dir.

### DIFF
--- a/src/cargo/core/compiler/context/compilation_files.rs
+++ b/src/cargo/core/compiler/context/compilation_files.rs
@@ -210,7 +210,7 @@ impl<'a, 'cfg: 'a> CompilationFiles<'a, 'cfg> {
         // we don't want to link it up.
         if out_dir.ends_with("deps") {
             // Don't lift up library dependencies
-            if self.roots.contains(unit) {
+            if unit.target.is_bin() || self.roots.contains(unit) {
                 Some((
                     out_dir.parent().unwrap().to_owned(),
                     if unit.mode.is_any_test() {

--- a/src/cargo/core/compiler/context/compilation_files.rs
+++ b/src/cargo/core/compiler/context/compilation_files.rs
@@ -113,12 +113,8 @@ impl<'a, 'cfg: 'a> CompilationFiles<'a, 'cfg> {
         }
     }
 
-    pub fn export_dir(&self, unit: &Unit<'a>) -> Option<PathBuf> {
-        if self.roots.contains(unit) {
-            self.export_dir.clone()
-        } else {
-            None
-        }
+    pub fn export_dir(&self) -> Option<PathBuf> {
+        self.export_dir.clone()
     }
 
     pub fn pkg_dir(&self, unit: &Unit<'a>) -> String {

--- a/src/cargo/core/compiler/context/compilation_files.rs
+++ b/src/cargo/core/compiler/context/compilation_files.rs
@@ -25,7 +25,11 @@ pub struct CompilationFiles<'a, 'cfg: 'a> {
     pub(super) host: Layout,
     /// The target directory layout for the target (if different from then host)
     pub(super) target: Option<Layout>,
-    export_dir: Option<(PathBuf, Vec<Unit<'a>>)>,
+    /// Additional directory to include a copy of the outputs.
+    export_dir: Option<PathBuf>,
+    /// The root targets requested by the user on the command line (does not
+    /// include dependencies).
+    roots: Vec<Unit<'a>>,
     ws: &'a Workspace<'cfg>,
     metas: HashMap<Unit<'a>, Option<Metadata>>,
     /// For each Unit, a list all files produced.
@@ -65,7 +69,8 @@ impl<'a, 'cfg: 'a> CompilationFiles<'a, 'cfg> {
             ws,
             host,
             target,
-            export_dir: export_dir.map(|dir| (dir, roots.to_vec())),
+            export_dir,
+            roots: roots.to_vec(),
             metas,
             outputs,
         }
@@ -109,9 +114,8 @@ impl<'a, 'cfg: 'a> CompilationFiles<'a, 'cfg> {
     }
 
     pub fn export_dir(&self, unit: &Unit<'a>) -> Option<PathBuf> {
-        let &(ref dir, ref roots) = self.export_dir.as_ref()?;
-        if roots.contains(unit) {
-            Some(dir.clone())
+        if self.roots.contains(unit) {
+            self.export_dir.clone()
         } else {
             None
         }
@@ -206,9 +210,7 @@ impl<'a, 'cfg: 'a> CompilationFiles<'a, 'cfg> {
         // we don't want to link it up.
         if out_dir.ends_with("deps") {
             // Don't lift up library dependencies
-            if self.ws.members().find(|&p| p == unit.pkg).is_none() && !unit.target.is_bin() {
-                None
-            } else {
+            if self.roots.contains(unit) {
                 Some((
                     out_dir.parent().unwrap().to_owned(),
                     if unit.mode.is_any_test() {
@@ -217,6 +219,8 @@ impl<'a, 'cfg: 'a> CompilationFiles<'a, 'cfg> {
                         bin_stem
                     },
                 ))
+            } else {
+                None
             }
         } else if bin_stem == file_stem {
             None

--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -362,7 +362,7 @@ fn link_targets<'a, 'cfg>(
 ) -> CargoResult<Work> {
     let bcx = cx.bcx;
     let outputs = cx.outputs(unit)?;
-    let export_dir = cx.files().export_dir(unit);
+    let export_dir = cx.files().export_dir();
     let package_id = unit.pkg.package_id().clone();
     let target = unit.target.clone();
     let profile = unit.profile;

--- a/tests/testsuite/check.rs
+++ b/tests/testsuite/check.rs
@@ -1,4 +1,5 @@
 use cargotest::install::exe;
+use cargotest::is_nightly;
 use cargotest::support::paths::CargoPathExt;
 use cargotest::support::registry::Package;
 use cargotest::support::{execs, project};
@@ -830,7 +831,12 @@ fn check_artifacts() {
         p.cargo("check").arg("--bin").arg("foo"),
         execs().with_status(0),
     );
-    assert_that(&p.root().join("target/debug/libfoo.rmeta"), existing_file());
+    if is_nightly() {
+        // The nightly check can be removed once 1.27 is stable.
+        // Bins now generate `rmeta` files.
+        // See: https://github.com/rust-lang/rust/pull/49289
+        assert_that(&p.root().join("target/debug/libfoo.rmeta"), existing_file());
+    }
     assert_that(
         &p.root().join("target/debug/libfoo.rlib"),
         is_not(existing_file()),

--- a/tests/testsuite/check.rs
+++ b/tests/testsuite/check.rs
@@ -845,7 +845,10 @@ fn check_artifacts() {
         p.cargo("check").arg("--test").arg("t1"),
         execs().with_status(0),
     );
-    assert_that(&p.root().join("target/debug/libfoo.rmeta"), existing_file());
+    assert_that(
+        &p.root().join("target/debug/libfoo.rmeta"),
+        is_not(existing_file()),
+    );
     assert_that(
         &p.root().join("target/debug/libfoo.rlib"),
         is_not(existing_file()),
@@ -866,7 +869,10 @@ fn check_artifacts() {
         p.cargo("check").arg("--example").arg("ex1"),
         execs().with_status(0),
     );
-    assert_that(&p.root().join("target/debug/libfoo.rmeta"), existing_file());
+    assert_that(
+        &p.root().join("target/debug/libfoo.rmeta"),
+        is_not(existing_file()),
+    );
     assert_that(
         &p.root().join("target/debug/libfoo.rlib"),
         is_not(existing_file()),
@@ -881,7 +887,10 @@ fn check_artifacts() {
         p.cargo("check").arg("--bench").arg("b1"),
         execs().with_status(0),
     );
-    assert_that(&p.root().join("target/debug/libfoo.rmeta"), existing_file());
+    assert_that(
+        &p.root().join("target/debug/libfoo.rmeta"),
+        is_not(existing_file()),
+    );
     assert_that(
         &p.root().join("target/debug/libfoo.rlib"),
         is_not(existing_file()),

--- a/tests/testsuite/path.rs
+++ b/tests/testsuite/path.rs
@@ -4,9 +4,9 @@ use std::io::prelude::*;
 use cargo::util::process;
 use cargotest::sleep_ms;
 use cargotest::support::paths::{self, CargoPathExt};
-use cargotest::support::{execs, main_file, project};
 use cargotest::support::registry::Package;
-use hamcrest::{assert_that, existing_file};
+use cargotest::support::{execs, main_file, project};
+use hamcrest::{assert_that, existing_file, is_not};
 
 #[test]
 #[cfg(not(windows))] // I have no idea why this is failing spuriously on
@@ -1278,7 +1278,10 @@ fn workspace_produces_rlib() {
     assert_that(p.cargo("build"), execs().with_status(0));
 
     assert_that(&p.root().join("target/debug/libtop.rlib"), existing_file());
-    assert_that(&p.root().join("target/debug/libfoo.rlib"), existing_file());
+    assert_that(
+        &p.root().join("target/debug/libfoo.rlib"),
+        is_not(existing_file()),
+    );
 }
 
 #[test]


### PR DESCRIPTION
This changes it so that only top-level targets requested on the command-line will be included in the output directory.  Dependencies are no longer included.

Fixes #5444.