### PR TITLE
Only use non-absolute paths for `path` dependencies

### DIFF
--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -680,8 +680,10 @@ fn path_args(bcx: &BuildContext, unit: &Unit) -> (PathBuf, PathBuf) {
         unit.target.src_path().path().to_path_buf()
     };
     assert!(src.is_absolute());
-    if let Ok(path) = src.strip_prefix(ws_root) {
-        return (path.to_path_buf(), ws_root.to_path_buf());
+    if unit.pkg.package_id().source_id().is_path() {
+        if let Ok(path) = src.strip_prefix(ws_root) {
+            return (path.to_path_buf(), ws_root.to_path_buf());
+        }
     }
     (src, unit.pkg.root().to_path_buf())
 }


### PR DESCRIPTION
Previously Cargo would use a non-absolute path for any dependency contained
within the workspace root but this switches Cargo to only using relative paths
for `path` dependencies. In practice this shouldn't make much difference, but
for vendored crates and moving around `CARGO_HOME` it can produce more
consistent results when target directories are shared.

Closes #5923