### PR TITLE
change package cache lock message

### DIFF
--- a/src/cargo/core/package_id.rs
+++ b/src/cargo/core/package_id.rs
@@ -104,7 +104,7 @@ impl PartialEq for PackageId {
     }
 }
 
-impl<'a> Hash for PackageId {
+impl Hash for PackageId {
     fn hash<S: hash::Hasher>(&self, state: &mut S) {
         self.inner.name.hash(state);
         self.inner.version.hash(state);

--- a/src/cargo/util/config.rs
+++ b/src/cargo/util/config.rs
@@ -882,7 +882,7 @@ impl Config {
             }
             None => {
                 let path = ".package-cache";
-                let desc = "package cache lock";
+                let desc = "package cache";
 
                 // First, attempt to open an exclusive lock which is in general
                 // the purpose of this lock!


### PR DESCRIPTION
Change the message from
waiting for file lock on package cache lock
to
waiting for file lock on package cache

The former message made it sound like the lock itself had a lock.