### PR TITLE
Add edition info into metadata

### DIFF
--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -231,6 +231,7 @@ struct SerializedTarget<'a> {
     crate_types: Vec<&'a str>,
     name: &'a str,
     src_path: &'a PathBuf,
+    edition: &'a str,
 }
 
 impl ser::Serialize for Target {
@@ -240,6 +241,7 @@ impl ser::Serialize for Target {
             crate_types: self.rustc_crate_types(),
             name: &self.name,
             src_path: &self.src_path.path,
+            edition: &self.edition.to_string()
         }.serialize(s)
     }
 }

--- a/src/cargo/core/package.rs
+++ b/src/cargo/core/package.rs
@@ -47,6 +47,7 @@ struct SerializedPackage<'a> {
     keywords: &'a [String],
     readme: Option<&'a str>,
     repository: Option<&'a str>,
+    edition: &'a str,
 }
 
 impl ser::Serialize for Package {
@@ -84,6 +85,7 @@ impl ser::Serialize for Package {
             keywords,
             readme,
             repository,
+            edition: &self.manifest.edition().to_string(),
         }.serialize(s)
     }
 }

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -3399,6 +3399,7 @@ fn compiler_json_error_format() {
         "target":{
             "kind":["custom-build"],
             "crate_types":["bin"],
+            "edition": "2015",
             "name":"build-script-build",
             "src_path":"[..]build.rs"
         },
@@ -3420,6 +3421,7 @@ fn compiler_json_error_format() {
         "target":{
             "kind":["lib"],
             "crate_types":["lib"],
+            "edition": "2015",
             "name":"bar",
             "src_path":"[..]lib.rs"
         },
@@ -3440,6 +3442,7 @@ fn compiler_json_error_format() {
         "target":{
             "kind":["lib"],
             "crate_types":["lib"],
+            "edition": "2015",
             "name":"bar",
             "src_path":"[..]lib.rs"
         },
@@ -3462,6 +3465,7 @@ fn compiler_json_error_format() {
         "target":{
             "kind":["bin"],
             "crate_types":["bin"],
+            "edition": "2015",
             "name":"foo",
             "src_path":"[..]main.rs"
         },
@@ -3474,6 +3478,7 @@ fn compiler_json_error_format() {
         "target":{
             "kind":["bin"],
             "crate_types":["bin"],
+            "edition": "2015",
             "name":"foo",
             "src_path":"[..]main.rs"
         },
@@ -3504,6 +3509,7 @@ fn compiler_json_error_format() {
         "target":{
             "kind":["custom-build"],
             "crate_types":["bin"],
+            "edition": "2015",
             "name":"build-script-build",
             "src_path":"[..]build.rs"
         },
@@ -3533,6 +3539,7 @@ fn compiler_json_error_format() {
         "target":{
             "kind":["lib"],
             "crate_types":["lib"],
+            "edition": "2015",
             "name":"bar",
             "src_path":"[..]lib.rs"
         },
@@ -3555,6 +3562,7 @@ fn compiler_json_error_format() {
         "target":{
             "kind":["bin"],
             "crate_types":["bin"],
+            "edition": "2015",
             "name":"foo",
             "src_path":"[..]main.rs"
         },
@@ -3614,6 +3622,7 @@ fn message_format_json_forward_stderr() {
         "target":{
             "kind":["bin"],
             "crate_types":["bin"],
+            "edition": "2015",
             "name":"foo",
             "src_path":"[..]"
         },
@@ -3626,6 +3635,7 @@ fn message_format_json_forward_stderr() {
         "target":{
             "kind":["bin"],
             "crate_types":["bin"],
+            "edition": "2015",
             "name":"foo",
             "src_path":"[..]"
         },

--- a/tests/testsuite/metadata.rs
+++ b/tests/testsuite/metadata.rs
@@ -1,5 +1,5 @@
 use support::registry::Package;
-use support::{basic_bin_manifest, basic_lib_manifest, execs, main_file, project};
+use support::{basic_bin_manifest, basic_lib_manifest, execs, main_file, project, ChannelChanger};
 use support::hamcrest::assert_that;
 
 #[test]
@@ -26,6 +26,7 @@ fn cargo_metadata_simple() {
                 "keywords": [],
                 "source": null,
                 "dependencies": [],
+                "edition": "2015",
                 "license": null,
                 "license_file": null,
                 "description": null,
@@ -117,6 +118,7 @@ crate-type = ["lib", "staticlib"]
                 "keywords": [],
                 "source": null,
                 "dependencies": [],
+                "edition": "2015",
                 "license": null,
                 "license_file": null,
                 "description": null,
@@ -194,6 +196,7 @@ optional_feat = []
                 "keywords": [],
                 "source": null,
                 "dependencies": [],
+                "edition": "2015",
                 "license": null,
                 "license_file": null,
                 "description": null,
@@ -292,6 +295,7 @@ fn cargo_metadata_with_deps_and_version() {
                 "license": null,
                 "license_file": null,
                 "description": null,
+                "edition": "2015",
                 "targets": [
                     {
                         "kind": [
@@ -334,6 +338,7 @@ fn cargo_metadata_with_deps_and_version() {
                 "license": null,
                 "license_file": null,
                 "description": null,
+                "edition": "2015",
                 "targets": [
                     {
                         "kind": [
@@ -376,6 +381,7 @@ fn cargo_metadata_with_deps_and_version() {
                 "license": "MIT",
                 "license_file": null,
                 "description": "foo",
+                "edition": "2015",
                 "targets": [
                     {
                         "kind": [
@@ -461,6 +467,7 @@ name = "ex"
                 "license": null,
                 "license_file": null,
                 "description": null,
+                "edition": "2015",
                 "source": null,
                 "dependencies": [],
                 "targets": [
@@ -540,6 +547,7 @@ crate-type = ["rlib", "dylib"]
                 "license": null,
                 "license_file": null,
                 "description": null,
+                "edition": "2015",
                 "source": null,
                 "dependencies": [],
                 "targets": [
@@ -620,6 +628,7 @@ fn workspace_metadata() {
                 "license": null,
                 "license_file": null,
                 "description": null,
+                "edition": "2015",
                 "targets": [
                     {
                         "kind": [ "lib" ],
@@ -648,6 +657,7 @@ fn workspace_metadata() {
                 "license": null,
                 "license_file": null,
                 "description": null,
+                "edition": "2015",
                 "targets": [
                     {
                         "kind": [ "lib" ],
@@ -723,6 +733,7 @@ fn workspace_metadata_no_deps() {
                 "license": null,
                 "license_file": null,
                 "description": null,
+                "edition": "2015",
                 "targets": [
                     {
                         "kind": [ "lib" ],
@@ -751,6 +762,7 @@ fn workspace_metadata_no_deps() {
                 "license": null,
                 "license_file": null,
                 "description": null,
+                "edition": "2015",
                 "targets": [
                     {
                         "kind": [ "lib" ],
@@ -806,6 +818,7 @@ const MANIFEST_OUTPUT: &str = r#"
         "license": null,
         "license_file": null,
         "description": null,
+        "edition": "2015",
         "targets":[{
             "kind":["bin"],
             "crate_types":["bin"],
@@ -998,6 +1011,7 @@ fn package_metadata() {
                 "keywords": ["database"],
                 "source": null,
                 "dependencies": [],
+                "edition": "2015",
                 "license": null,
                 "license_file": null,
                 "description": null,
@@ -1065,6 +1079,7 @@ fn cargo_metadata_path_to_cargo_toml_project() {
                 "categories": [],
                 "dependencies": [],
                 "description": null,
+                "edition": "2015",
                 "features": {},
                 "id": "bar 0.5.0 ([..])",
                 "keywords": [],
@@ -1113,4 +1128,81 @@ fn cargo_metadata_path_to_cargo_toml_project() {
     );
 }
 
+#[test]
+fn edition_2018() {
+    let p = project()
+        .file("src/lib.rs", "")
+        .file(
+            "Cargo.toml",
+            r#"
+            cargo-features = ["edition"]
 
+            [package]
+            name = "foo"
+            version = "0.1.0"
+            authors = ["wycats@example.com"]
+            edition = "2018"
+        "#,
+        )
+        .build();
+    assert_that(
+        p.cargo("metadata").masquerade_as_nightly_cargo(),
+        execs().with_status(0).with_json(
+            r#"
+        {
+            "packages": [
+                {
+                    "authors": [
+                        "wycats@example.com"
+                    ],
+                    "categories": [],
+                    "dependencies": [],
+                    "description": null,
+                    "edition": "2018",
+                    "features": {},
+                    "id": "foo 0.1.0 (path+file:[..])",
+                    "keywords": [],
+                    "license": null,
+                    "license_file": null,
+                    "manifest_path": "[..]Cargo.toml",
+                    "metadata": null,
+                    "name": "foo",
+                    "readme": null,
+                    "repository": null,
+                    "source": null,
+                    "targets": [
+                        {
+                            "crate_types": [
+                                "lib"
+                            ],
+                            "kind": [
+                                "lib"
+                            ],
+                            "name": "foo",
+                            "src_path": "[..]src[/]lib.rs"
+                        }
+                    ],
+                    "version": "0.1.0"
+                }
+            ],
+            "resolve": {
+                "nodes": [
+                    {
+                        "dependencies": [],
+                        "features": [],
+                        "id": "foo 0.1.0 (path+file:[..])"
+                    }
+                ],
+                "root": "foo 0.1.0 (path+file:[..])"
+            },
+            "target_directory": "[..]",
+            "version": 1,
+            "workspace_members": [
+                "foo 0.1.0 (path+file:[..])"
+            ],
+            "workspace_root": "[..]"
+        }
+        "#,
+        ),
+    );
+}

--- a/tests/testsuite/metadata.rs
+++ b/tests/testsuite/metadata.rs
@@ -1197,7 +1197,7 @@ fn package_edition_2018() {
                                 "lib"
                             ],
                             "name": "foo",
-                            "src_path": "[..]src/lib.rs"
+                            "src_path": "[..]src[/]lib.rs"
                         }
                     ],
                     "version": "0.1.0"
@@ -1281,7 +1281,7 @@ fn target_edition_2018() {
                                 "lib"
                             ],
                             "name": "foo",
-                            "src_path": "[..]src/lib.rs"
+                            "src_path": "[..]src[/]lib.rs"
                         },
                         {
                             "crate_types": [
@@ -1292,7 +1292,7 @@ fn target_edition_2018() {
                                 "bin"
                             ],
                             "name": "foo",
-                            "src_path": "[..]src/main.rs"
+                            "src_path": "[..]src[/]main.rs"
                         }
                     ],
                     "version": "0.1.0"

--- a/tests/testsuite/metadata.rs
+++ b/tests/testsuite/metadata.rs
@@ -40,6 +40,7 @@ fn cargo_metadata_simple() {
                         "crate_types": [
                             "bin"
                         ],
+                        "edition": "2015",
                         "name": "foo",
                         "src_path": "[..][/]foo[/]src[/]foo.rs"
                     }
@@ -132,6 +133,7 @@ crate-type = ["lib", "staticlib"]
                             "lib",
                             "staticlib"
                         ],
+                        "edition": "2015",
                         "name": "foo",
                         "src_path": "[..][/]foo[/]src[/]lib.rs"
                     }
@@ -208,6 +210,7 @@ optional_feat = []
                         "crate_types": [
                             "lib"
                         ],
+                        "edition": "2015",
                         "name": "foo",
                         "src_path": "[..][/]foo[/]src[/]lib.rs"
                     }
@@ -304,6 +307,7 @@ fn cargo_metadata_with_deps_and_version() {
                         "crate_types": [
                             "lib"
                         ],
+                        "edition": "2015",
                         "name": "baz",
                         "src_path": "[..]lib.rs"
                     }
@@ -347,6 +351,7 @@ fn cargo_metadata_with_deps_and_version() {
                         "crate_types": [
                             "lib"
                         ],
+                        "edition": "2015",
                         "name": "bar",
                         "src_path": "[..]lib.rs"
                     }
@@ -390,6 +395,7 @@ fn cargo_metadata_with_deps_and_version() {
                         "crate_types": [
                             "bin"
                         ],
+                        "edition": "2015",
                         "name": "foo",
                         "src_path": "[..]foo.rs"
                     }
@@ -474,12 +480,14 @@ name = "ex"
                     {
                         "kind": [ "lib" ],
                         "crate_types": [ "lib" ],
+                        "edition": "2015",
                         "name": "foo",
                         "src_path": "[..][/]foo[/]src[/]lib.rs"
                     },
                     {
                         "kind": [ "example" ],
                         "crate_types": [ "bin" ],
+                        "edition": "2015",
                         "name": "ex",
                         "src_path": "[..][/]foo[/]examples[/]ex.rs"
                     }
@@ -554,12 +562,14 @@ crate-type = ["rlib", "dylib"]
                     {
                         "kind": [ "lib" ],
                         "crate_types": [ "lib" ],
+                        "edition": "2015",
                         "name": "foo",
                         "src_path": "[..][/]foo[/]src[/]lib.rs"
                     },
                     {
                         "kind": [ "example" ],
                         "crate_types": [ "rlib", "dylib" ],
+                        "edition": "2015",
                         "name": "ex",
                         "src_path": "[..][/]foo[/]examples[/]ex.rs"
                     }
@@ -633,6 +643,7 @@ fn workspace_metadata() {
                     {
                         "kind": [ "lib" ],
                         "crate_types": [ "lib" ],
+                        "edition": "2015",
                         "name": "bar",
                         "src_path": "[..]bar[/]src[/]lib.rs"
                     }
@@ -662,6 +673,7 @@ fn workspace_metadata() {
                     {
                         "kind": [ "lib" ],
                         "crate_types": [ "lib" ],
+                        "edition": "2015",
                         "name": "baz",
                         "src_path": "[..]baz[/]src[/]lib.rs"
                     }
@@ -738,6 +750,7 @@ fn workspace_metadata_no_deps() {
                     {
                         "kind": [ "lib" ],
                         "crate_types": [ "lib" ],
+                        "edition": "2015",
                         "name": "bar",
                         "src_path": "[..]bar[/]src[/]lib.rs"
                     }
@@ -767,6 +780,7 @@ fn workspace_metadata_no_deps() {
                     {
                         "kind": [ "lib" ],
                         "crate_types": ["lib"],
+                        "edition": "2015",
                         "name": "baz",
                         "src_path": "[..]baz[/]src[/]lib.rs"
                     }
@@ -822,6 +836,7 @@ const MANIFEST_OUTPUT: &str = r#"
         "targets":[{
             "kind":["bin"],
             "crate_types":["bin"],
+            "edition": "2015",
             "name":"foo",
             "src_path":"[..][/]foo[/]src[/]foo.rs"
         }],
@@ -1019,6 +1034,7 @@ fn package_metadata() {
                     {
                         "kind": [ "lib" ],
                         "crate_types": [ "lib" ],
+                        "edition": "2015",
                         "name": "foo",
                         "src_path": "[..]foo[/]src[/]lib.rs"
                     }
@@ -1096,6 +1112,7 @@ fn cargo_metadata_path_to_cargo_toml_project() {
                     "crate_types": [
                         "lib"
                     ],
+                    "edition": "2015",
                     "kind": [
                         "lib"
                     ],
@@ -1129,7 +1146,7 @@ fn cargo_metadata_path_to_cargo_toml_project() {
 }
 
 #[test]
-fn edition_2018() {
+fn package_edition_2018() {
     let p = project()
         .file("src/lib.rs", "")
         .file(
@@ -1175,11 +1192,107 @@ fn edition_2018() {
                             "crate_types": [
                                 "lib"
                             ],
+                            "edition": "2018",
                             "kind": [
                                 "lib"
                             ],
                             "name": "foo",
-                            "src_path": "[..]src[/]lib.rs"
+                            "src_path": "[..]src/lib.rs"
+                        }
+                    ],
+                    "version": "0.1.0"
+                }
+            ],
+            "resolve": {
+                "nodes": [
+                    {
+                        "dependencies": [],
+                        "features": [],
+                        "id": "foo 0.1.0 (path+file:[..])"
+                    }
+                ],
+                "root": "foo 0.1.0 (path+file:[..])"
+            },
+            "target_directory": "[..]",
+            "version": 1,
+            "workspace_members": [
+                "foo 0.1.0 (path+file:[..])"
+            ],
+            "workspace_root": "[..]"
+        }
+        "#,
+        ),
+    );
+}
+
+#[test]
+fn target_edition_2018() {
+    let p = project()
+        .file("src/lib.rs", "")
+        .file("src/main.rs", "")
+        .file(
+            "Cargo.toml",
+            r#"
+            cargo-features = ["edition"]
+
+            [package]
+            name = "foo"
+            version = "0.1.0"
+            authors = ["wycats@example.com"]
+            edition = "2015"
+
+            [lib]
+            edition = "2018"
+        "#,
+        )
+        .build();
+    assert_that(
+        p.cargo("metadata").masquerade_as_nightly_cargo(),
+        execs().with_status(0).with_json(
+            r#"
+        {
+            "packages": [
+                {
+                    "authors": [
+                        "wycats@example.com"
+                    ],
+                    "categories": [],
+                    "dependencies": [],
+                    "description": null,
+                    "edition": "2015",
+                    "features": {},
+                    "id": "foo 0.1.0 (path+file:[..])",
+                    "keywords": [],
+                    "license": null,
+                    "license_file": null,
+                    "manifest_path": "[..]Cargo.toml",
+                    "metadata": null,
+                    "name": "foo",
+                    "readme": null,
+                    "repository": null,
+                    "source": null,
+                    "targets": [
+                        {
+                            "crate_types": [
+                                "lib"
+                            ],
+                            "edition": "2018",
+                            "kind": [
+                                "lib"
+                            ],
+                            "name": "foo",
+                            "src_path": "[..]src/lib.rs"
+                        },
+                        {
+                            "crate_types": [
+                                "bin"
+                            ],
+                            "edition": "2015",
+                            "kind": [
+                                "bin"
+                            ],
+                            "name": "foo",
+                            "src_path": "[..]src/main.rs"
                         }
                     ],
                     "version": "0.1.0"

--- a/tests/testsuite/read_manifest.rs
+++ b/tests/testsuite/read_manifest.rs
@@ -22,6 +22,7 @@ static MANIFEST_OUTPUT: &'static str = r#"
     "targets":[{
         "kind":["bin"],
         "crate_types":["bin"],
+        "edition": "2015",
         "name":"foo",
         "src_path":"[..][/]foo[/]src[/]foo.rs"
     }],

--- a/tests/testsuite/read_manifest.rs
+++ b/tests/testsuite/read_manifest.rs
@@ -16,6 +16,7 @@ static MANIFEST_OUTPUT: &'static str = r#"
     "license": null,
     "license_file": null,
     "description": null,
+    "edition": "2015",
     "source":null,
     "dependencies":[],
     "targets":[{

--- a/tests/testsuite/test.rs
+++ b/tests/testsuite/test.rs
@@ -3491,6 +3491,7 @@ fn json_artifact_includes_test_flag() {
         "target":{
             "kind":["lib"],
             "crate_types":["lib"],
+            "edition": "2015",
             "name":"foo",
             "src_path":"[..]lib.rs"
         },
@@ -3512,6 +3513,7 @@ fn json_artifact_includes_test_flag() {
         "target":{
             "kind":["lib"],
             "crate_types":["lib"],
+            "edition": "2015",
             "name":"foo",
             "src_path":"[..]lib.rs"
         },


### PR DESCRIPTION
Since edition feature was introduced, external tools have to support this new feature.
But cargo metadata doesn't provide info about package edition.
This commit adds edition field to `SerializedPackage` struct to add the corresponding field into metadata output.