### PR TITLE
Don't include build scripts in --out-dir.

### DIFF
--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -437,11 +437,13 @@ fn link_targets<'a, 'cfg>(
             destinations.push(dst.display().to_string());
             hardlink_or_copy(src, dst)?;
             if let Some(ref path) = export_dir {
-                if !path.exists() {
-                    fs::create_dir_all(path)?;
-                }
+                if !target.is_custom_build() {
+                    if !path.exists() {
+                        fs::create_dir_all(path)?;
+                    }
 
-                hardlink_or_copy(src, &path.join(dst.file_name().unwrap()))?;
+                    hardlink_or_copy(src, &path.join(dst.file_name().unwrap()))?;
+                }
             }
         }
 


### PR DESCRIPTION
As I understand the `--out-dir` use cases, these shouldn't be needed.

Closes #6282
