### PR TITLE
A more complete example of authors

### DIFF
--- a/src/doc/src/reference/manifest.md
+++ b/src/doc/src/reference/manifest.md
@@ -11,7 +11,7 @@ The first section in a `Cargo.toml` is `[package]`.
 [package]
 name = "hello_world" # the name of the package
 version = "0.1.0"    # the current version, obeying semver
-authors = ["you@example.com"]
+authors = ["Alice <a@example.com>", "Bob <b@example.com>"]
 ```
 
 All three of these fields are mandatory.


### PR DESCRIPTION
Documentation doesn't show how to specify author names or how to specify multiple authors.