### PR TITLE
When running `cargo package -l` do not check for dependencies

### DIFF
--- a/src/cargo/ops/cargo_package.rs
+++ b/src/cargo/ops/cargo_package.rs
@@ -34,7 +34,9 @@ pub struct PackageOpts<'cfg> {
 static VCS_INFO_FILE: &'static str = ".cargo_vcs_info.json";
 
 pub fn package(ws: &Workspace<'_>, opts: &PackageOpts<'_>) -> CargoResult<Option<FileLock>> {
-    ops::resolve_ws(ws)?;
+    if ! opts.list {
+        ops::resolve_ws(ws)?;
+    }
     let pkg = ws.current()?;
     let config = ws.config();
 


### PR DESCRIPTION
It doesn't make sense and is also fixing problem when one overrides
crates.io registry with a folder and optional dependencies are missing.

Signed-off-by: Igor Gnatenko <i.gnatenko.brain@gmail.com>