### PR TITLE
Show error on JSON parse error and nonzero exit.

### DIFF
--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -4435,3 +4435,71 @@ Caused by:
         .with_status(101)
         .run();
 }
+
+#[test]
+fn json_parse_fail() {
+    // Ensure when json parsing fails, and rustc exits with non-zero exit
+    // code, that a useful error message is displayed.
+    let foo = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "foo"
+            version = "0.1.0"
+            [dependencies]
+            pm = { path = "pm" }
+        "#,
+        )
+        .file(
+            "src/lib.rs",
+            r#"
+            #[macro_use]
+            extern crate pm;
+
+            #[derive(Foo)]
+            pub struct S;
+        "#,
+        )
+        .file(
+            "pm/Cargo.toml",
+            r#"
+            [package]
+            name = "pm"
+            version = "0.1.0"
+            [lib]
+            proc-macro = true
+        "#,
+        )
+        .file(
+            "pm/src/lib.rs",
+            r#"
+            extern crate proc_macro;
+            use proc_macro::TokenStream;
+
+            #[proc_macro_derive(Foo)]
+            pub fn derive(_input: TokenStream) -> TokenStream {
+                eprintln!("{{evil proc macro}}");
+                panic!("something went wrong");
+            }
+        "#,
+        )
+        .build();
+
+    foo.cargo("build --message-format=json")
+        .with_stderr(
+            "\
+[COMPILING] pm [..]
+[COMPILING] foo [..]
+[ERROR] Could not compile `foo`.
+
+Caused by:
+  compiler produced invalid json: `{evil proc macro}`
+
+Caused by:
+  failed to parse process output: `rustc [..]
+",
+        )
+        .with_status(101)
+        .run();
+}


### PR DESCRIPTION
If JSON parsing failed, and rustc exits nonzero, the error was lost.
This would have made it easier to diagnose #5992.
