### PR TITLE
progress.rs: don't fail if not a tty

### DIFF
--- a/src/bin/cargo/cli.rs
+++ b/src/bin/cargo/cli.rs
@@ -150,6 +150,11 @@ fn execute_subcommand(config: &mut Config, args: &ArgMatches<'_>) -> CliResult {
         } else {
             None
         },
+        if args.is_present("progress") {
+            Some(true)
+        } else {
+            None
+        },
         &args.value_of("color").map(|s| s.to_string()),
         args.is_present("frozen"),
         args.is_present("locked"),
@@ -220,6 +225,10 @@ See 'cargo help <command>' for more information on a specific command.\n",
         .arg(
             opt("quiet", "No output printed to stdout")
                 .short("q")
+                .global(true),
+        )
+        .arg(
+            opt("progress", "Force output of progress updates")
                 .global(true),
         )
         .arg(

--- a/src/cargo/core/shell.rs
+++ b/src/cargo/core/shell.rs
@@ -26,6 +26,7 @@ pub struct Shell {
     /// Flag that indicates the current line needs to be cleared before
     /// printing. Used when a progress bar is currently displayed.
     needs_clear: bool,
+    force_progress: bool,
 }
 
 impl fmt::Debug for Shell {
@@ -79,6 +80,7 @@ impl Shell {
             },
             verbosity: Verbosity::Verbose,
             needs_clear: false,
+            force_progress: false,
         }
     }
 
@@ -88,6 +90,7 @@ impl Shell {
             err: ShellOut::Write(out),
             verbosity: Verbosity::Verbose,
             needs_clear: false,
+            force_progress: false,
         }
     }
 
@@ -226,6 +229,16 @@ impl Shell {
     /// Gets the verbosity of the shell.
     pub fn verbosity(&self) -> Verbosity {
         self.verbosity
+    }
+
+    /// Forces output of progress updates
+    pub fn set_force_progress(&mut self, force_progress: bool) {
+        self.force_progress = force_progress;
+    }
+
+    /// Checks whether to force output of progress updates
+    pub fn force_progress(&self) -> bool {
+        self.force_progress
     }
 
     /// Updates the color choice (always, never, or auto) from a string..

--- a/src/cargo/util/config.rs
+++ b/src/cargo/util/config.rs
@@ -544,6 +544,7 @@ impl Config {
         &mut self,
         verbose: u32,
         quiet: Option<bool>,
+        force_progress: Option<bool>,
         color: &Option<String>,
         frozen: bool,
         locked: bool,
@@ -588,6 +589,9 @@ impl Config {
 
         self.shell().set_verbosity(verbosity);
         self.shell().set_color_choice(color.map(|s| &s[..]))?;
+        if let Some(force_progress) = force_progress {
+            self.shell().set_force_progress(force_progress);
+        }
         self.extra_verbose = extra_verbose;
         self.frozen = frozen;
         self.locked = locked;

--- a/src/cargo/util/progress.rs
+++ b/src/cargo/util/progress.rs
@@ -49,8 +49,14 @@ impl<'cfg> Progress<'cfg> {
             return Progress { state: None };
         }
 
+        let err_width = if cfg.shell().force_progress() {
+            Some(cfg.shell().err_width().unwrap_or(80))
+        } else {
+            cfg.shell().err_width()
+        };
+
         Progress {
-            state: cfg.shell().err_width().map(|n| State {
+            state: err_width.map(|n| State {
                 config: cfg,
                 format: Format {
                     style,

--- a/tests/testsuite/config.rs
+++ b/tests/testsuite/config.rs
@@ -58,6 +58,7 @@ fn new_config(env: &[(&str, &str)]) -> Config {
         .configure(
             0,
             None,
+            None,
             &None,
             false,
             false,

--- a/tests/testsuite/resolve.rs
+++ b/tests/testsuite/resolve.rs
@@ -65,6 +65,7 @@ proptest! {
             .configure(
                 1,
                 None,
+                None,
                 &None,
                 false,
                 false,
@@ -399,6 +400,7 @@ fn test_resolving_minimum_version_with_transitive_deps() {
     config
         .configure(
             1,
+            None,
             None,
             &None,
             false,


### PR DESCRIPTION
It's not clear that it was intentional for progress to be disabled when
the output is not a tty.  Indeed there is reason we might want to have
progress output in that case.  For example, when cargo is invoked by
bitbake, cargo's output will be run through a pipe.  Bitbake can parse
out progress updates from that output, but only if cargo actually emits
them...