### PR TITLE
Partially revert dep changes in #5651

### DIFF
--- a/tests/testsuite/build_script.rs
+++ b/tests/testsuite/build_script.rs
@@ -3080,9 +3080,11 @@ fn panic_abort_with_build_scripts() {
         execs().with_status(0),
     );
 
+    p.root().join("target").rm_rf();
+
     assert_that(
-        p.cargo("test --release"),
-        execs().with_status(0)
+        p.cargo("test --release -v"),
+        execs().with_status(0).with_stderr_does_not_contain("[..]panic[..]"),
     );
 }
 

--- a/tests/testsuite/test.rs
+++ b/tests/testsuite/test.rs
@@ -4138,3 +4138,28 @@ fn json_artifact_includes_test_flag() {
         ),
     );
 }
+
+#[test]
+fn test_build_script_links() {
+    let p = project("foo")
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                links = 'something'
+
+                [lib]
+                test = false
+            "#,
+        )
+        .file("build.rs", "fn main() {}")
+        .file("src/lib.rs", "")
+        .build();
+
+    assert_that(
+        p.cargo("test --no-run"),
+        execs().with_status(0),
+    );
+}


### PR DESCRIPTION
Some logic which was tweaked around the dependencies of build script targets was
tweaked slightly in a way that causes cargo to stack overflow by accientally
adding a dependency loop. This commit implements one of the strategies discussed
in #5711 to fix this situation.

The problem here is that when calculating the deps of a build script we need the
build scripts of *other* packages, but the exact profile is somewhat difficult
to guess at the moment we're generating our build script unit. To solve this the
dependencies towards other build scripts' executions is added in a different
pass after all other units have been assembled. At this point we should know for
sure that all build script executions are in the dependency graph, and we just
need to add a few more edges.

Closes #5708