### PR TITLE
Reintroduce the compile progress bar as an unstable feature (-Z compile-progress)

### DIFF
--- a/src/bin/cargo/cli.rs
+++ b/src/bin/cargo/cli.rs
@@ -22,6 +22,7 @@ Available unstable (nightly-only) flags:
     -Z offline          -- Offline mode that does not perform network requests
     -Z unstable-options -- Allow the usage of unstable options such as --registry
     -Z config-profile   -- Read profiles from .cargo/config files
+    -Z compile-progress -- Display a progress bar while compiling
 
 Run with 'cargo -Z [FLAG] [SUBCOMMAND]'"
         );

--- a/src/cargo/core/compiler/job_queue.rs
+++ b/src/cargo/core/compiler/job_queue.rs
@@ -195,7 +195,9 @@ impl<'a> JobQueue<'a> {
         //       we're at it.
         let mut error = None;
         let mut progress = Progress::with_style("Building", ProgressStyle::Ratio, cx.bcx.config);
-        progress.disable();
+        if !cx.bcx.config.cli_unstable().compile_progress {
+            progress.disable();
+        }
         let total = self.queue.len();
         loop {
             // Dequeue as much work as we can, learning about everything

--- a/src/cargo/core/compiler/job_queue.rs
+++ b/src/cargo/core/compiler/job_queue.rs
@@ -190,11 +190,10 @@ impl<'a> JobQueue<'a> {
         //       bar we'll need to probably capture the stderr of rustc and
         //       capture compiler error messages, but that also means
         //       reproducing rustc's styling of error messages which is
-        //       currently a pretty big task. This is issue #5695. Note that
-        //       when reenabling it'd also probably be good to fix #5697 while
-        //       we're at it.
+        //       currently a pretty big task. This is issue #5695.
         let mut error = None;
         let mut progress = Progress::with_style("Building", ProgressStyle::Ratio, cx.bcx.config);
+        let mut progress_maybe_changed = true; // avoid flickering due to build script
         if !cx.bcx.config.cli_unstable().compile_progress {
             progress.disable();
         }
@@ -242,14 +241,23 @@ impl<'a> JobQueue<'a> {
             // to the jobserver itself.
             tokens.truncate(self.active.len() - 1);
 
-            let count = total - self.queue.len();
-            let active_names = self.active.iter().map(|key| match key.mode {
-                CompileMode::Doc { .. } => format!("{}(doc)", key.pkg.name()),
-                _ => key.pkg.name().to_string(),
-            }).collect::<Vec<_>>();
-            drop(progress.tick_now(count, total, &format!(": {}", active_names.join(", "))));
+            if progress_maybe_changed {
+                let count = total - self.queue.len();
+                let active_names = self.active.iter().map(|key| match key.mode {
+                    CompileMode::Doc { .. } => format!("{}(doc)", key.pkg.name()),
+                    _ => key.pkg.name().to_string(),
+                }).collect::<Vec<_>>();
+                drop(progress.tick_now(count, total, &format!(": {}", active_names.join(", "))));
+            }
             let event = self.rx.recv().unwrap();
-            progress.clear();
+
+            progress_maybe_changed = match event {
+                Message::Stdout(_) | Message::Stderr(_) => cx.bcx.config.extra_verbose(),
+                _ => true,
+            };
+            if progress_maybe_changed {
+                progress.clear();
+            }
 
             match event {
                 Message::Run(cmd) => {

--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -311,6 +311,7 @@ pub struct CliUnstable {
     pub package_features: bool,
     pub advanced_env: bool,
     pub config_profile: bool,
+    pub compile_progress: bool,
 }
 
 impl CliUnstable {
@@ -347,6 +348,7 @@ impl CliUnstable {
             "package-features" => self.package_features = true,
             "advanced-env" => self.advanced_env = true,
             "config-profile" => self.config_profile = true,
+            "compile-progress" => self.compile_progress = true,
             _ => bail!("unknown `-Z` flag specified: {}", k),
         }
 

--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -292,3 +292,19 @@ Example:
 ```
 cargo +nightly build --build-plan -Z unstable-options
 ```
+
+### Compile progress
+* Tracking Issue: [rust-lang/cargo#2536](https://github.com/rust-lang/cargo/issues/2536)
+
+The `-Z compile-progress` flag enables a progress bar while compiling.
+
+```console
+$ cargo +nightly build -Z compile-progress
+   Compiling libc v0.2.41
+   Compiling void v1.0.2
+   Compiling lazy_static v1.0.1
+   Compiling regex v1.0.0
+   Compiling ucd-util v0.1.1
+   Compiling utf8-ranges v1.0.0
+    Building [=======>                                                  ] 2/14: libc, regex, uc...
+```


### PR DESCRIPTION
This allows us to test the feature on-demand to see if there's any other bugs besides #5695.

Also, fixed the flickering #5697 (this was caused by build script emitting Stdout/Stderr events).

