### PR TITLE
Fix HgRepo::discover

### DIFF
--- a/src/cargo/util/vcs.rs
+++ b/src/cargo/util/vcs.rs
@@ -28,8 +28,9 @@ impl HgRepo {
     pub fn discover(path: &Path, cwd: &Path) -> CargoResult<HgRepo> {
         process("hg")
             .cwd(cwd)
+            .arg("--cwd")
+            .arg(path)
             .arg("root")
-            .cwd(path)
             .exec_with_output()?;
         Ok(HgRepo)
     }


### PR DESCRIPTION
Replace the duplicate .cwd call with an invocation taken from
https://stackoverflow.com/a/3138925/463761

Match the semantics of the other vcs calls, which is invoke from 'cwd'
targeting 'path'. Looks a little confusing because hg takes a '--cwd'
argument.