### PR TITLE
Don't treat rustc exit on signal as internal error.

### DIFF
--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -281,7 +281,7 @@ fn rustc<'a, 'cfg>(
                 .downcast_ref::<ProcessError>()
                 .as_ref()
                 .and_then(|perr| perr.exit.and_then(|e| e.code()))
-                .is_none()
+                != Some(1)
             {
                 return err;
             }


### PR DESCRIPTION
If rustc exits with a signal, previously all you saw was:
```
   Compiling foo ...
error: Could not compile `foo`.

To learn more, run the command again with --verbose.
```

Now it shows the complete error by default:
```
   Compiling foo ...
error: Could not compile `foo`.

Caused by:
  process didn't exit successfully: `rustc ...` (signal: 6, SIGABRT: process abort signal)
```