### PR TITLE
Download crates in parallel with HTTP/2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ path = "src/cargo/lib.rs"
 
 [dependencies]
 atty = "0.2"
+bytesize = "1.0"
 crates-io = { path = "src/crates-io", version = "0.20" }
 crossbeam-utils = "0.5"
 crypto-hash = "0.3.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ bytesize = "1.0"
 crates-io = { path = "src/crates-io", version = "0.20" }
 crossbeam-utils = "0.5"
 crypto-hash = "0.3.1"
-curl = { version = "0.4.15", features = ['http2'] }
+curl = { version = "0.4.17", features = ['http2'] }
 env_logger = "0.5.11"
 failure = "0.1.2"
 filetime = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ atty = "0.2"
 crates-io = { path = "src/crates-io", version = "0.20" }
 crossbeam-utils = "0.5"
 crypto-hash = "0.3.1"
-curl = "0.4.13"
+curl = { version = "0.4.15", features = ['http2'] }
 env_logger = "0.5.11"
 failure = "0.1.2"
 filetime = "0.2"

--- a/src/cargo/core/compiler/build_context/mod.rs
+++ b/src/cargo/core/compiler/build_context/mod.rs
@@ -5,7 +5,7 @@ use std::str;
 
 use core::profiles::Profiles;
 use core::{Dependency, Workspace};
-use core::{Package, PackageId, PackageSet, Resolve};
+use core::{PackageId, PackageSet, Resolve};
 use util::errors::CargoResult;
 use util::{profile, Cfg, CfgExpr, Config, Rustc};
 
@@ -107,11 +107,6 @@ impl<'a, 'cfg> BuildContext<'a, 'cfg> {
         platform.matches(name, info.cfg())
     }
 
