### PR TITLE
implement default-run option to set default binary for cargo run

### DIFF
--- a/src/bin/cargo/commands/run.rs
+++ b/src/bin/cargo/commands/run.rs
@@ -40,9 +40,26 @@ pub fn exec(config: &mut Config, args: &ArgMatches) -> CliResult {
 
     let mut compile_opts = args.compile_options_for_single_package(config, CompileMode::Build)?;
     if !args.is_present("example") && !args.is_present("bin") {
-        compile_opts.filter = CompileFilter::Default {
-            required_features_filterable: false,
-        };
+        if let Some(default_run) = compile_opts.get_package(&ws)?
+            .and_then(|pkg| pkg.manifest().default_run())
+        {
+            compile_opts.filter = CompileFilter::new(
+                false,
+                vec![default_run.to_owned()],
+                false,
+                vec![],
+                false,
+                vec![],
+                false,
+                vec![],
+                false,
+                false,
+            );
+        } else {
+            compile_opts.filter = CompileFilter::Default {
+                required_features_filterable: false,
+            };
+        }
     };
     match ops::run(&ws, &compile_opts, &values(args, "args"))? {
         None => Ok(()),

--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -186,6 +186,9 @@ features! {
 
         // Separating the namespaces for features and dependencies
         [unstable] namespaced_features: bool,
+
+        // "default-run" manifest option,
+        [unstable] default_run: bool,
     }
 }
 

--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -43,6 +43,7 @@ pub struct Manifest {
     features: Features,
     edition: Edition,
     im_a_teapot: Option<bool>,
+    default_run: Option<String>,
 }
 
 /// When parsing `Cargo.toml`, some warnings should silenced
@@ -297,6 +298,7 @@ impl Manifest {
         features: Features,
         edition: Edition,
         im_a_teapot: Option<bool>,
+        default_run: Option<String>,
         original: Rc<TomlManifest>,
     ) -> Manifest {
         Manifest {
@@ -317,6 +319,7 @@ impl Manifest {
             edition,
             original,
             im_a_teapot,
+            default_run,
             publish_lockfile,
         }
     }
@@ -425,6 +428,10 @@ impl Manifest {
 
     pub fn custom_metadata(&self) -> Option<&toml::Value> {
         self.custom_metadata.as_ref()
+    }
+
+    pub fn default_run(&self) -> Option<&str> {
+        self.default_run.as_ref().map(|s| &s[..])
     }
 }
 

--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -410,6 +410,16 @@ impl Manifest {
                 })?;
         }
 
+        if self.default_run.is_some() {
+            self.features
+                .require(Feature::default_run())
+                .chain_err(|| {
+                    format_err!(
+                        "the `default-run` manifest key is unstable"
+                    )
+                })?;
+        }
+
         Ok(())
     }
 

--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -83,6 +83,24 @@ impl<'a> CompileOptions<'a> {
             export_dir: None,
         })
     }
+
+    // Returns the unique specified package, or None
+    pub fn get_package<'b>(&self, ws: &'b Workspace) -> CargoResult<Option<&'b Package>> {
+        Ok(match self.spec {
+            Packages::All | Packages::Default | Packages::OptOut(_) => {
+                None
+            }
+            Packages::Packages(ref xs) => match xs.len() {
+                0 => Some(ws.current()?),
+                1 => Some(ws.members()
+                    .find(|pkg| *pkg.name() == xs[0])
+                    .ok_or_else(|| {
+                        format_err!("package `{}` is not a member of the workspace", xs[0])
+                    })?),
+                _ => None,
+            },
+        })
+    }
 }
 
 #[derive(Clone, PartialEq, Eq, Debug)]

