### PR TITLE
Remove the remove TODO on Compilation.native_dirs

### DIFF
--- a/src/cargo/core/compiler/compilation.rs
+++ b/src/cargo/core/compiler/compilation.rs
@@ -33,7 +33,6 @@ pub struct Compilation<'cfg> {
     /// LD_LIBRARY_PATH as appropriate.
     ///
     /// The order should be deterministic.
-    // TODO: deprecated, remove
     pub native_dirs: BTreeSet<PathBuf>,
 
     /// Root output directory (for the local package's artifacts)


### PR DESCRIPTION
It's still used, see tests:

* build_script::doctest_receives_build_link_args
* build_script::rename_with_link_search_path
* run::run_with_library_paths
* run::library_paths_sorted_alphabetically

Originally I was trying to action https://github.com/rust-lang/cargo/pull/792#discussion_r226826431 with this PR