### PR TITLE
 Add a `build.build-target` config key 

### DIFF
--- a/src/doc/src/reference/config.md
+++ b/src/doc/src/reference/config.md
@@ -124,10 +124,13 @@ debug = false
 jobs = 1                  # number of parallel jobs, defaults to # of CPUs
 rustc = "rustc"           # the rust compiler tool
 rustdoc = "rustdoc"       # the doc generator tool
-target = "triple"         # build and test for the target triple
-                          # (ignored by `cargo install`)
-build-target = "triple"   # build for the target triple, overrides `build.target`
-                          # (ignored by `cargo install`)
+target = "triple"         # the default target triple when no `--target` is
+                          # passed (ignored by `cargo install`)
+build-target = "triple"   # the default target triple for build commands such
+                          # as `build`, `check`, or `run`, but not for test
+                          # commands such as test or bench. Ignored by
+                          # `cargo install`. Takes precendence over
+                          # `build.target`.
 target-dir = "target"     # path of where to place all generated artifacts
 rustflags = ["..", ".."]  # custom flags to pass to all compiler invocations
 rustdocflags = ["..", ".."]  # custom flags to pass to rustdoc

--- a/src/doc/src/reference/config.md
+++ b/src/doc/src/reference/config.md
@@ -124,9 +124,10 @@ debug = false
 jobs = 1                  # number of parallel jobs, defaults to # of CPUs
 rustc = "rustc"           # the rust compiler tool
 rustdoc = "rustdoc"       # the doc generator tool
-target = "triple"         # build and test for the target triple (ignored by `cargo install`)
-build-target = "triple"   # build for the target triple (ignored by `cargo install`), overrides
-                          # `build.target`
+target = "triple"         # build and test for the target triple
+                          # (ignored by `cargo install`)
+build-target = "triple"   # build for the target triple, overrides `build.target`
+                          # (ignored by `cargo install`)
 target-dir = "target"     # path of where to place all generated artifacts
 rustflags = ["..", ".."]  # custom flags to pass to all compiler invocations
 rustdocflags = ["..", ".."]  # custom flags to pass to rustdoc

--- a/src/doc/src/reference/config.md
+++ b/src/doc/src/reference/config.md
@@ -124,7 +124,9 @@ debug = false
 jobs = 1                  # number of parallel jobs, defaults to # of CPUs
 rustc = "rustc"           # the rust compiler tool
 rustdoc = "rustdoc"       # the doc generator tool
-target = "triple"         # build for the target triple (ignored by `cargo install`)
+target = "triple"         # build and test for the target triple (ignored by `cargo install`)
+build-target = "triple"   # build for the target triple (ignored by `cargo install`), overrides
+                          # `build.target`
 target-dir = "target"     # path of where to place all generated artifacts
 rustflags = ["..", ".."]  # custom flags to pass to all compiler invocations
 rustdocflags = ["..", ".."]  # custom flags to pass to rustdoc


### PR DESCRIPTION
This key allows overriding the default target for build operations (e.g. `cargo build`, `cargo check`, `cargo run`), but not for test operations (`cargo test`, `cargo bench`).

See https://github.com/rust-lang/cargo/issues/6784 and https://internals.rust-lang.org/t/set-default-target-for-cargo-build-but-not-for-cargo-test/9777 for motivation.

Fixes https://github.com/rust-lang/cargo/issues/6784