### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ path = "src/cargo/lib.rs"
 
 [dependencies]
 atty = "0.2"
-byteorder = "1.2"
 bytesize = "1.0"
 crates-io = { path = "crates/crates-io", version = "0.27" }
 crossbeam-utils = "0.6"


### PR DESCRIPTION
This removes the `byteorder`-dependency, which was used in a few tests only anyway and is not needed since 1.32; also removes the `derive`-feature from the `failure`-crate, which is not needed also.