### PR TITLE
 `cargo vendor`: Don't delete hidden top-level files. 

### DIFF
--- a/src/cargo/ops/vendor.rs
+++ b/src/cargo/ops/vendor.rs
@@ -80,7 +80,13 @@ fn sync(
     if !opts.no_delete {
         for entry in canonical_destination.read_dir()? {
             let entry = entry?;
-            to_remove.insert(entry.path());
+            if !entry
+                .file_name()
+                .to_str()
+                .map_or(false, |s| s.starts_with('.'))
+            {
+                to_remove.insert(entry.path());
+            }
         }
     }
 

--- a/tests/testsuite/clean.rs
+++ b/tests/testsuite/clean.rs
@@ -212,8 +212,7 @@ fn clean_git() {
         project
             .file("Cargo.toml", &basic_manifest("dep", "0.5.0"))
             .file("src/lib.rs", "")
-    })
-    .unwrap();
+    });
 
     let p = project()
         .file(

--- a/tests/testsuite/concurrent.rs
+++ b/tests/testsuite/concurrent.rs
@@ -191,8 +191,7 @@ fn git_same_repo_different_tags() {
         project
             .file("Cargo.toml", &basic_manifest("dep", "0.5.0"))
             .file("src/lib.rs", "pub fn tag1() {}")
-    })
-    .unwrap();
+    });
 
     let repo = git2::Repository::open(&a.root()).unwrap();
     git::tag(&repo, "tag1");
@@ -269,8 +268,7 @@ fn git_same_branch_different_revs() {
         project
             .file("Cargo.toml", &basic_manifest("dep", "0.5.0"))
             .file("src/lib.rs", "pub fn f1() {}")
-    })
-    .unwrap();
+    });
 
     let p = project()
         .no_manifest()
@@ -476,15 +474,13 @@ fn no_deadlock_with_git_dependencies() {
         project
             .file("Cargo.toml", &basic_manifest("dep1", "0.5.0"))
             .file("src/lib.rs", "")
-    })
-    .unwrap();
+    });
 
     let dep2 = git::new("dep2", |project| {
         project
             .file("Cargo.toml", &basic_manifest("dep2", "0.5.0"))
             .file("src/lib.rs", "")
-    })
-    .unwrap();
+    });
 
     let p = project()
         .file(

--- a/tests/testsuite/corrupt_git.rs
+++ b/tests/testsuite/corrupt_git.rs
@@ -12,8 +12,7 @@ fn deleting_database_files() {
         project
             .file("Cargo.toml", &basic_manifest("bar", "0.5.0"))
             .file("src/lib.rs", "")
-    })
-    .unwrap();
+    });
 
     let project = project
         .file(
@@ -71,8 +70,7 @@ fn deleting_checkout_files() {
         project
             .file("Cargo.toml", &basic_manifest("bar", "0.5.0"))
             .file("src/lib.rs", "")
-    })
-    .unwrap();
+    });
 
     let project = project
         .file(

--- a/tests/testsuite/directory.rs
+++ b/tests/testsuite/directory.rs
@@ -545,8 +545,7 @@ fn git_lock_file_doesnt_change() {
     let git = git::new("git", |p| {
         p.file("Cargo.toml", &basic_manifest("git", "0.5.0"))
             .file("src/lib.rs", "")
-    })
-    .unwrap();
+    });
 
     VendorPackage::new("git")
         .file("Cargo.toml", &basic_manifest("git", "0.5.0"))

--- a/tests/testsuite/doc.rs
+++ b/tests/testsuite/doc.rs
@@ -1275,8 +1275,7 @@ fn doc_cap_lints() {
     let a = git::new("a", |p| {
         p.file("Cargo.toml", &basic_lib_manifest("a"))
             .file("src/lib.rs", BAD_INTRA_LINK_LIB)
-    })
-    .unwrap();
+    });
 
     let p = project()
         .file(

--- a/tests/testsuite/git.rs
+++ b/tests/testsuite/git.rs
@@ -34,8 +34,7 @@ fn cargo_compile_simple_git_dep() {
                 }
             "#,
             )
