### PR TITLE
Minor doc fix for publish command synopsis

### DIFF
--- a/src/doc/man/cargo-publish.adoc
+++ b/src/doc/man/cargo-publish.adoc
@@ -9,7 +9,7 @@ cargo-publish - Upload a package to the registry
 
 == SYNOPSIS
 
-`cargo package [_OPTIONS_]`
+`cargo publish [_OPTIONS_]`
 
 == DESCRIPTION
 

--- a/src/doc/man/generated/cargo-publish.html
+++ b/src/doc/man/generated/cargo-publish.html
@@ -6,7 +6,7 @@
 <h2 id="cargo_publish_synopsis">SYNOPSIS</h2>
 <div class="sectionbody">
 <div class="paragraph">
-<p><code>cargo package [<em>OPTIONS</em>]</code></p>
+<p><code>cargo publish [<em>OPTIONS</em>]</code></p>
 </div>
 </div>
 </div>

--- a/src/etc/man/cargo-publish.1
+++ b/src/etc/man/cargo-publish.1
@@ -31,7 +31,7 @@
 cargo\-publish \- Upload a package to the registry
 .SH "SYNOPSIS"
 .sp
-\fBcargo package [\fIOPTIONS\fP]\fP
+\fBcargo publish [\fIOPTIONS\fP]\fP
 .SH "DESCRIPTION"
 .sp
 This command will create a distributable, compressed \fB.crate\fP file with the


### PR DESCRIPTION
I think the synopsis for the [publish command doc]( https://doc.rust-lang.org/stable/cargo/commands/cargo-publish.html) should be `cargo publish` but it currently has `package` (screenshot below). 

Took a shot at making the change, not positive I did it the correct way though 😄   

![image](https://user-images.githubusercontent.com/13042488/54401497-e8b8b000-4695-11e9-872a-b467968af203.png)

