### PR TITLE
Always include `Cargo.toml` when packaging.

### DIFF
--- a/src/cargo/sources/path.rs
+++ b/src/cargo/sources/path.rs
@@ -199,6 +199,14 @@ impl<'cfg> PathSource<'cfg> {
 
         let mut filter = |path: &Path| -> CargoResult<bool> {
             let relative_path = path.strip_prefix(root)?;
+
+            let rel = relative_path.as_os_str();
+            if rel == "Cargo.lock" {
+                return Ok(pkg.include_lockfile());
+            } else if rel == "Cargo.toml" {
+                return Ok(true);
+            }
+
             let glob_should_package = glob_should_package(relative_path);
             let ignore_should_package = ignore_should_package(relative_path)?;
 
@@ -240,13 +248,8 @@ impl<'cfg> PathSource<'cfg> {
                 }
             }
 
-            let should_include = match path.file_name().and_then(|s| s.to_str()) {
-                Some("Cargo.lock") => pkg.include_lockfile(),
-                // Update to `ignore_should_package` for Stage 2.
-                _ => glob_should_package,
-            };
-
-            Ok(should_include)
+            // Update to `ignore_should_package` for Stage 2.
+            Ok(glob_should_package)
         };
 
         // Attempt Git-prepopulate only if no `include` (see rust-lang/cargo#4135).

--- a/src/doc/src/reference/manifest.md
+++ b/src/doc/src/reference/manifest.md
@@ -145,7 +145,8 @@ include = ["src/**/*", "Cargo.toml"]
 
 The options are mutually exclusive: setting `include` will override an
 `exclude`. Note that `include` must be an exhaustive list of files as otherwise
-necessary source files may not be included.
+necessary source files may not be included. The package's `Cargo.toml` is
+automatically included.
 
 [globs]: https://docs.rs/glob/0.2.11/glob/struct.Pattern.html
 

--- a/tests/testsuite/package.rs
+++ b/tests/testsuite/package.rs
@@ -1154,3 +1154,23 @@ fn package_no_default_features() {
         .with_status(101)
         .run();
 }
+
+#[test]
+fn include_cargo_toml_implicit() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "foo"
+            version = "0.1.0"
+            include = ["src/lib.rs"]
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    p.cargo("package --list")
+        .with_stdout("Cargo.toml\nsrc/lib.rs\n")
+        .run();
+}


### PR DESCRIPTION
Since `Cargo.toml` is required, might as well include it automatically rather than force everyone to include it explicitly. If it is not listed in `include`, there was a somewhat confusing error message when packaging.

Closes #6830
Closes #4660
