### PR TITLE
Add implib to the stamp files

### DIFF
--- a/src/cargo/core/compiler/build_context/target_info.rs
+++ b/src/cargo/core/compiler/build_context/target_info.rs
@@ -213,6 +213,17 @@ impl TargetInfo {
                 should_replace_hyphens: false,
             })
         }
+        else if target_triple.ends_with("windows-gnu")
+                && crate_type.ends_with("dylib")
+                && suffix == ".dll"
+        {
+            ret.push(FileType {
+                suffix: ".dll.a".to_string(),
+                prefix: "lib".to_string(),
+                flavor: FileFlavor::Normal,
+                should_replace_hyphens: false,
+            })
+        }
 
         // See rust-lang/cargo#4535.
         if target_triple.starts_with("wasm32-") && crate_type == "bin" && suffix == ".js" {


### PR DESCRIPTION
Hi,

This MR aims at including the import libraries in the stamp file, in order for them to be copied around when uplifting stages during rust-lang's compilation.

This was already done when targetting msvc, but it needs to be done for
all targets to allow rustc to link with shared libraries when using llvm.
-l<dllname> is only supported by gcc, while llvm needs an import library
to link indirectly with a dll

This MR is related to rust-lang/rust#60260

I'm unsure what the best way is, when it comes to cross dependent MRs, so I'll gladly change things according to your reviews!

Thanks,