### PR TITLE
Deduplicate a bunch more manifests in test code

### DIFF
--- a/tests/testsuite/alt_registry.rs
+++ b/tests/testsuite/alt_registry.rs
@@ -1,6 +1,6 @@
 use support::ChannelChanger;
 use support::registry::{self, alt_api_path, Package};
-use support::{execs, paths, project};
+use support::{basic_manifest, execs, paths, project};
 use support::hamcrest::assert_that;
 use std::fs::File;
 use std::io::Write;
@@ -249,15 +249,7 @@ fn registry_and_path_dep_works() {
         "#,
         )
         .file("src/main.rs", "fn main() {}")
-        .file(
-            "bar/Cargo.toml",
-            r#"
-            [project]
-            name = "bar"
-            version = "0.0.1"
-            authors = []
-        "#,
-        )
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.0.1"))
         .file("bar/src/lib.rs", "")
         .build();
 

--- a/tests/testsuite/bad_config.rs
+++ b/tests/testsuite/bad_config.rs
@@ -1,4 +1,4 @@
-use support::{execs, project};
+use support::{basic_manifest, execs, project};
 use support::registry::Package;
 use support::hamcrest::assert_that;
 
@@ -598,30 +598,14 @@ Caused by:
 #[test]
 fn duplicate_deps() {
     let p = project()
-        .file(
-            "shim-bar/Cargo.toml",
-            r#"
-           [package]
-           name = "bar"
-           version = "0.0.1"
-           authors = []
-        "#,
-        )
+        .file("shim-bar/Cargo.toml", &basic_manifest("bar", "0.0.1"))
         .file(
             "shim-bar/src/lib.rs",
             r#"
                 pub fn a() {}
         "#,
         )
-        .file(
-            "linux-bar/Cargo.toml",
-            r#"
-           [package]
-           name = "bar"
-           version = "0.0.1"
-           authors = []
-        "#,
-        )
+        .file("linux-bar/Cargo.toml", &basic_manifest("bar", "0.0.1"))
         .file(
             "linux-bar/src/lib.rs",
             r#"
@@ -663,30 +647,14 @@ have a single canonical source path irrespective of build target.
 #[test]
 fn duplicate_deps_diff_sources() {
     let p = project()
-        .file(
-            "shim-bar/Cargo.toml",
-            r#"
-           [package]
-           name = "bar"
-           version = "0.0.1"
-           authors = []
-        "#,
-        )
+        .file("shim-bar/Cargo.toml", &basic_manifest("bar", "0.0.1"))
         .file(
             "shim-bar/src/lib.rs",
             r#"
                 pub fn a() {}
         "#,
         )
-        .file(
-            "linux-bar/Cargo.toml",
-            r#"
-           [package]
-           name = "bar"
-           version = "0.0.1"
-           authors = []
-        "#,
-        )
+        .file("linux-bar/Cargo.toml", &basic_manifest("bar", "0.0.1"))
         .file(
             "linux-bar/src/lib.rs",
             r#"
@@ -828,14 +796,7 @@ fn unused_keys_in_virtual_manifest() {
             bulid = "foo"
         "#,
         )
-        .file(
-            "bar/Cargo.toml",
-            r#"
-            [project]
-            version = "0.0.1"
-            name = "bar"
-        "#,
-        )
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.0.1"))
         .file("bar/src/lib.rs", r"")
         .build();
     assert_that(

--- a/tests/testsuite/bench.rs
+++ b/tests/testsuite/bench.rs
@@ -3,7 +3,7 @@ use std::str;
 use cargo::util::process;
 use support::{is_nightly, ChannelChanger};
 use support::paths::CargoPathExt;
-use support::{basic_bin_manifest, basic_lib_manifest, execs, project};
+use support::{basic_manifest, basic_bin_manifest, basic_lib_manifest, execs, project};
 use support::hamcrest::{assert_that, existing_file};
 
 #[test]
@@ -876,15 +876,7 @@ fn lib_with_standard_name() {
     }
 
     let p = project()
-        .file(
-            "Cargo.toml",
-            r#"
-            [package]
-            name = "syntax"
-            version = "0.0.1"
-            authors = []
-        "#,
-        )
+        .file("Cargo.toml", &basic_manifest("syntax", "0.0.1"))
         .file(
             "src/lib.rs",
             "
@@ -1509,14 +1501,7 @@ fn bench_all_workspace() {
             fn bench_foo(_: &mut Bencher) -> () { () }
         "#,
         )
-        .file(
-            "bar/Cargo.toml",
-            r#"
-            [project]
-            name = "bar"
-            version = "0.1.0"
-        "#,
-        )
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file(
             "bar/src/lib.rs",
             r#"
@@ -1572,14 +1557,7 @@ fn bench_all_exclude() {
             fn main() {}
         "#,
         )
-        .file(
-            "bar/Cargo.toml",
-            r#"
-            [project]
-            name = "bar"
-            version = "0.1.0"
-        "#,
-        )
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file(
             "bar/src/lib.rs",
             r#"
@@ -1593,14 +1571,7 @@ fn bench_all_exclude() {
             }
         "#,
         )
-        .file(
-            "baz/Cargo.toml",
-            r#"
-            [project]
-            name = "baz"
-            version = "0.1.0"
-        "#,
-        )
+        .file("baz/Cargo.toml", &basic_manifest("baz", "0.1.0"))
         .file(
             "baz/src/lib.rs",
             r#"
@@ -1636,14 +1607,7 @@ fn bench_all_virtual_manifest() {
             members = ["bar", "baz"]
         "#,
         )
-        .file(
-            "bar/Cargo.toml",
-            r#"
-            [project]
-            name = "bar"
-            version = "0.1.0"
-        "#,
-        )
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file(
             "bar/src/lib.rs",
             r#"
@@ -1662,14 +1626,7 @@ fn bench_all_virtual_manifest() {
             fn bench_bar(_: &mut Bencher) -> () { () }
         "#,
         )
-        .file(
-            "baz/Cargo.toml",
-            r#"
-            [project]
-            name = "baz"
-            version = "0.1.0"
-        "#,
-        )
+        .file("baz/Cargo.toml", &basic_manifest("baz", "0.1.0"))
         .file(
             "baz/src/lib.rs",
             r#"
@@ -1765,14 +1722,7 @@ fn bench_virtual_manifest_all_implied() {
             members = ["bar", "baz"]
         "#,
         )
-        .file(
-            "bar/Cargo.toml",
-            r#"
-            [project]
-            name = "bar"
-            version = "0.1.0"
-        "#,
-        )
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file(
             "bar/src/lib.rs",
             r#"
@@ -1789,14 +1739,7 @@ fn bench_virtual_manifest_all_implied() {
             fn bench_bar(_: &mut Bencher) -> () { () }
         "#,
         )
-        .file(
-            "baz/Cargo.toml",
-            r#"
-            [project]
-            name = "baz"
-            version = "0.1.0"
-        "#,
-        )
+        .file("baz/Cargo.toml", &basic_manifest("baz", "0.1.0"))
         .file(
             "baz/src/lib.rs",
             r#"

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -7,7 +7,7 @@ use cargo::util::{process, ProcessBuilder};
 use support::{is_nightly, rustc_host, sleep_ms};
 use support::paths::{root, CargoPathExt};
 use support::ProjectBuilder;
-use support::{BASIC_MANIFEST, basic_bin_manifest, execs, main_file, project};
+use support::{basic_manifest, basic_bin_manifest, execs, main_file, project};
 use support::registry::Package;
 use support::ChannelChanger;
 use support::hamcrest::{assert_that, existing_dir, existing_file, is_not};
@@ -2414,7 +2414,7 @@ fn deletion_causes_failure() {
         .build();
 
     assert_that(p.cargo("build"), execs().with_status(0));
-    p.change_file("Cargo.toml", BASIC_MANIFEST);
+    p.change_file("Cargo.toml", basic_manifest("foo", "0.0.1"));
     assert_that(p.cargo("build"), execs().with_status(101));
 }
 

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -4,10 +4,10 @@ use std::io::prelude::*;
 
 use cargo::util::paths::dylib_path_envvar;
 use cargo::util::{process, ProcessBuilder};
-use support::{is_nightly, rustc_host, sleep_ms};
+use support::{basic_manifest, basic_bin_manifest, basic_lib_manifest, is_nightly, rustc_host, sleep_ms};
 use support::paths::{root, CargoPathExt};
 use support::ProjectBuilder;
-use support::{basic_manifest, basic_bin_manifest, execs, main_file, project};
+use support::{execs, main_file, project};
 use support::registry::Package;
 use support::ChannelChanger;
 use support::hamcrest::{assert_that, existing_dir, existing_file, is_not};
@@ -299,15 +299,7 @@ warning: file found to be present in multiple build targets: [..]main.rs
 #[test]
 fn cargo_compile_with_invalid_version() {
     let p = project()
-        .file(
-            "Cargo.toml",
-            r#"
-            [project]
-            name = "foo"
-            authors = []
-            version = "1.0"
-        "#,
-        )
+        .file("Cargo.toml", &basic_manifest("foo", "1.0"))
         .build();
 
     assert_that(
@@ -317,7 +309,7 @@ fn cargo_compile_with_invalid_version() {
 [ERROR] failed to parse manifest at `[..]`
 
 Caused by:
-  Expected dot for key `project.version`
+  Expected dot for key `package.version`
 ",
         ),
     )
@@ -326,15 +318,7 @@ Caused by:
 #[test]
 fn cargo_compile_with_invalid_package_name() {
     let p = project()
-        .file(
-            "Cargo.toml",
-            r#"
-            [package]
-            name = ""
-            authors = []
-            version = "0.0.0"
-        "#,
-        )
+        .file("Cargo.toml", &basic_manifest("", "0.0.0"))
         .build();
 
     assert_that(
@@ -603,20 +587,7 @@ fn cargo_compile_with_warnings_in_a_dep_package() {
         "#,
         )
         .file("src/foo.rs", &main_file(r#""{}", bar::gimme()"#, &["bar"]))
-        .file(
-            "bar/Cargo.toml",
-            r#"
-            [project]
-
-            name = "bar"
-            version = "0.5.0"
-            authors = ["wycats@example.com"]
-
-            [lib]
-
-            name = "bar"
-        "#,
-        )
+        .file("bar/Cargo.toml", &basic_lib_manifest("bar"))
         .file(
             "bar/src/bar.rs",
             r#"
@@ -687,16 +658,7 @@ fn cargo_compile_with_nested_deps_inferred() {
             }
         "#,
         )
-        .file(
-            "baz/Cargo.toml",
-            r#"
-            [project]
-
-            name = "baz"
-            version = "0.5.0"
-            authors = ["wycats@example.com"]
-        "#,
-        )
+        .file("baz/Cargo.toml", &basic_manifest("baz", "0.5.0"))
         .file(
             "baz/src/lib.rs",
             r#"
@@ -762,16 +724,7 @@ fn cargo_compile_with_nested_deps_correct_bin() {
             }
         "#,
         )
-        .file(
-            "baz/Cargo.toml",
-            r#"
-            [project]
-
-            name = "baz"
-            version = "0.5.0"
-            authors = ["wycats@example.com"]
-        "#,
-        )
+        .file("baz/Cargo.toml", &basic_manifest("baz", "0.5.0"))
         .file(
             "baz/src/lib.rs",
             r#"
@@ -838,20 +791,7 @@ fn cargo_compile_with_nested_deps_shorthand() {
             }
         "#,
         )
-        .file(
-            "baz/Cargo.toml",
-            r#"
-            [project]
-
-            name = "baz"
-            version = "0.5.0"
-            authors = ["wycats@example.com"]
-
-            [lib]
-
-            name = "baz"
-        "#,
-        )
+        .file("baz/Cargo.toml", &basic_lib_manifest("baz"))
         .file(
             "baz/src/baz.rs",
             r#"
@@ -924,20 +864,7 @@ fn cargo_compile_with_nested_deps_longhand() {
             }
         "#,
         )
-        .file(
-            "baz/Cargo.toml",
-            r#"
-            [project]
-
-            name = "baz"
-            version = "0.5.0"
-            authors = ["wycats@example.com"]
-
-            [lib]
-
-            name = "baz"
-        "#,
-        )
+        .file("baz/Cargo.toml", &basic_lib_manifest("baz"))
         .file(
             "baz/src/baz.rs",
             r#"
@@ -1070,15 +997,7 @@ fn cargo_compile_path_with_offline() {
         "#,
         )
         .file("src/lib.rs", "")
-        .file(
-            "bar/Cargo.toml",
-            r#"
-            [package]
-            name = "bar"
-            version = "0.0.1"
-            authors = []
-        "#,
-        )
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.0.1"))
         .file("bar/src/lib.rs", "")
         .build();
 
@@ -1093,14 +1012,7 @@ fn cargo_compile_path_with_offline() {
 #[test]
 fn cargo_compile_with_downloaded_dependency_with_offline() {
     Package::new("present_dep", "1.2.3")
-        .file(
-            "Cargo.toml",
-            r#"
-            [project]
-            name = "present_dep"
-            version = "1.2.3"
-        "#,
-        )
+        .file("Cargo.toml", &basic_manifest("present_dep", "1.2.3"))
         .file("src/lib.rs", "")
         .publish();
 
@@ -1191,14 +1103,7 @@ fn compile_offline_without_maxvers_cached() {
     Package::new("present_dep", "1.2.2").publish();
 
     Package::new("present_dep", "1.2.3")
-        .file(
-            "Cargo.toml",
-            r#"
-            [project]
-            name = "present_dep"
-            version = "1.2.3"
-        "#,
-        )
+        .file("Cargo.toml", &basic_manifest("present_dep", "1.2.3"))
         .file(
             "src/lib.rs",
             r#"pub fn get_version()->&'static str {"1.2.3"}"#,
@@ -1206,14 +1111,7 @@ fn compile_offline_without_maxvers_cached() {
         .publish();
 
     Package::new("present_dep", "1.2.5")
-        .file(
-            "Cargo.toml",
-            r#"
-            [project]
-            name = "present_dep"
-            version = "1.2.5"
-        "#,
-        )
+        .file("Cargo.toml", &basic_manifest("present_dep", "1.2.5"))
         .file("src/lib.rs", r#"pub fn get_version(){"1.2.5"}"#)
         .publish();
 
@@ -1444,15 +1342,7 @@ fn compile_path_dep_then_change_version() {
         "#,
         )
         .file("src/lib.rs", "")
-        .file(
-            "bar/Cargo.toml",
-            r#"
-            [package]
-            name = "bar"
-            version = "0.0.1"
-            authors = []
-        "#,
-        )
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.0.1"))
         .file("bar/src/lib.rs", "")
         .build();
 
@@ -1460,14 +1350,7 @@ fn compile_path_dep_then_change_version() {
 
     File::create(&p.root().join("bar/Cargo.toml"))
         .unwrap()
-        .write_all(
-            br#"
-        [package]
-        name = "bar"
-        version = "0.0.2"
-        authors = []
-    "#,
-        )
+        .write_all(basic_manifest("bar", "0.0.2").as_bytes())
         .unwrap();
 
     assert_that(p.cargo("build"), execs().with_status(0));
@@ -2401,35 +2284,18 @@ fn deletion_causes_failure() {
             fn main() {}
         "#,
         )
-        .file(
-            "bar/Cargo.toml",
-            r#"
-            [package]
-            name = "bar"
-            version = "0.0.1"
-            authors = []
-        "#,
-        )
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.0.1"))
         .file("bar/src/lib.rs", "")
         .build();
 
     assert_that(p.cargo("build"), execs().with_status(0));
-    p.change_file("Cargo.toml", basic_manifest("foo", "0.0.1"));
+    p.change_file("Cargo.toml", &basic_manifest("foo", "0.0.1"));
     assert_that(p.cargo("build"), execs().with_status(101));
 }
 
 #[test]
 fn bad_cargo_toml_in_target_dir() {
     let p = project()
-        .file(
-            "Cargo.toml",
-            r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-        "#,
-        )
         .file(
             "src/main.rs",
             r#"
@@ -2446,15 +2312,7 @@ fn bad_cargo_toml_in_target_dir() {
 #[test]
 fn lib_with_standard_name() {
     let p = project()
-        .file(
-            "Cargo.toml",
-            r#"
-            [package]
-            name = "syntax"
-            version = "0.0.1"
-            authors = []
-        "#,
-        )
+        .file("Cargo.toml", &basic_manifest("syntax", "0.0.1"))
         .file(
             "src/lib.rs",
             "
@@ -2694,15 +2552,7 @@ fn dep_no_libs() {
         "#,
         )
         .file("src/lib.rs", "pub fn bar() -> i32 { 1 }")
-        .file(
-            "bar/Cargo.toml",
-            r#"
-            [package]
-            name = "bar"
-            version = "0.0.0"
-            authors = []
-        "#,
-        )
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.0.0"))
         .file("bar/src/main.rs", "")
         .build();
     assert_that(foo.cargo("build"), execs().with_status(0));
@@ -2736,15 +2586,7 @@ fn recompile_space_in_name() {
 fn ignore_bad_directories() {
     use std::os::unix::prelude::*;
     let foo = project()
-        .file(
-            "Cargo.toml",
-            r#"
-            [package]
-            name = "foo"
-            version = "0.0.0"
-            authors = []
-        "#,
-        )
+        .file("Cargo.toml", &basic_manifest("foo", "0.0.0"))
         .file("src/lib.rs", "")
         .build();
     let dir = foo.root().join("tmp");
@@ -2761,15 +2603,7 @@ fn ignore_bad_directories() {
 #[test]
 fn bad_cargo_config() {
     let foo = project()
-        .file(
-            "Cargo.toml",
-            r#"
-            [package]
-            name = "foo"
-            version = "0.0.0"
-            authors = []
-        "#,
-        )
+        .file("Cargo.toml", &basic_manifest("foo", "0.0.0"))
         .file("src/lib.rs", "")
         .file(
             ".cargo/config",
@@ -2843,35 +2677,11 @@ fn cargo_platform_specific_dependency() {
             fn main() { build::build(); }
         "#,
         )
-        .file(
-            "dep/Cargo.toml",
-            r#"
-            [project]
-            name = "dep"
-            version = "0.5.0"
-            authors = ["wycats@example.com"]
-        "#,
-        )
+        .file("dep/Cargo.toml", &basic_manifest("dep", "0.5.0"))
         .file("dep/src/lib.rs", "pub fn dep() {}")
-        .file(
-            "build/Cargo.toml",
-            r#"
-            [project]
-            name = "build"
-            version = "0.5.0"
-            authors = ["wycats@example.com"]
-        "#,
-        )
+        .file("build/Cargo.toml", &basic_manifest("build", "0.5.0"))
         .file("build/src/lib.rs", "pub fn build() {}")
-        .file(
-            "dev/Cargo.toml",
-            r#"
-            [project]
-            name = "dev"
-            version = "0.5.0"
-            authors = ["wycats@example.com"]
-        "#,
-        )
+        .file("dev/Cargo.toml", &basic_manifest("dev", "0.5.0"))
         .file("dev/src/lib.rs", "pub fn dev() {}")
         .build();
 
@@ -2898,16 +2708,7 @@ fn bad_platform_specific_dependency() {
         "#,
         )
         .file("src/main.rs", &main_file(r#""{}", bar::gimme()"#, &["bar"]))
-        .file(
-            "bar/Cargo.toml",
-            r#"
-            [project]
-
-            name = "bar"
-            version = "0.5.0"
-            authors = ["wycats@example.com"]
-        "#,
-        )
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.5.0"))
         .file(
             "bar/src/lib.rs",
             r#"
@@ -2945,16 +2746,7 @@ fn cargo_platform_specific_dependency_wrong_platform() {
             fn main() {}
         "#,
         )
-        .file(
-            "bar/Cargo.toml",
-            r#"
-            [project]
-
-            name = "bar"
-            version = "0.5.0"
-            authors = ["wycats@example.com"]
-        "#,
-        )
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.5.0"))
         .file(
             "bar/src/lib.rs",
             r#"
@@ -3080,15 +2872,6 @@ fn example_as_proc_macro() {
 #[test]
 fn example_bin_same_name() {
     let p = project()
-        .file(
-            "Cargo.toml",
-            r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-        "#,
-        )
         .file("src/main.rs", "fn main() {}")
         .file("examples/foo.rs", "fn main() {}")
         .build();
@@ -3117,15 +2900,6 @@ fn example_bin_same_name() {
 #[test]
 fn compile_then_delete() {
     let p = project()
-        .file(
-            "Cargo.toml",
-            r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-        "#,
-        )
         .file("src/main.rs", "fn main() {}")
         .build();
 
@@ -3171,15 +2945,7 @@ fn transitive_dependencies_not_available() {
         "#,
         )
         .file("a/src/lib.rs", "extern crate bbbbb;")
-        .file(
-            "b/Cargo.toml",
-            r#"
-            [package]
-            name = "bbbbb"
-            version = "0.0.1"
-            authors = []
-        "#,
-        )
+        .file("b/Cargo.toml", &basic_manifest("bbbbb", "0.0.1"))
         .file("b/src/lib.rs", "")
         .build();
 
@@ -3261,15 +3027,7 @@ fn predictable_filenames() {
 #[test]
 fn dashes_to_underscores() {
     let p = project()
-        .file(
-            "Cargo.toml",
-            r#"
-            [package]
-            name = "foo-bar"
-            version = "0.0.1"
-            authors = []
-        "#,
-        )
+        .file("Cargo.toml", &basic_manifest("foo-bar", "0.0.1"))
         .file("src/lib.rs", "")
         .file("src/main.rs", "extern crate foo_bar; fn main() {}")
         .build();
@@ -3303,15 +3061,6 @@ fn dashes_in_crate_name_bad() {
 #[test]
 fn rustc_env_var() {
     let p = project()
-        .file(
-            "Cargo.toml",
-            r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-        "#,
-        )
         .file("src/lib.rs", "")
         .build();
 
@@ -3334,15 +3083,6 @@ Caused by:
 #[test]
 fn filtering() {
     let p = project()
-        .file(
-            "Cargo.toml",
-            r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-        "#,
-        )
         .file("src/lib.rs", "")
         .file("src/bin/a.rs", "fn main() {}")
         .file("src/bin/b.rs", "fn main() {}")
@@ -3366,15 +3106,6 @@ fn filtering() {
 #[test]
 fn filtering_implicit_bins() {
     let p = project()
-        .file(
-            "Cargo.toml",
-            r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-        "#,
-        )
         .file("src/lib.rs", "")
         .file("src/bin/a.rs", "fn main() {}")
         .file("src/bin/b.rs", "fn main() {}")
@@ -3392,15 +3123,6 @@ fn filtering_implicit_bins() {
 #[test]
 fn filtering_implicit_examples() {
     let p = project()
-        .file(
-            "Cargo.toml",
-            r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-        "#,
-        )
         .file("src/lib.rs", "")
         .file("src/bin/a.rs", "fn main() {}")
         .file("src/bin/b.rs", "fn main() {}")
@@ -3418,15 +3140,6 @@ fn filtering_implicit_examples() {
 #[test]
 fn ignore_dotfile() {
     let p = project()
-        .file(
-            "Cargo.toml",
-            r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-        "#,
-        )
         .file("src/bin/.a.rs", "")
         .file("src/bin/a.rs", "fn main() {}")
         .build();
@@ -3437,15 +3150,6 @@ fn ignore_dotfile() {
 #[test]
 fn ignore_dotdirs() {
     let p = project()
-        .file(
-            "Cargo.toml",
-            r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-        "#,
-        )
         .file("src/bin/a.rs", "fn main() {}")
         .file(".git/Cargo.toml", "")
         .file(".pc/dummy-fix.patch/Cargo.toml", "")
@@ -3457,15 +3161,6 @@ fn ignore_dotdirs() {
 #[test]
 fn dotdir_root() {
     let p = ProjectBuilder::new(root().join(".foo"))
-        .file(
-            "Cargo.toml",
-            r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-        "#,
-        )
         .file("src/bin/a.rs", "fn main() {}")
         .build();
     assert_that(p.cargo("build"), execs().with_status(0));
@@ -3474,15 +3169,6 @@ fn dotdir_root() {
 #[test]
 fn custom_target_dir_env() {
     let p = project()
-        .file(
-            "Cargo.toml",
-            r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-        "#,
-        )
         .file("src/main.rs", "fn main() {}")
         .build();
 
@@ -3542,15 +3228,6 @@ fn custom_target_dir_env() {
 #[test]
 fn custom_target_dir_line_parameter() {
     let p = project()
-        .file(
-            "Cargo.toml",
-            r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-        "#,
-        )
         .file("src/main.rs", "fn main() {}")
         .build();
 
@@ -3650,18 +3327,7 @@ fn build_multiple_packages() {
         "#,
         )
         .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
-        .file(
-            "d1/Cargo.toml",
-            r#"
-            [package]
-            name = "d1"
-            version = "0.0.1"
-            authors = []
-
-            [[bin]]
-                name = "d1"
-        "#,
-        )
+        .file("d1/Cargo.toml", &basic_bin_manifest("d1"))
         .file("d1/src/lib.rs", "")
         .file("d1/src/main.rs", "fn main() { println!(\"d1\"); }")
         .file(
@@ -3721,18 +3387,7 @@ fn invalid_spec() {
         "#,
         )
         .file("src/bin/foo.rs", &main_file(r#""i am foo""#, &[]))
-        .file(
-            "d1/Cargo.toml",
-            r#"
-            [package]
-            name = "d1"
-            version = "0.0.1"
-            authors = []
-
-            [[bin]]
-                name = "d1"
-        "#,
-        )
+        .file("d1/Cargo.toml", &basic_bin_manifest("d1"))
         .file("d1/src/lib.rs", "")
         .file("d1/src/main.rs", "fn main() { println!(\"d1\"); }")
         .build();
@@ -3801,16 +3456,7 @@ fn panic_abort_compiles_with_panic_abort() {
 #[test]
 fn explicit_color_config_is_propagated_to_rustc() {
     let p = project()
-        .file(
-            "Cargo.toml",
-            r#"
-                [package]
-
-                name = "test"
-                version = "0.0.0"
-                authors = []
-            "#,
-        )
+        .file("Cargo.toml", &basic_manifest("test", "0.0.0"))
         .file("src/lib.rs", "")
         .build();
     assert_that(
@@ -3852,16 +3498,7 @@ fn compiler_json_error_format() {
         )
         .file("build.rs", "fn main() { println!(\"cargo:rustc-cfg=xyz\") }")
         .file("src/main.rs", "fn main() { let unused = 92; }")
-        .file(
-            "bar/Cargo.toml",
-            r#"
-            [project]
-
-            name = "bar"
-            version = "0.5.0"
-            authors = ["wycats@example.com"]
-        "#,
-        )
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.5.0"))
         .file("bar/src/lib.rs", r#"fn dead() {}"#)
         .build();
 
@@ -4190,14 +3827,7 @@ fn build_all_workspace() {
             fn main() {}
         "#,
         )
-        .file(
-            "bar/Cargo.toml",
-            r#"
-            [project]
-            name = "bar"
-            version = "0.1.0"
-        "#,
-        )
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file(
             "bar/src/lib.rs",
             r#"
@@ -4236,28 +3866,14 @@ fn build_all_exclude() {
             fn main() {}
         "#,
         )
-        .file(
-            "bar/Cargo.toml",
-            r#"
-            [project]
-            name = "bar"
-            version = "0.1.0"
-        "#,
-        )
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file(
             "bar/src/lib.rs",
             r#"
             pub fn bar() {}
         "#,
         )
-        .file(
-            "baz/Cargo.toml",
-            r#"
-            [project]
-            name = "baz"
-            version = "0.1.0"
-        "#,
-        )
+        .file("baz/Cargo.toml", &basic_manifest("baz", "0.1.0"))
         .file(
             "baz/src/lib.rs",
             r#"
@@ -4299,14 +3915,7 @@ fn build_all_workspace_implicit_examples() {
         .file("src/bin/b.rs", "fn main() {}")
         .file("examples/c.rs", "fn main() {}")
         .file("examples/d.rs", "fn main() {}")
-        .file(
-            "bar/Cargo.toml",
-            r#"
-            [project]
-            name = "bar"
-            version = "0.1.0"
-        "#,
-        )
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file("bar/src/lib.rs", "")
         .file("bar/src/bin/e.rs", "fn main() {}")
         .file("bar/src/bin/f.rs", "fn main() {}")
@@ -4342,28 +3951,14 @@ fn build_all_virtual_manifest() {
             members = ["bar", "baz"]
         "#,
         )
-        .file(
-            "bar/Cargo.toml",
-            r#"
-            [project]
-            name = "bar"
-            version = "0.1.0"
-        "#,
-        )
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file(
             "bar/src/lib.rs",
             r#"
             pub fn bar() {}
         "#,
         )
-        .file(
-            "baz/Cargo.toml",
-            r#"
-            [project]
-            name = "baz"
-            version = "0.1.0"
-        "#,
-        )
+        .file("baz/Cargo.toml", &basic_manifest("baz", "0.1.0"))
         .file(
             "baz/src/lib.rs",
             r#"
@@ -4397,28 +3992,14 @@ fn build_virtual_manifest_all_implied() {
             members = ["bar", "baz"]
         "#,
         )
-        .file(
-            "bar/Cargo.toml",
-            r#"
-            [project]
-            name = "bar"
-            version = "0.1.0"
-        "#,
-        )
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file(
             "bar/src/lib.rs",
             r#"
             pub fn bar() {}
         "#,
         )
-        .file(
-            "baz/Cargo.toml",
-            r#"
-            [project]
-            name = "baz"
-            version = "0.1.0"
-        "#,
-        )
+        .file("baz/Cargo.toml", &basic_manifest("baz", "0.1.0"))
         .file(
             "baz/src/lib.rs",
             r#"
@@ -4452,28 +4033,14 @@ fn build_virtual_manifest_one_project() {
             members = ["bar", "baz"]
         "#,
         )
-        .file(
-            "bar/Cargo.toml",
-            r#"
-            [project]
-            name = "bar"
-            version = "0.1.0"
-        "#,
-        )
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file(
             "bar/src/lib.rs",
             r#"
             pub fn bar() {}
         "#,
         )
-        .file(
-            "baz/Cargo.toml",
-            r#"
-            [project]
-            name = "baz"
-            version = "0.1.0"
-        "#,
-        )
+        .file("baz/Cargo.toml", &basic_manifest("baz", "0.1.0"))
         .file(
             "baz/src/lib.rs",
             r#"
@@ -4505,27 +4072,13 @@ fn build_all_virtual_manifest_implicit_examples() {
             members = ["bar", "baz"]
         "#,
         )
-        .file(
-            "bar/Cargo.toml",
-            r#"
-            [project]
-            name = "bar"
-            version = "0.1.0"
-        "#,
-        )
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file("bar/src/lib.rs", "")
         .file("bar/src/bin/a.rs", "fn main() {}")
         .file("bar/src/bin/b.rs", "fn main() {}")
         .file("bar/examples/c.rs", "fn main() {}")
         .file("bar/examples/d.rs", "fn main() {}")
-        .file(
-            "baz/Cargo.toml",
-            r#"
-            [project]
-            name = "baz"
-            version = "0.1.0"
-        "#,
-        )
+        .file("baz/Cargo.toml", &basic_manifest("baz", "0.1.0"))
         .file("baz/src/lib.rs", "")
         .file("baz/src/bin/e.rs", "fn main() {}")
         .file("baz/src/bin/f.rs", "fn main() {}")
@@ -4642,17 +4195,7 @@ fn run_proper_binary() {
 #[test]
 fn run_proper_binary_main_rs() {
     let p = project()
-        .file(
-            "Cargo.toml",
-            r#"
-            [package]
-            name = "foo"
-            authors = []
-            version = "0.0.0"
-            [[bin]]
-            name = "foo"
-        "#,
-        )
+        .file("Cargo.toml", &basic_bin_manifest("foo"))
         .file("src/lib.rs", "")
         .file(
             "src/bin/main.rs",
@@ -4754,17 +4297,7 @@ fn run_proper_alias_binary_main_rs() {
 #[test]
 fn run_proper_binary_main_rs_as_foo() {
     let p = project()
-        .file(
-            "Cargo.toml",
-            r#"
-            [package]
-            name = "foo"
-            authors = []
-            version = "0.0.0"
-            [[bin]]
-            name = "foo"
-        "#,
-        )
+        .file("Cargo.toml", &basic_bin_manifest("foo"))
         .file(
             "src/foo.rs",
             r#"
@@ -4968,18 +4501,7 @@ fn explicit_bins_without_paths() {
 #[test]
 fn no_bin_in_src_with_lib() {
     let p = project()
-        .file(
-            "Cargo.toml",
-            r#"
-            [package]
-            name = "foo"
-            version = "0.1.0"
-            authors = []
-
-            [[bin]]
-            name = "foo"
-        "#,
-        )
+        .file("Cargo.toml", &basic_bin_manifest("foo"))
         .file("src/lib.rs", "")
         .file("src/foo.rs", "fn main() {}")
         .build();
@@ -4999,15 +4521,6 @@ Caused by:
 #[test]
 fn inferred_bins() {
     let p = project()
-        .file(
-            "Cargo.toml",
-            r#"
-            [package]
-            name = "foo"
-            version = "0.1.0"
-            authors = []
-        "#,
-        )
         .file("src/main.rs", "fn main() {}")
         .file("src/bin/bar.rs", "fn main() {}")
         .file("src/bin/baz/main.rs", "fn main() {}")
@@ -5023,15 +4536,6 @@ fn inferred_bins() {
 fn inferred_bins_duplicate_name() {
     // this should fail, because we have two binaries with the same name
     let p = project()
-        .file(
-            "Cargo.toml",
-            r#"
-            [package]
-            name = "foo"
-            version = "0.1.0"
-            authors = []
-        "#,
-        )
         .file("src/main.rs", "fn main() {}")
         .file("src/bin/bar.rs", "fn main() {}")
         .file("src/bin/bar/main.rs", "fn main() {}")
@@ -5071,15 +4575,6 @@ fn inferred_bin_path() {
 #[test]
 fn inferred_examples() {
     let p = project()
-        .file(
-            "Cargo.toml",
-            r#"
-            [package]
-            name = "foo"
-            version = "0.1.0"
-            authors = []
-        "#,
-        )
         .file("src/lib.rs", "fn main() {}")
         .file("examples/bar.rs", "fn main() {}")
         .file("examples/baz/main.rs", "fn main() {}")
@@ -5093,15 +4588,6 @@ fn inferred_examples() {
 #[test]
 fn inferred_tests() {
     let p = project()
-        .file(
-            "Cargo.toml",
-            r#"
-            [package]
-            name = "foo"
-            version = "0.1.0"
-            authors = []
-        "#,
-        )
         .file("src/lib.rs", "fn main() {}")
         .file("tests/bar.rs", "fn main() {}")
         .file("tests/baz/main.rs", "fn main() {}")
@@ -5116,15 +4602,6 @@ fn inferred_tests() {
 #[test]
 fn inferred_benchmarks() {
     let p = project()
-        .file(
-            "Cargo.toml",
-            r#"
-            [package]
-            name = "foo"
-            version = "0.1.0"
-            authors = []
-        "#,
-        )
         .file("src/lib.rs", "fn main() {}")
         .file("benches/bar.rs", "fn main() {}")
         .file("benches/baz/main.rs", "fn main() {}")
@@ -5211,14 +4688,6 @@ fn uplift_dsym_of_bin_on_mac() {
         return;
     }
     let p = project()
-        .file(
-            "Cargo.toml",
-            r#"
-            [project]
-            name = "foo"
-            version = "0.1.0"
-        "#,
-        )
         .file("src/main.rs", "fn main() { panic!(); }")
         .file("src/bin/b.rs", "fn main() { panic!(); }")
         .file("examples/c.rs", "fn main() { panic!(); }")
@@ -5251,14 +4720,6 @@ fn uplift_pdb_of_bin_on_windows() {
         return;
     }
     let p = project()
-        .file(
-            "Cargo.toml",
-            r#"
-            [project]
-            name = "foo"
-            version = "0.1.0"
-        "#,
-        )
         .file("src/main.rs", "fn main() { panic!(); }")
         .file("src/bin/b.rs", "fn main() { panic!(); }")
         .file("examples/c.rs", "fn main() { panic!(); }")
@@ -5283,15 +4744,6 @@ fn uplift_pdb_of_bin_on_windows() {
 #[test]
 fn build_filter_infer_profile() {
     let p = project()
-        .file(
-            "Cargo.toml",
-            r#"
-            [package]
-            name = "foo"
-            version = "0.1.0"
-            authors = []
-        "#,
-        )
         .file("src/lib.rs", "")
         .file("src/main.rs", "fn main() {}")
         .file("tests/t1.rs", "")
@@ -5361,15 +4813,6 @@ fn build_filter_infer_profile() {
 #[test]
 fn targets_selected_default() {
     let p = project()
-        .file(
-            "Cargo.toml",
-            r#"
-            [package]
-            name = "foo"
-            version = "0.1.0"
-            authors = []
-        "#,
-        )
         .file("src/main.rs", "fn main() {}")
         .build();
     assert_that(
@@ -5393,15 +4836,6 @@ fn targets_selected_default() {
 #[test]
 fn targets_selected_all() {
     let p = project()
-        .file(
-            "Cargo.toml",
-            r#"
-            [package]
-            name = "foo"
-            version = "0.1.0"
-            authors = []
-        "#,
-        )
         .file("src/main.rs", "fn main() {}")
         .build();
     assert_that(
@@ -5425,15 +4859,6 @@ fn targets_selected_all() {
 #[test]
 fn all_targets_no_lib() {
     let p = project()
-        .file(
-            "Cargo.toml",
-            r#"
-            [package]
-            name = "foo"
-            version = "0.1.0"
-            authors = []
-        "#,
-        )
         .file("src/main.rs", "fn main() {}")
         .build();
     assert_that(

--- a/tests/testsuite/build_auth.rs
+++ b/tests/testsuite/build_auth.rs
@@ -7,7 +7,7 @@ use std::thread;
 use git2;
 use bufstream::BufStream;
 use support::paths;
-use support::{execs, project};
+use support::{basic_manifest, execs, project};
 use support::hamcrest::assert_that;
 
 // Test that HTTP auth is offered from `credential.helper`
@@ -72,15 +72,7 @@ fn http_auth_offered() {
     });
 
     let script = project().at("script")
-        .file(
-            "Cargo.toml",
-            r#"
-            [project]
-            name = "script"
-            version = "0.0.1"
-            authors = []
-        "#,
-        )
+        .file("Cargo.toml", &basic_manifest("script", "0.1.0"))
         .file(
             "src/main.rs",
             r#"

--- a/tests/testsuite/build_lib.rs
+++ b/tests/testsuite/build_lib.rs
@@ -1,4 +1,4 @@
-use support::{basic_bin_manifest, execs, project, Project};
+use support::{basic_manifest, basic_bin_manifest, execs, project, Project};
 use support::hamcrest::assert_that;
 
 fn verbose_output_for_lib(p: &Project) -> String {
@@ -83,16 +83,7 @@ fn build_with_relative_cargo_home_path() {
         "#,
         )
         .file("src/test_dependency/src/lib.rs", r#" "#)
-        .file(
-            "src/test_dependency/Cargo.toml",
-            r#"
-            [package]
-
-            name = "test-dependency"
-            version = "0.0.1"
-            authors = ["wycats@example.com"]
-        "#,
-        )
+        .file("src/test_dependency/Cargo.toml", &basic_manifest("test-dependency", "0.0.1"))
         .build();
 
     assert_that(

--- a/tests/testsuite/build_plan.rs
+++ b/tests/testsuite/build_plan.rs
@@ -1,5 +1,5 @@
 use support::ChannelChanger;
-use support::{basic_bin_manifest, execs, main_file, project};
+use support::{basic_manifest, basic_bin_manifest, execs, main_file, project};
 use support::hamcrest::{assert_that, existing_file, is_not};
 
 #[test]
@@ -67,15 +67,7 @@ fn cargo_build_plan_single_dep() {
             fn test() { foo(); }
         "#,
         )
-        .file(
-            "bar/Cargo.toml",
-            r#"
-            [package]
-            name = "bar"
-            version = "0.0.1"
-            authors = []
-        "#,
-        )
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.0.1"))
         .file("bar/src/lib.rs", "pub fn bar() {}")
         .build();
     assert_that(

--- a/tests/testsuite/build_script.rs
+++ b/tests/testsuite/build_script.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 
 use cargo::util::paths::remove_dir_all;
 use support::{rustc_host, sleep_ms};
-use support::{cross_compile, execs, project};
+use support::{basic_manifest, cross_compile, execs, project};
 use support::paths::CargoPathExt;
 use support::registry::Package;
 use support::hamcrest::{assert_that, existing_dir, existing_file};
@@ -956,15 +956,7 @@ fn build_deps_simple() {
             fn main() {}
         ",
         )
-        .file(
-            "a/Cargo.toml",
-            r#"
-            [project]
-            name = "a"
-            version = "0.5.0"
-            authors = []
-        "#,
-        )
+        .file("a/Cargo.toml", &basic_manifest("a", "0.5.0"))
         .file("a/src/lib.rs", "")
         .build();
 
@@ -1012,15 +1004,7 @@ fn build_deps_not_for_normal() {
             fn main() {}
         ",
         )
-        .file(
-            "a/Cargo.toml",
-            r#"
-            [project]
-            name = "aaaaa"
-            version = "0.5.0"
-            authors = []
-        "#,
-        )
+        .file("a/Cargo.toml", &basic_manifest("aaaaa", "0.5.0"))
         .file("a/src/lib.rs", "")
         .build();
 
@@ -1083,15 +1067,7 @@ fn build_cmd_with_a_build_cmd() {
             "a/build.rs",
             "#[allow(unused_extern_crates)] extern crate b; fn main() {}",
         )
-        .file(
-            "b/Cargo.toml",
-            r#"
-            [project]
-            name = "b"
-            version = "0.5.0"
-            authors = []
-        "#,
-        )
+        .file("b/Cargo.toml", &basic_manifest("b", "0.5.0"))
         .file("b/src/lib.rs", "")
         .build();
 
@@ -1791,15 +1767,7 @@ fn test_duplicate_deps() {
             fn main() { bar::do_nothing() }
         "#,
         )
-        .file(
-            "bar/Cargo.toml",
-            r#"
-            [project]
-            name = "bar"
-            version = "0.1.0"
-            authors = []
-        "#,
-        )
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file("bar/src/lib.rs", "pub fn do_nothing() {}")
         .build();
 
@@ -3731,15 +3699,7 @@ fn rename_with_link_search_path() {
     assert_that(p.cargo("build"), execs().with_status(0));
 
     let p2 = project().at("bar")
-        .file(
-            "Cargo.toml",
-            r#"
-            [project]
-            name = "bar"
-            version = "0.5.0"
-            authors = []
-        "#,
-        )
+        .file("Cargo.toml", &basic_manifest("bar", "0.5.0"))
         .file(
             "build.rs",
             r#"
@@ -3890,15 +3850,7 @@ fn optional_build_script_dep() {
                 }
             "#,
         )
-        .file(
-            "bar/Cargo.toml",
-            r#"
-                [project]
-                name = "bar"
-                version = "0.5.0"
-                authors = []
-            "#,
-        )
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.5.0"))
         .file(
             "bar/src/lib.rs",
             r#"
@@ -3956,15 +3908,7 @@ fn optional_build_dep_and_required_normal_dep() {
                 }
             "#,
         )
-        .file(
-            "bar/Cargo.toml",
-            r#"
-                [project]
-                name = "bar"
-                version = "0.5.0"
-                authors = []
-            "#,
-        )
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.5.0"))
         .file(
             "bar/src/lib.rs",
             r#"

--- a/tests/testsuite/cargo_command.rs
+++ b/tests/testsuite/cargo_command.rs
@@ -8,7 +8,7 @@ use cargo;
 use support::cargo_process;
 use support::paths::{self, CargoPathExt};
 use support::registry::Package;
-use support::{basic_bin_manifest, cargo_exe, execs, project, Project};
+use support::{basic_manifest, basic_bin_manifest, cargo_exe, execs, project, Project};
 use support::hamcrest::{assert_that, existing_file};
 
 #[cfg_attr(windows, allow(dead_code))]
@@ -261,15 +261,7 @@ fn cargo_subcommand_env() {
 #[test]
 fn cargo_subcommand_args() {
     let p = project().at("cargo-foo")
-        .file(
-            "Cargo.toml",
-            r#"
-            [package]
-            name = "cargo-foo"
-            version = "0.0.1"
-            authors = []
-        "#,
-        )
+        .file("Cargo.toml", &basic_manifest("cargo-foo", "0.0.1"))
         .file(
             "src/main.rs",
             r#"

--- a/tests/testsuite/cfg.rs
+++ b/tests/testsuite/cfg.rs
@@ -4,7 +4,7 @@ use std::fmt;
 use cargo::util::{Cfg, CfgExpr};
 use support::rustc_host;
 use support::registry::Package;
-use support::{execs, project};
+use support::{basic_manifest, execs, project};
 use support::hamcrest::assert_that;
 
 macro_rules! c {
@@ -159,15 +159,7 @@ fn cfg_easy() {
         "#,
         )
         .file("src/lib.rs", "extern crate b;")
-        .file(
-            "b/Cargo.toml",
-            r#"
-            [package]
-            name = "b"
-            version = "0.0.1"
-            authors = []
-        "#,
-        )
+        .file("b/Cargo.toml", &basic_manifest("b", "0.0.1"))
         .file("b/src/lib.rs", "")
         .build();
     assert_that(p.cargo("build").arg("-v"), execs().with_status(0));
@@ -193,15 +185,7 @@ fn dont_include() {
             ),
         )
         .file("src/lib.rs", "")
-        .file(
-            "b/Cargo.toml",
-            r#"
-            [package]
-            name = "b"
-            version = "0.0.1"
-            authors = []
-        "#,
-        )
+        .file("b/Cargo.toml", &basic_manifest("b", "0.0.1"))
         .file("b/src/lib.rs", "")
         .build();
     assert_that(
@@ -402,15 +386,7 @@ fn multiple_match_ok() {
             ),
         )
         .file("src/lib.rs", "extern crate b;")
-        .file(
-            "b/Cargo.toml",
-            r#"
-            [package]
-            name = "b"
-            version = "0.0.1"
-            authors = []
-        "#,
-        )
+        .file("b/Cargo.toml", &basic_manifest("b", "0.0.1"))
         .file("b/src/lib.rs", "")
         .build();
     assert_that(p.cargo("build").arg("-v"), execs().with_status(0));
@@ -432,15 +408,7 @@ fn any_ok() {
         "#,
         )
         .file("src/lib.rs", "extern crate b;")
-        .file(
-            "b/Cargo.toml",
-            r#"
-            [package]
-            name = "b"
-            version = "0.0.1"
-            authors = []
-        "#,
-        )
+        .file("b/Cargo.toml", &basic_manifest("b", "0.0.1"))
         .file("b/src/lib.rs", "")
         .build();
     assert_that(p.cargo("build").arg("-v"), execs().with_status(0));
@@ -472,15 +440,7 @@ fn cfg_looks_at_rustflags_for_target() {
             fn main() { b::foo(); }
         "#,
         )
-        .file(
-            "b/Cargo.toml",
-            r#"
-            [package]
-            name = "b"
-            version = "0.0.1"
-            authors = []
-        "#,
-        )
+        .file("b/Cargo.toml", &basic_manifest("b", "0.0.1"))
         .file("b/src/lib.rs", "pub fn foo() {}")
         .build();
 

--- a/tests/testsuite/check.rs
+++ b/tests/testsuite/check.rs
@@ -2,7 +2,7 @@ use support::install::exe;
 use support::is_nightly;
 use support::paths::CargoPathExt;
 use support::registry::Package;
-use support::{execs, project};
+use support::{basic_manifest, execs, project};
 use glob::glob;
 use support::hamcrest::{assert_that, existing_file, is_not};
 
@@ -32,15 +32,7 @@ fn check_success() {
         )
         .build();
     let _bar = project().at("bar")
-        .file(
-            "Cargo.toml",
-            r#"
-            [package]
-            name = "bar"
-            version = "0.1.0"
-            authors = []
-        "#,
-        )
+        .file("Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file(
             "src/lib.rs",
             r#"
@@ -78,15 +70,7 @@ fn check_fail() {
         )
         .build();
     let _bar = project().at("bar")
-        .file(
-            "Cargo.toml",
-            r#"
-            [package]
-            name = "bar"
-            version = "0.1.0"
-            authors = []
-        "#,
-        )
+        .file("Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file(
             "src/lib.rs",
             r#"
@@ -190,15 +174,7 @@ fn check_build() {
         .build();
 
     let _bar = project().at("bar")
-        .file(
-            "Cargo.toml",
-            r#"
-            [package]
-            name = "bar"
-            version = "0.1.0"
-            authors = []
-        "#,
-        )
+        .file("Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file(
             "src/lib.rs",
             r#"
@@ -238,15 +214,7 @@ fn build_check() {
         .build();
 
     let _bar = project().at("bar")
-        .file(
-            "Cargo.toml",
-            r#"
-            [package]
-            name = "bar"
-            version = "0.1.0"
-            authors = []
-        "#,
-        )
+        .file("Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file(
             "src/lib.rs",
             r#"
@@ -406,15 +374,7 @@ fn rustc_check() {
         )
         .build();
     let _bar = project().at("bar")
-        .file(
-            "Cargo.toml",
-            r#"
-            [package]
-            name = "bar"
-            version = "0.1.0"
-            authors = []
-        "#,
-        )
+        .file("Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file(
             "src/lib.rs",
             r#"
@@ -459,15 +419,7 @@ fn rustc_check_err() {
         )
         .build();
     let _bar = project().at("bar")
-        .file(
-            "Cargo.toml",
-            r#"
-            [package]
-            name = "bar"
-            version = "0.1.0"
-            authors = []
-        "#,
-        )
+        .file("Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file(
             "src/lib.rs",
             r#"
@@ -506,15 +458,7 @@ fn check_all() {
         .file("examples/a.rs", "fn main() {}")
         .file("tests/a.rs", "")
         .file("src/lib.rs", "")
-        .file(
-            "b/Cargo.toml",
-            r#"
-            [package]
-            name = "b"
-            version = "0.0.1"
-            authors = []
-        "#,
-        )
+        .file("b/Cargo.toml", &basic_manifest("b", "0.0.1"))
         .file("b/src/main.rs", "fn main() {}")
         .file("b/src/lib.rs", "")
         .build();
@@ -540,28 +484,14 @@ fn check_virtual_all_implied() {
             members = ["bar", "baz"]
         "#,
         )
-        .file(
-            "bar/Cargo.toml",
-            r#"
-            [project]
-            name = "bar"
-            version = "0.1.0"
-        "#,
-        )
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file(
             "bar/src/lib.rs",
             r#"
             pub fn bar() {}
         "#,
         )
-        .file(
-            "baz/Cargo.toml",
-            r#"
-            [project]
-            name = "baz"
-            version = "0.1.0"
-        "#,
-        )
+        .file("baz/Cargo.toml", &basic_manifest("baz", "0.1.0"))
         .file(
             "baz/src/lib.rs",
             r#"

--- a/tests/testsuite/clean.rs
+++ b/tests/testsuite/clean.rs
@@ -1,6 +1,6 @@
 use std::env;
 
-use support::{basic_bin_manifest, execs, git, main_file, project};
+use support::{basic_manifest, basic_bin_manifest, execs, git, main_file, project};
 use support::registry::Package;
 use support::hamcrest::{assert_that, existing_dir, existing_file, is_not};
 
@@ -57,31 +57,9 @@ fn clean_multiple_packages() {
         "#,
         )
         .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
-        .file(
-            "d1/Cargo.toml",
-            r#"
-            [package]
-            name = "d1"
-            version = "0.0.1"
-            authors = []
-
-            [[bin]]
-                name = "d1"
-        "#,
-        )
+        .file("d1/Cargo.toml", &basic_bin_manifest("d1"))
         .file("d1/src/main.rs", "fn main() { println!(\"d1\"); }")
-        .file(
-            "d2/Cargo.toml",
-            r#"
-            [package]
-            name = "d2"
-            version = "0.0.1"
-            authors = []
-
-            [[bin]]
-                name = "d2"
-        "#,
-        )
+        .file("d2/Cargo.toml", &basic_bin_manifest("d2"))
         .file("d2/src/main.rs", "fn main() { println!(\"d2\"); }")
         .build();
 
@@ -123,15 +101,7 @@ fn clean_release() {
         "#,
         )
         .file("src/main.rs", "fn main() {}")
-        .file(
-            "a/Cargo.toml",
-            r#"
-            [package]
-            name = "a"
-            version = "0.0.1"
-            authors = []
-        "#,
-        )
+        .file("a/Cargo.toml", &basic_manifest("a", "0.0.1"))
         .file("a/src/lib.rs", "")
         .build();
 
@@ -177,15 +147,7 @@ fn clean_doc() {
         "#,
         )
         .file("src/main.rs", "fn main() {}")
-        .file(
-            "a/Cargo.toml",
-            r#"
-            [package]
-            name = "a"
-            version = "0.0.1"
-            authors = []
-        "#,
-        )
+        .file("a/Cargo.toml", &basic_manifest("a", "0.0.1"))
         .file("a/src/lib.rs", "")
         .build();
 
@@ -257,15 +219,7 @@ fn build_script() {
 fn clean_git() {
     let git = git::new("dep", |project| {
         project
-            .file(
-                "Cargo.toml",
-                r#"
-            [project]
-            name = "dep"
-            version = "0.5.0"
-            authors = []
-        "#,
-            )
+            .file("Cargo.toml", &basic_manifest("dep", "0.5.0"))
             .file("src/lib.rs", "")
     }).unwrap();
 

--- a/tests/testsuite/concurrent.rs
+++ b/tests/testsuite/concurrent.rs
@@ -12,7 +12,7 @@ use support;
 use support::install::{cargo_home, has_installed_exe};
 use support::git;
 use support::registry::Package;
-use support::{execs, project};
+use support::{basic_manifest, execs, project};
 use support::hamcrest::{assert_that, existing_file};
 
 fn pkg(name: &str, vers: &str) {
@@ -25,25 +25,9 @@ fn pkg(name: &str, vers: &str) {
 fn multiple_installs() {
     let p = project()
         .no_manifest()
-        .file(
-            "a/Cargo.toml",
-            r#"
-            [package]
-            name = "foo"
-            authors = []
-            version = "0.0.0"
-        "#,
-        )
+        .file("a/Cargo.toml", &basic_manifest("foo", "0.0.0"))
         .file("a/src/main.rs", "fn main() {}")
-        .file(
-            "b/Cargo.toml",
-            r#"
-            [package]
-            name = "bar"
-            authors = []
-            version = "0.0.0"
-        "#,
-        )
+        .file("b/Cargo.toml", &basic_manifest("bar", "0.0.0"))
         .file("b/src/main.rs", "fn main() {}");
     let p = p.build();
 
@@ -105,25 +89,9 @@ fn concurrent_installs() {
 fn one_install_should_be_bad() {
     let p = project()
         .no_manifest()
-        .file(
-            "a/Cargo.toml",
-            r#"
-            [package]
-            name = "foo"
-            authors = []
-            version = "0.0.0"
-        "#,
-        )
+        .file("a/Cargo.toml", &basic_manifest("foo", "0.0.0"))
         .file("a/src/main.rs", "fn main() {}")
-        .file(
-            "b/Cargo.toml",
-            r#"
-            [package]
-            name = "foo"
-            authors = []
-            version = "0.0.0"
-        "#,
-        )
+        .file("b/Cargo.toml", &basic_manifest("foo", "0.0.0"))
         .file("b/src/main.rs", "fn main() {}");
     let p = p.build();
 
@@ -234,15 +202,7 @@ fn multiple_registry_fetches() {
 fn git_same_repo_different_tags() {
     let a = git::new("dep", |project| {
         project
-            .file(
-                "Cargo.toml",
-                r#"
-            [project]
-            name = "dep"
-            version = "0.5.0"
-            authors = []
-        "#,
-            )
+            .file("Cargo.toml", &basic_manifest("dep", "0.5.0"))
             .file("src/lib.rs", "pub fn tag1() {}")
     }).unwrap();
 
@@ -325,15 +285,7 @@ fn git_same_repo_different_tags() {
 fn git_same_branch_different_revs() {
     let a = git::new("dep", |project| {
         project
-            .file(
-                "Cargo.toml",
-                r#"
-            [project]
-            name = "dep"
-            version = "0.5.0"
-            authors = []
-        "#,
-            )
+            .file("Cargo.toml", &basic_manifest("dep", "0.5.0"))
             .file("src/lib.rs", "pub fn f1() {}")
     }).unwrap();
 
@@ -545,29 +497,13 @@ fn debug_release_ok() {
 fn no_deadlock_with_git_dependencies() {
     let dep1 = git::new("dep1", |project| {
         project
-            .file(
-                "Cargo.toml",
-                r#"
-            [project]
-            name = "dep1"
-            version = "0.5.0"
-            authors = []
-        "#,
-            )
+            .file("Cargo.toml", &basic_manifest("dep1", "0.5.0"))
             .file("src/lib.rs", "")
     }).unwrap();
 
     let dep2 = git::new("dep2", |project| {
         project
-            .file(
-                "Cargo.toml",
-                r#"
-            [project]
-            name = "dep2"
-            version = "0.5.0"
-            authors = []
-        "#,
-            )
+            .file("Cargo.toml", &basic_manifest("dep2", "0.5.0"))
             .file("src/lib.rs", "")
     }).unwrap();
 

--- a/tests/testsuite/corrupt_git.rs
+++ b/tests/testsuite/corrupt_git.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 
 use cargo::util::paths as cargopaths;
 use support::paths;
-use support::{execs, git, project};
+use support::{basic_manifest, execs, git, project};
 use support::hamcrest::assert_that;
 
 #[test]
@@ -11,15 +11,7 @@ fn deleting_database_files() {
     let project = project();
     let git_project = git::new("bar", |project| {
         project
-            .file(
-                "Cargo.toml",
-                r#"
-                [project]
-                name = "bar"
-                version = "0.5.0"
-                authors = []
-            "#,
-            )
+            .file("Cargo.toml", &basic_manifest("bar", "0.5.0"))
             .file("src/lib.rs", "")
     }).unwrap();
 
@@ -83,15 +75,7 @@ fn deleting_checkout_files() {
     let project = project();
     let git_project = git::new("bar", |project| {
         project
-            .file(
-                "Cargo.toml",
-                r#"
-                [project]
-                name = "bar"
-                version = "0.5.0"
-                authors = []
-            "#,
-            )
+            .file("Cargo.toml", &basic_manifest("bar", "0.5.0"))
             .file("src/lib.rs", "")
     }).unwrap();
 

--- a/tests/testsuite/cross_compile.rs
+++ b/tests/testsuite/cross_compile.rs
@@ -1,6 +1,6 @@
 use cargo::util::process;
 use support::{is_nightly, rustc_host};
-use support::{basic_bin_manifest, cross_compile, execs, project};
+use support::{basic_manifest, basic_bin_manifest, cross_compile, execs, project};
 use support::hamcrest::{assert_that, existing_file};
 
 #[test]
@@ -148,15 +148,7 @@ fn simple_deps() {
         )
         .build();
     let _p2 = project().at("bar")
-        .file(
-            "Cargo.toml",
-            r#"
-            [package]
-            name = "bar"
-            version = "0.0.1"
-            authors = []
-        "#,
-        )
+        .file("Cargo.toml", &basic_manifest("bar", "0.0.1"))
         .file("src/lib.rs", "pub fn bar() {}")
         .build();
 
@@ -252,15 +244,7 @@ fn plugin_deps() {
         )
         .build();
     let _baz = project().at("baz")
-        .file(
-            "Cargo.toml",
-            r#"
-            [package]
-            name = "baz"
-            version = "0.0.1"
-            authors = []
-        "#,
-        )
+        .file("Cargo.toml", &basic_manifest("baz", "0.0.1"))
         .file("src/lib.rs", "pub fn baz() -> i32 { 1 }")
         .build();
 
@@ -363,15 +347,7 @@ fn plugin_to_the_max() {
         )
         .build();
     let _baz = project().at("baz")
-        .file(
-            "Cargo.toml",
-            r#"
-            [package]
-            name = "baz"
-            version = "0.0.1"
-            authors = []
-        "#,
-        )
+        .file("Cargo.toml",  &basic_manifest("baz", "0.0.1"))
         .file("src/lib.rs", "pub fn baz() -> i32 { 1 }")
         .build();
 
@@ -912,15 +888,7 @@ fn build_deps_for_the_right_arch() {
         "#,
         )
         .file("src/main.rs", "extern crate d2; fn main() {}")
-        .file(
-            "d1/Cargo.toml",
-            r#"
-            [package]
-            name = "d1"
-            version = "0.0.0"
-            authors = []
-        "#,
-        )
+        .file("d1/Cargo.toml",  &basic_manifest("d1", "0.0.0"))
         .file(
             "d1/src/lib.rs",
             "
@@ -1104,15 +1072,7 @@ fn build_script_with_platform_specific_dependencies() {
             extern crate d2;
         ",
         )
-        .file(
-            "d2/Cargo.toml",
-            r#"
-            [package]
-            name = "d2"
-            version = "0.0.0"
-            authors = []
-        "#,
-        )
+        .file("d2/Cargo.toml",  &basic_manifest("d2", "0.0.0"))
         .file("d2/src/lib.rs", "")
         .build();
 
@@ -1179,15 +1139,7 @@ fn platform_specific_dependencies_do_not_leak() {
             ),
         )
         .file("d1/src/lib.rs", "extern crate d2;")
-        .file(
-            "d2/Cargo.toml",
-            r#"
-            [package]
-            name = "d2"
-            version = "0.0.0"
-            authors = []
-        "#,
-        )
+        .file("d1/Cargo.toml",  &basic_manifest("d1", "0.0.0"))
         .file("d2/src/lib.rs", "")
         .build();
 

--- a/tests/testsuite/custom_target.rs
+++ b/tests/testsuite/custom_target.rs
@@ -1,5 +1,5 @@
 use support::is_nightly;
-use support::{execs, project};
+use support::{basic_manifest, execs, project};
 use support::hamcrest::assert_that;
 
 #[test]
@@ -101,16 +101,7 @@ fn custom_target_dependency() {
             unsafe auto trait Freeze {}
         "#,
         )
-        .file(
-            "bar/Cargo.toml",
-            r#"
-            [package]
-
-            name = "bar"
-            version = "0.0.1"
-            authors = ["author@example.com"]
-        "#,
-        )
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.0.1"))
         .file(
             "bar/src/lib.rs",
             r#"

--- a/tests/testsuite/directory.rs
+++ b/tests/testsuite/directory.rs
@@ -8,7 +8,7 @@ use support::cargo_process;
 use support::git;
 use support::paths;
 use support::registry::{cksum, Package};
-use support::{execs, project, ProjectBuilder};
+use support::{basic_manifest, execs, project, ProjectBuilder};
 use support::hamcrest::assert_that;
 
 fn setup() {
@@ -78,15 +78,7 @@ fn simple() {
     setup();
 
     VendorPackage::new("bar")
-        .file(
-            "Cargo.toml",
-            r#"
-            [package]
-            name = "bar"
-            version = "0.1.0"
-            authors = []
-        "#,
-        )
+        .file("Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file("src/lib.rs", "pub fn bar() {}")
         .build();
 
@@ -229,15 +221,6 @@ fn install_without_feature_dep() {
     setup();
 
     VendorPackage::new("foo")
-        .file(
-            "Cargo.toml",
-            r#"
-            [package]
-            name = "foo"
-            version = "0.1.0"
-            authors = []
-        "#,
-        )
         .file("src/lib.rs", "pub fn foo() {}")
         .build();
 
@@ -251,7 +234,7 @@ fn install_without_feature_dep() {
             authors = []
 
             [dependencies]
-            foo = "0.1.0"
+            foo = "0.0.1"
             baz = { version = "9.8.7", optional = true }
 
             [features]
@@ -274,7 +257,7 @@ fn install_without_feature_dep() {
         cargo_process().arg("install").arg("bar"),
         execs().with_status(0).with_stderr(
             "  Installing bar v0.1.0
-   Compiling foo v0.1.0
+   Compiling foo v0.0.1
    Compiling bar v0.1.0
     Finished release [optimized] target(s) in [..]s
   Installing [..]bar[..]
@@ -332,29 +315,13 @@ fn multiple() {
     setup();
 
     VendorPackage::new("bar-0.1.0")
-        .file(
-            "Cargo.toml",
-            r#"
-            [package]
-            name = "bar"
-            version = "0.1.0"
-            authors = []
-        "#,
-        )
+        .file("Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file("src/lib.rs", "pub fn bar() {}")
         .file(".cargo-checksum", "")
         .build();
 
     VendorPackage::new("bar-0.2.0")
-        .file(
-            "Cargo.toml",
-            r#"
-            [package]
-            name = "bar"
-            version = "0.2.0"
-            authors = []
-        "#,
-        )
+        .file("Cargo.toml", &basic_manifest("bar", "0.2.0"))
         .file("src/lib.rs", "pub fn bar() {}")
         .file(".cargo-checksum", "")
         .build();
@@ -443,15 +410,7 @@ fn crates_io_then_directory() {
     setup();
 
     let mut v = VendorPackage::new("bar");
-    v.file(
-        "Cargo.toml",
-        r#"
-        [package]
-        name = "bar"
-        version = "0.1.0"
-        authors = []
-    "#,
-    );
+    v.file("Cargo.toml", &basic_manifest("bar", "0.1.0"));
     v.file("src/lib.rs", "pub fn bar() -> u32 { 1 }");
     v.cksum.package = Some(cksum);
     v.build();
@@ -492,15 +451,7 @@ fn crates_io_then_bad_checksum() {
     setup();
 
     VendorPackage::new("bar")
-        .file(
-            "Cargo.toml",
-            r#"
-            [package]
-            name = "bar"
-            version = "0.1.0"
-            authors = []
-        "#,
-        )
+        .file("Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file("src/lib.rs", "")
         .build();
 
@@ -528,15 +479,7 @@ fn bad_file_checksum() {
     setup();
 
     VendorPackage::new("bar")
-        .file(
-            "Cargo.toml",
-            r#"
-            [package]
-            name = "bar"
-            version = "0.1.0"
-            authors = []
-        "#,
-        )
+        .file("Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file("src/lib.rs", "")
         .build();
 
@@ -580,15 +523,7 @@ fn only_dot_files_ok() {
     setup();
 
     VendorPackage::new("bar")
-        .file(
-            "Cargo.toml",
-            r#"
-            [package]
-            name = "bar"
-            version = "0.1.0"
-            authors = []
-        "#,
-        )
+        .file("Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file("src/lib.rs", "")
         .build();
     VendorPackage::new("foo").no_manifest().file(".bar", "").build();
@@ -617,15 +552,7 @@ fn random_files_ok() {
     setup();
 
     VendorPackage::new("bar")
-        .file(
-            "Cargo.toml",
-            r#"
-            [package]
-            name = "bar"
-            version = "0.1.0"
-            authors = []
-        "#,
-        )
+        .file("Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file("src/lib.rs", "")
         .build();
     VendorPackage::new("foo")
@@ -656,27 +583,12 @@ fn random_files_ok() {
 #[test]
 fn git_lock_file_doesnt_change() {
     let git = git::new("git", |p| {
-        p.file(
-            "Cargo.toml",
-            r#"
-            [project]
-            name = "git"
-            version = "0.5.0"
-            authors = []
-        "#,
-        ).file("src/lib.rs", "")
+        p.file("Cargo.toml", &basic_manifest("git", "0.5.0"))
+        .file("src/lib.rs", "")
     }).unwrap();
 
     VendorPackage::new("git")
-        .file(
-            "Cargo.toml",
-            r#"
-            [package]
-            name = "git"
-            version = "0.5.0"
-            authors = []
-        "#,
-        )
+        .file("Cargo.toml", &basic_manifest("git", "0.5.0"))
         .file("src/lib.rs", "")
         .disable_checksum()
         .build();
@@ -740,15 +652,7 @@ fn git_lock_file_doesnt_change() {
 #[test]
 fn git_override_requires_lockfile() {
     VendorPackage::new("git")
-        .file(
-            "Cargo.toml",
-            r#"
-            [package]
-            name = "git"
-            version = "0.5.0"
-            authors = []
-        "#,
-        )
+        .file("Cargo.toml", &basic_manifest("git", "0.5.0"))
         .file("src/lib.rs", "")
         .disable_checksum()
         .build();

--- a/tests/testsuite/doc.rs
+++ b/tests/testsuite/doc.rs
@@ -4,7 +4,7 @@ use std::fs::{self, File};
 use std::io::Read;
 
 use support::{is_nightly, rustc_host, ChannelChanger};
-use support::{basic_lib_manifest, execs, git, project, path2url};
+use support::{basic_manifest, basic_lib_manifest, execs, git, project, path2url};
 use support::paths::CargoPathExt;
 use support::registry::Package;
 use support::hamcrest::{assert_that, existing_dir, existing_file, is_not};
@@ -122,15 +122,7 @@ fn doc_deps() {
             pub fn foo() {}
         "#,
         )
-        .file(
-            "bar/Cargo.toml",
-            r#"
-            [package]
-            name = "bar"
-            version = "0.0.1"
-            authors = []
-        "#,
-        )
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.0.1"))
         .file(
             "bar/src/lib.rs",
             r#"
@@ -203,15 +195,7 @@ fn doc_no_deps() {
             pub fn foo() {}
         "#,
         )
-        .file(
-            "bar/Cargo.toml",
-            r#"
-            [package]
-            name = "bar"
-            version = "0.0.1"
-            authors = []
-        "#,
-        )
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.0.1"))
         .file(
             "bar/src/lib.rs",
             r#"
@@ -262,15 +246,7 @@ fn doc_only_bin() {
             pub fn foo() {}
         "#,
         )
-        .file(
-            "bar/Cargo.toml",
-            r#"
-            [package]
-            name = "bar"
-            version = "0.0.1"
-            authors = []
-        "#,
-        )
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.0.1"))
         .file(
             "bar/src/lib.rs",
             r#"
@@ -296,8 +272,7 @@ fn doc_multiple_targets_same_name_lib() {
             members = ["foo", "bar"]
         "#,
         )
-        .file(
-            "foo/Cargo.toml",
+        .file("foo/Cargo.toml",
             r#"
             [package]
             name = "foo"
@@ -669,15 +644,7 @@ fn doc_dash_p() {
         "#,
         )
         .file("a/src/lib.rs", "extern crate b;")
-        .file(
-            "b/Cargo.toml",
-            r#"
-            [package]
-            name = "b"
-            version = "0.0.1"
-            authors = []
-        "#,
-        )
+        .file("b/Cargo.toml", &basic_manifest("b", "0.0.1"))
         .file("b/src/lib.rs", "")
         .build();
 
@@ -755,15 +722,7 @@ fn target_specific_not_documented() {
         "#,
         )
         .file("src/lib.rs", "")
-        .file(
-            "a/Cargo.toml",
-            r#"
-            [package]
-            name = "a"
-            version = "0.0.1"
-            authors = []
-        "#,
-        )
+        .file("a/Cargo.toml", &basic_manifest("a", "0.0.1"))
         .file("a/src/lib.rs", "not rust")
         .build();
 
@@ -786,15 +745,7 @@ fn output_not_captured() {
         "#,
         )
         .file("src/lib.rs", "")
-        .file(
-            "a/Cargo.toml",
-            r#"
-            [package]
-            name = "a"
-            version = "0.0.1"
-            authors = []
-        "#,
-        )
+        .file("a/Cargo.toml", &basic_manifest("a", "0.0.1"))
         .file(
             "a/src/lib.rs",
             "
@@ -854,15 +805,7 @@ fn target_specific_documented() {
             pub fn foo() {}
         ",
         )
-        .file(
-            "a/Cargo.toml",
-            r#"
-            [package]
-            name = "a"
-            version = "0.0.1"
-            authors = []
-        "#,
-        )
+        .file("a/Cargo.toml", &basic_manifest("a", "0.0.1"))
         .file(
             "a/src/lib.rs",
             "
@@ -896,15 +839,7 @@ fn no_document_build_deps() {
             pub fn foo() {}
         ",
         )
-        .file(
-            "a/Cargo.toml",
-            r#"
-            [package]
-            name = "a"
-            version = "0.0.1"
-            authors = []
-        "#,
-        )
+        .file("a/Cargo.toml", &basic_manifest("a", "0.0.1"))
         .file(
             "a/src/lib.rs",
             "
@@ -963,30 +898,14 @@ fn doc_multiple_deps() {
             pub fn foo() {}
         "#,
         )
-        .file(
-            "bar/Cargo.toml",
-            r#"
-            [package]
-            name = "bar"
-            version = "0.0.1"
-            authors = []
-        "#,
-        )
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.0.1"))
         .file(
             "bar/src/lib.rs",
             r#"
             pub fn bar() {}
         "#,
         )
-        .file(
-            "baz/Cargo.toml",
-            r#"
-            [package]
-            name = "baz"
-            version = "0.0.1"
-            authors = []
-        "#,
-        )
+        .file("baz/Cargo.toml", &basic_manifest("baz", "0.0.1"))
         .file(
             "baz/src/lib.rs",
             r#"
@@ -1174,14 +1093,7 @@ fn doc_all_workspace() {
             fn main() {}
         "#,
         )
-        .file(
-            "bar/Cargo.toml",
-            r#"
-            [project]
-            name = "bar"
-            version = "0.1.0"
-        "#,
-        )
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file(
             "bar/src/lib.rs",
             r#"
@@ -1211,28 +1123,14 @@ fn doc_all_virtual_manifest() {
             members = ["bar", "baz"]
         "#,
         )
-        .file(
-            "bar/Cargo.toml",
-            r#"
-            [project]
-            name = "bar"
-            version = "0.1.0"
-        "#,
-        )
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file(
             "bar/src/lib.rs",
             r#"
             pub fn bar() {}
         "#,
         )
-        .file(
-            "baz/Cargo.toml",
-            r#"
-            [project]
-            name = "baz"
-            version = "0.1.0"
-        "#,
-        )
+        .file("baz/Cargo.toml", &basic_manifest("baz", "0.1.0"))
         .file(
             "baz/src/lib.rs",
             r#"
@@ -1261,28 +1159,14 @@ fn doc_virtual_manifest_all_implied() {
             members = ["bar", "baz"]
         "#,
         )
-        .file(
-            "bar/Cargo.toml",
-            r#"
-            [project]
-            name = "bar"
-            version = "0.1.0"
-        "#,
-        )
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file(
             "bar/src/lib.rs",
             r#"
             pub fn bar() {}
         "#,
         )
-        .file(
-            "baz/Cargo.toml",
-            r#"
-            [project]
-            name = "baz"
-            version = "0.1.0"
-        "#,
-        )
+        .file("baz/Cargo.toml", &basic_manifest("baz", "0.1.0"))
         .file(
             "baz/src/lib.rs",
             r#"
@@ -1355,23 +1239,9 @@ fn doc_workspace_open_help_message() {
             members = ["foo", "bar"]
         "#,
         )
-        .file(
-            "foo/Cargo.toml",
-            r#"
-            [package]
-            name = "foo"
-            version = "0.1.0"
-        "#,
-        )
+        .file("foo/Cargo.toml", &basic_manifest("foo", "0.1.0"))
         .file("foo/src/lib.rs", "")
-        .file(
-            "bar/Cargo.toml",
-            r#"
-            [package]
-            name = "bar"
-            version = "0.1.0"
-        "#,
-        )
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file("bar/src/lib.rs", "")
         .build();
 

--- a/tests/testsuite/features.rs
+++ b/tests/testsuite/features.rs
@@ -2,7 +2,7 @@ use std::fs::File;
 use std::io::prelude::*;
 
 use support::paths::CargoPathExt;
-use support::{BASIC_MANIFEST, execs, project};
+use support::{basic_manifest, execs, project};
 use support::ChannelChanger;
 use support::hamcrest::assert_that;
 use support::registry::Package;
@@ -151,7 +151,7 @@ failed to select a version for `bar` which could resolve this conflict",
         ),
     );
 
-    p.change_file("Cargo.toml", BASIC_MANIFEST);
+    p.change_file("Cargo.toml", basic_manifest("foo", "0.0.1"));
 
     assert_that(
         p.cargo("build").arg("--features").arg("test"),

--- a/tests/testsuite/features.rs
+++ b/tests/testsuite/features.rs
@@ -124,15 +124,7 @@ fn invalid4() {
         "#,
         )
         .file("src/main.rs", "")
-        .file(
-            "bar/Cargo.toml",
-            r#"
-            [project]
-            name = "bar"
-            version = "0.0.1"
-            authors = []
-        "#,
-        )
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.0.1"))
         .file("bar/src/lib.rs", "")
         .build();
 
@@ -151,7 +143,7 @@ failed to select a version for `bar` which could resolve this conflict",
         ),
     );
 
-    p.change_file("Cargo.toml", basic_manifest("foo", "0.0.1"));
+    p.change_file("Cargo.toml", &basic_manifest("foo", "0.0.1"));
 
     assert_that(
         p.cargo("build").arg("--features").arg("test"),
@@ -273,15 +265,7 @@ fn invalid8() {
         "#,
         )
         .file("src/main.rs", "")
-        .file(
-            "bar/Cargo.toml",
-            r#"
-            [package]
-            name = "bar"
-            version = "0.0.1"
-            authors = []
-        "#,
-        )
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.0.1"))
         .file("bar/src/lib.rs", "")
         .build();
 
@@ -309,15 +293,7 @@ fn invalid9() {
         "#,
         )
         .file("src/main.rs", "fn main() {}")
-        .file(
-            "bar/Cargo.toml",
-            r#"
-            [package]
-            name = "bar"
-            version = "0.0.1"
-            authors = []
-        "#,
-        )
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.0.1"))
         .file("bar/src/lib.rs", "")
         .build();
 
@@ -361,15 +337,7 @@ fn invalid10() {
         "#,
         )
         .file("bar/src/lib.rs", "")
-        .file(
-            "bar/baz/Cargo.toml",
-            r#"
-            [package]
-            name = "baz"
-            version = "0.0.1"
-            authors = []
-        "#,
-        )
+        .file("bar/baz/Cargo.toml", &basic_manifest("baz", "0.0.1"))
         .file("bar/baz/src/lib.rs", "")
         .build();
 
@@ -483,15 +451,7 @@ fn no_feature_doesnt_build() {
             fn main() {}
         "#,
         )
-        .file(
-            "bar/Cargo.toml",
-            r#"
-            [package]
-            name = "bar"
-            version = "0.0.1"
-            authors = []
-        "#,
-        )
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.0.1"))
         .file("bar/src/lib.rs", "pub fn bar() {}")
         .build();
 
@@ -557,15 +517,7 @@ fn default_feature_pulled_in() {
             fn main() {}
         "#,
         )
-        .file(
-            "bar/Cargo.toml",
-            r#"
-            [package]
-            name = "bar"
-            version = "0.0.1"
-            authors = []
-        "#,
-        )
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.0.1"))
         .file("bar/src/lib.rs", "pub fn bar() {}")
         .build();
 
@@ -689,25 +641,9 @@ fn groups_on_groups_on_groups() {
             fn main() {}
         "#,
         )
-        .file(
-            "bar/Cargo.toml",
-            r#"
-            [package]
-            name = "bar"
-            version = "0.0.1"
-            authors = []
-        "#,
-        )
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.0.1"))
         .file("bar/src/lib.rs", "pub fn bar() {}")
-        .file(
-            "baz/Cargo.toml",
-            r#"
-            [package]
-            name = "baz"
-            version = "0.0.1"
-            authors = []
-        "#,
-        )
+        .file("baz/Cargo.toml", &basic_manifest("baz", "0.0.1"))
         .file("baz/src/lib.rs", "pub fn baz() {}")
         .build();
 
@@ -755,25 +691,9 @@ fn many_cli_features() {
             fn main() {}
         "#,
         )
-        .file(
-            "bar/Cargo.toml",
-            r#"
-            [package]
-            name = "bar"
-            version = "0.0.1"
-            authors = []
-        "#,
-        )
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.0.1"))
         .file("bar/src/lib.rs", "pub fn bar() {}")
-        .file(
-            "baz/Cargo.toml",
-            r#"
-            [package]
-            name = "baz"
-            version = "0.0.1"
-            authors = []
-        "#,
-        )
+        .file("baz/Cargo.toml", &basic_manifest("baz", "0.0.1"))
         .file("baz/src/lib.rs", "pub fn baz() {}")
         .build();
 
@@ -1040,15 +960,7 @@ fn everything_in_the_lockfile() {
         "#,
         )
         .file("d1/src/lib.rs", "")
-        .file(
-            "d2/Cargo.toml",
-            r#"
-            [package]
-            name = "d2"
-            version = "0.0.2"
-            authors = []
-        "#,
-        )
+        .file("d2/Cargo.toml", &basic_manifest("d2", "0.0.2"))
         .file("d2/src/lib.rs", "")
         .file(
             "d3/Cargo.toml",
@@ -1218,15 +1130,7 @@ fn optional_and_dev_dep() {
         "#,
         )
         .file("src/lib.rs", "")
-        .file(
-            "foo/Cargo.toml",
-            r#"
-            [package]
-            name = "foo"
-            version = "0.1.0"
-            authors = []
-        "#,
-        )
+        .file("foo/Cargo.toml", &basic_manifest("foo", "0.1.0"))
         .file("foo/src/lib.rs", "")
         .build();
 
@@ -1431,15 +1335,7 @@ fn all_features_flag_enables_all_features() {
             }
         "#,
         )
-        .file(
-            "baz/Cargo.toml",
-            r#"
-            [package]
-            name = "baz"
-            version = "0.0.1"
-            authors = []
-        "#,
-        )
+        .file("baz/Cargo.toml", &basic_manifest("baz", "0.0.1"))
         .file("baz/src/lib.rs", "pub fn baz() {}")
         .build();
 
@@ -1479,25 +1375,9 @@ fn many_cli_features_comma_delimited() {
             fn main() {}
         "#,
         )
-        .file(
-            "bar/Cargo.toml",
-            r#"
-            [package]
-            name = "bar"
-            version = "0.0.1"
-            authors = []
-        "#,
-        )
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.0.1"))
         .file("bar/src/lib.rs", "pub fn bar() {}")
-        .file(
-            "baz/Cargo.toml",
-            r#"
-            [package]
-            name = "baz"
-            version = "0.0.1"
-            authors = []
-        "#,
-        )
+        .file("baz/Cargo.toml", &basic_manifest("baz", "0.0.1"))
         .file("baz/src/lib.rs", "pub fn baz() {}")
         .build();
 
@@ -1557,45 +1437,13 @@ fn many_cli_features_comma_and_space_delimited() {
             fn main() {}
         "#,
         )
-        .file(
-            "bar/Cargo.toml",
-            r#"
-            [package]
-            name = "bar"
-            version = "0.0.1"
-            authors = []
-        "#,
-        )
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.0.1"))
         .file("bar/src/lib.rs", "pub fn bar() {}")
-        .file(
-            "baz/Cargo.toml",
-            r#"
-            [package]
-            name = "baz"
-            version = "0.0.1"
-            authors = []
-        "#,
-        )
+        .file("baz/Cargo.toml", &basic_manifest("baz", "0.0.1"))
         .file("baz/src/lib.rs", "pub fn baz() {}")
-        .file(
-            "bam/Cargo.toml",
-            r#"
-            [package]
-            name = "bam"
-            version = "0.0.1"
-            authors = []
-        "#,
-        )
+        .file("bam/Cargo.toml", &basic_manifest("bam", "0.0.1"))
         .file("bam/src/lib.rs", "pub fn bam() {}")
-        .file(
-            "bap/Cargo.toml",
-            r#"
-            [package]
-            name = "bap"
-            version = "0.0.1"
-            authors = []
-        "#,
-        )
+        .file("bap/Cargo.toml", &basic_manifest("bap", "0.0.1"))
         .file("bap/src/lib.rs", "pub fn bap() {}")
         .build();
 

--- a/tests/testsuite/fetch.rs
+++ b/tests/testsuite/fetch.rs
@@ -1,6 +1,6 @@
 use support::rustc_host;
 use support::registry::Package;
-use support::{cross_compile, execs, project};
+use support::{basic_manifest, cross_compile, execs, project};
 use support::hamcrest::assert_that;
 
 #[test]
@@ -21,26 +21,12 @@ fn no_deps() {
 #[test]
 fn fetch_all_platform_dependencies_when_no_target_is_given() {
     Package::new("d1", "1.2.3")
-        .file(
-            "Cargo.toml",
-            r#"
-            [project]
-            name = "d1"
-            version = "1.2.3"
-        "#,
-        )
+        .file("Cargo.toml", &basic_manifest("d1", "1.2.3"))
         .file("src/lib.rs", "")
         .publish();
 
     Package::new("d2", "0.1.2")
-        .file(
-            "Cargo.toml",
-            r#"
-            [project]
-            name = "d2"
-            version = "0.1.2"
-        "#,
-        )
+        .file("Cargo.toml", &basic_manifest("d2", "0.1.2"))
         .file("src/lib.rs", "")
         .publish();
 
@@ -81,26 +67,12 @@ fn fetch_all_platform_dependencies_when_no_target_is_given() {
 #[test]
 fn fetch_platform_specific_dependencies() {
     Package::new("d1", "1.2.3")
-        .file(
-            "Cargo.toml",
-            r#"
-            [project]
-            name = "d1"
-            version = "1.2.3"
-        "#,
-        )
+        .file("Cargo.toml", &basic_manifest("d1", "1.2.3"))
         .file("src/lib.rs", "")
         .publish();
 
     Package::new("d2", "0.1.2")
-        .file(
-            "Cargo.toml",
-            r#"
-            [project]
-            name = "d2"
-            version = "0.1.2"
-        "#,
-        )
+        .file("Cargo.toml", &basic_manifest("d2", "0.1.2"))
         .file("src/lib.rs", "")
         .publish();
 

--- a/tests/testsuite/fix.rs
+++ b/tests/testsuite/fix.rs
@@ -3,7 +3,7 @@ use std::fs::File;
 use git2;
 
 use support::git;
-use support::{execs, project};
+use support::{basic_manifest, execs, project};
 use support::{is_nightly, ChannelChanger};
 use support::hamcrest::assert_that;
 
@@ -183,14 +183,7 @@ fn fix_path_deps() {
                 }
             "#,
         )
-        .file(
-            "bar/Cargo.toml",
-            r#"
-                [package]
-                name = "bar"
-                version = "0.1.0"
-            "#,
-        )
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file(
             "bar/src/lib.rs",
             r#"
@@ -236,14 +229,7 @@ fn do_not_fix_non_relevant_deps() {
             "#,
         )
         .file("foo/src/lib.rs", "")
-        .file(
-            "bar/Cargo.toml",
-            r#"
-                [package]
-                name = "bar"
-                version = "0.1.0"
-            "#,
-        )
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file(
             "bar/src/lib.rs",
             r#"
@@ -414,14 +400,7 @@ fn upgrade_extern_crate() {
                 }
             "#,
         )
-        .file(
-            "bar/Cargo.toml",
-            r#"
-                [package]
-                name = "bar"
-                version = "0.1.0"
-            "#,
-        )
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file("bar/src/lib.rs", "pub fn bar() {}")
         .build();
 

--- a/tests/testsuite/freshness.rs
+++ b/tests/testsuite/freshness.rs
@@ -4,7 +4,7 @@ use std::io::prelude::*;
 use support::sleep_ms;
 use support::paths::CargoPathExt;
 use support::registry::Package;
-use support::{execs, path2url, project};
+use support::{basic_manifest, execs, path2url, project};
 use support::hamcrest::{assert_that, existing_file};
 
 #[test]
@@ -141,15 +141,7 @@ fn rebuild_sub_package_then_while_package() {
         "#,
         )
         .file("a/src/lib.rs", "extern crate b;")
-        .file(
-            "b/Cargo.toml",
-            r#"
-            [package]
-            name = "b"
-            authors = []
-            version = "0.0.1"
-        "#,
-        )
+        .file("b/Cargo.toml", &basic_manifest("b", "0.0.1"))
         .file("b/src/lib.rs", "")
         .build();
 
@@ -635,15 +627,7 @@ fn no_rebuild_transitive_target_deps() {
         "#,
         )
         .file("b/src/lib.rs", "")
-        .file(
-            "c/Cargo.toml",
-            r#"
-            [package]
-            name = "c"
-            version = "0.0.1"
-            authors = []
-        "#,
-        )
+        .file("c/Cargo.toml", &basic_manifest("c", "0.0.1"))
         .file("c/src/lib.rs", "")
         .build();
 
@@ -754,15 +738,7 @@ fn same_build_dir_cached_packages() {
         "#,
         )
         .file("c/src/lib.rs", "")
-        .file(
-            "d/Cargo.toml",
-            r#"
-            [package]
-            name = "d"
-            version = "0.0.1"
-            authors = []
-        "#,
-        )
+        .file("d/Cargo.toml", &basic_manifest("d", "0.0.1"))
         .file("d/src/lib.rs", "")
         .file(
             ".cargo/config",
@@ -814,15 +790,7 @@ fn no_rebuild_if_build_artifacts_move_backwards_in_time() {
         "#,
         )
         .file("src/lib.rs", "")
-        .file(
-            "a/Cargo.toml",
-            r#"
-            [package]
-            name = "a"
-            version = "0.0.1"
-            authors = []
-        "#,
-        )
+        .file("a/Cargo.toml", &basic_manifest("a", "0.0.1"))
         .file("a/src/lib.rs", "")
         .build();
 
@@ -855,15 +823,7 @@ fn rebuild_if_build_artifacts_move_forward_in_time() {
         "#,
         )
         .file("src/lib.rs", "")
-        .file(
-            "a/Cargo.toml",
-            r#"
-            [package]
-            name = "a"
-            version = "0.0.1"
-            authors = []
-        "#,
-        )
+        .file("a/Cargo.toml", &basic_manifest("a", "0.0.1"))
         .file("a/src/lib.rs", "")
         .build();
 
@@ -966,15 +926,7 @@ fn no_rebuild_when_rename_dir() {
         "#,
         )
         .file("src/lib.rs", "")
-        .file(
-            "foo/Cargo.toml",
-            r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-        "#,
-        )
+        .file("foo/Cargo.toml", &basic_manifest("foo", "0.0.1"))
         .file("foo/src/lib.rs", "")
         .build();
 
@@ -1119,15 +1071,7 @@ fn change_panic_mode() {
             "#,
         )
         .file("src/lib.rs", "")
-        .file(
-            "bar/Cargo.toml",
-            r#"
-                [package]
-                name = "bar"
-                version = "0.1.1"
-                authors = []
-            "#,
-        )
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.1"))
         .file("bar/src/lib.rs", "")
         .file(
             "baz/Cargo.toml",
@@ -1196,14 +1140,7 @@ fn dont_rebuild_based_on_plugins() {
             "#,
         )
         .file("baz/src/main.rs", "fn main() {}")
-        .file(
-            "qux/Cargo.toml",
-            r#"
-                [package]
-                name = "qux"
-                version = "0.1.1"
-            "#,
-        )
+        .file("qux/Cargo.toml", &basic_manifest("qux", "0.1.1"))
         .file("qux/src/lib.rs", "")
         .build();
 
@@ -1236,14 +1173,7 @@ fn reuse_workspace_lib() {
             "#,
         )
         .file("src/lib.rs", "")
-        .file(
-            "baz/Cargo.toml",
-            r#"
-                [package]
-                name = "baz"
-                version = "0.1.1"
-            "#,
-        )
+        .file("baz/Cargo.toml", &basic_manifest("baz", "0.1.1"))
         .file("baz/src/lib.rs", "")
         .build();
 

--- a/tests/testsuite/generate_lockfile.rs
+++ b/tests/testsuite/generate_lockfile.rs
@@ -2,7 +2,7 @@ use std::fs::{self, File};
 use std::io::prelude::*;
 
 use support::registry::Package;
-use support::{execs, paths, project, ProjectBuilder};
+use support::{basic_manifest, execs, paths, project, ProjectBuilder};
 use support::ChannelChanger;
 use support::hamcrest::{assert_that, existing_file, is_not};
 
@@ -10,15 +10,7 @@ use support::hamcrest::{assert_that, existing_file, is_not};
 fn adding_and_removing_packages() {
     let p = project()
         .file("src/main.rs", "fn main() {}")
-        .file(
-            "bar/Cargo.toml",
-            r#"
-            [package]
-            name = "bar"
-            authors = []
-            version = "0.0.1"
-        "#,
-        )
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.0.1"))
         .file("bar/src/lib.rs", "")
         .build();
 
@@ -49,14 +41,7 @@ fn adding_and_removing_packages() {
     // change the dep
     File::create(&p.root().join("bar/Cargo.toml"))
         .unwrap()
-        .write_all(
-            br#"
-        [package]
-        name = "bar"
-        authors = []
-        version = "0.0.2"
-    "#,
-        )
+        .write_all(basic_manifest("bar", "0.0.2").as_bytes())
         .unwrap();
     assert_that(p.cargo("generate-lockfile"), execs().with_status(0));
     let lock3 = p.read_lockfile();
@@ -118,15 +103,7 @@ fn no_index_update() {
 fn preserve_metadata() {
     let p = project()
         .file("src/main.rs", "fn main() {}")
-        .file(
-            "bar/Cargo.toml",
-            r#"
-            [package]
-            name = "bar"
-            authors = []
-            version = "0.0.1"
-        "#,
-        )
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.0.1"))
         .file("bar/src/lib.rs", "")
         .build();
 
@@ -160,15 +137,7 @@ foo = "bar"
 fn preserve_line_endings_issue_2076() {
     let p = project()
         .file("src/main.rs", "fn main() {}")
-        .file(
-            "bar/Cargo.toml",
-            r#"
-            [package]
-            name = "bar"
-            authors = []
-            version = "0.0.1"
-        "#,
-        )
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.0.1"))
         .file("bar/src/lib.rs", "")
         .build();
 
@@ -233,12 +202,7 @@ fn duplicate_entries_in_lockfile() {
         .file("src/lib.rs", "")
         .build();
 
-    let common_toml = r#"
-        [package]
-        name = "common"
-        authors = []
-        version = "0.0.1"
-        "#;
+    let common_toml = &basic_manifest("common", "0.0.1");
 
     let _common_in_a = ProjectBuilder::new(paths::root().join("a/common"))
         .file("Cargo.toml", common_toml)

--- a/tests/testsuite/git.rs
+++ b/tests/testsuite/git.rs
@@ -10,7 +10,7 @@ use std::thread;
 use cargo::util::process;
 use support::sleep_ms;
 use support::paths::{self, CargoPathExt};
-use support::{basic_lib_manifest, execs, git, main_file, project, path2url};
+use support::{basic_manifest, basic_lib_manifest, execs, git, main_file, project, path2url};
 use support::ChannelChanger;
 use support::hamcrest::{assert_that, existing_file};
 
@@ -19,20 +19,7 @@ fn cargo_compile_simple_git_dep() {
     let project = project();
     let git_project = git::new("dep1", |project| {
         project
-            .file(
-                "Cargo.toml",
-                r#"
-                [project]
-
-                name = "dep1"
-                version = "0.5.0"
-                authors = ["carlhuda@example.com"]
-
-                [lib]
-
-                name = "dep1"
-            "#,
-            )
+            .file("Cargo.toml", &basic_lib_manifest("dep1"))
             .file(
                 "src/dep1.rs",
                 r#"
@@ -126,17 +113,7 @@ Caused by:
 fn cargo_compile_offline_with_cached_git_dep() {
     let git_project = git::new("dep1", |project| {
         project
-            .file(
-                "Cargo.toml",
-                r#"
-                [project]
-                name = "dep1"
-                version = "0.5.0"
-                authors = ["chabapok@example.com"]
-
-                [lib]
-                name = "dep1""#,
-            )
+            .file("Cargo.toml", &basic_lib_manifest("dep1"))
             .file(
                 "src/lib.rs",
                 r#"
@@ -283,20 +260,7 @@ fn cargo_compile_git_dep_branch() {
     let project = project();
     let git_project = git::new("dep1", |project| {
         project
-            .file(
-                "Cargo.toml",
-                r#"
-                [project]
-
-                name = "dep1"
-                version = "0.5.0"
-                authors = ["carlhuda@example.com"]
-
-                [lib]
-
-                name = "dep1"
-            "#,
-            )
+            .file("Cargo.toml", &basic_lib_manifest("dep1"))
             .file(
                 "src/dep1.rs",
                 r#"
@@ -368,20 +332,7 @@ fn cargo_compile_git_dep_tag() {
     let project = project();
     let git_project = git::new("dep1", |project| {
         project
-            .file(
-                "Cargo.toml",
-                r#"
-                [project]
-
-                name = "dep1"
-                version = "0.5.0"
-                authors = ["carlhuda@example.com"]
-
-                [lib]
-
-                name = "dep1"
-            "#,
-            )
+            .file("Cargo.toml", &basic_lib_manifest("dep1"))
             .file(
                 "src/dep1.rs",
                 r#"
@@ -487,20 +438,7 @@ fn cargo_compile_with_nested_paths() {
                 }
             "#,
             )
-            .file(
-                "vendor/dep2/Cargo.toml",
-                r#"
-                [project]
-
-                name = "dep2"
-                version = "0.5.0"
-                authors = ["carlhuda@example.com"]
-
-                [lib]
-
-                name = "dep2"
-            "#,
-            )
+            .file("vendor/dep2/Cargo.toml", &basic_lib_manifest("dep2"))
             .file(
                 "vendor/dep2/src/dep2.rs",
                 r#"
@@ -554,20 +492,7 @@ fn cargo_compile_with_nested_paths() {
 fn cargo_compile_with_malformed_nested_paths() {
     let git_project = git::new("dep1", |project| {
         project
-            .file(
-                "Cargo.toml",
-                r#"
-                [project]
-
-                name = "dep1"
-                version = "0.5.0"
-                authors = ["carlhuda@example.com"]
-
-                [lib]
-
-                name = "dep1"
-            "#,
-            )
+            .file("Cargo.toml", &basic_lib_manifest("dep1"))
             .file(
                 "src/dep1.rs",
                 r#"
@@ -627,20 +552,7 @@ fn cargo_compile_with_malformed_nested_paths() {
 fn cargo_compile_with_meta_package() {
     let git_project = git::new("meta-dep", |project| {
         project
-            .file(
-                "dep1/Cargo.toml",
-                r#"
-                [project]
-
-                name = "dep1"
-                version = "0.5.0"
-                authors = ["carlhuda@example.com"]
-
-                [lib]
-
-                name = "dep1"
-            "#,
-            )
+            .file("dep1/Cargo.toml", &basic_lib_manifest("dep1"))
             .file(
                 "dep1/src/dep1.rs",
                 r#"
@@ -649,20 +561,7 @@ fn cargo_compile_with_meta_package() {
                 }
             "#,
             )
-            .file(
-                "dep2/Cargo.toml",
-                r#"
-                [project]
-
-                name = "dep2"
-                version = "0.5.0"
-                authors = ["carlhuda@example.com"]
-
-                [lib]
-
-                name = "dep2"
-            "#,
-            )
+            .file("dep2/Cargo.toml", &basic_lib_manifest("dep2"))
             .file(
                 "dep2/src/dep2.rs",
                 r#"
@@ -771,15 +670,7 @@ Caused by:
 fn two_revs_same_deps() {
     let bar = git::new("meta-dep", |project| {
         project
-            .file(
-                "Cargo.toml",
-                r#"
-            [package]
-            name = "bar"
-            version = "0.0.0"
-            authors = []
-        "#,
-            )
+            .file("Cargo.toml", &basic_manifest("bar", "0.0.0"))
             .file("src/lib.rs", "pub fn bar() -> i32 { 1 }")
     }).unwrap();
 
@@ -1175,15 +1066,7 @@ Caused by:
 fn dep_with_submodule() {
     let project = project();
     let git_project = git::new("dep1", |project| {
-        project.file(
-            "Cargo.toml",
-            r#"
-                [package]
-                name = "dep1"
-                version = "0.5.0"
-                authors = ["carlhuda@example.com"]
-            "#,
-        )
+        project.file("Cargo.toml", &basic_manifest("dep1", "0.5.0"))
     }).unwrap();
     let git_project2 =
         git::new("dep2", |project| project.file("lib.rs", "pub fn dep() {}")).unwrap();
@@ -1238,15 +1121,7 @@ fn dep_with_submodule() {
 fn dep_with_bad_submodule() {
     let project = project();
     let git_project = git::new("dep1", |project| {
-        project.file(
-            "Cargo.toml",
-            r#"
-                [package]
-                name = "dep1"
-                version = "0.5.0"
-                authors = ["carlhuda@example.com"]
-            "#,
-        )
+        project.file("Cargo.toml", &basic_manifest("dep1", "0.5.0"))
     }).unwrap();
     let git_project2 =
         git::new("dep2", |project| project.file("lib.rs", "pub fn dep() {}")).unwrap();
@@ -1327,28 +1202,12 @@ fn two_deps_only_update_one() {
     let project = project();
     let git1 = git::new("dep1", |project| {
         project
-            .file(
-                "Cargo.toml",
-                r#"
-                [package]
-                name = "dep1"
-                version = "0.5.0"
-                authors = ["carlhuda@example.com"]
-            "#,
-            )
+            .file("Cargo.toml", &basic_manifest("dep1", "0.5.0"))
             .file("src/lib.rs", "")
     }).unwrap();
     let git2 = git::new("dep2", |project| {
         project
-            .file(
-                "Cargo.toml",
-                r#"
-                [package]
-                name = "dep2"
-                version = "0.5.0"
-                authors = ["carlhuda@example.com"]
-            "#,
-            )
+            .file("Cargo.toml", &basic_manifest("dep2", "0.5.0"))
             .file("src/lib.rs", "")
     }).unwrap();
 
@@ -1415,15 +1274,7 @@ fn two_deps_only_update_one() {
 fn stale_cached_version() {
     let bar = git::new("meta-dep", |project| {
         project
-            .file(
-                "Cargo.toml",
-                r#"
-            [package]
-            name = "bar"
-            version = "0.0.0"
-            authors = []
-        "#,
-            )
+            .file("Cargo.toml", &basic_manifest("bar", "0.0.0"))
             .file("src/lib.rs", "pub fn bar() -> i32 { 1 }")
     }).unwrap();
 
@@ -1520,15 +1371,7 @@ fn stale_cached_version() {
 fn dep_with_changed_submodule() {
     let project = project();
     let git_project = git::new("dep1", |project| {
-        project.file(
-            "Cargo.toml",
-            r#"
-                [package]
-                name = "dep1"
-                version = "0.5.0"
-                authors = ["carlhuda@example.com"]
-            "#,
-        )
+        project.file("Cargo.toml", &basic_manifest("dep1", "0.5.0"))
     }).unwrap();
 
     let git_project2 = git::new("dep2", |project| {
@@ -1646,15 +1489,7 @@ fn dep_with_changed_submodule() {
 fn dev_deps_with_testing() {
     let p2 = git::new("bar", |project| {
         project
-            .file(
-                "Cargo.toml",
-                r#"
-            [package]
-            name = "bar"
-            version = "0.5.0"
-            authors = ["wycats@example.com"]
-        "#,
-            )
+            .file("Cargo.toml", &basic_manifest("bar", "0.5.0"))
             .file(
                 "src/lib.rs",
                 r#"
@@ -1778,15 +1613,7 @@ fn git_build_cmd_freshness() {
 fn git_name_not_always_needed() {
     let p2 = git::new("bar", |project| {
         project
-            .file(
-                "Cargo.toml",
-                r#"
-            [package]
-            name = "bar"
-            version = "0.5.0"
-            authors = ["wycats@example.com"]
-        "#,
-            )
+            .file("Cargo.toml", &basic_manifest("bar", "0.5.0"))
             .file(
                 "src/lib.rs",
                 r#"
@@ -1839,15 +1666,7 @@ fn git_name_not_always_needed() {
 fn git_repo_changing_no_rebuild() {
     let bar = git::new("bar", |project| {
         project
-            .file(
-                "Cargo.toml",
-                r#"
-            [package]
-            name = "bar"
-            version = "0.5.0"
-            authors = ["wycats@example.com"]
-        "#,
-            )
+            .file("Cargo.toml", &basic_manifest("bar", "0.5.0"))
             .file("src/lib.rs", "pub fn bar() -> i32 { 1 }")
     }).unwrap();
 
@@ -2011,15 +1830,7 @@ fn git_dep_build_cmd() {
 fn fetch_downloads() {
     let bar = git::new("bar", |project| {
         project
-            .file(
-                "Cargo.toml",
-                r#"
-            [package]
-            name = "bar"
-            version = "0.5.0"
-            authors = ["wycats@example.com"]
-        "#,
-            )
+            .file("Cargo.toml", &basic_manifest("bar", "0.5.0"))
             .file("src/lib.rs", "pub fn bar() -> i32 { 1 }")
     }).unwrap();
 
@@ -2055,15 +1866,7 @@ fn fetch_downloads() {
 fn warnings_in_git_dep() {
     let bar = git::new("bar", |project| {
         project
-            .file(
-                "Cargo.toml",
-                r#"
-            [package]
-            name = "bar"
-            version = "0.5.0"
-            authors = ["wycats@example.com"]
-        "#,
-            )
+            .file("Cargo.toml", &basic_manifest("bar", "0.5.0"))
             .file("src/lib.rs", "fn unused() {}")
     }).unwrap();
 
@@ -2103,28 +1906,12 @@ fn warnings_in_git_dep() {
 fn update_ambiguous() {
     let bar1 = git::new("bar1", |project| {
         project
-            .file(
-                "Cargo.toml",
-                r#"
-            [package]
-            name = "bar"
-            version = "0.5.0"
-            authors = ["wycats@example.com"]
-        "#,
-            )
+            .file("Cargo.toml", &basic_manifest("bar", "0.5.0"))
             .file("src/lib.rs", "")
     }).unwrap();
     let bar2 = git::new("bar2", |project| {
         project
-            .file(
-                "Cargo.toml",
-                r#"
-            [package]
-            name = "bar"
-            version = "0.6.0"
-            authors = ["wycats@example.com"]
-        "#,
-            )
+            .file("Cargo.toml", &basic_manifest("bar", "0.6.0"))
             .file("src/lib.rs", "")
     }).unwrap();
     let baz = git::new("baz", |project| {
@@ -2188,25 +1975,9 @@ following:
 fn update_one_dep_in_repo_with_many_deps() {
     let bar = git::new("bar", |project| {
         project
-            .file(
-                "Cargo.toml",
-                r#"
-            [package]
-            name = "bar"
-            version = "0.5.0"
-            authors = ["wycats@example.com"]
-        "#,
-            )
+            .file("Cargo.toml", &basic_manifest("bar", "0.5.0"))
             .file("src/lib.rs", "")
-            .file(
-                "a/Cargo.toml",
-                r#"
-            [package]
-            name = "a"
-            version = "0.5.0"
-            authors = ["wycats@example.com"]
-        "#,
-            )
+            .file("a/Cargo.toml", &basic_manifest("a", "0.5.0"))
             .file("a/src/lib.rs", "")
     }).unwrap();
 
@@ -2244,15 +2015,7 @@ fn update_one_dep_in_repo_with_many_deps() {
 fn switch_deps_does_not_update_transitive() {
     let transitive = git::new("transitive", |project| {
         project
-            .file(
-                "Cargo.toml",
-                r#"
-            [package]
-            name = "transitive"
-            version = "0.5.0"
-            authors = ["wycats@example.com"]
-        "#,
-            )
+            .file("Cargo.toml", &basic_manifest("transitive", "0.5.0"))
             .file("src/lib.rs", "")
     }).unwrap();
     let dep1 = git::new("dep1", |project| {
@@ -2378,15 +2141,7 @@ fn update_one_source_updates_all_packages_in_that_git_source() {
         "#,
             )
             .file("src/lib.rs", "")
-            .file(
-                "a/Cargo.toml",
-                r#"
-            [package]
-            name = "a"
-            version = "0.5.0"
-            authors = []
-        "#,
-            )
+            .file("a/Cargo.toml", &basic_manifest("a", "0.5.0"))
             .file("a/src/lib.rs", "")
     }).unwrap();
 
@@ -2446,28 +2201,12 @@ fn update_one_source_updates_all_packages_in_that_git_source() {
 fn switch_sources() {
     let a1 = git::new("a1", |project| {
         project
-            .file(
-                "Cargo.toml",
-                r#"
-            [package]
-            name = "a"
-            version = "0.5.0"
-            authors = []
-        "#,
-            )
+            .file("Cargo.toml", &basic_manifest("a", "0.5.0"))
             .file("src/lib.rs", "")
     }).unwrap();
     let a2 = git::new("a2", |project| {
         project
-            .file(
-                "Cargo.toml",
-                r#"
-            [package]
-            name = "a"
-            version = "0.5.1"
-            authors = []
-        "#,
-            )
+            .file("Cargo.toml", &basic_manifest("a", "0.5.1"))
             .file("src/lib.rs", "")
     }).unwrap();
 
@@ -2583,15 +2322,8 @@ fn dont_require_submodules_are_checked_out() {
 #[test]
 fn doctest_same_name() {
     let a2 = git::new("a2", |p| {
-        p.file(
-            "Cargo.toml",
-            r#"
-            [project]
-            name = "a"
-            version = "0.5.0"
-            authors = []
-        "#,
-        ).file("src/lib.rs", "pub fn a2() {}")
+        p.file("Cargo.toml", &basic_manifest("a", "0.5.0"))
+         .file("src/lib.rs", "pub fn a2() {}")
     }).unwrap();
 
     let a1 = git::new("a1", |p| {
@@ -2642,15 +2374,8 @@ fn doctest_same_name() {
 #[test]
 fn lints_are_suppressed() {
     let a = git::new("a", |p| {
-        p.file(
-            "Cargo.toml",
-            r#"
-            [project]
-            name = "a"
-            version = "0.5.0"
-            authors = []
-        "#,
-        ).file(
+        p.file("Cargo.toml", &basic_manifest("a", "0.5.0"))
+         .file(
             "src/lib.rs",
             "
             use std::option;
@@ -2693,15 +2418,8 @@ fn lints_are_suppressed() {
 #[test]
 fn denied_lints_are_allowed() {
     let a = git::new("a", |p| {
-        p.file(
-            "Cargo.toml",
-            r#"
-            [project]
-            name = "a"
-            version = "0.5.0"
-            authors = []
-        "#,
-        ).file(
+        p.file("Cargo.toml", &basic_manifest("a", "0.5.0"))
+         .file(
             "src/lib.rs",
             "
             #![deny(warnings)]
@@ -2745,15 +2463,8 @@ fn denied_lints_are_allowed() {
 #[test]
 fn add_a_git_dep() {
     let git = git::new("git", |p| {
-        p.file(
-            "Cargo.toml",
-            r#"
-            [project]
-            name = "git"
-            version = "0.5.0"
-            authors = []
-        "#,
-        ).file("src/lib.rs", "")
+        p.file("Cargo.toml", &basic_manifest("git", "0.5.0"))
+         .file("src/lib.rs", "")
     }).unwrap();
 
     let p = project()
@@ -2774,15 +2485,7 @@ fn add_a_git_dep() {
             ),
         )
         .file("src/lib.rs", "")
-        .file(
-            "a/Cargo.toml",
-            r#"
-            [package]
-            name = "a"
-            version = "0.0.1"
-            authors = []
-        "#,
-        )
+        .file("a/Cargo.toml", &basic_manifest("a", "0.0.1"))
         .file("a/src/lib.rs", "")
         .build();
 
@@ -2812,25 +2515,10 @@ fn add_a_git_dep() {
 #[test]
 fn two_at_rev_instead_of_tag() {
     let git = git::new("git", |p| {
-        p.file(
-            "Cargo.toml",
-            r#"
-            [project]
-            name = "git1"
-            version = "0.5.0"
-            authors = []
-        "#,
-        ).file("src/lib.rs", "")
-            .file(
-                "a/Cargo.toml",
-                r#"
-            [project]
-            name = "git2"
-            version = "0.5.0"
-            authors = []
-        "#,
-            )
-            .file("a/src/lib.rs", "")
+        p.file("Cargo.toml", &basic_manifest("git1", "0.5.0"))
+         .file("src/lib.rs", "")
+         .file("a/Cargo.toml", &basic_manifest("git2", "0.5.0"))
+         .file("a/src/lib.rs", "")
     }).unwrap();
 
     // Make a tag corresponding to the current HEAD
@@ -3092,15 +2780,7 @@ fn invalid_git_dependency_manifest() {
 fn failed_submodule_checkout() {
     let project = project();
     let git_project = git::new("dep1", |project| {
-        project.file(
-            "Cargo.toml",
-            r#"
-                [package]
-                name = "dep1"
-                version = "0.5.0"
-                authors = [""]
-            "#,
-        )
+        project.file("Cargo.toml", &basic_manifest("dep1", "0.5.0"))
     }).unwrap();
 
     let git_project2 = git::new("dep2", |project| project.file("lib.rs", "")).unwrap();

--- a/tests/testsuite/install.rs
+++ b/tests/testsuite/install.rs
@@ -8,7 +8,7 @@ use support::cross_compile;
 use support::git;
 use support::paths;
 use support::registry::Package;
-use support::{execs, project};
+use support::{basic_manifest, execs, project};
 use support::ChannelChanger;
 use git2;
 use support::hamcrest::{assert_that, existing_dir, is_not};
@@ -142,15 +142,7 @@ warning: be sure to add `[..]` to your PATH to be able to run the installed bina
 #[test]
 fn installs_beta_version_by_explicit_name_from_git() {
     let p = git::repo(&paths::root().join("foo"))
-        .file(
-            "Cargo.toml",
-            r#"
-            [package]
-            name = "foo"
-            version = "0.3.0-beta.1"
-            authors = []
-        "#,
-        )
+        .file("Cargo.toml", &basic_manifest("foo", "0.3.0-beta.1"))
         .file("src/main.rs", "fn main() {}")
         .build();
 
@@ -301,25 +293,9 @@ Add --force to overwrite
 #[test]
 fn multiple_crates_error() {
     let p = git::repo(&paths::root().join("foo"))
-        .file(
-            "Cargo.toml",
-            r#"
-            [package]
-            name = "foo"
-            version = "0.1.0"
-            authors = []
-        "#,
-        )
+        .file("Cargo.toml", &basic_manifest("foo", "0.1.0"))
         .file("src/main.rs", "fn main() {}")
-        .file(
-            "a/Cargo.toml",
-            r#"
-            [package]
-            name = "bar"
-            version = "0.1.0"
-            authors = []
-        "#,
-        )
+        .file("a/Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file("a/src/main.rs", "fn main() {}")
         .build();
 
@@ -339,25 +315,9 @@ fn multiple_crates_error() {
 #[test]
 fn multiple_crates_select() {
     let p = git::repo(&paths::root().join("foo"))
-        .file(
-            "Cargo.toml",
-            r#"
-            [package]
-            name = "foo"
-            version = "0.1.0"
-            authors = []
-        "#,
-        )
+        .file("Cargo.toml", &basic_manifest("foo", "0.1.0"))
         .file("src/main.rs", "fn main() {}")
-        .file(
-            "a/Cargo.toml",
-            r#"
-            [package]
-            name = "bar"
-            version = "0.1.0"
-            authors = []
-        "#,
-        )
+        .file("a/Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file("a/src/main.rs", "fn main() {}")
         .build();
 
@@ -397,15 +357,7 @@ fn multiple_crates_auto_binaries() {
         "#,
         )
         .file("src/main.rs", "extern crate bar; fn main() {}")
-        .file(
-            "a/Cargo.toml",
-            r#"
-            [package]
-            name = "bar"
-            version = "0.1.0"
-            authors = []
-        "#,
-        )
+        .file("a/Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file("a/src/lib.rs", "")
         .build();
 
@@ -440,15 +392,7 @@ fn multiple_crates_auto_examples() {
             fn main() {}
         ",
         )
-        .file(
-            "a/Cargo.toml",
-            r#"
-            [package]
-            name = "bar"
-            version = "0.1.0"
-            authors = []
-        "#,
-        )
+        .file("a/Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file("a/src/lib.rs", "")
         .build();
 
@@ -478,15 +422,7 @@ fn no_binaries_or_examples() {
         "#,
         )
         .file("src/lib.rs", "")
-        .file(
-            "a/Cargo.toml",
-            r#"
-            [package]
-            name = "bar"
-            version = "0.1.0"
-            authors = []
-        "#,
-        )
+        .file("a/Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file("a/src/lib.rs", "")
         .build();
 
@@ -572,15 +508,7 @@ fn install_force() {
     );
 
     let p = project().at("foo2")
-        .file(
-            "Cargo.toml",
-            r#"
-            [package]
-            name = "foo"
-            version = "0.2.0"
-            authors = []
-        "#,
-        )
+        .file("Cargo.toml", &basic_manifest("foo", "0.2.0"))
         .file("src/main.rs", "fn main() {}")
         .build();
 
@@ -625,15 +553,7 @@ fn install_force_partial_overlap() {
     );
 
     let p = project().at("foo2")
-        .file(
-            "Cargo.toml",
-            r#"
-            [package]
-            name = "foo"
-            version = "0.2.0"
-            authors = []
-        "#,
-        )
+        .file("Cargo.toml", &basic_manifest("foo", "0.2.0"))
         .file("src/bin/foo-bin2.rs", "fn main() {}")
         .file("src/bin/foo-bin3.rs", "fn main() {}")
         .build();
@@ -683,15 +603,7 @@ fn install_force_bin() {
     );
 
     let p = project().at("foo2")
-        .file(
-            "Cargo.toml",
-            r#"
-            [package]
-            name = "foo"
-            version = "0.2.0"
-            authors = []
-        "#,
-        )
+        .file("Cargo.toml", &basic_manifest("foo", "0.2.0"))
         .file("src/bin/foo-bin1.rs", "fn main() {}")
         .file("src/bin/foo-bin2.rs", "fn main() {}")
         .build();
@@ -753,15 +665,7 @@ To learn more, run the command again with --verbose.
 #[test]
 fn git_repo() {
     let p = git::repo(&paths::root().join("foo"))
-        .file(
-            "Cargo.toml",
-            r#"
-            [package]
-            name = "foo"
-            version = "0.1.0"
-            authors = []
-        "#,
-        )
+        .file("Cargo.toml", &basic_manifest("foo", "0.1.0"))
         .file("src/main.rs", "fn main() {}")
         .build();
 
@@ -1063,15 +967,7 @@ fn git_with_lockfile() {
         "#,
         )
         .file("src/main.rs", "fn main() {}")
-        .file(
-            "bar/Cargo.toml",
-            r#"
-            [package]
-            name = "bar"
-            version = "0.1.0"
-            authors = []
-        "#,
-        )
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file("bar/src/lib.rs", "fn main() {}")
         .file(
             "Cargo.lock",
@@ -1208,15 +1104,7 @@ fn dev_dependencies_lock_file_untouched() {
         "#,
         )
         .file("src/main.rs", "fn main() {}")
-        .file(
-            "a/Cargo.toml",
-            r#"
-            [package]
-            name = "bar"
-            version = "0.1.0"
-            authors = []
-        "#,
-        )
+        .file("a/Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file("a/src/lib.rs", "")
         .build();
 
@@ -1369,15 +1257,7 @@ error: some packages failed to uninstall
 #[test]
 fn custom_target_dir_for_git_source() {
     let p = git::repo(&paths::root().join("foo"))
-        .file(
-            "Cargo.toml",
-            r#"
-                [package]
-                name = "foo"
-                version = "0.1.0"
-                authors = []
-        "#,
-        )
+        .file("Cargo.toml", &basic_manifest("foo", "0.1.0"))
         .file("src/main.rs", "fn main() {}")
         .build();
 
@@ -1490,15 +1370,7 @@ fn install_empty_argument() {
 #[test]
 fn git_repo_replace() {
     let p = git::repo(&paths::root().join("foo"))
-        .file(
-            "Cargo.toml",
-            r#"
-            [package]
-            name = "foo"
-            version = "0.1.0"
-            authors = []
-        "#,
-        )
+        .file("Cargo.toml", &basic_manifest("foo", "0.1.0"))
         .file("src/main.rs", "fn main() {}")
         .build();
     let repo = git2::Repository::open(&p.root()).unwrap();
@@ -1552,15 +1424,7 @@ fn workspace_uses_workspace_target_dir() {
             "#,
         )
         .file("src/main.rs", "fn main() {}")
-        .file(
-            "bar/Cargo.toml",
-            r#"
-                [package]
-                name = "bar"
-                version = "0.1.0"
-                authors = []
-            "#,
-        )
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file("bar/src/main.rs", "fn main() {}")
         .build();
 

--- a/tests/testsuite/local_registry.rs
+++ b/tests/testsuite/local_registry.rs
@@ -3,7 +3,7 @@ use std::io::prelude::*;
 
 use support::paths::{self, CargoPathExt};
 use support::registry::Package;
-use support::{execs, project};
+use support::{basic_manifest, execs, project};
 use support::hamcrest::assert_that;
 
 fn setup() {
@@ -265,15 +265,7 @@ fn path_dep_rewritten() {
             "#,
         )
         .file("src/lib.rs", "extern crate bar; pub fn baz() {}")
-        .file(
-            "bar/Cargo.toml",
-            r#"
-                [project]
-                name = "bar"
-                version = "0.0.1"
-                authors = []
-            "#,
-        )
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.0.1"))
         .file("bar/src/lib.rs", "pub fn bar() {}")
         .publish();
 

--- a/tests/testsuite/lockfile_compat.rs
+++ b/tests/testsuite/lockfile_compat.rs
@@ -1,6 +1,6 @@
 use support::git;
 use support::registry::Package;
-use support::{execs, lines_match, project};
+use support::{basic_manifest, execs, lines_match, project};
 use support::hamcrest::assert_that;
 
 #[test]
@@ -313,15 +313,8 @@ this could be indicative of a few possible situations:
 #[test]
 fn listed_checksum_bad_if_we_cannot_compute() {
     let git = git::new("bar", |p| {
-        p.file(
-            "Cargo.toml",
-            r#"
-            [project]
-            name = "bar"
-            version = "0.1.0"
-            authors = []
-        "#,
-        ).file("src/lib.rs", "")
+        p.file("Cargo.toml", &basic_manifest("bar", "0.1.0"))
+         .file("src/lib.rs", "")
     }).unwrap();
 
     let p = project()

--- a/tests/testsuite/out_dir.rs
+++ b/tests/testsuite/out_dir.rs
@@ -5,7 +5,7 @@ use std::env;
 use support::hamcrest::assert_that;
 
 use support::{process, sleep_ms, ChannelChanger};
-use support::{execs, project};
+use support::{basic_manifest, execs, project};
 
 #[test]
 fn binary_with_debug() {
@@ -164,15 +164,7 @@ fn include_only_the_binary_from_the_current_package() {
             }
         "#,
         )
-        .file(
-            "utils/Cargo.toml",
-            r#"
-            [project]
-            name = "utils"
-            version = "0.0.1"
-            authors = []
-        "#,
-        )
+        .file("utils/Cargo.toml", &basic_manifest("utils", "0.0.1"))
         .file("utils/src/lib.rs", "")
         .build();
 

--- a/tests/testsuite/overrides.rs
+++ b/tests/testsuite/overrides.rs
@@ -1,7 +1,7 @@
 use support::git;
 use support::paths;
 use support::registry::Package;
-use support::{execs, project};
+use support::{basic_manifest, execs, project};
 use support::hamcrest::assert_that;
 
 #[test]
@@ -9,15 +9,7 @@ fn override_simple() {
     Package::new("bar", "0.1.0").publish();
 
     let bar = git::repo(&paths::root().join("override"))
-        .file(
-            "Cargo.toml",
-            r#"
-            [package]
-            name = "bar"
-            version = "0.1.0"
-            authors = []
-        "#,
-        )
+        .file("Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file("src/lib.rs", "pub fn bar() {}")
         .build();
 
@@ -179,15 +171,7 @@ fn transitive() {
         .publish();
 
     let foo = git::repo(&paths::root().join("override"))
-        .file(
-            "Cargo.toml",
-            r#"
-            [package]
-            name = "bar"
-            version = "0.1.0"
-            authors = []
-        "#,
-        )
+        .file("Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file("src/lib.rs", "pub fn bar() {}")
         .build();
 
@@ -236,15 +220,7 @@ fn persists_across_rebuilds() {
     Package::new("bar", "0.1.0").publish();
 
     let foo = git::repo(&paths::root().join("override"))
-        .file(
-            "Cargo.toml",
-            r#"
-            [package]
-            name = "bar"
-            version = "0.1.0"
-            authors = []
-        "#,
-        )
+        .file("Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file("src/lib.rs", "pub fn bar() {}")
         .build();
 
@@ -299,15 +275,7 @@ fn replace_registry_with_path() {
     Package::new("bar", "0.1.0").publish();
 
     let _ = project().at("bar")
-        .file(
-            "Cargo.toml",
-            r#"
-            [package]
-            name = "bar"
-            version = "0.1.0"
-            authors = []
-        "#,
-        )
+        .file("Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file("src/lib.rs", "pub fn bar() {}")
         .build();
 
@@ -369,15 +337,7 @@ fn use_a_spec_to_select() {
         .publish();
 
     let foo = git::repo(&paths::root().join("override"))
-        .file(
-            "Cargo.toml",
-            r#"
-            [package]
-            name = "baz"
-            version = "0.2.0"
-            authors = []
-        "#,
-        )
+        .file("Cargo.toml", &basic_manifest("baz", "0.2.0"))
         .file("src/lib.rs", "pub fn baz3() {}")
         .build();
 
@@ -576,15 +536,7 @@ fn override_wrong_name() {
     Package::new("baz", "0.1.0").publish();
 
     let foo = git::repo(&paths::root().join("override"))
-        .file(
-            "Cargo.toml",
-            r#"
-            [package]
-            name = "bar"
-            version = "0.1.0"
-            authors = []
-        "#,
-        )
+        .file("Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file("src/lib.rs", "")
         .build();
 
@@ -708,15 +660,7 @@ fn multiple_specs() {
     Package::new("bar", "0.1.0").publish();
 
     let bar = git::repo(&paths::root().join("override"))
-        .file(
-            "Cargo.toml",
-            r#"
-            [package]
-            name = "bar"
-            version = "0.1.0"
-            authors = []
-        "#,
-        )
+        .file("Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file("src/lib.rs", "pub fn bar() {}")
         .build();
 
@@ -767,15 +711,7 @@ fn test_override_dep() {
     Package::new("bar", "0.1.0").publish();
 
     let bar = git::repo(&paths::root().join("override"))
-        .file(
-            "Cargo.toml",
-            r#"
-            [package]
-            name = "bar"
-            version = "0.1.0"
-            authors = []
-        "#,
-        )
+        .file("Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file("src/lib.rs", "pub fn bar() {}")
         .build();
 
@@ -819,15 +755,7 @@ fn update() {
     Package::new("bar", "0.1.0").publish();
 
     let bar = git::repo(&paths::root().join("override"))
-        .file(
-            "Cargo.toml",
-            r#"
-            [package]
-            name = "bar"
-            version = "0.1.0"
-            authors = []
-        "#,
-        )
+        .file("Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file("src/lib.rs", "pub fn bar() {}")
         .build();
 
@@ -870,15 +798,7 @@ fn update() {
 #[test]
 fn no_override_self() {
     let deps = git::repo(&paths::root().join("override"))
-        .file(
-            "far/Cargo.toml",
-            r#"
-            [package]
-            name = "far"
-            version = "0.1.0"
-            authors = []
-        "#,
-        )
+        .file("far/Cargo.toml", &basic_manifest("far", "0.1.0"))
         .file("far/src/lib.rs", "")
         .file(
             "near/Cargo.toml",
@@ -1118,15 +1038,7 @@ fn override_an_override() {
             }
         ",
         )
-        .file(
-            "serde/Cargo.toml",
-            r#"
-            [package]
-            name = "serde"
-            version = "0.8.0"
-            authors = []
-        "#,
-        )
+        .file("serde/Cargo.toml", &basic_manifest("serde", "0.8.0"))
         .file(
             "serde/src/lib.rs",
             "
@@ -1157,15 +1069,7 @@ fn overriding_nonexistent_no_spurious() {
         "#,
         )
         .file("src/lib.rs", "pub fn bar() {}")
-        .file(
-            "baz/Cargo.toml",
-            r#"
-            [package]
-            name = "baz"
-            version = "0.1.0"
-            authors = []
-        "#,
-        )
+        .file("baz/Cargo.toml", &basic_manifest("baz", "0.1.0"))
         .file("baz/src/lib.rs", "pub fn baz() {}")
         .build();
 
@@ -1234,23 +1138,9 @@ fn no_warnings_when_replace_is_used_in_another_workspace_member() {
         "#,
         )
         .file("first_crate/src/lib.rs", "")
-        .file(
-            "second_crate/Cargo.toml",
-            r#"
-            [package]
-            name = "second_crate"
-            version = "0.1.0"
-        "#,
-        )
+        .file("second_crate/Cargo.toml", &basic_manifest("second_crate", "0.1.0"))
         .file("second_crate/src/lib.rs", "")
-        .file(
-            "local_bar/Cargo.toml",
-            r#"
-            [package]
-            name = "bar"
-            version = "0.1.0"
-        "#,
-        )
+        .file("local_bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file("local_bar/src/lib.rs", "")
         .build();
 
@@ -1307,15 +1197,7 @@ fn override_to_path_dep() {
         "#,
         )
         .file("bar/src/lib.rs", "")
-        .file(
-            "bar/baz/Cargo.toml",
-            r#"
-            [package]
-            name = "baz"
-            version = "0.0.1"
-            authors = []
-        "#,
-        )
+        .file("bar/baz/Cargo.toml", &basic_manifest("baz", "0.0.1"))
         .file("bar/baz/src/lib.rs", "")
         .file(
             ".cargo/config",
@@ -1372,15 +1254,7 @@ fn replace_to_path_dep() {
             }
         ",
         )
-        .file(
-            "bar/baz/Cargo.toml",
-            r#"
-            [package]
-            name = "baz"
-            version = "0.1.0"
-            authors = []
-        "#,
-        )
+        .file("bar/baz/Cargo.toml", &basic_manifest("baz", "0.1.0"))
         .file("bar/baz/src/lib.rs", "pub fn baz() {}")
         .build();
 
@@ -1469,15 +1343,7 @@ fn paths_add_optional_bad() {
         "#,
         )
         .file("src/lib.rs", "")
-        .file(
-            "bar/Cargo.toml",
-            r#"
-            [package]
-            name = "bar"
-            version = "0.1.0"
-            authors = []
-        "#,
-        )
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file("bar/src/lib.rs", "")
         .file(
             "bar2/Cargo.toml",

--- a/tests/testsuite/package.rs
+++ b/tests/testsuite/package.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 
 use git2;
 use support::{cargo_process, process, sleep_ms, ChannelChanger};
-use support::{cargo_exe, execs, git, paths, project, registry, path2url};
+use support::{basic_manifest, cargo_exe, execs, git, paths, project, registry, path2url};
 use support::registry::Package;
 use flate2::read::GzDecoder;
 use support::hamcrest::{assert_that, contains, existing_file};
@@ -173,30 +173,14 @@ See http://doc.crates.io/manifest.html#package-metadata for more info.
 fn package_verbose() {
     let root = paths::root().join("all");
     let p = git::repo(&root)
-        .file(
-            "Cargo.toml",
-            r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-        "#,
-        )
+        .file("Cargo.toml", &basic_manifest("foo", "0.0.1"))
         .file(
             "src/main.rs",
             r#"
             fn main() {}
         "#,
         )
-        .file(
-            "a/Cargo.toml",
-            r#"
-            [project]
-            name = "a"
-            version = "0.0.1"
-            authors = []
-        "#,
-        )
+        .file("a/Cargo.toml", &basic_manifest("a", "0.0.1"))
         .file("a/src/lib.rs", "")
         .build();
     let mut cargo = cargo_process();
@@ -281,15 +265,7 @@ fn path_dependency_no_version() {
         "#,
         )
         .file("src/main.rs", "fn main() {}")
-        .file(
-            "bar/Cargo.toml",
-            r#"
-            [package]
-            name = "bar"
-            version = "0.0.1"
-            authors = []
-        "#,
-        )
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file("bar/src/lib.rs", "")
         .build();
 
@@ -545,15 +521,7 @@ fn package_git_submodule() {
 fn no_duplicates_from_modified_tracked_files() {
     let root = paths::root().join("all");
     let p = git::repo(&root)
-        .file(
-            "Cargo.toml",
-            r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-        "#,
-        )
+        .file("Cargo.toml", &basic_manifest("foo", "0.0.1"))
         .file(
             "src/main.rs",
             r#"
@@ -876,15 +844,7 @@ fn generated_manifest() {
         "#,
         )
         .file("src/main.rs", "")
-        .file(
-            "bar/Cargo.toml",
-            r#"
-            [package]
-            name = "bar"
-            version = "0.1.0"
-            authors = []
-        "#,
-        )
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file("bar/src/lib.rs", "")
         .build();
 

--- a/tests/testsuite/patch.rs
+++ b/tests/testsuite/patch.rs
@@ -5,7 +5,7 @@ use toml;
 use support::git;
 use support::paths;
 use support::registry::Package;
-use support::{execs, project};
+use support::{basic_manifest, execs, project};
 use support::hamcrest::assert_that;
 
 #[test]
@@ -52,15 +52,7 @@ fn replace() {
             }
         ",
         )
-        .file(
-            "bar/Cargo.toml",
-            r#"
-            [package]
-            name = "bar"
-            version = "0.1.0"
-            authors = []
-        "#,
-        )
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file(
             "bar/src/lib.rs",
             r#"
@@ -118,15 +110,7 @@ fn nonexistent() {
             }
         ",
         )
-        .file(
-            "bar/Cargo.toml",
-            r#"
-            [package]
-            name = "bar"
-            version = "0.1.0"
-            authors = []
-        "#,
-        )
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file(
             "bar/src/lib.rs",
             r#"
@@ -155,15 +139,7 @@ fn nonexistent() {
 #[test]
 fn patch_git() {
     let bar = git::repo(&paths::root().join("override"))
-        .file(
-            "Cargo.toml",
-            r#"
-            [package]
-            name = "bar"
-            version = "0.1.0"
-            authors = []
-        "#,
-        )
+        .file("Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file("src/lib.rs", "")
         .build();
 
@@ -195,15 +171,7 @@ fn patch_git() {
             }
         ",
         )
-        .file(
-            "bar/Cargo.toml",
-            r#"
-            [package]
-            name = "bar"
-            version = "0.1.0"
-            authors = []
-        "#,
-        )
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file(
             "bar/src/lib.rs",
             r#"
@@ -232,15 +200,7 @@ fn patch_git() {
 #[test]
 fn patch_to_git() {
     let bar = git::repo(&paths::root().join("override"))
-        .file(
-            "Cargo.toml",
-            r#"
-            [package]
-            name = "bar"
-            version = "0.1.0"
-            authors = []
-        "#,
-        )
+        .file("Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file("src/lib.rs", "pub fn bar() {}")
         .build();
 
@@ -315,15 +275,7 @@ fn unused() {
         "#,
         )
         .file("src/lib.rs", "")
-        .file(
-            "bar/Cargo.toml",
-            r#"
-            [package]
-            name = "bar"
-            version = "0.2.0"
-            authors = []
-        "#,
-        )
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.2.0"))
         .file(
             "bar/src/lib.rs",
             r#"
@@ -369,15 +321,7 @@ fn unused_git() {
     Package::new("bar", "0.1.0").publish();
 
     let foo = git::repo(&paths::root().join("override"))
-        .file(
-            "Cargo.toml",
-            r#"
-            [package]
-            name = "bar"
-            version = "0.2.0"
-            authors = []
-        "#,
-        )
+        .file("Cargo.toml", &basic_manifest("bar", "0.2.0"))
         .file("src/lib.rs", "")
         .build();
 
@@ -440,15 +384,7 @@ fn add_patch() {
         "#,
         )
         .file("src/lib.rs", "")
-        .file(
-            "bar/Cargo.toml",
-            r#"
-            [package]
-            name = "bar"
-            version = "0.1.0"
-            authors = []
-        "#,
-        )
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file("bar/src/lib.rs", r#""#)
         .build();
 
@@ -518,15 +454,7 @@ fn add_ignored_patch() {
         "#,
         )
         .file("src/lib.rs", "")
-        .file(
-            "bar/Cargo.toml",
-            r#"
-            [package]
-            name = "bar"
-            version = "0.1.1"
-            authors = []
-        "#,
-        )
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.1"))
         .file("bar/src/lib.rs", r#""#)
         .build();
 
@@ -595,15 +523,7 @@ fn new_minor() {
         "#,
         )
         .file("src/lib.rs", "")
-        .file(
-            "bar/Cargo.toml",
-            r#"
-            [package]
-            name = "bar"
-            version = "0.1.1"
-            authors = []
-        "#,
-        )
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.1"))
         .file("bar/src/lib.rs", r#""#)
         .build();
 
@@ -654,15 +574,7 @@ fn transitive_new_minor() {
         "#,
         )
         .file("bar/src/lib.rs", r#""#)
-        .file(
-            "baz/Cargo.toml",
-            r#"
-            [package]
-            name = "baz"
-            version = "0.1.1"
-            authors = []
-        "#,
-        )
+        .file("baz/Cargo.toml", &basic_manifest("baz", "0.1.1"))
         .file("baz/src/lib.rs", r#""#)
         .build();
 
@@ -701,15 +613,7 @@ fn new_major() {
         "#,
         )
         .file("src/lib.rs", "")
-        .file(
-            "bar/Cargo.toml",
-            r#"
-            [package]
-            name = "bar"
-            version = "0.2.0"
-            authors = []
-        "#,
-        )
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.2.0"))
         .file("bar/src/lib.rs", r#""#)
         .build();
 
@@ -793,15 +697,7 @@ fn transitive_new_major() {
         "#,
         )
         .file("bar/src/lib.rs", r#""#)
-        .file(
-            "baz/Cargo.toml",
-            r#"
-            [package]
-            name = "baz"
-            version = "0.2.0"
-            authors = []
-        "#,
-        )
+        .file("baz/Cargo.toml", &basic_manifest("baz", "0.2.0"))
         .file("baz/src/lib.rs", r#""#)
         .build();
 
@@ -842,25 +738,9 @@ fn remove_patch() {
         "#,
         )
         .file("src/lib.rs", "")
-        .file(
-            "bar/Cargo.toml",
-            r#"
-            [package]
-            name = "bar"
-            version = "0.1.0"
-            authors = []
-        "#,
-        )
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file("bar/src/lib.rs", r#""#)
-        .file(
-            "foo/Cargo.toml",
-            r#"
-            [package]
-            name = "foo"
-            version = "0.1.0"
-            authors = []
-        "#,
-        )
+        .file("foo/Cargo.toml", &basic_manifest("foo", "0.1.0"))
         .file("foo/src/lib.rs", r#""#)
         .build();
 
@@ -929,15 +809,7 @@ fn non_crates_io() {
         "#,
         )
         .file("src/lib.rs", "")
-        .file(
-            "bar/Cargo.toml",
-            r#"
-            [package]
-            name = "bar"
-            version = "0.1.0"
-            authors = []
-        "#,
-        )
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file("bar/src/lib.rs", r#""#)
         .build();
 
@@ -972,15 +844,7 @@ fn replace_with_crates_io() {
         "#,
         )
         .file("src/lib.rs", "")
-        .file(
-            "bar/Cargo.toml",
-            r#"
-            [package]
-            name = "bar"
-            version = "0.1.0"
-            authors = []
-        "#,
-        )
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file("bar/src/lib.rs", r#""#)
         .build();
 
@@ -1014,15 +878,7 @@ fn patch_in_virtual() {
             bar = { path = "bar" }
         "#,
         )
-        .file(
-            "bar/Cargo.toml",
-            r#"
-            [package]
-            name = "bar"
-            version = "0.1.0"
-            authors = []
-        "#,
-        )
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file("bar/src/lib.rs", r#""#)
         .file(
             "foo/Cargo.toml",
@@ -1076,15 +932,7 @@ fn patch_depends_on_another_patch() {
         "#,
         )
         .file("src/lib.rs", "")
-        .file(
-            "bar/Cargo.toml",
-            r#"
-            [package]
-            name = "bar"
-            version = "0.1.1"
-            authors = []
-        "#,
-        )
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.1"))
         .file("bar/src/lib.rs", r#""#)
         .file(
             "baz/Cargo.toml",

--- a/tests/testsuite/path.rs
+++ b/tests/testsuite/path.rs
@@ -5,7 +5,7 @@ use cargo::util::process;
 use support::sleep_ms;
 use support::paths::{self, CargoPathExt};
 use support::registry::Package;
-use support::{execs, main_file, project};
+use support::{basic_manifest, basic_lib_manifest, execs, main_file, project};
 use support::hamcrest::{assert_that, existing_file, is_not};
 
 #[test]
@@ -58,20 +58,7 @@ fn cargo_compile_with_nested_deps_shorthand() {
             }
         "#,
         )
-        .file(
-            "bar/baz/Cargo.toml",
-            r#"
-            [project]
-
-            name = "baz"
-            version = "0.5.0"
-            authors = ["wycats@example.com"]
-
-            [lib]
-
-            name = "baz"
-        "#,
-        )
+        .file("bar/baz/Cargo.toml", &basic_lib_manifest("baz"))
         .file(
             "bar/baz/src/baz.rs",
             r#"
@@ -156,16 +143,7 @@ fn cargo_compile_with_root_dev_deps() {
         .file("src/main.rs", &main_file(r#""{}", bar::gimme()"#, &["bar"]))
         .build();
     let _p2 = project().at("bar")
-        .file(
-            "Cargo.toml",
-            r#"
-            [package]
-
-            name = "bar"
-            version = "0.5.0"
-            authors = ["wycats@example.com"]
-        "#,
-        )
+        .file("Cargo.toml", &basic_manifest("bar", "0.5.0"))
         .file(
             "src/lib.rs",
             r#"
@@ -203,16 +181,7 @@ fn cargo_compile_with_root_dev_deps_with_testing() {
         .file("src/main.rs", &main_file(r#""{}", bar::gimme()"#, &["bar"]))
         .build();
     let _p2 = project().at("bar")
-        .file(
-            "Cargo.toml",
-            r#"
-            [package]
-
-            name = "bar"
-            version = "0.5.0"
-            authors = ["wycats@example.com"]
-        "#,
-        )
+        .file("Cargo.toml", &basic_manifest("bar", "0.5.0"))
         .file(
             "src/lib.rs",
             r#"
@@ -324,19 +293,7 @@ fn no_rebuild_dependency() {
             fn main() { bar::bar() }
         "#,
         )
-        .file(
-            "bar/Cargo.toml",
-            r#"
-            [project]
-
-            name = "bar"
-            version = "0.5.0"
-            authors = ["wycats@example.com"]
-
-            [lib]
-            name = "bar"
-        "#,
-        )
+        .file("bar/Cargo.toml", &basic_lib_manifest("bar"))
         .file(
             "bar/src/bar.rs",
             r#"
@@ -422,19 +379,7 @@ fn deep_dependencies_trigger_rebuild() {
             pub fn bar() { baz::baz() }
         "#,
         )
-        .file(
-            "baz/Cargo.toml",
-            r#"
-            [project]
-
-            name = "baz"
-            version = "0.5.0"
-            authors = ["wycats@example.com"]
-
-            [lib]
-            name = "baz"
-        "#,
-        )
+        .file("baz/Cargo.toml", &basic_lib_manifest("baz"))
         .file(
             "baz/src/baz.rs",
             r#"
@@ -554,19 +499,7 @@ fn no_rebuild_two_deps() {
             pub fn bar() {}
         "#,
         )
-        .file(
-            "baz/Cargo.toml",
-            r#"
-            [project]
-
-            name = "baz"
-            version = "0.5.0"
-            authors = ["wycats@example.com"]
-
-            [lib]
-            name = "baz"
-        "#,
-        )
+        .file("baz/Cargo.toml", &basic_lib_manifest("baz"))
         .file(
             "baz/src/baz.rs",
             r#"
@@ -611,20 +544,7 @@ fn nested_deps_recompile() {
         "#,
         )
         .file("src/main.rs", &main_file(r#""{}", bar::gimme()"#, &["bar"]))
-        .file(
-            "src/bar/Cargo.toml",
-            r#"
-            [project]
-
-            name = "bar"
-            version = "0.5.0"
-            authors = ["wycats@example.com"]
-
-            [lib]
-
-            name = "bar"
-        "#,
-        )
+        .file("src/bar/Cargo.toml", &basic_lib_manifest("bar"))
         .file("src/bar/src/bar.rs", "pub fn gimme() -> i32 { 92 }")
         .build();
     let bar = p.url();
@@ -706,16 +626,7 @@ Caused by:
 #[test]
 fn override_relative() {
     let bar = project().at("bar")
-        .file(
-            "Cargo.toml",
-            r#"
-            [package]
-
-            name = "bar"
-            version = "0.5.0"
-            authors = ["wycats@example.com"]
-        "#,
-        )
+        .file("Cargo.toml", &basic_manifest("bar", "0.5.0"))
         .file("src/lib.rs", "")
         .build();
 
@@ -750,16 +661,7 @@ fn override_relative() {
 #[test]
 fn override_self() {
     let bar = project().at("bar")
-        .file(
-            "Cargo.toml",
-            r#"
-            [package]
-
-            name = "bar"
-            version = "0.5.0"
-            authors = ["wycats@example.com"]
-        "#,
-        )
+        .file("Cargo.toml", &basic_manifest("bar", "0.5.0"))
         .file("src/lib.rs", "")
         .build();
 
@@ -813,15 +715,7 @@ fn override_path_dep() {
        "#,
         )
         .file("p1/src/lib.rs", "")
-        .file(
-            "p2/Cargo.toml",
-            r#"
-            [package]
-            name = "p2"
-            version = "0.5.0"
-            authors = []
-       "#,
-        )
+        .file("p2/Cargo.toml", &basic_manifest("p2", "0.5.0"))
         .file("p2/src/lib.rs", "")
         .build();
 
@@ -976,16 +870,7 @@ fn dev_deps_no_rebuild_lib() {
             #[cfg(not(test))] pub fn foo() { env!("FOO"); }
         "#,
         )
-        .file(
-            "bar/Cargo.toml",
-            r#"
-            [package]
-
-            name = "bar"
-            version = "0.5.0"
-            authors = ["wycats@example.com"]
-        "#,
-        )
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.5.0"))
         .file("bar/src/lib.rs", "pub fn bar() {}")
         .build();
     assert_that(
@@ -1031,15 +916,7 @@ fn custom_target_no_rebuild() {
         "#,
         )
         .file("src/lib.rs", "")
-        .file(
-            "a/Cargo.toml",
-            r#"
-            [project]
-            name = "a"
-            version = "0.5.0"
-            authors = []
-        "#,
-        )
+        .file("a/Cargo.toml", &basic_manifest("a", "0.5.0"))
         .file("a/src/lib.rs", "")
         .file(
             "b/Cargo.toml",
@@ -1098,15 +975,7 @@ fn override_and_depend() {
         "#,
         )
         .file("a/a1/src/lib.rs", "")
-        .file(
-            "a/a2/Cargo.toml",
-            r#"
-            [project]
-            name = "a2"
-            version = "0.5.0"
-            authors = []
-        "#,
-        )
+        .file("a/a2/Cargo.toml", &basic_manifest("a2", "0.5.0"))
         .file("a/a2/src/lib.rs", "")
         .file(
             "b/Cargo.toml",
@@ -1144,15 +1013,7 @@ fn override_and_depend() {
 #[test]
 fn missing_path_dependency() {
     let p = project()
-        .file(
-            "Cargo.toml",
-            r#"
-            [project]
-            name = "a"
-            version = "0.5.0"
-            authors = []
-        "#,
-        )
+        .file("Cargo.toml", &basic_manifest("a", "0.5.0"))
         .file("src/lib.rs", "")
         .file(
             ".cargo/config",
@@ -1265,15 +1126,7 @@ fn workspace_produces_rlib() {
         "#,
         )
         .file("src/lib.rs", "")
-        .file(
-            "foo/Cargo.toml",
-            r#"
-            [project]
-            name = "foo"
-            version = "0.5.0"
-            authors = []
-        "#,
-        )
+        .file("foo/Cargo.toml", &basic_manifest("foo", "0.5.0"))
         .file("foo/src/lib.rs", "")
         .build();
 

--- a/tests/testsuite/plugins.rs
+++ b/tests/testsuite/plugins.rs
@@ -2,7 +2,7 @@ use std::fs;
 use std::env;
 
 use support::{is_nightly, rustc_host};
-use support::{execs, project};
+use support::{basic_manifest, execs, project};
 use support::hamcrest::assert_that;
 
 #[test]
@@ -458,15 +458,7 @@ fn shared_panic_abort_plugins() {
             extern crate baz;
         "#,
         )
-        .file(
-            "baz/Cargo.toml",
-            r#"
-            [package]
-            name = "baz"
-            version = "0.0.1"
-            authors = []
-        "#,
-        )
+        .file("baz/Cargo.toml", &basic_manifest("baz", "0.0.1"))
         .file("baz/src/lib.rs", "")
         .build();
 

--- a/tests/testsuite/profile_overrides.rs
+++ b/tests/testsuite/profile_overrides.rs
@@ -1,4 +1,4 @@
-use support::{basic_lib_manifest, execs, project};
+use support::{basic_manifest, basic_lib_manifest, execs, project};
 use support::ChannelChanger;
 use support::hamcrest::assert_that;
 
@@ -436,26 +436,12 @@ fn profile_override_spec() {
         .build();
 
     project().at("dep1")
-        .file(
-            "Cargo.toml",
-            r#"
-            [package]
-            name = "dep"
-            version = "1.0.0"
-        "#,
-        )
+        .file("Cargo.toml", &basic_manifest("dep", "1.0.0"))
         .file("src/lib.rs", "")
         .build();
 
     project().at("dep2")
-        .file(
-            "Cargo.toml",
-            r#"
-            [package]
-            name = "dep"
-            version = "2.0.0"
-        "#,
-        )
+        .file("Cargo.toml", &basic_manifest("dep", "2.0.0"))
         .file("src/lib.rs", "")
         .build();
 

--- a/tests/testsuite/profile_targets.rs
+++ b/tests/testsuite/profile_targets.rs
@@ -1,5 +1,5 @@
 use support::is_nightly;
-use support::{execs, project, Project};
+use support::{basic_manifest, execs, project, Project};
 use support::hamcrest::assert_that;
 
 // These tests try to exercise exactly which profiles are selected for every
@@ -57,11 +57,7 @@ fn all_target_project() -> Project {
         "#)
 
         // bar package
-        .file("bar/Cargo.toml", r#"
-            [package]
-            name = "bar"
-            version = "0.0.1"
-        "#)
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.0.1"))
         .file("bar/src/lib.rs", "")
 
         // bdep package

--- a/tests/testsuite/publish.rs
+++ b/tests/testsuite/publish.rs
@@ -5,7 +5,7 @@ use std::io::SeekFrom;
 use support::ChannelChanger;
 use support::git::repo;
 use support::paths;
-use support::{execs, project, publish};
+use support::{basic_manifest, execs, project, publish};
 use flate2::read::GzDecoder;
 use support::hamcrest::assert_that;
 use tar::Archive;
@@ -376,15 +376,7 @@ fn path_dependency_no_version() {
         "#,
         )
         .file("src/main.rs", "fn main() {}")
-        .file(
-            "bar/Cargo.toml",
-            r#"
-            [package]
-            name = "bar"
-            version = "0.0.1"
-            authors = []
-        "#,
-        )
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.0.1"))
         .file("bar/src/lib.rs", "")
         .build();
 

--- a/tests/testsuite/registry.rs
+++ b/tests/testsuite/registry.rs
@@ -7,7 +7,7 @@ use support::cargo_process;
 use support::git;
 use support::paths::{self, CargoPathExt};
 use support::registry::{self, Package};
-use support::{execs, project};
+use support::{basic_manifest, execs, project};
 use support::hamcrest::assert_that;
 use url::Url;
 
@@ -371,15 +371,7 @@ fn package_with_path_deps() {
         "#,
         )
         .file("src/main.rs", "fn main() {}")
-        .file(
-            "notyet/Cargo.toml",
-            r#"
-            [package]
-            name = "notyet"
-            version = "0.0.1"
-            authors = []
-        "#,
-        )
+        .file("notyet/Cargo.toml", &basic_manifest("notyet", "0.0.1"))
         .file("notyet/src/lib.rs", "")
         .build();
 
@@ -1330,15 +1322,7 @@ fn bundled_crate_in_registry() {
         "#,
         )
         .file("src/lib.rs", "")
-        .file(
-            "bar/Cargo.toml",
-            r#"
-            [package]
-            name = "bar"
-            version = "0.1.0"
-            authors = []
-        "#,
-        )
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file("bar/src/lib.rs", "")
         .publish();
 

--- a/tests/testsuite/rename_deps.rs
+++ b/tests/testsuite/rename_deps.rs
@@ -2,7 +2,7 @@ use support::ChannelChanger;
 use support::git;
 use support::paths;
 use support::registry::Package;
-use support::{execs, project};
+use support::{basic_manifest, execs, project};
 use support::hamcrest::assert_that;
 
 #[test]
@@ -162,15 +162,7 @@ fn lots_of_names() {
         .publish();
 
     let g = git::repo(&paths::root().join("another"))
-        .file(
-            "Cargo.toml",
-            r#"
-                [package]
-                name = "foo"
-                version = "0.1.0"
-                authors = []
-            "#,
-        )
+        .file("Cargo.toml", &basic_manifest("foo", "0.1.0"))
         .file("src/lib.rs", "pub fn foo3() {}")
         .build();
 
@@ -212,15 +204,7 @@ fn lots_of_names() {
                 }
             ",
         )
-        .file(
-            "foo/Cargo.toml",
-            r#"
-                [project]
-                name = "foo"
-                version = "0.1.0"
-                authors = []
-            "#,
-        )
+        .file("foo/Cargo.toml", &basic_manifest("foo", "0.1.0"))
         .file("foo/src/lib.rs", "pub fn foo4() {}")
         .build();
 
@@ -262,15 +246,7 @@ fn rename_and_patch() {
                 }
             ",
         )
-        .file(
-            "foo/Cargo.toml",
-            r#"
-                [project]
-                name = "foo"
-                version = "0.1.0"
-                authors = []
-            "#,
-        )
+        .file("foo/Cargo.toml", &basic_manifest("foo", "0.1.0"))
         .file("foo/src/lib.rs", "pub fn foo() {}")
         .build();
 

--- a/tests/testsuite/run.rs
+++ b/tests/testsuite/run.rs
@@ -1,6 +1,6 @@
 use cargo::util::paths::dylib_path_envvar;
 use support::{self, ChannelChanger};
-use support::{execs, project, Project, path2url};
+use support::{basic_bin_manifest, basic_lib_manifest, execs, project, Project, path2url};
 use support::hamcrest::{assert_that, existing_file};
 
 #[test]
@@ -779,18 +779,7 @@ fn example_with_release_flag() {
             }
         "#,
         )
-        .file(
-            "bar/Cargo.toml",
-            r#"
-            [project]
-            name = "bar"
-            version = "0.0.1"
-            authors = []
-
-            [lib]
-            name = "bar"
-        "#,
-        )
+        .file("bar/Cargo.toml", &basic_lib_manifest("bar"))
         .file(
             "bar/src/bar.rs",
             r#"
@@ -815,7 +804,7 @@ fn example_with_release_flag() {
             .with_status(0)
             .with_stderr(&format!(
                 "\
-[COMPILING] bar v0.0.1 ({url}/bar)
+[COMPILING] bar v0.5.0 ({url}/bar)
 [RUNNING] `rustc --crate-name bar bar[/]src[/]bar.rs --crate-type lib \
         --emit=dep-info,link \
         -C opt-level=3 \
@@ -849,7 +838,7 @@ fast2",
             .with_status(0)
             .with_stderr(&format!(
                 "\
-[COMPILING] bar v0.0.1 ({url}/bar)
+[COMPILING] bar v0.5.0 ({url}/bar)
 [RUNNING] `rustc --crate-name bar bar[/]src[/]bar.rs --crate-type lib \
         --emit=dep-info,link \
         -C debuginfo=2 \
@@ -1179,42 +1168,12 @@ fn run_multiple_packages() {
         "#,
         )
         .file("foo/src/foo.rs", "fn main() { println!(\"foo\"); }")
-        .file(
-            "foo/d1/Cargo.toml",
-            r#"
-            [package]
-            name = "d1"
-            version = "0.0.1"
-            authors = []
-
-            [[bin]]
-            name = "d1"
-        "#,
-        )
+        .file("foo/d1/Cargo.toml", &basic_bin_manifest("d1"))
         .file("foo/d1/src/lib.rs", "")
         .file("foo/d1/src/main.rs", "fn main() { println!(\"d1\"); }")
-        .file(
-            "foo/d2/Cargo.toml",
-            r#"
-            [package]
-            name = "d2"
-            version = "0.0.1"
-            authors = []
-
-            [[bin]]
-            name = "d2"
-        "#,
-        )
+        .file("foo/d2/Cargo.toml", &basic_bin_manifest("d2"))
         .file("foo/d2/src/main.rs", "fn main() { println!(\"d2\"); }")
-        .file(
-            "d3/Cargo.toml",
-            r#"
-            [package]
-            name = "d3"
-            version = "0.0.1"
-            authors = []
-        "#,
-        )
+        .file("d3/Cargo.toml", &basic_bin_manifest("d3"))
         .file("d3/src/main.rs", "fn main() { println!(\"d2\"); }")
         .build();
 

--- a/tests/testsuite/rustc.rs
+++ b/tests/testsuite/rustc.rs
@@ -1,4 +1,4 @@
-use support::{basic_bin_manifest, basic_lib_manifest, execs, project};
+use support::{basic_manifest, basic_bin_manifest, basic_lib_manifest, execs, project};
 use support::hamcrest::assert_that;
 
 const CARGO_RUSTC_ERROR: &'static str =
@@ -259,15 +259,7 @@ fn build_foo_with_bar_dependency() {
         )
         .build();
     let _bar = project().at("bar")
-        .file(
-            "Cargo.toml",
-            r#"
-            [package]
-            name = "bar"
-            version = "0.1.0"
-            authors = []
-        "#,
-        )
+        .file("Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file(
             "src/lib.rs",
             r#"
@@ -321,15 +313,7 @@ fn build_only_bar_dependency() {
         )
         .build();
     let _bar = project().at("bar")
-        .file(
-            "Cargo.toml",
-            r#"
-            [package]
-            name = "bar"
-            version = "0.1.0"
-            authors = []
-        "#,
-        )
+        .file("Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file(
             "src/lib.rs",
             r#"
@@ -423,15 +407,7 @@ fn fail_with_multiple_packages() {
         .build();
 
     let _bar = project().at("bar")
-        .file(
-            "Cargo.toml",
-            r#"
-            [package]
-            name = "bar"
-            version = "0.1.0"
-            authors = []
-        "#,
-        )
+        .file("Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file(
             "src/main.rs",
             r#"
@@ -443,15 +419,7 @@ fn fail_with_multiple_packages() {
         .build();
 
     let _baz = project().at("baz")
-        .file(
-            "Cargo.toml",
-            r#"
-            [package]
-            name = "baz"
-            version = "0.1.0"
-            authors = []
-        "#,
-        )
+        .file("Cargo.toml", &basic_manifest("baz", "0.1.0"))
         .file(
             "src/main.rs",
             r#"
@@ -497,15 +465,7 @@ fn rustc_with_other_profile() {
             fn foo() {}
         "#,
         )
-        .file(
-            "a/Cargo.toml",
-            r#"
-            [package]
-            name = "a"
-            version = "0.1.0"
-            authors = []
-        "#,
-        )
+        .file("a/Cargo.toml", &basic_manifest("a", "0.1.0"))
         .file("a/src/lib.rs", "")
         .build();
 

--- a/tests/testsuite/rustc_info_cache.rs
+++ b/tests/testsuite/rustc_info_cache.rs
@@ -1,4 +1,4 @@
-use support::{execs, project};
+use support::{basic_manifest, execs, project};
 use support::paths::CargoPathExt;
 use support::hamcrest::assert_that;
 use std::env;
@@ -45,14 +45,7 @@ fn rustc_info_cache() {
 
     let other_rustc = {
         let p = project().at("compiler")
-            .file(
-                "Cargo.toml",
-                r#"
-            [package]
-            name = "compiler"
-            version = "0.1.0"
-        "#,
-            )
+            .file("Cargo.toml", &basic_manifest("compiler", "0.1.0"))
             .file(
                 "src/main.rs",
                 r#"

--- a/tests/testsuite/rustdoc.rs
+++ b/tests/testsuite/rustdoc.rs
@@ -1,4 +1,4 @@
-use support::{execs, project};
+use support::{basic_manifest, execs, project};
 use support::hamcrest::assert_that;
 
 #[test]
@@ -70,15 +70,7 @@ fn rustdoc_foo_with_bar_dependency() {
         )
         .build();
     let _bar = project().at("bar")
-        .file(
-            "Cargo.toml",
-            r#"
-            [package]
-            name = "bar"
-            version = "0.0.1"
-            authors = []
-        "#,
-        )
+        .file("Cargo.toml", &basic_manifest("bar", "0.0.1"))
         .file(
             "src/lib.rs",
             r#"
@@ -133,15 +125,7 @@ fn rustdoc_only_bar_dependency() {
         )
         .build();
     let _bar = project().at("bar")
-        .file(
-            "Cargo.toml",
-            r#"
-            [package]
-            name = "bar"
-            version = "0.0.1"
-            authors = []
-        "#,
-        )
+        .file("Cargo.toml", &basic_manifest("bar", "0.0.1"))
         .file(
             "src/lib.rs",
             r#"

--- a/tests/testsuite/rustflags.rs
+++ b/tests/testsuite/rustflags.rs
@@ -2,7 +2,7 @@ use std::io::Write;
 use std::fs::{self, File};
 
 use support::rustc_host;
-use support::{basic_lib_manifest, execs, paths, project, project_in_home};
+use support::{basic_manifest, basic_lib_manifest, execs, paths, project, project_in_home};
 use support::hamcrest::assert_that;
 
 #[test]
@@ -105,14 +105,7 @@ fn env_rustflags_build_script_dep() {
         )
         .build();
     let _bar = project().at("bar")
-        .file(
-            "Cargo.toml",
-            r#"
-            [package]
-            name = "bar"
-            version = "0.0.1"
-        "#,
-        )
+        .file("Cargo.toml", &basic_manifest("bar", "0.0.1"))
         .file(
             "src/lib.rs",
             r#"
@@ -331,14 +324,7 @@ fn env_rustflags_build_script_dep_with_target() {
         )
         .build();
     let _bar = project().at("bar")
-        .file(
-            "Cargo.toml",
-            r#"
-            [package]
-            name = "bar"
-            version = "0.0.1"
-        "#,
-        )
+        .file("Cargo.toml", &basic_manifest("bar", "0.0.1"))
         .file(
             "src/lib.rs",
             r#"
@@ -597,14 +583,7 @@ fn build_rustflags_build_script_dep() {
         )
         .build();
     let _bar = project().at("bar")
-        .file(
-            "Cargo.toml",
-            r#"
-            [package]
-            name = "bar"
-            version = "0.0.1"
-        "#,
-        )
+        .file("Cargo.toml", &basic_manifest("bar", "0.0.1"))
         .file(
             "src/lib.rs",
             r#"
@@ -831,14 +810,7 @@ fn build_rustflags_build_script_dep_with_target() {
         )
         .build();
     let _bar = project().at("bar")
-        .file(
-            "Cargo.toml",
-            r#"
-            [package]
-            name = "bar"
-            version = "0.0.1"
-        "#,
-        )
+        .file("Cargo.toml", &basic_manifest("bar", "0.0.1"))
         .file(
             "src/lib.rs",
             r#"

--- a/tests/testsuite/support/mod.rs
+++ b/tests/testsuite/support/mod.rs
@@ -258,7 +258,7 @@ impl ProjectBuilder {
 
         let manifest_path = self.root.root().join("Cargo.toml");
         if !self.no_manifest && self.files.iter().all(|fb| fb.path != manifest_path) {
-            self._file(Path::new("Cargo.toml"), basic_manifest("foo", "0.0.1"))
+            self._file(Path::new("Cargo.toml"), &basic_manifest("foo", "0.0.1"))
         }
 
         for file in self.files.iter() {

--- a/tests/testsuite/support/mod.rs
+++ b/tests/testsuite/support/mod.rs
@@ -118,13 +118,6 @@ pub mod paths;
 pub mod publish;
 pub mod registry;
 
-pub const BASIC_MANIFEST: &str = r#"
-[package]
-name = "foo"
-version = "0.0.1"
-authors = []
-"#;
-
 /*
  *
  * ===== Builders =====
@@ -265,7 +258,7 @@ impl ProjectBuilder {
 
         let manifest_path = self.root.root().join("Cargo.toml");
         if !self.no_manifest && self.files.iter().all(|fb| fb.path != manifest_path) {
-            self._file(Path::new("Cargo.toml"), BASIC_MANIFEST)
+            self._file(Path::new("Cargo.toml"), basic_manifest("foo", "0.0.1"))
         }
 
         for file in self.files.iter() {
@@ -1229,6 +1222,18 @@ impl<T> Tap for T {
         callback(&mut self);
         self
     }
+}
+
+pub fn basic_manifest(name: &str, version: &str) -> String {
+    format!(
+        r#"
+        [package]
+        name = "{}"
+        version = "{}"
+        authors = []
+    "#,
+        name, version
+    )
 }
 
 pub fn basic_bin_manifest(name: &str) -> String {

--- a/tests/testsuite/test.rs
+++ b/tests/testsuite/test.rs
@@ -6,7 +6,7 @@ use cargo;
 use cargo::util::process;
 use support::paths::CargoPathExt;
 use support::registry::Package;
-use support::{basic_bin_manifest, basic_lib_manifest, cargo_exe, execs, project};
+use support::{basic_manifest, basic_bin_manifest, basic_lib_manifest, cargo_exe, execs, project};
 use support::{is_nightly, rustc_host, sleep_ms};
 use support::hamcrest::{assert_that, existing_file, is_not};
 
@@ -89,15 +89,7 @@ fn cargo_test_release() {
             fn test() { foo::foo(); }
         "#,
         )
-        .file(
-            "bar/Cargo.toml",
-            r#"
-            [package]
-            name = "bar"
-            version = "0.0.1"
-            authors = []
-        "#,
-        )
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.0.1"))
         .file("bar/src/lib.rs", "pub fn bar() {}")
         .build();
 
@@ -515,15 +507,7 @@ fn test_with_deep_lib_dep() {
         )
         .build();
     let _p2 = project().at("bar")
-        .file(
-            "Cargo.toml",
-            r#"
-            [package]
-            name = "bar"
-            version = "0.0.1"
-            authors = []
-        "#,
-        )
+        .file("Cargo.toml", &basic_manifest("bar", "0.0.1"))
         .file(
             "src/lib.rs",
             "
@@ -819,15 +803,7 @@ fn lib_bin_same_name() {
 #[test]
 fn lib_with_standard_name() {
     let p = project()
-        .file(
-            "Cargo.toml",
-            r#"
-            [package]
-            name = "syntax"
-            version = "0.0.1"
-            authors = []
-        "#,
-        )
+        .file("Cargo.toml", &basic_manifest("syntax", "0.0.1"))
         .file(
             "src/lib.rs",
             "
@@ -1915,15 +1891,7 @@ fn almost_cyclic_but_not_quite() {
             extern crate foo;
         "#,
         )
-        .file(
-            "c/Cargo.toml",
-            r#"
-            [package]
-            name = "c"
-            version = "0.0.1"
-            authors = []
-        "#,
-        )
+        .file("c/Cargo.toml", &basic_manifest("c", "0.0.1"))
         .file("c/src/lib.rs", "")
         .build();
 
@@ -1960,15 +1928,7 @@ fn build_then_selective_test() {
             fn main() {}
         "#,
         )
-        .file(
-            "b/Cargo.toml",
-            r#"
-            [package]
-            name = "b"
-            version = "0.0.1"
-            authors = []
-        "#,
-        )
+        .file("b/Cargo.toml", &basic_manifest("b", "0.0.1"))
         .file("b/src/lib.rs", "")
         .build();
 
@@ -2004,15 +1964,7 @@ fn example_dev_dep() {
             fn main() { }
         "#,
         )
-        .file(
-            "bar/Cargo.toml",
-            r#"
-            [package]
-            name = "bar"
-            version = "0.0.1"
-            authors = []
-        "#,
-        )
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.0.1"))
         .file(
             "bar/src/lib.rs",
             r#"
@@ -2182,15 +2134,7 @@ fn example_with_dev_dep() {
             "examples/ex.rs",
             "#[allow(unused_extern_crates)] extern crate a; fn main() {}",
         )
-        .file(
-            "a/Cargo.toml",
-            r#"
-            [package]
-            name = "a"
-            version = "0.0.1"
-            authors = []
-        "#,
-        )
+        .file("a/Cargo.toml", &basic_manifest("a", "0.0.1"))
         .file("a/src/lib.rs", "")
         .build();
 
@@ -2289,15 +2233,7 @@ fn doctest_feature() {
 #[test]
 fn dashes_to_underscores() {
     let p = project()
-        .file(
-            "Cargo.toml",
-            r#"
-            [package]
-            name = "foo-bar"
-            version = "0.0.1"
-            authors = []
-        "#,
-        )
+        .file("Cargo.toml", &basic_manifest("foo-bar", "0.0.1"))
         .file(
             "src/lib.rs",
             r#"
@@ -2336,15 +2272,7 @@ fn doctest_dev_dep() {
             pub fn foo() {}
         "#,
         )
-        .file(
-            "b/Cargo.toml",
-            r#"
-            [package]
-            name = "b"
-            version = "0.0.1"
-            authors = []
-        "#,
-        )
+        .file("b/Cargo.toml", &basic_manifest("b", "0.0.1"))
         .file("b/src/lib.rs", "")
         .build();
 
@@ -2729,15 +2657,7 @@ fn selective_test_wonky_profile() {
         "#,
         )
         .file("src/lib.rs", "")
-        .file(
-            "a/Cargo.toml",
-            r#"
-            [package]
-            name = "a"
-            version = "0.0.1"
-            authors = []
-        "#,
-        )
+        .file("a/Cargo.toml", &basic_manifest("a", "0.0.1"))
         .file("a/src/lib.rs", "");
     let p = p.build();
 
@@ -2763,15 +2683,7 @@ fn selective_test_optional_dep() {
         "#,
         )
         .file("src/lib.rs", "")
-        .file(
-            "a/Cargo.toml",
-            r#"
-            [package]
-            name = "a"
-            version = "0.0.1"
-            authors = []
-        "#,
-        )
+        .file("a/Cargo.toml", &basic_manifest("a", "0.0.1"))
         .file("a/src/lib.rs", "");
     let p = p.build();
 
@@ -2857,15 +2769,7 @@ fn test_panic_abort_with_dep() {
             fn foo() {}
         "#,
         )
-        .file(
-            "bar/Cargo.toml",
-            r#"
-            [package]
-            name = "bar"
-            version = "0.0.1"
-            authors = []
-        "#,
-        )
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.0.1"))
         .file("bar/src/lib.rs", "")
         .build();
     assert_that(p.cargo("test").arg("-v"), execs().with_status(0));
@@ -2932,15 +2836,7 @@ fn panic_abort_multiple() {
             "src/lib.rs",
             "#[allow(unused_extern_crates)] extern crate a;",
         )
-        .file(
-            "a/Cargo.toml",
-            r#"
-            [package]
-            name = "a"
-            version = "0.0.1"
-            authors = []
-        "#,
-        )
+        .file("a/Cargo.toml", &basic_manifest("a", "0.0.1"))
         .file("a/src/lib.rs", "")
         .build();
     assert_that(
@@ -3014,25 +2910,9 @@ fn pass_correct_cfgs_flags_to_rustdoc() {
             }
         "#,
         )
-        .file(
-            "libs/mock_serde_derive/Cargo.toml",
-            r#"
-            [package]
-            name = "mock_serde_derive"
-            version = "0.1.0"
-            authors = []
-        "#,
-        )
+        .file("libs/mock_serde_derive/Cargo.toml", &basic_manifest("mock_serde_derive", "0.1.0"))
         .file("libs/mock_serde_derive/src/lib.rs", "")
-        .file(
-            "libs/mock_serde_codegen/Cargo.toml",
-            r#"
-                [package]
-                name = "mock_serde_codegen"
-                version = "0.1.0"
-                authors = []
-            "#,
-        )
+        .file("libs/mock_serde_codegen/Cargo.toml", &basic_manifest("mock_serde_codegen", "0.1.0"))
         .file("libs/mock_serde_codegen/src/lib.rs", "");
     let p = p.build();
 
@@ -3082,15 +2962,7 @@ fn test_release_ignore_panic() {
             "src/lib.rs",
             "#[allow(unused_extern_crates)] extern crate a;",
         )
-        .file(
-            "a/Cargo.toml",
-            r#"
-            [package]
-            name = "a"
-            version = "0.0.1"
-            authors = []
-        "#,
-        )
+        .file("a/Cargo.toml", &basic_manifest("a", "0.0.1"))
         .file("a/src/lib.rs", "");
     let p = p.build();
     println!("test");
@@ -3120,15 +2992,7 @@ fn test_many_with_features() {
         "#,
         )
         .file("src/lib.rs", "")
-        .file(
-            "a/Cargo.toml",
-            r#"
-            [package]
-            name = "a"
-            version = "0.0.1"
-            authors = []
-        "#,
-        )
+        .file("a/Cargo.toml", &basic_manifest("a", "0.0.1"))
         .file("a/src/lib.rs", "")
         .build();
 
@@ -3161,14 +3025,7 @@ fn test_all_workspace() {
             fn foo_test() {}
         "#,
         )
-        .file(
-            "bar/Cargo.toml",
-            r#"
-            [project]
-            name = "bar"
-            version = "0.1.0"
-        "#,
-        )
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file(
             "bar/src/lib.rs",
             r#"
@@ -3207,14 +3064,7 @@ fn test_all_exclude() {
             fn main() {}
         "#,
         )
-        .file(
-            "bar/Cargo.toml",
-            r#"
-            [project]
-            name = "bar"
-            version = "0.1.0"
-        "#,
-        )
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file(
             "bar/src/lib.rs",
             r#"
@@ -3222,14 +3072,7 @@ fn test_all_exclude() {
             pub fn bar() {}
         "#,
         )
-        .file(
-            "baz/Cargo.toml",
-            r#"
-            [project]
-            name = "baz"
-            version = "0.1.0"
-        "#,
-        )
+        .file("baz/Cargo.toml", &basic_manifest("baz", "0.1.0"))
         .file(
             "baz/src/lib.rs",
             r#"
@@ -3260,14 +3103,7 @@ fn test_all_virtual_manifest() {
             members = ["a", "b"]
         "#,
         )
-        .file(
-            "a/Cargo.toml",
-            r#"
-            [project]
-            name = "a"
-            version = "0.1.0"
-        "#,
-        )
+        .file("a/Cargo.toml", &basic_manifest("a", "0.1.0"))
         .file(
             "a/src/lib.rs",
             r#"
@@ -3275,14 +3111,7 @@ fn test_all_virtual_manifest() {
             fn a() {}
         "#,
         )
-        .file(
-            "b/Cargo.toml",
-            r#"
-            [project]
-            name = "b"
-            version = "0.1.0"
-        "#,
-        )
+        .file("b/Cargo.toml", &basic_manifest("b", "0.1.0"))
         .file(
             "b/src/lib.rs",
             r#"
@@ -3311,14 +3140,7 @@ fn test_virtual_manifest_all_implied() {
             members = ["a", "b"]
         "#,
         )
-        .file(
-            "a/Cargo.toml",
-            r#"
-            [project]
-            name = "a"
-            version = "0.1.0"
-        "#,
-        )
+        .file("a/Cargo.toml", &basic_manifest("a", "0.1.0"))
         .file(
             "a/src/lib.rs",
             r#"
@@ -3326,14 +3148,7 @@ fn test_virtual_manifest_all_implied() {
             fn a() {}
         "#,
         )
-        .file(
-            "b/Cargo.toml",
-            r#"
-            [project]
-            name = "b"
-            version = "0.1.0"
-        "#,
-        )
+        .file("b/Cargo.toml", &basic_manifest("b", "0.1.0"))
         .file(
             "b/src/lib.rs",
             r#"
@@ -3415,14 +3230,7 @@ fn doctest_only_with_dev_dep() {
             pub fn a() {}
         "#,
         )
-        .file(
-            "b/Cargo.toml",
-            r#"
-            [project]
-            name = "b"
-            version = "0.1.0"
-        "#,
-        )
+        .file("b/Cargo.toml", &basic_manifest("b", "0.1.0"))
         .file(
             "b/src/lib.rs",
             r#"
@@ -3545,14 +3353,7 @@ fn doctest_and_registry() {
         "#,
         )
         .file("src/lib.rs", "")
-        .file(
-            "b/Cargo.toml",
-            r#"
-            [project]
-            name = "b"
-            version = "0.1.0"
-        "#,
-        )
+        .file("b/Cargo.toml", &basic_manifest("b", "0.1.0"))
         .file(
             "b/src/lib.rs",
             "
@@ -3862,14 +3663,7 @@ fn test_hint_workspace() {
             members = ["a", "b"]
         "#,
         )
-        .file(
-            "a/Cargo.toml",
-            r#"
-            [project]
-            name = "a"
-            version = "0.1.0"
-        "#,
-        )
+        .file("a/Cargo.toml", &basic_manifest("a", "0.1.0"))
         .file(
             "a/src/lib.rs",
             r#"
@@ -3877,14 +3671,7 @@ fn test_hint_workspace() {
             fn t1() {}
         "#,
         )
-        .file(
-            "b/Cargo.toml",
-            r#"
-            [project]
-            name = "b"
-            version = "0.1.0"
-        "#,
-        )
+        .file("b/Cargo.toml", &basic_manifest("b", "0.1.0"))
         .file(
             "b/src/lib.rs",
             r#"

--- a/tests/testsuite/tool_paths.rs
+++ b/tests/testsuite/tool_paths.rs
@@ -106,18 +106,7 @@ fn relative_tools() {
     // by reference to the `.cargo/..` directory and not to (for example) the CWD.
     let p = project()
         .no_manifest()
-        .file(
-            "bar/Cargo.toml",
-            r#"
-            [package]
-            name = "bar"
-            version = "0.0.1"
-            authors = []
-
-            [lib]
-            name = "bar"
-        "#,
-        )
+        .file("bar/Cargo.toml", &basic_lib_manifest("bar"))
         .file("bar/src/lib.rs", "")
         .file(
             ".cargo/config",
@@ -153,7 +142,7 @@ fn relative_tools() {
         p.cargo("build").cwd(foo_path).arg("--verbose"),
         execs().with_stderr(&format!(
             "\
-[COMPILING] bar v0.0.1 ({url})
+[COMPILING] bar v0.5.0 ({url})
 [RUNNING] `rustc [..] -C ar={ar} -C linker={linker} [..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",

--- a/tests/testsuite/update.rs
+++ b/tests/testsuite/update.rs
@@ -1,7 +1,7 @@
 use std::fs::File;
 use std::io::prelude::*;
 
-use support::{execs, project};
+use support::{basic_manifest, execs, project};
 use support::registry::Package;
 use support::hamcrest::assert_that;
 
@@ -331,15 +331,7 @@ fn change_package_version() {
             "#,
         )
         .file("src/lib.rs", "")
-        .file(
-            "bar/Cargo.toml",
-            r#"
-                [package]
-                name = "bar"
-                version = "0.2.0-alpha"
-                authors = []
-            "#,
-        )
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.2.0-alpha"))
         .file("bar/src/lib.rs", "")
         .file(
             "Cargo.lock",

--- a/tests/testsuite/workspaces.rs
+++ b/tests/testsuite/workspaces.rs
@@ -3,7 +3,7 @@ use std::fs::{self, File};
 use std::io::{Read, Write};
 
 use support::sleep_ms;
-use support::{basic_lib_manifest, execs, git, project};
+use support::{basic_manifest, basic_lib_manifest, execs, git, project};
 use support::registry::Package;
 use support::hamcrest::{assert_that, existing_dir, existing_file, is_not};
 
@@ -102,15 +102,7 @@ fn inferred_root() {
         "#,
         )
         .file("src/main.rs", "fn main() {}")
-        .file(
-            "bar/Cargo.toml",
-            r#"
-            [project]
-            name = "bar"
-            version = "0.1.0"
-            authors = []
-        "#,
-        )
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file("bar/src/main.rs", "fn main() {}");
     let p = p.build();
 
@@ -147,15 +139,7 @@ fn inferred_path_dep() {
         "#,
         )
         .file("src/main.rs", "fn main() {}")
-        .file(
-            "bar/Cargo.toml",
-            r#"
-            [project]
-            name = "bar"
-            version = "0.1.0"
-            authors = []
-        "#,
-        )
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file("bar/src/main.rs", "fn main() {}")
         .file("bar/src/lib.rs", "");
     let p = p.build();
@@ -207,15 +191,7 @@ fn transitive_path_dep() {
         )
         .file("bar/src/main.rs", "fn main() {}")
         .file("bar/src/lib.rs", "")
-        .file(
-            "baz/Cargo.toml",
-            r#"
-            [project]
-            name = "baz"
-            version = "0.1.0"
-            authors = []
-        "#,
-        )
+        .file("baz/Cargo.toml", &basic_manifest("baz", "0.1.0"))
         .file("baz/src/main.rs", "fn main() {}")
         .file("baz/src/lib.rs", "");
     let p = p.build();
@@ -346,15 +322,7 @@ fn parent_doesnt_point_to_child() {
         "#,
         )
         .file("src/main.rs", "fn main() {}")
-        .file(
-            "bar/Cargo.toml",
-            r#"
-            [project]
-            name = "bar"
-            version = "0.1.0"
-            authors = []
-        "#,
-        )
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file("bar/src/main.rs", "fn main() {}");
     let p = p.build();
 
@@ -509,15 +477,7 @@ fn workspace_isnt_root() {
         "#,
         )
         .file("src/main.rs", "fn main() {}")
-        .file(
-            "bar/Cargo.toml",
-            r#"
-            [project]
-            name = "bar"
-            version = "0.1.0"
-            authors = []
-        "#,
-        )
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file("bar/src/main.rs", "fn main() {}");
     let p = p.build();
 
@@ -788,15 +748,7 @@ fn virtual_works() {
             members = ["bar"]
         "#,
         )
-        .file(
-            "bar/Cargo.toml",
-            r#"
-            [project]
-            name = "bar"
-            version = "0.1.0"
-            authors = []
-        "#,
-        )
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file("bar/src/main.rs", "fn main() {}");
     let p = p.build();
     assert_that(
@@ -818,15 +770,7 @@ fn explicit_package_argument_works_with_virtual_manifest() {
             members = ["bar"]
         "#,
         )
-        .file(
-            "bar/Cargo.toml",
-            r#"
-            [project]
-            name = "bar"
-            version = "0.1.0"
-            authors = []
-        "#,
-        )
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file("bar/src/main.rs", "fn main() {}");
     let p = p.build();
     assert_that(
@@ -847,15 +791,7 @@ fn virtual_misconfigure() {
             [workspace]
         "#,
         )
-        .file(
-            "bar/Cargo.toml",
-            r#"
-            [project]
-            name = "bar"
-            version = "0.1.0"
-            authors = []
-        "#,
-        )
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file("bar/src/main.rs", "fn main() {}");
     let p = p.build();
     assert_that(
@@ -883,15 +819,7 @@ fn virtual_build_all_implied() {
             members = ["bar"]
         "#,
         )
-        .file(
-            "bar/Cargo.toml",
-            r#"
-            [project]
-            name = "bar"
-            version = "0.1.0"
-            authors = []
-        "#,
-        )
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file("bar/src/main.rs", "fn main() {}");
     let p = p.build();
     assert_that(p.cargo("build"), execs().with_status(0));
@@ -908,24 +836,8 @@ fn virtual_default_members() {
             default-members = ["bar"]
         "#,
         )
-        .file(
-            "bar/Cargo.toml",
-            r#"
-            [project]
-            name = "bar"
-            version = "0.1.0"
-            authors = []
-        "#,
-        )
-        .file(
-            "baz/Cargo.toml",
-            r#"
-            [project]
-            name = "baz"
-            version = "0.1.0"
-            authors = []
-        "#,
-        )
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
+        .file("baz/Cargo.toml", &basic_manifest("baz", "0.1.0"))
         .file("bar/src/main.rs", "fn main() {}")
         .file("baz/src/main.rs", "fn main() {}");
     let p = p.build();
@@ -945,15 +857,7 @@ fn virtual_default_member_is_not_a_member() {
             default-members = ["something-else"]
         "#,
         )
-        .file(
-            "bar/Cargo.toml",
-            r#"
-            [project]
-            name = "bar"
-            version = "0.1.0"
-            authors = []
-        "#,
-        )
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file("bar/src/main.rs", "fn main() {}");
     let p = p.build();
     assert_that(
@@ -1053,25 +957,9 @@ fn members_include_path_deps() {
         "#,
         )
         .file("p1/src/lib.rs", "")
-        .file(
-            "p2/Cargo.toml",
-            r#"
-            [project]
-            name = "p2"
-            version = "0.1.0"
-            authors = []
-        "#,
-        )
+        .file("p2/Cargo.toml", &basic_manifest("p2", "0.1.0"))
         .file("p2/src/lib.rs", "")
-        .file(
-            "p3/Cargo.toml",
-            r#"
-            [project]
-            name = "p3"
-            version = "0.1.0"
-            authors = []
-        "#,
-        )
+        .file("p3/Cargo.toml", &basic_manifest("p3", "0.1.0"))
         .file("p3/src/lib.rs", "");
     let p = p.build();
 
@@ -1194,14 +1082,7 @@ fn rebuild_please() {
             members = ['lib', 'bin']
         "#,
         )
-        .file(
-            "lib/Cargo.toml",
-            r#"
-            [package]
-            name = "lib"
-            version = "0.1.0"
-        "#,
-        )
+        .file("lib/Cargo.toml", &basic_manifest("lib", "0.1.0"))
         .file(
             "lib/src/lib.rs",
             r#"
@@ -1266,14 +1147,7 @@ fn workspace_in_git() {
                 members = ["foo"]
             "#,
             )
-            .file(
-                "foo/Cargo.toml",
-                r#"
-                [package]
-                name = "foo"
-                version = "0.1.0"
-            "#,
-            )
+            .file("foo/Cargo.toml", &basic_manifest("foo", "0.1.0"))
             .file("foo/src/lib.rs", "")
     }).unwrap();
     let p = project()
@@ -1312,15 +1186,7 @@ fn lockfile_can_specify_nonexistant_members() {
             members = ["a"]
         "#,
         )
-        .file(
-            "a/Cargo.toml",
-            r#"
-            [project]
-            name = "a"
-            version = "0.1.0"
-            authors = []
-        "#,
-        )
+        .file("a/Cargo.toml", &basic_manifest("a", "0.1.0"))
         .file("a/src/main.rs", "fn main() {}")
         .file(
             "Cargo.lock",
@@ -1352,15 +1218,7 @@ fn you_cannot_generate_lockfile_for_empty_workspaces() {
             [workspace]
         "#,
         )
-        .file(
-            "bar/Cargo.toml",
-            r#"
-            [project]
-            name = "foo"
-            version = "0.1.0"
-            authors = []
-        "#,
-        )
+        .file("bar/Cargo.toml", &basic_manifest("foo", "0.1.0"))
         .file("bar/src/main.rs", "fn main() {}");
     let p = p.build();
 
@@ -1416,15 +1274,7 @@ fn workspace_with_transitive_dev_deps() {
             }
         "#,
         )
-        .file(
-            "baz/Cargo.toml",
-            r#"
-            [project]
-            name = "baz"
-            version = "0.5.0"
-            authors = ["mbrubeck@example.com"]
-        "#,
-        )
+        .file("baz/Cargo.toml", &basic_manifest("baz", "0.5.0"))
         .file("baz/src/lib.rs", r#"pub fn do_stuff() {}"#);
     let p = p.build();
 
@@ -1435,15 +1285,7 @@ fn workspace_with_transitive_dev_deps() {
 fn error_if_parent_cargo_toml_is_invalid() {
     let p = project()
         .file("Cargo.toml", "Totally not a TOML file")
-        .file(
-            "bar/Cargo.toml",
-            r#"
-            [project]
-            name = "bar"
-            version = "0.1.0"
-            authors = []
-        "#,
-        )
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file("bar/src/main.rs", "fn main() {}");
     let p = p.build();
 
@@ -1512,15 +1354,7 @@ fn relative_path_for_root_works() {
     "#,
         )
         .file("src/main.rs", "fn main() {}")
-        .file(
-            "subproj/Cargo.toml",
-            r#"
-        [project]
-        name = "subproj"
-        version = "0.1.0"
-        authors = []
-    "#,
-        )
+        .file("subproj/Cargo.toml", &basic_manifest("subproj", "0.1.0"))
         .file("subproj/src/main.rs", "fn main() {}");
     let p = p.build();
 
@@ -1560,15 +1394,7 @@ fn path_dep_outside_workspace_is_not_member() {
         "#,
         )
         .file("ws/src/lib.rs", r"extern crate foo;")
-        .file(
-            "foo/Cargo.toml",
-            r#"
-            [project]
-            name = "foo"
-            version = "0.1.0"
-            authors = []
-        "#,
-        )
+        .file("foo/Cargo.toml", &basic_manifest("foo", "0.1.0"))
         .file("foo/src/lib.rs", "");
     let p = p.build();
 
@@ -1690,15 +1516,7 @@ fn test_path_dependency_under_member() {
             "foo/src/lib.rs",
             "extern crate bar; pub fn f() { bar::f() }",
         )
-        .file(
-            "foo/bar/Cargo.toml",
-            r#"
-            [project]
-            name = "bar"
-            version = "0.1.0"
-            authors = []
-        "#,
-        )
+        .file("foo/bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file("foo/bar/src/lib.rs", "pub fn f() { }");
     let p = p.build();
 
@@ -1741,15 +1559,7 @@ fn excluded_simple() {
         "#,
         )
         .file("src/lib.rs", "")
-        .file(
-            "foo/Cargo.toml",
-            r#"
-            [project]
-            name = "foo"
-            version = "0.1.0"
-            authors = []
-        "#,
-        )
+        .file("foo/Cargo.toml", &basic_manifest("foo", "0.1.0"))
         .file("foo/src/lib.rs", "");
     let p = p.build();
 
@@ -1779,25 +1589,9 @@ fn exclude_members_preferred() {
         "#,
         )
         .file("src/lib.rs", "")
-        .file(
-            "foo/Cargo.toml",
-            r#"
-            [project]
-            name = "foo"
-            version = "0.1.0"
-            authors = []
-        "#,
-        )
+        .file("foo/Cargo.toml", &basic_manifest("foo", "0.1.0"))
         .file("foo/src/lib.rs", "")
-        .file(
-            "foo/bar/Cargo.toml",
-            r#"
-            [project]
-            name = "bar"
-            version = "0.1.0"
-            authors = []
-        "#,
-        )
+        .file("foo/bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file("foo/bar/src/lib.rs", "");
     let p = p.build();
 
@@ -1834,25 +1628,9 @@ fn exclude_but_also_depend() {
         "#,
         )
         .file("src/lib.rs", "")
-        .file(
-            "foo/Cargo.toml",
-            r#"
-            [project]
-            name = "foo"
-            version = "0.1.0"
-            authors = []
-        "#,
-        )
+        .file("foo/Cargo.toml", &basic_manifest("foo", "0.1.0"))
         .file("foo/src/lib.rs", "")
-        .file(
-            "foo/bar/Cargo.toml",
-            r#"
-            [project]
-            name = "bar"
-            version = "0.1.0"
-            authors = []
-        "#,
-        )
+        .file("foo/bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file("foo/bar/src/lib.rs", "");
     let p = p.build();
 
@@ -2159,14 +1937,7 @@ fn dep_used_with_separate_features() {
 fn dont_recurse_out_of_cargo_home() {
     let git_project = git::new("dep", |project| {
         project
-            .file(
-                "Cargo.toml",
-                r#"
-                [package]
-                name = "dep"
-                version = "0.1.0"
-            "#,
-            )
+            .file("Cargo.toml", &basic_manifest("dep", "0.1.0"))
             .file("src/lib.rs", "")
             .file(
                 "build.rs",
@@ -2226,19 +1997,9 @@ fn include_and_exclude() {
             members = ["foo"]
             exclude = ["foo/bar"]
             "#)
-        .file("foo/Cargo.toml", r#"
-            [project]
-            name = "foo"
-            version = "0.1.0"
-            authors = []
-            "#)
+        .file("foo/Cargo.toml", &basic_manifest("foo", "0.1.0"))
         .file("foo/src/lib.rs", "")
-        .file("foo/bar/Cargo.toml", r#"
-            [project]
-            name = "bar"
-            version = "0.1.0"
-            authors = []
-            "#)
+        .file("foo/bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file("foo/bar/src/lib.rs", "");
     p.build();
 
@@ -2267,14 +2028,7 @@ fn cargo_home_at_root_works() {
         "#,
         )
         .file("src/lib.rs", "")
-        .file(
-            "a/Cargo.toml",
-            r#"
-            [package]
-            name = "a"
-            version = "0.1.0"
-        "#,
-        )
+        .file("a/Cargo.toml", &basic_manifest("a", "0.1.0"))
         .file("a/src/lib.rs", "");
     let p = p.build();
 


### PR DESCRIPTION
Wanted to deduplicate the "bar" manifest files too, and found I hadn't even done build.rs.