### PR TITLE
Registry API Command Versioning

### DIFF
--- a/src/bin/cargo/commands/login.rs
+++ b/src/bin/cargo/commands/login.rs
@@ -1,11 +1,6 @@
 use crate::command_prelude::*;
 
-use std::io::{self, BufRead};
-
-use cargo::core::{Source, SourceId};
 use cargo::ops;
-use cargo::sources::RegistrySource;
-use cargo::util::CargoResultExt;
 
 pub fn cli() -> App {
     subcommand("login")
@@ -14,46 +9,19 @@ pub fn cli() -> App {
              If token is not specified, it will be read from stdin.",
         )
         .arg(Arg::with_name("token"))
-        .arg(opt("host", "Host to set the token for").value_name("HOST"))
+        .arg(
+            opt("host", "Host to set the token for")
+                .value_name("HOST")
+                .hidden(true),
+        )
         .arg(opt("registry", "Registry to use").value_name("REGISTRY"))
 }
 
 pub fn exec(config: &mut Config, args: &ArgMatches<'_>) -> CliResult {
-    let registry = args.registry(config)?;
-
-    let token = match args.value_of("token") {
-        Some(token) => token.to_string(),
-        None => {
-            let host = match registry {
-                Some(ref _registry) => {
-                    return Err(failure::format_err!(
-                        "token must be provided when \
-                         --registry is provided."
-                    )
-                    .into());
-                }
-                None => {
-                    let src = SourceId::crates_io(config)?;
-                    let mut src = RegistrySource::remote(src, config);
-                    src.update()?;
-                    let config = src.config()?.unwrap();
-                    args.value_of("host")
-                        .map(|s| s.to_string())
-                        .unwrap_or_else(|| config.api.unwrap())
-                }
-            };
-            println!("please visit {}/me and paste the API Token below", host);
-            let mut line = String::new();
-            let input = io::stdin();
-            input
-                .lock()
-                .read_line(&mut line)
-                .chain_err(|| "failed to read stdin")
-                .map_err(failure::Error::from)?;
-            line.trim().to_string()
-        }
-    };
-
-    ops::registry_login(config, token, registry)?;
+    ops::registry_login(
+        config,
+        args.value_of("token").map(String::from),
+        args.value_of("registry").map(String::from),
+    )?;
     Ok(())
 }

--- a/src/bin/cargo/commands/package.rs
+++ b/src/bin/cargo/commands/package.rs
@@ -42,7 +42,6 @@ pub fn exec(config: &mut Config, args: &ArgMatches<'_>) -> CliResult {
             allow_dirty: args.is_present("allow-dirty"),
             target: args.target(),
             jobs: args.jobs()?,
-            registry: None,
         },
     )?;
     Ok(())

--- a/src/cargo/ops/cargo_package.rs
+++ b/src/cargo/ops/cargo_package.rs
@@ -26,7 +26,6 @@ pub struct PackageOpts<'cfg> {
     pub verify: bool,
     pub jobs: Option<u32>,
     pub target: Option<String>,
-    pub registry: Option<String>,
 }
 
 static VCS_INFO_FILE: &'static str = ".cargo_vcs_info.json";

--- a/src/cargo/sources/registry/mod.rs
+++ b/src/cargo/sources/registry/mod.rs
@@ -211,7 +211,15 @@ pub struct RegistryConfig {
 
     /// API endpoint for the registry. This is what's actually hit to perform
     /// operations like yanks, owner modifications, publish new crates, etc.
+    /// If this is None, the registry does not support API commands.
     pub api: Option<String>,
+
+    /// Map of commands the registry supports.
+    /// Key is the command name ("yank", "publish", etc.) and the value is a
+    /// list of versions supported for that command (["v1"]).
+    /// If not specified, but `api` is set, all commands default to v1.
+    #[serde(default)]
+    pub commands: BTreeMap<String, Vec<String>>,
 }
 
 #[derive(Deserialize)]

