### PR TITLE
Update mdbook to 0.3.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ matrix:
            ALT=i686-unknown-linux-gnu
       rust: nightly
       install:
-        - travis_retry curl -Lf https://github.com/rust-lang-nursery/mdBook/releases/download/v0.1.7/mdbook-v0.1.7-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=$HOME/.cargo/bin
+        - travis_retry curl -Lf https://github.com/rust-lang-nursery/mdBook/releases/download/v0.3.1/mdbook-v0.3.1-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=$HOME/.cargo/bin
       script:
         - cargo test --features=deny-warnings || travis_terminate 1
         - cargo doc --no-deps || travis_terminate 1

--- a/src/doc/README.md
+++ b/src/doc/README.md
@@ -5,7 +5,7 @@
 
 Building the book requires [mdBook]. To get it:
 
-[mdBook]: https://github.com/azerupi/mdBook
+[mdBook]: https://github.com/rust-lang-nursery/mdBook
 
 ```console
 $ cargo install mdbook

--- a/src/doc/asciidoc-extension.rb
+++ b/src/doc/asciidoc-extension.rb
@@ -29,9 +29,9 @@ class ManInlineMacro < Extensions::InlineMacroProcessor
       elsif manname == 'rustdoc'
         html_target = 'https://doc.rust-lang.org/rustdoc/index.html'
       elsif manname == 'cargo'
-        html_target = 'commands/index.html'
+        html_target = 'index.html'
       else
-        html_target = %(commands/#{manname}.html)
+        html_target = %(#{manname}.html)
       end
       %(#{(create_anchor parent, text, type: :link, target: html_target).render})
     elsif parent.document.backend == 'manpage'
@@ -44,8 +44,8 @@ end
 
 # Creates a link to something in the cargo documentation.
 #
-# For HTML this creates a relative link (using mdbook's 0.1's base-style
-# links). For the man page it gives a direct link to doc.rust-lang.org.
+# For HTML this creates a relative link. For the man page it gives a direct
+# link to doc.rust-lang.org.
 #
 # Usage
 #
@@ -60,6 +60,7 @@ class LinkCargoInlineMacro < Extensions::InlineMacroProcessor
   def process parent, target, attrs
     text = attrs['text']
     if parent.document.basebackend? 'html'
+      target = %(../#{target})
       parent.document.register :links, target
       %(#{(create_anchor parent, text, type: :link, target: target).render})
     elsif parent.document.backend == 'manpage'

--- a/src/doc/book.toml
+++ b/src/doc/book.toml
@@ -1,2 +1,6 @@
+[book]
 title = "The Cargo Book"
 author = "Alex Crichton, Steve Klabnik and Carol Nichols, with Contributions from the Rust Community"
+
+[output.html]
+git-repository-url = "https://github.com/rust-lang/cargo/tree/master/src/doc/src"

--- a/src/doc/man/generated/cargo-bench.html
+++ b/src/doc/man/generated/cargo-bench.html
@@ -80,7 +80,7 @@ manifest.</p>
 <dt class="hdlist1"><strong>-p</strong> <em>SPEC</em>&#8230;&#8203;</dt>
 <dt class="hdlist1"><strong>--package</strong> <em>SPEC</em>&#8230;&#8203;</dt>
 <dd>
-<p>Benchmark only the specified packages. See <a href="commands/cargo-pkgid.html">cargo-pkgid(1)</a> for the
+<p>Benchmark only the specified packages. See <a href="cargo-pkgid.html">cargo-pkgid(1)</a> for the
 SPEC format. This flag may be specified multiple times.</p>
 </dd>
 <dt class="hdlist1"><strong>--all</strong></dt>
@@ -230,7 +230,7 @@ architecture. The general format of the triple is
 list of supported targets.</p>
 <div class="paragraph">
 <p>This may also be specified with the <code>build.target</code>
-<a href="reference/config.html">config value</a>.</p>
+<a href="../reference/config.html">config value</a>.</p>
 </div>
 </dd>
 </dl>
@@ -244,7 +244,7 @@ list of supported targets.</p>
 <dd>
 <p>Directory for all generated artifacts and intermediate files. May also be
 specified with the <code>CARGO_TARGET_DIR</code> environment variable, or the
-<code>build.target-dir</code> <a href="reference/config.html">config value</a>. Defaults
+<code>build.target-dir</code> <a href="../reference/config.html">config value</a>. Defaults
 to <code>target</code> in the root of the workspace.</p>
 </dd>
 </dl>
@@ -270,7 +270,7 @@ passing <code>--nocapture</code> to the benchmark binaries:</p>
 <p>Use verbose output. May be specified twice for "very verbose" output which
 includes extra output such as dependency warnings and build script output.
 May also be specified with the <code>term.verbose</code>
-<a href="reference/config.html">config value</a>.</p>
+<a href="../reference/config.html">config value</a>.</p>
 </dd>
 <dt class="hdlist1"><strong>-q</strong></dt>
 <dt class="hdlist1"><strong>--quiet</strong></dt>
@@ -296,7 +296,7 @@ terminal.</p>
 </div>
 <div class="paragraph">
 <p>May also be specified with the <code>term.color</code>
-<a href="reference/config.html">config value</a>.</p>
+<a href="../reference/config.html">config value</a>.</p>
 </div>
 </dd>
 <dt class="hdlist1"><strong>--message-format</strong> <em>FMT</em></dt>
@@ -351,11 +351,11 @@ proceed without the network if possible.</p>
 <p>Beware that this may result in different dependency resolution than online
 mode. Cargo will restrict itself to crates that are downloaded locally, even
 if there might be a newer version as indicated in the local copy of the index.
-See the <a href="commands/cargo-fetch.html">cargo-fetch(1)</a> command to download dependencies before going
+See the <a href="cargo-fetch.html">cargo-fetch(1)</a> command to download dependencies before going
 offline.</p>
 </div>
 <div class="paragraph">
-<p>May also be specified with the <code>net.offline</code> <a href="reference/config.html">config value</a>.</p>
+<p>May also be specified with the <code>net.offline</code> <a href="../reference/config.html">config value</a>.</p>
 </div>
 </dd>
 </dl>
@@ -391,7 +391,7 @@ Rust test harness runs benchmarks serially in a single thread.</p>
 <dt class="hdlist1"><strong>--jobs</strong> <em>N</em></dt>
 <dd>
 <p>Number of parallel jobs to run. May also be specified with the
-<code>build.jobs</code> <a href="reference/config.html">config value</a>. Defaults to
+<code>build.jobs</code> <a href="../reference/config.html">config value</a>. Defaults to
 the number of CPUs.</p>
 </dd>
 </dl>
@@ -405,7 +405,7 @@ the number of CPUs.</p>
 <div class="paragraph">
 <p>Profiles may be used to configure compiler options such as optimization levels
 and debug settings. See
-<a href="reference/manifest.html#the-profile-sections">the reference</a>
+<a href="../reference/manifest.html#the-profile-sections">the reference</a>
 for more details.</p>
 </div>
 <div class="paragraph">
@@ -416,7 +416,7 @@ Dependencies use the <code>release</code> profile.</p>
 </div>
 <div class="paragraph">
 <p>If you need a debug build of a benchmark, try building it with
-<a href="commands/cargo-build.html">cargo-build(1)</a> which will use the <code>test</code> profile which is by default
+<a href="cargo-build.html">cargo-build(1)</a> which will use the <code>test</code> profile which is by default
 unoptimized and includes debug information. You can then run the debug-enabled
 benchmark manually.</p>
 </div>
@@ -426,7 +426,7 @@ benchmark manually.</p>
 <h2 id="cargo_bench_environment">ENVIRONMENT</h2>
 <div class="sectionbody">
 <div class="paragraph">
-<p>See <a href="reference/environment-variables.html">the reference</a> for
+<p>See <a href="../reference/environment-variables.html">the reference</a> for
 details on environment variables that Cargo reads.</p>
 </div>
 </div>
@@ -477,7 +477,7 @@ details on environment variables that Cargo reads.</p>
 <h2 id="cargo_bench_see_also">SEE ALSO</h2>
 <div class="sectionbody">
 <div class="paragraph">
-<p><a href="commands/index.html">cargo(1)</a>, <a href="commands/cargo-test.html">cargo-test(1)</a></p>
+<p><a href="index.html">cargo(1)</a>, <a href="cargo-test.html">cargo-test(1)</a></p>
 </div>
 </div>
 </div>

--- a/src/doc/man/generated/cargo-build.html
+++ b/src/doc/man/generated/cargo-build.html
@@ -36,7 +36,7 @@ manifest.</p>
 <dt class="hdlist1"><strong>-p</strong> <em>SPEC</em>&#8230;&#8203;</dt>
 <dt class="hdlist1"><strong>--package</strong> <em>SPEC</em>&#8230;&#8203;</dt>
 <dd>
-<p>Build only the specified packages. See <a href="commands/cargo-pkgid.html">cargo-pkgid(1)</a> for the
+<p>Build only the specified packages. See <a href="cargo-pkgid.html">cargo-pkgid(1)</a> for the
 SPEC format. This flag may be specified multiple times.</p>
 </dd>
 <dt class="hdlist1"><strong>--all</strong></dt>
@@ -159,7 +159,7 @@ architecture. The general format of the triple is
 list of supported targets.</p>
 <div class="paragraph">
 <p>This may also be specified with the <code>build.target</code>
-<a href="reference/config.html">config value</a>.</p>
+<a href="../reference/config.html">config value</a>.</p>
 </div>
 </dd>
 <dt class="hdlist1"><strong>--release</strong></dt>
@@ -178,7 +178,7 @@ list of supported targets.</p>
 <dd>
 <p>Directory for all generated artifacts and intermediate files. May also be
 specified with the <code>CARGO_TARGET_DIR</code> environment variable, or the
-<code>build.target-dir</code> <a href="reference/config.html">config value</a>. Defaults
+<code>build.target-dir</code> <a href="../reference/config.html">config value</a>. Defaults
 to <code>target</code> in the root of the workspace.</p>
 </dd>
 <dt class="hdlist1"><strong>--out-dir</strong> <em>DIRECTORY</em></dt>
@@ -204,7 +204,7 @@ See <a href="https://github.com/rust-lang/cargo/issues/6790" class="bare">https:
 <p>Use verbose output. May be specified twice for "very verbose" output which
 includes extra output such as dependency warnings and build script output.
 May also be specified with the <code>term.verbose</code>
-<a href="reference/config.html">config value</a>.</p>
+<a href="../reference/config.html">config value</a>.</p>
 </dd>
 <dt class="hdlist1"><strong>-q</strong></dt>
 <dt class="hdlist1"><strong>--quiet</strong></dt>
@@ -230,7 +230,7 @@ terminal.</p>
 </div>
 <div class="paragraph">
 <p>May also be specified with the <code>term.color</code>
-<a href="reference/config.html">config value</a>.</p>
+<a href="../reference/config.html">config value</a>.</p>
 </div>
 </dd>
 <dt class="hdlist1"><strong>--message-format</strong> <em>FMT</em></dt>
@@ -296,11 +296,11 @@ proceed without the network if possible.</p>
 <p>Beware that this may result in different dependency resolution than online
 mode. Cargo will restrict itself to crates that are downloaded locally, even
 if there might be a newer version as indicated in the local copy of the index.
-See the <a href="commands/cargo-fetch.html">cargo-fetch(1)</a> command to download dependencies before going
+See the <a href="cargo-fetch.html">cargo-fetch(1)</a> command to download dependencies before going
 offline.</p>
 </div>
 <div class="paragraph">
-<p>May also be specified with the <code>net.offline</code> <a href="reference/config.html">config value</a>.</p>
+<p>May also be specified with the <code>net.offline</code> <a href="../reference/config.html">config value</a>.</p>
 </div>
 </dd>
 </dl>
@@ -331,7 +331,7 @@ details.</p>
 <dt class="hdlist1"><strong>--jobs</strong> <em>N</em></dt>
 <dd>
 <p>Number of parallel jobs to run. May also be specified with the
-<code>build.jobs</code> <a href="reference/config.html">config value</a>. Defaults to
+<code>build.jobs</code> <a href="../reference/config.html">config value</a>. Defaults to
 the number of CPUs.</p>
 </dd>
 </dl>
@@ -345,7 +345,7 @@ the number of CPUs.</p>
 <div class="paragraph">
 <p>Profiles may be used to configure compiler options such as optimization levels
 and debug settings. See
-<a href="reference/manifest.html#the-profile-sections">the reference</a>
+<a href="../reference/manifest.html#the-profile-sections">the reference</a>
 for more details.</p>
 </div>
 <div class="paragraph">
@@ -389,7 +389,7 @@ for more details.</p>
 <h2 id="cargo_build_environment">ENVIRONMENT</h2>
 <div class="sectionbody">
 <div class="paragraph">
-<p>See <a href="reference/environment-variables.html">the reference</a> for
+<p>See <a href="../reference/environment-variables.html">the reference</a> for
 details on environment variables that Cargo reads.</p>
 </div>
 </div>
@@ -440,7 +440,7 @@ details on environment variables that Cargo reads.</p>
 <h2 id="cargo_build_see_also">SEE ALSO</h2>
 <div class="sectionbody">
 <div class="paragraph">
-<p><a href="commands/index.html">cargo(1)</a>, <a href="commands/cargo-rustc.html">cargo-rustc(1)</a></p>
+<p><a href="index.html">cargo(1)</a>, <a href="cargo-rustc.html">cargo-rustc(1)</a></p>
 </div>
 </div>
 </div>

--- a/src/doc/man/generated/cargo-check.html
+++ b/src/doc/man/generated/cargo-check.html
@@ -40,7 +40,7 @@ manifest.</p>
 <dt class="hdlist1"><strong>-p</strong> <em>SPEC</em>&#8230;&#8203;</dt>
 <dt class="hdlist1"><strong>--package</strong> <em>SPEC</em>&#8230;&#8203;</dt>
 <dd>
-<p>Check only the specified packages. See <a href="commands/cargo-pkgid.html">cargo-pkgid(1)</a> for the
+<p>Check only the specified packages. See <a href="cargo-pkgid.html">cargo-pkgid(1)</a> for the
 SPEC format. This flag may be specified multiple times.</p>
 </dd>
 <dt class="hdlist1"><strong>--all</strong></dt>
@@ -163,7 +163,7 @@ architecture. The general format of the triple is
 list of supported targets.</p>
 <div class="paragraph">
 <p>This may also be specified with the <code>build.target</code>
-<a href="reference/config.html">config value</a>.</p>
+<a href="../reference/config.html">config value</a>.</p>
 </div>
 </dd>
 <dt class="hdlist1"><strong>--release</strong></dt>
@@ -190,7 +190,7 @@ the <code>cfg</code> attribute. This does not change the actual profile used.</p
 <dd>
 <p>Directory for all generated artifacts and intermediate files. May also be
 specified with the <code>CARGO_TARGET_DIR</code> environment variable, or the
-<code>build.target-dir</code> <a href="reference/config.html">config value</a>. Defaults
+<code>build.target-dir</code> <a href="../reference/config.html">config value</a>. Defaults
 to <code>target</code> in the root of the workspace.</p>
 </dd>
 </dl>
@@ -206,7 +206,7 @@ to <code>target</code> in the root of the workspace.</p>
 <p>Use verbose output. May be specified twice for "very verbose" output which
 includes extra output such as dependency warnings and build script output.
 May also be specified with the <code>term.verbose</code>
-<a href="reference/config.html">config value</a>.</p>
+<a href="../reference/config.html">config value</a>.</p>
 </dd>
 <dt class="hdlist1"><strong>-q</strong></dt>
 <dt class="hdlist1"><strong>--quiet</strong></dt>
@@ -232,7 +232,7 @@ terminal.</p>
 </div>
 <div class="paragraph">
 <p>May also be specified with the <code>term.color</code>
-<a href="reference/config.html">config value</a>.</p>
+<a href="../reference/config.html">config value</a>.</p>
 </div>
 </dd>
 <dt class="hdlist1"><strong>--message-format</strong> <em>FMT</em></dt>
@@ -287,11 +287,11 @@ proceed without the network if possible.</p>
 <p>Beware that this may result in different dependency resolution than online
 mode. Cargo will restrict itself to crates that are downloaded locally, even
 if there might be a newer version as indicated in the local copy of the index.
-See the <a href="commands/cargo-fetch.html">cargo-fetch(1)</a> command to download dependencies before going
+See the <a href="cargo-fetch.html">cargo-fetch(1)</a> command to download dependencies before going
 offline.</p>
 </div>
 <div class="paragraph">
-<p>May also be specified with the <code>net.offline</code> <a href="reference/config.html">config value</a>.</p>
+<p>May also be specified with the <code>net.offline</code> <a href="../reference/config.html">config value</a>.</p>
 </div>
 </dd>
 </dl>
@@ -322,7 +322,7 @@ details.</p>
 <dt class="hdlist1"><strong>--jobs</strong> <em>N</em></dt>
 <dd>
 <p>Number of parallel jobs to run. May also be specified with the
-<code>build.jobs</code> <a href="reference/config.html">config value</a>. Defaults to
+<code>build.jobs</code> <a href="../reference/config.html">config value</a>. Defaults to
 the number of CPUs.</p>
 </dd>
 </dl>
@@ -336,7 +336,7 @@ the number of CPUs.</p>
 <div class="paragraph">
 <p>Profiles may be used to configure compiler options such as optimization levels
 and debug settings. See
-<a href="reference/manifest.html#the-profile-sections">the reference</a>
+<a href="../reference/manifest.html#the-profile-sections">the reference</a>
 for more details.</p>
 </div>
 <div class="paragraph">
@@ -380,7 +380,7 @@ for more details.</p>
 <h2 id="cargo_check_environment">ENVIRONMENT</h2>
 <div class="sectionbody">
 <div class="paragraph">
-<p>See <a href="reference/environment-variables.html">the reference</a> for
+<p>See <a href="../reference/environment-variables.html">the reference</a> for
 details on environment variables that Cargo reads.</p>
 </div>
 </div>
@@ -431,7 +431,7 @@ details on environment variables that Cargo reads.</p>
 <h2 id="cargo_check_see_also">SEE ALSO</h2>
 <div class="sectionbody">
 <div class="paragraph">
-<p><a href="commands/index.html">cargo(1)</a>, <a href="commands/cargo-build.html">cargo-build(1)</a></p>
+<p><a href="index.html">cargo(1)</a>, <a href="cargo-build.html">cargo-build(1)</a></p>
 </div>
 </div>
 </div>

--- a/src/doc/man/generated/cargo-clean.html
+++ b/src/doc/man/generated/cargo-clean.html
@@ -37,7 +37,7 @@ workspace are cleaned.</p>
 <dt class="hdlist1"><strong>--package</strong> <em>SPEC</em>&#8230;&#8203;</dt>
 <dd>
 <p>Clean only the specified packages. This flag may be specified
-multiple times. See <a href="commands/cargo-pkgid.html">cargo-pkgid(1)</a> for the SPEC format.</p>
+multiple times. See <a href="cargo-pkgid.html">cargo-pkgid(1)</a> for the SPEC format.</p>
 </dd>
 </dl>
 </div>
@@ -60,7 +60,7 @@ profiles.</p>
 <dd>
 <p>Directory for all generated artifacts and intermediate files. May also be
 specified with the <code>CARGO_TARGET_DIR</code> environment variable, or the
-<code>build.target-dir</code> <a href="reference/config.html">config value</a>. Defaults
+<code>build.target-dir</code> <a href="../reference/config.html">config value</a>. Defaults
 to <code>target</code> in the root of the workspace.</p>
 </dd>
 <dt class="hdlist1"><strong>--target</strong> <em>TRIPLE</em></dt>
@@ -71,7 +71,7 @@ architecture. The general format of the triple is
 list of supported targets.</p>
 <div class="paragraph">
 <p>This may also be specified with the <code>build.target</code>
-<a href="reference/config.html">config value</a>.</p>
+<a href="../reference/config.html">config value</a>.</p>
 </div>
 </dd>
 </dl>
@@ -87,7 +87,7 @@ list of supported targets.</p>
 <p>Use verbose output. May be specified twice for "very verbose" output which
 includes extra output such as dependency warnings and build script output.
 May also be specified with the <code>term.verbose</code>
-<a href="reference/config.html">config value</a>.</p>
+<a href="../reference/config.html">config value</a>.</p>
 </dd>
 <dt class="hdlist1"><strong>-q</strong></dt>
 <dt class="hdlist1"><strong>--quiet</strong></dt>
@@ -113,7 +113,7 @@ terminal.</p>
 </div>
 <div class="paragraph">
 <p>May also be specified with the <code>term.color</code>
-<a href="reference/config.html">config value</a>.</p>
+<a href="../reference/config.html">config value</a>.</p>
 </div>
 </dd>
 </dl>
@@ -151,11 +151,11 @@ proceed without the network if possible.</p>
 <p>Beware that this may result in different dependency resolution than online
 mode. Cargo will restrict itself to crates that are downloaded locally, even
 if there might be a newer version as indicated in the local copy of the index.
-See the <a href="commands/cargo-fetch.html">cargo-fetch(1)</a> command to download dependencies before going
+See the <a href="cargo-fetch.html">cargo-fetch(1)</a> command to download dependencies before going
 offline.</p>
 </div>
 <div class="paragraph">
-<p>May also be specified with the <code>net.offline</code> <a href="reference/config.html">config value</a>.</p>
+<p>May also be specified with the <code>net.offline</code> <a href="../reference/config.html">config value</a>.</p>
 </div>
 </dd>
 </dl>
@@ -184,7 +184,7 @@ details.</p>
 <h2 id="cargo_clean_environment">ENVIRONMENT</h2>
 <div class="sectionbody">
 <div class="paragraph">
-<p>See <a href="reference/environment-variables.html">the reference</a> for
+<p>See <a href="../reference/environment-variables.html">the reference</a> for
 details on environment variables that Cargo reads.</p>
 </div>
 </div>
@@ -235,7 +235,7 @@ details on environment variables that Cargo reads.</p>
 <h2 id="cargo_clean_see_also">SEE ALSO</h2>
 <div class="sectionbody">
 <div class="paragraph">
-<p><a href="commands/index.html">cargo(1)</a>, <a href="commands/cargo-build.html">cargo-build(1)</a></p>
+<p><a href="index.html">cargo(1)</a>, <a href="cargo-build.html">cargo-build(1)</a></p>
 </div>
 </div>
 </div>

--- a/src/doc/man/generated/cargo-doc.html
+++ b/src/doc/man/generated/cargo-doc.html
@@ -56,7 +56,7 @@ manifest.</p>
 <dt class="hdlist1"><strong>-p</strong> <em>SPEC</em>&#8230;&#8203;</dt>
 <dt class="hdlist1"><strong>--package</strong> <em>SPEC</em>&#8230;&#8203;</dt>
 <dd>
-<p>Document only the specified packages. See <a href="commands/cargo-pkgid.html">cargo-pkgid(1)</a> for the
+<p>Document only the specified packages. See <a href="cargo-pkgid.html">cargo-pkgid(1)</a> for the
 SPEC format. This flag may be specified multiple times.</p>
 </dd>
 <dt class="hdlist1"><strong>--all</strong></dt>
@@ -139,7 +139,7 @@ architecture. The general format of the triple is
 list of supported targets.</p>
 <div class="paragraph">
 <p>This may also be specified with the <code>build.target</code>
-<a href="reference/config.html">config value</a>.</p>
+<a href="../reference/config.html">config value</a>.</p>
 </div>
 </dd>
 <dt class="hdlist1"><strong>--release</strong></dt>
@@ -158,7 +158,7 @@ list of supported targets.</p>
 <dd>
 <p>Directory for all generated artifacts and intermediate files. May also be
 specified with the <code>CARGO_TARGET_DIR</code> environment variable, or the
-<code>build.target-dir</code> <a href="reference/config.html">config value</a>. Defaults
+<code>build.target-dir</code> <a href="../reference/config.html">config value</a>. Defaults
 to <code>target</code> in the root of the workspace.</p>
 </dd>
 </dl>
@@ -174,7 +174,7 @@ to <code>target</code> in the root of the workspace.</p>
 <p>Use verbose output. May be specified twice for "very verbose" output which
 includes extra output such as dependency warnings and build script output.
 May also be specified with the <code>term.verbose</code>
-<a href="reference/config.html">config value</a>.</p>
+<a href="../reference/config.html">config value</a>.</p>
 </dd>
 <dt class="hdlist1"><strong>-q</strong></dt>
 <dt class="hdlist1"><strong>--quiet</strong></dt>
@@ -200,7 +200,7 @@ terminal.</p>
 </div>
 <div class="paragraph">
 <p>May also be specified with the <code>term.color</code>
-<a href="reference/config.html">config value</a>.</p>
+<a href="../reference/config.html">config value</a>.</p>
 </div>
 </dd>
 <dt class="hdlist1"><strong>--message-format</strong> <em>FMT</em></dt>
@@ -255,11 +255,11 @@ proceed without the network if possible.</p>
 <p>Beware that this may result in different dependency resolution than online
 mode. Cargo will restrict itself to crates that are downloaded locally, even
 if there might be a newer version as indicated in the local copy of the index.
-See the <a href="commands/cargo-fetch.html">cargo-fetch(1)</a> command to download dependencies before going
+See the <a href="cargo-fetch.html">cargo-fetch(1)</a> command to download dependencies before going
 offline.</p>
 </div>
 <div class="paragraph">
-<p>May also be specified with the <code>net.offline</code> <a href="reference/config.html">config value</a>.</p>
+<p>May also be specified with the <code>net.offline</code> <a href="../reference/config.html">config value</a>.</p>
 </div>
 </dd>
 </dl>
@@ -290,7 +290,7 @@ details.</p>
 <dt class="hdlist1"><strong>--jobs</strong> <em>N</em></dt>
 <dd>
 <p>Number of parallel jobs to run. May also be specified with the
-<code>build.jobs</code> <a href="reference/config.html">config value</a>. Defaults to
+<code>build.jobs</code> <a href="../reference/config.html">config value</a>. Defaults to
 the number of CPUs.</p>
 </dd>
 </dl>
@@ -304,7 +304,7 @@ the number of CPUs.</p>
 <div class="paragraph">
 <p>Profiles may be used to configure compiler options such as optimization levels
 and debug settings. See
-<a href="reference/manifest.html#the-profile-sections">the reference</a>
+<a href="../reference/manifest.html#the-profile-sections">the reference</a>
 for more details.</p>
 </div>
 <div class="paragraph">
@@ -348,7 +348,7 @@ for more details.</p>
 <h2 id="cargo_doc_environment">ENVIRONMENT</h2>
 <div class="sectionbody">
 <div class="paragraph">
-<p>See <a href="reference/environment-variables.html">the reference</a> for
+<p>See <a href="../reference/environment-variables.html">the reference</a> for
 details on environment variables that Cargo reads.</p>
 </div>
 </div>
@@ -392,7 +392,7 @@ details on environment variables that Cargo reads.</p>
 <h2 id="cargo_doc_see_also">SEE ALSO</h2>
 <div class="sectionbody">
 <div class="paragraph">
-<p><a href="commands/index.html">cargo(1)</a>, <a href="commands/cargo-rustdoc.html">cargo-rustdoc(1)</a>, <a href="https://doc.rust-lang.org/rustdoc/index.html">rustdoc(1)</a></p>
+<p><a href="index.html">cargo(1)</a>, <a href="cargo-rustdoc.html">cargo-rustdoc(1)</a>, <a href="https://doc.rust-lang.org/rustdoc/index.html">rustdoc(1)</a></p>
 </div>
 </div>
 </div>

--- a/src/doc/man/generated/cargo-fetch.html
+++ b/src/doc/man/generated/cargo-fetch.html
@@ -48,7 +48,7 @@ architecture. The general format of the triple is
 list of supported targets.</p>
 <div class="paragraph">
 <p>This may also be specified with the <code>build.target</code>
-<a href="reference/config.html">config value</a>.</p>
+<a href="../reference/config.html">config value</a>.</p>
 </div>
 </dd>
 </dl>
@@ -64,7 +64,7 @@ list of supported targets.</p>
 <p>Use verbose output. May be specified twice for "very verbose" output which
 includes extra output such as dependency warnings and build script output.
 May also be specified with the <code>term.verbose</code>
-<a href="reference/config.html">config value</a>.</p>
+<a href="../reference/config.html">config value</a>.</p>
 </dd>
 <dt class="hdlist1"><strong>-q</strong></dt>
 <dt class="hdlist1"><strong>--quiet</strong></dt>
@@ -90,7 +90,7 @@ terminal.</p>
 </div>
 <div class="paragraph">
 <p>May also be specified with the <code>term.color</code>
-<a href="reference/config.html">config value</a>.</p>
+<a href="../reference/config.html">config value</a>.</p>
 </div>
 </dd>
 </dl>
@@ -128,11 +128,11 @@ proceed without the network if possible.</p>
 <p>Beware that this may result in different dependency resolution than online
 mode. Cargo will restrict itself to crates that are downloaded locally, even
 if there might be a newer version as indicated in the local copy of the index.
-See the <a href="commands/cargo-fetch.html">cargo-fetch(1)</a> command to download dependencies before going
+See the <a href="cargo-fetch.html">cargo-fetch(1)</a> command to download dependencies before going
 offline.</p>
 </div>
 <div class="paragraph">
-<p>May also be specified with the <code>net.offline</code> <a href="reference/config.html">config value</a>.</p>
+<p>May also be specified with the <code>net.offline</code> <a href="../reference/config.html">config value</a>.</p>
 </div>
 </dd>
 </dl>
@@ -161,7 +161,7 @@ details.</p>
 <h2 id="cargo_fetch_environment">ENVIRONMENT</h2>
 <div class="sectionbody">
 <div class="paragraph">
-<p>See <a href="reference/environment-variables.html">the reference</a> for
+<p>See <a href="../reference/environment-variables.html">the reference</a> for
 details on environment variables that Cargo reads.</p>
 </div>
 </div>
@@ -204,7 +204,7 @@ details on environment variables that Cargo reads.</p>
 <h2 id="cargo_fetch_see_also">SEE ALSO</h2>
 <div class="sectionbody">
 <div class="paragraph">
-<p><a href="commands/index.html">cargo(1)</a>, <a href="commands/cargo-update.html">cargo-update(1)</a>, <a href="commands/cargo-generate-lockfile.html">cargo-generate-lockfile(1)</a></p>
+<p><a href="index.html">cargo(1)</a>, <a href="cargo-update.html">cargo-update(1)</a>, <a href="cargo-generate-lockfile.html">cargo-generate-lockfile(1)</a></p>
 </div>
 </div>
 </div>

--- a/src/doc/man/generated/cargo-fix.html
+++ b/src/doc/man/generated/cargo-fix.html
@@ -22,7 +22,7 @@ to provide code the ability to easily opt-in to the new edition without having
 to worry about any breakage.</p>
 </div>
 <div class="paragraph">
-<p>Executing <code>cargo fix</code> will under the hood execute <a href="commands/cargo-check.html">cargo-check(1)</a>. Any warnings
+<p>Executing <code>cargo fix</code> will under the hood execute <a href="cargo-check.html">cargo-check(1)</a>. Any warnings
 applicable to your crate will be automatically fixed (if possible) and all
 remaining warnings will be displayed when the check process is finished. For
 example if you&#8217;d like to prepare for the 2018 edition, you can do so by
@@ -111,7 +111,7 @@ manifest.</p>
 <dt class="hdlist1"><strong>-p</strong> <em>SPEC</em>&#8230;&#8203;</dt>
 <dt class="hdlist1"><strong>--package</strong> <em>SPEC</em>&#8230;&#8203;</dt>
 <dd>
-<p>Fix only the specified packages. See <a href="commands/cargo-pkgid.html">cargo-pkgid(1)</a> for the
+<p>Fix only the specified packages. See <a href="cargo-pkgid.html">cargo-pkgid(1)</a> for the
 SPEC format. This flag may be specified multiple times.</p>
 </dd>
 <dt class="hdlist1"><strong>--all</strong></dt>
@@ -234,7 +234,7 @@ architecture. The general format of the triple is
 list of supported targets.</p>
 <div class="paragraph">
 <p>This may also be specified with the <code>build.target</code>
-<a href="reference/config.html">config value</a>.</p>
+<a href="../reference/config.html">config value</a>.</p>
 </div>
 </dd>
 <dt class="hdlist1"><strong>--release</strong></dt>
@@ -261,7 +261,7 @@ the <code>cfg</code> attribute. This does not change the actual profile used.</p
 <dd>
 <p>Directory for all generated artifacts and intermediate files. May also be
 specified with the <code>CARGO_TARGET_DIR</code> environment variable, or the
-<code>build.target-dir</code> <a href="reference/config.html">config value</a>. Defaults
+<code>build.target-dir</code> <a href="../reference/config.html">config value</a>. Defaults
 to <code>target</code> in the root of the workspace.</p>
 </dd>
 </dl>
@@ -277,7 +277,7 @@ to <code>target</code> in the root of the workspace.</p>
 <p>Use verbose output. May be specified twice for "very verbose" output which
 includes extra output such as dependency warnings and build script output.
 May also be specified with the <code>term.verbose</code>
-<a href="reference/config.html">config value</a>.</p>
+<a href="../reference/config.html">config value</a>.</p>
 </dd>
 <dt class="hdlist1"><strong>-q</strong></dt>
 <dt class="hdlist1"><strong>--quiet</strong></dt>
@@ -303,7 +303,7 @@ terminal.</p>
 </div>
 <div class="paragraph">
 <p>May also be specified with the <code>term.color</code>
-<a href="reference/config.html">config value</a>.</p>
+<a href="../reference/config.html">config value</a>.</p>
 </div>
 </dd>
 <dt class="hdlist1"><strong>--message-format</strong> <em>FMT</em></dt>
@@ -358,11 +358,11 @@ proceed without the network if possible.</p>
 <p>Beware that this may result in different dependency resolution than online
 mode. Cargo will restrict itself to crates that are downloaded locally, even
 if there might be a newer version as indicated in the local copy of the index.
-See the <a href="commands/cargo-fetch.html">cargo-fetch(1)</a> command to download dependencies before going
+See the <a href="cargo-fetch.html">cargo-fetch(1)</a> command to download dependencies before going
 offline.</p>
 </div>
 <div class="paragraph">
-<p>May also be specified with the <code>net.offline</code> <a href="reference/config.html">config value</a>.</p>
+<p>May also be specified with the <code>net.offline</code> <a href="../reference/config.html">config value</a>.</p>
 </div>
 </dd>
 </dl>
@@ -393,7 +393,7 @@ details.</p>
 <dt class="hdlist1"><strong>--jobs</strong> <em>N</em></dt>
 <dd>
 <p>Number of parallel jobs to run. May also be specified with the
-<code>build.jobs</code> <a href="reference/config.html">config value</a>. Defaults to
+<code>build.jobs</code> <a href="../reference/config.html">config value</a>. Defaults to
 the number of CPUs.</p>
 </dd>
 </dl>
@@ -407,7 +407,7 @@ the number of CPUs.</p>
 <div class="paragraph">
 <p>Profiles may be used to configure compiler options such as optimization levels
 and debug settings. See
-<a href="reference/manifest.html#the-profile-sections">the reference</a>
+<a href="../reference/manifest.html#the-profile-sections">the reference</a>
 for more details.</p>
 </div>
 <div class="paragraph">
@@ -451,7 +451,7 @@ for more details.</p>
 <h2 id="cargo_fix_environment">ENVIRONMENT</h2>
 <div class="sectionbody">
 <div class="paragraph">
-<p>See <a href="reference/environment-variables.html">the reference</a> for
+<p>See <a href="../reference/environment-variables.html">the reference</a> for
 details on environment variables that Cargo reads.</p>
 </div>
 </div>
@@ -510,7 +510,7 @@ details on environment variables that Cargo reads.</p>
 <h2 id="cargo_fix_see_also">SEE ALSO</h2>
 <div class="sectionbody">
 <div class="paragraph">
-<p><a href="commands/index.html">cargo(1)</a>, <a href="commands/cargo-check.html">cargo-check(1)</a></p>
+<p><a href="index.html">cargo(1)</a>, <a href="cargo-check.html">cargo-check(1)</a></p>
 </div>
 </div>
 </div>

--- a/src/doc/man/generated/cargo-generate-lockfile.html
+++ b/src/doc/man/generated/cargo-generate-lockfile.html
@@ -19,7 +19,7 @@ workspace. If the lockfile already exists, it will be rebuilt if there are any
 manifest changes or dependency updates.</p>
 </div>
 <div class="paragraph">
-<p>See also <a href="commands/cargo-update.html">cargo-update(1)</a> which is also capable of creating a <code>Cargo.lock</code>
+<p>See also <a href="cargo-update.html">cargo-update(1)</a> which is also capable of creating a <code>Cargo.lock</code>
 lockfile and has more options for controlling update behavior.</p>
 </div>
 </div>
@@ -37,7 +37,7 @@ lockfile and has more options for controlling update behavior.</p>
 <p>Use verbose output. May be specified twice for "very verbose" output which
 includes extra output such as dependency warnings and build script output.
 May also be specified with the <code>term.verbose</code>
-<a href="reference/config.html">config value</a>.</p>
+<a href="../reference/config.html">config value</a>.</p>
 </dd>
 <dt class="hdlist1"><strong>-q</strong></dt>
 <dt class="hdlist1"><strong>--quiet</strong></dt>
@@ -63,7 +63,7 @@ terminal.</p>
 </div>
 <div class="paragraph">
 <p>May also be specified with the <code>term.color</code>
-<a href="reference/config.html">config value</a>.</p>
+<a href="../reference/config.html">config value</a>.</p>
 </div>
 </dd>
 </dl>
@@ -101,11 +101,11 @@ proceed without the network if possible.</p>
 <p>Beware that this may result in different dependency resolution than online
 mode. Cargo will restrict itself to crates that are downloaded locally, even
 if there might be a newer version as indicated in the local copy of the index.
-See the <a href="commands/cargo-fetch.html">cargo-fetch(1)</a> command to download dependencies before going
+See the <a href="cargo-fetch.html">cargo-fetch(1)</a> command to download dependencies before going
 offline.</p>
 </div>
 <div class="paragraph">
-<p>May also be specified with the <code>net.offline</code> <a href="reference/config.html">config value</a>.</p>
+<p>May also be specified with the <code>net.offline</code> <a href="../reference/config.html">config value</a>.</p>
 </div>
 </dd>
 </dl>
@@ -134,7 +134,7 @@ details.</p>
 <h2 id="cargo_generate_lockfile_environment">ENVIRONMENT</h2>
 <div class="sectionbody">
 <div class="paragraph">
-<p>See <a href="reference/environment-variables.html">the reference</a> for
+<p>See <a href="../reference/environment-variables.html">the reference</a> for
 details on environment variables that Cargo reads.</p>
 </div>
 </div>
@@ -177,7 +177,7 @@ details on environment variables that Cargo reads.</p>
 <h2 id="cargo_generate_lockfile_see_also">SEE ALSO</h2>
 <div class="sectionbody">
 <div class="paragraph">
-<p><a href="commands/index.html">cargo(1)</a>, <a href="commands/cargo-update.html">cargo-update(1)</a></p>
+<p><a href="index.html">cargo(1)</a>, <a href="cargo-update.html">cargo-update(1)</a></p>
 </div>
 </div>
 </div>

--- a/src/doc/man/generated/cargo-help.html
+++ b/src/doc/man/generated/cargo-help.html
@@ -47,7 +47,7 @@
 <h2 id="cargo_help_see_also">SEE ALSO</h2>
 <div class="sectionbody">
 <div class="paragraph">
-<p><a href="commands/index.html">cargo(1)</a></p>
+<p><a href="index.html">cargo(1)</a></p>
 </div>
 </div>
 </div>

--- a/src/doc/man/generated/cargo-init.html
+++ b/src/doc/man/generated/cargo-init.html
@@ -85,11 +85,11 @@ wins):</p>
 </ul>
 </div>
 <div class="paragraph">
-<p>See <a href="reference/config.html">the reference</a> for more information about
+<p>See <a href="../reference/config.html">the reference</a> for more information about
 configuration files.</p>
 </div>
 <div class="paragraph">
-<p>See <a href="commands/cargo-new.html">cargo-new(1)</a> for a similar command which will create a new package in
+<p>See <a href="cargo-new.html">cargo-new(1)</a> for a similar command which will create a new package in
 a new directory.</p>
 </div>
 </div>
@@ -131,7 +131,7 @@ hg, pijul, or fossil) or do not initialize any version control at all
 <p>This sets the <code>publish</code> field in <code>Cargo.toml</code> to the given registry name
 which will restrict publishing only to that registry.</p>
 <div class="paragraph">
-<p>Registry names are defined in <a href="reference/config.html">Cargo config files</a>.
+<p>Registry names are defined in <a href="../reference/config.html">Cargo config files</a>.
 If not specified, the default registry defined by the <code>registry.default</code>
 config key is used. If the default registry is not set and <code>--registry</code> is not
 used, the <code>publish</code> field will not be set which means that publishing will not
@@ -151,7 +151,7 @@ be restricted.</p>
 <p>Use verbose output. May be specified twice for "very verbose" output which
 includes extra output such as dependency warnings and build script output.
 May also be specified with the <code>term.verbose</code>
-<a href="reference/config.html">config value</a>.</p>
+<a href="../reference/config.html">config value</a>.</p>
 </dd>
 <dt class="hdlist1"><strong>-q</strong></dt>
 <dt class="hdlist1"><strong>--quiet</strong></dt>
@@ -177,7 +177,7 @@ terminal.</p>
 </div>
 <div class="paragraph">
 <p>May also be specified with the <code>term.color</code>
-<a href="reference/config.html">config value</a>.</p>
+<a href="../reference/config.html">config value</a>.</p>
 </div>
 </dd>
 </dl>
@@ -206,7 +206,7 @@ details.</p>
 <h2 id="cargo_init_environment">ENVIRONMENT</h2>
 <div class="sectionbody">
 <div class="paragraph">
-<p>See <a href="reference/environment-variables.html">the reference</a> for
+<p>See <a href="../reference/environment-variables.html">the reference</a> for
 details on environment variables that Cargo reads.</p>
 </div>
 </div>
@@ -249,7 +249,7 @@ details on environment variables that Cargo reads.</p>
 <h2 id="cargo_init_see_also">SEE ALSO</h2>
 <div class="sectionbody">
 <div class="paragraph">
-<p><a href="commands/index.html">cargo(1)</a>, <a href="commands/cargo-new.html">cargo-new(1)</a></p>
+<p><a href="index.html">cargo(1)</a>, <a href="cargo-new.html">cargo-new(1)</a></p>
 </div>
 </div>
 </div>

--- a/src/doc/man/generated/cargo-install.html
+++ b/src/doc/man/generated/cargo-install.html
@@ -34,7 +34,7 @@ installed, and all executables are installed into the installation root&#8217;s
 <p><code>CARGO_INSTALL_ROOT</code> environment variable</p>
 </li>
 <li>
-<p><code>install.root</code> Cargo <a href="reference/config.html">config value</a></p>
+<p><code>install.root</code> Cargo <a href="../reference/config.html">config value</a></p>
 </li>
 <li>
 <p><code>CARGO_HOME</code> environment variable</p>
@@ -147,7 +147,7 @@ reinstall or upgrade a crate.</p>
 </dd>
 <dt class="hdlist1"><strong>--registry</strong> <em>REGISTRY</em></dt>
 <dd>
-<p>Name of the registry to use. Registry names are defined in <a href="reference/config.html">Cargo config files</a>.
+<p>Name of the registry to use. Registry names are defined in <a href="../reference/config.html">Cargo config files</a>.
 If not specified, the default registry is used, which is defined by the
 <code>registry.default</code> config key which defaults to <code>crates-io</code>.</p>
 </dd>
@@ -192,7 +192,7 @@ architecture. The general format of the triple is
 list of supported targets.</p>
 <div class="paragraph">
 <p>This may also be specified with the <code>build.target</code>
-<a href="reference/config.html">config value</a>.</p>
+<a href="../reference/config.html">config value</a>.</p>
 </div>
 </dd>
 <dt class="hdlist1"><strong>--debug</strong></dt>
@@ -229,11 +229,11 @@ proceed without the network if possible.</p>
 <p>Beware that this may result in different dependency resolution than online
 mode. Cargo will restrict itself to crates that are downloaded locally, even
 if there might be a newer version as indicated in the local copy of the index.
-See the <a href="commands/cargo-fetch.html">cargo-fetch(1)</a> command to download dependencies before going
+See the <a href="cargo-fetch.html">cargo-fetch(1)</a> command to download dependencies before going
 offline.</p>
 </div>
 <div class="paragraph">
-<p>May also be specified with the <code>net.offline</code> <a href="reference/config.html">config value</a>.</p>
+<p>May also be specified with the <code>net.offline</code> <a href="../reference/config.html">config value</a>.</p>
 </div>
 </dd>
 </dl>
@@ -247,7 +247,7 @@ offline.</p>
 <dt class="hdlist1"><strong>--jobs</strong> <em>N</em></dt>
 <dd>
 <p>Number of parallel jobs to run. May also be specified with the
-<code>build.jobs</code> <a href="reference/config.html">config value</a>. Defaults to
+<code>build.jobs</code> <a href="../reference/config.html">config value</a>. Defaults to
 the number of CPUs.</p>
 </dd>
 </dl>
@@ -263,7 +263,7 @@ the number of CPUs.</p>
 <p>Use verbose output. May be specified twice for "very verbose" output which
 includes extra output such as dependency warnings and build script output.
 May also be specified with the <code>term.verbose</code>
-<a href="reference/config.html">config value</a>.</p>
+<a href="../reference/config.html">config value</a>.</p>
 </dd>
 <dt class="hdlist1"><strong>-q</strong></dt>
 <dt class="hdlist1"><strong>--quiet</strong></dt>
@@ -289,7 +289,7 @@ terminal.</p>
 </div>
 <div class="paragraph">
 <p>May also be specified with the <code>term.color</code>
-<a href="reference/config.html">config value</a>.</p>
+<a href="../reference/config.html">config value</a>.</p>
 </div>
 </dd>
 </dl>
@@ -318,7 +318,7 @@ details.</p>
 <h2 id="cargo_install_environment">ENVIRONMENT</h2>
 <div class="sectionbody">
 <div class="paragraph">
-<p>See <a href="reference/environment-variables.html">the reference</a> for
+<p>See <a href="../reference/environment-variables.html">the reference</a> for
 details on environment variables that Cargo reads.</p>
 </div>
 </div>
@@ -369,7 +369,7 @@ details on environment variables that Cargo reads.</p>
 <h2 id="cargo_install_see_also">SEE ALSO</h2>
 <div class="sectionbody">
 <div class="paragraph">
-<p><a href="commands/index.html">cargo(1)</a>, <a href="commands/cargo-uninstall.html">cargo-uninstall(1)</a>, <a href="commands/cargo-search.html">cargo-search(1)</a>, <a href="commands/cargo-publish.html">cargo-publish(1)</a></p>
+<p><a href="index.html">cargo(1)</a>, <a href="cargo-uninstall.html">cargo-uninstall(1)</a>, <a href="cargo-search.html">cargo-search(1)</a>, <a href="cargo-publish.html">cargo-publish(1)</a></p>
 </div>
 </div>
 </div>

--- a/src/doc/man/generated/cargo-locate-project.html
+++ b/src/doc/man/generated/cargo-locate-project.html
@@ -18,7 +18,7 @@
 <code>Cargo.toml</code> manifest.</p>
 </div>
 <div class="paragraph">
-<p>See also <a href="commands/cargo-metadata.html">cargo-metadata(1)</a> which is capable of returning the path to a
+<p>See also <a href="cargo-metadata.html">cargo-metadata(1)</a> which is capable of returning the path to a
 workspace root.</p>
 </div>
 </div>
@@ -36,7 +36,7 @@ workspace root.</p>
 <p>Use verbose output. May be specified twice for "very verbose" output which
 includes extra output such as dependency warnings and build script output.
 May also be specified with the <code>term.verbose</code>
-<a href="reference/config.html">config value</a>.</p>
+<a href="../reference/config.html">config value</a>.</p>
 </dd>
 <dt class="hdlist1"><strong>-q</strong></dt>
 <dt class="hdlist1"><strong>--quiet</strong></dt>
@@ -62,7 +62,7 @@ terminal.</p>
 </div>
 <div class="paragraph">
 <p>May also be specified with the <code>term.color</code>
-<a href="reference/config.html">config value</a>.</p>
+<a href="../reference/config.html">config value</a>.</p>
 </div>
 </dd>
 </dl>
@@ -103,7 +103,7 @@ details.</p>
 <h2 id="cargo_locate_project_environment">ENVIRONMENT</h2>
 <div class="sectionbody">
 <div class="paragraph">
-<p>See <a href="reference/environment-variables.html">the reference</a> for
+<p>See <a href="../reference/environment-variables.html">the reference</a> for
 details on environment variables that Cargo reads.</p>
 </div>
 </div>
@@ -146,7 +146,7 @@ details on environment variables that Cargo reads.</p>
 <h2 id="cargo_locate_project_see_also">SEE ALSO</h2>
 <div class="sectionbody">
 <div class="paragraph">
-<p><a href="commands/index.html">cargo(1)</a>, <a href="commands/cargo-metadata.html">cargo-metadata(1)</a></p>
+<p><a href="index.html">cargo(1)</a>, <a href="cargo-metadata.html">cargo-metadata(1)</a></p>
 </div>
 </div>
 </div>

--- a/src/doc/man/generated/cargo-login.html
+++ b/src/doc/man/generated/cargo-login.html
@@ -15,7 +15,7 @@
 <div class="sectionbody">
 <div class="paragraph">
 <p>This command will save the API token to disk so that commands that require
-authentication, such as <a href="commands/cargo-publish.html">cargo-publish(1)</a>, will be automatically
+authentication, such as <a href="cargo-publish.html">cargo-publish(1)</a>, will be automatically
 authenticated. The token is saved in <code>$CARGO_HOME/credentials</code>. <code>CARGO_HOME</code>
 defaults to <code>.cargo</code> in your home directory.</p>
 </div>
@@ -39,7 +39,7 @@ defaults to <code>.cargo</code> in your home directory.</p>
 <dl>
 <dt class="hdlist1"><strong>--registry</strong> <em>REGISTRY</em></dt>
 <dd>
-<p>Name of the registry to use. Registry names are defined in <a href="reference/config.html">Cargo config files</a>.
+<p>Name of the registry to use. Registry names are defined in <a href="../reference/config.html">Cargo config files</a>.
 If not specified, the default registry is used, which is defined by the
 <code>registry.default</code> config key which defaults to <code>crates-io</code>.</p>
 </dd>
@@ -56,7 +56,7 @@ If not specified, the default registry is used, which is defined by the
 <p>Use verbose output. May be specified twice for "very verbose" output which
 includes extra output such as dependency warnings and build script output.
 May also be specified with the <code>term.verbose</code>
-<a href="reference/config.html">config value</a>.</p>
+<a href="../reference/config.html">config value</a>.</p>
 </dd>
 <dt class="hdlist1"><strong>-q</strong></dt>
 <dt class="hdlist1"><strong>--quiet</strong></dt>
@@ -82,7 +82,7 @@ terminal.</p>
 </div>
 <div class="paragraph">
 <p>May also be specified with the <code>term.color</code>
-<a href="reference/config.html">config value</a>.</p>
+<a href="../reference/config.html">config value</a>.</p>
 </div>
 </dd>
 </dl>
@@ -111,7 +111,7 @@ details.</p>
 <h2 id="cargo_login_environment">ENVIRONMENT</h2>
 <div class="sectionbody">
 <div class="paragraph">
-<p>See <a href="reference/environment-variables.html">the reference</a> for
+<p>See <a href="../reference/environment-variables.html">the reference</a> for
 details on environment variables that Cargo reads.</p>
 </div>
 </div>
@@ -154,7 +154,7 @@ details on environment variables that Cargo reads.</p>
 <h2 id="cargo_login_see_also">SEE ALSO</h2>
 <div class="sectionbody">
 <div class="paragraph">
-<p><a href="commands/index.html">cargo(1)</a>, <a href="commands/cargo-publish.html">cargo-publish(1)</a></p>
+<p><a href="index.html">cargo(1)</a>, <a href="cargo-publish.html">cargo-publish(1)</a></p>
 </div>
 </div>
 </div>

--- a/src/doc/man/generated/cargo-metadata.html
+++ b/src/doc/man/generated/cargo-metadata.html
@@ -35,7 +35,7 @@ for a Rust API for reading the metadata.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight"><code data-lang="javascript" class="language-javascript hljs">{
+<pre class="highlightjs highlight"><code class="language-javascript hljs" data-lang="javascript">{
     /* Array of all packages in the workspace.
        It also includes all feature-enabled dependencies unless --no-deps is used.
     */
@@ -313,7 +313,7 @@ package.</p>
 <p>Use verbose output. May be specified twice for "very verbose" output which
 includes extra output such as dependency warnings and build script output.
 May also be specified with the <code>term.verbose</code>
-<a href="reference/config.html">config value</a>.</p>
+<a href="../reference/config.html">config value</a>.</p>
 </dd>
 <dt class="hdlist1"><strong>-q</strong></dt>
 <dt class="hdlist1"><strong>--quiet</strong></dt>
@@ -339,7 +339,7 @@ terminal.</p>
 </div>
 <div class="paragraph">
 <p>May also be specified with the <code>term.color</code>
-<a href="reference/config.html">config value</a>.</p>
+<a href="../reference/config.html">config value</a>.</p>
 </div>
 </dd>
 </dl>
@@ -377,11 +377,11 @@ proceed without the network if possible.</p>
 <p>Beware that this may result in different dependency resolution than online
 mode. Cargo will restrict itself to crates that are downloaded locally, even
 if there might be a newer version as indicated in the local copy of the index.
-See the <a href="commands/cargo-fetch.html">cargo-fetch(1)</a> command to download dependencies before going
+See the <a href="cargo-fetch.html">cargo-fetch(1)</a> command to download dependencies before going
 offline.</p>
 </div>
 <div class="paragraph">
-<p>May also be specified with the <code>net.offline</code> <a href="reference/config.html">config value</a>.</p>
+<p>May also be specified with the <code>net.offline</code> <a href="../reference/config.html">config value</a>.</p>
 </div>
 </dd>
 </dl>
@@ -410,7 +410,7 @@ details.</p>
 <h2 id="cargo_metadata_environment">ENVIRONMENT</h2>
 <div class="sectionbody">
 <div class="paragraph">
-<p>See <a href="reference/environment-variables.html">the reference</a> for
+<p>See <a href="../reference/environment-variables.html">the reference</a> for
 details on environment variables that Cargo reads.</p>
 </div>
 </div>
@@ -453,7 +453,7 @@ details on environment variables that Cargo reads.</p>
 <h2 id="cargo_metadata_see_also">SEE ALSO</h2>
 <div class="sectionbody">
 <div class="paragraph">
-<p><a href="commands/index.html">cargo(1)</a></p>
+<p><a href="index.html">cargo(1)</a></p>
 </div>
 </div>
 </div>

--- a/src/doc/man/generated/cargo-new.html
+++ b/src/doc/man/generated/cargo-new.html
@@ -78,11 +78,11 @@ wins):</p>
 </ul>
 </div>
 <div class="paragraph">
-<p>See <a href="reference/config.html">the reference</a> for more information about
+<p>See <a href="../reference/config.html">the reference</a> for more information about
 configuration files.</p>
 </div>
 <div class="paragraph">
-<p>See <a href="commands/cargo-init.html">cargo-init(1)</a> for a similar command which will create a new manifest
+<p>See <a href="cargo-init.html">cargo-init(1)</a> for a similar command which will create a new manifest
 in an existing directory.</p>
 </div>
 </div>
@@ -124,7 +124,7 @@ hg, pijul, or fossil) or do not initialize any version control at all
 <p>This sets the <code>publish</code> field in <code>Cargo.toml</code> to the given registry name
 which will restrict publishing only to that registry.</p>
 <div class="paragraph">
-<p>Registry names are defined in <a href="reference/config.html">Cargo config files</a>.
+<p>Registry names are defined in <a href="../reference/config.html">Cargo config files</a>.
 If not specified, the default registry defined by the <code>registry.default</code>
 config key is used. If the default registry is not set and <code>--registry</code> is not
 used, the <code>publish</code> field will not be set which means that publishing will not
@@ -144,7 +144,7 @@ be restricted.</p>
 <p>Use verbose output. May be specified twice for "very verbose" output which
 includes extra output such as dependency warnings and build script output.
 May also be specified with the <code>term.verbose</code>
-<a href="reference/config.html">config value</a>.</p>
+<a href="../reference/config.html">config value</a>.</p>
 </dd>
 <dt class="hdlist1"><strong>-q</strong></dt>
 <dt class="hdlist1"><strong>--quiet</strong></dt>
@@ -170,7 +170,7 @@ terminal.</p>
 </div>
 <div class="paragraph">
 <p>May also be specified with the <code>term.color</code>
-<a href="reference/config.html">config value</a>.</p>
+<a href="../reference/config.html">config value</a>.</p>
 </div>
 </dd>
 </dl>
@@ -199,7 +199,7 @@ details.</p>
 <h2 id="cargo_new_environment">ENVIRONMENT</h2>
 <div class="sectionbody">
 <div class="paragraph">
-<p>See <a href="reference/environment-variables.html">the reference</a> for
+<p>See <a href="../reference/environment-variables.html">the reference</a> for
 details on environment variables that Cargo reads.</p>
 </div>
 </div>
@@ -242,7 +242,7 @@ details on environment variables that Cargo reads.</p>
 <h2 id="cargo_new_see_also">SEE ALSO</h2>
 <div class="sectionbody">
 <div class="paragraph">
-<p><a href="commands/index.html">cargo(1)</a>, <a href="commands/cargo-init.html">cargo-init(1)</a></p>
+<p><a href="index.html">cargo(1)</a>, <a href="cargo-init.html">cargo-init(1)</a></p>
 </div>
 </div>
 </div>

--- a/src/doc/man/generated/cargo-owner.html
+++ b/src/doc/man/generated/cargo-owner.html
@@ -22,14 +22,14 @@ modify the set of owners, so take care!</p>
 </div>
 <div class="paragraph">
 <p>This command requires you to be authenticated with either the <code>--token</code> option
-or using <a href="commands/cargo-login.html">cargo-login(1)</a>.</p>
+or using <a href="cargo-login.html">cargo-login(1)</a>.</p>
 </div>
 <div class="paragraph">
 <p>If the crate name is not specified, it will use the package name from the
 current directory.</p>
 </div>
 <div class="paragraph">
-<p>See <a href="reference/publishing.html#cargo-owner">the reference</a> for more
+<p>See <a href="../reference/publishing.html#cargo-owner">the reference</a> for more
 information about owners and publishing.</p>
 </div>
 </div>
@@ -59,9 +59,9 @@ information about owners and publishing.</p>
 <dt class="hdlist1"><strong>--token</strong> <em>TOKEN</em></dt>
 <dd>
 <p>API token to use when authenticating. This overrides the token stored in
-the credentials file (which is created by <a href="commands/cargo-login.html">cargo-login(1)</a>).</p>
+the credentials file (which is created by <a href="cargo-login.html">cargo-login(1)</a>).</p>
 <div class="paragraph">
-<p><a href="reference/config.html">Cargo config</a> environment variables can be
+<p><a href="../reference/config.html">Cargo config</a> environment variables can be
 used to override the tokens stored in the credentials file. The token for
 crates.io may be specified with the <code>CARGO_REGISTRY_TOKEN</code> environment
 variable. Tokens for other registries may be specified with environment
@@ -75,7 +75,7 @@ of the registry in all capital letters.</p>
 </dd>
 <dt class="hdlist1"><strong>--registry</strong> <em>REGISTRY</em></dt>
 <dd>
-<p>Name of the registry to use. Registry names are defined in <a href="reference/config.html">Cargo config files</a>.
+<p>Name of the registry to use. Registry names are defined in <a href="../reference/config.html">Cargo config files</a>.
 If not specified, the default registry is used, which is defined by the
 <code>registry.default</code> config key which defaults to <code>crates-io</code>.</p>
 </dd>
@@ -92,7 +92,7 @@ If not specified, the default registry is used, which is defined by the
 <p>Use verbose output. May be specified twice for "very verbose" output which
 includes extra output such as dependency warnings and build script output.
 May also be specified with the <code>term.verbose</code>
-<a href="reference/config.html">config value</a>.</p>
+<a href="../reference/config.html">config value</a>.</p>
 </dd>
 <dt class="hdlist1"><strong>-q</strong></dt>
 <dt class="hdlist1"><strong>--quiet</strong></dt>
@@ -118,7 +118,7 @@ terminal.</p>
 </div>
 <div class="paragraph">
 <p>May also be specified with the <code>term.color</code>
-<a href="reference/config.html">config value</a>.</p>
+<a href="../reference/config.html">config value</a>.</p>
 </div>
 </dd>
 </dl>
@@ -147,7 +147,7 @@ details.</p>
 <h2 id="cargo_owner_environment">ENVIRONMENT</h2>
 <div class="sectionbody">
 <div class="paragraph">
-<p>See <a href="reference/environment-variables.html">the reference</a> for
+<p>See <a href="../reference/environment-variables.html">the reference</a> for
 details on environment variables that Cargo reads.</p>
 </div>
 </div>
@@ -206,7 +206,7 @@ details on environment variables that Cargo reads.</p>
 <h2 id="cargo_owner_see_also">SEE ALSO</h2>
 <div class="sectionbody">
 <div class="paragraph">
-<p><a href="commands/index.html">cargo(1)</a>, <a href="commands/cargo-login.html">cargo-login(1)</a>, <a href="commands/cargo-publish.html">cargo-publish(1)</a></p>
+<p><a href="index.html">cargo(1)</a>, <a href="cargo-login.html">cargo-login(1)</a>, <a href="cargo-publish.html">cargo-publish(1)</a></p>
 </div>
 </div>
 </div>

--- a/src/doc/man/generated/cargo-package.html
+++ b/src/doc/man/generated/cargo-package.html
@@ -45,7 +45,7 @@ manifest.</p>
 </li>
 <li>
 <p><code>Cargo.lock</code> is automatically included if the package contains an
-executable binary or example target. <a href="commands/cargo-install.html">cargo-install(1)</a> will use the
+executable binary or example target. <a href="cargo-install.html">cargo-install(1)</a> will use the
 packaged lock file if the <code>--locked</code> flag is used.</p>
 </li>
 <li>
@@ -69,7 +69,7 @@ about the current VCS checkout hash if available (not included with
 fields in the manifest.</p>
 </div>
 <div class="paragraph">
-<p>See <a href="reference/publishing.html">the reference</a> for more details about
+<p>See <a href="../reference/publishing.html">the reference</a> for more details about
 packaging and publishing.</p>
 </div>
 </div>
@@ -114,14 +114,14 @@ architecture. The general format of the triple is
 list of supported targets.</p>
 <div class="paragraph">
 <p>This may also be specified with the <code>build.target</code>
-<a href="reference/config.html">config value</a>.</p>
+<a href="../reference/config.html">config value</a>.</p>
 </div>
 </dd>
 <dt class="hdlist1"><strong>--target-dir</strong> <em>DIRECTORY</em></dt>
 <dd>
 <p>Directory for all generated artifacts and intermediate files. May also be
 specified with the <code>CARGO_TARGET_DIR</code> environment variable, or the
-<code>build.target-dir</code> <a href="reference/config.html">config value</a>. Defaults
+<code>build.target-dir</code> <a href="../reference/config.html">config value</a>. Defaults
 to <code>target</code> in the root of the workspace.</p>
 </dd>
 </dl>
@@ -185,11 +185,11 @@ proceed without the network if possible.</p>
 <p>Beware that this may result in different dependency resolution than online
 mode. Cargo will restrict itself to crates that are downloaded locally, even
 if there might be a newer version as indicated in the local copy of the index.
-See the <a href="commands/cargo-fetch.html">cargo-fetch(1)</a> command to download dependencies before going
+See the <a href="cargo-fetch.html">cargo-fetch(1)</a> command to download dependencies before going
 offline.</p>
 </div>
 <div class="paragraph">
-<p>May also be specified with the <code>net.offline</code> <a href="reference/config.html">config value</a>.</p>
+<p>May also be specified with the <code>net.offline</code> <a href="../reference/config.html">config value</a>.</p>
 </div>
 </dd>
 </dl>
@@ -203,7 +203,7 @@ offline.</p>
 <dt class="hdlist1"><strong>--jobs</strong> <em>N</em></dt>
 <dd>
 <p>Number of parallel jobs to run. May also be specified with the
-<code>build.jobs</code> <a href="reference/config.html">config value</a>. Defaults to
+<code>build.jobs</code> <a href="../reference/config.html">config value</a>. Defaults to
 the number of CPUs.</p>
 </dd>
 </dl>
@@ -219,7 +219,7 @@ the number of CPUs.</p>
 <p>Use verbose output. May be specified twice for "very verbose" output which
 includes extra output such as dependency warnings and build script output.
 May also be specified with the <code>term.verbose</code>
-<a href="reference/config.html">config value</a>.</p>
+<a href="../reference/config.html">config value</a>.</p>
 </dd>
 <dt class="hdlist1"><strong>-q</strong></dt>
 <dt class="hdlist1"><strong>--quiet</strong></dt>
@@ -245,7 +245,7 @@ terminal.</p>
 </div>
 <div class="paragraph">
 <p>May also be specified with the <code>term.color</code>
-<a href="reference/config.html">config value</a>.</p>
+<a href="../reference/config.html">config value</a>.</p>
 </div>
 </dd>
 </dl>
@@ -274,7 +274,7 @@ details.</p>
 <h2 id="cargo_package_environment">ENVIRONMENT</h2>
 <div class="sectionbody">
 <div class="paragraph">
-<p>See <a href="reference/environment-variables.html">the reference</a> for
+<p>See <a href="../reference/environment-variables.html">the reference</a> for
 details on environment variables that Cargo reads.</p>
 </div>
 </div>
@@ -317,7 +317,7 @@ details on environment variables that Cargo reads.</p>
 <h2 id="cargo_package_see_also">SEE ALSO</h2>
 <div class="sectionbody">
 <div class="paragraph">
-<p><a href="commands/index.html">cargo(1)</a>, <a href="commands/cargo-publish.html">cargo-publish(1)</a></p>
+<p><a href="index.html">cargo(1)</a>, <a href="cargo-publish.html">cargo-publish(1)</a></p>
 </div>
 </div>
 </div>

--- a/src/doc/man/generated/cargo-pkgid.html
+++ b/src/doc/man/generated/cargo-pkgid.html
@@ -96,7 +96,7 @@ following:</p>
 <p>Use verbose output. May be specified twice for "very verbose" output which
 includes extra output such as dependency warnings and build script output.
 May also be specified with the <code>term.verbose</code>
-<a href="reference/config.html">config value</a>.</p>
+<a href="../reference/config.html">config value</a>.</p>
 </dd>
 <dt class="hdlist1"><strong>-q</strong></dt>
 <dt class="hdlist1"><strong>--quiet</strong></dt>
@@ -122,7 +122,7 @@ terminal.</p>
 </div>
 <div class="paragraph">
 <p>May also be specified with the <code>term.color</code>
-<a href="reference/config.html">config value</a>.</p>
+<a href="../reference/config.html">config value</a>.</p>
 </div>
 </dd>
 </dl>
@@ -160,11 +160,11 @@ proceed without the network if possible.</p>
 <p>Beware that this may result in different dependency resolution than online
 mode. Cargo will restrict itself to crates that are downloaded locally, even
 if there might be a newer version as indicated in the local copy of the index.
-See the <a href="commands/cargo-fetch.html">cargo-fetch(1)</a> command to download dependencies before going
+See the <a href="cargo-fetch.html">cargo-fetch(1)</a> command to download dependencies before going
 offline.</p>
 </div>
 <div class="paragraph">
-<p>May also be specified with the <code>net.offline</code> <a href="reference/config.html">config value</a>.</p>
+<p>May also be specified with the <code>net.offline</code> <a href="../reference/config.html">config value</a>.</p>
 </div>
 </dd>
 </dl>
@@ -193,7 +193,7 @@ details.</p>
 <h2 id="cargo_pkgid_environment">ENVIRONMENT</h2>
 <div class="sectionbody">
 <div class="paragraph">
-<p>See <a href="reference/environment-variables.html">the reference</a> for
+<p>See <a href="../reference/environment-variables.html">the reference</a> for
 details on environment variables that Cargo reads.</p>
 </div>
 </div>
@@ -252,7 +252,7 @@ details on environment variables that Cargo reads.</p>
 <h2 id="cargo_pkgid_see_also">SEE ALSO</h2>
 <div class="sectionbody">
 <div class="paragraph">
-<p><a href="commands/index.html">cargo(1)</a>, <a href="commands/cargo-generate-lockfile.html">cargo-generate-lockfile(1)</a>, <a href="commands/cargo-metadata.html">cargo-metadata(1)</a></p>
+<p><a href="index.html">cargo(1)</a>, <a href="cargo-generate-lockfile.html">cargo-generate-lockfile(1)</a>, <a href="cargo-metadata.html">cargo-metadata(1)</a></p>
 </div>
 </div>
 </div>

--- a/src/doc/man/generated/cargo-publish.html
+++ b/src/doc/man/generated/cargo-publish.html
@@ -33,7 +33,7 @@ registries you are allowed to publish to.</p>
 </div>
 </li>
 <li>
-<p>Create a <code>.crate</code> file by following the steps in <a href="commands/cargo-package.html">cargo-package(1)</a>.</p>
+<p>Create a <code>.crate</code> file by following the steps in <a href="cargo-package.html">cargo-package(1)</a>.</p>
 </li>
 <li>
 <p>Upload the crate to the registry. Note that the server will perform
@@ -43,10 +43,10 @@ additional checks on the crate.</p>
 </div>
 <div class="paragraph">
 <p>This command requires you to be authenticated with either the <code>--token</code> option
-or using <a href="commands/cargo-login.html">cargo-login(1)</a>.</p>
+or using <a href="cargo-login.html">cargo-login(1)</a>.</p>
 </div>
 <div class="paragraph">
-<p>See <a href="reference/publishing.html">the reference</a> for more details about
+<p>See <a href="../reference/publishing.html">the reference</a> for more details about
 packaging and publishing.</p>
 </div>
 </div>
@@ -65,9 +65,9 @@ packaging and publishing.</p>
 <dt class="hdlist1"><strong>--token</strong> <em>TOKEN</em></dt>
 <dd>
 <p>API token to use when authenticating. This overrides the token stored in
-the credentials file (which is created by <a href="commands/cargo-login.html">cargo-login(1)</a>).</p>
+the credentials file (which is created by <a href="cargo-login.html">cargo-login(1)</a>).</p>
 <div class="paragraph">
-<p><a href="reference/config.html">Cargo config</a> environment variables can be
+<p><a href="../reference/config.html">Cargo config</a> environment variables can be
 used to override the tokens stored in the credentials file. The token for
 crates.io may be specified with the <code>CARGO_REGISTRY_TOKEN</code> environment
 variable. Tokens for other registries may be specified with environment
@@ -89,7 +89,7 @@ of the registry in all capital letters.</p>
 </dd>
 <dt class="hdlist1"><strong>--registry</strong> <em>REGISTRY</em></dt>
 <dd>
-<p>Name of the registry to use. Registry names are defined in <a href="reference/config.html">Cargo config files</a>.
+<p>Name of the registry to use. Registry names are defined in <a href="../reference/config.html">Cargo config files</a>.
 If not specified, the default registry is used, which is defined by the
 <code>registry.default</code> config key which defaults to <code>crates-io</code>.</p>
 </dd>
@@ -108,14 +108,14 @@ architecture. The general format of the triple is
 list of supported targets.</p>
 <div class="paragraph">
 <p>This may also be specified with the <code>build.target</code>
-<a href="reference/config.html">config value</a>.</p>
+<a href="../reference/config.html">config value</a>.</p>
 </div>
 </dd>
 <dt class="hdlist1"><strong>--target-dir</strong> <em>DIRECTORY</em></dt>
 <dd>
 <p>Directory for all generated artifacts and intermediate files. May also be
 specified with the <code>CARGO_TARGET_DIR</code> environment variable, or the
-<code>build.target-dir</code> <a href="reference/config.html">config value</a>. Defaults
+<code>build.target-dir</code> <a href="../reference/config.html">config value</a>. Defaults
 to <code>target</code> in the root of the workspace.</p>
 </dd>
 </dl>
@@ -179,11 +179,11 @@ proceed without the network if possible.</p>
 <p>Beware that this may result in different dependency resolution than online
 mode. Cargo will restrict itself to crates that are downloaded locally, even
 if there might be a newer version as indicated in the local copy of the index.
-See the <a href="commands/cargo-fetch.html">cargo-fetch(1)</a> command to download dependencies before going
+See the <a href="cargo-fetch.html">cargo-fetch(1)</a> command to download dependencies before going
 offline.</p>
 </div>
 <div class="paragraph">
-<p>May also be specified with the <code>net.offline</code> <a href="reference/config.html">config value</a>.</p>
+<p>May also be specified with the <code>net.offline</code> <a href="../reference/config.html">config value</a>.</p>
 </div>
 </dd>
 </dl>
@@ -197,7 +197,7 @@ offline.</p>
 <dt class="hdlist1"><strong>--jobs</strong> <em>N</em></dt>
 <dd>
 <p>Number of parallel jobs to run. May also be specified with the
-<code>build.jobs</code> <a href="reference/config.html">config value</a>. Defaults to
+<code>build.jobs</code> <a href="../reference/config.html">config value</a>. Defaults to
 the number of CPUs.</p>
 </dd>
 </dl>
@@ -213,7 +213,7 @@ the number of CPUs.</p>
 <p>Use verbose output. May be specified twice for "very verbose" output which
 includes extra output such as dependency warnings and build script output.
 May also be specified with the <code>term.verbose</code>
-<a href="reference/config.html">config value</a>.</p>
+<a href="../reference/config.html">config value</a>.</p>
 </dd>
 <dt class="hdlist1"><strong>-q</strong></dt>
 <dt class="hdlist1"><strong>--quiet</strong></dt>
@@ -239,7 +239,7 @@ terminal.</p>
 </div>
 <div class="paragraph">
 <p>May also be specified with the <code>term.color</code>
-<a href="reference/config.html">config value</a>.</p>
+<a href="../reference/config.html">config value</a>.</p>
 </div>
 </dd>
 </dl>
@@ -268,7 +268,7 @@ details.</p>
 <h2 id="cargo_publish_environment">ENVIRONMENT</h2>
 <div class="sectionbody">
 <div class="paragraph">
-<p>See <a href="reference/environment-variables.html">the reference</a> for
+<p>See <a href="../reference/environment-variables.html">the reference</a> for
 details on environment variables that Cargo reads.</p>
 </div>
 </div>
@@ -311,7 +311,7 @@ details on environment variables that Cargo reads.</p>
 <h2 id="cargo_publish_see_also">SEE ALSO</h2>
 <div class="sectionbody">
 <div class="paragraph">
-<p><a href="commands/index.html">cargo(1)</a>, <a href="commands/cargo-package.html">cargo-package(1)</a>, <a href="commands/cargo-login.html">cargo-login(1)</a></p>
+<p><a href="index.html">cargo(1)</a>, <a href="cargo-package.html">cargo-package(1)</a>, <a href="cargo-login.html">cargo-login(1)</a></p>
 </div>
 </div>
 </div>

--- a/src/doc/man/generated/cargo-run.html
+++ b/src/doc/man/generated/cargo-run.html
@@ -37,7 +37,7 @@ flag can be used to choose a different package in a workspace.</p>
 <dt class="hdlist1"><strong>-p</strong> <em>SPEC</em></dt>
 <dt class="hdlist1"><strong>--package</strong> <em>SPEC</em></dt>
 <dd>
-<p>The package to run. See <a href="commands/cargo-pkgid.html">cargo-pkgid(1)</a> for
+<p>The package to run. See <a href="cargo-pkgid.html">cargo-pkgid(1)</a> for
 the SPEC format.</p>
 </dd>
 </dl>
@@ -102,7 +102,7 @@ architecture. The general format of the triple is
 list of supported targets.</p>
 <div class="paragraph">
 <p>This may also be specified with the <code>build.target</code>
-<a href="reference/config.html">config value</a>.</p>
+<a href="../reference/config.html">config value</a>.</p>
 </div>
 </dd>
 <dt class="hdlist1"><strong>--release</strong></dt>
@@ -121,7 +121,7 @@ list of supported targets.</p>
 <dd>
 <p>Directory for all generated artifacts and intermediate files. May also be
 specified with the <code>CARGO_TARGET_DIR</code> environment variable, or the
-<code>build.target-dir</code> <a href="reference/config.html">config value</a>. Defaults
+<code>build.target-dir</code> <a href="../reference/config.html">config value</a>. Defaults
 to <code>target</code> in the root of the workspace.</p>
 </dd>
 </dl>
@@ -137,7 +137,7 @@ to <code>target</code> in the root of the workspace.</p>
 <p>Use verbose output. May be specified twice for "very verbose" output which
 includes extra output such as dependency warnings and build script output.
 May also be specified with the <code>term.verbose</code>
-<a href="reference/config.html">config value</a>.</p>
+<a href="../reference/config.html">config value</a>.</p>
 </dd>
 <dt class="hdlist1"><strong>-q</strong></dt>
 <dt class="hdlist1"><strong>--quiet</strong></dt>
@@ -163,7 +163,7 @@ terminal.</p>
 </div>
 <div class="paragraph">
 <p>May also be specified with the <code>term.color</code>
-<a href="reference/config.html">config value</a>.</p>
+<a href="../reference/config.html">config value</a>.</p>
 </div>
 </dd>
 <dt class="hdlist1"><strong>--message-format</strong> <em>FMT</em></dt>
@@ -218,11 +218,11 @@ proceed without the network if possible.</p>
 <p>Beware that this may result in different dependency resolution than online
 mode. Cargo will restrict itself to crates that are downloaded locally, even
 if there might be a newer version as indicated in the local copy of the index.
-See the <a href="commands/cargo-fetch.html">cargo-fetch(1)</a> command to download dependencies before going
+See the <a href="cargo-fetch.html">cargo-fetch(1)</a> command to download dependencies before going
 offline.</p>
 </div>
 <div class="paragraph">
-<p>May also be specified with the <code>net.offline</code> <a href="reference/config.html">config value</a>.</p>
+<p>May also be specified with the <code>net.offline</code> <a href="../reference/config.html">config value</a>.</p>
 </div>
 </dd>
 </dl>
@@ -253,7 +253,7 @@ details.</p>
 <dt class="hdlist1"><strong>--jobs</strong> <em>N</em></dt>
 <dd>
 <p>Number of parallel jobs to run. May also be specified with the
-<code>build.jobs</code> <a href="reference/config.html">config value</a>. Defaults to
+<code>build.jobs</code> <a href="../reference/config.html">config value</a>. Defaults to
 the number of CPUs.</p>
 </dd>
 </dl>
@@ -267,7 +267,7 @@ the number of CPUs.</p>
 <div class="paragraph">
 <p>Profiles may be used to configure compiler options such as optimization levels
 and debug settings. See
-<a href="reference/manifest.html#the-profile-sections">the reference</a>
+<a href="../reference/manifest.html#the-profile-sections">the reference</a>
 for more details.</p>
 </div>
 <div class="paragraph">
@@ -311,7 +311,7 @@ for more details.</p>
 <h2 id="cargo_run_environment">ENVIRONMENT</h2>
 <div class="sectionbody">
 <div class="paragraph">
-<p>See <a href="reference/environment-variables.html">the reference</a> for
+<p>See <a href="../reference/environment-variables.html">the reference</a> for
 details on environment variables that Cargo reads.</p>
 </div>
 </div>
@@ -362,7 +362,7 @@ details on environment variables that Cargo reads.</p>
 <h2 id="cargo_run_see_also">SEE ALSO</h2>
 <div class="sectionbody">
 <div class="paragraph">
-<p><a href="commands/index.html">cargo(1)</a>, <a href="commands/cargo-build.html">cargo-build(1)</a></p>
+<p><a href="index.html">cargo(1)</a>, <a href="cargo-build.html">cargo-build(1)</a></p>
 </div>
 </div>
 </div>

--- a/src/doc/man/generated/cargo-rustc.html
+++ b/src/doc/man/generated/cargo-rustc.html
@@ -32,7 +32,7 @@ package the filters of <code>--lib</code>, <code>--bin</code>, etc, must be used
 target is compiled.
 To pass flags to all compiler processes spawned by Cargo, use the <code>RUSTFLAGS</code>
 environment variable or the <code>build.rustflags</code>
-<a href="reference/config.html">config value</a>.</p>
+<a href="../reference/config.html">config value</a>.</p>
 </div>
 </div>
 </div>
@@ -50,7 +50,7 @@ flag can be used to choose a different package in a workspace.</p>
 <dt class="hdlist1"><strong>-p</strong> <em>SPEC</em></dt>
 <dt class="hdlist1"><strong>--package</strong> <em>SPEC</em></dt>
 <dd>
-<p>The package to build. See <a href="commands/cargo-pkgid.html">cargo-pkgid(1)</a> for
+<p>The package to build. See <a href="cargo-pkgid.html">cargo-pkgid(1)</a> for
 the SPEC format.</p>
 </dd>
 </dl>
@@ -163,7 +163,7 @@ architecture. The general format of the triple is
 list of supported targets.</p>
 <div class="paragraph">
 <p>This may also be specified with the <code>build.target</code>
-<a href="reference/config.html">config value</a>.</p>
+<a href="../reference/config.html">config value</a>.</p>
 </div>
 </dd>
 <dt class="hdlist1"><strong>--release</strong></dt>
@@ -182,7 +182,7 @@ list of supported targets.</p>
 <dd>
 <p>Directory for all generated artifacts and intermediate files. May also be
 specified with the <code>CARGO_TARGET_DIR</code> environment variable, or the
-<code>build.target-dir</code> <a href="reference/config.html">config value</a>. Defaults
+<code>build.target-dir</code> <a href="../reference/config.html">config value</a>. Defaults
 to <code>target</code> in the root of the workspace.</p>
 </dd>
 </dl>
@@ -198,7 +198,7 @@ to <code>target</code> in the root of the workspace.</p>
 <p>Use verbose output. May be specified twice for "very verbose" output which
 includes extra output such as dependency warnings and build script output.
 May also be specified with the <code>term.verbose</code>
-<a href="reference/config.html">config value</a>.</p>
+<a href="../reference/config.html">config value</a>.</p>
 </dd>
 <dt class="hdlist1"><strong>-q</strong></dt>
 <dt class="hdlist1"><strong>--quiet</strong></dt>
@@ -224,7 +224,7 @@ terminal.</p>
 </div>
 <div class="paragraph">
 <p>May also be specified with the <code>term.color</code>
-<a href="reference/config.html">config value</a>.</p>
+<a href="../reference/config.html">config value</a>.</p>
 </div>
 </dd>
 <dt class="hdlist1"><strong>--message-format</strong> <em>FMT</em></dt>
@@ -279,11 +279,11 @@ proceed without the network if possible.</p>
 <p>Beware that this may result in different dependency resolution than online
 mode. Cargo will restrict itself to crates that are downloaded locally, even
 if there might be a newer version as indicated in the local copy of the index.
-See the <a href="commands/cargo-fetch.html">cargo-fetch(1)</a> command to download dependencies before going
+See the <a href="cargo-fetch.html">cargo-fetch(1)</a> command to download dependencies before going
 offline.</p>
 </div>
 <div class="paragraph">
-<p>May also be specified with the <code>net.offline</code> <a href="reference/config.html">config value</a>.</p>
+<p>May also be specified with the <code>net.offline</code> <a href="../reference/config.html">config value</a>.</p>
 </div>
 </dd>
 </dl>
@@ -314,7 +314,7 @@ details.</p>
 <dt class="hdlist1"><strong>--jobs</strong> <em>N</em></dt>
 <dd>
 <p>Number of parallel jobs to run. May also be specified with the
-<code>build.jobs</code> <a href="reference/config.html">config value</a>. Defaults to
+<code>build.jobs</code> <a href="../reference/config.html">config value</a>. Defaults to
 the number of CPUs.</p>
 </dd>
 </dl>
@@ -328,7 +328,7 @@ the number of CPUs.</p>
 <div class="paragraph">
 <p>Profiles may be used to configure compiler options such as optimization levels
 and debug settings. See
-<a href="reference/manifest.html#the-profile-sections">the reference</a>
+<a href="../reference/manifest.html#the-profile-sections">the reference</a>
 for more details.</p>
 </div>
 <div class="paragraph">
@@ -372,7 +372,7 @@ for more details.</p>
 <h2 id="cargo_rustc_environment">ENVIRONMENT</h2>
 <div class="sectionbody">
 <div class="paragraph">
-<p>See <a href="reference/environment-variables.html">the reference</a> for
+<p>See <a href="../reference/environment-variables.html">the reference</a> for
 details on environment variables that Cargo reads.</p>
 </div>
 </div>
@@ -424,7 +424,7 @@ the size of every type:</p>
 <h2 id="cargo_rustc_see_also">SEE ALSO</h2>
 <div class="sectionbody">
 <div class="paragraph">
-<p><a href="commands/index.html">cargo(1)</a>, <a href="commands/cargo-build.html">cargo-build(1)</a>, <a href="https://doc.rust-lang.org/rustc/index.html">rustc(1)</a></p>
+<p><a href="index.html">cargo(1)</a>, <a href="cargo-build.html">cargo-build(1)</a>, <a href="https://doc.rust-lang.org/rustc/index.html">rustc(1)</a></p>
 </div>
 </div>
 </div>

--- a/src/doc/man/generated/cargo-rustdoc.html
+++ b/src/doc/man/generated/cargo-rustdoc.html
@@ -61,7 +61,7 @@ flag can be used to choose a different package in a workspace.</p>
 <dt class="hdlist1"><strong>-p</strong> <em>SPEC</em></dt>
 <dt class="hdlist1"><strong>--package</strong> <em>SPEC</em></dt>
 <dd>
-<p>The package to document. See <a href="commands/cargo-pkgid.html">cargo-pkgid(1)</a> for
+<p>The package to document. See <a href="cargo-pkgid.html">cargo-pkgid(1)</a> for
 the SPEC format.</p>
 </dd>
 </dl>
@@ -176,7 +176,7 @@ architecture. The general format of the triple is
 list of supported targets.</p>
 <div class="paragraph">
 <p>This may also be specified with the <code>build.target</code>
-<a href="reference/config.html">config value</a>.</p>
+<a href="../reference/config.html">config value</a>.</p>
 </div>
 </dd>
 <dt class="hdlist1"><strong>--release</strong></dt>
@@ -195,7 +195,7 @@ list of supported targets.</p>
 <dd>
 <p>Directory for all generated artifacts and intermediate files. May also be
 specified with the <code>CARGO_TARGET_DIR</code> environment variable, or the
-<code>build.target-dir</code> <a href="reference/config.html">config value</a>. Defaults
+<code>build.target-dir</code> <a href="../reference/config.html">config value</a>. Defaults
 to <code>target</code> in the root of the workspace.</p>
 </dd>
 </dl>
@@ -211,7 +211,7 @@ to <code>target</code> in the root of the workspace.</p>
 <p>Use verbose output. May be specified twice for "very verbose" output which
 includes extra output such as dependency warnings and build script output.
 May also be specified with the <code>term.verbose</code>
-<a href="reference/config.html">config value</a>.</p>
+<a href="../reference/config.html">config value</a>.</p>
 </dd>
 <dt class="hdlist1"><strong>-q</strong></dt>
 <dt class="hdlist1"><strong>--quiet</strong></dt>
@@ -237,7 +237,7 @@ terminal.</p>
 </div>
 <div class="paragraph">
 <p>May also be specified with the <code>term.color</code>
-<a href="reference/config.html">config value</a>.</p>
+<a href="../reference/config.html">config value</a>.</p>
 </div>
 </dd>
 <dt class="hdlist1"><strong>--message-format</strong> <em>FMT</em></dt>
@@ -292,11 +292,11 @@ proceed without the network if possible.</p>
 <p>Beware that this may result in different dependency resolution than online
 mode. Cargo will restrict itself to crates that are downloaded locally, even
 if there might be a newer version as indicated in the local copy of the index.
-See the <a href="commands/cargo-fetch.html">cargo-fetch(1)</a> command to download dependencies before going
+See the <a href="cargo-fetch.html">cargo-fetch(1)</a> command to download dependencies before going
 offline.</p>
 </div>
 <div class="paragraph">
-<p>May also be specified with the <code>net.offline</code> <a href="reference/config.html">config value</a>.</p>
+<p>May also be specified with the <code>net.offline</code> <a href="../reference/config.html">config value</a>.</p>
 </div>
 </dd>
 </dl>
@@ -327,7 +327,7 @@ details.</p>
 <dt class="hdlist1"><strong>--jobs</strong> <em>N</em></dt>
 <dd>
 <p>Number of parallel jobs to run. May also be specified with the
-<code>build.jobs</code> <a href="reference/config.html">config value</a>. Defaults to
+<code>build.jobs</code> <a href="../reference/config.html">config value</a>. Defaults to
 the number of CPUs.</p>
 </dd>
 </dl>
@@ -341,7 +341,7 @@ the number of CPUs.</p>
 <div class="paragraph">
 <p>Profiles may be used to configure compiler options such as optimization levels
 and debug settings. See
-<a href="reference/manifest.html#the-profile-sections">the reference</a>
+<a href="../reference/manifest.html#the-profile-sections">the reference</a>
 for more details.</p>
 </div>
 <div class="paragraph">
@@ -385,7 +385,7 @@ for more details.</p>
 <h2 id="cargo_rustdoc_environment">ENVIRONMENT</h2>
 <div class="sectionbody">
 <div class="paragraph">
-<p>See <a href="reference/environment-variables.html">the reference</a> for
+<p>See <a href="../reference/environment-variables.html">the reference</a> for
 details on environment variables that Cargo reads.</p>
 </div>
 </div>
@@ -428,7 +428,7 @@ details on environment variables that Cargo reads.</p>
 <h2 id="cargo_rustdoc_see_also">SEE ALSO</h2>
 <div class="sectionbody">
 <div class="paragraph">
-<p><a href="commands/index.html">cargo(1)</a>, <a href="commands/cargo-doc.html">cargo-doc(1)</a>, <a href="https://doc.rust-lang.org/rustdoc/index.html">rustdoc(1)</a></p>
+<p><a href="index.html">cargo(1)</a>, <a href="cargo-doc.html">cargo-doc(1)</a>, <a href="https://doc.rust-lang.org/rustdoc/index.html">rustdoc(1)</a></p>
 </div>
 </div>
 </div>

--- a/src/doc/man/generated/cargo-search.html
+++ b/src/doc/man/generated/cargo-search.html
@@ -37,7 +37,7 @@ for copying into a <code>Cargo.toml</code> manifest.</p>
 </dd>
 <dt class="hdlist1"><strong>--registry</strong> <em>REGISTRY</em></dt>
 <dd>
-<p>Name of the registry to use. Registry names are defined in <a href="reference/config.html">Cargo config files</a>.
+<p>Name of the registry to use. Registry names are defined in <a href="../reference/config.html">Cargo config files</a>.
 If not specified, the default registry is used, which is defined by the
 <code>registry.default</code> config key which defaults to <code>crates-io</code>.</p>
 </dd>
@@ -54,7 +54,7 @@ If not specified, the default registry is used, which is defined by the
 <p>Use verbose output. May be specified twice for "very verbose" output which
 includes extra output such as dependency warnings and build script output.
 May also be specified with the <code>term.verbose</code>
-<a href="reference/config.html">config value</a>.</p>
+<a href="../reference/config.html">config value</a>.</p>
 </dd>
 <dt class="hdlist1"><strong>-q</strong></dt>
 <dt class="hdlist1"><strong>--quiet</strong></dt>
@@ -80,7 +80,7 @@ terminal.</p>
 </div>
 <div class="paragraph">
 <p>May also be specified with the <code>term.color</code>
-<a href="reference/config.html">config value</a>.</p>
+<a href="../reference/config.html">config value</a>.</p>
 </div>
 </dd>
 </dl>
@@ -109,7 +109,7 @@ details.</p>
 <h2 id="cargo_search_environment">ENVIRONMENT</h2>
 <div class="sectionbody">
 <div class="paragraph">
-<p>See <a href="reference/environment-variables.html">the reference</a> for
+<p>See <a href="../reference/environment-variables.html">the reference</a> for
 details on environment variables that Cargo reads.</p>
 </div>
 </div>
@@ -152,7 +152,7 @@ details on environment variables that Cargo reads.</p>
 <h2 id="cargo_search_see_also">SEE ALSO</h2>
 <div class="sectionbody">
 <div class="paragraph">
-<p><a href="commands/index.html">cargo(1)</a>, <a href="commands/cargo-install.html">cargo-install(1)</a>, <a href="commands/cargo-publish.html">cargo-publish(1)</a></p>
+<p><a href="index.html">cargo(1)</a>, <a href="cargo-install.html">cargo-install(1)</a>, <a href="cargo-publish.html">cargo-publish(1)</a></p>
 </div>
 </div>
 </div>

--- a/src/doc/man/generated/cargo-test.html
+++ b/src/doc/man/generated/cargo-test.html
@@ -86,7 +86,7 @@ manifest.</p>
 <dt class="hdlist1"><strong>-p</strong> <em>SPEC</em>&#8230;&#8203;</dt>
 <dt class="hdlist1"><strong>--package</strong> <em>SPEC</em>&#8230;&#8203;</dt>
 <dd>
-<p>Test only the specified packages. See <a href="commands/cargo-pkgid.html">cargo-pkgid(1)</a> for the
+<p>Test only the specified packages. See <a href="cargo-pkgid.html">cargo-pkgid(1)</a> for the
 SPEC format. This flag may be specified multiple times.</p>
 </dd>
 <dt class="hdlist1"><strong>--all</strong></dt>
@@ -250,7 +250,7 @@ architecture. The general format of the triple is
 list of supported targets.</p>
 <div class="paragraph">
 <p>This may also be specified with the <code>build.target</code>
-<a href="reference/config.html">config value</a>.</p>
+<a href="../reference/config.html">config value</a>.</p>
 </div>
 </dd>
 <dt class="hdlist1"><strong>--release</strong></dt>
@@ -269,7 +269,7 @@ list of supported targets.</p>
 <dd>
 <p>Directory for all generated artifacts and intermediate files. May also be
 specified with the <code>CARGO_TARGET_DIR</code> environment variable, or the
-<code>build.target-dir</code> <a href="reference/config.html">config value</a>. Defaults
+<code>build.target-dir</code> <a href="../reference/config.html">config value</a>. Defaults
 to <code>target</code> in the root of the workspace.</p>
 </dd>
 </dl>
@@ -295,7 +295,7 @@ results readable. Test output can be recovered (e.g., for debugging) by passing
 <p>Use verbose output. May be specified twice for "very verbose" output which
 includes extra output such as dependency warnings and build script output.
 May also be specified with the <code>term.verbose</code>
-<a href="reference/config.html">config value</a>.</p>
+<a href="../reference/config.html">config value</a>.</p>
 </dd>
 <dt class="hdlist1"><strong>-q</strong></dt>
 <dt class="hdlist1"><strong>--quiet</strong></dt>
@@ -321,7 +321,7 @@ terminal.</p>
 </div>
 <div class="paragraph">
 <p>May also be specified with the <code>term.color</code>
-<a href="reference/config.html">config value</a>.</p>
+<a href="../reference/config.html">config value</a>.</p>
 </div>
 </dd>
 <dt class="hdlist1"><strong>--message-format</strong> <em>FMT</em></dt>
@@ -376,11 +376,11 @@ proceed without the network if possible.</p>
 <p>Beware that this may result in different dependency resolution than online
 mode. Cargo will restrict itself to crates that are downloaded locally, even
 if there might be a newer version as indicated in the local copy of the index.
-See the <a href="commands/cargo-fetch.html">cargo-fetch(1)</a> command to download dependencies before going
+See the <a href="cargo-fetch.html">cargo-fetch(1)</a> command to download dependencies before going
 offline.</p>
 </div>
 <div class="paragraph">
-<p>May also be specified with the <code>net.offline</code> <a href="reference/config.html">config value</a>.</p>
+<p>May also be specified with the <code>net.offline</code> <a href="../reference/config.html">config value</a>.</p>
 </div>
 </dd>
 </dl>
@@ -421,7 +421,7 @@ includes an option to control the number of threads used:</p>
 <dt class="hdlist1"><strong>--jobs</strong> <em>N</em></dt>
 <dd>
 <p>Number of parallel jobs to run. May also be specified with the
-<code>build.jobs</code> <a href="reference/config.html">config value</a>. Defaults to
+<code>build.jobs</code> <a href="../reference/config.html">config value</a>. Defaults to
 the number of CPUs.</p>
 </dd>
 </dl>
@@ -435,7 +435,7 @@ the number of CPUs.</p>
 <div class="paragraph">
 <p>Profiles may be used to configure compiler options such as optimization levels
 and debug settings. See
-<a href="reference/manifest.html#the-profile-sections">the reference</a>
+<a href="../reference/manifest.html#the-profile-sections">the reference</a>
 for more details.</p>
 </div>
 <div class="paragraph">
@@ -488,7 +488,7 @@ or doctest.</p>
 <h2 id="cargo_test_environment">ENVIRONMENT</h2>
 <div class="sectionbody">
 <div class="paragraph">
-<p>See <a href="reference/environment-variables.html">the reference</a> for
+<p>See <a href="../reference/environment-variables.html">the reference</a> for
 details on environment variables that Cargo reads.</p>
 </div>
 </div>
@@ -539,7 +539,7 @@ details on environment variables that Cargo reads.</p>
 <h2 id="cargo_test_see_also">SEE ALSO</h2>
 <div class="sectionbody">
 <div class="paragraph">
-<p><a href="commands/index.html">cargo(1)</a>, <a href="commands/cargo-bench.html">cargo-bench(1)</a></p>
+<p><a href="index.html">cargo(1)</a>, <a href="cargo-bench.html">cargo-bench(1)</a></p>
 </div>
 </div>
 </div>

--- a/src/doc/man/generated/cargo-uninstall.html
+++ b/src/doc/man/generated/cargo-uninstall.html
@@ -14,9 +14,9 @@
 <h2 id="cargo_uninstall_description">DESCRIPTION</h2>
 <div class="sectionbody">
 <div class="paragraph">
-<p>This command removes a package installed with <a href="commands/cargo-install.html">cargo-install(1)</a>. The <em>SPEC</em>
+<p>This command removes a package installed with <a href="cargo-install.html">cargo-install(1)</a>. The <em>SPEC</em>
 argument is a package ID specification of the package to remove (see
-<a href="commands/cargo-pkgid.html">cargo-pkgid(1)</a>).</p>
+<a href="cargo-pkgid.html">cargo-pkgid(1)</a>).</p>
 </div>
 <div class="paragraph">
 <p>By default all binaries are removed for a crate but the <code>--bin</code> and
@@ -34,7 +34,7 @@ argument is a package ID specification of the package to remove (see
 <p><code>CARGO_INSTALL_ROOT</code> environment variable</p>
 </li>
 <li>
-<p><code>install.root</code> Cargo <a href="reference/config.html">config value</a></p>
+<p><code>install.root</code> Cargo <a href="../reference/config.html">config value</a></p>
 </li>
 <li>
 <p><code>CARGO_HOME</code> environment variable</p>
@@ -79,7 +79,7 @@ argument is a package ID specification of the package to remove (see
 <p>Use verbose output. May be specified twice for "very verbose" output which
 includes extra output such as dependency warnings and build script output.
 May also be specified with the <code>term.verbose</code>
-<a href="reference/config.html">config value</a>.</p>
+<a href="../reference/config.html">config value</a>.</p>
 </dd>
 <dt class="hdlist1"><strong>-q</strong></dt>
 <dt class="hdlist1"><strong>--quiet</strong></dt>
@@ -105,7 +105,7 @@ terminal.</p>
 </div>
 <div class="paragraph">
 <p>May also be specified with the <code>term.color</code>
-<a href="reference/config.html">config value</a>.</p>
+<a href="../reference/config.html">config value</a>.</p>
 </div>
 </dd>
 </dl>
@@ -134,7 +134,7 @@ details.</p>
 <h2 id="cargo_uninstall_environment">ENVIRONMENT</h2>
 <div class="sectionbody">
 <div class="paragraph">
-<p>See <a href="reference/environment-variables.html">the reference</a> for
+<p>See <a href="../reference/environment-variables.html">the reference</a> for
 details on environment variables that Cargo reads.</p>
 </div>
 </div>
@@ -177,7 +177,7 @@ details on environment variables that Cargo reads.</p>
 <h2 id="cargo_uninstall_see_also">SEE ALSO</h2>
 <div class="sectionbody">
 <div class="paragraph">
-<p><a href="commands/index.html">cargo(1)</a>, <a href="commands/cargo-install.html">cargo-install(1)</a></p>
+<p><a href="index.html">cargo(1)</a>, <a href="cargo-install.html">cargo-install(1)</a></p>
 </div>
 </div>
 </div>

--- a/src/doc/man/generated/cargo-update.html
+++ b/src/doc/man/generated/cargo-update.html
@@ -16,7 +16,7 @@
 <div class="paragraph">
 <p>This command will update dependencies in the <code>Cargo.lock</code> file to the latest
 version. It requires that the <code>Cargo.lock</code> file already exists as generated
-by commands such as <a href="commands/cargo-build.html">cargo-build(1)</a> or <a href="commands/cargo-generate-lockfile.html">cargo-generate-lockfile(1)</a>.</p>
+by commands such as <a href="cargo-build.html">cargo-build(1)</a> or <a href="cargo-generate-lockfile.html">cargo-generate-lockfile(1)</a>.</p>
 </div>
 </div>
 </div>
@@ -31,7 +31,7 @@ by commands such as <a href="commands/cargo-build.html">cargo-build(1)</a> or <a
 <dt class="hdlist1"><strong>--package</strong> <em>SPEC</em>&#8230;&#8203;</dt>
 <dd>
 <p>Update only the specified packages. This flag may be specified
-multiple times. See <a href="commands/cargo-pkgid.html">cargo-pkgid(1)</a> for the SPEC format.</p>
+multiple times. See <a href="cargo-pkgid.html">cargo-pkgid(1)</a> for the SPEC format.</p>
 <div class="paragraph">
 <p>If packages are specified with the <code>-p</code> flag, then a conservative update of
 the lockfile will be performed. This means that only the dependency specified
@@ -71,7 +71,7 @@ be a git revision (such as a SHA hash or tag).</p>
 <p>Use verbose output. May be specified twice for "very verbose" output which
 includes extra output such as dependency warnings and build script output.
 May also be specified with the <code>term.verbose</code>
-<a href="reference/config.html">config value</a>.</p>
+<a href="../reference/config.html">config value</a>.</p>
 </dd>
 <dt class="hdlist1"><strong>-q</strong></dt>
 <dt class="hdlist1"><strong>--quiet</strong></dt>
@@ -97,7 +97,7 @@ terminal.</p>
 </div>
 <div class="paragraph">
 <p>May also be specified with the <code>term.color</code>
-<a href="reference/config.html">config value</a>.</p>
+<a href="../reference/config.html">config value</a>.</p>
 </div>
 </dd>
 </dl>
@@ -135,11 +135,11 @@ proceed without the network if possible.</p>
 <p>Beware that this may result in different dependency resolution than online
 mode. Cargo will restrict itself to crates that are downloaded locally, even
 if there might be a newer version as indicated in the local copy of the index.
-See the <a href="commands/cargo-fetch.html">cargo-fetch(1)</a> command to download dependencies before going
+See the <a href="cargo-fetch.html">cargo-fetch(1)</a> command to download dependencies before going
 offline.</p>
 </div>
 <div class="paragraph">
-<p>May also be specified with the <code>net.offline</code> <a href="reference/config.html">config value</a>.</p>
+<p>May also be specified with the <code>net.offline</code> <a href="../reference/config.html">config value</a>.</p>
 </div>
 </dd>
 </dl>
@@ -168,7 +168,7 @@ details.</p>
 <h2 id="cargo_update_environment">ENVIRONMENT</h2>
 <div class="sectionbody">
 <div class="paragraph">
-<p>See <a href="reference/environment-variables.html">the reference</a> for
+<p>See <a href="../reference/environment-variables.html">the reference</a> for
 details on environment variables that Cargo reads.</p>
 </div>
 </div>
@@ -227,7 +227,7 @@ details on environment variables that Cargo reads.</p>
 <h2 id="cargo_update_see_also">SEE ALSO</h2>
 <div class="sectionbody">
 <div class="paragraph">
-<p><a href="commands/index.html">cargo(1)</a>, <a href="commands/cargo-generate-lockfile.html">cargo-generate-lockfile(1)</a></p>
+<p><a href="index.html">cargo(1)</a>, <a href="cargo-generate-lockfile.html">cargo-generate-lockfile(1)</a></p>
 </div>
 </div>
 </div>

--- a/src/doc/man/generated/cargo-vendor.html
+++ b/src/doc/man/generated/cargo-vendor.html
@@ -74,7 +74,7 @@ directory or any parent directory for the <code>Cargo.toml</code> file.</p>
 <p>Use verbose output. May be specified twice for "very verbose" output which
 includes extra output such as dependency warnings and build script output.
 May also be specified with the <code>term.verbose</code>
-<a href="reference/config.html">config value</a>.</p>
+<a href="../reference/config.html">config value</a>.</p>
 </dd>
 <dt class="hdlist1"><strong>-q</strong></dt>
 <dt class="hdlist1"><strong>--quiet</strong></dt>
@@ -100,7 +100,7 @@ terminal.</p>
 </div>
 <div class="paragraph">
 <p>May also be specified with the <code>term.color</code>
-<a href="reference/config.html">config value</a>.</p>
+<a href="../reference/config.html">config value</a>.</p>
 </div>
 </dd>
 </dl>
@@ -133,6 +133,23 @@ attempting to access the network to determine if it is out-of-date.</p>
 access.</p>
 </div>
 </dd>
+<dt class="hdlist1"><strong>--offline</strong></dt>
+<dd>
+<p>Prevents Cargo from accessing the network for any reason. Without this
+flag, Cargo will stop with an error if it needs to access the network and
+the network is not available. With this flag, Cargo will attempt to
+proceed without the network if possible.</p>
+<div class="paragraph">
+<p>Beware that this may result in different dependency resolution than online
+mode. Cargo will restrict itself to crates that are downloaded locally, even
+if there might be a newer version as indicated in the local copy of the index.
+See the <a href="cargo-fetch.html">cargo-fetch(1)</a> command to download dependencies before going
+offline.</p>
+</div>
+<div class="paragraph">
+<p>May also be specified with the <code>net.offline</code> <a href="../reference/config.html">config value</a>.</p>
+</div>
+</dd>
 </dl>
 </div>
 </div>
@@ -142,7 +159,7 @@ access.</p>
 <h2 id="cargo_vendor_environment">ENVIRONMENT</h2>
 <div class="sectionbody">
 <div class="paragraph">
-<p>See <a href="reference/environment-variables.html">the reference</a> for
+<p>See <a href="../reference/environment-variables.html">the reference</a> for
 details on environment variables that Cargo reads.</p>
 </div>
 </div>
@@ -201,7 +218,7 @@ details on environment variables that Cargo reads.</p>
 <h2 id="cargo_vendor_see_also">SEE ALSO</h2>
 <div class="sectionbody">
 <div class="paragraph">
-<p><a href="commands/index.html">cargo(1)</a></p>
+<p><a href="index.html">cargo(1)</a></p>
 </div>
 </div>
 </div>

--- a/src/doc/man/generated/cargo-verify-project.html
+++ b/src/doc/man/generated/cargo-verify-project.html
@@ -45,7 +45,7 @@ JSON object with the result. A successful validation will display:</p>
 <p>Use verbose output. May be specified twice for "very verbose" output which
 includes extra output such as dependency warnings and build script output.
 May also be specified with the <code>term.verbose</code>
-<a href="reference/config.html">config value</a>.</p>
+<a href="../reference/config.html">config value</a>.</p>
 </dd>
 <dt class="hdlist1"><strong>-q</strong></dt>
 <dt class="hdlist1"><strong>--quiet</strong></dt>
@@ -71,7 +71,7 @@ terminal.</p>
 </div>
 <div class="paragraph">
 <p>May also be specified with the <code>term.color</code>
-<a href="reference/config.html">config value</a>.</p>
+<a href="../reference/config.html">config value</a>.</p>
 </div>
 </dd>
 </dl>
@@ -109,11 +109,11 @@ proceed without the network if possible.</p>
 <p>Beware that this may result in different dependency resolution than online
 mode. Cargo will restrict itself to crates that are downloaded locally, even
 if there might be a newer version as indicated in the local copy of the index.
-See the <a href="commands/cargo-fetch.html">cargo-fetch(1)</a> command to download dependencies before going
+See the <a href="cargo-fetch.html">cargo-fetch(1)</a> command to download dependencies before going
 offline.</p>
 </div>
 <div class="paragraph">
-<p>May also be specified with the <code>net.offline</code> <a href="reference/config.html">config value</a>.</p>
+<p>May also be specified with the <code>net.offline</code> <a href="../reference/config.html">config value</a>.</p>
 </div>
 </dd>
 </dl>
@@ -142,7 +142,7 @@ details.</p>
 <h2 id="cargo_verify_project_environment">ENVIRONMENT</h2>
 <div class="sectionbody">
 <div class="paragraph">
-<p>See <a href="reference/environment-variables.html">the reference</a> for
+<p>See <a href="../reference/environment-variables.html">the reference</a> for
 details on environment variables that Cargo reads.</p>
 </div>
 </div>
@@ -185,7 +185,7 @@ details on environment variables that Cargo reads.</p>
 <h2 id="cargo_verify_project_see_also">SEE ALSO</h2>
 <div class="sectionbody">
 <div class="paragraph">
-<p><a href="commands/index.html">cargo(1)</a>, <a href="commands/cargo-package.html">cargo-package(1)</a></p>
+<p><a href="index.html">cargo(1)</a>, <a href="cargo-package.html">cargo-package(1)</a></p>
 </div>
 </div>
 </div>

--- a/src/doc/man/generated/cargo-version.html
+++ b/src/doc/man/generated/cargo-version.html
@@ -70,7 +70,7 @@ cargo -V</pre>
 <h2 id="cargo_version_see_also">SEE ALSO</h2>
 <div class="sectionbody">
 <div class="paragraph">
-<p><a href="commands/index.html">cargo(1)</a></p>
+<p><a href="index.html">cargo(1)</a></p>
 </div>
 </div>
 </div>

--- a/src/doc/man/generated/cargo-yank.html
+++ b/src/doc/man/generated/cargo-yank.html
@@ -25,7 +25,7 @@ crates to be locked to any yanked version.</p>
 </div>
 <div class="paragraph">
 <p>This command requires you to be authenticated with either the <code>--token</code> option
-or using <a href="commands/cargo-login.html">cargo-login(1)</a>.</p>
+or using <a href="cargo-login.html">cargo-login(1)</a>.</p>
 </div>
 <div class="paragraph">
 <p>If the crate name is not specified, it will use the package name from the
@@ -51,9 +51,9 @@ current directory.</p>
 <dt class="hdlist1"><strong>--token</strong> <em>TOKEN</em></dt>
 <dd>
 <p>API token to use when authenticating. This overrides the token stored in
-the credentials file (which is created by <a href="commands/cargo-login.html">cargo-login(1)</a>).</p>
+the credentials file (which is created by <a href="cargo-login.html">cargo-login(1)</a>).</p>
 <div class="paragraph">
-<p><a href="reference/config.html">Cargo config</a> environment variables can be
+<p><a href="../reference/config.html">Cargo config</a> environment variables can be
 used to override the tokens stored in the credentials file. The token for
 crates.io may be specified with the <code>CARGO_REGISTRY_TOKEN</code> environment
 variable. Tokens for other registries may be specified with environment
@@ -67,7 +67,7 @@ of the registry in all capital letters.</p>
 </dd>
 <dt class="hdlist1"><strong>--registry</strong> <em>REGISTRY</em></dt>
 <dd>
-<p>Name of the registry to use. Registry names are defined in <a href="reference/config.html">Cargo config files</a>.
+<p>Name of the registry to use. Registry names are defined in <a href="../reference/config.html">Cargo config files</a>.
 If not specified, the default registry is used, which is defined by the
 <code>registry.default</code> config key which defaults to <code>crates-io</code>.</p>
 </dd>
@@ -84,7 +84,7 @@ If not specified, the default registry is used, which is defined by the
 <p>Use verbose output. May be specified twice for "very verbose" output which
 includes extra output such as dependency warnings and build script output.
 May also be specified with the <code>term.verbose</code>
-<a href="reference/config.html">config value</a>.</p>
+<a href="../reference/config.html">config value</a>.</p>
 </dd>
 <dt class="hdlist1"><strong>-q</strong></dt>
 <dt class="hdlist1"><strong>--quiet</strong></dt>
@@ -110,7 +110,7 @@ terminal.</p>
 </div>
 <div class="paragraph">
 <p>May also be specified with the <code>term.color</code>
-<a href="reference/config.html">config value</a>.</p>
+<a href="../reference/config.html">config value</a>.</p>
 </div>
 </dd>
 </dl>
@@ -139,7 +139,7 @@ details.</p>
 <h2 id="cargo_yank_environment">ENVIRONMENT</h2>
 <div class="sectionbody">
 <div class="paragraph">
-<p>See <a href="reference/environment-variables.html">the reference</a> for
+<p>See <a href="../reference/environment-variables.html">the reference</a> for
 details on environment variables that Cargo reads.</p>
 </div>
 </div>
@@ -182,7 +182,7 @@ details on environment variables that Cargo reads.</p>
 <h2 id="cargo_yank_see_also">SEE ALSO</h2>
 <div class="sectionbody">
 <div class="paragraph">
-<p><a href="commands/index.html">cargo(1)</a>, <a href="commands/cargo-login.html">cargo-login(1)</a>, <a href="commands/cargo-publish.html">cargo-publish(1)</a></p>
+<p><a href="index.html">cargo(1)</a>, <a href="cargo-login.html">cargo-login(1)</a>, <a href="cargo-publish.html">cargo-publish(1)</a></p>
 </div>
 </div>
 </div>

--- a/src/doc/man/generated/cargo.html
+++ b/src/doc/man/generated/cargo.html
@@ -30,47 +30,47 @@ available at <a href="https://rust-lang.org" class="bare">https://rust-lang.org<
 <h3 id="_build_commands">Build Commands</h3>
 <div class="dlist">
 <dl>
-<dt class="hdlist1"><a href="commands/cargo-bench.html">cargo-bench(1)</a></dt>
+<dt class="hdlist1"><a href="cargo-bench.html">cargo-bench(1)</a></dt>
 <dd>
 <p>Execute benchmarks of a package.</p>
 </dd>
-<dt class="hdlist1"><a href="commands/cargo-build.html">cargo-build(1)</a></dt>
+<dt class="hdlist1"><a href="cargo-build.html">cargo-build(1)</a></dt>
 <dd>
 <p>Compile a package.</p>
 </dd>
-<dt class="hdlist1"><a href="commands/cargo-check.html">cargo-check(1)</a></dt>
+<dt class="hdlist1"><a href="cargo-check.html">cargo-check(1)</a></dt>
 <dd>
 <p>Check a local package and all of its dependencies for errors.</p>
 </dd>
-<dt class="hdlist1"><a href="commands/cargo-clean.html">cargo-clean(1)</a></dt>
+<dt class="hdlist1"><a href="cargo-clean.html">cargo-clean(1)</a></dt>
 <dd>
 <p>Remove artifacts that Cargo has generated in the past.</p>
 </dd>
-<dt class="hdlist1"><a href="commands/cargo-doc.html">cargo-doc(1)</a></dt>
+<dt class="hdlist1"><a href="cargo-doc.html">cargo-doc(1)</a></dt>
 <dd>
 <p>Build a package&#8217;s documentation.</p>
 </dd>
-<dt class="hdlist1"><a href="commands/cargo-fetch.html">cargo-fetch(1)</a></dt>
+<dt class="hdlist1"><a href="cargo-fetch.html">cargo-fetch(1)</a></dt>
 <dd>
 <p>Fetch dependencies of a package from the network.</p>
 </dd>
-<dt class="hdlist1"><a href="commands/cargo-fix.html">cargo-fix(1)</a></dt>
+<dt class="hdlist1"><a href="cargo-fix.html">cargo-fix(1)</a></dt>
 <dd>
 <p>Automatically fix lint warnings reported by rustc.</p>
 </dd>
-<dt class="hdlist1"><a href="commands/cargo-run.html">cargo-run(1)</a></dt>
+<dt class="hdlist1"><a href="cargo-run.html">cargo-run(1)</a></dt>
 <dd>
 <p>Run a binary or example of the local package.</p>
 </dd>
-<dt class="hdlist1"><a href="commands/cargo-rustc.html">cargo-rustc(1)</a></dt>
+<dt class="hdlist1"><a href="cargo-rustc.html">cargo-rustc(1)</a></dt>
 <dd>
 <p>Compile a package, and pass extra options to the compiler.</p>
 </dd>
-<dt class="hdlist1"><a href="commands/cargo-rustdoc.html">cargo-rustdoc(1)</a></dt>
+<dt class="hdlist1"><a href="cargo-rustdoc.html">cargo-rustdoc(1)</a></dt>
 <dd>
 <p>Build a package&#8217;s documentation, using specified custom flags.</p>
 </dd>
-<dt class="hdlist1"><a href="commands/cargo-test.html">cargo-test(1)</a></dt>
+<dt class="hdlist1"><a href="cargo-test.html">cargo-test(1)</a></dt>
 <dd>
 <p>Execute unit and integration tests of a package.</p>
 </dd>
@@ -81,28 +81,28 @@ available at <a href="https://rust-lang.org" class="bare">https://rust-lang.org<
 <h3 id="_manifest_commands">Manifest Commands</h3>
 <div class="dlist">
 <dl>
-<dt class="hdlist1"><a href="commands/cargo-generate-lockfile.html">cargo-generate-lockfile(1)</a></dt>
+<dt class="hdlist1"><a href="cargo-generate-lockfile.html">cargo-generate-lockfile(1)</a></dt>
 <dd>
 <p>Generate <code>Cargo.lock</code> for a project.</p>
 </dd>
-<dt class="hdlist1"><a href="commands/cargo-locate-project.html">cargo-locate-project(1)</a></dt>
+<dt class="hdlist1"><a href="cargo-locate-project.html">cargo-locate-project(1)</a></dt>
 <dd>
 <p>Print a JSON representation of a <code>Cargo.toml</code> file&#8217;s location.</p>
 </dd>
-<dt class="hdlist1"><a href="commands/cargo-metadata.html">cargo-metadata(1)</a></dt>
+<dt class="hdlist1"><a href="cargo-metadata.html">cargo-metadata(1)</a></dt>
 <dd>
 <p>Output the resolved dependencies of a package, the concrete used versions
 including overrides, in machine-readable format.</p>
 </dd>
-<dt class="hdlist1"><a href="commands/cargo-pkgid.html">cargo-pkgid(1)</a></dt>
+<dt class="hdlist1"><a href="cargo-pkgid.html">cargo-pkgid(1)</a></dt>
 <dd>
 <p>Print a fully qualified package specification.</p>
 </dd>
-<dt class="hdlist1"><a href="commands/cargo-update.html">cargo-update(1)</a></dt>
+<dt class="hdlist1"><a href="cargo-update.html">cargo-update(1)</a></dt>
 <dd>
 <p>Update dependencies as recorded in the local lock file.</p>
 </dd>
-<dt class="hdlist1"><a href="commands/cargo-verify-project.html">cargo-verify-project(1)</a></dt>
+<dt class="hdlist1"><a href="cargo-verify-project.html">cargo-verify-project(1)</a></dt>
 <dd>
 <p>Check correctness of crate manifest.</p>
 </dd>
@@ -113,23 +113,23 @@ including overrides, in machine-readable format.</p>
 <h3 id="_package_commands">Package Commands</h3>
 <div class="dlist">
 <dl>
-<dt class="hdlist1"><a href="commands/cargo-init.html">cargo-init(1)</a></dt>
+<dt class="hdlist1"><a href="cargo-init.html">cargo-init(1)</a></dt>
 <dd>
 <p>Create a new Cargo package in an existing directory.</p>
 </dd>
-<dt class="hdlist1"><a href="commands/cargo-install.html">cargo-install(1)</a></dt>
+<dt class="hdlist1"><a href="cargo-install.html">cargo-install(1)</a></dt>
 <dd>
 <p>Build and install a Rust binary.</p>
 </dd>
-<dt class="hdlist1"><a href="commands/cargo-new.html">cargo-new(1)</a></dt>
+<dt class="hdlist1"><a href="cargo-new.html">cargo-new(1)</a></dt>
 <dd>
 <p>Create a new Cargo package.</p>
 </dd>
-<dt class="hdlist1"><a href="commands/cargo-search.html">cargo-search(1)</a></dt>
+<dt class="hdlist1"><a href="cargo-search.html">cargo-search(1)</a></dt>
 <dd>
 <p>Search packages in crates.io.</p>
 </dd>
-<dt class="hdlist1"><a href="commands/cargo-uninstall.html">cargo-uninstall(1)</a></dt>
+<dt class="hdlist1"><a href="cargo-uninstall.html">cargo-uninstall(1)</a></dt>
 <dd>
 <p>Remove a Rust binary.</p>
 </dd>
@@ -140,23 +140,23 @@ including overrides, in machine-readable format.</p>
 <h3 id="_publishing_commands">Publishing Commands</h3>
 <div class="dlist">
 <dl>
-<dt class="hdlist1"><a href="commands/cargo-login.html">cargo-login(1)</a></dt>
+<dt class="hdlist1"><a href="cargo-login.html">cargo-login(1)</a></dt>
 <dd>
 <p>Save an API token from the registry locally.</p>
 </dd>
-<dt class="hdlist1"><a href="commands/cargo-owner.html">cargo-owner(1)</a></dt>
+<dt class="hdlist1"><a href="cargo-owner.html">cargo-owner(1)</a></dt>
 <dd>
 <p>Manage the owners of a crate on the registry.</p>
 </dd>
-<dt class="hdlist1"><a href="commands/cargo-package.html">cargo-package(1)</a></dt>
+<dt class="hdlist1"><a href="cargo-package.html">cargo-package(1)</a></dt>
 <dd>
 <p>Assemble the local package into a distributable tarball.</p>
 </dd>
-<dt class="hdlist1"><a href="commands/cargo-publish.html">cargo-publish(1)</a></dt>
+<dt class="hdlist1"><a href="cargo-publish.html">cargo-publish(1)</a></dt>
 <dd>
 <p>Upload a package to the registry.</p>
 </dd>
-<dt class="hdlist1"><a href="commands/cargo-yank.html">cargo-yank(1)</a></dt>
+<dt class="hdlist1"><a href="cargo-yank.html">cargo-yank(1)</a></dt>
 <dd>
 <p>Remove a pushed crate from the index.</p>
 </dd>
@@ -167,11 +167,11 @@ including overrides, in machine-readable format.</p>
 <h3 id="_general_commands">General Commands</h3>
 <div class="dlist">
 <dl>
-<dt class="hdlist1"><a href="commands/cargo-help.html">cargo-help(1)</a></dt>
+<dt class="hdlist1"><a href="cargo-help.html">cargo-help(1)</a></dt>
 <dd>
 <p>Display help information about Cargo.</p>
 </dd>
-<dt class="hdlist1"><a href="commands/cargo-version.html">cargo-version(1)</a></dt>
+<dt class="hdlist1"><a href="cargo-version.html">cargo-version(1)</a></dt>
 <dd>
 <p>Show version information.</p>
 </dd>
@@ -216,7 +216,7 @@ an error message (for example, <code>E0004</code>).</p>
 <p>Use verbose output. May be specified twice for "very verbose" output which
 includes extra output such as dependency warnings and build script output.
 May also be specified with the <code>term.verbose</code>
-<a href="reference/config.html">config value</a>.</p>
+<a href="../reference/config.html">config value</a>.</p>
 </dd>
 <dt class="hdlist1"><strong>-q</strong></dt>
 <dt class="hdlist1"><strong>--quiet</strong></dt>
@@ -242,7 +242,7 @@ terminal.</p>
 </div>
 <div class="paragraph">
 <p>May also be specified with the <code>term.color</code>
-<a href="reference/config.html">config value</a>.</p>
+<a href="../reference/config.html">config value</a>.</p>
 </div>
 </dd>
 </dl>
@@ -275,11 +275,11 @@ proceed without the network if possible.</p>
 <p>Beware that this may result in different dependency resolution than online
 mode. Cargo will restrict itself to crates that are downloaded locally, even
 if there might be a newer version as indicated in the local copy of the index.
-See the <a href="commands/cargo-fetch.html">cargo-fetch(1)</a> command to download dependencies before going
+See the <a href="cargo-fetch.html">cargo-fetch(1)</a> command to download dependencies before going
 offline.</p>
 </div>
 <div class="paragraph">
-<p>May also be specified with the <code>net.offline</code> <a href="reference/config.html">config value</a>.</p>
+<p>May also be specified with the <code>net.offline</code> <a href="../reference/config.html">config value</a>.</p>
 </div>
 </dd>
 </dl>
@@ -308,7 +308,7 @@ details.</p>
 <h2 id="_environment">ENVIRONMENT</h2>
 <div class="sectionbody">
 <div class="paragraph">
-<p>See <a href="reference/environment-variables.html">the reference</a> for
+<p>See <a href="../reference/environment-variables.html">the reference</a> for
 details on environment variables that Cargo reads.</p>
 </div>
 </div>
@@ -343,12 +343,12 @@ variable.</p>
 </dd>
 <dt class="hdlist1"><code>$CARGO_HOME/bin/</code></dt>
 <dd>
-<p>Binaries installed by <a href="commands/cargo-install.html">cargo-install(1)</a> will be located here. If using
+<p>Binaries installed by <a href="cargo-install.html">cargo-install(1)</a> will be located here. If using
 rustup, executables distributed with Rust are also located here.</p>
 </dd>
 <dt class="hdlist1"><code>$CARGO_HOME/config</code></dt>
 <dd>
-<p>The global configuration file. See <a href="reference/config.html">the reference</a>
+<p>The global configuration file. See <a href="../reference/config.html">the reference</a>
 for more information about configuration files.</p>
 </dd>
 <dt class="hdlist1"><code>.cargo/config</code></dt>

--- a/src/doc/src/appendix/glossary.md
+++ b/src/doc/src/appendix/glossary.md
@@ -172,27 +172,27 @@ The *workspace root* is the directory where the workspace's `Cargo.toml`
 manifest is located.
 
 
-[Cargo.toml vs Cargo.lock]: guide/cargo-toml-vs-cargo-lock.html
-[Directory Sources]: reference/source-replacement.html#directory-sources
-[Local Registry Sources]: reference/source-replacement.html#local-registry-sources
-[Source Replacement]: reference/source-replacement.html
-[cargo-unstable]: reference/unstable.html
-[config option]: reference/config.html
-[directory layout]: reference/manifest.html#the-project-layout
-[edition guide]: ../edition-guide/index.html
-[edition-field]: reference/manifest.html#the-edition-field-optional
-[environment variable]: reference/environment-variables.html
-[feature]: reference/manifest.html#the-features-section
-[git dependency]: reference/specifying-dependencies.html#specifying-dependencies-from-git-repositories
-[git source]: reference/source-replacement.html
-[integration-tests]: reference/manifest.html#integration-tests
-[manifest]: reference/manifest.html
-[path dependency]: reference/specifying-dependencies.html#specifying-path-dependencies
-[path overrides]: reference/specifying-dependencies.html#overriding-with-local-dependencies
-[pkgid-spec]: reference/pkgid-spec.html
+[Cargo.toml vs Cargo.lock]: ../guide/cargo-toml-vs-cargo-lock.md
+[Directory Sources]: ../reference/source-replacement.md#directory-sources
+[Local Registry Sources]: ../reference/source-replacement.md#local-registry-sources
+[Source Replacement]: ../reference/source-replacement.md
+[cargo-unstable]: ../reference/unstable.md
+[config option]: ../reference/config.md
+[directory layout]: ../reference/manifest.md#the-project-layout
+[edition guide]: ../../edition-guide/index.html
+[edition-field]: ../reference/manifest.md#the-edition-field-optional
+[environment variable]: ../reference/environment-variables.md
+[feature]: ../reference/manifest.md#the-features-section
+[git dependency]: ../reference/specifying-dependencies.md#specifying-dependencies-from-git-repositories
+[git source]: ../reference/source-replacement.md
+[integration-tests]: ../reference/manifest.md#integration-tests
+[manifest]: ../reference/manifest.md
+[path dependency]: ../reference/specifying-dependencies.md#specifying-path-dependencies
+[path overrides]: ../reference/specifying-dependencies.md#overriding-with-local-dependencies
+[pkgid-spec]: ../reference/pkgid-spec.md
 [rustdoc-unstable]: https://doc.rust-lang.org/nightly/rustdoc/unstable-features.html
-[target-feature]: ../reference/attributes/codegen.html#the-target_feature-attribute
-[targets]: reference/manifest.html#configuring-a-target
+[target-feature]: ../../reference/attributes/codegen.html#the-target_feature-attribute
+[targets]: ../reference/manifest.md#configuring-a-target
 [unstable-book]: https://doc.rust-lang.org/nightly/unstable-book/index.html
-[virtual]: reference/manifest.html#virtual-manifest
-[workspace]: reference/manifest.html#the-workspace-section
+[virtual]: ../reference/manifest.md#virtual-manifest
+[workspace]: ../reference/manifest.md#the-workspace-section

--- a/src/doc/src/faq.md
+++ b/src/doc/src/faq.md
@@ -50,7 +50,7 @@ Cargo handles compiling Rust code, but we know that many Rust packages
 link against C code. We also know that there are decades of tooling
 built up around compiling languages other than Rust.
 
-Our solution: Cargo allows a package to [specify a script](reference/build-scripts.html)
+Our solution: Cargo allows a package to [specify a script](reference/build-scripts.md)
 (written in Rust) to run before invoking `rustc`. Rust is leveraged to
 implement platform-specific configuration and refactor out common build
 functionality among packages.
@@ -74,7 +74,7 @@ on the platform. Cargo also supports [platform-specific
 dependencies][target-deps], and we plan to support more per-platform
 configuration in `Cargo.toml` in the future.
 
-[target-deps]: reference/specifying-dependencies.html#platform-specific-dependencies
+[target-deps]: reference/specifying-dependencies.md#platform-specific-dependencies
 
 In the longer-term, we’re looking at ways to conveniently cross-compile
 packages using Cargo.
@@ -83,7 +83,7 @@ packages using Cargo.
 
 We support environments through the use of [profiles][profile] to support:
 
-[profile]: reference/manifest.html#the-profile-sections
+[profile]: reference/manifest.md#the-profile-sections
 
 * environment-specific flags (like `-g --opt-level=0` for development
   and `--opt-level=3` for production).
@@ -190,4 +190,4 @@ shouldn't be necessary.
 For more information about vendoring, see documentation on [source
 replacement][replace].
 
-[replace]: reference/source-replacement.html
+[replace]: reference/source-replacement.md

--- a/src/doc/src/getting-started/first-steps.md
+++ b/src/doc/src/getting-started/first-steps.md
@@ -70,4 +70,4 @@ Hello, world!
 
 ### Going further
 
-For more details on using Cargo, check out the [Cargo Guide](guide/index.html)
+For more details on using Cargo, check out the [Cargo Guide](../guide/index.md)

--- a/src/doc/src/getting-started/index.md
+++ b/src/doc/src/getting-started/index.md
@@ -2,5 +2,5 @@
 
 To get started with Cargo, install Cargo (and Rust) and set up your first crate.
 
-* [Installation](getting-started/installation.html)
-* [First steps with Cargo](getting-started/first-steps.html)
+* [Installation](installation.md)
+* [First steps with Cargo](first-steps.md)

--- a/src/doc/src/guide/cargo-toml-vs-cargo-lock.md
+++ b/src/doc/src/guide/cargo-toml-vs-cargo-lock.md
@@ -13,7 +13,7 @@ If you’re building a non-end product, such as a rust library that other rust p
 like command-line tool or an application, or a system library with crate-type of `staticlib` or `cdylib`,
 check `Cargo.lock` into `git`. If you're curious about why that is, see
 ["Why do binaries have `Cargo.lock` in version control, but not libraries?" in the
-FAQ](faq.html#why-do-binaries-have-cargolock-in-version-control-but-not-libraries).
+FAQ](../faq.md#why-do-binaries-have-cargolock-in-version-control-but-not-libraries).
 
 Let’s dig in a little bit more.
 
@@ -99,5 +99,5 @@ $ cargo update -p rand   # updates just “rand”
 
 This will write out a new `Cargo.lock` with the new version information. Note
 that the argument to `cargo update` is actually a
-[Package ID Specification](reference/pkgid-spec.html) and `rand` is just a short
+[Package ID Specification](../reference/pkgid-spec.md) and `rand` is just a short
 specification.

--- a/src/doc/src/guide/dependencies.md
+++ b/src/doc/src/guide/dependencies.md
@@ -20,7 +20,7 @@ time = "0.1.12"
 ```
 
 The version string is a [semver] version requirement. The [specifying
-dependencies](reference/specifying-dependencies.html) docs have more information about
+dependencies](../reference/specifying-dependencies.md) docs have more information about
 the options you have here.
 
 [semver]: https://github.com/steveklabnik/semver#requirements

