### PR TITLE
Add kind/platform info to `cargo metadata`

### DIFF
--- a/src/doc/man/cargo-metadata.adoc
+++ b/src/doc/man/cargo-metadata.adoc
@@ -201,6 +201,10 @@ The output has the following format:
     ],
     /* The resolved dependency graph, with the concrete versions and features
        selected. The set depends on the enabled features.
+
+       All platform-specific dependencies are listed regardless of the current
+       target.
+
        This is null if --no-deps is specified.
        By default, this includes all dependencies for all target platforms.
        The `--filter-platform` flag may be used to narrow to a specific
@@ -230,7 +234,20 @@ The output has the following format:
                         */
                         "name": "bitflags",
                         /* The Package ID of the dependency. */
-                        "pkg": "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+                        /* Array of dependency kinds. Added in Cargo 1.38. */
+                        "dep_kinds": [
+                            {
+                                /* The dependency kind.
+                                   "dev", "build", or null for a normal dependency.
+                                */
+                                "kind": null,
+                                /* The target platform for the dependency.
+                                   null if not a target dependency.
+                                */
+                                "target": "cfg(windows)"
+                            }
+                        ]
                     }
                 ],
                 /* Array of features enabled on this package. */

--- a/src/doc/man/cargo-metadata.adoc
+++ b/src/doc/man/cargo-metadata.adoc
@@ -235,7 +235,7 @@ The output has the following format:
                         "name": "bitflags",
                         /* The Package ID of the dependency. */
                         "pkg": "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
