### PR TITLE
Change default edition option for "cargo new" to 2019

### DIFF
--- a/src/cargo/ops/cargo_new.rs
+++ b/src/cargo/ops/cargo_new.rs
@@ -626,7 +626,7 @@ edition = {}
             toml::Value::String(author),
             match opts.edition {
                 Some(edition) => toml::Value::String(edition.to_string()),
-                None => toml::Value::String("2018".to_string()),
+                None => toml::Value::String("2019".to_string()),
             },
             match opts.registry {
                 Some(registry) => format!(

--- a/tests/testsuite/new.rs
+++ b/tests/testsuite/new.rs
@@ -500,7 +500,7 @@ fn new_with_edition_2018() {
 fn new_default_edition() {
     cargo_process("new foo").env("USER", "foo").run();
     let manifest = fs::read_to_string(paths::root().join("foo/Cargo.toml")).unwrap();
-    assert!(manifest.contains("edition = \"2018\""));
+    assert!(manifest.contains("edition = \"2019\""));
 }
 
 #[test]


### PR DESCRIPTION
Previously the command "cargo new" would create a Cargo.toml with a
value of "2018" for "edition". This updates it to 2019.