### PR TITLE
Added ability to crosscompile doctests

### DIFF
--- a/src/cargo/core/compiler/compilation.rs
+++ b/src/cargo/core/compiler/compilation.rs
@@ -163,7 +163,7 @@ impl<'cfg> Compilation<'cfg> {
         self.fill_env(process(cmd), pkg, true)
     }
 
-    fn target_runner(&self) -> &Option<(PathBuf, Vec<String>)> {
+    pub fn target_runner(&self) -> &Option<(PathBuf, Vec<String>)> {
         &self.target_runner
     }
 

--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -336,6 +336,7 @@ pub struct CliUnstable {
     pub binary_dep_depinfo: bool,
     pub build_std: Option<Vec<String>>,
     pub timings: Option<Vec<String>>,
+    pub doctest_xcompile: bool,
 }
 
 impl CliUnstable {
@@ -393,6 +394,7 @@ impl CliUnstable {
                 self.build_std = Some(crate::core::compiler::standard_lib::parse_unstable_flag(v))
             }
             "timings" => self.timings = Some(parse_timings(v)),
+            "doctest-xcompile" => self.doctest_xcompile = true,
             _ => failure::bail!("unknown `-Z` flag specified: {}", k),
         }
 

--- a/src/cargo/ops/cargo_test.rs
+++ b/src/cargo/ops/cargo_test.rs
@@ -165,12 +165,12 @@ fn run_doc_tests(
             .arg(&target.crate_name());
 
         if doctest_xcompile {
+            p.arg("--target").arg(&compilation.target);
             p.arg("-Zunstable-options");
             p.arg("--enable-per-target-ignores");
         }
 
         runtool.as_ref().map(|(runtool, runtool_args)| {
-            p.arg("--target").arg(&compilation.target);
             p.arg("--runtool").arg(runtool);
             for arg in runtool_args {
                 p.arg("--runtool-arg").arg(arg);

--- a/tests/testsuite/cross_compile.rs
+++ b/tests/testsuite/cross_compile.rs
@@ -535,8 +535,7 @@ fn cross_tests() {
 [COMPILING] foo v0.0.0 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target/{triple}/debug/deps/foo-[..][EXE]
-[RUNNING] target/{triple}/debug/deps/bar-[..][EXE]
-[DOCTEST] Skipping doctests, no runner defined for target",
+[RUNNING] target/{triple}/debug/deps/bar-[..][EXE]",
             triple = target
         ))
         .with_stdout_contains("test test_foo ... ok")
@@ -596,7 +595,6 @@ fn no_cross_doctests() {
 [COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target/{triple}/debug/deps/foo-[..][EXE]
-[DOCTEST] Skipping doctests, no runner defined for target
 ",
             triple = target
         ))
@@ -1225,8 +1223,7 @@ fn cross_test_dylib() {
 [COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target/{arch}/debug/deps/foo-[..][EXE]
-[RUNNING] target/{arch}/debug/deps/test-[..][EXE]
-[DOCTEST] Skipping doctests, no runner defined for target",
+[RUNNING] target/{arch}/debug/deps/test-[..][EXE]",
             arch = cross_compile::alternate()
         ))
         .with_stdout_contains_n("test foo ... ok", 2)

--- a/tests/testsuite/cross_compile.rs
+++ b/tests/testsuite/cross_compile.rs
@@ -535,7 +535,8 @@ fn cross_tests() {
 [COMPILING] foo v0.0.0 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target/{triple}/debug/deps/foo-[..][EXE]
-[RUNNING] target/{triple}/debug/deps/bar-[..][EXE]",
+[RUNNING] target/{triple}/debug/deps/bar-[..][EXE]
+[DOCTEST] Skipping doctests, no runner defined for target",
             triple = target
         ))
         .with_stdout_contains("test test_foo ... ok")
@@ -595,6 +596,7 @@ fn no_cross_doctests() {
 [COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target/{triple}/debug/deps/foo-[..][EXE]
+[DOCTEST] Skipping doctests, no runner defined for target
 ",
             triple = target
         ))
@@ -1223,7 +1225,8 @@ fn cross_test_dylib() {
 [COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target/{arch}/debug/deps/foo-[..][EXE]
-[RUNNING] target/{arch}/debug/deps/test-[..][EXE]",
+[RUNNING] target/{arch}/debug/deps/test-[..][EXE]
+[DOCTEST] Skipping doctests, no runner defined for target",
             arch = cross_compile::alternate()
         ))
         .with_stdout_contains_n("test foo ... ok", 2)


### PR DESCRIPTION
This commit adds the ability to cross-compile and run doctests.
Like before cargo checks if target == host, the difference is that if there is a runtool defined in config.toml, it passes the information forward to rustdoc so that it can run the doctests with that tool. If no tool is defined and the target != host, cargo instead displays a message that doctests will not be compiled because of the missing runtool.

See [here](https://github.com/rust-lang/rust/pull/60387) for the companion PR in the rust project that modifies rustdoc to accept the relevant options as well as allow ignoring doctests on a per target level.
Partially resolves [#6460](https://github.com/rust-lang/cargo/issues/6460)

See [here](https://github.com/rust-lang/cargo/issues/7040) for the tracking issue.