### PR TITLE
add `--dry-run` option to cargo update

### DIFF
--- a/src/bin/cargo/commands/publish.rs
+++ b/src/bin/cargo/commands/publish.rs
@@ -19,7 +19,7 @@ pub fn cli() -> App {
         .arg_target_dir()
         .arg_manifest_path()
         .arg_jobs()
-        .arg(opt("dry-run", "Perform all checks without uploading"))
+        .arg_dry_run("Perform all checks without uploading")
         .arg(opt("registry", "Registry to publish to").value_name("REGISTRY"))
 }
 

--- a/src/bin/cargo/commands/update.rs
+++ b/src/bin/cargo/commands/update.rs
@@ -10,6 +10,7 @@ pub fn cli() -> App {
             "aggressive",
             "Force updating all dependencies of <name> as well",
         ))
+        .arg_dry_run("Don't actually write the lockfile")
         .arg(opt("precise", "Update a single dependency to exactly PRECISE").value_name("PRECISE"))
         .arg_manifest_path()
         .after_help(
@@ -44,6 +45,7 @@ pub fn exec(config: &mut Config, args: &ArgMatches<'_>) -> CliResult {
         aggressive: args.is_present("aggressive"),
         precise: args.value_of("precise"),
         to_update: values(args, "package"),
+        dry_run: args.is_present("dry-run"),
         config,
     };
     ops::update_lockfile(&ws, &update_opts)?;

--- a/src/cargo/ops/cargo_generate_lockfile.rs
+++ b/src/cargo/ops/cargo_generate_lockfile.rs
@@ -15,6 +15,7 @@ pub struct UpdateOptions<'a> {
     pub to_update: Vec<String>,
     pub precise: Option<&'a str>,
     pub aggressive: bool,
+    pub dry_run: bool,
 }
 
 pub fn generate_lockfile(ws: &Workspace) -> CargoResult<()> {
@@ -118,8 +119,13 @@ pub fn update_lockfile(ws: &Workspace, opts: &UpdateOptions) -> CargoResult<()> 
             }
         }
     }
-
-    ops::write_pkg_lockfile(ws, &resolve)?;
+    if opts.dry_run {
+        opts.config
+            .shell()
+            .warn("not updating lockfile due to dry run")?;
+    } else {
+        ops::write_pkg_lockfile(ws, &resolve)?;
+    }
     return Ok(());
 
     fn fill_with_deps<'a>(

--- a/src/cargo/util/command_prelude.rs
+++ b/src/cargo/util/command_prelude.rs
@@ -177,6 +177,10 @@ pub trait AppExt: Sized {
                     .hidden(true),
             )
     }
+
+    fn arg_dry_run(self, dry_run: &'static str) -> Self {
+        self._arg(opt("dry-run", dry_run))
+    }
 }
 
 impl AppExt for App {


### PR DESCRIPTION
Hi!

This is just an idea, but what if we had a `--dry-run` argument for `cargo update`, which shows which crates would be updated, without actually writing the lockfile? If this seems useful, I'll write the tests and such. If we can leave without it, feel free to close. 

Context: at ferrous-systems, we put together a [small tool](https://github.com/ferrous-systems/cargo-review-deps) to review the source code changes between different versions of the same crate. This obviously was inspired by the most recent npm incident. While implementing the tool, I thought that having `--dry-run` might also be useful for folks who a cautious about updating. IE, you could run `cargo update --dry-run` once to see what **could** be updated, and follow up with a series of `update -p --precise`, to do the update in minimal steps, reviewing the actual source each time. 