### PR TITLE
Handle opening browser with `opener` crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ libc = "0.2"
 log = "0.4"
 libgit2-sys = "0.7.5"
 num_cpus = "1.0"
+opener = "0.2.0"
 rustfix = "0.4.2"
 same-file = "1"
 semver = { version = "0.9.0", features = ["serde"] }

--- a/src/cargo/lib.rs
+++ b/src/cargo/lib.rs
@@ -42,6 +42,7 @@ extern crate libgit2_sys;
 #[macro_use]
 extern crate log;
 extern crate num_cpus;
+extern crate opener;
 extern crate rustfix;
 extern crate same_file;
 extern crate semver;


### PR DESCRIPTION
Fixes #5701

A note about behavior on Linux:
When looking for a browser to open the docs with, Cargo currently tries the `$BROWSER` environment variable, `xdg-open`, `gnome-open`, and finally `kde-open`, in that order. With this commit, this behavior changes; the `opener` crate always uses the `xdg-open` script, which is included in the `opener` crate. The `xdg-open` script takes care of finding a suitable browser.