### PR TITLE
Disable progress bar for build in Cargo

### DIFF
--- a/src/cargo/core/compiler/job_queue.rs
+++ b/src/cargo/core/compiler/job_queue.rs
@@ -180,8 +180,22 @@ impl<'a> JobQueue<'a> {
         // After a job has finished we update our internal state if it was
         // successful and otherwise wait for pending work to finish if it failed
         // and then immediately return.
+        //
+        // TODO: the progress bar should be re-enabled but unfortunately it's
+        //       difficult to do so right now due to how compiler error messages
+        //       work. Cargo doesn't redirect stdout/stderr of compiler
+        //       processes so errors are not captured, and Cargo doesn't know
+        //       when an error is being printed, meaning that a progress bar
+        //       will get jumbled up in the output! To reenable this progress
+        //       bar we'll need to probably capture the stderr of rustc and
+        //       capture compiler error messages, but that also means
+        //       reproducing rustc's styling of error messages which is
+        //       currently a pretty big task. This is issue #5695. Note that
+        //       when reenabling it'd also probably be good to fix #5697 while
+        //       we're at it.
         let mut error = None;
         let mut progress = Progress::with_style("Building", ProgressStyle::Ratio, cx.bcx.config);
+        progress.disable();
         let total = self.queue.len();
         loop {
             // Dequeue as much work as we can, learning about everything

--- a/src/cargo/util/progress.rs
+++ b/src/cargo/util/progress.rs
@@ -58,6 +58,10 @@ impl<'cfg> Progress<'cfg> {
         }
     }
 
+    pub fn disable(&mut self) {
+        self.state = None;
+    }
+
     pub fn new(name: &str, cfg: &'cfg Config) -> Progress<'cfg> {
         Self::with_style(name, ProgressStyle::Percentage, cfg)
     }


### PR DESCRIPTION
This is primarily blocked on #5695 which unfortunately doesn't have a great fix
today, so disable it for now while we try to work out a better solution.

Closes #5695
Closes #5697