### PR TITLE
most sorts can be unstable

### DIFF
--- a/src/cargo/core/resolver/mod.rs
+++ b/src/cargo/core/resolver/mod.rs
@@ -1021,7 +1021,8 @@ fn check_cycles(resolve: &Resolve, activations: &Activations) -> CargoResult<()>
         .collect();
 
     // Sort packages to produce user friendly deterministic errors.
-    let all_packages = resolve.iter().collect::<BinaryHeap<_>>().into_sorted_vec();
+    let mut all_packages: Vec<_> = resolve.iter().collect();
+    all_packages.sort_unstable();
     let mut checked = HashSet::new();
     for pkg in all_packages {
         if !checked.contains(pkg) {

--- a/src/cargo/core/resolver/resolve.rs
+++ b/src/cargo/core/resolver/resolve.rs
@@ -193,7 +193,7 @@ unable to verify that `{0}` is the same as when the lockfile was generated
 
     pub fn features_sorted(&self, pkg: &PackageId) -> Vec<&str> {
         let mut v = Vec::from_iter(self.features(pkg).iter().map(|s| s.as_ref()));
-        v.sort();
+        v.sort_unstable();
         v
     }
 

--- a/src/cargo/ops/cargo_install.rs
+++ b/src/cargo/ops/cargo_install.rs
@@ -538,7 +538,7 @@ where
             return Ok((pkg.clone(), Box::new(source)));
 
             fn multi_err(kind: &str, mut pkgs: Vec<&Package>) -> String {
-                pkgs.sort_by(|a, b| a.name().cmp(&b.name()));
+                pkgs.sort_unstable_by_key(|a| a.name());
                 format!(
                     "multiple packages with {} found: {}",
                     kind,

--- a/src/cargo/ops/cargo_package.rs
+++ b/src/cargo/ops/cargo_package.rs
@@ -51,7 +51,7 @@ pub fn package(ws: &Workspace, opts: &PackageOpts) -> CargoResult<Option<FileLoc
         if include_lockfile(pkg) {
             list.push("Cargo.lock".into());
         }
-        list.sort();
+        list.sort_unstable();
         for file in list.iter() {
             println!("{}", file.display());
         }

--- a/src/cargo/sources/path.rs
+++ b/src/cargo/sources/path.rs
@@ -447,10 +447,9 @@ impl<'cfg> PathSource<'cfg> {
         // TODO: Drop collect and sort after transition period and dropping warning tests.
         // See <https://github.com/rust-lang/cargo/issues/4268>
         // and <https://github.com/rust-lang/cargo/pull/4270>
-        let mut entries: Vec<fs::DirEntry> = fs::read_dir(path)?.map(|e| e.unwrap()).collect();
-        entries.sort_by(|a, b| a.path().as_os_str().cmp(b.path().as_os_str()));
-        for entry in entries {
-            let path = entry.path();
+        let mut entries: Vec<PathBuf> = fs::read_dir(path)?.map(|e| e.unwrap().path()).collect();
+        entries.sort_unstable_by(|a, b| a.as_os_str().cmp(b.as_os_str()));
+        for path in entries {
             let name = path.file_name().and_then(|s| s.to_str());
             // Skip dotfile directories
             if name.map(|s| s.starts_with('.')) == Some(true) {

--- a/src/cargo/util/rustc.rs
+++ b/src/cargo/util/rustc.rs
@@ -239,7 +239,7 @@ fn process_fingerprint(cmd: &ProcessBuilder) -> u64 {
     let mut hasher = SipHasher::new_with_keys(0, 0);
     cmd.get_args().hash(&mut hasher);
     let mut env = cmd.get_envs().iter().collect::<Vec<_>>();
-    env.sort();
+    env.sort_unstable();
     env.hash(&mut hasher);
     hasher.finish()
 }

--- a/tests/testsuite/out_dir.rs
+++ b/tests/testsuite/out_dir.rs
@@ -280,7 +280,7 @@ fn check_dir_contents(
 
     let actual = list_dir(out_dir);
     let mut expected = expected.iter().map(|s| s.to_string()).collect::<Vec<_>>();
-    expected.sort();
+    expected.sort_unstable();
     assert_eq!(actual, expected);
 }
 
@@ -290,6 +290,6 @@ fn list_dir(dir: &Path) -> Vec<String> {
         let entry = entry.unwrap();
         res.push(entry.file_name().into_string().unwrap());
     }
-    res.sort();
+    res.sort_unstable();
     res
 }


### PR DESCRIPTION
Inspired by [this](https://github.com/rust-lang/cargo/blob/94f7058a483b05ad742da5efb66dd1c2d4b8619c/src/bin/cargo/main.rs#L112-L122) witch was improved in #5691, I did a quick review of `sort`s in the code. Most can be unstable, some can use a `_key` form, and none had unnecessary allocation.