### PR TITLE
Fix an issue of deadlock in Cargo

### DIFF
--- a/src/cargo/core/registry.rs
+++ b/src/cargo/core/registry.rs
@@ -286,6 +286,7 @@ impl<'cfg> PackageRegistry<'cfg> {
 
     fn load(&mut self, source_id: &SourceId, kind: Kind) -> CargoResult<()> {
         (|| {
+            debug!("loading source {}", source_id);
             let source = self.source_config.load(source_id)?;
             assert_eq!(source.source_id(), source_id);
 

--- a/src/cargo/sources/registry/index.rs
+++ b/src/cargo/sources/registry/index.rs
@@ -75,6 +75,12 @@ impl<'cfg> RegistryIndex<'cfg> {
         name: &str,
         load: &mut RegistryData,
     ) -> CargoResult<Vec<(Summary, bool)>> {
+        // Prepare the `RegistryData` which will lazily initialize internal data
+        // structures. Note that this is also importantly needed to initialize
+        // to avoid deadlocks where we acquire a lock below but the `load`
+        // function inside *also* wants to acquire a lock. See an instance of
+        // this on #5551.
+        load.prepare()?;
         let (root, _lock) = if self.locked {
             let lock = self.path
                 .open_ro(Path::new(INDEX_LOCK), self.config, "the registry index");

--- a/src/cargo/sources/registry/local.rs
+++ b/src/cargo/sources/registry/local.rs
@@ -29,6 +29,10 @@ impl<'cfg> LocalRegistry<'cfg> {
 }
 
 impl<'cfg> RegistryData for LocalRegistry<'cfg> {
+    fn prepare(&self) -> CargoResult<()> {
+        Ok(())
+    }
+
     fn index_path(&self) -> &Filesystem {
         &self.index_path
     }

--- a/src/cargo/sources/registry/mod.rs
+++ b/src/cargo/sources/registry/mod.rs
@@ -295,6 +295,7 @@ impl<'a> RegistryDependency<'a> {
 }
 
 pub trait RegistryData {
+    fn prepare(&self) -> CargoResult<()>;
     fn index_path(&self) -> &Filesystem;
     fn load(
         &self,
@@ -427,6 +428,7 @@ impl<'cfg> Source for RegistrySource<'cfg> {
         // come back with no summaries, then our registry may need to be
         // updated, so we fall back to performing a lazy update.
         if dep.source_id().precise().is_some() && !self.updated {
+            debug!("attempting query without update");
             let mut called = false;
             self.index.query(dep, &mut *self.ops, &mut |s| {
                 called = true;
@@ -435,6 +437,7 @@ impl<'cfg> Source for RegistrySource<'cfg> {
             if called {
                 return Ok(());
             } else {
+                debug!("falling back to an update");
                 self.do_update()?;
             }
         }
@@ -464,6 +467,8 @@ impl<'cfg> Source for RegistrySource<'cfg> {
         // --precise` request
         if self.source_id.precise() != Some("locked") {
             self.do_update()?;
+        } else {
+            debug!("skipping update due to locked registry");
         }
         Ok(())
     }

--- a/src/cargo/util/errors.rs
+++ b/src/cargo/util/errors.rs
@@ -28,8 +28,11 @@ where
         D: fmt::Display + Send + Sync + 'static,
     {
         self.map_err(|failure| {
+            let err = failure.into();
             let context = f();
-            failure.into().context(context)
+            trace!("error: {}", err);
+            trace!("\tcontext: {}", context);
+            err.context(context)
         })
     }
 }


### PR DESCRIPTION
Currently Cargo can deadlock itself via file locks in somewhat obscure
scenarios. One way to trigger this scenario is by causing the index to fail
being created, for example through an invalid `init.templatedir` configuration.

This commit takes the strategy of solving two bugs:

* First, the deadlock is fixed. This is done by manually ensuring that the
  current deadlock doesn't happen by scheduling cached work to happen outside
  the scope of a lock.
* Second, the initialization of the registry's index is fixed. We turn off the
  usage of external templates as we don't want to use them for this internally
  managed repository anyway.

Closes #5551