### PR TITLE
Deprecated ONCE_INIT in favor of Once::new()

### DIFF
--- a/src/cargo/util/config.rs
+++ b/src/cargo/util/config.rs
@@ -10,7 +10,7 @@ use std::io::{self, SeekFrom};
 use std::mem;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
-use std::sync::{Once, ONCE_INIT};
+use std::sync::Once;
 use std::time::Instant;
 use std::vec;
 
@@ -89,7 +89,7 @@ pub struct Config {
 impl Config {
     pub fn new(shell: Shell, cwd: PathBuf, homedir: PathBuf) -> Config {
         static mut GLOBAL_JOBSERVER: *mut jobserver::Client = 0 as *mut _;
-        static INIT: Once = ONCE_INIT;
+        static INIT: Once = Once::new();
 
         // This should be called early on in the process, so in theory the
         // unsafety is ok here. (taken ownership of random fds)

--- a/tests/testsuite/support/cross_compile.rs
+++ b/tests/testsuite/support/cross_compile.rs
@@ -1,7 +1,7 @@
 use std::env;
 use std::process::Command;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Once, ONCE_INIT};
+use std::sync::Once;
 
 use crate::support::{basic_bin_manifest, main_file, project};
 
@@ -23,7 +23,7 @@ pub fn disabled() -> bool {
     // try to detect that before we fail a bunch of tests through no fault
     // of the user.
     static CAN_RUN_CROSS_TESTS: AtomicBool = AtomicBool::new(false);
-    static CHECK: Once = ONCE_INIT;
+    static CHECK: Once = Once::new();
 
     let cross_target = alternate();
 


### PR DESCRIPTION
cc rust-lang/rust#61757
