### PR TITLE
Display errors when `cargo fix` fails.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ log = "0.4.6"
 libgit2-sys = "0.7.9"
 num_cpus = "1.0"
 opener = "0.3.0"
-rustfix = "0.4.2"
+rustfix = "0.4.3"
 same-file = "1"
 semver = { version = "0.9.0", features = ["serde"] }
 serde = { version = "1.0.82", features = ['derive'] }
@@ -108,3 +108,6 @@ doc = false
 deny-warnings = []
 vendored-openssl = ['openssl/vendored']
 pretty-env-logger = ['pretty_env_logger']
+
+[patch.crates-io]
+rustfix = {git="https://github.com/ehuss/rustfix", branch="pub-rendered"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ log = "0.4.6"
 libgit2-sys = "0.7.9"
 num_cpus = "1.0"
 opener = "0.3.0"
-rustfix = "0.4.3"
+rustfix = "0.4.4"
 same-file = "1"
 semver = { version = "0.9.0", features = ["serde"] }
 serde = { version = "1.0.82", features = ['derive'] }
@@ -108,6 +108,3 @@ doc = false
 deny-warnings = []
 vendored-openssl = ['openssl/vendored']
 pretty-env-logger = ['pretty_env_logger']
-
-[patch.crates-io]
-rustfix = {git="https://github.com/ehuss/rustfix", branch="pub-rendered"}

--- a/src/cargo/ops/fix.rs
+++ b/src/cargo/ops/fix.rs
@@ -496,7 +496,9 @@ fn log_failed_fix(stderr: &[u8]) -> Result<(), Error> {
         .filter(|x| !x.is_empty())
         .filter_map(|line| serde_json::from_str::<Diagnostic>(line).ok());
     let mut files = BTreeSet::new();
+    let mut errors = Vec::new();
     for diagnostic in diagnostics {
+        errors.push(diagnostic.rendered.unwrap_or(diagnostic.message));
         for span in diagnostic.spans.into_iter() {
             files.insert(span.file_name);
         }
@@ -516,7 +518,12 @@ fn log_failed_fix(stderr: &[u8]) -> Result<(), Error> {
     }
 
     let files = files.into_iter().collect();
-    Message::FixFailed { files, krate }.post()?;
+    Message::FixFailed {
+        files,
+        krate,
+        errors,
+    }
+    .post()?;
 
     Ok(())
 }


### PR DESCRIPTION
It can be difficult to figure out what's wrong when a user reports that `cargo fix` fails. It can be hard to figure out which suggestion caused a compile error, especially if the error is in another file/location.
