### PR TITLE
[beta]: Fixup the 1.30.0 branch

### DIFF
--- a/src/bin/cargo/cli.rs
+++ b/src/bin/cargo/cli.rs
@@ -34,7 +34,6 @@ Available unstable (nightly-only) flags:
     -Z offline          -- Offline mode that does not perform network requests
     -Z unstable-options -- Allow the usage of unstable options such as --registry
     -Z config-profile   -- Read profiles from .cargo/config files
-    -Z compile-progress -- Display a progress bar while compiling
 
 Run with 'cargo -Z [FLAG] [SUBCOMMAND]'"
         );

--- a/src/bin/cargo/command_prelude.rs
+++ b/src/bin/cargo/command_prelude.rs
@@ -315,6 +315,7 @@ pub trait ArgMatchesExt {
             ),
             target_rustdoc_args: None,
             target_rustc_args: None,
+            local_rustdoc_args: None,
             export_dir: None,
         };
         Ok(opts)

--- a/src/bin/cargo/commands/doc.rs
+++ b/src/bin/cargo/commands/doc.rs
@@ -51,7 +51,7 @@ pub fn exec(config: &mut Config, args: &ArgMatches) -> CliResult {
         deps: !args.is_present("no-deps"),
     };
     let mut compile_opts = args.compile_options(config, mode)?;
