### PR TITLE
Allow rustc bootstrap to use unstable features even though it's using a beta-cargo

### DIFF
--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -354,12 +354,18 @@ impl CliUnstable {
 }
 
 fn channel() -> String {
-    env::var("__CARGO_TEST_CHANNEL_OVERRIDE_DO_NOT_USE_THIS").unwrap_or_else(|_| {
-        ::version()
-            .cfg_info
-            .map(|c| c.release_channel)
-            .unwrap_or_else(|| String::from("dev"))
-    })
+    if let Ok(staging) = env::var("RUSTC_BOOTSTRAP") {
+        if staging == "1" {
+            return "dev".to_string();
+        }
+    }
+    if let Ok(override_channel) = env::var("__CARGO_TEST_CHANNEL_OVERRIDE_DO_NOT_USE_THIS") {
+        return override_channel;
+    }
+    ::version()
+        .cfg_info
+        .map(|c| c.release_channel)
+        .unwrap_or_else(|| String::from("dev"))
 }
 
 fn nightly_features_allowed() -> bool {


### PR DESCRIPTION
This is the sane alternative to https://github.com/rust-lang/rust/pull/51322#issuecomment-394828839

cc @kennytm 