--- a/src/cargo/ops/cargo_run.rs
+++ b/src/cargo/ops/cargo_run.rs
@@ -32,8 +32,7 @@ pub fn run(
     if bins.is_empty() {
         if !options.filter.is_specific() {
             bail!("a bin target must be available for `cargo run`")
-        }
-        else {
+        } else {
             // this will be verified in cargo_compile
         }
     }
@@ -55,10 +54,10 @@ pub fn run(
         if !options.filter.is_specific() {
             let names: Vec<&str> = bins.into_iter().map(|bin| bin.0).collect();
             bail!(
-                "`cargo run` could not determine which binary to run; set `default-run` \
-                 in the manifest or use the `--bin` option to specify\navailable binaries: {}",
+                "`cargo run` requires that a project only have one \
+                 executable; use the `--bin` option to specify which one \
+                 to run\navailable binaries: {}",
                  names.join(", ")
-                
             )
         } else {
             bail!(

--- a/src/cargo/ops/cargo_run.rs
+++ b/src/cargo/ops/cargo_run.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use ops::{self, Packages};
+use ops;
 use util::{self, CargoResult, ProcessError};
 use core::{TargetKind, Workspace};
 
@@ -11,21 +11,11 @@ pub fn run(
 ) -> CargoResult<Option<ProcessError>> {
     let config = ws.config();
 
-    let pkg = match options.spec {
-        Packages::All | Packages::Default | Packages::OptOut(_) => {
-            unreachable!("cargo run supports single package only")
-        }
-        Packages::Packages(ref xs) => match xs.len() {
-            0 => ws.current()?,
-            1 => ws.members()
-                .find(|pkg| *pkg.name() == xs[0])
-                .ok_or_else(|| {
-                    format_err!("package `{}` is not a member of the workspace", xs[0])
-                })?,
-            _ => unreachable!("cargo run supports single package only"),
-        },
-    };
+    let pkg = options.get_package(ws)?
+        .unwrap_or_else(|| unreachable!("cargo run supports single package only"));
 
+    // We compute the `bins` here *just for diagnosis*.  The actual set of packages to be run
+    // is determined by the `ops::compile` call below.
     let bins: Vec<_> = pkg.manifest()
         .targets()
         .iter()
@@ -42,7 +32,8 @@ pub fn run(
     if bins.is_empty() {
         if !options.filter.is_specific() {
             bail!("a bin target must be available for `cargo run`")
-        } else {
+        }
+        else {
             // this will be verified in cargo_compile
         }
     }
@@ -64,9 +55,8 @@ pub fn run(
         if !options.filter.is_specific() {
             let names: Vec<&str> = bins.into_iter().map(|bin| bin.0).collect();
             bail!(
-                "`cargo run` requires that a project only have one \
-                 executable; use the `--bin` option to specify which one \
-                 to run\navailable binaries: {}", 
+                "`cargo run` could not determine which binary to run; set `default-run` \
+                 in the manifest or use the `--bin` option to specify\navailable binaries: {}",
                  names.join(", ")
                 
             )

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -586,6 +586,8 @@ pub struct TomlProject {
     autobenches: Option<bool>,
     #[serde(rename = "namespaced-features")]
     namespaced_features: Option<bool>,
+    #[serde(rename = "default-run")]
+    default_run: Option<String>,
 
     // package metadata
     description: Option<String>,
@@ -970,6 +972,7 @@ impl TomlManifest {
             features,
             edition,
             project.im_a_teapot,
+            project.default_run.clone(),
             Rc::clone(me),
         );
         if project.license_file.is_some() && project.license.is_some() {

--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -308,3 +308,15 @@ $ cargo +nightly build -Z compile-progress
    Compiling utf8-ranges v1.0.0
     Building [=======>                                                  ] 2/14: libc, regex, uc...
 ```
+
+### default-run
+* Original issue: [#2200](https://github.com/rust-lang/cargo/issues/2200)
+
+The `default-run` option in the `[project]` section of the manifest can be used
+to specify a default binary picked by `cargo run`. For example, when there is
+both `src/bin/a.rs` and `src/bin/b.rs`:
+
+```toml
+[project]
+default-run = "a"
+```

--- a/tests/testsuite/required_features.rs
+++ b/tests/testsuite/required_features.rs
@@ -1347,8 +1347,9 @@ fn run_default_multiple_required_features() {
     assert_that(
         p.cargo("run"),
         execs().with_status(101).with_stderr(
-            "error: `cargo run` could not determine which binary to run; set `default-run` \
-             in the manifest or use the `--bin` option to specify\navailable binaries: foo1, foo2",
+            "\
+             error: `cargo run` requires that a project only have one executable; \
+             use the `--bin` option to specify which one to run\navailable binaries: foo1, foo2",
         ),
     );
 }

--- a/tests/testsuite/required_features.rs
+++ b/tests/testsuite/required_features.rs
@@ -1347,9 +1347,8 @@ fn run_default_multiple_required_features() {
     assert_that(
         p.cargo("run"),
         execs().with_status(101).with_stderr(
-            "\
-             error: `cargo run` requires that a project only have one executable; \
-             use the `--bin` option to specify which one to run\navailable binaries: foo1, foo2",
+            "error: `cargo run` could not determine which binary to run; set `default-run` \
+             in the manifest or use the `--bin` option to specify\navailable binaries: foo1, foo2",
         ),
     );
 }

--- a/tests/testsuite/run.rs
+++ b/tests/testsuite/run.rs
@@ -277,8 +277,9 @@ fn too_many_bins() {
         p.cargo("run"),
         // Using [..] here because the order is not stable
         execs().with_status(101).with_stderr(
-            "[ERROR] `cargo run` could not determine which binary to run; set `default-run` \
-             in the manifest or use the `--bin` option to specify\navailable binaries: [..]\n",
+            "[ERROR] `cargo run` requires that a project only \
+             have one executable; use the `--bin` option \
+             to specify which one to run\navailable binaries: [..]\n",
         ),
     );
 }

--- a/tests/testsuite/run.rs
+++ b/tests/testsuite/run.rs
@@ -275,9 +275,10 @@ fn too_many_bins() {
 
     assert_that(
         p.cargo("run"),
+        // Using [..] here because the order is not stable
         execs().with_status(101).with_stderr(
             "[ERROR] `cargo run` could not determine which binary to run; set `default-run` \
-             in the manifest or use the `--bin` option to specify\navailable binaries: a, b\n",
+             in the manifest or use the `--bin` option to specify\navailable binaries: [..]\n",
         ),
     );
 }


### PR DESCRIPTION
The implementation is not pretty but as good as I could make it. The fact that all this logic in `cargo_run` is for diagnosis only and essentially just re-implements the filtering done elsewhere really threw me off.

Fixes #2200