### PR TITLE
Configure tar to not set mtime

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,10 @@ openssl = { version = '0.10.11', optional = true }
 # for more information.
 rustc-workspace-hack = "1.0.0"
 
+# TODO: This patch will be removed before PR merge, when tar has a release containing this patch
+[patch.crates-io]
+tar = { git = "https://github.com/alexcrichton/tar-rs", rev = "f442964" }
+
 [target.'cfg(target_os = "macos")'.dependencies]
 core-foundation = { version = "0.6.0", features = ["mac_os_10_7_support"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ serde_derive = "1.0"
 serde_ignored = "0.0.4"
 serde_json = { version = "1.0.30", features = ["raw_value"] }
 shell-escape = "0.1.4"
-tar = { version = "0.4.15", default-features = false }
+tar = { version = "0.4.18", default-features = false }
 tempfile = "3.0"
 termcolor = "1.0"
 toml = "0.4.2"
@@ -63,10 +63,6 @@ openssl = { version = '0.10.11', optional = true }
 # See the `src/tools/rustc-workspace-hack/README.md` file in `rust-lang/rust`
 # for more information.
 rustc-workspace-hack = "1.0.0"
-
-# TODO: This patch will be removed before PR merge, when tar has a release containing this patch
-[patch.crates-io]
-tar = { git = "https://github.com/alexcrichton/tar-rs", rev = "f442964" }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 core-foundation = { version = "0.6.0", features = ["mac_os_10_7_support"] }

--- a/src/cargo/ops/cargo_package.rs
+++ b/src/cargo/ops/cargo_package.rs
@@ -418,6 +418,9 @@ fn run_verify(ws: &Workspace, tar: &FileLock, opts: &PackageOpts) -> CargoResult
         paths::remove_dir_all(&dst)?;
     }
     let mut archive = Archive::new(f);
+    // We don't need to set the Modified Time, as it's not relevant to verification
+    // and it errors on filesystems that don't support setting a modified timestamp
+    archive.set_preserve_mtime(false);
     archive.unpack(dst.parent().unwrap())?;
 
     // Manufacture an ephemeral workspace to ensure that even if the top-level


### PR DESCRIPTION
This PR is fixes #6238. Currently uses a `patch` on `tar`, and should not be merged until `tar` makes a release containing the function `set_preserve_mtime`.