### PR TITLE
Merge cargo-clone subcommand into cargo itself.

### DIFF
--- a/src/bin/cargo/commands/clone.rs
+++ b/src/bin/cargo/commands/clone.rs
@@ -1,0 +1,53 @@
+use command_prelude::*;
+
+use cargo::core::{GitReference, SourceId};
+use cargo::util::ToUrl;
+use cargo::ops::{self, CloneOptions};
+
+pub fn cli() -> App {
+    subcommand("clone")
+        .about("Clone source code of a Rust crate")
+        .arg(opt("prefix", "Directory to clone the package into").value_name("DIR"))
+        .arg(opt("force", "Force overwriting existing directory").short("f"))
+        .arg(Arg::with_name("crate").empty_values(false))
+        .arg(opt("version", "Specify a version to install from crates.io")
+                .alias("vers")
+                .value_name("VERSION"),
+        )
+        .arg(opt("git", "Git URL to clone the specified crate from").value_name("URL"))
+        .arg(opt("branch", "Branch to use when cloning from git").value_name("BRANCH"))
+        .arg(opt("tag", "Tag to use when cloning from git").value_name("TAG"))
+        .arg(opt("rev", "Specific commit to use when cloning from git").value_name("SHA"))
+        .arg(opt("path", "Filesystem path to local crate to clone").value_name("PATH"))
+}
+
+pub fn exec(config: &mut Config, args: &ArgMatches) -> CliResult {
+    let source = if let Some(url) = args.value_of("git") {
+        let url = url.to_url()?;
+        let gitref = if let Some(branch) = args.value_of("branch") {
+            GitReference::Branch(branch.to_string())
+        } else if let Some(tag) = args.value_of("tag") {
+            GitReference::Tag(tag.to_string())
+        } else if let Some(rev) = args.value_of("rev") {
+            GitReference::Rev(rev.to_string())
+        } else {
+            GitReference::Branch("master".to_string())
+        };
+        SourceId::for_git(&url, gitref)?
+    } else if let Some(path) = args.value_of_path("path", config) {
+        SourceId::for_path(&path)?
+    } else {
+        SourceId::crates_io(config)?
+    };
+
+    let opts = CloneOptions {
+        config,
+        name: args.value_of("crate"),
+        source_id: source,
+        prefix: args.value_of("prefix"),
+        force: args.is_present("force"),
+        version: args.value_of("version"),
+    };
+    ops::clone(opts)?;
+    Ok(())
+}

