### PR TITLE
Prefix build script output with crate name when running in extra verbose mode. Fixes #6158.

### DIFF
--- a/src/cargo/core/compiler/custom_build.rs
+++ b/src/cargo/core/compiler/custom_build.rs
@@ -326,7 +326,8 @@ fn build_work<'a, 'cfg>(cx: &mut Context<'a, 'cfg>, unit: &Unit<'a>) -> CargoRes
         } else {
             state.running(&cmd);
             let output = if extra_verbose {
-                state.capture_output(&cmd, true)
+                let prefix = format!("[{} {}] ", id.name(), id.version());
+                state.capture_output(&cmd, Some(prefix), true)
             } else {
                 cmd.exec_with_output()
             };

--- a/src/cargo/core/compiler/job_queue.rs
+++ b/src/cargo/core/compiler/job_queue.rs
@@ -112,15 +112,17 @@ impl<'a> JobState<'a> {
     pub fn capture_output(
         &self,
         cmd: &ProcessBuilder,
+        prefix: Option<String>,
         print_output: bool,
     ) -> CargoResult<Output> {
+        let prefix = prefix.unwrap_or_else(|| String::new());
         cmd.exec_with_streaming(
             &mut |out| {
-                let _ = self.tx.send(Message::Stdout(out.to_string()));
+                let _ = self.tx.send(Message::Stdout(format!("{}{}", prefix, out)));
                 Ok(())
             },
             &mut |err| {
-                let _ = self.tx.send(Message::Stderr(err.to_string()));
+                let _ = self.tx.send(Message::Stderr(format!("{}{}", prefix, err)));
                 Ok(())
             },
             print_output,

--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -118,7 +118,7 @@ impl Executor for DefaultExecutor {
         _mode: CompileMode,
         state: &job_queue::JobState<'_>,
     ) -> CargoResult<()> {
-        state.capture_output(&cmd, false).map(drop)
+        state.capture_output(&cmd, None, false).map(drop)
     }
 }
 
@@ -645,7 +645,7 @@ fn rustdoc<'a, 'cfg>(cx: &mut Context<'a, 'cfg>, unit: &Unit<'a>) -> CargoResult
                     false,
                 ).map(drop)
         } else {
-            state.capture_output(&rustdoc, false).map(drop)
+            state.capture_output(&rustdoc, None, false).map(drop)
         };
         exec_result.chain_err(|| format!("Could not document `{}`.", name))?;
         Ok(())

--- a/tests/testsuite/build_script.rs
+++ b/tests/testsuite/build_script.rs
@@ -2803,13 +2803,13 @@ fn output_shows_on_vv() {
         ).build();
 
     p.cargo("build -vv")
-        .with_stdout("stdout")
+        .with_stdout("[foo 0.5.0] stdout")
         .with_stderr(
             "\
 [COMPILING] foo v0.5.0 ([..])
 [RUNNING] `rustc [..]`
 [RUNNING] `[..]`
-stderr
+[foo 0.5.0] stderr
 [RUNNING] `rustc [..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",

--- a/tests/testsuite/metabuild.rs
+++ b/tests/testsuite/metabuild.rs
@@ -72,8 +72,8 @@ fn metabuild_basic() {
     let p = basic_project();
     p.cargo("build -vv")
         .masquerade_as_nightly_cargo()
-        .with_stdout_contains("Hello mb")
-        .with_stdout_contains("Hello mb-other")
+        .with_stdout_contains("[foo 0.0.1] Hello mb")
+        .with_stdout_contains("[foo 0.0.1] Hello mb-other")
         .run();
 }
 
@@ -164,12 +164,12 @@ fn metabuild_optional_dep() {
 
     p.cargo("build -vv")
         .masquerade_as_nightly_cargo()
-        .with_stdout_does_not_contain("Hello mb")
+        .with_stdout_does_not_contain("[foo 0.0.1] Hello mb")
         .run();
 
     p.cargo("build -vv --features mb")
         .masquerade_as_nightly_cargo()
-        .with_stdout_contains("Hello mb")
+        .with_stdout_contains("[foo 0.0.1] Hello mb")
         .run();
 }
 
@@ -206,7 +206,7 @@ fn metabuild_lib_name() {
 
     p.cargo("build -vv")
         .masquerade_as_nightly_cargo()
-        .with_stdout_contains("Hello mb")
+        .with_stdout_contains("[foo 0.0.1] Hello mb")
         .run();
 }
 
@@ -235,12 +235,12 @@ fn metabuild_fresh() {
 
     p.cargo("build -vv")
         .masquerade_as_nightly_cargo()
-        .with_stdout_contains("Hello mb")
+        .with_stdout_contains("[foo 0.0.1] Hello mb")
         .run();
 
     p.cargo("build -vv")
         .masquerade_as_nightly_cargo()
-        .with_stdout_does_not_contain("Hello mb")
+        .with_stdout_does_not_contain("[foo 0.0.1] Hello mb")
         .with_stderr(
             "\
 [FRESH] mb [..]
@@ -279,7 +279,7 @@ fn metabuild_links() {
 
     p.cargo("build -vv")
         .masquerade_as_nightly_cargo()
-        .with_stdout_contains("Hello mb")
+        .with_stdout_contains("[foo 0.0.1] Hello mb")
         .run();
 }
 
@@ -376,10 +376,10 @@ fn metabuild_workspace() {
 
     p.cargo("build -vv --all")
         .masquerade_as_nightly_cargo()
-        .with_stdout_contains("Hello mb1 [..]member1")
-        .with_stdout_contains("Hello mb2 [..]member1")
-        .with_stdout_contains("Hello mb1 [..]member2")
-        .with_stdout_does_not_contain("Hello mb2 [..]member2")
+        .with_stdout_contains("[member1 0.0.1] Hello mb1 [..]member1")
+        .with_stdout_contains("[member1 0.0.1] Hello mb2 [..]member1")
+        .with_stdout_contains("[member2 0.0.1] Hello mb1 [..]member2")
+        .with_stdout_does_not_contain("[member2 0.0.1] Hello mb2 [..]member2")
         .run();
 }
 
@@ -572,8 +572,8 @@ fn metabuild_two_versions() {
 
     p.cargo("build -vv --all")
         .masquerade_as_nightly_cargo()
-        .with_stdout_contains("Hello mb1 [..]member1")
-        .with_stdout_contains("Hello mb2 [..]member2")
+        .with_stdout_contains("[member1 0.0.1] Hello mb1 [..]member1")
+        .with_stdout_contains("[member2 0.0.1] Hello mb2 [..]member2")
         .run();
 
     assert_eq!(
@@ -628,7 +628,7 @@ fn metabuild_external_dependency() {
 
     p.cargo("build -vv")
         .masquerade_as_nightly_cargo()
-        .with_stdout_contains("Hello mb")
+        .with_stdout_contains("[dep 1.0.0] Hello mb")
         .run();
 
     assert_eq!(

--- a/tests/testsuite/profile_targets.rs
+++ b/tests/testsuite/profile_targets.rs
@@ -614,6 +614,7 @@ fn profile_selection_check_all_targets_test() {
 [RUNNING] `rustc --crate-name foo src/main.rs [..]--emit=dep-info,metadata -C codegen-units=1 -C debuginfo=2 --test [..]
 [RUNNING] `rustc --crate-name bench1 benches/bench1.rs [..]--emit=dep-info,metadata -C codegen-units=1 -C debuginfo=2 --test [..]
 [RUNNING] `rustc --crate-name ex1 examples/ex1.rs [..]--emit=dep-info,metadata -C codegen-units=1 -C debuginfo=2 --test [..]
+[FINISHED] dev [unoptimized + debuginfo] [..]
 ").run();
 
     p.cargo("check --all-targets --profile=test -vv")

--- a/tests/testsuite/profile_targets.rs
+++ b/tests/testsuite/profile_targets.rs
@@ -83,7 +83,7 @@ fn profile_selection_build() {
 [COMPILING] foo [..]
 [RUNNING] `rustc --crate-name build_script_build build.rs [..]--crate-type bin --emit=dep-info,link -C codegen-units=1 -C debuginfo=2 [..]
 [RUNNING] `[..]/target/debug/build/foo-[..]/build-script-build`
-foo custom build PROFILE=debug DEBUG=true OPT_LEVEL=0
+[foo 0.0.1] foo custom build PROFILE=debug DEBUG=true OPT_LEVEL=0
 [RUNNING] `rustc --crate-name foo src/lib.rs [..]--crate-type lib --emit=dep-info,link -C panic=abort -C codegen-units=1 -C debuginfo=2 [..]
 [RUNNING] `rustc --crate-name foo src/main.rs [..]--crate-type bin --emit=dep-info,link -C panic=abort -C codegen-units=1 -C debuginfo=2 [..]
 [FINISHED] dev [unoptimized + debuginfo] [..]
@@ -113,7 +113,7 @@ fn profile_selection_build_release() {
 [COMPILING] foo [..]
 [RUNNING] `rustc --crate-name build_script_build build.rs [..]--crate-type bin --emit=dep-info,link -C opt-level=3 -C codegen-units=2 [..]
 [RUNNING] `[..]/target/release/build/foo-[..]/build-script-build`
-foo custom build PROFILE=release DEBUG=false OPT_LEVEL=3
+[foo 0.0.1] foo custom build PROFILE=release DEBUG=false OPT_LEVEL=3
 [RUNNING] `rustc --crate-name foo src/lib.rs [..]--crate-type lib --emit=dep-info,link -C opt-level=3 -C panic=abort -C codegen-units=2 [..]
 [RUNNING] `rustc --crate-name foo src/main.rs [..]--crate-type bin --emit=dep-info,link -C opt-level=3 -C panic=abort -C codegen-units=2 [..]
 [FINISHED] release [optimized] [..]
@@ -174,8 +174,8 @@ fn profile_selection_build_all_targets() {
 [RUNNING] `rustc --crate-name build_script_build build.rs [..]--crate-type bin --emit=dep-info,link -C codegen-units=1 -C debuginfo=2 [..]
 [RUNNING] `[..]/target/debug/build/foo-[..]/build-script-build`
 [RUNNING] `[..]/target/debug/build/foo-[..]/build-script-build`
-foo custom build PROFILE=debug DEBUG=false OPT_LEVEL=3
-foo custom build PROFILE=debug DEBUG=true OPT_LEVEL=0
+[foo 0.0.1] foo custom build PROFILE=debug DEBUG=false OPT_LEVEL=3
+[foo 0.0.1] foo custom build PROFILE=debug DEBUG=true OPT_LEVEL=0
 [RUNNING] `rustc --crate-name foo src/lib.rs [..]--crate-type lib --emit=dep-info,link -C panic=abort -C codegen-units=1 -C debuginfo=2 [..]`
 [RUNNING] `rustc --crate-name foo src/lib.rs [..]--emit=dep-info,link -C codegen-units=3 -C debuginfo=2 --test [..]`
 [RUNNING] `rustc --crate-name foo src/lib.rs [..]--crate-type lib --emit=dep-info,link -C codegen-units=1 -C debuginfo=2 [..]`
@@ -241,7 +241,7 @@ fn profile_selection_build_all_targets_release() {
 [COMPILING] foo [..]
 [RUNNING] `rustc --crate-name build_script_build build.rs [..]--crate-type bin --emit=dep-info,link -C opt-level=3 -C codegen-units=2 [..]
 [RUNNING] `[..]/target/release/build/foo-[..]/build-script-build`
-foo custom build PROFILE=release DEBUG=false OPT_LEVEL=3
+[foo 0.0.1] foo custom build PROFILE=release DEBUG=false OPT_LEVEL=3
 [RUNNING] `rustc --crate-name foo src/lib.rs [..]--crate-type lib --emit=dep-info,link -C opt-level=3 -C panic=abort -C codegen-units=2 [..]`
 [RUNNING] `rustc --crate-name foo src/lib.rs [..]--emit=dep-info,link -C opt-level=3 -C codegen-units=4 --test [..]`
 [RUNNING] `rustc --crate-name foo src/lib.rs [..]--crate-type lib --emit=dep-info,link -C opt-level=3 -C codegen-units=2 [..]`
@@ -296,7 +296,7 @@ fn profile_selection_test() {
 [COMPILING] foo [..]
 [RUNNING] `rustc --crate-name build_script_build build.rs [..]--crate-type bin --emit=dep-info,link -C codegen-units=1 -C debuginfo=2 [..]
 [RUNNING] `[..]/target/debug/build/foo-[..]/build-script-build`
-foo custom build PROFILE=debug DEBUG=true OPT_LEVEL=0
+[foo 0.0.1] foo custom build PROFILE=debug DEBUG=true OPT_LEVEL=0
 [RUNNING] `rustc --crate-name foo src/lib.rs [..]--crate-type lib --emit=dep-info,link -C panic=abort -C codegen-units=1 -C debuginfo=2 [..]
 [RUNNING] `rustc --crate-name foo src/lib.rs [..]--crate-type lib --emit=dep-info,link -C codegen-units=1 -C debuginfo=2 [..]
 [RUNNING] `rustc --crate-name foo src/lib.rs [..]--emit=dep-info,link -C codegen-units=3 -C debuginfo=2 --test [..]
@@ -360,7 +360,7 @@ fn profile_selection_test_release() {
 [COMPILING] foo [..]
 [RUNNING] `rustc --crate-name build_script_build build.rs [..]--crate-type bin --emit=dep-info,link -C opt-level=3 -C codegen-units=2 [..]
 [RUNNING] `[..]/target/release/build/foo-[..]/build-script-build`
-foo custom build PROFILE=release DEBUG=false OPT_LEVEL=3
+[foo 0.0.1] foo custom build PROFILE=release DEBUG=false OPT_LEVEL=3
 [RUNNING] `rustc --crate-name foo src/lib.rs [..]--crate-type lib --emit=dep-info,link -C opt-level=3 -C panic=abort -C codegen-units=2 [..]
 [RUNNING] `rustc --crate-name foo src/lib.rs [..]--crate-type lib --emit=dep-info,link -C opt-level=3 -C codegen-units=2 [..]
 [RUNNING] `rustc --crate-name foo src/lib.rs [..]--emit=dep-info,link -C opt-level=3 -C codegen-units=4 --test [..]
@@ -424,7 +424,7 @@ fn profile_selection_bench() {
 [COMPILING] foo [..]
 [RUNNING] `rustc --crate-name build_script_build build.rs [..]--crate-type bin --emit=dep-info,link -C opt-level=3 -C codegen-units=2 [..]
 [RUNNING] `[..]target/release/build/foo-[..]/build-script-build`
-foo custom build PROFILE=release DEBUG=false OPT_LEVEL=3
+[foo 0.0.1] foo custom build PROFILE=release DEBUG=false OPT_LEVEL=3
 [RUNNING] `rustc --crate-name foo src/lib.rs [..]--crate-type lib --emit=dep-info,link -C opt-level=3 -C panic=abort -C codegen-units=2 [..]
 [RUNNING] `rustc --crate-name foo src/lib.rs [..]--crate-type lib --emit=dep-info,link -C opt-level=3 -C codegen-units=2 [..]
 [RUNNING] `rustc --crate-name foo src/lib.rs [..]--emit=dep-info,link -C opt-level=3 -C codegen-units=4 --test [..]
@@ -493,7 +493,7 @@ fn profile_selection_check_all_targets() {
 [COMPILING] foo [..]
 [RUNNING] `rustc --crate-name build_script_build build.rs [..]--crate-type bin --emit=dep-info,link -C codegen-units=1 -C debuginfo=2 [..]
 [RUNNING] `[..]target/debug/build/foo-[..]/build-script-build`
-foo custom build PROFILE=debug DEBUG=true OPT_LEVEL=0
+[foo 0.0.1] foo custom build PROFILE=debug DEBUG=true OPT_LEVEL=0
 [RUNNING] `rustc --crate-name foo src/lib.rs [..]--crate-type lib --emit=dep-info,metadata -C panic=abort -C codegen-units=1 -C debuginfo=2 [..]
 [RUNNING] `rustc --crate-name foo src/lib.rs [..]--crate-type lib --emit=dep-info,metadata -C codegen-units=1 -C debuginfo=2 [..]
 [RUNNING] `rustc --crate-name foo src/lib.rs [..]--emit=dep-info,metadata -C codegen-units=1 -C debuginfo=2 --test [..]
@@ -543,7 +543,7 @@ fn profile_selection_check_all_targets_release() {
 [COMPILING] foo [..]
 [RUNNING] `rustc --crate-name build_script_build build.rs [..]--crate-type bin --emit=dep-info,link -C opt-level=3 -C codegen-units=2 [..]
 [RUNNING] `[..]target/release/build/foo-[..]/build-script-build`
-foo custom build PROFILE=release DEBUG=false OPT_LEVEL=3
+[foo 0.0.1] foo custom build PROFILE=release DEBUG=false OPT_LEVEL=3
 [RUNNING] `rustc --crate-name foo src/lib.rs [..]--crate-type lib --emit=dep-info,metadata -C opt-level=3 -C panic=abort -C codegen-units=2 [..]
 [RUNNING] `rustc --crate-name foo src/lib.rs [..]--crate-type lib --emit=dep-info,metadata -C opt-level=3 -C codegen-units=2 [..]
 [RUNNING] `rustc --crate-name foo src/lib.rs [..]--emit=dep-info,metadata -C opt-level=3 -C codegen-units=2 --test [..]
@@ -607,14 +607,13 @@ fn profile_selection_check_all_targets_test() {
 [COMPILING] foo [..]
 [RUNNING] `rustc --crate-name build_script_build build.rs [..]--crate-type bin --emit=dep-info,link -C codegen-units=1 -C debuginfo=2 [..]
 [RUNNING] `[..]target/debug/build/foo-[..]/build-script-build`
-foo custom build PROFILE=debug DEBUG=true OPT_LEVEL=0
+[foo 0.0.1] foo custom build PROFILE=debug DEBUG=true OPT_LEVEL=0
 [RUNNING] `rustc --crate-name foo src/lib.rs [..]--crate-type lib --emit=dep-info,metadata -C codegen-units=1 -C debuginfo=2 [..]
 [RUNNING] `rustc --crate-name foo src/lib.rs [..]--emit=dep-info,metadata -C codegen-units=1 -C debuginfo=2 --test [..]
 [RUNNING] `rustc --crate-name test1 tests/test1.rs [..]--emit=dep-info,metadata -C codegen-units=1 -C debuginfo=2 --test [..]
 [RUNNING] `rustc --crate-name foo src/main.rs [..]--emit=dep-info,metadata -C codegen-units=1 -C debuginfo=2 --test [..]
 [RUNNING] `rustc --crate-name bench1 benches/bench1.rs [..]--emit=dep-info,metadata -C codegen-units=1 -C debuginfo=2 --test [..]
 [RUNNING] `rustc --crate-name ex1 examples/ex1.rs [..]--emit=dep-info,metadata -C codegen-units=1 -C debuginfo=2 --test [..]
-[FINISHED] dev [unoptimized + debuginfo] [..]
 ").run();
 
     p.cargo("check --all-targets --profile=test -vv")
@@ -653,7 +652,7 @@ fn profile_selection_doc() {
 [COMPILING] foo [..]
 [RUNNING] `rustc --crate-name build_script_build build.rs [..]--crate-type bin --emit=dep-info,link -C codegen-units=1 -C debuginfo=2 [..]
 [RUNNING] `[..]target/debug/build/foo-[..]/build-script-build`
-foo custom build PROFILE=debug DEBUG=true OPT_LEVEL=0
+[foo 0.0.1] foo custom build PROFILE=debug DEBUG=true OPT_LEVEL=0
 [DOCUMENTING] foo [..]
 [RUNNING] `rustdoc --crate-name foo src/lib.rs [..]
 [FINISHED] dev [unoptimized + debuginfo] [..]


### PR DESCRIPTION
cargo's extra verbose mode is useful for getting detailed information out of
builds in CI where it can be difficult to examine the build environment
after-the-fact. However, when multiple build scripts are running as part of a
build it's not always clear what output is from which build script. This patch
makes cargo prefix each line of build script output with the crate name
in this case.

I put together [a simple test crate](https://github.com/luser/snippet/tree/build-script-output) for this. Building that crate on my machine with stable cargo produces:
```
luser@eye7:/build/snippet$ cargo build -vv
   Compiling one v0.1.0 (file:///build/snippet/one)
   Compiling two v0.1.0 (file:///build/snippet/two)
       Fresh itoa v0.3.4
     Running `rustc --crate-name build_script_build one/build.rs --crate-type bin --emit=dep-info,link -C debuginfo=2 -C metadata=8e5ff38061b98562 -C extra-filename=-8e5ff38061b98562 --out-dir /build/snippet/target/debug/build/one-8e5ff38061b98562 -C incremental=/build/snippet/target/debug/incremental -L dependency=/build/snippet/target/debug/deps`
     Running `rustc --crate-name build_script_build two/build.rs --crate-type bin --emit=dep-info,link -C debuginfo=2 -C metadata=fcd8c089040e6ff4 -C extra-filename=-fcd8c089040e6ff4 --out-dir /build/snippet/target/debug/build/two-fcd8c089040e6ff4 -C incremental=/build/snippet/target/debug/incremental -L dependency=/build/snippet/target/debug/deps`
     Running `/build/snippet/target/debug/build/two-fcd8c089040e6ff4/build-script-build`
     Running `/build/snippet/target/debug/build/one-8e5ff38061b98562/build-script-build`
Error 0
Output 0
Output 0
Error 0
Output 1
Error 1
Error 1
Output 1
Error 2
Output 2
Error 2
Output 2
Error 3
Output 3
Error 3
Output 3
Error 4
Error 4
Output 4
Output 4
Error 5
Error 5
Output 5
Output 5
Error 6
Output 6
Error 6
Output 6
Error 7
Output 7
Error 7
Output 7
Error 8
Error 8
Output 8
Output 8
Error 9
Output 9
Error 9
Output 9
     Running `rustc --crate-name two two/src/lib.rs --crate-type lib --emit=dep-info,link -C debuginfo=2 -C metadata=904ea56f5613ae62 -C extra-filename=-904ea56f5613ae62 --out-dir /build/snippet/target/debug/deps -C incremental=/build/snippet/target/debug/incremental -L dependency=/build/snippet/target/debug/deps`
     Running `rustc --crate-name one one/src/lib.rs --crate-type lib --emit=dep-info,link -C debuginfo=2 -C metadata=c2b76a52468c9a0b -C extra-filename=-c2b76a52468c9a0b --out-dir /build/snippet/target/debug/deps -C incremental=/build/snippet/target/debug/incremental -L dependency=/build/snippet/target/debug/deps`
   Compiling snippet v0.1.4-alpha.0 (file:///build/snippet)
     Running `rustc --crate-name snippet src/lib.rs --crate-type lib --emit=dep-info,link -C debuginfo=2 -C metadata=a5c6abeab1e38e11 -C extra-filename=-a5c6abeab1e38e11 --out-dir /build/snippet/target/debug/deps -C incremental=/build/snippet/target/debug/incremental -L dependency=/build/snippet/target/debug/deps --extern itoa=/build/snippet/target/debug/deps/libitoa-327a92d5ddd56b4a.rlib --extern one=/build/snippet/target/debug/deps/libone-c2b76a52468c9a0b.rlib --extern two=/build/snippet/target/debug/deps/libtwo-904ea56f5613ae62.rlib`
     Running `rustc --crate-name snippet src/main.rs --crate-type bin --emit=dep-info,link -C debuginfo=2 -C metadata=8b5a0b44264aa67c -C extra-filename=-8b5a0b44264aa67c --out-dir /build/snippet/target/debug/deps -C incremental=/build/snippet/target/debug/incremental -L dependency=/build/snippet/target/debug/deps --extern itoa=/build/snippet/target/debug/deps/libitoa-327a92d5ddd56b4a.rlib --extern one=/build/snippet/target/debug/deps/libone-c2b76a52468c9a0b.rlib --extern snippet=/build/snippet/target/debug/deps/libsnippet-a5c6abeab1e38e11.rlib --extern two=/build/snippet/target/debug/deps/libtwo-904ea56f5613ae62.rlib`
    Finished dev [unoptimized + debuginfo] target(s) in 0.76s
```

Building that crate with my local cargo including this change produces:
```
luser@eye7:/build/snippet$ /build/cargo/target/debug/cargo build -vv
   Compiling one v0.1.0 (/build/snippet/one)                                                         
   Compiling two v0.1.0 (/build/snippet/two)                                                         
   Compiling itoa v0.3.4                                                                             
     Running `rustc --crate-name build_script_build one/build.rs --color always --crate-type bin --emit=dep-info,link -C debuginfo=2 -C metadata=8e5ff38061b98562 -C extra-filename=-8e5ff38061b98562 --out-dir /build/snippet/target/debug/build/one-8e5ff38061b98562 -C incremental=/build/snippet/target/debug/incremental -L dependency=/build/snippet/target/debug/deps`
     Running `rustc --crate-name build_script_build two/build.rs --color always --crate-type bin --emit=dep-info,link -C debuginfo=2 -C metadata=fcd8c089040e6ff4 -C extra-filename=-fcd8c089040e6ff4 --out-dir /build/snippet/target/debug/build/two-fcd8c089040e6ff4 -C incremental=/build/snippet/target/debug/incremental -L dependency=/build/snippet/target/debug/deps`
     Running `rustc --crate-name itoa /home/luser/.cargo/registry/src/github.com-1ecc6299db9ec823/itoa-0.3.4/src/lib.rs --color always --crate-type lib --emit=dep-info,link -C debuginfo=2 -C metadata=327a92d5ddd56b4a -C extra-filename=-327a92d5ddd56b4a --out-dir /build/snippet/target/debug/deps -L dependency=/build/snippet/target/debug/deps --cap-lints warn`
     Running `/build/snippet/target/debug/build/one-8e5ff38061b98562/build-script-build`             
     Running `/build/snippet/target/debug/build/two-fcd8c089040e6ff4/build-script-build`             
[one-e779b28932bbd20b] Error 0                                                                       
[one-e779b28932bbd20b] Output 0                                                                      
[one-e779b28932bbd20b] Output 1                                                                      
[one-e779b28932bbd20b] Error 1                                                                       
[two-adc2191c38bf9afc] Error 0                                                                       
[two-adc2191c38bf9afc] Output 0                                                                      
[one-e779b28932bbd20b] Error 2                                                                       
[one-e779b28932bbd20b] Output 2                                                                      
[two-adc2191c38bf9afc] Error 1                                                                       
[two-adc2191c38bf9afc] Output 1                                                                      
[one-e779b28932bbd20b] Output 3                                                                      
[one-e779b28932bbd20b] Error 3                                                                       
[two-adc2191c38bf9afc] Error 2                                                                       
[two-adc2191c38bf9afc] Output 2                                                                      
[one-e779b28932bbd20b] Error 4                                                                       
[one-e779b28932bbd20b] Output 4                                                                      
[two-adc2191c38bf9afc] Error 3                                                                       
[two-adc2191c38bf9afc] Output 3                                                                      
[one-e779b28932bbd20b] Error 5                                                                       
[one-e779b28932bbd20b] Output 5                                                                      
[two-adc2191c38bf9afc] Error 4                                                                       
[two-adc2191c38bf9afc] Output 4                                                                      
[one-e779b28932bbd20b] Error 6                                                                       
[one-e779b28932bbd20b] Output 6                                                                      
[two-adc2191c38bf9afc] Error 5                                                                       
[two-adc2191c38bf9afc] Output 5                                                                      
[one-e779b28932bbd20b] Error 7                                                                       
[one-e779b28932bbd20b] Output 7                                                                      
[two-adc2191c38bf9afc] Error 6                                                                       
[two-adc2191c38bf9afc] Output 6                                                                      
[one-e779b28932bbd20b] Error 8                                                                       
[one-e779b28932bbd20b] Output 8                                                                      
[two-adc2191c38bf9afc] Error 7                                                                       
[two-adc2191c38bf9afc] Output 7                                                                      
[one-e779b28932bbd20b] Error 9                                                                       
[one-e779b28932bbd20b] Output 9                                                                      
[two-adc2191c38bf9afc] Output 8                                                                      
[two-adc2191c38bf9afc] Error 8                                                                       
     Running `rustc --crate-name one one/src/lib.rs --color always --crate-type lib --emit=dep-info,link -C debuginfo=2 -C metadata=c2b76a52468c9a0b -C extra-filename=-c2b76a52468c9a0b --out-dir /build/snippet/target/debug/deps -C incremental=/build/snippet/target/debug/incremental -L dependency=/build/snippet/target/debug/deps`
[two-adc2191c38bf9afc] Error 9                                                                       
[two-adc2191c38bf9afc] Output 9                                                                      
     Running `rustc --crate-name two two/src/lib.rs --color always --crate-type lib --emit=dep-info,link -C debuginfo=2 -C metadata=904ea56f5613ae62 -C extra-filename=-904ea56f5613ae62 --out-dir /build/snippet/target/debug/deps -C incremental=/build/snippet/target/debug/incremental -L dependency=/build/snippet/target/debug/deps`
   Compiling snippet v0.1.4-alpha.0 (/build/snippet)                                                 
     Running `rustc --crate-name snippet src/lib.rs --color always --crate-type lib --emit=dep-info,link -C debuginfo=2 -C metadata=a5c6abeab1e38e11 -C extra-filename=-a5c6abeab1e38e11 --out-dir /build/snippet/target/debug/deps -C incremental=/build/snippet/target/debug/incremental -L dependency=/build/snippet/target/debug/deps --extern itoa=/build/snippet/target/debug/deps/libitoa-327a92d5ddd56b4a.rlib --extern one=/build/snippet/target/debug/deps/libone-c2b76a52468c9a0b.rlib --extern two=/build/snippet/target/debug/deps/libtwo-904ea56f5613ae62.rlib`
     Running `rustc --crate-name snippet src/main.rs --color always --crate-type bin --emit=dep-info,link -C debuginfo=2 -C metadata=8b5a0b44264aa67c -C extra-filename=-8b5a0b44264aa67c --out-dir /build/snippet/target/debug/deps -C incremental=/build/snippet/target/debug/incremental -L dependency=/build/snippet/target/debug/deps --extern itoa=/build/snippet/target/debug/deps/libitoa-327a92d5ddd56b4a.rlib --extern one=/build/snippet/target/debug/deps/libone-c2b76a52468c9a0b.rlib --extern snippet=/build/snippet/target/debug/deps/libsnippet-a5c6abeab1e38e11.rlib --extern two=/build/snippet/target/debug/deps/libtwo-904ea56f5613ae62.rlib`
    Finished dev [unoptimized + debuginfo] target(s) in 0.90s                                        
```
I used `invocation_name` here for no particular reason other than it was being used by the build plan code immediately above, but since that includes the fingerprint it might be nicer to use just `pkg_name`?