### PR TITLE
Only apply default-members when building root manifest

### DIFF
--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -452,11 +452,15 @@ impl<'cfg> Workspace<'cfg> {
                 WorkspaceConfig::Root(ref root_config) => {
                     members_paths = root_config
                         .members_paths(root_config.members.as_ref().unwrap_or(&vec![]))?;
-                    default_members_paths = if let Some(ref default) = root_config.default_members {
-                        Some(root_config.members_paths(default)?)
+                    default_members_paths = if root_manifest_path == self.current_manifest {
+                        if let Some(ref default) = root_config.default_members {
+                            Some(root_config.members_paths(default)?)
+                        } else {
+                            None
+                        }
                     } else {
                         None
-                    }
+                    };
                 }
                 _ => failure::bail!(
                     "root of a workspace inferred but wasn't a root: {}",

--- a/src/doc/man/generated/cargo-bench.html
+++ b/src/doc/man/generated/cargo-bench.html
@@ -69,11 +69,16 @@ the executable as a whole.</p>
 <h3 id="cargo_bench_package_selection">Package Selection</h3>
 <div class="paragraph">
 <p>By default, when no package selection options are given, the packages selected
-depend on the current working directory. In the root of a virtual workspace,
-all workspace members are selected (<code>--all</code> is implied). Otherwise, only the
-package in the current directory will be selected. The default packages may be
-overridden with the <code>workspace.default-members</code> key in the root <code>Cargo.toml</code>
-manifest.</p>
+depend on the selected manifest file (based on the current working directory if
+<code>--manifest-path</code> is not given). If the manifest is the root of a workspace then
+the workspaces default members are selected, otherwise only the package defined
+by the manifest will be selected.</p>
+</div>
+<div class="paragraph">
+<p>The default members of a workspace can be set explicitly with the
+<code>workspace.default-members</code> key in the root manifest. If this is not set, a
+virtual workspace will include all workspace members (equivalent to passing
+<code>--all</code>), and a non-virtual workspace will include only the root crate itself.</p>
 </div>
 <div class="dlist">
 <dl>

--- a/src/doc/man/generated/cargo-build.html
+++ b/src/doc/man/generated/cargo-build.html
@@ -25,11 +25,16 @@
 <h3 id="cargo_build_package_selection">Package Selection</h3>
 <div class="paragraph">
 <p>By default, when no package selection options are given, the packages selected
-depend on the current working directory. In the root of a virtual workspace,
-all workspace members are selected (<code>--all</code> is implied). Otherwise, only the
-package in the current directory will be selected. The default packages may be
-overridden with the <code>workspace.default-members</code> key in the root <code>Cargo.toml</code>
-manifest.</p>
+depend on the selected manifest file (based on the current working directory if
+<code>--manifest-path</code> is not given). If the manifest is the root of a workspace then
+the workspaces default members are selected, otherwise only the package defined
+by the manifest will be selected.</p>
+</div>
+<div class="paragraph">
+<p>The default members of a workspace can be set explicitly with the
+<code>workspace.default-members</code> key in the root manifest. If this is not set, a
+virtual workspace will include all workspace members (equivalent to passing
+<code>--all</code>), and a non-virtual workspace will include only the root crate itself.</p>
 </div>
 <div class="dlist">
 <dl>

--- a/src/doc/man/generated/cargo-check.html
+++ b/src/doc/man/generated/cargo-check.html
@@ -29,11 +29,16 @@ not been modified.</p>
 <h3 id="cargo_check_package_selection">Package Selection</h3>
 <div class="paragraph">
 <p>By default, when no package selection options are given, the packages selected
-depend on the current working directory. In the root of a virtual workspace,
-all workspace members are selected (<code>--all</code> is implied). Otherwise, only the
-package in the current directory will be selected. The default packages may be
-overridden with the <code>workspace.default-members</code> key in the root <code>Cargo.toml</code>
-manifest.</p>
+depend on the selected manifest file (based on the current working directory if
+<code>--manifest-path</code> is not given). If the manifest is the root of a workspace then
+the workspaces default members are selected, otherwise only the package defined
+by the manifest will be selected.</p>
+</div>
+<div class="paragraph">
+<p>The default members of a workspace can be set explicitly with the
+<code>workspace.default-members</code> key in the root manifest. If this is not set, a
+virtual workspace will include all workspace members (equivalent to passing
+<code>--all</code>), and a non-virtual workspace will include only the root crate itself.</p>
 </div>
 <div class="dlist">
 <dl>

--- a/src/doc/man/generated/cargo-doc.html
+++ b/src/doc/man/generated/cargo-doc.html
@@ -45,11 +45,16 @@ is placed in <code>target/doc</code> in rustdoc&#8217;s usual format.</p>
 <h3 id="cargo_doc_package_selection">Package Selection</h3>
 <div class="paragraph">
 <p>By default, when no package selection options are given, the packages selected
-depend on the current working directory. In the root of a virtual workspace,
-all workspace members are selected (<code>--all</code> is implied). Otherwise, only the
-package in the current directory will be selected. The default packages may be
-overridden with the <code>workspace.default-members</code> key in the root <code>Cargo.toml</code>
-manifest.</p>
+depend on the selected manifest file (based on the current working directory if
+<code>--manifest-path</code> is not given). If the manifest is the root of a workspace then
+the workspaces default members are selected, otherwise only the package defined
+by the manifest will be selected.</p>
+</div>
+<div class="paragraph">
+<p>The default members of a workspace can be set explicitly with the
+<code>workspace.default-members</code> key in the root manifest. If this is not set, a
+virtual workspace will include all workspace members (equivalent to passing
+<code>--all</code>), and a non-virtual workspace will include only the root crate itself.</p>
 </div>
 <div class="dlist">
 <dl>

--- a/src/doc/man/generated/cargo-fix.html
+++ b/src/doc/man/generated/cargo-fix.html
@@ -100,11 +100,16 @@ current edition.</p>
 <h3 id="cargo_fix_package_selection">Package Selection</h3>
 <div class="paragraph">
 <p>By default, when no package selection options are given, the packages selected
-depend on the current working directory. In the root of a virtual workspace,
-all workspace members are selected (<code>--all</code> is implied). Otherwise, only the
-package in the current directory will be selected. The default packages may be
-overridden with the <code>workspace.default-members</code> key in the root <code>Cargo.toml</code>
-manifest.</p>
+depend on the selected manifest file (based on the current working directory if
+<code>--manifest-path</code> is not given). If the manifest is the root of a workspace then
+the workspaces default members are selected, otherwise only the package defined
+by the manifest will be selected.</p>
+</div>
+<div class="paragraph">
+<p>The default members of a workspace can be set explicitly with the
+<code>workspace.default-members</code> key in the root manifest. If this is not set, a
+virtual workspace will include all workspace members (equivalent to passing
+<code>--all</code>), and a non-virtual workspace will include only the root crate itself.</p>
 </div>
 <div class="dlist">
 <dl>

--- a/src/doc/man/generated/cargo-test.html
+++ b/src/doc/man/generated/cargo-test.html
@@ -75,11 +75,16 @@ the executable as a whole.</p>
 <h3 id="cargo_test_package_selection">Package Selection</h3>
 <div class="paragraph">
 <p>By default, when no package selection options are given, the packages selected
-depend on the current working directory. In the root of a virtual workspace,
-all workspace members are selected (<code>--all</code> is implied). Otherwise, only the
-package in the current directory will be selected. The default packages may be
-overridden with the <code>workspace.default-members</code> key in the root <code>Cargo.toml</code>
-manifest.</p>
+depend on the selected manifest file (based on the current working directory if
+<code>--manifest-path</code> is not given). If the manifest is the root of a workspace then
+the workspaces default members are selected, otherwise only the package defined
+by the manifest will be selected.</p>
+</div>
+<div class="paragraph">
+<p>The default members of a workspace can be set explicitly with the
+<code>workspace.default-members</code> key in the root manifest. If this is not set, a
+virtual workspace will include all workspace members (equivalent to passing
+<code>--all</code>), and a non-virtual workspace will include only the root crate itself.</p>
 </div>
 <div class="dlist">
 <dl>

--- a/src/doc/man/options-packages.adoc
+++ b/src/doc/man/options-packages.adoc
@@ -1,9 +1,13 @@
 By default, when no package selection options are given, the packages selected
-depend on the current working directory. In the root of a virtual workspace,
-all workspace members are selected (`--all` is implied). Otherwise, only the
-package in the current directory will be selected. The default packages may be
-overridden with the `workspace.default-members` key in the root `Cargo.toml`
-manifest.
+depend on the selected manifest file (based on the current working directory if
+`--manifest-path` is not given). If the manifest is the root of a workspace then
+the workspaces default members are selected, otherwise only the package defined
+by the manifest will be selected.
+
+The default members of a workspace can be set explicitly with the
+`workspace.default-members` key in the root manifest. If this is not set, a
+virtual workspace will include all workspace members (equivalent to passing
+`--all`), and a non-virtual workspace will include only the root crate itself.
 
 *-p* _SPEC_...::
 *--package* _SPEC_...::

--- a/src/etc/man/cargo-bench.1
+++ b/src/etc/man/cargo-bench.1
@@ -1,13 +1,13 @@
 '\" t
 .\"     Title: cargo-bench
 .\"    Author: [see the "AUTHOR(S)" section]
-.\" Generator: Asciidoctor 2.0.8
-.\"      Date: 2019-06-07
+.\" Generator: Asciidoctor 2.0.10
+.\"      Date: 2019-08-19
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "CARGO\-BENCH" "1" "2019-06-07" "\ \&" "\ \&"
+.TH "CARGO\-BENCH" "1" "2019-08-19" "\ \&" "\ \&"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0
@@ -77,11 +77,15 @@ the executable as a whole.
 .SS "Package Selection"
 .sp
 By default, when no package selection options are given, the packages selected
-depend on the current working directory. In the root of a virtual workspace,
-all workspace members are selected (\fB\-\-all\fP is implied). Otherwise, only the
-package in the current directory will be selected. The default packages may be
-overridden with the \fBworkspace.default\-members\fP key in the root \fBCargo.toml\fP
-manifest.
+depend on the selected manifest file (based on the current working directory if
+\fB\-\-manifest\-path\fP is not given). If the manifest is the root of a workspace then
+the workspaces default members are selected, otherwise only the package defined
+by the manifest will be selected.
+.sp
+The default members of a workspace can be set explicitly with the
+\fBworkspace.default\-members\fP key in the root manifest. If this is not set, a
+virtual workspace will include all workspace members (equivalent to passing
+\fB\-\-all\fP), and a non\-virtual workspace will include only the root crate itself.
 .sp
 \fB\-p\fP \fISPEC\fP..., \fB\-\-package\fP \fISPEC\fP...
 .RS 4

--- a/src/etc/man/cargo-build.1
+++ b/src/etc/man/cargo-build.1
@@ -1,13 +1,13 @@
 '\" t
 .\"     Title: cargo-build
 .\"    Author: [see the "AUTHOR(S)" section]
-.\" Generator: Asciidoctor 2.0.8
-.\"      Date: 2019-06-07
+.\" Generator: Asciidoctor 2.0.10
+.\"      Date: 2019-08-19
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "CARGO\-BUILD" "1" "2019-06-07" "\ \&" "\ \&"
+.TH "CARGO\-BUILD" "1" "2019-08-19" "\ \&" "\ \&"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0
@@ -39,11 +39,15 @@ Compile local packages and all of their dependencies.
 .SS "Package Selection"
 .sp
 By default, when no package selection options are given, the packages selected
-depend on the current working directory. In the root of a virtual workspace,
-all workspace members are selected (\fB\-\-all\fP is implied). Otherwise, only the
-package in the current directory will be selected. The default packages may be
-overridden with the \fBworkspace.default\-members\fP key in the root \fBCargo.toml\fP
-manifest.
+depend on the selected manifest file (based on the current working directory if
+\fB\-\-manifest\-path\fP is not given). If the manifest is the root of a workspace then
+the workspaces default members are selected, otherwise only the package defined
+by the manifest will be selected.
+.sp
+The default members of a workspace can be set explicitly with the
+\fBworkspace.default\-members\fP key in the root manifest. If this is not set, a
+virtual workspace will include all workspace members (equivalent to passing
+\fB\-\-all\fP), and a non\-virtual workspace will include only the root crate itself.
 .sp
 \fB\-p\fP \fISPEC\fP..., \fB\-\-package\fP \fISPEC\fP...
 .RS 4

--- a/src/etc/man/cargo-check.1
+++ b/src/etc/man/cargo-check.1
@@ -1,13 +1,13 @@
 '\" t
 .\"     Title: cargo-check
 .\"    Author: [see the "AUTHOR(S)" section]
-.\" Generator: Asciidoctor 2.0.8
-.\"      Date: 2019-06-07
+.\" Generator: Asciidoctor 2.0.10
+.\"      Date: 2019-08-19
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "CARGO\-CHECK" "1" "2019-06-07" "\ \&" "\ \&"
+.TH "CARGO\-CHECK" "1" "2019-08-19" "\ \&" "\ \&"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0
@@ -43,11 +43,15 @@ not been modified.
 .SS "Package Selection"
 .sp
 By default, when no package selection options are given, the packages selected
-depend on the current working directory. In the root of a virtual workspace,
-all workspace members are selected (\fB\-\-all\fP is implied). Otherwise, only the
-package in the current directory will be selected. The default packages may be
-overridden with the \fBworkspace.default\-members\fP key in the root \fBCargo.toml\fP
-manifest.
+depend on the selected manifest file (based on the current working directory if
+\fB\-\-manifest\-path\fP is not given). If the manifest is the root of a workspace then
+the workspaces default members are selected, otherwise only the package defined
+by the manifest will be selected.
+.sp
+The default members of a workspace can be set explicitly with the
+\fBworkspace.default\-members\fP key in the root manifest. If this is not set, a
+virtual workspace will include all workspace members (equivalent to passing
+\fB\-\-all\fP), and a non\-virtual workspace will include only the root crate itself.
 .sp
 \fB\-p\fP \fISPEC\fP..., \fB\-\-package\fP \fISPEC\fP...
 .RS 4

--- a/src/etc/man/cargo-doc.1
+++ b/src/etc/man/cargo-doc.1
@@ -1,13 +1,13 @@
 '\" t
 .\"     Title: cargo-doc
 .\"    Author: [see the "AUTHOR(S)" section]
-.\" Generator: Asciidoctor 2.0.8
-.\"      Date: 2019-06-07
+.\" Generator: Asciidoctor 2.0.10
+.\"      Date: 2019-08-19
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "CARGO\-DOC" "1" "2019-06-07" "\ \&" "\ \&"
+.TH "CARGO\-DOC" "1" "2019-08-19" "\ \&" "\ \&"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0
@@ -56,11 +56,15 @@ Include non\-public items in the documentation.
 .SS "Package Selection"
 .sp
 By default, when no package selection options are given, the packages selected
-depend on the current working directory. In the root of a virtual workspace,
-all workspace members are selected (\fB\-\-all\fP is implied). Otherwise, only the
-package in the current directory will be selected. The default packages may be
-overridden with the \fBworkspace.default\-members\fP key in the root \fBCargo.toml\fP
-manifest.
+depend on the selected manifest file (based on the current working directory if
+\fB\-\-manifest\-path\fP is not given). If the manifest is the root of a workspace then
+the workspaces default members are selected, otherwise only the package defined
+by the manifest will be selected.
+.sp
+The default members of a workspace can be set explicitly with the
+\fBworkspace.default\-members\fP key in the root manifest. If this is not set, a
+virtual workspace will include all workspace members (equivalent to passing
+\fB\-\-all\fP), and a non\-virtual workspace will include only the root crate itself.
 .sp
 \fB\-p\fP \fISPEC\fP..., \fB\-\-package\fP \fISPEC\fP...
 .RS 4

--- a/src/etc/man/cargo-fix.1
+++ b/src/etc/man/cargo-fix.1
@@ -1,13 +1,13 @@
 '\" t
 .\"     Title: cargo-fix
 .\"    Author: [see the "AUTHOR(S)" section]
-.\" Generator: Asciidoctor 2.0.8
-.\"      Date: 2019-06-07
+.\" Generator: Asciidoctor 2.0.10
+.\"      Date: 2019-08-19
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "CARGO\-FIX" "1" "2019-06-07" "\ \&" "\ \&"
+.TH "CARGO\-FIX" "1" "2019-08-19" "\ \&" "\ \&"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0
@@ -113,11 +113,15 @@ Fix code even if the working directory has staged changes.
 .SS "Package Selection"
 .sp
 By default, when no package selection options are given, the packages selected
-depend on the current working directory. In the root of a virtual workspace,
-all workspace members are selected (\fB\-\-all\fP is implied). Otherwise, only the
-package in the current directory will be selected. The default packages may be
-overridden with the \fBworkspace.default\-members\fP key in the root \fBCargo.toml\fP
-manifest.
+depend on the selected manifest file (based on the current working directory if
+\fB\-\-manifest\-path\fP is not given). If the manifest is the root of a workspace then
+the workspaces default members are selected, otherwise only the package defined
+by the manifest will be selected.
+.sp
+The default members of a workspace can be set explicitly with the
+\fBworkspace.default\-members\fP key in the root manifest. If this is not set, a
+virtual workspace will include all workspace members (equivalent to passing
+\fB\-\-all\fP), and a non\-virtual workspace will include only the root crate itself.
 .sp
 \fB\-p\fP \fISPEC\fP..., \fB\-\-package\fP \fISPEC\fP...
 .RS 4

--- a/src/etc/man/cargo-test.1
+++ b/src/etc/man/cargo-test.1
@@ -1,13 +1,13 @@
 '\" t
 .\"     Title: cargo-test
 .\"    Author: [see the "AUTHOR(S)" section]
-.\" Generator: Asciidoctor 2.0.8
-.\"      Date: 2019-06-07
+.\" Generator: Asciidoctor 2.0.10
+.\"      Date: 2019-08-19
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "CARGO\-TEST" "1" "2019-06-07" "\ \&" "\ \&"
+.TH "CARGO\-TEST" "1" "2019-08-19" "\ \&" "\ \&"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0
@@ -83,11 +83,15 @@ the executable as a whole.
 .SS "Package Selection"
 .sp
 By default, when no package selection options are given, the packages selected
-depend on the current working directory. In the root of a virtual workspace,
-all workspace members are selected (\fB\-\-all\fP is implied). Otherwise, only the
-package in the current directory will be selected. The default packages may be
-overridden with the \fBworkspace.default\-members\fP key in the root \fBCargo.toml\fP
-manifest.
+depend on the selected manifest file (based on the current working directory if
+\fB\-\-manifest\-path\fP is not given). If the manifest is the root of a workspace then
+the workspaces default members are selected, otherwise only the package defined
+by the manifest will be selected.
+.sp
+The default members of a workspace can be set explicitly with the
+\fBworkspace.default\-members\fP key in the root manifest. If this is not set, a
+virtual workspace will include all workspace members (equivalent to passing
+\fB\-\-all\fP), and a non\-virtual workspace will include only the root crate itself.
 .sp
 \fB\-p\fP \fISPEC\fP..., \fB\-\-package\fP \fISPEC\fP...
 .RS 4

--- a/tests/testsuite/workspaces.rs
+++ b/tests/testsuite/workspaces.rs
@@ -83,6 +83,44 @@ fn simple_explicit_default_members() {
 }
 
 #[cargo_test]
+fn non_virtual_default_members_build_other_member() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [project]
+            name = "foo"
+            version = "0.1.0"
+            authors = []
+
+            [workspace]
+            members = [".", "bar", "baz"]
+            default-members = ["baz"]
+        "#,
+        )
+        .file("src/main.rs", "fn main() {}")
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
+        .file("bar/src/lib.rs", "pub fn bar() {}")
+        .file("baz/Cargo.toml", &basic_manifest("baz", "0.1.0"))
+        .file("baz/src/lib.rs", "pub fn baz() {}")
+        .build();
+
+    p.cargo("build")
+        .with_stderr(
+            "[..] Compiling baz v0.1.0 ([..])\n\
+             [..] Finished dev [unoptimized + debuginfo] target(s) in [..]\n",
+        )
+        .run();
+
+    p.cargo("build --manifest-path bar/Cargo.toml")
+        .with_stderr(
+            "[..] Compiling bar v0.1.0 ([..])\n\
+             [..] Finished dev [unoptimized + debuginfo] target(s) in [..]\n",
+        )
+        .run();
+}
+
+#[cargo_test]
 fn inferred_root() {
     let p = project()
         .file(
@@ -844,6 +882,31 @@ fn virtual_default_member_is_not_a_member() {
 error: package `[..]something-else` is listed in workspace’s default-members \
 but is not a member.
 ",
+        )
+        .run();
+}
+
+#[cargo_test]
+fn virtual_default_members_build_other_member() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [workspace]
+            members = ["bar", "baz"]
+            default-members = ["baz"]
+        "#,
+        )
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
+        .file("bar/src/lib.rs", "pub fn bar() {}")
+        .file("baz/Cargo.toml", &basic_manifest("baz", "0.1.0"))
+        .file("baz/src/lib.rs", "pub fn baz() {}")
+        .build();
+
+    p.cargo("build --manifest-path bar/Cargo.toml")
+        .with_stderr(
+            "[..] Compiling bar v0.1.0 ([..])\n\
+             [..] Finished dev [unoptimized + debuginfo] target(s) in [..]\n",
         )
         .run();
 }


### PR DESCRIPTION
This is a reopening of #6755 rebased on master.

Closes #5932
