### PR TITLE
Fix flakey broken_fixes_backed_out test.

### DIFF
--- a/tests/testsuite/fix.rs
+++ b/tests/testsuite/fix.rs
@@ -123,7 +123,7 @@ fn broken_fixes_backed_out() {
     p.cargo("build").cwd(p.root().join("foo")).run();
 
     // Attempt to fix code, but our shim will always fail the second compile
-    p.cargo("fix --allow-no-vcs")
+    p.cargo("fix --allow-no-vcs --lib")
         .cwd(p.root().join("bar"))
         .env("__CARGO_FIX_YOLO", "1")
         .env("RUSTC", p.root().join("foo/target/debug/foo"))


### PR DESCRIPTION
Since `fix` does `--all-targets` there is a race condition as to which target goes first. This has less than a 1% failure rate on CI, but it has been seen several times lately:

https://ci.appveyor.com/project/rust-lang-libs/cargo/builds/20878003/job/v01k5j14od50mghw
https://ci.appveyor.com/project/rust-lang-libs/cargo/builds/18699824/job/465w7uav7ew24yka
https://ci.appveyor.com/project/rust-lang-libs/cargo/builds/17283788/job/7cxp8bwm4d3i1xgl