### PR TITLE
keep track of crates that are whitelisted to be used even if yanked

### DIFF
--- a/src/cargo/core/package_id.rs
+++ b/src/cargo/core/package_id.rs
@@ -155,6 +155,14 @@ impl PackageId {
         PackageId::pure(self.inner.name, self.inner.version.clone(), source)
     }
 
+    pub fn map_source(self, to_replace: SourceId, replace_with: SourceId) -> Self {
+        if self.source_id() == to_replace {
+            self.with_source_id(replace_with)
+        } else {
+            self
+        }
+    }
+
     pub fn stable_hash(self, workspace: &Path) -> PackageIdStableHash<'_> {
         PackageIdStableHash(self, workspace)
     }

--- a/src/cargo/core/registry.rs
+++ b/src/cargo/core/registry.rs
@@ -304,9 +304,7 @@ impl<'cfg> PackageRegistry<'cfg> {
     fn load(&mut self, source_id: SourceId, kind: Kind) -> CargoResult<()> {
         (|| {
             debug!("loading source {}", source_id);
-            let source = self
-                .source_config
-                .load(source_id, self.yanked_whitelist.clone())?;
+            let source = self.source_config.load(source_id, &self.yanked_whitelist)?;
             assert_eq!(source.source_id(), source_id);
 
             if kind == Kind::Override {

--- a/src/cargo/core/registry.rs
+++ b/src/cargo/core/registry.rs
@@ -168,12 +168,15 @@ impl<'cfg> PackageRegistry<'cfg> {
         self.add_source(source, Kind::Override);
     }
 
+    pub fn add_to_yanked_whitelist(&mut self, iter: impl Iterator<Item = PackageId>) {
+        self.yanked_whitelist.extend(iter)
+    }
+
     pub fn register_lock(&mut self, id: PackageId, deps: Vec<PackageId>) {
         trace!("register_lock: {}", id);
         for dep in deps.iter() {
             trace!("\t-> {}", dep);
         }
-        self.yanked_whitelist.insert(id);
         let sub_map = self
             .locked
             .entry(id.source_id())

--- a/src/cargo/core/registry.rs
+++ b/src/cargo/core/registry.rs
@@ -168,15 +168,12 @@ impl<'cfg> PackageRegistry<'cfg> {
         self.add_source(source, Kind::Override);
     }
 
-    pub fn add_to_yanked_whitelist(&mut self, iter: impl Iterator<Item = PackageId>) {
-        self.yanked_whitelist.extend(iter)
-    }
-
     pub fn register_lock(&mut self, id: PackageId, deps: Vec<PackageId>) {
         trace!("register_lock: {}", id);
         for dep in deps.iter() {
             trace!("\t-> {}", dep);
         }
+        self.yanked_whitelist.insert(id);
         let sub_map = self
             .locked
             .entry(id.source_id())

--- a/src/cargo/core/registry.rs
+++ b/src/cargo/core/registry.rs
@@ -169,7 +169,11 @@ impl<'cfg> PackageRegistry<'cfg> {
     }
 
     pub fn add_to_yanked_whitelist(&mut self, iter: impl Iterator<Item = PackageId>) {
-        self.yanked_whitelist.extend(iter)
+        let pkgs = iter.collect::<Vec<_>>();
+        for (_, source) in self.sources.sources_mut() {
+            source.add_to_yanked_whitelist(&pkgs);
+        }
+        self.yanked_whitelist.extend(pkgs);
     }
 
     pub fn register_lock(&mut self, id: PackageId, deps: Vec<PackageId>) {

--- a/src/cargo/core/source/mod.rs
+++ b/src/cargo/core/source/mod.rs
@@ -83,6 +83,11 @@ pub trait Source {
     fn is_replaced(&self) -> bool {
         false
     }
+
+    /// Add a number of crates that should be whitelisted for showing up during
+    /// queries, even if they are yanked. Currently only applies to registry
+    /// sources.
+    fn add_to_yanked_whitelist(&mut self, pkgs: &[PackageId]);
 }
 
 pub enum MaybePackage {
@@ -152,6 +157,10 @@ impl<'a, T: Source + ?Sized + 'a> Source for Box<T> {
     fn is_replaced(&self) -> bool {
         (**self).is_replaced()
     }
+
+    fn add_to_yanked_whitelist(&mut self, pkgs: &[PackageId]) {
+        (**self).add_to_yanked_whitelist(pkgs);
+    }
 }
 
 impl<'a, T: Source + ?Sized + 'a> Source for &'a mut T {
@@ -205,6 +214,10 @@ impl<'a, T: Source + ?Sized + 'a> Source for &'a mut T {
 
     fn is_replaced(&self) -> bool {
         (**self).is_replaced()
+    }
+
+    fn add_to_yanked_whitelist(&mut self, pkgs: &[PackageId]) {
+        (**self).add_to_yanked_whitelist(pkgs);
     }
 }
 

--- a/src/cargo/core/source/source_id.rs
+++ b/src/cargo/core/source/source_id.rs
@@ -261,7 +261,7 @@ impl SourceId {
     pub fn load<'a>(
         self,
         config: &'a Config,
-        yanked_whitelist: HashSet<PackageId>,
+        yanked_whitelist: &HashSet<PackageId>,
     ) -> CargoResult<Box<dyn super::Source + 'a>> {
         trace!("loading SourceId; {}", self);
         match self.inner.kind {

--- a/src/cargo/ops/cargo_install.rs
+++ b/src/cargo/ops/cargo_install.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::{env, fs};
@@ -181,7 +181,7 @@ fn install_one(
         })?
     } else {
         select_pkg(
-            map.load(source_id)?,
+            map.load(source_id, HashSet::new())?,
             krate,
             vers,
             config,

--- a/src/cargo/ops/cargo_install.rs
+++ b/src/cargo/ops/cargo_install.rs
@@ -181,7 +181,7 @@ fn install_one(
         })?
     } else {
         select_pkg(
-            map.load(source_id, HashSet::new())?,
+            map.load(source_id, &HashSet::new())?,
             krate,
             vers,
             config,

--- a/src/cargo/ops/registry.rs
+++ b/src/cargo/ops/registry.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 use std::fs::{self, File};
 use std::io::{self, BufRead};
 use std::iter::repeat;
@@ -350,7 +350,7 @@ pub fn registry(
     let token = token.or(token_config);
     let sid = get_source_id(config, index_config.or(index), registry)?;
     let api_host = {
-        let mut src = RegistrySource::remote(sid, config);
+        let mut src = RegistrySource::remote(sid, HashSet::new(), config);
         // Only update the index if the config is not available or `force` is set.
         let cfg = src.config();
         let cfg = if force_update || cfg.is_err() {
@@ -696,7 +696,7 @@ fn get_source_id(
         (_, Some(i)) => SourceId::for_registry(&i.to_url()?),
         _ => {
             let map = SourceConfigMap::new(config)?;
-            let src = map.load(SourceId::crates_io(config)?)?;
+            let src = map.load(SourceId::crates_io(config)?, HashSet::new())?;
             Ok(src.replaced_source_id())
         }
     }

--- a/src/cargo/ops/registry.rs
+++ b/src/cargo/ops/registry.rs
@@ -350,7 +350,7 @@ pub fn registry(
     let token = token.or(token_config);
     let sid = get_source_id(config, index_config.or(index), registry)?;
     let api_host = {
-        let mut src = RegistrySource::remote(sid, HashSet::new(), config);
+        let mut src = RegistrySource::remote(sid, &HashSet::new(), config);
         // Only update the index if the config is not available or `force` is set.
         let cfg = src.config();
         let cfg = if force_update || cfg.is_err() {
@@ -696,7 +696,7 @@ fn get_source_id(
         (_, Some(i)) => SourceId::for_registry(&i.to_url()?),
         _ => {
             let map = SourceConfigMap::new(config)?;
-            let src = map.load(SourceId::crates_io(config)?, HashSet::new())?;
+            let src = map.load(SourceId::crates_io(config)?, &HashSet::new())?;
             Ok(src.replaced_source_id())
         }
     }

--- a/src/cargo/ops/resolve.rs
+++ b/src/cargo/ops/resolve.rs
@@ -471,7 +471,7 @@ fn register_previous_locks(
     // package's dependencies here as that'll be covered below to poison those
     // if they changed.
     let mut avoid_locking = HashSet::new();
-    registry.add_to_yanked_whitelist(resolve.iter());
+    registry.add_to_yanked_whitelist(resolve.iter().filter(keep));
     for node in resolve.iter() {
         if !keep(&node) {
             add_deps(resolve, node, &mut avoid_locking);

--- a/src/cargo/ops/resolve.rs
+++ b/src/cargo/ops/resolve.rs
@@ -471,6 +471,7 @@ fn register_previous_locks(
     // package's dependencies here as that'll be covered below to poison those
     // if they changed.
     let mut avoid_locking = HashSet::new();
+    registry.add_to_yanked_whitelist(resolve.iter());
     for node in resolve.iter() {
         if !keep(&node) {
             add_deps(resolve, node, &mut avoid_locking);

--- a/src/cargo/ops/resolve.rs
+++ b/src/cargo/ops/resolve.rs
@@ -471,7 +471,6 @@ fn register_previous_locks(
     // package's dependencies here as that'll be covered below to poison those
     // if they changed.
     let mut avoid_locking = HashSet::new();
-    registry.add_to_yanked_whitelist(resolve.iter());
     for node in resolve.iter() {
         if !keep(&node) {
             add_deps(resolve, node, &mut avoid_locking);

--- a/src/cargo/sources/config.rs
+++ b/src/cargo/sources/config.rs
@@ -4,13 +4,13 @@
 //! structure usable by Cargo itself. Currently this is primarily used to map
 //! sources to one another via the `replace-with` key in `.cargo/config`.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
 use log::debug;
 use url::Url;
 
-use crate::core::{GitReference, Source, SourceId};
+use crate::core::{GitReference, PackageId, Source, SourceId};
 use crate::sources::{ReplacedSource, CRATES_IO_REGISTRY};
 use crate::util::config::ConfigValue;
 use crate::util::errors::{CargoResult, CargoResultExt};
@@ -73,11 +73,15 @@ impl<'cfg> SourceConfigMap<'cfg> {
         self.config
     }
 
-    pub fn load(&self, id: SourceId) -> CargoResult<Box<dyn Source + 'cfg>> {
+    pub fn load(
+        &self,
+        id: SourceId,
+        yanked_whitelist: HashSet<PackageId>,
+    ) -> CargoResult<Box<dyn Source + 'cfg>> {
         debug!("loading: {}", id);
         let mut name = match self.id2name.get(&id) {
             Some(name) => name,
-            None => return Ok(id.load(self.config)?),
+            None => return Ok(id.load(self.config, yanked_whitelist)?),
         };
         let mut path = Path::new("/");
         let orig_name = name;
@@ -99,7 +103,7 @@ impl<'cfg> SourceConfigMap<'cfg> {
                     name = s;
                     path = p;
                 }
-                None if id == cfg.id => return Ok(id.load(self.config)?),
+                None if id == cfg.id => return Ok(id.load(self.config, yanked_whitelist)?),
                 None => {
                     new_id = cfg.id.with_precise(id.precise().map(|s| s.to_string()));
                     break;
@@ -116,8 +120,8 @@ impl<'cfg> SourceConfigMap<'cfg> {
                 )
             }
         }
-        let new_src = new_id.load(self.config)?;
-        let old_src = id.load(self.config)?;
+        let new_src = new_id.load(self.config, yanked_whitelist.clone())?;
+        let old_src = id.load(self.config, yanked_whitelist.clone())?;
         if !new_src.supports_checksums() && old_src.supports_checksums() {
             failure::bail!(
                 "\

--- a/src/cargo/sources/config.rs
+++ b/src/cargo/sources/config.rs
@@ -76,7 +76,7 @@ impl<'cfg> SourceConfigMap<'cfg> {
     pub fn load(
         &self,
         id: SourceId,
-        yanked_whitelist: HashSet<PackageId>,
+        yanked_whitelist: &HashSet<PackageId>,
     ) -> CargoResult<Box<dyn Source + 'cfg>> {
         debug!("loading: {}", id);
         let mut name = match self.id2name.get(&id) {
@@ -120,8 +120,8 @@ impl<'cfg> SourceConfigMap<'cfg> {
                 )
             }
         }
-        let new_src = new_id.load(self.config, yanked_whitelist.clone())?;
-        let old_src = id.load(self.config, yanked_whitelist.clone())?;
+        let new_src = new_id.load(self.config, yanked_whitelist)?;
+        let old_src = id.load(self.config, yanked_whitelist)?;
         if !new_src.supports_checksums() && old_src.supports_checksums() {
             failure::bail!(
                 "\

--- a/src/cargo/sources/config.rs
+++ b/src/cargo/sources/config.rs
@@ -120,7 +120,14 @@ impl<'cfg> SourceConfigMap<'cfg> {
                 )
             }
         }
-        let new_src = new_id.load(self.config, yanked_whitelist)?;
+
+        let new_src = new_id.load(
+            self.config,
+            &yanked_whitelist
+                .iter()
+                .map(|p| p.map_source(id, new_id))
+                .collect(),
+        )?;
         let old_src = id.load(self.config, yanked_whitelist)?;
         if !new_src.supports_checksums() && old_src.supports_checksums() {
             failure::bail!(

--- a/src/cargo/sources/directory.rs
+++ b/src/cargo/sources/directory.rs
@@ -214,4 +214,6 @@ impl<'cfg> Source for DirectorySource<'cfg> {
     fn describe(&self) -> String {
         format!("directory source `{}`", self.root.display())
     }
+
+    fn add_to_yanked_whitelist(&mut self, _pkgs: &[PackageId]) {}
 }

--- a/src/cargo/sources/git/source.rs
+++ b/src/cargo/sources/git/source.rs
@@ -238,6 +238,8 @@ impl<'cfg> Source for GitSource<'cfg> {
     fn describe(&self) -> String {
         format!("git repository {}", self.source_id)
     }
+
+    fn add_to_yanked_whitelist(&mut self, _pkgs: &[PackageId]) {}
 }
 
 #[cfg(test)]

--- a/src/cargo/sources/path.rs
+++ b/src/cargo/sources/path.rs
@@ -569,4 +569,6 @@ impl<'cfg> Source for PathSource<'cfg> {
             Err(_) => self.source_id.to_string(),
         }
     }
+
+    fn add_to_yanked_whitelist(&mut self, _pkgs: &[PackageId]) {}
 }

--- a/src/cargo/sources/registry/index.rs
+++ b/src/cargo/sources/registry/index.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::Path;
 use std::str;
 
@@ -273,6 +273,7 @@ impl<'cfg> RegistryIndex<'cfg> {
         &mut self,
         dep: &Dependency,
         load: &mut dyn RegistryData,
+        yanked_whitelist: &HashSet<PackageId>,
         f: &mut dyn FnMut(Summary),
     ) -> CargoResult<()> {
         let source_id = self.source_id;
@@ -280,7 +281,9 @@ impl<'cfg> RegistryIndex<'cfg> {
         let summaries = self.summaries(name, load)?;
         let summaries = summaries
             .iter()
-            .filter(|&&(_, yanked)| dep.source_id().precise().is_some() || !yanked)
+            .filter(|&(summary, yanked)| {
+                !yanked || yanked_whitelist.contains(&summary.package_id())
+            })
             .map(|s| s.0.clone());
 
         // Handle `cargo update --precise` here. If specified, our own source

--- a/src/cargo/sources/registry/index.rs
+++ b/src/cargo/sources/registry/index.rs
@@ -282,7 +282,11 @@ impl<'cfg> RegistryIndex<'cfg> {
         let summaries = summaries
             .iter()
             .filter(|&(summary, yanked)| {
-                !yanked || yanked_whitelist.contains(&summary.package_id())
+                !yanked || {
+                    log::debug!("{:?}", yanked_whitelist);
+                    log::debug!("{:?}", summary.package_id());
+                    yanked_whitelist.contains(&summary.package_id())
+                }
             })
             .map(|s| s.0.clone());
 

--- a/src/cargo/sources/registry/mod.rs
+++ b/src/cargo/sources/registry/mod.rs
@@ -389,7 +389,7 @@ fn short_name(id: SourceId) -> String {
 impl<'cfg> RegistrySource<'cfg> {
     pub fn remote(
         source_id: SourceId,
-        yanked_whitelist: HashSet<PackageId>,
+        yanked_whitelist: &HashSet<PackageId>,
         config: &'cfg Config,
     ) -> RegistrySource<'cfg> {
         let name = short_name(source_id);
@@ -412,7 +412,7 @@ impl<'cfg> RegistrySource<'cfg> {
             config,
             &name,
             Box::new(ops),
-            HashSet::new(),
+            &HashSet::new(),
             false,
         )
     }
@@ -422,7 +422,7 @@ impl<'cfg> RegistrySource<'cfg> {
         config: &'cfg Config,
         name: &str,
         ops: Box<dyn RegistryData + 'cfg>,
-        yanked_whitelist: HashSet<PackageId>,
+        yanked_whitelist: &HashSet<PackageId>,
         index_locked: bool,
     ) -> RegistrySource<'cfg> {
         RegistrySource {
@@ -431,7 +431,7 @@ impl<'cfg> RegistrySource<'cfg> {
             source_id,
             updated: false,
             index: index::RegistryIndex::new(source_id, ops.index_path(), config, index_locked),
-            yanked_whitelist,
+            yanked_whitelist: yanked_whitelist.clone(),
             index_locked,
             ops,
         }

--- a/src/cargo/sources/registry/mod.rs
+++ b/src/cargo/sources/registry/mod.rs
@@ -160,6 +160,7 @@
 
 use std::borrow::Cow;
 use std::collections::BTreeMap;
+use std::collections::HashSet;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 
@@ -192,6 +193,7 @@ pub struct RegistrySource<'cfg> {
     updated: bool,
     ops: Box<dyn RegistryData + 'cfg>,
     index: index::RegistryIndex<'cfg>,
+    yanked_whitelist: HashSet<PackageId>,
     index_locked: bool,
 }
 
@@ -385,16 +387,34 @@ fn short_name(id: SourceId) -> String {
 }
 
 impl<'cfg> RegistrySource<'cfg> {
-    pub fn remote(source_id: SourceId, config: &'cfg Config) -> RegistrySource<'cfg> {
+    pub fn remote(
+        source_id: SourceId,
+        yanked_whitelist: HashSet<PackageId>,
+        config: &'cfg Config,
+    ) -> RegistrySource<'cfg> {
         let name = short_name(source_id);
         let ops = remote::RemoteRegistry::new(source_id, config, &name);
-        RegistrySource::new(source_id, config, &name, Box::new(ops), true)
+        RegistrySource::new(
+            source_id,
+            config,
+            &name,
+            Box::new(ops),
+            yanked_whitelist,
+            true,
+        )
     }
 
     pub fn local(source_id: SourceId, path: &Path, config: &'cfg Config) -> RegistrySource<'cfg> {
         let name = short_name(source_id);
         let ops = local::LocalRegistry::new(path, config, &name);
-        RegistrySource::new(source_id, config, &name, Box::new(ops), false)
+        RegistrySource::new(
+            source_id,
+            config,
+            &name,
+            Box::new(ops),
+            HashSet::new(),
+            false,
+        )
     }
 
     fn new(
@@ -402,6 +422,7 @@ impl<'cfg> RegistrySource<'cfg> {
         config: &'cfg Config,
         name: &str,
         ops: Box<dyn RegistryData + 'cfg>,
+        yanked_whitelist: HashSet<PackageId>,
         index_locked: bool,
     ) -> RegistrySource<'cfg> {
         RegistrySource {
@@ -410,6 +431,7 @@ impl<'cfg> RegistrySource<'cfg> {
             source_id,
             updated: false,
             index: index::RegistryIndex::new(source_id, ops.index_path(), config, index_locked),
+            yanked_whitelist,
             index_locked,
             ops,
         }
@@ -431,9 +453,7 @@ impl<'cfg> RegistrySource<'cfg> {
         // unpacked and to lock the directory for unpacking.
         let mut ok = {
             let package_dir = format!("{}-{}", pkg.name(), pkg.version());
-            let dst = self
-                .src_path
-                .join(&package_dir);
+            let dst = self.src_path.join(&package_dir);
             dst.create_dir()?;
 
             // Attempt to open a read-only copy first to avoid an exclusive write
@@ -526,12 +546,13 @@ impl<'cfg> Source for RegistrySource<'cfg> {
         if dep.source_id().precise().is_some() && !self.updated {
             debug!("attempting query without update");
             let mut called = false;
-            self.index.query_inner(dep, &mut *self.ops, &mut |s| {
-                if dep.matches(&s) {
-                    called = true;
-                    f(s);
-                }
-            })?;
+            self.index
+                .query_inner(dep, &mut *self.ops, &self.yanked_whitelist, &mut |s| {
+                    if dep.matches(&s) {
+                        called = true;
+                        f(s);
+                    }
+                })?;
             if called {
                 return Ok(());
             } else {
@@ -540,15 +561,17 @@ impl<'cfg> Source for RegistrySource<'cfg> {
             }
         }
 
-        self.index.query_inner(dep, &mut *self.ops, &mut |s| {
-            if dep.matches(&s) {
-                f(s);
-            }
-        })
+        self.index
+            .query_inner(dep, &mut *self.ops, &self.yanked_whitelist, &mut |s| {
+                if dep.matches(&s) {
+                    f(s);
+                }
+            })
     }
 
     fn fuzzy_query(&mut self, dep: &Dependency, f: &mut dyn FnMut(Summary)) -> CargoResult<()> {
-        self.index.query_inner(dep, &mut *self.ops, f)
+        self.index
+            .query_inner(dep, &mut *self.ops, &self.yanked_whitelist, f)
     }
 
     fn supports_checksums(&self) -> bool {

--- a/src/cargo/sources/registry/mod.rs
+++ b/src/cargo/sources/registry/mod.rs
@@ -625,4 +625,8 @@ impl<'cfg> Source for RegistrySource<'cfg> {
     fn describe(&self) -> String {
         self.source_id.display_registry()
     }
+
+    fn add_to_yanked_whitelist(&mut self, pkgs: &[PackageId]) {
+        self.yanked_whitelist.extend(pkgs);
+    }
 }

--- a/src/cargo/sources/replaced.rs
+++ b/src/cargo/sources/replaced.rs
@@ -113,4 +113,10 @@ impl<'cfg> Source for ReplacedSource<'cfg> {
     fn is_replaced(&self) -> bool {
         true
     }
+
+    fn add_to_yanked_whitelist(&mut self, pkgs: &[PackageId]) {
+        let pkgs = pkgs.iter().map(|id| id.with_source_id(self.replace_with))
+            .collect::<Vec<_>>();
+        self.inner.add_to_yanked_whitelist(&pkgs);
+    }
 }

--- a/tests/testsuite/registry.rs
+++ b/tests/testsuite/registry.rs
@@ -635,7 +635,7 @@ required by package `foo v0.0.1 ([..])`
         .run();
 
     p.cargo("update -p baz")
-        .with_status(101)
+        .with_status(0)
         .with_stderr_contains(
             "\
 [UPDATING] `[..]` index

--- a/tests/testsuite/registry.rs
+++ b/tests/testsuite/registry.rs
@@ -591,6 +591,104 @@ required by package `foo v0.0.1 ([..])`
 }
 
 #[test]
+fn yanks_in_lockfiles_are_ok_for_other_update() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [project]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+
+            [dependencies]
+            bar = "*"
+            baz = "*"
+        "#,
+        )
+        .file("src/main.rs", "fn main() {}")
+        .build();
+
+    Package::new("bar", "0.0.1").publish();
+    Package::new("baz", "0.0.1").publish();
+
+    p.cargo("build").run();
+
+    registry_path().join("3").rm_rf();
+
+    Package::new("bar", "0.0.1").yanked(true).publish();
+    Package::new("baz", "0.0.1").publish();
+
+    p.cargo("build").with_stdout("").run();
+
+    Package::new("baz", "0.0.2").publish();
+
+    p.cargo("update")
+        .with_status(101)
+        .with_stderr_contains(
+            "\
+error: no matching package named `bar` found
+location searched: registry [..]
+required by package `foo v0.0.1 ([..])`
+",
+        )
+        .run();
+
+    p.cargo("update -p baz")
+        .with_status(101)
+        .with_stderr_contains(
+            "\
+[UPDATING] `[..]` index
+[UPDATING] baz v0.0.1 -> v0.0.2
+",
+        )
+        .run();
+}
+
+#[test]
+fn yanks_in_lockfiles_are_ok_with_new_dep() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [project]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+
+            [dependencies]
+            bar = "*"
+        "#,
+        )
+        .file("src/main.rs", "fn main() {}")
+        .build();
+
+    Package::new("bar", "0.0.1").publish();
+
+    p.cargo("build").run();
+
+    registry_path().join("3").rm_rf();
+
+    Package::new("bar", "0.0.1").yanked(true).publish();
+    Package::new("baz", "0.0.1").publish();
+
+    t!(t!(File::create(p.root().join("Cargo.toml"))).write_all(
+        br#"
+            [project]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+
+            [dependencies]
+            bar = "*"
+            baz = "*"
+    "#
+    ));
+
+    p.cargo("build").with_stdout("").run();
+}
+
+#[test]
 fn update_with_lockfile_if_packages_missing() {
     let p = project()
         .file(

--- a/tests/testsuite/search.rs
+++ b/tests/testsuite/search.rs
@@ -108,7 +108,7 @@ fn not_update() {
 
     let sid = SourceId::for_registry(&registry_url()).unwrap();
     let cfg = Config::new(Shell::new(), paths::root(), paths::home().join(".cargo"));
-    let mut regsrc = RegistrySource::remote(sid, HashSet::new(), &cfg);
+    let mut regsrc = RegistrySource::remote(sid, &HashSet::new(), &cfg);
     regsrc.update().unwrap();
 
     cargo_process("search postgres")

--- a/tests/testsuite/search.rs
+++ b/tests/testsuite/search.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::fs::{self, File};
 use std::io::prelude::*;
 use std::path::Path;
@@ -107,7 +108,7 @@ fn not_update() {
 
     let sid = SourceId::for_registry(&registry_url()).unwrap();
     let cfg = Config::new(Shell::new(), paths::root(), paths::home().join(".cargo"));
-    let mut regsrc = RegistrySource::remote(sid, &cfg);
+    let mut regsrc = RegistrySource::remote(sid, HashSet::new(), &cfg);
     regsrc.update().unwrap();
 
     cargo_process("search postgres")


### PR DESCRIPTION
This is a start on #6609. It definitely needs tests that the bug is fixed, and to reduce the clones. But for now let's see what CI thinks.