### PR TITLE
Fix a formatting of a cargo fix message

### DIFF
--- a/src/cargo/util/diagnostic_server.rs
+++ b/src/cargo/util/diagnostic_server.rs
@@ -83,7 +83,7 @@ impl Message {
                 config.shell().warn(&msg)?;
                 write!(
                     config.shell().err(),
-                    "The full error message was:\n\n> {}",
+                    "The full error message was:\n\n> {}\n\n",
                     message,
                 )?;
                 write!(config.shell().err(), "{}", PLEASE_REPORT_THIS_BUG)?;


### PR DESCRIPTION
Something I saw in the report of https://github.com/rust-lang/cargo/issues/5775