### PR TITLE
Support JSON with rustdoc.

### DIFF
--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -283,7 +283,7 @@ fn rustc<'a, 'cfg>(
                 &package_id,
                 &target,
                 mode,
-                &mut json_stdout,
+                &mut assert_is_empty,
                 &mut |line| json_stderr(line, &package_id, &target),
             ).map_err(Internal::new)
             .chain_err(|| format!("Could not compile `{}`.", name))?;
@@ -640,7 +640,7 @@ fn rustdoc<'a, 'cfg>(cx: &mut Context<'a, 'cfg>, unit: &Unit<'a>) -> CargoResult
         let exec_result = if json_messages {
             rustdoc
                 .exec_with_streaming(
-                    &mut json_stdout,
+                    &mut assert_is_empty,
                     &mut |line| json_stderr(line, &package_id, &target),
                     false,
                 ).map(drop)
@@ -988,7 +988,7 @@ impl Kind {
     }
 }
 
-fn json_stdout(line: &str) -> CargoResult<()> {
+fn assert_is_empty(line: &str) -> CargoResult<()> {
     if !line.is_empty() {
         Err(internal(&format!(
             "compiler stdout is not empty: `{}`",

--- a/tests/testsuite/doc.rs
+++ b/tests/testsuite/doc.rs
@@ -1421,3 +1421,33 @@ fn doc_cap_lints() {
     );
 
 }
+
+#[test]
+fn doc_message_format() {
+    if !is_nightly() {
+        // This can be removed once 1.30 is stable (rustdoc --error-format stabilized).
+        return;
+    }
+    let p = project().file("src/lib.rs", "asdf").build();
+
+    assert_that(
+        p.cargo("doc --message-format=json"),
+        execs().with_status(101).with_json(
+            r#"
+            {
+                "message": {
+                    "children": [],
+                    "code": null,
+                    "level": "error",
+                    "message": "[..]",
+                    "rendered": "[..]",
+                    "spans": "{...}"
+                },
+                "package_id": "foo [..]",
+                "reason": "compiler-message",
+                "target": "{...}"
+            }
+            "#,
+        ),
+    );
+}


### PR DESCRIPTION
This allows `cargo doc --message-format=json` to actually work.

Note that this explicitly does not attempt to support it for doctests for
several reasons:
- `rustdoc --test --error-format=json` does not work for some reason.
- Since the lib is usually compiled before running rustdoc, warnings/errors
  will be emitted correctly by rustc.
- I'm unaware of any errors/warnings `rustdoc --test` is capable of producing
  assuming the code passed `rustc`.
- The compilation of the tests themselves do not support JSON.
- libtest does not output json, so it's utility is limited.