### PR TITLE
Include path to manifest in workspace warnings.

### DIFF
--- a/tests/testsuite/bad_config.rs
+++ b/tests/testsuite/bad_config.rs
@@ -734,7 +734,7 @@ fn unused_keys_in_virtual_manifest() {
     p.cargo("build --all")
         .with_stderr(
             "\
-warning: unused manifest key: workspace.bulid
+[WARNING] [..]/foo/Cargo.toml: unused manifest key: workspace.bulid
 [COMPILING] bar [..]
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",

--- a/tests/testsuite/workspaces.rs
+++ b/tests/testsuite/workspaces.rs
@@ -1969,3 +1969,32 @@ workspace: [..]/foo/Cargo.toml
             .run();
     }
 }
+
+#[test]
+fn ws_warn_path() {
+    // Warnings include path to manifest.
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [workspace]
+            members = ["a"]
+            "#,
+        )
+        .file(
+            "a/Cargo.toml",
+            r#"
+            cargo-features = ["edition"]
+            [package]
+            name = "foo"
+            version = "0.1.0"
+            "#,
+        )
+        .file("a/src/lib.rs", "")
+        .build();
+
+    p.cargo("check")
+        .with_status(0)
+        .with_stderr_contains("[WARNING] [..]/foo/a/Cargo.toml: the cargo feature `edition`[..]")
+        .run();
+}


### PR DESCRIPTION
It can be confusing because almost all of the warnings give no indication which package issued the warning.

Closes #6168
