### PR TITLE
Allow publishing crates with nightly features

### DIFF
--- a/src/cargo/ops/registry.rs
+++ b/src/cargo/ops/registry.rs
@@ -43,12 +43,6 @@ pub struct PublishOpts<'cfg> {
 pub fn publish(ws: &Workspace, opts: &PublishOpts) -> CargoResult<()> {
     let pkg = ws.current()?;
 
-    // Allow publishing if a registry has been provided, or if there are no nightly
-    // features enabled.
-    if opts.registry.is_none() && !pkg.manifest().features().activated().is_empty() {
-        bail!("cannot publish crates which activate nightly-only cargo features to crates.io")
-    }
-
     if let Some(ref allowed_registries) = *pkg.publish() {
         if !match opts.registry {
             Some(ref registry) => allowed_registries.contains(registry),

--- a/tests/testsuite/cargo_features.rs
+++ b/tests/testsuite/cargo_features.rs
@@ -1,5 +1,5 @@
 use cargotest::ChannelChanger;
-use cargotest::support::{execs, project};
+use cargotest::support::{execs, project, publish};
 use hamcrest::assert_that;
 
 #[test]
@@ -303,7 +303,9 @@ fn z_flags_rejected() {
 }
 
 #[test]
-fn publish_rejected() {
+fn publish_allowed() {
+    publish::setup();
+
     let p = project("foo")
         .file(
             "Cargo.toml",
@@ -319,9 +321,10 @@ fn publish_rejected() {
         .file("src/lib.rs", "")
         .build();
     assert_that(
-        p.cargo("publish").masquerade_as_nightly_cargo(),
-        execs().with_status(101).with_stderr(
-            "error: cannot publish crates which activate nightly-only cargo features to crates.io",
-        ),
+        p.cargo("publish")
+            .arg("--index")
+            .arg(publish::registry().to_string())
+            .masquerade_as_nightly_cargo(),
+        execs().with_status(0),
     );
 }


### PR DESCRIPTION
closes #5427.

cc @rust-lang/cargo: I remember a vigorous debate over publishing crates with nightly Cargo features, but I can't recollect our exact plan of action. The discussion is logged here: https://paper.dropbox.com/doc/Unstable-Cargo-features-JBYMdsUYcO3FyW8Ubkjoz.

I think we just need to allow to publish crates with unstable cargo features, for the same reason we allow unstable rust features: you need explicit opt-in, even for deps. This is covered by Cargo tests: https://github.com/rust-lang/cargo/blob/9f097787b04b06cdde4fc42b26a531b22c1b37a6/tests/testsuite/cargo_features.rs#L115-L215.


I am not sure if we have ever implemented crates.io side of validation?

