### PR TITLE
Expose manifest error chain in CargoErrors

### DIFF
--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -495,11 +495,7 @@ impl<'cfg> Workspace<'cfg> {
         self.members.push(manifest_path.clone());
 
         let candidates = {
-            let pkg = match *self
-                .packages
-                .load(&manifest_path)
-                .map_err(|err| ManifestError::new(err, manifest_path.clone()))?
-            {
+            let pkg = match *self.packages.load(&manifest_path)? {
                 MaybePackage::Package(ref p) => p,
                 MaybePackage::Virtual(_) => return Ok(()),
             };

--- a/src/cargo/ops/cargo_read_manifest.rs
+++ b/src/cargo/ops/cargo_read_manifest.rs
@@ -153,7 +153,7 @@ fn read_nested_packages(
                 "skipping malformed package found at `{}`",
                 path.to_string_lossy()
             );
-            errors.push(err);
+            errors.push(err.into());
             return Ok(());
         }
         Ok(tuple) => tuple,

--- a/src/cargo/util/errors.rs
+++ b/src/cargo/util/errors.rs
@@ -3,6 +3,7 @@
 use std::fmt;
 use std::process::{ExitStatus, Output};
 use std::str;
+use std::path::PathBuf;
 
 use core::{TargetKind, Workspace};
 use failure::{Context, Error, Fail};
@@ -69,6 +70,40 @@ impl fmt::Debug for Internal {
 impl fmt::Display for Internal {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.inner.fmt(f)
+    }
+}
+
+/// Error related to a particular manifest and providing it's path.
+pub struct ManifestError {
+    cause: Error,
+    manifest: PathBuf,
+}
+
+impl ManifestError {
+    pub fn new(cause: Error, manifest: PathBuf) -> Self {
+        Self { cause, manifest }
+    }
+
+    pub fn manifest_path(&self) -> &PathBuf {
+        &self.manifest
+    }
+}
+
+impl Fail for ManifestError {
+    fn cause(&self) -> Option<&Fail> {
+        self.cause.as_fail().into()
+    }
+}
+
+impl fmt::Debug for ManifestError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.cause.fmt(f)
+    }
+}
+
+impl fmt::Display for ManifestError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.cause.fmt(f)
     }
 }
 

--- a/tests/testsuite/main.rs
+++ b/tests/testsuite/main.rs
@@ -66,6 +66,7 @@ mod jobserver;
 mod local_registry;
 mod lockfile_compat;
 mod login;
+mod member_errors;
 mod metabuild;
 mod metadata;
 mod net_config;

--- a/tests/testsuite/member_errors.rs
+++ b/tests/testsuite/member_errors.rs
@@ -44,15 +44,12 @@ fn toml_deserialize_manifest_error() {
     let error = Workspace::new(&root_manifest_path, &Config::default().unwrap()).unwrap_err();
     eprintln!("{:?}", error);
 
-    let manifest_errs: Vec<_> = error
-        .iter_chain()
-        .filter_map(|err| err.downcast_ref::<ManifestError>())
-        .map(|err| err.manifest_path())
-        .collect();
+    let manifest_err: &ManifestError = error.downcast_ref().expect("Not a ManifestError");
+    assert_eq!(manifest_err.manifest_path(), &root_manifest_path);
 
-    assert_eq!(manifest_errs.len(), 2, "{:?}", manifest_errs);
-    assert_eq!(manifest_errs[0], &root_manifest_path);
-    assert_eq!(manifest_errs[1], &member_manifest_path);
+    let causes: Vec<_> = manifest_err.manifest_causes().collect();
+    assert_eq!(causes.len(), 1, "{:?}", causes);
+    assert_eq!(causes[0].manifest_path(), &member_manifest_path);
 }
 
 /// Tests inclusion of a `ManifestError` pointing to a member manifest
@@ -97,14 +94,11 @@ fn member_manifest_path_io_error() {
     let error = Workspace::new(&root_manifest_path, &Config::default().unwrap()).unwrap_err();
     eprintln!("{:?}", error);
 
-    let manifest_errs: Vec<_> = error
-        .iter_chain()
-        .filter_map(|err| err.downcast_ref::<ManifestError>())
-        .map(|err| err.manifest_path())
-        .collect();
+    let manifest_err: &ManifestError = error.downcast_ref().expect("Not a ManifestError");
+    assert_eq!(manifest_err.manifest_path(), &root_manifest_path);
 
-    assert_eq!(manifest_errs.len(), 3, "{:?}", manifest_errs);
-    assert_eq!(manifest_errs[0], &root_manifest_path);
-    assert_eq!(manifest_errs[1], &member_manifest_path);
-    assert_eq!(manifest_errs[2], &missing_manifest_path);
+    let causes: Vec<_> = manifest_err.manifest_causes().collect();
+    assert_eq!(causes.len(), 2, "{:?}", causes);
+    assert_eq!(causes[0].manifest_path(), &member_manifest_path);
+    assert_eq!(causes[1].manifest_path(), &missing_manifest_path);
 }

--- a/tests/testsuite/member_errors.rs
+++ b/tests/testsuite/member_errors.rs
@@ -44,13 +44,15 @@ fn toml_deserialize_manifest_error() {
     let error = Workspace::new(&root_manifest_path, &Config::default().unwrap()).unwrap_err();
     eprintln!("{:?}", error);
 
-    let manifest_err = error
+    let manifest_errs: Vec<_> = error
         .iter_chain()
         .filter_map(|err| err.downcast_ref::<ManifestError>())
-        .last()
-        .expect("No ManifestError");
+        .map(|err| err.manifest_path())
+        .collect();
 
-    assert_eq!(manifest_err.manifest_path(), &member_manifest_path);
+    assert_eq!(manifest_errs.len(), 2, "{:?}", manifest_errs);
+    assert_eq!(manifest_errs[0], &root_manifest_path);
+    assert_eq!(manifest_errs[1], &member_manifest_path);
 }
 
 /// Tests inclusion of a `ManifestError` pointing to a member manifest
