### PR TITLE
Explicitly configure `noproxy` support in Curl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ bytesize = "1.0"
 crates-io = { path = "src/crates-io", version = "0.20" }
 crossbeam-utils = "0.5"
 crypto-hash = "0.3.1"
-curl = { version = "0.4.17", features = ['http2'] }
+curl = { version = "0.4.18", features = ['http2'] }
 env_logger = "0.5.11"
 failure = "0.1.2"
 filetime = "0.2"

--- a/src/cargo/ops/registry.rs
+++ b/src/cargo/ops/registry.rs
@@ -388,6 +388,14 @@ pub fn configure_http_handle(config: &Config, handle: &mut Easy) -> CargoResult<
     } else {
         handle.useragent(&version().to_string())?;
     }
+
+    let noproxy = env::var("NO_PROXY").ok()
+        .or_else(|| env::var("no_proxy").ok())
+        .or(config.get::<Option<Vec<String>>>("http.noproxy")?.map(|s| s.join(",")));
+    if let Some(noproxy) = noproxy {
+        handle.noproxy(&noproxy)
+            .chain_err(|| "malformed `noproxy` configuration")?;
+    }
     Ok(())
 }
 

--- a/src/doc/src/reference/config.md
+++ b/src/doc/src/reference/config.md
@@ -103,6 +103,9 @@ check-revoke = true # Indicates whether SSL certs are checked for revocation
 low-speed-limit = 5 # Lower threshold for bytes/sec (10 = default, 0 = disabled)
 multiplexing = false  # whether or not to use HTTP/2 multiplexing where possible
 
+# A list of hosts which do not use the proxy configuration, if any.
+noproxy = ['github.com']
+
 [build]
 jobs = 1                  # number of parallel jobs, defaults to # of CPUs
 rustc = "rustc"           # the rust compiler tool

--- a/src/doc/src/reference/environment-variables.md
+++ b/src/doc/src/reference/environment-variables.md
@@ -34,6 +34,8 @@ system:
   will otherwise be used.
 * `CARGO_CACHE_RUSTC_INFO` — If this is set to 0 then Cargo will not try to cache
   compiler version information.
+* `HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY` - these variables are all ready by
+  Cargo and correspond to proxy configuration for HTTP trafic.
 
 Note that Cargo will also read environment variables for `.cargo/config`
 configuration values, as described in [that documentation][config-env]


### PR DESCRIPTION
Apparently if we don't do it then our configuration otherwise means it
won't automatically get picked up!

Closes #6114