### PR TITLE
Fix built-in aliases taking arguments.

### DIFF
--- a/src/bin/cargo/commands/build.rs
+++ b/src/bin/cargo/commands/build.rs
@@ -4,7 +4,7 @@ use cargo::ops;
 
 pub fn cli() -> App {
     subcommand("build")
-        // subcommand aliases are handled in commands::builtin_exec() and cli::expand_aliases()
+        // subcommand aliases are handled in aliased_command()
         // .alias("b")
         .about("Compile a local package and all of its dependencies")
         .arg_package_spec(

--- a/src/bin/cargo/commands/check.rs
+++ b/src/bin/cargo/commands/check.rs
@@ -4,7 +4,7 @@ use cargo::ops;
 
 pub fn cli() -> App {
     subcommand("check")
-        // subcommand aliases are handled in commands::builtin_exec() and cli::expand_aliases()
+        // subcommand aliases are handled in aliased_command()
         // .alias("c")
         .about("Check a local package and all of its dependencies for errors")
         .arg_package_spec(

--- a/src/bin/cargo/commands/mod.rs
+++ b/src/bin/cargo/commands/mod.rs
@@ -35,16 +35,11 @@ pub fn builtin() -> Vec<App> {
     ]
 }
 
-pub struct BuiltinExec<'a> {
-    pub exec: fn(&'a mut Config, &'a ArgMatches) -> CliResult,
-    pub alias_for: Option<&'static str>,
-}
-
-pub fn builtin_exec(cmd: &str) -> Option<BuiltinExec> {
-    let exec = match cmd {
+ pub fn builtin_exec(cmd: &str) -> Option<fn(&mut Config, &ArgMatches) -> CliResult> {
+     let f = match cmd {
         "bench" => bench::exec,
-        "build" | "b" => build::exec,
-        "check" | "c" => check::exec,
+        "build" => build::exec,
+        "check" => check::exec,
         "clean" => clean::exec,
         "doc" => doc::exec,
         "fetch" => fetch::exec,
@@ -62,11 +57,11 @@ pub fn builtin_exec(cmd: &str) -> Option<BuiltinExec> {
         "pkgid" => pkgid::exec,
         "publish" => publish::exec,
         "read-manifest" => read_manifest::exec,
-        "run" | "r" => run::exec,
+        "run" => run::exec,
         "rustc" => rustc::exec,
         "rustdoc" => rustdoc::exec,
         "search" => search::exec,
-        "test" | "t" => test::exec,
+        "test" => test::exec,
         "uninstall" => uninstall::exec,
         "update" => update::exec,
         "verify-project" => verify_project::exec,
@@ -74,16 +69,7 @@ pub fn builtin_exec(cmd: &str) -> Option<BuiltinExec> {
         "yank" => yank::exec,
         _ => return None,
     };
-
-    let alias_for = match cmd {
-        "b" => Some("build"),
-        "c" => Some("check"),
-        "r" => Some("run"),
-        "t" => Some("test"),
-        _ => None,
-    };
-
-    Some(BuiltinExec { exec, alias_for })
+    Some(f)
 }
 
 pub mod bench;

--- a/src/bin/cargo/commands/run.rs
+++ b/src/bin/cargo/commands/run.rs
@@ -5,7 +5,7 @@ use cargo::ops::{self, CompileFilter};
 
 pub fn cli() -> App {
     subcommand("run")
-        // subcommand aliases are handled in commands::builtin_exec() and cli::expand_aliases()
+        // subcommand aliases are handled in aliased_command()
         // .alias("r")
         .setting(AppSettings::TrailingVarArg)
         .about("Run the main binary of the local package (src/main.rs)")

--- a/src/bin/cargo/commands/test.rs
+++ b/src/bin/cargo/commands/test.rs
@@ -4,7 +4,7 @@ use cargo::ops::{self, CompileFilter};
 
 pub fn cli() -> App {
     subcommand("test")
-        // subcommand aliases are handled in commands::builtin_exec() and cli::expand_aliases()
+        // subcommand aliases are handled in aliased_command()
         // .alias("t")
         .setting(AppSettings::TrailingVarArg)
         .about("Execute all unit and integration tests of a local package")

--- a/tests/testsuite/cargo_alias_config.rs
+++ b/tests/testsuite/cargo_alias_config.rs
@@ -148,3 +148,17 @@ fn alias_override_builtin_alias() {
 ",
         ).run();
 }
+
+#[test]
+fn builtin_alias_takes_options() {
+    // #6381
+    let p = project()
+        .file("src/lib.rs", "")
+        .file(
+            "examples/ex1.rs",
+            r#"fn main() { println!("{}", std::env::args().skip(1).next().unwrap()) }"#,
+        )
+        .build();
+
+    p.cargo("r --example ex1 -- asdf").with_stdout("asdf").run();
+}


### PR DESCRIPTION
The built-in aliases weren't parsing their arguments. Change implementation to treat built-in aliases the same as user aliases.

Fixes #6381
