### PR TITLE
Handle backcompat hazard with `toml` crate

### DIFF
--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -142,6 +142,24 @@ in the future.",
         return Ok(ret);
     }
 
+    let mut third_parser = toml::de::Deserializer::new(toml);
+    third_parser.set_allow_duplicate_after_longer_table(true);
+    if let Ok(ret) = toml::Value::deserialize(&mut third_parser) {
+        let msg = format!(
+            "\
+TOML file found which contains invalid syntax and will soon not parse
+at `{}`.
+
+The TOML spec requires that each table header is defined at most once, but
+historical versions of Cargo have erroneously accepted this file. The table
+definitions will need to be merged together with one table header to proceed,
+and this will become a hard error in the future.",
+            file.display()
+        );
+        config.shell().warn(&msg)?;
+        return Ok(ret);
+    }
+
     let first_error = failure::Error::from(first_error);
     Err(first_error.context("could not parse input as TOML").into())
 }


### PR DESCRIPTION
The 0.5.0 release contained a
[bugfix](https://github.com/alexcrichton/toml-rs/pull/280) which
previously successfully parsed invalid TOML files, so we'll need to
manually handle that in Cago to ensure that we don't accidentally
regress crates, but rather instead give them an appropriate amount of
time to get fixed.