### PR TITLE
Update display of contents of Cargo.toml

### DIFF
--- a/src/doc/src/guide/creating-a-new-project.md
+++ b/src/doc/src/guide/creating-a-new-project.md
@@ -30,6 +30,10 @@ Let’s take a closer look at `Cargo.toml`:
 name = "hello_world"
 version = "0.1.0"
 authors = ["Your Name <you@example.com>"]
+edition = "2018"
+
+[dependencies]
+
 ```
 
 This is called a **manifest**, and it contains all of the metadata that Cargo


### PR DESCRIPTION
The display of the contents of the Cargo.toml file needs to be updated, in keeping with the Rust 2018 edition.