### PR TITLE
Make index lookup robust to _ vs -, but don't let the user get it wrong.

### DIFF
--- a/src/bin/cargo/main.rs
+++ b/src/bin/cargo/main.rs
@@ -113,12 +113,11 @@ fn find_closest(config: &Config, cmd: &str) -> Option<String> {
     let cmds = list_commands(config);
     // Only consider candidates with a lev_distance of 3 or less so we don't
     // suggest out-of-the-blue options.
-    let mut filtered = cmds.iter()
-        .map(|&(ref c, _)| (lev_distance(c, cmd), c))
+    cmds.into_iter()
+        .map(|(c, _)| (lev_distance(&c, cmd), c))
         .filter(|&(d, _)| d < 4)
-        .collect::<Vec<_>>();
-    filtered.sort_by(|a, b| a.0.cmp(&b.0));
-    filtered.get(0).map(|slot| slot.1.clone())
+        .min_by_key(|a| a.0)
+        .map(|slot| slot.1)
 }
 
 fn execute_external_subcommand(config: &Config, cmd: &str, args: &[&str]) -> CliResult {

--- a/src/cargo/core/resolver/types.rs
+++ b/src/cargo/core/resolver/types.rs
@@ -52,7 +52,7 @@ impl<'a> RegistryQueryer<'a> {
                 summary: s,
                 replace: None,
             });
