### PR TITLE
run some tests with minimal-versions on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ matrix:
         - rustup toolchain install nightly
         - cargo +nightly generate-lockfile -Z minimal-versions
         - cargo -V
-        - cargo check --tests
+        - cargo test
 
     - env: TARGET=x86_64-unknown-linux-gnu
            ALT=i686-unknown-linux-gnu

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ matrix:
     # increased every 6 weeks or so when the first PR to use a new feature.
     - env: TARGET=x86_64-unknown-linux-gnu
            ALT=i686-unknown-linux-gnu
-      rust: 1.27.2
+      rust: 1.28.0
       script:
         - rustup toolchain install nightly
         - cargo +nightly generate-lockfile -Z minimal-versions

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ serde = "1.0"
 serde_derive = "1.0"
 serde_ignored = "0.0.4"
 serde_json = "1.0"
-shell-escape = "0.1"
+shell-escape = "0.1.4"
 tar = { version = "0.4.15", default-features = false }
 tempfile = "3.0"
 termcolor = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ semver = { version = "0.9.0", features = ["serde"] }
 serde = "1.0"
 serde_derive = "1.0"
 serde_ignored = "0.0.4"
-serde_json = "1.0"
+serde_json = "1.0.24"
 shell-escape = "0.1.4"
 tar = { version = "0.4.15", default-features = false }
 tempfile = "3.0"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,6 +7,7 @@ environment:
     OTHER_TARGET: i686-pc-windows-msvc
     MAKE_TARGETS: test-unit-x86_64-pc-windows-msvc
     MINIMAL_VERSIONS: true
+    CFG_DISABLE_CROSS_TESTS: 1
 
 install:
   - appveyor-retry appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,5 +24,8 @@ clone_depth: 1
 build: false
 
 test_script:
-  - if defined MINIMAL_VERSIONS cargo +nightly generate-lockfile -Z minimal-versions && cargo +stable test
+  # we don't have ci time to run the full `cargo test` with `minimal-versions` like
+  # - if defined MINIMAL_VERSIONS cargo +nightly generate-lockfile -Z minimal-versions && cargo +stable test
+  # so we just run `cargo check --tests` like
+  - if defined MINIMAL_VERSIONS cargo +nightly generate-lockfile -Z minimal-versions && cargo +stable check --tests
   - if NOT defined MINIMAL_VERSIONS cargo test

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,5 +23,5 @@ clone_depth: 1
 build: false
 
 test_script:
-  - if defined MINIMAL_VERSIONS cargo +nightly generate-lockfile -Z minimal-versions && cargo +stable check --tests
+  - if defined MINIMAL_VERSIONS cargo +nightly generate-lockfile -Z minimal-versions && cargo +stable test
   - if NOT defined MINIMAL_VERSIONS cargo test

--- a/src/cargo/lib.rs
+++ b/src/cargo/lib.rs
@@ -4,8 +4,8 @@
 #![cfg_attr(feature = "cargo-clippy", allow(boxed_local))]             // bug rust-lang-nursery/rust-clippy#1123
 #![cfg_attr(feature = "cargo-clippy", allow(cyclomatic_complexity))]   // large project
 #![cfg_attr(feature = "cargo-clippy", allow(derive_hash_xor_eq))]      // there's an intentional incoherence
-#![cfg_attr(feature = "cargo-clippy", allow(explicit_into_iter_loop))] // (unclear why)
-#![cfg_attr(feature = "cargo-clippy", allow(explicit_iter_loop))]      // (unclear why)
+#![cfg_attr(feature = "cargo-clippy", allow(explicit_into_iter_loop))] // explicit loops are clearer
+#![cfg_attr(feature = "cargo-clippy", allow(explicit_iter_loop))]      // explicit loops are clearer
 #![cfg_attr(feature = "cargo-clippy", allow(identity_op))]             // used for vertical alignment
 #![cfg_attr(feature = "cargo-clippy", allow(implicit_hasher))]         // large project
 #![cfg_attr(feature = "cargo-clippy", allow(large_enum_variant))]      // large project

--- a/tests/testsuite/check.rs
+++ b/tests/testsuite/check.rs
@@ -724,6 +724,10 @@ fn check_artifacts() {
 
 #[test]
 fn short_message_format() {
+    if !is_nightly() {
+        // This can be removed once 1.30 is stable (rustdoc --error-format stabilized).
+        return;
+    }
     let foo = project()
         .file("src/lib.rs", "fn foo() { let _x: bool = 'a'; }")
         .build();

--- a/tests/testsuite/check.rs
+++ b/tests/testsuite/check.rs
@@ -724,10 +724,6 @@ fn check_artifacts() {
 
 #[test]
 fn short_message_format() {
-    if !is_nightly() {
-        // This can be removed once 1.30 is stable (rustdoc --error-format stabilized).
-        return;
-    }
     let foo = project()
         .file("src/lib.rs", "fn foo() { let _x: bool = 'a'; }")
         .build();


### PR DESCRIPTION
In #5757 we discovered that sum test don't pass with minimal-versions, and so only added CI for `cargo check`. This PR is to see if that is still needed, and if it is then which test rely on upstream bugfix.