### PR TITLE
Don't need extern crate in 2018

### DIFF
--- a/src/doc/src/guide/dependencies.md
+++ b/src/doc/src/guide/dependencies.md
@@ -35,6 +35,7 @@ crates:
 name = "hello_world"
 version = "0.1.0"
 authors = ["Your Name <you@example.com>"]
+edition = "2018"
 
 [dependencies]
 time = "0.1.12"
@@ -68,11 +69,9 @@ these dependencies we used.
 Now, if `regex` gets updated, we will still build with the same revision until
 we choose to `cargo update`.
 
-You can now use the `regex` library using `extern crate` in `main.rs`.
+You can now use the `regex` library in `main.rs`.
 
 ```rust
-extern crate regex;
-
 use regex::Regex;
 
 fn main() {


### PR DESCRIPTION
The example in 2.4 Dependencies uses `extern crate` which you don't need in edition 2018. As a beginner Rustacean I find it's confusing that so many examples are still using `extern crate` so here is a pull request to fix that. 