### PR TITLE
Update replaced registry before search

### DIFF
--- a/src/cargo/core/source/mod.rs
+++ b/src/cargo/core/source/mod.rs
@@ -14,6 +14,11 @@ pub trait Source {
     /// Returns the `SourceId` corresponding to this source
     fn source_id(&self) -> &SourceId;
 
+    /// Returns the replaced `SourceId` corresponding to this source
+    fn replaced_source_id(&self) -> &SourceId {
+        self.source_id()
+    }
+
     /// Returns whether or not this source will return summaries with
     /// checksums listed.
     fn supports_checksums(&self) -> bool;
@@ -93,6 +98,11 @@ impl<'a, T: Source + ?Sized + 'a> Source for Box<T> {
     /// Forwards to `Source::source_id`
     fn source_id(&self) -> &SourceId {
         (**self).source_id()
+    }
+
+    /// Forwards to `Source::replaced_source_id`
+    fn replaced_source_id(&self) -> &SourceId {
+        (**self).replaced_source_id()
     }
 
     /// Forwards to `Source::update`

--- a/src/cargo/ops/registry.rs
+++ b/src/cargo/ops/registry.rs
@@ -1,8 +1,8 @@
-use std::{cmp, env};
 use std::collections::BTreeMap;
 use std::fs::{self, File};
 use std::iter::repeat;
 use std::time::Duration;
+use std::{cmp, env};
 
 use curl::easy::{Easy, SslOpt};
 use git2;
@@ -10,18 +10,18 @@ use registry::{NewCrate, NewCrateDependency, Registry};
 
 use url::percent_encoding::{percent_encode, QUERY_ENCODE_SET};
 
-use version;
-use core::source::Source;
-use core::{Package, SourceId, Workspace};
 use core::dependency::Kind;
 use core::manifest::ManifestMetadata;
+use core::source::Source;
+use core::{Package, SourceId, Workspace};
 use ops;
-use sources::RegistrySource;
+use sources::{RegistrySource, SourceConfigMap};
 use util::config::{self, Config};
-use util::paths;
-use util::ToUrl;
 use util::errors::{CargoResult, CargoResultExt};
 use util::important_paths::find_root_manifest_for_wd;
+use util::paths;
+use util::ToUrl;
+use version;
 
 pub struct RegistryConfig {
     pub index: Option<String>,
@@ -311,11 +311,7 @@ pub fn registry(
         index: index_config,
     } = registry_configuration(config, registry.clone())?;
     let token = token.or(token_config);
-    let sid = match (index_config, index, registry) {
-        (_, _, Some(registry)) => SourceId::alt_registry(config, &registry)?,
-        (Some(index), _, _) | (None, Some(index), _) => SourceId::for_registry(&index.to_url()?)?,
-        (None, None, _) => SourceId::crates_io(config)?,
-    };
+    let sid = get_source_id(config, index_config.or(index), registry)?;
     let api_host = {
         let mut src = RegistrySource::remote(&sid, config);
         src.update()
@@ -354,10 +350,11 @@ pub fn needs_custom_http_transport(config: &Config) -> CargoResult<bool> {
     let check_revoke = config.get_bool("http.check-revoke")?;
     let user_agent = config.get_string("http.user-agent")?;
 
-    Ok(
-        proxy_exists || timeout.is_some() || cainfo.is_some() || check_revoke.is_some()
-            || user_agent.is_some(),
-    )
+    Ok(proxy_exists
+        || timeout.is_some()
+        || cainfo.is_some()
+        || check_revoke.is_some()
+        || user_agent.is_some())
 }
 
 /// Configure a libcurl http handle with the defaults options for Cargo
@@ -553,6 +550,22 @@ pub fn yank(
     Ok(())
 }
 
+fn get_source_id(
+    config: &Config,
+    index: Option<String>,
+    reg: Option<String>,
+) -> CargoResult<SourceId> {
+    match (reg, index) {
+        (Some(r), _) => SourceId::alt_registry(config, &r),
+        (_, Some(i)) => SourceId::for_registry(&i.to_url()?),
+        _ => {
+            let map = SourceConfigMap::new(config)?;
+            let src = map.load(&SourceId::crates_io(config)?)?;
+            Ok(src.replaced_source_id().clone())
+        }
+    }
+}
+
 pub fn search(
     query: &str,
     config: &Config,
@@ -572,7 +585,22 @@ pub fn search(
         prefix
     }
 
-    let (mut registry, _) = registry(config, None, index, reg)?;
+    let sid = get_source_id(config, index, reg)?;
+
+    let mut regsrc = RegistrySource::remote(&sid, config);
+    let cfg = match regsrc.config() {
+        Ok(c) => c,
+        Err(_) => {
+            regsrc
+                .update()
+                .chain_err(|| format!("failed to update {}", &sid))?;
+            regsrc.config()?
+        }
+    };
+
+    let api_host = cfg.unwrap().api.unwrap();
+    let handle = http_handle(config)?;
+    let mut registry = Registry::new_handle(api_host, None, handle);
     let (crates, total_crates) = registry
         .search(query, limit)
         .chain_err(|| "failed to retrieve search results from the registry")?;

--- a/src/cargo/sources/replaced.rs
+++ b/src/cargo/sources/replaced.rs
@@ -60,6 +60,10 @@ impl<'cfg> Source for ReplacedSource<'cfg> {
         &self.to_replace
     }
 
+    fn replaced_source_id(&self) -> &SourceId {
+        &self.replace_with
+    }
+
     fn update(&mut self) -> CargoResult<()> {
         self.inner
             .update()

--- a/tests/testsuite/search.rs
+++ b/tests/testsuite/search.rs
@@ -1,33 +1,71 @@
 use std::fs::{self, File};
 use std::io::prelude::*;
-use std::path::PathBuf;
+use std::path::Path;
 
 use cargo::util::ProcessBuilder;
 use support;
 use support::execs;
 use support::git::repo;
 use support::paths;
+use support::registry::{api_path, registry as registry_url, registry_path};
 use support::hamcrest::assert_that;
 use url::Url;
 
-fn registry_path() -> PathBuf {
-    paths::root().join("registry")
-}
-fn registry() -> Url {
-    Url::from_file_path(&*registry_path()).ok().unwrap()
-}
-fn api_path() -> PathBuf {
-    paths::root().join("api")
-}
 fn api() -> Url {
     Url::from_file_path(&*api_path()).ok().unwrap()
 }
 
+fn write_crates(dest: &Path) {
+    let content = r#"{
+        "crates": [{
+            "created_at": "2014-11-16T20:17:35Z",
+            "description": "Design by contract style assertions for Rust",
+            "documentation": null,
+            "downloads": 2,
+            "homepage": null,
+            "id": "hoare",
+            "keywords": [],
+            "license": null,
+            "links": {
+                "owners": "/api/v1/crates/hoare/owners",
+                "reverse_dependencies": "/api/v1/crates/hoare/reverse_dependencies",
+                "version_downloads": "/api/v1/crates/hoare/downloads",
+                "versions": "/api/v1/crates/hoare/versions"
+            },
+            "max_version": "0.1.1",
+            "name": "hoare",
+            "repository": "https://github.com/nick29581/libhoare",
+            "updated_at": "2014-11-20T21:49:21Z",
+            "versions": null
+        }],
+        "meta": {
+            "total": 1
+        }
+    }"#;
+
+    // Older versions of curl don't peel off query parameters when looking for
+    // filenames, so just make both files.
+    //
+    // On windows, though, `?` is an invalid character, but we always build curl
+    // from source there anyway!
+    File::create(&dest)
+        .unwrap()
+        .write_all(content.as_bytes())
+        .unwrap();
+    if !cfg!(windows) {
+        File::create(&dest.with_file_name("crates?q=postgres&per_page=10"))
+            .unwrap()
+            .write_all(content.as_bytes())
+            .unwrap();
+    }
+}
+
 fn setup() {
-    let config = paths::root().join(".cargo/config");
-    fs::create_dir_all(config.parent().unwrap()).unwrap();
+    let cargo_home = paths::root().join(".cargo");
+    fs::create_dir_all(cargo_home).unwrap();
     fs::create_dir_all(&api_path().join("api/v1")).unwrap();
 
+    // Init a new registry
     let _ = repo(&registry_path())
         .file(
             "config.json",
@@ -40,6 +78,30 @@ fn setup() {
             ),
         )
         .build();
+
+    let base = api_path().join("api/v1/crates");
+    write_crates(&base);
+}
+
+fn set_cargo_config() {
+    let config = paths::root().join(".cargo/config");
+
+    File::create(&config)
+        .unwrap()
+        .write_all(
+            format!(
+                r#"
+[source.crates-io]
+registry = 'https://wut'
+replace-with = 'dummy-registry'
+
+[source.dummy-registry]
+registry = '{reg}'
+"#,
+                reg = registry_url(),
+            ).as_bytes(),
+        )
+        .unwrap();
 }
 
 fn cargo_process(s: &str) -> ProcessBuilder {
@@ -49,58 +111,55 @@ fn cargo_process(s: &str) -> ProcessBuilder {
 }
 
 #[test]
+fn not_update() {
+    setup();
+    set_cargo_config();
+
+    use cargo::core::{Shell, Source, SourceId};
+    use cargo::sources::RegistrySource;
+    use cargo::util::Config;
+
+    let sid = SourceId::for_registry(&registry_url()).unwrap();
+    let cfg = Config::new(Shell::new(), paths::root(), paths::home().join(".cargo"));
+    let mut regsrc = RegistrySource::remote(&sid, &cfg);
+    regsrc.update().unwrap();
+
+    assert_that(
+        cargo_process("search").arg("postgres"),
+        execs()
+            .with_status(0)
+            .with_stdout_contains(
+                "hoare = \"0.1.1\"    # Design by contract style assertions for Rust",
+            )
+            .with_stderr(""), // without "Updating registry ..."
+    );
+}
+
+#[test]
+fn replace_default() {
+    setup();
+    set_cargo_config();
+
+    assert_that(
+        cargo_process("search").arg("postgres"),
+        execs()
+            .with_status(0)
+            .with_stdout_contains(
+                "hoare = \"0.1.1\"    # Design by contract style assertions for Rust",
+            )
+            .with_stderr_contains("[..]Updating registry[..]"),
+    );
+}
+
+#[test]
 fn simple() {
     setup();
-
-    let contents = r#"{
-        "crates": [{
-            "created_at": "2014-11-16T20:17:35Z",
-            "description": "Design by contract style assertions for Rust",
-            "documentation": null,
-            "downloads": 2,
-            "homepage": null,
-            "id": "hoare",
-            "keywords": [],
-            "license": null,
-            "links": {
-                "owners": "/api/v1/crates/hoare/owners",
-                "reverse_dependencies": "/api/v1/crates/hoare/reverse_dependencies",
-                "version_downloads": "/api/v1/crates/hoare/downloads",
-                "versions": "/api/v1/crates/hoare/versions"
-            },
-            "max_version": "0.1.1",
-            "name": "hoare",
-            "repository": "https://github.com/nick29581/libhoare",
-            "updated_at": "2014-11-20T21:49:21Z",
-            "versions": null
-        }],
-        "meta": {
-            "total": 1
-        }
-    }"#;
-    let base = api_path().join("api/v1/crates");
-
-    // Older versions of curl don't peel off query parameters when looking for
-    // filenames, so just make both files.
-    //
-    // On windows, though, `?` is an invalid character, but we always build curl
-    // from source there anyway!
-    File::create(&base)
-        .unwrap()
-        .write_all(contents.as_bytes())
-        .unwrap();
-    if !cfg!(windows) {
-        File::create(&base.with_file_name("crates?q=postgres&per_page=10"))
-            .unwrap()
-            .write_all(contents.as_bytes())
-            .unwrap();
-    }
 
     assert_that(
         cargo_process("search")
             .arg("postgres")
             .arg("--index")
-            .arg(registry().to_string()),
+            .arg(registry_url().to_string()),
         execs().with_status(0).with_stdout_contains(
             "hoare = \"0.1.1\"    # Design by contract style assertions for Rust",
         ),
@@ -113,55 +172,11 @@ fn simple() {
 fn simple_with_host() {
     setup();
 
-    let contents = r#"{
-        "crates": [{
-            "created_at": "2014-11-16T20:17:35Z",
-            "description": "Design by contract style assertions for Rust",
-            "documentation": null,
-            "downloads": 2,
-            "homepage": null,
-            "id": "hoare",
-            "keywords": [],
-            "license": null,
-            "links": {
-                "owners": "/api/v1/crates/hoare/owners",
-                "reverse_dependencies": "/api/v1/crates/hoare/reverse_dependencies",
-                "version_downloads": "/api/v1/crates/hoare/downloads",
-                "versions": "/api/v1/crates/hoare/versions"
-            },
-            "max_version": "0.1.1",
-            "name": "hoare",
-            "repository": "https://github.com/nick29581/libhoare",
-            "updated_at": "2014-11-20T21:49:21Z",
-            "versions": null
-        }],
-        "meta": {
-            "total": 1
-        }
-    }"#;
-    let base = api_path().join("api/v1/crates");
-
-    // Older versions of curl don't peel off query parameters when looking for
-    // filenames, so just make both files.
-    //
-    // On windows, though, `?` is an invalid character, but we always build curl
-    // from source there anyway!
-    File::create(&base)
-        .unwrap()
-        .write_all(contents.as_bytes())
-        .unwrap();
-    if !cfg!(windows) {
-        File::create(&base.with_file_name("crates?q=postgres&per_page=10"))
-            .unwrap()
-            .write_all(contents.as_bytes())
-            .unwrap();
-    }
-
     assert_that(
         cargo_process("search")
             .arg("postgres")
             .arg("--host")
-            .arg(registry().to_string()),
+            .arg(registry_url().to_string()),
         execs()
             .with_status(0)
             .with_stderr(&format!(
@@ -177,7 +192,7 @@ to update to a fixed version or contact the upstream maintainer
 about this warning.
 [UPDATING] registry `{reg}`
 ",
-                reg = registry()
+                reg = registry_url()
             ))
             .with_stdout_contains(
                 "hoare = \"0.1.1\"    # Design by contract style assertions for Rust",
@@ -191,57 +206,13 @@ about this warning.
 fn simple_with_index_and_host() {
     setup();
 
-    let contents = r#"{
-        "crates": [{
-            "created_at": "2014-11-16T20:17:35Z",
-            "description": "Design by contract style assertions for Rust",
-            "documentation": null,
-            "downloads": 2,
-            "homepage": null,
-            "id": "hoare",
-            "keywords": [],
-            "license": null,
-            "links": {
-                "owners": "/api/v1/crates/hoare/owners",
-                "reverse_dependencies": "/api/v1/crates/hoare/reverse_dependencies",
-                "version_downloads": "/api/v1/crates/hoare/downloads",
-                "versions": "/api/v1/crates/hoare/versions"
-            },
-            "max_version": "0.1.1",
-            "name": "hoare",
-            "repository": "https://github.com/nick29581/libhoare",
-            "updated_at": "2014-11-20T21:49:21Z",
-            "versions": null
-        }],
-        "meta": {
-            "total": 1
-        }
-    }"#;
-    let base = api_path().join("api/v1/crates");
-
-    // Older versions of curl don't peel off query parameters when looking for
-    // filenames, so just make both files.
-    //
-    // On windows, though, `?` is an invalid character, but we always build curl
-    // from source there anyway!
-    File::create(&base)
-        .unwrap()
-        .write_all(contents.as_bytes())
-        .unwrap();
-    if !cfg!(windows) {
-        File::create(&base.with_file_name("crates?q=postgres&per_page=10"))
-            .unwrap()
-            .write_all(contents.as_bytes())
-            .unwrap();
-    }
-
     assert_that(
         cargo_process("search")
             .arg("postgres")
             .arg("--index")
-            .arg(registry().to_string())
+            .arg(registry_url().to_string())
             .arg("--host")
-            .arg(registry().to_string()),
+            .arg(registry_url().to_string()),
         execs()
             .with_status(0)
             .with_stderr(&format!(
@@ -257,7 +228,7 @@ to update to a fixed version or contact the upstream maintainer
 about this warning.
 [UPDATING] registry `{reg}`
 ",
-                reg = registry()
+                reg = registry_url()
             ))
             .with_stdout_contains(
                 "hoare = \"0.1.1\"    # Design by contract style assertions for Rust",
@@ -269,56 +240,12 @@ about this warning.
 fn multiple_query_params() {
     setup();
 
-    let contents = r#"{
-        "crates": [{
-            "created_at": "2014-11-16T20:17:35Z",
-            "description": "Design by contract style assertions for Rust",
-            "documentation": null,
-            "downloads": 2,
-            "homepage": null,
-            "id": "hoare",
-            "keywords": [],
-            "license": null,
-            "links": {
-                "owners": "/api/v1/crates/hoare/owners",
-                "reverse_dependencies": "/api/v1/crates/hoare/reverse_dependencies",
-                "version_downloads": "/api/v1/crates/hoare/downloads",
-                "versions": "/api/v1/crates/hoare/versions"
-            },
-            "max_version": "0.1.1",
-            "name": "hoare",
-            "repository": "https://github.com/nick29581/libhoare",
-            "updated_at": "2014-11-20T21:49:21Z",
-            "versions": null
-        }],
-        "meta": {
-            "total": 1
-        }
-    }"#;
-    let base = api_path().join("api/v1/crates");
-
-    // Older versions of curl don't peel off query parameters when looking for
-    // filenames, so just make both files.
-    //
-    // On windows, though, `?` is an invalid character, but we always build curl
-    // from source there anyway!
-    File::create(&base)
-        .unwrap()
-        .write_all(contents.as_bytes())
-        .unwrap();
-    if !cfg!(windows) {
-        File::create(&base.with_file_name("crates?q=postgres+sql&per_page=10"))
-            .unwrap()
-            .write_all(contents.as_bytes())
-            .unwrap();
-    }
-
     assert_that(
         cargo_process("search")
             .arg("postgres")
             .arg("sql")
             .arg("--index")
-            .arg(registry().to_string()),
+            .arg(registry_url().to_string()),
         execs().with_status(0).with_stdout_contains(
             "hoare = \"0.1.1\"    # Design by contract style assertions for Rust",
         ),

--- a/tests/testsuite/support/registry.rs
+++ b/tests/testsuite/support/registry.rs
@@ -20,6 +20,9 @@ pub fn registry_path() -> PathBuf {
 pub fn registry() -> Url {
     Url::from_file_path(&*registry_path()).ok().unwrap()
 }
+pub fn api_path() -> PathBuf {
+    paths::root().join("api")
+}
 pub fn dl_path() -> PathBuf {
     paths::root().join("dl")
 }
@@ -77,7 +80,7 @@ pub fn init() {
         format!(
             r#"
         [registry]
-            token = "api-token"
+        token = "api-token"
 
         [source.crates-io]
         registry = 'https://wut'


### PR DESCRIPTION
Close #5550.

It seems that updating the replaced registry before search has not been well considered in cargo and I have to add a function to trait `core::source::Source` to get the replaced `SourceId`. 

I am not sure whether this is a good design, any advice is welcome.

