### PR TITLE
Remove redundant imports

### DIFF
--- a/src/cargo/util/errors.rs
+++ b/src/cargo/util/errors.rs
@@ -307,7 +307,6 @@ pub fn process_error(
 
     #[cfg(unix)]
     fn status_to_string(status: ExitStatus) -> String {
-        use libc;
         use std::os::unix::process::*;
 
         if let Some(signal) = status.signal() {

--- a/src/cargo/util/paths.rs
+++ b/src/cargo/util/paths.rs
@@ -218,7 +218,6 @@ pub fn path2bytes(path: &Path) -> CargoResult<&[u8]> {
 
 #[cfg(unix)]
 pub fn bytes2path(bytes: &[u8]) -> CargoResult<PathBuf> {
-    use std::ffi::OsStr;
     use std::os::unix::prelude::*;
     Ok(PathBuf::from(OsStr::from_bytes(bytes)))
 }


### PR DESCRIPTION
Removes two redundant imports. These showed up while working on a [lint for rustc](https://github.com/rust-lang/rust/pull/58805/).