### PR TITLE
Only ensure solutions are in the same file in cargo fix

### DIFF
--- a/src/cargo/ops/fix.rs
+++ b/src/cargo/ops/fix.rs
@@ -400,21 +400,21 @@ fn rustfix_and_fix(
     for suggestion in suggestions {
         trace!("suggestion");
         // Make sure we've got a file associated with this suggestion and all
-        // snippets point to the same location. Right now it's not clear what
-        // we would do with multiple locations.
-        let (file_name, range) = match suggestion.snippets.get(0) {
-            Some(s) => (s.file_name.clone(), s.line_range),
+        // snippets point to the same file. Right now it's not clear what
+        // we would do with multiple files.
+        let file_name = match suggestion.solutions.get(0).and_then(|sol| sol.replacements.get(0)) {
+            Some(s) => s.snippet.file_name.clone(),
             None => {
-                trace!("rejecting as it has no snippets {:?}", suggestion);
+                trace!("rejecting as it has no solutions {:?}", suggestion);
                 continue;
             }
         };
         if !suggestion
-            .snippets
+            .solutions
             .iter()
-            .all(|s| s.file_name == file_name && s.line_range == range)
+            .all(|sol| sol.replacements.iter().all(|rep| rep.snippet.file_name == file_name))
         {
-            trace!("rejecting as it spans multiple files {:?}", suggestion);
+            trace!("rejecting as it changes multiple files: {:?}", suggestion);
             continue;
         }
 

--- a/src/cargo/ops/fix.rs
+++ b/src/cargo/ops/fix.rs
@@ -402,18 +402,18 @@ fn rustfix_and_fix(
         // Make sure we've got a file associated with this suggestion and all
         // snippets point to the same file. Right now it's not clear what
         // we would do with multiple files.
-        let file_name = match suggestion.solutions.get(0).and_then(|sol| sol.replacements.get(0)) {
-            Some(s) => s.snippet.file_name.clone(),
-            None => {
-                trace!("rejecting as it has no solutions {:?}", suggestion);
-                continue;
-            }
+        let file_names = suggestion.solutions.iter()
+            .flat_map(|s| s.replacements.iter())
+            .map(|r| &r.snippet.file_name);
+
+        let file_name = if let Some(file_name) = file_names.clone().next() {
+            file_name.clone()
+        } else {
+            trace!("rejecting as it has no solutions {:?}", suggestion);
+            continue;
         };
-        if !suggestion
-            .solutions
-            .iter()
-            .all(|sol| sol.replacements.iter().all(|rep| rep.snippet.file_name == file_name))
-        {
+
+        if !file_names.clone().all(|f| f == &file_name) {
             trace!("rejecting as it changes multiple files: {:?}", suggestion);
             continue;
         }


### PR DESCRIPTION
This PR changes `cargo fix` to avoid rejecting machine-applicable lints with multiple suggestions. Instead, now it only checks the solutions are in the same file.

I don't know how to write a test for this, since no lint in rustc relies on the new behavior and the existing `cargo fix` tests just invoke lints in rustc. Any idea on that would be appreciated.

r? @alexcrichton 
cc @killercup 
fixes https://github.com/rust-lang/cargo/issues/6401