### PR TITLE
Improve warning in `cargo new` with parse error.

### DIFF
--- a/src/cargo/ops/cargo_new.rs
+++ b/src/cargo/ops/cargo_new.rs
@@ -9,7 +9,7 @@ use git2::Config as GitConfig;
 use git2::Repository as GitRepository;
 
 use crate::core::{compiler, Workspace};
-use crate::util::errors::{CargoResult, CargoResultExt};
+use crate::util::errors::{self, CargoResult, CargoResultExt};
 use crate::util::{existing_vcs_repo, internal, FossilRepo, GitRepo, HgRepo, PijulRepo};
 use crate::util::{paths, validate_package_name, Config};
 
@@ -677,7 +677,7 @@ mod tests {
         let msg = format!(
             "compiling this new crate may not work due to invalid \
              workspace configuration\n\n{}",
-            e
+            errors::display_causes(&e)
         );
         config.shell().warn(msg)?;
     }

--- a/src/cargo/util/config.rs
+++ b/src/cargo/util/config.rs
@@ -25,7 +25,7 @@ use crate::core::profiles::ConfigProfiles;
 use crate::core::shell::Verbosity;
 use crate::core::{CliUnstable, Shell, SourceId, Workspace};
 use crate::ops;
-use crate::util::errors::{internal, CargoResult, CargoResultExt};
+use crate::util::errors::{self, internal, CargoResult, CargoResultExt};
 use crate::util::toml as cargo_toml;
 use crate::util::Filesystem;
 use crate::util::Rustc;
@@ -932,12 +932,7 @@ impl std::error::Error for ConfigError {}
 // `cause` and avoid doing the cause formatting here.
 impl fmt::Display for ConfigError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let message = self
-            .error
-            .iter_chain()
-            .map(|e| e.to_string())
-            .collect::<Vec<_>>()
-            .join("\nCaused by:\n  ");
+        let message = errors::display_causes(&self.error);
         if let Some(ref definition) = self.definition {
             write!(f, "error in {}: {}", definition, message)
         } else {

--- a/src/cargo/util/errors.rs
+++ b/src/cargo/util/errors.rs
@@ -388,3 +388,11 @@ pub fn internal<S: fmt::Display>(error: S) -> failure::Error {
 fn _internal(error: &dyn fmt::Display) -> failure::Error {
     Internal::new(failure::format_err!("{}", error)).into()
 }
+
+pub fn display_causes(error: &Error) -> String {
+    error
+        .iter_chain()
+        .map(|e| e.to_string())
+        .collect::<Vec<_>>()
+        .join("\nCaused by:\n  ")
+}

--- a/tests/testsuite/workspaces.rs
+++ b/tests/testsuite/workspaces.rs
@@ -989,6 +989,25 @@ root: [..]
 }
 
 #[test]
+fn new_warning_with_corrupt_ws() {
+    let p = project().file("Cargo.toml", "asdf").build();
+    p.cargo("new bar")
+        .with_stderr(
+            "\
+[WARNING] compiling this new crate may not work due to invalid workspace configuration
+
+failed to parse manifest at `[..]foo/Cargo.toml`
+Caused by:
+  could not parse input as TOML
+Caused by:
+  expected an equals, found eof at line 1
+     Created binary (application) `bar` package
+",
+        )
+        .run();
+}
+
+#[test]
 fn lock_doesnt_change_depending_on_crate() {
     let p = project()
         .file(


### PR DESCRIPTION
If `cargo new` fails to load a parent manifest (for whatever reason), it was not
displaying the reason why. Add the causes to provide more context.