### PR TITLE
Fix missing messages when --message-format=json is deeply nested

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ semver = { version = "0.9.0", features = ["serde"] }
 serde = "1.0"
 serde_derive = "1.0"
 serde_ignored = "0.0.4"
-serde_json = "1.0.24"
+serde_json = { version = "1.0.30", features = ["raw_value"] }
 shell-escape = "0.1.4"
 tar = { version = "0.4.15", default-features = false }
 tempfile = "3.0"

--- a/src/cargo/util/machine_message.rs
+++ b/src/cargo/util/machine_message.rs
@@ -1,5 +1,5 @@
 use serde::ser;
-use serde_json::{self, Value};
+use serde_json::{self, value::RawValue};
 
 use core::{PackageId, Target};
 
@@ -8,16 +8,17 @@ pub trait Message: ser::Serialize {
 }
 
 pub fn emit<T: Message>(t: &T) {
-    let mut json: Value = serde_json::to_value(t).unwrap();
-    json["reason"] = json!(t.reason());
-    println!("{}", json);
+    let json = serde_json::to_string(t).unwrap();
+    assert!(json.starts_with("{\""));
+    let reason = json!(t.reason());
+    println!("{{\"reason\":{},{}", reason, &json[1..]);
 }
 
 #[derive(Serialize)]
 pub struct FromCompiler<'a> {
     pub package_id: &'a PackageId,
     pub target: &'a Target,
-    pub message: serde_json::Value,
+    pub message: Box<RawValue>,
 }
 
 impl<'a> Message for FromCompiler<'a> {


### PR DESCRIPTION
This commit switches from `serde_json::Value` to [`RawValue`](https://docs.rs/serde_json/1.0/serde_json/value/struct.RawValue.html), which can process arbitrarily deeply nested JSON content without recursion.

Fixes #5992. @ehuss