### PR TITLE
Clarify optional registry key behaviour

### DIFF
--- a/src/doc/src/reference/registries.md
+++ b/src/doc/src/reference/registries.md
@@ -130,7 +130,7 @@ The keys are:
   may have the markers `{crate}` and `{version}` which are replaced with the
   name and version of the crate to download. If the markers are not present,
   then the value `/{crate}/{version}/download` is appended to the end.
-- `api`: This is the base URL for the web API. This key is optional, and if it
+- `api`: This is the base URL for the web API. This key is optional, but if it
   is not specified, commands such as [`cargo publish`] will not work. The web
   API is described below.
 


### PR DESCRIPTION
Changing from "and" to "but" makes the sentence clearer to read. I think it gives the reader an appropriate caution, as you do lose features if you don't provide the `api` key.