### PR TITLE
Make it clearer that rustup will also install cargo

### DIFF
--- a/src/doc/src/getting-started/installation.md
+++ b/src/doc/src/getting-started/installation.md
@@ -3,7 +3,7 @@
 ### Install Rust and Cargo
 
 The easiest way to get Cargo is to install the current stable release of [Rust]
-by using `rustup`.
+by using `rustup`. Installing Rust using `rustup` will also install `cargo`.
 
 On Linux and macOS systems, this is done as follows:
 


### PR DESCRIPTION
Make it clearer that cargo is automatically installed when installing Rust using `rustup`.