### PR TITLE
Add build profile.

### DIFF
--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -191,6 +191,9 @@ features! {
         // Overriding profiles for dependencies.
         [unstable] profile_overrides: bool,
 
+        // Build profile.
+        [unstable] build_profile: bool,
+
         // Separating the namespaces for features and dependencies
         [unstable] namespaced_features: bool,
 

--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -148,6 +148,36 @@ cargo +nightly build -Z config-profile
 ```
 
 
+### Build Profile
+* Tracking Issue: [rust-lang/rust#48683](https://github.com/rust-lang/rust/issues/48683)
+
+The `build` profile controls the build settings for build scripts,
+proc-macros, compiler plugins, and all of their dependencies. It requires the
+`build-profile` feature to be enabled.
+
+```toml
+cargo-features = ["build-profile"]
+
+[profile.build]
+# The following illustrates the defaults.
+opt-level = 0
+debug = false
+rpath = false
+lto = false
+debug-assertions = false
+codegen-units = 16
+panic = 'unwind'
+incremental = false
+overflow-checks = false
+```
+
+It is compatible with [Profile Overrides](#profile-overrides) and [Config
+Profiles](#config-profiles). If `build-override` is specified in a dev or
+release profile, that takes precedence over the `build` profile. Enabling
+`build-profile` will cause `build-override` to also affect proc-macros and
+plugins (normally it only affects build scripts).
+
+
 ### Namespaced features
 * Original issue: [#1286](https://github.com/rust-lang/cargo/issues/1286)
 * Tracking Issue: [#5565](https://github.com/rust-lang/cargo/issues/5565)

--- a/tests/testsuite/build_profile.rs
+++ b/tests/testsuite/build_profile.rs
@@ -1,0 +1,481 @@
+use crate::support::{basic_lib_manifest, project};
+
+#[test]
+fn build_profile_gated() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "foo"
+            version = "0.0.1"
+
+            [profile.build]
+            opt-level = 3
+        "#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    p.cargo("build")
+        .masquerade_as_nightly_cargo()
+        .with_status(101)
+        .with_stderr(
+            "\
+error: failed to parse manifest at `[..]`
+
+Caused by:
+  feature `build-profile` is required
+
+consider adding `cargo-features = [\"build-profile\"]` to the manifest
+",
+        )
+        .run();
+}
+
+#[test]
+fn build_profile_basic() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            cargo-features = ["build-profile"]
+
+            [package]
+            name = "foo"
+            version = "0.0.1"
+
+            [profile.build]
+            opt-level = 3
+        "#,
+        )
+        .file("src/lib.rs", "")
+        .file("build.rs", "fn main() {}")
+        .build();
+
+    p.cargo("build -v")
+        .masquerade_as_nightly_cargo()
+        .with_stderr_line_without(
+            &[
+                "[RUNNING] `rustc --crate-name build_script_build",
+                "-C opt-level=3",
+            ],
+            &["-C debuginfo", "-C incremental"],
+        )
+        .run();
+}
+
+#[test]
+fn build_profile_default_disabled() {
+    // Verify the defaults are not affected if build-profile is not enabled.
+    let p = project()
+        .file("src/lib.rs", "")
+        .file("build.rs", "fn main() {}")
+        .build();
+
+    p.cargo("build -v")
+        .masquerade_as_nightly_cargo()
+        .with_stderr_line_without(
+            &[
+                "[RUNNING] `rustc --crate-name build_script_build",
+                "-C debuginfo=2",
+            ],
+            &["-C opt-level"],
+        )
+        .run();
+
+    p.cargo("build -v --release")
+        .masquerade_as_nightly_cargo()
+        .with_stderr_line_without(
+            &[
+                "[RUNNING] `rustc --crate-name build_script_build",
+                "-C opt-level=3",
+            ],
+            &["-C debuginfo"],
+        )
+        .run();
+}
+
+#[test]
+fn build_profile_default_enabled() {
+    // Check the change in defaults when the feature is enabled.
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            cargo-features = ["build-profile"]
+
+            [package]
+            name = "foo"
+            version = "0.0.1"
+        "#,
+        )
+        .file("src/lib.rs", "")
+        .file("build.rs", "fn main() {}")
+        .build();
+
+    p.cargo("build -v")
+        .masquerade_as_nightly_cargo()
+        .with_stderr_line_without(
+            &["[RUNNING] `rustc --crate-name build_script_build"],
+            &["-C debuginfo", "-C opt-level"],
+        )
+        .run();
+
+    p.cargo("build -v --release")
+        .masquerade_as_nightly_cargo()
+        .with_stderr_line_without(
+            &["[RUNNING] `rustc --crate-name build_script_build"],
+            &["-C debuginfo", "-C opt-level"],
+        )
+        .run();
+}
+
+#[test]
+fn build_profile_with_override() {
+    // Check with `overrides` in `profile.build`.
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            cargo-features = ["build-profile", "profile-overrides"]
+
+            [package]
+            name = "foo"
+            version = "0.0.1"
+
+            [profile.build.overrides.bar]
+            opt-level = 3
+
+            [dependencies]
+            bar = { path = "bar" }
+
+            [build-dependencies]
+            bar = { path = "bar" }
+        "#,
+        )
+        .file("src/lib.rs", "extern crate bar;")
+        .file("build.rs", "extern crate bar; fn main() {}")
+        .file("bar/Cargo.toml", &basic_lib_manifest("bar"))
+        .file("bar/src/lib.rs", "")
+        .build();
+
+    p.cargo("build -v")
+        .masquerade_as_nightly_cargo()
+        // bar as a build-dependency
+        .with_stderr_line_without(
+            &["[RUNNING] `rustc --crate-name bar", "-C opt-level=3"],
+            &["-C debuginfo"],
+        )
+        // bar as a regular dependency
+        .with_stderr_line_without(
+            &["[RUNNING] `rustc --crate-name bar", "-C debuginfo=2"],
+            &["-C opt-level"],
+        )
+        .with_stderr_line_without(
+            &["[RUNNING] `rustc --crate-name build_script_build"],
+            &["-C opt-level", "-C debuginfo"],
+        )
+        .run();
+}
+
+#[test]
+fn build_profile_rejects_build_override() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            cargo-features = ["build-profile", "profile-overrides"]
+
+            [package]
+            name = "foo"
+            version = "0.0.1"
+
+            [profile.build.build-override]
+            opt-level = 3
+        "#,
+        )
+        .file("src/lib.rs", "")
+        .file("build.rs", "fn main() {}")
+        .build();
+
+    p.cargo("build -v")
+        .masquerade_as_nightly_cargo()
+        .with_status(101)
+        .with_stderr(
+            "\
+error: failed to parse manifest at `[..]`
+
+Caused by:
+  `build` profile cannot specify build overrides.
+",
+        )
+        .run();
+}
+
+#[test]
+fn build_profile_with_other_build_override() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            cargo-features = ["build-profile", "profile-overrides"]
+
+            [package]
+            name = "foo"
+            version = "0.0.1"
+
+            [profile.build]
+            codegen-units = 1
+
+            [profile.dev]
+            codegen-units = 2
+
+            [profile.dev.build-override]
+            codegen-units = 3
+
+            [profile.release]
+            codegen-units = 4
+        "#,
+        )
+        .file("src/lib.rs", "")
+        .file("build.rs", "fn main() {}")
+        .build();
+
+    // build script = 3
+    // lib = 2
+    p.cargo("build -v")
+        .masquerade_as_nightly_cargo()
+        // Note: it inherits all settings from profile.dev (including debuginfo)
+        .with_stderr_line_without(
+            &[
+                "[RUNNING] `rustc --crate-name build_script_build",
+                "-C codegen-units=3",
+                "-C debuginfo=2",
+            ],
+            &["-C opt-level"],
+        )
+        .with_stderr_line_without(
+            &[
+                "[RUNNING] `rustc --crate-name foo",
+                "-C codegen-units=2",
+                "-C debuginfo=2",
+            ],
+            &[],
+        )
+        .run();
+
+    // build script = 1
+    // lib = 4
+    p.cargo("build -v --release")
+        .masquerade_as_nightly_cargo()
+        // This is not overridden.
+        .with_stderr_line_without(
+            &[
+                "[RUNNING] `rustc --crate-name build_script_build",
+                "-C codegen-units=1",
+            ],
+            &["-C opt-level", "-C debuginfo"],
+        )
+        .with_stderr_line_without(
+            &["[RUNNING] `rustc --crate-name foo", "-C codegen-units=4"],
+            &["-C debuginfo"],
+        )
+        .run();
+}
+
+#[test]
+fn build_profile_default_with_pm_build_override() {
+    // Check that enabling build-profile engages the ability for
+    // build-overrides to affect proc-macros.
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            cargo-features = ["build-profile", "profile-overrides"]
+
+            [package]
+            name = "foo"
+            version = "0.0.1"
+
+            [profile.dev.build-override]
+            codegen-units = 3
+
+            [dependencies]
+            pm = { path = "pm" }
+        "#,
+        )
+        .file("src/lib.rs", "extern crate pm;")
+        .file(
+            "pm/Cargo.toml",
+            r#"
+            [package]
+            name = "pm"
+            version = "0.1.0"
+            [lib]
+            proc-macro = true
+        "#,
+        )
+        .file("pm/src/lib.rs", "")
+        .build();
+
+    p.cargo("build -v")
+        .masquerade_as_nightly_cargo()
+        .with_stderr_line_without(
+            &[
+                "[RUNNING] `rustc --crate-name pm",
+                "-C codegen-units=3",
+                "-C debuginfo=2",
+            ],
+            &["-C opt-level"],
+        )
+        .run();
+}
+
+#[test]
+fn build_profile_config() {
+    // Check `[profile.build]` inside .cargo/config.
+    let p = project()
+        .file("src/lib.rs", "")
+        .file("build.rs", "fn main() {}")
+        .file(
+            ".cargo/config",
+            r#"
+            [profile.build]
+            codegen-units = 3
+        "#,
+        )
+        .build();
+
+    p.cargo("build -v -Z config-profile")
+        .masquerade_as_nightly_cargo()
+        .with_stderr_contains("\
+[WARNING] profile `build` in config file will be ignored for manifest `[CWD]/Cargo.toml` \
+because \"build-profile\" feature is not enabled")
+        .with_stderr_line_without(
+            &["[RUNNING] `rustc --crate-name build_script_build", "-C debuginfo=2"],
+            &["-C codegen-units", "-C opt-level"])
+        .run();
+
+    p.change_file(
+        "Cargo.toml",
+        r#"
+        cargo-features = ["build-profile"]
+
+        [package]
+        name = "foo"
+        version = "0.0.1"
+    "#,
+    );
+
+    p.cargo("build -v -Z config-profile")
+        .masquerade_as_nightly_cargo()
+        .with_stderr_line_without(
+            &[
+                "[RUNNING] `rustc --crate-name build_script_build",
+                "-C codegen-units=3",
+            ],
+            &["-C debuginfo=2", "-C opt-level"],
+        )
+        .run();
+}
+
+#[test]
+fn proc_macro_default_disabled() {
+    // Make sure proc-macros are not affected if feature is not enabled.
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "foo"
+            version = "0.1.0"
+            [dependencies]
+            pm = { path = "pm" }
+        "#,
+        )
+        .file("src/lib.rs", "extern crate pm;")
+        .file(
+            "pm/Cargo.toml",
+            r#"
+            [package]
+            name = "pm"
+            version = "0.1.0"
+            [lib]
+            proc-macro = true
+        "#,
+        )
+        .file("pm/src/lib.rs", "")
+        .build();
+
+    p.cargo("build -v --release")
+        .with_stderr_line_without(
+            &["[RUNNING] `rustc --crate-name pm", "-C opt-level=3"],
+            &["-C debuginfo=2"],
+        )
+        .run();
+}
+
+#[test]
+fn proc_macro_default_enabled() {
+    // Check that proc-macros *are* affected when build-profile is enabled,
+    // but no profile settings are set (checking the default settings).
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            cargo-features = ["build-profile"]
+            [package]
+            name = "foo"
+            version = "0.1.0"
+            [dependencies]
+            bar = { path = "bar" }
+            pm = { path = "pm" }
+        "#,
+        )
+        .file(
+            "src/lib.rs",
+            "\
+            extern crate pm;
+            extern crate bar;
+        ",
+        )
+        .file(
+            "pm/Cargo.toml",
+            r#"
+            [package]
+            name = "pm"
+            version = "0.1.0"
+            [lib]
+            proc-macro = true
+            [dependencies]
+            bar = { path = "../bar" }
+        "#,
+        )
+        .file("pm/src/lib.rs", "")
+        .file("bar/Cargo.toml", &basic_lib_manifest("bar"))
+        .file("bar/src/lib.rs", "")
+        .build();
+
+    p.cargo("build -v --release")
+        .masquerade_as_nightly_cargo()
+        // bar for the proc-macro
+        .with_stderr_line_without(
+            &["[RUNNING] `rustc --crate-name bar"],
+            &["-C opt-level", "-C debuginfo"],
+        )
+        // bar as a normal dependency
+        .with_stderr_line_without(
+            &["[RUNNING] `rustc --crate-name bar", "-C opt-level=3"],
+            &["-C debuginfo"],
+        )
+        .with_stderr_line_without(
+            &["[RUNNING] `rustc --crate-name pm"],
+            &["-C debuginfo", "-C opt-level"],
+        )
+        .with_stderr_line_without(
+            &["[RUNNING] `rustc --crate-name foo", "-C opt-level=3"],
+            &["-C debuginfo"],
+        )
+        .run();
+}

--- a/tests/testsuite/main.rs
+++ b/tests/testsuite/main.rs
@@ -16,6 +16,7 @@ mod build;
 mod build_auth;
 mod build_lib;
 mod build_plan;
+mod build_profile;
 mod build_script;
 mod build_script_env;
 mod cargo_alias_config;


### PR DESCRIPTION
This adds a `build` profile as discussed at rust-lang/rust#48683. See `unstable.md` for a brief description.