### PR TITLE
Include proc-macros in `build-override`.

### DIFF
--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -118,8 +118,9 @@ opt-level = 3
 [profile.dev.overrides."*"]
 opt-level = 2
 
-# Build scripts and their dependencies will be compiled with -Copt-level=3
-# By default, build scripts use the same rules as the rest of the profile
+# Build scripts or proc-macros and their dependencies will be compiled with
+# `-Copt-level=3`. By default, they use the same rules as the rest of the
+# profile.
 [profile.dev.build-override]
 opt-level = 3
 ```


### PR DESCRIPTION
This adds proc-macros (and their dependencies) to the `build-override` profile setting.  The motivation is that these are all "build time" dependencies, and as such should probably behave the same.  See the discussion on the [tracking issue](https://github.com/rust-lang/rust/issues/48683#issuecomment-472705245).  My intent is that this paves the way for stabilizing without necessarily waiting for #6577.

The only change here is the line in `with_for_host`, the rest is just renaming for clarity.

This also includes some of the testsuite changes from #6577 to make it easier to check for compiler flags.
