### PR TITLE
Don't include metadata in wasm binary examples.

### DIFF
--- a/src/cargo/core/compiler/context/compilation_files.rs
+++ b/src/cargo/core/compiler/context/compilation_files.rs
@@ -444,7 +444,7 @@ fn compute_metadata<'a, 'cfg>(
     if !(unit.mode.is_any_test() || unit.mode.is_check())
         && (unit.target.is_dylib()
             || unit.target.is_cdylib()
-            || (unit.target.is_bin() && bcx.target_triple().starts_with("wasm32-")))
+            || (unit.target.is_executable() && bcx.target_triple().starts_with("wasm32-")))
         && unit.pkg.package_id().source_id().is_path()
         && __cargo_default_lib_metadata.is_err()
     {

--- a/src/cargo/core/compiler/context/mod.rs
+++ b/src/cargo/core/compiler/context/mod.rs
@@ -170,7 +170,7 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
                         unit.target.clone(),
                         output.path.clone(),
                     ));
-                } else if unit.target.is_bin() || unit.target.is_bin_example() {
+                } else if unit.target.is_executable() {
                     self.compilation.binaries.push(bindst.clone());
                 }
             }
@@ -276,7 +276,7 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
                 continue;
             }
 
-            let is_binary = unit.target.is_bin() || unit.target.is_bin_example();
+            let is_binary = unit.target.is_executable();
             let is_test = unit.mode.is_any_test() && !unit.mode.is_check();
 
             if is_binary || is_test {

--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -814,7 +814,14 @@ impl Target {
         }
     }
 
-    pub fn is_bin_example(&self) -> bool {
+    /// Returns `true` if it is a binary or executable example.
+    /// NOTE: Tests are `false`!
+    pub fn is_executable(&self) -> bool {
+        self.is_bin() || self.is_exe_example()
+    }
+
+    /// Returns `true` if it is an executable example.
+    pub fn is_exe_example(&self) -> bool {
         // Needed for --all-examples in contexts where only runnable examples make sense
         match self.kind {
             TargetKind::ExampleBin => true,

--- a/src/cargo/ops/cargo_install.rs
+++ b/src/cargo/ops/cargo_install.rs
@@ -475,7 +475,7 @@ fn find_duplicates(
             let all_examples: Vec<String> = examples.try_collect().unwrap_or_else(|| {
                 pkg.targets()
                     .iter()
-                    .filter(|t| t.is_bin_example())
+                    .filter(|t| t.is_exe_example())
                     .map(|t| t.name().to_string())
                     .collect()
             });


### PR DESCRIPTION
This removes the metadata hash from wasm example binaries, and consequently also includes the `.wasm` files in the artifact JSON message.

Closes #6810.

I renamed a method and added a new one to maybe make things a little clearer. This cannot be easily tested (see #4973).