### PR TITLE
Do not use a disabled-option in the docs

### DIFF
--- a/src/cargo/ops/registry.rs
+++ b/src/cargo/ops/registry.rs
@@ -367,6 +367,7 @@ pub fn configure_http_handle(config: &Config, handle: &mut Easy) -> CargoResult<
     // connect phase as well as a "low speed" timeout so if we don't receive
     // many bytes in a large-ish period of time then we time out.
     handle.connect_timeout(Duration::new(30, 0))?;
+    handle.low_speed_time(Duration::new(30, 0))?;
     handle.low_speed_limit(http_low_speed_limit(config)?)?;
     if let Some(proxy) = http_proxy(config)? {
         handle.proxy(&proxy)?;

--- a/src/doc/src/reference/config.md
+++ b/src/doc/src/reference/config.md
@@ -95,7 +95,7 @@ proxy = "host:port" # HTTP proxy to use for HTTP requests (defaults to none)
 timeout = 60000     # Timeout for each HTTP request, in milliseconds
 cainfo = "cert.pem" # Path to Certificate Authority (CA) bundle (optional)
 check-revoke = true # Indicates whether SSL certs are checked for revocation
-low-speed-limit = 0 # Lower threshold for bytes/sec (10 = default, 0 = disabled)
+low-speed-limit = 5 # Lower threshold for bytes/sec (10 = default, 0 = disabled)
 
 [build]
 jobs = 1                  # number of parallel jobs, defaults to # of CPUs


### PR DESCRIPTION
Updates rust-lang/cargo#5717

Since people tend to copy/paste, the docs should not use the option which will disable curls low-speed-limit. Rather use a value lower than the default of 10

Also reverts removal of default low-speed-time (30s) in case no timeout is configured