### PR TITLE
[WIP] Configure lints in Cargo.toml

### DIFF
--- a/src/cargo/core/compiler/compilation.rs
+++ b/src/cargo/core/compiler/compilation.rs
@@ -133,6 +133,17 @@ impl<'cfg> Compilation<'cfg> {
         if target.edition() != Edition::Edition2015 {
             p.arg(format!("--edition={}", target.edition()));
         }
+        if let Some(lints) = pkg.manifest().lints() {
+            if !lints.warn.is_empty() {
+                p.arg("-W").arg(lints.warn.join(","));
+            }
+            if !lints.allow.is_empty() {
+                p.arg("-A").arg(lints.allow.join(","));
+            }
+            if !lints.deny.is_empty() {
+                p.arg("-D").arg(lints.deny.join(","));
+            }
+        }
         Ok(p)
     }
 

--- a/src/cargo/core/compiler/compilation.rs
+++ b/src/cargo/core/compiler/compilation.rs
@@ -133,17 +133,6 @@ impl<'cfg> Compilation<'cfg> {
         if target.edition() != Edition::Edition2015 {
             p.arg(format!("--edition={}", target.edition()));
         }
-        if let Some(lints) = pkg.manifest().lints() {
-            if !lints.warn.is_empty() {
-                p.arg("-W").arg(lints.warn.join(","));
-            }
-            if !lints.allow.is_empty() {
-                p.arg("-A").arg(lints.allow.join(","));
-            }
-            if !lints.deny.is_empty() {
-                p.arg("-D").arg(lints.deny.join(","));
-            }
-        }
         Ok(p)
     }
 

--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -809,6 +809,8 @@ fn build_base_args<'a, 'cfg>(
         cmd.args(args);
     }
 
+    bcx.ws.lints().set_flags(cmd, unit.pkg.manifest().lints());
+
     // -C overflow-checks is implied by the setting of -C debug-assertions,
     // so we only need to provide -C overflow-checks if it differs from
     // the value of -C debug-assertions we would provide.

--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -809,7 +809,10 @@ fn build_base_args<'a, 'cfg>(
         cmd.args(args);
     }
 
-    bcx.ws.lints().set_flags(cmd, unit.pkg.manifest().lints());
+    unit.pkg.manifest().lints().set_flags(cmd);
+    if let Some(virtual_lints) = bcx.ws.virtual_lints() {
+        virtual_lints.set_flags(cmd);
+    }
 
     // -C overflow-checks is implied by the setting of -C debug-assertions,
     // so we only need to provide -C overflow-checks if it differs from

--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -809,9 +809,17 @@ fn build_base_args<'a, 'cfg>(
         cmd.args(args);
     }
 
-    unit.pkg.manifest().lints().set_flags(cmd);
-    if let Some(virtual_lints) = bcx.ws.virtual_lints() {
-        virtual_lints.set_flags(cmd);
+    let unit_cfg = bcx.cfg(unit.kind);
+    let features = bcx.resolve.features(unit.pkg.package_id());
+    if let Some(ref lints) = unit.pkg.manifest().lints() {
+        for ref lint_section in lints.iter() {
+            lint_section.set_lint_flags(unit_cfg, features, cmd);
+        }
+    }
+    if let Some(ref virtual_lints) = bcx.ws.virtual_lints() {
+        for ref lint_section in virtual_lints.iter() {
+            lint_section.set_lint_flags(unit_cfg, features, cmd);
+        }
     }
 
     // -C overflow-checks is implied by the setting of -C debug-assertions,

--- a/src/cargo/core/lints.rs
+++ b/src/cargo/core/lints.rs
@@ -8,6 +8,7 @@ enum LintKind {
     Allow,
     Warn,
     Deny,
+    Forbid,
 }
 
 #[derive(Clone, Debug)]
@@ -27,8 +28,9 @@ impl Lints {
                     "allow" => { lints.insert(lint_name.to_string(), LintKind::Allow); },
                     "warn" => { lints.insert(lint_name.to_string(), LintKind::Warn); },
                     "deny" => { lints.insert(lint_name.to_string(), LintKind::Deny); },
+                    "forbid" => { lints.insert(lint_name.to_string(), LintKind::Forbid); },
                     _ => warnings.push(format!(
-                        "invalid lint state for `{}` (expected `warn`, `allow` or `deny`)",
+                        "invalid lint state for `{}` (expected `warn`, `allow`, `deny` or `forbid`)",
                         lint_name
                     )),
                 }
@@ -59,6 +61,10 @@ impl Lints {
         let deny = get_kind(LintKind::Deny);
         if !deny.is_empty() {
             cmd.arg("-D").arg(deny);
+        }
+        let forbid = get_kind(LintKind::Forbid);
+        if !forbid.is_empty() {
+            cmd.arg("-F").arg(forbid);
         }
     }
 }

