### PR TITLE
Fix `error:`/`warning:` coloring inconsistency with rustc

### DIFF
--- a/src/cargo/core/shell.rs
+++ b/src/cargo/core/shell.rs
@@ -210,14 +210,14 @@ impl Shell {
         if self.needs_clear {
             self.err_erase_line();
         }
-        self.err.print(&"error:", Some(&message), Red, false)
+        self.err.print(&"error", Some(&message), Red, false)
     }
 
     /// Prints an amber 'warning' message.
     pub fn warn<T: fmt::Display>(&mut self, message: T) -> CargoResult<()> {
         match self.verbosity {
             Verbosity::Quiet => Ok(()),
-            _ => self.print(&"warning:", Some(&message), Yellow, false),
+            _ => self.print(&"warning", Some(&message), Yellow, false),
         }
     }
 
@@ -318,6 +318,8 @@ impl ShellOut {
                     write!(stream, "{:>12}", status)?;
                 } else {
                     write!(stream, "{}", status)?;
+                    stream.set_color(ColorSpec::new().set_bold(true))?;
+                    write!(stream, ":")?;
                 }
                 stream.reset()?;
                 match message {
@@ -329,7 +331,7 @@ impl ShellOut {
                 if justified {
                     write!(w, "{:>12}", status)?;
                 } else {
-                    write!(w, "{}", status)?;
+                    write!(w, "{}:", status)?;
                 }
                 match message {
                     Some(message) => writeln!(w, " {}", message)?,


### PR DESCRIPTION
When `rustc` prints an error, the word `error` is red, but the colon after it is white (and the same goes for `warn`, `note` and other messages). `cargo`, however, colors the colon as well, and it [looks inconsistent](https://user-images.githubusercontent.com/10610844/63640674-45040f00-c6cd-11e9-9ee9-6f6f44a51f83.png) when `rustc`'s output is followed by `cargo`'s side-by-side. If `cargo` prints the colon in white, the output [looks more accurate](https://user-images.githubusercontent.com/10610844/63640792-f2c3ed80-c6ce-11e9-9b6e-ba209a4f9788.png).
