### PR TITLE
Cargo test quicker by not building untested examples

### DIFF
--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -764,10 +764,7 @@ fn resolve_all_features(
 fn filter_default_targets(targets: &[Target], mode: CompileMode) -> Vec<&Target> {
     match mode {
         CompileMode::Bench => targets.iter().filter(|t| t.benched()).collect(),
-        CompileMode::Test => targets
-            .iter()
-            .filter(|t| t.tested() || t.is_example())
-            .collect(),
+        CompileMode::Test => targets.iter().filter(|t| t.tested()).collect(),
         CompileMode::Build | CompileMode::Check { .. } => targets
             .iter()
             .filter(|t| t.is_bin() || t.is_lib())

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -1955,7 +1955,7 @@ fn explicit_examples() {
         )
         .build();
 
-    p.cargo("test -v").run();
+    p.cargo("build --examples").run();
     p.process(&p.bin("examples/hello"))
         .with_stdout("Hello, World!\n")
         .run();
@@ -2126,7 +2126,7 @@ fn implicit_examples() {
         )
         .build();
 
-    p.cargo("test").run();
+    p.cargo("build --examples").run();
     p.process(&p.bin("examples/hello"))
         .with_stdout("Hello, World!\n")
         .run();
@@ -2739,13 +2739,13 @@ fn example_bin_same_name() {
         .file("examples/foo.rs", "fn main() {}")
         .build();
 
-    p.cargo("test --no-run -v").run();
+    p.cargo("build --examples").run();
 
     assert!(!p.bin("foo").is_file());
     // We expect a file of the form bin/foo-{metadata_hash}
     assert!(p.bin("examples/foo").is_file());
 
-    p.cargo("test --no-run -v").run();
+    p.cargo("build --examples").run();
 
     assert!(!p.bin("foo").is_file());
     // We expect a file of the form bin/foo-{metadata_hash}
@@ -4211,7 +4211,7 @@ fn inferred_examples() {
         .file("examples/baz/main.rs", "fn main() {}")
         .build();
 
-    p.cargo("test").run();
+    p.cargo("build --examples").run();
     assert!(p.bin("examples/bar").is_file());
     assert!(p.bin("examples/baz").is_file());
 }

--- a/tests/testsuite/profile_targets.rs
+++ b/tests/testsuite/profile_targets.rs
@@ -300,7 +300,6 @@ fn profile_selection_test() {
 [RUNNING] `[..] rustc --crate-name foo src/lib.rs [..]--crate-type lib --emit=dep-info,link -C codegen-units=1 -C debuginfo=2 [..]
 [RUNNING] `[..] rustc --crate-name foo src/lib.rs [..]--emit=dep-info,link -C codegen-units=3 -C debuginfo=2 --test [..]
 [RUNNING] `[..] rustc --crate-name test1 tests/test1.rs [..]--emit=dep-info,link -C codegen-units=3 -C debuginfo=2 --test [..]
-[RUNNING] `[..] rustc --crate-name ex1 examples/ex1.rs [..]--crate-type bin --emit=dep-info,link -C codegen-units=1 -C debuginfo=2 [..]
 [RUNNING] `[..] rustc --crate-name foo src/main.rs [..]--emit=dep-info,link -C codegen-units=3 -C debuginfo=2 --test [..]
 [RUNNING] `[..] rustc --crate-name foo src/main.rs [..]--crate-type bin --emit=dep-info,link -C panic=abort -C codegen-units=1 -C debuginfo=2 [..]
 [FINISHED] dev [unoptimized + debuginfo] [..]
@@ -366,7 +365,6 @@ fn profile_selection_test_release() {
 [RUNNING] `[..] rustc --crate-name foo src/lib.rs [..]--emit=dep-info,link -C opt-level=3 -C codegen-units=4 --test [..]
 [RUNNING] `[..] rustc --crate-name test1 tests/test1.rs [..]--emit=dep-info,link -C opt-level=3 -C codegen-units=4 --test [..]
 [RUNNING] `[..] rustc --crate-name foo src/main.rs [..]--emit=dep-info,link -C opt-level=3 -C codegen-units=4 --test [..]
-[RUNNING] `[..] rustc --crate-name ex1 examples/ex1.rs [..]--crate-type bin --emit=dep-info,link -C opt-level=3 -C codegen-units=2 [..]
 [RUNNING] `[..] rustc --crate-name foo src/main.rs [..]--crate-type bin --emit=dep-info,link -C opt-level=3 -C panic=abort -C codegen-units=2 [..]
 [FINISHED] release [optimized] [..]
 [RUNNING] `[..]/deps/foo-[..]`

--- a/tests/testsuite/test.rs
+++ b/tests/testsuite/test.rs
@@ -1429,9 +1429,7 @@ fn test_run_implicit_example_target() {
         )
         .build();
 
-    // Compiles myexm1 as normal, but does not run it.
     prj.cargo("test -v")
-        .with_stderr_contains("[RUNNING] `rustc [..]myexm1.rs [..]--crate-type bin[..]")
         .with_stderr_contains("[RUNNING] `rustc [..]myexm2.rs [..]--test[..]")
         .with_stderr_does_not_contain("[RUNNING] [..]myexm1-[..]")
         .with_stderr_contains("[RUNNING] [..]target/debug/examples/myexm2-[..]")
@@ -1787,18 +1785,13 @@ fn example_bin_same_name() {
             "\
 [COMPILING] foo v0.0.1 ([CWD])
 [RUNNING] `rustc [..]`
-[RUNNING] `rustc [..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
 
     assert!(!p.bin("foo").is_file());
-    assert!(p.bin("examples/foo").is_file());
-
-    p.process(&p.bin("examples/foo"))
-        .with_stdout("example\n")
-        .run();
+    assert!(!p.bin("examples/foo").is_file());
 
     p.cargo("run")
         .with_stderr(
@@ -1810,64 +1803,6 @@ fn example_bin_same_name() {
         .with_stdout("bin")
         .run();
     assert!(p.bin("foo").is_file());
-}
-
-#[test]
-fn test_with_example_twice() {
-    let p = project()
-        .file("src/bin/foo.rs", r#"fn main() { println!("bin"); }"#)
-        .file("examples/foo.rs", r#"fn main() { println!("example"); }"#)
-        .build();
-
-    println!("first");
-    p.cargo("test -v").run();
-    assert!(p.bin("examples/foo").is_file());
-    println!("second");
-    p.cargo("test -v").run();
-    assert!(p.bin("examples/foo").is_file());
-}
-
-#[test]
-fn example_with_dev_dep() {
-    let p = project()
-        .file(
-            "Cargo.toml",
-            r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-
-            [lib]
-            name = "foo"
-            test = false
-            doctest = false
-
-            [dev-dependencies.a]
-            path = "a"
-        "#,
-        )
-        .file("src/lib.rs", "")
-        .file(
-            "examples/ex.rs",
-            "#[allow(unused_extern_crates)] extern crate a; fn main() {}",
-        )
-        .file("a/Cargo.toml", &basic_manifest("a", "0.0.1"))
-        .file("a/src/lib.rs", "")
-        .build();
-
-    p.cargo("test -v")
-        .with_stderr(
-            "\
-[..]
-[..]
-[..]
-[..]
-[RUNNING] `rustc --crate-name ex [..] --extern a=[..]`
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
-",
-        )
-        .run();
 }
 
 #[test]


### PR DESCRIPTION
(TIL `cargo test --tests` runs test-enabled examples.)

Pushes forward from #5464
Fixes #6675
r? @ehuss