### PR TITLE
Display environment variables when showing the command being run

### DIFF
--- a/src/cargo/util/process_builder.rs
+++ b/src/cargo/util/process_builder.rs
@@ -30,7 +30,16 @@ pub struct ProcessBuilder {
 
 impl fmt::Display for ProcessBuilder {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "`{}", self.program.to_string_lossy())?;
+        write!(f, "`")?;
+
+        #[cfg(unix)]
+        for (key, val) in self.env.iter() {
+            if let Some(val) = val {
+                write!(f, "{}={} ", key, escape(val.to_string_lossy()))?;
+            }
+        }
+
+        write!(f, "{}", self.program.to_string_lossy())?;
 
         for arg in &self.args {
             write!(f, " {}", escape(arg.to_string_lossy()))?;


### PR DESCRIPTION
Even with #5666, when commands are shown in verbose output, there are still some cases where they can’t be run in the terminal. This is because the code is expecting certain environment variables that are provided by cargo. This PR updates the `Display` impl for `ProcessBuilder` to show the environment variables in front of the command (on unix), so that the command can be run. Example output:

![screen shot 2018-07-04 at 4 14 34 pm](https://user-images.githubusercontent.com/6751033/42293092-70ee2cc4-7fa5-11e8-96e2-d8559f227c98.png)

Note that for workspaces, you will still have to run the command from the workspace root.

I deliberately didn’t update any of the tests yet, because I want to see if this is desired. I also want to see if this can be done on windows, so hopefully someone with experience with that platform can comment.
