### PR TITLE
Fix mutable_borrow_reservation_conflict warning.

### DIFF
--- a/tests/testsuite/support/mod.rs
+++ b/tests/testsuite/support/mod.rs
@@ -791,7 +791,8 @@ impl Execs {
     pub fn cwd<T: AsRef<OsStr>>(&mut self, path: T) -> &mut Self {
         if let Some(ref mut p) = self.process_builder {
             if let Some(cwd) = p.get_cwd() {
-                p.cwd(cwd.join(path.as_ref()));
+                let new_path = cwd.join(path.as_ref());
+                p.cwd(new_path);
             } else {
                 p.cwd(path);
             }


### PR DESCRIPTION
nightly-2019-04-08 added a more restrictive borrowing rule (rust-lang/rust#58739).
