### PR TITLE
Clean environment when git-fetch-with-cli is used.

### DIFF
--- a/src/cargo/sources/git/utils.rs
+++ b/src/cargo/sources/git/utils.rs
@@ -770,6 +770,17 @@ fn fetch_with_cli(
         .arg("--update-head-ok") // see discussion in #2078
         .arg(url.to_string())
         .arg(refspec)
+        // If cargo is run by git (for example, the `exec` command in `git
+        // rebase`), the GIT_DIR is set by git and will point to the wrong
+        // location (this takes precedence over the cwd). Make sure this is
+        // unset so git will look at cwd for the repo.
+        .env_remove("GIT_DIR")
+        // The reset of these may not be necessary, but I'm including them
+        // just to be extra paranoid and avoid any issues.
+        .env_remove("GIT_WORK_TREE")
+        .env_remove("GIT_INDEX_FILE")
+        .env_remove("GIT_OBJECT_DIRECTORY")
+        .env_remove("GIT_ALTERNATE_OBJECT_DIRECTORIES")
         .cwd(repo.path());
     config
         .shell()

--- a/tests/testsuite/git.rs
+++ b/tests/testsuite/git.rs
@@ -2694,3 +2694,52 @@ fn git_with_cli_force() {
     p.cargo("build").run();
     p.rename_run("foo", "foo2").with_stdout("two").run();
 }
+
+#[cargo_test]
+fn git_fetch_cli_env_clean() {
+    if disable_git_cli() {
+        return;
+    }
+    // This tests that git-fetch-with-cli works when GIT_DIR environment
+    // variable is set (for whatever reason).
+    let git_dep = git::new("dep1", |project| {
+        project
+            .file("Cargo.toml", &basic_manifest("dep1", "0.5.0"))
+            .file("src/lib.rs", "")
+    })
+    .unwrap();
+
+    let git_proj = git::new("foo", |project| {
+        project
+            .file(
+                "Cargo.toml",
+                &format!(
+                    r#"
+                    [package]
+                    name = "foo"
+                    version = "0.1.0"
+                    [dependencies]
+                    dep1 = {{ git = '{}' }}
+                    "#,
+                    git_dep.url()
+                ),
+            )
+            .file("src/lib.rs", "pub extern crate dep1;")
+            .file(
+                ".cargo/config",
+                "
+                [net]
+                git-fetch-with-cli = true
+                ",
+            )
+    })
+    .unwrap();
+
+    // The directory set here isn't too important. Pointing to our own git
+    // directory causes git to be confused and fail. Can also point to an
+    // empty directory, or a nonexistent one.
+    git_proj
+        .cargo("fetch")
+        .env("GIT_DIR", git_proj.root().join(".git"))
+        .run();
+}


### PR DESCRIPTION
When the GIT_DIR environment variable is set, git-the-cli will use that instead of looking at cwd.  This can happen, for example, when using the `exec` command in `git rebase` to call cargo.  This causes cargo to fetch into the wrong directory.

Closes #7072
