### PR TITLE
Always rebuild targets when using cargo-fix

### DIFF
--- a/src/bin/cargo/commands/fix.rs
+++ b/src/bin/cargo/commands/fix.rs
@@ -54,7 +54,7 @@ pub fn cli() -> App {
         )
         .after_help(
             "\
-This Cargo subcommmand will automatically take rustc's suggestions from
+This Cargo subcommand will automatically take rustc's suggestions from
 diagnostics like warnings and apply them to your source code. This is intended
 to help automate tasks that rustc itself already knows how to tell you to fix!
 The `cargo fix` subcommand is also being developed for the Rust 2018 edition

--- a/src/cargo/core/compiler/build_config.rs
+++ b/src/cargo/core/compiler/build_config.rs
@@ -16,6 +16,8 @@ pub struct BuildConfig {
     pub mode: CompileMode,
     /// Whether to print std output in json format (for machine reading)
     pub message_format: MessageFormat,
+    /// Force cargo to do a full rebuild and treat each target as changed.
+    pub force_rebuild: bool,
     /// Output a build plan to stdout instead of actually compiling.
     pub build_plan: bool,
     /// Use Cargo itself as the wrapper around rustc, only used for `cargo fix`
@@ -79,6 +81,7 @@ impl BuildConfig {
             release: false,
             mode,
             message_format: MessageFormat::Human,
+            force_rebuild: false,
             build_plan: false,
             cargo_as_rustc_wrapper: false,
             extra_rustc_env: Vec::new(),

--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -101,6 +101,7 @@ fn compile<'a, 'cfg: 'a>(
 ) -> CargoResult<()> {
     let bcx = cx.bcx;
     let build_plan = bcx.build_config.build_plan;
+    let force_rebuild = bcx.build_config.force_rebuild;
     if !cx.compiled.insert(*unit) {
         return Ok(());
     }
@@ -124,6 +125,7 @@ fn compile<'a, 'cfg: 'a>(
         )
     } else {
         let (mut freshness, dirty, fresh) = fingerprint::prepare_target(cx, unit)?;
+
         let work = if unit.mode.is_doc() {
             rustdoc(cx, unit)?
         } else {
@@ -133,7 +135,7 @@ fn compile<'a, 'cfg: 'a>(
         let dirty = work.then(link_targets(cx, unit, false)?).then(dirty);
         let fresh = link_targets(cx, unit, true)?.then(fresh);
 
-        if exec.force_rebuild(unit) {
+        if exec.force_rebuild(unit) || force_rebuild {
             freshness = Freshness::Dirty;
         }
 

--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -433,7 +433,7 @@ impl CompileFilter {
 /// Generates all the base targets for the packages the user has requested to
 /// compile. Dependencies for these targets are computed later in
 /// `unit_dependencies`.
-fn generate_targets<'a>(
+pub fn generate_targets<'a>(
     ws: &Workspace,
     profiles: &Profiles,
     packages: &[&'a Package],

--- a/src/cargo/ops/fix.rs
+++ b/src/cargo/ops/fix.rs
@@ -43,6 +43,8 @@ pub fn fix(ws: &Workspace, opts: &mut FixOptions) -> CargoResult<()> {
     ));
     let _started = lock_server.start()?;
 
+    opts.compile_opts.build_config.force_rebuild = true;
+
     if opts.broken_code {
         let key = BROKEN_CODE_ENV.to_string();
         opts.compile_opts.build_config.extra_rustc_env.push((key, "1".to_string()));

--- a/src/cargo/ops/fix.rs
+++ b/src/cargo/ops/fix.rs
@@ -57,6 +57,8 @@ pub fn fix(ws: &Workspace, opts: &mut FixOptions) -> CargoResult<()> {
     *opts.compile_opts.build_config.rustfix_diagnostic_server.borrow_mut() =
         Some(RustfixDiagnosticServer::new()?);
 
+    touch_entrypoints(ws, &opts.compile_opts)?;
+
     ops::compile(ws, &opts.compile_opts)?;
     Ok(())
 }
@@ -108,6 +110,67 @@ fn check_version_control(opts: &FixOptions) -> CargoResult<()> {
            \n\
            {}\n\
           ", files_list);
+}
+
+fn touch_entrypoints<'a>(
+    ws: &Workspace<'a>,
+    options: &CompileOptions<'a>,
+) -> CargoResult<()> {
+    // Begin cargo cult from `ops::cargo_compile::compile_ws`
+    use core::resolver::Method;
+    use core::compiler::Kind;
+
+    let specs = options.spec.into_package_id_specs(ws)?;
+    let features = Method::split_features(&options.features);
+    let method = Method::Required {
+        dev_deps: ws.require_optional_deps() || options.filter.need_dev_deps(options.build_config.mode),
+        features: &features,
+        all_features: options.all_features,
+        uses_default_features: !options.no_default_features,
+    };
+    let resolve = ops::resolve_ws_with_method(ws, None, method, &specs)?;
+    let (packages, resolve_with_overrides) = resolve;
+    let to_builds = specs
+        .iter()
+        .map(|p| {
+            let pkgid = p.query(resolve_with_overrides.iter())?;
+            let p = packages.get(pkgid)?;
+            p.manifest().print_teapot(ws.config());
+            Ok(p)
+        })
+        .collect::<CargoResult<Vec<_>>>()?;
+
+    let default_arch_kind = if options.build_config.requested_target.is_some() {
+        Kind::Target
+    } else {
+        Kind::Host
+    };
+    let units = ops::generate_targets(
+        ws,
+        ws.profiles(),
+        &to_builds,
+        &options.filter,
+        default_arch_kind,
+        &resolve_with_overrides,
+        &options.build_config,
+    )?;
+    // End cargo cult from `ops::cargo_compile::compile_ws`
+
+    let entrypoints = units.iter().map(|u| u.target.src_path());
+    for file_path in entrypoints {
+        if file_path.is_file() {
+            use std::time::SystemTime;
+            use filetime::{FileTime, set_file_times};
+
+            let time = FileTime::from_system_time(SystemTime::now());
+            set_file_times(file_path, time, time)?;
+            info!("`touch`ed file `{}`", file_path.display());
+        } else {
+            info!("Couldn't `touch` file `{}`: {}", file_path.display(), "Not a file");
+        }
+    }
+
+    Ok(())
 }
 
 pub fn fix_maybe_exec_rustc() -> CargoResult<bool> {

--- a/src/cargo/ops/mod.rs
+++ b/src/cargo/ops/mod.rs
@@ -1,5 +1,5 @@
 pub use self::cargo_clean::{clean, CleanOptions};
-pub use self::cargo_compile::{compile, compile_with_exec, compile_ws, CompileOptions};
+pub use self::cargo_compile::{compile, compile_with_exec, compile_ws, CompileOptions, generate_targets};
 pub use self::cargo_compile::{CompileFilter, FilterRule, Packages};
 pub use self::cargo_read_manifest::{read_package, read_packages};
 pub use self::cargo_run::run;

--- a/tests/testsuite/fix.rs
+++ b/tests/testsuite/fix.rs
@@ -1071,7 +1071,7 @@ fn does_not_warn_about_dirty_ignored_files() {
 
 #[test]
 fn shows_warnings_on_second_run_without_changes() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1104,7 +1104,7 @@ fn shows_warnings_on_second_run_without_changes() {
 
 #[test]
 fn shows_warnings_on_second_run_without_changes_on_multiple_targets() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"

--- a/tests/testsuite/fix.rs
+++ b/tests/testsuite/fix.rs
@@ -1070,7 +1070,7 @@ fn does_not_warn_about_dirty_ignored_files() {
 }
 
 #[test]
-fn shows_warnings_one_second_run_without_changes() {
+fn shows_warnings_on_second_run_without_changes() {
     let p = project("foo")
         .file(
             "Cargo.toml",

--- a/tests/testsuite/fix.rs
+++ b/tests/testsuite/fix.rs
@@ -1118,60 +1118,68 @@ fn shows_warnings_on_second_run_without_changes_on_multiple_targets() {
         .file(
             "src/lib.rs",
             r#"
-                pub fn a() -> u32 { let mut x = 3; x }
+                use std::default::Default;
+
+                pub fn a() -> u32 { 3 }
             "#,
         )
         .file(
             "src/main.rs",
             r#"
-                fn main() { let mut x = 3; println!("{}", x); }
+                use std::default::Default;
+                fn main() { println!("3"); }
             "#,
         )
         .file(
             "tests/foo.rs",
             r#"
+                use std::default::Default;
                 #[test]
                 fn foo_test() {
-                    let mut x = 3; println!("{}", x);
+                    println!("3");
                 }
             "#,
         )
         .file(
             "tests/bar.rs",
             r#"
+                use std::default::Default;
+
                 #[test]
                 fn foo_test() {
-                    let mut x = 3; println!("{}", x);
+                    println!("3");
                 }
             "#,
         )
         .file(
             "examples/fooxample.rs",
             r#"
+                use std::default::Default;
+
                 fn main() {
-                    let mut x = 3; println!("{}", x);
+                    println!("3");
                 }
             "#,
         )
         .build();
 
     assert_that(
-        p.cargo("fix --allow-no-vcs --all-targets").env("__CARGO_FIX_YOLO", "1"),
+        p.cargo("fix --allow-no-vcs --all-targets"),
         execs().with_status(0)
-            .with_stderr_contains("[FIXING] src[/]lib.rs (1 fix)")
-            .with_stderr_contains("[FIXING] src[/]main.rs (1 fix)")
-            .with_stderr_contains("[FIXING] tests[/]foo.rs (1 fix)")
-            .with_stderr_contains("[FIXING] tests[/]bar.rs (1 fix)")
-            .with_stderr_contains("[FIXING] examples[/]fooxample.rs (1 fix)"),
+            .with_stderr_contains(" --> examples/fooxample.rs:2:21")
+            .with_stderr_contains(" --> src/lib.rs:2:21")
+            .with_stderr_contains(" --> src/main.rs:2:21")
+            .with_stderr_contains(" --> tests/bar.rs:2:21")
+            .with_stderr_contains(" --> tests/foo.rs:2:21"),
     );
 
     assert_that(
-        p.cargo("fix --allow-no-vcs --all-targets").env("__CARGO_FIX_YOLO", "1"),
+        p.cargo("fix --allow-no-vcs --all-targets"),
         execs().with_status(0)
-            .with_stderr_contains("[FIXING] src[/]lib.rs (1 fix)")
-            .with_stderr_contains("[FIXING] src[/]main.rs (1 fix)")
-            .with_stderr_contains("[FIXING] tests[/]foo.rs (1 fix)")
-            .with_stderr_contains("[FIXING] tests[/]bar.rs (1 fix)")
-            .with_stderr_contains("[FIXING] examples[/]fooxample.rs (1 fix)"),
+            .with_stderr_contains(" --> examples/fooxample.rs:2:21")
+            .with_stderr_contains(" --> src/lib.rs:2:21")
+            .with_stderr_contains(" --> src/main.rs:2:21")
+            .with_stderr_contains(" --> tests/bar.rs:2:21")
+            .with_stderr_contains(" --> tests/foo.rs:2:21"),
     );
 }

--- a/tests/testsuite/fix.rs
+++ b/tests/testsuite/fix.rs
@@ -1068,3 +1068,36 @@ fn does_not_warn_about_dirty_ignored_files() {
         execs().with_status(0),
     );
 }
+
+#[test]
+fn shows_warnings_one_second_run_without_changes() {
+    let p = project("foo")
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.1.0"
+            "#,
+        )
+        .file(
+            "src/lib.rs",
+            r#"
+                use std::default::Default;
+
+                pub fn foo() {
+                }
+            "#,
+        )
+        .build();
+
+    assert_that(
+        p.cargo("fix --allow-no-vcs"),
+        execs().with_status(0).with_stderr_contains("[..]warning: unused import[..]"),
+    );
+
+    assert_that(
+        p.cargo("fix --allow-no-vcs"),
+        execs().with_status(0).with_stderr_contains("[..]warning: unused import[..]"),
+    );
+}


### PR DESCRIPTION
Assume you run `cargo fix` and only get warnings that cannot be fixed.
Then, without changing the code, you run `cargo fix` again. The compiler
will see that no files have changed and output… nothing. This is very
confusing to the end user.

To mitigate this, we now `touch` the entry point files to trick
rustc/cargo into emitting the same warnings again.

This is a fix but a very "WIP" one for #5736