--- a/src/doc/src/guide/index.md
+++ b/src/doc/src/guide/index.md
@@ -3,12 +3,12 @@
 This guide will give you all that you need to know about how to use Cargo to
 develop Rust packages.
 
-* [Why Cargo Exists](guide/why-cargo-exists.html)
-* [Creating a New Package](guide/creating-a-new-project.html)
-* [Working on an Existing Cargo Package](guide/working-on-an-existing-project.html)
-* [Dependencies](guide/dependencies.html)
-* [Package Layout](guide/project-layout.html)
-* [Cargo.toml vs Cargo.lock](guide/cargo-toml-vs-cargo-lock.html)
-* [Tests](guide/tests.html)
-* [Continuous Integration](guide/continuous-integration.html)
-* [Build Cache](guide/build-cache.html)
+* [Why Cargo Exists](why-cargo-exists.md)
+* [Creating a New Package](creating-a-new-project.md)
+* [Working on an Existing Cargo Package](working-on-an-existing-project.md)
+* [Dependencies](dependencies.md)
+* [Package Layout](project-layout.md)
+* [Cargo.toml vs Cargo.lock](cargo-toml-vs-cargo-lock.md)
+* [Tests](tests.md)
+* [Continuous Integration](continuous-integration.md)
+* [Build Cache](build-cache.md)

