### PR TITLE
Ensure Summary::checksum works for registry crates

### DIFF
--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -428,6 +428,9 @@ impl Manifest {
     pub fn summary(&self) -> &Summary {
         &self.summary
     }
+    pub fn summary_mut(&mut self) -> &mut Summary {
+        &mut self.summary
+    }
     pub fn targets(&self) -> &[Target] {
         &self.targets
     }
@@ -468,10 +471,6 @@ impl Manifest {
 
     pub fn features(&self) -> &Features {
         &self.features
-    }
-
-    pub fn set_summary(&mut self, summary: Summary) {
-        self.summary = summary;
     }
 
     pub fn map_source(self, to_replace: SourceId, replace_with: SourceId) -> Manifest {

--- a/src/cargo/core/package.rs
+++ b/src/cargo/core/package.rs
@@ -146,6 +146,10 @@ impl Package {
     pub fn manifest(&self) -> &Manifest {
         &self.manifest
     }
+    /// Gets the manifest.
+    pub fn manifest_mut(&mut self) -> &mut Manifest {
+        &mut self.manifest
+    }
     /// Gets the path to the manifest.
     pub fn manifest_path(&self) -> &Path {
         &self.manifest_path

--- a/src/cargo/core/summary.rs
+++ b/src/cargo/core/summary.rs
@@ -104,9 +104,8 @@ impl Summary {
         self
     }
 
-    pub fn set_checksum(mut self, cksum: String) -> Summary {
+    pub fn set_checksum(&mut self, cksum: String) {
         Rc::make_mut(&mut self.inner).checksum = Some(cksum);
-        self
     }
 
     pub fn map_dependencies<F>(mut self, f: F) -> Summary

--- a/src/cargo/sources/directory.rs
+++ b/src/cargo/sources/directory.rs
@@ -116,7 +116,7 @@ impl<'cfg> Source for DirectorySource<'cfg> {
 
             let mut src = PathSource::new(&path, self.source_id, self.config);
             src.update()?;
-            let pkg = src.root_package()?;
+            let mut pkg = src.root_package()?;
 
             let cksum_file = path.join(".cargo-checksum.json");
             let cksum = paths::read(&path.join(cksum_file)).chain_err(|| {
@@ -136,13 +136,11 @@ impl<'cfg> Source for DirectorySource<'cfg> {
                 )
             })?;
 
-            let mut manifest = pkg.manifest().clone();
-            let mut summary = manifest.summary().clone();
-            if let Some(ref package) = cksum.package {
-                summary = summary.set_checksum(package.clone());
+            if let Some(package) = &cksum.package {
+                pkg.manifest_mut()
+                    .summary_mut()
+                    .set_checksum(package.clone());
             }
-            manifest.set_summary(summary);
-            let pkg = Package::new(manifest, pkg.manifest_path());
             self.packages.insert(pkg.package_id(), (pkg, cksum));
         }
 

--- a/src/cargo/sources/registry/index.rs
+++ b/src/cargo/sources/registry/index.rs
@@ -253,8 +253,8 @@ impl<'cfg> RegistryIndex<'cfg> {
             .into_iter()
             .map(|dep| dep.into_dep(self.source_id))
             .collect::<CargoResult<Vec<_>>>()?;
-        let summary = Summary::new(pkgid, deps, &features, links, false)?;
-        let summary = summary.set_checksum(cksum.clone());
+        let mut summary = Summary::new(pkgid, deps, &features, links, false)?;
+        summary.set_checksum(cksum.clone());
         self.hashes
             .entry(name.as_str())
             .or_insert_with(HashMap::new)


### PR DESCRIPTION
While not actually used in Cargo itself the `Summary::checksum` method
of downloaded packages from the registry currently returns `None`. This
was accidentally regressed in #6500 and noticed when updating
`cargo-vendor` (it took a long time to get around to updating that).

The fix here is to override the `checksum` field of the summary for
packages we return from the registry, and everything else should remain
the same!