### PR TITLE
Add `--target HOST` alias for host target

### DIFF
--- a/src/cargo/core/compiler/build_config.rs
+++ b/src/cargo/core/compiler/build_config.rs
@@ -68,6 +68,13 @@ impl BuildConfig {
         let cfg_target = config.get_string("build.target")?.map(|s| s.val);
         let target = requested_target.or(cfg_target);
 
+        let target = if target.as_ref().map(|t| t.as_str()) == Some("HOST") {
+            // Reset target to `None` so that the default host target is used.
+            None
+        } else {
+            target
+        };
+
         if jobs == Some(0) {
             failure::bail!("jobs must be at least 1")
         }

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -4807,3 +4807,10 @@ Caused by:
         .with_status(101)
         .run();
 }
+
+#[test]
+fn host_target() {
+    let p = project().file("src/lib.rs", "").build();
+    p.cargo("build -v --target HOST").with_status(0).run();
+    p.cargo("build -v --target=HOST").with_status(0).run();
+}


### PR DESCRIPTION
This adds a `HOST` alias for the host target. It is useful when the default target is overridden in a `.cargo/config` file. It provides a platform-independent way to reset the target back to the host target. See #6775 for more motivation.

Closes https://github.com/rust-lang/cargo/issues/6775