### PR TITLE
[1.30.0] Revert 6062 - restore -Zunstable-options for rustdoc

### DIFF
--- a/src/cargo/core/compiler/compilation.rs
+++ b/src/cargo/core/compiler/compilation.rs
@@ -140,6 +140,7 @@ impl<'cfg> Compilation<'cfg> {
     pub fn rustdoc_process(&self, pkg: &Package, target: &Target) -> CargoResult<ProcessBuilder> {
         let mut p = self.fill_env(process(&*self.config.rustdoc()?), pkg, false)?;
         if target.edition() != Edition::Edition2015 {
+            p.arg("-Zunstable-options");
             p.arg(format!("--edition={}", target.edition()));
         }
         Ok(p)

--- a/tests/testsuite/doc.rs
+++ b/tests/testsuite/doc.rs
@@ -1121,12 +1121,12 @@ fn doc_edition() {
 
     p.cargo("doc -v")
         .masquerade_as_nightly_cargo()
-        .with_stderr_contains("[RUNNING] `rustdoc [..]--edition=2018[..]")
+        .with_stderr_contains("[RUNNING] `rustdoc [..]-Zunstable-options --edition=2018[..]")
         .run();
 
     p.cargo("test -v")
         .masquerade_as_nightly_cargo()
-        .with_stderr_contains("[RUNNING] `rustdoc [..]--edition=2018[..]")
+        .with_stderr_contains("[RUNNING] `rustdoc [..]-Zunstable-options --edition=2018[..]")
         .run();
 }
 
@@ -1153,12 +1153,12 @@ fn doc_target_edition() {
 
     p.cargo("doc -v")
         .masquerade_as_nightly_cargo()
-        .with_stderr_contains("[RUNNING] `rustdoc [..]--edition=2018[..]")
+        .with_stderr_contains("[RUNNING] `rustdoc [..]-Zunstable-options --edition=2018[..]")
         .run();
 
     p.cargo("test -v")
         .masquerade_as_nightly_cargo()
-        .with_stderr_contains("[RUNNING] `rustdoc [..]--edition=2018[..]")
+        .with_stderr_contains("[RUNNING] `rustdoc [..]-Zunstable-options --edition=2018[..]")
         .run();
 }
 


### PR DESCRIPTION
This reverts commit 2131e5a253a5490c0ec478c9940193a48eff664c, reversing
changes made to 8dd0b1cc1980f00c94d661d5ccd9d31ac560302e.

Reverts #6062 since edition is destabilized on stable.