### PR TITLE
Remove redundant hashmap

### DIFF
--- a/src/cargo/core/interning.rs
+++ b/src/cargo/core/interning.rs
@@ -1,7 +1,7 @@
 use serde::{Serialize, Serializer};
 
 use std::fmt;
-use std::sync::RwLock;
+use std::sync::Mutex;
 use std::collections::HashSet;
 use std::str;
 use std::ptr;
@@ -14,8 +14,8 @@ pub fn leak(s: String) -> &'static str {
 }
 
 lazy_static! {
-    static ref STRING_CACHE: RwLock<HashSet<&'static str>> =
-        RwLock::new(HashSet::new());
+    static ref STRING_CACHE: Mutex<HashSet<&'static str>> =
+        Mutex::new(HashSet::new());
 }
 
 #[derive(Clone, Copy)]
@@ -33,7 +33,7 @@ impl Eq for InternedString {}
 
 impl InternedString {
     pub fn new(str: &str) -> InternedString {
-        let mut cache = STRING_CACHE.write().unwrap();
+        let mut cache = STRING_CACHE.lock().unwrap();
         let s = cache.get(str).map(|&s| s).unwrap_or_else(|| {
             let s = leak(str.to_string());
             cache.insert(s);

--- a/src/cargo/core/resolver/mod.rs
+++ b/src/cargo/core/resolver/mod.rs
@@ -730,7 +730,7 @@ impl RemainingCandidates {
                     if a != b.summary.package_id() {
                         conflicting_prev_active
                             .entry(a.clone())
-                            .or_insert_with(|| ConflictReason::Links(link.to_string()));
+                            .or_insert(ConflictReason::Links(link));
                         continue;
                     }
                 }

--- a/src/cargo/core/resolver/types.rs
+++ b/src/cargo/core/resolver/types.rs
@@ -279,7 +279,7 @@ pub enum ConflictReason {
     /// The `links` key is being violated. For example one crate in the
     /// dependency graph has `links = "foo"` but this crate also had that, and
     /// we're only allowed one per dependency graph.
-    Links(String),
+    Links(InternedString),
 
     /// A dependency listed features that weren't actually available on the
     /// candidate. For example we tried to activate feature `foo` but the


### PR DESCRIPTION
We have two structures keeping track of parshall lists of `conflicting_prev_active`. I believe that they are always merged with each other before being used. (CI will tell me if I am wrong.) So in this PR we us pass a `&mut` so that it is merged as it gos. This saves us a clone/allocation of a hashmap for every tick, although most of the time one or both are empty so I doubt it will be a big performance change.

Keeping the comments clear in this code is very important. @alexcrichton, are there new comments that should go in with this change or more that should come out?