### PR TITLE
Add a way to disable all nightly tests

### DIFF
--- a/tests/testsuite/support/mod.rs
+++ b/tests/testsuite/support/mod.rs
@@ -1650,7 +1650,9 @@ pub fn rustc_host() -> String {
 }
 
 pub fn is_nightly() -> bool {
-    RUSTC.with(|r| r.verbose_version.contains("-nightly") || r.verbose_version.contains("-dev"))
+    env::var("CARGO_TEST_DIABLE_NIGHTLY").is_err()
+        && RUSTC
+            .with(|r| r.verbose_version.contains("-nightly") || r.verbose_version.contains("-dev"))
 }
 
 pub fn process<T: AsRef<OsStr>>(t: T) -> cargo::util::ProcessBuilder {


### PR DESCRIPTION
One thing I'm realizing now is that we test a number of nightly features
of Cargo/rustc, but if they change in rustc then because
rust-lang/rust's CI run's Cargo's tests it could prevent those changes
from landing! The purpose of running Cargo's tests in CI in
rust-lang/rust is to ensure that Cargo generally works, but there's no
need to test the nightly features as that's Cargo's job.

As a result this adds an environment variable that will be set from
rust-lang/rust's CI which will disable these tests.