### PR TITLE
Adjust warning for rustdoc filename collision.

### DIFF
--- a/tests/testsuite/collisions.rs
+++ b/tests/testsuite/collisions.rs
@@ -141,8 +141,8 @@ The lib target `foo` in package `foo2 v0.1.0 ([..]/foo/foo2)` has the same outpu
 filename as the lib target `foo` in package `foo v0.1.0 ([..]/foo)`.
 Colliding filename is: [..]/foo/target/doc/foo/index.html
 The targets should have unique names.
-Consider changing their names to be unique or compiling them separately.
-This may become a hard error in the future; see <https://github.com/rust-lang/cargo/issues/6313>.
+This is a known bug where multiple crates with the same name use
+the same path; see <https://github.com/rust-lang/cargo/issues/6313>.
 ",
         )
         .run();


### PR DESCRIPTION
The existing warning was a little misleading, as this is a known bug, not something we currently plan to reject.

cc https://github.com/rust-lang/cargo/issues/6313#issuecomment-505632458
