### PR TITLE
Fix panic-in-panic in tests.

### DIFF
--- a/tests/testsuite/support/mod.rs
+++ b/tests/testsuite/support/mod.rs
@@ -1162,7 +1162,7 @@ impl Execs {
 
 impl Drop for Execs {
     fn drop(&mut self) {
-        if !self.ran {
+        if !self.ran && !std::thread::panicking() {
             panic!("forgot to run this command");
         }
     }


### PR DESCRIPTION
There are some very rare circumstances that can cause a double panic during
development. For example, `.with_json("")` (or any invalid JSON) will panic, and then the drop
will also panic.  This can cause a confusing SIGILL.