### PR TITLE
Add a configuration option to fetch with git-the-CLI

### DIFF
--- a/src/doc/src/reference/config.md
+++ b/src/doc/src/reference/config.md
@@ -113,6 +113,7 @@ color = 'auto'         # whether cargo colorizes output
 # Network configuration
 [net]
 retry = 2 # number of times a network call will automatically retried
+git-fetch-with-cli = false  # if `true` we'll use `git`-the-CLI to fetch git repos
 
 # Alias cargo commands. The first 3 aliases are built in. If your
 # command requires grouped whitespace use the list format.


### PR DESCRIPTION
Currently Cargo always uses `libgit2` to perform all fetches of git
repositories, but sometimes this is not sufficient. The `libgit2` library
doesn't support all authentication schemes that `git` does and it isn't always
quite at feature parity with `git` itself, especially in terms of network
configuration.

This commit adds a configuration option to Cargo for fetching git repositories
with the `git` CLI tool rather than the internal `libgit2`. While this exposes
us to changes over time in the `git` CLI it's hopefully a very targeted use case
that doesn't change much. The internal `libgit2` library should be sufficient
for all other forms of git repository management. (and using `git` for only
fetches shouldn't slow us down much)

The new configuration option in `.cargo/config` is:

    [net]
    git-fetch-with-cli = true

which can also be specified with `CARGO_NET_GIT_FETCH_WITH_CLI=true` via an
environment variable.

Closes #5903