### PR TITLE
cargo can silently fix some bad lockfiles (use --locked to disable)

### DIFF
--- a/src/cargo/core/resolver/encode.rs
+++ b/src/cargo/core/resolver/encode.rs
@@ -29,8 +29,23 @@ struct Patch {
 
 pub type Metadata = BTreeMap<String, String>;
 
+pub enum ErrorHandle{
+    Ignore,
+    Raise,
+}
+
+impl ErrorHandle {
+    fn is_ignore(&self) -> bool {
+        use self::ErrorHandle::*;
+        match self {
+            Ignore => true,
+            Raise => false,
+        }
+    }
+}
+
 impl EncodableResolve {
-    pub fn into_resolve(self, ws: &Workspace, ignore_errors: bool) -> CargoResult<Resolve> {
+    pub fn into_resolve(self, ws: &Workspace, ignore_errors: ErrorHandle) -> CargoResult<Resolve> {
         let path_deps = build_path_deps(ws);
 
         let packages = {
@@ -83,7 +98,7 @@ impl EncodableResolve {
                     // Package is found in the lockfile, but it is
                     // no longer a member of the workspace.
                     Ok(None)
-                } else if ignore_errors {
+                } else if ignore_errors.is_ignore() {
                     // We are asked to ignore errors
                     Ok(None)
                 } else {

--- a/src/cargo/core/resolver/encode.rs
+++ b/src/cargo/core/resolver/encode.rs
@@ -2,12 +2,12 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fmt;
 use std::str::FromStr;
 
-use serde::ser;
 use serde::de;
+use serde::ser;
 
 use core::{Dependency, Package, PackageId, SourceId, Workspace};
-use util::{internal, Graph};
 use util::errors::{CargoError, CargoResult, CargoResultExt};
+use util::{internal, Graph};
 
 use super::Resolve;
 
@@ -29,23 +29,8 @@ struct Patch {
 
 pub type Metadata = BTreeMap<String, String>;
 
-pub enum ErrorHandle{
-    Ignore,
-    Raise,
-}
-
-impl ErrorHandle {
-    fn is_ignore(&self) -> bool {
-        use self::ErrorHandle::*;
-        match self {
-            Ignore => true,
-            Raise => false,
-        }
-    }
-}
-
 impl EncodableResolve {
-    pub fn into_resolve(self, ws: &Workspace, ignore_errors: ErrorHandle) -> CargoResult<Resolve> {
+    pub fn into_resolve(self, ws: &Workspace) -> CargoResult<Resolve> {
         let path_deps = build_path_deps(ws);
 
         let packages = {
@@ -58,7 +43,7 @@ impl EncodableResolve {
 
         // `PackageId`s in the lock file don't include the `source` part
         // for workspace members, so we reconstruct proper ids.
-        let (live_pkgs, all_pkgs) = {
+        let live_pkgs = {
             let mut live_pkgs = HashMap::new();
             let mut all_pkgs = HashSet::new();
             for pkg in packages.iter() {
@@ -69,10 +54,7 @@ impl EncodableResolve {
                 };
 
                 if !all_pkgs.insert(enc_id.clone()) {
-                    bail!(
-                        "package `{}` is specified twice in the lockfile",
-                        pkg.name
-                    );
+                    bail!("package `{}` is specified twice in the lockfile", pkg.name);
                 }
                 let id = match pkg.source.as_ref().or_else(|| path_deps.get(&pkg.name)) {
                     // We failed to find a local package in the workspace.
@@ -86,33 +68,11 @@ impl EncodableResolve {
 
                 assert!(live_pkgs.insert(enc_id, (id, pkg)).is_none())
             }
-            (live_pkgs, all_pkgs)
+            live_pkgs
         };
 
-        let lookup_id = |enc_id: &EncodablePackageId,
-                         dependent_pkg: Option<&PackageId>|
-         -> CargoResult<Option<PackageId>> {
-            match live_pkgs.get(enc_id) {
-                Some(&(ref id, _)) => Ok(Some(id.clone())),
-                None => if all_pkgs.contains(enc_id) {
-                    // Package is found in the lockfile, but it is
-                    // no longer a member of the workspace.
-                    Ok(None)
-                } else if ignore_errors.is_ignore() {
-                    // We are asked to ignore errors
-                    Ok(None)
-                } else {
-                    let suggestion = dependent_pkg
-                        .map(|p| format!("\n  consider running 'cargo update -p {}'", p.name()))
-                        .unwrap_or_default();
-                    bail!(
-                        "package `{}` is specified as a dependency, \
-                         but is missing from the package list{}",
-                        enc_id,
-                        suggestion,
-                    );
-                },
-            }
+        let lookup_id = |enc_id: &EncodablePackageId| -> Option<PackageId> {
+            live_pkgs.get(enc_id).map(|&(ref id, _)| id.clone())
         };
 
         let g = {
@@ -129,7 +89,7 @@ impl EncodableResolve {
                 };
 
                 for edge in deps.iter() {
-                    if let Some(to_depend_on) = lookup_id(edge, Some(id))? {
+                    if let Some(to_depend_on) = lookup_id(edge) {
                         g.link(id.clone(), to_depend_on);
                     }
                 }
@@ -142,7 +102,7 @@ impl EncodableResolve {
             for &(ref id, pkg) in live_pkgs.values() {
                 if let Some(ref replace) = pkg.replace {
                     assert!(pkg.dependencies.is_none());
-                    if let Some(replace_id) = lookup_id(replace, Some(id))? {
+                    if let Some(replace_id) = lookup_id(replace) {
                         replacements.insert(id.clone(), replace_id);
                     }
                 }
@@ -173,10 +133,11 @@ impl EncodableResolve {
         for (k, v) in metadata.iter().filter(|p| p.0.starts_with(prefix)) {
             to_remove.push(k.to_string());
             let k = &k[prefix.len()..];
-            let enc_id: EncodablePackageId = k.parse()
+            let enc_id: EncodablePackageId = k
+                .parse()
                 .chain_err(|| internal("invalid encoding of checksum in lockfile"))?;
-            let id = match lookup_id(&enc_id, None) {
-                Ok(Some(id)) => id,
+            let id = match lookup_id(&enc_id) {
+                Some(id) => id,
                 _ => continue,
             };
 
@@ -217,7 +178,8 @@ fn build_path_deps(ws: &Workspace) -> HashMap<String, SourceId> {
     // such as `cargo install` with a lock file from a remote dependency. In
     // that case we don't need to fixup any path dependencies (as they're not
     // actually path dependencies any more), so we ignore them.
-    let members = ws.members()
+    let members = ws
+        .members()
         .filter(|p| p.package_id().source_id().is_path())
         .collect::<Vec<_>>();
 
@@ -317,7 +279,8 @@ impl FromStr for EncodablePackageId {
     fn from_str(s: &str) -> CargoResult<EncodablePackageId> {
         let mut s = s.splitn(3, ' ');
         let name = s.next().unwrap();
-        let version = s.next()
+        let version = s
+            .next()
             .ok_or_else(|| internal("invalid serialized PackageId"))?;
         let source_id = match s.next() {
             Some(s) => {
@@ -373,7 +336,8 @@ impl<'a, 'cfg> ser::Serialize for WorkspaceResolve<'a, 'cfg> {
         let mut ids: Vec<_> = self.resolve.iter().collect();
         ids.sort();
 
-        let encodable = ids.iter()
+        let encodable = ids
+            .iter()
             .filter_map(|&id| Some(encodable_resolve_node(id, self.resolve)))
             .collect::<Vec<_>>();
 
@@ -395,7 +359,8 @@ impl<'a, 'cfg> ser::Serialize for WorkspaceResolve<'a, 'cfg> {
         };
 
         let patch = Patch {
-            unused: self.resolve
+            unused: self
+                .resolve
                 .unused_patches()
                 .iter()
                 .map(|id| EncodableDependency {

--- a/src/cargo/core/resolver/encode.rs
+++ b/src/cargo/core/resolver/encode.rs
@@ -30,7 +30,7 @@ struct Patch {
 pub type Metadata = BTreeMap<String, String>;
 
 impl EncodableResolve {
-    pub fn into_resolve(self, ws: &Workspace) -> CargoResult<Resolve> {
+    pub fn into_resolve(self, ws: &Workspace, ignore_errors: bool) -> CargoResult<Resolve> {
         let path_deps = build_path_deps(ws);
 
         let packages = {
@@ -82,6 +82,9 @@ impl EncodableResolve {
                 None => if all_pkgs.contains(enc_id) {
                     // Package is found in the lockfile, but it is
                     // no longer a member of the workspace.
+                    Ok(None)
+                } else if ignore_errors {
+                    // We are asked to ignore errors
                     Ok(None)
                 } else {
                     let suggestion = dependent_pkg

--- a/src/cargo/core/resolver/mod.rs
+++ b/src/cargo/core/resolver/mod.rs
@@ -66,7 +66,7 @@ use self::context::{Activations, Context};
 use self::types::{ActivateError, ActivateResult, Candidate, ConflictReason, DepsFrame, GraphNode};
 use self::types::{RcVecIter, RegistryQueryer};
 
-pub use self::encode::{EncodableDependency, EncodablePackageId, EncodableResolve, ErrorHandle};
+pub use self::encode::{EncodableDependency, EncodablePackageId, EncodableResolve};
 pub use self::encode::{Metadata, WorkspaceResolve};
 pub use self::resolve::{Deps, DepsNotReplaced, Resolve};
 pub use self::types::Method;

--- a/src/cargo/core/resolver/mod.rs
+++ b/src/cargo/core/resolver/mod.rs
@@ -66,7 +66,7 @@ use self::context::{Activations, Context};
 use self::types::{ActivateError, ActivateResult, Candidate, ConflictReason, DepsFrame, GraphNode};
 use self::types::{RcVecIter, RegistryQueryer};
 
-pub use self::encode::{EncodableDependency, EncodablePackageId, EncodableResolve};
+pub use self::encode::{EncodableDependency, EncodablePackageId, EncodableResolve, ErrorHandle};
 pub use self::encode::{Metadata, WorkspaceResolve};
 pub use self::resolve::{Deps, DepsNotReplaced, Resolve};
 pub use self::types::Method;

--- a/src/cargo/ops/cargo_generate_lockfile.rs
+++ b/src/cargo/ops/cargo_generate_lockfile.rs
@@ -2,10 +2,10 @@ use std::collections::{BTreeMap, HashSet};
 
 use termcolor::Color::{self, Cyan, Green, Red};
 
-use core::PackageId;
 use core::registry::PackageRegistry;
+use core::resolver::Method;
+use core::PackageId;
 use core::{Resolve, SourceId, Workspace};
-use core::resolver::{Method, ErrorHandle};
 use ops;
 use util::config::Config;
 use util::CargoResult;
@@ -46,8 +46,7 @@ pub fn update_lockfile(ws: &Workspace, opts: &UpdateOptions) -> CargoResult<()> 
         bail!("you can't update in the offline mode");
     }
 
-    // ignore errors, because we are about to clean them up.
-    let previous_resolve = match ops::load_pkg_lockfile(ws, ErrorHandle::Ignore)? {
+    let previous_resolve = match ops::load_pkg_lockfile(ws)? {
         Some(resolve) => resolve,
         None => return generate_lockfile(ws),
     };

--- a/src/cargo/ops/cargo_generate_lockfile.rs
+++ b/src/cargo/ops/cargo_generate_lockfile.rs
@@ -46,7 +46,8 @@ pub fn update_lockfile(ws: &Workspace, opts: &UpdateOptions) -> CargoResult<()> 
         bail!("you can't update in the offline mode");
     }
 
-    let previous_resolve = match ops::load_pkg_lockfile(ws)? {
+    // `ignore_errors` is set to true, because we are about to clean the errors up.
+    let previous_resolve = match ops::load_pkg_lockfile(ws, true)? {
         Some(resolve) => resolve,
         None => return generate_lockfile(ws),
     };

--- a/src/cargo/ops/cargo_generate_lockfile.rs
+++ b/src/cargo/ops/cargo_generate_lockfile.rs
@@ -5,7 +5,7 @@ use termcolor::Color::{self, Cyan, Green, Red};
 use core::PackageId;
 use core::registry::PackageRegistry;
 use core::{Resolve, SourceId, Workspace};
-use core::resolver::Method;
+use core::resolver::{Method, ErrorHandle};
 use ops;
 use util::config::Config;
 use util::CargoResult;
@@ -46,8 +46,8 @@ pub fn update_lockfile(ws: &Workspace, opts: &UpdateOptions) -> CargoResult<()> 
         bail!("you can't update in the offline mode");
     }
 
-    // `ignore_errors` is set to true, because we are about to clean the errors up.
-    let previous_resolve = match ops::load_pkg_lockfile(ws, true)? {
+    // ignore errors, because we are about to clean them up.
+    let previous_resolve = match ops::load_pkg_lockfile(ws, ErrorHandle::Ignore)? {
         Some(resolve) => resolve,
         None => return generate_lockfile(ws),
     };

--- a/src/cargo/ops/cargo_pkgid.rs
+++ b/src/cargo/ops/cargo_pkgid.rs
@@ -1,9 +1,10 @@
 use ops;
 use core::{PackageIdSpec, Workspace};
+use core::resolver::ErrorHandle;
 use util::CargoResult;
 
 pub fn pkgid(ws: &Workspace, spec: Option<&str>) -> CargoResult<PackageIdSpec> {
-    let resolve = match ops::load_pkg_lockfile(ws, false)? {
+    let resolve = match ops::load_pkg_lockfile(ws, ErrorHandle::Raise)? {
         Some(resolve) => resolve,
         None => bail!("a Cargo.lock must exist for this command"),
     };

--- a/src/cargo/ops/cargo_pkgid.rs
+++ b/src/cargo/ops/cargo_pkgid.rs
@@ -1,10 +1,9 @@
-use ops;
 use core::{PackageIdSpec, Workspace};
-use core::resolver::ErrorHandle;
+use ops;
 use util::CargoResult;
 
 pub fn pkgid(ws: &Workspace, spec: Option<&str>) -> CargoResult<PackageIdSpec> {
-    let resolve = match ops::load_pkg_lockfile(ws, ErrorHandle::Raise)? {
+    let resolve = match ops::load_pkg_lockfile(ws)? {
         Some(resolve) => resolve,
         None => bail!("a Cargo.lock must exist for this command"),
     };

--- a/src/cargo/ops/cargo_pkgid.rs
+++ b/src/cargo/ops/cargo_pkgid.rs
@@ -3,7 +3,7 @@ use core::{PackageIdSpec, Workspace};
 use util::CargoResult;
 
 pub fn pkgid(ws: &Workspace, spec: Option<&str>) -> CargoResult<PackageIdSpec> {
-    let resolve = match ops::load_pkg_lockfile(ws)? {
+    let resolve = match ops::load_pkg_lockfile(ws, false)? {
         Some(resolve) => resolve,
         None => bail!("a Cargo.lock must exist for this command"),
     };

--- a/src/cargo/ops/lockfile.rs
+++ b/src/cargo/ops/lockfile.rs
@@ -3,12 +3,12 @@ use std::io::prelude::*;
 use toml;
 
 use core::{resolver, Resolve, Workspace};
-use core::resolver::WorkspaceResolve;
+use core::resolver::{WorkspaceResolve, ErrorHandle};
 use util::Filesystem;
 use util::errors::{CargoResult, CargoResultExt};
 use util::toml as cargo_toml;
 
-pub fn load_pkg_lockfile(ws: &Workspace, ignore_errors: bool) -> CargoResult<Option<Resolve>> {
+pub fn load_pkg_lockfile(ws: &Workspace, ignore_errors: ErrorHandle) -> CargoResult<Option<Resolve>> {
     if !ws.root().join("Cargo.lock").exists() {
         return Ok(None);
     }
@@ -115,8 +115,8 @@ fn are_equal_lockfiles(mut orig: String, current: &str, ws: &Workspace) -> bool 
         let res: CargoResult<bool> = (|| {
             let old: resolver::EncodableResolve = toml::from_str(&orig)?;
             let new: resolver::EncodableResolve = toml::from_str(current)?;
-            // `ignore_errors` is set to true, because we may be about to clean the errors up.
-            Ok(old.into_resolve(ws, true)? == new.into_resolve(ws, true)?)
+            // ignore errors, because we may be about to clean them up.
+            Ok(old.into_resolve(ws, ErrorHandle::Ignore)? == new.into_resolve(ws, ErrorHandle::Ignore)?)
         })();
         if let Ok(true) = res {
             return true;

--- a/src/cargo/ops/resolve.rs
+++ b/src/cargo/ops/resolve.rs
@@ -82,7 +82,7 @@ pub fn resolve_ws_with_method<'a>(
 
         Some(resolve)
     } else {
-        ops::load_pkg_lockfile(ws)?
+        ops::load_pkg_lockfile(ws, false)?
     };
 
     let resolved_with_overrides = ops::resolve_with_previous(
@@ -106,7 +106,7 @@ fn resolve_with_registry<'cfg>(
     registry: &mut PackageRegistry<'cfg>,
     warn: bool,
 ) -> CargoResult<Resolve> {
-    let prev = ops::load_pkg_lockfile(ws)?;
+    let prev = ops::load_pkg_lockfile(ws, false)?;
     let resolve = resolve_with_previous(
         registry,
         ws,

--- a/src/cargo/ops/resolve.rs
+++ b/src/cargo/ops/resolve.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 
 use core::{PackageId, PackageIdSpec, PackageSet, Source, SourceId, Workspace};
 use core::registry::PackageRegistry;
-use core::resolver::{self, Method, Resolve};
+use core::resolver::{self, Method, Resolve, ErrorHandle};
 use sources::PathSource;
 use ops;
 use util::profile;
@@ -82,7 +82,7 @@ pub fn resolve_ws_with_method<'a>(
 
         Some(resolve)
     } else {
-        ops::load_pkg_lockfile(ws, false)?
+        ops::load_pkg_lockfile(ws, ErrorHandle::Raise)?
     };
 
     let resolved_with_overrides = ops::resolve_with_previous(
@@ -106,7 +106,7 @@ fn resolve_with_registry<'cfg>(
     registry: &mut PackageRegistry<'cfg>,
     warn: bool,
 ) -> CargoResult<Resolve> {
-    let prev = ops::load_pkg_lockfile(ws, false)?;
+    let prev = ops::load_pkg_lockfile(ws, ErrorHandle::Raise)?;
     let resolve = resolve_with_previous(
         registry,
         ws,

--- a/tests/testsuite/bad_config.rs
+++ b/tests/testsuite/bad_config.rs
@@ -1,6 +1,6 @@
-use support::{basic_manifest, execs, project};
-use support::registry::Package;
 use support::hamcrest::assert_that;
+use support::registry::Package;
+use support::{basic_manifest, execs, project};
 
 #[test]
 fn bad1() {
@@ -153,13 +153,13 @@ fn bad_cargo_config_jobs() {
         .build();
     assert_that(
         p.cargo("build").arg("-v"),
-        execs()
-            .with_status(101)
-            .with_stderr("\
+        execs().with_status(101).with_stderr(
+            "\
 [ERROR] error in [..].cargo[/]config: \
 could not load config key `build.jobs`: \
 invalid value: integer `-1`, expected u32
-"),
+",
+        ),
     );
 }
 
@@ -371,23 +371,7 @@ fn bad_dependency_in_lockfile() {
         )
         .build();
 
-    assert_that(
-        p.cargo("build"),
-        execs().with_status(101).with_stderr(
-            "\
-[ERROR] failed to parse lock file at: [..]
-
-Caused by:
-  package `bar 0.1.0 ([..])` is specified as a dependency, but is missing from the package list
-  consider running 'cargo update -p foo'
-",
-        ),
-    );
-
-    assert_that(
-        p.cargo("update -p foo"),
-        execs().with_status(0),
-    );
+    assert_that(p.cargo("build"), execs().with_status(0));
 }
 
 #[test]
@@ -733,7 +717,8 @@ warning: unused manifest key: project.bulid
         ),
     );
 
-    let p = project().at("bar")
+    let p = project()
+        .at("bar")
         .file(
             "Cargo.toml",
             r#"

--- a/tests/testsuite/bad_config.rs
+++ b/tests/testsuite/bad_config.rs
@@ -385,16 +385,8 @@ Caused by:
     );
 
     assert_that(
-        p.cargo("build").arg("-v"),
-        execs().with_status(101).with_stderr(
-            "\
-[ERROR] failed to parse lock file at: [..]
-
-Caused by:
-  package `bar 0.1.0 ([..])` is specified as a dependency, but is missing from the package list
-  consider running 'cargo update -p foo'
-",
-        ),
+        p.cargo("update -p foo"),
+        execs().with_status(0),
     );
 }
 

--- a/tests/testsuite/bad_config.rs
+++ b/tests/testsuite/bad_config.rs
@@ -383,6 +383,19 @@ Caused by:
 ",
         ),
     );
+
+    assert_that(
+        p.cargo("build").arg("-v"),
+        execs().with_status(101).with_stderr(
+            "\
+[ERROR] failed to parse lock file at: [..]
+
+Caused by:
+  package `bar 0.1.0 ([..])` is specified as a dependency, but is missing from the package list
+  consider running 'cargo update -p foo'
+",
+        ),
+    );
 }
 
 #[test]

--- a/tests/testsuite/bad_config.rs
+++ b/tests/testsuite/bad_config.rs
@@ -379,6 +379,7 @@ fn bad_dependency_in_lockfile() {
 
 Caused by:
   package `bar 0.1.0 ([..])` is specified as a dependency, but is missing from the package list
+  consider running 'cargo update -p foo'
 ",
         ),
     );


### PR DESCRIPTION
Lock files often get corrupted by git merge. This makes all cargo commands silently fix that kind of corruption. 

If you want to be sure that your CI does not change the lock file you have commited
---

Then make sure to use `--locked` in your CI

Edit: original description below

---------------

This is a continuation of @dwijnand work in #5809, and closes #5684

This adds a `ignore_errors` arg to reading a lock file which ignores sections it doesn't understand. Specifically things that depend on versions that don't exist in the lock file. Then all users pass false except for the two that relate to `update` command.

I think the open questions for this pr relate to testing.
- Now that we are passing false in all other commands, do they each need a test for a bad lockfile?
- Do we need a test with a more subtly corrupted lock file, or is this always sufficient for `update` to clean up?