### PR TITLE
Fix panic in `cargo metadata` with dep on bin

### DIFF
--- a/tests/testsuite/metadata.rs
+++ b/tests/testsuite/metadata.rs
@@ -1248,3 +1248,35 @@ fn package_metadata() {
         ),
     );
 }
+
+#[test]
+fn bin_lib() {
+    let p = project("foo")
+        .file(
+            "foo/Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.1.0"
+            "#,
+        )
+        .file("foo/src/main.rs", "")
+        .file(
+            "bar/Cargo.toml",
+            r#"
+                [package]
+                name = "bar"
+                version = "0.1.0"
+
+                [dependencies]
+                foo = { path = "../foo" }
+            "#,
+        )
+        .file("bar/src/lib.rs", "")
+        .build();
+
+    assert_that(
+        p.cargo("metadata").cwd(p.root().join("bar")),
+        execs().with_status(0),
+    );
+}


### PR DESCRIPTION
This fixes an accidental `unwrap` on a package which doesn't actually have a lib
target in `cargo metadata`. It also refactors along the way to return a `Result`
to propagate the error from `packages.get`

Closes #5548