### PR TITLE
Allow integral edition specifier

### DIFF
--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -508,13 +508,6 @@ impl<'de> de::Deserialize<'de> for StringOrU32 {
                 Ok(StringOrU32::U32(u as u32))
             }
 
-            fn visit_u64<E>(self, u: u64) -> Result<Self::Value, E>
-            where
-                E: de::Error,
-            {
-                Ok(StringOrU32::U32(u as u32))
-            }
-
             fn visit_str<E>(self, s: &str) -> Result<Self::Value, E>
             where
                 E: de::Error,

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -482,6 +482,62 @@ impl TomlProfile {
 
 #[derive(Clone, Debug, Serialize, Eq, PartialEq)]
 #[serde(untagged)]
+pub enum StringOrU32 {
+    String(String),
+    U32(u32),
+}
+
+impl<'de> de::Deserialize<'de> for StringOrU32 {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        struct Visitor;
+
+        impl<'de> de::Visitor<'de> for Visitor {
+            type Value = StringOrU32;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("an integer or a string")
+            }
+
+            fn visit_i64<E>(self, u: i64) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Ok(StringOrU32::U32(u as u32))
+            }
+
+            fn visit_u64<E>(self, u: u64) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Ok(StringOrU32::U32(u as u32))
+            }
+
+            fn visit_str<E>(self, s: &str) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Ok(StringOrU32::String(s.to_string()))
+            }
+        }
+
+        deserializer.deserialize_any(Visitor)
+    }
+}
+
+impl StringOrU32 {
+    fn to_string(&self) -> String {
+        match self {
+            StringOrU32::String(v) => v.clone(),
+            StringOrU32::U32(v) => format!("{}", v),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Eq, PartialEq)]
+#[serde(untagged)]
 pub enum StringOrBool {
     String(String),
     Bool(bool),
@@ -595,7 +651,7 @@ pub struct TomlProject {
     license_file: Option<String>,
     repository: Option<String>,
     metadata: Option<toml::Value>,
-    edition: Option<String>,
+    edition: Option<StringOrU32>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -761,6 +817,7 @@ impl TomlManifest {
                 .require(Feature::edition())
                 .chain_err(|| "editions are unstable")?;
             edition
+                .to_string()
                 .parse()
                 .chain_err(|| "failed to parse the `edition` key")?
         } else {

--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -190,7 +190,7 @@ cargo-features = ["edition"]
 
 [package]
 ...
-edition = "2018"
+edition = 2018
 ```
 
 

--- a/tests/testsuite/package.rs
+++ b/tests/testsuite/package.rs
@@ -1130,6 +1130,36 @@ fn test_edition() {
 }
 
 #[test]
+fn test_edition_integral() {
+    let p = project("foo")
+        .file(
+            "Cargo.toml",
+            r#"
+            cargo-features = ["edition"]
+            [package]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+            edition = 2018
+        "#,
+        )
+        .file("src/lib.rs", r#" "#)
+        .build();
+
+    assert_that(
+        p.cargo("build").arg("-v").masquerade_as_nightly_cargo(),
+        execs()
+                // --edition is still in flux and we're not passing -Zunstable-options
+                // from Cargo so it will probably error. Only partially match the output
+                // until stuff stabilizes
+                .with_stderr_contains("\
+[COMPILING] foo v0.0.1 ([..])
+[RUNNING] `rustc [..]--edition=2018 [..]
+"),
+    );
+}
+
+#[test]
 fn test_edition_missing() {
     // no edition = 2015
     let p = project("foo")


### PR DESCRIPTION
This allows for more ergonomic edition switching. Instead of `edition = "2018"` you can now do `edition = 2018` which is 2 characters less. The string version is still allowed.