### PR TITLE
Also ignore remap-path-prefix in metadata for `cargo rustc`.

### DIFF
--- a/src/cargo/core/compiler/context/compilation_files.rs
+++ b/src/cargo/core/compiler/context/compilation_files.rs
@@ -547,32 +547,36 @@ fn compute_metadata<'a, 'cfg>(
     // settings like debuginfo and whatnot.
     unit.profile.hash(&mut hasher);
     unit.mode.hash(&mut hasher);
-    if let Some(args) = bcx.extra_args_for(unit) {
-        args.hash(&mut hasher);
-    }
 
     // Throw in the rustflags we're compiling with.
     // This helps when the target directory is a shared cache for projects with different cargo configs,
     // or if the user is experimenting with different rustflags manually.
-    let mut flags = if unit.mode.is_doc() {
-        cx.bcx.rustdocflags_args(unit)
+    let mut hash_flags = |flags: &[String]| {
+        // Ignore some flags. These may affect reproducible builds if they affect
+        // the path. The fingerprint will handle recompilation if these change.
+        let mut iter = flags.iter();
+        while let Some(flag) = iter.next() {
+            if flag.starts_with("--remap-path-prefix=") {
+                continue;
+            }
+            if flag == "--remap-path-prefix" {
+                iter.next();
+                continue;
+            }
+            flag.hash(&mut hasher);
+        }
+    };
+    if let Some(args) = bcx.extra_args_for(unit) {
+        // Arguments passed to `cargo rustc`.
+        hash_flags(args);
+    }
+    // Arguments passed in via RUSTFLAGS env var.
+    let flags = if unit.mode.is_doc() {
+        bcx.rustdocflags_args(unit)
     } else {
-        cx.bcx.rustflags_args(unit)
-    }
-    .iter();
-
-    // Ignore some flags. These may affect reproducible builds if they affect
-    // the path. The fingerprint will handle recompilation if these change.
-    while let Some(flag) = flags.next() {
-        if flag.starts_with("--remap-path-prefix=") {
-            continue;
-        }
-        if flag == "--remap-path-prefix" {
-            flags.next();
-            continue;
-        }
-        flag.hash(&mut hasher);
-    }
+        bcx.rustflags_args(unit)
+    };
+    hash_flags(flags);
 
     // Artifacts compiled for the host should have a different metadata
     // piece than those compiled for the target, so make sure we throw in


### PR DESCRIPTION
Also ignore `--remap-path-prefix` in `cargo rustc`.  Who knew that `BuildContext` had 3 sets of arguments?

Closes #7133