### PR TITLE
Having a [patch] section when publishing is not an error

### DIFF
--- a/src/cargo/ops/registry.rs
+++ b/src/cargo/ops/registry.rs
@@ -60,10 +60,6 @@ pub fn publish(ws: &Workspace<'_>, opts: &PublishOpts<'_>) -> CargoResult<()> {
         }
     }
 
-    if !pkg.manifest().patch().is_empty() {
-        failure::bail!("published crates cannot contain [patch] sections");
-    }
-
     let (mut registry, reg_id) = registry(
         opts.config,
         opts.token.clone(),

--- a/src/doc/man/cargo-publish.adoc
+++ b/src/doc/man/cargo-publish.adoc
@@ -19,7 +19,6 @@ registry. The default registry is https://crates.io. This performs the
 following steps:
 
 . Performs a few checks, including:
-  - No `[patch]` sections are allowed in the manifest.
   - Checks the `package.publish` key in the manifest for restrictions on which
     registries you are allowed to publish to.
 . Create a `.crate` file by following the steps in man:cargo-package[1].


### PR DESCRIPTION
It is not necessary to throw an error when your `Cargo.toml` has a `[patch]` section.

1. Cargo will normalize your `Cargo.toml` while packaging, which will remove the `[patch]` section.
2. Even if the `[patch]` section were to somehow get to crates.io, it would be ignored when the crate is used since only the top-level crate's `[patch]` section is used.

The current behavior is quite annoying for crate maintainers who need a permanent `[patch]` section, for example, [`rand`](https://github.com/rust-random/rand/pull/670#issuecomment-452390749). This is the situation that leads to rand needing a permanent `[patch]` section:

![image](https://user-images.githubusercontent.com/1132307/50951760-54cf3a00-14d4-11e9-8064-a7def2ed402f.png)

Here, `rand` and `rand_core` are in the same repository, and `rdrand` is in a separate repository. When building `rand` as the top-level crate (e.g. in CI), the `rand->rand_core` path dependency will be used. This is of course a different crate than the crates.io rand_core used by `rdrand`. Therefore, when building `rand` as a top-level crate, you will *always* need to patch `crates-io.rand` to the path dependency. When building `rand` as a dependency, there are no issues, as the crates.io crates are used everywhere.