### PR TITLE
Bring multiple test filtering to test/bench

### DIFF
--- a/src/bin/cargo/commands/bench.rs
+++ b/src/bin/cargo/commands/bench.rs
@@ -8,7 +8,8 @@ pub fn cli() -> App {
         .about("Execute all benchmarks of a local package")
         .arg(
             Arg::with_name("BENCHNAME")
-                .help("If specified, only run benches containing this string in their names"),
+                .help("If specified, only run benches containing this string in their names")
+                .multiple(true),
         )
         .arg(
             Arg::with_name("args")
@@ -82,11 +83,10 @@ pub fn exec(config: &mut Config, args: &ArgMatches<'_>) -> CliResult {
         compile_opts,
     };
 
-    let bench_args = args.value_of("BENCHNAME").into_iter();
-    let bench_args = bench_args.chain(args.values_of("args").unwrap_or_default());
-    let bench_args = bench_args.collect::<Vec<_>>();
+    let bench_names = args.values_of("BENCHNAME").unwrap_or_default().collect::<Vec<_>>();
+    let bench_args = args.values_of("args").unwrap_or_default().collect::<Vec<_>>();
 
-    let err = ops::run_benches(&ws, &ops, &bench_args)?;
+    let err = ops::run_benches(&ws, &ops, &bench_names, &bench_args)?;
     match err {
         None => Ok(()),
         Some(err) => Err(match err.exit.as_ref().and_then(|e| e.code()) {

--- a/src/bin/cargo/commands/bench.rs
+++ b/src/bin/cargo/commands/bench.rs
@@ -82,17 +82,9 @@ pub fn exec(config: &mut Config, args: &ArgMatches<'_>) -> CliResult {
         compile_opts,
     };
 
-    let mut bench_args = vec![];
-    bench_args.extend(
-        args.value_of("BENCHNAME")
-            .into_iter()
-            .map(|s| s.to_string()),
-    );
-    bench_args.extend(
-        args.values_of("args")
-            .unwrap_or_default()
-            .map(|s| s.to_string()),
-    );
+    let bench_args = args.value_of("BENCHNAME").into_iter();
+    let bench_args = bench_args.chain(args.values_of("args").unwrap_or_default());
+    let bench_args = bench_args.collect::<Vec<_>>();
 
     let err = ops::run_benches(&ws, &ops, &bench_args)?;
     match err {

--- a/src/bin/cargo/commands/test.rs
+++ b/src/bin/cargo/commands/test.rs
@@ -97,13 +97,9 @@ pub fn exec(config: &mut Config, args: &ArgMatches<'_>) -> CliResult {
     // `TESTNAME` is actually an argument of the test binary, but it's
     // important, so we explicitly mention it and reconfigure.
     let test_name: Option<&str> = args.value_of("TESTNAME");
-    let mut test_args = vec![];
-    test_args.extend(test_name.into_iter().map(|s| s.to_string()));
-    test_args.extend(
-        args.values_of("args")
-            .unwrap_or_default()
-            .map(|s| s.to_string()),
-    );
+    let test_args = args.value_of("TESTNAME").into_iter();
+    let test_args = test_args.chain(args.values_of("args").unwrap_or_default());
+    let test_args = test_args.collect::<Vec<_>>();
 
     let no_run = args.is_present("no-run");
     let doc = args.is_present("doc");

--- a/src/cargo/ops/cargo_test.rs
+++ b/src/cargo/ops/cargo_test.rs
@@ -15,7 +15,7 @@ pub struct TestOptions<'a> {
 pub fn run_tests(
     ws: &Workspace<'_>,
     options: &TestOptions<'_>,
-    test_args: &[String],
+    test_args: &[&str],
 ) -> CargoResult<Option<CargoTestError>> {
     let compilation = compile_tests(ws, options)?;
 
@@ -42,16 +42,19 @@ pub fn run_tests(
 pub fn run_benches(
     ws: &Workspace<'_>,
     options: &TestOptions<'_>,
-    args: &[String],
+    args: &[&str],
 ) -> CargoResult<Option<CargoTestError>> {
-    let mut args = args.to_vec();
-    args.push("--bench".to_string());
     let compilation = compile_tests(ws, options)?;
 
     if options.no_run {
         return Ok(None);
     }
+
+    let mut args = args.to_vec();
+    args.push("--bench");
+
     let (test, errors) = run_unit_tests(options, &args, &compilation)?;
+
     match errors.len() {
         0 => Ok(None),
         _ => Ok(Some(CargoTestError::new(test, errors))),
@@ -72,7 +75,7 @@ fn compile_tests<'a>(
 /// Runs the unit and integration tests of a package.
 fn run_unit_tests(
     options: &TestOptions<'_>,
-    test_args: &[String],
+    test_args: &[&str],
     compilation: &Compilation<'_>,
 ) -> CargoResult<(Test, Vec<ProcessError>)> {
     let config = options.compile_opts.config;
@@ -125,7 +128,7 @@ fn run_unit_tests(
 
 fn run_doc_tests(
     options: &TestOptions<'_>,
-    test_args: &[String],
+    test_args: &[&str],
     compilation: &Compilation<'_>,
 ) -> CargoResult<(Test, Vec<ProcessError>)> {
     let mut errors = Vec::new();

--- a/src/cargo/util/command_prelude.rs
+++ b/src/cargo/util/command_prelude.rs
@@ -481,10 +481,7 @@ impl<'a> ArgMatchesExt for ArgMatches<'a> {
 }
 
 pub fn values(args: &ArgMatches<'_>, name: &str) -> Vec<String> {
-    args.values_of(name)
-        .unwrap_or_default()
-        .map(|s| s.to_string())
-        .collect()
+    args._values_of(name)
 }
 
 #[derive(PartialEq, PartialOrd, Eq, Ord)]

--- a/src/doc/man/cargo-bench.adoc
+++ b/src/doc/man/cargo-bench.adoc
@@ -10,7 +10,7 @@ cargo-bench - Execute benchmarks of a package
 
 == SYNOPSIS
 
-`cargo bench [_OPTIONS_] [BENCHNAME] [-- _BENCH-OPTIONS_]`
+`cargo bench [_OPTIONS_] [BENCHNAME]... [-- _BENCH-OPTIONS_]`
 
 == DESCRIPTION
 

--- a/src/doc/man/cargo-test.adoc
+++ b/src/doc/man/cargo-test.adoc
@@ -10,7 +10,7 @@ cargo-test - Execute unit and integration tests of a package
 
 == SYNOPSIS
 
-`cargo test [_OPTIONS_] [TESTNAME] [-- _TEST-OPTIONS_]`
+`cargo test [_OPTIONS_] [TESTNAME]... [-- _TEST-OPTIONS_]`
 
 == DESCRIPTION
 

--- a/src/doc/man/generated/cargo-bench.html
+++ b/src/doc/man/generated/cargo-bench.html
@@ -6,7 +6,7 @@
 <h2 id="cargo_bench_synopsis">SYNOPSIS</h2>
 <div class="sectionbody">
 <div class="paragraph">
-<p><code>cargo bench [<em>OPTIONS</em>] [BENCHNAME] [-- <em>BENCH-OPTIONS</em>]</code></p>
+<p><code>cargo bench [<em>OPTIONS</em>] [BENCHNAME]&#8230;&#8203; [-- <em>BENCH-OPTIONS</em>]</code></p>
 </div>
 </div>
 </div>

--- a/src/doc/man/generated/cargo-test.html
+++ b/src/doc/man/generated/cargo-test.html
@@ -6,7 +6,7 @@
 <h2 id="cargo_test_synopsis">SYNOPSIS</h2>
 <div class="sectionbody">
 <div class="paragraph">
-<p><code>cargo test [<em>OPTIONS</em>] [TESTNAME] [-- <em>TEST-OPTIONS</em>]</code></p>
+<p><code>cargo test [<em>OPTIONS</em>] [TESTNAME]&#8230;&#8203; [-- <em>TEST-OPTIONS</em>]</code></p>
 </div>
 </div>
 </div>

--- a/src/etc/man/cargo-bench.1
+++ b/src/etc/man/cargo-bench.1
@@ -2,12 +2,12 @@
 .\"     Title: cargo-bench
 .\"    Author: [see the "AUTHOR(S)" section]
 .\" Generator: Asciidoctor 1.5.8
-.\"      Date: 2018-12-23
+.\"      Date: 2019-02-24
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "CARGO\-BENCH" "1" "2018-12-23" "\ \&" "\ \&"
+.TH "CARGO\-BENCH" "1" "2019-02-24" "\ \&" "\ \&"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0
@@ -31,7 +31,7 @@
 cargo\-bench \- Execute benchmarks of a package
 .SH "SYNOPSIS"
 .sp
-\fBcargo bench [\fIOPTIONS\fP] [BENCHNAME] [\-\- \fIBENCH\-OPTIONS\fP]\fP
+\fBcargo bench [\fIOPTIONS\fP] [BENCHNAME]... [\-\- \fIBENCH\-OPTIONS\fP]\fP
 .SH "DESCRIPTION"
 .sp
 Compile and execute benchmarks.

--- a/src/etc/man/cargo-test.1
+++ b/src/etc/man/cargo-test.1
@@ -2,12 +2,12 @@
 .\"     Title: cargo-test
 .\"    Author: [see the "AUTHOR(S)" section]
 .\" Generator: Asciidoctor 1.5.8
-.\"      Date: 2018-12-23
+.\"      Date: 2019-02-24
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "CARGO\-TEST" "1" "2018-12-23" "\ \&" "\ \&"
+.TH "CARGO\-TEST" "1" "2019-02-24" "\ \&" "\ \&"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0
@@ -31,7 +31,7 @@
 cargo\-test \- Execute unit and integration tests of a package
 .SH "SYNOPSIS"
 .sp
-\fBcargo test [\fIOPTIONS\fP] [TESTNAME] [\-\- \fITEST\-OPTIONS\fP]\fP
+\fBcargo test [\fIOPTIONS\fP] [TESTNAME]... [\-\- \fITEST\-OPTIONS\fP]\fP
 .SH "DESCRIPTION"
 .sp
 Compile and execute unit and integration tests.

--- a/tests/testsuite/test.rs
+++ b/tests/testsuite/test.rs
@@ -620,10 +620,43 @@ fn pass_through_command_line() {
         .run();
 }
 
-// Regression test for running cargo-test twice with
-// tests in an rlib
+#[test]
+fn specify_multiple_tests() {
+    let p = project()
+        .file("src/lib.rs", "#[test] fn foo() {} #[test] fn bar() {}")
+        .build();
+
+    p.cargo("test foo bar")
+        .with_stderr(
+            "\
+[COMPILING] foo v0.0.1 ([CWD])
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[RUNNING] target/debug/deps/foo-[..][EXE]
+[RUNNING] target/debug/deps/foo-[..][EXE]
+",
+        )
+        .with_stdout(
+            "
+running 1 test
+test foo ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 1 filtered out
+
+
+running 1 test
+test bar ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 1 filtered out
+
+",
+        )
+        .run();
+}
+
 #[test]
 fn cargo_test_twice() {
+    // Regression test for running cargo-test twice with
+    // tests in an rlib
     let p = project()
         .file("Cargo.toml", &basic_lib_manifest("foo"))
         .file(


### PR DESCRIPTION
When more than one TESTNAME/BENCHNAME is specified, run the tests / doctests / benches once per name, passing the rest of the arguments to each invocation.  So, for instance

    cargo test foo bar --nocapture

Will test foo with --nocapture first and then bar with --nocapture.