### PR TITLE
Fix example for usage still not published uuid 2.0.0

### DIFF
--- a/src/doc/src/reference/specifying-dependencies.md
+++ b/src/doc/src/reference/specifying-dependencies.md
@@ -376,7 +376,7 @@ my-library = { git = 'https://example.com/git/my-library' }
 uuid = "1.0"
 
 [patch.crates-io]
-uuid = { git = 'https://github.com/rust-lang-nursery/uuid', version = '2.0.0' }
+uuid = { git = 'https://github.com/rust-lang-nursery/uuid', branch = '2.0.0' }
 ```
 
 Note that this will actually resolve to two versions of the `uuid` crate. The


### PR DESCRIPTION
IMHO There some inconsistency in https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#prepublishing-a-breaking-change
We have unpublished version 2.0.0 for uuid crate in branch with same name.
Now we can test it in `my-library` without waiting for publish as written in docs.
But if `my-library` changes committed to its master, for `my-binary` patch need be same as in library,
as uuid 2.0.0 still not published.