### PR TITLE
crate download: don't print that a crate was the largest download if it was the only download

### DIFF
--- a/src/cargo/core/mod.rs
+++ b/src/cargo/core/mod.rs
@@ -3,6 +3,7 @@ pub use self::features::{
     enable_nightly_features, maybe_allow_nightly_features, nightly_features_allowed,
 };
 pub use self::features::{CliUnstable, Edition, Feature, Features};
+pub use self::interning::InternedString;
 pub use self::manifest::{EitherManifest, VirtualManifest};
 pub use self::manifest::{LibKind, Manifest, Target, TargetKind};
 pub use self::package::{Package, PackageSet};
@@ -14,7 +15,6 @@ pub use self::shell::{Shell, Verbosity};
 pub use self::source::{GitReference, Source, SourceId, SourceMap};
 pub use self::summary::{FeatureMap, FeatureValue, Summary};
 pub use self::workspace::{Members, Workspace, WorkspaceConfig, WorkspaceRootConfig};
-pub use self::interning::InternedString;
 
 pub mod compiler;
 pub mod dependency;

--- a/src/cargo/core/package.rs
+++ b/src/cargo/core/package.rs
@@ -22,10 +22,10 @@ use crate::core::source::MaybePackage;
 use crate::core::{Dependency, Manifest, PackageId, SourceId, Target};
 use crate::core::{FeatureMap, SourceMap, Summary};
 use crate::ops;
+use crate::util::config::PackageCacheLock;
 use crate::util::errors::{CargoResult, CargoResultExt, HttpNot200};
 use crate::util::network::Retry;
 use crate::util::{self, internal, lev_distance, Config, Progress, ProgressStyle};
-use crate::util::config::PackageCacheLock;
 
 /// Information about a package that is available somewhere in the file system.
 ///

--- a/src/cargo/core/package.rs
+++ b/src/cargo/core/package.rs
@@ -951,7 +951,10 @@ impl<'a, 'cfg> Drop for Downloads<'a, 'cfg> {
             ByteSize(self.downloaded_bytes),
             util::elapsed(self.start.elapsed())
         );
-        if self.largest.0 > ByteSize::mb(1).0 {
+        // print the size of largest crate if it was >1mb
+        // however don't print if only a single crate was downloaded
+        // because it is obvious that it will be the largest then
+        if self.largest.0 > ByteSize::mb(1).0 && self.downloads_finished > 1 {
             status.push_str(&format!(
                 " (largest was `{}` at {})",
                 self.largest.1,

--- a/src/cargo/sources/registry/local.rs
+++ b/src/cargo/sources/registry/local.rs
@@ -1,4 +1,4 @@
-use crate::core::{PackageId, InternedString};
+use crate::core::{InternedString, PackageId};
 use crate::sources::registry::{MaybeLock, RegistryConfig, RegistryData};
 use crate::util::errors::{CargoResult, CargoResultExt};
 use crate::util::paths;

--- a/src/cargo/sources/registry/mod.rs
+++ b/src/cargo/sources/registry/mod.rs
@@ -173,7 +173,7 @@ use tar::Archive;
 
 use crate::core::dependency::{Dependency, Kind};
 use crate::core::source::MaybePackage;
-use crate::core::{Package, PackageId, Source, SourceId, Summary, InternedString};
+use crate::core::{InternedString, Package, PackageId, Source, SourceId, Summary};
 use crate::sources::PathSource;
 use crate::util::errors::CargoResultExt;
 use crate::util::hex;

--- a/src/cargo/sources/registry/remote.rs
+++ b/src/cargo/sources/registry/remote.rs
@@ -1,4 +1,4 @@
-use crate::core::{PackageId, SourceId, InternedString};
+use crate::core::{InternedString, PackageId, SourceId};
 use crate::sources::git;
 use crate::sources::registry::MaybeLock;
 use crate::sources::registry::{RegistryConfig, RegistryData, CRATE_TEMPLATE, VERSION_TEMPLATE};

--- a/tests/testsuite/registry.rs
+++ b/tests/testsuite/registry.rs
@@ -1957,9 +1957,7 @@ fn rename_deps_and_features() {
 #[test]
 fn ignore_invalid_json_lines() {
     Package::new("foo", "0.1.0").publish();
-    Package::new("foo", "0.1.1")
-        .invalid_json(true)
-        .publish();
+    Package::new("foo", "0.1.1").invalid_json(true).publish();
     Package::new("foo", "0.2.0").publish();
 
     let p = project()


### PR DESCRIPTION
    before:

        Updating crates.io index
      Downloaded procs v0.8.4
      Downloaded 1 crates (1.1 MB) in 2.90s (largest was `procs` at 1.1 MB)
      Installing procs v0.8.4

    after:

        Updating crates.io index
      Downloaded procs v0.8.4
      Downloaded 1 crates (1.1 MB) in 1.50s
      Installing procs v0.8.4