### PR TITLE
Change docs "inequality" for semver requirement.

### DIFF
--- a/src/doc/src/reference/specifying-dependencies.md
+++ b/src/doc/src/reference/specifying-dependencies.md
@@ -83,12 +83,12 @@ positioned.
 1.2.* := >=1.2.0 <1.3.0
 ```
 
-### Inequality requirements
+### Comparison requirements
 
-**Inequality requirements** allow manually specifying a version range or an
+**Comparison requirements** allow manually specifying a version range or an
 exact version to depend on.
 
-Here are some examples of inequality requirements:
+Here are some examples of comparison requirements:
 
 ```notrust
 >= 1.2.0


### PR DESCRIPTION
I can see how "inequality" may be confusing. I considered a few other words ("operator", "range", "relational"), but settled on "comparison" since it conveys that it is *comparing* against a value. npm uses the term "comparator".

Closes #6958
