### PR TITLE
Clarify docs of install without <crate>

### DIFF
--- a/src/bin/cargo/commands/install.rs
+++ b/src/bin/cargo/commands/install.rs
@@ -89,9 +89,8 @@ enables overwriting existing binaries. Thus you can reinstall a crate with
 `cargo install --force <crate>`.
 
 Omitting the <crate> specification entirely will install the crate in the
-current directory. That is, `install` is equivalent to the more explicit
-`install --path .`. This behaviour is deprecated, and no longer supported as
-of the Rust 2018 edition.
+current directory. This behaviour is deprecated, and it no longer works in the
+Rust 2018 edition. Use the more explicit `install --path .` instead.
 
 If the source is crates.io or `--git` then by default the crate will be built
 in a temporary target directory. To avoid this, the target directory can be


### PR DESCRIPTION
This is an attempt to clarify the documentation of `install` without `<crate>`. I found it confusing trying to determine to which behavior “this” referred as well as whether “supported” meant “maintained” or “worked.”