### PR TITLE
Add empty ctrlc handler on Windows.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ rustc-workspace-hack = "1.0.0"
 core-foundation = { version = "0.6.0", features = ["mac_os_10_7_support"] }
 
 [target.'cfg(windows)'.dependencies]
+ctrlc = "3.1.1"
 miow = "0.3.1"
 fwdansi = "1"
 

--- a/src/cargo/lib.rs
+++ b/src/cargo/lib.rs
@@ -20,6 +20,8 @@ extern crate clap;
 extern crate core_foundation;
 extern crate crates_io as registry;
 extern crate crossbeam_utils;
+#[cfg(windows)]
+extern crate ctrlc;
 extern crate curl;
 #[macro_use]
 extern crate failure;

--- a/src/cargo/util/process_builder.rs
+++ b/src/cargo/util/process_builder.rs
@@ -170,9 +170,11 @@ impl ProcessBuilder {
 
     /// On unix, executes the process using the unix syscall `execvp`, which will block this
     /// process, and will only return if there is an error. On windows this is a synonym for
-    /// `exec`.
+    /// `exec`, except we install a ctrlc handler first to prevent us from eating
+    /// the signal the subprocess may care about.
     #[cfg(windows)]
     pub fn exec_replace(&self) -> CargoResult<()> {
+        ::ctrlc::set_handler(move || {} )?;
         self.exec()
     }
 


### PR DESCRIPTION
Fixes #6000.

When exec_replacing the cargo process, we want the new process to get any signals. This already works fine on Unix.

On Windows, pressing ctrlc kills the cargo process and doesn't pass the signal on to the child process. By adding an empty handler, we allow the child process to handle the signal instead.