### PR TITLE
Apply dependency renamings when running rustdoc

### DIFF
--- a/src/cargo/core/compiler/compilation.rs
+++ b/src/cargo/core/compiler/compilation.rs
@@ -17,7 +17,7 @@ pub struct Doctest {
     pub target: Target,
     /// Extern dependencies needed by `rustdoc`. The path is the location of
     /// the compiled lib.
-    pub deps: Vec<(Target, PathBuf)>,
+    pub deps: Vec<(String, PathBuf)>,
 }
 
 /// A structure returning the result of a compilation.

--- a/src/cargo/core/compiler/context/mod.rs
+++ b/src/cargo/core/compiler/context/mod.rs
@@ -244,15 +244,16 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
                 for dep in self.dep_targets(unit) {
                     if dep.target.is_lib() && dep.mode == CompileMode::Build {
                         let outputs = self.outputs(&dep)?;
-                        doctest_deps.extend(
-                            outputs
-                                .iter()
-                                .filter(|output| {
-                                    output.path.extension() == Some(OsStr::new("rlib"))
-                                        || dep.target.for_host()
-                                })
-                                .map(|output| (dep.target.clone(), output.path.clone())),
-                        );
+                        let outputs = outputs.iter().filter(|output| {
+                            output.path.extension() == Some(OsStr::new("rlib"))
+                                || dep.target.for_host()
+                        });
+                        for output in outputs {
+                            doctest_deps.push((
+                                self.bcx.extern_crate_name(unit, &dep)?,
+                                output.path.clone(),
+                            ));
+                        }
                     }
                 }
                 self.compilation.to_doc_test.push(compilation::Doctest {

--- a/src/cargo/ops/cargo_test.rs
+++ b/src/cargo/ops/cargo_test.rs
@@ -193,8 +193,8 @@ fn run_doc_tests(
             }
         }
 
-        for &(ref target, ref lib) in deps.iter() {
-            let mut arg = OsString::from(target.crate_name());
+        for &(ref extern_crate_name, ref lib) in deps.iter() {
+            let mut arg = OsString::from(extern_crate_name);
             arg.push("=");
             arg.push(lib);
             p.arg("--extern").arg(&arg);

--- a/tests/testsuite/rename_deps.rs
+++ b/tests/testsuite/rename_deps.rs
@@ -363,3 +363,48 @@ fn rename_affects_fingerprint() {
         execs().with_status(101),
     );
 }
+
+#[test]
+fn can_run_doc_tests() {
+    Package::new("bar", "0.1.0").publish();
+    Package::new("bar", "0.2.0").publish();
+
+    let foo = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            cargo-features = ["rename-dependency"]
+
+            [project]
+            name = "foo"
+            version = "0.0.1"
+
+            [dependencies]
+            bar = { version = "0.1.0" }
+            baz = { version = "0.2.0", package = "bar" }
+        "#,
+        )
+        .file(
+            "src/lib.rs",
+            "
+            extern crate bar;
+            extern crate baz;
+        ",
+        )
+        .build();
+
+    assert_that(
+        foo.cargo("test").arg("-v").masquerade_as_nightly_cargo(),
+        execs().with_status(0).with_stderr_contains(format!(
+            "\
+[DOCTEST] foo
+[RUNNING] `rustdoc --test {dir}[/]src[/]lib.rs \
+        [..] \
+        --extern baz={dir}[/]target[/]debug[/]deps[/]libbar-[..].rlib \
+        --extern bar={dir}[/]target[/]debug[/]deps[/]libbar-[..].rlib \
+        [..]`
+",
+            dir = foo.root().display(),
+        )),
+    );
+}


### PR DESCRIPTION
Fixes #5792