### PR TITLE
Fix `test --doc` with incompatible lib types.

### DIFF
--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -628,9 +628,12 @@ impl Target {
     pub fn benched(&self) -> bool {
         self.benched
     }
-
     pub fn doctested(&self) -> bool {
-        self.doctest && match self.kind {
+        self.doctest
+    }
+
+    pub fn doctestable(&self) -> bool {
+        match self.kind {
             TargetKind::Lib(ref kinds) => kinds
                 .iter()
                 .any(|k| *k == LibKind::Rlib || *k == LibKind::Lib || *k == LibKind::ProcMacro),

--- a/tests/testsuite/build_lib.rs
+++ b/tests/testsuite/build_lib.rs
@@ -45,7 +45,7 @@ fn build_with_no_lib() {
         p.cargo("build").arg("--lib"),
         execs()
             .with_status(101)
-            .with_stderr("[ERROR] no library targets found"),
+            .with_stderr("[ERROR] no library targets found in package `foo`"),
     );
 }
 

--- a/tests/testsuite/test.rs
+++ b/tests/testsuite/test.rs
@@ -3547,3 +3547,45 @@ fn test_build_script_links() {
         execs().with_status(0),
     );
 }
+
+#[test]
+fn doctest_skip_staticlib() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.0.1"
+
+                [lib]
+                crate-type = ["staticlib"]
+            "#,
+        )
+        .file(
+            "src/lib.rs",
+            r#"
+            //! ```
+            //! assert_eq!(1,2);
+            //! ```
+            "#,
+        )
+        .build();
+
+    assert_that(
+        p.cargo("test --doc"),
+        execs().with_status(101).with_stderr(
+            "[ERROR] doc tests are not supported for crate type(s) `staticlib` in package `foo`",
+        ),
+    );
+
+    assert_that(
+        p.cargo("test"),
+        execs().with_status(0).with_stderr(
+            "\
+[COMPILING] foo [..]
+[FINISHED] dev [..]
+[RUNNING] target[/]debug[/]deps[/]foo-[..]",
+        ),
+    )
+}


### PR DESCRIPTION
When I recently changed the doctest handling, I forgot to check the lib type in
the `test --doc` scenario.

I also added the package name to a nearby error message, since it can be
confusing in a workspace setting.