### PR TITLE
[backport] Fix resolving yanked crates when using a local registry.

### DIFF
--- a/src/cargo/core/source/source_id.rs
+++ b/src/cargo/core/source/source_id.rs
@@ -283,7 +283,12 @@ impl SourceId {
                     Ok(p) => p,
                     Err(()) => panic!("path sources cannot be remote"),
                 };
-                Ok(Box::new(RegistrySource::local(self, &path, config)))
+                Ok(Box::new(RegistrySource::local(
+                    self,
+                    &path,
+                    yanked_whitelist,
+                    config,
+                )))
             }
             Kind::Directory => {
                 let path = match self.inner.url.to_file_path() {

--- a/src/cargo/sources/registry/mod.rs
+++ b/src/cargo/sources/registry/mod.rs
@@ -404,7 +404,12 @@ impl<'cfg> RegistrySource<'cfg> {
         )
     }
 
-    pub fn local(source_id: SourceId, path: &Path, config: &'cfg Config) -> RegistrySource<'cfg> {
+    pub fn local(
+        source_id: SourceId,
+        path: &Path,
+        yanked_whitelist: &HashSet<PackageId>,
+        config: &'cfg Config,
+    ) -> RegistrySource<'cfg> {
         let name = short_name(source_id);
         let ops = local::LocalRegistry::new(path, config, &name);
         RegistrySource::new(
@@ -412,7 +417,7 @@ impl<'cfg> RegistrySource<'cfg> {
             config,
             &name,
             Box::new(ops),
-            &HashSet::new(),
+            yanked_whitelist,
             false,
         )
     }

--- a/tests/testsuite/doc.rs
+++ b/tests/testsuite/doc.rs
@@ -1372,7 +1372,7 @@ fn doc_message_format() {
 
     p.cargo("doc --message-format=json")
         .with_status(101)
-        .with_json(
+        .with_json_contains_unordered(
             r#"
             {
                 "message": {
@@ -1402,10 +1402,7 @@ fn short_message_format() {
     p.cargo("doc --message-format=short")
         .with_status(101)
         .with_stderr_contains(
-            "\
-src/lib.rs:4:6: error: `[bad_link]` cannot be resolved, ignoring it...
-error: Could not document `foo`.
-",
+            "src/lib.rs:4:6: error: `[bad_link]` cannot be resolved, ignoring it...",
         )
         .run();
 }


### PR DESCRIPTION
This is a backport #6742 to fix #6741.