### PR TITLE
Report fix bugs to Rust instead of Cargo

### DIFF
--- a/src/cargo/util/diagnostic_server.rs
+++ b/src/cargo/util/diagnostic_server.rs
@@ -23,8 +23,10 @@ const PLEASE_REPORT_THIS_BUG: &str =
      and we would appreciate a bug report! You're likely to see \n\
      a number of compiler warnings after this message which cargo\n\
      attempted to fix but failed. If you could open an issue at\n\
-     https://github.com/rust-lang/cargo/issues\n\
-     quoting the full output of this command we'd be very appreciative!\n\n\
+     https://github.com/rust-lang/rust/issues\n\
+     quoting the full output of this command we'd be very appreciative!\n\
+     Note that you may be able to make some more progress in the near-term\n\
+     fixing code with the `--broken-code` flag\n\n\
      ";
 
 #[derive(Deserialize, Serialize)]

--- a/tests/testsuite/fix.rs
+++ b/tests/testsuite/fix.rs
@@ -155,8 +155,10 @@ fn broken_fixes_backed_out() {
              and we would appreciate a bug report! You're likely to see \n\
              a number of compiler warnings after this message which cargo\n\
              attempted to fix but failed. If you could open an issue at\n\
-             https://github.com/rust-lang/cargo/issues\n\
+             [..]\n\
              quoting the full output of this command we'd be very appreciative!\n\
+             Note that you may be able to make some more progress in the near-term\n\
+             fixing code with the `--broken-code` flag\n\
              \n\
              The following errors were reported:\n\
              error: expected one of `!` or `::`, found `rust`\n\


### PR DESCRIPTION
I originally opted to report bugs to Cargo instead of Rust because I was
afraid of the implementation of `cargo fix` itself. These seem to all be
weeded out now (largely at least), and the overwhelming majority of bugs
are now rust-lang/rust suggestion bugs. Let's suggest reporting bugs
directly there!