### PR TITLE
Better error message for bad manifest with `cargo install`.

### DIFF
--- a/tests/testsuite/install.rs
+++ b/tests/testsuite/install.rs
@@ -160,20 +160,27 @@ fn bad_version() {
 }
 
 #[test]
-fn no_crate() {
+fn bad_paths() {
     cargo_process("install")
         .with_status(101)
-        .with_stderr(
-            "\
-[ERROR] `[..]` is not a crate root; specify a crate to install [..]
+        .with_stderr("[ERROR] `[CWD]` is not a crate root; specify a crate to install [..]")
+        .run();
 
-Caused by:
-  failed to read `[..]Cargo.toml`
+    cargo_process("install --path .")
+        .with_status(101)
+        .with_stderr("[ERROR] `[CWD]` does not contain a Cargo.toml file[..]")
+        .run();
 
-Caused by:
-  [..] (os error [..])
-",
-        )
+    let toml = paths::root().join("Cargo.toml");
+    fs::write(toml, "").unwrap();
+    cargo_process("install --path Cargo.toml")
+        .with_status(101)
+        .with_stderr("[ERROR] `[CWD]/Cargo.toml` is not a directory[..]")
+        .run();
+
+    cargo_process("install --path .")
+        .with_status(101)
+        .with_stderr_contains("[ERROR] failed to parse manifest at `[CWD]/Cargo.toml`")
         .run();
 }
 

--- a/tests/testsuite/support/mod.rs
+++ b/tests/testsuite/support/mod.rs
@@ -1249,6 +1249,8 @@ enum MatchKind {
 /// - There is a wide range of macros (such as `[COMPILING]` or `[WARNING]`)
 ///   to match cargo's "status" output and allows you to ignore the alignment.
 ///   See `substitute_macros` for a complete list of macros.
+/// - `[ROOT]` is `/` or `[..]:\` on Windows.
+/// - `[CWD]` is the working directory of the process that was run.
 pub fn lines_match(expected: &str, actual: &str) -> bool {
     // Let's not deal with / vs \ (windows...)
     // First replace backslash-escaped backslashes with forward slashes


### PR DESCRIPTION
The old code assumed that any error loading a manifest meant that the
manifest didn't exist, but there are many other reasons it may fail.
Add a few helpful messages for some common cases.

First noticed at https://github.com/rust-lang/cargo/issues/5654#issuecomment-455293220