-    })
-    .unwrap();
+    });
 
     let project = project
         .file(
@@ -97,8 +96,7 @@ fn cargo_compile_git_dep_branch() {
                 }
             "#,
             )
-    })
-    .unwrap();
+    });
 
     // Make a new branch based on the current HEAD commit
     let repo = git2::Repository::open(&git_project.root()).unwrap();
@@ -168,8 +166,7 @@ fn cargo_compile_git_dep_tag() {
                 }
             "#,
             )
-    })
-    .unwrap();
+    });
 
     // Make a tag corresponding to the current HEAD
     let repo = git2::Repository::open(&git_project.root()).unwrap();
@@ -274,8 +271,7 @@ fn cargo_compile_with_nested_paths() {
                 }
             "#,
             )
-    })
-    .unwrap();
+    });
 
     let p = project()
         .file(
@@ -327,8 +323,7 @@ fn cargo_compile_with_malformed_nested_paths() {
             "#,
             )
             .file("vendor/dep2/Cargo.toml", "!INVALID!")
-    })
-    .unwrap();
+    });
 
     let p = project()
         .file(
@@ -388,8 +383,7 @@ fn cargo_compile_with_meta_package() {
                 }
             "#,
             )
-    })
-    .unwrap();
+    });
 
     let p = project()
         .file(
@@ -491,8 +485,7 @@ fn two_revs_same_deps() {
         project
             .file("Cargo.toml", &basic_manifest("bar", "0.0.0"))
             .file("src/lib.rs", "pub fn bar() -> i32 { 1 }")
-    })
-    .unwrap();
+    });
 
     let repo = git2::Repository::open(&bar.root()).unwrap();
     let rev1 = repo.revparse_single("HEAD").unwrap().id();
@@ -579,8 +572,7 @@ fn recompilation() {
         project
             .file("Cargo.toml", &basic_lib_manifest("bar"))
             .file("src/bar.rs", "pub fn bar() {}")
-    })
-    .unwrap();
+    });
 
     let p = project()
         .file(
@@ -684,8 +676,7 @@ fn update_with_shared_deps() {
         project
             .file("Cargo.toml", &basic_lib_manifest("bar"))
             .file("src/bar.rs", "pub fn bar() {}")
-    })
-    .unwrap();
+    });
 
     let p = project()
         .file(
@@ -840,10 +831,8 @@ fn dep_with_submodule() {
     let project = project();
     let git_project = git::new("dep1", |project| {
         project.file("Cargo.toml", &basic_manifest("dep1", "0.5.0"))
-    })
-    .unwrap();
-    let git_project2 =
-        git::new("dep2", |project| project.file("lib.rs", "pub fn dep() {}")).unwrap();
+    });
+    let git_project2 = git::new("dep2", |project| project.file("lib.rs", "pub fn dep() {}"));
 
     let repo = git2::Repository::open(&git_project.root()).unwrap();
     let url = path2url(git_project2.root()).to_string();
@@ -891,10 +880,8 @@ fn dep_with_bad_submodule() {
     let project = project();
     let git_project = git::new("dep1", |project| {
         project.file("Cargo.toml", &basic_manifest("dep1", "0.5.0"))
-    })
-    .unwrap();
-    let git_project2 =
-        git::new("dep2", |project| project.file("lib.rs", "pub fn dep() {}")).unwrap();
+    });
+    let git_project2 = git::new("dep2", |project| project.file("lib.rs", "pub fn dep() {}"));
 
     let repo = git2::Repository::open(&git_project.root()).unwrap();
     let url = path2url(git_project2.root()).to_string();
