### PR TITLE
add flag to optionally document dev dependencies

### DIFF
--- a/src/bin/cargo/commands/rustdoc.rs
+++ b/src/bin/cargo/commands/rustdoc.rs
@@ -54,7 +54,7 @@ pub fn exec(config: &mut Config, args: &ArgMatches<'_>) -> CliResult {
     let mut compile_opts = args.compile_options_for_single_package(
         config,
         CompileMode::Doc {
-            dep_mode: DepDocMode::Normal,
+            dep_mode: DepDocMode::NoDeps,
         },
         Some(&ws),
     )?;

--- a/src/bin/cargo/commands/rustdoc.rs
+++ b/src/bin/cargo/commands/rustdoc.rs
@@ -53,7 +53,9 @@ pub fn exec(config: &mut Config, args: &ArgMatches<'_>) -> CliResult {
     let ws = args.workspace(config)?;
     let mut compile_opts = args.compile_options_for_single_package(
         config,
-        CompileMode::Doc { deps: false },
+        CompileMode::Doc {
+            dep_mode: DepDocMode::Normal,
+        },
         Some(&ws),
     )?;
     let target_args = values(args, "args");

--- a/src/cargo/core/compiler/build_config.rs
+++ b/src/cargo/core/compiler/build_config.rs
@@ -27,6 +27,8 @@ pub struct BuildConfig {
     /// An optional wrapper, if any, used to wrap rustc invocations
     pub rustc_wrapper: Option<ProcessBuilder>,
     pub rustfix_diagnostic_server: RefCell<Option<RustfixDiagnosticServer>>,
+    /// Wheather or not to document development dependencies
+    pub document_dev_dependencies: bool,
     /// Whether or not Cargo should cache compiler output on disk.
     cache_messages: bool,
 }
@@ -100,6 +102,7 @@ impl BuildConfig {
             build_plan: false,
             rustc_wrapper: None,
             rustfix_diagnostic_server: RefCell::new(None),
+            document_dev_dependencies: false,
             cache_messages: config.cli_unstable().cache_messages,
         })
     }

--- a/src/cargo/core/compiler/context/unit_dependencies.rs
+++ b/src/cargo/core/compiler/context/unit_dependencies.rs
@@ -299,6 +299,9 @@ fn compute_deps_doc<'a, 'cfg, 'tmp>(
         .filter(|&(_id, deps)| {
             deps.iter().any(|dep| match dep.kind() {
                 DepKind::Normal => bcx.dep_platform_activated(dep, unit.kind),
+                DepKind::Development if bcx.build_config.document_dev_dependencies => {
+                    bcx.dep_platform_activated(dep, unit.kind)
+                }
                 _ => false,
             })
         });

--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -24,7 +24,7 @@ use log::debug;
 use same_file::is_same_file;
 use serde::Serialize;
 
-pub use self::build_config::{BuildConfig, CompileMode, MessageFormat};
+pub use self::build_config::{BuildConfig, CompileMode, DepDocMode, MessageFormat};
 pub use self::build_context::{BuildContext, FileFlavor, TargetConfig, TargetInfo};
 use self::build_plan::BuildPlan;
 pub use self::compilation::{Compilation, Doctest};

--- a/src/cargo/util/command_prelude.rs
+++ b/src/cargo/util/command_prelude.rs
@@ -15,7 +15,7 @@ use crate::util::{
 use crate::CargoResult;
 use clap::{self, SubCommand};
 
-pub use crate::core::compiler::CompileMode;
+pub use crate::core::compiler::{CompileMode, DepDocMode};
 pub use crate::{CliError, CliResult, Config};
 pub use clap::{AppSettings, Arg, ArgMatches};
 

--- a/tests/testsuite/rustdoc.rs
+++ b/tests/testsuite/rustdoc.rs
@@ -61,7 +61,11 @@ fn rustdoc_foo_with_bar_dependency() {
     foo.cargo("rustdoc -v -- --cfg=foo")
         .with_stderr(
             "\
+[DOCUMENTING] bar v0.0.1 ([..])
 [CHECKING] bar v0.0.1 ([..])
+[RUNNING] `rustdoc --crate-name bar [..]\
+        -o [CWD]/target/doc \
+        -L dependency=[CWD]/target/debug/deps`
 [RUNNING] `rustc [..]bar/src/lib.rs [..]`
 [DOCUMENTING] foo v0.0.1 ([CWD])
 [RUNNING] `rustdoc --crate-name foo src/lib.rs [..]\

--- a/tests/testsuite/rustdoc.rs
+++ b/tests/testsuite/rustdoc.rs
@@ -61,11 +61,7 @@ fn rustdoc_foo_with_bar_dependency() {
     foo.cargo("rustdoc -v -- --cfg=foo")
         .with_stderr(
             "\
-[DOCUMENTING] bar v0.0.1 ([..])
 [CHECKING] bar v0.0.1 ([..])
-[RUNNING] `rustdoc --crate-name bar [..]\
-        -o [CWD]/target/doc \
-        -L dependency=[CWD]/target/debug/deps`
 [RUNNING] `rustc [..]bar/src/lib.rs [..]`
 [DOCUMENTING] foo v0.0.1 ([CWD])
 [RUNNING] `rustdoc --crate-name foo src/lib.rs [..]\


### PR DESCRIPTION
This is working. One issue that I noticed right away is that a second run of `cargo doc --open` without the `--dev` option after it has already been run once with dev documentation enabled it will still show the documentation items from the last run.

closes https://github.com/rust-lang/cargo/issues/3475