### PR TITLE
Remove `fix::local_paths_no_fix`, as `crate_in_paths` is getting stabilized.

### DIFF
--- a/tests/testsuite/fix.rs
+++ b/tests/testsuite/fix.rs
@@ -313,37 +313,6 @@ fn local_paths() {
 }
 
 #[test]
-fn local_paths_no_fix() {
-    if !is_nightly() {
-        return;
-    }
-    let p = project()
-        .file(
-            "src/lib.rs",
-            r#"
-                use test::foo;
-
-                mod test {
-                    pub fn foo() {}
-                }
-
-                pub fn f() {
-                    foo();
-                }
-            "#,
-        ).build();
-
-    let stderr = "\
-[CHECKING] foo v0.0.1 ([..])
-[FINISHED] [..]
-";
-    p.cargo("fix --edition --allow-no-vcs")
-        .with_stderr(stderr)
-        .with_stdout("")
-        .run();
-}
-
-#[test]
 fn upgrade_extern_crate() {
     if !is_nightly() {
         return;


### PR DESCRIPTION
Needed for rust-lang/rust#54403 (blocking RC1).
Ideally we'd also clean up the tests, e.g. removing `#![feature(rust_2018_preview)]` and `is_nightly` checks, but it's easier to just remove the only failing test (because it tests the feature gate is needed).