### PR TITLE
Fix error message when resolving dependencies

### DIFF
--- a/src/cargo/core/resolver/context.rs
+++ b/src/cargo/core/resolver/context.rs
@@ -65,8 +65,8 @@ impl Context {
             if let Some(link) = summary.links() {
                 ensure!(
                     self.links.insert(link, id).is_none(),
-                    "Attempting to resolve a with more then one crate with the links={}. \n\
-                     This will not build as is. Consider rebuilding the .lock file.",
+                    "Attempting to resolve a dependency with more then one crate with the \
+                     links={}.\nThis will not build as is. Consider rebuilding the .lock file.",
                     &*link
                 );
             }


### PR DESCRIPTION
The error message:
> Attempting to resolve a with more then one crate with the links=

seems to be missing a noun. It appears that we are resolving a
dependency, so adding that.