### PR TITLE
Rewrite `login` and registry cleanups.

### DIFF
--- a/src/bin/cargo/commands/login.rs
+++ b/src/bin/cargo/commands/login.rs
@@ -1,11 +1,6 @@
 use crate::command_prelude::*;
 
-use std::io::{self, BufRead};
-
-use cargo::core::{Source, SourceId};
 use cargo::ops;
-use cargo::sources::RegistrySource;
-use cargo::util::CargoResultExt;
 
 pub fn cli() -> App {
     subcommand("login")
@@ -14,46 +9,19 @@ pub fn cli() -> App {
              If token is not specified, it will be read from stdin.",
         )
         .arg(Arg::with_name("token"))
-        .arg(opt("host", "Host to set the token for").value_name("HOST"))
+        .arg(
+            opt("host", "Host to set the token for")
+                .value_name("HOST")
+                .hidden(true),
+        )
         .arg(opt("registry", "Registry to use").value_name("REGISTRY"))
 }
 
 pub fn exec(config: &mut Config, args: &ArgMatches<'_>) -> CliResult {
-    let registry = args.registry(config)?;
-
-    let token = match args.value_of("token") {
-        Some(token) => token.to_string(),
-        None => {
-            let host = match registry {
-                Some(ref _registry) => {
-                    return Err(failure::format_err!(
-                        "token must be provided when \
-                         --registry is provided."
-                    )
-                    .into());
-                }
-                None => {
-                    let src = SourceId::crates_io(config)?;
-                    let mut src = RegistrySource::remote(src, config);
-                    src.update()?;
-                    let config = src.config()?.unwrap();
-                    args.value_of("host")
-                        .map(|s| s.to_string())
-                        .unwrap_or_else(|| config.api.unwrap())
-                }
-            };
-            println!("please visit {}/me and paste the API Token below", host);
-            let mut line = String::new();
-            let input = io::stdin();
-            input
-                .lock()
-                .read_line(&mut line)
-                .chain_err(|| "failed to read stdin")
-                .map_err(failure::Error::from)?;
-            line.trim().to_string()
-        }
-    };
-
-    ops::registry_login(config, token, registry)?;
+    ops::registry_login(
+        config,
+        args.value_of("token").map(String::from),
+        args.value_of("registry").map(String::from),
+    )?;
     Ok(())
 }

--- a/src/bin/cargo/commands/package.rs
+++ b/src/bin/cargo/commands/package.rs
@@ -42,7 +42,6 @@ pub fn exec(config: &mut Config, args: &ArgMatches<'_>) -> CliResult {
             allow_dirty: args.is_present("allow-dirty"),
             target: args.target(),
             jobs: args.jobs()?,
-            registry: None,
         },
     )?;
     Ok(())

--- a/src/cargo/ops/cargo_package.rs
+++ b/src/cargo/ops/cargo_package.rs
@@ -26,7 +26,6 @@ pub struct PackageOpts<'cfg> {
     pub verify: bool,
     pub jobs: Option<u32>,
     pub target: Option<String>,
-    pub registry: Option<String>,
 }
 
 static VCS_INFO_FILE: &'static str = ".cargo_vcs_info.json";

--- a/src/cargo/sources/registry/mod.rs
+++ b/src/cargo/sources/registry/mod.rs
@@ -211,6 +211,7 @@ pub struct RegistryConfig {
 
     /// API endpoint for the registry. This is what's actually hit to perform
     /// operations like yanks, owner modifications, publish new crates, etc.
+    /// If this is None, the registry does not support API commands.
     pub api: Option<String>,
 }
 

--- a/src/crates-io/lib.rs
+++ b/src/crates-io/lib.rs
@@ -15,8 +15,12 @@ use url::percent_encoding::{percent_encode, QUERY_ENCODE_SET};
 pub type Result<T> = std::result::Result<T, failure::Error>;
 
 pub struct Registry {
+    /// The base URL for issuing API requests.
     host: String,
+    /// Optional authorization token.
+    /// If None, commands requiring authorization will fail.
     token: Option<String>,
+    /// Curl handle for issuing requests.
     handle: Easy,
 }
 
@@ -51,7 +55,8 @@ pub struct NewCrate {
     pub license_file: Option<String>,
     pub repository: Option<String>,
     pub badges: BTreeMap<String, BTreeMap<String, String>>,
-    #[serde(default)] pub links: Option<String>,
+    #[serde(default)]
+    pub links: Option<String>,
 }
 
 #[derive(Serialize)]
