### PR TITLE
Remove stale git init comment

### DIFF
--- a/src/doc/src/guide/creating-a-new-project.md
+++ b/src/doc/src/guide/creating-a-new-project.md
@@ -7,8 +7,7 @@ $ cargo new hello_world --bin
 ```
 
 We’re passing `--bin` because we’re making a binary program: if we
-were making a library, we’d pass `--lib`. This also initializes a new `git`
-repository by default. If you don't want it to do that, pass `--vcs none`.
+were making a library, we’d pass `--lib`.
 
 Let’s check out what Cargo has generated for us:
 

--- a/src/doc/src/guide/creating-a-new-project.md
+++ b/src/doc/src/guide/creating-a-new-project.md
@@ -7,7 +7,9 @@ $ cargo new hello_world --bin
 ```
 
 We’re passing `--bin` because we’re making a binary program: if we
-were making a library, we’d pass `--lib`.
+were making a library, we’d pass `--lib`. This also initializes a new `git`
+repository by default (unless the current directory is already under version
+control). If you don't want it to do that, pass `--vcs none`.
 
 Let’s check out what Cargo has generated for us:
 


### PR DESCRIPTION
Cargo does not intialize a git repository by default.  The docs currently incorrectly state that this is the default behaviour.

Remove incorrect comment about default Cargo --cvs behaviour.