### PR TITLE
Allow testsuite warnings in dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ matrix:
         - rustup toolchain install nightly
         - cargo +nightly generate-lockfile -Z minimal-versions
         - cargo -V
-        - cargo test
+        - cargo test --features=deny-warnings
       if: branch != master OR type = pull_request
 
     - env: TARGET=x86_64-unknown-linux-gnu
@@ -50,7 +50,7 @@ matrix:
       install:
         - mdbook --help || cargo install mdbook --force
       script:
-        - cargo test
+        - cargo test --features=deny-warnings
         - cargo doc --no-deps
         - (cd src/doc && mdbook build --dest-dir ../../target/doc)
       if: branch != master OR type = pull_request
@@ -61,7 +61,7 @@ matrix:
 before_script:
   - rustup target add $ALT
 script:
-  - cargo test
+  - cargo test --features=deny-warnings
 
 notifications:
   email:

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -114,10 +114,6 @@ and run with `rustup run` (e.g `rustup run nightly
 <path-to-cargo>/target/debug/cargo <args>..`) (or set the `RUSTC` env var to point
 to nightly rustc).
 
-Because the test suite has `#![deny(warnings)]` at times you might find it
-convenient to override this with `RUSTFLAGS`, for example
-`RUSTFLAGS="--cap-lints warn" cargo build`.
-
 ## Logging
 
 Cargo uses [`env_logger`](https://docs.rs/env_logger/*/env_logger/), so you can set

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,5 +105,6 @@ test = false
 doc = false
 
 [features]
+deny-warnings = []
 vendored-openssl = ['openssl/vendored']
 pretty-env-logger = ['pretty_env_logger']

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,5 +25,5 @@ test_script:
   # we don't have ci time to run the full `cargo test` with `minimal-versions` like
   # - if defined MINIMAL_VERSIONS cargo +nightly generate-lockfile -Z minimal-versions && cargo +stable test
   # so we just run `cargo check --tests` like
-  - if defined MINIMAL_VERSIONS cargo +nightly generate-lockfile -Z minimal-versions && cargo +1.31.0 check --tests
-  - if NOT defined MINIMAL_VERSIONS cargo test
+  - if defined MINIMAL_VERSIONS cargo +nightly generate-lockfile -Z minimal-versions && cargo +1.31.0 check --tests --features=deny-warnings
+  - if NOT defined MINIMAL_VERSIONS cargo test --features=deny-warnings

--- a/tests/testsuite/main.rs
+++ b/tests/testsuite/main.rs
@@ -1,5 +1,5 @@
 #![warn(rust_2018_idioms)] // while we're getting used to 2018
-#![deny(warnings)]
+#![cfg_attr(feature="deny-warnings", deny(warnings))]
 #![cfg_attr(feature = "cargo-clippy", allow(blacklisted_name))]
 #![cfg_attr(feature = "cargo-clippy", allow(explicit_iter_loop))]
 


### PR DESCRIPTION
This makes the deny(warnings) in the testsuite conditional on a new
"deny-warnings" feature, that is then enabled in CI.

Ideally I could use the (reasonably well established) CI env var (like
we do for proptests), but I don't know how to get the attribute to be
defined in terms of an env var.