### PR TITLE
Change the default edition for `cargo new` to 2018

### DIFF
--- a/src/cargo/ops/cargo_new.rs
+++ b/src/cargo/ops/cargo_new.rs
@@ -535,18 +535,16 @@ path = {}
             r#"[package]
 name = "{}"
 version = "0.1.0"
-authors = [{}]{}
+authors = [{}]
+edition = {}
 
 [dependencies]
 {}"#,
             name,
             toml::Value::String(author),
             match opts.edition {
-                Some(edition) => {
-                    let edition = toml::Value::String(edition.to_string());
-                    format!("\nedition = {}", edition)
-                }
-                None => String::new(),
+                Some(edition) => toml::Value::String(edition.to_string()),
+                None => toml::Value::String("2018".to_string()),
             },
             cargotoml_path_specifier
         ).as_bytes(),

--- a/tests/testsuite/init.rs
+++ b/tests/testsuite/init.rs
@@ -13,7 +13,7 @@ fn cargo_process(s: &str) -> Execs {
 
 #[test]
 fn simple_lib() {
-    cargo_process("init --lib --vcs none")
+    cargo_process("init --lib --vcs none --edition 2015")
         .env("USER", "foo")
         .with_stderr("[CREATED] library project")
         .run();
@@ -29,7 +29,7 @@ fn simple_lib() {
 fn simple_bin() {
     let path = paths::root().join("foo");
     fs::create_dir(&path).unwrap();
-    cargo_process("init --bin --vcs none")
+    cargo_process("init --bin --vcs none --edition 2015")
         .env("USER", "foo")
         .cwd(&path)
         .with_stderr("[CREATED] binary (application) project")

--- a/tests/testsuite/new.rs
+++ b/tests/testsuite/new.rs
@@ -14,7 +14,7 @@ fn create_empty_gitconfig() {
 
 #[test]
 fn simple_lib() {
-    cargo_process("new --lib foo --vcs none")
+    cargo_process("new --lib foo --vcs none --edition 2015")
         .env("USER", "foo")
         .with_stderr("[CREATED] library `foo` project")
         .run();
@@ -47,7 +47,7 @@ mod tests {
 
 #[test]
 fn simple_bin() {
-    cargo_process("new --bin foo")
+    cargo_process("new --bin foo --edition 2015")
         .env("USER", "foo")
         .with_stderr("[CREATED] binary (application) `foo` project")
         .run();
@@ -75,7 +75,7 @@ fn both_lib_and_bin() {
 
 #[test]
 fn simple_git() {
-    cargo_process("new --lib foo").env("USER", "foo").run();
+    cargo_process("new --lib foo --edition 2015").env("USER", "foo").run();
 
     assert!(paths::root().is_dir());
     assert!(paths::root().join("foo/Cargo.toml").is_file());
@@ -468,6 +468,15 @@ fn new_with_edition_2015() {
 #[test]
 fn new_with_edition_2018() {
     cargo_process("new --edition 2018 foo")
+        .env("USER", "foo")
+        .run();
+    let manifest = fs::read_to_string(paths::root().join("foo/Cargo.toml")).unwrap();
+    assert!(manifest.contains("edition = \"2018\""));
+}
+
+#[test]
+fn new_default_edition() {
+    cargo_process("new foo")
         .env("USER", "foo")
         .run();
     let manifest = fs::read_to_string(paths::root().join("foo/Cargo.toml")).unwrap();


### PR DESCRIPTION
As it says on the tin! Some tests were updated to explicitly pass 2015 so they
can continue to work on stable, and otherwise `cargo new` should now by default
generate a 2018 project.