### PR TITLE
Change shell-escape in favor of v_shellescape

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,13 +52,13 @@ semver = { version = "0.9.0", features = ["serde"] }
 serde = { version = "1.0.82", features = ['derive'] }
 serde_ignored = "0.0.4"
 serde_json = { version = "1.0.30", features = ["raw_value"] }
-shell-escape = "0.1.4"
 tar = { version = "0.4.18", default-features = false }
 tempfile = "3.0"
 termcolor = "1.0"
 toml = "0.4.2"
 url = "1.1"
 url_serde = "0.2.0"
+v_shellescape = "0.3"
 clap = "2.31.2"
 unicode-width = "0.1.5"
 openssl = { version = '0.10.11', optional = true }

--- a/src/cargo/util/process_builder.rs
+++ b/src/cargo/util/process_builder.rs
@@ -7,7 +7,7 @@ use std::process::{Command, Output, Stdio};
 
 use failure::Fail;
 use jobserver::Client;
-use shell_escape::escape;
+use v_shellescape::escape;
 
 use crate::util::{process_error, read2, CargoResult, CargoResultExt};
 
@@ -38,11 +38,10 @@ impl fmt::Display for ProcessBuilder {
         if self.display_env_vars {
             for (key, val) in self.env.iter() {
                 if let Some(val) = val {
-                    let val = escape(val.to_string_lossy());
                     if cfg!(windows) {
-                        write!(f, "set {}={}&& ", key, val)?;
+                        write!(f, "set {}={}&& ", key, escape(&val.to_string_lossy()))?;
                     } else {
-                        write!(f, "{}={} ", key, val)?;
+                        write!(f, "{}={} ", key, escape(&val.to_string_lossy()))?;
                     }
                 }
             }
@@ -51,7 +50,7 @@ impl fmt::Display for ProcessBuilder {
         write!(f, "{}", self.program.to_string_lossy())?;
 
         for arg in &self.args {
-            write!(f, " {}", escape(arg.to_string_lossy()))?;
+            write!(f, " {}", escape(&arg.to_string_lossy()))?;
         }
 
         write!(f, "`")


### PR DESCRIPTION
They share the same features and tests, `shell-escape` is outdated 10 months ago and `v_shellescape` has higher performance, [benches comparative at Travis](https://travis-ci.org/rust-iendo/v_htmlescape/jobs/478394752#L467)