### PR TITLE
[WIP] Do not build library with --test when passing --lib

### DIFF
--- a/tests/testsuite/tool_paths.rs
+++ b/tests/testsuite/tool_paths.rs
@@ -240,13 +240,24 @@ fn custom_runner() {
     );
 
     assert_that(
+        p.cargo("run").args(&["--release", "--", "--param"]),
+        execs().with_stderr_contains(&format!(
+            "\
+[COMPILING] foo v0.0.1 ({url})
+[FINISHED] release [optimized] target(s) in [..]
+[RUNNING] `nonexistent-runner -r target[/]release[/]foo[EXE] --param`
+",
+            url = p.url()
+        )),
+    );
+
+    assert_that(
         p.cargo("bench")
             .args(&["--bench", "bench", "--verbose", "--", "--param"]),
         execs().with_stderr_contains(&format!(
             "\
 [COMPILING] foo v0.0.1 ({url})
-[RUNNING] `rustc [..]`
-[RUNNING] `rustc [..]`
+[RUNNING] `rustc [..] benches/bench.rs [..]`
 [FINISHED] release [optimized] target(s) in [..]
 [RUNNING] `nonexistent-runner -r [..][/]target[/]release[/]deps[/]bench-[..][EXE] --param --bench`
 ",


### PR DESCRIPTION
Cargo will build a library with --test even if it is configured as `test = false` in Cargo.toml when the `--lib` flag is passed.

This PR for now just adds the test as I'm not sure where to start on fixing this; suggestions are appreciated.

This is a problem for rustbuild for example since we have a `--no-doc` flag to avoid a dependency on building rustdoc, but because there's no way to communicate that to Cargo we pass `--lib` which leads to this unwanted dependency edge.