### PR TITLE
Ignore Clippy redundant_closure

### DIFF
--- a/src/cargo/lib.rs
+++ b/src/cargo/lib.rs
@@ -10,6 +10,7 @@
 #![allow(clippy::identity_op)] // used for vertical alignment
 #![allow(clippy::implicit_hasher)] // large project
 #![allow(clippy::large_enum_variant)] // large project
+#![allow(clippy::redundant_closure)] // closures can be less verbose
 #![allow(clippy::redundant_closure_call)] // closures over try catch blocks
 #![allow(clippy::too_many_arguments)] // large project
 #![allow(clippy::type_complexity)] // there's an exceptionally complex type

--- a/tests/testsuite/main.rs
+++ b/tests/testsuite/main.rs
@@ -2,6 +2,7 @@
 #![cfg_attr(feature = "deny-warnings", deny(warnings))]
 #![allow(clippy::blacklisted_name)]
 #![allow(clippy::explicit_iter_loop)]
+#![allow(clippy::redundant_closure)]
 #![warn(clippy::needless_borrow)]
 #![warn(clippy::redundant_clone)]
 


### PR DESCRIPTION
I think sometimes the closure is easier to read. Compare

```rust
x.map(|s| s.to_string())
```

vs

```rust
x.map(std::string::ToString::to_string)
```

I think it is also easier to modify when it is a closure. However, I don't feel strongly about it, so if anyone wants the Clippy form, I'm fine with switching things over to that.