### PR TITLE
Publish from parent workspace

### DIFF
--- a/src/cargo/ops/registry.rs
+++ b/src/cargo/ops/registry.rs
@@ -41,6 +41,19 @@ pub struct PublishOpts<'cfg> {
 }
 
 pub fn publish(ws: &Workspace, opts: &PublishOpts) -> CargoResult<()> {
+    match ws.current_opt() {
+        Some(_) => publish_package(ws, opts),
+        None => {
+            for member in ws.members() {
+                let pkg_ws = Workspace::new(member.manifest_path(), ws.config())?;
+                publish(&pkg_ws, opts)?;
+            }
+            Ok(())
+        }
+    }
+}
+
+fn publish_package(ws: &Workspace, opts: &PublishOpts) -> CargoResult<()> {
     let pkg = ws.current()?;
 
     if let Some(ref allowed_registries) = *pkg.publish() {

--- a/tests/testsuite/publish.rs
+++ b/tests/testsuite/publish.rs
@@ -860,3 +860,70 @@ fn block_publish_no_registry() {
         ),
     );
 }
+
+#[test]
+fn simple_workspace() {
+    publish::setup();
+
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [workspace]
+
+            members = [
+                "foo",
+                "bar"
+            ] 
+        "#,
+        )
+        .file(
+            "foo/Cargo.toml",
+            r#"
+            [package]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+            license = "MIT"
+            description = "foo"
+        "#,
+        )
+        .file("foo/src/main.rs", "fn main() {}")
+        .file(
+            "bar/Cargo.toml",
+            r#"
+            [package]
+            name = "bar"
+            version = "0.0.2"
+            authors = []
+            license = "MIT"
+            description = "bar"
+        "#,
+        )
+        .file("bar/src/main.rs", "fn main() {}")
+        .build();
+
+    assert_that(
+        p.cargo("publish")
+            .arg("--no-verify")
+            .arg("--index")
+            .arg(publish::registry().to_string()),
+        execs().with_status(0).with_stderr(&format!(
+            "\
+[UPDATING] registry `{reg}`
+[WARNING] manifest has no documentation, [..]
+See [..]
+[PACKAGING] foo v0.0.1 ({dir}/foo)
+[UPLOADING] foo v0.0.1 ({dir}/foo)
+[UPDATING] registry `{reg}`
+[WARNING] manifest has no documentation, [..]
+See [..]
+[PACKAGING] bar v0.0.2 ({dir}/bar)
+[UPLOADING] bar v0.0.2 ({dir}/bar)
+",
+            dir = p.url(),
+            reg = publish::registry()
+        )),
+    );
+
+}


### PR DESCRIPTION
This PR deals with #1169 

The proposed implementation simply loops all the members of a workspace and publish them in the declared order. 
Limitations:

- `cargo publish --dry-run` fails if a member has path dependencies; nevertheless, running it without `--dry-run` will work as expected (because the referred package will be published beforehand)
- Due the `cargo package` limitations, it is not possible to upload all the packages together at the end of a global verification, this is because the "path" dependencies need to be present in the repository before the publish process of a package starts.

Please note that these two limitations are not introduced by this PR but are already present in cargo.