@@ -971,14 +958,12 @@ fn two_deps_only_update_one() {
         project
             .file("Cargo.toml", &basic_manifest("dep1", "0.5.0"))
             .file("src/lib.rs", "")
-    })
-    .unwrap();
+    });
     let git2 = git::new("dep2", |project| {
         project
             .file("Cargo.toml", &basic_manifest("dep2", "0.5.0"))
             .file("src/lib.rs", "")
-    })
-    .unwrap();
+    });
 
     let p = project
         .file(
@@ -1051,8 +1036,7 @@ fn stale_cached_version() {
         project
             .file("Cargo.toml", &basic_manifest("bar", "0.0.0"))
             .file("src/lib.rs", "pub fn bar() -> i32 { 1 }")
-    })
-    .unwrap();
+    });
 
     // Update the git database in the cache with the current state of the git
     // repo
@@ -1143,18 +1127,15 @@ fn dep_with_changed_submodule() {
     let project = project();
     let git_project = git::new("dep1", |project| {
         project.file("Cargo.toml", &basic_manifest("dep1", "0.5.0"))
-    })
-    .unwrap();
+    });
 
     let git_project2 = git::new("dep2", |project| {
         project.file("lib.rs", "pub fn dep() -> &'static str { \"project2\" }")
-    })
-    .unwrap();
+    });
 
     let git_project3 = git::new("dep3", |project| {
         project.file("lib.rs", "pub fn dep() -> &'static str { \"project3\" }")
-    })
-    .unwrap();
+    });
 
     let repo = git2::Repository::open(&git_project.root()).unwrap();
     let mut sub = git::add_submodule(&repo, &git_project2.url().to_string(), Path::new("src"));
@@ -1265,8 +1246,7 @@ fn dev_deps_with_testing() {
             pub fn gimme() -> &'static str { "zoidberg" }
         "#,
             )
-    })
-    .unwrap();
+    });
 
     let p = project()
         .file(
@@ -1344,8 +1324,7 @@ fn git_build_cmd_freshness() {
             .file("build.rs", "fn main() {}")
             .file("src/lib.rs", "pub fn bar() -> i32 { 1 }")
             .file(".gitignore", "src/bar.rs")
-    })
-    .unwrap();
+    });
     foo.root().move_into_the_past();
 
     sleep_ms(1000);
@@ -1380,8 +1359,7 @@ fn git_name_not_always_needed() {
             pub fn gimme() -> &'static str { "zoidberg" }
         "#,
             )
-    })
-    .unwrap();
+    });
 
     let repo = git2::Repository::open(&p2.root()).unwrap();
     let mut cfg = repo.config().unwrap();
@@ -1427,8 +1405,7 @@ fn git_repo_changing_no_rebuild() {
         project
             .file("Cargo.toml", &basic_manifest("bar", "0.5.0"))
             .file("src/lib.rs", "pub fn bar() -> i32 { 1 }")
-    })
-    .unwrap();
+    });
 
     // Lock p1 to the first rev in the git repo
     let p1 = project()
@@ -1563,8 +1540,7 @@ fn git_dep_build_cmd() {
             }
         "#,
             )
-    })
-    .unwrap();
+    });
 
     p.root().join("bar").move_into_the_past();
 
