### PR TITLE
Rustflags in metadata

### DIFF
--- a/src/cargo/core/compiler/context/compilation_files.rs
+++ b/src/cargo/core/compiler/context/compilation_files.rs
@@ -465,6 +465,15 @@ fn compute_metadata<'a, 'cfg>(
         args.hash(&mut hasher);
     }
 
+    // Throw in the rustflags we're compiling with.
+    // This helps when the target directory is a shared cache for projects with different cargo configs,
+    // or if the user is experimenting with different rustflags manually.
+    if unit.mode.is_doc() {
+        cx.bcx.rustdocflags_args(unit).hash(&mut hasher);
+    } else {
+        cx.bcx.rustflags_args(unit).hash(&mut hasher);
+    }
+
     // Artifacts compiled for the host should have a different metadata
     // piece than those compiled for the target, so make sure we throw in
     // the unit's `kind` as well

--- a/src/cargo/core/compiler/context/compilation_files.rs
+++ b/src/cargo/core/compiler/context/compilation_files.rs
@@ -25,12 +25,12 @@ use crate::util::{self, CargoResult};
 ///
 /// This also acts as the main layer of caching provided by Cargo.
 /// For example, we want to cache `cargo build` and `cargo doc` separately, so that running one
-/// does not invalidate the artifacts for the other. We do this by including `profile` in the hash,
-/// thus the artifacts go in different folders and do not override each other.
+/// does not invalidate the artifacts for the other. We do this by including `CompileMode` in the
+/// hash, thus the artifacts go in different folders and do not override each other.
 /// If we don't add something that we should have, for this reason, we get the
 /// correct output but rebuild more than is needed.
 ///
-/// Some things that need to be tract to ensure the correct output should definitely *not*
+/// Some things that need to be tracked to ensure the correct output should definitely *not*
 /// go in the `Metadata`. For example, the modification time of a file, should be tracked to make a
 /// rebuild when the file changes. However, it would be wasteful to include in the `Metadata`. The
 /// old artifacts are never going to be needed again. We can save space by just overwriting them.

--- a/src/cargo/core/compiler/context/compilation_files.rs
+++ b/src/cargo/core/compiler/context/compilation_files.rs
@@ -497,9 +497,9 @@ fn compute_metadata<'a, 'cfg>(
     // This helps when the target directory is a shared cache for projects with different cargo configs,
     // or if the user is experimenting with different rustflags manually.
     if unit.mode.is_doc() {
-        cx.bcx.rustdocflags_args(unit).hash(&mut hasher);
+        cx.bcx.rustdocflags_args(unit).ok().hash(&mut hasher);
     } else {
-        cx.bcx.rustflags_args(unit).hash(&mut hasher);
+        cx.bcx.rustflags_args(unit).ok().hash(&mut hasher);
     }
 
     // Artifacts compiled for the host should have a different metadata

--- a/tests/testsuite/freshness.rs
+++ b/tests/testsuite/freshness.rs
@@ -1160,6 +1160,11 @@ fn changing_rustflags_is_cached() {
     p.cargo("build").run();
     p.cargo("build")
         .env("RUSTFLAGS", "-C target-cpu=native")
+        .with_stderr(
+            "\
+[COMPILING] foo v0.0.1 ([..])
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]",
+        )
         .run();
     // This should not recompile!
     p.cargo("build")

--- a/tests/testsuite/freshness.rs
+++ b/tests/testsuite/freshness.rs
@@ -1154,6 +1154,54 @@ fn reuse_shared_build_dep() {
 }
 
 #[test]
+fn changing_rustflags_is_cached() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "foo"
+            authors = []
+            version = "0.0.1"
+
+            [dependencies.a]
+            path = "a"
+            [dependencies.b]
+            path = "b"
+        "#,
+        )
+        .file("src/lib.rs", "extern crate a; extern crate b;")
+        .file(
+            "a/Cargo.toml",
+            r#"
+            [package]
+            name = "a"
+            authors = []
+            version = "0.0.1"
+            [dependencies.b]
+            path = "../b"
+        "#,
+        )
+        .file("a/src/lib.rs", "extern crate b;")
+        .file("b/Cargo.toml", &basic_manifest("b", "0.0.1"))
+        .file("b/src/lib.rs", "")
+        .build();
+
+    p.cargo("build").run();
+    p.cargo("build")
+        .env("RUSTFLAGS", "-C target-cpu=native")
+        .run();
+    // This should not recompile!
+    p.cargo("build")
+        .with_stderr("[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]")
+        .run();
+    p.cargo("build")
+        .env("RUSTFLAGS", "-C target-cpu=native")
+        .with_stderr("[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]")
+        .run();
+}
+
+#[test]
 fn reuse_panic_build_dep_test() {
     let p = project()
         .file(

--- a/tests/testsuite/freshness.rs
+++ b/tests/testsuite/freshness.rs
@@ -1155,37 +1155,7 @@ fn reuse_shared_build_dep() {
 
 #[test]
 fn changing_rustflags_is_cached() {
-    let p = project()
-        .file(
-            "Cargo.toml",
-            r#"
-            [package]
-            name = "foo"
-            authors = []
-            version = "0.0.1"
-
-            [dependencies.a]
-            path = "a"
-            [dependencies.b]
-            path = "b"
-        "#,
-        )
-        .file("src/lib.rs", "extern crate a; extern crate b;")
-        .file(
-            "a/Cargo.toml",
-            r#"
-            [package]
-            name = "a"
-            authors = []
-            version = "0.0.1"
-            [dependencies.b]
-            path = "../b"
-        "#,
-        )
-        .file("a/src/lib.rs", "extern crate b;")
-        .file("b/Cargo.toml", &basic_manifest("b", "0.0.1"))
-        .file("b/src/lib.rs", "")
-        .build();
+    let p = project().file("src/lib.rs", "").build();
 
     p.cargo("build").run();
     p.cargo("build")


### PR DESCRIPTION
This is a small change that adds Rustflags to the `Metadata`. This means, for example, that if you do a plane build then build with "-C target-cpu=native", you will get 2 copies of the dependencies. Con, more space if you are changing Rustflags. Pro, not rebuilding all the dependencies when you switch back.

Suggested by <https://internals.rust-lang.org/t/idea-cargo-global-binary-cache/9002/31>