### PR TITLE
Move command prelude into main library

### DIFF
--- a/src/bin/cargo/main.rs
+++ b/src/bin/cargo/main.rs
@@ -19,11 +19,10 @@ use std::path::{Path, PathBuf};
 use std::collections::BTreeSet;
 
 use cargo::core::shell::Shell;
-use cargo::util::{self, lev_distance, CargoResult, CliResult, Config};
+use cargo::util::{self, command_prelude, lev_distance, CargoResult, CliResult, Config};
 use cargo::util::{CliError, ProcessError};
 
 mod cli;
-mod command_prelude;
 mod commands;
 
 use command_prelude::*;

--- a/src/cargo/util/command_prelude.rs
+++ b/src/cargo/util/command_prelude.rs
@@ -2,17 +2,17 @@ use std::path::PathBuf;
 use std::fs;
 
 use clap::{self, SubCommand};
-use cargo::CargoResult;
-use cargo::core::Workspace;
-use cargo::core::compiler::{BuildConfig, MessageFormat};
-use cargo::ops::{CompileFilter, CompileOptions, NewOptions, Packages, VersionControl};
-use cargo::sources::CRATES_IO_REGISTRY;
-use cargo::util::paths;
-use cargo::util::important_paths::find_root_manifest_for_wd;
+use CargoResult;
+use core::Workspace;
+use core::compiler::{BuildConfig, MessageFormat};
+use ops::{CompileFilter, CompileOptions, NewOptions, Packages, VersionControl};
+use sources::CRATES_IO_REGISTRY;
+use util::paths;
+use util::important_paths::find_root_manifest_for_wd;
 
 pub use clap::{AppSettings, Arg, ArgMatches};
-pub use cargo::{CliError, CliResult, Config};
-pub use cargo::core::compiler::CompileMode;
+pub use {CliError, CliResult, Config};
+pub use core::compiler::CompileMode;
 
 pub type App = clap::App<'static, 'static>;
 

--- a/src/cargo/util/mod.rs
+++ b/src/cargo/util/mod.rs
@@ -38,6 +38,7 @@ pub mod profile;
 pub mod to_semver;
 pub mod to_url;
 pub mod toml;
+pub mod command_prelude;
 mod cfg;
 mod dependency_queue;
 mod rustc;


### PR DESCRIPTION
When writing cargo sub-commands, it would be really useful to have access to these pre-built command line argument creates/parsers.

In a perfect world, I'd also move the contents of `src/bin/cargo/{cli.rs, main.rs, command/mod.rs}` that aren't specific to the built-in commands, but that's more complicated than this simple move of a module.