### PR TITLE
Bugfix/crt static in config

### DIFF
--- a/src/cargo/core/compiler/build_context/mod.rs
+++ b/src/cargo/core/compiler/build_context/mod.rs
@@ -345,7 +345,12 @@ fn env_args(
             .map(str::trim)
             .filter(|s| !s.is_empty())
             .map(str::to_string);
-        return Ok(args.collect());
+
+        let rustflags: Vec<_> = args.collect();
+
+        if rustflags.len() > 0 {
+            return Ok(rustflags);
+        }
     }
 
     let mut rustflags = Vec::new();


### PR DESCRIPTION
I ran into an issue when compiling xz2 crate under Windows, where .cargo/config RUSTFLAGS does not set the correct env vars in the build (full details can be found at 
https://github.com/alexcrichton/xz2-rs/issues/46).

The problem seems to be that an empty env var will take precedence over the config file.

Cargo version is:
cargo 1.34.0-nightly (5c6aa46e6 2019-02-22)

I added a test for this and a small fix.