### PR TITLE
Fix mode generated in `maybe_lib`

### DIFF
--- a/src/cargo/core/compiler/context/unit_dependencies.rs
+++ b/src/cargo/core/compiler/context/unit_dependencies.rs
@@ -301,8 +301,8 @@ fn maybe_lib<'a>(
     bcx: &BuildContext,
     profile_for: ProfileFor,
 ) -> Option<(Unit<'a>, ProfileFor)> {
-    let mode = check_or_build_mode(&unit.mode, unit.target);
     unit.pkg.targets().iter().find(|t| t.linkable()).map(|t| {
+        let mode = check_or_build_mode(&unit.mode, t);
         let unit = new_unit(bcx, unit.pkg, t, profile_for, unit.kind.for_target(t), mode);
         (unit, profile_for)
     })

--- a/tests/testsuite/check.rs
+++ b/tests/testsuite/check.rs
@@ -912,3 +912,49 @@ fn check_artifacts() {
         0
     );
 }
+
+#[test]
+fn proc_macro() {
+    let p = project("foo")
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "demo"
+                version = "0.0.1"
+
+                [lib]
+                proc-macro = true
+            "#,
+        )
+        .file(
+            "src/lib.rs",
+            r#"
+                extern crate proc_macro;
+
+                use proc_macro::TokenStream;
+
+                #[proc_macro_derive(Foo)]
+                pub fn demo(_input: TokenStream) -> TokenStream {
+                    "".parse().unwrap()
+                }
+            "#,
+        )
+        .file(
+            "src/main.rs",
+            r#"
+                #[macro_use]
+                extern crate demo;
+
+                #[derive(Foo)]
+                struct A;
+
+                fn main() {}
+            "#,
+        )
+        .build();
+    assert_that(
+        p.cargo("check").arg("-v").env("RUST_LOG", "cargo=trace"),
+        execs().with_status(0),
+    );
+}


### PR DESCRIPTION
The new `mode` for the library dependency is dependent on the library target
rather than the target which is the reason for the dependency on the library!

Closes rust-lang/rust#50640