### PR TITLE
docs: correct profile usage of `cargo test --release`

### DIFF
--- a/src/doc/src/reference/manifest.md
+++ b/src/doc/src/reference/manifest.md
@@ -341,7 +341,7 @@ incremental = true # whether or not incremental compilation is enabled
 overflow-checks = true # use overflow checks for integer arithmetic.
                    # Passes the `-C overflow-checks=...` flag to the compiler.
 
-# The release profile, used for `cargo build --release`.
+# The release profile, used for `cargo build --release` and `cargo test --release`.
 [profile.release]
 opt-level = 3
 debug = false
@@ -365,7 +365,7 @@ panic = 'unwind'
 incremental = true
 overflow-checks = true
 
-# The benchmarking profile, used for `cargo bench` and `cargo test --release`.
+# The benchmarking profile, used for `cargo bench`.
 [profile.bench]
 opt-level = 3
 debug = false


### PR DESCRIPTION
From trying it out on a project (see <https://github.com/PROSIC/libprosic/pull/54#issuecomment-441211463>), I have realised that the `profile` usage by `cargo test --release` differs from what is documented in the cargo book. So here comes my correction suggestion...