### PR TITLE
Fix overlapping progress with stdout.

### DIFF
--- a/src/cargo/core/compiler/job_queue.rs
+++ b/src/cargo/core/compiler/job_queue.rs
@@ -300,6 +300,7 @@ impl<'a, 'cfg> JobQueue<'a, 'cfg> {
                         plan.update(&module_name, &cmd, &filenames)?;
                     }
                     Message::Stdout(out) => {
+                        self.progress.clear();
                         println!("{}", out);
                     }
                     Message::Stderr(err) => {


### PR DESCRIPTION
Minor issue introduced in #6615. The progress bar was not being cleared for stdout output (because Shell only does stderr).
