### PR TITLE
Fix #7217: Add support for rustc-flags without spaces between flags and values

### DIFF
--- a/src/cargo/core/compiler/custom_build.rs
+++ b/src/cargo/core/compiler/custom_build.rs
@@ -514,29 +514,38 @@ impl BuildOutput {
             .split(|c: char| c.is_whitespace())
             .filter(|w| w.chars().any(|c| !c.is_whitespace()));
         let (mut library_paths, mut library_links) = (Vec::new(), Vec::new());
+        
         while let Some(flag) = flags_iter.next() {
-            if flag != "-l" && flag != "-L" {
+            if flag.starts_with("-l") || flag.starts_with("-L") {
+                // Check if this flag has no space before the value as is
+                // common with tools like pkg-config
+                // e.g. -L/some/dir/local/lib or -licui18n
+                let (flag, mut value) = flag.split_at(2);
+                if value.len() == 0 {
+                    value = match flags_iter.next() {
+                        Some(v) => v,
+                        None => failure::bail! {
+                            "Flag in rustc-flags has no value in {}: {}",
+                            whence,
+                            value
+                        }
+                    }
+                }
+
+                match flag {
+                    "-l" => library_links.push(value.to_string()),
+                    "-L" => library_paths.push(PathBuf::from(value)),
+
+                    // This was already checked above
+                    _ => unreachable!(),
+                };
+            } else {
                 failure::bail!(
                     "Only `-l` and `-L` flags are allowed in {}: `{}`",
                     whence,
                     value
                 )
             }
-            let value = match flags_iter.next() {
-                Some(v) => v,
-                None => failure::bail!(
-                    "Flag in rustc-flags has no value in {}: `{}`",
-                    whence,
-                    value
-                ),
-            };
-            match flag {
-                "-l" => library_links.push(value.to_string()),
-                "-L" => library_paths.push(PathBuf::from(value)),
-
-                // was already checked above
-                _ => failure::bail!("only -l and -L flags are allowed"),
-            };
         }
         Ok((library_paths, library_links))
     }

--- a/src/cargo/core/compiler/custom_build.rs
+++ b/src/cargo/core/compiler/custom_build.rs
@@ -514,7 +514,7 @@ impl BuildOutput {
             .split(|c: char| c.is_whitespace())
             .filter(|w| w.chars().any(|c| !c.is_whitespace()));
         let (mut library_paths, mut library_links) = (Vec::new(), Vec::new());
-        
+
         while let Some(flag) = flags_iter.next() {
             if flag.starts_with("-l") || flag.starts_with("-L") {
                 // Check if this flag has no space before the value as is
@@ -528,7 +528,7 @@ impl BuildOutput {
                             "Flag in rustc-flags has no value in {}: {}",
                             whence,
                             value
-                        }
+                        },
                     }
                 }
 


### PR DESCRIPTION
Hi, I believe this pull request contains a fix for issue #7217. This is my first pull request to any open source project, much less any Rust project. I'm not super familiar with Rust at the moment, so let me know if I should change anything. Also any help/advice you can give me about this PR would be much appreciated!

I do have some specific questions:
- Is the test I added worthy of being its own test? I basically copied the one above it and remove the spaces between the flags and the values. Should I have added on to the test above it instead?
- Would it be better if I directly unit-tested this function in some other test file?
- Is the `ureachable!` macro good style?