### PR TITLE
Ignore incremental when lto is set.

### DIFF
--- a/src/cargo/core/compiler/build_context/mod.rs
+++ b/src/cargo/core/compiler/build_context/mod.rs
@@ -38,7 +38,6 @@ pub struct BuildContext<'a, 'cfg: 'a> {
     pub target_config: TargetConfig,
     pub target_info: TargetInfo,
     pub host_info: TargetInfo,
-    pub incremental_env: Option<bool>,
 }
 
 impl<'a, 'cfg> BuildContext<'a, 'cfg> {
@@ -51,11 +50,6 @@ impl<'a, 'cfg> BuildContext<'a, 'cfg> {
         profiles: &'a Profiles,
         extra_compiler_args: HashMap<Unit<'a>, Vec<String>>,
     ) -> CargoResult<BuildContext<'a, 'cfg>> {
-        let incremental_env = match env::var("CARGO_INCREMENTAL") {
-            Ok(v) => Some(v == "1"),
-            Err(_) => None,
-        };
-
         let rustc = config.rustc(Some(ws))?;
         let host_config = TargetConfig::new(config, &rustc.host)?;
         let target_config = match build_config.requested_target.as_ref() {
@@ -84,7 +78,6 @@ impl<'a, 'cfg> BuildContext<'a, 'cfg> {
             host_info,
             build_config,
             profiles,
-            incremental_env,
             extra_compiler_args,
         })
     }

--- a/src/cargo/core/compiler/fingerprint.rs
+++ b/src/cargo/core/compiler/fingerprint.rs
@@ -492,12 +492,7 @@ fn calculate<'a, 'cfg>(
     } else {
         bcx.rustflags_args(unit)?
     };
-    let profile_hash = util::hash_u64(&(
-        &unit.profile,
-        unit.mode,
-        bcx.extra_args_for(unit),
-        cx.incremental_args(unit)?,
-    ));
+    let profile_hash = util::hash_u64(&(&unit.profile, unit.mode, bcx.extra_args_for(unit)));
     let fingerprint = Arc::new(Fingerprint {
         rustc: util::hash_u64(&bcx.rustc.verbose_version),
         target: util::hash_u64(&unit.target),

--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -763,6 +763,7 @@ fn build_base_args<'a, 'cfg>(
         overflow_checks,
         rpath,
         ref panic,
+        incremental,
         ..
     } = unit.profile;
     let test = unit.mode.is_any_test();
@@ -905,8 +906,10 @@ fn build_base_args<'a, 'cfg>(
         "linker=",
         bcx.linker(unit.kind).map(|s| s.as_ref()),
     );
-    cmd.args(&cx.incremental_args(unit)?);
-
+    if incremental {
+        let dir = cx.files().layout(unit.kind).incremental().as_os_str();
+        opt(cmd, "-C", "incremental=", Some(dir));
+    }
     Ok(())
 }
 

--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -66,6 +66,7 @@ pub struct VirtualManifest {
     workspace: WorkspaceConfig,
     profiles: Profiles,
     warnings: Warnings,
+    features: Features,
 }
 
 /// General metadata about a package which is just blindly uploaded to the
@@ -539,6 +540,7 @@ impl VirtualManifest {
         patch: HashMap<Url, Vec<Dependency>>,
         workspace: WorkspaceConfig,
         profiles: Profiles,
+        features: Features,
     ) -> VirtualManifest {
         VirtualManifest {
             replace,
@@ -546,6 +548,7 @@ impl VirtualManifest {
             workspace,
             profiles,
             warnings: Warnings::new(),
+            features,
         }
     }
 
@@ -571,6 +574,10 @@ impl VirtualManifest {
 
     pub fn warnings(&self) -> &Warnings {
         &self.warnings
+    }
+
+    pub fn features(&self) -> &Features {
+        &self.features
     }
 }
 

--- a/src/cargo/core/profiles.rs
+++ b/src/cargo/core/profiles.rs
@@ -1,5 +1,5 @@
 use std::collections::HashSet;
-use std::{cmp, fmt, hash};
+use std::{cmp, env, fmt, hash};
 
 use serde::Deserialize;
 
@@ -19,6 +19,10 @@ pub struct Profiles {
     test: ProfileMaker,
     bench: ProfileMaker,
     doc: ProfileMaker,
+    /// Incremental compilation can be overridden globally via:
+    /// - `CARGO_INCREMENTAL` environment variable.
+    /// - `build.incremental` config value.
+    incremental: Option<bool>,
 }
 
 impl Profiles {
@@ -33,7 +37,11 @@ impl Profiles {
         }
 
         let config_profiles = config.profiles()?;
-        config_profiles.validate(features, warnings)?;
+
+        let incremental = match env::var_os("CARGO_INCREMENTAL") {
+            Some(v) => Some(v == "1"),
+            None => config.get::<Option<bool>>("build.incremental")?,
+        };
 
         Ok(Profiles {
             dev: ProfileMaker {
@@ -61,6 +69,7 @@ impl Profiles {
                 toml: profiles.and_then(|p| p.doc.clone()),
                 config: None,
             },
+            incremental,
         })
     }
 
@@ -100,10 +109,29 @@ impl Profiles {
             CompileMode::Doc { .. } => &self.doc,
         };
         let mut profile = maker.get_profile(Some(pkg_id), is_member, unit_for);
+
         // `panic` should not be set for tests/benches, or any of their
         // dependencies.
         if !unit_for.is_panic_ok() || mode.is_any_test() {
             profile.panic = None;
+        }
+
+        // Incremental can be globally overridden.
+        if let Some(v) = self.incremental {
+            profile.incremental = v;
+        }
+        // Incremental is incompatible with LTO.
+        if profile.lto != Lto::Bool(false) {
+            profile.incremental = false;
+        }
+        // Only enable incremental compilation for sources the user can
+        // modify (aka path sources). For things that change infrequently,
+        // non-incremental builds yield better performance in the compiler
+        // itself (aka crates.io / git dependencies)
+        //
+        // (see also https://github.com/rust-lang/cargo/issues/3972)
+        if !pkg_id.source_id().is_path() {
+            profile.incremental = false;
         }
         profile
     }

--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -237,13 +237,9 @@ impl<'cfg> Workspace<'cfg> {
     }
 
     pub fn profiles(&self) -> &Profiles {
-        let root = self
-            .root_manifest
-            .as_ref()
-            .unwrap_or(&self.current_manifest);
-        match *self.packages.get(root) {
-            MaybePackage::Package(ref p) => p.manifest().profiles(),
-            MaybePackage::Virtual(ref vm) => vm.profiles(),
+        match self.root_maybe() {
+            MaybePackage::Package(p) => p.manifest().profiles(),
+            MaybePackage::Virtual(vm) => vm.profiles(),
         }
     }
 
@@ -260,6 +256,15 @@ impl<'cfg> Workspace<'cfg> {
         .unwrap()
     }
 
+    /// Return the root Package or VirtualManifest.
+    fn root_maybe(&self) -> &MaybePackage {
+        let root = self
+            .root_manifest
+            .as_ref()
+            .unwrap_or(&self.current_manifest);
+        self.packages.get(root)
+    }
+
     pub fn target_dir(&self) -> Filesystem {
         self.target_dir
             .clone()
@@ -270,13 +275,9 @@ impl<'cfg> Workspace<'cfg> {
     ///
     /// This may be from a virtual crate or an actual crate.
     pub fn root_replace(&self) -> &[(PackageIdSpec, Dependency)] {
-        let path = match self.root_manifest {
-            Some(ref p) => p,
-            None => &self.current_manifest,
-        };
-        match *self.packages.get(path) {
-            MaybePackage::Package(ref p) => p.manifest().replace(),
-            MaybePackage::Virtual(ref vm) => vm.replace(),
+        match self.root_maybe() {
+            MaybePackage::Package(p) => p.manifest().replace(),
+            MaybePackage::Virtual(vm) => vm.replace(),
         }
     }
 
@@ -284,13 +285,9 @@ impl<'cfg> Workspace<'cfg> {
     ///
     /// This may be from a virtual crate or an actual crate.
     pub fn root_patch(&self) -> &HashMap<Url, Vec<Dependency>> {
-        let path = match self.root_manifest {
-            Some(ref p) => p,
-            None => &self.current_manifest,
-        };
-        match *self.packages.get(path) {
-            MaybePackage::Package(ref p) => p.manifest().patch(),
-            MaybePackage::Virtual(ref vm) => vm.patch(),
+        match self.root_maybe() {
+            MaybePackage::Package(p) => p.manifest().patch(),
+            MaybePackage::Virtual(vm) => vm.patch(),
         }
     }
 
@@ -524,6 +521,18 @@ impl<'cfg> Workspace<'cfg> {
     /// 2. All workspace members agree on this one root as the root.
     /// 3. The current crate is a member of this workspace.
     fn validate(&mut self) -> CargoResult<()> {
+        // Validate config profiles only once per workspace.
+        let features = match self.root_maybe() {
+            MaybePackage::Package(p) => p.manifest().features(),
+            MaybePackage::Virtual(vm) => vm.features(),
+        };
+        let mut warnings = Vec::new();
+        self.config.profiles()?.validate(features, &mut warnings)?;
+        for warning in warnings {
+            self.config.shell().warn(&warning)?;
+        }
+
+        // The rest of the checks require a VirtualManifest or multiple members.
         if self.root_manifest.is_none() {
             return Ok(());
         }

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -473,6 +473,16 @@ impl TomlProfile {
             }
             _ => {}
         }
+
+        if self.incremental == Some(true)
+            && self.lto != None
+            && self.lto != Some(StringOrBool::Bool(false))
+        {
+            warnings.push(format!(
+                "`incremental` setting is ignored for the `{}` profile when `lto` is enabled",
+                name
+            ));
+        }
         Ok(())
     }
 
@@ -1144,7 +1154,7 @@ impl TomlManifest {
             }
         };
         Ok((
-            VirtualManifest::new(replace, patch, workspace_config, profiles),
+            VirtualManifest::new(replace, patch, workspace_config, profiles, features),
             nested_paths,
         ))
     }

--- a/src/doc/src/reference/config.md
+++ b/src/doc/src/reference/config.md
@@ -123,6 +123,8 @@ target-dir = "target"     # path of where to place all generated artifacts
 rustflags = ["..", ".."]  # custom flags to pass to all compiler invocations
 rustdocflags = ["..", ".."]  # custom flags to pass to rustdoc
 incremental = true        # whether or not to enable incremental compilation
+                          # If `incremental` is not set, then the value from
+                          # the profile is used.
 dep-info-basedir = ".."   # full path for the base directory for targets in depfiles
 
 [term]

--- a/src/doc/src/reference/manifest.md
+++ b/src/doc/src/reference/manifest.md
@@ -361,6 +361,10 @@ codegen-units = 16 # if > 1 enables parallel code generation which improves
                    # Passes `-C codegen-units`.
 panic = 'unwind'   # panic strategy (`-C panic=...`), can also be 'abort'
 incremental = true # whether or not incremental compilation is enabled
+                   # This can be overridden globally with CARGO_INCREMENTAL
+                   # environment variable or `build.incremental` config
+                   # variable. Incremental cannot be used with `lto`.
+                   # Incremental is only used for path sources.
 overflow-checks = true # use overflow checks for integer arithmetic.
                    # Passes the `-C overflow-checks=...` flag to the compiler.
 

--- a/tests/testsuite/profile_config.rs
+++ b/tests/testsuite/profile_config.rs
@@ -138,10 +138,7 @@ fn profile_config_validate_errors() {
         .with_status(101)
         .with_stderr(
             "\
-[ERROR] failed to parse manifest at `[CWD]/Cargo.toml`
-
-Caused by:
-  config profile `profile.dev` is not valid
+[ERROR] config profile `profile.dev` is not valid
 
 Caused by:
   `panic` may not be specified in a profile override.
@@ -235,8 +232,7 @@ found profile override specs: bar, bar:0.5.0",
 fn profile_config_all_options() {
     // Ensure all profile options are supported.
     let p = project()
-        .file("Cargo.toml", &basic_lib_manifest("foo"))
-        .file("src/lib.rs", "")
+        .file("src/main.rs", "fn main() {}")
         .file(
             ".cargo/config",
             r#"
@@ -258,10 +254,12 @@ fn profile_config_all_options() {
         .masquerade_as_nightly_cargo()
         .with_stderr(
             "\
+[WARNING] `incremental` setting is ignored [..]
 [COMPILING] foo [..]
 [RUNNING] `rustc --crate-name foo [..] \
             -C opt-level=1 \
             -C panic=abort \
+            -C lto \
             -C codegen-units=2 \
             -C debuginfo=2 \
             -C debug-assertions=on \


### PR DESCRIPTION
This makes it so that incremental compilation is forcefully disabled if `lto` is enabled, instead of failing to compile.

This moves incremental logic into the profile computation, which makes it a little more consistent and helps simplify things a little (such as removing the fingerprint special-case).

This also introduces a small change in behavior with the `build.incremental` config variable.  Previously `build.incremental = true` was completely ignored. Now, it is treated the same as `CARGO_INCREMENTAL=1` environment variable.

Another small change is to move config profile validation to the workspace so that warnings do not appear multiple times (once for each manifest).

Fixes #4255
