### PR TITLE
Fix the shell_quoting test

### DIFF
--- a/tests/testsuite/main.rs
+++ b/tests/testsuite/main.rs
@@ -87,6 +87,7 @@ mod rustdocflags;
 mod rustdoc;
 mod rustflags;
 mod search;
+mod shell_quoting;
 mod small_fd_limits;
 mod test;
 mod tool_paths;

--- a/tests/testsuite/shell_quoting.rs
+++ b/tests/testsuite/shell_quoting.rs
@@ -6,7 +6,7 @@ use cargotest::support::{
     execs,
     project,
 };
-use hamcrest::assert_that
+use hamcrest::assert_that;
 
 #[test]
 fn features_are_quoted() {
@@ -32,12 +32,11 @@ fn features_are_quoted() {
         execs()
             .with_status(101)
             .with_stderr_contains(
-                r#"\
-[CHECKING] foo [..]
-[RUNNING] `rustc [..] --cfg 'feature="default"' --cfg 'feature="some_feature"' [..]`
-[ERROR] [..]
-process didn't exit successfully: `rustc [..] --cfg 'feature="default"' --cfg 'feature="some_feature"' [..]`
-"#
+                r#"[RUNNING] `rustc [..] --cfg 'feature="default"' --cfg 'feature="some_feature"' [..]`"#
+            ).with_stderr_contains(
+                r#"
+Caused by:
+  process didn't exit successfully: [..] --cfg 'feature="default"' --cfg 'feature="some_feature"' [..]"#
             )
     );
 }

--- a/tests/testsuite/shell_quoting.rs
+++ b/tests/testsuite/shell_quoting.rs
@@ -28,7 +28,8 @@ fn features_are_quoted() {
         .build();
 
     assert_that(
-        p.cargo("check -v"),
+        p.cargo("check -v")
+            .env("MSYSTEM", "1"),
         execs()
             .with_status(101)
             .with_stderr_contains(


### PR DESCRIPTION
r? @alexcrichton 

add-on to #5666 
- Added `mod shell_quoting;` to testsuite/main.rs, so it actually runs
- fixed bugs in the test