### PR TITLE
Disable progress bar on CI.

### DIFF
--- a/src/cargo/util/progress.rs
+++ b/src/cargo/util/progress.rs
@@ -38,11 +38,13 @@ struct Format {
 impl<'cfg> Progress<'cfg> {
     pub fn with_style(name: &str, style: ProgressStyle, cfg: &'cfg Config) -> Progress<'cfg> {
         // report no progress when -q (for quiet) or TERM=dumb are set
+        // or if running on Continuous Integration service like Travis where the
+        // output logs get mangled.
         let dumb = match env::var("TERM") {
             Ok(term) => term == "dumb",
             Err(_) => false,
         };
-        if cfg.shell().verbosity() == Verbosity::Quiet || dumb {
+        if cfg.shell().verbosity() == Verbosity::Quiet || dumb || env::var("CI").is_ok() {
             return Progress { state: None };
         }
 


### PR DESCRIPTION
Due to the recent change (#6233) to use ansi escape codes to clear the progress bar, Travis logs are looking quite odd. Generally you don't want the progress bar during CI builds anyways, so just disable it if "CI" is set, which most of the CI services do.