--- a/src/bin/cargo/commands/mod.rs
+++ b/src/bin/cargo/commands/mod.rs
@@ -6,6 +6,7 @@ pub fn builtin() -> Vec<App> {
         build::cli(),
         check::cli(),
         clean::cli(),
+        clone::cli(),
         doc::cli(),
         fetch::cli(),
         generate_lockfile::cli(),
@@ -40,6 +41,7 @@ pub fn builtin_exec(cmd: &str) -> Option<fn(&mut Config, &ArgMatches) -> CliResu
         "build" => build::exec,
         "check" => check::exec,
         "clean" => clean::exec,
+        "clone" => clone::exec,
         "doc" => doc::exec,
         "fetch" => fetch::exec,
         "generate-lockfile" => generate_lockfile::exec,
@@ -74,6 +76,7 @@ pub mod bench;
 pub mod build;
 pub mod check;
 pub mod clean;
+pub mod clone;
 pub mod doc;
 pub mod fetch;
 pub mod generate_lockfile;

--- a/src/cargo/ops/cargo_clone.rs
+++ b/src/cargo/ops/cargo_clone.rs
@@ -1,0 +1,112 @@
+use std::path::{Path, PathBuf};
+use std::fs;
+use std::env;
+
+use util::Config;
+use core::{Source, SourceId};
+use sources::{GitSource, PathSource, SourceConfigMap};
+use util::errors::{CargoResult, CargoResultExt};
+use ops::select_pkg;
+
+
+pub struct CloneOptions<'a> {
+    pub config: &'a Config,
+    /// Crate's name
+    pub name: Option<&'a str>,
+    /// Source ID to clone from
+    pub source_id: SourceId,
+    /// Path to clone to
+    pub prefix: Option<&'a str>,
+    /// Overwrite an existing directory with crate's content
+    pub force: bool,
+    /// Crate's version
+    pub version: Option<&'a str>,
+}
+
+pub fn clone(opts: CloneOptions) -> CargoResult<()> {
+    let CloneOptions {
+        config,
+        name,
+        source_id,
+        prefix,
+        force,
+        version,
+    } = opts;
+
+    let (pkg, _) = if source_id.is_path() {
+        let path = source_id
+            .url()
+            .to_file_path()
+            .map_err(|()| format_err!("path sources must have a valid path"))?;
+        let mut src = PathSource::new(&path, &source_id, config);
+        src.update().chain_err(|| {
+            format_err!(
+                "`{}` is not a crate root; specify a crate to \
+                 install from crates.io, or use --path or --git to \
+                 specify an alternate source",
+                path.display()
+            )
+        })?;
+
+        select_pkg(src, name, version, config, true, &mut |path| path.read_packages())?
+    } else if source_id.is_git() {
+        select_pkg(GitSource::new(&source_id, config)?,
+                   name, version, config, true, &mut |git| git.read_packages())?
+    } else {
+        let map = SourceConfigMap::new(config)?;
+        select_pkg(map.load(&source_id)?,
+                   name, version, config, true,
+                   &mut |_| {
+                       bail!("must specify a crate to clone from \
+                              crates.io, or use --path or --git to \
+                              specify alternate source")
+                   }
+        )?
+    };
+
+    config.shell().status("Cloning", &pkg)?;
+
+    // If prefix was not supplied, clone into current dir
+    let mut dest_path = match prefix {
+        Some(prefix) => PathBuf::from(prefix),
+        None => env::current_dir()?,
+    };
+
+    dest_path.push(pkg.name().as_str());
+
+    if dest_path.exists() {
+        if force {
+            config.shell().status("Replacing", dest_path.display())?;
+            fs::remove_dir_all(&dest_path)?;
+        } else {
+            bail!(format!("Directory `{}` already exists. Add --force to overwrite",
+                          dest_path.display()));
+        }
+    }
+
+    clone_directory(&pkg.root(), &dest_path)
+}
+
+fn clone_directory(from: &Path, to: &Path) -> CargoResult<()> {
+    fs::create_dir_all(&to)?;
+
+    let entries = from.read_dir()
+        .chain_err(|| format!("failed to read directory `{}`", from.display()))?;
+
+    for entry in entries {
+        let entry = entry?;
+        let path = entry.path();
+        let mut to = to.to_owned();
+        to.push(path.strip_prefix(from)?);
+
+        if path.is_file() && &entry.file_name() != ".cargo-ok" {
+            // .cargo-ok is not wanted in this context
+            fs::copy(&path, &to)?;
+        } else if path.is_dir() {
+            fs::create_dir(&to)?;
+            clone_directory(&path, &to)?
+        }
+    }
+
+    Ok(())
+}

--- a/src/cargo/ops/cargo_install.rs
+++ b/src/cargo/ops/cargo_install.rs
@@ -405,7 +405,7 @@ fn install_one(
     Ok(())
 }
 
-fn select_pkg<'a, T>(
+pub fn select_pkg<'a, T>(
     mut source: T,
     name: Option<&str>,
     vers: Option<&str>,

--- a/src/cargo/ops/mod.rs
+++ b/src/cargo/ops/mod.rs
@@ -1,9 +1,10 @@
 pub use self::cargo_clean::{clean, CleanOptions};
+pub use self::cargo_clone::{clone, CloneOptions};
 pub use self::cargo_compile::{compile, compile_with_exec, compile_ws, CompileOptions};
 pub use self::cargo_compile::{CompileFilter, FilterRule, Packages};
 pub use self::cargo_read_manifest::{read_package, read_packages};
 pub use self::cargo_run::run;
-pub use self::cargo_install::{install, install_list, uninstall};
+pub use self::cargo_install::{install, install_list, uninstall, select_pkg};
 pub use self::cargo_new::{init, new, NewOptions, VersionControl};
 pub use self::cargo_doc::{doc, DocOptions};
 pub use self::cargo_generate_lockfile::generate_lockfile;
