### PR TITLE
testsuite: cleanup for `alternative-registries`

### DIFF
--- a/tests/testsuite/package.rs
+++ b/tests/testsuite/package.rs
@@ -771,8 +771,6 @@ fn generated_manifest() {
         .file(
             "Cargo.toml",
             r#"
-            cargo-features = ["alternative-registries"]
-
             [project]
             name = "foo"
             version = "0.0.1"
@@ -815,8 +813,6 @@ fn generated_manifest() {
 # issue against the rust-lang/cargo repository. If you're
 # editing this file be aware that the upstream Cargo.toml
 # will likely look very different (and much more reasonable)
-
-cargo-features = ["alternative-registries"]
 
 [package]
 name = "foo"

--- a/tests/testsuite/rename_deps.rs
+++ b/tests/testsuite/rename_deps.rs
@@ -85,7 +85,6 @@ fn lots_of_names() {
             "Cargo.toml",
             &format!(
                 r#"
-                cargo-features = ["alternative-registries"]
                 [package]
                 name = "test"
                 version = "0.1.0"

--- a/tests/testsuite/support/registry.rs
+++ b/tests/testsuite/support/registry.rs
@@ -445,19 +445,14 @@ impl Package {
     }
 
     fn make_archive(&self) {
-        let features = if self.deps.iter().any(|dep| dep.registry.is_some()) {
-            "cargo-features = [\"alternative-registries\"]\n"
-        } else {
-            ""
-        };
         let mut manifest = format!(
             r#"
-            {}[package]
+            [package]
             name = "{}"
             version = "{}"
             authors = []
         "#,
-            features, self.name, self.vers
+            self.name, self.vers
         );
         for dep in self.deps.iter() {
             let target = match dep.target {


### PR DESCRIPTION
Remove some `alternative-registries` features that were accidentally left
behind.