### PR TITLE
Make freshness/rebuilding tests more robust

### DIFF
--- a/tests/testsuite/bench.rs
+++ b/tests/testsuite/bench.rs
@@ -1,5 +1,4 @@
 use support::is_nightly;
-use support::paths::CargoPathExt;
 use support::{basic_bin_manifest, basic_lib_manifest, basic_manifest, project};
 
 #[test]
@@ -13,22 +12,23 @@ fn cargo_bench_simple() {
         .file(
             "src/main.rs",
             r#"
-            #![feature(test)]
-            #[cfg(test)]
-            extern crate test;
+                #![feature(test)]
+                #[cfg(test)]
+                extern crate test;
 
-            fn hello() -> &'static str {
-                "hello"
-            }
+                fn hello() -> &'static str {
+                    "hello"
+                }
 
-            pub fn main() {
-                println!("{}", hello())
-            }
+                pub fn main() {
+                    println!("{}", hello())
+                }
 
-            #[bench]
-            fn bench_hello(_b: &mut test::Bencher) {
-                assert_eq!(hello(), "hello")
-            }"#,
+                #[bench]
+                fn bench_hello(_b: &mut test::Bencher) {
+                    assert_eq!(hello(), "hello")
+                }
+            "#,
         ).build();
 
     p.cargo("build").run();
@@ -42,7 +42,8 @@ fn cargo_bench_simple() {
 [COMPILING] foo v0.5.0 (CWD)
 [FINISHED] release [optimized] target(s) in [..]
 [RUNNING] target/release/deps/foo-[..][EXE]",
-        ).with_stdout_contains("test bench_hello ... bench: [..]")
+        )
+        .with_stdout_contains("test bench_hello ... bench: [..]")
         .run();
 }
 
@@ -844,7 +845,7 @@ fn bench_dylib() {
         return;
     }
 
-    let p = project()
+    let mut p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -913,7 +914,7 @@ fn bench_dylib() {
         ).with_stdout_contains_n("test foo ... bench: [..]", 2)
         .run();
 
