### PR TITLE
Add module path to doc --open

### DIFF
--- a/src/bin/cargo/commands/doc.rs
+++ b/src/bin/cargo/commands/doc.rs
@@ -7,8 +7,8 @@ pub fn cli() -> App {
         .about("Build a package's documentation")
         .arg(opt(
             "open",
-            "Opens the docs in a browser after the operation",
-        ))
+            "Opens the docs in a browser after the operation. Optionally with a MODULE to open.",
+        ).min_values(0).value_name("MODULE"))
         .arg_package_spec(
             "Package to document",
             "Document all packages in the workspace",
@@ -51,7 +51,15 @@ pub fn exec(config: &mut Config, args: &ArgMatches) -> CliResult {
     };
     let compile_opts = args.compile_options(config, mode)?;
     let doc_opts = DocOptions {
-        open_result: args.is_present("open"),
+        open_result: args.value_of("open")
+            .or_else(|| {
+                if args.is_present("open") {
+                    Some("")
+                } else {
+                    None
+                }
+            })
+            .map(|s| s.to_string()),
         compile_opts,
     };
     ops::doc(&ws, &doc_opts)?;

--- a/src/bin/cargo/commands/rustdoc.rs
+++ b/src/bin/cargo/commands/rustdoc.rs
@@ -9,8 +9,8 @@ pub fn cli() -> App {
         .arg(Arg::with_name("args").multiple(true))
         .arg(opt(
             "open",
-            "Opens the docs in a browser after the operation",
-        ))
+            "Opens the docs in a browser after the operation. Optionally with a MODULE to open.",
+        ).min_values(0).value_name("MODULE"))
         .arg_package("Package to document")
         .arg_jobs()
         .arg_targets_all(
@@ -58,7 +58,15 @@ pub fn exec(config: &mut Config, args: &ArgMatches) -> CliResult {
         Some(target_args)
     };
     let doc_opts = DocOptions {
-        open_result: args.is_present("open"),
+        open_result: args.value_of("open")
+            .or_else(|| {
+                if args.is_present("open") {
+                    Some("")
+                } else {
+                    None
+                }
+            })
+            .map(|s| s.to_string()),
         compile_opts,
     };
     ops::doc(&ws, &doc_opts)?;

--- a/src/cargo/ops/cargo_doc.rs
+++ b/src/cargo/ops/cargo_doc.rs
@@ -5,13 +5,14 @@ use std::process::Command;
 
 use core::Workspace;
 use ops;
+use util::normalize_path;
 use util::CargoResult;
 
 /// Strongly typed options for the `cargo doc` command.
 #[derive(Debug)]
 pub struct DocOptions<'a> {
     /// Whether to attempt to open the browser after compiling the docs
-    pub open_result: bool,
+    pub open_result: Option<String>,
     /// Options to pass through to the compiler
     pub compile_opts: ops::CompileOptions<'a>,
 }
@@ -67,7 +68,7 @@ pub fn doc(ws: &Workspace, options: &DocOptions) -> CargoResult<()> {
 
     ops::compile(ws, &options.compile_opts)?;
 
-    if options.open_result {
+    if let Some(ref module) = options.open_result {
         let name = if pkgs.len() > 1 {
             bail!(
                 "Passing multiple packages and `open` is not supported.\n\
@@ -94,8 +95,62 @@ pub fn doc(ws: &Workspace, options: &DocOptions) -> CargoResult<()> {
         if let Some(ref triple) = options.compile_opts.build_config.requested_target {
             target_dir.push(Path::new(triple).file_stem().unwrap());
         }
-        let path = target_dir.join("doc").join(&name).join("index.html");
-        let path = path.into_path_unlocked();
+
+        target_dir = target_dir.join("doc").join(&name);
+        let default_path = target_dir.join("index.html").into_path_unlocked();
+
+        let path = if module.is_empty() {
+            default_path
+        } else {
+            // A module path was provided so we try to convert it to a filesystem path
+            let doc_root = target_dir.clone();
+            let mut module_path = target_dir;
+            let module_parts: Vec<&str> = module.split("::").collect();
+
+            for part in module_parts.iter() {
+                module_path = module_path.join(part);
+            }
+
+            let mut module_path = module_path.into_path_unlocked();
+
+            // If the last segment of the module path ia a directory we use the index.html inside
+            // otherwise we assume that it is a type and use the .t.html redirect page to avoid
+            // trying all possible types
+            module_path = if module_path.is_dir() {
+                module_path.join("index.html")
+            } else {
+                let last_part = module_parts.last().unwrap();
+                module_path.set_file_name(format!("{}.t.html", last_part));
+                module_path
+            };
+
+            let mut shell = options.compile_opts.config.shell();
+            if !module_path.exists() {
+                shell.warn(format!(
+                    "{} does not exist fallback to default path.",
+                    module_path.display()
+                ))?;
+
+                default_path
+            } else {
+                // Resolve any possible path traversal operations to check if the generated path
+                // is still within the doc directory
+                module_path = normalize_path(&module_path);
+                let doc_root = normalize_path(&doc_root.into_path_unlocked());
+
+                if !module_path.starts_with(doc_root) {
+                    shell.warn(format!(
+                        "{} is outside of the doc directory fallback to default path.",
+                        module_path.display()
+                    ))?;
+
+                    default_path
+                } else {
+                    module_path
+                }
+            }
+        };
+
         if fs::metadata(&path).is_ok() {
             let mut shell = options.compile_opts.config.shell();
             shell.status("Opening", path.display())?;


### PR DESCRIPTION
Implements #5368 
The parsing approach I choose doesn't filter out non module path like elements but checks the created path if it is still within the doc directory.

An open question for is if rustdoc applies some transformation to the module path segments to map them to directory and file names?