### PR TITLE
Handle symlinks to directories

### DIFF
--- a/ci/azure-test-all.yml
+++ b/ci/azure-test-all.yml
@@ -26,10 +26,3 @@ steps:
 # fix the link errors.
 - bash: cargo test --features 'deny-warnings curl/force-system-lib-on-osx'
   displayName: "cargo test"
-
-# Run any tests that have been marked ignore.
-#
-# `--include-ignored` is only supported on nightly so far, so we have to call
-# this separately for now.
-- bash: cargo test --features 'deny-warnings curl/force-system-lib-on-osx' -- --ignored
-  displayName: "cargo test -- --ignored"

--- a/ci/azure-test-all.yml
+++ b/ci/azure-test-all.yml
@@ -26,3 +26,10 @@ steps:
 # fix the link errors.
 - bash: cargo test --features 'deny-warnings curl/force-system-lib-on-osx'
   displayName: "cargo test"
+
+# Run any tests that have been marked ignore.
+#
+# `--include-ignored` is only supported on nightly so far, so we have to call
+# this separately for now.
+- bash: cargo test --features 'deny-warnings curl/force-system-lib-on-osx' -- --ignored
+  displayName: "cargo test -- --ignored"

--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -21,7 +21,7 @@
 //! 3. To actually perform the feature gate, you'll want to have code that looks
 //!    like:
 //!
-//! ```rust,ignore
+//! ```rust,compile_fail
 //! use core::{Feature, Features};
 //!
 //! let feature = Feature::launch_into_space();

--- a/src/cargo/util/network.rs
+++ b/src/cargo/util/network.rs
@@ -73,9 +73,12 @@ fn maybe_spurious(err: &Error) -> bool {
 ///
 /// # Examples
 ///
-/// ```ignore
-/// use util::network;
-/// cargo_result = network::with_retry(&config, || something.download());
+/// ```
+/// # use crate::cargo::util::{CargoResult, Config};
+/// # let download_something = || return Ok(());
+/// # let config = Config::default().unwrap();
+/// use cargo::util::network;
+/// let cargo_result = network::with_retry(&config, || download_something());
 /// ```
 pub fn with_retry<T, F>(config: &Config, mut callback: F) -> CargoResult<T>
 where

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -1495,12 +1495,12 @@ package `test v0.0.0 ([CWD])`",
 }
 
 #[cargo_test]
+#[cfg_attr(windows, ignore)]
+/// Make sure ignored symlinks don't break the build
+///
+/// This test is marked ``ignore`` on Windows because it needs admin permissions.
+/// Run it with ``--ignored``.
 fn ignore_broken_symlinks() {
-    // windows and symlinks don't currently agree that well
-    if cfg!(windows) {
-        return;
-    }
-
     let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
         .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -4,11 +4,10 @@ use std::io::prelude::*;
 
 use crate::support::paths::{root, CargoPathExt};
 use crate::support::registry::Package;
-use crate::support::ProjectBuilder;
 use crate::support::{
-    basic_bin_manifest, basic_lib_manifest, basic_manifest, rustc_host, sleep_ms,
+    basic_bin_manifest, basic_lib_manifest, basic_manifest, main_file, project, rustc_host,
+    sleep_ms, symlink_supported, Execs, ProjectBuilder,
 };
-use crate::support::{main_file, project, Execs};
 use cargo::util::paths::dylib_path_envvar;
 
 #[cargo_test]
@@ -1495,12 +1494,15 @@ package `test v0.0.0 ([CWD])`",
 }
 
 #[cargo_test]
-#[cfg_attr(windows, ignore)]
-/// Make sure ignored symlinks don't break the build
+/// Make sure broken symlinks don't break the build
 ///
-/// This test is marked ``ignore`` on Windows because it needs admin permissions.
-/// Run it with ``--ignored``.
+/// This test requires you to be able to make symlinks.
+/// For windows, this may require you to enable developer mode.
 fn ignore_broken_symlinks() {
+    if !symlink_supported() {
+        return;
+    }
+
     let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
         .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))

