### PR TITLE
Fix doctests linking too many libs.

### DIFF
--- a/src/cargo/core/compiler/compilation.rs
+++ b/src/cargo/core/compiler/compilation.rs
@@ -50,7 +50,9 @@ pub struct Compilation<'cfg> {
     /// be passed to future invocations of programs.
     pub extra_env: HashMap<PackageId, Vec<(String, String)>>,
 
-    pub to_doc_test: Vec<Package>,
+    /// Libraries to test with rustdoc.
+    /// The third value is the list of dependencies.
+    pub to_doc_test: Vec<(Package, Target, Vec<(Target, PathBuf)>)>,
 
     /// Features per package enabled during this compilation.
     pub cfgs: HashMap<PackageId, HashSet<String>>,

--- a/src/cargo/core/compiler/compilation.rs
+++ b/src/cargo/core/compiler/compilation.rs
@@ -9,10 +9,21 @@ use core::{Feature, Package, PackageId, Target, TargetKind};
 use util::{self, join_paths, process, CargoResult, Config, ProcessBuilder};
 use super::BuildContext;
 
+pub struct Doctest {
+    /// The package being doctested.
+    pub package: Package,
+    /// The target being tested (currently always the package's lib).
+    pub target: Target,
+    /// Extern dependencies needed by `rustdoc`. The path is the location of
+    /// the compiled lib.
+    pub deps: Vec<(Target, PathBuf)>,
+}
+
 /// A structure returning the result of a compilation.
 pub struct Compilation<'cfg> {
     /// A mapping from a package to the list of libraries that need to be
     /// linked when working with that package.
+    // TODO: deprecated, remove
     pub libraries: HashMap<PackageId, HashSet<(Target, PathBuf)>>,
 
     /// An array of all tests created during this compilation.
@@ -51,8 +62,7 @@ pub struct Compilation<'cfg> {
     pub extra_env: HashMap<PackageId, Vec<(String, String)>>,
 
     /// Libraries to test with rustdoc.
-    /// The third value is the list of dependencies.
-    pub to_doc_test: Vec<(Package, Target, Vec<(Target, PathBuf)>)>,
+    pub to_doc_test: Vec<Doctest>,
 
     /// Features per package enabled during this compilation.
     pub cfgs: HashMap<PackageId, HashSet<String>>,

