### PR TITLE
Fix download summary overlapping progress.

### DIFF
--- a/src/cargo/core/package.rs
+++ b/src/cargo/core/package.rs
@@ -694,6 +694,8 @@ impl<'a, 'cfg> Drop for Downloads<'a, 'cfg> {
                 ByteSize(self.largest.0),
             ));
         }
+        // Clear progress before displaying final summary.
+        drop(progress);
         drop(self.set.config.shell().status("Downloaded", status));
     }
 }


### PR DESCRIPTION
The following two lines:

```
 Downloading 0 crates, extracting cargo-modules ...
  Downloaded 1 crates (541.8 KB) in 1.64s
```

Were being combined resulting in:

```
  Downloaded 1 crates (541.8 KB) in 1.64sodules ...
```