### PR TITLE
improve uncommitted changes cargo-package message

### DIFF
--- a/src/cargo/ops/cargo_package.rs
+++ b/src/cargo/ops/cargo_package.rs
@@ -291,7 +291,7 @@ fn check_repo_state(
                 failure::bail!(
                     "{} files in the working directory contain changes that were \
                      not yet committed into git:\n\n{}\n\n\
-                     to proceed despite this, pass the `--allow-dirty` flag",
+                     to proceed despite this and include the uncommited changes, pass the `--allow-dirty` flag",
                     dirty.len(),
                     dirty.join("\n")
                 )

--- a/tests/testsuite/package.rs
+++ b/tests/testsuite/package.rs
@@ -758,7 +758,7 @@ committed into git:
 
 Cargo.toml
 
-to proceed despite this, pass the `--allow-dirty` flag
+to proceed despite this and include the uncommited changes, pass the `--allow-dirty` flag
 ",
         )
         .run();

--- a/tests/testsuite/publish.rs
+++ b/tests/testsuite/publish.rs
@@ -396,7 +396,7 @@ committed into git:
 
 bar
 
-to proceed despite this, pass the `--allow-dirty` flag
+to proceed despite this and include the uncommited changes, pass the `--allow-dirty` flag
 ",
         )
         .run();


### PR DESCRIPTION
fixes #7003

Explicitly state what the suggested flag `--allow-dirty`
actually does when packaging/publishing the crate. Primarily,
that the uncommitted changes are included within the resulting
package.