### PR TITLE
Check for duplicate output filenames.

### DIFF
--- a/src/cargo/core/compiler/build_config.rs
+++ b/src/cargo/core/compiler/build_config.rs
@@ -111,7 +111,7 @@ pub enum MessageFormat {
 /// `compile_ws` to tell it the general execution strategy.  This influences
 /// the default targets selected.  The other use is in the `Unit` struct
 /// to indicate what is being done with a specific target.
-#[derive(Clone, Copy, PartialEq, Debug, Eq, Hash)]
+#[derive(Clone, Copy, PartialEq, Debug, Eq, Hash, PartialOrd, Ord)]
 pub enum CompileMode {
     /// A target being built for a test.
     Test,

--- a/src/cargo/core/compiler/fingerprint.rs
+++ b/src/cargo/core/compiler/fingerprint.rs
@@ -9,7 +9,7 @@ use serde::de::{self, Deserialize};
 use serde::ser;
 use serde_json;
 
-use core::{Edition, Package, TargetKind};
+use core::{Edition, Package};
 use util;
 use util::errors::{CargoResult, CargoResultExt};
 use util::paths;
@@ -780,14 +780,7 @@ fn filename<'a, 'cfg>(cx: &mut Context<'a, 'cfg>, unit: &Unit<'a>) -> String {
     // fingerprint for every metadata hash version. This works because
     // even if the package is fresh, we'll still link the fresh target
     let file_stem = cx.files().file_stem(unit);
-    let kind = match *unit.target.kind() {
-        TargetKind::Lib(..) => "lib",
-        TargetKind::Bin => "bin",
-        TargetKind::Test => "integration-test",
-        TargetKind::ExampleBin | TargetKind::ExampleLib(..) => "example",
-        TargetKind::Bench => "bench",
-        TargetKind::CustomBuild => "build-script",
-    };
+    let kind = unit.target.kind().description();
     let flavor = if unit.mode.is_any_test() {
         "test-"
     } else if unit.mode.is_doc() {

--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -436,14 +436,13 @@ fn link_targets<'a, 'cfg>(
             };
             destinations.push(dst.display().to_string());
             hardlink_or_copy(src, dst)?;
-            if let Some(ref path) = export_dir {
-                if !target.is_custom_build() {
-                    if !path.exists() {
-                        fs::create_dir_all(path)?;
-                    }
-
-                    hardlink_or_copy(src, &path.join(dst.file_name().unwrap()))?;
+            if let Some(ref path) = output.export_path {
+                let export_dir = export_dir.as_ref().unwrap();
+                if !export_dir.exists() {
+                    fs::create_dir_all(export_dir)?;
                 }
+
+                hardlink_or_copy(src, path)?;
             }
         }
 

--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -181,9 +181,22 @@ impl fmt::Debug for TargetKind {
     }
 }
 
+impl TargetKind {
+    pub fn description(&self) -> &'static str {
+        match self {
+            TargetKind::Lib(..) => "lib",
+            TargetKind::Bin => "bin",
+            TargetKind::Test => "integration-test",
+            TargetKind::ExampleBin | TargetKind::ExampleLib(..) => "example",
+            TargetKind::Bench => "bench",
+            TargetKind::CustomBuild => "build-script",
+        }
+    }
+}
+
 /// Information about a binary, a library, an example, etc. that is part of the
 /// package.
-#[derive(Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Target {
     kind: TargetKind,
     name: String,
@@ -202,7 +215,7 @@ pub struct Target {
     edition: Edition,
 }
 
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum TargetSourcePath {
     Path(PathBuf),
     Metabuild,

--- a/src/cargo/core/package.rs
+++ b/src/cargo/core/package.rs
@@ -1,4 +1,5 @@
 use std::cell::{Ref, RefCell, Cell};
+use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet};
 use std::fmt;
 use std::hash;
@@ -36,6 +37,18 @@ pub struct Package {
     manifest: Manifest,
     /// The root of the package
     manifest_path: PathBuf,
+}
+
+impl Ord for Package {
+    fn cmp(&self, other: &Package) -> Ordering {
+        self.package_id().cmp(other.package_id())
+    }
+}
+
+impl PartialOrd for Package {
+    fn partial_cmp(&self, other: &Package) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
 }
 
 /// A Package in a form where `Serialize` can be derived.

--- a/src/cargo/core/profiles.rs
+++ b/src/cargo/core/profiles.rs
@@ -371,7 +371,7 @@ fn merge_profile(profile: &mut Profile, toml: &TomlProfile) {
 
 /// Profile settings used to determine which compiler flags to use for a
 /// target.
-#[derive(Clone, Copy, Eq)]
+#[derive(Clone, Copy, Eq, PartialOrd, Ord)]
 pub struct Profile {
     pub name: &'static str,
     pub opt_level: InternedString,
@@ -523,7 +523,7 @@ impl Profile {
 }
 
 /// The link-time-optimization setting.
-#[derive(Clone, Copy, PartialEq, Eq, Debug, Hash)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Hash, PartialOrd, Ord)]
 pub enum Lto {
     /// False = no LTO
     /// True = "Fat" LTO

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -4327,8 +4327,8 @@ fn target_filters_workspace() {
         .file("a/src/lib.rs", "")
         .file("a/examples/ex1.rs", "fn main() {}")
         .file("b/Cargo.toml", &basic_bin_manifest("b"))
+        .file("b/src/lib.rs", "")
         .file("b/src/main.rs", "fn main() {}")
-        .file("b/examples/ex1.rs", "fn main() {}")
         .build();
 
     ws.cargo("build -v --example ex")
@@ -4343,12 +4343,12 @@ Did you mean `ex1`?",
     ws.cargo("build -v --lib")
         .with_status(0)
         .with_stderr_contains("[RUNNING] `rustc [..]a/src/lib.rs[..]")
+        .with_stderr_contains("[RUNNING] `rustc [..]b/src/lib.rs[..]")
         .run();
 
     ws.cargo("build -v --example ex1")
         .with_status(0)
         .with_stderr_contains("[RUNNING] `rustc [..]a/examples/ex1.rs[..]")
-        .with_stderr_contains("[RUNNING] `rustc [..]b/examples/ex1.rs[..]")
         .run();
 }
 

--- a/tests/testsuite/collisions.rs
+++ b/tests/testsuite/collisions.rs
@@ -1,0 +1,103 @@
+use std::env;
+use support::{basic_manifest, project};
+
+#[test]
+fn collision_dylib() {
+    // Path dependencies don't include metadata hash in filename for dylibs.
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [workspace]
+            members = ["a", "b"]
+            "#,
+        )
+        .file(
+            "a/Cargo.toml",
+            r#"
+            [package]
+            name = "a"
+            version = "1.0.0"
+
+            [lib]
+            crate-type = ["dylib"]
+            "#,
+        )
+        .file("a/src/lib.rs", "")
+        .file(
+            "b/Cargo.toml",
+            r#"
+            [package]
+            name = "b"
+            version = "1.0.0"
+
+            [lib]
+            crate-type = ["dylib"]
+            name = "a"
+            "#,
+        )
+        .file("b/src/lib.rs", "")
+        .build();
+
+    p.cargo("build")
+        .with_stderr(&format!("\
+[ERROR] output filename collision.
+The lib target `a` in package `b v1.0.0 ([..]/foo/b)` has the same output filename as the lib target `a` in package `a v1.0.0 ([..]/foo/a)`.
+Colliding filename is: [..]/foo/target/debug/deps/{}a{}
+The targets must have unique names.
+Consider changing their names to be unique or compiling them separately.
+", env::consts::DLL_PREFIX, env::consts::DLL_SUFFIX))
+        .with_status(101)
+        .run();
+}
+
+#[test]
+fn collision_example() {
+    // Examples in a workspace can easily collide.
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [workspace]
+            members = ["a", "b"]
+            "#,
+        )
+        .file("a/Cargo.toml", &basic_manifest("a", "1.0.0"))
+        .file("a/examples/ex1.rs", "fn main() {}")
+        .file("b/Cargo.toml", &basic_manifest("b", "1.0.0"))
+        .file("b/examples/ex1.rs", "fn main() {}")
+        .build();
+
+    p.cargo("build --examples")
+        .with_stderr("\
+[ERROR] output filename collision.
+The example target `ex1` in package `b v1.0.0 ([..]/foo/b)` has the same output filename as the example target `ex1` in package `a v1.0.0 ([..]/foo/a)`.
+Colliding filename is: [..]/foo/target/debug/examples/ex1[EXE]
+The targets must have unique names.
+Consider changing their names to be unique or compiling them separately.
+")
+        .with_status(101)
+        .run();
+}
+
+#[test]
+fn collision_export() {
+    // --out-dir combines some things which can cause conflicts.
+    let p = project()
+        .file("Cargo.toml", &basic_manifest("foo", "1.0.0"))
+        .file("examples/foo.rs", "fn main() {}")
+        .file("src/main.rs", "fn main() {}")
+        .build();
+
+    p.cargo("build --out-dir=out -Z unstable-options --bins --examples")
+        .masquerade_as_nightly_cargo()
+        .with_stderr("\
+[ERROR] `--out-dir` filename collision.
+The example target `foo` in package `foo v1.0.0 ([..]/foo)` has the same output filename as the bin target `foo` in package `foo v1.0.0 ([..]/foo)`.
+Colliding filename is: [..]/foo/out/foo[EXE]
+The exported filenames must be unique.
+Consider changing their names to be unique or compiling them separately.
+")
+        .with_status(101)
+        .run();
+}

--- a/tests/testsuite/collisions.rs
+++ b/tests/testsuite/collisions.rs
@@ -39,7 +39,9 @@ fn collision_dylib() {
         .file("b/src/lib.rs", "")
         .build();
 
-    p.cargo("build")
+    // j=1 is required because on windows you'll get an error because
+    // two processes will be writing to the file at the same time.
+    p.cargo("build -j=1")
         .with_stderr_contains(&format!("\
 [WARNING] output filename collision.
 The lib target `a` in package `b v1.0.0 ([..]/foo/b)` has the same output filename as the lib target `a` in package `a v1.0.0 ([..]/foo/a)`.

--- a/tests/testsuite/collisions.rs
+++ b/tests/testsuite/collisions.rs
@@ -40,14 +40,14 @@ fn collision_dylib() {
         .build();
 
     p.cargo("build")
-        .with_stderr(&format!("\
-[ERROR] output filename collision.
+        .with_stderr_contains(&format!("\
+[WARNING] output filename collision.
 The lib target `a` in package `b v1.0.0 ([..]/foo/b)` has the same output filename as the lib target `a` in package `a v1.0.0 ([..]/foo/a)`.
 Colliding filename is: [..]/foo/target/debug/deps/{}a{}
-The targets must have unique names.
+The targets should have unique names.
 Consider changing their names to be unique or compiling them separately.
+This may become a hard error in the future, see https://github.com/rust-lang/cargo/issues/6313
 ", env::consts::DLL_PREFIX, env::consts::DLL_SUFFIX))
-        .with_status(101)
         .run();
 }
 
@@ -69,14 +69,14 @@ fn collision_example() {
         .build();
 
     p.cargo("build --examples")
-        .with_stderr("\
-[ERROR] output filename collision.
+        .with_stderr_contains("\
+[WARNING] output filename collision.
 The example target `ex1` in package `b v1.0.0 ([..]/foo/b)` has the same output filename as the example target `ex1` in package `a v1.0.0 ([..]/foo/a)`.
 Colliding filename is: [..]/foo/target/debug/examples/ex1[EXE]
-The targets must have unique names.
+The targets should have unique names.
 Consider changing their names to be unique or compiling them separately.
+This may become a hard error in the future, see https://github.com/rust-lang/cargo/issues/6313
 ")
-        .with_status(101)
         .run();
 }
 
@@ -91,13 +91,13 @@ fn collision_export() {
 
     p.cargo("build --out-dir=out -Z unstable-options --bins --examples")
         .masquerade_as_nightly_cargo()
-        .with_stderr("\
-[ERROR] `--out-dir` filename collision.
+        .with_stderr_contains("\
+[WARNING] `--out-dir` filename collision.
 The example target `foo` in package `foo v1.0.0 ([..]/foo)` has the same output filename as the bin target `foo` in package `foo v1.0.0 ([..]/foo)`.
 Colliding filename is: [..]/foo/out/foo[EXE]
-The exported filenames must be unique.
+The exported filenames should be unique.
 Consider changing their names to be unique or compiling them separately.
+This may become a hard error in the future, see https://github.com/rust-lang/cargo/issues/6313
 ")
-        .with_status(101)
         .run();
 }

--- a/tests/testsuite/main.rs
+++ b/tests/testsuite/main.rs
@@ -43,6 +43,7 @@ mod cargo_features;
 mod cfg;
 mod check;
 mod clean;
+mod collisions;
 mod concurrent;
 mod config;
 mod corrupt_git;


### PR DESCRIPTION
This generates an error if it detects that different units would output the same file name. This can happen in a few situations:
- Multiple targets in a workspace use the same name.
- `--out-dir` in some cases (like `examples` because it does not include the directory).
- Bugs in cargo (like #5524, #5444)

This includes a few cleanups/consolidations:
- `export_path` added to `OutputFile` so there is one place where the `--out-dir` filename logic is located.
- `TargetKind::description()` added for a simple way to get a human-readable name of a target kind.
- The `PartialOrd` changes are a slight performance improvement (overall things are now slightly faster even though it is doing more work).

Closes #5524, closes #6293.
