### PR TITLE
Move existing_vcs_repo to the util::vcs module

### DIFF
--- a/src/cargo/ops/cargo_new.rs
+++ b/src/cargo/ops/cargo_new.rs
@@ -8,7 +8,7 @@ use git2::Config as GitConfig;
 use git2::Repository as GitRepository;
 
 use core::{compiler, Workspace};
-use util::{internal, FossilRepo, GitRepo, HgRepo, PijulRepo};
+use util::{internal, FossilRepo, GitRepo, HgRepo, PijulRepo, existing_vcs_repo};
 use util::{paths, Config};
 use util::errors::{CargoResult, CargoResultExt};
 
@@ -407,21 +407,6 @@ pub fn init(opts: &NewOptions, config: &Config) -> CargoResult<()> {
         )
     })?;
     Ok(())
-}
-
-// Check if we are in an existing repo. We define that to be true if either:
-//
-// 1. We are in a git repo and the path to the new project is not an ignored
-//    path in that repo.
-// 2. We are in an HG repo.
-pub fn existing_vcs_repo(path: &Path, cwd: &Path) -> bool {
-    fn in_git_repo(path: &Path, cwd: &Path) -> bool {
-        if let Ok(repo) = GitRepo::discover(path, cwd) {
-            repo.is_path_ignored(path).map(|ignored| !ignored).unwrap_or(true)
-        } else { false }
-    }
-
-    in_git_repo(path, cwd) || HgRepo::discover(path, cwd).is_ok()
 }
 
 fn mk(config: &Config, opts: &MkOptions) -> CargoResult<()> {

--- a/src/cargo/ops/fix.rs
+++ b/src/cargo/ops/fix.rs
@@ -14,9 +14,8 @@ use serde_json;
 
 use core::Workspace;
 use ops::{self, CompileOptions};
-use ops::cargo_new::existing_vcs_repo;
 use util::errors::CargoResult;
-use util::{LockServer, LockServerClient};
+use util::{LockServer, LockServerClient, existing_vcs_repo};
 use util::diagnostic_server::{Message, RustfixDiagnosticServer};
 use util::paths;
 

--- a/src/cargo/util/mod.rs
+++ b/src/cargo/util/mod.rs
@@ -15,7 +15,7 @@ pub use self::rustc::Rustc;
 pub use self::sha256::Sha256;
 pub use self::to_semver::ToSemver;
 pub use self::to_url::ToUrl;
-pub use self::vcs::{FossilRepo, GitRepo, HgRepo, PijulRepo};
+pub use self::vcs::{FossilRepo, GitRepo, HgRepo, PijulRepo, existing_vcs_repo};
 pub use self::read2::read2;
 pub use self::progress::{Progress, ProgressStyle};
 pub use self::lockserver::{LockServer, LockServerStarted, LockServerClient};

--- a/src/cargo/util/vcs.rs
+++ b/src/cargo/util/vcs.rs
@@ -5,6 +5,21 @@ use git2;
 
 use util::{process, CargoResult};
 
+// Check if we are in an existing repo. We define that to be true if either:
+//
+// 1. We are in a git repo and the path to the new project is not an ignored
+//    path in that repo.
+// 2. We are in an HG repo.
+pub fn existing_vcs_repo(path: &Path, cwd: &Path) -> bool {
+    fn in_git_repo(path: &Path, cwd: &Path) -> bool {
+        if let Ok(repo) = GitRepo::discover(path, cwd) {
+            repo.is_path_ignored(path).map(|ignored| !ignored).unwrap_or(true)
+        } else { false }
+    }
+
+    in_git_repo(path, cwd) || HgRepo::discover(path, cwd).is_ok()
+}
+
 pub struct HgRepo;
 pub struct GitRepo;
 pub struct PijulRepo;


### PR DESCRIPTION
Rather than being in cargo_new publically exposed and used by cargo fix.

Just a proposal, as it looked weird to me.