### PR TITLE
Warn if built-in subcommand aliases shadow user-defined aliases

### DIFF
--- a/src/bin/cargo/cli.rs
+++ b/src/bin/cargo/cli.rs
@@ -118,11 +118,19 @@ fn expand_aliases(
                     .get_matches_from_safe(alias)?;
                 return expand_aliases(config, args);
             }
-            (Some(_), Some(_)) => {
-                config.shell().warn(format!(
-                    "alias `{}` is ignored, because it is shadowed by a built in command",
+            (Some((_, alias_for)), Some(_)) => {
+                let mut message = format!(
+                    "alias `{}` is ignored, because it is shadowed by a built-in ",
                     cmd
-                ))?;
+                );
+
+                if let Some(alias_for) = alias_for {
+                    message.push_str(&format!("alias for `{}`", alias_for));
+                } else {
+                    message.push_str("command");
+            }
+
+                config.shell().warn(message)?;
             }
             (_, None) => {}
         }
@@ -156,7 +164,7 @@ fn execute_subcommand(config: &mut Config, args: &ArgMatches) -> CliResult {
             .unwrap_or_default(),
     )?;
 
-    if let Some(exec) = commands::builtin_exec(cmd) {
+    if let Some((exec, _)) = commands::builtin_exec(cmd) {
         return exec(config, subcommand_args);
     }
 

--- a/src/bin/cargo/commands/build.rs
+++ b/src/bin/cargo/commands/build.rs
@@ -4,8 +4,7 @@ use cargo::ops;
 
 pub fn cli() -> App {
     subcommand("build")
-        // subcommand aliases are handled in
-        // commands::builtin_exec() and command::cli::aliased_command()
+        // subcommand aliases are handled in commands::builtin_exec() and cli::expand_aliases()
         // .alias("b")
         .about("Compile a local package and all of its dependencies")
         .arg_package_spec(

--- a/src/bin/cargo/commands/build.rs
+++ b/src/bin/cargo/commands/build.rs
@@ -4,7 +4,9 @@ use cargo::ops;
 
 pub fn cli() -> App {
     subcommand("build")
-        .alias("b")
+        // subcommand aliases are handled in
+        // commands::builtin_exec() and command::cli::aliased_command()
+        // .alias("b")
         .about("Compile a local package and all of its dependencies")
         .arg_package_spec(
             "Package to build (see `cargo help pkgid`)",

--- a/src/bin/cargo/commands/mod.rs
+++ b/src/bin/cargo/commands/mod.rs
@@ -35,10 +35,13 @@ pub fn builtin() -> Vec<App> {
     ]
 }
 
-pub fn builtin_exec(
-    cmd: &str,
-) -> Option<(fn(&mut Config, &ArgMatches) -> CliResult, Option<&str>)> {
-    let f = match cmd {
+pub struct BuiltinExec<'a> {
+    pub exec: fn(&'a mut Config, &'a ArgMatches) -> CliResult,
+    pub alias_for: Option<&'a str>,
+}
+
+pub fn builtin_exec(cmd: &str) -> Option<BuiltinExec> {
+    let exec = match cmd {
         "bench" => bench::exec,
         "build" => build::exec,
         "b" => build::exec,
@@ -75,14 +78,14 @@ pub fn builtin_exec(
         _ => return None,
     };
 
-    let is_alias = match cmd {
+    let alias_for = match cmd {
         "b" => Some("build"),
         "r" => Some("run"),
         "t" => Some("test"),
         _ => None,
     };
 
-    Some((f, is_alias))
+    Some(BuiltinExec { exec, alias_for })
 }
 
 pub mod bench;

--- a/src/bin/cargo/commands/mod.rs
+++ b/src/bin/cargo/commands/mod.rs
@@ -37,14 +37,13 @@ pub fn builtin() -> Vec<App> {
 
 pub struct BuiltinExec<'a> {
     pub exec: fn(&'a mut Config, &'a ArgMatches) -> CliResult,
-    pub alias_for: Option<&'a str>,
+    pub alias_for: Option<&'static str>,
 }
 
 pub fn builtin_exec(cmd: &str) -> Option<BuiltinExec> {
     let exec = match cmd {
         "bench" => bench::exec,
-        "build" => build::exec,
-        "b" => build::exec,
+        "build" | "b" => build::exec,
         "check" => check::exec,
         "clean" => clean::exec,
         "doc" => doc::exec,
@@ -63,13 +62,11 @@ pub fn builtin_exec(cmd: &str) -> Option<BuiltinExec> {
         "pkgid" => pkgid::exec,
         "publish" => publish::exec,
         "read-manifest" => read_manifest::exec,
-        "run" => run::exec,
-        "r" => run::exec,
+        "run" | "r" => run::exec,
         "rustc" => rustc::exec,
         "rustdoc" => rustdoc::exec,
         "search" => search::exec,
-        "test" => test::exec,
-        "t" => test::exec,
+        "test" | "t" => test::exec,
         "uninstall" => uninstall::exec,
         "update" => update::exec,
         "verify-project" => verify_project::exec,

--- a/src/bin/cargo/commands/mod.rs
+++ b/src/bin/cargo/commands/mod.rs
@@ -35,10 +35,13 @@ pub fn builtin() -> Vec<App> {
     ]
 }
 
-pub fn builtin_exec(cmd: &str) -> Option<fn(&mut Config, &ArgMatches) -> CliResult> {
+pub fn builtin_exec(
+    cmd: &str,
+) -> Option<(fn(&mut Config, &ArgMatches) -> CliResult, Option<&str>)> {
     let f = match cmd {
         "bench" => bench::exec,
         "build" => build::exec,
+        "b" => build::exec,
         "check" => check::exec,
         "clean" => clean::exec,
         "doc" => doc::exec,
@@ -58,10 +61,12 @@ pub fn builtin_exec(cmd: &str) -> Option<fn(&mut Config, &ArgMatches) -> CliResu
         "publish" => publish::exec,
         "read-manifest" => read_manifest::exec,
         "run" => run::exec,
+        "r" => run::exec,
         "rustc" => rustc::exec,
         "rustdoc" => rustdoc::exec,
         "search" => search::exec,
         "test" => test::exec,
+        "t" => test::exec,
         "uninstall" => uninstall::exec,
         "update" => update::exec,
         "verify-project" => verify_project::exec,
@@ -69,7 +74,15 @@ pub fn builtin_exec(cmd: &str) -> Option<fn(&mut Config, &ArgMatches) -> CliResu
         "yank" => yank::exec,
         _ => return None,
     };
-    Some(f)
+
+    let is_alias = match cmd {
+        "b" => Some("build"),
+        "r" => Some("run"),
+        "t" => Some("test"),
+        _ => None,
+    };
+
+    Some((f, is_alias))
 }
 
 pub mod bench;

--- a/src/bin/cargo/commands/run.rs
+++ b/src/bin/cargo/commands/run.rs
@@ -5,7 +5,9 @@ use cargo::ops::{self, CompileFilter};
 
 pub fn cli() -> App {
     subcommand("run")
-        .alias("r")
+        // subcommand aliases are handled in
+        // commands::builtin_exec() and command::cli::aliased_command()
+        // .alias("r")
         .setting(AppSettings::TrailingVarArg)
         .about("Run the main binary of the local package (src/main.rs)")
         .arg(Arg::with_name("args").multiple(true))

--- a/src/bin/cargo/commands/run.rs
+++ b/src/bin/cargo/commands/run.rs
@@ -5,8 +5,7 @@ use cargo::ops::{self, CompileFilter};
 
 pub fn cli() -> App {
     subcommand("run")
-        // subcommand aliases are handled in
-        // commands::builtin_exec() and command::cli::aliased_command()
+        // subcommand aliases are handled in commands::builtin_exec() and cli::expand_aliases()
         // .alias("r")
         .setting(AppSettings::TrailingVarArg)
         .about("Run the main binary of the local package (src/main.rs)")

--- a/src/bin/cargo/commands/test.rs
+++ b/src/bin/cargo/commands/test.rs
@@ -4,8 +4,7 @@ use cargo::ops::{self, CompileFilter};
 
 pub fn cli() -> App {
     subcommand("test")
-        // subcommand aliases are handled in
-        // commands::builtin_exec() and command::cli::aliased_command()
+        // subcommand aliases are handled in commands::builtin_exec() and cli::expand_aliases()
         // .alias("t")
         .setting(AppSettings::TrailingVarArg)
         .about("Execute all unit and integration tests of a local package")

--- a/src/bin/cargo/commands/test.rs
+++ b/src/bin/cargo/commands/test.rs
@@ -4,7 +4,9 @@ use cargo::ops::{self, CompileFilter};
 
 pub fn cli() -> App {
     subcommand("test")
-        .alias("t")
+        // subcommand aliases are handled in
+        // commands::builtin_exec() and command::cli::aliased_command()
+        // .alias("t")
         .setting(AppSettings::TrailingVarArg)
         .about("Execute all unit and integration tests of a local package")
         .arg(

--- a/tests/testsuite/cargo_alias_config.rs
+++ b/tests/testsuite/cargo_alias_config.rs
@@ -137,7 +137,30 @@ fn cant_shadow_builtin() {
     p.cargo("build")
         .with_stderr(
             "\
-[WARNING] alias `build` is ignored, because it is shadowed by a built in command
+[WARNING] alias `build` is ignored, because it is shadowed by a built-in command
+[COMPILING] foo v0.5.0 ([..])
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+",
+        ).run();
+}
+
+#[test]
+fn cant_shadow_builtin_alias() {
+    let p = project()
+        .file("Cargo.toml", &basic_bin_manifest("foo"))
+        .file("src/main.rs", "fn main() {}")
+        .file(
+            ".cargo/config",
+            r#"
+            [alias]
+            b = "fetch"
+         "#,
+        ).build();
+
+    p.cargo("b")
+        .with_stderr(
+            "\
+[WARNING] alias `b` is ignored, because it is shadowed by a built-in alias for `build`
 [COMPILING] foo v0.5.0 ([..])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",


### PR DESCRIPTION
This PR makes Cargo emit a warning if built-in subcommand aliases (`b`, `r`, and `t`) shadow user-defined aliases.

```
$ cat .cargo/config
[alias]
b = "foo"

$ ./target/debug/cargo b
warning: alias `b` is ignored, because it is shadowed by a built-in alias for `build`

```

In order to handle subcommand aliases **after** clap parses the command line options, it seems to be necessary to stop using clap for subcommand aliases.
So now `help` command does not work with subcommand aliases, but I think it is not a big problem.

Fixes #6221