### PR TITLE
Add explicit lifetimes to Executor::init.

### DIFF
--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -60,7 +60,7 @@ pub trait Executor: Send + Sync + 'static {
     /// Called after a rustc process invocation is prepared up-front for a given
     /// unit of work (may still be modified for runtime-known dependencies, when
     /// the work is actually executed).
-    fn init(&self, _cx: &Context<'_, '_>, _unit: &Unit<'_>) {}
+    fn init<'a, 'cfg>(&self, _cx: &Context<'a, 'cfg>, _unit: &Unit<'a>) {}
 
     /// In case of an `Err`, Cargo will not continue with the build process for
     /// this package.


### PR DESCRIPTION
Since the unit interner was added in #6867, I am getting a strange borrow check error compiling RLS with the latest Cargo (that is, linking rls with the new cargo).  Adding explicit lifetimes to the `Executor::init` function seems to fix the problem.  I don't 100% understand the error, because none of the relevant function or type signatures changed in that PR.  The only thing that gives me a clue is [this change](https://github.com/rust-lang/cargo/pull/6867/files#diff-0bb62cb712c0811a17d7a726e068bf65L112) to `BuildPlan::add` which does something similar, but that is not directly called by RLS.

The error looks like this:
```
error[E0623]: lifetime mismatch
   --> rls/src/build/cargo_plan.rs:149:24
    |
126 |         unit: &Unit<'_>,
    |                -------- these two types are declared with different lifetimes...
127 |         cx: &Context<'_, '_>,
    |              ---------------
...
149 |         let units = cx.dep_targets(unit);
    |                        ^^^^^^^^^^^ ...but data from `unit` flows into `cx` here
```

I generally don't like making changes if I don't understand them, but I'm a little stumped here how this is happening even though everything is defined with the same (`'a`) lifetime.

This unblocks updating RLS to the latest Cargo.
