### PR TITLE
Ignore ws-roots if there is a manifest-error

### DIFF
--- a/tests/testsuite/workspaces.rs
+++ b/tests/testsuite/workspaces.rs
@@ -1233,7 +1233,7 @@ fn workspace_with_transitive_dev_deps() {
 }
 
 #[test]
-fn error_if_parent_cargo_toml_is_invalid() {
+fn warn_if_parent_cargo_toml_is_invalid() {
     let p = project()
         .file("Cargo.toml", "Totally not a TOML file")
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
@@ -1242,8 +1242,7 @@ fn error_if_parent_cargo_toml_is_invalid() {
 
     p.cargo("build")
         .cwd(p.root().join("bar"))
-        .with_status(101)
-        .with_stderr_contains("[ERROR] failed to parse manifest at `[..]`")
+        .with_stderr_contains("[WARNING] Ignoring [..]foo/Cargo.toml[..]")
         .run();
 }
 


### PR DESCRIPTION
Cargo will try to figure out if the current crate is part of a workspace. Stray manifests in parent paths will be discovered greedily and errors in parsing those manifests are considered hard errors.

This PR may be a sufficient fix to issue #6706 by turning the hard errors into warnings. Errors are not silenced, so people who *expect* to be in a workspace can still find their way around.