--- a/src/doc/src/guide/project-layout.md
+++ b/src/doc/src/guide/project-layout.md
@@ -32,4 +32,4 @@ Cargo package:
 * Benchmarks go in the `benches` directory.
 
 These are explained in more detail in the [manifest
-description](reference/manifest.html#the-project-layout).
+description](../reference/manifest.md#the-project-layout).

--- a/src/doc/src/guide/tests.md
+++ b/src/doc/src/guide/tests.md
@@ -36,4 +36,4 @@ examples you’ve included and will also test the examples in your
 documentation. Please see the [testing guide][testing] in the Rust
 documentation for more details.
 
-[testing]: ../book/ch11-00-testing.html
+[testing]: ../../book/ch11-00-testing.html

--- a/src/doc/src/index.md
+++ b/src/doc/src/index.md
@@ -10,20 +10,20 @@ to this book on [GitHub].
 
 ### Sections
 
-**[Getting Started](getting-started/index.html)**
+**[Getting Started](getting-started/index.md)**
 
 To get started with Cargo, install Cargo (and Rust) and set up your first crate.
 
-**[Cargo Guide](guide/index.html)**
+**[Cargo Guide](guide/index.md)**
 
 The guide will give you all you need to know about how to use Cargo to develop
 Rust packages.
 
-**[Cargo Reference](reference/index.html)**
+**[Cargo Reference](reference/index.md)**
 
 The reference covers the details of various areas of Cargo.
 
-**[Frequently Asked Questions](faq.html)**
+**[Frequently Asked Questions](faq.md)**
 
 [rust]: https://www.rust-lang.org/
 [crates.io]: https://crates.io/

--- a/src/doc/src/reference/build-scripts.md
+++ b/src/doc/src/reference/build-scripts.md
@@ -41,7 +41,7 @@ all passed in the form of [environment variables][env].
 In addition to environment variables, the build script’s current directory is
 the source directory of the build script’s package.
 
-[env]: reference/environment-variables.html
+[env]: environment-variables.md
 
 ### Outputs of the Build Script
 
@@ -174,7 +174,7 @@ In other words, it’s forbidden to have two packages link to the same native
 library. Note, however, that there are [conventions in place][star-sys] to
 alleviate this.
 
-[star-sys]: #a-sys-packages
+[star-sys]: #-sys-packages
 
 As mentioned above in the output format, each build script can generate an
 arbitrary set of metadata in the form of key-value pairs. This metadata is
@@ -195,7 +195,7 @@ prevent running the build script in question altogether and instead supply the
 metadata ahead of time.
 
 To override a build script, place the following configuration in any acceptable
-Cargo [configuration location](reference/config.html).
+Cargo [configuration location](config.md).
 
 ```toml
 [target.x86_64-unknown-linux-gnu.foo]

--- a/src/doc/src/reference/config.md
+++ b/src/doc/src/reference/config.md
@@ -2,7 +2,7 @@
 
 This document will explain how Cargo’s configuration system works, as well as
 available keys or configuration. For configuration of a package through its
-manifest, see the [manifest format](reference/manifest.html).
+manifest, see the [manifest format](manifest.md).
 
 ### Hierarchical structure
 
@@ -196,7 +196,7 @@ be specified with environment variables of the form
 `CARGO_REGISTRIES_NAME_TOKEN` where `NAME` is the name of the registry in all
 capital letters.
 
-[`cargo login`]: commands/cargo-login.html
-[`cargo publish`]: commands/cargo-publish.html
-[env]: reference/environment-variables.html
-[source]: reference/source-replacement.html
+[`cargo login`]: ../commands/cargo-login.md
+[`cargo publish`]: ../commands/cargo-publish.md
+[env]: environment-variables.md
+[source]: source-replacement.md

--- a/src/doc/src/reference/environment-variables.md
+++ b/src/doc/src/reference/environment-variables.md
@@ -38,7 +38,7 @@ system:
 Note that Cargo will also read environment variables for `.cargo/config`
 configuration values, as described in [that documentation][config-env]
 
-[config-env]: reference/config.html#environment-variables
+[config-env]: config.md#environment-variables
 
 ### Environment variables Cargo sets for crates
 
@@ -130,11 +130,11 @@ let out_dir = env::var("OUT_DIR").unwrap();
                    about [cargo configuration][cargo-config] for more
                    information.
 
-[links]: reference/build-scripts.html#the-links-manifest-key
-[configuration]: ../reference/conditional-compilation.html
+[links]: build-scripts.md#the-links-manifest-key
+[configuration]: ../../reference/conditional-compilation.html
 [jobserver]: https://www.gnu.org/software/make/manual/html_node/Job-Slots.html
-[cargo-config]: reference/config.html
-[Target Triple]: appendix/glossary.html#target
+[cargo-config]: config.md
+[Target Triple]: ../appendix/glossary.md#target
 
 ### Environment variables Cargo sets for 3rd party subcommands
 

--- a/src/doc/src/reference/index.md
+++ b/src/doc/src/reference/index.md
@@ -2,13 +2,13 @@
 
 The reference covers the details of various areas of Cargo.
 
-* [Specifying Dependencies](reference/specifying-dependencies.html)
-* [The Manifest Format](reference/manifest.html)
-* [Configuration](reference/config.html)
-* [Environment Variables](reference/environment-variables.html)
-* [Build Scripts](reference/build-scripts.html)
-* [Publishing on crates.io](reference/publishing.html)
-* [Package ID Specifications](reference/pkgid-spec.html)
-* [Source Replacement](reference/source-replacement.html)
-* [External Tools](reference/external-tools.html)
-* [Unstable Features](reference/unstable.html)
+* [Specifying Dependencies](specifying-dependencies.md)
+* [The Manifest Format](manifest.md)
+* [Configuration](config.md)
+* [Environment Variables](environment-variables.md)
+* [Build Scripts](build-scripts.md)
+* [Publishing on crates.io](publishing.md)
+* [Package ID Specifications](pkgid-spec.md)
+* [Source Replacement](source-replacement.md)
+* [External Tools](external-tools.md)
+* [Unstable Features](unstable.md)

--- a/src/doc/src/reference/manifest.md
+++ b/src/doc/src/reference/manifest.md
@@ -27,7 +27,7 @@ a keyword. [crates.io][cratesio] imposes even more restrictions, such as
 enforcing only ASCII characters, not a reserved name, not a special Windows
 name such as "nul", is not too long, etc.
 
-[alphanumeric]: ../std/primitive.char.html#method.is_alphanumeric
+[alphanumeric]: ../../std/primitive.char.html#method.is_alphanumeric
 
 #### The `version` field
 
@@ -77,7 +77,7 @@ This field specifies a file in the package root which is a [build script] for
 building native code. More information can be found in the [build script
 guide][build script].
 
-[build script]: reference/build-scripts.html
+[build script]: build-scripts.md
 
 ```toml
 [package]
@@ -91,7 +91,7 @@ This field specifies the name of a native library that is being linked to.
 More information can be found in the [`links`][links] section of the build
 script guide.
 
-[links]: reference/build-scripts.html#the-links-manifest-key
+[links]: build-scripts.md#the-links-manifest-key
 
 ```toml
 [package]
@@ -377,7 +377,7 @@ default-run = "a"
 
 ### Dependency sections
 
-See the [specifying dependencies page](reference/specifying-dependencies.html) for
+See the [specifying dependencies page](specifying-dependencies.md) for
 information on the `[dependencies]`, `[dev-dependencies]`,
 `[build-dependencies]`, and target-specific `[target.*.dependencies]` sections.
 
@@ -710,7 +710,7 @@ may be composed of single files or directories with a `main.rs` file.
 To structure your code after you've created the files and folders for your
 package, you should remember to use Rust's module system, which you can read
 about in [the
-book](../book/ch07-00-managing-growing-projects-with-packages-crates-and-modules.html).
+book](../../book/ch07-00-managing-growing-projects-with-packages-crates-and-modules.html).
 
 See [Configuring a target](#configuring-a-target) below for more details on
 manually configuring target settings. See [Target
@@ -731,7 +731,7 @@ You can run individual executable examples with the command `cargo run --example
 
 Specify `crate-type` to make an example be compiled as a library (additional
 information about crate types is available in
-[The Rust Reference](../reference/linkage.html)):
+[The Rust Reference](../../reference/linkage.html)):
 
 ```toml
 [[example]]
@@ -909,7 +909,7 @@ The available options are `dylib`, `rlib`, `staticlib`, `cdylib`, and
 `proc-macro`.
 
 You can read more about the different crate types in the
-[Rust Reference Manual](../reference/linkage.html)
+[Rust Reference Manual](../../reference/linkage.html)
 
 ### The `[patch]` Section
 
@@ -953,7 +953,7 @@ technical specification of this feature.
 
 [RFC 1969]: https://github.com/rust-lang/rfcs/pull/1969
 [crates.io]: https://crates.io/
-[replace]: reference/specifying-dependencies.html#overriding-dependencies
+[replace]: specifying-dependencies.md#overriding-dependencies
 
 ### The `[replace]` Section
 
@@ -967,7 +967,7 @@ other copies. The syntax is similar to the `[dependencies]` section:
 ```
 
 Each key in the `[replace]` table is a [package ID
-specification](reference/pkgid-spec.html), which allows arbitrarily choosing a node in the
+specification](pkgid-spec.md), which allows arbitrarily choosing a node in the
 dependency graph to override. The value of each key is the same as the
 `[dependencies]` syntax for specifying dependencies, except that you can't
 specify features. Note that when a crate is overridden the copy it's overridden
