### PR TITLE
Remove unused AstBuilder

### DIFF
--- a/tests/testsuite/cross_compile.rs
+++ b/tests/testsuite/cross_compile.rs
@@ -209,7 +209,6 @@ fn plugin_deps() {
             use syntax::source_map::Span;
             use syntax::ast::*;
             use syntax::ext::base::{ExtCtxt, MacEager, MacResult};
-            use syntax::ext::build::AstBuilder;
 
             #[plugin_registrar]
             pub fn foo(reg: &mut Registry) {
@@ -306,7 +305,6 @@ fn plugin_to_the_max() {
             use syntax::source_map::Span;
             use syntax::ast::*;
             use syntax::ext::base::{ExtCtxt, MacEager, MacResult};
-            use syntax::ext::build::AstBuilder;
             use syntax::ptr::P;
 
             #[plugin_registrar]


### PR DESCRIPTION
This was removed in a recent rustc PR (https://github.com/rust-lang/rust/pull/63146), replaced with inherent impls.