### PR TITLE
Allow usernames in alt registry URLs

### DIFF
--- a/src/cargo/util/config.rs
+++ b/src/cargo/util/config.rs
@@ -669,8 +669,8 @@ impl Config {
             match self.get_string(&format!("registries.{}.index", registry))? {
                 Some(index) => {
                     let url = index.val.to_url()?;
-                    if url.username() != "" || url.password().is_some() {
-                        bail!("Registry URLs may not contain credentials");
+                    if url.password().is_some() {
+                        bail!("Registry URLs may not contain passwords");
                     }
                     url
                 }

--- a/tests/testsuite/alt_registry.rs
+++ b/tests/testsuite/alt_registry.rs
@@ -458,7 +458,7 @@ fn publish_with_crates_io_dep() {
 }
 
 #[test]
-fn credentials_in_url_forbidden() {
+fn passwords_in_url_forbidden() {
     registry::init();
 
     let config = paths::home().join(".cargo/config");
@@ -489,6 +489,6 @@ fn credentials_in_url_forbidden() {
     p.cargo("publish --registry alternative -Zunstable-options")
         .masquerade_as_nightly_cargo()
         .with_status(101)
-        .with_stderr_contains("error: Registry URLs may not contain credentials")
+        .with_stderr_contains("error: Registry URLs may not contain passwords")
         .run();
 }


### PR DESCRIPTION
We want to forbid secrets since they'll commonly end up checked into
source control, but usernames are fine (and are commonly going to be
`git`).

Closes #6241 

r? @alexcrichton 