### PR TITLE
Make cargo preduce dependency binaries to a shared directory for reuse

### DIFF
--- a/src/cargo/core/compiler/build_context/mod.rs
+++ b/src/cargo/core/compiler/build_context/mod.rs
@@ -160,15 +160,20 @@ impl<'a, 'cfg> BuildContext<'a, 'cfg> {
         self.build_config.jobs
     }
 
-    pub fn rustflags_args(&self, unit: &Unit<'_>) -> CargoResult<Vec<String>> {
+    /// Get the RUSTFLAGS argument by its kind
+    pub fn rustflags_args_for(&self, kind:Kind) -> CargoResult<Vec<String>> {
         env_args(
             self.config,
             &self.build_config.requested_target,
             self.host_triple(),
-            self.info(unit.kind).cfg(),
-            unit.kind,
+            self.info(kind).cfg(),
+            kind,
             "RUSTFLAGS",
         )
+    }
+
+    pub fn rustflags_args(&self, unit: &Unit<'_>) -> CargoResult<Vec<String>> {
+        self.rustflags_args_for(unit.kind)
     }
 
     pub fn rustdocflags_args(&self, unit: &Unit<'_>) -> CargoResult<Vec<String>> {

--- a/src/cargo/core/compiler/context/compilation_files.rs
+++ b/src/cargo/core/compiler/context/compilation_files.rs
@@ -1,12 +1,10 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::env;
 use std::fmt;
 use std::fs::metadata;
 use std::hash::{Hash, Hasher, SipHasher};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-
-use std::collections::HashSet;
 
 use lazycell::LazyCell;
 

--- a/src/cargo/core/compiler/context/compilation_files.rs
+++ b/src/cargo/core/compiler/context/compilation_files.rs
@@ -89,7 +89,7 @@ impl<'a, 'cfg: 'a> CompilationFiles<'a, 'cfg> {
 
         let shared_target_dir = env::var("CARGO_SHARED_TARGET_DIR")
             .ok()
-            .map_or(None, |path| path.parse().ok());
+            .map_or(None, |path| Some(PathBuf::from(path)));
 
         CompilationFiles {
             ws,

--- a/src/cargo/core/compiler/context/mod.rs
+++ b/src/cargo/core/compiler/context/mod.rs
@@ -361,6 +361,11 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
         self.files.as_ref().unwrap().outputs(unit, self.bcx)
     }
 
+    /// Examine if the target is already in the global cache
+    pub fn in_shared_dir(&self, unit: &Unit<'a>) -> bool {
+        self.files.as_ref().unwrap().in_shared_dir(unit, self.bcx)
+    }
+
     /// For a package, return all targets which are registered as dependencies
     /// for that package.
     // TODO: this ideally should be `-> &[Unit<'a>]`

--- a/src/cargo/core/compiler/job_queue.rs
+++ b/src/cargo/core/compiler/job_queue.rs
@@ -30,7 +30,7 @@ use super::{BuildContext, BuildPlan, CompileMode, Context, Kind, Unit};
 /// actual compilation step of each package. Packages enqueue units of work and
 /// then later on the entire graph is processed and compiled.
 pub struct JobQueue<'a> {
-    queue: DependencyQueue<Key<'a>, Vec<(Job, Freshness, bool)>>,
+    queue: DependencyQueue<Key<'a>, Vec<(Job, Freshness)>>,
     tx: Sender<Message<'a>>,
     rx: Receiver<Message<'a>>,
     active: Vec<Key<'a>>,
@@ -153,13 +153,12 @@ impl<'a> JobQueue<'a> {
         unit: &Unit<'a>,
         job: Job,
         fresh: Freshness,
-        cached: bool
     ) -> CargoResult<()> {
         let key = Key::new(unit);
         let deps = key.dependencies(cx)?;
         self.queue
             .queue(Fresh, &key, Vec::new(), &deps)
-            .push((job, fresh, cached));
+            .push((job, fresh));
         *self.counts.entry(key.pkg).or_insert(0) += 1;
         Ok(())
     }
@@ -240,7 +239,7 @@ impl<'a> JobQueue<'a> {
             // start requesting job tokens. Each job after the first needs to
             // request a token.
             while let Some((fresh, key, jobs)) = self.queue.dequeue() {
-                let total_fresh = jobs.iter().fold(fresh, |fresh, &(_, f, _)| f.combine(fresh));
+                let total_fresh = jobs.iter().fold(fresh, |fresh, &(_, f)| f.combine(fresh));
                 self.pending.insert(
                     key,
                     PendingBuild {
@@ -248,8 +247,8 @@ impl<'a> JobQueue<'a> {
                         fresh: total_fresh,
                     },
                 );
-                for (job, f, cached) in jobs {
-                    queue.push((key, job, f.combine(fresh), cached));
+                for (job, f) in jobs {
+                    queue.push((key, job, f.combine(fresh)));
                     if !self.active.is_empty() || !queue.is_empty() {
                         jobserver_helper.request_token();
                     }
@@ -260,8 +259,8 @@ impl<'a> JobQueue<'a> {
             // try to spawn it so long as we've got a jobserver token which says
             // we're able to perform some parallel work.
             while error.is_none() && self.active.len() < tokens.len() + 1 && !queue.is_empty() {
-                let (key, job, fresh, cached) = queue.remove(0);
-                self.run(key, fresh, job, cx.bcx.config, scope, build_plan, cached)?;
+                let (key, job, fresh) = queue.remove(0);
+                self.run(key, fresh, job, cx.bcx.config, scope, build_plan)?;
             }
 
             // If after all that we're not actually running anything then we're
@@ -395,7 +394,6 @@ impl<'a> JobQueue<'a> {
         config: &Config,
         scope: &Scope<'a>,
         build_plan: bool,
-        cached: bool
     ) -> CargoResult<()> {
         info!("start: {:?}", key);
 
@@ -410,7 +408,7 @@ impl<'a> JobQueue<'a> {
 
         if !build_plan {
             // Print out some nice progress information
-            self.note_working_on(config, &key, fresh, cached)?;
+            self.note_working_on(config, &key, fresh)?;
         }
 
         match fresh {
@@ -473,7 +471,6 @@ impl<'a> JobQueue<'a> {
         config: &Config,
         key: &Key<'a>,
         fresh: Freshness,
-        cached: bool
     ) -> CargoResult<()> {
         if (self.compiled.contains(&key.pkg) && !key.mode.is_doc())
             || (self.documented.contains(&key.pkg) && key.mode.is_doc())
@@ -496,12 +493,7 @@ impl<'a> JobQueue<'a> {
                     if key.mode.is_check() {
                         config.shell().status("Checking", key.pkg)?;
                     } else {
-                        if cached 
-                        {
-                            config.shell().status("Cached", key.pkg)?;
-                        } else {
-                            config.shell().status("Compiling", key.pkg)?;
-                        }
+                        config.shell().status("Compiling", key.pkg)?;
                     }
                 }
             }


### PR DESCRIPTION
Currently Cargo re-compiles all the dependencies for every package. But in fact, there's many dependency binaries can be shared across crates. In addition, once the target directory is cleaned, cargo will start to build all the dependencies again.

This change makes Cargo able to reuse the library binaries across the packages by setting environment variable `CARGO_SHARED_TARGET_DIR`. When this environment variable is set, the non-primary unit will produce output in `CARGO_SHARED_TARGET_DIR` and if the target is already in the directory `cargo` won't call `rustc` again.

The target name is determined by the name of the crate and the metadata of the output which also mixed the version, dependency versions, features and cfgs. 

Related discussion: https://internals.rust-lang.org/t/idea-cargo-global-binary-cache/9002