### PR TITLE
Don't hardlink rmeta files.

### DIFF
--- a/src/cargo/core/compiler/context/compilation_files.rs
+++ b/src/cargo/core/compiler/context/compilation_files.rs
@@ -245,16 +245,12 @@ impl<'a, 'cfg: 'a> CompilationFiles<'a, 'cfg> {
         let mut unsupported = Vec::new();
         {
             if unit.mode.is_check() {
-                // This is not quite correct for non-lib targets.  rustc
-                // currently does not emit rmeta files, so there is nothing to
-                // check for!  See #3624.
+                // This may be confusing. rustc outputs a file named `lib*.rmeta`
+                // for both libraries and binaries.
                 let path = out_dir.join(format!("lib{}.rmeta", file_stem));
-                let hardlink = link_stem
-                    .clone()
-                    .map(|(ld, ls)| ld.join(format!("lib{}.rmeta", ls)));
                 ret.push(OutputFile {
                     path,
-                    hardlink,
+                    hardlink: None,
                     flavor: FileFlavor::Linkable,
                 });
             } else {


### PR DESCRIPTION
`.rmeta` files shouldn't be needed in the main directory, and since rustc started outputing rmeta files for binaries, there are name collisions between bins and libs of the same name.

Partial fix for #5524.
