### PR TITLE
Fix overwriting .d file for binary with dSYM on apple targets.

### DIFF
--- a/src/cargo/core/compiler/output_depinfo.rs
+++ b/src/cargo/core/compiler/output_depinfo.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 
 use log::debug;
 
-use super::{fingerprint, Context, Unit};
+use super::{fingerprint, Context, FileFlavor, Unit};
 use crate::util::paths;
 use crate::util::{internal, CargoResult};
 
@@ -98,7 +98,11 @@ pub fn output_depinfo<'a, 'b>(cx: &mut Context<'a, 'b>, unit: &Unit<'a>) -> Carg
         .map(|f| render_filename(f, basedir))
         .collect::<CargoResult<Vec<_>>>()?;
 
-    for output in cx.outputs(unit)?.iter() {
+    for output in cx
+        .outputs(unit)?
+        .iter()
+        .filter(|o| o.flavor != FileFlavor::DebugInfo)
+    {
         if let Some(ref link_dst) = output.hardlink {
             let output_path = link_dst.with_extension("d");
             if success {

--- a/tests/testsuite/dep_info.rs
+++ b/tests/testsuite/dep_info.rs
@@ -13,6 +13,13 @@ fn build_dep_info() {
     let depinfo_bin_path = &p.bin("foo").with_extension("d");
 
     assert!(depinfo_bin_path.is_file());
+
+    let depinfo = p.read_file(depinfo_bin_path.to_str().unwrap());
+
+    let bin_path = p.bin("foo");
+    let src_path = p.root().join("src").join("foo.rs");
+    let expected_depinfo = format!("{}: {}\n", bin_path.display(), src_path.display());
+    assert_eq!(depinfo, expected_depinfo);
 }
 
 #[cargo_test]


### PR DESCRIPTION
When building a binary on targets containing `-apple-`, the resulting `.d` file gets overwritten with the dependencies of the `.dSYM` file. Eg. in the changed unit test, `foo.d` would start with `p.bin(foo).with_extension("dSYM")` instead of `p.bin(foo)`.

This PR fixes that problem by not generating `.d` dependency information files for outputs of the `DebugInfo` flavor.