### PR TITLE
[BETA] backports to appease CI

### DIFF
--- a/src/cargo/core/source/source_id.rs
+++ b/src/cargo/core/source/source_id.rs
@@ -5,7 +5,7 @@ use std::hash::{self, Hash};
 use std::path::Path;
 use std::ptr;
 use std::sync::atomic::Ordering::SeqCst;
-use std::sync::atomic::{AtomicBool, ATOMIC_BOOL_INIT};
+use std::sync::atomic::AtomicBool;
 use std::sync::Mutex;
 
 use log::trace;
@@ -193,7 +193,7 @@ impl SourceId {
         config.crates_io_source_id(|| {
             let cfg = ops::registry_configuration(config, None)?;
             let url = if let Some(ref index) = cfg.index {
-                static WARNED: AtomicBool = ATOMIC_BOOL_INIT;
+                static WARNED: AtomicBool = AtomicBool::new(false);
                 if !WARNED.swap(true, SeqCst) {
                     config.shell().warn(
                         "custom registry support via \

--- a/tests/testsuite/doc.rs
+++ b/tests/testsuite/doc.rs
@@ -679,8 +679,8 @@ fn output_not_captured() {
 
     p.cargo("doc")
         .without_status()
-        .with_stderr_contains("1 | ☃")
-        .with_stderr_contains(r"error: unknown start of token: \u{2603}")
+        .with_stderr_contains("[..]☃")
+        .with_stderr_contains(r"[..]unknown start of token: \u{2603}")
         .run();
 }
 

--- a/tests/testsuite/support/cross_compile.rs
+++ b/tests/testsuite/support/cross_compile.rs
@@ -1,6 +1,6 @@
 use std::env;
 use std::process::Command;
-use std::sync::atomic::{AtomicBool, Ordering, ATOMIC_BOOL_INIT};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Once, ONCE_INIT};
 
 use crate::support::{basic_bin_manifest, main_file, project};
@@ -22,7 +22,7 @@ pub fn disabled() -> bool {
     // It's not particularly common to have a cross-compilation setup, so
     // try to detect that before we fail a bunch of tests through no fault
     // of the user.
-    static CAN_RUN_CROSS_TESTS: AtomicBool = ATOMIC_BOOL_INIT;
+    static CAN_RUN_CROSS_TESTS: AtomicBool = AtomicBool::new(false);
     static CHECK: Once = ONCE_INIT;
 
     let cross_target = alternate();
@@ -56,7 +56,7 @@ pub fn disabled() -> bool {
     // pass.  We don't use std::sync::Once here because panicing inside its
     // call_once method would poison the Once instance, which is not what
     // we want.
-    static HAVE_WARNED: AtomicBool = ATOMIC_BOOL_INIT;
+    static HAVE_WARNED: AtomicBool = AtomicBool::new(false);
 
     if HAVE_WARNED.swap(true, Ordering::SeqCst) {
         // We are some other test and somebody else is handling the warning.

--- a/tests/testsuite/support/paths.rs
+++ b/tests/testsuite/support/paths.rs
@@ -3,13 +3,13 @@ use std::env;
 use std::fs;
 use std::io::{self, ErrorKind};
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicUsize, Ordering, ATOMIC_USIZE_INIT};
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Once, ONCE_INIT};
 
 use filetime::{self, FileTime};
 
 static CARGO_INTEGRATION_TEST_DIR: &'static str = "cit";
-static NEXT_ID: AtomicUsize = ATOMIC_USIZE_INIT;
+static NEXT_ID: AtomicUsize = AtomicUsize::new(0);
 
 thread_local!(static TASK_ID: usize = NEXT_ID.fetch_add(1, Ordering::SeqCst));
 


### PR DESCRIPTION
- #6559 — relax rustdoc output assertion
- #6600 — Remove deprecated ATOMIC initializers.

Required to get the rust-1.33.0 branch passing again.