### PR TITLE
Rework some test projects to use the "foo" default

### DIFF
--- a/tests/testsuite/bad_config.rs
+++ b/tests/testsuite/bad_config.rs
@@ -325,19 +325,19 @@ Caused by:
 
 #[test]
 fn duplicate_packages_in_cargo_lock() {
-    Package::new("foo", "0.1.0").publish();
+    Package::new("bar", "0.1.0").publish();
 
-    let p = project().at("bar")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
             [project]
-            name = "bar"
+            name = "foo"
             version = "0.0.1"
             authors = []
 
             [dependencies]
-            foo = "0.1.0"
+            bar = "0.1.0"
         "#,
         )
         .file("src/lib.rs", "")
@@ -345,19 +345,19 @@ fn duplicate_packages_in_cargo_lock() {
             "Cargo.lock",
             r#"
             [[package]]
-            name = "bar"
+            name = "foo"
             version = "0.0.1"
             dependencies = [
-             "foo 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+             "bar 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
             ]
 
             [[package]]
-            name = "foo"
+            name = "bar"
             version = "0.1.0"
             source = "registry+https://github.com/rust-lang/crates.io-index"
 
             [[package]]
-            name = "foo"
+            name = "bar"
             version = "0.1.0"
             source = "registry+https://github.com/rust-lang/crates.io-index"
         "#,
@@ -371,7 +371,7 @@ fn duplicate_packages_in_cargo_lock() {
 [ERROR] failed to parse lock file at: [..]
 
 Caused by:
-  package `foo` is specified twice in the lockfile
+  package `bar` is specified twice in the lockfile
 ",
         ),
     );
@@ -379,19 +379,19 @@ Caused by:
 
 #[test]
 fn bad_source_in_cargo_lock() {
-    Package::new("foo", "0.1.0").publish();
+    Package::new("bar", "0.1.0").publish();
 
-    let p = project().at("bar")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
             [project]
-            name = "bar"
+            name = "foo"
             version = "0.0.1"
             authors = []
 
             [dependencies]
-            foo = "0.1.0"
+            bar = "0.1.0"
         "#,
         )
         .file("src/lib.rs", "")
