### PR TITLE
Fix slow MacOS Travis issue.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ matrix:
     - env: TARGET=x86_64-apple-darwin
            ALT=i686-apple-darwin
       os: osx
+      osx_image: xcode9.2
       if: branch != master OR type = pull_request
 
     - env: TARGET=x86_64-unknown-linux-gnu

--- a/tests/testsuite/metabuild.rs
+++ b/tests/testsuite/metabuild.rs
@@ -2,7 +2,8 @@ use glob::glob;
 use serde_json;
 use std::str;
 use support::{
-    basic_lib_manifest, basic_manifest, project, registry::Package, rustc_host, Project,
+    basic_lib_manifest, basic_manifest, is_coarse_mtime, project, registry::Package, rustc_host,
+    Project,
 };
 
 #[test]
@@ -212,6 +213,14 @@ fn metabuild_lib_name() {
 
 #[test]
 fn metabuild_fresh() {
+    if is_coarse_mtime() {
+        // This test doesn't work on coarse mtimes very well. Because the
+        // metabuild script is created at build time, its mtime is almost
+        // always equal to the mtime of the output. The second call to `build`
+        // will then think it needs to be rebuilt when it should be fresh.
+        return;
+    }
+
     // Check that rebuild is fresh.
     let p = project()
         .file(


### PR DESCRIPTION
OS X 10.13 images on Travis are running very slow and causing timeouts. This PR does two things:

- Use OS X 10.12 (`xode9.2`) which is much faster.
- Implement a change to the testsuite to handle 1-second resolution mtimes on HFS. When a test executes cargo multiple times, and the first run finishes in under 1 second, the second one will think it needs to rebuild because the mtime of the files equals the mtime of the output. This change forces the mtime of every project to be created 1 second in the past. Tests that are still sensitive to mtimes are adjusted on a case-by-case basis.

Closes #6239, Closes #5940
