### PR TITLE
--{example,bin,bench,test} with no argument now lists all available targets

### DIFF
--- a/src/bin/cargo/commands/bench.rs
+++ b/src/bin/cargo/commands/bench.rs
@@ -73,6 +73,9 @@ Compilation can be customized with the `bench` profile in the manifest.
 pub fn exec(config: &mut Config, args: &ArgMatches<'_>) -> CliResult {
     let ws = args.workspace(config)?;
     let mut compile_opts = args.compile_options(config, CompileMode::Bench)?;
+
+    args.check_optional_opts_all(&ws, &compile_opts)?;
+
     compile_opts.build_config.release = true;
 
     let ops = TestOptions {

--- a/src/bin/cargo/commands/bench.rs
+++ b/src/bin/cargo/commands/bench.rs
@@ -72,9 +72,7 @@ Compilation can be customized with the `bench` profile in the manifest.
 
 pub fn exec(config: &mut Config, args: &ArgMatches<'_>) -> CliResult {
     let ws = args.workspace(config)?;
-    let mut compile_opts = args.compile_options(config, CompileMode::Bench)?;
-
-    args.check_optional_opts_all(&ws, &compile_opts)?;
+    let mut compile_opts = args.compile_options(config, CompileMode::Bench, Some(&ws))?;
 
     compile_opts.build_config.release = true;
 

--- a/src/bin/cargo/commands/build.rs
+++ b/src/bin/cargo/commands/build.rs
@@ -49,6 +49,9 @@ the --release flag will use the `release` profile instead.
 pub fn exec(config: &mut Config, args: &ArgMatches<'_>) -> CliResult {
     let ws = args.workspace(config)?;
     let mut compile_opts = args.compile_options(config, CompileMode::Build)?;
+
+    args.check_optional_opts_all(&ws, &compile_opts)?;
+
     compile_opts.export_dir = args.value_of_path("out-dir", config);
     if compile_opts.export_dir.is_some() && !config.cli_unstable().unstable_options {
         Err(failure::format_err!(

--- a/src/bin/cargo/commands/build.rs
+++ b/src/bin/cargo/commands/build.rs
@@ -48,9 +48,7 @@ the --release flag will use the `release` profile instead.
 
 pub fn exec(config: &mut Config, args: &ArgMatches<'_>) -> CliResult {
     let ws = args.workspace(config)?;
-    let mut compile_opts = args.compile_options(config, CompileMode::Build)?;
-
-    args.check_optional_opts_all(&ws, &compile_opts)?;
+    let mut compile_opts = args.compile_options(config, CompileMode::Build, Some(&ws))?;
 
     compile_opts.export_dir = args.value_of_path("out-dir", config);
     if compile_opts.export_dir.is_some() && !config.cli_unstable().unstable_options {

--- a/src/bin/cargo/commands/check.rs
+++ b/src/bin/cargo/commands/check.rs
@@ -68,9 +68,7 @@ pub fn exec(config: &mut Config, args: &ArgMatches<'_>) -> CliResult {
         }
     };
     let mode = CompileMode::Check { test };
-    let compile_opts = args.compile_options(config, mode)?;
-
-    args.check_optional_opts_all(&ws, &compile_opts)?;
+    let compile_opts = args.compile_options(config, mode, Some(&ws))?;
 
     ops::compile(&ws, &compile_opts)?;
     Ok(())

--- a/src/bin/cargo/commands/check.rs
+++ b/src/bin/cargo/commands/check.rs
@@ -69,6 +69,9 @@ pub fn exec(config: &mut Config, args: &ArgMatches<'_>) -> CliResult {
     };
     let mode = CompileMode::Check { test };
     let compile_opts = args.compile_options(config, mode)?;
+
+    args.check_optional_opts_all(&ws, &compile_opts)?;
+
     ops::compile(&ws, &compile_opts)?;
     Ok(())
 }

--- a/src/bin/cargo/commands/doc.rs
+++ b/src/bin/cargo/commands/doc.rs
@@ -50,7 +50,7 @@ pub fn exec(config: &mut Config, args: &ArgMatches<'_>) -> CliResult {
     let mode = CompileMode::Doc {
         deps: !args.is_present("no-deps"),
     };
-    let mut compile_opts = args.compile_options(config, mode)?;
+    let mut compile_opts = args.compile_options(config, mode, Some(&ws))?;
     compile_opts.local_rustdoc_args = if args.is_present("document-private-items") {
         Some(vec!["--document-private-items".to_string()])
     } else {

--- a/src/bin/cargo/commands/fix.rs
+++ b/src/bin/cargo/commands/fix.rs
@@ -123,6 +123,9 @@ pub fn exec(config: &mut Config, args: &ArgMatches<'_>) -> CliResult {
     // Unlike other commands default `cargo fix` to all targets to fix as much
     // code as we can.
     let mut opts = args.compile_options(config, mode)?;
+
+    args.check_optional_opts_all(&ws, &opts)?;
+
     if let CompileFilter::Default { .. } = opts.filter {
         opts.filter = CompileFilter::Only {
             all_targets: true,

--- a/src/bin/cargo/commands/fix.rs
+++ b/src/bin/cargo/commands/fix.rs
@@ -122,9 +122,7 @@ pub fn exec(config: &mut Config, args: &ArgMatches<'_>) -> CliResult {
 
     // Unlike other commands default `cargo fix` to all targets to fix as much
     // code as we can.
-    let mut opts = args.compile_options(config, mode)?;
-
-    args.check_optional_opts_all(&ws, &opts)?;
+    let mut opts = args.compile_options(config, mode, Some(&ws))?;
 
     if let CompileFilter::Default { .. } = opts.filter {
         opts.filter = CompileFilter::Only {

--- a/src/bin/cargo/commands/install.rs
+++ b/src/bin/cargo/commands/install.rs
@@ -80,6 +80,10 @@ pub fn exec(config: &mut Config, args: &ArgMatches<'_>) -> CliResult {
     config.reload_rooted_at_cargo_home()?;
     let mut compile_opts = args.compile_options(config, CompileMode::Build)?;
 
+    let ws = args.workspace(config)?;
+
+    args.check_optional_opts_example_and_bin(&ws, &compile_opts)?;
+
     compile_opts.build_config.release = !args.is_present("debug");
 
     let krates = args

--- a/src/bin/cargo/commands/install.rs
+++ b/src/bin/cargo/commands/install.rs
@@ -78,11 +78,9 @@ pub fn exec(config: &mut Config, args: &ArgMatches<'_>) -> CliResult {
     let registry = args.registry(config)?;
 
     config.reload_rooted_at_cargo_home()?;
-    let mut compile_opts = args.compile_options(config, CompileMode::Build)?;
-    
-    if let Ok(ws) = args.workspace(config) {
-        args.check_optional_opts_example_and_bin(&ws, &compile_opts)?;
-    }
+
+    let workspace = args.workspace(config).ok();
+    let mut compile_opts = args.compile_options(config, CompileMode::Build, workspace.as_ref())?;
 
     compile_opts.build_config.release = !args.is_present("debug");
 

--- a/src/bin/cargo/commands/install.rs
+++ b/src/bin/cargo/commands/install.rs
@@ -79,10 +79,10 @@ pub fn exec(config: &mut Config, args: &ArgMatches<'_>) -> CliResult {
 
     config.reload_rooted_at_cargo_home()?;
     let mut compile_opts = args.compile_options(config, CompileMode::Build)?;
-
-    let ws = args.workspace(config)?;
-
-    args.check_optional_opts_example_and_bin(&ws, &compile_opts)?;
+    
+    if let Ok(ws) = args.workspace(config) {
+        args.check_optional_opts_example_and_bin(&ws, &compile_opts)?;
+    }
 
     compile_opts.build_config.release = !args.is_present("debug");
 

--- a/src/bin/cargo/commands/run.rs
+++ b/src/bin/cargo/commands/run.rs
@@ -40,6 +40,9 @@ pub fn exec(config: &mut Config, args: &ArgMatches<'_>) -> CliResult {
     let ws = args.workspace(config)?;
 
     let mut compile_opts = args.compile_options(config, CompileMode::Build)?;
+
+    args.check_optional_opts_example_and_bin(&ws, &compile_opts)?;
+
     if !args.is_present("example") && !args.is_present("bin") {
         let default_runs: Vec<_> = compile_opts
             .spec

--- a/src/bin/cargo/commands/run.rs
+++ b/src/bin/cargo/commands/run.rs
@@ -39,9 +39,7 @@ run. If you're passing arguments to both Cargo and the binary, the ones after
 pub fn exec(config: &mut Config, args: &ArgMatches<'_>) -> CliResult {
     let ws = args.workspace(config)?;
 
-    let mut compile_opts = args.compile_options(config, CompileMode::Build)?;
-
-    args.check_optional_opts_example_and_bin(&ws, &compile_opts)?;
+    let mut compile_opts = args.compile_options(config, CompileMode::Build, Some(&ws))?;
 
     if !args.is_present("example") && !args.is_present("bin") {
         let default_runs: Vec<_> = compile_opts

--- a/src/bin/cargo/commands/rustc.rs
+++ b/src/bin/cargo/commands/rustc.rs
@@ -62,7 +62,7 @@ pub fn exec(config: &mut Config, args: &ArgMatches<'_>) -> CliResult {
             return Err(CliError::new(err, 101));
         }
     };
-    let mut compile_opts = args.compile_options_for_single_package(config, mode)?;
+    let mut compile_opts = args.compile_options_for_single_package(config, mode, Some(&ws))?;
     let target_args = values(args, "args");
     compile_opts.target_rustc_args = if target_args.is_empty() {
         None

--- a/src/bin/cargo/commands/rustdoc.rs
+++ b/src/bin/cargo/commands/rustdoc.rs
@@ -51,7 +51,7 @@ the `cargo help pkgid` command.
 pub fn exec(config: &mut Config, args: &ArgMatches<'_>) -> CliResult {
     let ws = args.workspace(config)?;
     let mut compile_opts =
-        args.compile_options_for_single_package(config, CompileMode::Doc { deps: false })?;
+        args.compile_options_for_single_package(config, CompileMode::Doc { deps: false }, Some(&ws))?;
     let target_args = values(args, "args");
     compile_opts.target_rustdoc_args = if target_args.is_empty() {
         None

--- a/src/bin/cargo/commands/test.rs
+++ b/src/bin/cargo/commands/test.rs
@@ -92,9 +92,7 @@ To get the list of all options available for the test binaries use this:
 pub fn exec(config: &mut Config, args: &ArgMatches<'_>) -> CliResult {
     let ws = args.workspace(config)?;
 
-    let mut compile_opts = args.compile_options(config, CompileMode::Test)?;
-
-    args.check_optional_opts_all(&ws, &compile_opts)?;
+    let mut compile_opts = args.compile_options(config, CompileMode::Test, Some(&ws))?;
 
     let doc = args.is_present("doc");
     if doc {

--- a/src/bin/cargo/commands/test.rs
+++ b/src/bin/cargo/commands/test.rs
@@ -94,6 +94,8 @@ pub fn exec(config: &mut Config, args: &ArgMatches<'_>) -> CliResult {
 
     let mut compile_opts = args.compile_options(config, CompileMode::Test)?;
 
+    args.check_optional_opts_all(&ws, &compile_opts)?;
+
     let doc = args.is_present("doc");
     if doc {
         if let CompileFilter::Only { .. } = compile_opts.filter {

--- a/src/cargo/util/command_prelude.rs
+++ b/src/cargo/util/command_prelude.rs
@@ -206,7 +206,7 @@ pub fn optional_multi_opt(
         .value_name(value_name)
         .multiple(true)
         .min_values(0)
-        .max_values(1)
+        .number_of_values(1)
 }
 
 pub fn multi_opt(

--- a/src/cargo/util/command_prelude.rs
+++ b/src/cargo/util/command_prelude.rs
@@ -288,6 +288,7 @@ pub trait ArgMatchesExt {
         &self,
         config: &'a Config,
         mode: CompileMode,
+        workspace: Option<&Workspace<'a>>,
     ) -> CargoResult<CompileOptions<'a>> {
         let spec = Packages::from_flags(
             self._is_present("all"),
@@ -344,6 +345,11 @@ pub trait ArgMatchesExt {
             local_rustdoc_args: None,
             export_dir: None,
         };
+
+        if let Some(ws) = workspace {
+            self.check_optional_opts(ws, &opts)?;
+        }
+
         Ok(opts)
     }
 
@@ -351,8 +357,9 @@ pub trait ArgMatchesExt {
         &self,
         config: &'a Config,
         mode: CompileMode,
+        workspace: Option<&Workspace<'a>>,
     ) -> CargoResult<CompileOptions<'a>> {
-        let mut compile_opts = self.compile_options(config, mode)?;
+        let mut compile_opts = self.compile_options(config, mode, workspace)?;
         compile_opts.spec = Packages::Packages(self._values_of("package"));
         Ok(compile_opts)
     }
@@ -429,27 +436,11 @@ about this warning.";
         Ok(index)
     }
 
-    fn check_optional_opts_example_and_bin(
+    fn check_optional_opts(
         &self,
         workspace: &Workspace<'_>,
         compile_opts: &CompileOptions<'_>,
-    ) -> CliResult {
-        if self.is_present_with_zero_values("example") {
-            print_available_examples(&workspace, &compile_opts)?;
-        }
-
-        if self.is_present_with_zero_values("bin") {
-            print_available_binaries(&workspace, &compile_opts)?;
-        }
-
-        Ok(())
-    }
-
-    fn check_optional_opts_all(
-        &self,
-        workspace: &Workspace<'_>,
-        compile_opts: &CompileOptions<'_>,
-    ) -> CliResult {
+    ) -> CargoResult<()> {
         if self.is_present_with_zero_values("example") {
             print_available_examples(&workspace, &compile_opts)?;
         }

--- a/src/cargo/util/mod.rs
+++ b/src/cargo/util/mod.rs
@@ -22,6 +22,10 @@ pub use self::sha256::Sha256;
 pub use self::to_semver::ToSemver;
 pub use self::to_url::ToUrl;
 pub use self::vcs::{existing_vcs_repo, FossilRepo, GitRepo, HgRepo, PijulRepo};
+pub use self::workspace::{
+    print_available_benches, print_available_binaries, print_available_examples,
+    print_available_tests,
+};
 
 mod cfg;
 pub mod command_prelude;
@@ -49,6 +53,7 @@ pub mod to_semver;
 pub mod to_url;
 pub mod toml;
 mod vcs;
+mod workspace;
 
 pub fn elapsed(duration: Duration) -> String {
     let secs = duration.as_secs();

--- a/src/cargo/util/workspace.rs
+++ b/src/cargo/util/workspace.rs
@@ -11,7 +11,7 @@ fn get_available_targets<'a>(
 ) -> CargoResult<Vec<&'a Target>> {
     let packages = options.spec.get_packages(ws)?;
 
-    let targets: Vec<_> = packages
+    let mut targets: Vec<_> = packages
         .into_iter()
         .flat_map(|pkg| {
             pkg.manifest()
@@ -20,6 +20,9 @@ fn get_available_targets<'a>(
                 .filter(|target| filter_fn(target))
         })
         .collect();
+
+    targets.sort();
+
     Ok(targets)
 }
 

--- a/src/cargo/util/workspace.rs
+++ b/src/cargo/util/workspace.rs
@@ -1,0 +1,72 @@
+use crate::core::{Target, Workspace};
+use crate::ops::CompileOptions;
+use crate::util::CargoResult;
+
+use std::fmt::Write;
+
+fn get_available_targets<'a>(
+    filter_fn: fn(&Target) -> bool,
+    ws: &'a Workspace<'_>,
+    options: &'a CompileOptions<'_>,
+) -> CargoResult<Vec<&'a Target>> {
+    let packages = options.spec.get_packages(ws)?;
+
+    let targets: Vec<_> = packages
+        .into_iter()
+        .flat_map(|pkg| {
+            pkg.manifest()
+                .targets()
+                .into_iter()
+                .filter(|target| filter_fn(target))
+        })
+        .collect();
+    Ok(targets)
+}
+
+fn print_available(
+    filter_fn: fn(&Target) -> bool,
+    ws: &Workspace<'_>,
+    options: &CompileOptions<'_>,
+    option_name: &str,
+    plural_name: &str,
+) -> CargoResult<()> {
+    let targets = get_available_targets(filter_fn, ws, options)?;
+
+    let mut output = String::new();
+    writeln!(output, "\"{}\" takes one argument.", option_name)?;
+
+    if targets.is_empty() {
+        writeln!(output, "No {} available.", plural_name)?;
+    } else {
+        writeln!(output, "Available {}:", plural_name)?;
+        for target in targets {
+            writeln!(output, "    {}", target.name())?;
+        }
+    }
+    Err(failure::err_msg(output))?
+}
+
+pub fn print_available_examples(
+    ws: &Workspace<'_>,
+    options: &CompileOptions<'_>,
+) -> CargoResult<()> {
+    print_available(Target::is_example, ws, options, "--example", "examples")
+}
+
+pub fn print_available_binaries(
+    ws: &Workspace<'_>,
+    options: &CompileOptions<'_>,
+) -> CargoResult<()> {
+    print_available(Target::is_bin, ws, options, "--bin", "binaries")
+}
+
+pub fn print_available_benches(
+    ws: &Workspace<'_>,
+    options: &CompileOptions<'_>,
+) -> CargoResult<()> {
+    print_available(Target::is_bench, ws, options, "--bench", "benches")
+}
+
+pub fn print_available_tests(ws: &Workspace<'_>, options: &CompileOptions<'_>) -> CargoResult<()> {
+    print_available(Target::is_test, ws, options, "--test", "tests")
+}

--- a/tests/testsuite/list_targets.rs
+++ b/tests/testsuite/list_targets.rs
@@ -1,0 +1,237 @@
+use crate::support::project;
+
+// cargo {run,install} only support --example and --bin
+// cargo {build,check,fix,test} support --example, --bin, --bench and --test
+
+fn test_list_targets_example_and_bin_only(command: &str) {
+    let p = project()
+        .file("examples/a.rs", "fn main() { }")
+        .file("examples/b.rs", "fn main() { }")
+        .file("src/main.rs", "fn main() { }")
+        .build();
+
+    p.cargo(&format!("{} --example", command))
+        .with_stderr(
+            "\
+error: \"--example\" takes one argument.
+Available examples:
+    a
+    b
+
+",
+        )
+        .with_status(101)
+        .run();
+
+    p.cargo(&format!("{} --bin", command))
+        .with_stderr(
+            "\
+error: \"--bin\" takes one argument.
+Available binaries:
+    foo
+
+",
+        )
+        .with_status(101)
+        .run();
+}
+
+fn test_empty_list_targets_example_and_bin_only(command: &str) {
+    let p = project().file("src/lib.rs", "").build();
+
+    p.cargo(&format!("{} --example", command))
+        .with_stderr(
+            "\
+error: \"--example\" takes one argument.
+No examples available.
+
+",
+        )
+        .with_status(101)
+        .run();
+
+    p.cargo(&format!("{} --bin", command))
+        .with_stderr(
+            "\
+error: \"--bin\" takes one argument.
+No binaries available.
+
+",
+        )
+        .with_status(101)
+        .run();
+}
+
+fn test_list_targets_full(command: &str) {
+    let p = project()
+        .file("examples/a.rs", "fn main() { }")
+        .file("examples/b.rs", "fn main() { }")
+        .file("benches/bench1.rs", "")
+        .file("benches/bench2.rs", "")
+        .file("tests/test1.rs", "")
+        .file("tests/test2.rs", "")
+        .file("src/main.rs", "fn main() { }")
+        .build();
+
+    p.cargo(&format!("{} --example", command))
+        .with_stderr(
+            "\
+error: \"--example\" takes one argument.
+Available examples:
+    a
+    b
+
+",
+        )
+        .with_status(101)
+        .run();
+
+    p.cargo(&format!("{} --bin", command))
+        .with_stderr(
+            "\
+error: \"--bin\" takes one argument.
+Available binaries:
+    foo
+
+",
+        )
+        .with_status(101)
+        .run();
+
+    p.cargo(&format!("{} --bench", command))
+        .with_stderr(
+            "\
+error: \"--bench\" takes one argument.
+Available benches:
+    bench1
+    bench2
+
+",
+        )
+        .with_status(101)
+        .run();
+
+    p.cargo(&format!("{} --test", command))
+        .with_stderr(
+            "\
+error: \"--test\" takes one argument.
+Available tests:
+    test1
+    test2
+
+",
+        )
+        .with_status(101)
+        .run();
+}
+
+fn test_empty_list_targets_full(command: &str) {
+    let p = project().file("src/lib.rs", "").build();
+
+    p.cargo(&format!("{} --example", command))
+        .with_stderr(
+            "\
+error: \"--example\" takes one argument.
+No examples available.
+
+",
+        )
+        .with_status(101)
+        .run();
+
+    p.cargo(&format!("{} --bin", command))
+        .with_stderr(
+            "\
+error: \"--bin\" takes one argument.
+No binaries available.
+
+",
+        )
+        .with_status(101)
+        .run();
+
+    p.cargo(&format!("{} --bench", command))
+        .with_stderr(
+            "\
+error: \"--bench\" takes one argument.
+No benches available.
+
+",
+        )
+        .with_status(101)
+        .run();
+
+    p.cargo(&format!("{} --test", command))
+        .with_stderr(
+            "\
+error: \"--test\" takes one argument.
+No tests available.
+
+",
+        )
+        .with_status(101)
+        .run();
+}
+
+#[test]
+fn build_list_targets() {
+    test_list_targets_full("build");
+}
+#[test]
+fn build_list_targets_empty() {
+    test_empty_list_targets_full("build");
+}
+
+#[test]
+fn check_list_targets() {
+    test_list_targets_full("check");
+}
+#[test]
+fn check_list_targets_empty() {
+    test_empty_list_targets_full("check");
+}
+
+#[test]
+fn fix_list_targets() {
+    test_list_targets_full("fix");
+}
+#[test]
+fn fix_list_targets_empty() {
+    test_empty_list_targets_full("fix");
+}
+
+#[test]
+fn run_list_targets() {
+    test_list_targets_example_and_bin_only("run");
+}
+#[test]
+fn run_list_targets_empty() {
+    test_empty_list_targets_example_and_bin_only("run");
+}
+
+#[test]
+fn test_list_targets() {
+    test_list_targets_full("test");
+}
+#[test]
+fn test_list_targets_empty() {
+    test_empty_list_targets_full("test");
+}
+
+#[test]
+fn bench_list_targets() {
+    test_list_targets_full("bench");
+}
+#[test]
+fn bench_list_targets_empty() {
+    test_empty_list_targets_full("bench");
+}
+
+#[test]
+fn install_list_targets() {
+    test_list_targets_example_and_bin_only("install");
+}
+#[test]
+fn install_list_targets_empty() {
+    test_empty_list_targets_example_and_bin_only("install");
+}

--- a/tests/testsuite/main.rs
+++ b/tests/testsuite/main.rs
@@ -43,6 +43,7 @@ mod git;
 mod init;
 mod install;
 mod jobserver;
+mod list_targets;
 mod local_registry;
 mod lockfile_compat;
 mod login;


### PR DESCRIPTION
```
cargo run --bin
error: "--bin" takes one argument.
Available binaries:
    cargo

error: process didn't exit successfully: `target\debug\cargo.exe run --bin` (exit code: 101)
```

Previous PR: #5062
Closes #2548

Notes:
- `optional_opt` is a weird name, can someone come up with a better one?
- Should I call clap's `usage()` as well when printing the error message?
