### PR TITLE
Cargo book: clarify that a maintenance of 'none' shows no badge on crates.io

### DIFF
--- a/src/doc/src/reference/manifest.md
+++ b/src/doc/src/reference/manifest.md
@@ -244,9 +244,9 @@ is-it-maintained-issue-resolution = { repository = "..." }
 # Is it maintained percentage of open issues: `repository` is required.
 is-it-maintained-open-issues = { repository = "..." }
 
-# Maintenance: `status` is required Available options are `actively-developed`,
-# `passively-maintained`, `as-is`, `none`, `experimental`, `looking-for-maintainer`
-# and `deprecated`.
+# Maintenance: `status` is required. Available options are `actively-developed`,
+# `passively-maintained`, `as-is`, `experimental`, `looking-for-maintainer`,
+# `deprecated`, and the default `none`, which displays no badge on crates.io.
 maintenance = { status = "..." }
 ```
 


### PR DESCRIPTION
I recently released a new version of [`bow`](https://crates.io/crates/bow), where I clarified that the crate will stop working in newer versions of Rust and that I have no intention of fixing it. Initially, I set the maintenance badge to "none" because I have no plans to maintain it, when I later realised that this means "no badge" and not "no maintenance," then released a new version with the badge set to "deprecated."

This seems like a reasonable enough mistake for someone to make, so, I've updated the docs for it.