### PR TITLE
cargo metadata: Don't show `null` deps.

### DIFF
--- a/src/cargo/ops/cargo_output_metadata.rs
+++ b/src/cargo/ops/cargo_output_metadata.rs
@@ -105,7 +105,7 @@ where
 {
     #[derive(Serialize)]
     struct Dep {
-        name: Option<String>,
+        name: String,
         pkg: PackageId,
     }
 
@@ -123,13 +123,12 @@ where
             dependencies: resolve.deps(id).map(|(pkg, _deps)| pkg).collect(),
             deps: resolve
                 .deps(id)
-                .map(|(pkg, _deps)| {
-                    let name = packages
+                .filter_map(|(pkg, _deps)| {
+                    packages
                         .get(&pkg)
                         .and_then(|pkg| pkg.targets().iter().find(|t| t.is_lib()))
-                        .and_then(|lib_target| resolve.extern_crate_name(id, pkg, lib_target).ok());
-
-                    Dep { name, pkg }
+                        .and_then(|lib_target| resolve.extern_crate_name(id, pkg, lib_target).ok())
+                        .map(|name| Dep { name, pkg })
                 })
                 .collect(),
             features: resolve.features_sorted(id),

--- a/src/doc/man/cargo-metadata.adoc
+++ b/src/doc/man/cargo-metadata.adoc
@@ -212,7 +212,7 @@ The output has the following format:
                 */
                 "deps": [
                     {
-                        /* The name of the dependency.
+                        /* The name of the dependency's library target.
                            If this is a renamed dependency, this is the new
                            name.
                         */

--- a/src/doc/man/generated/cargo-metadata.html
+++ b/src/doc/man/generated/cargo-metadata.html
@@ -219,7 +219,7 @@ for a Rust API for reading the metadata.</p>
                 */
                 "deps": [
                     {
-                        /* The name of the dependency.
+                        /* The name of the dependency's library target.
                            If this is a renamed dependency, this is the new
                            name.
                         */

--- a/src/etc/man/cargo-metadata.1
+++ b/src/etc/man/cargo-metadata.1
@@ -233,7 +233,7 @@ The output has the following format:
                 */
                 "deps": [
                     {
-                        /* The name of the dependency.
+                        /* The name of the dependency\(aqs library target.
                            If this is a renamed dependency, this is the new
                            name.
                         */


### PR DESCRIPTION
If a package has a dependency without a library target, the "name" field was
showing up as null in `resolve.nodes.deps`. At this time (AFAIK), binary-only
dependencies are always ignored. Instead of making users filter out this entry
(or more commonly, crash), just don't include it.