### PR TITLE
Removes -Zunstable-options for rustdoc testing

### DIFF
--- a/src/cargo/core/compiler/compilation.rs
+++ b/src/cargo/core/compiler/compilation.rs
@@ -140,7 +140,6 @@ impl<'cfg> Compilation<'cfg> {
     pub fn rustdoc_process(&self, pkg: &Package, target: &Target) -> CargoResult<ProcessBuilder> {
         let mut p = self.fill_env(process(&*self.config.rustdoc()?), pkg, false)?;
         if target.edition() != Edition::Edition2015 {
-            p.arg("-Zunstable-options");
             p.arg(format!("--edition={}", target.edition()));
         }
         Ok(p)

--- a/tests/testsuite/doc.rs
+++ b/tests/testsuite/doc.rs
@@ -1118,12 +1118,12 @@ fn doc_edition() {
 
     p.cargo("doc -v")
         .masquerade_as_nightly_cargo()
-        .with_stderr_contains("[RUNNING] `rustdoc [..]-Zunstable-options --edition=2018[..]")
+        .with_stderr_contains("[RUNNING] `rustdoc [..]--edition=2018[..]")
         .run();
 
     p.cargo("test -v")
         .masquerade_as_nightly_cargo()
-        .with_stderr_contains("[RUNNING] `rustdoc [..]-Zunstable-options --edition=2018[..]")
+        .with_stderr_contains("[RUNNING] `rustdoc [..]--edition=2018[..]")
         .run();
 }
 
@@ -1150,12 +1150,12 @@ fn doc_target_edition() {
 
     p.cargo("doc -v")
         .masquerade_as_nightly_cargo()
-        .with_stderr_contains("[RUNNING] `rustdoc [..]-Zunstable-options --edition=2018[..]")
+        .with_stderr_contains("[RUNNING] `rustdoc [..]--edition=2018[..]")
         .run();
 
     p.cargo("test -v")
         .masquerade_as_nightly_cargo()
-        .with_stderr_contains("[RUNNING] `rustdoc [..]-Zunstable-options --edition=2018[..]")
+        .with_stderr_contains("[RUNNING] `rustdoc [..]--edition=2018[..]")
         .run();
 }
 


### PR DESCRIPTION
As far as I understand, this flag isn't needed anymore, since --edition is stable on beta.

I ran in to this when running `cargo +beta test --doc --verbose` on my crate, which errors with:
```
     Running `rustdoc -Zunstable-options --edition=2018 [omitted...]`
error: the option `Z` is only accepted on the nightly compiler
```