### PR TITLE
Don't print crates.io-index URL when Updating

### DIFF
--- a/src/cargo/core/source/source_id.rs
+++ b/src/cargo/core/source/source_id.rs
@@ -211,9 +211,9 @@ impl SourceId {
 
     pub fn display_registry(&self) -> String {
         if self.is_default_registry() {
-            "registry".to_string()
+            "crates.io index".to_string()
         } else {
-            format!("registry `{}`", self.url())
+            format!("`{}` index", self.url())
         }
     }
 

--- a/src/cargo/core/source/source_id.rs
+++ b/src/cargo/core/source/source_id.rs
@@ -210,7 +210,11 @@ impl SourceId {
     }
 
     pub fn display_registry(&self) -> String {
-        format!("registry `{}`", self.url())
+        if self.is_default_registry() {
+            "registry".to_string()
+        } else {
+            format!("registry `{}`", self.url())
+        }
     }
 
     /// Is this source from a filesystem path

--- a/src/doc/src/guide/dependencies.md
+++ b/src/doc/src/guide/dependencies.md
@@ -46,7 +46,7 @@ their dependencies, compile them all, and update the `Cargo.lock`:
 
 ```console
 $ cargo build
-      Updating registry `https://github.com/rust-lang/crates.io-index`
+      Updating crates.io index
    Downloading memchr v0.1.5
    Downloading libc v0.1.10
    Downloading regex-syntax v0.2.1

--- a/tests/testsuite/alt_registry.rs
+++ b/tests/testsuite/alt_registry.rs
@@ -56,7 +56,7 @@ fn depend_on_alt_registry() {
         .masquerade_as_nightly_cargo()
         .with_stderr(&format!(
             "\
-[UPDATING] registry `{reg}`
+[UPDATING] `{reg}` index
 [DOWNLOADING] bar v0.0.1 (registry `file://[..]`)
 [COMPILING] bar v0.0.1 (registry `file://[..]`)
 [COMPILING] foo v0.0.1 (CWD)
@@ -109,7 +109,7 @@ fn depend_on_alt_registry_depends_on_same_registry_no_index() {
         .masquerade_as_nightly_cargo()
         .with_stderr(&format!(
             "\
-[UPDATING] registry `{reg}`
+[UPDATING] `{reg}` index
 [DOWNLOADING] [..] v0.0.1 (registry `file://[..]`)
 [DOWNLOADING] [..] v0.0.1 (registry `file://[..]`)
 [COMPILING] baz v0.0.1 (registry `file://[..]`)
@@ -151,7 +151,7 @@ fn depend_on_alt_registry_depends_on_same_registry() {
         .masquerade_as_nightly_cargo()
         .with_stderr(&format!(
             "\
-[UPDATING] registry `{reg}`
+[UPDATING] `{reg}` index
 [DOWNLOADING] [..] v0.0.1 (registry `file://[..]`)
 [DOWNLOADING] [..] v0.0.1 (registry `file://[..]`)
 [COMPILING] baz v0.0.1 (registry `file://[..]`)
@@ -193,8 +193,8 @@ fn depend_on_alt_registry_depends_on_crates_io() {
         .masquerade_as_nightly_cargo()
         .with_stderr(&format!(
             "\
-[UPDATING] registry `{alt_reg}`
-[UPDATING] registry `{reg}`
+[UPDATING] `{alt_reg}` index
+[UPDATING] `{reg}` index
 [DOWNLOADING] [..] v0.0.1 (registry `file://[..]`)
 [DOWNLOADING] [..] v0.0.1 (registry `file://[..]`)
 [COMPILING] baz v0.0.1 (registry `file://[..]`)
@@ -358,9 +358,9 @@ fn alt_registry_and_crates_io_deps() {
     p.cargo("build")
         .masquerade_as_nightly_cargo()
         .with_stderr_contains(format!(
-            "[UPDATING] registry `{}`",
+            "[UPDATING] `{}` index",
             registry::alt_registry()
-        )).with_stderr_contains(&format!("[UPDATING] registry `{}`", registry::registry()))
+        )).with_stderr_contains(&format!("[UPDATING] `{}` index", registry::registry()))
         .with_stderr_contains("[DOWNLOADING] crates_io_dep v0.0.1 (registry `file://[..]`)")
         .with_stderr_contains("[DOWNLOADING] alt_reg_dep v0.1.0 (registry `file://[..]`)")
         .with_stderr_contains("[COMPILING] alt_reg_dep v0.1.0 (registry `file://[..]`)")

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -3551,7 +3551,7 @@ fn build_all_member_dependency_same_name() {
 
     p.cargo("build --all")
         .with_stderr(
-            "[..] Updating registry `[..]`\n\
+            "[..] Updating `[..]` index\n\
              [..] Downloading a v0.1.0 ([..])\n\
              [..] Compiling a v0.1.0\n\
              [..] Compiling a v0.1.0 ([..])\n\

--- a/tests/testsuite/build_script.rs
+++ b/tests/testsuite/build_script.rs
@@ -2706,7 +2706,7 @@ fn warnings_hidden_for_upstream() {
     p.cargo("build -v")
         .with_stderr(
             "\
-[UPDATING] registry `[..]`
+[UPDATING] `[..]` index
 [DOWNLOADING] bar v0.1.0 ([..])
 [COMPILING] bar v0.1.0
 [RUNNING] `rustc [..]`
@@ -2760,7 +2760,7 @@ fn warnings_printed_on_vv() {
     p.cargo("build -vv")
         .with_stderr(
             "\
-[UPDATING] registry `[..]`
+[UPDATING] `[..]` index
 [DOWNLOADING] bar v0.1.0 ([..])
 [COMPILING] bar v0.1.0
 [RUNNING] `rustc [..]`

--- a/tests/testsuite/cfg.rs
+++ b/tests/testsuite/cfg.rs
@@ -222,7 +222,7 @@ fn works_through_the_registry() {
     p.cargo("build")
         .with_stderr(
             "\
-[UPDATING] registry [..]
+[UPDATING] [..] index
 [DOWNLOADING] [..]
 [DOWNLOADING] [..]
 [COMPILING] baz v0.1.0
@@ -266,7 +266,7 @@ fn ignore_version_from_other_platform() {
     p.cargo("build")
         .with_stderr(
             "\
-[UPDATING] registry [..]
+[UPDATING] [..] index
 [DOWNLOADING] [..]
 [COMPILING] bar v0.1.0
 [COMPILING] foo v0.0.1 ([..])

--- a/tests/testsuite/cross_publish.rs
+++ b/tests/testsuite/cross_publish.rs
@@ -104,7 +104,7 @@ fn publish_with_target() {
         .arg("--target")
         .arg(&target)
         .with_stderr(&format!(
-            "    Updating registry `{registry}`
+            "    Updating `{registry}` index
    Packaging foo v0.0.0 (CWD)
    Verifying foo v0.0.0 (CWD)
    Compiling foo v0.0.0 (CWD/target/package/foo-0.0.0)

--- a/tests/testsuite/directory.rs
+++ b/tests/testsuite/directory.rs
@@ -330,7 +330,7 @@ fn crates_io_then_directory() {
     p.cargo("build")
         .with_stderr(
             "\
-[UPDATING] registry `[..]`
+[UPDATING] `[..]` index
 [DOWNLOADING] bar v0.1.0 ([..])
 [COMPILING] bar v0.1.0
 [COMPILING] foo v0.1.0 (CWD)

--- a/tests/testsuite/doc.rs
+++ b/tests/testsuite/doc.rs
@@ -967,7 +967,7 @@ fn doc_all_member_dependency_same_name() {
     Package::new("bar", "0.1.0").publish();
 
     p.cargo("doc --all")
-        .with_stderr_contains("[..] Updating registry `[..]`")
+        .with_stderr_contains("[..] Updating `[..]` index")
         .with_stderr_contains("[..] Documenting bar v0.1.0 ([..])")
         .run();
 }

--- a/tests/testsuite/generate_lockfile.rs
+++ b/tests/testsuite/generate_lockfile.rs
@@ -82,7 +82,7 @@ fn no_index_update() {
         .build();
 
     p.cargo("generate-lockfile")
-        .with_stderr("[UPDATING] registry `[..]`")
+        .with_stderr("[UPDATING] `[..]` index")
         .run();
 
     p.cargo("generate-lockfile -Zno-index-update")

--- a/tests/testsuite/git.rs
+++ b/tests/testsuite/git.rs
@@ -2358,7 +2358,7 @@ fn include_overrides_gitignore() {
     p.cargo("build -v")
         .with_stderr(
             "\
-[UPDATING] registry `[..]`
+[UPDATING] `[..]` index
 [DOWNLOADING] filetime [..]
 [DOWNLOADING] libc [..]
 [COMPILING] libc [..]

--- a/tests/testsuite/install.rs
+++ b/tests/testsuite/install.rs
@@ -26,7 +26,7 @@ fn simple() {
     cargo_process("install foo")
         .with_stderr(
             "\
-[UPDATING] registry `[..]`
+[UPDATING] `[..]` index
 [DOWNLOADING] foo v0.0.1 (registry [..])
 [INSTALLING] foo v0.0.1
 [COMPILING] foo v0.0.1
@@ -52,7 +52,7 @@ fn multiple_pkgs() {
         .with_status(101)
         .with_stderr(
             "\
-[UPDATING] registry `[..]`
+[UPDATING] `[..]` index
 [DOWNLOADING] foo v0.0.1 (registry `CWD/registry`)
 [INSTALLING] foo v0.0.1
 [COMPILING] foo v0.0.1
@@ -96,7 +96,7 @@ fn pick_max_version() {
     cargo_process("install foo")
         .with_stderr(
             "\
-[UPDATING] registry `[..]`
+[UPDATING] `[..]` index
 [DOWNLOADING] foo v0.2.1 (registry [..])
 [INSTALLING] foo v0.2.1
 [COMPILING] foo v0.2.1
@@ -129,7 +129,7 @@ fn missing() {
         .with_status(101)
         .with_stderr(
             "\
-[UPDATING] registry [..]
+[UPDATING] [..] index
 [ERROR] could not find `bar` in registry `[..]`
 ",
         ).run();
@@ -142,7 +142,7 @@ fn bad_version() {
         .with_status(101)
         .with_stderr(
             "\
-[UPDATING] registry [..]
+[UPDATING] [..] index
 [ERROR] could not find `foo` in registry `[..]` with version `=0.2.0`
 ",
         ).run();

--- a/tests/testsuite/lockfile_compat.rs
+++ b/tests/testsuite/lockfile_compat.rs
@@ -224,7 +224,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
         .with_status(101)
         .with_stderr(
             "\
-[UPDATING] registry `[..]`
+[UPDATING] `[..]` index
 error: checksum for `bar v0.1.0` changed between lock files
 
 this could be indicative of a few possible errors:
@@ -284,7 +284,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
         .with_status(101)
         .with_stderr(
             "\
-[UPDATING] registry `[..]`
+[UPDATING] `[..]` index
 error: checksum for `bar v0.1.0` was not previously calculated, but a checksum \
 could now be calculated
 
@@ -479,7 +479,7 @@ fn locked_correct_error() {
         .with_status(101)
         .with_stderr(
             "\
-[UPDATING] registry `[..]`
+[UPDATING] `[..]` index
 error: the lock file needs to be updated but --locked was passed to prevent this
 ",
         ).run();

--- a/tests/testsuite/overrides.rs
+++ b/tests/testsuite/overrides.rs
@@ -38,7 +38,7 @@ fn override_simple() {
     p.cargo("build")
         .with_stderr(
             "\
-[UPDATING] registry `file://[..]`
+[UPDATING] `file://[..]` index
 [UPDATING] git repository `[..]`
 [COMPILING] bar v0.1.0 (file://[..])
 [COMPILING] foo v0.0.1 (CWD)
@@ -183,7 +183,7 @@ fn transitive() {
     p.cargo("build")
         .with_stderr(
             "\
-[UPDATING] registry `file://[..]`
+[UPDATING] `file://[..]` index
 [UPDATING] git repository `[..]`
 [DOWNLOADING] baz v0.2.0 (registry [..])
 [COMPILING] bar v0.1.0 (file://[..])
@@ -231,7 +231,7 @@ fn persists_across_rebuilds() {
     p.cargo("build")
         .with_stderr(
             "\
-[UPDATING] registry `file://[..]`
+[UPDATING] `file://[..]` index
 [UPDATING] git repository `file://[..]`
 [COMPILING] bar v0.1.0 (file://[..])
 [COMPILING] foo v0.0.1 (CWD)
@@ -275,7 +275,7 @@ fn replace_registry_with_path() {
     p.cargo("build")
         .with_stderr(
             "\
-[UPDATING] registry `file://[..]`
+[UPDATING] `file://[..]` index
 [COMPILING] bar v0.1.0 (file://[..])
 [COMPILING] foo v0.0.1 (CWD)
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
@@ -336,7 +336,7 @@ fn use_a_spec_to_select() {
     p.cargo("build")
         .with_stderr(
             "\
-[UPDATING] registry `file://[..]`
+[UPDATING] `file://[..]` index
 [UPDATING] git repository `[..]`
 [DOWNLOADING] [..]
 [DOWNLOADING] [..]
@@ -393,7 +393,7 @@ fn override_adds_some_deps() {
     p.cargo("build")
         .with_stderr(
             "\
-[UPDATING] registry `file://[..]`
+[UPDATING] `file://[..]` index
 [UPDATING] git repository `[..]`
 [DOWNLOADING] baz v0.1.1 (registry [..])
 [COMPILING] baz v0.1.1
@@ -411,13 +411,13 @@ fn override_adds_some_deps() {
         .with_stderr(
             "\
 [UPDATING] git repository `file://[..]`
-[UPDATING] registry `file://[..]`
+[UPDATING] `file://[..]` index
 ",
         ).run();
     p.cargo("update -p https://github.com/rust-lang/crates.io-index#bar")
         .with_stderr(
             "\
-[UPDATING] registry `file://[..]`
+[UPDATING] `file://[..]` index
 ",
         ).run();
 
@@ -508,7 +508,7 @@ fn override_wrong_name() {
         .with_status(101)
         .with_stderr(
             "\
-[UPDATING] registry [..]
+[UPDATING] [..] index
 [UPDATING] git repository [..]
 error: no matching package for override `[..]baz:0.1.0` found
 location searched: file://[..]
@@ -550,7 +550,7 @@ fn override_with_nothing() {
         .with_status(101)
         .with_stderr(
             "\
-[UPDATING] registry [..]
+[UPDATING] [..] index
 [UPDATING] git repository [..]
 [ERROR] failed to load source for a dependency on `bar`
 
@@ -629,7 +629,7 @@ fn multiple_specs() {
         .with_status(101)
         .with_stderr(
             "\
-[UPDATING] registry [..]
+[UPDATING] [..] index
 [UPDATING] git repository [..]
 error: overlapping replacement specifications found:
 
@@ -717,7 +717,7 @@ fn update() {
     p.cargo("update")
         .with_stderr(
             "\
-[UPDATING] registry `[..]`
+[UPDATING] `[..]` index
 [UPDATING] git repository `[..]`
 ",
         ).run();
@@ -1039,7 +1039,7 @@ fn no_warnings_when_replace_is_used_in_another_workspace_member() {
         .with_stdout("")
         .with_stderr(
             "\
-[UPDATING] registry `[..]`
+[UPDATING] `[..]` index
 [COMPILING] bar v0.1.0 ([..])
 [COMPILING] first_crate v0.1.0 ([..])
 [FINISHED] [..]",

--- a/tests/testsuite/patch.rs
+++ b/tests/testsuite/patch.rs
@@ -50,7 +50,7 @@ fn replace() {
     p.cargo("build")
         .with_stderr(
             "\
-[UPDATING] registry `file://[..]`
+[UPDATING] `file://[..]` index
 [DOWNLOADING] baz v0.1.0 ([..])
 [COMPILING] bar v0.1.0 (CWD/bar)
 [COMPILING] baz v0.1.0
@@ -91,7 +91,7 @@ fn nonexistent() {
     p.cargo("build")
         .with_stderr(
             "\
-[UPDATING] registry `file://[..]`
+[UPDATING] `file://[..]` index
 [COMPILING] bar v0.1.0 (CWD/bar)
 [COMPILING] foo v0.0.1 (CWD)
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
@@ -180,7 +180,7 @@ fn patch_to_git() {
         .with_stderr(
             "\
 [UPDATING] git repository `file://[..]`
-[UPDATING] registry `file://[..]`
+[UPDATING] `file://[..]` index
 [COMPILING] bar v0.1.0 (file://[..])
 [COMPILING] foo v0.0.1 (CWD)
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
@@ -216,7 +216,7 @@ fn unused() {
     p.cargo("build")
         .with_stderr(
             "\
-[UPDATING] registry `file://[..]`
+[UPDATING] `file://[..]` index
 [DOWNLOADING] bar v0.1.0 [..]
 [COMPILING] bar v0.1.0
 [COMPILING] foo v0.0.1 (CWD)
@@ -274,7 +274,7 @@ fn unused_git() {
         .with_stderr(
             "\
 [UPDATING] git repository `file://[..]`
-[UPDATING] registry `file://[..]`
+[UPDATING] `file://[..]` index
 [DOWNLOADING] bar v0.1.0 [..]
 [COMPILING] bar v0.1.0
 [COMPILING] foo v0.0.1 (CWD)
@@ -308,7 +308,7 @@ fn add_patch() {
     p.cargo("build")
         .with_stderr(
             "\
-[UPDATING] registry `file://[..]`
+[UPDATING] `file://[..]` index
 [DOWNLOADING] bar v0.1.0 [..]
 [COMPILING] bar v0.1.0
 [COMPILING] foo v0.0.1 (CWD)
@@ -367,7 +367,7 @@ fn add_ignored_patch() {
     p.cargo("build")
         .with_stderr(
             "\
-[UPDATING] registry `file://[..]`
+[UPDATING] `file://[..]` index
 [DOWNLOADING] bar v0.1.0 [..]
 [COMPILING] bar v0.1.0
 [COMPILING] foo v0.0.1 (CWD)
@@ -424,7 +424,7 @@ fn new_minor() {
     p.cargo("build")
         .with_stderr(
             "\
-[UPDATING] registry `file://[..]`
+[UPDATING] `file://[..]` index
 [COMPILING] bar v0.1.1 [..]
 [COMPILING] foo v0.0.1 (CWD)
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
@@ -471,7 +471,7 @@ fn transitive_new_minor() {
     p.cargo("build")
         .with_stderr(
             "\
-[UPDATING] registry `file://[..]`
+[UPDATING] `file://[..]` index
 [COMPILING] baz v0.1.1 [..]
 [COMPILING] bar v0.1.0 [..]
 [COMPILING] foo v0.0.1 (CWD)
@@ -507,7 +507,7 @@ fn new_major() {
     p.cargo("build")
         .with_stderr(
             "\
-[UPDATING] registry `file://[..]`
+[UPDATING] `file://[..]` index
 [COMPILING] bar v0.2.0 [..]
 [COMPILING] foo v0.0.1 (CWD)
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
@@ -534,7 +534,7 @@ fn new_major() {
     p.cargo("build")
         .with_stderr(
             "\
-[UPDATING] registry `file://[..]`
+[UPDATING] `file://[..]` index
 [DOWNLOADING] bar v0.2.0 [..]
 [COMPILING] bar v0.2.0
 [COMPILING] foo v0.0.1 (CWD)
@@ -582,7 +582,7 @@ fn transitive_new_major() {
     p.cargo("build")
         .with_stderr(
             "\
-[UPDATING] registry `file://[..]`
+[UPDATING] `file://[..]` index
 [COMPILING] baz v0.2.0 [..]
 [COMPILING] bar v0.1.0 [..]
 [COMPILING] foo v0.0.1 (CWD)

--- a/tests/testsuite/publish.rs
+++ b/tests/testsuite/publish.rs
@@ -30,7 +30,7 @@ fn simple() {
         .arg(publish::registry().to_string())
         .with_stderr(&format!(
             "\
-[UPDATING] registry `{reg}`
+[UPDATING] `{reg}` index
 [WARNING] manifest has no documentation, [..]
 See [..]
 [PACKAGING] foo v0.0.1 (CWD)
@@ -103,7 +103,7 @@ fn old_token_location() {
         .arg(publish::registry().to_string())
         .with_stderr(&format!(
             "\
-[UPDATING] registry `{reg}`
+[UPDATING] `{reg}` index
 [WARNING] manifest has no documentation, [..]
 See [..]
 [PACKAGING] foo v0.0.1 (CWD)
@@ -178,7 +178,7 @@ wants the location of the index. Please use '--index' instead.
 This will soon become a hard error, so it's either recommended
 to update to a fixed version or contact the upstream maintainer
 about this warning.
-[UPDATING] registry `{reg}`
+[UPDATING] `{reg}` index
 [WARNING] manifest has no documentation, [..]
 See [..]
 [PACKAGING] foo v0.0.1 (CWD)
@@ -255,7 +255,7 @@ wants the location of the index. Please use '--index' instead.
 This will soon become a hard error, so it's either recommended
 to update to a fixed version or contact the upstream maintainer
 about this warning.
-[UPDATING] registry `{reg}`
+[UPDATING] `{reg}` index
 [WARNING] manifest has no documentation, [..]
 See [..]
 [PACKAGING] foo v0.0.1 (CWD)
@@ -323,7 +323,7 @@ fn git_deps() {
         .with_status(101)
         .with_stderr(
             "\
-[UPDATING] registry [..]
+[UPDATING] [..] index
 [ERROR] crates cannot be published to crates.io with dependencies sourced from \
 a repository\neither publish `foo` as its own crate on crates.io and \
 specify a crates.io version as a dependency or pull it into this \
@@ -361,7 +361,7 @@ fn path_dependency_no_version() {
         .with_status(101)
         .with_stderr(
             "\
-[UPDATING] registry [..]
+[UPDATING] [..] index
 [ERROR] all path dependencies must have a version specified when publishing.
 dependency `bar` does not specify a version
 ",
@@ -425,7 +425,7 @@ fn dont_publish_dirty() {
         .with_status(101)
         .with_stderr(
             "\
-[UPDATING] registry `[..]`
+[UPDATING] `[..]` index
 error: 1 files in the working directory contain changes that were not yet \
 committed into git:
 
@@ -601,7 +601,7 @@ fn dry_run() {
         .arg(publish::registry().to_string())
         .with_stderr(
             "\
-[UPDATING] registry `[..]`
+[UPDATING] `[..]` index
 [WARNING] manifest has no documentation, [..]
 See [..]
 [PACKAGING] foo v0.0.1 (CWD)

--- a/tests/testsuite/registry.rs
+++ b/tests/testsuite/registry.rs
@@ -39,7 +39,7 @@ fn simple() {
     p.cargo("build")
         .with_stderr(&format!(
             "\
-[UPDATING] registry `{reg}`
+[UPDATING] `{reg}` index
 [DOWNLOADING] bar v0.0.1 (registry `file://[..]`)
 [COMPILING] bar v0.0.1
 [COMPILING] foo v0.0.1 (CWD)
@@ -84,7 +84,7 @@ fn deps() {
     p.cargo("build")
         .with_stderr(&format!(
             "\
-[UPDATING] registry `{reg}`
+[UPDATING] `{reg}` index
 [DOWNLOADING] [..] v0.0.1 (registry `file://[..]`)
 [DOWNLOADING] [..] v0.0.1 (registry `file://[..]`)
 [COMPILING] baz v0.0.1
@@ -119,7 +119,7 @@ fn nonexistent() {
         .with_status(101)
         .with_stderr(
             "\
-[UPDATING] registry [..]
+[UPDATING] [..] index
 error: no matching package named `nonexistent` found
 location searched: registry [..]
 required by package `foo v0.0.1 ([..])`
@@ -151,7 +151,7 @@ fn wrong_case() {
         .with_status(101)
         .with_stderr(
             "\
-[UPDATING] registry [..]
+[UPDATING] [..] index
 error: no matching package named `Init` found
 location searched: registry [..]
 did you mean: init
@@ -184,7 +184,7 @@ fn mis_hyphenated() {
         .with_status(101)
         .with_stderr(
             "\
-[UPDATING] registry [..]
+[UPDATING] [..] index
 error: no matching package named `mis_hyphenated` found
 location searched: registry [..]
 did you mean: mis-hyphenated
@@ -264,7 +264,7 @@ fn bad_cksum() {
         .with_status(101)
         .with_stderr(
             "\
-[UPDATING] registry [..]
+[UPDATING] [..] index
 [DOWNLOADING] bad-cksum [..]
 [ERROR] unable to get packages from source
 
@@ -311,7 +311,7 @@ required by package `foo v0.0.1 ([..])`
     p.cargo("build")
         .with_stderr(format!(
             "\
-[UPDATING] registry `{reg}`
+[UPDATING] `{reg}` index
 [DOWNLOADING] notyet v0.0.1 (registry `file://[..]`)
 [COMPILING] notyet v0.0.1
 [COMPILING] foo v0.0.1 (CWD)
@@ -366,7 +366,7 @@ required by package `foo v0.0.1 ([..])`
             "\
 [PACKAGING] foo v0.0.1 (CWD)
 [VERIFYING] foo v0.0.1 (CWD)
-[UPDATING] registry `[..]`
+[UPDATING] `[..]` index
 [DOWNLOADING] notyet v0.0.1 (registry `file://[..]`)
 [COMPILING] notyet v0.0.1
 [COMPILING] foo v0.0.1 (CWD[..])
@@ -397,7 +397,7 @@ fn lockfile_locks() {
     p.cargo("build")
         .with_stderr(
             "\
-[UPDATING] registry `[..]`
+[UPDATING] `[..]` index
 [DOWNLOADING] bar v0.0.1 (registry `file://[..]`)
 [COMPILING] bar v0.0.1
 [COMPILING] foo v0.0.1 (CWD)
@@ -434,7 +434,7 @@ fn lockfile_locks_transitively() {
     p.cargo("build")
         .with_stderr(
             "\
-[UPDATING] registry `[..]`
+[UPDATING] `[..]` index
 [DOWNLOADING] [..] v0.0.1 (registry `file://[..]`)
 [DOWNLOADING] [..] v0.0.1 (registry `file://[..]`)
 [COMPILING] baz v0.0.1
@@ -479,7 +479,7 @@ fn yanks_are_not_used() {
     p.cargo("build")
         .with_stderr(
             "\
-[UPDATING] registry `[..]`
+[UPDATING] `[..]` index
 [DOWNLOADING] [..] v0.0.1 (registry `file://[..]`)
 [DOWNLOADING] [..] v0.0.1 (registry `file://[..]`)
 [COMPILING] baz v0.0.1
@@ -586,7 +586,7 @@ fn update_with_lockfile_if_packages_missing() {
     p.cargo("build")
         .with_stderr(
             "\
-[UPDATING] registry `[..]`
+[UPDATING] `[..]` index
 [DOWNLOADING] bar v0.0.1 (registry `file://[..]`)
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
 ",
@@ -621,7 +621,7 @@ fn update_lockfile() {
     p.cargo("update -p bar --precise 0.0.2")
         .with_stderr(
             "\
-[UPDATING] registry `[..]`
+[UPDATING] `[..]` index
 [UPDATING] bar v0.0.1 -> v0.0.2
 ",
         ).run();
@@ -641,7 +641,7 @@ fn update_lockfile() {
     p.cargo("update -p bar")
         .with_stderr(
             "\
-[UPDATING] registry `[..]`
+[UPDATING] `[..]` index
 [UPDATING] bar v0.0.2 -> v0.0.3
 ",
         ).run();
@@ -663,7 +663,7 @@ fn update_lockfile() {
     p.cargo("update -p bar")
         .with_stderr(
             "\
-[UPDATING] registry `[..]`
+[UPDATING] `[..]` index
 [UPDATING] bar v0.0.3 -> v0.0.4
 [ADDING] spam v0.2.5
 ",
@@ -674,7 +674,7 @@ fn update_lockfile() {
     p.cargo("update -p bar")
         .with_stderr(
             "\
-[UPDATING] registry `[..]`
+[UPDATING] `[..]` index
 [UPDATING] bar v0.0.4 -> v0.0.5
 [REMOVING] spam v0.2.5
 ",
@@ -727,7 +727,7 @@ fn dev_dependency_not_used() {
     p.cargo("build")
         .with_stderr(
             "\
-[UPDATING] registry `[..]`
+[UPDATING] `[..]` index
 [DOWNLOADING] [..] v0.0.1 (registry `file://[..]`)
 [COMPILING] bar v0.0.1
 [COMPILING] foo v0.0.1 (CWD)
@@ -811,7 +811,7 @@ fn updating_a_dep() {
     p.cargo("build")
         .with_stderr(
             "\
-[UPDATING] registry `[..]`
+[UPDATING] `[..]` index
 [DOWNLOADING] bar v0.0.1 (registry `file://[..]`)
 [COMPILING] bar v0.0.1
 [COMPILING] a v0.0.1 (CWD/a)
@@ -837,7 +837,7 @@ fn updating_a_dep() {
     p.cargo("build")
         .with_stderr(
             "\
-[UPDATING] registry `[..]`
+[UPDATING] `[..]` index
 [DOWNLOADING] bar v0.1.0 (registry `file://[..]`)
 [COMPILING] bar v0.1.0
 [COMPILING] a v0.0.1 (CWD/a)
@@ -995,7 +995,7 @@ fn fetch_downloads() {
     p.cargo("fetch")
         .with_stderr(
             "\
-[UPDATING] registry `[..]`
+[UPDATING] `[..]` index
 [DOWNLOADING] a v0.1.0 (registry [..])
 ",
         ).run();
@@ -1028,7 +1028,7 @@ fn update_transitive_dependency() {
     p.cargo("update -pb")
         .with_stderr(
             "\
-[UPDATING] registry `[..]`
+[UPDATING] `[..]` index
 [UPDATING] b v0.1.0 -> v0.1.1
 ",
         ).run();
@@ -1085,7 +1085,7 @@ fn update_backtracking_ok() {
     p.cargo("update -p hyper")
         .with_stderr(
             "\
-[UPDATING] registry `[..]`
+[UPDATING] `[..]` index
 [UPDATING] hyper v0.6.5 -> v0.6.6
 [UPDATING] openssl v0.1.0 -> v0.1.1
 ",
@@ -1124,7 +1124,7 @@ fn update_multiple_packages() {
     p.cargo("update -pa -pb")
         .with_stderr(
             "\
-[UPDATING] registry `[..]`
+[UPDATING] `[..]` index
 [UPDATING] a v0.1.0 -> v0.1.1
 [UPDATING] b v0.1.0 -> v0.1.1
 ",
@@ -1133,7 +1133,7 @@ fn update_multiple_packages() {
     p.cargo("update -pb -pc")
         .with_stderr(
             "\
-[UPDATING] registry `[..]`
+[UPDATING] `[..]` index
 [UPDATING] c v0.1.0 -> v0.1.1
 ",
         ).run();
@@ -1265,7 +1265,7 @@ fn only_download_relevant() {
     p.cargo("build")
         .with_stderr(
             "\
-[UPDATING] registry `[..]`
+[UPDATING] `[..]` index
 [DOWNLOADING] baz v0.1.0 ([..])
 [COMPILING] baz v0.1.0
 [COMPILING] bar v0.5.0 ([..])

--- a/tests/testsuite/rename_deps.rs
+++ b/tests/testsuite/rename_deps.rs
@@ -247,7 +247,7 @@ fn rename_twice() {
         .with_status(101)
         .with_stderr(
             "\
-[UPDATING] registry `[..]`
+[UPDATING] `[..]` index
 [DOWNLOADING] foo v0.1.0 (registry [..])
 error: multiple dependencies listed for the same crate must all have the same \
 name, but the dependency on `foo v0.1.0` is listed as having different names

--- a/tests/testsuite/search.rs
+++ b/tests/testsuite/search.rs
@@ -111,7 +111,7 @@ fn not_update() {
             .with_stdout_contains(
                 "hoare = \"0.1.1\"    # Design by contract style assertions for Rust",
             )
-            .with_stderr("") // without "Updating registry ..."
+            .with_stderr("") // without "Updating ... index"
     .run();
 }
 
@@ -122,7 +122,7 @@ fn replace_default() {
 
     cargo_process("search postgres")
         .with_stdout_contains("hoare = \"0.1.1\"    # Design by contract style assertions for Rust")
-        .with_stderr_contains("[..]Updating registry[..]")
+        .with_stderr_contains("[..]Updating [..] index")
         .run();
 }
 

--- a/tests/testsuite/search.rs
+++ b/tests/testsuite/search.rs
@@ -154,7 +154,7 @@ wants the location of the index. Please use '--index' instead.
 This will soon become a hard error, so it's either recommended
 to update to a fixed version or contact the upstream maintainer
 about this warning.
-[UPDATING] registry `CWD/registry`
+[UPDATING] `CWD/registry` index
 ",
             )
             .with_stdout_contains(
@@ -181,7 +181,7 @@ wants the location of the index. Please use '--index' instead.
 This will soon become a hard error, so it's either recommended
 to update to a fixed version or contact the upstream maintainer
 about this warning.
-[UPDATING] registry `CWD/registry`
+[UPDATING] `CWD/registry` index
 ",
             )
             .with_stdout_contains(

--- a/tests/testsuite/update.rs
+++ b/tests/testsuite/update.rs
@@ -106,7 +106,7 @@ fn transitive_minor_update() {
     p.cargo("update -p serde")
         .with_stderr(
             "\
-[UPDATING] registry `[..]`
+[UPDATING] `[..]` index
 ",
         ).run();
 }
@@ -153,7 +153,7 @@ fn conservative() {
     p.cargo("update -p serde")
         .with_stderr(
             "\
-[UPDATING] registry `[..]`
+[UPDATING] `[..]` index
 [UPDATING] serde v0.1.0 -> v0.1.1
 ",
         ).run();
@@ -369,7 +369,7 @@ fn update_precise() {
     p.cargo("update -p serde:0.2.1 --precise 0.2.0")
         .with_stderr(
             "\
-[UPDATING] registry `[..]`
+[UPDATING] `[..]` index
 [UPDATING] serde v0.2.1 -> v0.2.0
 ",
         ).run();

--- a/tests/testsuite/warn_on_failure.rs
+++ b/tests/testsuite/warn_on_failure.rs
@@ -58,7 +58,7 @@ fn no_warning_on_success() {
         .cargo("build")
         .with_stderr(
             "\
-[UPDATING] registry `[..]`
+[UPDATING] `[..]` index
 [DOWNLOADING] bar v0.0.1 ([..])
 [COMPILING] bar v0.0.1
 [COMPILING] foo v0.0.1 ([..])
@@ -78,7 +78,7 @@ fn no_warning_on_bin_failure() {
         .with_stderr_does_not_contain("hidden stderr")
         .with_stderr_does_not_contain(&format!("[WARNING] {}", WARNING1))
         .with_stderr_does_not_contain(&format!("[WARNING] {}", WARNING2))
-        .with_stderr_contains("[UPDATING] registry `[..]`")
+        .with_stderr_contains("[UPDATING] `[..]` index")
         .with_stderr_contains("[DOWNLOADING] bar v0.0.1 ([..])")
         .with_stderr_contains("[COMPILING] bar v0.0.1")
         .with_stderr_contains("[COMPILING] foo v0.0.1 ([..])")
@@ -95,7 +95,7 @@ fn warning_on_lib_failure() {
         .with_stdout_does_not_contain("hidden stdout")
         .with_stderr_does_not_contain("hidden stderr")
         .with_stderr_does_not_contain("[COMPILING] foo v0.0.1 ([..])")
-        .with_stderr_contains("[UPDATING] registry `[..]`")
+        .with_stderr_contains("[UPDATING] `[..]` index")
         .with_stderr_contains("[DOWNLOADING] bar v0.0.1 ([..])")
         .with_stderr_contains("[COMPILING] bar v0.0.1")
         .with_stderr_contains(&format!("[WARNING] {}", WARNING1))

--- a/tests/testsuite/workspaces.rs
+++ b/tests/testsuite/workspaces.rs
@@ -556,7 +556,7 @@ fn share_dependencies() {
     p.cargo("build")
         .with_stderr(
             "\
-[UPDATING] registry `[..]`
+[UPDATING] `[..]` index
 [DOWNLOADING] dep1 v0.1.3 ([..])
 [COMPILING] dep1 v0.1.3
 [COMPILING] foo v0.1.0 ([..])
@@ -599,7 +599,7 @@ fn fetch_fetches_all() {
     p.cargo("fetch")
         .with_stderr(
             "\
-[UPDATING] registry `[..]`
+[UPDATING] `[..]` index
 [DOWNLOADING] dep1 v0.1.3 ([..])
 ",
         ).run();
@@ -641,7 +641,7 @@ fn lock_works_for_everyone() {
     Package::new("dep2", "0.1.0").publish();
 
     p.cargo("generate-lockfile")
-        .with_stderr("[UPDATING] registry `[..]`")
+        .with_stderr("[UPDATING] `[..]` index")
         .run();
 
     Package::new("dep1", "0.1.1").publish();


### PR DESCRIPTION
Following the lead from PackageId's Display, only display the registry's
URL if it's not the default registry (aka crates.io).

Before:

    $ cargo install lazy_static
        Updating registry `https://github.com/rust-lang/crates.io-index`

After:

    $ dcargo install lazy_static
        Updating crates.io index

Fixes #4208