### PR TITLE
Verify that src dir wasn't modified by build.rs when publishing

### DIFF
--- a/src/cargo/ops/cargo_package.rs
+++ b/src/cargo/ops/cargo_package.rs
@@ -360,8 +360,9 @@ fn run_verify(ws: &Workspace, tar: &FileLock, opts: &PackageOpts) -> CargoResult
         bail!(
             "Source directory was modified by build.rs during cargo publish. \
              Build scripts should not modify anything outside of OUT_DIR. \
-             Modified file: {}",
-             path.display()
+             Modified file: {}\n\n\
+             To proceed despite this, pass the `--no-verify` flag.",
+            path.display()
         )
     }
 

--- a/src/cargo/ops/cargo_package.rs
+++ b/src/cargo/ops/cargo_package.rs
@@ -330,7 +330,7 @@ fn run_verify(ws: &Workspace, tar: &FileLock, opts: &PackageOpts) -> CargoResult
     let id = SourceId::for_path(&dst)?;
     let mut src = PathSource::new(&dst, &id, ws.config());
     let new_pkg = src.root_package()?;
-    let pkg_fingerprint = src.fingerprint(&new_pkg)?;
+    let pkg_fingerprint = src.last_modified_file(&new_pkg)?;
     let ws = Workspace::ephemeral(new_pkg, config, None, true)?;
 
     ops::compile_ws(
@@ -354,11 +354,14 @@ fn run_verify(ws: &Workspace, tar: &FileLock, opts: &PackageOpts) -> CargoResult
     )?;
 
     // Check that build.rs didn't modify any files in the src directory.
-    let ws_fingerprint = src.fingerprint(ws.current()?)?;
+    let ws_fingerprint = src.last_modified_file(ws.current()?)?;
     if pkg_fingerprint != ws_fingerprint {
+        let (_, path) = ws_fingerprint;
         bail!(
             "Source directory was modified by build.rs during cargo publish. \
-             Build scripts should not modify anything outside of OUT_DIR."
+             Build scripts should not modify anything outside of OUT_DIR. \
+             Modified file: {}",
+             path.display()
         )
     }
 

--- a/src/doc/src/reference/build-scripts.md
+++ b/src/doc/src/reference/build-scripts.md
@@ -272,6 +272,11 @@ There’s a couple of points of note here:
   output files should be located. It can use the process’ current working
   directory to find where the input files should be located, but in this case we
   don’t have any input files.
+* In general, build scripts should not modify any files outside of `OUT_DIR`.
+  It may seem fine on the first blush, but it does cause problems when you use
+  such crate as a dependency, because there's an *implicit* invariant that
+  sources in `.cargo/registry` should be immutable. `cargo` won't allow such
+  scripts when packaging.
 * This script is relatively simple as it just writes out a small generated file.
   One could imagine that other more fanciful operations could take place such as
   generating a Rust module from a C header file or another language definition,

--- a/tests/testsuite/package.rs
+++ b/tests/testsuite/package.rs
@@ -1446,8 +1446,7 @@ fn do_not_package_if_src_was_modified() {
     );
 
     assert_that(
-        p.cargo("package")
-        .arg("--no-verify"),
+        p.cargo("package --no-verify"),
         execs().with_status(0),
     );
 }

--- a/tests/testsuite/package.rs
+++ b/tests/testsuite/package.rs
@@ -1449,7 +1449,7 @@ error: failed to verify package tarball
 
 Caused by:
   Source directory was modified by build.rs during cargo publish. \
-Build scripts should not modify anything outside of OUT_DIR. Modified file: [..]src/generated.txt
+Build scripts should not modify anything outside of OUT_DIR. Modified file: [..]src[/]generated.txt
 
 To proceed despite this, pass the `--no-verify` flag.",
                ),

--- a/tests/testsuite/package.rs
+++ b/tests/testsuite/package.rs
@@ -1442,7 +1442,17 @@ fn do_not_package_if_src_was_modified() {
 
     assert_that(
         p.cargo("package"),
-        execs().with_status(101),
+        execs().with_status(101)
+               .with_stderr_contains(
+                   "\
+error: failed to verify package tarball
+
+Caused by:
+  Source directory was modified by build.rs during cargo publish. \
+Build scripts should not modify anything outside of OUT_DIR. Modified file: [..]src/generated.txt
+
+To proceed despite this, pass the `--no-verify` flag.",
+               ),
     );
 
     assert_that(

--- a/tests/testsuite/publish.rs
+++ b/tests/testsuite/publish.rs
@@ -872,36 +872,3 @@ fn block_publish_no_registry() {
         ),
     );
 }
-
-#[test]
-fn do_not_publish_if_src_was_modified() {
-    publish::setup();
-
-    let p = project("foo")
-        .file("Cargo.toml", r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-        "#)
-        .file("src/main.rs", r#"
-            fn main() { println!("hello"); }
-        "#)
-        .file("build.rs", r#"
-            use std::fs::File;
-            use std::io::Write;
-
-            fn main() {
-                let mut file = File::create("src/generated.txt").expect("failed to create file");
-                file.write_all(b"Hello, world of generated files.").expect("failed to write");
-            }
-        "#)
-        .build();
-
-    assert_that(
-        p.cargo("publish")
-            .arg("--index")
-            .arg(publish::registry().to_string()),
-        execs().with_status(101),
-    );
-}


### PR DESCRIPTION
Fixes issue #5073.

Implemented during RustFest Paris `impl days`.