### PR TITLE
Support force-pushed repos with git-fetch-with-cli.

### DIFF
--- a/src/cargo/sources/git/utils.rs
+++ b/src/cargo/sources/git/utils.rs
@@ -765,7 +765,7 @@ fn fetch_with_cli(
     let mut cmd = process("git");
     cmd.arg("fetch")
         .arg("--tags") // fetch all tags
-        .arg("--quiet")
+        .arg("--force") // handle force pushes
         .arg("--update-head-ok") // see discussion in #2078
         .arg(url.to_string())
         .arg(refspec)
@@ -773,7 +773,7 @@ fn fetch_with_cli(
     config
         .shell()
         .verbose(|s| s.status("Running", &cmd.to_string()))?;
-    cmd.exec()?;
+    cmd.exec_with_output()?;
     Ok(())
 }
 

--- a/tests/testsuite/git.rs
+++ b/tests/testsuite/git.rs
@@ -13,6 +13,13 @@ use crate::support::sleep_ms;
 use crate::support::Project;
 use crate::support::{basic_lib_manifest, basic_manifest, git, main_file, path2url, project};
 
+fn disable_git_cli() -> bool {
+    // mingw git on Windows does not support Windows-style file URIs.
+    // Appveyor in the rust repo has that git up front in the PATH instead
+    // of Git-for-Windows, which causes this to fail.
+    env::var("CARGO_TEST_DISABLE_GIT_CLI") == Ok("1".to_string())
+}
+
 #[test]
 fn cargo_compile_simple_git_dep() {
     let project = project();
@@ -2772,10 +2779,7 @@ fn failed_submodule_checkout() {
 
 #[test]
 fn use_the_cli() {
-    if env::var("CARGO_TEST_DISABLE_GIT_CLI") == Ok("1".to_string()) {
-        // mingw git on Windows does not support Windows-style file URIs.
-        // Appveyor in the rust repo has that git up front in the PATH instead
-        // of Git-for-Windows, which causes this to fail.
+    if disable_git_cli() {
         return;
     }
     let project = project();
@@ -2879,4 +2883,65 @@ fn templatedir_doesnt_cause_problems() {
         .unwrap();
 
     p.cargo("build").run();
+}
+
+#[test]
+fn git_with_cli_force() {
+    if disable_git_cli() {
+        return;
+    }
+    // Supports a force-pushed repo.
+    let git_project = git::new("dep1", |project| {
+        project
+            .file("Cargo.toml", &basic_lib_manifest("dep1"))
+            .file("src/lib.rs", r#"pub fn f() { println!("one"); }"#)
+    })
+    .unwrap();
+    let p = project()
+        .file(
+            "Cargo.toml",
+            &format!(
+                r#"
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                edition = "2018"
+
+                [dependencies]
+                dep1 = {{ git = "{}" }}
+                "#,
+                git_project.url()
+            ),
+        )
+        .file("src/main.rs", "fn main() { dep1::f(); }")
+        .file(
+            ".cargo/config",
+            "
+            [net]
+            git-fetch-with-cli = true
+            ",
+        )
+        .build();
+    p.cargo("build").run();
+    p.rename_run("foo", "foo1").with_stdout("one").run();
+
+    // commit --amend a change that will require a force fetch.
+    let repo = git2::Repository::open(&git_project.root()).unwrap();
+    git_project.change_file("src/lib.rs", r#"pub fn f() { println!("two"); }"#);
+    git::add(&repo);
+    let id = repo.refname_to_id("HEAD").unwrap();
+    let commit = repo.find_commit(id).unwrap();
+    let tree_id = t!(t!(repo.index()).write_tree());
+    t!(commit.amend(
+        Some("HEAD"),
+        None,
+        None,
+        None,
+        None,
+        Some(&t!(repo.find_tree(tree_id)))
+    ));
+    // Perform the fetch.
+    p.cargo("update").run();
+    p.cargo("build").run();
+    p.rename_run("foo", "foo2").with_stdout("two").run();
 }


### PR DESCRIPTION
If a git repo had a force push, then the `git-fetch-with-cli` feature would fail to fetch an update.  This adds the `--force` flag to force the fetch.  There's a bit of a lengthy discussion in the [git docs](https://git-scm.com/docs/git-fetch#Documentation/git-fetch.txt-ltrefspecgt) about why this is needed when a refspec is supplied.

I also changed it to remove the `--quiet` flag and to capture the output, which is only displayed on error.  I'm not sure what the reasoning for the `--quiet` flag was, but I don't see any harm since the output was previously unused.  This can maybe help people debug problems, however in this situation 
all you would see is ` ! [rejected]        master     -> master  (non-fast-forward)` which isn't terribly informative.

Fixes #6795.