### PR TITLE
proptest basic validation

### DIFF
--- a/src/cargo/core/resolver/resolve.rs
+++ b/src/cargo/core/resolver/resolve.rs
@@ -1,5 +1,7 @@
+use std::borrow::Borrow;
 use std::collections::{HashMap, HashSet};
 use std::fmt;
+use std::hash::Hash;
 use std::iter::FromIterator;
 
 use url::Url;
@@ -159,6 +161,14 @@ unable to verify that `{0}` is the same as when the lockfile was generated
         // Be sure to just copy over any unknown metadata.
         self.metadata = previous.metadata.clone();
         Ok(())
+    }
+
+    pub fn contains<Q: ?Sized>(&self, k: &Q) -> bool
+    where
+        PackageId: Borrow<Q>,
+        Q: Hash + Eq,
+    {
+        self.graph.contains(k)
     }
 
     pub fn iter(&self) -> impl Iterator<Item = &PackageId> {

--- a/src/cargo/util/graph.rs
+++ b/src/cargo/util/graph.rs
@@ -1,3 +1,4 @@
+use std::borrow::Borrow;
 use std::collections::hash_map::HashMap;
 use std::fmt;
 use std::hash::Hash;
@@ -23,6 +24,14 @@ impl<N: Eq + Hash + Clone, E: Default> Graph<N, E> {
             .or_insert_with(HashMap::new)
             .entry(child)
             .or_insert_with(Default::default)
+    }
+
+    pub fn contains<Q: ?Sized>(&self, k: &Q) -> bool
+    where
+        N: Borrow<Q>,
+        Q: Hash + Eq,
+    {
+        self.nodes.contains_key(k)
     }
 
     pub fn edge(&self, from: &N, to: &N) -> Option<&E> {

--- a/tests/testsuite/support/resolver.rs
+++ b/tests/testsuite/support/resolver.rs
@@ -11,7 +11,7 @@ use cargo::core::Resolve;
 use cargo::core::{Dependency, PackageId, Registry, Summary};
 use cargo::util::{CargoResult, Config, ToUrl};
 
-use proptest::collection::{btree_map, btree_set, vec};
+use proptest::collection::{btree_map, vec};
 use proptest::prelude::*;
 use proptest::sample::Index;
 use proptest::strategy::ValueTree;
@@ -40,7 +40,7 @@ pub fn resolve_and_validated(
         if used.insert(p.clone()) {
             // in the tests all `links` crates end in `-sys`
             if p.name().ends_with("-sys") {
-                 assert!(links.insert(p.name()));
+                assert!(links.insert(p.name()));
             }
             stack.extend(resolve.deps(&p).map(|(dp, deps)| {
                 for d in deps {
@@ -336,8 +336,8 @@ pub fn registry_strategy(
     let allow_deps = prop::bool::weighted(0.99);
 
     let list_of_versions =
-        btree_set((raw_version, allow_deps), 1..=max_versions).prop_map(move |ver| {
-            ver.iter()
+        btree_map(raw_version, allow_deps, 1..=max_versions).prop_map(move |ver| {
+            ver.into_iter()
                 .map(|a| (version_from_raw(&a.0), a.1))
                 .collect::<Vec<_>>()
         });

--- a/tests/testsuite/support/resolver.rs
+++ b/tests/testsuite/support/resolver.rs
@@ -7,6 +7,7 @@ use std::time::{Duration, Instant};
 use cargo::core::dependency::Kind;
 use cargo::core::resolver::{self, Method};
 use cargo::core::source::{GitReference, SourceId};
+use cargo::core::Resolve;
 use cargo::core::{Dependency, PackageId, Registry, Summary};
 use cargo::util::{CargoResult, Config, ToUrl};
 
@@ -25,12 +26,52 @@ pub fn resolve(
     resolve_with_config(pkg, deps, registry, None)
 }
 
+pub fn resolve_and_validated(
+    pkg: &PackageId,
+    deps: Vec<Dependency>,
+    registry: &[Summary],
+) -> CargoResult<Vec<PackageId>> {
+    let resolve = resolve_with_config_raw(pkg, deps, registry, None)?;
+    let mut stack = vec![pkg.clone()];
+    let mut used = HashSet::new();
+    let mut links = HashSet::new();
+    while let Some(p) = stack.pop() {
+        assert!(resolve.contains(&p));
+        if used.insert(p.clone()) {
+            // in the tests all `links` crates end in `-sys`
+            if p.name().ends_with("-sys") {
+                 assert!(links.insert(p.name()));
+            }
+            stack.extend(resolve.deps(&p).map(|(dp, deps)| {
+                for d in deps {
+                    assert!(d.matches_id(dp));
+                }
+                dp.clone()
+            }));
+        }
+    }
+    let out: Vec<PackageId> = resolve.iter().cloned().collect();
+    assert_eq!(out.len(), used.len());
+    Ok(out)
+}
+
 pub fn resolve_with_config(
     pkg: &PackageId,
     deps: Vec<Dependency>,
     registry: &[Summary],
     config: Option<&Config>,
 ) -> CargoResult<Vec<PackageId>> {
+    let resolve = resolve_with_config_raw(pkg, deps, registry, config)?;
+    let out: Vec<PackageId> = resolve.iter().cloned().collect();
+    Ok(out)
+}
+
+pub fn resolve_with_config_raw(
+    pkg: &PackageId,
+    deps: Vec<Dependency>,
+    registry: &[Summary],
+    config: Option<&Config>,
+) -> CargoResult<Resolve> {
     struct MyRegistry<'a>(&'a [Summary]);
     impl<'a> Registry for MyRegistry<'a> {
         fn query(
@@ -62,7 +103,8 @@ pub fn resolve_with_config(
         &BTreeMap::<String, Vec<String>>::new(),
         None::<String>,
         false,
-    ).unwrap();
+    )
+    .unwrap();
     let method = Method::Everything;
     let start = Instant::now();
     let resolve = resolver::resolve(
@@ -72,13 +114,12 @@ pub fn resolve_with_config(
         &HashSet::new(),
         config,
         false,
-    )?;
+    );
 
     // The largest test in our suite takes less then 30 sec.
     // So lets fail the test if we have ben running for two long.
     assert!(start.elapsed() < Duration::from_secs(60));
-    let res = resolve.iter().cloned().collect();
-    Ok(res)
+    resolve
 }
 
 pub trait ToDep {
@@ -156,7 +197,8 @@ pub fn pkg_dep<T: ToPkgId>(name: T, dep: Vec<Dependency>) -> Summary {
         &BTreeMap::<String, Vec<String>>::new(),
         link,
         false,
-    ).unwrap()
+    )
+    .unwrap()
 }
 
 pub fn pkg_id(name: &str) -> PackageId {
@@ -183,7 +225,8 @@ pub fn pkg_loc(name: &str, loc: &str) -> Summary {
         &BTreeMap::<String, Vec<String>>::new(),
         link,
         false,
-    ).unwrap()
+    )
+    .unwrap()
 }
 
 pub fn dep(name: &str) -> Dependency {
@@ -366,7 +409,8 @@ pub fn registry_strategy(
                                 deps
                             },
                         )
-                    }).collect(),
+                    })
+                    .collect(),
             )
         },
     )
@@ -392,9 +436,9 @@ fn meta_test_deep_trees_from_strategy() {
                 &reg,
             );
             dis[res
-                    .as_ref()
-                    .map(|x| min(x.len(), dis.len()) - 1)
-                    .unwrap_or(0)] += 1;
+                .as_ref()
+                .map(|x| min(x.len(), dis.len()) - 1)
+                .unwrap_or(0)] += 1;
             if dis.iter().all(|&x| x > 0) {
                 return;
             }


### PR DESCRIPTION
This adds a function for testing that the output of the resolver is basically reasonable. This function has the same signature as the function for running the resolver in a test. So it is easy to switch back and forth, depending on the thoroughness vs speed tradeoff. This also adds a proptest/fuzz that runs this validation against arbitrary registry.

cc #6120
Sorry about the cargo fmt.