### PR TITLE
[beta] Remove `fix::local_paths_no_fix`, as `crate_in_paths` is getting stabilized.

### DIFF
--- a/tests/testsuite/fix.rs
+++ b/tests/testsuite/fix.rs
@@ -313,37 +313,6 @@ fn local_paths() {
 }
 
 #[test]
-fn local_paths_no_fix() {
-    if !is_nightly() {
-        return;
-    }
-    let p = project()
-        .file(
-            "src/lib.rs",
-            r#"
-                use test::foo;
-
-                mod test {
-                    pub fn foo() {}
-                }
-
-                pub fn f() {
-                    foo();
-                }
-            "#,
-        ).build();
-
-    let stderr = "\
-[CHECKING] foo v0.0.1 ([..])
-[FINISHED] [..]
-";
-    p.cargo("fix --edition --allow-no-vcs")
-        .with_stderr(stderr)
-        .with_stdout("")
-        .run();
-}
-
-#[test]
 fn upgrade_extern_crate() {
     if !is_nightly() {
         return;


### PR DESCRIPTION
Beta backport of #6068. Needed for rust-lang/rust#54404 (blocking RC1).

r? @alexcrichton 