### PR TITLE
remove all 4 RC clones in min_candidates. allowing it to be inlined

### DIFF
--- a/src/cargo/core/resolver/types.rs
+++ b/src/cargo/core/resolver/types.rs
@@ -3,8 +3,8 @@ use std::collections::{HashMap, HashSet};
 use std::ops::Range;
 use std::rc::Rc;
 
-use core::{Dependency, PackageId, PackageIdSpec, Registry, Summary};
 use core::interning::InternedString;
+use core::{Dependency, PackageId, PackageIdSpec, Registry, Summary};
 use util::{CargoError, CargoResult};
 
 pub struct RegistryQueryer<'a> {
@@ -200,13 +200,12 @@ impl DepsFrame {
     /// candidates in that entry.
     fn min_candidates(&self) -> usize {
         self.remaining_siblings
-            .clone()
-            .next()
+            .peek()
             .map(|(_, (_, candidates, _))| candidates.len())
             .unwrap_or(0)
     }
 
-    pub fn flatten<'s>(&'s self) -> impl Iterator<Item=(&PackageId, Dependency)> + 's {
+    pub fn flatten<'s>(&'s self) -> impl Iterator<Item = (&PackageId, Dependency)> + 's {
         self.remaining_siblings
             .clone()
             .map(move |(_, (d, _, _))| (self.parent.package_id(), d))
@@ -315,6 +314,13 @@ impl<T> RcVecIter<T> {
             vec,
         }
     }
+
+    fn peek(&self) -> Option<(usize, &T)> {
+        self.rest
+            .clone()
+            .next()
+            .and_then(|i| self.vec.get(i).map(|val| (i, &*val)))
+    }
 }
 
 // Not derived to avoid `T: Clone`
@@ -333,7 +339,7 @@ where
 {
     type Item = (usize, T);
 
-    fn next(&mut self) -> Option<(usize, T)> {
+    fn next(&mut self) -> Option<Self::Item> {
         self.rest
             .next()
             .and_then(|i| self.vec.get(i).map(|val| (i, val.clone())))


### PR DESCRIPTION
So I was looking at a profile, and noted that `DepsFrame::min_candidates` was taking ~10% of the runtime. The odd part is that it should be a thin wrapper around `Vec::len()`, and so should be completely inlined away. Also it is the key for the `BinaryHeap` so it gets called a lot! Looking into it `remaining_siblings.clone()` clones the RC in the `RcVecIter` then `.next()` clones `T` witch is a `DepInfo` each part of which is an RC that needs to be cloned. All 4 of these RC clones can be removed, but it is apparently too much for the optimizer. So I added a 'peek' method that uses a normal reference to the inner value instead of an RC clone. After this `DepsFrame::min_candidates` does not appear in the profile results. Probably as the name is inlined away. But is the inlined code faster? 

before: 20000000 ticks, 104s, 192.308 ticks/ms
after:    20000000 ticks, 87s,   229.885 ticks/ms

So yes ~16% faster!

All profiling/benchmark was done by commenting out the code from #5213 so its test case would run for a long time. But this should improve the happy path as well.
