### PR TITLE
`cargo fetch`: Display workspace warnings.

### DIFF
--- a/src/cargo/ops/cargo_fetch.rs
+++ b/src/cargo/ops/cargo_fetch.rs
@@ -16,6 +16,7 @@ pub fn fetch<'a>(
     ws: &Workspace<'a>,
     options: &FetchOptions<'a>,
 ) -> CargoResult<(Resolve, PackageSet<'a>)> {
+    ws.emit_warnings()?;
     let (packages, resolve) = ops::resolve_ws(ws)?;
 
     let jobs = Some(1);

--- a/tests/testsuite/fetch.rs
+++ b/tests/testsuite/fetch.rs
@@ -112,3 +112,22 @@ fn fetch_platform_specific_dependencies() {
         .with_stderr_does_not_contain("[DOWNLOADED] d1 v1.2.3 [..]")
         .run();
 }
+
+#[cargo_test]
+fn fetch_warning() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "foo"
+            version = "1.0.0"
+            misspelled = "wut"
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+    p.cargo("fetch")
+        .with_stderr("[WARNING] unused manifest key: package.misspelled")
+        .run();
+}


### PR DESCRIPTION
Warnings were previously hidden with `cargo fetch`. It may be a little confusing, so go ahead and display them.

cc https://github.com/rust-lang/cargo/issues/7180#issuecomment-515489257

I thought about other commands that don't display warnings, but I couldn't think of any others where it would be useful. The only edge case is `publish`/`package`, which won't display unused key warnings because the manifest is rewritten and they are stripped. But displaying warnings there is awkward because some warnings will be displayed twice.
