### PR TITLE
Add `doctest` field into metadata

### DIFF
--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -287,6 +287,7 @@ struct SerializedTarget<'a> {
     edition: &'a str,
     #[serde(rename = "required-features", skip_serializing_if = "Option::is_none")]
     required_features: Option<Vec<&'a str>>,
+    doctest: bool,
 }
 
 impl ser::Serialize for Target {
@@ -307,6 +308,7 @@ impl ser::Serialize for Target {
                 .required_features
                 .as_ref()
                 .map(|rf| rf.iter().map(|s| &**s).collect()),
+            doctest: self.doctest,
         }
         .serialize(s)
     }

--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -308,7 +308,7 @@ impl ser::Serialize for Target {
                 .required_features
                 .as_ref()
                 .map(|rf| rf.iter().map(|s| &**s).collect()),
-            doctest: self.doctest,
+            doctest: self.doctest && self.doctestable(),
         }
         .serialize(s)
     }

--- a/tests/testsuite/bench.rs
+++ b/tests/testsuite/bench.rs
@@ -1620,6 +1620,7 @@ fn json_artifact_includes_executable_for_benchmark() {
                 "target": {
                     "crate_types": [ "bin" ],
                     "kind": [ "bench" ],
+                    "doctest": false,
                     "edition": "2015",
                     "name": "benchmark",
                     "src_path": "[..]/foo/benches/benchmark.rs"

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -3052,6 +3052,7 @@ fn compiler_json_error_format() {
         "target":{
             "kind":["custom-build"],
             "crate_types":["bin"],
+            "doctest": false,
             "edition": "2015",
             "name":"build-script-build",
             "src_path":"[..]build.rs"
@@ -3075,6 +3076,7 @@ fn compiler_json_error_format() {
         "target":{
             "kind":["lib"],
             "crate_types":["lib"],
+            "doctest": true,
             "edition": "2015",
             "name":"bar",
             "src_path":"[..]lib.rs"
@@ -3097,6 +3099,7 @@ fn compiler_json_error_format() {
         "target":{
             "kind":["lib"],
             "crate_types":["lib"],
+            "doctest": true,
             "edition": "2015",
             "name":"bar",
             "src_path":"[..]lib.rs"
@@ -3123,6 +3126,7 @@ fn compiler_json_error_format() {
         "target":{
             "kind":["bin"],
             "crate_types":["bin"],
+            "doctest": false,
             "edition": "2015",
             "name":"foo",
             "src_path":"[..]main.rs"
@@ -3136,6 +3140,7 @@ fn compiler_json_error_format() {
         "target":{
             "kind":["bin"],
             "crate_types":["bin"],
+            "doctest": false,
             "edition": "2015",
             "name":"foo",
             "src_path":"[..]main.rs"
@@ -3167,6 +3172,7 @@ fn compiler_json_error_format() {
         "target":{
             "kind":["custom-build"],
             "crate_types":["bin"],
+            "doctest": false,
             "edition": "2015",
             "name":"build-script-build",
             "src_path":"[..]build.rs"
@@ -3199,6 +3205,7 @@ fn compiler_json_error_format() {
         "target":{
             "kind":["lib"],
             "crate_types":["lib"],
+            "doctest": true,
             "edition": "2015",
             "name":"bar",
             "src_path":"[..]lib.rs"
@@ -3225,6 +3232,7 @@ fn compiler_json_error_format() {
         "target":{
             "kind":["bin"],
             "crate_types":["bin"],
+            "doctest": false,
             "edition": "2015",
             "name":"foo",
             "src_path":"[..]main.rs"
@@ -3280,6 +3288,7 @@ fn message_format_json_forward_stderr() {
         "target":{
             "kind":["bin"],
             "crate_types":["bin"],
+            "doctest": false,
             "edition": "2015",
             "name":"foo",
             "src_path":"[..]"
@@ -3293,6 +3302,7 @@ fn message_format_json_forward_stderr() {
         "target":{
             "kind":["bin"],
             "crate_types":["bin"],
+            "doctest": false,
             "edition": "2015",
             "name":"foo",
             "src_path":"[..]"

--- a/tests/testsuite/metabuild.rs
+++ b/tests/testsuite/metabuild.rs
@@ -695,6 +695,7 @@ fn metabuild_json_artifact() {
     "crate_types": [
       "bin"
     ],
+    "doctest": false,
     "edition": "2018",
     "kind": [
       "custom-build"
@@ -742,6 +743,7 @@ fn metabuild_failed_build_json() {
     "crate_types": [
       "bin"
     ],
+    "doctest": false,
     "edition": "2018",
     "kind": [
       "custom-build"

--- a/tests/testsuite/metadata.rs
+++ b/tests/testsuite/metadata.rs
@@ -39,6 +39,7 @@ fn cargo_metadata_simple() {
                         "crate_types": [
                             "bin"
                         ],
+                        "doctest": false,
                         "edition": "2015",
                         "name": "foo",
                         "src_path": "[..]/foo/src/foo.rs"
@@ -129,6 +130,7 @@ crate-type = ["lib", "staticlib"]
                             "lib",
                             "staticlib"
                         ],
+                        "doctest": true,
                         "edition": "2015",
                         "name": "foo",
                         "src_path": "[..]/foo/src/lib.rs"
@@ -207,6 +209,7 @@ optional_feat = []
                         "crate_types": [
                             "lib"
                         ],
+                        "doctest": true,
                         "edition": "2015",
                         "name": "foo",
                         "src_path": "[..]/foo/src/lib.rs"
@@ -302,6 +305,7 @@ fn cargo_metadata_with_deps_and_version() {
                         "crate_types": [
                             "lib"
                         ],
+                        "doctest": true,
                         "edition": "2015",
                         "kind": [
                             "lib"
@@ -360,6 +364,7 @@ fn cargo_metadata_with_deps_and_version() {
                         "crate_types": [
                             "bin"
                         ],
+                        "doctest": false,
                         "edition": "2015",
                         "kind": [
                             "bin"
@@ -393,6 +398,7 @@ fn cargo_metadata_with_deps_and_version() {
                         "crate_types": [
                             "lib"
                         ],
+                        "doctest": true,
                         "edition": "2015",
                         "kind": [
                             "lib"
@@ -439,6 +445,7 @@ fn cargo_metadata_with_deps_and_version() {
                         "crate_types": [
                             "lib"
                         ],
+                        "doctest": true,
                         "edition": "2015",
                         "kind": [
                             "lib"
@@ -552,6 +559,7 @@ name = "ex"
                     {
                         "kind": [ "lib" ],
                         "crate_types": [ "lib" ],
+                        "doctest": true,
                         "edition": "2015",
                         "name": "foo",
                         "src_path": "[..]/foo/src/lib.rs"
@@ -559,6 +567,7 @@ name = "ex"
                     {
                         "kind": [ "example" ],
                         "crate_types": [ "bin" ],
+                        "doctest": false,
                         "edition": "2015",
                         "name": "ex",
                         "src_path": "[..]/foo/examples/ex.rs"
@@ -635,6 +644,7 @@ crate-type = ["rlib", "dylib"]
                     {
                         "kind": [ "lib" ],
                         "crate_types": [ "lib" ],
+                        "doctest": true,
                         "edition": "2015",
                         "name": "foo",
                         "src_path": "[..]/foo/src/lib.rs"
@@ -642,6 +652,7 @@ crate-type = ["rlib", "dylib"]
                     {
                         "kind": [ "example" ],
                         "crate_types": [ "rlib", "dylib" ],
+                        "doctest": false,
                         "edition": "2015",
                         "name": "ex",
                         "src_path": "[..]/foo/examples/ex.rs"
@@ -717,6 +728,7 @@ fn workspace_metadata() {
                     {
                         "kind": [ "lib" ],
                         "crate_types": [ "lib" ],
+                        "doctest": true,
                         "edition": "2015",
                         "name": "bar",
                         "src_path": "[..]bar/src/lib.rs"
@@ -748,6 +760,7 @@ fn workspace_metadata() {
                     {
                         "kind": [ "lib" ],
                         "crate_types": [ "lib" ],
+                        "doctest": true,
                         "edition": "2015",
                         "name": "baz",
                         "src_path": "[..]baz/src/lib.rs"
@@ -827,6 +840,7 @@ fn workspace_metadata_no_deps() {
                     {
                         "kind": [ "lib" ],
                         "crate_types": [ "lib" ],
+                        "doctest": true,
                         "edition": "2015",
                         "name": "bar",
                         "src_path": "[..]bar/src/lib.rs"
@@ -858,6 +872,7 @@ fn workspace_metadata_no_deps() {
                     {
                         "kind": [ "lib" ],
                         "crate_types": ["lib"],
+                        "doctest": true,
                         "edition": "2015",
                         "name": "baz",
                         "src_path": "[..]baz/src/lib.rs"
@@ -915,6 +930,7 @@ const MANIFEST_OUTPUT: &str = r#"
         "targets":[{
             "kind":["bin"],
             "crate_types":["bin"],
+            "doctest": false,
             "edition": "2015",
             "name":"foo",
             "src_path":"[..]/foo/src/foo.rs"
@@ -1093,6 +1109,7 @@ fn package_metadata() {
                     {
                         "kind": [ "lib" ],
                         "crate_types": [ "lib" ],
+                        "doctest": true,
                         "edition": "2015",
                         "name": "foo",
                         "src_path": "[..]foo/src/lib.rs"
@@ -1167,6 +1184,7 @@ fn cargo_metadata_path_to_cargo_toml_project() {
                     "crate_types": [
                         "lib"
                     ],
+                    "doctest": true,
                     "edition": "2015",
                     "kind": [
                         "lib"
@@ -1246,6 +1264,7 @@ fn package_edition_2018() {
                             "crate_types": [
                                 "lib"
                             ],
+                            "doctest": true,
                             "edition": "2018",
                             "kind": [
                                 "lib"
@@ -1329,6 +1348,7 @@ fn target_edition_2018() {
                             "crate_types": [
                                 "lib"
                             ],
+                            "doctest": true,
                             "edition": "2018",
                             "kind": [
                                 "lib"
@@ -1340,6 +1360,7 @@ fn target_edition_2018() {
                             "crate_types": [
                                 "bin"
                             ],
+                            "doctest": false,
                             "edition": "2015",
                             "kind": [
                                 "bin"
@@ -1449,6 +1470,7 @@ fn rename_dependency() {
                     "crate_types": [
                         "lib"
                     ],
+                    "doctest": true,
                     "edition": "2015",
                     "kind": [
                         "lib"
@@ -1482,6 +1504,7 @@ fn rename_dependency() {
                     "crate_types": [
                         "lib"
                     ],
+                    "doctest": true,
                     "edition": "2015",
                     "kind": [
                         "lib"
@@ -1515,6 +1538,7 @@ fn rename_dependency() {
                     "crate_types": [
                         "lib"
                     ],
+                    "doctest": true,
                     "edition": "2015",
                     "kind": [
                         "lib"
@@ -1616,6 +1640,7 @@ fn metadata_links() {
           "crate_types": [
             "lib"
           ],
+          "doctest": true,
           "edition": "2015",
           "kind": [
             "lib"
@@ -1627,6 +1652,7 @@ fn metadata_links() {
           "crate_types": [
             "bin"
           ],
+          "doctest": false,
           "edition": "2015",
           "kind": [
             "custom-build"

--- a/tests/testsuite/read_manifest.rs
+++ b/tests/testsuite/read_manifest.rs
@@ -22,6 +22,7 @@ static MANIFEST_OUTPUT: &'static str = r#"
     "targets":[{
         "kind":["bin"],
         "crate_types":["bin"],
+        "doctest": false,
         "edition": "2015",
         "name":"foo",
         "src_path":"[..]/foo/src/foo.rs"

--- a/tests/testsuite/test.rs
+++ b/tests/testsuite/test.rs
@@ -3362,6 +3362,7 @@ fn json_artifact_includes_test_flag() {
         "target":{
             "kind":["lib"],
             "crate_types":["lib"],
+            "doctest": true,
             "edition": "2015",
             "name":"foo",
             "src_path":"[..]lib.rs"
@@ -3395,6 +3396,7 @@ fn json_artifact_includes_executable_for_library_tests() {
                 "target": {
                     "crate_types": [ "lib" ],
                     "kind": [ "lib" ],
+                    "doctest": true,
                     "edition": "2015",
                     "name": "foo",
                     "src_path": "[..]/foo/src/lib.rs"
@@ -3428,6 +3430,7 @@ fn json_artifact_includes_executable_for_integration_tests() {
                 "target": {
                     "crate_types": [ "bin" ],
                     "kind": [ "test" ],
+                    "doctest": false,
                     "edition": "2015",
                     "name": "integration_test",
                     "src_path": "[..]/foo/tests/integration_test.rs"

--- a/tests/testsuite/update.rs
+++ b/tests/testsuite/update.rs
@@ -456,6 +456,7 @@ fn update_precise_first_run() {
           "crate_types": [
             "lib"
           ],
+          "doctest": true,
           "edition": "2015",
           "kind": [
             "lib"
@@ -502,6 +503,7 @@ fn update_precise_first_run() {
           "crate_types": [
             "lib"
           ],
+          "doctest": true,
           "edition": "2015",
           "kind": [
             "lib"


### PR DESCRIPTION
Some tools can support rust doctests (e.g. highlighting
or launching). So it should be possible to find out if
doctests are enabled for a target or not. This commit
adds `doctest` field to `cargo metadata` output.

Related to https://github.com/intellij-rust/intellij-rust/issues/3852