### PR TITLE
Use "test" profile for `cargo build` benchmarks.

### DIFF
--- a/src/cargo/core/profiles.rs
+++ b/src/cargo/core/profiles.rs
@@ -74,7 +74,7 @@ impl Profiles {
         release: bool,
     ) -> Profile {
         let maker = match mode {
-            CompileMode::Test => {
+            CompileMode::Test | CompileMode::Bench => {
                 if release {
                     &self.bench
                 } else {
@@ -95,7 +95,6 @@ impl Profiles {
                     &self.dev
                 }
             }
-            CompileMode::Bench => &self.bench,
             CompileMode::Doc { .. } => &self.doc,
         };
         let mut profile = maker.get_profile(Some(pkg_id), is_member, unit_for);

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -4147,43 +4147,40 @@ fn build_filter_infer_profile() {
 
     p.cargo("build -v")
         .with_stderr_contains(
-            "\
-             [RUNNING] `rustc --crate-name foo src/lib.rs --color never --crate-type lib \
+            "[RUNNING] `rustc --crate-name foo src/lib.rs --color never --crate-type lib \
              --emit=dep-info,link[..]",
         ).with_stderr_contains(
-            "\
-             [RUNNING] `rustc --crate-name foo src/main.rs --color never --crate-type bin \
+            "[RUNNING] `rustc --crate-name foo src/main.rs --color never --crate-type bin \
              --emit=dep-info,link[..]",
         ).run();
 
     p.root().join("target").rm_rf();
     p.cargo("build -v --test=t1")
         .with_stderr_contains(
-            "\
-             [RUNNING] `rustc --crate-name foo src/lib.rs --color never --crate-type lib \
-             --emit=dep-info,link[..]",
+            "[RUNNING] `rustc --crate-name foo src/lib.rs --color never --crate-type lib \
+             --emit=dep-info,link -C debuginfo=2 [..]",
         ).with_stderr_contains(
-            "[RUNNING] `rustc --crate-name t1 tests/t1.rs --color never --emit=dep-info,link[..]",
+            "[RUNNING] `rustc --crate-name t1 tests/t1.rs --color never --emit=dep-info,link \
+            -C debuginfo=2 [..]",
         ).with_stderr_contains(
-            "\
-             [RUNNING] `rustc --crate-name foo src/main.rs --color never --crate-type bin \
-             --emit=dep-info,link[..]",
+            "[RUNNING] `rustc --crate-name foo src/main.rs --color never --crate-type bin \
+             --emit=dep-info,link -C debuginfo=2 [..]",
         ).run();
 
     p.root().join("target").rm_rf();
+    // Bench uses test profile without `--release`.
     p.cargo("build -v --bench=b1")
         .with_stderr_contains(
-            "\
-             [RUNNING] `rustc --crate-name foo src/lib.rs --color never --crate-type lib \
-             --emit=dep-info,link[..]",
+            "[RUNNING] `rustc --crate-name foo src/lib.rs --color never --crate-type lib \
+             --emit=dep-info,link -C debuginfo=2 [..]",
         ).with_stderr_contains(
-            "\
-             [RUNNING] `rustc --crate-name b1 benches/b1.rs --color never --emit=dep-info,link \
-             -C opt-level=3[..]",
-        ).with_stderr_contains(
-            "\
-             [RUNNING] `rustc --crate-name foo src/main.rs --color never --crate-type bin \
-             --emit=dep-info,link[..]",
+            "[RUNNING] `rustc --crate-name b1 benches/b1.rs --color never --emit=dep-info,link \
+            -C debuginfo=2 [..]",
+        )
+        .with_stderr_does_not_contain("opt-level")
+        .with_stderr_contains(
+            "[RUNNING] `rustc --crate-name foo src/main.rs --color never --crate-type bin \
+             --emit=dep-info,link -C debuginfo=2 [..]",
         ).run();
 }
 
@@ -4213,10 +4210,6 @@ fn targets_selected_all() {
         .with_stderr_contains("\
             [RUNNING] `rustc --crate-name foo src/main.rs --color never --crate-type bin \
             --emit=dep-info,link[..]")
-        // bench
-        .with_stderr_contains("\
-            [RUNNING] `rustc --crate-name foo src/main.rs --color never --emit=dep-info,link \
-            -C opt-level=3 --test [..]")
         // unit test
         .with_stderr_contains("\
             [RUNNING] `rustc --crate-name foo src/main.rs --color never --emit=dep-info,link \
@@ -4231,10 +4224,6 @@ fn all_targets_no_lib() {
         .with_stderr_contains("\
             [RUNNING] `rustc --crate-name foo src/main.rs --color never --crate-type bin \
             --emit=dep-info,link[..]")
-        // bench
-        .with_stderr_contains("\
-            [RUNNING] `rustc --crate-name foo src/main.rs --color never --emit=dep-info,link \
-            -C opt-level=3 --test [..]")
         // unit test
         .with_stderr_contains("\
             [RUNNING] `rustc --crate-name foo src/main.rs --color never --emit=dep-info,link \

--- a/tests/testsuite/profile_targets.rs
+++ b/tests/testsuite/profile_targets.rs
@@ -137,9 +137,6 @@ fn profile_selection_build_all_targets() {
     // - bdep `panic` is not set because it thinks `build.rs` is a plugin.
     // - build_script_build is built without panic because it thinks
     //   `build.rs` is a plugin.
-    // - build_script_build is being run two times.  Once for the `dev` and
-    //   `test` targets, once for the `bench` targets.
-    //   TODO: "PROFILE" says debug both times, though!
     // - Benchmark dependencies are compiled in `dev` mode, which may be
     //   surprising.  See https://github.com/rust-lang/cargo/issues/4929.
     //
@@ -157,11 +154,9 @@ fn profile_selection_build_all_targets() {
     //   lib      dev+panic  build  (a normal lib target)
     //   lib      dev-panic  build  (used by tests/benches)
     //   lib      test       test
-    //   lib      bench      test(bench)
     //   test     test       test
-    //   bench    bench      test(bench)
+    //   bench    test       test
     //   bin      test       test
-    //   bin      bench      test(bench)
     //   bin      dev        build
     //   example  dev        build
     p.cargo("build --all-targets -vv").with_stderr_unordered("\
@@ -173,17 +168,13 @@ fn profile_selection_build_all_targets() {
 [COMPILING] foo [..]
 [RUNNING] `rustc --crate-name build_script_build build.rs [..]--crate-type bin --emit=dep-info,link -C codegen-units=1 -C debuginfo=2 [..]
 [RUNNING] `[..]/target/debug/build/foo-[..]/build-script-build`
-[RUNNING] `[..]/target/debug/build/foo-[..]/build-script-build`
-[foo 0.0.1] foo custom build PROFILE=debug DEBUG=false OPT_LEVEL=3
 [foo 0.0.1] foo custom build PROFILE=debug DEBUG=true OPT_LEVEL=0
 [RUNNING] `rustc --crate-name foo src/lib.rs [..]--crate-type lib --emit=dep-info,link -C panic=abort -C codegen-units=1 -C debuginfo=2 [..]`
 [RUNNING] `rustc --crate-name foo src/lib.rs [..]--emit=dep-info,link -C codegen-units=3 -C debuginfo=2 --test [..]`
 [RUNNING] `rustc --crate-name foo src/lib.rs [..]--crate-type lib --emit=dep-info,link -C codegen-units=1 -C debuginfo=2 [..]`
-[RUNNING] `rustc --crate-name foo src/lib.rs [..]--emit=dep-info,link -C opt-level=3 -C codegen-units=4 --test [..]`
 [RUNNING] `rustc --crate-name foo src/main.rs [..]--emit=dep-info,link -C codegen-units=3 -C debuginfo=2 --test [..]`
 [RUNNING] `rustc --crate-name test1 tests/test1.rs [..]--emit=dep-info,link -C codegen-units=3 -C debuginfo=2 --test [..]`
-[RUNNING] `rustc --crate-name bench1 benches/bench1.rs [..]--emit=dep-info,link -C opt-level=3 -C codegen-units=4 --test [..]`
-[RUNNING] `rustc --crate-name foo src/main.rs [..]--emit=dep-info,link -C opt-level=3 -C codegen-units=4 --test [..]`
+[RUNNING] `rustc --crate-name bench1 benches/bench1.rs [..]--emit=dep-info,link -C codegen-units=3 -C debuginfo=2 --test [..]`
 [RUNNING] `rustc --crate-name foo src/main.rs [..]--crate-type bin --emit=dep-info,link -C panic=abort -C codegen-units=1 -C debuginfo=2 [..]`
 [RUNNING] `rustc --crate-name ex1 examples/ex1.rs [..]--crate-type bin --emit=dep-info,link -C panic=abort -C codegen-units=1 -C debuginfo=2 [..]`
 [FINISHED] dev [unoptimized + debuginfo] [..]

--- a/tests/testsuite/rustc.rs
+++ b/tests/testsuite/rustc.rs
@@ -243,10 +243,6 @@ fn targets_selected_all() {
         .with_stderr_contains("\
             [RUNNING] `rustc --crate-name foo src/main.rs --color never --crate-type bin \
             --emit=dep-info,link[..]")
-        // bench
-        .with_stderr_contains("\
-            [RUNNING] `rustc --crate-name foo src/main.rs --color never --emit=dep-info,link \
-            -C opt-level=3 --test [..]")
         // unit test
         .with_stderr_contains("\
             [RUNNING] `rustc --crate-name foo src/main.rs --color never --emit=dep-info,link \


### PR DESCRIPTION
When using `cargo build` (without `--release`), build benchmarks using the "test" profile. This was causing some confusion where the benchmark is placed in the `target/debug` directory, and also causing some duplicates that may not be expected. It also makes it easier to debug benchmarks (previously you had to edit the `[profile.bench]` profile).

Closes #5575, closes #6301, closes #4240, closes #4929.
