### PR TITLE
Optimize runtime of `#[cargo_test_macro]`

### DIFF
--- a/crates/cargo-test-macro/Cargo.toml
+++ b/crates/cargo-test-macro/Cargo.toml
@@ -11,7 +11,3 @@ description = "Helper proc-macro for Cargo's testsuite."
 
 [lib]
 proc-macro = true
-
-[dependencies]
-quote = "0.6"
-syn = { version = "0.15", features = ["full"] }


### PR DESCRIPTION
I've noticed recently that the incremental compile time for our test
suite has felt like it's increased quite a bit. I think one reason is
that everything has to go through `#[cargo_test_macro]` unconditionally
on all incremental builds, and wow do we have a lot of tests being
pumped through that macro.

Instrumenting the macro a little bit shows that we spend nearly 2.5
seconds on each compilation simply executing this macro (note that it's
in debug mode as well, not release since we typically don't execute
tests in release mode.

This commit instead drops the usage of `syn` and `quote` in favor of a
"raw procedural macro" which is much more optimized for just our use
case, even in debug mode. This drops the collective time spent in the
macro to 0.2 seconds, even in debug mode!