### PR TITLE
Remove -Zno-trans test.

### DIFF
--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -3761,31 +3761,6 @@ fn custom_target_dir_line_parameter() {
 }
 
 #[test]
-fn rustc_no_trans() {
-    if !is_nightly() {
-        return;
-    }
-
-    let p = project("foo")
-        .file(
-            "Cargo.toml",
-            r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-        "#,
-        )
-        .file("src/main.rs", "fn main() {}")
-        .build();
-
-    assert_that(
-        p.cargo("rustc").arg("-v").arg("--").arg("-Zno-trans"),
-        execs().with_status(0),
-    );
-}
-
-#[test]
 fn build_multiple_packages() {
     let p = project("foo")
         .file(


### PR DESCRIPTION
Needed for https://github.com/rust-lang/rust/pull/50615 (where the flag is now `-Zno-codegen`) - which revealed that the test shouldn't even exist anymore, and was accidentally added back (https://github.com/rust-lang/rust/pull/50615#issuecomment-388968326).