### PR TITLE
Reinstate CARGO_PRIMARY_PACKAGE

### DIFF
--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -180,6 +180,9 @@ fn rustc<'a, 'cfg>(
     exec: &Arc<dyn Executor>,
 ) -> CargoResult<Work> {
     let mut rustc = prepare_rustc(cx, &unit.target.rustc_crate_types(), unit)?;
+    if cx.is_primary_package(unit) {
+        rustc.env("CARGO_PRIMARY_PACKAGE", "1");
+    }
     let build_plan = cx.bcx.build_config.build_plan;
 
     let name = unit.pkg.name().to_string();


### PR DESCRIPTION
#7069 removed `CARGO_PRIMARY_PACKAGE` since it's no longer needed by Clippy. It _is_, however, useful for other rustc wrappers. It'd be great to have this back.