### PR TITLE
Stabilize the `rename-dependency` feature

### DIFF
--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -177,7 +177,7 @@ features! {
         [stable] edition: bool,
 
         // Renaming a package in the manifest via the `package` key
-        [unstable] rename_dependency: bool,
+        [stable] rename_dependency: bool,
 
         // Whether a lock file is published with this crate
         [unstable] publish_lockfile: bool,

--- a/src/doc/src/reference/specifying-dependencies.md
+++ b/src/doc/src/reference/specifying-dependencies.md
@@ -113,7 +113,7 @@ rand = { git = "https://github.com/rust-lang-nursery/rand" }
 
 Cargo will fetch the `git` repository at this location then look for a
 `Cargo.toml` for the requested crate anywhere inside the `git` repository
-(not necessarily at the root - for example, specifying a member crate name 
+(not necessarily at the root - for example, specifying a member crate name
 of a workspace and setting `git` to the repository containing the workspace).
 
 Since we haven’t specified any other information, Cargo assumes that
@@ -535,3 +535,62 @@ features = ["secure-password", "civet"]
 
 More information about features can be found in the
 [manifest documentation](reference/manifest.html#the-features-section).
+
+### Renaming dependencies in `Cargo.toml`
+
+When writing a `[dependencies]` section in `Cargo.toml` the key you write for a
+dependency typically matches up to the name of the crate you import from in the
+code. For some projects, though, you may wish to reference the crate with a
+different name in the code regardless of how it's published on crates.io. For
+example you may wish to:
+
+* Avoid the need to  `use foo as bar` in Rust source.
+* Depend on multiple versions of a crate.
+* Depend on crates with the same name from different registries.
+
+To support this Cargo supports a `package` key in the `[dependencies]` section
+of which package should be depended on:
+
+```toml
+[package]
+name = "mypackage"
+version = "0.0.1"
+
+[dependencies]
+foo = "0.1"
+bar = { git = "https://github.com/example/project", package = "foo" }
+baz = { version = "0.1", registry = "custom", package = "foo" }
+```
+
+In this example, three crates are now available in your Rust code:
+
+```rust
+extern crate foo; // crates.io
+extern crate bar; // git repository
+extern crate baz; // registry `custom`
+```
+
+All three of these crates have the package name of `foo` in their own
+`Cargo.toml`, so we're explicitly using the `package` key to inform Cargo that
+we want the `foo` package even though we're calling it something else locally.
+The `package` key, if not specified, defaults to the name of the dependency
+being requested.
+
+Note that if you have an optional dependency like:
+
+```toml
+[dependencies]
+foo = { version = "0.1", package = 'bar', optional = true }
+```
+
+you're depending on the crate `bar` from crates.io, but your crate has a `foo`
+feature instead of a `bar` feature. That is, names of features take after the
+name of the dependency, not the package name, when renamed.
+
+Enabling transitive dependencies works similarly, for example we could add the
+following to the above manifest:
+
+```toml
+[features]
+log-debug = ['foo/log-debug'] # using 'bar/log-debug' would be an error!
+```

--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -63,61 +63,6 @@ publish = ["my-registry"]
 ```
 
 
-### rename-dependency
-* Original Issue: [#1311](https://github.com/rust-lang/cargo/issues/1311)
-* PR: [#4953](https://github.com/rust-lang/cargo/pull/4953)
-* Tracking Issue: [#5653](https://github.com/rust-lang/cargo/issues/5653)
-
-The rename-dependency feature allows you to import a dependency
-with a different name from the source.  This can be useful in a few scenarios:
-
-* Depending on crates with the same name from different registries.
-* Depending on multiple versions of a crate.
-* Avoid needing `extern crate foo as bar` in Rust source.
-
-Just include the `package` key to specify the actual name of the dependency.
-You must include `cargo-features` at the top of your `Cargo.toml`.
-
-```toml
-cargo-features = ["rename-dependency"]
-
-[package]
-name = "mypackage"
-version = "0.0.1"
-
-[dependencies]
-foo = "0.1"
-bar = { version = "0.1", registry = "custom", package = "foo" }
-baz = { git = "https://github.com/example/project", package = "foo" }
-```
-
-In this example, three crates are now available in your Rust code:
-
-```rust
-extern crate foo;  // crates.io
-extern crate bar;  // registry `custom`
-extern crate baz;  // git repository
-```
-
-Note that if you have an optional dependency like:
-
-```toml
-[dependencies]
-foo = { version = "0.1", package = 'bar', optional = true }
-```
-
-you're depending on the crate `bar` from crates.io, but your crate has a `foo`
-feature instead of a `bar` feature. That is, names of features take after the
-name of the dependency, not the package name, when renamed.
-
-Enabling transitive dependencies works similarly, for example we could add the
-following to the above manifest:
-
-```toml
-[features]
-log-debug = ['foo/log-debug'] # using 'bar/log-debug' would be an error!
-```
-
 ### publish-lockfile
 * Original Issue: [#2263](https://github.com/rust-lang/cargo/issues/2263)
 * PR: [#5093](https://github.com/rust-lang/cargo/pull/5093)


### PR DESCRIPTION
This commit stabilizes Cargo's `rename-dependency` feature which allows
renaming packages in `Cargo.toml`, enabling importing multiple versions
of a single crate or simply avoiding a `use foo as bar` in `src/lib.rs`.

Closes #5653