### PR TITLE
.gitignore should end with a newline.

### DIFF
--- a/src/cargo/ops/cargo_new.rs
+++ b/src/cargo/ops/cargo_new.rs
@@ -438,10 +438,12 @@ impl IgnoreList {
     /// Return the correctly formatted content of the ignore file for the given
     /// version control system as `String`.
     fn format_new(&self, vcs: VersionControl) -> String {
-        match vcs {
-            VersionControl::Hg => self.hg_ignore.join("\n"),
-            _ => self.ignore.join("\n"),
-        }
+        let ignore_items = match vcs {
+            VersionControl::Hg => &self.hg_ignore,
+            _ => &self.ignore,
+        };
+
+        ignore_items.join("\n") + "\n"
     }
 
     /// format_existing is used to format the IgnoreList when the ignore file
@@ -459,15 +461,15 @@ impl IgnoreList {
 
         let mut out = "\n\n#Added by cargo\n\
                        #\n\
-                       #already existing elements are commented out\n"
+                       #already existing elements are commented out\n\n"
             .to_string();
 
         for item in ignore_items {
-            out.push('\n');
             if existing_items.contains(item) {
                 out.push('#');
             }
-            out.push_str(item)
+            out.push_str(item);
+            out.push('\n');
         }
 
         out
@@ -543,7 +545,7 @@ fn mk(config: &Config, opts: &MkOptions<'_>) -> CargoResult<()> {
     // both `ignore` and `hgignore` are in sync.
     let mut ignore = IgnoreList::new();
     ignore.push("/target", "^target/");
-    ignore.push("**/*.rs.bk", "glob:*.rs.bk\n");
+    ignore.push("**/*.rs.bk", "glob:*.rs.bk");
     if !opts.bin {
         ignore.push("Cargo.lock", "glob:Cargo.lock");
     }

--- a/tests/testsuite/init.rs
+++ b/tests/testsuite/init.rs
@@ -79,7 +79,7 @@ fn simple_git_ignore_exists() {
          \n\
          #/target\n\
          **/*.rs.bk\n\
-         Cargo.lock",
+         Cargo.lock\n",
     );
 
     cargo_process("build").cwd(&paths::root().join("foo")).run();
@@ -450,6 +450,60 @@ fn mercurial_no_newline_in_new() {
         .read_to_string(&mut contents)
         .unwrap();
     assert!(!contents.starts_with('\n'));
+}
+
+#[test]
+fn terminating_newline_in_new_git_ignore() {
+    cargo_process("init --vcs git --lib")
+        .env("USER", "foo")
+        .run();
+
+    let content = fs::read_to_string(&paths::root().join(".gitignore")).unwrap();
+
+    let mut last_chars = content.chars().rev();
+    assert_eq!(last_chars.next(), Some('\n'));
+    assert_ne!(last_chars.next(), Some('\n'));
+}
+
+#[test]
+fn terminating_newline_in_new_mercurial_ignore() {
+    cargo_process("init --vcs hg --lib")
+        .env("USER", "foo")
+        .run();
+
+    let content = fs::read_to_string(&paths::root().join(".hgignore")).unwrap();
+
+    let mut last_chars = content.chars().rev();
+    assert_eq!(last_chars.next(), Some('\n'));
+    assert_ne!(last_chars.next(), Some('\n'));
+}
+
+#[test]
+fn terminating_newline_in_existing_git_ignore() {
+    fs::create_dir(&paths::root().join(".git")).unwrap();
+    fs::write(&paths::root().join(".gitignore"), b"first").unwrap();
+
+    cargo_process("init --lib").env("USER", "foo").run();
+
+    let content = fs::read_to_string(&paths::root().join(".gitignore")).unwrap();
+
+    let mut last_chars = content.chars().rev();
+    assert_eq!(last_chars.next(), Some('\n'));
+    assert_ne!(last_chars.next(), Some('\n'));
+}
+
+#[test]
+fn terminating_newline_in_existing_mercurial_ignore() {
+    fs::create_dir(&paths::root().join(".hg")).unwrap();
+    fs::write(&paths::root().join(".hgignore"), b"first").unwrap();
+
+    cargo_process("init --lib").env("USER", "foo").run();
+
+    let content = fs::read_to_string(&paths::root().join(".hgignore")).unwrap();
+
+    let mut last_chars = content.chars().rev();
+    assert_eq!(last_chars.next(), Some('\n'));
+    assert_ne!(last_chars.next(), Some('\n'));
 }
 
 #[test]

--- a/tests/testsuite/new.rs
+++ b/tests/testsuite/new.rs
@@ -89,7 +89,7 @@ fn simple_git() {
         .unwrap()
         .read_to_string(&mut contents)
         .unwrap();
-    assert_eq!(contents, "/target\n**/*.rs.bk\nCargo.lock",);
+    assert_eq!(contents, "/target\n**/*.rs.bk\nCargo.lock\n",);
 
     cargo_process("build").cwd(&paths::root().join("foo")).run();
 }


### PR DESCRIPTION
`.gitignore` as created by Cargo doesn't end with a newline, but it probably should.

Rationale:

  - [Why should text files end with a newline?][why]

Search terms:

  - `No newline at end of file` from Git


  [why]: https://stackoverflow.com/questions/729692/why-should-text-files-end-with-a-newline