### PR TITLE
Show "duplicates in lockfile" without --verbose

### DIFF
--- a/src/cargo/core/resolver/encode.rs
+++ b/src/cargo/core/resolver/encode.rs
@@ -54,10 +54,10 @@ impl EncodableResolve {
                 };
 
                 if !all_pkgs.insert(enc_id.clone()) {
-                    return Err(internal(format!(
+                    bail!(
                         "package `{}` is specified twice in the lockfile",
                         pkg.name
-                    )));
+                    );
                 }
                 let id = match pkg.source.as_ref().or_else(|| path_deps.get(&pkg.name)) {
                     // We failed to find a local package in the workspace.
@@ -82,11 +82,11 @@ impl EncodableResolve {
                     // no longer a member of the workspace.
                     Ok(None)
                 } else {
-                    Err(internal(format!(
+                    bail!(
                         "package `{}` is specified as a dependency, \
                          but is missing from the package list",
                         enc_id
-                    )))
+                    );
                 },
             }
         };

--- a/tests/testsuite/bad_config.rs
+++ b/tests/testsuite/bad_config.rs
@@ -365,7 +365,7 @@ fn duplicate_packages_in_cargo_lock() {
         .build();
 
     assert_that(
-        p.cargo("build").arg("--verbose"),
+        p.cargo("build"),
         execs().with_status(101).with_stderr(
             "\
 [ERROR] failed to parse lock file at: [..]
@@ -453,7 +453,7 @@ fn bad_dependency_in_lockfile() {
         .build();
 
     assert_that(
-        p.cargo("build").arg("--verbose"),
+        p.cargo("build"),
         execs().with_status(101).with_stderr(
             "\
 [ERROR] failed to parse lock file at: [..]


### PR DESCRIPTION
It is possible to get duplicate pacakges after a merge, so it make
sense to print a little bit more details by defaults than just
"failed to parse a lockfile".