### PR TITLE
Avoid retaining all rustc output in memory.

### DIFF
--- a/src/cargo/core/compiler/job_queue.rs
+++ b/src/cargo/core/compiler/job_queue.rs
@@ -113,7 +113,7 @@ impl<'a> JobState<'a> {
         &self,
         cmd: &ProcessBuilder,
         prefix: Option<String>,
-        print_output: bool,
+        capture_output: bool,
     ) -> CargoResult<Output> {
         let prefix = prefix.unwrap_or_else(|| String::new());
         cmd.exec_with_streaming(
@@ -125,7 +125,7 @@ impl<'a> JobState<'a> {
                 let _ = self.tx.send(Message::Stderr(format!("{}{}", prefix, err)));
                 Ok(())
             },
-            print_output,
+            capture_output,
         )
     }
 }

--- a/tests/testsuite/support/mod.rs
+++ b/tests/testsuite/support/mod.rs
@@ -770,7 +770,7 @@ impl Execs {
             process.exec_with_streaming(
                 &mut |out| Ok(println!("{}", out)),
                 &mut |err| Ok(eprintln!("{}", err)),
-                false,
+                true,
             )
         } else {
             process.exec_with_output()


### PR DESCRIPTION
There are still a few cases where all output is buffered. They are:
- Running discovery commands like `rustc -vV`, `rustc --print xxx`, etc.
- Build script output.
- Testsuite's debug `.stream()` function.

This should cover the concern of the issue, though, which is normal compilation.

Closes #6197
