### PR TITLE
Fix an old test.

### DIFF
--- a/tests/testsuite/build_script.rs
+++ b/tests/testsuite/build_script.rs
@@ -195,7 +195,6 @@ fn custom_build_script_wrong_rustc_flags() {
         .run();
 }
 
-/*
 #[cargo_test]
 fn custom_build_script_rustc_flags() {
     let p = project()
@@ -211,7 +210,8 @@ fn custom_build_script_rustc_flags() {
             [dependencies.foo]
             path = "foo"
         "#,
-        ).file("src/main.rs", "fn main() {}")
+        )
+        .file("src/main.rs", "fn main() {}")
         .file(
             "foo/Cargo.toml",
             r#"
@@ -222,7 +222,8 @@ fn custom_build_script_rustc_flags() {
             authors = ["wycats@example.com"]
             build = "build.rs"
         "#,
-        ).file("foo/src/lib.rs", "")
+        )
+        .file("foo/src/lib.rs", "")
         .file(
             "foo/build.rs",
             r#"
@@ -230,25 +231,28 @@ fn custom_build_script_rustc_flags() {
                 println!("cargo:rustc-flags=-l nonexistinglib -L /dummy/path1 -L /dummy/path2");
             }
         "#,
-        ).build();
+        )
+        .build();
 
-    // TODO: TEST FAILS BECAUSE OF WRONG STDOUT (but otherwise, the build works).
     p.cargo("build --verbose")
-        .with_status(101)
         .with_stderr(
             "\
-[COMPILING] bar v0.5.0 ([CWD])
-[RUNNING] `rustc --crate-name test [CWD]/src/lib.rs --crate-type lib -C debuginfo=2 \
-        -C metadata=[..] \
-        -C extra-filename=-[..] \
-        --out-dir [CWD]/target \
-        --emit=[..]link \
-        -L [CWD]/target \
-        -L [CWD]/target/deps`
+[COMPILING] foo [..]
+[RUNNING] `rustc --crate-name build_script_build foo/build.rs [..]
+[RUNNING] `[..]build-script-build`
+[RUNNING] `rustc --crate-name foo foo/src/lib.rs [..]\
+    -L dependency=[CWD]/target/debug/deps \
+    -L /dummy/path1 -L /dummy/path2 -l nonexistinglib`
+[COMPILING] bar [..]
+[RUNNING] `rustc --crate-name bar src/main.rs [..]\
+    -L dependency=[CWD]/target/debug/deps \
+    --extern foo=[..]libfoo-[..] \
+    -L /dummy/path1 -L /dummy/path2`
+[FINISHED] dev [..]
 ",
-        ).run();
+        )
+        .run();
 }
-*/
 
 #[cargo_test]
 fn links_no_build_cmd() {


### PR DESCRIPTION
This test was added in f888b4b7802d4c4699490af3810ce7dadf387915, part of #792, in a commented state. Might as well make it work. It is a bit surprising that passing `-l nonexistinglib` doesn't cause an error, but seems to be fine.