@@ -1589,8 +1565,7 @@ fn fetch_downloads() {
         project
             .file("Cargo.toml", &basic_manifest("bar", "0.5.0"))
             .file("src/lib.rs", "pub fn bar() -> i32 { 1 }")
-    })
-    .unwrap();
+    });
 
     let p = project()
         .file(
@@ -1625,8 +1600,7 @@ fn warnings_in_git_dep() {
         project
             .file("Cargo.toml", &basic_manifest("bar", "0.5.0"))
             .file("src/lib.rs", "fn unused() {}")
-    })
-    .unwrap();
+    });
 
     let p = project()
         .file(
@@ -1664,14 +1638,12 @@ fn update_ambiguous() {
         project
             .file("Cargo.toml", &basic_manifest("bar", "0.5.0"))
             .file("src/lib.rs", "")
-    })
-    .unwrap();
+    });
     let bar2 = git::new("bar2", |project| {
         project
             .file("Cargo.toml", &basic_manifest("bar", "0.6.0"))
             .file("src/lib.rs", "")
-    })
-    .unwrap();
+    });
     let baz = git::new("baz", |project| {
         project
             .file(
@@ -1690,8 +1662,7 @@ fn update_ambiguous() {
                 ),
             )
             .file("src/lib.rs", "")
-    })
-    .unwrap();
+    });
 
     let p = project()
         .file(
@@ -1738,8 +1709,7 @@ fn update_one_dep_in_repo_with_many_deps() {
             .file("src/lib.rs", "")
             .file("a/Cargo.toml", &basic_manifest("a", "0.5.0"))
             .file("a/src/lib.rs", "")
-    })
-    .unwrap();
+    });
 
     let p = project()
         .file(
@@ -1774,8 +1744,7 @@ fn switch_deps_does_not_update_transitive() {
         project
             .file("Cargo.toml", &basic_manifest("transitive", "0.5.0"))
             .file("src/lib.rs", "")
-    })
-    .unwrap();
+    });
     let dep1 = git::new("dep1", |project| {
         project
             .file(
@@ -1794,8 +1763,7 @@ fn switch_deps_does_not_update_transitive() {
                 ),
             )
             .file("src/lib.rs", "")
-    })
-    .unwrap();
+    });
     let dep2 = git::new("dep2", |project| {
         project
             .file(
@@ -1814,8 +1782,7 @@ fn switch_deps_does_not_update_transitive() {
                 ),
             )
             .file("src/lib.rs", "")
-    })
-    .unwrap();
+    });
 
     let p = project()
         .file(
@@ -1902,8 +1869,7 @@ fn update_one_source_updates_all_packages_in_that_git_source() {
             .file("src/lib.rs", "")
             .file("a/Cargo.toml", &basic_manifest("a", "0.5.0"))
             .file("a/src/lib.rs", "")
-    })
-    .unwrap();
+    });
 
     let p = project()
         .file(
@@ -1956,14 +1922,12 @@ fn switch_sources() {
         project
             .file("Cargo.toml", &basic_manifest("a", "0.5.0"))
             .file("src/lib.rs", "")
-    })
-    .unwrap();
+    });
     let a2 = git::new("a2", |project| {
         project
             .file("Cargo.toml", &basic_manifest("a", "0.5.1"))
             .file("src/lib.rs", "")
-    })
-    .unwrap();
+    });
 
     let p = project()
         .file(
@@ -2055,9 +2019,8 @@ fn dont_require_submodules_are_checked_out() {
         .file("build.rs", "fn main() {}")
         .file("src/lib.rs", "")
         .file("a/foo", "")
-    })
-    .unwrap();
-    let git2 = git::new("dep2", |p| p).unwrap();
+    });
+    let git2 = git::new("dep2", |p| p);
 
     let repo = git2::Repository::open(&git1.root()).unwrap();
     let url = path2url(git2.root()).to_string();
