### PR TITLE
[BETA] Partially destabilize edition.

### DIFF
--- a/src/bin/cargo/command_prelude.rs
+++ b/src/bin/cargo/command_prelude.rs
@@ -151,11 +151,6 @@ pub trait AppExt: Sized {
             ._arg(opt("bin", "Use a binary (application) template [default]"))
             ._arg(opt("lib", "Use a library template"))
             ._arg(
-                opt("edition", "Edition to set for the crate generated")
-                    .possible_values(&["2015", "2018"])
-                    .value_name("YEAR")
-            )
-            ._arg(
                 opt(
                     "name",
                     "Set the resulting package name, defaults to the directory name",
@@ -346,7 +341,6 @@ pub trait ArgMatchesExt {
             self._is_present("lib"),
             self.value_of_path("path", config).unwrap(),
             self._value_of("name").map(|s| s.to_string()),
-            self._value_of("edition").map(|s| s.to_string()),
         )
     }
 

--- a/src/cargo/ops/cargo_new.rs
+++ b/src/cargo/ops/cargo_new.rs
@@ -30,7 +30,6 @@ pub struct NewOptions {
     /// Absolute path to the directory for the new project
     pub path: PathBuf,
     pub name: Option<String>,
-    pub edition: Option<String>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -66,7 +65,6 @@ struct MkOptions<'a> {
     name: &'a str,
     source_files: Vec<SourceFileInformation>,
     bin: bool,
-    edition: Option<&'a str>,
 }
 
 impl NewOptions {
@@ -76,7 +74,6 @@ impl NewOptions {
         lib: bool,
         path: PathBuf,
         name: Option<String>,
-        edition: Option<String>,
     ) -> CargoResult<NewOptions> {
         let kind = match (bin, lib) {
             (true, true) => bail!("can't specify both lib and binary outputs"),
@@ -90,7 +87,6 @@ impl NewOptions {
             kind,
             path,
             name,
-            edition,
         };
         Ok(opts)
     }
@@ -325,7 +321,6 @@ pub fn new(opts: &NewOptions, config: &Config) -> CargoResult<()> {
         name,
         source_files: vec![plan_new_source_file(opts.kind.is_bin(), name.to_string())],
         bin: opts.kind.is_bin(),
-        edition: opts.edition.as_ref().map(|s| &**s),
     };
 
     mk(config, &mkopts).chain_err(|| {
@@ -402,7 +397,6 @@ pub fn init(opts: &NewOptions, config: &Config) -> CargoResult<()> {
         name,
         bin: src_paths_types.iter().any(|x| x.bin),
         source_files: src_paths_types,
-        edition: opts.edition.as_ref().map(|s| &**s),
     };
 
     mk(config, &mkopts).chain_err(|| {
@@ -536,16 +530,11 @@ path = {}
 name = "{}"
 version = "0.1.0"
 authors = [{}]
-edition = {}
 
 [dependencies]
 {}"#,
             name,
             toml::Value::String(author),
-            match opts.edition {
-                Some(edition) => toml::Value::String(edition.to_string()),
-                None => toml::Value::String("2018".to_string()),
-            },
             cargotoml_path_specifier
         ).as_bytes(),
     )?;

--- a/src/doc/src/reference/manifest.md
+++ b/src/doc/src/reference/manifest.md
@@ -31,24 +31,6 @@ Versioning](http://semver.org/), so make sure you follow some basic rules:
   traits, fields, types, functions, methods or anything else.
 * Use version numbers with three numeric parts such as 1.0.0 rather than 1.0.
 
-#### The `edition` field (optional)
-
-You can opt in to a specific Rust Edition for your package with the
-`edition` key in `Cargo.toml`.  If you don't specify the edition, it will
-default to 2015.
-
-```toml
-[package]
-# ...
-edition = '2018'
-```
-
-The `edition` key affects which edition your package is compiled with. Cargo
-will always generate projects via `cargo new` with the `edition` key set to the
-latest edition. Setting the `edition` key in `[package]` will affect all
-targets/crates in the package, including test suites, benchmarks, binaries,
-examples, etc.
-
 #### The `build` field (optional)
 
 This field specifies a file in the project root which is a [build script][1] for
@@ -732,12 +714,6 @@ proc-macro = false
 # stops it from generating a test harness. This is useful when the binary being
 # built manages the test runner itself.
 harness = true
-
-# If set then a target can be configured to use a different edition than the
-# `[package]` is configured to use, perhaps only compiling a library with the
-# 2018 edition or only compiling one unit test with the 2015 edition. By default
-# all targets are compiled with the edition specified in `[package]`.
-edition = '2015'
 ```
 
 The `[package]` also includes the optional `autobins`, `autoexamples`,

--- a/tests/testsuite/doc.rs
+++ b/tests/testsuite/doc.rs
@@ -568,8 +568,11 @@ fn doc_target() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(no_core)]
+            #![feature(no_core, lang_items)]
             #![no_core]
+
+            #[lang = "sized"]
+            trait Sized {}
 
             extern {
                 pub static A: u32;
@@ -635,7 +638,7 @@ fn output_not_captured() {
         ).build();
 
     p.cargo("doc")
-        .with_status(101)
+        .without_status()
         .with_stderr_contains("1 | ☃")
         .with_stderr_contains(r"error: unknown start of token: \u{2603}")
         .run();

--- a/tests/testsuite/init.rs
+++ b/tests/testsuite/init.rs
@@ -13,7 +13,7 @@ fn cargo_process(s: &str) -> Execs {
 
 #[test]
 fn simple_lib() {
-    cargo_process("init --lib --vcs none --edition 2015")
+    cargo_process("init --lib --vcs none")
         .env("USER", "foo")
         .with_stderr("[CREATED] library project")
         .run();
@@ -29,7 +29,7 @@ fn simple_lib() {
 fn simple_bin() {
     let path = paths::root().join("foo");
     fs::create_dir(&path).unwrap();
-    cargo_process("init --bin --vcs none --edition 2015")
+    cargo_process("init --bin --vcs none")
         .env("USER", "foo")
         .cwd(&path)
         .with_stderr("[CREATED] binary (application) project")

--- a/tests/testsuite/new.rs
+++ b/tests/testsuite/new.rs
@@ -14,7 +14,7 @@ fn create_empty_gitconfig() {
 
 #[test]
 fn simple_lib() {
-    cargo_process("new --lib foo --vcs none --edition 2015")
+    cargo_process("new --lib foo --vcs none")
         .env("USER", "foo")
         .with_stderr("[CREATED] library `foo` project")
         .run();
@@ -47,7 +47,7 @@ mod tests {
 
 #[test]
 fn simple_bin() {
-    cargo_process("new --bin foo --edition 2015")
+    cargo_process("new --bin foo")
         .env("USER", "foo")
         .with_stderr("[CREATED] binary (application) `foo` project")
         .run();
@@ -75,7 +75,7 @@ fn both_lib_and_bin() {
 
 #[test]
 fn simple_git() {
-    cargo_process("new --lib foo --edition 2015").env("USER", "foo").run();
+    cargo_process("new --lib foo").env("USER", "foo").run();
 
     assert!(paths::root().is_dir());
     assert!(paths::root().join("foo/Cargo.toml").is_file());
@@ -453,41 +453,5 @@ fn explicit_project_name() {
     cargo_process("new --lib foo --name bar")
         .env("USER", "foo")
         .with_stderr("[CREATED] library `bar` project")
-        .run();
-}
-
-#[test]
-fn new_with_edition_2015() {
-    cargo_process("new --edition 2015 foo")
-        .env("USER", "foo")
-        .run();
-    let manifest = fs::read_to_string(paths::root().join("foo/Cargo.toml")).unwrap();
-    assert!(manifest.contains("edition = \"2015\""));
-}
-
-#[test]
-fn new_with_edition_2018() {
-    cargo_process("new --edition 2018 foo")
-        .env("USER", "foo")
-        .run();
-    let manifest = fs::read_to_string(paths::root().join("foo/Cargo.toml")).unwrap();
-    assert!(manifest.contains("edition = \"2018\""));
-}
-
-#[test]
-fn new_default_edition() {
-    cargo_process("new foo")
-        .env("USER", "foo")
-        .run();
-    let manifest = fs::read_to_string(paths::root().join("foo/Cargo.toml")).unwrap();
-    assert!(manifest.contains("edition = \"2018\""));
-}
-
-#[test]
-fn new_with_bad_edition() {
-    cargo_process("new --edition something_else foo")
-        .env("USER", "foo")
-        .with_stderr_contains("error: 'something_else' isn't a valid value[..]")
-        .with_status(1)
         .run();
 }

--- a/tests/testsuite/support/mod.rs
+++ b/tests/testsuite/support/mod.rs
@@ -566,6 +566,14 @@ impl Execs {
         self
     }
 
+    /// Remove exit code check for the process.
+    ///
+    /// By default, the expected exit code is `0`.
+    pub fn without_status(&mut self) -> &mut Self {
+        self.expect_exit_code = None;
+        self
+    }
+
     /// Verify that stdout contains the given contiguous lines somewhere in
     /// its output.
     /// See `lines_match` for supported patterns.


### PR DESCRIPTION
Removes edition from `cargo new`, and documentation.

Also includes (parts of) #6176 and #6027 to get the beta branch to pass tests on CI.
