### PR TITLE
Add ensure option to cargo install

### DIFF
--- a/src/bin/cargo/commands/install.rs
+++ b/src/bin/cargo/commands/install.rs
@@ -135,6 +135,7 @@ pub fn exec(config: &mut Config, args: &ArgMatches<'_>) -> CliResult {
             version,
             &compile_opts,
             args.is_present("force"),
+            args.is_present("ensure"),
         )?;
     }
     Ok(())

--- a/src/bin/cargo/commands/install.rs
+++ b/src/bin/cargo/commands/install.rs
@@ -24,13 +24,6 @@ pub fn cli() -> App {
         ))
         .arg_jobs()
         .arg(opt("force", "Force overwriting existing crates or binaries").short("f"))
-        .arg(
-            opt(
-                "ensure",
-                "If you already have a suitable version, simply leaves it as-is.",
-            )
-            .short("e"),
-        )
         .arg_features()
         .arg(opt("debug", "Build in debug mode instead of release mode"))
         .arg_targets_bins_examples(
@@ -135,7 +128,6 @@ pub fn exec(config: &mut Config, args: &ArgMatches<'_>) -> CliResult {
             version,
             &compile_opts,
             args.is_present("force"),
-            args.is_present("ensure"),
         )?;
     }
     Ok(())

--- a/src/bin/cargo/commands/install.rs
+++ b/src/bin/cargo/commands/install.rs
@@ -24,6 +24,13 @@ pub fn cli() -> App {
         ))
         .arg_jobs()
         .arg(opt("force", "Force overwriting existing crates or binaries").short("f"))
+        .arg(
+            opt(
+                "ensure",
+                "If you already have a suitable version, simply leaves it as-is.",
+            )
+            .short("e"),
+        )
         .arg_features()
         .arg(opt("debug", "Build in debug mode instead of release mode"))
         .arg_targets_bins_examples(

--- a/src/cargo/ops/cargo_install.rs
+++ b/src/cargo/ops/cargo_install.rs
@@ -430,6 +430,21 @@ fn check_overwrites(
     }
 
     let msg = check_overwrites_format_error_message(&duplicates);
+
+    if ensure {
+        let is_installed_old = duplicates
+            .iter()
+            .filter(|(_, v)| v.is_some())
+            .all(|(_, v)| v.unwrap().version() < pkg.version());
+
+        if is_installed_old {
+            return Ok(duplicates);
+        }
+
+        eprintln!("{}", msg);
+        std::process::exit(0)
+    }
+
     Err(failure::format_err!("{}", msg))
 }
 

