### PR TITLE
Rejects publishing packages with wildcard version constraints (#5941)

### DIFF
--- a/src/cargo/ops/registry.rs
+++ b/src/cargo/ops/registry.rs
@@ -137,7 +137,7 @@ fn verify_dependencies(pkg: &Package, registry_src: &SourceId) -> CargoResult<()
                     dep.source_id()
                 );
             }
-        } else if *dep.version_req() == VersionReq::parse("*").unwrap() {
+        } else if registry_src.is_default_registry() && *dep.version_req() == VersionReq::parse("*").unwrap() {
             // crates.io rejects wildcard (`*`) dependency constraints (issue 5941)
             // https://doc.rust-lang.org/cargo/faq.html#can-libraries-use--as-a-version-for-their-dependencies
             bail!(

--- a/src/cargo/ops/registry.rs
+++ b/src/cargo/ops/registry.rs
@@ -8,8 +8,8 @@ use curl::easy::{Easy, SslOpt};
 use git2;
 use registry::{NewCrate, NewCrateDependency, Registry};
 
-use url::percent_encoding::{percent_encode, QUERY_ENCODE_SET};
 use semver::VersionReq;
+use url::percent_encoding::{percent_encode, QUERY_ENCODE_SET};
 
 use core::dependency::Kind;
 use core::manifest::ManifestMetadata;
@@ -137,7 +137,9 @@ fn verify_dependencies(pkg: &Package, registry_src: &SourceId) -> CargoResult<()
                     dep.source_id()
                 );
             }
-        } else if registry_src.is_default_registry() && *dep.version_req() == VersionReq::parse("*").unwrap() {
+        } else if registry_src.is_default_registry()
+            && *dep.version_req() == VersionReq::parse("*").unwrap()
+        {
             // crates.io rejects wildcard (`*`) dependency constraints (issue 5941)
             // https://doc.rust-lang.org/cargo/faq.html#can-libraries-use--as-a-version-for-their-dependencies
             bail!(

--- a/tests/testsuite/publish.rs
+++ b/tests/testsuite/publish.rs
@@ -646,9 +646,6 @@ error: the dependency `foo` used a wildcard (`*`) as a version, crates.io will n
 for more information, see the FAQ: https://doc.rust-lang.org/cargo/faq.html#can-libraries-use--as-a-version-for-their-dependencies
 ",
         ).run();
-
-    // Ensure the API request wasn't actually made
-    assert!(!publish::upload_path().join("api/v1/crates/new").exists());
 }
 
 #[test]


### PR DESCRIPTION
This should reject both `--dry-run` and a full `cargo publish`. It also only applies for the crates.io registry, which is probably fine, but easy to change.