### PR TITLE
Fix old lockfile encoding wrt newlines

### DIFF
--- a/src/cargo/core/mod.rs
+++ b/src/cargo/core/mod.rs
@@ -10,7 +10,7 @@ pub use self::package::{Package, PackageSet};
 pub use self::package_id::PackageId;
 pub use self::package_id_spec::PackageIdSpec;
 pub use self::registry::Registry;
-pub use self::resolver::Resolve;
+pub use self::resolver::{Resolve, ResolveVersion};
 pub use self::shell::{Shell, Verbosity};
 pub use self::source::{GitReference, Source, SourceId, SourceMap};
 pub use self::summary::{FeatureMap, FeatureValue, Summary};


### PR DESCRIPTION
This commit fixes "old lockfile" encodings back to what they were prior
to #7070 with respect to newlines. The changes in #7070 accidentally
introduced a change where old lockfiles might have some extraneous
newlines removed unintentionally.

In #7070 it was attempted to clean up how newlines are emitted to ensure
a trailing blank newline never shows up at the end of the file, but this
acccidentally regressed cases where today we actually do have blank
newlines at the end of lock files. This commit instead restores all the
previous newline handling, and then scopes the "remove trailing
newlines" fix to specifically just the new encoding.

Closes #7254