### PR TITLE
Meta rename

### DIFF
--- a/src/cargo/core/compiler/build_context/mod.rs
+++ b/src/cargo/core/compiler/build_context/mod.rs
@@ -92,29 +92,7 @@ impl<'a, 'cfg> BuildContext<'a, 'cfg> {
     }
 
     pub fn extern_crate_name(&self, unit: &Unit<'a>, dep: &Unit<'a>) -> CargoResult<String> {
-        let deps = {
-            let a = unit.pkg.package_id();
-            let b = dep.pkg.package_id();
-            if a == b {
-                &[]
-            } else {
-                self.resolve.dependencies_listed(a, b)
-            }
-        };
-
-        let crate_name = dep.target.crate_name();
-        let mut names = deps.iter()
-            .map(|d| d.rename().map(|s| s.as_str()).unwrap_or(&crate_name));
-        let name = names.next().unwrap_or(&crate_name);
-        for n in names {
-            if n == name {
-                continue
-            }
-            bail!("multiple dependencies listed for the same crate must \
-                   all have the same name, but the dependency on `{}` \
-                   is listed as having different names", dep.pkg.package_id());
-        }
-        Ok(name.to_string())
+        self.resolve.extern_crate_name(unit.pkg.package_id(), dep.pkg.package_id(), dep.target)
     }
 
     /// Whether a dependency should be compiled for the host or target platform,


### PR DESCRIPTION
Some work towards https://github.com/rust-lang/cargo/issues/5583

Previously, `cargo metadata` exposed dependencies info as a graph of
package id without any additional information on edges.

However, we do want to add some data to edges, including for example,
package renames and `cfg` info.

Internally, the edges info is represented as a `Vec<Dependnecy>`. We
could have exposed that directly, but that risks exposing and
ossifying an implementation details.

So instead we collapse a `Vec<Dependnecy>` to a single JSON object,
which at the moment contains `id` and `rename` info only. It should be
possible to add additional fields to that object backwards compatibly.
Such representation does not correspond directly to any internal Cargo
data structure, but hopefully it shouldn't be to hard to maintain.

This representation also does not quite correspond to the "real
world", where dependencies are between crate (cargo targets), and not
packages. However, because each dep edge is a JSON object, adding a
target filter should be possible, which would handle dev-, build-, and
potential future bin-specific dependencies backwards-compatibly.