### PR TITLE
remove clones made redundant by Intern PackageId

### DIFF
--- a/src/cargo/core/compiler/build_config.rs
+++ b/src/cargo/core/compiler/build_config.rs
@@ -1,5 +1,5 @@
-use std::path::Path;
 use std::cell::RefCell;
+use std::path::Path;
 
 use serde::ser;
 
@@ -51,9 +51,11 @@ impl BuildConfig {
                 let path = Path::new(target)
                     .canonicalize()
                     .chain_err(|| format_err!("Target path {:?} is not a valid file", target))?;
-                Some(path.into_os_string()
-                    .into_string()
-                    .map_err(|_| format_err!("Target path is not valid unicode"))?)
+                Some(
+                    path.into_os_string()
+                        .into_string()
+                        .map_err(|_| format_err!("Target path is not valid unicode"))?,
+                )
             }
             other => other.clone(),
         };

--- a/src/cargo/core/compiler/build_context/mod.rs
+++ b/src/cargo/core/compiler/build_context/mod.rs
@@ -180,7 +180,7 @@ impl<'a, 'cfg> BuildContext<'a, 'cfg> {
         )
     }
 
-    pub fn show_warnings(&self, pkg: &PackageId) -> bool {
+    pub fn show_warnings(&self, pkg: PackageId) -> bool {
         pkg.source_id().is_path() || self.config.extra_verbose()
     }
 

--- a/src/cargo/core/compiler/build_context/target_info.rs
+++ b/src/cargo/core/compiler/build_context/target_info.rs
@@ -4,9 +4,9 @@ use std::path::PathBuf;
 use std::str::{self, FromStr};
 
 use super::env_args;
-use util::{CargoResult, CargoResultExt, Cfg, Config, ProcessBuilder, Rustc};
-use core::TargetKind;
 use super::Kind;
+use core::TargetKind;
+use util::{CargoResult, CargoResultExt, Cfg, Config, ProcessBuilder, Rustc};
 
 #[derive(Clone)]
 pub struct TargetInfo {
@@ -173,17 +173,16 @@ impl TargetInfo {
             Some((ref prefix, ref suffix)) => (prefix, suffix),
             None => return Ok(None),
         };
-        let mut ret = vec![
-            FileType {
-                suffix: suffix.clone(),
-                prefix: prefix.clone(),
-                flavor,
-                should_replace_hyphens: false,
-            },
-        ];
+        let mut ret = vec![FileType {
+            suffix: suffix.clone(),
+            prefix: prefix.clone(),
+            flavor,
+            should_replace_hyphens: false,
+        }];
 
         // rust-lang/cargo#4500
-        if target_triple.ends_with("pc-windows-msvc") && crate_type.ends_with("dylib")
+        if target_triple.ends_with("pc-windows-msvc")
+            && crate_type.ends_with("dylib")
             && suffix == ".dll"
         {
             ret.push(FileType {

--- a/src/cargo/core/compiler/build_plan.rs
+++ b/src/cargo/core/compiler/build_plan.rs
@@ -8,13 +8,13 @@
 
 use std::collections::BTreeMap;
 
-use core::TargetKind;
-use super::{CompileMode, Context, Kind, Unit};
 use super::context::OutputFile;
-use util::{internal, CargoResult, ProcessBuilder};
-use std::path::PathBuf;
-use serde_json;
+use super::{CompileMode, Context, Kind, Unit};
+use core::TargetKind;
 use semver;
+use serde_json;
+use std::path::PathBuf;
+use util::{internal, CargoResult, ProcessBuilder};
 
 #[derive(Debug, Serialize)]
 struct Invocation {
@@ -71,7 +71,8 @@ impl Invocation {
     }
 
     pub fn update_cmd(&mut self, cmd: &ProcessBuilder) -> CargoResult<()> {
-        self.program = cmd.get_program()
+        self.program = cmd
+            .get_program()
             .to_str()
             .ok_or_else(|| format_err!("unicode program string required"))?
             .to_string();
@@ -111,7 +112,8 @@ impl BuildPlan {
     pub fn add(&mut self, cx: &Context, unit: &Unit) -> CargoResult<()> {
         let id = self.plan.invocations.len();
         self.invocation_map.insert(unit.buildkey(), id);
-        let deps = cx.dep_targets(&unit)
+        let deps = cx
+            .dep_targets(&unit)
             .iter()
             .map(|dep| self.invocation_map[&dep.buildkey()])
             .collect();
@@ -127,10 +129,10 @@ impl BuildPlan {
         outputs: &[OutputFile],
     ) -> CargoResult<()> {
         let id = self.invocation_map[invocation_name];
-        let invocation = self.plan
-            .invocations
-            .get_mut(id)
-            .ok_or_else(|| internal(format!("couldn't find invocation for {}", invocation_name)))?;
+        let invocation =
+            self.plan.invocations.get_mut(id).ok_or_else(|| {
+                internal(format!("couldn't find invocation for {}", invocation_name))
+            })?;
 
         invocation.update_cmd(cmd)?;
         for output in outputs.iter() {

--- a/src/cargo/core/compiler/compilation.rs
+++ b/src/cargo/core/compiler/compilation.rs
@@ -5,9 +5,9 @@ use std::path::PathBuf;
 
 use semver::Version;
 
+use super::BuildContext;
 use core::{Edition, Package, PackageId, Target, TargetKind};
 use util::{self, join_paths, process, CargoResult, CfgExpr, Config, ProcessBuilder};
-use super::BuildContext;
 
 pub struct Doctest {
     /// The package being doctested.
@@ -196,7 +196,7 @@ impl<'cfg> Compilation<'cfg> {
         let search_path = join_paths(&search_path, util::dylib_path_envvar())?;
 
         cmd.env(util::dylib_path_envvar(), &search_path);
-        if let Some(env) = self.extra_env.get(pkg.package_id()) {
+        if let Some(env) = self.extra_env.get(&pkg.package_id()) {
             for &(ref k, ref v) in env {
                 cmd.env(k, v);
             }
@@ -276,8 +276,10 @@ fn target_runner(bcx: &BuildContext) -> CargoResult<Option<(PathBuf, Vec<String>
                     if let Some(runner) = bcx.config.get_path_and_args(&key)? {
                         // more than one match, error out
                         if matching_runner.is_some() {
-                            bail!("several matching instances of `target.'cfg(..)'.runner` \
-                                   in `.cargo/config`")
+                            bail!(
+                                "several matching instances of `target.'cfg(..)'.runner` \
+                                 in `.cargo/config`"
+                            )
                         }
 
                         matching_runner = Some(runner.val);

--- a/src/cargo/core/compiler/context/compilation_files.rs
+++ b/src/cargo/core/compiler/context/compilation_files.rs
@@ -271,27 +271,29 @@ impl<'a, 'cfg: 'a> CompilationFiles<'a, 'cfg> {
                     )?;
 
                     match file_types {
-                        Some(types) => for file_type in types {
-                            let path = out_dir.join(file_type.filename(&file_stem));
-                            let hardlink = link_stem
-                                .as_ref()
-                                .map(|&(ref ld, ref ls)| ld.join(file_type.filename(ls)));
-                            let export_path = if unit.target.is_custom_build() {
-                                None
-                            } else {
-                                self.export_dir.as_ref().and_then(|export_dir| {
-                                    hardlink.as_ref().and_then(|hardlink| {
-                                        Some(export_dir.join(hardlink.file_name().unwrap()))
+                        Some(types) => {
+                            for file_type in types {
+                                let path = out_dir.join(file_type.filename(&file_stem));
+                                let hardlink = link_stem
+                                    .as_ref()
+                                    .map(|&(ref ld, ref ls)| ld.join(file_type.filename(ls)));
+                                let export_path = if unit.target.is_custom_build() {
+                                    None
+                                } else {
+                                    self.export_dir.as_ref().and_then(|export_dir| {
+                                        hardlink.as_ref().and_then(|hardlink| {
+                                            Some(export_dir.join(hardlink.file_name().unwrap()))
+                                        })
                                     })
-                                })
-                            };
-                            ret.push(OutputFile {
-                                path,
-                                hardlink,
-                                export_path,
-                                flavor: file_type.flavor,
-                            });
-                        },
+                                };
+                                ret.push(OutputFile {
+                                    path,
+                                    hardlink,
+                                    export_path,
+                                    flavor: file_type.flavor,
+                                });
+                            }
+                        }
                         // not supported, don't worry about it
                         None => {
                             unsupported.push(crate_type.to_string());
@@ -392,7 +394,8 @@ fn compute_metadata<'a, 'cfg>(
     let bcx = &cx.bcx;
     let __cargo_default_lib_metadata = env::var("__CARGO_DEFAULT_LIB_METADATA");
     if !(unit.mode.is_any_test() || unit.mode.is_check())
-        && (unit.target.is_dylib() || unit.target.is_cdylib()
+        && (unit.target.is_dylib()
+            || unit.target.is_cdylib()
             || (unit.target.is_bin() && bcx.target_triple().starts_with("wasm32-")))
         && unit.pkg.package_id().source_id().is_path()
         && __cargo_default_lib_metadata.is_err()
@@ -433,7 +436,8 @@ fn compute_metadata<'a, 'cfg>(
 
     // Mix in the target-metadata of all the dependencies of this target
     {
-        let mut deps_metadata = cx.dep_targets(unit)
+        let mut deps_metadata = cx
+            .dep_targets(unit)
             .iter()
             .map(|dep| metadata_of(dep, cx, metas))
             .collect::<Vec<_>>();

--- a/src/cargo/core/compiler/job.rs
+++ b/src/cargo/core/compiler/job.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 
-use util::{CargoResult, Dirty, Fresh, Freshness};
 use super::job_queue::JobState;
+use util::{CargoResult, Dirty, Fresh, Freshness};
 
 pub struct Job {
     dirty: Work,

--- a/src/cargo/core/compiler/layout.rs
+++ b/src/cargo/core/compiler/layout.rs
@@ -135,9 +135,9 @@ impl Layout {
     ///
     /// This is recommended to prevent derived/temporary files from bloating backups.
     fn exclude_from_backups(&self, path: &Path) {
-        use std::ptr;
-        use core_foundation::{number, string, url};
         use core_foundation::base::TCFType;
+        use core_foundation::{number, string, url};
+        use std::ptr;
 
         // For compatibility with 10.7 a string is used instead of global kCFURLIsExcludedFromBackupKey
         let is_excluded_key: Result<string::CFString, _> = "NSURLIsExcludedFromBackupKey".parse();

--- a/src/cargo/core/compiler/output_depinfo.rs
+++ b/src/cargo/core/compiler/output_depinfo.rs
@@ -52,7 +52,7 @@ fn add_deps_for_unit<'a, 'b>(
     }
 
     // Add rerun-if-changed dependencies
-    let key = (unit.pkg.package_id().clone(), unit.kind);
+    let key = (unit.pkg.package_id(), unit.kind);
     if let Some(output) = context.build_state.outputs.lock().unwrap().get(&key) {
         for path in &output.rerun_if_changed {
             deps.insert(path.into());
@@ -87,7 +87,8 @@ pub fn output_depinfo<'a, 'b>(cx: &mut Context<'a, 'b>, unit: &Unit<'a>) -> Carg
         }
         None => None,
     };
-    let deps = deps.iter()
+    let deps = deps
+        .iter()
         .map(|f| render_filename(f, basedir))
         .collect::<CargoResult<Vec<_>>>()?;
 

--- a/src/cargo/core/dependency.rs
+++ b/src/cargo/core/dependency.rs
@@ -89,7 +89,7 @@ pub enum Kind {
 fn parse_req_with_deprecated(
     name: &str,
     req: &str,
-    extra: Option<(&PackageId, &Config)>,
+    extra: Option<(PackageId, &Config)>,
 ) -> CargoResult<VersionReq> {
     match VersionReq::parse(req) {
         Err(ReqParseError::DeprecatedVersionRequirement(requirement)) => {
@@ -152,7 +152,7 @@ impl Dependency {
         name: &str,
         version: Option<&str>,
         source_id: SourceId,
-        inside: &PackageId,
+        inside: PackageId,
         config: &Config,
     ) -> CargoResult<Dependency> {
         let arg = Some((inside, config));
@@ -349,7 +349,7 @@ impl Dependency {
     }
 
     /// Lock this dependency to depending on the specified package id
-    pub fn lock_to(&mut self, id: &PackageId) -> &mut Dependency {
+    pub fn lock_to(&mut self, id: PackageId) -> &mut Dependency {
         assert_eq!(self.inner.source_id, id.source_id());
         assert!(self.inner.req.matches(id.version()));
         trace!(
@@ -404,12 +404,12 @@ impl Dependency {
     }
 
     /// Returns true if the package (`sum`) can fulfill this dependency request.
-    pub fn matches_ignoring_source(&self, id: &PackageId) -> bool {
+    pub fn matches_ignoring_source(&self, id: PackageId) -> bool {
         self.package_name() == id.name() && self.version_req().matches(id.version())
     }
 
     /// Returns true if the package (`id`) can fulfill this dependency request.
-    pub fn matches_id(&self, id: &PackageId) -> bool {
+    pub fn matches_id(&self, id: PackageId) -> bool {
         self.inner.name == id.name()
             && (self.inner.only_match_name
                 || (self.inner.req.matches(id.version()) && self.inner.source_id == id.source_id()))

--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -413,7 +413,7 @@ impl Manifest {
     pub fn name(&self) -> InternedString {
         self.package_id().name()
     }
-    pub fn package_id(&self) -> &PackageId {
+    pub fn package_id(&self) -> PackageId {
         self.summary.package_id()
     }
     pub fn summary(&self) -> &Summary {
@@ -519,7 +519,7 @@ impl Manifest {
     }
 
     pub fn metabuild_path(&self, target_dir: Filesystem) -> PathBuf {
-        let hash = short_hash(self.package_id());
+        let hash = short_hash(&self.package_id());
         target_dir
             .into_path_unlocked()
             .join(".metabuild")

--- a/src/cargo/core/package_id_spec.rs
+++ b/src/cargo/core/package_id_spec.rs
@@ -77,9 +77,9 @@ impl PackageIdSpec {
     }
 
     /// Roughly equivalent to `PackageIdSpec::parse(spec)?.query(i)`
-    pub fn query_str<'a, I>(spec: &str, i: I) -> CargoResult<&'a PackageId>
+    pub fn query_str<I>(spec: &str, i: I) -> CargoResult<PackageId>
     where
-        I: IntoIterator<Item = &'a PackageId>,
+        I: IntoIterator<Item = PackageId>,
     {
         let spec = PackageIdSpec::parse(spec)
             .chain_err(|| format_err!("invalid package id specification: `{}`", spec))?;
@@ -88,7 +88,7 @@ impl PackageIdSpec {
 
     /// Convert a `PackageId` to a `PackageIdSpec`, which will have both the `Version` and `Url`
     /// fields filled in.
-    pub fn from_package_id(package_id: &PackageId) -> PackageIdSpec {
+    pub fn from_package_id(package_id: PackageId) -> PackageIdSpec {
         PackageIdSpec {
             name: package_id.name().to_string(),
             version: Some(package_id.version().clone()),
@@ -160,7 +160,7 @@ impl PackageIdSpec {
     }
 
     /// Checks whether the given `PackageId` matches the `PackageIdSpec`.
-    pub fn matches(&self, package_id: &PackageId) -> bool {
+    pub fn matches(&self, package_id: PackageId) -> bool {
         if self.name() != &*package_id.name() {
             return false;
         }
@@ -179,9 +179,9 @@ impl PackageIdSpec {
 
     /// Checks a list of `PackageId`s to find 1 that matches this `PackageIdSpec`. If 0, 2, or
     /// more are found, then this returns an error.
-    pub fn query<'a, I>(&self, i: I) -> CargoResult<&'a PackageId>
+    pub fn query<I>(&self, i: I) -> CargoResult<PackageId>
     where
-        I: IntoIterator<Item = &'a PackageId>,
+        I: IntoIterator<Item = PackageId>,
     {
         let mut ids = i.into_iter().filter(|p| self.matches(*p));
         let ret = match ids.next() {
@@ -212,7 +212,7 @@ impl PackageIdSpec {
             None => Ok(ret),
         };
 
-        fn minimize(msg: &mut String, ids: &[&PackageId], spec: &PackageIdSpec) {
+        fn minimize(msg: &mut String, ids: &[PackageId], spec: &PackageIdSpec) {
             let mut version_cnt = HashMap::new();
             for id in ids {
                 *version_cnt.entry(id.version()).or_insert(0) += 1;
@@ -371,9 +371,9 @@ mod tests {
         let foo = PackageId::new("foo", "1.2.3", sid).unwrap();
         let bar = PackageId::new("bar", "1.2.3", sid).unwrap();
 
-        assert!(PackageIdSpec::parse("foo").unwrap().matches(&foo));
-        assert!(!PackageIdSpec::parse("foo").unwrap().matches(&bar));
-        assert!(PackageIdSpec::parse("foo:1.2.3").unwrap().matches(&foo));
-        assert!(!PackageIdSpec::parse("foo:1.2.2").unwrap().matches(&foo));
+        assert!(PackageIdSpec::parse("foo").unwrap().matches(foo));
+        assert!(!PackageIdSpec::parse("foo").unwrap().matches(bar));
+        assert!(PackageIdSpec::parse("foo:1.2.3").unwrap().matches(foo));
+        assert!(!PackageIdSpec::parse("foo:1.2.2").unwrap().matches(foo));
     }
 }

--- a/src/cargo/core/profiles.rs
+++ b/src/cargo/core/profiles.rs
@@ -67,7 +67,7 @@ impl Profiles {
     /// workspace.
     pub fn get_profile(
         &self,
-        pkg_id: &PackageId,
+        pkg_id: PackageId,
         is_member: bool,
         unit_for: UnitFor,
         mode: CompileMode,
@@ -163,7 +163,7 @@ struct ProfileMaker {
 impl ProfileMaker {
     fn get_profile(
         &self,
-        pkg_id: Option<&PackageId>,
+        pkg_id: Option<PackageId>,
         is_member: bool,
         unit_for: UnitFor,
     ) -> Profile {
@@ -292,7 +292,7 @@ impl ProfileMaker {
 }
 
 fn merge_toml(
-    pkg_id: Option<&PackageId>,
+    pkg_id: Option<PackageId>,
     is_member: bool,
     unit_for: UnitFor,
     profile: &mut Profile,

--- a/src/cargo/core/resolver/encode.rs
+++ b/src/cargo/core/resolver/encode.rs
@@ -72,7 +72,7 @@ impl EncodableResolve {
         };
 
         let lookup_id = |enc_id: &EncodablePackageId| -> Option<PackageId> {
-            live_pkgs.get(enc_id).map(|&(ref id, _)| id.clone())
+            live_pkgs.get(enc_id).map(|&(id, _)| id)
         };
 
         let g = {
@@ -343,8 +343,8 @@ impl<'a, 'cfg> ser::Serialize for WorkspaceResolve<'a, 'cfg> {
 
         let mut metadata = self.resolve.metadata().clone();
 
-        for id in ids.iter().filter(|id| !id.source_id().is_path()) {
-            let checksum = match self.resolve.checksums()[*id] {
+        for &id in ids.iter().filter(|id| !id.source_id().is_path()) {
+            let checksum = match self.resolve.checksums()[&id] {
                 Some(ref s) => &s[..],
                 None => "<none>",
             };
@@ -382,7 +382,7 @@ impl<'a, 'cfg> ser::Serialize for WorkspaceResolve<'a, 'cfg> {
     }
 }
 
-fn encodable_resolve_node(id: &PackageId, resolve: &Resolve) -> EncodableDependency {
+fn encodable_resolve_node(id: PackageId, resolve: &Resolve) -> EncodableDependency {
     let (replace, deps) = match resolve.replacement(id) {
         Some(id) => (Some(encodable_package_id(id)), None),
         None => {
@@ -404,7 +404,7 @@ fn encodable_resolve_node(id: &PackageId, resolve: &Resolve) -> EncodableDepende
     }
 }
 
-pub fn encodable_package_id(id: &PackageId) -> EncodablePackageId {
+pub fn encodable_package_id(id: PackageId) -> EncodablePackageId {
     EncodablePackageId {
         name: id.name().to_string(),
         version: id.version().to_string(),

--- a/src/cargo/core/resolver/errors.rs
+++ b/src/cargo/core/resolver/errors.rs
@@ -82,7 +82,7 @@ pub(super) fn activation_error(
         ResolveError::new(
             err,
             graph
-                .path_to_top(parent.package_id())
+                .path_to_top(&parent.package_id())
                 .into_iter()
                 .cloned()
                 .collect(),
@@ -92,7 +92,7 @@ pub(super) fn activation_error(
     if !candidates.is_empty() {
         let mut msg = format!("failed to select a version for `{}`.", dep.package_name());
         msg.push_str("\n    ... required by ");
-        msg.push_str(&describe_path(&graph.path_to_top(parent.package_id())));
+        msg.push_str(&describe_path(&graph.path_to_top(&parent.package_id())));
 
         msg.push_str("\nversions that meet the requirements `");
         msg.push_str(&dep.version_req().to_string());
@@ -204,7 +204,7 @@ pub(super) fn activation_error(
             registry.describe_source(dep.source_id()),
         );
         msg.push_str("required by ");
-        msg.push_str(&describe_path(&graph.path_to_top(parent.package_id())));
+        msg.push_str(&describe_path(&graph.path_to_top(&parent.package_id())));
 
         // If we have a path dependency with a locked version, then this may
         // indicate that we updated a sub-package and forgot to run `cargo
@@ -258,7 +258,7 @@ pub(super) fn activation_error(
             msg.push_str("\n");
         }
         msg.push_str("required by ");
-        msg.push_str(&describe_path(&graph.path_to_top(parent.package_id())));
+        msg.push_str(&describe_path(&graph.path_to_top(&parent.package_id())));
 
         msg
     };

--- a/src/cargo/core/resolver/resolve.rs
+++ b/src/cargo/core/resolver/resolve.rs
@@ -41,10 +41,7 @@ impl Resolve {
         metadata: Metadata,
         unused_patches: Vec<PackageId>,
     ) -> Resolve {
-        let reverse_replacements = replacements
-            .iter()
-            .map(|p| (p.1.clone(), p.0.clone()))
-            .collect();
+        let reverse_replacements = replacements.iter().map(|(&p, &r)| (r, p)).collect();
         Resolve {
             graph,
             replacements,
@@ -68,7 +65,7 @@ impl Resolve {
             if self.iter().any(|id| id == summary.package_id()) {
                 continue;
             }
-            self.unused_patches.push(summary.package_id().clone());
+            self.unused_patches.push(summary.package_id());
         }
     }
 
@@ -175,39 +172,39 @@ unable to verify that `{0}` is the same as when the lockfile was generated
         self.graph.sort()
     }
 
-    pub fn iter(&self) -> impl Iterator<Item = &PackageId> {
-        self.graph.iter()
+    pub fn iter<'a>(&'a self) -> impl Iterator<Item = PackageId> + 'a {
+        self.graph.iter().cloned()
     }
 
-    pub fn deps(&self, pkg: &PackageId) -> impl Iterator<Item = (&PackageId, &[Dependency])> {
+    pub fn deps(&self, pkg: PackageId) -> impl Iterator<Item = (PackageId, &[Dependency])> {
         self.graph
-            .edges(pkg)
-            .map(move |(id, deps)| (self.replacement(id).unwrap_or(id), deps.as_slice()))
+            .edges(&pkg)
+            .map(move |(&id, deps)| (self.replacement(id).unwrap_or(id), deps.as_slice()))
     }
 
-    pub fn deps_not_replaced(&self, pkg: &PackageId) -> impl Iterator<Item = &PackageId> {
-        self.graph.edges(pkg).map(|(id, _)| id)
+    pub fn deps_not_replaced<'a>(&'a self, pkg: PackageId) -> impl Iterator<Item = PackageId> + 'a {
+        self.graph.edges(&pkg).map(|(&id, _)| id)
     }
 
-    pub fn replacement(&self, pkg: &PackageId) -> Option<&PackageId> {
-        self.replacements.get(pkg)
+    pub fn replacement(&self, pkg: PackageId) -> Option<PackageId> {
+        self.replacements.get(&pkg).cloned()
     }
 
     pub fn replacements(&self) -> &HashMap<PackageId, PackageId> {
         &self.replacements
     }
 
-    pub fn features(&self, pkg: &PackageId) -> &HashSet<String> {
-        self.features.get(pkg).unwrap_or(&self.empty_features)
+    pub fn features(&self, pkg: PackageId) -> &HashSet<String> {
+        self.features.get(&pkg).unwrap_or(&self.empty_features)
     }
 
-    pub fn features_sorted(&self, pkg: &PackageId) -> Vec<&str> {
+    pub fn features_sorted(&self, pkg: PackageId) -> Vec<&str> {
         let mut v = Vec::from_iter(self.features(pkg).iter().map(|s| s.as_ref()));
         v.sort_unstable();
         v
     }
 
-    pub fn query(&self, spec: &str) -> CargoResult<&PackageId> {
+    pub fn query(&self, spec: &str) -> CargoResult<PackageId> {
         PackageIdSpec::query_str(spec, self.iter())
     }
 
@@ -225,8 +222,8 @@ unable to verify that `{0}` is the same as when the lockfile was generated
 
     pub fn extern_crate_name(
         &self,
-        from: &PackageId,
-        to: &PackageId,
+        from: PackageId,
+        to: PackageId,
         to_target: &Target,
     ) -> CargoResult<String> {
         let deps = if from == to {
@@ -256,7 +253,7 @@ unable to verify that `{0}` is the same as when the lockfile was generated
         Ok(name.to_string())
     }
 
-    fn dependencies_listed(&self, from: &PackageId, to: &PackageId) -> &[Dependency] {
+    fn dependencies_listed(&self, from: PackageId, to: PackageId) -> &[Dependency] {
         // We've got a dependency on `from` to `to`, but this dependency edge
         // may be affected by [replace]. If the `to` package is listed as the
         // target of a replacement (aka the key of a reverse replacement map)
@@ -266,12 +263,12 @@ unable to verify that `{0}` is the same as when the lockfile was generated
         // Note that we don't treat `from` as if it's been replaced because
         // that's where the dependency originates from, and we only replace
         // targets of dependencies not the originator.
-        if let Some(replace) = self.reverse_replacements.get(to) {
-            if let Some(deps) = self.graph.edge(from, replace) {
+        if let Some(replace) = self.reverse_replacements.get(&to) {
+            if let Some(deps) = self.graph.edge(&from, replace) {
                 return deps;
             }
         }
-        match self.graph.edge(from, to) {
+        match self.graph.edge(&from, &to) {
             Some(ret) => ret,
             None => panic!("no Dependency listed for `{}` => `{}`", from, to),
         }

--- a/src/cargo/core/resolver/types.rs
+++ b/src/cargo/core/resolver/types.rs
@@ -76,7 +76,7 @@ impl ResolverProgress {
 pub struct RegistryQueryer<'a> {
     pub registry: &'a mut (Registry + 'a),
     replacements: &'a [(PackageIdSpec, Dependency)],
-    try_to_use: &'a HashSet<&'a PackageId>,
+    try_to_use: &'a HashSet<PackageId>,
     cache: HashMap<Dependency, Rc<Vec<Candidate>>>,
     // If set the list of dependency candidates will be sorted by minimal
     // versions first. That allows `cargo update -Z minimal-versions` which will
@@ -88,7 +88,7 @@ impl<'a> RegistryQueryer<'a> {
     pub fn new(
         registry: &'a mut Registry,
         replacements: &'a [(PackageIdSpec, Dependency)],
-        try_to_use: &'a HashSet<&'a PackageId>,
+        try_to_use: &'a HashSet<PackageId>,
         minimal_versions: bool,
     ) -> Self {
         RegistryQueryer {
@@ -203,8 +203,8 @@ impl<'a> RegistryQueryer<'a> {
         // prioritized summaries (those in `try_to_use`) and failing that we
         // list everything from the maximum version to the lowest version.
         ret.sort_unstable_by(|a, b| {
-            let a_in_previous = self.try_to_use.contains(a.summary.package_id());
-            let b_in_previous = self.try_to_use.contains(b.summary.package_id());
+            let a_in_previous = self.try_to_use.contains(&a.summary.package_id());
+            let b_in_previous = self.try_to_use.contains(&b.summary.package_id());
             let previous_cmp = a_in_previous.cmp(&b_in_previous).reverse();
             match previous_cmp {
                 Ordering::Equal => {
@@ -279,7 +279,7 @@ impl DepsFrame {
             .unwrap_or(0)
     }
 
-    pub fn flatten(&self) -> impl Iterator<Item = (&PackageId, Dependency)> {
+    pub fn flatten<'a>(&'a self) -> impl Iterator<Item = (PackageId, Dependency)> + 'a {
         self.remaining_siblings
             .clone()
             .map(move |(_, (d, _, _))| (self.parent.package_id(), d))
@@ -353,7 +353,7 @@ impl RemainingDeps {
         }
         None
     }
-    pub fn iter(&mut self) -> impl Iterator<Item = (&PackageId, Dependency)> {
+    pub fn iter<'a>(&'a mut self) -> impl Iterator<Item = (PackageId, Dependency)> + 'a {
         self.data.iter().flat_map(|(other, _)| other.flatten())
     }
 }

--- a/src/cargo/core/source/mod.rs
+++ b/src/cargo/core/source/mod.rs
@@ -49,9 +49,9 @@ pub trait Source {
 
     /// The download method fetches the full package for each name and
     /// version specified.
-    fn download(&mut self, package: &PackageId) -> CargoResult<MaybePackage>;
+    fn download(&mut self, package: PackageId) -> CargoResult<MaybePackage>;
 
-    fn finish_download(&mut self, package: &PackageId, contents: Vec<u8>) -> CargoResult<Package>;
+    fn finish_download(&mut self, package: PackageId, contents: Vec<u8>) -> CargoResult<Package>;
 
     /// Generates a unique string which represents the fingerprint of the
     /// current state of the source.
@@ -71,7 +71,7 @@ pub trait Source {
     /// verification during the `download` step, but this is intended to be run
     /// just before a crate is compiled so it may perform more expensive checks
     /// which may not be cacheable.
-    fn verify(&self, _pkg: &PackageId) -> CargoResult<()> {
+    fn verify(&self, _pkg: PackageId) -> CargoResult<()> {
         Ok(())
     }
 
@@ -127,11 +127,11 @@ impl<'a, T: Source + ?Sized + 'a> Source for Box<T> {
     }
 
     /// Forwards to `Source::download`
-    fn download(&mut self, id: &PackageId) -> CargoResult<MaybePackage> {
+    fn download(&mut self, id: PackageId) -> CargoResult<MaybePackage> {
         (**self).download(id)
     }
 
-    fn finish_download(&mut self, id: &PackageId, data: Vec<u8>) -> CargoResult<Package> {
+    fn finish_download(&mut self, id: PackageId, data: Vec<u8>) -> CargoResult<Package> {
         (**self).finish_download(id, data)
     }
 
@@ -141,7 +141,7 @@ impl<'a, T: Source + ?Sized + 'a> Source for Box<T> {
     }
 
     /// Forwards to `Source::verify`
-    fn verify(&self, pkg: &PackageId) -> CargoResult<()> {
+    fn verify(&self, pkg: PackageId) -> CargoResult<()> {
         (**self).verify(pkg)
     }
 
@@ -183,11 +183,11 @@ impl<'a, T: Source + ?Sized + 'a> Source for &'a mut T {
         (**self).update()
     }
 
-    fn download(&mut self, id: &PackageId) -> CargoResult<MaybePackage> {
+    fn download(&mut self, id: PackageId) -> CargoResult<MaybePackage> {
         (**self).download(id)
     }
 
-    fn finish_download(&mut self, id: &PackageId, data: Vec<u8>) -> CargoResult<Package> {
+    fn finish_download(&mut self, id: PackageId, data: Vec<u8>) -> CargoResult<Package> {
         (**self).finish_download(id, data)
     }
 
@@ -195,7 +195,7 @@ impl<'a, T: Source + ?Sized + 'a> Source for &'a mut T {
         (**self).fingerprint(pkg)
     }
 
-    fn verify(&self, pkg: &PackageId) -> CargoResult<()> {
+    fn verify(&self, pkg: PackageId) -> CargoResult<()> {
         (**self).verify(pkg)
     }
 
@@ -255,7 +255,7 @@ impl<'src> SourceMap<'src> {
 
     /// Like `HashMap::get`, but first calculates the `SourceId` from a
     /// `PackageId`
-    pub fn get_by_package_id(&self, pkg_id: &PackageId) -> Option<&(Source + 'src)> {
+    pub fn get_by_package_id(&self, pkg_id: PackageId) -> Option<&(Source + 'src)> {
         self.get(pkg_id.source_id())
     }
 

--- a/src/cargo/core/source/source_id.rs
+++ b/src/cargo/core/source/source_id.rs
@@ -336,11 +336,11 @@ impl SourceId {
         self.hash(into)
     }
 
-    pub fn full_eq(&self, other: &SourceId) -> bool {
+    pub fn full_eq(self, other: SourceId) -> bool {
         ptr::eq(self.inner, other.inner)
     }
 
-    pub fn full_hash<S: hash::Hasher>(&self, into: &mut S) {
+    pub fn full_hash<S: hash::Hasher>(self, into: &mut S) {
         ptr::NonNull::from(self.inner).hash(into)
     }
 }

--- a/src/cargo/core/summary.rs
+++ b/src/cargo/core/summary.rs
@@ -71,8 +71,8 @@ impl Summary {
         })
     }
 
-    pub fn package_id(&self) -> &PackageId {
-        &self.inner.package_id
+    pub fn package_id(&self) -> PackageId {
+        self.inner.package_id
     }
     pub fn name(&self) -> InternedString {
         self.package_id().name()

--- a/src/cargo/ops/cargo_clean.rs
+++ b/src/cargo/ops/cargo_clean.rs
@@ -134,7 +134,8 @@ fn rm_rf(path: &Path, config: &Config) -> CargoResult<()> {
         config
             .shell()
             .verbose(|shell| shell.status("Removing", path.display()))?;
-        paths::remove_dir_all(path).chain_err(|| format_err!("could not remove build directory"))?;
+        paths::remove_dir_all(path)
+            .chain_err(|| format_err!("could not remove build directory"))?;
     } else if m.is_ok() {
         config
             .shell()

--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -28,7 +28,7 @@ use std::sync::Arc;
 
 use core::compiler::{BuildConfig, BuildContext, Compilation, Context, DefaultExecutor, Executor};
 use core::compiler::{CompileMode, Kind, Unit};
-use core::profiles::{UnitFor, Profiles};
+use core::profiles::{Profiles, UnitFor};
 use core::resolver::{Method, Resolve};
 use core::{Package, Source, Target};
 use core::{PackageId, PackageIdSpec, TargetKind, Workspace};
@@ -109,11 +109,13 @@ impl Packages {
 
     pub fn to_package_id_specs(&self, ws: &Workspace) -> CargoResult<Vec<PackageIdSpec>> {
         let specs = match *self {
-            Packages::All => ws.members()
+            Packages::All => ws
+                .members()
                 .map(Package::package_id)
                 .map(PackageIdSpec::from_package_id)
                 .collect(),
-            Packages::OptOut(ref opt_out) => ws.members()
+            Packages::OptOut(ref opt_out) => ws
+                .members()
                 .map(Package::package_id)
                 .map(PackageIdSpec::from_package_id)
                 .filter(|p| opt_out.iter().position(|x| *x == p.name()).is_none())
@@ -125,7 +127,8 @@ impl Packages {
                 .iter()
                 .map(|p| PackageIdSpec::parse(p))
                 .collect::<CargoResult<Vec<_>>>()?,
-            Packages::Default => ws.default_members()
+            Packages::Default => ws
+                .default_members()
                 .map(Package::package_id)
                 .map(PackageIdSpec::from_package_id)
                 .collect(),
@@ -159,7 +162,8 @@ impl Packages {
                         .ok_or_else(|| {
                             format_err!("package `{}` is not a member of the workspace", name)
                         })
-                }).collect::<CargoResult<Vec<_>>>()?,
+                })
+                .collect::<CargoResult<Vec<_>>>()?,
         };
         Ok(packages)
     }
@@ -243,7 +247,8 @@ pub fn compile_ws<'a>(
     let resolve = ops::resolve_ws_with_method(ws, source, method, &specs)?;
     let (packages, resolve_with_overrides) = resolve;
 
-    let to_build_ids = specs.iter()
+    let to_build_ids = specs
+        .iter()
         .map(|s| s.query(resolve_with_overrides.iter()))
         .collect::<CargoResult<Vec<_>>>()?;
     let mut to_builds = packages.get_many(to_build_ids)?;
@@ -390,8 +395,11 @@ impl CompileFilter {
                 benches: FilterRule::All,
                 tests: FilterRule::All,
             }
-        } else if lib_only || rule_bins.is_specific() || rule_tsts.is_specific()
-            || rule_exms.is_specific() || rule_bens.is_specific()
+        } else if lib_only
+            || rule_bins.is_specific()
+            || rule_tsts.is_specific()
+            || rule_exms.is_specific()
+            || rule_bens.is_specific()
         {
             CompileFilter::Only {
                 all_targets: false,
@@ -695,7 +703,13 @@ fn generate_targets<'a>(
     // features available.
     let mut features_map = HashMap::new();
     let mut units = HashSet::new();
-    for Proposal { pkg, target, requires_features, mode} in proposals {
+    for Proposal {
+        pkg,
+        target,
+        requires_features,
+        mode,
+    } in proposals
+    {
         let unavailable_features = match target.required_features() {
             Some(rf) => {
                 let features = features_map
@@ -730,7 +744,7 @@ fn generate_targets<'a>(
 
 fn resolve_all_features(
     resolve_with_overrides: &Resolve,
-    package_id: &PackageId,
+    package_id: PackageId,
 ) -> HashSet<String> {
     let mut features = resolve_with_overrides.features(package_id).clone();
 
@@ -843,7 +857,8 @@ fn find_named_targets<'a>(
                 pkg.targets()
                     .iter()
                     .filter(|target| is_expected_kind(target))
-            }).map(|target| (lev_distance(target_name, target.name()), target))
+            })
+            .map(|target| (lev_distance(target_name, target.name()), target))
             .filter(|&(d, _)| d < 4)
             .min_by_key(|t| t.0)
             .map(|t| t.1);

--- a/src/cargo/ops/cargo_doc.rs
+++ b/src/cargo/ops/cargo_doc.rs
@@ -31,7 +31,8 @@ pub fn doc(ws: &Workspace, options: &DocOptions) -> CargoResult<()> {
     )?;
     let (packages, resolve_with_overrides) = resolve;
 
-    let ids = specs.iter()
+    let ids = specs
+        .iter()
         .map(|s| s.query(resolve_with_overrides.iter()))
         .collect::<CargoResult<Vec<_>>>()?;
     let pkgs = packages.get_many(ids)?;

--- a/src/cargo/ops/cargo_fetch.rs
+++ b/src/cargo/ops/cargo_fetch.rs
@@ -34,31 +34,31 @@ pub fn fetch<'a>(
                 continue;
             }
 
-            to_download.push(id.clone());
-            let deps = resolve.deps(id)
+            to_download.push(id);
+            let deps = resolve
+                .deps(id)
                 .filter(|&(_id, deps)| {
-                    deps.iter()
-                        .any(|d| {
-                            // If no target was specified then all dependencies can
-                            // be fetched.
-                            let target = match options.target {
-                                Some(ref t) => t,
-                                None => return true,
-                            };
-                            // If this dependency is only available for certain
-                            // platforms, make sure we're only fetching it for that
-                            // platform.
-                            let platform = match d.platform() {
-                                Some(p) => p,
-                                None => return true,
-                            };
-                            platform.matches(target, target_info.cfg())
-                        })
+                    deps.iter().any(|d| {
+                        // If no target was specified then all dependencies can
+                        // be fetched.
+                        let target = match options.target {
+                            Some(ref t) => t,
+                            None => return true,
+                        };
+                        // If this dependency is only available for certain
+                        // platforms, make sure we're only fetching it for that
+                        // platform.
+                        let platform = match d.platform() {
+                            Some(p) => p,
+                            None => return true,
+                        };
+                        platform.matches(target, target_info.cfg())
+                    })
                 })
                 .map(|(id, _deps)| id);
             deps_to_fetch.extend(deps);
         }
-        packages.get_many(&to_download)?;
+        packages.get_many(to_download)?;
     }
 
     Ok((resolve, packages))

--- a/src/cargo/ops/cargo_generate_lockfile.rs
+++ b/src/cargo/ops/cargo_generate_lockfile.rs
@@ -124,9 +124,9 @@ pub fn update_lockfile(ws: &Workspace, opts: &UpdateOptions) -> CargoResult<()> 
 
     fn fill_with_deps<'a>(
         resolve: &'a Resolve,
-        dep: &'a PackageId,
-        set: &mut HashSet<&'a PackageId>,
-        visited: &mut HashSet<&'a PackageId>,
+        dep: PackageId,
+        set: &mut HashSet<PackageId>,
+        visited: &mut HashSet<PackageId>,
     ) {
         if !visited.insert(dep) {
             return;
@@ -137,11 +137,11 @@ pub fn update_lockfile(ws: &Workspace, opts: &UpdateOptions) -> CargoResult<()> 
         }
     }
 
-    fn compare_dependency_graphs<'a>(
-        previous_resolve: &'a Resolve,
-        resolve: &'a Resolve,
-    ) -> Vec<(Vec<&'a PackageId>, Vec<&'a PackageId>)> {
-        fn key(dep: &PackageId) -> (&str, SourceId) {
+    fn compare_dependency_graphs(
+        previous_resolve: &Resolve,
+        resolve: &Resolve,
+    ) -> Vec<(Vec<PackageId>, Vec<PackageId>)> {
+        fn key(dep: PackageId) -> (&'static str, SourceId) {
             (dep.name().as_str(), dep.source_id())
         }
 
@@ -149,7 +149,7 @@ pub fn update_lockfile(ws: &Workspace, opts: &UpdateOptions) -> CargoResult<()> 
         // more complicated because the equality for source ids does not take
         // precise versions into account (e.g. git shas), but we want to take
         // that into account here.
-        fn vec_subtract<'a>(a: &[&'a PackageId], b: &[&'a PackageId]) -> Vec<&'a PackageId> {
+        fn vec_subtract(a: &[PackageId], b: &[PackageId]) -> Vec<PackageId> {
             a.iter()
                 .filter(|a| {
                     // If this package id is not found in `b`, then it's definitely

--- a/src/cargo/ops/cargo_read_manifest.rs
+++ b/src/cargo/ops/cargo_read_manifest.rs
@@ -165,7 +165,7 @@ fn read_nested_packages(
     };
     let pkg = Package::new(manifest, &manifest_path);
 
-    let pkg_id = pkg.package_id().clone();
+    let pkg_id = pkg.package_id();
     use std::collections::hash_map::Entry;
     match all_packages.entry(pkg_id) {
         Entry::Vacant(v) => {

--- a/src/cargo/ops/cargo_test.rs
+++ b/src/cargo/ops/cargo_test.rs
@@ -1,10 +1,10 @@
 use std::ffi::OsString;
 
-use ops;
 use core::compiler::{Compilation, Doctest};
-use util::{self, CargoTestError, ProcessError, Test};
-use util::errors::CargoResult;
 use core::Workspace;
+use ops;
+use util::errors::CargoResult;
+use util::{self, CargoTestError, ProcessError, Test};
 
 pub struct TestOptions<'a> {
     pub compile_opts: ops::CompileOptions<'a>,
@@ -172,7 +172,7 @@ fn run_doc_tests(
             p.arg("--test-args").arg(arg);
         }
 
-        if let Some(cfgs) = compilation.cfgs.get(package.package_id()) {
+        if let Some(cfgs) = compilation.cfgs.get(&package.package_id()) {
             for cfg in cfgs.iter() {
                 p.arg("--cfg").arg(cfg);
             }
@@ -185,7 +185,7 @@ fn run_doc_tests(
             p.arg("--extern").arg(&arg);
         }
 
-        if let Some(flags) = compilation.rustdocflags.get(package.package_id()) {
+        if let Some(flags) = compilation.rustdocflags.get(&package.package_id()) {
             p.args(flags);
         }
 

--- a/src/cargo/sources/directory.rs
+++ b/src/cargo/sources/directory.rs
@@ -145,22 +145,22 @@ impl<'cfg> Source for DirectorySource<'cfg> {
             }
             manifest.set_summary(summary);
             let pkg = Package::new(manifest, pkg.manifest_path());
-            self.packages.insert(pkg.package_id().clone(), (pkg, cksum));
+            self.packages.insert(pkg.package_id(), (pkg, cksum));
         }
 
         Ok(())
     }
 
-    fn download(&mut self, id: &PackageId) -> CargoResult<MaybePackage> {
+    fn download(&mut self, id: PackageId) -> CargoResult<MaybePackage> {
         self.packages
-            .get(id)
+            .get(&id)
             .map(|p| &p.0)
             .cloned()
             .map(MaybePackage::Ready)
             .ok_or_else(|| format_err!("failed to find package with id: {}", id))
     }
 
-    fn finish_download(&mut self, _id: &PackageId, _data: Vec<u8>) -> CargoResult<Package> {
+    fn finish_download(&mut self, _id: PackageId, _data: Vec<u8>) -> CargoResult<Package> {
         panic!("no downloads to do")
     }
 
@@ -168,8 +168,8 @@ impl<'cfg> Source for DirectorySource<'cfg> {
         Ok(pkg.package_id().version().to_string())
     }
 
-    fn verify(&self, id: &PackageId) -> CargoResult<()> {
-        let (pkg, cksum) = match self.packages.get(id) {
+    fn verify(&self, id: PackageId) -> CargoResult<()> {
+        let (pkg, cksum) = match self.packages.get(&id) {
             Some(&(ref pkg, ref cksum)) => (pkg, cksum),
             None => bail!("failed to find entry for `{}` in directory source", id),
         };

--- a/src/cargo/sources/git/source.rs
+++ b/src/cargo/sources/git/source.rs
@@ -214,7 +214,7 @@ impl<'cfg> Source for GitSource<'cfg> {
         self.path_source.as_mut().unwrap().update()
     }
 
-    fn download(&mut self, id: &PackageId) -> CargoResult<MaybePackage> {
+    fn download(&mut self, id: PackageId) -> CargoResult<MaybePackage> {
         trace!(
             "getting packages for package id `{}` from `{:?}`",
             id,
@@ -226,7 +226,7 @@ impl<'cfg> Source for GitSource<'cfg> {
             .download(id)
     }
 
-    fn finish_download(&mut self, _id: &PackageId, _data: Vec<u8>) -> CargoResult<Package> {
+    fn finish_download(&mut self, _id: PackageId, _data: Vec<u8>) -> CargoResult<Package> {
         panic!("no download should have started")
     }
 

--- a/src/cargo/sources/path.rs
+++ b/src/cargo/sources/path.rs
@@ -545,7 +545,7 @@ impl<'cfg> Source for PathSource<'cfg> {
         Ok(())
     }
 
-    fn download(&mut self, id: &PackageId) -> CargoResult<MaybePackage> {
+    fn download(&mut self, id: PackageId) -> CargoResult<MaybePackage> {
         trace!("getting packages; id={}", id);
 
         let pkg = self.packages.iter().find(|pkg| pkg.package_id() == id);
@@ -554,7 +554,7 @@ impl<'cfg> Source for PathSource<'cfg> {
             .ok_or_else(|| internal(format!("failed to find {} in path source", id)))
     }
 
-    fn finish_download(&mut self, _id: &PackageId, _data: Vec<u8>) -> CargoResult<Package> {
+    fn finish_download(&mut self, _id: PackageId, _data: Vec<u8>) -> CargoResult<Package> {
         panic!("no download should have started")
     }
 

--- a/src/cargo/sources/registry/index.rs
+++ b/src/cargo/sources/registry/index.rs
@@ -124,7 +124,7 @@ impl<'cfg> RegistryIndex<'cfg> {
     }
 
     /// Return the hash listed for a specified PackageId.
-    pub fn hash(&mut self, pkg: &PackageId, load: &mut RegistryData) -> CargoResult<String> {
+    pub fn hash(&mut self, pkg: PackageId, load: &mut RegistryData) -> CargoResult<String> {
         let name = pkg.name().as_str();
         let version = pkg.version();
         if let Some(s) = self.hashes.get(name).and_then(|v| v.get(version)) {

--- a/src/cargo/sources/registry/local.rs
+++ b/src/cargo/sources/registry/local.rs
@@ -69,7 +69,7 @@ impl<'cfg> RegistryData for LocalRegistry<'cfg> {
         Ok(())
     }
 
-    fn download(&mut self, pkg: &PackageId, checksum: &str) -> CargoResult<MaybeLock> {
+    fn download(&mut self, pkg: PackageId, checksum: &str) -> CargoResult<MaybeLock> {
         let crate_file = format!("{}-{}.crate", pkg.name(), pkg.version());
         let mut crate_file = self.root.open_ro(&crate_file, self.config, "crate file")?;
 
@@ -106,7 +106,7 @@ impl<'cfg> RegistryData for LocalRegistry<'cfg> {
 
     fn finish_download(
         &mut self,
-        _pkg: &PackageId,
+        _pkg: PackageId,
         _checksum: &str,
         _data: &[u8],
     ) -> CargoResult<FileLock> {

--- a/src/cargo/sources/registry/mod.rs
+++ b/src/cargo/sources/registry/mod.rs
@@ -348,15 +348,15 @@ pub trait RegistryData {
     ) -> CargoResult<()>;
     fn config(&mut self) -> CargoResult<Option<RegistryConfig>>;
     fn update_index(&mut self) -> CargoResult<()>;
-    fn download(&mut self, pkg: &PackageId, checksum: &str) -> CargoResult<MaybeLock>;
+    fn download(&mut self, pkg: PackageId, checksum: &str) -> CargoResult<MaybeLock>;
     fn finish_download(
         &mut self,
-        pkg: &PackageId,
+        pkg: PackageId,
         checksum: &str,
         data: &[u8],
     ) -> CargoResult<FileLock>;
 
-    fn is_crate_downloaded(&self, _pkg: &PackageId) -> bool {
+    fn is_crate_downloaded(&self, _pkg: PackageId) -> bool {
         true
     }
 }
@@ -418,7 +418,7 @@ impl<'cfg> RegistrySource<'cfg> {
     /// compiled.
     ///
     /// No action is taken if the source looks like it's already unpacked.
-    fn unpack_package(&self, pkg: &PackageId, tarball: &FileLock) -> CargoResult<PathBuf> {
+    fn unpack_package(&self, pkg: PackageId, tarball: &FileLock) -> CargoResult<PathBuf> {
         let dst = self
             .src_path
             .join(&format!("{}-{}", pkg.name(), pkg.version()));
@@ -475,7 +475,7 @@ impl<'cfg> RegistrySource<'cfg> {
         Ok(())
     }
 
-    fn get_pkg(&mut self, package: &PackageId, path: &FileLock) -> CargoResult<Package> {
+    fn get_pkg(&mut self, package: PackageId, path: &FileLock) -> CargoResult<Package> {
         let path = self
             .unpack_package(package, path)
             .chain_err(|| internal(format!("failed to unpack package `{}`", package)))?;
@@ -566,7 +566,7 @@ impl<'cfg> Source for RegistrySource<'cfg> {
         Ok(())
     }
 
-    fn download(&mut self, package: &PackageId) -> CargoResult<MaybePackage> {
+    fn download(&mut self, package: PackageId) -> CargoResult<MaybePackage> {
         let hash = self.index.hash(package, &mut *self.ops)?;
         match self.ops.download(package, &hash)? {
             MaybeLock::Ready(file) => self.get_pkg(package, &file).map(MaybePackage::Ready),
@@ -576,7 +576,7 @@ impl<'cfg> Source for RegistrySource<'cfg> {
         }
     }
 
-    fn finish_download(&mut self, package: &PackageId, data: Vec<u8>) -> CargoResult<Package> {
+    fn finish_download(&mut self, package: PackageId, data: Vec<u8>) -> CargoResult<Package> {
         let hash = self.index.hash(package, &mut *self.ops)?;
         let file = self.ops.finish_download(package, &hash, &data)?;
         self.get_pkg(package, &file)

--- a/src/cargo/sources/registry/remote.rs
+++ b/src/cargo/sources/registry/remote.rs
@@ -126,7 +126,7 @@ impl<'cfg> RemoteRegistry<'cfg> {
         Ok(Ref::map(self.tree.borrow(), |s| s.as_ref().unwrap()))
     }
 
-    fn filename(&self, pkg: &PackageId) -> String {
+    fn filename(&self, pkg: PackageId) -> String {
         format!("{}-{}.crate", pkg.name(), pkg.version())
     }
 }
@@ -213,7 +213,7 @@ impl<'cfg> RegistryData for RemoteRegistry<'cfg> {
         Ok(())
     }
 
-    fn download(&mut self, pkg: &PackageId, _checksum: &str) -> CargoResult<MaybeLock> {
+    fn download(&mut self, pkg: PackageId, _checksum: &str) -> CargoResult<MaybeLock> {
         let filename = self.filename(pkg);
 
         // Attempt to open an read-only copy first to avoid an exclusive write
@@ -246,7 +246,7 @@ impl<'cfg> RegistryData for RemoteRegistry<'cfg> {
 
     fn finish_download(
         &mut self,
-        pkg: &PackageId,
+        pkg: PackageId,
         checksum: &str,
         data: &[u8],
     ) -> CargoResult<FileLock> {
@@ -269,7 +269,7 @@ impl<'cfg> RegistryData for RemoteRegistry<'cfg> {
         Ok(dst)
     }
 
-    fn is_crate_downloaded(&self, pkg: &PackageId) -> bool {
+    fn is_crate_downloaded(&self, pkg: PackageId) -> bool {
         let filename = format!("{}-{}.crate", pkg.name(), pkg.version());
         let path = Path::new(&filename);
 

--- a/src/cargo/sources/replaced.rs
+++ b/src/cargo/sources/replaced.rs
@@ -70,11 +70,11 @@ impl<'cfg> Source for ReplacedSource<'cfg> {
         Ok(())
     }
 
-    fn download(&mut self, id: &PackageId) -> CargoResult<MaybePackage> {
+    fn download(&mut self, id: PackageId) -> CargoResult<MaybePackage> {
         let id = id.with_source_id(self.replace_with);
         let pkg = self
             .inner
-            .download(&id)
+            .download(id)
             .chain_err(|| format!("failed to download replaced source {}", self.to_replace))?;
         Ok(match pkg {
             MaybePackage::Ready(pkg) => {
@@ -84,11 +84,11 @@ impl<'cfg> Source for ReplacedSource<'cfg> {
         })
     }
 
-    fn finish_download(&mut self, id: &PackageId, data: Vec<u8>) -> CargoResult<Package> {
+    fn finish_download(&mut self, id: PackageId, data: Vec<u8>) -> CargoResult<Package> {
         let id = id.with_source_id(self.replace_with);
         let pkg = self
             .inner
-            .finish_download(&id, data)
+            .finish_download(id, data)
             .chain_err(|| format!("failed to download replaced source {}", self.to_replace))?;
         Ok(pkg.map_source(self.replace_with, self.to_replace))
     }
@@ -97,9 +97,9 @@ impl<'cfg> Source for ReplacedSource<'cfg> {
         self.inner.fingerprint(id)
     }
 
-    fn verify(&self, id: &PackageId) -> CargoResult<()> {
+    fn verify(&self, id: PackageId) -> CargoResult<()> {
         let id = id.with_source_id(self.replace_with);
-        self.inner.verify(&id)
+        self.inner.verify(id)
     }
 
     fn describe(&self) -> String {

--- a/src/cargo/util/machine_message.rs
+++ b/src/cargo/util/machine_message.rs
@@ -16,7 +16,7 @@ pub fn emit<T: Message>(t: &T) {
 
 #[derive(Serialize)]
 pub struct FromCompiler<'a> {
-    pub package_id: &'a PackageId,
+    pub package_id: PackageId,
     pub target: &'a Target,
     pub message: Box<RawValue>,
 }
@@ -29,7 +29,7 @@ impl<'a> Message for FromCompiler<'a> {
 
 #[derive(Serialize)]
 pub struct Artifact<'a> {
-    pub package_id: &'a PackageId,
+    pub package_id: PackageId,
     pub target: &'a Target,
     pub profile: ArtifactProfile,
     pub features: Vec<String>,
@@ -57,7 +57,7 @@ pub struct ArtifactProfile {
 
 #[derive(Serialize)]
 pub struct BuildScript<'a> {
-    pub package_id: &'a PackageId,
+    pub package_id: PackageId,
     pub linked_libs: &'a [String],
     pub linked_paths: &'a [String],
     pub cfgs: &'a [String],

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -666,7 +666,7 @@ impl TomlProject {
 }
 
 struct Context<'a, 'b> {
-    pkgid: Option<&'a PackageId>,
+    pkgid: Option<PackageId>,
     deps: &'a mut Vec<Dependency>,
     source_id: SourceId,
     nested_paths: &'a mut Vec<PathBuf>,
@@ -873,7 +873,7 @@ impl TomlManifest {
 
         {
             let mut cx = Context {
-                pkgid: Some(&pkgid),
+                pkgid: Some(pkgid),
                 deps: &mut deps,
                 source_id,
                 nested_paths: &mut nested_paths,

--- a/tests/testsuite/member_errors.rs
+++ b/tests/testsuite/member_errors.rs
@@ -1,7 +1,7 @@
+use cargo::core::resolver::ResolveError;
 use cargo::core::{compiler::CompileMode, Workspace};
 use cargo::ops::{self, CompileOptions};
 use cargo::util::{config::Config, errors::ManifestError};
-use cargo::core::resolver::ResolveError;
 
 use support::project;
 
@@ -150,5 +150,5 @@ fn member_manifest_version_error() {
     let resolve_err: &ResolveError = error.downcast_ref().expect("Not a ResolveError");
     let package_path = resolve_err.package_path();
     assert_eq!(package_path.len(), 1, "package_path: {:?}", package_path);
-    assert_eq!(&package_path[0], member_bar.package_id());
+    assert_eq!(package_path[0], member_bar.package_id());
 }

--- a/tests/testsuite/resolve.rs
+++ b/tests/testsuite/resolve.rs
@@ -133,7 +133,7 @@ proptest! {
                     let not_selected: Vec<_> = input
                         .iter()
                         .cloned()
-                        .filter(|x| !r.contains(x.package_id()))
+                        .filter(|x| !r.contains(&x.package_id()))
                         .collect();
                     if !not_selected.is_empty() {
                         let indexs_to_unpublish: Vec<_> = indexs_to_unpublish.iter().map(|x| x.get(&not_selected)).collect();
@@ -1001,7 +1001,7 @@ fn incomplete_information_skiping() {
         input
             .iter()
             .cloned()
-            .filter(|x| &package_to_yank != x.package_id())
+            .filter(|x| package_to_yank != x.package_id())
             .collect(),
     );
     assert_eq!(input.len(), new_reg.len() + 1);
@@ -1070,7 +1070,7 @@ fn incomplete_information_skiping_2() {
         input
             .iter()
             .cloned()
-            .filter(|x| &package_to_yank != x.package_id())
+            .filter(|x| package_to_yank != x.package_id())
             .collect(),
     );
     assert_eq!(input.len(), new_reg.len() + 1);
@@ -1120,7 +1120,7 @@ fn incomplete_information_skiping_3() {
         input
             .iter()
             .cloned()
-            .filter(|x| &package_to_yank != x.package_id())
+            .filter(|x| package_to_yank != x.package_id())
             .collect(),
     );
     assert_eq!(input.len(), new_reg.len() + 1);

--- a/tests/testsuite/support/resolver.rs
+++ b/tests/testsuite/support/resolver.rs
@@ -42,7 +42,7 @@ pub fn resolve_and_validated(
             if p.name().ends_with("-sys") {
                 assert!(links.insert(p.name()));
             }
-            stack.extend(resolve.deps(&p).map(|(dp, deps)| {
+            stack.extend(resolve.deps(p).map(|(dp, deps)| {
                 for d in deps {
                     assert!(d.matches_id(dp));
                 }


### PR DESCRIPTION
This is a follow up to #6332. I used clippy to find all the places we called `.clone()`  on a `PackageId` or where we passed `&PackageId`. Yes that touches 44 files and 400+ lines, that is way we wanted `PackageId` to be `copy`.