### PR TITLE
Fix build plan output when a package has dependencies not used in the active configuration

### DIFF
--- a/src/cargo/core/compiler/context/mod.rs
+++ b/src/cargo/core/compiler/context/mod.rs
@@ -515,8 +515,9 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
     pub fn inputs(&self) -> CargoResult<Vec<PathBuf>> {
         let mut inputs = Vec::new();
         for id in self.bcx.packages.package_ids() {
-            let pkg = self.get_package(id)?;
-            inputs.push(pkg.manifest_path().to_path_buf());
+            if let Ok(pkg) = self.get_package(id) {
+                inputs.push(pkg.manifest_path().to_path_buf());
+            }
         }
         inputs.sort();
         Ok(inputs)


### PR DESCRIPTION
44a7ee7db8621c33b4ff519be98343f95dbc5ba6 introduced an issue when outputing a
build plan for a package with some dependencies that aren't used in the built
configuration: the machinery to download/populate packages doesn't bother for
packages that aren't going to be built, but the code to calculate inputs for
the sake of the build plan iterates over all the packages in the graph, and
panics if it can't find one. This commit makes us ignore the case a package
isn't found in the build map, as it's presumably not going to be built as a
consequence, and anyone consuming the build map wont care about inputs relevant
to that package.