### PR TITLE
Future proof an unstable test

### DIFF
--- a/tests/testsuite/doc.rs
+++ b/tests/testsuite/doc.rs
@@ -571,6 +571,9 @@ fn doc_target() {
             #![feature(no_core)]
             #![no_core]
 
+            #[lang = "sized"]
+            trait Sized {}
+
             extern {
                 pub static A: u32;
             }

--- a/tests/testsuite/doc.rs
+++ b/tests/testsuite/doc.rs
@@ -568,7 +568,7 @@ fn doc_target() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(no_core)]
+            #![feature(no_core, lang_items)]
             #![no_core]
 
             #[lang = "sized"]


### PR DESCRIPTION
statics (even extern ones) will get their type checked for a `Sized` bound in order to fix https://github.com/rust-lang/rust/issues/54410