@@ -977,11 +977,11 @@ source (e.g., git or a local path).
 More information about overriding dependencies can be found in the [overriding
 dependencies][replace] section of the documentation.
 
-[`cargo build`]: commands/cargo-build.html
-[`cargo init`]: commands/cargo-init.html
-[`cargo new`]: commands/cargo-new.html
-[`cargo run`]: commands/cargo-run.html
-[`cargo test`]: commands/cargo-test.html
+[`cargo build`]: ../commands/cargo-build.md
+[`cargo init`]: ../commands/cargo-init.md
+[`cargo new`]: ../commands/cargo-new.md
+[`cargo run`]: ../commands/cargo-run.md
+[`cargo test`]: ../commands/cargo-test.md
 [spdx-2.1-license-expressions]: https://spdx.org/spdx-specification-21-web-version#h.jxpfx0ykyb60
 [spdx-license-list-2.4]: https://github.com/spdx/license-list-data/tree/v2.4
 [spdx-license-list]: https://spdx.org/licenses/

--- a/src/doc/src/reference/publishing.md
+++ b/src/doc/src/reference/publishing.md
@@ -31,7 +31,7 @@ Keep in mind that crate names on [crates.io] are allocated on a first-come-first
 serve basis. Once a crate name is taken, it cannot be used for another crate.
 
 Check out the [metadata you can
-specify](reference/manifest.html#package-metadata) in `Cargo.toml` to ensure
+specify](manifest.md#package-metadata) in `Cargo.toml` to ensure
 your crate can be discovered more easily! Before publishing, make sure you have
 filled out the following fields:
 
@@ -84,7 +84,7 @@ $ cargo package --list
 Cargo will automatically ignore files ignored by your version control system
 when packaging, but if you want to specify an extra set of files to ignore you
 can use the [`exclude`
-key](reference/manifest.html#the-exclude-and-include-fields-optional) in the
+key](manifest.md#the-exclude-and-include-fields-optional) in the
 manifest:
 
 ```toml
@@ -123,7 +123,7 @@ And that’s it, you’ve now published your first crate!
 
 In order to release a new version, change the `version` value specified in
 your `Cargo.toml` manifest. Keep in mind [the semver
-rules](reference/manifest.html#the-version-field), and consult [RFC 1105] for
+rules](manifest.md#the-version-field), and consult [RFC 1105] for
 what constitutes a semver-breaking change. Then run [`cargo publish`] as
 described above to upload the new version.
 
@@ -227,7 +227,7 @@ actively denying third party access. To check this, you can go to:
 where `:org` is the name of the organization (e.g., `rust-lang`). You may see
 something like:
 
-![Organization Access Control](images/org-level-acl.png)
+![Organization Access Control](../images/org-level-acl.png)
 
 Where you may choose to explicitly remove [crates.io] from your organization’s
 blacklist, or simply press the “Remove Restrictions” button to allow all third
@@ -237,13 +237,13 @@ Alternatively, when [crates.io] requested the `read:org` scope, you could have
 explicitly whitelisted [crates.io] querying the org in question by pressing
 the “Grant Access” button next to its name:
 
-![Authentication Access Control](images/auth-level-acl.png)
+![Authentication Access Control](../images/auth-level-acl.png)
 
 [RFC 1105]: https://github.com/rust-lang/rfcs/blob/master/text/1105-api-evolution.md
 [Rust API Guidelines]: https://rust-lang-nursery.github.io/api-guidelines/
-[`cargo login`]: commands/cargo-login.html
-[`cargo package`]: commands/cargo-package.html
-[`cargo publish`]: commands/cargo-publish.html
+[`cargo login`]: ../commands/cargo-login.md
+[`cargo package`]: ../commands/cargo-package.md
+[`cargo publish`]: ../commands/cargo-publish.md
 [crates.io]: https://crates.io/
 [oauth-scopes]: https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/
 

--- a/src/doc/src/reference/registries.md
+++ b/src/doc/src/reference/registries.md
@@ -580,11 +580,11 @@ The "login" endpoint is not an actual API request. It exists solely for the
 [`cargo login`] command to display a URL to instruct a user to visit in a web
 browser to log in and retrieve an API token.
 
-[Source Replacement]: reference/source-replacement.html
-[`cargo login`]: commands/cargo-login.html
-[`cargo package`]: commands/cargo-package.html
-[`cargo publish`]: commands/cargo-publish.html
-[alphanumeric]: ../std/primitive.char.html#method.is_alphanumeric
-[config]: reference/config.html
+[Source Replacement]: source-replacement.md
+[`cargo login`]: ../commands/cargo-login.md
+[`cargo package`]: ../commands/cargo-package.md
+[`cargo publish`]: ../commands/cargo-publish.md
+[alphanumeric]: ../../std/primitive.char.html#method.is_alphanumeric
+[config]: config.md
 [crates.io]: https://crates.io/
-[publishing documentation]: reference/publishing.html#cargo-owner
+[publishing documentation]: publishing.md#cargo-owner

--- a/src/doc/src/reference/source-replacement.md
+++ b/src/doc/src/reference/source-replacement.md
@@ -25,9 +25,9 @@ patching a dependency or a private registry. Cargo supports patching
 dependencies through the usage of [the `[replace]` key][replace-section], and
 private registry support is described in [Registries][registries].
 
-[replace-section]: reference/manifest.html#the-replace-section
-[overriding]: reference/specifying-dependencies.html#overriding-dependencies
-[registries]: reference/registries.html
+[replace-section]: manifest.md#the-replace-section
+[overriding]: specifying-dependencies.md#overriding-dependencies
+[registries]: registries.md
 
 ### Configuration
 
@@ -72,7 +72,7 @@ git = "https://example.com/path/to/repo"
 # rev = "313f44e8"
 ```
 
-[config]: reference/config.html
+[config]: config.md
 
 ### Registry Sources
 

--- a/src/doc/src/reference/specifying-dependencies.md
+++ b/src/doc/src/reference/specifying-dependencies.md
@@ -12,7 +12,7 @@ to do each of these.
 
 Cargo is configured to look for dependencies on [crates.io] by default. Only
 the name and a version string are required in this case. In [the cargo
-guide](guide/index.html), we specified a dependency on the `time` crate:
+guide](../guide/index.md), we specified a dependency on the `time` crate:
 
 ```toml
 [dependencies]
@@ -114,7 +114,7 @@ to the name of the registry to use.
 some-crate = { version = "1.0", registry = "my-registry" }
 ```
 
-[registries documentation]: reference/registries.html
+[registries documentation]: registries.md
 
 ### Specifying dependencies from `git` repositories
 
@@ -144,7 +144,7 @@ rand = { git = "https://github.com/rust-lang-nursery/rand", branch = "next" }
 
 ### Specifying path dependencies
 
-Over time, our `hello_world` package from [the guide](guide/index.html) has
+Over time, our `hello_world` package from [the guide](../guide/index.md) has
 grown significantly in size! It’s gotten to the point that we probably want to
 split out a separate crate for others to use. To do this Cargo supports **path
 dependencies** which are typically sub-crates that live within one repository.
@@ -209,8 +209,8 @@ section][patch-section]. Historically some of these scenarios have been solved
 with [the `[replace]` section][replace-section], but we'll document the `[patch]`
 section here.
 