@@ -23,6 +24,7 @@ pub use self::resolve::{resolve_with_previous, resolve_ws, resolve_ws_precisely,
 pub use self::cargo_output_metadata::{output_metadata, ExportInfo, OutputMetadataOptions};
 
 mod cargo_clean;
+mod cargo_clone;
 mod cargo_compile;
 mod cargo_doc;
 mod cargo_fetch;

--- a/tests/testsuite/cargotest/support/mod.rs
+++ b/tests/testsuite/cargotest/support/mod.rs
@@ -1054,6 +1054,7 @@ fn substitute_macros(input: &str) -> String {
         ("[RUNNING]", "     Running"),
         ("[COMPILING]", "   Compiling"),
         ("[CHECKING]", "    Checking"),
+        ("[CLONING]", "     Cloning"),
         ("[CREATED]", "     Created"),
         ("[FINISHED]", "    Finished"),
         ("[ERROR]", "error:"),

--- a/tests/testsuite/clone.rs
+++ b/tests/testsuite/clone.rs
@@ -1,0 +1,274 @@
+use std::fs;
+use std::path::PathBuf;
+
+use cargotest::cargo_process;
+use cargotest::support::{paths, git, project_in_home, execs,
+                         Project, registry::Package};
+use hamcrest::{assert_that, existing_dir};
+
+
+const FOO_CRATE_NAME: &str = "foo";
+const BAR_CRATE_NAME: &str = "bar";
+
+fn pkg(name: &str, vers: &str) {
+    Package::new(name, vers)
+        .file("src/lib.rs", "")
+        .file(
+            "src/main.rs",
+            &format!("extern crate {};
+                      fn main() {{}}",
+                     name),
+        )
+        .publish();
+}
+
+fn proj(name: &str, vers: &str) -> Project {
+    project_in_home(name)
+        .file("Cargo.toml",
+              &format!("\
+                        [package]
+                        name = \"{name}\"
+                        version = \"{vers}\"
+                        authors = []",
+                       name = name, vers = vers))
+        .file("src/main.rs", "fn main() {}")
+        .build()
+}
+
+fn cwd_clone_path(name: &str) -> PathBuf {
+    paths::root().join(name)
+}
+
+#[test]
+fn simple() {
+    pkg(FOO_CRATE_NAME, "0.0.1");
+
+    assert_that(
+        cargo_process().arg("clone").arg(FOO_CRATE_NAME),
+        execs().with_status(0).with_stderr("\
+[UPDATING] registry `[..]`
+[DOWNLOADING] foo v0.0.1 (registry [..])
+[CLONING] foo v0.0.1"
+        )
+    );
+    assert_that(cwd_clone_path(FOO_CRATE_NAME), existing_dir());
+}
+
+#[test]
+fn pick_max_version() {
+    pkg(FOO_CRATE_NAME, "0.0.1");
+    pkg(FOO_CRATE_NAME, "0.0.2");
+
+    assert_that(
+        cargo_process().arg("clone").arg(FOO_CRATE_NAME),
+        execs().with_status(0).with_stderr("\
+[UPDATING] registry `[..]`
+[DOWNLOADING] foo v0.0.2 (registry [..])
+[CLONING] foo v0.0.2"
+        )
+    );
+    assert_that(cwd_clone_path(FOO_CRATE_NAME), existing_dir());
+}
+
+#[test]
+fn missing() {
+    pkg(FOO_CRATE_NAME, "0.0.1");
+    assert_that(
+        cargo_process().arg("clone").arg(BAR_CRATE_NAME),
+        execs().with_status(101).with_stderr("\
+[UPDATING] registry [..]
+[ERROR] could not find `bar` in registry `[..]`"
+        )
+    );
+}
+
+#[test]
+fn bad_version() {
+    pkg(FOO_CRATE_NAME, "0.0.1");
+    assert_that(
+        cargo_process().arg("clone").arg(FOO_CRATE_NAME).arg("--vers=0.2.0"),
+        execs().with_status(101).with_stderr("\
+[UPDATING] registry [..]
+[ERROR] could not find `foo` in registry `[..]` with version `=0.2.0`"
+        )
+    );
+}
+
+#[test]
+fn no_crate() {
+    pkg(FOO_CRATE_NAME, "0.0.1");
+    assert_that(
+        cargo_process().arg("clone"),
+        execs().with_status(101).with_stderr("\
+[UPDATING] registry [..]
+[ERROR] must specify a crate to clone [..]"
+        )
+    );
+}
+
+#[test]
+fn path_crate() {
+    let p = proj(FOO_CRATE_NAME, "0.1.0");
+
+    assert_that(
+        cargo_process().arg("clone").arg("--path").arg(p.root()),
+        execs().with_status(0),
+    );
+    assert_that(cwd_clone_path(FOO_CRATE_NAME), existing_dir());
+}
+
+#[test]
+fn twice() {
+    let p = proj(FOO_CRATE_NAME, "0.1.0");
+
+    assert_that(
+        cargo_process().arg("clone").arg("--path").arg(p.root()),
+        execs().with_status(0),
+    );
+    assert_that(
+        cargo_process().arg("clone").arg("--path").arg(p.root()),
+        execs().with_status(101).with_stderr("\
+[CLONING] foo v0.1.0 [..]
+[ERROR] Directory `[..]` already exists. Add --force to overwrite"
+        )
+    );
+}
+
+#[test]
+fn force() {
+    let p = proj(FOO_CRATE_NAME, "0.1.0");
+
+    assert_that(
+        cargo_process().arg("clone").arg("--path").arg(p.root()),
+        execs().with_status(0),
+    );
+
+    let p = proj(FOO_CRATE_NAME, "0.2.0");
+
+    assert_that(
+        cargo_process().arg("clone")
+            .arg("--force")
+            .arg("--path")
+            .arg(p.root()),
+        execs().with_status(0).with_stderr("\
+[CLONING] foo v0.2.0 [..]
+[REPLACING] [..]foo[..]"
+        )
+    );
+}
+
+#[test]
+fn git_repo() {
+    let p = git::repo(&paths::home().join(FOO_CRATE_NAME))
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "foo"
+            version = "0.1.0"
+            authors = []
+        "#,
+        )
+        .file("src/main.rs", "fn main() {}")
+        .build();
+
+    // use `--locked` to test that we don't even try to write a lockfile
+    assert_that(
+        cargo_process().arg("clone")
+            .arg("--locked")
+            .arg("--git")
+            .arg(p.url().to_string()),
+        execs().with_status(0).with_stderr("\
+[UPDATING] git repository `[..]`
+[CLONING] foo v0.1.0 ([..])"
+        )
+    );
+    assert_that(cwd_clone_path(FOO_CRATE_NAME), existing_dir());
+}
+
+#[test]
+fn vers_precise() {
+    pkg(FOO_CRATE_NAME, "0.1.1");
+    pkg(FOO_CRATE_NAME, "0.1.2");
+
+    assert_that(
+        cargo_process().arg("clone")
+            .arg(FOO_CRATE_NAME)
+            .arg("--vers")
+            .arg("0.1.1"),
+        execs().with_status(0).with_stderr_contains("\
+[DOWNLOADING] foo v0.1.1 (registry [..])"
+        )
+    );
+}
+
+#[test]
+fn version_precise() {
+    pkg(FOO_CRATE_NAME, "0.1.1");
+    pkg(FOO_CRATE_NAME, "0.1.2");
+
+    assert_that(
+        cargo_process().arg("clone")
+            .arg(FOO_CRATE_NAME)
+            .arg("--version")
+            .arg("0.1.1"),
+        execs().with_status(0).with_stderr_contains("\
+[DOWNLOADING] foo v0.1.1 (registry [..])"
+        )
+    );
+}
+
+#[test]
+fn not_both_vers_and_version() {
+    pkg(FOO_CRATE_NAME, "0.1.1");
+    pkg(FOO_CRATE_NAME, "0.1.2");
+
+    assert_that(
+        cargo_process().arg("clone")
+            .arg(FOO_CRATE_NAME)
+            .arg("--version")
+            .arg("0.1.1")
+            .arg("--vers")
+            .arg("0.1.2"),
+        execs().with_status(1).with_stderr_contains("\
+error: The argument '--version <VERSION>' was provided more than once, \
+but cannot be used multiple times"
+        ),
+    );
+}
+
+#[test]
+fn prefix() {
+    pkg(FOO_CRATE_NAME, "0.0.1");
+
+    assert_that(
+        cargo_process().arg("clone").arg(FOO_CRATE_NAME)
+            .arg(format!("--prefix={}", paths::root().join("test_prefix").display())),
+        execs().with_status(0).with_stderr("\
+[UPDATING] registry `[..]`
+[DOWNLOADING] foo v0.0.1 (registry [..])
+[CLONING] foo v0.0.1"
+        )
+    );
+    assert_that(paths::root().join("test_prefix").join(FOO_CRATE_NAME),
+                existing_dir());
+}
+
+#[test]
+fn prefix_already_exists() {
+    pkg(FOO_CRATE_NAME, "0.0.1");
+
+    let prefix = paths::root().join("test_prefix");
+    fs::create_dir_all(&prefix.join(FOO_CRATE_NAME)).unwrap();
+
+    assert_that(
+        cargo_process().arg("clone").arg(FOO_CRATE_NAME)
+            .arg(&format!("--prefix={}", prefix.display())),
+        execs().with_status(101).with_stderr("\
+[UPDATING] registry `[..]`
+[DOWNLOADING] foo v0.0.1 (registry [..])
+[CLONING] foo v0.0.1
+[ERROR] Directory `[..]` already exists. Add --force to overwrite"
+        )
+    );
+}

--- a/tests/testsuite/main.rs
+++ b/tests/testsuite/main.rs
@@ -38,6 +38,7 @@ mod cargo_command;
 mod cfg;
 mod check;
 mod clean;
+mod clone;
 mod concurrent;
 mod config;
 mod corrupt_git;


### PR DESCRIPTION
#1545 
Tests mostly copy-pasted from `install` subcommand. I just adjusted them a little bit. 
Should we refactor and merge some parts of `install` and `clone` tests?