### PR TITLE
Migrate to some Rust 2018 idioms

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,8 +48,7 @@ opener = "0.3.0"
 rustfix = "0.4.2"
 same-file = "1"
 semver = { version = "0.9.0", features = ["serde"] }
-serde = "1.0"
-serde_derive = "1.0"
+serde = { version = "1.0", features = ['derive'] }
 serde_ignored = "0.0.4"
 serde_json = { version = "1.0.30", features = ["raw_value"] }
 shell-escape = "0.1.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,18 +37,18 @@ glob = "0.2.11"
 hex = "0.3"
 home = "0.3"
 ignore = "0.4"
-lazy_static = "1.0.0"
+lazy_static = "1.2.0"
 jobserver = "0.1.11"
 lazycell = "1.2.0"
 libc = "0.2"
-log = "0.4"
+log = "0.4.6"
 libgit2-sys = "0.7.9"
 num_cpus = "1.0"
 opener = "0.3.0"
 rustfix = "0.4.2"
 same-file = "1"
 semver = { version = "0.9.0", features = ["serde"] }
-serde = { version = "1.0", features = ['derive'] }
+serde = { version = "1.0.82", features = ['derive'] }
 serde_ignored = "0.0.4"
 serde_json = { version = "1.0.30", features = ["raw_value"] }
 shell-escape = "0.1.4"

--- a/src/bin/cargo/commands/locate_project.rs
+++ b/src/bin/cargo/commands/locate_project.rs
@@ -1,6 +1,7 @@
 use crate::command_prelude::*;
 
 use cargo::print_json;