@@ -2077,8 +2040,7 @@ fn doctest_same_name() {
     let a2 = git::new("a2", |p| {
         p.file("Cargo.toml", &basic_manifest("a", "0.5.0"))
             .file("src/lib.rs", "pub fn a2() {}")
-    })
-    .unwrap();
+    });
 
     let a1 = git::new("a1", |p| {
         p.file(
@@ -2096,8 +2058,7 @@ fn doctest_same_name() {
             ),
         )
         .file("src/lib.rs", "extern crate a; pub fn a1() {}")
-    })
-    .unwrap();
+    });
 
     let p = project()
         .file(
@@ -2136,8 +2097,7 @@ fn lints_are_suppressed() {
             use std::option;
         ",
         )
-    })
-    .unwrap();
+    });
 
     let p = project()
         .file(
@@ -2180,8 +2140,7 @@ fn denied_lints_are_allowed() {
             use std::option;
         ",
         )
-    })
-    .unwrap();
+    });
 
     let p = project()
         .file(
@@ -2219,8 +2178,7 @@ fn add_a_git_dep() {
     let git = git::new("git", |p| {
         p.file("Cargo.toml", &basic_manifest("git", "0.5.0"))
             .file("src/lib.rs", "")
-    })
-    .unwrap();
+    });
 
     let p = project()
         .file(
@@ -2275,8 +2233,7 @@ fn two_at_rev_instead_of_tag() {
             .file("src/lib.rs", "")
             .file("a/Cargo.toml", &basic_manifest("git2", "0.5.0"))
             .file("a/src/lib.rs", "")
-    })
-    .unwrap();
+    });
 
     // Make a tag corresponding to the current HEAD
     let repo = git2::Repository::open(&git.root()).unwrap();
@@ -2338,8 +2295,7 @@ fn include_overrides_gitignore() {
         .file("src/lib.rs", "")
         .file("ignored.txt", "")
         .file("build.rs", "fn main() {}")
-    })
-    .unwrap();
+    });
 
     p.cargo("build").run();
     p.change_file("ignored.txt", "Trigger rebuild.");
@@ -2393,8 +2349,7 @@ fn invalid_git_dependency_manifest() {
                 }
             "#,
             )
-    })
-    .unwrap();
+    });
 
     let project = project
         .file(
@@ -2451,10 +2406,9 @@ fn failed_submodule_checkout() {
     let project = project();
     let git_project = git::new("dep1", |project| {
         project.file("Cargo.toml", &basic_manifest("dep1", "0.5.0"))
-    })
-    .unwrap();
+    });
 
-    let git_project2 = git::new("dep2", |project| project.file("lib.rs", "")).unwrap();
+    let git_project2 = git::new("dep2", |project| project.file("lib.rs", ""));
 
     let listener = TcpListener::bind("127.0.0.1:0").unwrap();
     let addr = listener.local_addr().unwrap();
@@ -2536,8 +2490,7 @@ fn use_the_cli() {
         project
             .file("Cargo.toml", &basic_manifest("dep1", "0.5.0"))
             .file("src/lib.rs", "")
-    })
-    .unwrap();
+    });
 
     let project = project
         .file(
@@ -2584,14 +2537,12 @@ fn templatedir_doesnt_cause_problems() {
         project
             .file("Cargo.toml", &basic_manifest("dep2", "0.5.0"))
             .file("src/lib.rs", "")
-    })
-    .unwrap();
+    });
     let git_project = git::new("dep1", |project| {
         project
             .file("Cargo.toml", &basic_manifest("dep1", "0.5.0"))
             .file("src/lib.rs", "")
-    })
-    .unwrap();
+    });
     let p = project()
         .file(
             "Cargo.toml",
@@ -2644,8 +2595,7 @@ fn git_with_cli_force() {
         project
             .file("Cargo.toml", &basic_lib_manifest("dep1"))
             .file("src/lib.rs", r#"pub fn f() { println!("one"); }"#)
-    })
-    .unwrap();
+    });
     let p = project()
         .file(
             "Cargo.toml",
@@ -2706,8 +2656,7 @@ fn git_fetch_cli_env_clean() {
         project
             .file("Cargo.toml", &basic_manifest("dep1", "0.5.0"))
             .file("src/lib.rs", "")
-    })
-    .unwrap();
+    });
 
     let git_proj = git::new("foo", |project| {
         project
@@ -2732,8 +2681,7 @@ fn git_fetch_cli_env_clean() {
                 git-fetch-with-cli = true
                 ",
             )
-    })
-    .unwrap();
+    });
 
     // The directory set here isn't too important. Pointing to our own git
     // directory causes git to be confused and fail. Can also point to an

