### PR TITLE
Upgrade the metabuild to Rust 2018

### DIFF
--- a/src/cargo/core/compiler/custom_build.rs
+++ b/src/cargo/core/compiler/custom_build.rs
@@ -571,7 +571,7 @@ fn prepare_metabuild<'a, 'cfg>(
         })
         .collect();
     for dep in &meta_deps {
-        output.push(format!("extern crate {};\n", dep));
+        output.push(format!("use {};\n", dep));
     }
     output.push("fn main() {\n".to_string());
     for dep in &meta_deps {

--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -638,7 +638,7 @@ impl Target {
             for_host: true,
             benched: false,
             tested: false,
-            ..Target::new(TargetSourcePath::Metabuild, Edition::Edition2015)
+            ..Target::new(TargetSourcePath::Metabuild, Edition::Edition2018)
         }
     }
 


### PR DESCRIPTION
Just happened across the code that @ehuss mentioned in https://github.com/rust-lang/cargo/pull/6423#issuecomment-446807216 and thought of reviving that effort.

@ehuss says there's no reason to.  Let's see if it passes CI and we should land this change or not.