### PR TITLE
Improve error message to rerun a test in a workspace.

### DIFF
--- a/src/bin/cargo/commands/test.rs
+++ b/src/bin/cargo/commands/test.rs
@@ -150,7 +150,10 @@ pub fn exec(config: &mut Config, args: &ArgMatches<'_>) -> CliResult {
     match err {
         None => Ok(()),
         Some(err) => Err(match err.exit.as_ref().and_then(|e| e.code()) {
-            Some(i) => CliError::new(failure::format_err!("{}", err.hint(&ws)), i),
+            Some(i) => CliError::new(
+                failure::format_err!("{}", err.hint(&ws, &ops.compile_opts)),
+                i,
+            ),
             None => CliError::new(err.into(), 101),
         }),
     }

--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -182,6 +182,17 @@ impl Packages {
         };
         Ok(packages)
     }
+
+    /// Returns whether or not the user needs to pass a `-p` flag to target a
+    /// specific package in the workspace.
+    pub fn needs_spec_flag(&self, ws: &Workspace<'_>) -> bool {
+        match self {
+            Packages::Default => ws.default_members().count() > 1,
+            Packages::All => ws.members().count() > 1,
+            Packages::Packages(_) => true,
+            Packages::OptOut(_) => true,
+        }
+    }
 }
 
 #[derive(Debug, PartialEq, Eq)]

--- a/src/cargo/util/errors.rs
+++ b/src/cargo/util/errors.rs
@@ -10,6 +10,7 @@ use failure::{Context, Error, Fail};
 use log::trace;
 
 use crate::core::{TargetKind, Workspace};
+use crate::ops::CompileOptions;
 
 pub type CargoResult<T> = failure::Fallible<T>; // Alex's body isn't quite ready to give up "Result"
 
@@ -188,14 +189,14 @@ impl CargoTestError {
         }
     }
 
-    pub fn hint(&self, ws: &Workspace<'_>) -> String {
+    pub fn hint(&self, ws: &Workspace<'_>, opts: &CompileOptions<'_>) -> String {
         match self.test {
             Test::UnitTest {
                 ref kind,
                 ref name,
                 ref pkg_name,
             } => {
-                let pkg_info = if ws.members().count() > 1 && ws.is_virtual() {
+                let pkg_info = if opts.spec.needs_spec_flag(ws) {
                     format!("-p {} ", pkg_name)
                 } else {
                     String::new()


### PR DESCRIPTION
In a non-virtual workspace, if you run `cargo test --all` and something fails, it tells you to rerun `--test foo`, but if `foo` is not the default, then it won't work without a `-p` flag.  This tries to be a little more careful about when `-p` is needed in the hint.