### PR TITLE
Update some doc links.

### DIFF
--- a/src/doc/src/appendix/glossary.md
+++ b/src/doc/src/appendix/glossary.md
@@ -176,7 +176,7 @@ manifest is located.
 [Directory Sources]: reference/source-replacement.html#directory-sources
 [Local Registry Sources]: reference/source-replacement.html#local-registry-sources
 [Source Replacement]: reference/source-replacement.html
-[cargo-unstable]: https://doc.rust-lang.org/nightly/cargo/reference/unstable.html
+[cargo-unstable]: reference/unstable.html
 [config option]: reference/config.html
 [directory layout]: reference/manifest.html#the-project-layout
 [edition guide]: ../edition-guide/index.html

--- a/src/doc/src/guide/tests.md
+++ b/src/doc/src/guide/tests.md
@@ -36,4 +36,4 @@ examples you’ve included and will also test the examples in your
 documentation. Please see the [testing guide][testing] in the Rust
 documentation for more details.
 
-[testing]: https://doc.rust-lang.org/book/testing.html
+[testing]: ../book/ch11-00-testing.html

--- a/src/doc/src/reference/environment-variables.md
+++ b/src/doc/src/reference/environment-variables.md
@@ -131,7 +131,7 @@ let out_dir = env::var("OUT_DIR").unwrap();
                    information.
 
 [links]: reference/build-scripts.html#the-links-manifest-key
-[configuration]: https://doc.rust-lang.org/reference/attributes.html#conditional-compilation
+[configuration]: ../reference/conditional-compilation.html
 [jobserver]: https://www.gnu.org/software/make/manual/html_node/Job-Slots.html
 [cargo-config]: reference/config.html
 [Target Triple]: appendix/glossary.html#target

--- a/src/doc/src/reference/manifest.md
+++ b/src/doc/src/reference/manifest.md
@@ -27,7 +27,7 @@ a keyword. [crates.io][cratesio] imposes even more restrictions, such as
 enforcing only ASCII characters, not a reserved name, not a special Windows
 name such as "nul", is not too long, etc.
 
-[alphanumeric]: https://doc.rust-lang.org/std/primitive.char.html#method.is_alphanumeric
+[alphanumeric]: ../std/primitive.char.html#method.is_alphanumeric
 
 #### The `version` field
 
@@ -682,7 +682,8 @@ may be composed of single files or directories with a `main.rs` file.
 
 To structure your code after you've created the files and folders for your
 package, you should remember to use Rust's module system, which you can read
-about in [the book](https://doc.rust-lang.org/book/crates-and-modules.html).
+about in [the
+book](../book/ch07-00-managing-growing-projects-with-packages-crates-and-modules.html).
 
 ### Examples
 
@@ -698,7 +699,7 @@ You can run individual executable examples with the command `cargo run --example
 
 Specify `crate-type` to make an example be compiled as a library (additional
 information about crate types is available in
-[The Rust Reference](https://doc.rust-lang.org/reference/linkage.html)):
+[The Rust Reference](../reference/linkage.html)):
 
 ```toml
 [[example]]
@@ -840,7 +841,7 @@ The available options are `dylib`, `rlib`, `staticlib`, `cdylib`, and
 `proc-macro`.
 
 You can read more about the different crate types in the
-[Rust Reference Manual](https://doc.rust-lang.org/reference/linkage.html)
+[Rust Reference Manual](../reference/linkage.html)
 
 ### The `[patch]` Section
 

--- a/src/doc/src/reference/registries.md
+++ b/src/doc/src/reference/registries.md
@@ -584,7 +584,7 @@ browser to log in and retrieve an API token.
 [`cargo login`]: commands/cargo-login.html
 [`cargo package`]: commands/cargo-package.html
 [`cargo publish`]: commands/cargo-publish.html
-[alphanumeric]: https://doc.rust-lang.org/std/primitive.char.html#method.is_alphanumeric
+[alphanumeric]: ../std/primitive.char.html#method.is_alphanumeric
 [config]: reference/config.html
 [crates.io]: https://crates.io/
 [publishing documentation]: reference/publishing.html#cargo-owner


### PR DESCRIPTION
This updates some links to their new locations.

This also switches to relative-style cross-book links. This allows the links
to work better when viewing local documentation (such as through rustup),
keeps links to the same toolchain (not just stable), and allows the rust-repo
linkchecker to validate the links. The downside is that when working on the
documentation in the cargo repo, the links won't work.