### PR TITLE
Improved docs for `maintenance` options

### DIFF
--- a/src/doc/src/reference/manifest.md
+++ b/src/doc/src/reference/manifest.md
@@ -298,9 +298,21 @@ is-it-maintained-issue-resolution = { repository = "..." }
 # Is it maintained percentage of open issues: `repository` is required.
 is-it-maintained-open-issues = { repository = "..." }
 
-# Maintenance: `status` is required. Available options are `actively-developed`,
-# `passively-maintained`, `as-is`, `experimental`, `looking-for-maintainer`,
-# `deprecated`, and the default `none`, which displays no badge on crates.io.
+# Maintenance: `status` is required. Available options are:
+# - `actively-developed`: New features are being added and bugs are being fixed.
+# - `passively-maintained`: There are no plans for new features, but the maintainer intends to
+#   respond to issues that get filed.
+# - `as-is`: The crate is feature complete, the maintainer does not intend to continue working on
+#   it or providing support, but it works for the purposes it was designed for.
+# - `experimental`: The author wants to share it with the community but is not intending to meet
+#   anyone's particular use case.
+# - `looking-for-maintainer`: The current maintainer would like to transfer the crate to someone
+#   else.
+# - `deprecated`: The maintainer does not recommend using this crate (the description of the crate
+#   can describe why, there could be a better solution available or there could be problems with
+#   the crate that the author does not want to fix).
+# - `none`: Displays no badge on crates.io, since the maintainer has not chosen to specify
+#   their intentions, potential crate users will need to investigate on their own.
 maintenance = { status = "..." }
 ```
 


### PR DESCRIPTION
I thought the lack of clear meanings for the available options could use some improvement.
Basically an upgrade of #4431.

Got the relevant text from rust-lang/crates.io#704 and the corresponding [rfc](https://github.com/rust-lang/rfcs/blob/master/text/1824-crates.io-default-ranking.md)

*Questions*
1. Should I put the descriptions outside of the code block?
2. I copied the wording including "maintainer" and "author", should I replace it with "you" or something more appropriate?