### PR TITLE
Drop after_help in generate-lockfile

### DIFF
--- a/src/bin/cargo/commands/generate_lockfile.rs
+++ b/src/bin/cargo/commands/generate_lockfile.rs
@@ -6,18 +6,6 @@ pub fn cli() -> App {
     subcommand("generate-lockfile")
         .about("Generate the lockfile for a project")
         .arg_manifest_path()
-        .after_help(
-            "\
-If a lockfile is available, this command will ensure that all of the git
-dependencies and/or registries dependencies are downloaded and locally
-available. The network is never touched after a `cargo fetch` unless
-the lockfile changes.
-
-If the lockfile is not available, then this is the equivalent of
-`cargo generate-lockfile`. A lockfile is generated and dependencies are also
-all updated.
-",
-        )
 }
 
 pub fn exec(config: &mut Config, args: &ArgMatches) -> CliResult {


### PR DESCRIPTION
From reviewing the history this looks like a copy-paste error while
porting to clap (https://github.com/rust-lang/cargo/pull/5152): this is
fetch's after_help info

Fixes #5692