--- a/src/cargo/core/lints.rs
+++ b/src/cargo/core/lints.rs
@@ -1,0 +1,64 @@
+use std::collections::BTreeMap;
+use std::collections::HashMap;
+
+use util::{CargoResult, ProcessBuilder};
+
+#[derive(Clone, PartialEq, Debug)]
+enum LintKind {
+    Allow,
+    Warn,
+    Deny,
+}
+
+#[derive(Clone, Debug)]
+pub struct Lints {
+    lints: HashMap<String, LintKind>,
+}
+
+impl Lints {
+    pub fn new(
+        manifest_lints: Option<&BTreeMap<String, String>>,
+        warnings: &mut Vec<String>,
+    ) -> CargoResult<Lints> {
+        let mut lints = HashMap::new();
+        if let Some(lint_section) = manifest_lints {
+            for (lint_name, lint_state) in lint_section.iter() {
+                match lint_state.as_ref() {
+                    "allow" => { lints.insert(lint_name.to_string(), LintKind::Allow); },
+                    "warn" => { lints.insert(lint_name.to_string(), LintKind::Warn); },
+                    "deny" => { lints.insert(lint_name.to_string(), LintKind::Deny); },
+                    _ => warnings.push(format!(
+                        "invalid lint state for `{}` (expected `warn`, `allow` or `deny`)",
+                        lint_name
+                    )),
+                }
+            }
+        }
+        Ok(Lints { lints })
+    }
+
+    pub fn set_flags(&self, cmd: &mut ProcessBuilder, package_lints: &Lints) {
+        let get_kind = |kind: LintKind| {
+            self.lints.iter()
+                .filter(|l| *l.1 == kind)
+                .chain(package_lints.lints.iter()
+                    .filter(|l| *l.1 == kind && !self.lints.contains_key(l.0)))
+                .map(|l| l.0.to_string())
+                .collect::<Vec<String>>()
+                .join(",")
+        };
+
+        let allow = get_kind(LintKind::Allow);
+        if !allow.is_empty() {
+            cmd.arg("-A").arg(allow);
+        }
+        let warn = get_kind(LintKind::Warn);
+        if !warn.is_empty() {
+            cmd.arg("-W").arg(warn);
+        }
+        let deny = get_kind(LintKind::Deny);
+        if !deny.is_empty() {
+            cmd.arg("-D").arg(deny);
+        }
+    }
+}