@@ -129,6 +134,10 @@ impl Registry {
             token,
             handle,
         }
+    }
+
+    pub fn host(&self) -> &str {
+        &self.host
     }
 
     pub fn add_owners(&mut self, krate: &str, owners: &[&str]) -> Result<String> {

--- a/tests/testsuite/login.rs
+++ b/tests/testsuite/login.rs
@@ -3,26 +3,13 @@ use std::io::prelude::*;
 
 use crate::support::cargo_process;
 use crate::support::install::cargo_home;
-use crate::support::registry::registry;
+use crate::support::registry::{self, registry};
 use cargo::core::Shell;
 use cargo::util::config::Config;
 use toml;
 
 const TOKEN: &str = "test-token";
 const ORIGINAL_TOKEN: &str = "api-token";
-const CONFIG_FILE: &str = r#"
-    [registry]
-    token = "api-token"
-
-    [registries.test-reg]
-    index = "http://dummy_index/"
-"#;
-
-fn setup_old_credentials() {
-    let config = cargo_home().join("config");
-    t!(fs::create_dir_all(config.parent().unwrap()));
-    t!(t!(File::create(&config)).write_all(CONFIG_FILE.as_bytes()));
-}
 
 fn setup_new_credentials() {
     let config = cargo_home().join("credentials");
@@ -72,22 +59,12 @@ fn check_token(expected_token: &str, registry: Option<&str>) -> bool {
 
 #[test]
 fn login_with_old_credentials() {
-    setup_old_credentials();
+    registry::init();
 
     cargo_process("login --host")
         .arg(registry().to_string())
         .arg(TOKEN)
         .run();
-
-    let config = cargo_home().join("config");
-    assert!(config.is_file());
-
-    let mut contents = String::new();
-    File::open(&config)
-        .unwrap()
-        .read_to_string(&mut contents)
-        .unwrap();
-    assert_eq!(CONFIG_FILE, contents);
 
     // Ensure that we get the new token for the registry
     assert!(check_token(TOKEN, None));
@@ -95,15 +72,13 @@ fn login_with_old_credentials() {
 
 #[test]
 fn login_with_new_credentials() {
+    registry::init();
     setup_new_credentials();
 
     cargo_process("login --host")
         .arg(registry().to_string())
         .arg(TOKEN)
         .run();
-
-    let config = cargo_home().join("config");
-    assert!(!config.is_file());
 
     // Ensure that we get the new token for the registry
     assert!(check_token(TOKEN, None));
@@ -117,13 +92,11 @@ fn login_with_old_and_new_credentials() {
 
 #[test]
 fn login_without_credentials() {
+    registry::init();
     cargo_process("login --host")
         .arg(registry().to_string())
         .arg(TOKEN)
         .run();
-
-    let config = cargo_home().join("config");
-    assert!(!config.is_file());
 
     // Ensure that we get the new token for the registry
     assert!(check_token(TOKEN, None));
@@ -131,7 +104,7 @@ fn login_without_credentials() {
 
 #[test]
 fn new_credentials_is_used_instead_old() {
-    setup_old_credentials();
+    registry::init();
     setup_new_credentials();
 
     cargo_process("login --host")
@@ -147,10 +120,10 @@ fn new_credentials_is_used_instead_old() {
 
 #[test]
 fn registry_credentials() {
-    setup_old_credentials();
+    registry::init();
     setup_new_credentials();
 
-    let reg = "test-reg";
+    let reg = "alternative";
 
     cargo_process("login --registry")
         .arg(reg)

--- a/tests/testsuite/main.rs
+++ b/tests/testsuite/main.rs
@@ -1,5 +1,5 @@
 #![warn(rust_2018_idioms)] // while we're getting used to 2018
-#![cfg_attr(feature="deny-warnings", deny(warnings))]
+#![cfg_attr(feature = "deny-warnings", deny(warnings))]
 #![allow(clippy::blacklisted_name)]
 #![allow(clippy::explicit_iter_loop)]
 


### PR DESCRIPTION
- Login:
    - Change `login` so that it reads the API host from the registry config so it knows the `{api}/me` URL to display.
    - The `--host` flag is deprecated/unused. It wasn't used for much before.
    - `--registry` supports interactive entry of the token (does not require it on the command line).
    - Displays a message after saving the token (fixes #5868).
    - Because `login` now requires an index, some of the tests had to be updated.
- Fix so that if `api` is missing from the config, it will display a nice error message instead of panicking with unwrap.
