### PR TITLE
Drop PathSource TODO in GitSource

### DIFF
--- a/src/cargo/sources/git/source.rs
+++ b/src/cargo/sources/git/source.rs
@@ -11,8 +11,6 @@ use util::hex::short_hash;
 use sources::PathSource;
 use sources::git::utils::{GitRemote, GitRevision};
 
-/* TODO: Refactor GitSource to delegate to a PathSource
- */
 pub struct GitSource<'cfg> {
     remote: GitRemote,
     reference: GitReference,


### PR DESCRIPTION
This effort was started in de6944798cf2940b91c742b8d6cd4294ea28f76a,
and looks (to me) to be resolved at this point.