### PR TITLE
Support untyped warnings from registries with successful publish

### DIFF
--- a/src/cargo/ops/registry.rs
+++ b/src/cargo/ops/registry.rs
@@ -276,6 +276,12 @@ fn transmit(
                 config.shell().warn(&msg)?;
             }
 
+            if !warnings.other.is_empty() {
+                for msg in warnings.other {
+                    config.shell().warn(&msg)?;
+                }
+            }
+
             Ok(())
         }
         Err(e) => Err(e),

--- a/src/crates-io/lib.rs
+++ b/src/crates-io/lib.rs
@@ -86,6 +86,7 @@ pub struct User {
 pub struct Warnings {
     pub invalid_categories: Vec<String>,
     pub invalid_badges: Vec<String>,
+    pub other: Vec<String>,
 }
 
 #[derive(Deserialize)]
@@ -223,9 +224,17 @@ impl Registry {
             .map(|x| x.iter().flat_map(|j| j.as_str()).map(Into::into).collect())
             .unwrap_or_else(Vec::new);
 
+        let other: Vec<String> = response
+            .get("warnings")
+            .and_then(|j| j.get("other"))
+            .and_then(|j| j.as_array())
+            .map(|x| x.iter().flat_map(|j| j.as_str()).map(Into::into).collect())
+            .unwrap_or_else(Vec::new);
+
         Ok(Warnings {
             invalid_categories,
             invalid_badges,
+            other,
         })
     }
 


### PR DESCRIPTION
This adds a field "other" to the warnings deserialized from a successful publish response from a registry.

This is [part of our plan to eventually require an email address to publish on crates.io to comply with DMCA](https://github.com/rust-lang/crates-io-cargo-teams/issues/8). The TL;DR of that is we plan to warn for a release cycle when you publish without a verified email address once this change makes it to stable.

I'm opting to add an "other" field rather than another field like the invalid badges/categories fields for a few reasons:

- The warning we're planning on adding about emails will only exist for 6 weeks; those other warnings have happened in the past and will continue to happen.
- There may be other transient warnings on publish that we'd like to send from crates.io in the future; it'd be nice to have a way of doing that without having to update cargo as well.
- Other registries may have different warnings than we could ever anticipate in cargo; if usage of alternate registries grows, it'd be nice to give them a mechanism to warn as well.

I've tested:

- Cargo compiled with this change against a crates.io instance that doesn't return `other` warnings
- Cargo compiled with this change against a crates.io instance that DOES return `other` warnings
- Current Cargo against a crates.io instance that does return `other` warnings

and they all behaved as I expected.

I haven't added any tests because there aren't any tests that inject registry responses, and while I think cargo should have some of those eventually, I'm not going to add that infrastructure without discussing it with lots of folks first :)

I know there's a soft feature freeze right now, buuuuut [it's wafer thin](https://proxy.duckduckgo.com/iu/?u=https%3A%2F%2Fs4.thcdn.com%2Fproductimg%2F0%2F600%2F600%2F27%2F10284327-1288263770-74000.jpg&f=1)!! It doesn't add any surface area to the CLI or manifest format! ❤️ 