-    /// Gets a package for the given package id.
-    pub fn get_package(&self, id: &PackageId) -> CargoResult<&'a Package> {
-        self.packages.get_one(id)
-    }
-
     /// Get the user-specified linker for a particular host or target
     pub fn linker(&self, kind: Kind) -> Option<&Path> {
         self.target_config(kind).linker.as_ref().map(|s| s.as_ref())
@@ -197,18 +192,6 @@ impl<'a, 'cfg> BuildContext<'a, 'cfg> {
 
     pub fn extra_args_for(&self, unit: &Unit<'a>) -> Option<&Vec<String>> {
         self.extra_compiler_args.get(unit)
-    }
-
-    /// Return the list of filenames read by cargo to generate the BuildContext
-    /// (all Cargo.toml, etc).
-    pub fn inputs(&self) -> CargoResult<Vec<PathBuf>> {
-        let mut inputs = Vec::new();
-        for id in self.packages.package_ids() {
-            let pkg = self.get_package(id)?;
-            inputs.push(pkg.manifest_path().to_path_buf());
-        }
-        inputs.sort();
-        Ok(inputs)
     }
 }
 

--- a/src/cargo/core/compiler/build_context/mod.rs
+++ b/src/cargo/core/compiler/build_context/mod.rs
@@ -109,7 +109,7 @@ impl<'a, 'cfg> BuildContext<'a, 'cfg> {
 
     /// Gets a package for the given package id.
     pub fn get_package(&self, id: &PackageId) -> CargoResult<&'a Package> {
-        self.packages.get(id)
+        self.packages.get_one(id)
     }
 
     /// Get the user-specified linker for a particular host or target

--- a/src/cargo/core/compiler/context/unit_dependencies.rs
+++ b/src/cargo/core/compiler/context/unit_dependencies.rs
@@ -509,11 +509,11 @@ impl<'a, 'cfg, 'tmp> State<'a, 'cfg, 'tmp> {
     /// Completes at least one downloading, maybe waiting for more to complete.
     ///
     /// This function will block the current thread waiting for at least one
-    /// create to finish downloading. The function may continue to download more
+    /// crate to finish downloading. The function may continue to download more
     /// crates if it looks like there's a long enough queue of crates to keep
     /// downloading. When only a handful of packages remain this function
     /// returns, and it's hoped that by returning we'll be able to push more
-    /// packages to download into the queu.
+    /// packages to download into the queue.
     fn finish_some_downloads(&mut self) -> CargoResult<()> {
         assert!(self.downloads.remaining() > 0);
         loop {

--- a/src/cargo/core/compiler/context/unit_dependencies.rs
+++ b/src/cargo/core/compiler/context/unit_dependencies.rs
@@ -15,46 +15,72 @@
 //! (for example, with and without tests), so we actually build a dependency
 //! graph of `Unit`s, which capture these properties.
 
+use std::cell::{RefCell, Cell};
 use std::collections::{HashMap, HashSet};
 
 use CargoResult;
 use core::dependency::Kind as DepKind;
 use core::profiles::ProfileFor;
-use core::{Package, Target};
+use core::{Package, Target, PackageId};
 use super::{BuildContext, CompileMode, Kind, Unit};
+
+struct State<'a: 'tmp, 'cfg: 'a, 'tmp> {
+    bcx: &'tmp BuildContext<'a, 'cfg>,
+    deps: &'tmp mut HashMap<Unit<'a>, Vec<Unit<'a>>>,
+    pkgs: RefCell<&'tmp mut HashMap<&'a PackageId, &'a Package>>,
+    waiting_on_downloads: Cell<bool>,
+}
 
 pub fn build_unit_dependencies<'a, 'cfg>(
     roots: &[Unit<'a>],
     bcx: &BuildContext<'a, 'cfg>,
     deps: &mut HashMap<Unit<'a>, Vec<Unit<'a>>>,
+    pkgs: &mut HashMap<&'a PackageId, &'a Package>,
 ) -> CargoResult<()> {
     assert!(deps.is_empty(), "can only build unit deps once");
 
-    for unit in roots.iter() {
-        // Dependencies of tests/benches should not have `panic` set.
-        // We check the global test mode to see if we are running in `cargo
-        // test` in which case we ensure all dependencies have `panic`
-        // cleared, and avoid building the lib thrice (once with `panic`, once
-        // without, once for --test).  In particular, the lib included for
-        // doctests and examples are `Build` mode here.
-        let profile_for = if unit.mode.is_any_test() || bcx.build_config.test() {
-            ProfileFor::TestDependency
-        } else {
-            ProfileFor::Any
-        };
-        deps_of(unit, bcx, deps, profile_for)?;
-    }
-    trace!("ALL UNIT DEPENDENCIES {:#?}", deps);
+    let mut state = State {
+        bcx,
+        deps,
+        pkgs: RefCell::new(pkgs),
+        waiting_on_downloads: Cell::new(false),
+    };
 
-    connect_run_custom_build_deps(bcx, deps);
+    loop {
+        for unit in roots.iter() {
+            state.get(unit.pkg.package_id())?;
+
+            // Dependencies of tests/benches should not have `panic` set.
+            // We check the global test mode to see if we are running in `cargo
+            // test` in which case we ensure all dependencies have `panic`
+            // cleared, and avoid building the lib thrice (once with `panic`, once
+            // without, once for --test).  In particular, the lib included for
+            // doctests and examples are `Build` mode here.
+            let profile_for = if unit.mode.is_any_test() || bcx.build_config.test() {
+                ProfileFor::TestDependency
+            } else {
+                ProfileFor::Any
+            };
+            deps_of(unit, &mut state, profile_for)?;
+        }
+
+        if state.waiting_on_downloads.replace(false) {
+            state.finish_some_downloads()?;
+            state.deps.clear();
+        } else {
+            break
+        }
+    }
+    trace!("ALL UNIT DEPENDENCIES {:#?}", state.deps);
+
+    connect_run_custom_build_deps(&mut state);
 
     Ok(())
 }
 
-fn deps_of<'a, 'cfg>(
+fn deps_of<'a, 'cfg, 'tmp>(
     unit: &Unit<'a>,
-    bcx: &BuildContext<'a, 'cfg>,
-    deps: &mut HashMap<Unit<'a>, Vec<Unit<'a>>>,
+    state: &mut State<'a, 'cfg, 'tmp>,
     profile_for: ProfileFor,
 ) -> CargoResult<()> {
     // Currently the `deps` map does not include `profile_for`.  This should
@@ -63,12 +89,12 @@ fn deps_of<'a, 'cfg>(
     // `TestDependency`.  `CustomBuild` should also be fine since if the
     // requested unit's settings are the same as `Any`, `CustomBuild` can't
     // affect anything else in the hierarchy.
-    if !deps.contains_key(unit) {
-        let unit_deps = compute_deps(unit, bcx, profile_for)?;
+    if !state.deps.contains_key(unit) {
+        let unit_deps = compute_deps(unit, state, profile_for)?;
         let to_insert: Vec<_> = unit_deps.iter().map(|&(unit, _)| unit).collect();
-        deps.insert(*unit, to_insert);
+        state.deps.insert(*unit, to_insert);
         for (unit, profile_for) in unit_deps {
-            deps_of(&unit, bcx, deps, profile_for)?;
+            deps_of(&unit, state, profile_for)?;
         }
     }
     Ok(())
@@ -78,63 +104,82 @@ fn deps_of<'a, 'cfg>(
 /// for that package.
 /// This returns a vec of `(Unit, ProfileFor)` pairs.  The `ProfileFor`
 /// is the profile type that should be used for dependencies of the unit.
-fn compute_deps<'a, 'cfg>(
+fn compute_deps<'a, 'cfg, 'tmp>(
     unit: &Unit<'a>,
-    bcx: &BuildContext<'a, 'cfg>,
+    state: &mut State<'a, 'cfg, 'tmp>,
     profile_for: ProfileFor,
 ) -> CargoResult<Vec<(Unit<'a>, ProfileFor)>> {
     if unit.mode.is_run_custom_build() {
-        return compute_deps_custom_build(unit, bcx);
+        return compute_deps_custom_build(unit, state.bcx);
     } else if unit.mode.is_doc() && !unit.mode.is_any_test() {
         // Note: This does not include Doctest.
-        return compute_deps_doc(unit, bcx);
+        return compute_deps_doc(unit, state);
     }
 
+    let bcx = state.bcx;
     let id = unit.pkg.package_id();
-    let deps = bcx.resolve.deps(id);
-    let mut ret = deps.filter(|&(_id, deps)| {
-        assert!(!deps.is_empty());
-        deps.iter().any(|dep| {
-            // If this target is a build command, then we only want build
-            // dependencies, otherwise we want everything *other than* build
-            // dependencies.
-            if unit.target.is_custom_build() != dep.is_build() {
-                return false;
-            }
+    let deps = bcx.resolve.deps(id)
+        .filter(|&(_id, deps)| {
+            assert!(!deps.is_empty());
+            deps.iter().any(|dep| {
+                // If this target is a build command, then we only want build
+                // dependencies, otherwise we want everything *other than* build
+                // dependencies.
+                if unit.target.is_custom_build() != dep.is_build() {
+                    return false;
+                }
 
-            // If this dependency is *not* a transitive dependency, then it
-            // only applies to test/example targets
-            if !dep.is_transitive() && !unit.target.is_test() && !unit.target.is_example()
-                && !unit.mode.is_any_test()
-            {
-                return false;
-            }
+                // If this dependency is *not* a transitive dependency, then it
+                // only applies to test/example targets
+                if !dep.is_transitive() &&
+                    !unit.target.is_test() &&
+                    !unit.target.is_example() &&
+                    !unit.mode.is_any_test()
+                {
+                    return false;
+                }
 
-            // If this dependency is only available for certain platforms,
-            // make sure we're only enabling it for that platform.
-            if !bcx.dep_platform_activated(dep, unit.kind) {
-                return false;
-            }
+                // If this dependency is only available for certain platforms,
+                // make sure we're only enabling it for that platform.
+                if !bcx.dep_platform_activated(dep, unit.kind) {
+                    return false;
+                }
 
-            // If the dependency is optional, then we're only activating it
-            // if the corresponding feature was activated
-            if dep.is_optional() && !bcx.resolve.features(id).contains(&*dep.name_in_toml()) {
-                return false;
-            }
+                // If the dependency is optional, then we're only activating it
+                // if the corresponding feature was activated
+                if dep.is_optional() &&
+                    !bcx.resolve.features(id).contains(&*dep.name_in_toml())
+                {
+                    return false;
+                }
 
-            // If we've gotten past all that, then this dependency is
-            // actually used!
-            true
-        })
-    }).filter_map(|(id, _)| match bcx.get_package(id) {
-            Ok(pkg) => pkg.targets().iter().find(|t| t.is_lib()).map(|t| {
-                let mode = check_or_build_mode(unit.mode, t);
-                let unit = new_unit(bcx, pkg, t, profile_for, unit.kind.for_target(t), mode);
-                Ok((unit, profile_for))
-            }),
-            Err(e) => Some(Err(e)),
-        })
-        .collect::<CargoResult<Vec<_>>>()?;
+                // If we've gotten past all that, then this dependency is
+                // actually used!
+                true
+            })
+        });
+
+    let mut ret = Vec::new();
+    for (id, _) in deps {
+        let pkg = match state.get(id)? {
+            Some(pkg) => pkg,
+            None => continue,
+        };
+        let lib = match pkg.targets().iter().find(|t| t.is_lib()) {
+            Some(t) => t,
+            None => continue,
+        };
+        let mode = check_or_build_mode(unit.mode, lib);
+        let unit = new_unit(
+            bcx,
+            pkg,
+            lib,
+            profile_for,
+            unit.kind.for_target(lib),
+            mode,
+        );
+        ret.push((unit, profile_for));
+    }
 
     // If this target is a build script, then what we've collected so far is
     // all we need. If this isn't a build script, then it depends on the
@@ -221,10 +266,11 @@ fn compute_deps_custom_build<'a, 'cfg>(
 }
 
 /// Returns the dependencies necessary to document a package
-fn compute_deps_doc<'a, 'cfg>(
+fn compute_deps_doc<'a, 'cfg, 'tmp>(
     unit: &Unit<'a>,
-    bcx: &BuildContext<'a, 'cfg>,
+    state: &mut State<'a, 'cfg, 'tmp>,
 ) -> CargoResult<Vec<(Unit<'a>, ProfileFor)>> {
+    let bcx = state.bcx;
     let deps = bcx.resolve
         .deps(unit.pkg.package_id())
         .filter(|&(_id, deps)| {
@@ -232,15 +278,17 @@ fn compute_deps_doc<'a, 'cfg>(
                 DepKind::Normal => bcx.dep_platform_activated(dep, unit.kind),
                 _ => false,
             })
-        })
-        .map(|(id, _deps)| bcx.get_package(id));
+        });
 
     // To document a library, we depend on dependencies actually being
     // built. If we're documenting *all* libraries, then we also depend on
     // the documentation of the library being built.
     let mut ret = Vec::new();
-    for dep in deps {
-        let dep = dep?;
+    for (id, _deps) in deps {
+        let dep = match state.get(id)? {
+            Some(dep) => dep,
+            None => continue,
+        };
         let lib = match dep.targets().iter().find(|t| t.is_lib()) {
             Some(lib) => lib,
             None => continue,
@@ -288,7 +336,14 @@ fn maybe_lib<'a>(
 ) -> Option<(Unit<'a>, ProfileFor)> {
     unit.pkg.targets().iter().find(|t| t.linkable()).map(|t| {
         let mode = check_or_build_mode(unit.mode, t);
-        let unit = new_unit(bcx, unit.pkg, t, profile_for, unit.kind.for_target(t), mode);
+        let unit = new_unit(
+            bcx,
+            unit.pkg,
+            t,
+            profile_for,
+            unit.kind.for_target(t),
+            mode,
+        );
         (unit, profile_for)
     })
 }
@@ -373,10 +428,7 @@ fn new_unit<'a>(
 ///
 /// Here we take the entire `deps` map and add more dependencies from execution
 /// of one build script to execution of another build script.
-fn connect_run_custom_build_deps<'a>(
-    bcx: &BuildContext,
-    deps: &mut HashMap<Unit<'a>, Vec<Unit<'a>>>,
-) {
+fn connect_run_custom_build_deps(state: &mut State) {
     let mut new_deps = Vec::new();
 
     {
@@ -386,7 +438,7 @@ fn connect_run_custom_build_deps<'a>(
         // have the build script as the key and the library would be in the
         // value's set.
         let mut reverse_deps = HashMap::new();
-        for (unit, deps) in deps.iter() {
+        for (unit, deps) in state.deps.iter() {
             for dep in deps {
                 if dep.mode == CompileMode::RunCustomBuild {
                     reverse_deps.entry(dep)
@@ -405,7 +457,7 @@ fn connect_run_custom_build_deps<'a>(
         // `links`, then we depend on that package's build script! Here we use
         // `dep_build_script` to manufacture an appropriate build script unit to
         // depend on.
-        for unit in deps.keys().filter(|k| k.mode == CompileMode::RunCustomBuild) {
+        for unit in state.deps.keys().filter(|k| k.mode == CompileMode::RunCustomBuild) {
             let reverse_deps = match reverse_deps.get(unit) {
                 Some(set) => set,
                 None => continue,
@@ -413,13 +465,13 @@ fn connect_run_custom_build_deps<'a>(
 
             let to_add = reverse_deps
                 .iter()
-                .flat_map(|reverse_dep| deps[reverse_dep].iter())
+                .flat_map(|reverse_dep| state.deps[reverse_dep].iter())
                 .filter(|other| {
                     other.pkg != unit.pkg &&
                         other.target.linkable() &&
                         other.pkg.manifest().links().is_some()
                 })
-                .filter_map(|other| dep_build_script(other, bcx).map(|p| p.0))
+                .filter_map(|other| dep_build_script(other, state.bcx).map(|p| p.0))
                 .collect::<HashSet<_>>();
 
             if !to_add.is_empty() {
@@ -430,6 +482,46 @@ fn connect_run_custom_build_deps<'a>(
 
     // And finally, add in all the missing dependencies!
     for (unit, new_deps) in new_deps {
-        deps.get_mut(&unit).unwrap().extend(new_deps);
+        state.deps.get_mut(&unit).unwrap().extend(new_deps);
+    }
+}
+
+impl<'a, 'cfg, 'tmp> State<'a, 'cfg, 'tmp> {
+    fn get(&mut self, id: &'a PackageId) -> CargoResult<Option<&'a Package>> {
+        let mut pkgs = self.pkgs.borrow_mut();
+        if let Some(pkg) = pkgs.get(id) {
+            return Ok(Some(pkg))
+        }
+        if let Some(pkg) = self.bcx.packages.start_download(id)? {
+            pkgs.insert(id, pkg);
+            return Ok(Some(pkg))
+        }
+        self.waiting_on_downloads.set(true);
+        Ok(None)
+    }
+
+    /// Completes at least one downloading, maybe waiting for more to complete.
+    ///
+    /// This function will block the current thread waiting for at least one
+    /// create to finish downloading. The function may continue to download more
+    /// crates if it looks like there's a long enough queue of crates to keep
+    /// downloading. When only a handful of packages remain this function
+    /// returns, and it's hoped that by returning we'll be able to push more
+    /// packages to download into the queu.
+    fn finish_some_downloads(&mut self) -> CargoResult<()> {
+        assert!(self.bcx.packages.remaining_downloads() > 0);
+        loop {
+            let pkg = self.bcx.packages.wait_for_download()?;
+            self.pkgs.borrow_mut().insert(pkg.package_id(), pkg);
+
+            // Arbitrarily choose that 5 or more packages concurrently download
+            // is a good enough number to "fill the network pipe". If we have
+            // less than this let's recompute the whole unit dependency graph
+            // again and try to find some more packages to download.
+            if self.bcx.packages.remaining_downloads() < 5 {
+                break
+            }
+        }
+        Ok(())
     }
 }

--- a/src/cargo/core/compiler/job_queue.rs
+++ b/src/cargo/core/compiler/job_queue.rs
@@ -535,7 +535,7 @@ impl<'a> Key<'a> {
 
     fn dependencies<'cfg>(&self, cx: &Context<'a, 'cfg>) -> CargoResult<Vec<Key<'a>>> {
         let unit = Unit {
-            pkg: cx.bcx.get_package(self.pkg)?,
+            pkg: cx.get_package(self.pkg)?,
             target: self.target,
             profile: self.profile,
             kind: self.kind,

--- a/src/cargo/core/compiler/job_queue.rs
+++ b/src/cargo/core/compiler/job_queue.rs
@@ -14,6 +14,7 @@ use jobserver::{Acquired, HelperThread};
 use core::profiles::Profile;
 use core::{PackageId, Target, TargetKind};
 use handle_error;
+use util;
 use util::{internal, profile, CargoResult, CargoResultExt, ProcessBuilder};
 use util::{Config, DependencyQueue, Dirty, Fresh, Freshness};
 use util::{Progress, ProgressStyle};
@@ -368,16 +369,7 @@ impl<'a> JobQueue<'a> {
             opt_type += " + debuginfo";
         }
 
-        let time_elapsed = {
-            let duration = cx.bcx.config.creation_time().elapsed();
-            let secs = duration.as_secs();
-
-            if secs >= 60 {
-                format!("{}m {:02}s", secs / 60, secs % 60)
-            } else {
-                format!("{}.{:02}s", secs, duration.subsec_nanos() / 10_000_000)
-            }
-        };
+        let time_elapsed = util::elapsed(cx.bcx.config.creation_time().elapsed());
 
         if self.queue.is_empty() {
             let message = format!(

--- a/src/cargo/core/package.rs
+++ b/src/cargo/core/package.rs
@@ -287,7 +287,7 @@ impl<'cfg> PackageSet<'cfg> {
         // We've enabled the `http2` feature of `curl` in Cargo, so treat
         // failures here as fatal as it would indicate a build-time problem.
         let mut multi = Multi::new();
-        multi.pipelining(true, true)
+        multi.pipelining(false, true)
             .chain_err(|| "failed to enable multiplexing/pipelining in curl")?;
 
         Ok(PackageSet {

--- a/src/cargo/core/package.rs
+++ b/src/cargo/core/package.rs
@@ -585,9 +585,11 @@ impl<'a, 'cfg> Downloads<'a, 'cfg> {
             })?;
             debug!("handles remaining: {}", n);
             let results = &mut self.results;
+            let pending = &self.pending;
             self.set.multi.messages(|msg| {
                 let token = msg.token().expect("failed to read token");
-                if let Some(result) = msg.result() {
+                let handle = &pending[&token].1;
+                if let Some(result) = msg.result_for(&handle) {
                     results.push((token, result.map_err(|e| e.into())));
                 } else {
                     debug!("message without a result (?)");

--- a/src/cargo/core/package.rs
+++ b/src/cargo/core/package.rs
@@ -627,7 +627,12 @@ impl<'a, 'cfg> Downloads<'a, 'cfg> {
                 let mut remaining = 0;
                 for (dl, _) in self.pending.values() {
                     dur += dl.start.elapsed();
-                    remaining += dl.total.get() - dl.current.get();
+                    // If the total/current look weird just throw out the data
+                    // point, sounds like curl has more to learn before we have
+                    // the true information.
+                    if dl.total.get() >= dl.current.get() {
+                        remaining += dl.total.get() - dl.current.get();
+                    }
                 }
                 if remaining > 0 && dur > Duration::from_millis(500) {
                     msg.push_str(&format!(", remaining bytes: {}", ByteSize(remaining)));

--- a/src/cargo/core/registry.rs
+++ b/src/cargo/core/registry.rs
@@ -37,6 +37,7 @@ pub trait Registry {
 /// a `Source`. Each `Source` in the map has been updated (using network
 /// operations if necessary) and is ready to be queried for packages.
 pub struct PackageRegistry<'cfg> {
+    config: &'cfg Config,
     sources: SourceMap<'cfg>,
 
     // A list of sources which are considered "overrides" which take precedent
@@ -81,6 +82,7 @@ impl<'cfg> PackageRegistry<'cfg> {
     pub fn new(config: &'cfg Config) -> CargoResult<PackageRegistry<'cfg>> {
         let source_config = SourceConfigMap::new(config)?;
         Ok(PackageRegistry {
+            config,
             sources: SourceMap::new(),
             source_ids: HashMap::new(),
             overrides: Vec::new(),
@@ -94,7 +96,7 @@ impl<'cfg> PackageRegistry<'cfg> {
 
     pub fn get(self, package_ids: &[PackageId]) -> PackageSet<'cfg> {
         trace!("getting packages; sources={}", self.sources.len());
-        PackageSet::new(package_ids, self.sources)
+        PackageSet::new(package_ids, self.sources, self.config)
     }
 
     fn ensure_loaded(&mut self, namespace: &SourceId, kind: Kind) -> CargoResult<()> {

--- a/src/cargo/core/registry.rs
+++ b/src/cargo/core/registry.rs
@@ -94,7 +94,7 @@ impl<'cfg> PackageRegistry<'cfg> {
         })
     }
 
-    pub fn get(self, package_ids: &[PackageId]) -> PackageSet<'cfg> {
+    pub fn get(self, package_ids: &[PackageId]) -> CargoResult<PackageSet<'cfg>> {
         trace!("getting packages; sources={}", self.sources.len());
         PackageSet::new(package_ids, self.sources, self.config)
     }

--- a/src/cargo/lib.rs
+++ b/src/cargo/lib.rs
@@ -15,6 +15,7 @@
 #![cfg_attr(feature = "cargo-clippy", allow(wrong_self_convention))]   // perhaps Rc should be special cased in Clippy?
 
 extern crate atty;
+extern crate bytesize;
 extern crate clap;
 #[cfg(target_os = "macos")]
 extern crate core_foundation;

--- a/src/cargo/ops/cargo_clean.rs
+++ b/src/cargo/ops/cargo_clean.rs
@@ -52,7 +52,7 @@ pub fn clean(ws: &Workspace, opts: &CleanOptions) -> CargoResult<()> {
     for spec in opts.spec.iter() {
         // Translate the spec to a Package
         let pkgid = resolve.query(spec)?;
-        let pkg = packages.get(pkgid)?;
+        let pkg = packages.get_one(pkgid)?;
 
         // Generate all relevant `Unit` targets for this package
         for target in pkg.targets() {

--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -243,15 +243,22 @@ pub fn compile_ws<'a>(
     let resolve = ops::resolve_ws_with_method(ws, source, method, &specs)?;
     let (packages, resolve_with_overrides) = resolve;
 
-    let to_builds = specs
-        .iter()
-        .map(|p| {
-            let pkgid = p.query(resolve_with_overrides.iter())?;
-            let p = packages.get(pkgid)?;
-            p.manifest().print_teapot(ws.config());
-            Ok(p)
-        })
-        .collect::<CargoResult<Vec<_>>>()?;
+    let mut to_builds = Vec::new();
+    for spec in specs.iter() {
+        let pkgid = spec.query(resolve_with_overrides.iter())?;
+        to_builds.extend(packages.start_download(pkgid)?);
+    }
+    while packages.remaining_downloads() > 0 {
+        to_builds.push(packages.wait_for_download()?);
+    }
+    // The ordering here affects some error messages coming out of cargo, so
+    // let's be test and CLI friendly by always printing in the same order if
+    // there's an error.
+    to_builds.sort_by_key(|p| p.package_id());
+
+    for pkg in to_builds.iter() {
+        pkg.manifest().print_teapot(ws.config());
+    }
 
     let (extra_args, extra_args_name) = match (target_rustc_args, target_rustdoc_args) {
         (&Some(ref args), _) => (Some(args.clone()), "rustc"),

--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -244,13 +244,16 @@ pub fn compile_ws<'a>(
     let (packages, resolve_with_overrides) = resolve;
 
     let mut to_builds = Vec::new();
+    let mut downloads = packages.enable_download()?;
     for spec in specs.iter() {
         let pkgid = spec.query(resolve_with_overrides.iter())?;
-        to_builds.extend(packages.start_download(pkgid)?);
+        to_builds.extend(downloads.start(pkgid)?);
     }
-    while packages.remaining_downloads() > 0 {
-        to_builds.push(packages.wait_for_download()?);
+    while downloads.remaining() > 0 {
+        to_builds.push(downloads.wait()?);
     }
+    drop(downloads);
+
     // The ordering here affects some error messages coming out of cargo, so
     // let's be test and CLI friendly by always printing in the same order if
     // there's an error.

--- a/src/cargo/ops/cargo_doc.rs
+++ b/src/cargo/ops/cargo_doc.rs
@@ -32,13 +32,15 @@ pub fn doc(ws: &Workspace, options: &DocOptions) -> CargoResult<()> {
     let (packages, resolve_with_overrides) = resolve;
 
     let mut pkgs = Vec::new();
+    let mut downloads = packages.enable_download()?;
     for spec in specs.iter() {
         let pkgid = spec.query(resolve_with_overrides.iter())?;
-        pkgs.extend(packages.start_download(pkgid)?);
+        pkgs.extend(downloads.start(pkgid)?);
     }
-    while packages.remaining_downloads() > 0 {
-        pkgs.push(packages.wait_for_download()?);
+    while downloads.remaining() > 0 {
+        pkgs.push(downloads.wait()?);
     }
+    drop(downloads);
 
     let mut lib_names = HashMap::new();
     let mut bin_names = HashMap::new();

--- a/src/cargo/ops/cargo_doc.rs
+++ b/src/cargo/ops/cargo_doc.rs
@@ -31,16 +31,10 @@ pub fn doc(ws: &Workspace, options: &DocOptions) -> CargoResult<()> {
     )?;
     let (packages, resolve_with_overrides) = resolve;
 
-    let mut pkgs = Vec::new();
-    let mut downloads = packages.enable_download()?;
-    for spec in specs.iter() {
-        let pkgid = spec.query(resolve_with_overrides.iter())?;
-        pkgs.extend(downloads.start(pkgid)?);
-    }
-    while downloads.remaining() > 0 {
-        pkgs.push(downloads.wait()?);
-    }
-    drop(downloads);
+    let ids = specs.iter()
+        .map(|s| s.query(resolve_with_overrides.iter()))
+        .collect::<CargoResult<Vec<_>>>()?;
+    let pkgs = packages.get_many(ids)?;
 
     let mut lib_names = HashMap::new();
     let mut bin_names = HashMap::new();

--- a/src/cargo/ops/cargo_fetch.rs
+++ b/src/cargo/ops/cargo_fetch.rs
@@ -33,7 +33,7 @@ pub fn fetch<'a>(
                 continue;
             }
 
-            packages.get(id)?;
+            packages.start_download(id)?;
             let deps = resolve.deps(id)
                 .filter(|&(_id, deps)| {
                     deps.iter()
@@ -57,6 +57,10 @@ pub fn fetch<'a>(
                 .map(|(id, _deps)| id);
             deps_to_fetch.extend(deps);
         }
+    }
+
+    while packages.remaining_downloads() > 0 {
+        packages.wait_for_download()?;
     }
 
     Ok((resolve, packages))

--- a/src/cargo/ops/cargo_install.rs
+++ b/src/cargo/ops/cargo_install.rs
@@ -518,7 +518,7 @@ where
             let pkg = {
                 let mut map = SourceMap::new();
                 map.insert(Box::new(&mut source));
-                PackageSet::new(&[pkgid.clone()], map, config)
+                PackageSet::new(&[pkgid.clone()], map, config)?
                     .get_one(&pkgid)?
                     .clone()
             };

--- a/src/cargo/ops/cargo_install.rs
+++ b/src/cargo/ops/cargo_install.rs
@@ -519,7 +519,7 @@ where
                 let mut map = SourceMap::new();
                 map.insert(Box::new(&mut source));
                 PackageSet::new(&[pkgid.clone()], map, config)
-                    .get(&pkgid)?
+                    .get_one(&pkgid)?
                     .clone()
             };
             Ok((pkg, Box::new(source)))

--- a/src/cargo/ops/cargo_output_metadata.rs
+++ b/src/cargo/ops/cargo_output_metadata.rs
@@ -57,17 +57,9 @@ fn metadata_full(ws: &Workspace, opt: &OutputMetadataOptions) -> CargoResult<Exp
         &specs,
     )?;
     let mut packages = HashMap::new();
-    let mut downloads = package_set.enable_download()?;
-    for id in package_set.package_ids() {
-        if let Some(pkg) = downloads.start(id)? {
-            packages.insert(id.clone(), pkg.clone());
-        }
-    }
-    while downloads.remaining() > 0 {
-        let pkg = downloads.wait()?;
+    for pkg in package_set.get_many(package_set.package_ids())? {
         packages.insert(pkg.package_id().clone(), pkg.clone());
     }
-    drop(downloads);
 
     Ok(ExportInfo {
         packages: packages.values().map(|p| (*p).clone()).collect(),

--- a/src/cargo/ops/cargo_output_metadata.rs
+++ b/src/cargo/ops/cargo_output_metadata.rs
@@ -1,7 +1,9 @@
+use std::collections::HashMap;
+
 use serde::ser;
 
 use core::resolver::Resolve;
-use core::{Package, PackageId, Workspace, PackageSet};
+use core::{Package, PackageId, Workspace};
 use ops::{self, Packages};
 use util::CargoResult;
 
@@ -18,7 +20,7 @@ pub struct OutputMetadataOptions {
 /// Loads the manifest, resolves the dependencies of the project to the concrete
 /// used versions - considering overrides - and writes all dependencies in a JSON
 /// format to stdout.
-pub fn output_metadata<'a>(ws: &'a Workspace, opt: &OutputMetadataOptions) -> CargoResult<ExportInfo<'a>> {
+pub fn output_metadata(ws: &Workspace, opt: &OutputMetadataOptions) -> CargoResult<ExportInfo> {
     if opt.version != VERSION {
         bail!(
             "metadata version {} not supported, only {} is currently supported",
@@ -33,7 +35,7 @@ pub fn output_metadata<'a>(ws: &'a Workspace, opt: &OutputMetadataOptions) -> Ca
     }
 }
 
-fn metadata_no_deps<'a>(ws: &'a Workspace, _opt: &OutputMetadataOptions) -> CargoResult<ExportInfo<'a>> {
+fn metadata_no_deps(ws: &Workspace, _opt: &OutputMetadataOptions) -> CargoResult<ExportInfo> {
     Ok(ExportInfo {
         packages: ws.members().cloned().collect(),
         workspace_members: ws.members().map(|pkg| pkg.package_id().clone()).collect(),
@@ -44,9 +46,9 @@ fn metadata_no_deps<'a>(ws: &'a Workspace, _opt: &OutputMetadataOptions) -> Carg
     })
 }
 
-fn metadata_full<'a>(ws: &'a Workspace, opt: &OutputMetadataOptions) -> CargoResult<ExportInfo<'a>> {
+fn metadata_full(ws: &Workspace, opt: &OutputMetadataOptions) -> CargoResult<ExportInfo> {
     let specs = Packages::All.to_package_id_specs(ws)?;
-    let deps = ops::resolve_ws_precisely(
+    let (package_set, resolve) = ops::resolve_ws_precisely(
         ws,
         None,
         &opt.features,
@@ -54,18 +56,22 @@ fn metadata_full<'a>(ws: &'a Workspace, opt: &OutputMetadataOptions) -> CargoRes
         opt.no_default_features,
         &specs,
     )?;
-    let (package_set, resolve) = deps;
-
-    let packages = package_set
-        .package_ids()
-        .map(|i| package_set.get(i).map(|p| p.clone()))
-        .collect::<CargoResult<Vec<_>>>()?;
+    let mut packages = HashMap::new();
+    for id in package_set.package_ids() {
+        if let Some(pkg) = package_set.start_download(id)? {
+            packages.insert(id.clone(), pkg.clone());
+        }
+    }
+    while package_set.remaining_downloads() > 0 {
+        let pkg = package_set.wait_for_download()?;
+        packages.insert(pkg.package_id().clone(), pkg.clone());
+    }
 
     Ok(ExportInfo {
-        packages,
+        packages: packages.values().map(|p| (*p).clone()).collect(),
         workspace_members: ws.members().map(|pkg| pkg.package_id().clone()).collect(),
         resolve: Some(MetadataResolve {
-            resolve: (package_set, resolve),
+            resolve: (packages, resolve),
             root: ws.current_opt().map(|pkg| pkg.package_id().clone()),
         }),
         target_directory: ws.target_dir().display().to_string(),
@@ -75,10 +81,10 @@ fn metadata_full<'a>(ws: &'a Workspace, opt: &OutputMetadataOptions) -> CargoRes
 }
 
 #[derive(Serialize)]
-pub struct ExportInfo<'a> {
+pub struct ExportInfo {
     packages: Vec<Package>,
     workspace_members: Vec<PackageId>,
-    resolve: Option<MetadataResolve<'a>>,
+    resolve: Option<MetadataResolve>,
     target_directory: String,
     version: u32,
     workspace_root: String,
@@ -88,13 +94,13 @@ pub struct ExportInfo<'a> {
 /// The one from lockfile does not fit because it uses a non-standard
 /// format for `PackageId`s
 #[derive(Serialize)]
-struct MetadataResolve<'a> {
+struct MetadataResolve {
     #[serde(rename = "nodes", serialize_with = "serialize_resolve")]
-    resolve: (PackageSet<'a>, Resolve),
+    resolve: (HashMap<PackageId, Package>, Resolve),
     root: Option<PackageId>,
 }
 
-fn serialize_resolve<S>((package_set, resolve): &(PackageSet, Resolve), s: S) -> Result<S::Ok, S::Error>
+fn serialize_resolve<S>((packages, resolve): &(HashMap<PackageId, Package>, Resolve), s: S) -> Result<S::Ok, S::Error>
 where
     S: ser::Serializer,
 {
@@ -119,7 +125,7 @@ where
             dependencies: resolve.deps(id).map(|(pkg, _deps)| pkg).collect(),
             deps: resolve.deps(id)
                 .map(|(pkg, _deps)| {
-                    let name = package_set.get(pkg).ok()
+                    let name = packages.get(pkg)
                         .and_then(|pkg| pkg.targets().iter().find(|t| t.is_lib()))
                         .and_then(|lib_target| {
                             resolve.extern_crate_name(id, pkg, lib_target).ok()

--- a/src/cargo/ops/resolve.rs
+++ b/src/cargo/ops/resolve.rs
@@ -16,7 +16,7 @@ use util::profile;
 pub fn resolve_ws<'a>(ws: &Workspace<'a>) -> CargoResult<(PackageSet<'a>, Resolve)> {
     let mut registry = PackageRegistry::new(ws.config())?;
     let resolve = resolve_with_registry(ws, &mut registry, true)?;
-    let packages = get_resolved_packages(&resolve, registry);
+    let packages = get_resolved_packages(&resolve, registry)?;
     Ok((packages, resolve))
 }
 
@@ -96,7 +96,7 @@ pub fn resolve_ws_with_method<'a>(
         true,
     )?;
 
-    let packages = get_resolved_packages(&resolved_with_overrides, registry);
+    let packages = get_resolved_packages(&resolved_with_overrides, registry)?;
 
     Ok((packages, resolved_with_overrides))
 }
@@ -374,7 +374,7 @@ pub fn add_overrides<'a>(
 pub fn get_resolved_packages<'a>(
     resolve: &Resolve,
     registry: PackageRegistry<'a>,
-) -> PackageSet<'a> {
+) -> CargoResult<PackageSet<'a>> {
     let ids: Vec<PackageId> = resolve.iter().cloned().collect();
     registry.get(&ids)
 }

--- a/src/cargo/sources/directory.rs
+++ b/src/cargo/sources/directory.rs
@@ -9,6 +9,7 @@ use hex;
 use serde_json;
 
 use core::{Dependency, Package, PackageId, Source, SourceId, Summary};
+use core::source::MaybePackage;
 use sources::PathSource;
 use util::{Config, Sha256};
 use util::errors::{CargoResult, CargoResultExt};
@@ -150,12 +151,17 @@ impl<'cfg> Source for DirectorySource<'cfg> {
         Ok(())
     }
 
-    fn download(&mut self, id: &PackageId) -> CargoResult<Package> {
+    fn download(&mut self, id: &PackageId) -> CargoResult<MaybePackage> {
         self.packages
             .get(id)
             .map(|p| &p.0)
             .cloned()
+            .map(MaybePackage::Ready)
             .ok_or_else(|| format_err!("failed to find package with id: {}", id))
+    }
+
+    fn finish_download(&mut self, _id: &PackageId, _data: Vec<u8>) -> CargoResult<Package> {
+        panic!("no downloads to do")
     }
 
     fn fingerprint(&self, pkg: &Package) -> CargoResult<String> {

--- a/src/cargo/sources/git/source.rs
+++ b/src/cargo/sources/git/source.rs
@@ -2,7 +2,7 @@ use std::fmt::{self, Debug, Formatter};
 
 use url::Url;
 
-use core::source::{Source, SourceId};
+use core::source::{Source, SourceId, MaybePackage};
 use core::GitReference;
 use core::{Dependency, Package, PackageId, Summary};
 use util::Config;
@@ -210,7 +210,7 @@ impl<'cfg> Source for GitSource<'cfg> {
         self.path_source.as_mut().unwrap().update()
     }
 
-    fn download(&mut self, id: &PackageId) -> CargoResult<Package> {
+    fn download(&mut self, id: &PackageId) -> CargoResult<MaybePackage> {
         trace!(
             "getting packages for package id `{}` from `{:?}`",
             id,
@@ -220,6 +220,10 @@ impl<'cfg> Source for GitSource<'cfg> {
             .as_mut()
             .expect("BUG: update() must be called before get()")
             .download(id)
+    }
+
+    fn finish_download(&mut self, _id: &PackageId, _data: Vec<u8>) -> CargoResult<Package> {
+        panic!("no download should have started")
     }
 
     fn fingerprint(&self, _pkg: &Package) -> CargoResult<String> {

--- a/src/cargo/sources/path.rs
+++ b/src/cargo/sources/path.rs
@@ -9,6 +9,7 @@ use ignore::Match;
 use ignore::gitignore::GitignoreBuilder;
 
 use core::{Dependency, Package, PackageId, Source, SourceId, Summary};
+use core::source::MaybePackage;
 use ops;
 use util::{self, internal, CargoResult};
 use util::paths;
@@ -540,12 +541,17 @@ impl<'cfg> Source for PathSource<'cfg> {
         Ok(())
     }
 
-    fn download(&mut self, id: &PackageId) -> CargoResult<Package> {
+    fn download(&mut self, id: &PackageId) -> CargoResult<MaybePackage> {
         trace!("getting packages; id={}", id);
 
         let pkg = self.packages.iter().find(|pkg| pkg.package_id() == id);
         pkg.cloned()
+            .map(MaybePackage::Ready)
             .ok_or_else(|| internal(format!("failed to find {} in path source", id)))
+    }
+
+    fn finish_download(&mut self, _id: &PackageId, _data: Vec<u8>) -> CargoResult<Package> {
+        panic!("no download should have started")
     }
 
     fn fingerprint(&self, pkg: &Package) -> CargoResult<String> {

--- a/src/cargo/util/mod.rs
+++ b/src/cargo/util/mod.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 pub use self::cfg::{Cfg, CfgExpr};
 pub use self::config::{homedir, Config, ConfigValue};
 pub use self::dependency_queue::{DependencyQueue, Dirty, Fresh, Freshness};
@@ -46,3 +48,13 @@ mod read2;
 mod progress;
 mod lockserver;
 pub mod diagnostic_server;
+
+pub fn elapsed(duration: Duration) -> String {
+    let secs = duration.as_secs();
+
+    if secs >= 60 {
+        format!("{}m {:02}s", secs / 60, secs % 60)
+    } else {
+        format!("{}.{:02}s", secs, duration.subsec_nanos() / 10_000_000)
+    }
+}

--- a/src/cargo/util/progress.rs
+++ b/src/cargo/util/progress.rs
@@ -16,13 +16,17 @@ pub enum ProgressStyle {
     Ratio,
 }
 
+struct Throttle {
+    first: bool,
+    last_update: Instant,
+}
+
 struct State<'cfg> {
     config: &'cfg Config,
     format: Format,
-    first: bool,
-    last_update: Instant,
     name: String,
     done: bool,
+    throttle: Throttle,
 }
 
 struct Format {
@@ -50,10 +54,9 @@ impl<'cfg> Progress<'cfg> {
                     max_width: n,
                     max_print: 80,
                 },
-                first: true,
-                last_update: Instant::now(),
                 name: name.to_string(),
                 done: false,
+                throttle: Throttle::new(),
             }),
         }
     }
@@ -71,31 +74,10 @@ impl<'cfg> Progress<'cfg> {
     }
 
     pub fn tick(&mut self, cur: usize, max: usize) -> CargoResult<()> {
-        match self.state {
-            Some(ref mut s) => s.tick(cur, max, "", true),
-            None => Ok(()),
-        }
-    }
-
-    pub fn clear(&mut self) {
-        if let Some(ref mut s) = self.state {
-            s.clear();
-        }
-    }
-
-    pub fn tick_now(&mut self, cur: usize, max: usize, msg: &str) -> CargoResult<()> {
-        match self.state {
-            Some(ref mut s) => s.tick(cur, max, msg, false),
-            None => Ok(()),
-        }
-    }
-}
-
-impl<'cfg> State<'cfg> {
-    fn tick(&mut self, cur: usize, max: usize, msg: &str, throttle: bool) -> CargoResult<()> {
-        if self.done {
-            return Ok(());
-        }
+        let s = match &mut self.state {
+            Some(s) => s,
+            None => return Ok(()),
+        };
 
         // Don't update too often as it can cause excessive performance loss
         // just putting stuff onto the terminal. We also want to avoid
@@ -109,33 +91,107 @@ impl<'cfg> State<'cfg> {
         // 2. If we've drawn something, then we rate limit ourselves to only
         //    draw to the console every so often. Currently there's a 100ms
         //    delay between updates.
-        if throttle {
-            if self.first {
-                let delay = Duration::from_millis(500);
-                if self.last_update.elapsed() < delay {
-                    return Ok(());
-                }
-                self.first = false;
-            } else {
-                let interval = Duration::from_millis(100);
-                if self.last_update.elapsed() < interval {
-                    return Ok(());
-                }
-            }
-            self.last_update = Instant::now();
+        if !s.throttle.allowed() {
+            return Ok(())
         }
 
-        if cur == max {
+        s.tick(cur, max, "")
+    }
+
+    pub fn tick_now(&mut self, cur: usize, max: usize, msg: &str) -> CargoResult<()> {
+        match self.state {
+            Some(ref mut s) => s.tick(cur, max, msg),
+            None => Ok(()),
+        }
+    }
+
+    pub fn update_allowed(&mut self) -> bool {
+        match &mut self.state {
+            Some(s) => s.throttle.allowed(),
+            None => false,
+        }
+    }
+
+    pub fn print_now(&mut self, msg: &str) -> CargoResult<()> {
+        match &mut self.state {
+            Some(s) => s.print("", msg),
+            None => Ok(()),
+        }
+    }
+
+    pub fn clear(&mut self) {
+        if let Some(ref mut s) = self.state {
+            s.clear();
+        }
+    }
+}
+
+impl Throttle {
+    fn new() -> Throttle {
+        Throttle {
+            first: true,
+            last_update: Instant::now(),
+        }
+    }
+
+    fn allowed(&mut self) -> bool {
+        if self.first {
+            let delay = Duration::from_millis(500);
+            if self.last_update.elapsed() < delay {
+                return false
+            }
+        } else {
+            let interval = Duration::from_millis(100);
+            if self.last_update.elapsed() < interval {
+                return false
+            }
+        }
+        self.update();
+        true
+    }
+
+    fn update(&mut self) {
+        self.first = false;
+        self.last_update = Instant::now();
+    }
+}
+
+impl<'cfg> State<'cfg> {
+    fn tick(&mut self, cur: usize, max: usize, msg: &str) -> CargoResult<()> {
+        if self.done {
+            return Ok(());
+        }
+
+        if max > 0 && cur == max {
             self.done = true;
         }
 
         // Write out a pretty header, then the progress bar itself, and then
         // return back to the beginning of the line for the next print.
         self.try_update_max_width();
-        if let Some(string) = self.format.progress_status(cur, max, msg) {
-            self.config.shell().status_header(&self.name)?;
-            write!(self.config.shell().err(), "{}\r", string)?;
+        if let Some(pbar) = self.format.progress(cur, max) {
+            self.print(&pbar, msg)?;
         }
+        Ok(())
+    }
+
+    fn print(&mut self, prefix: &str, msg: &str) -> CargoResult<()> {
+        self.throttle.update();
+        self.try_update_max_width();
+
+        // make sure we have enough room for the header
+        if self.format.max_width < 15 {
+            return Ok(())
+        }
+        self.config.shell().status_header(&self.name)?;
+        let mut line = prefix.to_string();
+        self.format.render(&mut line, msg);
+
+        while line.len() < self.format.max_width - 15 {
+            line.push(' ');
+        }
+
+        write!(self.config.shell().err(), "{}\r", line)?;
         Ok(())
     }
 
@@ -153,7 +209,7 @@ impl<'cfg> State<'cfg> {
 }
 
 impl Format {
-    fn progress_status(&self, cur: usize, max: usize, msg: &str) -> Option<String> {
+    fn progress(&self, cur: usize, max: usize) -> Option<String> {
         // Render the percentage at the far right and then figure how long the
         // progress bar is
         let pct = (cur as f64) / (max as f64);
@@ -192,26 +248,36 @@ impl Format {
         string.push_str("]");
         string.push_str(&stats);
 
-        let mut avail_msg_len = self.max_width - self.width();
+        Some(string)
+    }
+
+    fn render(&self, string: &mut String, msg: &str) {
+        let mut avail_msg_len = self.max_width - string.len() - 15;
         let mut ellipsis_pos = 0;
-        if avail_msg_len > 3 {
-            for c in msg.chars() {
-                let display_width = c.width().unwrap_or(0);
-                if avail_msg_len >= display_width {
-                    avail_msg_len -= display_width;
-                    string.push(c);
-                    if avail_msg_len >= 3 {
-                        ellipsis_pos = string.len();
-                    }
-                } else {
-                    string.truncate(ellipsis_pos);
-                    string.push_str("...");
-                    break;
+        if avail_msg_len <= 3 {
+            return
+        }
+        for c in msg.chars() {
+            let display_width = c.width().unwrap_or(0);
+            if avail_msg_len >= display_width {
+                avail_msg_len -= display_width;
+                string.push(c);
+                if avail_msg_len >= 3 {
+                    ellipsis_pos = string.len();
                 }
+            } else {
+                string.truncate(ellipsis_pos);
+                string.push_str("...");
+                break;
             }
         }
+    }
 
-        Some(string)
+    #[cfg(test)]
+    fn progress_status(&self, cur: usize, max: usize, msg: &str) -> Option<String> {
+        let mut ret = self.progress(cur, max)?;
+        self.render(&mut ret, msg);
+        Some(ret)
     }
 
     fn width(&self) -> usize {

--- a/src/cargo/util/progress.rs
+++ b/src/cargo/util/progress.rs
@@ -62,6 +62,10 @@ impl<'cfg> Progress<'cfg> {
         self.state = None;
     }
 
+    pub fn is_enabled(&self) -> bool {
+        self.state.is_some()
+    }
+
     pub fn new(name: &str, cfg: &'cfg Config) -> Progress<'cfg> {
         Self::with_style(name, ProgressStyle::Percentage, cfg)
     }

--- a/src/doc/src/reference/config.md
+++ b/src/doc/src/reference/config.md
@@ -101,6 +101,7 @@ timeout = 30        # Timeout for each HTTP request, in seconds
 cainfo = "cert.pem" # Path to Certificate Authority (CA) bundle (optional)
 check-revoke = true # Indicates whether SSL certs are checked for revocation
 low-speed-limit = 5 # Lower threshold for bytes/sec (10 = default, 0 = disabled)
+multiplexing = false  # whether or not to use HTTP/2 multiplexing where possible
 
 [build]
 jobs = 1                  # number of parallel jobs, defaults to # of CPUs

--- a/tests/testsuite/alt_registry.rs
+++ b/tests/testsuite/alt_registry.rs
@@ -57,7 +57,8 @@ fn depend_on_alt_registry() {
         .with_stderr(&format!(
             "\
 [UPDATING] `{reg}` index
-[DOWNLOADING] bar v0.0.1 (registry `[ROOT][..]`)
+[DOWNLOADING] crates ...
+[DOWNLOADED] bar v0.0.1 (registry `[ROOT][..]`)
 [COMPILING] bar v0.0.1 (registry `[ROOT][..]`)
 [COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
@@ -110,8 +111,9 @@ fn depend_on_alt_registry_depends_on_same_registry_no_index() {
         .with_stderr(&format!(
             "\
 [UPDATING] `{reg}` index
-[DOWNLOADING] [..] v0.0.1 (registry `[ROOT][..]`)
-[DOWNLOADING] [..] v0.0.1 (registry `[ROOT][..]`)
+[DOWNLOADING] crates ...
+[DOWNLOADED] [..] v0.0.1 (registry `[ROOT][..]`)
+[DOWNLOADED] [..] v0.0.1 (registry `[ROOT][..]`)
 [COMPILING] baz v0.0.1 (registry `[ROOT][..]`)
 [COMPILING] bar v0.0.1 (registry `[ROOT][..]`)
 [COMPILING] foo v0.0.1 ([CWD])
@@ -152,8 +154,9 @@ fn depend_on_alt_registry_depends_on_same_registry() {
         .with_stderr(&format!(
             "\
 [UPDATING] `{reg}` index
-[DOWNLOADING] [..] v0.0.1 (registry `[ROOT][..]`)
-[DOWNLOADING] [..] v0.0.1 (registry `[ROOT][..]`)
+[DOWNLOADING] crates ...
+[DOWNLOADED] [..] v0.0.1 (registry `[ROOT][..]`)
+[DOWNLOADED] [..] v0.0.1 (registry `[ROOT][..]`)
 [COMPILING] baz v0.0.1 (registry `[ROOT][..]`)
 [COMPILING] bar v0.0.1 (registry `[ROOT][..]`)
 [COMPILING] foo v0.0.1 ([CWD])
@@ -195,8 +198,9 @@ fn depend_on_alt_registry_depends_on_crates_io() {
             "\
 [UPDATING] `{alt_reg}` index
 [UPDATING] `{reg}` index
-[DOWNLOADING] [..] v0.0.1 (registry `[ROOT][..]`)
-[DOWNLOADING] [..] v0.0.1 (registry `[ROOT][..]`)
+[DOWNLOADING] crates ...
+[DOWNLOADED] [..] v0.0.1 (registry `[ROOT][..]`)
+[DOWNLOADED] [..] v0.0.1 (registry `[ROOT][..]`)
 [COMPILING] baz v0.0.1 (registry `[ROOT][..]`)
 [COMPILING] bar v0.0.1 (registry `[ROOT][..]`)
 [COMPILING] foo v0.0.1 ([CWD])
@@ -363,8 +367,8 @@ fn alt_registry_and_crates_io_deps() {
         )).with_stderr_contains(&format!(
             "[UPDATING] `{}` index",
             registry::registry_path().to_str().unwrap()))
-        .with_stderr_contains("[DOWNLOADING] crates_io_dep v0.0.1 (registry `[ROOT][..]`)")
-        .with_stderr_contains("[DOWNLOADING] alt_reg_dep v0.1.0 (registry `[ROOT][..]`)")
+        .with_stderr_contains("[DOWNLOADED] crates_io_dep v0.0.1 (registry `[ROOT][..]`)")
+        .with_stderr_contains("[DOWNLOADED] alt_reg_dep v0.1.0 (registry `[ROOT][..]`)")
         .with_stderr_contains("[COMPILING] alt_reg_dep v0.1.0 (registry `[ROOT][..]`)")
         .with_stderr_contains("[COMPILING] crates_io_dep v0.0.1")
         .with_stderr_contains("[COMPILING] foo v0.0.1 ([CWD])")

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -3569,11 +3569,12 @@ fn build_all_member_dependency_same_name() {
 
     p.cargo("build --all")
         .with_stderr(
-            "[..] Updating `[..]` index\n\
-             [..] Downloading a v0.1.0 ([..])\n\
-             [..] Compiling a v0.1.0\n\
-             [..] Compiling a v0.1.0 ([..])\n\
-             [..] Finished dev [unoptimized + debuginfo] target(s) in [..]\n",
+            "[UPDATING] `[..]` index\n\
+             [DOWNLOADING] crates ...\n\
+             [DOWNLOADED] a v0.1.0 ([..])\n\
+             [COMPILING] a v0.1.0\n\
+             [COMPILING] a v0.1.0 ([..])\n\
+             [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]\n",
         ).run();
 }
 

--- a/tests/testsuite/build_script.rs
+++ b/tests/testsuite/build_script.rs
@@ -2707,7 +2707,8 @@ fn warnings_hidden_for_upstream() {
         .with_stderr(
             "\
 [UPDATING] `[..]` index
-[DOWNLOADING] bar v0.1.0 ([..])
+[DOWNLOADING] crates ...
+[DOWNLOADED] bar v0.1.0 ([..])
 [COMPILING] bar v0.1.0
 [RUNNING] `rustc [..]`
 [RUNNING] `[..]`
@@ -2761,7 +2762,8 @@ fn warnings_printed_on_vv() {
         .with_stderr(
             "\
 [UPDATING] `[..]` index
-[DOWNLOADING] bar v0.1.0 ([..])
+[DOWNLOADING] crates ...
+[DOWNLOADED] bar v0.1.0 ([..])
 [COMPILING] bar v0.1.0
 [RUNNING] `rustc [..]`
 [RUNNING] `[..]`

--- a/tests/testsuite/cfg.rs
+++ b/tests/testsuite/cfg.rs
@@ -223,8 +223,9 @@ fn works_through_the_registry() {
         .with_stderr(
             "\
 [UPDATING] [..] index
-[DOWNLOADING] [..]
-[DOWNLOADING] [..]
+[DOWNLOADING] crates ...
+[DOWNLOADED] [..]
+[DOWNLOADED] [..]
 [COMPILING] baz v0.1.0
 [COMPILING] bar v0.1.0
 [COMPILING] foo v0.0.1 ([..])
@@ -267,7 +268,8 @@ fn ignore_version_from_other_platform() {
         .with_stderr(
             "\
 [UPDATING] [..] index
-[DOWNLOADING] [..]
+[DOWNLOADING] crates ...
+[DOWNLOADED] [..]
 [COMPILING] bar v0.1.0
 [COMPILING] foo v0.0.1 ([..])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]

--- a/tests/testsuite/directory.rs
+++ b/tests/testsuite/directory.rs
@@ -331,7 +331,8 @@ fn crates_io_then_directory() {
         .with_stderr(
             "\
 [UPDATING] `[..]` index
-[DOWNLOADING] bar v0.1.0 ([..])
+[DOWNLOADING] crates ...
+[DOWNLOADED] bar v0.1.0 ([..])
 [COMPILING] bar v0.1.0
 [COMPILING] foo v0.1.0 ([CWD])
 [FINISHED] [..]

--- a/tests/testsuite/fetch.rs
+++ b/tests/testsuite/fetch.rs
@@ -53,8 +53,8 @@ fn fetch_all_platform_dependencies_when_no_target_is_given() {
         .build();
 
     p.cargo("fetch")
-        .with_stderr_contains("[..] Downloading d1 v1.2.3 [..]")
-        .with_stderr_contains("[..] Downloading d2 v0.1.2 [..]")
+        .with_stderr_contains("[DOWNLOADED] d1 v1.2.3 [..]")
+        .with_stderr_contains("[DOWNLOADED] d2 v0.1.2 [..]")
         .run();
 }
 
@@ -100,13 +100,13 @@ fn fetch_platform_specific_dependencies() {
 
     p.cargo("fetch --target")
         .arg(&host)
-        .with_stderr_contains("[..] Downloading d1 v1.2.3 [..]")
-        .with_stderr_does_not_contain("[..] Downloading d2 v0.1.2 [..]")
+        .with_stderr_contains("[DOWNLOADED] d1 v1.2.3 [..]")
+        .with_stderr_does_not_contain("[DOWNLOADED] d2 v0.1.2 [..]")
         .run();
 
     p.cargo("fetch --target")
         .arg(&target)
-        .with_stderr_contains("[..] Downloading d2 v0.1.2[..]")
-        .with_stderr_does_not_contain("[..] Downloading d1 v1.2.3 [..]")
+        .with_stderr_contains("[DOWNLOADED] d2 v0.1.2[..]")
+        .with_stderr_does_not_contain("[DOWNLOADED] d1 v1.2.3 [..]")
         .run();
 }

--- a/tests/testsuite/git.rs
+++ b/tests/testsuite/git.rs
@@ -2359,8 +2359,8 @@ fn include_overrides_gitignore() {
         .with_stderr(
             "\
 [UPDATING] `[..]` index
-[DOWNLOADING] filetime [..]
-[DOWNLOADING] libc [..]
+[DOWNLOADED] filetime [..]
+[DOWNLOADED] libc [..]
 [COMPILING] libc [..]
 [RUNNING] `rustc --crate-name libc [..]`
 [COMPILING] filetime [..]

--- a/tests/testsuite/install.rs
+++ b/tests/testsuite/install.rs
@@ -27,7 +27,8 @@ fn simple() {
         .with_stderr(
             "\
 [UPDATING] `[..]` index
-[DOWNLOADING] foo v0.0.1 (registry [..])
+[DOWNLOADING] crates ...
+[DOWNLOADED] foo v0.0.1 (registry [..])
 [INSTALLING] foo v0.0.1
 [COMPILING] foo v0.0.1
 [FINISHED] release [optimized] target(s) in [..]
@@ -53,12 +54,14 @@ fn multiple_pkgs() {
         .with_stderr(
             "\
 [UPDATING] `[..]` index
-[DOWNLOADING] foo v0.0.1 (registry `[CWD]/registry`)
+[DOWNLOADING] crates ...
+[DOWNLOADED] foo v0.0.1 (registry `[CWD]/registry`)
 [INSTALLING] foo v0.0.1
 [COMPILING] foo v0.0.1
 [FINISHED] release [optimized] target(s) in [..]
 [INSTALLING] [CWD]/home/.cargo/bin/foo[EXE]
-[DOWNLOADING] bar v0.0.2 (registry `[CWD]/registry`)
+[DOWNLOADING] crates ...
+[DOWNLOADED] bar v0.0.2 (registry `[CWD]/registry`)
 [INSTALLING] bar v0.0.2
 [COMPILING] bar v0.0.2
 [FINISHED] release [optimized] target(s) in [..]
@@ -97,7 +100,8 @@ fn pick_max_version() {
         .with_stderr(
             "\
 [UPDATING] `[..]` index
-[DOWNLOADING] foo v0.2.1 (registry [..])
+[DOWNLOADING] crates ...
+[DOWNLOADED] foo v0.2.1 (registry [..])
 [INSTALLING] foo v0.2.1
 [COMPILING] foo v0.2.1
 [FINISHED] release [optimized] target(s) in [..]
@@ -1004,7 +1008,7 @@ fn vers_precise() {
     pkg("foo", "0.1.2");
 
     cargo_process("install foo --vers 0.1.1")
-        .with_stderr_contains("[DOWNLOADING] foo v0.1.1 (registry [..])")
+        .with_stderr_contains("[DOWNLOADED] foo v0.1.1 (registry [..])")
         .run();
 }
 
@@ -1014,7 +1018,7 @@ fn version_too() {
     pkg("foo", "0.1.2");
 
     cargo_process("install foo --version 0.1.1")
-        .with_stderr_contains("[DOWNLOADING] foo v0.1.1 (registry [..])")
+        .with_stderr_contains("[DOWNLOADED] foo v0.1.1 (registry [..])")
         .run();
 }
 

--- a/tests/testsuite/overrides.rs
+++ b/tests/testsuite/overrides.rs
@@ -185,7 +185,8 @@ fn transitive() {
             "\
 [UPDATING] `[ROOT][..]` index
 [UPDATING] git repository `[..]`
-[DOWNLOADING] baz v0.2.0 (registry [..])
+[DOWNLOADING] crates ...
+[DOWNLOADED] baz v0.2.0 (registry [..])
 [COMPILING] bar v0.1.0 (file://[..])
 [COMPILING] baz v0.2.0
 [COMPILING] foo v0.0.1 ([CWD])
@@ -338,8 +339,9 @@ fn use_a_spec_to_select() {
             "\
 [UPDATING] `[ROOT][..]` index
 [UPDATING] git repository `[..]`
-[DOWNLOADING] [..]
-[DOWNLOADING] [..]
+[DOWNLOADING] crates ...
+[DOWNLOADED] [..]
+[DOWNLOADED] [..]
 [COMPILING] [..]
 [COMPILING] [..]
 [COMPILING] [..]
@@ -395,7 +397,8 @@ fn override_adds_some_deps() {
             "\
 [UPDATING] `[ROOT][..]` index
 [UPDATING] git repository `[..]`
-[DOWNLOADING] baz v0.1.1 (registry [..])
+[DOWNLOADING] crates ...
+[DOWNLOADED] baz v0.1.1 (registry [..])
 [COMPILING] baz v0.1.1
 [COMPILING] bar v0.1.0 ([..])
 [COMPILING] foo v0.0.1 ([CWD])
@@ -832,7 +835,8 @@ documented online at the url below for more information.
 
 https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#overriding-dependencies
 
-[DOWNLOADING] [..]
+[DOWNLOADING] crates ...
+[DOWNLOADED] [..]
 [COMPILING] [..]
 [COMPILING] [..]
 [COMPILING] [..]

--- a/tests/testsuite/patch.rs
+++ b/tests/testsuite/patch.rs
@@ -51,7 +51,8 @@ fn replace() {
         .with_stderr(
             "\
 [UPDATING] `[ROOT][..]` index
-[DOWNLOADING] baz v0.1.0 ([..])
+[DOWNLOADING] crates ...
+[DOWNLOADED] baz v0.1.0 ([..])
 [COMPILING] bar v0.1.0 ([CWD]/bar)
 [COMPILING] baz v0.1.0
 [COMPILING] foo v0.0.1 ([CWD])
@@ -217,7 +218,8 @@ fn unused() {
         .with_stderr(
             "\
 [UPDATING] `[ROOT][..]` index
-[DOWNLOADING] bar v0.1.0 [..]
+[DOWNLOADING] crates ...
+[DOWNLOADED] bar v0.1.0 [..]
 [COMPILING] bar v0.1.0
 [COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
@@ -275,7 +277,8 @@ fn unused_git() {
             "\
 [UPDATING] git repository `file://[..]`
 [UPDATING] `[ROOT][..]` index
-[DOWNLOADING] bar v0.1.0 [..]
+[DOWNLOADING] crates ...
+[DOWNLOADED] bar v0.1.0 [..]
 [COMPILING] bar v0.1.0
 [COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
@@ -309,7 +312,8 @@ fn add_patch() {
         .with_stderr(
             "\
 [UPDATING] `[ROOT][..]` index
-[DOWNLOADING] bar v0.1.0 [..]
+[DOWNLOADING] crates ...
+[DOWNLOADED] bar v0.1.0 [..]
 [COMPILING] bar v0.1.0
 [COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
@@ -368,7 +372,8 @@ fn add_ignored_patch() {
         .with_stderr(
             "\
 [UPDATING] `[ROOT][..]` index
-[DOWNLOADING] bar v0.1.0 [..]
+[DOWNLOADING] crates ...
+[DOWNLOADED] bar v0.1.0 [..]
 [COMPILING] bar v0.1.0
 [COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
@@ -535,7 +540,8 @@ fn new_major() {
         .with_stderr(
             "\
 [UPDATING] `[ROOT][..]` index
-[DOWNLOADING] bar v0.2.0 [..]
+[DOWNLOADING] crates ...
+[DOWNLOADED] bar v0.2.0 [..]
 [COMPILING] bar v0.2.0
 [COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]

--- a/tests/testsuite/registry.rs
+++ b/tests/testsuite/registry.rs
@@ -40,7 +40,8 @@ fn simple() {
         .with_stderr(&format!(
             "\
 [UPDATING] `{reg}` index
-[DOWNLOADING] bar v0.0.1 (registry `[ROOT][..]`)
+[DOWNLOADING] crates ...
+[DOWNLOADED] bar v0.0.1 (registry `[ROOT][..]`)
 [COMPILING] bar v0.0.1
 [COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
@@ -85,8 +86,9 @@ fn deps() {
         .with_stderr(&format!(
             "\
 [UPDATING] `{reg}` index
-[DOWNLOADING] [..] v0.0.1 (registry `[ROOT][..]`)
-[DOWNLOADING] [..] v0.0.1 (registry `[ROOT][..]`)
+[DOWNLOADING] crates ...
+[DOWNLOADED] [..] v0.0.1 (registry `[ROOT][..]`)
+[DOWNLOADED] [..] v0.0.1 (registry `[ROOT][..]`)
 [COMPILING] baz v0.0.1
 [COMPILING] bar v0.0.1
 [COMPILING] foo v0.0.1 ([CWD])
@@ -265,7 +267,8 @@ fn bad_cksum() {
         .with_stderr(
             "\
 [UPDATING] [..] index
-[DOWNLOADING] bad-cksum [..]
+[DOWNLOADING] crates ...
+[DOWNLOADED] bad-cksum [..]
 [ERROR] failed to download replaced source registry `https://[..]`
 
 Caused by:
@@ -309,7 +312,8 @@ required by package `foo v0.0.1 ([..])`
         .with_stderr(format!(
             "\
 [UPDATING] `{reg}` index
-[DOWNLOADING] notyet v0.0.1 (registry `[ROOT][..]`)
+[DOWNLOADING] crates ...
+[DOWNLOADED] notyet v0.0.1 (registry `[ROOT][..]`)
 [COMPILING] notyet v0.0.1
 [COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
@@ -364,7 +368,8 @@ required by package `foo v0.0.1 ([..])`
 [PACKAGING] foo v0.0.1 ([CWD])
 [VERIFYING] foo v0.0.1 ([CWD])
 [UPDATING] `[..]` index
-[DOWNLOADING] notyet v0.0.1 (registry `[ROOT][..]`)
+[DOWNLOADING] crates ...
+[DOWNLOADED] notyet v0.0.1 (registry `[ROOT][..]`)
 [COMPILING] notyet v0.0.1
 [COMPILING] foo v0.0.1 ([CWD][..])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
@@ -395,7 +400,8 @@ fn lockfile_locks() {
         .with_stderr(
             "\
 [UPDATING] `[..]` index
-[DOWNLOADING] bar v0.0.1 (registry `[ROOT][..]`)
+[DOWNLOADING] crates ...
+[DOWNLOADED] bar v0.0.1 (registry `[ROOT][..]`)
 [COMPILING] bar v0.0.1
 [COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
@@ -432,8 +438,9 @@ fn lockfile_locks_transitively() {
         .with_stderr(
             "\
 [UPDATING] `[..]` index
-[DOWNLOADING] [..] v0.0.1 (registry `[ROOT][..]`)
-[DOWNLOADING] [..] v0.0.1 (registry `[ROOT][..]`)
+[DOWNLOADING] crates ...
+[DOWNLOADED] [..] v0.0.1 (registry `[ROOT][..]`)
+[DOWNLOADED] [..] v0.0.1 (registry `[ROOT][..]`)
 [COMPILING] baz v0.0.1
 [COMPILING] bar v0.0.1
 [COMPILING] foo v0.0.1 ([CWD])
@@ -477,8 +484,9 @@ fn yanks_are_not_used() {
         .with_stderr(
             "\
 [UPDATING] `[..]` index
-[DOWNLOADING] [..] v0.0.1 (registry `[ROOT][..]`)
-[DOWNLOADING] [..] v0.0.1 (registry `[ROOT][..]`)
+[DOWNLOADING] crates ...
+[DOWNLOADED] [..] v0.0.1 (registry `[ROOT][..]`)
+[DOWNLOADED] [..] v0.0.1 (registry `[ROOT][..]`)
 [COMPILING] baz v0.0.1
 [COMPILING] bar v0.0.1
 [COMPILING] foo v0.0.1 ([CWD])
@@ -584,7 +592,8 @@ fn update_with_lockfile_if_packages_missing() {
         .with_stderr(
             "\
 [UPDATING] `[..]` index
-[DOWNLOADING] bar v0.0.1 (registry `[ROOT][..]`)
+[DOWNLOADING] crates ...
+[DOWNLOADED] bar v0.0.1 (registry `[ROOT][..]`)
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
 ",
         ).run();
@@ -627,7 +636,8 @@ fn update_lockfile() {
     p.cargo("build")
         .with_stderr(
             "\
-[DOWNLOADING] [..] v0.0.2 (registry `[ROOT][..]`)
+[DOWNLOADING] crates ...
+[DOWNLOADED] [..] v0.0.2 (registry `[ROOT][..]`)
 [COMPILING] bar v0.0.2
 [COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
@@ -647,7 +657,8 @@ fn update_lockfile() {
     p.cargo("build")
         .with_stderr(
             "\
-[DOWNLOADING] [..] v0.0.3 (registry `[ROOT][..]`)
+[DOWNLOADING] crates ...
+[DOWNLOADED] [..] v0.0.3 (registry `[ROOT][..]`)
 [COMPILING] bar v0.0.3
 [COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
@@ -725,7 +736,8 @@ fn dev_dependency_not_used() {
         .with_stderr(
             "\
 [UPDATING] `[..]` index
-[DOWNLOADING] [..] v0.0.1 (registry `[ROOT][..]`)
+[DOWNLOADING] crates ...
+[DOWNLOADED] [..] v0.0.1 (registry `[ROOT][..]`)
 [COMPILING] bar v0.0.1
 [COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
@@ -809,7 +821,8 @@ fn updating_a_dep() {
         .with_stderr(
             "\
 [UPDATING] `[..]` index
-[DOWNLOADING] bar v0.0.1 (registry `[ROOT][..]`)
+[DOWNLOADING] crates ...
+[DOWNLOADED] bar v0.0.1 (registry `[ROOT][..]`)
 [COMPILING] bar v0.0.1
 [COMPILING] a v0.0.1 ([CWD]/a)
 [COMPILING] foo v0.0.1 ([CWD])
@@ -835,7 +848,8 @@ fn updating_a_dep() {
         .with_stderr(
             "\
 [UPDATING] `[..]` index
-[DOWNLOADING] bar v0.1.0 (registry `[ROOT][..]`)
+[DOWNLOADING] crates ...
+[DOWNLOADED] bar v0.1.0 (registry `[ROOT][..]`)
 [COMPILING] bar v0.1.0
 [COMPILING] a v0.0.1 ([CWD]/a)
 [COMPILING] foo v0.0.1 ([CWD])
@@ -889,7 +903,8 @@ fn git_and_registry_dep() {
             "\
 [UPDATING] [..]
 [UPDATING] [..]
-[DOWNLOADING] a v0.0.1 (registry `[ROOT][..]`)
+[DOWNLOADING] crates ...
+[DOWNLOADED] a v0.0.1 (registry `[ROOT][..]`)
 [COMPILING] a v0.0.1
 [COMPILING] b v0.0.1 ([..])
 [COMPILING] foo v0.0.1 ([CWD])
@@ -962,7 +977,8 @@ fn update_publish_then_update() {
         .with_stderr(
             "\
 [UPDATING] [..]
-[DOWNLOADING] a v0.1.1 (registry `[ROOT][..]`)
+[DOWNLOADING] crates ...
+[DOWNLOADED] a v0.1.1 (registry `[ROOT][..]`)
 [COMPILING] a v0.1.1
 [COMPILING] foo v0.5.0 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
@@ -993,7 +1009,8 @@ fn fetch_downloads() {
         .with_stderr(
             "\
 [UPDATING] `[..]` index
-[DOWNLOADING] a v0.1.0 (registry [..])
+[DOWNLOADING] crates ...
+[DOWNLOADED] a v0.1.0 (registry [..])
 ",
         ).run();
 }
@@ -1033,7 +1050,8 @@ fn update_transitive_dependency() {
     p.cargo("build")
         .with_stderr(
             "\
-[DOWNLOADING] b v0.1.1 (registry `[ROOT][..]`)
+[DOWNLOADING] crates ...
+[DOWNLOADED] b v0.1.1 (registry `[ROOT][..]`)
 [COMPILING] b v0.1.1
 [COMPILING] a v0.1.0
 [COMPILING] foo v0.5.0 ([..])
@@ -1136,9 +1154,9 @@ fn update_multiple_packages() {
         ).run();
 
     p.cargo("build")
-        .with_stderr_contains("[DOWNLOADING] a v0.1.1 (registry `[ROOT][..]`)")
-        .with_stderr_contains("[DOWNLOADING] b v0.1.1 (registry `[ROOT][..]`)")
-        .with_stderr_contains("[DOWNLOADING] c v0.1.1 (registry `[ROOT][..]`)")
+        .with_stderr_contains("[DOWNLOADED] a v0.1.1 (registry `[ROOT][..]`)")
+        .with_stderr_contains("[DOWNLOADED] b v0.1.1 (registry `[ROOT][..]`)")
+        .with_stderr_contains("[DOWNLOADED] c v0.1.1 (registry `[ROOT][..]`)")
         .with_stderr_contains("[COMPILING] a v0.1.1")
         .with_stderr_contains("[COMPILING] b v0.1.1")
         .with_stderr_contains("[COMPILING] c v0.1.1")
@@ -1263,7 +1281,8 @@ fn only_download_relevant() {
         .with_stderr(
             "\
 [UPDATING] `[..]` index
-[DOWNLOADING] baz v0.1.0 ([..])
+[DOWNLOADING] crates ...
+[DOWNLOADED] baz v0.1.0 ([..])
 [COMPILING] baz v0.1.0
 [COMPILING] bar v0.5.0 ([..])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
@@ -1506,7 +1525,8 @@ update to a fixed version or contact the upstream maintainer about
 this warning.
 
 [UPDATING] [..]
-[DOWNLOADING] [..]
+[DOWNLOADING] crates ...
+[DOWNLOADED] [..]
 [COMPILING] [..]
 [COMPILING] [..]
 [FINISHED] [..]
@@ -1551,7 +1571,8 @@ fn old_version_req_upstream() {
         .with_stderr(
             "\
 [UPDATING] [..]
-[DOWNLOADING] [..]
+[DOWNLOADING] crates ...
+[DOWNLOADED] [..]
 warning: parsed version requirement `0.2*` is no longer valid
 
 Previous versions of Cargo accepted this malformed requirement,
@@ -1658,7 +1679,8 @@ fn bad_and_or_malicious_packages_rejected() {
         .with_stderr(
             "\
 [UPDATING] [..]
-[DOWNLOADING] [..]
+[DOWNLOADING] crates ...
+[DOWNLOADED] [..]
 error: failed to download [..]
 
 Caused by:

--- a/tests/testsuite/registry.rs
+++ b/tests/testsuite/registry.rs
@@ -266,10 +266,7 @@ fn bad_cksum() {
             "\
 [UPDATING] [..] index
 [DOWNLOADING] bad-cksum [..]
-[ERROR] unable to get packages from source
-
-Caused by:
-  failed to download replaced source registry `https://[..]`
+[ERROR] failed to download replaced source registry `https://[..]`
 
 Caused by:
   failed to verify the checksum of `bad-cksum v0.0.1 (registry `[ROOT][..]`)`
@@ -1662,10 +1659,7 @@ fn bad_and_or_malicious_packages_rejected() {
             "\
 [UPDATING] [..]
 [DOWNLOADING] [..]
-error: unable to get packages from source
-
-Caused by:
-  failed to download [..]
+error: failed to download [..]
 
 Caused by:
   failed to unpack [..]

--- a/tests/testsuite/rename_deps.rs
+++ b/tests/testsuite/rename_deps.rs
@@ -248,7 +248,8 @@ fn rename_twice() {
         .with_stderr(
             "\
 [UPDATING] `[..]` index
-[DOWNLOADING] foo v0.1.0 (registry [..])
+[DOWNLOADING] crates ...
+[DOWNLOADED] foo v0.1.0 (registry [..])
 error: multiple dependencies listed for the same crate must all have the same \
 name, but the dependency on `foo v0.1.0` is listed as having different names
 ",

--- a/tests/testsuite/support/mod.rs
+++ b/tests/testsuite/support/mod.rs
@@ -1389,6 +1389,7 @@ fn substitute_macros(input: &str) -> String {
         ("[DOCTEST]", "   Doc-tests"),
         ("[PACKAGING]", "   Packaging"),
         ("[DOWNLOADING]", " Downloading"),
+        ("[DOWNLOADED]", "  Downloaded"),
         ("[UPLOADING]", "   Uploading"),
         ("[VERIFYING]", "   Verifying"),
         ("[ARCHIVING]", "   Archiving"),

--- a/tests/testsuite/warn_on_failure.rs
+++ b/tests/testsuite/warn_on_failure.rs
@@ -59,7 +59,8 @@ fn no_warning_on_success() {
         .with_stderr(
             "\
 [UPDATING] `[..]` index
-[DOWNLOADING] bar v0.0.1 ([..])
+[DOWNLOADING] crates ...
+[DOWNLOADED] bar v0.0.1 ([..])
 [COMPILING] bar v0.0.1
 [COMPILING] foo v0.0.1 ([..])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
@@ -79,7 +80,7 @@ fn no_warning_on_bin_failure() {
         .with_stderr_does_not_contain(&format!("[WARNING] {}", WARNING1))
         .with_stderr_does_not_contain(&format!("[WARNING] {}", WARNING2))
         .with_stderr_contains("[UPDATING] `[..]` index")
-        .with_stderr_contains("[DOWNLOADING] bar v0.0.1 ([..])")
+        .with_stderr_contains("[DOWNLOADED] bar v0.0.1 ([..])")
         .with_stderr_contains("[COMPILING] bar v0.0.1")
         .with_stderr_contains("[COMPILING] foo v0.0.1 ([..])")
         .run();
@@ -96,7 +97,7 @@ fn warning_on_lib_failure() {
         .with_stderr_does_not_contain("hidden stderr")
         .with_stderr_does_not_contain("[COMPILING] foo v0.0.1 ([..])")
         .with_stderr_contains("[UPDATING] `[..]` index")
-        .with_stderr_contains("[DOWNLOADING] bar v0.0.1 ([..])")
+        .with_stderr_contains("[DOWNLOADED] bar v0.0.1 ([..])")
         .with_stderr_contains("[COMPILING] bar v0.0.1")
         .with_stderr_contains(&format!("[WARNING] {}", WARNING1))
         .with_stderr_contains(&format!("[WARNING] {}", WARNING2))

--- a/tests/testsuite/workspaces.rs
+++ b/tests/testsuite/workspaces.rs
@@ -557,7 +557,8 @@ fn share_dependencies() {
         .with_stderr(
             "\
 [UPDATING] `[..]` index
-[DOWNLOADING] dep1 v0.1.3 ([..])
+[DOWNLOADING] crates ...
+[DOWNLOADED] dep1 v0.1.3 ([..])
 [COMPILING] dep1 v0.1.3
 [COMPILING] foo v0.1.0 ([..])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
@@ -600,7 +601,8 @@ fn fetch_fetches_all() {
         .with_stderr(
             "\
 [UPDATING] `[..]` index
-[DOWNLOADING] dep1 v0.1.3 ([..])
+[DOWNLOADING] crates ...
+[DOWNLOADED] dep1 v0.1.3 ([..])
 ",
         ).run();
 }
@@ -650,7 +652,8 @@ fn lock_works_for_everyone() {
     p.cargo("build")
         .with_stderr(
             "\
-[DOWNLOADING] dep2 v0.1.0 ([..])
+[DOWNLOADING] crates ...
+[DOWNLOADED] dep2 v0.1.0 ([..])
 [COMPILING] dep2 v0.1.0
 [COMPILING] foo v0.1.0 ([..])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
@@ -661,7 +664,8 @@ fn lock_works_for_everyone() {
         .cwd(p.root().join("bar"))
         .with_stderr(
             "\
-[DOWNLOADING] dep1 v0.1.0 ([..])
+[DOWNLOADING] crates ...
+[DOWNLOADED] dep1 v0.1.0 ([..])
 [COMPILING] dep1 v0.1.0
 [COMPILING] bar v0.1.0 ([..])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]


### PR DESCRIPTION
This PR revives some of the work of https://github.com/rust-lang/cargo/pull/5161 by refactoring Cargo to make it much easier to add parallel downloads, and then it does so with the `curl` crate's new `http2` feature to compile `nghttp2` has a backend.

The primary refactoring done here is to remove the concept of "download this one package" deep within a `Source`. Instead a `Source` still has a `download` method but it's considered to be largely non-blocking. If a crate needs to be downloaded it immediately returns information as to such. The `PackageSet` abstraction is now a central location for all parallel downloads, and all users of it have been refactored to be amenable to parallel downloads, when added.

Many more details are in the commits...