### PR TITLE
enable progress bar for FreeBSD

### DIFF
--- a/src/cargo/core/shell.rs
+++ b/src/cargo/core/shell.rs
@@ -366,7 +366,7 @@ impl ColorChoice {
     }
 }
 
-#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "freebsd"))]
 mod imp {
     use std::mem;
 
@@ -377,7 +377,7 @@ mod imp {
     pub fn stderr_width() -> Option<usize> {
         unsafe {
             let mut winsize: libc::winsize = mem::zeroed();
-            if libc::ioctl(libc::STDERR_FILENO, libc::TIOCGWINSZ, &mut winsize) < 0 {
+            if libc::ioctl(libc::STDERR_FILENO, libc::TIOCGWINSZ.into(), &mut winsize) < 0 {
                 return None;
             }
             if winsize.ws_col > 0 {
@@ -396,7 +396,10 @@ mod imp {
     }
 }
 
-#[cfg(all(unix, not(any(target_os = "linux", target_os = "macos"))))]
+#[cfg(all(
+    unix,
+    not(any(target_os = "linux", target_os = "macos", target_os = "freebsd"))
+))]
 mod imp {
     pub(super) use super::default_err_erase_line as err_erase_line;
 

--- a/src/cargo/core/shell.rs
+++ b/src/cargo/core/shell.rs
@@ -464,7 +464,13 @@ mod imp {
     }
 }
 
-#[cfg(any(all(unix, not(any(target_os = "linux", target_os = "macos"))), windows,))]
+#[cfg(any(
+    all(
+        unix,
+        not(any(target_os = "linux", target_os = "macos", target_os = "freebsd"))
+    ),
+    windows,
+))]
 fn default_err_erase_line(shell: &mut Shell) {
     if let Some(max_width) = imp::stderr_width() {
         let blank = " ".repeat(max_width);


### PR DESCRIPTION
As FreeBSD uses a unsigned long for the IOCTL syscall this code would
previously fail to compile. Adding a call to into() fixes this problem.

This code should still work on other platfroms as into() is able to
'convert' an u32 into a u32.

Also change the cfg attributes so that the working code is used.

This may also work on other not yet supported platforms, but it was not
tested.