### PR TITLE
Remove `cmake` as a requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ Cargo requires the following tools and packages to build:
 
 * `python`
 * `curl` (on Unix)
-* `cmake`
 * OpenSSL headers (only for Unix, this is the `libssl-dev` package on ubuntu)
 * `cargo` and `rustc`
 


### PR DESCRIPTION
No longer needed as outlined in https://github.com/rust-lang/cargo/issues/6367