### PR TITLE
Treat HTTP/2 stream errors as spurious network errors.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,8 @@ bytesize = "1.0"
 crates-io = { path = "src/crates-io", version = "0.24" }
 crossbeam-utils = "0.6"
 crypto-hash = "0.3.1"
-curl = { version = "0.4.19", features = ['http2'] }
-curl-sys = "0.4.15"
+curl = { version = "0.4.21", features = ['http2'] }
+curl-sys = "0.4.18"
 env_logger = "0.6.0"
 pretty_env_logger = { version = "0.3", optional = true }
 failure = "0.1.5"

--- a/src/cargo/util/network.rs
+++ b/src/cargo/util/network.rs
@@ -50,6 +50,7 @@ fn maybe_spurious(err: &Error) -> bool {
                 || curl_err.is_couldnt_resolve_host()
                 || curl_err.is_operation_timedout()
                 || curl_err.is_recv_error()
+                || curl_err.is_http2_stream_error()
             {
                 return true;
             }
@@ -124,4 +125,11 @@ fn with_retry_finds_nested_spurious_errors() {
     let config = Config::default().unwrap();
     let result = with_retry(&config, || results.pop().unwrap());
     assert_eq!(result.unwrap(), ())
+}
+
+#[test]
+fn curle_http2_stream_is_spurious() {
+    let code = curl_sys::CURLE_HTTP2_STREAM;
+    let err = curl::Error::new(code);
+    assert!(maybe_spurious(&err.into()));
 }


### PR DESCRIPTION
Closes https://github.com/rust-lang/cargo/issues/6788.