### PR TITLE
Add document-private-items flag to cargo doc

### DIFF
--- a/src/bin/cargo/commands/doc.rs
+++ b/src/bin/cargo/commands/doc.rs
@@ -15,6 +15,7 @@ pub fn cli() -> App {
             "Exclude packages from the build",
         )
         .arg(opt("no-deps", "Don't build documentation for dependencies"))
+        .arg(opt("document-private-items", "Document private items"))
         .arg_jobs()
         .arg_targets_lib_bin(
             "Document only this package's library",
@@ -49,7 +50,12 @@ pub fn exec(config: &mut Config, args: &ArgMatches) -> CliResult {
     let mode = CompileMode::Doc {
         deps: !args.is_present("no-deps"),
     };
-    let compile_opts = args.compile_options(config, mode)?;
+    let mut compile_opts = args.compile_options(config, mode)?;
+    compile_opts.target_rustdoc_args = if args.is_present("document-private-items") {
+        Some(vec!["--document-private-items".to_string()])
+    } else {
+        None
+    };
     let doc_opts = DocOptions {
         open_result: args.is_present("open"),
         compile_opts,

--- a/tests/testsuite/doc.rs
+++ b/tests/testsuite/doc.rs
@@ -1545,3 +1545,22 @@ fn issue_5345() {
     assert_that(foo.cargo("build"), execs().with_status(0));
     assert_that(foo.cargo("doc"), execs().with_status(0));
 }
+
+#[test]
+fn doc_private_items() {
+    let foo = project("foo")
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "foo"
+            version = "0.0.1"
+           "#,
+        )
+        .file("src/lib.rs", "fn private_item() {}")
+        .build();
+    assert_that(foo.cargo("doc").arg("--document-private-items"), execs().with_status(0));
+
+    assert_that(&foo.root().join("target/doc"), existing_dir());
+    assert_that(&foo.root().join("target/doc/foo/index.html"), existing_file());
+}

--- a/tests/testsuite/doc.rs
+++ b/tests/testsuite/doc.rs
@@ -1557,10 +1557,10 @@ fn doc_private_items() {
             version = "0.0.1"
            "#,
         )
-        .file("src/lib.rs", "fn private_item() {}")
+        .file("src/lib.rs", "mod private { fn private_item() {} }")
         .build();
     assert_that(foo.cargo("doc").arg("--document-private-items"), execs().with_status(0));
 
     assert_that(&foo.root().join("target/doc"), existing_dir());
-    assert_that(&foo.root().join("target/doc/foo/index.html"), existing_file());
+    assert_that(&foo.root().join("target/doc/foo/private/index.html"), existing_file());
 }


### PR DESCRIPTION
Add a `--document-private-items` flag to `cargo doc`, that mimics the equivalent `cargo rustdoc -- --document-private-items`. This works by relaying the flag to the underlying rustdoc call.