### PR TITLE
Travis: only use mdbook 0.1.7.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,14 +6,6 @@ dist: trusty
 git:
   depth: 1
 
-# Using 'cache: cargo' to cache target/ and all of $HOME/.cargo/
-# doesn't work well: the cache is large and it takes several minutes
-# to move it to and from S3. So instead we only cache the mdbook
-# binary.
-cache:
-  directories:
-    - $HOME/.cargo/bin/
-
 matrix:
   include:
     - env: TARGET=x86_64-unknown-linux-gnu
@@ -48,7 +40,7 @@ matrix:
            ALT=i686-unknown-linux-gnu
       rust: nightly
       install:
-        - mdbook --help || cargo install mdbook --force
+        - travis_retry curl -Lf https://github.com/rust-lang-nursery/mdBook/releases/download/v0.1.7/mdbook-v0.1.7-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=$HOME/.cargo/bin
       script:
         - cargo test --features=deny-warnings
         - cargo doc --no-deps


### PR DESCRIPTION
The latest mdbook does not build (https://github.com/rust-lang-nursery/mdBook/issues/852). Cargo uses 0.1.7, so force install only that version.