### PR TITLE
 Only apply default-members when building root manifest

### DIFF
--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -427,11 +427,15 @@ impl<'cfg> Workspace<'cfg> {
                 WorkspaceConfig::Root(ref root_config) => {
                     members_paths = root_config
                         .members_paths(root_config.members.as_ref().unwrap_or(&vec![]))?;
-                    default_members_paths = if let Some(ref default) = root_config.default_members {
-                        Some(root_config.members_paths(default)?)
+                    default_members_paths = if root_manifest_path == self.current_manifest {
+                        if let Some(ref default) = root_config.default_members {
+                            Some(root_config.members_paths(default)?)
+                        } else {
+                            None
+                        }
                     } else {
                         None
-                    }
+                    };
                 }
                 _ => failure::bail!(
                     "root of a workspace inferred but wasn't a root: {}",

--- a/src/doc/man/generated/cargo-bench.html
+++ b/src/doc/man/generated/cargo-bench.html
@@ -69,11 +69,16 @@ the executable as a whole.</p>
 <h3 id="cargo_bench_package_selection">Package Selection</h3>
 <div class="paragraph">
 <p>By default, when no package selection options are given, the packages selected
-depend on the current working directory. In the root of a virtual workspace,
-all workspace members are selected (<code>--all</code> is implied). Otherwise, only the
-package in the current directory will be selected. The default packages may be
-overridden with the <code>workspace.default-members</code> key in the root <code>Cargo.toml</code>
-manifest.</p>
+depend on the selected manifest file (based on the current working directory if
+<code>--manifest-path</code> is not given). If the manifest is the root of a workspace then
+the workspaces default members are selected, otherwise only the package defined
+by the manifest will be selected.</p>
+</div>
+<div class="paragraph">
+<p>The default members of a workspace can be set explicitly with the
+<code>workspace.default-members</code> key in the root manifest. If this is not set, a
+virtual workspace will include all workspace members (equivalent to passing
+<code>--all</code>), and a non-virtual workspace will include only the root crate itself.</p>
 </div>
 <div class="dlist">
 <dl>

--- a/src/doc/man/generated/cargo-build.html
+++ b/src/doc/man/generated/cargo-build.html
@@ -25,11 +25,16 @@
 <h3 id="cargo_build_package_selection">Package Selection</h3>
 <div class="paragraph">
 <p>By default, when no package selection options are given, the packages selected
-depend on the current working directory. In the root of a virtual workspace,
-all workspace members are selected (<code>--all</code> is implied). Otherwise, only the
-package in the current directory will be selected. The default packages may be
-overridden with the <code>workspace.default-members</code> key in the root <code>Cargo.toml</code>
-manifest.</p>
+depend on the selected manifest file (based on the current working directory if
+<code>--manifest-path</code> is not given). If the manifest is the root of a workspace then
+the workspaces default members are selected, otherwise only the package defined
+by the manifest will be selected.</p>
+</div>
+<div class="paragraph">
+<p>The default members of a workspace can be set explicitly with the
+<code>workspace.default-members</code> key in the root manifest. If this is not set, a
+virtual workspace will include all workspace members (equivalent to passing
+<code>--all</code>), and a non-virtual workspace will include only the root crate itself.</p>
 </div>
 <div class="dlist">
 <dl>

--- a/src/doc/man/generated/cargo-check.html
+++ b/src/doc/man/generated/cargo-check.html
@@ -29,11 +29,16 @@ not been modified.</p>
 <h3 id="cargo_check_package_selection">Package Selection</h3>
 <div class="paragraph">
 <p>By default, when no package selection options are given, the packages selected
-depend on the current working directory. In the root of a virtual workspace,
-all workspace members are selected (<code>--all</code> is implied). Otherwise, only the
-package in the current directory will be selected. The default packages may be
-overridden with the <code>workspace.default-members</code> key in the root <code>Cargo.toml</code>
-manifest.</p>
+depend on the selected manifest file (based on the current working directory if
+<code>--manifest-path</code> is not given). If the manifest is the root of a workspace then
+the workspaces default members are selected, otherwise only the package defined
+by the manifest will be selected.</p>
+</div>
+<div class="paragraph">
+<p>The default members of a workspace can be set explicitly with the
+<code>workspace.default-members</code> key in the root manifest. If this is not set, a
+virtual workspace will include all workspace members (equivalent to passing
+<code>--all</code>), and a non-virtual workspace will include only the root crate itself.</p>
 </div>
 <div class="dlist">
 <dl>

--- a/src/doc/man/generated/cargo-doc.html
+++ b/src/doc/man/generated/cargo-doc.html
@@ -45,11 +45,16 @@ is placed in <code>target/doc</code> in rustdoc&#8217;s usual format.</p>
 <h3 id="cargo_doc_package_selection">Package Selection</h3>
 <div class="paragraph">
 <p>By default, when no package selection options are given, the packages selected
-depend on the current working directory. In the root of a virtual workspace,
-all workspace members are selected (<code>--all</code> is implied). Otherwise, only the
-package in the current directory will be selected. The default packages may be
-overridden with the <code>workspace.default-members</code> key in the root <code>Cargo.toml</code>
-manifest.</p>
+depend on the selected manifest file (based on the current working directory if
+<code>--manifest-path</code> is not given). If the manifest is the root of a workspace then
+the workspaces default members are selected, otherwise only the package defined
+by the manifest will be selected.</p>
+</div>
+<div class="paragraph">
+<p>The default members of a workspace can be set explicitly with the
+<code>workspace.default-members</code> key in the root manifest. If this is not set, a
+virtual workspace will include all workspace members (equivalent to passing
+<code>--all</code>), and a non-virtual workspace will include only the root crate itself.</p>
 </div>
 <div class="dlist">
 <dl>

--- a/src/doc/man/generated/cargo-fix.html
+++ b/src/doc/man/generated/cargo-fix.html
@@ -100,11 +100,16 @@ current edition.</p>
 <h3 id="cargo_fix_package_selection">Package Selection</h3>
 <div class="paragraph">
 <p>By default, when no package selection options are given, the packages selected
-depend on the current working directory. In the root of a virtual workspace,
-all workspace members are selected (<code>--all</code> is implied). Otherwise, only the
-package in the current directory will be selected. The default packages may be
-overridden with the <code>workspace.default-members</code> key in the root <code>Cargo.toml</code>
-manifest.</p>
+depend on the selected manifest file (based on the current working directory if
+<code>--manifest-path</code> is not given). If the manifest is the root of a workspace then
+the workspaces default members are selected, otherwise only the package defined
+by the manifest will be selected.</p>
+</div>
+<div class="paragraph">
+<p>The default members of a workspace can be set explicitly with the
+<code>workspace.default-members</code> key in the root manifest. If this is not set, a
+virtual workspace will include all workspace members (equivalent to passing
+<code>--all</code>), and a non-virtual workspace will include only the root crate itself.</p>
 </div>
 <div class="dlist">
 <dl>

--- a/src/doc/man/generated/cargo-test.html
+++ b/src/doc/man/generated/cargo-test.html
@@ -75,11 +75,16 @@ the executable as a whole.</p>
 <h3 id="cargo_test_package_selection">Package Selection</h3>
 <div class="paragraph">
 <p>By default, when no package selection options are given, the packages selected
-depend on the current working directory. In the root of a virtual workspace,
-all workspace members are selected (<code>--all</code> is implied). Otherwise, only the
-package in the current directory will be selected. The default packages may be
-overridden with the <code>workspace.default-members</code> key in the root <code>Cargo.toml</code>
-manifest.</p>
+depend on the selected manifest file (based on the current working directory if
+<code>--manifest-path</code> is not given). If the manifest is the root of a workspace then
+the workspaces default members are selected, otherwise only the package defined
+by the manifest will be selected.</p>
+</div>
+<div class="paragraph">
+<p>The default members of a workspace can be set explicitly with the
+<code>workspace.default-members</code> key in the root manifest. If this is not set, a
+virtual workspace will include all workspace members (equivalent to passing
+<code>--all</code>), and a non-virtual workspace will include only the root crate itself.</p>
 </div>
 <div class="dlist">
 <dl>

--- a/src/doc/man/options-packages.adoc
+++ b/src/doc/man/options-packages.adoc
@@ -1,9 +1,13 @@
 By default, when no package selection options are given, the packages selected
-depend on the current working directory. In the root of a virtual workspace,
-all workspace members are selected (`--all` is implied). Otherwise, only the
-package in the current directory will be selected. The default packages may be
-overridden with the `workspace.default-members` key in the root `Cargo.toml`
-manifest.
+depend on the selected manifest file (based on the current working directory if
+`--manifest-path` is not given). If the manifest is the root of a workspace then
+the workspaces default members are selected, otherwise only the package defined
+by the manifest will be selected.
+
+The default members of a workspace can be set explicitly with the
+`workspace.default-members` key in the root manifest. If this is not set, a
+virtual workspace will include all workspace members (equivalent to passing
+`--all`), and a non-virtual workspace will include only the root crate itself.
 
 *-p* _SPEC_...::
 *--package* _SPEC_...::

--- a/src/etc/man/cargo-bench.1
+++ b/src/etc/man/cargo-bench.1
@@ -2,12 +2,12 @@
 .\"     Title: cargo-bench
 .\"    Author: [see the "AUTHOR(S)" section]
 .\" Generator: Asciidoctor 1.5.8
-.\"      Date: 2018-12-23
+.\"      Date: 2019-03-16
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "CARGO\-BENCH" "1" "2018-12-23" "\ \&" "\ \&"
+.TH "CARGO\-BENCH" "1" "2019-03-16" "\ \&" "\ \&"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0
@@ -77,11 +77,15 @@ the executable as a whole.
 .SS "Package Selection"
 .sp
 By default, when no package selection options are given, the packages selected
-depend on the current working directory. In the root of a virtual workspace,
-all workspace members are selected (\fB\-\-all\fP is implied). Otherwise, only the
-package in the current directory will be selected. The default packages may be
-overridden with the \fBworkspace.default\-members\fP key in the root \fBCargo.toml\fP
-manifest.
+depend on the selected manifest file (based on the current working directory if
+\fB\-\-manifest\-path\fP is not given). If the manifest is the root of a workspace then
+the workspaces default members are selected, otherwise only the package defined
+by the manifest will be selected.
+.sp
+The default members of a workspace can be set explicitly with the
+\fBworkspace.default\-members\fP key in the root manifest. If this is not set, a
+virtual workspace will include all workspace members (equivalent to passing
+\fB\-\-all\fP), and a non\-virtual workspace will include only the root crate itself.
 .sp
 \fB\-p\fP \fISPEC\fP..., \fB\-\-package\fP \fISPEC\fP...
 .RS 4

--- a/src/etc/man/cargo-build.1
+++ b/src/etc/man/cargo-build.1
@@ -2,12 +2,12 @@
 .\"     Title: cargo-build
 .\"    Author: [see the "AUTHOR(S)" section]
 .\" Generator: Asciidoctor 1.5.8
-.\"      Date: 2018-12-20
+.\"      Date: 2019-01-09
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "CARGO\-BUILD" "1" "2018-12-20" "\ \&" "\ \&"
+.TH "CARGO\-BUILD" "1" "2019-01-09" "\ \&" "\ \&"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0
@@ -39,11 +39,15 @@ Compile local packages and all of their dependencies.
 .SS "Package Selection"
 .sp
 By default, when no package selection options are given, the packages selected
-depend on the current working directory. In the root of a virtual workspace,
-all workspace members are selected (\fB\-\-all\fP is implied). Otherwise, only the
-package in the current directory will be selected. The default packages may be
-overridden with the \fBworkspace.default\-members\fP key in the root \fBCargo.toml\fP
-manifest.
+depend on the selected manifest file (based on the current working directory if
+\fB\-\-manifest\-path\fP is not given). If the manifest is the root of a workspace then
+the workspaces default members are selected, otherwise only the package defined
+by the manifest will be selected.
+.sp
+The default members of a workspace can be set explicitly with the
+\fBworkspace.default\-members\fP key in the root manifest. If this is not set, a
+virtual workspace will include all workspace members (equivalent to passing
+\fB\-\-all\fP), and a non\-virtual workspace will include only the root crate itself.
 .sp
 \fB\-p\fP \fISPEC\fP..., \fB\-\-package\fP \fISPEC\fP...
 .RS 4

--- a/src/etc/man/cargo-check.1
+++ b/src/etc/man/cargo-check.1
@@ -2,12 +2,12 @@
 .\"     Title: cargo-check
 .\"    Author: [see the "AUTHOR(S)" section]
 .\" Generator: Asciidoctor 1.5.8
-.\"      Date: 2018-12-20
+.\"      Date: 2019-01-09
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "CARGO\-CHECK" "1" "2018-12-20" "\ \&" "\ \&"
+.TH "CARGO\-CHECK" "1" "2019-01-09" "\ \&" "\ \&"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0
@@ -43,11 +43,15 @@ not been modified.
 .SS "Package Selection"
 .sp
 By default, when no package selection options are given, the packages selected
-depend on the current working directory. In the root of a virtual workspace,
-all workspace members are selected (\fB\-\-all\fP is implied). Otherwise, only the
-package in the current directory will be selected. The default packages may be
-overridden with the \fBworkspace.default\-members\fP key in the root \fBCargo.toml\fP
-manifest.
+depend on the selected manifest file (based on the current working directory if
+\fB\-\-manifest\-path\fP is not given). If the manifest is the root of a workspace then
+the workspaces default members are selected, otherwise only the package defined
+by the manifest will be selected.
+.sp
+The default members of a workspace can be set explicitly with the
+\fBworkspace.default\-members\fP key in the root manifest. If this is not set, a
+virtual workspace will include all workspace members (equivalent to passing
+\fB\-\-all\fP), and a non\-virtual workspace will include only the root crate itself.
 .sp
 \fB\-p\fP \fISPEC\fP..., \fB\-\-package\fP \fISPEC\fP...
 .RS 4

--- a/src/etc/man/cargo-clean.1
+++ b/src/etc/man/cargo-clean.1
@@ -2,12 +2,12 @@
 .\"     Title: cargo-clean
 .\"    Author: [see the "AUTHOR(S)" section]
 .\" Generator: Asciidoctor 1.5.8
-.\"      Date: 2018-12-20
+.\"      Date: 2019-01-09
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "CARGO\-CLEAN" "1" "2018-12-20" "\ \&" "\ \&"
+.TH "CARGO\-CLEAN" "1" "2019-01-09" "\ \&" "\ \&"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0

--- a/src/etc/man/cargo-doc.1
+++ b/src/etc/man/cargo-doc.1
@@ -2,12 +2,12 @@
 .\"     Title: cargo-doc
 .\"    Author: [see the "AUTHOR(S)" section]
 .\" Generator: Asciidoctor 1.5.8
-.\"      Date: 2018-12-20
+.\"      Date: 2019-01-09
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "CARGO\-DOC" "1" "2018-12-20" "\ \&" "\ \&"
+.TH "CARGO\-DOC" "1" "2019-01-09" "\ \&" "\ \&"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0
@@ -56,11 +56,15 @@ Include non\-public items in the documentation.
 .SS "Package Selection"
 .sp
 By default, when no package selection options are given, the packages selected
-depend on the current working directory. In the root of a virtual workspace,
-all workspace members are selected (\fB\-\-all\fP is implied). Otherwise, only the
-package in the current directory will be selected. The default packages may be
-overridden with the \fBworkspace.default\-members\fP key in the root \fBCargo.toml\fP
-manifest.
+depend on the selected manifest file (based on the current working directory if
+\fB\-\-manifest\-path\fP is not given). If the manifest is the root of a workspace then
+the workspaces default members are selected, otherwise only the package defined
+by the manifest will be selected.
+.sp
+The default members of a workspace can be set explicitly with the
+\fBworkspace.default\-members\fP key in the root manifest. If this is not set, a
+virtual workspace will include all workspace members (equivalent to passing
+\fB\-\-all\fP), and a non\-virtual workspace will include only the root crate itself.
 .sp
 \fB\-p\fP \fISPEC\fP..., \fB\-\-package\fP \fISPEC\fP...
 .RS 4

--- a/src/etc/man/cargo-fetch.1
+++ b/src/etc/man/cargo-fetch.1
@@ -2,12 +2,12 @@
 .\"     Title: cargo-fetch
 .\"    Author: [see the "AUTHOR(S)" section]
 .\" Generator: Asciidoctor 1.5.8
-.\"      Date: 2018-12-20
+.\"      Date: 2019-01-09
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "CARGO\-FETCH" "1" "2018-12-20" "\ \&" "\ \&"
+.TH "CARGO\-FETCH" "1" "2019-01-09" "\ \&" "\ \&"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0

--- a/src/etc/man/cargo-fix.1
+++ b/src/etc/man/cargo-fix.1
@@ -2,12 +2,12 @@
 .\"     Title: cargo-fix
 .\"    Author: [see the "AUTHOR(S)" section]
 .\" Generator: Asciidoctor 1.5.8
-.\"      Date: 2018-12-20
+.\"      Date: 2019-01-09
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "CARGO\-FIX" "1" "2018-12-20" "\ \&" "\ \&"
+.TH "CARGO\-FIX" "1" "2019-01-09" "\ \&" "\ \&"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0
@@ -113,11 +113,15 @@ Fix code even if the working directory has staged changes.
 .SS "Package Selection"
 .sp
 By default, when no package selection options are given, the packages selected
-depend on the current working directory. In the root of a virtual workspace,
-all workspace members are selected (\fB\-\-all\fP is implied). Otherwise, only the
-package in the current directory will be selected. The default packages may be
-overridden with the \fBworkspace.default\-members\fP key in the root \fBCargo.toml\fP
-manifest.
+depend on the selected manifest file (based on the current working directory if
+\fB\-\-manifest\-path\fP is not given). If the manifest is the root of a workspace then
+the workspaces default members are selected, otherwise only the package defined
+by the manifest will be selected.
+.sp
+The default members of a workspace can be set explicitly with the
+\fBworkspace.default\-members\fP key in the root manifest. If this is not set, a
+virtual workspace will include all workspace members (equivalent to passing
+\fB\-\-all\fP), and a non\-virtual workspace will include only the root crate itself.
 .sp
 \fB\-p\fP \fISPEC\fP..., \fB\-\-package\fP \fISPEC\fP...
 .RS 4

--- a/src/etc/man/cargo-generate-lockfile.1
+++ b/src/etc/man/cargo-generate-lockfile.1
@@ -2,12 +2,12 @@
 .\"     Title: cargo-generate-lockfile
 .\"    Author: [see the "AUTHOR(S)" section]
 .\" Generator: Asciidoctor 1.5.8
-.\"      Date: 2018-12-20
+.\"      Date: 2019-01-09
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "CARGO\-GENERATE\-LOCKFILE" "1" "2018-12-20" "\ \&" "\ \&"
+.TH "CARGO\-GENERATE\-LOCKFILE" "1" "2019-01-09" "\ \&" "\ \&"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0

--- a/src/etc/man/cargo-help.1
+++ b/src/etc/man/cargo-help.1
@@ -2,12 +2,12 @@
 .\"     Title: cargo-help
 .\"    Author: [see the "AUTHOR(S)" section]
 .\" Generator: Asciidoctor 1.5.8
-.\"      Date: 2018-12-20
+.\"      Date: 2019-01-09
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "CARGO\-HELP" "1" "2018-12-20" "\ \&" "\ \&"
+.TH "CARGO\-HELP" "1" "2019-01-09" "\ \&" "\ \&"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0

--- a/src/etc/man/cargo-init.1
+++ b/src/etc/man/cargo-init.1
@@ -2,12 +2,12 @@
 .\"     Title: cargo-init
 .\"    Author: [see the "AUTHOR(S)" section]
 .\" Generator: Asciidoctor 1.5.8
-.\"      Date: 2019-01-23
+.\"      Date: 2019-01-09
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "CARGO\-INIT" "1" "2019-01-23" "\ \&" "\ \&"
+.TH "CARGO\-INIT" "1" "2019-01-09" "\ \&" "\ \&"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0

--- a/src/etc/man/cargo-install.1
+++ b/src/etc/man/cargo-install.1
@@ -2,12 +2,12 @@
 .\"     Title: cargo-install
 .\"    Author: [see the "AUTHOR(S)" section]
 .\" Generator: Asciidoctor 1.5.8
-.\"      Date: 2019-01-23
+.\"      Date: 2019-01-09
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "CARGO\-INSTALL" "1" "2019-01-23" "\ \&" "\ \&"
+.TH "CARGO\-INSTALL" "1" "2019-01-09" "\ \&" "\ \&"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0

--- a/src/etc/man/cargo-locate-project.1
+++ b/src/etc/man/cargo-locate-project.1
@@ -2,12 +2,12 @@
 .\"     Title: cargo-locate-project
 .\"    Author: [see the "AUTHOR(S)" section]
 .\" Generator: Asciidoctor 1.5.8
-.\"      Date: 2018-12-20
+.\"      Date: 2019-01-09
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "CARGO\-LOCATE\-PROJECT" "1" "2018-12-20" "\ \&" "\ \&"
+.TH "CARGO\-LOCATE\-PROJECT" "1" "2019-01-09" "\ \&" "\ \&"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0

--- a/src/etc/man/cargo-login.1
+++ b/src/etc/man/cargo-login.1
@@ -2,12 +2,12 @@
 .\"     Title: cargo-login
 .\"    Author: [see the "AUTHOR(S)" section]
 .\" Generator: Asciidoctor 1.5.8
-.\"      Date: 2019-01-23
+.\"      Date: 2019-01-09
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "CARGO\-LOGIN" "1" "2019-01-23" "\ \&" "\ \&"
+.TH "CARGO\-LOGIN" "1" "2019-01-09" "\ \&" "\ \&"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0

--- a/src/etc/man/cargo-metadata.1
+++ b/src/etc/man/cargo-metadata.1
@@ -2,12 +2,12 @@
 .\"     Title: cargo-metadata
 .\"    Author: [see the "AUTHOR(S)" section]
 .\" Generator: Asciidoctor 1.5.8
-.\"      Date: 2019-01-05
+.\"      Date: 2019-01-09
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "CARGO\-METADATA" "1" "2019-01-05" "\ \&" "\ \&"
+.TH "CARGO\-METADATA" "1" "2019-01-09" "\ \&" "\ \&"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0

--- a/src/etc/man/cargo-new.1
+++ b/src/etc/man/cargo-new.1
@@ -2,12 +2,12 @@
 .\"     Title: cargo-new
 .\"    Author: [see the "AUTHOR(S)" section]
 .\" Generator: Asciidoctor 1.5.8
-.\"      Date: 2019-01-23
+.\"      Date: 2019-01-09
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "CARGO\-NEW" "1" "2019-01-23" "\ \&" "\ \&"
+.TH "CARGO\-NEW" "1" "2019-01-09" "\ \&" "\ \&"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0

--- a/src/etc/man/cargo-owner.1
+++ b/src/etc/man/cargo-owner.1
@@ -2,12 +2,12 @@
 .\"     Title: cargo-owner
 .\"    Author: [see the "AUTHOR(S)" section]
 .\" Generator: Asciidoctor 1.5.8
-.\"      Date: 2019-02-05
+.\"      Date: 2019-03-16
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "CARGO\-OWNER" "1" "2019-02-05" "\ \&" "\ \&"
+.TH "CARGO\-OWNER" "1" "2019-03-16" "\ \&" "\ \&"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0

--- a/src/etc/man/cargo-package.1
+++ b/src/etc/man/cargo-package.1
@@ -2,12 +2,12 @@
 .\"     Title: cargo-package
 .\"    Author: [see the "AUTHOR(S)" section]
 .\" Generator: Asciidoctor 1.5.8
-.\"      Date: 2019-02-13
+.\"      Date: 2019-03-16
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "CARGO\-PACKAGE" "1" "2019-02-13" "\ \&" "\ \&"
+.TH "CARGO\-PACKAGE" "1" "2019-03-16" "\ \&" "\ \&"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0

--- a/src/etc/man/cargo-pkgid.1
+++ b/src/etc/man/cargo-pkgid.1
@@ -2,12 +2,12 @@
 .\"     Title: cargo-pkgid
 .\"    Author: [see the "AUTHOR(S)" section]
 .\" Generator: Asciidoctor 1.5.8
-.\"      Date: 2018-12-20
+.\"      Date: 2019-01-09
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "CARGO\-PKGID" "1" "2018-12-20" "\ \&" "\ \&"
+.TH "CARGO\-PKGID" "1" "2019-01-09" "\ \&" "\ \&"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0

--- a/src/etc/man/cargo-publish.1
+++ b/src/etc/man/cargo-publish.1
@@ -2,12 +2,12 @@
 .\"     Title: cargo-publish
 .\"    Author: [see the "AUTHOR(S)" section]
 .\" Generator: Asciidoctor 1.5.8
-.\"      Date: 2019-02-13
+.\"      Date: 2019-03-16
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "CARGO\-PUBLISH" "1" "2019-02-13" "\ \&" "\ \&"
+.TH "CARGO\-PUBLISH" "1" "2019-03-16" "\ \&" "\ \&"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0

--- a/src/etc/man/cargo-run.1
+++ b/src/etc/man/cargo-run.1
@@ -2,12 +2,12 @@
 .\"     Title: cargo-run
 .\"    Author: [see the "AUTHOR(S)" section]
 .\" Generator: Asciidoctor 1.5.8
-.\"      Date: 2019-02-05
+.\"      Date: 2019-03-16
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "CARGO\-RUN" "1" "2019-02-05" "\ \&" "\ \&"
+.TH "CARGO\-RUN" "1" "2019-03-16" "\ \&" "\ \&"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0

--- a/src/etc/man/cargo-rustc.1
+++ b/src/etc/man/cargo-rustc.1
@@ -2,12 +2,12 @@
 .\"     Title: cargo-rustc
 .\"    Author: [see the "AUTHOR(S)" section]
 .\" Generator: Asciidoctor 1.5.8
-.\"      Date: 2018-12-20
+.\"      Date: 2019-01-09
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "CARGO\-RUSTC" "1" "2018-12-20" "\ \&" "\ \&"
+.TH "CARGO\-RUSTC" "1" "2019-01-09" "\ \&" "\ \&"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0

--- a/src/etc/man/cargo-rustdoc.1
+++ b/src/etc/man/cargo-rustdoc.1
@@ -2,12 +2,12 @@
 .\"     Title: cargo-rustdoc
 .\"    Author: [see the "AUTHOR(S)" section]
 .\" Generator: Asciidoctor 1.5.8
-.\"      Date: 2018-12-20
+.\"      Date: 2019-01-09
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "CARGO\-RUSTDOC" "1" "2018-12-20" "\ \&" "\ \&"
+.TH "CARGO\-RUSTDOC" "1" "2019-01-09" "\ \&" "\ \&"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0

--- a/src/etc/man/cargo-search.1
+++ b/src/etc/man/cargo-search.1
@@ -2,12 +2,12 @@
 .\"     Title: cargo-search
 .\"    Author: [see the "AUTHOR(S)" section]
 .\" Generator: Asciidoctor 1.5.8
-.\"      Date: 2019-01-23
+.\"      Date: 2019-01-09
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "CARGO\-SEARCH" "1" "2019-01-23" "\ \&" "\ \&"
+.TH "CARGO\-SEARCH" "1" "2019-01-09" "\ \&" "\ \&"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0

--- a/src/etc/man/cargo-test.1
+++ b/src/etc/man/cargo-test.1
@@ -2,12 +2,12 @@
 .\"     Title: cargo-test
 .\"    Author: [see the "AUTHOR(S)" section]
 .\" Generator: Asciidoctor 1.5.8
-.\"      Date: 2018-12-23
+.\"      Date: 2019-03-16
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "CARGO\-TEST" "1" "2018-12-23" "\ \&" "\ \&"
+.TH "CARGO\-TEST" "1" "2019-03-16" "\ \&" "\ \&"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0
@@ -83,11 +83,15 @@ the executable as a whole.
 .SS "Package Selection"
 .sp
 By default, when no package selection options are given, the packages selected
-depend on the current working directory. In the root of a virtual workspace,
-all workspace members are selected (\fB\-\-all\fP is implied). Otherwise, only the
-package in the current directory will be selected. The default packages may be
-overridden with the \fBworkspace.default\-members\fP key in the root \fBCargo.toml\fP
-manifest.
+depend on the selected manifest file (based on the current working directory if
+\fB\-\-manifest\-path\fP is not given). If the manifest is the root of a workspace then
+the workspaces default members are selected, otherwise only the package defined
+by the manifest will be selected.
+.sp
+The default members of a workspace can be set explicitly with the
+\fBworkspace.default\-members\fP key in the root manifest. If this is not set, a
+virtual workspace will include all workspace members (equivalent to passing
+\fB\-\-all\fP), and a non\-virtual workspace will include only the root crate itself.
 .sp
 \fB\-p\fP \fISPEC\fP..., \fB\-\-package\fP \fISPEC\fP...
 .RS 4

--- a/src/etc/man/cargo-uninstall.1
+++ b/src/etc/man/cargo-uninstall.1
@@ -2,12 +2,12 @@
 .\"     Title: cargo-uninstall
 .\"    Author: [see the "AUTHOR(S)" section]
 .\" Generator: Asciidoctor 1.5.8
-.\"      Date: 2018-12-20
+.\"      Date: 2019-01-09
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "CARGO\-UNINSTALL" "1" "2018-12-20" "\ \&" "\ \&"
+.TH "CARGO\-UNINSTALL" "1" "2019-01-09" "\ \&" "\ \&"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0

--- a/src/etc/man/cargo-update.1
+++ b/src/etc/man/cargo-update.1
@@ -2,12 +2,12 @@
 .\"     Title: cargo-update
 .\"    Author: [see the "AUTHOR(S)" section]
 .\" Generator: Asciidoctor 1.5.8
-.\"      Date: 2018-12-23
+.\"      Date: 2019-01-09
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "CARGO\-UPDATE" "1" "2018-12-23" "\ \&" "\ \&"
+.TH "CARGO\-UPDATE" "1" "2019-01-09" "\ \&" "\ \&"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0

--- a/src/etc/man/cargo-verify-project.1
+++ b/src/etc/man/cargo-verify-project.1
@@ -2,12 +2,12 @@
 .\"     Title: cargo-verify-project
 .\"    Author: [see the "AUTHOR(S)" section]
 .\" Generator: Asciidoctor 1.5.8
-.\"      Date: 2018-12-20
+.\"      Date: 2019-01-09
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "CARGO\-VERIFY\-PROJECT" "1" "2018-12-20" "\ \&" "\ \&"
+.TH "CARGO\-VERIFY\-PROJECT" "1" "2019-01-09" "\ \&" "\ \&"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0

--- a/src/etc/man/cargo-version.1
+++ b/src/etc/man/cargo-version.1
@@ -2,12 +2,12 @@
 .\"     Title: cargo-version
 .\"    Author: [see the "AUTHOR(S)" section]
 .\" Generator: Asciidoctor 1.5.8
-.\"      Date: 2018-12-20
+.\"      Date: 2019-01-09
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "CARGO\-VERSION" "1" "2018-12-20" "\ \&" "\ \&"
+.TH "CARGO\-VERSION" "1" "2019-01-09" "\ \&" "\ \&"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0

--- a/src/etc/man/cargo-yank.1
+++ b/src/etc/man/cargo-yank.1
@@ -2,12 +2,12 @@
 .\"     Title: cargo-yank
 .\"    Author: [see the "AUTHOR(S)" section]
 .\" Generator: Asciidoctor 1.5.8
-.\"      Date: 2019-01-23
+.\"      Date: 2019-01-09
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "CARGO\-YANK" "1" "2019-01-23" "\ \&" "\ \&"
+.TH "CARGO\-YANK" "1" "2019-01-09" "\ \&" "\ \&"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0

--- a/src/etc/man/cargo.1
+++ b/src/etc/man/cargo.1
@@ -2,12 +2,12 @@
 .\"     Title: cargo
 .\"    Author: [see the "AUTHOR(S)" section]
 .\" Generator: Asciidoctor 1.5.8
-.\"      Date: 2019-02-05
+.\"      Date: 2019-03-16
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "CARGO" "1" "2019-02-05" "\ \&" "\ \&"
+.TH "CARGO" "1" "2019-03-16" "\ \&" "\ \&"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0


### PR DESCRIPTION
Fixes #5932 

The first commit includes all actual changes, the second commit is just running Asciidoctor on the already updated man-pages source, so I suggest looking at the individual commits.