### PR TITLE
Include build script execution in the fingerprint.

### DIFF
--- a/src/cargo/core/compiler/context/compilation_files.rs
+++ b/src/cargo/core/compiler/context/compilation_files.rs
@@ -186,7 +186,8 @@ impl<'a, 'cfg: 'a> CompilationFiles<'a, 'cfg> {
         self.layout(unit.kind).fingerprint().join(dir)
     }
 
-    /// Returns the appropriate directory layout for either a plugin or not.
+    /// Returns the directory where a compiled build script is stored.
+    /// `/path/to/target/{debug,release}/build/PKG-HASH`
     pub fn build_script_dir(&self, unit: &Unit<'a>) -> PathBuf {
         assert!(unit.target.is_custom_build());
         assert!(!unit.mode.is_run_custom_build());
@@ -194,12 +195,20 @@ impl<'a, 'cfg: 'a> CompilationFiles<'a, 'cfg> {
         self.layout(Kind::Host).build().join(dir)
     }
 
-    /// Returns the appropriate directory layout for either a plugin or not.
-    pub fn build_script_out_dir(&self, unit: &Unit<'a>) -> PathBuf {
+    /// Returns the directory where information about running a build script
+    /// is stored.
+    /// `/path/to/target/{debug,release}/build/PKG-HASH`
+    pub fn build_script_run_dir(&self, unit: &Unit<'a>) -> PathBuf {
         assert!(unit.target.is_custom_build());
         assert!(unit.mode.is_run_custom_build());
         let dir = self.pkg_dir(unit);
-        self.layout(unit.kind).build().join(dir).join("out")
+        self.layout(unit.kind).build().join(dir)
+    }
+
+    /// Returns the "OUT_DIR" directory for running a build script.
+    /// `/path/to/target/{debug,release}/build/PKG-HASH/out`
+    pub fn build_script_out_dir(&self, unit: &Unit<'a>) -> PathBuf {
+        self.build_script_run_dir(unit).join("out")
     }
 
     /// Returns the file stem for a given target/profile combo (with metadata).

--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -239,6 +239,7 @@ fn rustc<'a, 'cfg>(
         .get_cwd()
         .unwrap_or_else(|| cx.bcx.config.cwd())
         .to_path_buf();
+    let fingerprint_dir = cx.files().fingerprint_dir(unit);
 
     return Ok(Work::new(move |state| {
         // Only at runtime have we discovered what the extra -L and -l
@@ -289,7 +290,7 @@ fn rustc<'a, 'cfg>(
         }
 
         state.running(&rustc);
-        let timestamp = paths::get_current_filesystem_time(&dep_info_loc)?;
+        let timestamp = paths::set_invocation_time(&fingerprint_dir)?;
         if json_messages {
             exec.exec_json(
                 rustc,

--- a/src/cargo/util/paths.rs
+++ b/src/cargo/util/paths.rs
@@ -187,16 +187,17 @@ pub fn mtime(path: &Path) -> CargoResult<FileTime> {
     Ok(FileTime::from_last_modification_time(&meta))
 }
 
-/// get `FileTime::from_system_time(SystemTime::now());` using the exact clock that this file system is using.
-pub fn get_current_filesystem_time(path: &Path) -> CargoResult<FileTime> {
+/// Record the current time on the filesystem (using the filesystem's clock)
+/// using a file at the given directory. Returns the current time.
+pub fn set_invocation_time(path: &Path) -> CargoResult<FileTime> {
     // note that if `FileTime::from_system_time(SystemTime::now());` is determined to be sufficient,
     // then this can be removed.
-    let timestamp = path.with_file_name("invoked.timestamp");
+    let timestamp = path.join("invoked.timestamp");
     write(
         &timestamp,
         b"This file has an mtime of when this was started.",
     )?;
-    Ok(mtime(&timestamp)?)
+    mtime(&timestamp)
 }
 
 #[cfg(unix)]

--- a/tests/testsuite/freshness.rs
+++ b/tests/testsuite/freshness.rs
@@ -1616,3 +1616,91 @@ fn rebuild_on_mid_build_file_modification() {
 
     t.join().ok().unwrap();
 }
+
+#[test]
+fn dirty_both_lib_and_test() {
+    // This tests that all artifacts that depend on the results of a build
+    // script will get rebuilt when the build script reruns, even for separate
+    // commands. It does the following:
+    //
+    // 1. Project "foo" has a build script which will compile a small
+    //    staticlib to link against. Normally this would use the `cc` crate,
+    //    but here we just use rustc to avoid the `cc` dependency.
+    // 2. Build the library.
+    // 3. Build the unit test. The staticlib intentionally has a bad value.
+    // 4. Rewrite the staticlib with the correct value.
+    // 5. Build the library again.
+    // 6. Build the unit test. This should recompile.
+
+    let slib = |n| {
+        format!(
+            r#"
+            #[no_mangle]
+            pub extern "C" fn doit() -> i32 {{
+                return {};
+            }}
+        "#,
+            n
+        )
+    };
+
+    let p = project()
+        .file(
+            "src/lib.rs",
+            r#"
+            extern "C" {
+                fn doit() -> i32;
+            }
+
+            #[test]
+            fn t1() {
+                assert_eq!(unsafe { doit() }, 1, "doit assert failure");
+            }
+        "#,
+        )
+        .file(
+            "build.rs",
+            r#"
+            use std::env;
+            use std::path::PathBuf;
+            use std::process::Command;
+
+            fn main() {
+                let rustc = env::var_os("RUSTC").unwrap();
+                let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
+                assert!(
+                    Command::new(rustc)
+                        .args(&[
+                            "--crate-type=staticlib",
+                            "--out-dir",
+                            out_dir.to_str().unwrap(),
+                            "slib.rs"
+                        ])
+                        .status()
+                        .unwrap()
+                        .success(),
+                    "slib build failed"
+                );
+                println!("cargo:rustc-link-lib=slib");
+                println!("cargo:rustc-link-search={}", out_dir.display());
+            }
+        "#,
+        )
+        .file("slib.rs", &slib(2))
+        .build();
+
+    p.cargo("build").run();
+
+    // 2 != 1
+    p.cargo("test --lib")
+        .with_status(101)
+        .with_stdout_contains("[..]doit assert failure[..]")
+        .run();
+
+    // Fix the mistake.
+    p.change_file("slib.rs", &slib(1));
+
+    p.cargo("build").run();
+    // This should recompile with the new static lib, and the test should pass.
+    p.cargo("test --lib").run();
+}


### PR DESCRIPTION
This adds information about the execution of a build script to the fingerprint. Previously, no information was included, and cargo relied on dirty propagation in `JobQueue` to trigger recompiles. However, if two separate targets are built via separate commands (such as `cargo build` then `cargo test`), the second command did not know that the build script was updated, and thus was incorrectly treated as "fresh".

This works by including the timestamp of the last time the build script was ran in the fingerprint. For overridden build scripts, it includes the replaced output.

Fixes #4979