-[patch-section]: reference/manifest.html#the-patch-section
-[replace-section]: reference/manifest.html#the-replace-section
+[patch-section]: manifest.md#the-patch-section
+[replace-section]: manifest.md#the-replace-section
 
 ### Testing a bugfix
 
@@ -412,7 +412,7 @@ Path overrides are specified through `.cargo/config` instead of `Cargo.toml`,
 and you can find [more documentation about this configuration][config-docs].
 Inside of `.cargo/config` you'll specify a key called `paths`:
 
-[config-docs]: reference/config.html
+[config-docs]: config.md
 
 ```toml
 paths = ["/path/to/uuid"]
@@ -441,7 +441,7 @@ Cargo how to find local unpublished crates.
 
 Platform-specific dependencies take the same format, but are listed under a
 `target` section. Normally Rust-like [`#[cfg]`
-syntax](../reference/conditional-compilation.html) will be used to define
+syntax](../../reference/conditional-compilation.html) will be used to define
 these sections:
 
 ```toml
@@ -469,7 +469,7 @@ run `rustc --print=cfg --target=x86_64-pc-windows-msvc`.
 Unlike in your Rust source code,
 you cannot use `[target.'cfg(feature = "my_crate")'.dependencies]` to add
 dependencies based on optional crate features.
-Use [the `[features]` section](reference/manifest.html#the-features-section)
+Use [the `[features]` section](manifest.md#the-features-section)
 instead.
 
 In addition to `#[cfg]` syntax, Cargo also supports listing out the full target
@@ -560,7 +560,7 @@ features = ["secure-password", "civet"]
 ```
 
 More information about features can be found in the
-[manifest documentation](reference/manifest.html#the-features-section).
+[manifest documentation](manifest.md#the-features-section).
 
 ### Renaming dependencies in `Cargo.toml`
 

--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -102,7 +102,7 @@ Overrides can only be specified for dev and release profiles.
 Profiles can be specified in `.cargo/config` files. The `-Z config-profile`
 command-line flag is required to use this feature. The format is the same as
 in a `Cargo.toml` manifest. If found in multiple config files, settings will
-be merged using the regular [config hierarchy](reference/config.html#hierarchical-structure).
+be merged using the regular [config hierarchy](config.md#hierarchical-structure).
 Config settings take precedence over manifest settings.
 
 ```toml


### PR DESCRIPTION
This updates to mdbook 0.3 which uses relative links, which are much better
(the pages mostly work when viewing on GitHub for example).