--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -45,7 +45,7 @@ pub struct Manifest {
     original: Rc<TomlManifest>,
     features: Features,
     edition: Edition,
-    lints: Lints,
+    lints: Option<Vec<Lints>>,
     im_a_teapot: Option<bool>,
     default_run: Option<String>,
     metabuild: Option<Vec<String>>,
@@ -70,7 +70,7 @@ pub struct VirtualManifest {
     workspace: WorkspaceConfig,
     profiles: Profiles,
     warnings: Warnings,
-    lints: Lints,
+    lints: Option<Vec<Lints>>,
 }
 
 /// General metadata about a package which is just blindly uploaded to the
@@ -364,7 +364,7 @@ impl Manifest {
         workspace: WorkspaceConfig,
         features: Features,
         edition: Edition,
-        lints: Lints,
+        lints: Option<Vec<Lints>>,
         im_a_teapot: Option<bool>,
         default_run: Option<String>,
         original: Rc<TomlManifest>,
@@ -428,7 +428,7 @@ impl Manifest {
     pub fn warnings(&self) -> &Warnings {
         &self.warnings
     }
-    pub fn lints(&self) -> &Lints {
+    pub fn lints(&self) -> &Option<Vec<Lints>> {
         &self.lints
     }
     pub fn profiles(&self) -> &Profiles {
@@ -539,7 +539,7 @@ impl VirtualManifest {
         patch: HashMap<Url, Vec<Dependency>>,
         workspace: WorkspaceConfig,
         profiles: Profiles,
-        lints: Lints,
+        lints: Option<Vec<Lints>>,
     ) -> VirtualManifest {
         VirtualManifest {
             replace,
@@ -563,7 +563,7 @@ impl VirtualManifest {
         &self.workspace
     }
 
-    pub fn lints(&self) -> &Lints {
+    pub fn lints(&self) -> &Option<Vec<Lints>> {
         &self.lints
     }
 

--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -12,6 +12,7 @@ use toml;
 use url::Url;
 
 use core::interning::InternedString;
+use core::lints::Lints;
 use core::profiles::Profiles;
 use core::{Dependency, PackageId, PackageIdSpec, SourceId, Summary};
 use core::{Edition, Feature, Features, WorkspaceConfig};
@@ -44,17 +45,10 @@ pub struct Manifest {
     original: Rc<TomlManifest>,
     features: Features,
     edition: Edition,
-    lints: Option<Lints>,
+    lints: Lints,
     im_a_teapot: Option<bool>,
     default_run: Option<String>,
     metabuild: Option<Vec<String>>,
-}
-
-#[derive(Clone, Debug)]
-pub struct Lints {
-    pub warn: Vec<String>,
-    pub allow: Vec<String>,
-    pub deny: Vec<String>,
 }
 
 /// When parsing `Cargo.toml`, some warnings should silenced
@@ -76,6 +70,7 @@ pub struct VirtualManifest {
     workspace: WorkspaceConfig,
     profiles: Profiles,
     warnings: Warnings,
+    lints: Lints,
 }
 
 /// General metadata about a package which is just blindly uploaded to the
@@ -369,7 +364,7 @@ impl Manifest {
         workspace: WorkspaceConfig,
         features: Features,
         edition: Edition,
-        lints: Option<Lints>,
+        lints: Lints,
         im_a_teapot: Option<bool>,
         default_run: Option<String>,
         original: Rc<TomlManifest>,
@@ -433,6 +428,9 @@ impl Manifest {
     pub fn warnings(&self) -> &Warnings {
         &self.warnings
     }
+    pub fn lints(&self) -> &Lints {
+        &self.lints
+    }
     pub fn profiles(&self) -> &Profiles {
         &self.profiles
     }
@@ -461,10 +459,6 @@ impl Manifest {
 
     pub fn features(&self) -> &Features {
         &self.features
-    }
-
-    pub fn lints(&self) -> &Option<Lints> {
-        &self.lints
     }
 
     pub fn set_summary(&mut self, summary: Summary) {
@@ -545,6 +539,7 @@ impl VirtualManifest {
         patch: HashMap<Url, Vec<Dependency>>,
         workspace: WorkspaceConfig,
         profiles: Profiles,
+        lints: Lints,
     ) -> VirtualManifest {
         VirtualManifest {
             replace,
@@ -552,6 +547,7 @@ impl VirtualManifest {
             workspace,
             profiles,
             warnings: Warnings::new(),
+            lints,
         }
     }
 
@@ -565,6 +561,10 @@ impl VirtualManifest {
 
     pub fn workspace_config(&self) -> &WorkspaceConfig {
         &self.workspace
+    }
+
+    pub fn lints(&self) -> &Lints {
+        &self.lints
     }
 
     pub fn profiles(&self) -> &Profiles {

--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -44,9 +44,17 @@ pub struct Manifest {
     original: Rc<TomlManifest>,
     features: Features,
     edition: Edition,
+    lints: Option<Lints>,
     im_a_teapot: Option<bool>,
     default_run: Option<String>,
     metabuild: Option<Vec<String>>,
+}
+
+#[derive(Clone, Debug)]
+pub struct Lints {
+    pub warn: Vec<String>,
+    pub allow: Vec<String>,
+    pub deny: Vec<String>,
 }
 
 /// When parsing `Cargo.toml`, some warnings should silenced
@@ -361,6 +369,7 @@ impl Manifest {
         workspace: WorkspaceConfig,
         features: Features,
         edition: Edition,
+        lints: Option<Lints>,
         im_a_teapot: Option<bool>,
         default_run: Option<String>,
         original: Rc<TomlManifest>,
@@ -383,6 +392,7 @@ impl Manifest {
             features,
             edition,
             original,
+            lints,
             im_a_teapot,
             default_run,
             publish_lockfile,
@@ -451,6 +461,10 @@ impl Manifest {
 
     pub fn features(&self) -> &Features {
         &self.features
+    }
+
+    pub fn lints(&self) -> &Option<Lints> {
+        &self.lints
     }
 
     pub fn set_summary(&mut self, summary: Summary) {

--- a/src/cargo/core/mod.rs
+++ b/src/cargo/core/mod.rs
@@ -21,6 +21,7 @@ pub mod compiler;
 pub mod dependency;
 mod features;
 mod interning;
+pub mod lints;
 pub mod manifest;
 pub mod package;
 pub mod package_id;

--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -246,13 +246,13 @@ impl<'cfg> Workspace<'cfg> {
         }
     }
 
-    pub fn lints(&self) -> &Lints {
+    pub fn virtual_lints(&self) -> Option<&Lints> {
         let root = self.root_manifest
             .as_ref()
             .unwrap_or(&self.current_manifest);
         match *self.packages.get(root) {
-            MaybePackage::Package(ref p) => p.manifest().lints(),
-            MaybePackage::Virtual(ref vm) => vm.lints(),
+            MaybePackage::Virtual(ref vm) => Some(vm.lints()),
+            _ => None,
         }
     }
 

--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -7,6 +7,7 @@ use std::slice;
 use glob::glob;
 use url::Url;
 
+use core::lints::Lints;
 use core::profiles::Profiles;
 use core::registry::PackageRegistry;
 use core::{Dependency, PackageIdSpec};
@@ -242,6 +243,16 @@ impl<'cfg> Workspace<'cfg> {
         match *self.packages.get(root) {
             MaybePackage::Package(ref p) => p.manifest().profiles(),
             MaybePackage::Virtual(ref vm) => vm.profiles(),
+        }
+    }
+
+    pub fn lints(&self) -> &Lints {
+        let root = self.root_manifest
+            .as_ref()
+            .unwrap_or(&self.current_manifest);
+        match *self.packages.get(root) {
+            MaybePackage::Package(ref p) => p.manifest().lints(),
+            MaybePackage::Virtual(ref vm) => vm.lints(),
         }
     }
 

--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -246,13 +246,13 @@ impl<'cfg> Workspace<'cfg> {
         }
     }
 
-    pub fn virtual_lints(&self) -> Option<&Lints> {
+    pub fn virtual_lints(&self) -> &Option<Vec<Lints>> {
         let root = self.root_manifest
             .as_ref()
             .unwrap_or(&self.current_manifest);
         match *self.packages.get(root) {
-            MaybePackage::Virtual(ref vm) => Some(vm.lints()),
-            _ => None,
+            MaybePackage::Virtual(ref vm) => vm.lints(),
+            _ => &None,
         }
     }
 

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -1021,13 +1021,20 @@ impl TomlManifest {
         };
 
         let lints = me.lints.as_ref().map(|ref ls| {
-            let mut lints = Lints { warn: vec![], allow: vec![], deny: vec![] };
+            let mut lints = Lints {
+                warn: vec![],
+                allow: vec![],
+                deny: vec![],
+            };
             for (lint_name, lint_state) in ls.iter() {
                 match lint_state.as_ref() {
                     "warn" => lints.warn.push(lint_name.to_string()),
                     "allow" => lints.allow.push(lint_name.to_string()),
                     "deny" => lints.deny.push(lint_name.to_string()),
-                    _ => continue, // TODO error here?
+                    _ => warnings.push(format!(
+                        "invalid lint state for `{}` (expected `warn`, `allow` or `deny`)",
+                        lint_name
+                    )),
                 }
             }
             lints

--- a/tests/testsuite/lints.rs
+++ b/tests/testsuite/lints.rs
@@ -1,0 +1,28 @@
+use cargotest::support::{execs, project};
+use hamcrest::assert_that;
+
+#[test]
+fn deny() {
+    let p = project("foo")
+        .file(
+            "Cargo.toml",
+            r#"
+            [project]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+
+            [lints]
+            dead_code = "deny"
+        "#,
+        )
+        .file("src/lib.rs", "fn foo() {}")
+        .build();
+
+    assert_that(
+        p.cargo("build"),
+        execs()
+            .with_status(101)
+            .with_stderr_contains("[..]error: function is never used: `foo`[..]"),
+    );
+}

--- a/tests/testsuite/lints.rs
+++ b/tests/testsuite/lints.rs
@@ -26,3 +26,50 @@ fn deny() {
             .with_stderr_contains("[..]error: function is never used: `foo`[..]"),
     );
 }
+
+#[test]
+fn empty_lints_block() {
+    let p = project("foo")
+        .file(
+            "Cargo.toml",
+            r#"
+            [project]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+
+            [lints]
+        "#,
+        )
+        .file("src/lib.rs", "fn foo() {}")
+        .build();
+
+    assert_that(
+        p.cargo("build"),
+        execs().with_status(0),
+    );
+}
+
+#[test]
+fn invalid_state() {
+    let p = project("foo")
+        .file(
+            "Cargo.toml",
+            r#"
+            [project]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+
+            [lints]
+            non_snake_case = "something something"
+        "#,
+        )
+        .file("src/lib.rs", "fn foo() {}")
+        .build();
+
+    assert_that(
+        p.cargo("build"),
+        execs().with_status(0),
+    );
+}

--- a/tests/testsuite/lints.rs
+++ b/tests/testsuite/lints.rs
@@ -1,5 +1,4 @@
-use support::{execs, project};
-use support::hamcrest::assert_that;
+use support::project;
 
 #[test]
 fn deny() {
@@ -19,12 +18,10 @@ fn deny() {
         .file("src/lib.rs", "fn foo() {}")
         .build();
 
-    assert_that(
-        p.cargo("build"),
-        execs()
-            .with_status(101)
-            .with_stderr_contains("[..]error: function is never used: `foo`[..]"),
-    );
+    p.cargo("build")
+        .with_status(101)
+        .with_stderr_contains("[..]error: function is never used: `foo`[..]")
+        .run();
 }
 
 #[test]
@@ -44,10 +41,7 @@ fn empty_lints_block() {
         .file("src/lib.rs", "fn foo() {}")
         .build();
 
-    assert_that(
-        p.cargo("build"),
-        execs().with_status(0),
-    );
+    p.cargo("build").with_status(0).run();
 }
 
 #[test]
@@ -68,10 +62,7 @@ fn invalid_state() {
         .file("src/lib.rs", "fn foo() {}")
         .build();
 
-    assert_that(
-        p.cargo("build"),
-        execs().with_status(0),
-    );
+    p.cargo("build").with_status(0).run();
 }
 
 #[test]
@@ -99,12 +90,10 @@ fn virtual_workspace() {
         .file("bar/src/lib.rs", "fn baz() {}")
         .build();
 
-    assert_that(
-        p.cargo("build"),
-        execs()
-            .with_status(101)
-            .with_stderr_contains("[..]error: function is never used: `baz`[..]"),
-    );
+    p.cargo("build")
+        .with_status(101)
+        .with_stderr_contains("[..]error: function is never used: `baz`[..]")
+        .run();
 }
 
 #[test]
@@ -132,12 +121,10 @@ fn member_workspace() {
         .file("bar/src/lib.rs", "fn baz() {}")
         .build();
 
-    assert_that(
-        p.cargo("build"),
-        execs()
-            .with_status(101)
-            .with_stderr_contains("[..]error: function is never used: `baz`[..]"),
-    );
+    p.cargo("build")
+        .with_status(101)
+        .with_stderr_contains("[..]error: function is never used: `baz`[..]")
+        .run();
 }
 
 #[test]
@@ -168,10 +155,36 @@ fn virtual_workspace_overrides() {
         .file("bar/src/lib.rs", "fn baz() {}")
         .build();
 
-    assert_that(
-        p.cargo("build"),
-        execs()
-            .with_status(101)
-            .with_stderr_contains("[..]error: function is never used: `baz`[..]"),
-    );
+    p.cargo("build")
+        .with_status(101)
+        .with_stderr_contains("[..]error: function is never used: `baz`[..]")
+        .run();
+}
+
+#[test]
+fn feature_flag() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+
+            [features]
+            bar = []
+
+            [lints2.'cfg(feature = "bar")']
+            dead_code = "deny"
+        "#,
+        )
+        .file("src/lib.rs", "fn foo() {}")
+        .build();
+
+    p.cargo("build").with_status(0).run();
+    p.cargo("build --features bar")
+        .with_status(101)
+        .with_stderr_contains("[..]error: function is never used: `foo`[..]")
+        .run();
 }

--- a/tests/testsuite/main.rs
+++ b/tests/testsuite/main.rs
@@ -59,6 +59,7 @@ mod git;
 mod init;
 mod install;
 mod jobserver;
+mod lints;
 mod local_registry;
 mod lockfile_compat;
 mod login;


### PR DESCRIPTION
Implements #5034 

This PR adds a `[lints]` section to `Cargo.toml` using the following format:
```
[lints]
allow_unused = "allow"
non_snake_case = "allow"
```
## Progress
- [X] Add lints section to manifest
- [X] Pass `-A`/`-W`/`-D`/`-F` flags to rustc
- [x] Allow specifying lints in workspaces (workspace level lints take precedence over package level)
- [ ] Support feature syntax: `[lints.'cfg(feature = "clippy")']`
- [ ] Pass lints to rustdoc too, based on a feature flag
- [ ] Unknown lints are a warning (currently flags are directly passed to rustc which results in an error)
