### PR TITLE
Add support for a default registry for cargo commands

### DIFF
--- a/src/bin/cargo/command_prelude.rs
+++ b/src/bin/cargo/command_prelude.rs
@@ -360,9 +360,22 @@ pub trait ArgMatchesExt {
                          requires -Zunstable-options to use."
                     ));
                 }
-                Ok(Some(registry.to_string()))
+
+                if registry == "crates.io" {
+                    // If "crates.io" is specified then we just need to return None
+                    // as that will cause cargo to use crates.io. This is required
+                    // for the case where a default alterative registry is used
+                    // but the user wants to switch back to crates.io for a single
+                    // command.
+                    Ok(None)
+                }
+                else {
+                    Ok(Some(registry.to_string()))                    
+                }
             }
-            None => Ok(None),
+            None => {
+                config.default_registry()
+            }
         }
     }
 

--- a/src/bin/cargo/command_prelude.rs
+++ b/src/bin/cargo/command_prelude.rs
@@ -6,6 +6,7 @@ use cargo::CargoResult;
 use cargo::core::Workspace;
 use cargo::core::compiler::{BuildConfig, MessageFormat};
 use cargo::ops::{CompileFilter, CompileOptions, NewOptions, Packages, VersionControl};
+use cargo::sources::CRATES_IO_REGISTRY;
 use cargo::util::paths;
 use cargo::util::important_paths::find_root_manifest_for_wd;
 
@@ -361,7 +362,7 @@ pub trait ArgMatchesExt {
                     ));
                 }
 
-                if registry == "crates.io" {
+                if registry == CRATES_IO_REGISTRY {
                     // If "crates.io" is specified then we just need to return None
                     // as that will cause cargo to use crates.io. This is required
                     // for the case where a default alterative registry is used

--- a/src/bin/cargo/command_prelude.rs
+++ b/src/bin/cargo/command_prelude.rs
@@ -347,6 +347,7 @@ pub trait ArgMatchesExt {
             self.value_of_path("path", config).unwrap(),
             self._value_of("name").map(|s| s.to_string()),
             self._value_of("edition").map(|s| s.to_string()),
+            self.registry(config)?,
         )
     }
 

--- a/src/bin/cargo/commands/init.rs
+++ b/src/bin/cargo/commands/init.rs
@@ -6,6 +6,7 @@ pub fn cli() -> App {
     subcommand("init")
         .about("Create a new cargo package in an existing directory")
         .arg(Arg::with_name("path").default_value("."))
+        .arg(opt("registry", "Registry to use").value_name("REGISTRY"))
         .arg_new_opts()
 }
 

--- a/src/bin/cargo/commands/new.rs
+++ b/src/bin/cargo/commands/new.rs
@@ -6,6 +6,7 @@ pub fn cli() -> App {
     subcommand("new")
         .about("Create a new cargo package at <path>")
         .arg(Arg::with_name("path").required(true))
+        .arg(opt("registry", "Registry to use").value_name("REGISTRY"))
         .arg_new_opts()
 }
 

--- a/src/cargo/core/package_id.rs
+++ b/src/cargo/core/package_id.rs
@@ -182,12 +182,12 @@ impl fmt::Debug for PackageId {
 mod tests {
     use super::PackageId;
     use core::source::SourceId;
-    use sources::CRATES_IO;
+    use sources::CRATES_IO_INDEX;
     use util::ToUrl;
 
     #[test]
     fn invalid_version_handled_nicely() {
-        let loc = CRATES_IO.to_url().unwrap();
+        let loc = CRATES_IO_INDEX.to_url().unwrap();
         let repo = SourceId::for_registry(&loc).unwrap();
 
         assert!(PackageId::new("foo", "1.0", &repo).is_err());

--- a/src/cargo/core/source/source_id.rs
+++ b/src/cargo/core/source/source_id.rs
@@ -12,7 +12,7 @@ use url::Url;
 
 use ops;
 use sources::git;
-use sources::{GitSource, PathSource, RegistrySource, CRATES_IO};
+use sources::{GitSource, PathSource, RegistrySource, CRATES_IO_INDEX};
 use sources::DirectorySource;
 use util::{CargoResult, Config, ToUrl};
 
@@ -184,7 +184,7 @@ impl SourceId {
                 }
                 &index[..]
             } else {
-                CRATES_IO
+                CRATES_IO_INDEX
             };
             let url = url.to_url()?;
             SourceId::for_registry(&url)
@@ -302,7 +302,7 @@ impl SourceId {
             Kind::Registry => {}
             _ => return false,
         }
-        self.inner.url.to_string() == CRATES_IO
+        self.inner.url.to_string() == CRATES_IO_INDEX
     }
 
     /// Hash `self`

--- a/src/cargo/ops/cargo_new.rs
+++ b/src/cargo/ops/cargo_new.rs
@@ -543,8 +543,7 @@ name = "{}"
 version = "0.1.0"
 authors = [{}]
 edition = {}
-publish = {}
-
+{}
 [dependencies]
 {}"#,
             name,
@@ -554,8 +553,12 @@ publish = {}
                 None => toml::Value::String("2018".to_string()),
             },
             match opts.registry {
-                Some(registry) => toml::Value::Array(vec!(toml::Value::String(registry.to_string()))),
-                None => toml::Value::Boolean(true),
+                Some(registry) => {
+                    format!("publish = {}\n",
+                        toml::Value::Array(vec!(toml::Value::String(registry.to_string())))
+                    )
+                }
+                None => "".to_string(),
             }, 
             cargotoml_path_specifier
         ).as_bytes(),

