### PR TITLE
Some CI setups are much slower then the equipment used by Cargo itself

### DIFF
--- a/tests/testsuite/build_script.rs
+++ b/tests/testsuite/build_script.rs
@@ -3,12 +3,11 @@ use std::fs::{self, File};
 use std::io;
 use std::io::prelude::*;
 use std::thread;
-use std::time::Duration;
 
 use crate::support::paths::CargoPathExt;
 use crate::support::registry::Package;
 use crate::support::{basic_manifest, cross_compile, project};
-use crate::support::{rustc_host, sleep_ms};
+use crate::support::{rustc_host, sleep_ms, slow_cpu_multiplier};
 use cargo::util::paths::remove_dir_all;
 
 #[test]
@@ -3174,7 +3173,9 @@ fn switch_features_rerun() {
     p.cargo("build -v --features=foo").run();
     p.rename_run("foo", "with_foo").with_stdout("foo\n").run();
     p.cargo("build -v").run();
-    p.rename_run("foo", "without_foo").with_stdout("bar\n").run();
+    p.rename_run("foo", "without_foo")
+        .with_stdout("bar\n")
+        .run();
     p.cargo("build -v --features=foo").run();
     p.rename_run("foo", "with_foo2").with_stdout("foo\n").run();
 }
@@ -3569,7 +3570,7 @@ fn _rename_with_link_search_path(cross: bool) {
             panic!("failed to rename: {}", error);
         }
         println!("assuming {} is spurious, waiting to try again", error);
-        thread::sleep(Duration::from_millis(100));
+        thread::sleep(slow_cpu_multiplier(100));
     }
 
     p2.cargo(&format!("run{}", target_arg))

--- a/tests/testsuite/concurrent.rs
+++ b/tests/testsuite/concurrent.rs
@@ -4,14 +4,13 @@ use std::net::TcpListener;
 use std::process::Stdio;
 use std::sync::mpsc::channel;
 use std::thread;
-use std::time::Duration;
 use std::{env, str};
 
 use crate::support::cargo_process;
 use crate::support::git;
 use crate::support::install::{assert_has_installed_exe, cargo_home};
 use crate::support::registry::Package;
-use crate::support::{basic_manifest, execs, project};
+use crate::support::{basic_manifest, execs, project, slow_cpu_multiplier};
 use git2;
 
 fn pkg(name: &str, vers: &str) {
@@ -526,7 +525,7 @@ fn no_deadlock_with_git_dependencies() {
     }
 
     for _ in 0..n_concurrent_builds {
-        let result = rx.recv_timeout(Duration::from_secs(30)).expect("Deadlock!");
+        let result = rx.recv_timeout(slow_cpu_multiplier(30)).expect("Deadlock!");
         execs().run_output(&result);
     }
 }

--- a/tests/testsuite/death.rs
+++ b/tests/testsuite/death.rs
@@ -3,9 +3,8 @@ use std::io::{self, Read};
 use std::net::TcpListener;
 use std::process::{Child, Stdio};
 use std::thread;
-use std::time::Duration;
 
-use crate::support::project;
+use crate::{support::project, support::slow_cpu_multiplier};
 
 #[cfg(unix)]
 fn enabled() -> bool {
@@ -121,7 +120,7 @@ fn ctrl_c_kills_everyone() {
             Ok(()) => return,
             Err(e) => println!("attempt {}: {}", i, e),
         }
-        thread::sleep(Duration::from_millis(100));
+        thread::sleep(slow_cpu_multiplier(100));
     }
 
     panic!(

--- a/tests/testsuite/resolve.rs
+++ b/tests/testsuite/resolve.rs
@@ -32,7 +32,7 @@ proptest! {
         // and locally.
         cases: 256,
         max_shrink_iters:
-            if env::var("CI").is_ok() {
+            if env::var("CI").is_ok() || !atty::is(atty::Stream::Stderr) {
                 // This attempts to make sure that CI will fail fast,
                 0
             } else {

--- a/tests/testsuite/support/mod.rs
+++ b/tests/testsuite/support/mod.rs
@@ -1634,3 +1634,14 @@ pub fn is_coarse_mtime() -> bool {
     // that's tricky to detect, so for now just deal with CI.
     cfg!(target_os = "macos") && env::var("CI").is_ok()
 }
+
+/// Some CI setups are much slower then the equipment used by Cargo itself.
+/// Architectures that do not have a modern processor, hardware emulation, ect.
+/// This provides a way for those setups to increase the cut off for all the time based test.
+pub fn slow_cpu_multiplier(main: u64) -> Duration {
+    lazy_static::lazy_static! {
+        static ref SLOW_CPU_MULTIPLIER: u64 =
+            env::var("CARGO_TEST_SLOW_CPU_MULTIPLIER").ok().and_then(|m| m.parse().ok()).unwrap_or(1);
+    }
+    Duration::from_secs(*SLOW_CPU_MULTIPLIER * main)
+}

--- a/tests/testsuite/support/resolver.rs
+++ b/tests/testsuite/support/resolver.rs
@@ -2,7 +2,9 @@ use std::cmp::PartialEq;
 use std::cmp::{max, min};
 use std::collections::{BTreeMap, HashSet};
 use std::fmt;
-use std::time::{Duration, Instant};
+use std::time::Instant;
+
+use crate::support::slow_cpu_multiplier;
 
 use cargo::core::dependency::Kind;
 use cargo::core::resolver::{self, Method};
@@ -117,7 +119,7 @@ pub fn resolve_with_config_raw(
 
     // The largest test in our suite takes less then 30 sec.
     // So lets fail the test if we have ben running for two long.
-    assert!(start.elapsed() < Duration::from_secs(60));
+    assert!(start.elapsed() < slow_cpu_multiplier(60));
     resolve
 }
 


### PR DESCRIPTION
This adds a "CARGO_TEST_SLOW_CPU_MULTIPLIER" that increases all the time outs used in the tests, and disables Proptest shrinking on non tty cases.

Closes: #6491
CC: #6490, @infinity0