### PR TITLE
support for [patch] override from .cargo/config

### DIFF
--- a/tests/testsuite/patch.rs
+++ b/tests/testsuite/patch.rs
@@ -400,6 +400,48 @@ fn add_patch() {
 }
 
 #[cargo_test]
+fn patch_in_config() {
+    Package::new("bar", "0.1.0").publish();
+
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+
+            [dependencies]
+            bar = "0.1.0"
+        "#,
+        )
+        .file(
+            ".cargo/config",
+            r#"
+            [patch.crates-io]
+            bar = { path = 'bar' }
+        "#
+        )
+        .file("src/lib.rs", "")
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
+        .file("bar/src/lib.rs", r#""#)
+        .build();
+
+    p.cargo("build")
+        .with_stderr(
+            "\
+[UPDATING] `[ROOT][..]` index
+[COMPILING] bar v0.1.0 ([CWD]/bar)
+[COMPILING] foo v0.0.1 ([CWD])
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+",
+        )
+        .run();
+    p.cargo("build").with_stderr("[FINISHED] [..]").run();
+}
+
+#[cargo_test]
 fn add_ignored_patch() {
     Package::new("bar", "0.1.0").publish();
 


### PR DESCRIPTION
We have exactly the same scenario as described in #5539. We would like to be able to override `[patch]` for some crates *WITHOUT* the need to modify their individual `Cargo.toml` manifests.

This PR is a draft implementation of this use case, where all entries from `[patch]` section defined in `.cargo/config` are picked up for every manifest.
Please comment if such a change is viable for cargo. Some potential problems/design decisions that should be solved:
1. Should `[patch]` entries be merged from both `.cargo/config` and `Cargo.toml`, or simply overridden entirely from `.cargo/config` if present.
1. What about `[replace]` section? I have seen a few open issues with discussion whether this section should be deprecated/removed?
1. If `[patch]` is overridden for several nested crates, from `.cargo/config`, probably warnings about unused patch dependency for each crate should then be silenced? 

As a more detailed explanation why we want this feature - we develop a large project consisting of a few crates that are regular `[workspace]` members, as well as a few crates that are self-contained libraries, published independently on crates.io (however some depend on others). 
In order to be able to work on a project as a whole, we nested those self-contained libraries in main repository as git submodules, and patched workspace members to use local versions of those libraries, instead of downloading them from crates.io. This makes developement much easier, since simultaneous changes in dependent libraries can be tested, before releasing them on crates.io.
However since, those libraries are independent from the main project, they had to be excluded from the workspace, and as such, their dependencies are not patched. This creates a problem, since when testing, each library is build using all of its dependencies from crates.io (skipping locally made changes in other libs).
