### PR TITLE
Small things

### DIFF
--- a/src/cargo/core/resolver/mod.rs
+++ b/src/cargo/core/resolver/mod.rs
@@ -936,8 +936,7 @@ fn generalize_conflicting(
                 }
                 con.insert(*critical_parent, backtrack_critical_reason);
 
-                #[cfg(debug_assertions)]
-                {
+                if cfg!(debug_assertions) {
                     // the entire point is to find an older conflict, so let's make sure we did
                     let new_age = con
                         .keys()


### PR DESCRIPTION
This has two small changes that are worth saving from my most recent attempt to speedup https://github.com/rust-lang/cargo/issues/6258#issuecomment-479204465:

1. This removes the `ConflictCache::contains` added in #6776. Replacing it with a more general and easier to explain system based on the existing `ConflictCache::find_conflicting`.
2. This adds code to print the used part of the input for failing resolver tests. This is very helpful when 
    1. The proptest shrinking algorithm is interrupted, at least you have the smallest one found so far.
    2. Hand minimizing, remove a dep and it will tell you all the packages that are no longer needed for the test to fail.