### PR TITLE
Fix spurious error for test json_artifact_includes_test_flag

### DIFF
--- a/tests/testsuite/test.rs
+++ b/tests/testsuite/test.rs
@@ -2992,32 +2992,9 @@ fn json_artifact_includes_test_flag() {
         ).file("src/lib.rs", "")
         .build();
 
-    p.cargo("test -v --message-format=json")
+    p.cargo("test --lib -v --message-format=json")
         .with_json(
             r#"
-    {
-        "reason":"compiler-artifact",
-        "profile": {
-            "debug_assertions": true,
-            "debuginfo": 2,
-            "opt_level": "0",
-            "overflow_checks": true,
-            "test": false
-        },
-        "executable": null,
-        "features": [],
-        "package_id":"foo 0.0.1 ([..])",
-        "target":{
-            "kind":["lib"],
-            "crate_types":["lib"],
-            "edition": "2015",
-            "name":"foo",
-            "src_path":"[..]lib.rs"
-        },
-        "filenames":["[..].rlib"],
-        "fresh": false
-    }
-
     {
         "reason":"compiler-artifact",
         "profile": {


### PR DESCRIPTION
There is a race condition for which job finishes first. On CI I am able
to reproduce the error about 1% of the time.

Recent failures:
- https://ci.appveyor.com/project/rust-lang-libs/cargo/builds/20151768/job/oghwemec7b19turs
- https://travis-ci.org/rust-lang/cargo/jobs/464717439