### PR TITLE
Add more diagnostics to smooth edition transition 

### DIFF
--- a/src/cargo/core/compiler/job_queue.rs
+++ b/src/cargo/core/compiler/job_queue.rs
@@ -16,7 +16,7 @@ use handle_error;
 use util::{internal, profile, CargoResult, CargoResultExt, ProcessBuilder};
 use util::{Config, DependencyQueue, Dirty, Fresh, Freshness};
 use util::{Progress, ProgressStyle};
-use util::diagnostic_server;
+use util::diagnostic_server::{self, DiagnosticPrinter};
 
 use super::job::Job;
 use super::{BuildContext, BuildPlan, CompileMode, Context, Kind, Unit};
@@ -200,6 +200,7 @@ impl<'a> JobQueue<'a> {
         let mut tokens = Vec::new();
         let mut queue = Vec::new();
         let build_plan = cx.bcx.build_config.build_plan;
+        let mut print = DiagnosticPrinter::new(cx.bcx.config);
         trace!("queue: {:#?}", self.queue);
 
         // Iteratively execute the entire dependency graph. Each turn of the
@@ -311,7 +312,7 @@ impl<'a> JobQueue<'a> {
                     }
                 }
                 Message::FixDiagnostic(msg) => {
-                    msg.print_to(cx.bcx.config)?;
+                    print.print(&msg)?;
                 }
                 Message::Finish(key, result) => {
                     info!("end: {:?}", key);

--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -161,11 +161,14 @@ fn compile<'a, 'cfg: 'a>(
 }
 
 fn rustc<'a, 'cfg>(
-    mut cx: &mut Context<'a, 'cfg>,
+    cx: &mut Context<'a, 'cfg>,
     unit: &Unit<'a>,
     exec: &Arc<Executor>,
 ) -> CargoResult<Work> {
     let mut rustc = prepare_rustc(cx, &unit.target.rustc_crate_types(), unit)?;
+    if cx.is_primary_package(unit) {
+        rustc.env("CARGO_PRIMARY_PACKAGE", "1");
+    }
     let build_plan = cx.bcx.build_config.build_plan;
 
     let name = unit.pkg.name().to_string();
@@ -195,7 +198,7 @@ fn rustc<'a, 'cfg>(
     } else {
         root.join(&cx.files().file_stem(unit))
     }.with_extension("d");
-    let dep_info_loc = fingerprint::dep_info_loc(&mut cx, unit);
+    let dep_info_loc = fingerprint::dep_info_loc(cx, unit);
 
     rustc.args(&cx.bcx.rustflags_args(unit)?);
     let json_messages = cx.bcx.build_config.json_messages();

--- a/src/cargo/ops/fix.rs
+++ b/src/cargo/ops/fix.rs
@@ -134,7 +134,7 @@ pub fn fix_maybe_exec_rustc() -> CargoResult<bool> {
     // not the best heuristic but matches what Cargo does today at least.
     let mut fixes = FixedCrate::default();
     if let Some(path) = filename {
-        if !Path::new(&path).is_absolute() {
+        if env::var("CARGO_PRIMARY_PACKAGE").is_ok() {
             trace!("start rustfixing {:?}", path);
             fixes = rustfix_crate(&lock_addr, rustc.as_ref(), &path)?;
         }

--- a/src/cargo/util/diagnostic_server.rs
+++ b/src/cargo/util/diagnostic_server.rs
@@ -1,6 +1,7 @@
 //! A small TCP server to handle collection of diagnostics information in a
 //! cross-platform way for the `cargo fix` command.
 
+use std::collections::HashSet;
 use std::env;
 use std::io::{BufReader, Read, Write};
 use std::net::{Shutdown, SocketAddr, TcpListener, TcpStream};
@@ -39,6 +40,14 @@ pub enum Message {
         file: String,
         message: String,
     },
+    PreviewNotFound {
+        file: String,
+        edition: String,
+    },
+    EditionAlreadyEnabled {
+        file: String,
+        edition: String,
+    },
 }
 
 impl Message {
@@ -70,49 +79,104 @@ impl Message {
 
         Ok(())
     }
+}
 
-    pub fn print_to(&self, config: &Config) -> CargoResult<()> {
-        match self {
+pub struct DiagnosticPrinter<'a> {
+    config: &'a Config,
+    preview_not_found: HashSet<String>,
+    edition_already_enabled: HashSet<String>,
+}
+
+impl<'a> DiagnosticPrinter<'a> {
+    pub fn new(config: &'a Config) -> DiagnosticPrinter<'a> {
+        DiagnosticPrinter {
+            config,
+            preview_not_found: HashSet::new(),
+            edition_already_enabled: HashSet::new(),
+        }
+    }
+
+    pub fn print(&mut self, msg: &Message) -> CargoResult<()> {
+        match msg {
             Message::Fixing { file, fixes } => {
                 let msg = if *fixes == 1 { "fix" } else { "fixes" };
                 let msg = format!("{} ({} {})", file, fixes, msg);
-                config.shell().status("Fixing", msg)
+                self.config.shell().status("Fixing", msg)
             }
             Message::ReplaceFailed { file, message } => {
                 let msg = format!("error applying suggestions to `{}`\n", file);
-                config.shell().warn(&msg)?;
+                self.config.shell().warn(&msg)?;
                 write!(
-                    config.shell().err(),
+                    self.config.shell().err(),
                     "The full error message was:\n\n> {}\n\n",
                     message,
                 )?;
-                write!(config.shell().err(), "{}", PLEASE_REPORT_THIS_BUG)?;
+                write!(self.config.shell().err(), "{}", PLEASE_REPORT_THIS_BUG)?;
                 Ok(())
             }
             Message::FixFailed { files, krate } => {
                 if let Some(ref krate) = *krate {
-                    config.shell().warn(&format!(
+                    self.config.shell().warn(&format!(
                         "failed to automatically apply fixes suggested by rustc \
                          to crate `{}`",
                         krate,
                     ))?;
                 } else {
-                    config.shell().warn(
+                    self.config.shell().warn(
                         "failed to automatically apply fixes suggested by rustc"
                     )?;
                 }
                 if !files.is_empty() {
                     writeln!(
-                        config.shell().err(),
+                        self.config.shell().err(),
                         "\nafter fixes were automatically applied the compiler \
                          reported errors within these files:\n"
                     )?;
                     for file in files {
-                        writeln!(config.shell().err(), "  * {}", file)?;
+                        writeln!(self.config.shell().err(), "  * {}", file)?;
                     }
-                    writeln!(config.shell().err())?;
+                    writeln!(self.config.shell().err())?;
                 }
-                write!(config.shell().err(), "{}", PLEASE_REPORT_THIS_BUG)?;
+                write!(self.config.shell().err(), "{}", PLEASE_REPORT_THIS_BUG)?;
+                Ok(())
+            }
+            Message::PreviewNotFound { file, edition } => {
+                // By default we're fixing a lot of things concurrently, don't
+                // warn about the same file multiple times.
+                if !self.preview_not_found.insert(file.clone()) {
+                    return Ok(())
+                }
+                self.config.shell().warn(&format!(
+                    "failed to find `#![feature(rust_{}_preview)]` in `{}`\n\
+                     this may cause `cargo fix` to not be able to fix all\n\
+                     issues in preparation for the {0} edition",
+                    edition,
+                    file,
+                ))?;
+                Ok(())
+            }
+            Message::EditionAlreadyEnabled { file, edition } => {
+                // Like above, only warn once per file
+                if !self.edition_already_enabled.insert(file.clone()) {
+                    return Ok(())
+                }
+
+                let msg = format!(
+                    "\
+cannot prepare for the {} edition when it is enabled, so cargo cannot
+automatically fix errors in `{}`
+
+To prepare for the {0} edition you should first remove `edition = '{0}'` from
+your `Cargo.toml` and then rerun this command. Once all warnings have been fixed
+then you can re-enable the `edition` key in `Cargo.toml`. For some more
+information about transitioning to the {0} edition see:
+
+  https://rust-lang-nursery.github.io/edition-guide/editions/transitioning.html
+",
+                    edition,
+                    file,
+                );
+                self.config.shell().error(&msg)?;
                 Ok(())
             }
         }

--- a/src/cargo/util/lockserver.rs
+++ b/src/cargo/util/lockserver.rs
@@ -14,6 +14,7 @@
 use std::collections::HashMap;
 use std::io::{BufRead, BufReader, Read, Write};
 use std::net::{SocketAddr, TcpListener, TcpStream};
+use std::path::Path;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::thread::{self, JoinHandle};
@@ -155,11 +156,11 @@ impl Drop for LockServerStarted {
 }
 
 impl LockServerClient {
-    pub fn lock(addr: &SocketAddr, name: &str) -> Result<LockServerClient, Error> {
+    pub fn lock(addr: &SocketAddr, name: &Path) -> Result<LockServerClient, Error> {
         let mut client =
             TcpStream::connect(&addr).with_context(|_| "failed to connect to parent lock server")?;
         client
-            .write_all(name.as_bytes())
+            .write_all(name.display().to_string().as_bytes())
             .and_then(|_| client.write_all(b"\n"))
             .with_context(|_| "failed to write to lock server")?;
         let mut buf = [0];

--- a/tests/testsuite/fix.rs
+++ b/tests/testsuite/fix.rs
@@ -196,7 +196,7 @@ fn fix_path_deps() {
         .build();
 
     assert_that(
-        p.cargo("fix --allow-no-vcs")
+        p.cargo("fix --allow-no-vcs -p foo -p bar")
             .env("__CARGO_FIX_YOLO", "1"),
         execs()
             .with_status(0)

--- a/tests/testsuite/fix.rs
+++ b/tests/testsuite/fix.rs
@@ -356,6 +356,9 @@ fn local_paths_no_fix() {
 
     let stderr = "\
 [CHECKING] foo v0.0.1 ([..])
+warning: failed to find `#![feature(rust_2018_preview)]` in `src[/]lib.rs`
+this may cause `cargo fix` to not be able to fix all
+issues in preparation for the 2018 edition
 [FINISHED] [..]
 ";
     assert_that(
@@ -856,4 +859,71 @@ fn fix_all_targets_by_default() {
     );
     assert!(!p.read_file("src/lib.rs").contains("let mut x"));
     assert!(!p.read_file("tests/foo.rs").contains("let mut x"));
+}
+
+#[test]
+fn prepare_for_and_enable() {
+    if !is_nightly() {
+        return
+    }
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                cargo-features = ['edition']
+
+                [package]
+                name = 'foo'
+                version = '0.1.0'
+                edition = '2018'
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    let stderr = "\
+[CHECKING] foo v0.1.0 ([..])
+error: cannot prepare for the 2018 edition when it is enabled, so cargo cannot
+automatically fix errors in `src[/]lib.rs`
+
+To prepare for the 2018 edition you should first remove `edition = '2018'` from
+your `Cargo.toml` and then rerun this command. Once all warnings have been fixed
+then you can re-enable the `edition` key in `Cargo.toml`. For some more
+information about transitioning to the 2018 edition see:
+
+  https://[..]
+
+";
+    assert_that(
+        p.cargo("fix --prepare-for 2018 --allow-no-vcs")
+            .masquerade_as_nightly_cargo(),
+        execs()
+            .with_stderr_contains(stderr)
+            .with_status(101),
+    );
+}
+
+#[test]
+fn prepare_for_without_feature_issues_warning() {
+    if !is_nightly() {
+        return
+    }
+    let p = project()
+        .file("src/lib.rs", "")
+        .build();
+
+    let stderr = "\
+[CHECKING] foo v0.0.1 ([..])
+warning: failed to find `#![feature(rust_2018_preview)]` in `src[/]lib.rs`
+this may cause `cargo fix` to not be able to fix all
+issues in preparation for the 2018 edition
+[FINISHED] [..]
+";
+    assert_that(
+        p.cargo("fix --prepare-for 2018 --allow-no-vcs")
+            .masquerade_as_nightly_cargo(),
+        execs()
+            .with_stderr(stderr)
+            .with_status(0),
+    );
 }


### PR DESCRIPTION
This commit adds two diagnostics in particular to ease the transition into the
2018 edition. The current transition process is pretty particular and must be
done carefully, so let's try to automate things to make it as painless as
possible! Notably the new diagnostics are:

* If you `cargo fix --prepare-for 2018` a crate which already has the 2018
  edition enabled, then an error is generated. This is because the compiler
  can't prepare for the 2018 edition if you're already in the 2018 edition, the
  lints won't have a chance to fire. You can only execute `--prepare-for 2018`
  over crates in the 2015 edition.

* If you `cargo fix --prepare-for 2018` and have forgotten the
  `rust_2018_preview` feature, a warning is issued. The lints don't fire unless
  the feature is enabled, so this is intended to warn in this situation to
  ensure that lints fire as much as they can.

After this commit if `cargo fix --prepare-for` exits successfully with zero
warnings then crates should be guaranteed to be compatible!

Closes #5778

