### PR TITLE
now that we respect gitignore tests can be simplified

### DIFF
--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -11,7 +11,6 @@ use support::{execs, main_file, project};
 use support::registry::Package;
 use support::ChannelChanger;
 use support::hamcrest::{assert_that, existing_dir, existing_file, is_not};
-use tempfile;
 
 #[test]
 fn cargo_compile_simple() {
@@ -485,8 +484,7 @@ Caused by:
 
 #[test]
 fn cargo_compile_without_manifest() {
-    let tmpdir = tempfile::Builder::new().prefix("cargo").tempdir().unwrap();
-    let p = ProjectBuilder::new(tmpdir.path().to_path_buf()).no_manifest().build();
+    let p = project().no_manifest().build();
 
     assert_that(
         p.cargo("build"),

--- a/tests/testsuite/fix.rs
+++ b/tests/testsuite/fix.rs
@@ -747,7 +747,6 @@ fn shows_warnings() {
 #[test]
 fn warns_if_no_vcs_detected() {
     let p = project()
-        .use_temp_dir()
         .file("src/lib.rs", "pub fn foo() {}")
         .build();
 

--- a/tests/testsuite/init.rs
+++ b/tests/testsuite/init.rs
@@ -6,7 +6,6 @@ use std::env;
 use cargo::util::ProcessBuilder;
 use support::{cargo_exe, execs, paths};
 use support::hamcrest::{assert_that, existing_dir, existing_file, is_not};
-use tempfile;
 
 fn cargo_process(s: &str) -> ProcessBuilder {
     let mut p = support::process(&cargo_exe());
@@ -62,12 +61,10 @@ fn simple_bin() {
 
 #[test]
 fn both_lib_and_bin() {
-    let td = tempfile::Builder::new().prefix("cargo").tempdir().unwrap();
     assert_that(
         cargo_process("init")
             .arg("--lib")
             .arg("--bin")
-            .cwd(td.path())
             .env("USER", "foo"),
         execs()
             .with_status(101)
@@ -304,21 +301,17 @@ fn simple_git() {
 
 #[test]
 fn auto_git() {
-    let td = tempfile::Builder::new().prefix("cargo").tempdir().unwrap();
-    let foo = &td.path().join("foo");
-    fs::create_dir_all(&foo).unwrap();
     assert_that(
         cargo_process("init")
             .arg("--lib")
-            .cwd(foo.clone())
             .env("USER", "foo"),
         execs().with_status(0),
     );
 
-    assert_that(&foo.join("Cargo.toml"), existing_file());
-    assert_that(&foo.join("src/lib.rs"), existing_file());
-    assert_that(&foo.join(".git"), existing_dir());
-    assert_that(&foo.join(".gitignore"), existing_file());
+    assert_that(&paths::root().join("Cargo.toml"), existing_file());
+    assert_that(&paths::root().join("src/lib.rs"), existing_file());
+    assert_that(&paths::root().join(".git"), existing_dir());
+    assert_that(&paths::root().join(".gitignore"), existing_file());
 }
 
 #[test]

--- a/tests/testsuite/main.rs
+++ b/tests/testsuite/main.rs
@@ -13,7 +13,6 @@ extern crate serde_derive;
 #[macro_use]
 extern crate serde_json;
 extern crate tar;
-extern crate tempfile;
 extern crate toml;
 extern crate url;
 #[cfg(windows)]


### PR DESCRIPTION
There are a lot of test that used a tempfile to avoid the fact that cargo would not init a git in the test folder. (or because they were copy/pasted from one that did.) Now that #5733 landed we can remove them all.