### PR TITLE
Fix setting `panic=unwind` compiling lib a extra time.

### DIFF
--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -23,7 +23,7 @@ use same_file::is_same_file;
 use serde::Serialize;
 
 use crate::core::manifest::TargetSourcePath;
-use crate::core::profiles::{Lto, Profile};
+use crate::core::profiles::{Lto, PanicStrategy, Profile};
 use crate::core::{PackageId, Target};
 use crate::util::errors::{CargoResult, CargoResultExt, Internal, ProcessError};
 use crate::util::paths;
@@ -794,7 +794,7 @@ fn build_base_args<'a, 'cfg>(
         cmd.arg("-C").arg(&format!("opt-level={}", opt_level));
     }
 
-    if let Some(panic) = panic.as_ref() {
+    if *panic != PanicStrategy::Unwind {
         cmd.arg("-C").arg(format!("panic={}", panic));
     }
 

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -5,6 +5,7 @@ use std::path::{Path, PathBuf};
 use std::rc::Rc;
 use std::str;
 
+use failure::bail;
 use log::{debug, trace};
 use semver::{self, VersionReq};
 use serde::de;
@@ -52,8 +53,9 @@ fn do_read_manifest(
     let package_root = manifest_file.parent().unwrap();
 
     let toml = {
-        let pretty_filename =
-            manifest_file.strip_prefix(config.cwd()).unwrap_or(manifest_file);
+        let pretty_filename = manifest_file
+            .strip_prefix(config.cwd())
+            .unwrap_or(manifest_file);
         parse(contents, pretty_filename, config)?
     };
 
@@ -78,7 +80,7 @@ fn do_read_manifest(
             TomlManifest::to_real_manifest(&manifest, source_id, package_root, config)?;
         add_unused(manifest.warnings_mut());
         if !manifest.targets().iter().any(|t| !t.is_custom_build()) {
-            failure::bail!(
+            bail!(
                 "no targets specified in the manifest\n  \
                  either src/lib.rs, src/main.rs, a [lib] section, or \
                  [[bin]] section must be present"
@@ -471,7 +473,7 @@ impl TomlProfile {
             "dev" | "release" => {}
             _ => {
                 if self.overrides.is_some() || self.build_override.is_some() {
-                    failure::bail!(
+                    bail!(
                         "Profile overrides may only be specified for \
                          `dev` or `release` profile, not `{}`.",
                         name
@@ -491,21 +493,31 @@ impl TomlProfile {
             }
             _ => {}
         }
+
+        if let Some(panic) = &self.panic {
+            if panic != "unwind" && panic != "abort" {
+                bail!(
+                    "`panic` setting of `{}` is not a valid setting,\
+                     must be `unwind` or `abort`",
+                    panic
+                );
+            }
+        }
         Ok(())
     }
 
     fn validate_override(&self) -> CargoResult<()> {
         if self.overrides.is_some() || self.build_override.is_some() {
-            failure::bail!("Profile overrides cannot be nested.");
+            bail!("Profile overrides cannot be nested.");
         }
         if self.panic.is_some() {
-            failure::bail!("`panic` may not be specified in a profile override.")
+            bail!("`panic` may not be specified in a profile override.")
         }
         if self.lto.is_some() {
-            failure::bail!("`lto` may not be specified in a profile override.")
+            bail!("`lto` may not be specified in a profile override.")
         }
         if self.rpath.is_some() {
-            failure::bail!("`rpath` may not be specified in a profile override.")
+            bail!("`rpath` may not be specified in a profile override.")
         }
         Ok(())
     }
@@ -830,7 +842,7 @@ impl TomlManifest {
 
         let package_name = project.name.trim();
         if package_name.is_empty() {
-            failure::bail!("package name cannot be an empty string")
+            bail!("package name cannot be an empty string")
         }
 
         validate_package_name(package_name, "package name", "")?;
@@ -951,7 +963,7 @@ impl TomlManifest {
                 let name = dep.name_in_toml();
                 let prev = names_sources.insert(name.to_string(), dep.source_id());
                 if prev.is_some() && prev != Some(dep.source_id()) {
-                    failure::bail!(
+                    bail!(
                         "Dependency '{}' has different source paths depending on the build \
                          target. Each dependency must have a single canonical source path \
                          irrespective of build target.",
@@ -1006,7 +1018,7 @@ impl TomlManifest {
             (None, root) => WorkspaceConfig::Member {
                 root: root.cloned(),
             },
-            (Some(..), Some(..)) => failure::bail!(
+            (Some(..), Some(..)) => bail!(
                 "cannot configure both `package.workspace` and \
                  `[workspace]`, only one can be specified"
             ),
@@ -1082,43 +1094,43 @@ impl TomlManifest {
         config: &Config,
     ) -> CargoResult<(VirtualManifest, Vec<PathBuf>)> {
         if me.project.is_some() {
-            failure::bail!("virtual manifests do not define [project]");
+            bail!("virtual manifests do not define [project]");
         }
         if me.package.is_some() {
-            failure::bail!("virtual manifests do not define [package]");
+            bail!("virtual manifests do not define [package]");
         }
         if me.lib.is_some() {
-            failure::bail!("virtual manifests do not specify [lib]");
+            bail!("virtual manifests do not specify [lib]");
         }
         if me.bin.is_some() {
-            failure::bail!("virtual manifests do not specify [[bin]]");
+            bail!("virtual manifests do not specify [[bin]]");
         }
         if me.example.is_some() {
-            failure::bail!("virtual manifests do not specify [[example]]");
+            bail!("virtual manifests do not specify [[example]]");
         }
         if me.test.is_some() {
-            failure::bail!("virtual manifests do not specify [[test]]");
+            bail!("virtual manifests do not specify [[test]]");
         }
         if me.bench.is_some() {
-            failure::bail!("virtual manifests do not specify [[bench]]");
+            bail!("virtual manifests do not specify [[bench]]");
         }
         if me.dependencies.is_some() {
-            failure::bail!("virtual manifests do not specify [dependencies]");
+            bail!("virtual manifests do not specify [dependencies]");
         }
         if me.dev_dependencies.is_some() || me.dev_dependencies2.is_some() {
-            failure::bail!("virtual manifests do not specify [dev-dependencies]");
+            bail!("virtual manifests do not specify [dev-dependencies]");
         }
         if me.build_dependencies.is_some() || me.build_dependencies2.is_some() {
-            failure::bail!("virtual manifests do not specify [build-dependencies]");
+            bail!("virtual manifests do not specify [build-dependencies]");
         }
         if me.features.is_some() {
-            failure::bail!("virtual manifests do not specify [features]");
+            bail!("virtual manifests do not specify [features]");
         }
         if me.target.is_some() {
-            failure::bail!("virtual manifests do not specify [target]");
+            bail!("virtual manifests do not specify [target]");
         }
         if me.badges.is_some() {
-            failure::bail!("virtual manifests do not specify [badges]");
+            bail!("virtual manifests do not specify [badges]");
         }
 
         let mut nested_paths = Vec::new();
@@ -1151,7 +1163,7 @@ impl TomlManifest {
                 &config.exclude,
             )),
             None => {
-                failure::bail!("virtual manifests must be configured with [workspace]");
+                bail!("virtual manifests must be configured with [workspace]");
             }
         };
         Ok((
@@ -1162,7 +1174,7 @@ impl TomlManifest {
 
     fn replace(&self, cx: &mut Context<'_, '_>) -> CargoResult<Vec<(PackageIdSpec, Dependency)>> {
         if self.patch.is_some() && self.replace.is_some() {
-            failure::bail!("cannot specify both [replace] and [patch]");
+            bail!("cannot specify both [replace] and [patch]");
         }
         let mut replace = Vec::new();
         for (spec, replacement) in self.replace.iter().flat_map(|x| x) {
@@ -1182,7 +1194,7 @@ impl TomlManifest {
                 TomlDependency::Simple(..) => true,
             };
             if version_specified {
-                failure::bail!(
+                bail!(
                     "replacements cannot specify a version \
                      requirement, but found one for `{}`",
                     spec
@@ -1331,12 +1343,12 @@ impl DetailedTomlDependency {
             self.registry.as_ref(),
             self.registry_index.as_ref(),
         ) {
-            (Some(_), _, Some(_), _) | (Some(_), _, _, Some(_)) => failure::bail!(
+            (Some(_), _, Some(_), _) | (Some(_), _, _, Some(_)) => bail!(
                 "dependency ({}) specification is ambiguous. \
                  Only one of `git` or `registry` is allowed.",
                 name_in_toml
             ),
-            (_, _, Some(_), Some(_)) => failure::bail!(
+            (_, _, Some(_), Some(_)) => bail!(
                 "dependency ({}) specification is ambiguous. \
                  Only one of `registry` or `registry-index` is allowed.",
                 name_in_toml


### PR DESCRIPTION
Explicitly setting `panic=unwind` in a profile could cause the `lib` target to be built multiple times when it shouldn't be. This is because libs as a test dependency explicitly clear the panic setting (because they are incompatible with `abort`). However, the deduplication logic doesn't know that `panic=None` is the same as `panic=Some("unwind")`. This changes it so there is an explicit enum that defaults to `PanicStrategy::Unwind`.

Fixes #6774.
