### PR TITLE
Registries report which commands they support.

### DIFF
--- a/src/cargo/sources/registry/mod.rs
+++ b/src/cargo/sources/registry/mod.rs
@@ -210,6 +210,9 @@ pub struct RegistryConfig {
     /// API endpoint for the registry. This is what's actually hit to perform
     /// operations like yanks, owner modifications, publish new crates, etc.
     pub api: Option<String>,
+
+    #[serde(default)]
+    pub commands: BTreeMap<String, Vec<String>>,
 }
 
 #[derive(Deserialize)]

--- a/tests/testsuite/search.rs
+++ b/tests/testsuite/search.rs
@@ -65,7 +65,7 @@ fn setup() {
 
     // Init a new registry
     let _ = repo(&registry_path())
-        .file("config.json", &format!(r#"{{"dl":"{0}","api":"{0}","commands":"{1}"}}"#, api(),
+        .file("config.json", &format!(r#"{{"dl":"{0}","api":"{0}","commands":{1}}}"#, api(),
                                       COMMANDS))
         .build();
 

--- a/tests/testsuite/search.rs
+++ b/tests/testsuite/search.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 use support::{cargo_process, execs};
 use support::git::repo;
 use support::paths;
-use support::registry::{api_path, registry as registry_url, registry_path};
+use support::registry::{api_path, registry as registry_url, registry_path, COMMANDS};
 use support::hamcrest::assert_that;
 use url::Url;
 
@@ -65,7 +65,8 @@ fn setup() {
 
     // Init a new registry
     let _ = repo(&registry_path())
-        .file("config.json", &format!(r#"{{"dl":"{0}","api":"{0}"}}"#, api()))
+        .file("config.json", &format!(r#"{{"dl":"{0}","api":"{0}","commands":"{1}"}}"#, api(),
+                                      COMMANDS))
         .build();
 
     let base = api_path().join("api/v1/crates");

--- a/tests/testsuite/support/publish.rs
+++ b/tests/testsuite/support/publish.rs
@@ -40,11 +40,11 @@ pub fn setup() -> Repository {
             "config.json",
             &format!(
                 r#"{{
-            "dl": "{0}",
-            "api": "{0}",
-            "commands": "{1}"
-        }}"#,
-                upload()
+                    "dl": "{0}",
+                    "api": "{0}",
+                    "commands": "{1}"
+                }}"#,
+                upload(),
                 COMMANDS,
             ),
         )

--- a/tests/testsuite/support/publish.rs
+++ b/tests/testsuite/support/publish.rs
@@ -42,7 +42,7 @@ pub fn setup() -> Repository {
                 r#"{{
                     "dl": "{0}",
                     "api": "{0}",
-                    "commands": "{1}"
+                    "commands": {1}
                 }}"#,
                 upload(),
                 COMMANDS,

--- a/tests/testsuite/support/publish.rs
+++ b/tests/testsuite/support/publish.rs
@@ -4,6 +4,7 @@ use std::fs::{self, File};
 
 use support::paths;
 use support::git::{repo, Repository};
+use support::registry::COMMANDS;
 
 use url::Url;
 
@@ -40,9 +41,11 @@ pub fn setup() -> Repository {
             &format!(
                 r#"{{
             "dl": "{0}",
-            "api": "{0}"
+            "api": "{0}",
+            "commands": "{1}"
         }}"#,
                 upload()
+                COMMANDS,
             ),
         )
         .build()

--- a/tests/testsuite/support/registry.rs
+++ b/tests/testsuite/support/registry.rs
@@ -110,7 +110,7 @@ pub fn init() {
         .file(
             "config.json",
             &format!(
-                r#"{{"dl":"{0}","api":"{0}","commands":"{1}"}}"#,
+                r#"{{"dl":"{0}","api":"{0}","commands":{1}}}"#,
                 dl_url(),
                 COMMANDS,
             ),
@@ -124,7 +124,7 @@ pub fn init() {
             "config.json",
             &format!(
                 r#"
-            {{"dl":"{}","api":"{}","commands":"{}"}}
+            {{"dl":"{}","api":"{}","commands":{}}}
         "#,
                 alt_dl_url(),
                 alt_api_url(),

--- a/tests/testsuite/support/registry.rs
+++ b/tests/testsuite/support/registry.rs
@@ -55,7 +55,7 @@ pub const COMMANDS: &str = r#"{
     "search": ["v1"],
     "owner": ["v1"],
     "login": ["v1"]
-}";
+}"#;
 
 pub struct Package {
     name: String,
@@ -110,10 +110,9 @@ pub fn init() {
         .file(
             "config.json",
             &format!(
-                r#"
-            {{"dl":"{0}","api":"{0}","commands":"{1}"}}
-        "#,
-                dl_url(), COMMANDS,
+                r#"{{"dl":"{0}","api":"{0}","commands":"{1}"}}"#,
+                dl_url(),
+                COMMANDS,
             ),
         )
         .build();

--- a/tests/testsuite/support/registry.rs
+++ b/tests/testsuite/support/registry.rs
@@ -49,6 +49,14 @@ pub fn alt_api_url() -> Url {
     Url::from_file_path(&*alt_api_path()).ok().unwrap()
 }
 
+pub const COMMANDS: &str = r#"{
+    "publish": ["v1"],
+    "yank": ["v1"],
+    "search": ["v1"],
+    "owner": ["v1"],
+    "login": ["v1"]
+}";
+
 pub struct Package {
     name: String,
     vers: String,
@@ -103,9 +111,9 @@ pub fn init() {
             "config.json",
             &format!(
                 r#"
-            {{"dl":"{0}","api":"{0}"}}
+            {{"dl":"{0}","api":"{0}","commands":"{1}"}}
         "#,
-                dl_url()
+                dl_url(), COMMANDS,
             ),
         )
         .build();
@@ -117,10 +125,11 @@ pub fn init() {
             "config.json",
             &format!(
                 r#"
-            {{"dl":"{}","api":"{}"}}
+            {{"dl":"{}","api":"{}","commands":"{}"}}
         "#,
                 alt_dl_url(),
-                alt_api_url()
+                alt_api_url(),
+                COMMANDS,
             ),
         )
         .build();


### PR DESCRIPTION
In the `config.json` of each registry's index, that registry can report
which commands it supports, under which versions. For example, crates.io's
config.json should look like:

```json
{
    "api": "https://crates.io/",
    "dl": "https://crates.io/api/v1/crates",
    "commands": {
        "publish": ["v1"],
        "yank": ["v1"],
        "owner": ["v1"],
        "search": ["v1"],
        "login": ["v1"]
    }
}
```

Currently, these five commands only have one version, "v1," but this allows us
to release new, breaking changes to these commands' interface with crates.io
without disrupting the operation of any alternative registry.

Before this is merged, crates.io's config.json will need to be updated, and we
should make an effort to inform known maintainers of alternative registries
that they need to update their indices as well.

This also involved rewriting the initial stage of the `cargo login` flow to be a
bit more clear.