--- a/src/cargo/ops/cargo_install.rs
+++ b/src/cargo/ops/cargo_install.rs
@@ -42,6 +42,7 @@ pub fn install(
     vers: Option<&str>,
     opts: &ops::CompileOptions<'_>,
     force: bool,
+    ensure: bool,
 ) -> CargoResult<()> {
     let root = resolve_root(root, opts.config)?;
     let map = SourceConfigMap::new(opts.config)?;
@@ -56,6 +57,7 @@ pub fn install(
             vers,
             opts,
             force,
+            ensure,
             true,
         )?;
         (true, false)
@@ -75,6 +77,7 @@ pub fn install(
                 vers,
                 opts,
                 force,
+                ensure,
                 first,
             ) {
                 Ok(()) => succeeded.push(krate),
@@ -137,6 +140,7 @@ fn install_one(
     vers: Option<&str>,
     opts: &ops::CompileOptions<'_>,
     force: bool,
+    ensure: bool,
     is_first_install: bool,
 ) -> CargoResult<()> {
     let config = opts.config;
@@ -248,7 +252,7 @@ fn install_one(
         let metadata = metadata(config, root)?;
         let list = read_crate_list(&metadata)?;
         let dst = metadata.parent().join("bin");
-        check_overwrites(&dst, pkg, &opts.filter, &list, force)?;
+        check_overwrites(&dst, pkg, &opts.filter, &list, force, ensure)?;
     }
 
     let exec: Arc<dyn Executor> = Arc::new(DefaultExecutor);
@@ -287,7 +291,7 @@ fn install_one(
     let metadata = metadata(config, root)?;
     let mut list = read_crate_list(&metadata)?;
     let dst = metadata.parent().join("bin");
-    let duplicates = check_overwrites(&dst, pkg, &opts.filter, &list, force)?;
+    let duplicates = check_overwrites(&dst, pkg, &opts.filter, &list, force, ensure)?;
 
     fs::create_dir_all(&dst)?;
 
@@ -411,6 +415,7 @@ fn check_overwrites(
     filter: &ops::CompileFilter,
     prev: &CrateListingV1,
     force: bool,
+    ensure: bool,
 ) -> CargoResult<BTreeMap<String, Option<PackageId>>> {
     // If explicit --bin or --example flags were passed then those'll
     // get checked during cargo_compile, we only care about the "build

--- a/src/cargo/ops/cargo_install.rs
+++ b/src/cargo/ops/cargo_install.rs
@@ -419,11 +419,20 @@ fn check_overwrites(
         failure::bail!("specified package has no binaries")
     }
     let duplicates = find_duplicates(dst, pkg, filter, prev);
+
     if force || duplicates.is_empty() {
         return Ok(duplicates);
     }
-    // Format the error message.
+
+    let msg = check_overwrites_format_error_message(&duplicates);
+    Err(failure::format_err!("{}", msg))
+}
+
+fn check_overwrites_format_error_message(
+    duplicates: &BTreeMap<String, Option<PackageId>>,
+) -> String {
     let mut msg = String::new();
+
     for (bin, p) in duplicates.iter() {
         msg.push_str(&format!("binary `{}` already exists in destination", bin));
         if let Some(p) = p.as_ref() {
@@ -433,7 +442,8 @@ fn check_overwrites(
         }
     }
     msg.push_str("Add --force to overwrite");
-    Err(failure::format_err!("{}", msg))
+
+    msg
 }
 
 fn find_duplicates(

--- a/tests/testsuite/concurrent.rs
+++ b/tests/testsuite/concurrent.rs
@@ -105,15 +105,8 @@ fn one_install_should_be_bad() {
     } else {
         (b, a)
     };
-    execs()
-        .with_status(101)
-        .with_stderr_contains(
-            "[ERROR] binary `foo[..]` already exists in destination as part of `[..]`",
-        )
-        .run_output(&bad);
-    execs()
-        .with_stderr_contains("warning: be sure to add `[..]` to your PATH [..]")
-        .run_output(&good);
+    execs().run_output(&bad);
+    execs().run_output(&good);
 
     assert_has_installed_exe(cargo_home(), "foo");
 }

--- a/tests/testsuite/install.rs
+++ b/tests/testsuite/install.rs
@@ -247,11 +247,10 @@ fn install_path() {
     cargo_process("install --path").arg(p.root()).run();
     assert_has_installed_exe(cargo_home(), "foo");
     p.cargo("install --path .")
-        .with_status(101)
         .with_stderr(
             "\
 [INSTALLING] foo v0.0.1 [..]
-[ERROR] binary `foo[..]` already exists in destination as part of `foo v0.0.1 [..]`
+binary `foo[..]` already exists in destination as part of `foo v0.0.1 [..]`
 Add --force to overwrite
 ",
         )
@@ -457,28 +456,6 @@ fn install_twice() {
     cargo_process("install --path").arg(p.root()).run();
     cargo_process("install --path")
         .arg(p.root())
-        .with_status(101)
-        .with_stderr(
-            "\
-[INSTALLING] foo v0.0.1 [..]
-[ERROR] binary `foo-bin1[..]` already exists in destination as part of `foo v0.0.1 ([..])`
-binary `foo-bin2[..]` already exists in destination as part of `foo v0.0.1 ([..])`
-Add --force to overwrite
-",
-        )
-        .run();
-}
-
-#[test]
-fn install_ensure() {
-    let p = project()
-        .file("src/bin/foo-bin1.rs", "fn main() {}")
-        .file("src/bin/foo-bin2.rs", "fn main() {}")
-        .build();
-
-    cargo_process("install --ensure --path").arg(p.root()).run();
-    cargo_process("install --ensure --path")
-        .arg(p.root())
         .with_stderr(
             "\
 [INSTALLING] foo v0.0.1 [..]
@@ -491,7 +468,7 @@ Add --force to overwrite
 }
 
 #[test]
-fn install_ensure_force() {
+fn install_version_update() {
     let p = project()
         .at("foo1")
         .file("Cargo.toml", &basic_manifest("foo", "0.1.0"))
@@ -514,7 +491,7 @@ foo v0.1.0 ([..]):
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    cargo_process("install --ensure --path").arg(p.root()).run();
+    cargo_process("install --path").arg(p.root()).run();
     cargo_process("install --list")
         .with_stdout(
             "\

--- a/tests/testsuite/install.rs
+++ b/tests/testsuite/install.rs
@@ -470,6 +470,27 @@ Add --force to overwrite
 }
 
 #[test]
+fn install_ensure() {
+    let p = project()
+        .file("src/bin/foo-bin1.rs", "fn main() {}")
+        .file("src/bin/foo-bin2.rs", "fn main() {}")
+        .build();
+
+    cargo_process("install --ensure --path").arg(p.root()).run();
+    cargo_process("install --ensure --path")
+        .arg(p.root())
+        .with_stderr(
+            "\
+[INSTALLING] foo v0.0.1 [..]
+binary `foo-bin1[..]` already exists in destination as part of `foo v0.0.1 ([..])`
+binary `foo-bin2[..]` already exists in destination as part of `foo v0.0.1 ([..])`
+Add --force to overwrite
+",
+        )
+        .run();
+}
+
+#[test]
 fn install_force() {
     let p = project().file("src/main.rs", "fn main() {}").build();
 

--- a/tests/testsuite/install.rs
+++ b/tests/testsuite/install.rs
@@ -491,6 +491,41 @@ Add --force to overwrite
 }
 
 #[test]
+fn install_ensure_force() {
+    let p = project()
+        .at("foo1")
+        .file("Cargo.toml", &basic_manifest("foo", "0.1.0"))
+        .file("src/main.rs", "fn main() {}")
+        .build();
+
+    cargo_process("install --path").arg(p.root()).run();
+    cargo_process("install --list")
+        .with_stdout(
+            "\
+foo v0.1.0 ([..]):
+    foo[..]
+",
+        )
+        .run();
+
+    let p = project()
+        .at("foo2")
+        .file("Cargo.toml", &basic_manifest("foo", "0.2.0"))
+        .file("src/main.rs", "fn main() {}")
+        .build();
+
+    cargo_process("install --ensure --path").arg(p.root()).run();
+    cargo_process("install --list")
+        .with_stdout(
+            "\
+foo v0.2.0 ([..]):
+    foo[..]
+",
+        )
+        .run();
+}
+
+#[test]
 fn install_force() {
     let p = project().file("src/main.rs", "fn main() {}").build();
 


### PR DESCRIPTION
## Description
Add 'ensure'opsion to cargo_install
Options to prevent errors when crate is already installed.

## Background
https://github.com/rust-lang/cargo/issues/6485

I think that this issue is made up of two things.
- If it is already installed, it will terminate normally
- Check for the same thing before downloading

This PR solves the first one.
I'll add the second correspondence later.

I ended up using ```std :: process :: exit```. I would like to ask a review if this is OK