### PR TITLE
skip test if not nightly; fix for #5648

### DIFF
--- a/src/bin/cargo/main.rs
+++ b/src/bin/cargo/main.rs
@@ -25,6 +25,7 @@ mod commands;
 
 fn main() {
     env_logger::init();
+    cargo::core::maybe_allow_nightly_features();
 
     let mut config = match Config::default() {
         Ok(cfg) => cfg,

--- a/src/cargo/core/mod.rs
+++ b/src/cargo/core/mod.rs
@@ -1,5 +1,6 @@
 pub use self::dependency::Dependency;
 pub use self::features::{CliUnstable, Edition, Feature, Features};
+pub use self::features::{maybe_allow_nightly_features, enable_nightly_features};
 pub use self::manifest::{EitherManifest, VirtualManifest};
 pub use self::manifest::{LibKind, Manifest, Target, TargetKind};
 pub use self::package::{Package, PackageSet};

--- a/tests/testsuite/config.rs
+++ b/tests/testsuite/config.rs
@@ -1,4 +1,4 @@
-use cargo::core::Shell;
+use cargo::core::{Shell, enable_nightly_features};
 use cargo::util::config::{self, Config};
 use cargo::util::toml::{self, VecStringOrBool as VSOB};
 use cargo::CargoError;
@@ -45,6 +45,7 @@ fn write_config(config: &str) {
 }
 
 fn new_config(env: &[(&str, &str)]) -> Config {
+    enable_nightly_features(); // -Z advanced-env
     let output = Box::new(fs::File::create(paths::root().join("shell.out")).unwrap());
     let shell = Shell::from_write(output);
     let cwd = paths::root();

--- a/tests/testsuite/resolve.rs
+++ b/tests/testsuite/resolve.rs
@@ -4,7 +4,7 @@ use hamcrest::{assert_that, contains, is_not};
 
 use cargo::core::source::{GitReference, SourceId};
 use cargo::core::dependency::Kind::{self, Development};
-use cargo::core::{Dependency, PackageId, Registry, Summary};
+use cargo::core::{Dependency, PackageId, Registry, Summary, enable_nightly_features};
 use cargo::util::{CargoResult, Config, ToUrl};
 use cargo::core::resolver::{self, Method};
 
@@ -342,6 +342,7 @@ fn test_resolving_maximum_version_with_transitive_deps() {
 
 #[test]
 fn test_resolving_minimum_version_with_transitive_deps() {
+    enable_nightly_features(); // -Z minimal-versions
     // When the minimal-versions config option is specified then the lowest
     // possible version of a package should be selected. "util 1.0.0" can't be
     // selected because of the requirements of "bar", so the minimum version


### PR DESCRIPTION
closes #5648
The alternative was to use `set_var` to emulate `masquerade_as_nightly_cargo` but we worried that it would not get unset correctly. Although I think each test is its own process, so it should work.