@@ -90,15 +92,19 @@ fn member_manifest_path_io_error() {
 
     let root_manifest_path = p.root().join("Cargo.toml");
     let member_manifest_path = p.root().join("bar").join("Cargo.toml");
+    let missing_manifest_path = p.root().join("bar").join("nosuch").join("Cargo.toml");
 
     let error = Workspace::new(&root_manifest_path, &Config::default().unwrap()).unwrap_err();
     eprintln!("{:?}", error);
 
-    let manifest_err = error
+    let manifest_errs: Vec<_> = error
         .iter_chain()
         .filter_map(|err| err.downcast_ref::<ManifestError>())
-        .last()
-        .expect("No ManifestError");
+        .map(|err| err.manifest_path())
+        .collect();
 
-    assert_eq!(manifest_err.manifest_path(), &member_manifest_path);
+    assert_eq!(manifest_errs.len(), 3, "{:?}", manifest_errs);
+    assert_eq!(manifest_errs[0], &root_manifest_path);
+    assert_eq!(manifest_errs[1], &member_manifest_path);
+    assert_eq!(manifest_errs[2], &missing_manifest_path);
 }

--- a/tests/testsuite/member_errors.rs
+++ b/tests/testsuite/member_errors.rs
@@ -1,0 +1,104 @@
+use cargo::core::Workspace;
+use cargo::util::{config::Config, errors::ManifestError};
+
+use support::project;
+
+/// Tests inclusion of a `ManifestError` pointing to a member manifest
+/// when that manifest fails to deserialize.
+#[test]
+fn toml_deserialize_manifest_error() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [project]
+            name = "foo"
+            version = "0.1.0"
+            authors = []
+
+            [dependencies]
+            bar = { path = "bar" }
+
+            [workspace]
+        "#,
+        )
+        .file("src/main.rs", "fn main() {}")
+        .file(
+            "bar/Cargo.toml",
+            r#"
+            [project]
+            name = "bar"
+            version = "0.1.0"
+            authors = []
+
+            [dependencies]
+            foobar == "0.55"
+        "#,
+        )
+        .file("bar/src/main.rs", "fn main() {}")
+        .build();
+
+    let root_manifest_path = p.root().join("Cargo.toml");
+    let member_manifest_path = p.root().join("bar").join("Cargo.toml");
+
+    let error = Workspace::new(&root_manifest_path, &Config::default().unwrap()).unwrap_err();
+    eprintln!("{:?}", error);
+
+    let manifest_err = error
+        .iter_chain()
+        .filter_map(|err| err.downcast_ref::<ManifestError>())
+        .last()
+        .expect("No ManifestError");
+
+    assert_eq!(manifest_err.manifest_path(), &member_manifest_path);
+}
+
+/// Tests inclusion of a `ManifestError` pointing to a member manifest
+/// when that manifest has an invalid dependency path.
+#[test]
+fn member_manifest_path_io_error() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [project]
+            name = "foo"
+            version = "0.1.0"
+            authors = []
+
+            [dependencies]
+            bar = { path = "bar" }
+
+            [workspace]
+        "#,
+        )
+        .file("src/main.rs", "fn main() {}")
+        .file(
+            "bar/Cargo.toml",
+            r#"
+            [project]
+            name = "bar"
+            version = "0.1.0"
+            authors = []
+
+            [dependencies]
+            foobar = { path = "nosuch" }
+        "#,
+        )
+        .file("bar/src/main.rs", "fn main() {}")
+        .build();
+
+    let root_manifest_path = p.root().join("Cargo.toml");
+    let member_manifest_path = p.root().join("bar").join("Cargo.toml");
+
+    let error = Workspace::new(&root_manifest_path, &Config::default().unwrap()).unwrap_err();
+    eprintln!("{:?}", error);
+
+    let manifest_err = error
+        .iter_chain()
+        .filter_map(|err| err.downcast_ref::<ManifestError>())
+        .last()
+        .expect("No ManifestError");
+
+    assert_eq!(manifest_err.manifest_path(), &member_manifest_path);
+}


### PR DESCRIPTION
Adds new `ManifestError`s to the `CargoError` causal chain. These errors pass on their display, but provide more detail on which manifests are at fault when failing to build a `Workspace`. This is useful for lib users, in particular rls, allowing lookup of a particular manifest file that caused the error. See #6144.

For example a workspace _foo_ where a member _bar_ has an invalid toml manifest would have the error chain:
- failed to parse manifest at `/home/alex/project/foo/bar/Cargo.toml` 
  _ManifestError: /home/alex/project/foo/Cargo.toml_
- failed to parse manifest at `/home/alex/project/foo/bar/Cargo.toml` 
  _ManifestError: /home/alex/project/foo/bar/Cargo.toml_
- failed to parse manifest at `/home/alex/project/foo/bar/Cargo.toml`
- could not parse input as TOML
- expected a value, found an equals at line 8

This will allow rls to point to a particular workspace member's manifest file when that manifest fails to deserialize, has invalid paths, etc.

This change should not affect binary use.