### PR TITLE
ConflictStoreTrie: Faster filtered search

### DIFF
--- a/src/cargo/core/resolver/conflict_cache.rs
+++ b/src/cargo/core/resolver/conflict_cache.rs
@@ -11,7 +11,7 @@ enum ConflictStoreTrie {
     Leaf(BTreeMap<PackageId, ConflictReason>),
     /// a Node is a map from an element to a subTrie where
     /// all the Sets in the subTrie contains that element.
-    Node(HashMap<PackageId, ConflictStoreTrie>),
+    Node(BTreeMap<PackageId, ConflictStoreTrie>),
 }
 
 impl ConflictStoreTrie {
@@ -59,7 +59,7 @@ impl ConflictStoreTrie {
         if let Some(pid) = iter.next() {
             if let ConflictStoreTrie::Node(p) = self {
                 p.entry(pid)
-                    .or_insert_with(|| ConflictStoreTrie::Node(HashMap::new()))
+                    .or_insert_with(|| ConflictStoreTrie::Node(BTreeMap::new()))
                     .insert(iter, con);
             } // else, We already have a subset of this in the ConflictStore
         } else {
@@ -159,7 +159,7 @@ impl ConflictCache {
     pub fn insert(&mut self, dep: &Dependency, con: &BTreeMap<PackageId, ConflictReason>) {
         self.con_from_dep
             .entry(dep.clone())
-            .or_insert_with(|| ConflictStoreTrie::Node(HashMap::new()))
+            .or_insert_with(|| ConflictStoreTrie::Node(BTreeMap::new()))
             .insert(con.keys().cloned(), con.clone());
 
         trace!(

--- a/src/cargo/core/resolver/mod.rs
+++ b/src/cargo/core/resolver/mod.rs
@@ -442,9 +442,7 @@ fn activate_deps_loop(
                                 })
                                 .filter_map(|(other_parent, other_dep)| {
                                     past_conflicting_activations
-                                        .find_conflicting(&cx, &other_dep, |con| {
-                                            con.contains_key(&pid)
-                                        })
+                                        .find_conflicting(&cx, &other_dep, Some(pid))
                                         .map(|con| (other_parent, con))
                                 })
                                 .next()

--- a/tests/testsuite/resolve.rs
+++ b/tests/testsuite/resolve.rs
@@ -1201,3 +1201,43 @@ fn large_conflict_cache() {
     let reg = registry(input);
     let _ = resolve(&pkg_id("root"), root_deps, &reg);
 }
+
+#[test]
+fn conflict_store_bug() {
+    let input = vec![
+        pkg!(("A", "0.0.3")),
+        pkg!(("A", "0.0.5")),
+        pkg!(("A", "0.0.9") => [dep("bad"),]),
+        pkg!(("A", "0.0.10") => [dep("bad"),]),
+        pkg!(("L-sys", "0.0.1") => [dep("bad"),]),
+        pkg!(("L-sys", "0.0.5")),
+        pkg!(("R", "0.0.4") => [
+            dep_req("L-sys", "= 0.0.5"),
+        ]),
+        pkg!(("R", "0.0.6")),
+        pkg!(("a-sys", "0.0.5")),
+        pkg!(("a-sys", "0.0.11")),
+        pkg!(("c", "0.0.12") => [
+            dep_req("R", ">= 0.0.3, <= 0.0.4"),
+        ]),
+        pkg!(("c", "0.0.13") => [
+            dep_req("a-sys", ">= 0.0.8, <= 0.0.11"),
+        ]),
+        pkg!(("c0", "0.0.6") => [
+            dep_req("L-sys", "<= 0.0.2"),
+        ]),
+        pkg!(("c0", "0.0.10") => [
+            dep_req("A", ">= 0.0.9, <= 0.0.10"),
+            dep_req("a-sys", "= 0.0.5"),
+        ]),
+        pkg!("j" => [
+            dep_req("A", ">= 0.0.3, <= 0.0.5"),
+            dep_req("R", ">=0.0.4, <= 0.0.6"),
+            dep_req("c", ">= 0.0.9"),
+            dep_req("c0", ">= 0.0.6"),
+        ]),
+    ];
+
+    let reg = registry(input.clone());
+    let _ = resolve_and_validated(&pkg_id("root"), vec![dep("j")], &reg);
+}


### PR DESCRIPTION
This is an optimization that I was thinking of doing in #6283. I did not then as this is optimizing a not particularly hot path. I wish to do it now as it is stuck in my head, and I need that head space for more important things.

This also "accidentally" fixes the [indeterminacy](https://github.com/rust-lang/cargo/pull/6283#issuecomment-443358988) introduced in #6283, by replacing the `HashMap.iter().find()` like code with `BTreeMap.iter().find()` like code. This is not strictly needed, as @alexcrichton pointed out (In most use cases the index will change between any two invocations anyway), but does make it much easier to deal with (fuzz) test cases.