### PR TITLE
Rename `--all` to `--workspace`

### DIFF
--- a/src/bin/cargo/commands/bench.rs
+++ b/src/bin/cargo/commands/bench.rs
@@ -59,9 +59,9 @@ which indicates which package should be benchmarked. If it is not given, then
 the current package is benchmarked. For more information on SPEC and its format,
 see the `cargo help pkgid` command.
 
-All packages in the workspace are benchmarked if the `--all` flag is supplied. The
-`--all` flag is automatically assumed for a virtual manifest.
-Note that `--exclude` has to be specified in conjunction with the `--all` flag.
+All packages in the workspace are benchmarked if the `--workspace` flag is supplied. The
+`--workspace` flag is automatically assumed for a virtual manifest.
+Note that `--exclude` has to be specified in conjunction with the `--workspace` flag.
 
 The `--jobs` argument affects the building of the benchmark executable but does
 not affect how many jobs are used when running the benchmarks.

--- a/src/bin/cargo/commands/build.rs
+++ b/src/bin/cargo/commands/build.rs
@@ -42,9 +42,9 @@ pub fn cli() -> App {
         .arg_build_plan()
         .after_help(
             "\
-All packages in the workspace are built if the `--all` flag is supplied. The
-`--all` flag is automatically assumed for a virtual manifest.
-Note that `--exclude` has to be specified in conjunction with the `--all` flag.
+All packages in the workspace are built if the `--workspace` flag is supplied. The
+`--workspace` flag is automatically assumed for a virtual manifest.
+Note that `--exclude` has to be specified in conjunction with the `--workspace` flag.
 
 Compilation can be configured via the use of profiles which are configured in
 the manifest. The default profile for this command is `dev`, but passing

--- a/src/bin/cargo/commands/check.rs
+++ b/src/bin/cargo/commands/check.rs
@@ -40,9 +40,9 @@ which indicates which package should be built. If it is not given, then the
 current package is built. For more information on SPEC and its format, see the
 `cargo help pkgid` command.
 
-All packages in the workspace are checked if the `--all` flag is supplied. The
-`--all` flag is automatically assumed for a virtual manifest.
-Note that `--exclude` has to be specified in conjunction with the `--all` flag.
+All packages in the workspace are checked if the `--workspace` flag is supplied. The
+`--workspace` flag is automatically assumed for a virtual manifest.
+Note that `--exclude` has to be specified in conjunction with the `--workspace` flag.
 
 Compilation can be configured via the use of profiles which are configured in
 the manifest. The default profile for this command is `dev`, but passing

--- a/src/bin/cargo/commands/clippy.rs
+++ b/src/bin/cargo/commands/clippy.rs
@@ -38,9 +38,9 @@ which indicates which package should be built. If it is not given, then the
 current package is built. For more information on SPEC and its format, see the
 `cargo help pkgid` command.
 
-All packages in the workspace are checked if the `--all` flag is supplied. The
-`--all` flag is automatically assumed for a virtual manifest.
-Note that `--exclude` has to be specified in conjunction with the `--all` flag.
+All packages in the workspace are checked if the `--workspace` flag is supplied. The
+`--workspace` flag is automatically assumed for a virtual manifest.
+Note that `--exclude` has to be specified in conjunction with the `--workspace` flag.
 
 To allow or deny a lint from the command line you can use `cargo clippy --`
 with:

--- a/src/bin/cargo/commands/doc.rs
+++ b/src/bin/cargo/commands/doc.rs
@@ -34,9 +34,10 @@ pub fn cli() -> App {
 By default the documentation for the local package and all dependencies is
 built. The output is all placed in `target/doc` in rustdoc's usual format.
 
-All packages in the workspace are documented if the `--all` flag is supplied. The
-`--all` flag is automatically assumed for a virtual manifest.
-Note that `--exclude` has to be specified in conjunction with the `--all` flag.
+All packages in the workspace are documented if the `--workspace` flag is
+supplied. The `--workspace` flag is automatically assumed for a virtual
+manifest. Note that `--exclude` has to be specified in conjunction with the
+`--workspace` flag.
 
 If the `--package` argument is given, then SPEC is a package ID specification
 which indicates which package should be documented. If it is not given, then the

--- a/src/bin/cargo/commands/test.rs
+++ b/src/bin/cargo/commands/test.rs
@@ -69,9 +69,9 @@ which indicates which package should be tested. If it is not given, then the
 current package is tested. For more information on SPEC and its format, see the
 `cargo help pkgid` command.
 
-All packages in the workspace are tested if the `--all` flag is supplied. The
-`--all` flag is automatically assumed for a virtual manifest.
-Note that `--exclude` has to be specified in conjunction with the `--all` flag.
+All packages in the workspace are tested if the `--workspace` flag is supplied. The
+`--workspace` flag is automatically assumed for a virtual manifest.
+Note that `--exclude` has to be specified in conjunction with the `--workspace` flag.
 
 The `--jobs` argument affects the building of the test executable but does
 not affect how many jobs are used when running the tests. The default value

--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -56,13 +56,13 @@ pub struct Workspace<'cfg> {
 
     // The subset of `members` that are used by the
     // `build`, `check`, `test`, and `bench` subcommands
-    // when no package is selected with `--package` / `-p` and `--all`
+    // when no package is selected with `--package` / `-p` and `--workspace`
     // is not used.
     //
     // This is set by the `default-members` config
     // in the `[workspace]` section.
     // When unset, this is the same as `members` for virtual workspaces
-    // (`--all` is implied)
+    // (`--workspace` is implied)
     // or only the root package for non-virtual workspaces.
     default_members: Vec<PathBuf>,
 

--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -106,7 +106,7 @@ impl Packages {
         Ok(match (all, exclude.len(), package.len()) {
             (false, 0, 0) => Packages::Default,
             (false, 0, _) => Packages::Packages(package),
-            (false, _, _) => failure::bail!("--exclude can only be used together with --all"),
+            (false, _, _) => failure::bail!("--exclude can only be used together with --workspace"),
             (true, 0, _) => Packages::All,
             (true, _, _) => Packages::OptOut(exclude),
         })

--- a/src/cargo/util/command_prelude.rs
+++ b/src/cargo/util/command_prelude.rs
@@ -31,10 +31,7 @@ pub trait AppExt: Sized {
         exclude: &'static str,
     ) -> Self {
         self.arg_package_spec_simple(package)
-            ._arg(opt(
-                "all",
-                "Will be changed to 'workspace' option (deprecated)",
-            ))
+            ._arg(opt("all", "Alias for --workspace (deprecated)"))
             ._arg(opt("workspace", all))
             ._arg(multi_opt("exclude", "SPEC", exclude))
     }

--- a/src/cargo/util/command_prelude.rs
+++ b/src/cargo/util/command_prelude.rs
@@ -31,7 +31,11 @@ pub trait AppExt: Sized {
         exclude: &'static str,
     ) -> Self {
         self.arg_package_spec_simple(package)
-            ._arg(opt("all", all))
+            ._arg(opt(
+                "all",
+                "Will be changed to 'workspace' option (deprecated)",
+            ))
+            ._arg(opt("workspace", all))
             ._arg(multi_opt("exclude", "SPEC", exclude))
     }
 
@@ -290,7 +294,8 @@ pub trait ArgMatchesExt {
         workspace: Option<&Workspace<'a>>,
     ) -> CargoResult<CompileOptions<'a>> {
         let spec = Packages::from_flags(
-            self._is_present("all"),
+            // TODO Integrate into 'workspace'
+            self._is_present("workspace") || self._is_present("all"),
             self._values_of("exclude"),
             self._values_of("package"),
         )?;

--- a/src/doc/man/generated/cargo-bench.html
+++ b/src/doc/man/generated/cargo-bench.html
@@ -78,7 +78,7 @@ by the manifest will be selected.</p>
 <p>The default members of a workspace can be set explicitly with the
 <code>workspace.default-members</code> key in the root manifest. If this is not set, a
 virtual workspace will include all workspace members (equivalent to passing
-<code>--all</code>), and a non-virtual workspace will include only the root crate itself.</p>
+<code>--workspace</code>), and a non-virtual workspace will include only the root crate itself.</p>
 </div>
 <div class="dlist">
 <dl>
@@ -88,14 +88,14 @@ virtual workspace will include all workspace members (equivalent to passing
 <p>Benchmark only the specified packages. See <a href="cargo-pkgid.html">cargo-pkgid(1)</a> for the
 SPEC format. This flag may be specified multiple times.</p>
 </dd>
-<dt class="hdlist1"><strong>--all</strong></dt>
+<dt class="hdlist1"><strong>--workspace</strong></dt>
 <dd>
 <p>Benchmark all members in the workspace.</p>
 </dd>
 <dt class="hdlist1"><strong>--exclude</strong> <em>SPEC</em>&#8230;&#8203;</dt>
 <dd>
 <p>Exclude the specified packages. Must be used in conjunction with the
-<code>--all</code> flag. This flag may be specified multiple times.</p>
+<code>--workspace</code> flag. This flag may be specified multiple times.</p>
 </dd>
 </dl>
 </div>

--- a/src/doc/man/generated/cargo-bench.html
+++ b/src/doc/man/generated/cargo-bench.html
@@ -92,6 +92,10 @@ SPEC format. This flag may be specified multiple times.</p>
 <dd>
 <p>Benchmark all members in the workspace.</p>
 </dd>
+<dt class="hdlist1"><strong>--all</strong></dt>
+<dd>
+<p>Deprecated alias for <code>--workspace</code>.</p>
+</dd>
 <dt class="hdlist1"><strong>--exclude</strong> <em>SPEC</em>&#8230;&#8203;</dt>
 <dd>
 <p>Exclude the specified packages. Must be used in conjunction with the

--- a/src/doc/man/generated/cargo-build.html
+++ b/src/doc/man/generated/cargo-build.html
@@ -34,7 +34,7 @@ by the manifest will be selected.</p>
 <p>The default members of a workspace can be set explicitly with the
 <code>workspace.default-members</code> key in the root manifest. If this is not set, a
 virtual workspace will include all workspace members (equivalent to passing
-<code>--all</code>), and a non-virtual workspace will include only the root crate itself.</p>
+<code>--workspace</code>), and a non-virtual workspace will include only the root crate itself.</p>
 </div>
 <div class="dlist">
 <dl>
@@ -44,14 +44,14 @@ virtual workspace will include all workspace members (equivalent to passing
 <p>Build only the specified packages. See <a href="cargo-pkgid.html">cargo-pkgid(1)</a> for the
 SPEC format. This flag may be specified multiple times.</p>
 </dd>
-<dt class="hdlist1"><strong>--all</strong></dt>
+<dt class="hdlist1"><strong>--workspace</strong></dt>
 <dd>
 <p>Build all members in the workspace.</p>
 </dd>
 <dt class="hdlist1"><strong>--exclude</strong> <em>SPEC</em>&#8230;&#8203;</dt>
 <dd>
 <p>Exclude the specified packages. Must be used in conjunction with the
-<code>--all</code> flag. This flag may be specified multiple times.</p>
+<code>--workspace</code> flag. This flag may be specified multiple times.</p>
 </dd>
 </dl>
 </div>

--- a/src/doc/man/generated/cargo-build.html
+++ b/src/doc/man/generated/cargo-build.html
@@ -48,6 +48,10 @@ SPEC format. This flag may be specified multiple times.</p>
 <dd>
 <p>Build all members in the workspace.</p>
 </dd>
+<dt class="hdlist1"><strong>--all</strong></dt>
+<dd>
+<p>Deprecated alias for <code>--workspace</code>.</p>
+</dd>
 <dt class="hdlist1"><strong>--exclude</strong> <em>SPEC</em>&#8230;&#8203;</dt>
 <dd>
 <p>Exclude the specified packages. Must be used in conjunction with the

--- a/src/doc/man/generated/cargo-check.html
+++ b/src/doc/man/generated/cargo-check.html
@@ -38,7 +38,7 @@ by the manifest will be selected.</p>
 <p>The default members of a workspace can be set explicitly with the
 <code>workspace.default-members</code> key in the root manifest. If this is not set, a
 virtual workspace will include all workspace members (equivalent to passing
-<code>--all</code>), and a non-virtual workspace will include only the root crate itself.</p>
+<code>--workspace</code>), and a non-virtual workspace will include only the root crate itself.</p>
 </div>
 <div class="dlist">
 <dl>
@@ -48,14 +48,14 @@ virtual workspace will include all workspace members (equivalent to passing
 <p>Check only the specified packages. See <a href="cargo-pkgid.html">cargo-pkgid(1)</a> for the
 SPEC format. This flag may be specified multiple times.</p>
 </dd>
-<dt class="hdlist1"><strong>--all</strong></dt>
+<dt class="hdlist1"><strong>--workspace</strong></dt>
 <dd>
 <p>Check all members in the workspace.</p>
 </dd>
 <dt class="hdlist1"><strong>--exclude</strong> <em>SPEC</em>&#8230;&#8203;</dt>
 <dd>
 <p>Exclude the specified packages. Must be used in conjunction with the
-<code>--all</code> flag. This flag may be specified multiple times.</p>
+<code>--workspace</code> flag. This flag may be specified multiple times.</p>
 </dd>
 </dl>
 </div>

--- a/src/doc/man/generated/cargo-check.html
+++ b/src/doc/man/generated/cargo-check.html
@@ -52,6 +52,10 @@ SPEC format. This flag may be specified multiple times.</p>
 <dd>
 <p>Check all members in the workspace.</p>
 </dd>
+<dt class="hdlist1"><strong>--all</strong></dt>
+<dd>
+<p>Deprecated alias for <code>--workspace</code>.</p>
+</dd>
 <dt class="hdlist1"><strong>--exclude</strong> <em>SPEC</em>&#8230;&#8203;</dt>
 <dd>
 <p>Exclude the specified packages. Must be used in conjunction with the

--- a/src/doc/man/generated/cargo-doc.html
+++ b/src/doc/man/generated/cargo-doc.html
@@ -68,6 +68,10 @@ SPEC format. This flag may be specified multiple times.</p>
 <dd>
 <p>Document all members in the workspace.</p>
 </dd>
+<dt class="hdlist1"><strong>--all</strong></dt>
+<dd>
+<p>Deprecated alias for <code>--workspace</code>.</p>
+</dd>
 <dt class="hdlist1"><strong>--exclude</strong> <em>SPEC</em>&#8230;&#8203;</dt>
 <dd>
 <p>Exclude the specified packages. Must be used in conjunction with the

--- a/src/doc/man/generated/cargo-doc.html
+++ b/src/doc/man/generated/cargo-doc.html
@@ -54,7 +54,7 @@ by the manifest will be selected.</p>
 <p>The default members of a workspace can be set explicitly with the
 <code>workspace.default-members</code> key in the root manifest. If this is not set, a
 virtual workspace will include all workspace members (equivalent to passing
-<code>--all</code>), and a non-virtual workspace will include only the root crate itself.</p>
+<code>--workspace</code>), and a non-virtual workspace will include only the root crate itself.</p>
 </div>
 <div class="dlist">
 <dl>
@@ -64,14 +64,14 @@ virtual workspace will include all workspace members (equivalent to passing
 <p>Document only the specified packages. See <a href="cargo-pkgid.html">cargo-pkgid(1)</a> for the
 SPEC format. This flag may be specified multiple times.</p>
 </dd>
-<dt class="hdlist1"><strong>--all</strong></dt>
+<dt class="hdlist1"><strong>--workspace</strong></dt>
 <dd>
 <p>Document all members in the workspace.</p>
 </dd>
 <dt class="hdlist1"><strong>--exclude</strong> <em>SPEC</em>&#8230;&#8203;</dt>
 <dd>
 <p>Exclude the specified packages. Must be used in conjunction with the
-<code>--all</code> flag. This flag may be specified multiple times.</p>
+<code>--workspace</code> flag. This flag may be specified multiple times.</p>
 </dd>
 </dl>
 </div>

--- a/src/doc/man/generated/cargo-fix.html
+++ b/src/doc/man/generated/cargo-fix.html
@@ -109,7 +109,7 @@ by the manifest will be selected.</p>
 <p>The default members of a workspace can be set explicitly with the
 <code>workspace.default-members</code> key in the root manifest. If this is not set, a
 virtual workspace will include all workspace members (equivalent to passing
-<code>--all</code>), and a non-virtual workspace will include only the root crate itself.</p>
+<code>--workspace</code>), and a non-virtual workspace will include only the root crate itself.</p>
 </div>
 <div class="dlist">
 <dl>
@@ -119,14 +119,14 @@ virtual workspace will include all workspace members (equivalent to passing
 <p>Fix only the specified packages. See <a href="cargo-pkgid.html">cargo-pkgid(1)</a> for the
 SPEC format. This flag may be specified multiple times.</p>
 </dd>
-<dt class="hdlist1"><strong>--all</strong></dt>
+<dt class="hdlist1"><strong>--workspace</strong></dt>
 <dd>
 <p>Fix all members in the workspace.</p>
 </dd>
 <dt class="hdlist1"><strong>--exclude</strong> <em>SPEC</em>&#8230;&#8203;</dt>
 <dd>
 <p>Exclude the specified packages. Must be used in conjunction with the
-<code>--all</code> flag. This flag may be specified multiple times.</p>
+<code>--workspace</code> flag. This flag may be specified multiple times.</p>
 </dd>
 </dl>
 </div>

--- a/src/doc/man/generated/cargo-fix.html
+++ b/src/doc/man/generated/cargo-fix.html
@@ -123,6 +123,10 @@ SPEC format. This flag may be specified multiple times.</p>
 <dd>
 <p>Fix all members in the workspace.</p>
 </dd>
+<dt class="hdlist1"><strong>--all</strong></dt>
+<dd>
+<p>Deprecated alias for <code>--workspace</code>.</p>
+</dd>
 <dt class="hdlist1"><strong>--exclude</strong> <em>SPEC</em>&#8230;&#8203;</dt>
 <dd>
 <p>Exclude the specified packages. Must be used in conjunction with the

--- a/src/doc/man/generated/cargo-test.html
+++ b/src/doc/man/generated/cargo-test.html
@@ -84,7 +84,7 @@ by the manifest will be selected.</p>
 <p>The default members of a workspace can be set explicitly with the
 <code>workspace.default-members</code> key in the root manifest. If this is not set, a
 virtual workspace will include all workspace members (equivalent to passing
-<code>--all</code>), and a non-virtual workspace will include only the root crate itself.</p>
+<code>--workspace</code>), and a non-virtual workspace will include only the root crate itself.</p>
 </div>
 <div class="dlist">
 <dl>
@@ -94,14 +94,14 @@ virtual workspace will include all workspace members (equivalent to passing
 <p>Test only the specified packages. See <a href="cargo-pkgid.html">cargo-pkgid(1)</a> for the
 SPEC format. This flag may be specified multiple times.</p>
 </dd>
-<dt class="hdlist1"><strong>--all</strong></dt>
+<dt class="hdlist1"><strong>--workspace</strong></dt>
 <dd>
 <p>Test all members in the workspace.</p>
 </dd>
 <dt class="hdlist1"><strong>--exclude</strong> <em>SPEC</em>&#8230;&#8203;</dt>
 <dd>
 <p>Exclude the specified packages. Must be used in conjunction with the
-<code>--all</code> flag. This flag may be specified multiple times.</p>
+<code>--workspace</code> flag. This flag may be specified multiple times.</p>
 </dd>
 </dl>
 </div>

--- a/src/doc/man/generated/cargo-test.html
+++ b/src/doc/man/generated/cargo-test.html
@@ -98,6 +98,10 @@ SPEC format. This flag may be specified multiple times.</p>
 <dd>
 <p>Test all members in the workspace.</p>
 </dd>
+<dt class="hdlist1"><strong>--all</strong></dt>
+<dd>
+<p>Deprecated alias for <code>--workspace</code>.</p>
+</dd>
 <dt class="hdlist1"><strong>--exclude</strong> <em>SPEC</em>&#8230;&#8203;</dt>
 <dd>
 <p>Exclude the specified packages. Must be used in conjunction with the

--- a/src/doc/man/options-packages.adoc
+++ b/src/doc/man/options-packages.adoc
@@ -7,16 +7,16 @@ by the manifest will be selected.
 The default members of a workspace can be set explicitly with the
 `workspace.default-members` key in the root manifest. If this is not set, a
 virtual workspace will include all workspace members (equivalent to passing
-`--all`), and a non-virtual workspace will include only the root crate itself.
+`--workspace`), and a non-virtual workspace will include only the root crate itself.
 
 *-p* _SPEC_...::
 *--package* _SPEC_...::
     {actionverb} only the specified packages. See man:cargo-pkgid[1] for the
     SPEC format. This flag may be specified multiple times.
 
-*--all*::
+*--workspace*::
     {actionverb} all members in the workspace.
 
 *--exclude* _SPEC_...::
     Exclude the specified packages. Must be used in conjunction with the
-    `--all` flag. This flag may be specified multiple times.
+    `--workspace` flag. This flag may be specified multiple times.

--- a/src/doc/man/options-packages.adoc
+++ b/src/doc/man/options-packages.adoc
@@ -17,6 +17,9 @@ virtual workspace will include all workspace members (equivalent to passing
 *--workspace*::
     {actionverb} all members in the workspace.
 
+*--all*::
+    Deprecated alias for `--workspace`.
+
 *--exclude* _SPEC_...::
     Exclude the specified packages. Must be used in conjunction with the
     `--workspace` flag. This flag may be specified multiple times.

--- a/src/doc/src/reference/manifest.md
+++ b/src/doc/src/reference/manifest.md
@@ -658,7 +658,7 @@ manifest*.
 #### Package selection
 
 In a workspace, package-related cargo commands like [`cargo build`] apply to
-packages selected by `-p` / `--package` or `--all` command-line parameters.
+packages selected by `-p` / `--package` or `--workspace` command-line parameters.
 When neither is specified, the optional `default-members` configuration is used:
 
 ```toml
@@ -670,7 +670,7 @@ default-members = ["path/to/member2", "path/to/member3/foo"]
 When specified, `default-members` must expand to a subset of `members`.
 
 When `default-members` is not specified, the default is the root manifest
-if it is a package, or every member manifest (as if `--all` were specified
+if it is a package, or every member manifest (as if `--workspace` were specified
 on the command-line) for virtual workspaces.
 
 ### The project layout

--- a/src/etc/cargo.bashcomp.sh
+++ b/src/etc/cargo.bashcomp.sh
@@ -37,7 +37,7 @@ _cargo()
 	local opt_quiet='-q --quiet'
 	local opt_color='--color'
 	local opt_common="$opt_help $opt_verbose $opt_quiet $opt_color"
-	local opt_pkg_spec='-p --package --all --exclude'
+	local opt_pkg_spec='-p --package --all --exclude --workspace'
 	local opt_pkg='-p --package'
 	local opt_feat='--features --all-features --no-default-features'
 	local opt_mani='--manifest-path'

--- a/src/etc/man/cargo-bench.1
+++ b/src/etc/man/cargo-bench.1
@@ -85,7 +85,7 @@ by the manifest will be selected.
 The default members of a workspace can be set explicitly with the
 \fBworkspace.default\-members\fP key in the root manifest. If this is not set, a
 virtual workspace will include all workspace members (equivalent to passing
-\fB\-\-all\fP), and a non\-virtual workspace will include only the root crate itself.
+\fB\-\-workspace\fP), and a non\-virtual workspace will include only the root crate itself.
 .sp
 \fB\-p\fP \fISPEC\fP..., \fB\-\-package\fP \fISPEC\fP...
 .RS 4
@@ -93,15 +93,20 @@ Benchmark only the specified packages. See \fBcargo\-pkgid\fP(1) for the
 SPEC format. This flag may be specified multiple times.
 .RE
 .sp
-\fB\-\-all\fP
+\fB\-\-workspace\fP
 .RS 4
 Benchmark all members in the workspace.
+.RE
+.sp
+\fB\-\-all\fP
+.RS 4
+Deprecated alias for \fB\-\-workspace\fP.
 .RE
 .sp
 \fB\-\-exclude\fP \fISPEC\fP...
 .RS 4
 Exclude the specified packages. Must be used in conjunction with the
-\fB\-\-all\fP flag. This flag may be specified multiple times.
+\fB\-\-workspace\fP flag. This flag may be specified multiple times.
 .RE
 .SS "Target Selection"
 .sp

--- a/src/etc/man/cargo-build.1
+++ b/src/etc/man/cargo-build.1
@@ -47,7 +47,7 @@ by the manifest will be selected.
 The default members of a workspace can be set explicitly with the
 \fBworkspace.default\-members\fP key in the root manifest. If this is not set, a
 virtual workspace will include all workspace members (equivalent to passing
-\fB\-\-all\fP), and a non\-virtual workspace will include only the root crate itself.
+\fB\-\-workspace\fP), and a non\-virtual workspace will include only the root crate itself.
 .sp
 \fB\-p\fP \fISPEC\fP..., \fB\-\-package\fP \fISPEC\fP...
 .RS 4
@@ -55,15 +55,20 @@ Build only the specified packages. See \fBcargo\-pkgid\fP(1) for the
 SPEC format. This flag may be specified multiple times.
 .RE
 .sp
-\fB\-\-all\fP
+\fB\-\-workspace\fP
 .RS 4
 Build all members in the workspace.
+.RE
+.sp
+\fB\-\-all\fP
+.RS 4
+Deprecated alias for \fB\-\-workspace\fP.
 .RE
 .sp
 \fB\-\-exclude\fP \fISPEC\fP...
 .RS 4
 Exclude the specified packages. Must be used in conjunction with the
-\fB\-\-all\fP flag. This flag may be specified multiple times.
+\fB\-\-workspace\fP flag. This flag may be specified multiple times.
 .RE
 .SS "Target Selection"
 .sp

--- a/src/etc/man/cargo-check.1
+++ b/src/etc/man/cargo-check.1
@@ -51,7 +51,7 @@ by the manifest will be selected.
 The default members of a workspace can be set explicitly with the
 \fBworkspace.default\-members\fP key in the root manifest. If this is not set, a
 virtual workspace will include all workspace members (equivalent to passing
-\fB\-\-all\fP), and a non\-virtual workspace will include only the root crate itself.
+\fB\-\-workspace\fP), and a non\-virtual workspace will include only the root crate itself.
 .sp
 \fB\-p\fP \fISPEC\fP..., \fB\-\-package\fP \fISPEC\fP...
 .RS 4
@@ -59,15 +59,20 @@ Check only the specified packages. See \fBcargo\-pkgid\fP(1) for the
 SPEC format. This flag may be specified multiple times.
 .RE
 .sp
-\fB\-\-all\fP
+\fB\-\-workspace\fP
 .RS 4
 Check all members in the workspace.
+.RE
+.sp
+\fB\-\-all\fP
+.RS 4
+Deprecated alias for \fB\-\-workspace\fP.
 .RE
 .sp
 \fB\-\-exclude\fP \fISPEC\fP...
 .RS 4
 Exclude the specified packages. Must be used in conjunction with the
-\fB\-\-all\fP flag. This flag may be specified multiple times.
+\fB\-\-workspace\fP flag. This flag may be specified multiple times.
 .RE
 .SS "Target Selection"
 .sp

--- a/src/etc/man/cargo-doc.1
+++ b/src/etc/man/cargo-doc.1
@@ -64,7 +64,7 @@ by the manifest will be selected.
 The default members of a workspace can be set explicitly with the
 \fBworkspace.default\-members\fP key in the root manifest. If this is not set, a
 virtual workspace will include all workspace members (equivalent to passing
-\fB\-\-all\fP), and a non\-virtual workspace will include only the root crate itself.
+\fB\-\-workspace\fP), and a non\-virtual workspace will include only the root crate itself.
 .sp
 \fB\-p\fP \fISPEC\fP..., \fB\-\-package\fP \fISPEC\fP...
 .RS 4
@@ -72,15 +72,20 @@ Document only the specified packages. See \fBcargo\-pkgid\fP(1) for the
 SPEC format. This flag may be specified multiple times.
 .RE
 .sp
-\fB\-\-all\fP
+\fB\-\-workspace\fP
 .RS 4
 Document all members in the workspace.
+.RE
+.sp
+\fB\-\-all\fP
+.RS 4
+Deprecated alias for \fB\-\-workspace\fP.
 .RE
 .sp
 \fB\-\-exclude\fP \fISPEC\fP...
 .RS 4
 Exclude the specified packages. Must be used in conjunction with the
-\fB\-\-all\fP flag. This flag may be specified multiple times.
+\fB\-\-workspace\fP flag. This flag may be specified multiple times.
 .RE
 .SS "Target Selection"
 .sp

--- a/src/etc/man/cargo-fix.1
+++ b/src/etc/man/cargo-fix.1
@@ -121,7 +121,7 @@ by the manifest will be selected.
 The default members of a workspace can be set explicitly with the
 \fBworkspace.default\-members\fP key in the root manifest. If this is not set, a
 virtual workspace will include all workspace members (equivalent to passing
-\fB\-\-all\fP), and a non\-virtual workspace will include only the root crate itself.
+\fB\-\-workspace\fP), and a non\-virtual workspace will include only the root crate itself.
 .sp
 \fB\-p\fP \fISPEC\fP..., \fB\-\-package\fP \fISPEC\fP...
 .RS 4
@@ -129,15 +129,20 @@ Fix only the specified packages. See \fBcargo\-pkgid\fP(1) for the
 SPEC format. This flag may be specified multiple times.
 .RE
 .sp
-\fB\-\-all\fP
+\fB\-\-workspace\fP
 .RS 4
 Fix all members in the workspace.
+.RE
+.sp
+\fB\-\-all\fP
+.RS 4
+Deprecated alias for \fB\-\-workspace\fP.
 .RE
 .sp
 \fB\-\-exclude\fP \fISPEC\fP...
 .RS 4
 Exclude the specified packages. Must be used in conjunction with the
-\fB\-\-all\fP flag. This flag may be specified multiple times.
+\fB\-\-workspace\fP flag. This flag may be specified multiple times.
 .RE
 .SS "Target Selection"
 .sp

--- a/src/etc/man/cargo-test.1
+++ b/src/etc/man/cargo-test.1
@@ -91,7 +91,7 @@ by the manifest will be selected.
 The default members of a workspace can be set explicitly with the
 \fBworkspace.default\-members\fP key in the root manifest. If this is not set, a
 virtual workspace will include all workspace members (equivalent to passing
-\fB\-\-all\fP), and a non\-virtual workspace will include only the root crate itself.
+\fB\-\-workspace\fP), and a non\-virtual workspace will include only the root crate itself.
 .sp
 \fB\-p\fP \fISPEC\fP..., \fB\-\-package\fP \fISPEC\fP...
 .RS 4
@@ -99,15 +99,20 @@ Test only the specified packages. See \fBcargo\-pkgid\fP(1) for the
 SPEC format. This flag may be specified multiple times.
 .RE
 .sp
-\fB\-\-all\fP
+\fB\-\-workspace\fP
 .RS 4
 Test all members in the workspace.
+.RE
+.sp
+\fB\-\-all\fP
+.RS 4
+Deprecated alias for \fB\-\-workspace\fP.
 .RE
 .sp
 \fB\-\-exclude\fP \fISPEC\fP...
 .RS 4
 Exclude the specified packages. Must be used in conjunction with the
-\fB\-\-all\fP flag. This flag may be specified multiple times.
+\fB\-\-workspace\fP flag. This flag may be specified multiple times.
 .RE
 .SS "Target Selection"
 .sp

--- a/tests/testsuite/bad_config.rs
+++ b/tests/testsuite/bad_config.rs
@@ -780,7 +780,7 @@ fn unused_keys_in_virtual_manifest() {
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.0.1"))
         .file("bar/src/lib.rs", r"")
         .build();
-    p.cargo("build --all")
+    p.cargo("build --workspace")
         .with_stderr(
             "\
 [WARNING] [..]/foo/Cargo.toml: unused manifest key: workspace.bulid

--- a/tests/testsuite/bench.rs
+++ b/tests/testsuite/bench.rs
@@ -1382,7 +1382,7 @@ fn bench_all_workspace() {
         )
         .build();
 
-    p.cargo("bench --all")
+    p.cargo("bench --workspace")
         .with_stderr_contains("[RUNNING] target/release/deps/bar-[..][EXE]")
         .with_stdout_contains("test bench_bar ... bench: [..]")
         .with_stderr_contains("[RUNNING] target/release/deps/foo-[..][EXE]")
@@ -1430,7 +1430,7 @@ fn bench_all_exclude() {
         )
         .build();
 
-    p.cargo("bench --all --exclude baz")
+    p.cargo("bench --workspace --exclude baz")
         .with_stdout_contains(
             "\
 running 1 test
@@ -1484,7 +1484,7 @@ fn bench_all_virtual_manifest() {
         .build();
 
     // The order in which bar and baz are built is not guaranteed
-    p.cargo("bench --all")
+    p.cargo("bench --workspace")
         .with_stderr_contains("[RUNNING] target/release/deps/baz-[..][EXE]")
         .with_stdout_contains("test bench_baz ... bench: [..]")
         .with_stderr_contains("[RUNNING] target/release/deps/bar-[..][EXE]")

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -129,7 +129,7 @@ fn incremental_config() {
 fn cargo_compile_with_workspace_excluded() {
     let p = project().file("src/main.rs", "fn main() {}").build();
 
-    p.cargo("build --all --exclude foo")
+    p.cargo("build --workspace --exclude foo")
         .with_stderr_does_not_contain("[..]virtual[..]")
         .with_stderr_contains("[..]no packages to compile")
         .with_status(101)
@@ -3390,7 +3390,7 @@ fn build_all_workspace() {
         .file("bar/src/lib.rs", "pub fn bar() {}")
         .build();
 
-    p.cargo("build --all")
+    p.cargo("build --workspace")
         .with_stderr(
             "[..] Compiling bar v0.1.0 ([..])\n\
              [..] Compiling foo v0.1.0 ([..])\n\
@@ -3420,7 +3420,7 @@ fn build_all_exclude() {
         .file("baz/src/lib.rs", "pub fn baz() { break_the_build(); }")
         .build();
 
-    p.cargo("build --all --exclude baz")
+    p.cargo("build --workspace --exclude baz")
         .with_stderr_contains("[..]Compiling foo v0.1.0 [..]")
         .with_stderr_contains("[..]Compiling bar v0.1.0 [..]")
         .with_stderr_does_not_contain("[..]Compiling baz v0.1.0 [..]")
@@ -3456,7 +3456,7 @@ fn build_all_workspace_implicit_examples() {
         .file("bar/examples/h.rs", "fn main() {}")
         .build();
 
-    p.cargo("build --all --examples")
+    p.cargo("build --workspace --examples")
         .with_stderr(
             "[..] Compiling bar v0.1.0 ([..])\n\
              [..] Compiling foo v0.1.0 ([..])\n\
@@ -3490,7 +3490,7 @@ fn build_all_virtual_manifest() {
         .build();
 
     // The order in which bar and baz are built is not guaranteed
-    p.cargo("build --all")
+    p.cargo("build --workspace")
         .with_stderr_contains("[..] Compiling baz v0.1.0 ([..])")
         .with_stderr_contains("[..] Compiling bar v0.1.0 ([..])")
         .with_stderr(
@@ -3580,7 +3580,7 @@ fn build_all_virtual_manifest_implicit_examples() {
         .build();
 
     // The order in which bar and baz are built is not guaranteed
-    p.cargo("build --all --examples")
+    p.cargo("build --workspace --examples")
         .with_stderr_contains("[..] Compiling baz v0.1.0 ([..])")
         .with_stderr_contains("[..] Compiling bar v0.1.0 ([..])")
         .with_stderr(
@@ -3625,7 +3625,7 @@ fn build_all_member_dependency_same_name() {
 
     Package::new("a", "0.1.0").publish();
 
-    p.cargo("build --all")
+    p.cargo("build --workspace")
         .with_stderr(
             "[UPDATING] `[..]` index\n\
              [DOWNLOADING] crates ...\n\
@@ -3695,7 +3695,7 @@ fn run_proper_alias_binary_from_src() {
         .file("src/bar.rs", r#"fn main() { println!("bar"); }"#)
         .build();
 
-    p.cargo("build --all").run();
+    p.cargo("build --workspace").run();
     p.process(&p.bin("foo")).with_stdout("foo\n").run();
     p.process(&p.bin("bar")).with_stdout("bar\n").run();
 }
@@ -3719,7 +3719,7 @@ fn run_proper_alias_binary_main_rs() {
         .file("src/main.rs", r#"fn main() { println!("main"); }"#)
         .build();
 
-    p.cargo("build --all").run();
+    p.cargo("build --workspace").run();
     p.process(&p.bin("foo")).with_stdout("main\n").run();
     p.process(&p.bin("bar")).with_stdout("main\n").run();
 }

--- a/tests/testsuite/check.rs
+++ b/tests/testsuite/check.rs
@@ -396,7 +396,7 @@ fn check_all() {
         .file("b/src/lib.rs", "")
         .build();
 
-    p.cargo("check --all -v")
+    p.cargo("check --workspace -v")
         .with_stderr_contains("[..] --crate-name foo src/lib.rs [..]")
         .with_stderr_contains("[..] --crate-name foo src/main.rs [..]")
         .with_stderr_contains("[..] --crate-name b b/src/lib.rs [..]")
@@ -429,7 +429,7 @@ fn check_virtual_all_implied() {
 #[cargo_test]
 fn exclude_warns_on_non_existing_package() {
     let p = project().file("src/lib.rs", "").build();
-    p.cargo("check --all --exclude bar")
+    p.cargo("check --workspace --exclude bar")
         .with_stdout("")
         .with_stderr(
             r#"[WARNING] excluded package(s) bar not found in workspace `[CWD]`

--- a/tests/testsuite/doc.rs
+++ b/tests/testsuite/doc.rs
@@ -220,7 +220,7 @@ fn doc_multiple_targets_same_name_lib() {
         .file("bar/src/lib.rs", "")
         .build();
 
-    p.cargo("doc --all")
+    p.cargo("doc --workspace")
         .with_status(101)
         .with_stderr_contains("[..] library `foo_lib` is specified [..]")
         .with_stderr_contains("[..] `foo v0.1.0[..]` [..]")
@@ -263,7 +263,7 @@ fn doc_multiple_targets_same_name() {
         .file("bar/src/lib.rs", "")
         .build();
 
-    p.cargo("doc --all")
+    p.cargo("doc --workspace")
         .with_stderr_contains("[DOCUMENTING] foo v0.1.0 ([CWD]/foo)")
         .with_stderr_contains("[DOCUMENTING] bar v0.1.0 ([CWD]/bar)")
         .with_stderr_contains("[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]")
@@ -307,7 +307,7 @@ fn doc_multiple_targets_same_name_bin() {
         .file("bar/src/foo-cli.rs", "")
         .build();
 
-    p.cargo("doc --all")
+    p.cargo("doc --workspace")
         .with_status(101)
         .with_stderr_contains("[..] binary `foo_cli` is specified [..]")
         .with_stderr_contains("[..] `foo v0.1.0[..]` [..]")
@@ -350,7 +350,7 @@ fn doc_multiple_targets_same_name_undoced() {
         .file("bar/src/foo-cli.rs", "")
         .build();
 
-    p.cargo("doc --all").run();
+    p.cargo("doc --workspace").run();
 }
 
 #[cargo_test]
@@ -926,7 +926,7 @@ fn doc_all_workspace() {
         .build();
 
     // The order in which bar is compiled or documented is not deterministic
-    p.cargo("doc --all")
+    p.cargo("doc --workspace")
         .with_stderr_contains("[..] Documenting bar v0.1.0 ([..])")
         .with_stderr_contains("[..] Checking bar v0.1.0 ([..])")
         .with_stderr_contains("[..] Documenting foo v0.1.0 ([..])")
@@ -950,7 +950,7 @@ fn doc_all_virtual_manifest() {
         .build();
 
     // The order in which bar and baz are documented is not guaranteed
-    p.cargo("doc --all")
+    p.cargo("doc --workspace")
         .with_stderr_contains("[..] Documenting baz v0.1.0 ([..])")
         .with_stderr_contains("[..] Documenting bar v0.1.0 ([..])")
         .run();
@@ -1005,7 +1005,7 @@ fn doc_all_member_dependency_same_name() {
 
     Package::new("bar", "0.1.0").publish();
 
-    p.cargo("doc --all")
+    p.cargo("doc --workspace")
         .with_stderr_contains("[..] Updating `[..]` index")
         .with_stderr_contains("[..] Documenting bar v0.1.0 ([..])")
         .run();
@@ -1029,7 +1029,7 @@ fn doc_workspace_open_help_message() {
         .build();
 
     // The order in which bar is compiled or documented is not deterministic
-    p.cargo("doc --all --open")
+    p.cargo("doc --workspace --open")
         .env("BROWSER", "echo")
         .with_stderr_contains("[..] Documenting bar v0.1.0 ([..])")
         .with_stderr_contains("[..] Documenting foo v0.1.0 ([..])")
@@ -1246,7 +1246,7 @@ fn doc_private_ws() {
         .file("b/src/lib.rs", "fn p2() {}")
         .file("b/src/main.rs", "fn main() {}")
         .build();
-    p.cargo("doc --all --bins --lib --document-private-items -v")
+    p.cargo("doc --workspace --bins --lib --document-private-items -v")
         .with_stderr_contains(
             "[RUNNING] `rustdoc [..] a/src/lib.rs [..]--document-private-items[..]",
         )

--- a/tests/testsuite/features.rs
+++ b/tests/testsuite/features.rs
@@ -1397,7 +1397,7 @@ fn combining_features_and_package() {
         )
         .build();
 
-    p.cargo("build -Z package-features --all --features main")
+    p.cargo("build -Z package-features --workspace --features main")
         .masquerade_as_nightly_cargo()
         .with_status(101)
         .with_stderr_contains("[ERROR] cannot specify features for more than one package")
@@ -1419,7 +1419,7 @@ fn combining_features_and_package() {
         .with_stderr_contains("[ERROR] cannot specify features for packages outside of workspace")
         .run();
 
-    p.cargo("build -Z package-features --all --all-features")
+    p.cargo("build -Z package-features --workspace --all-features")
         .masquerade_as_nightly_cargo()
         .run();
     p.cargo("run -Z package-features --package bar --features main")

--- a/tests/testsuite/features.rs
+++ b/tests/testsuite/features.rs
@@ -1764,7 +1764,7 @@ fn all_features_all_crates() {
         .file("bar/src/main.rs", "#[cfg(feature = \"foo\")] fn main() {}")
         .build();
 
-    p.cargo("build --all-features --all").run();
+    p.cargo("build --all-features --workspace").run();
 }
 
 #[cargo_test]

--- a/tests/testsuite/freshness.rs
+++ b/tests/testsuite/freshness.rs
@@ -1134,7 +1134,7 @@ fn reuse_shared_build_dep() {
         .file("bar/build.rs", "fn main() {}")
         .build();
 
-    p.cargo("build --all").run();
+    p.cargo("build --workspace").run();
     // This should not recompile!
     p.cargo("build -p foo -v")
         .with_stderr(

--- a/tests/testsuite/metabuild.rs
+++ b/tests/testsuite/metabuild.rs
@@ -409,7 +409,7 @@ fn metabuild_workspace() {
         )
         .build();
 
-    p.cargo("build -vv --all")
+    p.cargo("build -vv --workspace")
         .masquerade_as_nightly_cargo()
         .with_stdout_contains("[member1 0.0.1] Hello mb1 [..]member1")
         .with_stdout_contains("[member1 0.0.1] Hello mb2 [..]member1")
@@ -613,7 +613,7 @@ fn metabuild_two_versions() {
         )
         .build();
 
-    p.cargo("build -vv --all")
+    p.cargo("build -vv --workspace")
         .masquerade_as_nightly_cargo()
         .with_stdout_contains("[member1 0.0.1] Hello mb1 [..]member1")
         .with_stdout_contains("[member2 0.0.1] Hello mb2 [..]member2")

--- a/tests/testsuite/test.rs
+++ b/tests/testsuite/test.rs
@@ -2797,7 +2797,7 @@ fn test_all_workspace() {
         .file("bar/src/lib.rs", "#[test] fn bar_test() {}")
         .build();
 
-    p.cargo("test --all")
+    p.cargo("test --workspace")
         .with_stdout_contains("test foo_test ... ok")
         .with_stdout_contains("test bar_test ... ok")
         .run();
@@ -2824,7 +2824,7 @@ fn test_all_exclude() {
         .file("baz/src/lib.rs", "#[test] pub fn baz() { assert!(false); }")
         .build();
 
-    p.cargo("test --all --exclude baz")
+    p.cargo("test --workspace --exclude baz")
         .with_stdout_contains(
             "running 1 test
 test bar ... ok",
@@ -2848,7 +2848,7 @@ fn test_all_virtual_manifest() {
         .file("b/src/lib.rs", "#[test] fn b() {}")
         .build();
 
-    p.cargo("test --all")
+    p.cargo("test --workspace")
         .with_stdout_contains("test a ... ok")
         .with_stdout_contains("test b ... ok")
         .run();
@@ -2902,7 +2902,7 @@ fn test_all_member_dependency_same_name() {
 
     Package::new("a", "0.1.0").publish();
 
-    p.cargo("test --all")
+    p.cargo("test --workspace")
         .with_stdout_contains("test a ... ok")
         .run();
 }
@@ -3037,7 +3037,7 @@ fn doctest_and_registry() {
 
     Package::new("b", "0.1.0").publish();
 
-    p.cargo("test --all -v").run();
+    p.cargo("test --workspace -v").run();
 }
 
 #[cargo_test]
@@ -3075,7 +3075,7 @@ fn test_order() {
         .file("tests/z.rs", "#[test] fn test_z() {}")
         .build();
 
-    p.cargo("test --all")
+    p.cargo("test --workspace")
         .with_stdout_contains(
             "
 running 1 test
@@ -3117,7 +3117,7 @@ fn cyclic_dev() {
         .file("tests/foo.rs", "extern crate foo;")
         .build();
 
-    p.cargo("test --all").run();
+    p.cargo("test --workspace").run();
 }
 
 #[cargo_test]
@@ -3228,7 +3228,7 @@ fn find_dependency_of_proc_macro_dependency_with_target() {
         .dep("bar", "0.1")
         .file("src/lib.rs", "extern crate bar;")
         .publish();
-    p.cargo("test --all --target").arg(rustc_host()).run();
+    p.cargo("test --workspace --target").arg(rustc_host()).run();
 }
 
 #[cargo_test]
@@ -3310,7 +3310,7 @@ fn test_hint_workspace_nonvirtual() {
         .file("a/src/lib.rs", "#[test] fn t1() {assert!(false)}")
         .build();
 
-    p.cargo("test --all")
+    p.cargo("test --workspace")
         .with_stderr_contains("[ERROR] test failed, to rerun pass '-p a --lib'")
         .with_status(101)
         .run();

--- a/tests/testsuite/workspaces.rs
+++ b/tests/testsuite/workspaces.rs
@@ -1862,7 +1862,7 @@ fn dep_used_with_separate_features() {
     let p = p.build();
 
     // Build the entire workspace.
-    p.cargo("build --all")
+    p.cargo("build --workspace")
         .with_stderr(
             "\
 [..]Compiling feat_lib v0.1.0 ([..])


### PR DESCRIPTION
## Background

close: https://github.com/rust-lang/cargo/issues/6977

## Description
- Warn when using the 'all' option
- Changed help text