### PR TITLE
Allow using `[target.'cfg[test']` in .cargo/config

### DIFF
--- a/src/cargo/core/compiler/build_context/mod.rs
+++ b/src/cargo/core/compiler/build_context/mod.rs
@@ -68,9 +68,9 @@ impl<'a, 'cfg> BuildContext<'a, 'cfg> {
             let _p = profile::start("BuildContext::probe_target_info");
             debug!("probe_target_info");
             let host_info =
-                TargetInfo::new(config, &build_config.requested_target, &rustc, Kind::Host)?;
+                TargetInfo::new(config, build_config, &rustc, Kind::Host)?;
             let target_info =
-                TargetInfo::new(config, &build_config.requested_target, &rustc, Kind::Target)?;
+                TargetInfo::new(config, build_config, &rustc, Kind::Target)?;
             (host_info, target_info)
         };
 

--- a/src/cargo/ops/cargo_fetch.rs
+++ b/src/cargo/ops/cargo_fetch.rs
@@ -23,7 +23,7 @@ pub fn fetch<'a>(
     let build_config = BuildConfig::new(config, jobs, &options.target, CompileMode::Build)?;
     let rustc = config.rustc(Some(ws))?;
     let target_info =
-        TargetInfo::new(config, &build_config.requested_target, &rustc, Kind::Target)?;
+        TargetInfo::new(config, &build_config, &rustc, Kind::Target)?;
     {
         let mut fetched_packages = HashSet::new();
         let mut deps_to_fetch = ws.members().map(|p| p.package_id()).collect::<Vec<_>>();


### PR DESCRIPTION
Previously, when I type `[target.'cfg[test]']`, it does not work. I
revise the code so that we can use it.

```
[target.'cfg(not(test))']
rustflags = [
  "-C", "link-arg=-nostartfiles",
]
```