### PR TITLE
Support absolute paths in dep-info files

### DIFF
--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -315,13 +315,19 @@ fn rustc<'a, 'cfg>(
         }
 
         if rustc_dep_info_loc.exists() {
-            fingerprint::translate_dep_info(&rustc_dep_info_loc, &dep_info_loc, &pkg_root, &cwd)
-                .chain_err(|| {
-                    internal(format!(
-                        "could not parse/generate dep info at: {}",
-                        rustc_dep_info_loc.display()
-                    ))
-                })?;
+            fingerprint::translate_dep_info(
+                &rustc_dep_info_loc,
+                &dep_info_loc,
+                &cwd,
+                &pkg_root,
+                &root_output,
+            )
+            .chain_err(|| {
+                internal(format!(
+                    "could not parse/generate dep info at: {}",
+                    rustc_dep_info_loc.display()
+                ))
+            })?;
             filetime::set_file_times(dep_info_loc, timestamp, timestamp)?;
         }
 

--- a/src/cargo/core/compiler/output_depinfo.rs
+++ b/src/cargo/core/compiler/output_depinfo.rs
@@ -39,7 +39,11 @@ fn add_deps_for_unit<'a, 'b>(
     if !unit.mode.is_run_custom_build() {
         // Add dependencies from rustc dep-info output (stored in fingerprint directory)
         let dep_info_loc = fingerprint::dep_info_loc(context, unit);
-        if let Some(paths) = fingerprint::parse_dep_info(unit.pkg.root(), &dep_info_loc)? {
+        if let Some(paths) = fingerprint::parse_dep_info(
+            unit.pkg.root(),
+            context.files().host_root(),
+            &dep_info_loc,
+        )? {
             for path in paths {
                 deps.insert(path);
             }


### PR DESCRIPTION
These changes are a little more invasive then I would've liked, but I couldn't come up with a significantly better way to structure this. Comments (or backwards-compat) concerns are appreciated, of course!

cc https://github.com/rust-lang/rust/pull/61727

r? @alexcrichton 