### PR TITLE
Fix can_run_doc_tests order depends on hash.

### DIFF
--- a/src/cargo/core/compiler/context/mod.rs
+++ b/src/cargo/core/compiler/context/mod.rs
@@ -234,6 +234,8 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
                         }
                     }
                 }
+                // Help with tests to get a stable order with renamed deps.
+                doctest_deps.sort();
                 self.compilation.to_doc_test.push(compilation::Doctest {
                     package: unit.pkg.clone(),
                     target: unit.target.clone(),

--- a/tests/testsuite/rename_deps.rs
+++ b/tests/testsuite/rename_deps.rs
@@ -334,8 +334,8 @@ fn can_run_doc_tests() {
 [DOCTEST] foo
 [RUNNING] `rustdoc --test [CWD]/src/lib.rs \
         [..] \
-        --extern baz=[CWD]/target/debug/deps/libbar-[..].rlib \
         --extern bar=[CWD]/target/debug/deps/libbar-[..].rlib \
+        --extern baz=[CWD]/target/debug/deps/libbar-[..].rlib \
         [..]`
 ",
         ).run();


### PR DESCRIPTION
The deps are sorted, but the name is the same so the order depends on the metadata hash.
Fix by sorting by the actual name, too.

Fixes #6261.