-                        /* Array of dependency kinds. Added in Cargo 1.38. */
+                        /* Array of dependency kinds. Added in Cargo 1.40. */
                         "dep_kinds": [
                             {
                                 /* The dependency kind.

--- a/src/doc/man/cargo-metadata.adoc
+++ b/src/doc/man/cargo-metadata.adoc
@@ -199,17 +199,14 @@ The output has the following format:
     "workspace_members": [
         "my-package 0.1.0 (path+file:///path/to/my-package)",
     ],
-    /* The resolved dependency graph, with the concrete versions and features
-       selected. The set depends on the enabled features.
-
-       All platform-specific dependencies are listed regardless of the current
-       target.
-
-       This is null if --no-deps is specified.
-       By default, this includes all dependencies for all target platforms.
-       The `--filter-platform` flag may be used to narrow to a specific
-       target triple.
-    */
+    // The resolved dependency graph, with the concrete versions and features
+    // selected. The set depends on the enabled features.
+    //
+    // This is null if --no-deps is specified.
+    //
+    // By default, this includes all dependencies for all target platforms.
+    // The `--filter-platform` flag may be used to narrow to a specific
+    // target triple.
     "resolve": {
         /* Array of nodes within the dependency graph.
            Each node is a package.

--- a/src/doc/man/generated/cargo-metadata.html
+++ b/src/doc/man/generated/cargo-metadata.html
@@ -242,7 +242,7 @@ for a Rust API for reading the metadata.</p>
                         "name": "bitflags",
                         /* The Package ID of the dependency. */
                         "pkg": "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
-                        /* Array of dependency kinds. Added in Cargo 1.38. */
+                        /* Array of dependency kinds. Added in Cargo 1.40. */
                         "dep_kinds": [
                             {
                                 /* The dependency kind.

--- a/src/doc/man/generated/cargo-metadata.html
+++ b/src/doc/man/generated/cargo-metadata.html
@@ -208,6 +208,10 @@ for a Rust API for reading the metadata.</p>
     ],
     /* The resolved dependency graph, with the concrete versions and features
        selected. The set depends on the enabled features.
+
+       All platform-specific dependencies are listed regardless of the current
+       target.
+
        This is null if --no-deps is specified.
        By default, this includes all dependencies for all target platforms.
        The `--filter-platform` flag may be used to narrow to a specific
@@ -237,7 +241,20 @@ for a Rust API for reading the metadata.</p>
                         */
                         "name": "bitflags",
                         /* The Package ID of the dependency. */
-                        "pkg": "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+                        /* Array of dependency kinds. Added in Cargo 1.38. */
+                        "dep_kinds": [
+                            {
+                                /* The dependency kind.
+                                   "dev", "build", or null for a normal dependency.
+                                */
+                                "kind": null,
+                                /* The target platform for the dependency.
+                                   null if not a target dependency.
+                                */
+                                "target": "cfg(windows)"
+                            }
+                        ]
                     }
                 ],
                 /* Array of features enabled on this package. */

--- a/src/doc/man/generated/cargo-metadata.html
+++ b/src/doc/man/generated/cargo-metadata.html
@@ -206,17 +206,14 @@ for a Rust API for reading the metadata.</p>
     "workspace_members": [
         "my-package 0.1.0 (path+file:///path/to/my-package)",
     ],
-    /* The resolved dependency graph, with the concrete versions and features
-       selected. The set depends on the enabled features.
-
-       All platform-specific dependencies are listed regardless of the current
-       target.
-
-       This is null if --no-deps is specified.
-       By default, this includes all dependencies for all target platforms.
-       The `--filter-platform` flag may be used to narrow to a specific
-       target triple.
-    */
+    // The resolved dependency graph, with the concrete versions and features
+    // selected. The set depends on the enabled features.
+    //
+    // This is null if --no-deps is specified.
+    //
+    // By default, this includes all dependencies for all target platforms.
+    // The `--filter-platform` flag may be used to narrow to a specific
+    // target triple.
     "resolve": {
         /* Array of nodes within the dependency graph.
            Each node is a package.

--- a/src/etc/man/cargo-metadata.1
+++ b/src/etc/man/cargo-metadata.1
@@ -222,6 +222,10 @@ The output has the following format:
     ],
     /* The resolved dependency graph, with the concrete versions and features
        selected. The set depends on the enabled features.
+
+       All platform\-specific dependencies are listed regardless of the current
+       target.
+
        This is null if \-\-no\-deps is specified.
        By default, this includes all dependencies for all target platforms.
        The `\-\-filter\-platform` flag may be used to narrow to a specific
@@ -251,7 +255,20 @@ The output has the following format:
                         */
                         "name": "bitflags",
                         /* The Package ID of the dependency. */
-                        "pkg": "bitflags 1.0.4 (registry+https://github.com/rust\-lang/crates.io\-index)"
+                        "pkg": "bitflags 1.0.4 (registry+https://github.com/rust\-lang/crates.io\-index)",
+                        /* Array of dependency kinds. Added in Cargo 1.38. */
+                        "dep_kinds": [
+                            {
+                                /* The dependency kind.
+                                   "dev", "build", or null for a normal dependency.
+                                */
+                                "kind": null,
+                                /* The target platform for the dependency.
+                                   null if not a target dependency.
+                                */
+                                "target": "cfg(windows)"
+                            }
+                        ]
                     }
                 ],
                 /* Array of features enabled on this package. */

--- a/src/etc/man/cargo-metadata.1
+++ b/src/etc/man/cargo-metadata.1
@@ -256,7 +256,7 @@ The output has the following format:
                         "name": "bitflags",
                         /* The Package ID of the dependency. */
                         "pkg": "bitflags 1.0.4 (registry+https://github.com/rust\-lang/crates.io\-index)",
-                        /* Array of dependency kinds. Added in Cargo 1.38. */
+                        /* Array of dependency kinds. Added in Cargo 1.40. */
                         "dep_kinds": [
                             {
                                 /* The dependency kind.

--- a/src/etc/man/cargo-metadata.1
+++ b/src/etc/man/cargo-metadata.1
@@ -220,17 +220,14 @@ The output has the following format:
     "workspace_members": [
         "my\-package 0.1.0 (path+file:///path/to/my\-package)",
     ],
-    /* The resolved dependency graph, with the concrete versions and features
-       selected. The set depends on the enabled features.
-
-       All platform\-specific dependencies are listed regardless of the current
-       target.
-
-       This is null if \-\-no\-deps is specified.
-       By default, this includes all dependencies for all target platforms.
-       The `\-\-filter\-platform` flag may be used to narrow to a specific
-       target triple.
-    */
+    // The resolved dependency graph, with the concrete versions and features
+    // selected. The set depends on the enabled features.
+    //
+    // This is null if \-\-no\-deps is specified.
+    //
+    // By default, this includes all dependencies for all target platforms.
+    // The `\-\-filter\-platform` flag may be used to narrow to a specific
+    // target triple.
     "resolve": {
         /* Array of nodes within the dependency graph.
            Each node is a package.

--- a/tests/testsuite/metadata.rs
+++ b/tests/testsuite/metadata.rs
@@ -486,10 +486,22 @@ fn cargo_metadata_with_deps_and_version() {
                     ],
                     "deps": [
                         {
+                            "dep_kinds": [
+                              {
+                                "kind": null,
+                                "target": null
+                              }
+                            ],
                             "name": "bar",
                             "pkg": "bar 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)"
                         },
                         {
+                            "dep_kinds": [
+                              {
+                                "kind": "dev",
+                                "target": null
+                              }
+                            ],
                             "name": "foobar",
                             "pkg": "foobar 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)"
                         }
@@ -503,6 +515,12 @@ fn cargo_metadata_with_deps_and_version() {
                     ],
                     "deps": [
                         {
+                            "dep_kinds": [
+                              {
+                                "kind": null,
+                                "target": null
+                              }
+                            ],
                             "name": "baz",
                             "pkg": "baz 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)"
                         }
@@ -1660,10 +1678,22 @@ fn rename_dependency() {
                 ],
                 "deps": [
                     {
+                        "dep_kinds": [
+                          {
+                            "kind": null,
+                            "target": null
+                          }
+                        ],
                         "name": "bar",
                         "pkg": "bar 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)"
                     },
                     {
+                        "dep_kinds": [
+                          {
+                            "kind": null,
+                            "target": null
+                          }
+                        ],
                         "name": "baz",
                         "pkg": "bar 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)"
                     }
@@ -2102,7 +2132,7 @@ fn filter_platform() {
           "optional": false,
           "uses_default_features": true,
           "features": [],
-          "target": "$ALT",
+          "target": "$ALT_TRIPLE",
           "registry": null
         },
         {
@@ -2114,7 +2144,7 @@ fn filter_platform() {
           "optional": false,
           "uses_default_features": true,
           "features": [],
-          "target": "$HOST",
+          "target": "$HOST_TRIPLE",
           "registry": null
         }
       ],
@@ -2145,8 +2175,8 @@ fn filter_platform() {
       "links": null
     }
     "#
-    .replace("$ALT", &alternate())
-    .replace("$HOST", &rustc_host());
+    .replace("$ALT_TRIPLE", &alternate())
+    .replace("$HOST_TRIPLE", &rustc_host());
 
     // Normal metadata, no filtering, returns *everything*.
     p.cargo("metadata")
@@ -2188,19 +2218,43 @@ fn filter_platform() {
         "deps": [
           {
             "name": "alt_dep",
-            "pkg": "alt-dep 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)"
+            "pkg": "alt-dep 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "dep_kinds": [
+              {
+                "kind": null,
+                "target": "$ALT_TRIPLE"
+              }
+            ]
           },
           {
             "name": "cfg_dep",
-            "pkg": "cfg-dep 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)"
+            "pkg": "cfg-dep 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "dep_kinds": [
+              {
+                "kind": null,
+                "target": "cfg(foobar)"
+              }
+            ]
           },
           {
             "name": "host_dep",
-            "pkg": "host-dep 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)"
+            "pkg": "host-dep 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "dep_kinds": [
+              {
+                "kind": null,
+                "target": "$HOST_TRIPLE"
+              }
+            ]
           },
           {
             "name": "normal_dep",
-            "pkg": "normal-dep 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)"
+            "pkg": "normal-dep 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "dep_kinds": [
+              {
+                "kind": null,
+                "target": null
+              }
+            ]
           }
         ],
         "features": []
@@ -2225,6 +2279,8 @@ fn filter_platform() {
   "workspace_root": "[..]/foo"
 }
 "#
+            .replace("$ALT_TRIPLE", &alternate())
+            .replace("$HOST_TRIPLE", &rustc_host())
             .replace("$ALT_DEP", alt_dep)
             .replace("$CFG_DEP", cfg_dep)
             .replace("$HOST_DEP", host_dep)
@@ -2262,11 +2318,23 @@ fn filter_platform() {
         "deps": [
           {
             "name": "alt_dep",
-            "pkg": "alt-dep 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)"
+            "pkg": "alt-dep 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "dep_kinds": [
+              {
+                "kind": null,
+                "target": "$ALT_TRIPLE"
+              }
+            ]
           },
           {
             "name": "normal_dep",
-            "pkg": "normal-dep 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)"
+            "pkg": "normal-dep 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "dep_kinds": [
+              {
+                "kind": null,
+                "target": null
+              }
+            ]
           }
         ],
         "features": []
@@ -2285,6 +2353,7 @@ fn filter_platform() {
   "workspace_root": "[..]foo"
 }
 "#
+            .replace("$ALT_TRIPLE", &alternate())
             .replace("$ALT_DEP", alt_dep)
             .replace("$NORMAL_DEP", normal_dep)
             .replace("$FOO", &foo),
@@ -2314,11 +2383,23 @@ fn filter_platform() {
         "deps": [
           {
             "name": "host_dep",
-            "pkg": "host-dep 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)"
+            "pkg": "host-dep 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "dep_kinds": [
+              {
+                "kind": null,
+                "target": "$HOST_TRIPLE"
+              }
+            ]
           },
           {
             "name": "normal_dep",
-            "pkg": "normal-dep 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)"
+            "pkg": "normal-dep 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "dep_kinds": [
+              {
+                "kind": null,
+                "target": null
+              }
+            ]
           }
         ],
         "features": []
@@ -2343,6 +2424,7 @@ fn filter_platform() {
   "workspace_root": "[..]foo"
 }
 "#
+            .replace("$HOST_TRIPLE", &rustc_host())
             .replace("$HOST_DEP", host_dep)
             .replace("$NORMAL_DEP", normal_dep)
             .replace("$FOO", &foo),
@@ -2381,15 +2463,33 @@ fn filter_platform() {
         "deps": [
           {
             "name": "cfg_dep",
-            "pkg": "cfg-dep 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)"
+            "pkg": "cfg-dep 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "dep_kinds": [
+              {
+                "kind": null,
+                "target": "cfg(foobar)"
+              }
+            ]
           },
           {
             "name": "host_dep",
-            "pkg": "host-dep 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)"
+            "pkg": "host-dep 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "dep_kinds": [
+              {
+                "kind": null,
+                "target": "$HOST_TRIPLE"
+              }
+            ]
           },
           {
             "name": "normal_dep",
-            "pkg": "normal-dep 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)"
+            "pkg": "normal-dep 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "dep_kinds": [
+              {
+                "kind": null,
+                "target": null
+              }
+            ]
           }
         ],
         "features": []
@@ -2414,10 +2514,110 @@ fn filter_platform() {
   "workspace_root": "[..]/foo"
 }
 "#
+            .replace("$HOST_TRIPLE", &rustc_host())
             .replace("$CFG_DEP", cfg_dep)
             .replace("$HOST_DEP", host_dep)
             .replace("$NORMAL_DEP", normal_dep)
             .replace("$FOO", &foo),
+        )
+        .run();
+}
+
+#[cargo_test]
+fn dep_kinds() {
+    Package::new("bar", "0.1.0").publish();
+    Package::new("winapi", "0.1.0").publish();
+
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "foo"
+            version = "0.1.0"
+
+            [dependencies]
+            bar = "0.1"
+
+            [dev-dependencies]
+            bar = "0.1"
+
+            [build-dependencies]
+            bar = "0.1"
+
+            [target.'cfg(windows)'.dependencies]
+            winapi = "0.1"
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    p.cargo("metadata")
+        .with_json(
+            r#"
+{
+  "packages": "{...}",
+  "workspace_members": "{...}",
+  "target_directory": "{...}",
+  "version": 1,
+  "workspace_root": "{...}",
+  "resolve": {
+    "nodes": [
+      {
+        "id": "bar 0.1.0 [..]",
+        "dependencies": [],
+        "deps": [],
+        "features": []
+      },
+      {
+        "id": "foo 0.1.0 [..]",
+        "dependencies": [
+          "bar 0.1.0 [..]",
+          "winapi 0.1.0 [..]"
+        ],
+        "deps": [
+          {
+            "name": "bar",
+            "pkg": "bar 0.1.0 [..]",
+            "dep_kinds": [
+              {
+                "kind": null,
+                "target": null
+              },
+              {
+                "kind": "dev",
+                "target": null
+              },
+              {
+                "kind": "build",
+                "target": null
+              }
+            ]
+          },
+          {
+            "name": "winapi",
+            "pkg": "winapi 0.1.0 [..]",
+            "dep_kinds": [
+              {
+                "kind": null,
+                "target": "cfg(windows)"
+              }
+            ]
+          }
+        ],
+        "features": []
+      },
+      {
+        "id": "winapi 0.1.0 [..]",
+        "dependencies": [],
+        "deps": [],
+        "features": []
+      }
+    ],
+    "root": "foo 0.1.0 [..]"
+  }
+}
+"#,
         )
         .run();
 }

--- a/tests/testsuite/update.rs
+++ b/tests/testsuite/update.rs
@@ -525,6 +525,12 @@ fn update_precise_first_run() {
         ],
         "deps": [
           {
+            "dep_kinds": [
+              {
+                "kind": null,
+                "target": null
+              }
+            ],
             "name": "serde",
             "pkg": "serde 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)"
           }


### PR DESCRIPTION
This adds an array `"dep_kinds"` to the resolve nodes of the `cargo metadata` output. It looks something like this:

```javascript
"resolve": {
  "nodes": [
    "id": "cargo 0.39.0 (path+file:///Users/eric/Proj/rust/cargo2)",
    "deps": [
      {
        "name": "bufstream",
        "pkg": "bufstream 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
        "dep_kinds": [
          {
            "kind": "dev",
            "target": null
          }
        ]
      },
      {
        "name": "winapi",
        "pkg": "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
        "dep_kinds": [
          {
            "kind": null,
            "target": "cfg(windows)"
          }
        ]
      }
    ]
  ]
}
```

This allows one to filter the graph based on the dependency kind and platform.

I'm not completely confident that this is the right course, but I can't think of a better design. In particular, it seems a little strange to include all platforms, but features get filtered. This is probably not a problem in practice (one can use `--all-features` to ensure all features are shown for the top-level packages). Filtering out based on platform is very difficult, because you cannot determine from the resolve alone which nodes will be host vs target. That requires the entire Unit graph. We may expose the Unit graph in the future, but this seems like a useful and simple step.

This is a draft because I wanted to discuss this before moving forward. I'd like to add some more tests.

cc #4632. This doesn't filter based on target, but does expose the target names. As mentioned above, I don't think filtering is possible.
cc #5583. This adds more information.
Closes #3984.
Closes #4631 (I think).

cc @sfackler who filed some of these issues.