--- a/tests/testsuite/package.rs
+++ b/tests/testsuite/package.rs
@@ -509,7 +509,7 @@ fn package_symlink_to_submodule() {
     #[cfg(unix)]
     use std::os::unix::fs::symlink as symlink;
     #[cfg(windows)]
-    use std::os::unix::fs::symlink_dir as symlink;
+    use std::os::windows::fs::symlink_dir as symlink;
 
     let project = git::new("foo", |project| {
         project
@@ -697,9 +697,11 @@ See [..]
 }
 
 #[cargo_test]
-#[cfg(unix)]
 fn broken_symlink() {
-    use std::os::unix::fs;
+    #[cfg(unix)]
+    use std::os::unix::fs::symlink as symlink;
+    #[cfg(windows)]
+    use std::os::windows::fs::symlink_dir as symlink;
 
     let p = project()
         .file(
@@ -718,7 +720,7 @@ fn broken_symlink() {
         )
         .file("src/main.rs", r#"fn main() { println!("hello"); }"#)
         .build();
-    t!(fs::symlink("nowhere", &p.root().join("src/foo.rs")));
+    t!(symlink("nowhere", &p.root().join("src/foo.rs")));
 
     p.cargo("package -v")
         .with_status(101)

--- a/tests/testsuite/package.rs
+++ b/tests/testsuite/package.rs
@@ -3,11 +3,11 @@ use std::fs::File;
 use std::io::prelude::*;
 use std::path::Path;
 
-use crate::support::cargo_process;
 use crate::support::paths::CargoPathExt;
 use crate::support::registry::Package;
 use crate::support::{
-    basic_manifest, git, path2url, paths, project, publish::validate_crate_contents, registry,
+    basic_manifest, cargo_process, git, path2url, paths, project, publish::validate_crate_contents,
+    registry, symlink_supported,
 };
 use git2;
 
@@ -505,21 +505,19 @@ fn package_git_submodule() {
 }
 
 #[cargo_test]
-#[cfg_attr(windows, ignore)]
 /// Tests if a symlink to a git submodule is properly handled.
 ///
-/// This test is ignored on Windows, because it needs Administrator
-/// permissions to run. If you do want to run this test, please
-/// run the tests with ``--ignored``, e.g.
-///
-/// ```text
-/// cargo test -- --ignored
-/// ```
+/// This test requires you to be able to make symlinks.
+/// For windows, this may require you to enable developer mode.
 fn package_symlink_to_submodule() {
     #[cfg(unix)]
     use std::os::unix::fs::symlink;
     #[cfg(windows)]
     use std::os::windows::fs::symlink_dir as symlink;
+
+    if !symlink_supported() {
+        return;
+    }
 
     let project = git::new("foo", |project| {
         project.file("src/lib.rs", "pub fn foo() {}")
@@ -712,21 +710,19 @@ See [..]
 }
 
 #[cargo_test]
-#[cfg_attr(windows, ignore)]
 /// Tests if a broken symlink is properly handled when packaging.
 ///
-/// This test is ignored on Windows, because it needs Administrator
-/// permissions to run. If you do want to run this test, please
-/// run the tests with ``--ignored``, e.g.
-///
-/// ```text
-/// cargo test -- --ignored
-/// ```
+/// This test requires you to be able to make symlinks.
+/// For windows, this may require you to enable developer mode.
 fn broken_symlink() {
     #[cfg(unix)]
     use std::os::unix::fs::symlink;
     #[cfg(windows)]
     use std::os::windows::fs::symlink_dir as symlink;
+
+    if !symlink_supported() {
+        return;
+    }
 
     let p = project()
         .file(
@@ -764,17 +760,16 @@ Caused by:
 }
 
 #[cargo_test]
-#[cfg_attr(windows, ignore)]
 /// Tests if a symlink to a directory is proberly included.
 ///
-/// This test is ignored on Windows, because it needs Administrator
-/// permissions to run. If you do want to run this test, please
-/// run the tests with ``--ignored``, e.g.
-///
-/// ```text
-/// cargo test -- --ignored
-/// ```
+/// This test requires you to be able to make symlinks.
+/// For windows, this may require you to enable developer mode.
 fn package_symlink_to_dir() {
+
+    if !symlink_supported() {
+        return;
+    }
+
     project()
         .file("src/main.rs", r#"fn main() { println!("hello"); }"#)
         .file("bla/Makefile", "all:")

--- a/tests/testsuite/package.rs
+++ b/tests/testsuite/package.rs
@@ -765,7 +765,6 @@ Caused by:
 /// This test requires you to be able to make symlinks.
 /// For windows, this may require you to enable developer mode.
 fn package_symlink_to_dir() {
-
     if !symlink_supported() {
         return;
     }

--- a/tests/testsuite/package.rs
+++ b/tests/testsuite/package.rs
@@ -505,25 +505,39 @@ fn package_git_submodule() {
 }
 
 #[cargo_test]
+#[cfg_attr(windows, ignore)]
+/// Tests if a symlink to a git submodule is properly handled.
+///
+/// This test is ignored on Windows, because it needs Administrator
+/// permissions to run. If you do want to run this test, please
+/// run the tests with ``--ignored``, e.g.
+///
+/// ```text
+/// cargo test -- --ignored
+/// ```
 fn package_symlink_to_submodule() {
     #[cfg(unix)]
-    use std::os::unix::fs::symlink as symlink;
+    use std::os::unix::fs::symlink;
     #[cfg(windows)]
     use std::os::windows::fs::symlink_dir as symlink;
 
     let project = git::new("foo", |project| {
-        project
-            .file("src/lib.rs", "pub fn foo() {}")
-        }).unwrap();
+        project.file("src/lib.rs", "pub fn foo() {}")
+    })
+    .unwrap();
 
     let library = git::new("submodule", |library| {
         library.no_manifest().file("Makefile", "all:")
-    }).unwrap();
+    })
+    .unwrap();
 
     let repository = git2::Repository::open(&project.root()).unwrap();
     let url = path2url(library.root()).to_string();
     git::add_submodule(&repository, &url, Path::new("submodule"));
-    t!(symlink(&project.root().join("submodule"), &project.root().join("submodule-link")));
+    t!(symlink(
+        &project.root().join("submodule"),
+        &project.root().join("submodule-link")
+    ));
     git::add(&repository);
     git::commit(&repository);
 
@@ -532,8 +546,9 @@ fn package_symlink_to_submodule() {
         .reset(
             &repository.revparse_single("HEAD").unwrap(),
             git2::ResetType::Hard,
-            None
-        ).unwrap();
+            None,
+        )
+        .unwrap();
 
     project
         .cargo("package --no-verify -v")
@@ -697,9 +712,19 @@ See [..]
 }
 
 #[cargo_test]
+#[cfg_attr(windows, ignore)]
+/// Tests if a broken symlink is properly handled when packaging.
+///
+/// This test is ignored on Windows, because it needs Administrator
+/// permissions to run. If you do want to run this test, please
+/// run the tests with ``--ignored``, e.g.
+///
+/// ```text
+/// cargo test -- --ignored
+/// ```
 fn broken_symlink() {
     #[cfg(unix)]
-    use std::os::unix::fs::symlink as symlink;
+    use std::os::unix::fs::symlink;
     #[cfg(windows)]
     use std::os::windows::fs::symlink_dir as symlink;
 
@@ -739,6 +764,16 @@ Caused by:
 }
 
 #[cargo_test]
+#[cfg_attr(windows, ignore)]
+/// Tests if a symlink to a directory is proberly included.
+///
+/// This test is ignored on Windows, because it needs Administrator
+/// permissions to run. If you do want to run this test, please
+/// run the tests with ``--ignored``, e.g.
+///
+/// ```text
+/// cargo test -- --ignored
+/// ```
 fn package_symlink_to_dir() {
     project()
         .file("src/main.rs", r#"fn main() { println!("hello"); }"#)

--- a/tests/testsuite/small_fd_limits.rs
+++ b/tests/testsuite/small_fd_limits.rs
@@ -98,9 +98,6 @@ fn use_git_gc() {
 }
 
 #[cargo_test]
-// it looks like this test passes on some windows machines but not others,
-// notably not on AppVeyor's machines. Sounds like another but for another day.
-#[cfg_attr(windows, ignore)]
 fn avoid_using_git() {
     let path = env::var_os("PATH").unwrap_or_default();
     let mut paths = env::split_paths(&path).collect::<Vec<_>>();

--- a/tests/testsuite/support/mod.rs
+++ b/tests/testsuite/support/mod.rs
@@ -178,11 +178,16 @@ impl FileBuilder {
 struct SymlinkBuilder {
     dst: PathBuf,
     src: PathBuf,
+    src_is_dir: bool,
 }
 
 impl SymlinkBuilder {
     pub fn new(dst: PathBuf, src: PathBuf) -> SymlinkBuilder {
-        SymlinkBuilder { dst, src }
+        SymlinkBuilder { dst, src, src_is_dir: false }
+    }
+
+    pub fn new_dir(dst: PathBuf, src: PathBuf) -> SymlinkBuilder {
+        SymlinkBuilder { dst, src, src_is_dir: true }
     }
 
     #[cfg(unix)]
@@ -194,7 +199,11 @@ impl SymlinkBuilder {
     #[cfg(windows)]
     fn mk(&self) {
         self.dirname().mkdir_p();
-        t!(os::windows::fs::symlink_file(&self.dst, &self.src));
+        if self.src_is_dir {
+            t!(os::window::fs::symlink_dir(&self.dst, &self.src));
+        } else {
+            t!(os::windows::fs::symlink_file(&self.dst, &self.src));
+        }
     }
 
     fn dirname(&self) -> &Path {
@@ -258,6 +267,14 @@ impl ProjectBuilder {
             self.root.root().join(dst),
             self.root.root().join(src),
         ));
+        self
+    }
+
+    pub fn symlink_dir<T: AsRef<Path>>(mut self, dst: T, src: T) -> Self {
+        self.symlinks.push(SymlinkBuilder::new_dir(
+                self.root.root().join(dst),
+                self.root.root().join(src),
+            ));
         self
     }
 

--- a/tests/testsuite/support/mod.rs
+++ b/tests/testsuite/support/mod.rs
@@ -183,11 +183,19 @@ struct SymlinkBuilder {
 
 impl SymlinkBuilder {
     pub fn new(dst: PathBuf, src: PathBuf) -> SymlinkBuilder {
-        SymlinkBuilder { dst, src, src_is_dir: false }
+        SymlinkBuilder {
+            dst,
+            src,
+            src_is_dir: false,
+        }
     }
 
     pub fn new_dir(dst: PathBuf, src: PathBuf) -> SymlinkBuilder {
-        SymlinkBuilder { dst, src, src_is_dir: true }
+        SymlinkBuilder {
+            dst,
+            src,
+            src_is_dir: true,
+        }
     }
 
     #[cfg(unix)]
@@ -273,9 +281,9 @@ impl ProjectBuilder {
     /// Create a symlink to a directory
     pub fn symlink_dir<T: AsRef<Path>>(mut self, dst: T, src: T) -> Self {
         self.symlinks.push(SymlinkBuilder::new_dir(
-                self.root.root().join(dst),
-                self.root.root().join(src),
-            ));
+            self.root.root().join(dst),
+            self.root.root().join(src),
+        ));
         self
     }
 

--- a/tests/testsuite/support/mod.rs
+++ b/tests/testsuite/support/mod.rs
@@ -200,7 +200,7 @@ impl SymlinkBuilder {
     fn mk(&self) {
         self.dirname().mkdir_p();
         if self.src_is_dir {
-            t!(os::window::fs::symlink_dir(&self.dst, &self.src));
+            t!(os::windows::fs::symlink_dir(&self.dst, &self.src));
         } else {
             t!(os::windows::fs::symlink_file(&self.dst, &self.src));
         }
@@ -261,7 +261,7 @@ impl ProjectBuilder {
             .push(FileBuilder::new(self.root.root().join(path), body));
     }
 
-    /// Adds a symlink to the project.
+    /// Adds a symlink to a file to the project.
     pub fn symlink<T: AsRef<Path>>(mut self, dst: T, src: T) -> Self {
         self.symlinks.push(SymlinkBuilder::new(
             self.root.root().join(dst),
@@ -270,6 +270,7 @@ impl ProjectBuilder {
         self
     }
 
+    /// Create a symlink to a directory
     pub fn symlink_dir<T: AsRef<Path>>(mut self, dst: T, src: T) -> Self {
         self.symlinks.push(SymlinkBuilder::new_dir(
                 self.root.root().join(dst),

--- a/tests/testsuite/support/paths.rs
+++ b/tests/testsuite/support/paths.rs
@@ -153,7 +153,7 @@ impl CargoPathExt for Path {
         where
             F: Fn(i64, u32) -> ((i64, u32)),
         {
-            let stat = t!(path.metadata());
+            let stat = t!(path.symlink_metadata());
 
             let mtime = FileTime::from_last_modification_time(&stat);
 


### PR DESCRIPTION
When cargo encounters a link, check if it's a directory when considering it for further processing.
I'm not sure how this interacts with things such as submodules – it allowed me to publish the crate [pqcrypto-kyber768](https://github.com/rustpq/pqcrypto) which uses a link to a submodule.

Fixes #2748.

This PR: 
* Add new tests that demonstrate that links to dirs can't be packaged
* Fixes those tests
* Enabled symlink tests to run on Windows
* Fix a bug in the handling of symlinks
* Add new test runner behaviour on Windows (it will ignore symlink-related tests and instead run them if you specify --ignored.)