--- a/src/cargo/sources/registry/remote.rs
+++ b/src/cargo/sources/registry/remote.rs
@@ -167,7 +167,17 @@ impl<'cfg> RegistryData for RemoteRegistry<'cfg> {
                 .open_ro(Path::new(INDEX_LOCK), self.config, "the registry index")?;
         let mut config = None;
         self.load(Path::new(""), Path::new("config.json"), &mut |json| {
-            config = Some(serde_json::from_slice(json)?);
+            let mut reg_conf: RegistryConfig = serde_json::from_slice(json)?;
+            if reg_conf.api.is_some() && reg_conf.commands.is_empty() {
+                // Default to V1 if not specified.
+                let v1 = vec!["v1".to_string()];
+                reg_conf.commands.insert("publish".to_string(), v1.clone());
+                reg_conf.commands.insert("yank".to_string(), v1.clone());
+                reg_conf.commands.insert("search".to_string(), v1.clone());
+                reg_conf.commands.insert("owner".to_string(), v1.clone());
+                reg_conf.commands.insert("login".to_string(), v1.clone());
+            }
+            config = Some(reg_conf);
             Ok(())
         })?;
         trace!("config loaded");

--- a/tests/testsuite/login.rs
+++ b/tests/testsuite/login.rs
@@ -3,26 +3,13 @@ use std::io::prelude::*;
 
 use crate::support::cargo_process;
 use crate::support::install::cargo_home;
-use crate::support::registry::registry;
+use crate::support::registry::{self, registry};
 use cargo::core::Shell;
 use cargo::util::config::Config;
 use toml;
 
 const TOKEN: &str = "test-token";
 const ORIGINAL_TOKEN: &str = "api-token";
-const CONFIG_FILE: &str = r#"
-    [registry]
-    token = "api-token"
-
-    [registries.test-reg]
-    index = "http://dummy_index/"
-"#;
-
-fn setup_old_credentials() {
-    let config = cargo_home().join("config");
-    t!(fs::create_dir_all(config.parent().unwrap()));
-    t!(t!(File::create(&config)).write_all(CONFIG_FILE.as_bytes()));
-}
 
 fn setup_new_credentials() {
     let config = cargo_home().join("credentials");
@@ -72,22 +59,12 @@ fn check_token(expected_token: &str, registry: Option<&str>) -> bool {
 
 #[test]
 fn login_with_old_credentials() {
-    setup_old_credentials();
+    registry::init();
 
     cargo_process("login --host")
         .arg(registry().to_string())
         .arg(TOKEN)
         .run();
-
-    let config = cargo_home().join("config");
-    assert!(config.is_file());
-
-    let mut contents = String::new();
-    File::open(&config)
-        .unwrap()
-        .read_to_string(&mut contents)
-        .unwrap();
-    assert_eq!(CONFIG_FILE, contents);
 
     // Ensure that we get the new token for the registry
     assert!(check_token(TOKEN, None));
@@ -95,15 +72,13 @@ fn login_with_old_credentials() {
 
 #[test]
 fn login_with_new_credentials() {
+    registry::init();
     setup_new_credentials();
 
     cargo_process("login --host")
         .arg(registry().to_string())
         .arg(TOKEN)
         .run();
-
-    let config = cargo_home().join("config");
-    assert!(!config.is_file());
 
     // Ensure that we get the new token for the registry
     assert!(check_token(TOKEN, None));
@@ -117,13 +92,11 @@ fn login_with_old_and_new_credentials() {
 
 #[test]
 fn login_without_credentials() {
+    registry::init();
     cargo_process("login --host")
         .arg(registry().to_string())
         .arg(TOKEN)
         .run();
-
-    let config = cargo_home().join("config");
-    assert!(!config.is_file());
 
     // Ensure that we get the new token for the registry
     assert!(check_token(TOKEN, None));
@@ -131,7 +104,7 @@ fn login_without_credentials() {
 
 #[test]
 fn new_credentials_is_used_instead_old() {
-    setup_old_credentials();
+    registry::init();
     setup_new_credentials();
 
     cargo_process("login --host")
@@ -147,10 +120,10 @@ fn new_credentials_is_used_instead_old() {
 
 #[test]
 fn registry_credentials() {
-    setup_old_credentials();
+    registry::init();
     setup_new_credentials();
 
-    let reg = "test-reg";
+    let reg = "alternative";
 
     cargo_process("login --registry")
         .arg(reg)

--- a/tests/testsuite/main.rs
+++ b/tests/testsuite/main.rs
@@ -1,5 +1,5 @@
 #![warn(rust_2018_idioms)] // while we're getting used to 2018
-#![cfg_attr(feature="deny-warnings", deny(warnings))]
+#![cfg_attr(feature = "deny-warnings", deny(warnings))]
 #![allow(clippy::blacklisted_name)]
 #![allow(clippy::explicit_iter_loop)]
 

--- a/tests/testsuite/search.rs
+++ b/tests/testsuite/search.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 use crate::support::cargo_process;
 use crate::support::git::repo;
 use crate::support::paths;
-use crate::support::registry::{api_path, registry as registry_url, registry_path};
+use crate::support::registry::{api_path, registry as registry_url, registry_path, COMMANDS};
 use url::Url;
 
 fn api() -> Url {
@@ -66,7 +66,11 @@ fn setup() {
     let _ = repo(&registry_path())
         .file(
             "config.json",
-            &format!(r#"{{"dl":"{0}","api":"{0}"}}"#, api()),
+            &format!(
+                r#"{{"dl":"{0}","api":"{0}","commands":{1}}}"#,
+                api(),
+                COMMANDS
+            ),
         )
         .build();
 

--- a/tests/testsuite/support/publish.rs
+++ b/tests/testsuite/support/publish.rs
@@ -3,7 +3,7 @@ use std::io::prelude::*;
 use std::path::PathBuf;
 
 use crate::support::git::{repo, Repository};
-use crate::support::paths;
+use crate::support::{paths, registry};
 
 use url::Url;
 
@@ -41,9 +41,11 @@ pub fn setup() -> Repository {
             &format!(
                 r#"{{
             "dl": "{0}",
-            "api": "{0}"
+            "api": "{0}",
+            "commands": {1}
         }}"#,
-                upload()
+                upload(),
+                registry::COMMANDS
             ),
         )
         .build()

--- a/tests/testsuite/support/registry.rs
+++ b/tests/testsuite/support/registry.rs
@@ -14,6 +14,14 @@ use url::Url;
 use crate::support::git::repo;
 use crate::support::paths;
 
+pub const COMMANDS: &str = r#"{
+    "publish":  ["v1"],
+    "yank":     ["v1"],
+    "search":   ["v1"],
+    "owner":    ["v1"],
+    "login":    ["v1"]
+}"#;
+
 pub fn registry_path() -> PathBuf {
     paths::root().join("registry")
 }
@@ -169,9 +177,10 @@ pub fn init() {
             "config.json",
             &format!(
                 r#"
-            {{"dl":"{0}","api":"{0}"}}
+            {{"dl":"{0}","api":"{0}","commands":{1}}}
         "#,
-                dl_url()
+                dl_url(),
+                COMMANDS
             ),
         )
         .build();
@@ -183,10 +192,11 @@ pub fn init() {
             "config.json",
             &format!(
                 r#"
-            {{"dl":"{}","api":"{}"}}
+            {{"dl":"{}","api":"{}","commands":{}}}
         "#,
                 alt_dl_url(),
-                alt_api_url()
+                alt_api_url(),
+                COMMANDS
             ),
         )
         .build();


### PR DESCRIPTION
This is a revival of @withoutboats' PR (https://github.com/rust-lang/cargo/pull/4747) with a few other changes. I can split this up if necessary. This includes the following:

- Add `commands` to `config.json` in the index which indicates which version of each command the registry supports. Example:
    ```json
    {
        "dl": "https://crates.io/api/v1/crates",
        "api": "https://crates.io",
        "commands": {
            "publish":  ["v1"],
            "yank":     ["v1"],
            "search":   ["v1"],
            "owner":    ["v1"],
            "login":    ["v1"]
        }
    }
    ```

    - If `commands` is not specified, it defaults to `v1`.
- Change registry commands (publish/yank/owner/login) to work the same as search works – the index is only updated if the config file is missing. None of those commands appear to actually use the index directly and are only interested in the config file. The likelyhood of the config file changing is small. This is probably the riskiest change and worthy of discussion.
- Rewrite of `login` command:
    - In order to check the API version, it needs the config file, which means the index will be downloaded if it is not available.
    - The `--host` flag is deprecated/unused. It wasn't used for much before. Now, the interactive part that asks for the token will use `{api}/me` as the URL in the interactive message.
    - `--registry` supports interactive entry of the token (does not require it on the command line).
    - Displays a message after saving the token (fixes #5868).
    - Because `login` now requires an index, some of the tests had to be updated.
- Fix so that if `api` is missing from the config, it will display a nice error message instead of panicking with unwrap.
