### PR TITLE
In the default test template allow tests to see library's items

### DIFF
--- a/src/cargo/ops/cargo_new.rs
+++ b/src/cargo/ops/cargo_new.rs
@@ -657,6 +657,8 @@ fn main() {
             b"\
 #[cfg(test)]
 mod tests {
+    use super::*;
+
     #[test]
     fn it_works() {
         assert_eq!(2 + 2, 4);

--- a/tests/testsuite/new.rs
+++ b/tests/testsuite/new.rs
@@ -34,6 +34,8 @@ fn simple_lib() {
         contents,
         r#"#[cfg(test)]
 mod tests {
+    use super::*;
+
     #[test]
     fn it_works() {
         assert_eq!(2 + 2, 4);


### PR DESCRIPTION
Modules are hard, and inability to test library's content from "the same file" is an annoying gotcha.

I propose to add `use super::*` to the default template that demonstrates that there's a module boundary.