-    compile_opts.target_rustdoc_args = if args.is_present("document-private-items") {
+    compile_opts.local_rustdoc_args = if args.is_present("document-private-items") {
         Some(vec!["--document-private-items".to_string()])
     } else {
         None

--- a/src/cargo/core/compiler/build_context/mod.rs
+++ b/src/cargo/core/compiler/build_context/mod.rs
@@ -24,12 +24,8 @@ pub struct BuildContext<'a, 'cfg: 'a> {
     pub resolve: &'a Resolve,
     pub profiles: &'a Profiles,
     pub build_config: &'a BuildConfig,
-    /// This is a workaround to carry the extra compiler args for either
-    /// `rustc` or `rustdoc` given on the command-line for the commands `cargo
-    /// rustc` and `cargo rustdoc`.  These commands only support one target,
-    /// but we don't want the args passed to any dependencies, so we include
-    /// the `Unit` corresponding to the top-level target.
-    pub extra_compiler_args: Option<(Unit<'a>, Vec<String>)>,
+    /// Extra compiler args for either `rustc` or `rustdoc`.
+    pub extra_compiler_args: HashMap<Unit<'a>, Vec<String>>,
     pub packages: &'a PackageSet<'cfg>,
 
     /// Information about the compiler
@@ -51,7 +47,7 @@ impl<'a, 'cfg> BuildContext<'a, 'cfg> {
         config: &'cfg Config,
         build_config: &'a BuildConfig,
         profiles: &'a Profiles,
-        extra_compiler_args: Option<(Unit<'a>, Vec<String>)>,
+        extra_compiler_args: HashMap<Unit<'a>, Vec<String>>,
     ) -> CargoResult<BuildContext<'a, 'cfg>> {
         let incremental_env = match env::var("CARGO_INCREMENTAL") {
             Ok(v) => Some(v == "1"),
@@ -200,12 +196,7 @@ impl<'a, 'cfg> BuildContext<'a, 'cfg> {
     }
 
     pub fn extra_args_for(&self, unit: &Unit<'a>) -> Option<&Vec<String>> {
-        if let Some((ref args_unit, ref args)) = self.extra_compiler_args {
-            if args_unit == unit {
-                return Some(args);
-            }
-        }
-        None
+        self.extra_compiler_args.get(unit)
     }
 
     /// Return the list of filenames read by cargo to generate the BuildContext

--- a/src/cargo/core/compiler/job_queue.rs
+++ b/src/cargo/core/compiler/job_queue.rs
@@ -237,9 +237,6 @@ impl<'a> JobQueue<'a> {
         //       currently a pretty big task. This is issue #5695.
         let mut error = None;
         let mut progress = Progress::with_style("Building", ProgressStyle::Ratio, cx.bcx.config);
-        if !cx.bcx.config.cli_unstable().compile_progress {
-            progress.disable();
-        }
         let total = self.queue.len();
         loop {
             // Dequeue as much work as we can, learning about everything

--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -10,11 +10,10 @@ use serde_json;
 
 use core::manifest::TargetSourcePath;
 use core::profiles::{Lto, Profile};
-use core::shell::ColorChoice;
 use core::{PackageId, Target};
 use util::errors::{CargoResult, CargoResultExt, Internal};
 use util::paths;
-use util::{self, machine_message, Freshness, ProcessBuilder};
+use util::{self, machine_message, Freshness, ProcessBuilder, process};
 use util::{internal, join_paths, profile};
 
 use self::build_plan::BuildPlan;
@@ -241,8 +240,6 @@ fn rustc<'a, 'cfg>(
         .unwrap_or_else(|| cx.bcx.config.cwd())
         .to_path_buf();
 
-    let should_capture_output = cx.bcx.config.cli_unstable().compile_progress;
-
     return Ok(Work::new(move |state| {
         // Only at runtime have we discovered what the extra -L and -l
         // arguments are for native libraries, so we process those here. We
@@ -292,12 +289,7 @@ fn rustc<'a, 'cfg>(
         } else if build_plan {
             state.build_plan(buildkey, rustc.clone(), outputs.clone());
         } else {
-            let exec_result = if should_capture_output {
-                exec.exec_and_capture_output(rustc, &package_id, &target, mode, state)
-            } else {
-                exec.exec(rustc, &package_id, &target, mode)
-            };
-            exec_result
+            exec.exec_and_capture_output(rustc, &package_id, &target, mode, state)
                 .map_err(Internal::new)
                 .chain_err(|| format!("Could not compile `{}`.", name))?;
         }
@@ -591,7 +583,12 @@ fn rustdoc<'a, 'cfg>(cx: &mut Context<'a, 'cfg>, unit: &Unit<'a>) -> CargoResult
     rustdoc.arg("--crate-name").arg(&unit.target.crate_name());
     add_path_args(bcx, unit, &mut rustdoc);
     add_cap_lints(bcx, unit, &mut rustdoc);
-    add_color(bcx, &mut rustdoc);
+
+    let mut can_add_color_process = process(&*bcx.config.rustdoc()?);
+    can_add_color_process.args(&["--color", "never", "-V"]);
+    if bcx.rustc.cached_success(&can_add_color_process)? {
+        add_color(bcx, &mut rustdoc);
+    }
 
     if unit.kind != Kind::Host {
         if let Some(ref target) = bcx.build_config.requested_target {
@@ -629,8 +626,6 @@ fn rustdoc<'a, 'cfg>(cx: &mut Context<'a, 'cfg>, unit: &Unit<'a>) -> CargoResult
     let package_id = unit.pkg.package_id().clone();
     let target = unit.target.clone();
 
-    let should_capture_output = cx.bcx.config.cli_unstable().compile_progress;
-
     Ok(Work::new(move |state| {
         if let Some(output) = build_state.outputs.lock().unwrap().get(&key) {
             for cfg in output.cfgs.iter() {
@@ -649,10 +644,8 @@ fn rustdoc<'a, 'cfg>(cx: &mut Context<'a, 'cfg>, unit: &Unit<'a>) -> CargoResult
                     &mut |line| json_stderr(line, &package_id, &target),
                     false,
                 ).map(drop)
-        } else if should_capture_output {
-            state.capture_output(&rustdoc, false).map(drop)
         } else {
-            rustdoc.exec()
+            state.capture_output(&rustdoc, false).map(drop)
         };
         exec_result.chain_err(|| format!("Could not document `{}`.", name))?;
         Ok(())
@@ -709,12 +702,9 @@ fn add_cap_lints(bcx: &BuildContext, unit: &Unit, cmd: &mut ProcessBuilder) {
 }
 
 fn add_color(bcx: &BuildContext, cmd: &mut ProcessBuilder) {
-    let capture_output = bcx.config.cli_unstable().compile_progress;
     let shell = bcx.config.shell();
-    if capture_output || shell.color_choice() != ColorChoice::CargoAuto {
-        let color = if shell.supports_color() { "always" } else { "never" };
-        cmd.args(&["--color", color]);
-    }
+    let color = if shell.supports_color() { "always" } else { "never" };
+    cmd.args(&["--color", color]);
 }
 
 fn add_error_format(bcx: &BuildContext, cmd: &mut ProcessBuilder) {

--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -318,7 +318,6 @@ pub struct CliUnstable {
     pub package_features: bool,
     pub advanced_env: bool,
     pub config_profile: bool,
-    pub compile_progress: bool,
 }
 
 impl CliUnstable {
@@ -355,7 +354,6 @@ impl CliUnstable {
             "package-features" => self.package_features = true,
             "advanced-env" => self.advanced_env = true,
             "config-profile" => self.config_profile = true,
-            "compile-progress" => self.compile_progress = true,
             _ => bail!("unknown `-Z` flag specified: {}", k),
         }
 

--- a/src/cargo/core/shell.rs
+++ b/src/cargo/core/shell.rs
@@ -359,18 +359,51 @@ mod imp {
     extern crate winapi;
 
     use std::mem;
+    use std::ptr;
+    use self::winapi::um::fileapi::*;
+    use self::winapi::um::handleapi::*;
     use self::winapi::um::processenv::*;
     use self::winapi::um::winbase::*;
     use self::winapi::um::wincon::*;
+    use self::winapi::um::winnt::*;
 
     pub fn stderr_width() -> Option<usize> {
         unsafe {
             let stdout = GetStdHandle(STD_ERROR_HANDLE);
             let mut csbi: CONSOLE_SCREEN_BUFFER_INFO = mem::zeroed();
-            if GetConsoleScreenBufferInfo(stdout, &mut csbi) == 0 {
+            if GetConsoleScreenBufferInfo(stdout, &mut csbi) != 0 {
+                return Some((csbi.srWindow.Right - csbi.srWindow.Left) as usize)
+            }
+
+            // On mintty/msys/cygwin based terminals, the above fails with
+            // INVALID_HANDLE_VALUE. Use an alternate method which works
+            // in that case as well.
+            let h = CreateFileA("CONOUT$\0".as_ptr() as *const CHAR,
+                GENERIC_READ | GENERIC_WRITE,
+                FILE_SHARE_READ | FILE_SHARE_WRITE,
+                ptr::null_mut(),
+                OPEN_EXISTING,
+                0,
+                ptr::null_mut()
+            );
+            if h == INVALID_HANDLE_VALUE {
                 return None;
             }
-            Some((csbi.srWindow.Right - csbi.srWindow.Left) as usize)
+
+            let mut csbi: CONSOLE_SCREEN_BUFFER_INFO = mem::zeroed();
+            let rc = GetConsoleScreenBufferInfo(h, &mut csbi);
+            CloseHandle(h);
+            if rc != 0 {
+                let width = (csbi.srWindow.Right - csbi.srWindow.Left) as usize;
+                // Some terminals, such as mintty, always return 79 instead of
+                // the actual width. In that case, use a conservative value.
+                if width == 79 {
+                    return Some(60);
+                } else {
+                    return Some(width);
+                }
+            }
+            return None;
         }
     }
 }

--- a/src/cargo/core/source/source_id.rs
+++ b/src/cargo/core/source/source_id.rs
@@ -213,7 +213,7 @@ impl SourceId {
         if self.is_default_registry() {
             "crates.io index".to_string()
         } else {
-            format!("`{}` index", self.url())
+            format!("`{}` index", url_display(self.url()))
         }
     }
 
@@ -367,6 +367,18 @@ impl<'de> de::Deserialize<'de> for SourceId {
     }
 }
 
+fn url_display(url: &Url) -> String {
+    if url.scheme() == "file" {
+        if let Ok(path) = url.to_file_path() {
+            if let Some(path_str) = path.to_str() {
+                return path_str.to_string();
+            }
+        }
+    }
+
+    url.as_str().to_string()
+}
+
 impl fmt::Display for SourceId {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         match *self.inner {
@@ -374,13 +386,15 @@ impl fmt::Display for SourceId {
                 kind: Kind::Path,
                 ref url,
                 ..
-            } => fmt::Display::fmt(url, f),
+            } => write!(f, "{}", url_display(url)),
             SourceIdInner {
                 kind: Kind::Git(ref reference),
                 ref url,
                 ref precise,
                 ..
             } => {
+                // Don't replace the URL display for git references,
+                // because those are kind of expected to be URLs.
                 write!(f, "{}", url)?;
                 if let Some(pretty) = reference.pretty_ref() {
                     write!(f, "?{}", pretty)?;
@@ -401,12 +415,12 @@ impl fmt::Display for SourceId {
                 kind: Kind::LocalRegistry,
                 ref url,
                 ..
-            } => write!(f, "registry `{}`", url),
+            } => write!(f, "registry `{}`", url_display(url)),
             SourceIdInner {
                 kind: Kind::Directory,
                 ref url,
                 ..
-            } => write!(f, "dir {}", url),
+            } => write!(f, "dir {}", url_display(url)),
         }
     }
 }

--- a/src/cargo/ops/cargo_clean.rs
+++ b/src/cargo/ops/cargo_clean.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::fs;
 use std::path::Path;
 
@@ -97,7 +98,7 @@ pub fn clean(ws: &Workspace, opts: &CleanOptions) -> CargoResult<()> {
         opts.config,
         &build_config,
         profiles,
-        None,
+        HashMap::new(),
     )?;
     let mut cx = Context::new(config, &bcx)?;
     cx.prepare_units(None, &units)?;

--- a/src/cargo/ops/cargo_package.rs
+++ b/src/cargo/ops/cargo_package.rs
@@ -444,6 +444,7 @@ fn run_verify(ws: &Workspace, tar: &FileLock, opts: &PackageOpts) -> CargoResult
             },
             target_rustdoc_args: None,
             target_rustc_args: None,
+            local_rustdoc_args: None,
             export_dir: None,
         },
         &exec,

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -810,6 +810,16 @@ impl TomlManifest {
             bail!("package name cannot be an empty string")
         }
 
+        for c in package_name.chars() {
+            if c.is_alphanumeric() {
+                continue;
+            }
+            if c == '_' || c == '-' {
+                continue;
+            }
+            bail!("Invalid character `{}` in package name: `{}`", c, package_name)
+        }
+
         let pkgid = project.to_package_id(source_id)?;
 
         let edition = if let Some(ref edition) = project.edition {

--- a/src/doc/src/reference/specifying-dependencies.md
+++ b/src/doc/src/reference/specifying-dependencies.md
@@ -250,13 +250,13 @@ In any case, typically all you need to do now is:
 
 ```console
 $ cargo build
-   Compiling uuid v1.0.0 (file://.../uuid)
-   Compiling my-library v0.1.0 (file://.../my-library)
+   Compiling uuid v1.0.0 (.../uuid)
+   Compiling my-library v0.1.0 (.../my-library)
     Finished dev [unoptimized + debuginfo] target(s) in 0.32 secs
 ```
 
 And that's it! You're now building with the local version of `uuid` (note the
-`file://` in the build output). If you don't see the `file://` version getting
+path in parentheses in the build output). If you don't see the local path version getting
 built then you may need to run `cargo update -p uuid --precise $version` where
 `$version` is the version of the locally checked out copy of `uuid`.
 
@@ -376,7 +376,7 @@ my-library = { git = 'https://example.com/git/my-library' }
 uuid = "1.0"
 
 [patch.crates-io]
-uuid = { git = 'https://github.com/rust-lang-nursery/uuid', version = '2.0.0' }
+uuid = { git = 'https://github.com/rust-lang-nursery/uuid', branch = '2.0.0' }
 ```
 
 Note that this will actually resolve to two versions of the `uuid` crate. The

--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -294,22 +294,6 @@ Example:
 cargo +nightly build --build-plan -Z unstable-options
 ```
 
-### Compile progress
-* Tracking Issue: [rust-lang/cargo#2536](https://github.com/rust-lang/cargo/issues/2536)
-
-The `-Z compile-progress` flag enables a progress bar while compiling.
-
-```console
-$ cargo +nightly build -Z compile-progress
-   Compiling libc v0.2.41
-   Compiling void v1.0.2
-   Compiling lazy_static v1.0.1
-   Compiling regex v1.0.0
-   Compiling ucd-util v0.1.1
-   Compiling utf8-ranges v1.0.0
-    Building [=======>                                                  ] 2/14: libc, regex, uc...
-```
-
 ### default-run
 * Original issue: [#2200](https://github.com/rust-lang/cargo/issues/2200)
 

--- a/tests/testsuite/alt_registry.rs
+++ b/tests/testsuite/alt_registry.rs
@@ -57,12 +57,12 @@ fn depend_on_alt_registry() {
         .with_stderr(&format!(
             "\
 [UPDATING] `{reg}` index
-[DOWNLOADING] bar v0.0.1 (registry `file://[..]`)
-[COMPILING] bar v0.0.1 (registry `file://[..]`)
-[COMPILING] foo v0.0.1 (CWD)
+[DOWNLOADING] bar v0.0.1 (registry `[ROOT][..]`)
+[COMPILING] bar v0.0.1 (registry `[ROOT][..]`)
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
 ",
-            reg = registry::alt_registry()
+            reg = registry::alt_registry_path().to_str().unwrap()
         )).run();
 
     p.cargo("clean").masquerade_as_nightly_cargo().run();
@@ -72,8 +72,8 @@ fn depend_on_alt_registry() {
         .masquerade_as_nightly_cargo()
         .with_stderr(
             "\
-[COMPILING] bar v0.0.1 (registry `file://[..]`)
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] bar v0.0.1 (registry `[ROOT][..]`)
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
 ",
         ).run();
@@ -110,14 +110,14 @@ fn depend_on_alt_registry_depends_on_same_registry_no_index() {
         .with_stderr(&format!(
             "\
 [UPDATING] `{reg}` index
-[DOWNLOADING] [..] v0.0.1 (registry `file://[..]`)
-[DOWNLOADING] [..] v0.0.1 (registry `file://[..]`)
-[COMPILING] baz v0.0.1 (registry `file://[..]`)
-[COMPILING] bar v0.0.1 (registry `file://[..]`)
-[COMPILING] foo v0.0.1 (CWD)
+[DOWNLOADING] [..] v0.0.1 (registry `[ROOT][..]`)
+[DOWNLOADING] [..] v0.0.1 (registry `[ROOT][..]`)
+[COMPILING] baz v0.0.1 (registry `[ROOT][..]`)
+[COMPILING] bar v0.0.1 (registry `[ROOT][..]`)
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
 ",
-            reg = registry::alt_registry()
+            reg = registry::alt_registry_path().to_str().unwrap()
         )).run();
 }
 
@@ -152,14 +152,14 @@ fn depend_on_alt_registry_depends_on_same_registry() {
         .with_stderr(&format!(
             "\
 [UPDATING] `{reg}` index
-[DOWNLOADING] [..] v0.0.1 (registry `file://[..]`)
-[DOWNLOADING] [..] v0.0.1 (registry `file://[..]`)
-[COMPILING] baz v0.0.1 (registry `file://[..]`)
-[COMPILING] bar v0.0.1 (registry `file://[..]`)
-[COMPILING] foo v0.0.1 (CWD)
+[DOWNLOADING] [..] v0.0.1 (registry `[ROOT][..]`)
+[DOWNLOADING] [..] v0.0.1 (registry `[ROOT][..]`)
+[COMPILING] baz v0.0.1 (registry `[ROOT][..]`)
+[COMPILING] bar v0.0.1 (registry `[ROOT][..]`)
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
 ",
-            reg = registry::alt_registry()
+            reg = registry::alt_registry_path().to_str().unwrap()
         )).run();
 }
 
@@ -195,15 +195,15 @@ fn depend_on_alt_registry_depends_on_crates_io() {
             "\
 [UPDATING] `{alt_reg}` index
 [UPDATING] `{reg}` index
-[DOWNLOADING] [..] v0.0.1 (registry `file://[..]`)
-[DOWNLOADING] [..] v0.0.1 (registry `file://[..]`)
-[COMPILING] baz v0.0.1 (registry `file://[..]`)
-[COMPILING] bar v0.0.1 (registry `file://[..]`)
-[COMPILING] foo v0.0.1 (CWD)
+[DOWNLOADING] [..] v0.0.1 (registry `[ROOT][..]`)
+[DOWNLOADING] [..] v0.0.1 (registry `[ROOT][..]`)
+[COMPILING] baz v0.0.1 (registry `[ROOT][..]`)
+[COMPILING] bar v0.0.1 (registry `[ROOT][..]`)
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
 ",
-            alt_reg = registry::alt_registry(),
-            reg = registry::registry()
+            alt_reg = registry::alt_registry_path().to_str().unwrap(),
+            reg = registry::registry_path().to_str().unwrap()
         )).run();
 }
 
@@ -235,8 +235,8 @@ fn registry_and_path_dep_works() {
         .masquerade_as_nightly_cargo()
         .with_stderr(
             "\
-[COMPILING] bar v0.0.1 (CWD/bar)
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] bar v0.0.1 ([CWD]/bar)
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
 ",
         ).run();
@@ -359,13 +359,15 @@ fn alt_registry_and_crates_io_deps() {
         .masquerade_as_nightly_cargo()
         .with_stderr_contains(format!(
             "[UPDATING] `{}` index",
-            registry::alt_registry()
-        )).with_stderr_contains(&format!("[UPDATING] `{}` index", registry::registry()))
-        .with_stderr_contains("[DOWNLOADING] crates_io_dep v0.0.1 (registry `file://[..]`)")
-        .with_stderr_contains("[DOWNLOADING] alt_reg_dep v0.1.0 (registry `file://[..]`)")
-        .with_stderr_contains("[COMPILING] alt_reg_dep v0.1.0 (registry `file://[..]`)")
+            registry::alt_registry_path().to_str().unwrap()
+        )).with_stderr_contains(&format!(
+            "[UPDATING] `{}` index",
+            registry::registry_path().to_str().unwrap()))
+        .with_stderr_contains("[DOWNLOADING] crates_io_dep v0.0.1 (registry `[ROOT][..]`)")
+        .with_stderr_contains("[DOWNLOADING] alt_reg_dep v0.1.0 (registry `[ROOT][..]`)")
+        .with_stderr_contains("[COMPILING] alt_reg_dep v0.1.0 (registry `[ROOT][..]`)")
         .with_stderr_contains("[COMPILING] crates_io_dep v0.0.1")
-        .with_stderr_contains("[COMPILING] foo v0.0.1 (CWD)")
+        .with_stderr_contains("[COMPILING] foo v0.0.1 ([CWD])")
         .with_stderr_contains("[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s")
         .run();
 }

--- a/tests/testsuite/bad_config.rs
+++ b/tests/testsuite/bad_config.rs
@@ -641,7 +641,7 @@ fn unused_keys() {
         .with_stderr(
             "\
 warning: unused manifest key: target.foo.bar
-[COMPILING] foo v0.1.0 (CWD)
+[COMPILING] foo v0.1.0 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ).run();

--- a/tests/testsuite/bench.rs
+++ b/tests/testsuite/bench.rs
@@ -39,7 +39,7 @@ fn cargo_bench_simple() {
     p.cargo("bench")
         .with_stderr(
             "\
-[COMPILING] foo v0.5.0 (CWD)
+[COMPILING] foo v0.5.0 ([CWD])
 [FINISHED] release [optimized] target(s) in [..]
 [RUNNING] target/release/deps/foo-[..][EXE]",
         ).with_stdout_contains("test bench_hello ... bench: [..]")
@@ -78,7 +78,7 @@ fn bench_bench_implicit() {
     p.cargo("bench --benches")
         .with_stderr(
             "\
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] release [optimized] target(s) in [..]
 [RUNNING] target/release/deps/foo-[..][EXE]
 [RUNNING] target/release/deps/mybench-[..][EXE]
@@ -119,7 +119,7 @@ fn bench_bin_implicit() {
     p.cargo("bench --bins")
         .with_stderr(
             "\
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] release [optimized] target(s) in [..]
 [RUNNING] target/release/deps/foo-[..][EXE]
 ",
@@ -151,7 +151,7 @@ fn bench_tarname() {
     p.cargo("bench --bench bin2")
         .with_stderr(
             "\
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] release [optimized] target(s) in [..]
 [RUNNING] target/release/deps/bin2-[..][EXE]
 ",
@@ -215,7 +215,7 @@ fn cargo_bench_verbose() {
     p.cargo("bench -v hello")
         .with_stderr(
             "\
-[COMPILING] foo v0.5.0 (CWD)
+[COMPILING] foo v0.5.0 ([CWD])
 [RUNNING] `rustc [..] src/main.rs [..]`
 [FINISHED] release [optimized] target(s) in [..]
 [RUNNING] `[..]target/release/deps/foo-[..][EXE] hello --bench`",
@@ -305,7 +305,7 @@ fn cargo_bench_failing_test() {
         .with_stdout_contains("test bench_hello ...[..]")
         .with_stderr_contains(
             "\
-[COMPILING] foo v0.5.0 (CWD)[..]
+[COMPILING] foo v0.5.0 ([CWD])[..]
 [FINISHED] release [optimized] target(s) in [..]
 [RUNNING] target/release/deps/foo-[..][EXE]",
         ).with_either_contains(
@@ -372,7 +372,7 @@ fn bench_with_lib_dep() {
     p.cargo("bench")
         .with_stderr(
             "\
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] release [optimized] target(s) in [..]
 [RUNNING] target/release/deps/foo-[..][EXE]
 [RUNNING] target/release/deps/baz-[..][EXE]",
@@ -433,7 +433,7 @@ fn bench_with_deep_lib_dep() {
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([..])
-[COMPILING] bar v0.0.1 (CWD)
+[COMPILING] bar v0.0.1 ([CWD])
 [FINISHED] release [optimized] target(s) in [..]
 [RUNNING] target/release/deps/bar-[..][EXE]",
         ).with_stdout_contains("test bar_bench ... bench: [..]")
@@ -486,7 +486,7 @@ fn external_bench_explicit() {
     p.cargo("bench")
         .with_stderr(
             "\
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] release [optimized] target(s) in [..]
 [RUNNING] target/release/deps/foo-[..][EXE]
 [RUNNING] target/release/deps/bench-[..][EXE]",
@@ -530,7 +530,7 @@ fn external_bench_implicit() {
     p.cargo("bench")
         .with_stderr(
             "\
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] release [optimized] target(s) in [..]
 [RUNNING] target/release/deps/foo-[..][EXE]
 [RUNNING] target/release/deps/external-[..][EXE]",
@@ -602,7 +602,7 @@ automatically infer them to be a target, such as in subfolders.
 
 For more information on this warning you can consult
 https://github.com/rust-lang/cargo/issues/5330
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] release [optimized] target(s) in [..]
 [RUNNING] target/release/deps/foo-[..][EXE]
 ",
@@ -646,7 +646,7 @@ fn pass_through_command_line() {
     p.cargo("bench bar")
         .with_stderr(
             "\
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] release [optimized] target(s) in [..]
 [RUNNING] target/release/deps/foo-[..][EXE]",
         ).with_stdout_contains("test bar ... bench: [..]")
@@ -733,7 +733,7 @@ fn lib_bin_same_name() {
     p.cargo("bench")
         .with_stderr(
             "\
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] release [optimized] target(s) in [..]
 [RUNNING] target/release/deps/foo-[..][EXE]
 [RUNNING] target/release/deps/foo-[..][EXE]",
@@ -779,7 +779,7 @@ fn lib_with_standard_name() {
     p.cargo("bench")
         .with_stderr(
             "\
-[COMPILING] syntax v0.0.1 (CWD)
+[COMPILING] syntax v0.0.1 ([CWD])
 [FINISHED] release [optimized] target(s) in [..]
 [RUNNING] target/release/deps/syntax-[..][EXE]
 [RUNNING] target/release/deps/bench-[..][EXE]",
@@ -828,7 +828,7 @@ fn lib_with_standard_name2() {
     p.cargo("bench")
         .with_stderr(
             "\
-[COMPILING] syntax v0.0.1 (CWD)
+[COMPILING] syntax v0.0.1 ([CWD])
 [FINISHED] release [optimized] target(s) in [..]
 [RUNNING] target/release/deps/syntax-[..][EXE]",
         ).with_stdout_contains("test bench ... bench: [..]")
@@ -898,9 +898,9 @@ fn bench_dylib() {
     p.cargo("bench -v")
         .with_stderr(
             "\
-[COMPILING] bar v0.0.1 (CWD/bar)
+[COMPILING] bar v0.0.1 ([CWD]/bar)
 [RUNNING] [..] -C opt-level=3 [..]
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] foo v0.0.1 ([CWD])
 [RUNNING] [..] -C opt-level=3 [..]
 [RUNNING] [..] -C opt-level=3 [..]
 [RUNNING] [..] -C opt-level=3 [..]
@@ -914,8 +914,8 @@ fn bench_dylib() {
     p.cargo("bench -v")
         .with_stderr(
             "\
-[FRESH] bar v0.0.1 (CWD/bar)
-[FRESH] foo v0.0.1 (CWD)
+[FRESH] bar v0.0.1 ([CWD]/bar)
+[FRESH] foo v0.0.1 ([CWD])
 [FINISHED] release [optimized] target(s) in [..]
 [RUNNING] `[..]target/release/deps/foo-[..][EXE] --bench`
 [RUNNING] `[..]target/release/deps/bench-[..][EXE] --bench`",
@@ -954,7 +954,7 @@ fn bench_twice_with_build_cmd() {
     p.cargo("bench")
         .with_stderr(
             "\
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] release [optimized] target(s) in [..]
 [RUNNING] target/release/deps/foo-[..][EXE]",
         ).with_stdout_contains("test foo ... bench: [..]")
@@ -1038,13 +1038,13 @@ fn bench_with_examples() {
     p.cargo("bench -v")
         .with_stderr(
             "\
-[COMPILING] foo v6.6.6 (CWD)
+[COMPILING] foo v6.6.6 ([CWD])
 [RUNNING] `rustc [..]`
 [RUNNING] `rustc [..]`
 [RUNNING] `rustc [..]`
 [FINISHED] release [optimized] target(s) in [..]
-[RUNNING] `CWD/target/release/deps/foo-[..][EXE] --bench`
-[RUNNING] `CWD/target/release/deps/testb1-[..][EXE] --bench`",
+[RUNNING] `[CWD]/target/release/deps/foo-[..][EXE] --bench`
+[RUNNING] `[CWD]/target/release/deps/testb1-[..][EXE] --bench`",
         ).with_stdout_contains("test bench_bench1 ... bench: [..]")
         .with_stdout_contains("test bench_bench2 ... bench: [..]")
         .run();

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -257,7 +257,7 @@ Caused by:
 }
 
 #[test]
-fn cargo_compile_with_invalid_package_name() {
+fn cargo_compile_with_empty_package_name() {
     let p = project()
         .file("Cargo.toml", &basic_manifest("", "0.0.0"))
         .build();
@@ -270,6 +270,24 @@ fn cargo_compile_with_invalid_package_name() {
 
 Caused by:
   package name cannot be an empty string
+",
+        ).run();
+}
+
+#[test]
+fn cargo_compile_with_invalid_package_name() {
+    let p = project()
+        .file("Cargo.toml", &basic_manifest("foo::bar", "0.0.0"))
+        .build();
+
+    p.cargo("build")
+        .with_status(101)
+        .with_stderr(
+            "\
+[ERROR] failed to parse manifest at `[..]`
+
+Caused by:
+  Invalid character `:` in package name: `foo::bar`
 ",
         ).run();
 }
@@ -806,8 +824,8 @@ fn cargo_compile_with_dep_name_mismatch() {
         .with_status(101)
         .with_stderr(
             r#"error: no matching package named `notquitebar` found
-location searched: CWD/bar
-required by package `foo v0.0.1 (CWD)`
+location searched: [CWD]/bar
+required by package `foo v0.0.1 ([CWD])`
 "#,
         ).run();
 }
@@ -1020,7 +1038,7 @@ fn main(){
         .with_stderr(
             "\
 [COMPILING] present_dep v1.2.3
-[COMPILING] foo v0.1.0 (CWD)
+[COMPILING] foo v0.1.0 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
      Running `[..]`",
         ).with_stdout("1.2.3")
@@ -1164,7 +1182,7 @@ fn compile_offline_while_transitive_dep_not_cached() {
 error: no matching package named `baz` found
 location searched: registry `[..]`
 required by package `bar v0.1.0`
-    ... which is depended on by `foo v0.0.1 (CWD)`
+    ... which is depended on by `foo v0.0.1 ([CWD])`
 As a reminder, you're using offline mode (-Z offline) \
 which can sometimes cause surprising resolution failures, \
 if this error is too confusing you may with to retry \
@@ -1260,21 +1278,21 @@ fn cargo_default_env_metadata_env_var() {
     p.cargo("build -v")
         .with_stderr(&format!(
             "\
-[COMPILING] bar v0.0.1 (CWD/bar)
-[RUNNING] `rustc --crate-name bar bar/src/lib.rs --crate-type dylib \
+[COMPILING] bar v0.0.1 ([CWD]/bar)
+[RUNNING] `rustc --crate-name bar bar/src/lib.rs --color never --crate-type dylib \
         --emit=dep-info,link \
         -C prefer-dynamic -C debuginfo=2 \
         -C metadata=[..] \
         --out-dir [..] \
-        -L dependency=CWD/target/debug/deps`
-[COMPILING] foo v0.0.1 (CWD)
-[RUNNING] `rustc --crate-name foo src/lib.rs --crate-type lib \
+        -L dependency=[CWD]/target/debug/deps`
+[COMPILING] foo v0.0.1 ([CWD])
+[RUNNING] `rustc --crate-name foo src/lib.rs --color never --crate-type lib \
         --emit=dep-info,link -C debuginfo=2 \
         -C metadata=[..] \
         -C extra-filename=[..] \
         --out-dir [..] \
-        -L dependency=CWD/target/debug/deps \
-        --extern bar=CWD/target/debug/deps/{prefix}bar{suffix}`
+        -L dependency=[CWD]/target/debug/deps \
+        --extern bar=[CWD]/target/debug/deps/{prefix}bar{suffix}`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]",
             prefix = env::consts::DLL_PREFIX,
             suffix = env::consts::DLL_SUFFIX,
@@ -1287,21 +1305,21 @@ fn cargo_default_env_metadata_env_var() {
         .env("__CARGO_DEFAULT_LIB_METADATA", "stable")
         .with_stderr(&format!(
             "\
-[COMPILING] bar v0.0.1 (CWD/bar)
-[RUNNING] `rustc --crate-name bar bar/src/lib.rs --crate-type dylib \
+[COMPILING] bar v0.0.1 ([CWD]/bar)
+[RUNNING] `rustc --crate-name bar bar/src/lib.rs --color never --crate-type dylib \
         --emit=dep-info,link \
         -C prefer-dynamic -C debuginfo=2 \
         -C metadata=[..] \
         --out-dir [..] \
-        -L dependency=CWD/target/debug/deps`
-[COMPILING] foo v0.0.1 (CWD)
-[RUNNING] `rustc --crate-name foo src/lib.rs --crate-type lib \
+        -L dependency=[CWD]/target/debug/deps`
+[COMPILING] foo v0.0.1 ([CWD])
+[RUNNING] `rustc --crate-name foo src/lib.rs --color never --crate-type lib \
         --emit=dep-info,link -C debuginfo=2 \
         -C metadata=[..] \
         -C extra-filename=[..] \
         --out-dir [..] \
-        -L dependency=CWD/target/debug/deps \
-        --extern bar=CWD/target/debug/deps/{prefix}bar-[..]{suffix}`
+        -L dependency=[CWD]/target/debug/deps \
+        --extern bar=[CWD]/target/debug/deps/{prefix}bar-[..]{suffix}`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
             prefix = env::consts::DLL_PREFIX,
@@ -1370,7 +1388,7 @@ fn crate_env_vars() {
     p.cargo("build -v").run();
 
     println!("bin");
-    p.process(&p.bin("foo")).with_stdout("0-5-1 @ alpha.1 in CWD").run();
+    p.process(&p.bin("foo")).with_stdout("0-5-1 @ alpha.1 in [CWD]").run();
 
     println!("test");
     p.cargo("test -v").run();
@@ -1551,8 +1569,8 @@ fn self_dependency() {
         .with_status(101)
         .with_stderr(
             "\
-[ERROR] cyclic package dependency: package `test v0.0.0 (CWD)` depends on itself. Cycle:
-package `test v0.0.0 (CWD)`",
+[ERROR] cyclic package dependency: package `test v0.0.0 ([CWD])` depends on itself. Cycle:
+package `test v0.0.0 ([CWD])`",
         ).run();
 }
 
@@ -1615,14 +1633,14 @@ fn lto_build() {
     p.cargo("build -v --release")
         .with_stderr(
             "\
-[COMPILING] test v0.0.0 (CWD)
-[RUNNING] `rustc --crate-name test src/main.rs --crate-type bin \
+[COMPILING] test v0.0.0 ([CWD])
+[RUNNING] `rustc --crate-name test src/main.rs --color never --crate-type bin \
         --emit=dep-info,link \
         -C opt-level=3 \
         -C lto \
         -C metadata=[..] \
-        --out-dir CWD/target/release/deps \
-        -L dependency=CWD/target/release/deps`
+        --out-dir [CWD]/target/release/deps \
+        -L dependency=[CWD]/target/release/deps`
 [FINISHED] release [optimized] target(s) in [..]
 ",
         ).run();
@@ -1634,12 +1652,12 @@ fn verbose_build() {
     p.cargo("build -v")
         .with_stderr(
             "\
-[COMPILING] foo v0.0.1 (CWD)
-[RUNNING] `rustc --crate-name foo src/lib.rs --crate-type lib \
+[COMPILING] foo v0.0.1 ([CWD])
+[RUNNING] `rustc --crate-name foo src/lib.rs --color never --crate-type lib \
         --emit=dep-info,link -C debuginfo=2 \
         -C metadata=[..] \
         --out-dir [..] \
-        -L dependency=CWD/target/debug/deps`
+        -L dependency=[CWD]/target/debug/deps`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ).run();
@@ -1651,13 +1669,13 @@ fn verbose_release_build() {
     p.cargo("build -v --release")
         .with_stderr(
             "\
-[COMPILING] foo v0.0.1 (CWD)
-[RUNNING] `rustc --crate-name foo src/lib.rs --crate-type lib \
+[COMPILING] foo v0.0.1 ([CWD])
+[RUNNING] `rustc --crate-name foo src/lib.rs --color never --crate-type lib \
         --emit=dep-info,link \
         -C opt-level=3 \
         -C metadata=[..] \
         --out-dir [..] \
-        -L dependency=CWD/target/release/deps`
+        -L dependency=[CWD]/target/release/deps`
 [FINISHED] release [optimized] target(s) in [..]
 ",
         ).run();
@@ -1697,24 +1715,24 @@ fn verbose_release_build_deps() {
     p.cargo("build -v --release")
         .with_stderr(&format!(
             "\
-[COMPILING] foo v0.0.0 (CWD/foo)
-[RUNNING] `rustc --crate-name foo foo/src/lib.rs \
+[COMPILING] foo v0.0.0 ([CWD]/foo)
+[RUNNING] `rustc --crate-name foo foo/src/lib.rs --color never \
         --crate-type dylib --crate-type rlib \
         --emit=dep-info,link \
         -C prefer-dynamic \
         -C opt-level=3 \
         -C metadata=[..] \
         --out-dir [..] \
-        -L dependency=CWD/target/release/deps`
-[COMPILING] test v0.0.0 (CWD)
-[RUNNING] `rustc --crate-name test src/lib.rs --crate-type lib \
+        -L dependency=[CWD]/target/release/deps`
+[COMPILING] test v0.0.0 ([CWD])
+[RUNNING] `rustc --crate-name test src/lib.rs --color never --crate-type lib \
         --emit=dep-info,link \
         -C opt-level=3 \
         -C metadata=[..] \
         --out-dir [..] \
-        -L dependency=CWD/target/release/deps \
-        --extern foo=CWD/target/release/deps/{prefix}foo{suffix} \
-        --extern foo=CWD/target/release/deps/libfoo.rlib`
+        -L dependency=[CWD]/target/release/deps \
+        --extern foo=[CWD]/target/release/deps/{prefix}foo{suffix} \
+        --extern foo=[CWD]/target/release/deps/libfoo.rlib`
 [FINISHED] release [optimized] target(s) in [..]
 ",
             prefix = env::consts::DLL_PREFIX,
@@ -2032,7 +2050,7 @@ fn lib_with_standard_name() {
     p.cargo("build")
         .with_stderr(
             "\
-[COMPILING] syntax v0.0.1 (CWD)
+[COMPILING] syntax v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ).run();
@@ -2142,7 +2160,7 @@ fn freshness_ignores_excluded() {
     foo.cargo("build")
         .with_stderr(
             "\
-[COMPILING] foo v0.0.0 (CWD)
+[COMPILING] foo v0.0.0 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ).run();
@@ -2193,7 +2211,7 @@ fn rebuild_preserves_out_dir() {
         .env("FIRST", "1")
         .with_stderr(
             "\
-[COMPILING] foo v0.0.0 (CWD)
+[COMPILING] foo v0.0.0 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ).run();
@@ -2202,7 +2220,7 @@ fn rebuild_preserves_out_dir() {
     foo.cargo("build")
         .with_stderr(
             "\
-[COMPILING] foo v0.0.0 (CWD)
+[COMPILING] foo v0.0.0 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ).run();
@@ -2601,9 +2619,9 @@ fn cyclic_deps_rejected() {
     p.cargo("build -v")
         .with_status(101)
         .with_stderr(
-"[ERROR] cyclic package dependency: package `a v0.0.1 (CWD/a)` depends on itself. Cycle:
-package `a v0.0.1 (CWD/a)`
-    ... which is depended on by `foo v0.0.1 (CWD)`",
+"[ERROR] cyclic package dependency: package `a v0.0.1 ([CWD]/a)` depends on itself. Cycle:
+package `a v0.0.1 ([CWD]/a)`
+    ... which is depended on by `foo v0.0.1 ([CWD])`",
         ).run();
 }
 
@@ -4099,11 +4117,11 @@ fn build_filter_infer_profile() {
     p.cargo("build -v")
         .with_stderr_contains(
             "\
-             [RUNNING] `rustc --crate-name foo src/lib.rs --crate-type lib \
+             [RUNNING] `rustc --crate-name foo src/lib.rs --color never --crate-type lib \
              --emit=dep-info,link[..]",
         ).with_stderr_contains(
             "\
-             [RUNNING] `rustc --crate-name foo src/main.rs --crate-type bin \
+             [RUNNING] `rustc --crate-name foo src/main.rs --color never --crate-type bin \
              --emit=dep-info,link[..]",
         ).run();
 
@@ -4111,13 +4129,13 @@ fn build_filter_infer_profile() {
     p.cargo("build -v --test=t1")
         .with_stderr_contains(
             "\
-             [RUNNING] `rustc --crate-name foo src/lib.rs --crate-type lib \
+             [RUNNING] `rustc --crate-name foo src/lib.rs --color never --crate-type lib \
              --emit=dep-info,link[..]",
         ).with_stderr_contains(
-            "[RUNNING] `rustc --crate-name t1 tests/t1.rs --emit=dep-info,link[..]",
+            "[RUNNING] `rustc --crate-name t1 tests/t1.rs --color never --emit=dep-info,link[..]",
         ).with_stderr_contains(
             "\
-             [RUNNING] `rustc --crate-name foo src/main.rs --crate-type bin \
+             [RUNNING] `rustc --crate-name foo src/main.rs --color never --crate-type bin \
              --emit=dep-info,link[..]",
         ).run();
 
@@ -4125,15 +4143,15 @@ fn build_filter_infer_profile() {
     p.cargo("build -v --bench=b1")
         .with_stderr_contains(
             "\
-             [RUNNING] `rustc --crate-name foo src/lib.rs --crate-type lib \
+             [RUNNING] `rustc --crate-name foo src/lib.rs --color never --crate-type lib \
              --emit=dep-info,link[..]",
         ).with_stderr_contains(
             "\
-             [RUNNING] `rustc --crate-name b1 benches/b1.rs --emit=dep-info,link \
+             [RUNNING] `rustc --crate-name b1 benches/b1.rs --color never --emit=dep-info,link \
              -C opt-level=3[..]",
         ).with_stderr_contains(
             "\
-             [RUNNING] `rustc --crate-name foo src/main.rs --crate-type bin \
+             [RUNNING] `rustc --crate-name foo src/main.rs --color never --crate-type bin \
              --emit=dep-info,link[..]",
         ).run();
 }
@@ -4144,15 +4162,15 @@ fn targets_selected_default() {
     p.cargo("build -v")
         // bin
         .with_stderr_contains("\
-            [RUNNING] `rustc --crate-name foo src/main.rs --crate-type bin \
+            [RUNNING] `rustc --crate-name foo src/main.rs --color never --crate-type bin \
             --emit=dep-info,link[..]")
         // bench
         .with_stderr_does_not_contain("\
-            [RUNNING] `rustc --crate-name foo src/main.rs --emit=dep-info,link \
+            [RUNNING] `rustc --crate-name foo src/main.rs --color never --emit=dep-info,link \
             -C opt-level=3 --test [..]")
         // unit test
         .with_stderr_does_not_contain("\
-            [RUNNING] `rustc --crate-name foo src/main.rs --emit=dep-info,link \
+            [RUNNING] `rustc --crate-name foo src/main.rs --color never --emit=dep-info,link \
             -C debuginfo=2 --test [..]").run();
 }
 
@@ -4162,15 +4180,15 @@ fn targets_selected_all() {
     p.cargo("build -v --all-targets")
         // bin
         .with_stderr_contains("\
-            [RUNNING] `rustc --crate-name foo src/main.rs --crate-type bin \
+            [RUNNING] `rustc --crate-name foo src/main.rs --color never --crate-type bin \
             --emit=dep-info,link[..]")
         // bench
         .with_stderr_contains("\
-            [RUNNING] `rustc --crate-name foo src/main.rs --emit=dep-info,link \
+            [RUNNING] `rustc --crate-name foo src/main.rs --color never --emit=dep-info,link \
             -C opt-level=3 --test [..]")
         // unit test
         .with_stderr_contains("\
-            [RUNNING] `rustc --crate-name foo src/main.rs --emit=dep-info,link \
+            [RUNNING] `rustc --crate-name foo src/main.rs --color never --emit=dep-info,link \
             -C debuginfo=2 --test [..]").run();
 }
 
@@ -4180,15 +4198,15 @@ fn all_targets_no_lib() {
     p.cargo("build -v --all-targets")
         // bin
         .with_stderr_contains("\
-            [RUNNING] `rustc --crate-name foo src/main.rs --crate-type bin \
+            [RUNNING] `rustc --crate-name foo src/main.rs --color never --crate-type bin \
             --emit=dep-info,link[..]")
         // bench
         .with_stderr_contains("\
-            [RUNNING] `rustc --crate-name foo src/main.rs --emit=dep-info,link \
+            [RUNNING] `rustc --crate-name foo src/main.rs --color never --emit=dep-info,link \
             -C opt-level=3 --test [..]")
         // unit test
         .with_stderr_contains("\
-            [RUNNING] `rustc --crate-name foo src/main.rs --emit=dep-info,link \
+            [RUNNING] `rustc --crate-name foo src/main.rs --color never --emit=dep-info,link \
             -C debuginfo=2 --test [..]").run();
 }
 

--- a/tests/testsuite/build_lib.rs
+++ b/tests/testsuite/build_lib.rs
@@ -10,12 +10,12 @@ fn build_lib_only() {
     p.cargo("build --lib -v")
         .with_stderr(
             "\
-[COMPILING] foo v0.0.1 (CWD)
-[RUNNING] `rustc --crate-name foo src/lib.rs --crate-type lib \
+[COMPILING] foo v0.0.1 ([CWD])
+[RUNNING] `rustc --crate-name foo src/lib.rs --color never --crate-type lib \
         --emit=dep-info,link -C debuginfo=2 \
         -C metadata=[..] \
         --out-dir [..] \
-        -L dependency=CWD/target/debug/deps`
+        -L dependency=[CWD]/target/debug/deps`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]",
         ).run();
 }

--- a/tests/testsuite/build_script.rs
+++ b/tests/testsuite/build_script.rs
@@ -31,10 +31,10 @@ fn custom_build_script_failed() {
         .with_status(101)
         .with_stderr(
             "\
-[COMPILING] foo v0.5.0 (CWD)
-[RUNNING] `rustc --crate-name build_script_build build.rs --crate-type bin [..]`
+[COMPILING] foo v0.5.0 ([CWD])
+[RUNNING] `rustc --crate-name build_script_build build.rs --color never --crate-type bin [..]`
 [RUNNING] `[..]/build-script-build`
-[ERROR] failed to run custom build command for `foo v0.5.0 (CWD)`
+[ERROR] failed to run custom build command for `foo v0.5.0 ([CWD])`
 process didn't exit successfully: `[..]/build-script-build` (exit code: 101)",
         ).run();
 }
@@ -181,7 +181,7 @@ fn custom_build_script_wrong_rustc_flags() {
         .with_status(101)
         .with_stderr_contains(
             "\
-             [ERROR] Only `-l` and `-L` flags are allowed in build script of `foo v0.5.0 (CWD)`: \
+             [ERROR] Only `-l` and `-L` flags are allowed in build script of `foo v0.5.0 ([CWD])`: \
              `-aaa -bbb`",
         ).run();
 }
@@ -228,14 +228,14 @@ fn custom_build_script_rustc_flags() {
         .with_status(101)
         .with_stderr(
             "\
-[COMPILING] bar v0.5.0 (CWD)
-[RUNNING] `rustc --crate-name test CWD/src/lib.rs --crate-type lib -C debuginfo=2 \
+[COMPILING] bar v0.5.0 ([CWD])
+[RUNNING] `rustc --crate-name test [CWD]/src/lib.rs --crate-type lib -C debuginfo=2 \
         -C metadata=[..] \
         -C extra-filename=-[..] \
-        --out-dir CWD/target \
+        --out-dir [CWD]/target \
         --emit=dep-info,link \
-        -L CWD/target \
-        -L CWD/target/deps`
+        -L [CWD]/target \
+        -L [CWD]/target/deps`
 ",
         ).run();
 }
@@ -260,7 +260,7 @@ fn links_no_build_cmd() {
         .with_status(101)
         .with_stderr(
             "\
-[ERROR] package `foo v0.5.0 (CWD)` specifies that it links to `a` but does \
+[ERROR] package `foo v0.5.0 ([CWD])` specifies that it links to `a` but does \
 not have a custom build script
 ",
         ).run();
@@ -551,7 +551,7 @@ fn only_rerun_build_script() {
     p.cargo("build -v")
         .with_stderr(
             "\
-[COMPILING] foo v0.5.0 (CWD)
+[COMPILING] foo v0.5.0 ([CWD])
 [RUNNING] `[..]/build-script-build`
 [RUNNING] `rustc --crate-name foo [..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
@@ -651,7 +651,7 @@ fn testing_and_such() {
     p.cargo("test -vj1")
         .with_stderr(
             "\
-[COMPILING] foo v0.5.0 (CWD)
+[COMPILING] foo v0.5.0 ([CWD])
 [RUNNING] `[..]/build-script-build`
 [RUNNING] `rustc --crate-name foo [..]`
 [RUNNING] `rustc --crate-name foo [..]`
@@ -666,7 +666,7 @@ fn testing_and_such() {
     p.cargo("doc -v")
         .with_stderr(
             "\
-[DOCUMENTING] foo v0.5.0 (CWD)
+[DOCUMENTING] foo v0.5.0 ([CWD])
 [RUNNING] `rustdoc [..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
@@ -680,7 +680,7 @@ fn testing_and_such() {
     p.cargo("run")
         .with_stderr(
             "\
-[COMPILING] foo v0.5.0 (CWD)
+[COMPILING] foo v0.5.0 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `target/debug/foo[EXE]`
 ",
@@ -746,7 +746,7 @@ fn propagation_of_l_flags() {
         .with_stderr_contains(
             "\
 [RUNNING] `rustc --crate-name a [..] -L bar[..]-L foo[..]`
-[COMPILING] foo v0.5.0 (CWD)
+[COMPILING] foo v0.5.0 ([CWD])
 [RUNNING] `rustc --crate-name foo [..] -L bar -L foo`
 ",
         ).run();
@@ -815,7 +815,7 @@ fn propagation_of_l_flags_new() {
         .with_stderr_contains(
             "\
 [RUNNING] `rustc --crate-name a [..] -L bar[..]-L foo[..]`
-[COMPILING] foo v0.5.0 (CWD)
+[COMPILING] foo v0.5.0 ([CWD])
 [RUNNING] `rustc --crate-name foo [..] -L bar -L foo`
 ",
         ).run();
@@ -850,9 +850,9 @@ fn build_deps_simple() {
     p.cargo("build -v")
         .with_stderr(
             "\
-[COMPILING] a v0.5.0 (CWD/a)
+[COMPILING] a v0.5.0 ([CWD]/a)
 [RUNNING] `rustc --crate-name a [..]`
-[COMPILING] foo v0.5.0 (CWD)
+[COMPILING] foo v0.5.0 ([CWD])
 [RUNNING] `rustc [..] build.rs [..] --extern a=[..]`
 [RUNNING] `[..]/foo-[..]/build-script-build`
 [RUNNING] `rustc --crate-name foo [..]`
@@ -950,24 +950,24 @@ fn build_cmd_with_a_build_cmd() {
     p.cargo("build -v")
         .with_stderr(
             "\
-[COMPILING] b v0.5.0 (CWD/b)
+[COMPILING] b v0.5.0 ([CWD]/b)
 [RUNNING] `rustc --crate-name b [..]`
-[COMPILING] a v0.5.0 (CWD/a)
+[COMPILING] a v0.5.0 ([CWD]/a)
 [RUNNING] `rustc [..] a/build.rs [..] --extern b=[..]`
 [RUNNING] `[..]/a-[..]/build-script-build`
-[RUNNING] `rustc --crate-name a [..]lib.rs --crate-type lib \
+[RUNNING] `rustc --crate-name a [..]lib.rs --color never --crate-type lib \
     --emit=dep-info,link -C debuginfo=2 \
     -C metadata=[..] \
     --out-dir [..]target/debug/deps \
     -L [..]target/debug/deps`
-[COMPILING] foo v0.5.0 (CWD)
-[RUNNING] `rustc --crate-name build_script_build build.rs --crate-type bin \
+[COMPILING] foo v0.5.0 ([CWD])
+[RUNNING] `rustc --crate-name build_script_build build.rs --color never --crate-type bin \
     --emit=dep-info,link \
     -C debuginfo=2 -C metadata=[..] --out-dir [..] \
     -L [..]target/debug/deps \
     --extern a=[..]liba[..].rlib`
 [RUNNING] `[..]/foo-[..]/build-script-build`
-[RUNNING] `rustc --crate-name foo [..]lib.rs --crate-type lib \
+[RUNNING] `rustc --crate-name foo [..]lib.rs --color never --crate-type lib \
     --emit=dep-info,link -C debuginfo=2 \
     -C metadata=[..] \
     --out-dir [..] \
@@ -1057,7 +1057,7 @@ fn output_separate_lines() {
         .with_status(101)
         .with_stderr_contains(
             "\
-[COMPILING] foo v0.5.0 (CWD)
+[COMPILING] foo v0.5.0 ([CWD])
 [RUNNING] `rustc [..] build.rs [..]`
 [RUNNING] `[..]/foo-[..]/build-script-build`
 [RUNNING] `rustc --crate-name foo [..] -L foo -l static=foo`
@@ -1092,7 +1092,7 @@ fn output_separate_lines_new() {
         .with_status(101)
         .with_stderr_contains(
             "\
-[COMPILING] foo v0.5.0 (CWD)
+[COMPILING] foo v0.5.0 ([CWD])
 [RUNNING] `rustc [..] build.rs [..]`
 [RUNNING] `[..]/foo-[..]/build-script-build`
 [RUNNING] `rustc --crate-name foo [..] -L foo -l static=foo`
@@ -1146,7 +1146,7 @@ fn code_generation() {
     p.cargo("run")
         .with_stderr(
             "\
-[COMPILING] foo v0.5.0 (CWD)
+[COMPILING] foo v0.5.0 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `target/debug/foo`",
         ).with_stdout("Hello, World!")
@@ -1671,7 +1671,7 @@ fn cfg_test() {
     p.cargo("test -v")
         .with_stderr(
             "\
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] foo v0.0.1 ([CWD])
 [RUNNING] [..] build.rs [..]
 [RUNNING] `[..]/build-script-build`
 [RUNNING] [..] --cfg foo[..]
@@ -1776,7 +1776,7 @@ fn cfg_override_test() {
     p.cargo("test -v")
         .with_stderr(
             "\
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] foo v0.0.1 ([CWD])
 [RUNNING] `[..]`
 [RUNNING] `[..]`
 [RUNNING] `[..]`
@@ -1899,7 +1899,7 @@ fn env_test() {
     p.cargo("test -v")
         .with_stderr(
             "\
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] foo v0.0.1 ([CWD])
 [RUNNING] [..] build.rs [..]
 [RUNNING] `[..]/build-script-build`
 [RUNNING] [..] --crate-name foo[..]

--- a/tests/testsuite/cargo_command.rs
+++ b/tests/testsuite/cargo_command.rs
@@ -268,7 +268,7 @@ fn cargo_subcommand_args() {
             if cfg!(windows) { // weird edge-case w/ CWD & (windows vs unix)
                 format!(r#"[{:?}, "foo", "bar", "-v", "--help"]"#, cargo_foo_bin)
             } else {
-                r#"["CWD/cargo-foo/target/debug/cargo-foo", "foo", "bar", "-v", "--help"]"#.to_string()
+                r#"["[CWD]/cargo-foo/target/debug/cargo-foo", "foo", "bar", "-v", "--help"]"#.to_string()
             }
         ).run();
 }

--- a/tests/testsuite/check.rs
+++ b/tests/testsuite/check.rs
@@ -521,7 +521,7 @@ fn check_filters() {
     p.root().join("target").rm_rf();
     p.cargo("check --tests -v")
         .with_stderr_contains("[..] --crate-name foo src/lib.rs [..] --test [..]")
-        .with_stderr_contains("[..] --crate-name foo src/lib.rs --crate-type lib [..]")
+        .with_stderr_contains("[..] --crate-name foo src/lib.rs [..] --crate-type lib [..]")
         .with_stderr_contains("[..] --crate-name foo src/main.rs [..] --test [..]")
         .with_stderr_contains("[..]unused_unit_lib[..]")
         .with_stderr_contains("[..]unused_unit_bin[..]")

--- a/tests/testsuite/cross_compile.rs
+++ b/tests/testsuite/cross_compile.rs
@@ -357,15 +357,15 @@ fn linker_and_ar() {
         .with_status(101)
         .with_stderr_contains(&format!(
             "\
-[COMPILING] foo v0.5.0 (CWD)
-[RUNNING] `rustc --crate-name foo src/foo.rs --crate-type bin \
+[COMPILING] foo v0.5.0 ([CWD])
+[RUNNING] `rustc --crate-name foo src/foo.rs --color never --crate-type bin \
     --emit=dep-info,link -C debuginfo=2 \
     -C metadata=[..] \
-    --out-dir CWD/target/{target}/debug/deps \
+    --out-dir [CWD]/target/{target}/debug/deps \
     --target {target} \
     -C ar=my-ar-tool -C linker=my-linker-tool \
-    -L dependency=CWD/target/{target}/debug/deps \
-    -L dependency=CWD/target/debug/deps`
+    -L dependency=[CWD]/target/{target}/debug/deps \
+    -L dependency=[CWD]/target/debug/deps`
 ",
             target = target,
         )).run();
@@ -504,7 +504,7 @@ fn cross_tests() {
         .arg(&target)
         .with_stderr(&format!(
             "\
-[COMPILING] foo v0.0.0 (CWD)
+[COMPILING] foo v0.0.0 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target/{triple}/debug/deps/foo-[..][EXE]
 [RUNNING] target/{triple}/debug/deps/bar-[..][EXE]",
@@ -533,7 +533,7 @@ fn no_cross_doctests() {
 
     let host_output =
         "\
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target/debug/deps/foo-[..][EXE]
 [DOCTEST] foo
@@ -548,7 +548,7 @@ fn no_cross_doctests() {
         .arg(&target)
         .with_stderr(&format!(
             "\
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target/{triple}/debug/deps/foo-[..][EXE]
 [DOCTEST] foo
@@ -562,7 +562,7 @@ fn no_cross_doctests() {
         .arg(&target)
         .with_stderr(&format!(
             "\
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target/{triple}/debug/deps/foo-[..][EXE]
 ",
@@ -643,9 +643,9 @@ fn cross_with_a_build_script() {
         .arg(&target)
         .with_stderr(&format!(
             "\
-[COMPILING] foo v0.0.0 (CWD)
-[RUNNING] `rustc [..] build.rs [..] --out-dir CWD/target/debug/build/foo-[..]`
-[RUNNING] `CWD/target/debug/build/foo-[..]/build-script-build`
+[COMPILING] foo v0.0.0 ([CWD])
+[RUNNING] `rustc [..] build.rs [..] --out-dir [CWD]/target/debug/build/foo-[..]`
+[RUNNING] `[CWD]/target/debug/build/foo-[..]/build-script-build`
 [RUNNING] `rustc [..] src/main.rs [..] --target {target} [..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
@@ -731,19 +731,19 @@ fn build_script_needed_for_host_and_target() {
 
     p.cargo("build -v --target")
         .arg(&target)
-        .with_stderr_contains(&"[COMPILING] d1 v0.0.0 (CWD/d1)")
+        .with_stderr_contains(&"[COMPILING] d1 v0.0.0 ([CWD]/d1)")
         .with_stderr_contains(
-            "[RUNNING] `rustc [..] d1/build.rs [..] --out-dir CWD/target/debug/build/d1-[..]`",
+            "[RUNNING] `rustc [..] d1/build.rs [..] --out-dir [CWD]/target/debug/build/d1-[..]`",
         )
-        .with_stderr_contains("[RUNNING] `CWD/target/debug/build/d1-[..]/build-script-build`")
+        .with_stderr_contains("[RUNNING] `[CWD]/target/debug/build/d1-[..]/build-script-build`")
         .with_stderr_contains("[RUNNING] `rustc [..] d1/src/lib.rs [..]`")
-        .with_stderr_contains("[COMPILING] d2 v0.0.0 (CWD/d2)")
+        .with_stderr_contains("[COMPILING] d2 v0.0.0 ([CWD]/d2)")
         .with_stderr_contains(&format!(
             "[RUNNING] `rustc [..] d2/src/lib.rs [..] -L /path/to/{host}`",
             host = host
-        )).with_stderr_contains("[COMPILING] foo v0.0.0 (CWD)")
+        )).with_stderr_contains("[COMPILING] foo v0.0.0 ([CWD])")
         .with_stderr_contains(&format!(
-            "[RUNNING] `rustc [..] build.rs [..] --out-dir CWD/target/debug/build/foo-[..] \
+            "[RUNNING] `rustc [..] build.rs [..] --out-dir [CWD]/target/debug/build/foo-[..] \
              -L /path/to/{host}`",
             host = host
         )).with_stderr_contains(&format!(
@@ -939,7 +939,7 @@ fn build_script_with_platform_specific_dependencies() {
 [RUNNING] `rustc [..] d1/src/lib.rs [..]`
 [COMPILING] foo v0.0.1 ([..])
 [RUNNING] `rustc [..] build.rs [..]`
-[RUNNING] `CWD/target/debug/build/foo-[..]/build-script-build`
+[RUNNING] `[CWD]/target/debug/build/foo-[..]/build-script-build`
 [RUNNING] `rustc [..] src/lib.rs [..] --target {target} [..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
@@ -1152,8 +1152,8 @@ fn cross_test_dylib() {
         .arg(&target)
         .with_stderr(&format!(
             "\
-[COMPILING] bar v0.0.1 (CWD/bar)
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] bar v0.0.1 ([CWD]/bar)
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target/{arch}/debug/deps/foo-[..][EXE]
 [RUNNING] target/{arch}/debug/deps/test-[..][EXE]",

--- a/tests/testsuite/cross_publish.rs
+++ b/tests/testsuite/cross_publish.rs
@@ -42,9 +42,9 @@ fn simple_cross_package() {
     p.cargo("package --target")
         .arg(&target)
         .with_stderr(
-            "   Packaging foo v0.0.0 (CWD)
-   Verifying foo v0.0.0 (CWD)
-   Compiling foo v0.0.0 (CWD/target/package/foo-0.0.0)
+            "   Packaging foo v0.0.0 ([CWD])
+   Verifying foo v0.0.0 ([CWD])
+   Compiling foo v0.0.0 ([CWD]/target/package/foo-0.0.0)
     Finished dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ).run();
@@ -105,12 +105,12 @@ fn publish_with_target() {
         .arg(&target)
         .with_stderr(&format!(
             "    Updating `{registry}` index
-   Packaging foo v0.0.0 (CWD)
-   Verifying foo v0.0.0 (CWD)
-   Compiling foo v0.0.0 (CWD/target/package/foo-0.0.0)
+   Packaging foo v0.0.0 ([CWD])
+   Verifying foo v0.0.0 ([CWD])
+   Compiling foo v0.0.0 ([CWD]/target/package/foo-0.0.0)
     Finished dev [unoptimized + debuginfo] target(s) in [..]
-   Uploading foo v0.0.0 (CWD)
+   Uploading foo v0.0.0 ([CWD])
 ",
-            registry = publish::registry()
+            registry = publish::registry_path().to_str().unwrap()
         )).run();
 }

--- a/tests/testsuite/directory.rs
+++ b/tests/testsuite/directory.rs
@@ -102,7 +102,7 @@ fn simple() {
         .with_stderr(
             "\
 [COMPILING] bar v0.1.0
-[COMPILING] foo v0.1.0 (CWD)
+[COMPILING] foo v0.1.0 ([CWD])
 [FINISHED] [..]
 ",
         ).run();
@@ -298,7 +298,7 @@ fn multiple() {
         .with_stderr(
             "\
 [COMPILING] bar v0.1.0
-[COMPILING] foo v0.1.0 (CWD)
+[COMPILING] foo v0.1.0 ([CWD])
 [FINISHED] [..]
 ",
         ).run();
@@ -333,7 +333,7 @@ fn crates_io_then_directory() {
 [UPDATING] `[..]` index
 [DOWNLOADING] bar v0.1.0 ([..])
 [COMPILING] bar v0.1.0
-[COMPILING] foo v0.1.0 (CWD)
+[COMPILING] foo v0.1.0 ([CWD])
 [FINISHED] [..]
 ",
         ).run();
@@ -350,7 +350,7 @@ fn crates_io_then_directory() {
         .with_stderr(
             "\
 [COMPILING] bar v0.1.0
-[COMPILING] foo v0.1.0 (CWD)
+[COMPILING] foo v0.1.0 ([CWD])
 [FINISHED] [..]
 ",
         ).run();

--- a/tests/testsuite/doc.rs
+++ b/tests/testsuite/doc.rs
@@ -28,8 +28,8 @@ fn simple() {
     p.cargo("doc")
         .with_stderr(
             "\
-[..] foo v0.0.1 (CWD)
-[..] foo v0.0.1 (CWD)
+[..] foo v0.0.1 ([CWD])
+[..] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ).run();
@@ -65,7 +65,7 @@ fn doc_twice() {
     p.cargo("doc")
         .with_stderr(
             "\
-[DOCUMENTING] foo v0.0.1 (CWD)
+[DOCUMENTING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ).run();
@@ -95,9 +95,9 @@ fn doc_deps() {
     p.cargo("doc")
         .with_stderr(
             "\
-[..] bar v0.0.1 (CWD/bar)
-[..] bar v0.0.1 (CWD/bar)
-[DOCUMENTING] foo v0.0.1 (CWD)
+[..] bar v0.0.1 ([CWD]/bar)
+[..] bar v0.0.1 ([CWD]/bar)
+[DOCUMENTING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ).run();
@@ -156,8 +156,8 @@ fn doc_no_deps() {
     p.cargo("doc --no-deps")
         .with_stderr(
             "\
-[CHECKING] bar v0.0.1 (CWD/bar)
-[DOCUMENTING] foo v0.0.1 (CWD)
+[CHECKING] bar v0.0.1 ([CWD]/bar)
+[DOCUMENTING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ).run();
@@ -265,8 +265,8 @@ fn doc_multiple_targets_same_name() {
         .build();
 
     p.cargo("doc --all")
-        .with_stderr_contains("[DOCUMENTING] foo v0.1.0 (CWD/foo)")
-        .with_stderr_contains("[DOCUMENTING] bar v0.1.0 (CWD/bar)")
+        .with_stderr_contains("[DOCUMENTING] foo v0.1.0 ([CWD]/foo)")
+        .with_stderr_contains("[DOCUMENTING] bar v0.1.0 ([CWD]/bar)")
         .with_stderr_contains("[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]")
         .run();
     assert!(p.root().join("target/doc").is_dir());
@@ -371,7 +371,7 @@ fn doc_lib_bin_same_name_documents_lib() {
     p.cargo("doc")
         .with_stderr(
             "\
-[DOCUMENTING] foo v0.0.1 (CWD)
+[DOCUMENTING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ).run();
@@ -410,7 +410,7 @@ fn doc_lib_bin_same_name_documents_lib_when_requested() {
     p.cargo("doc --lib")
         .with_stderr(
             "\
-[DOCUMENTING] foo v0.0.1 (CWD)
+[DOCUMENTING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ).run();
@@ -449,8 +449,8 @@ fn doc_lib_bin_same_name_documents_named_bin_when_requested() {
     p.cargo("doc --bin foo")
         .with_stderr(
             "\
-[CHECKING] foo v0.0.1 (CWD)
-[DOCUMENTING] foo v0.0.1 (CWD)
+[CHECKING] foo v0.0.1 ([CWD])
+[DOCUMENTING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ).run();
@@ -489,8 +489,8 @@ fn doc_lib_bin_same_name_documents_bins_when_requested() {
     p.cargo("doc --bins")
         .with_stderr(
             "\
-[CHECKING] foo v0.0.1 (CWD)
-[DOCUMENTING] foo v0.0.1 (CWD)
+[CHECKING] foo v0.0.1 ([CWD])
+[DOCUMENTING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ).run();
@@ -540,9 +540,9 @@ fn doc_dash_p() {
     p.cargo("doc -p a")
         .with_stderr(
             "\
-[..] b v0.0.1 (CWD/b)
-[..] b v0.0.1 (CWD/b)
-[DOCUMENTING] a v0.0.1 (CWD/a)
+[..] b v0.0.1 ([CWD]/b)
+[..] b v0.0.1 ([CWD]/b)
+[DOCUMENTING] a v0.0.1 ([CWD]/a)
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ).run();
@@ -1028,7 +1028,7 @@ fn doc_workspace_open_different_library_and_package_names() {
     p.cargo("doc --open")
         .env("BROWSER", "echo")
         .with_stderr_contains("[..] Documenting foo v0.1.0 ([..])")
-        .with_stderr_contains("[..] CWD/target/doc/foolib/index.html")
+        .with_stderr_contains("[..] [CWD]/target/doc/foolib/index.html")
         .run();
 }
 
@@ -1058,7 +1058,7 @@ fn doc_workspace_open_binary() {
     p.cargo("doc --open")
         .env("BROWSER", "echo")
         .with_stderr_contains("[..] Documenting foo v0.1.0 ([..])")
-        .with_stderr_contains("[..] Opening CWD/target/doc/foobin/index.html")
+        .with_stderr_contains("[..] Opening [CWD]/target/doc/foobin/index.html")
         .run();
 }
 
@@ -1091,7 +1091,7 @@ fn doc_workspace_open_binary_and_library() {
     p.cargo("doc --open")
         .env("BROWSER", "echo")
         .with_stderr_contains("[..] Documenting foo v0.1.0 ([..])")
-        .with_stderr_contains("[..] Opening CWD/target/doc/foolib/index.html")
+        .with_stderr_contains("[..] Opening [CWD]/target/doc/foolib/index.html")
         .run();
 }
 
@@ -1204,6 +1204,31 @@ fn doc_private_items() {
             .join("target/doc/foo/private/index.html")
             .is_file()
     );
+}
+
+#[test]
+fn doc_private_ws() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [workspace]
+            members = ["a", "b"]
+        "#,
+        ).file("a/Cargo.toml", &basic_manifest("a", "0.0.1"))
+        .file("a/src/lib.rs", "fn p() {}")
+        .file("b/Cargo.toml", &basic_manifest("b", "0.0.1"))
+        .file("b/src/lib.rs", "fn p2() {}")
+        .file("b/src/main.rs", "fn main() {}")
+        .build();
+    p.cargo("doc --all --bins --lib --document-private-items -v")
+        .with_stderr_contains(
+            "[RUNNING] `rustdoc [..] a/src/lib.rs [..]--document-private-items[..]",
+        ).with_stderr_contains(
+            "[RUNNING] `rustdoc [..] b/src/lib.rs [..]--document-private-items[..]",
+        ).with_stderr_contains(
+            "[RUNNING] `rustdoc [..] b/src/main.rs [..]--document-private-items[..]",
+        ).run();
 }
 
 const BAD_INTRA_LINK_LIB: &str = r#"

--- a/tests/testsuite/features.rs
+++ b/tests/testsuite/features.rs
@@ -417,7 +417,7 @@ fn no_feature_doesnt_build() {
     p.cargo("build")
         .with_stderr(
             "\
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ).run();
@@ -426,8 +426,8 @@ fn no_feature_doesnt_build() {
     p.cargo("build --features bar")
         .with_stderr(
             "\
-[COMPILING] bar v0.0.1 (CWD/bar)
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] bar v0.0.1 ([CWD]/bar)
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ).run();
@@ -469,8 +469,8 @@ fn default_feature_pulled_in() {
     p.cargo("build")
         .with_stderr(
             "\
-[COMPILING] bar v0.0.1 (CWD/bar)
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] bar v0.0.1 ([CWD]/bar)
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ).run();
@@ -479,7 +479,7 @@ fn default_feature_pulled_in() {
     p.cargo("build --no-default-features")
         .with_stderr(
             "\
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ).run();
@@ -577,9 +577,9 @@ fn groups_on_groups_on_groups() {
     p.cargo("build")
         .with_stderr(
             "\
-[COMPILING] ba[..] v0.0.1 (CWD/ba[..])
-[COMPILING] ba[..] v0.0.1 (CWD/ba[..])
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] ba[..] v0.0.1 ([CWD]/ba[..])
+[COMPILING] ba[..] v0.0.1 ([CWD]/ba[..])
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ).run();
@@ -623,9 +623,9 @@ fn many_cli_features() {
         .arg("bar baz")
         .with_stderr(
             "\
-[COMPILING] ba[..] v0.0.1 (CWD/ba[..])
-[COMPILING] ba[..] v0.0.1 (CWD/ba[..])
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] ba[..] v0.0.1 ([CWD]/ba[..])
+[COMPILING] ba[..] v0.0.1 ([CWD]/ba[..])
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ).run();
@@ -700,9 +700,9 @@ fn union_features() {
     p.cargo("build")
         .with_stderr(
             "\
-[COMPILING] d2 v0.0.1 (CWD/d2)
-[COMPILING] d1 v0.0.1 (CWD/d1)
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] d2 v0.0.1 ([CWD]/d2)
+[COMPILING] d1 v0.0.1 ([CWD]/d1)
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ).run();
@@ -743,8 +743,8 @@ fn many_features_no_rebuilds() {
     p.cargo("build")
         .with_stderr(
             "\
-[COMPILING] a v0.1.0 (CWD/a)
-[COMPILING] b v0.1.0 (CWD)
+[COMPILING] a v0.1.0 ([CWD]/a)
+[COMPILING] b v0.1.0 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ).run();
@@ -1199,9 +1199,9 @@ fn many_cli_features_comma_delimited() {
     p.cargo("build --features bar,baz")
         .with_stderr(
             "\
-[COMPILING] ba[..] v0.0.1 (CWD/ba[..])
-[COMPILING] ba[..] v0.0.1 (CWD/ba[..])
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] ba[..] v0.0.1 ([CWD]/ba[..])
+[COMPILING] ba[..] v0.0.1 ([CWD]/ba[..])
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ).run();
@@ -1261,11 +1261,11 @@ fn many_cli_features_comma_and_space_delimited() {
         .arg("bar,baz bam bap")
         .with_stderr(
             "\
-[COMPILING] ba[..] v0.0.1 (CWD/ba[..])
-[COMPILING] ba[..] v0.0.1 (CWD/ba[..])
-[COMPILING] ba[..] v0.0.1 (CWD/ba[..])
-[COMPILING] ba[..] v0.0.1 (CWD/ba[..])
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] ba[..] v0.0.1 ([CWD]/ba[..])
+[COMPILING] ba[..] v0.0.1 ([CWD]/ba[..])
+[COMPILING] ba[..] v0.0.1 ([CWD]/ba[..])
+[COMPILING] ba[..] v0.0.1 ([CWD]/ba[..])
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ).run();

--- a/tests/testsuite/freshness.rs
+++ b/tests/testsuite/freshness.rs
@@ -16,7 +16,7 @@ fn modifying_and_moving() {
     p.cargo("build")
         .with_stderr(
             "\
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ).run();
@@ -32,7 +32,7 @@ fn modifying_and_moving() {
     p.cargo("build")
         .with_stderr(
             "\
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ).run();
@@ -54,7 +54,7 @@ fn modify_only_some_files() {
     p.cargo("build")
         .with_stderr(
             "\
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ).run();
@@ -80,7 +80,7 @@ fn modify_only_some_files() {
     p.cargo("build")
         .with_stderr(
             "\
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ).run();
@@ -644,16 +644,16 @@ fn same_build_dir_cached_packages() {
 [COMPILING] d v0.0.1 ({dir}/d)
 [COMPILING] c v0.0.1 ({dir}/c)
 [COMPILING] b v0.0.1 ({dir}/b)
-[COMPILING] a1 v0.0.1 (CWD)
+[COMPILING] a1 v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
-            dir = p.url()
+            dir = p.url().to_file_path().unwrap().to_str().unwrap()
         )).run();
     p.cargo("build")
         .cwd(p.root().join("a2"))
         .with_stderr(
             "\
-[COMPILING] a2 v0.0.1 (CWD)
+[COMPILING] a2 v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ).run();
@@ -748,7 +748,7 @@ fn rebuild_if_environment_changes() {
         .with_stdout("old desc")
         .with_stderr(
             "\
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `target/debug/foo[EXE]`
 ",
@@ -770,7 +770,7 @@ fn rebuild_if_environment_changes() {
         .with_stdout("new desc")
         .with_stderr(
             "\
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `target/debug/foo[EXE]`
 ",

--- a/tests/testsuite/git.rs
+++ b/tests/testsuite/git.rs
@@ -57,7 +57,7 @@ fn cargo_compile_simple_git_dep() {
         .with_stderr(&format!(
             "[UPDATING] git repository `{}`\n\
              [COMPILING] dep1 v0.5.0 ({}#[..])\n\
-             [COMPILING] foo v0.5.0 (CWD)\n\
+             [COMPILING] foo v0.5.0 ([CWD])\n\
              [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]\n",
             path2url(&git_root),
             path2url(&git_root),
@@ -193,7 +193,7 @@ fn cargo_compile_offline_with_cached_git_dep() {
         .with_stderr(format!(
             "\
 [COMPILING] dep1 v0.5.0 ({}#[..])
-[COMPILING] foo v0.5.0 (CWD)
+[COMPILING] foo v0.5.0 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]",
             path2url(git_root),
         )).run();
@@ -281,7 +281,7 @@ fn cargo_compile_git_dep_branch() {
         .with_stderr(&format!(
             "[UPDATING] git repository `{}`\n\
              [COMPILING] dep1 v0.5.0 ({}?branch=branchy#[..])\n\
-             [COMPILING] foo v0.5.0 (CWD)\n\
+             [COMPILING] foo v0.5.0 ([CWD])\n\
              [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]\n",
             path2url(&git_root),
             path2url(&git_root),
@@ -352,7 +352,7 @@ fn cargo_compile_git_dep_tag() {
         .with_stderr(&format!(
             "[UPDATING] git repository `{}`\n\
              [COMPILING] dep1 v0.5.0 ({}?tag=v0.1.0#[..])\n\
-             [COMPILING] foo v0.5.0 (CWD)\n\
+             [COMPILING] foo v0.5.0 ([CWD])\n\
              [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]\n",
             path2url(&git_root),
             path2url(&git_root),
@@ -722,7 +722,7 @@ fn recompilation() {
         .with_stderr(&format!(
             "[UPDATING] git repository `{}`\n\
              [COMPILING] bar v0.5.0 ({}#[..])\n\
-             [COMPILING] foo v0.5.0 (CWD)\n\
+             [COMPILING] foo v0.5.0 ([CWD])\n\
              [FINISHED] dev [unoptimized + debuginfo] target(s) \
              in [..]\n",
             git_project.url(),
@@ -770,7 +770,7 @@ fn recompilation() {
     p.cargo("build")
         .with_stderr(&format!(
             "[COMPILING] bar v0.5.0 ({}#[..])\n\
-             [COMPILING] foo v0.5.0 (CWD)\n\
+             [COMPILING] foo v0.5.0 ([CWD])\n\
              [FINISHED] dev [unoptimized + debuginfo] target(s) \
              in [..]\n",
             git_project.url(),
@@ -780,7 +780,7 @@ fn recompilation() {
     p.cargo("clean -p foo").with_stdout("").run();
     p.cargo("build")
         .with_stderr(
-            "[COMPILING] foo v0.5.0 (CWD)\n\
+            "[COMPILING] foo v0.5.0 ([CWD])\n\
              [FINISHED] dev [unoptimized + debuginfo] target(s) \
              in [..]"
         ).run();
@@ -859,7 +859,7 @@ fn update_with_shared_deps() {
 [COMPILING] bar v0.5.0 ({git}#[..])
 [COMPILING] [..] v0.5.0 ([..])
 [COMPILING] [..] v0.5.0 ([..])
-[COMPILING] foo v0.5.0 (CWD)
+[COMPILING] foo v0.5.0 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]\n",
             git = git_project.url(),
         )).run();
@@ -918,9 +918,9 @@ Caused by:
         .with_stderr(&format!(
             "\
 [COMPILING] bar v0.5.0 ({git}#[..])
-[COMPILING] [..] v0.5.0 (CWD[..]dep[..])
-[COMPILING] [..] v0.5.0 (CWD[..]dep[..])
-[COMPILING] foo v0.5.0 (CWD)
+[COMPILING] [..] v0.5.0 ([CWD][..]dep[..])
+[COMPILING] [..] v0.5.0 ([CWD][..]dep[..])
+[COMPILING] foo v0.5.0 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]\n",
             git = git_project.url(),
         )).run();
@@ -1096,7 +1096,7 @@ fn two_deps_only_update_one() {
              [UPDATING] git repository `[..]`\n\
              [COMPILING] [..] v0.5.0 ([..])\n\
              [COMPILING] [..] v0.5.0 ([..])\n\
-             [COMPILING] foo v0.5.0 (CWD)\n\
+             [COMPILING] foo v0.5.0 ([CWD])\n\
              [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]\n",
         ).run();
 
@@ -1196,7 +1196,7 @@ fn stale_cached_version() {
             "\
 [UPDATING] git repository `{bar}`
 [COMPILING] bar v0.0.0 ({bar}#[..])
-[COMPILING] foo v0.0.0 (CWD)
+[COMPILING] foo v0.0.0 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
             bar = bar.url(),
@@ -1359,7 +1359,7 @@ fn dev_deps_with_testing() {
         .with_stderr(&format!(
             "\
 [UPDATING] git repository `{bar}`
-[COMPILING] foo v0.5.0 (CWD)
+[COMPILING] foo v0.5.0 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
             bar = p2.url()
@@ -1402,7 +1402,7 @@ fn git_build_cmd_freshness() {
     foo.cargo("build")
         .with_stderr(
             "\
-[COMPILING] foo v0.0.0 (CWD)
+[COMPILING] foo v0.0.0 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ).run();
@@ -1459,7 +1459,7 @@ fn git_name_not_always_needed() {
         .with_stderr(&format!(
             "\
 [UPDATING] git repository `{bar}`
-[COMPILING] foo v0.5.0 (CWD)
+[COMPILING] foo v0.5.0 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
             bar = p2.url()
@@ -1681,7 +1681,7 @@ fn warnings_in_git_dep() {
         .with_stderr(&format!(
             "[UPDATING] git repository `{}`\n\
              [COMPILING] bar v0.5.0 ({}#[..])\n\
-             [COMPILING] foo v0.5.0 (CWD)\n\
+             [COMPILING] foo v0.5.0 ([CWD])\n\
              [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]\n",
             bar.url(),
             bar.url(),

--- a/tests/testsuite/install.rs
+++ b/tests/testsuite/install.rs
@@ -31,14 +31,14 @@ fn simple() {
 [INSTALLING] foo v0.0.1
 [COMPILING] foo v0.0.1
 [FINISHED] release [optimized] target(s) in [..]
-[INSTALLING] CWD/home/.cargo/bin/foo[EXE]
+[INSTALLING] [CWD]/home/.cargo/bin/foo[EXE]
 warning: be sure to add `[..]` to your PATH to be able to run the installed binaries
 ",
         ).run();
     assert_has_installed_exe(cargo_home(), "foo");
 
     cargo_process("uninstall foo")
-        .with_stderr("[REMOVING] CWD/home/.cargo/bin/foo[EXE]")
+        .with_stderr("[REMOVING] [CWD]/home/.cargo/bin/foo[EXE]")
         .run();
     assert_has_not_installed_exe(cargo_home(), "foo");
 }
@@ -53,16 +53,16 @@ fn multiple_pkgs() {
         .with_stderr(
             "\
 [UPDATING] `[..]` index
-[DOWNLOADING] foo v0.0.1 (registry `CWD/registry`)
+[DOWNLOADING] foo v0.0.1 (registry `[CWD]/registry`)
 [INSTALLING] foo v0.0.1
 [COMPILING] foo v0.0.1
 [FINISHED] release [optimized] target(s) in [..]
-[INSTALLING] CWD/home/.cargo/bin/foo[EXE]
-[DOWNLOADING] bar v0.0.2 (registry `CWD/registry`)
+[INSTALLING] [CWD]/home/.cargo/bin/foo[EXE]
+[DOWNLOADING] bar v0.0.2 (registry `[CWD]/registry`)
 [INSTALLING] bar v0.0.2
 [COMPILING] bar v0.0.2
 [FINISHED] release [optimized] target(s) in [..]
-[INSTALLING] CWD/home/.cargo/bin/bar[EXE]
+[INSTALLING] [CWD]/home/.cargo/bin/bar[EXE]
 error: could not find `baz` in registry `[..]`
 [SUMMARY] Successfully installed foo, bar! Failed to install baz (see error(s) above).
 warning: be sure to add `[..]` to your PATH to be able to run the installed binaries
@@ -75,8 +75,8 @@ error: some crates failed to install
     cargo_process("uninstall foo bar")
         .with_stderr(
             "\
-[REMOVING] CWD/home/.cargo/bin/foo[EXE]
-[REMOVING] CWD/home/.cargo/bin/bar[EXE]
+[REMOVING] [CWD]/home/.cargo/bin/foo[EXE]
+[REMOVING] [CWD]/home/.cargo/bin/bar[EXE]
 [SUMMARY] Successfully uninstalled foo, bar!
 ",
         ).run();
@@ -101,7 +101,7 @@ fn pick_max_version() {
 [INSTALLING] foo v0.2.1
 [COMPILING] foo v0.2.1
 [FINISHED] release [optimized] target(s) in [..]
-[INSTALLING] CWD/home/.cargo/bin/foo[EXE]
+[INSTALLING] [CWD]/home/.cargo/bin/foo[EXE]
 warning: be sure to add `[..]` to your PATH to be able to run the installed binaries
 ",
         ).run();
@@ -434,7 +434,7 @@ fn install_force() {
 [INSTALLING] foo v0.2.0 ([..])
 [COMPILING] foo v0.2.0 ([..])
 [FINISHED] release [optimized] target(s) in [..]
-[REPLACING] CWD/home/.cargo/bin/foo[EXE]
+[REPLACING] [CWD]/home/.cargo/bin/foo[EXE]
 warning: be sure to add `[..]` to your PATH to be able to run the installed binaries
 ",
         ).run();
@@ -471,8 +471,8 @@ fn install_force_partial_overlap() {
 [INSTALLING] foo v0.2.0 ([..])
 [COMPILING] foo v0.2.0 ([..])
 [FINISHED] release [optimized] target(s) in [..]
-[INSTALLING] CWD/home/.cargo/bin/foo-bin3[EXE]
-[REPLACING] CWD/home/.cargo/bin/foo-bin2[EXE]
+[INSTALLING] [CWD]/home/.cargo/bin/foo-bin3[EXE]
+[REPLACING] [CWD]/home/.cargo/bin/foo-bin2[EXE]
 warning: be sure to add `[..]` to your PATH to be able to run the installed binaries
 ",
         ).run();
@@ -512,7 +512,7 @@ fn install_force_bin() {
 [INSTALLING] foo v0.2.0 ([..])
 [COMPILING] foo v0.2.0 ([..])
 [FINISHED] release [optimized] target(s) in [..]
-[REPLACING] CWD/home/.cargo/bin/foo-bin2[EXE]
+[REPLACING] [CWD]/home/.cargo/bin/foo-bin2[EXE]
 warning: be sure to add `[..]` to your PATH to be able to run the installed binaries
 ",
         ).run();
@@ -564,7 +564,7 @@ fn git_repo() {
 [INSTALLING] foo v0.1.0 ([..])
 [COMPILING] foo v0.1.0 ([..])
 [FINISHED] release [optimized] target(s) in [..]
-[INSTALLING] CWD/home/.cargo/bin/foo[EXE]
+[INSTALLING] [CWD]/home/.cargo/bin/foo[EXE]
 warning: be sure to add `[..]` to your PATH to be able to run the installed binaries
 ",
         ).run();
@@ -741,8 +741,8 @@ fn uninstall_cwd() {
     p.cargo("install --path .")
         .with_stderr(&format!(
             "\
-[INSTALLING] foo v0.0.1 (CWD)
-[COMPILING] foo v0.0.1 (CWD)
+[INSTALLING] foo v0.0.1 ([CWD])
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] release [optimized] target(s) in [..]
 [INSTALLING] {home}/bin/foo[EXE]
 warning: be sure to add `{home}/bin` to your PATH to be able to run the installed binaries",
@@ -768,7 +768,7 @@ fn uninstall_cwd_not_installed() {
         .with_stdout("")
         .with_stderr(
             "\
-             error: package `foo v0.0.1 (CWD)` is not installed",
+             error: package `foo v0.0.1 ([CWD])` is not installed",
         ).run();
 }
 
@@ -784,7 +784,7 @@ fn uninstall_cwd_no_project() {
         .with_stdout("")
         .with_stderr(format!(
             "\
-[ERROR] failed to read `CWD/Cargo.toml`
+[ERROR] failed to read `[CWD]/Cargo.toml`
 
 Caused by:
   {err_msg} (os error 2)",
@@ -1068,7 +1068,7 @@ fn uninstall_multiple_and_some_pkg_does_not_exist() {
         .with_status(101)
         .with_stderr(
             "\
-[REMOVING] CWD/home/.cargo/bin/foo[EXE]
+[REMOVING] [CWD]/home/.cargo/bin/foo[EXE]
 error: package id specification `bar` matched no packages
 [SUMMARY] Successfully uninstalled foo! Failed to uninstall bar (see error(s) above).
 error: some packages failed to uninstall

--- a/tests/testsuite/local_registry.rs
+++ b/tests/testsuite/local_registry.rs
@@ -50,7 +50,7 @@ fn simple() {
             "\
 [UNPACKING] bar v0.0.1 ([..])
 [COMPILING] bar v0.0.1
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] [..]
 ",
         ).run();
@@ -89,7 +89,7 @@ fn multiple_versions() {
             "\
 [UNPACKING] bar v0.1.0 ([..])
 [COMPILING] bar v0.1.0
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] [..]
 ",
         ).run();
@@ -148,7 +148,7 @@ fn multiple_names() {
 [UNPACKING] [..]
 [COMPILING] [..]
 [COMPILING] [..]
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] [..]
 ",
         ).run();
@@ -199,7 +199,7 @@ fn interdependent() {
 [UNPACKING] [..]
 [COMPILING] bar v0.0.1
 [COMPILING] baz v0.1.0
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] [..]
 ",
         ).run();
@@ -263,7 +263,7 @@ fn path_dep_rewritten() {
 [UNPACKING] [..]
 [COMPILING] bar v0.0.1
 [COMPILING] baz v0.1.0
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] [..]
 ",
         ).run();
@@ -413,7 +413,7 @@ fn crates_io_registry_url_is_optional() {
             "\
 [UNPACKING] bar v0.0.1 ([..])
 [COMPILING] bar v0.0.1
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] [..]
 ",
         ).run();

--- a/tests/testsuite/new.rs
+++ b/tests/testsuite/new.rs
@@ -105,7 +105,7 @@ fn existing() {
     cargo_process("new foo")
         .with_status(101)
         .with_stderr(
-            "[ERROR] destination `CWD/foo` already exists\n\n\
+            "[ERROR] destination `[CWD]/foo` already exists\n\n\
              Use `cargo init` to initialize the directory",
         ).run();
 }

--- a/tests/testsuite/overrides.rs
+++ b/tests/testsuite/overrides.rs
@@ -38,10 +38,10 @@ fn override_simple() {
     p.cargo("build")
         .with_stderr(
             "\
-[UPDATING] `file://[..]` index
+[UPDATING] `[ROOT][..]` index
 [UPDATING] git repository `[..]`
 [COMPILING] bar v0.1.0 (file://[..])
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ).run();
@@ -183,12 +183,12 @@ fn transitive() {
     p.cargo("build")
         .with_stderr(
             "\
-[UPDATING] `file://[..]` index
+[UPDATING] `[ROOT][..]` index
 [UPDATING] git repository `[..]`
 [DOWNLOADING] baz v0.2.0 (registry [..])
 [COMPILING] bar v0.1.0 (file://[..])
 [COMPILING] baz v0.2.0
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ).run();
@@ -231,10 +231,10 @@ fn persists_across_rebuilds() {
     p.cargo("build")
         .with_stderr(
             "\
-[UPDATING] `file://[..]` index
+[UPDATING] `[ROOT][..]` index
 [UPDATING] git repository `file://[..]`
 [COMPILING] bar v0.1.0 (file://[..])
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ).run();
@@ -275,9 +275,9 @@ fn replace_registry_with_path() {
     p.cargo("build")
         .with_stderr(
             "\
-[UPDATING] `file://[..]` index
-[COMPILING] bar v0.1.0 (file://[..])
-[COMPILING] foo v0.0.1 (CWD)
+[UPDATING] `[ROOT][..]` index
+[COMPILING] bar v0.1.0 ([ROOT][..])
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ).run();
@@ -336,14 +336,14 @@ fn use_a_spec_to_select() {
     p.cargo("build")
         .with_stderr(
             "\
-[UPDATING] `file://[..]` index
+[UPDATING] `[ROOT][..]` index
 [UPDATING] git repository `[..]`
 [DOWNLOADING] [..]
 [DOWNLOADING] [..]
 [COMPILING] [..]
 [COMPILING] [..]
 [COMPILING] [..]
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ).run();
@@ -393,12 +393,12 @@ fn override_adds_some_deps() {
     p.cargo("build")
         .with_stderr(
             "\
-[UPDATING] `file://[..]` index
+[UPDATING] `[ROOT][..]` index
 [UPDATING] git repository `[..]`
 [DOWNLOADING] baz v0.1.1 (registry [..])
 [COMPILING] baz v0.1.1
 [COMPILING] bar v0.1.0 ([..])
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ).run();
@@ -411,13 +411,13 @@ fn override_adds_some_deps() {
         .with_stderr(
             "\
 [UPDATING] git repository `file://[..]`
-[UPDATING] `file://[..]` index
+[UPDATING] `[ROOT][..]` index
 ",
         ).run();
     p.cargo("update -p https://github.com/rust-lang/crates.io-index#bar")
         .with_stderr(
             "\
-[UPDATING] `file://[..]` index
+[UPDATING] `[ROOT][..]` index
 ",
         ).run();
 

--- a/tests/testsuite/package.rs
+++ b/tests/testsuite/package.rs
@@ -31,9 +31,9 @@ fn simple() {
             "\
 [WARNING] manifest has no documentation[..]
 See [..]
-[PACKAGING] foo v0.0.1 (CWD)
-[VERIFYING] foo v0.0.1 (CWD)
-[COMPILING] foo v0.0.1 (CWD[..])
+[PACKAGING] foo v0.0.1 ([CWD])
+[VERIFYING] foo v0.0.1 ([CWD])
+[COMPILING] foo v0.0.1 ([CWD][..])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ).run();
@@ -75,9 +75,9 @@ fn metadata_warning() {
 warning: manifest has no description, license, license-file, documentation, \
 homepage or repository.
 See http://doc.crates.io/manifest.html#package-metadata for more info.
-[PACKAGING] foo v0.0.1 (CWD)
-[VERIFYING] foo v0.0.1 (CWD)
-[COMPILING] foo v0.0.1 (CWD[..])
+[PACKAGING] foo v0.0.1 ([CWD])
+[VERIFYING] foo v0.0.1 ([CWD])
+[COMPILING] foo v0.0.1 ([CWD][..])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ).run();
@@ -99,9 +99,9 @@ See http://doc.crates.io/manifest.html#package-metadata for more info.
             "\
 warning: manifest has no description, documentation, homepage or repository.
 See http://doc.crates.io/manifest.html#package-metadata for more info.
-[PACKAGING] foo v0.0.1 (CWD)
-[VERIFYING] foo v0.0.1 (CWD)
-[COMPILING] foo v0.0.1 (CWD[..])
+[PACKAGING] foo v0.0.1 ([CWD])
+[VERIFYING] foo v0.0.1 ([CWD])
+[COMPILING] foo v0.0.1 ([CWD][..])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ).run();
@@ -123,9 +123,9 @@ See http://doc.crates.io/manifest.html#package-metadata for more info.
     p.cargo("package")
         .with_stderr(
             "\
-[PACKAGING] foo v0.0.1 (CWD)
-[VERIFYING] foo v0.0.1 (CWD)
-[COMPILING] foo v0.0.1 (CWD[..])
+[PACKAGING] foo v0.0.1 ([CWD])
+[VERIFYING] foo v0.0.1 ([CWD])
+[COMPILING] foo v0.0.1 ([CWD][..])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ).run();
@@ -206,9 +206,9 @@ fn package_verification() {
             "\
 [WARNING] manifest has no description[..]
 See http://doc.crates.io/manifest.html#package-metadata for more info.
-[PACKAGING] foo v0.0.1 (CWD)
-[VERIFYING] foo v0.0.1 (CWD)
-[COMPILING] foo v0.0.1 (CWD[..])
+[PACKAGING] foo v0.0.1 ([CWD])
+[VERIFYING] foo v0.0.1 ([CWD])
+[COMPILING] foo v0.0.1 ([CWD][..])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ).run();
@@ -544,9 +544,9 @@ fn ignore_nested() {
             "\
 [WARNING] manifest has no documentation[..]
 See http://doc.crates.io/manifest.html#package-metadata for more info.
-[PACKAGING] foo v0.0.1 (CWD)
-[VERIFYING] foo v0.0.1 (CWD)
-[COMPILING] foo v0.0.1 (CWD[..])
+[PACKAGING] foo v0.0.1 ([CWD])
+[VERIFYING] foo v0.0.1 ([CWD])
+[COMPILING] foo v0.0.1 ([CWD][..])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ).run();
@@ -629,9 +629,9 @@ fn repackage_on_source_change() {
             "\
 [WARNING] [..]
 See [..]
-[PACKAGING] foo v0.0.1 (CWD)
-[VERIFYING] foo v0.0.1 (CWD)
-[COMPILING] foo v0.0.1 (CWD[..])
+[PACKAGING] foo v0.0.1 ([CWD])
+[VERIFYING] foo v0.0.1 ([CWD])
+[COMPILING] foo v0.0.1 ([CWD][..])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ).run();
@@ -1041,9 +1041,9 @@ fn package_lockfile() {
             "\
 [WARNING] manifest has no documentation[..]
 See [..]
-[PACKAGING] foo v0.0.1 (CWD)
-[VERIFYING] foo v0.0.1 (CWD)
-[COMPILING] foo v0.0.1 (CWD[..])
+[PACKAGING] foo v0.0.1 ([CWD])
+[VERIFYING] foo v0.0.1 ([CWD])
+[COMPILING] foo v0.0.1 ([CWD][..])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ).run();

--- a/tests/testsuite/patch.rs
+++ b/tests/testsuite/patch.rs
@@ -50,11 +50,11 @@ fn replace() {
     p.cargo("build")
         .with_stderr(
             "\
-[UPDATING] `file://[..]` index
+[UPDATING] `[ROOT][..]` index
 [DOWNLOADING] baz v0.1.0 ([..])
-[COMPILING] bar v0.1.0 (CWD/bar)
+[COMPILING] bar v0.1.0 ([CWD]/bar)
 [COMPILING] baz v0.1.0
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ).run();
@@ -91,9 +91,9 @@ fn nonexistent() {
     p.cargo("build")
         .with_stderr(
             "\
-[UPDATING] `file://[..]` index
-[COMPILING] bar v0.1.0 (CWD/bar)
-[COMPILING] foo v0.0.1 (CWD)
+[UPDATING] `[ROOT][..]` index
+[COMPILING] bar v0.1.0 ([CWD]/bar)
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ).run();
@@ -136,8 +136,8 @@ fn patch_git() {
         .with_stderr(
             "\
 [UPDATING] git repository `file://[..]`
-[COMPILING] bar v0.1.0 (CWD/bar)
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] bar v0.1.0 ([CWD]/bar)
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ).run();
@@ -180,9 +180,9 @@ fn patch_to_git() {
         .with_stderr(
             "\
 [UPDATING] git repository `file://[..]`
-[UPDATING] `file://[..]` index
+[UPDATING] `[ROOT][..]` index
 [COMPILING] bar v0.1.0 (file://[..])
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ).run();
@@ -216,10 +216,10 @@ fn unused() {
     p.cargo("build")
         .with_stderr(
             "\
-[UPDATING] `file://[..]` index
+[UPDATING] `[ROOT][..]` index
 [DOWNLOADING] bar v0.1.0 [..]
 [COMPILING] bar v0.1.0
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ).run();
@@ -274,10 +274,10 @@ fn unused_git() {
         .with_stderr(
             "\
 [UPDATING] git repository `file://[..]`
-[UPDATING] `file://[..]` index
+[UPDATING] `[ROOT][..]` index
 [DOWNLOADING] bar v0.1.0 [..]
 [COMPILING] bar v0.1.0
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ).run();
@@ -308,10 +308,10 @@ fn add_patch() {
     p.cargo("build")
         .with_stderr(
             "\
-[UPDATING] `file://[..]` index
+[UPDATING] `[ROOT][..]` index
 [DOWNLOADING] bar v0.1.0 [..]
 [COMPILING] bar v0.1.0
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ).run();
@@ -335,8 +335,8 @@ fn add_patch() {
     p.cargo("build")
         .with_stderr(
             "\
-[COMPILING] bar v0.1.0 (CWD/bar)
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] bar v0.1.0 ([CWD]/bar)
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ).run();
@@ -367,10 +367,10 @@ fn add_ignored_patch() {
     p.cargo("build")
         .with_stderr(
             "\
-[UPDATING] `file://[..]` index
+[UPDATING] `[ROOT][..]` index
 [DOWNLOADING] bar v0.1.0 [..]
 [COMPILING] bar v0.1.0
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ).run();
@@ -424,9 +424,9 @@ fn new_minor() {
     p.cargo("build")
         .with_stderr(
             "\
-[UPDATING] `file://[..]` index
+[UPDATING] `[ROOT][..]` index
 [COMPILING] bar v0.1.1 [..]
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ).run();
@@ -471,10 +471,10 @@ fn transitive_new_minor() {
     p.cargo("build")
         .with_stderr(
             "\
-[UPDATING] `file://[..]` index
+[UPDATING] `[ROOT][..]` index
 [COMPILING] baz v0.1.1 [..]
 [COMPILING] bar v0.1.0 [..]
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ).run();
@@ -507,9 +507,9 @@ fn new_major() {
     p.cargo("build")
         .with_stderr(
             "\
-[UPDATING] `file://[..]` index
+[UPDATING] `[ROOT][..]` index
 [COMPILING] bar v0.2.0 [..]
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ).run();
@@ -534,10 +534,10 @@ fn new_major() {
     p.cargo("build")
         .with_stderr(
             "\
-[UPDATING] `file://[..]` index
+[UPDATING] `[ROOT][..]` index
 [DOWNLOADING] bar v0.2.0 [..]
 [COMPILING] bar v0.2.0
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ).run();
@@ -582,10 +582,10 @@ fn transitive_new_major() {
     p.cargo("build")
         .with_stderr(
             "\
-[UPDATING] `file://[..]` index
+[UPDATING] `[ROOT][..]` index
 [COMPILING] baz v0.2.0 [..]
 [COMPILING] bar v0.1.0 [..]
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ).run();

--- a/tests/testsuite/path.rs
+++ b/tests/testsuite/path.rs
@@ -65,9 +65,9 @@ fn cargo_compile_with_nested_deps_shorthand() {
 
     p.cargo("build")
         .with_stderr(
-            "[COMPILING] baz v0.5.0 (CWD/bar/baz)\n\
-             [COMPILING] bar v0.5.0 (CWD/bar)\n\
-             [COMPILING] foo v0.5.0 (CWD)\n\
+            "[COMPILING] baz v0.5.0 ([CWD]/bar/baz)\n\
+             [COMPILING] bar v0.5.0 ([CWD]/bar)\n\
+             [COMPILING] foo v0.5.0 ([CWD])\n\
              [FINISHED] dev [unoptimized + debuginfo] target(s) \
              in [..]\n",
         ).run();
@@ -81,15 +81,15 @@ fn cargo_compile_with_nested_deps_shorthand() {
     println!("building baz");
     p.cargo("build -p baz")
         .with_stderr(
-            "[COMPILING] baz v0.5.0 (CWD/bar/baz)\n\
+            "[COMPILING] baz v0.5.0 ([CWD]/bar/baz)\n\
              [FINISHED] dev [unoptimized + debuginfo] target(s) \
              in [..]\n",
         ).run();
     println!("building foo");
     p.cargo("build -p foo")
         .with_stderr(
-            "[COMPILING] bar v0.5.0 (CWD/bar)\n\
-             [COMPILING] foo v0.5.0 (CWD)\n\
+            "[COMPILING] bar v0.5.0 ([CWD]/bar)\n\
+             [COMPILING] foo v0.5.0 ([CWD])\n\
              [FINISHED] dev [unoptimized + debuginfo] target(s) \
              in [..]\n",
         ).run();
@@ -223,8 +223,8 @@ fn cargo_compile_with_transitive_dev_deps() {
 
     p.cargo("build")
         .with_stderr(
-            "[COMPILING] bar v0.5.0 (CWD/bar)\n\
-             [COMPILING] foo v0.5.0 (CWD)\n\
+            "[COMPILING] bar v0.5.0 ([CWD]/bar)\n\
+             [COMPILING] foo v0.5.0 ([CWD])\n\
              [FINISHED] dev [unoptimized + debuginfo] target(s) in \
              [..]\n",
         ).run();
@@ -256,8 +256,8 @@ fn no_rebuild_dependency() {
     // First time around we should compile both foo and bar
     p.cargo("build")
         .with_stderr(
-            "[COMPILING] bar v0.5.0 (CWD/bar)\n\
-             [COMPILING] foo v0.5.0 (CWD)\n\
+            "[COMPILING] bar v0.5.0 ([CWD]/bar)\n\
+             [COMPILING] foo v0.5.0 ([CWD])\n\
              [FINISHED] dev [unoptimized + debuginfo] target(s) \
              in [..]\n",
         ).run();
@@ -318,9 +318,9 @@ fn deep_dependencies_trigger_rebuild() {
         .build();
     p.cargo("build")
         .with_stderr(
-            "[COMPILING] baz v0.5.0 (CWD/baz)\n\
-             [COMPILING] bar v0.5.0 (CWD/bar)\n\
-             [COMPILING] foo v0.5.0 (CWD)\n\
+            "[COMPILING] baz v0.5.0 ([CWD]/baz)\n\
+             [COMPILING] bar v0.5.0 ([CWD]/bar)\n\
+             [COMPILING] foo v0.5.0 ([CWD])\n\
              [FINISHED] dev [unoptimized + debuginfo] target(s) \
              in [..]\n",
         ).run();
@@ -337,9 +337,9 @@ fn deep_dependencies_trigger_rebuild() {
     sleep_ms(1000);
     p.cargo("build")
         .with_stderr(
-            "[COMPILING] baz v0.5.0 (CWD/baz)\n\
-             [COMPILING] bar v0.5.0 (CWD/bar)\n\
-             [COMPILING] foo v0.5.0 (CWD)\n\
+            "[COMPILING] baz v0.5.0 ([CWD]/baz)\n\
+             [COMPILING] bar v0.5.0 ([CWD]/bar)\n\
+             [COMPILING] foo v0.5.0 ([CWD])\n\
              [FINISHED] dev [unoptimized + debuginfo] target(s) \
              in [..]\n",
         ).run();
@@ -356,8 +356,8 @@ fn deep_dependencies_trigger_rebuild() {
     sleep_ms(1000);
     p.cargo("build")
         .with_stderr(
-            "[COMPILING] bar v0.5.0 (CWD/bar)\n\
-             [COMPILING] foo v0.5.0 (CWD)\n\
+            "[COMPILING] bar v0.5.0 ([CWD]/bar)\n\
+             [COMPILING] foo v0.5.0 ([CWD])\n\
              [FINISHED] dev [unoptimized + debuginfo] target(s) \
              in [..]\n",
         ).run();
@@ -401,9 +401,9 @@ fn no_rebuild_two_deps() {
         .build();
     p.cargo("build")
         .with_stderr(
-            "[COMPILING] baz v0.5.0 (CWD/baz)\n\
-             [COMPILING] bar v0.5.0 (CWD/bar)\n\
-             [COMPILING] foo v0.5.0 (CWD)\n\
+            "[COMPILING] baz v0.5.0 ([CWD]/baz)\n\
+             [COMPILING] bar v0.5.0 ([CWD]/bar)\n\
+             [COMPILING] foo v0.5.0 ([CWD])\n\
              [FINISHED] dev [unoptimized + debuginfo] target(s) \
              in [..]\n",
         ).run();
@@ -436,8 +436,8 @@ fn nested_deps_recompile() {
 
     p.cargo("build")
         .with_stderr(
-            "[COMPILING] bar v0.5.0 (CWD/src/bar)\n\
-             [COMPILING] foo v0.5.0 (CWD)\n\
+            "[COMPILING] bar v0.5.0 ([CWD]/src/bar)\n\
+             [COMPILING] foo v0.5.0 ([CWD])\n\
              [FINISHED] dev [unoptimized + debuginfo] target(s) \
              in [..]\n",
         ).run();
@@ -451,7 +451,7 @@ fn nested_deps_recompile() {
     // This shouldn't recompile `bar`
     p.cargo("build")
         .with_stderr(
-            "[COMPILING] foo v0.5.0 (CWD)\n\
+            "[COMPILING] foo v0.5.0 ([CWD])\n\
              [FINISHED] dev [unoptimized + debuginfo] target(s) \
              in [..]\n",
         ).run();
@@ -484,7 +484,7 @@ fn error_message_for_missing_manifest() {
 [ERROR] failed to load source for a dependency on `bar`
 
 Caused by:
-  Unable to update CWD/src/bar
+  Unable to update [CWD]/src/bar
 
 Caused by:
   failed to read `[..]bar/Cargo.toml`
@@ -661,8 +661,8 @@ fn path_dep_build_cmd() {
 
     p.cargo("build")
         .with_stderr(
-            "[COMPILING] bar v0.5.0 (CWD/bar)\n\
-             [COMPILING] foo v0.5.0 (CWD)\n\
+            "[COMPILING] bar v0.5.0 ([CWD]/bar)\n\
+             [COMPILING] foo v0.5.0 ([CWD])\n\
              [FINISHED] dev [unoptimized + debuginfo] target(s) in \
              [..]\n",
         ).run();
@@ -681,8 +681,8 @@ fn path_dep_build_cmd() {
 
     p.cargo("build")
         .with_stderr(
-            "[COMPILING] bar v0.5.0 (CWD/bar)\n\
-             [COMPILING] foo v0.5.0 (CWD)\n\
+            "[COMPILING] bar v0.5.0 ([CWD]/bar)\n\
+             [COMPILING] foo v0.5.0 ([CWD])\n\
              [FINISHED] dev [unoptimized + debuginfo] target(s) in \
              [..]\n",
         ).run();
@@ -720,7 +720,7 @@ fn dev_deps_no_rebuild_lib() {
     p.cargo("build")
         .env("FOO", "bar")
         .with_stderr(
-            "[COMPILING] foo v0.5.0 (CWD)\n\
+            "[COMPILING] foo v0.5.0 ([CWD])\n\
              [FINISHED] dev [unoptimized + debuginfo] target(s) \
              in [..]\n",
         ).run();
@@ -728,8 +728,8 @@ fn dev_deps_no_rebuild_lib() {
     p.cargo("test")
         .with_stderr(
             "\
-[COMPILING] [..] v0.5.0 (CWD[..])
-[COMPILING] [..] v0.5.0 (CWD[..])
+[COMPILING] [..] v0.5.0 ([CWD][..])
+[COMPILING] [..] v0.5.0 ([CWD][..])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target/debug/deps/foo-[..][EXE]",
         ).with_stdout_contains("running 0 tests")

--- a/tests/testsuite/profile_config.rs
+++ b/tests/testsuite/profile_config.rs
@@ -94,7 +94,7 @@ fn profile_config_error_paths() {
         .with_status(101)
         .with_stderr(
             "\
-[ERROR] failed to parse manifest at `CWD/Cargo.toml`
+[ERROR] failed to parse manifest at `[CWD]/Cargo.toml`
 
 Caused by:
   error in [..].cargo/config: `profile.dev.rpath` expected true/false, but found a string
@@ -128,7 +128,7 @@ fn profile_config_validate_errors() {
         .with_status(101)
         .with_stderr(
             "\
-[ERROR] failed to parse manifest at `CWD/Cargo.toml`
+[ERROR] failed to parse manifest at `[CWD]/Cargo.toml`
 
 Caused by:
   config profile `profile.dev` is not valid

--- a/tests/testsuite/profile_overrides.rs
+++ b/tests/testsuite/profile_overrides.rs
@@ -305,17 +305,17 @@ fn profile_override_hierarchy() {
     p.cargo("build -v").masquerade_as_nightly_cargo().with_stderr_unordered("\
 [COMPILING] m3 [..]
 [COMPILING] dep [..]
-[RUNNING] `rustc --crate-name m3 m3/src/lib.rs --crate-type lib --emit=dep-info,link -C codegen-units=4 [..]
-[RUNNING] `rustc --crate-name dep [..]dep/src/lib.rs --crate-type lib --emit=dep-info,link -C codegen-units=3 [..]
-[RUNNING] `rustc --crate-name m3 m3/src/lib.rs --crate-type lib --emit=dep-info,link -C codegen-units=1 [..]
-[RUNNING] `rustc --crate-name build_script_build m1/build.rs --crate-type bin --emit=dep-info,link -C codegen-units=4 [..]
+[RUNNING] `rustc --crate-name m3 m3/src/lib.rs --color never --crate-type lib --emit=dep-info,link -C codegen-units=4 [..]
+[RUNNING] `rustc --crate-name dep [..]dep/src/lib.rs --color never --crate-type lib --emit=dep-info,link -C codegen-units=3 [..]
+[RUNNING] `rustc --crate-name m3 m3/src/lib.rs --color never --crate-type lib --emit=dep-info,link -C codegen-units=1 [..]
+[RUNNING] `rustc --crate-name build_script_build m1/build.rs --color never --crate-type bin --emit=dep-info,link -C codegen-units=4 [..]
 [COMPILING] m2 [..]
-[RUNNING] `rustc --crate-name build_script_build m2/build.rs --crate-type bin --emit=dep-info,link -C codegen-units=2 [..]
+[RUNNING] `rustc --crate-name build_script_build m2/build.rs --color never --crate-type bin --emit=dep-info,link -C codegen-units=2 [..]
 [RUNNING] `[..]/m1-[..]/build-script-build`
 [RUNNING] `[..]/m2-[..]/build-script-build`
-[RUNNING] `rustc --crate-name m2 m2/src/lib.rs --crate-type lib --emit=dep-info,link -C codegen-units=2 [..]
+[RUNNING] `rustc --crate-name m2 m2/src/lib.rs --color never --crate-type lib --emit=dep-info,link -C codegen-units=2 [..]
 [COMPILING] m1 [..]
-[RUNNING] `rustc --crate-name m1 m1/src/lib.rs --crate-type lib --emit=dep-info,link -C codegen-units=1 [..]
+[RUNNING] `rustc --crate-name m1 m1/src/lib.rs --color never --crate-type lib --emit=dep-info,link -C codegen-units=1 [..]
 [FINISHED] dev [unoptimized + debuginfo] [..]
 ",
         )

--- a/tests/testsuite/profile_targets.rs
+++ b/tests/testsuite/profile_targets.rs
@@ -77,15 +77,15 @@ fn profile_selection_build() {
     // - build_script_build is built without panic because it thinks `build.rs` is a plugin.
     p.cargo("build -vv").with_stderr_unordered("\
 [COMPILING] bar [..]
-[RUNNING] `rustc --crate-name bar bar/src/lib.rs --crate-type lib --emit=dep-info,link -C codegen-units=1 -C debuginfo=2 [..]
+[RUNNING] `rustc --crate-name bar bar/src/lib.rs --color never --crate-type lib --emit=dep-info,link -C codegen-units=1 -C debuginfo=2 [..]
 [COMPILING] bdep [..]
-[RUNNING] `rustc --crate-name bdep bdep/src/lib.rs --crate-type lib --emit=dep-info,link -C codegen-units=1 -C debuginfo=2 [..]
+[RUNNING] `rustc --crate-name bdep bdep/src/lib.rs --color never --crate-type lib --emit=dep-info,link -C codegen-units=1 -C debuginfo=2 [..]
 [COMPILING] foo [..]
-[RUNNING] `rustc --crate-name build_script_build build.rs --crate-type bin --emit=dep-info,link -C codegen-units=1 -C debuginfo=2 [..]
+[RUNNING] `rustc --crate-name build_script_build build.rs --color never --crate-type bin --emit=dep-info,link -C codegen-units=1 -C debuginfo=2 [..]
 [RUNNING] `[..]/target/debug/build/foo-[..]/build-script-build`
 foo custom build PROFILE=debug DEBUG=true OPT_LEVEL=0
-[RUNNING] `rustc --crate-name foo src/lib.rs --crate-type lib --emit=dep-info,link -C panic=abort -C codegen-units=1 -C debuginfo=2 [..]
-[RUNNING] `rustc --crate-name foo src/main.rs --crate-type bin --emit=dep-info,link -C panic=abort -C codegen-units=1 -C debuginfo=2 [..]
+[RUNNING] `rustc --crate-name foo src/lib.rs --color never --crate-type lib --emit=dep-info,link -C panic=abort -C codegen-units=1 -C debuginfo=2 [..]
+[RUNNING] `rustc --crate-name foo src/main.rs --color never --crate-type bin --emit=dep-info,link -C panic=abort -C codegen-units=1 -C debuginfo=2 [..]
 [FINISHED] dev [unoptimized + debuginfo] [..]
 ").run();
     p.cargo("build -vv")
@@ -106,15 +106,15 @@ fn profile_selection_build_release() {
     // Build default targets, release.
     p.cargo("build --release -vv").with_stderr_unordered("\
 [COMPILING] bar [..]
-[RUNNING] `rustc --crate-name bar bar/src/lib.rs --crate-type lib --emit=dep-info,link -C opt-level=3 -C codegen-units=2 [..]
+[RUNNING] `rustc --crate-name bar bar/src/lib.rs --color never --crate-type lib --emit=dep-info,link -C opt-level=3 -C codegen-units=2 [..]
 [COMPILING] bdep [..]
-[RUNNING] `rustc --crate-name bdep bdep/src/lib.rs --crate-type lib --emit=dep-info,link -C opt-level=3 -C codegen-units=2 [..]
+[RUNNING] `rustc --crate-name bdep bdep/src/lib.rs --color never --crate-type lib --emit=dep-info,link -C opt-level=3 -C codegen-units=2 [..]
 [COMPILING] foo [..]
-[RUNNING] `rustc --crate-name build_script_build build.rs --crate-type bin --emit=dep-info,link -C opt-level=3 -C codegen-units=2 [..]
+[RUNNING] `rustc --crate-name build_script_build build.rs --color never --crate-type bin --emit=dep-info,link -C opt-level=3 -C codegen-units=2 [..]
 [RUNNING] `[..]/target/release/build/foo-[..]/build-script-build`
 foo custom build PROFILE=release DEBUG=false OPT_LEVEL=3
-[RUNNING] `rustc --crate-name foo src/lib.rs --crate-type lib --emit=dep-info,link -C opt-level=3 -C panic=abort -C codegen-units=2 [..]
-[RUNNING] `rustc --crate-name foo src/main.rs --crate-type bin --emit=dep-info,link -C opt-level=3 -C panic=abort -C codegen-units=2 [..]
+[RUNNING] `rustc --crate-name foo src/lib.rs --color never --crate-type lib --emit=dep-info,link -C opt-level=3 -C panic=abort -C codegen-units=2 [..]
+[RUNNING] `rustc --crate-name foo src/main.rs --color never --crate-type bin --emit=dep-info,link -C opt-level=3 -C panic=abort -C codegen-units=2 [..]
 [FINISHED] release [optimized] [..]
 ").run();
     p.cargo("build --release -vv")
@@ -169,26 +169,26 @@ fn profile_selection_build_all_targets() {
     //   example  dev        build
     p.cargo("build --all-targets -vv").with_stderr_unordered("\
 [COMPILING] bar [..]
-[RUNNING] `rustc --crate-name bar bar/src/lib.rs --crate-type lib --emit=dep-info,link -C codegen-units=1 -C debuginfo=2 [..]
-[RUNNING] `rustc --crate-name bar bar/src/lib.rs --crate-type lib --emit=dep-info,link -C codegen-units=1 -C debuginfo=2 [..]
+[RUNNING] `rustc --crate-name bar bar/src/lib.rs --color never --crate-type lib --emit=dep-info,link -C codegen-units=1 -C debuginfo=2 [..]
+[RUNNING] `rustc --crate-name bar bar/src/lib.rs --color never --crate-type lib --emit=dep-info,link -C codegen-units=1 -C debuginfo=2 [..]
 [COMPILING] bdep [..]
-[RUNNING] `rustc --crate-name bdep bdep/src/lib.rs --crate-type lib --emit=dep-info,link -C codegen-units=1 -C debuginfo=2 [..]
+[RUNNING] `rustc --crate-name bdep bdep/src/lib.rs --color never --crate-type lib --emit=dep-info,link -C codegen-units=1 -C debuginfo=2 [..]
 [COMPILING] foo [..]
-[RUNNING] `rustc --crate-name build_script_build build.rs --crate-type bin --emit=dep-info,link -C codegen-units=1 -C debuginfo=2 [..]
+[RUNNING] `rustc --crate-name build_script_build build.rs --color never --crate-type bin --emit=dep-info,link -C codegen-units=1 -C debuginfo=2 [..]
 [RUNNING] `[..]/target/debug/build/foo-[..]/build-script-build`
 [RUNNING] `[..]/target/debug/build/foo-[..]/build-script-build`
 foo custom build PROFILE=debug DEBUG=false OPT_LEVEL=3
 foo custom build PROFILE=debug DEBUG=true OPT_LEVEL=0
-[RUNNING] `rustc --crate-name foo src/lib.rs --crate-type lib --emit=dep-info,link -C panic=abort -C codegen-units=1 -C debuginfo=2 [..]`
-[RUNNING] `rustc --crate-name foo src/lib.rs --emit=dep-info,link -C codegen-units=3 -C debuginfo=2 --test [..]`
-[RUNNING] `rustc --crate-name foo src/lib.rs --crate-type lib --emit=dep-info,link -C codegen-units=1 -C debuginfo=2 [..]`
-[RUNNING] `rustc --crate-name foo src/lib.rs --emit=dep-info,link -C opt-level=3 -C codegen-units=4 --test [..]`
-[RUNNING] `rustc --crate-name foo src/main.rs --emit=dep-info,link -C codegen-units=3 -C debuginfo=2 --test [..]`
-[RUNNING] `rustc --crate-name test1 tests/test1.rs --emit=dep-info,link -C codegen-units=3 -C debuginfo=2 --test [..]`
-[RUNNING] `rustc --crate-name bench1 benches/bench1.rs --emit=dep-info,link -C opt-level=3 -C codegen-units=4 --test [..]`
-[RUNNING] `rustc --crate-name foo src/main.rs --emit=dep-info,link -C opt-level=3 -C codegen-units=4 --test [..]`
-[RUNNING] `rustc --crate-name foo src/main.rs --crate-type bin --emit=dep-info,link -C panic=abort -C codegen-units=1 -C debuginfo=2 [..]`
-[RUNNING] `rustc --crate-name ex1 examples/ex1.rs --crate-type bin --emit=dep-info,link -C panic=abort -C codegen-units=1 -C debuginfo=2 [..]`
+[RUNNING] `rustc --crate-name foo src/lib.rs --color never --crate-type lib --emit=dep-info,link -C panic=abort -C codegen-units=1 -C debuginfo=2 [..]`
+[RUNNING] `rustc --crate-name foo src/lib.rs --color never --emit=dep-info,link -C codegen-units=3 -C debuginfo=2 --test [..]`
+[RUNNING] `rustc --crate-name foo src/lib.rs --color never --crate-type lib --emit=dep-info,link -C codegen-units=1 -C debuginfo=2 [..]`
+[RUNNING] `rustc --crate-name foo src/lib.rs --color never --emit=dep-info,link -C opt-level=3 -C codegen-units=4 --test [..]`
+[RUNNING] `rustc --crate-name foo src/main.rs --color never --emit=dep-info,link -C codegen-units=3 -C debuginfo=2 --test [..]`
+[RUNNING] `rustc --crate-name test1 tests/test1.rs --color never --emit=dep-info,link -C codegen-units=3 -C debuginfo=2 --test [..]`
+[RUNNING] `rustc --crate-name bench1 benches/bench1.rs --color never --emit=dep-info,link -C opt-level=3 -C codegen-units=4 --test [..]`
+[RUNNING] `rustc --crate-name foo src/main.rs --color never --emit=dep-info,link -C opt-level=3 -C codegen-units=4 --test [..]`
+[RUNNING] `rustc --crate-name foo src/main.rs --color never --crate-type bin --emit=dep-info,link -C panic=abort -C codegen-units=1 -C debuginfo=2 [..]`
+[RUNNING] `rustc --crate-name ex1 examples/ex1.rs --color never --crate-type bin --emit=dep-info,link -C panic=abort -C codegen-units=1 -C debuginfo=2 [..]`
 [FINISHED] dev [unoptimized + debuginfo] [..]
 ").run();
     p.cargo("build -vv")
@@ -240,22 +240,22 @@ fn profile_selection_build_all_targets_release() {
     //   example  release        build
     p.cargo("build --all-targets --release -vv").with_stderr_unordered("\
 [COMPILING] bar [..]
-[RUNNING] `rustc --crate-name bar bar/src/lib.rs --crate-type lib --emit=dep-info,link -C opt-level=3 -C codegen-units=2 [..]
-[RUNNING] `rustc --crate-name bar bar/src/lib.rs --crate-type lib --emit=dep-info,link -C opt-level=3 -C codegen-units=2 [..]
+[RUNNING] `rustc --crate-name bar bar/src/lib.rs --color never --crate-type lib --emit=dep-info,link -C opt-level=3 -C codegen-units=2 [..]
+[RUNNING] `rustc --crate-name bar bar/src/lib.rs --color never --crate-type lib --emit=dep-info,link -C opt-level=3 -C codegen-units=2 [..]
 [COMPILING] bdep [..]
-[RUNNING] `rustc --crate-name bdep bdep/src/lib.rs --crate-type lib --emit=dep-info,link -C opt-level=3 -C codegen-units=2 [..]
+[RUNNING] `rustc --crate-name bdep bdep/src/lib.rs --color never --crate-type lib --emit=dep-info,link -C opt-level=3 -C codegen-units=2 [..]
 [COMPILING] foo [..]
-[RUNNING] `rustc --crate-name build_script_build build.rs --crate-type bin --emit=dep-info,link -C opt-level=3 -C codegen-units=2 [..]
+[RUNNING] `rustc --crate-name build_script_build build.rs --color never --crate-type bin --emit=dep-info,link -C opt-level=3 -C codegen-units=2 [..]
 [RUNNING] `[..]/target/release/build/foo-[..]/build-script-build`
 foo custom build PROFILE=release DEBUG=false OPT_LEVEL=3
-[RUNNING] `rustc --crate-name foo src/lib.rs --crate-type lib --emit=dep-info,link -C opt-level=3 -C panic=abort -C codegen-units=2 [..]`
-[RUNNING] `rustc --crate-name foo src/lib.rs --emit=dep-info,link -C opt-level=3 -C codegen-units=4 --test [..]`
-[RUNNING] `rustc --crate-name foo src/lib.rs --crate-type lib --emit=dep-info,link -C opt-level=3 -C codegen-units=2 [..]`
-[RUNNING] `rustc --crate-name test1 tests/test1.rs --emit=dep-info,link -C opt-level=3 -C codegen-units=4 --test [..]`
-[RUNNING] `rustc --crate-name bench1 benches/bench1.rs --emit=dep-info,link -C opt-level=3 -C codegen-units=4 --test [..]`
-[RUNNING] `rustc --crate-name foo src/main.rs --emit=dep-info,link -C opt-level=3 -C codegen-units=4 --test [..]`
-[RUNNING] `rustc --crate-name foo src/main.rs --crate-type bin --emit=dep-info,link -C opt-level=3 -C panic=abort -C codegen-units=2 [..]`
-[RUNNING] `rustc --crate-name ex1 examples/ex1.rs --crate-type bin --emit=dep-info,link -C opt-level=3 -C panic=abort -C codegen-units=2 [..]`
+[RUNNING] `rustc --crate-name foo src/lib.rs --color never --crate-type lib --emit=dep-info,link -C opt-level=3 -C panic=abort -C codegen-units=2 [..]`
+[RUNNING] `rustc --crate-name foo src/lib.rs --color never --emit=dep-info,link -C opt-level=3 -C codegen-units=4 --test [..]`
+[RUNNING] `rustc --crate-name foo src/lib.rs --color never --crate-type lib --emit=dep-info,link -C opt-level=3 -C codegen-units=2 [..]`
+[RUNNING] `rustc --crate-name test1 tests/test1.rs --color never --emit=dep-info,link -C opt-level=3 -C codegen-units=4 --test [..]`
+[RUNNING] `rustc --crate-name bench1 benches/bench1.rs --color never --emit=dep-info,link -C opt-level=3 -C codegen-units=4 --test [..]`
+[RUNNING] `rustc --crate-name foo src/main.rs --color never --emit=dep-info,link -C opt-level=3 -C codegen-units=4 --test [..]`
+[RUNNING] `rustc --crate-name foo src/main.rs --color never --crate-type bin --emit=dep-info,link -C opt-level=3 -C panic=abort -C codegen-units=2 [..]`
+[RUNNING] `rustc --crate-name ex1 examples/ex1.rs --color never --crate-type bin --emit=dep-info,link -C opt-level=3 -C panic=abort -C codegen-units=2 [..]`
 [FINISHED] release [optimized] [..]
 ").run();
     p.cargo("build --all-targets --release -vv")
@@ -297,21 +297,21 @@ fn profile_selection_test() {
     //
     p.cargo("test -vv").with_stderr_unordered("\
 [COMPILING] bar [..]
-[RUNNING] `rustc --crate-name bar bar/src/lib.rs --crate-type lib --emit=dep-info,link -C codegen-units=1 -C debuginfo=2 [..]
-[RUNNING] `rustc --crate-name bar bar/src/lib.rs --crate-type lib --emit=dep-info,link -C codegen-units=1 -C debuginfo=2 [..]
+[RUNNING] `rustc --crate-name bar bar/src/lib.rs --color never --crate-type lib --emit=dep-info,link -C codegen-units=1 -C debuginfo=2 [..]
+[RUNNING] `rustc --crate-name bar bar/src/lib.rs --color never --crate-type lib --emit=dep-info,link -C codegen-units=1 -C debuginfo=2 [..]
 [COMPILING] bdep [..]
-[RUNNING] `rustc --crate-name bdep bdep/src/lib.rs --crate-type lib --emit=dep-info,link -C codegen-units=1 -C debuginfo=2 [..]
+[RUNNING] `rustc --crate-name bdep bdep/src/lib.rs --color never --crate-type lib --emit=dep-info,link -C codegen-units=1 -C debuginfo=2 [..]
 [COMPILING] foo [..]
-[RUNNING] `rustc --crate-name build_script_build build.rs --crate-type bin --emit=dep-info,link -C codegen-units=1 -C debuginfo=2 [..]
+[RUNNING] `rustc --crate-name build_script_build build.rs --color never --crate-type bin --emit=dep-info,link -C codegen-units=1 -C debuginfo=2 [..]
 [RUNNING] `[..]/target/debug/build/foo-[..]/build-script-build`
 foo custom build PROFILE=debug DEBUG=true OPT_LEVEL=0
-[RUNNING] `rustc --crate-name foo src/lib.rs --crate-type lib --emit=dep-info,link -C panic=abort -C codegen-units=1 -C debuginfo=2 [..]
-[RUNNING] `rustc --crate-name foo src/lib.rs --crate-type lib --emit=dep-info,link -C codegen-units=1 -C debuginfo=2 [..]
-[RUNNING] `rustc --crate-name foo src/lib.rs --emit=dep-info,link -C codegen-units=3 -C debuginfo=2 --test [..]
-[RUNNING] `rustc --crate-name test1 tests/test1.rs --emit=dep-info,link -C codegen-units=3 -C debuginfo=2 --test [..]
-[RUNNING] `rustc --crate-name ex1 examples/ex1.rs --crate-type bin --emit=dep-info,link -C codegen-units=1 -C debuginfo=2 [..]
-[RUNNING] `rustc --crate-name foo src/main.rs --emit=dep-info,link -C codegen-units=3 -C debuginfo=2 --test [..]
-[RUNNING] `rustc --crate-name foo src/main.rs --crate-type bin --emit=dep-info,link -C panic=abort -C codegen-units=1 -C debuginfo=2 [..]
+[RUNNING] `rustc --crate-name foo src/lib.rs --color never --crate-type lib --emit=dep-info,link -C panic=abort -C codegen-units=1 -C debuginfo=2 [..]
+[RUNNING] `rustc --crate-name foo src/lib.rs --color never --crate-type lib --emit=dep-info,link -C codegen-units=1 -C debuginfo=2 [..]
+[RUNNING] `rustc --crate-name foo src/lib.rs --color never --emit=dep-info,link -C codegen-units=3 -C debuginfo=2 --test [..]
+[RUNNING] `rustc --crate-name test1 tests/test1.rs --color never --emit=dep-info,link -C codegen-units=3 -C debuginfo=2 --test [..]
+[RUNNING] `rustc --crate-name ex1 examples/ex1.rs --color never --crate-type bin --emit=dep-info,link -C codegen-units=1 -C debuginfo=2 [..]
+[RUNNING] `rustc --crate-name foo src/main.rs --color never --emit=dep-info,link -C codegen-units=3 -C debuginfo=2 --test [..]
+[RUNNING] `rustc --crate-name foo src/main.rs --color never --crate-type bin --emit=dep-info,link -C panic=abort -C codegen-units=1 -C debuginfo=2 [..]
 [FINISHED] dev [unoptimized + debuginfo] [..]
 [RUNNING] `[..]/deps/foo-[..]`
 [RUNNING] `[..]/deps/foo-[..]`
@@ -363,21 +363,21 @@ fn profile_selection_test_release() {
     //
     p.cargo("test --release -vv").with_stderr_unordered("\
 [COMPILING] bar [..]
-[RUNNING] `rustc --crate-name bar bar/src/lib.rs --crate-type lib --emit=dep-info,link -C opt-level=3 -C codegen-units=2 [..]
-[RUNNING] `rustc --crate-name bar bar/src/lib.rs --crate-type lib --emit=dep-info,link -C opt-level=3 -C codegen-units=2 [..]
+[RUNNING] `rustc --crate-name bar bar/src/lib.rs --color never --crate-type lib --emit=dep-info,link -C opt-level=3 -C codegen-units=2 [..]
+[RUNNING] `rustc --crate-name bar bar/src/lib.rs --color never --crate-type lib --emit=dep-info,link -C opt-level=3 -C codegen-units=2 [..]
 [COMPILING] bdep [..]
-[RUNNING] `rustc --crate-name bdep bdep/src/lib.rs --crate-type lib --emit=dep-info,link -C opt-level=3 -C codegen-units=2 [..]
+[RUNNING] `rustc --crate-name bdep bdep/src/lib.rs --color never --crate-type lib --emit=dep-info,link -C opt-level=3 -C codegen-units=2 [..]
 [COMPILING] foo [..]
-[RUNNING] `rustc --crate-name build_script_build build.rs --crate-type bin --emit=dep-info,link -C opt-level=3 -C codegen-units=2 [..]
+[RUNNING] `rustc --crate-name build_script_build build.rs --color never --crate-type bin --emit=dep-info,link -C opt-level=3 -C codegen-units=2 [..]
 [RUNNING] `[..]/target/release/build/foo-[..]/build-script-build`
 foo custom build PROFILE=release DEBUG=false OPT_LEVEL=3
-[RUNNING] `rustc --crate-name foo src/lib.rs --crate-type lib --emit=dep-info,link -C opt-level=3 -C panic=abort -C codegen-units=2 [..]
-[RUNNING] `rustc --crate-name foo src/lib.rs --crate-type lib --emit=dep-info,link -C opt-level=3 -C codegen-units=2 [..]
-[RUNNING] `rustc --crate-name foo src/lib.rs --emit=dep-info,link -C opt-level=3 -C codegen-units=4 --test [..]
-[RUNNING] `rustc --crate-name test1 tests/test1.rs --emit=dep-info,link -C opt-level=3 -C codegen-units=4 --test [..]
-[RUNNING] `rustc --crate-name foo src/main.rs --emit=dep-info,link -C opt-level=3 -C codegen-units=4 --test [..]
-[RUNNING] `rustc --crate-name ex1 examples/ex1.rs --crate-type bin --emit=dep-info,link -C opt-level=3 -C codegen-units=2 [..]
-[RUNNING] `rustc --crate-name foo src/main.rs --crate-type bin --emit=dep-info,link -C opt-level=3 -C panic=abort -C codegen-units=2 [..]
+[RUNNING] `rustc --crate-name foo src/lib.rs --color never --crate-type lib --emit=dep-info,link -C opt-level=3 -C panic=abort -C codegen-units=2 [..]
+[RUNNING] `rustc --crate-name foo src/lib.rs --color never --crate-type lib --emit=dep-info,link -C opt-level=3 -C codegen-units=2 [..]
+[RUNNING] `rustc --crate-name foo src/lib.rs --color never --emit=dep-info,link -C opt-level=3 -C codegen-units=4 --test [..]
+[RUNNING] `rustc --crate-name test1 tests/test1.rs --color never --emit=dep-info,link -C opt-level=3 -C codegen-units=4 --test [..]
+[RUNNING] `rustc --crate-name foo src/main.rs --color never --emit=dep-info,link -C opt-level=3 -C codegen-units=4 --test [..]
+[RUNNING] `rustc --crate-name ex1 examples/ex1.rs --color never --crate-type bin --emit=dep-info,link -C opt-level=3 -C codegen-units=2 [..]
+[RUNNING] `rustc --crate-name foo src/main.rs --color never --crate-type bin --emit=dep-info,link -C opt-level=3 -C panic=abort -C codegen-units=2 [..]
 [FINISHED] release [optimized] [..]
 [RUNNING] `[..]/deps/foo-[..]`
 [RUNNING] `[..]/deps/foo-[..]`
@@ -429,20 +429,20 @@ fn profile_selection_bench() {
     //
     p.cargo("bench -vv").with_stderr_unordered("\
 [COMPILING] bar [..]
-[RUNNING] `rustc --crate-name bar bar/src/lib.rs --crate-type lib --emit=dep-info,link -C opt-level=3 -C codegen-units=2 [..]
-[RUNNING] `rustc --crate-name bar bar/src/lib.rs --crate-type lib --emit=dep-info,link -C opt-level=3 -C codegen-units=2 [..]
+[RUNNING] `rustc --crate-name bar bar/src/lib.rs --color never --crate-type lib --emit=dep-info,link -C opt-level=3 -C codegen-units=2 [..]
+[RUNNING] `rustc --crate-name bar bar/src/lib.rs --color never --crate-type lib --emit=dep-info,link -C opt-level=3 -C codegen-units=2 [..]
 [COMPILING] bdep [..]
-[RUNNING] `rustc --crate-name bdep bdep/src/lib.rs --crate-type lib --emit=dep-info,link -C opt-level=3 -C codegen-units=2 [..]
+[RUNNING] `rustc --crate-name bdep bdep/src/lib.rs --color never --crate-type lib --emit=dep-info,link -C opt-level=3 -C codegen-units=2 [..]
 [COMPILING] foo [..]
-[RUNNING] `rustc --crate-name build_script_build build.rs --crate-type bin --emit=dep-info,link -C opt-level=3 -C codegen-units=2 [..]
+[RUNNING] `rustc --crate-name build_script_build build.rs --color never --crate-type bin --emit=dep-info,link -C opt-level=3 -C codegen-units=2 [..]
 [RUNNING] `[..]target/release/build/foo-[..]/build-script-build`
 foo custom build PROFILE=release DEBUG=false OPT_LEVEL=3
-[RUNNING] `rustc --crate-name foo src/lib.rs --crate-type lib --emit=dep-info,link -C opt-level=3 -C panic=abort -C codegen-units=2 [..]
-[RUNNING] `rustc --crate-name foo src/lib.rs --crate-type lib --emit=dep-info,link -C opt-level=3 -C codegen-units=2 [..]
-[RUNNING] `rustc --crate-name foo src/lib.rs --emit=dep-info,link -C opt-level=3 -C codegen-units=4 --test [..]
-[RUNNING] `rustc --crate-name bench1 benches/bench1.rs --emit=dep-info,link -C opt-level=3 -C codegen-units=4 --test [..]
-[RUNNING] `rustc --crate-name foo src/main.rs --emit=dep-info,link -C opt-level=3 -C codegen-units=4 --test [..]
-[RUNNING] `rustc --crate-name foo src/main.rs --crate-type bin --emit=dep-info,link -C opt-level=3 -C panic=abort -C codegen-units=2 [..]
+[RUNNING] `rustc --crate-name foo src/lib.rs --color never --crate-type lib --emit=dep-info,link -C opt-level=3 -C panic=abort -C codegen-units=2 [..]
+[RUNNING] `rustc --crate-name foo src/lib.rs --color never --crate-type lib --emit=dep-info,link -C opt-level=3 -C codegen-units=2 [..]
+[RUNNING] `rustc --crate-name foo src/lib.rs --color never --emit=dep-info,link -C opt-level=3 -C codegen-units=4 --test [..]
+[RUNNING] `rustc --crate-name bench1 benches/bench1.rs --color never --emit=dep-info,link -C opt-level=3 -C codegen-units=4 --test [..]
+[RUNNING] `rustc --crate-name foo src/main.rs --color never --emit=dep-info,link -C opt-level=3 -C codegen-units=4 --test [..]
+[RUNNING] `rustc --crate-name foo src/main.rs --color never --crate-type bin --emit=dep-info,link -C opt-level=3 -C panic=abort -C codegen-units=2 [..]
 [FINISHED] release [optimized] [..]
 [RUNNING] `[..]/deps/foo-[..] --bench`
 [RUNNING] `[..]/deps/foo-[..] --bench`
@@ -497,23 +497,23 @@ fn profile_selection_check_all_targets() {
     //
     p.cargo("check --all-targets -vv").with_stderr_unordered("\
 [COMPILING] bar [..]
-[RUNNING] `rustc --crate-name bar bar/src/lib.rs --crate-type lib --emit=dep-info,link -C codegen-units=1 -C debuginfo=2 [..]
-[RUNNING] `rustc --crate-name bar bar/src/lib.rs --crate-type lib --emit=dep-info,metadata -C codegen-units=1 -C debuginfo=2 [..]
-[RUNNING] `rustc --crate-name bar bar/src/lib.rs --crate-type lib --emit=dep-info,metadata -C panic=abort -C codegen-units=1 -C debuginfo=2 [..]
+[RUNNING] `rustc --crate-name bar bar/src/lib.rs --color never --crate-type lib --emit=dep-info,link -C codegen-units=1 -C debuginfo=2 [..]
+[RUNNING] `rustc --crate-name bar bar/src/lib.rs --color never --crate-type lib --emit=dep-info,metadata -C codegen-units=1 -C debuginfo=2 [..]
+[RUNNING] `rustc --crate-name bar bar/src/lib.rs --color never --crate-type lib --emit=dep-info,metadata -C panic=abort -C codegen-units=1 -C debuginfo=2 [..]
 [COMPILING] bdep[..]
-[RUNNING] `rustc --crate-name bdep bdep/src/lib.rs --crate-type lib --emit=dep-info,link -C codegen-units=1 -C debuginfo=2 [..]
+[RUNNING] `rustc --crate-name bdep bdep/src/lib.rs --color never --crate-type lib --emit=dep-info,link -C codegen-units=1 -C debuginfo=2 [..]
 [COMPILING] foo [..]
-[RUNNING] `rustc --crate-name build_script_build build.rs --crate-type bin --emit=dep-info,link -C codegen-units=1 -C debuginfo=2 [..]
+[RUNNING] `rustc --crate-name build_script_build build.rs --color never --crate-type bin --emit=dep-info,link -C codegen-units=1 -C debuginfo=2 [..]
 [RUNNING] `[..]target/debug/build/foo-[..]/build-script-build`
 foo custom build PROFILE=debug DEBUG=true OPT_LEVEL=0
-[RUNNING] `rustc --crate-name foo src/lib.rs --crate-type lib --emit=dep-info,metadata -C panic=abort -C codegen-units=1 -C debuginfo=2 [..]
-[RUNNING] `rustc --crate-name foo src/lib.rs --crate-type lib --emit=dep-info,metadata -C codegen-units=1 -C debuginfo=2 [..]
-[RUNNING] `rustc --crate-name foo src/lib.rs --emit=dep-info,metadata -C codegen-units=1 -C debuginfo=2 --test [..]
-[RUNNING] `rustc --crate-name test1 tests/test1.rs --emit=dep-info,metadata -C codegen-units=1 -C debuginfo=2 --test [..]
-[RUNNING] `rustc --crate-name foo src/main.rs --emit=dep-info,metadata -C codegen-units=1 -C debuginfo=2 --test [..]
-[RUNNING] `rustc --crate-name bench1 benches/bench1.rs --emit=dep-info,metadata -C codegen-units=1 -C debuginfo=2 --test [..]
-[RUNNING] `rustc --crate-name ex1 examples/ex1.rs --crate-type bin --emit=dep-info,metadata -C panic=abort -C codegen-units=1 -C debuginfo=2 [..]
-[RUNNING] `rustc --crate-name foo src/main.rs --crate-type bin --emit=dep-info,metadata -C panic=abort -C codegen-units=1 -C debuginfo=2 [..]
+[RUNNING] `rustc --crate-name foo src/lib.rs --color never --crate-type lib --emit=dep-info,metadata -C panic=abort -C codegen-units=1 -C debuginfo=2 [..]
+[RUNNING] `rustc --crate-name foo src/lib.rs --color never --crate-type lib --emit=dep-info,metadata -C codegen-units=1 -C debuginfo=2 [..]
+[RUNNING] `rustc --crate-name foo src/lib.rs --color never --emit=dep-info,metadata -C codegen-units=1 -C debuginfo=2 --test [..]
+[RUNNING] `rustc --crate-name test1 tests/test1.rs --color never --emit=dep-info,metadata -C codegen-units=1 -C debuginfo=2 --test [..]
+[RUNNING] `rustc --crate-name foo src/main.rs --color never --emit=dep-info,metadata -C codegen-units=1 -C debuginfo=2 --test [..]
+[RUNNING] `rustc --crate-name bench1 benches/bench1.rs --color never --emit=dep-info,metadata -C codegen-units=1 -C debuginfo=2 --test [..]
+[RUNNING] `rustc --crate-name ex1 examples/ex1.rs --color never --crate-type bin --emit=dep-info,metadata -C panic=abort -C codegen-units=1 -C debuginfo=2 [..]
+[RUNNING] `rustc --crate-name foo src/main.rs --color never --crate-type bin --emit=dep-info,metadata -C panic=abort -C codegen-units=1 -C debuginfo=2 [..]
 [FINISHED] dev [unoptimized + debuginfo] [..]
 ").run();
     // Starting with Rust 1.27, rustc emits `rmeta` files for bins, so
@@ -547,23 +547,23 @@ fn profile_selection_check_all_targets_release() {
     // `dev` for all targets.
     p.cargo("check --all-targets --release -vv").with_stderr_unordered("\
 [COMPILING] bar [..]
-[RUNNING] `rustc --crate-name bar bar/src/lib.rs --crate-type lib --emit=dep-info,link -C opt-level=3 -C codegen-units=2 [..]
-[RUNNING] `rustc --crate-name bar bar/src/lib.rs --crate-type lib --emit=dep-info,metadata -C opt-level=3 -C codegen-units=2 [..]
-[RUNNING] `rustc --crate-name bar bar/src/lib.rs --crate-type lib --emit=dep-info,metadata -C opt-level=3 -C panic=abort -C codegen-units=2 [..]
+[RUNNING] `rustc --crate-name bar bar/src/lib.rs --color never --crate-type lib --emit=dep-info,link -C opt-level=3 -C codegen-units=2 [..]
+[RUNNING] `rustc --crate-name bar bar/src/lib.rs --color never --crate-type lib --emit=dep-info,metadata -C opt-level=3 -C codegen-units=2 [..]
+[RUNNING] `rustc --crate-name bar bar/src/lib.rs --color never --crate-type lib --emit=dep-info,metadata -C opt-level=3 -C panic=abort -C codegen-units=2 [..]
 [COMPILING] bdep[..]
-[RUNNING] `rustc --crate-name bdep bdep/src/lib.rs --crate-type lib --emit=dep-info,link -C opt-level=3 -C codegen-units=2 [..]
+[RUNNING] `rustc --crate-name bdep bdep/src/lib.rs --color never --crate-type lib --emit=dep-info,link -C opt-level=3 -C codegen-units=2 [..]
 [COMPILING] foo [..]
-[RUNNING] `rustc --crate-name build_script_build build.rs --crate-type bin --emit=dep-info,link -C opt-level=3 -C codegen-units=2 [..]
+[RUNNING] `rustc --crate-name build_script_build build.rs --color never --crate-type bin --emit=dep-info,link -C opt-level=3 -C codegen-units=2 [..]
 [RUNNING] `[..]target/release/build/foo-[..]/build-script-build`
 foo custom build PROFILE=release DEBUG=false OPT_LEVEL=3
-[RUNNING] `rustc --crate-name foo src/lib.rs --crate-type lib --emit=dep-info,metadata -C opt-level=3 -C panic=abort -C codegen-units=2 [..]
-[RUNNING] `rustc --crate-name foo src/lib.rs --crate-type lib --emit=dep-info,metadata -C opt-level=3 -C codegen-units=2 [..]
-[RUNNING] `rustc --crate-name foo src/lib.rs --emit=dep-info,metadata -C opt-level=3 -C codegen-units=2 --test [..]
-[RUNNING] `rustc --crate-name test1 tests/test1.rs --emit=dep-info,metadata -C opt-level=3 -C codegen-units=2 --test [..]
-[RUNNING] `rustc --crate-name foo src/main.rs --emit=dep-info,metadata -C opt-level=3 -C codegen-units=2 --test [..]
-[RUNNING] `rustc --crate-name bench1 benches/bench1.rs --emit=dep-info,metadata -C opt-level=3 -C codegen-units=2 --test [..]
-[RUNNING] `rustc --crate-name ex1 examples/ex1.rs --crate-type bin --emit=dep-info,metadata -C opt-level=3 -C panic=abort -C codegen-units=2 [..]
-[RUNNING] `rustc --crate-name foo src/main.rs --crate-type bin --emit=dep-info,metadata -C opt-level=3 -C panic=abort -C codegen-units=2 [..]
+[RUNNING] `rustc --crate-name foo src/lib.rs --color never --crate-type lib --emit=dep-info,metadata -C opt-level=3 -C panic=abort -C codegen-units=2 [..]
+[RUNNING] `rustc --crate-name foo src/lib.rs --color never --crate-type lib --emit=dep-info,metadata -C opt-level=3 -C codegen-units=2 [..]
+[RUNNING] `rustc --crate-name foo src/lib.rs --color never --emit=dep-info,metadata -C opt-level=3 -C codegen-units=2 --test [..]
+[RUNNING] `rustc --crate-name test1 tests/test1.rs --color never --emit=dep-info,metadata -C opt-level=3 -C codegen-units=2 --test [..]
+[RUNNING] `rustc --crate-name foo src/main.rs --color never --emit=dep-info,metadata -C opt-level=3 -C codegen-units=2 --test [..]
+[RUNNING] `rustc --crate-name bench1 benches/bench1.rs --color never --emit=dep-info,metadata -C opt-level=3 -C codegen-units=2 --test [..]
+[RUNNING] `rustc --crate-name ex1 examples/ex1.rs --color never --crate-type bin --emit=dep-info,metadata -C opt-level=3 -C panic=abort -C codegen-units=2 [..]
+[RUNNING] `rustc --crate-name foo src/main.rs --color never --crate-type bin --emit=dep-info,metadata -C opt-level=3 -C panic=abort -C codegen-units=2 [..]
 [FINISHED] release [optimized] [..]
 ").run();
 
@@ -612,20 +612,20 @@ fn profile_selection_check_all_targets_test() {
     //
     p.cargo("check --all-targets --profile=test -vv").with_stderr_unordered("\
 [COMPILING] bar [..]
-[RUNNING] `rustc --crate-name bar bar/src/lib.rs --crate-type lib --emit=dep-info,link -C codegen-units=1 -C debuginfo=2 [..]
-[RUNNING] `rustc --crate-name bar bar/src/lib.rs --crate-type lib --emit=dep-info,metadata -C codegen-units=1 -C debuginfo=2 [..]
+[RUNNING] `rustc --crate-name bar bar/src/lib.rs --color never --crate-type lib --emit=dep-info,link -C codegen-units=1 -C debuginfo=2 [..]
+[RUNNING] `rustc --crate-name bar bar/src/lib.rs --color never --crate-type lib --emit=dep-info,metadata -C codegen-units=1 -C debuginfo=2 [..]
 [COMPILING] bdep[..]
-[RUNNING] `rustc --crate-name bdep bdep/src/lib.rs --crate-type lib --emit=dep-info,link -C codegen-units=1 -C debuginfo=2 [..]
+[RUNNING] `rustc --crate-name bdep bdep/src/lib.rs --color never --crate-type lib --emit=dep-info,link -C codegen-units=1 -C debuginfo=2 [..]
 [COMPILING] foo [..]
-[RUNNING] `rustc --crate-name build_script_build build.rs --crate-type bin --emit=dep-info,link -C codegen-units=1 -C debuginfo=2 [..]
+[RUNNING] `rustc --crate-name build_script_build build.rs --color never --crate-type bin --emit=dep-info,link -C codegen-units=1 -C debuginfo=2 [..]
 [RUNNING] `[..]target/debug/build/foo-[..]/build-script-build`
 foo custom build PROFILE=debug DEBUG=true OPT_LEVEL=0
-[RUNNING] `rustc --crate-name foo src/lib.rs --crate-type lib --emit=dep-info,metadata -C codegen-units=1 -C debuginfo=2 [..]
-[RUNNING] `rustc --crate-name foo src/lib.rs --emit=dep-info,metadata -C codegen-units=1 -C debuginfo=2 --test [..]
-[RUNNING] `rustc --crate-name test1 tests/test1.rs --emit=dep-info,metadata -C codegen-units=1 -C debuginfo=2 --test [..]
-[RUNNING] `rustc --crate-name foo src/main.rs --emit=dep-info,metadata -C codegen-units=1 -C debuginfo=2 --test [..]
-[RUNNING] `rustc --crate-name bench1 benches/bench1.rs --emit=dep-info,metadata -C codegen-units=1 -C debuginfo=2 --test [..]
-[RUNNING] `rustc --crate-name ex1 examples/ex1.rs --emit=dep-info,metadata -C codegen-units=1 -C debuginfo=2 --test [..]
+[RUNNING] `rustc --crate-name foo src/lib.rs --color never --crate-type lib --emit=dep-info,metadata -C codegen-units=1 -C debuginfo=2 [..]
+[RUNNING] `rustc --crate-name foo src/lib.rs --color never --emit=dep-info,metadata -C codegen-units=1 -C debuginfo=2 --test [..]
+[RUNNING] `rustc --crate-name test1 tests/test1.rs --color never --emit=dep-info,metadata -C codegen-units=1 -C debuginfo=2 --test [..]
+[RUNNING] `rustc --crate-name foo src/main.rs --color never --emit=dep-info,metadata -C codegen-units=1 -C debuginfo=2 --test [..]
+[RUNNING] `rustc --crate-name bench1 benches/bench1.rs --color never --emit=dep-info,metadata -C codegen-units=1 -C debuginfo=2 --test [..]
+[RUNNING] `rustc --crate-name ex1 examples/ex1.rs --color never --emit=dep-info,metadata -C codegen-units=1 -C debuginfo=2 --test [..]
 [FINISHED] dev [unoptimized + debuginfo] [..]
 ").run();
 
@@ -657,13 +657,13 @@ fn profile_selection_doc() {
     p.cargo("doc -vv").with_stderr_unordered("\
 [COMPILING] bar [..]
 [DOCUMENTING] bar [..]
-[RUNNING] `rustc --crate-name bar bar/src/lib.rs --crate-type lib --emit=dep-info,link -C codegen-units=1 -C debuginfo=2 [..]
+[RUNNING] `rustc --crate-name bar bar/src/lib.rs --color never --crate-type lib --emit=dep-info,link -C codegen-units=1 -C debuginfo=2 [..]
 [RUNNING] `rustdoc --crate-name bar bar/src/lib.rs [..]
-[RUNNING] `rustc --crate-name bar bar/src/lib.rs --crate-type lib --emit=dep-info,metadata -C panic=abort -C codegen-units=1 -C debuginfo=2 [..]
+[RUNNING] `rustc --crate-name bar bar/src/lib.rs --color never --crate-type lib --emit=dep-info,metadata -C panic=abort -C codegen-units=1 -C debuginfo=2 [..]
 [COMPILING] bdep [..]
-[RUNNING] `rustc --crate-name bdep bdep/src/lib.rs --crate-type lib --emit=dep-info,link -C codegen-units=1 -C debuginfo=2 [..]
+[RUNNING] `rustc --crate-name bdep bdep/src/lib.rs --color never --crate-type lib --emit=dep-info,link -C codegen-units=1 -C debuginfo=2 [..]
 [COMPILING] foo [..]
-[RUNNING] `rustc --crate-name build_script_build build.rs --crate-type bin --emit=dep-info,link -C codegen-units=1 -C debuginfo=2 [..]
+[RUNNING] `rustc --crate-name build_script_build build.rs --color never --crate-type bin --emit=dep-info,link -C codegen-units=1 -C debuginfo=2 [..]
 [RUNNING] `[..]target/debug/build/foo-[..]/build-script-build`
 foo custom build PROFILE=debug DEBUG=true OPT_LEVEL=0
 [DOCUMENTING] foo [..]

--- a/tests/testsuite/profiles.rs
+++ b/tests/testsuite/profiles.rs
@@ -25,15 +25,15 @@ fn profile_overrides() {
     p.cargo("build -v")
         .with_stderr(
             "\
-[COMPILING] test v0.0.0 (CWD)
-[RUNNING] `rustc --crate-name test src/lib.rs --crate-type lib \
+[COMPILING] test v0.0.0 ([CWD])
+[RUNNING] `rustc --crate-name test src/lib.rs --color never --crate-type lib \
         --emit=dep-info,link \
         -C opt-level=1 \
         -C debug-assertions=on \
         -C metadata=[..] \
         -C rpath \
         --out-dir [..] \
-        -L dependency=CWD/target/debug/deps`
+        -L dependency=[CWD]/target/debug/deps`
 [FINISHED] dev [optimized] target(s) in [..]
 ",
         ).run();
@@ -59,13 +59,13 @@ fn opt_level_override_0() {
     p.cargo("build -v")
         .with_stderr(
             "\
-[COMPILING] test v0.0.0 (CWD)
-[RUNNING] `rustc --crate-name test src/lib.rs --crate-type lib \
+[COMPILING] test v0.0.0 ([CWD])
+[RUNNING] `rustc --crate-name test src/lib.rs --color never --crate-type lib \
         --emit=dep-info,link \
         -C debuginfo=2 \
         -C metadata=[..] \
         --out-dir [..] \
-        -L dependency=CWD/target/debug/deps`
+        -L dependency=[CWD]/target/debug/deps`
 [FINISHED] [..] target(s) in [..]
 ",
         ).run();
@@ -90,13 +90,13 @@ fn debug_override_1() {
     p.cargo("build -v")
         .with_stderr(
             "\
-[COMPILING] test v0.0.0 (CWD)
-[RUNNING] `rustc --crate-name test src/lib.rs --crate-type lib \
+[COMPILING] test v0.0.0 ([CWD])
+[RUNNING] `rustc --crate-name test src/lib.rs --color never --crate-type lib \
         --emit=dep-info,link \
         -C debuginfo=1 \
         -C metadata=[..] \
         --out-dir [..] \
-        -L dependency=CWD/target/debug/deps`
+        -L dependency=[CWD]/target/debug/deps`
 [FINISHED] [..] target(s) in [..]
 ",
         ).run();
@@ -124,15 +124,15 @@ fn check_opt_level_override(profile_level: &str, rustc_level: &str) {
     p.cargo("build -v")
         .with_stderr(&format!(
             "\
-[COMPILING] test v0.0.0 (CWD)
-[RUNNING] `rustc --crate-name test src/lib.rs --crate-type lib \
+[COMPILING] test v0.0.0 ([CWD])
+[RUNNING] `rustc --crate-name test src/lib.rs --color never --crate-type lib \
         --emit=dep-info,link \
         -C opt-level={level} \
         -C debuginfo=2 \
         -C debug-assertions=on \
         -C metadata=[..] \
         --out-dir [..] \
-        -L dependency=CWD/target/debug/deps`
+        -L dependency=[CWD]/target/debug/deps`
 [FINISHED] [..] target(s) in [..]
 ",
             level = rustc_level
@@ -198,27 +198,27 @@ fn top_level_overrides_deps() {
     p.cargo("build -v --release")
         .with_stderr(&format!(
             "\
-[COMPILING] foo v0.0.0 (CWD/foo)
-[RUNNING] `rustc --crate-name foo foo/src/lib.rs \
+[COMPILING] foo v0.0.0 ([CWD]/foo)
+[RUNNING] `rustc --crate-name foo foo/src/lib.rs --color never \
         --crate-type dylib --crate-type rlib \
         --emit=dep-info,link \
         -C prefer-dynamic \
         -C opt-level=1 \
         -C debuginfo=2 \
         -C metadata=[..] \
-        --out-dir CWD/target/release/deps \
-        -L dependency=CWD/target/release/deps`
-[COMPILING] test v0.0.0 (CWD)
-[RUNNING] `rustc --crate-name test src/lib.rs --crate-type lib \
+        --out-dir [CWD]/target/release/deps \
+        -L dependency=[CWD]/target/release/deps`
+[COMPILING] test v0.0.0 ([CWD])
+[RUNNING] `rustc --crate-name test src/lib.rs --color never --crate-type lib \
         --emit=dep-info,link \
         -C opt-level=1 \
         -C debuginfo=2 \
         -C metadata=[..] \
         --out-dir [..] \
-        -L dependency=CWD/target/release/deps \
-        --extern foo=CWD/target/release/deps/\
+        -L dependency=[CWD]/target/release/deps \
+        --extern foo=[CWD]/target/release/deps/\
                      {prefix}foo[..]{suffix} \
-        --extern foo=CWD/target/release/deps/libfoo.rlib`
+        --extern foo=[CWD]/target/release/deps/libfoo.rlib`
 [FINISHED] release [optimized + debuginfo] target(s) in [..]
 ",
             prefix = env::consts::DLL_PREFIX,

--- a/tests/testsuite/publish.rs
+++ b/tests/testsuite/publish.rs
@@ -33,10 +33,10 @@ fn simple() {
 [UPDATING] `{reg}` index
 [WARNING] manifest has no documentation, [..]
 See [..]
-[PACKAGING] foo v0.0.1 (CWD)
-[UPLOADING] foo v0.0.1 (CWD)
+[PACKAGING] foo v0.0.1 ([CWD])
+[UPLOADING] foo v0.0.1 ([CWD])
 ",
-            reg = publish::registry()
+            reg = publish::registry_path().to_str().unwrap()
         )).run();
 
     let mut f = File::open(&publish::upload_path().join("api/v1/crates/new")).unwrap();
@@ -106,10 +106,10 @@ fn old_token_location() {
 [UPDATING] `{reg}` index
 [WARNING] manifest has no documentation, [..]
 See [..]
-[PACKAGING] foo v0.0.1 (CWD)
-[UPLOADING] foo v0.0.1 (CWD)
+[PACKAGING] foo v0.0.1 ([CWD])
+[UPLOADING] foo v0.0.1 ([CWD])
 ",
-            reg = publish::registry()
+            reg = publish::registry_path().to_str().unwrap()
         )).run();
 
     let mut f = File::open(&publish::upload_path().join("api/v1/crates/new")).unwrap();
@@ -181,10 +181,10 @@ about this warning.
 [UPDATING] `{reg}` index
 [WARNING] manifest has no documentation, [..]
 See [..]
-[PACKAGING] foo v0.0.1 (CWD)
-[UPLOADING] foo v0.0.1 (CWD)
+[PACKAGING] foo v0.0.1 ([CWD])
+[UPLOADING] foo v0.0.1 ([CWD])
 ",
-            reg = publish::registry()
+            reg = publish::registry_path().to_str().unwrap()
         )).run();
 
     let mut f = File::open(&publish::upload_path().join("api/v1/crates/new")).unwrap();
@@ -258,10 +258,10 @@ about this warning.
 [UPDATING] `{reg}` index
 [WARNING] manifest has no documentation, [..]
 See [..]
-[PACKAGING] foo v0.0.1 (CWD)
-[UPLOADING] foo v0.0.1 (CWD)
+[PACKAGING] foo v0.0.1 ([CWD])
+[UPLOADING] foo v0.0.1 ([CWD])
 ",
-            reg = publish::registry()
+            reg = publish::registry_path().to_str().unwrap()
         )).run();
 
     let mut f = File::open(&publish::upload_path().join("api/v1/crates/new")).unwrap();
@@ -604,11 +604,11 @@ fn dry_run() {
 [UPDATING] `[..]` index
 [WARNING] manifest has no documentation, [..]
 See [..]
-[PACKAGING] foo v0.0.1 (CWD)
-[VERIFYING] foo v0.0.1 (CWD)
+[PACKAGING] foo v0.0.1 ([CWD])
+[VERIFYING] foo v0.0.1 ([CWD])
 [COMPILING] foo v0.0.1 [..]
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
-[UPLOADING] foo v0.0.1 (CWD)
+[UPLOADING] foo v0.0.1 ([CWD])
 [WARNING] aborting upload due to dry run
 ",
         ).run();

--- a/tests/testsuite/registry.rs
+++ b/tests/testsuite/registry.rs
@@ -40,12 +40,12 @@ fn simple() {
         .with_stderr(&format!(
             "\
 [UPDATING] `{reg}` index
-[DOWNLOADING] bar v0.0.1 (registry `file://[..]`)
+[DOWNLOADING] bar v0.0.1 (registry `[ROOT][..]`)
 [COMPILING] bar v0.0.1
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
 ",
-            reg = registry::registry()
+            reg = registry::registry_path().to_str().unwrap()
         )).run();
 
     p.cargo("clean").run();
@@ -55,7 +55,7 @@ fn simple() {
         .with_stderr(
             "\
 [COMPILING] bar v0.0.1
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
 ",
         ).run();
@@ -85,14 +85,14 @@ fn deps() {
         .with_stderr(&format!(
             "\
 [UPDATING] `{reg}` index
-[DOWNLOADING] [..] v0.0.1 (registry `file://[..]`)
-[DOWNLOADING] [..] v0.0.1 (registry `file://[..]`)
+[DOWNLOADING] [..] v0.0.1 (registry `[ROOT][..]`)
+[DOWNLOADING] [..] v0.0.1 (registry `[ROOT][..]`)
 [COMPILING] baz v0.0.1
 [COMPILING] bar v0.0.1
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
 ",
-            reg = registry::registry()
+            reg = registry::registry_path().to_str().unwrap()
         )).run();
 }
 
@@ -272,7 +272,7 @@ Caused by:
   failed to download replaced source registry `https://[..]`
 
 Caused by:
-  failed to verify the checksum of `bad-cksum v0.0.1 (registry `file://[..]`)`
+  failed to verify the checksum of `bad-cksum v0.0.1 (registry `[ROOT][..]`)`
 ",
         ).run();
 }
@@ -312,12 +312,12 @@ required by package `foo v0.0.1 ([..])`
         .with_stderr(format!(
             "\
 [UPDATING] `{reg}` index
-[DOWNLOADING] notyet v0.0.1 (registry `file://[..]`)
+[DOWNLOADING] notyet v0.0.1 (registry `[ROOT][..]`)
 [COMPILING] notyet v0.0.1
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
 ",
-            reg = registry::registry()
+            reg = registry::registry_path().to_str().unwrap()
         )).run();
 }
 
@@ -364,12 +364,12 @@ required by package `foo v0.0.1 ([..])`
     p.cargo("package")
         .with_stderr(
             "\
-[PACKAGING] foo v0.0.1 (CWD)
-[VERIFYING] foo v0.0.1 (CWD)
+[PACKAGING] foo v0.0.1 ([CWD])
+[VERIFYING] foo v0.0.1 ([CWD])
 [UPDATING] `[..]` index
-[DOWNLOADING] notyet v0.0.1 (registry `file://[..]`)
+[DOWNLOADING] notyet v0.0.1 (registry `[ROOT][..]`)
 [COMPILING] notyet v0.0.1
-[COMPILING] foo v0.0.1 (CWD[..])
+[COMPILING] foo v0.0.1 ([CWD][..])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
 ",
         ).run();
@@ -398,9 +398,9 @@ fn lockfile_locks() {
         .with_stderr(
             "\
 [UPDATING] `[..]` index
-[DOWNLOADING] bar v0.0.1 (registry `file://[..]`)
+[DOWNLOADING] bar v0.0.1 (registry `[ROOT][..]`)
 [COMPILING] bar v0.0.1
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
 ",
         ).run();
@@ -435,11 +435,11 @@ fn lockfile_locks_transitively() {
         .with_stderr(
             "\
 [UPDATING] `[..]` index
-[DOWNLOADING] [..] v0.0.1 (registry `file://[..]`)
-[DOWNLOADING] [..] v0.0.1 (registry `file://[..]`)
+[DOWNLOADING] [..] v0.0.1 (registry `[ROOT][..]`)
+[DOWNLOADING] [..] v0.0.1 (registry `[ROOT][..]`)
 [COMPILING] baz v0.0.1
 [COMPILING] bar v0.0.1
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
 ",
         ).run();
@@ -480,11 +480,11 @@ fn yanks_are_not_used() {
         .with_stderr(
             "\
 [UPDATING] `[..]` index
-[DOWNLOADING] [..] v0.0.1 (registry `file://[..]`)
-[DOWNLOADING] [..] v0.0.1 (registry `file://[..]`)
+[DOWNLOADING] [..] v0.0.1 (registry `[ROOT][..]`)
+[DOWNLOADING] [..] v0.0.1 (registry `[ROOT][..]`)
 [COMPILING] baz v0.0.1
 [COMPILING] bar v0.0.1
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
 ",
         ).run();
@@ -587,7 +587,7 @@ fn update_with_lockfile_if_packages_missing() {
         .with_stderr(
             "\
 [UPDATING] `[..]` index
-[DOWNLOADING] bar v0.0.1 (registry `file://[..]`)
+[DOWNLOADING] bar v0.0.1 (registry `[ROOT][..]`)
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
 ",
         ).run();
@@ -630,9 +630,9 @@ fn update_lockfile() {
     p.cargo("build")
         .with_stderr(
             "\
-[DOWNLOADING] [..] v0.0.2 (registry `file://[..]`)
+[DOWNLOADING] [..] v0.0.2 (registry `[ROOT][..]`)
 [COMPILING] bar v0.0.2
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
 ",
         ).run();
@@ -650,9 +650,9 @@ fn update_lockfile() {
     p.cargo("build")
         .with_stderr(
             "\
-[DOWNLOADING] [..] v0.0.3 (registry `file://[..]`)
+[DOWNLOADING] [..] v0.0.3 (registry `[ROOT][..]`)
 [COMPILING] bar v0.0.3
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
 ",
         ).run();
@@ -728,9 +728,9 @@ fn dev_dependency_not_used() {
         .with_stderr(
             "\
 [UPDATING] `[..]` index
-[DOWNLOADING] [..] v0.0.1 (registry `file://[..]`)
+[DOWNLOADING] [..] v0.0.1 (registry `[ROOT][..]`)
 [COMPILING] bar v0.0.1
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
 ",
         ).run();
@@ -812,10 +812,10 @@ fn updating_a_dep() {
         .with_stderr(
             "\
 [UPDATING] `[..]` index
-[DOWNLOADING] bar v0.0.1 (registry `file://[..]`)
+[DOWNLOADING] bar v0.0.1 (registry `[ROOT][..]`)
 [COMPILING] bar v0.0.1
-[COMPILING] a v0.0.1 (CWD/a)
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] a v0.0.1 ([CWD]/a)
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
 ",
         ).run();
@@ -838,10 +838,10 @@ fn updating_a_dep() {
         .with_stderr(
             "\
 [UPDATING] `[..]` index
-[DOWNLOADING] bar v0.1.0 (registry `file://[..]`)
+[DOWNLOADING] bar v0.1.0 (registry `[ROOT][..]`)
 [COMPILING] bar v0.1.0
-[COMPILING] a v0.0.1 (CWD/a)
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] a v0.0.1 ([CWD]/a)
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
 ",
         ).run();
@@ -892,10 +892,10 @@ fn git_and_registry_dep() {
             "\
 [UPDATING] [..]
 [UPDATING] [..]
-[DOWNLOADING] a v0.0.1 (registry `file://[..]`)
+[DOWNLOADING] a v0.0.1 (registry `[ROOT][..]`)
 [COMPILING] a v0.0.1
 [COMPILING] b v0.0.1 ([..])
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
 ",
         ).run();
@@ -965,9 +965,9 @@ fn update_publish_then_update() {
         .with_stderr(
             "\
 [UPDATING] [..]
-[DOWNLOADING] a v0.1.1 (registry `file://[..]`)
+[DOWNLOADING] a v0.1.1 (registry `[ROOT][..]`)
 [COMPILING] a v0.1.1
-[COMPILING] foo v0.5.0 (CWD)
+[COMPILING] foo v0.5.0 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
 ",
         ).run();
@@ -1036,7 +1036,7 @@ fn update_transitive_dependency() {
     p.cargo("build")
         .with_stderr(
             "\
-[DOWNLOADING] b v0.1.1 (registry `file://[..]`)
+[DOWNLOADING] b v0.1.1 (registry `[ROOT][..]`)
 [COMPILING] b v0.1.1
 [COMPILING] a v0.1.0
 [COMPILING] foo v0.5.0 ([..])
@@ -1139,9 +1139,9 @@ fn update_multiple_packages() {
         ).run();
 
     p.cargo("build")
-        .with_stderr_contains("[DOWNLOADING] a v0.1.1 (registry `file://[..]`)")
-        .with_stderr_contains("[DOWNLOADING] b v0.1.1 (registry `file://[..]`)")
-        .with_stderr_contains("[DOWNLOADING] c v0.1.1 (registry `file://[..]`)")
+        .with_stderr_contains("[DOWNLOADING] a v0.1.1 (registry `[ROOT][..]`)")
+        .with_stderr_contains("[DOWNLOADING] b v0.1.1 (registry `[ROOT][..]`)")
+        .with_stderr_contains("[DOWNLOADING] c v0.1.1 (registry `[ROOT][..]`)")
         .with_stderr_contains("[COMPILING] a v0.1.1")
         .with_stderr_contains("[COMPILING] b v0.1.1")
         .with_stderr_contains("[COMPILING] c v0.1.1")

--- a/tests/testsuite/rename_deps.rs
+++ b/tests/testsuite/rename_deps.rs
@@ -331,10 +331,10 @@ fn can_run_doc_tests() {
         .with_stderr_contains(
             "\
 [DOCTEST] foo
-[RUNNING] `rustdoc --test CWD/src/lib.rs \
+[RUNNING] `rustdoc --test [CWD]/src/lib.rs \
         [..] \
-        --extern baz=CWD/target/debug/deps/libbar-[..].rlib \
-        --extern bar=CWD/target/debug/deps/libbar-[..].rlib \
+        --extern baz=[CWD]/target/debug/deps/libbar-[..].rlib \
+        --extern bar=[CWD]/target/debug/deps/libbar-[..].rlib \
         [..]`
 ",
         ).run();

--- a/tests/testsuite/required_features.rs
+++ b/tests/testsuite/required_features.rs
@@ -274,7 +274,7 @@ fn test_default_features() {
     p.cargo("test")
         .with_stderr(
             "\
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target/debug/deps/foo-[..][EXE]",
         ).with_stdout_contains("test test ... ok")
@@ -327,7 +327,7 @@ fn test_arg_features() {
     p.cargo("test --features a")
         .with_stderr(
             "\
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target/debug/deps/foo-[..][EXE]",
         ).with_stdout_contains("test test ... ok")
@@ -366,7 +366,7 @@ fn test_multiple_required_features() {
     p.cargo("test")
         .with_stderr(
             "\
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target/debug/deps/foo_2-[..][EXE]",
         ).with_stdout_contains("test test ... ok")
@@ -375,7 +375,7 @@ fn test_multiple_required_features() {
     p.cargo("test --features c")
         .with_stderr(
             "\
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target/debug/deps/foo_1-[..][EXE]
 [RUNNING] target/debug/deps/foo_2-[..][EXE]",
@@ -425,7 +425,7 @@ fn bench_default_features() {
     p.cargo("bench")
         .with_stderr(
             "\
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] release [optimized] target(s) in [..]
 [RUNNING] target/release/deps/foo-[..][EXE]",
         ).with_stdout_contains("test bench ... bench: [..]")
@@ -490,7 +490,7 @@ fn bench_arg_features() {
     p.cargo("bench --features a")
         .with_stderr(
             "\
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] release [optimized] target(s) in [..]
 [RUNNING] target/release/deps/foo-[..][EXE]",
         ).with_stdout_contains("test bench ... bench: [..]")
@@ -549,7 +549,7 @@ fn bench_multiple_required_features() {
     p.cargo("bench")
         .with_stderr(
             "\
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] release [optimized] target(s) in [..]
 [RUNNING] target/release/deps/foo_2-[..][EXE]",
         ).with_stdout_contains("test bench ... bench: [..]")
@@ -558,7 +558,7 @@ fn bench_multiple_required_features() {
     p.cargo("bench --features c")
         .with_stderr(
             "\
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] release [optimized] target(s) in [..]
 [RUNNING] target/release/deps/foo_1-[..][EXE]
 [RUNNING] target/release/deps/foo_2-[..][EXE]",
@@ -802,7 +802,7 @@ fn dep_feature_in_toml() {
     p.cargo("test --test=foo")
         .with_stderr(
             "\
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target/debug/deps/foo-[..][EXE]",
         ).with_stdout_contains("test test ... ok")
@@ -813,8 +813,8 @@ fn dep_feature_in_toml() {
         p.cargo("bench --bench=foo")
             .with_stderr(
                 "\
-[COMPILING] bar v0.0.1 (CWD/bar)
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] bar v0.0.1 ([CWD]/bar)
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] release [optimized] target(s) in [..]
 [RUNNING] target/release/deps/foo-[..][EXE]",
             ).with_stdout_contains("test bench ... bench: [..]")
@@ -920,7 +920,7 @@ Consider enabling them by passing e.g. `--features=\"bar/a\"`
     p.cargo("test --test=foo --features bar/a")
         .with_stderr(
             "\
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target/debug/deps/foo-[..][EXE]",
         ).with_stdout_contains("test test ... ok")
@@ -936,8 +936,8 @@ Consider enabling them by passing e.g. `--features=\"bar/a\"`
         p.cargo("bench --bench=foo --features bar/a")
             .with_stderr(
                 "\
-[COMPILING] bar v0.0.1 (CWD/bar)
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] bar v0.0.1 ([CWD]/bar)
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] release [optimized] target(s) in [..]
 [RUNNING] target/release/deps/foo-[..][EXE]",
             ).with_stdout_contains("test bench ... bench: [..]")
@@ -988,7 +988,7 @@ fn test_skips_compiling_bin_with_missing_required_features() {
     p.cargo("test")
         .with_stderr(
             "\
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target/debug/deps/foo-[..][EXE]",
         ).with_stdout_contains("running 0 tests")
@@ -998,7 +998,7 @@ fn test_skips_compiling_bin_with_missing_required_features() {
         .with_status(101)
         .with_stderr_contains(
             "\
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] foo v0.0.1 ([CWD])
 error[E0463]: can't find crate for `bar`",
         ).run();
 
@@ -1006,7 +1006,7 @@ error[E0463]: can't find crate for `bar`",
         p.cargo("bench")
             .with_stderr(
                 "\
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] release [optimized] target(s) in [..]
 [RUNNING] target/release/deps/foo-[..][EXE]",
             ).with_stdout_contains("running 0 tests")
@@ -1016,7 +1016,7 @@ error[E0463]: can't find crate for `bar`",
             .with_status(101)
             .with_stderr_contains(
                 "\
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] foo v0.0.1 ([CWD])
 error[E0463]: can't find crate for `bar`",
             ).run();
     }

--- a/tests/testsuite/run.rs
+++ b/tests/testsuite/run.rs
@@ -11,7 +11,7 @@ fn simple() {
     p.cargo("run")
         .with_stderr(
             "\
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `target/debug/foo[EXE]`",
         ).with_stdout("hello")
@@ -81,7 +81,7 @@ fn exit_code() {
 
     let mut output = String::from(
         "\
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `target[..]`
 ",
@@ -102,7 +102,7 @@ fn exit_code_verbose() {
 
     let mut output = String::from(
         "\
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] foo v0.0.1 ([CWD])
 [RUNNING] `rustc [..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `target[..]`
@@ -181,7 +181,7 @@ fn specify_name() {
     p.cargo("run --bin a -v")
         .with_stderr(
             "\
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] foo v0.0.1 ([CWD])
 [RUNNING] `rustc [..] src/lib.rs [..]`
 [RUNNING] `rustc [..] src/bin/a.rs [..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
@@ -318,7 +318,7 @@ fn run_example() {
     p.cargo("run --example a")
         .with_stderr(
             "\
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `target/debug/examples/a[EXE]`",
         ).with_stdout("example")
@@ -426,7 +426,7 @@ fn run_example_autodiscover_2015_with_autoexamples_enabled() {
     p.cargo("run --example a")
         .with_stderr(
             "\
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `target/debug/examples/a[EXE]`",
         ).with_stdout("example")
@@ -456,7 +456,7 @@ fn run_example_autodiscover_2018() {
     p.cargo("run --example a")
         .with_stderr(
             "\
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `target/debug/examples/a[EXE]`",
         ).with_stdout("example")
@@ -550,7 +550,7 @@ fn one_bin_multiple_examples() {
     p.cargo("run")
         .with_stderr(
             "\
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `target/debug/main[EXE]`",
         ).with_stdout("hello main.rs")
@@ -603,21 +603,21 @@ fn example_with_release_flag() {
     p.cargo("run -v --release --example a")
         .with_stderr(
             "\
-[COMPILING] bar v0.5.0 (CWD/bar)
-[RUNNING] `rustc --crate-name bar bar/src/bar.rs --crate-type lib \
+[COMPILING] bar v0.5.0 ([CWD]/bar)
+[RUNNING] `rustc --crate-name bar bar/src/bar.rs --color never --crate-type lib \
         --emit=dep-info,link \
         -C opt-level=3 \
         -C metadata=[..] \
-        --out-dir CWD/target/release/deps \
-        -L dependency=CWD/target/release/deps`
-[COMPILING] foo v0.0.1 (CWD)
-[RUNNING] `rustc --crate-name a examples/a.rs --crate-type bin \
+        --out-dir [CWD]/target/release/deps \
+        -L dependency=[CWD]/target/release/deps`
+[COMPILING] foo v0.0.1 ([CWD])
+[RUNNING] `rustc --crate-name a examples/a.rs --color never --crate-type bin \
         --emit=dep-info,link \
         -C opt-level=3 \
         -C metadata=[..] \
-        --out-dir CWD/target/release/examples \
-        -L dependency=CWD/target/release/deps \
-         --extern bar=CWD/target/release/deps/libbar-[..].rlib`
+        --out-dir [CWD]/target/release/examples \
+        -L dependency=[CWD]/target/release/deps \
+         --extern bar=[CWD]/target/release/deps/libbar-[..].rlib`
 [FINISHED] release [optimized] target(s) in [..]
 [RUNNING] `target/release/examples/a[EXE]`
 ",
@@ -630,21 +630,21 @@ fast2",
     p.cargo("run -v --example a")
         .with_stderr(
             "\
-[COMPILING] bar v0.5.0 (CWD/bar)
-[RUNNING] `rustc --crate-name bar bar/src/bar.rs --crate-type lib \
+[COMPILING] bar v0.5.0 ([CWD]/bar)
+[RUNNING] `rustc --crate-name bar bar/src/bar.rs --color never --crate-type lib \
         --emit=dep-info,link \
         -C debuginfo=2 \
         -C metadata=[..] \
-        --out-dir CWD/target/debug/deps \
-        -L dependency=CWD/target/debug/deps`
-[COMPILING] foo v0.0.1 (CWD)
-[RUNNING] `rustc --crate-name a examples/a.rs --crate-type bin \
+        --out-dir [CWD]/target/debug/deps \
+        -L dependency=[CWD]/target/debug/deps`
+[COMPILING] foo v0.0.1 ([CWD])
+[RUNNING] `rustc --crate-name a examples/a.rs --color never --crate-type bin \
         --emit=dep-info,link \
         -C debuginfo=2 \
         -C metadata=[..] \
-        --out-dir CWD/target/debug/examples \
-        -L dependency=CWD/target/debug/deps \
-         --extern bar=CWD/target/debug/deps/libbar-[..].rlib`
+        --out-dir [CWD]/target/debug/examples \
+        -L dependency=[CWD]/target/debug/deps \
+         --extern bar=[CWD]/target/debug/deps/libbar-[..].rlib`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `target/debug/examples/a[EXE]`
 ",
@@ -703,7 +703,7 @@ fn release_works() {
     p.cargo("run --release")
         .with_stderr(
             "\
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] release [optimized] target(s) in [..]
 [RUNNING] `target/release/foo[EXE]`
 ",

--- a/tests/testsuite/rustc.rs
+++ b/tests/testsuite/rustc.rs
@@ -14,12 +14,12 @@ fn build_lib_for_foo() {
     p.cargo("rustc --lib -v")
         .with_stderr(
             "\
-[COMPILING] foo v0.0.1 (CWD)
-[RUNNING] `rustc --crate-name foo src/lib.rs --crate-type lib \
+[COMPILING] foo v0.0.1 ([CWD])
+[RUNNING] `rustc --crate-name foo src/lib.rs --color never --crate-type lib \
         --emit=dep-info,link -C debuginfo=2 \
         -C metadata=[..] \
         --out-dir [..] \
-        -L dependency=CWD/target/debug/deps`
+        -L dependency=[CWD]/target/debug/deps`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ).run();
@@ -35,13 +35,13 @@ fn lib() {
     p.cargo("rustc --lib -v -- -C debug-assertions=off")
         .with_stderr(
             "\
-[COMPILING] foo v0.0.1 (CWD)
-[RUNNING] `rustc --crate-name foo src/lib.rs --crate-type lib \
+[COMPILING] foo v0.0.1 ([CWD])
+[RUNNING] `rustc --crate-name foo src/lib.rs --color never --crate-type lib \
         --emit=dep-info,link -C debuginfo=2 \
         -C debug-assertions=off \
         -C metadata=[..] \
         --out-dir [..] \
-        -L dependency=CWD/target/debug/deps`
+        -L dependency=[CWD]/target/debug/deps`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ).run();
@@ -57,19 +57,19 @@ fn build_main_and_allow_unstable_options() {
     p.cargo("rustc -v --bin foo -- -C debug-assertions")
         .with_stderr(format!(
             "\
-[COMPILING] {name} v{version} (CWD)
-[RUNNING] `rustc --crate-name {name} src/lib.rs --crate-type lib \
+[COMPILING] {name} v{version} ([CWD])
+[RUNNING] `rustc --crate-name {name} src/lib.rs --color never --crate-type lib \
         --emit=dep-info,link -C debuginfo=2 \
         -C metadata=[..] \
         --out-dir [..] \
-        -L dependency=CWD/target/debug/deps`
-[RUNNING] `rustc --crate-name {name} src/main.rs --crate-type bin \
+        -L dependency=[CWD]/target/debug/deps`
+[RUNNING] `rustc --crate-name {name} src/main.rs --color never --crate-type bin \
         --emit=dep-info,link -C debuginfo=2 \
         -C debug-assertions \
         -C metadata=[..] \
         --out-dir [..] \
-        -L dependency=CWD/target/debug/deps \
-        --extern {name}=CWD/target/debug/deps/lib{name}-[..].rlib`
+        -L dependency=[CWD]/target/debug/deps \
+        --extern {name}=[CWD]/target/debug/deps/lib{name}-[..].rlib`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
             name = "foo",
@@ -102,11 +102,11 @@ fn build_with_args_to_one_of_multiple_binaries() {
     p.cargo("rustc -v --bin bar -- -C debug-assertions")
         .with_stderr(
             "\
-[COMPILING] foo v0.0.1 (CWD)
-[RUNNING] `rustc --crate-name foo src/lib.rs --crate-type lib --emit=dep-info,link \
+[COMPILING] foo v0.0.1 ([CWD])
+[RUNNING] `rustc --crate-name foo src/lib.rs --color never --crate-type lib --emit=dep-info,link \
         -C debuginfo=2 -C metadata=[..] \
         --out-dir [..]`
-[RUNNING] `rustc --crate-name bar src/bin/bar.rs --crate-type bin --emit=dep-info,link \
+[RUNNING] `rustc --crate-name bar src/bin/bar.rs --color never --crate-type bin --emit=dep-info,link \
         -C debuginfo=2 -C debug-assertions [..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
@@ -140,11 +140,11 @@ fn build_with_args_to_one_of_multiple_tests() {
     p.cargo("rustc -v --test bar -- -C debug-assertions")
         .with_stderr(
             "\
-[COMPILING] foo v0.0.1 (CWD)
-[RUNNING] `rustc --crate-name foo src/lib.rs --crate-type lib --emit=dep-info,link \
+[COMPILING] foo v0.0.1 ([CWD])
+[RUNNING] `rustc --crate-name foo src/lib.rs --color never --crate-type lib --emit=dep-info,link \
         -C debuginfo=2 -C metadata=[..] \
         --out-dir [..]`
-[RUNNING] `rustc --crate-name bar tests/bar.rs --emit=dep-info,link -C debuginfo=2 \
+[RUNNING] `rustc --crate-name bar tests/bar.rs --color never --emit=dep-info,link -C debuginfo=2 \
         -C debug-assertions [..]--test[..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
@@ -178,7 +178,7 @@ fn build_foo_with_bar_dependency() {
             "\
 [COMPILING] bar v0.1.0 ([..])
 [RUNNING] `[..] -C debuginfo=2 [..]`
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] foo v0.0.1 ([CWD])
 [RUNNING] `[..] -C debuginfo=2 -C debug-assertions [..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
@@ -211,7 +211,7 @@ fn build_only_bar_dependency() {
         .with_stderr(
             "\
 [COMPILING] bar v0.1.0 ([..])
-[RUNNING] `rustc --crate-name bar [..] --crate-type lib [..] -C debug-assertions [..]`
+[RUNNING] `rustc --crate-name bar [..] --color never --crate-type lib [..] -C debug-assertions [..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ).run();
@@ -223,15 +223,15 @@ fn targets_selected_default() {
     p.cargo("rustc -v")
         // bin
         .with_stderr_contains("\
-            [RUNNING] `rustc --crate-name foo src/main.rs --crate-type bin \
+            [RUNNING] `rustc --crate-name foo src/main.rs --color never --crate-type bin \
             --emit=dep-info,link[..]")
         // bench
         .with_stderr_does_not_contain("\
-            [RUNNING] `rustc --crate-name foo src/main.rs --emit=dep-info,link \
+            [RUNNING] `rustc --crate-name foo src/main.rs --color never --emit=dep-info,link \
             -C opt-level=3 --test [..]")
         // unit test
         .with_stderr_does_not_contain("\
-            [RUNNING] `rustc --crate-name foo src/main.rs --emit=dep-info,link \
+            [RUNNING] `rustc --crate-name foo src/main.rs --color never --emit=dep-info,link \
             -C debuginfo=2 --test [..]").run();
 }
 
@@ -241,15 +241,15 @@ fn targets_selected_all() {
     p.cargo("rustc -v --all-targets")
         // bin
         .with_stderr_contains("\
-            [RUNNING] `rustc --crate-name foo src/main.rs --crate-type bin \
+            [RUNNING] `rustc --crate-name foo src/main.rs --color never --crate-type bin \
             --emit=dep-info,link[..]")
         // bench
         .with_stderr_contains("\
-            [RUNNING] `rustc --crate-name foo src/main.rs --emit=dep-info,link \
+            [RUNNING] `rustc --crate-name foo src/main.rs --color never --emit=dep-info,link \
             -C opt-level=3 --test [..]")
         // unit test
         .with_stderr_contains("\
-            [RUNNING] `rustc --crate-name foo src/main.rs --emit=dep-info,link \
+            [RUNNING] `rustc --crate-name foo src/main.rs --color never --emit=dep-info,link \
             -C debuginfo=2 --test [..]").run();
 }
 

--- a/tests/testsuite/rustdoc.rs
+++ b/tests/testsuite/rustdoc.rs
@@ -7,10 +7,10 @@ fn rustdoc_simple() {
     p.cargo("rustdoc -v")
         .with_stderr(
             "\
-[DOCUMENTING] foo v0.0.1 (CWD)
-[RUNNING] `rustdoc --crate-name foo src/lib.rs \
-        -o CWD/target/doc \
-        -L dependency=CWD/target/debug/deps`
+[DOCUMENTING] foo v0.0.1 ([CWD])
+[RUNNING] `rustdoc --crate-name foo src/lib.rs [..]\
+        -o [CWD]/target/doc \
+        -L dependency=[CWD]/target/debug/deps`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ).run();
@@ -23,11 +23,11 @@ fn rustdoc_args() {
     p.cargo("rustdoc -v -- --cfg=foo")
         .with_stderr(
             "\
-[DOCUMENTING] foo v0.0.1 (CWD)
-[RUNNING] `rustdoc --crate-name foo src/lib.rs \
-        -o CWD/target/doc \
+[DOCUMENTING] foo v0.0.1 ([CWD])
+[RUNNING] `rustdoc --crate-name foo src/lib.rs [..]\
+        -o [CWD]/target/doc \
         --cfg=foo \
-        -L dependency=CWD/target/debug/deps`
+        -L dependency=[CWD]/target/debug/deps`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ).run();
@@ -60,11 +60,11 @@ fn rustdoc_foo_with_bar_dependency() {
             "\
 [CHECKING] bar v0.0.1 ([..])
 [RUNNING] `rustc [..]bar/src/lib.rs [..]`
-[DOCUMENTING] foo v0.0.1 (CWD)
-[RUNNING] `rustdoc --crate-name foo src/lib.rs \
-        -o CWD/target/doc \
+[DOCUMENTING] foo v0.0.1 ([CWD])
+[RUNNING] `rustdoc --crate-name foo src/lib.rs [..]\
+        -o [CWD]/target/doc \
         --cfg=foo \
-        -L dependency=CWD/target/debug/deps \
+        -L dependency=[CWD]/target/debug/deps \
         --extern [..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
@@ -97,10 +97,10 @@ fn rustdoc_only_bar_dependency() {
         .with_stderr(
             "\
 [DOCUMENTING] bar v0.0.1 ([..])
-[RUNNING] `rustdoc --crate-name bar [..]bar/src/lib.rs \
-        -o CWD/target/doc \
+[RUNNING] `rustdoc --crate-name bar [..]bar/src/lib.rs [..]\
+        -o [CWD]/target/doc \
         --cfg=foo \
-        -L dependency=CWD/target/debug/deps`
+        -L dependency=[CWD]/target/debug/deps`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ).run();
@@ -117,10 +117,10 @@ fn rustdoc_same_name_documents_lib() {
         .with_stderr(
             "\
 [DOCUMENTING] foo v0.0.1 ([..])
-[RUNNING] `rustdoc --crate-name foo src/lib.rs \
-        -o CWD/target/doc \
+[RUNNING] `rustdoc --crate-name foo src/lib.rs [..]\
+        -o [CWD]/target/doc \
         --cfg=foo \
-        -L dependency=CWD/target/debug/deps`
+        -L dependency=[CWD]/target/debug/deps`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ).run();
@@ -161,11 +161,11 @@ fn rustdoc_target() {
         .with_stderr(
             "\
 [DOCUMENTING] foo v0.0.1 ([..])
-[RUNNING] `rustdoc --crate-name foo src/lib.rs \
+[RUNNING] `rustdoc --crate-name foo src/lib.rs [..]\
     --target x86_64-unknown-linux-gnu \
-    -o CWD/target/x86_64-unknown-linux-gnu/doc \
-    -L dependency=CWD/target/x86_64-unknown-linux-gnu/debug/deps \
-    -L dependency=CWD/target/debug/deps`
+    -o [CWD]/target/x86_64-unknown-linux-gnu/doc \
+    -L dependency=[CWD]/target/x86_64-unknown-linux-gnu/debug/deps \
+    -L dependency=[CWD]/target/debug/deps`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]",
         ).run();
 }

--- a/tests/testsuite/search.rs
+++ b/tests/testsuite/search.rs
@@ -154,7 +154,7 @@ wants the location of the index. Please use '--index' instead.
 This will soon become a hard error, so it's either recommended
 to update to a fixed version or contact the upstream maintainer
 about this warning.
-[UPDATING] `CWD/registry` index
+[UPDATING] `[CWD]/registry` index
 ",
             )
             .with_stdout_contains(
@@ -181,7 +181,7 @@ wants the location of the index. Please use '--index' instead.
 This will soon become a hard error, so it's either recommended
 to update to a fixed version or contact the upstream maintainer
 about this warning.
-[UPDATING] `CWD/registry` index
+[UPDATING] `[CWD]/registry` index
 ",
             )
             .with_stdout_contains(

--- a/tests/testsuite/support/publish.rs
+++ b/tests/testsuite/support/publish.rs
@@ -47,7 +47,7 @@ pub fn setup() -> Repository {
         ).build()
 }
 
-fn registry_path() -> PathBuf {
+pub fn registry_path() -> PathBuf {
     paths::root().join("registry")
 }
 pub fn registry() -> Url {

--- a/tests/testsuite/test.rs
+++ b/tests/testsuite/test.rs
@@ -36,7 +36,7 @@ fn cargo_test_simple() {
     p.cargo("test")
         .with_stderr(
             "\
-[COMPILING] foo v0.5.0 (CWD)
+[COMPILING] foo v0.5.0 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target/debug/deps/foo-[..][EXE]",
         ).with_stdout_contains("test test_hello ... ok")
@@ -81,9 +81,9 @@ fn cargo_test_release() {
     p.cargo("test -v --release")
         .with_stderr(
             "\
-[COMPILING] bar v0.0.1 (CWD/bar)
+[COMPILING] bar v0.0.1 ([CWD]/bar)
 [RUNNING] [..] -C opt-level=3 [..]
-[COMPILING] foo v0.1.0 (CWD)
+[COMPILING] foo v0.1.0 ([CWD])
 [RUNNING] [..] -C opt-level=3 [..]
 [RUNNING] [..] -C opt-level=3 [..]
 [RUNNING] [..] -C opt-level=3 [..]
@@ -150,7 +150,7 @@ fn cargo_test_verbose() {
     p.cargo("test -v hello")
         .with_stderr(
             "\
-[COMPILING] foo v0.5.0 (CWD)
+[COMPILING] foo v0.5.0 ([CWD])
 [RUNNING] `rustc [..] src/main.rs [..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `[..]target/debug/deps/foo-[..][EXE] hello`",
@@ -218,7 +218,7 @@ fn cargo_test_failing_test_in_bin() {
     p.cargo("test")
         .with_stderr(
             "\
-[COMPILING] foo v0.5.0 (CWD)
+[COMPILING] foo v0.5.0 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target/debug/deps/foo-[..][EXE]
 [ERROR] test failed, to rerun pass '--bin foo'",
@@ -262,7 +262,7 @@ fn cargo_test_failing_test_in_test() {
     p.cargo("test")
         .with_stderr(
             "\
-[COMPILING] foo v0.5.0 (CWD)
+[COMPILING] foo v0.5.0 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target/debug/deps/foo-[..][EXE]
 [RUNNING] target/debug/deps/footest-[..][EXE]
@@ -298,7 +298,7 @@ fn cargo_test_failing_test_in_lib() {
     p.cargo("test")
         .with_stderr(
             "\
-[COMPILING] foo v0.5.0 (CWD)
+[COMPILING] foo v0.5.0 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target/debug/deps/foo-[..][EXE]
 [ERROR] test failed, to rerun pass '--lib'",
@@ -366,7 +366,7 @@ fn test_with_lib_dep() {
     p.cargo("test")
         .with_stderr(
             "\
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target/debug/deps/foo-[..][EXE]
 [RUNNING] target/debug/deps/baz-[..][EXE]
@@ -417,7 +417,7 @@ fn test_with_deep_lib_dep() {
         .with_stderr(
             "\
 [COMPILING] bar v0.0.1 ([..])
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target[..]
 [DOCTEST] foo",
@@ -462,7 +462,7 @@ fn external_test_explicit() {
     p.cargo("test")
         .with_stderr(
             "\
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target/debug/deps/foo-[..][EXE]
 [RUNNING] target/debug/deps/test-[..][EXE]
@@ -518,7 +518,7 @@ fn external_test_implicit() {
     p.cargo("test")
         .with_stderr(
             "\
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target/debug/deps/foo-[..][EXE]
 [RUNNING] target/debug/deps/external-[..][EXE]
@@ -556,7 +556,7 @@ fn pass_through_command_line() {
     p.cargo("test bar")
         .with_stderr(
             "\
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target/debug/deps/foo-[..][EXE]
 [DOCTEST] foo",
@@ -627,7 +627,7 @@ fn lib_bin_same_name() {
     p.cargo("test")
         .with_stderr(
             "\
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target/debug/deps/foo-[..][EXE]
 [RUNNING] target/debug/deps/foo-[..][EXE]
@@ -665,7 +665,7 @@ fn lib_with_standard_name() {
     p.cargo("test")
         .with_stderr(
             "\
-[COMPILING] syntax v0.0.1 (CWD)
+[COMPILING] syntax v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target/debug/deps/syntax-[..][EXE]
 [RUNNING] target/debug/deps/test-[..][EXE]
@@ -708,7 +708,7 @@ fn lib_with_standard_name2() {
     p.cargo("test")
         .with_stderr(
             "\
-[COMPILING] syntax v0.0.1 (CWD)
+[COMPILING] syntax v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target/debug/deps/syntax-[..][EXE]",
         ).with_stdout_contains("test test ... ok")
@@ -746,7 +746,7 @@ fn lib_without_name() {
     p.cargo("test")
         .with_stderr(
             "\
-[COMPILING] syntax v0.0.1 (CWD)
+[COMPILING] syntax v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target/debug/deps/syntax-[..][EXE]",
         ).with_stdout_contains("test test ... ok")
@@ -1034,8 +1034,8 @@ fn test_dylib() {
     p.cargo("test")
         .with_stderr(
             "\
-[COMPILING] bar v0.0.1 (CWD/bar)
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] bar v0.0.1 ([CWD]/bar)
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target/debug/deps/foo-[..][EXE]
 [RUNNING] target/debug/deps/test-[..][EXE]",
@@ -1072,7 +1072,7 @@ fn test_twice_with_build_cmd() {
     p.cargo("test")
         .with_stderr(
             "\
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target/debug/deps/foo-[..][EXE]
 [DOCTEST] foo",
@@ -1098,7 +1098,7 @@ fn test_then_build() {
     p.cargo("test")
         .with_stderr(
             "\
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target/debug/deps/foo-[..][EXE]
 [DOCTEST] foo",
@@ -1118,7 +1118,7 @@ fn test_no_run() {
     p.cargo("test --no-run")
         .with_stderr(
             "\
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         ).run();
@@ -1150,7 +1150,7 @@ fn test_run_specific_bin_target() {
     prj.cargo("test --bin bin2")
         .with_stderr(
             "\
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target/debug/deps/bin2-[..][EXE]",
         ).with_stdout_contains("test test2 ... ok")
@@ -1187,7 +1187,7 @@ fn test_run_implicit_bin_target() {
     prj.cargo("test --bins")
         .with_stderr(
             "\
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target/debug/deps/mybin-[..][EXE]",
         ).with_stdout_contains("test test_in_bin ... ok")
@@ -1206,7 +1206,7 @@ fn test_run_specific_test_target() {
     prj.cargo("test --test b")
         .with_stderr(
             "\
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target/debug/deps/b-[..][EXE]",
         ).with_stdout_contains("test test_b ... ok")
@@ -1242,7 +1242,7 @@ fn test_run_implicit_test_target() {
     prj.cargo("test --tests")
         .with_stderr(
             "\
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target/debug/deps/mybin-[..][EXE]
 [RUNNING] target/debug/deps/mytest-[..][EXE]",
@@ -1279,7 +1279,7 @@ fn test_run_implicit_bench_target() {
     prj.cargo("test --benches")
         .with_stderr(
             "\
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target/debug/deps/mybin-[..][EXE]
 [RUNNING] target/debug/deps/mybench-[..][EXE]",
@@ -1327,7 +1327,7 @@ fn test_run_implicit_example_target() {
 
     // Compiles myexm1 as normal, but does not run it.
     prj.cargo("test -v")
-        .with_stderr_contains("[RUNNING] `rustc [..]myexm1.rs --crate-type bin[..]")
+        .with_stderr_contains("[RUNNING] `rustc [..]myexm1.rs [..]--crate-type bin[..]")
         .with_stderr_contains("[RUNNING] `rustc [..]myexm2.rs [..]--test[..]")
         .with_stderr_does_not_contain("[RUNNING] [..]myexm1-[..]")
         .with_stderr_contains("[RUNNING] [..]target/debug/examples/myexm2-[..]")
@@ -1384,7 +1384,7 @@ fn test_no_harness() {
     p.cargo("test -- --nocapture")
         .with_stderr(
             "\
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target/debug/deps/bar-[..][EXE]
 ",
@@ -1451,7 +1451,7 @@ fn selective_testing() {
     p.cargo("test -p d1")
         .with_stderr(
             "\
-[COMPILING] d1 v0.0.1 (CWD/d1)
+[COMPILING] d1 v0.0.1 ([CWD]/d1)
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target/debug/deps/d1-[..][EXE]
 [RUNNING] target/debug/deps/d1-[..][EXE]",
@@ -1462,7 +1462,7 @@ fn selective_testing() {
     p.cargo("test -p d2")
         .with_stderr(
             "\
-[COMPILING] d2 v0.0.1 (CWD/d2)
+[COMPILING] d2 v0.0.1 ([CWD]/d2)
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target/debug/deps/d2-[..][EXE]
 [RUNNING] target/debug/deps/d2-[..][EXE]",
@@ -1473,7 +1473,7 @@ fn selective_testing() {
     p.cargo("test")
         .with_stderr(
             "\
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target/debug/deps/foo-[..][EXE]",
         ).with_stdout_contains("running 0 tests")
@@ -1641,7 +1641,7 @@ fn selective_testing_with_docs() {
     p.cargo("test -p d1")
         .with_stderr(
             "\
-[COMPILING] d1 v0.0.1 (CWD/d1)
+[COMPILING] d1 v0.0.1 ([CWD]/d1)
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target/debug/deps/d1[..][EXE]
 [DOCTEST] d1",
@@ -1659,7 +1659,7 @@ fn example_bin_same_name() {
     p.cargo("test --no-run -v")
         .with_stderr(
             "\
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] foo v0.0.1 ([CWD])
 [RUNNING] `rustc [..]`
 [RUNNING] `rustc [..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]

--- a/tests/testsuite/tool_paths.rs
+++ b/tests/testsuite/tool_paths.rs
@@ -23,7 +23,7 @@ fn pathless_tools() {
     foo.cargo("build --verbose")
         .with_stderr(
             "\
-[COMPILING] foo v0.5.0 (CWD)
+[COMPILING] foo v0.5.0 ([CWD])
 [RUNNING] `rustc [..] -C ar=nonexistent-ar -C linker=nonexistent-linker [..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
@@ -64,7 +64,7 @@ fn absolute_tools() {
 
     foo.cargo("build --verbose").with_stderr(&format!(
             "\
-[COMPILING] foo v0.5.0 (CWD)
+[COMPILING] foo v0.5.0 ([CWD])
 [RUNNING] `rustc [..] -C ar={root}bogus/nonexistent-ar -C linker={root}bogus/nonexistent-linker [..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
@@ -107,7 +107,7 @@ fn relative_tools() {
 
     p.cargo("build --verbose").cwd(p.root().join("bar")).with_stderr(&format!(
             "\
-[COMPILING] bar v0.5.0 (CWD)
+[COMPILING] bar v0.5.0 ([CWD])
 [RUNNING] `rustc [..] -C ar={prefix}/./nonexistent-ar -C linker={prefix}/./tools/nonexistent-linker [..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
@@ -138,7 +138,7 @@ fn custom_runner() {
         .with_status(101)
         .with_stderr_contains(
             "\
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `nonexistent-runner -r target/debug/foo[EXE] --param`
 ",
@@ -148,7 +148,7 @@ fn custom_runner() {
         .with_status(101)
         .with_stderr_contains(
             "\
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] foo v0.0.1 ([CWD])
 [RUNNING] `rustc [..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `nonexistent-runner -r [..]/target/debug/deps/test-[..][EXE] --param`
@@ -159,7 +159,7 @@ fn custom_runner() {
         .with_status(101)
         .with_stderr_contains(
             "\
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] foo v0.0.1 ([CWD])
 [RUNNING] `rustc [..]`
 [RUNNING] `rustc [..]`
 [FINISHED] release [optimized] target(s) in [..]
@@ -185,7 +185,7 @@ fn custom_runner_cfg() {
         .with_status(101)
         .with_stderr_contains(&format!(
             "\
-[COMPILING] foo v0.0.1 (CWD)
+[COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `nonexistent-runner -r target/debug/foo[EXE] --param`
 ",
@@ -217,7 +217,7 @@ fn custom_runner_cfg_precedence() {
         .with_status(101)
         .with_stderr_contains(&format!(
             "\
-            [COMPILING] foo v0.0.1 (CWD)
+            [COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `nonexistent-runner -r target/debug/foo[EXE] --param`
 ",

--- a/tests/testsuite/workspaces.rs
+++ b/tests/testsuite/workspaces.rs
@@ -722,7 +722,7 @@ fn virtual_misconfigure() {
         .with_stderr(
             "\
 error: current package believes it's in a workspace when it's not:
-current:   CWD/Cargo.toml
+current:   [CWD]/Cargo.toml
 workspace: [..]Cargo.toml
 
 this may be fixable by adding `bar` to the `workspace.members` array of the \


### PR DESCRIPTION
Reconciles data found in this comment https://github.com/rust-lang/rust/pull/54342#issuecomment-422640987 by merging the cargo submodule's commit of the original beta for 1.30.0 into the current 1.30.0 branch.

Includes stabilization of `-Z compile-progress` as well as a number of other nice fixes!

r? @ehuss 