### PR TITLE
Less duplication in activate

### DIFF
--- a/src/cargo/core/resolver/mod.rs
+++ b/src/cargo/core/resolver/mod.rs
@@ -622,8 +622,11 @@ fn activate(
                 while let Some((p, public)) = stack.pop() {
                     match public_dependency.entry(p).or_default().entry(c.name()) {
                         im_rc::hashmap::Entry::Occupied(mut o) => {
-                            // the (transitive) parent can already see something by `c`s name, it had better be `c`.
-                            assert_eq!(o.get().0, c);
+                            if o.get().0 != c {
+                                // the (transitive) parent can already see a different version by `t`s name.
+                                // So, adding `b` will cause `p` to have a public dependency conflict on `c`.
+                                return Err((p, ConflictReason::PublicDependency).into());
+                            }
                             if o.get().1 {
                                 // The previous time the parent saw `c`, it was a public dependency.
                                 // So all of its parents already know about `c`

--- a/src/cargo/core/resolver/types.rs
+++ b/src/cargo/core/resolver/types.rs
@@ -139,14 +139,14 @@ impl DepsFrame {
     fn min_candidates(&self) -> usize {
         self.remaining_siblings
             .peek()
-            .map(|(_, (_, candidates, _))| candidates.len())
+            .map(|(_, candidates, _)| candidates.len())
             .unwrap_or(0)
     }
 
     pub fn flatten<'a>(&'a self) -> impl Iterator<Item = (PackageId, Dependency)> + 'a {
         self.remaining_siblings
             .clone()
-            .map(move |(_, (d, _, _))| (self.parent.package_id(), d))
+            .map(move |(d, _, _)| (self.parent.package_id(), d))
     }
 }
 
@@ -202,7 +202,7 @@ impl RemainingDeps {
         self.data.insert((x, insertion_time));
         self.time += 1;
     }
-    pub fn pop_most_constrained(&mut self) -> Option<(bool, (Summary, (usize, DepInfo)))> {
+    pub fn pop_most_constrained(&mut self) -> Option<(bool, (Summary, DepInfo))> {
         while let Some((mut deps_frame, insertion_time)) = self.data.remove_min() {
             let just_here_for_the_error_messages = deps_frame.just_for_error_messages;
 
@@ -307,11 +307,8 @@ impl<T> RcVecIter<T> {
         self.rest.start < self.rest.end
     }
 
-    fn peek(&self) -> Option<(usize, &T)> {
-        self.rest
-            .clone()
-            .next()
-            .and_then(|i| self.vec.get(i).map(|val| (i, &*val)))
+    fn peek(&self) -> Option<&T> {
+        self.rest.clone().next().and_then(|i| self.vec.get(i))
     }
 }
 
@@ -329,12 +326,10 @@ impl<T> Iterator for RcVecIter<T>
 where
     T: Clone,
 {
-    type Item = (usize, T);
+    type Item = T;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.rest
-            .next()
-            .and_then(|i| self.vec.get(i).map(|val| (i, val.clone())))
+        self.rest.next().and_then(|i| self.vec.get(i).cloned())
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {

--- a/src/cargo/core/resolver/types.rs
+++ b/src/cargo/core/resolver/types.rs
@@ -303,6 +303,10 @@ impl<T> RcVecIter<T> {
         }
     }
 
+    pub fn has_another(&self) -> bool {
+        self.rest.start < self.rest.end
+    }
+
     fn peek(&self) -> Option<(usize, &T)> {
         self.rest
             .clone()


### PR DESCRIPTION
One of the "background context" things I re-explained in https://github.com/rust-lang/cargo/pull/6919#issuecomment-493219120 is why we have checks in `RemainingCandidates::next` and in `flag_activated`.  "Why the duplication? Because cloning a `BacktrackFrame` is more expensive than doing the work twice." But thanks to a lot of work, and `im.rs`, the clone is now not so bad.

This PR attempts to go all in on removing this duplication. Anything to simplify the resolver is good! But, this removes or hamstrings several important optimizations that make NOP builds fast. Specifically #5132 will kick in far less often. Alex, can you look at the times after/before this PR on some larger projects? You have seen this be slow with `perf record ./x.py build` before, but servo or cargo may be easy and interesting.

Note that Master is at "Fast but duplicated" and this PR may be at "Slow but clean", the best solution may be somewhere in between. 