### PR TITLE
Fix 'getting started' internal links

### DIFF
--- a/src/doc/src/getting-started/first-steps.md
+++ b/src/doc/src/getting-started/first-steps.md
@@ -70,4 +70,4 @@ Hello, world!
 
 ### Going further
 
-For more details on using Cargo, check out the [Cargo Guide](guide/index.html)
+For more details on using Cargo, check out the [Cargo Guide](../guide/index.html)

--- a/src/doc/src/getting-started/index.md
+++ b/src/doc/src/getting-started/index.md
@@ -2,5 +2,5 @@
 
 To get started with Cargo, install Cargo (and Rust) and set up your first crate.
 
-* [Installation](getting-started/installation.html)
-* [First steps with Cargo](getting-started/first-steps.html)
+* [Installation](installation.html)
+* [First steps with Cargo](first-steps.html)


### PR DESCRIPTION
Currently the internal links do not work, the path is incorrect.

Update the path for internal links in the index file of 'getting started' section thereby fixing the links generated in HTML.