### PR TITLE
Remove the argument from the `project` test support function

### DIFF
--- a/tests/testsuite/alt_registry.rs
+++ b/tests/testsuite/alt_registry.rs
@@ -7,7 +7,7 @@ use std::io::Write;
 
 #[test]
 fn is_feature_gated() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -36,7 +36,7 @@ fn is_feature_gated() {
 
 #[test]
 fn depend_on_alt_registry() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -93,7 +93,7 @@ fn depend_on_alt_registry() {
 
 #[test]
 fn depend_on_alt_registry_depends_on_same_registry_no_index() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -138,7 +138,7 @@ fn depend_on_alt_registry_depends_on_same_registry_no_index() {
 
 #[test]
 fn depend_on_alt_registry_depends_on_same_registry() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -183,7 +183,7 @@ fn depend_on_alt_registry_depends_on_same_registry() {
 
 #[test]
 fn depend_on_alt_registry_depends_on_crates_io() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -232,7 +232,7 @@ fn depend_on_alt_registry_depends_on_crates_io() {
 fn registry_and_path_dep_works() {
     registry::init();
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -278,7 +278,7 @@ fn registry_and_path_dep_works() {
 fn registry_incompatible_with_git() {
     registry::init();
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -304,7 +304,7 @@ fn registry_incompatible_with_git() {
 
 #[test]
 fn cannot_publish_to_crates_io_with_registry_dependency() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -334,7 +334,7 @@ fn cannot_publish_to_crates_io_with_registry_dependency() {
 
 #[test]
 fn publish_with_registry_dependency() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -378,7 +378,7 @@ fn publish_with_registry_dependency() {
 
 #[test]
 fn alt_registry_and_crates_io_deps() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -427,7 +427,7 @@ fn alt_registry_and_crates_io_deps() {
 
 #[test]
 fn block_publish_due_to_no_token() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -458,7 +458,7 @@ fn block_publish_due_to_no_token() {
 
 #[test]
 fn publish_to_alt_registry() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -503,7 +503,7 @@ fn publish_to_alt_registry() {
 
 #[test]
 fn publish_with_crates_io_dep() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -562,7 +562,7 @@ fn credentials_in_url_forbidden() {
         )
         .unwrap();
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"

--- a/tests/testsuite/bad_config.rs
+++ b/tests/testsuite/bad_config.rs
@@ -4,7 +4,7 @@ use hamcrest::assert_that;
 
 #[test]
 fn bad1() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -38,7 +38,7 @@ but found string in [..]config
 
 #[test]
 fn bad2() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -81,7 +81,7 @@ Caused by:
 
 #[test]
 fn bad3() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -117,7 +117,7 @@ Caused by:
 
 #[test]
 fn bad4() {
-    let p = project("foo")
+    let p = project()
         .file(
             ".cargo/config",
             r#"
@@ -141,7 +141,7 @@ Caused by:
 
 #[test]
 fn bad6() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -177,7 +177,7 @@ Caused by:
 
 #[test]
 fn bad_cargo_config_jobs() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -210,7 +210,7 @@ invalid value: integer `-1`, expected u32
 
 #[test]
 fn default_cargo_config_jobs() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -234,7 +234,7 @@ fn default_cargo_config_jobs() {
 
 #[test]
 fn good_cargo_config_jobs() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -258,7 +258,7 @@ fn good_cargo_config_jobs() {
 
 #[test]
 fn invalid_global_config() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -296,7 +296,7 @@ Caused by:
 
 #[test]
 fn bad_cargo_lock() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -327,7 +327,7 @@ Caused by:
 fn duplicate_packages_in_cargo_lock() {
     Package::new("foo", "0.1.0").publish();
 
-    let p = project("bar")
+    let p = project().at("bar")
         .file(
             "Cargo.toml",
             r#"
@@ -381,7 +381,7 @@ Caused by:
 fn bad_source_in_cargo_lock() {
     Package::new("foo", "0.1.0").publish();
 
-    let p = project("bar")
+    let p = project().at("bar")
         .file(
             "Cargo.toml",
             r#"
@@ -428,7 +428,7 @@ Caused by:
 
 #[test]
 fn bad_dependency_in_lockfile() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -467,7 +467,7 @@ Caused by:
 
 #[test]
 fn bad_git_dependency() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -505,7 +505,7 @@ Caused by:
 
 #[test]
 fn bad_crate_type() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -531,7 +531,7 @@ fn bad_crate_type() {
 
 #[test]
 fn malformed_override() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -567,7 +567,7 @@ Caused by:
 
 #[test]
 fn duplicate_binary_names() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -604,7 +604,7 @@ Caused by:
 
 #[test]
 fn duplicate_example_names() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -641,7 +641,7 @@ Caused by:
 
 #[test]
 fn duplicate_bench_names() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -678,7 +678,7 @@ Caused by:
 
 #[test]
 fn duplicate_deps() {
-    let p = project("foo")
+    let p = project()
         .file(
             "shim-bar/Cargo.toml",
             r#"
@@ -743,7 +743,7 @@ have a single canonical source path irrespective of build target.
 
 #[test]
 fn duplicate_deps_diff_sources() {
-    let p = project("foo")
+    let p = project()
         .file(
             "shim-bar/Cargo.toml",
             r#"
@@ -808,7 +808,7 @@ have a single canonical source path irrespective of build target.
 
 #[test]
 fn unused_keys() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -835,7 +835,7 @@ warning: unused manifest key: target.foo.bar
         ),
     );
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -865,7 +865,7 @@ warning: unused manifest key: project.bulid
         ),
     );
 
-    let p = project("bar")
+    let p = project().at("bar")
         .file(
             "Cargo.toml",
             r#"
@@ -900,7 +900,7 @@ warning: unused manifest key: lib.build
 
 #[test]
 fn unused_keys_in_virtual_manifest() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -933,7 +933,7 @@ warning: unused manifest key: workspace.bulid
 
 #[test]
 fn empty_dependencies() {
-    let p = project("empty_deps")
+    let p = project().at("empty_deps")
         .file(
             "Cargo.toml",
             r#"
@@ -964,7 +964,7 @@ to use. This will be considered an error in future versions
 
 #[test]
 fn invalid_toml_historically_allowed_is_warned() {
-    let p = project("empty_deps")
+    let p = project().at("empty_deps")
         .file(
             "Cargo.toml",
             r#"
@@ -1003,7 +1003,7 @@ in the future.
 
 #[test]
 fn ambiguous_git_reference() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1035,7 +1035,7 @@ This will be considered an error in future versions
 
 #[test]
 fn bad_source_config1() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1064,7 +1064,7 @@ fn bad_source_config1() {
 
 #[test]
 fn bad_source_config2() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1107,7 +1107,7 @@ Caused by:
 
 #[test]
 fn bad_source_config3() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1149,7 +1149,7 @@ Caused by:
 
 #[test]
 fn bad_source_config4() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1196,7 +1196,7 @@ Caused by:
 
 #[test]
 fn bad_source_config5() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1238,7 +1238,7 @@ Caused by:
 
 #[test]
 fn both_git_and_path_specified() {
-    let foo = project("foo")
+    let foo = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1269,7 +1269,7 @@ This will be considered an error in future versions
 
 #[test]
 fn bad_source_config6() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1303,7 +1303,7 @@ fn bad_source_config6() {
 
 #[test]
 fn ignored_git_revision() {
-    let foo = project("foo")
+    let foo = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1332,7 +1332,7 @@ fn ignored_git_revision() {
 
 #[test]
 fn bad_source_config7() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1368,7 +1368,7 @@ fn bad_source_config7() {
 
 #[test]
 fn bad_dependency() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1399,7 +1399,7 @@ Caused by:
 
 #[test]
 fn bad_debuginfo() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1430,7 +1430,7 @@ Caused by:
 
 #[test]
 fn bad_opt_level() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"

--- a/tests/testsuite/bad_manifest_path.rs
+++ b/tests/testsuite/bad_manifest_path.rs
@@ -2,7 +2,7 @@ use cargotest::support::{basic_bin_manifest, execs, main_file, project};
 use hamcrest::assert_that;
 
 fn assert_not_a_cargo_toml(command: &str, manifest_path_argument: &str) {
-    let p = project("foo")
+    let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
         .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
         .build();
@@ -20,7 +20,7 @@ fn assert_not_a_cargo_toml(command: &str, manifest_path_argument: &str) {
 }
 
 fn assert_cargo_toml_doesnt_exist(command: &str, manifest_path_argument: &str) {
-    let p = project("foo").build();
+    let p = project().build();
     let expected_path = manifest_path_argument
         .split('/')
         .collect::<Vec<_>>()
@@ -320,7 +320,7 @@ fn update_dir_to_nonexistent_cargo_toml() {
 
 #[test]
 fn verify_project_dir_containing_cargo_toml() {
-    let p = project("foo")
+    let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
         .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
         .build();
@@ -339,7 +339,7 @@ fn verify_project_dir_containing_cargo_toml() {
 
 #[test]
 fn verify_project_dir_plus_file() {
-    let p = project("foo")
+    let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
         .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
         .build();
@@ -358,7 +358,7 @@ fn verify_project_dir_plus_file() {
 
 #[test]
 fn verify_project_dir_plus_path() {
-    let p = project("foo")
+    let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
         .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
         .build();
@@ -377,7 +377,7 @@ fn verify_project_dir_plus_path() {
 
 #[test]
 fn verify_project_dir_to_nonexistent_cargo_toml() {
-    let p = project("foo").build();
+    let p = project().build();
     assert_that(
         p.cargo("verify-project")
             .arg("--manifest-path")

--- a/tests/testsuite/bench.rs
+++ b/tests/testsuite/bench.rs
@@ -12,7 +12,7 @@ fn cargo_bench_simple() {
         return;
     }
 
-    let p = project("foo")
+    let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
         .file(
             "src/main.rs",
@@ -61,7 +61,7 @@ fn bench_bench_implicit() {
         return;
     }
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -119,7 +119,7 @@ fn bench_bin_implicit() {
         return;
     }
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -176,7 +176,7 @@ fn bench_tarname() {
         return;
     }
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -224,7 +224,7 @@ fn bench_multiple_targets() {
         return;
     }
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -277,7 +277,7 @@ fn cargo_bench_verbose() {
         return;
     }
 
-    let p = project("foo")
+    let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
         .file(
             "src/main.rs",
@@ -312,7 +312,7 @@ fn many_similar_names() {
         return;
     }
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -380,7 +380,7 @@ fn cargo_bench_failing_test() {
         return;
     }
 
-    let p = project("foo")
+    let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
         .file(
             "src/main.rs",
@@ -436,7 +436,7 @@ fn bench_with_lib_dep() {
         return;
     }
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -507,7 +507,7 @@ fn bench_with_deep_lib_dep() {
         return;
     }
 
-    let p = project("bar")
+    let p = project().at("bar")
         .file(
             "Cargo.toml",
             r#"
@@ -535,7 +535,7 @@ fn bench_with_deep_lib_dep() {
         ",
         )
         .build();
-    let _p2 = project("foo")
+    let _p2 = project()
         .file(
             "Cargo.toml",
             r#"
@@ -582,7 +582,7 @@ fn external_bench_explicit() {
         return;
     }
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -644,7 +644,7 @@ fn external_bench_implicit() {
         return;
     }
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -703,7 +703,7 @@ fn bench_autodiscover_2015() {
         return;
     }
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -783,7 +783,7 @@ fn dont_run_examples() {
         return;
     }
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -810,7 +810,7 @@ fn pass_through_command_line() {
         return;
     }
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -867,7 +867,7 @@ fn cargo_bench_twice() {
         return;
     }
 
-    let p = project("test_twice")
+    let p = project().at("test_twice")
         .file("Cargo.toml", &basic_lib_manifest("test_twice"))
         .file(
             "src/test_twice.rs",
@@ -896,7 +896,7 @@ fn lib_bin_same_name() {
         return;
     }
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -956,7 +956,7 @@ fn lib_with_standard_name() {
         return;
     }
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1018,7 +1018,7 @@ fn lib_with_standard_name2() {
         return;
     }
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1077,7 +1077,7 @@ fn bench_dylib() {
         return;
     }
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1184,7 +1184,7 @@ fn bench_twice_with_build_cmd() {
         return;
     }
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1240,7 +1240,7 @@ fn bench_with_examples() {
         return;
     }
 
-    let p = project("testbench")
+    let p = project().at("testbench")
         .file(
             "Cargo.toml",
             r#"
@@ -1332,7 +1332,7 @@ fn test_a_bench() {
         return;
     }
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1381,7 +1381,7 @@ fn test_bench_no_run() {
         return;
     }
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1424,7 +1424,7 @@ fn test_bench_no_fail_fast() {
         return;
     }
 
-    let p = project("foo")
+    let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
         .file(
             "src/foo.rs",
@@ -1473,7 +1473,7 @@ fn test_bench_multiple_packages() {
         return;
     }
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1492,7 +1492,7 @@ fn test_bench_multiple_packages() {
         .file("src/lib.rs", "")
         .build();
 
-    let _bar = project("bar")
+    let _bar = project().at("bar")
         .file(
             "Cargo.toml",
             r#"
@@ -1521,7 +1521,7 @@ fn test_bench_multiple_packages() {
         )
         .build();
 
-    let _baz = project("baz")
+    let _baz = project().at("baz")
         .file(
             "Cargo.toml",
             r#"
@@ -1567,7 +1567,7 @@ fn bench_all_workspace() {
         return;
     }
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1644,7 +1644,7 @@ fn bench_all_exclude() {
         return;
     }
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1718,7 +1718,7 @@ fn bench_all_virtual_manifest() {
         return;
     }
 
-    let p = project("workspace")
+    let p = project().at("workspace")
         .file(
             "Cargo.toml",
             r#"
@@ -1799,7 +1799,7 @@ fn legacy_bench_name() {
         return;
     }
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1847,7 +1847,7 @@ fn bench_virtual_manifest_all_implied() {
         return;
     }
 
-    let p = project("workspace")
+    let p = project().at("workspace")
         .file(
             "Cargo.toml",
             r#"

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -15,7 +15,7 @@ use tempfile;
 
 #[test]
 fn cargo_compile_simple() {
-    let p = project("foo")
+    let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
         .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
         .build();
@@ -31,7 +31,7 @@ fn cargo_compile_simple() {
 
 #[test]
 fn cargo_fail_with_no_stderr() {
-    let p = project("foo")
+    let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
         .file("src/foo.rs", &String::from("refusal"))
         .build();
@@ -47,7 +47,7 @@ fn cargo_fail_with_no_stderr() {
 /// `rustc` getting `-Zincremental` passed to it.
 #[test]
 fn cargo_compile_incremental() {
-    let p = project("foo")
+    let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
         .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
         .build();
@@ -73,7 +73,7 @@ fn cargo_compile_incremental() {
 
 #[test]
 fn incremental_profile() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -129,7 +129,7 @@ fn incremental_profile() {
 
 #[test]
 fn incremental_config() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -166,7 +166,7 @@ fn incremental_config() {
 
 #[test]
 fn cargo_compile_with_workspace_excluded() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -190,7 +190,7 @@ fn cargo_compile_with_workspace_excluded() {
 
 #[test]
 fn cargo_compile_manifest_path() {
-    let p = project("foo")
+    let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
         .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
         .build();
@@ -207,7 +207,7 @@ fn cargo_compile_manifest_path() {
 
 #[test]
 fn cargo_compile_with_invalid_manifest() {
-    let p = project("foo").file("Cargo.toml", "").build();
+    let p = project().file("Cargo.toml", "").build();
 
     assert_that(
         p.cargo("build"),
@@ -224,7 +224,7 @@ Caused by:
 
 #[test]
 fn cargo_compile_with_invalid_manifest2() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r"
@@ -252,7 +252,7 @@ Caused by:
 
 #[test]
 fn cargo_compile_with_invalid_manifest3() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -285,7 +285,7 @@ Caused by:
 
 #[test]
 fn cargo_compile_duplicate_build_targets() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -325,7 +325,7 @@ warning: file found to be present in multiple build targets: [..]main.rs
 
 #[test]
 fn cargo_compile_with_invalid_version() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -352,7 +352,7 @@ Caused by:
 
 #[test]
 fn cargo_compile_with_invalid_package_name() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -379,7 +379,7 @@ Caused by:
 
 #[test]
 fn cargo_compile_with_invalid_bin_target_name() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -409,7 +409,7 @@ Caused by:
 
 #[test]
 fn cargo_compile_with_forbidden_bin_target_name() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -439,7 +439,7 @@ Caused by:
 
 #[test]
 fn cargo_compile_with_bin_and_crate_type() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -472,7 +472,7 @@ Caused by:
 
 #[test]
 fn cargo_compile_with_bin_and_proc() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -504,7 +504,7 @@ Caused by:
 
 #[test]
 fn cargo_compile_with_invalid_lib_target_name() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -547,7 +547,7 @@ fn cargo_compile_without_manifest() {
 
 #[test]
 fn cargo_compile_with_invalid_code() {
-    let p = project("foo")
+    let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
         .file("src/foo.rs", "invalid rust code!")
         .build();
@@ -566,7 +566,7 @@ To learn more, run the command again with --verbose.\n",
 
 #[test]
 fn cargo_compile_with_invalid_code_in_deps() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -583,11 +583,11 @@ fn cargo_compile_with_invalid_code_in_deps() {
         )
         .file("src/main.rs", "invalid rust code!")
         .build();
-    let _bar = project("bar")
+    let _bar = project().at("bar")
         .file("Cargo.toml", &basic_bin_manifest("bar"))
         .file("src/lib.rs", "invalid rust code!")
         .build();
-    let _baz = project("baz")
+    let _baz = project().at("baz")
         .file("Cargo.toml", &basic_bin_manifest("baz"))
         .file("src/lib.rs", "invalid rust code!")
         .build();
@@ -596,7 +596,7 @@ fn cargo_compile_with_invalid_code_in_deps() {
 
 #[test]
 fn cargo_compile_with_warnings_in_the_root_package() {
-    let p = project("foo")
+    let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
         .file("src/foo.rs", "fn main() {} fn dead() {}")
         .build();
@@ -611,7 +611,7 @@ fn cargo_compile_with_warnings_in_the_root_package() {
 
 #[test]
 fn cargo_compile_with_warnings_in_a_dep_package() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -673,7 +673,7 @@ fn cargo_compile_with_warnings_in_a_dep_package() {
 
 #[test]
 fn cargo_compile_with_nested_deps_inferred() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -748,7 +748,7 @@ fn cargo_compile_with_nested_deps_inferred() {
 
 #[test]
 fn cargo_compile_with_nested_deps_correct_bin() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -823,7 +823,7 @@ fn cargo_compile_with_nested_deps_correct_bin() {
 
 #[test]
 fn cargo_compile_with_nested_deps_shorthand() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -903,7 +903,7 @@ fn cargo_compile_with_nested_deps_shorthand() {
 
 #[test]
 fn cargo_compile_with_nested_deps_longhand() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -991,7 +991,7 @@ fn cargo_compile_with_nested_deps_longhand() {
 // because of a name mismatch.
 #[test]
 fn cargo_compile_with_dep_name_mismatch() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1029,7 +1029,7 @@ required by package `foo v0.0.1 ({proj_dir})`
 
 #[test]
 fn cargo_compile_with_filename() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1092,7 +1092,7 @@ Did you mean `a`?",
 
 #[test]
 fn cargo_compile_path_with_offline() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1142,7 +1142,7 @@ fn cargo_compile_with_downloaded_dependency_with_offline() {
 
     {
         // make package downloaded
-        let p = project("foo")
+        let p = project()
             .file(
                 "Cargo.toml",
                 r#"
@@ -1159,7 +1159,7 @@ fn cargo_compile_with_downloaded_dependency_with_offline() {
         assert_that(p.cargo("build"), execs().with_status(0));
     }
 
-    let p2 = project("bar")
+    let p2 = project().at("bar")
         .file(
             "Cargo.toml",
             r#"
@@ -1189,7 +1189,7 @@ fn cargo_compile_with_downloaded_dependency_with_offline() {
 
 #[test]
 fn cargo_compile_offline_not_try_update() {
-    let p = project("bar")
+    let p = project().at("bar")
         .file(
             "Cargo.toml",
             r#"
@@ -1255,7 +1255,7 @@ fn compile_offline_without_maxvers_cached() {
 
     {
         // make package cached
-        let p = project("foo")
+        let p = project()
             .file(
                 "Cargo.toml",
                 r#"
@@ -1272,7 +1272,7 @@ fn compile_offline_without_maxvers_cached() {
         assert_that(p.cargo("build"), execs().with_status(0));
     }
 
-    let p2 = project("foo")
+    let p2 = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1325,7 +1325,7 @@ fn incompatible_dependencies() {
     Package::new("baz", "0.1.1").dep("bad", ">=1.0.1").publish();
     Package::new("baz", "0.1.0").dep("bad", ">=1.0.1").publish();
 
-    let p = project("transitive_load_test")
+    let p = project().at("transitive_load_test")
         .file(
             "Cargo.toml",
             r#"
@@ -1371,7 +1371,7 @@ fn incompatible_dependencies_with_multi_semver() {
     Package::new("bar", "0.1.0").dep("bad", "=1.0.0").publish();
     Package::new("baz", "0.1.0").dep("bad", ">=2.0.1").publish();
 
-    let p = project("transitive_load_test")
+    let p = project().at("transitive_load_test")
         .file(
             "Cargo.toml",
             r#"
@@ -1426,7 +1426,7 @@ fn compile_offline_while_transitive_dep_not_cached() {
 
     Package::new("foo", "0.1.0").dep("bar", "1.0.0").publish();
 
-    let p = project("transitive_load_test")
+    let p = project().at("transitive_load_test")
         .file(
             "Cargo.toml",
             r#"
@@ -1466,7 +1466,7 @@ without the offline flag.",
 
 #[test]
 fn compile_path_dep_then_change_version() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1511,7 +1511,7 @@ fn compile_path_dep_then_change_version() {
 
 #[test]
 fn ignores_carriage_return_in_lockfile() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1550,7 +1550,7 @@ fn ignores_carriage_return_in_lockfile() {
 fn cargo_default_env_metadata_env_var() {
     // Ensure that path dep + dylib + env_var get metadata
     // (even though path_dep + dylib should not)
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1644,7 +1644,7 @@ fn cargo_default_env_metadata_env_var() {
 
 #[test]
 fn crate_env_vars() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1719,7 +1719,7 @@ fn crate_env_vars() {
 
 #[test]
 fn crate_authors_env_vars() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1784,7 +1784,7 @@ fn setenv_for_removing_empty_component(mut p: ProcessBuilder) -> ProcessBuilder 
 // Regression test for #4277
 #[test]
 fn crate_library_path_env_var() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1818,7 +1818,7 @@ fn crate_library_path_env_var() {
 // Regression test for #4277
 #[test]
 fn build_with_fake_libc_not_loading() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1847,7 +1847,7 @@ fn build_with_fake_libc_not_loading() {
 // this is testing that src/<pkg-name>.rs still works (for now)
 #[test]
 fn many_crate_types_old_style_lib_location() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1886,7 +1886,7 @@ please rename the file to `src/lib.rs` or set lib.path in Cargo.toml",
 
 #[test]
 fn many_crate_types_correct() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1918,7 +1918,7 @@ fn many_crate_types_correct() {
 
 #[test]
 fn self_dependency() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1956,7 +1956,7 @@ fn ignore_broken_symlinks() {
         return;
     }
 
-    let p = project("foo")
+    let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
         .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
         .symlink("Notafile", "bar")
@@ -1973,7 +1973,7 @@ fn ignore_broken_symlinks() {
 
 #[test]
 fn missing_lib_and_bin() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -2005,7 +2005,7 @@ fn lto_build() {
         return;
     }
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -2043,7 +2043,7 @@ fn lto_build() {
 
 #[test]
 fn verbose_build() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -2076,7 +2076,7 @@ fn verbose_build() {
 
 #[test]
 fn verbose_release_build() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -2110,7 +2110,7 @@ fn verbose_release_build() {
 
 #[test]
 fn verbose_release_build_deps() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -2175,7 +2175,7 @@ fn verbose_release_build_deps() {
 
 #[test]
 fn explicit_examples() {
-    let p = project("world")
+    let p = project().at("world")
         .file(
             "Cargo.toml",
             r#"
@@ -2234,7 +2234,7 @@ fn explicit_examples() {
 
 #[test]
 fn non_existing_example() {
-    let p = project("world")
+    let p = project().at("world")
         .file(
             "Cargo.toml",
             r#"
@@ -2268,7 +2268,7 @@ Caused by:
 
 #[test]
 fn non_existing_binary() {
-    let p = project("world")
+    let p = project().at("world")
         .file(
             "Cargo.toml",
             r#"
@@ -2299,7 +2299,7 @@ Caused by:
 
 #[test]
 fn legacy_binary_paths_warinigs() {
-    let p = project("world")
+    let p = project().at("world")
         .file(
             "Cargo.toml",
             r#"
@@ -2325,7 +2325,7 @@ please set bin.path in Cargo.toml",
         ),
     );
 
-    let p = project("world")
+    let p = project().at("world")
         .file(
             "Cargo.toml",
             r#"
@@ -2351,7 +2351,7 @@ please set bin.path in Cargo.toml",
         ),
     );
 
-    let p = project("world")
+    let p = project().at("world")
         .file(
             "Cargo.toml",
             r#"
@@ -2379,7 +2379,7 @@ please set bin.path in Cargo.toml",
 
 #[test]
 fn implicit_examples() {
-    let p = project("world")
+    let p = project().at("world")
         .file(
             "Cargo.toml",
             r#"
@@ -2430,7 +2430,7 @@ fn implicit_examples() {
 
 #[test]
 fn standard_build_no_ndebug() {
-    let p = project("world")
+    let p = project().at("world")
         .file("Cargo.toml", &basic_bin_manifest("foo"))
         .file(
             "src/foo.rs",
@@ -2455,7 +2455,7 @@ fn standard_build_no_ndebug() {
 
 #[test]
 fn release_build_ndebug() {
-    let p = project("world")
+    let p = project().at("world")
         .file("Cargo.toml", &basic_bin_manifest("foo"))
         .file(
             "src/foo.rs",
@@ -2480,7 +2480,7 @@ fn release_build_ndebug() {
 
 #[test]
 fn inferred_main_bin() {
-    let p = project("world")
+    let p = project().at("world")
         .file(
             "Cargo.toml",
             r#"
@@ -2504,7 +2504,7 @@ fn inferred_main_bin() {
 
 #[test]
 fn deletion_causes_failure() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -2551,7 +2551,7 @@ fn deletion_causes_failure() {
 
 #[test]
 fn bad_cargo_toml_in_target_dir() {
-    let p = project("world")
+    let p = project().at("world")
         .file(
             "Cargo.toml",
             r#"
@@ -2576,7 +2576,7 @@ fn bad_cargo_toml_in_target_dir() {
 
 #[test]
 fn lib_with_standard_name() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -2615,7 +2615,7 @@ fn lib_with_standard_name() {
 
 #[test]
 fn simple_staticlib() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -2641,7 +2641,7 @@ fn simple_staticlib() {
 
 #[test]
 fn staticlib_rlib_and_bin() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -2672,7 +2672,7 @@ fn staticlib_rlib_and_bin() {
 
 #[test]
 fn opt_out_of_bin() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -2692,7 +2692,7 @@ fn opt_out_of_bin() {
 
 #[test]
 fn single_lib() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -2713,7 +2713,7 @@ fn single_lib() {
 
 #[test]
 fn freshness_ignores_excluded() {
-    let foo = project("foo")
+    let foo = project()
         .file(
             "Cargo.toml",
             r#"
@@ -2753,7 +2753,7 @@ fn freshness_ignores_excluded() {
 
 #[test]
 fn rebuild_preserves_out_dir() {
-    let foo = project("foo")
+    let foo = project()
         .file(
             "Cargo.toml",
             r#"
@@ -2811,7 +2811,7 @@ fn rebuild_preserves_out_dir() {
 
 #[test]
 fn dep_no_libs() {
-    let foo = project("foo")
+    let foo = project()
         .file(
             "Cargo.toml",
             r#"
@@ -2841,7 +2841,7 @@ fn dep_no_libs() {
 
 #[test]
 fn recompile_space_in_name() {
-    let foo = project("foo")
+    let foo = project()
         .file(
             "Cargo.toml",
             r#"
@@ -2866,7 +2866,7 @@ fn recompile_space_in_name() {
 #[test]
 fn ignore_bad_directories() {
     use std::os::unix::prelude::*;
-    let foo = project("foo")
+    let foo = project()
         .file(
             "Cargo.toml",
             r#"
@@ -2891,7 +2891,7 @@ fn ignore_bad_directories() {
 
 #[test]
 fn bad_cargo_config() {
-    let foo = project("foo")
+    let foo = project()
         .file(
             "Cargo.toml",
             r#"
@@ -2931,7 +2931,7 @@ Caused by:
 #[test]
 fn cargo_platform_specific_dependency() {
     let host = rustc_host();
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             &format!(
@@ -3014,7 +3014,7 @@ fn cargo_platform_specific_dependency() {
 
 #[test]
 fn bad_platform_specific_dependency() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -3056,7 +3056,7 @@ fn bad_platform_specific_dependency() {
 
 #[test]
 fn cargo_platform_specific_dependency_wrong_platform() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -3110,7 +3110,7 @@ fn cargo_platform_specific_dependency_wrong_platform() {
 
 #[test]
 fn example_as_lib() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -3134,7 +3134,7 @@ fn example_as_lib() {
 
 #[test]
 fn example_as_rlib() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -3158,7 +3158,7 @@ fn example_as_rlib() {
 
 #[test]
 fn example_as_dylib() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -3186,7 +3186,7 @@ fn example_as_proc_macro() {
         return;
     }
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -3210,7 +3210,7 @@ fn example_as_proc_macro() {
 
 #[test]
 fn example_bin_same_name() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -3247,7 +3247,7 @@ fn example_bin_same_name() {
 
 #[test]
 fn compile_then_delete() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -3272,7 +3272,7 @@ fn compile_then_delete() {
 
 #[test]
 fn transitive_dependencies_not_available() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -3324,7 +3324,7 @@ fn transitive_dependencies_not_available() {
 
 #[test]
 fn cyclic_deps_rejected() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -3363,7 +3363,7 @@ package `a v0.0.1 ([..]a)`
 
 #[test]
 fn predictable_filenames() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -3391,7 +3391,7 @@ fn predictable_filenames() {
 
 #[test]
 fn dashes_to_underscores() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -3411,7 +3411,7 @@ fn dashes_to_underscores() {
 
 #[test]
 fn dashes_in_crate_name_bad() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -3433,7 +3433,7 @@ fn dashes_in_crate_name_bad() {
 
 #[test]
 fn rustc_env_var() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -3464,7 +3464,7 @@ Caused by:
 
 #[test]
 fn filtering() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -3496,7 +3496,7 @@ fn filtering() {
 
 #[test]
 fn filtering_implicit_bins() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -3522,7 +3522,7 @@ fn filtering_implicit_bins() {
 
 #[test]
 fn filtering_implicit_examples() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -3548,7 +3548,7 @@ fn filtering_implicit_examples() {
 
 #[test]
 fn ignore_dotfile() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -3567,7 +3567,7 @@ fn ignore_dotfile() {
 
 #[test]
 fn ignore_dotdirs() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -3604,7 +3604,7 @@ fn dotdir_root() {
 
 #[test]
 fn custom_target_dir_env() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -3672,7 +3672,7 @@ fn custom_target_dir_env() {
 
 #[test]
 fn custom_target_dir_line_parameter() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -3762,7 +3762,7 @@ fn custom_target_dir_line_parameter() {
 
 #[test]
 fn build_multiple_packages() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -3835,7 +3835,7 @@ fn build_multiple_packages() {
 
 #[test]
 fn invalid_spec() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -3889,7 +3889,7 @@ fn invalid_spec() {
 
 #[test]
 fn manifest_with_bom_is_ok() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             "\u{FEFF}
@@ -3906,7 +3906,7 @@ fn manifest_with_bom_is_ok() {
 
 #[test]
 fn panic_abort_compiles_with_panic_abort() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -3931,7 +3931,7 @@ fn panic_abort_compiles_with_panic_abort() {
 
 #[test]
 fn explicit_color_config_is_propagated_to_rustc() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -3967,7 +3967,7 @@ fn explicit_color_config_is_propagated_to_rustc() {
 
 #[test]
 fn compiler_json_error_format() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -4184,7 +4184,7 @@ fn compiler_json_error_format() {
 
 #[test]
 fn wrong_message_format_option() {
-    let p = project("foo")
+    let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
         .file("src/main.rs", "fn main() {}")
         .build();
@@ -4202,7 +4202,7 @@ error: 'XML' isn't a valid value for '--message-format <FMT>'
 
 #[test]
 fn message_format_json_forward_stderr() {
-    let p = project("foo")
+    let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
         .file("src/main.rs", "fn main() { let unused = 0; }")
         .build();
@@ -4255,7 +4255,7 @@ fn message_format_json_forward_stderr() {
 
 #[test]
 fn no_warn_about_package_metadata() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -4286,7 +4286,7 @@ fn no_warn_about_package_metadata() {
 
 #[test]
 fn cargo_build_empty_target() {
-    let p = project("foo")
+    let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
         .file("src/main.rs", "fn main() {}")
         .build();
@@ -4301,7 +4301,7 @@ fn cargo_build_empty_target() {
 
 #[test]
 fn build_all_workspace() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -4349,7 +4349,7 @@ fn build_all_workspace() {
 
 #[test]
 fn build_all_exclude() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -4411,7 +4411,7 @@ fn build_all_exclude() {
 
 #[test]
 fn build_all_workspace_implicit_examples() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -4465,7 +4465,7 @@ fn build_all_workspace_implicit_examples() {
 
 #[test]
 fn build_all_virtual_manifest() {
-    let p = project("workspace")
+    let p = project().at("workspace")
         .file(
             "Cargo.toml",
             r#"
@@ -4520,7 +4520,7 @@ fn build_all_virtual_manifest() {
 
 #[test]
 fn build_virtual_manifest_all_implied() {
-    let p = project("workspace")
+    let p = project().at("workspace")
         .file(
             "Cargo.toml",
             r#"
@@ -4575,7 +4575,7 @@ fn build_virtual_manifest_all_implied() {
 
 #[test]
 fn build_virtual_manifest_one_project() {
-    let p = project("workspace")
+    let p = project().at("workspace")
         .file(
             "Cargo.toml",
             r#"
@@ -4628,7 +4628,7 @@ fn build_virtual_manifest_one_project() {
 
 #[test]
 fn build_all_virtual_manifest_implicit_examples() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -4689,7 +4689,7 @@ fn build_all_virtual_manifest_implicit_examples() {
 
 #[test]
 fn build_all_member_dependency_same_name() {
-    let p = project("workspace")
+    let p = project().at("workspace")
         .file(
             "Cargo.toml",
             r#"
@@ -4732,7 +4732,7 @@ fn build_all_member_dependency_same_name() {
 
 #[test]
 fn run_proper_binary() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -4772,7 +4772,7 @@ fn run_proper_binary() {
 
 #[test]
 fn run_proper_binary_main_rs() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -4802,7 +4802,7 @@ fn run_proper_binary_main_rs() {
 
 #[test]
 fn run_proper_alias_binary_from_src() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -4847,7 +4847,7 @@ fn run_proper_alias_binary_from_src() {
 
 #[test]
 fn run_proper_alias_binary_main_rs() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -4884,7 +4884,7 @@ fn run_proper_alias_binary_main_rs() {
 
 #[test]
 fn run_proper_binary_main_rs_as_foo() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -4926,7 +4926,7 @@ fn rustc_wrapper() {
         return;
     }
 
-    let p = project("foo")
+    let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
         .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
         .build();
@@ -4943,7 +4943,7 @@ fn rustc_wrapper() {
 
 #[test]
 fn cdylib_not_lifted() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -4980,7 +4980,7 @@ fn cdylib_not_lifted() {
 
 #[test]
 fn cdylib_final_outputs() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -5016,7 +5016,7 @@ fn cdylib_final_outputs() {
 fn deterministic_cfg_flags() {
     // This bug is non-deterministic
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -5072,7 +5072,7 @@ fn deterministic_cfg_flags() {
 
 #[test]
 fn explicit_bins_without_paths() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -5098,7 +5098,7 @@ fn explicit_bins_without_paths() {
 
 #[test]
 fn no_bin_in_src_with_lib() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -5129,7 +5129,7 @@ Caused by:
 
 #[test]
 fn inferred_bins() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -5153,7 +5153,7 @@ fn inferred_bins() {
 #[test]
 fn inferred_bins_duplicate_name() {
     // this should fail, because we have two binaries with the same name
-    let p = project("bar")
+    let p = project().at("bar")
         .file(
             "Cargo.toml",
             r#"
@@ -5178,7 +5178,7 @@ fn inferred_bins_duplicate_name() {
 
 #[test]
 fn inferred_bin_path() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -5201,7 +5201,7 @@ fn inferred_bin_path() {
 
 #[test]
 fn inferred_examples() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -5223,7 +5223,7 @@ fn inferred_examples() {
 
 #[test]
 fn inferred_tests() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -5246,7 +5246,7 @@ fn inferred_tests() {
 
 #[test]
 fn inferred_benchmarks() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -5271,7 +5271,7 @@ fn inferred_benchmarks() {
 fn same_metadata_different_directory() {
     // A top-level crate built in two different workspaces should have the
     // same metadata hash.
-    let p = project("foo1")
+    let p = project().at("foo1")
         .file("Cargo.toml", &basic_bin_manifest("foo"))
         .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
         .build();
@@ -5283,7 +5283,7 @@ fn same_metadata_different_directory() {
         .find(|arg| arg.starts_with("metadata="))
         .unwrap();
 
-    let p = project("foo2")
+    let p = project().at("foo2")
         .file("Cargo.toml", &basic_bin_manifest("foo"))
         .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
         .build();
@@ -5313,7 +5313,7 @@ fn building_a_dependent_crate_witout_bin_should_fail() {
         .file("src/lib.rs", "")
         .publish();
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -5341,7 +5341,7 @@ fn uplift_dsym_of_bin_on_mac() {
     if !cfg!(any(target_os = "macos", target_os = "ios")) {
         return;
     }
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -5381,7 +5381,7 @@ fn uplift_pdb_of_bin_on_windows() {
     if !cfg!(all(target_os = "windows", target_env = "msvc")) {
         return;
     }
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -5413,7 +5413,7 @@ fn uplift_pdb_of_bin_on_windows() {
 // targets based on filters (assuming --profile is not specified).
 #[test]
 fn build_filter_infer_profile() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -5491,7 +5491,7 @@ fn build_filter_infer_profile() {
 
 #[test]
 fn targets_selected_default() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -5523,7 +5523,7 @@ fn targets_selected_default() {
 
 #[test]
 fn targets_selected_all() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -5555,7 +5555,7 @@ fn targets_selected_all() {
 
 #[test]
 fn all_targets_no_lib() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -5588,7 +5588,7 @@ fn all_targets_no_lib() {
 #[test]
 fn no_linkable_target() {
     // Issue 3169. This is currently not an error as per discussion in PR #4797
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -5627,7 +5627,7 @@ fn no_linkable_target() {
 #[test]
 fn avoid_dev_deps() {
     Package::new("foo", "1.0.0").publish();
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -5654,7 +5654,7 @@ fn avoid_dev_deps() {
 
 #[test]
 fn invalid_jobs() {
-    let p = project("foo")
+    let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
         .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
         .build();

--- a/tests/testsuite/build_auth.rs
+++ b/tests/testsuite/build_auth.rs
@@ -71,7 +71,7 @@ fn http_auth_offered() {
         );
     });
 
-    let script = project("script")
+    let script = project().at("script")
         .file(
             "Cargo.toml",
             r#"
@@ -101,7 +101,7 @@ fn http_auth_offered() {
         .set_str("credential.helper", &script.display().to_string())
         .unwrap();
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             &format!(
@@ -167,7 +167,7 @@ fn https_something_happens() {
         drop(conn.read(&mut [0; 16]));
     });
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             &format!(
@@ -231,7 +231,7 @@ fn ssh_something_happens() {
         drop(server.accept().unwrap());
     });
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             &format!(

--- a/tests/testsuite/build_lib.rs
+++ b/tests/testsuite/build_lib.rs
@@ -21,7 +21,7 @@ fn verbose_output_for_lib(p: &Project) -> String {
 
 #[test]
 fn build_lib_only() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -51,7 +51,7 @@ fn build_lib_only() {
 
 #[test]
 fn build_with_no_lib() {
-    let p = project("foo")
+    let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
         .file(
             "src/main.rs",
@@ -71,7 +71,7 @@ fn build_with_no_lib() {
 
 #[test]
 fn build_with_relative_cargo_home_path() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"

--- a/tests/testsuite/build_plan.rs
+++ b/tests/testsuite/build_plan.rs
@@ -4,7 +4,7 @@ use hamcrest::{assert_that, existing_file, is_not};
 
 #[test]
 fn cargo_build_plan_simple() {
-    let p = project("foo")
+    let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
         .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
         .build();
@@ -44,7 +44,7 @@ fn cargo_build_plan_simple() {
 
 #[test]
 fn cargo_build_plan_single_dep() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -130,7 +130,7 @@ fn cargo_build_plan_single_dep() {
 
 #[test]
 fn cargo_build_plan_build_script() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"

--- a/tests/testsuite/build_script.rs
+++ b/tests/testsuite/build_script.rs
@@ -245,7 +245,7 @@ fn custom_build_script_wrong_rustc_flags() {
 /*
 #[test]
 fn custom_build_script_rustc_flags() {
-    let p = project("foo")
+    let p = project()
         .file("Cargo.toml", r#"
             [project]
 

--- a/tests/testsuite/build_script.rs
+++ b/tests/testsuite/build_script.rs
@@ -15,7 +15,7 @@ use hamcrest::{assert_that, existing_dir, existing_file};
 
 #[test]
 fn custom_build_script_failed() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -58,7 +58,7 @@ process didn't exit successfully: `[..][/]build-script-build` (exit code: 101)",
 
 #[test]
 fn custom_build_env_vars() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -162,7 +162,7 @@ fn custom_build_env_vars() {
 fn custom_build_env_var_rustc_linker() {
     if cross_compile::disabled() { return; }
     let target = cross_compile::alternate();
-    let p = project("foo")
+    let p = project()
         .file("Cargo.toml",
               r#"
               [project]
@@ -203,7 +203,7 @@ fn custom_build_env_var_rustc_linker() {
 
 #[test]
 fn custom_build_script_wrong_rustc_flags() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -297,7 +297,7 @@ url = p.url(),
 
 #[test]
 fn links_no_build_cmd() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -325,7 +325,7 @@ not have a custom build script
 #[test]
 fn links_duplicates() {
     // this tests that the links_duplicates are caught at resolver time
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -374,7 +374,7 @@ failed to select a version for `a-sys` which could resolve this conflict
 #[test]
 fn links_duplicates_deep_dependency() {
     // this tests that the links_duplicates are caught at resolver time
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -440,7 +440,7 @@ failed to select a version for `a-sys` which could resolve this conflict
 fn overrides_and_links() {
     let target = rustc_host();
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -514,7 +514,7 @@ fn overrides_and_links() {
 fn unused_overrides() {
     let target = rustc_host();
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -546,7 +546,7 @@ fn unused_overrides() {
 
 #[test]
 fn links_passes_env_vars() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -603,7 +603,7 @@ fn links_passes_env_vars() {
 
 #[test]
 fn only_rerun_build_script() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -644,7 +644,7 @@ fn only_rerun_build_script() {
 
 #[test]
 fn rebuild_continues_to_pass_env_vars() {
-    let a = project("a")
+    let a = project().at("a")
         .file(
             "Cargo.toml",
             r#"
@@ -671,7 +671,7 @@ fn rebuild_continues_to_pass_env_vars() {
         .build();
     a.root().move_into_the_past();
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             &format!(
@@ -712,7 +712,7 @@ fn rebuild_continues_to_pass_env_vars() {
 
 #[test]
 fn testing_and_such() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -790,7 +790,7 @@ fn testing_and_such() {
 #[test]
 fn propagation_of_l_flags() {
     let target = rustc_host();
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -866,7 +866,7 @@ fn propagation_of_l_flags() {
 #[test]
 fn propagation_of_l_flags_new() {
     let target = rustc_host();
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -941,7 +941,7 @@ fn propagation_of_l_flags_new() {
 
 #[test]
 fn build_deps_simple() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -994,7 +994,7 @@ fn build_deps_simple() {
 #[test]
 fn build_deps_not_for_normal() {
     let target = rustc_host();
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1049,7 +1049,7 @@ Caused by:
 
 #[test]
 fn build_cmd_with_a_build_cmd() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1136,7 +1136,7 @@ fn build_cmd_with_a_build_cmd() {
 
 #[test]
 fn out_dir_is_preserved() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1193,7 +1193,7 @@ fn out_dir_is_preserved() {
 
 #[test]
 fn output_separate_lines() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1231,7 +1231,7 @@ fn output_separate_lines() {
 
 #[test]
 fn output_separate_lines_new() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1270,7 +1270,7 @@ fn output_separate_lines_new() {
 #[cfg(not(windows))] // FIXME(#867)
 #[test]
 fn code_generation() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1330,7 +1330,7 @@ fn code_generation() {
 
 #[test]
 fn release_with_build_script() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1358,7 +1358,7 @@ fn release_with_build_script() {
 
 #[test]
 fn build_script_only() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1386,7 +1386,7 @@ Caused by:
 
 #[test]
 fn shared_dep_with_a_build_script() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1436,7 +1436,7 @@ fn shared_dep_with_a_build_script() {
 
 #[test]
 fn transitive_dep_host() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1488,7 +1488,7 @@ fn transitive_dep_host() {
 
 #[test]
 fn test_a_lib_with_a_build_command() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1534,7 +1534,7 @@ fn test_a_lib_with_a_build_command() {
 
 #[test]
 fn test_dev_dep_build_script() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1567,7 +1567,7 @@ fn test_dev_dep_build_script() {
 
 #[test]
 fn build_script_with_dynamic_native_dependency() {
-    let _workspace = project("ws")
+    let _workspace = project().at("ws")
         .file(
             "Cargo.toml",
             r#"
@@ -1577,7 +1577,7 @@ fn build_script_with_dynamic_native_dependency() {
         )
         .build();
 
-    let build = project("ws/builder")
+    let build = project().at("ws/builder")
         .file(
             "Cargo.toml",
             r#"
@@ -1601,7 +1601,7 @@ fn build_script_with_dynamic_native_dependency() {
         )
         .build();
 
-    let foo = project("ws/foo")
+    let foo = project().at("ws/foo")
         .file(
             "Cargo.toml",
             r#"
@@ -1678,7 +1678,7 @@ fn build_script_with_dynamic_native_dependency() {
 
 #[test]
 fn profile_and_opt_level_set_correctly() {
-    let build = project("builder")
+    let build = project().at("builder")
         .file(
             "Cargo.toml",
             r#"
@@ -1708,7 +1708,7 @@ fn profile_and_opt_level_set_correctly() {
 
 #[test]
 fn profile_debug_0() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1739,7 +1739,7 @@ fn profile_debug_0() {
 
 #[test]
 fn build_script_with_lto() {
-    let build = project("builder")
+    let build = project().at("builder")
         .file(
             "Cargo.toml",
             r#"
@@ -1767,7 +1767,7 @@ fn build_script_with_lto() {
 
 #[test]
 fn test_duplicate_deps() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1815,7 +1815,7 @@ fn test_duplicate_deps() {
 
 #[test]
 fn cfg_feedback() {
-    let build = project("builder")
+    let build = project().at("builder")
         .file(
             "Cargo.toml",
             r#"
@@ -1849,7 +1849,7 @@ fn cfg_feedback() {
 fn cfg_override() {
     let target = rustc_host();
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1886,7 +1886,7 @@ fn cfg_override() {
 
 #[test]
 fn cfg_test() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1962,7 +1962,7 @@ fn cfg_test() {
 
 #[test]
 fn cfg_doc() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -2031,7 +2031,7 @@ fn cfg_doc() {
 
 #[test]
 fn cfg_override_test() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -2109,7 +2109,7 @@ fn cfg_override_test() {
 
 #[test]
 fn cfg_override_doc() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -2178,7 +2178,7 @@ fn cfg_override_doc() {
 
 #[test]
 fn env_build() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -2216,7 +2216,7 @@ fn env_build() {
 
 #[test]
 fn env_test() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -2278,7 +2278,7 @@ fn env_test() {
 
 #[test]
 fn env_doc() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -2310,7 +2310,7 @@ fn env_doc() {
 
 #[test]
 fn flags_go_into_tests() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -2397,7 +2397,7 @@ fn flags_go_into_tests() {
 
 #[test]
 fn diamond_passes_args_only_once() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -2482,7 +2482,7 @@ fn diamond_passes_args_only_once() {
 #[test]
 fn adding_an_override_invalidates() {
     let target = rustc_host();
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -2547,7 +2547,7 @@ fn adding_an_override_invalidates() {
 #[test]
 fn changing_an_override_invalidates() {
     let target = rustc_host();
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -2613,7 +2613,7 @@ fn changing_an_override_invalidates() {
 fn fresh_builds_possible_with_link_libs() {
     // The bug is non-deterministic. Sometimes you can get a fresh build
     let target = rustc_host();
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -2669,7 +2669,7 @@ fn fresh_builds_possible_with_link_libs() {
 fn fresh_builds_possible_with_multiple_metadata_overrides() {
     // The bug is non-deterministic. Sometimes you can get a fresh build
     let target = rustc_host();
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -2725,7 +2725,7 @@ fn fresh_builds_possible_with_multiple_metadata_overrides() {
 
 #[test]
 fn rebuild_only_on_explicit_paths() {
-    let p = project("a")
+    let p = project().at("a")
         .file(
             "Cargo.toml",
             r#"
@@ -2841,7 +2841,7 @@ fn rebuild_only_on_explicit_paths() {
 
 #[test]
 fn doctest_receives_build_link_args() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -2886,7 +2886,7 @@ fn doctest_receives_build_link_args() {
 
 #[test]
 fn please_respect_the_dag() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -2941,7 +2941,7 @@ fn please_respect_the_dag() {
 
 #[test]
 fn non_utf8_output() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -2984,7 +2984,7 @@ fn non_utf8_output() {
 
 #[test]
 fn custom_target_dir() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -3024,7 +3024,7 @@ fn custom_target_dir() {
 
 #[test]
 fn panic_abort_with_build_scripts() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -3090,7 +3090,7 @@ fn panic_abort_with_build_scripts() {
 
 #[test]
 fn warnings_emitted() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -3154,7 +3154,7 @@ fn warnings_hidden_for_upstream() {
         .file("src/lib.rs", "")
         .publish();
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -3213,7 +3213,7 @@ fn warnings_printed_on_vv() {
         .file("src/lib.rs", "")
         .publish();
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -3251,7 +3251,7 @@ warning: bar
 
 #[test]
 fn output_shows_on_vv() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -3295,7 +3295,7 @@ stderr
 fn links_with_dots() {
     let target = rustc_host();
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -3338,7 +3338,7 @@ fn links_with_dots() {
 
 #[test]
 fn rustc_and_rustdoc_set_correctly() {
-    let p = project("builder")
+    let p = project().at("builder")
         .file(
             "Cargo.toml",
             r#"
@@ -3367,7 +3367,7 @@ fn rustc_and_rustdoc_set_correctly() {
 
 #[test]
 fn cfg_env_vars_available() {
-    let p = project("builder")
+    let p = project().at("builder")
         .file(
             "Cargo.toml",
             r#"
@@ -3400,7 +3400,7 @@ fn cfg_env_vars_available() {
 
 #[test]
 fn switch_features_rerun() {
-    let p = project("builder")
+    let p = project().at("builder")
         .file(
             "Cargo.toml",
             r#"
@@ -3461,7 +3461,7 @@ fn switch_features_rerun() {
 
 #[test]
 fn assume_build_script_when_build_rs_present() {
-    let p = project("builder")
+    let p = project().at("builder")
         .file(
             "Cargo.toml",
             r#"
@@ -3496,7 +3496,7 @@ fn assume_build_script_when_build_rs_present() {
 
 #[test]
 fn if_build_set_to_false_dont_treat_build_rs_as_build_script() {
-    let p = project("builder")
+    let p = project().at("builder")
         .file(
             "Cargo.toml",
             r#"
@@ -3620,7 +3620,7 @@ fn deterministic_rustc_dependency_flags() {
         .file("src/lib.rs", "")
         .publish();
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -3658,7 +3658,7 @@ fn deterministic_rustc_dependency_flags() {
 #[test]
 fn links_duplicates_with_cycle() {
     // this tests that the links_duplicates are caught at resolver time
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -3722,7 +3722,7 @@ failed to select a version for `a` which could resolve this conflict
 
 #[test]
 fn rename_with_link_search_path() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -3746,7 +3746,7 @@ fn rename_with_link_search_path() {
 
     assert_that(p.cargo("build"), execs().with_status(0));
 
-    let p2 = project("bar")
+    let p2 = project().at("bar")
         .file(
             "Cargo.toml",
             r#"
@@ -3867,7 +3867,7 @@ fn rename_with_link_search_path() {
 
 #[test]
 fn optional_build_script_dep() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -3933,7 +3933,7 @@ fn optional_build_script_dep() {
 
 #[test]
 fn optional_build_dep_and_required_normal_dep() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"

--- a/tests/testsuite/build_script_env.rs
+++ b/tests/testsuite/build_script_env.rs
@@ -6,7 +6,7 @@ use hamcrest::assert_that;
 
 #[test]
 fn rerun_if_env_changes() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -76,7 +76,7 @@ fn rerun_if_env_changes() {
 
 #[test]
 fn rerun_if_env_or_file_changes() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"

--- a/tests/testsuite/cargo_alias_config.rs
+++ b/tests/testsuite/cargo_alias_config.rs
@@ -3,7 +3,7 @@ use hamcrest::assert_that;
 
 #[test]
 fn alias_incorrect_config_type() {
-    let p = project("foo")
+    let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
         .file(
             "src/main.rs",
@@ -32,7 +32,7 @@ expected a list, but found a integer for [..]",
 
 #[test]
 fn alias_default_config_overrides_config() {
-    let p = project("foo")
+    let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
         .file(
             "src/main.rs",
@@ -59,7 +59,7 @@ fn alias_default_config_overrides_config() {
 
 #[test]
 fn alias_config() {
-    let p = project("foo")
+    let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
         .file(
             "src/main.rs",
@@ -90,7 +90,7 @@ fn alias_config() {
 
 #[test]
 fn recursive_alias() {
-    let p = project("foo")
+    let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
         .file(
             "src/main.rs",
@@ -120,7 +120,7 @@ fn recursive_alias() {
 
 #[test]
 fn alias_list_test() {
-    let p = project("foo")
+    let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
         .file(
             "src/main.rs",
@@ -148,7 +148,7 @@ fn alias_list_test() {
 
 #[test]
 fn alias_with_flags_config() {
-    let p = project("foo")
+    let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
         .file(
             "src/main.rs",
@@ -176,7 +176,7 @@ fn alias_with_flags_config() {
 
 #[test]
 fn cant_shadow_builtin() {
-    let p = project("foo")
+    let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
         .file(
             "src/main.rs",

--- a/tests/testsuite/cargo_command.rs
+++ b/tests/testsuite/cargo_command.rs
@@ -62,7 +62,7 @@ fn path() -> Vec<PathBuf> {
 
 #[test]
 fn list_command_looks_at_path() {
-    let proj = project("list-non-overlapping").build();
+    let proj = project().at("list-non-overlapping").build();
     let proj = fake_file(
         proj,
         Path::new("path-test"),
@@ -88,7 +88,7 @@ fn list_command_looks_at_path() {
 #[cfg(unix)]
 #[test]
 fn list_command_resolves_symlinks() {
-    let proj = project("list-non-overlapping").build();
+    let proj = project().at("list-non-overlapping").build();
     let proj = fake_file(
         proj,
         Path::new("path-test"),
@@ -236,7 +236,7 @@ fn cargo_subcommand_env() {
         cargo::CARGO_ENV
     );
 
-    let p = project("cargo-envtest")
+    let p = project().at("cargo-envtest")
         .file("Cargo.toml", &basic_bin_manifest("cargo-envtest"))
         .file("src/main.rs", &src)
         .build();
@@ -260,7 +260,7 @@ fn cargo_subcommand_env() {
 
 #[test]
 fn cargo_subcommand_args() {
-    let p = project("cargo-foo")
+    let p = project().at("cargo-foo")
         .file(
             "Cargo.toml",
             r#"

--- a/tests/testsuite/cargo_features.rs
+++ b/tests/testsuite/cargo_features.rs
@@ -4,7 +4,7 @@ use hamcrest::assert_that;
 
 #[test]
 fn feature_required() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -56,7 +56,7 @@ switch to nightly channel you can add
 
 #[test]
 fn unknown_feature() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -85,7 +85,7 @@ Caused by:
 
 #[test]
 fn stable_feature_warns() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -114,7 +114,7 @@ necessary to be listed in the manifest
 
 #[test]
 fn nightly_feature_requires_nightly() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -155,7 +155,7 @@ Caused by:
 
 #[test]
 fn nightly_feature_requires_nightly_in_dep() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -216,7 +216,7 @@ Caused by:
 
 #[test]
 fn cant_publish() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -257,7 +257,7 @@ Caused by:
 
 #[test]
 fn z_flags_rejected() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -306,7 +306,7 @@ fn z_flags_rejected() {
 fn publish_allowed() {
     publish::setup();
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"

--- a/tests/testsuite/cargotest/mod.rs
+++ b/tests/testsuite/cargotest/mod.rs
@@ -10,7 +10,7 @@ checking the result.  Projects are created with the `ProjectBuilder` where you
 specify some files to create.  The general form looks like this:
 
 ```
-let p = project("foo")
+let p = project()
     .file("Cargo.toml", &basic_bin_manifest("foo"))
     .file("src/main.rs", r#"fn main() { println!("hi!"); }"#)
     .build();

--- a/tests/testsuite/cargotest/support/cross_compile.rs
+++ b/tests/testsuite/cargotest/support/cross_compile.rs
@@ -28,7 +28,7 @@ pub fn disabled() -> bool {
     let cross_target = alternate();
 
     CHECK.call_once(|| {
-        let p = project("cross_test")
+        let p = project().at("cross_test")
             .file("Cargo.toml", &basic_bin_manifest("cross_test"))
             .file("src/cross_test.rs", &main_file(r#""testing!""#, &[]))
             .build();

--- a/tests/testsuite/cargotest/support/git.rs
+++ b/tests/testsuite/cargotest/support/git.rs
@@ -80,7 +80,7 @@ pub fn new<F>(name: &str, callback: F) -> Result<Project, ProcessError>
 where
     F: FnOnce(ProjectBuilder) -> ProjectBuilder,
 {
-    let mut git_project = project(name);
+    let mut git_project = project().at(name);
     git_project = callback(git_project);
     let git_project = git_project.build();
 

--- a/tests/testsuite/cargotest/support/mod.rs
+++ b/tests/testsuite/cargotest/support/mod.rs
@@ -126,7 +126,6 @@ impl ProjectBuilder {
         }
     }
 
-    #[allow(dead_code)]
     pub fn at<P: AsRef<Path>>(mut self, path: P) -> Self {
         self.root = Project::Rooted(paths::root().join(path));
         self
@@ -351,8 +350,8 @@ impl Project {
 }
 
 // Generates a project layout
-pub fn project(name: &str) -> ProjectBuilder {
-    ProjectBuilder::new(paths::root().join(name))
+pub fn project() -> ProjectBuilder {
+    ProjectBuilder::new(paths::root().join("foo"))
 }
 
 // Generates a project layout inside our fake home dir

--- a/tests/testsuite/cargotest/support/mod.rs
+++ b/tests/testsuite/cargotest/support/mod.rs
@@ -126,6 +126,12 @@ impl ProjectBuilder {
         }
     }
 
+    #[allow(dead_code)]
+    pub fn at<P: AsRef<Path>>(mut self, path: P) -> Self {
+        self.root = Project::Rooted(paths::root().join(path));
+        self
+    }
+
     /// Add a file to the project.
     pub fn file<B: AsRef<Path>>(mut self, path: B, body: &str) -> Self {
         self._file(path.as_ref(), body);

--- a/tests/testsuite/cfg.rs
+++ b/tests/testsuite/cfg.rs
@@ -450,7 +450,7 @@ fn any_ok() {
 #[test]
 #[cfg(all(target_arch = "x86_64", target_os = "linux"))]
 fn cfg_looks_at_rustflags_for_target() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"

--- a/tests/testsuite/cfg.rs
+++ b/tests/testsuite/cfg.rs
@@ -143,7 +143,7 @@ fn cfg_matches() {
 
 #[test]
 fn cfg_easy() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -176,7 +176,7 @@ fn cfg_easy() {
 #[test]
 fn dont_include() {
     let other_family = if cfg!(unix) { "windows" } else { "unix" };
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             &format!(
@@ -223,7 +223,7 @@ fn works_through_the_registry() {
         .target_dep("foo", "0.1.0", "cfg(windows)")
         .publish();
 
-    let p = project("a")
+    let p = project().at("a")
         .file(
             "Cargo.toml",
             r#"
@@ -265,7 +265,7 @@ fn ignore_version_from_other_platform() {
     Package::new("foo", "0.1.0").publish();
     Package::new("foo", "0.2.0").publish();
 
-    let p = project("a")
+    let p = project().at("a")
         .file(
             "Cargo.toml",
             &format!(
@@ -306,7 +306,7 @@ fn ignore_version_from_other_platform() {
 
 #[test]
 fn bad_target_spec() {
-    let p = project("a")
+    let p = project().at("a")
         .file(
             "Cargo.toml",
             r#"
@@ -340,7 +340,7 @@ Caused by:
 
 #[test]
 fn bad_target_spec2() {
-    let p = project("a")
+    let p = project().at("a")
         .file(
             "Cargo.toml",
             r#"
@@ -374,7 +374,7 @@ Caused by:
 
 #[test]
 fn multiple_match_ok() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             &format!(
@@ -418,7 +418,7 @@ fn multiple_match_ok() {
 
 #[test]
 fn any_ok() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"

--- a/tests/testsuite/check.rs
+++ b/tests/testsuite/check.rs
@@ -15,7 +15,7 @@ authors = []
 
 #[test]
 fn check_success() {
-    let foo = project("foo")
+    let foo = project()
         .file(
             "Cargo.toml",
             r#"
@@ -38,7 +38,7 @@ fn check_success() {
         "#,
         )
         .build();
-    let _bar = project("bar")
+    let _bar = project().at("bar")
         .file(
             "Cargo.toml",
             r#"
@@ -61,7 +61,7 @@ fn check_success() {
 
 #[test]
 fn check_fail() {
-    let foo = project("foo")
+    let foo = project()
         .file(
             "Cargo.toml",
             r#"
@@ -84,7 +84,7 @@ fn check_fail() {
         "#,
         )
         .build();
-    let _bar = project("bar")
+    let _bar = project().at("bar")
         .file(
             "Cargo.toml",
             r#"
@@ -107,7 +107,7 @@ fn check_fail() {
 
 #[test]
 fn custom_derive() {
-    let foo = project("foo")
+    let foo = project()
         .file(
             "Cargo.toml",
             r#"
@@ -140,7 +140,7 @@ fn main() {
 "#,
         )
         .build();
-    let _bar = project("bar")
+    let _bar = project().at("bar")
         .file(
             "Cargo.toml",
             r#"
@@ -172,7 +172,7 @@ pub fn derive(_input: TokenStream) -> TokenStream {
 
 #[test]
 fn check_build() {
-    let foo = project("foo")
+    let foo = project()
         .file(
             "Cargo.toml",
             r#"
@@ -196,7 +196,7 @@ fn check_build() {
         )
         .build();
 
-    let _bar = project("bar")
+    let _bar = project().at("bar")
         .file(
             "Cargo.toml",
             r#"
@@ -220,7 +220,7 @@ fn check_build() {
 
 #[test]
 fn build_check() {
-    let foo = project("foo")
+    let foo = project()
         .file(
             "Cargo.toml",
             r#"
@@ -244,7 +244,7 @@ fn build_check() {
         )
         .build();
 
-    let _bar = project("bar")
+    let _bar = project().at("bar")
         .file(
             "Cargo.toml",
             r#"
@@ -270,7 +270,7 @@ fn build_check() {
 // not built.
 #[test]
 fn issue_3418() {
-    let foo = project("foo")
+    let foo = project()
         .file(
             "Cargo.toml",
             r#"
@@ -298,7 +298,7 @@ fn issue_3418() {
 // checked, but in this case with a proc macro too.
 #[test]
 fn issue_3419() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -359,7 +359,7 @@ fn issue_3419() {
 // Check on a dylib should have a different metadata hash than build.
 #[test]
 fn dylib_check_preserves_build_cache() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -400,7 +400,7 @@ fn dylib_check_preserves_build_cache() {
 // test `cargo rustc --profile check`
 #[test]
 fn rustc_check() {
-    let foo = project("foo")
+    let foo = project()
         .file(
             "Cargo.toml",
             r#"
@@ -423,7 +423,7 @@ fn rustc_check() {
         "#,
         )
         .build();
-    let _bar = project("bar")
+    let _bar = project().at("bar")
         .file(
             "Cargo.toml",
             r#"
@@ -453,7 +453,7 @@ fn rustc_check() {
 
 #[test]
 fn rustc_check_err() {
-    let foo = project("foo")
+    let foo = project()
         .file(
             "Cargo.toml",
             r#"
@@ -476,7 +476,7 @@ fn rustc_check_err() {
         "#,
         )
         .build();
-    let _bar = project("bar")
+    let _bar = project().at("bar")
         .file(
             "Cargo.toml",
             r#"
@@ -506,7 +506,7 @@ fn rustc_check_err() {
 
 #[test]
 fn check_all() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -550,7 +550,7 @@ fn check_all() {
 
 #[test]
 fn check_virtual_all_implied() {
-    let p = project("workspace")
+    let p = project().at("workspace")
         .file(
             "Cargo.toml",
             r#"
@@ -599,7 +599,7 @@ fn check_virtual_all_implied() {
 
 #[test]
 fn targets_selected_default() {
-    let foo = project("foo")
+    let foo = project()
         .file("Cargo.toml", SIMPLE_MANIFEST)
         .file("src/main.rs", "fn main() {}")
         .file("src/lib.rs", "pub fn smth() {}")
@@ -622,7 +622,7 @@ fn targets_selected_default() {
 
 #[test]
 fn targets_selected_all() {
-    let foo = project("foo")
+    let foo = project()
         .file("Cargo.toml", SIMPLE_MANIFEST)
         .file("src/main.rs", "fn main() {}")
         .file("src/lib.rs", "pub fn smth() {}")
@@ -645,7 +645,7 @@ fn targets_selected_all() {
 
 #[test]
 fn check_unit_test_profile() {
-    let foo = project("foo")
+    let foo = project()
         .file("Cargo.toml", SIMPLE_MANIFEST)
         .file(
             "src/lib.rs",
@@ -673,7 +673,7 @@ fn check_unit_test_profile() {
 // Verify what is checked with various command-line filters.
 #[test]
 fn check_filters() {
-    let p = project("foo")
+    let p = project()
         .file("Cargo.toml", SIMPLE_MANIFEST)
         .file(
             "src/lib.rs",
@@ -795,7 +795,7 @@ fn check_filters() {
 #[test]
 fn check_artifacts() {
     // Verify which artifacts are created when running check (#4059).
-    let p = project("foo")
+    let p = project()
         .file("Cargo.toml", SIMPLE_MANIFEST)
         .file("src/lib.rs", "")
         .file("src/main.rs", "fn main() {}")
@@ -915,7 +915,7 @@ fn check_artifacts() {
 
 #[test]
 fn proc_macro() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"

--- a/tests/testsuite/clean.rs
+++ b/tests/testsuite/clean.rs
@@ -6,7 +6,7 @@ use hamcrest::{assert_that, existing_dir, existing_file, is_not};
 
 #[test]
 fn cargo_clean_simple() {
-    let p = project("foo")
+    let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
         .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
         .build();
@@ -20,7 +20,7 @@ fn cargo_clean_simple() {
 
 #[test]
 fn different_dir() {
-    let p = project("foo")
+    let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
         .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
         .file("src/bar/a.rs", "")
@@ -38,7 +38,7 @@ fn different_dir() {
 
 #[test]
 fn clean_multiple_packages() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -109,7 +109,7 @@ fn clean_multiple_packages() {
 
 #[test]
 fn clean_release() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -163,7 +163,7 @@ fn clean_release() {
 
 #[test]
 fn clean_doc() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -203,7 +203,7 @@ fn clean_doc() {
 
 #[test]
 fn build_script() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -269,7 +269,7 @@ fn clean_git() {
             .file("src/lib.rs", "")
     }).unwrap();
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             &format!(
@@ -298,7 +298,7 @@ fn clean_git() {
 
 #[test]
 fn registry() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -326,7 +326,7 @@ fn registry() {
 
 #[test]
 fn clean_verbose() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"

--- a/tests/testsuite/concurrent.rs
+++ b/tests/testsuite/concurrent.rs
@@ -23,7 +23,7 @@ fn pkg(name: &str, vers: &str) {
 
 #[test]
 fn multiple_installs() {
-    let p = project("foo")
+    let p = project()
         .file(
             "a/Cargo.toml",
             r#"
@@ -102,7 +102,7 @@ fn concurrent_installs() {
 
 #[test]
 fn one_install_should_be_bad() {
-    let p = project("foo")
+    let p = project()
         .file(
             "a/Cargo.toml",
             r#"
@@ -168,7 +168,7 @@ fn multiple_registry_fetches() {
     }
     pkg.publish();
 
-    let p = project("foo")
+    let p = project()
         .file(
             "a/Cargo.toml",
             r#"
@@ -254,7 +254,7 @@ fn git_same_repo_different_tags() {
     git::commit(&repo);
     git::tag(&repo, "tag2");
 
-    let p = project("foo")
+    let p = project()
         .file(
             "a/Cargo.toml",
             &format!(
@@ -333,7 +333,7 @@ fn git_same_branch_different_revs() {
             .file("src/lib.rs", "pub fn f1() {}")
     }).unwrap();
 
-    let p = project("foo")
+    let p = project()
         .file(
             "a/Cargo.toml",
             &format!(
@@ -411,7 +411,7 @@ fn git_same_branch_different_revs() {
 
 #[test]
 fn same_project() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -447,7 +447,7 @@ fn same_project() {
 #[test]
 #[cfg_attr(target_os = "windows", ignore)]
 fn killing_cargo_releases_the_lock() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -508,7 +508,7 @@ fn killing_cargo_releases_the_lock() {
 
 #[test]
 fn debug_release_ok() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -584,7 +584,7 @@ fn no_deadlock_with_git_dependencies() {
             .file("src/lib.rs", "")
     }).unwrap();
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             &format!(

--- a/tests/testsuite/config.rs
+++ b/tests/testsuite/config.rs
@@ -9,7 +9,7 @@ use std::fs;
 
 #[test]
 fn read_env_vars_for_config() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"

--- a/tests/testsuite/corrupt_git.rs
+++ b/tests/testsuite/corrupt_git.rs
@@ -8,7 +8,7 @@ use hamcrest::assert_that;
 
 #[test]
 fn deleting_database_files() {
-    let project = project("foo");
+    let project = project();
     let git_project = git::new("bar", |project| {
         project
             .file(
@@ -80,7 +80,7 @@ fn deleting_database_files() {
 
 #[test]
 fn deleting_checkout_files() {
-    let project = project("foo");
+    let project = project();
     let git_project = git::new("bar", |project| {
         project
             .file(

--- a/tests/testsuite/cross_compile.rs
+++ b/tests/testsuite/cross_compile.rs
@@ -9,7 +9,7 @@ fn simple_cross() {
         return;
     }
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -64,7 +64,7 @@ fn simple_cross_config() {
         return;
     }
 
-    let p = project("foo")
+    let p = project()
         .file(
             ".cargo/config",
             &format!(
@@ -126,7 +126,7 @@ fn simple_deps() {
         return;
     }
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -147,7 +147,7 @@ fn simple_deps() {
         "#,
         )
         .build();
-    let _p2 = project("bar")
+    let _p2 = project().at("bar")
         .file(
             "Cargo.toml",
             r#"
@@ -182,7 +182,7 @@ fn plugin_deps() {
         return;
     }
 
-    let foo = project("foo")
+    let foo = project()
         .file(
             "Cargo.toml",
             r#"
@@ -210,7 +210,7 @@ fn plugin_deps() {
         "#,
         )
         .build();
-    let _bar = project("bar")
+    let _bar = project().at("bar")
         .file(
             "Cargo.toml",
             r#"
@@ -251,7 +251,7 @@ fn plugin_deps() {
         "#,
         )
         .build();
-    let _baz = project("baz")
+    let _baz = project().at("baz")
         .file(
             "Cargo.toml",
             r#"
@@ -286,7 +286,7 @@ fn plugin_to_the_max() {
         return;
     }
 
-    let foo = project("foo")
+    let foo = project()
         .file(
             "Cargo.toml",
             r#"
@@ -314,7 +314,7 @@ fn plugin_to_the_max() {
         "#,
         )
         .build();
-    let _bar = project("bar")
+    let _bar = project().at("bar")
         .file(
             "Cargo.toml",
             r#"
@@ -362,7 +362,7 @@ fn plugin_to_the_max() {
         "#,
         )
         .build();
-    let _baz = project("baz")
+    let _baz = project().at("baz")
         .file(
             "Cargo.toml",
             r#"
@@ -400,7 +400,7 @@ fn linker_and_ar() {
     }
 
     let target = cross_compile::alternate();
-    let p = project("foo")
+    let p = project()
         .file(
             ".cargo/config",
             &format!(
@@ -457,7 +457,7 @@ fn plugin_with_extra_dylib_dep() {
         return;
     }
 
-    let foo = project("foo")
+    let foo = project()
         .file(
             "Cargo.toml",
             r#"
@@ -480,7 +480,7 @@ fn plugin_with_extra_dylib_dep() {
         "#,
         )
         .build();
-    let _bar = project("bar")
+    let _bar = project().at("bar")
         .file(
             "Cargo.toml",
             r#"
@@ -514,7 +514,7 @@ fn plugin_with_extra_dylib_dep() {
         "#,
         )
         .build();
-    let _baz = project("baz")
+    let _baz = project().at("baz")
         .file(
             "Cargo.toml",
             r#"
@@ -544,7 +544,7 @@ fn cross_tests() {
         return;
     }
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -610,7 +610,7 @@ fn no_cross_doctests() {
         return;
     }
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -685,7 +685,7 @@ fn simple_cargo_run() {
         return;
     }
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -723,7 +723,7 @@ fn cross_with_a_build_script() {
     }
 
     let target = cross_compile::alternate();
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -787,7 +787,7 @@ fn build_script_needed_for_host_and_target() {
 
     let target = cross_compile::alternate();
     let host = rustc_host();
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -916,7 +916,7 @@ fn build_deps_for_the_right_arch() {
         return;
     }
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -975,7 +975,7 @@ fn build_script_only_host() {
         return;
     }
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1033,7 +1033,7 @@ fn plugin_build_script_right_arch() {
     if cross_compile::disabled() {
         return;
     }
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1077,7 +1077,7 @@ fn build_script_with_platform_specific_dependencies() {
 
     let target = cross_compile::alternate();
     let host = rustc_host();
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1162,7 +1162,7 @@ fn platform_specific_dependencies_do_not_leak() {
 
     let target = cross_compile::alternate();
     let host = rustc_host();
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1225,7 +1225,7 @@ fn platform_specific_variables_reflected_in_build_scripts() {
 
     let target = cross_compile::alternate();
     let host = rustc_host();
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             &format!(
@@ -1324,7 +1324,7 @@ fn cross_test_dylib() {
 
     let target = cross_compile::alternate();
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"

--- a/tests/testsuite/cross_publish.rs
+++ b/tests/testsuite/cross_publish.rs
@@ -13,7 +13,7 @@ fn simple_cross_package() {
         return;
     }
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -86,7 +86,7 @@ fn publish_with_target() {
 
     publish::setup();
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"

--- a/tests/testsuite/custom_target.rs
+++ b/tests/testsuite/custom_target.rs
@@ -7,7 +7,7 @@ fn custom_target_minimal() {
     if !is_nightly() {
         return;
     }
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -79,7 +79,7 @@ fn custom_target_dependency() {
     if !is_nightly() {
         return;
     }
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"

--- a/tests/testsuite/death.rs
+++ b/tests/testsuite/death.rs
@@ -56,7 +56,7 @@ fn ctrl_c_kills_everyone() {
     let listener = TcpListener::bind("127.0.0.1:0").unwrap();
     let addr = listener.local_addr().unwrap();
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"

--- a/tests/testsuite/dep_info.rs
+++ b/tests/testsuite/dep_info.rs
@@ -4,7 +4,7 @@ use hamcrest::{assert_that, existing_file};
 
 #[test]
 fn build_dep_info() {
-    let p = project("foo")
+    let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
         .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
         .build();
@@ -18,7 +18,7 @@ fn build_dep_info() {
 
 #[test]
 fn build_dep_info_lib() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -46,7 +46,7 @@ fn build_dep_info_lib() {
 
 #[test]
 fn build_dep_info_rlib() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -73,7 +73,7 @@ fn build_dep_info_rlib() {
 
 #[test]
 fn build_dep_info_dylib() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -100,7 +100,7 @@ fn build_dep_info_dylib() {
 
 #[test]
 fn no_rewrite_if_no_change() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"

--- a/tests/testsuite/directory.rs
+++ b/tests/testsuite/directory.rs
@@ -39,7 +39,7 @@ struct Checksum {
 impl VendorPackage {
     fn new(name: &str) -> VendorPackage {
         VendorPackage {
-            p: Some(project(&format!("index/{}", name))),
+            p: Some(project().at(&format!("index/{}", name))),
             cksum: Checksum {
                 package: Some(String::new()),
                 files: HashMap::new(),
@@ -85,7 +85,7 @@ fn simple() {
         .file("src/lib.rs", "pub fn foo() {}")
         .build();
 
-    let p = project("bar")
+    let p = project().at("bar")
         .file(
             "Cargo.toml",
             r#"
@@ -301,9 +301,9 @@ warning: be sure to add `[..]` to your PATH to be able to run the installed bina
 fn not_there() {
     setup();
 
-    let _ = project("index").build();
+    let _ = project().at("index").build();
 
-    let p = project("bar")
+    let p = project().at("bar")
         .file(
             "Cargo.toml",
             r#"
@@ -372,7 +372,7 @@ fn multiple() {
         .file(".cargo-checksum", "")
         .build();
 
-    let p = project("bar")
+    let p = project().at("bar")
         .file(
             "Cargo.toml",
             r#"
@@ -411,7 +411,7 @@ fn multiple() {
 
 #[test]
 fn crates_io_then_directory() {
-    let p = project("bar")
+    let p = project().at("bar")
         .file(
             "Cargo.toml",
             r#"
@@ -483,7 +483,7 @@ fn crates_io_then_directory() {
 
 #[test]
 fn crates_io_then_bad_checksum() {
-    let p = project("bar")
+    let p = project().at("bar")
         .file(
             "Cargo.toml",
             r#"
@@ -556,7 +556,7 @@ fn bad_file_checksum() {
     let mut f = t!(File::create(paths::root().join("index/foo/src/lib.rs")));
     t!(f.write_all(b"fn foo() -> u32 { 0 }"));
 
-    let p = project("bar")
+    let p = project().at("bar")
         .file(
             "Cargo.toml",
             r#"
@@ -606,7 +606,7 @@ fn only_dot_files_ok() {
         .build();
     VendorPackage::new("bar").file(".foo", "").build();
 
-    let p = project("bar")
+    let p = project().at("bar")
         .file(
             "Cargo.toml",
             r#"
@@ -646,7 +646,7 @@ fn random_files_ok() {
         .file("../test", "")
         .build();
 
-    let p = project("bar")
+    let p = project().at("bar")
         .file(
             "Cargo.toml",
             r#"
@@ -693,7 +693,7 @@ fn git_lock_file_doesnt_change() {
         .disable_checksum()
         .build();
 
-    let p = project("bar")
+    let p = project().at("bar")
         .file(
             "Cargo.toml",
             &format!(
@@ -765,7 +765,7 @@ fn git_override_requires_lockfile() {
         .disable_checksum()
         .build();
 
-    let p = project("bar")
+    let p = project().at("bar")
         .file(
             "Cargo.toml",
             r#"

--- a/tests/testsuite/doc.rs
+++ b/tests/testsuite/doc.rs
@@ -1483,7 +1483,7 @@ fn doc_workspace_open_help_message() {
 #[test]
 #[cfg(not(any(target_os = "windows", target_os = "macos")))]
 fn doc_workspace_open_different_library_and_package_names() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1516,7 +1516,7 @@ fn doc_workspace_open_different_library_and_package_names() {
 #[test]
 #[cfg(not(any(target_os = "windows", target_os = "macos")))]
 fn doc_workspace_open_binary() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1550,7 +1550,7 @@ fn doc_workspace_open_binary() {
 #[test]
 #[cfg(not(any(target_os = "windows", target_os = "macos")))]
 fn doc_workspace_open_binary_and_library() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"

--- a/tests/testsuite/doc.rs
+++ b/tests/testsuite/doc.rs
@@ -12,7 +12,7 @@ use glob::glob;
 
 #[test]
 fn simple() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -49,7 +49,7 @@ fn simple() {
 
 #[test]
 fn doc_no_libs() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -76,7 +76,7 @@ fn doc_no_libs() {
 
 #[test]
 fn doc_twice() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -110,7 +110,7 @@ fn doc_twice() {
 
 #[test]
 fn doc_deps() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -191,7 +191,7 @@ fn doc_deps() {
 
 #[test]
 fn doc_no_deps() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -250,7 +250,7 @@ fn doc_no_deps() {
 
 #[test]
 fn doc_only_bin() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -296,7 +296,7 @@ fn doc_only_bin() {
 
 #[test]
 fn doc_multiple_targets_same_name_lib() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -340,7 +340,7 @@ fn doc_multiple_targets_same_name_lib() {
 
 #[test]
 fn doc_multiple_targets_same_name() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -390,7 +390,7 @@ fn doc_multiple_targets_same_name() {
 
 #[test]
 fn doc_multiple_targets_same_name_bin() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -434,7 +434,7 @@ fn doc_multiple_targets_same_name_bin() {
 
 #[test]
 fn doc_multiple_targets_same_name_undoced() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -472,7 +472,7 @@ fn doc_multiple_targets_same_name_undoced() {
 
 #[test]
 fn doc_lib_bin_same_name_documents_lib() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -525,7 +525,7 @@ fn doc_lib_bin_same_name_documents_lib() {
 
 #[test]
 fn doc_lib_bin_same_name_documents_lib_when_requested() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -578,7 +578,7 @@ fn doc_lib_bin_same_name_documents_lib_when_requested() {
 
 #[test]
 fn doc_lib_bin_same_name_documents_named_bin_when_requested() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -632,7 +632,7 @@ fn doc_lib_bin_same_name_documents_named_bin_when_requested() {
 
 #[test]
 fn doc_lib_bin_same_name_documents_bins_when_requested() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -686,7 +686,7 @@ fn doc_lib_bin_same_name_documents_bins_when_requested() {
 
 #[test]
 fn doc_dash_p() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -740,7 +740,7 @@ fn doc_dash_p() {
 
 #[test]
 fn doc_same_name() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -763,7 +763,7 @@ fn doc_same_name() {
 fn doc_target() {
     const TARGET: &'static str = "arm-unknown-linux-gnueabihf";
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -803,7 +803,7 @@ fn doc_target() {
 
 #[test]
 fn target_specific_not_documented() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -834,7 +834,7 @@ fn target_specific_not_documented() {
 
 #[test]
 fn output_not_captured() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -889,7 +889,7 @@ fn output_not_captured() {
 
 #[test]
 fn target_specific_documented() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             &format!(
@@ -939,7 +939,7 @@ fn target_specific_documented() {
 
 #[test]
 fn no_document_build_deps() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -983,7 +983,7 @@ fn no_document_build_deps() {
 
 #[test]
 fn doc_release() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1011,7 +1011,7 @@ fn doc_release() {
 
 #[test]
 fn doc_multiple_deps() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1083,7 +1083,7 @@ fn doc_multiple_deps() {
 
 #[test]
 fn features() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1151,7 +1151,7 @@ fn features() {
 
 #[test]
 fn rerun_when_dir_removed() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1181,7 +1181,7 @@ fn rerun_when_dir_removed() {
 
 #[test]
 fn document_only_lib() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1218,7 +1218,7 @@ fn plugins_no_use_target() {
     if !cargotest::is_nightly() {
         return;
     }
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1243,7 +1243,7 @@ fn plugins_no_use_target() {
 
 #[test]
 fn doc_all_workspace() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1292,7 +1292,7 @@ fn doc_all_workspace() {
 
 #[test]
 fn doc_all_virtual_manifest() {
-    let p = project("workspace")
+    let p = project().at("workspace")
         .file(
             "Cargo.toml",
             r#"
@@ -1342,7 +1342,7 @@ fn doc_all_virtual_manifest() {
 
 #[test]
 fn doc_virtual_manifest_all_implied() {
-    let p = project("workspace")
+    let p = project().at("workspace")
         .file(
             "Cargo.toml",
             r#"
@@ -1392,7 +1392,7 @@ fn doc_virtual_manifest_all_implied() {
 
 #[test]
 fn doc_all_member_dependency_same_name() {
-    let p = project("workspace")
+    let p = project().at("workspace")
         .file(
             "Cargo.toml",
             r#"
@@ -1432,7 +1432,7 @@ fn doc_all_member_dependency_same_name() {
 
 #[test]
 fn doc_workspace_open_help_message() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1591,7 +1591,7 @@ fn doc_edition() {
         // is stabilized.
         return;
     }
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1625,7 +1625,7 @@ fn doc_edition() {
 // caused `cargo doc` to fail.
 #[test]
 fn issue_5345() {
-    let foo = project("foo")
+    let foo = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1652,7 +1652,7 @@ fn issue_5345() {
 
 #[test]
 fn doc_private_items() {
-    let foo = project("foo")
+    let foo = project()
         .file(
             "Cargo.toml",
             r#"

--- a/tests/testsuite/features.rs
+++ b/tests/testsuite/features.rs
@@ -9,7 +9,7 @@ use cargotest::support::registry::Package;
 
 #[test]
 fn invalid1() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -40,7 +40,7 @@ Caused by:
 
 #[test]
 fn invalid2() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -74,7 +74,7 @@ Caused by:
 
 #[test]
 fn invalid3() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -109,7 +109,7 @@ Consider adding `optional = true` to the dependency
 
 #[test]
 fn invalid4() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -171,7 +171,7 @@ failed to select a version for `bar` which could resolve this conflict",
 
 #[test]
 fn invalid5() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -203,7 +203,7 @@ Caused by:
 
 #[test]
 fn invalid6() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -234,7 +234,7 @@ Caused by:
 
 #[test]
 fn invalid7() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -266,7 +266,7 @@ Caused by:
 
 #[test]
 fn invalid8() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -303,7 +303,7 @@ fn invalid8() {
 
 #[test]
 fn invalid9() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -341,7 +341,7 @@ that name, but only optional dependencies can be used as features. [..]
 
 #[test]
 fn invalid10() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -394,7 +394,7 @@ that name, but only optional dependencies can be used as features. [..]
 
 #[test]
 fn no_transitive_dep_feature_requirement() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -466,7 +466,7 @@ fn no_transitive_dep_feature_requirement() {
 
 #[test]
 fn no_feature_doesnt_build() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -537,7 +537,7 @@ fn no_feature_doesnt_build() {
 
 #[test]
 fn default_feature_pulled_in() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -611,7 +611,7 @@ fn default_feature_pulled_in() {
 
 #[test]
 fn cyclic_feature() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -637,7 +637,7 @@ fn cyclic_feature() {
 
 #[test]
 fn cyclic_feature2() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -659,7 +659,7 @@ fn cyclic_feature2() {
 
 #[test]
 fn groups_on_groups_on_groups() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -735,7 +735,7 @@ fn groups_on_groups_on_groups() {
 
 #[test]
 fn many_cli_features() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -801,7 +801,7 @@ fn many_cli_features() {
 
 #[test]
 fn union_features() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -886,7 +886,7 @@ fn union_features() {
 
 #[test]
 fn many_features_no_rebuilds() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -946,7 +946,7 @@ fn many_features_no_rebuilds() {
 // Tests that all cmd lines work with `--features ""`
 #[test]
 fn empty_features() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -968,7 +968,7 @@ fn empty_features() {
 // Tests that all cmd lines work with `--features ""`
 #[test]
 fn transitive_features() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1020,7 +1020,7 @@ fn transitive_features() {
 
 #[test]
 fn everything_in_the_lockfile() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1105,7 +1105,7 @@ fn everything_in_the_lockfile() {
 
 #[test]
 fn no_rebuild_when_frobbing_default_feature() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1156,7 +1156,7 @@ fn no_rebuild_when_frobbing_default_feature() {
 
 #[test]
 fn unions_work_with_no_default_features() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1219,7 +1219,7 @@ fn unions_work_with_no_default_features() {
 
 #[test]
 fn optional_and_dev_dep() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1260,7 +1260,7 @@ fn optional_and_dev_dep() {
 
 #[test]
 fn activating_feature_activates_dep() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1314,7 +1314,7 @@ fn activating_feature_activates_dep() {
 
 #[test]
 fn dep_feature_in_cmd_line() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1412,7 +1412,7 @@ fn dep_feature_in_cmd_line() {
 
 #[test]
 fn all_features_flag_enables_all_features() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1468,7 +1468,7 @@ fn all_features_flag_enables_all_features() {
 
 #[test]
 fn many_cli_features_comma_delimited() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1534,7 +1534,7 @@ fn many_cli_features_comma_delimited() {
 
 #[test]
 fn many_cli_features_comma_and_space_delimited() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1636,7 +1636,7 @@ fn many_cli_features_comma_and_space_delimited() {
 fn combining_features_and_package() {
     Package::new("dep", "1.0.0").publish();
 
-    let p = project("ws")
+    let p = project().at("ws")
         .file(
             "Cargo.toml",
             r#"
@@ -1721,7 +1721,7 @@ fn combining_features_and_package() {
 
 #[test]
 fn namespaced_invalid_feature() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1755,7 +1755,7 @@ Caused by:
 
 #[test]
 fn namespaced_invalid_dependency() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1789,7 +1789,7 @@ Caused by:
 
 #[test]
 fn namespaced_non_optional_dependency() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1827,7 +1827,7 @@ Consider adding `optional = true` to the dependency
 
 #[test]
 fn namespaced_implicit_feature() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1857,7 +1857,7 @@ fn namespaced_implicit_feature() {
 
 #[test]
 fn namespaced_shadowed_dep() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1895,7 +1895,7 @@ Consider adding `crate:baz` to this feature's requirements.
 
 #[test]
 fn namespaced_shadowed_non_optional() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1934,7 +1934,7 @@ Consider adding `crate:baz` to this feature's requirements and marking the depen
 
 #[test]
 fn namespaced_implicit_non_optional() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1972,7 +1972,7 @@ A non-optional dependency of the same name is defined; consider adding `optional
 
 #[test]
 fn namespaced_same_name() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -2004,7 +2004,7 @@ fn namespaced_same_name() {
 fn only_dep_is_optional() {
     Package::new("bar", "0.1.0").publish();
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -2036,7 +2036,7 @@ fn only_dep_is_optional() {
 fn all_features_all_crates() {
     Package::new("bar", "0.1.0").publish();
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"

--- a/tests/testsuite/fetch.rs
+++ b/tests/testsuite/fetch.rs
@@ -5,7 +5,7 @@ use hamcrest::assert_that;
 
 #[test]
 fn no_deps() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -55,7 +55,7 @@ fn fetch_all_platform_dependencies_when_no_target_is_given() {
 
     let target = cross_compile::alternate();
     let host = rustc_host();
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             &format!(
@@ -115,7 +115,7 @@ fn fetch_platform_specific_dependencies() {
 
     let target = cross_compile::alternate();
     let host = rustc_host();
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             &format!(

--- a/tests/testsuite/fix.rs
+++ b/tests/testsuite/fix.rs
@@ -6,7 +6,7 @@ use hamcrest::assert_that;
 
 #[test]
 fn do_not_fix_broken_builds() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -40,7 +40,7 @@ fn do_not_fix_broken_builds() {
 
 #[test]
 fn fix_broken_if_requested() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -69,7 +69,7 @@ fn fix_broken_if_requested() {
 
 #[test]
 fn broken_fixes_backed_out() {
-    let p = project("foo")
+    let p = project()
         .file(
             "foo/Cargo.toml",
             r#"
@@ -171,7 +171,7 @@ fn broken_fixes_backed_out() {
 
 #[test]
 fn fix_path_deps() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -233,7 +233,7 @@ fn fix_path_deps() {
 
 #[test]
 fn do_not_fix_non_relevant_deps() {
-    let p = project("foo")
+    let p = project()
         .file(
             "foo/Cargo.toml",
             r#"
@@ -282,7 +282,7 @@ fn prepare_for_2018() {
     if !is_nightly() {
         return
     }
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -332,7 +332,7 @@ fn local_paths() {
     if !is_nightly() {
         return
     }
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -379,7 +379,7 @@ fn local_paths_no_fix() {
     if !is_nightly() {
         return
     }
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -419,7 +419,7 @@ fn upgrade_extern_crate() {
     if !is_nightly() {
         return
     }
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -482,7 +482,7 @@ fn specify_rustflags() {
     if !is_nightly() {
         return
     }
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -522,7 +522,7 @@ fn specify_rustflags() {
 
 #[test]
 fn no_changes_necessary() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -546,7 +546,7 @@ fn no_changes_necessary() {
 
 #[test]
 fn fixes_extra_mut() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -580,7 +580,7 @@ fn fixes_extra_mut() {
 
 #[test]
 fn fixes_two_missing_ampersands() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -615,7 +615,7 @@ fn fixes_two_missing_ampersands() {
 
 #[test]
 fn tricky() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -649,7 +649,7 @@ fn tricky() {
 
 #[test]
 fn preserve_line_endings() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -677,7 +677,7 @@ fn preserve_line_endings() {
 
 #[test]
 fn fix_deny_warnings() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -704,7 +704,7 @@ fn fix_deny_warnings() {
 
 #[test]
 fn fix_deny_warnings_but_not_others() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -739,7 +739,7 @@ fn fix_deny_warnings_but_not_others() {
 
 #[test]
 fn fix_two_files() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -785,7 +785,7 @@ fn fix_two_files() {
 
 #[test]
 fn fixes_missing_ampersand() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -853,7 +853,7 @@ fn fixes_missing_ampersand() {
 
 #[test]
 fn fix_features() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -884,7 +884,7 @@ fn fix_features() {
 
 #[test]
 fn shows_warnings() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -912,7 +912,7 @@ fn shows_warnings() {
 
 #[test]
 fn warns_if_no_vcs_detected() {
-    let p = project("foo")
+    let p = project()
         .use_temp_dir()
         .file(
             "Cargo.toml",
@@ -948,7 +948,7 @@ destructive changes; if you'd like to suppress this error pass `--allow-no-vcs`\
 
 #[test]
 fn warns_about_dirty_working_directory() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -992,7 +992,7 @@ these files:
 
 #[test]
 fn does_not_warn_about_clean_working_directory() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"

--- a/tests/testsuite/freshness.rs
+++ b/tests/testsuite/freshness.rs
@@ -9,7 +9,7 @@ use hamcrest::{assert_that, existing_file};
 
 #[test]
 fn modifying_and_moving() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -64,7 +64,7 @@ fn modifying_and_moving() {
 
 #[test]
 fn modify_only_some_files() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -131,7 +131,7 @@ fn modify_only_some_files() {
 
 #[test]
 fn rebuild_sub_package_then_while_package() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -200,7 +200,7 @@ fn rebuild_sub_package_then_while_package() {
 
 #[test]
 fn changing_lib_features_caches_targets() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -257,7 +257,7 @@ fn changing_lib_features_caches_targets() {
 
 #[test]
 fn changing_profiles_caches_targets() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -319,7 +319,7 @@ fn changing_profiles_caches_targets() {
 #[test]
 fn changing_bin_paths_common_target_features_caches_targets() {
     // Make sure dep_cache crate is built once per feature
-    let p = project("foo")
+    let p = project()
         .file(
             ".cargo/config",
             r#"
@@ -491,7 +491,7 @@ fn changing_bin_paths_common_target_features_caches_targets() {
 
 #[test]
 fn changing_bin_features_caches_targets() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -585,7 +585,7 @@ fn changing_bin_features_caches_targets() {
 
 #[test]
 fn rebuild_tests_if_lib_changes() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -618,7 +618,7 @@ fn rebuild_tests_if_lib_changes() {
 
 #[test]
 fn no_rebuild_transitive_target_deps() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -689,7 +689,7 @@ fn no_rebuild_transitive_target_deps() {
 
 #[test]
 fn rerun_if_changed_in_dep() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -730,7 +730,7 @@ fn rerun_if_changed_in_dep() {
 
 #[test]
 fn same_build_dir_cached_packages() {
-    let p = project("foo")
+    let p = project()
         .file(
             "a1/Cargo.toml",
             r#"
@@ -825,7 +825,7 @@ fn same_build_dir_cached_packages() {
 
 #[test]
 fn no_rebuild_if_build_artifacts_move_backwards_in_time() {
-    let p = project("backwards_in_time")
+    let p = project().at("backwards_in_time")
         .file(
             "Cargo.toml",
             r#"
@@ -866,7 +866,7 @@ fn no_rebuild_if_build_artifacts_move_backwards_in_time() {
 
 #[test]
 fn rebuild_if_build_artifacts_move_forward_in_time() {
-    let p = project("forwards_in_time")
+    let p = project().at("forwards_in_time")
         .file(
             "Cargo.toml",
             r#"
@@ -910,7 +910,7 @@ fn rebuild_if_build_artifacts_move_forward_in_time() {
 
 #[test]
 fn rebuild_if_environment_changes() {
-    let p = project("env_change")
+    let p = project().at("env_change")
         .file(
             "Cargo.toml",
             r#"
@@ -977,7 +977,7 @@ fn rebuild_if_environment_changes() {
 
 #[test]
 fn no_rebuild_when_rename_dir() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1023,7 +1023,7 @@ fn unused_optional_dep() {
     Package::new("registry2", "0.1.0").publish();
     Package::new("registry3", "0.1.0").publish();
 
-    let p = project("p")
+    let p = project().at("p")
         .file(
             "Cargo.toml",
             r#"
@@ -1079,7 +1079,7 @@ fn path_dev_dep_registry_updates() {
     Package::new("registry1", "0.1.0").publish();
     Package::new("registry2", "0.1.0").publish();
 
-    let p = project("p")
+    let p = project().at("p")
         .file(
             "Cargo.toml",
             r#"
@@ -1133,7 +1133,7 @@ fn path_dev_dep_registry_updates() {
 
 #[test]
 fn change_panic_mode() {
-    let p = project("p")
+    let p = project().at("p")
         .file(
             "Cargo.toml",
             r#"
@@ -1178,7 +1178,7 @@ fn change_panic_mode() {
 
 #[test]
 fn dont_rebuild_based_on_plugins() {
-    let p = project("p")
+    let p = project().at("p")
         .file(
             "Cargo.toml",
             r#"
@@ -1246,7 +1246,7 @@ fn dont_rebuild_based_on_plugins() {
 
 #[test]
 fn reuse_workspace_lib() {
-    let p = project("p")
+    let p = project().at("p")
         .file(
             "Cargo.toml",
             r#"

--- a/tests/testsuite/generate_lockfile.rs
+++ b/tests/testsuite/generate_lockfile.rs
@@ -8,7 +8,7 @@ use hamcrest::{assert_that, existing_file, is_not};
 
 #[test]
 fn adding_and_removing_packages() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -94,7 +94,7 @@ fn adding_and_removing_packages() {
 fn no_index_update() {
     Package::new("serde", "1.0.0").publish();
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -125,7 +125,7 @@ fn no_index_update() {
 
 #[test]
 fn preserve_metadata() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -176,7 +176,7 @@ foo = "bar"
 
 #[test]
 fn preserve_line_endings_issue_2076() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -226,7 +226,7 @@ fn preserve_line_endings_issue_2076() {
 
 #[test]
 fn cargo_update_generate_lockfile() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"

--- a/tests/testsuite/git.rs
+++ b/tests/testsuite/git.rs
@@ -16,7 +16,7 @@ use hamcrest::{assert_that, existing_file};
 
 #[test]
 fn cargo_compile_simple_git_dep() {
-    let project = project("foo");
+    let project = project();
     let git_project = git::new("dep1", |project| {
         project
             .file(
@@ -93,7 +93,7 @@ fn cargo_compile_simple_git_dep() {
 
 #[test]
 fn cargo_compile_forbird_git_httpsrepo_offline() {
-    let p = project("need_remote_repo")
+    let p = project().at("need_remote_repo")
         .file(
             "Cargo.toml",
             r#"
@@ -162,7 +162,7 @@ fn cargo_compile_offline_with_cached_git_dep() {
 
     {
         // cache to registry rev1 and rev2
-        let prj = project("cache_git_dep")
+        let prj = project().at("cache_git_dep")
             .file(
                 "Cargo.toml",
                 &format!(
@@ -202,7 +202,7 @@ fn cargo_compile_offline_with_cached_git_dep() {
         assert_that(prj.cargo("build"), execs().with_status(0));
     }
 
-    let project = project("foo")
+    let project = project()
         .file(
             "Cargo.toml",
             &format!(
@@ -280,7 +280,7 @@ fn cargo_compile_offline_with_cached_git_dep() {
 
 #[test]
 fn cargo_compile_git_dep_branch() {
-    let project = project("foo");
+    let project = project();
     let git_project = git::new("dep1", |project| {
         project
             .file(
@@ -365,7 +365,7 @@ fn cargo_compile_git_dep_branch() {
 
 #[test]
 fn cargo_compile_git_dep_tag() {
-    let project = project("foo");
+    let project = project();
     let git_project = git::new("dep1", |project| {
         project
             .file(
@@ -511,7 +511,7 @@ fn cargo_compile_with_nested_paths() {
             )
     }).unwrap();
 
-    let p = project("parent")
+    let p = project().at("parent")
         .file(
             "Cargo.toml",
             &format!(
@@ -584,7 +584,7 @@ fn cargo_compile_with_malformed_nested_paths() {
             )
     }).unwrap();
 
-    let p = project("parent")
+    let p = project().at("parent")
         .file(
             "Cargo.toml",
             &format!(
@@ -673,7 +673,7 @@ fn cargo_compile_with_meta_package() {
             )
     }).unwrap();
 
-    let p = project("parent")
+    let p = project().at("parent")
         .file(
             "Cargo.toml",
             &format!(
@@ -725,7 +725,7 @@ fn cargo_compile_with_meta_package() {
 fn cargo_compile_with_short_ssh_git() {
     let url = "git@github.com:a/dep";
 
-    let project = project("project")
+    let project = project().at("project")
         .file(
             "Cargo.toml",
             &format!(
@@ -798,7 +798,7 @@ fn two_revs_same_deps() {
     git::add(&repo);
     let rev2 = git::commit(&repo);
 
-    let foo = project("foo")
+    let foo = project()
         .file(
             "Cargo.toml",
             &format!(
@@ -833,7 +833,7 @@ fn two_revs_same_deps() {
         )
         .build();
 
-    let _baz = project("baz")
+    let _baz = project().at("baz")
         .file(
             "Cargo.toml",
             &format!(
@@ -890,7 +890,7 @@ fn recompilation() {
             )
     }).unwrap();
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             &format!(
@@ -1026,7 +1026,7 @@ fn update_with_shared_deps() {
             )
     }).unwrap();
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1197,7 +1197,7 @@ Caused by:
 
 #[test]
 fn dep_with_submodule() {
-    let project = project("foo");
+    let project = project();
     let git_project = git::new("dep1", |project| {
         project.file(
             "Cargo.toml",
@@ -1260,7 +1260,7 @@ fn dep_with_submodule() {
 
 #[test]
 fn dep_with_bad_submodule() {
-    let project = project("foo");
+    let project = project();
     let git_project = git::new("dep1", |project| {
         project.file(
             "Cargo.toml",
@@ -1348,7 +1348,7 @@ Caused by:
 
 #[test]
 fn two_deps_only_update_one() {
-    let project = project("foo");
+    let project = project();
     let git1 = git::new("dep1", |project| {
         project
             .file(
@@ -1453,7 +1453,7 @@ fn stale_cached_version() {
 
     // Update the git database in the cache with the current state of the git
     // repo
-    let foo = project("foo")
+    let foo = project()
         .file(
             "Cargo.toml",
             &format!(
@@ -1542,7 +1542,7 @@ fn stale_cached_version() {
 
 #[test]
 fn dep_with_changed_submodule() {
-    let project = project("foo");
+    let project = project();
     let git_project = git::new("dep1", |project| {
         project.file(
             "Cargo.toml",
@@ -1687,7 +1687,7 @@ fn dev_deps_with_testing() {
             )
     }).unwrap();
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             &format!(
@@ -1824,7 +1824,7 @@ fn git_name_not_always_needed() {
     let _ = cfg.remove("user.name");
     let _ = cfg.remove("user.email");
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             &format!(
@@ -1876,7 +1876,7 @@ fn git_repo_changing_no_rebuild() {
     }).unwrap();
 
     // Lock p1 to the first rev in the git repo
-    let p1 = project("p1")
+    let p1 = project().at("p1")
         .file(
             "Cargo.toml",
             &format!(
@@ -1923,7 +1923,7 @@ fn git_repo_changing_no_rebuild() {
     git::commit(&repo);
 
     // Lock p2 to the second rev
-    let p2 = project("p2")
+    let p2 = project().at("p2")
         .file(
             "Cargo.toml",
             &format!(
@@ -2047,7 +2047,7 @@ fn fetch_downloads() {
             .file("src/lib.rs", "pub fn bar() -> i32 { 1 }")
     }).unwrap();
 
-    let p = project("p1")
+    let p = project().at("p1")
         .file(
             "Cargo.toml",
             &format!(
@@ -2091,7 +2091,7 @@ fn warnings_in_git_dep() {
             .file("src/lib.rs", "fn unused() {}")
     }).unwrap();
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             &format!(
@@ -2171,7 +2171,7 @@ fn update_ambiguous() {
             .file("src/lib.rs", "")
     }).unwrap();
 
-    let p = project("project")
+    let p = project().at("project")
         .file(
             "Cargo.toml",
             &format!(
@@ -2234,7 +2234,7 @@ fn update_one_dep_in_repo_with_many_deps() {
             .file("a/src/lib.rs", "")
     }).unwrap();
 
-    let p = project("project")
+    let p = project().at("project")
         .file(
             "Cargo.toml",
             &format!(
@@ -2318,7 +2318,7 @@ fn switch_deps_does_not_update_transitive() {
             .file("src/lib.rs", "")
     }).unwrap();
 
-    let p = project("project")
+    let p = project().at("project")
         .file(
             "Cargo.toml",
             &format!(
@@ -2414,7 +2414,7 @@ fn update_one_source_updates_all_packages_in_that_git_source() {
             .file("a/src/lib.rs", "")
     }).unwrap();
 
-    let p = project("project")
+    let p = project().at("project")
         .file(
             "Cargo.toml",
             &format!(
@@ -2495,7 +2495,7 @@ fn switch_sources() {
             .file("src/lib.rs", "")
     }).unwrap();
 
-    let p = project("project")
+    let p = project().at("project")
         .file(
             "Cargo.toml",
             r#"
@@ -2571,7 +2571,7 @@ fn switch_sources() {
 
 #[test]
 fn dont_require_submodules_are_checked_out() {
-    let p = project("foo").build();
+    let p = project().build();
     let git1 = git::new("dep1", |p| {
         p.file(
             "Cargo.toml",
@@ -2635,7 +2635,7 @@ fn doctest_same_name() {
         ).file("src/lib.rs", "extern crate a; pub fn a1() {}")
     }).unwrap();
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             &format!(
@@ -2682,7 +2682,7 @@ fn lints_are_suppressed() {
         )
     }).unwrap();
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             &format!(
@@ -2734,7 +2734,7 @@ fn denied_lints_are_allowed() {
         )
     }).unwrap();
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             &format!(
@@ -2780,7 +2780,7 @@ fn add_a_git_dep() {
         ).file("src/lib.rs", "")
     }).unwrap();
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             &format!(
@@ -2868,7 +2868,7 @@ fn two_at_rev_instead_of_tag() {
         false,
     ).unwrap();
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             &format!(
@@ -3034,7 +3034,7 @@ fn include_overrides_gitignore() {
 
 #[test]
 fn invalid_git_dependency_manifest() {
-    let project = project("foo");
+    let project = project();
     let git_project = git::new("dep1", |project| {
         project
             .file(
@@ -3114,7 +3114,7 @@ fn invalid_git_dependency_manifest() {
 
 #[test]
 fn failed_submodule_checkout() {
-    let project = project("foo");
+    let project = project();
     let git_project = git::new("dep1", |project| {
         project.file(
             "Cargo.toml",

--- a/tests/testsuite/install.rs
+++ b/tests/testsuite/install.rs
@@ -274,7 +274,7 @@ fn install_location_precedence() {
 
 #[test]
 fn install_path() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -392,7 +392,7 @@ fn multiple_crates_select() {
 
 #[test]
 fn multiple_crates_auto_binaries() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -427,7 +427,7 @@ fn multiple_crates_auto_binaries() {
 
 #[test]
 fn multiple_crates_auto_examples() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -473,7 +473,7 @@ fn multiple_crates_auto_examples() {
 
 #[test]
 fn no_binaries_or_examples() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -509,7 +509,7 @@ fn no_binaries_or_examples() {
 
 #[test]
 fn no_binaries() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -539,7 +539,7 @@ fn no_binaries() {
 
 #[test]
 fn examples() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -565,7 +565,7 @@ fn examples() {
 
 #[test]
 fn install_twice() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -598,7 +598,7 @@ Add --force to overwrite
 
 #[test]
 fn install_force() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -616,7 +616,7 @@ fn install_force() {
         execs().with_status(0),
     );
 
-    let p = project("foo2")
+    let p = project().at("foo2")
         .file(
             "Cargo.toml",
             r#"
@@ -659,7 +659,7 @@ foo v0.2.0 ([..]):
 
 #[test]
 fn install_force_partial_overlap() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -678,7 +678,7 @@ fn install_force_partial_overlap() {
         execs().with_status(0),
     );
 
-    let p = project("foo2")
+    let p = project().at("foo2")
         .file(
             "Cargo.toml",
             r#"
@@ -726,7 +726,7 @@ foo v0.2.0 ([..]):
 
 #[test]
 fn install_force_bin() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -745,7 +745,7 @@ fn install_force_bin() {
         execs().with_status(0),
     );
 
-    let p = project("foo2")
+    let p = project().at("foo2")
         .file(
             "Cargo.toml",
             r#"
@@ -793,7 +793,7 @@ foo v0.2.0 ([..]):
 
 #[test]
 fn compile_failure() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -953,7 +953,7 @@ fn uninstall_bin_does_not_exist() {
 
 #[test]
 fn uninstall_piecemeal() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1024,7 +1024,7 @@ fn subcommand_works_out_of_the_box() {
 
 #[test]
 fn installs_from_cwd_by_default() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1055,7 +1055,7 @@ fn installs_from_cwd_with_2018_warnings() {
         // is stabilized.
         return;
     }
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1088,7 +1088,7 @@ fn installs_from_cwd_with_2018_warnings() {
 
 #[test]
 fn do_not_rebuilds_on_local_install() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1197,7 +1197,7 @@ fn git_with_lockfile() {
 
 #[test]
 fn q_silences_warnings() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1240,7 +1240,7 @@ fn readonly_dir() {
 #[test]
 fn use_path_workspace() {
     Package::new("foo", "1.0.0").publish();
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1279,7 +1279,7 @@ fn use_path_workspace() {
 #[test]
 fn dev_dependencies_no_check() {
     Package::new("foo", "1.0.0").publish();
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1302,7 +1302,7 @@ fn dev_dependencies_no_check() {
 #[test]
 fn dev_dependencies_lock_file_untouched() {
     Package::new("foo", "1.0.0").publish();
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1644,7 +1644,7 @@ fn git_repo_replace() {
 
 #[test]
 fn workspace_uses_workspace_target_dir() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"

--- a/tests/testsuite/jobserver.rs
+++ b/tests/testsuite/jobserver.rs
@@ -7,7 +7,7 @@ use hamcrest::assert_that;
 
 #[test]
 fn jobserver_exists() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -73,7 +73,7 @@ fn makes_jobserver_used() {
         return;
     }
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -187,7 +187,7 @@ fn jobserver_and_j() {
         return;
     }
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"

--- a/tests/testsuite/local_registry.rs
+++ b/tests/testsuite/local_registry.rs
@@ -29,7 +29,7 @@ fn simple() {
         .file("src/lib.rs", "pub fn foo() {}")
         .publish();
 
-    let p = project("bar")
+    let p = project().at("bar")
         .file(
             "Cargo.toml",
             r#"
@@ -81,7 +81,7 @@ fn multiple_versions() {
         .file("src/lib.rs", "pub fn foo() {}")
         .publish();
 
-    let p = project("bar")
+    let p = project().at("bar")
         .file(
             "Cargo.toml",
             r#"
@@ -143,7 +143,7 @@ fn multiple_names() {
         .file("src/lib.rs", "pub fn bar() {}")
         .publish();
 
-    let p = project("local")
+    let p = project().at("local")
         .file(
             "Cargo.toml",
             r#"
@@ -199,7 +199,7 @@ fn interdependent() {
         .file("src/lib.rs", "extern crate foo; pub fn bar() {}")
         .publish();
 
-    let p = project("local")
+    let p = project().at("local")
         .file(
             "Cargo.toml",
             r#"
@@ -277,7 +277,7 @@ fn path_dep_rewritten() {
         .file("foo/src/lib.rs", "pub fn foo() {}")
         .publish();
 
-    let p = project("local")
+    let p = project().at("local")
         .file(
             "Cargo.toml",
             r#"
@@ -323,7 +323,7 @@ fn path_dep_rewritten() {
 #[test]
 fn invalid_dir_bad() {
     setup();
-    let p = project("local")
+    let p = project().at("local")
         .file(
             "Cargo.toml",
             r#"
@@ -379,7 +379,7 @@ fn different_directory_replacing_the_registry_is_bad() {
     let config_tmp = paths::root().join(".cargo-old");
     t!(fs::rename(&config, &config_tmp));
 
-    let p = project("local")
+    let p = project().at("local")
         .file(
             "Cargo.toml",
             r#"
@@ -447,7 +447,7 @@ fn crates_io_registry_url_is_optional() {
         .file("src/lib.rs", "pub fn foo() {}")
         .publish();
 
-    let p = project("bar")
+    let p = project().at("bar")
         .file(
             "Cargo.toml",
             r#"

--- a/tests/testsuite/lockfile_compat.rs
+++ b/tests/testsuite/lockfile_compat.rs
@@ -43,7 +43,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 "#;
 
-    let p = project("bar")
+    let p = project().at("bar")
         .file(
             "Cargo.toml",
             r#"
@@ -93,7 +93,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
         cksum,
     );
 
-    let p = project("bar")
+    let p = project().at("bar")
         .file(
             "Cargo.toml",
             r#"
@@ -124,7 +124,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 fn totally_wild_checksums_works() {
     Package::new("foo", "0.1.0").publish();
 
-    let p = project("bar")
+    let p = project().at("bar")
         .file(
             "Cargo.toml",
             r#"
@@ -189,7 +189,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 fn wrong_checksum_is_an_error() {
     Package::new("foo", "0.1.0").publish();
 
-    let p = project("bar")
+    let p = project().at("bar")
         .file(
             "Cargo.toml",
             r#"
@@ -252,7 +252,7 @@ unable to verify that `foo v0.1.0` is the same as when the lockfile was generate
 fn unlisted_checksum_is_bad_if_we_calculate() {
     Package::new("foo", "0.1.0").publish();
 
-    let p = project("bar")
+    let p = project().at("bar")
         .file(
             "Cargo.toml",
             r#"
@@ -324,7 +324,7 @@ fn listed_checksum_bad_if_we_cannot_compute() {
         ).file("src/lib.rs", "")
     }).unwrap();
 
-    let p = project("bar")
+    let p = project().at("bar")
         .file(
             "Cargo.toml",
             &format!(
@@ -391,7 +391,7 @@ unable to verify that `foo v0.1.0 ([..])` is the same as when the lockfile was g
 fn current_lockfile_format() {
     Package::new("foo", "0.1.0").publish();
 
-    let p = project("bar")
+    let p = project().at("bar")
         .file(
             "Cargo.toml",
             r#"
@@ -451,7 +451,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 "#;
 
-    let p = project("bar")
+    let p = project().at("bar")
         .file(
             "Cargo.toml",
             r#"
@@ -479,7 +479,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 fn locked_correct_error() {
     Package::new("foo", "0.1.0").publish();
 
-    let p = project("bar")
+    let p = project().at("bar")
         .file(
             "Cargo.toml",
             r#"

--- a/tests/testsuite/metadata.rs
+++ b/tests/testsuite/metadata.rs
@@ -4,7 +4,7 @@ use hamcrest::assert_that;
 
 #[test]
 fn cargo_metadata_simple() {
-    let p = project("foo")
+    let p = project()
         .file("src/foo.rs", "")
         .file("Cargo.toml", &basic_bin_manifest("foo"))
         .build();
@@ -69,7 +69,7 @@ fn cargo_metadata_simple() {
 
 #[test]
 fn cargo_metadata_warns_on_implicit_version() {
-    let p = project("foo")
+    let p = project()
         .file("src/foo.rs", "")
         .file("Cargo.toml", &basic_bin_manifest("foo"))
         .build();
@@ -85,7 +85,7 @@ fn cargo_metadata_warns_on_implicit_version() {
 
 #[test]
 fn library_with_several_crate_types() {
-    let p = project("foo")
+    let p = project()
         .file("src/lib.rs", "")
         .file(
             "Cargo.toml",
@@ -160,7 +160,7 @@ crate-type = ["lib", "staticlib"]
 
 #[test]
 fn library_with_features() {
-    let p = project("foo")
+    let p = project()
         .file("src/lib.rs", "")
         .file(
             "Cargo.toml",
@@ -244,7 +244,7 @@ optional_feat = []
 
 #[test]
 fn cargo_metadata_with_deps_and_version() {
-    let p = project("foo")
+    let p = project()
         .file("src/foo.rs", "")
         .file(
             "Cargo.toml",
@@ -427,7 +427,7 @@ fn cargo_metadata_with_deps_and_version() {
 
 #[test]
 fn example() {
-    let p = project("foo")
+    let p = project()
         .file("src/lib.rs", "")
         .file("examples/ex.rs", "")
         .file(
@@ -505,7 +505,7 @@ name = "ex"
 
 #[test]
 fn example_lib() {
-    let p = project("foo")
+    let p = project()
         .file("src/lib.rs", "")
         .file("examples/ex.rs", "")
         .file(
@@ -584,7 +584,7 @@ crate-type = ["rlib", "dylib"]
 
 #[test]
 fn workspace_metadata() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -687,7 +687,7 @@ fn workspace_metadata() {
 
 #[test]
 fn workspace_metadata_no_deps() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -776,7 +776,7 @@ fn workspace_metadata_no_deps() {
 
 #[test]
 fn cargo_metadata_with_invalid_manifest() {
-    let p = project("foo").file("Cargo.toml", "").build();
+    let p = project().file("Cargo.toml", "").build();
 
     assert_that(
         p.cargo("metadata").arg("--format-version").arg("1"),
@@ -827,7 +827,7 @@ const MANIFEST_OUTPUT: &str = r#"
 
 #[test]
 fn cargo_metadata_no_deps_path_to_cargo_toml_relative() {
-    let p = project("foo")
+    let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
         .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
         .build();
@@ -844,7 +844,7 @@ fn cargo_metadata_no_deps_path_to_cargo_toml_relative() {
 
 #[test]
 fn cargo_metadata_no_deps_path_to_cargo_toml_absolute() {
-    let p = project("foo")
+    let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
         .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
         .build();
@@ -861,7 +861,7 @@ fn cargo_metadata_no_deps_path_to_cargo_toml_absolute() {
 
 #[test]
 fn cargo_metadata_no_deps_path_to_cargo_toml_parent_relative() {
-    let p = project("foo")
+    let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
         .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
         .build();
@@ -881,7 +881,7 @@ fn cargo_metadata_no_deps_path_to_cargo_toml_parent_relative() {
 
 #[test]
 fn cargo_metadata_no_deps_path_to_cargo_toml_parent_absolute() {
-    let p = project("foo")
+    let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
         .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
         .build();
@@ -901,7 +901,7 @@ fn cargo_metadata_no_deps_path_to_cargo_toml_parent_absolute() {
 
 #[test]
 fn cargo_metadata_no_deps_cwd() {
-    let p = project("foo")
+    let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
         .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
         .build();
@@ -914,7 +914,7 @@ fn cargo_metadata_no_deps_cwd() {
 
 #[test]
 fn cargo_metadata_bad_version() {
-    let p = project("foo")
+    let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
         .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
         .build();
@@ -936,7 +936,7 @@ error: '2' isn't a valid value for '--format-version <VERSION>'
 
 #[test]
 fn multiple_features() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -961,7 +961,7 @@ fn multiple_features() {
 
 #[test]
 fn package_metadata() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1030,7 +1030,7 @@ fn package_metadata() {
 
 #[test]
 fn cargo_metadata_path_to_cargo_toml_project() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"

--- a/tests/testsuite/net_config.rs
+++ b/tests/testsuite/net_config.rs
@@ -3,7 +3,7 @@ use hamcrest::assert_that;
 
 #[test]
 fn net_retry_loads_from_config() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -39,7 +39,7 @@ fn net_retry_loads_from_config() {
 
 #[test]
 fn net_retry_git_outputs_warning() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"

--- a/tests/testsuite/out_dir.rs
+++ b/tests/testsuite/out_dir.rs
@@ -9,7 +9,7 @@ use cargotest::support::{execs, project};
 
 #[test]
 fn binary_with_debug() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -37,7 +37,7 @@ fn binary_with_debug() {
 
 #[test]
 fn static_library_with_debug() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -74,7 +74,7 @@ fn static_library_with_debug() {
 
 #[test]
 fn dynamic_library_with_debug() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -111,7 +111,7 @@ fn dynamic_library_with_debug() {
 
 #[test]
 fn rlib_with_debug() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -147,7 +147,7 @@ fn rlib_with_debug() {
 
 #[test]
 fn include_only_the_binary_from_the_current_package() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -200,7 +200,7 @@ fn include_only_the_binary_from_the_current_package() {
 
 #[test]
 fn out_dir_is_a_file() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -225,7 +225,7 @@ fn out_dir_is_a_file() {
 
 #[test]
 fn replaces_artifacts() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"

--- a/tests/testsuite/overrides.rs
+++ b/tests/testsuite/overrides.rs
@@ -21,7 +21,7 @@ fn override_simple() {
         .file("src/lib.rs", "pub fn foo() {}")
         .build();
 
-    let p = project("local")
+    let p = project().at("local")
         .file(
             "Cargo.toml",
             &format!(
@@ -67,7 +67,7 @@ fn override_simple() {
 
 #[test]
 fn missing_version() {
-    let p = project("local")
+    let p = project().at("local")
         .file(
             "Cargo.toml",
             r#"
@@ -101,7 +101,7 @@ Caused by:
 
 #[test]
 fn invalid_semver_version() {
-    let p = project("local")
+    let p = project().at("local")
         .file(
             "Cargo.toml",
             r#"
@@ -138,7 +138,7 @@ fn different_version() {
     Package::new("foo", "0.2.0").publish();
     Package::new("foo", "0.1.0").publish();
 
-    let p = project("local")
+    let p = project().at("local")
         .file(
             "Cargo.toml",
             r#"
@@ -191,7 +191,7 @@ fn transitive() {
         .file("src/lib.rs", "pub fn foo() {}")
         .build();
 
-    let p = project("local")
+    let p = project().at("local")
         .file(
             "Cargo.toml",
             &format!(
@@ -248,7 +248,7 @@ fn persists_across_rebuilds() {
         .file("src/lib.rs", "pub fn foo() {}")
         .build();
 
-    let p = project("local")
+    let p = project().at("local")
         .file(
             "Cargo.toml",
             &format!(
@@ -298,7 +298,7 @@ fn persists_across_rebuilds() {
 fn replace_registry_with_path() {
     Package::new("foo", "0.1.0").publish();
 
-    let _ = project("foo")
+    let _ = project()
         .file(
             "Cargo.toml",
             r#"
@@ -311,7 +311,7 @@ fn replace_registry_with_path() {
         .file("src/lib.rs", "pub fn foo() {}")
         .build();
 
-    let p = project("local")
+    let p = project().at("local")
         .file(
             "Cargo.toml",
             r#"
@@ -381,7 +381,7 @@ fn use_a_spec_to_select() {
         .file("src/lib.rs", "pub fn foo3() {}")
         .build();
 
-    let p = project("local")
+    let p = project().at("local")
         .file(
             "Cargo.toml",
             &format!(
@@ -454,7 +454,7 @@ fn override_adds_some_deps() {
         .file("src/lib.rs", "")
         .build();
 
-    let p = project("local")
+    let p = project().at("local")
         .file(
             "Cargo.toml",
             &format!(
@@ -542,7 +542,7 @@ fn locked_means_locked_yes_no_seriously_i_mean_locked() {
         .file("src/lib.rs", "")
         .build();
 
-    let p = project("local")
+    let p = project().at("local")
         .file(
             "Cargo.toml",
             &format!(
@@ -588,7 +588,7 @@ fn override_wrong_name() {
         .file("src/lib.rs", "")
         .build();
 
-    let p = project("local")
+    let p = project().at("local")
         .file(
             "Cargo.toml",
             &format!(
@@ -632,7 +632,7 @@ fn override_with_nothing() {
         .file("src/lib.rs", "")
         .build();
 
-    let p = project("local")
+    let p = project().at("local")
         .file(
             "Cargo.toml",
             &format!(
@@ -674,7 +674,7 @@ Caused by:
 
 #[test]
 fn override_wrong_version() {
-    let p = project("local")
+    let p = project().at("local")
         .file(
             "Cargo.toml",
             r#"
@@ -720,7 +720,7 @@ fn multiple_specs() {
         .file("src/lib.rs", "pub fn foo() {}")
         .build();
 
-    let p = project("local")
+    let p = project().at("local")
         .file(
             "Cargo.toml",
             &format!(
@@ -779,7 +779,7 @@ fn test_override_dep() {
         .file("src/lib.rs", "pub fn foo() {}")
         .build();
 
-    let p = project("local")
+    let p = project().at("local")
         .file(
             "Cargo.toml",
             &format!(
@@ -831,7 +831,7 @@ fn update() {
         .file("src/lib.rs", "pub fn foo() {}")
         .build();
 
-    let p = project("local")
+    let p = project().at("local")
         .file(
             "Cargo.toml",
             &format!(
@@ -901,7 +901,7 @@ fn no_override_self() {
         )
         .build();
 
-    let p = project("local")
+    let p = project().at("local")
         .file(
             "Cargo.toml",
             &format!(
@@ -937,7 +937,7 @@ fn broken_path_override_warns() {
     Package::new("foo", "0.1.0").publish();
     Package::new("foo", "0.2.0").publish();
 
-    let p = project("local")
+    let p = project().at("local")
         .file(
             "Cargo.toml",
             r#"
@@ -1027,7 +1027,7 @@ fn override_an_override() {
         .file("src/lib.rs", "pub fn serde08() {}")
         .publish();
 
-    let p = project("local")
+    let p = project().at("local")
         .file(
             "Cargo.toml",
             r#"
@@ -1169,7 +1169,7 @@ fn overriding_nonexistent_no_spurious() {
         .file("bar/src/lib.rs", "pub fn foo() {}")
         .build();
 
-    let p = project("local")
+    let p = project().at("local")
         .file(
             "Cargo.toml",
             &format!(
@@ -1212,7 +1212,7 @@ fn no_warnings_when_replace_is_used_in_another_workspace_member() {
     Package::new("foo", "0.1.0").publish();
     Package::new("bar", "0.1.0").publish();
 
-    let p = project("ws")
+    let p = project().at("ws")
         .file(
             "Cargo.toml",
             r#"
@@ -1280,7 +1280,7 @@ fn override_to_path_dep() {
     Package::new("foo", "0.1.0").dep("bar", "0.1").publish();
     Package::new("bar", "0.1.0").publish();
 
-    let p = project("local")
+    let p = project().at("local")
         .file(
             "Cargo.toml",
             r#"
@@ -1333,7 +1333,7 @@ fn replace_to_path_dep() {
     Package::new("foo", "0.1.0").dep("bar", "0.1").publish();
     Package::new("bar", "0.1.0").publish();
 
-    let p = project("local")
+    let p = project().at("local")
         .file(
             "Cargo.toml",
             r#"
@@ -1391,7 +1391,7 @@ fn replace_to_path_dep() {
 fn paths_ok_with_optional() {
     Package::new("bar", "0.1.0").publish();
 
-    let p = project("local")
+    let p = project().at("local")
         .file(
             "Cargo.toml",
             r#"
@@ -1455,7 +1455,7 @@ fn paths_ok_with_optional() {
 fn paths_add_optional_bad() {
     Package::new("bar", "0.1.0").publish();
 
-    let p = project("local")
+    let p = project().at("local")
         .file(
             "Cargo.toml",
             r#"
@@ -1517,7 +1517,7 @@ fn override_with_default_feature() {
     Package::new("another", "0.1.1").dep("bar", "0.1").publish();
     Package::new("bar", "0.1.0").publish();
 
-    let p = project("local")
+    let p = project().at("local")
         .file(
             "Cargo.toml",
             r#"
@@ -1586,7 +1586,7 @@ fn override_with_default_feature() {
 fn override_plus_dep() {
     Package::new("bar", "0.1.0").publish();
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"

--- a/tests/testsuite/package.rs
+++ b/tests/testsuite/package.rs
@@ -13,7 +13,7 @@ use tar::Archive;
 
 #[test]
 fn simple() {
-    let p = project("foo")
+    let p = project()
         .file("Cargo.toml", r#"
             [project]
             name = "foo"
@@ -78,7 +78,7 @@ src[/]main.rs
 
 #[test]
 fn metadata_warning() {
-    let p = project("all")
+    let p = project().at("all")
         .file(
             "Cargo.toml",
             r#"
@@ -111,7 +111,7 @@ See http://doc.crates.io/manifest.html#package-metadata for more info.
         )),
     );
 
-    let p = project("one")
+    let p = project().at("one")
         .file(
             "Cargo.toml",
             r#"
@@ -144,7 +144,7 @@ See http://doc.crates.io/manifest.html#package-metadata for more info.
         )),
     );
 
-    let p = project("all")
+    let p = project().at("all")
         .file(
             "Cargo.toml",
             r#"
@@ -247,7 +247,7 @@ See http://doc.crates.io/manifest.html#package-metadata for more info.
 
 #[test]
 fn package_verification() {
-    let p = project("all")
+    let p = project().at("all")
         .file(
             "Cargo.toml",
             r#"
@@ -283,7 +283,7 @@ See http://doc.crates.io/manifest.html#package-metadata for more info.
 
 #[test]
 fn path_dependency_no_version() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -326,7 +326,7 @@ dependency `bar` does not specify a version.
 
 #[test]
 fn exclude() {
-    let p = project("foo")
+    let p = project()
         .file("Cargo.toml", r#"
             [project]
             name = "foo"
@@ -466,7 +466,7 @@ src[/]main.rs
 
 #[test]
 fn include() {
-    let p = project("foo")
+    let p = project()
         .file("Cargo.toml", r#"
             [project]
             name = "foo"
@@ -499,7 +499,7 @@ See http://doc.crates.io/manifest.html#package-metadata for more info.
 
 #[test]
 fn package_lib_with_bin() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -623,7 +623,7 @@ fn ignore_nested() {
     let main_rs = r#"
             fn main() { println!("hello"); }
         "#;
-    let p = project("nested")
+    let p = project().at("nested")
         .file("Cargo.toml", cargo_toml)
         .file("src/main.rs", main_rs)
         // If a project happens to contain a copy of itself, we should
@@ -682,7 +682,7 @@ src[..]main.rs
 #[cfg(unix)] // windows doesn't allow these characters in filenames
 #[test]
 fn package_weird_characters() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -719,7 +719,7 @@ Caused by:
 
 #[test]
 fn repackage_on_source_change() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -795,7 +795,7 @@ See [..]
 fn broken_symlink() {
     use std::os::unix::fs;
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -837,7 +837,7 @@ Caused by:
 
 #[test]
 fn do_not_package_if_repository_is_dirty() {
-    let p = project("foo").build();
+    let p = project().build();
 
     // Create a Git repository containing a minimal Rust project.
     let _ = git::repo(&paths::root().join("foo"))
@@ -894,7 +894,7 @@ fn generated_manifest() {
     Package::new("def", "1.0.0").alternative(true).publish();
     Package::new("ghi", "1.0.0").publish();
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1001,7 +1001,7 @@ version = "1.0"
 
 #[test]
 fn ignore_workspace_specifier() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1076,7 +1076,7 @@ authors = []
 fn package_two_kinds_of_deps() {
     Package::new("other", "1.0.0").publish();
     Package::new("other1", "1.0.0").publish();
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1101,7 +1101,7 @@ fn package_two_kinds_of_deps() {
 
 #[test]
 fn test_edition() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1132,7 +1132,7 @@ fn test_edition() {
 #[test]
 fn test_edition_missing() {
     // no edition = 2015
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1161,7 +1161,7 @@ fn test_edition_missing() {
 
 #[test]
 fn test_edition_malformed() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1194,7 +1194,7 @@ Caused by:
 
 #[test]
 fn test_edition_nightly() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1228,7 +1228,7 @@ consider adding `cargo-features = [\"edition\"]` to the manifest
 
 #[test]
 fn package_lockfile() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1300,7 +1300,7 @@ src[/]main.rs
 
 #[test]
 fn package_lockfile_git_repo() {
-    let p = project("foo").build();
+    let p = project().build();
 
     // Create a Git repository containing a minimal Rust project.
     let _ = git::repo(&paths::root().join("foo"))
@@ -1336,7 +1336,7 @@ src/main.rs
 
 #[test]
 fn no_lock_file_with_library() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1373,7 +1373,7 @@ fn no_lock_file_with_library() {
 
 #[test]
 fn lock_file_and_workspace() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1419,7 +1419,7 @@ fn lock_file_and_workspace() {
 
 #[test]
 fn do_not_package_if_src_was_modified() {
-    let p = project("foo")
+    let p = project()
         .file("Cargo.toml", r#"
             [project]
             name = "foo"

--- a/tests/testsuite/patch.rs
+++ b/tests/testsuite/patch.rs
@@ -24,7 +24,7 @@ fn replace() {
         .dep("foo", "0.1.0")
         .publish();
 
-    let p = project("bar")
+    let p = project().at("bar")
         .file(
             "Cargo.toml",
             r#"
@@ -93,7 +93,7 @@ fn replace() {
 fn nonexistent() {
     Package::new("baz", "0.1.0").publish();
 
-    let p = project("bar")
+    let p = project().at("bar")
         .file(
             "Cargo.toml",
             r#"
@@ -167,7 +167,7 @@ fn patch_git() {
         .file("src/lib.rs", "")
         .build();
 
-    let p = project("bar")
+    let p = project().at("bar")
         .file(
             "Cargo.toml",
             &format!(
@@ -246,7 +246,7 @@ fn patch_to_git() {
 
     Package::new("foo", "0.1.0").publish();
 
-    let p = project("bar")
+    let p = project().at("bar")
         .file(
             "Cargo.toml",
             &format!(
@@ -298,7 +298,7 @@ fn patch_to_git() {
 fn unused() {
     Package::new("foo", "0.1.0").publish();
 
-    let p = project("bar")
+    let p = project().at("bar")
         .file(
             "Cargo.toml",
             r#"
@@ -381,7 +381,7 @@ fn unused_git() {
         .file("src/lib.rs", "")
         .build();
 
-    let p = project("bar")
+    let p = project().at("bar")
         .file(
             "Cargo.toml",
             &format!(
@@ -426,7 +426,7 @@ fn unused_git() {
 fn add_patch() {
     Package::new("foo", "0.1.0").publish();
 
-    let p = project("bar")
+    let p = project().at("bar")
         .file(
             "Cargo.toml",
             r#"
@@ -504,7 +504,7 @@ fn add_patch() {
 fn add_ignored_patch() {
     Package::new("foo", "0.1.0").publish();
 
-    let p = project("bar")
+    let p = project().at("bar")
         .file(
             "Cargo.toml",
             r#"
@@ -578,7 +578,7 @@ fn add_ignored_patch() {
 fn new_minor() {
     Package::new("foo", "0.1.0").publish();
 
-    let p = project("bar")
+    let p = project().at("bar")
         .file(
             "Cargo.toml",
             r#"
@@ -624,7 +624,7 @@ fn new_minor() {
 fn transitive_new_minor() {
     Package::new("foo", "0.1.0").publish();
 
-    let p = project("bar")
+    let p = project().at("bar")
         .file(
             "Cargo.toml",
             r#"
@@ -684,7 +684,7 @@ fn transitive_new_minor() {
 fn new_major() {
     Package::new("foo", "0.1.0").publish();
 
-    let p = project("bar")
+    let p = project().at("bar")
         .file(
             "Cargo.toml",
             r#"
@@ -763,7 +763,7 @@ fn new_major() {
 fn transitive_new_major() {
     Package::new("foo", "0.1.0").publish();
 
-    let p = project("bar")
+    let p = project().at("bar")
         .file(
             "Cargo.toml",
             r#"
@@ -824,7 +824,7 @@ fn remove_patch() {
     Package::new("foo", "0.1.0").publish();
     Package::new("bar", "0.1.0").publish();
 
-    let p = project("bar")
+    let p = project().at("bar")
         .file(
             "Cargo.toml",
             r#"
@@ -915,7 +915,7 @@ fn remove_patch() {
 fn non_crates_io() {
     Package::new("foo", "0.1.0").publish();
 
-    let p = project("bar")
+    let p = project().at("bar")
         .file(
             "Cargo.toml",
             r#"
@@ -958,7 +958,7 @@ Caused by:
 fn replace_with_crates_io() {
     Package::new("foo", "0.1.0").publish();
 
-    let p = project("bar")
+    let p = project().at("bar")
         .file(
             "Cargo.toml",
             r#"
@@ -1003,7 +1003,7 @@ Caused by:
 fn patch_in_virtual() {
     Package::new("foo", "0.1.0").publish();
 
-    let p = project("bar")
+    let p = project().at("bar")
         .file(
             "Cargo.toml",
             r#"
@@ -1057,7 +1057,7 @@ fn patch_depends_on_another_patch() {
         .file("src/lib.rs", "broken code")
         .publish();
 
-    let p = project("p")
+    let p = project().at("p")
         .file(
             "Cargo.toml",
             r#"
@@ -1113,7 +1113,7 @@ fn patch_depends_on_another_patch() {
 #[test]
 fn replace_prerelease() {
     Package::new("bar", "1.1.0-pre.1").publish();
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"

--- a/tests/testsuite/path.rs
+++ b/tests/testsuite/path.rs
@@ -12,7 +12,7 @@ use hamcrest::{assert_that, existing_file, is_not};
 #[cfg(not(windows))] // I have no idea why this is failing spuriously on
                      // Windows, for more info see #3466.
 fn cargo_compile_with_nested_deps_shorthand() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -134,7 +134,7 @@ fn cargo_compile_with_nested_deps_shorthand() {
 
 #[test]
 fn cargo_compile_with_root_dev_deps() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -155,7 +155,7 @@ fn cargo_compile_with_root_dev_deps() {
         )
         .file("src/main.rs", &main_file(r#""{}", bar::gimme()"#, &["bar"]))
         .build();
-    let _p2 = project("bar")
+    let _p2 = project().at("bar")
         .file(
             "Cargo.toml",
             r#"
@@ -181,7 +181,7 @@ fn cargo_compile_with_root_dev_deps() {
 
 #[test]
 fn cargo_compile_with_root_dev_deps_with_testing() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -202,7 +202,7 @@ fn cargo_compile_with_root_dev_deps_with_testing() {
         )
         .file("src/main.rs", &main_file(r#""{}", bar::gimme()"#, &["bar"]))
         .build();
-    let _p2 = project("bar")
+    let _p2 = project().at("bar")
         .file(
             "Cargo.toml",
             r#"
@@ -239,7 +239,7 @@ fn cargo_compile_with_root_dev_deps_with_testing() {
 
 #[test]
 fn cargo_compile_with_transitive_dev_deps() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -303,7 +303,7 @@ fn cargo_compile_with_transitive_dev_deps() {
 
 #[test]
 fn no_rebuild_dependency() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -379,7 +379,7 @@ fn no_rebuild_dependency() {
 
 #[test]
 fn deep_dependencies_trigger_rebuild() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -510,7 +510,7 @@ fn deep_dependencies_trigger_rebuild() {
 
 #[test]
 fn no_rebuild_two_deps() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -594,7 +594,7 @@ fn no_rebuild_two_deps() {
 
 #[test]
 fn nested_deps_recompile() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -665,7 +665,7 @@ fn nested_deps_recompile() {
 
 #[test]
 fn error_message_for_missing_manifest() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -705,7 +705,7 @@ Caused by:
 
 #[test]
 fn override_relative() {
-    let bar = project("bar")
+    let bar = project().at("bar")
         .file(
             "Cargo.toml",
             r#"
@@ -725,7 +725,7 @@ fn override_relative() {
         .write_all(br#"paths = ["bar"]"#)
         .unwrap();
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             &format!(
@@ -749,7 +749,7 @@ fn override_relative() {
 
 #[test]
 fn override_self() {
-    let bar = project("bar")
+    let bar = project().at("bar")
         .file(
             "Cargo.toml",
             r#"
@@ -763,7 +763,7 @@ fn override_self() {
         .file("src/lib.rs", "")
         .build();
 
-    let p = project("foo");
+    let p = project();
     let root = p.root().clone();
     let p = p.file(
         ".cargo/config",
@@ -799,7 +799,7 @@ fn override_self() {
 
 #[test]
 fn override_path_dep() {
-    let bar = project("bar")
+    let bar = project().at("bar")
         .file(
             "p1/Cargo.toml",
             r#"
@@ -825,7 +825,7 @@ fn override_path_dep() {
         .file("p2/src/lib.rs", "")
         .build();
 
-    let p = project("foo")
+    let p = project()
         .file(
             ".cargo/config",
             &format!(
@@ -861,7 +861,7 @@ fn override_path_dep() {
 
 #[test]
 fn path_dep_build_cmd() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -952,7 +952,7 @@ fn path_dep_build_cmd() {
 
 #[test]
 fn dev_deps_no_rebuild_lib() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1016,7 +1016,7 @@ fn dev_deps_no_rebuild_lib() {
 
 #[test]
 fn custom_target_no_rebuild() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1084,7 +1084,7 @@ fn custom_target_no_rebuild() {
 
 #[test]
 fn override_and_depend() {
-    let p = project("foo")
+    let p = project()
         .file(
             "a/a1/Cargo.toml",
             r#"
@@ -1142,7 +1142,7 @@ fn override_and_depend() {
 
 #[test]
 fn missing_path_dependency() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1181,7 +1181,7 @@ Caused by:
 fn invalid_path_dep_in_workspace_with_lockfile() {
     Package::new("bar", "1.0.0").publish();
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1248,7 +1248,7 @@ required by package `foo v0.5.0 ([..])`
 
 #[test]
 fn workspace_produces_rlib() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1287,7 +1287,7 @@ fn workspace_produces_rlib() {
 
 #[test]
 fn thin_lto_works() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"

--- a/tests/testsuite/plugins.rs
+++ b/tests/testsuite/plugins.rs
@@ -11,7 +11,7 @@ fn plugin_to_the_max() {
         return;
     }
 
-    let foo = project("foo")
+    let foo = project()
         .file(
             "Cargo.toml",
             r#"
@@ -47,7 +47,7 @@ fn plugin_to_the_max() {
         "#,
         )
         .build();
-    let _bar = project("bar")
+    let _bar = project().at("bar")
         .file(
             "Cargo.toml",
             r#"
@@ -81,7 +81,7 @@ fn plugin_to_the_max() {
         "#,
         )
         .build();
-    let _baz = project("baz")
+    let _baz = project().at("baz")
         .file(
             "Cargo.toml",
             r#"
@@ -108,7 +108,7 @@ fn plugin_with_dynamic_native_dependency() {
         return;
     }
 
-    let workspace = project("ws")
+    let workspace = project().at("ws")
         .file(
             "Cargo.toml",
             r#"
@@ -118,7 +118,7 @@ fn plugin_with_dynamic_native_dependency() {
         )
         .build();
 
-    let build = project("ws/builder")
+    let build = project().at("ws/builder")
         .file(
             "Cargo.toml",
             r#"
@@ -141,7 +141,7 @@ fn plugin_with_dynamic_native_dependency() {
         )
         .build();
 
-    let foo = project("ws/foo")
+    let foo = project().at("ws/foo")
         .file(
             "Cargo.toml",
             r#"
@@ -229,7 +229,7 @@ fn plugin_with_dynamic_native_dependency() {
 
 #[test]
 fn plugin_integration() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -255,7 +255,7 @@ fn plugin_integration() {
 
 #[test]
 fn doctest_a_plugin() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -304,7 +304,7 @@ fn doctest_a_plugin() {
 fn native_plugin_dependency_with_custom_ar_linker() {
     let target = rustc_host();
 
-    let _foo = project("foo")
+    let _foo = project()
         .file(
             "Cargo.toml",
             r#"
@@ -320,7 +320,7 @@ fn native_plugin_dependency_with_custom_ar_linker() {
         .file("src/lib.rs", "")
         .build();
 
-    let bar = project("bar")
+    let bar = project().at("bar")
         .file(
             "Cargo.toml",
             r#"
@@ -365,7 +365,7 @@ fn panic_abort_plugins() {
         return;
     }
 
-    let p = project("bar")
+    let p = project().at("bar")
         .file(
             "Cargo.toml",
             r#"
@@ -412,7 +412,7 @@ fn shared_panic_abort_plugins() {
         return;
     }
 
-    let p = project("top")
+    let p = project().at("top")
         .file(
             "Cargo.toml",
             r#"

--- a/tests/testsuite/proc_macro.rs
+++ b/tests/testsuite/proc_macro.rs
@@ -4,7 +4,7 @@ use hamcrest::assert_that;
 
 #[test]
 fn probe_cfg_before_crate_type_discovery() {
-    let client = project("client")
+    let client = project().at("client")
         .file(
             "Cargo.toml",
             r#"
@@ -30,7 +30,7 @@ fn probe_cfg_before_crate_type_discovery() {
         "#,
         )
         .build();
-    let _noop = project("noop")
+    let _noop = project().at("noop")
         .file(
             "Cargo.toml",
             r#"
@@ -62,7 +62,7 @@ fn probe_cfg_before_crate_type_discovery() {
 
 #[test]
 fn noop() {
-    let client = project("client")
+    let client = project().at("client")
         .file(
             "Cargo.toml",
             r#"
@@ -88,7 +88,7 @@ fn noop() {
         "#,
         )
         .build();
-    let _noop = project("noop")
+    let _noop = project().at("noop")
         .file(
             "Cargo.toml",
             r#"
@@ -121,7 +121,7 @@ fn noop() {
 
 #[test]
 fn impl_and_derive() {
-    let client = project("client")
+    let client = project().at("client")
         .file(
             "Cargo.toml",
             r#"
@@ -155,7 +155,7 @@ fn impl_and_derive() {
         "#,
         )
         .build();
-    let _transmogrify = project("transmogrify")
+    let _transmogrify = project().at("transmogrify")
         .file(
             "Cargo.toml",
             r#"
@@ -208,7 +208,7 @@ fn plugin_and_proc_macro() {
         return;
     }
 
-    let questionable = project("questionable")
+    let questionable = project().at("questionable")
         .file(
             "Cargo.toml",
             r#"
@@ -254,7 +254,7 @@ fn plugin_and_proc_macro() {
 
 #[test]
 fn proc_macro_doctest() {
-    let foo = project("foo")
+    let foo = project()
         .file(
             "Cargo.toml",
             r#"

--- a/tests/testsuite/profile_config.rs
+++ b/tests/testsuite/profile_config.rs
@@ -4,7 +4,7 @@ use hamcrest::assert_that;
 
 #[test]
 fn profile_config_gated() {
-    let p = project("foo")
+    let p = project()
         .file("Cargo.toml", &basic_lib_manifest("foo"))
         .file("src/lib.rs", "")
         .file(
@@ -31,7 +31,7 @@ fn profile_config_gated() {
 
 #[test]
 fn profile_config_validate_warnings() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -83,7 +83,7 @@ fn profile_config_validate_warnings() {
 
 #[test]
 fn profile_config_error_paths() {
-    let p = project("foo")
+    let p = project()
         .file("Cargo.toml", &basic_lib_manifest("foo"))
         .file("src/lib.rs", "")
         .file(
@@ -118,7 +118,7 @@ Caused by:
 
 #[test]
 fn profile_config_validate_errors() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -158,7 +158,7 @@ Caused by:
 
 #[test]
 fn profile_config_syntax_errors() {
-    let p = project("foo")
+    let p = project()
         .file("Cargo.toml", &basic_lib_manifest("foo"))
         .file("src/lib.rs", "")
         .file(
@@ -186,7 +186,7 @@ Caused by:
 
 #[test]
 fn profile_config_override_spec_multiple() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -240,7 +240,7 @@ found profile override specs: bar, bar:0.5.0",
 #[test]
 fn profile_config_all_options() {
     // Ensure all profile options are supported.
-    let p = project("foo")
+    let p = project()
         .file("Cargo.toml", &basic_lib_manifest("foo"))
         .file("src/lib.rs", "")
         .file(
@@ -283,7 +283,7 @@ fn profile_config_all_options() {
 #[test]
 fn profile_config_override_precedence() {
     // Config values take precedence over manifest values.
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -340,7 +340,7 @@ fn profile_config_override_precedence() {
 
 #[test]
 fn profile_config_no_warn_unknown_override() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -372,7 +372,7 @@ fn profile_config_no_warn_unknown_override() {
 
 #[test]
 fn profile_config_mixed_types() {
-    let p = project("foo")
+    let p = project()
         .file("Cargo.toml", &basic_lib_manifest("foo"))
         .file("src/lib.rs", "")
         .file(

--- a/tests/testsuite/profile_overrides.rs
+++ b/tests/testsuite/profile_overrides.rs
@@ -4,7 +4,7 @@ use hamcrest::assert_that;
 
 #[test]
 fn profile_override_gated() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -34,7 +34,7 @@ consider adding `cargo-features = [\"profile-overrides\"]` to the manifest
         ),
     );
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -67,7 +67,7 @@ consider adding `cargo-features = [\"profile-overrides\"]` to the manifest
 
 #[test]
 fn profile_override_basic() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -107,7 +107,7 @@ fn profile_override_basic() {
 
 #[test]
 fn profile_override_warnings() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -152,7 +152,7 @@ Did you mean `bar`?
 
 #[test]
 fn profile_override_dev_release_only() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -203,7 +203,7 @@ fn profile_override_bad_settings() {
         ("overrides = {}", "Profile overrides cannot be nested."),
     ];
     for &(ref snippet, ref expected) in bad_values.iter() {
-        let p = project("foo")
+        let p = project()
             .file(
                 "Cargo.toml",
                 &format!(
@@ -240,7 +240,7 @@ fn profile_override_bad_settings() {
 #[test]
 fn profile_override_hierarchy() {
     // Test that the precedence rules are correct for different types.
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -312,7 +312,7 @@ fn profile_override_hierarchy() {
         .build();
 
     // dep (outside of workspace)
-    let _dep = project("dep")
+    let _dep = project().at("dep")
         .file("Cargo.toml", &basic_lib_manifest("dep"))
         .file("src/lib.rs", "")
         .build();
@@ -350,7 +350,7 @@ fn profile_override_hierarchy() {
 
 #[test]
 fn profile_override_spec_multiple() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -387,7 +387,7 @@ found profile override specs: bar, bar:0.5.0",
 
 #[test]
 fn profile_override_spec() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -435,7 +435,7 @@ fn profile_override_spec() {
 
         .build();
 
-    project("dep1")
+    project().at("dep1")
         .file(
             "Cargo.toml",
             r#"
@@ -447,7 +447,7 @@ fn profile_override_spec() {
         .file("src/lib.rs", "")
         .build();
 
-    project("dep2")
+    project().at("dep2")
         .file(
             "Cargo.toml",
             r#"

--- a/tests/testsuite/profile_targets.rs
+++ b/tests/testsuite/profile_targets.rs
@@ -8,7 +8,7 @@ use hamcrest::assert_that;
 fn all_target_project() -> Project {
     // This abuses the `codegen-units` setting so that we can verify exactly
     // which profile is used for each compiler invocation.
-    project("foo")
+    project()
         .file(
             "Cargo.toml",
             r#"

--- a/tests/testsuite/profiles.rs
+++ b/tests/testsuite/profiles.rs
@@ -6,7 +6,7 @@ use hamcrest::assert_that;
 
 #[test]
 fn profile_overrides() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -47,7 +47,7 @@ fn profile_overrides() {
 
 #[test]
 fn opt_level_override_0() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -84,7 +84,7 @@ fn opt_level_override_0() {
 
 #[test]
 fn debug_override_1() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -119,7 +119,7 @@ fn debug_override_1() {
 }
 
 fn check_opt_level_override(profile_level: &str, rustc_level: &str) {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             &format!(
@@ -179,7 +179,7 @@ fn opt_level_overrides() {
 
 #[test]
 fn top_level_overrides_deps() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -255,7 +255,7 @@ fn top_level_overrides_deps() {
 
 #[test]
 fn profile_in_non_root_manifest_triggers_a_warning() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -304,7 +304,7 @@ workspace: [..]
 
 #[test]
 fn profile_in_virtual_manifest_works() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -343,7 +343,7 @@ fn profile_in_virtual_manifest_works() {
 
 #[test]
 fn profile_panic_test_bench() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -374,7 +374,7 @@ fn profile_panic_test_bench() {
 
 #[test]
 fn profile_doc_deprecated() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"

--- a/tests/testsuite/publish.rs
+++ b/tests/testsuite/publish.rs
@@ -14,7 +14,7 @@ use tar::Archive;
 fn simple() {
     publish::setup();
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -94,7 +94,7 @@ fn old_token_location() {
         )
         .unwrap();
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -163,7 +163,7 @@ See [..]
 fn simple_with_host() {
     publish::setup();
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -241,7 +241,7 @@ See [..]
 fn simple_with_index_and_host() {
     publish::setup();
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -319,7 +319,7 @@ See [..]
 fn git_deps() {
     publish::setup();
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -360,7 +360,7 @@ repository and specify it with a path and version\n\
 fn path_dependency_no_version() {
     publish::setup();
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -406,7 +406,7 @@ dependency `bar` does not specify a version
 fn unpublishable_crate() {
     publish::setup();
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -438,7 +438,7 @@ fn unpublishable_crate() {
 #[test]
 fn dont_publish_dirty() {
     publish::setup();
-    let p = project("foo").file("bar", "").build();
+    let p = project().file("bar", "").build();
 
     let _ = repo(&paths::root().join("foo"))
         .file(
@@ -480,7 +480,7 @@ to proceed despite this, pass the `--allow-dirty` flag
 fn publish_clean() {
     publish::setup();
 
-    let p = project("foo").build();
+    let p = project().build();
 
     let _ = repo(&paths::root().join("foo"))
         .file(
@@ -512,7 +512,7 @@ fn publish_clean() {
 fn publish_in_sub_repo() {
     publish::setup();
 
-    let p = project("foo").file("baz", "").build();
+    let p = project().file("baz", "").build();
 
     let _ = repo(&paths::root().join("foo"))
         .file(
@@ -545,7 +545,7 @@ fn publish_in_sub_repo() {
 fn publish_when_ignored() {
     publish::setup();
 
-    let p = project("foo").file("baz", "").build();
+    let p = project().file("baz", "").build();
 
     let _ = repo(&paths::root().join("foo"))
         .file(
@@ -578,7 +578,7 @@ fn publish_when_ignored() {
 fn ignore_when_crate_ignored() {
     publish::setup();
 
-    let p = project("foo").file("bar/baz", "").build();
+    let p = project().file("bar/baz", "").build();
 
     let _ = repo(&paths::root().join("foo"))
         .file(".gitignore", "bar")
@@ -610,7 +610,7 @@ fn ignore_when_crate_ignored() {
 fn new_crate_rejected() {
     publish::setup();
 
-    let p = project("foo").file("baz", "").build();
+    let p = project().file("baz", "").build();
 
     let _ = repo(&paths::root().join("foo"))
         .nocommit_file(
@@ -640,7 +640,7 @@ fn new_crate_rejected() {
 fn dry_run() {
     publish::setup();
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -684,7 +684,7 @@ See [..]
 fn block_publish_feature_not_enabled() {
     publish::setup();
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -728,7 +728,7 @@ consider adding `cargo-features = [\"alternative-registries\"]` to the manifest
 fn registry_not_in_publish_list() {
     publish::setup();
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -767,7 +767,7 @@ fn registry_not_in_publish_list() {
 fn publish_empty_list() {
     publish::setup();
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -804,7 +804,7 @@ fn publish_empty_list() {
 fn publish_allowed_registry() {
     publish::setup();
 
-    let p = project("foo").build();
+    let p = project().build();
 
     let _ = repo(&paths::root().join("foo"))
         .file(
@@ -840,7 +840,7 @@ fn publish_allowed_registry() {
 fn block_publish_no_registry() {
     publish::setup();
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"

--- a/tests/testsuite/read_manifest.rs
+++ b/tests/testsuite/read_manifest.rs
@@ -31,7 +31,7 @@ static MANIFEST_OUTPUT: &'static str = r#"
 
 #[test]
 fn cargo_read_manifest_path_to_cargo_toml_relative() {
-    let p = project("foo")
+    let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
         .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
         .build();
@@ -47,7 +47,7 @@ fn cargo_read_manifest_path_to_cargo_toml_relative() {
 
 #[test]
 fn cargo_read_manifest_path_to_cargo_toml_absolute() {
-    let p = project("foo")
+    let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
         .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
         .build();
@@ -63,7 +63,7 @@ fn cargo_read_manifest_path_to_cargo_toml_absolute() {
 
 #[test]
 fn cargo_read_manifest_path_to_cargo_toml_parent_relative() {
-    let p = project("foo")
+    let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
         .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
         .build();
@@ -82,7 +82,7 @@ fn cargo_read_manifest_path_to_cargo_toml_parent_relative() {
 
 #[test]
 fn cargo_read_manifest_path_to_cargo_toml_parent_absolute() {
-    let p = project("foo")
+    let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
         .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
         .build();
@@ -101,7 +101,7 @@ fn cargo_read_manifest_path_to_cargo_toml_parent_absolute() {
 
 #[test]
 fn cargo_read_manifest_cwd() {
-    let p = project("foo")
+    let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
         .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
         .build();

--- a/tests/testsuite/registry.rs
+++ b/tests/testsuite/registry.rs
@@ -20,7 +20,7 @@ fn registry() -> Url {
 
 #[test]
 fn simple() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -71,7 +71,7 @@ fn simple() {
 
 #[test]
 fn deps() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -112,7 +112,7 @@ fn deps() {
 fn nonexistent() {
     Package::new("init", "0.0.1").publish();
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -145,7 +145,7 @@ required by package `foo v0.0.1 ([..])`
 fn wrong_case() {
     Package::new("init", "0.0.1").publish();
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -180,7 +180,7 @@ required by package `foo v0.0.1 ([..])`
 fn mis_hyphenated() {
     Package::new("mis-hyphenated", "0.0.1").publish();
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -213,7 +213,7 @@ required by package `foo v0.0.1 ([..])`
 
 #[test]
 fn wrong_version() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -262,7 +262,7 @@ required by package `foo v0.0.1 ([..])`
 
 #[test]
 fn bad_cksum() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -304,7 +304,7 @@ Caused by:
 fn update_registry() {
     Package::new("init", "0.0.1").publish();
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -353,7 +353,7 @@ required by package `foo v0.0.1 ([..])`
 fn package_with_path_deps() {
     Package::new("init", "0.0.1").publish();
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -418,7 +418,7 @@ required by package `foo v0.0.1 ([..])`
 
 #[test]
 fn lockfile_locks() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -458,7 +458,7 @@ fn lockfile_locks() {
 
 #[test]
 fn lockfile_locks_transitively() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -502,7 +502,7 @@ fn lockfile_locks_transitively() {
 
 #[test]
 fn yanks_are_not_used() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -545,7 +545,7 @@ fn yanks_are_not_used() {
 
 #[test]
 fn relying_on_a_yank_is_bad() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -580,7 +580,7 @@ required by package `bar v0.0.1`
 
 #[test]
 fn yanks_in_lockfiles_are_ok() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -620,7 +620,7 @@ required by package `foo v0.0.1 ([..])`
 
 #[test]
 fn update_with_lockfile_if_packages_missing() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -655,7 +655,7 @@ fn update_with_lockfile_if_packages_missing() {
 
 #[test]
 fn update_lockfile() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -763,7 +763,7 @@ fn update_lockfile() {
 #[test]
 fn update_offline() {
     use cargotest::ChannelChanger;
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -790,7 +790,7 @@ fn update_offline() {
 
 #[test]
 fn dev_dependency_not_used() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -856,7 +856,7 @@ fn login_with_differently_sized_token() {
 #[test]
 fn bad_license_file() {
     Package::new("foo", "1.0.0").publish();
-    let p = project("all")
+    let p = project().at("all")
         .file(
             "Cargo.toml",
             r#"
@@ -889,7 +889,7 @@ fn bad_license_file() {
 
 #[test]
 fn updating_a_dep() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -982,7 +982,7 @@ fn git_and_registry_dep() {
         )
         .file("src/lib.rs", "")
         .build();
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             &format!(
@@ -1032,7 +1032,7 @@ fn git_and_registry_dep() {
 fn update_publish_then_update() {
     // First generate a Cargo.lock and a clone of the registry index at the
     // "head" of the current registry.
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1059,7 +1059,7 @@ fn update_publish_then_update() {
 
     // Generate a Cargo.lock with the newer version, and then move the old copy
     // of the registry back into place.
-    let p2 = project("foo2")
+    let p2 = project().at("foo2")
         .file(
             "Cargo.toml",
             r#"
@@ -1102,7 +1102,7 @@ fn update_publish_then_update() {
 
 #[test]
 fn fetch_downloads() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1133,7 +1133,7 @@ fn fetch_downloads() {
 
 #[test]
 fn update_transitive_dependency() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1182,7 +1182,7 @@ fn update_transitive_dependency() {
 
 #[test]
 fn update_backtracking_ok() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1232,7 +1232,7 @@ fn update_backtracking_ok() {
 
 #[test]
 fn update_multiple_packages() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1297,7 +1297,7 @@ fn update_multiple_packages() {
 
 #[test]
 fn bundled_crate_in_registry() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1347,7 +1347,7 @@ fn bundled_crate_in_registry() {
 
 #[test]
 fn update_same_prefix_oh_my_how_was_this_a_bug() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1377,7 +1377,7 @@ fn update_same_prefix_oh_my_how_was_this_a_bug() {
 
 #[test]
 fn use_semver() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1400,7 +1400,7 @@ fn use_semver() {
 
 #[test]
 fn only_download_relevant() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1440,7 +1440,7 @@ fn only_download_relevant() {
 
 #[test]
 fn resolve_and_backtracking() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1466,7 +1466,7 @@ fn resolve_and_backtracking() {
 
 #[test]
 fn upstream_warnings_on_extra_verbose() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1496,7 +1496,7 @@ fn upstream_warnings_on_extra_verbose() {
 
 #[test]
 fn disallow_network() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1530,7 +1530,7 @@ Caused by:
 
 #[test]
 fn add_dep_dont_update_registry() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1589,7 +1589,7 @@ fn add_dep_dont_update_registry() {
 
 #[test]
 fn bump_version_dont_update_registry() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1647,7 +1647,7 @@ fn bump_version_dont_update_registry() {
 
 #[test]
 fn old_version_req() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1701,7 +1701,7 @@ this warning.
 
 #[test]
 fn old_version_req_upstream() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1778,7 +1778,7 @@ fn toml_lies_but_index_is_truth() {
         .file("src/lib.rs", "extern crate foo;")
         .publish();
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1810,7 +1810,7 @@ fn vv_prints_warnings() {
         )
         .publish();
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1835,7 +1835,7 @@ fn bad_and_or_malicious_packages_rejected() {
         .extra_file("foo-0.1.0/src/lib.rs", "")
         .publish();
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1877,7 +1877,7 @@ fn git_init_templatedir_missing() {
     Package::new("foo", "0.2.0").dep("bar", "*").publish();
     Package::new("bar", "0.2.0").publish();
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"

--- a/tests/testsuite/rename_deps.rs
+++ b/tests/testsuite/rename_deps.rs
@@ -7,7 +7,7 @@ use hamcrest::assert_that;
 
 #[test]
 fn gated() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -37,7 +37,7 @@ consider adding `cargo-features = [\"rename-dependency\"]` to the manifest
         ),
     );
 
-    let p = project("bar")
+    let p = project().at("bar")
         .file(
             "Cargo.toml",
             r#"
@@ -73,7 +73,7 @@ fn rename_dependency() {
     Package::new("bar", "0.1.0").publish();
     Package::new("bar", "0.2.0").publish();
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -106,7 +106,7 @@ fn rename_dependency() {
 
 #[test]
 fn rename_with_different_names() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -174,7 +174,7 @@ fn lots_of_names() {
         .file("src/lib.rs", "pub fn foo3() {}")
         .build();
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             &format!(r#"
@@ -234,7 +234,7 @@ fn lots_of_names() {
 fn rename_and_patch() {
     Package::new("foo", "0.1.0").publish();
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -284,7 +284,7 @@ fn rename_and_patch() {
 fn rename_twice() {
     Package::new("foo", "0.1.0").publish();
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -320,7 +320,7 @@ name, but the dependency on `foo v0.1.0` is listed as having different names
 fn rename_affects_fingerprint() {
     Package::new("foo", "0.1.0").publish();
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"

--- a/tests/testsuite/required_features.rs
+++ b/tests/testsuite/required_features.rs
@@ -5,7 +5,7 @@ use hamcrest::{assert_that, existing_file, is_not};
 
 #[test]
 fn build_bin_default_features() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -71,7 +71,7 @@ Consider enabling them by passing e.g. `--features=\"a\"`
 
 #[test]
 fn build_bin_arg_features() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -100,7 +100,7 @@ fn build_bin_arg_features() {
 
 #[test]
 fn build_bin_multiple_required_features() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -151,7 +151,7 @@ fn build_bin_multiple_required_features() {
 
 #[test]
 fn build_example_default_features() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -193,7 +193,7 @@ Consider enabling them by passing e.g. `--features=\"a\"`
 
 #[test]
 fn build_example_arg_features() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -225,7 +225,7 @@ fn build_example_arg_features() {
 
 #[test]
 fn build_example_multiple_required_features() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -314,7 +314,7 @@ Consider enabling them by passing e.g. `--features=\"a\"`
 
 #[test]
 fn test_default_features() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -386,7 +386,7 @@ Consider enabling them by passing e.g. `--features=\"a\"`
 
 #[test]
 fn test_arg_features() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -423,7 +423,7 @@ fn test_arg_features() {
 
 #[test]
 fn test_multiple_required_features() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -497,7 +497,7 @@ fn bench_default_features() {
         return;
     }
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -580,7 +580,7 @@ fn bench_arg_features() {
         return;
     }
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -630,7 +630,7 @@ fn bench_multiple_required_features() {
         return;
     }
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -716,7 +716,7 @@ fn bench_multiple_required_features() {
 
 #[test]
 fn install_default_features() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -811,7 +811,7 @@ Consider enabling them by passing e.g. `--features=\"a\"`
 
 #[test]
 fn install_arg_features() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -841,7 +841,7 @@ fn install_arg_features() {
 
 #[test]
 fn install_multiple_required_features() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -900,7 +900,7 @@ fn install_multiple_required_features() {
 
 #[test]
 fn dep_feature_in_toml() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1011,7 +1011,7 @@ fn dep_feature_in_toml() {
 
 #[test]
 fn dep_feature_in_cmd_line() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1190,7 +1190,7 @@ Consider enabling them by passing e.g. `--features=\"bar/a\"`
 
 #[test]
 fn test_skips_compiling_bin_with_missing_required_features() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1274,7 +1274,7 @@ error[E0463]: can't find crate for `bar`",
 
 #[test]
 fn run_default() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1314,7 +1314,7 @@ Consider enabling them by passing e.g. `--features=\"a\"`
 
 #[test]
 fn run_default_multiple_required_features() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"

--- a/tests/testsuite/resolve.rs
+++ b/tests/testsuite/resolve.rs
@@ -395,7 +395,7 @@ fn minimal_version_cli() {
     Package::new("dep", "1.0.0").publish();
     Package::new("dep", "1.1.0").publish();
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"

--- a/tests/testsuite/run.rs
+++ b/tests/testsuite/run.rs
@@ -5,7 +5,7 @@ use hamcrest::{assert_that, existing_file};
 
 #[test]
 fn simple() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -41,7 +41,7 @@ fn simple() {
 
 #[test]
 fn simple_quiet() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -72,7 +72,7 @@ fn simple_quiet() {
 
 #[test]
 fn simple_quiet_and_verbose() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -100,7 +100,7 @@ fn simple_quiet_and_verbose() {
 
 #[test]
 fn quiet_and_verbose_config() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -130,7 +130,7 @@ fn quiet_and_verbose_config() {
 
 #[test]
 fn simple_with_args() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -159,7 +159,7 @@ fn simple_with_args() {
 
 #[test]
 fn exit_code() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -194,7 +194,7 @@ fn exit_code() {
 
 #[test]
 fn exit_code_verbose() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -234,7 +234,7 @@ fn exit_code_verbose() {
 
 #[test]
 fn no_main_file() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -258,7 +258,7 @@ fn no_main_file() {
 
 #[test]
 fn too_many_bins() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -286,7 +286,7 @@ fn too_many_bins() {
 
 #[test]
 fn specify_name() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -348,7 +348,7 @@ fn specify_name() {
 
 #[test]
 fn specify_default_run() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -388,7 +388,7 @@ fn specify_default_run() {
 
 #[test]
 fn bogus_default_run() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -415,7 +415,7 @@ fn bogus_default_run() {
 
 #[test]
 fn default_run_unstable() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -466,7 +466,7 @@ consider adding `cargo-features = ["default-run"]` to the manifest
 
 #[test]
 fn run_example() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -508,7 +508,7 @@ fn run_example() {
 
 #[test]
 fn run_library_example() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -543,7 +543,7 @@ fn autodiscover_examples_project(rust_edition: &str, autoexamples: Option<bool>)
         None => "".to_string(),
         Some(bool) => format!("autoexamples = {}", bool),
     };
-    project("foo")
+    project()
         .file(
             "Cargo.toml",
             &format!(
@@ -688,7 +688,7 @@ fn run_example_autodiscover_2018() {
 
 #[test]
 fn run_bins() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -723,7 +723,7 @@ fn run_bins() {
 
 #[test]
 fn run_with_filename() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -786,7 +786,7 @@ Did you mean `a`?",
 
 #[test]
 fn either_name_or_example() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -826,7 +826,7 @@ fn either_name_or_example() {
 
 #[test]
 fn one_bin_multiple_examples() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -874,7 +874,7 @@ fn one_bin_multiple_examples() {
 
 #[test]
 fn example_with_release_flag() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1004,7 +1004,7 @@ slow2",
 
 #[test]
 fn run_dylib_dep() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1048,7 +1048,7 @@ fn run_dylib_dep() {
 
 #[test]
 fn release_works() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1082,7 +1082,7 @@ fn release_works() {
 
 #[test]
 fn run_bin_different_name() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1108,7 +1108,7 @@ fn run_bin_different_name() {
 
 #[test]
 fn dashes_are_forwarded() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1140,7 +1140,7 @@ fn dashes_are_forwarded() {
 
 #[test]
 fn run_from_executable_folder() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1176,7 +1176,7 @@ fn run_from_executable_folder() {
 
 #[test]
 fn run_with_library_paths() {
-    let p = project("foo");
+    let p = project();
 
     // Only link search directories within the target output directory are
     // propagated through to dylib_path_envvar() (see #3366).
@@ -1231,7 +1231,7 @@ fn run_with_library_paths() {
 
 #[test]
 fn library_paths_sorted_alphabetically() {
-    let p = project("foo");
+    let p = project();
 
     let mut dir1 = p.target_debug_dir();
     dir1.push("zzzzzzz");
@@ -1289,7 +1289,7 @@ fn library_paths_sorted_alphabetically() {
 
 #[test]
 fn fail_no_extra_verbose() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1317,7 +1317,7 @@ fn fail_no_extra_verbose() {
 
 #[test]
 fn run_multiple_packages() {
-    let p = project("foo")
+    let p = project()
         .file(
             "foo/Cargo.toml",
             r#"
@@ -1410,7 +1410,7 @@ fn run_multiple_packages() {
 
 #[test]
 fn explicit_bin_with_args() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"

--- a/tests/testsuite/rustc.rs
+++ b/tests/testsuite/rustc.rs
@@ -7,7 +7,7 @@ the package by passing e.g. `--lib` or `--bin NAME` to specify a single target";
 
 #[test]
 fn build_lib_for_foo() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -46,7 +46,7 @@ fn build_lib_for_foo() {
 
 #[test]
 fn lib() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -91,7 +91,7 @@ fn lib() {
 
 #[test]
 fn build_main_and_allow_unstable_options() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -139,7 +139,7 @@ fn build_main_and_allow_unstable_options() {
 
 #[test]
 fn fails_when_trying_to_build_main_and_lib_with_args() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -170,7 +170,7 @@ fn fails_when_trying_to_build_main_and_lib_with_args() {
 
 #[test]
 fn build_with_args_to_one_of_multiple_binaries() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -220,7 +220,7 @@ fn build_with_args_to_one_of_multiple_binaries() {
 
 #[test]
 fn fails_with_args_to_all_binaries() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -263,7 +263,7 @@ fn fails_with_args_to_all_binaries() {
 
 #[test]
 fn build_with_args_to_one_of_multiple_tests() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -298,7 +298,7 @@ fn build_with_args_to_one_of_multiple_tests() {
 
 #[test]
 fn build_foo_with_bar_dependency() {
-    let foo = project("foo")
+    let foo = project()
         .file(
             "Cargo.toml",
             r#"
@@ -321,7 +321,7 @@ fn build_foo_with_bar_dependency() {
         "#,
         )
         .build();
-    let _bar = project("bar")
+    let _bar = project().at("bar")
         .file(
             "Cargo.toml",
             r#"
@@ -360,7 +360,7 @@ fn build_foo_with_bar_dependency() {
 
 #[test]
 fn build_only_bar_dependency() {
-    let foo = project("foo")
+    let foo = project()
         .file(
             "Cargo.toml",
             r#"
@@ -383,7 +383,7 @@ fn build_only_bar_dependency() {
         "#,
         )
         .build();
-    let _bar = project("bar")
+    let _bar = project().at("bar")
         .file(
             "Cargo.toml",
             r#"
@@ -415,7 +415,7 @@ fn build_only_bar_dependency() {
 
 #[test]
 fn targets_selected_default() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -447,7 +447,7 @@ fn targets_selected_default() {
 
 #[test]
 fn targets_selected_all() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -479,7 +479,7 @@ fn targets_selected_all() {
 
 #[test]
 fn fail_with_multiple_packages() {
-    let foo = project("foo")
+    let foo = project()
         .file(
             "Cargo.toml",
             r#"
@@ -503,7 +503,7 @@ fn fail_with_multiple_packages() {
         )
         .build();
 
-    let _bar = project("bar")
+    let _bar = project().at("bar")
         .file(
             "Cargo.toml",
             r#"
@@ -523,7 +523,7 @@ fn fail_with_multiple_packages() {
         )
         .build();
 
-    let _baz = project("baz")
+    let _baz = project().at("baz")
         .file(
             "Cargo.toml",
             r#"
@@ -556,7 +556,7 @@ error: The argument '--package <SPEC>' was provided more than once, \
 
 #[test]
 fn rustc_with_other_profile() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -599,7 +599,7 @@ fn rustc_with_other_profile() {
 #[test]
 fn rustc_fingerprint() {
     // Verify that the fingerprint includes the rustc args.
-    let p = project("foo")
+    let p = project()
         .file("Cargo.toml", &basic_lib_manifest("foo"))
         .file("src/lib.rs", "")
         .build();
@@ -652,7 +652,7 @@ fn rustc_fingerprint() {
 
 #[test]
 fn rustc_test_with_implicit_bin() {
-    let p = project("foo")
+    let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
         .file(
             "src/main.rs",

--- a/tests/testsuite/rustc_info_cache.rs
+++ b/tests/testsuite/rustc_info_cache.rs
@@ -5,7 +5,7 @@ use std::env;
 
 #[test]
 fn rustc_info_cache() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -53,7 +53,7 @@ fn rustc_info_cache() {
     );
 
     let other_rustc = {
-        let p = project("compiler")
+        let p = project().at("compiler")
             .file(
                 "Cargo.toml",
                 r#"

--- a/tests/testsuite/rustdoc.rs
+++ b/tests/testsuite/rustdoc.rs
@@ -255,7 +255,7 @@ fn features() {
 #[test]
 #[cfg(all(target_arch = "x86_64", target_os = "linux"))]
 fn rustdoc_target() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"

--- a/tests/testsuite/rustdoc.rs
+++ b/tests/testsuite/rustdoc.rs
@@ -3,7 +3,7 @@ use hamcrest::assert_that;
 
 #[test]
 fn rustdoc_simple() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -34,7 +34,7 @@ fn rustdoc_simple() {
 
 #[test]
 fn rustdoc_args() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -66,7 +66,7 @@ fn rustdoc_args() {
 
 #[test]
 fn rustdoc_foo_with_bar_dependency() {
-    let foo = project("foo")
+    let foo = project()
         .file(
             "Cargo.toml",
             r#"
@@ -87,7 +87,7 @@ fn rustdoc_foo_with_bar_dependency() {
         "#,
         )
         .build();
-    let _bar = project("bar")
+    let _bar = project().at("bar")
         .file(
             "Cargo.toml",
             r#"
@@ -127,7 +127,7 @@ fn rustdoc_foo_with_bar_dependency() {
 
 #[test]
 fn rustdoc_only_bar_dependency() {
-    let foo = project("foo")
+    let foo = project()
         .file(
             "Cargo.toml",
             r#"
@@ -150,7 +150,7 @@ fn rustdoc_only_bar_dependency() {
         "#,
         )
         .build();
-    let _bar = project("bar")
+    let _bar = project().at("bar")
         .file(
             "Cargo.toml",
             r#"
@@ -191,7 +191,7 @@ fn rustdoc_only_bar_dependency() {
 
 #[test]
 fn rustdoc_same_name_documents_lib() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -228,7 +228,7 @@ fn rustdoc_same_name_documents_lib() {
 
 #[test]
 fn features() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"

--- a/tests/testsuite/rustdocflags.rs
+++ b/tests/testsuite/rustdocflags.rs
@@ -3,7 +3,7 @@ use hamcrest::assert_that;
 
 #[test]
 fn parses_env() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -26,7 +26,7 @@ fn parses_env() {
 
 #[test]
 fn parses_config() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -56,7 +56,7 @@ fn parses_config() {
 
 #[test]
 fn bad_flags() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -77,7 +77,7 @@ fn bad_flags() {
 
 #[test]
 fn rerun() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -113,7 +113,7 @@ fn rerun() {
 
 #[test]
 fn rustdocflags_passed_to_rustdoc_through_cargo_test() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -142,7 +142,7 @@ fn rustdocflags_passed_to_rustdoc_through_cargo_test() {
 
 #[test]
 fn rustdocflags_passed_to_rustdoc_through_cargo_test_only_once() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"

--- a/tests/testsuite/rustflags.rs
+++ b/tests/testsuite/rustflags.rs
@@ -7,7 +7,7 @@ use hamcrest::assert_that;
 
 #[test]
 fn env_rustflags_normal_source() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -59,7 +59,7 @@ fn env_rustflags_build_script() {
     // RUSTFLAGS should be passed to rustc for build scripts
     // when --target is not specified.
     // In this test if --cfg foo is passed the build will fail.
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -91,7 +91,7 @@ fn env_rustflags_build_script_dep() {
     // RUSTFLAGS should be passed to rustc for build scripts
     // when --target is not specified.
     // In this test if --cfg foo is not passed the build will fail.
-    let foo = project("foo")
+    let foo = project()
         .file(
             "Cargo.toml",
             r#"
@@ -112,7 +112,7 @@ fn env_rustflags_build_script_dep() {
         "#,
         )
         .build();
-    let _bar = project("bar")
+    let _bar = project().at("bar")
         .file(
             "Cargo.toml",
             r#"
@@ -142,7 +142,7 @@ fn env_rustflags_plugin() {
     // RUSTFLAGS should be passed to rustc for plugins
     // when --target is not specified.
     // In this test if --cfg foo is not passed the build will fail.
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -176,7 +176,7 @@ fn env_rustflags_plugin_dep() {
     // RUSTFLAGS should be passed to rustc for plugins
     // when --target is not specified.
     // In this test if --cfg foo is not passed the build will fail.
-    let foo = project("foo")
+    let foo = project()
         .file(
             "Cargo.toml",
             r#"
@@ -199,7 +199,7 @@ fn env_rustflags_plugin_dep() {
         "#,
         )
         .build();
-    let _bar = project("bar")
+    let _bar = project().at("bar")
         .file(
             "Cargo.toml",
             r#"
@@ -229,7 +229,7 @@ fn env_rustflags_plugin_dep() {
 
 #[test]
 fn env_rustflags_normal_source_with_target() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -299,7 +299,7 @@ fn env_rustflags_build_script_with_target() {
     // RUSTFLAGS should not be passed to rustc for build scripts
     // when --target is specified.
     // In this test if --cfg foo is passed the build will fail.
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -335,7 +335,7 @@ fn env_rustflags_build_script_dep_with_target() {
     // RUSTFLAGS should not be passed to rustc for build scripts
     // when --target is specified.
     // In this test if --cfg foo is passed the build will fail.
-    let foo = project("foo")
+    let foo = project()
         .file(
             "Cargo.toml",
             r#"
@@ -356,7 +356,7 @@ fn env_rustflags_build_script_dep_with_target() {
         "#,
         )
         .build();
-    let _bar = project("bar")
+    let _bar = project().at("bar")
         .file(
             "Cargo.toml",
             r#"
@@ -390,7 +390,7 @@ fn env_rustflags_plugin_with_target() {
     // RUSTFLAGS should not be passed to rustc for plugins
     // when --target is specified.
     // In this test if --cfg foo is passed the build will fail.
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -428,7 +428,7 @@ fn env_rustflags_plugin_dep_with_target() {
     // RUSTFLAGS should not be passed to rustc for plugins
     // when --target is specified.
     // In this test if --cfg foo is passed the build will fail.
-    let foo = project("foo")
+    let foo = project()
         .file(
             "Cargo.toml",
             r#"
@@ -451,7 +451,7 @@ fn env_rustflags_plugin_dep_with_target() {
         "#,
         )
         .build();
-    let _bar = project("bar")
+    let _bar = project().at("bar")
         .file(
             "Cargo.toml",
             r#"
@@ -485,7 +485,7 @@ fn env_rustflags_plugin_dep_with_target() {
 
 #[test]
 fn env_rustflags_recompile() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -507,7 +507,7 @@ fn env_rustflags_recompile() {
 
 #[test]
 fn env_rustflags_recompile2() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -532,7 +532,7 @@ fn env_rustflags_recompile2() {
 
 #[test]
 fn env_rustflags_no_recompile() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -556,7 +556,7 @@ fn env_rustflags_no_recompile() {
 
 #[test]
 fn build_rustflags_normal_source() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -600,7 +600,7 @@ fn build_rustflags_build_script() {
     // RUSTFLAGS should be passed to rustc for build scripts
     // when --target is not specified.
     // In this test if --cfg foo is passed the build will fail.
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -636,7 +636,7 @@ fn build_rustflags_build_script_dep() {
     // RUSTFLAGS should be passed to rustc for build scripts
     // when --target is not specified.
     // In this test if --cfg foo is not passed the build will fail.
-    let foo = project("foo")
+    let foo = project()
         .file(
             "Cargo.toml",
             r#"
@@ -664,7 +664,7 @@ fn build_rustflags_build_script_dep() {
             "#,
         )
         .build();
-    let _bar = project("bar")
+    let _bar = project().at("bar")
         .file(
             "Cargo.toml",
             r#"
@@ -691,7 +691,7 @@ fn build_rustflags_plugin() {
     // RUSTFLAGS should be passed to rustc for plugins
     // when --target is not specified.
     // In this test if --cfg foo is not passed the build will fail.
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -729,7 +729,7 @@ fn build_rustflags_plugin_dep() {
     // RUSTFLAGS should be passed to rustc for plugins
     // when --target is not specified.
     // In this test if --cfg foo is not passed the build will fail.
-    let foo = project("foo")
+    let foo = project()
         .file(
             "Cargo.toml",
             r#"
@@ -759,7 +759,7 @@ fn build_rustflags_plugin_dep() {
             "#,
         )
         .build();
-    let _bar = project("bar")
+    let _bar = project().at("bar")
         .file(
             "Cargo.toml",
             r#"
@@ -786,7 +786,7 @@ fn build_rustflags_plugin_dep() {
 
 #[test]
 fn build_rustflags_normal_source_with_target() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -848,7 +848,7 @@ fn build_rustflags_build_script_with_target() {
     // RUSTFLAGS should not be passed to rustc for build scripts
     // when --target is specified.
     // In this test if --cfg foo is passed the build will fail.
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -888,7 +888,7 @@ fn build_rustflags_build_script_dep_with_target() {
     // RUSTFLAGS should not be passed to rustc for build scripts
     // when --target is specified.
     // In this test if --cfg foo is passed the build will fail.
-    let foo = project("foo")
+    let foo = project()
         .file(
             "Cargo.toml",
             r#"
@@ -916,7 +916,7 @@ fn build_rustflags_build_script_dep_with_target() {
             "#,
         )
         .build();
-    let _bar = project("bar")
+    let _bar = project().at("bar")
         .file(
             "Cargo.toml",
             r#"
@@ -947,7 +947,7 @@ fn build_rustflags_plugin_with_target() {
     // RUSTFLAGS should not be passed to rustc for plugins
     // when --target is specified.
     // In this test if --cfg foo is passed the build will fail.
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -989,7 +989,7 @@ fn build_rustflags_plugin_dep_with_target() {
     // RUSTFLAGS should not be passed to rustc for plugins
     // when --target is specified.
     // In this test if --cfg foo is passed the build will fail.
-    let foo = project("foo")
+    let foo = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1019,7 +1019,7 @@ fn build_rustflags_plugin_dep_with_target() {
             "#,
         )
         .build();
-    let _bar = project("bar")
+    let _bar = project().at("bar")
         .file(
             "Cargo.toml",
             r#"
@@ -1050,7 +1050,7 @@ fn build_rustflags_plugin_dep_with_target() {
 
 #[test]
 fn build_rustflags_recompile() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1079,7 +1079,7 @@ fn build_rustflags_recompile() {
 
 #[test]
 fn build_rustflags_recompile2() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1111,7 +1111,7 @@ fn build_rustflags_recompile2() {
 
 #[test]
 fn build_rustflags_no_recompile() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1175,7 +1175,7 @@ fn build_rustflags_with_home_config() {
 
 #[test]
 fn target_rustflags_normal_source() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1220,7 +1220,7 @@ fn target_rustflags_normal_source() {
 // target.{}.rustflags takes precedence over build.rustflags
 #[test]
 fn target_rustflags_precedence() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1257,7 +1257,7 @@ fn target_rustflags_precedence() {
 
 #[test]
 fn cfg_rustflags_normal_source() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1349,7 +1349,7 @@ fn cfg_rustflags_normal_source() {
 // target.'cfg(...)'.rustflags takes precedence over build.rustflags
 #[test]
 fn cfg_rustflags_precedence() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1443,7 +1443,7 @@ fn cfg_rustflags_precedence() {
 
 #[test]
 fn target_rustflags_string_and_array_form1() {
-    let p1 = project("foo")
+    let p1 = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1473,7 +1473,7 @@ fn target_rustflags_string_and_array_form1() {
         ),
     );
 
-    let p2 = project("foo")
+    let p2 = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1506,7 +1506,7 @@ fn target_rustflags_string_and_array_form1() {
 
 #[test]
 fn target_rustflags_string_and_array_form2() {
-    let p1 = project("foo")
+    let p1 = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1539,7 +1539,7 @@ fn target_rustflags_string_and_array_form2() {
         ),
     );
 
-    let p2 = project("foo")
+    let p2 = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1575,7 +1575,7 @@ fn target_rustflags_string_and_array_form2() {
 
 #[test]
 fn two_matching_in_config() {
-    let p1 = project("foo")
+    let p1 = project()
         .file(
             "Cargo.toml",
             r#"

--- a/tests/testsuite/shell_quoting.rs
+++ b/tests/testsuite/shell_quoting.rs
@@ -10,7 +10,7 @@ use hamcrest::assert_that;
 
 #[test]
 fn features_are_quoted() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"

--- a/tests/testsuite/small_fd_limits.rs
+++ b/tests/testsuite/small_fd_limits.rs
@@ -20,7 +20,7 @@ fn find_index() -> PathBuf {
 fn run_test(path_env: Option<&OsStr>) {
     const N: usize = 50;
 
-    let foo = project("foo")
+    let foo = project()
         .file(
             "Cargo.toml",
             r#"

--- a/tests/testsuite/test.rs
+++ b/tests/testsuite/test.rs
@@ -12,7 +12,7 @@ use hamcrest::{assert_that, existing_file, is_not};
 
 #[test]
 fn cargo_test_simple() {
-    let p = project("foo")
+    let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
         .file(
             "src/main.rs",
@@ -57,7 +57,7 @@ fn cargo_test_simple() {
 
 #[test]
 fn cargo_test_release() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -130,7 +130,7 @@ fn cargo_test_overflow_checks() {
     if !is_nightly() {
         return;
     }
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -170,7 +170,7 @@ fn cargo_test_overflow_checks() {
 
 #[test]
 fn cargo_test_verbose() {
-    let p = project("foo")
+    let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
         .file(
             "src/main.rs",
@@ -199,7 +199,7 @@ fn cargo_test_verbose() {
 
 #[test]
 fn many_similar_names() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -254,7 +254,7 @@ fn many_similar_names() {
 
 #[test]
 fn cargo_test_failing_test_in_bin() {
-    let p = project("foo")
+    let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
         .file(
             "src/main.rs",
@@ -319,7 +319,7 @@ failures:
 
 #[test]
 fn cargo_test_failing_test_in_test() {
-    let p = project("foo")
+    let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
         .file(
             "src/main.rs",
@@ -383,7 +383,7 @@ failures:
 
 #[test]
 fn cargo_test_failing_test_in_lib() {
-    let p = project("foo")
+    let p = project()
         .file("Cargo.toml", &basic_lib_manifest("foo"))
         .file(
             "src/lib.rs",
@@ -429,7 +429,7 @@ failures:
 
 #[test]
 fn test_with_lib_dep() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -493,7 +493,7 @@ fn test_with_lib_dep() {
 
 #[test]
 fn test_with_deep_lib_dep() {
-    let p = project("bar")
+    let p = project().at("bar")
         .file(
             "Cargo.toml",
             r#"
@@ -523,7 +523,7 @@ fn test_with_deep_lib_dep() {
         ",
         )
         .build();
-    let _p2 = project("foo")
+    let _p2 = project()
         .file(
             "Cargo.toml",
             r#"
@@ -564,7 +564,7 @@ fn test_with_deep_lib_dep() {
 
 #[test]
 fn external_test_explicit() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -619,7 +619,7 @@ fn external_test_explicit() {
 
 #[test]
 fn external_test_named_test() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -647,7 +647,7 @@ fn external_test_named_test() {
 
 #[test]
 fn external_test_implicit() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -698,7 +698,7 @@ fn external_test_implicit() {
 
 #[test]
 fn dont_run_examples() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -725,7 +725,7 @@ fn dont_run_examples() {
 
 #[test]
 fn pass_through_command_line() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -779,7 +779,7 @@ fn pass_through_command_line() {
 // tests in an rlib
 #[test]
 fn cargo_test_twice() {
-    let p = project("test_twice")
+    let p = project().at("test_twice")
         .file("Cargo.toml", &basic_lib_manifest("test_twice"))
         .file(
             "src/test_twice.rs",
@@ -801,7 +801,7 @@ fn cargo_test_twice() {
 
 #[test]
 fn lib_bin_same_name() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -854,7 +854,7 @@ fn lib_bin_same_name() {
 
 #[test]
 fn lib_with_standard_name() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -908,7 +908,7 @@ fn lib_with_standard_name() {
 
 #[test]
 fn lib_with_standard_name2() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -959,7 +959,7 @@ fn lib_with_standard_name2() {
 
 #[test]
 fn lib_without_name() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1009,7 +1009,7 @@ fn lib_without_name() {
 
 #[test]
 fn bin_without_name() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1059,7 +1059,7 @@ Caused by:
 
 #[test]
 fn bench_without_name() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1120,7 +1120,7 @@ Caused by:
 
 #[test]
 fn test_without_name() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1180,7 +1180,7 @@ Caused by:
 
 #[test]
 fn example_without_name() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1240,7 +1240,7 @@ Caused by:
 
 #[test]
 fn bin_there_for_integration() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1286,7 +1286,7 @@ fn bin_there_for_integration() {
 
 #[test]
 fn test_dylib() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1377,7 +1377,7 @@ fn test_dylib() {
 
 #[test]
 fn test_twice_with_build_cmd() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1431,7 +1431,7 @@ fn test_twice_with_build_cmd() {
 
 #[test]
 fn test_then_build() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1471,7 +1471,7 @@ fn test_then_build() {
 
 #[test]
 fn test_no_run() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1504,7 +1504,7 @@ fn test_no_run() {
 
 #[test]
 fn test_run_specific_bin_target() {
-    let prj = project("foo")
+    let prj = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1543,7 +1543,7 @@ fn test_run_specific_bin_target() {
 
 #[test]
 fn test_run_implicit_bin_target() {
-    let prj = project("foo")
+    let prj = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1588,7 +1588,7 @@ fn test_run_implicit_bin_target() {
 
 #[test]
 fn test_run_specific_test_target() {
-    let prj = project("foo")
+    let prj = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1621,7 +1621,7 @@ fn test_run_specific_test_target() {
 
 #[test]
 fn test_run_implicit_test_target() {
-    let prj = project("foo")
+    let prj = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1666,7 +1666,7 @@ fn test_run_implicit_test_target() {
 
 #[test]
 fn test_run_implicit_bench_target() {
-    let prj = project("foo")
+    let prj = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1711,7 +1711,7 @@ fn test_run_implicit_bench_target() {
 
 #[test]
 fn test_run_implicit_example_target() {
-    let prj = project("foo")
+    let prj = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1800,7 +1800,7 @@ fn test_run_implicit_example_target() {
 
 #[test]
 fn test_no_harness() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1838,7 +1838,7 @@ fn test_no_harness() {
 
 #[test]
 fn selective_testing() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1946,7 +1946,7 @@ fn selective_testing() {
 
 #[test]
 fn almost_cyclic_but_not_quite() {
-    let p = project("a")
+    let p = project().at("a")
         .file(
             "Cargo.toml",
             r#"
@@ -2005,7 +2005,7 @@ fn almost_cyclic_but_not_quite() {
 
 #[test]
 fn build_then_selective_test() {
-    let p = project("a")
+    let p = project().at("a")
         .file(
             "Cargo.toml",
             r#"
@@ -2051,7 +2051,7 @@ fn build_then_selective_test() {
 
 #[test]
 fn example_dev_dep() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -2117,7 +2117,7 @@ fn example_dev_dep() {
 
 #[test]
 fn selective_testing_with_docs() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -2173,7 +2173,7 @@ fn selective_testing_with_docs() {
 
 #[test]
 fn example_bin_same_name() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -2225,7 +2225,7 @@ fn example_bin_same_name() {
 
 #[test]
 fn test_with_example_twice() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -2249,7 +2249,7 @@ fn test_with_example_twice() {
 
 #[test]
 fn example_with_dev_dep() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -2301,7 +2301,7 @@ fn example_with_dev_dep() {
 
 #[test]
 fn bin_is_preserved() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -2325,7 +2325,7 @@ fn bin_is_preserved() {
 
 #[test]
 fn bad_example() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -2354,7 +2354,7 @@ fn bad_example() {
 
 #[test]
 fn doctest_feature() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -2396,7 +2396,7 @@ fn doctest_feature() {
 
 #[test]
 fn dashes_to_underscores() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -2422,7 +2422,7 @@ fn dashes_to_underscores() {
 
 #[test]
 fn doctest_dev_dep() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -2461,7 +2461,7 @@ fn doctest_dev_dep() {
 
 #[test]
 fn filter_no_doc_tests() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -2499,7 +2499,7 @@ fn filter_no_doc_tests() {
 
 #[test]
 fn dylib_doctest() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -2542,7 +2542,7 @@ fn dylib_doctest() {
 #[test]
 fn dylib_doctest2() {
     // can't doctest dylibs as they're statically linked together
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -2573,7 +2573,7 @@ fn dylib_doctest2() {
 
 #[test]
 fn cyclic_dev_dep_doc_test() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -2633,7 +2633,7 @@ fn cyclic_dev_dep_doc_test() {
 
 #[test]
 fn dev_dep_with_build_script() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -2666,7 +2666,7 @@ fn dev_dep_with_build_script() {
 
 #[test]
 fn no_fail_fast() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -2747,7 +2747,7 @@ fn no_fail_fast() {
 
 #[test]
 fn test_multiple_packages() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -2809,7 +2809,7 @@ fn test_multiple_packages() {
 
 #[test]
 fn bin_does_not_rebuild_tests() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -2847,7 +2847,7 @@ fn bin_does_not_rebuild_tests() {
 
 #[test]
 fn selective_test_wonky_profile() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -2884,7 +2884,7 @@ fn selective_test_wonky_profile() {
 
 #[test]
 fn selective_test_optional_dep() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -2931,7 +2931,7 @@ fn selective_test_optional_dep() {
 
 #[test]
 fn only_test_docs() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -2976,7 +2976,7 @@ fn only_test_docs() {
 
 #[test]
 fn test_panic_abort_with_dep() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -3017,7 +3017,7 @@ fn test_panic_abort_with_dep() {
 
 #[test]
 fn cfg_test_even_with_no_harness() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -3056,7 +3056,7 @@ fn cfg_test_even_with_no_harness() {
 
 #[test]
 fn panic_abort_multiple() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -3095,7 +3095,7 @@ fn panic_abort_multiple() {
 
 #[test]
 fn pass_correct_cfgs_flags_to_rustdoc() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -3204,7 +3204,7 @@ fn pass_correct_cfgs_flags_to_rustdoc() {
 
 #[test]
 fn test_release_ignore_panic() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -3245,7 +3245,7 @@ fn test_release_ignore_panic() {
 
 #[test]
 fn test_many_with_features() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -3284,7 +3284,7 @@ fn test_many_with_features() {
 
 #[test]
 fn test_all_workspace() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -3333,7 +3333,7 @@ fn test_all_workspace() {
 
 #[test]
 fn test_all_exclude() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -3396,7 +3396,7 @@ test bar ... ok",
 
 #[test]
 fn test_all_virtual_manifest() {
-    let p = project("workspace")
+    let p = project().at("workspace")
         .file(
             "Cargo.toml",
             r#"
@@ -3447,7 +3447,7 @@ fn test_all_virtual_manifest() {
 
 #[test]
 fn test_virtual_manifest_all_implied() {
-    let p = project("workspace")
+    let p = project().at("workspace")
         .file(
             "Cargo.toml",
             r#"
@@ -3498,7 +3498,7 @@ fn test_virtual_manifest_all_implied() {
 
 #[test]
 fn test_all_member_dependency_same_name() {
-    let p = project("workspace")
+    let p = project().at("workspace")
         .file(
             "Cargo.toml",
             r#"
@@ -3536,7 +3536,7 @@ fn test_all_member_dependency_same_name() {
 
 #[test]
 fn doctest_only_with_dev_dep() {
-    let p = project("workspace")
+    let p = project().at("workspace")
         .file(
             "Cargo.toml",
             r#"
@@ -3583,7 +3583,7 @@ fn doctest_only_with_dev_dep() {
 
 #[test]
 fn test_many_targets() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -3681,7 +3681,7 @@ fn test_many_targets() {
 
 #[test]
 fn doctest_and_registry() {
-    let p = project("workspace")
+    let p = project().at("workspace")
         .file(
             "Cargo.toml",
             r#"
@@ -3751,7 +3751,7 @@ fn cargo_test_env() {
         cargo::CARGO_ENV
     );
 
-    let p = project("env_test")
+    let p = project().at("env_test")
         .file("Cargo.toml", &basic_lib_manifest("env_test"))
         .file("src/lib.rs", &src)
         .build();
@@ -3772,7 +3772,7 @@ test env_test ... ok
 
 #[test]
 fn test_order() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -3828,7 +3828,7 @@ test result: ok. [..]
 
 #[test]
 fn cyclic_dev() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -3879,7 +3879,7 @@ fn publish_a_crate_without_tests() {
 
         .publish();
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -3903,7 +3903,7 @@ fn publish_a_crate_without_tests() {
 
 #[test]
 fn find_dependency_of_proc_macro_dependency_with_target() {
-    let workspace = project("workspace")
+    let workspace = project().at("workspace")
         .file(
             "Cargo.toml",
             r#"
@@ -3979,7 +3979,7 @@ fn find_dependency_of_proc_macro_dependency_with_target() {
 
 #[test]
 fn test_hint_not_masked_by_doctest() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -4022,7 +4022,7 @@ fn test_hint_not_masked_by_doctest() {
 
 #[test]
 fn test_hint_workspace() {
-    let workspace = project("workspace")
+    let workspace = project().at("workspace")
         .file(
             "Cargo.toml",
             r#"
@@ -4073,7 +4073,7 @@ fn test_hint_workspace() {
 #[test]
 fn json_artifact_includes_test_flag() {
     // Verify that the JSON artifact output includes `test` flag.
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -4141,7 +4141,7 @@ fn json_artifact_includes_test_flag() {
 
 #[test]
 fn test_build_script_links() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"

--- a/tests/testsuite/tool_paths.rs
+++ b/tests/testsuite/tool_paths.rs
@@ -6,7 +6,7 @@ use hamcrest::assert_that;
 fn pathless_tools() {
     let target = rustc_host();
 
-    let foo = project("foo")
+    let foo = project()
         .file(
             "Cargo.toml",
             r#"
@@ -60,7 +60,7 @@ fn absolute_tools() {
         (r#"/bogus/nonexistent-ar"#, r#"/bogus/nonexistent-linker"#)
     };
 
-    let foo = project("foo")
+    let foo = project()
         .file(
             "Cargo.toml",
             r#"
@@ -126,7 +126,7 @@ fn relative_tools() {
 
     // Funky directory structure to test that relative tool paths are made absolute
     // by reference to the `.cargo/..` directory and not to (for example) the CWD.
-    let origin = project("origin")
+    let origin = project().at("origin")
         .file(
             "foo/Cargo.toml",
             r#"
@@ -189,7 +189,7 @@ fn relative_tools() {
 fn custom_runner() {
     let target = rustc_host();
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"

--- a/tests/testsuite/update.rs
+++ b/tests/testsuite/update.rs
@@ -8,7 +8,7 @@ use hamcrest::assert_that;
 #[test]
 fn minor_update_two_places() {
     Package::new("log", "0.1.0").publish();
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -64,7 +64,7 @@ fn transitive_minor_update() {
     Package::new("log", "0.1.0").publish();
     Package::new("serde", "0.1.0").dep("log", "0.1").publish();
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -124,7 +124,7 @@ fn conservative() {
     Package::new("log", "0.1.0").publish();
     Package::new("serde", "0.1.0").dep("log", "0.1").publish();
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -174,7 +174,7 @@ fn conservative() {
 #[test]
 fn update_via_new_dep() {
     Package::new("log", "0.1.0").publish();
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -217,7 +217,7 @@ fn update_via_new_dep() {
 #[test]
 fn update_via_new_member() {
     Package::new("log", "0.1.0").publish();
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -259,7 +259,7 @@ fn update_via_new_member() {
 #[test]
 fn add_dep_deep_new_requirement() {
     Package::new("log", "0.1.0").publish();
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -289,7 +289,7 @@ fn add_dep_deep_new_requirement() {
 fn everything_real_deep() {
     Package::new("log", "0.1.0").publish();
     Package::new("foo", "0.1.0").dep("log", "0.1").publish();
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -317,7 +317,7 @@ fn everything_real_deep() {
 
 #[test]
 fn change_package_version() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -365,7 +365,7 @@ fn update_precise() {
     Package::new("serde", "0.1.0").publish();
     Package::new("serde", "0.2.1").publish();
 
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"

--- a/tests/testsuite/verify_project.rs
+++ b/tests/testsuite/verify_project.rs
@@ -7,7 +7,7 @@ fn verify_project_success_output() -> String {
 
 #[test]
 fn cargo_verify_project_path_to_cargo_toml_relative() {
-    let p = project("foo")
+    let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
         .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
         .build();
@@ -25,7 +25,7 @@ fn cargo_verify_project_path_to_cargo_toml_relative() {
 
 #[test]
 fn cargo_verify_project_path_to_cargo_toml_absolute() {
-    let p = project("foo")
+    let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
         .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
         .build();
@@ -43,7 +43,7 @@ fn cargo_verify_project_path_to_cargo_toml_absolute() {
 
 #[test]
 fn cargo_verify_project_cwd() {
-    let p = project("foo")
+    let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
         .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
         .build();

--- a/tests/testsuite/version.rs
+++ b/tests/testsuite/version.rs
@@ -4,7 +4,7 @@ use hamcrest::assert_that;
 
 #[test]
 fn simple() {
-    let p = project("foo").build();
+    let p = project().build();
 
     assert_that(
         p.cargo("version"),
@@ -24,13 +24,13 @@ fn simple() {
 #[test]
 #[cfg_attr(target_os = "windows", ignore)]
 fn version_works_without_rustc() {
-    let p = project("foo").build();
+    let p = project().build();
     assert_that(p.cargo("version").env("PATH", ""), execs().with_status(0));
 }
 
 #[test]
 fn version_works_with_bad_config() {
-    let p = project("foo")
+    let p = project()
         .file(".cargo/config", "this is not toml")
         .build();
     assert_that(p.cargo("version"), execs().with_status(0));
@@ -38,7 +38,7 @@ fn version_works_with_bad_config() {
 
 #[test]
 fn version_works_with_bad_target_dir() {
-    let p = project("foo")
+    let p = project()
         .file(
             ".cargo/config",
             r#"

--- a/tests/testsuite/warn_on_failure.rs
+++ b/tests/testsuite/warn_on_failure.rs
@@ -37,7 +37,7 @@ fn make_lib(lib_src: &str) {
 }
 
 fn make_upstream(main_src: &str) -> Project {
-    project("bar")
+    project().at("bar")
         .file(
             "Cargo.toml",
             r#"

--- a/tests/testsuite/workspaces.rs
+++ b/tests/testsuite/workspaces.rs
@@ -1947,7 +1947,7 @@ fn glob_syntax() {
 /*FIXME: This fails because of how workspace.exclude and workspace.members are working.
 #[test]
 fn glob_syntax_2() {
-    let p = project("foo")
+    let p = project()
         .file("Cargo.toml", r#"
             [project]
             name = "foo"
@@ -2218,7 +2218,7 @@ fn dont_recurse_out_of_cargo_home() {
 /*FIXME: This fails because of how workspace.exclude and workspace.members are working.
 #[test]
 fn include_and_exclude() {
-    let p = project("foo")
+    let p = project()
         .file("Cargo.toml", r#"
             [workspace]
             members = ["foo"]

--- a/tests/testsuite/workspaces.rs
+++ b/tests/testsuite/workspaces.rs
@@ -9,7 +9,7 @@ use hamcrest::{assert_that, existing_dir, existing_file, is_not};
 
 #[test]
 fn simple_explicit() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -53,7 +53,7 @@ fn simple_explicit() {
 
 #[test]
 fn simple_explicit_default_members() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -88,7 +88,7 @@ fn simple_explicit_default_members() {
 
 #[test]
 fn inferred_root() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -131,7 +131,7 @@ fn inferred_root() {
 
 #[test]
 fn inferred_path_dep() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -177,7 +177,7 @@ fn inferred_path_dep() {
 
 #[test]
 fn transitive_path_dep() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -248,7 +248,7 @@ fn transitive_path_dep() {
 
 #[test]
 fn parent_pointer_works() {
-    let p = project("foo")
+    let p = project()
         .file(
             "foo/Cargo.toml",
             r#"
@@ -292,7 +292,7 @@ fn parent_pointer_works() {
 
 #[test]
 fn same_names_in_workspace() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -333,7 +333,7 @@ error: two packages named `foo` in this workspace:
 
 #[test]
 fn parent_doesnt_point_to_child() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -374,7 +374,7 @@ this may be fixable [..]
 
 #[test]
 fn invalid_parent_pointer() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -403,7 +403,7 @@ Caused by:
 
 #[test]
 fn invalid_members() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -434,7 +434,7 @@ Caused by:
 
 #[test]
 fn bare_workspace_ok() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -454,7 +454,7 @@ fn bare_workspace_ok() {
 
 #[test]
 fn two_roots() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -497,7 +497,7 @@ error: multiple workspace roots found in the same workspace:
 
 #[test]
 fn workspace_isnt_root() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -531,7 +531,7 @@ fn workspace_isnt_root() {
 
 #[test]
 fn dangling_member() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -583,7 +583,7 @@ actual: [..]
 
 #[test]
 fn cycle() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -613,7 +613,7 @@ fn cycle() {
 
 #[test]
 fn share_dependencies() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -664,7 +664,7 @@ fn share_dependencies() {
 
 #[test]
 fn fetch_fetches_all() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -708,7 +708,7 @@ fn fetch_fetches_all() {
 
 #[test]
 fn lock_works_for_everyone() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -780,7 +780,7 @@ fn lock_works_for_everyone() {
 
 #[test]
 fn virtual_works() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -810,7 +810,7 @@ fn virtual_works() {
 
 #[test]
 fn explicit_package_argument_works_with_virtual_manifest() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -840,7 +840,7 @@ fn explicit_package_argument_works_with_virtual_manifest() {
 
 #[test]
 fn virtual_misconfigure() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -875,7 +875,7 @@ manifest located at: [..]
 
 #[test]
 fn virtual_build_all_implied() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -899,7 +899,7 @@ fn virtual_build_all_implied() {
 
 #[test]
 fn virtual_default_members() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -936,7 +936,7 @@ fn virtual_default_members() {
 
 #[test]
 fn virtual_default_member_is_not_a_member() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -969,7 +969,7 @@ but is not a member.
 
 #[test]
 fn virtual_build_no_members() {
-    let p = project("foo").file(
+    let p = project().file(
         "Cargo.toml",
         r#"
             [workspace]
@@ -989,7 +989,7 @@ and the workspace has no members.
 
 #[test]
 fn include_virtual() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1023,7 +1023,7 @@ error: multiple workspace roots found in the same workspace:
 
 #[test]
 fn members_include_path_deps() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1097,7 +1097,7 @@ fn members_include_path_deps() {
 
 #[test]
 fn new_warns_you_this_will_not_work() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1133,7 +1133,7 @@ root: [..]
 
 #[test]
 fn lock_doesnt_change_depending_on_crate() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1186,7 +1186,7 @@ fn lock_doesnt_change_depending_on_crate() {
 
 #[test]
 fn rebuild_please() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1276,7 +1276,7 @@ fn workspace_in_git() {
             )
             .file("foo/src/lib.rs", "")
     }).unwrap();
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             &format!(
@@ -1304,7 +1304,7 @@ fn workspace_in_git() {
 
 #[test]
 fn lockfile_can_specify_nonexistant_members() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1345,7 +1345,7 @@ fn lockfile_can_specify_nonexistant_members() {
 
 #[test]
 fn you_cannot_generate_lockfile_for_empty_workspaces() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1374,7 +1374,7 @@ fn you_cannot_generate_lockfile_for_empty_workspaces() {
 
 #[test]
 fn workspace_with_transitive_dev_deps() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1433,7 +1433,7 @@ fn workspace_with_transitive_dev_deps() {
 
 #[test]
 fn error_if_parent_cargo_toml_is_invalid() {
-    let p = project("foo")
+    let p = project()
         .file("Cargo.toml", "Totally not a TOML file")
         .file(
             "bar/Cargo.toml",
@@ -1457,7 +1457,7 @@ fn error_if_parent_cargo_toml_is_invalid() {
 
 #[test]
 fn relative_path_for_member_works() {
-    let p = project("foo")
+    let p = project()
         .file(
             "foo/Cargo.toml",
             r#"
@@ -1496,7 +1496,7 @@ fn relative_path_for_member_works() {
 
 #[test]
 fn relative_path_for_root_works() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1543,7 +1543,7 @@ fn relative_path_for_root_works() {
 
 #[test]
 fn path_dep_outside_workspace_is_not_member() {
-    let p = project("foo")
+    let p = project()
         .file(
             "ws/Cargo.toml",
             r#"
@@ -1579,7 +1579,7 @@ fn path_dep_outside_workspace_is_not_member() {
 
 #[test]
 fn test_in_and_out_of_workspace() {
-    let p = project("foo")
+    let p = project()
         .file(
             "ws/Cargo.toml",
             r#"
@@ -1652,7 +1652,7 @@ fn test_in_and_out_of_workspace() {
 
 #[test]
 fn test_path_dependency_under_member() {
-    let p = project("foo")
+    let p = project()
         .file(
             "ws/Cargo.toml",
             r#"
@@ -1725,7 +1725,7 @@ fn test_path_dependency_under_member() {
 
 #[test]
 fn excluded_simple() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1762,7 +1762,7 @@ fn excluded_simple() {
 
 #[test]
 fn exclude_members_preferred() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1815,7 +1815,7 @@ fn exclude_members_preferred() {
 
 #[test]
 fn exclude_but_also_depend() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -1870,7 +1870,7 @@ fn exclude_but_also_depend() {
 
 #[test]
 fn glob_syntax() {
-    let p = project("foo")
+    let p = project()
         .file("Cargo.toml", r#"
             [project]
             name = "foo"
@@ -2012,7 +2012,7 @@ fn glob_syntax_2() {
 
 #[test]
 fn glob_syntax_invalid_members() {
-    let p = project("foo")
+    let p = project()
         .file("Cargo.toml", r#"
             [project]
             name = "foo"
@@ -2049,7 +2049,7 @@ Caused by:
 /// a single cargo build at the top level will be enough.
 #[test]
 fn dep_used_with_separate_features() {
-    let p = project("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -2189,7 +2189,7 @@ fn dont_recurse_out_of_cargo_home() {
             "#,
             )
     }).unwrap();
-    let p = project("lib")
+    let p = project().at("lib")
         .file(
             "Cargo.toml",
             &format!(
@@ -2252,7 +2252,7 @@ fn include_and_exclude() {
 
 #[test]
 fn cargo_home_at_root_works() {
-    let p = project("lib")
+    let p = project().at("lib")
         .file(
             "Cargo.toml",
             r#"
@@ -2285,7 +2285,7 @@ fn cargo_home_at_root_works() {
 
 #[test]
 fn relative_rustc() {
-    let p = project("the_exe")
+    let p = project().at("the_exe")
         .file(
             "Cargo.toml",
             r#"
@@ -2318,7 +2318,7 @@ fn relative_rustc() {
 
     Package::new("a", "0.1.0").publish();
 
-    let p = project("lib")
+    let p = project().at("lib")
         .file(
             "Cargo.toml",
             r#"
@@ -2342,7 +2342,7 @@ fn relative_rustc() {
 
 #[test]
 fn ws_rustc_err() {
-    let p = project("ws")
+    let p = project().at("ws")
         .file(
             "Cargo.toml",
             r#"


### PR DESCRIPTION
By rewriting the tests, with rerast (https://github.com/google/rerast), to
use the newly introduced "at" method.

First I added the following temporary function to cargotest::support:

    pub fn project_foo() -> ProjectBuilder {
       project("foo")
    }

Then I defined the following rewrite.rs:

    use cargotest::support::{ project, project_foo };

    fn rule1(a: &'static str) {
       replace!(project("foo") => project_foo());
       replace!(project(a) => project_foo().at(a));
    }

Then I ran rerast:

    cargo +nightly rerast --rules_file=rewrite.rs --force --targets tests --file tests/testsuite/main.rs

Finally I searched and replaced the references to project_foo with
argument-less project (a little awkardly on macOS with a git clean).

    find tests -type f -exec sed -i -e 's/project_foo/project/g' {} +
    git clean -d tests

Fixes #5746