### PR TITLE
Pass `--update-head-ok` when fetching via git CLI

### DIFF
--- a/src/cargo/sources/git/utils.rs
+++ b/src/cargo/sources/git/utils.rs
@@ -755,6 +755,7 @@ fn fetch_with_cli(
     cmd.arg("fetch")
         .arg("--tags") // fetch all tags
         .arg("--quiet")
+        .arg("--update-head-ok") // see discussion in #2078
         .arg(url.to_string())
         .arg(refspec)
         .cwd(repo.path());


### PR DESCRIPTION
Discovered in a recent [comment] it looks like not passing this may
cause the git CLI to fail in some situations.

[comment]: https://github.com/rust-lang/cargo/issues/2078#issuecomment-435333292