### PR TITLE
Fix a typo in an env var name

### DIFF
--- a/tests/testsuite/support/mod.rs
+++ b/tests/testsuite/support/mod.rs
@@ -1650,7 +1650,7 @@ pub fn rustc_host() -> String {
 }
 
 pub fn is_nightly() -> bool {
-    env::var("CARGO_TEST_DIABLE_NIGHTLY").is_err()
+    env::var("CARGO_TEST_DISABLE_NIGHTLY").is_err()
         && RUSTC
             .with(|r| r.verbose_version.contains("-nightly") || r.verbose_version.contains("-dev"))
 }


### PR DESCRIPTION
Not actually used yet in rust-lang/rust, but may as well try to get it
right on the first try.