### PR TITLE
remove clones made redundant by Intern SourceId

### DIFF
--- a/src/bin/cargo/cli.rs
+++ b/src/bin/cargo/cli.rs
@@ -81,7 +81,7 @@ Run with 'cargo -Z [FLAG] [SUBCOMMAND]'"
 
 pub fn get_version_string(is_verbose: bool) -> String {
     let version = cargo::version();
-    let mut version_string = String::from(version.to_string());
+    let mut version_string = version.to_string();
     version_string.push_str("\n");
     if is_verbose {
         version_string.push_str(&format!(
@@ -218,9 +218,10 @@ See 'cargo help <command>' for more information on a specific command.\n",
             opt(
                 "verbose",
                 "Use verbose output (-vv very verbose/build.rs output)",
-            ).short("v")
-                .multiple(true)
-                .global(true),
+            )
+            .short("v")
+            .multiple(true)
+            .global(true),
         )
         .arg(
             opt("quiet", "No output printed to stdout")

--- a/src/bin/cargo/commands/git_checkout.rs
+++ b/src/bin/cargo/commands/git_checkout.rs
@@ -28,7 +28,7 @@ pub fn exec(config: &mut Config, args: &ArgMatches) -> CliResult {
     let reference = GitReference::Branch(reference.to_string());
     let source_id = SourceId::for_git(&url, reference)?;
 
-    let mut source = GitSource::new(&source_id, config)?;
+    let mut source = GitSource::new(source_id, config)?;
 
     source.update()?;
 

--- a/src/bin/cargo/commands/install.rs
+++ b/src/bin/cargo/commands/install.rs
@@ -82,7 +82,8 @@ pub fn exec(config: &mut Config, args: &ArgMatches) -> CliResult {
 
     compile_opts.build_config.release = !args.is_present("debug");
 
-    let krates = args.values_of("crate")
+    let krates = args
+        .values_of("crate")
         .unwrap_or_default()
         .collect::<Vec<_>>();
 
@@ -120,7 +121,7 @@ pub fn exec(config: &mut Config, args: &ArgMatches) -> CliResult {
         ops::install(
             root,
             krates,
-            &source,
+            source,
             from_cwd,
             version,
             &compile_opts,

--- a/src/bin/cargo/commands/login.rs
+++ b/src/bin/cargo/commands/login.rs
@@ -3,9 +3,9 @@ use command_prelude::*;
 use std::io::{self, BufRead};
 
 use cargo::core::{Source, SourceId};
+use cargo::ops;
 use cargo::sources::RegistrySource;
 use cargo::util::{CargoError, CargoResultExt};
-use cargo::ops;
 
 pub fn cli() -> App {
     subcommand("login")
@@ -29,11 +29,12 @@ pub fn exec(config: &mut Config, args: &ArgMatches) -> CliResult {
                     return Err(format_err!(
                         "token must be provided when \
                          --registry is provided."
-                    ).into());
+                    )
+                    .into());
                 }
                 None => {
                     let src = SourceId::crates_io(config)?;
-                    let mut src = RegistrySource::remote(&src, config);
+                    let mut src = RegistrySource::remote(src, config);
                     src.update()?;
                     let config = src.config()?.unwrap();
                     args.value_of("host")

--- a/src/bin/cargo/main.rs
+++ b/src/bin/cargo/main.rs
@@ -1,5 +1,5 @@
-#![cfg_attr(feature = "cargo-clippy", allow(too_many_arguments))] // large project
-#![cfg_attr(feature = "cargo-clippy", allow(redundant_closure))]  // there's a false positive
+#![cfg_attr(feature = "cargo-clippy", allow(clippy::too_many_arguments))] // large project
+#![cfg_attr(feature = "cargo-clippy", allow(clippy::redundant_closure))]  // there's a false positive
 
 extern crate cargo;
 extern crate clap;
@@ -13,10 +13,10 @@ extern crate serde_derive;
 extern crate serde_json;
 extern crate toml;
 
+use std::collections::BTreeSet;
 use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::collections::BTreeSet;
 
 use cargo::core::shell::Shell;
 use cargo::util::{self, command_prelude, lev_distance, CargoResult, CliResult, Config};

--- a/src/cargo/core/interning.rs
+++ b/src/cargo/core/interning.rs
@@ -34,7 +34,7 @@ impl Eq for InternedString {}
 impl InternedString {
     pub fn new(str: &str) -> InternedString {
         let mut cache = STRING_CACHE.lock().unwrap();
-        let s = cache.get(str).map(|&s| s).unwrap_or_else(|| {
+        let s = cache.get(str).cloned().unwrap_or_else(|| {
             let s = leak(str.to_string());
             cache.insert(s);
             s

--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -15,7 +15,7 @@ use core::{Dependency, PackageId, PackageIdSpec, SourceId, Summary};
 use core::{Edition, Feature, Features, WorkspaceConfig};
 use util::errors::*;
 use util::toml::TomlManifest;
-use util::{Config, Filesystem, short_hash};
+use util::{short_hash, Config, Filesystem};
 
 pub enum EitherManifest {
     Real(Manifest),
@@ -254,11 +254,7 @@ impl fmt::Debug for TargetSourcePath {
 
 impl From<PathBuf> for TargetSourcePath {
     fn from(path: PathBuf) -> Self {
-        assert!(
-            path.is_absolute(),
-            "`{}` is not absolute",
-            path.display()
-        );
+        assert!(path.is_absolute(), "`{}` is not absolute", path.display());
         TargetSourcePath::Path(path)
     }
 }
@@ -290,7 +286,8 @@ impl ser::Serialize for Target {
                 .required_features
                 .as_ref()
                 .map(|rf| rf.iter().map(|s| &**s).collect()),
-        }.serialize(s)
+        }
+        .serialize(s)
     }
 }
 
@@ -468,7 +465,7 @@ impl Manifest {
         self.summary = summary;
     }
 
-    pub fn map_source(self, to_replace: &SourceId, replace_with: &SourceId) -> Manifest {
+    pub fn map_source(self, to_replace: SourceId, replace_with: SourceId) -> Manifest {
         Manifest {
             summary: self.summary.map_source(to_replace, replace_with),
             ..self
@@ -490,11 +487,7 @@ impl Manifest {
         if self.default_run.is_some() {
             self.features
                 .require(Feature::default_run())
-                .chain_err(|| {
-                    format_err!(
-                        "the `default-run` manifest key is unstable"
-                    )
-                })?;
+                .chain_err(|| format_err!("the `default-run` manifest key is unstable"))?;
         }
 
         Ok(())
@@ -627,11 +620,7 @@ impl Target {
     }
 
     /// Builds a `Target` corresponding to the `build = "build.rs"` entry.
-    pub fn custom_build_target(
-        name: &str,
-        src_path: PathBuf,
-        edition: Edition,
-    ) -> Target {
+    pub fn custom_build_target(name: &str, src_path: PathBuf, edition: Edition) -> Target {
         Target {
             kind: TargetKind::CustomBuild,
             name: name.to_string(),
@@ -740,7 +729,9 @@ impl Target {
     pub fn for_host(&self) -> bool {
         self.for_host
     }
-    pub fn edition(&self) -> Edition { self.edition }
+    pub fn edition(&self) -> Edition {
+        self.edition
+    }
     pub fn benched(&self) -> bool {
         self.benched
     }
@@ -839,7 +830,8 @@ impl Target {
     pub fn can_lto(&self) -> bool {
         match self.kind {
             TargetKind::Lib(ref v) => {
-                !v.contains(&LibKind::Rlib) && !v.contains(&LibKind::Dylib)
+                !v.contains(&LibKind::Rlib)
+                    && !v.contains(&LibKind::Dylib)
                     && !v.contains(&LibKind::Lib)
             }
             _ => true,

--- a/src/cargo/core/package.rs
+++ b/src/cargo/core/package.rs
@@ -530,7 +530,7 @@ impl<'a, 'cfg> Downloads<'a, 'cfg> {
         // first crate finishes downloading so we inform immediately that we're
         // downloading crates here.
         if self.downloads_finished == 0
-            && self.pending.len() == 0
+            && self.pending.is_empty()
             && !self.progress.borrow().as_ref().unwrap().is_enabled()
         {
             self.set

--- a/src/cargo/core/package.rs
+++ b/src/cargo/core/package.rs
@@ -1,16 +1,16 @@
-use std::cell::{Ref, RefCell, Cell};
+use std::cell::{Cell, Ref, RefCell};
 use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet};
 use std::fmt;
 use std::hash;
 use std::mem;
 use std::path::{Path, PathBuf};
-use std::time::{Instant, Duration};
+use std::time::{Duration, Instant};
 
 use bytesize::ByteSize;
-use curl::easy::{Easy, HttpVersion};
-use curl::multi::{Multi, EasyHandle};
 use curl;
+use curl::easy::{Easy, HttpVersion};
+use curl::multi::{EasyHandle, Multi};
 use curl_sys;
 use failure::ResultExt;
 use lazycell::LazyCell;
@@ -18,14 +18,14 @@ use semver::Version;
 use serde::ser;
 use toml;
 
+use core::interning::InternedString;
+use core::source::MaybePackage;
 use core::{Dependency, Manifest, PackageId, SourceId, Target};
 use core::{FeatureMap, SourceMap, Summary};
-use core::source::MaybePackage;
-use core::interning::InternedString;
 use ops;
-use util::{self, internal, lev_distance, Config, Progress, ProgressStyle};
 use util::errors::{CargoResult, CargoResultExt, HttpNot200};
 use util::network::Retry;
+use util::{self, internal, lev_distance, Config, Progress, ProgressStyle};
 
 /// Information about a package that is available somewhere in the file system.
 ///
@@ -60,7 +60,7 @@ struct SerializedPackage<'a> {
     license: Option<&'a str>,
     license_file: Option<&'a str>,
     description: Option<&'a str>,
-    source: &'a SourceId,
+    source: SourceId,
     dependencies: &'a [Dependency],
     targets: Vec<&'a Target>,
     features: &'a FeatureMap,
@@ -122,7 +122,8 @@ impl ser::Serialize for Package {
             repository,
             edition: &self.manifest.edition().to_string(),
             metabuild: self.manifest.metabuild(),
-        }.serialize(s)
+        }
+        .serialize(s)
     }
 }
 
@@ -200,7 +201,7 @@ impl Package {
         matches.min_by_key(|t| t.0).map(|t| t.1)
     }
 
-    pub fn map_source(self, to_replace: &SourceId, replace_with: &SourceId) -> Package {
+    pub fn map_source(self, to_replace: SourceId, replace_with: SourceId) -> Package {
         Package {
             manifest: self.manifest.map_source(to_replace, replace_with),
             manifest_path: self.manifest_path,
@@ -289,7 +290,7 @@ pub struct Downloads<'a, 'cfg: 'a> {
     /// because we want to apply timeouts to an entire batch of operations, not
     /// any one particular single operatino
     timeout: ops::HttpTimeout, // timeout configuration
-    updated_at: Cell<Instant>, // last time we received bytes
+    updated_at: Cell<Instant>,       // last time we received bytes
     next_speed_check: Cell<Instant>, // if threshold isn't 0 by this time, error
     next_speed_check_bytes_threshold: Cell<u64>, // decremented when we receive bytes
 }
@@ -340,9 +341,11 @@ impl<'cfg> PackageSet<'cfg> {
         // that it's buggy, and we've empirically seen that it's buggy with HTTP
         // proxies.
         let mut multi = Multi::new();
-        let multiplexing = config.get::<Option<bool>>("http.multiplexing")?
+        let multiplexing = config
+            .get::<Option<bool>>("http.multiplexing")?
             .unwrap_or(true);
-        multi.pipelining(false, multiplexing)
+        multi
+            .pipelining(false, multiplexing)
             .chain_err(|| "failed to enable multiplexing/pipelining in curl")?;
 
         // let's not flood crates.io with connections
@@ -395,9 +398,10 @@ impl<'cfg> PackageSet<'cfg> {
         Ok(self.get_many(Some(id))?.remove(0))
     }
 
-    pub fn get_many<'a>(&self, ids: impl IntoIterator<Item = &'a PackageId>)
-        -> CargoResult<Vec<&Package>>
-    {
+    pub fn get_many<'a>(
+        &self,
+        ids: impl IntoIterator<Item = &'a PackageId>,
+    ) -> CargoResult<Vec<&Package>> {
         let mut pkgs = Vec::new();
         let mut downloads = self.enable_download()?;
         for id in ids {
@@ -424,7 +428,9 @@ impl<'a, 'cfg> Downloads<'a, 'cfg> {
     pub fn start(&mut self, id: &PackageId) -> CargoResult<Option<&'a Package>> {
         // First up see if we've already cached this package, in which case
         // there's nothing to do.
-        let slot = self.set.packages
+        let slot = self
+            .set
+            .packages
             .get(id)
             .ok_or_else(|| internal(format!("couldn't find `{}` in package set", id)))?;
         if let Some(pkg) = slot.borrow() {
@@ -445,7 +451,7 @@ impl<'a, 'cfg> Downloads<'a, 'cfg> {
             MaybePackage::Ready(pkg) => {
                 debug!("{} doesn't need a download", id);
                 assert!(slot.fill(pkg).is_ok());
-                return Ok(Some(slot.borrow().unwrap()))
+                return Ok(Some(slot.borrow().unwrap()));
             }
             MaybePackage::Download { url, descriptor } => (url, descriptor),
         };
@@ -483,9 +489,7 @@ impl<'a, 'cfg> Downloads<'a, 'cfg> {
                     warn!("ignoring HTTP/2 activation error: {}", e)
                 }
             } else {
-                result.with_context(|_| {
-                    "failed to enable HTTP2, is curl not built right?"
-                })?;
+                result.with_context(|_| "failed to enable HTTP2, is curl not built right?")?;
             }
         } else {
             handle.http_version(HttpVersion::V11)?;
@@ -504,7 +508,9 @@ impl<'a, 'cfg> Downloads<'a, 'cfg> {
             debug!("{} - {} bytes of data", token, buf.len());
             tls::with(|downloads| {
                 if let Some(downloads) = downloads {
-                    downloads.pending[&token].0.data
+                    downloads.pending[&token]
+                        .0
+                        .data
                         .borrow_mut()
                         .extend_from_slice(buf);
                 }
@@ -514,22 +520,23 @@ impl<'a, 'cfg> Downloads<'a, 'cfg> {
 
         handle.progress(true)?;
         handle.progress_function(move |dl_total, dl_cur, _, _| {
-            tls::with(|downloads| {
-                match downloads {
-                    Some(d) => d.progress(token, dl_total as u64, dl_cur as u64),
-                    None => false,
-                }
+            tls::with(|downloads| match downloads {
+                Some(d) => d.progress(token, dl_total as u64, dl_cur as u64),
+                None => false,
             })
         })?;
 
         // If the progress bar isn't enabled then it may be awhile before the
         // first crate finishes downloading so we inform immediately that we're
         // downloading crates here.
-        if self.downloads_finished == 0 &&
-            self.pending.len() == 0 &&
-            !self.progress.borrow().as_ref().unwrap().is_enabled()
+        if self.downloads_finished == 0
+            && self.pending.len() == 0
+            && !self.progress.borrow().as_ref().unwrap().is_enabled()
         {
-            self.set.config.shell().status("Downloading", "crates ...")?;
+            self.set
+                .config
+                .shell()
+                .status("Downloading", "crates ...")?;
         }
 
         let dl = Download {
@@ -569,7 +576,9 @@ impl<'a, 'cfg> Downloads<'a, 'cfg> {
             let (token, result) = self.wait_for_curl()?;
             debug!("{} finished with {:?}", token, result);
 
-            let (mut dl, handle) = self.pending.remove(&token)
+            let (mut dl, handle) = self
+                .pending
+                .remove(&token)
                 .expect("got a token for a non-in-progress transfer");
             let data = mem::replace(&mut *dl.data.borrow_mut(), Vec::new());
             let mut handle = self.set.multi.remove(handle)?;
@@ -581,42 +590,44 @@ impl<'a, 'cfg> Downloads<'a, 'cfg> {
             let ret = {
                 let timed_out = &dl.timed_out;
                 let url = &dl.url;
-                dl.retry.try(|| {
-                    if let Err(e) = result {
-                        // If this error is "aborted by callback" then that's
-                        // probably because our progress callback aborted due to
-                        // a timeout. We'll find out by looking at the
-                        // `timed_out` field, looking for a descriptive message.
-                        // If one is found we switch the error code (to ensure
-                        // it's flagged as spurious) and then attach our extra
-                        // information to the error.
-                        if !e.is_aborted_by_callback() {
-                            return Err(e.into())
+                dl.retry
+                    .try(|| {
+                        if let Err(e) = result {
+                            // If this error is "aborted by callback" then that's
+                            // probably because our progress callback aborted due to
+                            // a timeout. We'll find out by looking at the
+                            // `timed_out` field, looking for a descriptive message.
+                            // If one is found we switch the error code (to ensure
+                            // it's flagged as spurious) and then attach our extra
+                            // information to the error.
+                            if !e.is_aborted_by_callback() {
+                                return Err(e.into());
+                            }
+
+                            return Err(match timed_out.replace(None) {
+                                Some(msg) => {
+                                    let code = curl_sys::CURLE_OPERATION_TIMEDOUT;
+                                    let mut err = curl::Error::new(code);
+                                    err.set_extra(msg);
+                                    err
+                                }
+                                None => e,
+                            }
+                            .into());
                         }
 
-                        return Err(match timed_out.replace(None) {
-                            Some(msg) => {
-                                let code = curl_sys::CURLE_OPERATION_TIMEDOUT;
-                                let mut err = curl::Error::new(code);
-                                err.set_extra(msg);
-                                err
+                        let code = handle.response_code()?;
+                        if code != 200 && code != 0 {
+                            let url = handle.effective_url()?.unwrap_or(url);
+                            return Err(HttpNot200 {
+                                code,
+                                url: url.to_string(),
                             }
-                            None => e,
-                        }.into())
-                    }
-
-                    let code = handle.response_code()?;
-                    if code != 200 && code != 0 {
-                        let url = handle.effective_url()?.unwrap_or(url);
-                        return Err(HttpNot200 {
-                            code,
-                            url: url.to_string(),
-                        }.into())
-                    }
-                    Ok(())
-                }).chain_err(|| {
-                    format!("failed to download from `{}`", dl.url)
-                })?
+                            .into());
+                        }
+                        Ok(())
+                    })
+                    .chain_err(|| format!("failed to download from `{}`", dl.url))?
             };
             match ret {
                 Some(()) => break (dl, data),
@@ -631,7 +642,10 @@ impl<'a, 'cfg> Downloads<'a, 'cfg> {
         // semblance of progress of how we're downloading crates, and if the
         // progress bar is enabled this provides a good log of what's happening.
         self.progress.borrow_mut().as_mut().unwrap().clear();
-        self.set.config.shell().status("Downloaded", &dl.descriptor)?;
+        self.set
+            .config
+            .shell()
+            .status("Downloaded", &dl.descriptor)?;
 
         self.downloads_finished += 1;
         self.downloaded_bytes += dl.total.get();
@@ -665,7 +679,8 @@ impl<'a, 'cfg> Downloads<'a, 'cfg> {
         // extracted tarball.
         let finish_dur = start.elapsed();
         self.updated_at.set(self.updated_at.get() + finish_dur);
-        self.next_speed_check.set(self.next_speed_check.get() + finish_dur);
+        self.next_speed_check
+            .set(self.next_speed_check.get() + finish_dur);
 
         let slot = &self.set.packages[&dl.id];
         assert!(slot.fill(pkg).is_ok());
@@ -678,7 +693,8 @@ impl<'a, 'cfg> Downloads<'a, 'cfg> {
         handle.set_token(dl.token)?;
         self.updated_at.set(now);
         self.next_speed_check.set(now + self.timeout.dur);
-        self.next_speed_check_bytes_threshold.set(self.timeout.low_speed_limit as u64);
+        self.next_speed_check_bytes_threshold
+            .set(self.timeout.low_speed_limit as u64);
         dl.timed_out.set(None);
         dl.current.set(0);
         dl.total.set(0);
@@ -704,7 +720,9 @@ impl<'a, 'cfg> Downloads<'a, 'cfg> {
         // `wait` method on `multi`.
         loop {
             let n = tls::set(self, || {
-                self.set.multi.perform()
+                self.set
+                    .multi
+                    .perform()
                     .chain_err(|| "failed to perform http requests")
             })?;
             debug!("handles remaining: {}", n);
@@ -721,12 +739,13 @@ impl<'a, 'cfg> Downloads<'a, 'cfg> {
             });
 
             if let Some(pair) = results.pop() {
-                break Ok(pair)
+                break Ok(pair);
             }
             assert!(self.pending.len() > 0);
-            let timeout = self.set.multi.get_timeout()?
-                .unwrap_or(Duration::new(5, 0));
-            self.set.multi.wait(&mut [], timeout)
+            let timeout = self.set.multi.get_timeout()?.unwrap_or(Duration::new(5, 0));
+            self.set
+                .multi
+                .wait(&mut [], timeout)
                 .chain_err(|| "failed to wait on curl `Multi`")?;
         }
     }
@@ -744,25 +763,26 @@ impl<'a, 'cfg> Downloads<'a, 'cfg> {
 
             if delta >= threshold {
                 self.next_speed_check.set(now + self.timeout.dur);
-                self.next_speed_check_bytes_threshold.set(
-                    self.timeout.low_speed_limit as u64,
-                );
+                self.next_speed_check_bytes_threshold
+                    .set(self.timeout.low_speed_limit as u64);
             } else {
                 self.next_speed_check_bytes_threshold.set(threshold - delta);
             }
         }
         if !self.tick(WhyTick::DownloadUpdate).is_ok() {
-            return false
+            return false;
         }
 
         // If we've spent too long not actually receiving any data we time out.
         if now - self.updated_at.get() > self.timeout.dur {
             self.updated_at.set(now);
-            let msg = format!("failed to download any data for `{}` within {}s",
-                              dl.id,
-                              self.timeout.dur.as_secs());
+            let msg = format!(
+                "failed to download any data for `{}` within {}s",
+                dl.id,
+                self.timeout.dur.as_secs()
+            );
             dl.timed_out.set(Some(msg));
-            return false
+            return false;
         }
 
         // If we reached the point in time that we need to check our speed
@@ -772,13 +792,15 @@ impl<'a, 'cfg> Downloads<'a, 'cfg> {
         if now >= self.next_speed_check.get() {
             self.next_speed_check.set(now + self.timeout.dur);
             assert!(self.next_speed_check_bytes_threshold.get() > 0);
-            let msg = format!("download of `{}` failed to transfer more \
-                               than {} bytes in {}s",
-                              dl.id,
-                              self.timeout.low_speed_limit,
-                              self.timeout.dur.as_secs());
+            let msg = format!(
+                "download of `{}` failed to transfer more \
+                 than {} bytes in {}s",
+                dl.id,
+                self.timeout.low_speed_limit,
+                self.timeout.dur.as_secs()
+            );
             dl.timed_out.set(Some(msg));
-            return false
+            return false;
         }
 
         true
@@ -790,7 +812,7 @@ impl<'a, 'cfg> Downloads<'a, 'cfg> {
 
         if let WhyTick::DownloadUpdate = why {
             if !progress.update_allowed() {
-                return Ok(())
+                return Ok(());
             }
         }
         let mut msg = format!("{} crates", self.pending.len());
@@ -833,20 +855,22 @@ impl<'a, 'cfg> Drop for Downloads<'a, 'cfg> {
         // Don't print a download summary if we're not using a progress bar,
         // we've already printed lots of `Downloading...` items.
         if !progress.is_enabled() {
-            return
+            return;
         }
         // If we didn't download anything, no need for a summary
         if self.downloads_finished == 0 {
-            return
+            return;
         }
         // If an error happened, let's not clutter up the output
         if !self.success {
-            return
+            return;
         }
-        let mut status = format!("{} crates ({}) in {}",
-                                 self.downloads_finished,
-                                 ByteSize(self.downloaded_bytes),
-                                 util::elapsed(self.start.elapsed()));
+        let mut status = format!(
+            "{} crates ({}) in {}",
+            self.downloads_finished,
+            ByteSize(self.downloaded_bytes),
+            util::elapsed(self.start.elapsed())
+        );
         if self.largest.0 > ByteSize::mb(1).0 {
             status.push_str(&format!(
                 " (largest was `{}` at {})",
@@ -872,9 +896,7 @@ mod tls {
         if ptr == 0 {
             f(None)
         } else {
-            unsafe {
-                f(Some(&*(ptr as *const Downloads)))
-            }
+            unsafe { f(Some(&*(ptr as *const Downloads))) }
         }
     }
 

--- a/src/cargo/core/package_id.rs
+++ b/src/cargo/core/package_id.rs
@@ -1,7 +1,7 @@
 use std::cmp::Ordering;
 use std::fmt::{self, Formatter};
-use std::hash::Hash;
 use std::hash;
+use std::hash::Hash;
 use std::path::Path;
 use std::sync::Arc;
 
@@ -9,9 +9,9 @@ use semver;
 use serde::de;
 use serde::ser;
 
-use util::{CargoResult, ToSemver};
-use core::source::SourceId;
 use core::interning::InternedString;
+use core::source::SourceId;
+use util::{CargoResult, ToSemver};
 
 /// Identifier for a specific version of a package in a specific source.
 #[derive(Clone)]
@@ -100,13 +100,13 @@ impl Ord for PackageId {
 }
 
 impl PackageId {
-    pub fn new<T: ToSemver>(name: &str, version: T, sid: &SourceId) -> CargoResult<PackageId> {
+    pub fn new<T: ToSemver>(name: &str, version: T, sid: SourceId) -> CargoResult<PackageId> {
         let v = version.to_semver()?;
         Ok(PackageId {
             inner: Arc::new(PackageIdInner {
                 name: InternedString::new(name),
                 version: v,
-                source_id: sid.clone(),
+                source_id: sid,
             }),
         })
     }
@@ -117,8 +117,8 @@ impl PackageId {
     pub fn version(&self) -> &semver::Version {
         &self.inner.version
     }
-    pub fn source_id(&self) -> &SourceId {
-        &self.inner.source_id
+    pub fn source_id(&self) -> SourceId {
+        self.inner.source_id
     }
 
     pub fn with_precise(&self, precise: Option<String>) -> PackageId {
@@ -131,12 +131,12 @@ impl PackageId {
         }
     }
 
-    pub fn with_source_id(&self, source: &SourceId) -> PackageId {
+    pub fn with_source_id(&self, source: SourceId) -> PackageId {
         PackageId {
             inner: Arc::new(PackageIdInner {
                 name: self.inner.name,
                 version: self.inner.version.clone(),
-                source_id: source.clone(),
+                source_id: source,
             }),
         }
     }
@@ -190,9 +190,9 @@ mod tests {
         let loc = CRATES_IO_INDEX.to_url().unwrap();
         let repo = SourceId::for_registry(&loc).unwrap();
 
-        assert!(PackageId::new("foo", "1.0", &repo).is_err());
-        assert!(PackageId::new("foo", "1", &repo).is_err());
-        assert!(PackageId::new("foo", "bar", &repo).is_err());
-        assert!(PackageId::new("foo", "", &repo).is_err());
+        assert!(PackageId::new("foo", "1.0", repo).is_err());
+        assert!(PackageId::new("foo", "1", repo).is_err());
+        assert!(PackageId::new("foo", "bar", repo).is_err());
+        assert!(PackageId::new("foo", "", repo).is_err());
     }
 }

--- a/src/cargo/core/package_id_spec.rs
+++ b/src/cargo/core/package_id_spec.rs
@@ -6,8 +6,8 @@ use serde::{de, ser};
 use url::Url;
 
 use core::PackageId;
-use util::{ToSemver, ToUrl};
 use util::errors::{CargoResult, CargoResultExt};
+use util::{ToSemver, ToUrl};
 
 /// Some or all of the data required to identify a package:
 ///
@@ -104,7 +104,8 @@ impl PackageIdSpec {
         let frag = url.fragment().map(|s| s.to_owned());
         url.set_fragment(None);
         let (name, version) = {
-            let mut path = url.path_segments()
+            let mut path = url
+                .path_segments()
                 .ok_or_else(|| format_err!("pkgid urls must have a path: {}", url))?;
             let path_name = path.next_back().ok_or_else(|| {
                 format_err!(
@@ -275,10 +276,10 @@ impl<'de> de::Deserialize<'de> for PackageIdSpec {
 
 #[cfg(test)]
 mod tests {
-    use core::{PackageId, SourceId};
     use super::PackageIdSpec;
-    use url::Url;
+    use core::{PackageId, SourceId};
     use semver::Version;
+    use url::Url;
 
     #[test]
     fn good_parsing() {
@@ -367,8 +368,8 @@ mod tests {
     fn matching() {
         let url = Url::parse("http://example.com").unwrap();
         let sid = SourceId::for_registry(&url).unwrap();
-        let foo = PackageId::new("foo", "1.2.3", &sid).unwrap();
-        let bar = PackageId::new("bar", "1.2.3", &sid).unwrap();
+        let foo = PackageId::new("foo", "1.2.3", sid).unwrap();
+        let bar = PackageId::new("bar", "1.2.3", sid).unwrap();
 
         assert!(PackageIdSpec::parse("foo").unwrap().matches(&foo));
         assert!(!PackageIdSpec::parse("foo").unwrap().matches(&bar));

--- a/src/cargo/core/profiles.rs
+++ b/src/cargo/core/profiles.rs
@@ -205,11 +205,13 @@ impl ProfileMaker {
                 .keys()
                 .filter_map(|key| match *key {
                     ProfilePackageSpec::All => None,
-                    ProfilePackageSpec::Spec(ref spec) => if spec.matches(pkg_id) {
-                        Some(spec)
-                    } else {
-                        None
-                    },
+                    ProfilePackageSpec::Spec(ref spec) => {
+                        if spec.matches(pkg_id) {
+                            Some(spec)
+                        } else {
+                            None
+                        }
+                    }
                 })
                 .collect();
             match matches.len() {
@@ -313,11 +315,13 @@ fn merge_toml(
                 .iter()
                 .filter_map(|(key, spec_profile)| match *key {
                     ProfilePackageSpec::All => None,
-                    ProfilePackageSpec::Spec(ref s) => if s.matches(pkg_id) {
-                        Some(spec_profile)
-                    } else {
-                        None
-                    },
+                    ProfilePackageSpec::Spec(ref s) => {
+                        if s.matches(pkg_id) {
+                            Some(spec_profile)
+                        } else {
+                            None
+                        }
+                    }
                 });
             if let Some(spec_profile) = matches.next() {
                 merge_profile(profile, spec_profile);
@@ -586,7 +590,7 @@ impl UnitFor {
     pub fn with_for_host(self, for_host: bool) -> UnitFor {
         UnitFor {
             custom_build: self.custom_build,
-            panic_ok: self.panic_ok && !for_host
+            panic_ok: self.panic_ok && !for_host,
         }
     }
 
@@ -597,16 +601,25 @@ impl UnitFor {
     }
 
     /// Returns true if this unit is allowed to set the `panic` compiler flag.
-    pub fn is_panic_ok(&self) -> bool {
+    pub fn is_panic_ok(self) -> bool {
         self.panic_ok
     }
 
     /// All possible values, used by `clean`.
     pub fn all_values() -> &'static [UnitFor] {
         static ALL: [UnitFor; 3] = [
-            UnitFor { custom_build: false, panic_ok: true },
-            UnitFor { custom_build: true, panic_ok: false },
-            UnitFor { custom_build: false, panic_ok: false },
+            UnitFor {
+                custom_build: false,
+                panic_ok: true,
+            },
+            UnitFor {
+                custom_build: true,
+                panic_ok: false,
+            },
+            UnitFor {
+                custom_build: false,
+                panic_ok: false,
+            },
         ];
         &ALL
     }

--- a/src/cargo/core/profiles.rs
+++ b/src/cargo/core/profiles.rs
@@ -596,7 +596,7 @@ impl UnitFor {
 
     /// Returns true if this unit is for a custom build script or one of its
     /// dependencies.
-    pub fn is_custom_build(&self) -> bool {
+    pub fn is_custom_build(self) -> bool {
         self.custom_build
     }
 

--- a/src/cargo/core/resolver/context.rs
+++ b/src/cargo/core/resolver/context.rs
@@ -3,9 +3,9 @@ use std::rc::Rc;
 
 use core::interning::InternedString;
 use core::{Dependency, FeatureValue, PackageId, SourceId, Summary};
+use im_rc;
 use util::CargoResult;
 use util::Graph;
-use im_rc;
 
 use super::errors::ActivateResult;
 use super::types::{ConflictReason, DepInfo, GraphNode, Method, RcList, RegistryQueryer};
@@ -55,7 +55,7 @@ impl Context {
         let id = summary.package_id();
         let prev = self
             .activations
-            .entry((id.name(), id.source_id().clone()))
+            .entry((id.name(), id.source_id()))
             .or_insert_with(|| Rc::new(Vec::new()));
         if !prev.iter().any(|c| c == summary) {
             self.resolve_graph.push(GraphNode::Add(id.clone()));
@@ -126,14 +126,14 @@ impl Context {
 
     pub fn prev_active(&self, dep: &Dependency) -> &[Summary] {
         self.activations
-            .get(&(dep.package_name(), dep.source_id().clone()))
+            .get(&(dep.package_name(), dep.source_id()))
             .map(|v| &v[..])
             .unwrap_or(&[])
     }
 
     pub fn is_active(&self, id: &PackageId) -> bool {
         self.activations
-            .get(&(id.name(), id.source_id().clone()))
+            .get(&(id.name(), id.source_id()))
             .map(|v| v.iter().any(|s| s.package_id() == id))
             .unwrap_or(false)
     }

--- a/src/cargo/core/resolver/encode.rs
+++ b/src/cargo/core/resolver/encode.rs
@@ -338,7 +338,7 @@ impl<'a, 'cfg> ser::Serialize for WorkspaceResolve<'a, 'cfg> {
 
         let encodable = ids
             .iter()
-            .filter_map(|&id| Some(encodable_resolve_node(id, self.resolve)))
+            .map(|&id| encodable_resolve_node(id, self.resolve))
             .collect::<Vec<_>>();
 
         let mut metadata = self.resolve.metadata().clone();

--- a/src/cargo/core/resolver/encode.rs
+++ b/src/cargo/core/resolver/encode.rs
@@ -50,7 +50,7 @@ impl EncodableResolve {
                 let enc_id = EncodablePackageId {
                     name: pkg.name.clone(),
                     version: pkg.version.clone(),
-                    source: pkg.source.clone(),
+                    source: pkg.source,
                 };
 
                 if !all_pkgs.insert(enc_id.clone()) {
@@ -63,7 +63,7 @@ impl EncodableResolve {
                         debug!("path dependency now missing {} v{}", pkg.name, pkg.version);
                         continue;
                     }
-                    Some(source) => PackageId::new(&pkg.name, &pkg.version, source)?,
+                    Some(&source) => PackageId::new(&pkg.name, &pkg.version, source)?,
                 };
 
                 assert!(live_pkgs.insert(enc_id, (id, pkg)).is_none())
@@ -156,7 +156,7 @@ impl EncodableResolve {
         let mut unused_patches = Vec::new();
         for pkg in self.patch.unused {
             let id = match pkg.source.as_ref().or_else(|| path_deps.get(&pkg.name)) {
-                Some(src) => PackageId::new(&pkg.name, &pkg.version, src)?,
+                Some(&src) => PackageId::new(&pkg.name, &pkg.version, src)?,
                 None => continue,
             };
             unused_patches.push(id);
@@ -188,9 +188,9 @@ fn build_path_deps(ws: &Workspace) -> HashMap<String, SourceId> {
     for member in members.iter() {
         ret.insert(
             member.package_id().name().to_string(),
-            member.package_id().source_id().clone(),
+            member.package_id().source_id(),
         );
-        visited.insert(member.package_id().source_id().clone());
+        visited.insert(member.package_id().source_id());
     }
     for member in members.iter() {
         build_pkg(member, ws, &mut ret, &mut visited);
@@ -224,7 +224,7 @@ fn build_path_deps(ws: &Workspace) -> HashMap<String, SourceId> {
         visited: &mut HashSet<SourceId>,
     ) {
         let id = dep.source_id();
-        if visited.contains(id) || !id.is_path() {
+        if visited.contains(&id) || !id.is_path() {
             return;
         }
         let path = match id.url().to_file_path() {
@@ -235,8 +235,8 @@ fn build_path_deps(ws: &Workspace) -> HashMap<String, SourceId> {
             Ok(p) => p,
             Err(_) => return,
         };
-        ret.insert(pkg.name().to_string(), pkg.package_id().source_id().clone());
-        visited.insert(pkg.package_id().source_id().clone());
+        ret.insert(pkg.name().to_string(), pkg.package_id().source_id());
+        visited.insert(pkg.package_id().source_id());
         build_pkg(&pkg, ws, ret, visited);
     }
 }
@@ -412,10 +412,10 @@ pub fn encodable_package_id(id: &PackageId) -> EncodablePackageId {
     }
 }
 
-fn encode_source(id: &SourceId) -> Option<SourceId> {
+fn encode_source(id: SourceId) -> Option<SourceId> {
     if id.is_path() {
         None
     } else {
-        Some(id.clone())
+        Some(id)
     }
 }

--- a/src/cargo/core/resolver/mod.rs
+++ b/src/cargo/core/resolver/mod.rs
@@ -802,20 +802,19 @@ fn find_candidate(
         // active in this back up we know that we're guaranteed to not actually
         // make any progress. As a result if we hit this condition we can
         // completely skip this backtrack frame and move on to the next.
-        if !backtracked {
-            if frame
+        if !backtracked
+            && frame
                 .context
                 .is_conflicting(Some(parent.package_id()), conflicting_activations)
-            {
-                trace!(
-                    "{} = \"{}\" skip as not solving {}: {:?}",
-                    frame.dep.package_name(),
-                    frame.dep.version_req(),
-                    parent.package_id(),
-                    conflicting_activations
-                );
-                continue;
-            }
+        {
+            trace!(
+                "{} = \"{}\" skip as not solving {}: {:?}",
+                frame.dep.package_name(),
+                frame.dep.version_req(),
+                parent.package_id(),
+                conflicting_activations
+            );
+            continue;
         }
 
         return Some((candidate, has_another, frame));

--- a/src/cargo/core/resolver/resolve.rs
+++ b/src/cargo/core/resolver/resolve.rs
@@ -239,9 +239,9 @@ unable to verify that `{0}` is the same as when the lockfile was generated
         let mut names = deps.iter().map(|d| {
             d.explicit_name_in_toml()
                 .map(|s| s.as_str().replace("-", "_"))
-                .unwrap_or(crate_name.clone())
+                .unwrap_or_else(|| crate_name.clone())
         });
-        let name = names.next().unwrap_or(crate_name.clone());
+        let name = names.next().unwrap_or_else(|| crate_name.clone());
         for n in names {
             if n == name {
                 continue;

--- a/src/cargo/core/shell.rs
+++ b/src/cargo/core/shell.rs
@@ -28,10 +28,12 @@ pub struct Shell {
 impl fmt::Debug for Shell {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self.err {
-            ShellOut::Write(_) => f.debug_struct("Shell")
+            ShellOut::Write(_) => f
+                .debug_struct("Shell")
                 .field("verbosity", &self.verbosity)
                 .finish(),
-            ShellOut::Stream { color_choice, .. } => f.debug_struct("Shell")
+            ShellOut::Stream { color_choice, .. } => f
+                .debug_struct("Shell")
                 .field("verbosity", &self.verbosity)
                 .field("color_choice", &color_choice)
                 .finish(),
@@ -376,13 +378,13 @@ mod imp {
 mod imp {
     extern crate winapi;
 
-    use std::{cmp, mem, ptr};
     use self::winapi::um::fileapi::*;
     use self::winapi::um::handleapi::*;
     use self::winapi::um::processenv::*;
     use self::winapi::um::winbase::*;
     use self::winapi::um::wincon::*;
     use self::winapi::um::winnt::*;
+    use std::{cmp, mem, ptr};
 
     pub(super) use super::default_err_erase_line as err_erase_line;
 
@@ -391,19 +393,20 @@ mod imp {
             let stdout = GetStdHandle(STD_ERROR_HANDLE);
             let mut csbi: CONSOLE_SCREEN_BUFFER_INFO = mem::zeroed();
             if GetConsoleScreenBufferInfo(stdout, &mut csbi) != 0 {
-                return Some((csbi.srWindow.Right - csbi.srWindow.Left) as usize)
+                return Some((csbi.srWindow.Right - csbi.srWindow.Left) as usize);
             }
 
             // On mintty/msys/cygwin based terminals, the above fails with
             // INVALID_HANDLE_VALUE. Use an alternate method which works
             // in that case as well.
-            let h = CreateFileA("CONOUT$\0".as_ptr() as *const CHAR,
+            let h = CreateFileA(
+                "CONOUT$\0".as_ptr() as *const CHAR,
                 GENERIC_READ | GENERIC_WRITE,
                 FILE_SHARE_READ | FILE_SHARE_WRITE,
                 ptr::null_mut(),
                 OPEN_EXISTING,
                 0,
-                ptr::null_mut()
+                ptr::null_mut(),
             );
             if h == INVALID_HANDLE_VALUE {
                 return None;
@@ -424,15 +427,12 @@ mod imp {
                 // GetConsoleScreenBufferInfo returns accurate information.
                 return Some(cmp::min(60, width));
             }
-            return None;
+            None
         }
     }
 }
 
-#[cfg(any(
-    all(unix, not(any(target_os = "linux", target_os = "macos"))),
-    windows,
-))]
+#[cfg(any(all(unix, not(any(target_os = "linux", target_os = "macos"))), windows,))]
 fn default_err_erase_line(shell: &mut Shell) {
     if let Some(max_width) = imp::stderr_width() {
         let blank = " ".repeat(max_width);

--- a/src/cargo/core/source/mod.rs
+++ b/src/cargo/core/source/mod.rs
@@ -12,10 +12,10 @@ pub use self::source_id::{GitReference, SourceId};
 /// versions.
 pub trait Source {
     /// Returns the `SourceId` corresponding to this source
-    fn source_id(&self) -> &SourceId;
+    fn source_id(&self) -> SourceId;
 
     /// Returns the replaced `SourceId` corresponding to this source
-    fn replaced_source_id(&self) -> &SourceId {
+    fn replaced_source_id(&self) -> SourceId {
         self.source_id()
     }
 
@@ -92,12 +92,12 @@ pub enum MaybePackage {
 
 impl<'a, T: Source + ?Sized + 'a> Source for Box<T> {
     /// Forwards to `Source::source_id`
-    fn source_id(&self) -> &SourceId {
+    fn source_id(&self) -> SourceId {
         (**self).source_id()
     }
 
     /// Forwards to `Source::replaced_source_id`
-    fn replaced_source_id(&self) -> &SourceId {
+    fn replaced_source_id(&self) -> SourceId {
         (**self).replaced_source_id()
     }
 
@@ -155,11 +155,11 @@ impl<'a, T: Source + ?Sized + 'a> Source for Box<T> {
 }
 
 impl<'a, T: Source + ?Sized + 'a> Source for &'a mut T {
-    fn source_id(&self) -> &SourceId {
+    fn source_id(&self) -> SourceId {
         (**self).source_id()
     }
 
-    fn replaced_source_id(&self) -> &SourceId {
+    fn replaced_source_id(&self) -> SourceId {
         (**self).replaced_source_id()
     }
 
@@ -231,13 +231,13 @@ impl<'src> SourceMap<'src> {
     }
 
     /// Like `HashMap::contains_key`
-    pub fn contains(&self, id: &SourceId) -> bool {
-        self.map.contains_key(id)
+    pub fn contains(&self, id: SourceId) -> bool {
+        self.map.contains_key(&id)
     }
 
     /// Like `HashMap::get`
-    pub fn get(&self, id: &SourceId) -> Option<&(Source + 'src)> {
-        let source = self.map.get(id);
+    pub fn get(&self, id: SourceId) -> Option<&(Source + 'src)> {
+        let source = self.map.get(&id);
 
         source.map(|s| {
             let s: &(Source + 'src) = &**s;
@@ -246,8 +246,8 @@ impl<'src> SourceMap<'src> {
     }
 
     /// Like `HashMap::get_mut`
-    pub fn get_mut(&mut self, id: &SourceId) -> Option<&mut (Source + 'src)> {
-        self.map.get_mut(id).map(|s| {
+    pub fn get_mut(&mut self, id: SourceId) -> Option<&mut (Source + 'src)> {
+        self.map.get_mut(&id).map(|s| {
             let s: &mut (Source + 'src) = &mut **s;
             s
         })
@@ -261,7 +261,7 @@ impl<'src> SourceMap<'src> {
 
     /// Like `HashMap::insert`, but derives the SourceId key from the Source
     pub fn insert(&mut self, source: Box<Source + 'src>) {
-        let id = source.source_id().clone();
+        let id = source.source_id();
         self.map.insert(id, source);
     }
 

--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -236,7 +236,8 @@ impl<'cfg> Workspace<'cfg> {
     }
 
     pub fn profiles(&self) -> &Profiles {
-        let root = self.root_manifest
+        let root = self
+            .root_manifest
             .as_ref()
             .unwrap_or(&self.current_manifest);
         match *self.packages.get(root) {
@@ -253,8 +254,9 @@ impl<'cfg> Workspace<'cfg> {
         match self.root_manifest {
             Some(ref p) => p,
             None => &self.current_manifest,
-        }.parent()
-            .unwrap()
+        }
+        .parent()
+        .unwrap()
     }
 
     pub fn target_dir(&self) -> Filesystem {
@@ -425,8 +427,8 @@ impl<'cfg> Workspace<'cfg> {
             let root_package = self.packages.load(&root_manifest_path)?;
             match *root_package.workspace_config() {
                 WorkspaceConfig::Root(ref root_config) => {
-                    members_paths =
-                        root_config.members_paths(root_config.members.as_ref().unwrap_or(&vec![]))?;
+                    members_paths = root_config
+                        .members_paths(root_config.members.as_ref().unwrap_or(&vec![]))?;
                     default_members_paths = if let Some(ref default) = root_config.default_members {
                         Some(root_config.members_paths(default)?)
                     } else {
@@ -475,7 +477,8 @@ impl<'cfg> Workspace<'cfg> {
         if self.members.contains(&manifest_path) {
             return Ok(());
         }
-        if is_path_dep && !manifest_path.parent().unwrap().starts_with(self.root())
+        if is_path_dep
+            && !manifest_path.parent().unwrap().starts_with(self.root())
             && self.find_root(&manifest_path)? != self.root_manifest
         {
             // If `manifest_path` is a path dependency outside of the workspace,
@@ -655,7 +658,8 @@ impl<'cfg> Workspace<'cfg> {
         }
 
         if let Some(ref root_manifest) = self.root_manifest {
-            for pkg in self.members()
+            for pkg in self
+                .members()
                 .filter(|p| p.manifest_path() != root_manifest)
             {
                 let manifest = pkg.manifest();
@@ -699,7 +703,7 @@ impl<'cfg> Workspace<'cfg> {
             return Ok(p);
         }
         let source_id = SourceId::for_path(manifest_path.parent().unwrap())?;
-        let (package, _nested_paths) = ops::read_package(manifest_path, &source_id, self.config)?;
+        let (package, _nested_paths) = ops::read_package(manifest_path, source_id, self.config)?;
         loaded.insert(manifest_path.to_path_buf(), package.clone());
         Ok(package)
     }
@@ -745,10 +749,7 @@ impl<'cfg> Workspace<'cfg> {
             for warning in warnings {
                 if warning.is_critical {
                     let err = format_err!("{}", warning.message);
-                    let cx = format_err!(
-                        "failed to parse manifest at `{}`",
-                        path.display()
-                    );
+                    let cx = format_err!("failed to parse manifest at `{}`", path.display());
                     return Err(err.context(cx).into());
                 } else {
                     let msg = if self.root_manifest.is_none() {
@@ -782,7 +783,7 @@ impl<'cfg> Packages<'cfg> {
             Entry::Vacant(v) => {
                 let source_id = SourceId::for_path(key)?;
                 let (manifest, _nested_paths) =
-                    read_manifest(manifest_path, &source_id, self.config)?;
+                    read_manifest(manifest_path, source_id, self.config)?;
                 Ok(v.insert(match manifest {
                     EitherManifest::Real(manifest) => {
                         MaybePackage::Package(Package::new(manifest, manifest_path))
@@ -843,7 +844,8 @@ impl WorkspaceRootConfig {
     ///
     /// This method does NOT consider the `members` list.
     fn is_excluded(&self, manifest_path: &Path) -> bool {
-        let excluded = self.exclude
+        let excluded = self
+            .exclude
             .iter()
             .any(|ex| manifest_path.starts_with(self.root_dir.join(ex)));
 
@@ -886,9 +888,9 @@ impl WorkspaceRootConfig {
             None => return Ok(Vec::new()),
         };
         let res = glob(path).chain_err(|| format_err!("could not parse pattern `{}`", &path))?;
-        let res = res.map(|p| {
-            p.chain_err(|| format_err!("unable to match path to pattern `{}`", &path))
-        }).collect::<Result<Vec<_>, _>>()?;
+        let res = res
+            .map(|p| p.chain_err(|| format_err!("unable to match path to pattern `{}`", &path)))
+            .collect::<Result<Vec<_>, _>>()?;
         Ok(res)
     }
 }

--- a/src/cargo/lib.rs
+++ b/src/cargo/lib.rs
@@ -1,18 +1,17 @@
 #![cfg_attr(test, deny(warnings))]
-
 // Clippy isn't enforced by CI, and know that @alexcrichton isn't a fan :)
-#![cfg_attr(feature = "cargo-clippy", allow(boxed_local))]             // bug rust-lang-nursery/rust-clippy#1123
-#![cfg_attr(feature = "cargo-clippy", allow(cyclomatic_complexity))]   // large project
-#![cfg_attr(feature = "cargo-clippy", allow(derive_hash_xor_eq))]      // there's an intentional incoherence
-#![cfg_attr(feature = "cargo-clippy", allow(explicit_into_iter_loop))] // explicit loops are clearer
-#![cfg_attr(feature = "cargo-clippy", allow(explicit_iter_loop))]      // explicit loops are clearer
-#![cfg_attr(feature = "cargo-clippy", allow(identity_op))]             // used for vertical alignment
-#![cfg_attr(feature = "cargo-clippy", allow(implicit_hasher))]         // large project
-#![cfg_attr(feature = "cargo-clippy", allow(large_enum_variant))]      // large project
-#![cfg_attr(feature = "cargo-clippy", allow(redundant_closure_call))]  // closures over try catch blocks
-#![cfg_attr(feature = "cargo-clippy", allow(too_many_arguments))]      // large project
-#![cfg_attr(feature = "cargo-clippy", allow(type_complexity))]         // there's an exceptionally complex type
-#![cfg_attr(feature = "cargo-clippy", allow(wrong_self_convention))]   // perhaps Rc should be special cased in Clippy?
+#![cfg_attr(feature = "cargo-clippy", allow(clippy::boxed_local))]             // bug rust-lang-nursery/rust-clippy#1123
+#![cfg_attr(feature = "cargo-clippy", allow(clippy::cyclomatic_complexity))]   // large project
+#![cfg_attr(feature = "cargo-clippy", allow(clippy::derive_hash_xor_eq))]      // there's an intentional incoherence
+#![cfg_attr(feature = "cargo-clippy", allow(clippy::explicit_into_iter_loop))] // explicit loops are clearer
+#![cfg_attr(feature = "cargo-clippy", allow(clippy::explicit_iter_loop))]      // explicit loops are clearer
+#![cfg_attr(feature = "cargo-clippy", allow(clippy::identity_op))]             // used for vertical alignment
+#![cfg_attr(feature = "cargo-clippy", allow(clippy::implicit_hasher))]         // large project
+#![cfg_attr(feature = "cargo-clippy", allow(clippy::large_enum_variant))]      // large project
+#![cfg_attr(feature = "cargo-clippy", allow(clippy::redundant_closure_call))]  // closures over try catch blocks
+#![cfg_attr(feature = "cargo-clippy", allow(clippy::too_many_arguments))]      // large project
+#![cfg_attr(feature = "cargo-clippy", allow(clippy::type_complexity))]         // there's an exceptionally complex type
+#![cfg_attr(feature = "cargo-clippy", allow(clippy::wrong_self_convention))]   // perhaps Rc should be special cased in Clippy?
 
 extern crate atty;
 extern crate bytesize;
@@ -55,6 +54,7 @@ extern crate serde_derive;
 extern crate serde_ignored;
 #[macro_use]
 extern crate serde_json;
+extern crate im_rc;
 extern crate shell_escape;
 extern crate tar;
 extern crate tempfile;
@@ -62,18 +62,17 @@ extern crate termcolor;
 extern crate toml;
 extern crate unicode_width;
 extern crate url;
-extern crate im_rc;
 
 use std::fmt;
 
-use serde::ser;
 use failure::Error;
+use serde::ser;
 
-use core::Shell;
 use core::shell::Verbosity::Verbose;
+use core::Shell;
 
-pub use util::{CargoError, CargoResult, CliError, CliResult, Config};
 pub use util::errors::Internal;
+pub use util::{CargoError, CargoResult, CliError, CliResult, Config};
 
 pub const CARGO_ENV: &str = "CARGO";
 
@@ -210,7 +209,9 @@ fn handle_cause(cargo_err: &Error, shell: &mut Shell) -> bool {
 
 pub fn version() -> VersionInfo {
     macro_rules! option_env_str {
-        ($name:expr) => { option_env!($name).map(|s| s.to_string()) }
+        ($name:expr) => {
+            option_env!($name).map(|s| s.to_string())
+        };
     }
 
     // So this is pretty horrible...

--- a/src/cargo/ops/cargo_generate_lockfile.rs
+++ b/src/cargo/ops/cargo_generate_lockfile.rs
@@ -73,13 +73,13 @@ pub fn update_lockfile(ws: &Workspace, opts: &UpdateOptions) -> CargoResult<()> 
                         } else {
                             precise.to_string()
                         };
-                        dep.source_id().clone().with_precise(Some(precise))
+                        dep.source_id().with_precise(Some(precise))
                     }
-                    None => dep.source_id().clone().with_precise(None),
+                    None => dep.source_id().with_precise(None),
                 });
             }
         }
-        registry.add_sources(&sources)?;
+        registry.add_sources(sources)?;
     }
 
     let resolve = ops::resolve_with_previous(
@@ -141,7 +141,7 @@ pub fn update_lockfile(ws: &Workspace, opts: &UpdateOptions) -> CargoResult<()> 
         previous_resolve: &'a Resolve,
         resolve: &'a Resolve,
     ) -> Vec<(Vec<&'a PackageId>, Vec<&'a PackageId>)> {
-        fn key(dep: &PackageId) -> (&str, &SourceId) {
+        fn key(dep: &PackageId) -> (&str, SourceId) {
             (dep.name().as_str(), dep.source_id())
         }
 

--- a/src/cargo/ops/cargo_install.rs
+++ b/src/cargo/ops/cargo_install.rs
@@ -726,7 +726,7 @@ pub fn uninstall(
     let scheduled_error = if specs.len() == 1 {
         uninstall_one(&root, specs[0], bins, config)?;
         false
-    } else if specs.len() == 0 {
+    } else if specs.is_empty() {
         uninstall_cwd(&root, bins, config)?;
         false
     } else {
@@ -780,7 +780,7 @@ pub fn uninstall_one(
     let crate_metadata = metadata(config, root)?;
     let metadata = read_crate_list(&crate_metadata)?;
     let pkgid = PackageIdSpec::query_str(spec, metadata.v1.keys())?.clone();
-    uninstall_pkgid(crate_metadata, metadata, &pkgid, bins, config)
+    uninstall_pkgid(&crate_metadata, metadata, &pkgid, bins, config)
 }
 
 fn uninstall_cwd(root: &Filesystem, bins: &[String], config: &Config) -> CargoResult<()> {
@@ -792,11 +792,11 @@ fn uninstall_cwd(root: &Filesystem, bins: &[String], config: &Config) -> CargoRe
         path.read_packages()
     })?;
     let pkgid = pkg.package_id();
-    uninstall_pkgid(crate_metadata, metadata, pkgid, bins, config)
+    uninstall_pkgid(&crate_metadata, metadata, pkgid, bins, config)
 }
 
 fn uninstall_pkgid(
-    crate_metadata: FileLock,
+    crate_metadata: &FileLock,
     mut metadata: CrateListingV1,
     pkgid: &PackageId,
     bins: &[String],

--- a/src/cargo/ops/cargo_install.rs
+++ b/src/cargo/ops/cargo_install.rs
@@ -1,26 +1,26 @@
 use std::collections::btree_map::Entry;
 use std::collections::{BTreeMap, BTreeSet};
-use std::{env, fs};
 use std::io::prelude::*;
 use std::io::SeekFrom;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::{env, fs};
 
 use semver::{Version, VersionReq};
 use tempfile::Builder as TempFileBuilder;
 use toml;
 
+use core::compiler::{DefaultExecutor, Executor};
+use core::package::PackageSet;
+use core::source::SourceMap;
 use core::{Dependency, Edition, Package, PackageIdSpec, Source, SourceId};
 use core::{PackageId, Workspace};
-use core::source::SourceMap;
-use core::package::PackageSet;
-use core::compiler::{DefaultExecutor, Executor};
 use ops::{self, CompileFilter};
 use sources::{GitSource, PathSource, SourceConfigMap};
-use util::{internal, Config};
-use util::{FileLock, Filesystem};
 use util::errors::{CargoResult, CargoResultExt};
 use util::paths;
+use util::{internal, Config};
+use util::{FileLock, Filesystem};
 
 #[derive(Deserialize, Serialize)]
 #[serde(untagged)]
@@ -59,7 +59,7 @@ impl Drop for Transaction {
 pub fn install(
     root: Option<&str>,
     krates: Vec<&str>,
-    source_id: &SourceId,
+    source_id: SourceId,
     from_cwd: bool,
     vers: Option<&str>,
     opts: &ops::CompileOptions,
@@ -154,7 +154,7 @@ fn install_one(
     root: &Filesystem,
     map: &SourceConfigMap,
     krate: Option<&str>,
-    source_id: &SourceId,
+    source_id: SourceId,
     from_cwd: bool,
     vers: Option<&str>,
     opts: &ops::CompileOptions,
@@ -182,7 +182,9 @@ fn install_one(
                 src.path().display()
             )
         })?;
-        select_pkg(src, krate, vers, config, false, &mut |path| path.read_packages())?
+        select_pkg(src, krate, vers, config, false, &mut |path| {
+            path.read_packages()
+        })?
     } else {
         select_pkg(
             map.load(source_id)?,
@@ -255,20 +257,19 @@ fn install_one(
     }
 
     let exec: Arc<Executor> = Arc::new(DefaultExecutor);
-    let compile =
-        ops::compile_ws(&ws, Some(source), opts, &exec).chain_err(|| {
-            if let Some(td) = td_opt.take() {
-                // preserve the temporary directory, so the user can inspect it
-                td.into_path();
-            }
+    let compile = ops::compile_ws(&ws, Some(source), opts, &exec).chain_err(|| {
+        if let Some(td) = td_opt.take() {
+            // preserve the temporary directory, so the user can inspect it
+            td.into_path();
+        }
 
-            format_err!(
-                "failed to compile `{}`, intermediate artifacts can be \
-                 found at `{}`",
-                pkg,
-                ws.target_dir().display()
-            )
-        })?;
+        format_err!(
+            "failed to compile `{}`, intermediate artifacts can be \
+             found at `{}`",
+            pkg,
+            ws.target_dir().display()
+        )
+    })?;
     let binaries: Vec<(&str, &Path)> = compile
         .binaries
         .iter()
@@ -368,7 +369,8 @@ fn install_one(
     }
 
     // Remove empty metadata lines.
-    let pkgs = list.v1
+    let pkgs = list
+        .v1
         .iter()
         .filter_map(|(p, set)| {
             if set.is_empty() {
@@ -410,7 +412,7 @@ fn install_one(
     Ok(())
 }
 
-fn path_source<'a>(source_id: &SourceId, config: &'a Config) -> CargoResult<PathSource<'a>> {
+fn path_source<'a>(source_id: SourceId, config: &'a Config) -> CargoResult<PathSource<'a>> {
     let path = source_id
         .url()
         .to_file_path()
@@ -439,7 +441,8 @@ where
                 Some(v) => {
                     // If the version begins with character <, >, =, ^, ~ parse it as a
                     // version range, otherwise parse it as a specific version
-                    let first = v.chars()
+                    let first = v
+                        .chars()
                         .nth(0)
                         .ok_or_else(|| format_err!("no version provided for the `--vers` flag"))?;
 
@@ -495,16 +498,13 @@ where
             } else {
                 vers
             };
-            let dep = Dependency::parse_no_deprecated(
-                name,
-                vers_spec,
-                source.source_id(),
-            )?;
+            let dep = Dependency::parse_no_deprecated(name, vers_spec, source.source_id())?;
             let deps = source.query_vec(&dep)?;
             let pkgid = match deps.iter().map(|p| p.package_id()).max() {
                 Some(pkgid) => pkgid,
                 None => {
-                    let vers_info = vers.map(|v| format!(" with version `{}`", v))
+                    let vers_info = vers
+                        .map(|v| format!(" with version `{}`", v))
                         .unwrap_or_default();
                     bail!(
                         "could not find `{}` in {}{}",
@@ -624,7 +624,8 @@ fn find_duplicates(
         }
     };
     match *filter {
-        CompileFilter::Default { .. } => pkg.targets()
+        CompileFilter::Default { .. } => pkg
+            .targets()
             .iter()
             .filter(|t| t.is_bin())
             .filter_map(|t| check(t.name().to_string()))
@@ -671,7 +672,7 @@ fn read_crate_list(file: &FileLock) -> CargoResult<CrateListingV1> {
             }),
         }
     })()
-        .chain_err(|| {
+    .chain_err(|| {
         format_err!(
             "failed to parse crate metadata at `{}`",
             file.path().to_string_lossy()
@@ -689,7 +690,7 @@ fn write_crate_list(file: &FileLock, listing: CrateListingV1) -> CargoResult<()>
         file.write_all(data.as_bytes())?;
         Ok(())
     })()
-        .chain_err(|| {
+    .chain_err(|| {
         format_err!(
             "failed to write crate metadata at `{}`",
             file.path().to_string_lossy()
@@ -782,17 +783,14 @@ pub fn uninstall_one(
     uninstall_pkgid(crate_metadata, metadata, &pkgid, bins, config)
 }
 
-fn uninstall_cwd(
-    root: &Filesystem,
-    bins: &[String],
-    config: &Config,
-) -> CargoResult<()> {
+fn uninstall_cwd(root: &Filesystem, bins: &[String], config: &Config) -> CargoResult<()> {
     let crate_metadata = metadata(config, root)?;
     let metadata = read_crate_list(&crate_metadata)?;
     let source_id = SourceId::for_path(config.cwd())?;
-    let src = path_source(&source_id, config)?;
-    let (pkg, _source) =
-        select_pkg(src, None, None, config, true, &mut |path| path.read_packages())?;
+    let src = path_source(source_id, config)?;
+    let (pkg, _source) = select_pkg(src, None, None, config, true, &mut |path| {
+        path.read_packages()
+    })?;
     let pkgid = pkg.package_id();
     uninstall_pkgid(crate_metadata, metadata, pkgid, bins, config)
 }
@@ -821,7 +819,8 @@ fn uninstall_pkgid(
             }
         }
 
-        let bins = bins.iter()
+        let bins = bins
+            .iter()
             .map(|s| {
                 if s.ends_with(env::consts::EXE_SUFFIX) {
                     s.to_string()
@@ -865,7 +864,8 @@ fn metadata(config: &Config, root: &Filesystem) -> CargoResult<FileLock> {
 
 fn resolve_root(flag: Option<&str>, config: &Config) -> CargoResult<Filesystem> {
     let config_root = config.get_path("install.root")?;
-    Ok(flag.map(PathBuf::from)
+    Ok(flag
+        .map(PathBuf::from)
         .or_else(|| env::var_os("CARGO_INSTALL_ROOT").map(PathBuf::from))
         .or_else(move || config_root.map(|v| v.val))
         .map(Filesystem::new)

--- a/src/cargo/ops/cargo_new.rs
+++ b/src/cargo/ops/cargo_new.rs
@@ -1,16 +1,16 @@
 use std::collections::BTreeMap;
 use std::env;
-use std::fs;
 use std::fmt;
+use std::fs;
 use std::path::{Path, PathBuf};
 
 use git2::Config as GitConfig;
 use git2::Repository as GitRepository;
 
 use core::{compiler, Workspace};
-use util::{internal, FossilRepo, GitRepo, HgRepo, PijulRepo, existing_vcs_repo};
-use util::{paths, Config};
 use util::errors::{CargoResult, CargoResultExt};
+use util::{existing_vcs_repo, internal, FossilRepo, GitRepo, HgRepo, PijulRepo};
+use util::{paths, Config};
 
 use toml;
 
@@ -51,7 +51,8 @@ impl fmt::Display for NewProjectKind {
         match *self {
             NewProjectKind::Bin => "binary (application)",
             NewProjectKind::Lib => "library",
-        }.fmt(f)
+        }
+        .fmt(f)
     }
 }
 
@@ -430,7 +431,8 @@ fn mk(config: &Config, opts: &MkOptions) -> CargoResult<()> {
         "/target\n",
         "**/*.rs.bk\n",
         if !opts.bin { "Cargo.lock\n" } else { "" },
-    ].concat();
+    ]
+    .concat();
     // Mercurial glob ignores can't be rooted, so just sticking a 'syntax: glob' at the top of the
     // file will exclude too much. Instead, use regexp-based ignores. See 'hg help ignore' for
     // more.
@@ -438,7 +440,8 @@ fn mk(config: &Config, opts: &MkOptions) -> CargoResult<()> {
         "^target/\n",
         "glob:*.rs.bk\n",
         if !opts.bin { "glob:Cargo.lock\n" } else { "" },
-    ].concat();
+    ]
+    .concat();
 
     let vcs = opts.version_control.unwrap_or_else(|| {
         let in_existing_vcs = existing_vcs_repo(path.parent().unwrap_or(path), config.cwd());
@@ -553,15 +556,15 @@ edition = {}
                 None => toml::Value::String("2018".to_string()),
             },
             match opts.registry {
-                Some(registry) => {
-                    format!("publish = {}\n",
-                        toml::Value::Array(vec!(toml::Value::String(registry.to_string())))
-                    )
-                }
+                Some(registry) => format!(
+                    "publish = {}\n",
+                    toml::Value::Array(vec!(toml::Value::String(registry.to_string())))
+                ),
                 None => "".to_string(),
-            }, 
+            },
             cargotoml_path_specifier
-        ).as_bytes(),
+        )
+        .as_bytes(),
     )?;
 
     // Create all specified source files
@@ -665,7 +668,7 @@ fn discover_author() -> CargoResult<(String, Option<String>)> {
 
         // In some cases emails will already have <> remove them since they
         // are already added when needed.
-        if s.starts_with("<") && s.ends_with(">") {
+        if s.starts_with('<') && s.ends_with('>') {
             s = &s[1..s.len() - 1];
         }
 

--- a/src/cargo/ops/cargo_read_manifest.rs
+++ b/src/cargo/ops/cargo_read_manifest.rs
@@ -4,14 +4,14 @@ use std::io;
 use std::path::{Path, PathBuf};
 
 use core::{EitherManifest, Package, PackageId, SourceId};
-use util::{self, Config};
 use util::errors::{CargoError, CargoResult};
 use util::important_paths::find_project_manifest_exact;
 use util::toml::read_manifest;
+use util::{self, Config};
 
 pub fn read_package(
     path: &Path,
-    source_id: &SourceId,
+    source_id: SourceId,
     config: &Config,
 ) -> CargoResult<(Package, Vec<PathBuf>)> {
     trace!(
@@ -34,7 +34,7 @@ pub fn read_package(
 
 pub fn read_packages(
     path: &Path,
-    source_id: &SourceId,
+    source_id: SourceId,
     config: &Config,
 ) -> CargoResult<Vec<Package>> {
     let mut all_packages = HashMap::new();
@@ -129,7 +129,7 @@ fn has_manifest(path: &Path) -> bool {
 fn read_nested_packages(
     path: &Path,
     all_packages: &mut HashMap<PackageId, Package>,
-    source_id: &SourceId,
+    source_id: SourceId,
     config: &Config,
     visited: &mut HashSet<PathBuf>,
     errors: &mut Vec<CargoError>,

--- a/src/cargo/ops/lockfile.rs
+++ b/src/cargo/ops/lockfile.rs
@@ -20,12 +20,12 @@ pub fn load_pkg_lockfile(ws: &Workspace) -> CargoResult<Option<Resolve>> {
     f.read_to_string(&mut s)
         .chain_err(|| format!("failed to read file: {}", f.path().display()))?;
 
-    let resolve =
-        (|| -> CargoResult<Option<Resolve>> {
-            let resolve: toml::Value = cargo_toml::parse(&s, f.path(), ws.config())?;
-            let v: resolver::EncodableResolve = resolve.try_into()?;
-            Ok(Some(v.into_resolve(ws)?))
-        })().chain_err(|| format!("failed to parse lock file at: {}", f.path().display()))?;
+    let resolve = (|| -> CargoResult<Option<Resolve>> {
+        let resolve: toml::Value = cargo_toml::parse(&s, f.path(), ws.config())?;
+        let v: resolver::EncodableResolve = resolve.try_into()?;
+        Ok(Some(v.into_resolve(ws)?))
+    })()
+    .chain_err(|| format!("failed to parse lock file at: {}", f.path().display()))?;
     Ok(resolve)
 }
 
@@ -47,7 +47,7 @@ pub fn write_pkg_lockfile(ws: &Workspace, resolve: &Resolve) -> CargoResult<()> 
     // This is in preparation for marking it as generated
     // https://github.com/rust-lang/cargo/issues/6180
     if let Ok(orig) = &orig {
-        for line in orig.lines().take_while(|line| line.starts_with("#")) {
+        for line in orig.lines().take_while(|line| line.starts_with('#')) {
             out.push_str(line);
             out.push_str("\n");
         }

--- a/src/cargo/sources/config.rs
+++ b/src/cargo/sources/config.rs
@@ -11,9 +11,9 @@ use url::Url;
 
 use core::{GitReference, Source, SourceId};
 use sources::{ReplacedSource, CRATES_IO_REGISTRY};
-use util::{Config, ToUrl};
 use util::config::ConfigValue;
 use util::errors::{CargoResult, CargoResultExt};
+use util::{Config, ToUrl};
 
 #[derive(Clone)]
 pub struct SourceConfigMap<'cfg> {
@@ -72,9 +72,9 @@ impl<'cfg> SourceConfigMap<'cfg> {
         self.config
     }
 
-    pub fn load(&self, id: &SourceId) -> CargoResult<Box<Source + 'cfg>> {
+    pub fn load(&self, id: SourceId) -> CargoResult<Box<Source + 'cfg>> {
         debug!("loading: {}", id);
-        let mut name = match self.id2name.get(id) {
+        let mut name = match self.id2name.get(&id) {
             Some(name) => name,
             None => return Ok(id.load(self.config)?),
         };
@@ -98,7 +98,7 @@ impl<'cfg> SourceConfigMap<'cfg> {
                     name = s;
                     path = p;
                 }
-                None if *id == cfg.id => return Ok(id.load(self.config)?),
+                None if id == cfg.id => return Ok(id.load(self.config)?),
                 None => {
                     new_id = cfg.id.with_precise(id.precise().map(|s| s.to_string()));
                     break;
@@ -143,11 +143,11 @@ restore the source replacement configuration to continue the build
             );
         }
 
-        Ok(Box::new(ReplacedSource::new(id, &new_id, new_src)))
+        Ok(Box::new(ReplacedSource::new(id, new_id, new_src)))
     }
 
     fn add(&mut self, name: &str, cfg: SourceConfig) {
-        self.id2name.insert(cfg.id.clone(), name.to_string());
+        self.id2name.insert(cfg.id, name.to_string());
         self.cfgs.insert(name.to_string(), cfg);
     }
 

--- a/src/cargo/sources/directory.rs
+++ b/src/cargo/sources/directory.rs
@@ -8,12 +8,12 @@ use hex;
 
 use serde_json;
 
-use core::{Dependency, Package, PackageId, Source, SourceId, Summary};
 use core::source::MaybePackage;
+use core::{Dependency, Package, PackageId, Source, SourceId, Summary};
 use sources::PathSource;
-use util::{Config, Sha256};
 use util::errors::{CargoResult, CargoResultExt};
 use util::paths;
+use util::{Config, Sha256};
 
 pub struct DirectorySource<'cfg> {
     source_id: SourceId,
@@ -29,9 +29,9 @@ struct Checksum {
 }
 
 impl<'cfg> DirectorySource<'cfg> {
-    pub fn new(path: &Path, id: &SourceId, config: &'cfg Config) -> DirectorySource<'cfg> {
+    pub fn new(path: &Path, id: SourceId, config: &'cfg Config) -> DirectorySource<'cfg> {
         DirectorySource {
-            source_id: id.clone(),
+            source_id: id,
             root: path.to_path_buf(),
             config,
             packages: HashMap::new(),
@@ -71,8 +71,8 @@ impl<'cfg> Source for DirectorySource<'cfg> {
         true
     }
 
-    fn source_id(&self) -> &SourceId {
-        &self.source_id
+    fn source_id(&self) -> SourceId {
+        self.source_id
     }
 
     fn update(&mut self) -> CargoResult<()> {
@@ -116,7 +116,7 @@ impl<'cfg> Source for DirectorySource<'cfg> {
                 continue;
             }
 
-            let mut src = PathSource::new(&path, &self.source_id, self.config);
+            let mut src = PathSource::new(&path, self.source_id, self.config);
             src.update()?;
             let pkg = src.root_package()?;
 
@@ -188,7 +188,7 @@ impl<'cfg> Source for DirectorySource<'cfg> {
                     }
                 }
             })()
-                .chain_err(|| format!("failed to calculate checksum of: {}", file.display()))?;
+            .chain_err(|| format!("failed to calculate checksum of: {}", file.display()))?;
 
             let actual = hex::encode(h.finish());
             if &*actual != cksum {

--- a/src/cargo/sources/registry/local.rs
+++ b/src/cargo/sources/registry/local.rs
@@ -1,13 +1,13 @@
-use std::io::SeekFrom;
 use std::io::prelude::*;
+use std::io::SeekFrom;
 use std::path::Path;
 
 use core::PackageId;
 use hex;
-use sources::registry::{RegistryConfig, RegistryData, MaybeLock};
-use util::paths;
-use util::{Config, Filesystem, Sha256, FileLock};
+use sources::registry::{MaybeLock, RegistryConfig, RegistryData};
 use util::errors::{CargoResult, CargoResultExt};
+use util::paths;
+use util::{Config, FileLock, Filesystem, Sha256};
 
 pub struct LocalRegistry<'cfg> {
     index_path: Filesystem,
@@ -104,9 +104,12 @@ impl<'cfg> RegistryData for LocalRegistry<'cfg> {
         Ok(MaybeLock::Ready(crate_file))
     }
 
-    fn finish_download(&mut self, _pkg: &PackageId, _checksum: &str, _data: &[u8])
-        -> CargoResult<FileLock>
-    {
+    fn finish_download(
+        &mut self,
+        _pkg: &PackageId,
+        _checksum: &str,
+        _data: &[u8],
+    ) -> CargoResult<FileLock> {
         panic!("this source doesn't download")
     }
 }

--- a/src/cargo/sources/registry/mod.rs
+++ b/src/cargo/sources/registry/mod.rs
@@ -475,9 +475,9 @@ impl<'cfg> RegistrySource<'cfg> {
         Ok(())
     }
 
-    fn get_pkg(&mut self, package: &PackageId, path: FileLock) -> CargoResult<Package> {
+    fn get_pkg(&mut self, package: &PackageId, path: &FileLock) -> CargoResult<Package> {
         let path = self
-            .unpack_package(package, &path)
+            .unpack_package(package, path)
             .chain_err(|| internal(format!("failed to unpack package `{}`", package)))?;
         let mut src = PathSource::new(&path, self.source_id, self.config);
         src.update()?;
@@ -569,7 +569,7 @@ impl<'cfg> Source for RegistrySource<'cfg> {
     fn download(&mut self, package: &PackageId) -> CargoResult<MaybePackage> {
         let hash = self.index.hash(package, &mut *self.ops)?;
         match self.ops.download(package, &hash)? {
-            MaybeLock::Ready(file) => self.get_pkg(package, file).map(MaybePackage::Ready),
+            MaybeLock::Ready(file) => self.get_pkg(package, &file).map(MaybePackage::Ready),
             MaybeLock::Download { url, descriptor } => {
                 Ok(MaybePackage::Download { url, descriptor })
             }
@@ -579,7 +579,7 @@ impl<'cfg> Source for RegistrySource<'cfg> {
     fn finish_download(&mut self, package: &PackageId, data: Vec<u8>) -> CargoResult<Package> {
         let hash = self.index.hash(package, &mut *self.ops)?;
         let file = self.ops.finish_download(package, &hash, &data)?;
-        self.get_pkg(package, file)
+        self.get_pkg(package, &file)
     }
 
     fn fingerprint(&self, pkg: &Package) -> CargoResult<String> {

--- a/src/cargo/sources/registry/mod.rs
+++ b/src/cargo/sources/registry/mod.rs
@@ -228,15 +228,17 @@ pub struct RegistryPackage<'a> {
 #[test]
 fn escaped_cher_in_json() {
     let _: RegistryPackage = serde_json::from_str(
-        r#"{"name":"a","vers":"0.0.1","deps":[],"cksum":"bae3","features":{}}"#
-    ).unwrap();
+        r#"{"name":"a","vers":"0.0.1","deps":[],"cksum":"bae3","features":{}}"#,
+    )
+    .unwrap();
     let _: RegistryPackage = serde_json::from_str(
         r#"{"name":"a","vers":"0.0.1","deps":[],"cksum":"bae3","features":{"test":["k","q"]},"links":"a-sys"}"#
     ).unwrap();
 
     // Now we add escaped cher all the places they can go
     // these are not valid, but it should error later than json parsing
-    let _: RegistryPackage = serde_json::from_str(r#"{
+    let _: RegistryPackage = serde_json::from_str(
+        r#"{
         "name":"This name has a escaped cher in it \n\t\" ",
         "vers":"0.0.1",
         "deps":[{
@@ -251,8 +253,9 @@ fn escaped_cher_in_json() {
         }],
         "cksum":"bae3",
         "features":{"test \n\t\" ":["k \n\t\" ","q \n\t\" "]},
-        "links":" \n\t\" "}"#
-    ).unwrap();
+        "links":" \n\t\" "}"#,
+    )
+    .unwrap();
 }
 
 #[derive(Deserialize)]
@@ -282,7 +285,7 @@ struct RegistryDependency<'a> {
 
 impl<'a> RegistryDependency<'a> {
     /// Converts an encoded dependency in the registry to a cargo dependency
-    pub fn into_dep(self, default: &SourceId) -> CargoResult<Dependency> {
+    pub fn into_dep(self, default: SourceId) -> CargoResult<Dependency> {
         let RegistryDependency {
             name,
             req,
@@ -298,15 +301,11 @@ impl<'a> RegistryDependency<'a> {
         let id = if let Some(registry) = registry {
             SourceId::for_registry(&registry.to_url()?)?
         } else {
-            default.clone()
+            default
         };
 
-
-        let mut dep = Dependency::parse_no_deprecated(
-            package.as_ref().unwrap_or(&name),
-            Some(&req),
-            &id,
-        )?;
+        let mut dep =
+            Dependency::parse_no_deprecated(package.as_ref().unwrap_or(&name), Some(&req), id)?;
         if package.is_some() {
             dep.set_explicit_name_in_toml(&name);
         }
@@ -350,8 +349,12 @@ pub trait RegistryData {
     fn config(&mut self) -> CargoResult<Option<RegistryConfig>>;
     fn update_index(&mut self) -> CargoResult<()>;
     fn download(&mut self, pkg: &PackageId, checksum: &str) -> CargoResult<MaybeLock>;
-    fn finish_download(&mut self, pkg: &PackageId, checksum: &str, data: &[u8])
-        -> CargoResult<FileLock>;
+    fn finish_download(
+        &mut self,
+        pkg: &PackageId,
+        checksum: &str,
+        data: &[u8],
+    ) -> CargoResult<FileLock>;
 
     fn is_crate_downloaded(&self, _pkg: &PackageId) -> bool {
         true
@@ -360,34 +363,34 @@ pub trait RegistryData {
 
 pub enum MaybeLock {
     Ready(FileLock),
-    Download { url: String, descriptor: String }
+    Download { url: String, descriptor: String },
 }
 
 mod index;
 mod local;
 mod remote;
 
-fn short_name(id: &SourceId) -> String {
-    let hash = hex::short_hash(id);
+fn short_name(id: SourceId) -> String {
+    let hash = hex::short_hash(&id);
     let ident = id.url().host_str().unwrap_or("").to_string();
     format!("{}-{}", ident, hash)
 }
 
 impl<'cfg> RegistrySource<'cfg> {
-    pub fn remote(source_id: &SourceId, config: &'cfg Config) -> RegistrySource<'cfg> {
+    pub fn remote(source_id: SourceId, config: &'cfg Config) -> RegistrySource<'cfg> {
         let name = short_name(source_id);
         let ops = remote::RemoteRegistry::new(source_id, config, &name);
         RegistrySource::new(source_id, config, &name, Box::new(ops), true)
     }
 
-    pub fn local(source_id: &SourceId, path: &Path, config: &'cfg Config) -> RegistrySource<'cfg> {
+    pub fn local(source_id: SourceId, path: &Path, config: &'cfg Config) -> RegistrySource<'cfg> {
         let name = short_name(source_id);
         let ops = local::LocalRegistry::new(path, config, &name);
         RegistrySource::new(source_id, config, &name, Box::new(ops), false)
     }
 
     fn new(
-        source_id: &SourceId,
+        source_id: SourceId,
         config: &'cfg Config,
         name: &str,
         ops: Box<RegistryData + 'cfg>,
@@ -396,7 +399,7 @@ impl<'cfg> RegistrySource<'cfg> {
         RegistrySource {
             src_path: config.registry_source_path().join(name),
             config,
-            source_id: source_id.clone(),
+            source_id,
             updated: false,
             index: index::RegistryIndex::new(source_id, ops.index_path(), config, index_locked),
             index_locked,
@@ -468,7 +471,7 @@ impl<'cfg> RegistrySource<'cfg> {
         self.ops.update_index()?;
         let path = self.ops.index_path();
         self.index =
-            index::RegistryIndex::new(&self.source_id, path, self.config, self.index_locked);
+            index::RegistryIndex::new(self.source_id, path, self.config, self.index_locked);
         Ok(())
     }
 
@@ -476,7 +479,7 @@ impl<'cfg> RegistrySource<'cfg> {
         let path = self
             .unpack_package(package, &path)
             .chain_err(|| internal(format!("failed to unpack package `{}`", package)))?;
-        let mut src = PathSource::new(&path, &self.source_id, self.config);
+        let mut src = PathSource::new(&path, self.source_id, self.config);
         src.update()?;
         let pkg = match src.download(package)? {
             MaybePackage::Ready(pkg) => pkg,
@@ -543,8 +546,8 @@ impl<'cfg> Source for RegistrySource<'cfg> {
         false
     }
 
-    fn source_id(&self) -> &SourceId {
-        &self.source_id
+    fn source_id(&self) -> SourceId {
+        self.source_id
     }
 
     fn update(&mut self) -> CargoResult<()> {
@@ -566,18 +569,14 @@ impl<'cfg> Source for RegistrySource<'cfg> {
     fn download(&mut self, package: &PackageId) -> CargoResult<MaybePackage> {
         let hash = self.index.hash(package, &mut *self.ops)?;
         match self.ops.download(package, &hash)? {
-            MaybeLock::Ready(file) => {
-                self.get_pkg(package, file).map(MaybePackage::Ready)
-            }
+            MaybeLock::Ready(file) => self.get_pkg(package, file).map(MaybePackage::Ready),
             MaybeLock::Download { url, descriptor } => {
                 Ok(MaybePackage::Download { url, descriptor })
             }
         }
     }
 
-    fn finish_download(&mut self, package: &PackageId, data: Vec<u8>)
-        -> CargoResult<Package>
-    {
+    fn finish_download(&mut self, package: &PackageId, data: Vec<u8>) -> CargoResult<Package> {
         let hash = self.index.hash(package, &mut *self.ops)?;
         let file = self.ops.finish_download(package, &hash, &data)?;
         self.get_pkg(package, file)

--- a/src/cargo/sources/registry/remote.rs
+++ b/src/cargo/sources/registry/remote.rs
@@ -1,23 +1,25 @@
 use std::cell::{Cell, Ref, RefCell};
 use std::fmt::Write as FmtWrite;
-use std::io::SeekFrom;
 use std::io::prelude::*;
+use std::io::SeekFrom;
 use std::mem;
 use std::path::Path;
 use std::str;
 
 use git2;
 use hex;
-use serde_json;
 use lazycell::LazyCell;
+use serde_json;
 
 use core::{PackageId, SourceId};
 use sources::git;
-use sources::registry::{RegistryConfig, RegistryData, CRATE_TEMPLATE, INDEX_LOCK, VERSION_TEMPLATE};
 use sources::registry::MaybeLock;
-use util::{FileLock, Filesystem};
-use util::{Config, Sha256};
+use sources::registry::{
+    RegistryConfig, RegistryData, CRATE_TEMPLATE, INDEX_LOCK, VERSION_TEMPLATE,
+};
 use util::errors::{CargoResult, CargoResultExt};
+use util::{Config, Sha256};
+use util::{FileLock, Filesystem};
 
 pub struct RemoteRegistry<'cfg> {
     index_path: Filesystem,
@@ -30,11 +32,11 @@ pub struct RemoteRegistry<'cfg> {
 }
 
 impl<'cfg> RemoteRegistry<'cfg> {
-    pub fn new(source_id: &SourceId, config: &'cfg Config, name: &str) -> RemoteRegistry<'cfg> {
+    pub fn new(source_id: SourceId, config: &'cfg Config, name: &str) -> RemoteRegistry<'cfg> {
         RemoteRegistry {
             index_path: config.registry_index_path().join(name),
             cache_path: config.registry_cache_path().join(name),
-            source_id: source_id.clone(),
+            source_id,
             config,
             tree: RefCell::new(None),
             repo: LazyCell::new(),
@@ -54,9 +56,11 @@ impl<'cfg> RemoteRegistry<'cfg> {
 
             // Ok, now we need to lock and try the whole thing over again.
             trace!("acquiring registry index lock");
-            let lock =
-                self.index_path
-                    .open_rw(Path::new(INDEX_LOCK), self.config, "the registry index")?;
+            let lock = self.index_path.open_rw(
+                Path::new(INDEX_LOCK),
+                self.config,
+                "the registry index",
+            )?;
             match git2::Repository::open(&path) {
                 Ok(repo) => Ok(repo),
                 Err(_) => {
@@ -79,9 +83,8 @@ impl<'cfg> RemoteRegistry<'cfg> {
                     // things that we don't want.
                     let mut opts = git2::RepositoryInitOptions::new();
                     opts.external_template(false);
-                    Ok(git2::Repository::init_opts(&path, &opts).chain_err(|| {
-                        "failed to initialized index git repository"
-                    })?)
+                    Ok(git2::Repository::init_opts(&path, &opts)
+                        .chain_err(|| "failed to initialized index git repository")?)
                 }
             }
         })
@@ -231,15 +234,22 @@ impl<'cfg> RegistryData for RemoteRegistry<'cfg> {
         if !url.contains(CRATE_TEMPLATE) && !url.contains(VERSION_TEMPLATE) {
             write!(url, "/{}/{}/download", CRATE_TEMPLATE, VERSION_TEMPLATE).unwrap();
         }
-        let url = url.replace(CRATE_TEMPLATE, &*pkg.name())
+        let url = url
+            .replace(CRATE_TEMPLATE, &*pkg.name())
             .replace(VERSION_TEMPLATE, &pkg.version().to_string());
 
-        Ok(MaybeLock::Download { url, descriptor: pkg.to_string() })
+        Ok(MaybeLock::Download {
+            url,
+            descriptor: pkg.to_string(),
+        })
     }
 
-    fn finish_download(&mut self, pkg: &PackageId, checksum: &str, data: &[u8])
-        -> CargoResult<FileLock>
-    {
+    fn finish_download(
+        &mut self,
+        pkg: &PackageId,
+        checksum: &str,
+        data: &[u8],
+    ) -> CargoResult<FileLock> {
         // Verify what we just downloaded
         let mut state = Sha256::new();
         state.update(data);

--- a/src/cargo/sources/replaced.rs
+++ b/src/cargo/sources/replaced.rs
@@ -1,5 +1,5 @@
-use core::{Dependency, Package, PackageId, Source, SourceId, Summary};
 use core::source::MaybePackage;
+use core::{Dependency, Package, PackageId, Source, SourceId, Summary};
 use util::errors::{CargoResult, CargoResultExt};
 
 pub struct ReplacedSource<'cfg> {
@@ -10,43 +10,25 @@ pub struct ReplacedSource<'cfg> {
 
 impl<'cfg> ReplacedSource<'cfg> {
     pub fn new(
-        to_replace: &SourceId,
-        replace_with: &SourceId,
+        to_replace: SourceId,
+        replace_with: SourceId,
         src: Box<Source + 'cfg>,
     ) -> ReplacedSource<'cfg> {
         ReplacedSource {
-            to_replace: to_replace.clone(),
-            replace_with: replace_with.clone(),
+            to_replace,
+            replace_with,
             inner: src,
         }
     }
 }
 
 impl<'cfg> Source for ReplacedSource<'cfg> {
-    fn query(&mut self, dep: &Dependency, f: &mut FnMut(Summary)) -> CargoResult<()> {
-        let (replace_with, to_replace) = (&self.replace_with, &self.to_replace);
-        let dep = dep.clone().map_source(to_replace, replace_with);
-
-        self.inner
-            .query(
-                &dep,
-                &mut |summary| f(summary.map_source(replace_with, to_replace)),
-            )
-            .chain_err(|| format!("failed to query replaced source {}", self.to_replace))?;
-        Ok(())
+    fn source_id(&self) -> SourceId {
+        self.to_replace
     }
 
-    fn fuzzy_query(&mut self, dep: &Dependency, f: &mut FnMut(Summary)) -> CargoResult<()> {
-        let (replace_with, to_replace) = (&self.replace_with, &self.to_replace);
-        let dep = dep.clone().map_source(to_replace, replace_with);
-
-        self.inner
-            .fuzzy_query(
-                &dep,
-                &mut |summary| f(summary.map_source(replace_with, to_replace)),
-            )
-            .chain_err(|| format!("failed to query replaced source {}", self.to_replace))?;
-        Ok(())
+    fn replaced_source_id(&self) -> SourceId {
+        self.replace_with
     }
 
     fn supports_checksums(&self) -> bool {
@@ -57,12 +39,28 @@ impl<'cfg> Source for ReplacedSource<'cfg> {
         self.inner.requires_precise()
     }
 
-    fn source_id(&self) -> &SourceId {
-        &self.to_replace
+    fn query(&mut self, dep: &Dependency, f: &mut FnMut(Summary)) -> CargoResult<()> {
+        let (replace_with, to_replace) = (self.replace_with, self.to_replace);
+        let dep = dep.clone().map_source(to_replace, replace_with);
+
+        self.inner
+            .query(&dep, &mut |summary| {
+                f(summary.map_source(replace_with, to_replace))
+            })
+            .chain_err(|| format!("failed to query replaced source {}", self.to_replace))?;
+        Ok(())
     }
 
-    fn replaced_source_id(&self) -> &SourceId {
-        &self.replace_with
+    fn fuzzy_query(&mut self, dep: &Dependency, f: &mut FnMut(Summary)) -> CargoResult<()> {
+        let (replace_with, to_replace) = (self.replace_with, self.to_replace);
+        let dep = dep.clone().map_source(to_replace, replace_with);
+
+        self.inner
+            .fuzzy_query(&dep, &mut |summary| {
+                f(summary.map_source(replace_with, to_replace))
+            })
+            .chain_err(|| format!("failed to query replaced source {}", self.to_replace))?;
+        Ok(())
     }
 
     fn update(&mut self) -> CargoResult<()> {
@@ -73,26 +71,26 @@ impl<'cfg> Source for ReplacedSource<'cfg> {
     }
 
     fn download(&mut self, id: &PackageId) -> CargoResult<MaybePackage> {
-        let id = id.with_source_id(&self.replace_with);
-        let pkg = self.inner
+        let id = id.with_source_id(self.replace_with);
+        let pkg = self
+            .inner
             .download(&id)
             .chain_err(|| format!("failed to download replaced source {}", self.to_replace))?;
         Ok(match pkg {
             MaybePackage::Ready(pkg) => {
-                MaybePackage::Ready(pkg.map_source(&self.replace_with, &self.to_replace))
+                MaybePackage::Ready(pkg.map_source(self.replace_with, self.to_replace))
             }
             other @ MaybePackage::Download { .. } => other,
         })
     }
 
-    fn finish_download(&mut self, id: &PackageId, data: Vec<u8>)
-        -> CargoResult<Package>
-    {
-        let id = id.with_source_id(&self.replace_with);
-        let pkg = self.inner
+    fn finish_download(&mut self, id: &PackageId, data: Vec<u8>) -> CargoResult<Package> {
+        let id = id.with_source_id(self.replace_with);
+        let pkg = self
+            .inner
             .finish_download(&id, data)
             .chain_err(|| format!("failed to download replaced source {}", self.to_replace))?;
-        Ok(pkg.map_source(&self.replace_with, &self.to_replace))
+        Ok(pkg.map_source(self.replace_with, self.to_replace))
     }
 
     fn fingerprint(&self, id: &Package) -> CargoResult<String> {
@@ -100,12 +98,16 @@ impl<'cfg> Source for ReplacedSource<'cfg> {
     }
 
     fn verify(&self, id: &PackageId) -> CargoResult<()> {
-        let id = id.with_source_id(&self.replace_with);
+        let id = id.with_source_id(self.replace_with);
         self.inner.verify(&id)
     }
 
     fn describe(&self) -> String {
-        format!("{} (which is replacing {})", self.inner.describe(), self.to_replace)
+        format!(
+            "{} (which is replacing {})",
+            self.inner.describe(),
+            self.to_replace
+        )
     }
 
     fn is_replaced(&self) -> bool {

--- a/src/cargo/util/config.rs
+++ b/src/cargo/util/config.rs
@@ -176,12 +176,10 @@ impl Config {
 
     /// The default cargo registry (`alternative-registry`)
     pub fn default_registry(&self) -> CargoResult<Option<String>> {
-        Ok(
-            match self.get_string("registry.default")? {
-                Some(registry) => Some(registry.val),
-                None => None,
-            }
-        )
+        Ok(match self.get_string("registry.default")? {
+            Some(registry) => Some(registry.val),
+            None => None,
+        })
     }
 
     /// Get a reference to the shell, for e.g. writing error messages
@@ -245,7 +243,7 @@ impl Config {
                     let argv0 = env::args_os()
                         .map(PathBuf::from)
                         .next()
-                        .ok_or_else(||format_err!("no argv[0]"))?;
+                        .ok_or_else(|| format_err!("no argv[0]"))?;
                     paths::resolve_executable(&argv0)
                 }
 
@@ -458,10 +456,7 @@ impl Config {
         }
     }
 
-    pub fn get_path_and_args(
-        &self,
-        key: &str,
-    ) -> CargoResult<OptValue<(PathBuf, Vec<String>)>> {
+    pub fn get_path_and_args(&self, key: &str) -> CargoResult<OptValue<(PathBuf, Vec<String>)>> {
         if let Some(mut val) = self.get_list_or_split_string(key)? {
             if !val.val.is_empty() {
                 return Ok(Some(Value {
@@ -631,9 +626,7 @@ impl Config {
         self.load_values_from(&self.cwd)
     }
 
-    fn load_values_from(&self, path: &Path)
-        -> CargoResult<HashMap<String, ConfigValue>>
-    {
+    fn load_values_from(&self, path: &Path) -> CargoResult<HashMap<String, ConfigValue>> {
         let mut cfg = CV::Table(HashMap::new(), PathBuf::from("."));
         let home = self.home_path.clone().into_path_unlocked();
 
@@ -654,7 +647,8 @@ impl Config {
             cfg.merge(value)
                 .chain_err(|| format!("failed to merge configuration at `{}`", path.display()))?;
             Ok(())
-        }).chain_err(|| "could not load Cargo configuration")?;
+        })
+        .chain_err(|| "could not load Cargo configuration")?;
 
         self.load_credentials(&mut cfg)?;
         match cfg {
@@ -790,7 +784,7 @@ impl Config {
     where
         F: FnMut() -> CargoResult<SourceId>,
     {
-        Ok(self.crates_io_source_id.try_borrow_with(f)?.clone())
+        Ok(*(self.crates_io_source_id.try_borrow_with(f)?))
     }
 
     pub fn creation_time(&self) -> Instant {

--- a/src/cargo/util/lev_distance.rs
+++ b/src/cargo/util/lev_distance.rs
@@ -8,7 +8,7 @@ pub fn lev_distance(me: &str, t: &str) -> usize {
         return me.chars().count();
     }
 
-    let mut dcol = (0..t.len() + 1).collect::<Vec<_>>();
+    let mut dcol = (0..=t.len()).collect::<Vec<_>>();
     let mut t_last = 0;
 
     for (i, sc) in me.chars().enumerate() {

--- a/src/cargo/util/read2.rs
+++ b/src/cargo/util/read2.rs
@@ -2,12 +2,12 @@ pub use self::imp::read2;
 
 #[cfg(unix)]
 mod imp {
-    use std::io::prelude::*;
+    use libc;
     use std::io;
+    use std::io::prelude::*;
     use std::mem;
     use std::os::unix::prelude::*;
     use std::process::{ChildStderr, ChildStdout};
-    use libc;
 
     pub fn read2(
         mut out_pipe: ChildStdout,
@@ -177,9 +177,6 @@ mod imp {
         if v.capacity() == v.len() {
             v.reserve(1);
         }
-        slice::from_raw_parts_mut(
-            v.as_mut_ptr().offset(v.len() as isize),
-            v.capacity() - v.len(),
-        )
+        slice::from_raw_parts_mut(v.as_mut_ptr().add(v.len()), v.capacity() - v.len())
     }
 }

--- a/tests/testsuite/search.rs
+++ b/tests/testsuite/search.rs
@@ -67,7 +67,8 @@ fn setup() {
         .file(
             "config.json",
             &format!(r#"{{"dl":"{0}","api":"{0}"}}"#, api()),
-        ).build();
+        )
+        .build();
 
     let base = api_path().join("api/v1/crates");
     write_crates(&base);
@@ -89,8 +90,10 @@ replace-with = 'dummy-registry'
 registry = '{reg}'
 "#,
                 reg = registry_url(),
-            ).as_bytes(),
-        ).unwrap();
+            )
+            .as_bytes(),
+        )
+        .unwrap();
 }
 
 #[test]
@@ -104,7 +107,7 @@ fn not_update() {
 
     let sid = SourceId::for_registry(&registry_url()).unwrap();
     let cfg = Config::new(Shell::new(), paths::root(), paths::home().join(".cargo"));
-    let mut regsrc = RegistrySource::remote(&sid, &cfg);
+    let mut regsrc = RegistrySource::remote(sid, &cfg);
     regsrc.update().unwrap();
 
     cargo_process("search postgres")
@@ -142,9 +145,10 @@ fn simple() {
 fn simple_with_host() {
     setup();
 
-    cargo_process("search postgres --host").arg(registry_url().to_string())
-            .with_stderr(
-                "\
+    cargo_process("search postgres --host")
+        .arg(registry_url().to_string())
+        .with_stderr(
+            "\
 [WARNING] The flag '--host' is no longer valid.
 
 Previous versions of Cargo accepted this flag, but it is being
@@ -156,10 +160,8 @@ to update to a fixed version or contact the upstream maintainer
 about this warning.
 [UPDATING] `[CWD]/registry` index
 ",
-            )
-            .with_stdout_contains(
-                "hoare = \"0.1.1\"    # Design by contract style assertions for Rust",
-            )
+        )
+        .with_stdout_contains("hoare = \"0.1.1\"    # Design by contract style assertions for Rust")
         .run();
 }
 
@@ -169,9 +171,12 @@ about this warning.
 fn simple_with_index_and_host() {
     setup();
 
-    cargo_process("search postgres --index").arg(registry_url().to_string()).arg("--host").arg(registry_url().to_string())
-            .with_stderr(
-                "\
+    cargo_process("search postgres --index")
+        .arg(registry_url().to_string())
+        .arg("--host")
+        .arg(registry_url().to_string())
+        .with_stderr(
+            "\
 [WARNING] The flag '--host' is no longer valid.
 
 Previous versions of Cargo accepted this flag, but it is being
@@ -183,10 +188,8 @@ to update to a fixed version or contact the upstream maintainer
 about this warning.
 [UPDATING] `[CWD]/registry` index
 ",
-            )
-            .with_stdout_contains(
-                "hoare = \"0.1.1\"    # Design by contract style assertions for Rust",
-            )
+        )
+        .with_stdout_contains("hoare = \"0.1.1\"    # Design by contract style assertions for Rust")
         .run();
 }
 


### PR DESCRIPTION
This is a follow up to #6342. I used clippy to find all the places we called `.clone()`  on a `SourceId` or where we passed `&SourceId`. This also involved fixing a large number of other things clippy was complaining about, and running `fmt` on a large number of files.