### PR TITLE
Stop printing rustc command line if normally errored

### DIFF
--- a/src/cargo/util/config.rs
+++ b/src/cargo/util/config.rs
@@ -207,6 +207,7 @@ impl Config {
             } else {
                 None
             },
+            self.extra_verbose(),
         )
     }
 

--- a/tests/testsuite/shell_quoting.rs
+++ b/tests/testsuite/shell_quoting.rs
@@ -34,10 +34,6 @@ fn features_are_quoted() {
             .with_status(101)
             .with_stderr_contains(
                 r#"[RUNNING] `rustc [..] --cfg 'feature="default"' --cfg 'feature="some_feature"' [..]`"#
-            ).with_stderr_contains(
-                r#"
-Caused by:
-  process didn't exit successfully: [..] --cfg 'feature="default"' --cfg 'feature="some_feature"' [..]"#
             )
     );
 }

--- a/tests/testsuite/support/mod.rs
+++ b/tests/testsuite/support/mod.rs
@@ -1307,6 +1307,7 @@ pub static RUSTC: Rustc = Rustc::new(
     None,
     Path::new("should be path to rustup rustc, but we don't care in tests"),
     None,
+    false,
 ).unwrap()
 );
 


### PR DESCRIPTION
We used to print a wall of text especially in larger projects like the
compiler, now we print a much smaller message. It's not generally useful
to know the full compiler command anyway.

Not completely sure this is the best place to have this, but seems to work in local testing.