### PR TITLE
Add `cargo clean --no-deps`

### DIFF
--- a/src/bin/cargo/commands/clean.rs
+++ b/src/bin/cargo/commands/clean.rs
@@ -12,6 +12,7 @@ pub fn cli() -> App {
         .arg_target_dir()
         .arg_release("Whether or not to clean release artifacts")
         .arg_doc("Whether or not to clean just the documentation directory")
+        .arg(opt("no-deps", "Don't clean dependency artifacts"))
         .after_help(
             "\
 If the `--package` argument is given, then SPEC is a package ID specification
@@ -30,6 +31,7 @@ pub fn exec(config: &mut Config, args: &ArgMatches<'_>) -> CliResult {
         target: args.target(),
         release: args.is_present("release"),
         doc: args.is_present("doc"),
+        no_deps: args.is_present("no-deps"),
     };
     ops::clean(&ws, &opts)?;
     Ok(())


### PR DESCRIPTION
I sometimes find myself wanting to clean out a project without blowing away the dependencies. The `-p` option works, but can be tedious, especially in a multi-crate workspace.

This PR add a `--no-deps` option to preserve all non-workspace artifacts. The flag name and docs are modeled after `cargo doc --no-deps`.

Inspired by: https://github.com/rust-lang/cargo/issues/573#issuecomment-468793358