### PR TITLE
Use ANSI escape code to clear line

### DIFF
--- a/src/cargo/util/progress.rs
+++ b/src/cargo/util/progress.rs
@@ -196,9 +196,7 @@ impl<'cfg> State<'cfg> {
     }
 
     fn clear(&mut self) {
-        self.try_update_max_width();
-        let blank = " ".repeat(self.format.max_width);
-        drop(write!(self.config.shell().err(), "{}\r", blank));
+        self.config.shell().err_erase_line();
     }
 
     fn try_update_max_width(&mut self) {


### PR DESCRIPTION
This eliminates the trailing spaces that Cargo used to use for clearing a line of output. Trailing spaces are problematic because they take up space on the next line when reducing the width of a terminal.