### PR TITLE
Support for `Cargo.toml` manifest override from another file (like `Cargo.patch`)

### DIFF
--- a/tests/testsuite/main.rs
+++ b/tests/testsuite/main.rs
@@ -75,6 +75,7 @@ mod profile_overrides;
 mod profile_targets;
 mod publish;
 mod read_manifest;
+mod read_patched_manifest;
 mod registry;
 mod rename_deps;
 mod required_features;

--- a/tests/testsuite/read_patched_manifest.rs
+++ b/tests/testsuite/read_patched_manifest.rs
@@ -1,0 +1,48 @@
+use cargotest::support::{basic_bin_manifest, execs, main_file, project};
+use hamcrest::assert_that;
+
+static MANIFEST_OUTPUT: &'static str = r#"
+{
+    "authors": [
+        "wycats@example.com"
+    ],
+    "categories": [],
+    "name":"foo",
+    "readme": null,
+    "repository": null,
+    "version":"0.6.0",
+    "id":"foo[..]0.6.0[..](path+file://[..]/foo)",
+    "keywords": [],
+    "license": null,
+    "license_file": null,
+    "description": null,
+    "source":null,
+    "dependencies":[],
+    "targets":[{
+        "kind":["bin"],
+        "crate_types":["bin"],
+        "name":"foo",
+        "src_path":"[..][/]foo[/]src[/]foo.rs"
+    }],
+    "features":{},
+    "manifest_path":"[..]Cargo.toml",
+    "metadata": null
+}"#;
+
+#[test]
+fn cargo_read_manifest_with_patch() {
+    let p = project("foo")
+        .file("Cargo.toml", &basic_bin_manifest("foo"))
+        .file("Cargo.patch", "[package]\nversion = \"0.6.0\"\n")
+        .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
+        .build();
+
+    assert_that(
+        p.cargo("read-manifest")
+            .arg("--manifest-path")
+            .arg("foo/Cargo.toml")
+            .cwd(p.root().parent().unwrap()),
+        execs().with_status(0).with_json(MANIFEST_OUTPUT),
+    );
+}
+


### PR DESCRIPTION
When working on multiple dependent crates from different repositories I often find it is much easier to edit some of the dependencies to use local paths, for instance 
```Cargo.toml
[dependencies]
some_dep = "1.0"
```
becomes 
```Cargo.toml
[dependencies]
some_dep = { path = "../some_dep" }
```
so that I can test a change in `some_dep` crate from some another crate without having to commit `some_dep` to git or publish on crates.io.
On the other hand when publishing I do not want to publish `Cargo.toml` file with dependencies defined like that. Therefore I think it would be nice to be able to provide some overrides (similiar to `[patch]` or `[replace]` sections of the manifest), but defined in *another file*, that I could add to `.gitignore` and not worry about Cargo.toml content when publishing.

In this PR I propose to provide a mechanism for overriding manifest content if there is a file named `Cargo.patch` next to `Cargo.toml`. I have implemented this simply by replacing (merging) parsed manifest when it is in its generic toml tree format.

I have provided a very simple test, as I expect this might be a rather controversial feature, and the implementation might require some more work.

Regards,
Jakub  