### PR TITLE
Ignore remap-path-prefix in metadata hash.

### DIFF
--- a/src/cargo/core/compiler/context/compilation_files.rs
+++ b/src/cargo/core/compiler/context/compilation_files.rs
@@ -513,10 +513,24 @@ fn compute_metadata<'a, 'cfg>(
     // Throw in the rustflags we're compiling with.
     // This helps when the target directory is a shared cache for projects with different cargo configs,
     // or if the user is experimenting with different rustflags manually.
-    if unit.mode.is_doc() {
-        cx.bcx.rustdocflags_args(unit).hash(&mut hasher);
+    let mut flags = if unit.mode.is_doc() {
+        cx.bcx.rustdocflags_args(unit)
     } else {
-        cx.bcx.rustflags_args(unit).hash(&mut hasher);
+        cx.bcx.rustflags_args(unit)
+    }
+    .into_iter();
+
+    // Ignore some flags. These may affect reproducible builds if they affect
+    // the path. The fingerprint will handle recompilation if these change.
+    while let Some(flag) = flags.next() {
+        if flag.starts_with("--remap-path-prefix=") {
+            continue;
+        }
+        if flag == "--remap-path-prefix" {
+            flags.next();
+            continue;
+        }
+        flag.hash(&mut hasher);
     }
 
     // Artifacts compiled for the host should have a different metadata

--- a/src/cargo/core/compiler/fingerprint.rs
+++ b/src/cargo/core/compiler/fingerprint.rs
@@ -59,7 +59,7 @@
 //! Target flags (test/bench/for_host/edition) | ✓           |
 //! -C incremental=… flag                      | ✓           |
 //! mtime of sources                           | ✓[^3]       |
-//! RUSTFLAGS/RUSTDOCFLAGS                     | ✓           |
+//! RUSTFLAGS/RUSTDOCFLAGS                     | ✓           | ✓
 //!
 //! [^1]: Build script and bin dependencies are not included.
 //!


### PR DESCRIPTION
Including this flag in the metadata hash causes problems with reproducible builds.

I spent some time considering the different alternatives (such as providing a config option, or an unhashed RUSTFLAGS alternative), and decided this might be the best option.

- It is a very simple, small change. 
- It should be safe.
- It is transparent to the user, they don't need to do anything special.
- It doesn't expand Cargo's interface.

Fixes #6914.
