### PR TITLE
Remove extern crate usage in custom build

### DIFF
--- a/src/cargo/core/compiler/custom_build.rs
+++ b/src/cargo/core/compiler/custom_build.rs
@@ -571,7 +571,7 @@ fn prepare_metabuild<'a, 'cfg>(
         })
         .collect();
     for dep in &meta_deps {
-        output.push(format!("extern crate {};\n", dep));
+        output.push(format!("use {};\n", dep));
     }
     output.push("fn main() {\n".to_string());
     for dep in &meta_deps {


### PR DESCRIPTION
Is this needed?  Let's find out together.