### PR TITLE
Show stdout from the compiler with json error mode

### DIFF
--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -299,7 +299,11 @@ fn rustc<'a, 'cfg>(
                 package_id,
                 &target,
                 mode,
-                &mut assert_is_empty,
+                &mut |line| {
+                    // Forward compiler stdout to stderr
+                    writeln!(io::stderr(), "{}", line)?;
+                    Ok(())
+                },
                 &mut |line| json_stderr(line, package_id, &target),
             )
             .map_err(internal_if_simple_exit_code)


### PR DESCRIPTION
This allows using commands like `-Z time-passes` and `println!` debugging in rustc.

r? @alexcrichton 