### PR TITLE
Fix Init for Fossil SCM project

### DIFF
--- a/src/cargo/ops/cargo_new.rs
+++ b/src/cargo/ops/cargo_new.rs
@@ -524,7 +524,7 @@ fn init_vcs(path: &Path, vcs: VersionControl, config: &Config) -> CargoResult<()
             }
         }
         VersionControl::Fossil => {
-            if path.join(".fossil").exists() {
+            if !path.join(".fossil").exists() {
                 FossilRepo::init(path, config.cwd())?;
             }
         }


### PR DESCRIPTION
I believe [here](https://github.com/rust-lang/cargo/pull/6792/files#diff-149dd4362a3b0dc13b113762713119dfL527) we should be checking if `.fossil` doesn't exist instead of the latter!