### PR TITLE
cbfct: Take 3

### DIFF
--- a/tests/testsuite/freshness.rs
+++ b/tests/testsuite/freshness.rs
@@ -522,7 +522,7 @@ fn changing_bin_features_caches_targets() {
     let foo_proc = |name: &str| {
         let src = p.bin("foo");
         let dst = p.bin(name);
-        fs::hard_link(&src, &dst).expect("Failed to link foo");
+        fs::rename(&src, &dst).expect("Failed to rename foo");
         p.process(dst)
     };
 


### PR DESCRIPTION
Third attempt to fix race condition in changing_bin_features_caches_targets.
Previous fix for linux re-broke Windows
(https://ci.appveyor.com/project/rust-lang-libs/cargo/build/1.0.5004)