### PR TITLE
Attmept to fix a spurious failure on AppVeyor

### DIFF
--- a/tests/testsuite/build_script.rs
+++ b/tests/testsuite/build_script.rs
@@ -3742,6 +3742,9 @@ fn rename_with_link_search_path() {
             name = "bar"
             version = "0.5.0"
             authors = []
+
+            [profile.dev]
+            debug = false
         "#,
         )
         .file(

--- a/tests/testsuite/freshness.rs
+++ b/tests/testsuite/freshness.rs
@@ -502,6 +502,9 @@ fn changing_bin_features_caches_targets() {
 
             [features]
             foo = []
+
+            [profile.dev]
+            debug = false
         "#,
         )
         .file(
@@ -523,7 +526,7 @@ fn changing_bin_features_caches_targets() {
             .with_stderr(
                 "\
 [..]Compiling foo v0.0.1 ([..])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized] target(s) in [..]
 [RUNNING] `target[/]debug[/]foo[EXE]`
 ",
             ),
@@ -537,7 +540,7 @@ fn changing_bin_features_caches_targets() {
             .with_stderr(
                 "\
 [..]Compiling foo v0.0.1 ([..])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized] target(s) in [..]
 [RUNNING] `target[/]debug[/]foo[EXE]`
 ",
             ),
@@ -552,7 +555,7 @@ fn changing_bin_features_caches_targets() {
             .with_stdout("feature off")
             .with_stderr(
                 "\
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized] target(s) in [..]
 [RUNNING] `target[/]debug[/]foo[EXE]`
 ",
             ),
@@ -565,7 +568,7 @@ fn changing_bin_features_caches_targets() {
             .with_stdout("feature on")
             .with_stderr(
                 "\
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] dev [unoptimized] target(s) in [..]
 [RUNNING] `target[/]debug[/]foo[EXE]`
 ",
             ),


### PR DESCRIPTION
I *think* the issue is that `link.exe` is generating debuginfo in the background
which keeps the file open and prevents us from deleting it, but hopefully by
disabling debug information we'll either be able to confirm or deny this
hypothesis.