### PR TITLE
Validate feature names are crates.io friendly.

### DIFF
--- a/src/cargo/ops/cargo_package.rs
+++ b/src/cargo/ops/cargo_package.rs
@@ -232,7 +232,10 @@ fn verify_features(pkg: &Package) -> CargoResult<()> {
                  feature `{}` is not valid.",
                 feature
             )
-        } else if !feature.chars().all(|ch| ch.is_ascii_alphanumeric() || ch == '-' || ch == '_') {
+        } else if !feature
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || ch == '-' || ch == '_')
+        {
             failure::bail!(
                 "expected a valid (not empty nor \"_\") feature name containing \
                  only letters, numbers, hyphens, or underscores.\n\

--- a/tests/testsuite/publish.rs
+++ b/tests/testsuite/publish.rs
@@ -899,6 +899,36 @@ fn publish_with_no_default_features() {
 }
 
 #[cargo_test]
+fn publish_with_unrusty_features() {
+    registry::init();
+
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [project]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+            license = "MIT"
+            description = "foo"
+
+            [features]
+            "invalid::characters" = []
+        "#,
+        )
+        .file("src/main.rs", "fn main() {}")
+        .build();
+
+    p.cargo("publish --no-default-features --dry-run --index")
+        .arg(registry_url().to_string())
+        .with_stderr_contains("error: expected a valid (not empty nor \"_\") feature name containing only letters, numbers, hyphens, or underscores.")
+        .with_stderr_contains("feature `invalid::characters` contains other characters.")
+        .with_status(101)
+        .run();
+}
+
+#[cargo_test]
 fn publish_with_patch() {
     Package::new("bar", "1.0.0").publish();
 


### PR DESCRIPTION
Closes rust-lang/cargo#5554
Relates to rust-lang/crates-io-cargo-teams#41