### PR TITLE
Test the Resolver against the varisat Library

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,6 +103,7 @@ features = [
 [dev-dependencies]
 bufstream = "0.1"
 proptest = "0.9.1"
+varisat = "0.2.1"
 
 [[bin]]
 name = "cargo"

--- a/tests/testsuite/resolve.rs
+++ b/tests/testsuite/resolve.rs
@@ -46,13 +46,12 @@ proptest! {
         // crate will be interesting.
         // So we try some of the most complicated.
         for this in input.iter().rev().take(20) {
-            let should_resolve = sat_resolve.sat_resolve(this.package_id());
-            let resolve = resolve_and_validated(
+            let _ = resolve_and_validated(
                 pkg_id("root"),
                 vec![dep_req(&this.name(), &format!("={}", this.version()))],
                 &reg,
+                Some(&mut sat_resolve),
             );
-            assert_eq!(resolve.is_ok(), should_resolve);
         }
     }
 
@@ -248,7 +247,7 @@ fn basic_public_dependency() {
         pkg!("C" => [dep("A"), dep("B")]),
     ]);
 
-    let res = resolve_and_validated(pkg_id("root"), vec![dep("C")], &reg).unwrap();
+    let res = resolve_and_validated(pkg_id("root"), vec![dep("C")], &reg, None).unwrap();
     assert_same(
         &res,
         &names(&[
@@ -284,7 +283,7 @@ fn public_dependency_filling_in() {
         pkg!("d" => [dep("c"), dep("a"), dep("b")]),
     ]);
 
-    let res = resolve_and_validated(pkg_id("root"), vec![dep("d")], &reg).unwrap();
+    let res = resolve_and_validated(pkg_id("root"), vec![dep("d")], &reg, None).unwrap();
     assert_same(
         &res,
         &names(&[
@@ -319,7 +318,7 @@ fn public_dependency_filling_in_and_update() {
         pkg!("C" => [dep("A"),dep("B")]),
         pkg!("D" => [dep("B"),dep("C")]),
     ]);
-    let res = resolve_and_validated(pkg_id("root"), vec![dep("D")], &reg).unwrap();
+    let res = resolve_and_validated(pkg_id("root"), vec![dep("D")], &reg, None).unwrap();
     assert_same(
         &res,
         &names(&[
@@ -1410,7 +1409,7 @@ fn conflict_store_bug() {
     ];
 
     let reg = registry(input);
-    let _ = resolve_and_validated(pkg_id("root"), vec![dep("j")], &reg);
+    let _ = resolve_and_validated(pkg_id("root"), vec![dep("j")], &reg, None);
 }
 
 #[test]
@@ -1438,5 +1437,5 @@ fn conflict_store_more_then_one_match() {
         ]),
     ];
     let reg = registry(input);
-    let _ = resolve_and_validated(pkg_id("root"), vec![dep("nA")], &reg);
+    let _ = resolve_and_validated(pkg_id("root"), vec![dep("nA")], &reg, None);
 }

--- a/tests/testsuite/resolve.rs
+++ b/tests/testsuite/resolve.rs
@@ -239,6 +239,18 @@ proptest! {
 }
 
 #[test]
+fn pub_fail() {
+    let input = vec![
+        pkg!(("a", "0.0.4")),
+        pkg!(("a", "0.0.5")),
+        pkg!(("e", "0.0.6") => [dep_req_kind("a", "<= 0.0.4", Kind::Normal, true),]),
+        pkg!(("kB", "0.0.3") => [dep_req("a", ">= 0.0.5"),dep("e"),]),
+    ];
+    let reg = registry(input.clone());
+    assert!(resolve_and_validated(pkg_id("root"), vec![dep("kB")], &reg, None).is_err());
+}
+
+#[test]
 fn basic_public_dependency() {
     let reg = registry(vec![
         pkg!(("A", "0.1.0")),

--- a/tests/testsuite/support/resolver.rs
+++ b/tests/testsuite/support/resolver.rs
@@ -820,25 +820,30 @@ pub fn registry_strategy(
                     ))
                 }
 
-                PrettyPrintRegistry(
-                    list_of_pkgid
-                        .into_iter()
-                        .zip(dependency_by_pkgid.into_iter())
-                        .map(|(((name, ver), allow_deps), deps)| {
-                            pkg_dep(
-                                (name, ver).to_pkgid(),
-                                if !allow_deps {
-                                    vec![dep_req("bad", "*")]
-                                } else {
-                                    let mut deps = deps;
-                                    deps.sort_by_key(|d| d.name_in_toml());
-                                    deps.dedup_by_key(|d| d.name_in_toml());
-                                    deps
-                                },
-                            )
-                        })
-                        .collect(),
-                )
+                let mut out: Vec<Summary> = list_of_pkgid
+                    .into_iter()
+                    .zip(dependency_by_pkgid.into_iter())
+                    .map(|(((name, ver), allow_deps), deps)| {
+                        pkg_dep(
+                            (name, ver).to_pkgid(),
+                            if !allow_deps {
+                                vec![dep_req("bad", "*")]
+                            } else {
+                                let mut deps = deps;
+                                deps.sort_by_key(|d| d.name_in_toml());
+                                deps.dedup_by_key(|d| d.name_in_toml());
+                                deps
+                            },
+                        )
+                    })
+                    .collect();
+
+                if reverse_alphabetical {
+                    // make sure the complicated cases are at the end
+                    out.reverse();
+                }
+
+                PrettyPrintRegistry(out)
             },
         )
 }

--- a/tests/testsuite/support/resolver.rs
+++ b/tests/testsuite/support/resolver.rs
@@ -369,18 +369,6 @@ impl SatResolve {
         // `can_see` as being in terms of a set of `activations_key`s
         let mut can_see: HashMap<_, HashMap<_, varisat::Var>> = HashMap::new();
 
-        // if `p` `publicly_exports` `export` then it `can_see` `export`
-        for (&p, exports) in &publicly_exports {
-            for (&export_pid, export_var) in exports {
-                let our_var = can_see
-                    .entry(p)
-                    .or_default()
-                    .entry(export_pid)
-                    .or_insert_with(|| cnf.new_var());
-                cnf.add_clause(&[export_var.negative(), our_var.positive()]);
-            }
-        }
-
         // if `p` has a `dep` that selected `ver` then it `can_see` all the things that the selected version `publicly_exports`
         for (&p, deps) in version_selected_for.iter() {
             for (_, versions) in deps {


### PR DESCRIPTION
Resolution can be reduced to the SAT problem. So this is an alternative implementation of the resolver that uses a SAT library for the hard work. This is intended to be easy to read, as compared to the real resolver, and run as part of the test sweet to make sure the real resolver works as expected. Part of #6120.

Some notes on performance:
The initial version did not support public & private deps:
~64 loc, `O(nln(n))` vars, `O(nln(n) + n*d)` clauses, 0.5x slower on `prop_passes_validation`
The final version:
~163 loc, `O(dn^2`) vars, `O(dn^3)`  clauses, 1.5x slower on `prop_passes_validation`

That comparison makes me feel better about spending months trying to get public & private deps to be fast enough for stabilization.