### PR TITLE
Canonicalize default target if it ends with `.json`

### DIFF
--- a/src/cargo/core/compiler/build_config.rs
+++ b/src/cargo/core/compiler/build_config.rs
@@ -65,7 +65,17 @@ impl BuildConfig {
                 failure::bail!("target was empty")
             }
         }
-        let cfg_target = config.get_string("build.target")?.map(|s| s.val);
+        let cfg_target = match config.get_string("build.target")? {
+            Some(ref target) if target.val.ends_with(".json") => {
+                let path = target.definition.root(config).join(&target.val);
+                let path_string = path
+                    .into_os_string()
+                    .into_string()
+                    .map_err(|_| failure::format_err!("Target path is not valid unicode"));
+                Some(path_string?)
+            }
+            other => other.map(|t| t.val),
+        };
         let target = requested_target.or(cfg_target);
 
         if jobs == Some(0) {


### PR DESCRIPTION
Targets that end with `.json` are not target triples but paths to target configuration files. We currently canonicalize all `.json` paths that are passed as `--target` so that the paths are still valid when building dependencies (where the current working directory is changed).

This commit adds the same canonicalization to default targets specified in a `build.target` key in a `.cargo/config` file by adding a new `Config::target_triple` function.