### PR TITLE
Remove Candidate

### DIFF
--- a/src/cargo/core/resolver/errors.rs
+++ b/src/cargo/core/resolver/errors.rs
@@ -7,7 +7,7 @@ use failure::{Error, Fail};
 use semver;
 
 use super::context::Context;
-use super::types::{Candidate, ConflictMap, ConflictReason};
+use super::types::{ConflictMap, ConflictReason};
 
 /// Error during resolution providing a path of `PackageId`s.
 pub struct ResolveError {
@@ -74,7 +74,7 @@ pub(super) fn activation_error(
     parent: &Summary,
     dep: &Dependency,
     conflicting_activations: &ConflictMap,
-    candidates: &[Candidate],
+    candidates: &[Summary],
     config: Option<&Config>,
 ) -> ResolveError {
     let to_resolve_err = |err| {
@@ -101,7 +101,7 @@ pub(super) fn activation_error(
         msg.push_str(
             &candidates
                 .iter()
-                .map(|v| v.summary.version())
+                .map(|v| v.version())
                 .map(|v| v.to_string())
                 .collect::<Vec<_>>()
                 .join(", "),

--- a/src/cargo/core/resolver/mod.rs
+++ b/src/cargo/core/resolver/mod.rs
@@ -183,7 +183,6 @@ fn activate_deps_loop(
         debug!("initial activation: {}", summary.package_id());
         let candidate = Candidate {
             summary: summary.clone(),
-            replace: None,
         };
         let res = activate(&mut cx, registry, None, candidate, method.clone());
         match res {
@@ -659,7 +658,7 @@ fn activate(
 
     let activated = cx.flag_activated(&candidate.summary, &method)?;
 
-    let candidate = match candidate.replace {
+    let candidate = match registry.replacement_summary(candidate_pid) {
         Some(replace) => {
             if cx.flag_activated(&replace, &method)? && activated {
                 return Ok(None);
@@ -669,7 +668,7 @@ fn activate(
                 replace.package_id(),
                 candidate_pid
             );
-            replace
+            replace.clone()
         }
         None => {
             if activated {

--- a/src/cargo/core/resolver/types.rs
+++ b/src/cargo/core/resolver/types.rs
@@ -125,7 +125,6 @@ impl Method {
 #[derive(Clone)]
 pub struct Candidate {
     pub summary: Summary,
-    pub replace: Option<Summary>,
 }
 
 #[derive(Clone)]

--- a/src/cargo/core/resolver/types.rs
+++ b/src/cargo/core/resolver/types.rs
@@ -123,11 +123,6 @@ impl Method {
 }
 
 #[derive(Clone)]
-pub struct Candidate {
-    pub summary: Summary,
-}
-
-#[derive(Clone)]
 pub struct DepsFrame {
     pub parent: Summary,
     pub just_for_error_messages: bool,
@@ -230,7 +225,7 @@ impl RemainingDeps {
 /// Information about the dependencies for a crate, a tuple of:
 ///
 /// (dependency info, candidates, features activated)
-pub type DepInfo = (Dependency, Rc<Vec<Candidate>>, FeaturesSet);
+pub type DepInfo = (Dependency, Rc<Vec<Summary>>, FeaturesSet);
 
 /// All possible reasons that a package might fail to activate.
 ///


### PR DESCRIPTION
`Candidate` was a type to record the possibility that a package was replaced using the replacements feature. However there were only two places that cared about this possibility. One was switched to used a lookup table in #6860. This PR switches the other to use that table as well. Making the entire `Candidate` type unnecessary.

The main benefit of this change is a reduction in the cognitive complexity.