### PR TITLE
add support for `target.'cfg(..)'.runner`

### DIFF
--- a/src/cargo/core/compiler/build_context/mod.rs
+++ b/src/cargo/core/compiler/build_context/mod.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::env;
 use std::path::{Path, PathBuf};
-use std::str::{self, FromStr};
+use std::str;
 
 use core::profiles::Profiles;
 use core::{Dependency, Workspace};
@@ -393,16 +393,9 @@ fn env_args(
     // ...including target.'cfg(...)'.rustflags
     if let Some(target_cfg) = target_cfg {
         if let Some(table) = config.get_table("target")? {
-            let cfgs = table.val.keys().filter_map(|t| {
-                if t.starts_with("cfg(") && t.ends_with(')') {
-                    let cfg = &t[4..t.len() - 1];
-                    CfgExpr::from_str(cfg).ok().and_then(|c| {
-                        if c.matches(target_cfg) {
-                            Some(t)
-                        } else {
-                            None
-                        }
-                    })
+            let cfgs = table.val.keys().filter_map(|key| {
+                if CfgExpr::matches_key(key, target_cfg) {
+                    Some(key)
                 } else {
                     None
                 }

--- a/src/cargo/util/cfg.rs
+++ b/src/cargo/util/cfg.rs
@@ -60,6 +60,17 @@ impl fmt::Display for Cfg {
 }
 
 impl CfgExpr {
+    /// Utility function to check if the key, "cfg(..)" matches the `target_cfg`
+    pub fn matches_key(key: &str, target_cfg: &[Cfg]) -> bool {
+        if key.starts_with("cfg(") && key.ends_with(')') {
+            let cfg = &key[4..key.len() - 1 ];
+
+            CfgExpr::from_str(cfg).ok().map(|ce| ce.matches(target_cfg)).unwrap_or(false)
+        } else {
+            false
+        }
+    }
+
     pub fn matches(&self, cfg: &[Cfg]) -> bool {
         match *self {
             CfgExpr::Not(ref e) => !e.matches(cfg),

--- a/src/doc/src/reference/config.md
+++ b/src/doc/src/reference/config.md
@@ -83,6 +83,11 @@ rustflags = ["..", ".."]
 # are concatenated. The `cfg` syntax only applies to rustflags, and not to
 # linker.
 rustflags = ["..", ".."]
+# Similar for the $triple configuration, but using the `cfg` syntax.
+# If one or more `cfg`s, and a $triple target are candidates, then the $triple
+# will be used
+# If several `cfg` are candidates, then the build will error
+runner = ".."
 
 # Configuration keys related to the registry
 [registry]


### PR DESCRIPTION
`cfg` can be used to reduce the number of `runner`s one needs to type in
`.cargo/config`. So instead of writing this:

``` toml
[target.thumbv6m-none-eabi]
runner = "arm-none-eabi-gdb"

[target.thumbv7m-none-eabi]
runner = "arm-none-eabi-gdb"

[target.thumbv7em-none-eabi]
runner = "arm-none-eabi-gdb"

[target.thumbv7em-none-eabihf]
runner = "arm-none-eabi-gdb"
```

one can write:

``` toml
[target.'cfg(all(target_arch = "arm", target_os = "none"))']
runner = "arm-none-eabi-gdb"
```

Handling of edge cases:

- When `target.$triple.runner` matches it will be chosen regardless of the
  existence of others `target.'cfg(..)'.runner`s.

- If more than one `target.'cfg(..)'.runner` matches the target the command will
  fail.

closes #5946

---

Does this sound like a reasonable feature / implementation?