### PR TITLE
part of the infrastructure for public & private dependencies in the resolver

### DIFF
--- a/src/cargo/core/dependency.rs
+++ b/src/cargo/core/dependency.rs
@@ -40,6 +40,7 @@ struct Inner {
     explicit_name_in_toml: Option<InternedString>,
 
     optional: bool,
+    public: bool,
     default_features: bool,
     features: Vec<InternedString>,
 
@@ -217,6 +218,7 @@ impl Dependency {
                 kind: Kind::Normal,
                 only_match_name: true,
                 optional: false,
+                public: false,
                 features: Vec::new(),
                 default_features: true,
                 specified_req: false,
@@ -291,6 +293,16 @@ impl Dependency {
 
     pub fn kind(&self) -> Kind {
         self.inner.kind
+    }
+
+    pub fn is_public(&self) -> bool {
+        self.inner.public
+    }
+
+    /// Sets whether the dependency is public.
+    pub fn set_public(&mut self, public: bool) -> &mut Dependency {
+        Rc::make_mut(&mut self.inner).public = public;
+        self
     }
 
     pub fn specified_req(&self) -> bool {

--- a/src/cargo/core/resolver/conflict_cache.rs
+++ b/src/cargo/core/resolver/conflict_cache.rs
@@ -173,6 +173,11 @@ impl ConflictCache {
     /// `dep` is known to be unresolvable if
     /// all the `PackageId` entries are activated.
     pub fn insert(&mut self, dep: &Dependency, con: &BTreeMap<PackageId, ConflictReason>) {
+        if con.values().any(|c| *c == ConflictReason::PublicDependency) {
+            // TODO: needs more info for back jumping
+            // for now refuse to cache it.
+            return;
+        }
         self.con_from_dep
             .entry(dep.clone())
             .or_insert_with(|| ConflictStoreTrie::Node(BTreeMap::new()))

--- a/src/cargo/core/resolver/conflict_cache.rs
+++ b/src/cargo/core/resolver/conflict_cache.rs
@@ -64,7 +64,7 @@ impl ConflictStoreTrie {
                     .or_insert_with(|| ConflictStoreTrie::Node(BTreeMap::new()))
                     .insert(iter, con);
             }
-            // Else, we already have a subset of this in the `ConflictStore`.
+        // Else, we already have a subset of this in the `ConflictStore`.
         } else {
             // We are at the end of the set we are adding, there are three cases for what to do
             // next:

--- a/src/cargo/core/resolver/conflict_cache.rs
+++ b/src/cargo/core/resolver/conflict_cache.rs
@@ -2,7 +2,7 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 
 use log::trace;
 
-use super::types::{Conflict, ConflictReason};
+use super::types::{ConflictMap, ConflictReason};
 use crate::core::resolver::Context;
 use crate::core::{Dependency, PackageId};
 
@@ -10,7 +10,7 @@ use crate::core::{Dependency, PackageId};
 /// efficiently see if any of the stored sets are a subset of a search set.
 enum ConflictStoreTrie {
     /// One of the stored sets.
-    Leaf(Conflict),
+    Leaf(ConflictMap),
     /// A map from an element to a subtrie where
     /// all the sets in the subtrie contains that element.
     Node(BTreeMap<PackageId, ConflictStoreTrie>),
@@ -19,7 +19,11 @@ enum ConflictStoreTrie {
 impl ConflictStoreTrie {
     /// Finds any known set of conflicts, if any,
     /// which are activated in `cx` and pass the `filter` specified?
-    fn find_conflicting(&self, cx: &Context, must_contain: Option<PackageId>) -> Option<&Conflict> {
+    fn find_conflicting(
+        &self,
+        cx: &Context,
+        must_contain: Option<PackageId>,
+    ) -> Option<&ConflictMap> {
         match self {
             ConflictStoreTrie::Leaf(c) => {
                 if must_contain.is_none() {
@@ -53,7 +57,7 @@ impl ConflictStoreTrie {
         }
     }
 
-    fn insert(&mut self, mut iter: impl Iterator<Item = PackageId>, con: Conflict) {
+    fn insert(&mut self, mut iter: impl Iterator<Item = PackageId>, con: ConflictMap) {
         if let Some(pid) = iter.next() {
             if let ConflictStoreTrie::Node(p) = self {
                 p.entry(pid)
@@ -139,7 +143,7 @@ impl ConflictCache {
         cx: &Context,
         dep: &Dependency,
         must_contain: Option<PackageId>,
-    ) -> Option<&Conflict> {
+    ) -> Option<&ConflictMap> {
         let out = self
             .con_from_dep
             .get(dep)?
@@ -153,14 +157,14 @@ impl ConflictCache {
         }
         out
     }
-    pub fn conflicting(&self, cx: &Context, dep: &Dependency) -> Option<&Conflict> {
+    pub fn conflicting(&self, cx: &Context, dep: &Dependency) -> Option<&ConflictMap> {
         self.find_conflicting(cx, dep, None)
     }
 
     /// Adds to the cache a conflict of the form:
     /// `dep` is known to be unresolvable if
     /// all the `PackageId` entries are activated.
-    pub fn insert(&mut self, dep: &Dependency, con: &Conflict) {
+    pub fn insert(&mut self, dep: &Dependency, con: &ConflictMap) {
         if con.values().any(|c| *c == ConflictReason::PublicDependency) {
             // TODO: needs more info for back jumping
             // for now refuse to cache it.

--- a/src/cargo/core/resolver/conflict_cache.rs
+++ b/src/cargo/core/resolver/conflict_cache.rs
@@ -2,7 +2,7 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 
 use log::trace;
 
-use super::types::ConflictReason;
+use super::types::{Conflict, ConflictReason};
 use crate::core::resolver::Context;
 use crate::core::{Dependency, PackageId};
 
@@ -10,7 +10,7 @@ use crate::core::{Dependency, PackageId};
 /// efficiently see if any of the stored sets are a subset of a search set.
 enum ConflictStoreTrie {
     /// One of the stored sets.
-    Leaf(BTreeMap<PackageId, ConflictReason>),
+    Leaf(Conflict),
     /// A map from an element to a subtrie where
     /// all the sets in the subtrie contains that element.
     Node(BTreeMap<PackageId, ConflictStoreTrie>),
@@ -19,11 +19,7 @@ enum ConflictStoreTrie {
 impl ConflictStoreTrie {
     /// Finds any known set of conflicts, if any,
     /// which are activated in `cx` and pass the `filter` specified?
-    fn find_conflicting(
-        &self,
-        cx: &Context,
-        must_contain: Option<PackageId>,
-    ) -> Option<&BTreeMap<PackageId, ConflictReason>> {
+    fn find_conflicting(&self, cx: &Context, must_contain: Option<PackageId>) -> Option<&Conflict> {
         match self {
             ConflictStoreTrie::Leaf(c) => {
                 if must_contain.is_none() {
@@ -57,11 +53,7 @@ impl ConflictStoreTrie {
         }
     }
 
-    fn insert(
-        &mut self,
-        mut iter: impl Iterator<Item = PackageId>,
-        con: BTreeMap<PackageId, ConflictReason>,
-    ) {
+    fn insert(&mut self, mut iter: impl Iterator<Item = PackageId>, con: Conflict) {
         if let Some(pid) = iter.next() {
             if let ConflictStoreTrie::Node(p) = self {
                 p.entry(pid)
@@ -147,7 +139,7 @@ impl ConflictCache {
         cx: &Context,
         dep: &Dependency,
         must_contain: Option<PackageId>,
-    ) -> Option<&BTreeMap<PackageId, ConflictReason>> {
+    ) -> Option<&Conflict> {
         let out = self
             .con_from_dep
             .get(dep)?
@@ -161,18 +153,14 @@ impl ConflictCache {
         }
         out
     }
-    pub fn conflicting(
-        &self,
-        cx: &Context,
-        dep: &Dependency,
-    ) -> Option<&BTreeMap<PackageId, ConflictReason>> {
+    pub fn conflicting(&self, cx: &Context, dep: &Dependency) -> Option<&Conflict> {
         self.find_conflicting(cx, dep, None)
     }
 
     /// Adds to the cache a conflict of the form:
     /// `dep` is known to be unresolvable if
     /// all the `PackageId` entries are activated.
-    pub fn insert(&mut self, dep: &Dependency, con: &BTreeMap<PackageId, ConflictReason>) {
+    pub fn insert(&mut self, dep: &Dependency, con: &Conflict) {
         if con.values().any(|c| *c == ConflictReason::PublicDependency) {
             // TODO: needs more info for back jumping
             // for now refuse to cache it.

--- a/src/cargo/core/resolver/context.rs
+++ b/src/cargo/core/resolver/context.rs
@@ -34,7 +34,7 @@ pub struct Context {
     /// for each package the list of names it can see,
     /// then for each name the exact version that name represents and weather the name is public.
     pub public_dependency:
-        im_rc::HashMap<PackageId, im_rc::HashMap<InternedString, (PackageId, bool)>>,
+        Option<im_rc::HashMap<PackageId, im_rc::HashMap<InternedString, (PackageId, bool)>>>,
 
     // This is somewhat redundant with the `resolve_graph` that stores the same data,
     //   but for querying in the opposite order.
@@ -56,12 +56,16 @@ pub struct Context {
 pub type Activations = im_rc::HashMap<(InternedString, SourceId), Rc<Vec<Summary>>>;
 
 impl Context {
-    pub fn new() -> Context {
+    pub fn new(check_public_visible_dependencies: bool) -> Context {
         Context {
             resolve_graph: RcList::new(),
             resolve_features: im_rc::HashMap::new(),
             links: im_rc::HashMap::new(),
-            public_dependency: im_rc::HashMap::new(),
+            public_dependency: if check_public_visible_dependencies {
+                Some(im_rc::HashMap::new())
+            } else {
+                None
+            },
             parents: Graph::new(),
             resolve_replacements: RcList::new(),
             activations: im_rc::HashMap::new(),

--- a/src/cargo/core/resolver/context.rs
+++ b/src/cargo/core/resolver/context.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
 
 // "ensure" seems to require "bail" be in scope (macro hygiene issue?).
@@ -12,7 +12,7 @@ use crate::util::CargoResult;
 use crate::util::Graph;
 
 use super::errors::ActivateResult;
-use super::types::{ConflictReason, DepInfo, GraphNode, Method, RcList, RegistryQueryer};
+use super::types::{Conflict, ConflictReason, DepInfo, GraphNode, Method, RcList, RegistryQueryer};
 
 pub use super::encode::{EncodableDependency, EncodablePackageId, EncodableResolve};
 pub use super::encode::{Metadata, WorkspaceResolve};
@@ -155,7 +155,7 @@ impl Context {
     pub fn is_conflicting(
         &self,
         parent: Option<PackageId>,
-        conflicting_activations: &BTreeMap<PackageId, ConflictReason>,
+        conflicting_activations: &Conflict,
     ) -> bool {
         conflicting_activations
             .keys()

--- a/src/cargo/core/resolver/context.rs
+++ b/src/cargo/core/resolver/context.rs
@@ -28,6 +28,10 @@ pub struct Context {
     pub resolve_features: im_rc::HashMap<PackageId, Rc<HashSet<InternedString>>>,
     pub links: im_rc::HashMap<InternedString, PackageId>,
 
+    // This is somewhat redundant with the `resolve_graph` that stores the same data,
+    //   but for querying in the opposite order.
+    pub parents: Graph<PackageId, Rc<Vec<Dependency>>>,
+
     // These are two cheaply-cloneable lists (O(1) clone) which are effectively
     // hash maps but are built up as "construction lists". We'll iterate these
     // at the very end and actually construct the map that we're making.
@@ -46,6 +50,7 @@ impl Context {
             resolve_graph: RcList::new(),
             resolve_features: im_rc::HashMap::new(),
             links: im_rc::HashMap::new(),
+            parents: Graph::new(),
             resolve_replacements: RcList::new(),
             activations: im_rc::HashMap::new(),
             warnings: RcList::new(),

--- a/src/cargo/core/resolver/context.rs
+++ b/src/cargo/core/resolver/context.rs
@@ -27,6 +27,8 @@ pub struct Context {
     pub activations: Activations,
     pub resolve_features: im_rc::HashMap<PackageId, Rc<HashSet<InternedString>>>,
     pub links: im_rc::HashMap<InternedString, PackageId>,
+    pub public_dependency:
+        im_rc::HashMap<PackageId, im_rc::HashMap<InternedString, (PackageId, bool)>>,
 
     // This is somewhat redundant with the `resolve_graph` that stores the same data,
     //   but for querying in the opposite order.
@@ -50,6 +52,7 @@ impl Context {
             resolve_graph: RcList::new(),
             resolve_features: im_rc::HashMap::new(),
             links: im_rc::HashMap::new(),
+            public_dependency: im_rc::HashMap::new(),
             parents: Graph::new(),
             resolve_replacements: RcList::new(),
             activations: im_rc::HashMap::new(),

--- a/src/cargo/core/resolver/errors.rs
+++ b/src/cargo/core/resolver/errors.rs
@@ -1,4 +1,3 @@
-use std::collections::BTreeMap;
 use std::fmt;
 
 use crate::core::{Dependency, PackageId, Registry, Summary};
@@ -8,7 +7,7 @@ use failure::{Error, Fail};
 use semver;
 
 use super::context::Context;
-use super::types::{Candidate, ConflictReason};
+use super::types::{Candidate, Conflict, ConflictReason};
 
 /// Error during resolution providing a path of `PackageId`s.
 pub struct ResolveError {
@@ -73,7 +72,7 @@ pub(super) fn activation_error(
     registry: &mut dyn Registry,
     parent: &Summary,
     dep: &Dependency,
-    conflicting_activations: &BTreeMap<PackageId, ConflictReason>,
+    conflicting_activations: &Conflict,
     candidates: &[Candidate],
     config: Option<&Config>,
 ) -> ResolveError {

--- a/src/cargo/core/resolver/errors.rs
+++ b/src/cargo/core/resolver/errors.rs
@@ -7,7 +7,7 @@ use failure::{Error, Fail};
 use semver;
 
 use super::context::Context;
-use super::types::{Candidate, Conflict, ConflictReason};
+use super::types::{Candidate, ConflictMap, ConflictReason};
 
 /// Error during resolution providing a path of `PackageId`s.
 pub struct ResolveError {
@@ -72,7 +72,7 @@ pub(super) fn activation_error(
     registry: &mut dyn Registry,
     parent: &Summary,
     dep: &Dependency,
-    conflicting_activations: &Conflict,
+    conflicting_activations: &ConflictMap,
     candidates: &[Candidate],
     config: Option<&Config>,
 ) -> ResolveError {

--- a/src/cargo/core/resolver/errors.rs
+++ b/src/cargo/core/resolver/errors.rs
@@ -77,12 +77,11 @@ pub(super) fn activation_error(
     candidates: &[Candidate],
     config: Option<&Config>,
 ) -> ResolveError {
-    let graph = cx.graph();
     let to_resolve_err = |err| {
         ResolveError::new(
             err,
-            graph
-                .path_to_top(&parent.package_id())
+            cx.parents
+                .path_to_bottom(&parent.package_id())
                 .into_iter()
                 .cloned()
                 .collect(),
@@ -92,7 +91,9 @@ pub(super) fn activation_error(
     if !candidates.is_empty() {
         let mut msg = format!("failed to select a version for `{}`.", dep.package_name());
         msg.push_str("\n    ... required by ");
-        msg.push_str(&describe_path(&graph.path_to_top(&parent.package_id())));
+        msg.push_str(&describe_path(
+            &cx.parents.path_to_bottom(&parent.package_id()),
+        ));
 
         msg.push_str("\nversions that meet the requirements `");
         msg.push_str(&dep.version_req().to_string());
@@ -123,7 +124,7 @@ pub(super) fn activation_error(
                 msg.push_str(link);
                 msg.push_str("` as well:\n");
             }
-            msg.push_str(&describe_path(&graph.path_to_top(p)));
+            msg.push_str(&describe_path(&cx.parents.path_to_bottom(p)));
         }
 
         let (features_errors, other_errors): (Vec<_>, Vec<_>) = other_errors
@@ -154,7 +155,7 @@ pub(super) fn activation_error(
 
         for &(p, _) in other_errors.iter() {
             msg.push_str("\n\n  previously selected ");
-            msg.push_str(&describe_path(&graph.path_to_top(p)));
+            msg.push_str(&describe_path(&cx.parents.path_to_bottom(p)));
         }
 
         msg.push_str("\n\nfailed to select a version for `");
@@ -204,7 +205,9 @@ pub(super) fn activation_error(
             registry.describe_source(dep.source_id()),
         );
         msg.push_str("required by ");
-        msg.push_str(&describe_path(&graph.path_to_top(&parent.package_id())));
+        msg.push_str(&describe_path(
+            &cx.parents.path_to_bottom(&parent.package_id()),
+        ));
 
         // If we have a path dependency with a locked version, then this may
         // indicate that we updated a sub-package and forgot to run `cargo
@@ -265,7 +268,9 @@ pub(super) fn activation_error(
             msg.push_str("\n");
         }
         msg.push_str("required by ");
-        msg.push_str(&describe_path(&graph.path_to_top(&parent.package_id())));
+        msg.push_str(&describe_path(
+            &cx.parents.path_to_bottom(&parent.package_id()),
+        ));
 
         msg
     };

--- a/src/cargo/core/resolver/mod.rs
+++ b/src/cargo/core/resolver/mod.rs
@@ -782,7 +782,7 @@ impl RemainingCandidates {
                     // TODO: dont look at the same thing more then once
                     if let Some(o) = cx.public_dependency.get(&p).and_then(|x| x.get(&t.name())) {
                         if o.0 != t {
-                            // TODO: conflicting_prev_active
+                            conflicting_prev_active.insert(p, ConflictReason::PublicDependency);
                             continue 'main;
                         }
                     }
@@ -868,6 +868,9 @@ fn find_candidate(
         // make any progress. As a result if we hit this condition we can
         // completely skip this backtrack frame and move on to the next.
         if !backtracked
+            && !conflicting_activations
+                .values()
+                .any(|c| *c == ConflictReason::PublicDependency)
             && frame
                 .context
                 .is_conflicting(Some(parent.package_id()), conflicting_activations)

--- a/src/cargo/core/resolver/mod.rs
+++ b/src/cargo/core/resolver/mod.rs
@@ -591,6 +591,11 @@ fn activate(
             candidate.summary.package_id(),
             dep.clone(),
         ));
+        Rc::make_mut(
+            cx.parents
+                .link(candidate.summary.package_id(), parent.package_id()),
+        )
+        .push(dep.clone());
     }
 
     let activated = cx.flag_activated(&candidate.summary, method)?;

--- a/src/cargo/core/resolver/resolve.rs
+++ b/src/cargo/core/resolver/resolve.rs
@@ -1,7 +1,6 @@
 use std::borrow::Borrow;
 use std::collections::{HashMap, HashSet};
 use std::fmt;
-use std::hash::Hash;
 use std::iter::FromIterator;
 
 use url::Url;
@@ -163,7 +162,7 @@ unable to verify that `{0}` is the same as when the lockfile was generated
     pub fn contains<Q: ?Sized>(&self, k: &Q) -> bool
     where
         PackageId: Borrow<Q>,
-        Q: Hash + Eq,
+        Q: Ord + Eq,
     {
         self.graph.contains(k)
     }
@@ -179,11 +178,11 @@ unable to verify that `{0}` is the same as when the lockfile was generated
     pub fn deps(&self, pkg: PackageId) -> impl Iterator<Item = (PackageId, &[Dependency])> {
         self.graph
             .edges(&pkg)
-            .map(move |(&id, deps)| (self.replacement(id).unwrap_or(id), deps.as_slice()))
+            .map(move |&(id, ref deps)| (self.replacement(id).unwrap_or(id), deps.as_slice()))
     }
 
     pub fn deps_not_replaced<'a>(&'a self, pkg: PackageId) -> impl Iterator<Item = PackageId> + 'a {
-        self.graph.edges(&pkg).map(|(&id, _)| id)
+        self.graph.edges(&pkg).map(|&(id, _)| id)
     }
 
     pub fn replacement(&self, pkg: PackageId) -> Option<PackageId> {

--- a/src/cargo/core/resolver/types.rs
+++ b/src/cargo/core/resolver/types.rs
@@ -402,6 +402,11 @@ pub enum ConflictReason {
     /// candidate. For example we tried to activate feature `foo` but the
     /// candidate we're activating didn't actually have the feature `foo`.
     MissingFeatures(String),
+
+    // TODO: needs more info for errors maneges
+    // TODO: needs more info for back jumping
+    /// pub dep errore
+    PublicDependency,
 }
 
 impl ConflictReason {

--- a/src/cargo/core/resolver/types.rs
+++ b/src/cargo/core/resolver/types.rs
@@ -1,5 +1,5 @@
 use std::cmp::Ordering;
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::ops::Range;
 use std::rc::Rc;
 use std::time::{Duration, Instant};
@@ -424,6 +424,8 @@ impl ConflictReason {
         false
     }
 }
+
+pub type Conflict = BTreeMap<PackageId, ConflictReason>;
 
 pub struct RcVecIter<T> {
     vec: Rc<Vec<T>>,

--- a/src/cargo/core/resolver/types.rs
+++ b/src/cargo/core/resolver/types.rs
@@ -425,7 +425,7 @@ impl ConflictReason {
     }
 }
 
-pub type Conflict = BTreeMap<PackageId, ConflictReason>;
+pub type ConflictMap = BTreeMap<PackageId, ConflictReason>;
 
 pub struct RcVecIter<T> {
     vec: Rc<Vec<T>>,

--- a/src/cargo/ops/resolve.rs
+++ b/src/cargo/ops/resolve.rs
@@ -338,6 +338,7 @@ pub fn resolve_with_previous<'cfg>(
         &try_to_use,
         Some(ws.config()),
         warn,
+        false, // TODO: use "public and private dependencies" feature flag
     )?;
     resolved.register_used_patches(registry.patches());
     if register_patches {

--- a/tests/testsuite/support/resolver.rs
+++ b/tests/testsuite/support/resolver.rs
@@ -115,6 +115,7 @@ pub fn resolve_with_config_raw(
         &HashSet::new(),
         config,
         false,
+        true,
     );
 
     // The largest test in our suite takes less then 30 sec.

--- a/tests/testsuite/support/resolver.rs
+++ b/tests/testsuite/support/resolver.rs
@@ -250,9 +250,10 @@ pub fn dep(name: &str) -> Dependency {
 pub fn dep_req(name: &str, req: &str) -> Dependency {
     Dependency::parse_no_deprecated(name, Some(req), registry_loc()).unwrap()
 }
-pub fn dep_req_kind(name: &str, req: &str, kind: Kind) -> Dependency {
+pub fn dep_req_kind(name: &str, req: &str, kind: Kind, public: bool) -> Dependency {
     let mut dep = dep_req(name, req);
     dep.set_kind(kind);
+    dep.set_public(public);
     dep
 }
 
@@ -297,9 +298,12 @@ impl fmt::Debug for PrettyPrintRegistry {
             } else {
                 write!(f, "pkg!((\"{}\", \"{}\") => [", s.name(), s.version())?;
                 for d in s.dependencies() {
-                    if d.kind() == Kind::Normal && &d.version_req().to_string() == "*" {
+                    if d.kind() == Kind::Normal
+                        && &d.version_req().to_string() == "*"
+                        && !d.is_public()
+                    {
                         write!(f, "dep(\"{}\"),", d.name_in_toml())?;
-                    } else if d.kind() == Kind::Normal {
+                    } else if d.kind() == Kind::Normal && !d.is_public() {
                         write!(
                             f,
                             "dep_req(\"{}\", \"{}\"),",
@@ -309,14 +313,15 @@ impl fmt::Debug for PrettyPrintRegistry {
                     } else {
                         write!(
                             f,
-                            "dep_req_kind(\"{}\", \"{}\", {}),",
+                            "dep_req_kind(\"{}\", \"{}\", {}, {}),",
                             d.name_in_toml(),
                             d.version_req(),
                             match d.kind() {
                                 Kind::Development => "Kind::Development",
                                 Kind::Build => "Kind::Build",
                                 Kind::Normal => "Kind::Normal",
-                            }
+                            },
+                            d.is_public()
                         )?;
                     }
                 }
@@ -341,8 +346,10 @@ fn meta_test_deep_pretty_print_registry() {
                 pkg!(("bar", "2.0.0") => [dep_req("baz", "=1.0.1")]),
                 pkg!(("baz", "1.0.2") => [dep_req("other", "2")]),
                 pkg!(("baz", "1.0.1")),
-                pkg!(("cat", "1.0.2") => [dep_req_kind("other", "2", Kind::Build)]),
-                pkg!(("cat", "1.0.2") => [dep_req_kind("other", "2", Kind::Development)]),
+                pkg!(("cat", "1.0.2") => [dep_req_kind("other", "2", Kind::Build, false)]),
+                pkg!(("cat", "1.0.3") => [dep_req_kind("other", "2", Kind::Development, false)]),
+                pkg!(("cat", "1.0.4") => [dep_req_kind("other", "2", Kind::Build, true)]),
+                pkg!(("cat", "1.0.5") => [dep_req_kind("other", "2", Kind::Development, true)]),
                 pkg!(("dep_req", "1.0.0")),
                 pkg!(("dep_req", "2.0.0")),
             ])
@@ -354,8 +361,10 @@ fn meta_test_deep_pretty_print_registry() {
          pkg!((\"bar\", \"2.0.0\") => [dep_req(\"baz\", \"= 1.0.1\"),]),\
          pkg!((\"baz\", \"1.0.2\") => [dep_req(\"other\", \"^2\"),]),\
          pkg!((\"baz\", \"1.0.1\")),\
-         pkg!((\"cat\", \"1.0.2\") => [dep_req_kind(\"other\", \"^2\", Kind::Build),]),\
-         pkg!((\"cat\", \"1.0.2\") => [dep_req_kind(\"other\", \"^2\", Kind::Development),]),\
+         pkg!((\"cat\", \"1.0.2\") => [dep_req_kind(\"other\", \"^2\", Kind::Build, false),]),\
+         pkg!((\"cat\", \"1.0.3\") => [dep_req_kind(\"other\", \"^2\", Kind::Development, false),]),\
+         pkg!((\"cat\", \"1.0.4\") => [dep_req_kind(\"other\", \"^2\", Kind::Build, true),]),\
+         pkg!((\"cat\", \"1.0.5\") => [dep_req_kind(\"other\", \"^2\", Kind::Development, true),]),\
          pkg!((\"dep_req\", \"1.0.0\")),\
          pkg!((\"dep_req\", \"2.0.0\")),]"
     )
@@ -405,7 +414,13 @@ pub fn registry_strategy(
     let max_deps = max_versions * (max_crates * (max_crates - 1)) / shrinkage;
 
     let raw_version_range = (any::<Index>(), any::<Index>());
-    let raw_dependency = (any::<Index>(), any::<Index>(), raw_version_range, 0..=1);
+    let raw_dependency = (
+        any::<Index>(),
+        any::<Index>(),
+        raw_version_range,
+        0..=1,
+        any::<bool>(),
+    );
 
     fn order_index(a: Index, b: Index, size: usize) -> (usize, usize) {
         let (a, b) = (a.index(size), b.index(size));
@@ -432,7 +447,7 @@ pub fn registry_strategy(
                     .collect();
                 let len_all_pkgid = list_of_pkgid.len();
                 let mut dependency_by_pkgid = vec![vec![]; len_all_pkgid];
-                for (a, b, (c, d), k) in raw_dependencies {
+                for (a, b, (c, d), k, p) in raw_dependencies {
                     let (a, b) = order_index(a, b, len_all_pkgid);
                     let (a, b) = if reverse_alphabetical { (b, a) } else { (a, b) };
                     let ((dep_name, _), _) = list_of_pkgid[a];
@@ -443,27 +458,28 @@ pub fn registry_strategy(
                     let s_last_index = s.len() - 1;
                     let (c, d) = order_index(c, d, s.len());
 
-                    dependency_by_pkgid[b].push(dep_req_kind(
-                        &dep_name,
-                        &if c == 0 && d == s_last_index {
-                            "*".to_string()
-                        } else if c == 0 {
-                            format!("<={}", s[d].0)
-                        } else if d == s_last_index {
-                            format!(">={}", s[c].0)
-                        } else if c == d {
-                            format!("={}", s[c].0)
-                        } else {
-                            format!(">={}, <={}", s[c].0, s[d].0)
-                        },
-                        match k {
-                            0 => Kind::Normal,
-                            1 => Kind::Build,
-                            // => Kind::Development, // Development has not impact so don't gen
-                            _ => panic!("bad index for Kind"),
-                        },
-                    ))
-                }
+                dependency_by_pkgid[b].push(dep_req_kind(
+                    &dep_name,
+                    &if c == 0 && d == s_last_index {
+                        "*".to_string()
+                    } else if c == 0 {
+                        format!("<={}", s[d].0)
+                    } else if d == s_last_index {
+                        format!(">={}", s[c].0)
+                    } else if c == d {
+                        format!("={}", s[c].0)
+                    } else {
+                        format!(">={}, <={}", s[c].0, s[d].0)
+                    },
+                    match k {
+                        0 => Kind::Normal,
+                        1 => Kind::Build,
+                        // => Kind::Development, // Development has not impact so don't gen
+                        _ => panic!("bad index for Kind"),
+                    },
+                    p,
+                ))
+            }
 
                 PrettyPrintRegistry(
                     list_of_pkgid

--- a/tests/testsuite/support/resolver.rs
+++ b/tests/testsuite/support/resolver.rs
@@ -419,7 +419,8 @@ pub fn registry_strategy(
         any::<Index>(),
         raw_version_range,
         0..=1,
-        any::<bool>(),
+        Just(false),
+        // TODO: ^ this needs to be set back to `any::<bool>()` and work before public & private dependencies can stabilize
     );
 
     fn order_index(a: Index, b: Index, size: usize) -> (usize, usize) {
@@ -458,28 +459,28 @@ pub fn registry_strategy(
                     let s_last_index = s.len() - 1;
                     let (c, d) = order_index(c, d, s.len());
 
-                dependency_by_pkgid[b].push(dep_req_kind(
-                    &dep_name,
-                    &if c == 0 && d == s_last_index {
-                        "*".to_string()
-                    } else if c == 0 {
-                        format!("<={}", s[d].0)
-                    } else if d == s_last_index {
-                        format!(">={}", s[c].0)
-                    } else if c == d {
-                        format!("={}", s[c].0)
-                    } else {
-                        format!(">={}, <={}", s[c].0, s[d].0)
-                    },
-                    match k {
-                        0 => Kind::Normal,
-                        1 => Kind::Build,
-                        // => Kind::Development, // Development has not impact so don't gen
-                        _ => panic!("bad index for Kind"),
-                    },
-                    p,
-                ))
-            }
+                    dependency_by_pkgid[b].push(dep_req_kind(
+                        &dep_name,
+                        &if c == 0 && d == s_last_index {
+                            "*".to_string()
+                        } else if c == 0 {
+                            format!("<={}", s[d].0)
+                        } else if d == s_last_index {
+                            format!(">={}", s[c].0)
+                        } else if c == d {
+                            format!("={}", s[c].0)
+                        } else {
+                            format!(">={}, <={}", s[c].0, s[d].0)
+                        },
+                        match k {
+                            0 => Kind::Normal,
+                            1 => Kind::Build,
+                            // => Kind::Development, // Development has no impact so don't gen
+                            _ => panic!("bad index for Kind"),
+                        },
+                        p,
+                    ))
+                }
 
                 PrettyPrintRegistry(
                     list_of_pkgid


### PR DESCRIPTION
This is part of my work on public & private dependencies in the resolver from #6129. As discussed there the proptest fuzzers are happy to find exponential blow up with all the back jumping strategies I have tried. So this PR does not have a back jumping strategie nor does it have the proptest fuzzers generating public dependencies. These will both need to change for the feature to stabilize. In the meantime it gives the correct results on the cases it can handle.

With https://github.com/rust-lang/rust/pull/57586 landed there is a lot of work to do on Cargos front end. Adding a UI for this, passing the relevant things to rustc, passing it to crates.io, passing it to cargo-metadata. This is good enough to allow that work to proceed.