### PR TITLE
Allow multiple pre-release versions of a crate to co-exist

### DIFF
--- a/src/cargo/core/resolver/mod.rs
+++ b/src/cargo/core/resolver/mod.rs
@@ -782,6 +782,10 @@ impl RemainingCandidates {
 // Versions `a` and `b` are compatible if their left-most nonzero digit is the
 // same.
 fn compatible(a: &semver::Version, b: &semver::Version) -> bool {
+    if !a.pre.is_empty() || !b.pre.is_empty() {
+        return a == b;
+    }
+
     if a.major != b.major {
         return false;
     }

--- a/tests/testsuite/resolve.rs
+++ b/tests/testsuite/resolve.rs
@@ -509,7 +509,7 @@ fn resolving_backtrack_features() {
 }
 
 #[test]
-fn resolving_allows_multiple_compatible_versions() {
+fn resolving_allows_multiple_incompatible_versions() {
     let reg = registry(vec![
         pkg!(("foo", "1.0.0")),
         pkg!(("foo", "2.0.0")),
@@ -532,6 +532,39 @@ fn resolving_allows_multiple_compatible_versions() {
             ("foo", "2.0.0"),
             ("foo", "0.1.0"),
             ("foo", "0.2.0"),
+            ("d1", "1.0.0"),
+            ("d2", "1.0.0"),
+            ("d3", "1.0.0"),
+            ("d4", "1.0.0"),
+            ("bar", "1.0.0"),
+        ]),
+    );
+}
+
+#[test]
+fn resolving_allows_multiple_prerelease_versions() {
+    let reg = registry(vec![
+        pkg!(("foo", "1.0.0")),
+        pkg!(("foo", "2.0.0")),
+        pkg!(("foo", "2.0.0-alpha")),
+        pkg!(("foo", "2.0.0-beta")),
+        pkg!("bar" => ["d1", "d2", "d3", "d4"]),
+        pkg!("d1" => [dep_req("foo", "=1")]),
+        pkg!("d2" => [dep_req("foo", "=2")]),
+        pkg!("d3" => [dep_req("foo", "=2.0.0-alpha")]),
+        pkg!("d4" => [dep_req("foo", "=2.0.0-beta")]),
+    ]);
+
+    let res = resolve(&pkg_id("root"), vec![dep("bar")], &reg).unwrap();
+
+    assert_contains(
+        &res,
+        &names(&[
+            ("root", "1.0.0"),
+            ("foo", "1.0.0"),
+            ("foo", "2.0.0"),
+            ("foo", "2.0.0-alpha"),
+            ("foo", "2.0.0-beta"),
             ("d1", "1.0.0"),
             ("d2", "1.0.0"),
             ("d3", "1.0.0"),


### PR DESCRIPTION
Fixes #6016

Does not change behaviour described in #2222

The semver crate currently differs from the spec in that it believes that a version `2.0.0` is compatible with a version requirement of `^2.0.0-alpha`. The spec says that all pre-release versions are unstable, and therefore not necessarily compatible with any other versions. This is why the test needs to use exact version requirements to exhibit the behaviour where multiple pre-release versions are included.

I also renamed the `resolving_allows_multiple_compatible_versions` test as it is actually testing that *incompatible* versions can co-exist (this relationship should probably not be called `is_compatible` to begin with!)