### PR TITLE
Fix timeouts firing while tarballs are extracted 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ crates-io = { path = "src/crates-io", version = "0.20" }
 crossbeam-utils = "0.5"
 crypto-hash = "0.3.1"
 curl = { version = "0.4.17", features = ['http2'] }
+curl-sys = "0.4.12"
 env_logger = "0.5.11"
 failure = "0.1.2"
 filetime = "0.2"

--- a/src/cargo/core/package.rs
+++ b/src/cargo/core/package.rs
@@ -619,7 +619,9 @@ impl<'a, 'cfg> Downloads<'a, 'cfg> {
                 break Ok(pair)
             }
             assert!(self.pending.len() > 0);
-            self.set.multi.wait(&mut [], Duration::new(60, 0))
+            let timeout = self.set.multi.get_timeout()?
+                .unwrap_or(Duration::new(5, 0));
+            self.set.multi.wait(&mut [], timeout)
                 .chain_err(|| "failed to wait on curl `Multi`")?;
         }
     }

--- a/src/cargo/lib.rs
+++ b/src/cargo/lib.rs
@@ -22,6 +22,7 @@ extern crate core_foundation;
 extern crate crates_io as registry;
 extern crate crossbeam_utils;
 extern crate curl;
+extern crate curl_sys;
 #[macro_use]
 extern crate failure;
 extern crate filetime;

--- a/src/cargo/ops/mod.rs
+++ b/src/cargo/ops/mod.rs
@@ -15,7 +15,8 @@ pub use self::cargo_package::{package, PackageOpts};
 pub use self::registry::{publish, registry_configuration, RegistryConfig};
 pub use self::registry::{http_handle, needs_custom_http_transport, registry_login, search};
 pub use self::registry::{modify_owners, yank, OwnersOptions, PublishOpts};
