### PR TITLE
small cleanups to registry tests

### DIFF
--- a/tests/testsuite/resolve.rs
+++ b/tests/testsuite/resolve.rs
@@ -35,7 +35,7 @@ proptest! {
     })]
     #[test]
     fn passes_validation(
-        PrettyPrintRegistry(input) in registry_strategy(50, 10, 50)
+        PrettyPrintRegistry(input) in registry_strategy(50, 20, 60)
     )  {
         let reg = registry(input.clone());
         // there is only a small chance that eny one
@@ -51,7 +51,7 @@ proptest! {
     }
     #[test]
     fn limited_independence_of_irrelevant_alternatives(
-        PrettyPrintRegistry(input) in registry_strategy(50, 10, 50),
+        PrettyPrintRegistry(input) in registry_strategy(50, 20, 60),
         indexs_to_unpublish in vec(any::<prop::sample::Index>(), 10)
     )  {
         let reg = registry(input.clone());

--- a/tests/testsuite/resolve.rs
+++ b/tests/testsuite/resolve.rs
@@ -180,7 +180,7 @@ fn test_resolving_transitive_deps() {
     let reg = registry(vec![pkg!("foo"), pkg!("bar" => ["foo"])]);
     let res = resolve(&pkg_id("root"), vec![dep("bar")], &reg).unwrap();
 
-    assert_contains(&res, &names(&["root", "foo", "bar"]));
+    assert_same(&res, &names(&["root", "foo", "bar"]));
 }
 
 #[test]
@@ -188,7 +188,7 @@ fn test_resolving_common_transitive_deps() {
     let reg = registry(vec![pkg!("foo" => ["bar"]), pkg!("bar")]);
     let res = resolve(&pkg_id("root"), vec![dep("foo"), dep("bar")], &reg).unwrap();
 
-    assert_contains(&res, &names(&["root", "foo", "bar"]));
+    assert_same(&res, &names(&["root", "foo", "bar"]));
 }
 
 #[test]
@@ -234,7 +234,7 @@ fn test_resolving_with_dev_deps() {
     )
     .unwrap();
 
-    assert_contains(&res, &names(&["root", "foo", "bar", "baz"]));
+    assert_same(&res, &names(&["root", "foo", "bar", "baz", "bat"]));
 }
 
 #[test]
@@ -243,7 +243,7 @@ fn resolving_with_many_versions() {
 
     let res = resolve(&pkg_id("root"), vec![dep("foo")], &reg).unwrap();
 
-    assert_contains(&res, &names(&[("root", "1.0.0"), ("foo", "1.0.2")]));
+    assert_same(&res, &names(&[("root", "1.0.0"), ("foo", "1.0.2")]));
 }
 
 #[test]
@@ -252,7 +252,7 @@ fn resolving_with_specific_version() {
 
     let res = resolve(&pkg_id("root"), vec![dep_req("foo", "=1.0.1")], &reg).unwrap();
 
-    assert_contains(&res, &names(&[("root", "1.0.0"), ("foo", "1.0.1")]));
+    assert_same(&res, &names(&[("root", "1.0.0"), ("foo", "1.0.1")]));
 }
 
 #[test]
@@ -459,7 +459,7 @@ fn resolving_allows_multiple_compatible_versions() {
 
     let res = resolve(&pkg_id("root"), vec![dep("bar")], &reg).unwrap();
 
-    assert_contains(
+    assert_same(
         &res,
         &names(&[
             ("root", "1.0.0"),
@@ -492,7 +492,7 @@ fn resolving_with_deep_backtracking() {
 
     let res = resolve(&pkg_id("root"), vec![dep_req("foo", "1")], &reg).unwrap();
 
-    assert_contains(
+    assert_same(
         &res,
         &names(&[
             ("root", "1.0.0"),
@@ -524,7 +524,7 @@ fn resolving_with_sys_crates() {
     )
     .unwrap();
 
-    assert_contains(
+    assert_same(
         &res,
         &names(&[
             ("root", "1.0.0"),
@@ -891,9 +891,10 @@ fn resolving_with_constrained_sibling_transitive_dep_effects() {
 
     let res = resolve(&pkg_id("root"), vec![dep_req("A", "1")], &reg).unwrap();
 
-    assert_contains(
+    assert_same(
         &res,
         &names(&[
+            ("root", "1.0.0"),
             ("A", "1.0.0"),
             ("B", "1.0.0"),
             ("C", "1.0.0"),
@@ -1109,7 +1110,7 @@ fn hard_equality() {
     )
     .unwrap();
 
-    assert_contains(
+    assert_same(
         &res,
         &names(&[("root", "1.0.0"), ("foo", "1.0.0"), ("bar", "1.0.0")]),
     );


### PR DESCRIPTION
This should make the slow proptest tests approximately 10x faster. It also adds a test ensuring that we make fuzz inputs that involve multiple versions of the same library. 