### PR TITLE
Fix new unused patch warning.

### DIFF
--- a/src/cargo/ops/resolve.rs
+++ b/src/cargo/ops/resolve.rs
@@ -340,7 +340,7 @@ pub fn resolve_with_previous<'cfg>(
         warn,
     )?;
     resolved.register_used_patches(registry.patches());
-    if warn {
+    if register_patches {
         // It would be good if this warning was more targeted and helpful
         // (such as showing close candidates that failed to match). However,
         // that's not terribly easy to do, so just show a general help


### PR DESCRIPTION
The unused `[patch]` warning added in #6470 was misfiring if you build only a subset of a workspace that doesn't include the patch.

I'm about 80% confident this new logic is correct. It addresses the scenario I discovered, and I tested a bunch of commands (generate-lockfile, update, etc.) to make sure they all work. However, the many ways that `resolve_with_previous` is called is tricky to ensure every scenario works correctly.