@@ -399,14 +399,14 @@ fn bad_source_in_cargo_lock() {
             "Cargo.lock",
             r#"
             [[package]]
-            name = "bar"
+            name = "foo"
             version = "0.0.1"
             dependencies = [
-             "foo 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+             "bar 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
             ]
 
             [[package]]
-            name = "foo"
+            name = "bar"
             version = "0.1.0"
             source = "You shall not parse"
         "#,
@@ -933,29 +933,29 @@ warning: unused manifest key: workspace.bulid
 
 #[test]
 fn empty_dependencies() {
-    let p = project().at("empty_deps")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
             [package]
-            name = "empty_deps"
+            name = "foo"
             version = "0.0.0"
             authors = []
 
             [dependencies]
-            foo = {}
+            bar = {}
         "#,
         )
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    Package::new("foo", "0.0.1").publish();
+    Package::new("bar", "0.0.1").publish();
 
     assert_that(
         p.cargo("build"),
         execs().with_status(0).with_stderr_contains(
             "\
-warning: dependency (foo) specified without providing a local path, Git repository, or version \
+warning: dependency (bar) specified without providing a local path, Git repository, or version \
 to use. This will be considered an error in future versions
 ",
         ),
@@ -964,12 +964,12 @@ to use. This will be considered an error in future versions
 
 #[test]
 fn invalid_toml_historically_allowed_is_warned() {
-    let p = project().at("empty_deps")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
             [package]
-            name = "empty_deps"
+            name = "foo"
             version = "0.0.0"
             authors = []
         "#,
@@ -977,7 +977,7 @@ fn invalid_toml_historically_allowed_is_warned() {
         .file(
             ".cargo/config",
             r#"
-            [foo] bar = 2
+            [bar] baz = 2
         "#,
         )
         .file("src/main.rs", "fn main() {}")
@@ -994,7 +994,7 @@ The TOML spec requires newlines after table definitions (e.g. `[a] b = 1` is
 invalid), but this file has a table header which does not have a newline after
 it. A newline needs to be added and this warning will soon become a hard error
 in the future.
-[COMPILING] empty_deps v0.0.0 ([..])
+[COMPILING] foo v0.0.0 ([..])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ),

--- a/tests/testsuite/build_script.rs
+++ b/tests/testsuite/build_script.rs
@@ -1678,12 +1678,12 @@ fn build_script_with_dynamic_native_dependency() {
 
 #[test]
 fn profile_and_opt_level_set_correctly() {
-    let build = project().at("builder")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
             [package]
-            name = "builder"
+            name = "foo"
             version = "0.0.1"
             authors = []
             build = "build.rs"
@@ -1703,7 +1703,7 @@ fn profile_and_opt_level_set_correctly() {
         "#,
         )
         .build();
-    assert_that(build.cargo("bench"), execs().with_status(0));
+    assert_that(p.cargo("bench"), execs().with_status(0));
 }
 
 #[test]
@@ -1739,12 +1739,12 @@ fn profile_debug_0() {
 
 #[test]
 fn build_script_with_lto() {
-    let build = project().at("builder")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
             [package]
-            name = "builder"
+            name = "foo"
             version = "0.0.1"
             authors = []
             build = "build.rs"
@@ -1762,7 +1762,7 @@ fn build_script_with_lto() {
         "#,
         )
         .build();
-    assert_that(build.cargo("build"), execs().with_status(0));
+    assert_that(p.cargo("build"), execs().with_status(0));
 }
 
 #[test]
@@ -1815,12 +1815,12 @@ fn test_duplicate_deps() {
 
 #[test]
 fn cfg_feedback() {
-    let build = project().at("builder")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
             [package]
-            name = "builder"
+            name = "foo"
             version = "0.0.1"
             authors = []
             build = "build.rs"
@@ -1842,7 +1842,7 @@ fn cfg_feedback() {
         "#,
         )
         .build();
-    assert_that(build.cargo("build").arg("-v"), execs().with_status(0));
+    assert_that(p.cargo("build").arg("-v"), execs().with_status(0));
 }
 
 #[test]
@@ -2725,12 +2725,12 @@ fn fresh_builds_possible_with_multiple_metadata_overrides() {
 
 #[test]
 fn rebuild_only_on_explicit_paths() {
-    let p = project().at("a")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
             [project]
-            name = "a"
+            name = "foo"
             version = "0.5.0"
             authors = []
             build = "build.rs"
@@ -2756,7 +2756,7 @@ fn rebuild_only_on_explicit_paths() {
         p.cargo("build").arg("-v"),
         execs().with_status(0).with_stderr(
             "\
-[COMPILING] a v0.5.0 ([..])
+[COMPILING] foo v0.5.0 ([..])
 [RUNNING] `[..][/]build-script-build`
 [RUNNING] `rustc [..] src[/]lib.rs [..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
@@ -2774,7 +2774,7 @@ fn rebuild_only_on_explicit_paths() {
         p.cargo("build").arg("-v"),
         execs().with_status(0).with_stderr(
             "\
-[COMPILING] a v0.5.0 ([..])
+[COMPILING] foo v0.5.0 ([..])
 [RUNNING] `[..][/]build-script-build`
 [RUNNING] `rustc [..] src[/]lib.rs [..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
@@ -2787,7 +2787,7 @@ fn rebuild_only_on_explicit_paths() {
         p.cargo("build").arg("-v"),
         execs().with_status(0).with_stderr(
             "\
-[FRESH] a v0.5.0 ([..])
+[FRESH] foo v0.5.0 ([..])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ),
@@ -2802,7 +2802,7 @@ fn rebuild_only_on_explicit_paths() {
         p.cargo("build").arg("-v"),
         execs().with_status(0).with_stderr(
             "\
-[FRESH] a v0.5.0 ([..])
+[FRESH] foo v0.5.0 ([..])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ),
@@ -2815,7 +2815,7 @@ fn rebuild_only_on_explicit_paths() {
         p.cargo("build").arg("-v"),
         execs().with_status(0).with_stderr(
             "\
-[COMPILING] a v0.5.0 ([..])
+[COMPILING] foo v0.5.0 ([..])
 [RUNNING] `[..][/]build-script-build`
 [RUNNING] `rustc [..] src[/]lib.rs [..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
@@ -2830,7 +2830,7 @@ fn rebuild_only_on_explicit_paths() {
         p.cargo("build").arg("-v"),
         execs().with_status(0).with_stderr(
             "\
-[COMPILING] a v0.5.0 ([..])
+[COMPILING] foo v0.5.0 ([..])
 [RUNNING] `[..][/]build-script-build`
 [RUNNING] `rustc [..] src[/]lib.rs [..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
@@ -3338,12 +3338,12 @@ fn links_with_dots() {
 
 #[test]
 fn rustc_and_rustdoc_set_correctly() {
-    let p = project().at("builder")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
             [package]
-            name = "builder"
+            name = "foo"
             version = "0.0.1"
             authors = []
             build = "build.rs"
@@ -3367,12 +3367,12 @@ fn rustc_and_rustdoc_set_correctly() {
 
 #[test]
 fn cfg_env_vars_available() {
-    let p = project().at("builder")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
             [package]
-            name = "builder"
+            name = "foo"
             version = "0.0.1"
             authors = []
             build = "build.rs"
@@ -3400,12 +3400,12 @@ fn cfg_env_vars_available() {
 
 #[test]
 fn switch_features_rerun() {
-    let p = project().at("builder")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
             [package]
-            name = "builder"
+            name = "foo"
             version = "0.0.1"
             authors = []
             build = "build.rs"
@@ -3461,12 +3461,12 @@ fn switch_features_rerun() {
 
 #[test]
 fn assume_build_script_when_build_rs_present() {
-    let p = project().at("builder")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
             [package]
-            name = "builder"
+            name = "foo"
             version = "0.0.1"
             authors = []
         "#,
@@ -3496,12 +3496,12 @@ fn assume_build_script_when_build_rs_present() {
 
 #[test]
 fn if_build_set_to_false_dont_treat_build_rs_as_build_script() {
-    let p = project().at("builder")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
             [package]
-            name = "builder"
+            name = "foo"
             version = "0.0.1"
             authors = []
             build = false

--- a/tests/testsuite/cargo_command.rs
+++ b/tests/testsuite/cargo_command.rs
@@ -62,7 +62,7 @@ fn path() -> Vec<PathBuf> {
 
 #[test]
 fn list_command_looks_at_path() {
-    let proj = project().at("list-non-overlapping").build();
+    let proj = project().build();
     let proj = fake_file(
         proj,
         Path::new("path-test"),
@@ -88,7 +88,7 @@ fn list_command_looks_at_path() {
 #[cfg(unix)]
 #[test]
 fn list_command_resolves_symlinks() {
-    let proj = project().at("list-non-overlapping").build();
+    let proj = project().build();
     let proj = fake_file(
         proj,
         Path::new("path-test"),

--- a/tests/testsuite/cfg.rs
+++ b/tests/testsuite/cfg.rs
@@ -217,18 +217,18 @@ fn dont_include() {
 
 #[test]
 fn works_through_the_registry() {
-    Package::new("foo", "0.1.0").publish();
+    Package::new("baz", "0.1.0").publish();
     Package::new("bar", "0.1.0")
-        .target_dep("foo", "0.1.0", "cfg(unix)")
-        .target_dep("foo", "0.1.0", "cfg(windows)")
+        .target_dep("baz", "0.1.0", "cfg(unix)")
+        .target_dep("baz", "0.1.0", "cfg(windows)")
         .publish();
 
-    let p = project().at("a")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
             [package]
-            name = "a"
+            name = "foo"
             version = "0.0.1"
             authors = []
 
@@ -249,9 +249,9 @@ fn works_through_the_registry() {
 [UPDATING] registry [..]
 [DOWNLOADING] [..]
 [DOWNLOADING] [..]
-[COMPILING] foo v0.1.0
+[COMPILING] baz v0.1.0
 [COMPILING] bar v0.1.0
-[COMPILING] a v0.0.1 ([..])
+[COMPILING] foo v0.0.1 ([..])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ),
@@ -262,31 +262,31 @@ fn works_through_the_registry() {
 fn ignore_version_from_other_platform() {
     let this_family = if cfg!(unix) { "unix" } else { "windows" };
     let other_family = if cfg!(unix) { "windows" } else { "unix" };
-    Package::new("foo", "0.1.0").publish();
-    Package::new("foo", "0.2.0").publish();
+    Package::new("bar", "0.1.0").publish();
+    Package::new("bar", "0.2.0").publish();
 
-    let p = project().at("a")
+    let p = project()
         .file(
             "Cargo.toml",
             &format!(
                 r#"
             [package]
-            name = "a"
+            name = "foo"
             version = "0.0.1"
             authors = []
 
             [target.'cfg({})'.dependencies]
-            foo = "0.1.0"
+            bar = "0.1.0"
 
             [target.'cfg({})'.dependencies]
-            foo = "0.2.0"
+            bar = "0.2.0"
         "#,
                 this_family, other_family
             ),
         )
         .file(
             "src/lib.rs",
-            "#[allow(unused_extern_crates)] extern crate foo;",
+            "#[allow(unused_extern_crates)] extern crate bar;",
         )
         .build();
 
@@ -296,8 +296,8 @@ fn ignore_version_from_other_platform() {
             "\
 [UPDATING] registry [..]
 [DOWNLOADING] [..]
-[COMPILING] foo v0.1.0
-[COMPILING] a v0.0.1 ([..])
+[COMPILING] bar v0.1.0
+[COMPILING] foo v0.0.1 ([..])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ),
@@ -306,12 +306,12 @@ fn ignore_version_from_other_platform() {
 
 #[test]
 fn bad_target_spec() {
-    let p = project().at("a")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
             [package]
-            name = "a"
+            name = "foo"
             version = "0.0.1"
             authors = []
 
@@ -340,17 +340,17 @@ Caused by:
 
 #[test]
 fn bad_target_spec2() {
-    let p = project().at("a")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
             [package]
-            name = "a"
+            name = "foo"
             version = "0.0.1"
             authors = []
 
-            [target.'cfg(foo =)'.dependencies]
-            bar = "0.1.0"
+            [target.'cfg(bar =)'.dependencies]
+            baz = "0.1.0"
         "#,
         )
         .file("src/lib.rs", "")
@@ -363,7 +363,7 @@ fn bad_target_spec2() {
 [ERROR] failed to parse manifest at `[..]`
 
 Caused by:
-  failed to parse `foo =` as a cfg expression
+  failed to parse `bar =` as a cfg expression
 
 Caused by:
   expected a string, found nothing

--- a/tests/testsuite/check.rs
+++ b/tests/testsuite/check.rs
@@ -550,26 +550,12 @@ fn check_all() {
 
 #[test]
 fn check_virtual_all_implied() {
-    let p = project().at("workspace")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
             [workspace]
-            members = ["foo", "bar"]
-        "#,
-        )
-        .file(
-            "foo/Cargo.toml",
-            r#"
-            [project]
-            name = "foo"
-            version = "0.1.0"
-        "#,
-        )
-        .file(
-            "foo/src/lib.rs",
-            r#"
-            pub fn foo() {}
+            members = ["bar", "baz"]
         "#,
         )
         .file(
@@ -586,14 +572,28 @@ fn check_virtual_all_implied() {
             pub fn bar() {}
         "#,
         )
+        .file(
+            "baz/Cargo.toml",
+            r#"
+            [project]
+            name = "baz"
+            version = "0.1.0"
+        "#,
+        )
+        .file(
+            "baz/src/lib.rs",
+            r#"
+            pub fn baz() {}
+        "#,
+        )
         .build();
 
     assert_that(
         p.cargo("check").arg("-v"),
         execs()
             .with_status(0)
-            .with_stderr_contains("[..] --crate-name foo foo[/]src[/]lib.rs [..]")
-            .with_stderr_contains("[..] --crate-name bar bar[/]src[/]lib.rs [..]"),
+            .with_stderr_contains("[..] --crate-name bar bar[/]src[/]lib.rs [..]")
+            .with_stderr_contains("[..] --crate-name baz baz[/]src[/]lib.rs [..]"),
     );
 }
 

--- a/tests/testsuite/directory.rs
+++ b/tests/testsuite/directory.rs
@@ -72,20 +72,7 @@ impl VendorPackage {
 fn simple() {
     setup();
 
-    VendorPackage::new("foo")
-        .file(
-            "Cargo.toml",
-            r#"
-            [package]
-            name = "foo"
-            version = "0.1.0"
-            authors = []
-        "#,
-        )
-        .file("src/lib.rs", "pub fn foo() {}")
-        .build();
-
-    let p = project().at("bar")
+    VendorPackage::new("bar")
         .file(
             "Cargo.toml",
             r#"
@@ -93,18 +80,31 @@ fn simple() {
             name = "bar"
             version = "0.1.0"
             authors = []
+        "#,
+        )
+        .file("src/lib.rs", "pub fn bar() {}")
+        .build();
+
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "foo"
+            version = "0.1.0"
+            authors = []
 
             [dependencies]
-            foo = "0.1.0"
+            bar = "0.1.0"
         "#,
         )
         .file(
             "src/lib.rs",
             r#"
-            extern crate foo;
+            extern crate bar;
 
-            pub fn bar() {
-                foo::foo();
+            pub fn foo() {
+                bar::bar();
             }
         "#,
         )
@@ -114,8 +114,8 @@ fn simple() {
         p.cargo("build"),
         execs().with_status(0).with_stderr(
             "\
-[COMPILING] foo v0.1.0
-[COMPILING] bar v0.1.0 ([..]bar)
+[COMPILING] bar v0.1.0
+[COMPILING] foo v0.1.0 ([..]foo)
 [FINISHED] [..]
 ",
         ),
@@ -303,26 +303,26 @@ fn not_there() {
 
     let _ = project().at("index").build();
 
-    let p = project().at("bar")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
             [package]
-            name = "bar"
+            name = "foo"
             version = "0.1.0"
             authors = []
 
             [dependencies]
-            foo = "0.1.0"
+            bar = "0.1.0"
         "#,
         )
         .file(
             "src/lib.rs",
             r#"
-            extern crate foo;
+            extern crate bar;
 
-            pub fn bar() {
-                foo::foo();
+            pub fn foo() {
+                bar::bar();
             }
         "#,
         )
@@ -332,9 +332,9 @@ fn not_there() {
         p.cargo("build"),
         execs().with_status(101).with_stderr(
             "\
-error: no matching package named `foo` found
+error: no matching package named `bar` found
 location searched: [..]
-required by package `bar v0.1.0 ([..])`
+required by package `foo v0.1.0 ([..])`
 ",
         ),
     );
@@ -344,35 +344,7 @@ required by package `bar v0.1.0 ([..])`
 fn multiple() {
     setup();
 
-    VendorPackage::new("foo-0.1.0")
-        .file(
-            "Cargo.toml",
-            r#"
-            [package]
-            name = "foo"
-            version = "0.1.0"
-            authors = []
-        "#,
-        )
-        .file("src/lib.rs", "pub fn foo() {}")
-        .file(".cargo-checksum", "")
-        .build();
-
-    VendorPackage::new("foo-0.2.0")
-        .file(
-            "Cargo.toml",
-            r#"
-            [package]
-            name = "foo"
-            version = "0.2.0"
-            authors = []
-        "#,
-        )
-        .file("src/lib.rs", "pub fn foo() {}")
-        .file(".cargo-checksum", "")
-        .build();
-
-    let p = project().at("bar")
+    VendorPackage::new("bar-0.1.0")
         .file(
             "Cargo.toml",
             r#"
@@ -380,18 +352,46 @@ fn multiple() {
             name = "bar"
             version = "0.1.0"
             authors = []
+        "#,
+        )
+        .file("src/lib.rs", "pub fn bar() {}")
+        .file(".cargo-checksum", "")
+        .build();
+
+    VendorPackage::new("bar-0.2.0")
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "bar"
+            version = "0.2.0"
+            authors = []
+        "#,
+        )
+        .file("src/lib.rs", "pub fn bar() {}")
+        .file(".cargo-checksum", "")
+        .build();
+
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "foo"
+            version = "0.1.0"
+            authors = []
 
             [dependencies]
-            foo = "0.1.0"
+            bar = "0.1.0"
         "#,
         )
         .file(
             "src/lib.rs",
             r#"
-            extern crate foo;
+            extern crate bar;
 
-            pub fn bar() {
-                foo::foo();
+            pub fn foo() {
+                bar::bar();
             }
         "#,
         )
@@ -401,8 +401,8 @@ fn multiple() {
         p.cargo("build"),
         execs().with_status(0).with_stderr(
             "\
-[COMPILING] foo v0.1.0
-[COMPILING] bar v0.1.0 ([..]bar)
+[COMPILING] bar v0.1.0
+[COMPILING] foo v0.1.0 ([..]foo)
 [FINISHED] [..]
 ",
         ),
@@ -411,33 +411,33 @@ fn multiple() {
 
 #[test]
 fn crates_io_then_directory() {
-    let p = project().at("bar")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
             [package]
-            name = "bar"
+            name = "foo"
             version = "0.1.0"
             authors = []
 
             [dependencies]
-            foo = "0.1.0"
+            bar = "0.1.0"
         "#,
         )
         .file(
             "src/lib.rs",
             r#"
-            extern crate foo;
+            extern crate bar;
 
-            pub fn bar() {
-                foo::foo();
+            pub fn foo() {
+                bar::bar();
             }
         "#,
         )
         .build();
 
-    let cksum = Package::new("foo", "0.1.0")
-        .file("src/lib.rs", "pub fn foo() -> u32 { 0 }")
+    let cksum = Package::new("bar", "0.1.0")
+        .file("src/lib.rs", "pub fn bar() -> u32 { 0 }")
         .publish();
 
     assert_that(
@@ -445,9 +445,9 @@ fn crates_io_then_directory() {
         execs().with_status(0).with_stderr(
             "\
 [UPDATING] registry `[..]`
-[DOWNLOADING] foo v0.1.0 ([..])
-[COMPILING] foo v0.1.0
-[COMPILING] bar v0.1.0 ([..]bar)
+[DOWNLOADING] bar v0.1.0 ([..])
+[COMPILING] bar v0.1.0
+[COMPILING] foo v0.1.0 ([..]foo)
 [FINISHED] [..]
 ",
         ),
@@ -455,17 +455,17 @@ fn crates_io_then_directory() {
 
     setup();
 
-    let mut v = VendorPackage::new("foo");
+    let mut v = VendorPackage::new("bar");
     v.file(
         "Cargo.toml",
         r#"
         [package]
-        name = "foo"
+        name = "bar"
         version = "0.1.0"
         authors = []
     "#,
     );
-    v.file("src/lib.rs", "pub fn foo() -> u32 { 1 }");
+    v.file("src/lib.rs", "pub fn bar() -> u32 { 1 }");
     v.cksum.package = Some(cksum);
     v.build();
 
@@ -473,8 +473,8 @@ fn crates_io_then_directory() {
         p.cargo("build"),
         execs().with_status(0).with_stderr(
             "\
-[COMPILING] foo v0.1.0
-[COMPILING] bar v0.1.0 ([..]bar)
+[COMPILING] bar v0.1.0
+[COMPILING] foo v0.1.0 ([..]foo)
 [FINISHED] [..]
 ",
         ),
@@ -483,33 +483,33 @@ fn crates_io_then_directory() {
 
 #[test]
 fn crates_io_then_bad_checksum() {
-    let p = project().at("bar")
-        .file(
-            "Cargo.toml",
-            r#"
-            [package]
-            name = "bar"
-            version = "0.1.0"
-            authors = []
-
-            [dependencies]
-            foo = "0.1.0"
-        "#,
-        )
-        .file("src/lib.rs", "")
-        .build();
-
-    Package::new("foo", "0.1.0").publish();
-
-    assert_that(p.cargo("build"), execs().with_status(0));
-    setup();
-
-    VendorPackage::new("foo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
             [package]
             name = "foo"
+            version = "0.1.0"
+            authors = []
+
+            [dependencies]
+            bar = "0.1.0"
+        "#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    Package::new("bar", "0.1.0").publish();
+
+    assert_that(p.cargo("build"), execs().with_status(0));
+    setup();
+
+    VendorPackage::new("bar")
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "bar"
             version = "0.1.0"
             authors = []
         "#,
@@ -521,7 +521,7 @@ fn crates_io_then_bad_checksum() {
         p.cargo("build"),
         execs().with_status(101).with_stderr(
             "\
-error: checksum for `foo v0.1.0` changed between lock files
+error: checksum for `bar v0.1.0` changed between lock files
 
 this could be indicative of a few possible errors:
 
@@ -529,7 +529,7 @@ this could be indicative of a few possible errors:
     * a replacement source in use (e.g. a mirror) returned a different checksum
     * the source itself may be corrupt in one way or another
 
-unable to verify that `foo v0.1.0` is the same as when the lockfile was generated
+unable to verify that `bar v0.1.0` is the same as when the lockfile was generated
 
 ",
         ),
@@ -540,23 +540,7 @@ unable to verify that `foo v0.1.0` is the same as when the lockfile was generate
 fn bad_file_checksum() {
     setup();
 
-    VendorPackage::new("foo")
-        .file(
-            "Cargo.toml",
-            r#"
-            [package]
-            name = "foo"
-            version = "0.1.0"
-            authors = []
-        "#,
-        )
-        .file("src/lib.rs", "")
-        .build();
-
-    let mut f = t!(File::create(paths::root().join("index/foo/src/lib.rs")));
-    t!(f.write_all(b"fn foo() -> u32 { 0 }"));
-
-    let p = project().at("bar")
+    VendorPackage::new("bar")
         .file(
             "Cargo.toml",
             r#"
@@ -564,9 +548,25 @@ fn bad_file_checksum() {
             name = "bar"
             version = "0.1.0"
             authors = []
+        "#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    let mut f = t!(File::create(paths::root().join("index/bar/src/lib.rs")));
+    t!(f.write_all(b"fn bar() -> u32 { 0 }"));
+
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "foo"
+            version = "0.1.0"
+            authors = []
 
             [dependencies]
-            foo = "0.1.0"
+            bar = "0.1.0"
         "#,
         )
         .file("src/lib.rs", "")
@@ -592,21 +592,7 @@ the source
 fn only_dot_files_ok() {
     setup();
 
-    VendorPackage::new("foo")
-        .file(
-            "Cargo.toml",
-            r#"
-            [package]
-            name = "foo"
-            version = "0.1.0"
-            authors = []
-        "#,
-        )
-        .file("src/lib.rs", "")
-        .build();
-    VendorPackage::new("bar").file(".foo", "").build();
-
-    let p = project().at("bar")
+    VendorPackage::new("bar")
         .file(
             "Cargo.toml",
             r#"
@@ -614,9 +600,23 @@ fn only_dot_files_ok() {
             name = "bar"
             version = "0.1.0"
             authors = []
+        "#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+    VendorPackage::new("foo").file(".bar", "").build();
+
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "foo"
+            version = "0.1.0"
+            authors = []
 
             [dependencies]
-            foo = "0.1.0"
+            bar = "0.1.0"
         "#,
         )
         .file("src/lib.rs", "")
@@ -629,24 +629,7 @@ fn only_dot_files_ok() {
 fn random_files_ok() {
     setup();
 
-    VendorPackage::new("foo")
-        .file(
-            "Cargo.toml",
-            r#"
-            [package]
-            name = "foo"
-            version = "0.1.0"
-            authors = []
-        "#,
-        )
-        .file("src/lib.rs", "")
-        .build();
     VendorPackage::new("bar")
-        .file("foo", "")
-        .file("../test", "")
-        .build();
-
-    let p = project().at("bar")
         .file(
             "Cargo.toml",
             r#"
@@ -654,9 +637,26 @@ fn random_files_ok() {
             name = "bar"
             version = "0.1.0"
             authors = []
+        "#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+    VendorPackage::new("foo")
+        .file("bar", "")
+        .file("../test", "")
+        .build();
+
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "foo"
+            version = "0.1.0"
+            authors = []
 
             [dependencies]
-            foo = "0.1.0"
+            bar = "0.1.0"
         "#,
         )
         .file("src/lib.rs", "")
@@ -693,7 +693,7 @@ fn git_lock_file_doesnt_change() {
         .disable_checksum()
         .build();
 
-    let p = project().at("bar")
+    let p = project()
         .file(
             "Cargo.toml",
             &format!(
@@ -765,7 +765,7 @@ fn git_override_requires_lockfile() {
         .disable_checksum()
         .build();
 
-    let p = project().at("bar")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"

--- a/tests/testsuite/doc.rs
+++ b/tests/testsuite/doc.rs
@@ -1292,26 +1292,12 @@ fn doc_all_workspace() {
 
 #[test]
 fn doc_all_virtual_manifest() {
-    let p = project().at("workspace")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
             [workspace]
-            members = ["foo", "bar"]
-        "#,
-        )
-        .file(
-            "foo/Cargo.toml",
-            r#"
-            [project]
-            name = "foo"
-            version = "0.1.0"
-        "#,
-        )
-        .file(
-            "foo/src/lib.rs",
-            r#"
-            pub fn foo() {}
+            members = ["bar", "baz"]
         "#,
         )
         .file(
@@ -1328,40 +1314,40 @@ fn doc_all_virtual_manifest() {
             pub fn bar() {}
         "#,
         )
+        .file(
+            "baz/Cargo.toml",
+            r#"
+            [project]
+            name = "baz"
+            version = "0.1.0"
+        "#,
+        )
+        .file(
+            "baz/src/lib.rs",
+            r#"
+            pub fn baz() {}
+        "#,
+        )
         .build();
 
-    // The order in which foo and bar are documented is not guaranteed
+    // The order in which bar and baz are documented is not guaranteed
     assert_that(
         p.cargo("doc").arg("--all"),
         execs()
             .with_status(0)
-            .with_stderr_contains("[..] Documenting bar v0.1.0 ([..])")
-            .with_stderr_contains("[..] Documenting foo v0.1.0 ([..])"),
+            .with_stderr_contains("[..] Documenting baz v0.1.0 ([..])")
+            .with_stderr_contains("[..] Documenting bar v0.1.0 ([..])"),
     );
 }
 
 #[test]
 fn doc_virtual_manifest_all_implied() {
-    let p = project().at("workspace")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
             [workspace]
-            members = ["foo", "bar"]
-        "#,
-        )
-        .file(
-            "foo/Cargo.toml",
-            r#"
-            [project]
-            name = "foo"
-            version = "0.1.0"
-        "#,
-        )
-        .file(
-            "foo/src/lib.rs",
-            r#"
-            pub fn foo() {}
+            members = ["bar", "baz"]
         "#,
         )
         .file(
@@ -1378,55 +1364,69 @@ fn doc_virtual_manifest_all_implied() {
             pub fn bar() {}
         "#,
         )
+        .file(
+            "baz/Cargo.toml",
+            r#"
+            [project]
+            name = "baz"
+            version = "0.1.0"
+        "#,
+        )
+        .file(
+            "baz/src/lib.rs",
+            r#"
+            pub fn baz() {}
+        "#,
+        )
         .build();
 
-    // The order in which foo and bar are documented is not guaranteed
+    // The order in which bar and baz are documented is not guaranteed
     assert_that(
         p.cargo("doc"),
         execs()
             .with_status(0)
-            .with_stderr_contains("[..] Documenting bar v0.1.0 ([..])")
-            .with_stderr_contains("[..] Documenting foo v0.1.0 ([..])"),
+            .with_stderr_contains("[..] Documenting baz v0.1.0 ([..])")
+            .with_stderr_contains("[..] Documenting bar v0.1.0 ([..])"),
     );
 }
 
 #[test]
 fn doc_all_member_dependency_same_name() {
-    let p = project().at("workspace")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
             [workspace]
-            members = ["a"]
+            members = ["bar"]
         "#,
         )
         .file(
-            "a/Cargo.toml",
+            "bar/Cargo.toml",
             r#"
             [project]
-            name = "a"
+            name = "bar"
             version = "0.1.0"
 
             [dependencies]
-            a = "0.1.0"
+            bar = "0.1.0"
         "#,
         )
         .file(
-            "a/src/lib.rs",
+            "bar/src/lib.rs",
             r#"
-            pub fn a() {}
+            pub fn bar() {}
         "#,
         )
         .build();
 
-    Package::new("a", "0.1.0").publish();
+    Package::new("bar", "0.1.0").publish();
 
     assert_that(
         p.cargo("doc").arg("--all"),
         execs()
             .with_status(0)
             .with_stderr_contains("[..] Updating registry `[..]`")
-            .with_stderr_contains("[..] Documenting a v0.1.0 ([..])"),
+            .with_stderr_contains("[..] Documenting bar v0.1.0 ([..])"),
     );
 }
 

--- a/tests/testsuite/features.rs
+++ b/tests/testsuite/features.rs
@@ -1636,17 +1636,17 @@ fn many_cli_features_comma_and_space_delimited() {
 fn combining_features_and_package() {
     Package::new("dep", "1.0.0").publish();
 
-    let p = project().at("ws")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
             [project]
-            name = "ws"
+            name = "foo"
             version = "0.0.1"
             authors = []
 
             [workspace]
-            members = ["foo"]
+            members = ["bar"]
 
             [dependencies]
             dep = "1"
@@ -1654,10 +1654,10 @@ fn combining_features_and_package() {
         )
         .file("src/lib.rs", "")
         .file(
-            "foo/Cargo.toml",
+            "bar/Cargo.toml",
             r#"
             [package]
-            name = "foo"
+            name = "bar"
             version = "0.0.1"
             authors = []
             [features]
@@ -1665,7 +1665,7 @@ fn combining_features_and_package() {
         "#,
         )
         .file(
-            "foo/src/main.rs",
+            "bar/src/main.rs",
             r#"
             #[cfg(feature = "main")]
             fn main() {}
@@ -1713,7 +1713,7 @@ fn combining_features_and_package() {
         execs().with_status(0),
     );
     assert_that(
-        p.cargo("run -Z package-features --package foo --features main")
+        p.cargo("run -Z package-features --package bar --features main")
             .masquerade_as_nightly_cargo(),
         execs().with_status(0),
     );

--- a/tests/testsuite/git.rs
+++ b/tests/testsuite/git.rs
@@ -93,13 +93,13 @@ fn cargo_compile_simple_git_dep() {
 
 #[test]
 fn cargo_compile_forbird_git_httpsrepo_offline() {
-    let p = project().at("need_remote_repo")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
 
             [project]
-            name = "need_remote_repo"
+            name = "foo"
             version = "0.5.0"
             authors = ["chabapok@example.com"]
 
@@ -202,7 +202,7 @@ fn cargo_compile_offline_with_cached_git_dep() {
         assert_that(prj.cargo("build"), execs().with_status(0));
     }
 
-    let project = project()
+    let p = project()
         .file(
             "Cargo.toml",
             &format!(
@@ -223,11 +223,11 @@ fn cargo_compile_offline_with_cached_git_dep() {
         )
         .build();
 
-    let root = project.root();
+    let root = p.root();
     let git_root = git_project.root();
 
     assert_that(
-        project
+        p
             .cargo("build")
             .masquerade_as_nightly_cargo()
             .arg("-Zoffline"),
@@ -241,15 +241,15 @@ fn cargo_compile_offline_with_cached_git_dep() {
         )),
     );
 
-    assert_that(&project.bin("foo"), existing_file());
+    assert_that(&p.bin("foo"), existing_file());
 
     assert_that(
-        process(&project.bin("foo")),
+        process(&p.bin("foo")),
         execs().with_stdout("hello from cached git repo rev2\n"),
     );
 
     drop(
-        File::create(&project.root().join("Cargo.toml"))
+        File::create(&p.root().join("Cargo.toml"))
             .unwrap()
             .write_all(&format!(
                 r#"
@@ -267,13 +267,13 @@ fn cargo_compile_offline_with_cached_git_dep() {
             .unwrap(),
     );
 
-    let _out = project
+    let _out = p
         .cargo("build")
         .masquerade_as_nightly_cargo()
         .arg("-Zoffline")
         .exec_with_output();
     assert_that(
-        process(&project.bin("foo")),
+        process(&p.bin("foo")),
         execs().with_stdout("hello from cached git repo rev1\n"),
     );
 }
@@ -511,14 +511,14 @@ fn cargo_compile_with_nested_paths() {
             )
     }).unwrap();
 
-    let p = project().at("parent")
+    let p = project()
         .file(
             "Cargo.toml",
             &format!(
                 r#"
             [project]
 
-            name = "parent"
+            name = "foo"
             version = "0.5.0"
             authors = ["wycats@example.com"]
 
@@ -529,23 +529,23 @@ fn cargo_compile_with_nested_paths() {
 
             [[bin]]
 
-            name = "parent"
+            name = "foo"
         "#,
                 git_project.url()
             ),
         )
         .file(
-            "src/parent.rs",
+            "src/foo.rs",
             &main_file(r#""{}", dep1::hello()"#, &["dep1"]),
         )
         .build();
 
     p.cargo("build").exec_with_output().unwrap();
 
-    assert_that(&p.bin("parent"), existing_file());
+    assert_that(&p.bin("foo"), existing_file());
 
     assert_that(
-        process(&p.bin("parent")),
+        process(&p.bin("foo")),
         execs().with_stdout("hello world\n"),
     );
 }
@@ -584,14 +584,14 @@ fn cargo_compile_with_malformed_nested_paths() {
             )
     }).unwrap();
 
-    let p = project().at("parent")
+    let p = project()
         .file(
             "Cargo.toml",
             &format!(
                 r#"
             [project]
 
-            name = "parent"
+            name = "foo"
             version = "0.5.0"
             authors = ["wycats@example.com"]
 
@@ -602,23 +602,23 @@ fn cargo_compile_with_malformed_nested_paths() {
 
             [[bin]]
 
-            name = "parent"
+            name = "foo"
         "#,
                 git_project.url()
             ),
         )
         .file(
-            "src/parent.rs",
+            "src/foo.rs",
             &main_file(r#""{}", dep1::hello()"#, &["dep1"]),
         )
         .build();
 
     p.cargo("build").exec_with_output().unwrap();
 
-    assert_that(&p.bin("parent"), existing_file());
+    assert_that(&p.bin("foo"), existing_file());
 
     assert_that(
-        process(&p.bin("parent")),
+        process(&p.bin("foo")),
         execs().with_stdout("hello world\n"),
     );
 }
@@ -673,14 +673,14 @@ fn cargo_compile_with_meta_package() {
             )
     }).unwrap();
 
-    let p = project().at("parent")
+    let p = project()
         .file(
             "Cargo.toml",
             &format!(
                 r#"
             [project]
 
-            name = "parent"
+            name = "foo"
             version = "0.5.0"
             authors = ["wycats@example.com"]
 
@@ -696,14 +696,14 @@ fn cargo_compile_with_meta_package() {
 
             [[bin]]
 
-            name = "parent"
+            name = "foo"
         "#,
                 git_project.url(),
                 git_project.url()
             ),
         )
         .file(
-            "src/parent.rs",
+            "src/foo.rs",
             &main_file(
                 r#""{} {}", dep1::hello(), dep2::hello()"#,
                 &["dep1", "dep2"],
@@ -713,10 +713,10 @@ fn cargo_compile_with_meta_package() {
 
     p.cargo("build").exec_with_output().unwrap();
 
-    assert_that(&p.bin("parent"), existing_file());
+    assert_that(&p.bin("foo"), existing_file());
 
     assert_that(
-        process(&p.bin("parent")),
+        process(&p.bin("foo")),
         execs().with_stdout("this is dep1 this is dep2\n"),
     );
 }
@@ -725,7 +725,7 @@ fn cargo_compile_with_meta_package() {
 fn cargo_compile_with_short_ssh_git() {
     let url = "git@github.com:a/dep";
 
-    let project = project().at("project")
+    let p = project()
         .file(
             "Cargo.toml",
             &format!(
@@ -754,7 +754,7 @@ fn cargo_compile_with_short_ssh_git() {
         .build();
 
     assert_that(
-        project.cargo("build"),
+        p.cargo("build"),
         execs().with_stdout("").with_stderr(&format!(
             "\
 [ERROR] failed to parse manifest at `[..]`
@@ -2047,13 +2047,13 @@ fn fetch_downloads() {
             .file("src/lib.rs", "pub fn bar() -> i32 { 1 }")
     }).unwrap();
 
-    let p = project().at("p1")
+    let p = project()
         .file(
             "Cargo.toml",
             &format!(
                 r#"
             [project]
-            name = "p1"
+            name = "foo"
             version = "0.5.0"
             authors = []
             [dependencies.bar]
@@ -2125,68 +2125,68 @@ fn warnings_in_git_dep() {
 
 #[test]
 fn update_ambiguous() {
-    let foo1 = git::new("foo1", |project| {
+    let bar1 = git::new("bar1", |project| {
         project
             .file(
                 "Cargo.toml",
                 r#"
             [package]
-            name = "foo"
+            name = "bar"
             version = "0.5.0"
             authors = ["wycats@example.com"]
         "#,
             )
             .file("src/lib.rs", "")
     }).unwrap();
-    let foo2 = git::new("foo2", |project| {
+    let bar2 = git::new("bar2", |project| {
         project
             .file(
                 "Cargo.toml",
                 r#"
             [package]
-            name = "foo"
+            name = "bar"
             version = "0.6.0"
             authors = ["wycats@example.com"]
         "#,
             )
             .file("src/lib.rs", "")
     }).unwrap();
-    let bar = git::new("bar", |project| {
+    let baz = git::new("baz", |project| {
         project
             .file(
                 "Cargo.toml",
                 &format!(
                     r#"
             [package]
-            name = "bar"
+            name = "baz"
             version = "0.5.0"
             authors = ["wycats@example.com"]
 
-            [dependencies.foo]
+            [dependencies.bar]
             git = '{}'
         "#,
-                    foo2.url()
+                    bar2.url()
                 ),
             )
             .file("src/lib.rs", "")
     }).unwrap();
 
-    let p = project().at("project")
+    let p = project()
         .file(
             "Cargo.toml",
             &format!(
                 r#"
             [project]
-            name = "project"
+            name = "foo"
             version = "0.5.0"
             authors = []
-            [dependencies.foo]
-            git = '{}'
             [dependencies.bar]
             git = '{}'
+            [dependencies.baz]
+            git = '{}'
         "#,
-                foo1.url(),
-                bar.url()
+                bar1.url(),
+                baz.url()
             ),
         )
         .file("src/main.rs", "fn main() {}")
@@ -2194,15 +2194,15 @@ fn update_ambiguous() {
 
     assert_that(p.cargo("generate-lockfile"), execs().with_status(0));
     assert_that(
-        p.cargo("update").arg("-p").arg("foo"),
+        p.cargo("update").arg("-p").arg("bar"),
         execs().with_status(101).with_stderr(
             "\
-[ERROR] There are multiple `foo` packages in your project, and the specification `foo` \
+[ERROR] There are multiple `bar` packages in your project, and the specification `bar` \
 is ambiguous.
 Please re-run this command with `-p <spec>` where `<spec>` is one of the \
 following:
-  foo:0.[..].0
-  foo:0.[..].0
+  bar:0.[..].0
+  bar:0.[..].0
 ",
         ),
     );
@@ -2210,13 +2210,13 @@ following:
 
 #[test]
 fn update_one_dep_in_repo_with_many_deps() {
-    let foo = git::new("foo", |project| {
+    let bar = git::new("bar", |project| {
         project
             .file(
                 "Cargo.toml",
                 r#"
             [package]
-            name = "foo"
+            name = "bar"
             version = "0.5.0"
             authors = ["wycats@example.com"]
         "#,
@@ -2234,22 +2234,22 @@ fn update_one_dep_in_repo_with_many_deps() {
             .file("a/src/lib.rs", "")
     }).unwrap();
 
-    let p = project().at("project")
+    let p = project()
         .file(
             "Cargo.toml",
             &format!(
                 r#"
             [project]
-            name = "project"
+            name = "foo"
             version = "0.5.0"
             authors = []
-            [dependencies.foo]
+            [dependencies.bar]
             git = '{}'
             [dependencies.a]
             git = '{}'
         "#,
-                foo.url(),
-                foo.url()
+                bar.url(),
+                bar.url()
             ),
         )
         .file("src/main.rs", "fn main() {}")
@@ -2257,10 +2257,10 @@ fn update_one_dep_in_repo_with_many_deps() {
 
     assert_that(p.cargo("generate-lockfile"), execs().with_status(0));
     assert_that(
-        p.cargo("update").arg("-p").arg("foo"),
+        p.cargo("update").arg("-p").arg("bar"),
         execs()
             .with_status(0)
-            .with_stderr(&format!("[UPDATING] git repository `{}`", foo.url())),
+            .with_stderr(&format!("[UPDATING] git repository `{}`", bar.url())),
     );
 }
 
@@ -2318,13 +2318,13 @@ fn switch_deps_does_not_update_transitive() {
             .file("src/lib.rs", "")
     }).unwrap();
 
-    let p = project().at("project")
+    let p = project()
         .file(
             "Cargo.toml",
             &format!(
                 r#"
             [project]
-            name = "project"
+            name = "foo"
             version = "0.5.0"
             authors = []
             [dependencies.dep]
@@ -2344,7 +2344,7 @@ fn switch_deps_does_not_update_transitive() {
 [UPDATING] git repository `{}`
 [COMPILING] transitive [..]
 [COMPILING] dep [..]
-[COMPILING] project [..]
+[COMPILING] foo [..]
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
             dep1.url(),
@@ -2360,7 +2360,7 @@ fn switch_deps_does_not_update_transitive() {
             format!(
                 r#"
             [project]
-            name = "project"
+            name = "foo"
             version = "0.5.0"
             authors = []
             [dependencies.dep]
@@ -2377,7 +2377,7 @@ fn switch_deps_does_not_update_transitive() {
             "\
 [UPDATING] git repository `{}`
 [COMPILING] dep [..]
-[COMPILING] project [..]
+[COMPILING] foo [..]
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
             dep2.url()
@@ -2414,13 +2414,13 @@ fn update_one_source_updates_all_packages_in_that_git_source() {
             .file("a/src/lib.rs", "")
     }).unwrap();
 
-    let p = project().at("project")
+    let p = project()
         .file(
             "Cargo.toml",
             &format!(
                 r#"
             [project]
-            name = "project"
+            name = "foo"
             version = "0.5.0"
             authors = []
             [dependencies.dep]
@@ -2495,12 +2495,12 @@ fn switch_sources() {
             .file("src/lib.rs", "")
     }).unwrap();
 
-    let p = project().at("project")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
             [project]
-            name = "project"
+            name = "foo"
             version = "0.5.0"
             authors = []
             [dependencies.b]
@@ -2532,7 +2532,7 @@ fn switch_sources() {
 [UPDATING] git repository `file://[..]a1`
 [COMPILING] a v0.5.0 ([..]a1#[..]
 [COMPILING] b v0.5.0 ([..])
-[COMPILING] project v0.5.0 ([..])
+[COMPILING] foo v0.5.0 ([..])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ),
@@ -2562,7 +2562,7 @@ fn switch_sources() {
 [UPDATING] git repository `file://[..]a2`
 [COMPILING] a v0.5.1 ([..]a2#[..]
 [COMPILING] b v0.5.0 ([..])
-[COMPILING] project v0.5.0 ([..])
+[COMPILING] foo v0.5.0 ([..])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ),

--- a/tests/testsuite/local_registry.rs
+++ b/tests/testsuite/local_registry.rs
@@ -24,30 +24,30 @@ fn setup() {
 #[test]
 fn simple() {
     setup();
-    Package::new("foo", "0.0.1")
+    Package::new("bar", "0.0.1")
         .local(true)
-        .file("src/lib.rs", "pub fn foo() {}")
+        .file("src/lib.rs", "pub fn bar() {}")
         .publish();
 
-    let p = project().at("bar")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
             [project]
-            name = "bar"
+            name = "foo"
             version = "0.0.1"
             authors = []
 
             [dependencies]
-            foo = "0.0.1"
+            bar = "0.0.1"
         "#,
         )
         .file(
             "src/lib.rs",
             r#"
-            extern crate foo;
-            pub fn bar() {
-                foo::foo();
+            extern crate bar;
+            pub fn foo() {
+                bar::bar();
             }
         "#,
         )
@@ -57,9 +57,9 @@ fn simple() {
         p.cargo("build"),
         execs().with_status(0).with_stderr(&format!(
             "\
-[UNPACKING] foo v0.0.1 ([..])
-[COMPILING] foo v0.0.1
-[COMPILING] bar v0.0.1 ({dir})
+[UNPACKING] bar v0.0.1 ([..])
+[COMPILING] bar v0.0.1
+[COMPILING] foo v0.0.1 ({dir})
 [FINISHED] [..]
 ",
             dir = p.url()
@@ -75,95 +75,30 @@ fn simple() {
 #[test]
 fn multiple_versions() {
     setup();
-    Package::new("foo", "0.0.1").local(true).publish();
-    Package::new("foo", "0.1.0")
-        .local(true)
-        .file("src/lib.rs", "pub fn foo() {}")
-        .publish();
-
-    let p = project().at("bar")
-        .file(
-            "Cargo.toml",
-            r#"
-            [project]
-            name = "bar"
-            version = "0.0.1"
-            authors = []
-
-            [dependencies]
-            foo = "*"
-        "#,
-        )
-        .file(
-            "src/lib.rs",
-            r#"
-            extern crate foo;
-            pub fn bar() {
-                foo::foo();
-            }
-        "#,
-        )
-        .build();
-
-    assert_that(
-        p.cargo("build"),
-        execs().with_status(0).with_stderr(&format!(
-            "\
-[UNPACKING] foo v0.1.0 ([..])
-[COMPILING] foo v0.1.0
-[COMPILING] bar v0.0.1 ({dir})
-[FINISHED] [..]
-",
-            dir = p.url()
-        )),
-    );
-
-    Package::new("foo", "0.2.0")
-        .local(true)
-        .file("src/lib.rs", "pub fn foo() {}")
-        .publish();
-
-    assert_that(
-        p.cargo("update").arg("-v"),
-        execs()
-            .with_status(0)
-            .with_stderr("[UPDATING] foo v0.1.0 -> v0.2.0"),
-    );
-}
-
-#[test]
-fn multiple_names() {
-    setup();
-    Package::new("foo", "0.0.1")
-        .local(true)
-        .file("src/lib.rs", "pub fn foo() {}")
-        .publish();
+    Package::new("bar", "0.0.1").local(true).publish();
     Package::new("bar", "0.1.0")
         .local(true)
         .file("src/lib.rs", "pub fn bar() {}")
         .publish();
 
-    let p = project().at("local")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
             [project]
-            name = "local"
+            name = "foo"
             version = "0.0.1"
             authors = []
 
             [dependencies]
-            foo = "*"
             bar = "*"
         "#,
         )
         .file(
             "src/lib.rs",
             r#"
-            extern crate foo;
             extern crate bar;
-            pub fn local() {
-                foo::foo();
+            pub fn foo() {
                 bar::bar();
             }
         "#,
@@ -174,11 +109,76 @@ fn multiple_names() {
         p.cargo("build"),
         execs().with_status(0).with_stderr(&format!(
             "\
+[UNPACKING] bar v0.1.0 ([..])
+[COMPILING] bar v0.1.0
+[COMPILING] foo v0.0.1 ({dir})
+[FINISHED] [..]
+",
+            dir = p.url()
+        )),
+    );
+
+    Package::new("bar", "0.2.0")
+        .local(true)
+        .file("src/lib.rs", "pub fn bar() {}")
+        .publish();
+
+    assert_that(
+        p.cargo("update").arg("-v"),
+        execs()
+            .with_status(0)
+            .with_stderr("[UPDATING] bar v0.1.0 -> v0.2.0"),
+    );
+}
+
+#[test]
+fn multiple_names() {
+    setup();
+    Package::new("bar", "0.0.1")
+        .local(true)
+        .file("src/lib.rs", "pub fn bar() {}")
+        .publish();
+    Package::new("baz", "0.1.0")
+        .local(true)
+        .file("src/lib.rs", "pub fn baz() {}")
+        .publish();
+
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [project]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+
+            [dependencies]
+            bar = "*"
+            baz = "*"
+        "#,
+        )
+        .file(
+            "src/lib.rs",
+            r#"
+            extern crate bar;
+            extern crate baz;
+            pub fn foo() {
+                bar::bar();
+                baz::baz();
+            }
+        "#,
+        )
+        .build();
+
+    assert_that(
+        p.cargo("build"),
+        execs().with_status(0).with_stderr(&format!(
+            "\
 [UNPACKING] [..]
 [UNPACKING] [..]
 [COMPILING] [..]
 [COMPILING] [..]
-[COMPILING] local v0.0.1 ({dir})
+[COMPILING] foo v0.0.1 ({dir})
 [FINISHED] [..]
 ",
             dir = p.url()
@@ -189,38 +189,38 @@ fn multiple_names() {
 #[test]
 fn interdependent() {
     setup();
-    Package::new("foo", "0.0.1")
+    Package::new("bar", "0.0.1")
         .local(true)
-        .file("src/lib.rs", "pub fn foo() {}")
+        .file("src/lib.rs", "pub fn bar() {}")
         .publish();
-    Package::new("bar", "0.1.0")
+    Package::new("baz", "0.1.0")
         .local(true)
-        .dep("foo", "*")
-        .file("src/lib.rs", "extern crate foo; pub fn bar() {}")
+        .dep("bar", "*")
+        .file("src/lib.rs", "extern crate bar; pub fn baz() {}")
         .publish();
 
-    let p = project().at("local")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
             [project]
-            name = "local"
+            name = "foo"
             version = "0.0.1"
             authors = []
 
             [dependencies]
-            foo = "*"
             bar = "*"
+            baz = "*"
         "#,
         )
         .file(
             "src/lib.rs",
             r#"
-            extern crate foo;
             extern crate bar;
-            pub fn local() {
-                foo::foo();
+            extern crate baz;
+            pub fn foo() {
                 bar::bar();
+                baz::baz();
             }
         "#,
         )
@@ -232,9 +232,9 @@ fn interdependent() {
             "\
 [UNPACKING] [..]
 [UNPACKING] [..]
-[COMPILING] foo v0.0.1
-[COMPILING] bar v0.1.0
-[COMPILING] local v0.0.1 ({dir})
+[COMPILING] bar v0.0.1
+[COMPILING] baz v0.1.0
+[COMPILING] foo v0.0.1 ({dir})
 [FINISHED] [..]
 ",
             dir = p.url()
@@ -245,60 +245,60 @@ fn interdependent() {
 #[test]
 fn path_dep_rewritten() {
     setup();
-    Package::new("foo", "0.0.1")
+    Package::new("bar", "0.0.1")
         .local(true)
-        .file("src/lib.rs", "pub fn foo() {}")
+        .file("src/lib.rs", "pub fn bar() {}")
         .publish();
-    Package::new("bar", "0.1.0")
+    Package::new("baz", "0.1.0")
         .local(true)
-        .dep("foo", "*")
+        .dep("bar", "*")
         .file(
             "Cargo.toml",
             r#"
                 [project]
-                name = "bar"
+                name = "baz"
                 version = "0.1.0"
                 authors = []
 
                 [dependencies]
-                foo = { path = "foo", version = "*" }
+                bar = { path = "bar", version = "*" }
             "#,
         )
-        .file("src/lib.rs", "extern crate foo; pub fn bar() {}")
+        .file("src/lib.rs", "extern crate bar; pub fn baz() {}")
         .file(
-            "foo/Cargo.toml",
+            "bar/Cargo.toml",
             r#"
                 [project]
-                name = "foo"
+                name = "bar"
                 version = "0.0.1"
                 authors = []
             "#,
         )
-        .file("foo/src/lib.rs", "pub fn foo() {}")
+        .file("bar/src/lib.rs", "pub fn bar() {}")
         .publish();
 
-    let p = project().at("local")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
             [project]
-            name = "local"
+            name = "foo"
             version = "0.0.1"
             authors = []
 
             [dependencies]
-            foo = "*"
             bar = "*"
+            baz = "*"
         "#,
         )
         .file(
             "src/lib.rs",
             r#"
-            extern crate foo;
             extern crate bar;
-            pub fn local() {
-                foo::foo();
+            extern crate baz;
+            pub fn foo() {
                 bar::bar();
+                baz::baz();
             }
         "#,
         )
@@ -310,9 +310,9 @@ fn path_dep_rewritten() {
             "\
 [UNPACKING] [..]
 [UNPACKING] [..]
-[COMPILING] foo v0.0.1
-[COMPILING] bar v0.1.0
-[COMPILING] local v0.0.1 ({dir})
+[COMPILING] bar v0.0.1
+[COMPILING] baz v0.1.0
+[COMPILING] foo v0.0.1 ({dir})
 [FINISHED] [..]
 ",
             dir = p.url()
@@ -323,17 +323,17 @@ fn path_dep_rewritten() {
 #[test]
 fn invalid_dir_bad() {
     setup();
-    let p = project().at("local")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
             [project]
-            name = "local"
+            name = "foo"
             version = "0.0.1"
             authors = []
 
             [dependencies]
-            foo = "*"
+            bar = "*"
         "#,
         )
         .file("src/lib.rs", "")
@@ -354,7 +354,7 @@ fn invalid_dir_bad() {
         p.cargo("build"),
         execs().with_status(101).with_stderr(
             "\
-[ERROR] failed to load source for a dependency on `foo`
+[ERROR] failed to load source for a dependency on `bar`
 
 Caused by:
   Unable to update registry `https://[..]`
@@ -379,24 +379,24 @@ fn different_directory_replacing_the_registry_is_bad() {
     let config_tmp = paths::root().join(".cargo-old");
     t!(fs::rename(&config, &config_tmp));
 
-    let p = project().at("local")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
             [project]
-            name = "local"
+            name = "foo"
             version = "0.0.1"
             authors = []
 
             [dependencies]
-            foo = "*"
+            bar = "*"
         "#,
         )
         .file("src/lib.rs", "")
         .build();
 
     // Generate a lock file against the crates.io registry
-    Package::new("foo", "0.0.1").publish();
+    Package::new("bar", "0.0.1").publish();
     assert_that(p.cargo("build"), execs().with_status(0));
 
     // Switch back to our directory source, and now that we're replacing
@@ -404,7 +404,7 @@ fn different_directory_replacing_the_registry_is_bad() {
     // different checksum
     config.rm_rf();
     t!(fs::rename(&config_tmp, &config));
-    Package::new("foo", "0.0.1")
+    Package::new("bar", "0.0.1")
         .file("src/lib.rs", "invalid")
         .local(true)
         .publish();
@@ -413,7 +413,7 @@ fn different_directory_replacing_the_registry_is_bad() {
         p.cargo("build"),
         execs().with_status(101).with_stderr(
             "\
-[ERROR] checksum for `foo v0.0.1` changed between lock files
+[ERROR] checksum for `bar v0.0.1` changed between lock files
 
 this could be indicative of a few possible errors:
 
@@ -421,7 +421,7 @@ this could be indicative of a few possible errors:
     * a replacement source in use (e.g. a mirror) returned a different checksum
     * the source itself may be corrupt in one way or another
 
-unable to verify that `foo v0.0.1` is the same as when the lockfile was generated
+unable to verify that `bar v0.0.1` is the same as when the lockfile was generated
 
 ",
         ),
@@ -442,30 +442,30 @@ fn crates_io_registry_url_is_optional() {
     "#
     ));
 
-    Package::new("foo", "0.0.1")
+    Package::new("bar", "0.0.1")
         .local(true)
-        .file("src/lib.rs", "pub fn foo() {}")
+        .file("src/lib.rs", "pub fn bar() {}")
         .publish();
 
-    let p = project().at("bar")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
             [project]
-            name = "bar"
+            name = "foo"
             version = "0.0.1"
             authors = []
 
             [dependencies]
-            foo = "0.0.1"
+            bar = "0.0.1"
         "#,
         )
         .file(
             "src/lib.rs",
             r#"
-            extern crate foo;
-            pub fn bar() {
-                foo::foo();
+            extern crate bar;
+            pub fn foo() {
+                bar::bar();
             }
         "#,
         )
@@ -475,9 +475,9 @@ fn crates_io_registry_url_is_optional() {
         p.cargo("build"),
         execs().with_status(0).with_stderr(&format!(
             "\
-[UNPACKING] foo v0.0.1 ([..])
-[COMPILING] foo v0.0.1
-[COMPILING] bar v0.0.1 ({dir})
+[UNPACKING] bar v0.0.1 ([..])
+[COMPILING] bar v0.0.1
+[COMPILING] foo v0.0.1 ({dir})
 [FINISHED] [..]
 ",
             dir = p.url()

--- a/tests/testsuite/lockfile_compat.rs
+++ b/tests/testsuite/lockfile_compat.rs
@@ -12,48 +12,48 @@ fn oldest_lockfile_still_works() {
 }
 
 fn oldest_lockfile_still_works_with_command(cargo_command: &str) {
-    Package::new("foo", "0.1.0").publish();
+    Package::new("bar", "0.1.0").publish();
 
     let expected_lockfile = r#"[[package]]
-name = "foo"
+name = "bar"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "zzz"
+name = "foo"
 version = "0.0.1"
 dependencies = [
- "foo 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bar 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [metadata]
-"checksum foo 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "[..]"
+"checksum bar 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "[..]"
 "#;
 
     let old_lockfile = r#"[root]
-name = "zzz"
+name = "foo"
 version = "0.0.1"
 dependencies = [
- "foo 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bar 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
-name = "foo"
+name = "bar"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 "#;
 
-    let p = project().at("bar")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
             [project]
-            name = "zzz"
+            name = "foo"
             version = "0.0.1"
             authors = []
 
             [dependencies]
-            foo = "0.1.0"
+            bar = "0.1.0"
         "#,
         )
         .file("src/lib.rs", "")
@@ -72,38 +72,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 #[test]
 fn frozen_flag_preserves_old_lockfile() {
-    let cksum = Package::new("foo", "0.1.0").publish();
+    let cksum = Package::new("bar", "0.1.0").publish();
 
     let old_lockfile = format!(
         r#"[root]
-name = "zzz"
+name = "foo"
 version = "0.0.1"
 dependencies = [
- "foo 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bar 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
-name = "foo"
+name = "bar"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
-"checksum foo 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "{}"
+"checksum bar 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "{}"
 "#,
         cksum,
     );
 
-    let p = project().at("bar")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
             [project]
-            name = "zzz"
+            name = "foo"
             version = "0.0.1"
             authors = []
 
             [dependencies]
-            foo = "0.1.0"
+            bar = "0.1.0"
         "#,
         )
         .file("src/lib.rs", "")
@@ -122,19 +122,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 #[test]
 fn totally_wild_checksums_works() {
-    Package::new("foo", "0.1.0").publish();
+    Package::new("bar", "0.1.0").publish();
 
-    let p = project().at("bar")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
             [project]
-            name = "bar"
+            name = "foo"
             version = "0.0.1"
             authors = []
 
             [dependencies]
-            foo = "0.1.0"
+            bar = "0.1.0"
         "#,
         )
         .file("src/lib.rs", "")
@@ -142,20 +142,20 @@ fn totally_wild_checksums_works() {
             "Cargo.lock",
             r#"
 [[package]]
-name = "bar"
+name = "foo"
 version = "0.0.1"
 dependencies = [
- "foo 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bar 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
-name = "foo"
+name = "bar"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
 "checksum baz 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "checksum"
-"checksum foo 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "checksum"
+"checksum bar 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "checksum"
 "#,
         );
 
@@ -169,15 +169,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
             r#"
 [[package]]
 name = "bar"
-version = "0.0.1"
-dependencies = [
- "foo 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "foo"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "0.0.1"
+dependencies = [
+ "bar 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [metadata]
 "#.trim()
@@ -187,19 +187,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 #[test]
 fn wrong_checksum_is_an_error() {
-    Package::new("foo", "0.1.0").publish();
+    Package::new("bar", "0.1.0").publish();
 
-    let p = project().at("bar")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
             [project]
-            name = "bar"
+            name = "foo"
             version = "0.0.1"
             authors = []
 
             [dependencies]
-            foo = "0.1.0"
+            bar = "0.1.0"
         "#,
         )
         .file("src/lib.rs", "")
@@ -207,19 +207,19 @@ fn wrong_checksum_is_an_error() {
             "Cargo.lock",
             r#"
 [[package]]
-name = "bar"
+name = "foo"
 version = "0.0.1"
 dependencies = [
- "foo 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bar 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
-name = "foo"
+name = "bar"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
-"checksum foo 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "checksum"
+"checksum bar 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "checksum"
 "#,
         );
 
@@ -230,7 +230,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
         execs().with_status(101).with_stderr(
             "\
 [UPDATING] registry `[..]`
-error: checksum for `foo v0.1.0` changed between lock files
+error: checksum for `bar v0.1.0` changed between lock files
 
 this could be indicative of a few possible errors:
 
@@ -238,7 +238,7 @@ this could be indicative of a few possible errors:
     * a replacement source in use (e.g. a mirror) returned a different checksum
     * the source itself may be corrupt in one way or another
 
-unable to verify that `foo v0.1.0` is the same as when the lockfile was generated
+unable to verify that `bar v0.1.0` is the same as when the lockfile was generated
 
 ",
         ),
@@ -250,19 +250,19 @@ unable to verify that `foo v0.1.0` is the same as when the lockfile was generate
 // it in.
 #[test]
 fn unlisted_checksum_is_bad_if_we_calculate() {
-    Package::new("foo", "0.1.0").publish();
+    Package::new("bar", "0.1.0").publish();
 
-    let p = project().at("bar")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
             [project]
-            name = "bar"
+            name = "foo"
             version = "0.0.1"
             authors = []
 
             [dependencies]
-            foo = "0.1.0"
+            bar = "0.1.0"
         "#,
         )
         .file("src/lib.rs", "")
@@ -270,19 +270,19 @@ fn unlisted_checksum_is_bad_if_we_calculate() {
             "Cargo.lock",
             r#"
 [[package]]
-name = "bar"
+name = "foo"
 version = "0.0.1"
 dependencies = [
- "foo 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bar 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
-name = "foo"
+name = "bar"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
-"checksum foo 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "<none>"
+"checksum bar 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "<none>"
 "#,
         );
     let p = p.build();
@@ -292,7 +292,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
         execs().with_status(101).with_stderr(
             "\
 [UPDATING] registry `[..]`
-error: checksum for `foo v0.1.0` was not previously calculated, but a checksum \
+error: checksum for `bar v0.1.0` was not previously calculated, but a checksum \
 could now be calculated
 
 this could be indicative of a few possible situations:
@@ -312,30 +312,30 @@ this could be indicative of a few possible situations:
 // git dependencies as of today), then make sure we choke.
 #[test]
 fn listed_checksum_bad_if_we_cannot_compute() {
-    let git = git::new("foo", |p| {
+    let git = git::new("bar", |p| {
         p.file(
             "Cargo.toml",
             r#"
             [project]
-            name = "foo"
+            name = "bar"
             version = "0.1.0"
             authors = []
         "#,
         ).file("src/lib.rs", "")
     }).unwrap();
 
-    let p = project().at("bar")
+    let p = project()
         .file(
             "Cargo.toml",
             &format!(
                 r#"
             [project]
-            name = "bar"
+            name = "foo"
             version = "0.0.1"
             authors = []
 
             [dependencies]
-            foo = {{ git = '{}' }}
+            bar = {{ git = '{}' }}
         "#,
                 git.url()
             ),
@@ -346,19 +346,19 @@ fn listed_checksum_bad_if_we_cannot_compute() {
             &format!(
                 r#"
 [[package]]
-name = "bar"
+name = "foo"
 version = "0.0.1"
 dependencies = [
- "foo 0.1.0 (git+{0})"
+ "bar 0.1.0 (git+{0})"
 ]
 
 [[package]]
-name = "foo"
+name = "bar"
 version = "0.1.0"
 source = "git+{0}"
 
 [metadata]
-"checksum foo 0.1.0 (git+{0})" = "checksum"
+"checksum bar 0.1.0 (git+{0})" = "checksum"
 "#,
                 git.url()
             ),
@@ -371,7 +371,7 @@ source = "git+{0}"
         execs().with_status(101).with_stderr(
             "\
 [UPDATING] git repository `[..]`
-error: checksum for `foo v0.1.0 ([..])` could not be calculated, but a \
+error: checksum for `bar v0.1.0 ([..])` could not be calculated, but a \
 checksum is listed in the existing lock file[..]
 
 this could be indicative of a few possible situations:
@@ -380,7 +380,7 @@ this could be indicative of a few possible situations:
       but was replaced with one that doesn't
     * the lock file is corrupt
 
-unable to verify that `foo v0.1.0 ([..])` is the same as when the lockfile was generated
+unable to verify that `bar v0.1.0 ([..])` is the same as when the lockfile was generated
 
 ",
         ),
@@ -389,19 +389,19 @@ unable to verify that `foo v0.1.0 ([..])` is the same as when the lockfile was g
 
 #[test]
 fn current_lockfile_format() {
-    Package::new("foo", "0.1.0").publish();
+    Package::new("bar", "0.1.0").publish();
 
-    let p = project().at("bar")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
             [package]
-            name = "bar"
+            name = "foo"
             version = "0.0.1"
             authors = []
 
             [dependencies]
-            foo = "0.1.0"
+            bar = "0.1.0"
         "#,
         )
         .file("src/lib.rs", "");
@@ -414,18 +414,18 @@ fn current_lockfile_format() {
     let expected = "\
 [[package]]
 name = \"bar\"
-version = \"0.0.1\"
-dependencies = [
- \"foo 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)\",
-]
-
-[[package]]
-name = \"foo\"
 version = \"0.1.0\"
 source = \"registry+https://github.com/rust-lang/crates.io-index\"
 
+[[package]]
+name = \"foo\"
+version = \"0.0.1\"
+dependencies = [
+ \"bar 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)\",
+]
+
 [metadata]
-\"checksum foo 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)\" = \"[..]\"";
+\"checksum bar 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)\" = \"[..]\"";
 
     for (l, r) in expected.lines().zip(actual.lines()) {
         assert!(lines_match(l, r), "Lines differ:\n{}\n\n{}", l, r);
@@ -436,32 +436,32 @@ source = \"registry+https://github.com/rust-lang/crates.io-index\"
 
 #[test]
 fn lockfile_without_root() {
-    Package::new("foo", "0.1.0").publish();
+    Package::new("bar", "0.1.0").publish();
 
     let lockfile = r#"[[package]]
 name = "bar"
-version = "0.0.1"
-dependencies = [
- "foo 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "foo"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "0.0.1"
+dependencies = [
+ "bar 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 "#;
 
-    let p = project().at("bar")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
             [package]
-            name = "bar"
+            name = "foo"
             version = "0.0.1"
             authors = []
 
             [dependencies]
-            foo = "0.1.0"
+            bar = "0.1.0"
         "#,
         )
         .file("src/lib.rs", "")
@@ -477,19 +477,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 #[test]
 fn locked_correct_error() {
-    Package::new("foo", "0.1.0").publish();
+    Package::new("bar", "0.1.0").publish();
 
-    let p = project().at("bar")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
             [project]
-            name = "bar"
+            name = "foo"
             version = "0.0.1"
             authors = []
 
             [dependencies]
-            foo = "0.1.0"
+            bar = "0.1.0"
         "#,
         )
         .file("src/lib.rs", "");

--- a/tests/testsuite/package.rs
+++ b/tests/testsuite/package.rs
@@ -78,7 +78,7 @@ src[/]main.rs
 
 #[test]
 fn metadata_warning() {
-    let p = project().at("all")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -111,7 +111,7 @@ See http://doc.crates.io/manifest.html#package-metadata for more info.
         )),
     );
 
-    let p = project().at("one")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -144,7 +144,7 @@ See http://doc.crates.io/manifest.html#package-metadata for more info.
         )),
     );
 
-    let p = project().at("all")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -247,7 +247,7 @@ See http://doc.crates.io/manifest.html#package-metadata for more info.
 
 #[test]
 fn package_verification() {
-    let p = project().at("all")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -614,22 +614,22 @@ src/main.rs
 fn ignore_nested() {
     let cargo_toml = r#"
             [project]
-            name = "nested"
+            name = "foo"
             version = "0.0.1"
             authors = []
             license = "MIT"
-            description = "nested"
+            description = "foo"
         "#;
     let main_rs = r#"
             fn main() { println!("hello"); }
         "#;
-    let p = project().at("nested")
+    let p = project()
         .file("Cargo.toml", cargo_toml)
         .file("src/main.rs", main_rs)
         // If a project happens to contain a copy of itself, we should
         // ignore it.
-        .file("a_dir/nested/Cargo.toml", cargo_toml)
-        .file("a_dir/nested/src/main.rs", main_rs)
+        .file("a_dir/foo/Cargo.toml", cargo_toml)
+        .file("a_dir/foo/src/main.rs", main_rs)
         .build();
 
     assert_that(
@@ -638,16 +638,16 @@ fn ignore_nested() {
             "\
 [WARNING] manifest has no documentation[..]
 See http://doc.crates.io/manifest.html#package-metadata for more info.
-[PACKAGING] nested v0.0.1 ({dir})
-[VERIFYING] nested v0.0.1 ({dir})
-[COMPILING] nested v0.0.1 ({dir}[..])
+[PACKAGING] foo v0.0.1 ({dir})
+[VERIFYING] foo v0.0.1 ({dir})
+[COMPILING] foo v0.0.1 ({dir}[..])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
             dir = p.url()
         )),
     );
     assert_that(
-        &p.root().join("target/package/nested-0.0.1.crate"),
+        &p.root().join("target/package/foo-0.0.1.crate"),
         existing_file(),
     );
     assert_that(
@@ -661,7 +661,7 @@ src[..]main.rs
     );
     assert_that(p.cargo("package"), execs().with_status(0).with_stdout(""));
 
-    let f = File::open(&p.root().join("target/package/nested-0.0.1.crate")).unwrap();
+    let f = File::open(&p.root().join("target/package/foo-0.0.1.crate")).unwrap();
     let mut rdr = GzDecoder::new(f);
     let mut contents = Vec::new();
     rdr.read_to_end(&mut contents).unwrap();
@@ -671,8 +671,8 @@ src[..]main.rs
         let fname = f.header().path_bytes();
         let fname = &*fname;
         assert!(
-            fname == b"nested-0.0.1/Cargo.toml" || fname == b"nested-0.0.1/Cargo.toml.orig"
-                || fname == b"nested-0.0.1/src/main.rs",
+            fname == b"foo-0.0.1/Cargo.toml" || fname == b"foo-0.0.1/Cargo.toml.orig"
+                || fname == b"foo-0.0.1/src/main.rs",
             "unexpected filename: {:?}",
             f.header().path()
         )

--- a/tests/testsuite/patch.rs
+++ b/tests/testsuite/patch.rs
@@ -10,61 +10,61 @@ use hamcrest::assert_that;
 
 #[test]
 fn replace() {
-    Package::new("foo", "0.1.0").publish();
-    Package::new("deep-foo", "0.1.0")
+    Package::new("bar", "0.1.0").publish();
+    Package::new("baz", "0.1.0")
         .file(
             "src/lib.rs",
             r#"
-            extern crate foo;
-            pub fn deep() {
-                foo::foo();
+            extern crate bar;
+            pub fn baz() {
+                bar::bar();
             }
         "#,
         )
-        .dep("foo", "0.1.0")
+        .dep("bar", "0.1.0")
         .publish();
 
-    let p = project().at("bar")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
             [package]
-            name = "bar"
+            name = "foo"
             version = "0.0.1"
             authors = []
 
             [dependencies]
-            foo = "0.1.0"
-            deep-foo = "0.1.0"
+            bar = "0.1.0"
+            baz = "0.1.0"
 
             [patch.crates-io]
-            foo = { path = "foo" }
+            bar = { path = "bar" }
         "#,
         )
         .file(
             "src/lib.rs",
             "
-            extern crate foo;
-            extern crate deep_foo;
+            extern crate bar;
+            extern crate baz;
             pub fn bar() {
-                foo::foo();
-                deep_foo::deep();
+                bar::bar();
+                baz::baz();
             }
         ",
         )
         .file(
-            "foo/Cargo.toml",
+            "bar/Cargo.toml",
             r#"
             [package]
-            name = "foo"
+            name = "bar"
             version = "0.1.0"
             authors = []
         "#,
         )
         .file(
-            "foo/src/lib.rs",
+            "bar/src/lib.rs",
             r#"
-            pub fn foo() {}
+            pub fn bar() {}
         "#,
         )
         .build();
@@ -74,17 +74,17 @@ fn replace() {
         execs().with_status(0).with_stderr(
             "\
 [UPDATING] registry `file://[..]`
-[DOWNLOADING] deep-foo v0.1.0 ([..])
-[COMPILING] foo v0.1.0 (file://[..])
-[COMPILING] deep-foo v0.1.0
-[COMPILING] bar v0.0.1 (file://[..])
+[DOWNLOADING] baz v0.1.0 ([..])
+[COMPILING] bar v0.1.0 (file://[..])
+[COMPILING] baz v0.1.0
+[COMPILING] foo v0.0.1 (file://[..])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ),
     );
 
     assert_that(
-        p.cargo("build"), //.env("RUST_LOG", "trace"),
+        p.cargo("build"),
         execs().with_status(0).with_stderr("[FINISHED] [..]"),
     );
 }
@@ -93,44 +93,44 @@ fn replace() {
 fn nonexistent() {
     Package::new("baz", "0.1.0").publish();
 
-    let p = project().at("bar")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
             [package]
-            name = "bar"
+            name = "foo"
             version = "0.0.1"
             authors = []
 
             [dependencies]
-            foo = "0.1.0"
+            bar = "0.1.0"
 
             [patch.crates-io]
-            foo = { path = "foo" }
+            bar = { path = "bar" }
         "#,
         )
         .file(
             "src/lib.rs",
             "
-            extern crate foo;
-            pub fn bar() {
-                foo::foo();
+            extern crate bar;
+            pub fn foo() {
+                bar::bar();
             }
         ",
         )
         .file(
-            "foo/Cargo.toml",
+            "bar/Cargo.toml",
             r#"
             [package]
-            name = "foo"
+            name = "bar"
             version = "0.1.0"
             authors = []
         "#,
         )
         .file(
-            "foo/src/lib.rs",
+            "bar/src/lib.rs",
             r#"
-            pub fn foo() {}
+            pub fn bar() {}
         "#,
         )
         .build();
@@ -140,8 +140,8 @@ fn nonexistent() {
         execs().with_status(0).with_stderr(
             "\
 [UPDATING] registry `file://[..]`
-[COMPILING] foo v0.1.0 (file://[..])
-[COMPILING] bar v0.0.1 (file://[..])
+[COMPILING] bar v0.1.0 (file://[..])
+[COMPILING] foo v0.0.1 (file://[..])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ),
@@ -154,12 +154,12 @@ fn nonexistent() {
 
 #[test]
 fn patch_git() {
-    let foo = git::repo(&paths::root().join("override"))
+    let bar = git::repo(&paths::root().join("override"))
         .file(
             "Cargo.toml",
             r#"
             [package]
-            name = "foo"
+            name = "bar"
             version = "0.1.0"
             authors = []
         "#,
@@ -167,47 +167,47 @@ fn patch_git() {
         .file("src/lib.rs", "")
         .build();
 
-    let p = project().at("bar")
+    let p = project()
         .file(
             "Cargo.toml",
             &format!(
                 r#"
             [package]
-            name = "bar"
+            name = "foo"
             version = "0.0.1"
             authors = []
 
             [dependencies]
-            foo = {{ git = '{}' }}
+            bar = {{ git = '{}' }}
 
             [patch.'{0}']
-            foo = {{ path = "foo" }}
+            bar = {{ path = "bar" }}
         "#,
-                foo.url()
+                bar.url()
             ),
         )
         .file(
             "src/lib.rs",
             "
-            extern crate foo;
-            pub fn bar() {
-                foo::foo();
+            extern crate bar;
+            pub fn foo() {
+                bar::bar();
             }
         ",
         )
         .file(
-            "foo/Cargo.toml",
+            "bar/Cargo.toml",
             r#"
             [package]
-            name = "foo"
+            name = "bar"
             version = "0.1.0"
             authors = []
         "#,
         )
         .file(
-            "foo/src/lib.rs",
+            "bar/src/lib.rs",
             r#"
-            pub fn foo() {}
+            pub fn bar() {}
         "#,
         )
         .build();
@@ -217,8 +217,8 @@ fn patch_git() {
         execs().with_status(0).with_stderr(
             "\
 [UPDATING] git repository `file://[..]`
-[COMPILING] foo v0.1.0 (file://[..])
-[COMPILING] bar v0.0.1 (file://[..])
+[COMPILING] bar v0.1.0 (file://[..])
+[COMPILING] foo v0.0.1 (file://[..])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ),
@@ -231,59 +231,59 @@ fn patch_git() {
 
 #[test]
 fn patch_to_git() {
-    let foo = git::repo(&paths::root().join("override"))
+    let bar = git::repo(&paths::root().join("override"))
         .file(
             "Cargo.toml",
             r#"
             [package]
-            name = "foo"
+            name = "bar"
             version = "0.1.0"
             authors = []
         "#,
         )
-        .file("src/lib.rs", "pub fn foo() {}")
+        .file("src/lib.rs", "pub fn bar() {}")
         .build();
 
-    Package::new("foo", "0.1.0").publish();
+    Package::new("bar", "0.1.0").publish();
 
-    let p = project().at("bar")
+    let p = project()
         .file(
             "Cargo.toml",
             &format!(
                 r#"
             [package]
-            name = "bar"
+            name = "foo"
             version = "0.0.1"
             authors = []
 
             [dependencies]
-            foo = "0.1"
+            bar = "0.1"
 
             [patch.crates-io]
-            foo = {{ git = '{}' }}
+            bar = {{ git = '{}' }}
         "#,
-                foo.url()
+                bar.url()
             ),
         )
         .file(
             "src/lib.rs",
             "
-            extern crate foo;
-            pub fn bar() {
-                foo::foo();
+            extern crate bar;
+            pub fn foo() {
+                bar::bar();
             }
         ",
         )
         .build();
 
     assert_that(
-        p.cargo("build"), //.env("RUST_LOG", "cargo=trace"),
+        p.cargo("build"),
         execs().with_status(0).with_stderr(
             "\
 [UPDATING] git repository `file://[..]`
 [UPDATING] registry `file://[..]`
-[COMPILING] foo v0.1.0 (file://[..])
-[COMPILING] bar v0.0.1 (file://[..])
+[COMPILING] bar v0.1.0 (file://[..])
+[COMPILING] foo v0.0.1 (file://[..])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ),
@@ -296,36 +296,36 @@ fn patch_to_git() {
 
 #[test]
 fn unused() {
-    Package::new("foo", "0.1.0").publish();
+    Package::new("bar", "0.1.0").publish();
 
-    let p = project().at("bar")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
             [package]
-            name = "bar"
+            name = "foo"
             version = "0.0.1"
             authors = []
 
             [dependencies]
-            foo = "0.1.0"
+            bar = "0.1.0"
 
             [patch.crates-io]
-            foo = { path = "foo" }
+            bar = { path = "bar" }
         "#,
         )
         .file("src/lib.rs", "")
         .file(
-            "foo/Cargo.toml",
+            "bar/Cargo.toml",
             r#"
             [package]
-            name = "foo"
+            name = "bar"
             version = "0.2.0"
             authors = []
         "#,
         )
         .file(
-            "foo/src/lib.rs",
+            "bar/src/lib.rs",
             r#"
             not rust code
         "#,
@@ -337,9 +337,9 @@ fn unused() {
         execs().with_status(0).with_stderr(
             "\
 [UPDATING] registry `file://[..]`
-[DOWNLOADING] foo v0.1.0 [..]
-[COMPILING] foo v0.1.0
-[COMPILING] bar v0.0.1 (file://[..])
+[DOWNLOADING] bar v0.1.0 [..]
+[COMPILING] bar v0.1.0
+[COMPILING] foo v0.0.1 (file://[..])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ),
@@ -357,7 +357,7 @@ fn unused() {
         .unwrap();
     let toml: toml::Value = toml::from_str(&lock).unwrap();
     assert_eq!(toml["patch"]["unused"].as_array().unwrap().len(), 1);
-    assert_eq!(toml["patch"]["unused"][0]["name"].as_str(), Some("foo"));
+    assert_eq!(toml["patch"]["unused"][0]["name"].as_str(), Some("bar"));
     assert_eq!(
         toml["patch"]["unused"][0]["version"].as_str(),
         Some("0.2.0")
@@ -366,14 +366,14 @@ fn unused() {
 
 #[test]
 fn unused_git() {
-    Package::new("foo", "0.1.0").publish();
+    Package::new("bar", "0.1.0").publish();
 
     let foo = git::repo(&paths::root().join("override"))
         .file(
             "Cargo.toml",
             r#"
             [package]
-            name = "foo"
+            name = "bar"
             version = "0.2.0"
             authors = []
         "#,
@@ -381,21 +381,21 @@ fn unused_git() {
         .file("src/lib.rs", "")
         .build();
 
-    let p = project().at("bar")
+    let p = project()
         .file(
             "Cargo.toml",
             &format!(
                 r#"
             [package]
-            name = "bar"
+            name = "foo"
             version = "0.0.1"
             authors = []
 
             [dependencies]
-            foo = "0.1"
+            bar = "0.1"
 
             [patch.crates-io]
-            foo = {{ git = '{}' }}
+            bar = {{ git = '{}' }}
         "#,
                 foo.url()
             ),
@@ -409,9 +409,9 @@ fn unused_git() {
             "\
 [UPDATING] git repository `file://[..]`
 [UPDATING] registry `file://[..]`
-[DOWNLOADING] foo v0.1.0 [..]
-[COMPILING] foo v0.1.0
-[COMPILING] bar v0.0.1 (file://[..])
+[DOWNLOADING] bar v0.1.0 [..]
+[COMPILING] bar v0.1.0
+[COMPILING] foo v0.0.1 (file://[..])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ),
@@ -424,32 +424,32 @@ fn unused_git() {
 
 #[test]
 fn add_patch() {
-    Package::new("foo", "0.1.0").publish();
+    Package::new("bar", "0.1.0").publish();
 
-    let p = project().at("bar")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
             [package]
-            name = "bar"
+            name = "foo"
             version = "0.0.1"
             authors = []
 
             [dependencies]
-            foo = "0.1.0"
+            bar = "0.1.0"
         "#,
         )
         .file("src/lib.rs", "")
         .file(
-            "foo/Cargo.toml",
+            "bar/Cargo.toml",
             r#"
             [package]
-            name = "foo"
+            name = "bar"
             version = "0.1.0"
             authors = []
         "#,
         )
-        .file("foo/src/lib.rs", r#""#)
+        .file("bar/src/lib.rs", r#""#)
         .build();
 
     assert_that(
@@ -457,9 +457,9 @@ fn add_patch() {
         execs().with_status(0).with_stderr(
             "\
 [UPDATING] registry `file://[..]`
-[DOWNLOADING] foo v0.1.0 [..]
-[COMPILING] foo v0.1.0
-[COMPILING] bar v0.0.1 (file://[..])
+[DOWNLOADING] bar v0.1.0 [..]
+[COMPILING] bar v0.1.0
+[COMPILING] foo v0.0.1 (file://[..])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ),
@@ -472,15 +472,15 @@ fn add_patch() {
     t!(t!(File::create(p.root().join("Cargo.toml"))).write_all(
         br#"
             [package]
-            name = "bar"
+            name = "foo"
             version = "0.0.1"
             authors = []
 
             [dependencies]
-            foo = "0.1.0"
+            bar = "0.1.0"
 
             [patch.crates-io]
-            foo = { path = 'foo' }
+            bar = { path = 'bar' }
     "#
     ));
 
@@ -488,8 +488,8 @@ fn add_patch() {
         p.cargo("build"),
         execs().with_status(0).with_stderr(
             "\
-[COMPILING] foo v0.1.0 (file://[..])
-[COMPILING] bar v0.0.1 (file://[..])
+[COMPILING] bar v0.1.0 (file://[..])
+[COMPILING] foo v0.0.1 (file://[..])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ),
@@ -502,32 +502,32 @@ fn add_patch() {
 
 #[test]
 fn add_ignored_patch() {
-    Package::new("foo", "0.1.0").publish();
+    Package::new("bar", "0.1.0").publish();
 
-    let p = project().at("bar")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
             [package]
-            name = "bar"
+            name = "foo"
             version = "0.0.1"
             authors = []
 
             [dependencies]
-            foo = "0.1.0"
+            bar = "0.1.0"
         "#,
         )
         .file("src/lib.rs", "")
         .file(
-            "foo/Cargo.toml",
+            "bar/Cargo.toml",
             r#"
             [package]
-            name = "foo"
+            name = "bar"
             version = "0.1.1"
             authors = []
         "#,
         )
-        .file("foo/src/lib.rs", r#""#)
+        .file("bar/src/lib.rs", r#""#)
         .build();
 
     assert_that(
@@ -535,9 +535,9 @@ fn add_ignored_patch() {
         execs().with_status(0).with_stderr(
             "\
 [UPDATING] registry `file://[..]`
-[DOWNLOADING] foo v0.1.0 [..]
-[COMPILING] foo v0.1.0
-[COMPILING] bar v0.0.1 (file://[..])
+[DOWNLOADING] bar v0.1.0 [..]
+[COMPILING] bar v0.1.0
+[COMPILING] foo v0.0.1 (file://[..])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ),
@@ -550,15 +550,15 @@ fn add_ignored_patch() {
     t!(t!(File::create(p.root().join("Cargo.toml"))).write_all(
         br#"
             [package]
-            name = "bar"
+            name = "foo"
             version = "0.0.1"
             authors = []
 
             [dependencies]
-            foo = "0.1.0"
+            bar = "0.1.0"
 
             [patch.crates-io]
-            foo = { path = 'foo' }
+            bar = { path = 'bar' }
     "#
     ));
 
@@ -576,35 +576,35 @@ fn add_ignored_patch() {
 
 #[test]
 fn new_minor() {
-    Package::new("foo", "0.1.0").publish();
+    Package::new("bar", "0.1.0").publish();
 
-    let p = project().at("bar")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
             [package]
-            name = "bar"
+            name = "foo"
             version = "0.0.1"
             authors = []
 
             [dependencies]
-            foo = "0.1.0"
+            bar = "0.1.0"
 
             [patch.crates-io]
-            foo = { path = 'foo' }
+            bar = { path = 'bar' }
         "#,
         )
         .file("src/lib.rs", "")
         .file(
-            "foo/Cargo.toml",
+            "bar/Cargo.toml",
             r#"
             [package]
-            name = "foo"
+            name = "bar"
             version = "0.1.1"
             authors = []
         "#,
         )
-        .file("foo/src/lib.rs", r#""#)
+        .file("bar/src/lib.rs", r#""#)
         .build();
 
     assert_that(
@@ -612,8 +612,8 @@ fn new_minor() {
         execs().with_status(0).with_stderr(
             "\
 [UPDATING] registry `file://[..]`
-[COMPILING] foo v0.1.1 [..]
-[COMPILING] bar v0.0.1 (file://[..])
+[COMPILING] bar v0.1.1 [..]
+[COMPILING] foo v0.0.1 (file://[..])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ),
@@ -622,48 +622,48 @@ fn new_minor() {
 
 #[test]
 fn transitive_new_minor() {
-    Package::new("foo", "0.1.0").publish();
+    Package::new("baz", "0.1.0").publish();
 
-    let p = project().at("bar")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
             [package]
-            name = "bar"
+            name = "foo"
             version = "0.0.1"
             authors = []
 
             [dependencies]
-            subdir = { path = 'subdir' }
+            bar = { path = 'bar' }
 
             [patch.crates-io]
-            foo = { path = 'foo' }
+            baz = { path = 'baz' }
         "#,
         )
         .file("src/lib.rs", "")
         .file(
-            "subdir/Cargo.toml",
+            "bar/Cargo.toml",
             r#"
             [package]
-            name = "subdir"
+            name = "bar"
             version = "0.1.0"
             authors = []
 
             [dependencies]
-            foo = '0.1.0'
+            baz = '0.1.0'
         "#,
         )
-        .file("subdir/src/lib.rs", r#""#)
+        .file("bar/src/lib.rs", r#""#)
         .file(
-            "foo/Cargo.toml",
+            "baz/Cargo.toml",
             r#"
             [package]
-            name = "foo"
+            name = "baz"
             version = "0.1.1"
             authors = []
         "#,
         )
-        .file("foo/src/lib.rs", r#""#)
+        .file("baz/src/lib.rs", r#""#)
         .build();
 
     assert_that(
@@ -671,9 +671,9 @@ fn transitive_new_minor() {
         execs().with_status(0).with_stderr(
             "\
 [UPDATING] registry `file://[..]`
-[COMPILING] foo v0.1.1 [..]
-[COMPILING] subdir v0.1.0 [..]
-[COMPILING] bar v0.0.1 (file://[..])
+[COMPILING] baz v0.1.1 [..]
+[COMPILING] bar v0.1.0 [..]
+[COMPILING] foo v0.0.1 (file://[..])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ),
@@ -682,35 +682,35 @@ fn transitive_new_minor() {
 
 #[test]
 fn new_major() {
-    Package::new("foo", "0.1.0").publish();
+    Package::new("bar", "0.1.0").publish();
 
-    let p = project().at("bar")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
             [package]
-            name = "bar"
+            name = "foo"
             version = "0.0.1"
             authors = []
 
             [dependencies]
-            foo = "0.2.0"
+            bar = "0.2.0"
 
             [patch.crates-io]
-            foo = { path = 'foo' }
+            bar = { path = 'bar' }
         "#,
         )
         .file("src/lib.rs", "")
         .file(
-            "foo/Cargo.toml",
+            "bar/Cargo.toml",
             r#"
             [package]
-            name = "foo"
+            name = "bar"
             version = "0.2.0"
             authors = []
         "#,
         )
-        .file("foo/src/lib.rs", r#""#)
+        .file("bar/src/lib.rs", r#""#)
         .build();
 
     assert_that(
@@ -718,14 +718,14 @@ fn new_major() {
         execs().with_status(0).with_stderr(
             "\
 [UPDATING] registry `file://[..]`
-[COMPILING] foo v0.2.0 [..]
-[COMPILING] bar v0.0.1 (file://[..])
+[COMPILING] bar v0.2.0 [..]
+[COMPILING] foo v0.0.1 (file://[..])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ),
     );
 
-    Package::new("foo", "0.2.0").publish();
+    Package::new("bar", "0.2.0").publish();
     assert_that(p.cargo("update"), execs().with_status(0));
     assert_that(
         p.cargo("build"),
@@ -737,12 +737,12 @@ fn new_major() {
     t!(t!(File::create(p.root().join("Cargo.toml"))).write_all(
         br#"
             [package]
-            name = "bar"
+            name = "foo"
             version = "0.0.1"
             authors = []
 
             [dependencies]
-            foo = "0.2.0"
+            bar = "0.2.0"
     "#
     ));
     assert_that(
@@ -750,9 +750,9 @@ fn new_major() {
         execs().with_status(0).with_stderr(
             "\
 [UPDATING] registry `file://[..]`
-[DOWNLOADING] foo v0.2.0 [..]
-[COMPILING] foo v0.2.0
-[COMPILING] bar v0.0.1 (file://[..])
+[DOWNLOADING] bar v0.2.0 [..]
+[COMPILING] bar v0.2.0
+[COMPILING] foo v0.0.1 (file://[..])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ),
@@ -761,48 +761,48 @@ fn new_major() {
 
 #[test]
 fn transitive_new_major() {
-    Package::new("foo", "0.1.0").publish();
+    Package::new("baz", "0.1.0").publish();
 
-    let p = project().at("bar")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
             [package]
-            name = "bar"
+            name = "foo"
             version = "0.0.1"
             authors = []
 
             [dependencies]
-            subdir = { path = 'subdir' }
+            bar = { path = 'bar' }
 
             [patch.crates-io]
-            foo = { path = 'foo' }
+            baz = { path = 'baz' }
         "#,
         )
         .file("src/lib.rs", "")
         .file(
-            "subdir/Cargo.toml",
+            "bar/Cargo.toml",
             r#"
             [package]
-            name = "subdir"
+            name = "bar"
             version = "0.1.0"
             authors = []
 
             [dependencies]
-            foo = '0.2.0'
+            baz = '0.2.0'
         "#,
         )
-        .file("subdir/src/lib.rs", r#""#)
+        .file("bar/src/lib.rs", r#""#)
         .file(
-            "foo/Cargo.toml",
+            "baz/Cargo.toml",
             r#"
             [package]
-            name = "foo"
+            name = "baz"
             version = "0.2.0"
             authors = []
         "#,
         )
-        .file("foo/src/lib.rs", r#""#)
+        .file("baz/src/lib.rs", r#""#)
         .build();
 
     assert_that(
@@ -810,9 +810,9 @@ fn transitive_new_major() {
         execs().with_status(0).with_stderr(
             "\
 [UPDATING] registry `file://[..]`
-[COMPILING] foo v0.2.0 [..]
-[COMPILING] subdir v0.1.0 [..]
-[COMPILING] bar v0.0.1 (file://[..])
+[COMPILING] baz v0.2.0 [..]
+[COMPILING] bar v0.1.0 [..]
+[COMPILING] foo v0.0.1 (file://[..])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ),
@@ -824,17 +824,17 @@ fn remove_patch() {
     Package::new("foo", "0.1.0").publish();
     Package::new("bar", "0.1.0").publish();
 
-    let p = project().at("bar")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
             [package]
-            name = "bar"
+            name = "foo"
             version = "0.0.1"
             authors = []
 
             [dependencies]
-            foo = "0.1"
+            bar = "0.1"
 
             [patch.crates-io]
             foo = { path = 'foo' }
@@ -842,16 +842,6 @@ fn remove_patch() {
         "#,
         )
         .file("src/lib.rs", "")
-        .file(
-            "foo/Cargo.toml",
-            r#"
-            [package]
-            name = "foo"
-            version = "0.1.0"
-            authors = []
-        "#,
-        )
-        .file("foo/src/lib.rs", r#""#)
         .file(
             "bar/Cargo.toml",
             r#"
@@ -862,9 +852,19 @@ fn remove_patch() {
         "#,
         )
         .file("bar/src/lib.rs", r#""#)
+        .file(
+            "foo/Cargo.toml",
+            r#"
+            [package]
+            name = "foo"
+            version = "0.1.0"
+            authors = []
+        "#,
+        )
+        .file("foo/src/lib.rs", r#""#)
         .build();
 
-    // Generate a lock file where `bar` is unused
+    // Generate a lock file where `foo` is unused
     assert_that(p.cargo("build"), execs().with_status(0));
     let mut lock_file1 = String::new();
     File::open(p.root().join("Cargo.lock"))
@@ -872,21 +872,21 @@ fn remove_patch() {
         .read_to_string(&mut lock_file1)
         .unwrap();
 
-    // Remove `bar` and generate a new lock file form the old one
+    // Remove `foo` and generate a new lock file form the old one
     File::create(p.root().join("Cargo.toml"))
         .unwrap()
         .write_all(
             r#"
         [package]
-        name = "bar"
+        name = "foo"
         version = "0.0.1"
         authors = []
 
         [dependencies]
-        foo = "0.1"
+        bar = "0.1"
 
         [patch.crates-io]
-        foo = { path = 'foo' }
+        bar = { path = 'bar' }
     "#.as_bytes(),
         )
         .unwrap();
@@ -906,39 +906,39 @@ fn remove_patch() {
         .read_to_string(&mut lock_file3)
         .unwrap();
 
-    assert!(lock_file1.contains("bar"));
+    assert!(lock_file1.contains("foo"));
     assert_eq!(lock_file2, lock_file3);
     assert_ne!(lock_file1, lock_file2);
 }
 
 #[test]
 fn non_crates_io() {
-    Package::new("foo", "0.1.0").publish();
+    Package::new("bar", "0.1.0").publish();
 
-    let p = project().at("bar")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
             [package]
-            name = "bar"
+            name = "foo"
             version = "0.0.1"
             authors = []
 
             [patch.some-other-source]
-            foo = { path = 'foo' }
+            bar = { path = 'bar' }
         "#,
         )
         .file("src/lib.rs", "")
         .file(
-            "foo/Cargo.toml",
+            "bar/Cargo.toml",
             r#"
             [package]
-            name = "foo"
+            name = "bar"
             version = "0.1.0"
             authors = []
         "#,
         )
-        .file("foo/src/lib.rs", r#""#)
+        .file("bar/src/lib.rs", r#""#)
         .build();
 
     assert_that(
@@ -956,32 +956,32 @@ Caused by:
 
 #[test]
 fn replace_with_crates_io() {
-    Package::new("foo", "0.1.0").publish();
+    Package::new("bar", "0.1.0").publish();
 
-    let p = project().at("bar")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
             [package]
-            name = "bar"
+            name = "foo"
             version = "0.0.1"
             authors = []
 
             [patch.crates-io]
-            foo = "0.1"
+            bar = "0.1"
         "#,
         )
         .file("src/lib.rs", "")
         .file(
-            "foo/Cargo.toml",
+            "bar/Cargo.toml",
             r#"
             [package]
-            name = "foo"
+            name = "bar"
             version = "0.1.0"
             authors = []
         "#,
         )
-        .file("foo/src/lib.rs", r#""#)
+        .file("bar/src/lib.rs", r#""#)
         .build();
 
     assert_that(
@@ -992,7 +992,7 @@ fn replace_with_crates_io() {
 error: failed to resolve patches for `[..]`
 
 Caused by:
-  patch for `foo` in `[..]` points to the same source, but patches must point \
+  patch for `bar` in `[..]` points to the same source, but patches must point \
   to different sources
 ",
         ),
@@ -1001,29 +1001,19 @@ Caused by:
 
 #[test]
 fn patch_in_virtual() {
-    Package::new("foo", "0.1.0").publish();
+    Package::new("bar", "0.1.0").publish();
 
-    let p = project().at("bar")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
             [workspace]
-            members = ["bar"]
+            members = ["foo"]
 
             [patch.crates-io]
-            foo = { path = "foo" }
+            bar = { path = "bar" }
         "#,
         )
-        .file(
-            "foo/Cargo.toml",
-            r#"
-            [package]
-            name = "foo"
-            version = "0.1.0"
-            authors = []
-        "#,
-        )
-        .file("foo/src/lib.rs", r#""#)
         .file(
             "bar/Cargo.toml",
             r#"
@@ -1031,12 +1021,22 @@ fn patch_in_virtual() {
             name = "bar"
             version = "0.1.0"
             authors = []
-
-            [dependencies]
-            foo = "0.1"
         "#,
         )
         .file("bar/src/lib.rs", r#""#)
+        .file(
+            "foo/Cargo.toml",
+            r#"
+            [package]
+            name = "foo"
+            version = "0.1.0"
+            authors = []
+
+            [dependencies]
+            bar = "0.1"
+        "#,
+        )
+        .file("foo/src/lib.rs", r#""#)
         .build();
 
     assert_that(p.cargo("build"), execs().with_status(0));
@@ -1048,44 +1048,34 @@ fn patch_in_virtual() {
 
 #[test]
 fn patch_depends_on_another_patch() {
-    Package::new("foo", "0.1.0")
-        .file("src/lib.rs", "broken code")
-        .publish();
-
     Package::new("bar", "0.1.0")
-        .dep("foo", "0.1")
         .file("src/lib.rs", "broken code")
         .publish();
 
-    let p = project().at("p")
+    Package::new("baz", "0.1.0")
+        .dep("bar", "0.1")
+        .file("src/lib.rs", "broken code")
+        .publish();
+
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
             [package]
-            name = "p"
+            name = "foo"
             authors = []
             version = "0.1.0"
 
             [dependencies]
-            foo = "0.1"
             bar = "0.1"
+            baz = "0.1"
 
             [patch.crates-io]
-            foo = { path = "foo" }
             bar = { path = "bar" }
+            baz = { path = "baz" }
         "#,
         )
         .file("src/lib.rs", "")
-        .file(
-            "foo/Cargo.toml",
-            r#"
-            [package]
-            name = "foo"
-            version = "0.1.1"
-            authors = []
-        "#,
-        )
-        .file("foo/src/lib.rs", r#""#)
         .file(
             "bar/Cargo.toml",
             r#"
@@ -1093,12 +1083,22 @@ fn patch_depends_on_another_patch() {
             name = "bar"
             version = "0.1.1"
             authors = []
-
-            [dependencies]
-            foo = "0.1"
         "#,
         )
         .file("bar/src/lib.rs", r#""#)
+        .file(
+            "baz/Cargo.toml",
+            r#"
+            [package]
+            name = "baz"
+            version = "0.1.1"
+            authors = []
+
+            [dependencies]
+            bar = "0.1"
+        "#,
+        )
+        .file("baz/src/lib.rs", r#""#)
         .build();
 
     assert_that(p.cargo("build"), execs().with_status(0));
@@ -1112,48 +1112,48 @@ fn patch_depends_on_another_patch() {
 
 #[test]
 fn replace_prerelease() {
-    Package::new("bar", "1.1.0-pre.1").publish();
+    Package::new("baz", "1.1.0-pre.1").publish();
     let p = project()
         .file(
             "Cargo.toml",
             r#"
             [workspace]
-            members = ["foo"]
+            members = ["bar"]
 
             [patch.crates-io]
-            bar = { path = "./bar" }
+            baz = { path = "./baz" }
         "#,
-        )
-        .file(
-            "foo/Cargo.toml",
-            r#"
-            [project]
-            name = "foo"
-            version = "0.5.0"
-            authors = []
-
-            [dependencies]
-            bar = "1.1.0-pre.1"
-        "#,
-        )
-        .file(
-            "foo/src/main.rs",
-            "
-            extern crate bar;
-            fn main() { bar::bar() }
-        ",
         )
         .file(
             "bar/Cargo.toml",
             r#"
             [project]
             name = "bar"
+            version = "0.5.0"
+            authors = []
+
+            [dependencies]
+            baz = "1.1.0-pre.1"
+        "#,
+        )
+        .file(
+            "bar/src/main.rs",
+            "
+            extern crate baz;
+            fn main() { baz::baz() }
+        ",
+        )
+        .file(
+            "baz/Cargo.toml",
+            r#"
+            [project]
+            name = "baz"
             version = "1.1.0-pre.1"
             authors = []
             [workspace]
         "#,
         )
-        .file("bar/src/lib.rs", "pub fn bar() {}")
+        .file("baz/src/lib.rs", "pub fn baz() {}")
         .build();
 
     assert_that(p.cargo("build"), execs().with_status(0));

--- a/tests/testsuite/plugins.rs
+++ b/tests/testsuite/plugins.rs
@@ -365,12 +365,12 @@ fn panic_abort_plugins() {
         return;
     }
 
-    let p = project().at("bar")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
             [package]
-            name = "bar"
+            name = "foo"
             version = "0.0.1"
             authors = []
 
@@ -378,15 +378,15 @@ fn panic_abort_plugins() {
             panic = 'abort'
 
             [dependencies]
-            foo = { path = "foo" }
+            bar = { path = "bar" }
         "#,
         )
         .file("src/lib.rs", "")
         .file(
-            "foo/Cargo.toml",
+            "bar/Cargo.toml",
             r#"
             [package]
-            name = "foo"
+            name = "bar"
             version = "0.0.1"
             authors = []
 
@@ -395,7 +395,7 @@ fn panic_abort_plugins() {
         "#,
         )
         .file(
-            "foo/src/lib.rs",
+            "bar/src/lib.rs",
             r#"
             #![feature(rustc_private)]
             extern crate syntax;
@@ -412,12 +412,12 @@ fn shared_panic_abort_plugins() {
         return;
     }
 
-    let p = project().at("top")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
             [package]
-            name = "top"
+            name = "foo"
             version = "0.0.1"
             authors = []
 
@@ -425,38 +425,15 @@ fn shared_panic_abort_plugins() {
             panic = 'abort'
 
             [dependencies]
-            foo = { path = "foo" }
             bar = { path = "bar" }
+            baz = { path = "baz" }
         "#,
         )
         .file(
             "src/lib.rs",
             "
-            extern crate bar;
+            extern crate baz;
         ",
-        )
-        .file(
-            "foo/Cargo.toml",
-            r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-
-            [lib]
-            plugin = true
-
-            [dependencies]
-            bar = { path = "../bar" }
-        "#,
-        )
-        .file(
-            "foo/src/lib.rs",
-            r#"
-            #![feature(rustc_private)]
-            extern crate syntax;
-            extern crate bar;
-        "#,
         )
         .file(
             "bar/Cargo.toml",
@@ -465,9 +442,32 @@ fn shared_panic_abort_plugins() {
             name = "bar"
             version = "0.0.1"
             authors = []
+
+            [lib]
+            plugin = true
+
+            [dependencies]
+            baz = { path = "../baz" }
         "#,
         )
-        .file("bar/src/lib.rs", "")
+        .file(
+            "bar/src/lib.rs",
+            r#"
+            #![feature(rustc_private)]
+            extern crate syntax;
+            extern crate baz;
+        "#,
+        )
+        .file(
+            "baz/Cargo.toml",
+            r#"
+            [package]
+            name = "baz"
+            version = "0.0.1"
+            authors = []
+        "#,
+        )
+        .file("baz/src/lib.rs", "")
         .build();
 
     assert_that(p.cargo("build"), execs().with_status(0));

--- a/tests/testsuite/proc_macro.rs
+++ b/tests/testsuite/proc_macro.rs
@@ -4,12 +4,12 @@ use hamcrest::assert_that;
 
 #[test]
 fn probe_cfg_before_crate_type_discovery() {
-    let client = project().at("client")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
             [package]
-            name = "client"
+            name = "foo"
             version = "0.0.1"
             authors = []
 
@@ -57,17 +57,17 @@ fn probe_cfg_before_crate_type_discovery() {
         )
         .build();
 
-    assert_that(client.cargo("build"), execs().with_status(0));
+    assert_that(p.cargo("build"), execs().with_status(0));
 }
 
 #[test]
 fn noop() {
-    let client = project().at("client")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
             [package]
-            name = "client"
+            name = "foo"
             version = "0.0.1"
             authors = []
 
@@ -115,18 +115,18 @@ fn noop() {
         )
         .build();
 
-    assert_that(client.cargo("build"), execs().with_status(0));
-    assert_that(client.cargo("build"), execs().with_status(0));
+    assert_that(p.cargo("build"), execs().with_status(0));
+    assert_that(p.cargo("build"), execs().with_status(0));
 }
 
 #[test]
 fn impl_and_derive() {
-    let client = project().at("client")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
             [package]
-            name = "client"
+            name = "foo"
             version = "0.0.1"
             authors = []
 
@@ -195,9 +195,9 @@ fn impl_and_derive() {
         )
         .build();
 
-    assert_that(client.cargo("build"), execs().with_status(0));
+    assert_that(p.cargo("build"), execs().with_status(0));
     assert_that(
-        client.cargo("run"),
+        p.cargo("run"),
         execs().with_status(0).with_stdout("X { success: true }"),
     );
 }
@@ -208,12 +208,12 @@ fn plugin_and_proc_macro() {
         return;
     }
 
-    let questionable = project().at("questionable")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
             [package]
-            name = "questionable"
+            name = "foo"
             version = "0.0.1"
             authors = []
 
@@ -247,7 +247,7 @@ fn plugin_and_proc_macro() {
 
     let msg = "  lib.plugin and lib.proc-macro cannot both be true";
     assert_that(
-        questionable.cargo("build"),
+        p.cargo("build"),
         execs().with_status(101).with_stderr_contains(msg),
     );
 }

--- a/tests/testsuite/registry.rs
+++ b/tests/testsuite/registry.rs
@@ -856,7 +856,7 @@ fn login_with_differently_sized_token() {
 #[test]
 fn bad_license_file() {
     Package::new("foo", "1.0.0").publish();
-    let p = project().at("all")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"

--- a/tests/testsuite/tool_paths.rs
+++ b/tests/testsuite/tool_paths.rs
@@ -126,20 +126,20 @@ fn relative_tools() {
 
     // Funky directory structure to test that relative tool paths are made absolute
     // by reference to the `.cargo/..` directory and not to (for example) the CWD.
-    let origin = project().at("origin")
+    let p = project()
         .file(
-            "foo/Cargo.toml",
+            "bar/Cargo.toml",
             r#"
             [package]
-            name = "foo"
+            name = "bar"
             version = "0.0.1"
             authors = []
 
             [lib]
-            name = "foo"
+            name = "bar"
         "#,
         )
-        .file("foo/src/lib.rs", "")
+        .file("bar/src/lib.rs", "")
         .file(
             ".cargo/config",
             &format!(
@@ -155,9 +155,9 @@ fn relative_tools() {
         )
         .build();
 
-    let foo_path = origin.root().join("foo");
+    let foo_path = p.root().join("bar");
     let foo_url = path2url(foo_path.clone());
-    let prefix = origin.root().into_os_string().into_string().unwrap();
+    let prefix = p.root().into_os_string().into_string().unwrap();
     let output = if cfg!(windows) {
         (
             format!(r#"{}\.\nonexistent-ar"#, prefix),
@@ -171,10 +171,10 @@ fn relative_tools() {
     };
 
     assert_that(
-        origin.cargo("build").cwd(foo_path).arg("--verbose"),
+        p.cargo("build").cwd(foo_path).arg("--verbose"),
         execs().with_stderr(&format!(
             "\
-[COMPILING] foo v0.0.1 ({url})
+[COMPILING] bar v0.0.1 ({url})
 [RUNNING] `rustc [..] -C ar={ar} -C linker={linker} [..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",

--- a/tests/testsuite/warn_on_failure.rs
+++ b/tests/testsuite/warn_on_failure.rs
@@ -6,12 +6,12 @@ static WARNING1: &'static str = "Hello! I'm a warning. :)";
 static WARNING2: &'static str = "And one more!";
 
 fn make_lib(lib_src: &str) {
-    Package::new("foo", "0.0.1")
+    Package::new("bar", "0.0.1")
         .file(
             "Cargo.toml",
             r#"
             [package]
-            name = "foo"
+            name = "bar"
             authors = []
             version = "0.0.1"
             build = "build.rs"
@@ -37,17 +37,17 @@ fn make_lib(lib_src: &str) {
 }
 
 fn make_upstream(main_src: &str) -> Project {
-    project().at("bar")
+    project()
         .file(
             "Cargo.toml",
             r#"
             [package]
-            name = "bar"
+            name = "foo"
             version = "0.0.1"
             authors = []
 
             [dependencies]
-            foo = "*"
+            bar = "*"
         "#,
         )
         .file("src/main.rs", &format!("fn main() {{ {} }}", main_src))
@@ -63,9 +63,9 @@ fn no_warning_on_success() {
         execs().with_status(0).with_stderr(
             "\
 [UPDATING] registry `[..]`
-[DOWNLOADING] foo v0.0.1 ([..])
-[COMPILING] foo v0.0.1
-[COMPILING] bar v0.0.1 ([..])
+[DOWNLOADING] bar v0.0.1 ([..])
+[COMPILING] bar v0.0.1
+[COMPILING] foo v0.0.1 ([..])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ),
@@ -85,9 +85,9 @@ fn no_warning_on_bin_failure() {
             .with_stderr_does_not_contain(&format!("[WARNING] {}", WARNING1))
             .with_stderr_does_not_contain(&format!("[WARNING] {}", WARNING2))
             .with_stderr_contains("[UPDATING] registry `[..]`")
-            .with_stderr_contains("[DOWNLOADING] foo v0.0.1 ([..])")
-            .with_stderr_contains("[COMPILING] foo v0.0.1")
-            .with_stderr_contains("[COMPILING] bar v0.0.1 ([..])"),
+            .with_stderr_contains("[DOWNLOADING] bar v0.0.1 ([..])")
+            .with_stderr_contains("[COMPILING] bar v0.0.1")
+            .with_stderr_contains("[COMPILING] foo v0.0.1 ([..])"),
     );
 }
 
@@ -101,10 +101,10 @@ fn warning_on_lib_failure() {
             .with_status(101)
             .with_stdout_does_not_contain("hidden stdout")
             .with_stderr_does_not_contain("hidden stderr")
-            .with_stderr_does_not_contain("[COMPILING] bar v0.0.1 ([..])")
+            .with_stderr_does_not_contain("[COMPILING] foo v0.0.1 ([..])")
             .with_stderr_contains("[UPDATING] registry `[..]`")
-            .with_stderr_contains("[DOWNLOADING] foo v0.0.1 ([..])")
-            .with_stderr_contains("[COMPILING] foo v0.0.1")
+            .with_stderr_contains("[DOWNLOADING] bar v0.0.1 ([..])")
+            .with_stderr_contains("[COMPILING] bar v0.0.1")
             .with_stderr_contains(&format!("[WARNING] {}", WARNING1))
             .with_stderr_contains(&format!("[WARNING] {}", WARNING2)),
     );

--- a/tests/testsuite/workspaces.rs
+++ b/tests/testsuite/workspaces.rs
@@ -2189,13 +2189,13 @@ fn dont_recurse_out_of_cargo_home() {
             "#,
             )
     }).unwrap();
-    let p = project().at("lib")
+    let p = project()
         .file(
             "Cargo.toml",
             &format!(
                 r#"
             [package]
-            name = "lib"
+            name = "foo"
             version = "0.1.0"
 
             [dependencies.dep]
@@ -2252,12 +2252,12 @@ fn include_and_exclude() {
 
 #[test]
 fn cargo_home_at_root_works() {
-    let p = project().at("lib")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
             [package]
-            name = "lib"
+            name = "foo"
             version = "0.1.0"
 
             [workspace]
@@ -2285,7 +2285,7 @@ fn cargo_home_at_root_works() {
 
 #[test]
 fn relative_rustc() {
-    let p = project().at("the_exe")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -2342,7 +2342,7 @@ fn relative_rustc() {
 
 #[test]
 fn ws_rustc_err() {
-    let p = project().at("ws")
+    let p = project()
         .file(
             "Cargo.toml",
             r#"


### PR DESCRIPTION
Generally that means either switching "foo" and "bar" around (reversing
the arrow), or it means push "foo" to "bar" (and sometimes "bar" to
"baz", etc..) to free up "foo".

For trivia that leaves 80/1222 outliers, therefore 93.4% of test
project use the default. :)

Refs #5746