### PR TITLE
Re-enable compatibility with readonly CARGO_HOME

### DIFF
--- a/src/cargo/sources/registry/mod.rs
+++ b/src/cargo/sources/registry/mod.rs
@@ -449,15 +449,16 @@ impl<'cfg> RegistrySource<'cfg> {
         let path = dst.join(PACKAGE_SOURCE_LOCK);
         let path = self.config.assert_package_cache_locked(&path);
         let unpack_dir = path.parent().unwrap();
+        if let Ok(meta) = path.metadata() {
+            if meta.len() > 0 {
+                return Ok(unpack_dir.to_path_buf());
+            }
+        }
         let mut ok = OpenOptions::new()
             .create(true)
             .read(true)
             .write(true)
             .open(&path)?;
-        let meta = ok.metadata()?;
-        if meta.len() > 0 {
-            return Ok(unpack_dir.to_path_buf());
-        }
 
         let gz = GzDecoder::new(tarball);
         let mut tar = Archive::new(gz);


### PR DESCRIPTION
Previously Cargo would attempt to work as much as possible with a
previously filled out CARGO_HOME, even if it was mounted as read-only.
In #6880 this was regressed as a few global locks and files were always
attempted to be opened in writable mode.

This commit fixes these issues by correcting two locations:

* First the global package cache lock has error handling to allow
  acquiring the lock in read-only mode inaddition to read/write mode. If
  the read/write mode failed due to an error that looks like a readonly
  filesystem then we assume everything in the package cache is readonly
  and we switch to just acquiring any lock, this time a shared readonly
  one. We in theory aren't actually doing any synchronization at that
  point since it's all readonly anyway.

* Next when unpacking package we're careful to issue a `stat` call
  before opening a file in writable mode. This way our preexisting guard
  to return early if a package is unpacked will succeed before we open
  anything in writable mode.

Closes #6928