### PR TITLE
avoid duplicates in ignore files

### DIFF
--- a/tests/testsuite/init.rs
+++ b/tests/testsuite/init.rs
@@ -45,6 +45,45 @@ fn simple_bin() {
 }
 
 #[test]
+fn simple_git_ignore_exists() {
+    // write a .gitignore file with one entry
+    fs::create_dir_all(paths::root().join("foo")).unwrap();
+    let mut ignore_file = File::create(paths::root().join("foo/.gitignore")).unwrap();
+    ignore_file.write("/target\n**/some.file".as_bytes()).unwrap();
+
+    cargo_process("init --lib foo --edition 2015")
+        .env("USER", "foo")
+        .run();
+
+    assert!(paths::root().is_dir());
+    assert!(paths::root().join("foo/Cargo.toml").is_file());
+    assert!(paths::root().join("foo/src/lib.rs").is_file());
+    assert!(paths::root().join("foo/.git").is_dir());
+    assert!(paths::root().join("foo/.gitignore").is_file());
+
+    let fp = paths::root().join("foo/.gitignore");
+    let mut contents = String::new();
+    File::open(&fp)
+        .unwrap()
+        .read_to_string(&mut contents)
+        .unwrap();
+    assert_eq!(
+        contents,
+        "/target\n\
+        **/some.file\n\n\
+        #Added by cargo\n\
+        #\n\
+        #already existing elements are commented out\n\
+        \n\
+        #/target\n\
+        **/*.rs.bk\n\
+        Cargo.lock",
+    );
+
+    cargo_process("build").cwd(&paths::root().join("foo")).run();
+}
+
+#[test]
 fn both_lib_and_bin() {
     cargo_process("init --lib --bin")
         .env("USER", "foo")

--- a/tests/testsuite/new.rs
+++ b/tests/testsuite/new.rs
@@ -83,8 +83,20 @@ fn simple_git() {
     assert!(paths::root().join("foo/.git").is_dir());
     assert!(paths::root().join("foo/.gitignore").is_file());
 
+    let fp = paths::root().join("foo/.gitignore");
+    let mut contents = String::new();
+    File::open(&fp)
+        .unwrap()
+        .read_to_string(&mut contents)
+        .unwrap();
+    assert_eq!(
+        contents,
+        "/target\n**/*.rs.bk\nCargo.lock",
+    );
+
     cargo_process("build").cwd(&paths::root().join("foo")).run();
 }
+
 
 #[test]
 fn no_argument() {


### PR DESCRIPTION
Hi, 
here is my first PR for cargo. It's my take on #6377 with some minor refactoring included, mainly to avoid keeping the two different types of ignore file entries (gitignore and hg) in sync.) Basically, the contents of a ignore file are now read if the file exists and filtered out. To filter out I would propose to just comment the entries that cargo would add out, in that way it is nice to see which duplicates were found and more important _what cargo usually adds_. In that way, a user can modify his ignore file and be sure that he can keep everything that cargo would add.

A new ignore file will look like this:
```
/target
**/*.rs.bk
Cargo.lock",
```

An existing ignore file will be modified like this:
```
/target
/some/other/path

#Added by cargo
#
#already existing elements are commented out

#/target
**/*.rs.bk
Cargo.lock
```

Fixes #6377