### PR TITLE
Tweak handling of aliases 

### DIFF
--- a/src/cargo/util/config.rs
+++ b/src/cargo/util/config.rs
@@ -557,7 +557,7 @@ impl Config {
             cfg.merge(value)
                 .chain_err(|| format!("failed to merge configuration at `{}`", path.display()))?;
             Ok(())
-        }).chain_err(|| "Couldn't load Cargo configuration")?;
+        }).chain_err(|| "could not load Cargo configuration")?;
 
         self.load_credentials(&mut cfg)?;
         match cfg {

--- a/tests/testsuite/bad_config.rs
+++ b/tests/testsuite/bad_config.rs
@@ -61,7 +61,7 @@ fn bad2() {
         p.cargo("publish").arg("-v"),
         execs().with_status(101).with_stderr(
             "\
-[ERROR] Couldn't load Cargo configuration
+[ERROR] could not load Cargo configuration
 
 Caused by:
   failed to load TOML configuration from `[..]config`
@@ -164,10 +164,7 @@ fn bad5() {
             .cwd(&p.root().join("foo")),
         execs().with_status(101).with_stderr(
             "\
-[ERROR] Failed to create project `foo` at `[..]`
-
-Caused by:
-  Couldn't load Cargo configuration
+[ERROR] could not load Cargo configuration
 
 Caused by:
   failed to merge configuration at `[..]`
@@ -284,7 +281,7 @@ fn invalid_global_config() {
         p.cargo("build").arg("-v"),
         execs().with_status(101).with_stderr(
             "\
-[ERROR] Couldn't load Cargo configuration
+[ERROR] could not load Cargo configuration
 
 Caused by:
   could not parse TOML configuration in `[..]`

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -2913,7 +2913,7 @@ fn bad_cargo_config() {
         foo.cargo("build").arg("-v"),
         execs().with_status(101).with_stderr(
             "\
-[ERROR] Couldn't load Cargo configuration
+[ERROR] could not load Cargo configuration
 
 Caused by:
   could not parse TOML configuration in `[..]`

--- a/tests/testsuite/cargo_alias_config.rs
+++ b/tests/testsuite/cargo_alias_config.rs
@@ -23,8 +23,8 @@ fn alias_incorrect_config_type() {
     assert_that(
         p.cargo("b-cargo-test").arg("-v"),
         execs().with_status(101).with_stderr_contains(
-            "[ERROR] invalid configuration \
-for key `alias.b-cargo-test`
+            "\
+[ERROR] invalid configuration for key `alias.b-cargo-test`
 expected a list, but found a integer for [..]",
         ),
     );
@@ -77,9 +77,43 @@ fn alias_config() {
         .build();
 
     assert_that(
-        p.cargo("b-cargo-test").arg("-v"),
+        p.cargo("b-cargo-test -v"),
+        execs()
+            .with_status(0)
+            .with_stderr_contains(
+                "\
+[COMPILING] foo v0.5.0 [..]
+[RUNNING] `rustc --crate-name foo [..]",
+            )
+            .stream(),
+    );
+}
+
+#[test]
+fn recursive_alias() {
+    let p = project("foo")
+        .file("Cargo.toml", &basic_bin_manifest("foo"))
+        .file(
+            "src/main.rs",
+            r#"
+            fn main() {
+        }"#,
+        )
+        .file(
+            ".cargo/config",
+            r#"
+            [alias]
+            b-cargo-test = "build"
+            a-cargo-test = ["b-cargo-test", "-v"]
+        "#,
+        )
+        .build();
+
+    assert_that(
+        p.cargo("a-cargo-test"),
         execs().with_status(0).with_stderr_contains(
-            "[COMPILING] foo v0.5.0 [..]
+            "\
+[COMPILING] foo v0.5.0 [..]
 [RUNNING] `rustc --crate-name foo [..]",
         ),
     );
@@ -164,6 +198,7 @@ fn cant_shadow_builtin() {
         p.cargo("build"),
         execs().with_status(0).with_stderr(
             "\
+[WARNING] alias `build` is ignored, because it is shadowed by a built in command
 [COMPILING] foo v0.5.0 ([..])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",

--- a/tests/testsuite/cargo_alias_config.rs
+++ b/tests/testsuite/cargo_alias_config.rs
@@ -84,8 +84,7 @@ fn alias_config() {
                 "\
 [COMPILING] foo v0.5.0 [..]
 [RUNNING] `rustc --crate-name foo [..]",
-            )
-            .stream(),
+            ),
     );
 }
 


### PR DESCRIPTION
Previously, `execute_subcommand` was called recursively, and each call
would `.configure` the `config` again. It worked, but seemed rather
fragile.

This commit handles aliases more explicitly, ensures that `.configure`
is called once and, as a bonus, adds a warning for when an alias is
shadowed by the built in.


