### PR TITLE
relax rustdoc output assertion

### DIFF
--- a/tests/testsuite/doc.rs
+++ b/tests/testsuite/doc.rs
@@ -679,8 +679,8 @@ fn output_not_captured() {
 
     p.cargo("doc")
         .without_status()
-        .with_stderr_contains("1 | ☃")
-        .with_stderr_contains(r"error: unknown start of token: \u{2603}")
+        .with_stderr_contains("[..]☃")
+        .with_stderr_contains(r"[..]unknown start of token: \u{2603}")
         .run();
 }
 


### PR DESCRIPTION
The output of this rustdoc error is changing in rust-lang/rust#56884. This PR relaxes an assertion on the output so that the test will still pass once the rustdoc PR is merged.