--- a/src/cargo/sources/config.rs
+++ b/src/cargo/sources/config.rs
@@ -10,7 +10,7 @@ use std::path::{Path, PathBuf};
 use url::Url;
 
 use core::{GitReference, Source, SourceId};
-use sources::ReplacedSource;
+use sources::{ReplacedSource, CRATES_IO_REGISTRY};
 use util::{Config, ToUrl};
 use util::config::ConfigValue;
 use util::errors::{CargoResult, CargoResultExt};
@@ -59,7 +59,7 @@ impl<'cfg> SourceConfigMap<'cfg> {
             config,
         };
         base.add(
-            "crates-io",
+            CRATES_IO_REGISTRY,
             SourceConfig {
                 id: SourceId::crates_io(config)?,
                 replace_with: None,

--- a/src/cargo/sources/mod.rs
+++ b/src/cargo/sources/mod.rs
@@ -2,7 +2,7 @@ pub use self::config::SourceConfigMap;
 pub use self::directory::DirectorySource;
 pub use self::git::GitSource;
 pub use self::path::PathSource;
-pub use self::registry::{RegistrySource, CRATES_IO};
+pub use self::registry::{RegistrySource, CRATES_IO_INDEX, CRATES_IO_REGISTRY};
 pub use self::replaced::ReplacedSource;
 
 pub mod config;

--- a/src/cargo/sources/registry/mod.rs
+++ b/src/cargo/sources/registry/mod.rs
@@ -179,7 +179,8 @@ use util::to_url::ToUrl;
 use util::{internal, CargoResult, Config, FileLock, Filesystem};
 
 const INDEX_LOCK: &str = ".cargo-index-lock";
-pub const CRATES_IO: &str = "https://github.com/rust-lang/crates.io-index";
+pub const CRATES_IO_INDEX: &str = "https://github.com/rust-lang/crates.io-index";
+pub const CRATES_IO_REGISTRY: &str = "crates-io";
 const CRATE_TEMPLATE: &str = "{crate}";
 const VERSION_TEMPLATE: &str = "{version}";
 

--- a/src/cargo/util/config.rs
+++ b/src/cargo/util/config.rs
@@ -174,6 +174,16 @@ impl Config {
         self.home_path.join("registry").join("src")
     }
 
+    /// The default cargo registry (`alternative-registry`)
+    pub fn default_registry(&self) -> CargoResult<Option<String>> {
+        Ok(
+            match self.get_string("registry.default")? {
+                Some(registry) => Some(registry.val),
+                None => None,
+            }
+        )
+    }
+
     /// Get a reference to the shell, for e.g. writing error messages
     pub fn shell(&self) -> RefMut<Shell> {
         self.shell.borrow_mut()

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -18,7 +18,7 @@ use core::profiles::Profiles;
 use core::{Dependency, Manifest, PackageId, Summary, Target};
 use core::{Edition, EitherManifest, Feature, Features, VirtualManifest};
 use core::{GitReference, PackageIdSpec, SourceId, WorkspaceConfig, WorkspaceRootConfig};
-use sources::CRATES_IO;
+use sources::{CRATES_IO_INDEX, CRATES_IO_REGISTRY};
 use util::errors::{CargoError, CargoResult, CargoResultExt};
 use util::paths;
 use util::{self, Config, ToUrl};
@@ -1140,7 +1140,7 @@ impl TomlManifest {
                 )
             })?;
             if spec.url().is_none() {
-                spec.set_url(CRATES_IO.parse().unwrap());
+                spec.set_url(CRATES_IO_INDEX.parse().unwrap());
             }
 
             let version_specified = match *replacement {
@@ -1175,7 +1175,7 @@ impl TomlManifest {
         let mut patch = HashMap::new();
         for (url, deps) in self.patch.iter().flat_map(|x| x) {
             let url = match &url[..] {
-                "crates-io" => CRATES_IO.parse().unwrap(),
+                CRATES_IO_REGISTRY => CRATES_IO_INDEX.parse().unwrap(),
                 _ => url.to_url()?,
             };
             patch.insert(

--- a/src/doc/src/reference/config.md
+++ b/src/doc/src/reference/config.md
@@ -93,6 +93,7 @@ runner = ".."
 [registry]
 index = "..."   # URL of the registry index (defaults to the central repository)
 token = "..."   # Access token (found on the central repo’s website)
+default = "..." # Default alternative registry to use (can be overriden with --registry)
 
 [http]
 proxy = "host:port" # HTTP proxy to use for HTTP requests (defaults to none)


### PR DESCRIPTION
This adds two things:
  - --registry support for new and init
 - adds default registry configuration to cargo

The main reason for these changes is to reduce the risk of closed-source software ending up accidentally on crates.io.

This fixes #6123.