### PR TITLE
Allow git+version dependency to be published.

### DIFF
--- a/src/cargo/ops/registry.rs
+++ b/src/cargo/ops/registry.rs
@@ -114,41 +114,47 @@ fn verify_dependencies(
     registry_src: SourceId,
 ) -> CargoResult<()> {
     for dep in pkg.dependencies().iter() {
-        if dep.source_id().is_path() {
+        if dep.source_id().is_path() || dep.source_id().is_git() {
             if !dep.specified_req() {
+                let which = if dep.source_id().is_path() {
+                    "path"
+                } else {
+                    "git"
+                };
+                let dep_version_source = dep.registry_id().map_or_else(
+                    || "crates.io".to_string(),
+                    |registry_id| registry_id.display_registry_name(),
+                );
                 bail!(
-                    "all path dependencies must have a version specified \
-                     when publishing.\ndependency `{}` does not specify \
-                     a version",
-                    dep.package_name()
+                    "all dependencies must have a version specified when publishing.\n\
+                     dependency `{}` does not specify a version\n\
+                     Note: The published dependency will use the version from {},\n\
+                     the `{}` specification will be removed from the dependency declaration.",
+                    dep.package_name(),
+                    dep_version_source,
+                    which,
                 )
             }
+        // TomlManifest::prepare_for_publish will rewrite the dependency
+        // to be just the `version` field.
         } else if dep.source_id() != registry_src {
-            if dep.source_id().is_registry() {
-                // Block requests to send to crates.io with alt-registry deps.
-                // This extra hostname check is mostly to assist with testing,
-                // but also prevents someone using `--index` to specify
-                // something that points to crates.io.
-                if registry_src.is_default_registry() || registry.host_is_crates_io() {
-                    bail!("crates cannot be published to crates.io with dependencies sourced from other\n\
-                           registries either publish `{}` on crates.io or pull it into this repository\n\
-                           and specify it with a path and version\n\
-                           (crate `{}` is pulled from {})",
-                          dep.package_name(),
-                          dep.package_name(),
-                          dep.source_id());
-                }
-            } else {
-                bail!(
-                    "crates cannot be published with dependencies sourced from \
-                     a repository\neither publish `{}` as its own crate and \
-                     specify a version as a dependency or pull it into this \
-                     repository and specify it with a path and version\n(crate `{}` has \
-                     repository path `{}`)",
-                    dep.package_name(),
-                    dep.package_name(),
-                    dep.source_id()
-                );
+            if !dep.source_id().is_registry() {
+                // Consider making SourceId::kind a public type that we can
+                // exhaustively match on. Using match can help ensure that
+                // every kind is properly handled.
+                panic!("unexpected source kind for dependency {:?}", dep);
+            }
+            // Block requests to send to crates.io with alt-registry deps.
+            // This extra hostname check is mostly to assist with testing,
+            // but also prevents someone using `--index` to specify
+            // something that points to crates.io.
+            if registry_src.is_default_registry() || registry.host_is_crates_io() {
+                bail!("crates cannot be published to crates.io with dependencies sourced from other\n\
+                       registries. `{}` needs to be published to crates.io before publishing this crate.\n\
+                       (crate `{}` is pulled from {})",
+                      dep.package_name(),
+                      dep.package_name(),
+                      dep.source_id());
             }
         }
     }

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -801,23 +801,27 @@ impl TomlManifest {
         }
 
         fn map_dependency(config: &Config, dep: &TomlDependency) -> CargoResult<TomlDependency> {
-            match *dep {
-                TomlDependency::Detailed(ref d) => {
+            match dep {
+                TomlDependency::Detailed(d) => {
                     let mut d = d.clone();
-                    d.path.take(); // path dependencies become crates.io deps
-                                   // registry specifications are elaborated to the index URL
+                    // Path dependencies become crates.io deps.
+                    d.path.take();
+                    // Same with git dependencies.
+                    d.git.take();
+                    d.branch.take();
+                    d.tag.take();
+                    d.rev.take();
+                    // registry specifications are elaborated to the index URL
                     if let Some(registry) = d.registry.take() {
                         let src = SourceId::alt_registry(config, &registry)?;
                         d.registry_index = Some(src.url().to_string());
                     }
                     Ok(TomlDependency::Detailed(d))
                 }
-                TomlDependency::Simple(ref s) => {
-                    Ok(TomlDependency::Detailed(DetailedTomlDependency {
-                        version: Some(s.clone()),
-                        ..Default::default()
-                    }))
-                }
+                TomlDependency::Simple(s) => Ok(TomlDependency::Detailed(DetailedTomlDependency {
+                    version: Some(s.clone()),
+                    ..Default::default()
+                })),
             }
         }
     }


### PR DESCRIPTION
This allows you to publish a dependency that specifies both `git` and `version`. The `git` value will be stripped out, just like a `path` dependency.

My original intent was to improve the error message, which was very confusing. I figured I might as well make `git` behave the same as `path`. I can change this PR to just reword the error instead of changing behavior if the new behavior isn't desired.

Closes #6738
