### PR TITLE
Refactor resolve `Method`

### DIFF
--- a/crates/resolver-tests/src/lib.rs
+++ b/crates/resolver-tests/src/lib.rs
@@ -8,7 +8,7 @@ use std::rc::Rc;
 use std::time::Instant;
 
 use cargo::core::dependency::Kind;
-use cargo::core::resolver::{self, Method};
+use cargo::core::resolver::{self, ResolveOpts};
 use cargo::core::source::{GitReference, SourceId};
 use cargo::core::Resolve;
 use cargo::core::{Dependency, PackageId, Registry, Summary};
@@ -175,10 +175,10 @@ pub fn resolve_with_config_raw(
         false,
     )
     .unwrap();
-    let method = Method::Everything;
+    let opts = ResolveOpts::everything();
     let start = Instant::now();
     let resolve = resolver::resolve(
-        &[(summary, method)],
+        &[(summary, opts)],
         &[],
         &mut registry,
         &HashSet::new(),

--- a/src/cargo/core/compiler/layout.rs
+++ b/src/cargo/core/compiler/layout.rs
@@ -3,7 +3,7 @@
 //! The directory layout is a little tricky at times, hence a separate file to
 //! house this logic. The current layout looks like this:
 //!
-//! ```ignore
+//! ```text
 //! # This is the root directory for all output, the top-level package
 //! # places all of its output here.
 //! target/

--- a/src/cargo/core/resolver/encode.rs
+++ b/src/cargo/core/resolver/encode.rs
@@ -105,6 +105,7 @@ use crate::util::{internal, Graph};
 
 use super::{Resolve, ResolveVersion};
 
+/// The `Cargo.lock` structure.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct EncodableResolve {
     package: Option<Vec<EncodableDependency>>,
@@ -123,6 +124,14 @@ struct Patch {
 pub type Metadata = BTreeMap<String, String>;
 
 impl EncodableResolve {
+    /// Convert a `Cargo.lock` to a Resolve.
+    ///
+    /// Note that this `Resolve` is not "complete". For example, the
+    /// dependencies do not know the difference between regular/dev/build
+    /// dependencies, so they are not filled in. It also does not include
+    /// `features`. Care should be taken when using this Resolve. One of the
+    /// primary uses is to be used with `resolve_with_previous` to guide the
+    /// resolver to create a complete Resolve.
     pub fn into_resolve(self, ws: &Workspace<'_>) -> CargoResult<Resolve> {
         let path_deps = build_path_deps(ws);
         let mut checksums = HashMap::new();

--- a/src/cargo/core/resolver/mod.rs
+++ b/src/cargo/core/resolver/mod.rs
@@ -69,7 +69,7 @@ pub use self::encode::Metadata;
 pub use self::encode::{EncodableDependency, EncodablePackageId, EncodableResolve};
 pub use self::errors::{ActivateError, ActivateResult, ResolveError};
 pub use self::resolve::{Resolve, ResolveVersion};
-pub use self::types::Method;
+pub use self::types::ResolveOpts;
 
 mod conflict_cache;
 mod context;
@@ -120,7 +120,7 @@ mod types;
 ///     When we have a decision for how to implement is without breaking existing functionality
 ///     this flag can be removed.
 pub fn resolve(
-    summaries: &[(Summary, Method)],
+    summaries: &[(Summary, ResolveOpts)],
     replacements: &[(PackageIdSpec, Dependency)],
     registry: &mut dyn Registry,
     try_to_use: &HashSet<PackageId>,
@@ -169,7 +169,7 @@ pub fn resolve(
 fn activate_deps_loop(
     mut cx: Context,
     registry: &mut RegistryQueryer<'_>,
-    summaries: &[(Summary, Method)],
+    summaries: &[(Summary, ResolveOpts)],
     config: Option<&Config>,
 ) -> CargoResult<Context> {
     let mut backtrack_stack = Vec::new();
@@ -180,9 +180,9 @@ fn activate_deps_loop(
     let mut past_conflicting_activations = conflict_cache::ConflictCache::new();
 
     // Activate all the initial summaries to kick off some work.
-    for &(ref summary, ref method) in summaries {
+    for &(ref summary, ref opts) in summaries {
         debug!("initial activation: {}", summary.package_id());
-        let res = activate(&mut cx, registry, None, summary.clone(), method.clone());
+        let res = activate(&mut cx, registry, None, summary.clone(), opts.clone());
         match res {
             Ok(Some((frame, _))) => remaining_deps.push(frame),
             Ok(None) => (),
@@ -366,7 +366,7 @@ fn activate_deps_loop(
             };
 
             let pid = candidate.package_id();
-            let method = Method::Required {
+            let opts = ResolveOpts {
                 dev_deps: false,
                 features: Rc::clone(&features),
                 all_features: false,
@@ -379,7 +379,7 @@ fn activate_deps_loop(
                 dep.package_name(),
                 candidate.version()
             );
-            let res = activate(&mut cx, registry, Some((&parent, &dep)), candidate, method);
+            let res = activate(&mut cx, registry, Some((&parent, &dep)), candidate, opts);
 
             let successfully_activated = match res {
                 // Success! We've now activated our `candidate` in our context
@@ -583,7 +583,7 @@ fn activate_deps_loop(
 /// Attempts to activate the summary `candidate` in the context `cx`.
 ///
 /// This function will pull dependency summaries from the registry provided, and
-/// the dependencies of the package will be determined by the `method` provided.
+/// the dependencies of the package will be determined by the `opts` provided.
 /// If `candidate` was activated, this function returns the dependency frame to
 /// iterate through next.
 fn activate(
@@ -591,7 +591,7 @@ fn activate(
     registry: &mut RegistryQueryer<'_>,
     parent: Option<(&Summary, &Dependency)>,
     candidate: Summary,
-    method: Method,
+    opts: ResolveOpts,
 ) -> ActivateResult<Option<(DepsFrame, Duration)>> {
     let candidate_pid = candidate.package_id();
     if let Some((parent, dep)) = parent {
@@ -652,7 +652,7 @@ fn activate(
         }
     }
 
-    let activated = cx.flag_activated(&candidate, &method, parent)?;
+    let activated = cx.flag_activated(&candidate, &opts, parent)?;
 
     let candidate = match registry.replacement_summary(candidate_pid) {
         Some(replace) => {
@@ -661,7 +661,7 @@ fn activate(
             // does. TBH it basically cause panics in the test suite if
             // `parent` is passed through here and `[replace]` is otherwise
             // on life support so it's not critical to fix bugs anyway per se.
-            if cx.flag_activated(replace, &method, None)? && activated {
+            if cx.flag_activated(replace, &opts, None)? && activated {
                 return Ok(None);
             }
             trace!(
@@ -682,7 +682,7 @@ fn activate(
 
     let now = Instant::now();
     let (used_features, deps) =
-        &*registry.build_deps(parent.map(|p| p.0.package_id()), &candidate, &method)?;
+        &*registry.build_deps(parent.map(|p| p.0.package_id()), &candidate, &opts)?;
 
     // Record what list of features is active for this package.
     if !used_features.is_empty() {

--- a/src/cargo/core/resolver/resolve.rs
+++ b/src/cargo/core/resolver/resolve.rs
@@ -23,15 +23,33 @@ pub struct Resolve {
     /// from `Cargo.toml`. We need a `Vec` here because the same package
     /// might be present in both `[dependencies]` and `[build-dependencies]`.
     graph: Graph<PackageId, Vec<Dependency>>,
+    /// Replacements from the `[replace]` table.
     replacements: HashMap<PackageId, PackageId>,
+    /// Inverted version of `replacements`.
     reverse_replacements: HashMap<PackageId, PackageId>,
+    /// An empty `HashSet` to avoid creating a new `HashSet` for every package
+    /// that does not have any features, and to avoid using `Option` to
+    /// simplify the API.
     empty_features: HashSet<String>,
+    /// Features enabled for a given package.
     features: HashMap<PackageId, HashSet<String>>,
+    /// Checksum for each package. A SHA256 hash of the `.crate` file used to
+    /// validate the correct crate file is used. This is `None` for sources
+    /// that do not use `.crate` files, like path or git dependencies.
     checksums: HashMap<PackageId, Option<String>>,
+    /// "Unknown" metadata. This is a collection of extra, unrecognized data
+    /// found in the `[metadata]` section of `Cargo.lock`, preserved for
+    /// forwards compatibility.
     metadata: Metadata,
+    /// `[patch]` entries that did not match anything, preserved in
+    /// `Cargo.lock` as the `[[patch.unused]]` table array.
+    /// TODO: *Why* is this kept in `Cargo.lock`? Removing it doesn't seem to
+    /// affect anything.
     unused_patches: Vec<PackageId>,
-    // A map from packages to a set of their public dependencies
+    /// A map from packages to a set of their public dependencies
     public_dependencies: HashMap<PackageId, HashSet<PackageId>>,
+    /// Version of the `Cargo.lock` format, see
+    /// `cargo::core::resolver::encode` for more.
     version: ResolveVersion,
 }
 

--- a/src/cargo/core/resolver/resolve.rs
+++ b/src/cargo/core/resolver/resolve.rs
@@ -42,9 +42,10 @@ pub struct Resolve {
     /// forwards compatibility.
     metadata: Metadata,
     /// `[patch]` entries that did not match anything, preserved in
-    /// `Cargo.lock` as the `[[patch.unused]]` table array.
-    /// TODO: *Why* is this kept in `Cargo.lock`? Removing it doesn't seem to
-    /// affect anything.
+    /// `Cargo.lock` as the `[[patch.unused]]` table array. Tracking unused
+    /// patches helps prevent Cargo from being forced to re-update the
+    /// registry every time it runs, and keeps the resolve in a locked state
+    /// so it doesn't re-resolve the unused entries.
     unused_patches: Vec<PackageId>,
     /// A map from packages to a set of their public dependencies
     public_dependencies: HashMap<PackageId, HashSet<PackageId>>,

--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -283,7 +283,7 @@ impl<'cfg> Workspace<'cfg> {
             .unwrap_or_else(|| Filesystem::new(self.root().join("target")))
     }
 
-    /// Returns the root [replace] section of this workspace.
+    /// Returns the root `[replace]` section of this workspace.
     ///
     /// This may be from a virtual crate or an actual crate.
     pub fn root_replace(&self) -> &[(PackageIdSpec, Dependency)] {
@@ -293,7 +293,7 @@ impl<'cfg> Workspace<'cfg> {
         }
     }
 
-    /// Returns the root [patch] section of this workspace.
+    /// Returns the root `[patch]` section of this workspace.
     ///
     /// This may be from a virtual crate or an actual crate.
     pub fn root_patch(&self) -> &HashMap<Url, Vec<Dependency>> {

--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -23,14 +23,13 @@
 use std::collections::{BTreeSet, HashMap, HashSet};
 use std::iter::FromIterator;
 use std::path::PathBuf;
-use std::rc::Rc;
 use std::sync::Arc;
 
 use crate::core::compiler::{BuildConfig, BuildContext, Compilation, Context};
 use crate::core::compiler::{CompileMode, Kind, Unit};
 use crate::core::compiler::{DefaultExecutor, Executor, UnitInterner};
 use crate::core::profiles::{Profiles, UnitFor};
-use crate::core::resolver::{Method, Resolve};
+use crate::core::resolver::{Resolve, ResolveOpts};
 use crate::core::{Package, Target};
 use crate::core::{PackageId, PackageIdSpec, TargetKind, Workspace};
 use crate::ops;
@@ -297,14 +296,9 @@ pub fn compile_ws<'a>(
     };
 
     let specs = spec.to_package_id_specs(ws)?;
-    let features = Method::split_features(features);
-    let method = Method::Required {
-        dev_deps: ws.require_optional_deps() || filter.need_dev_deps(build_config.mode),
-        features: Rc::new(features),
-        all_features,
-        uses_default_features: !no_default_features,
-    };
-    let resolve = ops::resolve_ws_with_method(ws, method, &specs)?;
+    let dev_deps = ws.require_optional_deps() || filter.need_dev_deps(build_config.mode);
+    let opts = ResolveOpts::new(dev_deps, features, all_features, !no_default_features);
+    let resolve = ops::resolve_ws_with_opts(ws, opts, &specs)?;
     let (packages, resolve_with_overrides) = resolve;
 
     let to_build_ids = specs

--- a/src/cargo/ops/cargo_doc.rs
+++ b/src/cargo/ops/cargo_doc.rs
@@ -5,6 +5,7 @@ use std::path::Path;
 use failure::Fail;
 use opener;
 
+use crate::core::resolver::ResolveOpts;
 use crate::core::Workspace;
 use crate::ops;
 use crate::util::CargoResult;
@@ -21,13 +22,13 @@ pub struct DocOptions<'a> {
 /// Main method for `cargo doc`.
 pub fn doc(ws: &Workspace<'_>, options: &DocOptions<'_>) -> CargoResult<()> {
     let specs = options.compile_opts.spec.to_package_id_specs(ws)?;
-    let resolve = ops::resolve_ws_precisely(
-        ws,
+    let opts = ResolveOpts::new(
+        /*dev_deps*/ true,
         &options.compile_opts.features,
         options.compile_opts.all_features,
-        options.compile_opts.no_default_features,
-        &specs,
-    )?;
+        !options.compile_opts.no_default_features,
+    );
+    let resolve = ops::resolve_ws_with_opts(ws, opts, &specs)?;
     let (packages, resolve_with_overrides) = resolve;
 
     let ids = specs

--- a/src/cargo/ops/cargo_generate_lockfile.rs
+++ b/src/cargo/ops/cargo_generate_lockfile.rs
@@ -4,7 +4,7 @@ use log::debug;
 use termcolor::Color::{self, Cyan, Green, Red};
 
 use crate::core::registry::PackageRegistry;
-use crate::core::resolver::Method;
+use crate::core::resolver::ResolveOpts;
 use crate::core::PackageId;
 use crate::core::{Resolve, SourceId, Workspace};
 use crate::ops;
@@ -21,8 +21,15 @@ pub struct UpdateOptions<'a> {
 
 pub fn generate_lockfile(ws: &Workspace<'_>) -> CargoResult<()> {
     let mut registry = PackageRegistry::new(ws.config())?;
-    let resolve =
-        ops::resolve_with_previous(&mut registry, ws, Method::Everything, None, None, &[], true)?;
+    let resolve = ops::resolve_with_previous(
+        &mut registry,
+        ws,
+        ResolveOpts::everything(),
+        None,
+        None,
+        &[],
+        true,
+    )?;
     ops::write_pkg_lockfile(ws, &resolve)?;
     Ok(())
 }
@@ -57,7 +64,7 @@ pub fn update_lockfile(ws: &Workspace<'_>, opts: &UpdateOptions<'_>) -> CargoRes
                     ops::resolve_with_previous(
                         &mut registry,
                         ws,
-                        Method::Everything,
+                        ResolveOpts::everything(),
                         None,
                         None,
                         &[],
@@ -103,7 +110,7 @@ pub fn update_lockfile(ws: &Workspace<'_>, opts: &UpdateOptions<'_>) -> CargoRes
     let resolve = ops::resolve_with_previous(
         &mut registry,
         ws,
-        Method::Everything,
+        ResolveOpts::everything(),
         Some(&previous_resolve),
         Some(&to_avoid),
         &[],

--- a/src/cargo/ops/cargo_install.rs
+++ b/src/cargo/ops/cargo_install.rs
@@ -8,7 +8,7 @@ use tempfile::Builder as TempFileBuilder;
 
 use crate::core::compiler::Freshness;
 use crate::core::compiler::{DefaultExecutor, Executor};
-use crate::core::resolver::Method;
+use crate::core::resolver::ResolveOpts;
 use crate::core::{Edition, PackageId, PackageIdSpec, Source, SourceId, Workspace};
 use crate::ops;
 use crate::ops::common_for_install_and_uninstall::*;
@@ -486,10 +486,10 @@ fn check_yanked_install(ws: &Workspace<'_>) -> CargoResult<()> {
     // It would be best if `source` could be passed in here to avoid a
     // duplicate "Updating", but since `source` is taken by value, then it
     // wouldn't be available for `compile_ws`.
-    let (pkg_set, resolve) = ops::resolve_ws_with_method(ws, Method::Everything, &specs)?;
+    let (pkg_set, resolve) = ops::resolve_ws_with_opts(ws, ResolveOpts::everything(), &specs)?;
     let mut sources = pkg_set.sources_mut();
 
-    // Checking the yanked status invovles taking a look at the registry and
+    // Checking the yanked status involves taking a look at the registry and
     // maybe updating files, so be sure to lock it here.
     let _lock = ws.config().acquire_package_cache_lock()?;
 

--- a/src/cargo/ops/cargo_output_metadata.rs
+++ b/src/cargo/ops/cargo_output_metadata.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use serde::ser;
 use serde::Serialize;
 
-use crate::core::resolver::Resolve;
+use crate::core::resolver::{Resolve, ResolveOpts};
 use crate::core::{Package, PackageId, Workspace};
 use crate::ops::{self, Packages};
 use crate::util::CargoResult;
@@ -50,13 +50,13 @@ fn metadata_no_deps(ws: &Workspace<'_>, _opt: &OutputMetadataOptions) -> CargoRe
 
 fn metadata_full(ws: &Workspace<'_>, opt: &OutputMetadataOptions) -> CargoResult<ExportInfo> {
     let specs = Packages::All.to_package_id_specs(ws)?;
-    let (package_set, resolve) = ops::resolve_ws_precisely(
-        ws,
+    let opts = ResolveOpts::new(
+        /*dev_deps*/ true,
         &opt.features,
         opt.all_features,
-        opt.no_default_features,
-        &specs,
-    )?;
+        !opt.no_default_features,
+    );
+    let (package_set, resolve) = ops::resolve_ws_with_opts(ws, opts, &specs)?;
     let mut packages = HashMap::new();
     for pkg in package_set.get_many(package_set.package_ids())? {
         packages.insert(pkg.package_id(), pkg.clone());

--- a/src/cargo/ops/cargo_package.rs
+++ b/src/cargo/ops/cargo_package.rs
@@ -14,7 +14,7 @@ use tar::{Archive, Builder, EntryType, Header};
 use termcolor::Color;
 
 use crate::core::compiler::{BuildConfig, CompileMode, DefaultExecutor, Executor};
-use crate::core::resolver::Method;
+use crate::core::resolver::ResolveOpts;
 use crate::core::Feature;
 use crate::core::{
     Package, PackageId, PackageIdSpec, PackageSet, Resolve, Source, SourceId, Verbosity, Workspace,
@@ -152,7 +152,8 @@ fn build_lock(ws: &Workspace<'_>) -> CargoResult<String> {
     // Regenerate Cargo.lock using the old one as a guide.
     let specs = vec![PackageIdSpec::from_package_id(new_pkg.package_id())];
     let tmp_ws = Workspace::ephemeral(new_pkg, ws.config(), None, true)?;
-    let (pkg_set, new_resolve) = ops::resolve_ws_with_method(&tmp_ws, Method::Everything, &specs)?;
+    let (pkg_set, new_resolve) =
+        ops::resolve_ws_with_opts(&tmp_ws, ResolveOpts::everything(), &specs)?;
 
     if let Some(orig_resolve) = orig_resolve {
         compare_resolve(config, tmp_ws.current()?, &orig_resolve, &new_resolve)?;
@@ -558,7 +559,7 @@ fn compare_resolve(
 }
 
 fn check_yanked(config: &Config, pkg_set: &PackageSet<'_>, resolve: &Resolve) -> CargoResult<()> {
-    // Checking the yanked status invovles taking a look at the registry and
+    // Checking the yanked status involves taking a look at the registry and
     // maybe updating files, so be sure to lock it here.
     let _lock = config.acquire_package_cache_lock()?;
 

--- a/src/cargo/ops/mod.rs
+++ b/src/cargo/ops/mod.rs
@@ -23,8 +23,7 @@ pub use self::registry::{http_handle, needs_custom_http_transport, registry_logi
 pub use self::registry::{modify_owners, yank, OwnersOptions, PublishOpts};
 pub use self::registry::{publish, registry_configuration, RegistryConfig};
 pub use self::resolve::{
-    add_overrides, get_resolved_packages, resolve_with_previous, resolve_ws, resolve_ws_precisely,
-    resolve_ws_with_method,
+    add_overrides, get_resolved_packages, resolve_with_previous, resolve_ws, resolve_ws_with_opts,
 };
 pub use self::vendor::{vendor, VendorOptions};
 


### PR DESCRIPTION
This changes the enum `Method` to a struct called `ResolveOpts`. The intent is to try to make it a little easier to read and understand.

If this doesn't actually look better to anyone, I'm fine with discarding this (I can resubmit just with documentation). It only seems marginally better, but I have had difficulty with understanding the subtleties of `Method` for a while. I wasn't able to measure any performance difference.

This also has a few other changes:
- Adds some documentation.
- Removes `resolve_ws_precisely`, cutting down the number of resolve functions from 4 to 3.
