### PR TITLE
Add a "cargo bench --debug" option

### DIFF
--- a/src/bin/cargo/commands/bench.rs
+++ b/src/bin/cargo/commands/bench.rs
@@ -7,6 +7,12 @@ pub fn cli() -> App {
         .setting(AppSettings::TrailingVarArg)
         .about("Execute all benchmarks of a local package")
         .arg(
+            Arg::with_name("debug")
+                .help("Build benchmarks in debug mode, without optimizations")
+                .long("debug")
+                .short("d")
+        )
+        .arg(
             Arg::with_name("BENCHNAME")
                 .help("If specified, only run benches containing this string in their names"),
         )
@@ -73,7 +79,7 @@ Compilation can be customized with the `bench` profile in the manifest.
 pub fn exec(config: &mut Config, args: &ArgMatches<'_>) -> CliResult {
     let ws = args.workspace(config)?;
     let mut compile_opts = args.compile_options(config, CompileMode::Bench)?;
-    compile_opts.build_config.release = true;
+    compile_opts.build_config.release = !args.is_present("debug");
 
     let ops = TestOptions {
         no_run: args.is_present("no-run"),

--- a/tests/testsuite/bench.rs
+++ b/tests/testsuite/bench.rs
@@ -210,6 +210,37 @@ fn bench_multiple_targets() {
 }
 
 #[test]
+fn cargo_bench_debug() {
+    if !is_nightly() {
+        return;
+    }
+
+    let p = project()
+        .file("Cargo.toml", &basic_bin_manifest("foo"))
+        .file(
+            "src/main.rs",
+            r#"
+            #![feature(test)]
+            #[cfg(test)]
+            extern crate test;
+            fn main() {}
+            #[bench] fn bench_hello(_b: &mut test::Bencher) {}
+        "#,
+        )
+        .build();
+
+    p.cargo("bench -d hello")
+        .with_stderr(
+            "\
+[COMPILING] foo v0.5.0 ([CWD])
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[RUNNING] target/debug/deps/foo-[..][EXE]",
+        )
+        .with_stdout_contains("test bench_hello ... bench: [..]")
+        .run();
+}
+
+#[test]
 fn cargo_bench_verbose() {
     if !is_nightly() {
         return;


### PR DESCRIPTION
It builds the benchmarks in debug mode and then runs them.  It's useful
in a CI context where it's important that the benches aren't broken, but
it's not important how fast they run.

Fixes #6445