### PR TITLE
convert unused doc comments to regular comments

### DIFF
--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -150,17 +150,17 @@ macro_rules! stab {
     };
 }
 
-/// A listing of all features in Cargo
-///
-/// "look here"
-///
-/// This is the macro that lists all stable and unstable features in Cargo.
-/// You'll want to add to this macro whenever you add a feature to Cargo, also
-/// following the directions above.
-///
-/// Note that all feature names here are valid Rust identifiers, but the `_`
-/// character is translated to `-` when specified in the `cargo-features`
-/// manifest entry in `Cargo.toml`.
+// A listing of all features in Cargo.
+//
+// "look here"
+//
+// This is the macro that lists all stable and unstable features in Cargo.
+// You'll want to add to this macro whenever you add a feature to Cargo, also
+// following the directions above.
+//
+// Note that all feature names here are valid Rust identifiers, but the `_`
+// character is translated to `-` when specified in the `cargo-features`
+// manifest entry in `Cargo.toml`.
 features! {
     pub struct Features {
 

--- a/tests/testsuite/resolve.rs
+++ b/tests/testsuite/resolve.rs
@@ -14,13 +14,13 @@ use crate::support::resolver::{
 
 use proptest::{prelude::*, *};
 
-/// NOTE: proptest is a form of fuzz testing. It generates random input and makes sure that
-/// certain universal truths are upheld. Therefore, it can pass when there is a problem,
-/// but if it fails then there really is something wrong. When testing something as
-/// complicated as the resolver, the problems can be very subtle and hard to generate.
-/// We have had a history of these tests only failing on PRs long after a bug is introduced.
-/// If you have one of these test fail please report it on #6258,
-/// and if you did not change the resolver then feel free to retry without concern.
+// NOTE: proptest is a form of fuzz testing. It generates random input and makes sure that
+// certain universal truths are upheld. Therefore, it can pass when there is a problem,
+// but if it fails then there really is something wrong. When testing something as
+// complicated as the resolver, the problems can be very subtle and hard to generate.
+// We have had a history of these tests only failing on PRs long after a bug is introduced.
+// If you have one of these test fail please report it on #6258,
+// and if you did not change the resolver then feel free to retry without concern.
 proptest! {
     #![proptest_config(ProptestConfig {
         max_shrink_iters:


### PR DESCRIPTION
rust-lang/rust#57882 will cause the unused_doc_comments lint to fire when doc comments are present on macro expansions, where they aren't used. Since cargo uses `#![deny(warnings)]` in tests, the tests fail to build with that change.

This PR changes the unused doc comments to be regular comments so the warning isn't triggered.

It would be helpful to update cargo in the rust repo after this change, since this blocks the above PR from landing.