### PR TITLE
Add required user-agent to crates-io lib api (breaking change)

### DIFF
--- a/src/cargo/ops/registry.rs
+++ b/src/cargo/ops/registry.rs
@@ -366,7 +366,7 @@ fn registry(
     if validate_token && token.is_none() {
         bail!("no upload token found, please run `cargo login`");
     };
-    Ok((Registry::new_handle(api_host, token, handle), sid))
+    Ok((Registry::new_handle(api_host, token, format!("{}/{}", env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION")), handle), sid))
 }
 
 /// Creates a new HTTP handle with appropriate global configuration for cargo.

--- a/src/crates-io/lib.rs
+++ b/src/crates-io/lib.rs
@@ -138,7 +138,7 @@ impl Registry {
         Registry {
             host,
             token,
-            user_agent: userAgent,
+            user_agent,
             handle,
         }
     }

--- a/src/crates-io/lib.rs
+++ b/src/crates-io/lib.rs
@@ -23,6 +23,9 @@ pub struct Registry {
     /// Optional authorization token.
     /// If None, commands requiring authorization will fail.
     token: Option<String>,
+    /// Optional user-agent
+    /// If None, a default user-agent ("crates-io") will be used
+    user_agent: Option<String>,
     /// Curl handle for issuing requests.
     handle: Easy,
 }
@@ -127,14 +130,15 @@ struct Crates {
     meta: TotalCrates,
 }
 impl Registry {
-    pub fn new(host: String, token: Option<String>) -> Registry {
-        Registry::new_handle(host, token, Easy::new())
+    pub fn new(host: String, token: Option<String>, user_agent: Option<String>) -> Registry {
+        Registry::new_handle(host, token, user_agent, Easy::new())
     }
 
-    pub fn new_handle(host: String, token: Option<String>, handle: Easy) -> Registry {
+    pub fn new_handle(host: String, token: Option<String>, user_agent: Option<String>, handle: Easy) -> Registry {
         Registry {
             host,
             token,
+            user_agent: userAgent,
             handle,
         }
     }
@@ -295,6 +299,7 @@ impl Registry {
         let mut headers = List::new();
         headers.append("Accept: application/json")?;
         headers.append("Content-Type: application/json")?;
+        headers.append(format!("User-Agent: {}", self.user_agent.unwrap_or("crates-io".to_string())).as_str());
 
         if authorized == Auth::Authorized {
             let token = match self.token.as_ref() {

--- a/src/crates-io/lib.rs
+++ b/src/crates-io/lib.rs
@@ -23,9 +23,11 @@ pub struct Registry {
     /// Optional authorization token.
     /// If None, commands requiring authorization will fail.
     token: Option<String>,
-    /// Optional user-agent
-    /// If None, a default user-agent ("crates-io") will be used
-    user_agent: Option<String>,
+    /// User-agent, required by crates.io for every requests
+    /// To allow us to determine the impact your bot has on our service,
+    /// we ask that your user agent actually identify your bot,
+    /// and not just report the HTTP client library you're using.
+    user_agent: String,
     /// Curl handle for issuing requests.
     handle: Easy,
 }
@@ -130,11 +132,11 @@ struct Crates {
     meta: TotalCrates,
 }
 impl Registry {
-    pub fn new(host: String, token: Option<String>, user_agent: Option<String>) -> Registry {
+    pub fn new(host: String, token: Option<String>, user_agent: String) -> Registry {
         Registry::new_handle(host, token, user_agent, Easy::new())
     }
 
-    pub fn new_handle(host: String, token: Option<String>, user_agent: Option<String>, handle: Easy) -> Registry {
+    pub fn new_handle(host: String, token: Option<String>, user_agent: String, handle: Easy) -> Registry {
         Registry {
             host,
             token,
@@ -299,7 +301,7 @@ impl Registry {
         let mut headers = List::new();
         headers.append("Accept: application/json")?;
         headers.append("Content-Type: application/json")?;
-        headers.append(format!("User-Agent: {}", self.user_agent.unwrap_or("crates-io".to_string())).as_str());
+        headers.append(format!("User-Agent: {}", self.user_agent).as_str());
 
         if authorized == Auth::Authorized {
             let token = match self.token.as_ref() {


### PR DESCRIPTION
Since cargo.io now requires a User-Agent header (see message below), I've updated the crates-io crate accordingly. Hope this will be approved and generate a new release of crates-io :)

This is a breaking change because there is an contract change on (added `user_agent: Option<String>`):
- `Registry::new(host: String, token: Option<String>, user_agent: Option<String>)`
- `Registry::new_handle(host: String, token: Option<String>, user_agent: Option<String>, handle: Easy)`

Message from crates.io:

```
We require that all requests include a `User-Agent` header. 
To allow us to determine the impact your bot has on our service, we ask that your user agent actually identify your bot, and not just report the HTTP client library you're using.  
Including contact information will also reduce the chance that we will need to take action against your bot.

Bad:
User-Agent: reqwest/0.9.1

Better:
User-Agent: my_crawler

Best:
User-Agent: my_crawler (my_crawler.com/info)
User-Agent: my_crawler (help@my_crawler.com)

If you believe you've received this message in error, please email help@crates.io and include the request id 7da610ae-264a-4738-a979-c53465fa8c99.
```

