### PR TITLE
Fix test failure in changing_bin_features_caches_targets for Linux.

### DIFF
--- a/tests/testsuite/freshness.rs
+++ b/tests/testsuite/freshness.rs
@@ -522,7 +522,7 @@ fn changing_bin_features_caches_targets() {
     let foo_proc = |name: &str| {
         let src = p.bin("foo");
         let dst = p.bin(name);
-        fs::copy(&src, &dst).expect("Failed to copy foo");
+        fs::hard_link(&src, &dst).expect("Failed to link foo");
         p.process(dst)
     };
 


### PR DESCRIPTION
Fixes rust-lang/rust#50962.

My theory is that while copying the binary, another thread forked with the fd
open.  The copy finishes and attempts to exec before the other child execs (and
closes the writeable fd).

I was able to easily repro this on linux.  I ran some stress tests of this fix
locally on linux and on appveyor, and was unable to trigger it again.