### PR TITLE
Better error messages when `rustc` discovery parsing fails.

### DIFF
--- a/src/cargo/core/compiler/build_context/target_info.rs
+++ b/src/cargo/core/compiler/build_context/target_info.rs
@@ -170,7 +170,15 @@ impl TargetInfo {
             }
         };
 
-        let cfg = lines.map(Cfg::from_str).collect::<CargoResult<Vec<_>>>()?;
+        let cfg = lines
+            .map(Cfg::from_str)
+            .collect::<CargoResult<Vec<_>>>()
+            .chain_err(|| {
+                format!(
+                    "failed to parse the cfg from `rustc --print=cfg`, got:\n{}",
+                    output
+                )
+            })?;
 
         Ok(TargetInfo {
             crate_type_process,

--- a/src/cargo/util/rustc.rs
+++ b/src/cargo/util/rustc.rs
@@ -52,7 +52,12 @@ impl Rustc {
                 .lines()
                 .find(|l| l.starts_with("host: "))
                 .map(|l| &l[6..])
-                .ok_or_else(|| internal("rustc -v didn't have a line for `host:`"))?;
+                .ok_or_else(|| {
+                    failure::format_err!(
+                        "`rustc -vV` didn't have a line for `host:`, got:\n{}",
+                        verbose_version
+                    )
+                })?;
             triple.to_string()
         };
 


### PR DESCRIPTION
This adds a little extra info to help debug when cargo fails to parse the output from `rustc` when querying it for information.

Closes #2929
