### PR TITLE
Add newline spacing to stale bot's message

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -11,7 +11,7 @@ staleLabel: stale
 
 markComment: >
   As there hasn't been any activity here in over 180 days I've marked this as
-  stale and if no further activity happens for 7 days I'll will close it.
+  stale and if no further activity happens for 7 days I will close it.
 
 
   [I'm a bot](https://github.com/probot/stale) so this may be in error!  If this

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -10,7 +10,7 @@ exemptLabels:
 staleLabel: stale
 
 markComment: >
-  As there hasn't been any activity here in over 180 days I've marked this as
+  As there hasn't been any activity here in over 6 months I've marked this as
   stale and if no further activity happens for 7 days I will close it.
 
 

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -25,7 +25,6 @@ markComment: >
     * If so, what is blocking it?
     * Is it known what could be done to help move this forward?
 
-
   Thank you for contributing!
 
 

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -13,18 +13,24 @@ markComment: >
   As there hasn't been any activity here in over 180 days I've marked this as
   stale and if no further activity happens for 7 days I'll will close it.
 
+
   [I'm a bot](https://github.com/probot/stale) so this may be in error!  If this
   issue should remain open, could someone (the author, a team member, or any
   interested party) please comment to that effect?
+
 
   The team would be especially grateful if such a comment included details such
   as:
 
   * Is this still relevant?
+
   * If so, what is blocking it?
+
   * Is it known what could be done to help move this forward?
 
+
   Thank you for contributing!
+
 
   If you're reading this comment from the distant future, fear not if this
   was closed automatically. If you believe it's still an issue please leave a

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -21,12 +21,9 @@ markComment: >
 
   The team would be especially grateful if such a comment included details such
   as:
-
-  * Is this still relevant?
-
-  * If so, what is blocking it?
-
-  * Is it known what could be done to help move this forward?
+    * Is this still relevant?
+    * If so, what is blocking it?
+    * Is it known what could be done to help move this forward?
 
 
   Thank you for contributing!


### PR DESCRIPTION
So our first incantation produced:

https://github.com/rust-lang/cargo/issues/4866#issuecomment-421597598

Perhaps there's a better indicator to use, but for now let's just fix
this with more newlines.

r? @alexcrichton