### PR TITLE
Fix incorrect help message

### DIFF
--- a/src/bin/cargo/commands/clean.rs
+++ b/src/bin/cargo/commands/clean.rs
@@ -7,7 +7,7 @@ pub fn cli() -> App {
         .about("Remove artifacts that cargo has generated in the past")
         .arg_package_spec_simple("Package to clean artifacts for")
         .arg_manifest_path()
-        .arg_target_triple("Target triple to clean output for (default all)")
+        .arg_target_triple("Target triple to clean output for")
         .arg_target_dir()
         .arg_release("Whether or not to clean release artifacts")
         .arg_doc("Whether or not to clean just the documentation directory")


### PR DESCRIPTION
The `cargo clean --target` command does not have a default setting, but the command-line help text says it does.