### PR TITLE
[BETA] Fix fingerprint calculation for patched deps.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ matrix:
     # increased every 6 weeks or so when the first PR to use a new feature.
     - env: TARGET=x86_64-unknown-linux-gnu
            ALT=i686-unknown-linux-gnu
-      rust: 1.28.0
+      rust: 1.31.0
       script:
         - rustup toolchain install nightly
         - cargo +nightly generate-lockfile -Z minimal-versions

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ install:
   - appveyor-retry appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe
   - rustup-init.exe -y --default-host x86_64-pc-windows-msvc --default-toolchain nightly
   - set PATH=%PATH%;C:\Users\appveyor\.cargo\bin
-  - if defined MINIMAL_VERSIONS rustup toolchain install 1.28.0
+  - if defined MINIMAL_VERSIONS rustup toolchain install 1.31.0
   - if defined OTHER_TARGET rustup target add %OTHER_TARGET%
   - rustc -V
   - cargo -V
@@ -25,5 +25,5 @@ test_script:
   # we don't have ci time to run the full `cargo test` with `minimal-versions` like
   # - if defined MINIMAL_VERSIONS cargo +nightly generate-lockfile -Z minimal-versions && cargo +stable test
   # so we just run `cargo check --tests` like
-  - if defined MINIMAL_VERSIONS cargo +nightly generate-lockfile -Z minimal-versions && cargo +1.28.0 check --tests
+  - if defined MINIMAL_VERSIONS cargo +nightly generate-lockfile -Z minimal-versions && cargo +1.31.0 check --tests
   - if NOT defined MINIMAL_VERSIONS cargo test

--- a/src/cargo/core/compiler/custom_build.rs
+++ b/src/cargo/core/compiler/custom_build.rs
@@ -466,7 +466,7 @@ impl BuildOutput {
             let key = iter.next();
             let value = iter.next();
             let (key, value) = match (key, value) {
-                (Some(a), Some(b)) => (a, b.trim_right()),
+                (Some(a), Some(b)) => (a, b.trim_end()),
                 // line started with `cargo:` but didn't match `key=value`
                 _ => bail!("Wrong output in {}: `{}`", whence, line),
             };

--- a/src/cargo/core/compiler/fingerprint.rs
+++ b/src/cargo/core/compiler/fingerprint.rs
@@ -228,7 +228,6 @@ struct MtimeSlot(Mutex<Option<FileTime>>);
 
 impl Fingerprint {
     fn update_local(&self, root: &Path) -> CargoResult<()> {
-        let mut hash_busted = false;
         for local in self.local.iter() {
             match *local {
                 LocalFingerprint::MtimeBased(ref slot, ref path) => {
@@ -238,12 +237,9 @@ impl Fingerprint {
                 }
                 LocalFingerprint::EnvBased(..) | LocalFingerprint::Precalculated(..) => continue,
             }
-            hash_busted = true;
         }
 
-        if hash_busted {
-            *self.memoized_hash.lock().unwrap() = None;
-        }
+        *self.memoized_hash.lock().unwrap() = None;
         Ok(())
     }
 

--- a/tests/testsuite/freshness.rs
+++ b/tests/testsuite/freshness.rs
@@ -4,7 +4,7 @@ use std::io::prelude::*;
 use support::paths::CargoPathExt;
 use support::registry::Package;
 use support::sleep_ms;
-use support::{basic_manifest, project};
+use support::{basic_manifest, is_coarse_mtime, project};
 
 #[test]
 fn modifying_and_moving() {
@@ -1172,6 +1172,63 @@ fn reuse_panic_pm() {
 [RUNNING] `rustc --crate-name somepm [..]
 [COMPILING] foo [..]
 [RUNNING] `rustc --crate-name foo src/lib.rs [..]-C panic=abort[..]
+[FINISHED] [..]
+",
+        )
+        .run();
+}
+
+#[test]
+fn bust_patched_dep() {
+    Package::new("registry1", "0.1.0").publish();
+    Package::new("registry2", "0.1.0")
+        .dep("registry1", "0.1.0")
+        .publish();
+
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "foo"
+            version = "0.0.1"
+
+            [dependencies]
+            registry2 = "0.1.0"
+
+            [patch.crates-io]
+            registry1 = { path = "reg1new" }
+        "#,
+        )
+        .file("src/lib.rs", "")
+        .file("reg1new/Cargo.toml", &basic_manifest("registry1", "0.1.0"))
+        .file("reg1new/src/lib.rs", "")
+        .build();
+
+    p.cargo("build").run();
+
+    File::create(&p.root().join("reg1new/src/lib.rs")).unwrap();
+    if is_coarse_mtime() {
+        sleep_ms(1000);
+    }
+
+    p.cargo("build")
+        .with_stderr(
+            "\
+[COMPILING] registry1 v0.1.0 ([..])
+[COMPILING] registry2 v0.1.0
+[COMPILING] foo v0.0.1 ([..])
+[FINISHED] [..]
+",
+        )
+        .run();
+
+    p.cargo("build -v")
+        .with_stderr(
+            "\
+[FRESH] registry1 v0.1.0 ([..])
+[FRESH] registry2 v0.1.0
+[FRESH] foo v0.0.1 ([..])
 [FINISHED] [..]
 ",
         )


### PR DESCRIPTION
Backport of #6493.
Also includes the following to pass CI:
- #6417 
- Bump min version in CI for `trim_end`.