### PR TITLE
Fix random errors in test compiler_json_error_format.

### DIFF
--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -3996,13 +3996,32 @@ fn compiler_json_error_format() {
         .file("bar/src/lib.rs", r#"fn dead() {}"#)
         .build();
 
+    // Using jobs=1 to ensure that the order of messages is consistent.
     assert_that(
-        p.cargo("build")
-            .arg("-v")
-            .arg("--message-format")
-            .arg("json"),
+        p.cargo("build -v --message-format=json --jobs=1"),
         execs().with_status(0).with_json(
             r#"
+    {
+        "reason":"compiler-artifact",
+        "package_id":"foo 0.5.0 ([..])",
+        "target":{
+            "kind":["custom-build"],
+            "crate_types":["bin"],
+            "name":"build-script-build",
+            "src_path":"[..]build.rs"
+        },
+        "profile": {
+            "debug_assertions": true,
+            "debuginfo": 2,
+            "opt_level": "0",
+            "overflow_checks": true,
+            "test": false
+        },
+        "features": [],
+        "filenames": "{...}",
+        "fresh": false
+    }
+
     {
         "reason":"compiler-message",
         "package_id":"bar 0.5.0 ([..])",
@@ -4033,27 +4052,6 @@ fn compiler_json_error_format() {
             "src_path":"[..]lib.rs"
         },
         "filenames":["[..].rlib"],
-        "fresh": false
-    }
-
-    {
-        "reason":"compiler-artifact",
-        "package_id":"foo 0.5.0 ([..])",
-        "target":{
-            "kind":["custom-build"],
-            "crate_types":["bin"],
-            "name":"build-script-build",
-            "src_path":"[..]build.rs"
-        },
-        "profile": {
-            "debug_assertions": true,
-            "debuginfo": 2,
-            "opt_level": "0",
-            "overflow_checks": true,
-            "test": false
-        },
-        "features": [],
-        "filenames": "{...}",
         "fresh": false
     }
 
@@ -4105,10 +4103,7 @@ fn compiler_json_error_format() {
     // With fresh build, we should repeat the artifacts,
     // but omit compiler warnings.
     assert_that(
-        p.cargo("build")
-            .arg("-v")
-            .arg("--message-format")
-            .arg("json"),
+        p.cargo("build -v --message-format=json --jobs=1"),
         execs().with_status(0).with_json(
             r#"
     {


### PR DESCRIPTION
The dependencies `bar` and the build script are built at the same time, so there is a race as to which outputs its message first.  

This tripped on stable (1.27) on MacOS on Travis twice on #5647 ([job 10419.2](https://travis-ci.org/rust-lang/cargo/jobs/395843646) and [job 10421.2](https://travis-ci.org/rust-lang/cargo/jobs/395925454))