### PR TITLE
Enable yanked dependencies with an unstable flag

### DIFF
--- a/src/bin/cargo/cli.rs
+++ b/src/bin/cargo/cli.rs
@@ -28,13 +28,14 @@ pub fn main(config: &mut Config) -> CliResult {
             "
 Available unstable (nightly-only) flags:
 
-    -Z avoid-dev-deps   -- Avoid installing dev-dependencies if possible
-    -Z minimal-versions -- Install minimal dependency versions instead of maximum
-    -Z no-index-update  -- Do not update the registry, avoids a network request for benchmarking
-    -Z offline          -- Offline mode that does not perform network requests
-    -Z unstable-options -- Allow the usage of unstable options such as --registry
-    -Z config-profile   -- Read profiles from .cargo/config files
-    -Z compile-progress -- Display a progress bar while compiling
+    -Z avoid-dev-deps    -- Avoid installing dev-dependencies if possible
+    -Z minimal-versions  -- Install minimal dependency versions instead of maximum
+    -Z no-index-update   -- Do not update the registry, avoids a network request for benchmarking
+    -Z offline           -- Offline mode that does not perform network requests
+    -Z unstable-options  -- Allow the usage of unstable options such as --registry
+    -Z config-profile    -- Read profiles from .cargo/config files
+    -Z compile-progress  -- Display a progress bar while compiling
+    -Z allow-yanked-deps -- Allow depending on yanked crates
 
 Run with 'cargo -Z [FLAG] [SUBCOMMAND]'"
         );

--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -318,6 +318,7 @@ pub struct CliUnstable {
     pub advanced_env: bool,
     pub config_profile: bool,
     pub compile_progress: bool,
+    pub allow_yanked_deps: bool,
 }
 
 impl CliUnstable {
@@ -355,6 +356,7 @@ impl CliUnstable {
             "advanced-env" => self.advanced_env = true,
             "config-profile" => self.config_profile = true,
             "compile-progress" => self.compile_progress = true,
+            "allow-yanked-deps" => self.allow_yanked_deps = true,
             _ => bail!("unknown `-Z` flag specified: {}", k),
         }
 

--- a/src/cargo/sources/registry/index.rs
+++ b/src/cargo/sources/registry/index.rs
@@ -268,12 +268,15 @@ impl<'cfg> RegistryIndex<'cfg> {
         load: &mut RegistryData,
         f: &mut FnMut(Summary),
     ) -> CargoResult<()> {
+        let allow_yanked_deps = self.config.cli_unstable().allow_yanked_deps;
         let source_id = self.source_id.clone();
         let name = dep.package_name().as_str();
         let summaries = self.summaries(name, load)?;
         let summaries = summaries
             .iter()
-            .filter(|&&(_, yanked)| dep.source_id().precise().is_some() || !yanked)
+            .filter(|&&(_, yanked)| {
+                dep.source_id().precise().is_some() || allow_yanked_deps || !yanked
+            })
             .map(|s| s.0.clone());
 
         // Handle `cargo update --precise` here. If specified, our own source

--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -198,6 +198,18 @@ directory.  Example:
 cargo +nightly build --out-dir=out -Z unstable-options
 ```
 
+## allow-yanked-deps
+* Original Issue: [#4425](https://github.com/rust-lang/cargo/issues/4225)
+
+This feature allows your project to depend on yanked crates.
+
+The flag can be useful if you need to build an old project that relies on a
+yanked dependency, and you can't update it. The flag should not be used on new
+or maintained projects: remember that yanked crates are not meant to be used.
+
+```
+cargo +nightly build -Z allow-yanked-deps
+```
 
 ### Edition
 * Tracking Issue: [rust-lang/rust#44581](https://github.com/rust-lang/rust/issues/44581)

--- a/tests/testsuite/cargo_command.rs
+++ b/tests/testsuite/cargo_command.rs
@@ -315,6 +315,6 @@ fn explain() {
 fn z_flags_help() {
     cargo_process("-Z help")
         .with_stdout_contains(
-            "    -Z unstable-options -- Allow the usage of unstable options such as --registry",
+            "    -Z unstable-options  -- Allow the usage of unstable options such as --registry",
         ).run();
 }


### PR DESCRIPTION
This PR adds a new unstable CLI flag, `-Z allow-yanked-deps`, that allows to depend on yanked crates even if there is no existing lockfile pointing at them (it basically disables the yanked check).

Crater needs this because it regenerates lockfiles on every run, so there are tons of crates that fail to build because they depend on yanked deps (like futures 0.2). Crater already uses unstable flags during lockfile generation, so I don't really care if this is stabilized or not.

Closes #4225
cc https://github.com/rust-lang-nursery/crater/issues/243