-    p.root().move_into_the_past();
+    p.write_file("foo", "bar");
     p.cargo("bench -v")
         .with_stderr(
             "\

--- a/tests/testsuite/build_script_env.rs
+++ b/tests/testsuite/build_script_env.rs
@@ -1,7 +1,4 @@
-use std::fs::File;
-
 use support::project;
-use support::sleep_ms;
 
 #[test]
 fn rerun_if_env_changes() {
@@ -54,7 +51,7 @@ fn rerun_if_env_changes() {
 
 #[test]
 fn rerun_if_env_or_file_changes() {
-    let p = project()
+    let mut p = project()
         .file("src/main.rs", "fn main() {}")
         .file(
             "build.rs",
@@ -86,8 +83,7 @@ fn rerun_if_env_or_file_changes() {
         .env("FOO", "bar")
         .with_stderr("[FINISHED] [..]")
         .run();
-    sleep_ms(1000);
-    File::create(p.root().join("foo")).unwrap();
+    p.write_file("foo", "");
     p.cargo("build")
         .env("FOO", "bar")
         .with_stderr(

--- a/tests/testsuite/features.rs
+++ b/tests/testsuite/features.rs
@@ -1,7 +1,6 @@
 use std::fs::File;
 use std::io::prelude::*;
 
-use support::paths::CargoPathExt;
 use support::registry::Package;
 use support::{basic_manifest, project};
 
@@ -101,7 +100,7 @@ Consider adding `optional = true` to the dependency
 
 #[test]
 fn invalid4() {
-    let p = project()
+    let mut p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -133,7 +132,7 @@ the package `foo` depends on `bar`, with features: `bar` but `bar` does not have
 failed to select a version for `bar` which could resolve this conflict",
         ).run();
 
-    p.change_file("Cargo.toml", &basic_manifest("foo", "0.0.1"));
+    p.write_file("Cargo.toml", &basic_manifest("foo", "0.0.1"));
 
     p.cargo("build --features test")
         .with_status(101)
@@ -747,8 +746,8 @@ fn many_features_no_rebuilds() {
 [COMPILING] b v0.1.0 (CWD)
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
-        ).run();
-    p.root().move_into_the_past();
+        )
+        .run();
 
     p.cargo("build -v")
         .with_stderr(

--- a/tests/testsuite/out_dir.rs
+++ b/tests/testsuite/out_dir.rs
@@ -2,7 +2,6 @@ use std::env;
 use std::fs::{self, File};
 use std::path::Path;
 
-use support::sleep_ms;
 use support::{basic_manifest, project};
 
 #[test]
@@ -177,7 +176,7 @@ fn out_dir_is_a_file() {
 
 #[test]
 fn replaces_artifacts() {
-    let p = project()
+    let mut p = project()
         .file("src/main.rs", r#"fn main() { println!("foo") }"#)
         .build();
 
@@ -190,8 +189,7 @@ fn replaces_artifacts() {
     ).with_stdout("foo")
     .run();
 
-    sleep_ms(1000);
-    p.change_file("src/main.rs", r#"fn main() { println!("bar") }"#);
+    p.write_file("src/main.rs", r#"fn main() { println!("bar") }"#);
 
     p.cargo("build -Z unstable-options --out-dir out")
         .masquerade_as_nightly_cargo()

--- a/tests/testsuite/publish.rs
+++ b/tests/testsuite/publish.rs
@@ -407,16 +407,16 @@ fn dont_publish_dirty() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-            license = "MIT"
-            description = "foo"
-            documentation = "foo"
-            homepage = "foo"
-            repository = "foo"
-        "#,
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+                license = "MIT"
+                description = "foo"
+                documentation = "foo"
+                homepage = "foo"
+                repository = "foo"
+            "#,
         ).file("src/main.rs", "fn main() {}")
         .build();
 

--- a/tests/testsuite/registry.rs
+++ b/tests/testsuite/registry.rs
@@ -405,10 +405,9 @@ fn lockfile_locks() {
 ",
         ).run();
 
-    p.root().move_into_the_past();
     Package::new("bar", "0.0.2").publish();
 
-    p.cargo("build").with_stdout("").run();
+    p.cargo("build").with_stderr("[FINISHED] [..]\n").run();
 }
 
 #[test]
@@ -444,11 +443,10 @@ fn lockfile_locks_transitively() {
 ",
         ).run();
 
-    p.root().move_into_the_past();
     Package::new("baz", "0.0.2").publish();
     Package::new("bar", "0.0.2").dep("baz", "*").publish();
 
-    p.cargo("build").with_stdout("").run();
+    p.cargo("build").with_stderr("[FINISHED] [..]\n").run();
 }
 
 #[test]
@@ -548,7 +546,7 @@ fn yanks_in_lockfiles_are_ok() {
 
     Package::new("bar", "0.0.1").yanked(true).publish();
 
-    p.cargo("build").with_stdout("").run();
+    p.cargo("build").with_stderr("[FINISHED] [..]\n").run();
 
     p.cargo("update")
         .with_status(101)
@@ -580,7 +578,6 @@ fn update_with_lockfile_if_packages_missing() {
 
     Package::new("bar", "0.0.1").publish();
     p.cargo("build").run();
-    p.root().move_into_the_past();
 
     paths::home().join(".cargo/registry").rm_rf();
     p.cargo("build")
@@ -886,7 +883,6 @@ fn git_and_registry_dep() {
 
     Package::new("a", "0.0.1").publish();
 
-    p.root().move_into_the_past();
     p.cargo("build")
         .with_stderr(
             "\
@@ -898,11 +894,11 @@ fn git_and_registry_dep() {
 [COMPILING] foo v0.0.1 (CWD)
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
 ",
-        ).run();
-    p.root().move_into_the_past();
+        )
+        .run();
 
     println!("second");
-    p.cargo("build").with_stdout("").run();
+    p.cargo("build").with_stderr("[FINISHED] [..]\n").run();
 }
 
 #[test]

--- a/tests/testsuite/rename_deps.rs
+++ b/tests/testsuite/rename_deps.rs
@@ -259,7 +259,7 @@ name, but the dependency on `foo v0.1.0` is listed as having different names
 fn rename_affects_fingerprint() {
     Package::new("foo", "0.1.0").publish();
 
-    let p = project()
+    let mut p = project()
         .file(
             "Cargo.toml",
             r#"
@@ -278,7 +278,7 @@ fn rename_affects_fingerprint() {
 
     p.cargo("build -v").masquerade_as_nightly_cargo().run();
 
-    p.change_file(
+    p.write_file(
         "Cargo.toml",
         r#"
                 cargo-features = ["rename-dependency"]

--- a/tests/testsuite/rustc_info_cache.rs
+++ b/tests/testsuite/rustc_info_cache.rs
@@ -1,5 +1,5 @@
 use std::env;
-use support::paths::CargoPathExt;
+use filetime::{self, FileTime};
 use support::{basic_manifest, project};
 
 #[test]
@@ -79,7 +79,9 @@ fn rustc_info_cache() {
         .with_stderr_does_not_contain(update)
         .run();
 
-    other_rustc.move_into_the_future();
+    let mtime = FileTime::from_last_modification_time(&other_rustc.metadata().unwrap());
+    let mtime = FileTime::from_unix_time(mtime.unix_seconds() + 1, mtime.nanoseconds());
+    filetime::set_file_times(&other_rustc, mtime, mtime).unwrap();
 
     p.cargo("build")
         .env("RUST_LOG", "cargo::util::rustc=info")

--- a/tests/testsuite/workspaces.rs
+++ b/tests/testsuite/workspaces.rs
@@ -1,9 +1,8 @@
 use std::env;
 use std::fs::{self, File};
-use std::io::{Read, Write};
+use std::io::Read;
 
 use support::registry::Package;
-use support::sleep_ms;
 use support::{basic_lib_manifest, basic_manifest, git, project};
 
 #[test]
@@ -1004,14 +1003,11 @@ fn rebuild_please() {
             }
         "#,
         );
-    let p = p.build();
+    let mut p = p.build();
 
     p.cargo("run").cwd(p.root().join("bin")).run();
 
-    sleep_ms(1000);
-
-    t!(t!(File::create(p.root().join("lib/src/lib.rs")))
-        .write_all(br#"pub fn foo() -> u32 { 1 }"#));
+    p.write_file("lib/src/lib.rs", "pub fn foo() -> u32 { 1 }");
 
     p.cargo("build").cwd(p.root().join("lib")).run();
 


### PR DESCRIPTION
This commit implements a new heavy handed strategy in the test suite to avoid
spurious test failures and improve consistency across platforms. Instead of
letting mtimes naturally work as they normally do through out tests we force all
executions of `cargo` in the tests to, just before `cargo` is run`,
deterministically set all mtime values. This way all executions of `cargo`
should see the same mtime and hopefully not be susceptible to drift here and
there.

Additionally tests now have the ability to say that a file needs to be created
(to test mtimes and such). This will whitelist the file as having a new mtime
which is known to be a large amount of time in the future (to avoid bugs with
fast or slow tests). This way we also know exactly that we can bust caches in
tests.

Finally, Cargo was outfitted with a new change. Whenever Cargo is tracking mtime
data it will latch onto the newest mtime (even if it's in the future) for the
output. This is meant to handle two cases:

* For tests which have files in the far future it allows subsequent rebuilds to
  work correctly, otherwise since a test never takes hours it looks like there's
  always a file modified in the future.

* When a file is edited during a build this should ensure that the mtime
  recorded for the build is the mtime *before* the build starts rather than
  after the build finishes, ensuring that we correctly schedule builds for
  edited files.

Closes #5940