### PR TITLE
Update the rustup URL

### DIFF
--- a/src/doc/src/getting-started/installation.md
+++ b/src/doc/src/getting-started/installation.md
@@ -8,7 +8,7 @@ by using `rustup`. Installing Rust using `rustup` will also install `cargo`.
 On Linux and macOS systems, this is done as follows:
 
 ```console
-$ curl -sSf https://static.rust-lang.org/rustup.sh | sh
+$ curl https://sh.rustup.rs -sSf | sh
 ```
 
 It will download a script, and start the installation. If everything goes well,


### PR DESCRIPTION
Yesterday at the Melbourne Rust meetup I helped someone install Rust on their Mac. They were following the instructions from the cargo book and I was surprised to see `rustup` and all the tools being installed globally in `/usr/local/bin`. Eventually we worked out that the URL in the cargo book was different from the one on the Rust website and on rustup.rs. After using the other URL the install proceeded as expected, installing into the user's home directory. It appears the old link is an old version of rustup/rust-init.

This PR updates the install command to match the Rust home page.