### PR TITLE
Replace remaining uses of `[project]` in documentation with `[package]`

### DIFF
--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -115,7 +115,7 @@ appropriate `cargo-features`:
 ```toml
 cargo-features = ["publish-lockfile"]
 
-[project]
+[package]
 ...
 publish-lockfile = true
 ```
@@ -263,7 +263,7 @@ for features and dependencies are separated. The effect of this is that, in the
 feature requirements, dependencies have to be prefixed with `crate:`. Like this:
 
 ```toml
-[project]
+[package]
 namespaced-features = true
 
 [features]


### PR DESCRIPTION
The `[project]` section is not currently referenced anywhere else in the documentation, so the use here confused me, and I spent a while trying to add it to a `Cargo.toml` that already had a `[package]`.

`[project]` seems to be a deprecated alias for `[package]`, which is documented, so let's swap it out.