### PR TITLE
Provide http-config option for curl low-speed-limit/time

### DIFF
--- a/src/cargo/ops/registry.rs
+++ b/src/cargo/ops/registry.rs
@@ -367,12 +367,7 @@ pub fn configure_http_handle(config: &Config, handle: &mut Easy) -> CargoResult<
     // connect phase as well as a "low speed" timeout so if we don't receive
     // many bytes in a large-ish period of time then we time out.
     handle.connect_timeout(Duration::new(30, 0))?;
-    if let Some(config_low_speed_limit) = low_speed_limit(config)? {
-        handle.low_speed_limit(config_low_speed_limit)?;
-    }
-    if let Some(config_low_speed_time) = low_speed_time(config)? {
-        handle.low_speed_time(config_low_speed_time)?;
-    }
+    handle.low_speed_limit(http_low_speed_limit(config)?)?;
     if let Some(proxy) = http_proxy(config)? {
         handle.proxy(&proxy)?;
     }
@@ -395,19 +390,11 @@ pub fn configure_http_handle(config: &Config, handle: &mut Easy) -> CargoResult<
 }
 
 /// Find an override from config for curl low-speed-limit option, otherwise use default value
-fn low_speed_limit(config: &Config) -> CargoResult<Option<u32>> {
+fn http_low_speed_limit(config: &Config) -> CargoResult<u32> {
     if let Some(s) = config.get::<Option<u32>>("http.low-speed-limit")? {
-        return Ok(Some(s));
+        return Ok(s);
     }
-    Ok(Some(10))
-}
-
-/// Find an override from config for curl low-speed-time option, otherwise use default value
-fn low_speed_time(config: &Config) -> CargoResult<Option<Duration>> {
-    if let Some(s) = config.get::<Option<u64>>("http.low-speed-time")? {
-        return Ok(Some(Duration::new(s, 0)));
-    }
-    Ok(Some(Duration::new(30, 0)))
+    Ok(10)
 }
 
 /// Find an explicit HTTP proxy if one is available.

--- a/src/doc/src/reference/config.md
+++ b/src/doc/src/reference/config.md
@@ -95,6 +95,7 @@ proxy = "host:port" # HTTP proxy to use for HTTP requests (defaults to none)
 timeout = 60000     # Timeout for each HTTP request, in milliseconds
 cainfo = "cert.pem" # Path to Certificate Authority (CA) bundle (optional)
 check-revoke = true # Indicates whether SSL certs are checked for revocation
+low-speed-limit = 0 # Lower threshold for bytes/sec (10 = default, 0 = disabled)
 
 [build]
 jobs = 1                  # number of parallel jobs, defaults to # of CPUs


### PR DESCRIPTION
Fixes rust-lang/cargo#5717

Provides new override options for curl in Cargo http config-section.

```
[http]
timeout = 2
low-speed-limit = 5
```

Test with the following during crate-download
`sudo tc qdisc add dev eth0 handle 1: root htb default 11 && sudo tc class add dev eth0 parent 1: classid 1:1 htb rate 8bps && sudo tc class add dev eth0 parent 1:1 classid 1:11 htb rate 8bps`

Clear with
`sudo tc qdisc del dev eth0 root`