### PR TITLE
[revert 6193] Remove Compilation.libraries

### DIFF
--- a/src/cargo/core/compiler/compilation.rs
+++ b/src/cargo/core/compiler/compilation.rs
@@ -21,6 +21,10 @@ pub struct Doctest {
 
 /// A structure returning the result of a compilation.
 pub struct Compilation<'cfg> {
+    /// A mapping from a package to the list of libraries that need to be
+    /// linked when working with that package.
+    pub libraries: HashMap<PackageId, HashSet<(Target, PathBuf)>>,
+
     /// An array of all tests created during this compilation.
     pub tests: Vec<(Package, TargetKind, String, PathBuf)>,
 
@@ -100,6 +104,7 @@ impl<'cfg> Compilation<'cfg> {
             server.configure(&mut rustc);
         }
         Ok(Compilation {
+            libraries: HashMap::new(),
             native_dirs: BTreeSet::new(), // TODO: deprecated, remove
             root_output: PathBuf::from("/"),
             deps_output: PathBuf::from("/"),

--- a/src/cargo/core/compiler/context/mod.rs
+++ b/src/cargo/core/compiler/context/mod.rs
@@ -174,6 +174,13 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
                     ));
                 } else if unit.target.is_bin() || unit.target.is_bin_example() {
                     self.compilation.binaries.push(bindst.clone());
+                } else if unit.target.is_lib() {
+                    let pkgid = unit.pkg.package_id().clone();
+                    self.compilation
+                        .libraries
+                        .entry(pkgid)
+                        .or_insert_with(HashSet::new)
+                        .insert((unit.target.clone(), output.path.clone()));
                 }
             }
 
@@ -190,6 +197,24 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
                         .or_insert_with(Vec::new)
                         .push(("OUT_DIR".to_string(), out_dir));
                 }
+
+                if !dep.target.is_lib() {
+                    continue;
+                }
+                if dep.mode.is_doc() {
+                    continue;
+                }
+
+                let outputs = self.outputs(dep)?;
+                self.compilation
+                    .libraries
+                    .entry(unit.pkg.package_id().clone())
+                    .or_insert_with(HashSet::new)
+                    .extend(
+                        outputs
+                            .iter()
+                            .map(|output| (dep.target.clone(), output.path.clone())),
+                    );
             }
 
             if unit.mode == CompileMode::Doctest {


### PR DESCRIPTION
This PR reverts #6193 .

It appears that the only reason for the removal was that this API was unused, but [as pointed out in the original PR](https://github.com/rust-lang/cargo/pull/6193#issuecomment-431589091), Rust projects are using this API.

No deprecation warning indicating the migration path was issued (there was a non-doc comment indicating that the API was deprecated, but that's it, no `deprecation()` attribute was used at all). 

#6193 cites #5651 for the removal, but [this comment](https://github.com/rust-lang/cargo/pull/5651#issuecomment-400143150) there also states that there are projects using this API and therefore "I'm not sure if we should just leave it, remove it, or replace it with something better". No replacement is discussed anywhere in those PRs and AFAICT no such replacement is available.

Please, do a cargo release after this PR is merged.

cc @dwijnand 