### PR TITLE
use more common semver terminology for clarity in docs

### DIFF
--- a/src/doc/src/reference/manifest.md
+++ b/src/doc/src/reference/manifest.md
@@ -26,7 +26,7 @@ Versioning](http://semver.org/), so make sure you follow some basic rules:
   structs or variants to enums.
 * After 1.0.0, only make breaking changes when you increment the major version.
   Don’t break the build.
-* After 1.0.0, don’t add any new public API (no new `pub` anything) in tiny
+* After 1.0.0, don’t add any new public API (no new `pub` anything) in patch-level
   versions. Always increment the minor version if you add any new `pub` structs,
   traits, fields, types, functions, methods or anything else.
 * Use version numbers with three numeric parts such as 1.0.0 rather than 1.0.


### PR DESCRIPTION
`tiny` made me wonder whether that means `patch-level`, `minor` or both. I think `patch-level` is more common semver terminology.