### PR TITLE
Symlink dSYM on macOS example binaries.

### DIFF
--- a/tests/testsuite/support/paths.rs
+++ b/tests/testsuite/support/paths.rs
@@ -70,6 +70,8 @@ pub trait CargoPathExt {
     fn move_in_time<F>(&self, travel_amount: F)
     where
         F: Fn(i64, u32) -> (i64, u32);
+
+    fn is_symlink(&self) -> bool;
 }
 
 impl CargoPathExt for Path {
@@ -141,6 +143,10 @@ impl CargoPathExt for Path {
                 filetime::set_file_times(path, newtime, newtime)
             });
         }
+    }
+
+    fn is_symlink(&self) -> bool {
+        fs::symlink_metadata(self).map(|m| m.file_type().is_symlink()).unwrap_or(false)
     }
 }
 


### PR DESCRIPTION
Examples previously ended up with a layout such as:

```
target/debug/examples/ex1
target/debug/examples/ex1.d
target/debug/examples/ex1-966e505ad4696130
target/debug/examples/ex1-966e505ad4696130.d
target/debug/examples/ex1-966e505ad4696130.dSYM/…
```

If you attempt to run lldb on the executable without the hash (`target/debug/examples/ex1`), then symbols could not be found. This PR solves this by creating a symlink from `ex1.dSYM -> ex1-966e505ad4696130.dSYM`.

Closes #6889