-pub use self::registry::configure_http_handle;
+pub use self::registry::{configure_http_handle, http_handle_and_timeout};
+pub use self::registry::HttpTimeout;
 pub use self::cargo_fetch::{fetch, FetchOptions};
 pub use self::cargo_pkgid::pkgid;
 pub use self::resolve::{add_overrides, get_resolved_packages, resolve_with_previous, resolve_ws,

--- a/src/cargo/ops/registry.rs
+++ b/src/cargo/ops/registry.rs
@@ -330,6 +330,12 @@ pub fn registry(
 
 /// Create a new HTTP handle with appropriate global configuration for cargo.
 pub fn http_handle(config: &Config) -> CargoResult<Easy> {
+    let (mut handle, timeout) = http_handle_and_timeout(config)?;
+    timeout.configure(&mut handle)?;
+    Ok(handle)
+}
+
+pub fn http_handle_and_timeout(config: &Config) -> CargoResult<(Easy, HttpTimeout)> {
     if config.frozen() {
         bail!(
             "attempting to make an HTTP request, but --frozen was \
@@ -345,33 +351,26 @@ pub fn http_handle(config: &Config) -> CargoResult<Easy> {
     // connect phase as well as a "low speed" timeout so if we don't receive
     // many bytes in a large-ish period of time then we time out.
     let mut handle = Easy::new();
-    configure_http_handle(config, &mut handle)?;
-    Ok(handle)
+    let timeout = configure_http_handle(config, &mut handle)?;
+    Ok((handle, timeout))
 }
 
 pub fn needs_custom_http_transport(config: &Config) -> CargoResult<bool> {
     let proxy_exists = http_proxy_exists(config)?;
-    let timeout = http_timeout(config)?;
+    let timeout = HttpTimeout::new(config)?.is_non_default();
     let cainfo = config.get_path("http.cainfo")?;
     let check_revoke = config.get_bool("http.check-revoke")?;
     let user_agent = config.get_string("http.user-agent")?;
 
     Ok(proxy_exists
-        || timeout.is_some()
+        || timeout
         || cainfo.is_some()
         || check_revoke.is_some()
         || user_agent.is_some())
 }
 
 /// Configure a libcurl http handle with the defaults options for Cargo
-pub fn configure_http_handle(config: &Config, handle: &mut Easy) -> CargoResult<()> {
-    // The timeout option for libcurl by default times out the entire transfer,
-    // but we probably don't want this. Instead we only set timeouts for the
-    // connect phase as well as a "low speed" timeout so if we don't receive
-    // many bytes in a large-ish period of time then we time out.
-    handle.connect_timeout(Duration::new(30, 0))?;
-    handle.low_speed_time(Duration::new(30, 0))?;
-    handle.low_speed_limit(http_low_speed_limit(config)?)?;
+pub fn configure_http_handle(config: &Config, handle: &mut Easy) -> CargoResult<HttpTimeout> {
     if let Some(proxy) = http_proxy(config)? {
         handle.proxy(&proxy)?;
     }
@@ -380,10 +379,6 @@ pub fn configure_http_handle(config: &Config, handle: &mut Easy) -> CargoResult<
     }
     if let Some(check) = config.get_bool("http.check-revoke")? {
         handle.ssl_options(SslOpt::new().no_revoke(!check.val))?;
-    }
-    if let Some(timeout) = http_timeout(config)? {
-        handle.connect_timeout(Duration::new(timeout as u64, 0))?;
-        handle.low_speed_time(Duration::new(timeout as u64, 0))?;
     }
     if let Some(user_agent) = config.get_string("http.user-agent")? {
         handle.useragent(&user_agent.val)?;
@@ -416,15 +411,44 @@ pub fn configure_http_handle(config: &Config, handle: &mut Easy) -> CargoResult<
             }
         })?;
     }
-    Ok(())
+
+    HttpTimeout::new(config)
 }
 
-/// Find an override from config for curl low-speed-limit option, otherwise use default value
-fn http_low_speed_limit(config: &Config) -> CargoResult<u32> {
-    if let Some(s) = config.get::<Option<u32>>("http.low-speed-limit")? {
-        return Ok(s);
+#[must_use]
+pub struct HttpTimeout {
+    pub dur: Duration,
+    pub low_speed_limit: u32,
+}
+
+impl HttpTimeout {
+    pub fn new(config: &Config) -> CargoResult<HttpTimeout> {
+        let low_speed_limit = config.get::<Option<u32>>("http.low-speed-limit")?
+            .unwrap_or(10);
+        let seconds = config.get::<Option<u64>>("http.timeout")?
+            .or_else(|| env::var("HTTP_TIMEOUT").ok().and_then(|s| s.parse().ok()))
+            .unwrap_or(30);
+        Ok(HttpTimeout {
+            dur: Duration::new(seconds, 0),
+            low_speed_limit,
+        })
     }
-    Ok(10)
+
+    fn is_non_default(&self) -> bool {
+        self.dur != Duration::new(30, 0) || self.low_speed_limit != 10
+    }
+
+    pub fn configure(&self, handle: &mut Easy) -> CargoResult<()> {
+        // The timeout option for libcurl by default times out the entire
+        // transfer, but we probably don't want this. Instead we only set
+        // timeouts for the connect phase as well as a "low speed" timeout so
+        // if we don't receive many bytes in a large-ish period of time then we
+        // time out.
+        handle.connect_timeout(self.dur)?;
+        handle.low_speed_time(self.dur)?;
+        handle.low_speed_limit(self.low_speed_limit)?;
+        Ok(())
+    }
 }
 
 /// Find an explicit HTTP proxy if one is available.
@@ -461,13 +485,6 @@ fn http_proxy_exists(config: &Config) -> CargoResult<bool> {
             .iter()
             .any(|v| env::var(v).is_ok()))
     }
-}
-
-fn http_timeout(config: &Config) -> CargoResult<Option<i64>> {
-    if let Some(s) = config.get_i64("http.timeout")? {
-        return Ok(Some(s.val));
-    }
-    Ok(env::var("HTTP_TIMEOUT").ok().and_then(|s| s.parse().ok()))
 }
 
 pub fn registry_login(config: &Config, token: String, registry: Option<String>) -> CargoResult<()> {

--- a/src/cargo/util/config.rs
+++ b/src/cargo/util/config.rs
@@ -780,7 +780,8 @@ impl Config {
         {
             let mut http = http.borrow_mut();
             http.reset();
-            ops::configure_http_handle(self, &mut http)?;
+            let timeout = ops::configure_http_handle(self, &mut http)?;
+            timeout.configure(&mut http)?;
         }
         Ok(http)
     }

--- a/src/cargo/util/network.rs
+++ b/src/cargo/util/network.rs
@@ -47,9 +47,11 @@ fn maybe_spurious(err: &Error) -> bool {
             }
         }
         if let Some(curl_err) = e.downcast_ref::<curl::Error>() {
-            if curl_err.is_couldnt_connect() || curl_err.is_couldnt_resolve_proxy()
+            if curl_err.is_couldnt_connect()
+                || curl_err.is_couldnt_resolve_proxy()
                 || curl_err.is_couldnt_resolve_host()
-                || curl_err.is_operation_timedout() || curl_err.is_recv_error()
+                || curl_err.is_operation_timedout()
+                || curl_err.is_recv_error()
             {
                 return true;
             }


### PR DESCRIPTION
This commit fixes #6125 by ensuring that while we're extracting tarballs
or doing other synchronous work like grabbing file locks we're not
letting the timeout timers of each HTTP transfer keep ticking. This is
curl's default behavior (which we don't want in this scenario). Instead
the timeout logic is inlined directly and we manually account for the
synchronous work happening not counting towards timeout limits.

Closes #6125