### PR TITLE
Enable the `zlib` feature of `flate2`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ curl-sys = "0.4.15"
 env_logger = "0.6.0"
 failure = "0.1.2"
 filetime = "0.2"
-flate2 = "1.0.3"
+flate2 = { version = "1.0.3", features = ['zlib'] }
 fs2 = "0.4"
 git2 = "0.7.5"
 git2-curl = "0.8.1"


### PR DESCRIPTION
We're already pulling in zlib for other dependencies like curl/libgit2
so there's not really much use in duplicating the compression code with
miniz, so let's instruct `flate2` to use libz as well to compress and
decompress chunks.