### PR TITLE
Update docs for removed `patch` restriction.

### DIFF
--- a/src/doc/man/cargo-package.adoc
+++ b/src/doc/man/cargo-package.adoc
@@ -23,6 +23,8 @@ steps:
       will ignore the path key for dependencies in published packages.
 . Create the compressed `.crate` file.
     - The original `Cargo.toml` file is rewritten and normalized.
+    - `[patch]`, `[replace]`, and `[workspace]` sections are removed from the
+      manifest.
     - A `.cargo_vcs_info.json` file is included that contains information
       about the current VCS checkout hash if available (not included with
       `--allow-dirty`).

--- a/src/doc/man/generated/cargo-package.html
+++ b/src/doc/man/generated/cargo-package.html
@@ -40,6 +40,10 @@ will ignore the path key for dependencies in published packages.</p>
 <p>The original <code>Cargo.toml</code> file is rewritten and normalized.</p>
 </li>
 <li>
+<p><code>[patch]</code>, <code>[replace]</code>, and <code>[workspace]</code> sections are removed from the
+manifest.</p>
+</li>
+<li>
 <p>A <code>.cargo_vcs_info.json</code> file is included that contains information
 about the current VCS checkout hash if available (not included with
 <code>--allow-dirty</code>).</p>

--- a/src/doc/man/generated/cargo-publish.html
+++ b/src/doc/man/generated/cargo-publish.html
@@ -26,9 +26,6 @@ following steps:</p>
 <div class="ulist">
 <ul>
 <li>
-<p>No <code>[patch]</code> sections are allowed in the manifest.</p>
-</li>
-<li>
 <p>Checks the <code>package.publish</code> key in the manifest for restrictions on which
 registries you are allowed to publish to.</p>
 </li>

--- a/src/etc/man/cargo-package.1
+++ b/src/etc/man/cargo-package.1
@@ -2,12 +2,12 @@
 .\"     Title: cargo-package
 .\"    Author: [see the "AUTHOR(S)" section]
 .\" Generator: Asciidoctor 1.5.8
-.\"      Date: 2019-01-14
+.\"      Date: 2019-02-13
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "CARGO\-PACKAGE" "1" "2019-01-14" "\ \&" "\ \&"
+.TH "CARGO\-PACKAGE" "1" "2019-02-13" "\ \&" "\ \&"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0
@@ -81,6 +81,18 @@ Create the compressed \fB.crate\fP file.
 .  IP \(bu 2.3
 .\}
 The original \fBCargo.toml\fP file is rewritten and normalized.
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.  sp -1
+.  IP \(bu 2.3
+.\}
+\fB[patch]\fP, \fB[replace]\fP, and \fB[workspace]\fP sections are removed from the
+manifest.
 .RE
 .sp
 .RS 4

--- a/src/etc/man/cargo-publish.1
+++ b/src/etc/man/cargo-publish.1
@@ -2,12 +2,12 @@
 .\"     Title: cargo-publish
 .\"    Author: [see the "AUTHOR(S)" section]
 .\" Generator: Asciidoctor 1.5.8
-.\"      Date: 2019-02-05
+.\"      Date: 2019-02-13
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "CARGO\-PUBLISH" "1" "2019-02-05" "\ \&" "\ \&"
+.TH "CARGO\-PUBLISH" "1" "2019-02-13" "\ \&" "\ \&"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0
@@ -50,17 +50,6 @@ following steps:
 .  IP " 1." 4.2
 .\}
 Performs a few checks, including:
-.sp
-.RS 4
-.ie n \{\
-\h'-04'\(bu\h'+03'\c
-.\}
-.el \{\
-.  sp -1
-.  IP \(bu 2.3
-.\}
-No \fB[patch]\fP sections are allowed in the manifest.
-.RE
 .sp
 .RS 4
 .ie n \{\


### PR DESCRIPTION
The html/man pages need to be rebuilt after changes in #6535. I also included a minor clarification about sections that are removed when a package is published.