### PR TITLE
fetch: skip target tests when cross_compile is disabled

### DIFF
--- a/tests/testsuite/fetch.rs
+++ b/tests/testsuite/fetch.rs
@@ -15,6 +15,10 @@ fn no_deps() {
 
 #[test]
 fn fetch_all_platform_dependencies_when_no_target_is_given() {
+    if cross_compile::disabled() {
+        return;
+    }
+
     Package::new("d1", "1.2.3")
         .file("Cargo.toml", &basic_manifest("d1", "1.2.3"))
         .file("src/lib.rs", "")
@@ -60,6 +64,10 @@ fn fetch_all_platform_dependencies_when_no_target_is_given() {
 
 #[test]
 fn fetch_platform_specific_dependencies() {
+    if cross_compile::disabled() {
+        return;
+    }
+
     Package::new("d1", "1.2.3")
         .file("Cargo.toml", &basic_manifest("d1", "1.2.3"))
         .file("src/lib.rs", "")


### PR DESCRIPTION
It was reported in #5864 that the fetch-by-target tests fail when run on a non-x86 platform.  This is due to the cross_compile module being disabled when running on non-x86 platforms.  Fix this by skipping the two fetch tests which rely on the cross_compile module, when cross_compile has been disabled.

Signed-off-by: Brandon Williams <bmwill@google.com>