### PR TITLE
Fix fix_path_deps again.

### DIFF
--- a/tests/testsuite/fix.rs
+++ b/tests/testsuite/fix.rs
@@ -183,7 +183,7 @@ fn fix_path_deps() {
     p.cargo("fix --allow-no-vcs -p foo -p bar")
         .env("__CARGO_FIX_YOLO", "1")
         .with_stdout("")
-        .with_stderr(
+        .with_stderr_unordered(
             "\
 [CHECKING] bar v0.1.0 ([..])
 [FIXING] bar/src/lib.rs (1 fix)


### PR DESCRIPTION
The previous fix in #6236 wasn't enough to make this test not fail. On Travis MacOS it fails about 5% of the time. Essentially the first "FIXING" line is sometimes delayed until after the second "CHECKING" line. The "FIXING" message is sent async to the diagnostic server, so I think it's just a race that doesn't have a good way to enforce.  Oddly, I can only repro this on Travis.

Error seen at:
https://travis-ci.org/rust-lang/cargo/jobs/450956693