### PR TITLE
Fix unused import warning.

### DIFF
--- a/tests/testsuite/death.rs
+++ b/tests/testsuite/death.rs
@@ -131,8 +131,6 @@ fn ctrl_c_kills_everyone() {
 
 #[cfg(unix)]
 fn ctrl_c(child: &mut Child) {
-    use libc;
-
     let r = unsafe { libc::kill(-(child.id() as i32), libc::SIGINT) };
     if r < 0 {
         panic!("failed to kill: {}", io::Error::last_os_error());


### PR DESCRIPTION
2019-04-01 nightly introduced a new warning (presumably rust-lang/rust#58805).