### PR TITLE
Remove unused feature filter.

### DIFF
--- a/src/cargo/core/compiler/context/unit_dependencies.rs
+++ b/src/cargo/core/compiler/context/unit_dependencies.rs
@@ -162,12 +162,6 @@ fn compute_deps<'a, 'cfg, 'tmp>(
                 return false;
             }
 
-            // If the dependency is optional, then we're only activating it
-            // if the corresponding feature was activated
-            if dep.is_optional() && !bcx.resolve.features(id).contains(&*dep.name_in_toml()) {
-                return false;
-            }
-
             // If we've gotten past all that, then this dependency is
             // actually used!
             true


### PR DESCRIPTION
NOTE: Do not merge this lightly. This upended my understanding of how the resolver handles features, and I'm still not sure about it.

Remove an unused check that an optional dependency is activated.

This was originally added 4 years ago in #1812, during a time when this code iterated over the actual dependencies from `Package.dependencies()`. In #5415 this was refactored so that it gets the `deps` list directly from the Resolver, which AFAIK has already filtered out the features. IIUC, this filtering is done [here](https://github.com/rust-lang/cargo/blame/705009eb3828123cc9dbcf5b28988cc63f60b03b/src/cargo/core/resolver/dep_cache.rs#L270-L272).
