### PR TITLE
Accept trailing comma in test of impl Debug for PackageId

### DIFF
--- a/src/cargo/core/package_id.rs
+++ b/src/cargo/core/package_id.rs
@@ -224,7 +224,18 @@ mod tests {
         let pkg_id = PackageId::new("foo", "1.0.0", SourceId::for_registry(&loc).unwrap()).unwrap();
         assert_eq!(r#"PackageId { name: "foo", version: "1.0.0", source: "registry `https://github.com/rust-lang/crates.io-index`" }"#, format!("{:?}", pkg_id));
 
-        let pretty = r#"
+        let expected = r#"
+PackageId {
+    name: "foo",
+    version: "1.0.0",
+    source: "registry `https://github.com/rust-lang/crates.io-index`",
+}
+"#
+        .trim();
+
+        // Can be removed once trailing commas in Debug have reached the stable
+        // channel.
+        let expected_without_trailing_comma = r#"
 PackageId {
     name: "foo",
     version: "1.0.0",
@@ -232,7 +243,13 @@ PackageId {
 }
 "#
         .trim();
-        assert_eq!(pretty, format!("{:#?}", pkg_id));
+
+        let actual = format!("{:#?}", pkg_id);
+        if actual.ends_with(",\n}") {
+            assert_eq!(actual, expected);
+        } else {
+            assert_eq!(actual, expected_without_trailing_comma);
+        }
     }
 
     #[test]


### PR DESCRIPTION
The standard library is planning to begin emitting trailing commas in multiline Debug representations to align with the dominant style in modern Rust code -- https://github.com/rust-lang/rust/pull/59076.

```diff
  PackageId {
      name: "foo",
      version: "1.0.0",
-     source: "registry `https://github.com/rust-lang/crates.io-index`"
+     source: "registry `https://github.com/rust-lang/crates.io-index`",
  }
```

For now, change this tests to accept both with and without trailing comma. Once the trailing comma change reaches the stable channel we will be able to remove one of the cases.