### PR TITLE
Revert "Fix 'getting started' internal links"

### DIFF
--- a/src/doc/src/getting-started/first-steps.md
+++ b/src/doc/src/getting-started/first-steps.md
@@ -70,4 +70,4 @@ Hello, world!
 
 ### Going further
 
-For more details on using Cargo, check out the [Cargo Guide](../guide/index.html)
+For more details on using Cargo, check out the [Cargo Guide](guide/index.html)

--- a/src/doc/src/getting-started/index.md
+++ b/src/doc/src/getting-started/index.md
@@ -2,5 +2,5 @@
 
 To get started with Cargo, install Cargo (and Rust) and set up your first crate.
 
-* [Installation](installation.html)
-* [First steps with Cargo](first-steps.html)
+* [Installation](getting-started/installation.html)
+* [First steps with Cargo](getting-started/first-steps.html)


### PR DESCRIPTION
This reverts commit 60f25f56b8f398e935d7e8d952c4c2e6cc0bc7d5 (#7093).

Cargo currently uses mdbook 0.1, so the links were correct.
