### PR TITLE
publish: rework the crates.io detection logic.

### DIFF
--- a/src/cargo/core/source/source_id.rs
+++ b/src/cargo/core/source/source_id.rs
@@ -248,13 +248,6 @@ impl SourceId {
         }
     }
 
-    /// Is this source from an alternative registry
-    /// DEPRECATED: This is not correct if the registry name is not known
-    /// (for example when loaded from an index).
-    pub fn is_alt_registry(self) -> bool {
-        self.is_registry() && self.inner.name.is_some()
-    }
-
     /// Is this source from a git repository
     pub fn is_git(self) -> bool {
         match self.inner.kind {

--- a/tests/testsuite/publish.rs
+++ b/tests/testsuite/publish.rs
@@ -273,9 +273,9 @@ fn git_deps() {
         .with_stderr(
             "\
 [UPDATING] [..] index
-[ERROR] crates cannot be published to crates.io with dependencies sourced from \
-a repository\neither publish `foo` as its own crate on crates.io and \
-specify a crates.io version as a dependency or pull it into this \
+[ERROR] crates cannot be published with dependencies sourced from \
+a repository\neither publish `foo` as its own crate and \
+specify a version as a dependency or pull it into this \
 repository and specify it with a path and version\n\
 (crate `foo` has repository path `git://path/to/nowhere`)\
 ",


### PR DESCRIPTION
The old code used an unreliable method to detect if `cargo publish` was publishing to crates.io. This should work even if the `--index` flag is used.

Also includes a very minor rewording of an error message mentioning crates.io, even for alternative registries.