### PR TITLE
Changed RUST_LOG usage to CARGO_LOG to avoid confusion.

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -132,16 +132,16 @@ to nightly rustc).
 ## Logging
 
 Cargo uses [`env_logger`], so you can set
-`RUST_LOG` environment variable to get the logs. This is useful both for diagnosing
+`CARGO_LOG` environment variable to get the logs. This is useful both for diagnosing
 bugs in stable Cargo and for local development. Cargo also has internal hierarchical
 profiling infrastructure, which is activated via `CARGO_PROFILE` variable
 
 ```
 # Outputs all logs with levels debug and higher
-$ RUST_LOG=debug cargo generate-lockfile
+$ CARGO_LOG=debug cargo generate-lockfile
 
 # Don't forget that you can filter by module as well
-$ RUST_LOG=cargo::core::resolver=trace cargo generate-lockfile
+$ CARGO_LOG=cargo::core::resolver=trace cargo generate-lockfile
 
 # Output first three levels of profiling info
 $ CARGO_PROFILE=3 cargo generate-lockfile

--- a/src/bin/cargo/main.rs
+++ b/src/bin/cargo/main.rs
@@ -20,9 +20,9 @@ use crate::command_prelude::*;
 
 fn main() {
     #[cfg(feature = "pretty-env-logger")]
-    pretty_env_logger::init();
+    pretty_env_logger::init_custom_env("CARGO_LOG");
     #[cfg(not(feature = "pretty-env-logger"))]
-    env_logger::init();
+    env_logger::init_from_env("CARGO_LOG");
     cargo::core::maybe_allow_nightly_features();
 
     let mut config = match Config::default() {

--- a/src/cargo/core/compiler/build_context/target_info.rs
+++ b/src/cargo/core/compiler/build_context/target_info.rs
@@ -75,7 +75,7 @@ impl TargetInfo {
             .arg("___")
             .arg("--print=file-names")
             .args(&rustflags)
-            .env_remove("RUST_LOG");
+            .env_remove("RUSTC_LOG");
 
         let target_triple = requested_target
             .as_ref()

--- a/src/cargo/core/compiler/fingerprint.rs
+++ b/src/cargo/core/compiler/fingerprint.rs
@@ -79,7 +79,7 @@
 //!   quick loading and comparison.
 //! - A `.json` file that contains details about the Fingerprint. This is only
 //!   used to log details about *why* a fingerprint is considered dirty.
-//!   `RUST_LOG=cargo::core::compiler::fingerprint=trace cargo build` can be
+//!   `CARGO_LOG=cargo::core::compiler::fingerprint=trace cargo build` can be
 //!   used to display this log information.
 //! - A "dep-info" file which contains a list of source filenames for the
 //!   target. This is produced by reading the output of `rustc
