### PR TITLE
Revert part of #5393

### DIFF
--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -131,7 +131,7 @@ impl<'cfg> Workspace<'cfg> {
     /// root and all member packages. It will then validate the workspace
     /// before returning it, so `Ok` is only returned for valid workspaces.
     pub fn new(manifest_path: &Path, config: &'cfg Config) -> CargoResult<Workspace<'cfg>> {
-        let target_dir = config.target_dir();
+        let target_dir = config.target_dir()?;
 
         let mut ws = Workspace {
             config,
@@ -191,7 +191,7 @@ impl<'cfg> Workspace<'cfg> {
             ws.target_dir = if let Some(dir) = target_dir {
                 Some(dir)
             } else {
-                ws.config.target_dir()
+                ws.config.target_dir()?
             };
             ws.members.push(ws.current_manifest.clone());
             ws.default_members.push(ws.current_manifest.clone());

--- a/src/cargo/ops/cargo_install.rs
+++ b/src/cargo/ops/cargo_install.rs
@@ -213,7 +213,7 @@ fn install_one(
     let mut needs_cleanup = false;
     let overidden_target_dir = if source_id.is_path() {
         None
-    } else if let Some(dir) = config.target_dir() {
+    } else if let Some(dir) = config.target_dir()? {
         Some(dir)
     } else if let Ok(td) = TempFileBuilder::new().prefix("cargo-install").tempdir() {
         let p = td.path().to_owned();


### PR DESCRIPTION
Commit 0b530c30867da26a4b59146f490c9f1d5377c20a (which this commit mostly reverts) did some refactoring around the `target_dir` function. However, it introduced a bug because it meant that where `CARGO_TARGET_DIR` was specified but `--target-dir` was not, the value from `CARGO_TARGET_DIR` was ignored.

r? @matklad 

This bug is causing RLS tests to fail in the Rust repo (see https://github.com/rust-lang/rust/pull/50379#issuecomment-385844511) because on Linux, the src directory is write-protected. This bug causes Rust build's `CARGO_TARGET_DIR` to be ignored by the RLS tests so that they write files into the src directory (CWD) rather than the target directory.