### PR TITLE
Rename the `rust` manifest key to `edition`

### DIFF
--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -49,6 +49,8 @@ use std::env;
 use std::fmt;
 use std::str::FromStr;
 
+use failure::Error;
+
 use util::errors::CargoResult;
 
 /// The edition of the compiler (RFC 2052)
@@ -69,12 +71,15 @@ impl fmt::Display for Edition {
     }
 }
 impl FromStr for Edition {
-    type Err = ();
-    fn from_str(s: &str) -> Result<Self, ()> {
+    type Err = Error;
+    fn from_str(s: &str) -> Result<Self, Error> {
         match s {
             "2015" => Ok(Edition::Edition2015),
             "2018" => Ok(Edition::Edition2018),
-            _ => Err(()),
+            s => {
+                bail!("supported edition values are `2015` or `2018`, but `{}` \
+                       is unknown", s)
+            }
         }
     }
 }

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -558,7 +558,7 @@ pub struct TomlProject {
     license_file: Option<String>,
     repository: Option<String>,
     metadata: Option<toml::Value>,
-    rust: Option<String>,
+    edition: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -719,15 +719,12 @@ impl TomlManifest {
 
         let pkgid = project.to_package_id(source_id)?;
 
-        let edition = if let Some(ref edition) = project.rust {
+        let edition = if let Some(ref edition) = project.edition {
             features
                 .require(Feature::edition())
                 .chain_err(|| "editions are unstable")?;
-            if let Ok(edition) = edition.parse() {
-                edition
-            } else {
-                bail!("the `rust` key must be one of: `2015`, `2018`")
-            }
+            edition.parse()
+                .chain_err(|| "failed to parse the `edition` key")?
         } else {
             Edition::Edition2015
         };

--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -181,16 +181,16 @@ cargo +nightly build --out-dir=out -Z unstable-options
 * Tracking Issue: [rust-lang/rust#44581](https://github.com/rust-lang/rust/issues/44581)
 * RFC: [#2052](https://github.com/rust-lang/rfcs/blob/master/text/2052-epochs.md)
 
-You can opt in to a specific Rust Edition for your package with the `rust` key
-in `Cargo.toml`.  If you don't specify the edition, it will default to 2015.
-You need to include the appropriate `cargo-features`:
+You can opt in to a specific Rust Edition for your package with the `edition`
+key in `Cargo.toml`.  If you don't specify the edition, it will default to
+2015.  You need to include the appropriate `cargo-features`:
 
 ```toml
 cargo-features = ["edition"]
 
 [package]
 ...
-rust = "2018"
+edition = "2018"
 ```
 
 

--- a/tests/testsuite/bench.rs
+++ b/tests/testsuite/bench.rs
@@ -713,7 +713,7 @@ fn bench_autodiscover_2015() {
             name = "foo"
             version = "0.0.1"
             authors = []
-            rust = "2015"
+            edition = "2015"
 
             [[bench]]
             name = "bench_magic"

--- a/tests/testsuite/doc.rs
+++ b/tests/testsuite/doc.rs
@@ -1496,7 +1496,7 @@ fn doc_edition() {
             name = "foo"
             version = "0.0.1"
             authors = []
-            rust = "2018"
+            edition = "2018"
         "#,
         )
         .file("src/lib.rs", "")

--- a/tests/testsuite/install.rs
+++ b/tests/testsuite/install.rs
@@ -1038,7 +1038,7 @@ fn installs_from_cwd_with_2018_warnings() {
             name = "foo"
             version = "0.1.0"
             authors = []
-            rust = "2018"
+            edition = "2018"
         "#,
         )
         .file("src/main.rs", "fn main() {}")

--- a/tests/testsuite/package.rs
+++ b/tests/testsuite/package.rs
@@ -1110,7 +1110,7 @@ fn test_edition() {
             name = "foo"
             version = "0.0.1"
             authors = []
-            rust = "2018"
+            edition = "2018"
         "#,
         )
         .file("src/lib.rs", r#" "#)
@@ -1178,7 +1178,7 @@ fn test_edition_malformed() {
             name = "foo"
             version = "0.0.1"
             authors = []
-            rust = "chicken"
+            edition = "chicken"
         "#,
         )
         .file("src/lib.rs", r#" "#)
@@ -1191,7 +1191,10 @@ fn test_edition_malformed() {
 error: failed to parse manifest at `[..]`
 
 Caused by:
-  the `rust` key must be one of: `2015`, `2018`
+  failed to parse the `edition` key
+
+Caused by:
+  supported edition values are `2015` or `2018`, but `chicken` is unknown
 "
         )),
     );
@@ -1207,7 +1210,7 @@ fn test_edition_nightly() {
             name = "foo"
             version = "0.0.1"
             authors = []
-            rust = "2015"
+            edition = "2015"
         "#,
         )
         .file("src/lib.rs", r#" "#)

--- a/tests/testsuite/run.rs
+++ b/tests/testsuite/run.rs
@@ -403,7 +403,7 @@ fn autodiscover_examples_project(rust_edition: &str, autoexamples: Option<bool>)
             name = "foo"
             version = "0.0.1"
             authors = []
-            rust = "{rust_edition}"
+            edition = "{rust_edition}"
             {autoexamples}
 
             [features]


### PR DESCRIPTION
This'll hopefully jive better with the terminology of "edition" throughout the
rest of Rust!