### PR TITLE
Don't retry invalid credentials from git credential helpers

### DIFF
--- a/src/cargo/sources/git/utils.rs
+++ b/src/cargo/sources/git/utils.rs
@@ -451,6 +451,7 @@ where
     let mut ssh_agent_attempts = Vec::new();
     let mut any_attempts = false;
     let mut tried_sshkey = false;
+    let mut tried_cred_helper = false;
 
     let mut res = f(&mut |url, username, allowed| {
         any_attempts = true;
@@ -503,7 +504,8 @@ where
         // but we currently don't! Right now the only way we support fetching a
         // plaintext password is through the `credential.helper` support, so
         // fetch that here.
-        if allowed.contains(git2::CredentialType::USER_PASS_PLAINTEXT) {
+        if allowed.contains(git2::CredentialType::USER_PASS_PLAINTEXT) && !tried_cred_helper {
+            tried_cred_helper = true;
             let r = git2::Cred::credential_helper(cfg, url, username);
             cred_helper_bad = Some(r.is_err());
             return r;


### PR DESCRIPTION
If a git credential helper returns invalid credentials, we currently get stuck in an infinite retry loop by calling the credentials callback over and over, each time returning the same invalid credentials. This change means we only invoke the credential helper once.

## How to reproduce

1. Create a git credential store with some invalid credentials:

```
echo "https://example-user:invalid-credentials@github.com" > ~/invalid-store
```

2. Tell git to use that as your credential store by adding this to your `~/.gitconfig`:

```
[credential]
	helper = store --file=/home/<user>/invalid-store
```

3. Add an invalid Git dependency to a `Cargo.toml`. For instance:

```
[dependencies.fake-repository]
git = "https://github.com/fake-user/fake-repository"
version = ">= 1.0.0"
```

4. Try to update the dependencies (e.g. with `cargo update` or `cargo build`).

Cargo hangs forever, retrying the invalid credentials.