--- a/tests/testsuite/install_upgrade.rs
+++ b/tests/testsuite/install_upgrade.rs
@@ -562,8 +562,7 @@ two v1.0.0:
 
 #[cargo_test]
 fn upgrade_git() {
-    let git_project =
-        git::new("foo", |project| project.file("src/main.rs", "fn main() {}")).unwrap();
+    let git_project = git::new("foo", |project| project.file("src/main.rs", "fn main() {}"));
     // install
     cargo_process("install -Z install-upgrade --git")
         .arg(git_project.url().to_string())
@@ -618,8 +617,7 @@ fn switch_sources() {
         .build();
     let git_project = git::new("foo", |project| {
         project.file("src/main.rs", r#"fn main() { println!("git"); }"#)
-    })
-    .unwrap();
+    });
 
     cargo_process("install -Z install-upgrade foo")
         .masquerade_as_nightly_cargo()

--- a/tests/testsuite/lockfile_compat.rs
+++ b/tests/testsuite/lockfile_compat.rs
@@ -318,8 +318,7 @@ fn listed_checksum_bad_if_we_cannot_compute() {
     let git = git::new("bar", |p| {
         p.file("Cargo.toml", &basic_manifest("bar", "0.1.0"))
             .file("src/lib.rs", "")
-    })
-    .unwrap();
+    });
 
     let p = project()
         .file(

--- a/tests/testsuite/offline.rs
+++ b/tests/testsuite/offline.rs
@@ -363,8 +363,7 @@ fn cargo_compile_offline_with_cached_git_dep() {
                 pub static COOL_STR:&str = "cached git repo rev1";
                 "#,
             )
-    })
-    .unwrap();
+    });
 
     let repo = git2::Repository::open(&git_project.root()).unwrap();
     let rev1 = repo.revparse_single("HEAD").unwrap().id();

--- a/tests/testsuite/package.rs
+++ b/tests/testsuite/package.rs
@@ -477,12 +477,10 @@ fn package_git_submodule() {
                 "#,
             )
             .file("src/lib.rs", "pub fn foo() {}")
-    })
-    .unwrap();
+    });
     let library = git::new("bar", |library| {
         library.no_manifest().file("Makefile", "all:")
-    })
-    .unwrap();
+    });
 
     let repository = git2::Repository::open(&project.root()).unwrap();
     let url = path2url(library.root()).to_string();
@@ -521,13 +519,11 @@ fn package_symlink_to_submodule() {
 
     let project = git::new("foo", |project| {
         project.file("src/lib.rs", "pub fn foo() {}")
-    })
-    .unwrap();
+    });
 
     let library = git::new("submodule", |library| {
         library.no_manifest().file("Makefile", "all:")
-    })
-    .unwrap();
+    });
 
     let repository = git2::Repository::open(&project.root()).unwrap();
     let url = path2url(library.root()).to_string();

--- a/tests/testsuite/support/git.rs
+++ b/tests/testsuite/support/git.rs
@@ -42,7 +42,6 @@ use std::fs::{self, File};
 use std::io::prelude::*;
 use std::path::{Path, PathBuf};
 
-use cargo::util::ProcessError;
 use git2;
 use url::Url;
 
