### PR TITLE
Fixes #6874

### DIFF
--- a/src/etc/cargo.bashcomp.sh
+++ b/src/etc/cargo.bashcomp.sh
@@ -1,3 +1,7 @@
+# Required for bash versions < 4.1
+# Default bash version is 3.2 on latest macOS. See #6874
+shopt -s extglob
+
 command -v cargo >/dev/null 2>&1 &&
 _cargo()
 {


### PR DESCRIPTION
Bash completion for cargo on the latest version of stock macOS produced syntax errors. More info in #6874 . This PR should fix that, but as I don't have any apple devices, I can't test it.

Pinging @jimmycuadra or anyone who runs macOS: If you have the time, could you please check if applying the commit in this PR fixes the syntax error when running the stock bash that comes with macOS?
Quick one-liner to apply the commit would be:
```bash
patch -d "$(rustc --print sysroot)/etc/bash_completion.d/" cargo <(curl https://github.com/rust-lang/cargo/commit/e2c519dd7ac61e4d2f94cad60ef920ce4aa1718f.patch)
```

Once this PR is confirmed to work, it can marked as ready.