### PR TITLE
Support `--target` argument in `cargo rustdoc`

### DIFF
--- a/src/bin/cargo/commands/rustdoc.rs
+++ b/src/bin/cargo/commands/rustdoc.rs
@@ -27,6 +27,7 @@ pub fn cli() -> App {
         )
         .arg_release("Build artifacts in release mode, with optimizations")
         .arg_features()
+        .arg_target_triple("Build for the target triple")
         .arg_target_dir()
         .arg_manifest_path()
         .arg_message_format()

--- a/tests/testsuite/rustdoc.rs
+++ b/tests/testsuite/rustdoc.rs
@@ -251,3 +251,32 @@ fn features() {
             .with_stderr_contains("[..]feature=[..]quux[..]"),
     );
 }
+
+#[test]
+#[cfg(all(target_arch = "x86_64", target_os = "linux"))]
+fn rustdoc_target() {
+    let p = project("foo")
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "a"
+            version = "0.0.1"
+            authors = []
+        "#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    assert_that(
+        p.cargo("rustdoc --verbose --target x86_64-unknown-linux-gnu"),
+        execs().with_status(0).with_stderr("\
+[DOCUMENTING] a v0.0.1 ([..])
+[RUNNING] `rustdoc --crate-name a src[/]lib.rs \
+    --target x86_64-unknown-linux-gnu \
+    -o [..]foo[/]target[/]x86_64-unknown-linux-gnu[/]doc \
+    -L dependency=[..]foo[/]target[/]x86_64-unknown-linux-gnu[/]debug[/]deps \
+    -L dependency=[..]foo[/]target[/]debug[/]deps`
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]"),
+    );
+}


### PR DESCRIPTION
We don't support `--target` in `cargo rustdoc`. Seems like an omission to me? We support it in `cargo rustc`. Discovered in https://github.com/rust-lang/cargo/pull/5543#issuecomment-392525154.