### PR TITLE
Add `c` alias for `check`

### DIFF
--- a/src/bin/cargo/commands/check.rs
+++ b/src/bin/cargo/commands/check.rs
@@ -4,6 +4,8 @@ use cargo::ops;
 
 pub fn cli() -> App {
     subcommand("check")
+        // subcommand aliases are handled in commands::builtin_exec() and cli::expand_aliases()
+        // .alias("c")
         .about("Check a local package and all of its dependencies for errors")
         .arg_package_spec(
             "Package(s) to check",

--- a/src/bin/cargo/commands/mod.rs
+++ b/src/bin/cargo/commands/mod.rs
@@ -44,7 +44,7 @@ pub fn builtin_exec(cmd: &str) -> Option<BuiltinExec> {
     let exec = match cmd {
         "bench" => bench::exec,
         "build" | "b" => build::exec,
-        "check" => check::exec,
+        "check" | "c" => check::exec,
         "clean" => clean::exec,
         "doc" => doc::exec,
         "fetch" => fetch::exec,
@@ -77,6 +77,7 @@ pub fn builtin_exec(cmd: &str) -> Option<BuiltinExec> {
 
     let alias_for = match cmd {
         "b" => Some("build"),
+        "c" => Some("check"),
         "r" => Some("run"),
         "t" => Some("test"),
         _ => None,


### PR DESCRIPTION
This PR adds `cargo c` alias for `cargo check`.

I believe that one of the most frequently used subcommands is `check`.
Adding this alias would save much time.

Currently, there are three aliases: `b` for `build`, `r` for `run`, `t` for `test`.
I think that adding out-of-the-box `c` alias is *natural* for many developers, and these aliases would cover most of the use cases.
We can add aliases via a configuration file, but I guess people would expect built-in `c` alias along with `b` and others.

One problem I have come up with is that the `clean` subcommand also starts with the letter `c`.
But I believe that running `check` subcommand by mistake would not hurt developers so much.

Fixes #6215 