### PR TITLE
new/init: Don't include email if it is empty.

### DIFF
--- a/src/cargo/ops/cargo_new.rs
+++ b/src/cargo/ops/cargo_new.rs
@@ -567,7 +567,13 @@ fn mk(config: &Config, opts: &MkOptions<'_>) -> CargoResult<()> {
         (Some(name), Some(email), _, _)
         | (Some(name), None, _, Some(email))
         | (None, Some(email), name, _)
-        | (None, None, name, Some(email)) => format!("{} <{}>", name, email),
+        | (None, None, name, Some(email)) => {
+            if email.is_empty() {
+                name
+            } else {
+                format!("{} <{}>", name, email)
+            }
+        }
         (Some(name), None, _, None) | (None, None, name, None) => name,
     };
 

--- a/tests/testsuite/new.rs
+++ b/tests/testsuite/new.rs
@@ -511,3 +511,14 @@ fn new_with_bad_edition() {
         .with_status(1)
         .run();
 }
+
+#[test]
+fn new_with_blank_email() {
+    cargo_process("new foo")
+        .env("CARGO_NAME", "Sen")
+        .env("CARGO_EMAIL", "")
+        .run();
+
+    let contents = fs::read_to_string(paths::root().join("foo/Cargo.toml")).unwrap();
+    assert!(contents.contains(r#"authors = ["Sen"]"#), contents);
+}


### PR DESCRIPTION
For `cargo new` or `cargo init`, if the email address is empty, don't include an empty `<>` in the `authors` field in `Cargo.toml`. This can be useful if you want to include an email address in the git config, but you don't want it in new manifest files.

Closes #4892
