### PR TITLE
Lie a little less about what's Running

### DIFF
--- a/src/cargo/util/process_builder.rs
+++ b/src/cargo/util/process_builder.rs
@@ -30,7 +30,13 @@ pub struct ProcessBuilder {
 
 impl fmt::Display for ProcessBuilder {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "`{}", self.program.to_string_lossy())?;
+        write!(f, "`");
+
+        for (key, value) in self.env.iter() {
+            write!(f, "{}={} ", key, escape(value.as_ref().unwrap_or(&OsString::from("")).to_string_lossy()));
+        }
+
+        write!(f, "{}", self.program.to_string_lossy())?;
 
         for arg in &self.args {
             write!(f, " {}", escape(arg.to_string_lossy()))?;

--- a/src/cargo/util/process_builder.rs
+++ b/src/cargo/util/process_builder.rs
@@ -30,10 +30,10 @@ pub struct ProcessBuilder {
 
 impl fmt::Display for ProcessBuilder {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "`");
+        write!(f, "`")?;
 
         for (key, value) in self.env.iter() {
-            write!(f, "{}={} ", key, escape(value.as_ref().unwrap_or(&OsString::from("")).to_string_lossy()));
+            write!(f, "{}={} ", key, escape(value.as_ref().unwrap_or(&OsString::from("")).to_string_lossy()))?;
         }
 
         write!(f, "{}", self.program.to_string_lossy())?;

--- a/tests/testsuite/bench.rs
+++ b/tests/testsuite/bench.rs
@@ -216,7 +216,7 @@ fn cargo_bench_verbose() {
         .with_stderr(
             "\
 [COMPILING] foo v0.5.0 ([CWD])
-[RUNNING] `rustc [..] src/main.rs [..]`
+[RUNNING] `[..] rustc [..] src/main.rs [..]`
 [FINISHED] release [optimized] target(s) in [..]
 [RUNNING] `[..]target/release/deps/foo-[..][EXE] hello --bench`",
         ).with_stdout_contains("test bench_hello ... bench: [..]")
@@ -1039,12 +1039,12 @@ fn bench_with_examples() {
         .with_stderr(
             "\
 [COMPILING] foo v6.6.6 ([CWD])
-[RUNNING] `rustc [..]`
-[RUNNING] `rustc [..]`
-[RUNNING] `rustc [..]`
+[RUNNING] `[..] rustc [..]`
+[RUNNING] `[..] rustc [..]`
+[RUNNING] `[..] rustc [..]`
 [FINISHED] release [optimized] target(s) in [..]
-[RUNNING] `[CWD]/target/release/deps/foo-[..][EXE] --bench`
-[RUNNING] `[CWD]/target/release/deps/testb1-[..][EXE] --bench`",
+[RUNNING] `[..] [CWD]/target/release/deps/foo-[..][EXE] --bench`
+[RUNNING] `[..] [CWD]/target/release/deps/testb1-[..][EXE] --bench`",
         ).with_stdout_contains("test bench_bench1 ... bench: [..]")
         .with_stdout_contains("test bench_bench2 ... bench: [..]")
         .run();

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -48,13 +48,13 @@ fn cargo_compile_incremental() {
     p.cargo("build -v")
         .env("CARGO_INCREMENTAL", "1")
         .with_stderr_contains(
-            "[RUNNING] `rustc [..] -C incremental=[..]/target/debug/incremental[..]`\n",
+            "[RUNNING] `[..] rustc [..] -C incremental=[..]/target/debug/incremental[..]`\n",
         ).run();
 
     p.cargo("test -v")
         .env("CARGO_INCREMENTAL", "1")
         .with_stderr_contains(
-            "[RUNNING] `rustc [..] -C incremental=[..]/target/debug/incremental[..]`\n",
+            "[RUNNING] `[..] rustc [..] -C incremental=[..]/target/debug/incremental[..]`\n",
         ).run();
 }
 
@@ -1261,14 +1261,14 @@ fn cargo_default_env_metadata_env_var() {
         .with_stderr(&format!(
             "\
 [COMPILING] bar v0.0.1 ([CWD]/bar)
-[RUNNING] `rustc --crate-name bar bar/src/lib.rs --color never --crate-type dylib \
+[RUNNING] `[..] rustc --crate-name bar bar/src/lib.rs --color never --crate-type dylib \
         --emit=dep-info,link \
         -C prefer-dynamic -C debuginfo=2 \
         -C metadata=[..] \
         --out-dir [..] \
         -L dependency=[CWD]/target/debug/deps`
 [COMPILING] foo v0.0.1 ([CWD])
-[RUNNING] `rustc --crate-name foo src/lib.rs --color never --crate-type lib \
+[RUNNING] `[..] rustc --crate-name foo src/lib.rs --color never --crate-type lib \
         --emit=dep-info,link -C debuginfo=2 \
         -C metadata=[..] \
         -C extra-filename=[..] \
@@ -1288,14 +1288,14 @@ fn cargo_default_env_metadata_env_var() {
         .with_stderr(&format!(
             "\
 [COMPILING] bar v0.0.1 ([CWD]/bar)
-[RUNNING] `rustc --crate-name bar bar/src/lib.rs --color never --crate-type dylib \
+[RUNNING] `[..] rustc --crate-name bar bar/src/lib.rs --color never --crate-type dylib \
         --emit=dep-info,link \
         -C prefer-dynamic -C debuginfo=2 \
         -C metadata=[..] \
         --out-dir [..] \
         -L dependency=[CWD]/target/debug/deps`
 [COMPILING] foo v0.0.1 ([CWD])
-[RUNNING] `rustc --crate-name foo src/lib.rs --color never --crate-type lib \
+[RUNNING] `[..] rustc --crate-name foo src/lib.rs --color never --crate-type lib \
         --emit=dep-info,link -C debuginfo=2 \
         -C metadata=[..] \
         -C extra-filename=[..] \
@@ -1616,7 +1616,7 @@ fn lto_build() {
         .with_stderr(
             "\
 [COMPILING] test v0.0.0 ([CWD])
-[RUNNING] `rustc --crate-name test src/main.rs --color never --crate-type bin \
+[RUNNING] `[..] rustc --crate-name test src/main.rs --color never --crate-type bin \
         --emit=dep-info,link \
         -C opt-level=3 \
         -C lto \
@@ -1635,7 +1635,7 @@ fn verbose_build() {
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([CWD])
-[RUNNING] `rustc --crate-name foo src/lib.rs --color never --crate-type lib \
+[RUNNING] `[..] rustc --crate-name foo src/lib.rs --color never --crate-type lib \
         --emit=dep-info,link -C debuginfo=2 \
         -C metadata=[..] \
         --out-dir [..] \
@@ -1652,7 +1652,7 @@ fn verbose_release_build() {
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([CWD])
-[RUNNING] `rustc --crate-name foo src/lib.rs --color never --crate-type lib \
+[RUNNING] `[..] rustc --crate-name foo src/lib.rs --color never --crate-type lib \
         --emit=dep-info,link \
         -C opt-level=3 \
         -C metadata=[..] \
@@ -1698,7 +1698,7 @@ fn verbose_release_build_deps() {
         .with_stderr(&format!(
             "\
 [COMPILING] foo v0.0.0 ([CWD]/foo)
-[RUNNING] `rustc --crate-name foo foo/src/lib.rs --color never \
+[RUNNING] `[..] rustc --crate-name foo foo/src/lib.rs --color never \
         --crate-type dylib --crate-type rlib \
         --emit=dep-info,link \
         -C prefer-dynamic \
@@ -1707,7 +1707,7 @@ fn verbose_release_build_deps() {
         --out-dir [..] \
         -L dependency=[CWD]/target/release/deps`
 [COMPILING] test v0.0.0 ([CWD])
-[RUNNING] `rustc --crate-name test src/lib.rs --color never --crate-type lib \
+[RUNNING] `[..] rustc --crate-name test src/lib.rs --color never --crate-type lib \
         --emit=dep-info,link \
         -C opt-level=3 \
         -C metadata=[..] \
@@ -2982,7 +2982,7 @@ fn explicit_color_config_is_propagated_to_rustc() {
         .with_stderr(
             "\
 [COMPILING] test v0.0.0 ([..])
-[RUNNING] `rustc [..] --color never [..]`
+[RUNNING] `[..] rustc [..] --color never [..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ).run();
@@ -3669,7 +3669,7 @@ fn rustc_wrapper() {
 
     p.cargo("build -v")
         .env("RUSTC_WRAPPER", "/usr/bin/env")
-        .with_stderr_contains("[RUNNING] `/usr/bin/env rustc --crate-name foo [..]")
+        .with_stderr_contains("[RUNNING] `[..] /usr/bin/env rustc --crate-name foo [..]")
         .run();
 }
 
@@ -3780,7 +3780,7 @@ fn deterministic_cfg_flags() {
 [COMPILING] foo v0.1.0 [..]
 [RUNNING] [..]
 [RUNNING] [..]
-[RUNNING] `rustc --crate-name foo [..] \
+[RUNNING] `[..] rustc --crate-name foo [..] \
 --cfg[..]default[..]--cfg[..]f_a[..]--cfg[..]f_b[..]\
 --cfg[..]f_c[..]--cfg[..]f_d[..] \
 --cfg cfg_a --cfg cfg_b --cfg cfg_c --cfg cfg_d --cfg cfg_e`
@@ -3942,7 +3942,7 @@ fn target_edition() {
         .with_stderr_contains(
             "\
 [COMPILING] foo v0.0.1 ([..])
-[RUNNING] `rustc [..]--edition=2018 [..]
+[RUNNING] `[..] rustc [..]--edition=2018 [..]
 ",
         ).run();
 }
@@ -4099,11 +4099,11 @@ fn build_filter_infer_profile() {
     p.cargo("build -v")
         .with_stderr_contains(
             "\
-             [RUNNING] `rustc --crate-name foo src/lib.rs --color never --crate-type lib \
+             [RUNNING] `[..] rustc --crate-name foo src/lib.rs --color never --crate-type lib \
              --emit=dep-info,link[..]",
         ).with_stderr_contains(
             "\
-             [RUNNING] `rustc --crate-name foo src/main.rs --color never --crate-type bin \
+             [RUNNING] `[..] rustc --crate-name foo src/main.rs --color never --crate-type bin \
              --emit=dep-info,link[..]",
         ).run();
 
@@ -4111,13 +4111,13 @@ fn build_filter_infer_profile() {
     p.cargo("build -v --test=t1")
         .with_stderr_contains(
             "\
-             [RUNNING] `rustc --crate-name foo src/lib.rs --color never --crate-type lib \
+             [RUNNING] `[..] rustc --crate-name foo src/lib.rs --color never --crate-type lib \
              --emit=dep-info,link[..]",
         ).with_stderr_contains(
-            "[RUNNING] `rustc --crate-name t1 tests/t1.rs --color never --emit=dep-info,link[..]",
+            "[RUNNING] `[..] rustc --crate-name t1 tests/t1.rs --color never --emit=dep-info,link[..]",
         ).with_stderr_contains(
             "\
-             [RUNNING] `rustc --crate-name foo src/main.rs --color never --crate-type bin \
+             [RUNNING] `[..] rustc --crate-name foo src/main.rs --color never --crate-type bin \
              --emit=dep-info,link[..]",
         ).run();
 
@@ -4125,15 +4125,15 @@ fn build_filter_infer_profile() {
     p.cargo("build -v --bench=b1")
         .with_stderr_contains(
             "\
-             [RUNNING] `rustc --crate-name foo src/lib.rs --color never --crate-type lib \
+             [RUNNING] `[..] rustc --crate-name foo src/lib.rs --color never --crate-type lib \
              --emit=dep-info,link[..]",
         ).with_stderr_contains(
             "\
-             [RUNNING] `rustc --crate-name b1 benches/b1.rs --color never --emit=dep-info,link \
+             [RUNNING] `[..] rustc --crate-name b1 benches/b1.rs --color never --emit=dep-info,link \
              -C opt-level=3[..]",
         ).with_stderr_contains(
             "\
-             [RUNNING] `rustc --crate-name foo src/main.rs --color never --crate-type bin \
+             [RUNNING] `[..] rustc --crate-name foo src/main.rs --color never --crate-type bin \
              --emit=dep-info,link[..]",
         ).run();
 }
@@ -4144,15 +4144,15 @@ fn targets_selected_default() {
     p.cargo("build -v")
         // bin
         .with_stderr_contains("\
-            [RUNNING] `rustc --crate-name foo src/main.rs --color never --crate-type bin \
+            [RUNNING] `[..] rustc --crate-name foo src/main.rs --color never --crate-type bin \
             --emit=dep-info,link[..]")
         // bench
         .with_stderr_does_not_contain("\
-            [RUNNING] `rustc --crate-name foo src/main.rs --color never --emit=dep-info,link \
+            [RUNNING] `[..] rustc --crate-name foo src/main.rs --color never --emit=dep-info,link \
             -C opt-level=3 --test [..]")
         // unit test
         .with_stderr_does_not_contain("\
-            [RUNNING] `rustc --crate-name foo src/main.rs --color never --emit=dep-info,link \
+            [RUNNING] `[..] rustc --crate-name foo src/main.rs --color never --emit=dep-info,link \
             -C debuginfo=2 --test [..]").run();
 }
 
@@ -4162,15 +4162,15 @@ fn targets_selected_all() {
     p.cargo("build -v --all-targets")
         // bin
         .with_stderr_contains("\
-            [RUNNING] `rustc --crate-name foo src/main.rs --color never --crate-type bin \
+            [RUNNING] `[..] rustc --crate-name foo src/main.rs --color never --crate-type bin \
             --emit=dep-info,link[..]")
         // bench
         .with_stderr_contains("\
-            [RUNNING] `rustc --crate-name foo src/main.rs --color never --emit=dep-info,link \
+            [RUNNING] `[..] rustc --crate-name foo src/main.rs --color never --emit=dep-info,link \
             -C opt-level=3 --test [..]")
         // unit test
         .with_stderr_contains("\
-            [RUNNING] `rustc --crate-name foo src/main.rs --color never --emit=dep-info,link \
+            [RUNNING] `[..] rustc --crate-name foo src/main.rs --color never --emit=dep-info,link \
             -C debuginfo=2 --test [..]").run();
 }
 
@@ -4180,15 +4180,15 @@ fn all_targets_no_lib() {
     p.cargo("build -v --all-targets")
         // bin
         .with_stderr_contains("\
-            [RUNNING] `rustc --crate-name foo src/main.rs --color never --crate-type bin \
+            [RUNNING] `[..] rustc --crate-name foo src/main.rs --color never --crate-type bin \
             --emit=dep-info,link[..]")
         // bench
         .with_stderr_contains("\
-            [RUNNING] `rustc --crate-name foo src/main.rs --color never --emit=dep-info,link \
+            [RUNNING] `[..] rustc --crate-name foo src/main.rs --color never --emit=dep-info,link \
             -C opt-level=3 --test [..]")
         // unit test
         .with_stderr_contains("\
-            [RUNNING] `rustc --crate-name foo src/main.rs --color never --emit=dep-info,link \
+            [RUNNING] `[..] rustc --crate-name foo src/main.rs --color never --emit=dep-info,link \
             -C debuginfo=2 --test [..]").run();
 }
 
@@ -4293,13 +4293,13 @@ Did you mean `ex1`?",
 
     ws.cargo("build -v --lib")
         .with_status(0)
-        .with_stderr_contains("[RUNNING] `rustc [..]a/src/lib.rs[..]")
+        .with_stderr_contains("[RUNNING] `[..] rustc [..]a/src/lib.rs[..]")
         .run();
 
     ws.cargo("build -v --example ex1")
         .with_status(0)
-        .with_stderr_contains("[RUNNING] `rustc [..]a/examples/ex1.rs[..]")
-        .with_stderr_contains("[RUNNING] `rustc [..]b/examples/ex1.rs[..]")
+        .with_stderr_contains("[RUNNING] `[..] rustc [..]a/examples/ex1.rs[..]")
+        .with_stderr_contains("[RUNNING] `[..] rustc [..]b/examples/ex1.rs[..]")
         .run();
 }
 

--- a/tests/testsuite/build_lib.rs
+++ b/tests/testsuite/build_lib.rs
@@ -11,7 +11,7 @@ fn build_lib_only() {
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([CWD])
-[RUNNING] `rustc --crate-name foo src/lib.rs --color never --crate-type lib \
+[RUNNING] `[..] rustc --crate-name foo src/lib.rs --color never --crate-type lib \
         --emit=dep-info,link -C debuginfo=2 \
         -C metadata=[..] \
         --out-dir [..] \

--- a/tests/testsuite/build_script.rs
+++ b/tests/testsuite/build_script.rs
@@ -1148,7 +1148,7 @@ fn code_generation() {
             "\
 [COMPILING] foo v0.5.0 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] `target/debug/foo`",
+[RUNNING] `[..] target/debug/foo`",
         ).with_stdout("Hello, World!")
         .run();
 

--- a/tests/testsuite/build_script.rs
+++ b/tests/testsuite/build_script.rs
@@ -32,7 +32,7 @@ fn custom_build_script_failed() {
         .with_stderr(
             "\
 [COMPILING] foo v0.5.0 ([CWD])
-[RUNNING] `rustc --crate-name build_script_build build.rs --color never --crate-type bin [..]`
+[RUNNING] `[..] rustc --crate-name build_script_build build.rs --color never --crate-type bin [..]`
 [RUNNING] `[..]/build-script-build`
 [ERROR] failed to run custom build command for `foo v0.5.0 ([CWD])`
 process didn't exit successfully: `[..]/build-script-build` (exit code: 101)",
@@ -229,7 +229,7 @@ fn custom_build_script_rustc_flags() {
         .with_stderr(
             "\
 [COMPILING] bar v0.5.0 ([CWD])
-[RUNNING] `rustc --crate-name test [CWD]/src/lib.rs --crate-type lib -C debuginfo=2 \
+[RUNNING] `[..] rustc --crate-name test [CWD]/src/lib.rs --crate-type lib -C debuginfo=2 \
         -C metadata=[..] \
         -C extra-filename=-[..] \
         --out-dir [CWD]/target \
@@ -435,7 +435,7 @@ fn overrides_and_links() {
 [..]
 [..]
 [..]
-[RUNNING] `rustc --crate-name foo [..] -L foo -L bar`
+[RUNNING] `[..] rustc --crate-name foo [..] -L foo -L bar`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ).run();
@@ -553,7 +553,7 @@ fn only_rerun_build_script() {
             "\
 [COMPILING] foo v0.5.0 ([CWD])
 [RUNNING] `[..]/build-script-build`
-[RUNNING] `rustc --crate-name foo [..]`
+[RUNNING] `[..] rustc --crate-name foo [..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ).run();
@@ -653,12 +653,12 @@ fn testing_and_such() {
             "\
 [COMPILING] foo v0.5.0 ([CWD])
 [RUNNING] `[..]/build-script-build`
-[RUNNING] `rustc --crate-name foo [..]`
-[RUNNING] `rustc --crate-name foo [..]`
+[RUNNING] `[..] rustc --crate-name foo [..]`
+[RUNNING] `[..] rustc --crate-name foo [..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `[..]/foo-[..][EXE]`
 [DOCTEST] foo
-[RUNNING] `rustdoc --test [..]`",
+[RUNNING] `[..] rustdoc --test [..]`",
         ).with_stdout_contains_n("running 0 tests", 2)
         .run();
 
@@ -667,7 +667,7 @@ fn testing_and_such() {
         .with_stderr(
             "\
 [DOCUMENTING] foo v0.5.0 ([CWD])
-[RUNNING] `rustdoc [..]`
+[RUNNING] `[..] rustdoc [..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ).run();
@@ -682,7 +682,7 @@ fn testing_and_such() {
             "\
 [COMPILING] foo v0.5.0 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] `target/debug/foo[EXE]`
+[RUNNING] `[..] target/debug/foo[EXE]`
 ",
         ).run();
 }
@@ -745,9 +745,9 @@ fn propagation_of_l_flags() {
     p.cargo("build -v -j1")
         .with_stderr_contains(
             "\
-[RUNNING] `rustc --crate-name a [..] -L bar[..]-L foo[..]`
+[RUNNING] `[..] rustc --crate-name a [..] -L bar[..]-L foo[..]`
 [COMPILING] foo v0.5.0 ([CWD])
-[RUNNING] `rustc --crate-name foo [..] -L bar -L foo`
+[RUNNING] `[..] rustc --crate-name foo [..] -L bar -L foo`
 ",
         ).run();
 }
@@ -814,9 +814,9 @@ fn propagation_of_l_flags_new() {
     p.cargo("build -v -j1")
         .with_stderr_contains(
             "\
-[RUNNING] `rustc --crate-name a [..] -L bar[..]-L foo[..]`
+[RUNNING] `[..] rustc --crate-name a [..] -L bar[..]-L foo[..]`
 [COMPILING] foo v0.5.0 ([CWD])
-[RUNNING] `rustc --crate-name foo [..] -L bar -L foo`
+[RUNNING] `[..] rustc --crate-name foo [..] -L bar -L foo`
 ",
         ).run();
 }
@@ -851,11 +851,11 @@ fn build_deps_simple() {
         .with_stderr(
             "\
 [COMPILING] a v0.5.0 ([CWD]/a)
-[RUNNING] `rustc --crate-name a [..]`
+[RUNNING] `[..] rustc --crate-name a [..]`
 [COMPILING] foo v0.5.0 ([CWD])
-[RUNNING] `rustc [..] build.rs [..] --extern a=[..]`
+[RUNNING] `[..] rustc [..] build.rs [..] --extern a=[..]`
 [RUNNING] `[..]/foo-[..]/build-script-build`
-[RUNNING] `rustc --crate-name foo [..]`
+[RUNNING] `[..] rustc --crate-name foo [..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ).run();
@@ -951,23 +951,23 @@ fn build_cmd_with_a_build_cmd() {
         .with_stderr(
             "\
 [COMPILING] b v0.5.0 ([CWD]/b)
-[RUNNING] `rustc --crate-name b [..]`
+[RUNNING] `[..] rustc --crate-name b [..]`
 [COMPILING] a v0.5.0 ([CWD]/a)
-[RUNNING] `rustc [..] a/build.rs [..] --extern b=[..]`
+[RUNNING] `[..] rustc [..] a/build.rs [..] --extern b=[..]`
 [RUNNING] `[..]/a-[..]/build-script-build`
-[RUNNING] `rustc --crate-name a [..]lib.rs --color never --crate-type lib \
+[RUNNING] `[..] rustc --crate-name a [..]lib.rs --color never --crate-type lib \
     --emit=dep-info,link -C debuginfo=2 \
     -C metadata=[..] \
     --out-dir [..]target/debug/deps \
     -L [..]target/debug/deps`
 [COMPILING] foo v0.5.0 ([CWD])
-[RUNNING] `rustc --crate-name build_script_build build.rs --color never --crate-type bin \
+[RUNNING] `[..] rustc --crate-name build_script_build build.rs --color never --crate-type bin \
     --emit=dep-info,link \
     -C debuginfo=2 -C metadata=[..] --out-dir [..] \
     -L [..]target/debug/deps \
     --extern a=[..]liba[..].rlib`
 [RUNNING] `[..]/foo-[..]/build-script-build`
-[RUNNING] `rustc --crate-name foo [..]lib.rs --color never --crate-type lib \
+[RUNNING] `[..] rustc --crate-name foo [..]lib.rs --color never --crate-type lib \
     --emit=dep-info,link -C debuginfo=2 \
     -C metadata=[..] \
     --out-dir [..] \
@@ -1058,9 +1058,9 @@ fn output_separate_lines() {
         .with_stderr_contains(
             "\
 [COMPILING] foo v0.5.0 ([CWD])
-[RUNNING] `rustc [..] build.rs [..]`
+[RUNNING] `[..] rustc [..] build.rs [..]`
 [RUNNING] `[..]/foo-[..]/build-script-build`
-[RUNNING] `rustc --crate-name foo [..] -L foo -l static=foo`
+[RUNNING] `[..] rustc --crate-name foo [..] -L foo -l static=foo`
 [ERROR] could not find native static library [..]
 ",
         ).run();
@@ -1093,9 +1093,9 @@ fn output_separate_lines_new() {
         .with_stderr_contains(
             "\
 [COMPILING] foo v0.5.0 ([CWD])
-[RUNNING] `rustc [..] build.rs [..]`
+[RUNNING] `[..] rustc [..] build.rs [..]`
 [RUNNING] `[..]/foo-[..]/build-script-build`
-[RUNNING] `rustc --crate-name foo [..] -L foo -l static=foo`
+[RUNNING] `[..] rustc --crate-name foo [..] -L foo -l static=foo`
 [ERROR] could not find native static library [..]
 ",
         ).run();
@@ -1990,14 +1990,14 @@ fn flags_go_into_tests() {
         .with_stderr(
             "\
 [COMPILING] a v0.5.0 ([..]
-[RUNNING] `rustc [..] a/build.rs [..]`
+[RUNNING] `[..] rustc [..] a/build.rs [..]`
 [RUNNING] `[..]/build-script-build`
-[RUNNING] `rustc [..] a/src/lib.rs [..] -L test[..]`
+[RUNNING] `[..] rustc [..] a/src/lib.rs [..] -L test[..]`
 [COMPILING] b v0.5.0 ([..]
-[RUNNING] `rustc [..] b/src/lib.rs [..] -L test[..]`
+[RUNNING] `[..] rustc [..] b/src/lib.rs [..] -L test[..]`
 [COMPILING] foo v0.5.0 ([..]
-[RUNNING] `rustc [..] src/lib.rs [..] -L test[..]`
-[RUNNING] `rustc [..] tests/foo.rs [..] -L test[..]`
+[RUNNING] `[..] rustc [..] src/lib.rs [..] -L test[..]`
+[RUNNING] `[..] rustc [..] tests/foo.rs [..] -L test[..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `[..]/foo-[..][EXE]`",
         ).with_stdout_contains("running 0 tests")
@@ -2008,7 +2008,7 @@ fn flags_go_into_tests() {
             "\
 [FRESH] a v0.5.0 ([..]
 [COMPILING] b v0.5.0 ([..]
-[RUNNING] `rustc [..] b/src/lib.rs [..] -L test[..]`
+[RUNNING] `[..] rustc [..] b/src/lib.rs [..] -L test[..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `[..]/b-[..][EXE]`",
         ).with_stdout_contains("running 0 tests")
@@ -2078,13 +2078,13 @@ fn diamond_passes_args_only_once() {
         .with_stderr(
             "\
 [COMPILING] c v0.5.0 ([..]
-[RUNNING] `rustc [..]`
+[RUNNING] `[..] rustc [..]`
 [RUNNING] `[..]`
-[RUNNING] `rustc [..]`
+[RUNNING] `[..] rustc [..]`
 [COMPILING] b v0.5.0 ([..]
-[RUNNING] `rustc [..]`
+[RUNNING] `[..] rustc [..]`
 [COMPILING] a v0.5.0 ([..]
-[RUNNING] `rustc [..]`
+[RUNNING] `[..] rustc [..]`
 [COMPILING] foo v0.5.0 ([..]
 [RUNNING] `[..]rlib -L native=test`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
@@ -2121,9 +2121,9 @@ fn adding_an_override_invalidates() {
         .with_stderr(
             "\
 [COMPILING] foo v0.5.0 ([..]
-[RUNNING] `rustc [..]`
+[RUNNING] `[..] rustc [..]`
 [RUNNING] `[..]`
-[RUNNING] `rustc [..] -L native=foo`
+[RUNNING] `[..] rustc [..] -L native=foo`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ).run();
@@ -2144,7 +2144,7 @@ fn adding_an_override_invalidates() {
         .with_stderr(
             "\
 [COMPILING] foo v0.5.0 ([..]
-[RUNNING] `rustc [..] -L native=bar`
+[RUNNING] `[..] rustc [..] -L native=bar`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ).run();
@@ -2181,7 +2181,7 @@ fn changing_an_override_invalidates() {
         .with_stderr(
             "\
 [COMPILING] foo v0.5.0 ([..]
-[RUNNING] `rustc [..] -L native=foo`
+[RUNNING] `[..] rustc [..] -L native=foo`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ).run();
@@ -2202,7 +2202,7 @@ fn changing_an_override_invalidates() {
         .with_stderr(
             "\
 [COMPILING] foo v0.5.0 ([..]
-[RUNNING] `rustc [..] -L native=bar`
+[RUNNING] `[..] rustc [..] -L native=bar`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ).run();
@@ -2242,7 +2242,7 @@ fn fresh_builds_possible_with_link_libs() {
         .with_stderr(
             "\
 [COMPILING] foo v0.5.0 ([..]
-[RUNNING] `rustc [..]`
+[RUNNING] `[..] rustc [..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ).run();
@@ -2293,7 +2293,7 @@ fn fresh_builds_possible_with_multiple_metadata_overrides() {
         .with_stderr(
             "\
 [COMPILING] foo v0.5.0 ([..]
-[RUNNING] `rustc [..]`
+[RUNNING] `[..] rustc [..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ).run();
@@ -2340,7 +2340,7 @@ fn rebuild_only_on_explicit_paths() {
             "\
 [COMPILING] foo v0.5.0 ([..])
 [RUNNING] `[..]/build-script-build`
-[RUNNING] `rustc [..] src/lib.rs [..]`
+[RUNNING] `[..] rustc [..] src/lib.rs [..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ).run();
@@ -2357,7 +2357,7 @@ fn rebuild_only_on_explicit_paths() {
             "\
 [COMPILING] foo v0.5.0 ([..])
 [RUNNING] `[..]/build-script-build`
-[RUNNING] `rustc [..] src/lib.rs [..]`
+[RUNNING] `[..] rustc [..] src/lib.rs [..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ).run();
@@ -2392,7 +2392,7 @@ fn rebuild_only_on_explicit_paths() {
             "\
 [COMPILING] foo v0.5.0 ([..])
 [RUNNING] `[..]/build-script-build`
-[RUNNING] `rustc [..] src/lib.rs [..]`
+[RUNNING] `[..] rustc [..] src/lib.rs [..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ).run();
@@ -2405,7 +2405,7 @@ fn rebuild_only_on_explicit_paths() {
             "\
 [COMPILING] foo v0.5.0 ([..])
 [RUNNING] `[..]/build-script-build`
-[RUNNING] `rustc [..] src/lib.rs [..]`
+[RUNNING] `[..] rustc [..] src/lib.rs [..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ).run();
@@ -2447,7 +2447,7 @@ fn doctest_receives_build_link_args() {
 
     p.cargo("test -v")
         .with_stderr_contains(
-            "[RUNNING] `rustdoc --test [..] --crate-name foo [..]-L native=bar[..]`",
+            "[RUNNING] `[..] rustdoc --test [..] --crate-name foo [..]-L native=bar[..]`",
         ).run();
 }
 
@@ -2495,7 +2495,7 @@ fn please_respect_the_dag() {
         ).build();
 
     p.cargo("build -v")
-        .with_stderr_contains("[RUNNING] `rustc [..] -L native=foo -L native=bar[..]`")
+        .with_stderr_contains("[RUNNING] `[..] rustc [..] -L native=foo -L native=bar[..]`")
         .run();
 }
 
@@ -2655,11 +2655,11 @@ fn warnings_emitted() {
         .with_stderr(
             "\
 [COMPILING] foo v0.5.0 ([..])
-[RUNNING] `rustc [..]`
+[RUNNING] `[..] rustc [..]`
 [RUNNING] `[..]`
 warning: foo
 warning: bar
-[RUNNING] `rustc [..]`
+[RUNNING] `[..] rustc [..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ).run();
@@ -2709,11 +2709,11 @@ fn warnings_hidden_for_upstream() {
 [UPDATING] `[..]` index
 [DOWNLOADING] bar v0.1.0 ([..])
 [COMPILING] bar v0.1.0
-[RUNNING] `rustc [..]`
+[RUNNING] `[..] rustc [..]`
 [RUNNING] `[..]`
-[RUNNING] `rustc [..]`
+[RUNNING] `[..] rustc [..]`
 [COMPILING] foo v0.5.0 ([..])
-[RUNNING] `rustc [..]`
+[RUNNING] `[..] rustc [..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ).run();
@@ -2763,13 +2763,13 @@ fn warnings_printed_on_vv() {
 [UPDATING] `[..]` index
 [DOWNLOADING] bar v0.1.0 ([..])
 [COMPILING] bar v0.1.0
-[RUNNING] `rustc [..]`
+[RUNNING] `[..] rustc [..]`
 [RUNNING] `[..]`
 warning: foo
 warning: bar
-[RUNNING] `rustc [..]`
+[RUNNING] `[..] rustc [..]`
 [COMPILING] foo v0.5.0 ([..])
-[RUNNING] `rustc [..]`
+[RUNNING] `[..] rustc [..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ).run();
@@ -2805,10 +2805,10 @@ fn output_shows_on_vv() {
         .with_stderr(
             "\
 [COMPILING] foo v0.5.0 ([..])
-[RUNNING] `rustc [..]`
+[RUNNING] `[..] rustc [..]`
 [RUNNING] `[..]`
 stderr
-[RUNNING] `rustc [..]`
+[RUNNING] `[..] rustc [..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ).run();
@@ -2849,7 +2849,7 @@ fn links_with_dots() {
         ).build();
 
     p.cargo("build -v")
-        .with_stderr_contains("[RUNNING] `rustc --crate-name foo [..] [..] -L foo[..]`")
+        .with_stderr_contains("[RUNNING] `[..] rustc --crate-name foo [..] [..] -L foo[..]`")
         .run();
 }
 
@@ -3120,7 +3120,7 @@ fn deterministic_rustc_dependency_flags() {
     p.cargo("build -v")
         .with_stderr_contains(
             "\
-[RUNNING] `rustc --crate-name foo [..] -L native=test1 -L native=test2 \
+[RUNNING] `[..] rustc --crate-name foo [..] -L native=test1 -L native=test2 \
 -L native=test3 -L native=test4`
 ",
         ).run();

--- a/tests/testsuite/cargo_alias_config.rs
+++ b/tests/testsuite/cargo_alias_config.rs
@@ -57,7 +57,7 @@ fn alias_config() {
         .with_stderr_contains(
             "\
 [COMPILING] foo v0.5.0 [..]
-[RUNNING] `rustc --crate-name foo [..]",
+[RUNNING] `[..] rustc --crate-name foo [..]",
         ).run();
 }
 
@@ -79,7 +79,7 @@ fn recursive_alias() {
         .with_stderr_contains(
             "\
 [COMPILING] foo v0.5.0 [..]
-[RUNNING] `rustc --crate-name foo [..]",
+[RUNNING] `[..] rustc --crate-name foo [..]",
         ).run();
 }
 
@@ -98,7 +98,7 @@ fn alias_list_test() {
 
     p.cargo("b-cargo-test -v")
         .with_stderr_contains("[COMPILING] foo v0.5.0 [..]")
-        .with_stderr_contains("[RUNNING] `rustc --crate-name [..]")
+        .with_stderr_contains("[RUNNING] `[..] rustc --crate-name [..]")
         .run();
 }
 
@@ -117,7 +117,7 @@ fn alias_with_flags_config() {
 
     p.cargo("b-cargo-test -v")
         .with_stderr_contains("[COMPILING] foo v0.5.0 [..]")
-        .with_stderr_contains("[RUNNING] `rustc --crate-name foo [..]")
+        .with_stderr_contains("[RUNNING] `[..] rustc --crate-name foo [..]")
         .run();
 }
 

--- a/tests/testsuite/clean.rs
+++ b/tests/testsuite/clean.rs
@@ -187,9 +187,9 @@ fn build_script() {
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([..])
-[RUNNING] `rustc [..] build.rs [..]`
+[RUNNING] `[..] rustc [..] build.rs [..]`
 [RUNNING] `[..]build-script-build`
-[RUNNING] `rustc [..] src/main.rs [..]`
+[RUNNING] `[..] rustc [..] src/main.rs [..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ).run();

--- a/tests/testsuite/cross_compile.rs
+++ b/tests/testsuite/cross_compile.rs
@@ -358,7 +358,7 @@ fn linker_and_ar() {
         .with_stderr_contains(&format!(
             "\
 [COMPILING] foo v0.5.0 ([CWD])
-[RUNNING] `rustc --crate-name foo src/foo.rs --color never --crate-type bin \
+[RUNNING] `[..] rustc --crate-name foo src/foo.rs --color never --crate-type bin \
     --emit=dep-info,link -C debuginfo=2 \
     -C metadata=[..] \
     --out-dir [CWD]/target/{target}/debug/deps \
@@ -644,9 +644,9 @@ fn cross_with_a_build_script() {
         .with_stderr(&format!(
             "\
 [COMPILING] foo v0.0.0 ([CWD])
-[RUNNING] `rustc [..] build.rs [..] --out-dir [CWD]/target/debug/build/foo-[..]`
-[RUNNING] `[CWD]/target/debug/build/foo-[..]/build-script-build`
-[RUNNING] `rustc [..] src/main.rs [..] --target {target} [..]`
+[RUNNING] `[..] rustc [..] build.rs [..] --out-dir [CWD]/target/debug/build/foo-[..]`
+[RUNNING] `[..] [CWD]/target/debug/build/foo-[..]/build-script-build`
+[RUNNING] `[..] rustc [..] src/main.rs [..] --target {target} [..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
             target = target,
@@ -733,22 +733,22 @@ fn build_script_needed_for_host_and_target() {
         .arg(&target)
         .with_stderr_contains(&"[COMPILING] d1 v0.0.0 ([CWD]/d1)")
         .with_stderr_contains(
-            "[RUNNING] `rustc [..] d1/build.rs [..] --out-dir [CWD]/target/debug/build/d1-[..]`",
+            "[RUNNING] `[..] rustc [..] d1/build.rs [..] --out-dir [CWD]/target/debug/build/d1-[..]`",
         )
-        .with_stderr_contains("[RUNNING] `[CWD]/target/debug/build/d1-[..]/build-script-build`")
-        .with_stderr_contains("[RUNNING] `rustc [..] d1/src/lib.rs [..]`")
+        .with_stderr_contains("[RUNNING] `[..] [CWD]/target/debug/build/d1-[..]/build-script-build`")
+        .with_stderr_contains("[RUNNING] `[..] rustc [..] d1/src/lib.rs [..]`")
         .with_stderr_contains("[COMPILING] d2 v0.0.0 ([CWD]/d2)")
         .with_stderr_contains(&format!(
-            "[RUNNING] `rustc [..] d2/src/lib.rs [..] -L /path/to/{host}`",
+            "[RUNNING] `[..] rustc [..] d2/src/lib.rs [..] -L /path/to/{host}`",
             host = host
         )).with_stderr_contains("[COMPILING] foo v0.0.0 ([CWD])")
         .with_stderr_contains(&format!(
-            "[RUNNING] `rustc [..] build.rs [..] --out-dir [CWD]/target/debug/build/foo-[..] \
+            "[RUNNING] `[..] rustc [..] build.rs [..] --out-dir [CWD]/target/debug/build/foo-[..] \
              -L /path/to/{host}`",
             host = host
         )).with_stderr_contains(&format!(
             "\
-             [RUNNING] `rustc [..] src/main.rs [..] --target {target} [..] \
+             [RUNNING] `[..] rustc [..] src/main.rs [..] --target {target} [..] \
              -L /path/to/{target}`",
             target = target
         )).run();
@@ -871,9 +871,9 @@ fn plugin_build_script_right_arch() {
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([..])
-[RUNNING] `rustc [..] build.rs [..]`
+[RUNNING] `[..] rustc [..] build.rs [..]`
 [RUNNING] `[..]/build-script-build`
-[RUNNING] `rustc [..] src/lib.rs [..]`
+[RUNNING] `[..] rustc [..] src/lib.rs [..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ).run();
@@ -934,13 +934,13 @@ fn build_script_with_platform_specific_dependencies() {
         .with_stderr(&format!(
             "\
 [COMPILING] d2 v0.0.0 ([..])
-[RUNNING] `rustc [..] d2/src/lib.rs [..]`
+[RUNNING] `[..] rustc [..] d2/src/lib.rs [..]`
 [COMPILING] d1 v0.0.0 ([..])
-[RUNNING] `rustc [..] d1/src/lib.rs [..]`
+[RUNNING] `[..] rustc [..] d1/src/lib.rs [..]`
 [COMPILING] foo v0.0.1 ([..])
-[RUNNING] `rustc [..] build.rs [..]`
-[RUNNING] `[CWD]/target/debug/build/foo-[..]/build-script-build`
-[RUNNING] `rustc [..] src/lib.rs [..] --target {target} [..]`
+[RUNNING] `[..] rustc [..] build.rs [..]`
+[RUNNING] `[..] [CWD]/target/debug/build/foo-[..]/build-script-build`
+[RUNNING] `[..] rustc [..] src/lib.rs [..] --target {target} [..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
             target = target

--- a/tests/testsuite/doc.rs
+++ b/tests/testsuite/doc.rs
@@ -718,7 +718,7 @@ fn doc_release() {
         .with_stderr(
             "\
 [DOCUMENTING] foo v0.0.1 ([..])
-[RUNNING] `rustdoc [..] src/lib.rs [..]`
+[RUNNING] `[..] rustdoc [..] src/lib.rs [..]`
 [FINISHED] release [optimized] target(s) in [..]
 ",
         ).run();
@@ -1118,12 +1118,12 @@ fn doc_edition() {
 
     p.cargo("doc -v")
         .masquerade_as_nightly_cargo()
-        .with_stderr_contains("[RUNNING] `rustdoc [..]-Zunstable-options --edition=2018[..]")
+        .with_stderr_contains("[RUNNING] `[..] rustdoc [..]-Zunstable-options --edition=2018[..]")
         .run();
 
     p.cargo("test -v")
         .masquerade_as_nightly_cargo()
-        .with_stderr_contains("[RUNNING] `rustdoc [..]-Zunstable-options --edition=2018[..]")
+        .with_stderr_contains("[RUNNING] `[..] rustdoc [..]-Zunstable-options --edition=2018[..]")
         .run();
 }
 
@@ -1150,12 +1150,12 @@ fn doc_target_edition() {
 
     p.cargo("doc -v")
         .masquerade_as_nightly_cargo()
-        .with_stderr_contains("[RUNNING] `rustdoc [..]-Zunstable-options --edition=2018[..]")
+        .with_stderr_contains("[RUNNING] `[..] rustdoc [..]-Zunstable-options --edition=2018[..]")
         .run();
 
     p.cargo("test -v")
         .masquerade_as_nightly_cargo()
-        .with_stderr_contains("[RUNNING] `rustdoc [..]-Zunstable-options --edition=2018[..]")
+        .with_stderr_contains("[RUNNING] `[..] rustdoc [..]-Zunstable-options --edition=2018[..]")
         .run();
 }
 

--- a/tests/testsuite/freshness.rs
+++ b/tests/testsuite/freshness.rs
@@ -750,7 +750,7 @@ fn rebuild_if_environment_changes() {
             "\
 [COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] `target/debug/foo[EXE]`
+[RUNNING] `[..] target/debug/foo[EXE]`
 ",
         ).run();
 
@@ -772,7 +772,7 @@ fn rebuild_if_environment_changes() {
             "\
 [COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] `target/debug/foo[EXE]`
+[RUNNING] `[..] target/debug/foo[EXE]`
 ",
         ).run();
 }

--- a/tests/testsuite/freshness.rs
+++ b/tests/testsuite/freshness.rs
@@ -1024,7 +1024,7 @@ fn reuse_workspace_lib() {
         .with_stderr(
             "\
 [COMPILING] baz v0.1.1 ([..])
-[RUNNING] `rustc[..] --test [..]`
+[RUNNING] `[..] rustc[..] --test [..]`
 [FINISHED] [..]
 ",
         ).run();

--- a/tests/testsuite/git.rs
+++ b/tests/testsuite/git.rs
@@ -1253,7 +1253,7 @@ fn dep_with_changed_submodule() {
              [COMPILING] foo v0.5.0 ([..])\n\
              [FINISHED] dev [unoptimized + debuginfo] target(s) in \
              [..]\n\
-             [RUNNING] `target/debug/foo[EXE]`\n",
+             [RUNNING] `[..] target/debug/foo[EXE]`\n",
         ).with_stdout("project2\n")
         .run();
 
@@ -1305,7 +1305,7 @@ fn dep_with_changed_submodule() {
              [COMPILING] foo v0.5.0 ([..])\n\
              [FINISHED] dev [unoptimized + debuginfo] target(s) in \
              [..]\n\
-             [RUNNING] `target/debug/foo[EXE]`\n",
+             [RUNNING] `[..] target/debug/foo[EXE]`\n",
         ).with_stdout("project3\n")
         .run();
 }

--- a/tests/testsuite/git.rs
+++ b/tests/testsuite/git.rs
@@ -2362,13 +2362,13 @@ fn include_overrides_gitignore() {
 [DOWNLOADING] filetime [..]
 [DOWNLOADING] libc [..]
 [COMPILING] libc [..]
-[RUNNING] `rustc --crate-name libc [..]`
+[RUNNING] `[..] rustc --crate-name libc [..]`
 [COMPILING] filetime [..]
-[RUNNING] `rustc --crate-name filetime [..]`
+[RUNNING] `[..] rustc --crate-name filetime [..]`
 [COMPILING] reduction [..]
-[RUNNING] `rustc --crate-name build_script_tango_build tango-build.rs --crate-type bin [..]`
+[RUNNING] `[..] rustc --crate-name build_script_tango_build tango-build.rs --crate-type bin [..]`
 [RUNNING] `[..]/build-script-tango-build`
-[RUNNING] `rustc --crate-name reduction src/lib.rs --crate-type lib [..]`
+[RUNNING] `[..] rustc --crate-name reduction src/lib.rs --crate-type lib [..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ).run();
@@ -2394,7 +2394,7 @@ fn include_overrides_gitignore() {
 [FRESH] libc [..]
 [FRESH] filetime [..]
 [COMPILING] reduction [..]
-[RUNNING] `rustc --crate-name reduction src/lib.rs --crate-type lib [..]`
+[RUNNING] `[..] rustc --crate-name reduction src/lib.rs --crate-type lib [..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ).run();
@@ -2413,7 +2413,7 @@ fn include_overrides_gitignore() {
 [FRESH] filetime [..]
 [COMPILING] reduction [..]
 [RUNNING] `[..]/build-script-tango-build`
-[RUNNING] `rustc --crate-name reduction src/lib.rs --crate-type lib [..]`
+[RUNNING] `[..] rustc --crate-name reduction src/lib.rs --crate-type lib [..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ).run();
@@ -2617,9 +2617,9 @@ fn use_the_cli() {
 [UPDATING] git repository `[..]`
 [RUNNING] `git fetch [..]`
 [COMPILING] dep1 [..]
-[RUNNING] `rustc [..]`
+[RUNNING] `[..] rustc [..]`
 [COMPILING] foo [..]
-[RUNNING] `rustc [..]`
+[RUNNING] `[..] rustc [..]`
 [FINISHED] [..]
 ";
 

--- a/tests/testsuite/package.rs
+++ b/tests/testsuite/package.rs
@@ -956,7 +956,7 @@ fn test_edition() {
                 // until stuff stabilizes
                 .with_stderr_contains("\
 [COMPILING] foo v0.0.1 ([..])
-[RUNNING] `rustc [..]--edition=2018 [..]
+[RUNNING] `[..] rustc [..]--edition=2018 [..]
 ").run();
 }
 

--- a/tests/testsuite/path.rs
+++ b/tests/testsuite/path.rs
@@ -970,7 +970,7 @@ fn thin_lto_works() {
         .with_stderr(
             "\
 [COMPILING] top [..]
-[RUNNING] `rustc [..] -C lto=thin [..]`
+[RUNNING] `[..] rustc [..] -C lto=thin [..]`
 [FINISHED] [..]
 ",
         ).run();

--- a/tests/testsuite/plugins.rs
+++ b/tests/testsuite/plugins.rs
@@ -317,7 +317,7 @@ fn native_plugin_dependency_with_custom_ar_linker() {
         .with_stderr_contains(
             "\
 [COMPILING] foo v0.0.1 ([..])
-[RUNNING] `rustc [..] -C ar=nonexistent-ar -C linker=nonexistent-linker [..]`
+[RUNNING] `[..] rustc [..] -C ar=nonexistent-ar -C linker=nonexistent-linker [..]`
 [ERROR] [..]linker[..]
 ",
         ).run();

--- a/tests/testsuite/profile_config.rs
+++ b/tests/testsuite/profile_config.rs
@@ -241,7 +241,7 @@ fn profile_config_all_options() {
         .with_stderr(
             "\
 [COMPILING] foo [..]
-[RUNNING] `rustc --crate-name foo [..] \
+[RUNNING] `[..] rustc --crate-name foo [..] \
             -C opt-level=1 \
             -C panic=abort \
             -C codegen-units=2 \
@@ -300,9 +300,9 @@ fn profile_config_override_precedence() {
         .with_stderr(
             "\
 [COMPILING] bar [..]
-[RUNNING] `rustc --crate-name bar [..] -C opt-level=2 -C codegen-units=2 [..]
+[RUNNING] `[..] rustc --crate-name bar [..] -C opt-level=2 -C codegen-units=2 [..]
 [COMPILING] foo [..]
-[RUNNING] `rustc --crate-name foo [..]-C codegen-units=2 [..]
+[RUNNING] `[..] rustc --crate-name foo [..]-C codegen-units=2 [..]
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]",
         ).run();
 }

--- a/tests/testsuite/profile_overrides.rs
+++ b/tests/testsuite/profile_overrides.rs
@@ -92,9 +92,9 @@ fn profile_override_basic() {
         .masquerade_as_nightly_cargo()
         .with_stderr(
             "[COMPILING] bar [..]
-[RUNNING] `rustc --crate-name bar [..] -C opt-level=3 [..]`
+[RUNNING] `[..] rustc --crate-name bar [..] -C opt-level=3 [..]`
 [COMPILING] foo [..]
-[RUNNING] `rustc --crate-name foo [..] -C opt-level=1 [..]`
+[RUNNING] `[..] rustc --crate-name foo [..] -C opt-level=1 [..]`
 [FINISHED] dev [optimized + debuginfo] target(s) in [..]",
         ).run();
 }
@@ -305,17 +305,17 @@ fn profile_override_hierarchy() {
     p.cargo("build -v").masquerade_as_nightly_cargo().with_stderr_unordered("\
 [COMPILING] m3 [..]
 [COMPILING] dep [..]
-[RUNNING] `rustc --crate-name m3 m3/src/lib.rs --color never --crate-type lib --emit=dep-info,link -C codegen-units=4 [..]
-[RUNNING] `rustc --crate-name dep [..]dep/src/lib.rs --color never --crate-type lib --emit=dep-info,link -C codegen-units=3 [..]
-[RUNNING] `rustc --crate-name m3 m3/src/lib.rs --color never --crate-type lib --emit=dep-info,link -C codegen-units=1 [..]
-[RUNNING] `rustc --crate-name build_script_build m1/build.rs --color never --crate-type bin --emit=dep-info,link -C codegen-units=4 [..]
+[RUNNING] `[..] rustc --crate-name m3 m3/src/lib.rs --color never --crate-type lib --emit=dep-info,link -C codegen-units=4 [..]
+[RUNNING] `[..] rustc --crate-name dep [..]dep/src/lib.rs --color never --crate-type lib --emit=dep-info,link -C codegen-units=3 [..]
+[RUNNING] `[..] rustc --crate-name m3 m3/src/lib.rs --color never --crate-type lib --emit=dep-info,link -C codegen-units=1 [..]
+[RUNNING] `[..] rustc --crate-name build_script_build m1/build.rs --color never --crate-type bin --emit=dep-info,link -C codegen-units=4 [..]
 [COMPILING] m2 [..]
-[RUNNING] `rustc --crate-name build_script_build m2/build.rs --color never --crate-type bin --emit=dep-info,link -C codegen-units=2 [..]
+[RUNNING] `[..] rustc --crate-name build_script_build m2/build.rs --color never --crate-type bin --emit=dep-info,link -C codegen-units=2 [..]
 [RUNNING] `[..]/m1-[..]/build-script-build`
 [RUNNING] `[..]/m2-[..]/build-script-build`
-[RUNNING] `rustc --crate-name m2 m2/src/lib.rs --color never --crate-type lib --emit=dep-info,link -C codegen-units=2 [..]
+[RUNNING] `[..] rustc --crate-name m2 m2/src/lib.rs --color never --crate-type lib --emit=dep-info,link -C codegen-units=2 [..]
 [COMPILING] m1 [..]
-[RUNNING] `rustc --crate-name m1 m1/src/lib.rs --color never --crate-type lib --emit=dep-info,link -C codegen-units=1 [..]
+[RUNNING] `[..] rustc --crate-name m1 m1/src/lib.rs --color never --crate-type lib --emit=dep-info,link -C codegen-units=1 [..]
 [FINISHED] dev [unoptimized + debuginfo] [..]
 ",
         )
@@ -416,7 +416,7 @@ fn profile_override_spec() {
 
     p.cargo("build -v")
         .masquerade_as_nightly_cargo()
-        .with_stderr_contains("[RUNNING] `rustc [..]dep1/src/lib.rs [..] -C codegen-units=1 [..]")
-        .with_stderr_contains("[RUNNING] `rustc [..]dep2/src/lib.rs [..] -C codegen-units=2 [..]")
+        .with_stderr_contains("[RUNNING] `[..] rustc [..]dep1/src/lib.rs [..] -C codegen-units=1 [..]")
+        .with_stderr_contains("[RUNNING] `[..] rustc [..]dep2/src/lib.rs [..] -C codegen-units=2 [..]")
         .run();
 }

--- a/tests/testsuite/profile_targets.rs
+++ b/tests/testsuite/profile_targets.rs
@@ -77,15 +77,15 @@ fn profile_selection_build() {
     // - build_script_build is built without panic because it thinks `build.rs` is a plugin.
     p.cargo("build -vv").with_stderr_unordered("\
 [COMPILING] bar [..]
-[RUNNING] `rustc --crate-name bar bar/src/lib.rs --color never --crate-type lib --emit=dep-info,link -C codegen-units=1 -C debuginfo=2 [..]
+[RUNNING] `[..] rustc --crate-name bar bar/src/lib.rs --color never --crate-type lib --emit=dep-info,link -C codegen-units=1 -C debuginfo=2 [..]
 [COMPILING] bdep [..]
-[RUNNING] `rustc --crate-name bdep bdep/src/lib.rs --color never --crate-type lib --emit=dep-info,link -C codegen-units=1 -C debuginfo=2 [..]
+[RUNNING] `[..] rustc --crate-name bdep bdep/src/lib.rs --color never --crate-type lib --emit=dep-info,link -C codegen-units=1 -C debuginfo=2 [..]
 [COMPILING] foo [..]
-[RUNNING] `rustc --crate-name build_script_build build.rs --color never --crate-type bin --emit=dep-info,link -C codegen-units=1 -C debuginfo=2 [..]
+[RUNNING] `[..] rustc --crate-name build_script_build build.rs --color never --crate-type bin --emit=dep-info,link -C codegen-units=1 -C debuginfo=2 [..]
 [RUNNING] `[..]/target/debug/build/foo-[..]/build-script-build`
 foo custom build PROFILE=debug DEBUG=true OPT_LEVEL=0
-[RUNNING] `rustc --crate-name foo src/lib.rs --color never --crate-type lib --emit=dep-info,link -C panic=abort -C codegen-units=1 -C debuginfo=2 [..]
-[RUNNING] `rustc --crate-name foo src/main.rs --color never --crate-type bin --emit=dep-info,link -C panic=abort -C codegen-units=1 -C debuginfo=2 [..]
+[RUNNING] `[..] rustc --crate-name foo src/lib.rs --color never --crate-type lib --emit=dep-info,link -C panic=abort -C codegen-units=1 -C debuginfo=2 [..]
+[RUNNING] `[..] rustc --crate-name foo src/main.rs --color never --crate-type bin --emit=dep-info,link -C panic=abort -C codegen-units=1 -C debuginfo=2 [..]
 [FINISHED] dev [unoptimized + debuginfo] [..]
 ").run();
     p.cargo("build -vv")
@@ -106,15 +106,15 @@ fn profile_selection_build_release() {
     // Build default targets, release.
     p.cargo("build --release -vv").with_stderr_unordered("\
 [COMPILING] bar [..]
-[RUNNING] `rustc --crate-name bar bar/src/lib.rs --color never --crate-type lib --emit=dep-info,link -C opt-level=3 -C codegen-units=2 [..]
+[RUNNING] `[..] rustc --crate-name bar bar/src/lib.rs --color never --crate-type lib --emit=dep-info,link -C opt-level=3 -C codegen-units=2 [..]
 [COMPILING] bdep [..]
-[RUNNING] `rustc --crate-name bdep bdep/src/lib.rs --color never --crate-type lib --emit=dep-info,link -C opt-level=3 -C codegen-units=2 [..]
+[RUNNING] `[..] rustc --crate-name bdep bdep/src/lib.rs --color never --crate-type lib --emit=dep-info,link -C opt-level=3 -C codegen-units=2 [..]
 [COMPILING] foo [..]
-[RUNNING] `rustc --crate-name build_script_build build.rs --color never --crate-type bin --emit=dep-info,link -C opt-level=3 -C codegen-units=2 [..]
+[RUNNING] `[..] rustc --crate-name build_script_build build.rs --color never --crate-type bin --emit=dep-info,link -C opt-level=3 -C codegen-units=2 [..]
 [RUNNING] `[..]/target/release/build/foo-[..]/build-script-build`
 foo custom build PROFILE=release DEBUG=false OPT_LEVEL=3
-[RUNNING] `rustc --crate-name foo src/lib.rs --color never --crate-type lib --emit=dep-info,link -C opt-level=3 -C panic=abort -C codegen-units=2 [..]
-[RUNNING] `rustc --crate-name foo src/main.rs --color never --crate-type bin --emit=dep-info,link -C opt-level=3 -C panic=abort -C codegen-units=2 [..]
+[RUNNING] `[..] rustc --crate-name foo src/lib.rs --color never --crate-type lib --emit=dep-info,link -C opt-level=3 -C panic=abort -C codegen-units=2 [..]
+[RUNNING] `[..] rustc --crate-name foo src/main.rs --color never --crate-type bin --emit=dep-info,link -C opt-level=3 -C panic=abort -C codegen-units=2 [..]
 [FINISHED] release [optimized] [..]
 ").run();
     p.cargo("build --release -vv")
@@ -169,26 +169,26 @@ fn profile_selection_build_all_targets() {
     //   example  dev        build
     p.cargo("build --all-targets -vv").with_stderr_unordered("\
 [COMPILING] bar [..]
-[RUNNING] `rustc --crate-name bar bar/src/lib.rs --color never --crate-type lib --emit=dep-info,link -C codegen-units=1 -C debuginfo=2 [..]
-[RUNNING] `rustc --crate-name bar bar/src/lib.rs --color never --crate-type lib --emit=dep-info,link -C codegen-units=1 -C debuginfo=2 [..]
+[RUNNING] `[..] rustc --crate-name bar bar/src/lib.rs --color never --crate-type lib --emit=dep-info,link -C codegen-units=1 -C debuginfo=2 [..]
+[RUNNING] `[..] rustc --crate-name bar bar/src/lib.rs --color never --crate-type lib --emit=dep-info,link -C codegen-units=1 -C debuginfo=2 [..]
 [COMPILING] bdep [..]
-[RUNNING] `rustc --crate-name bdep bdep/src/lib.rs --color never --crate-type lib --emit=dep-info,link -C codegen-units=1 -C debuginfo=2 [..]
+[RUNNING] `[..] rustc --crate-name bdep bdep/src/lib.rs --color never --crate-type lib --emit=dep-info,link -C codegen-units=1 -C debuginfo=2 [..]
 [COMPILING] foo [..]
-[RUNNING] `rustc --crate-name build_script_build build.rs --color never --crate-type bin --emit=dep-info,link -C codegen-units=1 -C debuginfo=2 [..]
+[RUNNING] `[..] rustc --crate-name build_script_build build.rs --color never --crate-type bin --emit=dep-info,link -C codegen-units=1 -C debuginfo=2 [..]
 [RUNNING] `[..]/target/debug/build/foo-[..]/build-script-build`
 [RUNNING] `[..]/target/debug/build/foo-[..]/build-script-build`
 foo custom build PROFILE=debug DEBUG=false OPT_LEVEL=3
 foo custom build PROFILE=debug DEBUG=true OPT_LEVEL=0
-[RUNNING] `rustc --crate-name foo src/lib.rs --color never --crate-type lib --emit=dep-info,link -C panic=abort -C codegen-units=1 -C debuginfo=2 [..]`
-[RUNNING] `rustc --crate-name foo src/lib.rs --color never --emit=dep-info,link -C codegen-units=3 -C debuginfo=2 --test [..]`
-[RUNNING] `rustc --crate-name foo src/lib.rs --color never --crate-type lib --emit=dep-info,link -C codegen-units=1 -C debuginfo=2 [..]`
-[RUNNING] `rustc --crate-name foo src/lib.rs --color never --emit=dep-info,link -C opt-level=3 -C codegen-units=4 --test [..]`
-[RUNNING] `rustc --crate-name foo src/main.rs --color never --emit=dep-info,link -C codegen-units=3 -C debuginfo=2 --test [..]`
-[RUNNING] `rustc --crate-name test1 tests/test1.rs --color never --emit=dep-info,link -C codegen-units=3 -C debuginfo=2 --test [..]`
-[RUNNING] `rustc --crate-name bench1 benches/bench1.rs --color never --emit=dep-info,link -C opt-level=3 -C codegen-units=4 --test [..]`
-[RUNNING] `rustc --crate-name foo src/main.rs --color never --emit=dep-info,link -C opt-level=3 -C codegen-units=4 --test [..]`
-[RUNNING] `rustc --crate-name foo src/main.rs --color never --crate-type bin --emit=dep-info,link -C panic=abort -C codegen-units=1 -C debuginfo=2 [..]`
-[RUNNING] `rustc --crate-name ex1 examples/ex1.rs --color never --crate-type bin --emit=dep-info,link -C panic=abort -C codegen-units=1 -C debuginfo=2 [..]`
+[RUNNING] `[..] rustc --crate-name foo src/lib.rs --color never --crate-type lib --emit=dep-info,link -C panic=abort -C codegen-units=1 -C debuginfo=2 [..]`
+[RUNNING] `[..] rustc --crate-name foo src/lib.rs --color never --emit=dep-info,link -C codegen-units=3 -C debuginfo=2 --test [..]`
+[RUNNING] `[..] rustc --crate-name foo src/lib.rs --color never --crate-type lib --emit=dep-info,link -C codegen-units=1 -C debuginfo=2 [..]`
+[RUNNING] `[..] rustc --crate-name foo src/lib.rs --color never --emit=dep-info,link -C opt-level=3 -C codegen-units=4 --test [..]`
+[RUNNING] `[..] rustc --crate-name foo src/main.rs --color never --emit=dep-info,link -C codegen-units=3 -C debuginfo=2 --test [..]`
+[RUNNING] `[..] rustc --crate-name test1 tests/test1.rs --color never --emit=dep-info,link -C codegen-units=3 -C debuginfo=2 --test [..]`
+[RUNNING] `[..] rustc --crate-name bench1 benches/bench1.rs --color never --emit=dep-info,link -C opt-level=3 -C codegen-units=4 --test [..]`
+[RUNNING] `[..] rustc --crate-name foo src/main.rs --color never --emit=dep-info,link -C opt-level=3 -C codegen-units=4 --test [..]`
+[RUNNING] `[..] rustc --crate-name foo src/main.rs --color never --crate-type bin --emit=dep-info,link -C panic=abort -C codegen-units=1 -C debuginfo=2 [..]`
+[RUNNING] `[..] rustc --crate-name ex1 examples/ex1.rs --color never --crate-type bin --emit=dep-info,link -C panic=abort -C codegen-units=1 -C debuginfo=2 [..]`
 [FINISHED] dev [unoptimized + debuginfo] [..]
 ").run();
     p.cargo("build -vv")
@@ -240,22 +240,22 @@ fn profile_selection_build_all_targets_release() {
     //   example  release        build
     p.cargo("build --all-targets --release -vv").with_stderr_unordered("\
 [COMPILING] bar [..]
-[RUNNING] `rustc --crate-name bar bar/src/lib.rs --color never --crate-type lib --emit=dep-info,link -C opt-level=3 -C codegen-units=2 [..]
-[RUNNING] `rustc --crate-name bar bar/src/lib.rs --color never --crate-type lib --emit=dep-info,link -C opt-level=3 -C codegen-units=2 [..]
+[RUNNING] `[..] rustc --crate-name bar bar/src/lib.rs --color never --crate-type lib --emit=dep-info,link -C opt-level=3 -C codegen-units=2 [..]
+[RUNNING] `[..] rustc --crate-name bar bar/src/lib.rs --color never --crate-type lib --emit=dep-info,link -C opt-level=3 -C codegen-units=2 [..]
 [COMPILING] bdep [..]
-[RUNNING] `rustc --crate-name bdep bdep/src/lib.rs --color never --crate-type lib --emit=dep-info,link -C opt-level=3 -C codegen-units=2 [..]
+[RUNNING] `[..] rustc --crate-name bdep bdep/src/lib.rs --color never --crate-type lib --emit=dep-info,link -C opt-level=3 -C codegen-units=2 [..]
 [COMPILING] foo [..]
-[RUNNING] `rustc --crate-name build_script_build build.rs --color never --crate-type bin --emit=dep-info,link -C opt-level=3 -C codegen-units=2 [..]
+[RUNNING] `[..] rustc --crate-name build_script_build build.rs --color never --crate-type bin --emit=dep-info,link -C opt-level=3 -C codegen-units=2 [..]
 [RUNNING] `[..]/target/release/build/foo-[..]/build-script-build`
 foo custom build PROFILE=release DEBUG=false OPT_LEVEL=3
-[RUNNING] `rustc --crate-name foo src/lib.rs --color never --crate-type lib --emit=dep-info,link -C opt-level=3 -C panic=abort -C codegen-units=2 [..]`
-[RUNNING] `rustc --crate-name foo src/lib.rs --color never --emit=dep-info,link -C opt-level=3 -C codegen-units=4 --test [..]`
-[RUNNING] `rustc --crate-name foo src/lib.rs --color never --crate-type lib --emit=dep-info,link -C opt-level=3 -C codegen-units=2 [..]`
-[RUNNING] `rustc --crate-name test1 tests/test1.rs --color never --emit=dep-info,link -C opt-level=3 -C codegen-units=4 --test [..]`
-[RUNNING] `rustc --crate-name bench1 benches/bench1.rs --color never --emit=dep-info,link -C opt-level=3 -C codegen-units=4 --test [..]`
-[RUNNING] `rustc --crate-name foo src/main.rs --color never --emit=dep-info,link -C opt-level=3 -C codegen-units=4 --test [..]`
-[RUNNING] `rustc --crate-name foo src/main.rs --color never --crate-type bin --emit=dep-info,link -C opt-level=3 -C panic=abort -C codegen-units=2 [..]`
-[RUNNING] `rustc --crate-name ex1 examples/ex1.rs --color never --crate-type bin --emit=dep-info,link -C opt-level=3 -C panic=abort -C codegen-units=2 [..]`
+[RUNNING] `[..] rustc --crate-name foo src/lib.rs --color never --crate-type lib --emit=dep-info,link -C opt-level=3 -C panic=abort -C codegen-units=2 [..]`
+[RUNNING] `[..] rustc --crate-name foo src/lib.rs --color never --emit=dep-info,link -C opt-level=3 -C codegen-units=4 --test [..]`
+[RUNNING] `[..] rustc --crate-name foo src/lib.rs --color never --crate-type lib --emit=dep-info,link -C opt-level=3 -C codegen-units=2 [..]`
+[RUNNING] `[..] rustc --crate-name test1 tests/test1.rs --color never --emit=dep-info,link -C opt-level=3 -C codegen-units=4 --test [..]`
+[RUNNING] `[..] rustc --crate-name bench1 benches/bench1.rs --color never --emit=dep-info,link -C opt-level=3 -C codegen-units=4 --test [..]`
+[RUNNING] `[..] rustc --crate-name foo src/main.rs --color never --emit=dep-info,link -C opt-level=3 -C codegen-units=4 --test [..]`
+[RUNNING] `[..] rustc --crate-name foo src/main.rs --color never --crate-type bin --emit=dep-info,link -C opt-level=3 -C panic=abort -C codegen-units=2 [..]`
+[RUNNING] `[..] rustc --crate-name ex1 examples/ex1.rs --color never --crate-type bin --emit=dep-info,link -C opt-level=3 -C panic=abort -C codegen-units=2 [..]`
 [FINISHED] release [optimized] [..]
 ").run();
     p.cargo("build --all-targets --release -vv")
@@ -297,27 +297,27 @@ fn profile_selection_test() {
     //
     p.cargo("test -vv").with_stderr_unordered("\
 [COMPILING] bar [..]
-[RUNNING] `rustc --crate-name bar bar/src/lib.rs --color never --crate-type lib --emit=dep-info,link -C codegen-units=1 -C debuginfo=2 [..]
-[RUNNING] `rustc --crate-name bar bar/src/lib.rs --color never --crate-type lib --emit=dep-info,link -C codegen-units=1 -C debuginfo=2 [..]
+[RUNNING] `[..] rustc --crate-name bar bar/src/lib.rs --color never --crate-type lib --emit=dep-info,link -C codegen-units=1 -C debuginfo=2 [..]
+[RUNNING] `[..] rustc --crate-name bar bar/src/lib.rs --color never --crate-type lib --emit=dep-info,link -C codegen-units=1 -C debuginfo=2 [..]
 [COMPILING] bdep [..]
-[RUNNING] `rustc --crate-name bdep bdep/src/lib.rs --color never --crate-type lib --emit=dep-info,link -C codegen-units=1 -C debuginfo=2 [..]
+[RUNNING] `[..] rustc --crate-name bdep bdep/src/lib.rs --color never --crate-type lib --emit=dep-info,link -C codegen-units=1 -C debuginfo=2 [..]
 [COMPILING] foo [..]
-[RUNNING] `rustc --crate-name build_script_build build.rs --color never --crate-type bin --emit=dep-info,link -C codegen-units=1 -C debuginfo=2 [..]
+[RUNNING] `[..] rustc --crate-name build_script_build build.rs --color never --crate-type bin --emit=dep-info,link -C codegen-units=1 -C debuginfo=2 [..]
 [RUNNING] `[..]/target/debug/build/foo-[..]/build-script-build`
 foo custom build PROFILE=debug DEBUG=true OPT_LEVEL=0
-[RUNNING] `rustc --crate-name foo src/lib.rs --color never --crate-type lib --emit=dep-info,link -C panic=abort -C codegen-units=1 -C debuginfo=2 [..]
-[RUNNING] `rustc --crate-name foo src/lib.rs --color never --crate-type lib --emit=dep-info,link -C codegen-units=1 -C debuginfo=2 [..]
-[RUNNING] `rustc --crate-name foo src/lib.rs --color never --emit=dep-info,link -C codegen-units=3 -C debuginfo=2 --test [..]
-[RUNNING] `rustc --crate-name test1 tests/test1.rs --color never --emit=dep-info,link -C codegen-units=3 -C debuginfo=2 --test [..]
-[RUNNING] `rustc --crate-name ex1 examples/ex1.rs --color never --crate-type bin --emit=dep-info,link -C codegen-units=1 -C debuginfo=2 [..]
-[RUNNING] `rustc --crate-name foo src/main.rs --color never --emit=dep-info,link -C codegen-units=3 -C debuginfo=2 --test [..]
-[RUNNING] `rustc --crate-name foo src/main.rs --color never --crate-type bin --emit=dep-info,link -C panic=abort -C codegen-units=1 -C debuginfo=2 [..]
+[RUNNING] `[..] rustc --crate-name foo src/lib.rs --color never --crate-type lib --emit=dep-info,link -C panic=abort -C codegen-units=1 -C debuginfo=2 [..]
+[RUNNING] `[..] rustc --crate-name foo src/lib.rs --color never --crate-type lib --emit=dep-info,link -C codegen-units=1 -C debuginfo=2 [..]
+[RUNNING] `[..] rustc --crate-name foo src/lib.rs --color never --emit=dep-info,link -C codegen-units=3 -C debuginfo=2 --test [..]
+[RUNNING] `[..] rustc --crate-name test1 tests/test1.rs --color never --emit=dep-info,link -C codegen-units=3 -C debuginfo=2 --test [..]
+[RUNNING] `[..] rustc --crate-name ex1 examples/ex1.rs --color never --crate-type bin --emit=dep-info,link -C codegen-units=1 -C debuginfo=2 [..]
+[RUNNING] `[..] rustc --crate-name foo src/main.rs --color never --emit=dep-info,link -C codegen-units=3 -C debuginfo=2 --test [..]
+[RUNNING] `[..] rustc --crate-name foo src/main.rs --color never --crate-type bin --emit=dep-info,link -C panic=abort -C codegen-units=1 -C debuginfo=2 [..]
 [FINISHED] dev [unoptimized + debuginfo] [..]
 [RUNNING] `[..]/deps/foo-[..]`
 [RUNNING] `[..]/deps/foo-[..]`
 [RUNNING] `[..]/deps/test1-[..]`
 [DOCTEST] foo
-[RUNNING] `rustdoc --test [..]
+[RUNNING] `[..] rustdoc --test [..]
 ").run();
     p.cargo("test -vv")
         .with_stderr_unordered(
@@ -330,7 +330,7 @@ foo custom build PROFILE=debug DEBUG=true OPT_LEVEL=0
 [RUNNING] `[..]/deps/foo-[..]`
 [RUNNING] `[..]/deps/test1-[..]`
 [DOCTEST] foo
-[RUNNING] `rustdoc --test [..]
+[RUNNING] `[..] rustdoc --test [..]
 ",
         ).run();
 }
@@ -363,27 +363,27 @@ fn profile_selection_test_release() {
     //
     p.cargo("test --release -vv").with_stderr_unordered("\
 [COMPILING] bar [..]
-[RUNNING] `rustc --crate-name bar bar/src/lib.rs --color never --crate-type lib --emit=dep-info,link -C opt-level=3 -C codegen-units=2 [..]
-[RUNNING] `rustc --crate-name bar bar/src/lib.rs --color never --crate-type lib --emit=dep-info,link -C opt-level=3 -C codegen-units=2 [..]
+[RUNNING] `[..] rustc --crate-name bar bar/src/lib.rs --color never --crate-type lib --emit=dep-info,link -C opt-level=3 -C codegen-units=2 [..]
+[RUNNING] `[..] rustc --crate-name bar bar/src/lib.rs --color never --crate-type lib --emit=dep-info,link -C opt-level=3 -C codegen-units=2 [..]
 [COMPILING] bdep [..]
-[RUNNING] `rustc --crate-name bdep bdep/src/lib.rs --color never --crate-type lib --emit=dep-info,link -C opt-level=3 -C codegen-units=2 [..]
+[RUNNING] `[..] rustc --crate-name bdep bdep/src/lib.rs --color never --crate-type lib --emit=dep-info,link -C opt-level=3 -C codegen-units=2 [..]
 [COMPILING] foo [..]
-[RUNNING] `rustc --crate-name build_script_build build.rs --color never --crate-type bin --emit=dep-info,link -C opt-level=3 -C codegen-units=2 [..]
+[RUNNING] `[..] rustc --crate-name build_script_build build.rs --color never --crate-type bin --emit=dep-info,link -C opt-level=3 -C codegen-units=2 [..]
 [RUNNING] `[..]/target/release/build/foo-[..]/build-script-build`
 foo custom build PROFILE=release DEBUG=false OPT_LEVEL=3
-[RUNNING] `rustc --crate-name foo src/lib.rs --color never --crate-type lib --emit=dep-info,link -C opt-level=3 -C panic=abort -C codegen-units=2 [..]
-[RUNNING] `rustc --crate-name foo src/lib.rs --color never --crate-type lib --emit=dep-info,link -C opt-level=3 -C codegen-units=2 [..]
-[RUNNING] `rustc --crate-name foo src/lib.rs --color never --emit=dep-info,link -C opt-level=3 -C codegen-units=4 --test [..]
-[RUNNING] `rustc --crate-name test1 tests/test1.rs --color never --emit=dep-info,link -C opt-level=3 -C codegen-units=4 --test [..]
-[RUNNING] `rustc --crate-name foo src/main.rs --color never --emit=dep-info,link -C opt-level=3 -C codegen-units=4 --test [..]
-[RUNNING] `rustc --crate-name ex1 examples/ex1.rs --color never --crate-type bin --emit=dep-info,link -C opt-level=3 -C codegen-units=2 [..]
-[RUNNING] `rustc --crate-name foo src/main.rs --color never --crate-type bin --emit=dep-info,link -C opt-level=3 -C panic=abort -C codegen-units=2 [..]
+[RUNNING] `[..] rustc --crate-name foo src/lib.rs --color never --crate-type lib --emit=dep-info,link -C opt-level=3 -C panic=abort -C codegen-units=2 [..]
+[RUNNING] `[..] rustc --crate-name foo src/lib.rs --color never --crate-type lib --emit=dep-info,link -C opt-level=3 -C codegen-units=2 [..]
+[RUNNING] `[..] rustc --crate-name foo src/lib.rs --color never --emit=dep-info,link -C opt-level=3 -C codegen-units=4 --test [..]
+[RUNNING] `[..] rustc --crate-name test1 tests/test1.rs --color never --emit=dep-info,link -C opt-level=3 -C codegen-units=4 --test [..]
+[RUNNING] `[..] rustc --crate-name foo src/main.rs --color never --emit=dep-info,link -C opt-level=3 -C codegen-units=4 --test [..]
+[RUNNING] `[..] rustc --crate-name ex1 examples/ex1.rs --color never --crate-type bin --emit=dep-info,link -C opt-level=3 -C codegen-units=2 [..]
+[RUNNING] `[..] rustc --crate-name foo src/main.rs --color never --crate-type bin --emit=dep-info,link -C opt-level=3 -C panic=abort -C codegen-units=2 [..]
 [FINISHED] release [optimized] [..]
 [RUNNING] `[..]/deps/foo-[..]`
 [RUNNING] `[..]/deps/foo-[..]`
 [RUNNING] `[..]/deps/test1-[..]`
 [DOCTEST] foo
-[RUNNING] `rustdoc --test [..]`
+[RUNNING] `[..] rustdoc --test [..]`
 ").run();
     p.cargo("test --release -vv")
         .with_stderr_unordered(
@@ -396,7 +396,7 @@ foo custom build PROFILE=release DEBUG=false OPT_LEVEL=3
 [RUNNING] `[..]/deps/foo-[..]`
 [RUNNING] `[..]/deps/test1-[..]`
 [DOCTEST] foo
-[RUNNING] `rustdoc --test [..]
+[RUNNING] `[..] rustdoc --test [..]
 ",
         ).run();
 }
@@ -429,20 +429,20 @@ fn profile_selection_bench() {
     //
     p.cargo("bench -vv").with_stderr_unordered("\
 [COMPILING] bar [..]
-[RUNNING] `rustc --crate-name bar bar/src/lib.rs --color never --crate-type lib --emit=dep-info,link -C opt-level=3 -C codegen-units=2 [..]
-[RUNNING] `rustc --crate-name bar bar/src/lib.rs --color never --crate-type lib --emit=dep-info,link -C opt-level=3 -C codegen-units=2 [..]
+[RUNNING] `[..] rustc --crate-name bar bar/src/lib.rs --color never --crate-type lib --emit=dep-info,link -C opt-level=3 -C codegen-units=2 [..]
+[RUNNING] `[..] rustc --crate-name bar bar/src/lib.rs --color never --crate-type lib --emit=dep-info,link -C opt-level=3 -C codegen-units=2 [..]
 [COMPILING] bdep [..]
-[RUNNING] `rustc --crate-name bdep bdep/src/lib.rs --color never --crate-type lib --emit=dep-info,link -C opt-level=3 -C codegen-units=2 [..]
+[RUNNING] `[..] rustc --crate-name bdep bdep/src/lib.rs --color never --crate-type lib --emit=dep-info,link -C opt-level=3 -C codegen-units=2 [..]
 [COMPILING] foo [..]
-[RUNNING] `rustc --crate-name build_script_build build.rs --color never --crate-type bin --emit=dep-info,link -C opt-level=3 -C codegen-units=2 [..]
+[RUNNING] `[..] rustc --crate-name build_script_build build.rs --color never --crate-type bin --emit=dep-info,link -C opt-level=3 -C codegen-units=2 [..]
 [RUNNING] `[..]target/release/build/foo-[..]/build-script-build`
 foo custom build PROFILE=release DEBUG=false OPT_LEVEL=3
-[RUNNING] `rustc --crate-name foo src/lib.rs --color never --crate-type lib --emit=dep-info,link -C opt-level=3 -C panic=abort -C codegen-units=2 [..]
-[RUNNING] `rustc --crate-name foo src/lib.rs --color never --crate-type lib --emit=dep-info,link -C opt-level=3 -C codegen-units=2 [..]
-[RUNNING] `rustc --crate-name foo src/lib.rs --color never --emit=dep-info,link -C opt-level=3 -C codegen-units=4 --test [..]
-[RUNNING] `rustc --crate-name bench1 benches/bench1.rs --color never --emit=dep-info,link -C opt-level=3 -C codegen-units=4 --test [..]
-[RUNNING] `rustc --crate-name foo src/main.rs --color never --emit=dep-info,link -C opt-level=3 -C codegen-units=4 --test [..]
-[RUNNING] `rustc --crate-name foo src/main.rs --color never --crate-type bin --emit=dep-info,link -C opt-level=3 -C panic=abort -C codegen-units=2 [..]
+[RUNNING] `[..] rustc --crate-name foo src/lib.rs --color never --crate-type lib --emit=dep-info,link -C opt-level=3 -C panic=abort -C codegen-units=2 [..]
+[RUNNING] `[..] rustc --crate-name foo src/lib.rs --color never --crate-type lib --emit=dep-info,link -C opt-level=3 -C codegen-units=2 [..]
+[RUNNING] `[..] rustc --crate-name foo src/lib.rs --color never --emit=dep-info,link -C opt-level=3 -C codegen-units=4 --test [..]
+[RUNNING] `[..] rustc --crate-name bench1 benches/bench1.rs --color never --emit=dep-info,link -C opt-level=3 -C codegen-units=4 --test [..]
+[RUNNING] `[..] rustc --crate-name foo src/main.rs --color never --emit=dep-info,link -C opt-level=3 -C codegen-units=4 --test [..]
+[RUNNING] `[..] rustc --crate-name foo src/main.rs --color never --crate-type bin --emit=dep-info,link -C opt-level=3 -C panic=abort -C codegen-units=2 [..]
 [FINISHED] release [optimized] [..]
 [RUNNING] `[..]/deps/foo-[..] --bench`
 [RUNNING] `[..]/deps/foo-[..] --bench`
@@ -497,23 +497,23 @@ fn profile_selection_check_all_targets() {
     //
     p.cargo("check --all-targets -vv").with_stderr_unordered("\
 [COMPILING] bar [..]
-[RUNNING] `rustc --crate-name bar bar/src/lib.rs --color never --crate-type lib --emit=dep-info,link -C codegen-units=1 -C debuginfo=2 [..]
-[RUNNING] `rustc --crate-name bar bar/src/lib.rs --color never --crate-type lib --emit=dep-info,metadata -C codegen-units=1 -C debuginfo=2 [..]
-[RUNNING] `rustc --crate-name bar bar/src/lib.rs --color never --crate-type lib --emit=dep-info,metadata -C panic=abort -C codegen-units=1 -C debuginfo=2 [..]
+[RUNNING] `[..] rustc --crate-name bar bar/src/lib.rs --color never --crate-type lib --emit=dep-info,link -C codegen-units=1 -C debuginfo=2 [..]
+[RUNNING] `[..] rustc --crate-name bar bar/src/lib.rs --color never --crate-type lib --emit=dep-info,metadata -C codegen-units=1 -C debuginfo=2 [..]
+[RUNNING] `[..] rustc --crate-name bar bar/src/lib.rs --color never --crate-type lib --emit=dep-info,metadata -C panic=abort -C codegen-units=1 -C debuginfo=2 [..]
 [COMPILING] bdep[..]
-[RUNNING] `rustc --crate-name bdep bdep/src/lib.rs --color never --crate-type lib --emit=dep-info,link -C codegen-units=1 -C debuginfo=2 [..]
+[RUNNING] `[..] rustc --crate-name bdep bdep/src/lib.rs --color never --crate-type lib --emit=dep-info,link -C codegen-units=1 -C debuginfo=2 [..]
 [COMPILING] foo [..]
-[RUNNING] `rustc --crate-name build_script_build build.rs --color never --crate-type bin --emit=dep-info,link -C codegen-units=1 -C debuginfo=2 [..]
+[RUNNING] `[..] rustc --crate-name build_script_build build.rs --color never --crate-type bin --emit=dep-info,link -C codegen-units=1 -C debuginfo=2 [..]
 [RUNNING] `[..]target/debug/build/foo-[..]/build-script-build`
 foo custom build PROFILE=debug DEBUG=true OPT_LEVEL=0
-[RUNNING] `rustc --crate-name foo src/lib.rs --color never --crate-type lib --emit=dep-info,metadata -C panic=abort -C codegen-units=1 -C debuginfo=2 [..]
-[RUNNING] `rustc --crate-name foo src/lib.rs --color never --crate-type lib --emit=dep-info,metadata -C codegen-units=1 -C debuginfo=2 [..]
-[RUNNING] `rustc --crate-name foo src/lib.rs --color never --emit=dep-info,metadata -C codegen-units=1 -C debuginfo=2 --test [..]
-[RUNNING] `rustc --crate-name test1 tests/test1.rs --color never --emit=dep-info,metadata -C codegen-units=1 -C debuginfo=2 --test [..]
-[RUNNING] `rustc --crate-name foo src/main.rs --color never --emit=dep-info,metadata -C codegen-units=1 -C debuginfo=2 --test [..]
-[RUNNING] `rustc --crate-name bench1 benches/bench1.rs --color never --emit=dep-info,metadata -C codegen-units=1 -C debuginfo=2 --test [..]
-[RUNNING] `rustc --crate-name ex1 examples/ex1.rs --color never --crate-type bin --emit=dep-info,metadata -C panic=abort -C codegen-units=1 -C debuginfo=2 [..]
-[RUNNING] `rustc --crate-name foo src/main.rs --color never --crate-type bin --emit=dep-info,metadata -C panic=abort -C codegen-units=1 -C debuginfo=2 [..]
+[RUNNING] `[..] rustc --crate-name foo src/lib.rs --color never --crate-type lib --emit=dep-info,metadata -C panic=abort -C codegen-units=1 -C debuginfo=2 [..]
+[RUNNING] `[..] rustc --crate-name foo src/lib.rs --color never --crate-type lib --emit=dep-info,metadata -C codegen-units=1 -C debuginfo=2 [..]
+[RUNNING] `[..] rustc --crate-name foo src/lib.rs --color never --emit=dep-info,metadata -C codegen-units=1 -C debuginfo=2 --test [..]
+[RUNNING] `[..] rustc --crate-name test1 tests/test1.rs --color never --emit=dep-info,metadata -C codegen-units=1 -C debuginfo=2 --test [..]
+[RUNNING] `[..] rustc --crate-name foo src/main.rs --color never --emit=dep-info,metadata -C codegen-units=1 -C debuginfo=2 --test [..]
+[RUNNING] `[..] rustc --crate-name bench1 benches/bench1.rs --color never --emit=dep-info,metadata -C codegen-units=1 -C debuginfo=2 --test [..]
+[RUNNING] `[..] rustc --crate-name ex1 examples/ex1.rs --color never --crate-type bin --emit=dep-info,metadata -C panic=abort -C codegen-units=1 -C debuginfo=2 [..]
+[RUNNING] `[..] rustc --crate-name foo src/main.rs --color never --crate-type bin --emit=dep-info,metadata -C panic=abort -C codegen-units=1 -C debuginfo=2 [..]
 [FINISHED] dev [unoptimized + debuginfo] [..]
 ").run();
     // Starting with Rust 1.27, rustc emits `rmeta` files for bins, so
@@ -547,23 +547,23 @@ fn profile_selection_check_all_targets_release() {
     // `dev` for all targets.
     p.cargo("check --all-targets --release -vv").with_stderr_unordered("\
 [COMPILING] bar [..]
-[RUNNING] `rustc --crate-name bar bar/src/lib.rs --color never --crate-type lib --emit=dep-info,link -C opt-level=3 -C codegen-units=2 [..]
-[RUNNING] `rustc --crate-name bar bar/src/lib.rs --color never --crate-type lib --emit=dep-info,metadata -C opt-level=3 -C codegen-units=2 [..]
-[RUNNING] `rustc --crate-name bar bar/src/lib.rs --color never --crate-type lib --emit=dep-info,metadata -C opt-level=3 -C panic=abort -C codegen-units=2 [..]
+[RUNNING] `[..] rustc --crate-name bar bar/src/lib.rs --color never --crate-type lib --emit=dep-info,link -C opt-level=3 -C codegen-units=2 [..]
+[RUNNING] `[..] rustc --crate-name bar bar/src/lib.rs --color never --crate-type lib --emit=dep-info,metadata -C opt-level=3 -C codegen-units=2 [..]
+[RUNNING] `[..] rustc --crate-name bar bar/src/lib.rs --color never --crate-type lib --emit=dep-info,metadata -C opt-level=3 -C panic=abort -C codegen-units=2 [..]
 [COMPILING] bdep[..]
-[RUNNING] `rustc --crate-name bdep bdep/src/lib.rs --color never --crate-type lib --emit=dep-info,link -C opt-level=3 -C codegen-units=2 [..]
+[RUNNING] `[..] rustc --crate-name bdep bdep/src/lib.rs --color never --crate-type lib --emit=dep-info,link -C opt-level=3 -C codegen-units=2 [..]
 [COMPILING] foo [..]
-[RUNNING] `rustc --crate-name build_script_build build.rs --color never --crate-type bin --emit=dep-info,link -C opt-level=3 -C codegen-units=2 [..]
+[RUNNING] `[..] rustc --crate-name build_script_build build.rs --color never --crate-type bin --emit=dep-info,link -C opt-level=3 -C codegen-units=2 [..]
 [RUNNING] `[..]target/release/build/foo-[..]/build-script-build`
 foo custom build PROFILE=release DEBUG=false OPT_LEVEL=3
-[RUNNING] `rustc --crate-name foo src/lib.rs --color never --crate-type lib --emit=dep-info,metadata -C opt-level=3 -C panic=abort -C codegen-units=2 [..]
-[RUNNING] `rustc --crate-name foo src/lib.rs --color never --crate-type lib --emit=dep-info,metadata -C opt-level=3 -C codegen-units=2 [..]
-[RUNNING] `rustc --crate-name foo src/lib.rs --color never --emit=dep-info,metadata -C opt-level=3 -C codegen-units=2 --test [..]
-[RUNNING] `rustc --crate-name test1 tests/test1.rs --color never --emit=dep-info,metadata -C opt-level=3 -C codegen-units=2 --test [..]
-[RUNNING] `rustc --crate-name foo src/main.rs --color never --emit=dep-info,metadata -C opt-level=3 -C codegen-units=2 --test [..]
-[RUNNING] `rustc --crate-name bench1 benches/bench1.rs --color never --emit=dep-info,metadata -C opt-level=3 -C codegen-units=2 --test [..]
-[RUNNING] `rustc --crate-name ex1 examples/ex1.rs --color never --crate-type bin --emit=dep-info,metadata -C opt-level=3 -C panic=abort -C codegen-units=2 [..]
-[RUNNING] `rustc --crate-name foo src/main.rs --color never --crate-type bin --emit=dep-info,metadata -C opt-level=3 -C panic=abort -C codegen-units=2 [..]
+[RUNNING] `[..] rustc --crate-name foo src/lib.rs --color never --crate-type lib --emit=dep-info,metadata -C opt-level=3 -C panic=abort -C codegen-units=2 [..]
+[RUNNING] `[..] rustc --crate-name foo src/lib.rs --color never --crate-type lib --emit=dep-info,metadata -C opt-level=3 -C codegen-units=2 [..]
+[RUNNING] `[..] rustc --crate-name foo src/lib.rs --color never --emit=dep-info,metadata -C opt-level=3 -C codegen-units=2 --test [..]
+[RUNNING] `[..] rustc --crate-name test1 tests/test1.rs --color never --emit=dep-info,metadata -C opt-level=3 -C codegen-units=2 --test [..]
+[RUNNING] `[..] rustc --crate-name foo src/main.rs --color never --emit=dep-info,metadata -C opt-level=3 -C codegen-units=2 --test [..]
+[RUNNING] `[..] rustc --crate-name bench1 benches/bench1.rs --color never --emit=dep-info,metadata -C opt-level=3 -C codegen-units=2 --test [..]
+[RUNNING] `[..] rustc --crate-name ex1 examples/ex1.rs --color never --crate-type bin --emit=dep-info,metadata -C opt-level=3 -C panic=abort -C codegen-units=2 [..]
+[RUNNING] `[..] rustc --crate-name foo src/main.rs --color never --crate-type bin --emit=dep-info,metadata -C opt-level=3 -C panic=abort -C codegen-units=2 [..]
 [FINISHED] release [optimized] [..]
 ").run();
 
@@ -612,20 +612,20 @@ fn profile_selection_check_all_targets_test() {
     //
     p.cargo("check --all-targets --profile=test -vv").with_stderr_unordered("\
 [COMPILING] bar [..]
-[RUNNING] `rustc --crate-name bar bar/src/lib.rs --color never --crate-type lib --emit=dep-info,link -C codegen-units=1 -C debuginfo=2 [..]
-[RUNNING] `rustc --crate-name bar bar/src/lib.rs --color never --crate-type lib --emit=dep-info,metadata -C codegen-units=1 -C debuginfo=2 [..]
+[RUNNING] `[..] rustc --crate-name bar bar/src/lib.rs --color never --crate-type lib --emit=dep-info,link -C codegen-units=1 -C debuginfo=2 [..]
+[RUNNING] `[..] rustc --crate-name bar bar/src/lib.rs --color never --crate-type lib --emit=dep-info,metadata -C codegen-units=1 -C debuginfo=2 [..]
 [COMPILING] bdep[..]
-[RUNNING] `rustc --crate-name bdep bdep/src/lib.rs --color never --crate-type lib --emit=dep-info,link -C codegen-units=1 -C debuginfo=2 [..]
+[RUNNING] `[..] rustc --crate-name bdep bdep/src/lib.rs --color never --crate-type lib --emit=dep-info,link -C codegen-units=1 -C debuginfo=2 [..]
 [COMPILING] foo [..]
-[RUNNING] `rustc --crate-name build_script_build build.rs --color never --crate-type bin --emit=dep-info,link -C codegen-units=1 -C debuginfo=2 [..]
+[RUNNING] `[..] rustc --crate-name build_script_build build.rs --color never --crate-type bin --emit=dep-info,link -C codegen-units=1 -C debuginfo=2 [..]
 [RUNNING] `[..]target/debug/build/foo-[..]/build-script-build`
 foo custom build PROFILE=debug DEBUG=true OPT_LEVEL=0
-[RUNNING] `rustc --crate-name foo src/lib.rs --color never --crate-type lib --emit=dep-info,metadata -C codegen-units=1 -C debuginfo=2 [..]
-[RUNNING] `rustc --crate-name foo src/lib.rs --color never --emit=dep-info,metadata -C codegen-units=1 -C debuginfo=2 --test [..]
-[RUNNING] `rustc --crate-name test1 tests/test1.rs --color never --emit=dep-info,metadata -C codegen-units=1 -C debuginfo=2 --test [..]
-[RUNNING] `rustc --crate-name foo src/main.rs --color never --emit=dep-info,metadata -C codegen-units=1 -C debuginfo=2 --test [..]
-[RUNNING] `rustc --crate-name bench1 benches/bench1.rs --color never --emit=dep-info,metadata -C codegen-units=1 -C debuginfo=2 --test [..]
-[RUNNING] `rustc --crate-name ex1 examples/ex1.rs --color never --emit=dep-info,metadata -C codegen-units=1 -C debuginfo=2 --test [..]
+[RUNNING] `[..] rustc --crate-name foo src/lib.rs --color never --crate-type lib --emit=dep-info,metadata -C codegen-units=1 -C debuginfo=2 [..]
+[RUNNING] `[..] rustc --crate-name foo src/lib.rs --color never --emit=dep-info,metadata -C codegen-units=1 -C debuginfo=2 --test [..]
+[RUNNING] `[..] rustc --crate-name test1 tests/test1.rs --color never --emit=dep-info,metadata -C codegen-units=1 -C debuginfo=2 --test [..]
+[RUNNING] `[..] rustc --crate-name foo src/main.rs --color never --emit=dep-info,metadata -C codegen-units=1 -C debuginfo=2 --test [..]
+[RUNNING] `[..] rustc --crate-name bench1 benches/bench1.rs --color never --emit=dep-info,metadata -C codegen-units=1 -C debuginfo=2 --test [..]
+[RUNNING] `[..] rustc --crate-name ex1 examples/ex1.rs --color never --emit=dep-info,metadata -C codegen-units=1 -C debuginfo=2 --test [..]
 [FINISHED] dev [unoptimized + debuginfo] [..]
 ").run();
 
@@ -657,17 +657,17 @@ fn profile_selection_doc() {
     p.cargo("doc -vv").with_stderr_unordered("\
 [COMPILING] bar [..]
 [DOCUMENTING] bar [..]
-[RUNNING] `rustc --crate-name bar bar/src/lib.rs --color never --crate-type lib --emit=dep-info,link -C codegen-units=1 -C debuginfo=2 [..]
-[RUNNING] `rustdoc --crate-name bar bar/src/lib.rs [..]
-[RUNNING] `rustc --crate-name bar bar/src/lib.rs --color never --crate-type lib --emit=dep-info,metadata -C panic=abort -C codegen-units=1 -C debuginfo=2 [..]
+[RUNNING] `[..] rustc --crate-name bar bar/src/lib.rs --color never --crate-type lib --emit=dep-info,link -C codegen-units=1 -C debuginfo=2 [..]
+[RUNNING] `[..] rustdoc --crate-name bar bar/src/lib.rs [..]
+[RUNNING] `[..] rustc --crate-name bar bar/src/lib.rs --color never --crate-type lib --emit=dep-info,metadata -C panic=abort -C codegen-units=1 -C debuginfo=2 [..]
 [COMPILING] bdep [..]
-[RUNNING] `rustc --crate-name bdep bdep/src/lib.rs --color never --crate-type lib --emit=dep-info,link -C codegen-units=1 -C debuginfo=2 [..]
+[RUNNING] `[..] rustc --crate-name bdep bdep/src/lib.rs --color never --crate-type lib --emit=dep-info,link -C codegen-units=1 -C debuginfo=2 [..]
 [COMPILING] foo [..]
-[RUNNING] `rustc --crate-name build_script_build build.rs --color never --crate-type bin --emit=dep-info,link -C codegen-units=1 -C debuginfo=2 [..]
+[RUNNING] `[..] rustc --crate-name build_script_build build.rs --color never --crate-type bin --emit=dep-info,link -C codegen-units=1 -C debuginfo=2 [..]
 [RUNNING] `[..]target/debug/build/foo-[..]/build-script-build`
 foo custom build PROFILE=debug DEBUG=true OPT_LEVEL=0
 [DOCUMENTING] foo [..]
-[RUNNING] `rustdoc --crate-name foo src/lib.rs [..]
+[RUNNING] `[..] rustdoc --crate-name foo src/lib.rs [..]
 [FINISHED] dev [unoptimized + debuginfo] [..]
 ").run();
 }

--- a/tests/testsuite/profiles.rs
+++ b/tests/testsuite/profiles.rs
@@ -26,7 +26,7 @@ fn profile_overrides() {
         .with_stderr(
             "\
 [COMPILING] test v0.0.0 ([CWD])
-[RUNNING] `rustc --crate-name test src/lib.rs --color never --crate-type lib \
+[RUNNING] `[..] rustc --crate-name test src/lib.rs --color never --crate-type lib \
         --emit=dep-info,link \
         -C opt-level=1 \
         -C debug-assertions=on \
@@ -60,7 +60,7 @@ fn opt_level_override_0() {
         .with_stderr(
             "\
 [COMPILING] test v0.0.0 ([CWD])
-[RUNNING] `rustc --crate-name test src/lib.rs --color never --crate-type lib \
+[RUNNING] `[..] rustc --crate-name test src/lib.rs --color never --crate-type lib \
         --emit=dep-info,link \
         -C debuginfo=2 \
         -C metadata=[..] \
@@ -91,7 +91,7 @@ fn debug_override_1() {
         .with_stderr(
             "\
 [COMPILING] test v0.0.0 ([CWD])
-[RUNNING] `rustc --crate-name test src/lib.rs --color never --crate-type lib \
+[RUNNING] `[..] rustc --crate-name test src/lib.rs --color never --crate-type lib \
         --emit=dep-info,link \
         -C debuginfo=1 \
         -C metadata=[..] \
@@ -125,7 +125,7 @@ fn check_opt_level_override(profile_level: &str, rustc_level: &str) {
         .with_stderr(&format!(
             "\
 [COMPILING] test v0.0.0 ([CWD])
-[RUNNING] `rustc --crate-name test src/lib.rs --color never --crate-type lib \
+[RUNNING] `[..] rustc --crate-name test src/lib.rs --color never --crate-type lib \
         --emit=dep-info,link \
         -C opt-level={level} \
         -C debuginfo=2 \
@@ -199,7 +199,7 @@ fn top_level_overrides_deps() {
         .with_stderr(&format!(
             "\
 [COMPILING] foo v0.0.0 ([CWD]/foo)
-[RUNNING] `rustc --crate-name foo foo/src/lib.rs --color never \
+[RUNNING] `[..] rustc --crate-name foo foo/src/lib.rs --color never \
         --crate-type dylib --crate-type rlib \
         --emit=dep-info,link \
         -C prefer-dynamic \
@@ -209,7 +209,7 @@ fn top_level_overrides_deps() {
         --out-dir [CWD]/target/release/deps \
         -L dependency=[CWD]/target/release/deps`
 [COMPILING] test v0.0.0 ([CWD])
-[RUNNING] `rustc --crate-name test src/lib.rs --color never --crate-type lib \
+[RUNNING] `[..] rustc --crate-name test src/lib.rs --color never --crate-type lib \
         --emit=dep-info,link \
         -C opt-level=1 \
         -C debuginfo=2 \
@@ -267,7 +267,7 @@ fn profile_in_non_root_manifest_triggers_a_warning() {
 package:   [..]
 workspace: [..]
 [COMPILING] bar v0.1.0 ([..])
-[RUNNING] `rustc [..]`
+[RUNNING] `[..] rustc [..]`
 [FINISHED] dev [unoptimized] target(s) in [..]",
         ).run();
 }
@@ -303,7 +303,7 @@ fn profile_in_virtual_manifest_works() {
         .with_stderr(
             "\
 [COMPILING] bar v0.1.0 ([..])
-[RUNNING] `rustc [..]`
+[RUNNING] `[..] rustc [..]`
 [FINISHED] dev [optimized] target(s) in [..]",
         ).run();
 }

--- a/tests/testsuite/rename_deps.rs
+++ b/tests/testsuite/rename_deps.rs
@@ -331,7 +331,7 @@ fn can_run_doc_tests() {
         .with_stderr_contains(
             "\
 [DOCTEST] foo
-[RUNNING] `rustdoc --test [CWD]/src/lib.rs \
+[RUNNING] `[..] rustdoc --test [CWD]/src/lib.rs \
         [..] \
         --extern baz=[CWD]/target/debug/deps/libbar-[..].rlib \
         --extern bar=[CWD]/target/debug/deps/libbar-[..].rlib \

--- a/tests/testsuite/run.rs
+++ b/tests/testsuite/run.rs
@@ -103,9 +103,9 @@ fn exit_code_verbose() {
     let mut output = String::from(
         "\
 [COMPILING] foo v0.0.1 ([CWD])
-[RUNNING] `rustc [..]`
+[RUNNING] `[..] rustc [..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] `target[..]`
+[RUNNING] `[..] target[..]`
 ",
     );
     if !cfg!(unix) {
@@ -182,10 +182,10 @@ fn specify_name() {
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([CWD])
-[RUNNING] `rustc [..] src/lib.rs [..]`
-[RUNNING] `rustc [..] src/bin/a.rs [..]`
+[RUNNING] `[..] rustc [..] src/lib.rs [..]`
+[RUNNING] `[..] rustc [..] src/bin/a.rs [..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] `target/debug/a[EXE]`",
+[RUNNING] `[..] target/debug/a[EXE]`",
         ).with_stdout("hello a.rs")
         .run();
 
@@ -193,9 +193,9 @@ fn specify_name() {
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([..])
-[RUNNING] `rustc [..] src/bin/b.rs [..]`
+[RUNNING] `[..] rustc [..] src/bin/b.rs [..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] `target/debug/b[EXE]`",
+[RUNNING] `[..] target/debug/b[EXE]`",
         ).with_stdout("hello b.rs")
         .run();
 }
@@ -604,14 +604,14 @@ fn example_with_release_flag() {
         .with_stderr(
             "\
 [COMPILING] bar v0.5.0 ([CWD]/bar)
-[RUNNING] `rustc --crate-name bar bar/src/bar.rs --color never --crate-type lib \
+[RUNNING] `[..] rustc --crate-name bar bar/src/bar.rs --color never --crate-type lib \
         --emit=dep-info,link \
         -C opt-level=3 \
         -C metadata=[..] \
         --out-dir [CWD]/target/release/deps \
         -L dependency=[CWD]/target/release/deps`
 [COMPILING] foo v0.0.1 ([CWD])
-[RUNNING] `rustc --crate-name a examples/a.rs --color never --crate-type bin \
+[RUNNING] `[..] rustc --crate-name a examples/a.rs --color never --crate-type bin \
         --emit=dep-info,link \
         -C opt-level=3 \
         -C metadata=[..] \
@@ -619,7 +619,7 @@ fn example_with_release_flag() {
         -L dependency=[CWD]/target/release/deps \
          --extern bar=[CWD]/target/release/deps/libbar-[..].rlib`
 [FINISHED] release [optimized] target(s) in [..]
-[RUNNING] `target/release/examples/a[EXE]`
+[RUNNING] `[..] target/release/examples/a[EXE]`
 ",
         ).with_stdout(
             "\
@@ -631,14 +631,14 @@ fast2",
         .with_stderr(
             "\
 [COMPILING] bar v0.5.0 ([CWD]/bar)
-[RUNNING] `rustc --crate-name bar bar/src/bar.rs --color never --crate-type lib \
+[RUNNING] `[..] rustc --crate-name bar bar/src/bar.rs --color never --crate-type lib \
         --emit=dep-info,link \
         -C debuginfo=2 \
         -C metadata=[..] \
         --out-dir [CWD]/target/debug/deps \
         -L dependency=[CWD]/target/debug/deps`
 [COMPILING] foo v0.0.1 ([CWD])
-[RUNNING] `rustc --crate-name a examples/a.rs --color never --crate-type bin \
+[RUNNING] `[..] rustc --crate-name a examples/a.rs --color never --crate-type bin \
         --emit=dep-info,link \
         -C debuginfo=2 \
         -C metadata=[..] \
@@ -646,7 +646,7 @@ fast2",
         -L dependency=[CWD]/target/debug/deps \
          --extern bar=[CWD]/target/debug/deps/libbar-[..].rlib`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] `target/debug/examples/a[EXE]`
+[RUNNING] `[..] target/debug/examples/a[EXE]`
 ",
         ).with_stdout(
             "\

--- a/tests/testsuite/run.rs
+++ b/tests/testsuite/run.rs
@@ -13,7 +13,7 @@ fn simple() {
             "\
 [COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] `target/debug/foo[EXE]`",
+[RUNNING] `[..] target/debug/foo[EXE]`",
         ).with_stdout("hello")
         .run();
     assert!(p.bin("foo").is_file());
@@ -83,7 +83,7 @@ fn exit_code() {
         "\
 [COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] `target[..]`
+[RUNNING] `[..] target[..]`
 ",
     );
     if !cfg!(unix) {
@@ -320,7 +320,7 @@ fn run_example() {
             "\
 [COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] `target/debug/examples/a[EXE]`",
+[RUNNING] `[..] target/debug/examples/a[EXE]`",
         ).with_stdout("example")
         .run();
 }
@@ -428,7 +428,7 @@ fn run_example_autodiscover_2015_with_autoexamples_enabled() {
             "\
 [COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] `target/debug/examples/a[EXE]`",
+[RUNNING] `[..] target/debug/examples/a[EXE]`",
         ).with_stdout("example")
         .run();
 }
@@ -458,7 +458,7 @@ fn run_example_autodiscover_2018() {
             "\
 [COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] `target/debug/examples/a[EXE]`",
+[RUNNING] `[..] target/debug/examples/a[EXE]`",
         ).with_stdout("example")
         .run();
 }
@@ -552,7 +552,7 @@ fn one_bin_multiple_examples() {
             "\
 [COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] `target/debug/main[EXE]`",
+[RUNNING] `[..] target/debug/main[EXE]`",
         ).with_stdout("hello main.rs")
         .run();
 }
@@ -705,7 +705,7 @@ fn release_works() {
             "\
 [COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] release [optimized] target(s) in [..]
-[RUNNING] `target/release/foo[EXE]`
+[RUNNING] `[..] target/release/foo[EXE]`
 ",
         ).run();
     assert!(p.release_bin("foo").is_file());
@@ -764,7 +764,7 @@ fn run_from_executable_folder() {
         .with_stderr(
             "\
              [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]\n\
-             [RUNNING] `./foo[EXE]`",
+             [RUNNING] `[..] ./foo[EXE]`",
         ).with_stdout("hello")
         .run();
 }

--- a/tests/testsuite/rustc.rs
+++ b/tests/testsuite/rustc.rs
@@ -15,7 +15,7 @@ fn build_lib_for_foo() {
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([CWD])
-[RUNNING] `rustc --crate-name foo src/lib.rs --color never --crate-type lib \
+[RUNNING] `[..] rustc --crate-name foo src/lib.rs --color never --crate-type lib \
         --emit=dep-info,link -C debuginfo=2 \
         -C metadata=[..] \
         --out-dir [..] \
@@ -36,7 +36,7 @@ fn lib() {
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([CWD])
-[RUNNING] `rustc --crate-name foo src/lib.rs --color never --crate-type lib \
+[RUNNING] `[..] rustc --crate-name foo src/lib.rs --color never --crate-type lib \
         --emit=dep-info,link -C debuginfo=2 \
         -C debug-assertions=off \
         -C metadata=[..] \
@@ -58,12 +58,12 @@ fn build_main_and_allow_unstable_options() {
         .with_stderr(format!(
             "\
 [COMPILING] {name} v{version} ([CWD])
-[RUNNING] `rustc --crate-name {name} src/lib.rs --color never --crate-type lib \
+[RUNNING] `[..] rustc --crate-name {name} src/lib.rs --color never --crate-type lib \
         --emit=dep-info,link -C debuginfo=2 \
         -C metadata=[..] \
         --out-dir [..] \
         -L dependency=[CWD]/target/debug/deps`
-[RUNNING] `rustc --crate-name {name} src/main.rs --color never --crate-type bin \
+[RUNNING] `[..] rustc --crate-name {name} src/main.rs --color never --crate-type bin \
         --emit=dep-info,link -C debuginfo=2 \
         -C debug-assertions \
         -C metadata=[..] \
@@ -103,10 +103,10 @@ fn build_with_args_to_one_of_multiple_binaries() {
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([CWD])
-[RUNNING] `rustc --crate-name foo src/lib.rs --color never --crate-type lib --emit=dep-info,link \
+[RUNNING] `[..] rustc --crate-name foo src/lib.rs --color never --crate-type lib --emit=dep-info,link \
         -C debuginfo=2 -C metadata=[..] \
         --out-dir [..]`
-[RUNNING] `rustc --crate-name bar src/bin/bar.rs --color never --crate-type bin --emit=dep-info,link \
+[RUNNING] `[..] rustc --crate-name bar src/bin/bar.rs --color never --crate-type bin --emit=dep-info,link \
         -C debuginfo=2 -C debug-assertions [..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
@@ -141,10 +141,10 @@ fn build_with_args_to_one_of_multiple_tests() {
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([CWD])
-[RUNNING] `rustc --crate-name foo src/lib.rs --color never --crate-type lib --emit=dep-info,link \
+[RUNNING] `[..] rustc --crate-name foo src/lib.rs --color never --crate-type lib --emit=dep-info,link \
         -C debuginfo=2 -C metadata=[..] \
         --out-dir [..]`
-[RUNNING] `rustc --crate-name bar tests/bar.rs --color never --emit=dep-info,link -C debuginfo=2 \
+[RUNNING] `[..] rustc --crate-name bar tests/bar.rs --color never --emit=dep-info,link -C debuginfo=2 \
         -C debug-assertions [..]--test[..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
@@ -211,7 +211,7 @@ fn build_only_bar_dependency() {
         .with_stderr(
             "\
 [COMPILING] bar v0.1.0 ([..])
-[RUNNING] `rustc --crate-name bar [..] --color never --crate-type lib [..] -C debug-assertions [..]`
+[RUNNING] `[..] rustc --crate-name bar [..] --color never --crate-type lib [..] -C debug-assertions [..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ).run();
@@ -223,15 +223,15 @@ fn targets_selected_default() {
     p.cargo("rustc -v")
         // bin
         .with_stderr_contains("\
-            [RUNNING] `rustc --crate-name foo src/main.rs --color never --crate-type bin \
+            [RUNNING] `[..] rustc --crate-name foo src/main.rs --color never --crate-type bin \
             --emit=dep-info,link[..]")
         // bench
         .with_stderr_does_not_contain("\
-            [RUNNING] `rustc --crate-name foo src/main.rs --color never --emit=dep-info,link \
+            [RUNNING] `[..] rustc --crate-name foo src/main.rs --color never --emit=dep-info,link \
             -C opt-level=3 --test [..]")
         // unit test
         .with_stderr_does_not_contain("\
-            [RUNNING] `rustc --crate-name foo src/main.rs --color never --emit=dep-info,link \
+            [RUNNING] `[..] rustc --crate-name foo src/main.rs --color never --emit=dep-info,link \
             -C debuginfo=2 --test [..]").run();
 }
 
@@ -241,15 +241,15 @@ fn targets_selected_all() {
     p.cargo("rustc -v --all-targets")
         // bin
         .with_stderr_contains("\
-            [RUNNING] `rustc --crate-name foo src/main.rs --color never --crate-type bin \
+            [RUNNING] `[..] rustc --crate-name foo src/main.rs --color never --crate-type bin \
             --emit=dep-info,link[..]")
         // bench
         .with_stderr_contains("\
-            [RUNNING] `rustc --crate-name foo src/main.rs --color never --emit=dep-info,link \
+            [RUNNING] `[..] rustc --crate-name foo src/main.rs --color never --emit=dep-info,link \
             -C opt-level=3 --test [..]")
         // unit test
         .with_stderr_contains("\
-            [RUNNING] `rustc --crate-name foo src/main.rs --color never --emit=dep-info,link \
+            [RUNNING] `[..] rustc --crate-name foo src/main.rs --color never --emit=dep-info,link \
             -C debuginfo=2 --test [..]").run();
 }
 
@@ -348,7 +348,7 @@ fn rustc_fingerprint() {
         .with_stderr(
             "\
 [COMPILING] foo [..]
-[RUNNING] `rustc [..]-C debug-assertions [..]
+[RUNNING] `[..] rustc [..]-C debug-assertions [..]
 [FINISHED] [..]
 ",
         ).run();
@@ -366,7 +366,7 @@ fn rustc_fingerprint() {
         .with_stderr(
             "\
 [COMPILING] foo [..]
-[RUNNING] `rustc [..]
+[RUNNING] `[..] rustc [..]
 [FINISHED] [..]
 ",
         ).run();
@@ -401,11 +401,11 @@ fn rustc_test_with_implicit_bin() {
     p.cargo("rustc --test test1 -v -- --cfg foo")
         .with_stderr_contains(
             "\
-[RUNNING] `rustc --crate-name test1 tests/test1.rs [..] --cfg foo [..]
+[RUNNING] `[..] rustc --crate-name test1 tests/test1.rs [..] --cfg foo [..]
 ",
         ).with_stderr_contains(
             "\
-[RUNNING] `rustc --crate-name foo src/main.rs [..]
+[RUNNING] `[..] rustc --crate-name foo src/main.rs [..]
 ",
         ).run();
 }

--- a/tests/testsuite/rustdoc.rs
+++ b/tests/testsuite/rustdoc.rs
@@ -8,7 +8,7 @@ fn rustdoc_simple() {
         .with_stderr(
             "\
 [DOCUMENTING] foo v0.0.1 ([CWD])
-[RUNNING] `rustdoc --crate-name foo src/lib.rs [..]\
+[RUNNING] `[..] rustdoc --crate-name foo src/lib.rs [..]\
         -o [CWD]/target/doc \
         -L dependency=[CWD]/target/debug/deps`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
@@ -24,7 +24,7 @@ fn rustdoc_args() {
         .with_stderr(
             "\
 [DOCUMENTING] foo v0.0.1 ([CWD])
-[RUNNING] `rustdoc --crate-name foo src/lib.rs [..]\
+[RUNNING] `[..] rustdoc --crate-name foo src/lib.rs [..]\
         -o [CWD]/target/doc \
         --cfg=foo \
         -L dependency=[CWD]/target/debug/deps`
@@ -59,9 +59,9 @@ fn rustdoc_foo_with_bar_dependency() {
         .with_stderr(
             "\
 [CHECKING] bar v0.0.1 ([..])
-[RUNNING] `rustc [..]bar/src/lib.rs [..]`
+[RUNNING] `[..] rustc [..]bar/src/lib.rs [..]`
 [DOCUMENTING] foo v0.0.1 ([CWD])
-[RUNNING] `rustdoc --crate-name foo src/lib.rs [..]\
+[RUNNING] `[..] rustdoc --crate-name foo src/lib.rs [..]\
         -o [CWD]/target/doc \
         --cfg=foo \
         -L dependency=[CWD]/target/debug/deps \
@@ -97,7 +97,7 @@ fn rustdoc_only_bar_dependency() {
         .with_stderr(
             "\
 [DOCUMENTING] bar v0.0.1 ([..])
-[RUNNING] `rustdoc --crate-name bar [..]bar/src/lib.rs [..]\
+[RUNNING] `[..] rustdoc --crate-name bar [..]bar/src/lib.rs [..]\
         -o [CWD]/target/doc \
         --cfg=foo \
         -L dependency=[CWD]/target/debug/deps`
@@ -117,7 +117,7 @@ fn rustdoc_same_name_documents_lib() {
         .with_stderr(
             "\
 [DOCUMENTING] foo v0.0.1 ([..])
-[RUNNING] `rustdoc --crate-name foo src/lib.rs [..]\
+[RUNNING] `[..] rustdoc --crate-name foo src/lib.rs [..]\
         -o [CWD]/target/doc \
         --cfg=foo \
         -L dependency=[CWD]/target/debug/deps`
@@ -161,7 +161,7 @@ fn rustdoc_target() {
         .with_stderr(
             "\
 [DOCUMENTING] foo v0.0.1 ([..])
-[RUNNING] `rustdoc --crate-name foo src/lib.rs [..]\
+[RUNNING] `[..] rustdoc --crate-name foo src/lib.rs [..]\
     --target x86_64-unknown-linux-gnu \
     -o [CWD]/target/x86_64-unknown-linux-gnu/doc \
     -L dependency=[CWD]/target/x86_64-unknown-linux-gnu/debug/deps \

--- a/tests/testsuite/rustdocflags.rs
+++ b/tests/testsuite/rustdocflags.rs
@@ -6,7 +6,7 @@ fn parses_env() {
 
     p.cargo("doc -v")
         .env("RUSTDOCFLAGS", "--cfg=foo")
-        .with_stderr_contains("[RUNNING] `rustdoc [..] --cfg=foo[..]`")
+        .with_stderr_contains("[RUNNING] `[..] rustdoc [..] --cfg=foo[..]`")
         .run();
 }
 
@@ -23,7 +23,7 @@ fn parses_config() {
         ).build();
 
     p.cargo("doc -v")
-        .with_stderr_contains("[RUNNING] `rustdoc [..] --cfg foo[..]`")
+        .with_stderr_contains("[RUNNING] `[..] rustdoc [..] --cfg foo[..]`")
         .run();
 }
 

--- a/tests/testsuite/rustflags.rs
+++ b/tests/testsuite/rustflags.rs
@@ -932,7 +932,7 @@ fn cfg_rustflags_normal_source() {
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([..])
-[RUNNING] `rustc [..] --cfg bar[..]`
+[RUNNING] `[..] rustc [..] --cfg bar[..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ).run();
@@ -941,7 +941,7 @@ fn cfg_rustflags_normal_source() {
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([..])
-[RUNNING] `rustc [..] --cfg bar[..]`
+[RUNNING] `[..] rustc [..] --cfg bar[..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ).run();
@@ -950,7 +950,7 @@ fn cfg_rustflags_normal_source() {
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([..])
-[RUNNING] `rustc [..] --cfg bar[..]`
+[RUNNING] `[..] rustc [..] --cfg bar[..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ).run();
@@ -959,9 +959,9 @@ fn cfg_rustflags_normal_source() {
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([..])
-[RUNNING] `rustc [..] --cfg bar[..]`
-[RUNNING] `rustc [..] --cfg bar[..]`
-[RUNNING] `rustc [..] --cfg bar[..]`
+[RUNNING] `[..] rustc [..] --cfg bar[..]`
+[RUNNING] `[..] rustc [..] --cfg bar[..]`
+[RUNNING] `[..] rustc [..] --cfg bar[..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ).run();
@@ -970,9 +970,9 @@ fn cfg_rustflags_normal_source() {
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([..])
-[RUNNING] `rustc [..] --cfg bar[..]`
-[RUNNING] `rustc [..] --cfg bar[..]`
-[RUNNING] `rustc [..] --cfg bar[..]`
+[RUNNING] `[..] rustc [..] --cfg bar[..]`
+[RUNNING] `[..] rustc [..] --cfg bar[..]`
+[RUNNING] `[..] rustc [..] --cfg bar[..]`
 [FINISHED] release [optimized] target(s) in [..]
 ",
         ).run();
@@ -1008,7 +1008,7 @@ fn cfg_rustflags_precedence() {
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([..])
-[RUNNING] `rustc [..] --cfg bar[..]`
+[RUNNING] `[..] rustc [..] --cfg bar[..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ).run();
@@ -1017,7 +1017,7 @@ fn cfg_rustflags_precedence() {
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([..])
-[RUNNING] `rustc [..] --cfg bar[..]`
+[RUNNING] `[..] rustc [..] --cfg bar[..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ).run();
@@ -1026,7 +1026,7 @@ fn cfg_rustflags_precedence() {
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([..])
-[RUNNING] `rustc [..] --cfg bar[..]`
+[RUNNING] `[..] rustc [..] --cfg bar[..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ).run();
@@ -1035,9 +1035,9 @@ fn cfg_rustflags_precedence() {
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([..])
-[RUNNING] `rustc [..] --cfg bar[..]`
-[RUNNING] `rustc [..] --cfg bar[..]`
-[RUNNING] `rustc [..] --cfg bar[..]`
+[RUNNING] `[..] rustc [..] --cfg bar[..]`
+[RUNNING] `[..] rustc [..] --cfg bar[..]`
+[RUNNING] `[..] rustc [..] --cfg bar[..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ).run();
@@ -1046,9 +1046,9 @@ fn cfg_rustflags_precedence() {
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([..])
-[RUNNING] `rustc [..] --cfg bar[..]`
-[RUNNING] `rustc [..] --cfg bar[..]`
-[RUNNING] `rustc [..] --cfg bar[..]`
+[RUNNING] `[..] rustc [..] --cfg bar[..]`
+[RUNNING] `[..] rustc [..] --cfg bar[..]`
+[RUNNING] `[..] rustc [..] --cfg bar[..]`
 [FINISHED] release [optimized] target(s) in [..]
 ",
         ).run();
@@ -1070,7 +1070,7 @@ fn target_rustflags_string_and_array_form1() {
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([..])
-[RUNNING] `rustc [..] --cfg foo[..]`
+[RUNNING] `[..] rustc [..] --cfg foo[..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ).run();
@@ -1089,7 +1089,7 @@ fn target_rustflags_string_and_array_form1() {
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([..])
-[RUNNING] `rustc [..] --cfg foo[..]`
+[RUNNING] `[..] rustc [..] --cfg foo[..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ).run();
@@ -1114,7 +1114,7 @@ fn target_rustflags_string_and_array_form2() {
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([..])
-[RUNNING] `rustc [..] --cfg foo[..]`
+[RUNNING] `[..] rustc [..] --cfg foo[..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ).run();
@@ -1136,7 +1136,7 @@ fn target_rustflags_string_and_array_form2() {
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([..])
-[RUNNING] `rustc [..] --cfg foo[..]`
+[RUNNING] `[..] rustc [..] --cfg foo[..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ).run();

--- a/tests/testsuite/shell_quoting.rs
+++ b/tests/testsuite/shell_quoting.rs
@@ -26,7 +26,7 @@ fn features_are_quoted() {
             .env("MSYSTEM", "1")
             .with_status(101)
             .with_stderr_contains(
-                r#"[RUNNING] `rustc [..] --cfg 'feature="default"' --cfg 'feature="some_feature"' [..]`"#
+                r#"[RUNNING] `[..] rustc [..] --cfg 'feature="default"' --cfg 'feature="some_feature"' [..]`"#
             ).with_stderr_contains(
                 r#"
 Caused by:

--- a/tests/testsuite/support/mod.rs
+++ b/tests/testsuite/support/mod.rs
@@ -26,7 +26,7 @@ p.cargo("run --bin foo")
         "\
 [COMPILING] foo [..]
 [FINISHED] [..]
-[RUNNING] `target/debug/foo`
+[RUNNING] `[..] target/debug/foo`
 ",
     )
     .with_stdout("hi!")

--- a/tests/testsuite/support/mod.rs
+++ b/tests/testsuite/support/mod.rs
@@ -631,8 +631,8 @@ impl Execs {
     /// Be careful when using patterns such as `[..]`, because you may end up
     /// with multiple lines that might match, and this is not smart enough to
     /// do anything like longest-match.  For example, avoid something like:
-    ///     [RUNNING] `rustc [..]
-    ///     [RUNNING] `rustc --crate-name foo [..]
+    ///     [RUNNING] `[..] rustc [..]
+    ///     [RUNNING] `[..] rustc --crate-name foo [..]
     /// This will randomly fail if the other crate name is `bar`, and the
     /// order changes.
     pub fn with_stderr_unordered<S: ToString>(&mut self, expected: S) -> &mut Self {

--- a/tests/testsuite/test.rs
+++ b/tests/testsuite/test.rs
@@ -91,7 +91,7 @@ fn cargo_test_release() {
 [RUNNING] `[..]target/release/deps/foo-[..][EXE]`
 [RUNNING] `[..]target/release/deps/test-[..][EXE]`
 [DOCTEST] foo
-[RUNNING] `rustdoc --test [..]lib.rs[..]`",
+[RUNNING] `[..] rustdoc --test [..]lib.rs[..]`",
         ).with_stdout_contains_n("test test ... ok", 2)
         .with_stdout_contains("running 0 tests")
         .run();
@@ -151,7 +151,7 @@ fn cargo_test_verbose() {
         .with_stderr(
             "\
 [COMPILING] foo v0.5.0 ([CWD])
-[RUNNING] `rustc [..] src/main.rs [..]`
+[RUNNING] `[..] rustc [..] src/main.rs [..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `[..]target/debug/deps/foo-[..][EXE] hello`",
         ).with_stdout_contains("test test_hello ... ok")
@@ -1327,8 +1327,8 @@ fn test_run_implicit_example_target() {
 
     // Compiles myexm1 as normal, but does not run it.
     prj.cargo("test -v")
-        .with_stderr_contains("[RUNNING] `rustc [..]myexm1.rs [..]--crate-type bin[..]")
-        .with_stderr_contains("[RUNNING] `rustc [..]myexm2.rs [..]--test[..]")
+        .with_stderr_contains("[RUNNING] `[..] rustc [..]myexm1.rs [..]--crate-type bin[..]")
+        .with_stderr_contains("[RUNNING] `[..] rustc [..]myexm2.rs [..]--test[..]")
         .with_stderr_does_not_contain("[RUNNING] [..]myexm1-[..]")
         .with_stderr_contains("[RUNNING] [..]target/debug/examples/myexm2-[..]")
         .run();
@@ -1660,8 +1660,8 @@ fn example_bin_same_name() {
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([CWD])
-[RUNNING] `rustc [..]`
-[RUNNING] `rustc [..]`
+[RUNNING] `[..] rustc [..]`
+[RUNNING] `[..] rustc [..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ).run();
@@ -1733,7 +1733,7 @@ fn example_with_dev_dep() {
 [..]
 [..]
 [..]
-[RUNNING] `rustc --crate-name ex [..] --extern a=[..]`
+[RUNNING] `[..] rustc --crate-name ex [..] --extern a=[..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ).run();
@@ -2165,8 +2165,8 @@ fn bin_does_not_rebuild_tests() {
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([..])
-[RUNNING] `rustc [..] src/main.rs [..]`
-[RUNNING] `rustc [..] src/main.rs [..]`
+[RUNNING] `[..] rustc [..] src/main.rs [..]`
+[RUNNING] `[..] rustc [..] src/main.rs [..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ).run();
@@ -2220,8 +2220,8 @@ fn selective_test_optional_dep() {
         .with_stderr(
             "\
 [COMPILING] a v0.0.1 ([..])
-[RUNNING] `rustc [..] a/src/lib.rs [..]`
-[RUNNING] `rustc [..] a/src/lib.rs [..]`
+[RUNNING] `[..] rustc [..] a/src/lib.rs [..]`
+[RUNNING] `[..] rustc [..] a/src/lib.rs [..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ).run();
@@ -2313,7 +2313,7 @@ fn cfg_test_even_with_no_harness() {
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([..])
-[RUNNING] `rustc [..]`
+[RUNNING] `[..] rustc [..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `[..]`
 ",
@@ -2421,14 +2421,14 @@ fn pass_correct_cfgs_flags_to_rustdoc() {
         .with_stderr_contains(
             "\
 [DOCTEST] feature_a
-[RUNNING] `rustdoc --test [..]mock_serde_codegen[..]`",
+[RUNNING] `[..] rustdoc --test [..]mock_serde_codegen[..]`",
         ).run();
 
     p.cargo("test --verbose")
         .with_stderr_contains(
             "\
 [DOCTEST] foo
-[RUNNING] `rustdoc --test [..]feature_a[..]`",
+[RUNNING] `[..] rustdoc --test [..]feature_a[..]`",
         ).run();
 }
 
@@ -2688,8 +2688,8 @@ fn test_many_targets() {
         .with_stdout_contains("test bin_b ... ok")
         .with_stdout_contains("test test_a ... ok")
         .with_stdout_contains("test test_b ... ok")
-        .with_stderr_contains("[RUNNING] `rustc --crate-name a examples/a.rs [..]`")
-        .with_stderr_contains("[RUNNING] `rustc --crate-name b examples/b.rs [..]`")
+        .with_stderr_contains("[RUNNING] `[..] rustc --crate-name a examples/a.rs [..]`")
+        .with_stderr_contains("[RUNNING] `[..] rustc --crate-name b examples/b.rs [..]`")
         .run();
 }
 

--- a/tests/testsuite/tool_paths.rs
+++ b/tests/testsuite/tool_paths.rs
@@ -24,7 +24,7 @@ fn pathless_tools() {
         .with_stderr(
             "\
 [COMPILING] foo v0.5.0 ([CWD])
-[RUNNING] `rustc [..] -C ar=nonexistent-ar -C linker=nonexistent-linker [..]`
+[RUNNING] `[..] rustc [..] -C ar=nonexistent-ar -C linker=nonexistent-linker [..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ).run();
@@ -65,7 +65,7 @@ fn absolute_tools() {
     foo.cargo("build --verbose").with_stderr(&format!(
             "\
 [COMPILING] foo v0.5.0 ([CWD])
-[RUNNING] `rustc [..] -C ar={root}bogus/nonexistent-ar -C linker={root}bogus/nonexistent-linker [..]`
+[RUNNING] `[..] rustc [..] -C ar={root}bogus/nonexistent-ar -C linker={root}bogus/nonexistent-linker [..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
             root = root,
@@ -108,7 +108,7 @@ fn relative_tools() {
     p.cargo("build --verbose").cwd(p.root().join("bar")).with_stderr(&format!(
             "\
 [COMPILING] bar v0.5.0 ([CWD])
-[RUNNING] `rustc [..] -C ar={prefix}/./nonexistent-ar -C linker={prefix}/./tools/nonexistent-linker [..]`
+[RUNNING] `[..] rustc [..] -C ar={prefix}/./nonexistent-ar -C linker={prefix}/./tools/nonexistent-linker [..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
             prefix = prefix,
@@ -140,7 +140,7 @@ fn custom_runner() {
             "\
 [COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] `nonexistent-runner -r target/debug/foo[EXE] --param`
+[RUNNING] `[..] nonexistent-runner -r target/debug/foo[EXE] --param`
 ",
         ).run();
 
@@ -149,9 +149,9 @@ fn custom_runner() {
         .with_stderr_contains(
             "\
 [COMPILING] foo v0.0.1 ([CWD])
-[RUNNING] `rustc [..]`
+[RUNNING] `[..] rustc [..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] `nonexistent-runner -r [..]/target/debug/deps/test-[..][EXE] --param`
+[RUNNING] `[..] nonexistent-runner -r [..]/target/debug/deps/test-[..][EXE] --param`
 ",
         ).run();
 
@@ -160,10 +160,10 @@ fn custom_runner() {
         .with_stderr_contains(
             "\
 [COMPILING] foo v0.0.1 ([CWD])
-[RUNNING] `rustc [..]`
-[RUNNING] `rustc [..]`
+[RUNNING] `[..] rustc [..]`
+[RUNNING] `[..] rustc [..]`
 [FINISHED] release [optimized] target(s) in [..]
-[RUNNING] `nonexistent-runner -r [..]/target/release/deps/bench-[..][EXE] --param --bench`
+[RUNNING] `[..] nonexistent-runner -r [..]/target/release/deps/bench-[..][EXE] --param --bench`
 ",
         ).run();
 }
@@ -187,7 +187,7 @@ fn custom_runner_cfg() {
             "\
 [COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] `nonexistent-runner -r target/debug/foo[EXE] --param`
+[RUNNING] `[..] nonexistent-runner -r target/debug/foo[EXE] --param`
 ",
         )).run();
 }
@@ -219,7 +219,7 @@ fn custom_runner_cfg_precedence() {
             "\
             [COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] `nonexistent-runner -r target/debug/foo[EXE] --param`
+[RUNNING] `[..] nonexistent-runner -r target/debug/foo[EXE] --param`
 ",
         )).run();
 }


### PR DESCRIPTION
.. by trying to include the env vars in ProcessBuilder's Display.

Before:

    $ cargo +nightly clean
    $ cargo +nightly -v fix
       Compiling proc-macro2 v0.4.13
    ...
         Running `/Users/dnw/.rustup/toolchains/nightly-x86_64-apple-darwin/bin/cargo --crate-name build_script_build /Users/dnw/.cargo/registry/src/github.com-1ecc6299db9ec823/proc-macro2-0.4.13/build.rs --crate-type bin --emit=dep-info,link -C debuginfo=2 --cfg 'feature="default"' --cfg 'feature="proc-macro"' -C metadata=508bb5643dd19cf3 -C extra-filename=-508bb5643dd19cf3 --out-dir /d/cargo/target/debug/build/proc-macro2-508bb5643dd19cf3 -L dependency=/d/cargo/target/debug/deps --cap-lints allow`
    ...
    ^C

After:

    $ cargo +nightly build
    ...
       Compiling cargo v0.31.0 (file:///d/cargo)
    $ mv target/debug/cargo .
    $ ./cargo clean
    $ ./cargo -v fix --allow-dirty
       Compiling proc-macro2 v0.4.13
    ...
         Running `DYLD_LIBRARY_PATH='/d/cargo/target/debug/deps:/Users/dnw/.rustup/toolchains/stable-x86_64-apple-darwin/lib:/Users/dnw/.rustup/toolchains/stable-x86_64-apple-darwin/lib:' RUSTC=rustc CARGO_PKG_HOMEPAGE='https://github.com/alexcrichton/proc-macro2' CARGO_PKG_AUTHORS='Alex Crichton <alex@alexcrichton.com>' CARGO_PKG_VERSION=0.4.13 __CARGO_FIX_PLZ='127.0.0.1:56360' CARGO=/d/cargo/cargo CARGO_PKG_VERSION_MAJOR=0 CARGO_PKG_VERSION_PATCH=13 __CARGO_FIX_DIAGNOSTICS_SERVER='127.0.0.1:56361' CARGO_MANIFEST_DIR=/Users/dnw/.cargo/registry/src/github.com-1ecc6299db9ec823/proc-macro2-0.4.13 CARGO_PKG_VERSION_MINOR=4 CARGO_PKG_DESCRIPTION='A stable implementation of the upcoming new `proc_macro` API. Comes with an
    option, off by default, to also reimplement itself in terms of the upstream
    unstable API.
    ' CARGO_PKG_VERSION_PRE= CARGO_PKG_NAME=proc-macro2 /d/cargo/./cargo --crate-name build_script_build /Users/dnw/.cargo/registry/src/github.com-1ecc6299db9ec823/proc-macro2-0.4.13/build.rs --color always --crate-type bin --emit=dep-info,link -C debuginfo=2 --cfg 'feature="default"' --cfg 'feature="proc-macro"' -C metadata=4a230ad2dbc01421 -C extra-filename=-4a230ad2dbc01421 --out-dir /d/cargo/target/debug/build/proc-macro2-4a230ad2dbc01421 -L dependency=/d/cargo/target/debug/deps --cap-lints allow`
    ...
    ^C

Fixes #5964