### PR TITLE
Improve error message when using API command with non-remote registry.

### DIFF
--- a/src/cargo/core/source/source_id.rs
+++ b/src/cargo/core/source/source_id.rs
@@ -259,6 +259,17 @@ impl SourceId {
         }
     }
 
+    /// Returns `true` if this source is a "remote" registry.
+    ///
+    /// "remote" may also mean a file URL to a git index, so it is not
+    /// necessarily "remote". This just means it is not `local-registry`.
+    pub fn is_remote_registry(self) -> bool {
+        match self.inner.kind {
+            Kind::Registry => true,
+            _ => false,
+        }
+    }
+
     /// Returns `true` if this source from a Git repository.
     pub fn is_git(self) -> bool {
         match self.inner.kind {

--- a/src/cargo/ops/registry.rs
+++ b/src/cargo/ops/registry.rs
@@ -345,6 +345,13 @@ fn registry(
     } = registry_configuration(config, registry.clone())?;
     let token = token.or(token_config);
     let sid = get_source_id(config, index_config.or(index), registry)?;
+    if !sid.is_remote_registry() {
+        bail!(
+            "{} does not support API commands.\n\
+             Check for a source-replacement in .cargo/config.",
+            sid
+        );
+    }
     let api_host = {
         let _lock = config.acquire_package_cache_lock()?;
         let mut src = RegistrySource::remote(sid, &HashSet::new(), config);


### PR DESCRIPTION
If you try to use an API command (publish, yank, search, etc.) with a source replacement active (like cargo-vendor or cargo-local-registry), then you get a really weird "failed to fetch" error. This adds a specific check to provide a slightly nicer error.

I'm not entirely happy with the wording, but I think it gets the point across.
