### PR TITLE
Add builds.sr.ht CI config to book

### DIFF
--- a/src/doc/src/guide/continuous-integration.md
+++ b/src/doc/src/guide/continuous-integration.md
@@ -48,3 +48,41 @@ This will test on the stable channel and nightly channel, but any
 breakage in nightly will not fail your overall build. Please see the
 [GitLab CI](https://docs.gitlab.com/ce/ci/yaml/README.html) for more
 information.
+
+### builds.sr.ht
+
+To test your package on sr.ht, here is a sample `.build.yml` file.
+Be sure to change `<your repo>` and `<your project>` to the repo to clone and
+the directory where it was cloned.
+
+```yaml
+image: archlinux
+packages:
+  - rustup
+sources:
+  - <your repo>
+tasks:
+  - setup: |
+      rustup toolchain install nightly stable
+      cd <your project>/
+      rustup run stable cargo fetch
+  - stable: |
+      rustup default stable
+      cd <your project>/
+      cargo build --verbose
+      cargo test --verbose
+  - nightly: |
+      rustup default nightly
+      cd <your project>/
+      cargo build --verbose ||:
+      cargo test --verbose  ||:
+  - docs: |
+      cd <your project>/
+      rustup run stable cargo doc --no-deps
+      rustup run nightly cargo doc --no-deps ||:
+```
+
+This will test and build documentation on the stable channel and nightly
+channel, but any breakage in nightly will not fail your overall build. Please
+see the [builds.sr.ht documentation](https://man.sr.ht/builds.sr.ht/) for more
+information.


### PR DESCRIPTION
This adds a CI configuration for [builds.sr.ht](https://builds.sr.ht) to the book alongside the existing configurations for Travis and GitLab CI.
The config in question is broadly similar to those two, except that I also opted to build the docs as I commonly find markdown oddities this way from the warnings it spits out.
I picked Arch Linux as the base image because it's easy to install rustup there (since there's a package for it in the Arch repos), but it could have been Debian or FreeBSD or something else just as easily if you have strong opinions about manually installing rustup.

**EDIT:** None of the other build configs had it, so I didn't add publishing tagged commits to crates.io using its secrets mechanism to log cargo in. However, if that's something you think would be beneficial, I can add it.