### PR TITLE
Fix rustfmt instructions in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,8 +96,8 @@ ignore the cross-compile test failures or disable them by
 using `CFG_DISABLE_CROSS_TESTS=1 cargo test`. Note that some tests are enabled
 only on `nightly` toolchain. If you can, test both toolchains.
 * All code changes are expected to comply with the formatting suggested by `rustfmt`.
-You can use `rustup +stable component add rustfmt-preview` to install `rustfmt` and use
-`rustfmt +stable --skip-children $FILE` on the changed files to automatically format your code.
+You can use `rustup component add --toolchain nightly rustfmt-preview` to install `rustfmt` and use
+`rustfmt +nightly --unstable-features --skip-children` on the changed files to automatically format your code.
 * Push your commits to GitHub and create a pull request against Cargo's
 `master` branch.
 


### PR DESCRIPTION
rustfmt's --skip-children is now behind --unstable-features
(rust-lang-nursery/rustfmt#2796) which only works on nightly rustfmt, so
change the install instructions too.