### PR TITLE
Hint correct name of profile.debug

### DIFF
--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -66,6 +66,9 @@ fn do_read_manifest(
     let add_unused = |warnings: &mut Warnings| {
         for key in unused {
             warnings.add_warning(format!("unused manifest key: {}", key));
+            if key == "profile.debug" || key == "profiles.debug" {
+                warnings.add_warning("use `[profile.dev]` to configure debug builds".to_string());
+            }
         }
     };
 

--- a/tests/testsuite/bad_config.rs
+++ b/tests/testsuite/bad_config.rs
@@ -706,6 +706,33 @@ warning: unused manifest key: target.foo.bar
         .file(
             "Cargo.toml",
             r#"
+           [package]
+           name = "foo"
+           version = "0.1.0"
+           authors = []
+
+           [profile.debug]
+           debug = 1
+        "#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    assert_that(
+        p.cargo("build"),
+        execs().with_status(0).with_stderr(
+            "\
+warning: unused manifest key: profile.debug
+warning: use `[profile.dev]` to configure debug builds
+[..]
+[..]",
+        ),
+    );
+
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
             [project]
 
             name = "foo"


### PR DESCRIPTION
Cargo talks about "debug" and "release" builds, but there are "dev" and "release" profiles. [This is a gotcha](https://users.rust-lang.org/t/rust-emscripten-emterpreter/19215/5). I've added an explicit hint that `profile.debug` is supposed to be `profile.dev`.