### PR TITLE
Some fingerprint cleanup.

### DIFF
--- a/src/cargo/core/compiler/context/compilation_files.rs
+++ b/src/cargo/core/compiler/context/compilation_files.rs
@@ -469,13 +469,6 @@ fn compute_metadata<'a, 'cfg>(
         .stable_hash(bcx.ws.root())
         .hash(&mut hasher);
 
-    // Add package properties which map to environment variables
-    // exposed by Cargo.
-    let manifest_metadata = unit.pkg.manifest().metadata();
-    manifest_metadata.authors.hash(&mut hasher);
-    manifest_metadata.description.hash(&mut hasher);
-    manifest_metadata.homepage.hash(&mut hasher);
-
     // Also mix in enabled features to our metadata. This'll ensure that
     // when changing feature sets each lib is separately cached.
     bcx.resolve

--- a/tests/testsuite/check.rs
+++ b/tests/testsuite/check.rs
@@ -4,7 +4,6 @@ use crate::support::install::exe;
 use crate::support::paths::CargoPathExt;
 use crate::support::registry::Package;
 use crate::support::{basic_manifest, project};
-use glob::glob;
 
 #[test]
 fn check_success() {
@@ -623,43 +622,34 @@ fn check_artifacts() {
         .file("benches/b1.rs", "")
         .build();
 
-    let assert_glob = |path: &str, count: usize| {
-        assert_eq!(
-            glob(&p.root().join(path).to_str().unwrap())
-                .unwrap()
-                .count(),
-            count
-        );
-    };
-
     p.cargo("check").run();
     assert!(!p.root().join("target/debug/libfoo.rmeta").is_file());
     assert!(!p.root().join("target/debug/libfoo.rlib").is_file());
     assert!(!p.root().join("target/debug").join(exe("foo")).is_file());
-    assert_glob("target/debug/deps/libfoo-*.rmeta", 2);
+    assert_eq!(p.glob("target/debug/deps/libfoo-*.rmeta").count(), 2);
 
     p.root().join("target").rm_rf();
     p.cargo("check --lib").run();
     assert!(!p.root().join("target/debug/libfoo.rmeta").is_file());
     assert!(!p.root().join("target/debug/libfoo.rlib").is_file());
     assert!(!p.root().join("target/debug").join(exe("foo")).is_file());
-    assert_glob("target/debug/deps/libfoo-*.rmeta", 1);
+    assert_eq!(p.glob("target/debug/deps/libfoo-*.rmeta").count(), 1);
 
     p.root().join("target").rm_rf();
     p.cargo("check --bin foo").run();
     assert!(!p.root().join("target/debug/libfoo.rmeta").is_file());
     assert!(!p.root().join("target/debug/libfoo.rlib").is_file());
     assert!(!p.root().join("target/debug").join(exe("foo")).is_file());
-    assert_glob("target/debug/deps/libfoo-*.rmeta", 2);
+    assert_eq!(p.glob("target/debug/deps/libfoo-*.rmeta").count(), 2);
 
     p.root().join("target").rm_rf();
     p.cargo("check --test t1").run();
     assert!(!p.root().join("target/debug/libfoo.rmeta").is_file());
     assert!(!p.root().join("target/debug/libfoo.rlib").is_file());
     assert!(!p.root().join("target/debug").join(exe("foo")).is_file());
-    assert_glob("target/debug/t1-*", 0);
-    assert_glob("target/debug/deps/libfoo-*.rmeta", 1);
-    assert_glob("target/debug/deps/libt1-*.rmeta", 1);
+    assert_eq!(p.glob("target/debug/t1-*").count(), 0);
+    assert_eq!(p.glob("target/debug/deps/libfoo-*.rmeta").count(), 1);
+    assert_eq!(p.glob("target/debug/deps/libt1-*.rmeta").count(), 1);
 
     p.root().join("target").rm_rf();
     p.cargo("check --example ex1").run();
@@ -670,17 +660,17 @@ fn check_artifacts() {
         .join("target/debug/examples")
         .join(exe("ex1"))
         .is_file());
-    assert_glob("target/debug/deps/libfoo-*.rmeta", 1);
-    assert_glob("target/debug/examples/libex1-*.rmeta", 1);
+    assert_eq!(p.glob("target/debug/deps/libfoo-*.rmeta").count(), 1);
+    assert_eq!(p.glob("target/debug/examples/libex1-*.rmeta").count(), 1);
 
     p.root().join("target").rm_rf();
     p.cargo("check --bench b1").run();
     assert!(!p.root().join("target/debug/libfoo.rmeta").is_file());
     assert!(!p.root().join("target/debug/libfoo.rlib").is_file());
     assert!(!p.root().join("target/debug").join(exe("foo")).is_file());
-    assert_glob("target/debug/b1-*", 0);
-    assert_glob("target/debug/deps/libfoo-*.rmeta", 1);
-    assert_glob("target/debug/deps/libb1-*.rmeta", 1);
+    assert_eq!(p.glob("target/debug/b1-*").count(), 0);
+    assert_eq!(p.glob("target/debug/deps/libfoo-*.rmeta").count(), 1);
+    assert_eq!(p.glob("target/debug/deps/libb1-*.rmeta").count(), 1);
 }
 
 #[test]

--- a/tests/testsuite/doc.rs
+++ b/tests/testsuite/doc.rs
@@ -2,8 +2,6 @@ use std::fs::{self, File};
 use std::io::Read;
 use std::str;
 
-use glob::glob;
-
 use crate::support::paths::CargoPathExt;
 use crate::support::registry::Package;
 use crate::support::{basic_lib_manifest, basic_manifest, git, project};
@@ -113,23 +111,8 @@ fn doc_deps() {
     assert!(p.root().join("target/doc/bar/index.html").is_file());
 
     // Verify that it only emits rmeta for the dependency.
-    assert_eq!(
-        glob(&p.root().join("target/debug/**/*.rlib").to_str().unwrap())
-            .unwrap()
-            .count(),
-        0
-    );
-    assert_eq!(
-        glob(
-            &p.root()
-                .join("target/debug/deps/libbar-*.rmeta")
-                .to_str()
-                .unwrap()
-        )
-        .unwrap()
-        .count(),
-        1
-    );
+    assert_eq!(p.glob("target/debug/**/*.rlib").count(), 0);
+    assert_eq!(p.glob("target/debug/deps/libbar-*.rmeta").count(), 1);
 
     p.cargo("doc")
         .env("RUST_LOG", "cargo::ops::cargo_rustc::fingerprint")

--- a/tests/testsuite/metabuild.rs
+++ b/tests/testsuite/metabuild.rs
@@ -2,7 +2,6 @@ use crate::support::{
     basic_lib_manifest, basic_manifest, is_coarse_mtime, project, registry::Package, rustc_host,
     Project,
 };
-use glob::glob;
 use serde_json;
 use std::str;
 
@@ -537,17 +536,7 @@ fn metabuild_build_plan() {
         )
         .run();
 
-    assert_eq!(
-        glob(
-            &p.root()
-                .join("target/.metabuild/metabuild-foo-*.rs")
-                .to_str()
-                .unwrap()
-        )
-        .unwrap()
-        .count(),
-        1
-    );
+    assert_eq!(p.glob("target/.metabuild/metabuild-foo-*.rs").count(), 1);
 }
 
 #[test]
@@ -623,14 +612,7 @@ fn metabuild_two_versions() {
         .run();
 
     assert_eq!(
-        glob(
-            &p.root()
-                .join("target/.metabuild/metabuild-member?-*.rs")
-                .to_str()
-                .unwrap()
-        )
-        .unwrap()
-        .count(),
+        p.glob("target/.metabuild/metabuild-member?-*.rs").count(),
         2
     );
 }
@@ -681,17 +663,7 @@ fn metabuild_external_dependency() {
         .with_stdout_contains("[dep 1.0.0] Hello mb")
         .run();
 
-    assert_eq!(
-        glob(
-            &p.root()
-                .join("target/.metabuild/metabuild-dep-*.rs")
-                .to_str()
-                .unwrap()
-        )
-        .unwrap()
-        .count(),
-        1
-    );
+    assert_eq!(p.glob("target/.metabuild/metabuild-dep-*.rs").count(), 1);
 }
 
 #[test]

--- a/tests/testsuite/support/mod.rs
+++ b/tests/testsuite/support/mod.rs
@@ -370,6 +370,14 @@ impl Project {
         ))
     }
 
+    /// Returns an iterator of paths matching the glob pattern, which is
+    /// relative to the project root.
+    pub fn glob<P: AsRef<Path>>(&self, pattern: P) -> glob::Paths {
+        let pattern = self.root().join(pattern);
+        glob::glob(pattern.to_str().expect("failed to convert pattern to str"))
+            .expect("failed to glob")
+    }
+
     /// Changes the contents of an existing file.
     pub fn change_file(&self, path: &str, body: &str) {
         FileBuilder::new(self.root().join(path), body).mk()
@@ -753,7 +761,6 @@ impl Execs {
                 p.cwd(cwd.join(path.as_ref()));
             } else {
                 p.cwd(path);
-
             }
         }
         self


### PR DESCRIPTION
Just a minor cleanup.

Move `CARGO_PKG_*` values from Metadata to Fingerprint (added in #3857).  Closes #6208.  This prevents stale artifacts from being left behind when these values change. Also tracks changes to the "repository" value (added in #6096).

Remove `edition` as a separate field. It is already tracked in `target`. This was required previously to #5816 which added per-target editions.

Also adds a helper to the testsuite to make globbing easier.
