### PR TITLE
Fix nonconcurrent tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /target
+/tests/testsuite/support/cargo-test-macro/target
 Cargo.lock
 .cargo
 /config.stamp

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,6 +104,7 @@ features = [
 bufstream = "0.1"
 proptest = "0.9.1"
 varisat = "0.2.1"
+cargo-test-macro = { "path" = "tests/testsuite/support/cargo-test-macro" }
 
 [[bin]]
 name = "cargo"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,7 +104,7 @@ features = [
 bufstream = "0.1"
 proptest = "0.9.1"
 varisat = "0.2.1"
-cargo-test-macro = { "path" = "tests/testsuite/support/cargo-test-macro" }
+cargo-test-macro = { "path" = "tests/testsuite/support/cargo-test-macro", version = "0.1.0" }
 
 [[bin]]
 name = "cargo"

--- a/tests/testsuite/alt_registry.rs
+++ b/tests/testsuite/alt_registry.rs
@@ -5,7 +5,7 @@ use cargo::util::ToUrl;
 use std::fs::{self, File};
 use std::io::Write;
 
-#[test]
+#[cargo_test]
 fn depend_on_alt_registry() {
     let p = project()
         .file(
@@ -54,7 +54,7 @@ fn depend_on_alt_registry() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn depend_on_alt_registry_depends_on_same_registry_no_index() {
     let p = project()
         .file(
@@ -96,7 +96,7 @@ fn depend_on_alt_registry_depends_on_same_registry_no_index() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn depend_on_alt_registry_depends_on_same_registry() {
     let p = project()
         .file(
@@ -138,7 +138,7 @@ fn depend_on_alt_registry_depends_on_same_registry() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn depend_on_alt_registry_depends_on_crates_io() {
     let p = project()
         .file(
@@ -182,7 +182,7 @@ fn depend_on_alt_registry_depends_on_crates_io() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn registry_and_path_dep_works() {
     registry::init();
 
@@ -216,7 +216,7 @@ fn registry_and_path_dep_works() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn registry_incompatible_with_git() {
     registry::init();
 
@@ -246,7 +246,7 @@ fn registry_incompatible_with_git() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn cannot_publish_to_crates_io_with_registry_dependency() {
     let fakeio_path = paths::root().join("fake.io");
     let fakeio_url = fakeio_path.to_url().unwrap();
@@ -304,7 +304,7 @@ fn cannot_publish_to_crates_io_with_registry_dependency() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn publish_with_registry_dependency() {
     let p = project()
         .file(
@@ -365,7 +365,7 @@ fn publish_with_registry_dependency() {
     );
 }
 
-#[test]
+#[cargo_test]
 fn alt_registry_and_crates_io_deps() {
     let p = project()
         .file(
@@ -410,7 +410,7 @@ fn alt_registry_and_crates_io_deps() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn block_publish_due_to_no_token() {
     let p = project().file("src/main.rs", "fn main() {}").build();
 
@@ -426,7 +426,7 @@ fn block_publish_due_to_no_token() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn publish_to_alt_registry() {
     let p = project().file("src/main.rs", "fn main() {}").build();
 
@@ -464,7 +464,7 @@ fn publish_to_alt_registry() {
     );
 }
 
-#[test]
+#[cargo_test]
 fn publish_with_crates_io_dep() {
     let p = project()
         .file(
@@ -527,7 +527,7 @@ fn publish_with_crates_io_dep() {
     );
 }
 
-#[test]
+#[cargo_test]
 fn passwords_in_registry_index_url_forbidden() {
     registry::init();
 
@@ -551,7 +551,7 @@ fn passwords_in_registry_index_url_forbidden() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn passwords_in_registries_index_url_forbidden() {
     registry::init();
 
@@ -575,7 +575,7 @@ fn passwords_in_registries_index_url_forbidden() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn patch_alt_reg() {
     Package::new("bar", "0.1.0").publish();
     let p = project()
@@ -616,7 +616,7 @@ fn patch_alt_reg() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn bad_registry_name() {
     let p = project()
         .file(
@@ -664,7 +664,7 @@ Caused by:
     }
 }
 
-#[test]
+#[cargo_test]
 fn no_api() {
     Package::new("bar", "0.0.1").alternative(true).publish();
     // Configure without `api`.
@@ -746,7 +746,7 @@ fn no_api() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn alt_reg_metadata() {
     // Check for "registry" entries in `cargo metadata` with alternative registries.
     let p = project()
@@ -1019,7 +1019,7 @@ fn alt_reg_metadata() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn unknown_registry() {
     // A known registry refers to an unknown registry.
     // foo -> bar(crates.io) -> baz(alt)
@@ -1166,7 +1166,7 @@ fn unknown_registry() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn registries_index_relative_url() {
     let config = paths::root().join(".cargo/config");
     fs::create_dir_all(config.parent().unwrap()).unwrap();
@@ -1216,7 +1216,7 @@ fn registries_index_relative_url() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn registry_index_relative_url() {
     let config = paths::root().join(".cargo/config");
     fs::create_dir_all(config.parent().unwrap()).unwrap();
@@ -1268,7 +1268,7 @@ warning: custom registry support via the `registry.index` configuration is being
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn registries_index_relative_path_not_allowed() {
     let config = paths::root().join(".cargo/config");
     fs::create_dir_all(config.parent().unwrap()).unwrap();

--- a/tests/testsuite/bad_config.rs
+++ b/tests/testsuite/bad_config.rs
@@ -1,7 +1,7 @@
 use crate::support::registry::Package;
 use crate::support::{basic_manifest, project};
 
-#[test]
+#[cargo_test]
 fn bad1() {
     let p = project()
         .file("src/lib.rs", "")
@@ -24,7 +24,7 @@ but found string in [..]config
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn bad2() {
     let p = project()
         .file("src/lib.rs", "")
@@ -58,7 +58,7 @@ Caused by:
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn bad3() {
     let p = project()
         .file("src/lib.rs", "")
@@ -85,7 +85,7 @@ Caused by:
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn bad4() {
     let p = project()
         .file(
@@ -109,7 +109,7 @@ Caused by:
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn bad6() {
     let p = project()
         .file("src/lib.rs", "")
@@ -136,7 +136,7 @@ Caused by:
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn bad_cargo_config_jobs() {
     let p = project()
         .file("src/lib.rs", "")
@@ -160,7 +160,7 @@ invalid value: integer `-1`, expected u32
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn default_cargo_config_jobs() {
     let p = project()
         .file("src/lib.rs", "")
@@ -175,7 +175,7 @@ fn default_cargo_config_jobs() {
     p.cargo("build -v").run();
 }
 
-#[test]
+#[cargo_test]
 fn good_cargo_config_jobs() {
     let p = project()
         .file("src/lib.rs", "")
@@ -190,7 +190,7 @@ fn good_cargo_config_jobs() {
     p.cargo("build -v").run();
 }
 
-#[test]
+#[cargo_test]
 fn invalid_global_config() {
     let p = project()
         .file(
@@ -228,7 +228,7 @@ Caused by:
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn bad_cargo_lock() {
     let p = project()
         .file("Cargo.lock", "[[package]]\nfoo = 92")
@@ -248,7 +248,7 @@ Caused by:
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn duplicate_packages_in_cargo_lock() {
     Package::new("bar", "0.1.0").publish();
 
@@ -302,7 +302,7 @@ Caused by:
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn bad_source_in_cargo_lock() {
     Package::new("bar", "0.1.0").publish();
 
@@ -351,7 +351,7 @@ Caused by:
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn bad_dependency_in_lockfile() {
     let p = project()
         .file("src/lib.rs", "")
@@ -371,7 +371,7 @@ fn bad_dependency_in_lockfile() {
     p.cargo("build").run();
 }
 
-#[test]
+#[cargo_test]
 fn bad_git_dependency() {
     let p = project()
         .file(
@@ -409,7 +409,7 @@ Caused by:
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn bad_crate_type() {
     let p = project()
         .file(
@@ -435,7 +435,7 @@ fn bad_crate_type() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn malformed_override() {
     let p = project()
         .file(
@@ -471,7 +471,7 @@ Caused by:
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn duplicate_binary_names() {
     let p = project()
         .file(
@@ -508,7 +508,7 @@ Caused by:
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn duplicate_example_names() {
     let p = project()
         .file(
@@ -545,7 +545,7 @@ Caused by:
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn duplicate_bench_names() {
     let p = project()
         .file(
@@ -582,7 +582,7 @@ Caused by:
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn duplicate_deps() {
     let p = project()
         .file("shim-bar/Cargo.toml", &basic_manifest("bar", "0.0.1"))
@@ -621,7 +621,7 @@ have a single canonical source path irrespective of build target.
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn duplicate_deps_diff_sources() {
     let p = project()
         .file("shim-bar/Cargo.toml", &basic_manifest("bar", "0.0.1"))
@@ -660,7 +660,7 @@ have a single canonical source path irrespective of build target.
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn unused_keys() {
     let p = project()
         .file(
@@ -766,7 +766,7 @@ warning: unused manifest key: lib.build
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn unused_keys_in_virtual_manifest() {
     let p = project()
         .file(
@@ -791,7 +791,7 @@ fn unused_keys_in_virtual_manifest() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn empty_dependencies() {
     let p = project()
         .file(
@@ -821,7 +821,7 @@ to use. This will be considered an error in future versions
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn invalid_toml_historically_allowed_is_warned() {
     let p = project()
         .file(".cargo/config", "[bar] baz = 2")
@@ -845,7 +845,7 @@ in the future.
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn ambiguous_git_reference() {
     let p = project()
         .file(
@@ -877,7 +877,7 @@ This will be considered an error in future versions
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn bad_source_config1() {
     let p = project()
         .file("src/lib.rs", "")
@@ -890,7 +890,7 @@ fn bad_source_config1() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn bad_source_config2() {
     let p = project()
         .file(
@@ -933,7 +933,7 @@ Caused by:
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn bad_source_config3() {
     let p = project()
         .file(
@@ -975,7 +975,7 @@ Caused by:
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn bad_source_config4() {
     let p = project()
         .file(
@@ -1022,7 +1022,7 @@ Caused by:
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn bad_source_config5() {
     let p = project()
         .file(
@@ -1064,7 +1064,7 @@ Caused by:
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn both_git_and_path_specified() {
     let foo = project()
         .file(
@@ -1095,7 +1095,7 @@ This will be considered an error in future versions
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn bad_source_config6() {
     let p = project()
         .file(
@@ -1127,7 +1127,7 @@ fn bad_source_config6() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn ignored_git_revision() {
     let foo = project()
         .file(
@@ -1156,7 +1156,7 @@ fn ignored_git_revision() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn bad_source_config7() {
     let p = project()
         .file(
@@ -1190,7 +1190,7 @@ fn bad_source_config7() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn bad_dependency() {
     let p = project()
         .file(
@@ -1221,7 +1221,7 @@ Caused by:
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn bad_debuginfo() {
     let p = project()
         .file(
@@ -1252,7 +1252,7 @@ Caused by:
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn bad_opt_level() {
     let p = project()
         .file(
@@ -1281,7 +1281,7 @@ Caused by:
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn warn_semver_metadata() {
     Package::new("bar", "1.0.0").publish();
     let p = project()

--- a/tests/testsuite/bad_manifest_path.rs
+++ b/tests/testsuite/bad_manifest_path.rs
@@ -37,287 +37,287 @@ fn assert_cargo_toml_doesnt_exist(command: &str, manifest_path_argument: &str) {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn bench_dir_containing_cargo_toml() {
     assert_not_a_cargo_toml("bench", "foo");
 }
 
-#[test]
+#[cargo_test]
 fn bench_dir_plus_file() {
     assert_not_a_cargo_toml("bench", "foo/bar");
 }
 
-#[test]
+#[cargo_test]
 fn bench_dir_plus_path() {
     assert_not_a_cargo_toml("bench", "foo/bar/baz");
 }
 
-#[test]
+#[cargo_test]
 fn bench_dir_to_nonexistent_cargo_toml() {
     assert_cargo_toml_doesnt_exist("bench", "foo/bar/baz/Cargo.toml");
 }
 
-#[test]
+#[cargo_test]
 fn build_dir_containing_cargo_toml() {
     assert_not_a_cargo_toml("build", "foo");
 }
 
-#[test]
+#[cargo_test]
 fn build_dir_plus_file() {
     assert_not_a_cargo_toml("bench", "foo/bar");
 }
 
-#[test]
+#[cargo_test]
 fn build_dir_plus_path() {
     assert_not_a_cargo_toml("bench", "foo/bar/baz");
 }
 
-#[test]
+#[cargo_test]
 fn build_dir_to_nonexistent_cargo_toml() {
     assert_cargo_toml_doesnt_exist("build", "foo/bar/baz/Cargo.toml");
 }
 
-#[test]
+#[cargo_test]
 fn clean_dir_containing_cargo_toml() {
     assert_not_a_cargo_toml("clean", "foo");
 }
 
-#[test]
+#[cargo_test]
 fn clean_dir_plus_file() {
     assert_not_a_cargo_toml("clean", "foo/bar");
 }
 
-#[test]
+#[cargo_test]
 fn clean_dir_plus_path() {
     assert_not_a_cargo_toml("clean", "foo/bar/baz");
 }
 
-#[test]
+#[cargo_test]
 fn clean_dir_to_nonexistent_cargo_toml() {
     assert_cargo_toml_doesnt_exist("clean", "foo/bar/baz/Cargo.toml");
 }
 
-#[test]
+#[cargo_test]
 fn doc_dir_containing_cargo_toml() {
     assert_not_a_cargo_toml("doc", "foo");
 }
 
-#[test]
+#[cargo_test]
 fn doc_dir_plus_file() {
     assert_not_a_cargo_toml("doc", "foo/bar");
 }
 
-#[test]
+#[cargo_test]
 fn doc_dir_plus_path() {
     assert_not_a_cargo_toml("doc", "foo/bar/baz");
 }
 
-#[test]
+#[cargo_test]
 fn doc_dir_to_nonexistent_cargo_toml() {
     assert_cargo_toml_doesnt_exist("doc", "foo/bar/baz/Cargo.toml");
 }
 
-#[test]
+#[cargo_test]
 fn fetch_dir_containing_cargo_toml() {
     assert_not_a_cargo_toml("fetch", "foo");
 }
 
-#[test]
+#[cargo_test]
 fn fetch_dir_plus_file() {
     assert_not_a_cargo_toml("fetch", "foo/bar");
 }
 
-#[test]
+#[cargo_test]
 fn fetch_dir_plus_path() {
     assert_not_a_cargo_toml("fetch", "foo/bar/baz");
 }
 
-#[test]
+#[cargo_test]
 fn fetch_dir_to_nonexistent_cargo_toml() {
     assert_cargo_toml_doesnt_exist("fetch", "foo/bar/baz/Cargo.toml");
 }
 
-#[test]
+#[cargo_test]
 fn generate_lockfile_dir_containing_cargo_toml() {
     assert_not_a_cargo_toml("generate-lockfile", "foo");
 }
 
-#[test]
+#[cargo_test]
 fn generate_lockfile_dir_plus_file() {
     assert_not_a_cargo_toml("generate-lockfile", "foo/bar");
 }
 
-#[test]
+#[cargo_test]
 fn generate_lockfile_dir_plus_path() {
     assert_not_a_cargo_toml("generate-lockfile", "foo/bar/baz");
 }
 
-#[test]
+#[cargo_test]
 fn generate_lockfile_dir_to_nonexistent_cargo_toml() {
     assert_cargo_toml_doesnt_exist("generate-lockfile", "foo/bar/baz/Cargo.toml");
 }
 
-#[test]
+#[cargo_test]
 fn package_dir_containing_cargo_toml() {
     assert_not_a_cargo_toml("package", "foo");
 }
 
-#[test]
+#[cargo_test]
 fn package_dir_plus_file() {
     assert_not_a_cargo_toml("package", "foo/bar");
 }
 
-#[test]
+#[cargo_test]
 fn package_dir_plus_path() {
     assert_not_a_cargo_toml("package", "foo/bar/baz");
 }
 
-#[test]
+#[cargo_test]
 fn package_dir_to_nonexistent_cargo_toml() {
     assert_cargo_toml_doesnt_exist("package", "foo/bar/baz/Cargo.toml");
 }
 
-#[test]
+#[cargo_test]
 fn pkgid_dir_containing_cargo_toml() {
     assert_not_a_cargo_toml("pkgid", "foo");
 }
 
-#[test]
+#[cargo_test]
 fn pkgid_dir_plus_file() {
     assert_not_a_cargo_toml("pkgid", "foo/bar");
 }
 
-#[test]
+#[cargo_test]
 fn pkgid_dir_plus_path() {
     assert_not_a_cargo_toml("pkgid", "foo/bar/baz");
 }
 
-#[test]
+#[cargo_test]
 fn pkgid_dir_to_nonexistent_cargo_toml() {
     assert_cargo_toml_doesnt_exist("pkgid", "foo/bar/baz/Cargo.toml");
 }
 
-#[test]
+#[cargo_test]
 fn publish_dir_containing_cargo_toml() {
     assert_not_a_cargo_toml("publish", "foo");
 }
 
-#[test]
+#[cargo_test]
 fn publish_dir_plus_file() {
     assert_not_a_cargo_toml("publish", "foo/bar");
 }
 
-#[test]
+#[cargo_test]
 fn publish_dir_plus_path() {
     assert_not_a_cargo_toml("publish", "foo/bar/baz");
 }
 
-#[test]
+#[cargo_test]
 fn publish_dir_to_nonexistent_cargo_toml() {
     assert_cargo_toml_doesnt_exist("publish", "foo/bar/baz/Cargo.toml");
 }
 
-#[test]
+#[cargo_test]
 fn read_manifest_dir_containing_cargo_toml() {
     assert_not_a_cargo_toml("read-manifest", "foo");
 }
 
-#[test]
+#[cargo_test]
 fn read_manifest_dir_plus_file() {
     assert_not_a_cargo_toml("read-manifest", "foo/bar");
 }
 
-#[test]
+#[cargo_test]
 fn read_manifest_dir_plus_path() {
     assert_not_a_cargo_toml("read-manifest", "foo/bar/baz");
 }
 
-#[test]
+#[cargo_test]
 fn read_manifest_dir_to_nonexistent_cargo_toml() {
     assert_cargo_toml_doesnt_exist("read-manifest", "foo/bar/baz/Cargo.toml");
 }
 
-#[test]
+#[cargo_test]
 fn run_dir_containing_cargo_toml() {
     assert_not_a_cargo_toml("run", "foo");
 }
 
-#[test]
+#[cargo_test]
 fn run_dir_plus_file() {
     assert_not_a_cargo_toml("run", "foo/bar");
 }
 
-#[test]
+#[cargo_test]
 fn run_dir_plus_path() {
     assert_not_a_cargo_toml("run", "foo/bar/baz");
 }
 
-#[test]
+#[cargo_test]
 fn run_dir_to_nonexistent_cargo_toml() {
     assert_cargo_toml_doesnt_exist("run", "foo/bar/baz/Cargo.toml");
 }
 
-#[test]
+#[cargo_test]
 fn rustc_dir_containing_cargo_toml() {
     assert_not_a_cargo_toml("rustc", "foo");
 }
 
-#[test]
+#[cargo_test]
 fn rustc_dir_plus_file() {
     assert_not_a_cargo_toml("rustc", "foo/bar");
 }
 
-#[test]
+#[cargo_test]
 fn rustc_dir_plus_path() {
     assert_not_a_cargo_toml("rustc", "foo/bar/baz");
 }
 
-#[test]
+#[cargo_test]
 fn rustc_dir_to_nonexistent_cargo_toml() {
     assert_cargo_toml_doesnt_exist("rustc", "foo/bar/baz/Cargo.toml");
 }
 
-#[test]
+#[cargo_test]
 fn test_dir_containing_cargo_toml() {
     assert_not_a_cargo_toml("test", "foo");
 }
 
-#[test]
+#[cargo_test]
 fn test_dir_plus_file() {
     assert_not_a_cargo_toml("test", "foo/bar");
 }
 
-#[test]
+#[cargo_test]
 fn test_dir_plus_path() {
     assert_not_a_cargo_toml("test", "foo/bar/baz");
 }
 
-#[test]
+#[cargo_test]
 fn test_dir_to_nonexistent_cargo_toml() {
     assert_cargo_toml_doesnt_exist("test", "foo/bar/baz/Cargo.toml");
 }
 
-#[test]
+#[cargo_test]
 fn update_dir_containing_cargo_toml() {
     assert_not_a_cargo_toml("update", "foo");
 }
 
-#[test]
+#[cargo_test]
 fn update_dir_plus_file() {
     assert_not_a_cargo_toml("update", "foo/bar");
 }
 
-#[test]
+#[cargo_test]
 fn update_dir_plus_path() {
     assert_not_a_cargo_toml("update", "foo/bar/baz");
 }
 
-#[test]
+#[cargo_test]
 fn update_dir_to_nonexistent_cargo_toml() {
     assert_cargo_toml_doesnt_exist("update", "foo/bar/baz/Cargo.toml");
 }
 
-#[test]
+#[cargo_test]
 fn verify_project_dir_containing_cargo_toml() {
     let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
@@ -334,7 +334,7 @@ fn verify_project_dir_containing_cargo_toml() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn verify_project_dir_plus_file() {
     let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
@@ -351,7 +351,7 @@ fn verify_project_dir_plus_file() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn verify_project_dir_plus_path() {
     let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
@@ -368,7 +368,7 @@ fn verify_project_dir_plus_path() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn verify_project_dir_to_nonexistent_cargo_toml() {
     let p = project().build();
     p.cargo("verify-project --manifest-path foo/bar/baz/Cargo.toml")

--- a/tests/testsuite/bench.rs
+++ b/tests/testsuite/bench.rs
@@ -2,7 +2,7 @@ use crate::support::is_nightly;
 use crate::support::paths::CargoPathExt;
 use crate::support::{basic_bin_manifest, basic_lib_manifest, basic_manifest, project};
 
-#[test]
+#[cargo_test]
 fn cargo_bench_simple() {
     if !is_nightly() {
         return;
@@ -48,7 +48,7 @@ fn cargo_bench_simple() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn bench_bench_implicit() {
     if !is_nightly() {
         return;
@@ -93,7 +93,7 @@ fn bench_bench_implicit() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn bench_bin_implicit() {
     if !is_nightly() {
         return;
@@ -137,7 +137,7 @@ fn bench_bin_implicit() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn bench_tarname() {
     if !is_nightly() {
         return;
@@ -172,7 +172,7 @@ fn bench_tarname() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn bench_multiple_targets() {
     if !is_nightly() {
         return;
@@ -209,7 +209,7 @@ fn bench_multiple_targets() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn cargo_bench_verbose() {
     if !is_nightly() {
         return;
@@ -241,7 +241,7 @@ fn cargo_bench_verbose() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn many_similar_names() {
     if !is_nightly() {
         return;
@@ -288,7 +288,7 @@ fn many_similar_names() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn cargo_bench_failing_test() {
     if !is_nightly() {
         return;
@@ -341,7 +341,7 @@ fn cargo_bench_failing_test() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn bench_with_lib_dep() {
     if !is_nightly() {
         return;
@@ -409,7 +409,7 @@ fn bench_with_lib_dep() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn bench_with_deep_lib_dep() {
     if !is_nightly() {
         return;
@@ -472,7 +472,7 @@ fn bench_with_deep_lib_dep() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn external_bench_explicit() {
     if !is_nightly() {
         return;
@@ -531,7 +531,7 @@ fn external_bench_explicit() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn external_bench_implicit() {
     if !is_nightly() {
         return;
@@ -578,7 +578,7 @@ fn external_bench_implicit() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn bench_autodiscover_2015() {
     if !is_nightly() {
         return;
@@ -652,7 +652,7 @@ https://github.com/rust-lang/cargo/issues/5330
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn dont_run_examples() {
     if !is_nightly() {
         return;
@@ -668,7 +668,7 @@ fn dont_run_examples() {
     p.cargo("bench").run();
 }
 
-#[test]
+#[cargo_test]
 fn pass_through_command_line() {
     if !is_nightly() {
         return;
@@ -709,7 +709,7 @@ fn pass_through_command_line() {
 
 // Regression test for running cargo-bench twice with
 // tests in an rlib
-#[test]
+#[cargo_test]
 fn cargo_bench_twice() {
     if !is_nightly() {
         return;
@@ -736,7 +736,7 @@ fn cargo_bench_twice() {
     }
 }
 
-#[test]
+#[cargo_test]
 fn lib_bin_same_name() {
     if !is_nightly() {
         return;
@@ -793,7 +793,7 @@ fn lib_bin_same_name() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn lib_with_standard_name() {
     if !is_nightly() {
         return;
@@ -843,7 +843,7 @@ fn lib_with_standard_name() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn lib_with_standard_name2() {
     if !is_nightly() {
         return;
@@ -893,7 +893,7 @@ fn lib_with_standard_name2() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn bench_dylib() {
     if !is_nightly() {
         return;
@@ -987,7 +987,7 @@ fn bench_dylib() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn bench_twice_with_build_cmd() {
     if !is_nightly() {
         return;
@@ -1036,7 +1036,7 @@ fn bench_twice_with_build_cmd() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn bench_with_examples() {
     if !is_nightly() {
         return;
@@ -1123,7 +1123,7 @@ fn bench_with_examples() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn test_a_bench() {
     if !is_nightly() {
         return;
@@ -1163,7 +1163,7 @@ fn test_a_bench() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn test_bench_no_run() {
     if !is_nightly() {
         return;
@@ -1196,7 +1196,7 @@ fn test_bench_no_run() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn test_bench_no_fail_fast() {
     if !is_nightly() {
         return;
@@ -1240,7 +1240,7 @@ fn test_bench_no_fail_fast() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn test_bench_multiple_packages() {
     if !is_nightly() {
         return;
@@ -1333,7 +1333,7 @@ fn test_bench_multiple_packages() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn bench_all_workspace() {
     if !is_nightly() {
         return;
@@ -1390,7 +1390,7 @@ fn bench_all_workspace() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn bench_all_exclude() {
     if !is_nightly() {
         return;
@@ -1439,7 +1439,7 @@ test bar ... bench:           [..] ns/iter (+/- [..])",
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn bench_all_virtual_manifest() {
     if !is_nightly() {
         return;
@@ -1493,7 +1493,7 @@ fn bench_all_virtual_manifest() {
 }
 
 // https://github.com/rust-lang/cargo/issues/4287
-#[test]
+#[cargo_test]
 fn legacy_bench_name() {
     if !is_nightly() {
         return;
@@ -1535,7 +1535,7 @@ please set bench.path in Cargo.toml",
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn bench_virtual_manifest_all_implied() {
     if !is_nightly() {
         return;
@@ -1585,7 +1585,7 @@ fn bench_virtual_manifest_all_implied() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn json_artifact_includes_executable_for_benchmark() {
     if !is_nightly() {
         return;

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -11,7 +11,7 @@ use crate::support::{
 use crate::support::{main_file, project, Execs};
 use cargo::util::paths::dylib_path_envvar;
 
-#[test]
+#[cargo_test]
 fn cargo_compile_simple() {
     let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
@@ -24,7 +24,7 @@ fn cargo_compile_simple() {
     p.process(&p.bin("foo")).with_stdout("i am foo\n").run();
 }
 
-#[test]
+#[cargo_test]
 fn cargo_fail_with_no_stderr() {
     let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
@@ -38,7 +38,7 @@ fn cargo_fail_with_no_stderr() {
 
 /// Checks that the `CARGO_INCREMENTAL` environment variable results in
 /// `rustc` getting `-C incremental` passed to it.
-#[test]
+#[cargo_test]
 fn cargo_compile_incremental() {
     let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
@@ -60,7 +60,7 @@ fn cargo_compile_incremental() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn incremental_profile() {
     let p = project()
         .file(
@@ -102,7 +102,7 @@ fn incremental_profile() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn incremental_config() {
     let p = project()
         .file("src/main.rs", "fn main() {}")
@@ -126,7 +126,7 @@ fn incremental_config() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn cargo_compile_with_workspace_excluded() {
     let p = project().file("src/main.rs", "fn main() {}").build();
 
@@ -137,7 +137,7 @@ fn cargo_compile_with_workspace_excluded() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn cargo_compile_manifest_path() {
     let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
@@ -150,7 +150,7 @@ fn cargo_compile_manifest_path() {
     assert!(p.bin("foo").is_file());
 }
 
-#[test]
+#[cargo_test]
 fn cargo_compile_with_invalid_manifest() {
     let p = project().file("Cargo.toml", "").build();
 
@@ -167,7 +167,7 @@ Caused by:
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn cargo_compile_with_invalid_manifest2() {
     let p = project()
         .file(
@@ -195,7 +195,7 @@ Caused by:
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn cargo_compile_with_invalid_manifest3() {
     let p = project().file("src/Cargo.toml", "a = bar").build();
 
@@ -215,7 +215,7 @@ Caused by:
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn cargo_compile_duplicate_build_targets() {
     let p = project()
         .file(
@@ -248,7 +248,7 @@ warning: file found to be present in multiple build targets: [..]main.rs
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn cargo_compile_with_invalid_version() {
     let p = project()
         .file("Cargo.toml", &basic_manifest("foo", "1.0"))
@@ -267,7 +267,7 @@ Caused by:
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn cargo_compile_with_empty_package_name() {
     let p = project()
         .file("Cargo.toml", &basic_manifest("", "0.0.0"))
@@ -286,7 +286,7 @@ Caused by:
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn cargo_compile_with_invalid_package_name() {
     let p = project()
         .file("Cargo.toml", &basic_manifest("foo::bar", "0.0.0"))
@@ -305,7 +305,7 @@ Caused by:
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn cargo_compile_with_invalid_bin_target_name() {
     let p = project()
         .file(
@@ -335,7 +335,7 @@ Caused by:
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn cargo_compile_with_forbidden_bin_target_name() {
     let p = project()
         .file(
@@ -365,7 +365,7 @@ Caused by:
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn cargo_compile_with_bin_and_crate_type() {
     let p = project()
         .file(
@@ -398,7 +398,7 @@ Caused by:
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn cargo_compile_with_bin_and_proc() {
     let p = project()
         .file(
@@ -430,7 +430,7 @@ Caused by:
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn cargo_compile_with_invalid_lib_target_name() {
     let p = project()
         .file(
@@ -460,7 +460,7 @@ Caused by:
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn cargo_compile_with_invalid_non_numeric_dep_version() {
     let p = project()
         .file(
@@ -492,7 +492,7 @@ Caused by:
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn cargo_compile_without_manifest() {
     let p = project().no_manifest().build();
 
@@ -502,7 +502,7 @@ fn cargo_compile_without_manifest() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn cargo_compile_with_invalid_code() {
     let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
@@ -521,7 +521,7 @@ To learn more, run the command again with --verbose.\n",
     assert!(p.root().join("Cargo.lock").is_file());
 }
 
-#[test]
+#[cargo_test]
 fn cargo_compile_with_invalid_code_in_deps() {
     let p = project()
         .file(
@@ -557,7 +557,7 @@ fn cargo_compile_with_invalid_code_in_deps() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn cargo_compile_with_warnings_in_the_root_package() {
     let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
@@ -569,7 +569,7 @@ fn cargo_compile_with_warnings_in_the_root_package() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn cargo_compile_with_warnings_in_a_dep_package() {
     let p = project()
         .file(
@@ -612,7 +612,7 @@ fn cargo_compile_with_warnings_in_a_dep_package() {
     p.process(&p.bin("foo")).with_stdout("test passed\n").run();
 }
 
-#[test]
+#[cargo_test]
 fn cargo_compile_with_nested_deps_inferred() {
     let p = project()
         .file(
@@ -675,7 +675,7 @@ fn cargo_compile_with_nested_deps_inferred() {
     p.process(&p.bin("foo")).with_stdout("test passed\n").run();
 }
 
-#[test]
+#[cargo_test]
 fn cargo_compile_with_nested_deps_correct_bin() {
     let p = project()
         .file(
@@ -738,7 +738,7 @@ fn cargo_compile_with_nested_deps_correct_bin() {
     p.process(&p.bin("foo")).with_stdout("test passed\n").run();
 }
 
-#[test]
+#[cargo_test]
 fn cargo_compile_with_nested_deps_shorthand() {
     let p = project()
         .file(
@@ -802,7 +802,7 @@ fn cargo_compile_with_nested_deps_shorthand() {
     p.process(&p.bin("foo")).with_stdout("test passed\n").run();
 }
 
-#[test]
+#[cargo_test]
 fn cargo_compile_with_nested_deps_longhand() {
     let p = project()
         .file(
@@ -874,7 +874,7 @@ fn cargo_compile_with_nested_deps_longhand() {
 
 // Check that Cargo gives a sensible error if a dependency can't be found
 // because of a name mismatch.
-#[test]
+#[cargo_test]
 fn cargo_compile_with_dep_name_mismatch() {
     let p = project()
         .file(
@@ -911,7 +911,7 @@ required by package `foo v0.0.1 ([CWD])`
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn cargo_compile_with_filename() {
     let p = project()
         .file("src/lib.rs", "")
@@ -956,7 +956,7 @@ Did you mean `a`?",
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn incompatible_dependencies() {
     Package::new("bad", "0.1.0").publish();
     Package::new("bad", "1.0.0").publish();
@@ -1006,7 +1006,7 @@ failed to select a version for `bad` which could resolve this conflict",
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn incompatible_dependencies_with_multi_semver() {
     Package::new("bad", "1.0.0").publish();
     Package::new("bad", "1.0.1").publish();
@@ -1055,7 +1055,7 @@ failed to select a version for `bad` which could resolve this conflict",
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn compile_path_dep_then_change_version() {
     let p = project()
         .file(
@@ -1085,7 +1085,7 @@ fn compile_path_dep_then_change_version() {
     p.cargo("build").run();
 }
 
-#[test]
+#[cargo_test]
 fn ignores_carriage_return_in_lockfile() {
     let p = project()
         .file("src/main.rs", r"mod a; fn main() {}")
@@ -1108,7 +1108,7 @@ fn ignores_carriage_return_in_lockfile() {
     p.cargo("build").run();
 }
 
-#[test]
+#[cargo_test]
 fn cargo_default_env_metadata_env_var() {
     // Ensure that path dep + dylib + env_var get metadata
     // (even though path_dep + dylib should not)
@@ -1197,7 +1197,7 @@ fn cargo_default_env_metadata_env_var() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn crate_env_vars() {
     let p = project()
         .file(
@@ -1272,7 +1272,7 @@ fn crate_env_vars() {
     p.cargo("test -v").run();
 }
 
-#[test]
+#[cargo_test]
 fn crate_authors_env_vars() {
     let p = project()
         .file(
@@ -1321,7 +1321,7 @@ fn crate_authors_env_vars() {
     p.cargo("test -v").run();
 }
 
-#[test]
+#[cargo_test]
 fn vv_prints_rustc_env_vars() {
     let p = project()
         .file(
@@ -1367,7 +1367,7 @@ fn setenv_for_removing_empty_component(mut execs: Execs) -> Execs {
 }
 
 // Regression test for #4277
-#[test]
+#[cargo_test]
 fn crate_library_path_env_var() {
     let p = project()
         .file(
@@ -1389,7 +1389,7 @@ fn crate_library_path_env_var() {
 }
 
 // Regression test for #4277
-#[test]
+#[cargo_test]
 fn build_with_fake_libc_not_loading() {
     let p = project()
         .file("src/main.rs", "fn main() {}")
@@ -1401,7 +1401,7 @@ fn build_with_fake_libc_not_loading() {
 }
 
 // this is testing that src/<pkg-name>.rs still works (for now)
-#[test]
+#[cargo_test]
 fn many_crate_types_old_style_lib_location() {
     let p = project()
         .file(
@@ -1434,7 +1434,7 @@ please rename the file to `src/lib.rs` or set lib.path in Cargo.toml",
     assert!(p.root().join("target/debug").join(&fname).is_file());
 }
 
-#[test]
+#[cargo_test]
 fn many_crate_types_correct() {
     let p = project()
         .file(
@@ -1461,7 +1461,7 @@ fn many_crate_types_correct() {
     assert!(p.root().join("target/debug").join(&fname).is_file());
 }
 
-#[test]
+#[cargo_test]
 fn self_dependency() {
     let p = project()
         .file(
@@ -1494,7 +1494,7 @@ package `test v0.0.0 ([CWD])`",
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn ignore_broken_symlinks() {
     // windows and symlinks don't currently agree that well
     if cfg!(windows) {
@@ -1513,7 +1513,7 @@ fn ignore_broken_symlinks() {
     p.process(&p.bin("foo")).with_stdout("i am foo\n").run();
 }
 
-#[test]
+#[cargo_test]
 fn missing_lib_and_bin() {
     let p = project().build();
     p.cargo("build")
@@ -1529,7 +1529,7 @@ Caused by:
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn lto_build() {
     // FIXME: currently this hits a linker bug on 32-bit MSVC
     if cfg!(all(target_env = "msvc", target_pointer_width = "32")) {
@@ -1569,7 +1569,7 @@ fn lto_build() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn verbose_build() {
     let p = project().file("src/lib.rs", "").build();
     p.cargo("build -v")
@@ -1587,7 +1587,7 @@ fn verbose_build() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn verbose_release_build() {
     let p = project().file("src/lib.rs", "").build();
     p.cargo("build -v --release")
@@ -1606,7 +1606,7 @@ fn verbose_release_build() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn verbose_release_build_deps() {
     let p = project()
         .file(
@@ -1668,7 +1668,7 @@ fn verbose_release_build_deps() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn explicit_examples() {
     let p = project()
         .file(
@@ -1725,7 +1725,7 @@ fn explicit_examples() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn non_existing_example() {
     let p = project()
         .file(
@@ -1759,7 +1759,7 @@ Caused by:
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn non_existing_binary() {
     let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
@@ -1779,7 +1779,7 @@ Caused by:
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn legacy_binary_paths_warnings() {
     let p = project()
         .file(
@@ -1856,7 +1856,7 @@ please set bin.path in Cargo.toml",
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn implicit_examples() {
     let p = project()
         .file(
@@ -1896,7 +1896,7 @@ fn implicit_examples() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn standard_build_no_ndebug() {
     let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
@@ -1918,7 +1918,7 @@ fn standard_build_no_ndebug() {
     p.process(&p.bin("foo")).with_stdout("slow\n").run();
 }
 
-#[test]
+#[cargo_test]
 fn release_build_ndebug() {
     let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
@@ -1940,7 +1940,7 @@ fn release_build_ndebug() {
     p.process(&p.release_bin("foo")).with_stdout("fast\n").run();
 }
 
-#[test]
+#[cargo_test]
 fn inferred_main_bin() {
     let p = project().file("src/main.rs", "fn main() {}").build();
 
@@ -1948,7 +1948,7 @@ fn inferred_main_bin() {
     p.process(&p.bin("foo")).run();
 }
 
-#[test]
+#[cargo_test]
 fn deletion_causes_failure() {
     let p = project()
         .file(
@@ -1976,7 +1976,7 @@ fn deletion_causes_failure() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn bad_cargo_toml_in_target_dir() {
     let p = project()
         .file("src/main.rs", "fn main() {}")
@@ -1987,7 +1987,7 @@ fn bad_cargo_toml_in_target_dir() {
     p.process(&p.bin("foo")).run();
 }
 
-#[test]
+#[cargo_test]
 fn lib_with_standard_name() {
     let p = project()
         .file("Cargo.toml", &basic_manifest("syntax", "0.0.1"))
@@ -2008,7 +2008,7 @@ fn lib_with_standard_name() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn simple_staticlib() {
     let p = project()
         .file(
@@ -2031,7 +2031,7 @@ fn simple_staticlib() {
     p.cargo("build").env("CARGO_LOG", "nekoneko=trace").run();
 }
 
-#[test]
+#[cargo_test]
 fn staticlib_rlib_and_bin() {
     let p = project()
         .file(
@@ -2054,7 +2054,7 @@ fn staticlib_rlib_and_bin() {
     p.cargo("build -v").run();
 }
 
-#[test]
+#[cargo_test]
 fn opt_out_of_bin() {
     let p = project()
         .file(
@@ -2074,7 +2074,7 @@ fn opt_out_of_bin() {
     p.cargo("build").run();
 }
 
-#[test]
+#[cargo_test]
 fn single_lib() {
     let p = project()
         .file(
@@ -2095,7 +2095,7 @@ fn single_lib() {
     p.cargo("build").run();
 }
 
-#[test]
+#[cargo_test]
 fn freshness_ignores_excluded() {
     let foo = project()
         .file(
@@ -2133,7 +2133,7 @@ fn freshness_ignores_excluded() {
     foo.cargo("build").with_stdout("").run();
 }
 
-#[test]
+#[cargo_test]
 fn rebuild_preserves_out_dir() {
     let foo = project()
         .file(
@@ -2188,7 +2188,7 @@ fn rebuild_preserves_out_dir() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn dep_no_libs() {
     let foo = project()
         .file(
@@ -2210,7 +2210,7 @@ fn dep_no_libs() {
     foo.cargo("build").run();
 }
 
-#[test]
+#[cargo_test]
 fn recompile_space_in_name() {
     let foo = project()
         .file(
@@ -2234,7 +2234,7 @@ fn recompile_space_in_name() {
 }
 
 #[cfg(unix)]
-#[test]
+#[cargo_test]
 fn ignore_bad_directories() {
     use std::os::unix::prelude::*;
     let foo = project()
@@ -2252,7 +2252,7 @@ fn ignore_bad_directories() {
     fs::set_permissions(&dir, perms).unwrap();
 }
 
-#[test]
+#[cargo_test]
 fn bad_cargo_config() {
     let foo = project()
         .file("Cargo.toml", &basic_manifest("foo", "0.0.0"))
@@ -2278,7 +2278,7 @@ Caused by:
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn cargo_platform_specific_dependency() {
     let host = rustc_host();
     let p = project()
@@ -2325,7 +2325,7 @@ fn cargo_platform_specific_dependency() {
     p.cargo("test").run();
 }
 
-#[test]
+#[cargo_test]
 fn bad_platform_specific_dependency() {
     let p = project()
         .file(
@@ -2355,7 +2355,7 @@ fn bad_platform_specific_dependency() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn cargo_platform_specific_dependency_wrong_platform() {
     let p = project()
         .file(
@@ -2393,7 +2393,7 @@ fn cargo_platform_specific_dependency_wrong_platform() {
     assert!(lockfile.contains("bar"));
 }
 
-#[test]
+#[cargo_test]
 fn example_as_lib() {
     let p = project()
         .file(
@@ -2417,7 +2417,7 @@ fn example_as_lib() {
     assert!(p.example_lib("ex", "lib").is_file());
 }
 
-#[test]
+#[cargo_test]
 fn example_as_rlib() {
     let p = project()
         .file(
@@ -2441,7 +2441,7 @@ fn example_as_rlib() {
     assert!(p.example_lib("ex", "rlib").is_file());
 }
 
-#[test]
+#[cargo_test]
 fn example_as_dylib() {
     let p = project()
         .file(
@@ -2465,7 +2465,7 @@ fn example_as_dylib() {
     assert!(p.example_lib("ex", "dylib").is_file());
 }
 
-#[test]
+#[cargo_test]
 fn example_as_proc_macro() {
     let p = project()
         .file(
@@ -2500,7 +2500,7 @@ fn example_as_proc_macro() {
     assert!(p.example_lib("ex", "proc-macro").is_file());
 }
 
-#[test]
+#[cargo_test]
 fn example_bin_same_name() {
     let p = project()
         .file("src/main.rs", "fn main() {}")
@@ -2520,7 +2520,7 @@ fn example_bin_same_name() {
     assert!(p.bin("examples/foo").is_file());
 }
 
-#[test]
+#[cargo_test]
 fn compile_then_delete() {
     let p = project().file("src/main.rs", "fn main() {}").build();
 
@@ -2534,7 +2534,7 @@ fn compile_then_delete() {
     p.cargo("run -v").run();
 }
 
-#[test]
+#[cargo_test]
 fn transitive_dependencies_not_available() {
     let p = project()
         .file(
@@ -2576,7 +2576,7 @@ fn transitive_dependencies_not_available() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn cyclic_deps_rejected() {
     let p = project()
         .file(
@@ -2616,7 +2616,7 @@ package `a v0.0.1 ([CWD]/a)`
         ).run();
 }
 
-#[test]
+#[cargo_test]
 fn predictable_filenames() {
     let p = project()
         .file(
@@ -2641,7 +2641,7 @@ fn predictable_filenames() {
     assert!(p.root().join("target/debug").join(dylib_name).is_file());
 }
 
-#[test]
+#[cargo_test]
 fn dashes_to_underscores() {
     let p = project()
         .file("Cargo.toml", &basic_manifest("foo-bar", "0.0.1"))
@@ -2653,7 +2653,7 @@ fn dashes_to_underscores() {
     assert!(p.bin("foo-bar").is_file());
 }
 
-#[test]
+#[cargo_test]
 fn dashes_in_crate_name_bad() {
     let p = project()
         .file(
@@ -2685,7 +2685,7 @@ Caused by:
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn rustc_env_var() {
     let p = project().file("src/lib.rs", "").build();
 
@@ -2704,7 +2704,7 @@ Caused by:
     assert!(!p.bin("a").is_file());
 }
 
-#[test]
+#[cargo_test]
 fn filtering() {
     let p = project()
         .file("src/lib.rs", "")
@@ -2724,7 +2724,7 @@ fn filtering() {
     assert!(!p.bin("examples/b").is_file());
 }
 
-#[test]
+#[cargo_test]
 fn filtering_implicit_bins() {
     let p = project()
         .file("src/lib.rs", "")
@@ -2741,7 +2741,7 @@ fn filtering_implicit_bins() {
     assert!(!p.bin("examples/b").is_file());
 }
 
-#[test]
+#[cargo_test]
 fn filtering_implicit_examples() {
     let p = project()
         .file("src/lib.rs", "")
@@ -2758,7 +2758,7 @@ fn filtering_implicit_examples() {
     assert!(p.bin("examples/b").is_file());
 }
 
-#[test]
+#[cargo_test]
 fn ignore_dotfile() {
     let p = project()
         .file("src/bin/.a.rs", "")
@@ -2768,7 +2768,7 @@ fn ignore_dotfile() {
     p.cargo("build").run();
 }
 
-#[test]
+#[cargo_test]
 fn ignore_dotdirs() {
     let p = project()
         .file("src/bin/a.rs", "fn main() {}")
@@ -2779,7 +2779,7 @@ fn ignore_dotdirs() {
     p.cargo("build").run();
 }
 
-#[test]
+#[cargo_test]
 fn dotdir_root() {
     let p = ProjectBuilder::new(root().join(".foo"))
         .file("src/bin/a.rs", "fn main() {}")
@@ -2787,7 +2787,7 @@ fn dotdir_root() {
     p.cargo("build").run();
 }
 
-#[test]
+#[cargo_test]
 fn custom_target_dir_env() {
     let p = project().file("src/main.rs", "fn main() {}").build();
 
@@ -2817,7 +2817,7 @@ fn custom_target_dir_env() {
     assert!(p.root().join("target/debug").join(&exe_name).is_file());
 }
 
-#[test]
+#[cargo_test]
 fn custom_target_dir_line_parameter() {
     let p = project().file("src/main.rs", "fn main() {}").build();
 
@@ -2859,7 +2859,7 @@ fn custom_target_dir_line_parameter() {
     assert!(p.root().join("target/debug").join(&exe_name).is_file());
 }
 
-#[test]
+#[cargo_test]
 fn build_multiple_packages() {
     let p = project()
         .file(
@@ -2920,7 +2920,7 @@ fn build_multiple_packages() {
     p.process(d2_path).with_stdout("d2").run();
 }
 
-#[test]
+#[cargo_test]
 fn invalid_spec() {
     let p = project()
         .file(
@@ -2955,7 +2955,7 @@ fn invalid_spec() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn manifest_with_bom_is_ok() {
     let p = project()
         .file(
@@ -2972,7 +2972,7 @@ fn manifest_with_bom_is_ok() {
     p.cargo("build -v").run();
 }
 
-#[test]
+#[cargo_test]
 fn panic_abort_compiles_with_panic_abort() {
     let p = project()
         .file(
@@ -2994,7 +2994,7 @@ fn panic_abort_compiles_with_panic_abort() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn explicit_color_config_is_propagated_to_rustc() {
     let p = project()
         .file("Cargo.toml", &basic_manifest("test", "0.0.0"))
@@ -3017,7 +3017,7 @@ fn explicit_color_config_is_propagated_to_rustc() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn compiler_json_error_format() {
     let p = project()
         .file(
@@ -3254,7 +3254,7 @@ fn compiler_json_error_format() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn wrong_message_format_option() {
     let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
@@ -3272,7 +3272,7 @@ error: 'XML' isn't a valid value for '--message-format <FMT>'
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn message_format_json_forward_stderr() {
     let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
@@ -3324,7 +3324,7 @@ fn message_format_json_forward_stderr() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn no_warn_about_package_metadata() {
     let p = project()
         .file(
@@ -3354,7 +3354,7 @@ fn no_warn_about_package_metadata() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn cargo_build_empty_target() {
     let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
@@ -3368,7 +3368,7 @@ fn cargo_build_empty_target() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn build_all_workspace() {
     let p = project()
         .file(
@@ -3398,7 +3398,7 @@ fn build_all_workspace() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn build_all_exclude() {
     let p = project()
         .file(
@@ -3426,7 +3426,7 @@ fn build_all_exclude() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn build_all_workspace_implicit_examples() {
     let p = project()
         .file(
@@ -3472,7 +3472,7 @@ fn build_all_workspace_implicit_examples() {
     assert!(p.bin("examples/h").is_file());
 }
 
-#[test]
+#[cargo_test]
 fn build_all_virtual_manifest() {
     let p = project()
         .file(
@@ -3500,7 +3500,7 @@ fn build_all_virtual_manifest() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn build_virtual_manifest_all_implied() {
     let p = project()
         .file(
@@ -3528,7 +3528,7 @@ fn build_virtual_manifest_all_implied() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn build_virtual_manifest_one_project() {
     let p = project()
         .file(
@@ -3554,7 +3554,7 @@ fn build_virtual_manifest_one_project() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn build_all_virtual_manifest_implicit_examples() {
     let p = project()
         .file(
@@ -3598,7 +3598,7 @@ fn build_all_virtual_manifest_implicit_examples() {
     assert!(p.bin("examples/h").is_file());
 }
 
-#[test]
+#[cargo_test]
 fn build_all_member_dependency_same_name() {
     let p = project()
         .file(
@@ -3636,7 +3636,7 @@ fn build_all_member_dependency_same_name() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn run_proper_binary() {
     let p = project()
         .file(
@@ -3663,7 +3663,7 @@ fn run_proper_binary() {
     p.cargo("run --bin other").run();
 }
 
-#[test]
+#[cargo_test]
 fn run_proper_binary_main_rs() {
     let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
@@ -3674,7 +3674,7 @@ fn run_proper_binary_main_rs() {
     p.cargo("run --bin foo").run();
 }
 
-#[test]
+#[cargo_test]
 fn run_proper_alias_binary_from_src() {
     let p = project()
         .file(
@@ -3699,7 +3699,7 @@ fn run_proper_alias_binary_from_src() {
     p.process(&p.bin("bar")).with_stdout("bar\n").run();
 }
 
-#[test]
+#[cargo_test]
 fn run_proper_alias_binary_main_rs() {
     let p = project()
         .file(
@@ -3723,7 +3723,7 @@ fn run_proper_alias_binary_main_rs() {
     p.process(&p.bin("bar")).with_stdout("main\n").run();
 }
 
-#[test]
+#[cargo_test]
 fn run_proper_binary_main_rs_as_foo() {
     let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
@@ -3737,7 +3737,7 @@ fn run_proper_binary_main_rs_as_foo() {
     p.cargo("run --bin foo").run();
 }
 
-#[test]
+#[cargo_test]
 // NOTE: we don't have `/usr/bin/env` on Windows.
 #[cfg(not(windows))]
 fn rustc_wrapper() {
@@ -3748,7 +3748,7 @@ fn rustc_wrapper() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 #[cfg(not(windows))]
 fn rustc_wrapper_relative() {
     let p = project().file("src/lib.rs", "").build();
@@ -3759,7 +3759,7 @@ fn rustc_wrapper_relative() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 #[cfg(not(windows))]
 fn rustc_wrapper_from_path() {
     let p = project().file("src/lib.rs", "").build();
@@ -3770,7 +3770,7 @@ fn rustc_wrapper_from_path() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn cdylib_not_lifted() {
     let p = project()
         .file(
@@ -3804,7 +3804,7 @@ fn cdylib_not_lifted() {
     }
 }
 
-#[test]
+#[cargo_test]
 fn cdylib_final_outputs() {
     let p = project()
         .file(
@@ -3838,7 +3838,7 @@ fn cdylib_final_outputs() {
     }
 }
 
-#[test]
+#[cargo_test]
 fn deterministic_cfg_flags() {
     // This bug is non-deterministic.
 
@@ -3890,7 +3890,7 @@ fn deterministic_cfg_flags() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn explicit_bins_without_paths() {
     let p = project()
         .file(
@@ -3916,7 +3916,7 @@ fn explicit_bins_without_paths() {
     p.cargo("build").run();
 }
 
-#[test]
+#[cargo_test]
 fn no_bin_in_src_with_lib() {
     let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
@@ -3936,7 +3936,7 @@ Caused by:
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn inferred_bins() {
     let p = project()
         .file("src/main.rs", "fn main() {}")
@@ -3950,7 +3950,7 @@ fn inferred_bins() {
     assert!(p.bin("baz").is_file());
 }
 
-#[test]
+#[cargo_test]
 fn inferred_bins_duplicate_name() {
     // this should fail, because we have two binaries with the same name
     let p = project()
@@ -3965,7 +3965,7 @@ fn inferred_bins_duplicate_name() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn inferred_bin_path() {
     let p = project()
         .file(
@@ -3988,7 +3988,7 @@ fn inferred_bin_path() {
     assert!(p.bin("bar").is_file());
 }
 
-#[test]
+#[cargo_test]
 fn inferred_examples() {
     let p = project()
         .file("src/lib.rs", "fn main() {}")
@@ -4001,7 +4001,7 @@ fn inferred_examples() {
     assert!(p.bin("examples/baz").is_file());
 }
 
-#[test]
+#[cargo_test]
 fn inferred_tests() {
     let p = project()
         .file("src/lib.rs", "fn main() {}")
@@ -4012,7 +4012,7 @@ fn inferred_tests() {
     p.cargo("test --test=bar --test=baz").run();
 }
 
-#[test]
+#[cargo_test]
 fn inferred_benchmarks() {
     let p = project()
         .file("src/lib.rs", "fn main() {}")
@@ -4023,7 +4023,7 @@ fn inferred_benchmarks() {
     p.cargo("bench --bench=bar --bench=baz").run();
 }
 
-#[test]
+#[cargo_test]
 fn target_edition() {
     let p = project()
         .file(
@@ -4052,7 +4052,7 @@ fn target_edition() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn target_edition_override() {
     let p = project()
         .file(
@@ -4081,7 +4081,7 @@ fn target_edition_override() {
     p.cargo("build -v").run();
 }
 
-#[test]
+#[cargo_test]
 fn same_metadata_different_directory() {
     // A top-level crate built in two different workspaces should have the
     // same metadata hash.
@@ -4109,7 +4109,7 @@ fn same_metadata_different_directory() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn building_a_dependent_crate_witout_bin_should_fail() {
     Package::new("testless", "0.1.0")
         .file(
@@ -4147,7 +4147,7 @@ fn building_a_dependent_crate_witout_bin_should_fail() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 #[cfg(any(target_os = "macos", target_os = "ios"))]
 fn uplift_dsym_of_bin_on_mac() {
     let p = project()
@@ -4166,7 +4166,7 @@ fn uplift_dsym_of_bin_on_mac() {
     assert!(!p.target_debug_dir().join("d.dSYM").exists());
 }
 
-#[test]
+#[cargo_test]
 #[cfg(all(target_os = "windows", target_env = "msvc"))]
 fn uplift_pdb_of_bin_on_windows() {
     let p = project()
@@ -4187,7 +4187,7 @@ fn uplift_pdb_of_bin_on_windows() {
 
 // Ensure that `cargo build` chooses the correct profile for building
 // targets based on filters (assuming `--profile` is not specified).
-#[test]
+#[cargo_test]
 fn build_filter_infer_profile() {
     let p = project()
         .file("src/lib.rs", "")
@@ -4243,7 +4243,7 @@ fn build_filter_infer_profile() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn targets_selected_default() {
     let p = project().file("src/main.rs", "fn main() {}").build();
     p.cargo("build -v")
@@ -4268,7 +4268,7 @@ fn targets_selected_default() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn targets_selected_all() {
     let p = project().file("src/main.rs", "fn main() {}").build();
     p.cargo("build -v --all-targets")
@@ -4287,7 +4287,7 @@ fn targets_selected_all() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn all_targets_no_lib() {
     let p = project().file("src/main.rs", "fn main() {}").build();
     p.cargo("build -v --all-targets")
@@ -4306,7 +4306,7 @@ fn all_targets_no_lib() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn no_linkable_target() {
     // Issue 3169: this is currently not an error as per discussion in PR #4797.
     let p = project()
@@ -4344,7 +4344,7 @@ fn no_linkable_target() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn avoid_dev_deps() {
     Package::new("foo", "1.0.0").publish();
     let p = project()
@@ -4379,7 +4379,7 @@ required by package `bar v0.1.0 ([..]/foo)`
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn invalid_jobs() {
     let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
@@ -4392,7 +4392,7 @@ fn invalid_jobs() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn target_filters_workspace() {
     let ws = project()
         .at("ws")
@@ -4431,7 +4431,7 @@ Did you mean `ex1`?",
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn target_filters_workspace_not_found() {
     let ws = project()
         .at("ws")
@@ -4455,7 +4455,7 @@ fn target_filters_workspace_not_found() {
 }
 
 #[cfg(unix)]
-#[test]
+#[cargo_test]
 fn signal_display() {
     // Cause the compiler to crash with a signal.
     let foo = project()
@@ -4518,7 +4518,7 @@ Caused by:
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn tricky_pipelining() {
     if !crate::support::is_nightly() {
         return;
@@ -4548,7 +4548,7 @@ fn tricky_pipelining() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn pipelining_works() {
     if !crate::support::is_nightly() {
         return;
@@ -4583,7 +4583,7 @@ fn pipelining_works() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn forward_rustc_output() {
     let foo = project()
         .file(

--- a/tests/testsuite/build_auth.rs
+++ b/tests/testsuite/build_auth.rs
@@ -10,7 +10,7 @@ use bufstream::BufStream;
 use git2;
 
 // Tests that HTTP auth is offered from `credential.helper`.
-#[test]
+#[cargo_test]
 fn http_auth_offered() {
     let server = TcpListener::bind("127.0.0.1:0").unwrap();
     let addr = server.local_addr().unwrap();
@@ -153,7 +153,7 @@ Caused by:
 }
 
 // Boy, sure would be nice to have a TLS implementation in rust!
-#[test]
+#[cargo_test]
 fn https_something_happens() {
     let server = TcpListener::bind("127.0.0.1:0").unwrap();
     let addr = server.local_addr().unwrap();
@@ -218,7 +218,7 @@ Caused by:
 }
 
 // It would sure be nice to have an SSH implementation in Rust!
-#[test]
+#[cargo_test]
 fn ssh_something_happens() {
     let server = TcpListener::bind("127.0.0.1:0").unwrap();
     let addr = server.local_addr().unwrap();

--- a/tests/testsuite/build_lib.rs
+++ b/tests/testsuite/build_lib.rs
@@ -1,6 +1,6 @@
 use crate::support::{basic_bin_manifest, basic_manifest, project};
 
-#[test]
+#[cargo_test]
 fn build_lib_only() {
     let p = project()
         .file("src/main.rs", "fn main() {}")
@@ -21,7 +21,7 @@ fn build_lib_only() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn build_with_no_lib() {
     let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
@@ -34,7 +34,7 @@ fn build_with_no_lib() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn build_with_relative_cargo_home_path() {
     let p = project()
         .file(

--- a/tests/testsuite/build_plan.rs
+++ b/tests/testsuite/build_plan.rs
@@ -1,7 +1,7 @@
 use crate::support::registry::Package;
 use crate::support::{basic_bin_manifest, basic_manifest, main_file, project};
 
-#[test]
+#[cargo_test]
 fn cargo_build_plan_simple() {
     let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
@@ -39,7 +39,7 @@ fn cargo_build_plan_simple() {
     assert!(!p.bin("foo").is_file());
 }
 
-#[test]
+#[cargo_test]
 fn cargo_build_plan_single_dep() {
     let p = project()
         .file(
@@ -118,7 +118,7 @@ fn cargo_build_plan_single_dep() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn cargo_build_plan_build_script() {
     let p = project()
         .file(
@@ -196,7 +196,7 @@ fn cargo_build_plan_build_script() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn build_plan_with_dev_dep() {
     Package::new("bar", "0.1.0").publish();
 

--- a/tests/testsuite/build_script.rs
+++ b/tests/testsuite/build_script.rs
@@ -10,7 +10,7 @@ use crate::support::{basic_manifest, cross_compile, project};
 use crate::support::{rustc_host, sleep_ms, slow_cpu_multiplier};
 use cargo::util::paths::remove_dir_all;
 
-#[test]
+#[cargo_test]
 fn custom_build_script_failed() {
     let p = project()
         .file(
@@ -42,7 +42,7 @@ Caused by:
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn custom_build_env_vars() {
     let p = project()
         .file(
@@ -130,7 +130,7 @@ fn custom_build_env_vars() {
     p.cargo("build --features bar_feat").run();
 }
 
-#[test]
+#[cargo_test]
 fn custom_build_env_var_rustc_linker() {
     if cross_compile::disabled() {
         return;
@@ -165,7 +165,7 @@ fn custom_build_env_var_rustc_linker() {
     p.cargo("build --target").arg(&target).run();
 }
 
-#[test]
+#[cargo_test]
 fn custom_build_script_wrong_rustc_flags() {
     let p = project()
         .file(
@@ -197,7 +197,7 @@ fn custom_build_script_wrong_rustc_flags() {
 }
 
 /*
-#[test]
+#[cargo_test]
 fn custom_build_script_rustc_flags() {
     let p = project()
         .file(
@@ -251,7 +251,7 @@ fn custom_build_script_rustc_flags() {
 }
 */
 
-#[test]
+#[cargo_test]
 fn links_no_build_cmd() {
     let p = project()
         .file(
@@ -278,7 +278,7 @@ not have a custom build script
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn links_duplicates() {
     // this tests that the links_duplicates are caught at resolver time
     let p = project()
@@ -326,7 +326,7 @@ failed to select a version for `a-sys` which could resolve this conflict
 ").run();
 }
 
-#[test]
+#[cargo_test]
 fn links_duplicates_deep_dependency() {
     // this tests that the links_duplicates are caught at resolver time
     let p = project()
@@ -390,7 +390,7 @@ failed to select a version for `a-sys` which could resolve this conflict
 ").run();
 }
 
-#[test]
+#[cargo_test]
 fn overrides_and_links() {
     let target = rustc_host();
 
@@ -463,7 +463,7 @@ fn overrides_and_links() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn unused_overrides() {
     let target = rustc_host();
 
@@ -497,7 +497,7 @@ fn unused_overrides() {
     p.cargo("build -v").run();
 }
 
-#[test]
+#[cargo_test]
 fn links_passes_env_vars() {
     let p = project()
         .file(
@@ -554,7 +554,7 @@ fn links_passes_env_vars() {
     p.cargo("build -v").run();
 }
 
-#[test]
+#[cargo_test]
 fn only_rerun_build_script() {
     let p = project()
         .file(
@@ -589,7 +589,7 @@ fn only_rerun_build_script() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn rebuild_continues_to_pass_env_vars() {
     let a = project()
         .at("a")
@@ -658,7 +658,7 @@ fn rebuild_continues_to_pass_env_vars() {
     p.cargo("build -v").run();
 }
 
-#[test]
+#[cargo_test]
 fn testing_and_such() {
     let p = project()
         .file(
@@ -725,7 +725,7 @@ fn testing_and_such() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn propagation_of_l_flags() {
     let target = rustc_host();
     let p = project()
@@ -796,7 +796,7 @@ fn propagation_of_l_flags() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn propagation_of_l_flags_new() {
     let target = rustc_host();
     let p = project()
@@ -871,7 +871,7 @@ fn propagation_of_l_flags_new() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn build_deps_simple() {
     let p = project()
         .file(
@@ -914,7 +914,7 @@ fn build_deps_simple() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn build_deps_not_for_normal() {
     let target = rustc_host();
     let p = project()
@@ -961,7 +961,7 @@ Caused by:
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn build_cmd_with_a_build_cmd() {
     let p = project()
         .file(
@@ -1039,7 +1039,7 @@ fn build_cmd_with_a_build_cmd() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn out_dir_is_preserved() {
     let p = project()
         .file(
@@ -1096,7 +1096,7 @@ fn out_dir_is_preserved() {
     p.cargo("build -v").run();
 }
 
-#[test]
+#[cargo_test]
 fn output_separate_lines() {
     let p = project()
         .file(
@@ -1134,7 +1134,7 @@ fn output_separate_lines() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn output_separate_lines_new() {
     let p = project()
         .file(
@@ -1173,7 +1173,7 @@ fn output_separate_lines_new() {
 }
 
 #[cfg(not(windows))] // FIXME(#867)
-#[test]
+#[cargo_test]
 fn code_generation() {
     let p = project()
         .file(
@@ -1230,7 +1230,7 @@ fn code_generation() {
     p.cargo("test").run();
 }
 
-#[test]
+#[cargo_test]
 fn release_with_build_script() {
     let p = project()
         .file(
@@ -1255,7 +1255,7 @@ fn release_with_build_script() {
     p.cargo("build -v --release").run();
 }
 
-#[test]
+#[cargo_test]
 fn build_script_only() {
     let p = project()
         .file(
@@ -1283,7 +1283,7 @@ Caused by:
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn shared_dep_with_a_build_script() {
     let p = project()
         .file(
@@ -1333,7 +1333,7 @@ fn shared_dep_with_a_build_script() {
     p.cargo("build -v").run();
 }
 
-#[test]
+#[cargo_test]
 fn transitive_dep_host() {
     let p = project()
         .file(
@@ -1385,7 +1385,7 @@ fn transitive_dep_host() {
     p.cargo("build").run();
 }
 
-#[test]
+#[cargo_test]
 fn test_a_lib_with_a_build_command() {
     let p = project()
         .file(
@@ -1431,7 +1431,7 @@ fn test_a_lib_with_a_build_command() {
     p.cargo("test").run();
 }
 
-#[test]
+#[cargo_test]
 fn test_dev_dep_build_script() {
     let p = project()
         .file(
@@ -1464,7 +1464,7 @@ fn test_dev_dep_build_script() {
     p.cargo("test").run();
 }
 
-#[test]
+#[cargo_test]
 fn build_script_with_dynamic_native_dependency() {
     let build = project()
         .at("builder")
@@ -1559,7 +1559,7 @@ fn build_script_with_dynamic_native_dependency() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn profile_and_opt_level_set_correctly() {
     let p = project()
         .file(
@@ -1589,7 +1589,7 @@ fn profile_and_opt_level_set_correctly() {
     p.cargo("bench").run();
 }
 
-#[test]
+#[cargo_test]
 fn profile_debug_0() {
     let p = project()
         .file(
@@ -1620,7 +1620,7 @@ fn profile_debug_0() {
     p.cargo("build").run();
 }
 
-#[test]
+#[cargo_test]
 fn build_script_with_lto() {
     let p = project()
         .file(
@@ -1642,7 +1642,7 @@ fn build_script_with_lto() {
     p.cargo("build").run();
 }
 
-#[test]
+#[cargo_test]
 fn test_duplicate_deps() {
     let p = project()
         .file(
@@ -1682,7 +1682,7 @@ fn test_duplicate_deps() {
     p.cargo("build").run();
 }
 
-#[test]
+#[cargo_test]
 fn cfg_feedback() {
     let p = project()
         .file(
@@ -1704,7 +1704,7 @@ fn cfg_feedback() {
     p.cargo("build -v").run();
 }
 
-#[test]
+#[cargo_test]
 fn cfg_override() {
     let target = rustc_host();
 
@@ -1737,7 +1737,7 @@ fn cfg_override() {
     p.cargo("build -v").run();
 }
 
-#[test]
+#[cargo_test]
 fn cfg_test() {
     let p = project()
         .file(
@@ -1799,7 +1799,7 @@ fn cfg_test() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn cfg_doc() {
     let p = project()
         .file(
@@ -1842,7 +1842,7 @@ fn cfg_doc() {
     assert!(p.root().join("target/doc/bar/fn.bar.html").is_file());
 }
 
-#[test]
+#[cargo_test]
 fn cfg_override_test() {
     let p = project()
         .file(
@@ -1910,7 +1910,7 @@ fn cfg_override_test() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn cfg_override_doc() {
     let p = project()
         .file(
@@ -1961,7 +1961,7 @@ fn cfg_override_doc() {
     assert!(p.root().join("target/doc/bar/fn.bar.html").is_file());
 }
 
-#[test]
+#[cargo_test]
 fn env_build() {
     let p = project()
         .file(
@@ -1992,7 +1992,7 @@ fn env_build() {
     p.cargo("run -v").with_stdout("foo\n").run();
 }
 
-#[test]
+#[cargo_test]
 fn env_test() {
     let p = project()
         .file(
@@ -2045,7 +2045,7 @@ fn env_test() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn env_doc() {
     let p = project()
         .file(
@@ -2073,7 +2073,7 @@ fn env_doc() {
     p.cargo("doc -v").run();
 }
 
-#[test]
+#[cargo_test]
 fn flags_go_into_tests() {
     let p = project()
         .file(
@@ -2154,7 +2154,7 @@ fn flags_go_into_tests() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn diamond_passes_args_only_once() {
     let p = project()
         .file(
@@ -2237,7 +2237,7 @@ fn diamond_passes_args_only_once() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn adding_an_override_invalidates() {
     let target = rustc_host();
     let p = project()
@@ -2301,7 +2301,7 @@ fn adding_an_override_invalidates() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn changing_an_override_invalidates() {
     let target = rustc_host();
     let p = project()
@@ -2365,7 +2365,7 @@ fn changing_an_override_invalidates() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn fresh_builds_possible_with_link_libs() {
     // The bug is non-deterministic. Sometimes you can get a fresh build
     let target = rustc_host();
@@ -2417,7 +2417,7 @@ fn fresh_builds_possible_with_link_libs() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn fresh_builds_possible_with_multiple_metadata_overrides() {
     // The bug is non-deterministic. Sometimes you can get a fresh build
     let target = rustc_host();
@@ -2472,7 +2472,7 @@ fn fresh_builds_possible_with_multiple_metadata_overrides() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn rebuild_only_on_explicit_paths() {
     let p = project()
         .file(
@@ -2583,7 +2583,7 @@ fn rebuild_only_on_explicit_paths() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn doctest_receives_build_link_args() {
     let p = project()
         .file(
@@ -2627,7 +2627,7 @@ fn doctest_receives_build_link_args() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn please_respect_the_dag() {
     let p = project()
         .file(
@@ -2679,7 +2679,7 @@ fn please_respect_the_dag() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn non_utf8_output() {
     let p = project()
         .file(
@@ -2716,7 +2716,7 @@ fn non_utf8_output() {
     p.cargo("build -v").run();
 }
 
-#[test]
+#[cargo_test]
 fn custom_target_dir() {
     let p = project()
         .file(
@@ -2756,7 +2756,7 @@ fn custom_target_dir() {
     p.cargo("build -v").run();
 }
 
-#[test]
+#[cargo_test]
 fn panic_abort_with_build_scripts() {
     let p = project()
         .file(
@@ -2818,7 +2818,7 @@ fn panic_abort_with_build_scripts() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn warnings_emitted() {
     let p = project()
         .file(
@@ -2858,7 +2858,7 @@ warning: bar
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn warnings_hidden_for_upstream() {
     Package::new("bar", "0.1.0")
         .file(
@@ -2917,7 +2917,7 @@ fn warnings_hidden_for_upstream() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn warnings_printed_on_vv() {
     Package::new("bar", "0.1.0")
         .file(
@@ -2978,7 +2978,7 @@ warning: bar
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn output_shows_on_vv() {
     let p = project()
         .file(
@@ -3020,7 +3020,7 @@ fn output_shows_on_vv() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn links_with_dots() {
     let target = rustc_host();
 
@@ -3062,7 +3062,7 @@ fn links_with_dots() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn rustc_and_rustdoc_set_correctly() {
     let p = project()
         .file(
@@ -3091,7 +3091,7 @@ fn rustc_and_rustdoc_set_correctly() {
     p.cargo("bench").run();
 }
 
-#[test]
+#[cargo_test]
 fn cfg_env_vars_available() {
     let p = project()
         .file(
@@ -3124,7 +3124,7 @@ fn cfg_env_vars_available() {
     p.cargo("bench").run();
 }
 
-#[test]
+#[cargo_test]
 fn switch_features_rerun() {
     let p = project()
         .file(
@@ -3181,7 +3181,7 @@ fn switch_features_rerun() {
     p.rename_run("foo", "with_foo2").with_stdout("foo\n").run();
 }
 
-#[test]
+#[cargo_test]
 fn assume_build_script_when_build_rs_present() {
     let p = project()
         .file(
@@ -3207,7 +3207,7 @@ fn assume_build_script_when_build_rs_present() {
     p.cargo("run -v").run();
 }
 
-#[test]
+#[cargo_test]
 fn if_build_set_to_false_dont_treat_build_rs_as_build_script() {
     let p = project()
         .file(
@@ -3243,7 +3243,7 @@ fn if_build_set_to_false_dont_treat_build_rs_as_build_script() {
     p.cargo("run -v").run();
 }
 
-#[test]
+#[cargo_test]
 fn deterministic_rustc_dependency_flags() {
     // This bug is non-deterministic hence the large number of dependencies
     // in the hopes it will have a much higher chance of triggering it.
@@ -3362,7 +3362,7 @@ fn deterministic_rustc_dependency_flags() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn links_duplicates_with_cycle() {
     // this tests that the links_duplicates are caught at resolver time
     let p = project()
@@ -3426,12 +3426,12 @@ failed to select a version for `a` which could resolve this conflict
 ").run();
 }
 
-#[test]
+#[cargo_test]
 fn rename_with_link_search_path() {
     _rename_with_link_search_path(false);
 }
 
-#[test]
+#[cargo_test]
 fn rename_with_link_search_path_cross() {
     if cross_compile::disabled() {
         return;
@@ -3585,7 +3585,7 @@ fn _rename_with_link_search_path(cross: bool) {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn optional_build_script_dep() {
     let p = project()
         .file(
@@ -3637,7 +3637,7 @@ fn optional_build_script_dep() {
     p.cargo("run --features bar").with_stdout("1\n").run();
 }
 
-#[test]
+#[cargo_test]
 fn optional_build_dep_and_required_normal_dep() {
     let p = project()
         .file(
@@ -3698,7 +3698,7 @@ fn optional_build_dep_and_required_normal_dep() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn using_rerun_if_changed_does_not_rebuild() {
     let p = project()
         .file(
@@ -3725,7 +3725,7 @@ fn using_rerun_if_changed_does_not_rebuild() {
     p.cargo("build").with_stderr("[FINISHED] [..]").run();
 }
 
-#[test]
+#[cargo_test]
 fn links_interrupted_can_restart() {
     // Test for a `links` dependent build script getting canceled and then
     // restarted. Steps:
@@ -3808,7 +3808,7 @@ fn links_interrupted_can_restart() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 #[cfg(unix)]
 fn build_script_scan_eacces() {
     // build.rs causes a scan of the whole project, which can be a problem if

--- a/tests/testsuite/build_script_env.rs
+++ b/tests/testsuite/build_script_env.rs
@@ -3,7 +3,7 @@ use std::fs::File;
 use crate::support::project;
 use crate::support::sleep_ms;
 
-#[test]
+#[cargo_test]
 fn rerun_if_env_changes() {
     let p = project()
         .file("src/main.rs", "fn main() {}")
@@ -57,7 +57,7 @@ fn rerun_if_env_changes() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn rerun_if_env_or_file_changes() {
     let p = project()
         .file("src/main.rs", "fn main() {}")

--- a/tests/testsuite/cache_messages.rs
+++ b/tests/testsuite/cache_messages.rs
@@ -5,7 +5,7 @@ fn as_str(bytes: &[u8]) -> &str {
     std::str::from_utf8(bytes).expect("valid utf-8")
 }
 
-#[test]
+#[cargo_test]
 fn simple() {
     if !is_nightly() {
         // --json-rendered is unstable
@@ -54,7 +54,7 @@ fn simple() {
     assert!(cargo_output2.stdout.is_empty());
 }
 
-#[test]
+#[cargo_test]
 fn color() {
     if !is_nightly() {
         // --json-rendered is unstable
@@ -109,7 +109,7 @@ fn color() {
     assert_eq!(rustc_nocolor, as_str(&cargo_output_nocolor.stderr));
 }
 
-#[test]
+#[cargo_test]
 fn cached_as_json() {
     if !is_nightly() {
         // --json-rendered is unstable
@@ -148,7 +148,7 @@ fn cached_as_json() {
     assert_eq!(fix_fresh, orig_cargo_out);
 }
 
-#[test]
+#[cargo_test]
 fn clears_cache_after_fix() {
     if !is_nightly() {
         // --json-rendered is unstable
@@ -195,7 +195,7 @@ fn clears_cache_after_fix() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn rustdoc() {
     if !is_nightly() {
         // --json-rendered is unstable
@@ -239,7 +239,7 @@ fn rustdoc() {
     assert_eq!(as_str(&rustdoc_output.stderr), rustdoc_stderr);
 }
 
-#[test]
+#[cargo_test]
 fn clippy() {
     if !is_nightly() {
         // --json-rendered is unstable
@@ -277,7 +277,7 @@ fn clippy() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn fix() {
     if !is_nightly() {
         // --json-rendered is unstable
@@ -293,7 +293,7 @@ fn fix() {
     assert_eq!(p.read_file("src/lib.rs"), "pub fn r#try() {}");
 }
 
-#[test]
+#[cargo_test]
 fn very_verbose() {
     if !is_nightly() {
         // --json-rendered is unstable
@@ -335,7 +335,7 @@ fn very_verbose() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn short_incompatible() {
     let p = project().file("src/lib.rs", "").build();
     p.cargo("check -Zcache-messages --message-format=short")

--- a/tests/testsuite/cargo_alias_config.rs
+++ b/tests/testsuite/cargo_alias_config.rs
@@ -1,6 +1,6 @@
 use crate::support::{basic_bin_manifest, project};
 
-#[test]
+#[cargo_test]
 fn alias_incorrect_config_type() {
     let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
@@ -24,7 +24,7 @@ expected a list, but found a integer for [..]",
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn alias_config() {
     let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
@@ -47,7 +47,7 @@ fn alias_config() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn recursive_alias() {
     let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
@@ -71,7 +71,7 @@ fn recursive_alias() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn alias_list_test() {
     let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
@@ -91,7 +91,7 @@ fn alias_list_test() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn alias_with_flags_config() {
     let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
@@ -111,7 +111,7 @@ fn alias_with_flags_config() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn alias_cannot_shadow_builtin_command() {
     let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
@@ -136,7 +136,7 @@ fn alias_cannot_shadow_builtin_command() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn alias_override_builtin_alias() {
     let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
@@ -161,7 +161,7 @@ fn alias_override_builtin_alias() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn builtin_alias_takes_options() {
     // #6381
     let p = project()

--- a/tests/testsuite/cargo_command.rs
+++ b/tests/testsuite/cargo_command.rs
@@ -61,7 +61,7 @@ fn path() -> Vec<PathBuf> {
     env::split_paths(&env::var_os("PATH").unwrap_or_default()).collect()
 }
 
-#[test]
+#[cargo_test]
 fn list_commands_with_descriptions() {
     let p = project().build();
     p.cargo("--list")
@@ -76,7 +76,7 @@ fn list_commands_with_descriptions() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn list_command_looks_at_path() {
     let proj = project().build();
     let proj = fake_file(
@@ -103,7 +103,7 @@ fn list_command_looks_at_path() {
 
 // Windows and symlinks don't currently mix well.
 #[cfg(unix)]
-#[test]
+#[cargo_test]
 fn list_command_resolves_symlinks() {
     let proj = project().build();
     let proj = fake_file(
@@ -130,7 +130,7 @@ fn list_command_resolves_symlinks() {
     );
 }
 
-#[test]
+#[cargo_test]
 fn find_closest_biuld_to_build() {
     cargo_process("biuld")
         .with_status(101)
@@ -169,7 +169,7 @@ error: no such subcommand: `biuld`
 }
 
 // If a subcommand is more than an edit distance of 3 away, we don't make a suggestion.
-#[test]
+#[cargo_test]
 fn find_closest_dont_correct_nonsense() {
     cargo_process("there-is-no-way-that-there-is-a-command-close-to-this")
         .cwd(&paths::root())
@@ -182,7 +182,7 @@ fn find_closest_dont_correct_nonsense() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn displays_subcommand_on_error() {
     cargo_process("invalid-command")
         .with_status(101)
@@ -190,7 +190,7 @@ fn displays_subcommand_on_error() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn override_cargo_home() {
     let root = paths::root();
     let my_home = root.join("my_home");
@@ -221,7 +221,7 @@ fn override_cargo_home() {
     assert!(contents.contains(r#"authors = ["foo <bar>"]"#));
 }
 
-#[test]
+#[cargo_test]
 fn cargo_subcommand_env() {
     let src = format!(
         r#"
@@ -256,7 +256,7 @@ fn cargo_subcommand_env() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn cargo_subcommand_args() {
     let p = project()
         .at("cargo-foo")
@@ -288,7 +288,7 @@ fn cargo_subcommand_args() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn cargo_help() {
     cargo_process("").run();
     cargo_process("help").run();
@@ -298,7 +298,7 @@ fn cargo_help() {
     cargo_process("help help").run();
 }
 
-#[test]
+#[cargo_test]
 fn cargo_help_external_subcommand() {
     Package::new("cargo-fake-help", "1.0.0")
         .file(
@@ -317,7 +317,7 @@ fn cargo_help_external_subcommand() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn explain() {
     cargo_process("--explain E0001")
         .with_stdout_contains(
@@ -328,7 +328,7 @@ fn explain() {
 
 // Test that the output of `cargo -Z help` shows a different help screen with
 // all the `-Z` flags.
-#[test]
+#[cargo_test]
 fn z_flags_help() {
     cargo_process("-Z help")
         .with_stdout_contains(

--- a/tests/testsuite/cargo_features.rs
+++ b/tests/testsuite/cargo_features.rs
@@ -1,6 +1,6 @@
 use crate::support::{project, registry};
 
-#[test]
+#[cargo_test]
 fn feature_required() {
     let p = project()
         .file(
@@ -53,7 +53,7 @@ switch to nightly channel you can add
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn unknown_feature() {
     let p = project()
         .file(
@@ -82,7 +82,7 @@ Caused by:
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn stable_feature_warns() {
     let p = project()
         .file(
@@ -110,7 +110,7 @@ necessary to be listed in the manifest
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn nightly_feature_requires_nightly() {
     let p = project()
         .file(
@@ -152,7 +152,7 @@ See [..]
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn nightly_feature_requires_nightly_in_dep() {
     let p = project()
         .file(
@@ -214,7 +214,7 @@ See [..]
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn cant_publish() {
     let p = project()
         .file(
@@ -256,7 +256,7 @@ See [..]
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn z_flags_rejected() {
     let p = project()
         .file(
@@ -300,7 +300,7 @@ fn z_flags_rejected() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn publish_allowed() {
     registry::init();
 

--- a/tests/testsuite/cfg.rs
+++ b/tests/testsuite/cfg.rs
@@ -54,7 +54,7 @@ where
     );
 }
 
-#[test]
+#[cargo_test]
 fn cfg_syntax() {
     good("foo", c!(foo));
     good("_bar", c!(_bar));
@@ -66,7 +66,7 @@ fn cfg_syntax() {
     good("foo = \"3 e\"", c!(foo = "3 e"));
 }
 
-#[test]
+#[cargo_test]
 fn cfg_syntax_bad() {
     bad::<Cfg>("", "found nothing");
     bad::<Cfg>(" ", "found nothing");
@@ -81,7 +81,7 @@ fn cfg_syntax_bad() {
     bad::<Cfg>("foo, bar", "malformed cfg value");
 }
 
-#[test]
+#[cargo_test]
 fn cfg_expr() {
     good("foo", e!(foo));
     good("_bar", e!(_bar));
@@ -100,7 +100,7 @@ fn cfg_expr() {
     good("not(all(a))", e!(not(all(a))));
 }
 
-#[test]
+#[cargo_test]
 fn cfg_expr_bad() {
     bad::<CfgExpr>(" ", "found nothing");
     bad::<CfgExpr>(" all", "expected `(`");
@@ -112,7 +112,7 @@ fn cfg_expr_bad() {
     bad::<CfgExpr>("foo(a)", "consider using all() or any() explicitly");
 }
 
-#[test]
+#[cargo_test]
 fn cfg_matches() {
     assert!(e!(foo).matches(&[c!(bar), c!(foo), c!(baz)]));
     assert!(e!(any(foo)).matches(&[c!(bar), c!(foo), c!(baz)]));
@@ -140,7 +140,7 @@ fn cfg_matches() {
     assert!(!e!(any((not(foo)), (all(foo, bar)))).matches(&[c!(foo)]));
 }
 
-#[test]
+#[cargo_test]
 fn cfg_easy() {
     let p = project()
         .file(
@@ -164,7 +164,7 @@ fn cfg_easy() {
     p.cargo("build -v").run();
 }
 
-#[test]
+#[cargo_test]
 fn dont_include() {
     let other_family = if cfg!(unix) { "windows" } else { "unix" };
     let p = project()
@@ -197,7 +197,7 @@ fn dont_include() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn works_through_the_registry() {
     Package::new("baz", "0.1.0").publish();
     Package::new("bar", "0.1.0")
@@ -240,7 +240,7 @@ fn works_through_the_registry() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn ignore_version_from_other_platform() {
     let this_family = if cfg!(unix) { "unix" } else { "windows" };
     let other_family = if cfg!(unix) { "windows" } else { "unix" };
@@ -286,7 +286,7 @@ fn ignore_version_from_other_platform() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn bad_target_spec() {
     let p = project()
         .file(
@@ -320,7 +320,7 @@ Caused by:
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn bad_target_spec2() {
     let p = project()
         .file(
@@ -354,7 +354,7 @@ Caused by:
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn multiple_match_ok() {
     let p = project()
         .file(
@@ -390,7 +390,7 @@ fn multiple_match_ok() {
     p.cargo("build -v").run();
 }
 
-#[test]
+#[cargo_test]
 fn any_ok() {
     let p = project()
         .file(
@@ -413,7 +413,7 @@ fn any_ok() {
 }
 
 // https://github.com/rust-lang/cargo/issues/5313
-#[test]
+#[cargo_test]
 #[cfg(all(target_arch = "x86_64", target_os = "linux", target_env = "gnu"))]
 fn cfg_looks_at_rustflags_for_target() {
     let p = project()

--- a/tests/testsuite/check.rs
+++ b/tests/testsuite/check.rs
@@ -5,7 +5,7 @@ use crate::support::paths::CargoPathExt;
 use crate::support::registry::Package;
 use crate::support::{basic_manifest, project};
 
-#[test]
+#[cargo_test]
 fn check_success() {
     let foo = project()
         .file(
@@ -34,7 +34,7 @@ fn check_success() {
     foo.cargo("check").run();
 }
 
-#[test]
+#[cargo_test]
 fn check_fail() {
     let foo = project()
         .file(
@@ -66,7 +66,7 @@ fn check_fail() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn custom_derive() {
     let foo = project()
         .file(
@@ -132,7 +132,7 @@ pub fn derive(_input: TokenStream) -> TokenStream {
     foo.cargo("check").run();
 }
 
-#[test]
+#[cargo_test]
 fn check_build() {
     let foo = project()
         .file(
@@ -163,7 +163,7 @@ fn check_build() {
     foo.cargo("build").run();
 }
 
-#[test]
+#[cargo_test]
 fn build_check() {
     let foo = project()
         .file(
@@ -196,7 +196,7 @@ fn build_check() {
 
 // Checks that where a project has both a lib and a bin, the lib is only checked
 // not built.
-#[test]
+#[cargo_test]
 fn issue_3418() {
     let foo = project()
         .file("src/lib.rs", "")
@@ -210,7 +210,7 @@ fn issue_3418() {
 
 // Some weirdness that seems to be caused by a crate being built as well as
 // checked, but in this case with a proc macro too.
-#[test]
+#[cargo_test]
 fn issue_3419() {
     let p = project()
         .file(
@@ -271,7 +271,7 @@ fn issue_3419() {
 }
 
 // Check on a dylib should have a different metadata hash than build.
-#[test]
+#[cargo_test]
 fn dylib_check_preserves_build_cache() {
     let p = project()
         .file(
@@ -308,7 +308,7 @@ fn dylib_check_preserves_build_cache() {
 }
 
 // test `cargo rustc --profile check`
-#[test]
+#[cargo_test]
 fn rustc_check() {
     let foo = project()
         .file(
@@ -337,7 +337,7 @@ fn rustc_check() {
     foo.cargo("rustc --profile check -- --emit=metadata").run();
 }
 
-#[test]
+#[cargo_test]
 fn rustc_check_err() {
     let foo = project()
         .file(
@@ -371,7 +371,7 @@ fn rustc_check_err() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn check_all() {
     let p = project()
         .file(
@@ -404,7 +404,7 @@ fn check_all() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn check_virtual_all_implied() {
     let p = project()
         .file(
@@ -426,7 +426,7 @@ fn check_virtual_all_implied() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn exclude_warns_on_non_existing_package() {
     let p = project().file("src/lib.rs", "").build();
     p.cargo("check --all --exclude bar")
@@ -440,7 +440,7 @@ fn exclude_warns_on_non_existing_package() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn targets_selected_default() {
     let foo = project()
         .file("src/main.rs", "fn main() {}")
@@ -459,7 +459,7 @@ fn targets_selected_default() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn targets_selected_all() {
     let foo = project()
         .file("src/main.rs", "fn main() {}")
@@ -478,7 +478,7 @@ fn targets_selected_all() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn check_unit_test_profile() {
     let foo = project()
         .file(
@@ -503,7 +503,7 @@ fn check_unit_test_profile() {
 }
 
 // Verify what is checked with various command-line filters.
-#[test]
+#[cargo_test]
 fn check_filters() {
     let p = project()
         .file(
@@ -611,7 +611,7 @@ fn check_filters() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn check_artifacts() {
     // Verify which artifacts are created when running check (#4059).
     let p = project()
@@ -673,7 +673,7 @@ fn check_artifacts() {
     assert_eq!(p.glob("target/debug/deps/libb1-*.rmeta").count(), 1);
 }
 
-#[test]
+#[cargo_test]
 fn short_message_format() {
     let foo = project()
         .file("src/lib.rs", "fn foo() { let _x: bool = 'a'; }")
@@ -690,7 +690,7 @@ error: Could not compile `foo`.
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn proc_macro() {
     let p = project()
         .file(
@@ -733,13 +733,13 @@ fn proc_macro() {
     p.cargo("check -v").env("CARGO_LOG", "cargo=trace").run();
 }
 
-#[test]
+#[cargo_test]
 fn does_not_use_empty_rustc_wrapper() {
     let p = project().file("src/lib.rs", "").build();
     p.cargo("check").env("RUSTC_WRAPPER", "").run();
 }
 
-#[test]
+#[cargo_test]
 fn error_from_deep_recursion() -> Result<(), fmt::Error> {
     let mut big_macro = String::new();
     writeln!(big_macro, "macro_rules! m {{")?;

--- a/tests/testsuite/clean.rs
+++ b/tests/testsuite/clean.rs
@@ -3,7 +3,7 @@ use std::env;
 use crate::support::registry::Package;
 use crate::support::{basic_bin_manifest, basic_manifest, git, main_file, project};
 
-#[test]
+#[cargo_test]
 fn cargo_clean_simple() {
     let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
@@ -17,7 +17,7 @@ fn cargo_clean_simple() {
     assert!(!p.build_dir().is_dir());
 }
 
-#[test]
+#[cargo_test]
 fn different_dir() {
     let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
@@ -32,7 +32,7 @@ fn different_dir() {
     assert!(!p.build_dir().is_dir());
 }
 
-#[test]
+#[cargo_test]
 fn clean_multiple_packages() {
     let p = project()
         .file(
@@ -83,7 +83,7 @@ fn clean_multiple_packages() {
     assert!(!d2_path.is_file());
 }
 
-#[test]
+#[cargo_test]
 fn clean_release() {
     let p = project()
         .file(
@@ -126,7 +126,7 @@ fn clean_release() {
     assert!(!p.build_dir().join("release").is_dir());
 }
 
-#[test]
+#[cargo_test]
 fn clean_doc() {
     let p = project()
         .file(
@@ -158,7 +158,7 @@ fn clean_doc() {
     assert!(p.build_dir().is_dir());
 }
 
-#[test]
+#[cargo_test]
 fn build_script() {
     let p = project()
         .file(
@@ -206,7 +206,7 @@ fn build_script() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn clean_git() {
     let git = git::new("dep", |project| {
         project
@@ -239,7 +239,7 @@ fn clean_git() {
     p.cargo("build").run();
 }
 
-#[test]
+#[cargo_test]
 fn registry() {
     let p = project()
         .file(
@@ -264,7 +264,7 @@ fn registry() {
     p.cargo("build").run();
 }
 
-#[test]
+#[cargo_test]
 fn clean_verbose() {
     let p = project()
         .file(
@@ -296,7 +296,7 @@ fn clean_verbose() {
     p.cargo("build").run();
 }
 
-#[test]
+#[cargo_test]
 fn clean_remove_rlib_rmeta() {
     let p = project()
         .file(

--- a/tests/testsuite/collisions.rs
+++ b/tests/testsuite/collisions.rs
@@ -1,7 +1,7 @@
 use crate::support::{basic_manifest, project};
 use std::env;
 
-#[test]
+#[cargo_test]
 fn collision_dylib() {
     // Path dependencies don't include metadata hash in filename for dylibs.
     let p = project()
@@ -53,7 +53,7 @@ This may become a hard error in the future; see <https://github.com/rust-lang/ca
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn collision_example() {
     // Examples in a workspace can easily collide.
     let p = project()
@@ -82,7 +82,7 @@ This may become a hard error in the future; see <https://github.com/rust-lang/ca
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn collision_export() {
     // `--out-dir` combines some things which can cause conflicts.
     let p = project()
@@ -104,7 +104,7 @@ This may become a hard error in the future; see <https://github.com/rust-lang/ca
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn collision_doc() {
     let p = project()
         .file(

--- a/tests/testsuite/concurrent.rs
+++ b/tests/testsuite/concurrent.rs
@@ -19,7 +19,7 @@ fn pkg(name: &str, vers: &str) {
         .publish();
 }
 
-#[test]
+#[cargo_test]
 fn multiple_installs() {
     let p = project()
         .no_manifest()
@@ -48,7 +48,7 @@ fn multiple_installs() {
     assert_has_installed_exe(cargo_home(), "bar");
 }
 
-#[test]
+#[cargo_test]
 fn concurrent_installs() {
     const LOCKED_BUILD: &str = "waiting for file lock on build directory";
 
@@ -77,7 +77,7 @@ fn concurrent_installs() {
     assert_has_installed_exe(cargo_home(), "bar");
 }
 
-#[test]
+#[cargo_test]
 fn one_install_should_be_bad() {
     let p = project()
         .no_manifest()
@@ -117,7 +117,7 @@ fn one_install_should_be_bad() {
     assert_has_installed_exe(cargo_home(), "foo");
 }
 
-#[test]
+#[cargo_test]
 fn multiple_registry_fetches() {
     let mut pkg = Package::new("bar", "1.0.2");
     for i in 0..10 {
@@ -185,7 +185,7 @@ fn multiple_registry_fetches() {
         .is_file());
 }
 
-#[test]
+#[cargo_test]
 fn git_same_repo_different_tags() {
     let a = git::new("dep", |project| {
         project
@@ -263,7 +263,7 @@ fn git_same_repo_different_tags() {
     execs().run_output(&b);
 }
 
-#[test]
+#[cargo_test]
 fn git_same_branch_different_revs() {
     let a = git::new("dep", |project| {
         project
@@ -346,7 +346,7 @@ fn git_same_branch_different_revs() {
     execs().run_output(&b);
 }
 
-#[test]
+#[cargo_test]
 fn same_project() {
     let p = project()
         .file("src/main.rs", "fn main() {}")
@@ -372,7 +372,7 @@ fn same_project() {
 // Make sure that if Cargo dies while holding a lock that it's released and the
 // next Cargo to come in will take over cleanly.
 // older win versions don't support job objects, so skip test there
-#[test]
+#[cargo_test]
 #[cfg_attr(target_os = "windows", ignore)]
 fn killing_cargo_releases_the_lock() {
     let p = project()
@@ -434,7 +434,7 @@ fn killing_cargo_releases_the_lock() {
     execs().run_output(&b);
 }
 
-#[test]
+#[cargo_test]
 fn debug_release_ok() {
     let p = project().file("src/main.rs", "fn main() {}");
     let p = p.build();
@@ -470,7 +470,7 @@ fn debug_release_ok() {
         .run_output(&b);
 }
 
-#[test]
+#[cargo_test]
 fn no_deadlock_with_git_dependencies() {
     let dep1 = git::new("dep1", |project| {
         project

--- a/tests/testsuite/config.rs
+++ b/tests/testsuite/config.rs
@@ -8,7 +8,7 @@ use cargo::util::config::{self, Config};
 use cargo::util::toml::{self, VecStringOrBool as VSOB};
 use serde::Deserialize;
 
-#[test]
+#[cargo_test]
 fn read_env_vars_for_config() {
     let p = project()
         .file(
@@ -84,7 +84,7 @@ fn assert_error<E: Borrow<failure::Error>>(error: E, msgs: &str) {
     }
 }
 
-#[test]
+#[cargo_test]
 fn get_config() {
     write_config(
         "\
@@ -106,7 +106,7 @@ f1 = 123
     assert_eq!(s, S { f1: Some(456) });
 }
 
-#[test]
+#[cargo_test]
 fn config_unused_fields() {
     write_config(
         "\
@@ -144,7 +144,7 @@ warning: unused key `S.unused` in config file `[..]/.cargo/config`
     }
 }
 
-#[test]
+#[cargo_test]
 fn config_load_toml_profile() {
     write_config(
         "\
@@ -238,7 +238,7 @@ codegen-units = 9
     );
 }
 
-#[test]
+#[cargo_test]
 fn config_deserialize_any() {
     // Some tests to exercise deserialize_any for deserializers that need to
     // be told the format.
@@ -283,7 +283,7 @@ c = ['c']
     }
 }
 
-#[test]
+#[cargo_test]
 fn config_toml_errors() {
     write_config(
         "\
@@ -311,7 +311,7 @@ opt-level = 'foo'
     );
 }
 
-#[test]
+#[cargo_test]
 fn load_nested() {
     write_config(
         "\
@@ -347,7 +347,7 @@ asdf = 3
     assert_eq!(n, expected);
 }
 
-#[test]
+#[cargo_test]
 fn get_errors() {
     write_config(
         "\
@@ -402,7 +402,7 @@ big = 123456789
     );
 }
 
-#[test]
+#[cargo_test]
 fn config_get_option() {
     write_config(
         "\
@@ -420,7 +420,7 @@ f1 = 1
     assert_eq!(config.get::<Option<i32>>("bar.zzzz").unwrap(), None);
 }
 
-#[test]
+#[cargo_test]
 fn config_bad_toml() {
     write_config("asdf");
     let config = new_config(&[]);
@@ -437,7 +437,7 @@ Caused by:
     );
 }
 
-#[test]
+#[cargo_test]
 fn config_get_list() {
     write_config(
         "\
@@ -562,7 +562,7 @@ expected a list, but found a integer for `l3` in [..]/.cargo/config",
     );
 }
 
-#[test]
+#[cargo_test]
 fn config_get_other_types() {
     write_config(
         "\
@@ -584,7 +584,7 @@ ns2 = 456
     );
 }
 
-#[test]
+#[cargo_test]
 fn config_relative_path() {
     write_config(&format!(
         "\
@@ -635,7 +635,7 @@ abs = '{}'
     );
 }
 
-#[test]
+#[cargo_test]
 fn config_get_integers() {
     write_config(
         "\

--- a/tests/testsuite/corrupt_git.rs
+++ b/tests/testsuite/corrupt_git.rs
@@ -5,7 +5,7 @@ use crate::support::paths;
 use crate::support::{basic_manifest, git, project};
 use cargo::util::paths as cargopaths;
 
-#[test]
+#[cargo_test]
 fn deleting_database_files() {
     let project = project();
     let git_project = git::new("bar", |project| {
@@ -64,7 +64,7 @@ fn deleting_database_files() {
     }
 }
 
-#[test]
+#[cargo_test]
 fn deleting_checkout_files() {
     let project = project();
     let git_project = git::new("bar", |project| {

--- a/tests/testsuite/cross_compile.rs
+++ b/tests/testsuite/cross_compile.rs
@@ -1,7 +1,7 @@
 use crate::support::{basic_bin_manifest, basic_manifest, cross_compile, project};
 use crate::support::{is_nightly, rustc_host};
 
-#[test]
+#[cargo_test]
 fn simple_cross() {
     if cross_compile::disabled() {
         return;
@@ -50,7 +50,7 @@ fn simple_cross() {
     p.process(&p.target_bin(&target, "foo")).run();
 }
 
-#[test]
+#[cargo_test]
 fn simple_cross_config() {
     if cross_compile::disabled() {
         return;
@@ -109,7 +109,7 @@ fn simple_cross_config() {
     p.process(&p.target_bin(&target, "foo")).run();
 }
 
-#[test]
+#[cargo_test]
 fn simple_deps() {
     if cross_compile::disabled() {
         return;
@@ -143,7 +143,7 @@ fn simple_deps() {
     p.process(&p.target_bin(&target, "foo")).run();
 }
 
-#[test]
+#[cargo_test]
 fn plugin_deps() {
     if cross_compile::disabled() {
         return;
@@ -236,7 +236,7 @@ fn plugin_deps() {
     foo.process(&foo.target_bin(&target, "foo")).run();
 }
 
-#[test]
+#[cargo_test]
 fn plugin_to_the_max() {
     if cross_compile::disabled() {
         return;
@@ -338,7 +338,7 @@ fn plugin_to_the_max() {
     foo.process(&foo.target_bin(&target, "foo")).run();
 }
 
-#[test]
+#[cargo_test]
 fn linker_and_ar() {
     if cross_compile::disabled() {
         return;
@@ -392,7 +392,7 @@ fn linker_and_ar() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn plugin_with_extra_dylib_dep() {
     if cross_compile::disabled() {
         return;
@@ -482,7 +482,7 @@ fn plugin_with_extra_dylib_dep() {
     foo.cargo("build --target").arg(&target).run();
 }
 
-#[test]
+#[cargo_test]
 fn cross_tests() {
     if cross_compile::disabled() {
         return;
@@ -545,7 +545,7 @@ fn cross_tests() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn no_cross_doctests() {
     if cross_compile::disabled() {
         return;
@@ -603,7 +603,7 @@ fn no_cross_doctests() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn simple_cargo_run() {
     if cross_compile::disabled() {
         return;
@@ -628,7 +628,7 @@ fn simple_cargo_run() {
     p.cargo("run --target").arg(&target).run();
 }
 
-#[test]
+#[cargo_test]
 fn cross_with_a_build_script() {
     if cross_compile::disabled() {
         return;
@@ -690,7 +690,7 @@ fn cross_with_a_build_script() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn build_script_needed_for_host_and_target() {
     if cross_compile::disabled() {
         return;
@@ -801,7 +801,7 @@ fn build_script_needed_for_host_and_target() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn build_deps_for_the_right_arch() {
     if cross_compile::disabled() {
         return;
@@ -844,7 +844,7 @@ fn build_deps_for_the_right_arch() {
     p.cargo("build -v --target").arg(&target).run();
 }
 
-#[test]
+#[cargo_test]
 fn build_script_only_host() {
     if cross_compile::disabled() {
         return;
@@ -895,7 +895,7 @@ fn build_script_only_host() {
     p.cargo("build -v --target").arg(&target).run();
 }
 
-#[test]
+#[cargo_test]
 fn plugin_build_script_right_arch() {
     if cross_compile::disabled() {
         return;
@@ -933,7 +933,7 @@ fn plugin_build_script_right_arch() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn build_script_with_platform_specific_dependencies() {
     if cross_compile::disabled() {
         return;
@@ -1006,7 +1006,7 @@ fn build_script_with_platform_specific_dependencies() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn platform_specific_dependencies_do_not_leak() {
     if cross_compile::disabled() {
         return;
@@ -1060,7 +1060,7 @@ fn platform_specific_dependencies_do_not_leak() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn platform_specific_variables_reflected_in_build_scripts() {
     if cross_compile::disabled() {
         return;
@@ -1146,7 +1146,7 @@ fn platform_specific_variables_reflected_in_build_scripts() {
     p.cargo("build -v --target").arg(&target).run();
 }
 
-#[test]
+#[cargo_test]
 fn cross_test_dylib() {
     if cross_compile::disabled() {
         return;

--- a/tests/testsuite/cross_publish.rs
+++ b/tests/testsuite/cross_publish.rs
@@ -2,7 +2,7 @@ use std::fs::File;
 
 use crate::support::{cross_compile, project, publish, registry};
 
-#[test]
+#[cargo_test]
 fn simple_cross_package() {
     if cross_compile::disabled() {
         return;
@@ -58,7 +58,7 @@ fn simple_cross_package() {
     );
 }
 
-#[test]
+#[cargo_test]
 fn publish_with_target() {
     if cross_compile::disabled() {
         return;

--- a/tests/testsuite/custom_target.rs
+++ b/tests/testsuite/custom_target.rs
@@ -1,7 +1,7 @@
 use crate::support::is_nightly;
 use crate::support::{basic_manifest, project};
 
-#[test]
+#[cargo_test]
 fn custom_target_minimal() {
     if !is_nightly() {
         // Requires features no_core, lang_items
@@ -51,7 +51,7 @@ fn custom_target_minimal() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn custom_target_dependency() {
     if !is_nightly() {
         // Requires features no_core, lang_items, optin_builtin_traits

--- a/tests/testsuite/death.rs
+++ b/tests/testsuite/death.rs
@@ -46,7 +46,7 @@ fn enabled() -> bool {
     }
 }
 
-#[test]
+#[cargo_test]
 fn ctrl_c_kills_everyone() {
     if !enabled() {
         return;

--- a/tests/testsuite/dep_info.rs
+++ b/tests/testsuite/dep_info.rs
@@ -1,7 +1,7 @@
 use crate::support::{basic_bin_manifest, main_file, project};
 use filetime::FileTime;
 
-#[test]
+#[cargo_test]
 fn build_dep_info() {
     let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
@@ -15,7 +15,7 @@ fn build_dep_info() {
     assert!(depinfo_bin_path.is_file());
 }
 
-#[test]
+#[cargo_test]
 fn build_dep_info_lib() {
     let p = project()
         .file(
@@ -40,7 +40,7 @@ fn build_dep_info_lib() {
     assert!(p.example_lib("ex", "lib").with_extension("d").is_file());
 }
 
-#[test]
+#[cargo_test]
 fn build_dep_info_rlib() {
     let p = project()
         .file(
@@ -64,7 +64,7 @@ fn build_dep_info_rlib() {
     assert!(p.example_lib("ex", "rlib").with_extension("d").is_file());
 }
 
-#[test]
+#[cargo_test]
 fn build_dep_info_dylib() {
     let p = project()
         .file(
@@ -88,7 +88,7 @@ fn build_dep_info_dylib() {
     assert!(p.example_lib("ex", "dylib").with_extension("d").is_file());
 }
 
-#[test]
+#[cargo_test]
 fn no_rewrite_if_no_change() {
     let p = project().file("src/lib.rs", "").build();
 

--- a/tests/testsuite/directory.rs
+++ b/tests/testsuite/directory.rs
@@ -73,7 +73,7 @@ impl VendorPackage {
     }
 }
 
-#[test]
+#[cargo_test]
 fn simple() {
     setup();
 
@@ -112,7 +112,7 @@ fn simple() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn simple_install() {
     setup();
 
@@ -154,7 +154,7 @@ fn simple_install() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn simple_install_fail() {
     setup();
 
@@ -198,7 +198,7 @@ required by package `bar v0.1.0`
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn install_without_feature_dep() {
     setup();
 
@@ -244,7 +244,7 @@ fn install_without_feature_dep() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn not_there() {
     setup();
 
@@ -281,7 +281,7 @@ required by package `foo v0.1.0 ([..])`
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn multiple() {
     setup();
 
@@ -327,7 +327,7 @@ fn multiple() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn crates_io_then_directory() {
     let p = project()
         .file(
@@ -384,7 +384,7 @@ fn crates_io_then_directory() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn crates_io_then_bad_checksum() {
     let p = project()
         .file(
@@ -431,7 +431,7 @@ unable to verify that `bar v0.1.0` is the same as when the lockfile was generate
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn bad_file_checksum() {
     setup();
 
@@ -475,7 +475,7 @@ the source
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn only_dot_files_ok() {
     setup();
 
@@ -507,7 +507,7 @@ fn only_dot_files_ok() {
     p.cargo("build").run();
 }
 
-#[test]
+#[cargo_test]
 fn random_files_ok() {
     setup();
 
@@ -540,7 +540,7 @@ fn random_files_ok() {
     p.cargo("build").run();
 }
 
-#[test]
+#[cargo_test]
 fn git_lock_file_doesnt_change() {
     let git = git::new("git", |p| {
         p.file("Cargo.toml", &basic_manifest("git", "0.5.0"))
@@ -610,7 +610,7 @@ fn git_lock_file_doesnt_change() {
     assert_eq!(lock1, lock2, "lock files changed");
 }
 
-#[test]
+#[cargo_test]
 fn git_override_requires_lockfile() {
     VendorPackage::new("git")
         .file("Cargo.toml", &basic_manifest("git", "0.5.0"))
@@ -668,7 +668,7 @@ restore the source replacement configuration to continue the build
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn workspace_different_locations() {
     let p = project()
         .no_manifest()
@@ -726,7 +726,7 @@ fn workspace_different_locations() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn version_missing() {
     setup();
 

--- a/tests/testsuite/doc.rs
+++ b/tests/testsuite/doc.rs
@@ -7,7 +7,7 @@ use crate::support::registry::Package;
 use crate::support::{basic_lib_manifest, basic_manifest, git, project};
 use crate::support::{is_nightly, rustc_host};
 
-#[test]
+#[cargo_test]
 fn simple() {
     let p = project()
         .file(
@@ -37,7 +37,7 @@ fn simple() {
     assert!(p.root().join("target/doc/foo/index.html").is_file());
 }
 
-#[test]
+#[cargo_test]
 fn doc_no_libs() {
     let p = project()
         .file(
@@ -59,7 +59,7 @@ fn doc_no_libs() {
     p.cargo("doc").run();
 }
 
-#[test]
+#[cargo_test]
 fn doc_twice() {
     let p = project().file("src/lib.rs", "pub fn foo() {}").build();
 
@@ -75,7 +75,7 @@ fn doc_twice() {
     p.cargo("doc").with_stdout("").run();
 }
 
-#[test]
+#[cargo_test]
 fn doc_deps() {
     let p = project()
         .file(
@@ -124,7 +124,7 @@ fn doc_deps() {
     assert!(p.root().join("target/doc/bar/index.html").is_file());
 }
 
-#[test]
+#[cargo_test]
 fn doc_no_deps() {
     let p = project()
         .file(
@@ -159,7 +159,7 @@ fn doc_no_deps() {
     assert!(!p.root().join("target/doc/bar/index.html").is_file());
 }
 
-#[test]
+#[cargo_test]
 fn doc_only_bin() {
     let p = project()
         .file(
@@ -186,7 +186,7 @@ fn doc_only_bin() {
     assert!(p.root().join("target/doc/foo/index.html").is_file());
 }
 
-#[test]
+#[cargo_test]
 fn doc_multiple_targets_same_name_lib() {
     let p = project()
         .file(
@@ -228,7 +228,7 @@ fn doc_multiple_targets_same_name_lib() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn doc_multiple_targets_same_name() {
     let p = project()
         .file(
@@ -273,7 +273,7 @@ fn doc_multiple_targets_same_name() {
     assert!(doc_file.is_file());
 }
 
-#[test]
+#[cargo_test]
 fn doc_multiple_targets_same_name_bin() {
     let p = project()
         .file(
@@ -315,7 +315,7 @@ fn doc_multiple_targets_same_name_bin() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn doc_multiple_targets_same_name_undoced() {
     let p = project()
         .file(
@@ -353,7 +353,7 @@ fn doc_multiple_targets_same_name_undoced() {
     p.cargo("doc --all").run();
 }
 
-#[test]
+#[cargo_test]
 fn doc_lib_bin_same_name_documents_lib() {
     let p = project()
         .file(
@@ -395,7 +395,7 @@ fn doc_lib_bin_same_name_documents_lib() {
     assert!(!doc_html.contains("Binary"));
 }
 
-#[test]
+#[cargo_test]
 fn doc_lib_bin_same_name_documents_lib_when_requested() {
     let p = project()
         .file(
@@ -437,7 +437,7 @@ fn doc_lib_bin_same_name_documents_lib_when_requested() {
     assert!(!doc_html.contains("Binary"));
 }
 
-#[test]
+#[cargo_test]
 fn doc_lib_bin_same_name_documents_named_bin_when_requested() {
     let p = project()
         .file(
@@ -480,7 +480,7 @@ fn doc_lib_bin_same_name_documents_named_bin_when_requested() {
     assert!(doc_html.contains("Binary"));
 }
 
-#[test]
+#[cargo_test]
 fn doc_lib_bin_same_name_documents_bins_when_requested() {
     let p = project()
         .file(
@@ -523,7 +523,7 @@ fn doc_lib_bin_same_name_documents_bins_when_requested() {
     assert!(doc_html.contains("Binary"));
 }
 
-#[test]
+#[cargo_test]
 fn doc_dash_p() {
     let p = project()
         .file(
@@ -568,7 +568,7 @@ fn doc_dash_p() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn doc_same_name() {
     let p = project()
         .file("src/lib.rs", "")
@@ -580,7 +580,7 @@ fn doc_same_name() {
     p.cargo("doc").run();
 }
 
-#[test]
+#[cargo_test]
 fn doc_target() {
     const TARGET: &str = "arm-unknown-linux-gnueabihf";
 
@@ -609,7 +609,7 @@ fn doc_target() {
         .is_file());
 }
 
-#[test]
+#[cargo_test]
 fn target_specific_not_documented() {
     let p = project()
         .file(
@@ -632,7 +632,7 @@ fn target_specific_not_documented() {
     p.cargo("doc").run();
 }
 
-#[test]
+#[cargo_test]
 fn output_not_captured() {
     let p = project()
         .file(
@@ -667,7 +667,7 @@ fn output_not_captured() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn target_specific_documented() {
     let p = project()
         .file(
@@ -709,7 +709,7 @@ fn target_specific_documented() {
     p.cargo("doc").run();
 }
 
-#[test]
+#[cargo_test]
 fn no_document_build_deps() {
     let p = project()
         .file(
@@ -740,7 +740,7 @@ fn no_document_build_deps() {
     p.cargo("doc").run();
 }
 
-#[test]
+#[cargo_test]
 fn doc_release() {
     let p = project().file("src/lib.rs", "").build();
 
@@ -756,7 +756,7 @@ fn doc_release() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn doc_multiple_deps() {
     let p = project()
         .file(
@@ -788,7 +788,7 @@ fn doc_multiple_deps() {
     assert!(p.root().join("target/doc/baz/index.html").is_file());
 }
 
-#[test]
+#[cargo_test]
 fn features() {
     let p = project()
         .file(
@@ -838,7 +838,7 @@ fn features() {
     assert!(p.root().join("target/doc/bar/fn.bar.html").is_file());
 }
 
-#[test]
+#[cargo_test]
 fn rerun_when_dir_removed() {
     let p = project()
         .file(
@@ -859,7 +859,7 @@ fn rerun_when_dir_removed() {
     assert!(p.root().join("target/doc/foo/index.html").is_file());
 }
 
-#[test]
+#[cargo_test]
 fn document_only_lib() {
     let p = project()
         .file(
@@ -884,7 +884,7 @@ fn document_only_lib() {
     assert!(p.root().join("target/doc/foo/index.html").is_file());
 }
 
-#[test]
+#[cargo_test]
 fn plugins_no_use_target() {
     let p = project()
         .file(
@@ -904,7 +904,7 @@ fn plugins_no_use_target() {
     p.cargo("doc --target=x86_64-unknown-openbsd -v").run();
 }
 
-#[test]
+#[cargo_test]
 fn doc_all_workspace() {
     let p = project()
         .file(
@@ -933,7 +933,7 @@ fn doc_all_workspace() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn doc_all_virtual_manifest() {
     let p = project()
         .file(
@@ -956,7 +956,7 @@ fn doc_all_virtual_manifest() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn doc_virtual_manifest_all_implied() {
     let p = project()
         .file(
@@ -979,7 +979,7 @@ fn doc_virtual_manifest_all_implied() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn doc_all_member_dependency_same_name() {
     let p = project()
         .file(
@@ -1011,7 +1011,7 @@ fn doc_all_member_dependency_same_name() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 #[cfg(not(any(target_os = "windows", target_os = "macos")))]
 fn doc_workspace_open_help_message() {
     let p = project()
@@ -1037,7 +1037,7 @@ fn doc_workspace_open_help_message() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 #[cfg(not(any(target_os = "windows", target_os = "macos")))]
 fn doc_workspace_open_different_library_and_package_names() {
     let p = project()
@@ -1068,7 +1068,7 @@ fn doc_workspace_open_different_library_and_package_names() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 #[cfg(not(any(target_os = "windows", target_os = "macos")))]
 fn doc_workspace_open_binary() {
     let p = project()
@@ -1100,7 +1100,7 @@ fn doc_workspace_open_binary() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 #[cfg(not(any(target_os = "windows", target_os = "macos")))]
 fn doc_workspace_open_binary_and_library() {
     let p = project()
@@ -1135,7 +1135,7 @@ fn doc_workspace_open_binary_and_library() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn doc_edition() {
     let p = project()
         .file(
@@ -1160,7 +1160,7 @@ fn doc_edition() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn doc_target_edition() {
     let p = project()
         .file(
@@ -1189,7 +1189,7 @@ fn doc_target_edition() {
 
 // Tests an issue where depending on different versions of the same crate depending on `cfg`s
 // caused `cargo doc` to fail.
-#[test]
+#[cargo_test]
 fn issue_5345() {
     let foo = project()
         .file(
@@ -1216,7 +1216,7 @@ fn issue_5345() {
     foo.cargo("doc").run();
 }
 
-#[test]
+#[cargo_test]
 fn doc_private_items() {
     let foo = project()
         .file("src/lib.rs", "mod private { fn private_item() {} }")
@@ -1230,7 +1230,7 @@ fn doc_private_items() {
         .is_file());
 }
 
-#[test]
+#[cargo_test]
 fn doc_private_ws() {
     let p = project()
         .file(
@@ -1266,7 +1266,7 @@ const BAD_INTRA_LINK_LIB: &str = r#"
 pub fn foo() {}
 "#;
 
-#[test]
+#[cargo_test]
 fn doc_cap_lints() {
     if !is_nightly() {
         // This can be removed once intra_doc_link_resolution_failure fails on stable.
@@ -1320,7 +1320,7 @@ fn doc_cap_lints() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn doc_message_format() {
     if !is_nightly() {
         // This can be removed once intra_doc_link_resolution_failure fails on stable.
@@ -1350,7 +1350,7 @@ fn doc_message_format() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn short_message_format() {
     if !is_nightly() {
         // This can be removed once intra_doc_link_resolution_failure fails on stable.

--- a/tests/testsuite/edition.rs
+++ b/tests/testsuite/edition.rs
@@ -1,6 +1,6 @@
 use crate::support::{basic_lib_manifest, project};
 
-#[test]
+#[cargo_test]
 fn edition_works_for_build_script() {
     let p = project()
         .file(

--- a/tests/testsuite/features.rs
+++ b/tests/testsuite/features.rs
@@ -5,7 +5,7 @@ use crate::support::paths::CargoPathExt;
 use crate::support::registry::Package;
 use crate::support::{basic_manifest, project};
 
-#[test]
+#[cargo_test]
 fn invalid1() {
     let p = project()
         .file(
@@ -36,7 +36,7 @@ Caused by:
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn invalid2() {
     let p = project()
         .file(
@@ -70,7 +70,7 @@ Caused by:
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn invalid3() {
     let p = project()
         .file(
@@ -105,7 +105,7 @@ Consider adding `optional = true` to the dependency
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn invalid4() {
     let p = project()
         .file(
@@ -149,7 +149,7 @@ failed to select a version for `bar` which could resolve this conflict",
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn invalid5() {
     let p = project()
         .file(
@@ -181,7 +181,7 @@ Caused by:
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn invalid6() {
     let p = project()
         .file(
@@ -212,7 +212,7 @@ Caused by:
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn invalid7() {
     let p = project()
         .file(
@@ -244,7 +244,7 @@ Caused by:
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn invalid8() {
     let p = project()
         .file(
@@ -271,7 +271,7 @@ fn invalid8() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn invalid9() {
     let p = project()
         .file(
@@ -299,7 +299,7 @@ error: Package `foo v0.0.1 ([..])` does not have feature `bar`. It has a require
         ).with_status(101).run();
 }
 
-#[test]
+#[cargo_test]
 fn invalid10() {
     let p = project()
         .file(
@@ -347,7 +347,7 @@ failed to select a version for `bar` which could resolve this conflict
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn no_transitive_dep_feature_requirement() {
     let p = project()
         .file(
@@ -411,7 +411,7 @@ fn no_transitive_dep_feature_requirement() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn no_feature_doesnt_build() {
     let p = project()
         .file(
@@ -464,7 +464,7 @@ fn no_feature_doesnt_build() {
     p.process(&p.bin("foo")).with_stdout("bar\n").run();
 }
 
-#[test]
+#[cargo_test]
 fn default_feature_pulled_in() {
     let p = project()
         .file(
@@ -520,7 +520,7 @@ fn default_feature_pulled_in() {
     p.process(&p.bin("foo")).with_stdout("").run();
 }
 
-#[test]
+#[cargo_test]
 fn cyclic_feature() {
     let p = project()
         .file(
@@ -544,7 +544,7 @@ fn cyclic_feature() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn cyclic_feature2() {
     let p = project()
         .file(
@@ -566,7 +566,7 @@ fn cyclic_feature2() {
     p.cargo("build").with_stdout("").run();
 }
 
-#[test]
+#[cargo_test]
 fn groups_on_groups_on_groups() {
     let p = project()
         .file(
@@ -624,7 +624,7 @@ fn groups_on_groups_on_groups() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn many_cli_features() {
     let p = project()
         .file(
@@ -673,7 +673,7 @@ fn many_cli_features() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn union_features() {
     let p = project()
         .file(
@@ -756,7 +756,7 @@ fn union_features() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn many_features_no_rebuilds() {
     let p = project()
         .file(
@@ -813,7 +813,7 @@ fn many_features_no_rebuilds() {
 }
 
 // Tests that all cmd lines work with `--features ""`
-#[test]
+#[cargo_test]
 fn empty_features() {
     let p = project().file("src/main.rs", "fn main() {}").build();
 
@@ -821,7 +821,7 @@ fn empty_features() {
 }
 
 // Tests that all cmd lines work with `--features ""`
-#[test]
+#[cargo_test]
 fn transitive_features() {
     let p = project()
         .file(
@@ -861,7 +861,7 @@ fn transitive_features() {
     p.cargo("build --features foo").run();
 }
 
-#[test]
+#[cargo_test]
 fn everything_in_the_lockfile() {
     let p = project()
         .file(
@@ -938,7 +938,7 @@ fn everything_in_the_lockfile() {
     );
 }
 
-#[test]
+#[cargo_test]
 fn no_rebuild_when_frobbing_default_feature() {
     let p = project()
         .file(
@@ -989,7 +989,7 @@ fn no_rebuild_when_frobbing_default_feature() {
     p.cargo("build").with_stdout("").run();
 }
 
-#[test]
+#[cargo_test]
 fn unions_work_with_no_default_features() {
     let p = project()
         .file(
@@ -1040,7 +1040,7 @@ fn unions_work_with_no_default_features() {
     p.cargo("build").with_stdout("").run();
 }
 
-#[test]
+#[cargo_test]
 fn optional_and_dev_dep() {
     let p = project()
         .file(
@@ -1072,7 +1072,7 @@ fn optional_and_dev_dep() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn activating_feature_activates_dep() {
     let p = project()
         .file(
@@ -1112,7 +1112,7 @@ fn activating_feature_activates_dep() {
     p.cargo("build --features a -v").run();
 }
 
-#[test]
+#[cargo_test]
 fn dep_feature_in_cmd_line() {
     let p = project()
         .file(
@@ -1196,7 +1196,7 @@ fn dep_feature_in_cmd_line() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn all_features_flag_enables_all_features() {
     let p = project()
         .file(
@@ -1241,7 +1241,7 @@ fn all_features_flag_enables_all_features() {
     p.cargo("build --all-features").run();
 }
 
-#[test]
+#[cargo_test]
 fn many_cli_features_comma_delimited() {
     let p = project()
         .file(
@@ -1289,7 +1289,7 @@ fn many_cli_features_comma_delimited() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn many_cli_features_comma_and_space_delimited() {
     let p = project()
         .file(
@@ -1356,7 +1356,7 @@ fn many_cli_features_comma_and_space_delimited() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn combining_features_and_package() {
     Package::new("dep", "1.0.0").publish();
 
@@ -1439,7 +1439,7 @@ fn combining_features_and_package() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn namespaced_invalid_feature() {
     let p = project()
         .file(
@@ -1474,7 +1474,7 @@ Caused by:
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn namespaced_invalid_dependency() {
     let p = project()
         .file(
@@ -1509,7 +1509,7 @@ Caused by:
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn namespaced_non_optional_dependency() {
     let p = project()
         .file(
@@ -1548,7 +1548,7 @@ Consider adding `optional = true` to the dependency
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn namespaced_implicit_feature() {
     let p = project()
         .file(
@@ -1575,7 +1575,7 @@ fn namespaced_implicit_feature() {
     p.cargo("build").masquerade_as_nightly_cargo().run();
 }
 
-#[test]
+#[cargo_test]
 fn namespaced_shadowed_dep() {
     let p = project()
         .file(
@@ -1611,7 +1611,7 @@ Consider adding `crate:baz` to this feature's requirements.
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn namespaced_shadowed_non_optional() {
     let p = project()
         .file(
@@ -1648,7 +1648,7 @@ Consider adding `crate:baz` to this feature's requirements and marking the depen
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn namespaced_implicit_non_optional() {
     let p = project()
         .file(
@@ -1684,7 +1684,7 @@ A non-optional dependency of the same name is defined; consider adding `optional
     );
 }
 
-#[test]
+#[cargo_test]
 fn namespaced_same_name() {
     let p = project()
         .file(
@@ -1711,7 +1711,7 @@ fn namespaced_same_name() {
     p.cargo("build").masquerade_as_nightly_cargo().run();
 }
 
-#[test]
+#[cargo_test]
 fn only_dep_is_optional() {
     Package::new("bar", "0.1.0").publish();
 
@@ -1740,7 +1740,7 @@ fn only_dep_is_optional() {
     p.cargo("build").run();
 }
 
-#[test]
+#[cargo_test]
 fn all_features_all_crates() {
     Package::new("bar", "0.1.0").publish();
 
@@ -1776,7 +1776,7 @@ fn all_features_all_crates() {
     p.cargo("build --all-features --all").run();
 }
 
-#[test]
+#[cargo_test]
 fn feature_off_dylib() {
     let p = project()
         .file(
@@ -1837,7 +1837,7 @@ fn feature_off_dylib() {
     p.cargo("run -p bar").run();
 }
 
-#[test]
+#[cargo_test]
 fn warn_if_default_features() {
     let p = project()
         .file(
@@ -1871,7 +1871,7 @@ fn warn_if_default_features() {
         ).run();
 }
 
-#[test]
+#[cargo_test]
 fn no_feature_for_non_optional_dep() {
     let p = project()
         .file(

--- a/tests/testsuite/fetch.rs
+++ b/tests/testsuite/fetch.rs
@@ -2,7 +2,7 @@ use crate::support::registry::Package;
 use crate::support::rustc_host;
 use crate::support::{basic_manifest, cross_compile, project};
 
-#[test]
+#[cargo_test]
 fn no_deps() {
     let p = project()
         .file("src/main.rs", "mod a; fn main() {}")
@@ -12,7 +12,7 @@ fn no_deps() {
     p.cargo("fetch").with_stdout("").run();
 }
 
-#[test]
+#[cargo_test]
 fn fetch_all_platform_dependencies_when_no_target_is_given() {
     if cross_compile::disabled() {
         return;
@@ -59,7 +59,7 @@ fn fetch_all_platform_dependencies_when_no_target_is_given() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn fetch_platform_specific_dependencies() {
     if cross_compile::disabled() {
         return;

--- a/tests/testsuite/fix.rs
+++ b/tests/testsuite/fix.rs
@@ -7,7 +7,7 @@ use crate::support::{basic_manifest, project};
 
 use std::io::Write;
 
-#[test]
+#[cargo_test]
 fn do_not_fix_broken_builds() {
     let p = project()
         .file(
@@ -33,7 +33,7 @@ fn do_not_fix_broken_builds() {
     assert!(p.read_file("src/lib.rs").contains("let mut x = 3;"));
 }
 
-#[test]
+#[cargo_test]
 fn fix_broken_if_requested() {
     let p = project()
         .file(
@@ -52,7 +52,7 @@ fn fix_broken_if_requested() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn broken_fixes_backed_out() {
     // This works as follows:
     // - Create a `rustc` shim (the "foo" project) which will pretend that the
@@ -172,7 +172,7 @@ fn broken_fixes_backed_out() {
     assert!(p.read_file("bar/src/lib.rs").contains("let mut x = 3;"));
 }
 
-#[test]
+#[cargo_test]
 fn fix_path_deps() {
     let p = project()
         .file(
@@ -226,7 +226,7 @@ fn fix_path_deps() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn do_not_fix_non_relevant_deps() {
     let p = project()
         .no_manifest()
@@ -264,7 +264,7 @@ fn do_not_fix_non_relevant_deps() {
     assert!(p.read_file("bar/src/lib.rs").contains("mut"));
 }
 
-#[test]
+#[cargo_test]
 fn prepare_for_2018() {
     let p = project()
         .file(
@@ -304,7 +304,7 @@ fn prepare_for_2018() {
         .contains("let x = crate::foo::FOO;"));
 }
 
-#[test]
+#[cargo_test]
 fn local_paths() {
     let p = project()
         .file(
@@ -338,7 +338,7 @@ fn local_paths() {
     assert!(p.read_file("src/lib.rs").contains("use crate::test::foo;"));
 }
 
-#[test]
+#[cargo_test]
 fn upgrade_extern_crate() {
     let p = project()
         .file(
@@ -388,7 +388,7 @@ fn upgrade_extern_crate() {
     assert!(!p.read_file("src/lib.rs").contains("extern crate"));
 }
 
-#[test]
+#[cargo_test]
 fn specify_rustflags() {
     let p = project()
         .file(
@@ -419,7 +419,7 @@ fn specify_rustflags() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn no_changes_necessary() {
     let p = project().file("src/lib.rs", "").build();
 
@@ -433,7 +433,7 @@ fn no_changes_necessary() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn fixes_extra_mut() {
     let p = project()
         .file(
@@ -459,7 +459,7 @@ fn fixes_extra_mut() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn fixes_two_missing_ampersands() {
     let p = project()
         .file(
@@ -486,7 +486,7 @@ fn fixes_two_missing_ampersands() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn tricky() {
     let p = project()
         .file(
@@ -512,7 +512,7 @@ fn tricky() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn preserve_line_endings() {
     let p = project()
         .file(
@@ -530,7 +530,7 @@ fn preserve_line_endings() {
     assert!(p.read_file("src/lib.rs").contains("\r\n"));
 }
 
-#[test]
+#[cargo_test]
 fn fix_deny_warnings() {
     let p = project()
         .file(
@@ -547,7 +547,7 @@ fn fix_deny_warnings() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn fix_deny_warnings_but_not_others() {
     let p = project()
         .file(
@@ -572,7 +572,7 @@ fn fix_deny_warnings_but_not_others() {
     assert!(p.read_file("src/lib.rs").contains("fn bar() {}"));
 }
 
-#[test]
+#[cargo_test]
 fn fix_two_files() {
     let p = project()
         .file(
@@ -607,7 +607,7 @@ fn fix_two_files() {
     assert!(!p.read_file("src/bar.rs").contains("let mut x = 3;"));
 }
 
-#[test]
+#[cargo_test]
 fn fixes_missing_ampersand() {
     let p = project()
         .file("src/main.rs", "fn main() { let mut x = 3; drop(x); }")
@@ -651,7 +651,7 @@ fn fixes_missing_ampersand() {
     p.cargo("test").run();
 }
 
-#[test]
+#[cargo_test]
 fn fix_features() {
     let p = project()
         .file(
@@ -682,7 +682,7 @@ fn fix_features() {
     p.cargo("build --features bar").run();
 }
 
-#[test]
+#[cargo_test]
 fn shows_warnings() {
     let p = project()
         .file(
@@ -696,7 +696,7 @@ fn shows_warnings() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn warns_if_no_vcs_detected() {
     let p = project().file("src/lib.rs", "pub fn foo() {}").build();
 
@@ -712,7 +712,7 @@ fn warns_if_no_vcs_detected() {
     p.cargo("fix --allow-no-vcs").run();
 }
 
-#[test]
+#[cargo_test]
 fn warns_about_dirty_working_directory() {
     let p = project().file("src/lib.rs", "pub fn foo() {}").build();
 
@@ -743,7 +743,7 @@ commit the changes to these files:
     p.cargo("fix --allow-dirty").run();
 }
 
-#[test]
+#[cargo_test]
 fn warns_about_staged_working_directory() {
     let p = project().file("src/lib.rs", "pub fn foo() {}").build();
 
@@ -778,7 +778,7 @@ commit the changes to these files:
     p.cargo("fix --allow-staged").run();
 }
 
-#[test]
+#[cargo_test]
 fn does_not_warn_about_clean_working_directory() {
     let p = project().file("src/lib.rs", "pub fn foo() {}").build();
 
@@ -793,7 +793,7 @@ fn does_not_warn_about_clean_working_directory() {
     p.cargo("fix").run();
 }
 
-#[test]
+#[cargo_test]
 fn does_not_warn_about_dirty_ignored_files() {
     let p = project()
         .file("src/lib.rs", "pub fn foo() {}")
@@ -812,7 +812,7 @@ fn does_not_warn_about_dirty_ignored_files() {
     p.cargo("fix").run();
 }
 
-#[test]
+#[cargo_test]
 fn fix_all_targets_by_default() {
     let p = project()
         .file("src/lib.rs", "pub fn foo() { let mut x = 3; drop(x); }")
@@ -825,7 +825,7 @@ fn fix_all_targets_by_default() {
     assert!(!p.read_file("tests/foo.rs").contains("let mut x"));
 }
 
-#[test]
+#[cargo_test]
 fn prepare_for_and_enable() {
     let p = project()
         .file(
@@ -858,7 +858,7 @@ information about transitioning to the 2018 edition see:
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn fix_overlapping() {
     let p = project()
         .file(
@@ -891,7 +891,7 @@ fn fix_overlapping() {
     assert!(contents.contains("crate::foo::<crate::A>()"));
 }
 
-#[test]
+#[cargo_test]
 fn fix_idioms() {
     let p = project()
         .file(
@@ -926,14 +926,14 @@ fn fix_idioms() {
     assert!(p.read_file("src/lib.rs").contains("Box<dyn Any>"));
 }
 
-#[test]
+#[cargo_test]
 fn idioms_2015_ok() {
     let p = project().file("src/lib.rs", "").build();
 
     p.cargo("fix --edition-idioms --allow-no-vcs").run();
 }
 
-#[test]
+#[cargo_test]
 fn both_edition_migrate_flags() {
     let p = project().file("src/lib.rs", "").build();
 
@@ -952,7 +952,7 @@ For more information try --help
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn shows_warnings_on_second_run_without_changes() {
     let p = project()
         .file(
@@ -977,7 +977,7 @@ fn shows_warnings_on_second_run_without_changes() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn shows_warnings_on_second_run_without_changes_on_multiple_targets() {
     let p = project()
         .file(
@@ -1056,7 +1056,7 @@ fn shows_warnings_on_second_run_without_changes_on_multiple_targets() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn doesnt_rebuild_dependencies() {
     let p = project()
         .file(
@@ -1101,7 +1101,7 @@ fn doesnt_rebuild_dependencies() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn does_not_crash_with_rustc_wrapper() {
     // We don't have /usr/bin/env on Windows.
     if cfg!(windows) {
@@ -1124,7 +1124,7 @@ fn does_not_crash_with_rustc_wrapper() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn only_warn_for_relevant_crates() {
     let p = project()
         .file(
@@ -1170,7 +1170,7 @@ fn only_warn_for_relevant_crates() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn fix_to_broken_code() {
     let p = project()
         .file(
@@ -1243,7 +1243,7 @@ fn fix_to_broken_code() {
     );
 }
 
-#[test]
+#[cargo_test]
 fn fix_with_common() {
     let p = project()
         .file("src/lib.rs", "")
@@ -1263,7 +1263,7 @@ fn fix_with_common() {
     assert_eq!(p.read_file("tests/common/mod.rs"), "pub fn r#try() {}");
 }
 
-#[test]
+#[cargo_test]
 fn fix_in_existing_repo_weird_ignore() {
     // Check that ignore doesn't ignore the repo itself.
     let p = git::new("foo", |project| {

--- a/tests/testsuite/freshness.rs
+++ b/tests/testsuite/freshness.rs
@@ -12,7 +12,7 @@ use crate::support::registry::Package;
 use crate::support::sleep_ms;
 use crate::support::{basic_manifest, is_coarse_mtime, project};
 
-#[test]
+#[cargo_test]
 fn modifying_and_moving() {
     let p = project()
         .file("src/main.rs", "mod a; fn main() {}")
@@ -52,7 +52,7 @@ fn modifying_and_moving() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn modify_only_some_files() {
     let p = project()
         .file("src/lib.rs", "mod a;")
@@ -100,7 +100,7 @@ fn modify_only_some_files() {
     assert!(p.bin("foo").is_file());
 }
 
-#[test]
+#[cargo_test]
 fn rebuild_sub_package_then_while_package() {
     let p = project()
         .file(
@@ -151,7 +151,7 @@ fn rebuild_sub_package_then_while_package() {
     p.cargo("build").run();
 }
 
-#[test]
+#[cargo_test]
 fn changing_lib_features_caches_targets() {
     let p = project()
         .file(
@@ -200,7 +200,7 @@ fn changing_lib_features_caches_targets() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn changing_profiles_caches_targets() {
     let p = project()
         .file(
@@ -254,7 +254,7 @@ fn changing_profiles_caches_targets() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn changing_bin_paths_common_target_features_caches_targets() {
     // Make sure dep_cache crate is built once per feature
     let p = project()
@@ -422,7 +422,7 @@ fn changing_bin_paths_common_target_features_caches_targets() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn changing_bin_features_caches_targets() {
     let p = project()
         .file(
@@ -489,7 +489,7 @@ fn changing_bin_features_caches_targets() {
     p.rename_run("foo", "on2").with_stdout("feature on").run();
 }
 
-#[test]
+#[cargo_test]
 fn rebuild_tests_if_lib_changes() {
     let p = project()
         .file("src/lib.rs", "pub fn foo() {}")
@@ -516,7 +516,7 @@ fn rebuild_tests_if_lib_changes() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn no_rebuild_transitive_target_deps() {
     let p = project()
         .file(
@@ -578,7 +578,7 @@ fn no_rebuild_transitive_target_deps() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn rerun_if_changed_in_dep() {
     let p = project()
         .file(
@@ -619,7 +619,7 @@ fn rerun_if_changed_in_dep() {
     p.cargo("build").with_stdout("").run();
 }
 
-#[test]
+#[cargo_test]
 fn same_build_dir_cached_packages() {
     let p = project()
         .no_manifest()
@@ -706,7 +706,7 @@ fn same_build_dir_cached_packages() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn no_rebuild_if_build_artifacts_move_backwards_in_time() {
     let p = project()
         .file(
@@ -736,7 +736,7 @@ fn no_rebuild_if_build_artifacts_move_backwards_in_time() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn rebuild_if_build_artifacts_move_forward_in_time() {
     let p = project()
         .file(
@@ -773,7 +773,7 @@ fn rebuild_if_build_artifacts_move_forward_in_time() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn rebuild_if_environment_changes() {
     let p = project()
         .file(
@@ -832,7 +832,7 @@ fn rebuild_if_environment_changes() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn no_rebuild_when_rename_dir() {
     let p = project()
         .file(
@@ -864,7 +864,7 @@ fn no_rebuild_when_rename_dir() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn unused_optional_dep() {
     Package::new("registry1", "0.1.0").publish();
     Package::new("registry2", "0.1.0").publish();
@@ -918,7 +918,7 @@ fn unused_optional_dep() {
     p.cargo("build").with_stderr("[FINISHED] [..]").run();
 }
 
-#[test]
+#[cargo_test]
 fn path_dev_dep_registry_updates() {
     Package::new("registry1", "0.1.0").publish();
     Package::new("registry2", "0.1.0").publish();
@@ -972,7 +972,7 @@ fn path_dev_dep_registry_updates() {
     p.cargo("build").with_stderr("[FINISHED] [..]").run();
 }
 
-#[test]
+#[cargo_test]
 fn change_panic_mode() {
     let p = project()
         .file(
@@ -1009,7 +1009,7 @@ fn change_panic_mode() {
     p.cargo("build -p baz").run();
 }
 
-#[test]
+#[cargo_test]
 fn dont_rebuild_based_on_plugins() {
     let p = project()
         .file(
@@ -1066,7 +1066,7 @@ fn dont_rebuild_based_on_plugins() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn reuse_workspace_lib() {
     let p = project()
         .file(
@@ -1099,7 +1099,7 @@ fn reuse_workspace_lib() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn reuse_shared_build_dep() {
     let p = project()
         .file(
@@ -1147,7 +1147,7 @@ fn reuse_shared_build_dep() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn changing_rustflags_is_cached() {
     let p = project().file("src/lib.rs", "").build();
 
@@ -1193,7 +1193,7 @@ fn simple_deps_cleaner(mut dir: PathBuf, timestamp: filetime::FileTime) {
     );
 }
 
-#[test]
+#[cargo_test]
 fn simple_deps_cleaner_does_not_rebuild() {
     let p = project()
         .file(
@@ -1289,7 +1289,7 @@ fn fingerprint_cleaner(mut dir: PathBuf, timestamp: filetime::FileTime) {
     );
 }
 
-#[test]
+#[cargo_test]
 fn fingerprint_cleaner_does_not_rebuild() {
     let p = project()
         .file(
@@ -1353,7 +1353,7 @@ fn fingerprint_cleaner_does_not_rebuild() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn reuse_panic_build_dep_test() {
     let p = project()
         .file(
@@ -1395,7 +1395,7 @@ fn reuse_panic_build_dep_test() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn reuse_panic_pm() {
     // foo(panic) -> bar(panic)
     // somepm(nopanic) -> bar(nopanic)
@@ -1453,7 +1453,7 @@ fn reuse_panic_pm() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn bust_patched_dep() {
     Package::new("registry1", "0.1.0").publish();
     Package::new("registry2", "0.1.0")
@@ -1513,7 +1513,7 @@ fn bust_patched_dep() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn rebuild_on_mid_build_file_modification() {
     let server = TcpListener::bind("127.0.0.1:0").unwrap();
     let addr = server.local_addr().unwrap();
@@ -1620,7 +1620,7 @@ fn rebuild_on_mid_build_file_modification() {
     t.join().ok().unwrap();
 }
 
-#[test]
+#[cargo_test]
 fn dirty_both_lib_and_test() {
     // This tests that all artifacts that depend on the results of a build
     // script will get rebuilt when the build script reruns, even for separate
@@ -1712,7 +1712,7 @@ fn dirty_both_lib_and_test() {
     p.cargo("test --lib").run();
 }
 
-#[test]
+#[cargo_test]
 fn script_fails_stay_dirty() {
     // Check if a script is aborted (such as hitting Ctrl-C) that it will re-run.
     // Steps:
@@ -1751,7 +1751,7 @@ fn script_fails_stay_dirty() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn simulated_docker_deps_stay_cached() {
     // Test what happens in docker where the nanoseconds are zeroed out.
     Package::new("regdep", "1.0.0").publish();
@@ -1897,7 +1897,7 @@ fn simulated_docker_deps_stay_cached() {
     }
 }
 
-#[test]
+#[cargo_test]
 fn metadata_change_invalidates() {
     let p = project()
         .file(
@@ -1935,7 +1935,7 @@ fn metadata_change_invalidates() {
     assert_eq!(p.glob("target/debug/deps/libfoo-*.rlib").count(), 1);
 }
 
-#[test]
+#[cargo_test]
 fn edition_change_invalidates() {
     const MANIFEST: &str = r#"
         [package]
@@ -1970,7 +1970,7 @@ fn edition_change_invalidates() {
     assert_eq!(p.glob("target/debug/deps/libfoo-*.rlib").count(), 1);
 }
 
-#[test]
+#[cargo_test]
 fn rename_with_path_deps() {
     let p = project()
         .file(

--- a/tests/testsuite/generate_lockfile.rs
+++ b/tests/testsuite/generate_lockfile.rs
@@ -4,7 +4,7 @@ use std::io::prelude::*;
 use crate::support::registry::Package;
 use crate::support::{basic_manifest, paths, project, ProjectBuilder};
 
-#[test]
+#[cargo_test]
 fn adding_and_removing_packages() {
     let p = project()
         .file("src/main.rs", "fn main() {}")
@@ -64,7 +64,7 @@ fn adding_and_removing_packages() {
     assert_eq!(lock1, lock4);
 }
 
-#[test]
+#[cargo_test]
 fn no_index_update() {
     Package::new("serde", "1.0.0").publish();
 
@@ -95,7 +95,7 @@ fn no_index_update() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn preserve_metadata() {
     let p = project()
         .file("src/main.rs", "fn main() {}")
@@ -129,7 +129,7 @@ foo = "bar"
     assert!(lock.contains(metadata.trim()), "{}", lock);
 }
 
-#[test]
+#[cargo_test]
 fn preserve_line_endings_issue_2076() {
     let p = project()
         .file("src/main.rs", "fn main() {}")
@@ -162,7 +162,7 @@ fn preserve_line_endings_issue_2076() {
     assert_eq!(lock1, lock2);
 }
 
-#[test]
+#[cargo_test]
 fn cargo_update_generate_lockfile() {
     let p = project().file("src/main.rs", "fn main() {}").build();
 
@@ -178,7 +178,7 @@ fn cargo_update_generate_lockfile() {
     assert!(lockfile.is_file());
 }
 
-#[test]
+#[cargo_test]
 fn duplicate_entries_in_lockfile() {
     let _a = ProjectBuilder::new(paths::root().join("a"))
         .file(

--- a/tests/testsuite/git.rs
+++ b/tests/testsuite/git.rs
@@ -20,7 +20,7 @@ fn disable_git_cli() -> bool {
     env::var("CARGO_TEST_DISABLE_GIT_CLI") == Ok("1".to_string())
 }
 
-#[test]
+#[cargo_test]
 fn cargo_compile_simple_git_dep() {
     let project = project();
     let git_project = git::new("dep1", |project| {
@@ -83,7 +83,7 @@ fn cargo_compile_simple_git_dep() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn cargo_compile_git_dep_branch() {
     let project = project();
     let git_project = git::new("dep1", |project| {
@@ -154,7 +154,7 @@ fn cargo_compile_git_dep_branch() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn cargo_compile_git_dep_tag() {
     let project = project();
     let git_project = git::new("dep1", |project| {
@@ -232,7 +232,7 @@ fn cargo_compile_git_dep_tag() {
     project.cargo("build").run();
 }
 
-#[test]
+#[cargo_test]
 fn cargo_compile_with_nested_paths() {
     let git_project = git::new("dep1", |project| {
         project
@@ -313,7 +313,7 @@ fn cargo_compile_with_nested_paths() {
     p.process(&p.bin("foo")).with_stdout("hello world\n").run();
 }
 
-#[test]
+#[cargo_test]
 fn cargo_compile_with_malformed_nested_paths() {
     let git_project = git::new("dep1", |project| {
         project
@@ -366,7 +366,7 @@ fn cargo_compile_with_malformed_nested_paths() {
     p.process(&p.bin("foo")).with_stdout("hello world\n").run();
 }
 
-#[test]
+#[cargo_test]
 fn cargo_compile_with_meta_package() {
     let git_project = git::new("meta-dep", |project| {
         project
@@ -438,7 +438,7 @@ fn cargo_compile_with_meta_package() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn cargo_compile_with_short_ssh_git() {
     let url = "git@github.com:a/dep";
 
@@ -485,7 +485,7 @@ Caused by:
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn two_revs_same_deps() {
     let bar = git::new("meta-dep", |project| {
         project
@@ -573,7 +573,7 @@ fn two_revs_same_deps() {
     foo.process(&foo.bin("foo")).run();
 }
 
-#[test]
+#[cargo_test]
 fn recompilation() {
     let git_project = git::new("bar", |project| {
         project
@@ -678,7 +678,7 @@ fn recompilation() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn update_with_shared_deps() {
     let git_project = git::new("bar", |project| {
         project
@@ -835,7 +835,7 @@ Caused by:
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn dep_with_submodule() {
     let project = project();
     let git_project = git::new("dep1", |project| {
@@ -886,7 +886,7 @@ fn dep_with_submodule() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn dep_with_bad_submodule() {
     let project = project();
     let git_project = git::new("dep1", |project| {
@@ -964,7 +964,7 @@ Caused by:
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn two_deps_only_update_one() {
     let project = project();
     let git1 = git::new("dep1", |project| {
@@ -1045,7 +1045,7 @@ fn two_deps_only_update_one() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn stale_cached_version() {
     let bar = git::new("meta-dep", |project| {
         project
@@ -1138,7 +1138,7 @@ fn stale_cached_version() {
     foo.process(&foo.bin("foo")).run();
 }
 
-#[test]
+#[cargo_test]
 fn dep_with_changed_submodule() {
     let project = project();
     let git_project = git::new("dep1", |project| {
@@ -1254,7 +1254,7 @@ fn dep_with_changed_submodule() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn dev_deps_with_testing() {
     let p2 = git::new("bar", |project| {
         project
@@ -1327,7 +1327,7 @@ fn dev_deps_with_testing() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn git_build_cmd_freshness() {
     let foo = git::new("foo", |project| {
         project
@@ -1369,7 +1369,7 @@ fn git_build_cmd_freshness() {
     foo.cargo("build").with_stdout("").run();
 }
 
-#[test]
+#[cargo_test]
 fn git_name_not_always_needed() {
     let p2 = git::new("bar", |project| {
         project
@@ -1421,7 +1421,7 @@ fn git_name_not_always_needed() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn git_repo_changing_no_rebuild() {
     let bar = git::new("bar", |project| {
         project
@@ -1509,7 +1509,7 @@ fn git_repo_changing_no_rebuild() {
     p1.cargo("build").with_stdout("").run();
 }
 
-#[test]
+#[cargo_test]
 fn git_dep_build_cmd() {
     let p = git::new("foo", |project| {
         project
@@ -1583,7 +1583,7 @@ fn git_dep_build_cmd() {
     p.process(&p.bin("foo")).with_stdout("1\n").run();
 }
 
-#[test]
+#[cargo_test]
 fn fetch_downloads() {
     let bar = git::new("bar", |project| {
         project
@@ -1619,7 +1619,7 @@ fn fetch_downloads() {
     p.cargo("fetch").with_stdout("").run();
 }
 
-#[test]
+#[cargo_test]
 fn warnings_in_git_dep() {
     let bar = git::new("bar", |project| {
         project
@@ -1658,7 +1658,7 @@ fn warnings_in_git_dep() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn update_ambiguous() {
     let bar1 = git::new("bar1", |project| {
         project
@@ -1730,7 +1730,7 @@ following:
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn update_one_dep_in_repo_with_many_deps() {
     let bar = git::new("bar", |project| {
         project
@@ -1768,7 +1768,7 @@ fn update_one_dep_in_repo_with_many_deps() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn switch_deps_does_not_update_transitive() {
     let transitive = git::new("transitive", |project| {
         project
@@ -1883,7 +1883,7 @@ fn switch_deps_does_not_update_transitive() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn update_one_source_updates_all_packages_in_that_git_source() {
     let dep = git::new("dep", |project| {
         project
@@ -1950,7 +1950,7 @@ fn update_one_source_updates_all_packages_in_that_git_source() {
     );
 }
 
-#[test]
+#[cargo_test]
 fn switch_sources() {
     let a1 = git::new("a1", |project| {
         project
@@ -2038,7 +2038,7 @@ fn switch_sources() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn dont_require_submodules_are_checked_out() {
     let p = project().build();
     let git1 = git::new("dep1", |p| {
@@ -2072,7 +2072,7 @@ fn dont_require_submodules_are_checked_out() {
     git1.cargo("build -v").cwd(&dst).run();
 }
 
-#[test]
+#[cargo_test]
 fn doctest_same_name() {
     let a2 = git::new("a2", |p| {
         p.file("Cargo.toml", &basic_manifest("a", "0.5.0"))
@@ -2127,7 +2127,7 @@ fn doctest_same_name() {
     p.cargo("test -v").run();
 }
 
-#[test]
+#[cargo_test]
 fn lints_are_suppressed() {
     let a = git::new("a", |p| {
         p.file("Cargo.toml", &basic_manifest("a", "0.5.0")).file(
@@ -2170,7 +2170,7 @@ fn lints_are_suppressed() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn denied_lints_are_allowed() {
     let a = git::new("a", |p| {
         p.file("Cargo.toml", &basic_manifest("a", "0.5.0")).file(
@@ -2214,7 +2214,7 @@ fn denied_lints_are_allowed() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn add_a_git_dep() {
     let git = git::new("git", |p| {
         p.file("Cargo.toml", &basic_manifest("git", "0.5.0"))
@@ -2268,7 +2268,7 @@ fn add_a_git_dep() {
     p.cargo("build").run();
 }
 
-#[test]
+#[cargo_test]
 fn two_at_rev_instead_of_tag() {
     let git = git::new("git", |p| {
         p.file("Cargo.toml", &basic_manifest("git1", "0.5.0"))
@@ -2314,7 +2314,7 @@ fn two_at_rev_instead_of_tag() {
     p.cargo("build -v").run();
 }
 
-#[test]
+#[cargo_test]
 fn include_overrides_gitignore() {
     // Make sure that `package.include` takes precedence over .gitignore.
     let p = git::new("foo", |repo| {
@@ -2364,7 +2364,7 @@ src/lib.rs
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn invalid_git_dependency_manifest() {
     let project = project();
     let git_project = git::new("dep1", |project| {
@@ -2446,7 +2446,7 @@ fn invalid_git_dependency_manifest() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn failed_submodule_checkout() {
     let project = project();
     let git_project = git::new("dep1", |project| {
@@ -2526,7 +2526,7 @@ fn failed_submodule_checkout() {
     t.join().unwrap();
 }
 
-#[test]
+#[cargo_test]
 fn use_the_cli() {
     if disable_git_cli() {
         return;
@@ -2578,7 +2578,7 @@ fn use_the_cli() {
     project.cargo("build -v").with_stderr(stderr).run();
 }
 
-#[test]
+#[cargo_test]
 fn templatedir_doesnt_cause_problems() {
     let git_project2 = git::new("dep2", |project| {
         project
@@ -2634,7 +2634,7 @@ fn templatedir_doesnt_cause_problems() {
     p.cargo("build").run();
 }
 
-#[test]
+#[cargo_test]
 fn git_with_cli_force() {
     if disable_git_cli() {
         return;

--- a/tests/testsuite/init.rs
+++ b/tests/testsuite/init.rs
@@ -24,7 +24,7 @@ fn mercurial_available() -> bool {
     result
 }
 
-#[test]
+#[cargo_test]
 fn simple_lib() {
     cargo_process("init --lib --vcs none --edition 2015")
         .env("USER", "foo")
@@ -38,7 +38,7 @@ fn simple_lib() {
     cargo_process("build").run();
 }
 
-#[test]
+#[cargo_test]
 fn simple_bin() {
     let path = paths::root().join("foo");
     fs::create_dir(&path).unwrap();
@@ -57,7 +57,7 @@ fn simple_bin() {
         .is_file());
 }
 
-#[test]
+#[cargo_test]
 fn simple_git_ignore_exists() {
     // write a .gitignore file with one entry
     fs::create_dir_all(paths::root().join("foo")).unwrap();
@@ -99,7 +99,7 @@ fn simple_git_ignore_exists() {
     cargo_process("build").cwd(&paths::root().join("foo")).run();
 }
 
-#[test]
+#[cargo_test]
 fn both_lib_and_bin() {
     cargo_process("init --lib --bin")
         .env("USER", "foo")
@@ -149,37 +149,37 @@ fn bin_already_exists(explicit: bool, rellocation: &str) {
     assert_eq!(Vec::from(content as &[u8]), new_content);
 }
 
-#[test]
+#[cargo_test]
 fn bin_already_exists_explicit() {
     bin_already_exists(true, "src/main.rs")
 }
 
-#[test]
+#[cargo_test]
 fn bin_already_exists_implicit() {
     bin_already_exists(false, "src/main.rs")
 }
 
-#[test]
+#[cargo_test]
 fn bin_already_exists_explicit_nosrc() {
     bin_already_exists(true, "main.rs")
 }
 
-#[test]
+#[cargo_test]
 fn bin_already_exists_implicit_nosrc() {
     bin_already_exists(false, "main.rs")
 }
 
-#[test]
+#[cargo_test]
 fn bin_already_exists_implicit_namenosrc() {
     bin_already_exists(false, "foo.rs")
 }
 
-#[test]
+#[cargo_test]
 fn bin_already_exists_implicit_namesrc() {
     bin_already_exists(false, "src/foo.rs")
 }
 
-#[test]
+#[cargo_test]
 fn confused_by_multiple_lib_files() {
     let path = paths::root().join("foo");
     fs::create_dir_all(&path.join("src")).unwrap();
@@ -206,7 +206,7 @@ fn confused_by_multiple_lib_files() {
     assert!(!paths::root().join("foo/Cargo.toml").is_file());
 }
 
-#[test]
+#[cargo_test]
 fn multibin_project_name_clash() {
     let path = paths::root().join("foo");
     fs::create_dir(&path).unwrap();
@@ -274,17 +274,17 @@ fn lib_already_exists(rellocation: &str) {
     assert_eq!(Vec::from(content as &[u8]), new_content);
 }
 
-#[test]
+#[cargo_test]
 fn lib_already_exists_src() {
     lib_already_exists("src/lib.rs");
 }
 
-#[test]
+#[cargo_test]
 fn lib_already_exists_nosrc() {
     lib_already_exists("lib.rs");
 }
 
-#[test]
+#[cargo_test]
 fn simple_git() {
     cargo_process("init --lib --vcs git")
         .env("USER", "foo")
@@ -296,7 +296,7 @@ fn simple_git() {
     assert!(paths::root().join(".gitignore").is_file());
 }
 
-#[test]
+#[cargo_test]
 fn auto_git() {
     cargo_process("init --lib").env("USER", "foo").run();
 
@@ -306,7 +306,7 @@ fn auto_git() {
     assert!(paths::root().join(".gitignore").is_file());
 }
 
-#[test]
+#[cargo_test]
 fn invalid_dir_name() {
     let foo = &paths::root().join("foo.bar");
     fs::create_dir_all(&foo).unwrap();
@@ -325,7 +325,7 @@ use --name to override crate name
     assert!(!foo.join("Cargo.toml").is_file());
 }
 
-#[test]
+#[cargo_test]
 fn reserved_name() {
     let test = &paths::root().join("test");
     fs::create_dir_all(&test).unwrap();
@@ -344,7 +344,7 @@ use --name to override crate name
     assert!(!test.join("Cargo.toml").is_file());
 }
 
-#[test]
+#[cargo_test]
 fn git_autodetect() {
     fs::create_dir(&paths::root().join(".git")).unwrap();
 
@@ -356,7 +356,7 @@ fn git_autodetect() {
     assert!(paths::root().join(".gitignore").is_file());
 }
 
-#[test]
+#[cargo_test]
 fn mercurial_autodetect() {
     fs::create_dir(&paths::root().join(".hg")).unwrap();
 
@@ -368,7 +368,7 @@ fn mercurial_autodetect() {
     assert!(paths::root().join(".hgignore").is_file());
 }
 
-#[test]
+#[cargo_test]
 fn gitignore_appended_not_replaced() {
     fs::create_dir(&paths::root().join(".git")).unwrap();
 
@@ -392,7 +392,7 @@ fn gitignore_appended_not_replaced() {
     assert!(contents.contains(r#"qqqqqq"#));
 }
 
-#[test]
+#[cargo_test]
 fn gitignore_added_newline_in_existing() {
     fs::create_dir(&paths::root().join(".git")).unwrap();
 
@@ -413,7 +413,7 @@ fn gitignore_added_newline_in_existing() {
     assert!(contents.starts_with("first\n"));
 }
 
-#[test]
+#[cargo_test]
 fn gitignore_no_newline_in_new() {
     fs::create_dir(&paths::root().join(".git")).unwrap();
 
@@ -429,7 +429,7 @@ fn gitignore_no_newline_in_new() {
     assert!(!contents.starts_with('\n'));
 }
 
-#[test]
+#[cargo_test]
 fn mercurial_added_newline_in_existing() {
     fs::create_dir(&paths::root().join(".hg")).unwrap();
 
@@ -450,7 +450,7 @@ fn mercurial_added_newline_in_existing() {
     assert!(contents.starts_with("first\n"));
 }
 
-#[test]
+#[cargo_test]
 fn mercurial_no_newline_in_new() {
     fs::create_dir(&paths::root().join(".hg")).unwrap();
 
@@ -466,7 +466,7 @@ fn mercurial_no_newline_in_new() {
     assert!(!contents.starts_with('\n'));
 }
 
-#[test]
+#[cargo_test]
 fn terminating_newline_in_new_git_ignore() {
     cargo_process("init --vcs git --lib")
         .env("USER", "foo")
@@ -479,7 +479,7 @@ fn terminating_newline_in_new_git_ignore() {
     assert_ne!(last_chars.next(), Some('\n'));
 }
 
-#[test]
+#[cargo_test]
 fn terminating_newline_in_new_mercurial_ignore() {
     if !mercurial_available() {
         return;
@@ -495,7 +495,7 @@ fn terminating_newline_in_new_mercurial_ignore() {
     assert_ne!(last_chars.next(), Some('\n'));
 }
 
-#[test]
+#[cargo_test]
 fn terminating_newline_in_existing_git_ignore() {
     fs::create_dir(&paths::root().join(".git")).unwrap();
     fs::write(&paths::root().join(".gitignore"), b"first").unwrap();
@@ -509,7 +509,7 @@ fn terminating_newline_in_existing_git_ignore() {
     assert_ne!(last_chars.next(), Some('\n'));
 }
 
-#[test]
+#[cargo_test]
 fn terminating_newline_in_existing_mercurial_ignore() {
     fs::create_dir(&paths::root().join(".hg")).unwrap();
     fs::write(&paths::root().join(".hgignore"), b"first").unwrap();
@@ -523,7 +523,7 @@ fn terminating_newline_in_existing_mercurial_ignore() {
     assert_ne!(last_chars.next(), Some('\n'));
 }
 
-#[test]
+#[cargo_test]
 fn cargo_lock_gitignored_if_lib1() {
     fs::create_dir(&paths::root().join(".git")).unwrap();
 
@@ -541,7 +541,7 @@ fn cargo_lock_gitignored_if_lib1() {
     assert!(contents.contains(r#"Cargo.lock"#));
 }
 
-#[test]
+#[cargo_test]
 fn cargo_lock_gitignored_if_lib2() {
     fs::create_dir(&paths::root().join(".git")).unwrap();
 
@@ -562,7 +562,7 @@ fn cargo_lock_gitignored_if_lib2() {
     assert!(contents.contains(r#"Cargo.lock"#));
 }
 
-#[test]
+#[cargo_test]
 fn cargo_lock_not_gitignored_if_bin1() {
     fs::create_dir(&paths::root().join(".git")).unwrap();
 
@@ -580,7 +580,7 @@ fn cargo_lock_not_gitignored_if_bin1() {
     assert!(!contents.contains(r#"Cargo.lock"#));
 }
 
-#[test]
+#[cargo_test]
 fn cargo_lock_not_gitignored_if_bin2() {
     fs::create_dir(&paths::root().join(".git")).unwrap();
 
@@ -601,7 +601,7 @@ fn cargo_lock_not_gitignored_if_bin2() {
     assert!(!contents.contains(r#"Cargo.lock"#));
 }
 
-#[test]
+#[cargo_test]
 fn with_argument() {
     cargo_process("init foo --vcs none")
         .env("USER", "foo")
@@ -609,7 +609,7 @@ fn with_argument() {
     assert!(paths::root().join("foo/Cargo.toml").is_file());
 }
 
-#[test]
+#[cargo_test]
 fn unknown_flags() {
     cargo_process("init foo --flag")
         .with_status(1)
@@ -620,7 +620,7 @@ fn unknown_flags() {
 }
 
 #[cfg(not(windows))]
-#[test]
+#[cargo_test]
 fn no_filename() {
     cargo_process("init /")
         .with_status(101)

--- a/tests/testsuite/install.rs
+++ b/tests/testsuite/install.rs
@@ -21,7 +21,7 @@ fn pkg(name: &str, vers: &str) {
         .publish();
 }
 
-#[test]
+#[cargo_test]
 fn simple() {
     pkg("foo", "0.0.1");
 
@@ -48,7 +48,7 @@ fn simple() {
     assert_has_not_installed_exe(cargo_home(), "foo");
 }
 
-#[test]
+#[cargo_test]
 fn multiple_pkgs() {
     pkg("foo", "0.0.1");
     pkg("bar", "0.0.2");
@@ -96,7 +96,7 @@ fn multiple_pkgs() {
     assert_has_not_installed_exe(cargo_home(), "bar");
 }
 
-#[test]
+#[cargo_test]
 fn pick_max_version() {
     pkg("foo", "0.1.0");
     pkg("foo", "0.2.0");
@@ -122,7 +122,7 @@ fn pick_max_version() {
     assert_has_installed_exe(cargo_home(), "foo");
 }
 
-#[test]
+#[cargo_test]
 fn installs_beta_version_by_explicit_name_from_git() {
     let p = git::repo(&paths::root().join("foo"))
         .file("Cargo.toml", &basic_manifest("foo", "0.3.0-beta.1"))
@@ -136,7 +136,7 @@ fn installs_beta_version_by_explicit_name_from_git() {
     assert_has_installed_exe(cargo_home(), "foo");
 }
 
-#[test]
+#[cargo_test]
 fn missing() {
     pkg("foo", "0.0.1");
     cargo_process("install bar")
@@ -150,7 +150,7 @@ fn missing() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn bad_version() {
     pkg("foo", "0.0.1");
     cargo_process("install foo --vers=0.2.0")
@@ -164,7 +164,7 @@ fn bad_version() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn bad_paths() {
     cargo_process("install")
         .with_status(101)
@@ -189,7 +189,7 @@ fn bad_paths() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn install_location_precedence() {
     pkg("foo", "0.0.1");
 
@@ -245,7 +245,7 @@ fn install_location_precedence() {
     assert_has_installed_exe(&t4, "foo");
 }
 
-#[test]
+#[cargo_test]
 fn install_path() {
     let p = project().file("src/main.rs", "fn main() {}").build();
 
@@ -262,7 +262,7 @@ Add --force to overwrite
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn multiple_crates_error() {
     let p = git::repo(&paths::root().join("foo"))
         .file("Cargo.toml", &basic_manifest("foo", "0.1.0"))
@@ -283,7 +283,7 @@ fn multiple_crates_error() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn multiple_crates_select() {
     let p = git::repo(&paths::root().join("foo"))
         .file("Cargo.toml", &basic_manifest("foo", "0.1.0"))
@@ -306,7 +306,7 @@ fn multiple_crates_select() {
     assert_has_installed_exe(cargo_home(), "bar");
 }
 
-#[test]
+#[cargo_test]
 fn multiple_crates_git_all() {
     let p = git::repo(&paths::root().join("foo"))
         .file(
@@ -331,7 +331,7 @@ members = ["bin1", "bin2"]
     cargo_process(&format!("install --git {} bin1 bin2", p.url().to_string())).run();
 }
 
-#[test]
+#[cargo_test]
 fn multiple_crates_auto_binaries() {
     let p = project()
         .file(
@@ -355,7 +355,7 @@ fn multiple_crates_auto_binaries() {
     assert_has_installed_exe(cargo_home(), "foo");
 }
 
-#[test]
+#[cargo_test]
 fn multiple_crates_auto_examples() {
     let p = project()
         .file(
@@ -390,7 +390,7 @@ fn multiple_crates_auto_examples() {
     assert_has_installed_exe(cargo_home(), "foo");
 }
 
-#[test]
+#[cargo_test]
 fn no_binaries_or_examples() {
     let p = project()
         .file(
@@ -417,7 +417,7 @@ fn no_binaries_or_examples() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn no_binaries() {
     let p = project()
         .file("src/lib.rs", "")
@@ -436,7 +436,7 @@ fn no_binaries() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn examples() {
     let p = project()
         .file("src/lib.rs", "")
@@ -450,7 +450,7 @@ fn examples() {
     assert_has_installed_exe(cargo_home(), "foo");
 }
 
-#[test]
+#[cargo_test]
 fn install_twice() {
     let p = project()
         .file("src/bin/foo-bin1.rs", "fn main() {}")
@@ -471,7 +471,7 @@ Add --force to overwrite
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn install_force() {
     let p = project().file("src/main.rs", "fn main() {}").build();
 
@@ -507,7 +507,7 @@ foo v0.2.0 ([..]):
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn install_force_partial_overlap() {
     let p = project()
         .file("src/bin/foo-bin1.rs", "fn main() {}")
@@ -552,7 +552,7 @@ foo v0.2.0 ([..]):
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn install_force_bin() {
     let p = project()
         .file("src/bin/foo-bin1.rs", "fn main() {}")
@@ -594,7 +594,7 @@ foo v0.2.0 ([..]):
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn compile_failure() {
     let p = project().file("src/main.rs", "").build();
 
@@ -615,7 +615,7 @@ To learn more, run the command again with --verbose.
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn git_repo() {
     let p = git::repo(&paths::root().join("foo"))
         .file("Cargo.toml", &basic_manifest("foo", "0.1.0"))
@@ -641,7 +641,7 @@ fn git_repo() {
     assert_has_installed_exe(cargo_home(), "foo");
 }
 
-#[test]
+#[cargo_test]
 fn list() {
     pkg("foo", "0.0.1");
     pkg("bar", "0.2.1");
@@ -663,7 +663,7 @@ foo v0.0.1:
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn list_error() {
     pkg("foo", "0.0.1");
     cargo_process("install foo").run();
@@ -699,7 +699,7 @@ Caused by:
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn uninstall_pkg_does_not_exist() {
     cargo_process("uninstall foo")
         .with_status(101)
@@ -707,7 +707,7 @@ fn uninstall_pkg_does_not_exist() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn uninstall_bin_does_not_exist() {
     pkg("foo", "0.0.1");
 
@@ -718,7 +718,7 @@ fn uninstall_bin_does_not_exist() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn uninstall_piecemeal() {
     let p = project()
         .file("src/bin/foo.rs", "fn main() {}")
@@ -747,7 +747,7 @@ fn uninstall_piecemeal() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn subcommand_works_out_of_the_box() {
     Package::new("cargo-foo", "1.0.0")
         .file("src/main.rs", r#"fn main() { println!("bar"); }"#)
@@ -759,7 +759,7 @@ fn subcommand_works_out_of_the_box() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn installs_from_cwd_by_default() {
     let p = project().file("src/main.rs", "fn main() {}").build();
 
@@ -774,7 +774,7 @@ fn installs_from_cwd_by_default() {
     assert_has_installed_exe(cargo_home(), "foo");
 }
 
-#[test]
+#[cargo_test]
 fn installs_from_cwd_with_2018_warnings() {
     let p = project()
         .file(
@@ -802,7 +802,7 @@ fn installs_from_cwd_with_2018_warnings() {
     assert_has_not_installed_exe(cargo_home(), "foo");
 }
 
-#[test]
+#[cargo_test]
 fn uninstall_cwd() {
     let p = project().file("src/main.rs", "fn main() {}").build();
     p.cargo("install --path .")
@@ -830,7 +830,7 @@ fn uninstall_cwd() {
     assert_has_not_installed_exe(cargo_home(), "foo");
 }
 
-#[test]
+#[cargo_test]
 fn uninstall_cwd_not_installed() {
     let p = project().file("src/main.rs", "fn main() {}").build();
     p.cargo("uninstall")
@@ -843,7 +843,7 @@ fn uninstall_cwd_not_installed() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn uninstall_cwd_no_project() {
     let err_msg = if cfg!(windows) {
         "The system cannot find the file specified."
@@ -864,7 +864,7 @@ Caused by:
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn do_not_rebuilds_on_local_install() {
     let p = project().file("src/main.rs", "fn main() {}").build();
 
@@ -887,7 +887,7 @@ fn do_not_rebuilds_on_local_install() {
     assert_has_installed_exe(cargo_home(), "foo");
 }
 
-#[test]
+#[cargo_test]
 fn reports_unsuccessful_subcommand_result() {
     Package::new("cargo-fail", "1.0.0")
         .file("src/main.rs", "fn main() { panic!(); }")
@@ -902,7 +902,7 @@ fn reports_unsuccessful_subcommand_result() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn git_with_lockfile() {
     let p = git::repo(&paths::root().join("foo"))
         .file(
@@ -940,7 +940,7 @@ fn git_with_lockfile() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn q_silences_warnings() {
     let p = project().file("src/main.rs", "fn main() {}").build();
 
@@ -950,7 +950,7 @@ fn q_silences_warnings() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn readonly_dir() {
     pkg("foo", "0.0.1");
 
@@ -965,7 +965,7 @@ fn readonly_dir() {
     assert_has_installed_exe(cargo_home(), "foo");
 }
 
-#[test]
+#[cargo_test]
 fn use_path_workspace() {
     Package::new("foo", "1.0.0").publish();
     let p = project()
@@ -1004,7 +1004,7 @@ fn use_path_workspace() {
     assert_eq!(lock, lock2, "different lockfiles");
 }
 
-#[test]
+#[cargo_test]
 fn dev_dependencies_no_check() {
     Package::new("foo", "1.0.0").publish();
     let p = project()
@@ -1030,7 +1030,7 @@ fn dev_dependencies_no_check() {
     p.cargo("install").run();
 }
 
-#[test]
+#[cargo_test]
 fn dev_dependencies_lock_file_untouched() {
     Package::new("foo", "1.0.0").publish();
     let p = project()
@@ -1058,7 +1058,7 @@ fn dev_dependencies_lock_file_untouched() {
     assert!(lock == lock2, "different lockfiles");
 }
 
-#[test]
+#[cargo_test]
 fn install_target_native() {
     pkg("foo", "0.1.0");
 
@@ -1068,7 +1068,7 @@ fn install_target_native() {
     assert_has_installed_exe(cargo_home(), "foo");
 }
 
-#[test]
+#[cargo_test]
 fn install_target_foreign() {
     if cross_compile::disabled() {
         return;
@@ -1082,7 +1082,7 @@ fn install_target_foreign() {
     assert_has_installed_exe(cargo_home(), "foo");
 }
 
-#[test]
+#[cargo_test]
 fn vers_precise() {
     pkg("foo", "0.1.1");
     pkg("foo", "0.1.2");
@@ -1092,7 +1092,7 @@ fn vers_precise() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn version_too() {
     pkg("foo", "0.1.1");
     pkg("foo", "0.1.2");
@@ -1102,7 +1102,7 @@ fn version_too() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn not_both_vers_and_version() {
     pkg("foo", "0.1.1");
     pkg("foo", "0.1.2");
@@ -1118,7 +1118,7 @@ but cannot be used multiple times
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn legacy_version_requirement() {
     pkg("foo", "0.1.1");
 
@@ -1134,17 +1134,17 @@ and will continue to do so, but this behavior will be removed eventually
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn test_install_git_cannot_be_a_base_url() {
     cargo_process("install --git github.com:rust-lang-nursery/rustfmt.git").with_status(101).with_stderr("error: invalid url `github.com:rust-lang-nursery/rustfmt.git`: cannot-be-a-base-URLs are not supported").run();
 }
 
-#[test]
+#[cargo_test]
 fn uninstall_multiple_and_specifying_bin() {
     cargo_process("uninstall foo bar --bin baz").with_status(101).with_stderr("error: A binary can only be associated with a single installed package, specifying multiple specs with --bin is redundant.").run();
 }
 
-#[test]
+#[cargo_test]
 fn uninstall_multiple_and_some_pkg_does_not_exist() {
     pkg("foo", "0.0.1");
 
@@ -1166,7 +1166,7 @@ error: some packages failed to uninstall
     assert_has_not_installed_exe(cargo_home(), "bar");
 }
 
-#[test]
+#[cargo_test]
 fn custom_target_dir_for_git_source() {
     let p = git::repo(&paths::root().join("foo"))
         .file("Cargo.toml", &basic_manifest("foo", "0.1.0"))
@@ -1185,7 +1185,7 @@ fn custom_target_dir_for_git_source() {
     assert!(paths::root().join("target/release").is_dir());
 }
 
-#[test]
+#[cargo_test]
 fn install_respects_lock_file() {
     // `cargo install` now requires --locked to use a Cargo.lock.
     Package::new("bar", "0.1.0").publish();
@@ -1224,7 +1224,7 @@ dependencies = [
     cargo_process("install --locked foo").run();
 }
 
-#[test]
+#[cargo_test]
 fn install_path_respects_lock_file() {
     // --path version of install_path_respects_lock_file, --locked is required
     // to use Cargo.lock.
@@ -1270,7 +1270,7 @@ dependencies = [
     p.cargo("install --path . --locked").run();
 }
 
-#[test]
+#[cargo_test]
 fn lock_file_path_deps_ok() {
     Package::new("bar", "0.1.0").publish();
 
@@ -1301,7 +1301,7 @@ dependencies = [
     cargo_process("install foo").run();
 }
 
-#[test]
+#[cargo_test]
 fn install_empty_argument() {
     // Bug 5229
     cargo_process("install")
@@ -1313,7 +1313,7 @@ fn install_empty_argument() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn git_repo_replace() {
     let p = git::repo(&paths::root().join("foo"))
         .file("Cargo.toml", &basic_manifest("foo", "0.1.0"))
@@ -1341,7 +1341,7 @@ fn git_repo_replace() {
         .contains(&format!("{}", new_rev)));
 }
 
-#[test]
+#[cargo_test]
 fn workspace_uses_workspace_target_dir() {
     let p = project()
         .file(
@@ -1377,7 +1377,7 @@ fn workspace_uses_workspace_target_dir() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn install_ignores_local_cargo_config() {
     pkg("bar", "0.0.1");
 
@@ -1396,7 +1396,7 @@ fn install_ignores_local_cargo_config() {
     assert_has_installed_exe(cargo_home(), "bar");
 }
 
-#[test]
+#[cargo_test]
 fn install_global_cargo_config() {
     pkg("bar", "0.0.1");
 
@@ -1417,7 +1417,7 @@ fn install_global_cargo_config() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn install_path_config() {
     project()
         .file(
@@ -1435,7 +1435,7 @@ fn install_path_config() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn install_version_req() {
     // Try using a few versionreq styles.
     pkg("foo", "0.0.3");

--- a/tests/testsuite/install_upgrade.rs
+++ b/tests/testsuite/install_upgrade.rs
@@ -106,7 +106,7 @@ fn validate_trackers(name: &str, version: &str, bins: &[&str]) {
     }
 }
 
-#[test]
+#[cargo_test]
 fn registry_upgrade() {
     // Installing and upgrading from a registry.
     pkg("foo", "1.0.0");
@@ -182,7 +182,7 @@ fn registry_upgrade() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn uninstall() {
     // Basic uninstall test.
     pkg("foo", "1.0.0");
@@ -198,7 +198,7 @@ fn uninstall() {
     assert_eq!(v1_table.get("v1").unwrap().as_table().unwrap().len(), 0);
 }
 
-#[test]
+#[cargo_test]
 fn upgrade_force() {
     pkg("foo", "1.0.0");
     cargo_process("install foo -Z install-upgrade")
@@ -221,7 +221,7 @@ fn upgrade_force() {
     validate_trackers("foo", "1.0.0", &["foo"]);
 }
 
-#[test]
+#[cargo_test]
 fn ambiguous_version_no_longer_allowed() {
     // Non-semver-requirement is not allowed for `--version`.
     pkg("foo", "1.0.0");
@@ -239,7 +239,7 @@ if you want to specify semver range, add an explicit qualifier, like ^1.0
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn path_is_always_dirty() {
     // --path should always reinstall.
     let p = project().file("src/main.rs", "fn main() {}").build();
@@ -252,7 +252,7 @@ fn path_is_always_dirty() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn fails_for_conflicts_unknown() {
     // If an untracked file is in the way, it should fail.
     pkg("foo", "1.0.0");
@@ -266,7 +266,7 @@ fn fails_for_conflicts_unknown() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn fails_for_conflicts_known() {
     // If the same binary exists in another package, it should fail.
     pkg("foo", "1.0.0");
@@ -285,7 +285,7 @@ fn fails_for_conflicts_known() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn supports_multiple_binary_names() {
     // Can individually install with --bin or --example
     Package::new("foo", "1.0.0")
@@ -324,7 +324,7 @@ fn supports_multiple_binary_names() {
     assert!(!installed_exe("a").exists());
 }
 
-#[test]
+#[cargo_test]
 fn v1_already_installed_fresh() {
     // Install with v1, then try to install again with v2.
     pkg("foo", "1.0.0");
@@ -335,7 +335,7 @@ fn v1_already_installed_fresh() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn v1_already_installed_dirty() {
     // Install with v1, then install a new version with v2.
     pkg("foo", "1.0.0");
@@ -349,7 +349,7 @@ fn v1_already_installed_dirty() {
     validate_trackers("foo", "1.0.1", &["foo"]);
 }
 
-#[test]
+#[cargo_test]
 fn change_features_rebuilds() {
     Package::new("foo", "1.0.0")
         .file(
@@ -395,7 +395,7 @@ fn change_features_rebuilds() {
     installed_process("foo").with_stdout("f1").run();
 }
 
-#[test]
+#[cargo_test]
 fn change_profile_rebuilds() {
     pkg("foo", "1.0.0");
     cargo_process("install foo -Z install-upgrade")
@@ -412,7 +412,7 @@ fn change_profile_rebuilds() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn change_target_rebuilds() {
     if cross_compile::disabled() {
         return;
@@ -431,7 +431,7 @@ fn change_target_rebuilds() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn change_bin_sets_rebuilds() {
     // Changing which bins in a multi-bin project should reinstall.
     Package::new("foo", "1.0.0")
@@ -467,7 +467,7 @@ fn change_bin_sets_rebuilds() {
     validate_trackers("foo", "1.0.0", &["foo", "x", "y"]);
 }
 
-#[test]
+#[cargo_test]
 fn forwards_compatible() {
     // Unknown fields should be preserved.
     pkg("foo", "1.0.0");
@@ -492,7 +492,7 @@ fn forwards_compatible() {
     );
 }
 
-#[test]
+#[cargo_test]
 fn v2_syncs() {
     // V2 inherits the installs from V1.
     pkg("one", "1.0.0");
@@ -560,7 +560,7 @@ two v1.0.0:
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn upgrade_git() {
     let git_project =
         git::new("foo", |project| project.file("src/main.rs", "fn main() {}")).unwrap();
@@ -602,7 +602,7 @@ fn upgrade_git() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn switch_sources() {
     // Installing what appears to be the same thing, but from different
     // sources should reinstall.
@@ -640,7 +640,7 @@ fn switch_sources() {
     installed_process("foo").with_stdout("git").run();
 }
 
-#[test]
+#[cargo_test]
 fn multiple_report() {
     // Testing the full output that indicates installed/ignored/replaced/summary.
     pkg("one", "1.0.0");
@@ -753,7 +753,7 @@ fn multiple_report() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn no_track_gated() {
     cargo_process("install --no-track foo")
         .masquerade_as_nightly_cargo()
@@ -764,7 +764,7 @@ fn no_track_gated() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn no_track() {
     pkg("foo", "1.0.0");
     cargo_process("install --no-track foo -Z install-upgrade")

--- a/tests/testsuite/jobserver.rs
+++ b/tests/testsuite/jobserver.rs
@@ -4,7 +4,7 @@ use std::thread;
 
 use crate::support::{cargo_exe, project};
 
-#[test]
+#[cargo_test]
 fn jobserver_exists() {
     let p = project()
         .file(
@@ -52,7 +52,7 @@ fn jobserver_exists() {
     p.cargo("build").run();
 }
 
-#[test]
+#[cargo_test]
 fn makes_jobserver_used() {
     let make = if cfg!(windows) {
         "mingw32-make"
@@ -164,7 +164,7 @@ all:
     child.join().unwrap();
 }
 
-#[test]
+#[cargo_test]
 fn jobserver_and_j() {
     let make = if cfg!(windows) {
         "mingw32-make"

--- a/tests/testsuite/list_targets.rs
+++ b/tests/testsuite/list_targets.rs
@@ -138,52 +138,52 @@ No tests available.
     }
 }
 
-#[test]
+#[cargo_test]
 fn build_list_targets() {
     list_targets_test("build", EXAMPLE | BIN | TEST | BENCH);
 }
 
-#[test]
+#[cargo_test]
 fn check_list_targets() {
     list_targets_test("check", EXAMPLE | BIN | TEST | BENCH);
 }
 
-#[test]
+#[cargo_test]
 fn doc_list_targets() {
     list_targets_test("doc", BIN);
 }
 
-#[test]
+#[cargo_test]
 fn fix_list_targets() {
     list_targets_test("fix", EXAMPLE | BIN | TEST | BENCH);
 }
 
-#[test]
+#[cargo_test]
 fn run_list_targets() {
     list_targets_test("run", EXAMPLE | BIN);
 }
 
-#[test]
+#[cargo_test]
 fn test_list_targets() {
     list_targets_test("test", EXAMPLE | BIN | TEST | BENCH);
 }
 
-#[test]
+#[cargo_test]
 fn bench_list_targets() {
     list_targets_test("bench", EXAMPLE | BIN | TEST | BENCH);
 }
 
-#[test]
+#[cargo_test]
 fn install_list_targets() {
     list_targets_test("install", EXAMPLE | BIN);
 }
 
-#[test]
+#[cargo_test]
 fn rustdoc_list_targets() {
     list_targets_test("rustdoc", EXAMPLE | BIN | TEST | BENCH);
 }
 
-#[test]
+#[cargo_test]
 fn rustc_list_targets() {
     list_targets_test("rustc", EXAMPLE | BIN | TEST | BENCH);
 }

--- a/tests/testsuite/local_registry.rs
+++ b/tests/testsuite/local_registry.rs
@@ -20,7 +20,7 @@ fn setup() {
     ));
 }
 
-#[test]
+#[cargo_test]
 fn simple() {
     setup();
     Package::new("bar", "0.0.1")
@@ -61,7 +61,7 @@ fn simple() {
     p.cargo("test").run();
 }
 
-#[test]
+#[cargo_test]
 fn depend_on_yanked() {
     setup();
     Package::new("bar", "0.0.1").local(true).publish();
@@ -100,7 +100,7 @@ fn depend_on_yanked() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn multiple_versions() {
     setup();
     Package::new("bar", "0.0.1").local(true).publish();
@@ -149,7 +149,7 @@ fn multiple_versions() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn multiple_names() {
     setup();
     Package::new("bar", "0.0.1")
@@ -202,7 +202,7 @@ fn multiple_names() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn interdependent() {
     setup();
     Package::new("bar", "0.0.1")
@@ -256,7 +256,7 @@ fn interdependent() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn path_dep_rewritten() {
     setup();
     Package::new("bar", "0.0.1")
@@ -324,7 +324,7 @@ fn path_dep_rewritten() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn invalid_dir_bad() {
     setup();
     let p = project()
@@ -373,7 +373,7 @@ Caused by:
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn different_directory_replacing_the_registry_is_bad() {
     setup();
 
@@ -432,7 +432,7 @@ unable to verify that `bar v0.0.1` is the same as when the lockfile was generate
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn crates_io_registry_url_is_optional() {
     let root = paths::root();
     t!(fs::create_dir(&root.join(".cargo")));

--- a/tests/testsuite/lockfile_compat.rs
+++ b/tests/testsuite/lockfile_compat.rs
@@ -2,7 +2,7 @@ use crate::support::git;
 use crate::support::registry::Package;
 use crate::support::{basic_manifest, lines_match, project};
 
-#[test]
+#[cargo_test]
 fn oldest_lockfile_still_works() {
     let cargo_commands = vec!["build", "update"];
     for cargo_command in cargo_commands {
@@ -72,7 +72,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
     assert_eq!(lock.lines().count(), expected_lockfile.lines().count());
 }
 
-#[test]
+#[cargo_test]
 fn frozen_flag_preserves_old_lockfile() {
     let cksum = Package::new("bar", "0.1.0").publish();
 
@@ -122,7 +122,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
     assert_eq!(lock.lines().count(), old_lockfile.lines().count());
 }
 
-#[test]
+#[cargo_test]
 fn totally_wild_checksums_works() {
     Package::new("bar", "0.1.0").publish();
 
@@ -188,7 +188,7 @@ dependencies = [
     ));
 }
 
-#[test]
+#[cargo_test]
 fn wrong_checksum_is_an_error() {
     Package::new("bar", "0.1.0").publish();
 
@@ -251,7 +251,7 @@ unable to verify that `bar v0.1.0` is the same as when the lockfile was generate
 // If the checksum is unlisted in the lock file (e.g., <none>) yet we can
 // calculate it (e.g., it's a registry dep), then we should in theory just fill
 // it in.
-#[test]
+#[cargo_test]
 fn unlisted_checksum_is_bad_if_we_calculate() {
     Package::new("bar", "0.1.0").publish();
 
@@ -313,7 +313,7 @@ this could be indicative of a few possible situations:
 
 // If the checksum is listed in the lock file yet we cannot calculate it (e.g.,
 // Git dependencies as of today), then make sure we choke.
-#[test]
+#[cargo_test]
 fn listed_checksum_bad_if_we_cannot_compute() {
     let git = git::new("bar", |p| {
         p.file("Cargo.toml", &basic_manifest("bar", "0.1.0"))
@@ -384,7 +384,7 @@ unable to verify that `bar v0.1.0 ([..])` is the same as when the lockfile was g
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn current_lockfile_format() {
     Package::new("bar", "0.1.0").publish();
 
@@ -432,7 +432,7 @@ dependencies = [
     assert_eq!(actual.lines().count(), expected.lines().count());
 }
 
-#[test]
+#[cargo_test]
 fn lockfile_without_root() {
     Package::new("bar", "0.1.0").publish();
 
@@ -476,7 +476,7 @@ dependencies = [
     assert!(lock.starts_with(lockfile.trim()));
 }
 
-#[test]
+#[cargo_test]
 fn locked_correct_error() {
     Package::new("bar", "0.1.0").publish();
 

--- a/tests/testsuite/login.rs
+++ b/tests/testsuite/login.rs
@@ -57,7 +57,7 @@ fn check_token(expected_token: &str, registry: Option<&str>) -> bool {
     }
 }
 
-#[test]
+#[cargo_test]
 fn login_with_old_credentials() {
     registry::init();
 
@@ -70,7 +70,7 @@ fn login_with_old_credentials() {
     assert!(check_token(TOKEN, None));
 }
 
-#[test]
+#[cargo_test]
 fn login_with_new_credentials() {
     registry::init();
     setup_new_credentials();
@@ -84,13 +84,13 @@ fn login_with_new_credentials() {
     assert!(check_token(TOKEN, None));
 }
 
-#[test]
+#[cargo_test]
 fn login_with_old_and_new_credentials() {
     setup_new_credentials();
     login_with_old_credentials();
 }
 
-#[test]
+#[cargo_test]
 fn login_without_credentials() {
     registry::init();
     cargo_process("login --host")
@@ -102,7 +102,7 @@ fn login_without_credentials() {
     assert!(check_token(TOKEN, None));
 }
 
-#[test]
+#[cargo_test]
 fn new_credentials_is_used_instead_old() {
     registry::init();
     setup_new_credentials();
@@ -118,7 +118,7 @@ fn new_credentials_is_used_instead_old() {
     assert_eq!(token.unwrap(), TOKEN);
 }
 
-#[test]
+#[cargo_test]
 fn registry_credentials() {
     registry::init();
     setup_new_credentials();

--- a/tests/testsuite/main.rs
+++ b/tests/testsuite/main.rs
@@ -98,7 +98,7 @@ mod version;
 mod warn_on_failure;
 mod workspaces;
 
-#[test]
+#[cargo_test]
 fn aaa_trigger_cross_compile_disabled_check() {
     // This triggers the cross compile disabled check to run ASAP, see #5141
     support::cross_compile::disabled();

--- a/tests/testsuite/main.rs
+++ b/tests/testsuite/main.rs
@@ -7,6 +7,9 @@
 #![warn(clippy::redundant_clone)]
 
 #[macro_use]
+extern crate cargo_test_macro;
+
+#[macro_use]
 mod support;
 
 mod alt_registry;

--- a/tests/testsuite/member_errors.rs
+++ b/tests/testsuite/member_errors.rs
@@ -9,7 +9,7 @@ use crate::support::registry;
 
 /// Tests inclusion of a `ManifestError` pointing to a member manifest
 /// when that manifest fails to deserialize.
-#[test]
+#[cargo_test]
 fn toml_deserialize_manifest_error() {
     let p = project()
         .file(
@@ -58,7 +58,7 @@ fn toml_deserialize_manifest_error() {
 
 /// Tests inclusion of a `ManifestError` pointing to a member manifest
 /// when that manifest has an invalid dependency path.
-#[test]
+#[cargo_test]
 fn member_manifest_path_io_error() {
     let p = project()
         .file(
@@ -108,7 +108,7 @@ fn member_manifest_path_io_error() {
 }
 
 /// Tests dependency version errors provide which package failed via a `ResolveError`.
-#[test]
+#[cargo_test]
 fn member_manifest_version_error() {
     let p = project()
         .file(

--- a/tests/testsuite/metabuild.rs
+++ b/tests/testsuite/metabuild.rs
@@ -5,7 +5,7 @@ use crate::support::{
 use serde_json;
 use std::str;
 
-#[test]
+#[cargo_test]
 fn metabuild_gated() {
     let p = project()
         .file(
@@ -73,7 +73,7 @@ fn basic_project() -> Project {
         .build()
 }
 
-#[test]
+#[cargo_test]
 fn metabuild_basic() {
     let p = basic_project();
     p.cargo("build -vv")
@@ -83,7 +83,7 @@ fn metabuild_basic() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn metabuild_error_both() {
     let p = project()
         .file(
@@ -122,7 +122,7 @@ Caused by:
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn metabuild_missing_dep() {
     let p = project()
         .file(
@@ -151,7 +151,7 @@ Caused by:
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn metabuild_optional_dep() {
     let p = project()
         .file(
@@ -186,7 +186,7 @@ fn metabuild_optional_dep() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn metabuild_lib_name() {
     // Test when setting `name` on [lib].
     let p = project()
@@ -226,7 +226,7 @@ fn metabuild_lib_name() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn metabuild_fresh() {
     if is_coarse_mtime() {
         // This test doesn't work on coarse mtimes very well. Because the
@@ -277,7 +277,7 @@ fn metabuild_fresh() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn metabuild_links() {
     let p = project()
         .file(
@@ -312,7 +312,7 @@ fn metabuild_links() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn metabuild_override() {
     let p = project()
         .file(
@@ -350,7 +350,7 @@ fn metabuild_override() {
     p.cargo("build -vv").masquerade_as_nightly_cargo().run();
 }
 
-#[test]
+#[cargo_test]
 fn metabuild_workspace() {
     let p = project()
         .file(
@@ -418,7 +418,7 @@ fn metabuild_workspace() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn metabuild_metadata() {
     // The metabuild Target is filtered out of the `metadata` results.
     let p = basic_project();
@@ -444,7 +444,7 @@ fn metabuild_metadata() {
     assert_eq!(mb_info, ["mb", "mb-other"]);
 }
 
-#[test]
+#[cargo_test]
 fn metabuild_build_plan() {
     let p = basic_project();
 
@@ -547,7 +547,7 @@ fn metabuild_build_plan() {
     assert_eq!(p.glob("target/.metabuild/metabuild-foo-*.rs").count(), 1);
 }
 
-#[test]
+#[cargo_test]
 fn metabuild_two_versions() {
     // Two versions of a metabuild dep with the same name.
     let p = project()
@@ -625,7 +625,7 @@ fn metabuild_two_versions() {
     );
 }
 
-#[test]
+#[cargo_test]
 fn metabuild_external_dependency() {
     Package::new("mb", "1.0.0")
         .file("Cargo.toml", &basic_manifest("mb", "1.0.0"))
@@ -674,7 +674,7 @@ fn metabuild_external_dependency() {
     assert_eq!(p.glob("target/.metabuild/metabuild-dep-*.rs").count(), 1);
 }
 
-#[test]
+#[cargo_test]
 fn metabuild_json_artifact() {
     let p = basic_project();
     p.cargo("build --message-format=json")
@@ -718,7 +718,7 @@ fn metabuild_json_artifact() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn metabuild_failed_build_json() {
     let p = basic_project();
     // Modify the metabuild dep so that it fails to compile.

--- a/tests/testsuite/metadata.rs
+++ b/tests/testsuite/metadata.rs
@@ -1,7 +1,7 @@
 use crate::support::registry::Package;
 use crate::support::{basic_bin_manifest, basic_lib_manifest, main_file, project};
 
-#[test]
+#[cargo_test]
 fn cargo_metadata_simple() {
     let p = project()
         .file("src/foo.rs", "")
@@ -70,7 +70,7 @@ fn cargo_metadata_simple() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn cargo_metadata_warns_on_implicit_version() {
     let p = project()
         .file("src/foo.rs", "")
@@ -82,7 +82,7 @@ fn cargo_metadata_warns_on_implicit_version() {
     p.cargo("metadata --format-version 1").with_stderr("").run();
 }
 
-#[test]
+#[cargo_test]
 fn library_with_several_crate_types() {
     let p = project()
         .file("src/lib.rs", "")
@@ -161,7 +161,7 @@ crate-type = ["lib", "staticlib"]
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn library_with_features() {
     let p = project()
         .file("src/lib.rs", "")
@@ -249,7 +249,7 @@ optional_feat = []
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn cargo_metadata_with_deps_and_version() {
     let p = project()
         .file("src/foo.rs", "")
@@ -516,7 +516,7 @@ fn cargo_metadata_with_deps_and_version() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn example() {
     let p = project()
         .file("src/lib.rs", "")
@@ -600,7 +600,7 @@ name = "ex"
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn example_lib() {
     let p = project()
         .file("src/lib.rs", "")
@@ -685,7 +685,7 @@ crate-type = ["rlib", "dylib"]
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn workspace_metadata() {
     let p = project()
         .file(
@@ -797,7 +797,7 @@ fn workspace_metadata() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn workspace_metadata_no_deps() {
     let p = project()
         .file(
@@ -893,7 +893,7 @@ fn workspace_metadata_no_deps() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn cargo_metadata_with_invalid_manifest() {
     let p = project().file("Cargo.toml", "").build();
 
@@ -948,7 +948,7 @@ const MANIFEST_OUTPUT: &str = r#"
     "workspace_root": "[..]/foo"
 }"#;
 
-#[test]
+#[cargo_test]
 fn cargo_metadata_no_deps_path_to_cargo_toml_relative() {
     let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
@@ -961,7 +961,7 @@ fn cargo_metadata_no_deps_path_to_cargo_toml_relative() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn cargo_metadata_no_deps_path_to_cargo_toml_absolute() {
     let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
@@ -975,7 +975,7 @@ fn cargo_metadata_no_deps_path_to_cargo_toml_absolute() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn cargo_metadata_no_deps_path_to_cargo_toml_parent_relative() {
     let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
@@ -992,7 +992,7 @@ fn cargo_metadata_no_deps_path_to_cargo_toml_parent_relative() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn cargo_metadata_no_deps_path_to_cargo_toml_parent_absolute() {
     let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
@@ -1010,7 +1010,7 @@ fn cargo_metadata_no_deps_path_to_cargo_toml_parent_absolute() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn cargo_metadata_no_deps_cwd() {
     let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
@@ -1022,7 +1022,7 @@ fn cargo_metadata_no_deps_cwd() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn cargo_metadata_bad_version() {
     let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
@@ -1040,7 +1040,7 @@ error: '2' isn't a valid value for '--format-version <VERSION>'
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn multiple_features() {
     let p = project()
         .file(
@@ -1062,7 +1062,7 @@ fn multiple_features() {
     p.cargo("metadata --features").arg("a b").run();
 }
 
-#[test]
+#[cargo_test]
 fn package_metadata() {
     let p = project()
         .file(
@@ -1134,7 +1134,7 @@ fn package_metadata() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn cargo_metadata_path_to_cargo_toml_project() {
     let p = project()
         .file(
@@ -1219,7 +1219,7 @@ fn cargo_metadata_path_to_cargo_toml_project() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn package_edition_2018() {
     let p = project()
         .file("src/lib.rs", "")
@@ -1299,7 +1299,7 @@ fn package_edition_2018() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn target_edition_2018() {
     let p = project()
         .file("src/lib.rs", "")
@@ -1395,7 +1395,7 @@ fn target_edition_2018() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn rename_dependency() {
     Package::new("bar", "0.1.0").publish();
     Package::new("bar", "0.2.0").publish();
@@ -1596,7 +1596,7 @@ fn rename_dependency() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn metadata_links() {
     let p = project()
         .file(
@@ -1687,7 +1687,7 @@ fn metadata_links() {
         .run()
 }
 
-#[test]
+#[cargo_test]
 fn deps_with_bin_only() {
     let p = project()
         .file(

--- a/tests/testsuite/net_config.rs
+++ b/tests/testsuite/net_config.rs
@@ -1,6 +1,6 @@
 use crate::support::project;
 
-#[test]
+#[cargo_test]
 fn net_retry_loads_from_config() {
     let p = project()
         .file(
@@ -36,7 +36,7 @@ fn net_retry_loads_from_config() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn net_retry_git_outputs_warning() {
     let p = project()
         .file(

--- a/tests/testsuite/new.rs
+++ b/tests/testsuite/new.rs
@@ -12,7 +12,7 @@ fn create_empty_gitconfig() {
     File::create(gitconfig).unwrap();
 }
 
-#[test]
+#[cargo_test]
 fn simple_lib() {
     cargo_process("new --lib foo --vcs none --edition 2015")
         .env("USER", "foo")
@@ -45,7 +45,7 @@ mod tests {
     cargo_process("build").cwd(&paths::root().join("foo")).run();
 }
 
-#[test]
+#[cargo_test]
 fn simple_bin() {
     cargo_process("new --bin foo --edition 2015")
         .env("USER", "foo")
@@ -62,7 +62,7 @@ fn simple_bin() {
         .is_file());
 }
 
-#[test]
+#[cargo_test]
 fn both_lib_and_bin() {
     cargo_process("new --lib --bin foo")
         .env("USER", "foo")
@@ -71,7 +71,7 @@ fn both_lib_and_bin() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn simple_git() {
     cargo_process("new --lib foo --edition 2015")
         .env("USER", "foo")
@@ -94,7 +94,7 @@ fn simple_git() {
     cargo_process("build").cwd(&paths::root().join("foo")).run();
 }
 
-#[test]
+#[cargo_test]
 fn no_argument() {
     cargo_process("new")
         .with_status(1)
@@ -107,7 +107,7 @@ error: The following required arguments were not provided:
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn existing() {
     let dst = paths::root().join("foo");
     fs::create_dir(&dst).unwrap();
@@ -120,7 +120,7 @@ fn existing() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn invalid_characters() {
     cargo_process("new foo.rs")
         .with_status(101)
@@ -132,7 +132,7 @@ use --name to override crate name",
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn reserved_name() {
     cargo_process("new test")
         .with_status(101)
@@ -144,7 +144,7 @@ fn reserved_name() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn reserved_binary_name() {
     cargo_process("new --bin incremental")
         .with_status(101)
@@ -156,7 +156,7 @@ fn reserved_binary_name() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn keyword_name() {
     cargo_process("new pub")
         .with_status(101)
@@ -168,7 +168,7 @@ fn keyword_name() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn finds_author_user() {
     create_empty_gitconfig();
     cargo_process("new foo").env("USER", "foo").run();
@@ -182,7 +182,7 @@ fn finds_author_user() {
     assert!(contents.contains(r#"authors = ["foo"]"#));
 }
 
-#[test]
+#[cargo_test]
 fn finds_author_user_escaped() {
     create_empty_gitconfig();
     cargo_process("new foo").env("USER", "foo \"bar\"").run();
@@ -196,7 +196,7 @@ fn finds_author_user_escaped() {
     assert!(contents.contains(r#"authors = ["foo \"bar\""]"#));
 }
 
-#[test]
+#[cargo_test]
 fn finds_author_username() {
     create_empty_gitconfig();
     cargo_process("new foo")
@@ -213,7 +213,7 @@ fn finds_author_username() {
     assert!(contents.contains(r#"authors = ["foo"]"#));
 }
 
-#[test]
+#[cargo_test]
 fn finds_author_priority() {
     cargo_process("new foo")
         .env("USER", "bar2")
@@ -231,7 +231,7 @@ fn finds_author_priority() {
     assert!(contents.contains(r#"authors = ["bar <baz>"]"#));
 }
 
-#[test]
+#[cargo_test]
 fn finds_author_email() {
     create_empty_gitconfig();
     cargo_process("new foo")
@@ -248,7 +248,7 @@ fn finds_author_email() {
     assert!(contents.contains(r#"authors = ["bar <baz>"]"#));
 }
 
-#[test]
+#[cargo_test]
 fn finds_author_git() {
     git_process("config --global user.name bar").exec().unwrap();
     git_process("config --global user.email baz")
@@ -265,7 +265,7 @@ fn finds_author_git() {
     assert!(contents.contains(r#"authors = ["bar <baz>"]"#));
 }
 
-#[test]
+#[cargo_test]
 fn finds_local_author_git() {
     git_process("init").exec().unwrap();
     git_process("config --global user.name foo").exec().unwrap();
@@ -287,7 +287,7 @@ fn finds_local_author_git() {
     assert!(contents.contains(r#"authors = ["bar <baz>"]"#));
 }
 
-#[test]
+#[cargo_test]
 fn finds_git_email() {
     cargo_process("new foo")
         .env("GIT_AUTHOR_NAME", "foo")
@@ -303,7 +303,7 @@ fn finds_git_email() {
     assert!(contents.contains(r#"authors = ["foo <gitfoo>"]"#), contents);
 }
 
-#[test]
+#[cargo_test]
 fn finds_git_author() {
     create_empty_gitconfig();
     cargo_process("new foo")
@@ -320,7 +320,7 @@ fn finds_git_author() {
     assert!(contents.contains(r#"authors = ["gitfoo"]"#));
 }
 
-#[test]
+#[cargo_test]
 fn author_prefers_cargo() {
     git_process("config --global user.name foo").exec().unwrap();
     git_process("config --global user.email bar")
@@ -352,7 +352,7 @@ fn author_prefers_cargo() {
     assert!(!root.join("foo/.gitignore").exists());
 }
 
-#[test]
+#[cargo_test]
 fn strip_angle_bracket_author_email() {
     create_empty_gitconfig();
     cargo_process("new foo")
@@ -369,7 +369,7 @@ fn strip_angle_bracket_author_email() {
     assert!(contents.contains(r#"authors = ["bar <baz>"]"#));
 }
 
-#[test]
+#[cargo_test]
 fn git_prefers_command_line() {
     let root = paths::root();
     fs::create_dir(&root.join(".cargo")).unwrap();
@@ -389,7 +389,7 @@ fn git_prefers_command_line() {
     assert!(paths::root().join("foo/.gitignore").exists());
 }
 
-#[test]
+#[cargo_test]
 fn subpackage_no_git() {
     cargo_process("new foo").env("USER", "foo").run();
 
@@ -410,7 +410,7 @@ fn subpackage_no_git() {
         .is_file());
 }
 
-#[test]
+#[cargo_test]
 fn subpackage_git_with_gitignore() {
     cargo_process("new foo").env("USER", "foo").run();
 
@@ -434,7 +434,7 @@ fn subpackage_git_with_gitignore() {
         .is_file());
 }
 
-#[test]
+#[cargo_test]
 fn subpackage_git_with_vcs_arg() {
     cargo_process("new foo").env("USER", "foo").run();
 
@@ -452,7 +452,7 @@ fn subpackage_git_with_vcs_arg() {
         .is_file());
 }
 
-#[test]
+#[cargo_test]
 fn unknown_flags() {
     cargo_process("new foo --flag")
         .with_status(1)
@@ -462,7 +462,7 @@ fn unknown_flags() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn explicit_invalid_name_not_suggested() {
     cargo_process("new --name 10-invalid a")
         .with_status(101)
@@ -470,7 +470,7 @@ fn explicit_invalid_name_not_suggested() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn explicit_project_name() {
     cargo_process("new --lib foo --name bar")
         .env("USER", "foo")
@@ -478,7 +478,7 @@ fn explicit_project_name() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn new_with_edition_2015() {
     cargo_process("new --edition 2015 foo")
         .env("USER", "foo")
@@ -487,7 +487,7 @@ fn new_with_edition_2015() {
     assert!(manifest.contains("edition = \"2015\""));
 }
 
-#[test]
+#[cargo_test]
 fn new_with_edition_2018() {
     cargo_process("new --edition 2018 foo")
         .env("USER", "foo")
@@ -496,14 +496,14 @@ fn new_with_edition_2018() {
     assert!(manifest.contains("edition = \"2018\""));
 }
 
-#[test]
+#[cargo_test]
 fn new_default_edition() {
     cargo_process("new foo").env("USER", "foo").run();
     let manifest = fs::read_to_string(paths::root().join("foo/Cargo.toml")).unwrap();
     assert!(manifest.contains("edition = \"2018\""));
 }
 
-#[test]
+#[cargo_test]
 fn new_with_bad_edition() {
     cargo_process("new --edition something_else foo")
         .env("USER", "foo")
@@ -512,7 +512,7 @@ fn new_with_bad_edition() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn new_with_blank_email() {
     cargo_process("new foo")
         .env("CARGO_NAME", "Sen")
@@ -523,7 +523,7 @@ fn new_with_blank_email() {
     assert!(contents.contains(r#"authors = ["Sen"]"#), contents);
 }
 
-#[test]
+#[cargo_test]
 fn new_with_reference_link() {
     cargo_process("new foo").env("USER", "foo").run();
 

--- a/tests/testsuite/offline.rs
+++ b/tests/testsuite/offline.rs
@@ -1,7 +1,7 @@
 use crate::support::{basic_manifest, git, main_file, path2url, project, registry::Package};
 use std::fs;
 
-#[test]
+#[cargo_test]
 fn offline_unused_target_dep() {
     // --offline with a target dependency that is not used and not downloaded.
     Package::new("unused_dep", "1.0.0").publish();
@@ -31,7 +31,7 @@ fn offline_unused_target_dep() {
     p.cargo("build --offline").run();
 }
 
-#[test]
+#[cargo_test]
 fn offline_missing_optional() {
     Package::new("opt_dep", "1.0.0").publish();
     let p = project()
@@ -67,7 +67,7 @@ Caused by:
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn cargo_compile_path_with_offline() {
     let p = project()
         .file(
@@ -90,7 +90,7 @@ fn cargo_compile_path_with_offline() {
     p.cargo("build --offline").run();
 }
 
-#[test]
+#[cargo_test]
 fn cargo_compile_with_downloaded_dependency_with_offline() {
     Package::new("present_dep", "1.2.3")
         .file("Cargo.toml", &basic_manifest("present_dep", "1.2.3"))
@@ -140,7 +140,7 @@ fn cargo_compile_with_downloaded_dependency_with_offline() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn cargo_compile_offline_not_try_update() {
     let p = project()
         .at("bar")
@@ -182,7 +182,7 @@ project directory before going offline.
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn compile_offline_without_maxvers_cached() {
     Package::new("present_dep", "1.2.1").publish();
     Package::new("present_dep", "1.2.2").publish();
@@ -251,7 +251,7 @@ fn main(){
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn cargo_compile_forbird_git_httpsrepo_offline() {
     let p = project()
         .file(
@@ -280,7 +280,7 @@ Caused by:
   can't checkout from 'https://github.com/some_user/dep1.git': you are in the offline mode (--offline)").run();
 }
 
-#[test]
+#[cargo_test]
 fn compile_offline_while_transitive_dep_not_cached() {
     let baz = Package::new("baz", "1.0.0");
     let baz_path = baz.archive_dst();
@@ -329,7 +329,7 @@ Caused by:
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn update_offline() {
     let p = project()
         .file(
@@ -352,7 +352,7 @@ fn update_offline() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn cargo_compile_offline_with_cached_git_dep() {
     let git_project = git::new("dep1", |project| {
         project
@@ -480,7 +480,7 @@ fn cargo_compile_offline_with_cached_git_dep() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn offline_resolve_optional_fail() {
     // Example where resolve fails offline.
     //

--- a/tests/testsuite/out_dir.rs
+++ b/tests/testsuite/out_dir.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 use crate::support::sleep_ms;
 use crate::support::{basic_manifest, project};
 
-#[test]
+#[cargo_test]
 fn binary_with_debug() {
     let p = project()
         .file("src/main.rs", r#"fn main() { println!("Hello, World!") }"#)
@@ -22,7 +22,7 @@ fn binary_with_debug() {
     );
 }
 
-#[test]
+#[cargo_test]
 fn static_library_with_debug() {
     let p = project()
         .file(
@@ -57,7 +57,7 @@ fn static_library_with_debug() {
     );
 }
 
-#[test]
+#[cargo_test]
 fn dynamic_library_with_debug() {
     let p = project()
         .file(
@@ -92,7 +92,7 @@ fn dynamic_library_with_debug() {
     );
 }
 
-#[test]
+#[cargo_test]
 fn rlib_with_debug() {
     let p = project()
         .file(
@@ -126,7 +126,7 @@ fn rlib_with_debug() {
     );
 }
 
-#[test]
+#[cargo_test]
 fn include_only_the_binary_from_the_current_package() {
     let p = project()
         .file(
@@ -169,7 +169,7 @@ fn include_only_the_binary_from_the_current_package() {
     );
 }
 
-#[test]
+#[cargo_test]
 fn out_dir_is_a_file() {
     let p = project()
         .file("src/main.rs", r#"fn main() { println!("Hello, World!") }"#)
@@ -183,7 +183,7 @@ fn out_dir_is_a_file() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn replaces_artifacts() {
     let p = project()
         .file("src/main.rs", r#"fn main() { println!("foo") }"#)
@@ -213,7 +213,7 @@ fn replaces_artifacts() {
     .run();
 }
 
-#[test]
+#[cargo_test]
 fn avoid_build_scripts() {
     let p = project()
         .file(

--- a/tests/testsuite/overrides.rs
+++ b/tests/testsuite/overrides.rs
@@ -3,7 +3,7 @@ use crate::support::paths;
 use crate::support::registry::Package;
 use crate::support::{basic_manifest, project};
 
-#[test]
+#[cargo_test]
 fn override_simple() {
     Package::new("bar", "0.1.0").publish();
 
@@ -50,7 +50,7 @@ fn override_simple() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn missing_version() {
     let p = project()
         .file(
@@ -84,7 +84,7 @@ Caused by:
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn invalid_semver_version() {
     let p = project()
         .file(
@@ -118,7 +118,7 @@ Caused by:
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn different_version() {
     Package::new("bar", "0.2.0").publish();
     Package::new("bar", "0.1.0").publish();
@@ -155,7 +155,7 @@ Caused by:
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn transitive() {
     Package::new("bar", "0.1.0").publish();
     Package::new("baz", "0.2.0")
@@ -208,7 +208,7 @@ fn transitive() {
     p.cargo("build").with_stdout("").run();
 }
 
-#[test]
+#[cargo_test]
 fn persists_across_rebuilds() {
     Package::new("bar", "0.1.0").publish();
 
@@ -257,7 +257,7 @@ fn persists_across_rebuilds() {
     p.cargo("build").with_stdout("").run();
 }
 
-#[test]
+#[cargo_test]
 fn replace_registry_with_path() {
     Package::new("bar", "0.1.0").publish();
 
@@ -301,7 +301,7 @@ fn replace_registry_with_path() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn use_a_spec_to_select() {
     Package::new("baz", "0.1.1")
         .file("src/lib.rs", "pub fn baz1() {}")
@@ -372,7 +372,7 @@ fn use_a_spec_to_select() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn override_adds_some_deps() {
     Package::new("baz", "0.1.1").publish();
     Package::new("bar", "0.1.0").publish();
@@ -453,7 +453,7 @@ fn override_adds_some_deps() {
     p.cargo("build").with_stdout("").run();
 }
 
-#[test]
+#[cargo_test]
 fn locked_means_locked_yes_no_seriously_i_mean_locked() {
     // this in theory exercises #2041
     Package::new("baz", "0.1.0").publish();
@@ -505,7 +505,7 @@ fn locked_means_locked_yes_no_seriously_i_mean_locked() {
     p.cargo("build").with_stdout("").run();
 }
 
-#[test]
+#[cargo_test]
 fn override_wrong_name() {
     Package::new("baz", "0.1.0").publish();
 
@@ -550,7 +550,7 @@ version required: = 0.1.0
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn override_with_nothing() {
     Package::new("bar", "0.1.0").publish();
 
@@ -598,7 +598,7 @@ Caused by:
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn override_wrong_version() {
     let p = project()
         .file(
@@ -629,7 +629,7 @@ Caused by:
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn multiple_specs() {
     Package::new("bar", "0.1.0").publish();
 
@@ -680,7 +680,7 @@ both specifications match: bar v0.1.0
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn test_override_dep() {
     Package::new("bar", "0.1.0").publish();
 
@@ -724,7 +724,7 @@ Please re-run this command with [..]
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn update() {
     Package::new("bar", "0.1.0").publish();
 
@@ -768,7 +768,7 @@ fn update() {
 
 // foo -> near -> far
 // near is overridden with itself
-#[test]
+#[cargo_test]
 fn no_override_self() {
     let deps = git::repo(&paths::root().join("override"))
         .file("far/Cargo.toml", &basic_manifest("far", "0.1.0"))
@@ -813,7 +813,7 @@ fn no_override_self() {
     p.cargo("build --verbose").run();
 }
 
-#[test]
+#[cargo_test]
 fn broken_path_override_warns() {
     Package::new("bar", "0.1.0").publish();
     Package::new("bar", "0.2.0").publish();
@@ -891,7 +891,7 @@ https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#overridin
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn override_an_override() {
     Package::new("chrono", "0.2.0")
         .dep("serde", "< 0.9")
@@ -1001,7 +1001,7 @@ fn override_an_override() {
     p.cargo("build -v").run();
 }
 
-#[test]
+#[cargo_test]
 fn overriding_nonexistent_no_spurious() {
     Package::new("bar", "0.1.0").dep("baz", "0.1").publish();
     Package::new("baz", "0.1.0").publish();
@@ -1059,7 +1059,7 @@ fn overriding_nonexistent_no_spurious() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn no_warnings_when_replace_is_used_in_another_workspace_member() {
     Package::new("bar", "0.1.0").publish();
     Package::new("baz", "0.1.0").publish();
@@ -1118,7 +1118,7 @@ fn no_warnings_when_replace_is_used_in_another_workspace_member() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn override_to_path_dep() {
     Package::new("bar", "0.1.0").dep("baz", "0.1").publish();
     Package::new("baz", "0.1.0").publish();
@@ -1158,7 +1158,7 @@ fn override_to_path_dep() {
     p.cargo("build").run();
 }
 
-#[test]
+#[cargo_test]
 fn replace_to_path_dep() {
     Package::new("bar", "0.1.0").dep("baz", "0.1").publish();
     Package::new("baz", "0.1.0").publish();
@@ -1203,7 +1203,7 @@ fn replace_to_path_dep() {
     p.cargo("build").run();
 }
 
-#[test]
+#[cargo_test]
 fn paths_ok_with_optional() {
     Package::new("baz", "0.1.0").publish();
 
@@ -1261,7 +1261,7 @@ fn paths_ok_with_optional() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn paths_add_optional_bad() {
     Package::new("baz", "0.1.0").publish();
 
@@ -1307,7 +1307,7 @@ dependencies; the dependency on `baz` was either added or\
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn override_with_default_feature() {
     Package::new("another", "0.1.0").publish();
     Package::new("another", "0.1.1").dep("bar", "0.1").publish();
@@ -1369,7 +1369,7 @@ fn override_with_default_feature() {
     p.cargo("run").run();
 }
 
-#[test]
+#[cargo_test]
 fn override_plus_dep() {
     Package::new("bar", "0.1.0").publish();
 

--- a/tests/testsuite/package.rs
+++ b/tests/testsuite/package.rs
@@ -11,7 +11,7 @@ use crate::support::{
 };
 use git2;
 
-#[test]
+#[cargo_test]
 fn simple() {
     let p = project()
         .file(
@@ -62,7 +62,7 @@ src/main.rs
     );
 }
 
-#[test]
+#[cargo_test]
 fn metadata_warning() {
     let p = project().file("src/main.rs", "fn main() {}").build();
     p.cargo("package")
@@ -132,7 +132,7 @@ See https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn package_verbose() {
     let root = paths::root().join("all");
     let repo = git::repo(&root)
@@ -196,7 +196,7 @@ See https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn package_verification() {
     let p = project().file("src/main.rs", "fn main() {}").build();
     p.cargo("build").run();
@@ -214,7 +214,7 @@ See https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn vcs_file_collision() {
     let p = project().build();
     let _ = git::repo(&paths::root().join("foo"))
@@ -253,7 +253,7 @@ in package source
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn path_dependency_no_version() {
     let p = project()
         .file(
@@ -288,7 +288,7 @@ dependency `bar` does not specify a version.
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn exclude() {
     let root = paths::root().join("exclude");
     let repo = git::repo(&root)
@@ -418,7 +418,7 @@ src/main.rs
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn include() {
     let root = paths::root().join("include");
     let repo = git::repo(&root)
@@ -456,7 +456,7 @@ See https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn package_lib_with_bin() {
     let p = project()
         .file("src/main.rs", "extern crate foo; fn main() {}")
@@ -466,7 +466,7 @@ fn package_lib_with_bin() {
     p.cargo("package -v").run();
 }
 
-#[test]
+#[cargo_test]
 fn package_git_submodule() {
     let project = git::new("foo", |project| {
         project
@@ -510,7 +510,7 @@ fn package_git_submodule() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn no_duplicates_from_modified_tracked_files() {
     let root = paths::root().join("all");
     let p = git::repo(&root)
@@ -533,7 +533,7 @@ src/main.rs
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn ignore_nested() {
     let cargo_toml = r#"
             [project]
@@ -589,7 +589,7 @@ src[..]main.rs
 
 // Windows doesn't allow these characters in filenames.
 #[cfg(unix)]
-#[test]
+#[cargo_test]
 fn package_weird_characters() {
     let p = project()
         .file("src/main.rs", r#"fn main() { println!("hello"); }"#)
@@ -612,7 +612,7 @@ Caused by:
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn repackage_on_source_change() {
     let p = project()
         .file("src/main.rs", r#"fn main() { println!("hello"); }"#)
@@ -657,7 +657,7 @@ See [..]
     );
 }
 
-#[test]
+#[cargo_test]
 #[cfg(unix)]
 fn broken_symlink() {
     use std::os::unix::fs;
@@ -697,7 +697,7 @@ Caused by:
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn do_not_package_if_repository_is_dirty() {
     let p = project().build();
 
@@ -750,7 +750,7 @@ to proceed despite this, pass the `--allow-dirty` flag
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn generated_manifest() {
     Package::new("abc", "1.0.0").publish();
     Package::new("def", "1.0.0").alternative(true).publish();
@@ -835,7 +835,7 @@ version = "1.0"
     );
 }
 
-#[test]
+#[cargo_test]
 fn ignore_workspace_specifier() {
     let p = project()
         .file(
@@ -895,7 +895,7 @@ authors = []
     );
 }
 
-#[test]
+#[cargo_test]
 fn package_two_kinds_of_deps() {
     Package::new("other", "1.0.0").publish();
     Package::new("other1", "1.0.0").publish();
@@ -919,7 +919,7 @@ fn package_two_kinds_of_deps() {
     p.cargo("package --no-verify").run();
 }
 
-#[test]
+#[cargo_test]
 fn test_edition() {
     let p = project()
         .file(
@@ -946,7 +946,7 @@ fn test_edition() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn edition_with_metadata() {
     let p = project()
         .file(
@@ -968,7 +968,7 @@ fn edition_with_metadata() {
     p.cargo("package").run();
 }
 
-#[test]
+#[cargo_test]
 fn test_edition_malformed() {
     let p = project()
         .file(
@@ -1001,7 +1001,7 @@ Caused by:
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn do_not_package_if_src_was_modified() {
     let p = project()
         .file("src/main.rs", r#"fn main() { println!("hello"); }"#)
@@ -1047,7 +1047,7 @@ To proceed despite this, pass the `--no-verify` flag.",
     p.cargo("package --no-verify").run();
 }
 
-#[test]
+#[cargo_test]
 fn package_with_select_features() {
     let p = project()
         .file(
@@ -1076,7 +1076,7 @@ fn package_with_select_features() {
     p.cargo("package --features required").run();
 }
 
-#[test]
+#[cargo_test]
 fn package_with_all_features() {
     let p = project()
         .file(
@@ -1105,7 +1105,7 @@ fn package_with_all_features() {
     p.cargo("package --all-features").run();
 }
 
-#[test]
+#[cargo_test]
 fn package_no_default_features() {
     let p = project()
         .file(
@@ -1137,7 +1137,7 @@ fn package_no_default_features() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn include_cargo_toml_implicit() {
     let p = project()
         .file(
@@ -1198,7 +1198,7 @@ fn include_exclude_test(
     p.root().rm_rf();
 }
 
-#[test]
+#[cargo_test]
 fn package_include_ignore_only() {
     // Test with a gitignore pattern that fails to parse with glob.
     // This is a somewhat nonsense pattern, but is an example of something git
@@ -1219,7 +1219,7 @@ fn package_include_ignore_only() {
     )
 }
 
-#[test]
+#[cargo_test]
 fn gitignore_patterns() {
     include_exclude_test(
         r#"["Cargo.toml", "foo"]"#, // include
@@ -1313,7 +1313,7 @@ fn gitignore_patterns() {
     );
 }
 
-#[test]
+#[cargo_test]
 fn gitignore_negate() {
     include_exclude_test(
         r#"["Cargo.toml", "*.rs", "!foo.rs", "\\!important"]"#, // include

--- a/tests/testsuite/patch.rs
+++ b/tests/testsuite/patch.rs
@@ -7,7 +7,7 @@ use crate::support::registry::Package;
 use crate::support::{basic_manifest, project};
 use toml;
 
-#[test]
+#[cargo_test]
 fn replace() {
     Package::new("bar", "0.1.0").publish();
     Package::new("baz", "0.1.0")
@@ -67,7 +67,7 @@ fn replace() {
     p.cargo("build").with_stderr("[FINISHED] [..]").run();
 }
 
-#[test]
+#[cargo_test]
 fn nonexistent() {
     Package::new("baz", "0.1.0").publish();
 
@@ -108,7 +108,7 @@ fn nonexistent() {
     p.cargo("build").with_stderr("[FINISHED] [..]").run();
 }
 
-#[test]
+#[cargo_test]
 fn patch_git() {
     let bar = git::repo(&paths::root().join("override"))
         .file("Cargo.toml", &basic_manifest("bar", "0.1.0"))
@@ -155,7 +155,7 @@ fn patch_git() {
     p.cargo("build").with_stderr("[FINISHED] [..]").run();
 }
 
-#[test]
+#[cargo_test]
 fn patch_to_git() {
     let bar = git::repo(&paths::root().join("override"))
         .file("Cargo.toml", &basic_manifest("bar", "0.1.0"))
@@ -203,7 +203,7 @@ fn patch_to_git() {
     p.cargo("build").with_stderr("[FINISHED] [..]").run();
 }
 
-#[test]
+#[cargo_test]
 fn unused() {
     Package::new("bar", "0.1.0").publish();
 
@@ -273,7 +273,7 @@ fn unused() {
     );
 }
 
-#[test]
+#[cargo_test]
 fn unused_git() {
     Package::new("bar", "0.1.0").publish();
 
@@ -336,7 +336,7 @@ fn unused_git() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn add_patch() {
     Package::new("bar", "0.1.0").publish();
 
@@ -399,7 +399,7 @@ fn add_patch() {
     p.cargo("build").with_stderr("[FINISHED] [..]").run();
 }
 
-#[test]
+#[cargo_test]
 fn add_ignored_patch() {
     Package::new("bar", "0.1.0").publish();
 
@@ -485,7 +485,7 @@ fn add_ignored_patch() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn no_warn_ws_patch() {
     Package::new("c", "0.1.0").publish();
 
@@ -529,7 +529,7 @@ fn no_warn_ws_patch() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn new_minor() {
     Package::new("bar", "0.1.0").publish();
 
@@ -566,7 +566,7 @@ fn new_minor() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn transitive_new_minor() {
     Package::new("baz", "0.1.0").publish();
 
@@ -617,7 +617,7 @@ fn transitive_new_minor() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn new_major() {
     Package::new("bar", "0.1.0").publish();
 
@@ -684,7 +684,7 @@ fn new_major() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn transitive_new_major() {
     Package::new("baz", "0.1.0").publish();
 
@@ -735,7 +735,7 @@ fn transitive_new_major() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn remove_patch() {
     Package::new("foo", "0.1.0").publish();
     Package::new("bar", "0.1.0").publish();
@@ -811,7 +811,7 @@ fn remove_patch() {
     assert_ne!(lock_file1, lock_file2);
 }
 
-#[test]
+#[cargo_test]
 fn non_crates_io() {
     Package::new("bar", "0.1.0").publish();
 
@@ -849,7 +849,7 @@ Caused by:
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn replace_with_crates_io() {
     Package::new("bar", "0.1.0").publish();
 
@@ -886,7 +886,7 @@ Caused by:
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn patch_in_virtual() {
     Package::new("bar", "0.1.0").publish();
 
@@ -922,7 +922,7 @@ fn patch_in_virtual() {
     p.cargo("build").with_stderr("[FINISHED] [..]").run();
 }
 
-#[test]
+#[cargo_test]
 fn patch_depends_on_another_patch() {
     Package::new("bar", "0.1.0")
         .file("src/lib.rs", "broken code")
@@ -975,7 +975,7 @@ fn patch_depends_on_another_patch() {
     p.cargo("build").with_stderr("[FINISHED] [..]").run();
 }
 
-#[test]
+#[cargo_test]
 fn replace_prerelease() {
     Package::new("baz", "1.1.0-pre.1").publish();
     let p = project()

--- a/tests/testsuite/path.rs
+++ b/tests/testsuite/path.rs
@@ -6,7 +6,7 @@ use crate::support::registry::Package;
 use crate::support::sleep_ms;
 use crate::support::{basic_lib_manifest, basic_manifest, main_file, project};
 
-#[test]
+#[cargo_test]
 // I have no idea why this is failing spuriously on Windows;
 // for more info, see #3466.
 #[cfg(not(windows))]
@@ -103,7 +103,7 @@ fn cargo_compile_with_nested_deps_shorthand() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn cargo_compile_with_root_dev_deps() {
     let p = project()
         .file(
@@ -145,7 +145,7 @@ fn cargo_compile_with_root_dev_deps() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn cargo_compile_with_root_dev_deps_with_testing() {
     let p = project()
         .file(
@@ -193,7 +193,7 @@ fn cargo_compile_with_root_dev_deps_with_testing() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn cargo_compile_with_transitive_dev_deps() {
     let p = project()
         .file(
@@ -254,7 +254,7 @@ fn cargo_compile_with_transitive_dev_deps() {
     p.process(&p.bin("foo")).with_stdout("zoidberg\n").run();
 }
 
-#[test]
+#[cargo_test]
 fn no_rebuild_dependency() {
     let p = project()
         .file(
@@ -303,7 +303,7 @@ fn no_rebuild_dependency() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn deep_dependencies_trigger_rebuild() {
     let p = project()
         .file(
@@ -395,7 +395,7 @@ fn deep_dependencies_trigger_rebuild() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn no_rebuild_two_deps() {
     let p = project()
         .file(
@@ -447,7 +447,7 @@ fn no_rebuild_two_deps() {
     assert!(p.bin("foo").is_file());
 }
 
-#[test]
+#[cargo_test]
 fn nested_deps_recompile() {
     let p = project()
         .file(
@@ -495,7 +495,7 @@ fn nested_deps_recompile() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn error_message_for_missing_manifest() {
     let p = project()
         .file(
@@ -535,7 +535,7 @@ Caused by:
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn override_relative() {
     let bar = project()
         .at("bar")
@@ -571,7 +571,7 @@ fn override_relative() {
     p.cargo("build -v").run();
 }
 
-#[test]
+#[cargo_test]
 fn override_self() {
     let bar = project()
         .at("bar")
@@ -607,7 +607,7 @@ fn override_self() {
     p.cargo("build").run();
 }
 
-#[test]
+#[cargo_test]
 fn override_path_dep() {
     let bar = project()
         .at("bar")
@@ -660,7 +660,7 @@ fn override_path_dep() {
     p.cargo("build -v").run();
 }
 
-#[test]
+#[cargo_test]
 fn path_dep_build_cmd() {
     let p = project()
         .file(
@@ -740,7 +740,7 @@ fn path_dep_build_cmd() {
     p.process(&p.bin("foo")).with_stdout("1\n").run();
 }
 
-#[test]
+#[cargo_test]
 fn dev_deps_no_rebuild_lib() {
     let p = project()
         .file(
@@ -790,7 +790,7 @@ fn dev_deps_no_rebuild_lib() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn custom_target_no_rebuild() {
     let p = project()
         .file(
@@ -847,7 +847,7 @@ fn custom_target_no_rebuild() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn override_and_depend() {
     let p = project()
         .no_manifest()
@@ -893,7 +893,7 @@ fn override_and_depend() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn missing_path_dependency() {
     let p = project()
         .file("Cargo.toml", &basic_manifest("a", "0.5.0"))
@@ -920,7 +920,7 @@ Caused by:
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn invalid_path_dep_in_workspace_with_lockfile() {
     Package::new("bar", "1.0.0").publish();
 
@@ -989,7 +989,7 @@ required by package `foo v0.5.0 ([..])`
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn workspace_produces_rlib() {
     let p = project()
         .file(
@@ -1017,7 +1017,7 @@ fn workspace_produces_rlib() {
     assert!(!p.root().join("target/debug/libfoo.rlib").is_file());
 }
 
-#[test]
+#[cargo_test]
 fn thin_lto_works() {
     let p = project()
         .file(

--- a/tests/testsuite/plugins.rs
+++ b/tests/testsuite/plugins.rs
@@ -1,7 +1,7 @@
 use crate::support::{basic_manifest, project};
 use crate::support::{is_nightly, rustc_host};
 
-#[test]
+#[cargo_test]
 fn plugin_to_the_max() {
     if !is_nightly() {
         // plugins are unstable
@@ -101,7 +101,7 @@ fn plugin_to_the_max() {
     foo.cargo("doc").run();
 }
 
-#[test]
+#[cargo_test]
 fn plugin_with_dynamic_native_dependency() {
     if !is_nightly() {
         // plugins are unstable
@@ -212,7 +212,7 @@ fn plugin_with_dynamic_native_dependency() {
     foo.cargo("build -v").env("BUILDER_ROOT", root).run();
 }
 
-#[test]
+#[cargo_test]
 fn plugin_integration() {
     let p = project()
         .file(
@@ -238,7 +238,7 @@ fn plugin_integration() {
     p.cargo("test -v").run();
 }
 
-#[test]
+#[cargo_test]
 fn doctest_a_plugin() {
     let p = project()
         .file(
@@ -274,7 +274,7 @@ fn doctest_a_plugin() {
 }
 
 // See #1515
-#[test]
+#[cargo_test]
 fn native_plugin_dependency_with_custom_ar_linker() {
     let target = rustc_host();
 
@@ -334,7 +334,7 @@ fn native_plugin_dependency_with_custom_ar_linker() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn panic_abort_plugins() {
     if !is_nightly() {
         // requires rustc_private
@@ -382,7 +382,7 @@ fn panic_abort_plugins() {
     p.cargo("build").run();
 }
 
-#[test]
+#[cargo_test]
 fn shared_panic_abort_plugins() {
     if !is_nightly() {
         // requires rustc_private

--- a/tests/testsuite/proc_macro.rs
+++ b/tests/testsuite/proc_macro.rs
@@ -1,7 +1,7 @@
 use crate::support::is_nightly;
 use crate::support::project;
 
-#[test]
+#[cargo_test]
 fn probe_cfg_before_crate_type_discovery() {
     let p = project()
         .file(
@@ -60,7 +60,7 @@ fn probe_cfg_before_crate_type_discovery() {
     p.cargo("build").run();
 }
 
-#[test]
+#[cargo_test]
 fn noop() {
     let p = project()
         .file(
@@ -120,7 +120,7 @@ fn noop() {
     p.cargo("build").run();
 }
 
-#[test]
+#[cargo_test]
 fn impl_and_derive() {
     let p = project()
         .file(
@@ -201,7 +201,7 @@ fn impl_and_derive() {
     p.cargo("run").with_stdout("X { success: true }").run();
 }
 
-#[test]
+#[cargo_test]
 fn plugin_and_proc_macro() {
     if !is_nightly() {
         // plugins are unstable
@@ -252,7 +252,7 @@ fn plugin_and_proc_macro() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn proc_macro_doctest() {
     let foo = project()
         .file(
@@ -297,7 +297,7 @@ fn a() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn proc_macro_crate_type() {
     // Verify that `crate-type = ["proc-macro"]` is the same as `proc-macro = true`
     // and that everything, including rustdoc, works correctly.
@@ -363,7 +363,7 @@ fn proc_macro_crate_type() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn proc_macro_crate_type_warning() {
     let foo = project()
         .file(
@@ -385,7 +385,7 @@ fn proc_macro_crate_type_warning() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn proc_macro_crate_type_warning_plugin() {
     let foo = project()
         .file(
@@ -410,7 +410,7 @@ fn proc_macro_crate_type_warning_plugin() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn proc_macro_crate_type_multiple() {
     let foo = project()
         .file(

--- a/tests/testsuite/profile_config.rs
+++ b/tests/testsuite/profile_config.rs
@@ -1,6 +1,6 @@
 use crate::support::{basic_lib_manifest, is_nightly, paths, project};
 
-#[test]
+#[cargo_test]
 fn profile_config_gated() {
     let p = project()
         .file("Cargo.toml", &basic_lib_manifest("foo"))
@@ -24,7 +24,7 @@ fn profile_config_gated() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn profile_config_validate_warnings() {
     let p = project()
         .file(
@@ -75,7 +75,7 @@ fn profile_config_validate_warnings() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn profile_config_error_paths() {
     let p = project()
         .file("Cargo.toml", &basic_lib_manifest("foo"))
@@ -110,7 +110,7 @@ Caused by:
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn profile_config_validate_errors() {
     let p = project()
         .file(
@@ -147,7 +147,7 @@ Caused by:
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn profile_config_syntax_errors() {
     let p = project()
         .file("Cargo.toml", &basic_lib_manifest("foo"))
@@ -175,7 +175,7 @@ Caused by:
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn profile_config_override_spec_multiple() {
     let p = project()
         .file(
@@ -228,7 +228,7 @@ found profile override specs: bar, bar:0.5.0",
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn profile_config_all_options() {
     if !is_nightly() {
         // May be removed once 1.34 is stable (added support for incremental-LTO).
@@ -277,7 +277,7 @@ fn profile_config_all_options() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn profile_config_override_precedence() {
     // Config values take precedence over manifest values.
     let p = project()
@@ -334,7 +334,7 @@ fn profile_config_override_precedence() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn profile_config_no_warn_unknown_override() {
     let p = project()
         .file(
@@ -363,7 +363,7 @@ fn profile_config_no_warn_unknown_override() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn profile_config_mixed_types() {
     let p = project()
         .file("Cargo.toml", &basic_lib_manifest("foo"))

--- a/tests/testsuite/profile_overrides.rs
+++ b/tests/testsuite/profile_overrides.rs
@@ -1,7 +1,7 @@
 use crate::support::registry::Package;
 use crate::support::{basic_lib_manifest, basic_manifest, project};
 
-#[test]
+#[cargo_test]
 fn profile_override_gated() {
     let p = project()
         .file(
@@ -66,7 +66,7 @@ consider adding `cargo-features = [\"profile-overrides\"]` to the manifest
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn profile_override_basic() {
     let p = project()
         .file(
@@ -106,7 +106,7 @@ fn profile_override_basic() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn profile_override_warnings() {
     let p = project()
         .file(
@@ -149,7 +149,7 @@ Did you mean `bar`?
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn profile_override_dev_release_only() {
     let p = project()
         .file(
@@ -185,7 +185,7 @@ Caused by:
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn profile_override_bad_settings() {
     let bad_values = [
         (
@@ -236,7 +236,7 @@ fn profile_override_bad_settings() {
     }
 }
 
-#[test]
+#[cargo_test]
 fn profile_override_hierarchy() {
     // Test that the precedence rules are correct for different types.
     let p = project()
@@ -338,7 +338,7 @@ fn profile_override_hierarchy() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn profile_override_spec_multiple() {
     let p = project()
         .file(
@@ -376,7 +376,7 @@ found profile override specs: bar, bar:0.5.0",
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn profile_override_spec() {
     let p = project()
         .file(
@@ -441,7 +441,7 @@ fn profile_override_spec() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn override_proc_macro() {
     Package::new("shared", "1.0.0").publish();
     let p = project()

--- a/tests/testsuite/profile_targets.rs
+++ b/tests/testsuite/profile_targets.rs
@@ -68,7 +68,7 @@ fn all_target_project() -> Project {
         .build()
 }
 
-#[test]
+#[cargo_test]
 fn profile_selection_build() {
     let p = all_target_project();
 
@@ -102,7 +102,7 @@ fn profile_selection_build() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn profile_selection_build_release() {
     let p = all_target_project();
 
@@ -133,7 +133,7 @@ fn profile_selection_build_release() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn profile_selection_build_all_targets() {
     let p = all_target_project();
     // `build`
@@ -195,7 +195,7 @@ fn profile_selection_build_all_targets() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn profile_selection_build_all_targets_release() {
     let p = all_target_project();
     // `build --all-targets --release`
@@ -260,7 +260,7 @@ fn profile_selection_build_all_targets_release() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn profile_selection_test() {
     let p = all_target_project();
     // `test`
@@ -325,7 +325,7 @@ fn profile_selection_test() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn profile_selection_test_release() {
     let p = all_target_project();
     // `test --release`
@@ -390,7 +390,7 @@ fn profile_selection_test_release() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn profile_selection_bench() {
     let p = all_target_project();
 
@@ -450,7 +450,7 @@ fn profile_selection_bench() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn profile_selection_check_all_targets() {
     let p = all_target_project();
     // `check`
@@ -515,7 +515,7 @@ fn profile_selection_check_all_targets() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn profile_selection_check_all_targets_release() {
     let p = all_target_project();
     // `check --release`
@@ -557,7 +557,7 @@ fn profile_selection_check_all_targets_release() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn profile_selection_check_all_targets_test() {
     let p = all_target_project();
     // `check --profile=test`
@@ -615,7 +615,7 @@ fn profile_selection_check_all_targets_test() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn profile_selection_doc() {
     let p = all_target_project();
     // `doc`

--- a/tests/testsuite/profiles.rs
+++ b/tests/testsuite/profiles.rs
@@ -2,7 +2,7 @@ use std::env;
 
 use crate::support::project;
 
-#[test]
+#[cargo_test]
 fn profile_overrides() {
     let p = project()
         .file(
@@ -40,7 +40,7 @@ fn profile_overrides() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn opt_level_override_0() {
     let p = project()
         .file(
@@ -74,7 +74,7 @@ fn opt_level_override_0() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn debug_override_1() {
     let p = project()
         .file(
@@ -146,7 +146,7 @@ fn check_opt_level_override(profile_level: &str, rustc_level: &str) {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn opt_level_overrides() {
     for &(profile_level, rustc_level) in &[
         ("1", "1"),
@@ -159,7 +159,7 @@ fn opt_level_overrides() {
     }
 }
 
-#[test]
+#[cargo_test]
 fn top_level_overrides_deps() {
     let p = project()
         .file(
@@ -232,7 +232,7 @@ fn top_level_overrides_deps() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn profile_in_non_root_manifest_triggers_a_warning() {
     let p = project()
         .file(
@@ -281,7 +281,7 @@ workspace: [..]
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn profile_in_virtual_manifest_works() {
     let p = project()
         .file(
@@ -320,7 +320,7 @@ fn profile_in_virtual_manifest_works() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn profile_panic_test_bench() {
     let p = project()
         .file(
@@ -350,7 +350,7 @@ fn profile_panic_test_bench() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn profile_doc_deprecated() {
     let p = project()
         .file(
@@ -372,7 +372,7 @@ fn profile_doc_deprecated() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn panic_unwind_does_not_build_twice() {
     // Check for a bug where `lib` was built twice, once with panic set and
     // once without. Since "unwind" is the default, they are the same and
@@ -409,7 +409,7 @@ fn panic_unwind_does_not_build_twice() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn debug_0_report() {
     // The finished line handles 0 correctly.
     let p = project()

--- a/tests/testsuite/pub_priv.rs
+++ b/tests/testsuite/pub_priv.rs
@@ -1,7 +1,7 @@
 use crate::support::registry::Package;
 use crate::support::{is_nightly, project};
 
-#[test]
+#[cargo_test]
 fn exported_priv_warning() {
     if !is_nightly() {
         return;
@@ -49,7 +49,7 @@ src/lib.rs:3:13: warning: type `priv_dep::FromPriv` from private dependency 'pri
         .run()
 }
 
-#[test]
+#[cargo_test]
 fn exported_pub_dep() {
     if !is_nightly() {
         return;
@@ -96,7 +96,7 @@ fn exported_pub_dep() {
         .run()
 }
 
-#[test]
+#[cargo_test]
 pub fn requires_nightly_cargo() {
     let p = project()
         .file(
@@ -122,7 +122,7 @@ See https://doc.rust-lang.org/book/appendix-07-nightly-rust.html for more inform
         .run()
 }
 
-#[test]
+#[cargo_test]
 fn requires_feature() {
     Package::new("pub_dep", "0.1.0")
         .file("src/lib.rs", "")
@@ -160,7 +160,7 @@ consider adding `cargo-features = [\"public-dependency\"]` to the manifest
         .run()
 }
 
-#[test]
+#[cargo_test]
 fn pub_dev_dependency() {
     Package::new("pub_dep", "0.1.0")
         .file("src/lib.rs", "pub struct FromPub;")

--- a/tests/testsuite/publish.rs
+++ b/tests/testsuite/publish.rs
@@ -69,7 +69,7 @@ fn validate_upload_foo_clean() {
     );
 }
 
-#[test]
+#[cargo_test]
 fn simple() {
     registry::init();
 
@@ -105,7 +105,7 @@ See [..]
     validate_upload_foo();
 }
 
-#[test]
+#[cargo_test]
 fn old_token_location() {
     // Check that the `token` key works at the root instead of under a
     // `[registry]` table.
@@ -160,7 +160,7 @@ See [..]
 
 // TODO: Deprecated
 // remove once it has been decided --host can be removed
-#[test]
+#[cargo_test]
 fn simple_with_host() {
     registry::init();
 
@@ -207,7 +207,7 @@ See [..]
 
 // TODO: Deprecated
 // remove once it has been decided --host can be removed
-#[test]
+#[cargo_test]
 fn simple_with_index_and_host() {
     registry::init();
 
@@ -254,7 +254,7 @@ See [..]
     validate_upload_foo();
 }
 
-#[test]
+#[cargo_test]
 fn git_deps() {
     registry::init();
 
@@ -292,7 +292,7 @@ repository and specify it with a path and version\n\
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn path_dependency_no_version() {
     registry::init();
 
@@ -329,7 +329,7 @@ dependency `bar` does not specify a version
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn unpublishable_crate() {
     registry::init();
 
@@ -361,7 +361,7 @@ The registry `crates-io` is not listed in the `publish` value in Cargo.toml.
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn dont_publish_dirty() {
     registry::init();
     let p = project().file("bar", "").build();
@@ -401,7 +401,7 @@ to proceed despite this, pass the `--allow-dirty` flag
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn publish_clean() {
     registry::init();
 
@@ -432,7 +432,7 @@ fn publish_clean() {
     validate_upload_foo_clean();
 }
 
-#[test]
+#[cargo_test]
 fn publish_in_sub_repo() {
     registry::init();
 
@@ -465,7 +465,7 @@ fn publish_in_sub_repo() {
     validate_upload_foo_clean();
 }
 
-#[test]
+#[cargo_test]
 fn publish_when_ignored() {
     registry::init();
 
@@ -507,7 +507,7 @@ fn publish_when_ignored() {
     );
 }
 
-#[test]
+#[cargo_test]
 fn ignore_when_crate_ignored() {
     registry::init();
 
@@ -543,7 +543,7 @@ fn ignore_when_crate_ignored() {
     );
 }
 
-#[test]
+#[cargo_test]
 fn new_crate_rejected() {
     registry::init();
 
@@ -575,7 +575,7 @@ fn new_crate_rejected() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn dry_run() {
     registry::init();
 
@@ -616,7 +616,7 @@ See [..]
     assert!(!registry::api_path().join("api/v1/crates/new").exists());
 }
 
-#[test]
+#[cargo_test]
 fn registry_not_in_publish_list() {
     registry::init();
 
@@ -651,7 +651,7 @@ The registry `alternative` is not listed in the `publish` value in Cargo.toml.
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn publish_empty_list() {
     registry::init();
 
@@ -682,7 +682,7 @@ The registry `alternative` is not listed in the `publish` value in Cargo.toml.
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn publish_allowed_registry() {
     registry::init();
 
@@ -721,7 +721,7 @@ fn publish_allowed_registry() {
     );
 }
 
-#[test]
+#[cargo_test]
 fn block_publish_no_registry() {
     registry::init();
 
@@ -752,7 +752,7 @@ The registry `alternative` is not listed in the `publish` value in Cargo.toml.
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn publish_with_crates_io_explicit() {
     // Explicitly setting `crates-io` in the publish list.
     registry::init();
@@ -786,7 +786,7 @@ The registry `alternative` is not listed in the `publish` value in Cargo.toml.
     p.cargo("publish").run();
 }
 
-#[test]
+#[cargo_test]
 fn publish_with_select_features() {
     registry::init();
 
@@ -820,7 +820,7 @@ fn publish_with_select_features() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn publish_with_all_features() {
     registry::init();
 
@@ -854,7 +854,7 @@ fn publish_with_all_features() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn publish_with_no_default_features() {
     registry::init();
 
@@ -889,7 +889,7 @@ fn publish_with_no_default_features() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn publish_with_patch() {
     Package::new("bar", "1.0.0").publish();
 
@@ -978,7 +978,7 @@ fn publish_with_patch() {
     );
 }
 
-#[test]
+#[cargo_test]
 fn publish_checks_for_token_before_verify() {
     registry::init();
 

--- a/tests/testsuite/publish_lockfile.rs
+++ b/tests/testsuite/publish_lockfile.rs
@@ -28,7 +28,7 @@ fn pl_manifest(name: &str, version: &str, extra: &str) -> String {
     )
 }
 
-#[test]
+#[cargo_test]
 fn package_lockfile() {
     let p = project()
         .file("Cargo.toml", &pl_manifest("foo", "0.0.1", ""))
@@ -71,7 +71,7 @@ src/main.rs
     );
 }
 
-#[test]
+#[cargo_test]
 fn package_lockfile_git_repo() {
     // Create a Git repository containing a minimal Rust project.
     let g = git::repo(&paths::root().join("foo"))
@@ -109,7 +109,7 @@ src/main.rs
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn no_lock_file_with_library() {
     let p = project()
         .file("Cargo.toml", &pl_manifest("foo", "0.0.1", ""))
@@ -127,7 +127,7 @@ fn no_lock_file_with_library() {
     );
 }
 
-#[test]
+#[cargo_test]
 fn lock_file_and_workspace() {
     let p = project()
         .file(
@@ -155,7 +155,7 @@ fn lock_file_and_workspace() {
     );
 }
 
-#[test]
+#[cargo_test]
 fn note_resolve_changes() {
     // `multi` has multiple sources (path and registry).
     Package::new("mutli", "0.1.0").publish();
@@ -211,7 +211,7 @@ fn note_resolve_changes() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn outdated_lock_version_change_does_not_warn() {
     // If the version of the package being packaged changes, but Cargo.lock is
     // not updated, don't bother warning about it.
@@ -232,7 +232,7 @@ fn outdated_lock_version_change_does_not_warn() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn no_warn_workspace_extras() {
     // Other entries in workspace lock file should be ignored.
     Package::new("dep1", "1.0.0").publish();
@@ -286,7 +286,7 @@ fn no_warn_workspace_extras() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn warn_package_with_yanked() {
     Package::new("bar", "0.1.0").publish();
     let p = project()
@@ -322,7 +322,7 @@ fn warn_package_with_yanked() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn warn_install_with_yanked() {
     Package::new("bar", "0.1.0").yanked(true).publish();
     Package::new("bar", "0.1.1").publish();
@@ -387,7 +387,7 @@ dependencies = [
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn publish_lockfile_default() {
     let p = project()
         .file(

--- a/tests/testsuite/read_manifest.rs
+++ b/tests/testsuite/read_manifest.rs
@@ -32,7 +32,7 @@ static MANIFEST_OUTPUT: &'static str = r#"
     "metadata": null
 }"#;
 
-#[test]
+#[cargo_test]
 fn cargo_read_manifest_path_to_cargo_toml_relative() {
     let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
@@ -45,7 +45,7 @@ fn cargo_read_manifest_path_to_cargo_toml_relative() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn cargo_read_manifest_path_to_cargo_toml_absolute() {
     let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
@@ -59,7 +59,7 @@ fn cargo_read_manifest_path_to_cargo_toml_absolute() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn cargo_read_manifest_path_to_cargo_toml_parent_relative() {
     let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
@@ -76,7 +76,7 @@ fn cargo_read_manifest_path_to_cargo_toml_parent_relative() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn cargo_read_manifest_path_to_cargo_toml_parent_absolute() {
     let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
@@ -94,7 +94,7 @@ fn cargo_read_manifest_path_to_cargo_toml_parent_absolute() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn cargo_read_manifest_cwd() {
     let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))

--- a/tests/testsuite/registry.rs
+++ b/tests/testsuite/registry.rs
@@ -9,7 +9,7 @@ use crate::support::registry::{self, registry_path, registry_url, Dependency, Pa
 use crate::support::{basic_manifest, project};
 use cargo::util::paths::remove_dir_all;
 
-#[test]
+#[cargo_test]
 fn simple() {
     let p = project()
         .file(
@@ -57,7 +57,7 @@ fn simple() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn deps() {
     let p = project()
         .file(
@@ -95,7 +95,7 @@ fn deps() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn nonexistent() {
     Package::new("init", "0.0.1").publish();
 
@@ -128,7 +128,7 @@ required by package `foo v0.0.1 ([..])`
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn wrong_case() {
     Package::new("init", "0.0.1").publish();
 
@@ -163,7 +163,7 @@ required by package `foo v0.0.1 ([..])`
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn mis_hyphenated() {
     Package::new("mis-hyphenated", "0.0.1").publish();
 
@@ -198,7 +198,7 @@ required by package `foo v0.0.1 ([..])`
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn wrong_version() {
     let p = project()
         .file(
@@ -247,7 +247,7 @@ required by package `foo v0.0.1 ([..])`
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn bad_cksum() {
     let p = project()
         .file(
@@ -285,7 +285,7 @@ Caused by:
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn update_registry() {
     Package::new("init", "0.0.1").publish();
 
@@ -333,7 +333,7 @@ required by package `foo v0.0.1 ([..])`
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn package_with_path_deps() {
     Package::new("init", "0.0.1").publish();
 
@@ -391,7 +391,7 @@ required by package `foo v0.0.1 ([..])`
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn lockfile_locks() {
     let p = project()
         .file(
@@ -430,7 +430,7 @@ fn lockfile_locks() {
     p.cargo("build").with_stdout("").run();
 }
 
-#[test]
+#[cargo_test]
 fn lockfile_locks_transitively() {
     let p = project()
         .file(
@@ -473,7 +473,7 @@ fn lockfile_locks_transitively() {
     p.cargo("build").with_stdout("").run();
 }
 
-#[test]
+#[cargo_test]
 fn yanks_are_not_used() {
     let p = project()
         .file(
@@ -515,7 +515,7 @@ fn yanks_are_not_used() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn relying_on_a_yank_is_bad() {
     let p = project()
         .file(
@@ -551,7 +551,7 @@ required by package `bar v0.0.1`
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn yanks_in_lockfiles_are_ok() {
     let p = project()
         .file(
@@ -591,7 +591,7 @@ required by package `foo v0.0.1 ([..])`
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn yanks_in_lockfiles_are_ok_for_other_update() {
     let p = project()
         .file(
@@ -645,7 +645,7 @@ required by package `foo v0.0.1 ([..])`
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn yanks_in_lockfiles_are_ok_with_new_dep() {
     let p = project()
         .file(
@@ -688,7 +688,7 @@ fn yanks_in_lockfiles_are_ok_with_new_dep() {
     p.cargo("build").with_stdout("").run();
 }
 
-#[test]
+#[cargo_test]
 fn update_with_lockfile_if_packages_missing() {
     let p = project()
         .file(
@@ -723,7 +723,7 @@ fn update_with_lockfile_if_packages_missing() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn update_lockfile() {
     let p = project()
         .file(
@@ -820,7 +820,7 @@ fn update_lockfile() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn dev_dependency_not_used() {
     let p = project()
         .file(
@@ -855,7 +855,7 @@ fn dev_dependency_not_used() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn login_with_no_cargo_dir() {
     // Create a config in the root directory because `login` requires the
     // index to be updated, and we don't want to hit crates.io.
@@ -867,7 +867,7 @@ fn login_with_no_cargo_dir() {
     assert_eq!(credentials, "[registry]\ntoken = \"foo\"\n");
 }
 
-#[test]
+#[cargo_test]
 fn login_with_differently_sized_token() {
     // Verify that the configuration file gets properly truncated.
     registry::init();
@@ -880,7 +880,7 @@ fn login_with_differently_sized_token() {
     assert_eq!(credentials, "[registry]\ntoken = \"lmaolmaolmao\"\n");
 }
 
-#[test]
+#[cargo_test]
 fn bad_license_file() {
     Package::new("foo", "1.0.0").publish();
     let p = project()
@@ -905,7 +905,7 @@ fn bad_license_file() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn updating_a_dep() {
     let p = project()
         .file(
@@ -981,7 +981,7 @@ fn updating_a_dep() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn git_and_registry_dep() {
     let b = git::repo(&paths::root().join("b"))
         .file(
@@ -1043,7 +1043,7 @@ fn git_and_registry_dep() {
     p.cargo("build").with_stdout("").run();
 }
 
-#[test]
+#[cargo_test]
 fn update_publish_then_update() {
     // First generate a Cargo.lock and a clone of the registry index at the
     // "head" of the current registry.
@@ -1115,7 +1115,7 @@ fn update_publish_then_update() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn fetch_downloads() {
     let p = project()
         .file(
@@ -1146,7 +1146,7 @@ fn fetch_downloads() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn update_transitive_dependency() {
     let p = project()
         .file(
@@ -1194,7 +1194,7 @@ fn update_transitive_dependency() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn update_backtracking_ok() {
     let p = project()
         .file(
@@ -1243,7 +1243,7 @@ fn update_backtracking_ok() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn update_multiple_packages() {
     let p = project()
         .file(
@@ -1303,7 +1303,7 @@ fn update_multiple_packages() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn bundled_crate_in_registry() {
     let p = project()
         .file(
@@ -1345,7 +1345,7 @@ fn bundled_crate_in_registry() {
     p.cargo("run").run();
 }
 
-#[test]
+#[cargo_test]
 fn update_same_prefix_oh_my_how_was_this_a_bug() {
     let p = project()
         .file(
@@ -1372,7 +1372,7 @@ fn update_same_prefix_oh_my_how_was_this_a_bug() {
     p.cargo("update -pfoobar --precise=0.2.0").run();
 }
 
-#[test]
+#[cargo_test]
 fn use_semver() {
     let p = project()
         .file(
@@ -1395,7 +1395,7 @@ fn use_semver() {
     p.cargo("build").run();
 }
 
-#[test]
+#[cargo_test]
 fn only_download_relevant() {
     let p = project()
         .file(
@@ -1435,7 +1435,7 @@ fn only_download_relevant() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn resolve_and_backtracking() {
     let p = project()
         .file(
@@ -1461,7 +1461,7 @@ fn resolve_and_backtracking() {
     p.cargo("build").run();
 }
 
-#[test]
+#[cargo_test]
 fn upstream_warnings_on_extra_verbose() {
     let p = project()
         .file(
@@ -1488,7 +1488,7 @@ fn upstream_warnings_on_extra_verbose() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn disallow_network() {
     let p = project()
         .file(
@@ -1522,7 +1522,7 @@ Caused by:
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn add_dep_dont_update_registry() {
     let p = project()
         .file(
@@ -1580,7 +1580,7 @@ fn add_dep_dont_update_registry() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn bump_version_dont_update_registry() {
     let p = project()
         .file(
@@ -1637,7 +1637,7 @@ fn bump_version_dont_update_registry() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn old_version_req() {
     let p = project()
         .file(
@@ -1691,7 +1691,7 @@ this warning.
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn old_version_req_upstream() {
     let p = project()
         .file(
@@ -1750,7 +1750,7 @@ this warning.
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn toml_lies_but_index_is_truth() {
     Package::new("foo", "0.2.0").publish();
     Package::new("bar", "0.3.0")
@@ -1789,7 +1789,7 @@ fn toml_lies_but_index_is_truth() {
     p.cargo("build -v").run();
 }
 
-#[test]
+#[cargo_test]
 fn vv_prints_warnings() {
     Package::new("foo", "0.2.0")
         .file(
@@ -1817,7 +1817,7 @@ fn vv_prints_warnings() {
     p.cargo("build -vv").run();
 }
 
-#[test]
+#[cargo_test]
 fn bad_and_or_malicious_packages_rejected() {
     Package::new("foo", "0.2.0")
         .extra_file("foo-0.1.0/src/lib.rs", "")
@@ -1858,7 +1858,7 @@ Caused by:
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn git_init_templatedir_missing() {
     Package::new("foo", "0.2.0").dep("bar", "*").publish();
     Package::new("bar", "0.2.0").publish();
@@ -1896,7 +1896,7 @@ fn git_init_templatedir_missing() {
     p.cargo("build").run();
 }
 
-#[test]
+#[cargo_test]
 fn rename_deps_and_features() {
     Package::new("foo", "0.1.0")
         .file("src/lib.rs", "pub fn f1() {}")
@@ -1955,7 +1955,7 @@ fn rename_deps_and_features() {
     p.cargo("build --features bar/another").run();
 }
 
-#[test]
+#[cargo_test]
 fn ignore_invalid_json_lines() {
     Package::new("foo", "0.1.0").publish();
     Package::new("foo", "0.1.1").invalid_json(true).publish();
@@ -1981,7 +1981,7 @@ fn ignore_invalid_json_lines() {
     p.cargo("build").run();
 }
 
-#[test]
+#[cargo_test]
 fn readonly_registry_still_works() {
     Package::new("foo", "0.1.0").publish();
 

--- a/tests/testsuite/rename_deps.rs
+++ b/tests/testsuite/rename_deps.rs
@@ -3,7 +3,7 @@ use crate::support::paths;
 use crate::support::registry::Package;
 use crate::support::{basic_manifest, project};
 
-#[test]
+#[cargo_test]
 fn rename_dependency() {
     Package::new("bar", "0.1.0").publish();
     Package::new("bar", "0.2.0").publish();
@@ -28,7 +28,7 @@ fn rename_dependency() {
     p.cargo("build").run();
 }
 
-#[test]
+#[cargo_test]
 fn rename_with_different_names() {
     let p = project()
         .file(
@@ -62,7 +62,7 @@ fn rename_with_different_names() {
     p.cargo("build").run();
 }
 
-#[test]
+#[cargo_test]
 fn lots_of_names() {
     Package::new("foo", "0.1.0")
         .file("src/lib.rs", "pub fn foo1() {}")
@@ -125,7 +125,7 @@ fn lots_of_names() {
     p.cargo("build -v").run();
 }
 
-#[test]
+#[cargo_test]
 fn rename_and_patch() {
     Package::new("foo", "0.1.0").publish();
 
@@ -156,7 +156,7 @@ fn rename_and_patch() {
     p.cargo("build -v").run();
 }
 
-#[test]
+#[cargo_test]
 fn rename_twice() {
     Package::new("foo", "0.1.0").publish();
 
@@ -191,7 +191,7 @@ error: the crate `test v0.1.0 ([CWD])` depends on crate `foo v0.1.0` multiple ti
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn rename_affects_fingerprint() {
     Package::new("foo", "0.1.0").publish();
 
@@ -232,7 +232,7 @@ fn rename_affects_fingerprint() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn can_run_doc_tests() {
     Package::new("bar", "0.1.0").publish();
     Package::new("bar", "0.2.0").publish();
@@ -273,7 +273,7 @@ fn can_run_doc_tests() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn features_still_work() {
     Package::new("foo", "0.1.0").publish();
     Package::new("bar", "0.1.0").publish();
@@ -327,7 +327,7 @@ fn features_still_work() {
     p.cargo("build -v").run();
 }
 
-#[test]
+#[cargo_test]
 fn features_not_working() {
     Package::new("foo", "0.1.0").publish();
     Package::new("bar", "0.1.0").publish();
@@ -365,7 +365,7 @@ Caused by:
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn rename_with_dash() {
     let p = project()
         .file(

--- a/tests/testsuite/required_features.rs
+++ b/tests/testsuite/required_features.rs
@@ -2,7 +2,7 @@ use crate::support::install::{assert_has_installed_exe, assert_has_not_installed
 use crate::support::is_nightly;
 use crate::support::project;
 
-#[test]
+#[cargo_test]
 fn build_bin_default_features() {
     let p = project()
         .file(
@@ -57,7 +57,7 @@ Consider enabling them by passing, e.g., `--features=\"a\"`
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn build_bin_arg_features() {
     let p = project()
         .file(
@@ -83,7 +83,7 @@ fn build_bin_arg_features() {
     assert!(p.bin("foo").is_file());
 }
 
-#[test]
+#[cargo_test]
 fn build_bin_multiple_required_features() {
     let p = project()
         .file(
@@ -128,7 +128,7 @@ fn build_bin_multiple_required_features() {
     p.cargo("build --no-default-features").run();
 }
 
-#[test]
+#[cargo_test]
 fn build_example_default_features() {
     let p = project()
         .file(
@@ -165,7 +165,7 @@ Consider enabling them by passing, e.g., `--features=\"a\"`
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn build_example_arg_features() {
     let p = project()
         .file(
@@ -191,7 +191,7 @@ fn build_example_arg_features() {
     assert!(p.bin("examples/foo").is_file());
 }
 
-#[test]
+#[cargo_test]
 fn build_example_multiple_required_features() {
     let p = project()
         .file(
@@ -261,7 +261,7 @@ Consider enabling them by passing, e.g., `--features=\"a\"`
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn test_default_features() {
     let p = project()
         .file(
@@ -319,7 +319,7 @@ Consider enabling them by passing, e.g., `--features=\"a\"`
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn test_arg_features() {
     let p = project()
         .file(
@@ -352,7 +352,7 @@ fn test_arg_features() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn test_multiple_required_features() {
     let p = project()
         .file(
@@ -409,7 +409,7 @@ fn test_multiple_required_features() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn bench_default_features() {
     if !is_nightly() {
         return;
@@ -480,7 +480,7 @@ Consider enabling them by passing, e.g., `--features=\"a\"`
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn bench_arg_features() {
     if !is_nightly() {
         return;
@@ -526,7 +526,7 @@ fn bench_arg_features() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn bench_multiple_required_features() {
     if !is_nightly() {
         return;
@@ -605,7 +605,7 @@ fn bench_multiple_required_features() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn install_default_features() {
     let p = project()
         .file(
@@ -690,7 +690,7 @@ Consider enabling them by passing, e.g., `--features=\"a\"`
     assert_has_not_installed_exe(cargo_home(), "foo");
 }
 
-#[test]
+#[cargo_test]
 fn install_arg_features() {
     let p = project()
         .file(
@@ -717,7 +717,7 @@ fn install_arg_features() {
     p.cargo("uninstall foo").run();
 }
 
-#[test]
+#[cargo_test]
 fn install_multiple_required_features() {
     let p = project()
         .file(
@@ -773,7 +773,7 @@ fn install_multiple_required_features() {
     assert_has_not_installed_exe(cargo_home(), "foo_2");
 }
 
-#[test]
+#[cargo_test]
 fn dep_feature_in_toml() {
     let p = project()
         .file(
@@ -873,7 +873,7 @@ fn dep_feature_in_toml() {
     p.cargo("uninstall foo").run();
 }
 
-#[test]
+#[cargo_test]
 fn dep_feature_in_cmd_line() {
     let p = project()
         .file(
@@ -1015,7 +1015,7 @@ Consider enabling them by passing, e.g., `--features=\"bar/a\"`
     p.cargo("uninstall foo").run();
 }
 
-#[test]
+#[cargo_test]
 fn test_skips_compiling_bin_with_missing_required_features() {
     let p = project()
         .file(
@@ -1081,7 +1081,7 @@ error[E0463]: can't find crate for `bar`",
     }
 }
 
-#[test]
+#[cargo_test]
 fn run_default() {
     let p = project()
         .file(
@@ -1118,7 +1118,7 @@ Consider enabling them by passing, e.g., `--features=\"a\"`
     p.cargo("run --features a").run();
 }
 
-#[test]
+#[cargo_test]
 fn run_default_multiple_required_features() {
     let p = project()
         .file(

--- a/tests/testsuite/resolve.rs
+++ b/tests/testsuite/resolve.rs
@@ -238,7 +238,7 @@ proptest! {
     }
 }
 
-#[test]
+#[cargo_test]
 fn pub_fail() {
     let input = vec![
         pkg!(("a", "0.0.4")),
@@ -250,7 +250,7 @@ fn pub_fail() {
     assert!(resolve_and_validated(pkg_id("root"), vec![dep("kB")], &reg, None).is_err());
 }
 
-#[test]
+#[cargo_test]
 fn basic_public_dependency() {
     let reg = registry(vec![
         pkg!(("A", "0.1.0")),
@@ -271,7 +271,7 @@ fn basic_public_dependency() {
     );
 }
 
-#[test]
+#[cargo_test]
 fn public_dependency_filling_in() {
     // The resolver has an optimization where if a candidate to resolve a dependency
     // has already bean activated then we skip looking at the candidates dependencies.
@@ -308,7 +308,7 @@ fn public_dependency_filling_in() {
     );
 }
 
-#[test]
+#[cargo_test]
 fn public_dependency_filling_in_and_update() {
     // The resolver has an optimization where if a candidate to resolve a dependency
     // has already bean activated then we skip looking at the candidates dependencies.
@@ -343,7 +343,7 @@ fn public_dependency_filling_in_and_update() {
     );
 }
 
-#[test]
+#[cargo_test]
 fn public_dependency_skipping() {
     // When backtracking due to a failed dependency, if Cargo is
     // trying to be clever and skip irrelevant dependencies, care must
@@ -360,7 +360,7 @@ fn public_dependency_skipping() {
     resolve_and_validated(pkg_id("root"), vec![dep("c")], &reg, None).unwrap();
 }
 
-#[test]
+#[cargo_test]
 fn public_dependency_skipping_in_backtracking() {
     // When backtracking due to a failed dependency, if Cargo is
     // trying to be clever and skip irrelevant dependencies, care must
@@ -380,7 +380,7 @@ fn public_dependency_skipping_in_backtracking() {
     resolve_and_validated(pkg_id("root"), vec![dep("C")], &reg, None).unwrap();
 }
 
-#[test]
+#[cargo_test]
 fn public_sat_topological_order() {
     let input = vec![
         pkg!(("a", "0.0.1")),
@@ -394,7 +394,7 @@ fn public_sat_topological_order() {
     assert!(resolve_and_validated(pkg_id("root"), vec![dep("A")], &reg, None).is_err());
 }
 
-#[test]
+#[cargo_test]
 fn public_sat_unused_makes_things_pub() {
     let input = vec![
         pkg!(("a", "0.0.1")),
@@ -408,7 +408,7 @@ fn public_sat_unused_makes_things_pub() {
     resolve_and_validated(pkg_id("root"), vec![dep("c")], &reg, None).unwrap();
 }
 
-#[test]
+#[cargo_test]
 fn public_sat_unused_makes_things_pub_2() {
     let input = vec![
         pkg!(("c", "0.0.2")),
@@ -423,42 +423,42 @@ fn public_sat_unused_makes_things_pub_2() {
     resolve_and_validated(pkg_id("root"), vec![dep("A")], &reg, None).unwrap();
 }
 
-#[test]
+#[cargo_test]
 #[should_panic(expected = "assertion failed: !name.is_empty()")]
 fn test_dependency_with_empty_name() {
     // Bug 5229, dependency-names must not be empty
     "".to_dep();
 }
 
-#[test]
+#[cargo_test]
 fn test_resolving_empty_dependency_list() {
     let res = resolve(pkg_id("root"), Vec::new(), &registry(vec![])).unwrap();
 
     assert_eq!(res, names(&["root"]));
 }
 
-#[test]
+#[cargo_test]
 fn test_resolving_only_package() {
     let reg = registry(vec![pkg!("foo")]);
     let res = resolve(pkg_id("root"), vec![dep("foo")], &reg).unwrap();
     assert_same(&res, &names(&["root", "foo"]));
 }
 
-#[test]
+#[cargo_test]
 fn test_resolving_one_dep() {
     let reg = registry(vec![pkg!("foo"), pkg!("bar")]);
     let res = resolve(pkg_id("root"), vec![dep("foo")], &reg).unwrap();
     assert_same(&res, &names(&["root", "foo"]));
 }
 
-#[test]
+#[cargo_test]
 fn test_resolving_multiple_deps() {
     let reg = registry(vec![pkg!("foo"), pkg!("bar"), pkg!("baz")]);
     let res = resolve(pkg_id("root"), vec![dep("foo"), dep("baz")], &reg).unwrap();
     assert_same(&res, &names(&["root", "foo", "baz"]));
 }
 
-#[test]
+#[cargo_test]
 fn test_resolving_transitive_deps() {
     let reg = registry(vec![pkg!("foo"), pkg!("bar" => ["foo"])]);
     let res = resolve(pkg_id("root"), vec![dep("bar")], &reg).unwrap();
@@ -466,7 +466,7 @@ fn test_resolving_transitive_deps() {
     assert_same(&res, &names(&["root", "foo", "bar"]));
 }
 
-#[test]
+#[cargo_test]
 fn test_resolving_common_transitive_deps() {
     let reg = registry(vec![pkg!("foo" => ["bar"]), pkg!("bar")]);
     let res = resolve(pkg_id("root"), vec![dep("foo"), dep("bar")], &reg).unwrap();
@@ -474,7 +474,7 @@ fn test_resolving_common_transitive_deps() {
     assert_same(&res, &names(&["root", "foo", "bar"]));
 }
 
-#[test]
+#[cargo_test]
 fn test_resolving_with_same_name() {
     let list = vec![
         pkg_loc("foo", "https://first.example.com"),
@@ -501,7 +501,7 @@ fn test_resolving_with_same_name() {
     assert_same(&res, &names);
 }
 
-#[test]
+#[cargo_test]
 fn test_resolving_with_dev_deps() {
     let reg = registry(vec![
         pkg!("foo" => ["bar", dep_kind("baz", Kind::Development)]),
@@ -520,7 +520,7 @@ fn test_resolving_with_dev_deps() {
     assert_same(&res, &names(&["root", "foo", "bar", "baz", "bat"]));
 }
 
-#[test]
+#[cargo_test]
 fn resolving_with_many_versions() {
     let reg = registry(vec![pkg!(("foo", "1.0.1")), pkg!(("foo", "1.0.2"))]);
 
@@ -529,7 +529,7 @@ fn resolving_with_many_versions() {
     assert_same(&res, &names(&[("root", "1.0.0"), ("foo", "1.0.2")]));
 }
 
-#[test]
+#[cargo_test]
 fn resolving_with_specific_version() {
     let reg = registry(vec![pkg!(("foo", "1.0.1")), pkg!(("foo", "1.0.2"))]);
 
@@ -538,7 +538,7 @@ fn resolving_with_specific_version() {
     assert_same(&res, &names(&[("root", "1.0.0"), ("foo", "1.0.1")]));
 }
 
-#[test]
+#[cargo_test]
 fn test_resolving_maximum_version_with_transitive_deps() {
     let reg = registry(vec![
         pkg!(("util", "1.2.2")),
@@ -568,7 +568,7 @@ fn test_resolving_maximum_version_with_transitive_deps() {
     assert!(!res.contains(&("util", "1.1.1").to_pkgid()));
 }
 
-#[test]
+#[cargo_test]
 fn test_resolving_minimum_version_with_transitive_deps() {
     enable_nightly_features(); // -Z minimal-versions
                                // When the minimal-versions config option is specified then the lowest
@@ -620,7 +620,7 @@ fn test_resolving_minimum_version_with_transitive_deps() {
 
 // Ensure that the "-Z minimal-versions" CLI option works and the minimal
 // version of a dependency ends up in the lock file.
-#[test]
+#[cargo_test]
 fn minimal_version_cli() {
     Package::new("dep", "1.0.0").publish();
     Package::new("dep", "1.1.0").publish();
@@ -650,7 +650,7 @@ fn minimal_version_cli() {
     assert!(lock.contains("dep 1.0.0"));
 }
 
-#[test]
+#[cargo_test]
 fn resolving_incompat_versions() {
     let reg = registry(vec![
         pkg!(("foo", "1.0.1")),
@@ -666,7 +666,7 @@ fn resolving_incompat_versions() {
     .is_err());
 }
 
-#[test]
+#[cargo_test]
 fn resolving_wrong_case_from_registry() {
     // In the future we may #5678 allow this to happen.
     // For back compatibility reasons, we probably won't.
@@ -677,7 +677,7 @@ fn resolving_wrong_case_from_registry() {
     assert!(resolve(pkg_id("root"), vec![dep("bar")], &reg).is_err());
 }
 
-#[test]
+#[cargo_test]
 fn resolving_mis_hyphenated_from_registry() {
     // In the future we may #2775 allow this to happen.
     // For back compatibility reasons, we probably won't.
@@ -688,7 +688,7 @@ fn resolving_mis_hyphenated_from_registry() {
     assert!(resolve(pkg_id("root"), vec![dep("bar")], &reg).is_err());
 }
 
-#[test]
+#[cargo_test]
 fn resolving_backtrack() {
     let reg = registry(vec![
         pkg!(("foo", "1.0.2") => [dep("bar")]),
@@ -705,7 +705,7 @@ fn resolving_backtrack() {
     );
 }
 
-#[test]
+#[cargo_test]
 fn resolving_backtrack_features() {
     // test for cargo/issues/4347
     let mut bad = dep("bar");
@@ -725,7 +725,7 @@ fn resolving_backtrack_features() {
     );
 }
 
-#[test]
+#[cargo_test]
 fn resolving_allows_multiple_compatible_versions() {
     let reg = registry(vec![
         pkg!(("foo", "1.0.0")),
@@ -758,7 +758,7 @@ fn resolving_allows_multiple_compatible_versions() {
     );
 }
 
-#[test]
+#[cargo_test]
 fn resolving_with_deep_backtracking() {
     let reg = registry(vec![
         pkg!(("foo", "1.0.1") => [dep_req("bar", "1")]),
@@ -785,7 +785,7 @@ fn resolving_with_deep_backtracking() {
     );
 }
 
-#[test]
+#[cargo_test]
 fn resolving_with_sys_crates() {
     // This is based on issues/4902
     // With `l` a normal library we get 2copies so everyone gets the newest compatible.
@@ -819,7 +819,7 @@ fn resolving_with_sys_crates() {
     );
 }
 
-#[test]
+#[cargo_test]
 fn resolving_with_constrained_sibling_backtrack_parent() {
     // There is no point in considering all of the backtrack_trap{1,2}
     // candidates since they can't change the result of failing to
@@ -866,7 +866,7 @@ fn resolving_with_constrained_sibling_backtrack_parent() {
     );
 }
 
-#[test]
+#[cargo_test]
 fn resolving_with_many_equivalent_backtracking() {
     let mut reglist = Vec::new();
 
@@ -956,7 +956,7 @@ fn resolving_with_many_equivalent_backtracking() {
     assert!(res.is_err());
 }
 
-#[test]
+#[cargo_test]
 fn resolving_with_deep_traps() {
     let mut reglist = Vec::new();
 
@@ -999,7 +999,7 @@ fn resolving_with_deep_traps() {
     assert!(res.is_err());
 }
 
-#[test]
+#[cargo_test]
 fn resolving_with_constrained_cousins_backtrack() {
     let mut reglist = Vec::new();
 
@@ -1093,7 +1093,7 @@ fn resolving_with_constrained_cousins_backtrack() {
     );
 }
 
-#[test]
+#[cargo_test]
 fn resolving_with_constrained_sibling_backtrack_activation() {
     // It makes sense to resolve most-constrained deps first, but
     // with that logic the backtrack traps here come between the two
@@ -1138,7 +1138,7 @@ fn resolving_with_constrained_sibling_backtrack_activation() {
     );
 }
 
-#[test]
+#[cargo_test]
 fn resolving_with_constrained_sibling_transitive_dep_effects() {
     // When backtracking due to a failed dependency, if Cargo is
     // trying to be clever and skip irrelevant dependencies, care must
@@ -1185,7 +1185,7 @@ fn resolving_with_constrained_sibling_transitive_dep_effects() {
     );
 }
 
-#[test]
+#[cargo_test]
 fn incomplete_information_skipping() {
     // When backtracking due to a failed dependency, if Cargo is
     // trying to be clever and skip irrelevant dependencies, care must
@@ -1234,7 +1234,7 @@ fn incomplete_information_skipping() {
     assert!(resolve(pkg_id("root"), vec![dep("g")], &new_reg).is_ok());
 }
 
-#[test]
+#[cargo_test]
 fn incomplete_information_skipping_2() {
     // When backtracking due to a failed dependency, if Cargo is
     // trying to be clever and skip irrelevant dependencies, care must
@@ -1303,7 +1303,7 @@ fn incomplete_information_skipping_2() {
     assert!(resolve(pkg_id("root"), vec![dep("i")], &new_reg).is_ok());
 }
 
-#[test]
+#[cargo_test]
 fn incomplete_information_skipping_3() {
     // When backtracking due to a failed dependency, if Cargo is
     // trying to be clever and skip irrelevant dependencies, care must
@@ -1353,7 +1353,7 @@ fn incomplete_information_skipping_3() {
     assert!(resolve(pkg_id("root"), vec![dep("b")], &new_reg).is_ok());
 }
 
-#[test]
+#[cargo_test]
 fn resolving_but_no_exists() {
     let reg = registry(vec![]);
 
@@ -1370,14 +1370,14 @@ fn resolving_but_no_exists() {
     );
 }
 
-#[test]
+#[cargo_test]
 fn resolving_cycle() {
     let reg = registry(vec![pkg!("foo" => ["foo"])]);
 
     let _ = resolve(pkg_id("root"), vec![dep_req("foo", "1")], &reg);
 }
 
-#[test]
+#[cargo_test]
 fn hard_equality() {
     let reg = registry(vec![
         pkg!(("foo", "1.0.1")),
@@ -1398,7 +1398,7 @@ fn hard_equality() {
     );
 }
 
-#[test]
+#[cargo_test]
 fn large_conflict_cache() {
     let mut input = vec![
         pkg!(("last", "0.0.0") => [dep("bad")]), // just to make sure last is less constrained
@@ -1427,7 +1427,7 @@ fn large_conflict_cache() {
     let _ = resolve(pkg_id("root"), root_deps, &reg);
 }
 
-#[test]
+#[cargo_test]
 fn conflict_store_bug() {
     let input = vec![
         pkg!(("A", "0.0.3")),
@@ -1467,7 +1467,7 @@ fn conflict_store_bug() {
     let _ = resolve_and_validated(pkg_id("root"), vec![dep("j")], &reg, None);
 }
 
-#[test]
+#[cargo_test]
 fn conflict_store_more_then_one_match() {
     let input = vec![
         pkg!(("A", "0.0.0")),

--- a/tests/testsuite/run.rs
+++ b/tests/testsuite/run.rs
@@ -1,7 +1,7 @@
 use crate::support::{basic_bin_manifest, basic_lib_manifest, project, Project};
 use cargo::util::paths::dylib_path_envvar;
 
-#[test]
+#[cargo_test]
 fn simple() {
     let p = project()
         .file("src/main.rs", r#"fn main() { println!("hello"); }"#)
@@ -19,7 +19,7 @@ fn simple() {
     assert!(p.bin("foo").is_file());
 }
 
-#[test]
+#[cargo_test]
 fn simple_quiet() {
     let p = project()
         .file("src/main.rs", r#"fn main() { println!("hello"); }"#)
@@ -30,7 +30,7 @@ fn simple_quiet() {
     p.cargo("run --quiet").with_stdout("hello").run();
 }
 
-#[test]
+#[cargo_test]
 fn simple_quiet_and_verbose() {
     let p = project()
         .file("src/main.rs", r#"fn main() { println!("hello"); }"#)
@@ -42,7 +42,7 @@ fn simple_quiet_and_verbose() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn quiet_and_verbose_config() {
     let p = project()
         .file(
@@ -58,7 +58,7 @@ fn quiet_and_verbose_config() {
     p.cargo("run -q").run();
 }
 
-#[test]
+#[cargo_test]
 fn simple_with_args() {
     let p = project()
         .file(
@@ -76,7 +76,7 @@ fn simple_with_args() {
 }
 
 #[cfg(unix)]
-#[test]
+#[cargo_test]
 fn simple_with_non_utf8_args() {
     use std::os::unix::ffi::OsStrExt;
 
@@ -101,7 +101,7 @@ fn simple_with_non_utf8_args() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn exit_code() {
     let p = project()
         .file("src/main.rs", "fn main() { std::process::exit(2); }")
@@ -122,7 +122,7 @@ fn exit_code() {
     p.cargo("run").with_status(2).with_stderr(output).run();
 }
 
-#[test]
+#[cargo_test]
 fn exit_code_verbose() {
     let p = project()
         .file("src/main.rs", "fn main() { std::process::exit(2); }")
@@ -145,7 +145,7 @@ fn exit_code_verbose() {
     p.cargo("run -v").with_status(2).with_stderr(output).run();
 }
 
-#[test]
+#[cargo_test]
 fn no_main_file() {
     let p = project().file("src/lib.rs", "").build();
 
@@ -158,7 +158,7 @@ fn no_main_file() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn too_many_bins() {
     let p = project()
         .file("src/lib.rs", "")
@@ -189,7 +189,7 @@ fn too_many_bins() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn specify_name() {
     let p = project()
         .file("src/lib.rs", "")
@@ -235,7 +235,7 @@ fn specify_name() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn specify_default_run() {
     let p = project()
         .file(
@@ -269,7 +269,7 @@ fn specify_default_run() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn bogus_default_run() {
     let p = project()
         .file(
@@ -295,7 +295,7 @@ fn bogus_default_run() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn default_run_unstable() {
     let p = project()
         .file(
@@ -347,7 +347,7 @@ consider adding `cargo-features = ["default-run"]` to the manifest
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn run_example() {
     let p = project()
         .file("src/lib.rs", "")
@@ -366,7 +366,7 @@ fn run_example() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn run_library_example() {
     let p = project()
         .file(
@@ -391,7 +391,7 @@ fn run_library_example() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn run_bin_example() {
     let p = project()
         .file(
@@ -458,7 +458,7 @@ fn autodiscover_examples_project(rust_edition: &str, autoexamples: Option<bool>)
         .build()
 }
 
-#[test]
+#[cargo_test]
 fn run_example_autodiscover_2015() {
     let p = autodiscover_examples_project("2015", None);
     p.cargo("run --example a")
@@ -486,7 +486,7 @@ error: no example target named `a`
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn run_example_autodiscover_2015_with_autoexamples_enabled() {
     let p = autodiscover_examples_project("2015", Some(true));
     p.cargo("run --example a")
@@ -500,7 +500,7 @@ fn run_example_autodiscover_2015_with_autoexamples_enabled() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn run_example_autodiscover_2015_with_autoexamples_disabled() {
     let p = autodiscover_examples_project("2015", Some(false));
     p.cargo("run --example a")
@@ -509,7 +509,7 @@ fn run_example_autodiscover_2015_with_autoexamples_disabled() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn run_example_autodiscover_2018() {
     let p = autodiscover_examples_project("2018", None);
     p.cargo("run --example a")
@@ -523,7 +523,7 @@ fn run_example_autodiscover_2018() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn autobins_disables() {
     let p = project()
         .file(
@@ -545,7 +545,7 @@ fn autobins_disables() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn run_bins() {
     let p = project()
         .file("src/lib.rs", "")
@@ -561,7 +561,7 @@ fn run_bins() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn run_with_filename() {
     let p = project()
         .file("src/lib.rs", "")
@@ -606,7 +606,7 @@ Did you mean `a`?",
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn either_name_or_example() {
     let p = project()
         .file("src/bin/a.rs", r#"fn main() { println!("hello a.rs"); }"#)
@@ -623,7 +623,7 @@ fn either_name_or_example() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn one_bin_multiple_examples() {
     let p = project()
         .file("src/lib.rs", "")
@@ -646,7 +646,7 @@ fn one_bin_multiple_examples() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn example_with_release_flag() {
     let p = project()
         .file(
@@ -751,7 +751,7 @@ slow2",
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn run_dylib_dep() {
     let p = project()
         .file(
@@ -789,7 +789,7 @@ fn run_dylib_dep() {
     p.cargo("run hello world").run();
 }
 
-#[test]
+#[cargo_test]
 fn release_works() {
     let p = project()
         .file(
@@ -812,7 +812,7 @@ fn release_works() {
     assert!(p.release_bin("foo").is_file());
 }
 
-#[test]
+#[cargo_test]
 fn run_bin_different_name() {
     let p = project()
         .file(
@@ -833,7 +833,7 @@ fn run_bin_different_name() {
     p.cargo("run").run();
 }
 
-#[test]
+#[cargo_test]
 fn dashes_are_forwarded() {
     let p = project()
         .file(
@@ -853,7 +853,7 @@ fn dashes_are_forwarded() {
     p.cargo("run -- -- a -- b").run();
 }
 
-#[test]
+#[cargo_test]
 fn run_from_executable_folder() {
     let p = project()
         .file("src/main.rs", r#"fn main() { println!("hello"); }"#)
@@ -873,7 +873,7 @@ fn run_from_executable_folder() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn run_with_library_paths() {
     let p = project();
 
@@ -930,7 +930,7 @@ fn run_with_library_paths() {
     p.cargo("run").run();
 }
 
-#[test]
+#[cargo_test]
 fn library_paths_sorted_alphabetically() {
     let p = project();
 
@@ -990,7 +990,7 @@ fn library_paths_sorted_alphabetically() {
     p.cargo("run").run();
 }
 
-#[test]
+#[cargo_test]
 fn fail_no_extra_verbose() {
     let p = project()
         .file("src/main.rs", "fn main() { std::process::exit(1); }")
@@ -1003,7 +1003,7 @@ fn fail_no_extra_verbose() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn run_multiple_packages() {
     let p = project()
         .no_manifest()
@@ -1066,7 +1066,7 @@ fn run_multiple_packages() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn explicit_bin_with_args() {
     let p = project()
         .file(
@@ -1083,7 +1083,7 @@ fn explicit_bin_with_args() {
     p.cargo("run --bin foo hello world").run();
 }
 
-#[test]
+#[cargo_test]
 fn run_workspace() {
     let p = project()
         .file(
@@ -1110,7 +1110,7 @@ available binaries: a, b",
     p.cargo("run --bin a").with_stdout("run-a").run();
 }
 
-#[test]
+#[cargo_test]
 fn default_run_workspace() {
     let p = project()
         .file(
@@ -1142,7 +1142,7 @@ fn default_run_workspace() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 #[cfg(target_os = "macos")]
 fn run_link_system_path_macos() {
     use crate::support::paths::{self, CargoPathExt};

--- a/tests/testsuite/rustc.rs
+++ b/tests/testsuite/rustc.rs
@@ -4,7 +4,7 @@ const CARGO_RUSTC_ERROR: &str =
     "[ERROR] extra arguments to `rustc` can only be passed to one target, consider filtering
 the package by passing, e.g., `--lib` or `--bin NAME` to specify a single target";
 
-#[test]
+#[cargo_test]
 fn build_lib_for_foo() {
     let p = project()
         .file("src/main.rs", "fn main() {}")
@@ -26,7 +26,7 @@ fn build_lib_for_foo() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn lib() {
     let p = project()
         .file("src/main.rs", "fn main() {}")
@@ -49,7 +49,7 @@ fn lib() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn build_main_and_allow_unstable_options() {
     let p = project()
         .file("src/main.rs", "fn main() {}")
@@ -80,7 +80,7 @@ fn build_main_and_allow_unstable_options() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn fails_when_trying_to_build_main_and_lib_with_args() {
     let p = project()
         .file("src/main.rs", "fn main() {}")
@@ -93,7 +93,7 @@ fn fails_when_trying_to_build_main_and_lib_with_args() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn build_with_args_to_one_of_multiple_binaries() {
     let p = project()
         .file("src/bin/foo.rs", "fn main() {}")
@@ -117,7 +117,7 @@ fn build_with_args_to_one_of_multiple_binaries() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn fails_with_args_to_all_binaries() {
     let p = project()
         .file("src/bin/foo.rs", "fn main() {}")
@@ -132,7 +132,7 @@ fn fails_with_args_to_all_binaries() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn build_with_args_to_one_of_multiple_tests() {
     let p = project()
         .file("tests/foo.rs", r#" "#)
@@ -156,7 +156,7 @@ fn build_with_args_to_one_of_multiple_tests() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn build_foo_with_bar_dependency() {
     let foo = project()
         .file(
@@ -192,7 +192,7 @@ fn build_foo_with_bar_dependency() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn build_only_bar_dependency() {
     let foo = project()
         .file(
@@ -226,7 +226,7 @@ fn build_only_bar_dependency() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn targets_selected_default() {
     let p = project().file("src/main.rs", "fn main() {}").build();
     p.cargo("rustc -v")
@@ -251,7 +251,7 @@ fn targets_selected_default() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn targets_selected_all() {
     let p = project().file("src/main.rs", "fn main() {}").build();
     p.cargo("rustc -v --all-targets")
@@ -270,7 +270,7 @@ fn targets_selected_all() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn fail_with_multiple_packages() {
     let foo = project()
         .file(
@@ -328,7 +328,7 @@ error: The argument '--package <SPEC>' was provided more than once, \
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn rustc_with_other_profile() {
     let p = project()
         .file(
@@ -359,7 +359,7 @@ fn rustc_with_other_profile() {
     p.cargo("rustc --profile test").run();
 }
 
-#[test]
+#[cargo_test]
 fn rustc_fingerprint() {
     // Verify that the fingerprint includes the rustc args.
     let p = project()
@@ -407,7 +407,7 @@ fn rustc_fingerprint() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn rustc_test_with_implicit_bin() {
     let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))

--- a/tests/testsuite/rustc_info_cache.rs
+++ b/tests/testsuite/rustc_info_cache.rs
@@ -2,7 +2,7 @@ use crate::support::paths::CargoPathExt;
 use crate::support::{basic_manifest, project};
 use std::env;
 
-#[test]
+#[cargo_test]
 fn rustc_info_cache() {
     let p = project()
         .file("src/main.rs", r#"fn main() { println!("hello"); }"#)

--- a/tests/testsuite/rustdoc.rs
+++ b/tests/testsuite/rustdoc.rs
@@ -1,6 +1,6 @@
 use crate::support::{basic_manifest, project};
 
-#[test]
+#[cargo_test]
 fn rustdoc_simple() {
     let p = project().file("src/lib.rs", "").build();
 
@@ -17,7 +17,7 @@ fn rustdoc_simple() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn rustdoc_args() {
     let p = project().file("src/lib.rs", "").build();
 
@@ -35,7 +35,7 @@ fn rustdoc_args() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn rustdoc_foo_with_bar_dependency() {
     let foo = project()
         .file(
@@ -75,7 +75,7 @@ fn rustdoc_foo_with_bar_dependency() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn rustdoc_only_bar_dependency() {
     let foo = project()
         .file(
@@ -112,7 +112,7 @@ fn rustdoc_only_bar_dependency() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn rustdoc_same_name_documents_lib() {
     let p = project()
         .file("src/main.rs", "fn main() {}")
@@ -133,7 +133,7 @@ fn rustdoc_same_name_documents_lib() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn features() {
     let p = project()
         .file(
@@ -156,7 +156,7 @@ fn features() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 #[cfg(all(target_arch = "x86_64", target_os = "linux", target_env = "gnu"))]
 fn rustdoc_target() {
     let p = project().file("src/lib.rs", "").build();

--- a/tests/testsuite/rustdocflags.rs
+++ b/tests/testsuite/rustdocflags.rs
@@ -1,6 +1,6 @@
 use crate::support::project;
 
-#[test]
+#[cargo_test]
 fn parses_env() {
     let p = project().file("src/lib.rs", "").build();
 
@@ -10,7 +10,7 @@ fn parses_env() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn parses_config() {
     let p = project()
         .file("src/lib.rs", "")
@@ -28,7 +28,7 @@ fn parses_config() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn bad_flags() {
     let p = project().file("src/lib.rs", "").build();
 
@@ -39,7 +39,7 @@ fn bad_flags() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn rerun() {
     let p = project().file("src/lib.rs", "").build();
 
@@ -59,7 +59,7 @@ fn rerun() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn rustdocflags_passed_to_rustdoc_through_cargo_test() {
     let p = project()
         .file(
@@ -77,7 +77,7 @@ fn rustdocflags_passed_to_rustdoc_through_cargo_test() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn rustdocflags_passed_to_rustdoc_through_cargo_test_only_once() {
     let p = project().file("src/lib.rs", "").build();
 
@@ -86,7 +86,7 @@ fn rustdocflags_passed_to_rustdoc_through_cargo_test_only_once() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn rustdocflags_misspelled() {
     let p = project().file("src/main.rs", "fn main() { }").build();
 

--- a/tests/testsuite/rustflags.rs
+++ b/tests/testsuite/rustflags.rs
@@ -1360,7 +1360,7 @@ fn env_rustflags_misspelled_build_script() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn reamp_path_prefix_ignored() {
     // Ensure that --remap-path-prefix does not affect metadata hash.
     let p = project().file("src/lib.rs", "").build();

--- a/tests/testsuite/rustflags.rs
+++ b/tests/testsuite/rustflags.rs
@@ -4,7 +4,7 @@ use std::io::Write;
 use crate::support::rustc_host;
 use crate::support::{basic_lib_manifest, basic_manifest, paths, project, project_in_home};
 
-#[test]
+#[cargo_test]
 fn env_rustflags_normal_source() {
     let p = project()
         .file("src/lib.rs", "")
@@ -48,7 +48,7 @@ fn env_rustflags_normal_source() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn env_rustflags_build_script() {
     // RUSTFLAGS should be passed to rustc for build scripts
     // when --target is not specified.
@@ -77,7 +77,7 @@ fn env_rustflags_build_script() {
     p.cargo("build").env("RUSTFLAGS", "--cfg foo").run();
 }
 
-#[test]
+#[cargo_test]
 fn env_rustflags_build_script_dep() {
     // RUSTFLAGS should be passed to rustc for build scripts
     // when --target is not specified.
@@ -114,7 +114,7 @@ fn env_rustflags_build_script_dep() {
     foo.cargo("build").env("RUSTFLAGS", "--cfg foo").run();
 }
 
-#[test]
+#[cargo_test]
 fn env_rustflags_plugin() {
     // RUSTFLAGS should be passed to rustc for plugins
     // when --target is not specified.
@@ -145,7 +145,7 @@ fn env_rustflags_plugin() {
     p.cargo("build").env("RUSTFLAGS", "--cfg foo").run();
 }
 
-#[test]
+#[cargo_test]
 fn env_rustflags_plugin_dep() {
     // RUSTFLAGS should be passed to rustc for plugins
     // when --target is not specified.
@@ -184,7 +184,7 @@ fn env_rustflags_plugin_dep() {
     foo.cargo("build").env("RUSTFLAGS", "--cfg foo").run();
 }
 
-#[test]
+#[cargo_test]
 fn env_rustflags_normal_source_with_target() {
     let p = project()
         .file("src/lib.rs", "")
@@ -235,7 +235,7 @@ fn env_rustflags_normal_source_with_target() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn env_rustflags_build_script_with_target() {
     // RUSTFLAGS should not be passed to rustc for build scripts
     // when --target is specified.
@@ -268,7 +268,7 @@ fn env_rustflags_build_script_with_target() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn env_rustflags_build_script_dep_with_target() {
     // RUSTFLAGS should not be passed to rustc for build scripts
     // when --target is specified.
@@ -309,7 +309,7 @@ fn env_rustflags_build_script_dep_with_target() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn env_rustflags_plugin_with_target() {
     // RUSTFLAGS should not be passed to rustc for plugins
     // when --target is specified.
@@ -344,7 +344,7 @@ fn env_rustflags_plugin_with_target() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn env_rustflags_plugin_dep_with_target() {
     // RUSTFLAGS should not be passed to rustc for plugins
     // when --target is specified.
@@ -387,7 +387,7 @@ fn env_rustflags_plugin_dep_with_target() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn env_rustflags_recompile() {
     let p = project().file("src/lib.rs", "").build();
 
@@ -400,7 +400,7 @@ fn env_rustflags_recompile() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn env_rustflags_recompile2() {
     let p = project().file("src/lib.rs", "").build();
 
@@ -413,7 +413,7 @@ fn env_rustflags_recompile2() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn env_rustflags_no_recompile() {
     let p = project().file("src/lib.rs", "").build();
 
@@ -424,7 +424,7 @@ fn env_rustflags_no_recompile() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn build_rustflags_normal_source() {
     let p = project()
         .file("src/lib.rs", "")
@@ -469,7 +469,7 @@ fn build_rustflags_normal_source() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn build_rustflags_build_script() {
     // RUSTFLAGS should be passed to rustc for build scripts
     // when --target is not specified.
@@ -505,7 +505,7 @@ fn build_rustflags_build_script() {
     p.cargo("build").run();
 }
 
-#[test]
+#[cargo_test]
 fn build_rustflags_build_script_dep() {
     // RUSTFLAGS should be passed to rustc for build scripts
     // when --target is not specified.
@@ -549,7 +549,7 @@ fn build_rustflags_build_script_dep() {
     foo.cargo("build").run();
 }
 
-#[test]
+#[cargo_test]
 fn build_rustflags_plugin() {
     // RUSTFLAGS should be passed to rustc for plugins
     // when --target is not specified.
@@ -587,7 +587,7 @@ fn build_rustflags_plugin() {
     p.cargo("build").run();
 }
 
-#[test]
+#[cargo_test]
 fn build_rustflags_plugin_dep() {
     // RUSTFLAGS should be passed to rustc for plugins
     // when --target is not specified.
@@ -633,7 +633,7 @@ fn build_rustflags_plugin_dep() {
     foo.cargo("build").run();
 }
 
-#[test]
+#[cargo_test]
 fn build_rustflags_normal_source_with_target() {
     let p = project()
         .file("src/lib.rs", "")
@@ -686,7 +686,7 @@ fn build_rustflags_normal_source_with_target() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn build_rustflags_build_script_with_target() {
     // RUSTFLAGS should not be passed to rustc for build scripts
     // when --target is specified.
@@ -723,7 +723,7 @@ fn build_rustflags_build_script_with_target() {
     p.cargo("build --target").arg(host).run();
 }
 
-#[test]
+#[cargo_test]
 fn build_rustflags_build_script_dep_with_target() {
     // RUSTFLAGS should not be passed to rustc for build scripts
     // when --target is specified.
@@ -768,7 +768,7 @@ fn build_rustflags_build_script_dep_with_target() {
     foo.cargo("build --target").arg(host).run();
 }
 
-#[test]
+#[cargo_test]
 fn build_rustflags_plugin_with_target() {
     // RUSTFLAGS should not be passed to rustc for plugins
     // when --target is specified.
@@ -807,7 +807,7 @@ fn build_rustflags_plugin_with_target() {
     p.cargo("build --target").arg(host).run();
 }
 
-#[test]
+#[cargo_test]
 fn build_rustflags_plugin_dep_with_target() {
     // RUSTFLAGS should not be passed to rustc for plugins
     // when --target is specified.
@@ -854,7 +854,7 @@ fn build_rustflags_plugin_dep_with_target() {
     foo.cargo("build --target").arg(host).run();
 }
 
-#[test]
+#[cargo_test]
 fn build_rustflags_recompile() {
     let p = project().file("src/lib.rs", "").build();
 
@@ -876,7 +876,7 @@ fn build_rustflags_recompile() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn build_rustflags_recompile2() {
     let p = project().file("src/lib.rs", "").build();
 
@@ -898,7 +898,7 @@ fn build_rustflags_recompile2() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn build_rustflags_no_recompile() {
     let p = project()
         .file("src/lib.rs", "")
@@ -918,7 +918,7 @@ fn build_rustflags_no_recompile() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn build_rustflags_with_home_config() {
     // We need a config file inside the home directory
     let home = paths::home();
@@ -941,7 +941,7 @@ fn build_rustflags_with_home_config() {
     p.cargo("build -v").run();
 }
 
-#[test]
+#[cargo_test]
 fn target_rustflags_normal_source() {
     let p = project()
         .file("src/lib.rs", "")
@@ -990,7 +990,7 @@ fn target_rustflags_normal_source() {
 }
 
 // target.{}.rustflags takes precedence over build.rustflags
-#[test]
+#[cargo_test]
 fn target_rustflags_precedence() {
     let p = project()
         .file("src/lib.rs", "")
@@ -1034,7 +1034,7 @@ fn target_rustflags_precedence() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn cfg_rustflags_normal_source() {
     let p = project()
         .file("src/lib.rs", "pub fn t() {}")
@@ -1113,7 +1113,7 @@ fn cfg_rustflags_normal_source() {
 }
 
 // target.'cfg(...)'.rustflags takes precedence over build.rustflags
-#[test]
+#[cargo_test]
 fn cfg_rustflags_precedence() {
     let p = project()
         .file("src/lib.rs", "pub fn t() {}")
@@ -1194,7 +1194,7 @@ fn cfg_rustflags_precedence() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn target_rustflags_string_and_array_form1() {
     let p1 = project()
         .file("src/lib.rs", "")
@@ -1239,7 +1239,7 @@ fn target_rustflags_string_and_array_form1() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn target_rustflags_string_and_array_form2() {
     let p1 = project()
         .file(
@@ -1290,7 +1290,7 @@ fn target_rustflags_string_and_array_form2() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn two_matching_in_config() {
     let p1 = project()
         .file(
@@ -1326,7 +1326,7 @@ fn two_matching_in_config() {
     p1.cargo("build").with_stderr("[FINISHED] [..]").run();
 }
 
-#[test]
+#[cargo_test]
 fn env_rustflags_misspelled() {
     let p = project().file("src/main.rs", "fn main() { }").build();
 
@@ -1338,7 +1338,7 @@ fn env_rustflags_misspelled() {
     }
 }
 
-#[test]
+#[cargo_test]
 fn env_rustflags_misspelled_build_script() {
     let p = project()
         .file(

--- a/tests/testsuite/search.rs
+++ b/tests/testsuite/search.rs
@@ -97,7 +97,7 @@ registry = '{reg}'
         .unwrap();
 }
 
-#[test]
+#[cargo_test]
 fn not_update() {
     setup();
     set_cargo_config();
@@ -119,7 +119,7 @@ fn not_update() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn replace_default() {
     setup();
     set_cargo_config();
@@ -130,7 +130,7 @@ fn replace_default() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn simple() {
     setup();
 
@@ -142,7 +142,7 @@ fn simple() {
 
 // TODO: Deprecated
 // remove once it has been decided '--host' can be safely removed
-#[test]
+#[cargo_test]
 fn simple_with_host() {
     setup();
 
@@ -168,7 +168,7 @@ about this warning.
 
 // TODO: Deprecated
 // remove once it has been decided '--host' can be safely removed
-#[test]
+#[cargo_test]
 fn simple_with_index_and_host() {
     setup();
 
@@ -194,7 +194,7 @@ about this warning.
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn multiple_query_params() {
     setup();
 
@@ -204,7 +204,7 @@ fn multiple_query_params() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn help() {
     cargo_process("search -h").run();
     cargo_process("help search").run();

--- a/tests/testsuite/shell_quoting.rs
+++ b/tests/testsuite/shell_quoting.rs
@@ -4,7 +4,7 @@
 
 use crate::support::project;
 
-#[test]
+#[cargo_test]
 fn features_are_quoted() {
     let p = project()
         .file(

--- a/tests/testsuite/small_fd_limits.rs
+++ b/tests/testsuite/small_fd_limits.rs
@@ -89,7 +89,7 @@ fn run_test(path_env: Option<&OsStr>) {
     );
 }
 
-#[test]
+#[cargo_test]
 fn use_git_gc() {
     if Command::new("git").arg("--version").output().is_err() {
         return;
@@ -97,7 +97,7 @@ fn use_git_gc() {
     run_test(None);
 }
 
-#[test]
+#[cargo_test]
 // it looks like this test passes on some windows machines but not others,
 // notably not on AppVeyor's machines. Sounds like another but for another day.
 #[cfg_attr(windows, ignore)]

--- a/tests/testsuite/support/cargo-test-macro/Cargo.toml
+++ b/tests/testsuite/support/cargo-test-macro/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "cargo-test-macro"
+version = "0.1.0"
+authors = ["Jethro Beekman <jethro@fortanix.com>"]
+edition = "2018"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+quote = "0.6"
+syn = { version = "0.15", features = ["full"] }

--- a/tests/testsuite/support/cargo-test-macro/Cargo.toml
+++ b/tests/testsuite/support/cargo-test-macro/Cargo.toml
@@ -3,6 +3,11 @@ name = "cargo-test-macro"
 version = "0.1.0"
 authors = ["Jethro Beekman <jethro@fortanix.com>"]
 edition = "2018"
+license = "MIT OR Apache-2.0"
+homepage = "https://github.com/rust-lang/cargo"
+repository = "https://github.com/rust-lang/cargo"
+documentation = "https://github.com/rust-lang/cargo"
+description = "Helper proc-macro for Cargo's testsuite."
 
 [lib]
 proc-macro = true

--- a/tests/testsuite/support/cargo-test-macro/src/lib.rs
+++ b/tests/testsuite/support/cargo-test-macro/src/lib.rs
@@ -1,0 +1,24 @@
+extern crate proc_macro;
+
+use quote::{quote, ToTokens};
+use syn::{*, parse::Parser};
+
+#[proc_macro_attribute]
+pub fn cargo_test(
+    _attr: proc_macro::TokenStream,
+    item: proc_macro::TokenStream,
+) -> proc_macro::TokenStream {
+    let mut fn_def = parse_macro_input!(item as ItemFn);
+
+    let attr = quote! {
+        #[test]
+    };
+    fn_def.attrs.extend(Attribute::parse_outer.parse2(attr).unwrap());
+
+    let stmt = quote! {
+        let _test_guard = crate::support::paths::init_root();
+    };
+    fn_def.block.stmts.insert(0, parse2(stmt).unwrap());
+
+    fn_def.into_token_stream().into()
+}

--- a/tests/testsuite/support/mod.rs
+++ b/tests/testsuite/support/mod.rs
@@ -1397,7 +1397,7 @@ pub fn lines_match(expected: &str, actual: &str) -> bool {
     actual.is_empty() || expected.ends_with("[..]")
 }
 
-#[test]
+#[cargo_test]
 fn lines_match_works() {
     assert!(lines_match("a b", "a b"));
     assert!(lines_match("a[..]b", "a b"));

--- a/tests/testsuite/support/paths.rs
+++ b/tests/testsuite/support/paths.rs
@@ -1,58 +1,93 @@
-use std::cell::Cell;
+use std::cell::RefCell;
+use std::collections::HashMap;
 use std::env;
 use std::fs;
 use std::io::{self, ErrorKind};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::{Once, ONCE_INIT};
+use std::sync::Mutex;
 
 use filetime::{self, FileTime};
+use lazy_static::lazy_static;
 
 static CARGO_INTEGRATION_TEST_DIR: &'static str = "cit";
-static NEXT_ID: AtomicUsize = AtomicUsize::new(0);
 
-thread_local!(static TASK_ID: usize = NEXT_ID.fetch_add(1, Ordering::SeqCst));
+lazy_static! {
+    static ref GLOBAL_ROOT: PathBuf = {
+        let mut path = t!(env::current_exe());
+        path.pop(); // chop off exe name
+        path.pop(); // chop off 'debug'
 
-fn init() {
-    static GLOBAL_INIT: Once = ONCE_INIT;
-    thread_local!(static LOCAL_INIT: Cell<bool> = Cell::new(false));
-    GLOBAL_INIT.call_once(|| {
-        global_root().mkdir_p();
-    });
-    LOCAL_INIT.with(|i| {
-        if i.get() {
-            return;
+        // If `cargo test` is run manually then our path looks like
+        // `target/debug/foo`, in which case our `path` is already pointing at
+        // `target`. If, however, `cargo test --target $target` is used then the
+        // output is `target/$target/debug/foo`, so our path is pointing at
+        // `target/$target`. Here we conditionally pop the `$target` name.
+        if path.file_name().and_then(|s| s.to_str()) != Some("target") {
+            path.pop();
         }
-        i.set(true);
-        root().rm_rf();
-        home().mkdir_p();
-    })
+
+        path.push(CARGO_INTEGRATION_TEST_DIR);
+
+        path.rm_rf();
+        path.mkdir_p();
+
+        path
+    };
+
+    static ref TEST_ROOTS: Mutex<HashMap<String, PathBuf>> = Default::default();
 }
 
-fn global_root() -> PathBuf {
-    let mut path = t!(env::current_exe());
-    path.pop(); // chop off exe name
-    path.pop(); // chop off 'debug'
+// We need to give each test a unique id. The test name could serve this
+// purpose, but the `test` crate doesn't have a way to obtain the current test
+// name.[*] Instead, we used the `cargo-test-macro` crate to automatically
+// insert an init function for each test that sets the test name in a thread
+// local variable.
+//
+// [*] It does set the thread name, but only when running concurrently. If not
+// running concurrently, all tests are run on the main thread.
+thread_local! {
+    static TEST_ID: RefCell<Option<usize>> = RefCell::new(None);
+}
 
-    // If `cargo test` is run manually then our path looks like
-    // `target/debug/foo`, in which case our `path` is already pointing at
-    // `target`. If, however, `cargo test --target $target` is used then the
-    // output is `target/$target/debug/foo`, so our path is pointing at
-    // `target/$target`. Here we conditionally pop the `$target` name.
-    if path.file_name().and_then(|s| s.to_str()) != Some("target") {
-        path.pop();
+pub struct TestIdGuard {
+    _private: ()
+}
+
+pub fn init_root() -> TestIdGuard {
+    static NEXT_ID: AtomicUsize = AtomicUsize::new(0);
+
+    let id = NEXT_ID.fetch_add(1, Ordering::Relaxed);
+    TEST_ID.with(|n| { *n.borrow_mut() = Some(id) } );
+
+    let guard = TestIdGuard {
+        _private: ()
+    };
+
+    root().mkdir_p();
+
+    guard
+}
+
+impl Drop for TestIdGuard {
+    fn drop(&mut self) {
+        TEST_ID.with(|n| { *n.borrow_mut() = None } );
     }
-
-    path.join(CARGO_INTEGRATION_TEST_DIR)
 }
 
 pub fn root() -> PathBuf {
-    init();
-    global_root().join(&TASK_ID.with(|my_id| format!("t{}", my_id)))
+    let id = TEST_ID.with(|n| {
+        n.borrow().expect("Tests must use the `#[cargo_test]` attribute in \
+                            order to be able to use the crate root.")
+    } );
+    GLOBAL_ROOT.join(&format!("t{}", id))
 }
 
 pub fn home() -> PathBuf {
-    root().join("home")
+    let mut path = root();
+    path.push("home");
+    path.mkdir_p();
+    path
 }
 
 pub trait CargoPathExt {

--- a/tests/testsuite/support/resolver.rs
+++ b/tests/testsuite/support/resolver.rs
@@ -663,7 +663,7 @@ impl fmt::Debug for PrettyPrintRegistry {
     }
 }
 
-#[test]
+#[cargo_test]
 fn meta_test_deep_pretty_print_registry() {
     assert_eq!(
         &format!(
@@ -839,7 +839,7 @@ pub fn registry_strategy(
 
 /// This test is to test the generator to ensure
 /// that it makes registries with large dependency trees
-#[test]
+#[cargo_test]
 fn meta_test_deep_trees_from_strategy() {
     let mut dis = [0; 21];
 
@@ -878,7 +878,7 @@ fn meta_test_deep_trees_from_strategy() {
 
 /// This test is to test the generator to ensure
 /// that it makes registries that include multiple versions of the same library
-#[test]
+#[cargo_test]
 fn meta_test_multiple_versions_strategy() {
     let mut dis = [0; 10];
 

--- a/tests/testsuite/test.rs
+++ b/tests/testsuite/test.rs
@@ -3049,7 +3049,7 @@ fn cargo_test_env() {
         #[test]
         fn env_test() {{
             use std::env;
-            println!("{{}}", env::var("{}").unwrap());
+            eprintln!("{{}}", env::var("{}").unwrap());
         }}
         "#,
         cargo::CARGO_ENV
@@ -3062,12 +3062,16 @@ fn cargo_test_env() {
 
     let cargo = cargo_exe().canonicalize().unwrap();
     p.cargo("test --lib -- --nocapture")
-        .with_stdout_contains(format!(
+        .with_stderr_contains(format!(
             "\
 {}
-test env_test ... ok
 ",
             cargo.to_str().unwrap()
+        ))
+        .with_stdout_contains(format!(
+            "\
+test env_test ... ok
+",
         ))
         .run();
 }

--- a/tests/testsuite/test.rs
+++ b/tests/testsuite/test.rs
@@ -8,7 +8,7 @@ use crate::support::registry::Package;
 use crate::support::{basic_bin_manifest, basic_lib_manifest, basic_manifest, cargo_exe, project};
 use crate::support::{rustc_host, sleep_ms};
 
-#[test]
+#[cargo_test]
 fn cargo_test_simple() {
     let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
@@ -46,7 +46,7 @@ fn cargo_test_simple() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn cargo_test_release() {
     let p = project()
         .file(
@@ -104,7 +104,7 @@ fn cargo_test_release() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn cargo_test_overflow_checks() {
     let p = project()
         .file(
@@ -141,7 +141,7 @@ fn cargo_test_overflow_checks() {
     p.process(&p.release_bin("foo")).with_stdout("").run();
 }
 
-#[test]
+#[cargo_test]
 fn cargo_test_quiet_with_harness() {
     let p = project()
         .file(
@@ -180,7 +180,7 @@ test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn cargo_test_quiet_no_harness() {
     let p = project()
         .file(
@@ -213,7 +213,7 @@ fn cargo_test_quiet_no_harness() {
     p.cargo("test -q").with_stdout("").with_stderr("").run();
 }
 
-#[test]
+#[cargo_test]
 fn cargo_test_verbose() {
     let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
@@ -239,7 +239,7 @@ fn cargo_test_verbose() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn many_similar_names() {
     let p = project()
         .file(
@@ -273,7 +273,7 @@ fn many_similar_names() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn cargo_test_failing_test_in_bin() {
     let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
@@ -332,7 +332,7 @@ failures:
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn cargo_test_failing_test_in_test() {
     let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
@@ -380,7 +380,7 @@ failures:
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn cargo_test_failing_test_in_lib() {
     let p = project()
         .file("Cargo.toml", &basic_lib_manifest("foo"))
@@ -416,7 +416,7 @@ failures:
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn test_with_lib_dep() {
     let p = project()
         .file(
@@ -476,7 +476,7 @@ fn test_with_lib_dep() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn test_with_deep_lib_dep() {
     let p = project()
         .file(
@@ -528,7 +528,7 @@ fn test_with_deep_lib_dep() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn external_test_explicit() {
     let p = project()
         .file(
@@ -579,7 +579,7 @@ fn external_test_explicit() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn external_test_named_test() {
     let p = project()
         .file(
@@ -601,7 +601,7 @@ fn external_test_named_test() {
     p.cargo("test").run();
 }
 
-#[test]
+#[cargo_test]
 fn external_test_implicit() {
     let p = project()
         .file(
@@ -639,7 +639,7 @@ fn external_test_implicit() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn dont_run_examples() {
     let p = project()
         .file("src/lib.rs", "")
@@ -653,7 +653,7 @@ fn dont_run_examples() {
     p.cargo("test").run();
 }
 
-#[test]
+#[cargo_test]
 fn pass_through_command_line() {
     let p = project()
         .file(
@@ -691,7 +691,7 @@ fn pass_through_command_line() {
 
 // Regression test for running cargo-test twice with
 // tests in an rlib
-#[test]
+#[cargo_test]
 fn cargo_test_twice() {
     let p = project()
         .file("Cargo.toml", &basic_lib_manifest("foo"))
@@ -711,7 +711,7 @@ fn cargo_test_twice() {
     }
 }
 
-#[test]
+#[cargo_test]
 fn lib_bin_same_name() {
     let p = project()
         .file(
@@ -755,7 +755,7 @@ fn lib_bin_same_name() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn lib_with_standard_name() {
     let p = project()
         .file("Cargo.toml", &basic_manifest("syntax", "0.0.1"))
@@ -797,7 +797,7 @@ fn lib_with_standard_name() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn lib_with_standard_name2() {
     let p = project()
         .file(
@@ -839,7 +839,7 @@ fn lib_with_standard_name2() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn lib_without_name() {
     let p = project()
         .file(
@@ -880,7 +880,7 @@ fn lib_without_name() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn bin_without_name() {
     let p = project()
         .file(
@@ -925,7 +925,7 @@ Caused by:
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn bench_without_name() {
     let p = project()
         .file(
@@ -981,7 +981,7 @@ Caused by:
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn test_without_name() {
     let p = project()
         .file(
@@ -1041,7 +1041,7 @@ Caused by:
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn example_without_name() {
     let p = project()
         .file(
@@ -1096,7 +1096,7 @@ Caused by:
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn bin_there_for_integration() {
     let p = project()
         .file(
@@ -1125,7 +1125,7 @@ fn bin_there_for_integration() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn test_dylib() {
     let p = project()
         .file(
@@ -1204,7 +1204,7 @@ fn test_dylib() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn test_twice_with_build_cmd() {
     let p = project()
         .file(
@@ -1245,7 +1245,7 @@ fn test_twice_with_build_cmd() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn test_then_build() {
     let p = project().file("src/lib.rs", "#[test] fn foo() {}").build();
 
@@ -1264,7 +1264,7 @@ fn test_then_build() {
     p.cargo("build").with_stdout("").run();
 }
 
-#[test]
+#[cargo_test]
 fn test_no_run() {
     let p = project()
         .file("src/lib.rs", "#[test] fn foo() { panic!() }")
@@ -1280,7 +1280,7 @@ fn test_no_run() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn test_run_specific_bin_target() {
     let prj = project()
         .file(
@@ -1315,7 +1315,7 @@ fn test_run_specific_bin_target() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn test_run_implicit_bin_target() {
     let prj = project()
         .file(
@@ -1356,7 +1356,7 @@ fn test_run_implicit_bin_target() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn test_run_specific_test_target() {
     let prj = project()
         .file("src/bin/a.rs", "fn main() { }")
@@ -1376,7 +1376,7 @@ fn test_run_specific_test_target() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn test_run_implicit_test_target() {
     let prj = project()
         .file(
@@ -1417,7 +1417,7 @@ fn test_run_implicit_test_target() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn test_run_implicit_bench_target() {
     let prj = project()
         .file(
@@ -1458,7 +1458,7 @@ fn test_run_implicit_bench_target() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn test_run_implicit_example_target() {
     let prj = project()
         .file(
@@ -1532,7 +1532,7 @@ fn test_run_implicit_example_target() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn test_filtered_excludes_compiling_examples() {
     let p = project()
         .file(
@@ -1564,7 +1564,7 @@ test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn test_no_harness() {
     let p = project()
         .file(
@@ -1600,7 +1600,7 @@ fn test_no_harness() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn selective_testing() {
     let p = project()
         .file(
@@ -1696,7 +1696,7 @@ fn selective_testing() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn almost_cyclic_but_not_quite() {
     let p = project()
         .file(
@@ -1747,7 +1747,7 @@ fn almost_cyclic_but_not_quite() {
     p.cargo("test").run();
 }
 
-#[test]
+#[cargo_test]
 fn build_then_selective_test() {
     let p = project()
         .file(
@@ -1785,7 +1785,7 @@ fn build_then_selective_test() {
     p.cargo("test -p b").run();
 }
 
-#[test]
+#[cargo_test]
 fn example_dev_dep() {
     let p = project()
         .file(
@@ -1826,7 +1826,7 @@ fn example_dev_dep() {
     p.cargo("run --example e1 --release -v").run();
 }
 
-#[test]
+#[cargo_test]
 fn selective_testing_with_docs() {
     let p = project()
         .file(
@@ -1878,7 +1878,7 @@ fn selective_testing_with_docs() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn example_bin_same_name() {
     let p = project()
         .file("src/bin/foo.rs", r#"fn main() { println!("bin"); }"#)
@@ -1915,7 +1915,7 @@ fn example_bin_same_name() {
     assert!(p.bin("foo").is_file());
 }
 
-#[test]
+#[cargo_test]
 fn test_with_example_twice() {
     let p = project()
         .file("src/bin/foo.rs", r#"fn main() { println!("bin"); }"#)
@@ -1930,7 +1930,7 @@ fn test_with_example_twice() {
     assert!(p.bin("examples/foo").is_file());
 }
 
-#[test]
+#[cargo_test]
 fn example_with_dev_dep() {
     let p = project()
         .file(
@@ -1973,7 +1973,7 @@ fn example_with_dev_dep() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn bin_is_preserved() {
     let p = project()
         .file("src/lib.rs", "")
@@ -1988,7 +1988,7 @@ fn bin_is_preserved() {
     assert!(p.bin("foo").is_file());
 }
 
-#[test]
+#[cargo_test]
 fn bad_example() {
     let p = project().file("src/lib.rs", "");
     let p = p.build();
@@ -2003,7 +2003,7 @@ fn bad_example() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn doctest_feature() {
     let p = project()
         .file(
@@ -2042,7 +2042,7 @@ fn doctest_feature() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn dashes_to_underscores() {
     let p = project()
         .file("Cargo.toml", &basic_manifest("foo-bar", "0.0.1"))
@@ -2060,7 +2060,7 @@ fn dashes_to_underscores() {
     p.cargo("test -v").run();
 }
 
-#[test]
+#[cargo_test]
 fn doctest_dev_dep() {
     let p = project()
         .file(
@@ -2091,7 +2091,7 @@ fn doctest_dev_dep() {
     p.cargo("test -v").run();
 }
 
-#[test]
+#[cargo_test]
 fn filter_no_doc_tests() {
     let p = project()
         .file(
@@ -2117,7 +2117,7 @@ fn filter_no_doc_tests() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn dylib_doctest() {
     let p = project()
         .file(
@@ -2156,7 +2156,7 @@ fn dylib_doctest() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn dylib_doctest2() {
     // Can't doc-test dylibs, as they're statically linked together.
     let p = project()
@@ -2188,7 +2188,7 @@ fn dylib_doctest2() {
     p.cargo("test").with_stdout("").run();
 }
 
-#[test]
+#[cargo_test]
 fn cyclic_dev_dep_doc_test() {
     let p = project()
         .file(
@@ -2245,7 +2245,7 @@ fn cyclic_dev_dep_doc_test() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn dev_dep_with_build_script() {
     let p = project()
         .file(
@@ -2278,7 +2278,7 @@ fn dev_dep_with_build_script() {
     p.cargo("test").run();
 }
 
-#[test]
+#[cargo_test]
 fn no_fail_fast() {
     let p = project()
         .file(
@@ -2348,7 +2348,7 @@ fn no_fail_fast() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn test_multiple_packages() {
     let p = project()
         .file(
@@ -2407,7 +2407,7 @@ fn test_multiple_packages() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn bin_does_not_rebuild_tests() {
     let p = project()
         .file("src/lib.rs", "")
@@ -2435,7 +2435,7 @@ fn bin_does_not_rebuild_tests() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn selective_test_wonky_profile() {
     let p = project()
         .file(
@@ -2461,7 +2461,7 @@ fn selective_test_wonky_profile() {
     p.cargo("test -v --no-run --release -p foo -p a").run();
 }
 
-#[test]
+#[cargo_test]
 fn selective_test_optional_dep() {
     let p = project()
         .file(
@@ -2493,7 +2493,7 @@ fn selective_test_optional_dep() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn only_test_docs() {
     let p = project()
         .file(
@@ -2526,7 +2526,7 @@ fn only_test_docs() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn test_panic_abort_with_dep() {
     let p = project()
         .file(
@@ -2559,7 +2559,7 @@ fn test_panic_abort_with_dep() {
     p.cargo("test -v").run();
 }
 
-#[test]
+#[cargo_test]
 fn cfg_test_even_with_no_harness() {
     let p = project()
         .file(
@@ -2593,7 +2593,7 @@ fn cfg_test_even_with_no_harness() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn panic_abort_multiple() {
     let p = project()
         .file(
@@ -2621,7 +2621,7 @@ fn panic_abort_multiple() {
     p.cargo("test --release -v -p foo -p a").run();
 }
 
-#[test]
+#[cargo_test]
 fn pass_correct_cfgs_flags_to_rustdoc() {
     let p = project()
         .file(
@@ -2715,7 +2715,7 @@ fn pass_correct_cfgs_flags_to_rustdoc() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn test_release_ignore_panic() {
     let p = project()
         .file(
@@ -2748,7 +2748,7 @@ fn test_release_ignore_panic() {
     p.cargo("bench -v").run();
 }
 
-#[test]
+#[cargo_test]
 fn test_many_with_features() {
     let p = project()
         .file(
@@ -2776,7 +2776,7 @@ fn test_many_with_features() {
     p.cargo("test -v -p a -p foo --features foo").run();
 }
 
-#[test]
+#[cargo_test]
 fn test_all_workspace() {
     let p = project()
         .file(
@@ -2803,7 +2803,7 @@ fn test_all_workspace() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn test_all_exclude() {
     let p = project()
         .file(
@@ -2832,7 +2832,7 @@ test bar ... ok",
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn test_all_virtual_manifest() {
     let p = project()
         .file(
@@ -2854,7 +2854,7 @@ fn test_all_virtual_manifest() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn test_virtual_manifest_all_implied() {
     let p = project()
         .file(
@@ -2876,7 +2876,7 @@ fn test_virtual_manifest_all_implied() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn test_all_member_dependency_same_name() {
     let p = project()
         .file(
@@ -2907,7 +2907,7 @@ fn test_all_member_dependency_same_name() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn doctest_only_with_dev_dep() {
     let p = project()
         .file(
@@ -2939,7 +2939,7 @@ fn doctest_only_with_dev_dep() {
     p.cargo("test --doc -v").run();
 }
 
-#[test]
+#[cargo_test]
 fn test_many_targets() {
     let p = project()
         .file(
@@ -2993,7 +2993,7 @@ fn test_many_targets() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn doctest_and_registry() {
     let p = project()
         .file(
@@ -3040,7 +3040,7 @@ fn doctest_and_registry() {
     p.cargo("test --all -v").run();
 }
 
-#[test]
+#[cargo_test]
 fn cargo_test_env() {
     let src = format!(
         r#"
@@ -3076,7 +3076,7 @@ test env_test ... ok
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn test_order() {
     let p = project()
         .file("src/lib.rs", "#[test] fn test_lib() {}")
@@ -3108,7 +3108,7 @@ test result: ok. [..]
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn cyclic_dev() {
     let p = project()
         .file(
@@ -3129,7 +3129,7 @@ fn cyclic_dev() {
     p.cargo("test --all").run();
 }
 
-#[test]
+#[cargo_test]
 fn publish_a_crate_without_tests() {
     Package::new("testless", "0.1.0")
         .file(
@@ -3171,7 +3171,7 @@ fn publish_a_crate_without_tests() {
     p.cargo("test --package testless").run();
 }
 
-#[test]
+#[cargo_test]
 fn find_dependency_of_proc_macro_dependency_with_target() {
     let p = project()
         .file(
@@ -3240,7 +3240,7 @@ fn find_dependency_of_proc_macro_dependency_with_target() {
     p.cargo("test --all --target").arg(rustc_host()).run();
 }
 
-#[test]
+#[cargo_test]
 fn test_hint_not_masked_by_doctest() {
     let p = project()
         .file(
@@ -3273,7 +3273,7 @@ fn test_hint_not_masked_by_doctest() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn test_hint_workspace_virtual() {
     let p = project()
         .file(
@@ -3300,7 +3300,7 @@ fn test_hint_workspace_virtual() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn test_hint_workspace_nonvirtual() {
     let p = project()
         .file(
@@ -3329,7 +3329,7 @@ fn test_hint_workspace_nonvirtual() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn json_artifact_includes_test_flag() {
     // Verify that the JSON artifact output includes `test` flag.
     let p = project()
@@ -3379,7 +3379,7 @@ fn json_artifact_includes_test_flag() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn json_artifact_includes_executable_for_library_tests() {
     let p = project()
         .file("src/main.rs", "fn main() { }")
@@ -3411,7 +3411,7 @@ fn json_artifact_includes_executable_for_library_tests() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn json_artifact_includes_executable_for_integration_tests() {
     let p = project()
         .file(
@@ -3445,7 +3445,7 @@ fn json_artifact_includes_executable_for_integration_tests() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn test_build_script_links() {
     let p = project()
         .file(
@@ -3467,7 +3467,7 @@ fn test_build_script_links() {
     p.cargo("test --no-run").run();
 }
 
-#[test]
+#[cargo_test]
 fn doctest_skip_staticlib() {
     let p = project()
         .file(
@@ -3510,7 +3510,7 @@ fn doctest_skip_staticlib() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn can_not_mix_doc_tests_and_regular_tests() {
     let p = project()
         .file(
@@ -3594,7 +3594,7 @@ test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn can_not_no_run_doc_tests() {
     let p = project()
         .file(
@@ -3614,7 +3614,7 @@ pub fn foo() -> u8 { 1 }
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn test_all_targets_lib() {
     let p = project().file("src/lib.rs", "").build();
 
@@ -3629,7 +3629,7 @@ fn test_all_targets_lib() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn test_dep_with_dev() {
     Package::new("devdep", "0.1.0").publish();
     let p = project()

--- a/tests/testsuite/test.rs
+++ b/tests/testsuite/test.rs
@@ -316,7 +316,7 @@ test test_hello ... FAILED
 failures:
 
 ---- test_hello stdout ----
-[..]thread 'test_hello' panicked at 'assertion failed:[..]",
+[..]thread '[..]' panicked at 'assertion failed:[..]",
         )
         .with_stdout_contains("[..]`(left == right)`[..]")
         .with_stdout_contains("[..]left: `\"hello\"`,[..]")
@@ -366,7 +366,7 @@ test test_hello ... FAILED
 failures:
 
 ---- test_hello stdout ----
-[..]thread 'test_hello' panicked at 'assertion failed: false', \
+[..]thread '[..]' panicked at 'assertion failed: false', \
       tests/footest.rs:1[..]
 ",
         )
@@ -402,7 +402,7 @@ test test_hello ... FAILED
 failures:
 
 ---- test_hello stdout ----
-[..]thread 'test_hello' panicked at 'assertion failed: false', \
+[..]thread '[..]' panicked at 'assertion failed: false', \
       src/lib.rs:1[..]
 ",
         )

--- a/tests/testsuite/tool_paths.rs
+++ b/tests/testsuite/tool_paths.rs
@@ -1,7 +1,7 @@
 use crate::support::rustc_host;
 use crate::support::{basic_lib_manifest, project};
 
-#[test]
+#[cargo_test]
 fn pathless_tools() {
     let target = rustc_host();
 
@@ -32,7 +32,7 @@ fn pathless_tools() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn absolute_tools() {
     let target = rustc_host();
 
@@ -71,7 +71,7 @@ fn absolute_tools() {
 ").run();
 }
 
-#[test]
+#[cargo_test]
 fn relative_tools() {
     let target = rustc_host();
 
@@ -115,7 +115,7 @@ fn relative_tools() {
         )).run();
 }
 
-#[test]
+#[cargo_test]
 fn custom_runner() {
     let target = rustc_host();
 
@@ -173,7 +173,7 @@ fn custom_runner() {
 }
 
 // can set a custom runner via `target.'cfg(..)'.runner`
-#[test]
+#[cargo_test]
 fn custom_runner_cfg() {
     let p = project()
         .file("src/main.rs", "fn main() {}")
@@ -199,7 +199,7 @@ fn custom_runner_cfg() {
 }
 
 // custom runner set via `target.$triple.runner` have precende over `target.'cfg(..)'.runner`
-#[test]
+#[cargo_test]
 fn custom_runner_cfg_precedence() {
     let target = rustc_host();
 
@@ -232,7 +232,7 @@ fn custom_runner_cfg_precedence() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn custom_runner_cfg_collision() {
     let p = project()
         .file("src/main.rs", "fn main() {}")

--- a/tests/testsuite/update.rs
+++ b/tests/testsuite/update.rs
@@ -4,7 +4,7 @@ use std::io::prelude::*;
 use crate::support::registry::Package;
 use crate::support::{basic_manifest, project};
 
-#[test]
+#[cargo_test]
 fn minor_update_two_places() {
     Package::new("log", "0.1.0").publish();
     let p = project()
@@ -58,7 +58,7 @@ fn minor_update_two_places() {
     p.cargo("build").run();
 }
 
-#[test]
+#[cargo_test]
 fn transitive_minor_update() {
     Package::new("log", "0.1.0").publish();
     Package::new("serde", "0.1.0").dep("log", "0.1").publish();
@@ -117,7 +117,7 @@ fn transitive_minor_update() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn conservative() {
     Package::new("log", "0.1.0").publish();
     Package::new("serde", "0.1.0").dep("log", "0.1").publish();
@@ -168,7 +168,7 @@ fn conservative() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn update_via_new_dep() {
     Package::new("log", "0.1.0").publish();
     let p = project()
@@ -208,7 +208,7 @@ fn update_via_new_dep() {
     p.cargo("build").env("CARGO_LOG", "cargo=trace").run();
 }
 
-#[test]
+#[cargo_test]
 fn update_via_new_member() {
     Package::new("log", "0.1.0").publish();
     let p = project()
@@ -250,7 +250,7 @@ fn update_via_new_member() {
     p.cargo("build").run();
 }
 
-#[test]
+#[cargo_test]
 fn add_dep_deep_new_requirement() {
     Package::new("log", "0.1.0").publish();
     let p = project()
@@ -279,7 +279,7 @@ fn add_dep_deep_new_requirement() {
     p.cargo("build").run();
 }
 
-#[test]
+#[cargo_test]
 fn everything_real_deep() {
     Package::new("log", "0.1.0").publish();
     Package::new("foo", "0.1.0").dep("log", "0.1").publish();
@@ -309,7 +309,7 @@ fn everything_real_deep() {
     p.cargo("build").run();
 }
 
-#[test]
+#[cargo_test]
 fn change_package_version() {
     let p = project()
         .file(
@@ -345,7 +345,7 @@ fn change_package_version() {
     p.cargo("build").run();
 }
 
-#[test]
+#[cargo_test]
 fn update_precise() {
     Package::new("log", "0.1.0").publish();
     Package::new("serde", "0.1.0").publish();
@@ -398,7 +398,7 @@ fn update_precise() {
 // cargo update should respect its arguments even without a lockfile.
 // See issue "Running cargo update without a Cargo.lock ignores arguments"
 // at <https://github.com/rust-lang/cargo/issues/6872>.
-#[test]
+#[cargo_test]
 fn update_precise_first_run() {
     Package::new("serde", "0.1.0").publish();
     Package::new("serde", "0.2.0").publish();
@@ -558,7 +558,7 @@ fn update_precise_first_run() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn preserve_top_comment() {
     let p = project().file("src/lib.rs", "").build();
 
@@ -583,7 +583,7 @@ fn preserve_top_comment() {
     assert_eq!(lockfile, lockfile2);
 }
 
-#[test]
+#[cargo_test]
 fn dry_run_update() {
     Package::new("log", "0.1.0").publish();
     Package::new("serde", "0.1.0").dep("log", "0.1").publish();

--- a/tests/testsuite/vendor.rs
+++ b/tests/testsuite/vendor.rs
@@ -2,7 +2,7 @@ use crate::support::git;
 use crate::support::registry::Package;
 use crate::support::{basic_lib_manifest, project, Project};
 
-#[test]
+#[cargo_test]
 fn vendor_simple() {
     let p = project()
         .file(
@@ -42,7 +42,7 @@ fn add_vendor_config(p: &Project) {
     );
 }
 
-#[test]
+#[cargo_test]
 fn two_versions() {
     let p = project()
         .file(
@@ -86,13 +86,13 @@ fn two_versions() {
     p.cargo("build").run();
 }
 
-#[test]
+#[cargo_test]
 fn help() {
     let p = project().build();
     p.cargo("vendor -h").run();
 }
 
-#[test]
+#[cargo_test]
 fn update_versions() {
     let p = project()
         .file(
@@ -134,7 +134,7 @@ fn update_versions() {
     assert!(lock.contains("version = \"0.8.0\""));
 }
 
-#[test]
+#[cargo_test]
 fn two_lockfiles() {
     let p = project()
         .no_manifest()
@@ -180,7 +180,7 @@ fn two_lockfiles() {
     p.cargo("build").cwd("bar").run();
 }
 
-#[test]
+#[cargo_test]
 fn delete_old_crates() {
     let p = project()
         .file(
@@ -221,7 +221,7 @@ fn delete_old_crates() {
     assert!(!p.root().join("vendor/bitflags/Cargo.toml").exists());
 }
 
-#[test]
+#[cargo_test]
 fn ignore_files() {
     let p = project()
         .file(
@@ -255,7 +255,7 @@ fn ignore_files() {
     assert!(!csum.contains("foo.rej"));
 }
 
-#[test]
+#[cargo_test]
 fn included_files_only() {
     let git = git::new("a", |p| {
         p.file("Cargo.toml", &basic_lib_manifest("a"))
@@ -288,7 +288,7 @@ fn included_files_only() {
     assert!(!csum.contains("a/b.md"));
 }
 
-#[test]
+#[cargo_test]
 fn dependent_crates_in_crates() {
     let git = git::new("a", |p| {
         p.file(
@@ -330,7 +330,7 @@ fn dependent_crates_in_crates() {
     p.read_file("vendor/b/.cargo-checksum.json");
 }
 
-#[test]
+#[cargo_test]
 fn vendoring_git_crates() {
     let git = git::new("git", |p| {
         p.file("Cargo.toml", &basic_lib_manifest("serde_derive"))
@@ -374,7 +374,7 @@ fn vendoring_git_crates() {
     p.cargo("build").run();
 }
 
-#[test]
+#[cargo_test]
 fn git_simple() {
     let git = git::new("git", |p| {
         p.file("Cargo.toml", &basic_lib_manifest("a"))
@@ -405,7 +405,7 @@ fn git_simple() {
     assert!(csum.contains("\"package\":null"));
 }
 
-#[test]
+#[cargo_test]
 fn git_duplicate() {
     let git = git::new("a", |p| {
         p.file(
@@ -466,7 +466,7 @@ Caused by:
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn depend_on_vendor_dir_not_deleted() {
     let p = project()
         .file(

--- a/tests/testsuite/verify_project.rs
+++ b/tests/testsuite/verify_project.rs
@@ -4,7 +4,7 @@ fn verify_project_success_output() -> String {
     r#"{"success":"true"}"#.into()
 }
 
-#[test]
+#[cargo_test]
 fn cargo_verify_project_path_to_cargo_toml_relative() {
     let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
@@ -17,7 +17,7 @@ fn cargo_verify_project_path_to_cargo_toml_relative() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn cargo_verify_project_path_to_cargo_toml_absolute() {
     let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
@@ -31,7 +31,7 @@ fn cargo_verify_project_path_to_cargo_toml_absolute() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn cargo_verify_project_cwd() {
     let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
@@ -43,7 +43,7 @@ fn cargo_verify_project_cwd() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn cargo_verify_project_honours_unstable_features() {
     let p = project()
         .file(

--- a/tests/testsuite/version.rs
+++ b/tests/testsuite/version.rs
@@ -1,7 +1,7 @@
 use crate::support::project;
 use cargo;
 
-#[test]
+#[cargo_test]
 fn simple() {
     let p = project().build();
 
@@ -14,20 +14,20 @@ fn simple() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 #[cfg_attr(target_os = "windows", ignore)]
 fn version_works_without_rustc() {
     let p = project().build();
     p.cargo("version").env("PATH", "").run();
 }
 
-#[test]
+#[cargo_test]
 fn version_works_with_bad_config() {
     let p = project().file(".cargo/config", "this is not toml").build();
     p.cargo("version").run();
 }
 
-#[test]
+#[cargo_test]
 fn version_works_with_bad_target_dir() {
     let p = project()
         .file(

--- a/tests/testsuite/warn_on_failure.rs
+++ b/tests/testsuite/warn_on_failure.rs
@@ -53,7 +53,7 @@ fn make_upstream(main_src: &str) -> Project {
         .build()
 }
 
-#[test]
+#[cargo_test]
 fn no_warning_on_success() {
     make_lib("");
     let upstream = make_upstream("");
@@ -72,7 +72,7 @@ fn no_warning_on_success() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn no_warning_on_bin_failure() {
     make_lib("");
     let upstream = make_upstream("hi()");
@@ -90,7 +90,7 @@ fn no_warning_on_bin_failure() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn warning_on_lib_failure() {
     make_lib("err()");
     let upstream = make_upstream("");

--- a/tests/testsuite/workspaces.rs
+++ b/tests/testsuite/workspaces.rs
@@ -6,7 +6,7 @@ use crate::support::registry::Package;
 use crate::support::sleep_ms;
 use crate::support::{basic_lib_manifest, basic_manifest, git, project};
 
-#[test]
+#[cargo_test]
 fn simple_explicit() {
     let p = project()
         .file(
@@ -47,7 +47,7 @@ fn simple_explicit() {
     assert!(!p.root().join("bar/Cargo.lock").is_file());
 }
 
-#[test]
+#[cargo_test]
 fn simple_explicit_default_members() {
     let p = project()
         .file(
@@ -82,7 +82,7 @@ fn simple_explicit_default_members() {
     assert!(!p.bin("foo").is_file());
 }
 
-#[test]
+#[cargo_test]
 fn inferred_root() {
     let p = project()
         .file(
@@ -114,7 +114,7 @@ fn inferred_root() {
     assert!(!p.root().join("bar/Cargo.lock").is_file());
 }
 
-#[test]
+#[cargo_test]
 fn inferred_path_dep() {
     let p = project()
         .file(
@@ -149,7 +149,7 @@ fn inferred_path_dep() {
     assert!(!p.root().join("bar/Cargo.lock").is_file());
 }
 
-#[test]
+#[cargo_test]
 fn transitive_path_dep() {
     let p = project()
         .file(
@@ -206,7 +206,7 @@ fn transitive_path_dep() {
     assert!(!p.root().join("baz/Cargo.lock").is_file());
 }
 
-#[test]
+#[cargo_test]
 fn parent_pointer_works() {
     let p = project()
         .file(
@@ -244,7 +244,7 @@ fn parent_pointer_works() {
     assert!(!p.root().join("bar/Cargo.lock").is_file());
 }
 
-#[test]
+#[cargo_test]
 fn same_names_in_workspace() {
     let p = project()
         .file(
@@ -285,7 +285,7 @@ error: two packages named `foo` in this workspace:
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn parent_doesnt_point_to_child() {
     let p = project()
         .file(
@@ -320,7 +320,7 @@ this may be fixable [..]
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn invalid_parent_pointer() {
     let p = project()
         .file(
@@ -349,7 +349,7 @@ Caused by:
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn invalid_members() {
     let p = project()
         .file(
@@ -380,7 +380,7 @@ Caused by:
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn bare_workspace_ok() {
     let p = project()
         .file(
@@ -400,7 +400,7 @@ fn bare_workspace_ok() {
     p.cargo("build").run();
 }
 
-#[test]
+#[cargo_test]
 fn two_roots() {
     let p = project()
         .file(
@@ -443,7 +443,7 @@ error: multiple workspace roots found in the same workspace:
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn workspace_isnt_root() {
     let p = project()
         .file(
@@ -467,7 +467,7 @@ fn workspace_isnt_root() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn dangling_member() {
     let p = project()
         .file(
@@ -519,7 +519,7 @@ actual: [..]
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn cycle() {
     let p = project()
         .file(
@@ -554,7 +554,7 @@ fn cycle() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn share_dependencies() {
     let p = project()
         .file(
@@ -605,7 +605,7 @@ fn share_dependencies() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn fetch_fetches_all() {
     let p = project()
         .file(
@@ -649,7 +649,7 @@ fn fetch_fetches_all() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn lock_works_for_everyone() {
     let p = project()
         .file(
@@ -719,7 +719,7 @@ fn lock_works_for_everyone() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn virtual_works() {
     let p = project()
         .file(
@@ -738,7 +738,7 @@ fn virtual_works() {
     assert!(!p.root().join("bar/Cargo.lock").is_file());
 }
 
-#[test]
+#[cargo_test]
 fn explicit_package_argument_works_with_virtual_manifest() {
     let p = project()
         .file(
@@ -757,7 +757,7 @@ fn explicit_package_argument_works_with_virtual_manifest() {
     assert!(!p.root().join("bar/Cargo.lock").is_file());
 }
 
-#[test]
+#[cargo_test]
 fn virtual_misconfigure() {
     let p = project()
         .file(
@@ -786,7 +786,7 @@ manifest located at: [..]
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn virtual_build_all_implied() {
     let p = project()
         .file(
@@ -802,7 +802,7 @@ fn virtual_build_all_implied() {
     p.cargo("build").run();
 }
 
-#[test]
+#[cargo_test]
 fn virtual_default_members() {
     let p = project()
         .file(
@@ -823,7 +823,7 @@ fn virtual_default_members() {
     assert!(!p.bin("baz").is_file());
 }
 
-#[test]
+#[cargo_test]
 fn virtual_default_member_is_not_a_member() {
     let p = project()
         .file(
@@ -848,7 +848,7 @@ but is not a member.
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn virtual_build_no_members() {
     let p = project().file(
         "Cargo.toml",
@@ -868,7 +868,7 @@ and the workspace has no members.
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn include_virtual() {
     let p = project()
         .file(
@@ -902,7 +902,7 @@ error: multiple workspace roots found in the same workspace:
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn members_include_path_deps() {
     let p = project()
         .file(
@@ -951,7 +951,7 @@ fn members_include_path_deps() {
     assert!(!p.root().join("p3/target").is_dir());
 }
 
-#[test]
+#[cargo_test]
 fn new_warns_you_this_will_not_work() {
     let p = project()
         .file(
@@ -988,7 +988,7 @@ root: [..]
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn new_warning_with_corrupt_ws() {
     let p = project().file("Cargo.toml", "asdf").build();
     p.cargo("new bar")
@@ -1008,7 +1008,7 @@ Caused by:
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn lock_doesnt_change_depending_on_crate() {
     let p = project()
         .file(
@@ -1058,7 +1058,7 @@ fn lock_doesnt_change_depending_on_crate() {
     assert_eq!(lockfile, lockfile2);
 }
 
-#[test]
+#[cargo_test]
 fn rebuild_please() {
     let p = project()
         .file(
@@ -1114,7 +1114,7 @@ fn rebuild_please() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn workspace_in_git() {
     let git_project = git::new("dep1", |project| {
         project
@@ -1155,7 +1155,7 @@ fn workspace_in_git() {
     p.cargo("build").run();
 }
 
-#[test]
+#[cargo_test]
 fn lockfile_can_specify_nonexistant_members() {
     let p = project()
         .file(
@@ -1185,7 +1185,7 @@ fn lockfile_can_specify_nonexistant_members() {
     p.cargo("build").cwd("a").run();
 }
 
-#[test]
+#[cargo_test]
 fn you_cannot_generate_lockfile_for_empty_workspaces() {
     let p = project()
         .file(
@@ -1204,7 +1204,7 @@ fn you_cannot_generate_lockfile_for_empty_workspaces() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn workspace_with_transitive_dev_deps() {
     let p = project()
         .file(
@@ -1255,7 +1255,7 @@ fn workspace_with_transitive_dev_deps() {
     p.cargo("test -p bar").run();
 }
 
-#[test]
+#[cargo_test]
 fn error_if_parent_cargo_toml_is_invalid() {
     let p = project()
         .file("Cargo.toml", "Totally not a TOML file")
@@ -1270,7 +1270,7 @@ fn error_if_parent_cargo_toml_is_invalid() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn relative_path_for_member_works() {
     let p = project()
         .file(
@@ -1303,7 +1303,7 @@ fn relative_path_for_member_works() {
     p.cargo("build").cwd("bar").run();
 }
 
-#[test]
+#[cargo_test]
 fn relative_path_for_root_works() {
     let p = project()
         .file(
@@ -1332,7 +1332,7 @@ fn relative_path_for_root_works() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn path_dep_outside_workspace_is_not_member() {
     let p = project()
         .no_manifest()
@@ -1358,7 +1358,7 @@ fn path_dep_outside_workspace_is_not_member() {
     p.cargo("build").cwd("ws").run();
 }
 
-#[test]
+#[cargo_test]
 fn test_in_and_out_of_workspace() {
     let p = project()
         .no_manifest()
@@ -1426,7 +1426,7 @@ fn test_in_and_out_of_workspace() {
     assert!(!p.root().join("bar/target").is_dir());
 }
 
-#[test]
+#[cargo_test]
 fn test_path_dependency_under_member() {
     let p = project()
         .file(
@@ -1479,7 +1479,7 @@ fn test_path_dependency_under_member() {
     assert!(!p.root().join("foo/bar/target").is_dir());
 }
 
-#[test]
+#[cargo_test]
 fn excluded_simple() {
     let p = project()
         .file(
@@ -1505,7 +1505,7 @@ fn excluded_simple() {
     assert!(p.root().join("foo/target").is_dir());
 }
 
-#[test]
+#[cargo_test]
 fn exclude_members_preferred() {
     let p = project()
         .file(
@@ -1536,7 +1536,7 @@ fn exclude_members_preferred() {
     assert!(!p.root().join("foo/bar/target").is_dir());
 }
 
-#[test]
+#[cargo_test]
 fn exclude_but_also_depend() {
     let p = project()
         .file(
@@ -1569,7 +1569,7 @@ fn exclude_but_also_depend() {
     assert!(p.root().join("foo/bar/target").is_dir());
 }
 
-#[test]
+#[cargo_test]
 fn glob_syntax() {
     let p = project()
         .file(
@@ -1643,7 +1643,7 @@ fn glob_syntax() {
 }
 
 /*FIXME: This fails because of how workspace.exclude and workspace.members are working.
-#[test]
+#[cargo_test]
 fn glob_syntax_2() {
     let p = project()
         .file("Cargo.toml", r#"
@@ -1705,7 +1705,7 @@ fn glob_syntax_2() {
 }
 */
 
-#[test]
+#[cargo_test]
 fn glob_syntax_invalid_members() {
     let p = project()
         .file(
@@ -1745,7 +1745,7 @@ Caused by:
 ///
 /// Ideally, once we solve rust-lang/cargo#3620, then a single Cargo build at the top level
 /// will be enough.
-#[test]
+#[cargo_test]
 fn dep_used_with_separate_features() {
     let p = project()
         .file(
@@ -1844,7 +1844,7 @@ fn dep_used_with_separate_features() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn dont_recurse_out_of_cargo_home() {
     let git_project = git::new("dep", |project| {
         project
@@ -1901,7 +1901,7 @@ fn dont_recurse_out_of_cargo_home() {
 
 // FIXME: this fails because of how workspace.exclude and workspace.members are working.
 /*
-#[test]
+#[cargo_test]
 fn include_and_exclude() {
     let p = project()
         .file("Cargo.toml", r#"
@@ -1923,7 +1923,7 @@ fn include_and_exclude() {
 }
 */
 
-#[test]
+#[cargo_test]
 fn cargo_home_at_root_works() {
     let p = project()
         .file(
@@ -1946,7 +1946,7 @@ fn cargo_home_at_root_works() {
     p.cargo("build --frozen").env("CARGO_HOME", p.root()).run();
 }
 
-#[test]
+#[cargo_test]
 fn relative_rustc() {
     let p = project()
         .file(
@@ -1996,7 +1996,7 @@ fn relative_rustc() {
     p.cargo("build").env("RUSTC", &file).run();
 }
 
-#[test]
+#[cargo_test]
 fn ws_rustc_err() {
     let p = project()
         .file(
@@ -2021,7 +2021,7 @@ fn ws_rustc_err() {
         .run();
 }
 
-#[test]
+#[cargo_test]
 fn ws_err_unused() {
     for key in &[
         "[lib]",
@@ -2067,7 +2067,7 @@ Caused by:
     }
 }
 
-#[test]
+#[cargo_test]
 fn ws_warn_unused() {
     for (key, name) in &[
         ("[profile.dev]\nopt-level = 1", "profiles"),
@@ -2110,7 +2110,7 @@ workspace: [..]/foo/Cargo.toml
     }
 }
 
-#[test]
+#[cargo_test]
 fn ws_warn_path() {
     // Warnings include path to manifest.
     let p = project()


### PR DESCRIPTION
The cargo testsuite relies on a clean test “root” for every test (i.e. `#[test]`-annotated function). It relied on the `test` crate's behavior to spawn a new thread for each test, which isn't done when tests aren't run concurrently, breaking the test suite. In this PR, I'm using backtraces to figure out which test is being run, which is much more robust. I also cleaned up the root initialization logic so that it no longer recursive calls the `init` function.

Fixes #6746