### PR TITLE
Clarify FAQ about Cargo.lock for libraries

### DIFF
--- a/src/doc/src/faq.md
+++ b/src/doc/src/faq.md
@@ -120,8 +120,8 @@ recompiled for all users of the library.
 
 If a library ends up being used transitively by several dependencies, it’s
 likely that just a single copy of the library is desired (based on semver
-compatibility). If all libraries were to check in their `Cargo.lock`, then
-multiple copies of the library would be used, and perhaps even a version
+compatibility). If Cargo used all of the dependencies' `Cargo.lock` files,
+then multiple copies of the library could be used, and perhaps even a version
 conflict.
 
 In other words, libraries specify semver requirements for their dependencies but


### PR DESCRIPTION
The current wording in the FAQ implies that checking in a Cargo.lock for a library could cause version conflicts in consumers of the library, which is not true.

The text in the FAQ was based on [this comment][1] (emphasis mine):

> If each dependent library checked in a Cargo.lock, **and Cargo used it,** you would instead get multiple, duplicate copies of those dependencies

but it accidentally dropped the "and Cargo used it" requirement, which I think is the more important part.

[1]: https://github.com/rust-lang/cargo/pull/534#issuecomment-54776481