### PR TITLE
Warn on version req with metadata.

### DIFF
--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -1318,6 +1318,17 @@ impl DetailedTomlDependency {
             cx.warnings.push(msg);
         }
 
+        if let Some(version) = &self.version {
+            if version.contains('+') {
+                cx.warnings.push(format!(
+                    "version requirement `{}` for dependency `{}` \
+                     includes semver metadata which will be ignored, removing the \
+                     metadata is recommended to avoid confusion",
+                    version, name_in_toml
+                ));
+            }
+        }
+
         if self.git.is_none() {
             let git_only_keys = [
                 (&self.branch, "branch"),

--- a/tests/testsuite/bad_config.rs
+++ b/tests/testsuite/bad_config.rs
@@ -1280,3 +1280,25 @@ Caused by:
         )
         .run();
 }
+
+#[test]
+fn warn_semver_metadata() {
+    Package::new("bar", "1.0.0").publish();
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "foo"
+            version = "1.0.0"
+
+            [dependencies]
+            bar = "1.0.0+1234"
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+    p.cargo("check")
+        .with_stderr_contains("[WARNING] version requirement `1.0.0+1234` for dependency `bar`[..]")
+        .run();
+}


### PR DESCRIPTION
Metadata in a version requirement (such as `1.0.0+1234`) is ignored. This adds a warning that it will be ignored.

On crates.io I found about 5 crates, plus a few dozen google-* crates (presumably all created by the same person) which have dependencies of this form.

See discussion at https://github.com/rust-lang/cargo/issues/6504#issuecomment-451254084. cc rust-lang/crates.io#1059 for ongoing discussion about what to do about publishing such versions.