@@ -66,12 +65,7 @@ pub fn repo(p: &Path) -> RepoBuilder {
 impl RepoBuilder {
     pub fn init(p: &Path) -> RepoBuilder {
         t!(fs::create_dir_all(p.parent().unwrap()));
-        let repo = t!(git2::Repository::init(p));
-        {
-            let mut config = t!(repo.config());
-            t!(config.set_str("user.name", "name"));
-            t!(config.set_str("user.email", "email"));
-        }
+        let repo = init(p);
         RepoBuilder {
             repo,
             files: Vec::new(),
@@ -132,8 +126,27 @@ impl Repository {
     }
 }
 
+/// Initialize a new repository at the given path.
+pub fn init(path: &Path) -> git2::Repository {
+    let repo = t!(git2::Repository::init(path));
+    let mut cfg = t!(repo.config());
+    t!(cfg.set_str("user.email", "foo@bar.com"));
+    t!(cfg.set_str("user.name", "Foo Bar"));
+    drop(cfg);
+    repo
+}
+
 /// Create a new git repository with a project.
-pub fn new<F>(name: &str, callback: F) -> Result<Project, ProcessError>
+pub fn new<F>(name: &str, callback: F) -> Project
+where
+    F: FnOnce(ProjectBuilder) -> ProjectBuilder,
+{
+    new_repo(name, callback).0
+}
+
+/// Create a new git repository with a project.
+/// Returns both the Project and the git Repository.
+pub fn new_repo<F>(name: &str, callback: F) -> (Project, git2::Repository)
 where
     F: FnOnce(ProjectBuilder) -> ProjectBuilder,
 {
@@ -141,14 +154,10 @@ where
     git_project = callback(git_project);
     let git_project = git_project.build();
 
-    let repo = t!(git2::Repository::init(&git_project.root()));
-    let mut cfg = t!(repo.config());
-    t!(cfg.set_str("user.email", "foo@bar.com"));
-    t!(cfg.set_str("user.name", "Foo Bar"));
-    drop(cfg);
+    let repo = init(&git_project.root());
     add(&repo);
     commit(&repo);
-    Ok(git_project)
+    (git_project, repo)
 }
 
 /// Add all files in the working directory to the git index.

--- a/tests/testsuite/vendor.rs
+++ b/tests/testsuite/vendor.rs
@@ -262,8 +262,7 @@ fn included_files_only() {
             .file("src/lib.rs", "")
             .file(".gitignore", "a")
             .file("a/b.md", "")
-    })
-    .unwrap();
+    });
 
     let p = project()
         .file(
@@ -305,8 +304,7 @@ fn dependent_crates_in_crates() {
         .file("src/lib.rs", "")
         .file("b/Cargo.toml", &basic_lib_manifest("b"))
         .file("b/src/lib.rs", "")
-    })
-    .unwrap();
+    });
     let p = project()
         .file(
             "Cargo.toml",
@@ -336,8 +334,7 @@ fn vendoring_git_crates() {
         p.file("Cargo.toml", &basic_lib_manifest("serde_derive"))
             .file("src/lib.rs", "")
             .file("src/wut.rs", "")
-    })
-    .unwrap();
+    });
 
     let p = project()
         .file(
@@ -379,8 +376,7 @@ fn git_simple() {
     let git = git::new("git", |p| {
         p.file("Cargo.toml", &basic_lib_manifest("a"))
             .file("src/lib.rs", "")
-    })
-    .unwrap();
+    });
 
     let p = project()
         .file(
@@ -422,8 +418,7 @@ fn git_duplicate() {
         .file("src/lib.rs", "")
         .file("b/Cargo.toml", &basic_lib_manifest("b"))
         .file("b/src/lib.rs", "")
-    })
-    .unwrap();
+    });
 
     let p = project()
         .file(

--- a/tests/testsuite/workspaces.rs
+++ b/tests/testsuite/workspaces.rs
@@ -1127,8 +1127,7 @@ fn workspace_in_git() {
             )
             .file("foo/Cargo.toml", &basic_manifest("foo", "0.1.0"))
             .file("foo/src/lib.rs", "")
-    })
-    .unwrap();
+    });
     let p = project()
         .file(
             "Cargo.toml",
@@ -1872,8 +1871,7 @@ fn dont_recurse_out_of_cargo_home() {
                 }
             "#,
             )
-    })
-    .unwrap();
+    });
     let p = project()
         .file(
             "Cargo.toml",


### PR DESCRIPTION
`cargo vendor` (without `--no-delete`) will delete all files in the `vendor/` directory when it starts. This changes it so that it will skip any entries starting with a dot. This allows one to track the vendor directory with a source control system like git.

Closes #7109

(Note: two commits, one is a test change.)