### PR TITLE
Default Cargo.toml template provide help for completing the metadata

### DIFF
--- a/src/cargo/ops/cargo_new.rs
+++ b/src/cargo/ops/cargo_new.rs
@@ -618,6 +618,8 @@ version = "0.1.0"
 authors = [{}]
 edition = {}
 {}
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
 [dependencies]
 {}"#,
             name,

--- a/tests/testsuite/new.rs
+++ b/tests/testsuite/new.rs
@@ -522,3 +522,11 @@ fn new_with_blank_email() {
     let contents = fs::read_to_string(paths::root().join("foo/Cargo.toml")).unwrap();
     assert!(contents.contains(r#"authors = ["Sen"]"#), contents);
 }
+
+#[test]
+fn new_with_reference_link() {
+    cargo_process("new foo").env("USER", "foo").run();
+
+    let contents = fs::read_to_string(paths::root().join("foo/Cargo.toml")).unwrap();
+    assert!(contents.contains("# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html"))
+}


### PR DESCRIPTION
## Descriptio
This is new Cargo.toml example.
```toml
[package]
name = "foo"
version = "0.1.0"
authors = ["k-nasa"]
documentation = ""
homepage = ""
repository = ""
readme = ""
categories = []
keywords = []
license = ""
edition = "2018"

[dependencies]

# See more https://doc.rust-lang.org/cargo/reference/manifest.html

```
## Motivation
close: https://github.com/rust-lang/cargo/issues/6845