### PR TITLE
Add a new update-registry subcommand for use by scripts and third-party tools

### DIFF
--- a/src/bin/cargo/commands/mod.rs
+++ b/src/bin/cargo/commands/mod.rs
@@ -29,6 +29,7 @@ pub fn builtin() -> Vec<App> {
         test::cli(),
         uninstall::cli(),
         update::cli(),
+        update_registry::cli(),
         verify_project::cli(),
         version::cli(),
         yank::cli(),
@@ -64,6 +65,7 @@ pub fn builtin_exec(cmd: &str) -> Option<fn(&mut Config, &ArgMatches) -> CliResu
         "test" => test::exec,
         "uninstall" => uninstall::exec,
         "update" => update::exec,
+        "update-registry" => update_registry::exec,
         "verify-project" => verify_project::exec,
         "version" => version::exec,
         "yank" => yank::exec,
@@ -99,6 +101,7 @@ pub mod search;
 pub mod test;
 pub mod uninstall;
 pub mod update;
+pub mod update_registry;
 pub mod verify_project;
 pub mod version;
 pub mod yank;

--- a/src/bin/cargo/commands/update_registry.rs
+++ b/src/bin/cargo/commands/update_registry.rs
@@ -1,0 +1,22 @@
+use command_prelude::*;
+
+use cargo::core::{Source, SourceId};
+use cargo::sources::RegistrySource;
+
+pub fn cli() -> App {
+    subcommand("update-registry")
+        .about("Update the local copy of the registry from the network")
+        .after_help(
+            "\
+Most Cargo commands will update the registry automatically when needed, so you
+should not need to invoke this command directly. This command exists primarily
+for use by scripts or third-party tools integrating with Cargo.
+"
+        )
+}
+
+pub fn exec(config: &mut Config, _args: &ArgMatches) -> CliResult {
+    let crates_io = SourceId::crates_io(&config)?;
+    RegistrySource::remote(&crates_io, &config).update()?;
+    Ok(())
+}


### PR DESCRIPTION
Scripts and third-party tools often need to update the registry, and
they resort to invoking other cargo commands such as `search` to do so,
which can and does potentially break when cargo changes the semantics of
those commands.

Add a dedicated command to update the registry instead.