### PR TITLE
Implement the 'frontend' of public-private dependencies

### DIFF
--- a/src/cargo/core/compiler/build_context/mod.rs
+++ b/src/cargo/core/compiler/build_context/mod.rs
@@ -93,6 +93,11 @@ impl<'a, 'cfg> BuildContext<'a, 'cfg> {
             .extern_crate_name(unit.pkg.package_id(), dep.pkg.package_id(), dep.target)
     }
 
+    pub fn is_public_dependency(&self, unit: &Unit<'a>, dep: &Unit<'a>) -> bool {
+        self.resolve
+            .is_public_dep(unit.pkg.package_id(), dep.pkg.package_id())
+    }
+
     /// Whether a dependency should be compiled for the host or target platform,
     /// specified by `Kind`.
     pub fn dep_platform_activated(&self, dep: &Dependency, kind: Kind) -> bool {

--- a/src/cargo/core/compiler/fingerprint.rs
+++ b/src/cargo/core/compiler/fingerprint.rs
@@ -422,7 +422,7 @@ impl Serialize for DepFingerprint {
     where
         S: ser::Serializer,
     {
-        (&self.pkg_id, &self.name, &self.fingerprint.hash()).serialize(ser)
+        (&self.pkg_id, &self.name, &self.public, &self.fingerprint.hash()).serialize(ser)
     }
 }
 

--- a/src/cargo/core/compiler/fingerprint.rs
+++ b/src/cargo/core/compiler/fingerprint.rs
@@ -315,11 +315,13 @@ pub fn prepare_target<'a, 'cfg>(
 /// A compilation unit dependency has a fingerprint that is comprised of:
 /// * its package ID
 /// * its extern crate name
+/// * its public/private status
 /// * its calculated fingerprint for the dependency
 #[derive(Clone)]
 struct DepFingerprint {
     pkg_id: u64,
     name: String,
+    public: bool,
     fingerprint: Arc<Fingerprint>,
 }
 
@@ -429,10 +431,11 @@ impl<'de> Deserialize<'de> for DepFingerprint {
     where
         D: de::Deserializer<'de>,
     {
-        let (pkg_id, name, hash) = <(u64, String, u64)>::deserialize(d)?;
+        let (pkg_id, name, public, hash) = <(u64, String, bool, u64)>::deserialize(d)?;
         Ok(DepFingerprint {
             pkg_id,
             name,
+            public,
             fingerprint: Arc::new(Fingerprint {
                 memoized_hash: Mutex::new(Some(hash)),
                 ..Fingerprint::new()
@@ -850,11 +853,13 @@ impl hash::Hash for Fingerprint {
         for DepFingerprint {
             pkg_id,
             name,
+            public,
             fingerprint,
         } in deps
         {
             pkg_id.hash(h);
             name.hash(h);
+            public.hash(h);
             // use memoized dep hashes to avoid exponential blowup
             h.write_u64(Fingerprint::hash(fingerprint));
         }
@@ -900,6 +905,7 @@ impl DepFingerprint {
     ) -> CargoResult<DepFingerprint> {
         let fingerprint = calculate(cx, dep)?;
         let name = cx.bcx.extern_crate_name(parent, dep)?;
+        let public = cx.bcx.is_public_dependency(parent, dep);
 
         // We need to be careful about what we hash here. We have a goal of
         // supporting renaming a project directory and not rebuilding
@@ -920,6 +926,7 @@ impl DepFingerprint {
         Ok(DepFingerprint {
             pkg_id,
             name,
+            public,
             fingerprint,
         })
     }

--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -1006,14 +1006,24 @@ fn build_deps_args<'a, 'cfg>(
             v.push(cx.files().out_dir(dep));
             v.push(&path::MAIN_SEPARATOR.to_string());
             v.push(&output.path.file_name().unwrap());
-            cmd.arg("--extern").arg(&v);
+
+            let mut private = false;
 
             if current.pkg.manifest().features().require(Feature::public_dependency()).is_ok() {
                 if !bcx.is_public_dependency(current, dep) {
-                    cmd.arg("--extern-private").arg(&v);
-                    *need_unstable_opts = true
+                    private = true;
                 }
             }
+
+            if private {
+                cmd.arg("--extern-private");
+            } else {
+                cmd.arg("--extern");
+            }
+
+            cmd.arg(&v);
+            *need_unstable_opts |= private;
+
         }
         Ok(())
     }

--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -23,6 +23,7 @@ use log::debug;
 use same_file::is_same_file;
 use serde::Serialize;
 
+use crate::core::Feature;
 pub use self::build_config::{BuildConfig, CompileMode, MessageFormat};
 pub use self::build_context::{BuildContext, FileFlavor, TargetConfig, TargetInfo};
 use self::build_plan::BuildPlan;
@@ -966,14 +967,23 @@ fn build_deps_args<'a, 'cfg>(
         }
     }
 
+    let mut unstable_opts = false;
+
     for dep in dep_targets {
         if dep.mode.is_run_custom_build() {
             cmd.env("OUT_DIR", &cx.files().build_script_out_dir(&dep));
         }
         if dep.target.linkable() && !dep.mode.is_doc() {
-            link_to(cmd, cx, unit, &dep)?;
+            link_to(cmd, cx, unit, &dep, &mut unstable_opts)?;
         }
     }
+
+    // This will only be set if we're already usign a feature
+    // requiring nightly rust
+    if unstable_opts {
+        cmd.arg("-Z").arg("unstable-options");
+    }
+
 
     return Ok(());
 
@@ -982,6 +992,7 @@ fn build_deps_args<'a, 'cfg>(
         cx: &mut Context<'a, 'cfg>,
         current: &Unit<'a>,
         dep: &Unit<'a>,
+        need_unstable_opts: &mut bool
     ) -> CargoResult<()> {
         let bcx = cx.bcx;
         for output in cx.outputs(dep)?.iter() {
@@ -996,6 +1007,13 @@ fn build_deps_args<'a, 'cfg>(
             v.push(&path::MAIN_SEPARATOR.to_string());
             v.push(&output.path.file_name().unwrap());
             cmd.arg("--extern").arg(&v);
+
+            if current.pkg.manifest().features().require(Feature::public_dependency()).is_ok() {
+                if !bcx.is_public_dependency(current, dep) {
+                    cmd.arg("--extern-private").arg(&v);
+                    *need_unstable_opts = true
+                }
+            }
         }
         Ok(())
     }

--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -1007,23 +1007,16 @@ fn build_deps_args<'a, 'cfg>(
             v.push(&path::MAIN_SEPARATOR.to_string());
             v.push(&output.path.file_name().unwrap());
 
-            let mut private = false;
+            if current.pkg.manifest().features().require(Feature::public_dependency()).is_ok() &&
+                !bcx.is_public_dependency(current, dep)  {
 
-            if current.pkg.manifest().features().require(Feature::public_dependency()).is_ok() {
-                if !bcx.is_public_dependency(current, dep) {
-                    private = true;
-                }
-            }
-
-            if private {
-                cmd.arg("--extern-private");
+                    cmd.arg("--extern-private");
+                    *need_unstable_opts = true;
             } else {
                 cmd.arg("--extern");
             }
 
             cmd.arg(&v);
-            *need_unstable_opts |= private;
-
         }
         Ok(())
     }

--- a/src/cargo/core/dependency.rs
+++ b/src/cargo/core/dependency.rs
@@ -301,8 +301,8 @@ impl Dependency {
 
     /// Sets whether the dependency is public.
     pub fn set_public(&mut self, public: bool) -> &mut Dependency {
-        if !public {
-            // Setting 'private' only makes sense for normal dependencies
+        if public {
+            // Setting 'public' only makes sense for normal dependencies
             assert_eq!(self.kind(), Kind::Normal);
         }
         Rc::make_mut(&mut self.inner).public = public;

--- a/src/cargo/core/dependency.rs
+++ b/src/cargo/core/dependency.rs
@@ -301,6 +301,8 @@ impl Dependency {
 
     /// Sets whether the dependency is public.
     pub fn set_public(&mut self, public: bool) -> &mut Dependency {
+        // Setting 'public' only makes sense for normal dependencies
+        assert_eq!(self.kind(), Kind::Normal);
         Rc::make_mut(&mut self.inner).public = public;
         self
     }

--- a/src/cargo/core/dependency.rs
+++ b/src/cargo/core/dependency.rs
@@ -301,8 +301,10 @@ impl Dependency {
 
     /// Sets whether the dependency is public.
     pub fn set_public(&mut self, public: bool) -> &mut Dependency {
-        // Setting 'public' only makes sense for normal dependencies
-        assert_eq!(self.kind(), Kind::Normal);
+        if !public {
+            // Setting 'private' only makes sense for normal dependencies
+            assert_eq!(self.kind(), Kind::Normal);
+        }
         Rc::make_mut(&mut self.inner).public = public;
         self
     }

--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -199,6 +199,9 @@ features! {
 
         // Declarative build scripts.
         [unstable] metabuild: bool,
+
+        // Specifying the 'public' attribute on dependencies
+        [unstable] public_dependency: bool,
     }
 }
 

--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -8,6 +8,7 @@ use glob::glob;
 use log::debug;
 use url::Url;
 
+use crate::core::features::Features;
 use crate::core::profiles::Profiles;
 use crate::core::registry::PackageRegistry;
 use crate::core::{Dependency, PackageIdSpec, PackageId};
@@ -540,6 +541,13 @@ impl<'cfg> Workspace<'cfg> {
         Ok(())
     }
 
+    pub fn features(&self) -> &Features {
+        match self.root_maybe() {
+            MaybePackage::Package(p) => p.manifest().features(),
+            MaybePackage::Virtual(vm) => vm.features(),
+        }
+    }
+
     /// Validates a workspace, ensuring that a number of invariants are upheld:
     ///
     /// 1. A workspace only has one root.
@@ -547,10 +555,7 @@ impl<'cfg> Workspace<'cfg> {
     /// 3. The current crate is a member of this workspace.
     fn validate(&mut self) -> CargoResult<()> {
         // Validate config profiles only once per workspace.
-        let features = match self.root_maybe() {
-            MaybePackage::Package(p) => p.manifest().features(),
-            MaybePackage::Virtual(vm) => vm.features(),
-        };
+        let features = self.features();
         let mut warnings = Vec::new();
         self.config.profiles()?.validate(features, &mut warnings)?;
         for warning in warnings {

--- a/src/cargo/ops/resolve.rs
+++ b/src/cargo/ops/resolve.rs
@@ -2,6 +2,7 @@ use std::collections::HashSet;
 
 use log::{debug, trace};
 
+use crate::core::Feature;
 use crate::core::registry::PackageRegistry;
 use crate::core::resolver::{self, Method, Resolve};
 use crate::core::{PackageId, PackageIdSpec, PackageSet, Source, SourceId, Workspace};
@@ -330,7 +331,7 @@ pub fn resolve_with_previous<'cfg>(
         registry,
         &try_to_use,
         Some(ws.config()),
-        false, // TODO: use "public and private dependencies" feature flag
+        ws.features().require(Feature::public_dependency()).is_ok(),
     )?;
     resolved.register_used_patches(registry.patches());
     if register_patches {

--- a/src/cargo/sources/registry/mod.rs
+++ b/src/cargo/sources/registry/mod.rs
@@ -285,6 +285,7 @@ struct RegistryDependency<'a> {
     kind: Option<Cow<'a, str>>,
     registry: Option<Cow<'a, str>>,
     package: Option<Cow<'a, str>>,
+    public: Option<bool>
 }
 
 impl<'a> RegistryDependency<'a> {
@@ -300,6 +301,7 @@ impl<'a> RegistryDependency<'a> {
             kind,
             registry,
             package,
+            public
         } = self;
 
         let id = if let Some(registry) = &registry {
@@ -324,6 +326,9 @@ impl<'a> RegistryDependency<'a> {
             None => None,
         };
 
+        // All dependencies are private by default
+        let public = public.unwrap_or(false);
+
         // Unfortunately older versions of cargo and/or the registry ended up
         // publishing lots of entries where the features array contained the
         // empty feature, "", inside. This confuses the resolution process much
@@ -341,7 +346,8 @@ impl<'a> RegistryDependency<'a> {
             .set_default_features(default_features)
             .set_features(features)
             .set_platform(platform)
-            .set_kind(kind);
+            .set_kind(kind)
+            .set_public(public);
 
         Ok(dep)
     }

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -239,6 +239,7 @@ pub struct DetailedTomlDependency {
     #[serde(rename = "default_features")]
     default_features2: Option<bool>,
     package: Option<String>,
+    public: Option<bool>
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -1460,6 +1461,11 @@ impl DetailedTomlDependency {
         if let Some(name_in_toml) = explicit_name_in_toml {
             cx.features.require(Feature::rename_dependency())?;
             dep.set_explicit_name_in_toml(name_in_toml);
+        }
+
+        if let Some(p) = self.public {
+            cx.features.require(Feature::public_dependency())?;
+            dep.set_public(p);
         }
         Ok(dep)
     }

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -1465,6 +1465,11 @@ impl DetailedTomlDependency {
 
         if let Some(p) = self.public {
             cx.features.require(Feature::public_dependency())?;
+
+            if dep.kind() != Kind::Normal {
+                bail!("'public' specifier can only be used on regular dependencies, not {:?} dependencies", dep.kind());
+            }
+
             dep.set_public(p);
         }
         Ok(dep)

--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -264,3 +264,20 @@ conflicting binaries from another package.
 Additionally, a new flag `--no-track` is available to prevent `cargo install`
 from writing tracking information in `$CARGO_HOME` about which packages are
 installed.
+
+### public-dependency
+* Tracking Issue: [#44663](https://github.com/rust-lang/rust/issues/44663)
+
+The 'public-dependency' features allows marking dependencies as 'public'
+or 'private'. When this feature is enabled, additional information is passed to rustc to allow
+the 'exported_private_dependencies' lint to function properly.
+
+This requires the appropriate key to be set in `cargo-features`:
+
+```toml
+cargo-features = ["public-dependency"]
+
+[dependencies]
+my_dep = { version = "1.2.3", public = true }
+private_dep = "2.0.0" # Will be 'private' by default
+```

--- a/tests/testsuite/main.rs
+++ b/tests/testsuite/main.rs
@@ -67,6 +67,7 @@ mod profile_config;
 mod profile_overrides;
 mod profile_targets;
 mod profiles;
+mod pub_priv;
 mod publish;
 mod publish_lockfile;
 mod read_manifest;

--- a/tests/testsuite/pub_priv.rs
+++ b/tests/testsuite/pub_priv.rs
@@ -1,5 +1,5 @@
 use crate::support::registry::Package;
-use crate::support::{project, is_nightly};
+use crate::support::{is_nightly, project};
 
 #[test]
 fn exported_priv_warning() {
@@ -7,10 +7,7 @@ fn exported_priv_warning() {
         return;
     }
     Package::new("priv_dep", "0.1.0")
-        .file(
-            "src/lib.rs",
-            "pub struct FromPriv;"
-        )
+        .file("src/lib.rs", "pub struct FromPriv;")
         .publish();
 
     let p = project()
@@ -58,10 +55,7 @@ fn exported_pub_dep() {
         return;
     }
     Package::new("pub_dep", "0.1.0")
-        .file(
-            "src/lib.rs",
-            "pub struct FromPub;"
-        )
+        .file("src/lib.rs", "pub struct FromPub;")
         .publish();
 
     let p = project()
@@ -97,10 +91,9 @@ fn exported_pub_dep() {
 [COMPILING] pub_dep v0.1.0
 [COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
-"
+",
         )
         .run()
-
 }
 
 #[test]
@@ -112,10 +105,7 @@ pub fn requires_nightly_cargo() {
             cargo-features = ["public-dependency"]
         "#,
         )
-        .file(
-            "src/lib.rs",
-            ""
-        )
+        .file("src/lib.rs", "")
         .build();
 
     p.cargo("build --message-format=short")
@@ -134,15 +124,9 @@ See https://doc.rust-lang.org/book/appendix-07-nightly-rust.html for more inform
 
 #[test]
 fn requires_feature() {
-
-
     Package::new("pub_dep", "0.1.0")
-        .file(
-            "src/lib.rs",
-            ""
-        )
+        .file("src/lib.rs", "")
         .publish();
-
 
     let p = project()
         .file(
@@ -157,10 +141,7 @@ fn requires_feature() {
             pub_dep = { version = "0.1.0", public = true }
         "#,
         )
-        .file(
-            "src/lib.rs",
-            ""
-        )
+        .file("src/lib.rs", "")
         .build();
 
     p.cargo("build --message-format=short")
@@ -174,8 +155,7 @@ Caused by:
   feature `public-dependency` is required
 
 consider adding `cargo-features = [\"public-dependency\"]` to the manifest
-"
+",
         )
         .run()
-
 }

--- a/tests/testsuite/pub_priv.rs
+++ b/tests/testsuite/pub_priv.rs
@@ -1,0 +1,180 @@
+use crate::support::registry::Package;
+use crate::support::{project, is_nightly};
+
+#[test]
+fn exported_priv_warning() {
+    if !is_nightly() {
+        return;
+    }
+    Package::new("priv_dep", "0.1.0")
+        .file(
+            "src/lib.rs",
+            "pub struct FromPriv;"
+        )
+        .publish();
+
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            cargo-features = ["public-dependency"]
+
+            [package]
+            name = "foo"
+            version = "0.0.1"
+
+            [dependencies]
+            priv_dep = "0.1.0"
+        "#,
+        )
+        .file(
+            "src/lib.rs",
+            "
+            extern crate priv_dep;
+            pub fn use_priv(_: priv_dep::FromPriv) {}
+        ",
+        )
+        .build();
+
+    p.cargo("build --message-format=short")
+        .masquerade_as_nightly_cargo()
+        .with_stderr(
+            "\
+[UPDATING] `[..]` index
+[DOWNLOADING] crates ...
+[DOWNLOADED] priv_dep v0.1.0 ([..])
+[COMPILING] priv_dep v0.1.0
+[COMPILING] foo v0.0.1 ([CWD])
+src/lib.rs:3:13: warning: type `priv_dep::FromPriv` from private dependency 'priv_dep' in public interface
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+"
+        )
+        .run()
+}
+
+#[test]
+fn exported_pub_dep() {
+    if !is_nightly() {
+        return;
+    }
+    Package::new("pub_dep", "0.1.0")
+        .file(
+            "src/lib.rs",
+            "pub struct FromPub;"
+        )
+        .publish();
+
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            cargo-features = ["public-dependency"]
+
+            [package]
+            name = "foo"
+            version = "0.0.1"
+
+            [dependencies]
+            pub_dep = {version = "0.1.0", public = true}
+        "#,
+        )
+        .file(
+            "src/lib.rs",
+            "
+            extern crate pub_dep;
+            pub fn use_pub(_: pub_dep::FromPub) {}
+        ",
+        )
+        .build();
+
+    p.cargo("build --message-format=short")
+        .masquerade_as_nightly_cargo()
+        .with_stderr(
+            "\
+[UPDATING] `[..]` index
+[DOWNLOADING] crates ...
+[DOWNLOADED] pub_dep v0.1.0 ([..])
+[COMPILING] pub_dep v0.1.0
+[COMPILING] foo v0.0.1 ([CWD])
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+"
+        )
+        .run()
+
+}
+
+#[test]
+pub fn requires_nightly_cargo() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            cargo-features = ["public-dependency"]
+        "#,
+        )
+        .file(
+            "src/lib.rs",
+            ""
+        )
+        .build();
+
+    p.cargo("build --message-format=short")
+        .with_status(101)
+        .with_stderr(
+            "\
+error: failed to parse manifest at `[..]`
+
+Caused by:
+  the cargo feature `public-dependency` requires a nightly version of Cargo, but this is the `stable` channel
+"
+        )
+        .run()
+}
+
+#[test]
+fn requires_feature() {
+
+
+    Package::new("pub_dep", "0.1.0")
+        .file(
+            "src/lib.rs",
+            ""
+        )
+        .publish();
+
+
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+
+            [package]
+            name = "foo"
+            version = "0.0.1"
+
+            [dependencies]
+            pub_dep = { version = "0.1.0", public = true }
+        "#,
+        )
+        .file(
+            "src/lib.rs",
+            ""
+        )
+        .build();
+
+    p.cargo("build --message-format=short")
+        .masquerade_as_nightly_cargo()
+        .with_status(101)
+        .with_stderr(
+            "\
+error: failed to parse manifest at `[..]`
+
+Caused by:
+  feature `public-dependency` is required
+
+consider adding `cargo-features = [\"public-dependency\"]` to the manifest
+"
+        )
+        .run()
+
+}

--- a/tests/testsuite/pub_priv.rs
+++ b/tests/testsuite/pub_priv.rs
@@ -126,6 +126,7 @@ error: failed to parse manifest at `[..]`
 
 Caused by:
   the cargo feature `public-dependency` requires a nightly version of Cargo, but this is the `stable` channel
+See https://doc.rust-lang.org/book/appendix-07-nightly-rust.html for more information about Rust release channels.
 "
         )
         .run()

--- a/tests/testsuite/support/resolver.rs
+++ b/tests/testsuite/support/resolver.rs
@@ -348,8 +348,8 @@ fn meta_test_deep_pretty_print_registry() {
                 pkg!(("baz", "1.0.1")),
                 pkg!(("cat", "1.0.2") => [dep_req_kind("other", "2", Kind::Build, false)]),
                 pkg!(("cat", "1.0.3") => [dep_req_kind("other", "2", Kind::Development, false)]),
-                pkg!(("cat", "1.0.4") => [dep_req_kind("other", "2", Kind::Build, true)]),
-                pkg!(("cat", "1.0.5") => [dep_req_kind("other", "2", Kind::Development, true)]),
+                pkg!(("cat", "1.0.4") => [dep_req_kind("other", "2", Kind::Build, false)]),
+                pkg!(("cat", "1.0.5") => [dep_req_kind("other", "2", Kind::Development, false)]),
                 pkg!(("dep_req", "1.0.0")),
                 pkg!(("dep_req", "2.0.0")),
             ])
@@ -363,8 +363,8 @@ fn meta_test_deep_pretty_print_registry() {
          pkg!((\"baz\", \"1.0.1\")),\
          pkg!((\"cat\", \"1.0.2\") => [dep_req_kind(\"other\", \"^2\", Kind::Build, false),]),\
          pkg!((\"cat\", \"1.0.3\") => [dep_req_kind(\"other\", \"^2\", Kind::Development, false),]),\
-         pkg!((\"cat\", \"1.0.4\") => [dep_req_kind(\"other\", \"^2\", Kind::Build, true),]),\
-         pkg!((\"cat\", \"1.0.5\") => [dep_req_kind(\"other\", \"^2\", Kind::Development, true),]),\
+         pkg!((\"cat\", \"1.0.4\") => [dep_req_kind(\"other\", \"^2\", Kind::Build, false),]),\
+         pkg!((\"cat\", \"1.0.5\") => [dep_req_kind(\"other\", \"^2\", Kind::Development, false),]),\
          pkg!((\"dep_req\", \"1.0.0\")),\
          pkg!((\"dep_req\", \"2.0.0\")),]"
     )


### PR DESCRIPTION
This is part of https://github.com/rust-lang/rust/issues/44663

This implements the 'frontend' portion of [RFC 1977](https://github.com/rust-lang/rfcs/blob/master/text/1977-public-private-dependencies.md). Once PRs https://github.com/rust-lang/rust/pull/59335 and https://github.com/rust-lang/crates.io/pull/1685 are merged,
it will be possible to test the full public-private dependency feature:
marking a dependency a public, seeing exported_private_dependencies
warnings from rustc, and seeing pub-dep-reachability errors from Cargo.

Everything in this commit should be fully backwards-compatible - users
who don't enable the 'public-dependency' cargo feature won't notice any
changes.

Note that this commit does *not* implement the remaining two features of
the RFC:

* Choosing smallest versions when 'cargo publish' is run
* Turning exported_private_dependencies warnings into hard errors when 'cargo publish' is run

The former is a major change to Cargo's behavior, and should be done in a separate PR with some kind of rollout plan.

The latter is described by the RFC as being enabled at 'some point in the future'. This can be done via a follow-up PR.