### PR TITLE
cargo version: support --verbose

### DIFF
--- a/src/bin/cargo/cli.rs
+++ b/src/bin/cargo/cli.rs
@@ -42,20 +42,8 @@ Run with 'cargo -Z [FLAG] [SUBCOMMAND]'"
 
     let is_verbose = args.occurrences_of("verbose") > 0;
     if args.is_present("version") {
-        let version = cargo::version();
-        println!("{}", version);
-        if is_verbose {
-            println!(
-                "release: {}.{}.{}",
-                version.major, version.minor, version.patch
-            );
-            if let Some(ref cfg) = version.cfg_info {
-                if let Some(ref ci) = cfg.commit_info {
-                    println!("commit-hash: {}", ci.commit_hash);
-                    println!("commit-date: {}", ci.commit_date);
-                }
-            }
-        }
+        let version = get_version_string(is_verbose);
+        print!("{}", version);
         return Ok(());
     }
 
@@ -89,6 +77,25 @@ Run with 'cargo -Z [FLAG] [SUBCOMMAND]'"
     let args = expand_aliases(config, args)?;
 
     execute_subcommand(config, &args)
+}
+
+pub fn get_version_string(is_verbose: bool) -> String {
+    let version = cargo::version();
+    let mut version_string = String::from(version.to_string());
+    version_string.push_str("\n");
+    if is_verbose {
+        version_string.push_str(&format!(
+            "release: {}.{}.{}\n",
+            version.major, version.minor, version.patch
+        ));
+        if let Some(ref cfg) = version.cfg_info {
+            if let Some(ref ci) = cfg.commit_info {
+                version_string.push_str(&format!("commit-hash: {}\n", ci.commit_hash));
+                version_string.push_str(&format!("commit-date: {}\n", ci.commit_date));
+            }
+        }
+    }
+    version_string
 }
 
 fn expand_aliases(

--- a/src/bin/cargo/commands/version.rs
+++ b/src/bin/cargo/commands/version.rs
@@ -1,12 +1,14 @@
 use command_prelude::*;
 
-use cargo;
+use cli;
 
 pub fn cli() -> App {
     subcommand("version").about("Show version information")
 }
 
-pub fn exec(_config: &mut Config, _args: &ArgMatches) -> CliResult {
-    println!("{}", cargo::version());
+pub fn exec(_config: &mut Config, args: &ArgMatches) -> CliResult {
+    let verbose = args.occurrences_of("verbose") > 0;
+    let version = cli::get_version_string(verbose);
+    print!("{}", version);
     Ok(())
 }


### PR DESCRIPTION
make obtaining of the version output an own function and use it in the "version" subcommand

makes "cargo version -v" work equivalent to "cargo -Vv"