### PR TITLE
custom compile progress via env var template

### DIFF
--- a/src/cargo/core/compiler/job_queue.rs
+++ b/src/cargo/core/compiler/job_queue.rs
@@ -277,7 +277,7 @@ impl<'a> JobQueue<'a> {
             let active_names = self.active.iter()
                 .map(Key::name_for_progress)
                 .collect::<Vec<_>>();
-            drop(progress.tick_now(count, total, &format!(": {}", active_names.join(", "))));
+            drop(progress.tick_now(count, total, active_names));
             let event = self.rx.recv().unwrap();
             progress.clear();
 

--- a/src/cargo/core/compiler/job_queue.rs
+++ b/src/cargo/core/compiler/job_queue.rs
@@ -16,8 +16,7 @@ use core::{PackageId, Target, TargetKind};
 use handle_error;
 use util;
 use util::{internal, profile, CargoResult, CargoResultExt, ProcessBuilder};
-use util::{Config, DependencyQueue, Dirty, Fresh, Freshness};
-use util::{Progress, ProgressStyle};
+use util::{Config, DependencyQueue, Dirty, Fresh, Freshness, Progress};
 use util::diagnostic_server::{self, DiagnosticPrinter};
 
 use super::job::Job;
@@ -228,7 +227,7 @@ impl<'a> JobQueue<'a> {
         // successful and otherwise wait for pending work to finish if it failed
         // and then immediately return.
         let mut error = None;
-        let mut progress = Progress::with_style("Building", ProgressStyle::Ratio, cx.bcx.config);
+        let mut progress = Progress::with_style("Building", cx.bcx.config);
         let total = self.queue.len();
         loop {
             // Dequeue as much work as we can, learning about everything

--- a/src/cargo/core/compiler/job_queue.rs
+++ b/src/cargo/core/compiler/job_queue.rs
@@ -227,7 +227,7 @@ impl<'a> JobQueue<'a> {
         // successful and otherwise wait for pending work to finish if it failed
         // and then immediately return.
         let mut error = None;
-        let mut progress = Progress::with_style("Building", cx.bcx.config);
+        let mut progress = Progress::with_custom_style("Building", cx.bcx.config);
         let total = self.queue.len();
         loop {
             // Dequeue as much work as we can, learning about everything
@@ -276,7 +276,7 @@ impl<'a> JobQueue<'a> {
             let active_names = self.active.iter()
                 .map(Key::name_for_progress)
                 .collect::<Vec<_>>();
-            drop(progress.tick_now(count, total, active_names));
+            drop(progress.tick_now(count, total, active_names, false /*force-render jobs*/));
             let event = self.rx.recv().unwrap();
             progress.clear();
 

--- a/src/cargo/core/package.rs
+++ b/src/cargo/core/package.rs
@@ -330,7 +330,7 @@ impl<'cfg> PackageSet<'cfg> {
             pending_ids: HashSet::new(),
             results: Vec::new(),
             retry: Retry::new(self.config)?,
-            progress: RefCell::new(Some(Progress::with_style(
+            progress: RefCell::new(Some(Progress::new(
                 "Downloading",
                 self.config,
             ))),
@@ -654,7 +654,7 @@ impl<'a, 'cfg> Downloads<'a, 'cfg> {
                 }
             }
         }
-        progress.print_now(&msg)
+        progress.print_now(&msg, true /*force-render jobs*/)
     }
 }
 

--- a/src/cargo/core/package.rs
+++ b/src/cargo/core/package.rs
@@ -19,7 +19,7 @@ use core::{FeatureMap, SourceMap, Summary};
 use core::source::MaybePackage;
 use core::interning::InternedString;
 use ops;
-use util::{self, internal, lev_distance, Config, Progress, ProgressStyle};
+use util::{self, internal, lev_distance, Config, Progress};
 use util::errors::{CargoResult, CargoResultExt, HttpNot200};
 use util::network::Retry;
 
@@ -332,7 +332,6 @@ impl<'cfg> PackageSet<'cfg> {
             retry: Retry::new(self.config)?,
             progress: RefCell::new(Some(Progress::with_style(
                 "Downloading",
-                ProgressStyle::Ratio,
                 self.config,
             ))),
             downloads_finished: 0,

--- a/src/cargo/sources/git/utils.rs
+++ b/src/cargo/sources/git/utils.rs
@@ -621,7 +621,7 @@ fn reset(repo: &git2::Repository, obj: &git2::Object, config: &Config) -> CargoR
     let mut pb = Progress::new("Checkout", config);
     let mut opts = git2::build::CheckoutBuilder::new();
     opts.progress(|_, cur, max| {
-        drop(pb.tick(cur, max));
+        drop(pb.tick(cur, max, 1 /* active count */));
     });
     repo.reset(obj, git2::ResetType::Hard, Some(&mut opts))?;
     Ok(())
@@ -641,7 +641,7 @@ pub fn with_fetch_options(
 
             rcb.transfer_progress(|stats| {
                 progress
-                    .tick(stats.indexed_objects(), stats.total_objects())
+                    .tick(stats.indexed_objects(), stats.total_objects(), 1 /*active count*/)
                     .is_ok()
             });
 

--- a/src/cargo/util/progress.rs
+++ b/src/cargo/util/progress.rs
@@ -37,7 +37,9 @@ struct Format {
 
 impl<'cfg> Progress<'cfg> {
     pub fn with_custom_style(name: &str, cfg: &'cfg Config) -> Progress<'cfg> {
-   // @TODO: use   let format_template = cfg.get_string("TERM").unwrap().map(|s| s.val);
+        // todo: since cfg stores all the env vars, maybe we can use that one, one day
+        // cfg.get_string("CARGO_STATUS").unwrap().map(|s| s.val);
+
         let format_template: String = match env::var("CARGO_STATUS") {
             Ok(template) => template,
             // if not set, fall back to default

--- a/src/cargo/util/progress.rs
+++ b/src/cargo/util/progress.rs
@@ -313,8 +313,8 @@ impl Format {
         // what is left if we remove all dynamic parameters
         // will be "[] /: " for default formatting of "[%b] %f/%t: %n"
         let mut template_skelleton = template.to_string();
-        for fmt in &["%b", "%f", "%t", "%p", "%P", "%%", "%n", "%r", "%s", "%u"] {
-            // remove all the formatting specifiers
+        for fmt in &["%b", "%f", "%t", "%p", "%P", "%n", "%r", "%s", "%u", "%%"] {
+            // remove all the formatting parameters
             template_skelleton = template_skelleton.replace(fmt, "");
         }
         let length_of_formatters = template.len() - template_skelleton.len();
@@ -447,12 +447,12 @@ impl Format {
             .replace("%t", &max_str)
             .replace("%p", &percentage)
             .replace("%P", &percentage_int)
-            .replace("%%", &percentage_char)
             .replace("%b", &progress_bar)
             .replace("%n", &jobs_names)
             .replace("%r", &running_str)
             .replace("%s", &started_str)
-            .replace("%u", &remaining_str);
+            .replace("%u", &remaining_str)
+            .replace("%%", &percentage_char);
 
         Some(progress_line)
     }
@@ -734,6 +734,26 @@ fn test_progress_status_format_standalone() {
             "Hello world, let's make this a bit longer actually..."
         ),
         Some("Hello world, let\'s make this a bit longer actual...".to_string())
+    );
+    // make sure that in %%r, the we first evaluate %r and then %%
+    let format = Format {
+        formatting: "%%r".to_string(),
+        max_print: 42,
+        max_width: 60,
+    };
+    assert_eq!(
+        format.progress_status(5, 10, 3, "foo"),
+        Some("%3".to_string())
+    );
+
+    let format = Format {
+        formatting: "%%r%%%".to_string(),
+        max_print: 42,
+        max_width: 60,
+    };
+    assert_eq!(
+        format.progress_status(5, 10, 3, "foo"),
+        Some("%3%%".to_string())
     );
 }
 

--- a/src/cargo/util/progress.rs
+++ b/src/cargo/util/progress.rs
@@ -73,7 +73,7 @@ impl<'cfg> Progress<'cfg> {
         Self::with_style(name, ProgressStyle::Percentage, cfg)
     }
 
-    pub fn tick(&mut self, cur: usize, max: usize) -> CargoResult<()> {
+    pub fn tick(&mut self, cur: usize, max: usize, active: usize) -> CargoResult<()> {
         let s = match &mut self.state {
             Some(s) => s,
             None => return Ok(()),
@@ -95,12 +95,14 @@ impl<'cfg> Progress<'cfg> {
             return Ok(())
         }
 
-        s.tick(cur, max, "")
+        s.tick(cur, max, active, "")
     }
 
-    pub fn tick_now(&mut self, cur: usize, max: usize, msg: &str) -> CargoResult<()> {
+    pub fn tick_now(&mut self, cur: usize, max: usize, active_names: Vec<String>) -> CargoResult<()> {
+        let active = active_names.len();
+        let msg = &format!(": {}", active_names.join(", "));
         match self.state {
-            Some(ref mut s) => s.tick(cur, max, msg),
+            Some(ref mut s) => s.tick(cur, max, active, msg),
             None => Ok(()),
         }
     }
@@ -157,7 +159,7 @@ impl Throttle {
 }
 
 impl<'cfg> State<'cfg> {
-    fn tick(&mut self, cur: usize, max: usize, msg: &str) -> CargoResult<()> {
+    fn tick(&mut self, cur: usize, max: usize, active: usize, msg: &str) -> CargoResult<()> {
         if self.done {
             return Ok(());
         }
@@ -169,7 +171,7 @@ impl<'cfg> State<'cfg> {
         // Write out a pretty header, then the progress bar itself, and then
         // return back to the beginning of the line for the next print.
         self.try_update_max_width();
-        if let Some(pbar) = self.format.progress(cur, max) {
+        if let Some(pbar) = self.format.progress(cur, max, active) {
             self.print(&pbar, msg)?;
         }
         Ok(())
@@ -207,7 +209,7 @@ impl<'cfg> State<'cfg> {
 }
 
 impl Format {
-    fn progress(&self, cur: usize, max: usize) -> Option<String> {
+    fn progress(&self, cur: usize, max: usize, _active: usize) -> Option<String> {
         // Render the percentage at the far right and then figure how long the
         // progress bar is
         let pct = (cur as f64) / (max as f64);
@@ -239,7 +241,7 @@ impl Format {
 
         // Draw the empty space we have left to do
         string.push_str(&" ".repeat(display_width - hashes));
-        
+
         string.push_str("]");
         string.push_str(&stats);
 
@@ -269,8 +271,8 @@ impl Format {
     }
 
     #[cfg(test)]
-    fn progress_status(&self, cur: usize, max: usize, msg: &str) -> Option<String> {
-        let mut ret = self.progress(cur, max)?;
+    fn progress_status(&self, cur: usize, max: usize, active: usize, msg: &str) -> Option<String> {
+        let mut ret = self.progress(cur, max, active)?;
         self.render(&mut ret, msg);
         Some(ret)
     }
@@ -294,62 +296,62 @@ fn test_progress_status() {
         max_width: 60,
     };
     assert_eq!(
-        format.progress_status(0, 4, ""),
+        format.progress_status(0, 4, 1, ""),
         Some("[                   ] 0/4".to_string())
     );
     assert_eq!(
-        format.progress_status(1, 4, ""),
+        format.progress_status(1, 4, 1, ""),
         Some("[===>               ] 1/4".to_string())
     );
     assert_eq!(
-        format.progress_status(2, 4, ""),
+        format.progress_status(2, 4, 1, ""),
         Some("[========>          ] 2/4".to_string())
     );
     assert_eq!(
-        format.progress_status(3, 4, ""),
+        format.progress_status(3, 4, 1, ""),
         Some("[=============>     ] 3/4".to_string())
     );
     assert_eq!(
-        format.progress_status(4, 4, ""),
+        format.progress_status(4, 4, 0, ""),
         Some("[===================] 4/4".to_string())
     );
 
     assert_eq!(
-        format.progress_status(3999, 4000, ""),
+        format.progress_status(3999, 4000, 1, ""),
         Some("[===========> ] 3999/4000".to_string())
     );
     assert_eq!(
-        format.progress_status(4000, 4000, ""),
+        format.progress_status(4000, 4000, 0, ""),
         Some("[=============] 4000/4000".to_string())
     );
 
     assert_eq!(
-        format.progress_status(3, 4, ": short message"),
+        format.progress_status(3, 4, 1, ": short message"),
         Some("[=============>     ] 3/4: short message".to_string())
     );
     assert_eq!(
-        format.progress_status(3, 4, ": msg thats just fit"),
+        format.progress_status(3, 4, 1,": msg thats just fit"),
         Some("[=============>     ] 3/4: msg thats just fit".to_string())
     );
     assert_eq!(
-        format.progress_status(3, 4, ": msg that's just fit"),
+        format.progress_status(3, 4, 1,": msg that's just fit"),
         Some("[=============>     ] 3/4: msg that's just...".to_string())
     );
 
     // combining diacritics have width zero and thus can fit max_width.
     let zalgo_msg = "z̸̧̢̗͉̝̦͍̱ͧͦͨ̑̅̌ͥ́͢a̢ͬͨ̽ͯ̅̑ͥ͋̏̑ͫ̄͢͏̫̝̪̤͎̱̣͍̭̞̙̱͙͍̘̭͚l̶̡̛̥̝̰̭̹̯̯̞̪͇̱̦͙͔̘̼͇͓̈ͨ͗ͧ̓͒ͦ̀̇ͣ̈ͭ͊͛̃̑͒̿̕͜g̸̷̢̩̻̻͚̠͓̞̥͐ͩ͌̑ͥ̊̽͋͐̐͌͛̐̇̑ͨ́ͅo͙̳̣͔̰̠̜͕͕̞̦̙̭̜̯̹̬̻̓͑ͦ͋̈̉͌̃ͯ̀̂͠ͅ ̸̡͎̦̲̖̤̺̜̮̱̰̥͔̯̅̏ͬ̂ͨ̋̃̽̈́̾̔̇ͣ̚͜͜h̡ͫ̐̅̿̍̀͜҉̛͇̭̹̰̠͙̞ẽ̶̙̹̳̖͉͎̦͂̋̓ͮ̔ͬ̐̀͂̌͑̒͆̚͜͠ ͓͓̟͍̮̬̝̝̰͓͎̼̻ͦ͐̾̔͒̃̓͟͟c̮̦͍̺͈͚̯͕̄̒͐̂͊̊͗͊ͤͣ̀͘̕͝͞o̶͍͚͍̣̮͌ͦ̽̑ͩ̅ͮ̐̽̏͗́͂̅ͪ͠m̷̧͖̻͔̥̪̭͉͉̤̻͖̩̤͖̘ͦ̂͌̆̂ͦ̒͊ͯͬ͊̉̌ͬ͝͡e̵̹̣͍̜̺̤̤̯̫̹̠̮͎͙̯͚̰̼͗͐̀̒͂̉̀̚͝͞s̵̲͍͙͖̪͓͓̺̱̭̩̣͖̣ͤͤ͂̎̈͗͆ͨͪ̆̈͗͝͠";
     assert_eq!(
-        format.progress_status(3, 4, zalgo_msg),
+        format.progress_status(3, 4, 1, zalgo_msg),
         Some("[=============>     ] 3/4".to_string() + zalgo_msg)
     );
 
     // some non-ASCII ellipsize test
     assert_eq!(
-        format.progress_status(3, 4, "_123456789123456e\u{301}\u{301}8\u{301}90a"),
+        format.progress_status(3, 4, 1, "_123456789123456e\u{301}\u{301}8\u{301}90a"),
         Some("[=============>     ] 3/4_123456789123456e\u{301}\u{301}...".to_string())
     );
     assert_eq!(
-        format.progress_status(3, 4, "：每個漢字佔據了兩個字元"),
+        format.progress_status(3, 4, 1, "：每個漢字佔據了兩個字元"),
         Some("[=============>     ] 3/4：每個漢字佔據了...".to_string())
     );
 }
@@ -362,19 +364,19 @@ fn test_progress_status_percentage() {
         max_width: 60,
     };
     assert_eq!(
-        format.progress_status(0, 77, ""),
+        format.progress_status(0, 77, 1,""),
         Some("[               ]   0.00%".to_string())
     );
     assert_eq!(
-        format.progress_status(1, 77, ""),
+        format.progress_status(1, 77, 1, ""),
         Some("[               ]   1.30%".to_string())
     );
     assert_eq!(
-        format.progress_status(76, 77, ""),
+        format.progress_status(76, 77, 1, ""),
         Some("[=============> ]  98.70%".to_string())
     );
     assert_eq!(
-        format.progress_status(77, 77, ""),
+        format.progress_status(77, 77, 1, ""),
         Some("[===============] 100.00%".to_string())
     );
 }
@@ -387,7 +389,7 @@ fn test_progress_status_too_short() {
         max_width: 25,
     };
     assert_eq!(
-        format.progress_status(1, 1, ""),
+        format.progress_status(1, 1, 0, ""),
         Some("[] 100.00%".to_string())
     );
 
@@ -397,7 +399,7 @@ fn test_progress_status_too_short() {
         max_width: 24,
     };
     assert_eq!(
-        format.progress_status(1, 1, ""),
+        format.progress_status(1, 1, 1, ""),
         None
     );
 }

--- a/src/cargo/util/progress.rs
+++ b/src/cargo/util/progress.rs
@@ -229,9 +229,7 @@ impl Format {
 
         // Draw the `===>`
         if hashes > 0 {
-            for _ in 0..hashes - 1 {
-                string.push_str("=");
-            }
+            string.push_str(&"=".repeat(hashes-1));
             if cur == max {
                 string.push_str("=");
             } else {
@@ -240,9 +238,8 @@ impl Format {
         }
 
         // Draw the empty space we have left to do
-        for _ in 0..(display_width - hashes) {
-            string.push_str(" ");
-        }
+        string.push_str(&" ".repeat(display_width - hashes));
+        
         string.push_str("]");
         string.push_str(&stats);
 

--- a/src/cargo/util/progress.rs
+++ b/src/cargo/util/progress.rs
@@ -277,6 +277,8 @@ impl<'cfg> State<'cfg> {
 
 impl Format {
     fn progress(&self, cur: usize, max: usize, active: usize, msg: &str) -> Option<String> {
+        // if you edit this, please make sure to keep environment-variables.md up to date!
+
         // %b progress bar
         // %s the number of started jobs
         // %f number of finished jobs

--- a/src/cargo/util/progress.rs
+++ b/src/cargo/util/progress.rs
@@ -329,64 +329,69 @@ impl Format {
             None => return None,
         };
 
-        let mut progress_bar = String::with_capacity(self.max_width);
-        let hashes = display_width as f64 * pct;
-        let hashes = hashes as usize;
+        let mut progress_bar = String::new();
+        if template.contains("%b") {
+            progress_bar = String::with_capacity(self.max_width);
+            let hashes = display_width as f64 * pct;
+            let hashes = hashes as usize;
 
-        // Draw the `===>`
-        if hashes > 0 {
-            progress_bar.push_str(&"=".repeat(hashes-1));
-            if cur == max {
-                progress_bar.push_str("=");
-            } else {
-                progress_bar.push_str(">");
+            // Draw the `===>`
+            if hashes > 0 {
+                progress_bar.push_str(&"=".repeat(hashes-1));
+                if cur == max {
+                    progress_bar.push_str("=");
+                } else {
+                    progress_bar.push_str(">");
+                }
             }
+
+            // Draw the empty space we have left to do
+            progress_bar.push_str(&" ".repeat(display_width - hashes));
         }
 
-        // Draw the empty space we have left to do
-        progress_bar.push_str(&" ".repeat(display_width - hashes));
-
         let mut jobs_names = String::new();
-        let mut avail_msg_len = self.max_width - (
-                progress_bar.len()
-                + template_skelleton.len()
-                + length_of_formatters
-                + percentage.len()
-                + percentage_int.len()
-                + percentage_char.len()
-                + cur_str.len()
-                + max_str.len()
-                + running_str.len()
-                + 7  /* ?? */);
+        if template.contains("%n") {
+            let mut avail_msg_len = self.max_width - (
+                    progress_bar.len()
+                    + template_skelleton.len()
+                    + length_of_formatters
+                    + percentage.len()
+                    + percentage_int.len()
+                    + percentage_char.len()
+                    + cur_str.len()
+                    + max_str.len()
+                    + running_str.len()
+                    + 7  /* ?? */);
 
-        let mut ellipsis_pos = 0;
-        if avail_msg_len > 3 {
-            for c in msg.chars() {
-                let display_width = c.width().unwrap_or(0);
-                if avail_msg_len >= display_width {
-                    avail_msg_len -= display_width;
-                    jobs_names.push(c);
-                    if avail_msg_len >= 3 {
-                        ellipsis_pos = jobs_names.len();
+            let mut ellipsis_pos = 0;
+            if avail_msg_len > 3 {
+                for c in msg.chars() {
+                    let display_width = c.width().unwrap_or(0);
+                    if avail_msg_len >= display_width {
+                        avail_msg_len -= display_width;
+                        jobs_names.push(c);
+                        if avail_msg_len >= 3 {
+                            ellipsis_pos = jobs_names.len();
+                        }
+                    } else {
+                        jobs_names.truncate(ellipsis_pos);
+                        jobs_names.push_str("...");
+                        break;
                     }
-                } else {
-                    jobs_names.truncate(ellipsis_pos);
-                    jobs_names.push_str("...");
-                    break;
                 }
             }
         }
-        let mut string = template.clone();
-        string = string.replace("%s", &cur_str);
-        string = string.replace("%t", &max_str);
-        string = string.replace("%p", &percentage);
-        string = string.replace("%P", &percentage_int);
-        string = string.replace("%%", &percentage_char);
-        string = string.replace("%b", &progress_bar);
-        string = string.replace("%n", &jobs_names);
-        string = string.replace("%r", &running_str);
+        let mut progress_line = template.clone();
+        progress_line = progress_line.replace("%s", &cur_str);
+        progress_line = progress_line.replace("%t", &max_str);
+        progress_line = progress_line.replace("%p", &percentage);
+        progress_line = progress_line.replace("%P", &percentage_int);
+        progress_line = progress_line.replace("%%", &percentage_char);
+        progress_line = progress_line.replace("%b", &progress_bar);
+        progress_line = progress_line.replace("%n", &jobs_names);
+        progress_line = progress_line.replace("%r", &running_str);
 
-        Some(string)
+        Some(progress_line)
     }
 
     #[inline]

--- a/src/cargo/util/progress.rs
+++ b/src/cargo/util/progress.rs
@@ -41,7 +41,7 @@ impl<'cfg> Progress<'cfg> {
         let format_template: String = match env::var("CARGO_STATUS") {
             Ok(template) => template,
             // if not set, fall back to default
-            Err(_) => String::from("[%b] %s/%t%n"),
+            Err(_) => String::from("[%b] %s/%t: %n"),
         };
 
         // report no progress when -q (for quiet) or TERM=dumb are set
@@ -162,7 +162,7 @@ impl<'cfg> Progress<'cfg> {
 
     pub fn tick_now(&mut self, cur: usize, max: usize, active_names: Vec<String>, render_jobs: bool) -> CargoResult<()> {
         let active = active_names.len();
-        let msg = &format!(": {}", active_names.join(", "));
+        let msg = &active_names.join(", ");
         match self.state {
             Some(ref mut s) => s.tick(cur, max, active, msg, render_jobs),
             None => Ok(()),
@@ -289,9 +289,9 @@ impl Format {
             // remove all the formatting specifiers
             template_skelleton = template_skelleton.replace(fmt, "");
         }
-        let length_of_formatters = template.len() - template_skelleton.len(); // will be 12-4 = 8 for default, "%b%s%t%n".len()
+        let length_of_formatters = template.len() - template_skelleton.len();
 
-        // Render the percentage at the far right and then figure how long the progress bar is
+        // Render the percentage at the far right and then figure how long the progress bar iscustom.compile_progress
         let pct = (cur as f64) / (max as f64);
         let pct = if !pct.is_finite() { 0.0 } else { pct };
 
@@ -411,50 +411,50 @@ impl<'cfg> Drop for State<'cfg> {
 #[test]
 fn test_progress_status() {
     let format = Format {
-        formatting: "[%b] %s/%t%n".to_string(),
-        max_print: 40,
+        formatting: "[%b] %s/%t: %n".to_string(),
+        max_print: 42,
         max_width: 60,
     };
     assert_eq!(
         format.progress_status(0, 4, 1, ""),
-        Some("[                   ] 0/4".to_string())
+        Some("[                   ] 0/4: ".to_string())
     );
     assert_eq!(
         format.progress_status(1, 4, 1, ""),
-        Some("[===>               ] 1/4".to_string())
+        Some("[===>               ] 1/4: ".to_string())
     );
     assert_eq!(
         format.progress_status(2, 4, 1, ""),
-        Some("[========>          ] 2/4".to_string())
+        Some("[========>          ] 2/4: ".to_string())
     );
     assert_eq!(
         format.progress_status(3, 4, 1, ""),
-        Some("[=============>     ] 3/4".to_string())
+        Some("[=============>     ] 3/4: ".to_string())
     );
     assert_eq!(
         format.progress_status(4, 4, 0, ""),
-        Some("[===================] 4/4".to_string())
+        Some("[===================] 4/4: ".to_string())
     );
 
     assert_eq!(
         format.progress_status(3999, 4000, 1, ""),
-        Some("[===========> ] 3999/4000".to_string())
+        Some("[===========> ] 3999/4000: ".to_string())
     );
     assert_eq!(
         format.progress_status(4000, 4000, 0, ""),
-        Some("[=============] 4000/4000".to_string())
+        Some("[=============] 4000/4000: ".to_string())
     );
 
     assert_eq!(
-        format.progress_status(3, 4, 1, ": short message"),
+        format.progress_status(3, 4, 1, "short message"),
         Some("[=============>     ] 3/4: short message".to_string())
     );
     assert_eq!(
-        format.progress_status(3, 4, 1,": msg thats just fit"),
+        format.progress_status(3, 4, 1, "msg thats just fit"),
         Some("[=============>     ] 3/4: msg thats just fit".to_string())
     );
     assert_eq!(
-        format.progress_status(3, 4, 1,": msg that's just fit"),
+        format.progress_status(3, 4, 1, "msg that's just fit"),
         Some("[=============>     ] 3/4: msg that's just...".to_string())
     );
 
@@ -462,61 +462,61 @@ fn test_progress_status() {
     let zalgo_msg = "z̸̧̢̗͉̝̦͍̱ͧͦͨ̑̅̌ͥ́͢a̢ͬͨ̽ͯ̅̑ͥ͋̏̑ͫ̄͢͏̫̝̪̤͎̱̣͍̭̞̙̱͙͍̘̭͚l̶̡̛̥̝̰̭̹̯̯̞̪͇̱̦͙͔̘̼͇͓̈ͨ͗ͧ̓͒ͦ̀̇ͣ̈ͭ͊͛̃̑͒̿̕͜g̸̷̢̩̻̻͚̠͓̞̥͐ͩ͌̑ͥ̊̽͋͐̐͌͛̐̇̑ͨ́ͅo͙̳̣͔̰̠̜͕͕̞̦̙̭̜̯̹̬̻̓͑ͦ͋̈̉͌̃ͯ̀̂͠ͅ ̸̡͎̦̲̖̤̺̜̮̱̰̥͔̯̅̏ͬ̂ͨ̋̃̽̈́̾̔̇ͣ̚͜͜h̡ͫ̐̅̿̍̀͜҉̛͇̭̹̰̠͙̞ẽ̶̙̹̳̖͉͎̦͂̋̓ͮ̔ͬ̐̀͂̌͑̒͆̚͜͠ ͓͓̟͍̮̬̝̝̰͓͎̼̻ͦ͐̾̔͒̃̓͟͟c̮̦͍̺͈͚̯͕̄̒͐̂͊̊͗͊ͤͣ̀͘̕͝͞o̶͍͚͍̣̮͌ͦ̽̑ͩ̅ͮ̐̽̏͗́͂̅ͪ͠m̷̧͖̻͔̥̪̭͉͉̤̻͖̩̤͖̘ͦ̂͌̆̂ͦ̒͊ͯͬ͊̉̌ͬ͝͡e̵̹̣͍̜̺̤̤̯̫̹̠̮͎͙̯͚̰̼͗͐̀̒͂̉̀̚͝͞s̵̲͍͙͖̪͓͓̺̱̭̩̣͖̣ͤͤ͂̎̈͗͆ͨͪ̆̈͗͝͠";
     assert_eq!(
         format.progress_status(3, 4, 1, zalgo_msg),
-        Some("[=============>     ] 3/4".to_string() + zalgo_msg)
+        Some("[=============>     ] 3/4: ".to_string() + zalgo_msg)
     );
 
     // some non-ASCII ellipsize test
     assert_eq!(
-        format.progress_status(3, 4, 1, "_123456789123456e\u{301}\u{301}8\u{301}90a"),
-        Some("[=============>     ] 3/4_123456789123456e\u{301}\u{301}...".to_string())
+        format.progress_status(3, 4, 1, "_1234567891234e\u{301}\u{301}8\u{301}90a"),
+        Some("[=============>     ] 3/4: _1234567891234e\u{301}\u{301}...".to_string())
     );
     assert_eq!(
-        format.progress_status(3, 4, 1, "：每個漢字佔據了兩個字元"),
-        Some("[=============>     ] 3/4：每個漢字佔據了...".to_string())
+        format.progress_status(3, 4, 1, "每個漢字佔據了兩個字元"),
+        Some("[=============>     ] 3/4: 每個漢字佔據了...".to_string())
     );
 }
 
 #[test]
 fn test_progress_status_percentage() {
     let format = Format {
-        formatting: "[%b] %p%n".to_string(),
-        max_print: 40,
+        formatting: "[%b] %p: %n".to_string(),
+        max_print: 42,
         max_width: 60,
     };
     assert_eq!(
-        format.progress_status(0, 77, 1,""),
-        Some("[               ]   0.00%".to_string())
+        format.progress_status(0, 77, 1, ""),
+        Some("[               ]   0.00%: ".to_string())
     );
     assert_eq!(
         format.progress_status(1, 77, 1, ""),
-        Some("[               ]   1.30%".to_string())
+        Some("[               ]   1.30%: ".to_string())
     );
     assert_eq!(
         format.progress_status(76, 77, 1, ""),
-        Some("[=============> ]  98.70%".to_string())
+        Some("[=============> ]  98.70%: ".to_string())
     );
     assert_eq!(
         format.progress_status(77, 77, 1, ""),
-        Some("[===============] 100.00%".to_string())
+        Some("[===============] 100.00%: ".to_string())
     );
 }
 
 #[test]
 fn test_progress_status_too_short() {
     let format = Format {
-        formatting: "[%b] %p%n".to_string(),
-        max_print: 25,
-        max_width: 25,
+        formatting: "[%b] %p: %n".to_string(),
+        max_print: 27,
+        max_width: 27,
     };
     assert_eq!(
         format.progress_status(1, 1, 0, ""),
-        Some("[] 100.00%".to_string())
+        Some("[] 100.00%: ".to_string())
     );
 
     let format = Format {
-         formatting: "[%b] %p%n".to_string(),
-        max_print: 24,
-        max_width: 24,
+        formatting: "[%b] %p: %n".to_string(),
+        max_print: 26,
+        max_width: 26,
     };
     assert_eq!(
         format.progress_status(1, 1, 1, ""),

--- a/src/cargo/util/progress.rs
+++ b/src/cargo/util/progress.rs
@@ -124,7 +124,6 @@ impl<'cfg> Progress<'cfg> {
         }
     }
 
-
     pub fn disable(&mut self) {
         self.state = None;
     }
@@ -137,7 +136,13 @@ impl<'cfg> Progress<'cfg> {
         Self::with_custom_style(name, cfg)
     }
 
-    pub fn tick(&mut self, cur: usize, max: usize, active: usize, render_jobs: bool) -> CargoResult<()> {
+    pub fn tick(
+        &mut self,
+        cur: usize,
+        max: usize,
+        active: usize,
+        render_jobs: bool,
+    ) -> CargoResult<()> {
         let s = match &mut self.state {
             Some(s) => s,
             None => return Ok(()),
@@ -156,13 +161,19 @@ impl<'cfg> Progress<'cfg> {
         //    draw to the console every so often. Currently there's a 100ms
         //    delay between updates.
         if !s.throttle.allowed() {
-            return Ok(())
+            return Ok(());
         }
 
         s.tick(cur, max, active, "", render_jobs)
     }
 
-    pub fn tick_now(&mut self, cur: usize, max: usize, active_names: Vec<String>, render_jobs: bool) -> CargoResult<()> {
+    pub fn tick_now(
+        &mut self,
+        cur: usize,
+        max: usize,
+        active_names: Vec<String>,
+        render_jobs: bool,
+    ) -> CargoResult<()> {
         let active = active_names.len();
         let msg = &active_names.join(", ");
         match self.state {
@@ -204,12 +215,12 @@ impl Throttle {
         if self.first {
             let delay = Duration::from_millis(500);
             if self.last_update.elapsed() < delay {
-                return false
+                return false;
             }
         } else {
             let interval = Duration::from_millis(100);
             if self.last_update.elapsed() < interval {
-                return false
+                return false;
             }
         }
         self.update();
@@ -223,7 +234,14 @@ impl Throttle {
 }
 
 impl<'cfg> State<'cfg> {
-    fn tick(&mut self, cur: usize, max: usize, active: usize, msg: &str, render_jobs: bool) -> CargoResult<()> {
+    fn tick(
+        &mut self,
+        cur: usize,
+        max: usize,
+        active: usize,
+        msg: &str,
+        render_jobs: bool,
+    ) -> CargoResult<()> {
         if self.done {
             return Ok(());
         }
@@ -247,7 +265,7 @@ impl<'cfg> State<'cfg> {
 
         // make sure we have enough room for the header
         if self.format.max_width < 15 {
-            return Ok(())
+            return Ok(());
         }
         self.config.shell().status_header(&self.name)?;
         let mut line = prefix.to_string();
@@ -291,8 +309,9 @@ impl Format {
         // %n list of names of running jobs
 
         let template = &self.formatting; // what the formatting is supposed to look like
-         // what is left if we remove all dynamic parameters
-         // will be "[] /: " for default formatting of "[%b] %f/%t: %n"
+
+        // what is left if we remove all dynamic parameters
+        // will be "[] /: " for default formatting of "[%b] %f/%t: %n"
         let mut template_skelleton = template.to_string();
         for fmt in &["%b", "%f", "%t", "%p", "%P", "%%", "%n", "%r", "%s", "%u"] {
             // remove all the formatting specifiers
@@ -300,23 +319,54 @@ impl Format {
         }
         let length_of_formatters = template.len() - template_skelleton.len();
 
-        // Render the percentage at the far right and then figure how long the progress bar iscustom.compile_progress
+        // Render the percentage at the far right and then figure how long the progress bar is
         let pct = (cur as f64) / (max as f64);
         let pct = if !pct.is_finite() { 0.0 } else { pct };
-        let started_str = if template.contains("%s") { (cur + active).to_string() } else { String::new() };
-        let remaining_str = if template.contains("%s") { (max - (cur + active)).to_string() } else { String::new() };
-        let percentage = if template.contains("%p") { format!("{:6.02}", pct * 100.0) } else { String::new() };
-        let percentage_int = if template.contains("%P") { format!("{:4}", (pct * 100.0) as i8 ) } else { String::new() };
-        let percentage_char = if template.contains("%%") { "%".to_string() } else { String::new() };
-        let cur_str = if template.contains("%f") { cur.to_string() } else { String::new() };
-        let max_str = if template.contains("%t") { max.to_string() } else { String::new() };
-        let running_str = if template.contains("%r") { active.to_string() } else { String::new() };
+        let started_str = if template.contains("%s") {
+            (cur + active).to_string()
+        } else {
+            String::new()
+        };
+        let remaining_str = if template.contains("%s") {
+            (max - (cur + active)).to_string()
+        } else {
+            String::new()
+        };
+        let percentage = if template.contains("%p") {
+            format!("{:6.02}", pct * 100.0)
+        } else {
+            String::new()
+        };
+        let percentage_int = if template.contains("%P") {
+            format!("{:4}", (pct * 100.0) as i8)
+        } else {
+            String::new()
+        };
+        let percentage_char = if template.contains("%%") {
+            "%".to_string()
+        } else {
+            String::new()
+        };
+        let cur_str = if template.contains("%f") {
+            cur.to_string()
+        } else {
+            String::new()
+        };
+        let max_str = if template.contains("%t") {
+            max.to_string()
+        } else {
+            String::new()
+        };
+        let running_str = if template.contains("%r") {
+            active.to_string()
+        } else {
+            String::new()
+        };
         // compile status default looks like this
         //      Building [=====>                    ] 30/128:
         // |____________|||________________________||| ||    \_
         // status header |    progress bar          `|cur`fmt  max
         // passed via formatting          both passed via formatting
-
 
         const STATUS_HEADER_LEN: usize = 15;
         // extra_len is everything without the progress bar and without the jobs_names
@@ -346,7 +396,7 @@ impl Format {
 
             // Draw the `===>`
             if hashes > 0 {
-                progress_bar.push_str(&"=".repeat(hashes-1));
+                progress_bar.push_str(&"=".repeat(hashes - 1));
                 if cur == max {
                     progress_bar.push_str("=");
                 } else {
@@ -360,8 +410,8 @@ impl Format {
 
         let mut jobs_names = String::new();
         if template.contains("%n") {
-            let mut avail_msg_len = self.max_width - (
-                    progress_bar.len()
+            let mut avail_msg_len = self.max_width
+                - (progress_bar.len()
                     + template_skelleton.len()
                     + length_of_formatters
                     + percentage.len()
@@ -372,7 +422,7 @@ impl Format {
                     + running_str.len()
                     + started_str.len()
                     + remaining_str.len()
-                    + 7  /* ?? */);
+                    + 7);
 
             let mut ellipsis_pos = 0;
             if avail_msg_len > 3 {
@@ -392,18 +442,17 @@ impl Format {
                 }
             }
         }
-        let mut progress_line = template.clone();
-        progress_line = progress_line.replace("%f", &cur_str);
-        progress_line = progress_line.replace("%t", &max_str);
-        progress_line = progress_line.replace("%p", &percentage);
-        progress_line = progress_line.replace("%P", &percentage_int);
-        progress_line = progress_line.replace("%%", &percentage_char);
-        progress_line = progress_line.replace("%b", &progress_bar);
-        progress_line = progress_line.replace("%n", &jobs_names);
-        progress_line = progress_line.replace("%r", &running_str);
-        progress_line = progress_line.replace("%s", &started_str);
-        progress_line = progress_line.replace("%u", &remaining_str);
-
+        let progress_line = template
+            .replace("%f", &cur_str)
+            .replace("%t", &max_str)
+            .replace("%p", &percentage)
+            .replace("%P", &percentage_int)
+            .replace("%%", &percentage_char)
+            .replace("%b", &progress_bar)
+            .replace("%n", &jobs_names)
+            .replace("%r", &running_str)
+            .replace("%s", &started_str)
+            .replace("%u", &remaining_str);
 
         Some(progress_line)
     }
@@ -413,7 +462,7 @@ impl Format {
         let mut avail_msg_len = self.max_width - string.len() - 15;
         let mut ellipsis_pos = 0;
         if avail_msg_len <= 3 {
-            return
+            return;
         }
         for c in msg.chars() {
             let display_width = c.width().unwrap_or(0);
@@ -558,8 +607,5 @@ fn test_progress_status_too_short() {
         max_print: 26,
         max_width: 26,
     };
-    assert_eq!(
-        format.progress_status(1, 1, 1, ""),
-        None
-    );
+    assert_eq!(format.progress_status(1, 1, 1, ""), None);
 }

--- a/src/cargo/util/progress.rs
+++ b/src/cargo/util/progress.rs
@@ -274,10 +274,11 @@ impl<'cfg> State<'cfg> {
 }
 
 impl Format {
-    fn progress(&self, cur: usize, max: usize, _active: usize, msg: &str) -> Option<String> {
+    fn progress(&self, cur: usize, max: usize, active: usize, msg: &str) -> Option<String> {
         // %b progress bar
         // %s number of done jobs
         // %t number of total jobs
+        // %r number of active (currently running) jobs
         // %p progress percentage
         // %n list of names of running jobs
 
@@ -285,7 +286,7 @@ impl Format {
          // what is left if we remove all dynamic parameters
          // will be "[] /" for default formatting of "[%b] %s/%t%n"
         let mut template_skelleton = template.to_string();
-        for fmt in &["%b", "%s", "%t", "%p", "%n"] {
+        for fmt in &["%b", "%s", "%t", "%p", "%n", "%r"] {
             // remove all the formatting specifiers
             template_skelleton = template_skelleton.replace(fmt, "");
         }
@@ -303,11 +304,14 @@ impl Format {
         // passed via formatting          both passed via formatting
         let cur_str = if template.contains("%s") { cur.to_string() } else { String::new() };
         let max_str = if template.contains("%t") { max.to_string() } else { String::new() };
+        let running_str = if template.contains("%r") { active.to_string() } else { String::new() };
+
         const STATUS_HEADER_LEN: usize = 15;
         // extra_len is everything without the progress bar and without the jobs_names
-        let extra_len =  STATUS_HEADER_LEN + percentage.len() + cur_str.len() + max_str.len()  + /* all other fmt chars: */ template_skelleton.len();
-        // display_width will determine the length of the progress bar
+        let extra_len = STATUS_HEADER_LEN + percentage.len() + cur_str.len() + max_str.len()
+                        + running_str.len() + /* all other fmt chars: */ template_skelleton.len();
 
+        // display_width will determine the length of the progress bar
         let display_width = match self.width().checked_sub(extra_len) {
             Some(n) => n,
             None => return None,
@@ -338,6 +342,7 @@ impl Format {
                 + percentage.len()
                 + cur_str.len()
                 + max_str.len()
+                + running_str.len()
                 + 7  /* ?? */);
 
         let mut ellipsis_pos = 0;
@@ -363,7 +368,7 @@ impl Format {
         string = string.replace("%p", &percentage);
         string = string.replace("%b", &progress_bar);
         string = string.replace("%n", &jobs_names);
-
+        string = string.replace("%r", &running_str);
 
         Some(string)
     }

--- a/src/doc/src/reference/environment-variables.md
+++ b/src/doc/src/reference/environment-variables.md
@@ -48,6 +48,11 @@ system:
     * `%P`  progress percentage without decimals
     * `%%`  plain `%` character (can be used for `%P%%` => `14%`)
     * `%n`  (truncated) list of names of running jobs
+    * `%e`  elapsed time in seconds
+    * `%E`  elasped time in seconds (human readable)
+    * `%o`  overall time per job
+    * `%O`  overall time per job (human readable)
+    * `%c`  jobs per second
     Note that `%%` is evaluated last so `%%s` will be evaluated as `%2` and not `%s`
 
 Note that Cargo will also read environment variables for `.cargo/config`

--- a/src/doc/src/reference/environment-variables.md
+++ b/src/doc/src/reference/environment-variables.md
@@ -34,6 +34,20 @@ system:
   will otherwise be used.
 * `CARGO_CACHE_RUSTC_INFO` — If this is set to 0 then Cargo will not try to cache
   compiler version information.
+* `CARGO_STATUS` — If this is set, cargo will read it as compile progress template.
+  The default format is `[%b] %f/%t: %n` which will looke like this:
+  ` Building [=====>      ] 115/145: libssh2-sys(build), thread_l...`
+  The following parameters are supported:
+    * `%b`  progress bar `=======>`
+    * `%s`  number of started jobs
+    * `%f`  number of finished jobs
+    * `%t`  number of total jobs of the build
+    * `%u`  number or remaining jobs to start
+    * `%r`  number of active (currently running) jobs
+    * `%p`  progress percentage with decimals
+    * `%P`  progress percentage without decimals
+    * `%%`  plain `%` character (can be used for `%P%%` => `14%`)
+    * `%n`  (truncated) list of names of running jobs
 
 Note that Cargo will also read environment variables for `.cargo/config`
 configuration values, as described in [that documentation][config-env]

--- a/src/doc/src/reference/environment-variables.md
+++ b/src/doc/src/reference/environment-variables.md
@@ -48,6 +48,7 @@ system:
     * `%P`  progress percentage without decimals
     * `%%`  plain `%` character (can be used for `%P%%` => `14%`)
     * `%n`  (truncated) list of names of running jobs
+    Note that `%%` is evaluated last so `%%s` will be evaluated as `%2` and not `%s`
 
 Note that Cargo will also read environment variables for `.cargo/config`
 configuration values, as described in [that documentation][config-env]

--- a/src/doc/src/reference/environment-variables.md
+++ b/src/doc/src/reference/environment-variables.md
@@ -35,7 +35,7 @@ system:
 * `CARGO_CACHE_RUSTC_INFO` — If this is set to 0 then Cargo will not try to cache
   compiler version information.
 * `CARGO_STATUS` — If this is set, cargo will read it as compile progress template.
-  The default format is `[%b] %f/%t: %n` which will looke like this:
+  The default format is `[%b] %f/%t: %n` which will look like this:
   ` Building [=====>      ] 115/145: libssh2-sys(build), thread_l...`
   The following parameters are supported:
     * `%b`  progress bar `=======>`


### PR DESCRIPTION
Allows to customize the compile progress via env var.
This was inspired by `NINJA_STATUS` environmental variable:
https://ninja-build.org/manual.html#_environment_variables

I had to add some workarounds to make sure the `CARGO_STATUS` var does not mess with the git fetch/crate download progress indicators.
Right now this should only change the output of "cargo build/check"

Docs from the readme:

 `CARGO_STATUS` — If this is set, cargo will read it as compile progress template.
  The default format is `[%b] %f/%t: %n` which will look like this:
  ` Building [=====>      ] 115/145: libssh2-sys(build), thread_l...`
  The following parameters are supported:
    * `%b`  progress bar `=======>`
    * `%s`  number of started jobs
    * `%f`  number of finished jobs
    * `%t`  number of total jobs of the build
    * `%u`  number or remaining jobs to start
    * `%r`  number of active (currently running) jobs
    * `%p`  progress percentage with decimals
    * `%P`  progress percentage without decimals
    * `%%`  plain `%` character (can be used for `%P%%` => `14%`)
    * `%n`  (truncated) list of names of running jobs
    * `%e`  elapsed time in seconds
    * `%E`  elapsed time in seconds (human readable)
    * `%o`  overall time per job
    * `%O`  overall time per job (human readable)
    * `%c`  jobs per second


