### PR TITLE
job queue: remove outdated comment about reenabling compile-progress once #5695 is fixed

### DIFF
--- a/src/cargo/core/compiler/job_queue.rs
+++ b/src/cargo/core/compiler/job_queue.rs
@@ -225,17 +225,6 @@ impl<'a> JobQueue<'a> {
         // After a job has finished we update our internal state if it was
         // successful and otherwise wait for pending work to finish if it failed
         // and then immediately return.
-        //
-        // TODO: the progress bar should be re-enabled but unfortunately it's
-        //       difficult to do so right now due to how compiler error messages
-        //       work. Cargo doesn't redirect stdout/stderr of compiler
-        //       processes so errors are not captured, and Cargo doesn't know
-        //       when an error is being printed, meaning that a progress bar
-        //       will get jumbled up in the output! To reenable this progress
-        //       bar we'll need to probably capture the stderr of rustc and
-        //       capture compiler error messages, but that also means
-        //       reproducing rustc's styling of error messages which is
-        //       currently a pretty big task. This is issue #5695.
         let mut error = None;
         let mut progress = Progress::with_style("Building", ProgressStyle::Ratio, cx.bcx.config);
         let total = self.queue.len();


### PR DESCRIPTION
The issue has been resolved and the compile-progress has been reenabled already.