### PR TITLE
Fix default DYLD_FALLBACK_LIBRARY_PATH on MacOS.

### DIFF
--- a/src/cargo/core/compiler/compilation.rs
+++ b/src/cargo/core/compiler/compilation.rs
@@ -196,6 +196,17 @@ impl<'cfg> Compilation<'cfg> {
         };
 
         search_path.extend(util::dylib_path().into_iter());
+        if cfg!(target_os = "macos") {
+            // These are the defaults when DYLD_FALLBACK_LIBRARY_PATH isn't
+            // set. Since Cargo is explicitly setting the value, make sure the
+            // defaults still work.
+            if let Ok(home) = env::var("HOME") {
+                search_path.push(PathBuf::from(home).join("lib"));
+            }
+            search_path.push(PathBuf::from("/usr/local/lib"));
+            search_path.push(PathBuf::from("/lib"));
+            search_path.push(PathBuf::from("/usr/lib"));
+        }
         let search_path = join_paths(&search_path, util::dylib_path_envvar())?;
 
         cmd.env(util::dylib_path_envvar(), &search_path);

--- a/src/cargo/util/paths.rs
+++ b/src/cargo/util/paths.rs
@@ -45,6 +45,10 @@ pub fn dylib_path_envvar() -> &'static str {
         // find the library in the install path.
         // Setting DYLD_LIBRARY_PATH can easily have unintended
         // consequences.
+        //
+        // Also, DYLD_LIBRARY_PATH appears to have significant performance
+        // penalty starting in 10.13. Cargo's testsuite ran more than twice as
+        // slow with it on CI.
         "DYLD_FALLBACK_LIBRARY_PATH"
     } else {
         "LD_LIBRARY_PATH"


### PR DESCRIPTION
On MacOS, dyld uses the default `$(HOME)/lib:/usr/local/lib:/lib:/usr/lib` for `DYLD_FALLBACK_LIBRARY_PATH` when it is not set.  #6355 switched cargo to use `DYLD_FALLBACK_LIBRARY_PATH`, which means the default paths no longer worked. This explicitly adds the defaults back to the end of the list.

Fixes #6623
