### PR TITLE
Delete unnecessary 'return'

### DIFF
--- a/src/cargo/core/compiler/context/compilation_files.rs
+++ b/src/cargo/core/compiler/context/compilation_files.rs
@@ -53,10 +53,10 @@ pub struct OutputFile {
 impl OutputFile {
     /// Gets the hardlink if present. Otherwise returns the path.
     pub fn bin_dst(&self) -> &PathBuf {
-        return match self.hardlink {
+        match self.hardlink {
             Some(ref link_dst) => link_dst,
             None => &self.path,
-        };
+        }
     }
 }
 

--- a/src/cargo/core/compiler/context/mod.rs
+++ b/src/cargo/core/compiler/context/mod.rs
@@ -285,7 +285,6 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
                 return Ok(Option::Some(output.bin_dst().clone()));
             }
         }
-
         Ok(None)
     }
 

--- a/src/cargo/core/compiler/context/mod.rs
+++ b/src/cargo/core/compiler/context/mod.rs
@@ -285,7 +285,8 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
                 return Ok(Option::Some(output.bin_dst().clone()));
             }
         }
-        return Ok(None);
+
+        Ok(None)
     }
 
     pub fn prepare_units(


### PR DESCRIPTION
Unnecessary return keyword deleted as it is also in the title