### PR TITLE
Fix avoiding a rebuild when moving around a workspace

### DIFF
--- a/src/cargo/core/compiler/fingerprint.rs
+++ b/src/cargo/core/compiler/fingerprint.rs
@@ -96,9 +96,10 @@ pub fn prepare_target<'a, 'cfg>(
             if output.flavor == FileFlavor::DebugInfo {
                 continue;
             }
-            missing_outputs |= !output.path.exists();
-            if let Some(ref link_dst) = output.hardlink {
-                missing_outputs |= !link_dst.exists();
+            if !output.path.exists() {
+                info!("missing output path {:?}", output.path);
+                missing_outputs = true;
+                break
             }
         }
     }


### PR DESCRIPTION
There's a case where Cargo will recompile a project even if the fingerprint
looks like it's fresh, when some output files are missing. This was intended to
cover the case where an output file was deleted manually or otherwise messed
with. The check here was a bit too eager, however. It checked not only the
actual output destination of the compiler but *also* the location that we hard
link the output file up to.

Due to recent changes in #5460 we don't always create the hard links for path
dependencies in the top-level dir, and this meant that if the library were
compiled and then tested later on the test may recompile the original library by
accident.

The fix in this commit is to cease looking for the hardlink if it exists or not.
This way we only check for the presence of the output file itself and only
recompile if that file is missing. The reason for this is that we
unconditionally relink files into place whether it's fresh or not, so we'll
always recreate the hard link anyway if it's missing.

cc rust-lang/rust#51717