### PR TITLE
Force `cargo fix` to rebuild

### DIFF
--- a/src/bin/cargo/commands/fix.rs
+++ b/src/bin/cargo/commands/fix.rs
@@ -68,7 +68,7 @@ pub fn cli() -> App {
         )
         .after_help(
             "\
-This Cargo subcommmand will automatically take rustc's suggestions from
+This Cargo subcommand will automatically take rustc's suggestions from
 diagnostics like warnings and apply them to your source code. This is intended
 to help automate tasks that rustc itself already knows how to tell you to fix!
 The `cargo fix` subcommand is also being developed for the Rust 2018 edition

--- a/src/cargo/core/compiler/build_config.rs
+++ b/src/cargo/core/compiler/build_config.rs
@@ -16,6 +16,8 @@ pub struct BuildConfig {
     pub mode: CompileMode,
     /// Whether to print std output in json format (for machine reading)
     pub message_format: MessageFormat,
+    /// Force cargo to do a full rebuild and treat each target as changed.
+    pub force_rebuild: bool,
     /// Output a build plan to stdout instead of actually compiling.
     pub build_plan: bool,
     /// Use Cargo itself as the wrapper around rustc, only used for `cargo fix`
@@ -79,6 +81,7 @@ impl BuildConfig {
             release: false,
             mode,
             message_format: MessageFormat::Human,
+            force_rebuild: false,
             build_plan: false,
             cargo_as_rustc_wrapper: false,
             extra_rustc_env: Vec::new(),

--- a/src/cargo/core/compiler/context/mod.rs
+++ b/src/cargo/core/compiler/context/mod.rs
@@ -157,7 +157,8 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
             // part of this, that's all done next as part of the `execute`
             // function which will run everything in order with proper
             // parallelism.
-            super::compile(&mut self, &mut queue, &mut plan, unit, exec)?;
+            let force_rebuild = self.bcx.build_config.force_rebuild;
+            super::compile(&mut self, &mut queue, &mut plan, unit, exec, force_rebuild)?;
         }
 
         // Now that we've figured out everything that we're going to do, do it!

--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -129,10 +129,10 @@ fn compile<'a, 'cfg: 'a>(
     plan: &mut BuildPlan,
     unit: &Unit<'a>,
     exec: &Arc<Executor>,
+    force_rebuild: bool,
 ) -> CargoResult<()> {
     let bcx = cx.bcx;
     let build_plan = bcx.build_config.build_plan;
-    let force_rebuild = bcx.build_config.force_rebuild;
     if !cx.compiled.insert(*unit) {
         return Ok(());
     }
@@ -176,7 +176,7 @@ fn compile<'a, 'cfg: 'a>(
 
     // Be sure to compile all dependencies of this target as well.
     for unit in cx.dep_targets(unit).iter() {
-        compile(cx, jobs, plan, unit, exec)?;
+        compile(cx, jobs, plan, unit, exec, false)?;
     }
     if build_plan {
         plan.add(cx, unit)?;

--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -132,6 +132,7 @@ fn compile<'a, 'cfg: 'a>(
 ) -> CargoResult<()> {
     let bcx = cx.bcx;
     let build_plan = bcx.build_config.build_plan;
+    let force_rebuild = bcx.build_config.force_rebuild;
     if !cx.compiled.insert(*unit) {
         return Ok(());
     }
@@ -164,7 +165,7 @@ fn compile<'a, 'cfg: 'a>(
         let dirty = work.then(link_targets(cx, unit, false)?).then(dirty);
         let fresh = link_targets(cx, unit, true)?.then(fresh);
 
-        if exec.force_rebuild(unit) {
+        if exec.force_rebuild(unit) || force_rebuild {
             freshness = Freshness::Dirty;
         }
 

--- a/src/cargo/ops/fix.rs
+++ b/src/cargo/ops/fix.rs
@@ -48,6 +48,8 @@ pub fn fix(ws: &Workspace, opts: &mut FixOptions) -> CargoResult<()> {
     ));
     let _started = lock_server.start()?;
 
+    opts.compile_opts.build_config.force_rebuild = true;
+
     if opts.broken_code {
         let key = BROKEN_CODE_ENV.to_string();
         opts.compile_opts.build_config.extra_rustc_env.push((key, "1".to_string()));

--- a/tests/testsuite/fix.rs
+++ b/tests/testsuite/fix.rs
@@ -1065,14 +1065,19 @@ fn doesnt_rebuild_dependencies() {
     p.cargo("fix --allow-no-vcs -p foo")
         .env("__CARGO_FIX_YOLO", "1")
         .with_stdout("")
-        .with_stderr_contains("[CHECKING] bar v0.1.0 ([..])")
-        .with_stderr_contains("[CHECKING] foo v0.1.0 ([..])")
+        .with_stderr("\
+[CHECKING] bar v0.1.0 ([..])
+[CHECKING] foo v0.1.0 ([..])
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+")
         .run();
 
     p.cargo("fix --allow-no-vcs -p foo")
         .env("__CARGO_FIX_YOLO", "1")
         .with_stdout("")
-        .with_stderr_does_not_contain("[CHECKING] bar v0.1.0 ([..])")
-        .with_stderr_contains("[CHECKING] foo v0.1.0 ([..])")
+        .with_stderr("\
+[CHECKING] foo v0.1.0 ([..])
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+")
         .run();
 }


### PR DESCRIPTION
Fixes #5736

This is a resubmit of @killercup's #5750, rebased on current master.

@alexcrichton From browsing the code I feel like `-p` would still restrict the packages to rebuild, despite the rebuild flag added. But I might be misreading or not-fully-reading the code. Could you give me some mentoring instructions for the test cases you're concerned with?