### PR TITLE
Improve `check_not_dirty` git repo detection and status shell output of results.

### DIFF
--- a/src/cargo/ops/cargo_package.rs
+++ b/src/cargo/ops/cargo_package.rs
@@ -152,7 +152,12 @@ fn verify_dependencies(pkg: &Package) -> CargoResult<()> {
     Ok(())
 }
 
-fn check_not_dirty(p: &Package, src: &PathSource, ws: &Workspace, config: &Config) -> CargoResult<()> {
+fn check_not_dirty(
+    p: &Package,
+    src: &PathSource,
+    ws: &Workspace,
+    config: &Config
+) -> CargoResult<()> {
     let res = git2::Repository::discover(p.root())
         .or_else(|_e| git2::Repository::discover(ws.root()));
     match res {

--- a/src/cargo/ops/cargo_package.rs
+++ b/src/cargo/ops/cargo_package.rs
@@ -59,7 +59,7 @@ pub fn package(ws: &Workspace, opts: &PackageOpts) -> CargoResult<Option<FileLoc
     }
 
     if !opts.allow_dirty {
-        check_not_dirty(pkg, &src)?;
+        check_not_dirty(pkg, &src, &config)?;
     }
 
     let filename = format!("{}-{}.crate", pkg.name(), pkg.version());
@@ -152,7 +152,7 @@ fn verify_dependencies(pkg: &Package) -> CargoResult<()> {
     Ok(())
 }
 
-fn check_not_dirty(p: &Package, src: &PathSource) -> CargoResult<()> {
+fn check_not_dirty(p: &Package, src: &PathSource, config: &Config) -> CargoResult<()> {
     if let Ok(repo) = git2::Repository::discover(p.root()) {
         if let Some(workdir) = repo.workdir() {
             debug!(
@@ -172,6 +172,7 @@ fn check_not_dirty(p: &Package, src: &PathSource) -> CargoResult<()> {
 
     // No VCS recognized, we don't know if the directory is dirty or not, so we
     // have to assume that it's clean.
+    config.shell().verbose(|shell| shell.warn("No (git) VCS found"))?;
     return Ok(());
 
     fn git(p: &Package, src: &PathSource, repo: &git2::Repository) -> CargoResult<()> {

--- a/tests/testsuite/package.rs
+++ b/tests/testsuite/package.rs
@@ -219,6 +219,7 @@ fn package_verbose() {
             "\
 [WARNING] manifest has no description[..]
 See http://doc.crates.io/manifest.html#package-metadata for more info.
+[CHECKING] git repo ([..])
 [PACKAGING] foo v0.0.1 ([..])
 [ARCHIVING] [..]
 [ARCHIVING] [..]
@@ -237,6 +238,7 @@ See http://doc.crates.io/manifest.html#package-metadata for more info.
             "\
 [WARNING] manifest has no description[..]
 See http://doc.crates.io/manifest.html#package-metadata for more info.
+[CHECKING] git repo ([..])
 [PACKAGING] a v0.0.1 ([..])
 [ARCHIVING] [..]
 [ARCHIVING] [..]
@@ -397,7 +399,7 @@ fn exclude() {
             "\
 [WARNING] manifest has no description[..]
 See http://doc.crates.io/manifest.html#package-metadata for more info.
-[WARNING] No (git) VCS found
+[CHECKING] git repo ([..])
 [PACKAGING] foo v0.0.1 ([..])
 [WARNING] [..] file `dir_root_1[/]some_dir[/]file` WILL be excluded [..]
 See [..]
@@ -489,7 +491,7 @@ fn include() {
             "\
 [WARNING] manifest has no description[..]
 See http://doc.crates.io/manifest.html#package-metadata for more info.
-[WARNING] No (git) VCS found
+[CHECKING] git repo ([..])
 [PACKAGING] foo v0.0.1 ([..])
 [ARCHIVING] [..]
 [ARCHIVING] [..]

--- a/tests/testsuite/package.rs
+++ b/tests/testsuite/package.rs
@@ -397,6 +397,7 @@ fn exclude() {
             "\
 [WARNING] manifest has no description[..]
 See http://doc.crates.io/manifest.html#package-metadata for more info.
+[WARNING] No (git) VCS found
 [PACKAGING] foo v0.0.1 ([..])
 [WARNING] [..] file `dir_root_1[/]some_dir[/]file` WILL be excluded [..]
 See [..]
@@ -488,6 +489,7 @@ fn include() {
             "\
 [WARNING] manifest has no description[..]
 See http://doc.crates.io/manifest.html#package-metadata for more info.
+[WARNING] No (git) VCS found
 [PACKAGING] foo v0.0.1 ([..])
 [ARCHIVING] [..]
 [ARCHIVING] [..]


### PR DESCRIPTION
Fixes #5823 

Also fix associated tests. This is an attempt to clarify windows+git package behavior as uncovered in #5786.  ~~This is a Work In Progress not yet ready for merge.~~

This conflicts with #5786, but either could be merged first, requiring a rebase/merge in the other.  