### PR TITLE
Check in package/publish if a git submodule is dirty.

### DIFF
--- a/tests/testsuite/git.rs
+++ b/tests/testsuite/git.rs
@@ -2695,19 +2695,16 @@ fn git_fetch_cli_env_clean() {
 #[cargo_test]
 fn dirty_submodule() {
     // `cargo package` warns for dirty file in submodule.
-    let git_project = git::new("foo", |project| {
+    let (git_project, repo) = git::new_repo("foo", |project| {
         project
             .file("Cargo.toml", &basic_manifest("foo", "0.5.0"))
             // This is necessary because `git::add` is too eager.
             .file(".gitignore", "/target")
-    })
-    .unwrap();
+    });
     let git_project2 = git::new("src", |project| {
         project.no_manifest().file("lib.rs", "pub fn f() {}")
-    })
-    .unwrap();
+    });
 
-    let repo = git2::Repository::open(&git_project.root()).unwrap();
     let url = path2url(git_project2.root()).to_string();
     git::add_submodule(&repo, &url, Path::new("src"));
 
@@ -2757,7 +2754,7 @@ to proceed despite [..]
     git_project.cargo("package --no-verify").run();
 
     // Try with a nested submodule.
-    let git_project3 = git::new("bar", |project| project.no_manifest().file("mod.rs", "")).unwrap();
+    let git_project3 = git::new("bar", |project| project.no_manifest().file("mod.rs", ""));
     let url = path2url(git_project3.root()).to_string();
     git::add_submodule(&sub_repo, &url, Path::new("bar"));
     git_project

--- a/tests/testsuite/support/git.rs
+++ b/tests/testsuite/support/git.rs
@@ -129,11 +129,14 @@ impl Repository {
 /// Initialize a new repository at the given path.
 pub fn init(path: &Path) -> git2::Repository {
     let repo = t!(git2::Repository::init(path));
+    default_repo_cfg(&repo);
+    repo
+}
+
+fn default_repo_cfg(repo: &git2::Repository) {
     let mut cfg = t!(repo.config());
     t!(cfg.set_str("user.email", "foo@bar.com"));
     t!(cfg.set_str("user.name", "Foo Bar"));
-    drop(cfg);
-    repo
 }
 
 /// Create a new git repository with a project.
@@ -193,6 +196,7 @@ pub fn add_submodule<'a>(
     let path = path.to_str().unwrap().replace(r"\", "/");
     let mut s = t!(repo.submodule(url, Path::new(&path), false));
     let subrepo = t!(s.open());
+    default_repo_cfg(&subrepo);
     t!(subrepo.remote_add_fetch("origin", "refs/heads/*:refs/heads/*"));
     let mut origin = t!(subrepo.find_remote("origin"));
     t!(origin.fetch(&[], None, None));


### PR DESCRIPTION
This extends the "dirty" check during `cargo publish` to check files within a submodule.

It is a little crude, since it unconditionally tries to open every submodule even if it is not relevant to the current package. The performance doesn't seem too bad (~2s for rust-lang/rust with 16 submodules).

It's also a little lax, by ignoring uninitialized submodules. Presumably the verification build will fail if the submodule is not initialized. It could be more aggressive, by requiring all submodules to be initialized?

Closes #3622
