### PR TITLE
Create .gitignore even if inside existing repository `cargo new`

### DIFF
--- a/src/cargo/ops/cargo_new.rs
+++ b/src/cargo/ops/cargo_new.rs
@@ -459,19 +459,19 @@ impl IgnoreList {
             _ => &self.ignore,
         };
 
-        let mut out = "\n\n#Added by cargo\n\
-                       #\n\
-                       #already existing elements are commented out\n\n"
-            .to_string();
+        let mut out = "".to_string();
 
         for item in ignore_items {
             if existing_items.contains(item) {
-                out.push('#');
+                continue
             }
             out.push_str(item);
-            out.push('\n');
+            out.push_str("\n");
         }
 
+        if !out.is_empty() && !existing_items.is_empty() {
+            out.insert_str(0, "\n");
+        }
         out
     }
 }
@@ -506,7 +506,7 @@ fn write_ignore_file(
 }
 
 /// Initializes the correct VCS system based on the provided config.
-fn init_vcs(root: &Path, path: & Path, vcs: VersionControl, config: &Config) -> CargoResult<()> {
+fn init_vcs(root: &Path, path: &Path, vcs: VersionControl, config: &Config) -> CargoResult<()> {
     match vcs {
         VersionControl::Git => {
             if !root.join(".git").exists() {
@@ -528,7 +528,7 @@ fn init_vcs(root: &Path, path: & Path, vcs: VersionControl, config: &Config) -> 
                 FossilRepo::init(path, config.cwd())?;
             }
         }
-        VersionControl::NoVcs => { }
+        VersionControl::NoVcs => {}
     };
 
     if !path.exists() {
@@ -547,7 +547,7 @@ fn mk(config: &Config, opts: &MkOptions<'_>) -> CargoResult<()> {
     // Using the push method with two arguments ensures that the entries for
     // both `ignore` and `hgignore` are in sync.
     let mut ignore = IgnoreList::new();
-    ignore.push("/target", "^target/");
+    ignore.push("**/target", "^target/");
     ignore.push("**/*.rs.bk", "glob:*.rs.bk");
     if !opts.bin {
         ignore.push("Cargo.lock", "glob:Cargo.lock");
@@ -561,7 +561,7 @@ fn mk(config: &Config, opts: &MkOptions<'_>) -> CargoResult<()> {
             (_, Some((root, vcs))) => {
                 project_root = root;
                 vcs
-            },
+            }
         }
     });
 

--- a/src/cargo/ops/fix.rs
+++ b/src/cargo/ops/fix.rs
@@ -116,7 +116,7 @@ fn check_version_control(opts: &FixOptions<'_>) -> CargoResult<()> {
         return Ok(());
     }
     let config = opts.compile_opts.config;
-    if !existing_vcs_repo(config.cwd(), config.cwd()) {
+    if existing_vcs_repo(config.cwd(), config.cwd()).is_none() {
         failure::bail!(
             "no VCS found for this package and `cargo fix` can potentially \
              perform destructive changes; if you'd like to suppress this \

--- a/src/cargo/util/vcs.rs
+++ b/src/cargo/util/vcs.rs
@@ -50,7 +50,7 @@ impl HgRepo {
         Ok(HgRepo)
     }
     pub fn discover(path: &Path, cwd: &Path) -> CargoResult<Option<(PathBuf, VersionControl)>> {
-        let mut stdout = process("hg")
+        let stdout = process("hg")
             .cwd(cwd)
             .arg("--cwd")
             .arg(path)
@@ -58,11 +58,9 @@ impl HgRepo {
             .exec_with_output()?
             .stdout;
 
-        // We remove the last new-line character from stdout
-        stdout = stdout[ .. stdout.len() - 1].to_vec();
-
         let root = String::from_utf8(stdout)?;
-        Ok(Some((PathBuf::from(root), Hg)))
+        // We remove the last new-line character from stdout
+        Ok(Some((PathBuf::from(root.trim()), Hg)))
     }
 }
 

--- a/src/cargo/util/vcs.rs
+++ b/src/cargo/util/vcs.rs
@@ -14,8 +14,8 @@ use crate::ops::VersionControl::{self, Hg, Git};
 pub fn existing_vcs_repo(path: &Path, cwd: &Path) -> Option<(PathBuf, VersionControl)> {
     fn in_git_repo(path: &Path, cwd: &Path) -> Option<(PathBuf, VersionControl)> {
         if let Ok(repo) = GitRepo::discover(path, cwd) {
-            // Don't check if the working directory itself is ignored.
             let workdir = repo.workdir()?;
+            // Don't check if the working directory itself is ignored.
             if workdir == path || !repo.is_path_ignored(path).unwrap_or(false) {
                 Some((workdir.to_path_buf(), Git))
             } else {

--- a/tests/testsuite/new.rs
+++ b/tests/testsuite/new.rs
@@ -89,7 +89,7 @@ fn simple_git() {
         .unwrap()
         .read_to_string(&mut contents)
         .unwrap();
-    assert_eq!(contents, "/target\n**/*.rs.bk\nCargo.lock\n",);
+    assert_eq!(contents, "**/target\n**/*.rs.bk\nCargo.lock\n",);
 
     cargo_process("build").cwd(&paths::root().join("foo")).run();
 }

--- a/tests/testsuite/new.rs
+++ b/tests/testsuite/new.rs
@@ -522,3 +522,31 @@ fn new_with_blank_email() {
     let contents = fs::read_to_string(paths::root().join("foo/Cargo.toml")).unwrap();
     assert!(contents.contains(r#"authors = ["Sen"]"#), contents);
 }
+
+#[test]
+fn new_in_existing_git_repository() {
+    git_process("init foo").exec().unwrap();
+
+    assert!(paths::root().join("foo/.git").is_dir());
+    assert!(
+        !paths::root()
+            .join("foo/.gitignore")
+            .is_file()
+    );
+
+    cargo_process("new bar")
+        .env("USER", "foo")
+        .cwd("foo")
+        .run();
+
+    assert!(
+        paths::root()
+            .join("foo/.gitignore")
+            .is_file()
+    );
+    assert!(
+        paths::root()
+            .join("foo/bar")
+            .is_dir()
+    )
+}


### PR DESCRIPTION
Creates a VCS .ignore file if it doesn't exist or adds paths to be ignored when the project is created/initialized in an already existing VCS repository.

Fixes  #6357