### PR TITLE
Remove quote feature use

### DIFF
--- a/tests/testsuite/cross_compile.rs
+++ b/tests/testsuite/cross_compile.rs
@@ -227,7 +227,7 @@ fn plugin_deps() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(plugin_registrar, quote, rustc_private)]
+            #![feature(plugin_registrar, rustc_private)]
 
             extern crate rustc_plugin;
             extern crate syntax;
@@ -334,7 +334,7 @@ fn plugin_to_the_max() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(plugin_registrar, quote, rustc_private)]
+            #![feature(plugin_registrar, rustc_private)]
 
             extern crate rustc_plugin;
             extern crate syntax;


### PR DESCRIPTION
Quote is being removed see https://github.com/rust-lang/rust/issues/46849. Follow up of @Manishearth 's #4838 which removed usages of the feature so now we only have to remove `quote` from the `#![feature]` attrs.