### PR TITLE
Validate that the package name contains no invalid characters.

### DIFF
--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -810,6 +810,16 @@ impl TomlManifest {
             bail!("package name cannot be an empty string")
         }
 
+        for c in package_name.chars() {
+            if c.is_alphanumeric() {
+                continue;
+            }
+            if c == '_' || c == '-' {
+                continue;
+            }
+            bail!("Invalid character `{}` in package name: `{}`", c, package_name)
+        }
+
         let pkgid = project.to_package_id(source_id)?;
 
         let edition = if let Some(ref edition) = project.edition {

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -257,7 +257,7 @@ Caused by:
 }
 
 #[test]
-fn cargo_compile_with_invalid_package_name() {
+fn cargo_compile_with_empty_package_name() {
     let p = project()
         .file("Cargo.toml", &basic_manifest("", "0.0.0"))
         .build();
@@ -270,6 +270,24 @@ fn cargo_compile_with_invalid_package_name() {
 
 Caused by:
   package name cannot be an empty string
+",
+        ).run();
+}
+
+#[test]
+fn cargo_compile_with_invalid_package_name() {
+    let p = project()
+        .file("Cargo.toml", &basic_manifest("foo::bar", "0.0.0"))
+        .build();
+
+    p.cargo("build")
+        .with_status(101)
+        .with_stderr(
+            "\
+[ERROR] failed to parse manifest at `[..]`
+
+Caused by:
+  Invalid character `:` in package name: `foo::bar`
 ",
         ).run();
 }


### PR DESCRIPTION
Fixes #2388.

Invalid characters are currently defined as alphanumeric, _, and -. This matches the rustc restrictions but is not as restrictive as `cargo new` or crates.io.

Mostly this is just so there will be better error messages in the case where characters in the package name aren't valid path characters.