### PR TITLE
Don't suppress error messages with `-q`

### DIFF
--- a/src/cargo/core/shell.rs
+++ b/src/cargo/core/shell.rs
@@ -207,7 +207,10 @@ impl Shell {
 
     /// Prints a red 'error' message.
     pub fn error<T: fmt::Display>(&mut self, message: T) -> CargoResult<()> {
-        self.print(&"error:", Some(&message), Red, false)
+        if self.needs_clear {
+            self.err_erase_line();
+        }
+        self.err.print(&"error:", Some(&message), Red, false)
     }
 
     /// Prints an amber 'warning' message.

--- a/tests/testsuite/workspaces.rs
+++ b/tests/testsuite/workspaces.rs
@@ -2137,3 +2137,39 @@ fn ws_warn_path() {
         .with_stderr_contains("[WARNING] [..]/foo/a/Cargo.toml: the cargo feature `edition`[..]")
         .run();
 }
+
+#[cargo_test]
+fn invalid_missing() {
+    // Warnings include path to manifest.
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.1.0"
+
+                [dependencies]
+                x = { path = 'x' }
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    p.cargo("build -q")
+        .with_status(101)
+        .with_stderr(
+            "\
+error: [..]
+
+Caused by:
+  [..]
+
+Caused by:
+  [..]
+
+Caused by:
+  [..]",
+        )
+        .run();
+}


### PR DESCRIPTION
If we're printing an error, make sure we always print it regardless of
verbosity settings!

Closes #7025