### PR TITLE
Partially revert change to testing examples.

### DIFF
--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -603,7 +603,7 @@ fn generate_targets<'a>(
         };
         let target_mode = match target_mode {
             CompileMode::Test => {
-                if target.is_example() {
+                if target.is_example() && !filter.is_specific() && !target.tested() {
                     // Examples are included as regular binaries to verify
                     // that they compile.
                     CompileMode::Build


### PR DESCRIPTION
Fixes #5437

I don't think changing the behavior was quite the correct thing to do.  This new behavior is very similar to the old with a few small differences:

```
cargo test
    ORGINAL: Only builds examples.
    NEW: Builds all examples.  Any example with `test` set is tested.

cargo test --tests
    ORIGINAL: Runs all examples as tests.
    NEW: Only runs examples as tests if `test` is set.

cargo test --examples
    ORIGINAL: Runs all examples as tests.
    NEW: (SAME)

cargo test --example foo
    ORIGINAL: Runs the given example as a test.
    NEW: (SAME)

cargo test --all-targets
    ORIGINAL: Runs all examples as tests.
    NEW: (SAME)
```