### PR TITLE
use DYLD_FALLBACK_LIBRARY_PATH for dylib_path_envvar on macOS

### DIFF
--- a/src/cargo/util/paths.rs
+++ b/src/cargo/util/paths.rs
@@ -34,7 +34,18 @@ pub fn dylib_path_envvar() -> &'static str {
     if cfg!(windows) {
         "PATH"
     } else if cfg!(target_os = "macos") {
-        "DYLD_LIBRARY_PATH"
+        // When loading and linking a dynamic library or bundle, dlopen
+        // searches in LD_LIBRARY_PATH, DYLD_LIBRARY_PATH, PWD, and
+        // DYLD_FALLBACK_LIBRARY_PATH.
+        // In the Mach-O format, a dynamic library has an "install path."
+        // Clients linking against the library record this path, and the
+        // dynamic linker, dyld, uses it to locate the library.
+        // dyld searches DYLD_LIBRARY_PATH *before* the install path.
+        // dyld searches DYLD_FALLBACK_LIBRARY_PATH only if it cannot
+        // find the library in the install path.
+        // Setting DYLD_LIBRARY_PATH can easily have unintended
+        // consequences.
+        "DYLD_FALLBACK_LIBRARY_PATH"
     } else {
         "LD_LIBRARY_PATH"
     }


### PR DESCRIPTION
See https://users.rust-lang.org/t/subprocess-and-dynamic-library-linking-problem-interaction/7873/10
See https://trac.macports.org/ticket/57692