### PR TITLE
Fix skipping over invalid registry packages

### DIFF
--- a/src/cargo/sources/registry/index.rs
+++ b/src/cargo/sources/registry/index.rs
@@ -520,6 +520,7 @@ impl Summaries {
                 // interpretation of each line here and older cargo will simply
                 // ignore the new lines.
                 let line = &contents[start..end];
+                start = end + 1;
                 let summary = match IndexSummary::parse(line, source_id) {
                     Ok(summary) => summary,
                     Err(e) => {
@@ -530,7 +531,6 @@ impl Summaries {
                 let version = summary.summary.package_id().version().clone();
                 cache.versions.push((version.clone(), line));
                 ret.versions.insert(version, summary.into());
-                start = end + 1;
             }
             if let Some(index_version) = index_version {
                 cache_bytes = Some(cache.serialize(index_version));

--- a/tests/testsuite/registry.rs
+++ b/tests/testsuite/registry.rs
@@ -1953,3 +1953,31 @@ fn rename_deps_and_features() {
     p.cargo("build --features bar/foo01").run();
     p.cargo("build --features bar/another").run();
 }
+
+#[test]
+fn ignore_invalid_json_lines() {
+    Package::new("foo", "0.1.0").publish();
+    Package::new("foo", "0.1.1")
+        .invalid_json(true)
+        .publish();
+    Package::new("foo", "0.2.0").publish();
+
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [project]
+                name = "a"
+                version = "0.5.0"
+                authors = []
+
+                [dependencies]
+                foo = '0.1.0'
+                foo02 = { version = '0.2.0', package = 'foo' }
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    p.cargo("build").run();
+}


### PR DESCRIPTION
This accidentally regressed in the previous caching PR for Cargo.
Invalid lines of JSON in the registry are intended to be skipped over,
but when skipping we forgot to update some indices which meant that all
future versions would fail to parse as well!