### PR TITLE
Emit warning on misspelled environment variables

### DIFF
--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -245,6 +245,27 @@ pub fn compile_ws<'a>(
         ref export_dir,
     } = *options;
 
+    match build_config.mode {
+        CompileMode::Test
+        | CompileMode::Build
+        | CompileMode::Check { .. }
+        | CompileMode::Bench
+        | CompileMode::RunCustomBuild => {
+            if std::env::var("RUST_FLAGS").is_ok() {
+                config.shell().warn(
+                    "Cargo does not read `RUST_FLAGS` environment variable. Did you mean `RUSTFLAGS`?",
+                )?;
+            }
+        }
+        CompileMode::Doc { .. } | CompileMode::Doctest => {
+            if std::env::var("RUSTDOC_FLAGS").is_ok() {
+                config.shell().warn(
+                    "Cargo does not read `RUSTDOC_FLAGS` environment variable. Did you mean `RUSTDOCFLAGS`?"
+                )?;
+            }
+        }
+    }
+
     let default_arch_kind = if build_config.requested_target.is_some() {
         Kind::Target
     } else {

--- a/tests/testsuite/rustdocflags.rs
+++ b/tests/testsuite/rustdocflags.rs
@@ -85,3 +85,13 @@ fn rustdocflags_passed_to_rustdoc_through_cargo_test_only_once() {
         .env("RUSTDOCFLAGS", "--markdown-no-toc")
         .run();
 }
+
+#[test]
+fn rustdocflags_misspelled() {
+    let p = project().file("src/main.rs", "fn main() { }").build();
+
+    p.cargo("doc")
+        .env("RUSTDOC_FLAGS", "foo")
+        .with_stderr_contains("[WARNING] Cargo does not read `RUSTDOC_FLAGS` environment variable. Did you mean `RUSTDOCFLAGS`?")
+        .run();
+}

--- a/tests/testsuite/rustflags.rs
+++ b/tests/testsuite/rustflags.rs
@@ -1332,9 +1332,9 @@ fn env_rustflags_misspelled() {
 
     for cmd in &["check", "build", "run", "test", "bench"] {
         p.cargo(cmd)
-        .env("RUST_FLAGS", "foo")
-        .with_stderr_contains("[WARNING] Cargo does not read `RUST_FLAGS` environment variable. Did you mean `RUSTFLAGS`?")
-        .run();
+            .env("RUST_FLAGS", "foo")
+            .with_stderr_contains("[WARNING] Cargo does not read `RUST_FLAGS` environment variable. Did you mean `RUSTFLAGS`?")
+            .run();
     }
 }
 

--- a/tests/testsuite/rustflags.rs
+++ b/tests/testsuite/rustflags.rs
@@ -1325,3 +1325,37 @@ fn two_matching_in_config() {
     p1.cargo("run").run();
     p1.cargo("build").with_stderr("[FINISHED] [..]").run();
 }
+
+#[test]
+fn env_rustflags_misspelled() {
+    let p = project().file("src/main.rs", "fn main() { }").build();
+
+    for cmd in &["check", "build", "run", "test", "bench"] {
+        p.cargo(cmd)
+        .env("RUST_FLAGS", "foo")
+        .with_stderr_contains("[WARNING] Cargo does not read `RUST_FLAGS` environment variable. Did you mean `RUSTFLAGS`?")
+        .run();
+    }
+}
+
+#[test]
+fn env_rustflags_misspelled_build_script() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "foo"
+            version = "0.0.1"
+            build = "build.rs"
+        "#,
+        )
+        .file("src/lib.rs", "")
+        .file("build.rs", "fn main() { }")
+        .build();
+
+    p.cargo("build")
+        .env("RUST_FLAGS", "foo")
+        .with_stderr_contains("[WARNING] Cargo does not read `RUST_FLAGS` environment variable. Did you mean `RUSTFLAGS`?")
+        .run();
+}


### PR DESCRIPTION
This PR makes Cargo emit a warning when `RUST_FLAGS` or `RUSTDOC_FLAGS` environment variables are used instead of `RUSTFLAGS` or `RUSTDOCFLAGS`.

```shell
$ RUST_FLAGS=foo ./target/debug/cargo build
warning: Cargo does not read `RUST_FLAGS` environment variable. Did you mean `RUSTFLAGS`?
```

Fixes #6406