### PR TITLE
Copy `--all-features` request to all workspace members

### DIFF
--- a/src/cargo/ops/resolve.rs
+++ b/src/cargo/ops/resolve.rs
@@ -272,11 +272,11 @@ pub fn resolve_with_previous<'a, 'cfg>(
                 // workspace, then we use `method` specified. Otherwise we use a
                 // base method with no features specified but using default features
                 // for any other packages specified with `-p`.
-                Method::Required { dev_deps, .. } => {
+                Method::Required { dev_deps, all_features, .. } => {
                     let base = Method::Required {
                         dev_deps,
                         features: &[],
-                        all_features: false,
+                        all_features,
                         uses_default_features: true,
                     };
                     let member_id = member.package_id();

--- a/tests/testsuite/features.rs
+++ b/tests/testsuite/features.rs
@@ -2031,3 +2031,42 @@ fn only_dep_is_optional() {
         execs().with_status(0),
     );
 }
+
+#[test]
+fn all_features_all_crates() {
+    Package::new("bar", "0.1.0").publish();
+
+    let p = project("foo")
+        .file(
+            "Cargo.toml",
+            r#"
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+
+                [workspace]
+                members = ['bar']
+            "#,
+        )
+        .file("src/main.rs", "fn main() {}")
+        .file(
+            "bar/Cargo.toml",
+            r#"
+                [project]
+                name = "bar"
+                version = "0.0.1"
+                authors = []
+
+                [features]
+                foo = []
+            "#,
+        )
+        .file("bar/src/main.rs", "#[cfg(feature = \"foo\")] fn main() {}")
+        .build();
+
+    assert_that(
+        p.cargo("build --all-features --all"),
+        execs().with_status(0),
+    );
+}


### PR DESCRIPTION
This fixes an accidental regression introduced in #5012 where the
`--all-features` CLI flag was only propagated to the "main crate" as opposed to
all workspace packages. This behavior has [already been deemed][pr] as
"basically not what you want", but for now it's best to avoid the regression.

Closes #5518

[pr]: https://github.com/rust-lang/cargo/pull/5353