### PR TITLE
Alternative registries backed by local directories

### DIFF
--- a/src/cargo/sources/config.rs
+++ b/src/cargo/sources/config.rs
@@ -171,19 +171,11 @@ restore the source replacement configuration to continue the build
             srcs.push(SourceId::for_registry(&url)?);
         }
         if let Some(val) = table.get("local-registry") {
-            let (s, path) = val.string(&format!("source.{}.local-registry", name))?;
-            let mut path = path.to_path_buf();
-            path.pop();
-            path.pop();
-            path.push(s);
+            let path = val.path(&format!("source.{}.local-registry", name))?;
             srcs.push(SourceId::for_local_registry(&path)?);
         }
         if let Some(val) = table.get("directory") {
-            let (s, path) = val.string(&format!("source.{}.directory", name))?;
-            let mut path = path.to_path_buf();
-            path.pop();
-            path.pop();
-            path.push(s);
+            let path = val.path(&format!("source.{}.directory", name))?;
             srcs.push(SourceId::for_directory(&path)?);
         }
         if let Some(val) = table.get("git") {

--- a/src/doc/src/reference/registries.md
+++ b/src/doc/src/reference/registries.md
@@ -45,6 +45,25 @@ CARGO_REGISTRIES_MY_REGISTRY_INDEX=https://my-intranet:8080/git/index
 > Note: [crates.io] does not accept packages that depend on crates from other
 > registries.
 
+### Local alternative registries
+
+An alternative registry can also be loaded from a local directory tree by
+configuring it as follows:
+
+```toml
+[registries]
+my-registry = { local-registry = "some/local/path" }
+```
+
+The `local-registry` key is interpreted relative to the file in which it is
+declared. This key should point to a
+[local registry source tree][local-registry], containing an
+[index subdirectory][index], and the `.crate` files for all crates in this local
+registry.
+
+[local-registry]: source-replacement.md#local-registry-sources
+[index]: registries.md#index-format
+
 ### Publishing to an Alternate Registry
 
 If the registry supports web API access, then packages can be published

--- a/tests/testsuite/support/registry.rs
+++ b/tests/testsuite/support/registry.rs
@@ -524,7 +524,9 @@ impl Package {
 
     /// Returns the path to the compressed package file.
     pub fn archive_dst(&self) -> PathBuf {
-        if self.local {
+        if self.local && self.alternative {
+            alt_registry_path().join(format!("{}-{}.crate", self.name, self.vers))
+        } else if self.local {
             registry_path().join(format!("{}-{}.crate", self.name, self.vers))
         } else if self.alternative {
             alt_dl_path()


### PR DESCRIPTION
This patch adds support for declaring alternative registries backed by a local
directory tree, similar to vendoring crates.io. This can be useful when
integrating with external build systems with their own dependency resolution
and download framework, where reaching out to an external server to download
crates isn't possible, feasible, or desirable.