### PR TITLE
fix: Fix unusual errors with `RUSTC_WRAPPER`

### DIFF
--- a/src/cargo/core/compiler/compilation.rs
+++ b/src/cargo/core/compiler/compilation.rs
@@ -82,17 +82,25 @@ pub struct Compilation<'cfg> {
 
 impl<'cfg> Compilation<'cfg> {
     pub fn new<'a>(bcx: &BuildContext<'a, 'cfg>) -> CargoResult<Compilation<'cfg>> {
-        let mut rustc = bcx.rustc.process();
+        // If we're using cargo as a rustc wrapper then we're in a situation
+        // like `cargo fix`. For now just disregard the `RUSTC_WRAPPER` env var
+        // (which is typically set to `sccache` for now). Eventually we'll
+        // probably want to implement `RUSTC_WRAPPER` for `cargo fix`, but we'll
+        // leave that open as a bug for now.
+        let mut rustc = if bcx.build_config.cargo_as_rustc_wrapper {
+            let mut rustc = bcx.rustc.process_no_wrapper();
+            let prog = rustc.get_program().to_owned();
+            rustc.env("RUSTC", prog);
+            rustc.program(env::current_exe()?);
+            rustc
+        } else {
+            bcx.rustc.process()
+        };
         for (k, v) in bcx.build_config.extra_rustc_env.iter() {
             rustc.env(k, v);
         }
         for arg in bcx.build_config.extra_rustc_args.iter() {
             rustc.arg(arg);
-        }
-        if bcx.build_config.cargo_as_rustc_wrapper {
-            let prog = rustc.get_program().to_owned();
-            rustc.env("RUSTC", prog);
-            rustc.program(env::current_exe()?);
         }
         let srv = bcx.build_config.rustfix_diagnostic_server.borrow();
         if let Some(server) = &*srv {

--- a/src/cargo/util/rustc.rs
+++ b/src/cargo/util/rustc.rs
@@ -68,13 +68,15 @@ impl Rustc {
     pub fn process(&self) -> ProcessBuilder {
         if let Some(ref wrapper) = self.wrapper {
             let mut cmd = util::process(wrapper);
-            {
-                cmd.arg(&self.path);
-            }
+            cmd.arg(&self.path);
             cmd
         } else {
-            util::process(&self.path)
+            self.process_no_wrapper()
         }
+    }
+
+    pub fn process_no_wrapper(&self) -> ProcessBuilder {
+        util::process(&self.path)
     }
 
     pub fn cached_output(&self, cmd: &ProcessBuilder) -> CargoResult<(String, String)> {

--- a/tests/testsuite/fix.rs
+++ b/tests/testsuite/fix.rs
@@ -1117,3 +1117,26 @@ fn doesnt_rebuild_dependencies() {
 ")
         .run();
 }
+
+#[test]
+fn does_not_crash_with_rustc_wrapper() {
+    // We don't have /usr/bin/env on Windows.
+    if cfg!(windows) {
+        return;
+    }
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.1.0"
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    p.cargo("fix --allow-no-vcs")
+        .env("RUSTC_WRAPPER", "/usr/bin/env")
+        .run();
+}


### PR DESCRIPTION
This commit fixes the interaction of `cargo fix` and `RUSTC_WRAPPER`, ensuring
that Cargo at least doesn't die internally. For now `RUSTC_WRAPPER` is
overridden for normal execution but we can eventually one day probably support
`RUSTC_WRAPPER`!

Closes #5981