### PR TITLE
FIx false positive warning

### DIFF
--- a/src/cargo/core/resolver/context.rs
+++ b/src/cargo/core/resolver/context.rs
@@ -204,7 +204,11 @@ impl Context {
             // name.
             let base = reqs.deps.get(&*dep.name()).unwrap_or(&default_dep);
             used_features.insert(dep.name().as_str());
-            if !dep.is_optional() && base.0 {
+            let always_required = !dep.is_optional()
+                && !s.dependencies()
+                    .iter()
+                    .any(|d| d.is_optional() && d.name() == dep.name());
+            if always_required && base.0 {
                 self.warnings.push(format!(
                     "Package `{}` does not have feature `{}`. It has a required dependency \
                      with that name, but only optional dependencies can be used as features. \


### PR DESCRIPTION
We warn if a feature was specified corresponding to a dependency which
is not optional. However, a dependency can be both optional and
required, and we shouldn't warn in that case.

cc https://github.com/rust-lang/cargo/pull/5480

r? @alexcrichton 