### PR TITLE
add GitLab CI to the CI docs

### DIFF
--- a/src/doc/src/guide/continuous-integration.md
+++ b/src/doc/src/guide/continuous-integration.md
@@ -19,3 +19,32 @@ This will test all three release channels, but any breakage in nightly
 will not fail your overall build. Please see the [Travis CI Rust
 documentation](https://docs.travis-ci.com/user/languages/rust/) for more
 information.
+
+### GitLab CI
+
+To test your project on GitLab CI, here is a sample `.gitlab-ci.yml` file:
+
+```yaml
+stages:
+  - build
+
+rust-latest:
+  stage: build
+  image: rust:latest
+  script:
+    - cargo build --verbose
+    - cargo test --verbose
+
+rust-nightly:
+  stage: build
+  image: rustlang/rust:nightly
+  script:
+    - cargo build --verbose
+    - cargo test --verbose
+  allow_failure: true
+```
+
+This will test on the stable channel and nightly channel, but any
+breakage in nightly will not fail your overall build. Please see the
+[GitLab CI](https://docs.gitlab.com/ce/ci/yaml/README.html) for more
+information.


### PR DESCRIPTION
Cargo supports GitLab CI natively for CI badges so include a basic
example of how to use it in the CI section of the documentation.