### PR TITLE
tests: Enable features to fix unstabilized `#[bench]`

### DIFF
--- a/tests/testsuite/bench.rs
+++ b/tests/testsuite/bench.rs
@@ -58,7 +58,7 @@ fn bench_bench_implicit() {
         .file(
             "src/main.rs",
             r#"
-            #![cfg_attr(test, feature(test))]
+            #![feature(test)]
             #[cfg(test)]
             extern crate test;
             #[bench] fn run1(_ben: &mut test::Bencher) { }
@@ -364,7 +364,7 @@ fn bench_with_lib_dep() {
         .file(
             "src/lib.rs",
             r#"
-            #![cfg_attr(test, feature(test))]
+            #![feature(test)]
             #[cfg(test)]
             extern crate test;
             ///
@@ -432,7 +432,7 @@ fn bench_with_deep_lib_dep() {
         .file(
             "src/lib.rs",
             "
-            #![cfg_attr(test, feature(test))]
+            #![feature(test)]
             #[cfg(test)]
             extern crate foo;
             #[cfg(test)]
@@ -448,7 +448,7 @@ fn bench_with_deep_lib_dep() {
         .file(
             "src/lib.rs",
             "
-            #![cfg_attr(test, feature(test))]
+            #![feature(test)]
             #[cfg(test)]
             extern crate test;
 
@@ -495,7 +495,7 @@ fn external_bench_explicit() {
         .file(
             "src/lib.rs",
             r#"
-            #![cfg_attr(test, feature(test))]
+            #![feature(test)]
             #[cfg(test)]
             extern crate test;
             pub fn get_hello() -> &'static str { "Hello" }
@@ -541,7 +541,7 @@ fn external_bench_implicit() {
         .file(
             "src/lib.rs",
             r#"
-            #![cfg_attr(test, feature(test))]
+            #![feature(test)]
             #[cfg(test)]
             extern crate test;
 
@@ -760,7 +760,7 @@ fn lib_bin_same_name() {
         .file(
             "src/lib.rs",
             "
-            #![cfg_attr(test, feature(test))]
+            #![feature(test)]
             #[cfg(test)]
             extern crate test;
             #[bench] fn lib_bench(_b: &mut test::Bencher) {}
@@ -769,7 +769,7 @@ fn lib_bin_same_name() {
         .file(
             "src/main.rs",
             "
-            #![cfg_attr(test, feature(test))]
+            #![feature(test)]
             #[allow(unused_extern_crates)]
             extern crate foo;
             #[cfg(test)]
@@ -804,7 +804,7 @@ fn lib_with_standard_name() {
         .file(
             "src/lib.rs",
             "
-            #![cfg_attr(test, feature(test))]
+            #![feature(test)]
             #[cfg(test)]
             extern crate test;
 
@@ -919,7 +919,7 @@ fn bench_dylib() {
         .file(
             "src/lib.rs",
             r#"
-            #![cfg_attr(test, feature(test))]
+            #![feature(test)]
             extern crate bar as the_bar;
             #[cfg(test)]
             extern crate test;
@@ -1061,7 +1061,7 @@ fn bench_with_examples() {
         .file(
             "src/lib.rs",
             r#"
-            #![cfg_attr(test, feature(test))]
+            #![feature(test)]
             #[cfg(test)]
             extern crate test;
             #[cfg(test)]


### PR DESCRIPTION
Needed for https://github.com/rust-lang/rust/pull/62507.

(Even if unstabilization of `bench` is reverted later due to fallout, this change should be ok.)