--- a/src/cargo/core/compiler/context/unit_dependencies.rs
+++ b/src/cargo/core/compiler/context/unit_dependencies.rs
@@ -199,19 +199,11 @@ fn compute_deps_custom_build<'a, 'cfg>(
     // 1. Compiling the build script itself
     // 2. For each immediate dependency of our package which has a `links`
     //    key, the execution of that build script.
-    let not_custom_build = unit.pkg
-        .targets()
+    let deps = deps
         .iter()
-        .find(|t| !t.is_custom_build())
-        .unwrap();
-    let tmp = Unit {
-        pkg: unit.pkg,
-        target: not_custom_build,
-        profile: unit.profile,
-        kind: unit.kind,
-        mode: CompileMode::Build,
-    };
-    let deps = deps_of(&tmp, bcx, deps, ProfileFor::Any)?;
+        .find(|(key, _deps)| key.pkg == unit.pkg && !key.target.is_custom_build())
+        .expect("can't find package deps")
+        .1;
     Ok(deps.iter()
         .filter_map(|unit| {
             if !unit.target.linkable() || unit.pkg.manifest().links().is_none() {

--- a/src/cargo/core/compiler/job_queue.rs
+++ b/src/cargo/core/compiler/job_queue.rs
@@ -410,8 +410,6 @@ impl<'a> JobQueue<'a> {
     ) -> CargoResult<()> {
         if (self.compiled.contains(key.pkg) && !key.mode.is_doc())
             || (self.documented.contains(key.pkg) && key.mode.is_doc())
-            // Skip doctest, it is a dummy entry that is always fresh.
-            || key.mode == CompileMode::Doctest
         {
             return Ok(());
         }
@@ -421,8 +419,11 @@ impl<'a> JobQueue<'a> {
             // being a compiled package
             Dirty => {
                 if key.mode.is_doc() {
-                    self.documented.insert(key.pkg);
-                    config.shell().status("Documenting", key.pkg)?;
+                    // Skip Doctest
+                    if !key.mode.is_any_test() {
+                        self.documented.insert(key.pkg);
+                        config.shell().status("Documenting", key.pkg)?;
+                    }
                 } else {
                     self.compiled.insert(key.pkg);
                     if key.mode.is_check() {
@@ -432,11 +433,15 @@ impl<'a> JobQueue<'a> {
                     }
                 }
             }
-            Fresh if self.counts[key.pkg] == 0 => {
-                self.compiled.insert(key.pkg);
-                config.shell().verbose(|c| c.status("Fresh", key.pkg))?;
+            Fresh => {
+                // If doctest is last, only print "Fresh" if nothing has been printed.
+                if self.counts[key.pkg] == 0
+                    && !(key.mode == CompileMode::Doctest && self.compiled.contains(key.pkg))
+                {
+                    self.compiled.insert(key.pkg);
+                    config.shell().verbose(|c| c.status("Fresh", key.pkg))?;
+                }
             }
-            Fresh => {}
         }
         Ok(())
     }

--- a/src/cargo/core/compiler/job_queue.rs
+++ b/src/cargo/core/compiler/job_queue.rs
@@ -410,6 +410,8 @@ impl<'a> JobQueue<'a> {
     ) -> CargoResult<()> {
         if (self.compiled.contains(key.pkg) && !key.mode.is_doc())
             || (self.documented.contains(key.pkg) && key.mode.is_doc())
+            // Skip doctest, it is a dummy entry that is always fresh.
+            || key.mode == CompileMode::Doctest
         {
             return Ok(());
         }
@@ -419,11 +421,8 @@ impl<'a> JobQueue<'a> {
             // being a compiled package
             Dirty => {
                 if key.mode.is_doc() {
-                    // Skip Doctest
-                    if !key.mode.is_any_test() {
-                        self.documented.insert(key.pkg);
-                        config.shell().status("Documenting", key.pkg)?;
-                    }
+                    self.documented.insert(key.pkg);
+                    config.shell().status("Documenting", key.pkg)?;
                 } else {
                     self.compiled.insert(key.pkg);
                     if key.mode.is_check() {

--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -24,7 +24,7 @@ use self::output_depinfo::output_depinfo;
 
 pub use self::build_context::{BuildContext, FileFlavor, TargetConfig, TargetInfo};
 pub use self::build_config::{BuildConfig, CompileMode, MessageFormat};
-pub use self::compilation::Compilation;
+pub use self::compilation::{Compilation, Doctest};
 pub use self::context::{Context, Unit};
 pub use self::custom_build::{BuildMap, BuildOutput, BuildScripts};
 pub use self::layout::is_bad_artifact_name;

--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -280,7 +280,7 @@ pub fn compile_ws<'a>(
         extra_compiler_args = Some((units[0], args));
     }
 
-    let mut ret = {
+    let ret = {
         let _p = profile::start("compiling");
         let bcx = BuildContext::new(
             ws,
@@ -294,8 +294,6 @@ pub fn compile_ws<'a>(
         let mut cx = Context::new(config, &bcx)?;
         cx.compile(&units, export_dir.clone(), &exec)?
     };
-
-    ret.to_doc_test = to_builds.into_iter().cloned().collect();
 
     return Ok(ret);
 }
@@ -541,9 +539,9 @@ fn generate_targets<'a>(
                     .collect::<Vec<_>>();
                 proposals.extend(default_units);
                 if build_config.mode == CompileMode::Test {
-                    // Include the lib as it will be required for doctests.
+                    // Include doctest for lib.
                     if let Some(t) = pkg.targets().iter().find(|t| t.is_lib() && t.doctested()) {
-                        proposals.push((new_unit(pkg, t, CompileMode::Build), false));
+                        proposals.push((new_unit(pkg, t, CompileMode::Doctest), false));
                     }
                 }
             }
@@ -681,15 +679,7 @@ fn generate_default_targets(targets: &[Target], mode: CompileMode) -> Vec<&Targe
                 })
                 .collect()
         }
-        CompileMode::Doctest => {
-            // `test --doc``
-            targets
-                .iter()
-                .find(|t| t.is_lib() && t.doctested())
-                .into_iter()
-                .collect()
-        }
-        CompileMode::RunCustomBuild => panic!("Invalid mode"),
+        CompileMode::Doctest | CompileMode::RunCustomBuild => panic!("Invalid mode {:?}", mode),
     }
 }
 

--- a/src/cargo/ops/cargo_test.rs
+++ b/src/cargo/ops/cargo_test.rs
@@ -154,86 +154,72 @@ fn run_doc_tests(
         return Ok((Test::Doc, errors));
     }
 
-    let libs = compilation.to_doc_test.iter().map(|package| {
-        (
-            package,
-            package
-                .targets()
-                .iter()
-                .filter(|t| t.doctested())
-                .map(|t| (t.src_path(), t.name(), t.crate_name())),
-        )
-    });
+    for (package, target, deps) in &compilation.to_doc_test {
+        config.shell().status("Doc-tests", target.name())?;
+        let mut p = compilation.rustdoc_process(package)?;
+        p.arg("--test")
+            .arg(target.src_path())
+            .arg("--crate-name")
+            .arg(&target.crate_name());
 
-    for (package, tests) in libs {
-        for (lib, name, crate_name) in tests {
-            config.shell().status("Doc-tests", name)?;
-            let mut p = compilation.rustdoc_process(package)?;
-            p.arg("--test")
-                .arg(lib)
-                .arg("--crate-name")
-                .arg(&crate_name);
+        for &rust_dep in &[&compilation.deps_output] {
+            let mut arg = OsString::from("dependency=");
+            arg.push(rust_dep);
+            p.arg("-L").arg(arg);
+        }
 
-            for &rust_dep in &[&compilation.deps_output] {
-                let mut arg = OsString::from("dependency=");
-                arg.push(rust_dep);
-                p.arg("-L").arg(arg);
+        for native_dep in compilation.native_dirs.iter() {
+            p.arg("-L").arg(native_dep);
+        }
+
+        for &host_rust_dep in &[&compilation.host_deps_output] {
+            let mut arg = OsString::from("dependency=");
+            arg.push(host_rust_dep);
+            p.arg("-L").arg(arg);
+        }
+
+        for arg in test_args {
+            p.arg("--test-args").arg(arg);
+        }
+
+        if let Some(cfgs) = compilation.cfgs.get(package.package_id()) {
+            for cfg in cfgs.iter() {
+                p.arg("--cfg").arg(cfg);
             }
+        }
 
-            for native_dep in compilation.native_dirs.iter() {
-                p.arg("-L").arg(native_dep);
+        for &(ref target, ref lib) in deps.iter() {
+            // Note that we can *only* doctest rlib outputs here.  A
+            // staticlib output cannot be linked by the compiler (it just
+            // doesn't do that). A dylib output, however, can be linked by
+            // the compiler, but will always fail. Currently all dylibs are
+            // built as "static dylibs" where the standard library is
+            // statically linked into the dylib. The doc tests fail,
+            // however, for now as they try to link the standard library
+            // dynamically as well, causing problems. As a result we only
+            // pass `--extern` for rlib deps and skip out on all other
+            // artifacts.
+            if lib.extension() != Some(OsStr::new("rlib")) && !target.for_host() {
+                continue;
             }
+            let mut arg = OsString::from(target.crate_name());
+            arg.push("=");
+            arg.push(lib);
+            p.arg("--extern").arg(&arg);
+        }
 
-            for &host_rust_dep in &[&compilation.host_deps_output] {
-                let mut arg = OsString::from("dependency=");
-                arg.push(host_rust_dep);
-                p.arg("-L").arg(arg);
-            }
+        if let Some(flags) = compilation.rustdocflags.get(package.package_id()) {
+            p.args(flags);
+        }
 
-            for arg in test_args {
-                p.arg("--test-args").arg(arg);
-            }
-
-            if let Some(cfgs) = compilation.cfgs.get(package.package_id()) {
-                for cfg in cfgs.iter() {
-                    p.arg("--cfg").arg(cfg);
-                }
-            }
-
-            let libs = &compilation.libraries[package.package_id()];
-            for &(ref target, ref lib) in libs.iter() {
-                // Note that we can *only* doctest rlib outputs here.  A
-                // staticlib output cannot be linked by the compiler (it just
-                // doesn't do that). A dylib output, however, can be linked by
-                // the compiler, but will always fail. Currently all dylibs are
-                // built as "static dylibs" where the standard library is
-                // statically linked into the dylib. The doc tests fail,
-                // however, for now as they try to link the standard library
-                // dynamically as well, causing problems. As a result we only
-                // pass `--extern` for rlib deps and skip out on all other
-                // artifacts.
-                if lib.extension() != Some(OsStr::new("rlib")) && !target.for_host() {
-                    continue;
-                }
-                let mut arg = OsString::from(target.crate_name());
-                arg.push("=");
-                arg.push(lib);
-                p.arg("--extern").arg(&arg);
-            }
-
-            if let Some(flags) = compilation.rustdocflags.get(package.package_id()) {
-                p.args(flags);
-            }
-
-            config
-                .shell()
-                .verbose(|shell| shell.status("Running", p.to_string()))?;
-            if let Err(e) = p.exec() {
-                let e = e.downcast::<ProcessError>()?;
-                errors.push(e);
-                if !options.no_fail_fast {
-                    return Ok((Test::Doc, errors));
-                }
+        config
+            .shell()
+            .verbose(|shell| shell.status("Running", p.to_string()))?;
+        if let Err(e) = p.exec() {
+            let e = e.downcast::<ProcessError>()?;
+            errors.push(e);
+            if !options.no_fail_fast {
+                return Ok((Test::Doc, errors));
             }
         }
     }

--- a/tests/testsuite/build_script.rs
+++ b/tests/testsuite/build_script.rs
@@ -3044,6 +3044,7 @@ fn panic_abort_with_build_scripts() {
             "src/lib.rs",
             "#[allow(unused_extern_crates)] extern crate a;",
         )
+        .file("build.rs","fn main() {}")
         .file(
             "a/Cargo.toml",
             r#"
@@ -3077,6 +3078,11 @@ fn panic_abort_with_build_scripts() {
     assert_that(
         p.cargo("build").arg("-v").arg("--release"),
         execs().with_status(0),
+    );
+
+    assert_that(
+        p.cargo("test --release"),
+        execs().with_status(0)
     );
 }
 


### PR DESCRIPTION
Fixes #5650.  cc #5435

As part of my recent work on profiles, I introduced some situations where a
library can be compiled multiple times with different settings.  Doctests were
greedily grabbing all dependencies for a package, regardless of which target
is was for.  This can cause doctests to fail if it links multiple copies of
the same library.

One way to trigger this is `cargo test --release` if you have dependencies, a
build script, and `panic="abort"`.  There are other (more obscure) ways to
trigger it with profile overrides.