### PR TITLE
Typed Config Access

### DIFF
--- a/src/cargo/core/compiler/build_config.rs
+++ b/src/cargo/core/compiler/build_config.rs
@@ -62,26 +62,7 @@ impl BuildConfig {
                  its environment, ignoring the `-j` parameter",
             )?;
         }
-        let cfg_jobs = match config.get_i64("build.jobs")? {
-            Some(v) => {
-                if v.val <= 0 {
-                    bail!(
-                        "build.jobs must be positive, but found {} in {}",
-                        v.val,
-                        v.definition
-                    )
-                } else if v.val >= i64::from(u32::max_value()) {
-                    bail!(
-                        "build.jobs is too large: found {} in {}",
-                        v.val,
-                        v.definition
-                    )
-                } else {
-                    Some(v.val as u32)
-                }
-            }
-            None => None,
-        };
+        let cfg_jobs: Option<u32> = config.get("build.jobs")?;
         let jobs = jobs.or(cfg_jobs).unwrap_or(::num_cpus::get() as u32);
         Ok(BuildConfig {
             requested_target: target,

--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -308,6 +308,7 @@ pub struct CliUnstable {
     pub avoid_dev_deps: bool,
     pub minimal_versions: bool,
     pub package_features: bool,
+    pub advanced_env: bool,
 }
 
 impl CliUnstable {
@@ -342,6 +343,7 @@ impl CliUnstable {
             "avoid-dev-deps" => self.avoid_dev_deps = true,
             "minimal-versions" => self.minimal_versions = true,
             "package-features" => self.package_features = true,
+            "advanced-env" => self.advanced_env = true,
             _ => bail!("unknown `-Z` flag specified: {}", k),
         }
 

--- a/src/cargo/lib.rs
+++ b/src/cargo/lib.rs
@@ -30,7 +30,6 @@ extern crate libgit2_sys;
 #[macro_use]
 extern crate log;
 extern crate num_cpus;
-extern crate num_traits;
 extern crate same_file;
 extern crate semver;
 #[macro_use]

--- a/src/cargo/lib.rs
+++ b/src/cargo/lib.rs
@@ -30,8 +30,10 @@ extern crate libgit2_sys;
 #[macro_use]
 extern crate log;
 extern crate num_cpus;
+extern crate num_traits;
 extern crate same_file;
 extern crate semver;
+#[macro_use]
 extern crate serde;
 #[macro_use]
 extern crate serde_derive;

--- a/src/cargo/util/config.rs
+++ b/src/cargo/util/config.rs
@@ -246,7 +246,6 @@ impl Config {
             .map(AsRef::as_ref)
     }
 
-    // TODO: Why is this `pub`?
     pub fn values(&self) -> CargoResult<&HashMap<String, ConfigValue>> {
         self.values.try_borrow_with(|| self.load_values())
     }
@@ -508,8 +507,7 @@ impl Config {
         }
     }
 
-    // TODO: why is this pub?
-    pub fn expected<T>(&self, ty: &str, key: &str, val: CV) -> CargoResult<T> {
+    fn expected<T>(&self, ty: &str, key: &str, val: CV) -> CargoResult<T> {
         val.expected(ty, key)
             .map_err(|e| format_err!("invalid configuration for key `{}`\n{}", key, e))
     }
@@ -591,7 +589,6 @@ impl Config {
         !self.frozen && !self.locked
     }
 
-    // TODO: this was pub for RLS but may not be needed anymore?
     /// Loads configuration from the filesystem
     pub fn load_values(&self) -> CargoResult<HashMap<String, ConfigValue>> {
         let mut cfg = CV::Table(HashMap::new(), PathBuf::from("."));
@@ -1195,8 +1192,6 @@ impl<'de, 'config> de::MapAccess<'de> for ConfigMapAccess<'config> {
     where
         V: de::DeserializeSeed<'de>,
     {
-        // TODO: Is it safe to assume next_value_seed is always called
-        // (exactly once) after next_key_seed?
         let next_key = self.next.take().expect("next field missing");
         let next_key = self.key.join(next_key);
         seed.deserialize(Deserializer {
@@ -1490,7 +1485,7 @@ impl ConfigValue {
         }
     }
 
-    pub fn expected<T>(&self, wanted: &str, key: &str) -> CargoResult<T> {
+    fn expected<T>(&self, wanted: &str, key: &str) -> CargoResult<T> {
         bail!(
             "expected a {}, but found a {} for `{}` in {}",
             wanted,

--- a/src/cargo/util/config.rs
+++ b/src/cargo/util/config.rs
@@ -508,13 +508,6 @@ impl Config {
         }
     }
 
-    pub fn net_retry(&self) -> CargoResult<i64> {
-        match self.get::<Option<u32>>("net.retry")? {
-            Some(v) => Ok(v as i64),
-            None => Ok(2),
-        }
-    }
-
     // TODO: why is this pub?
     pub fn expected<T>(&self, ty: &str, key: &str, val: CV) -> CargoResult<T> {
         val.expected(ty, key)

--- a/src/cargo/util/network.rs
+++ b/src/cargo/util/network.rs
@@ -48,7 +48,7 @@ pub fn with_retry<T, F>(config: &Config, mut callback: F) -> CargoResult<T>
 where
     F: FnMut() -> CargoResult<T>,
 {
-    let mut remaining = config.net_retry()?;
+    let mut remaining = config.get::<Option<u32>>("net.retry")?.unwrap_or(2);
     loop {
         match callback() {
             Ok(ret) => return Ok(ret),

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -265,7 +265,7 @@ impl TomlProfiles {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct TomlOptLevel(pub String);
 
 impl<'de> de::Deserialize<'de> for TomlOptLevel {
@@ -305,7 +305,7 @@ impl<'de> de::Deserialize<'de> for TomlOptLevel {
             }
         }
 
-        d.deserialize_u32(Visitor)
+        d.deserialize_any(Visitor)
     }
 }
 
@@ -321,7 +321,7 @@ impl ser::Serialize for TomlOptLevel {
     }
 }
 
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Serialize, Eq, PartialEq)]
 #[serde(untagged)]
 pub enum U32OrBool {
     U32(u32),
@@ -368,7 +368,7 @@ impl<'de> de::Deserialize<'de> for U32OrBool {
     }
 }
 
-#[derive(Deserialize, Serialize, Clone, Debug, Default)]
+#[derive(Deserialize, Serialize, Clone, Debug, Default, Eq, PartialEq)]
 #[serde(rename_all = "kebab-case")]
 pub struct TomlProfile {
     pub opt_level: Option<TomlOptLevel>,
@@ -480,7 +480,7 @@ impl TomlProfile {
     }
 }
 
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Serialize, Eq, PartialEq)]
 #[serde(untagged)]
 pub enum StringOrBool {
     String(String),

--- a/tests/testsuite/bad_config.rs
+++ b/tests/testsuite/bad_config.rs
@@ -241,7 +241,9 @@ fn bad_cargo_config_jobs() {
         execs()
             .with_status(101)
             .with_stderr("\
-[ERROR] error in [..].cargo[/]config: `build.jobs` must be positive, found -1
+[ERROR] error in [..].cargo[/]config: \
+could not load config key `build.jobs`: \
+invalid value: integer `-1`, expected u32
 "),
     );
 }

--- a/tests/testsuite/bad_config.rs
+++ b/tests/testsuite/bad_config.rs
@@ -109,8 +109,7 @@ fn bad3() {
 error: failed to update registry [..]
 
 Caused by:
-  invalid configuration for key `http.proxy`
-expected a string, but found a boolean for `http.proxy` in [..]config
+  error in [..]config: `http.proxy` expected a string, but found a boolean
 ",
         ),
     );
@@ -134,8 +133,7 @@ fn bad4() {
 [ERROR] Failed to create project `foo` at `[..]`
 
 Caused by:
-  invalid configuration for key `cargo-new.name`
-expected a string, but found a boolean for `cargo-new.name` in [..]config
+  error in [..]config: `cargo-new.name` expected a string, but found a boolean
 ",
         ),
     );
@@ -211,8 +209,7 @@ fn bad6() {
 error: failed to update registry [..]
 
 Caused by:
-  invalid configuration for key `http.user-agent`
-expected a string, but found a boolean for `http.user-agent` in [..]config
+  error in [..]config: `http.user-agent` expected a string, but found a boolean
 ",
         ),
     );
@@ -243,7 +240,9 @@ fn bad_cargo_config_jobs() {
         p.cargo("build").arg("-v"),
         execs()
             .with_status(101)
-            .with_stderr("[ERROR] build.jobs must be positive, but found -1 in [..]"),
+            .with_stderr("\
+[ERROR] error in [..].cargo[/]config: `build.jobs` must be positive, found -1
+"),
     );
 }
 

--- a/tests/testsuite/config.rs
+++ b/tests/testsuite/config.rs
@@ -1,5 +1,11 @@
-use cargotest::support::{execs, project};
+use cargo::core::Shell;
+use cargo::util::config::{self, Config};
+use cargo::util::toml::{self, VecStringOrBool as VSOB};
+use cargo::CargoError;
+use cargotest::support::{execs, lines_match, paths, project};
 use hamcrest::assert_that;
+use std::collections;
+use std::fs;
 
 #[test]
 fn read_env_vars_for_config() {
@@ -29,5 +35,575 @@ fn read_env_vars_for_config() {
     assert_that(
         p.cargo("build").env("CARGO_BUILD_JOBS", "100"),
         execs().with_status(0),
+    );
+}
+
+fn write_config(config: &str) {
+    let path = paths::root().join(".cargo/config");
+    fs::create_dir_all(path.parent().unwrap()).unwrap();
+    fs::write(path, config).unwrap();
+}
+
+fn new_config(env: &[(&str, &str)]) -> Config {
+    let shell = Shell::new();
+    let cwd = paths::root();
+    let homedir = paths::home();
+    let env = env
+        .iter()
+        .map(|(k, v)| (k.to_string(), v.to_string()))
+        .collect();
+    let mut config = Config::new(shell, cwd, homedir);
+    config.set_env(env);
+    config
+}
+
+fn assert_error(error: CargoError, msgs: &str) {
+    let causes = error
+        .causes()
+        .map(|e| e.to_string())
+        .collect::<Vec<_>>()
+        .join("\n");
+    if !lines_match(msgs, &causes) {
+        panic!(
+            "Did not find expected:\n{}\nActual error:\n{}\n",
+            msgs, causes
+        );
+    }
+}
+
+#[test]
+fn get_config() {
+    write_config(
+        "\
+[S]
+f1 = 123
+",
+    );
+
+    let config = new_config(&[]);
+
+    #[derive(Debug, Deserialize, Eq, PartialEq)]
+    struct S {
+        f1: Option<i64>,
+    }
+    let s: S = config.get("S").unwrap();
+    assert_eq!(s, S { f1: Some(123) });
+    let config = new_config(&[("CARGO_S_F1", "456")]);
+    let s: S = config.get("S").unwrap();
+    assert_eq!(s, S { f1: Some(456) });
+}
+
+#[test]
+fn config_unused_fields() {
+    write_config(
+        "\
+[S]
+unused = 456
+",
+    );
+
+    let config = new_config(&[("CARGO_S_UNUSED2", "1"), ("CARGO_S2_UNUSED", "2")]);
+
+    #[derive(Debug, Deserialize, Eq, PartialEq)]
+    struct S {
+        f1: Option<i64>,
+    }
+    // TODO: This currently does not verify the stderr output (not sure how).
+    // This prints the following:
+    // warning: unused key `S.unused` in config file `[..][/].cargo[/]config`
+    let s: S = config.get("S").unwrap();
+    assert_eq!(s, S { f1: None });
+    // This does not print anything, we cannot easily/reliably warn for
+    // environment variables.
+    let s: S = config.get("S2").unwrap();
+    assert_eq!(s, S { f1: None });
+}
+
+#[test]
+fn config_load_toml_profile() {
+    write_config(
+        "\
+[profile.dev]
+opt-level = 's'
+lto = true
+codegen-units=4
+debug = true
+debug-assertions = true
+rpath = true
+panic = 'abort'
+overflow-checks = true
+incremental = true
+
+[profile.dev.build-override]
+opt-level = 1
+
+[profile.dev.overrides.bar]
+codegen-units = 9
+",
+    );
+
+    let config = new_config(&[
+        ("CARGO_PROFILE_DEV_CODEGEN_UNITS", "5"),
+        ("CARGO_PROFILE_DEV_BUILD_OVERRIDE_CODEGEN_UNITS", "11"),
+        ("CARGO_PROFILE_DEV_OVERRIDES_env_CODEGEN_UNITS", "13"),
+        ("CARGO_PROFILE_DEV_OVERRIDES_bar_OPT_LEVEL", "2"),
+    ]);
+
+    // TODO: don't use actual tomlprofile
+    let p: toml::TomlProfile = config.get("profile.dev").unwrap();
+    let mut overrides = collections::BTreeMap::new();
+    let key = toml::ProfilePackageSpec::Spec(::cargo::core::PackageIdSpec::parse("bar").unwrap());
+    let o_profile = toml::TomlProfile {
+        opt_level: Some(toml::TomlOptLevel("2".to_string())),
+        lto: None,
+        codegen_units: Some(9),
+        debug: None,
+        debug_assertions: None,
+        rpath: None,
+        panic: None,
+        overflow_checks: None,
+        incremental: None,
+        overrides: None,
+        build_override: None,
+    };
+    overrides.insert(key, o_profile);
+    let key = toml::ProfilePackageSpec::Spec(::cargo::core::PackageIdSpec::parse("env").unwrap());
+    let o_profile = toml::TomlProfile {
+        opt_level: None,
+        lto: None,
+        codegen_units: Some(13),
+        debug: None,
+        debug_assertions: None,
+        rpath: None,
+        panic: None,
+        overflow_checks: None,
+        incremental: None,
+        overrides: None,
+        build_override: None,
+    };
+    overrides.insert(key, o_profile);
+
+    assert_eq!(
+        p,
+        toml::TomlProfile {
+            opt_level: Some(toml::TomlOptLevel("s".to_string())),
+            lto: Some(toml::StringOrBool::Bool(true)),
+            codegen_units: Some(5),
+            debug: Some(toml::U32OrBool::Bool(true)),
+            debug_assertions: Some(true),
+            rpath: Some(true),
+            panic: Some("abort".to_string()),
+            overflow_checks: Some(true),
+            incremental: Some(true),
+            overrides: Some(overrides),
+            build_override: Some(Box::new(toml::TomlProfile {
+                opt_level: Some(toml::TomlOptLevel("1".to_string())),
+                lto: None,
+                codegen_units: Some(11),
+                debug: None,
+                debug_assertions: None,
+                rpath: None,
+                panic: None,
+                overflow_checks: None,
+                incremental: None,
+                overrides: None,
+                build_override: None
+            }))
+        }
+    );
+}
+
+#[test]
+fn config_deserialize_any() {
+    // Some tests to exercise deserialize_any for deserializers that need to
+    // be told the format.
+    write_config(
+        "\
+a = true
+b = ['b']
+c = ['c']
+",
+    );
+
+    let config = new_config(&[
+        ("CARGO_ENVB", "false"),
+        ("CARGO_C", "['d']"),
+        ("CARGO_ENVL", "['a', 'b']"),
+    ]);
+
+    let a = config.get::<VSOB>("a").unwrap();
+    match a {
+        VSOB::VecString(_) => panic!("expected bool"),
+        VSOB::Bool(b) => assert_eq!(b, true),
+    }
+    let b = config.get::<VSOB>("b").unwrap();
+    match b {
+        VSOB::VecString(l) => assert_eq!(l, vec!["b".to_string()]),
+        VSOB::Bool(_) => panic!("expected list"),
+    }
+    let c = config.get::<VSOB>("c").unwrap();
+    match c {
+        VSOB::VecString(l) => assert_eq!(l, vec!["c".to_string(), "d".to_string()]),
+        VSOB::Bool(_) => panic!("expected list"),
+    }
+    let envb = config.get::<VSOB>("envb").unwrap();
+    match envb {
+        VSOB::VecString(_) => panic!("expected bool"),
+        VSOB::Bool(b) => assert_eq!(b, false),
+    }
+    let envl = config.get::<VSOB>("envl").unwrap();
+    match envl {
+        VSOB::VecString(l) => assert_eq!(l, vec!["a".to_string(), "b".to_string()]),
+        VSOB::Bool(_) => panic!("expected list"),
+    }
+}
+
+#[test]
+fn config_toml_errors() {
+    write_config(
+        "\
+[profile.dev]
+opt-level = 'foo'
+",
+    );
+
+    let config = new_config(&[]);
+
+    assert_error(
+        config.get::<toml::TomlProfile>("profile.dev").unwrap_err(),
+        "error in [..][/].cargo[/]config: \
+         could not load config key `profile.dev.opt-level`: \
+         must be an integer, `z`, or `s`, but found: foo",
+    );
+
+    let config = new_config(&[("CARGO_PROFILE_DEV_OPT_LEVEL", "asdf")]);
+
+    assert_error(
+        config.get::<toml::TomlProfile>("profile.dev").unwrap_err(),
+        "error in environment variable `CARGO_PROFILE_DEV_OPT_LEVEL`: \
+         could not load config key `profile.dev.opt-level`: \
+         must be an integer, `z`, or `s`, but found: asdf",
+    );
+}
+
+#[test]
+fn load_nested() {
+    write_config(
+        "\
+[nest.foo]
+f1 = 1
+f2 = 2
+[nest.bar]
+asdf = 3
+",
+    );
+
+    let config = new_config(&[
+        ("CARGO_NEST_foo_f2", "3"),
+        ("CARGO_NESTE_foo_f1", "1"),
+        ("CARGO_NESTE_foo_f2", "3"),
+        ("CARGO_NESTE_bar_asdf", "3"),
+    ]);
+
+    type Nested = collections::HashMap<String, collections::HashMap<String, u8>>;
+
+    let n: Nested = config.get("nest").unwrap();
+    let mut expected = collections::HashMap::new();
+    let mut foo = collections::HashMap::new();
+    foo.insert("f1".to_string(), 1);
+    foo.insert("f2".to_string(), 3);
+    expected.insert("foo".to_string(), foo);
+    let mut bar = collections::HashMap::new();
+    bar.insert("asdf".to_string(), 3);
+    expected.insert("bar".to_string(), bar);
+    assert_eq!(n, expected);
+
+    let n: Nested = config.get("neste").unwrap();
+    assert_eq!(n, expected);
+}
+
+#[test]
+fn get_errors() {
+    write_config(
+        "\
+[S]
+f1 = 123
+f2 = 'asdf'
+big = 123456789
+",
+    );
+
+    let config = new_config(&[("CARGO_E_S", "asdf"), ("CARGO_E_BIG", "123456789")]);
+    assert_error(
+        config.get::<i64>("foo").unwrap_err(),
+        "missing config key `foo`",
+    );
+    assert_error(
+        config.get::<i64>("foo.bar").unwrap_err(),
+        "missing config key `foo.bar`",
+    );
+    assert_error(
+        config.get::<i64>("S.f2").unwrap_err(),
+        "error in [..][/].cargo[/]config: `S.f2` expected an integer, but found a string",
+    );
+    assert_error(
+        config.get::<u8>("S.big").unwrap_err(),
+        "error in [..][/].cargo[/]config: `S.big` is too large (min/max 0/255), found 123456789",
+    );
+
+    // Environment variable type errors.
+    assert_error(
+        config.get::<i64>("e.s").unwrap_err(),
+        "error in environment variable `CARGO_E_S`: invalid digit found in string",
+    );
+    assert_error(
+        config.get::<i8>("e.big").unwrap_err(),
+        "error in environment variable `CARGO_E_BIG`: \
+         `e.big` is too large (min/max -128/127), found 123456789",
+    );
+
+    #[derive(Debug, Deserialize)]
+    struct S {
+        f1: i64,
+        f2: String,
+        f3: i64,
+        big: i64,
+    }
+    assert_error(
+        config.get::<S>("S").unwrap_err(),
+        "missing config key `S.f3`",
+    );
+}
+
+#[test]
+fn config_get_option() {
+    write_config(
+        "\
+[foo]
+f1 = 1
+",
+    );
+
+    let config = new_config(&[("CARGO_BAR_ASDF", "3")]);
+
+    assert_eq!(config.get::<Option<i32>>("a").unwrap(), None);
+    assert_eq!(config.get::<Option<i32>>("a.b").unwrap(), None);
+    assert_eq!(config.get::<Option<i32>>("foo.f1").unwrap(), Some(1));
+    assert_eq!(config.get::<Option<i32>>("bar.asdf").unwrap(), Some(3));
+    assert_eq!(config.get::<Option<i32>>("bar.zzzz").unwrap(), None);
+}
+
+#[test]
+fn config_bad_toml() {
+    write_config("asdf");
+    let config = new_config(&[]);
+    assert_error(
+        config.get::<i32>("foo").unwrap_err(),
+        "\
+could not load Cargo configuration
+Caused by:
+  could not parse TOML configuration in `[..][/].cargo[/]config`
+Caused by:
+  could not parse input as TOML
+Caused by:
+  expected an equals, found eof at line 1",
+    );
+}
+
+#[test]
+fn config_get_list() {
+    write_config(
+        "\
+l1 = []
+l2 = ['one', 'two']
+l3 = 123
+l4 = ['one', 'two']
+
+[nested]
+l = ['x']
+
+[nested2]
+l = ['y']
+
+[nested-empty]
+",
+    );
+
+    type L = Vec<String>;
+
+    let config = new_config(&[
+        ("CARGO_L4", "['three', 'four']"),
+        ("CARGO_L5", "['a']"),
+        ("CARGO_ENV_EMPTY", "[]"),
+        ("CARGO_ENV_BLANK", ""),
+        ("CARGO_ENV_NUM", "1"),
+        ("CARGO_ENV_NUM_LIST", "[1]"),
+        ("CARGO_ENV_TEXT", "asdf"),
+        ("CARGO_LEPAIR", "['a', 'b']"),
+        ("CARGO_NESTED2_L", "['z']"),
+        ("CARGO_NESTEDE_L", "['env']"),
+        ("CARGO_BAD_ENV", "[zzz]"),
+    ]);
+
+    assert_eq!(config.get::<L>("unset").unwrap(), vec![] as Vec<String>);
+    assert_eq!(config.get::<L>("l1").unwrap(), vec![] as Vec<String>);
+    assert_eq!(config.get::<L>("l2").unwrap(), vec!["one", "two"]);
+    assert_error(
+        config.get::<L>("l3").unwrap_err(),
+        "\
+invalid configuration for key `l3`
+expected a list, but found a integer for `l3` in [..][/].cargo[/]config",
+    );
+    assert_eq!(
+        config.get::<L>("l4").unwrap(),
+        vec!["one", "two", "three", "four"]
+    );
+    assert_eq!(config.get::<L>("l5").unwrap(), vec!["a"]);
+    assert_eq!(config.get::<L>("env-empty").unwrap(), vec![] as Vec<String>);
+    assert_error(
+        config.get::<L>("env-blank").unwrap_err(),
+        "error in environment variable `CARGO_ENV_BLANK`: \
+         should have TOML list syntax, found ``",
+    );
+    assert_error(
+        config.get::<L>("env-num").unwrap_err(),
+        "error in environment variable `CARGO_ENV_NUM`: \
+         should have TOML list syntax, found `1`",
+    );
+    assert_error(
+        config.get::<L>("env-num-list").unwrap_err(),
+        "error in environment variable `CARGO_ENV_NUM_LIST`: \
+         expected string, found integer",
+    );
+    assert_error(
+        config.get::<L>("env-text").unwrap_err(),
+        "error in environment variable `CARGO_ENV_TEXT`: \
+         should have TOML list syntax, found `asdf`",
+    );
+    // "invalid number" here isn't the best error, but I think it's just toml.rs.
+    assert_error(
+        config.get::<L>("bad-env").unwrap_err(),
+        "error in environment variable `CARGO_BAD_ENV`: \
+         could not parse TOML list: invalid number at line 1",
+    );
+
+    // Try some other sequence-like types.
+    assert_eq!(
+        config
+            .get::<(String, String, String, String)>("l4")
+            .unwrap(),
+        (
+            "one".to_string(),
+            "two".to_string(),
+            "three".to_string(),
+            "four".to_string()
+        )
+    );
+    assert_eq!(config.get::<(String,)>("l5").unwrap(), ("a".to_string(),));
+
+    // Tuple struct
+    #[derive(Debug, Deserialize, Eq, PartialEq)]
+    struct TupS(String, String);
+    assert_eq!(
+        config.get::<TupS>("lepair").unwrap(),
+        TupS("a".to_string(), "b".to_string())
+    );
+
+    // Nested with an option.
+    #[derive(Debug, Deserialize, Eq, PartialEq)]
+    struct S {
+        l: Option<Vec<String>>,
+    }
+    assert_eq!(config.get::<S>("nested-empty").unwrap(), S { l: None });
+    assert_eq!(
+        config.get::<S>("nested").unwrap(),
+        S {
+            l: Some(vec!["x".to_string()]),
+        }
+    );
+    assert_eq!(
+        config.get::<S>("nested2").unwrap(),
+        S {
+            l: Some(vec!["y".to_string(), "z".to_string()]),
+        }
+    );
+    assert_eq!(
+        config.get::<S>("nestede").unwrap(),
+        S {
+            l: Some(vec!["env".to_string()]),
+        }
+    );
+}
+
+#[test]
+fn config_get_other_types() {
+    write_config(
+        "\
+ns = 123
+ns2 = 456
+",
+    );
+
+    let config = new_config(&[("CARGO_NSE", "987"), ("CARGO_NS2", "654")]);
+
+    #[derive(Debug, Deserialize, Eq, PartialEq)]
+    struct NewS(i32);
+    assert_eq!(config.get::<NewS>("ns").unwrap(), NewS(123));
+    assert_eq!(config.get::<NewS>("ns2").unwrap(), NewS(654));
+    assert_eq!(config.get::<NewS>("nse").unwrap(), NewS(987));
+    assert_error(
+        config.get::<NewS>("unset").unwrap_err(),
+        "missing config key `unset`",
+    );
+}
+
+#[test]
+fn config_relative_path() {
+    write_config(&format!(
+        "\
+p1 = 'foo/bar'
+p2 = '../abc'
+p3 = 'b/c'
+abs = '{}'
+",
+        paths::home().display(),
+    ));
+
+    let config = new_config(&[("CARGO_EPATH", "a/b"), ("CARGO_P3", "d/e")]);
+
+    assert_eq!(
+        config
+            .get::<config::ConfigRelativePath>("p1")
+            .unwrap()
+            .path(),
+        paths::root().join("foo/bar")
+    );
+    assert_eq!(
+        config
+            .get::<config::ConfigRelativePath>("p2")
+            .unwrap()
+            .path(),
+        paths::root().join("../abc")
+    );
+    assert_eq!(
+        config
+            .get::<config::ConfigRelativePath>("p3")
+            .unwrap()
+            .path(),
+        paths::root().join("d/e")
+    );
+    assert_eq!(
+        config
+            .get::<config::ConfigRelativePath>("abs")
+            .unwrap()
+            .path(),
+        paths::home()
+    );
+    assert_eq!(
+        config
+            .get::<config::ConfigRelativePath>("epath")
+            .unwrap()
+            .path(),
+        paths::root().join("a/b")
     );
 }

--- a/tests/testsuite/config.rs
+++ b/tests/testsuite/config.rs
@@ -55,6 +55,15 @@ fn new_config(env: &[(&str, &str)]) -> Config {
         .collect();
     let mut config = Config::new(shell, cwd, homedir);
     config.set_env(env);
+    config.configure(
+        0,
+        None,
+        &None,
+        false,
+        false,
+        &None,
+        &["advanced-env".into()],
+    ).unwrap();
     config
 }
 


### PR DESCRIPTION
This introduces a new API for accessing config values using serde to
automatically convert to a destination type.  By itself this shouldn't
introduce any behavioral changes (except for some slight wording changes to
error messages).  However, it unlocks the ability to use richer data types in
the future (such as `profile`, or `source`).  Example:

```rust
let p: Option<TomlProfile> = config.get("profile.dev")?;
```

Supports environment variables when fetching structs or maps.  Note that it can
support underscores in env var for struct field names, but not maps.  So for
example, "opt_level" works, but not "serde_json" (example:
`CARGO_PROFILE_DEV_OVERRIDES_serde_OPT_LEVEL`).  I don't have any ideas for a
workaround (though I feel this is an overuse of env vars).

It supports environment variables for lists.  The value in the env var will get
appended to anything in the config.  It uses TOML syntax, and currently only
supports strings.  Example:  `CARGO_FOO=['a', 'b']`.  I did *not* modify
`get_list` to avoid changing behavior, but that can easily be changed.