### PR TITLE
Does not print seconds fraction with minutes

### DIFF
--- a/src/cargo/core/compiler/job_queue.rs
+++ b/src/cargo/core/compiler/job_queue.rs
@@ -276,26 +276,14 @@ impl<'a> JobQueue<'a> {
         }
 
         let time_elapsed = {
-            use std::fmt::Write;
-
             let duration = cx.bcx.config.creation_time().elapsed();
-            let mut s = String::new();
             let secs = duration.as_secs();
 
             if secs >= 60 {
-                // We can safely unwrap, as writing to a `String` never errors
-                write!(s, "{}m ", secs / 60).unwrap();
-            };
-
-            // We can safely unwrap, as writing to a `String` never errors
-            write!(
-                s,
-                "{}.{:02}s",
-                secs % 60,
-                duration.subsec_nanos() / 10_000_000
-            ).unwrap();
-
-            s
+                format!("{}m {:02}s", secs / 60, secs % 60)
+            } else {
+                format!("{}.{:02}s", secs % 60, duration.subsec_nanos() / 10_000_000)
+            }
         };
 
         if self.queue.is_empty() {

--- a/src/cargo/core/compiler/job_queue.rs
+++ b/src/cargo/core/compiler/job_queue.rs
@@ -282,7 +282,7 @@ impl<'a> JobQueue<'a> {
             if secs >= 60 {
                 format!("{}m {:02}s", secs / 60, secs % 60)
             } else {
-                format!("{}.{:02}s", secs % 60, duration.subsec_nanos() / 10_000_000)
+                format!("{}.{:02}s", secs, duration.subsec_nanos() / 10_000_000)
             }
         };
 


### PR DESCRIPTION
As discussed in https://github.com/rust-lang/cargo/pull/5456#issuecomment-387731047,
seconds fraction seems unnecessary when the elapsed time is reported in minutes.