-        })?;
+        }, false)?;
         for candidate in ret.iter_mut() {
             let summary = &candidate.summary;
 
@@ -66,7 +66,7 @@ impl<'a> RegistryQueryer<'a> {
             };
             debug!("found an override for {} {}", dep.name(), dep.version_req());
 
-            let mut summaries = self.registry.query_vec(dep)?.into_iter();
+            let mut summaries = self.registry.query_vec(dep, false)?.into_iter();
             let s = summaries.next().ok_or_else(|| {
                 format_err!(
                     "no matching package for override `{}` found\n\

--- a/src/cargo/core/source/mod.rs
+++ b/src/cargo/core/source/mod.rs
@@ -25,6 +25,12 @@ pub trait Source {
     /// Attempt to find the packages that match a dependency request.
     fn query(&mut self, dep: &Dependency, f: &mut FnMut(Summary)) -> CargoResult<()>;
 
+    /// Attempt to find the packages that are close to a dependency request.
+    /// Each source gets to define what `close` means for it.
+    /// path/git sources may return all dependencies that are at that uri.
+    /// where as an Index source may return dependencies that have the same canonicalization.
+    fn fuzzy_query(&mut self, dep: &Dependency, f: &mut FnMut(Summary)) -> CargoResult<()>;
+
     fn query_vec(&mut self, dep: &Dependency) -> CargoResult<Vec<Summary>> {
         let mut ret = Vec::new();
         self.query(dep, &mut |s| ret.push(s))?;
@@ -77,6 +83,11 @@ impl<'a, T: Source + ?Sized + 'a> Source for Box<T> {
     /// Forwards to `Source::query`
     fn query(&mut self, dep: &Dependency, f: &mut FnMut(Summary)) -> CargoResult<()> {
         (**self).query(dep, f)
+    }
+
+    /// Forwards to `Source::query`
+    fn fuzzy_query(&mut self, dep: &Dependency, f: &mut FnMut(Summary)) -> CargoResult<()> {
+        (**self).fuzzy_query(dep, f)
     }
 
     /// Forwards to `Source::source_id`

--- a/src/cargo/sources/directory.rs
+++ b/src/cargo/sources/directory.rs
@@ -54,6 +54,14 @@ impl<'cfg> Source for DirectorySource<'cfg> {
         Ok(())
     }
 
+    fn fuzzy_query(&mut self, _dep: &Dependency, f: &mut FnMut(Summary)) -> CargoResult<()> {
+        let packages = self.packages.values().map(|p| &p.0);
+        for summary in packages.map(|pkg| pkg.summary().clone()) {
+            f(summary);
+        }
+        Ok(())
+    }
+
     fn supports_checksums(&self) -> bool {
         true
     }

--- a/src/cargo/sources/git/source.rs
+++ b/src/cargo/sources/git/source.rs
@@ -130,6 +130,13 @@ impl<'cfg> Source for GitSource<'cfg> {
         src.query(dep, f)
     }
 
+    fn fuzzy_query(&mut self, dep: &Dependency, f: &mut FnMut(Summary)) -> CargoResult<()> {
+        let src = self.path_source
+            .as_mut()
+            .expect("BUG: update() must be called before query()");
+        src.fuzzy_query(dep, f)
+    }
+
     fn supports_checksums(&self) -> bool {
         false
     }

--- a/src/cargo/sources/path.rs
+++ b/src/cargo/sources/path.rs
@@ -508,6 +508,13 @@ impl<'cfg> Source for PathSource<'cfg> {
         Ok(())
     }
 
+    fn fuzzy_query(&mut self, _dep: &Dependency, f: &mut FnMut(Summary)) -> CargoResult<()> {
+        for s in self.packages.iter().map(|p| p.summary()) {
+            f(s.clone())
+        }
+        Ok(())
+    }
+
     fn supports_checksums(&self) -> bool {
         false
     }

--- a/src/cargo/sources/registry/index.rs
+++ b/src/cargo/sources/registry/index.rs
@@ -208,7 +208,7 @@ impl<'cfg> RegistryIndex<'cfg> {
         Ok((summary, yanked.unwrap_or(false)))
     }
 
-    pub fn query(
+    pub fn query_inner(
         &mut self,
         dep: &Dependency,
         load: &mut RegistryData,
@@ -242,9 +242,7 @@ impl<'cfg> RegistryIndex<'cfg> {
         });
 
         for summary in summaries {
-            if dep.matches(&summary) {
-                f(summary);
-            }
+            f(summary);
         }
         Ok(())
     }

--- a/src/cargo/sources/registry/index.rs
+++ b/src/cargo/sources/registry/index.rs
@@ -66,6 +66,30 @@ impl<'s> Iterator for UncanonicalizedIter<'s> {
     }
 }
 
+#[test]
+fn no_hyphen() {
+    assert_eq!(
+        UncanonicalizedIter::new("test").collect::<Vec<_>>(),
+        vec!["test".to_string()]
+    )
+}
+
+#[test]
+fn two_hyphen() {
+    assert_eq!(
+        UncanonicalizedIter::new("te-_st").collect::<Vec<_>>(),
+        vec!["te-_st".to_string(), "te__st".to_string(), "te--st".to_string(), "te_-st".to_string()]
+    )
+}
+
+#[test]
+fn overflow_hyphen() {
+    assert_eq!(
+        UncanonicalizedIter::new("te-_-_-_-_-_-_-_-_-st").take(100).count(),
+        100
+    )
+}
+
 pub struct RegistryIndex<'cfg> {
     source_id: SourceId,
     path: Filesystem,

--- a/src/cargo/sources/registry/index.rs
+++ b/src/cargo/sources/registry/index.rs
@@ -115,13 +115,20 @@ impl<'cfg> RegistryIndex<'cfg> {
         // This loop tries all possible combinations of
         // hyphen and underscores to find the uncanonicalized one.
         for hyphen_combination_num in 0u16..(1 << num_hyphen_underscore) {
-            let path = raw_path.chars()
-                .scan(0u32, |s, c| if c == '_' || c == '-' {
-                    let out = Some(if (hyphen_combination_num & (1u16 << *s)) > 0 { '_' } else { '-' });
-                    *s += 1;
-                    out
-                } else {
-                    Some(c)
+            let path = raw_path
+                .chars()
+                .scan(0u32, |s, c| {
+                    if c == '_' || c == '-' {
+                        let out = Some(if (hyphen_combination_num & (1u16 << *s)) > 0 {
+                            '_'
+                        } else {
+                            '-'
+                        });
+                        *s += 1;
+                        out
+                    } else {
+                        Some(c)
+                    }
                 })
                 .collect::<String>();
             let mut hit_closure = false;

--- a/src/cargo/sources/replaced.rs
+++ b/src/cargo/sources/replaced.rs
@@ -35,6 +35,19 @@ impl<'cfg> Source for ReplacedSource<'cfg> {
         Ok(())
     }
 
+    fn fuzzy_query(&mut self, dep: &Dependency, f: &mut FnMut(Summary)) -> CargoResult<()> {
+        let (replace_with, to_replace) = (&self.replace_with, &self.to_replace);
+        let dep = dep.clone().map_source(to_replace, replace_with);
+
+        self.inner
+            .fuzzy_query(
+                &dep,
+                &mut |summary| f(summary.map_source(replace_with, to_replace)),
+            )
+            .chain_err(|| format!("failed to query replaced source {}", self.to_replace))?;
+        Ok(())
+    }
+
     fn supports_checksums(&self) -> bool {
         self.inner.supports_checksums()
     }

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -1020,6 +1020,7 @@ fn cargo_compile_with_dep_name_mismatch() {
         execs().with_status(101).with_stderr(&format!(
             r#"error: no matching package named `notquitebar` found
 location searched: {proj_dir}/bar
+did you mean: bar
 required by package `foo v0.0.1 ({proj_dir})`
 "#,
             proj_dir = p.url()

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -1020,7 +1020,6 @@ fn cargo_compile_with_dep_name_mismatch() {
         execs().with_status(101).with_stderr(&format!(
             r#"error: no matching package named `notquitebar` found
 location searched: {proj_dir}/bar
-did you mean: bar
 required by package `foo v0.0.1 ({proj_dir})`
 "#,
             proj_dir = p.url()

--- a/tests/testsuite/directory.rs
+++ b/tests/testsuite/directory.rs
@@ -230,6 +230,7 @@ error: failed to compile `bar v0.1.0`, intermediate artifacts can be found at `[
 Caused by:
   no matching package named `baz` found
 location searched: registry `https://github.com/rust-lang/crates.io-index`
+did you mean: bar or foo
 required by package `bar v0.1.0`
 ",
         ),

--- a/tests/testsuite/directory.rs
+++ b/tests/testsuite/directory.rs
@@ -230,7 +230,7 @@ error: failed to compile `bar v0.1.0`, intermediate artifacts can be found at `[
 Caused by:
   no matching package named `baz` found
 location searched: registry `https://github.com/rust-lang/crates.io-index`
-did you mean: bar or foo
+did you mean: bar, foo
 required by package `bar v0.1.0`
 ",
         ),

--- a/tests/testsuite/path.rs
+++ b/tests/testsuite/path.rs
@@ -1239,6 +1239,7 @@ fn invalid_path_dep_in_workspace_with_lockfile() {
             "\
 error: no matching package named `bar` found
 location searched: [..]
+did you mean: foo
 required by package `foo v0.5.0 ([..])`
 ",
         ),

--- a/tests/testsuite/registry.rs
+++ b/tests/testsuite/registry.rs
@@ -161,7 +161,7 @@ fn wrong_case() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    // TODO: #5678 to make this work or fleas give better error message
+    // TODO: #5678 to make this work or at least give better error message
     assert_that(
         p.cargo("build"),
         execs().with_status(101).with_stderr(
@@ -195,7 +195,7 @@ fn mis_hyphenated() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    // TODO: #2775 to make this work or fleas give better error message
+    // TODO: #2775 to make this work or at least give better error message
     assert_that(
         p.cargo("build"),
         execs().with_status(101).with_stderr(

--- a/tests/testsuite/registry.rs
+++ b/tests/testsuite/registry.rs
@@ -161,7 +161,7 @@ fn wrong_case() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    // TODO: #5678 to make this work or at least give better error message
+    // #5678 to make this work
     assert_that(
         p.cargo("build"),
         execs().with_status(101).with_stderr(
@@ -169,6 +169,7 @@ fn wrong_case() {
 [UPDATING] registry [..]
 error: no matching package named `Init` found
 location searched: registry [..]
+did you mean: init
 required by package `foo v0.0.1 ([..])`
 ",
         ),
@@ -195,7 +196,7 @@ fn mis_hyphenated() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    // TODO: #2775 to make this work or at least give better error message
+    // #2775 to make this work
     assert_that(
         p.cargo("build"),
         execs().with_status(101).with_stderr(
@@ -203,6 +204,7 @@ fn mis_hyphenated() {
 [UPDATING] registry [..]
 error: no matching package named `mis_hyphenated` found
 location searched: registry [..]
+did you mean: mis-hyphenated
 required by package `foo v0.0.1 ([..])`
 ",
         ),

--- a/tests/testsuite/registry.rs
+++ b/tests/testsuite/registry.rs
@@ -142,6 +142,74 @@ required by package `foo v0.0.1 ([..])`
 }
 
 #[test]
+fn wrong_case() {
+    Package::new("init", "0.0.1").publish();
+
+    let p = project("foo")
+        .file(
+            "Cargo.toml",
+            r#"
+            [project]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+
+            [dependencies]
+            Init = ">= 0.0.0"
+        "#,
+        )
+        .file("src/main.rs", "fn main() {}")
+        .build();
+
+    // TODO: #5678 to make this work or fleas give better error message
+    assert_that(
+        p.cargo("build"),
+        execs().with_status(101).with_stderr(
+            "\
+[UPDATING] registry [..]
+error: no matching package named `Init` found
+location searched: registry [..]
+required by package `foo v0.0.1 ([..])`
+",
+        ),
+    );
+}
+
+#[test]
+fn mis_hyphenated() {
+    Package::new("mis-hyphenated", "0.0.1").publish();
+
+    let p = project("foo")
+        .file(
+            "Cargo.toml",
+            r#"
+            [project]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+
+            [dependencies]
+            mis_hyphenated = ">= 0.0.0"
+        "#,
+        )
+        .file("src/main.rs", "fn main() {}")
+        .build();
+
+    // TODO: #2775 to make this work or fleas give better error message
+    assert_that(
+        p.cargo("build"),
+        execs().with_status(101).with_stderr(
+            "\
+[UPDATING] registry [..]
+error: no matching package named `mis_hyphenated` found
+location searched: registry [..]
+required by package `foo v0.0.1 ([..])`
+",
+        ),
+    );
+}
+
+#[test]
 fn wrong_version() {
     let p = project("foo")
         .file(

--- a/tests/testsuite/resolve.rs
+++ b/tests/testsuite/resolve.rs
@@ -441,6 +441,46 @@ fn resolving_incompat_versions() {
 }
 
 #[test]
+fn resolving_wrong_case_from_registry() {
+    // In the future we may #5678 allow this to happen.
+    // For back compatibility reasons, we probably won't.
+    // But we may want to future prove ourselves by understanding it.
+    // This test documents the current behavior.
+    let reg = registry(vec![
+        pkg!(("foo", "1.0.0")),
+        pkg!("bar" => ["Foo"]),
+    ]);
+
+    assert!(
+        resolve(
+            &pkg_id("root"),
+            vec![dep("bar")],
+            &reg
+        ).is_err()
+    );
+}
+
+#[test]
+fn resolving_mis_hyphenated_from_registry() {
+    // In the future we may #2775 allow this to happen.
+    // For back compatibility reasons, we probably won't.
+    // But we may want to future prove ourselves by understanding it.
+    // This test documents the current behavior.
+    let reg = registry(vec![
+        pkg!(("fo-o", "1.0.0")),
+        pkg!("bar" => ["fo_o"]),
+    ]);
+
+    assert!(
+        resolve(
+            &pkg_id("root"),
+            vec![dep("bar")],
+            &reg
+        ).is_err()
+    );
+}
+
+#[test]
 fn resolving_backtrack() {
     let reg = registry(vec![
         pkg!(("foo", "1.0.2") => [dep("bar")]),

--- a/tests/testsuite/resolve.rs
+++ b/tests/testsuite/resolve.rs
@@ -28,9 +28,9 @@ fn resolve_with_config(
 ) -> CargoResult<Vec<PackageId>> {
     struct MyRegistry<'a>(&'a [Summary]);
     impl<'a> Registry for MyRegistry<'a> {
-        fn query(&mut self, dep: &Dependency, f: &mut FnMut(Summary)) -> CargoResult<()> {
+        fn query(&mut self, dep: &Dependency, f: &mut FnMut(Summary), fuzzy: bool) -> CargoResult<()> {
             for summary in self.0.iter() {
-                if dep.matches(summary) {
+                if fuzzy || dep.matches(summary) {
                     f(summary.clone());
                 }
             }


### PR DESCRIPTION
This does a brute force search thru combinations of hyphen and underscores to allow queries of crates to pass the wrong one.

This is a small first step of fixing #2775

Where is best to add test?