### PR TITLE
Allow `cargo install --path P` to load config from P.

### DIFF
--- a/src/bin/cargo/commands/install.rs
+++ b/src/bin/cargo/commands/install.rs
@@ -78,7 +78,11 @@ continuous integration systems.",
 pub fn exec(config: &mut Config, args: &ArgMatches<'_>) -> CliResult {
     let registry = args.registry(config)?;
 
-    config.reload_rooted_at_cargo_home()?;
+    if let Some(path) = args.value_of_path("path", config) {
+        config.reload_rooted_at(path)?;
+    } else {
+        config.reload_rooted_at(config.home().clone().into_path_unlocked())?;
+    }
 
     let workspace = args.workspace(config).ok();
     let mut compile_opts = args.compile_options(config, CompileMode::Build, workspace.as_ref())?;

--- a/src/cargo/util/config.rs
+++ b/src/cargo/util/config.rs
@@ -285,9 +285,8 @@ impl Config {
         }
     }
 
-    pub fn reload_rooted_at_cargo_home(&mut self) -> CargoResult<()> {
-        let home = self.home_path.clone().into_path_unlocked();
-        let values = self.load_values_from(&home)?;
+    pub fn reload_rooted_at<P: AsRef<Path>>(&mut self, path: P) -> CargoResult<()> {
+        let values = self.load_values_from(path.as_ref())?;
         self.values.replace(values);
         Ok(())
     }

--- a/tests/testsuite/install.rs
+++ b/tests/testsuite/install.rs
@@ -1358,3 +1358,21 @@ fn install_global_cargo_config() {
         .with_stderr_contains("[..]--target nonexistent[..]")
         .run();
 }
+
+#[test]
+fn install_path_config() {
+    project()
+        .file(
+            ".cargo/config",
+            r#"
+            [build]
+            target = 'nonexistent'
+            "#,
+        )
+        .file("src/main.rs", "fn main() {}")
+        .build();
+    cargo_process("install --path foo")
+        .with_status(101)
+        .with_stderr_contains("[..]--target nonexistent[..]")
+        .run();
+}


### PR DESCRIPTION
`cargo install` was changed to ignore configs except for the home directory (#6026). However, it seems like there are legitimate needs when using `--path`, so allow loading from that path, too.

Closes #6498.
Closes #6397.
