### PR TITLE
Add support for rustc's --error-format short

### DIFF
--- a/src/bin/cargo/command_prelude.rs
+++ b/src/bin/cargo/command_prelude.rs
@@ -127,7 +127,7 @@ pub trait AppExt: Sized {
             opt("message-format", "Error format")
                 .value_name("FMT")
                 .case_insensitive(true)
-                .possible_values(&["human", "json"])
+                .possible_values(&["human", "json", "short"])
                 .default_value("human"),
         )
     }
@@ -270,6 +270,8 @@ pub trait ArgMatchesExt {
                     MessageFormat::Json
                 } else if f.eq_ignore_ascii_case("human") {
                     MessageFormat::Human
+                } else if f.eq_ignore_ascii_case("short") {
+                    MessageFormat::Short
                 } else {
                     panic!("Impossible message format: {:?}", f)
                 }

--- a/src/cargo/core/compiler/build_config.rs
+++ b/src/cargo/core/compiler/build_config.rs
@@ -100,6 +100,7 @@ impl BuildConfig {
 pub enum MessageFormat {
     Human,
     Json,
+    Short,
 }
 
 /// The general "mode" of what to do.

--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -733,8 +733,10 @@ fn build_base_args<'a, 'cfg>(
     add_path_args(bcx, unit, cmd);
     add_color(bcx, cmd);
 
-    if bcx.build_config.json_messages() {
-        cmd.arg("--error-format").arg("json");
+    match bcx.build_config.message_format {
+        MessageFormat::Human => (),
+        MessageFormat::Json => { cmd.arg("--error-format").arg("json"); },
+        MessageFormat::Short => { cmd.arg("--error-format").arg("short"); },
     }
 
     if !test {

--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -605,9 +605,7 @@ fn rustdoc<'a, 'cfg>(cx: &mut Context<'a, 'cfg>, unit: &Unit<'a>) -> CargoResult
         rustdoc.arg("--cfg").arg(&format!("feature=\"{}\"", feat));
     }
 
-    if bcx.build_config.json_messages() {
-        rustdoc.arg("--error-format").arg("json");
-    }
+    add_error_format(bcx, &mut rustdoc);
 
     if let Some(ref args) = bcx.extra_args_for(unit) {
         rustdoc.args(args);
@@ -706,6 +704,14 @@ fn add_color(bcx: &BuildContext, cmd: &mut ProcessBuilder) {
     }
 }
 
+fn add_error_format(bcx: &BuildContext, cmd: &mut ProcessBuilder) {
+    match bcx.build_config.message_format {
+        MessageFormat::Human => (),
+        MessageFormat::Json => { cmd.arg("--error-format").arg("json"); },
+        MessageFormat::Short => { cmd.arg("--error-format").arg("short"); },
+    }
+}
+
 fn build_base_args<'a, 'cfg>(
     cx: &mut Context<'a, 'cfg>,
     cmd: &mut ProcessBuilder,
@@ -732,12 +738,7 @@ fn build_base_args<'a, 'cfg>(
 
     add_path_args(bcx, unit, cmd);
     add_color(bcx, cmd);
-
-    match bcx.build_config.message_format {
-        MessageFormat::Human => (),
-        MessageFormat::Json => { cmd.arg("--error-format").arg("json"); },
-        MessageFormat::Short => { cmd.arg("--error-format").arg("short"); },
-    }
+    add_error_format(bcx, cmd);
 
     if !test {
         for crate_type in crate_types.iter() {

--- a/src/etc/_cargo
+++ b/src/etc/_cargo
@@ -364,7 +364,7 @@ case $state in
                     '(--lib --doc --bin --test --bench)--example=[example name]' \
                     '(--lib --doc --bin --example --bench)--test=[test name]' \
                     '(--lib --doc --bin --example --test)--bench=[benchmark name]' \
-                    '--message-format:error format:(human json)' \
+                    '--message-format:error format:(human json short)' \
                     '--frozen[require lock and cache up to date]' \
                     '--locked[require lock up to date]'
                     ;;

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -3571,7 +3571,7 @@ fn wrong_message_format_option() {
         execs().with_status(1).with_stderr_contains(
             "\
 error: 'XML' isn't a valid value for '--message-format <FMT>'
-<tab>[possible values: human, json]
+<tab>[possible values: human, json, short]
 ",
         ),
     );

--- a/tests/testsuite/check.rs
+++ b/tests/testsuite/check.rs
@@ -723,6 +723,23 @@ fn check_artifacts() {
 }
 
 #[test]
+fn short_message_format() {
+    let foo = project()
+        .file("src/lib.rs", "fn foo() { let _x: bool = 'a'; }")
+        .build();
+    assert_that(
+        foo.cargo("check --message-format=short"),
+        execs().with_status(101).with_stderr_contains(
+            "\
+src/lib.rs:1:27: error[E0308]: mismatched types
+error: aborting due to previous error
+error: Could not compile `foo`.
+",
+        ),
+    );
+}
+
+#[test]
 fn proc_macro() {
     let p = project()
         .file(

--- a/tests/testsuite/doc.rs
+++ b/tests/testsuite/doc.rs
@@ -1450,3 +1450,21 @@ fn doc_message_format() {
         ),
     );
 }
+
+#[test]
+fn short_message_format() {
+    if !is_nightly() {
+        // This can be removed once 1.30 is stable (rustdoc --error-format stabilized).
+        return;
+    }
+    let p = project().file("src/lib.rs", BAD_INTRA_LINK_LIB).build();
+    assert_that(
+        p.cargo("doc --message-format=short"),
+        execs().with_status(101).with_stderr_contains(
+            "\
+src/lib.rs:4:6: error: `[bad_link]` cannot be resolved, ignoring it...
+error: Could not document `foo`.
+",
+        ),
+    );
+}


### PR DESCRIPTION
Running a local build of this branch on some broken code shows this kind of output:

    18:42:29 $ dcargo check --message-format=short --tests
        Checking bufstream v0.1.3
        Checking cargo v0.30.0 (file:///d/cargo)
    tests/testsuite/config.rs:298:9: error[E0308]: mismatched types
    tests/testsuite/config.rs:307:9: error[E0308]: mismatched types
    tests/testsuite/config.rs:363:9: error[E0308]: mismatched types
    tests/testsuite/config.rs:367:9: error[E0308]: mismatched types
    tests/testsuite/config.rs:371:9: error[E0308]: mismatched types
    tests/testsuite/config.rs:375:9: error[E0308]: mismatched types
    tests/testsuite/config.rs:382:9: error[E0308]: mismatched types
    tests/testsuite/config.rs:386:9: error[E0308]: mismatched types
    tests/testsuite/config.rs:400:9: error[E0308]: mismatched types
    tests/testsuite/config.rs:428:9: error[E0308]: mismatched types
    tests/testsuite/config.rs:479:9: error[E0308]: mismatched types
    tests/testsuite/config.rs:491:9: error[E0308]: mismatched types
    tests/testsuite/config.rs:496:9: error[E0308]: mismatched types
    tests/testsuite/config.rs:501:9: error[E0308]: mismatched types
    tests/testsuite/config.rs:506:9: error[E0308]: mismatched types
    tests/testsuite/config.rs:512:9: error[E0308]: mismatched types
    tests/testsuite/config.rs:582:9: error[E0308]: mismatched types
    tests/testsuite/config.rs:660:9: error[E0308]: mismatched types
    tests/testsuite/config.rs:666:9: error[E0308]: mismatched types
    tests/testsuite/config.rs:672:9: error[E0308]: mismatched types
    tests/testsuite/config.rs:678:9: error[E0308]: mismatched types
    error: aborting due to 21 previous errors
    error: Could not compile `cargo`.
    warning: build failed, waiting for other jobs to finish...
    error: build failed

Rehash of @QuietMisdreavus' #4720 now that `--short-message` is stable (thanks for the ping @pickfire!).

Feedback welcome.