### PR TITLE
Fix detection of cyclic dependencies through `[patch]`

### DIFF
--- a/src/cargo/core/resolver/encode.rs
+++ b/src/cargo/core/resolver/encode.rs
@@ -582,7 +582,7 @@ fn encodable_resolve_node(
         None => {
             let mut deps = resolve
                 .deps_not_replaced(id)
-                .map(|id| encodable_package_id(id, state))
+                .map(|(id, _)| encodable_package_id(id, state))
                 .collect::<Vec<_>>();
             deps.sort();
             (None, Some(deps))

--- a/src/cargo/core/resolver/resolve.rs
+++ b/src/cargo/core/resolver/resolve.rs
@@ -229,13 +229,17 @@ unable to verify that `{0}` is the same as when the lockfile was generated
     }
 
     pub fn deps(&self, pkg: PackageId) -> impl Iterator<Item = (PackageId, &[Dependency])> {
-        self.graph
-            .edges(&pkg)
-            .map(move |&(id, ref deps)| (self.replacement(id).unwrap_or(id), deps.as_slice()))
+        self.deps_not_replaced(pkg)
+            .map(move |(id, deps)| (self.replacement(id).unwrap_or(id), deps))
     }
 
-    pub fn deps_not_replaced<'a>(&'a self, pkg: PackageId) -> impl Iterator<Item = PackageId> + 'a {
-        self.graph.edges(&pkg).map(|&(id, _)| id)
+    pub fn deps_not_replaced(
+        &self,
+        pkg: PackageId,
+    ) -> impl Iterator<Item = (PackageId, &[Dependency])> {
+        self.graph
+            .edges(&pkg)
+            .map(|(id, deps)| (*id, deps.as_slice()))
     }
 
     pub fn replacement(&self, pkg: PackageId) -> Option<PackageId> {

--- a/src/cargo/ops/cargo_generate_lockfile.rs
+++ b/src/cargo/ops/cargo_generate_lockfile.rs
@@ -154,7 +154,7 @@ pub fn update_lockfile(ws: &Workspace<'_>, opts: &UpdateOptions<'_>) -> CargoRes
             return;
         }
         set.insert(dep);
-        for dep in resolve.deps_not_replaced(dep) {
+        for (dep, _) in resolve.deps_not_replaced(dep) {
             fill_with_deps(resolve, dep, set, visited);
         }
     }

--- a/src/cargo/ops/resolve.rs
+++ b/src/cargo/ops/resolve.rs
@@ -572,7 +572,11 @@ fn register_previous_locks(
     let keep = |id: &PackageId| keep(id) && !avoid_locking.contains(id);
 
     for node in resolve.iter().filter(keep) {
-        let deps = resolve.deps_not_replaced(node).filter(keep).collect();
+        let deps = resolve
+            .deps_not_replaced(node)
+            .map(|p| p.0)
+            .filter(keep)
+            .collect();
         registry.register_lock(node, deps);
     }
 
@@ -582,7 +586,7 @@ fn register_previous_locks(
             return;
         }
         debug!("ignoring any lock pointing directly at {}", node);
-        for dep in resolve.deps_not_replaced(node) {
+        for (dep, _) in resolve.deps_not_replaced(node) {
             add_deps(resolve, dep, set);
         }
     }


### PR DESCRIPTION
This commit fixes detection of cyclic dependencies through the use of
`[patch]` by ensuring that `matches_id` isn't used because it returns a
false negative for registry dependencies when the dependency
specifications don't match but the resolve edges are still correct.

Closes #7163