### PR TITLE
Clean error msg when lockfile contains duplicate packages.

### DIFF
--- a/src/cargo/core/resolver/encode.rs
+++ b/src/cargo/core/resolver/encode.rs
@@ -414,7 +414,7 @@ fn encodable_resolve_node(id: &PackageId, resolve: &Resolve) -> EncodableDepende
     }
 }
 
-fn encodable_package_id(id: &PackageId) -> EncodablePackageId {
+pub fn encodable_package_id(id: &PackageId) -> EncodablePackageId {
     EncodablePackageId {
         name: id.name().to_string(),
         version: id.version().to_string(),

--- a/src/cargo/core/resolver/mod.rs
+++ b/src/cargo/core/resolver/mod.rs
@@ -65,7 +65,7 @@ use self::context::{Activations, Context};
 use self::types::{ActivateError, ActivateResult, Candidate, ConflictReason, DepsFrame, GraphNode};
 use self::types::{RcVecIter, RegistryQueryer};
 
-pub use self::encode::{EncodableDependency, EncodablePackageId, EncodableResolve};
+pub use self::encode::{EncodableDependency, EncodablePackageId, EncodableResolve, encodable_package_id};
 pub use self::encode::{Metadata, WorkspaceResolve};
 pub use self::resolve::{Deps, DepsNotReplaced, Resolve};
 pub use self::types::Method;

--- a/src/cargo/ops/lockfile.rs
+++ b/src/cargo/ops/lockfile.rs
@@ -30,19 +30,20 @@ pub fn load_pkg_lockfile(ws: &Workspace) -> CargoResult<Option<Resolve>> {
     Ok(resolve)
 }
 
-fn duplicate_pkg_names(resolve: &Resolve) -> Vec<&'static str> {
+fn duplicate_pkgs(resolve: &Resolve) -> Vec<&'static str> {
     let mut unique_names = HashSet::new();
     let mut result = HashSet::new();
     for pkg_id in resolve.iter() {
-        if !unique_names.insert(pkg_id.name()) {
+        let mut encodable_pkd_id = resolver::encodable_package_id(pkg_id);
+        if !unique_names.insert(encodable_pkd_id) {
             result.insert(pkg_id.name().as_str());
         }
     }
     result.into_iter().collect()
 }
 
-fn check_duplicate_pkg_names(resolve: &Resolve) -> Result<(), Internal> {
-    let names = duplicate_pkg_names(resolve);
+fn check_duplicate_pkgs(resolve: &Resolve) -> Result<(), Internal> {
+    let names = duplicate_pkgs(resolve);
     if names.is_empty() {
         Ok(())
     } else {
@@ -63,7 +64,7 @@ pub fn write_pkg_lockfile(ws: &Workspace, resolve: &Resolve) -> CargoResult<()> 
         Ok(s)
     });
 
-    check_duplicate_pkg_names(resolve).chain_err(|| format!("failed to generate lock file"))?;
+    check_duplicate_pkgs(resolve).chain_err(|| format!("failed to generate lock file"))?;
 
     let toml = toml::Value::try_from(WorkspaceResolve { ws, resolve }).unwrap();
 

--- a/src/cargo/ops/lockfile.rs
+++ b/src/cargo/ops/lockfile.rs
@@ -1,13 +1,12 @@
-use std::collections::HashSet;
 use std::io::prelude::*;
 
 use toml;
 
-use core::resolver::WorkspaceResolve;
 use core::{resolver, Resolve, Workspace};
-use util::errors::{CargoResult, CargoResultExt, Internal};
-use util::toml as cargo_toml;
+use core::resolver::WorkspaceResolve;
 use util::Filesystem;
+use util::errors::{CargoResult, CargoResultExt};
+use util::toml as cargo_toml;
 
 pub fn load_pkg_lockfile(ws: &Workspace) -> CargoResult<Option<Resolve>> {
     if !ws.root().join("Cargo.lock").exists() {
@@ -26,32 +25,9 @@ pub fn load_pkg_lockfile(ws: &Workspace) -> CargoResult<Option<Resolve>> {
             let resolve: toml::Value = cargo_toml::parse(&s, f.path(), ws.config())?;
             let v: resolver::EncodableResolve = resolve.try_into()?;
             Ok(Some(v.into_resolve(ws)?))
-        })().chain_err(|| format!("failed to parse lock file at: {}", f.path().display()))?;
+        })()
+            .chain_err(|| format!("failed to parse lock file at: {}", f.path().display()))?;
     Ok(resolve)
-}
-
-fn duplicate_pkgs(resolve: &Resolve) -> Vec<&'static str> {
-    let mut unique_names = HashSet::new();
-    let mut result = HashSet::new();
-    for pkg_id in resolve.iter() {
-        let mut encodable_pkd_id = resolver::encodable_package_id(pkg_id);
-        if !unique_names.insert(encodable_pkd_id) {
-            result.insert(pkg_id.name().as_str());
-        }
-    }
-    result.into_iter().collect()
-}
-
-fn check_duplicate_pkgs(resolve: &Resolve) -> Result<(), Internal> {
-    let names = duplicate_pkgs(resolve);
-    if names.is_empty() {
-        Ok(())
-    } else {
-        Err(Internal::new(format_err!(
-            "dependencies contain duplicate package(s): {}",
-            names.join(", ")
-        )))
-    }
 }
 
 pub fn write_pkg_lockfile(ws: &Workspace, resolve: &Resolve) -> CargoResult<()> {
@@ -63,8 +39,6 @@ pub fn write_pkg_lockfile(ws: &Workspace, resolve: &Resolve) -> CargoResult<()> 
         f.read_to_string(&mut s)?;
         Ok(s)
     });
-
-    check_duplicate_pkgs(resolve).chain_err(|| format!("failed to generate lock file"))?;
 
     let toml = toml::Value::try_from(WorkspaceResolve { ws, resolve }).unwrap();
 

--- a/tests/testsuite/generate_lockfile.rs
+++ b/tests/testsuite/generate_lockfile.rs
@@ -307,8 +307,9 @@ fn duplicate_entries_in_lockfile() {
     assert_that(
         b.cargo("build"),
         execs().with_status(101).with_stderr_contains(
-            "[..]dependencies contain duplicate package(s) in the \
-             same namespace from the same source: common",
+            "[..]package collision in the lockfile: packages common [..] and \
+             common [..] are different, but only one can be written to \
+             lockfile unambigiously",
         ),
     );
 }

--- a/tests/testsuite/generate_lockfile.rs
+++ b/tests/testsuite/generate_lockfile.rs
@@ -2,7 +2,7 @@ use std::fs::{self, File};
 use std::io::prelude::*;
 
 use cargotest::support::registry::Package;
-use cargotest::support::{execs, project, ProjectBuilder, paths};
+use cargotest::support::{execs, paths, project, ProjectBuilder};
 use cargotest::ChannelChanger;
 use hamcrest::{assert_that, existing_file, is_not};
 
@@ -304,5 +304,11 @@ fn duplicate_entries_in_lockfile() {
         .build();
 
     // should fail due to a duplicate package `common` in the lockfile
-    assert_that(b.cargo("build"), execs().with_status(101));
+    assert_that(
+        b.cargo("build"),
+        execs().with_status(101).with_stderr_contains(
+            "[..]dependencies contain duplicate package(s) in the \
+             same namespace from the same source: common",
+        ),
+    );
 }


### PR DESCRIPTION
Resolves #5267.

(Implemented at RustFest Paris `impl days`.)