@@ -936,7 +936,7 @@ impl DepFingerprint {
 impl StaleFile {
     /// Use the `log` crate to log a hopefully helpful message in diagnosing
     /// what file is considered stale and why. This is intended to be used in
-    /// conjunction with `RUST_LOG` to determine why Cargo is recompiling
+    /// conjunction with `CARGO_LOG` to determine why Cargo is recompiling
     /// something. Currently there's no user-facing usage of this other than
     /// that.
     fn log(&self) {

--- a/src/doc/src/reference/config.md
+++ b/src/doc/src/reference/config.md
@@ -113,7 +113,7 @@ multiplexing = true # whether or not to use HTTP/2 multiplexing where possible
 # This setting can be used to help debug what's going on with HTTP requests made
 # by Cargo. When set to `true` then Cargo's normal debug logging will be filled
 # in with HTTP information, which you can extract with
-# `RUST_LOG=cargo::ops::registry=debug` (and `trace` may print more).
+# `CARGO_LOG=cargo::ops::registry=debug` (and `trace` may print more).
 #
 # Be wary when posting these logs elsewhere though, it may be the case that a
 # header has an authentication token in it you don't want leaked! Be sure to

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -2028,7 +2028,7 @@ fn simple_staticlib() {
         .build();
 
     // env var is a test for #1381
-    p.cargo("build").env("RUST_LOG", "nekoneko=trace").run();
+    p.cargo("build").env("CARGO_LOG", "nekoneko=trace").run();
 }
 
 #[test]

--- a/tests/testsuite/build_script.rs
+++ b/tests/testsuite/build_script.rs
@@ -1547,13 +1547,13 @@ fn build_script_with_dynamic_native_dependency() {
 
     build
         .cargo("build -v")
-        .env("RUST_LOG", "cargo::ops::cargo_rustc")
+        .env("CARGO_LOG", "cargo::ops::cargo_rustc")
         .run();
 
     let root = build.root().join("target").join("debug");
     foo.cargo("build -v")
         .env("BUILDER_ROOT", root)
-        .env("RUST_LOG", "cargo::ops::cargo_rustc")
+        .env("CARGO_LOG", "cargo::ops::cargo_rustc")
         .run();
 }
 
@@ -2460,7 +2460,7 @@ fn fresh_builds_possible_with_multiple_metadata_overrides() {
         .run();
 
     p.cargo("build -v")
-        .env("RUST_LOG", "cargo::ops::cargo_rustc::fingerprint=info")
+        .env("CARGO_LOG", "cargo::ops::cargo_rustc::fingerprint=info")
         .with_stderr(
             "\
 [FRESH] foo v0.5.0 ([..])

--- a/tests/testsuite/check.rs
+++ b/tests/testsuite/check.rs
@@ -730,7 +730,7 @@ fn proc_macro() {
             "#,
         )
         .build();
-    p.cargo("check -v").env("RUST_LOG", "cargo=trace").run();
+    p.cargo("check -v").env("CARGO_LOG", "cargo=trace").run();
 }
 
 #[test]

--- a/tests/testsuite/corrupt_git.rs
+++ b/tests/testsuite/corrupt_git.rs
@@ -47,7 +47,7 @@ fn deleting_database_files() {
         }
         println!("deleting {}", file.display());
         cargopaths::remove_file(&file).unwrap();
-        project.cargo("build -v").env("RUST_LOG", log).run();
+        project.cargo("build -v").env("CARGO_LOG", log).run();
 
         if !file.exists() {
             continue;
@@ -60,7 +60,7 @@ fn deleting_database_files() {
             .unwrap()
             .set_len(2)
             .unwrap();
-        project.cargo("build -v").env("RUST_LOG", log).run();
+        project.cargo("build -v").env("CARGO_LOG", log).run();
     }
 }
 
@@ -124,7 +124,7 @@ fn deleting_checkout_files() {
         }
         println!("deleting {}", file.display());
         cargopaths::remove_file(&file).unwrap();
-        project.cargo("build -v").env("RUST_LOG", log).run();
+        project.cargo("build -v").env("CARGO_LOG", log).run();
 
         if !file.exists() {
             continue;
@@ -137,7 +137,7 @@ fn deleting_checkout_files() {
             .unwrap()
             .set_len(2)
             .unwrap();
-        project.cargo("build -v").env("RUST_LOG", log).run();
+        project.cargo("build -v").env("CARGO_LOG", log).run();
     }
 }
 

--- a/tests/testsuite/doc.rs
+++ b/tests/testsuite/doc.rs
@@ -115,7 +115,7 @@ fn doc_deps() {
     assert_eq!(p.glob("target/debug/deps/libbar-*.rmeta").count(), 1);
 
     p.cargo("doc")
-        .env("RUST_LOG", "cargo::ops::cargo_rustc::fingerprint")
+        .env("CARGO_LOG", "cargo::ops::cargo_rustc::fingerprint")
         .with_stdout("")
         .run();
 

--- a/tests/testsuite/freshness.rs
+++ b/tests/testsuite/freshness.rs
@@ -760,7 +760,7 @@ fn rebuild_if_build_artifacts_move_forward_in_time() {
     p.root().move_into_the_future();
 
     p.cargo("build")
-        .env("RUST_LOG", "")
+        .env("CARGO_LOG", "")
         .with_stdout("")
         .with_stderr(
             "\

--- a/tests/testsuite/rustc_info_cache.rs
+++ b/tests/testsuite/rustc_info_cache.rs
@@ -13,7 +13,7 @@ fn rustc_info_cache() {
     let update = "[..]updated rustc info cache[..]";
 
     p.cargo("build")
-        .env("RUST_LOG", "cargo::util::rustc=info")
+        .env("CARGO_LOG", "cargo::util::rustc=info")
         .with_stderr_contains("[..]failed to read rustc info cache[..]")
         .with_stderr_contains(miss)
         .with_stderr_does_not_contain(hit)
@@ -21,7 +21,7 @@ fn rustc_info_cache() {
         .run();
 
     p.cargo("build")
-        .env("RUST_LOG", "cargo::util::rustc=info")
+        .env("CARGO_LOG", "cargo::util::rustc=info")
         .with_stderr_contains("[..]reusing existing rustc info cache[..]")
         .with_stderr_contains(hit)
         .with_stderr_does_not_contain(miss)
@@ -29,7 +29,7 @@ fn rustc_info_cache() {
         .run();
 
     p.cargo("build")
-        .env("RUST_LOG", "cargo::util::rustc=info")
+        .env("CARGO_LOG", "cargo::util::rustc=info")
         .env("CARGO_CACHE_RUSTC_INFO", "0")
         .with_stderr_contains("[..]rustc info cache disabled[..]")
         .with_stderr_does_not_contain(update)
@@ -63,7 +63,7 @@ fn rustc_info_cache() {
     };
 
     p.cargo("build")
-        .env("RUST_LOG", "cargo::util::rustc=info")
+        .env("CARGO_LOG", "cargo::util::rustc=info")
         .env("RUSTC", other_rustc.display().to_string())
         .with_stderr_contains("[..]different compiler, creating new rustc info cache[..]")
         .with_stderr_contains(miss)
@@ -72,7 +72,7 @@ fn rustc_info_cache() {
         .run();
 
     p.cargo("build")
-        .env("RUST_LOG", "cargo::util::rustc=info")
+        .env("CARGO_LOG", "cargo::util::rustc=info")
         .env("RUSTC", other_rustc.display().to_string())
         .with_stderr_contains("[..]reusing existing rustc info cache[..]")
         .with_stderr_contains(hit)
@@ -83,7 +83,7 @@ fn rustc_info_cache() {
     other_rustc.move_into_the_future();
 
     p.cargo("build")
-        .env("RUST_LOG", "cargo::util::rustc=info")
+        .env("CARGO_LOG", "cargo::util::rustc=info")
         .env("RUSTC", other_rustc.display().to_string())
         .with_stderr_contains("[..]different compiler, creating new rustc info cache[..]")
         .with_stderr_contains(miss)
@@ -92,7 +92,7 @@ fn rustc_info_cache() {
         .run();
 
     p.cargo("build")
-        .env("RUST_LOG", "cargo::util::rustc=info")
+        .env("CARGO_LOG", "cargo::util::rustc=info")
         .env("RUSTC", other_rustc.display().to_string())
         .with_stderr_contains("[..]reusing existing rustc info cache[..]")
         .with_stderr_contains(hit)

--- a/tests/testsuite/small_fd_limits.rs
+++ b/tests/testsuite/small_fd_limits.rs
@@ -73,7 +73,7 @@ fn run_test(path_env: Option<&OsStr>) {
     if let Some(path) = path_env {
         cmd.env("PATH", path);
     }
-    cmd.env("RUST_LOG", "trace");
+    cmd.env("CARGO_LOG", "trace");
     cmd.run();
     let after = find_index()
         .join(".git/objects/pack")

--- a/tests/testsuite/test.rs
+++ b/tests/testsuite/test.rs
@@ -3578,7 +3578,7 @@ test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
 
 ",
         )
-        .env("RUST_LOG", "cargo=trace")
+        .env("CARGO_LOG", "cargo=trace")
         .run();
 
     p.cargo("test --lib --doc")

--- a/tests/testsuite/update.rs
+++ b/tests/testsuite/update.rs
@@ -205,7 +205,7 @@ fn update_via_new_dep() {
     Package::new("log", "0.1.1").publish();
 
     p.uncomment_root_manifest();
-    p.cargo("build").env("RUST_LOG", "cargo=trace").run();
+    p.cargo("build").env("CARGO_LOG", "cargo=trace").run();
 }
 
 #[test]


### PR DESCRIPTION
This is a repost of #6605 now that https://github.com/rust-lang/rust/pull/60401 has been merged.

This also includes a fix in `TargetInfo::new` to remove the **RUSTC_LOG** var.
