### PR TITLE
`cargo install` will ignore the target triple specified in a project directory

### DIFF
--- a/src/bin/cargo/commands/install.rs
+++ b/src/bin/cargo/commands/install.rs
@@ -74,6 +74,9 @@ continuous integration systems.",
 pub fn exec(config: &mut Config, args: &ArgMatches) -> CliResult {
     let mut compile_opts = args.compile_options(config, CompileMode::Build)?;
     compile_opts.build_config.release = !args.is_present("debug");
+    // We override target architecture to host architecture since it may be
+    // set to some other architecture in .cargo/config.
+    compile_opts.build_config.requested_target = None;
 
     let krates = args.values_of("crate")
         .unwrap_or_default()

--- a/tests/testsuite/install.rs
+++ b/tests/testsuite/install.rs
@@ -1581,3 +1581,35 @@ fn git_repo_replace() {
             .contains(&format!("{}", new_rev))
     );
 }
+
+#[test]
+fn install_with_non_existent_target() {
+    pkg("bar", "0.0.1");
+
+    let p = project("foo")
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "foo"
+            version = "0.1.0"
+            authors = []
+        "#,
+        )
+        .file(
+            ".cargo/config",
+            r#"
+            [build]
+            target = "non-existing-target"
+        "#,
+        )
+        .file("src/main.rs", "fn main() {}")
+        .build();
+
+    assert_that(
+        cargo_process("install").arg("bar").cwd(p.root()),
+        execs().with_status(0),
+    );
+    assert_that(cargo_home(), has_installed_exe("bar"));
+}
+


### PR DESCRIPTION
Fixes #5441 