### PR TITLE
Support for custom Cargo profiles, #2

### DIFF
--- a/src/bin/cargo/commands/bench.rs
+++ b/src/bin/cargo/commands/bench.rs
@@ -74,7 +74,7 @@ pub fn exec(config: &mut Config, args: &ArgMatches<'_>) -> CliResult {
     let ws = args.workspace(config)?;
     let mut compile_opts = args.compile_options(config, CompileMode::Bench, Some(&ws))?;
 
-    compile_opts.build_config.release = true;
+    compile_opts.build_config.build_profile = BuildProfile::Release;
 
     let ops = TestOptions {
         no_run: args.is_present("no-run"),

--- a/src/bin/cargo/commands/build.rs
+++ b/src/bin/cargo/commands/build.rs
@@ -26,6 +26,7 @@ pub fn cli() -> App {
             "Build all targets",
         )
         .arg_release("Build artifacts in release mode, with optimizations")
+        .arg_profile("Build artifacts with the specified custom profile")
         .arg_features()
         .arg_target_triple("Build for the target triple")
         .arg_target_dir()

--- a/src/bin/cargo/commands/install.rs
+++ b/src/bin/cargo/commands/install.rs
@@ -82,7 +82,11 @@ pub fn exec(config: &mut Config, args: &ArgMatches<'_>) -> CliResult {
     let workspace = args.workspace(config).ok();
     let mut compile_opts = args.compile_options(config, CompileMode::Build, workspace.as_ref())?;
 
-    compile_opts.build_config.release = !args.is_present("debug");
+    compile_opts.build_config.build_profile = if !args._is_present("debug") {
+        BuildProfile::Release
+    } else {
+        BuildProfile::Dev
+    };
 
     let krates = args
         .values_of("crate")

--- a/src/cargo/core/compiler/build_config.rs
+++ b/src/cargo/core/compiler/build_config.rs
@@ -5,6 +5,23 @@ use serde::ser;
 
 use crate::util::{CargoResult, CargoResultExt, Config, RustfixDiagnosticServer};
 
+#[derive(Debug, Clone)]
+pub enum BuildProfile {
+    Dev,
+    Release,
+    Custom(String),
+}
+
+impl BuildProfile {
+    pub fn dest(&self) -> &str {
+        match self {
+            BuildProfile::Dev => "debug",
+            BuildProfile::Release => "release",
+            BuildProfile::Custom(name) => &name,
+        }
+    }
+}
+
 /// Configuration information for a rustc build.
 #[derive(Debug)]
 pub struct BuildConfig {
@@ -12,8 +29,8 @@ pub struct BuildConfig {
     pub requested_target: Option<String>,
     /// How many rustc jobs to run in parallel
     pub jobs: u32,
-    /// Whether we are building for release
-    pub release: bool,
+    /// Custom profile
+    pub build_profile: BuildProfile,
     /// In what mode we are compiling
     pub mode: CompileMode,
     /// Whether to print std output in json format (for machine reading)
@@ -82,7 +99,7 @@ impl BuildConfig {
         Ok(BuildConfig {
             requested_target: target,
             jobs,
-            release: false,
+            build_profile: BuildProfile::Dev,
             mode,
             message_format: MessageFormat::Human,
             force_rebuild: false,

--- a/src/cargo/core/compiler/context/mod.rs
+++ b/src/cargo/core/compiler/context/mod.rs
@@ -293,11 +293,7 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
         export_dir: Option<PathBuf>,
         units: &[Unit<'a>],
     ) -> CargoResult<()> {
-        let dest = if self.bcx.build_config.release {
-            "release"
-        } else {
-            "debug"
-        };
+        let dest = self.bcx.build_config.build_profile.dest();
         let host_layout = Layout::new(self.bcx.ws, None, dest)?;
         let target_layout = match self.bcx.build_config.requested_target.as_ref() {
             Some(target) => Some(Layout::new(self.bcx.ws, Some(target), dest)?),

--- a/src/cargo/core/compiler/context/unit_dependencies.rs
+++ b/src/cargo/core/compiler/context/unit_dependencies.rs
@@ -402,7 +402,7 @@ fn new_unit<'a>(
         bcx.ws.is_member(pkg),
         unit_for,
         mode,
-        bcx.build_config.release,
+        bcx.build_config.build_profile.clone(),
     );
     Unit {
         pkg,

--- a/src/cargo/core/compiler/custom_build.rs
+++ b/src/cargo/core/compiler/custom_build.rs
@@ -164,14 +164,7 @@ fn build_work<'a, 'cfg>(cx: &mut Context<'a, 'cfg>, unit: &Unit<'a>) -> CargoRes
         )
         .env("DEBUG", debug.to_string())
         .env("OPT_LEVEL", &unit.profile.opt_level.to_string())
-        .env(
-            "PROFILE",
-            if bcx.build_config.release {
-                "release"
-            } else {
-                "debug"
-            },
-        )
+        .env("PROFILE", bcx.build_config.build_profile.dest())
         .env("HOST", &bcx.host_triple())
         .env("RUSTC", &bcx.rustc.path)
         .env("RUSTDOC", &*bcx.config.rustdoc()?)

--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -24,7 +24,7 @@ use self::job_queue::JobQueue;
 
 use self::output_depinfo::output_depinfo;
 
-pub use self::build_config::{BuildConfig, CompileMode, MessageFormat};
+pub use self::build_config::{BuildConfig, CompileMode, MessageFormat, BuildProfile};
 pub use self::build_context::{BuildContext, FileFlavor, TargetConfig, TargetInfo};
 pub use self::compilation::{Compilation, Doctest};
 pub use self::context::{Context, Unit};

--- a/src/cargo/ops/cargo_clean.rs
+++ b/src/cargo/ops/cargo_clean.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::fs;
 use std::path::Path;
 
-use crate::core::compiler::{BuildConfig, BuildContext, CompileMode, Context, Kind, Unit};
+use crate::core::compiler::{BuildConfig, BuildContext, BuildProfile, CompileMode, Context, Kind, Unit};
 use crate::core::profiles::UnitFor;
 use crate::core::Workspace;
 use crate::ops;
@@ -51,6 +51,11 @@ pub fn clean(ws: &Workspace<'_>, opts: &CleanOptions<'_>) -> CargoResult<()> {
 
     let profiles = ws.profiles();
     let mut units = Vec::new();
+    let build_profile = if opts.release {
+        BuildProfile::Release
+    } else {
+        BuildProfile::Dev
+    };
 
     for spec in opts.spec.iter() {
         // Translate the spec to a Package
@@ -68,7 +73,7 @@ pub fn clean(ws: &Workspace<'_>, opts: &CleanOptions<'_>) -> CargoResult<()> {
                                 ws.is_member(pkg),
                                 *unit_for,
                                 CompileMode::Build,
-                                opts.release,
+                                build_profile.clone(),
                             ))
                         } else {
                             profiles.get_profile(
@@ -76,7 +81,7 @@ pub fn clean(ws: &Workspace<'_>, opts: &CleanOptions<'_>) -> CargoResult<()> {
                                 ws.is_member(pkg),
                                 *unit_for,
                                 *mode,
-                                opts.release,
+                                build_profile.clone(),
                             )
                         };
                         units.push(Unit {
@@ -93,7 +98,7 @@ pub fn clean(ws: &Workspace<'_>, opts: &CleanOptions<'_>) -> CargoResult<()> {
     }
 
     let mut build_config = BuildConfig::new(config, Some(1), &opts.target, CompileMode::Build)?;
-    build_config.release = opts.release;
+    build_config.build_profile = build_profile;
     let bcx = BuildContext::new(
         ws,
         &resolve,

--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -567,7 +567,7 @@ fn generate_targets<'a>(
             ws.is_member(pkg),
             unit_for,
             target_mode,
-            build_config.release,
+            build_config.build_profile.clone(),
         );
         Unit {
             pkg,

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -255,6 +255,7 @@ pub struct TomlProfiles {
     pub bench: Option<TomlProfile>,
     pub dev: Option<TomlProfile>,
     pub release: Option<TomlProfile>,
+    pub custom: Option<BTreeMap<String, TomlProfile>>,
 }
 
 impl TomlProfiles {
@@ -395,6 +396,7 @@ pub struct TomlProfile {
     pub incremental: Option<bool>,
     pub overrides: Option<BTreeMap<ProfilePackageSpec, TomlProfile>>,
     pub build_override: Option<Box<TomlProfile>>,
+    pub inherits: Option<String>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Ord, PartialOrd, Hash)]


### PR DESCRIPTION
This allows creating custom profiles that inherit from other profiles.

For example, one can have a release-lto profile that looks like this:

    [profile.custom.release-lto]
    inherits = "release"
    lto = true

The profile name will also carry itself into the output directory name
so that the different build outputs can be cached independently from
one another.

So in effect, at the `target` directory, a name will be created for
the new profile, in addition to the 'debug' and 'release' builds:

```
    $ cargo build --profile release-lto
    $ ls -l target
    debug release release-lto
```