### PR TITLE
Fix spurious error in dirty_both_lib_and_test.

### DIFF
--- a/tests/testsuite/freshness.rs
+++ b/tests/testsuite/freshness.rs
@@ -1697,6 +1697,10 @@ fn dirty_both_lib_and_test() {
         .with_stdout_contains("[..]doit assert failure[..]")
         .run();
 
+    if is_coarse_mtime() {
+        // #5918
+        sleep_ms(1000);
+    }
     // Fix the mistake.
     p.change_file("slib.rs", &slib(1));
 


### PR DESCRIPTION
On HFS, if it runs fast enough, the mtimes will be equal, causing it to fail to rebuild.

Seen on #6755 https://travis-ci.com/rust-lang/cargo/jobs/185412514
