### PR TITLE
Force clippy to run.

### DIFF
--- a/src/bin/cargo/commands/clippy.rs
+++ b/src/bin/cargo/commands/clippy.rs
@@ -71,6 +71,7 @@ pub fn exec(config: &mut Config, args: &ArgMatches<'_>) -> CliResult {
 
     let wrapper = util::process(util::config::clippy_driver());
     compile_opts.build_config.primary_unit_rustc = Some(wrapper);
+    compile_opts.build_config.force_rebuild = true;
 
     ops::compile(&ws, &compile_opts)?;
     Ok(())

--- a/tests/testsuite/clippy.rs
+++ b/tests/testsuite/clippy.rs
@@ -1,0 +1,40 @@
+use crate::support::{clippy_is_available, project, registry::Package};
+
+#[cargo_test]
+// Clippy should never be considered fresh.
+fn clippy_force_rebuild() {
+    if !clippy_is_available() {
+        return;
+    }
+
+    Package::new("dep1", "0.1.0").publish();
+
+    // This is just a random clippy lint (assertions_on_constants) that
+    // hopefully won't change much in the future.
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "foo"
+            version = "0.1.0"
+
+            [dependencies]
+            dep1 = "0.1"
+            "#,
+        )
+        .file("src/lib.rs", "pub fn f() { assert!(true); }")
+        .build();
+
+    p.cargo("clippy-preview -Zunstable-options -v")
+        .masquerade_as_nightly_cargo()
+        .with_stderr_contains("[..]assert!(true)[..]")
+        .run();
+
+    // Make sure it runs again.
+    p.cargo("clippy-preview -Zunstable-options -v")
+        .masquerade_as_nightly_cargo()
+        .with_stderr_contains("[FRESH] dep1 v0.1.0")
+        .with_stderr_contains("[..]assert!(true)[..]")
+        .run();
+}

--- a/tests/testsuite/main.rs
+++ b/tests/testsuite/main.rs
@@ -29,6 +29,7 @@ mod cargo_features;
 mod cfg;
 mod check;
 mod clean;
+mod clippy;
 mod collisions;
 mod concurrent;
 mod config;


### PR DESCRIPTION
This causes `cargo clippy-preview` to always run, instead of possibly emitting no output if it is run a second time.

This is just a personal preference of mine, but I think would be better behavior which we have talked about before.  I don't think the arguments that it should be "fast" like `cargo check` apply here.  Once [cache-messages](https://github.com/rust-lang/cargo/issues/6986) is stabilized, this can be removed.