+use serde::Serialize;
 
 pub fn cli() -> App {
     subcommand("locate-project")

--- a/src/bin/cargo/main.rs
+++ b/src/bin/cargo/main.rs
@@ -1,18 +1,8 @@
-#![cfg_attr(feature = "cargo-clippy", allow(clippy::too_many_arguments))] // large project
-#![cfg_attr(feature = "cargo-clippy", allow(clippy::redundant_closure))] // there's a false positive
+#![allow(clippy::too_many_arguments)] // large project
+#![allow(clippy::redundant_closure)] // there's a false positive
 
-use cargo;
-
-#[cfg(not(feature = "pretty-env-logger"))]
-extern crate env_logger;
-#[cfg(feature = "pretty-env-logger")]
-extern crate pretty_env_logger;
 #[macro_use]
 extern crate failure;
-use git2_curl;
-
-#[macro_use]
-extern crate serde_derive;
 
 use std::collections::BTreeSet;
 use std::env;

--- a/src/bin/cargo/main.rs
+++ b/src/bin/cargo/main.rs
@@ -1,3 +1,4 @@
+#![warn(rust_2018_idioms)] // while we're getting used to 2018
 #![allow(clippy::too_many_arguments)] // large project
 #![allow(clippy::redundant_closure)] // there's a false positive
 

--- a/src/cargo/core/compiler/build_context/mod.rs
+++ b/src/cargo/core/compiler/build_context/mod.rs
@@ -160,7 +160,7 @@ impl<'a, 'cfg> BuildContext<'a, 'cfg> {
         self.build_config.jobs
     }
 
-    pub fn rustflags_args(&self, unit: &Unit) -> CargoResult<Vec<String>> {
+    pub fn rustflags_args(&self, unit: &Unit<'_>) -> CargoResult<Vec<String>> {
         env_args(
             self.config,
             &self.build_config.requested_target,
@@ -171,7 +171,7 @@ impl<'a, 'cfg> BuildContext<'a, 'cfg> {
         )
     }
 
-    pub fn rustdocflags_args(&self, unit: &Unit) -> CargoResult<Vec<String>> {
+    pub fn rustdocflags_args(&self, unit: &Unit<'_>) -> CargoResult<Vec<String>> {
         env_args(
             self.config,
             &self.build_config.requested_target,

--- a/src/cargo/core/compiler/build_context/mod.rs
+++ b/src/cargo/core/compiler/build_context/mod.rs
@@ -3,6 +3,8 @@ use std::env;
 use std::path::{Path, PathBuf};
 use std::str;
 
+use log::debug;
+
 use crate::core::profiles::Profiles;
 use crate::core::{Dependency, Workspace};
 use crate::core::{PackageId, PackageSet, Resolve};

--- a/src/cargo/core/compiler/build_context/target_info.rs
+++ b/src/cargo/core/compiler/build_context/target_info.rs
@@ -259,7 +259,7 @@ impl TargetInfo {
 fn parse_crate_type(
     crate_type: &str,
     error: &str,
-    lines: &mut str::Lines,
+    lines: &mut str::Lines<'_>,
 ) -> CargoResult<Option<(String, String)>> {
     let not_supported = error.lines().any(|line| {
         (line.contains("unsupported crate type") || line.contains("unknown crate type"))

--- a/src/cargo/core/compiler/build_plan.rs
+++ b/src/cargo/core/compiler/build_plan.rs
@@ -7,14 +7,14 @@
 //! dependencies on other Invocations.
 
 use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+use serde::Serialize;
 
 use super::context::OutputFile;
 use super::{CompileMode, Context, Kind, Unit};
 use crate::core::TargetKind;
 use crate::util::{internal, CargoResult, ProcessBuilder};
-use semver;
-use serde_json;
-use std::path::PathBuf;
 
 #[derive(Debug, Serialize)]
 struct Invocation {

--- a/src/cargo/core/compiler/build_plan.rs
+++ b/src/cargo/core/compiler/build_plan.rs
@@ -45,7 +45,7 @@ struct SerializedBuildPlan {
 }
 
 impl Invocation {
-    pub fn new(unit: &Unit, deps: Vec<usize>) -> Invocation {
+    pub fn new(unit: &Unit<'_>, deps: Vec<usize>) -> Invocation {
         let id = unit.pkg.package_id();
         Invocation {
             package_name: id.name().to_string(),
@@ -109,7 +109,7 @@ impl BuildPlan {
         }
     }
 
-    pub fn add(&mut self, cx: &Context, unit: &Unit) -> CargoResult<()> {
+    pub fn add(&mut self, cx: &Context<'_, '_>, unit: &Unit<'_>) -> CargoResult<()> {
         let id = self.plan.invocations.len();
         self.invocation_map.insert(unit.buildkey(), id);
         let deps = cx

--- a/src/cargo/core/compiler/compilation.rs
+++ b/src/cargo/core/compiler/compilation.rs
@@ -256,7 +256,7 @@ fn pre_version_component(v: &Version) -> String {
     ret
 }
 
-fn target_runner(bcx: &BuildContext) -> CargoResult<Option<(PathBuf, Vec<String>)>> {
+fn target_runner(bcx: &BuildContext<'_, '_>) -> CargoResult<Option<(PathBuf, Vec<String>)>> {
     let target = bcx.target_triple();
 
     // try target.{}.runner

--- a/src/cargo/core/compiler/context/compilation_files.rs
+++ b/src/cargo/core/compiler/context/compilation_files.rs
@@ -6,6 +6,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use lazycell::LazyCell;
+use log::info;
 
 use super::{BuildContext, Context, FileFlavor, Kind, Layout, Unit};
 use crate::core::{TargetKind, Workspace};

--- a/src/cargo/core/compiler/context/compilation_files.rs
+++ b/src/cargo/core/compiler/context/compilation_files.rs
@@ -16,7 +16,7 @@ use crate::util::{self, CargoResult};
 pub struct Metadata(u64);
 
 impl fmt::Display for Metadata {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{:016x}", self.0)
     }
 }
@@ -107,7 +107,7 @@ impl<'a, 'cfg: 'a> CompilationFiles<'a, 'cfg> {
 
     /// Get the short hash based only on the PackageId
     /// Used for the metadata when target_metadata returns None
-    pub fn target_short_hash(&self, unit: &Unit) -> String {
+    pub fn target_short_hash(&self, unit: &Unit<'_>) -> String {
         let hashable = unit.pkg.package_id().stable_hash(self.ws.root());
         util::short_hash(&hashable)
     }
@@ -149,7 +149,7 @@ impl<'a, 'cfg: 'a> CompilationFiles<'a, 'cfg> {
 
     /// Returns the directories where Rust crate dependencies are found for the
     /// specified unit.
-    pub fn deps_dir(&self, unit: &Unit) -> &Path {
+    pub fn deps_dir(&self, unit: &Unit<'_>) -> &Path {
         self.layout(unit.kind).deps()
     }
 
@@ -193,7 +193,7 @@ impl<'a, 'cfg: 'a> CompilationFiles<'a, 'cfg> {
     }
 
     /// Returns the bin stem for a given target (without metadata)
-    fn bin_stem(&self, unit: &Unit) -> String {
+    fn bin_stem(&self, unit: &Unit<'_>) -> String {
         if unit.target.allows_underscores() {
             unit.target.name().to_string()
         } else {

--- a/src/cargo/core/compiler/context/mod.rs
+++ b/src/cargo/core/compiler/context/mod.rs
@@ -471,20 +471,21 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
 
     fn check_collistions(&self) -> CargoResult<()> {
         let mut output_collisions = HashMap::new();
-        let describe_collision = |unit: &Unit<'_>, other_unit: &Unit<'_>, path: &PathBuf| -> String {
-            format!(
-                "The {} target `{}` in package `{}` has the same output \
-                 filename as the {} target `{}` in package `{}`.\n\
-                 Colliding filename is: {}\n",
-                unit.target.kind().description(),
-                unit.target.name(),
-                unit.pkg.package_id(),
-                other_unit.target.kind().description(),
-                other_unit.target.name(),
-                other_unit.pkg.package_id(),
-                path.display()
-            )
-        };
+        let describe_collision =
+            |unit: &Unit<'_>, other_unit: &Unit<'_>, path: &PathBuf| -> String {
+                format!(
+                    "The {} target `{}` in package `{}` has the same output \
+                     filename as the {} target `{}` in package `{}`.\n\
+                     Colliding filename is: {}\n",
+                    unit.target.kind().description(),
+                    unit.target.name(),
+                    unit.pkg.package_id(),
+                    other_unit.target.kind().description(),
+                    other_unit.target.name(),
+                    other_unit.pkg.package_id(),
+                    path.display()
+                )
+            };
         let suggestion = "Consider changing their names to be unique or compiling them separately.\n\
             This may become a hard error in the future, see https://github.com/rust-lang/cargo/issues/6313";
         let report_collision = |unit: &Unit<'_>,

--- a/src/cargo/core/compiler/context/mod.rs
+++ b/src/cargo/core/compiler/context/mod.rs
@@ -129,7 +129,7 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
         mut self,
         units: &[Unit<'a>],
         export_dir: Option<PathBuf>,
-        exec: &Arc<Executor>,
+        exec: &Arc<dyn Executor>,
     ) -> CargoResult<Compilation<'cfg>> {
         let mut queue = JobQueue::new(self.bcx);
         let mut plan = BuildPlan::new();
@@ -386,7 +386,7 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
         deps
     }
 
-    pub fn incremental_args(&self, unit: &Unit) -> CargoResult<Vec<String>> {
+    pub fn incremental_args(&self, unit: &Unit<'_>) -> CargoResult<Vec<String>> {
         // There's a number of ways to configure incremental compilation right
         // now. In order of descending priority (first is highest priority) we
         // have:
@@ -471,7 +471,7 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
 
     fn check_collistions(&self) -> CargoResult<()> {
         let mut output_collisions = HashMap::new();
-        let describe_collision = |unit: &Unit, other_unit: &Unit, path: &PathBuf| -> String {
+        let describe_collision = |unit: &Unit<'_>, other_unit: &Unit<'_>, path: &PathBuf| -> String {
             format!(
                 "The {} target `{}` in package `{}` has the same output \
                  filename as the {} target `{}` in package `{}`.\n\
@@ -487,8 +487,8 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
         };
         let suggestion = "Consider changing their names to be unique or compiling them separately.\n\
             This may become a hard error in the future, see https://github.com/rust-lang/cargo/issues/6313";
-        let report_collision = |unit: &Unit,
-                                other_unit: &Unit,
+        let report_collision = |unit: &Unit<'_>,
+                                other_unit: &Unit<'_>,
                                 path: &PathBuf|
          -> CargoResult<()> {
             if unit.target.name() == other_unit.target.name() {
@@ -567,7 +567,7 @@ impl Links {
         }
     }
 
-    pub fn validate(&mut self, resolve: &Resolve, unit: &Unit) -> CargoResult<()> {
+    pub fn validate(&mut self, resolve: &Resolve, unit: &Unit<'_>) -> CargoResult<()> {
         if !self.validated.insert(unit.pkg.package_id()) {
             return Ok(());
         }

--- a/src/cargo/core/compiler/context/unit_dependencies.rs
+++ b/src/cargo/core/compiler/context/unit_dependencies.rs
@@ -18,6 +18,8 @@
 use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
 
+use log::trace;
+
 use super::{BuildContext, CompileMode, Kind, Unit};
 use crate::core::dependency::Kind as DepKind;
 use crate::core::package::Downloads;

--- a/src/cargo/core/compiler/context/unit_dependencies.rs
+++ b/src/cargo/core/compiler/context/unit_dependencies.rs
@@ -347,7 +347,10 @@ fn maybe_lib<'a>(
 /// script itself doesn't have any dependencies, so even in that case a unit
 /// of work is still returned. `None` is only returned if the package has no
 /// build script.
-fn dep_build_script<'a>(unit: &Unit<'a>, bcx: &BuildContext<'_, '_>) -> Option<(Unit<'a>, UnitFor)> {
+fn dep_build_script<'a>(
+    unit: &Unit<'a>,
+    bcx: &BuildContext<'_, '_>,
+) -> Option<(Unit<'a>, UnitFor)> {
     unit.pkg
         .targets()
         .iter()

--- a/src/cargo/core/compiler/context/unit_dependencies.rs
+++ b/src/cargo/core/compiler/context/unit_dependencies.rs
@@ -330,7 +330,7 @@ fn compute_deps_doc<'a, 'cfg, 'tmp>(
 
 fn maybe_lib<'a>(
     unit: &Unit<'a>,
-    bcx: &BuildContext,
+    bcx: &BuildContext<'_, '_>,
     unit_for: UnitFor,
 ) -> Option<(Unit<'a>, UnitFor)> {
     unit.pkg.targets().iter().find(|t| t.linkable()).map(|t| {
@@ -347,7 +347,7 @@ fn maybe_lib<'a>(
 /// script itself doesn't have any dependencies, so even in that case a unit
 /// of work is still returned. `None` is only returned if the package has no
 /// build script.
-fn dep_build_script<'a>(unit: &Unit<'a>, bcx: &BuildContext) -> Option<(Unit<'a>, UnitFor)> {
+fn dep_build_script<'a>(unit: &Unit<'a>, bcx: &BuildContext<'_, '_>) -> Option<(Unit<'a>, UnitFor)> {
     unit.pkg
         .targets()
         .iter()
@@ -387,7 +387,7 @@ fn check_or_build_mode(mode: CompileMode, target: &Target) -> CompileMode {
 }
 
 fn new_unit<'a>(
-    bcx: &BuildContext,
+    bcx: &BuildContext<'_, '_>,
     pkg: &'a Package,
     target: &'a Target,
     unit_for: UnitFor,
@@ -420,7 +420,7 @@ fn new_unit<'a>(
 ///
 /// Here we take the entire `deps` map and add more dependencies from execution
 /// of one build script to execution of another build script.
-fn connect_run_custom_build_deps(state: &mut State) {
+fn connect_run_custom_build_deps(state: &mut State<'_, '_, '_>) {
     let mut new_deps = Vec::new();
 
     {

--- a/src/cargo/core/compiler/fingerprint.rs
+++ b/src/cargo/core/compiler/fingerprint.rs
@@ -5,9 +5,10 @@ use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
 use filetime::FileTime;
-use serde::de::{self, Deserialize};
+use log::{debug, info};
+use serde::de;
 use serde::ser;
-use serde_json;
+use serde::{Deserialize, Serialize};
 
 use crate::core::{Edition, Package};
 use crate::util;

--- a/src/cargo/core/compiler/fingerprint.rs
+++ b/src/cargo/core/compiler/fingerprint.rs
@@ -496,7 +496,7 @@ fn calculate<'a, 'cfg>(
 // git/registry source, then the mtime of files may fluctuate, but they won't
 // change so long as the source itself remains constant (which is the
 // responsibility of the source)
-fn use_dep_info(unit: &Unit) -> bool {
+fn use_dep_info(unit: &Unit<'_>) -> bool {
     let path = unit.pkg.summary().source_id().is_path();
     !unit.mode.is_doc() && path
 }
@@ -684,7 +684,7 @@ fn compare_old_fingerprint(loc: &Path, new_fingerprint: &Fingerprint) -> CargoRe
     new_fingerprint.compare(&old_fingerprint)
 }
 
-fn log_compare(unit: &Unit, compare: &CargoResult<()>) {
+fn log_compare(unit: &Unit<'_>, compare: &CargoResult<()>) {
     let ce = match *compare {
         Ok(..) => return,
         Err(ref e) => e,
@@ -722,7 +722,7 @@ fn dep_info_mtime_if_fresh(pkg: &Package, dep_info: &Path) -> CargoResult<Option
     }
 }
 
-fn pkg_fingerprint(bcx: &BuildContext, pkg: &Package) -> CargoResult<String> {
+fn pkg_fingerprint(bcx: &BuildContext<'_, '_>, pkg: &Package) -> CargoResult<String> {
     let source_id = pkg.package_id().source_id();
     let sources = bcx.packages.sources();
 

--- a/src/cargo/core/compiler/job.rs
+++ b/src/cargo/core/compiler/job.rs
@@ -11,7 +11,7 @@ pub struct Job {
 /// Each proc should send its description before starting.
 /// It should send either once or close immediately.
 pub struct Work {
-    inner: Box<for<'a, 'b> FnBox<&'a JobState<'b>, CargoResult<()>> + Send>,
+    inner: Box<dyn for<'a, 'b> FnBox<&'a JobState<'b>, CargoResult<()>> + Send>,
 }
 
 trait FnBox<A, R> {
@@ -27,7 +27,7 @@ impl<A, R, F: FnOnce(A) -> R> FnBox<A, R> for F {
 impl Work {
     pub fn new<F>(f: F) -> Work
     where
-        F: FnOnce(&JobState) -> CargoResult<()> + Send + 'static,
+        F: FnOnce(&JobState<'_>) -> CargoResult<()> + Send + 'static,
     {
         Work { inner: Box::new(f) }
     }
@@ -36,7 +36,7 @@ impl Work {
         Work::new(|_| Ok(()))
     }
 
-    pub fn call(self, tx: &JobState) -> CargoResult<()> {
+    pub fn call(self, tx: &JobState<'_>) -> CargoResult<()> {
         self.inner.call_box(tx)
     }
 
@@ -56,7 +56,7 @@ impl Job {
 
     /// Consumes this job by running it, returning the result of the
     /// computation.
-    pub fn run(self, fresh: Freshness, state: &JobState) -> CargoResult<()> {
+    pub fn run(self, fresh: Freshness, state: &JobState<'_>) -> CargoResult<()> {
         match fresh {
             Fresh => self.fresh.call(state),
             Dirty => self.dirty.call(state),
@@ -65,7 +65,7 @@ impl Job {
 }
 
 impl fmt::Debug for Job {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Job {{ ... }}")
     }
 }

--- a/src/cargo/core/compiler/job_queue.rs
+++ b/src/cargo/core/compiler/job_queue.rs
@@ -421,7 +421,12 @@ impl<'a> JobQueue<'a> {
         Ok(())
     }
 
-    fn emit_warnings(&self, msg: Option<&str>, key: &Key<'a>, cx: &mut Context<'_, '_>) -> CargoResult<()> {
+    fn emit_warnings(
+        &self,
+        msg: Option<&str>,
+        key: &Key<'a>,
+        cx: &mut Context<'_, '_>,
+    ) -> CargoResult<()> {
         let output = cx.build_state.outputs.lock().unwrap();
         let bcx = &mut cx.bcx;
         if let Some(output) = output.get(&(key.pkg, key.kind)) {

--- a/src/cargo/core/compiler/job_queue.rs
+++ b/src/cargo/core/compiler/job_queue.rs
@@ -7,9 +7,9 @@ use std::process::Output;
 use std::sync::mpsc::{channel, Receiver, Sender};
 use std::sync::Arc;
 
-use crossbeam_utils;
 use crossbeam_utils::thread::Scope;
 use jobserver::{Acquired, HelperThread};
+use log::{debug, info, trace};
 
 use crate::core::profiles::Profile;
 use crate::core::{PackageId, Target, TargetKind};

--- a/src/cargo/core/compiler/job_queue.rs
+++ b/src/cargo/core/compiler/job_queue.rs
@@ -168,7 +168,7 @@ impl<'a> JobQueue<'a> {
     /// This function will spawn off `config.jobs()` workers to build all of the
     /// necessary dependencies, in order. Freshness is propagated as far as
     /// possible along each dependency chain.
-    pub fn execute(&mut self, cx: &mut Context, plan: &mut BuildPlan) -> CargoResult<()> {
+    pub fn execute(&mut self, cx: &mut Context<'_, '_>, plan: &mut BuildPlan) -> CargoResult<()> {
         let _p = profile::start("executing the job graph");
         self.queue.queue_finished();
 
@@ -209,7 +209,7 @@ impl<'a> JobQueue<'a> {
 
     fn drain_the_queue(
         &mut self,
-        cx: &mut Context,
+        cx: &mut Context<'_, '_>,
         plan: &mut BuildPlan,
         scope: &Scope<'a>,
         jobserver_helper: &HelperThread,
@@ -421,7 +421,7 @@ impl<'a> JobQueue<'a> {
         Ok(())
     }
 
-    fn emit_warnings(&self, msg: Option<&str>, key: &Key<'a>, cx: &mut Context) -> CargoResult<()> {
+    fn emit_warnings(&self, msg: Option<&str>, key: &Key<'a>, cx: &mut Context<'_, '_>) -> CargoResult<()> {
         let output = cx.build_state.outputs.lock().unwrap();
         let bcx = &mut cx.bcx;
         if let Some(output) = output.get(&(key.pkg, key.kind)) {
@@ -444,7 +444,7 @@ impl<'a> JobQueue<'a> {
         Ok(())
     }
 
-    fn finish(&mut self, key: Key<'a>, cx: &mut Context) -> CargoResult<()> {
+    fn finish(&mut self, key: Key<'a>, cx: &mut Context<'_, '_>) -> CargoResult<()> {
         if key.mode.is_run_custom_build() && cx.bcx.show_warnings(key.pkg) {
             self.emit_warnings(None, &key, cx)?;
         }
@@ -547,7 +547,7 @@ impl<'a> Key<'a> {
 }
 
 impl<'a> fmt::Debug for Key<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
             "{} => {}/{} => {:?}",

--- a/src/cargo/core/compiler/layout.rs
+++ b/src/cargo/core/compiler/layout.rs
@@ -84,7 +84,7 @@ impl Layout {
     ///
     /// Differs from `at` in that this calculates the root path from the workspace target directory,
     /// adding the target triple and the profile (debug, release, ...).
-    pub fn new(ws: &Workspace, triple: Option<&str>, dest: &str) -> CargoResult<Layout> {
+    pub fn new(ws: &Workspace<'_>, triple: Option<&str>, dest: &str) -> CargoResult<Layout> {
         let mut path = ws.target_dir();
         // Flexible target specifications often point at json files, so interpret
         // the target triple as a Path and then just use the file stem as the

--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -6,8 +6,9 @@ use std::path::{self, Path, PathBuf};
 use std::sync::Arc;
 
 use failure::Error;
+use log::debug;
 use same_file::is_same_file;
-use serde_json;
+use serde::Serialize;
 
 use crate::core::manifest::TargetSourcePath;
 use crate::core::profiles::{Lto, Profile};

--- a/src/cargo/core/compiler/output_depinfo.rs
+++ b/src/cargo/core/compiler/output_depinfo.rs
@@ -3,6 +3,8 @@ use std::fs::File;
 use std::io::{BufWriter, Write};
 use std::path::{Path, PathBuf};
 
+use log::debug;
+
 use super::{fingerprint, Context, Unit};
 use crate::util::paths;
 use crate::util::{internal, CargoResult};

--- a/src/cargo/core/dependency.rs
+++ b/src/cargo/core/dependency.rs
@@ -466,7 +466,7 @@ impl FromStr for Platform {
 }
 
 impl fmt::Display for Platform {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             Platform::Name(ref n) => n.fmt(f),
             Platform::Cfg(ref e) => write!(f, "cfg({})", e),

--- a/src/cargo/core/dependency.rs
+++ b/src/cargo/core/dependency.rs
@@ -2,9 +2,11 @@ use std::fmt;
 use std::rc::Rc;
 use std::str::FromStr;
 
+use log::trace;
 use semver::ReqParseError;
 use semver::VersionReq;
 use serde::ser;
+use serde::Serialize;
 
 use crate::core::interning::InternedString;
 use crate::core::{PackageId, SourceId, Summary};

--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -51,6 +51,7 @@ use std::fmt;
 use std::str::FromStr;
 
 use failure::Error;
+use serde::{Deserialize, Serialize};
 
 use crate::util::errors::CargoResult;
 

--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -65,7 +65,7 @@ pub enum Edition {
 }
 
 impl fmt::Display for Edition {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             Edition::Edition2015 => f.write_str("2015"),
             Edition::Edition2018 => f.write_str("2018"),

--- a/src/cargo/core/interning.rs
+++ b/src/cargo/core/interning.rs
@@ -74,13 +74,13 @@ impl Borrow<str> for InternedString {
 }
 
 impl fmt::Debug for InternedString {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Debug::fmt(self.as_str(), f)
     }
 }
 
 impl fmt::Display for InternedString {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(self.as_str(), f)
     }
 }

--- a/src/cargo/core/interning.rs
+++ b/src/cargo/core/interning.rs
@@ -14,7 +14,7 @@ pub fn leak(s: String) -> &'static str {
     Box::leak(s.into_boxed_str())
 }
 
-lazy_static! {
+lazy_static::lazy_static! {
     static ref STRING_CACHE: Mutex<HashSet<&'static str>> = Mutex::new(HashSet::new());
 }
 

--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -6,7 +6,7 @@ use std::rc::Rc;
 
 use semver::Version;
 use serde::ser;
-use toml;
+use serde::Serialize;
 use url::Url;
 
 use crate::core::interning::InternedString;

--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -122,7 +122,7 @@ impl LibKind {
 }
 
 impl fmt::Debug for LibKind {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.crate_type().fmt(f)
     }
 }
@@ -168,7 +168,7 @@ impl ser::Serialize for TargetKind {
 }
 
 impl fmt::Debug for TargetKind {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use self::TargetKind::*;
         match *self {
             Lib(ref kinds) => kinds.fmt(f),
@@ -244,7 +244,7 @@ impl Hash for TargetSourcePath {
 }
 
 impl fmt::Debug for TargetSourcePath {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             TargetSourcePath::Path(path) => path.fmt(f),
             TargetSourcePath::Metabuild => "metabuild".fmt(f),
@@ -869,7 +869,7 @@ impl Target {
 }
 
 impl fmt::Display for Target {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.kind {
             TargetKind::Lib(..) => write!(f, "Target(lib)"),
             TargetKind::Bin => write!(f, "Target(bin: {})", self.name),

--- a/src/cargo/core/package.rs
+++ b/src/cargo/core/package.rs
@@ -8,15 +8,14 @@ use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
 use bytesize::ByteSize;
-use curl;
 use curl::easy::{Easy, HttpVersion};
 use curl::multi::{EasyHandle, Multi};
-use curl_sys;
 use failure::ResultExt;
 use lazycell::LazyCell;
+use log::{debug, warn};
 use semver::Version;
 use serde::ser;
-use toml;
+use serde::Serialize;
 
 use crate::core::interning::InternedString;
 use crate::core::source::MaybePackage;

--- a/src/cargo/core/package_id.rs
+++ b/src/cargo/core/package_id.rs
@@ -14,7 +14,7 @@ use crate::core::interning::InternedString;
 use crate::core::source::SourceId;
 use crate::util::{CargoResult, ToSemver};
 
-lazy_static! {
+lazy_static::lazy_static! {
     static ref PACKAGE_ID_CACHE: Mutex<HashSet<&'static PackageIdInner>> =
         Mutex::new(HashSet::new());
 }

--- a/src/cargo/core/package_id.rs
+++ b/src/cargo/core/package_id.rs
@@ -162,7 +162,7 @@ impl PackageId {
         })
     }
 
-    pub fn stable_hash(self, workspace: &Path) -> PackageIdStableHash {
+    pub fn stable_hash(self, workspace: &Path) -> PackageIdStableHash<'_> {
         PackageIdStableHash(self, workspace)
     }
 }
@@ -178,7 +178,7 @@ impl<'a> Hash for PackageIdStableHash<'a> {
 }
 
 impl fmt::Display for PackageId {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(f, "{} v{}", self.inner.name, self.inner.version)?;
 
         if !self.inner.source_id.is_default_registry() {
@@ -190,7 +190,7 @@ impl fmt::Display for PackageId {
 }
 
 impl fmt::Debug for PackageId {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         f.debug_struct("PackageId")
             .field("name", &self.inner.name)
             .field("version", &self.inner.version.to_string())

--- a/src/cargo/core/package_id_spec.rs
+++ b/src/cargo/core/package_id_spec.rs
@@ -229,7 +229,7 @@ impl PackageIdSpec {
 }
 
 impl fmt::Display for PackageIdSpec {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut printed_name = false;
         match self.url {
             Some(ref url) => {

--- a/src/cargo/core/profiles.rs
+++ b/src/cargo/core/profiles.rs
@@ -132,7 +132,11 @@ impl Profiles {
     }
 
     /// Used to check for overrides for non-existing packages.
-    pub fn validate_packages(&self, shell: &mut Shell, packages: &PackageSet<'_>) -> CargoResult<()> {
+    pub fn validate_packages(
+        &self,
+        shell: &mut Shell,
+        packages: &PackageSet<'_>,
+    ) -> CargoResult<()> {
         self.dev.validate_packages(shell, packages)?;
         self.release.validate_packages(shell, packages)?;
         self.test.validate_packages(shell, packages)?;

--- a/src/cargo/core/profiles.rs
+++ b/src/cargo/core/profiles.rs
@@ -1,6 +1,8 @@
 use std::collections::HashSet;
 use std::{cmp, fmt, hash};
 
+use serde::Deserialize;
+
 use crate::core::compiler::CompileMode;
 use crate::core::interning::InternedString;
 use crate::core::{Features, PackageId, PackageIdSpec, PackageSet, Shell};

--- a/src/cargo/core/profiles.rs
+++ b/src/cargo/core/profiles.rs
@@ -132,7 +132,7 @@ impl Profiles {
     }
 
     /// Used to check for overrides for non-existing packages.
-    pub fn validate_packages(&self, shell: &mut Shell, packages: &PackageSet) -> CargoResult<()> {
+    pub fn validate_packages(&self, shell: &mut Shell, packages: &PackageSet<'_>) -> CargoResult<()> {
         self.dev.validate_packages(shell, packages)?;
         self.release.validate_packages(shell, packages)?;
         self.test.validate_packages(shell, packages)?;
@@ -179,7 +179,7 @@ impl ProfileMaker {
         profile
     }
 
-    fn validate_packages(&self, shell: &mut Shell, packages: &PackageSet) -> CargoResult<()> {
+    fn validate_packages(&self, shell: &mut Shell, packages: &PackageSet<'_>) -> CargoResult<()> {
         self.validate_packages_toml(shell, packages, &self.toml, true)?;
         self.validate_packages_toml(shell, packages, &self.config, false)?;
         Ok(())
@@ -188,7 +188,7 @@ impl ProfileMaker {
     fn validate_packages_toml(
         &self,
         shell: &mut Shell,
-        packages: &PackageSet,
+        packages: &PackageSet<'_>,
         toml: &Option<TomlProfile>,
         warn_unmatched: bool,
     ) -> CargoResult<()> {
@@ -436,7 +436,7 @@ compact_debug! {
 }
 
 impl fmt::Display for Profile {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Profile({})", self.name)
     }
 }

--- a/src/cargo/core/registry.rs
+++ b/src/cargo/core/registry.rs
@@ -15,7 +15,12 @@ use crate::util::{profile, Config};
 /// See also `core::Source`.
 pub trait Registry {
     /// Attempt to find the packages that match a dependency request.
-    fn query(&mut self, dep: &Dependency, f: &mut dyn FnMut(Summary), fuzzy: bool) -> CargoResult<()>;
+    fn query(
+        &mut self,
+        dep: &Dependency,
+        f: &mut dyn FnMut(Summary),
+        fuzzy: bool,
+    ) -> CargoResult<()>;
 
     fn query_vec(&mut self, dep: &Dependency, fuzzy: bool) -> CargoResult<Vec<Summary>> {
         let mut ret = Vec::new();
@@ -404,7 +409,12 @@ https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#overridin
 }
 
 impl<'cfg> Registry for PackageRegistry<'cfg> {
-    fn query(&mut self, dep: &Dependency, f: &mut dyn FnMut(Summary), fuzzy: bool) -> CargoResult<()> {
+    fn query(
+        &mut self,
+        dep: &Dependency,
+        f: &mut dyn FnMut(Summary),
+        fuzzy: bool,
+    ) -> CargoResult<()> {
         assert!(self.patches_locked);
         let (override_summary, n, to_warn) = {
             // Look for an override and get ready to query the real source.

--- a/src/cargo/core/registry.rs
+++ b/src/cargo/core/registry.rs
@@ -15,7 +15,7 @@ use crate::util::{profile, Config};
 /// See also `core::Source`.
 pub trait Registry {
     /// Attempt to find the packages that match a dependency request.
-    fn query(&mut self, dep: &Dependency, f: &mut FnMut(Summary), fuzzy: bool) -> CargoResult<()>;
+    fn query(&mut self, dep: &Dependency, f: &mut dyn FnMut(Summary), fuzzy: bool) -> CargoResult<()>;
 
     fn query_vec(&mut self, dep: &Dependency, fuzzy: bool) -> CargoResult<Vec<Summary>> {
         let mut ret = Vec::new();
@@ -146,17 +146,17 @@ impl<'cfg> PackageRegistry<'cfg> {
         Ok(())
     }
 
-    pub fn add_preloaded(&mut self, source: Box<Source + 'cfg>) {
+    pub fn add_preloaded(&mut self, source: Box<dyn Source + 'cfg>) {
         self.add_source(source, Kind::Locked);
     }
 
-    fn add_source(&mut self, source: Box<Source + 'cfg>, kind: Kind) {
+    fn add_source(&mut self, source: Box<dyn Source + 'cfg>, kind: Kind) {
         let id = source.source_id();
         self.sources.insert(source);
         self.source_ids.insert(id, (id, kind));
     }
 
-    pub fn add_override(&mut self, source: Box<Source + 'cfg>) {
+    pub fn add_override(&mut self, source: Box<dyn Source + 'cfg>) {
         self.overrides.push(source.source_id());
         self.add_source(source, Kind::Override);
     }
@@ -404,7 +404,7 @@ https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#overridin
 }
 
 impl<'cfg> Registry for PackageRegistry<'cfg> {
-    fn query(&mut self, dep: &Dependency, f: &mut FnMut(Summary), fuzzy: bool) -> CargoResult<()> {
+    fn query(&mut self, dep: &Dependency, f: &mut dyn FnMut(Summary), fuzzy: bool) -> CargoResult<()> {
         assert!(self.patches_locked);
         let (override_summary, n, to_warn) = {
             // Look for an override and get ready to query the real source.

--- a/src/cargo/core/registry.rs
+++ b/src/cargo/core/registry.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+use log::{debug, trace};
 use semver::VersionReq;
 use url::Url;
 

--- a/src/cargo/core/resolver/conflict_cache.rs
+++ b/src/cargo/core/resolver/conflict_cache.rs
@@ -1,5 +1,7 @@
 use std::collections::{BTreeMap, HashMap, HashSet};
 
+use log::trace;
+
 use super::types::ConflictReason;
 use crate::core::resolver::Context;
 use crate::core::{Dependency, PackageId};

--- a/src/cargo/core/resolver/context.rs
+++ b/src/cargo/core/resolver/context.rs
@@ -1,11 +1,12 @@
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::rc::Rc;
 
+use log::debug;
+
 use crate::core::interning::InternedString;
 use crate::core::{Dependency, FeatureValue, PackageId, SourceId, Summary};
 use crate::util::CargoResult;
 use crate::util::Graph;
-use im_rc;
 
 use super::errors::ActivateResult;
 use super::types::{ConflictReason, DepInfo, GraphNode, Method, RcList, RegistryQueryer};

--- a/src/cargo/core/resolver/context.rs
+++ b/src/cargo/core/resolver/context.rs
@@ -52,7 +52,7 @@ impl Context {
     /// Activate this summary by inserting it into our list of known activations.
     ///
     /// Returns true if this summary with the given method is already activated.
-    pub fn flag_activated(&mut self, summary: &Summary, method: &Method) -> CargoResult<bool> {
+    pub fn flag_activated(&mut self, summary: &Summary, method: &Method<'_>) -> CargoResult<bool> {
         let id = summary.package_id();
         let prev = self
             .activations
@@ -96,10 +96,10 @@ impl Context {
 
     pub fn build_deps(
         &mut self,
-        registry: &mut RegistryQueryer,
+        registry: &mut RegistryQueryer<'_>,
         parent: Option<&Summary>,
         candidate: &Summary,
-        method: &Method,
+        method: &Method<'_>,
     ) -> ActivateResult<Vec<DepInfo>> {
         // First, figure out our set of dependencies based on the requested set
         // of features. This also calculates what features we're going to enable
@@ -157,7 +157,7 @@ impl Context {
         &mut self,
         parent: Option<&Summary>,
         s: &'b Summary,
-        method: &'b Method,
+        method: &'b Method<'_>,
     ) -> ActivateResult<Vec<(Dependency, Vec<InternedString>)>> {
         let dev_deps = match *method {
             Method::Everything => true,
@@ -285,7 +285,7 @@ impl Context {
 /// dependency features in a Requirements object, returning it to the resolver.
 fn build_requirements<'a, 'b: 'a>(
     s: &'a Summary,
-    method: &'b Method,
+    method: &'b Method<'_>,
 ) -> CargoResult<Requirements<'a>> {
     let mut reqs = Requirements::new(s);
 
@@ -345,7 +345,7 @@ struct Requirements<'a> {
 }
 
 impl<'r> Requirements<'r> {
-    fn new(summary: &Summary) -> Requirements {
+    fn new(summary: &Summary) -> Requirements<'_> {
         Requirements {
             summary,
             deps: HashMap::new(),

--- a/src/cargo/core/resolver/encode.rs
+++ b/src/cargo/core/resolver/encode.rs
@@ -32,7 +32,7 @@ struct Patch {
 pub type Metadata = BTreeMap<String, String>;
 
 impl EncodableResolve {
-    pub fn into_resolve(self, ws: &Workspace) -> CargoResult<Resolve> {
+    pub fn into_resolve(self, ws: &Workspace<'_>) -> CargoResult<Resolve> {
         let path_deps = build_path_deps(ws);
 
         let packages = {
@@ -175,7 +175,7 @@ impl EncodableResolve {
     }
 }
 
-fn build_path_deps(ws: &Workspace) -> HashMap<String, SourceId> {
+fn build_path_deps(ws: &Workspace<'_>) -> HashMap<String, SourceId> {
     // If a crate is *not* a path source, then we're probably in a situation
     // such as `cargo install` with a lock file from a remote dependency. In
     // that case we don't need to fixup any path dependencies (as they're not
@@ -210,7 +210,7 @@ fn build_path_deps(ws: &Workspace) -> HashMap<String, SourceId> {
 
     fn build_pkg(
         pkg: &Package,
-        ws: &Workspace,
+        ws: &Workspace<'_>,
         ret: &mut HashMap<String, SourceId>,
         visited: &mut HashSet<SourceId>,
     ) {
@@ -221,7 +221,7 @@ fn build_path_deps(ws: &Workspace) -> HashMap<String, SourceId> {
 
     fn build_dep(
         dep: &Dependency,
-        ws: &Workspace,
+        ws: &Workspace<'_>,
         ret: &mut HashMap<String, SourceId>,
         visited: &mut HashSet<SourceId>,
     ) {
@@ -266,7 +266,7 @@ pub struct EncodablePackageId {
 }
 
 impl fmt::Display for EncodablePackageId {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{} {}", self.name, self.version)?;
         if let Some(ref s) = self.source {
             write!(f, " ({})", s.to_url())?;

--- a/src/cargo/core/resolver/encode.rs
+++ b/src/cargo/core/resolver/encode.rs
@@ -2,8 +2,10 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fmt;
 use std::str::FromStr;
 
+use log::debug;
 use serde::de;
 use serde::ser;
+use serde::{Deserialize, Serialize};
 
 use crate::core::{Dependency, Package, PackageId, SourceId, Workspace};
 use crate::util::errors::{CargoError, CargoResult, CargoResultExt};

--- a/src/cargo/core/resolver/errors.rs
+++ b/src/cargo/core/resolver/errors.rs
@@ -32,19 +32,19 @@ impl ResolveError {
 }
 
 impl Fail for ResolveError {
-    fn cause(&self) -> Option<&Fail> {
+    fn cause(&self) -> Option<&dyn Fail> {
         self.cause.as_fail().cause()
     }
 }
 
 impl fmt::Debug for ResolveError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.cause.fmt(f)
     }
 }
 
 impl fmt::Display for ResolveError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.cause.fmt(f)
     }
 }
@@ -70,7 +70,7 @@ impl From<(PackageId, ConflictReason)> for ActivateError {
 
 pub(super) fn activation_error(
     cx: &Context,
-    registry: &mut Registry,
+    registry: &mut dyn Registry,
     parent: &Summary,
     dep: &Dependency,
     conflicting_activations: &BTreeMap<PackageId, ConflictReason>,

--- a/src/cargo/core/resolver/mod.rs
+++ b/src/cargo/core/resolver/mod.rs
@@ -108,9 +108,9 @@ mod types;
 /// * `print_warnings` - whether or not to print backwards-compatibility
 ///   warnings and such
 pub fn resolve(
-    summaries: &[(Summary, Method)],
+    summaries: &[(Summary, Method<'_>)],
     replacements: &[(PackageIdSpec, Dependency)],
-    registry: &mut Registry,
+    registry: &mut dyn Registry,
     try_to_use: &HashSet<PackageId>,
     config: Option<&Config>,
     print_warnings: bool,
@@ -167,8 +167,8 @@ pub fn resolve(
 /// dependency graph, cx.resolve is returned.
 fn activate_deps_loop(
     mut cx: Context,
-    registry: &mut RegistryQueryer,
-    summaries: &[(Summary, Method)],
+    registry: &mut RegistryQueryer<'_>,
+    summaries: &[(Summary, Method<'_>)],
     config: Option<&Config>,
 ) -> CargoResult<Context> {
     let mut backtrack_stack = Vec::new();
@@ -580,10 +580,10 @@ fn activate_deps_loop(
 /// iterate through next.
 fn activate(
     cx: &mut Context,
-    registry: &mut RegistryQueryer,
+    registry: &mut RegistryQueryer<'_>,
     parent: Option<(&Summary, &Dependency)>,
     candidate: Candidate,
-    method: &Method,
+    method: &Method<'_>,
 ) -> ActivateResult<Option<(DepsFrame, Duration)>> {
     if let Some((parent, dep)) = parent {
         cx.resolve_graph.push(GraphNode::Link(

--- a/src/cargo/core/resolver/mod.rs
+++ b/src/cargo/core/resolver/mod.rs
@@ -52,7 +52,7 @@ use std::mem;
 use std::rc::Rc;
 use std::time::{Duration, Instant};
 
-use semver;
+use log::{debug, trace};
 
 use crate::core::interning::InternedString;
 use crate::core::PackageIdSpec;

--- a/src/cargo/core/resolver/resolve.rs
+++ b/src/cargo/core/resolver/resolve.rs
@@ -276,7 +276,7 @@ unable to verify that `{0}` is the same as when the lockfile was generated
 }
 
 impl fmt::Debug for Resolve {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(fmt, "graph: {:?}", self.graph)?;
         writeln!(fmt, "\nfeatures: {{")?;
         for (pkg, features) in &self.features {

--- a/src/cargo/core/resolver/types.rs
+++ b/src/cargo/core/resolver/types.rs
@@ -76,7 +76,7 @@ impl ResolverProgress {
 }
 
 pub struct RegistryQueryer<'a> {
-    pub registry: &'a mut (Registry + 'a),
+    pub registry: &'a mut (dyn Registry + 'a),
     replacements: &'a [(PackageIdSpec, Dependency)],
     try_to_use: &'a HashSet<PackageId>,
     cache: HashMap<Dependency, Rc<Vec<Candidate>>>,
@@ -88,7 +88,7 @@ pub struct RegistryQueryer<'a> {
 
 impl<'a> RegistryQueryer<'a> {
     pub fn new(
-        registry: &'a mut Registry,
+        registry: &'a mut dyn Registry,
         replacements: &'a [(PackageIdSpec, Dependency)],
         try_to_use: &'a HashSet<PackageId>,
         minimal_versions: bool,

--- a/src/cargo/core/resolver/types.rs
+++ b/src/cargo/core/resolver/types.rs
@@ -4,6 +4,8 @@ use std::ops::Range;
 use std::rc::Rc;
 use std::time::{Duration, Instant};
 
+use log::debug;
+
 use crate::core::interning::InternedString;
 use crate::core::{Dependency, PackageId, PackageIdSpec, Registry, Summary};
 use crate::util::errors::CargoResult;

--- a/src/cargo/core/shell.rs
+++ b/src/cargo/core/shell.rs
@@ -376,14 +376,12 @@ mod imp {
 
 #[cfg(windows)]
 mod imp {
-    extern crate winapi;
-
-    use self::winapi::um::fileapi::*;
-    use self::winapi::um::handleapi::*;
-    use self::winapi::um::processenv::*;
-    use self::winapi::um::winbase::*;
-    use self::winapi::um::wincon::*;
-    use self::winapi::um::winnt::*;
+    use winapi::um::fileapi::*;
+    use winapi::um::handleapi::*;
+    use winapi::um::processenv::*;
+    use winapi::um::winbase::*;
+    use winapi::um::wincon::*;
+    use winapi::um::winnt::*;
     use std::{cmp, mem, ptr};
 
     pub(super) use super::default_err_erase_line as err_erase_line;

--- a/src/cargo/core/shell.rs
+++ b/src/cargo/core/shell.rs
@@ -26,7 +26,7 @@ pub struct Shell {
 }
 
 impl fmt::Debug for Shell {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.err {
             ShellOut::Write(_) => f
                 .debug_struct("Shell")
@@ -44,7 +44,7 @@ impl fmt::Debug for Shell {
 /// A `Write`able object, either with or without color support
 enum ShellOut {
     /// A plain write object without color support
-    Write(Box<Write>),
+    Write(Box<dyn Write>),
     /// Color-enabled stdio, with information on whether color should be used
     Stream {
         stream: StandardStream,
@@ -79,7 +79,7 @@ impl Shell {
     }
 
     /// Create a shell from a plain writable object, with no color, and max verbosity.
-    pub fn from_write(out: Box<Write>) -> Shell {
+    pub fn from_write(out: Box<dyn Write>) -> Shell {
         Shell {
             err: ShellOut::Write(out),
             verbosity: Verbosity::Verbose,
@@ -90,8 +90,8 @@ impl Shell {
     /// messages follows without color.
     fn print(
         &mut self,
-        status: &fmt::Display,
-        message: Option<&fmt::Display>,
+        status: &dyn fmt::Display,
+        message: Option<&dyn fmt::Display>,
         color: Color,
         justified: bool,
     ) -> CargoResult<()> {
@@ -118,7 +118,7 @@ impl Shell {
     }
 
     /// Get a reference to the underlying writer
-    pub fn err(&mut self) -> &mut Write {
+    pub fn err(&mut self) -> &mut dyn Write {
         self.err.as_write()
     }
 
@@ -274,8 +274,8 @@ impl ShellOut {
     /// The status can be justified, in which case the max width that will right align is 12 chars.
     fn print(
         &mut self,
-        status: &fmt::Display,
-        message: Option<&fmt::Display>,
+        status: &dyn fmt::Display,
+        message: Option<&dyn fmt::Display>,
         color: Color,
         justified: bool,
     ) -> CargoResult<()> {
@@ -310,7 +310,7 @@ impl ShellOut {
     }
 
     /// Get this object as a `io::Write`.
-    fn as_write(&mut self) -> &mut Write {
+    fn as_write(&mut self) -> &mut dyn Write {
         match *self {
             ShellOut::Stream { ref mut stream, .. } => stream,
             ShellOut::Write(ref mut w) => w,

--- a/src/cargo/core/source/source_id.rs
+++ b/src/cargo/core/source/source_id.rs
@@ -144,7 +144,7 @@ impl SourceId {
     }
 
     /// A view of the `SourceId` that can be `Display`ed as a URL
-    pub fn to_url(&self) -> SourceIdToUrl {
+    pub fn to_url(&self) -> SourceIdToUrl<'_> {
         SourceIdToUrl {
             inner: &*self.inner,
         }
@@ -257,7 +257,7 @@ impl SourceId {
     }
 
     /// Creates an implementation of `Source` corresponding to this ID.
-    pub fn load<'a>(self, config: &'a Config) -> CargoResult<Box<super::Source + 'a>> {
+    pub fn load<'a>(self, config: &'a Config) -> CargoResult<Box<dyn super::Source + 'a>> {
         trace!("loading SourceId; {}", self);
         match self.inner.kind {
             Kind::Git(..) => Ok(Box::new(GitSource::new(self, config)?)),
@@ -394,7 +394,7 @@ fn url_display(url: &Url) -> String {
 }
 
 impl fmt::Display for SourceId {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match *self.inner {
             SourceIdInner {
                 kind: Kind::Path,
@@ -510,7 +510,7 @@ pub struct SourceIdToUrl<'a> {
 }
 
 impl<'a> fmt::Display for SourceIdToUrl<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self.inner {
             SourceIdInner {
                 kind: Kind::Path,
@@ -554,7 +554,7 @@ impl<'a> fmt::Display for SourceIdToUrl<'a> {
 impl GitReference {
     /// Returns a `Display`able view of this git reference, or None if using
     /// the head of the "master" branch
-    pub fn pretty_ref(&self) -> Option<PrettyRef> {
+    pub fn pretty_ref(&self) -> Option<PrettyRef<'_>> {
         match *self {
             GitReference::Branch(ref s) if *s == "master" => None,
             _ => Some(PrettyRef { inner: self }),
@@ -568,7 +568,7 @@ pub struct PrettyRef<'a> {
 }
 
 impl<'a> fmt::Display for PrettyRef<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self.inner {
             GitReference::Branch(ref b) => write!(f, "branch={}", b),
             GitReference::Tag(ref s) => write!(f, "tag={}", s),

--- a/src/cargo/core/source/source_id.rs
+++ b/src/cargo/core/source/source_id.rs
@@ -8,6 +8,7 @@ use std::sync::atomic::Ordering::SeqCst;
 use std::sync::atomic::{AtomicBool, ATOMIC_BOOL_INIT};
 use std::sync::Mutex;
 
+use log::trace;
 use serde::de;
 use serde::ser;
 use url::Url;
@@ -18,7 +19,7 @@ use crate::sources::DirectorySource;
 use crate::sources::{GitSource, PathSource, RegistrySource, CRATES_IO_INDEX};
 use crate::util::{CargoResult, Config, ToUrl};
 
-lazy_static! {
+lazy_static::lazy_static! {
     static ref SOURCE_ID_CACHE: Mutex<HashSet<&'static SourceIdInner>> = Mutex::new(HashSet::new());
 }
 

--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -5,6 +5,7 @@ use std::path::{Path, PathBuf};
 use std::slice;
 
 use glob::glob;
+use log::debug;
 use url::Url;
 
 use crate::core::profiles::Profiles;

--- a/src/cargo/lib.rs
+++ b/src/cargo/lib.rs
@@ -62,7 +62,7 @@ pub struct VersionInfo {
 }
 
 impl fmt::Display for VersionInfo {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "cargo {}.{}.{}", self.major, self.minor, self.patch)?;
         if let Some(channel) = self.cfg_info.as_ref().map(|ci| &ci.release_channel) {
             if channel != "stable" {

--- a/src/cargo/lib.rs
+++ b/src/cargo/lib.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(test, deny(warnings))]
+#![warn(rust_2018_idioms)] // while we're getting used to 2018
 // Clippy isn't enforced by CI, and know that @alexcrichton isn't a fan :)
 #![allow(clippy::boxed_local)] // bug rust-lang-nursery/rust-clippy#1123
 #![allow(clippy::cyclomatic_complexity)] // large project

--- a/src/cargo/lib.rs
+++ b/src/cargo/lib.rs
@@ -1,71 +1,25 @@
 #![cfg_attr(test, deny(warnings))]
 // Clippy isn't enforced by CI, and know that @alexcrichton isn't a fan :)
-#![cfg_attr(feature = "cargo-clippy", allow(clippy::boxed_local))] // bug rust-lang-nursery/rust-clippy#1123
-#![cfg_attr(feature = "cargo-clippy", allow(clippy::cyclomatic_complexity))] // large project
-#![cfg_attr(feature = "cargo-clippy", allow(clippy::derive_hash_xor_eq))] // there's an intentional incoherence
-#![cfg_attr(feature = "cargo-clippy", allow(clippy::explicit_into_iter_loop))] // explicit loops are clearer
-#![cfg_attr(feature = "cargo-clippy", allow(clippy::explicit_iter_loop))] // explicit loops are clearer
-#![cfg_attr(feature = "cargo-clippy", allow(clippy::identity_op))] // used for vertical alignment
-#![cfg_attr(feature = "cargo-clippy", allow(clippy::implicit_hasher))] // large project
-#![cfg_attr(feature = "cargo-clippy", allow(clippy::large_enum_variant))] // large project
-#![cfg_attr(feature = "cargo-clippy", allow(clippy::redundant_closure_call))] // closures over try catch blocks
-#![cfg_attr(feature = "cargo-clippy", allow(clippy::too_many_arguments))] // large project
-#![cfg_attr(feature = "cargo-clippy", allow(clippy::type_complexity))] // there's an exceptionally complex type
-#![cfg_attr(feature = "cargo-clippy", allow(clippy::wrong_self_convention))] // perhaps Rc should be special cased in Clippy?
+#![allow(clippy::boxed_local)] // bug rust-lang-nursery/rust-clippy#1123
+#![allow(clippy::cyclomatic_complexity)] // large project
+#![allow(clippy::derive_hash_xor_eq)] // there's an intentional incoherence
+#![allow(clippy::explicit_into_iter_loop)] // explicit loops are clearer
+#![allow(clippy::explicit_iter_loop)] // explicit loops are clearer
+#![allow(clippy::identity_op)] // used for vertical alignment
+#![allow(clippy::implicit_hasher)] // large project
+#![allow(clippy::large_enum_variant)] // large project
+#![allow(clippy::redundant_closure_call)] // closures over try catch blocks
+#![allow(clippy::too_many_arguments)] // large project
+#![allow(clippy::type_complexity)] // there's an exceptionally complex type
+#![allow(clippy::wrong_self_convention)] // perhaps Rc should be special cased in Clippy?
 
-extern crate atty;
-extern crate bytesize;
-extern crate clap;
-#[cfg(target_os = "macos")]
-extern crate core_foundation;
-extern crate crates_io as registry;
-extern crate crossbeam_utils;
-extern crate curl;
-extern crate curl_sys;
 #[macro_use]
 extern crate failure;
-extern crate filetime;
-extern crate flate2;
-extern crate fs2;
-#[cfg(windows)]
-extern crate fwdansi;
-extern crate git2;
-extern crate glob;
-extern crate hex;
-extern crate home;
-extern crate ignore;
-extern crate jobserver;
-#[macro_use]
-extern crate lazy_static;
-extern crate lazycell;
-extern crate libc;
-extern crate libgit2_sys;
-#[macro_use]
-extern crate log;
-extern crate num_cpus;
-extern crate opener;
-extern crate rustfix;
-extern crate same_file;
-extern crate semver;
-#[macro_use]
-extern crate serde;
-#[macro_use]
-extern crate serde_derive;
-extern crate serde_ignored;
-#[macro_use]
-extern crate serde_json;
-extern crate im_rc;
-extern crate shell_escape;
-extern crate tar;
-extern crate tempfile;
-extern crate termcolor;
-extern crate toml;
-extern crate unicode_width;
-extern crate url;
 
 use std::fmt;
 
 use failure::Error;
+use log::debug;
 use serde::ser;
 
 use crate::core::shell::Verbosity::Verbose;

--- a/src/cargo/macros.rs
+++ b/src/cargo/macros.rs
@@ -11,7 +11,7 @@ macro_rules! compact_debug {
     ) => (
 
         impl fmt::Debug for $ty {
-            fn fmt(&$this, f: &mut fmt::Formatter) -> fmt::Result {
+            fn fmt(&$this, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 // Try printing a pretty version where we collapse as many fields as
                 // possible, indicating that they're equivalent to a function call
                 // that's hopefully enough to indicate what each value is without
@@ -43,7 +43,7 @@ macro_rules! compact_debug {
 pub struct DisplayAsDebug<T>(pub T);
 
 impl<T: fmt::Display> fmt::Debug for DisplayAsDebug<T> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(&self.0, f)
     }
 }

--- a/src/cargo/ops/cargo_clean.rs
+++ b/src/cargo/ops/cargo_clean.rs
@@ -23,7 +23,7 @@ pub struct CleanOptions<'a> {
 }
 
 /// Cleans the package's build artifacts.
-pub fn clean(ws: &Workspace, opts: &CleanOptions) -> CargoResult<()> {
+pub fn clean(ws: &Workspace<'_>, opts: &CleanOptions<'_>) -> CargoResult<()> {
     let mut target_dir = ws.target_dir();
     let config = ws.config();
 

--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -109,7 +109,7 @@ impl Packages {
         })
     }
 
-    pub fn to_package_id_specs(&self, ws: &Workspace) -> CargoResult<Vec<PackageIdSpec>> {
+    pub fn to_package_id_specs(&self, ws: &Workspace<'_>) -> CargoResult<Vec<PackageIdSpec>> {
         let specs = match *self {
             Packages::All => ws
                 .members()
@@ -148,7 +148,7 @@ impl Packages {
         Ok(specs)
     }
 
-    pub fn get_packages<'ws>(&self, ws: &'ws Workspace) -> CargoResult<Vec<&'ws Package>> {
+    pub fn get_packages<'ws>(&self, ws: &'ws Workspace<'_>) -> CargoResult<Vec<&'ws Package>> {
         let packages: Vec<_> = match self {
             Packages::Default => ws.default_members().collect(),
             Packages::All => ws.members().collect(),
@@ -197,7 +197,7 @@ pub fn compile<'a>(
     ws: &Workspace<'a>,
     options: &CompileOptions<'a>,
 ) -> CargoResult<Compilation<'a>> {
-    let exec: Arc<Executor> = Arc::new(DefaultExecutor);
+    let exec: Arc<dyn Executor> = Arc::new(DefaultExecutor);
     compile_with_exec(ws, options, &exec)
 }
 
@@ -206,7 +206,7 @@ pub fn compile<'a>(
 pub fn compile_with_exec<'a>(
     ws: &Workspace<'a>,
     options: &CompileOptions<'a>,
-    exec: &Arc<Executor>,
+    exec: &Arc<dyn Executor>,
 ) -> CargoResult<Compilation<'a>> {
     ws.emit_warnings()?;
     compile_ws(ws, None, options, exec)
@@ -214,9 +214,9 @@ pub fn compile_with_exec<'a>(
 
 pub fn compile_ws<'a>(
     ws: &Workspace<'a>,
-    source: Option<Box<Source + 'a>>,
+    source: Option<Box<dyn Source + 'a>>,
     options: &CompileOptions<'a>,
-    exec: &Arc<Executor>,
+    exec: &Arc<dyn Executor>,
 ) -> CargoResult<Compilation<'a>> {
     let CompileOptions {
         config,
@@ -489,7 +489,7 @@ struct Proposal<'a> {
 /// compile. Dependencies for these targets are computed later in
 /// `unit_dependencies`.
 fn generate_targets<'a>(
-    ws: &Workspace,
+    ws: &Workspace<'_>,
     profiles: &Profiles,
     packages: &[&'a Package],
     filter: &CompileFilter,
@@ -576,7 +576,7 @@ fn generate_targets<'a>(
     };
 
     // Create a list of proposed targets.
-    let mut proposals: Vec<Proposal> = Vec::new();
+    let mut proposals: Vec<Proposal<'_>> = Vec::new();
 
     match *filter {
         CompileFilter::Default {

--- a/src/cargo/ops/cargo_doc.rs
+++ b/src/cargo/ops/cargo_doc.rs
@@ -19,7 +19,7 @@ pub struct DocOptions<'a> {
 }
 
 /// Main method for `cargo doc`.
-pub fn doc(ws: &Workspace, options: &DocOptions) -> CargoResult<()> {
+pub fn doc(ws: &Workspace<'_>, options: &DocOptions<'_>) -> CargoResult<()> {
     let specs = options.compile_opts.spec.to_package_id_specs(ws)?;
     let resolve = ops::resolve_ws_precisely(
         ws,
@@ -99,7 +99,7 @@ pub fn doc(ws: &Workspace, options: &DocOptions) -> CargoResult<()> {
             shell.status("Opening", path.display())?;
             if let Err(e) = opener::open(&path) {
                 shell.warn(format!("Couldn't open docs: {}", e))?;
-                for cause in (&e as &Fail).iter_chain() {
+                for cause in (&e as &dyn Fail).iter_chain() {
                     shell.warn(format!("Caused by:\n {}", cause))?;
                 }
             }

--- a/src/cargo/ops/cargo_generate_lockfile.rs
+++ b/src/cargo/ops/cargo_generate_lockfile.rs
@@ -18,7 +18,7 @@ pub struct UpdateOptions<'a> {
     pub aggressive: bool,
 }
 
-pub fn generate_lockfile(ws: &Workspace) -> CargoResult<()> {
+pub fn generate_lockfile(ws: &Workspace<'_>) -> CargoResult<()> {
     let mut registry = PackageRegistry::new(ws.config())?;
     let resolve = ops::resolve_with_previous(
         &mut registry,
@@ -34,7 +34,7 @@ pub fn generate_lockfile(ws: &Workspace) -> CargoResult<()> {
     Ok(())
 }
 
-pub fn update_lockfile(ws: &Workspace, opts: &UpdateOptions) -> CargoResult<()> {
+pub fn update_lockfile(ws: &Workspace<'_>, opts: &UpdateOptions<'_>) -> CargoResult<()> {
     if opts.aggressive && opts.precise.is_some() {
         bail!("cannot specify both aggressive and precise simultaneously")
     }

--- a/src/cargo/ops/cargo_generate_lockfile.rs
+++ b/src/cargo/ops/cargo_generate_lockfile.rs
@@ -1,5 +1,6 @@
 use std::collections::{BTreeMap, HashSet};
 
+use log::debug;
 use termcolor::Color::{self, Cyan, Green, Red};
 
 use crate::core::registry::PackageRegistry;

--- a/src/cargo/ops/cargo_install.rs
+++ b/src/cargo/ops/cargo_install.rs
@@ -62,7 +62,7 @@ pub fn install(
     source_id: SourceId,
     from_cwd: bool,
     vers: Option<&str>,
-    opts: &ops::CompileOptions,
+    opts: &ops::CompileOptions<'_>,
     force: bool,
 ) -> CargoResult<()> {
     let root = resolve_root(root, opts.config)?;
@@ -152,12 +152,12 @@ pub fn install(
 
 fn install_one(
     root: &Filesystem,
-    map: &SourceConfigMap,
+    map: &SourceConfigMap<'_>,
     krate: Option<&str>,
     source_id: SourceId,
     from_cwd: bool,
     vers: Option<&str>,
-    opts: &ops::CompileOptions,
+    opts: &ops::CompileOptions<'_>,
     force: bool,
     is_first_install: bool,
 ) -> CargoResult<()> {
@@ -256,7 +256,7 @@ fn install_one(
         check_overwrites(&dst, pkg, &opts.filter, &list, force)?;
     }
 
-    let exec: Arc<Executor> = Arc::new(DefaultExecutor);
+    let exec: Arc<dyn Executor> = Arc::new(DefaultExecutor);
     let compile = ops::compile_ws(&ws, Some(source), opts, &exec).chain_err(|| {
         if let Some(td) = td_opt.take() {
             // preserve the temporary directory, so the user can inspect it
@@ -420,8 +420,8 @@ fn select_pkg<'a, T>(
     vers: Option<&str>,
     config: &Config,
     needs_update: bool,
-    list_all: &mut FnMut(&mut T) -> CargoResult<Vec<Package>>,
-) -> CargoResult<(Package, Box<Source + 'a>)>
+    list_all: &mut dyn FnMut(&mut T) -> CargoResult<Vec<Package>>,
+) -> CargoResult<(Package, Box<dyn Source + 'a>)>
 where
     T: Source + 'a,
 {

--- a/src/cargo/ops/cargo_install.rs
+++ b/src/cargo/ops/cargo_install.rs
@@ -7,8 +7,8 @@ use std::sync::Arc;
 use std::{env, fs};
 
 use semver::{Version, VersionReq};
+use serde::{Deserialize, Serialize};
 use tempfile::Builder as TempFileBuilder;
-use toml;
 
 use crate::core::compiler::{DefaultExecutor, Executor};
 use crate::core::package::PackageSet;

--- a/src/cargo/ops/cargo_new.rs
+++ b/src/cargo/ops/cargo_new.rs
@@ -47,7 +47,7 @@ impl NewProjectKind {
 }
 
 impl fmt::Display for NewProjectKind {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             NewProjectKind::Bin => "binary (application)",
             NewProjectKind::Lib => "library",
@@ -422,7 +422,7 @@ pub fn init(opts: &NewOptions, config: &Config) -> CargoResult<()> {
     Ok(())
 }
 
-fn mk(config: &Config, opts: &MkOptions) -> CargoResult<()> {
+fn mk(config: &Config, opts: &MkOptions<'_>) -> CargoResult<()> {
     let path = opts.path;
     let name = opts.name;
     let cfg = global_config(config)?;

--- a/src/cargo/ops/cargo_output_metadata.rs
+++ b/src/cargo/ops/cargo_output_metadata.rs
@@ -21,7 +21,7 @@ pub struct OutputMetadataOptions {
 /// Loads the manifest, resolves the dependencies of the package to the concrete
 /// used versions - considering overrides - and writes all dependencies in a JSON
 /// format to stdout.
-pub fn output_metadata(ws: &Workspace, opt: &OutputMetadataOptions) -> CargoResult<ExportInfo> {
+pub fn output_metadata(ws: &Workspace<'_>, opt: &OutputMetadataOptions) -> CargoResult<ExportInfo> {
     if opt.version != VERSION {
         bail!(
             "metadata version {} not supported, only {} is currently supported",
@@ -36,7 +36,7 @@ pub fn output_metadata(ws: &Workspace, opt: &OutputMetadataOptions) -> CargoResu
     }
 }
 
-fn metadata_no_deps(ws: &Workspace, _opt: &OutputMetadataOptions) -> CargoResult<ExportInfo> {
+fn metadata_no_deps(ws: &Workspace<'_>, _opt: &OutputMetadataOptions) -> CargoResult<ExportInfo> {
     Ok(ExportInfo {
         packages: ws.members().cloned().collect(),
         workspace_members: ws.members().map(|pkg| pkg.package_id()).collect(),
@@ -47,7 +47,7 @@ fn metadata_no_deps(ws: &Workspace, _opt: &OutputMetadataOptions) -> CargoResult
     })
 }
 
-fn metadata_full(ws: &Workspace, opt: &OutputMetadataOptions) -> CargoResult<ExportInfo> {
+fn metadata_full(ws: &Workspace<'_>, opt: &OutputMetadataOptions) -> CargoResult<ExportInfo> {
     let specs = Packages::All.to_package_id_specs(ws)?;
     let (package_set, resolve) = ops::resolve_ws_precisely(
         ws,

--- a/src/cargo/ops/cargo_output_metadata.rs
+++ b/src/cargo/ops/cargo_output_metadata.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
 use serde::ser;
+use serde::Serialize;
 
 use crate::core::resolver::Resolve;
 use crate::core::{Package, PackageId, Workspace};

--- a/src/cargo/ops/cargo_package.rs
+++ b/src/cargo/ops/cargo_package.rs
@@ -31,7 +31,7 @@ pub struct PackageOpts<'cfg> {
 
 static VCS_INFO_FILE: &'static str = ".cargo_vcs_info.json";
 
-pub fn package(ws: &Workspace, opts: &PackageOpts) -> CargoResult<Option<FileLock>> {
+pub fn package(ws: &Workspace<'_>, opts: &PackageOpts<'_>) -> CargoResult<Option<FileLock>> {
     ops::resolve_ws(ws)?;
     let pkg = ws.current()?;
     let config = ws.config();
@@ -276,7 +276,7 @@ fn check_vcs_file_collision(pkg: &Package, src_files: &[PathBuf]) -> CargoResult
 }
 
 fn tar(
-    ws: &Workspace,
+    ws: &Workspace<'_>,
     src_files: &[PathBuf],
     vcs_info: Option<&serde_json::Value>,
     dst: &File,
@@ -414,7 +414,7 @@ fn tar(
     Ok(())
 }
 
-fn run_verify(ws: &Workspace, tar: &FileLock, opts: &PackageOpts) -> CargoResult<()> {
+fn run_verify(ws: &Workspace<'_>, tar: &FileLock, opts: &PackageOpts<'_>) -> CargoResult<()> {
     let config = ws.config();
     let pkg = ws.current()?;
 
@@ -441,7 +441,7 @@ fn run_verify(ws: &Workspace, tar: &FileLock, opts: &PackageOpts) -> CargoResult
     let pkg_fingerprint = src.last_modified_file(&new_pkg)?;
     let ws = Workspace::ephemeral(new_pkg, config, None, true)?;
 
-    let exec: Arc<Executor> = Arc::new(DefaultExecutor);
+    let exec: Arc<dyn Executor> = Arc::new(DefaultExecutor);
     ops::compile_ws(
         &ws,
         None,

--- a/src/cargo/ops/cargo_package.rs
+++ b/src/cargo/ops/cargo_package.rs
@@ -6,8 +6,8 @@ use std::sync::Arc;
 
 use flate2::read::GzDecoder;
 use flate2::{Compression, GzBuilder};
-use git2;
-use serde_json;
+use log::debug;
+use serde_json::{self, json};
 use tar::{Archive, Builder, EntryType, Header};
 
 use crate::core::compiler::{BuildConfig, CompileMode, DefaultExecutor, Executor};

--- a/src/cargo/ops/cargo_pkgid.rs
+++ b/src/cargo/ops/cargo_pkgid.rs
@@ -2,7 +2,7 @@ use crate::core::{PackageIdSpec, Workspace};
 use crate::ops;
 use crate::util::CargoResult;
 
-pub fn pkgid(ws: &Workspace, spec: Option<&str>) -> CargoResult<PackageIdSpec> {
+pub fn pkgid(ws: &Workspace<'_>, spec: Option<&str>) -> CargoResult<PackageIdSpec> {
     let resolve = match ops::load_pkg_lockfile(ws)? {
         Some(resolve) => resolve,
         None => bail!("a Cargo.lock must exist for this command"),

--- a/src/cargo/ops/cargo_read_manifest.rs
+++ b/src/cargo/ops/cargo_read_manifest.rs
@@ -98,7 +98,7 @@ pub fn read_packages(
     }
 }
 
-fn walk(path: &Path, callback: &mut FnMut(&Path) -> CargoResult<bool>) -> CargoResult<()> {
+fn walk(path: &Path, callback: &mut dyn FnMut(&Path) -> CargoResult<bool>) -> CargoResult<()> {
     if !callback(path)? {
         trace!("not processing {}", path.display());
         return Ok(());

--- a/src/cargo/ops/cargo_read_manifest.rs
+++ b/src/cargo/ops/cargo_read_manifest.rs
@@ -3,6 +3,8 @@ use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
 
+use log::{info, trace};
+
 use crate::core::{EitherManifest, Package, PackageId, SourceId};
 use crate::util::errors::{CargoError, CargoResult};
 use crate::util::important_paths::find_project_manifest_exact;

--- a/src/cargo/ops/cargo_run.rs
+++ b/src/cargo/ops/cargo_run.rs
@@ -82,9 +82,7 @@ pub fn run(
     assert_eq!(compile.binaries.len(), 1);
     let exe = &compile.binaries[0];
     let exe = match util::without_prefix(exe, config.cwd()) {
-        Some(path) if path.file_name() == Some(path.as_os_str()) => {
-            Path::new(".").join(path)
-        }
+        Some(path) if path.file_name() == Some(path.as_os_str()) => Path::new(".").join(path),
         Some(path) => path.to_path_buf(),
         None => exe.to_path_buf(),
     };

--- a/src/cargo/ops/cargo_run.rs
+++ b/src/cargo/ops/cargo_run.rs
@@ -6,8 +6,8 @@ use crate::ops;
 use crate::util::{self, CargoResult, ProcessError};
 
 pub fn run(
-    ws: &Workspace,
-    options: &ops::CompileOptions,
+    ws: &Workspace<'_>,
+    options: &ops::CompileOptions<'_>,
     args: &[String],
 ) -> CargoResult<Option<ProcessError>> {
     let config = ws.config();

--- a/src/cargo/ops/cargo_test.rs
+++ b/src/cargo/ops/cargo_test.rs
@@ -13,8 +13,8 @@ pub struct TestOptions<'a> {
 }
 
 pub fn run_tests(
-    ws: &Workspace,
-    options: &TestOptions,
+    ws: &Workspace<'_>,
+    options: &TestOptions<'_>,
     test_args: &[String],
 ) -> CargoResult<Option<CargoTestError>> {
     let compilation = compile_tests(ws, options)?;
@@ -40,8 +40,8 @@ pub fn run_tests(
 }
 
 pub fn run_benches(
-    ws: &Workspace,
-    options: &TestOptions,
+    ws: &Workspace<'_>,
+    options: &TestOptions<'_>,
     args: &[String],
 ) -> CargoResult<Option<CargoTestError>> {
     let mut args = args.to_vec();
@@ -71,9 +71,9 @@ fn compile_tests<'a>(
 
 /// Run the unit and integration tests of a package.
 fn run_unit_tests(
-    options: &TestOptions,
+    options: &TestOptions<'_>,
     test_args: &[String],
-    compilation: &Compilation,
+    compilation: &Compilation<'_>,
 ) -> CargoResult<(Test, Vec<ProcessError>)> {
     let config = options.compile_opts.config;
     let cwd = options.compile_opts.config.cwd();
@@ -127,9 +127,9 @@ fn run_unit_tests(
 }
 
 fn run_doc_tests(
-    options: &TestOptions,
+    options: &TestOptions<'_>,
     test_args: &[String],
-    compilation: &Compilation,
+    compilation: &Compilation<'_>,
 ) -> CargoResult<(Test, Vec<ProcessError>)> {
     let mut errors = Vec::new();
     let config = options.compile_opts.config;

--- a/src/cargo/ops/fix.rs
+++ b/src/cargo/ops/fix.rs
@@ -36,7 +36,7 @@ pub struct FixOptions<'a> {
     pub broken_code: bool,
 }
 
-pub fn fix(ws: &Workspace, opts: &mut FixOptions) -> CargoResult<()> {
+pub fn fix(ws: &Workspace<'_>, opts: &mut FixOptions<'_>) -> CargoResult<()> {
     check_version_control(opts)?;
 
     // Spin up our lock server which our subprocesses will use to synchronize
@@ -87,7 +87,7 @@ pub fn fix(ws: &Workspace, opts: &mut FixOptions) -> CargoResult<()> {
     Ok(())
 }
 
-fn check_version_control(opts: &FixOptions) -> CargoResult<()> {
+fn check_version_control(opts: &FixOptions<'_>) -> CargoResult<()> {
     if opts.allow_no_vcs {
         return Ok(());
     }

--- a/src/cargo/ops/fix.rs
+++ b/src/cargo/ops/fix.rs
@@ -7,10 +7,9 @@ use std::process::{self, Command, ExitStatus};
 use std::str;
 
 use failure::{Error, ResultExt};
-use git2;
+use log::{debug, trace, warn};
 use rustfix::diagnostics::Diagnostic;
 use rustfix::{self, CodeFix};
-use serde_json;
 
 use crate::core::Workspace;
 use crate::ops::{self, CompileOptions};
@@ -402,7 +401,9 @@ fn rustfix_and_fix(
         // Make sure we've got a file associated with this suggestion and all
         // snippets point to the same file. Right now it's not clear what
         // we would do with multiple files.
-        let file_names = suggestion.solutions.iter()
+        let file_names = suggestion
+            .solutions
+            .iter()
             .flat_map(|s| s.replacements.iter())
             .map(|r| &r.snippet.file_name);
 

--- a/src/cargo/ops/lockfile.rs
+++ b/src/cargo/ops/lockfile.rs
@@ -8,7 +8,7 @@ use crate::util::errors::{CargoResult, CargoResultExt};
 use crate::util::toml as cargo_toml;
 use crate::util::Filesystem;
 
-pub fn load_pkg_lockfile(ws: &Workspace) -> CargoResult<Option<Resolve>> {
+pub fn load_pkg_lockfile(ws: &Workspace<'_>) -> CargoResult<Option<Resolve>> {
     if !ws.root().join("Cargo.lock").exists() {
         return Ok(None);
     }
@@ -29,7 +29,7 @@ pub fn load_pkg_lockfile(ws: &Workspace) -> CargoResult<Option<Resolve>> {
     Ok(resolve)
 }
 
-pub fn write_pkg_lockfile(ws: &Workspace, resolve: &Resolve) -> CargoResult<()> {
+pub fn write_pkg_lockfile(ws: &Workspace<'_>, resolve: &Resolve) -> CargoResult<()> {
     // Load the original lockfile if it exists.
     let ws_root = Filesystem::new(ws.root().to_path_buf());
     let orig = ws_root.open_ro("Cargo.lock", ws.config(), "Cargo.lock file");
@@ -113,7 +113,7 @@ pub fn write_pkg_lockfile(ws: &Workspace, resolve: &Resolve) -> CargoResult<()> 
     Ok(())
 }
 
-fn are_equal_lockfiles(mut orig: String, current: &str, ws: &Workspace) -> bool {
+fn are_equal_lockfiles(mut orig: String, current: &str, ws: &Workspace<'_>) -> bool {
     if has_crlf_line_endings(&orig) {
         orig = orig.replace("\r\n", "\n");
     }

--- a/src/cargo/ops/registry.rs
+++ b/src/cargo/ops/registry.rs
@@ -40,7 +40,7 @@ pub struct PublishOpts<'cfg> {
     pub registry: Option<String>,
 }
 
-pub fn publish(ws: &Workspace, opts: &PublishOpts) -> CargoResult<()> {
+pub fn publish(ws: &Workspace<'_>, opts: &PublishOpts<'_>) -> CargoResult<()> {
     let pkg = ws.current()?;
 
     if let Some(ref allowed_registries) = *pkg.publish() {

--- a/src/cargo/ops/registry.rs
+++ b/src/cargo/ops/registry.rs
@@ -5,11 +5,9 @@ use std::str;
 use std::time::Duration;
 use std::{cmp, env};
 
-use crate::registry::{NewCrate, NewCrateDependency, Registry};
+use crates_io::{NewCrate, NewCrateDependency, Registry};
 use curl::easy::{Easy, InfoType, SslOpt};
-use git2;
-use log::Level;
-
+use log::{log, Level};
 use url::percent_encoding::{percent_encode, QUERY_ENCODE_SET};
 
 use crate::core::dependency::Kind;

--- a/src/cargo/ops/resolve.rs
+++ b/src/cargo/ops/resolve.rs
@@ -1,5 +1,7 @@
 use std::collections::HashSet;
 
+use log::{debug, trace};
+
 use crate::core::registry::PackageRegistry;
 use crate::core::resolver::{self, Method, Resolve};
 use crate::core::{PackageId, PackageIdSpec, PackageSet, Source, SourceId, Workspace};

--- a/src/cargo/ops/resolve.rs
+++ b/src/cargo/ops/resolve.rs
@@ -26,7 +26,7 @@ pub fn resolve_ws<'a>(ws: &Workspace<'a>) -> CargoResult<(PackageSet<'a>, Resolv
 /// taking into account `paths` overrides and activated features.
 pub fn resolve_ws_precisely<'a>(
     ws: &Workspace<'a>,
-    source: Option<Box<Source + 'a>>,
+    source: Option<Box<dyn Source + 'a>>,
     features: &[String],
     all_features: bool,
     no_default_features: bool,
@@ -48,8 +48,8 @@ pub fn resolve_ws_precisely<'a>(
 
 pub fn resolve_ws_with_method<'a>(
     ws: &Workspace<'a>,
-    source: Option<Box<Source + 'a>>,
-    method: Method,
+    source: Option<Box<dyn Source + 'a>>,
+    method: Method<'_>,
     specs: &[PackageIdSpec],
 ) -> CargoResult<(PackageSet<'a>, Resolve)> {
     let mut registry = PackageRegistry::new(ws.config())?;
@@ -138,7 +138,7 @@ fn resolve_with_registry<'cfg>(
 pub fn resolve_with_previous<'cfg>(
     registry: &mut PackageRegistry<'cfg>,
     ws: &Workspace<'cfg>,
-    method: Method,
+    method: Method<'_>,
     previous: Option<&Resolve>,
     to_avoid: Option<&HashSet<PackageId>>,
     specs: &[PackageIdSpec],
@@ -399,10 +399,10 @@ pub fn get_resolved_packages<'a>(
 /// Note that this function, at the time of this writing, is basically the
 /// entire fix for #4127
 fn register_previous_locks(
-    ws: &Workspace,
-    registry: &mut PackageRegistry,
+    ws: &Workspace<'_>,
+    registry: &mut PackageRegistry<'_>,
     resolve: &Resolve,
-    keep: &Fn(&PackageId) -> bool,
+    keep: &dyn Fn(&PackageId) -> bool,
 ) {
     let path_pkg = |id: SourceId| {
         if !id.is_path() {

--- a/src/cargo/sources/config.rs
+++ b/src/cargo/sources/config.rs
@@ -73,7 +73,7 @@ impl<'cfg> SourceConfigMap<'cfg> {
         self.config
     }
 
-    pub fn load(&self, id: SourceId) -> CargoResult<Box<Source + 'cfg>> {
+    pub fn load(&self, id: SourceId) -> CargoResult<Box<dyn Source + 'cfg>> {
         debug!("loading: {}", id);
         let mut name = match self.id2name.get(&id) {
             Some(name) => name,

--- a/src/cargo/sources/config.rs
+++ b/src/cargo/sources/config.rs
@@ -7,6 +7,7 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
+use log::debug;
 use url::Url;
 
 use crate::core::{GitReference, Source, SourceId};

--- a/src/cargo/sources/directory.rs
+++ b/src/cargo/sources/directory.rs
@@ -4,9 +4,7 @@ use std::fs::File;
 use std::io::Read;
 use std::path::{Path, PathBuf};
 
-use hex;
-
-use serde_json;
+use serde::Deserialize;
 
 use crate::core::source::MaybePackage;
 use crate::core::{Dependency, Package, PackageId, Source, SourceId, Summary};

--- a/src/cargo/sources/directory.rs
+++ b/src/cargo/sources/directory.rs
@@ -38,13 +38,13 @@ impl<'cfg> DirectorySource<'cfg> {
 }
 
 impl<'cfg> Debug for DirectorySource<'cfg> {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(f, "DirectorySource {{ root: {:?} }}", self.root)
     }
 }
 
 impl<'cfg> Source for DirectorySource<'cfg> {
-    fn query(&mut self, dep: &Dependency, f: &mut FnMut(Summary)) -> CargoResult<()> {
+    fn query(&mut self, dep: &Dependency, f: &mut dyn FnMut(Summary)) -> CargoResult<()> {
         let packages = self.packages.values().map(|p| &p.0);
         let matches = packages.filter(|pkg| dep.matches(pkg.summary()));
         for summary in matches.map(|pkg| pkg.summary().clone()) {
@@ -53,7 +53,7 @@ impl<'cfg> Source for DirectorySource<'cfg> {
         Ok(())
     }
 
-    fn fuzzy_query(&mut self, _dep: &Dependency, f: &mut FnMut(Summary)) -> CargoResult<()> {
+    fn fuzzy_query(&mut self, _dep: &Dependency, f: &mut dyn FnMut(Summary)) -> CargoResult<()> {
         let packages = self.packages.values().map(|p| &p.0);
         for summary in packages.map(|pkg| pkg.summary().clone()) {
             f(summary);

--- a/src/cargo/sources/git/source.rs
+++ b/src/cargo/sources/git/source.rs
@@ -1,5 +1,6 @@
 use std::fmt::{self, Debug, Formatter};
 
+use log::trace;
 use url::Url;
 
 use crate::core::source::{MaybePackage, Source, SourceId};

--- a/src/cargo/sources/git/source.rs
+++ b/src/cargo/sources/git/source.rs
@@ -114,7 +114,7 @@ pub fn canonicalize_url(url: &Url) -> CargoResult<Url> {
 }
 
 impl<'cfg> Debug for GitSource<'cfg> {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(f, "git repo at {}", self.remote.url())?;
 
         match self.reference.pretty_ref() {
@@ -125,7 +125,7 @@ impl<'cfg> Debug for GitSource<'cfg> {
 }
 
 impl<'cfg> Source for GitSource<'cfg> {
-    fn query(&mut self, dep: &Dependency, f: &mut FnMut(Summary)) -> CargoResult<()> {
+    fn query(&mut self, dep: &Dependency, f: &mut dyn FnMut(Summary)) -> CargoResult<()> {
         let src = self
             .path_source
             .as_mut()
@@ -133,7 +133,7 @@ impl<'cfg> Source for GitSource<'cfg> {
         src.query(dep, f)
     }
 
-    fn fuzzy_query(&mut self, dep: &Dependency, f: &mut FnMut(Summary)) -> CargoResult<()> {
+    fn fuzzy_query(&mut self, dep: &Dependency, f: &mut dyn FnMut(Summary)) -> CargoResult<()> {
         let src = self
             .path_source
             .as_mut()

--- a/src/cargo/sources/git/utils.rs
+++ b/src/cargo/sources/git/utils.rs
@@ -7,7 +7,9 @@ use std::process::Command;
 
 use curl::easy::{Easy, List};
 use git2::{self, ObjectType};
+use log::{debug, info};
 use serde::ser;
+use serde::Serialize;
 use url::Url;
 
 use crate::core::GitReference;

--- a/src/cargo/sources/path.rs
+++ b/src/cargo/sources/path.rs
@@ -3,10 +3,10 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use filetime::FileTime;
-use git2;
 use glob::Pattern;
 use ignore::gitignore::GitignoreBuilder;
 use ignore::Match;
+use log::{trace, warn};
 
 use crate::core::source::MaybePackage;
 use crate::core::{Dependency, Package, PackageId, Source, SourceId, Summary};

--- a/src/cargo/sources/path.rs
+++ b/src/cargo/sources/path.rs
@@ -257,7 +257,7 @@ impl<'cfg> PathSource<'cfg> {
         &self,
         pkg: &Package,
         root: &Path,
-        filter: &mut FnMut(&Path) -> CargoResult<bool>,
+        filter: &mut dyn FnMut(&Path) -> CargoResult<bool>,
     ) -> Option<CargoResult<Vec<PathBuf>>> {
         // If this package is in a git repository, then we really do want to
         // query the git repository as it takes into account items such as
@@ -300,7 +300,7 @@ impl<'cfg> PathSource<'cfg> {
         &self,
         pkg: &Package,
         repo: &git2::Repository,
-        filter: &mut FnMut(&Path) -> CargoResult<bool>,
+        filter: &mut dyn FnMut(&Path) -> CargoResult<bool>,
     ) -> CargoResult<Vec<PathBuf>> {
         warn!("list_files_git {}", pkg.package_id());
         let index = repo.index()?;
@@ -422,7 +422,7 @@ impl<'cfg> PathSource<'cfg> {
     fn list_files_walk(
         &self,
         pkg: &Package,
-        filter: &mut FnMut(&Path) -> CargoResult<bool>,
+        filter: &mut dyn FnMut(&Path) -> CargoResult<bool>,
     ) -> CargoResult<Vec<PathBuf>> {
         let mut ret = Vec::new();
         PathSource::walk(pkg.root(), &mut ret, true, filter)?;
@@ -433,7 +433,7 @@ impl<'cfg> PathSource<'cfg> {
         path: &Path,
         ret: &mut Vec<PathBuf>,
         is_root: bool,
-        filter: &mut FnMut(&Path) -> CargoResult<bool>,
+        filter: &mut dyn FnMut(&Path) -> CargoResult<bool>,
     ) -> CargoResult<()> {
         if !fs::metadata(&path).map(|m| m.is_dir()).unwrap_or(false) {
             if (*filter)(path)? {
@@ -501,13 +501,13 @@ impl<'cfg> PathSource<'cfg> {
 }
 
 impl<'cfg> Debug for PathSource<'cfg> {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(f, "the paths source")
     }
 }
 
 impl<'cfg> Source for PathSource<'cfg> {
-    fn query(&mut self, dep: &Dependency, f: &mut FnMut(Summary)) -> CargoResult<()> {
+    fn query(&mut self, dep: &Dependency, f: &mut dyn FnMut(Summary)) -> CargoResult<()> {
         for s in self.packages.iter().map(|p| p.summary()) {
             if dep.matches(s) {
                 f(s.clone())
@@ -516,7 +516,7 @@ impl<'cfg> Source for PathSource<'cfg> {
         Ok(())
     }
 
-    fn fuzzy_query(&mut self, _dep: &Dependency, f: &mut FnMut(Summary)) -> CargoResult<()> {
+    fn fuzzy_query(&mut self, _dep: &Dependency, f: &mut dyn FnMut(Summary)) -> CargoResult<()> {
         for s in self.packages.iter().map(|p| p.summary()) {
             f(s.clone())
         }

--- a/src/cargo/sources/registry/index.rs
+++ b/src/cargo/sources/registry/index.rs
@@ -2,8 +2,8 @@ use std::collections::HashMap;
 use std::path::Path;
 use std::str;
 
+use log::{info, trace};
 use semver::Version;
-use serde_json;
 
 use crate::core::dependency::Dependency;
 use crate::core::{PackageId, SourceId, Summary};

--- a/src/cargo/sources/registry/index.rs
+++ b/src/cargo/sources/registry/index.rs
@@ -124,7 +124,7 @@ impl<'cfg> RegistryIndex<'cfg> {
     }
 
     /// Return the hash listed for a specified PackageId.
-    pub fn hash(&mut self, pkg: PackageId, load: &mut RegistryData) -> CargoResult<String> {
+    pub fn hash(&mut self, pkg: PackageId, load: &mut dyn RegistryData) -> CargoResult<String> {
         let name = pkg.name().as_str();
         let version = pkg.version();
         if let Some(s) = self.hashes.get(name).and_then(|v| v.get(version)) {
@@ -146,7 +146,7 @@ impl<'cfg> RegistryIndex<'cfg> {
     pub fn summaries(
         &mut self,
         name: &'static str,
-        load: &mut RegistryData,
+        load: &mut dyn RegistryData,
     ) -> CargoResult<&Vec<(Summary, bool)>> {
         if self.cache.contains_key(name) {
             return Ok(&self.cache[name]);
@@ -159,7 +159,7 @@ impl<'cfg> RegistryIndex<'cfg> {
     fn load_summaries(
         &mut self,
         name: &str,
-        load: &mut RegistryData,
+        load: &mut dyn RegistryData,
     ) -> CargoResult<Vec<(Summary, bool)>> {
         // Prepare the `RegistryData` which will lazily initialize internal data
         // structures. Note that this is also importantly needed to initialize
@@ -272,8 +272,8 @@ impl<'cfg> RegistryIndex<'cfg> {
     pub fn query_inner(
         &mut self,
         dep: &Dependency,
-        load: &mut RegistryData,
-        f: &mut FnMut(Summary),
+        load: &mut dyn RegistryData,
+        f: &mut dyn FnMut(Summary),
     ) -> CargoResult<()> {
         let source_id = self.source_id;
         let name = dep.package_name().as_str();

--- a/src/cargo/sources/registry/local.rs
+++ b/src/cargo/sources/registry/local.rs
@@ -40,7 +40,7 @@ impl<'cfg> RegistryData for LocalRegistry<'cfg> {
         &self,
         root: &Path,
         path: &Path,
-        data: &mut FnMut(&[u8]) -> CargoResult<()>,
+        data: &mut dyn FnMut(&[u8]) -> CargoResult<()>,
     ) -> CargoResult<()> {
         data(&paths::read_bytes(&root.join(path))?)
     }

--- a/src/cargo/sources/registry/mod.rs
+++ b/src/cargo/sources/registry/mod.rs
@@ -189,7 +189,7 @@ pub struct RegistrySource<'cfg> {
     src_path: Filesystem,
     config: &'cfg Config,
     updated: bool,
-    ops: Box<RegistryData + 'cfg>,
+    ops: Box<dyn RegistryData + 'cfg>,
     index: index::RegistryIndex<'cfg>,
     index_locked: bool,
 }
@@ -227,17 +227,17 @@ pub struct RegistryPackage<'a> {
 
 #[test]
 fn escaped_cher_in_json() {
-    let _: RegistryPackage = serde_json::from_str(
+    let _: RegistryPackage<'_> = serde_json::from_str(
         r#"{"name":"a","vers":"0.0.1","deps":[],"cksum":"bae3","features":{}}"#,
     )
     .unwrap();
-    let _: RegistryPackage = serde_json::from_str(
+    let _: RegistryPackage<'_> = serde_json::from_str(
         r#"{"name":"a","vers":"0.0.1","deps":[],"cksum":"bae3","features":{"test":["k","q"]},"links":"a-sys"}"#
     ).unwrap();
 
     // Now we add escaped cher all the places they can go
     // these are not valid, but it should error later than json parsing
-    let _: RegistryPackage = serde_json::from_str(
+    let _: RegistryPackage<'_> = serde_json::from_str(
         r#"{
         "name":"This name has a escaped cher in it \n\t\" ",
         "vers":"0.0.1",
@@ -344,7 +344,7 @@ pub trait RegistryData {
         &self,
         _root: &Path,
         path: &Path,
-        data: &mut FnMut(&[u8]) -> CargoResult<()>,
+        data: &mut dyn FnMut(&[u8]) -> CargoResult<()>,
     ) -> CargoResult<()>;
     fn config(&mut self) -> CargoResult<Option<RegistryConfig>>;
     fn update_index(&mut self) -> CargoResult<()>;
@@ -393,7 +393,7 @@ impl<'cfg> RegistrySource<'cfg> {
         source_id: SourceId,
         config: &'cfg Config,
         name: &str,
-        ops: Box<RegistryData + 'cfg>,
+        ops: Box<dyn RegistryData + 'cfg>,
         index_locked: bool,
     ) -> RegistrySource<'cfg> {
         RegistrySource {
@@ -505,7 +505,7 @@ impl<'cfg> RegistrySource<'cfg> {
 }
 
 impl<'cfg> Source for RegistrySource<'cfg> {
-    fn query(&mut self, dep: &Dependency, f: &mut FnMut(Summary)) -> CargoResult<()> {
+    fn query(&mut self, dep: &Dependency, f: &mut dyn FnMut(Summary)) -> CargoResult<()> {
         // If this is a precise dependency, then it came from a lockfile and in
         // theory the registry is known to contain this version. If, however, we
         // come back with no summaries, then our registry may need to be
@@ -534,7 +534,7 @@ impl<'cfg> Source for RegistrySource<'cfg> {
         })
     }
 
-    fn fuzzy_query(&mut self, dep: &Dependency, f: &mut FnMut(Summary)) -> CargoResult<()> {
+    fn fuzzy_query(&mut self, dep: &Dependency, f: &mut dyn FnMut(Summary)) -> CargoResult<()> {
         self.index.query_inner(dep, &mut *self.ops, f)
     }
 

--- a/src/cargo/sources/registry/mod.rs
+++ b/src/cargo/sources/registry/mod.rs
@@ -164,9 +164,9 @@ use std::fs::File;
 use std::path::{Path, PathBuf};
 
 use flate2::read::GzDecoder;
+use log::debug;
 use semver::Version;
-#[cfg(test)]
-use serde_json;
+use serde::Deserialize;
 use tar::Archive;
 
 use crate::core::dependency::{Dependency, Kind};

--- a/src/cargo/sources/registry/remote.rs
+++ b/src/cargo/sources/registry/remote.rs
@@ -96,7 +96,7 @@ impl<'cfg> RemoteRegistry<'cfg> {
         Ok(self.head.get().unwrap())
     }
 
-    fn tree(&self) -> CargoResult<Ref<git2::Tree>> {
+    fn tree(&self) -> CargoResult<Ref<'_, git2::Tree<'_>>> {
         {
             let tree = self.tree.borrow();
             if tree.is_some() {
@@ -119,7 +119,7 @@ impl<'cfg> RemoteRegistry<'cfg> {
         // (`RemoteRegistry`) so we then just need to ensure that the tree is
         // destroyed first in the destructor, hence the destructor on
         // `RemoteRegistry` below.
-        let tree = unsafe { mem::transmute::<git2::Tree, git2::Tree<'static>>(tree) };
+        let tree = unsafe { mem::transmute::<git2::Tree<'_>, git2::Tree<'static>>(tree) };
         *self.tree.borrow_mut() = Some(tree);
         Ok(Ref::map(self.tree.borrow(), |s| s.as_ref().unwrap()))
     }
@@ -143,7 +143,7 @@ impl<'cfg> RegistryData for RemoteRegistry<'cfg> {
         &self,
         _root: &Path,
         path: &Path,
-        data: &mut FnMut(&[u8]) -> CargoResult<()>,
+        data: &mut dyn FnMut(&[u8]) -> CargoResult<()>,
     ) -> CargoResult<()> {
         // Note that the index calls this method and the filesystem is locked
         // in the index, so we don't need to worry about an `update_index`

--- a/src/cargo/sources/registry/remote.rs
+++ b/src/cargo/sources/registry/remote.rs
@@ -6,10 +6,8 @@ use std::mem;
 use std::path::Path;
 use std::str;
 
-use git2;
-use hex;
 use lazycell::LazyCell;
-use serde_json;
+use log::{debug, trace};
 
 use crate::core::{PackageId, SourceId};
 use crate::sources::git;

--- a/src/cargo/sources/replaced.rs
+++ b/src/cargo/sources/replaced.rs
@@ -5,14 +5,14 @@ use crate::util::errors::{CargoResult, CargoResultExt};
 pub struct ReplacedSource<'cfg> {
     to_replace: SourceId,
     replace_with: SourceId,
-    inner: Box<Source + 'cfg>,
+    inner: Box<dyn Source + 'cfg>,
 }
 
 impl<'cfg> ReplacedSource<'cfg> {
     pub fn new(
         to_replace: SourceId,
         replace_with: SourceId,
-        src: Box<Source + 'cfg>,
+        src: Box<dyn Source + 'cfg>,
     ) -> ReplacedSource<'cfg> {
         ReplacedSource {
             to_replace,
@@ -39,7 +39,7 @@ impl<'cfg> Source for ReplacedSource<'cfg> {
         self.inner.requires_precise()
     }
 
-    fn query(&mut self, dep: &Dependency, f: &mut FnMut(Summary)) -> CargoResult<()> {
+    fn query(&mut self, dep: &Dependency, f: &mut dyn FnMut(Summary)) -> CargoResult<()> {
         let (replace_with, to_replace) = (self.replace_with, self.to_replace);
         let dep = dep.clone().map_source(to_replace, replace_with);
 
@@ -51,7 +51,7 @@ impl<'cfg> Source for ReplacedSource<'cfg> {
         Ok(())
     }
 
-    fn fuzzy_query(&mut self, dep: &Dependency, f: &mut FnMut(Summary)) -> CargoResult<()> {
+    fn fuzzy_query(&mut self, dep: &Dependency, f: &mut dyn FnMut(Summary)) -> CargoResult<()> {
         let (replace_with, to_replace) = (self.replace_with, self.to_replace);
         let dep = dep.clone().map_source(to_replace, replace_with);
 

--- a/src/cargo/util/cfg.rs
+++ b/src/cargo/util/cfg.rs
@@ -51,7 +51,7 @@ impl FromStr for Cfg {
 }
 
 impl fmt::Display for Cfg {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             Cfg::Name(ref s) => s.fmt(f),
             Cfg::KeyPair(ref k, ref v) => write!(f, "{} = \"{}\"", k, v),
@@ -101,7 +101,7 @@ impl FromStr for CfgExpr {
 }
 
 impl fmt::Display for CfgExpr {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             CfgExpr::Not(ref e) => write!(f, "not({})", e),
             CfgExpr::All(ref e) => write!(f, "all({})", CommaSep(e)),
@@ -111,10 +111,10 @@ impl fmt::Display for CfgExpr {
     }
 }
 
-struct CommaSep<'a, T: 'a>(&'a [T]);
+struct CommaSep<'a, T>(&'a [T]);
 
 impl<'a, T: fmt::Display> fmt::Display for CommaSep<'a, T> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for (i, v) in self.0.iter().enumerate() {
             if i > 0 {
                 write!(f, ", ")?;

--- a/src/cargo/util/command_prelude.rs
+++ b/src/cargo/util/command_prelude.rs
@@ -432,7 +432,7 @@ impl<'a> ArgMatchesExt for ArgMatches<'a> {
     }
 }
 
-pub fn values(args: &ArgMatches, name: &str) -> Vec<String> {
+pub fn values(args: &ArgMatches<'_>, name: &str) -> Vec<String> {
     args.values_of(name)
         .unwrap_or_default()
         .map(|s| s.to_string())

--- a/src/cargo/util/config.rs
+++ b/src/cargo/util/config.rs
@@ -180,7 +180,7 @@ impl Config {
     }
 
     /// Get a reference to the shell, for e.g. writing error messages
-    pub fn shell(&self) -> RefMut<Shell> {
+    pub fn shell(&self) -> RefMut<'_, Shell> {
         self.shell.borrow_mut()
     }
 
@@ -192,7 +192,7 @@ impl Config {
     }
 
     /// Get the path to the `rustc` executable
-    pub fn rustc(&self, ws: Option<&Workspace>) -> CargoResult<Rustc> {
+    pub fn rustc(&self, ws: Option<&Workspace<'_>>) -> CargoResult<Rustc> {
         let cache_location = ws.map(|ws| {
             ws.target_dir()
                 .join(".rustc_info.json")
@@ -875,7 +875,7 @@ impl ConfigKey {
 }
 
 impl fmt::Display for ConfigKey {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.to_config().fmt(f)
     }
 }
@@ -934,7 +934,7 @@ impl std::error::Error for ConfigError {
 // future, once this limitation is lifted, this should instead implement
 // `cause` and avoid doing the cause formatting here.
 impl fmt::Display for ConfigError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let message = self
             .error
             .iter_chain()
@@ -1349,7 +1349,7 @@ pub enum Definition {
 }
 
 impl fmt::Debug for ConfigValue {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             CV::Integer(i, ref path) => write!(f, "{} (from {})", i, path.display()),
             CV::Boolean(b, ref path) => write!(f, "{} (from {})", b, path.display()),
@@ -1539,7 +1539,7 @@ impl Definition {
 }
 
 impl fmt::Display for Definition {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             Definition::Path(ref p) => p.display().fmt(f),
             Definition::Environment(ref key) => write!(f, "environment variable `{}`", key),

--- a/src/cargo/util/config.rs
+++ b/src/cargo/util/config.rs
@@ -1,4 +1,3 @@
-use std;
 use std::cell::{RefCell, RefMut};
 use std::collections::hash_map::Entry::{Occupied, Vacant};
 use std::collections::hash_map::HashMap;
@@ -16,11 +15,9 @@ use std::time::Instant;
 use std::vec;
 
 use curl::easy::Easy;
-use failure;
-use jobserver;
 use lazycell::LazyCell;
+use serde::Deserialize;
 use serde::{de, de::IntoDeserializer};
-use toml;
 
 use crate::core::profiles::ConfigProfiles;
 use crate::core::shell::Verbosity;
@@ -1140,7 +1137,7 @@ impl<'de, 'config> de::Deserializer<'de> for Deserializer<'config> {
     }
 
     // These aren't really supported, yet.
-    forward_to_deserialize_any! {
+    serde::forward_to_deserialize_any! {
         f32 f64 char str bytes
         byte_buf unit unit_struct
         enum identifier ignored_any

--- a/src/cargo/util/diagnostic_server.rs
+++ b/src/cargo/util/diagnostic_server.rs
@@ -10,7 +10,8 @@ use std::sync::Arc;
 use std::thread::{self, JoinHandle};
 
 use failure::{Error, ResultExt};
-use serde_json;
+use log::warn;
+use serde::{Deserialize, Serialize};
 
 use crate::util::errors::CargoResult;
 use crate::util::{Config, ProcessBuilder};

--- a/src/cargo/util/diagnostic_server.rs
+++ b/src/cargo/util/diagnostic_server.rs
@@ -235,7 +235,7 @@ impl RustfixDiagnosticServer {
         })
     }
 
-    fn run(self, on_message: &Fn(Message), done: &AtomicBool) {
+    fn run(self, on_message: &dyn Fn(Message), done: &AtomicBool) {
         while let Ok((client, _)) = self.listener.accept() {
             let client = BufReader::new(client);
             match serde_json::from_reader(client) {

--- a/src/cargo/util/errors.rs
+++ b/src/cargo/util/errors.rs
@@ -5,9 +5,11 @@ use std::path::PathBuf;
 use std::process::{ExitStatus, Output};
 use std::str;
 
-use crate::core::{TargetKind, Workspace};
 use clap;
 use failure::{Context, Error, Fail};
+use log::trace;
+
+use crate::core::{TargetKind, Workspace};
 
 pub use failure::Error as CargoError;
 pub type CargoResult<T> = Result<T, Error>;

--- a/src/cargo/util/errors.rs
+++ b/src/cargo/util/errors.rs
@@ -58,19 +58,19 @@ impl Internal {
 }
 
 impl Fail for Internal {
-    fn cause(&self) -> Option<&Fail> {
+    fn cause(&self) -> Option<&dyn Fail> {
         self.inner.as_fail().cause()
     }
 }
 
 impl fmt::Debug for Internal {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.inner.fmt(f)
     }
 }
 
 impl fmt::Display for Internal {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.inner.fmt(f)
     }
 }
@@ -98,25 +98,25 @@ impl ManifestError {
     /// Returns an iterator over the `ManifestError` chain of causes.
     ///
     /// So if this error was not caused by another `ManifestError` this will be empty.
-    pub fn manifest_causes(&self) -> ManifestCauses {
+    pub fn manifest_causes(&self) -> ManifestCauses<'_> {
         ManifestCauses { current: self }
     }
 }
 
 impl Fail for ManifestError {
-    fn cause(&self) -> Option<&Fail> {
+    fn cause(&self) -> Option<&dyn Fail> {
         self.cause.as_fail().cause()
     }
 }
 
 impl fmt::Debug for ManifestError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.cause.fmt(f)
     }
 }
 
 impl fmt::Display for ManifestError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.cause.fmt(f)
     }
 }
@@ -189,7 +189,7 @@ impl CargoTestError {
         }
     }
 
-    pub fn hint(&self, ws: &Workspace) -> String {
+    pub fn hint(&self, ws: &Workspace<'_>) -> String {
         match self.test {
             Test::UnitTest {
                 ref kind,
@@ -346,6 +346,6 @@ pub fn internal<S: fmt::Display>(error: S) -> CargoError {
     _internal(&error)
 }
 
-fn _internal(error: &fmt::Display) -> CargoError {
+fn _internal(error: &dyn fmt::Display) -> CargoError {
     Internal::new(format_err!("{}", error)).into()
 }

--- a/src/cargo/util/flock.rs
+++ b/src/cargo/util/flock.rs
@@ -146,7 +146,7 @@ impl Filesystem {
 
     /// Returns an adaptor that can be used to print the path of this
     /// filesystem.
-    pub fn display(&self) -> Display {
+    pub fn display(&self) -> Display<'_> {
         self.root.display()
     }
 
@@ -271,8 +271,8 @@ fn acquire(
     config: &Config,
     msg: &str,
     path: &Path,
-    r#try: &Fn() -> io::Result<()>,
-    block: &Fn() -> io::Result<()>,
+    r#try: &dyn Fn() -> io::Result<()>,
+    block: &dyn Fn() -> io::Result<()>,
 ) -> CargoResult<()> {
     // File locking on Unix is currently implemented via `flock`, which is known
     // to be broken on NFS. We could in theory just ignore errors that happen on

--- a/src/cargo/util/graph.rs
+++ b/src/cargo/util/graph.rs
@@ -101,7 +101,7 @@ impl<N: Eq + Hash + Clone, E: Default> Default for Graph<N, E> {
 }
 
 impl<N: fmt::Display + Eq + Hash, E> fmt::Debug for Graph<N, E> {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(fmt, "Graph {{")?;
 
         for (n, e) in &self.nodes {

--- a/src/cargo/util/job.rs
+++ b/src/cargo/util/job.rs
@@ -42,18 +42,18 @@ mod imp {
 
 #[cfg(windows)]
 mod imp {
-    extern crate winapi;
-
     use std::io;
     use std::mem;
     use std::ptr;
 
-    use self::winapi::shared::minwindef::*;
-    use self::winapi::um::handleapi::*;
-    use self::winapi::um::jobapi2::*;
-    use self::winapi::um::processthreadsapi::*;
-    use self::winapi::um::winnt::HANDLE;
-    use self::winapi::um::winnt::*;
+    use log::info;
+
+    use winapi::shared::minwindef::*;
+    use winapi::um::handleapi::*;
+    use winapi::um::jobapi2::*;
+    use winapi::um::processthreadsapi::*;
+    use winapi::um::winnt::HANDLE;
+    use winapi::um::winnt::*;
 
     pub struct Setup {
         job: Handle,

--- a/src/cargo/util/machine_message.rs
+++ b/src/cargo/util/machine_message.rs
@@ -1,7 +1,8 @@
 use std::path::PathBuf;
 
 use serde::ser;
-use serde_json::{self, value::RawValue};
+use serde::Serialize;
+use serde_json::{self, json, value::RawValue};
 
 use crate::core::{PackageId, Target};
 

--- a/src/cargo/util/paths.rs
+++ b/src/cargo/util/paths.rs
@@ -211,7 +211,7 @@ pub fn bytes2path(bytes: &[u8]) -> CargoResult<PathBuf> {
     }
 }
 
-pub fn ancestors(path: &Path) -> PathAncestors {
+pub fn ancestors(path: &Path) -> PathAncestors<'_> {
     PathAncestors::new(path)
 }
 
@@ -221,7 +221,7 @@ pub struct PathAncestors<'a> {
 }
 
 impl<'a> PathAncestors<'a> {
-    fn new(path: &Path) -> PathAncestors {
+    fn new(path: &Path) -> PathAncestors<'_> {
         PathAncestors {
             current: Some(path),
             //HACK: avoid reading `~/.cargo/config` when testing Cargo itself.

--- a/src/cargo/util/process_builder.rs
+++ b/src/cargo/util/process_builder.rs
@@ -340,10 +340,8 @@ mod imp {
 
 #[cfg(windows)]
 mod imp {
-    extern crate winapi;
-
-    use self::winapi::shared::minwindef::{BOOL, DWORD, FALSE, TRUE};
-    use self::winapi::um::consoleapi::SetConsoleCtrlHandler;
+    use winapi::shared::minwindef::{BOOL, DWORD, FALSE, TRUE};
+    use winapi::um::consoleapi::SetConsoleCtrlHandler;
     use crate::util::{process_error, ProcessBuilder};
     use crate::CargoResult;
 

--- a/src/cargo/util/process_builder.rs
+++ b/src/cargo/util/process_builder.rs
@@ -30,7 +30,7 @@ pub struct ProcessBuilder {
 }
 
 impl fmt::Display for ProcessBuilder {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "`{}", self.program.to_string_lossy())?;
 
         for arg in &self.args {
@@ -195,8 +195,8 @@ impl ProcessBuilder {
     /// Optionally, output can be passed to errors using `print_output`
     pub fn exec_with_streaming(
         &self,
-        on_stdout_line: &mut FnMut(&str) -> CargoResult<()>,
-        on_stderr_line: &mut FnMut(&str) -> CargoResult<()>,
+        on_stdout_line: &mut dyn FnMut(&str) -> CargoResult<()>,
+        on_stderr_line: &mut dyn FnMut(&str) -> CargoResult<()>,
         capture_output: bool,
     ) -> CargoResult<Output> {
         let mut stdout = Vec::new();

--- a/src/cargo/util/profile.rs
+++ b/src/cargo/util/profile.rs
@@ -56,7 +56,7 @@ impl Drop for Profiler {
         MESSAGES.with(|msgs| msgs.borrow_mut().push(msg));
 
         if stack_len == 0 {
-            fn print(lvl: usize, msgs: &[Message], enabled: usize, stdout: &mut StdoutLock) {
+            fn print(lvl: usize, msgs: &[Message], enabled: usize, stdout: &mut StdoutLock<'_>) {
                 if lvl > enabled {
                     return;
                 }

--- a/src/cargo/util/read2.rs
+++ b/src/cargo/util/read2.rs
@@ -97,7 +97,7 @@ mod imp {
     pub fn read2(
         out_pipe: ChildStdout,
         err_pipe: ChildStderr,
-        data: &mut FnMut(bool, &mut Vec<u8>, bool),
+        data: &mut dyn FnMut(bool, &mut Vec<u8>, bool),
     ) -> io::Result<()> {
         let mut out = Vec::new();
         let mut err = Vec::new();

--- a/src/cargo/util/read2.rs
+++ b/src/cargo/util/read2.rs
@@ -12,7 +12,7 @@ mod imp {
     pub fn read2(
         mut out_pipe: ChildStdout,
         mut err_pipe: ChildStderr,
-        data: &mut FnMut(bool, &mut Vec<u8>, bool),
+        data: &mut dyn FnMut(bool, &mut Vec<u8>, bool),
     ) -> io::Result<()> {
         unsafe {
             libc::fcntl(out_pipe.as_raw_fd(), libc::F_SETFL, libc::O_NONBLOCK);

--- a/src/cargo/util/read2.rs
+++ b/src/cargo/util/read2.rs
@@ -77,18 +77,15 @@ mod imp {
 
 #[cfg(windows)]
 mod imp {
-    extern crate miow;
-    extern crate winapi;
-
     use std::io;
     use std::os::windows::prelude::*;
     use std::process::{ChildStderr, ChildStdout};
     use std::slice;
 
-    use self::miow::iocp::{CompletionPort, CompletionStatus};
-    use self::miow::pipe::NamedPipe;
-    use self::miow::Overlapped;
-    use self::winapi::shared::winerror::ERROR_BROKEN_PIPE;
+    use miow::iocp::{CompletionPort, CompletionStatus};
+    use miow::pipe::NamedPipe;
+    use miow::Overlapped;
+    use winapi::shared::winerror::ERROR_BROKEN_PIPE;
 
     struct Pipe<'a> {
         dst: &'a mut Vec<u8>,

--- a/src/cargo/util/rustc.rs
+++ b/src/cargo/util/rustc.rs
@@ -7,7 +7,8 @@ use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::sync::Mutex;
 
-use serde_json;
+use log::{debug, info, warn};
+use serde::{Deserialize, Serialize};
 
 use crate::util::paths;
 use crate::util::{self, internal, profile, CargoResult, ProcessBuilder};

--- a/src/cargo/util/sha256.rs
+++ b/src/cargo/util/sha256.rs
@@ -1,4 +1,4 @@
-extern crate crypto_hash;
+use crypto_hash;
 use self::crypto_hash::{Algorithm, Hasher};
 use std::io::Write;
 

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -5,11 +5,11 @@ use std::path::{Path, PathBuf};
 use std::rc::Rc;
 use std::str;
 
+use log::{debug, trace};
 use semver::{self, VersionReq};
-use serde::de::{self, Deserialize};
+use serde::de;
 use serde::ser;
-use serde_ignored;
-use toml;
+use serde::{Deserialize, Serialize};
 use url::Url;
 
 use crate::core::dependency::{Kind, Platform};
@@ -152,7 +152,7 @@ type TomlExampleTarget = TomlTarget;
 type TomlTestTarget = TomlTarget;
 type TomlBenchTarget = TomlTarget;
 
-#[derive(Debug, Serialize)]
+#[derive(Serialize, Debug)]
 #[serde(untagged)]
 pub enum TomlDependency {
     Simple(String),

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -92,7 +92,7 @@ fn do_read_manifest(
         Ok((EitherManifest::Virtual(m), paths))
     };
 
-    fn stringify(dst: &mut String, path: &serde_ignored::Path) {
+    fn stringify(dst: &mut String, path: &serde_ignored::Path<'_>) {
         use serde_ignored::Path;
 
         match *path {
@@ -169,7 +169,7 @@ impl<'de> de::Deserialize<'de> for TomlDependency {
         impl<'de> de::Visitor<'de> for TomlDependencyVisitor {
             type Value = TomlDependency;
 
-            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
                 formatter.write_str(
                     "a version string like \"0.9.8\" or a \
                      detailed dependency like { version = \"0.9.8\" }",
@@ -285,7 +285,7 @@ impl<'de> de::Deserialize<'de> for TomlOptLevel {
         impl<'de> de::Visitor<'de> for Visitor {
             type Value = TomlOptLevel;
 
-            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
                 formatter.write_str("an optimization level")
             }
 
@@ -345,7 +345,7 @@ impl<'de> de::Deserialize<'de> for U32OrBool {
         impl<'de> de::Visitor<'de> for Visitor {
             type Value = U32OrBool;
 
-            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
                 formatter.write_str("a boolean or an integer")
             }
 
@@ -500,7 +500,7 @@ impl<'de> de::Deserialize<'de> for StringOrVec {
         impl<'de> de::Visitor<'de> for Visitor {
             type Value = StringOrVec;
 
-            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
                 formatter.write_str("string or list of strings")
             }
 
@@ -541,7 +541,7 @@ impl<'de> de::Deserialize<'de> for StringOrBool {
         impl<'de> de::Visitor<'de> for Visitor {
             type Value = StringOrBool;
 
-            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
                 formatter.write_str("a boolean or a string")
             }
 
@@ -581,7 +581,7 @@ impl<'de> de::Deserialize<'de> for VecStringOrBool {
         impl<'de> de::Visitor<'de> for Visitor {
             type Value = VecStringOrBool;
 
-            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
                 formatter.write_str("a boolean or vector of strings")
             }
 
@@ -885,7 +885,7 @@ impl TomlManifest {
             };
 
             fn process_dependencies(
-                cx: &mut Context,
+                cx: &mut Context<'_, '_>,
                 new_deps: Option<&BTreeMap<String, TomlDependency>>,
                 kind: Option<Kind>,
             ) -> CargoResult<()> {
@@ -1155,7 +1155,7 @@ impl TomlManifest {
         ))
     }
 
-    fn replace(&self, cx: &mut Context) -> CargoResult<Vec<(PackageIdSpec, Dependency)>> {
+    fn replace(&self, cx: &mut Context<'_, '_>) -> CargoResult<Vec<(PackageIdSpec, Dependency)>> {
         if self.patch.is_some() && self.replace.is_some() {
             bail!("cannot specify both [replace] and [patch]");
         }
@@ -1200,7 +1200,7 @@ impl TomlManifest {
         Ok(replace)
     }
 
-    fn patch(&self, cx: &mut Context) -> CargoResult<HashMap<Url, Vec<Dependency>>> {
+    fn patch(&self, cx: &mut Context<'_, '_>) -> CargoResult<HashMap<Url, Vec<Dependency>>> {
         let mut patch = HashMap::new();
         for (url, deps) in self.patch.iter().flat_map(|x| x) {
             let url = match &url[..] {
@@ -1262,7 +1262,7 @@ impl TomlDependency {
     fn to_dependency(
         &self,
         name: &str,
-        cx: &mut Context,
+        cx: &mut Context<'_, '_>,
         kind: Option<Kind>,
     ) -> CargoResult<Dependency> {
         match *self {
@@ -1280,7 +1280,7 @@ impl DetailedTomlDependency {
     fn to_dependency(
         &self,
         name_in_toml: &str,
-        cx: &mut Context,
+        cx: &mut Context<'_, '_>,
         kind: Option<Kind>,
     ) -> CargoResult<Dependency> {
         if self.version.is_none() && self.path.is_none() && self.git.is_none() {
@@ -1522,7 +1522,7 @@ impl TomlTarget {
 }
 
 impl fmt::Debug for PathValue {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.0.fmt(f)
     }
 }

--- a/src/cargo/util/toml/targets.rs
+++ b/src/cargo/util/toml/targets.rs
@@ -510,7 +510,7 @@ fn clean_targets_with_legacy_path(
     autodiscover: Option<bool>,
     warnings: &mut Vec<String>,
     errors: &mut Vec<String>,
-    legacy_path: &mut FnMut(&TomlTarget) -> Option<PathBuf>,
+    legacy_path: &mut dyn FnMut(&TomlTarget) -> Option<PathBuf>,
     autodiscover_flag_name: &str,
 ) -> CargoResult<Vec<(PathBuf, TomlTarget)>> {
     let toml_targets = toml_targets_and_inferred(
@@ -785,7 +785,7 @@ fn target_path(
     target_kind: &str,
     package_root: &Path,
     edition: Edition,
-    legacy_path: &mut FnMut(&TomlTarget) -> Option<PathBuf>,
+    legacy_path: &mut dyn FnMut(&TomlTarget) -> Option<PathBuf>,
 ) -> Result<PathBuf, String> {
     if let Some(ref path) = target.path {
         // Should we verify that this path exists here?

--- a/tests/testsuite/config.rs
+++ b/tests/testsuite/config.rs
@@ -1,11 +1,13 @@
+use std::borrow::Borrow;
+use std::collections;
+use std::fs;
+
 use crate::support::{lines_match, paths, project};
 use cargo::core::{enable_nightly_features, Shell};
 use cargo::util::config::{self, Config};
 use cargo::util::toml::{self, VecStringOrBool as VSOB};
 use cargo::CargoError;
-use std::borrow::Borrow;
-use std::collections;
-use std::fs;
+use serde::Deserialize;
 
 #[test]
 fn read_env_vars_for_config() {

--- a/tests/testsuite/directory.rs
+++ b/tests/testsuite/directory.rs
@@ -1,8 +1,9 @@
-use serde_json;
 use std::collections::HashMap;
 use std::fs::{self, File};
 use std::io::prelude::*;
 use std::str;
+
+use serde::Serialize;
 
 use crate::support::cargo_process;
 use crate::support::git;

--- a/tests/testsuite/main.rs
+++ b/tests/testsuite/main.rs
@@ -1,3 +1,4 @@
+#![warn(rust_2018_idioms)] // while we're getting used to 2018
 #![deny(warnings)]
 #![cfg_attr(feature = "cargo-clippy", allow(blacklisted_name))]
 #![cfg_attr(feature = "cargo-clippy", allow(explicit_iter_loop))]

--- a/tests/testsuite/main.rs
+++ b/tests/testsuite/main.rs
@@ -3,15 +3,6 @@
 #![cfg_attr(feature = "cargo-clippy", allow(explicit_iter_loop))]
 
 #[macro_use]
-extern crate lazy_static;
-#[macro_use]
-extern crate proptest;
-#[macro_use]
-extern crate serde_derive;
-#[macro_use]
-extern crate serde_json;
-
-#[macro_use]
 mod support;
 
 mod alt_registry;

--- a/tests/testsuite/resolve.rs
+++ b/tests/testsuite/resolve.rs
@@ -14,6 +14,7 @@ use crate::support::resolver::{
 
 use proptest::collection::vec;
 use proptest::prelude::*;
+use proptest::*;
 
 /// NOTE: proptest is a form of fuzz testing. It generates random input and makes shore that
 /// certain universal truths are upheld. Therefore, it can pass when there is a problem,

--- a/tests/testsuite/support/registry.rs
+++ b/tests/testsuite/support/registry.rs
@@ -333,7 +333,7 @@ impl Package {
             .deps
             .iter()
             .map(|dep| {
-                json!({
+                serde_json::json!({
                     "name": dep.name,
                     "req": dep.vers,
                     "features": dep.features,
@@ -351,7 +351,7 @@ impl Package {
             t!(t!(File::open(&self.archive_dst())).read_to_end(&mut c));
             cksum(&c)
         };
-        let line = json!({
+        let line = serde_json::json!({
             "name": self.name,
             "vers": self.vers,
             "deps": deps,

--- a/tests/testsuite/support/resolver.rs
+++ b/tests/testsuite/support/resolver.rs
@@ -172,7 +172,7 @@ macro_rules! pkg {
 }
 
 fn registry_loc() -> SourceId {
-    lazy_static! {
+    lazy_static::lazy_static! {
         static ref EXAMPLE_DOT_COM: SourceId =
             SourceId::for_registry(&"http://example.com".to_url().unwrap()).unwrap();
     }


### PR DESCRIPTION
Run a few lints, hand-edit a few things, otherwise try to help push Cargo into the 2018 edition!