### PR TITLE
Fix some issues with absolute paths in dep-info files.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ memchr = "2.1.3"
 num_cpus = "1.0"
 opener = "0.4"
 percent-encoding = "2.0"
+remove_dir_all = "0.5.2"
 rustfix = "0.4.4"
 same-file = "1"
 semver = { version = "0.9.0", features = ["serde"] }

--- a/crates/resolver-tests/tests/resolve.rs
+++ b/crates/resolver-tests/tests/resolve.rs
@@ -2,7 +2,7 @@ use std::env;
 
 use cargo::core::dependency::Kind;
 use cargo::core::{enable_nightly_features, Dependency};
-use cargo::util::Config;
+use cargo::util::{is_ci, Config};
 
 use resolver_tests::{
     assert_contains, assert_same, dep, dep_kind, dep_loc, dep_req, dep_req_kind, loc_names, names,
@@ -22,7 +22,7 @@ use proptest::prelude::*;
 proptest! {
     #![proptest_config(ProptestConfig {
         max_shrink_iters:
-            if env::var("CI").is_ok() || !atty::is(atty::Stream::Stderr) {
+            if is_ci() || !atty::is(atty::Stream::Stderr) {
                 // This attempts to make sure that CI will fail fast,
                 0
             } else {

--- a/src/cargo/core/compiler/context/mod.rs
+++ b/src/cargo/core/compiler/context/mod.rs
@@ -5,6 +5,7 @@ use std::fmt::Write;
 use std::path::PathBuf;
 use std::sync::Arc;
 
+use filetime::FileTime;
 use jobserver::Client;
 
 use crate::core::compiler::compilation;
@@ -34,6 +35,7 @@ pub struct Context<'a, 'cfg> {
     pub build_script_overridden: HashSet<(PackageId, Kind)>,
     pub build_explicit_deps: HashMap<Unit<'a>, BuildDeps>,
     pub fingerprints: HashMap<Unit<'a>, Arc<Fingerprint>>,
+    pub mtime_cache: HashMap<PathBuf, FileTime>,
     pub compiled: HashSet<Unit<'a>>,
     pub build_scripts: HashMap<Unit<'a>, Arc<BuildScripts>>,
     pub links: Links,
@@ -82,6 +84,7 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
             compilation: Compilation::new(bcx)?,
             build_state: Arc::new(BuildState::new(&bcx.host_config, &bcx.target_config)),
             fingerprints: HashMap::new(),
+            mtime_cache: HashMap::new(),
             compiled: HashSet::new(),
             build_scripts: HashMap::new(),
             build_explicit_deps: HashMap::new(),

--- a/src/cargo/core/compiler/fingerprint.rs
+++ b/src/cargo/core/compiler/fingerprint.rs
@@ -1571,7 +1571,13 @@ pub fn translate_dep_info(
 
     let mut new_contents = Vec::new();
     for file in deps {
-        let file = rustc_cwd.join(file);
+        let file = if cfg!(windows) && file.starts_with("\\\\?\\") {
+            // Remove Windows extended-length prefix, since functions like
+            // strip_prefix won't work if you mix with traditional dos paths.
+            PathBuf::from(&file[4..])
+        } else {
+            rustc_cwd.join(file)
+        };
         let (ty, path) = if let Ok(stripped) = file.strip_prefix(target_root) {
             (DepInfoPathType::TargetRootRelative, stripped)
         } else if let Ok(stripped) = file.strip_prefix(pkg_root) {

--- a/src/cargo/core/compiler/fingerprint.rs
+++ b/src/cargo/core/compiler/fingerprint.rs
@@ -1550,8 +1550,11 @@ impl DepInfoPathType {
 /// The `rustc_cwd` argument is the absolute path to the cwd of the compiler
 /// when it was invoked.
 ///
-/// If the `allow_package` argument is false, then package-relative paths are
-/// skipped and ignored.
+/// If the `allow_package` argument is true, then package-relative paths are
+/// included. If it is false, then package-relative paths are skipped and
+/// ignored (typically used for registry or git dependencies where we assume
+/// the source never changes, and we don't want the cost of running `stat` on
+/// all those files).
 ///
 /// The serialized Cargo format will contain a list of files, all of which are
 /// relative if they're under `root`. or absolute if they're elsewhere.

--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -214,6 +214,9 @@ fn rustc<'a, 'cfg>(
     let dep_info_loc = fingerprint::dep_info_loc(cx, unit);
 
     rustc.args(cx.bcx.rustflags_args(unit));
+    if cx.bcx.config.cli_unstable().binary_dep_depinfo {
+        rustc.arg("-Zbinary-dep-depinfo");
+    }
     let mut output_options = OutputOptions::new(cx, unit);
     let package_id = unit.pkg.package_id();
     let target = unit.target.clone();

--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -319,6 +319,8 @@ fn rustc<'a, 'cfg>(
                 &cwd,
                 &pkg_root,
                 &target_dir,
+                // Do not track source files in the fingerprint for registry dependencies.
+                current_id.source_id().is_path(),
             )
             .chain_err(|| {
                 internal(format!(

--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -223,6 +223,7 @@ fn rustc<'a, 'cfg>(
     let exec = exec.clone();
 
     let root_output = cx.files().host_root().to_path_buf();
+    let target_dir = cx.bcx.ws.target_dir().into_path_unlocked();
     let pkg_root = unit.pkg.root().to_path_buf();
     let cwd = rustc
         .get_cwd()
@@ -317,7 +318,7 @@ fn rustc<'a, 'cfg>(
                 &dep_info_loc,
                 &cwd,
                 &pkg_root,
-                &root_output,
+                &target_dir,
             )
             .chain_err(|| {
                 internal(format!(

--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -333,6 +333,7 @@ pub struct CliUnstable {
     pub mtime_on_use: bool,
     pub install_upgrade: bool,
     pub cache_messages: bool,
+    pub binary_dep_depinfo: bool,
 }
 
 impl CliUnstable {
@@ -378,6 +379,7 @@ impl CliUnstable {
             "mtime-on-use" => self.mtime_on_use = true,
             "install-upgrade" => self.install_upgrade = true,
             "cache-messages" => self.cache_messages = true,
+            "binary-dep-depinfo" => self.binary_dep_depinfo = true,
             _ => failure::bail!("unknown `-Z` flag specified: {}", k),
         }
 

--- a/src/cargo/util/mod.rs
+++ b/src/cargo/util/mod.rs
@@ -82,3 +82,8 @@ pub fn validate_package_name(name: &str, what: &str, help: &str) -> CargoResult<
     }
     Ok(())
 }
+
+/// Whether or not this running in a Continuous Integration environment.
+pub fn is_ci() -> bool {
+    std::env::var("CI").is_ok() || std::env::var("TF_BUILD").is_ok()
+}

--- a/src/cargo/util/progress.rs
+++ b/src/cargo/util/progress.rs
@@ -3,7 +3,7 @@ use std::env;
 use std::time::{Duration, Instant};
 
 use crate::core::shell::Verbosity;
-use crate::util::{CargoResult, Config};
+use crate::util::{is_ci, CargoResult, Config};
 
 use unicode_width::UnicodeWidthChar;
 
@@ -45,7 +45,7 @@ impl<'cfg> Progress<'cfg> {
             Ok(term) => term == "dumb",
             Err(_) => false,
         };
-        if cfg.shell().verbosity() == Verbosity::Quiet || dumb || env::var("CI").is_ok() {
+        if cfg.shell().verbosity() == Verbosity::Quiet || dumb || is_ci() {
             return Progress { state: None };
         }
 

--- a/tests/testsuite/support/mod.rs
+++ b/tests/testsuite/support/mod.rs
@@ -332,15 +332,9 @@ impl Project {
     /// `kind` should be one of: "lib", "rlib", "staticlib", "dylib", "proc-macro"
     /// ex: `/path/to/cargo/target/cit/t0/foo/target/debug/examples/libex.rlib`
     pub fn example_lib(&self, name: &str, kind: &str) -> PathBuf {
-        let prefix = Project::get_lib_prefix(kind);
-
-        let extension = Project::get_lib_extension(kind);
-
-        let lib_file_name = format!("{}{}.{}", prefix, name, extension);
-
         self.target_debug_dir()
             .join("examples")
-            .join(&lib_file_name)
+            .join(paths::get_lib_filename(name, kind))
     }
 
     /// Path to a debug binary.
@@ -453,43 +447,6 @@ impl Project {
             .unwrap()
             .write_all(contents.replace("#", "").as_bytes())
             .unwrap();
-    }
-
-    fn get_lib_prefix(kind: &str) -> &str {
-        match kind {
-            "lib" | "rlib" => "lib",
-            "staticlib" | "dylib" | "proc-macro" => {
-                if cfg!(windows) {
-                    ""
-                } else {
-                    "lib"
-                }
-            }
-            _ => unreachable!(),
-        }
-    }
-
-    fn get_lib_extension(kind: &str) -> &str {
-        match kind {
-            "lib" | "rlib" => "rlib",
-            "staticlib" => {
-                if cfg!(windows) {
-                    "lib"
-                } else {
-                    "a"
-                }
-            }
-            "dylib" | "proc-macro" => {
-                if cfg!(windows) {
-                    "dll"
-                } else if cfg!(target_os = "macos") {
-                    "dylib"
-                } else {
-                    "so"
-                }
-            }
-            _ => unreachable!(),
-        }
     }
 }
 

--- a/tests/testsuite/support/paths.rs
+++ b/tests/testsuite/support/paths.rs
@@ -213,3 +213,54 @@ where
         }
     }
 }
+
+/// Get the filename for a library.
+///
+/// `kind` should be one of: "lib", "rlib", "staticlib", "dylib", "proc-macro"
+///
+/// For example, dynamic library named "foo" would return:
+/// - macOS: "libfoo.dylib"
+/// - Windows: "foo.dll"
+/// - Unix: "libfoo.so"
+pub fn get_lib_filename(name: &str, kind: &str) -> String {
+    let prefix = get_lib_prefix(kind);
+    let extension = get_lib_extension(kind);
+    format!("{}{}.{}", prefix, name, extension)
+}
+
+pub fn get_lib_prefix(kind: &str) -> &str {
+    match kind {
+        "lib" | "rlib" => "lib",
+        "staticlib" | "dylib" | "proc-macro" => {
+            if cfg!(windows) {
+                ""
+            } else {
+                "lib"
+            }
+        }
+        _ => unreachable!(),
+    }
+}
+
+pub fn get_lib_extension(kind: &str) -> &str {
+    match kind {
+        "lib" | "rlib" => "rlib",
+        "staticlib" => {
+            if cfg!(windows) {
+                "lib"
+            } else {
+                "a"
+            }
+        }
+        "dylib" | "proc-macro" => {
+            if cfg!(windows) {
+                "dll"
+            } else if cfg!(target_os = "macos") {
+                "dylib"
+            } else {
+                "so"
+            }
+        }
+        _ => unreachable!(),
+    }
+}

--- a/tests/testsuite/support/paths.rs
+++ b/tests/testsuite/support/paths.rs
@@ -113,22 +113,11 @@ impl CargoPathExt for Path {
      * care all that much for our tests
      */
     fn rm_rf(&self) {
-        if !self.exists() {
-            return;
-        }
-
-        for file in t!(fs::read_dir(self)) {
-            let file = t!(file);
-            if file.file_type().map(|m| m.is_dir()).unwrap_or(false) {
-                file.path().rm_rf();
-            } else {
-                // On windows we can't remove a readonly file, and git will
-                // often clone files as readonly. As a result, we have some
-                // special logic to remove readonly files on windows.
-                do_op(&file.path(), "remove file", |p| fs::remove_file(p));
+        if self.exists() {
+            if let Err(e) = remove_dir_all::remove_dir_all(self) {
+                panic!("failed to remove {:?}: {:?}", self, e)
             }
         }
-        do_op(self, "remove dir", |p| fs::remove_dir(p));
     }
 
     fn mkdir_p(&self) {


### PR DESCRIPTION
There were some issues with how #7030 was handling translating paths in dep-info files. The main consequence is that when coupled with https://github.com/rust-lang/rust/pull/61727 (which has not yet merged), the fingerprint would fail and be considered dirty when it should be fresh.

It was joining [`target_root`](https://github.com/rust-lang/cargo/blame/1140c527c4c3b3e2533b9771d67f88509ef7fc16/src/cargo/core/compiler/fingerprint.rs#L1352-L1360) which had 3 different values, but stripping [only one](https://github.com/rust-lang/cargo/blame/1140c527c4c3b3e2533b9771d67f88509ef7fc16/src/cargo/core/compiler/mod.rs#L323). This means for different scenarios (like using `--target`), it was creating incorrect paths in some cases. For example a target having a proc-macro dependency which would be in the host directory.

The solution here is to always use CARGO_TARGET_DIR as the base that all relative paths are checked against. This should handle all host/target differences.

The tests are marked with `#[ignore]` because 61727 has not yet merged.

This includes a second commit (which I can open as a separate PR if needed) which is an alternate solution to #7034. It adds dep-info tracking for registry dependencies. However, it tries to limit which kinds of paths it tracks. It will not track package-relative paths (like source files). It also adds an mtime cache to significantly reduce the number of stat calls (because every dependency was stating every file in sysroot).

Finally, I've run some tests using this PR with 61727 in rust-lang/rust. I can confirm that a second build is fresh (it doesn't erroneously rebuild). I can also confirm that the problem in https://github.com/rust-lang/rust/issues/59105 has *finally* been fixed!

My confidence in all this is pretty low, but I've been unable to think of any specific ways to make it fail. If anyone has ideas on how to better test this, let me know. Also, feel free to ask questions since I've been thinking about this a lot for the past few weeks, and there is quite a bit of subtle stuff going on.
