### PR TITLE
Make incremental compilation the default for all profiles.

### DIFF
--- a/src/cargo/core/profiles.rs
+++ b/src/cargo/core/profiles.rs
@@ -406,7 +406,7 @@ impl Default for Profile {
             debug_assertions: false,
             overflow_checks: false,
             rpath: false,
-            incremental: false,
+            incremental: true,
             panic: None,
         }
     }
@@ -467,7 +467,6 @@ impl Profile {
             debuginfo: Some(2),
             debug_assertions: true,
             overflow_checks: true,
-            incremental: true,
             ..Profile::default()
         }
     }


### PR DESCRIPTION
This PR makes incremental compilation the default for all profiles, that is, also `release` and `bench`. `rustc` performs ThinLTO by default for incremental release builds for a while now and the [data we've gathered so far](https://github.com/rust-lang/rust/pull/56678) indicates that the generated binaries exhibit roughly the same runtime performance as non-incrementally compiled ones. At the same time, incremental release builds can be 2-5 times as fast as non-incremental ones.

Making incremental compilation (temporarily) the default in `cargo` would be a simple way of gathering more data about runtime performance via [lolbench.rs](https://lolbench.rs). If the results look acceptable, we can just leave it on and give a massive compile time reduction to everyone. If not, we can revert the change and think about a plan B. 

This strategy assumes that lolbench will actually use the nightly `cargo` version. Is that true, @anp?

r? @alexcrichton 
