### PR TITLE
Remove now-unused `WorkspaceResolve`

### DIFF
--- a/src/cargo/core/resolver/context.rs
+++ b/src/cargo/core/resolver/context.rs
@@ -15,8 +15,8 @@ use crate::util::Graph;
 use super::dep_cache::RegistryQueryer;
 use super::types::{ConflictMap, FeaturesSet, Method};
 
+pub use super::encode::Metadata;
 pub use super::encode::{EncodableDependency, EncodablePackageId, EncodableResolve};
-pub use super::encode::{Metadata, WorkspaceResolve};
 pub use super::resolve::Resolve;
 
 // A `Context` is basically a bunch of local resolution information which is

--- a/src/cargo/core/resolver/mod.rs
+++ b/src/cargo/core/resolver/mod.rs
@@ -65,8 +65,8 @@ use self::dep_cache::RegistryQueryer;
 use self::types::{ConflictMap, ConflictReason, DepsFrame};
 use self::types::{FeaturesSet, RcVecIter, RemainingDeps, ResolverProgress};
 
+pub use self::encode::Metadata;
 pub use self::encode::{EncodableDependency, EncodablePackageId, EncodableResolve};
-pub use self::encode::{Metadata, WorkspaceResolve};
 pub use self::errors::{ActivateError, ActivateResult, ResolveError};
 pub use self::resolve::Resolve;
 pub use self::types::Method;

--- a/src/cargo/ops/lockfile.rs
+++ b/src/cargo/ops/lockfile.rs
@@ -2,7 +2,6 @@ use std::io::prelude::*;
 
 use toml;
 
-use crate::core::resolver::WorkspaceResolve;
 use crate::core::{resolver, Resolve, Workspace};
 use crate::util::errors::{CargoResult, CargoResultExt};
 use crate::util::toml as cargo_toml;
@@ -89,7 +88,7 @@ fn resolve_to_string_orig(
         Ok(s)
     });
 
-    let toml = toml::Value::try_from(WorkspaceResolve { ws, resolve }).unwrap();
+    let toml = toml::Value::try_from(resolve).unwrap();
 
     let mut out = String::new();
 


### PR DESCRIPTION
The reason this type existed was to pass in a `Workspace`, but that's no
longer necessary!