### PR TITLE
Add support for customizing JSON diagnostics from Cargo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,20 @@
 
 ### Added
 
+- Cargo build pipelining has been enabled by default to leverage more idle CPU
+  parallelism during builds.
+  [#7143](https://github.com/rust-lang/cargo/pull/7143)
+- The `--message-format` option to Cargo can now be specified multiple times and
+  accepts a comma-separated list of values. In addition to the previous values
+  it also now accepts `json-diagnostic-short` and
+  `json-diagnostic-rendered-ansi` which configures the output coming from rustc
+  in `json` message mode.
+  [#7214](https://github.com/rust-lang/cargo/pull/7214)
+
 ### Changed
 
 ### Fixed
-- (Nightly only): Fixed exponential blowup when using CARGO_BUILD_PIPELINING.
+- (Nightly only): Fixed exponential blowup when using `CARGO_BUILD_PIPELINING`.
   [#7062](https://github.com/rust-lang/cargo/pull/7062)
 - Fixed using the wrong directory when updating git repositories when using
   the `git-fetch-with-cli` config option, and the `GIT_DIR` environment

--- a/src/cargo/core/compiler/build_config.rs
+++ b/src/cargo/core/compiler/build_config.rs
@@ -112,7 +112,10 @@ impl BuildConfig {
     /// Whether or not the *user* wants JSON output. Whether or not rustc
     /// actually uses JSON is decided in `add_error_format`.
     pub fn emit_json(&self) -> bool {
-        self.message_format == MessageFormat::Json
+        match self.message_format {
+            MessageFormat::Json { .. } => true,
+            _ => false,
+        }
     }
 
     pub fn test(&self) -> bool {
@@ -123,7 +126,17 @@ impl BuildConfig {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum MessageFormat {
     Human,
-    Json,
+    Json {
+        /// Whether rustc diagnostics are rendered by cargo or included into the
+        /// output stream.
+        render_diagnostics: bool,
+        /// Whether the `rendered` field of rustc diagnostics are using the
+        /// "short" rendering.
+        short: bool,
+        /// Whether the `rendered` field of rustc diagnostics embed ansi color
+        /// codes.
+        ansi: bool,
+    },
     Short,
 }
 

--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -754,27 +754,47 @@ fn add_error_format_and_color(
         if pipelined {
             json.push_str(",artifacts");
         }
-        if cx.bcx.build_config.message_format == MessageFormat::Short {
-            json.push_str(",diagnostic-short");
+        match cx.bcx.build_config.message_format {
+            MessageFormat::Short | MessageFormat::Json { short: true, .. } => {
+                json.push_str(",diagnostic-short");
+            }
+            _ => {}
         }
         cmd.arg(json);
     } else {
+        let mut color = true;
         match cx.bcx.build_config.message_format {
             MessageFormat::Human => (),
-            MessageFormat::Json => {
+            MessageFormat::Json {
+                ansi,
+                short,
+                render_diagnostics,
+            } => {
                 cmd.arg("--error-format").arg("json");
+                // If ansi is explicitly requested, enable it. If we're
+                // rendering diagnostics ourselves then also enable it because
+                // we'll figure out what to do with the colors later.
+                if ansi || render_diagnostics {
+                    cmd.arg("--json=diagnostic-rendered-ansi");
+                }
+                if short {
+                    cmd.arg("--json=diagnostic-short");
+                }
+                color = false;
             }
             MessageFormat::Short => {
                 cmd.arg("--error-format").arg("short");
             }
         }
 
-        let color = if cx.bcx.config.shell().supports_color() {
-            "always"
-        } else {
-            "never"
-        };
-        cmd.args(&["--color", color]);
+        if color {
+            let color = if cx.bcx.config.shell().supports_color() {
+                "always"
+            } else {
+                "never"
+            };
+            cmd.args(&["--color", color]);
+        }
     }
     Ok(())
 }
@@ -1094,9 +1114,8 @@ impl Kind {
 }
 
 struct OutputOptions {
-    /// Get the `"rendered"` field from the JSON output and display it on
-    /// stderr instead of the JSON message.
-    extract_rendered_messages: bool,
+    /// What format we're emitting from Cargo itself.
+    format: MessageFormat,
     /// Look for JSON message that indicates .rmeta file is available for
     /// pipelined compilation.
     look_for_metadata_directive: bool,
@@ -1110,7 +1129,6 @@ struct OutputOptions {
 
 impl OutputOptions {
     fn new<'a>(cx: &Context<'a, '_>, unit: &Unit<'a>) -> OutputOptions {
-        let extract_rendered_messages = cx.bcx.build_config.message_format != MessageFormat::Json;
         let look_for_metadata_directive = cx.rmeta_required(unit);
         let color = cx.bcx.config.shell().supports_color();
         let cache_cell = if cx.bcx.build_config.cache_messages() {
@@ -1122,7 +1140,7 @@ impl OutputOptions {
             None
         };
         OutputOptions {
-            extract_rendered_messages,
+            format: cx.bcx.build_config.message_format,
             look_for_metadata_directive,
             color,
             cache_cell,
@@ -1179,55 +1197,66 @@ fn on_stderr_line(
         }
     };
 
-    // In some modes of compilation Cargo switches the compiler to JSON mode
-    // but the user didn't request that so we still want to print pretty rustc
-    // colorized diagnostics. In those cases (`extract_rendered_messages`) we
-    // take a look at the JSON blob we go, see if it's a relevant diagnostics,
-    // and if so forward just that diagnostic for us to print.
-    if options.extract_rendered_messages {
-        #[derive(serde::Deserialize)]
-        struct CompilerMessage {
-            rendered: String,
-        }
-        if let Ok(mut error) = serde_json::from_str::<CompilerMessage>(compiler_message.get()) {
-            // state.stderr will add a newline
-            if error.rendered.ends_with('\n') {
-                error.rendered.pop();
+    // Depending on what we're emitting from Cargo itself, we figure out what to
+    // do with this JSON message.
+    match options.format {
+        // In the "human" output formats (human/short) or if diagnostic messages
+        // from rustc aren't being included in the output of Cargo's JSON
+        // messages then we extract the diagnostic (if present) here and handle
+        // it ourselves.
+        MessageFormat::Human
+        | MessageFormat::Short
+        | MessageFormat::Json {
+            render_diagnostics: true,
+            ..
+        } => {
+            #[derive(serde::Deserialize)]
+            struct CompilerMessage {
+                rendered: String,
             }
-            let rendered = if options.color {
-                error.rendered
-            } else {
-                // Strip only fails if the the Writer fails, which is Cursor
-                // on a Vec, which should never fail.
-                strip_ansi_escapes::strip(&error.rendered)
+            if let Ok(mut error) = serde_json::from_str::<CompilerMessage>(compiler_message.get()) {
+                // state.stderr will add a newline
+                if error.rendered.ends_with('\n') {
+                    error.rendered.pop();
+                }
+                let rendered = if options.color {
+                    error.rendered
+                } else {
+                    // Strip only fails if the the Writer fails, which is Cursor
+                    // on a Vec, which should never fail.
+                    strip_ansi_escapes::strip(&error.rendered)
+                        .map(|v| String::from_utf8(v).expect("utf8"))
+                        .expect("strip should never fail")
+                };
+                state.stderr(rendered);
+                return Ok(());
+            }
+        }
+
+        // Remove color information from the rendered string. When pipelining is
+        // enabled and/or when cached messages are enabled we're always asking
+        // for ANSI colors from rustc, so unconditionally postprocess here and
+        // remove ansi color codes.
+        MessageFormat::Json { ansi: false, .. } => {
+            #[derive(serde::Deserialize, serde::Serialize)]
+            struct CompilerMessage {
+                rendered: String,
+                #[serde(flatten)]
+                other: std::collections::BTreeMap<String, serde_json::Value>,
+            }
+            if let Ok(mut error) = serde_json::from_str::<CompilerMessage>(compiler_message.get()) {
+                error.rendered = strip_ansi_escapes::strip(&error.rendered)
                     .map(|v| String::from_utf8(v).expect("utf8"))
-                    .expect("strip should never fail")
-            };
-            state.stderr(rendered);
-            return Ok(());
+                    .unwrap_or(error.rendered);
+                let new_line = serde_json::to_string(&error)?;
+                let new_msg: Box<serde_json::value::RawValue> = serde_json::from_str(&new_line)?;
+                compiler_message = new_msg;
+            }
         }
-    } else {
-        // Remove color information from the rendered string. rustc has not
-        // included color in the past, so to avoid breaking anything, strip it
-        // out when --json=diagnostic-rendered-ansi is used. This runs
-        // unconditionally under the assumption that Cargo will eventually
-        // move to this as the default mode. Perhaps in the future, cargo
-        // could allow the user to enable/disable color (such as with a
-        // `--json` or `--color` or `--message-format` flag).
-        #[derive(serde::Deserialize, serde::Serialize)]
-        struct CompilerMessage {
-            rendered: String,
-            #[serde(flatten)]
-            other: std::collections::BTreeMap<String, serde_json::Value>,
-        }
-        if let Ok(mut error) = serde_json::from_str::<CompilerMessage>(compiler_message.get()) {
-            error.rendered = strip_ansi_escapes::strip(&error.rendered)
-                .map(|v| String::from_utf8(v).expect("utf8"))
-                .unwrap_or(error.rendered);
-            let new_line = serde_json::to_string(&error)?;
-            let new_msg: Box<serde_json::value::RawValue> = serde_json::from_str(&new_line)?;
-            compiler_message = new_msg;
-        }
+
+        // If ansi colors are desired then we should be good to go! We can just
+        // pass through this message as-is.
+        MessageFormat::Json { ansi: true, .. } => {}
     }
 
     // In some modes of execution we will execute rustc with `-Z
@@ -1278,12 +1307,8 @@ fn replay_output_cache(
     color: bool,
 ) -> Work {
     let target = target.clone();
-    let extract_rendered_messages = match format {
-        MessageFormat::Human | MessageFormat::Short => true,
-        MessageFormat::Json => false,
-    };
     let mut options = OutputOptions {
-        extract_rendered_messages,
+        format,
         look_for_metadata_directive: false,
         color,
         cache_cell: None,

--- a/src/doc/man/generated/cargo-bench.html
+++ b/src/doc/man/generated/cargo-bench.html
@@ -301,17 +301,33 @@ terminal.</p>
 </dd>
 <dt class="hdlist1"><strong>--message-format</strong> <em>FMT</em></dt>
 <dd>
-<p>The output format for diagnostic messages. Valid values:</p>
+<p>The output format for diagnostic messages. Can be specified multiple times
+and consists of comma-separated values. Valid values:</p>
 <div class="ulist">
 <ul>
 <li>
 <p><code>human</code> (default): Display in a human-readable text format.</p>
 </li>
 <li>
+<p><code>short</code>: Emit shorter, human-readable text messages.</p>
+</li>
+<li>
 <p><code>json</code>: Emit JSON messages to stdout.</p>
 </li>
 <li>
-<p><code>short</code>: Emit shorter, human-readable text messages.</p>
+<p><code>json-diagnostic-short</code>: Ensure the <code>rendered</code> field of JSON messages contains
+the "short" rendering from rustc.</p>
+</li>
+<li>
+<p><code>json-diagnostic-rendered-ansi</code>: Ensure the <code>rendered</code> field of JSON messages
+contains embedded ANSI color codes for respecting rustc&#8217;s default color
+scheme.</p>
+</li>
+<li>
+<p><code>json-render-diagnostics</code>: Instruct Cargo to not include rustc diagnostics in
+in JSON messages printed, but instead Cargo itself should render the
+JSON diagnostics coming from rustc. Cargo&#8217;s own JSON diagnostics and others
+coming from rustc are still emitted.</p>
 </li>
 </ul>
 </div>

--- a/src/doc/man/generated/cargo-build.html
+++ b/src/doc/man/generated/cargo-build.html
@@ -235,17 +235,33 @@ terminal.</p>
 </dd>
 <dt class="hdlist1"><strong>--message-format</strong> <em>FMT</em></dt>
 <dd>
-<p>The output format for diagnostic messages. Valid values:</p>
+<p>The output format for diagnostic messages. Can be specified multiple times
+and consists of comma-separated values. Valid values:</p>
 <div class="ulist">
 <ul>
 <li>
 <p><code>human</code> (default): Display in a human-readable text format.</p>
 </li>
 <li>
+<p><code>short</code>: Emit shorter, human-readable text messages.</p>
+</li>
+<li>
 <p><code>json</code>: Emit JSON messages to stdout.</p>
 </li>
 <li>
-<p><code>short</code>: Emit shorter, human-readable text messages.</p>
+<p><code>json-diagnostic-short</code>: Ensure the <code>rendered</code> field of JSON messages contains
+the "short" rendering from rustc.</p>
+</li>
+<li>
+<p><code>json-diagnostic-rendered-ansi</code>: Ensure the <code>rendered</code> field of JSON messages
+contains embedded ANSI color codes for respecting rustc&#8217;s default color
+scheme.</p>
+</li>
+<li>
+<p><code>json-render-diagnostics</code>: Instruct Cargo to not include rustc diagnostics in
+in JSON messages printed, but instead Cargo itself should render the
+JSON diagnostics coming from rustc. Cargo&#8217;s own JSON diagnostics and others
+coming from rustc are still emitted.</p>
 </li>
 </ul>
 </div>

--- a/src/doc/man/generated/cargo-check.html
+++ b/src/doc/man/generated/cargo-check.html
@@ -237,17 +237,33 @@ terminal.</p>
 </dd>
 <dt class="hdlist1"><strong>--message-format</strong> <em>FMT</em></dt>
 <dd>
-<p>The output format for diagnostic messages. Valid values:</p>
+<p>The output format for diagnostic messages. Can be specified multiple times
+and consists of comma-separated values. Valid values:</p>
 <div class="ulist">
 <ul>
 <li>
 <p><code>human</code> (default): Display in a human-readable text format.</p>
 </li>
 <li>
+<p><code>short</code>: Emit shorter, human-readable text messages.</p>
+</li>
+<li>
 <p><code>json</code>: Emit JSON messages to stdout.</p>
 </li>
 <li>
-<p><code>short</code>: Emit shorter, human-readable text messages.</p>
+<p><code>json-diagnostic-short</code>: Ensure the <code>rendered</code> field of JSON messages contains
+the "short" rendering from rustc.</p>
+</li>
+<li>
+<p><code>json-diagnostic-rendered-ansi</code>: Ensure the <code>rendered</code> field of JSON messages
+contains embedded ANSI color codes for respecting rustc&#8217;s default color
+scheme.</p>
+</li>
+<li>
+<p><code>json-render-diagnostics</code>: Instruct Cargo to not include rustc diagnostics in
+in JSON messages printed, but instead Cargo itself should render the
+JSON diagnostics coming from rustc. Cargo&#8217;s own JSON diagnostics and others
+coming from rustc are still emitted.</p>
 </li>
 </ul>
 </div>

--- a/src/doc/man/generated/cargo-doc.html
+++ b/src/doc/man/generated/cargo-doc.html
@@ -205,17 +205,33 @@ terminal.</p>
 </dd>
 <dt class="hdlist1"><strong>--message-format</strong> <em>FMT</em></dt>
 <dd>
-<p>The output format for diagnostic messages. Valid values:</p>
+<p>The output format for diagnostic messages. Can be specified multiple times
+and consists of comma-separated values. Valid values:</p>
 <div class="ulist">
 <ul>
 <li>
 <p><code>human</code> (default): Display in a human-readable text format.</p>
 </li>
 <li>
+<p><code>short</code>: Emit shorter, human-readable text messages.</p>
+</li>
+<li>
 <p><code>json</code>: Emit JSON messages to stdout.</p>
 </li>
 <li>
-<p><code>short</code>: Emit shorter, human-readable text messages.</p>
+<p><code>json-diagnostic-short</code>: Ensure the <code>rendered</code> field of JSON messages contains
+the "short" rendering from rustc.</p>
+</li>
+<li>
+<p><code>json-diagnostic-rendered-ansi</code>: Ensure the <code>rendered</code> field of JSON messages
+contains embedded ANSI color codes for respecting rustc&#8217;s default color
+scheme.</p>
+</li>
+<li>
+<p><code>json-render-diagnostics</code>: Instruct Cargo to not include rustc diagnostics in
+in JSON messages printed, but instead Cargo itself should render the
+JSON diagnostics coming from rustc. Cargo&#8217;s own JSON diagnostics and others
+coming from rustc are still emitted.</p>
 </li>
 </ul>
 </div>

--- a/src/doc/man/generated/cargo-fix.html
+++ b/src/doc/man/generated/cargo-fix.html
@@ -308,17 +308,33 @@ terminal.</p>
 </dd>
 <dt class="hdlist1"><strong>--message-format</strong> <em>FMT</em></dt>
 <dd>
-<p>The output format for diagnostic messages. Valid values:</p>
+<p>The output format for diagnostic messages. Can be specified multiple times
+and consists of comma-separated values. Valid values:</p>
 <div class="ulist">
 <ul>
 <li>
 <p><code>human</code> (default): Display in a human-readable text format.</p>
 </li>
 <li>
+<p><code>short</code>: Emit shorter, human-readable text messages.</p>
+</li>
+<li>
 <p><code>json</code>: Emit JSON messages to stdout.</p>
 </li>
 <li>
-<p><code>short</code>: Emit shorter, human-readable text messages.</p>
+<p><code>json-diagnostic-short</code>: Ensure the <code>rendered</code> field of JSON messages contains
+the "short" rendering from rustc.</p>
+</li>
+<li>
+<p><code>json-diagnostic-rendered-ansi</code>: Ensure the <code>rendered</code> field of JSON messages
+contains embedded ANSI color codes for respecting rustc&#8217;s default color
+scheme.</p>
+</li>
+<li>
+<p><code>json-render-diagnostics</code>: Instruct Cargo to not include rustc diagnostics in
+in JSON messages printed, but instead Cargo itself should render the
+JSON diagnostics coming from rustc. Cargo&#8217;s own JSON diagnostics and others
+coming from rustc are still emitted.</p>
 </li>
 </ul>
 </div>

--- a/src/doc/man/generated/cargo-metadata.html
+++ b/src/doc/man/generated/cargo-metadata.html
@@ -35,7 +35,7 @@ for a Rust API for reading the metadata.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight"><code class="language-javascript hljs" data-lang="javascript">{
+<pre class="highlightjs highlight"><code data-lang="javascript" class="language-javascript hljs">{
     /* Array of all packages in the workspace.
        It also includes all feature-enabled dependencies unless --no-deps is used.
     */

--- a/src/doc/man/generated/cargo-run.html
+++ b/src/doc/man/generated/cargo-run.html
@@ -168,17 +168,33 @@ terminal.</p>
 </dd>
 <dt class="hdlist1"><strong>--message-format</strong> <em>FMT</em></dt>
 <dd>
-<p>The output format for diagnostic messages. Valid values:</p>
+<p>The output format for diagnostic messages. Can be specified multiple times
+and consists of comma-separated values. Valid values:</p>
 <div class="ulist">
 <ul>
 <li>
 <p><code>human</code> (default): Display in a human-readable text format.</p>
 </li>
 <li>
+<p><code>short</code>: Emit shorter, human-readable text messages.</p>
+</li>
+<li>
 <p><code>json</code>: Emit JSON messages to stdout.</p>
 </li>
 <li>
-<p><code>short</code>: Emit shorter, human-readable text messages.</p>
+<p><code>json-diagnostic-short</code>: Ensure the <code>rendered</code> field of JSON messages contains
+the "short" rendering from rustc.</p>
+</li>
+<li>
+<p><code>json-diagnostic-rendered-ansi</code>: Ensure the <code>rendered</code> field of JSON messages
+contains embedded ANSI color codes for respecting rustc&#8217;s default color
+scheme.</p>
+</li>
+<li>
+<p><code>json-render-diagnostics</code>: Instruct Cargo to not include rustc diagnostics in
+in JSON messages printed, but instead Cargo itself should render the
+JSON diagnostics coming from rustc. Cargo&#8217;s own JSON diagnostics and others
+coming from rustc are still emitted.</p>
 </li>
 </ul>
 </div>

--- a/src/doc/man/generated/cargo-rustc.html
+++ b/src/doc/man/generated/cargo-rustc.html
@@ -229,17 +229,33 @@ terminal.</p>
 </dd>
 <dt class="hdlist1"><strong>--message-format</strong> <em>FMT</em></dt>
 <dd>
-<p>The output format for diagnostic messages. Valid values:</p>
+<p>The output format for diagnostic messages. Can be specified multiple times
+and consists of comma-separated values. Valid values:</p>
 <div class="ulist">
 <ul>
 <li>
 <p><code>human</code> (default): Display in a human-readable text format.</p>
 </li>
 <li>
+<p><code>short</code>: Emit shorter, human-readable text messages.</p>
+</li>
+<li>
 <p><code>json</code>: Emit JSON messages to stdout.</p>
 </li>
 <li>
-<p><code>short</code>: Emit shorter, human-readable text messages.</p>
+<p><code>json-diagnostic-short</code>: Ensure the <code>rendered</code> field of JSON messages contains
+the "short" rendering from rustc.</p>
+</li>
+<li>
+<p><code>json-diagnostic-rendered-ansi</code>: Ensure the <code>rendered</code> field of JSON messages
+contains embedded ANSI color codes for respecting rustc&#8217;s default color
+scheme.</p>
+</li>
+<li>
+<p><code>json-render-diagnostics</code>: Instruct Cargo to not include rustc diagnostics in
+in JSON messages printed, but instead Cargo itself should render the
+JSON diagnostics coming from rustc. Cargo&#8217;s own JSON diagnostics and others
+coming from rustc are still emitted.</p>
 </li>
 </ul>
 </div>

--- a/src/doc/man/generated/cargo-rustdoc.html
+++ b/src/doc/man/generated/cargo-rustdoc.html
@@ -242,17 +242,33 @@ terminal.</p>
 </dd>
 <dt class="hdlist1"><strong>--message-format</strong> <em>FMT</em></dt>
 <dd>
-<p>The output format for diagnostic messages. Valid values:</p>
+<p>The output format for diagnostic messages. Can be specified multiple times
+and consists of comma-separated values. Valid values:</p>
 <div class="ulist">
 <ul>
 <li>
 <p><code>human</code> (default): Display in a human-readable text format.</p>
 </li>
 <li>
+<p><code>short</code>: Emit shorter, human-readable text messages.</p>
+</li>
+<li>
 <p><code>json</code>: Emit JSON messages to stdout.</p>
 </li>
 <li>
-<p><code>short</code>: Emit shorter, human-readable text messages.</p>
+<p><code>json-diagnostic-short</code>: Ensure the <code>rendered</code> field of JSON messages contains
+the "short" rendering from rustc.</p>
+</li>
+<li>
+<p><code>json-diagnostic-rendered-ansi</code>: Ensure the <code>rendered</code> field of JSON messages
+contains embedded ANSI color codes for respecting rustc&#8217;s default color
+scheme.</p>
+</li>
+<li>
+<p><code>json-render-diagnostics</code>: Instruct Cargo to not include rustc diagnostics in
+in JSON messages printed, but instead Cargo itself should render the
+JSON diagnostics coming from rustc. Cargo&#8217;s own JSON diagnostics and others
+coming from rustc are still emitted.</p>
 </li>
 </ul>
 </div>

--- a/src/doc/man/generated/cargo-test.html
+++ b/src/doc/man/generated/cargo-test.html
@@ -326,17 +326,33 @@ terminal.</p>
 </dd>
 <dt class="hdlist1"><strong>--message-format</strong> <em>FMT</em></dt>
 <dd>
-<p>The output format for diagnostic messages. Valid values:</p>
+<p>The output format for diagnostic messages. Can be specified multiple times
+and consists of comma-separated values. Valid values:</p>
 <div class="ulist">
 <ul>
 <li>
 <p><code>human</code> (default): Display in a human-readable text format.</p>
 </li>
 <li>
+<p><code>short</code>: Emit shorter, human-readable text messages.</p>
+</li>
+<li>
 <p><code>json</code>: Emit JSON messages to stdout.</p>
 </li>
 <li>
-<p><code>short</code>: Emit shorter, human-readable text messages.</p>
+<p><code>json-diagnostic-short</code>: Ensure the <code>rendered</code> field of JSON messages contains
+the "short" rendering from rustc.</p>
+</li>
+<li>
+<p><code>json-diagnostic-rendered-ansi</code>: Ensure the <code>rendered</code> field of JSON messages
+contains embedded ANSI color codes for respecting rustc&#8217;s default color
+scheme.</p>
+</li>
+<li>
+<p><code>json-render-diagnostics</code>: Instruct Cargo to not include rustc diagnostics in
+in JSON messages printed, but instead Cargo itself should render the
+JSON diagnostics coming from rustc. Cargo&#8217;s own JSON diagnostics and others
+coming from rustc are still emitted.</p>
 </li>
 </ul>
 </div>

--- a/src/doc/man/options-message-format.adoc
+++ b/src/doc/man/options-message-format.adoc
@@ -1,6 +1,16 @@
 *--message-format* _FMT_::
-    The output format for diagnostic messages. Valid values:
+    The output format for diagnostic messages. Can be specified multiple times
+    and consists of comma-separated values. Valid values:
 +
 - `human` (default): Display in a human-readable text format.
-- `json`: Emit JSON messages to stdout.
 - `short`: Emit shorter, human-readable text messages.
+- `json`: Emit JSON messages to stdout.
+- `json-diagnostic-short`: Ensure the `rendered` field of JSON messages contains
+  the "short" rendering from rustc.
+- `json-diagnostic-rendered-ansi`: Ensure the `rendered` field of JSON messages
+  contains embedded ANSI color codes for respecting rustc's default color
+  scheme.
+- `json-render-diagnostics`: Instruct Cargo to not include rustc diagnostics in
+  in JSON messages printed, but instead Cargo itself should render the
+  JSON diagnostics coming from rustc. Cargo's own JSON diagnostics and others
+  coming from rustc are still emitted.

--- a/src/etc/man/cargo-bench.1
+++ b/src/etc/man/cargo-bench.1
@@ -1,13 +1,13 @@
 '\" t
 .\"     Title: cargo-bench
 .\"    Author: [see the "AUTHOR(S)" section]
-.\" Generator: Asciidoctor 1.5.8
-.\"      Date: 2019-05-08
+.\" Generator: Asciidoctor 2.0.8
+.\"      Date: 2019-06-07
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "CARGO\-BENCH" "1" "2019-05-08" "\ \&" "\ \&"
+.TH "CARGO\-BENCH" "1" "2019-06-07" "\ \&" "\ \&"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0
@@ -347,7 +347,8 @@ May also be specified with the \fBterm.color\fP
 .sp
 \fB\-\-message\-format\fP \fIFMT\fP
 .RS 4
-The output format for diagnostic messages. Valid values:
+The output format for diagnostic messages. Can be specified multiple times
+and consists of comma\-separated values. Valid values:
 .sp
 .RS 4
 .ie n \{\
@@ -358,6 +359,17 @@ The output format for diagnostic messages. Valid values:
 .  IP \(bu 2.3
 .\}
 \fBhuman\fP (default): Display in a human\-readable text format.
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.  sp -1
+.  IP \(bu 2.3
+.\}
+\fBshort\fP: Emit shorter, human\-readable text messages.
 .RE
 .sp
 .RS 4
@@ -379,7 +391,35 @@ The output format for diagnostic messages. Valid values:
 .  sp -1
 .  IP \(bu 2.3
 .\}
-\fBshort\fP: Emit shorter, human\-readable text messages.
+\fBjson\-diagnostic\-short\fP: Ensure the \fBrendered\fP field of JSON messages contains
+the "short" rendering from rustc.
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.  sp -1
+.  IP \(bu 2.3
+.\}
+\fBjson\-diagnostic\-rendered\-ansi\fP: Ensure the \fBrendered\fP field of JSON messages
+contains embedded ANSI color codes for respecting rustc\(cqs default color
+scheme.
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.  sp -1
+.  IP \(bu 2.3
+.\}
+\fBjson\-render\-diagnostics\fP: Instruct Cargo to not include rustc diagnostics in
+in JSON messages printed, but instead Cargo itself should render the
+JSON diagnostics coming from rustc. Cargo\(cqs own JSON diagnostics and others
+coming from rustc are still emitted.
 .RE
 .RE
 .SS "Manifest Options"

--- a/src/etc/man/cargo-build.1
+++ b/src/etc/man/cargo-build.1
@@ -1,13 +1,13 @@
 '\" t
 .\"     Title: cargo-build
 .\"    Author: [see the "AUTHOR(S)" section]
-.\" Generator: Asciidoctor 1.5.8
-.\"      Date: 2019-05-08
+.\" Generator: Asciidoctor 2.0.8
+.\"      Date: 2019-06-07
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "CARGO\-BUILD" "1" "2019-05-08" "\ \&" "\ \&"
+.TH "CARGO\-BUILD" "1" "2019-06-07" "\ \&" "\ \&"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0
@@ -256,7 +256,8 @@ May also be specified with the \fBterm.color\fP
 .sp
 \fB\-\-message\-format\fP \fIFMT\fP
 .RS 4
-The output format for diagnostic messages. Valid values:
+The output format for diagnostic messages. Can be specified multiple times
+and consists of comma\-separated values. Valid values:
 .sp
 .RS 4
 .ie n \{\
@@ -267,6 +268,17 @@ The output format for diagnostic messages. Valid values:
 .  IP \(bu 2.3
 .\}
 \fBhuman\fP (default): Display in a human\-readable text format.
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.  sp -1
+.  IP \(bu 2.3
+.\}
+\fBshort\fP: Emit shorter, human\-readable text messages.
 .RE
 .sp
 .RS 4
@@ -288,7 +300,35 @@ The output format for diagnostic messages. Valid values:
 .  sp -1
 .  IP \(bu 2.3
 .\}
-\fBshort\fP: Emit shorter, human\-readable text messages.
+\fBjson\-diagnostic\-short\fP: Ensure the \fBrendered\fP field of JSON messages contains
+the "short" rendering from rustc.
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.  sp -1
+.  IP \(bu 2.3
+.\}
+\fBjson\-diagnostic\-rendered\-ansi\fP: Ensure the \fBrendered\fP field of JSON messages
+contains embedded ANSI color codes for respecting rustc\(cqs default color
+scheme.
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.  sp -1
+.  IP \(bu 2.3
+.\}
+\fBjson\-render\-diagnostics\fP: Instruct Cargo to not include rustc diagnostics in
+in JSON messages printed, but instead Cargo itself should render the
+JSON diagnostics coming from rustc. Cargo\(cqs own JSON diagnostics and others
+coming from rustc are still emitted.
 .RE
 .RE
 .sp

--- a/src/etc/man/cargo-check.1
+++ b/src/etc/man/cargo-check.1
@@ -1,13 +1,13 @@
 '\" t
 .\"     Title: cargo-check
 .\"    Author: [see the "AUTHOR(S)" section]
-.\" Generator: Asciidoctor 1.5.8
-.\"      Date: 2019-04-16
+.\" Generator: Asciidoctor 2.0.8
+.\"      Date: 2019-06-07
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "CARGO\-CHECK" "1" "2019-04-16" "\ \&" "\ \&"
+.TH "CARGO\-CHECK" "1" "2019-06-07" "\ \&" "\ \&"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0
@@ -256,7 +256,8 @@ May also be specified with the \fBterm.color\fP
 .sp
 \fB\-\-message\-format\fP \fIFMT\fP
 .RS 4
-The output format for diagnostic messages. Valid values:
+The output format for diagnostic messages. Can be specified multiple times
+and consists of comma\-separated values. Valid values:
 .sp
 .RS 4
 .ie n \{\
@@ -267,6 +268,17 @@ The output format for diagnostic messages. Valid values:
 .  IP \(bu 2.3
 .\}
 \fBhuman\fP (default): Display in a human\-readable text format.
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.  sp -1
+.  IP \(bu 2.3
+.\}
+\fBshort\fP: Emit shorter, human\-readable text messages.
 .RE
 .sp
 .RS 4
@@ -288,7 +300,35 @@ The output format for diagnostic messages. Valid values:
 .  sp -1
 .  IP \(bu 2.3
 .\}
-\fBshort\fP: Emit shorter, human\-readable text messages.
+\fBjson\-diagnostic\-short\fP: Ensure the \fBrendered\fP field of JSON messages contains
+the "short" rendering from rustc.
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.  sp -1
+.  IP \(bu 2.3
+.\}
+\fBjson\-diagnostic\-rendered\-ansi\fP: Ensure the \fBrendered\fP field of JSON messages
+contains embedded ANSI color codes for respecting rustc\(cqs default color
+scheme.
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.  sp -1
+.  IP \(bu 2.3
+.\}
+\fBjson\-render\-diagnostics\fP: Instruct Cargo to not include rustc diagnostics in
+in JSON messages printed, but instead Cargo itself should render the
+JSON diagnostics coming from rustc. Cargo\(cqs own JSON diagnostics and others
+coming from rustc are still emitted.
 .RE
 .RE
 .SS "Manifest Options"

--- a/src/etc/man/cargo-clean.1
+++ b/src/etc/man/cargo-clean.1
@@ -1,13 +1,13 @@
 '\" t
 .\"     Title: cargo-clean
 .\"    Author: [see the "AUTHOR(S)" section]
-.\" Generator: Asciidoctor 1.5.8
-.\"      Date: 2019-04-16
+.\" Generator: Asciidoctor 2.0.8
+.\"      Date: 2019-06-07
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "CARGO\-CLEAN" "1" "2019-04-16" "\ \&" "\ \&"
+.TH "CARGO\-CLEAN" "1" "2019-06-07" "\ \&" "\ \&"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0

--- a/src/etc/man/cargo-doc.1
+++ b/src/etc/man/cargo-doc.1
@@ -1,13 +1,13 @@
 '\" t
 .\"     Title: cargo-doc
 .\"    Author: [see the "AUTHOR(S)" section]
-.\" Generator: Asciidoctor 1.5.8
-.\"      Date: 2019-04-16
+.\" Generator: Asciidoctor 2.0.8
+.\"      Date: 2019-06-07
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "CARGO\-DOC" "1" "2019-04-16" "\ \&" "\ \&"
+.TH "CARGO\-DOC" "1" "2019-06-07" "\ \&" "\ \&"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0
@@ -213,7 +213,8 @@ May also be specified with the \fBterm.color\fP
 .sp
 \fB\-\-message\-format\fP \fIFMT\fP
 .RS 4
-The output format for diagnostic messages. Valid values:
+The output format for diagnostic messages. Can be specified multiple times
+and consists of comma\-separated values. Valid values:
 .sp
 .RS 4
 .ie n \{\
@@ -224,6 +225,17 @@ The output format for diagnostic messages. Valid values:
 .  IP \(bu 2.3
 .\}
 \fBhuman\fP (default): Display in a human\-readable text format.
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.  sp -1
+.  IP \(bu 2.3
+.\}
+\fBshort\fP: Emit shorter, human\-readable text messages.
 .RE
 .sp
 .RS 4
@@ -245,7 +257,35 @@ The output format for diagnostic messages. Valid values:
 .  sp -1
 .  IP \(bu 2.3
 .\}
-\fBshort\fP: Emit shorter, human\-readable text messages.
+\fBjson\-diagnostic\-short\fP: Ensure the \fBrendered\fP field of JSON messages contains
+the "short" rendering from rustc.
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.  sp -1
+.  IP \(bu 2.3
+.\}
+\fBjson\-diagnostic\-rendered\-ansi\fP: Ensure the \fBrendered\fP field of JSON messages
+contains embedded ANSI color codes for respecting rustc\(cqs default color
+scheme.
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.  sp -1
+.  IP \(bu 2.3
+.\}
+\fBjson\-render\-diagnostics\fP: Instruct Cargo to not include rustc diagnostics in
+in JSON messages printed, but instead Cargo itself should render the
+JSON diagnostics coming from rustc. Cargo\(cqs own JSON diagnostics and others
+coming from rustc are still emitted.
 .RE
 .RE
 .SS "Manifest Options"

--- a/src/etc/man/cargo-fetch.1
+++ b/src/etc/man/cargo-fetch.1
@@ -1,13 +1,13 @@
 '\" t
 .\"     Title: cargo-fetch
 .\"    Author: [see the "AUTHOR(S)" section]
-.\" Generator: Asciidoctor 1.5.8
-.\"      Date: 2019-05-12
+.\" Generator: Asciidoctor 2.0.8
+.\"      Date: 2019-06-07
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "CARGO\-FETCH" "1" "2019-05-12" "\ \&" "\ \&"
+.TH "CARGO\-FETCH" "1" "2019-06-07" "\ \&" "\ \&"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0

--- a/src/etc/man/cargo-fix.1
+++ b/src/etc/man/cargo-fix.1
@@ -1,13 +1,13 @@
 '\" t
 .\"     Title: cargo-fix
 .\"    Author: [see the "AUTHOR(S)" section]
-.\" Generator: Asciidoctor 1.5.8
-.\"      Date: 2019-04-16
+.\" Generator: Asciidoctor 2.0.8
+.\"      Date: 2019-06-07
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "CARGO\-FIX" "1" "2019-04-16" "\ \&" "\ \&"
+.TH "CARGO\-FIX" "1" "2019-06-07" "\ \&" "\ \&"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0
@@ -326,7 +326,8 @@ May also be specified with the \fBterm.color\fP
 .sp
 \fB\-\-message\-format\fP \fIFMT\fP
 .RS 4
-The output format for diagnostic messages. Valid values:
+The output format for diagnostic messages. Can be specified multiple times
+and consists of comma\-separated values. Valid values:
 .sp
 .RS 4
 .ie n \{\
@@ -337,6 +338,17 @@ The output format for diagnostic messages. Valid values:
 .  IP \(bu 2.3
 .\}
 \fBhuman\fP (default): Display in a human\-readable text format.
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.  sp -1
+.  IP \(bu 2.3
+.\}
+\fBshort\fP: Emit shorter, human\-readable text messages.
 .RE
 .sp
 .RS 4
@@ -358,7 +370,35 @@ The output format for diagnostic messages. Valid values:
 .  sp -1
 .  IP \(bu 2.3
 .\}
-\fBshort\fP: Emit shorter, human\-readable text messages.
+\fBjson\-diagnostic\-short\fP: Ensure the \fBrendered\fP field of JSON messages contains
+the "short" rendering from rustc.
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.  sp -1
+.  IP \(bu 2.3
+.\}
+\fBjson\-diagnostic\-rendered\-ansi\fP: Ensure the \fBrendered\fP field of JSON messages
+contains embedded ANSI color codes for respecting rustc\(cqs default color
+scheme.
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.  sp -1
+.  IP \(bu 2.3
+.\}
+\fBjson\-render\-diagnostics\fP: Instruct Cargo to not include rustc diagnostics in
+in JSON messages printed, but instead Cargo itself should render the
+JSON diagnostics coming from rustc. Cargo\(cqs own JSON diagnostics and others
+coming from rustc are still emitted.
 .RE
 .RE
 .SS "Manifest Options"

--- a/src/etc/man/cargo-generate-lockfile.1
+++ b/src/etc/man/cargo-generate-lockfile.1
@@ -1,13 +1,13 @@
 '\" t
 .\"     Title: cargo-generate-lockfile
 .\"    Author: [see the "AUTHOR(S)" section]
-.\" Generator: Asciidoctor 1.5.8
-.\"      Date: 2019-04-16
+.\" Generator: Asciidoctor 2.0.8
+.\"      Date: 2019-06-07
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "CARGO\-GENERATE\-LOCKFILE" "1" "2019-04-16" "\ \&" "\ \&"
+.TH "CARGO\-GENERATE\-LOCKFILE" "1" "2019-06-07" "\ \&" "\ \&"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0

--- a/src/etc/man/cargo-help.1
+++ b/src/etc/man/cargo-help.1
@@ -1,13 +1,13 @@
 '\" t
 .\"     Title: cargo-help
 .\"    Author: [see the "AUTHOR(S)" section]
-.\" Generator: Asciidoctor 1.5.8
-.\"      Date: 2018-12-20
+.\" Generator: Asciidoctor 2.0.8
+.\"      Date: 2019-06-07
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "CARGO\-HELP" "1" "2018-12-20" "\ \&" "\ \&"
+.TH "CARGO\-HELP" "1" "2019-06-07" "\ \&" "\ \&"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0

--- a/src/etc/man/cargo-init.1
+++ b/src/etc/man/cargo-init.1
@@ -1,13 +1,13 @@
 '\" t
 .\"     Title: cargo-init
 .\"    Author: [see the "AUTHOR(S)" section]
-.\" Generator: Asciidoctor 1.5.8
-.\"      Date: 2019-01-23
+.\" Generator: Asciidoctor 2.0.8
+.\"      Date: 2019-06-07
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "CARGO\-INIT" "1" "2019-01-23" "\ \&" "\ \&"
+.TH "CARGO\-INIT" "1" "2019-06-07" "\ \&" "\ \&"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0

--- a/src/etc/man/cargo-install.1
+++ b/src/etc/man/cargo-install.1
@@ -1,13 +1,13 @@
 '\" t
 .\"     Title: cargo-install
 .\"    Author: [see the "AUTHOR(S)" section]
-.\" Generator: Asciidoctor 1.5.8
-.\"      Date: 2019-06-10
+.\" Generator: Asciidoctor 2.0.8
+.\"      Date: 2019-07-15
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "CARGO\-INSTALL" "1" "2019-06-10" "\ \&" "\ \&"
+.TH "CARGO\-INSTALL" "1" "2019-07-15" "\ \&" "\ \&"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0

--- a/src/etc/man/cargo-locate-project.1
+++ b/src/etc/man/cargo-locate-project.1
@@ -1,13 +1,13 @@
 '\" t
 .\"     Title: cargo-locate-project
 .\"    Author: [see the "AUTHOR(S)" section]
-.\" Generator: Asciidoctor 1.5.8
-.\"      Date: 2018-12-20
+.\" Generator: Asciidoctor 2.0.8
+.\"      Date: 2019-06-07
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "CARGO\-LOCATE\-PROJECT" "1" "2018-12-20" "\ \&" "\ \&"
+.TH "CARGO\-LOCATE\-PROJECT" "1" "2019-06-07" "\ \&" "\ \&"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0

--- a/src/etc/man/cargo-login.1
+++ b/src/etc/man/cargo-login.1
@@ -1,13 +1,13 @@
 '\" t
 .\"     Title: cargo-login
 .\"    Author: [see the "AUTHOR(S)" section]
-.\" Generator: Asciidoctor 1.5.8
-.\"      Date: 2019-01-23
+.\" Generator: Asciidoctor 2.0.8
+.\"      Date: 2019-06-07
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "CARGO\-LOGIN" "1" "2019-01-23" "\ \&" "\ \&"
+.TH "CARGO\-LOGIN" "1" "2019-06-07" "\ \&" "\ \&"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0

--- a/src/etc/man/cargo-metadata.1
+++ b/src/etc/man/cargo-metadata.1
@@ -1,13 +1,13 @@
 '\" t
 .\"     Title: cargo-metadata
 .\"    Author: [see the "AUTHOR(S)" section]
-.\" Generator: Asciidoctor 1.5.8
-.\"      Date: 2019-05-20
+.\" Generator: Asciidoctor 2.0.8
+.\"      Date: 2019-06-07
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "CARGO\-METADATA" "1" "2019-05-20" "\ \&" "\ \&"
+.TH "CARGO\-METADATA" "1" "2019-06-07" "\ \&" "\ \&"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0

--- a/src/etc/man/cargo-new.1
+++ b/src/etc/man/cargo-new.1
@@ -1,13 +1,13 @@
 '\" t
 .\"     Title: cargo-new
 .\"    Author: [see the "AUTHOR(S)" section]
-.\" Generator: Asciidoctor 1.5.8
-.\"      Date: 2019-01-23
+.\" Generator: Asciidoctor 2.0.8
+.\"      Date: 2019-06-07
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "CARGO\-NEW" "1" "2019-01-23" "\ \&" "\ \&"
+.TH "CARGO\-NEW" "1" "2019-06-07" "\ \&" "\ \&"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0

--- a/src/etc/man/cargo-owner.1
+++ b/src/etc/man/cargo-owner.1
@@ -1,13 +1,13 @@
 '\" t
 .\"     Title: cargo-owner
 .\"    Author: [see the "AUTHOR(S)" section]
-.\" Generator: Asciidoctor 1.5.8
-.\"      Date: 2019-02-05
+.\" Generator: Asciidoctor 2.0.8
+.\"      Date: 2019-06-07
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "CARGO\-OWNER" "1" "2019-02-05" "\ \&" "\ \&"
+.TH "CARGO\-OWNER" "1" "2019-06-07" "\ \&" "\ \&"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0

--- a/src/etc/man/cargo-package.1
+++ b/src/etc/man/cargo-package.1
@@ -1,13 +1,13 @@
 '\" t
 .\"     Title: cargo-package
 .\"    Author: [see the "AUTHOR(S)" section]
-.\" Generator: Asciidoctor 1.5.8
-.\"      Date: 2019-06-10
+.\" Generator: Asciidoctor 2.0.8
+.\"      Date: 2019-07-15
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "CARGO\-PACKAGE" "1" "2019-06-10" "\ \&" "\ \&"
+.TH "CARGO\-PACKAGE" "1" "2019-07-15" "\ \&" "\ \&"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0

--- a/src/etc/man/cargo-pkgid.1
+++ b/src/etc/man/cargo-pkgid.1
@@ -1,13 +1,13 @@
 '\" t
 .\"     Title: cargo-pkgid
 .\"    Author: [see the "AUTHOR(S)" section]
-.\" Generator: Asciidoctor 1.5.8
-.\"      Date: 2019-04-16
+.\" Generator: Asciidoctor 2.0.8
+.\"      Date: 2019-06-07
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "CARGO\-PKGID" "1" "2019-04-16" "\ \&" "\ \&"
+.TH "CARGO\-PKGID" "1" "2019-06-07" "\ \&" "\ \&"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0

--- a/src/etc/man/cargo-publish.1
+++ b/src/etc/man/cargo-publish.1
@@ -1,13 +1,13 @@
 '\" t
 .\"     Title: cargo-publish
 .\"    Author: [see the "AUTHOR(S)" section]
-.\" Generator: Asciidoctor 1.5.8
-.\"      Date: 2019-05-08
+.\" Generator: Asciidoctor 2.0.8
+.\"      Date: 2019-06-07
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "CARGO\-PUBLISH" "1" "2019-05-08" "\ \&" "\ \&"
+.TH "CARGO\-PUBLISH" "1" "2019-06-07" "\ \&" "\ \&"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0

--- a/src/etc/man/cargo-run.1
+++ b/src/etc/man/cargo-run.1
@@ -1,13 +1,13 @@
 '\" t
 .\"     Title: cargo-run
 .\"    Author: [see the "AUTHOR(S)" section]
-.\" Generator: Asciidoctor 1.5.8
-.\"      Date: 2019-06-21
+.\" Generator: Asciidoctor 2.0.8
+.\"      Date: 2019-07-15
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "CARGO\-RUN" "1" "2019-06-21" "\ \&" "\ \&"
+.TH "CARGO\-RUN" "1" "2019-07-15" "\ \&" "\ \&"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0
@@ -176,7 +176,8 @@ May also be specified with the \fBterm.color\fP
 .sp
 \fB\-\-message\-format\fP \fIFMT\fP
 .RS 4
-The output format for diagnostic messages. Valid values:
+The output format for diagnostic messages. Can be specified multiple times
+and consists of comma\-separated values. Valid values:
 .sp
 .RS 4
 .ie n \{\
@@ -187,6 +188,17 @@ The output format for diagnostic messages. Valid values:
 .  IP \(bu 2.3
 .\}
 \fBhuman\fP (default): Display in a human\-readable text format.
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.  sp -1
+.  IP \(bu 2.3
+.\}
+\fBshort\fP: Emit shorter, human\-readable text messages.
 .RE
 .sp
 .RS 4
@@ -208,7 +220,35 @@ The output format for diagnostic messages. Valid values:
 .  sp -1
 .  IP \(bu 2.3
 .\}
-\fBshort\fP: Emit shorter, human\-readable text messages.
+\fBjson\-diagnostic\-short\fP: Ensure the \fBrendered\fP field of JSON messages contains
+the "short" rendering from rustc.
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.  sp -1
+.  IP \(bu 2.3
+.\}
+\fBjson\-diagnostic\-rendered\-ansi\fP: Ensure the \fBrendered\fP field of JSON messages
+contains embedded ANSI color codes for respecting rustc\(cqs default color
+scheme.
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.  sp -1
+.  IP \(bu 2.3
+.\}
+\fBjson\-render\-diagnostics\fP: Instruct Cargo to not include rustc diagnostics in
+in JSON messages printed, but instead Cargo itself should render the
+JSON diagnostics coming from rustc. Cargo\(cqs own JSON diagnostics and others
+coming from rustc are still emitted.
 .RE
 .RE
 .SS "Manifest Options"

--- a/src/etc/man/cargo-rustc.1
+++ b/src/etc/man/cargo-rustc.1
@@ -1,13 +1,13 @@
 '\" t
 .\"     Title: cargo-rustc
 .\"    Author: [see the "AUTHOR(S)" section]
-.\" Generator: Asciidoctor 1.5.8
-.\"      Date: 2019-04-16
+.\" Generator: Asciidoctor 2.0.8
+.\"      Date: 2019-06-07
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "CARGO\-RUSTC" "1" "2019-04-16" "\ \&" "\ \&"
+.TH "CARGO\-RUSTC" "1" "2019-06-07" "\ \&" "\ \&"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0
@@ -245,7 +245,8 @@ May also be specified with the \fBterm.color\fP
 .sp
 \fB\-\-message\-format\fP \fIFMT\fP
 .RS 4
-The output format for diagnostic messages. Valid values:
+The output format for diagnostic messages. Can be specified multiple times
+and consists of comma\-separated values. Valid values:
 .sp
 .RS 4
 .ie n \{\
@@ -256,6 +257,17 @@ The output format for diagnostic messages. Valid values:
 .  IP \(bu 2.3
 .\}
 \fBhuman\fP (default): Display in a human\-readable text format.
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.  sp -1
+.  IP \(bu 2.3
+.\}
+\fBshort\fP: Emit shorter, human\-readable text messages.
 .RE
 .sp
 .RS 4
@@ -277,7 +289,35 @@ The output format for diagnostic messages. Valid values:
 .  sp -1
 .  IP \(bu 2.3
 .\}
-\fBshort\fP: Emit shorter, human\-readable text messages.
+\fBjson\-diagnostic\-short\fP: Ensure the \fBrendered\fP field of JSON messages contains
+the "short" rendering from rustc.
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.  sp -1
+.  IP \(bu 2.3
+.\}
+\fBjson\-diagnostic\-rendered\-ansi\fP: Ensure the \fBrendered\fP field of JSON messages
+contains embedded ANSI color codes for respecting rustc\(cqs default color
+scheme.
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.  sp -1
+.  IP \(bu 2.3
+.\}
+\fBjson\-render\-diagnostics\fP: Instruct Cargo to not include rustc diagnostics in
+in JSON messages printed, but instead Cargo itself should render the
+JSON diagnostics coming from rustc. Cargo\(cqs own JSON diagnostics and others
+coming from rustc are still emitted.
 .RE
 .RE
 .SS "Manifest Options"

--- a/src/etc/man/cargo-rustdoc.1
+++ b/src/etc/man/cargo-rustdoc.1
@@ -1,13 +1,13 @@
 '\" t
 .\"     Title: cargo-rustdoc
 .\"    Author: [see the "AUTHOR(S)" section]
-.\" Generator: Asciidoctor 1.5.8
-.\"      Date: 2019-04-16
+.\" Generator: Asciidoctor 2.0.8
+.\"      Date: 2019-06-07
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "CARGO\-RUSTDOC" "1" "2019-04-16" "\ \&" "\ \&"
+.TH "CARGO\-RUSTDOC" "1" "2019-06-07" "\ \&" "\ \&"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0
@@ -253,7 +253,8 @@ May also be specified with the \fBterm.color\fP
 .sp
 \fB\-\-message\-format\fP \fIFMT\fP
 .RS 4
-The output format for diagnostic messages. Valid values:
+The output format for diagnostic messages. Can be specified multiple times
+and consists of comma\-separated values. Valid values:
 .sp
 .RS 4
 .ie n \{\
@@ -264,6 +265,17 @@ The output format for diagnostic messages. Valid values:
 .  IP \(bu 2.3
 .\}
 \fBhuman\fP (default): Display in a human\-readable text format.
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.  sp -1
+.  IP \(bu 2.3
+.\}
+\fBshort\fP: Emit shorter, human\-readable text messages.
 .RE
 .sp
 .RS 4
@@ -285,7 +297,35 @@ The output format for diagnostic messages. Valid values:
 .  sp -1
 .  IP \(bu 2.3
 .\}
-\fBshort\fP: Emit shorter, human\-readable text messages.
+\fBjson\-diagnostic\-short\fP: Ensure the \fBrendered\fP field of JSON messages contains
+the "short" rendering from rustc.
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.  sp -1
+.  IP \(bu 2.3
+.\}
+\fBjson\-diagnostic\-rendered\-ansi\fP: Ensure the \fBrendered\fP field of JSON messages
+contains embedded ANSI color codes for respecting rustc\(cqs default color
+scheme.
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.  sp -1
+.  IP \(bu 2.3
+.\}
+\fBjson\-render\-diagnostics\fP: Instruct Cargo to not include rustc diagnostics in
+in JSON messages printed, but instead Cargo itself should render the
+JSON diagnostics coming from rustc. Cargo\(cqs own JSON diagnostics and others
+coming from rustc are still emitted.
 .RE
 .RE
 .SS "Manifest Options"

--- a/src/etc/man/cargo-search.1
+++ b/src/etc/man/cargo-search.1
@@ -1,13 +1,13 @@
 '\" t
 .\"     Title: cargo-search
 .\"    Author: [see the "AUTHOR(S)" section]
-.\" Generator: Asciidoctor 1.5.8
-.\"      Date: 2019-01-23
+.\" Generator: Asciidoctor 2.0.8
+.\"      Date: 2019-06-07
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "CARGO\-SEARCH" "1" "2019-01-23" "\ \&" "\ \&"
+.TH "CARGO\-SEARCH" "1" "2019-06-07" "\ \&" "\ \&"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0

--- a/src/etc/man/cargo-test.1
+++ b/src/etc/man/cargo-test.1
@@ -1,13 +1,13 @@
 '\" t
 .\"     Title: cargo-test
 .\"    Author: [see the "AUTHOR(S)" section]
-.\" Generator: Asciidoctor 1.5.8
-.\"      Date: 2019-05-08
+.\" Generator: Asciidoctor 2.0.8
+.\"      Date: 2019-06-07
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "CARGO\-TEST" "1" "2019-05-08" "\ \&" "\ \&"
+.TH "CARGO\-TEST" "1" "2019-06-07" "\ \&" "\ \&"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0
@@ -389,7 +389,8 @@ May also be specified with the \fBterm.color\fP
 .sp
 \fB\-\-message\-format\fP \fIFMT\fP
 .RS 4
-The output format for diagnostic messages. Valid values:
+The output format for diagnostic messages. Can be specified multiple times
+and consists of comma\-separated values. Valid values:
 .sp
 .RS 4
 .ie n \{\
@@ -400,6 +401,17 @@ The output format for diagnostic messages. Valid values:
 .  IP \(bu 2.3
 .\}
 \fBhuman\fP (default): Display in a human\-readable text format.
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.  sp -1
+.  IP \(bu 2.3
+.\}
+\fBshort\fP: Emit shorter, human\-readable text messages.
 .RE
 .sp
 .RS 4
@@ -421,7 +433,35 @@ The output format for diagnostic messages. Valid values:
 .  sp -1
 .  IP \(bu 2.3
 .\}
-\fBshort\fP: Emit shorter, human\-readable text messages.
+\fBjson\-diagnostic\-short\fP: Ensure the \fBrendered\fP field of JSON messages contains
+the "short" rendering from rustc.
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.  sp -1
+.  IP \(bu 2.3
+.\}
+\fBjson\-diagnostic\-rendered\-ansi\fP: Ensure the \fBrendered\fP field of JSON messages
+contains embedded ANSI color codes for respecting rustc\(cqs default color
+scheme.
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.  sp -1
+.  IP \(bu 2.3
+.\}
+\fBjson\-render\-diagnostics\fP: Instruct Cargo to not include rustc diagnostics in
+in JSON messages printed, but instead Cargo itself should render the
+JSON diagnostics coming from rustc. Cargo\(cqs own JSON diagnostics and others
+coming from rustc are still emitted.
 .RE
 .RE
 .SS "Manifest Options"

--- a/src/etc/man/cargo-uninstall.1
+++ b/src/etc/man/cargo-uninstall.1
@@ -1,13 +1,13 @@
 '\" t
 .\"     Title: cargo-uninstall
 .\"    Author: [see the "AUTHOR(S)" section]
-.\" Generator: Asciidoctor 1.5.8
-.\"      Date: 2018-12-20
+.\" Generator: Asciidoctor 2.0.8
+.\"      Date: 2019-06-07
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "CARGO\-UNINSTALL" "1" "2018-12-20" "\ \&" "\ \&"
+.TH "CARGO\-UNINSTALL" "1" "2019-06-07" "\ \&" "\ \&"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0

--- a/src/etc/man/cargo-update.1
+++ b/src/etc/man/cargo-update.1
@@ -1,13 +1,13 @@
 '\" t
 .\"     Title: cargo-update
 .\"    Author: [see the "AUTHOR(S)" section]
-.\" Generator: Asciidoctor 1.5.8
-.\"      Date: 2019-04-16
+.\" Generator: Asciidoctor 2.0.8
+.\"      Date: 2019-06-07
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "CARGO\-UPDATE" "1" "2019-04-16" "\ \&" "\ \&"
+.TH "CARGO\-UPDATE" "1" "2019-06-07" "\ \&" "\ \&"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0

--- a/src/etc/man/cargo-vendor.1
+++ b/src/etc/man/cargo-vendor.1
@@ -2,12 +2,12 @@
 .\"     Title: cargo-vendor
 .\"    Author: [see the "AUTHOR(S)" section]
 .\" Generator: Asciidoctor 2.0.8
-.\"      Date: 2019-04-29
+.\"      Date: 2019-07-15
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "CARGO\-VENDOR" "1" "2019-04-29" "\ \&" "\ \&"
+.TH "CARGO\-VENDOR" "1" "2019-07-15" "\ \&" "\ \&"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0
@@ -148,6 +148,23 @@ attempting to access the network to determine if it is out\-of\-date.
 These may be used in environments where you want to assert that the
 \fBCargo.lock\fP file is up\-to\-date (such as a CI build) or want to avoid network
 access.
+.RE
+.sp
+\fB\-\-offline\fP
+.RS 4
+Prevents Cargo from accessing the network for any reason. Without this
+flag, Cargo will stop with an error if it needs to access the network and
+the network is not available. With this flag, Cargo will attempt to
+proceed without the network if possible.
+.sp
+Beware that this may result in different dependency resolution than online
+mode. Cargo will restrict itself to crates that are downloaded locally, even
+if there might be a newer version as indicated in the local copy of the index.
+See the \fBcargo\-fetch\fP(1) command to download dependencies before going
+offline.
+.sp
+May also be specified with the \fBnet.offline\fP \c
+.URL "https://doc.rust\-lang.org/cargo/reference/config.html" "config value" "."
 .RE
 .SH "ENVIRONMENT"
 .sp

--- a/src/etc/man/cargo-verify-project.1
+++ b/src/etc/man/cargo-verify-project.1
@@ -1,13 +1,13 @@
 '\" t
 .\"     Title: cargo-verify-project
 .\"    Author: [see the "AUTHOR(S)" section]
-.\" Generator: Asciidoctor 1.5.8
-.\"      Date: 2019-04-16
+.\" Generator: Asciidoctor 2.0.8
+.\"      Date: 2019-06-07
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "CARGO\-VERIFY\-PROJECT" "1" "2019-04-16" "\ \&" "\ \&"
+.TH "CARGO\-VERIFY\-PROJECT" "1" "2019-06-07" "\ \&" "\ \&"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0

--- a/src/etc/man/cargo-version.1
+++ b/src/etc/man/cargo-version.1
@@ -1,13 +1,13 @@
 '\" t
 .\"     Title: cargo-version
 .\"    Author: [see the "AUTHOR(S)" section]
-.\" Generator: Asciidoctor 1.5.8
-.\"      Date: 2018-12-20
+.\" Generator: Asciidoctor 2.0.8
+.\"      Date: 2019-06-07
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "CARGO\-VERSION" "1" "2018-12-20" "\ \&" "\ \&"
+.TH "CARGO\-VERSION" "1" "2019-06-07" "\ \&" "\ \&"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0

--- a/src/etc/man/cargo-yank.1
+++ b/src/etc/man/cargo-yank.1
@@ -1,13 +1,13 @@
 '\" t
 .\"     Title: cargo-yank
 .\"    Author: [see the "AUTHOR(S)" section]
-.\" Generator: Asciidoctor 1.5.8
-.\"      Date: 2019-01-23
+.\" Generator: Asciidoctor 2.0.8
+.\"      Date: 2019-06-07
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "CARGO\-YANK" "1" "2019-01-23" "\ \&" "\ \&"
+.TH "CARGO\-YANK" "1" "2019-06-07" "\ \&" "\ \&"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0

--- a/src/etc/man/cargo.1
+++ b/src/etc/man/cargo.1
@@ -1,13 +1,13 @@
 '\" t
 .\"     Title: cargo
 .\"    Author: [see the "AUTHOR(S)" section]
-.\" Generator: Asciidoctor 1.5.8
-.\"      Date: 2019-05-20
+.\" Generator: Asciidoctor 2.0.8
+.\"      Date: 2019-06-07
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "CARGO" "1" "2019-05-20" "\ \&" "\ \&"
+.TH "CARGO" "1" "2019-06-07" "\ \&" "\ \&"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -3264,11 +3264,10 @@ fn wrong_message_format_option() {
         .build();
 
     p.cargo("build --message-format XML")
-        .with_status(1)
+        .with_status(101)
         .with_stderr_contains(
             "\
-error: 'XML' isn't a valid value for '--message-format <FMT>'
-<tab>[possible values: human, json, short]
+error: invalid message format specifier: `xml`
 ",
         )
         .run();

--- a/tests/testsuite/fix.rs
+++ b/tests/testsuite/fix.rs
@@ -937,7 +937,7 @@ fn both_edition_migrate_flags() {
 error: The argument '--edition' cannot be used with '--prepare-for <prepare-for>'
 
 USAGE:
-    cargo[..] fix --edition --message-format <FMT>
+    cargo[..] fix --edition
 
 For more information try --help
 ";

--- a/tests/testsuite/main.rs
+++ b/tests/testsuite/main.rs
@@ -57,6 +57,7 @@ mod local_registry;
 mod lockfile_compat;
 mod login;
 mod member_errors;
+mod message_format;
 mod metabuild;
 mod metadata;
 mod net_config;

--- a/tests/testsuite/message_format.rs
+++ b/tests/testsuite/message_format.rs
@@ -1,0 +1,126 @@
+use crate::support::{basic_manifest, project};
+
+#[cargo_test]
+fn cannot_specify_two() {
+    if !crate::support::is_nightly() {
+        return;
+    }
+
+    let p = project()
+        .file("Cargo.toml", &basic_manifest("foo", "0.1.0"))
+        .file("src/main.rs", "fn main() {}")
+        .build();
+
+    let formats = ["human", "json", "short"];
+
+    let two_kinds = "error: cannot specify two kinds of `message-format` arguments\n";
+    for a in formats.iter() {
+        for b in formats.iter() {
+            p.cargo(&format!("build --message-format {},{}", a, b))
+                .with_status(101)
+                .with_stderr(two_kinds)
+                .run();
+        }
+    }
+}
+
+#[cargo_test]
+fn double_json_works() {
+    if !crate::support::is_nightly() {
+        return;
+    }
+
+    let p = project()
+        .file("Cargo.toml", &basic_manifest("foo", "0.1.0"))
+        .file("src/main.rs", "fn main() {}")
+        .build();
+
+    p.cargo("build --message-format json,json-render-diagnostics")
+        .run();
+    p.cargo("build --message-format json,json-diagnostic-short")
+        .run();
+    p.cargo("build --message-format json,json-diagnostic-rendered-ansi")
+        .run();
+    p.cargo("build --message-format json --message-format json-diagnostic-rendered-ansi")
+        .run();
+    p.cargo("build --message-format json-diagnostic-rendered-ansi")
+        .run();
+    p.cargo("build --message-format json-diagnostic-short,json-diagnostic-rendered-ansi")
+        .run();
+}
+
+#[cargo_test]
+fn cargo_renders() {
+    if !crate::support::is_nightly() {
+        return;
+    }
+
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = 'foo'
+                version = '0.1.0'
+
+                [dependencies]
+                bar = { path = 'bar' }
+            "#,
+        )
+        .file("src/main.rs", "")
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
+        .file("bar/src/lib.rs", "")
+        .build();
+
+    p.cargo("build --message-format json-render-diagnostics")
+        .with_status(101)
+        .with_stdout("{\"reason\":\"compiler-artifact\",[..]")
+        .with_stderr_contains(
+            "\
+[COMPILING] bar [..]
+[COMPILING] foo [..]
+error[..]`main`[..]
+",
+        )
+        .run();
+}
+
+#[cargo_test]
+fn cargo_renders_short() {
+    if !crate::support::is_nightly() {
+        return;
+    }
+
+    let p = project()
+        .file("Cargo.toml", &basic_manifest("foo", "0.1.0"))
+        .file("src/main.rs", "")
+        .build();
+
+    p.cargo("build --message-format json-render-diagnostics,json-diagnostic-short")
+        .with_status(101)
+        .with_stderr_contains(
+            "\
+[COMPILING] foo [..]
+error[..]`main`[..]
+",
+        )
+        .with_stderr_does_not_contain("note:")
+        .run();
+}
+
+#[cargo_test]
+fn cargo_renders_ansi() {
+    if !crate::support::is_nightly() {
+        return;
+    }
+
+    let p = project()
+        .file("Cargo.toml", &basic_manifest("foo", "0.1.0"))
+        .file("src/main.rs", "")
+        .build();
+
+    p.cargo("build --message-format json-diagnostic-rendered-ansi")
+        .with_status(101)
+        .with_stdout_contains("[..]\\u001b[38;5;9merror[..]")
+        .run();
+}


### PR DESCRIPTION
Cargo has of #7143 enabled pipelined compilation by default which
affects how the compiler is invoked, especially with respect to JSON
messages. This, in some testing, has proven to cause quite a few issues
with rustbuild's current integration with Cargo. This commit is aimed at
adding features to Cargo to solve this issue.

This commit adds the ability to customize the stream of JSON messages
coming from Cargo. The new feature for Cargo is that it now also mirrors
rustc in how you can configure the JSON stream. Multiple
`--message-format` arguments are now supported and the value specified
is a comma-separated list of directives. In addition to the existing
`human`, `short`, and `json` directives these new directives have been
added:

* `json-render-diagnostics` - instructs Cargo to render rustc
  diagnostics and only print out JSON messages for artifacts and Cargo
  things.

* `json-diagnostic-short` - indicates that the `rendered` field of rustc
  diagnostics should use the "short" rendering.

* `json-diagnostic-rendered-ansi` - indicates that the `rendered` field of rustc
  diagnostics should embed ansi color codes.

The first option here, `json-render-diagnostics`, will be used by
rustbuild unconditionally. Additionally `json-diagnostic-short` will be
conditionally used based on the input to rustbuild itself.

This should be enough for external tools to customize how Cargo is
invoked and how all kinds of JSON diagnostics get printed, and it's
thought that we can relatively easily tweak this as necessary to extend
it and such.