### PR TITLE
Fix dylib reuse with uplift.

### DIFF
--- a/src/cargo/core/compiler/compilation.rs
+++ b/src/cargo/core/compiler/compilation.rs
@@ -193,8 +193,8 @@ impl<'cfg> Compilation<'cfg> {
         } else {
             let mut search_path =
                 super::filter_dynamic_search_path(self.native_dirs.iter(), &self.root_output);
-            search_path.push(self.root_output.clone());
             search_path.push(self.deps_output.clone());
+            search_path.push(self.root_output.clone());
             search_path.extend(self.target_dylib_path.clone());
             search_path
         };


### PR DESCRIPTION
Due to #5460, the files that are copied to the root of the target dir depend on whether or not it is a direct target. This causes a problem with dylibs if you build a dylib directly, and then separately run a target that depends on that dylib.  It will run with the dylib path preferring the root dir, which picks up the old dylib.  This PR swaps the preference of the dylib search path so that the dylib in the `deps` dir is preferred.

This is maybe not the best solution for dynamic dependencies. I can imagine if you are trying to create a package, you'll want all of the shared libs along with the binary, and digging through the `deps` dir is not optimal.  However, unconditionally linking dependencies into the root has issues (which #5460 fixed).  There are other issues because shared libs do not include a hash in the filename.  A grander solution might involve coming up with a better strategy for organizing the `target` directory to avoid conflicts between targets.

Fixes #6162