### PR TITLE
Update and improve zsh completion

### DIFF
--- a/src/etc/_cargo
+++ b/src/etc/_cargo
@@ -3,8 +3,20 @@
 autoload -U regexp-replace
 
 _cargo() {
-    local state
+    local curcontext="$curcontext" ret=1
+    local -a command_scope_spec common parallel features msgfmt triple target registry
+    local -a state line state_descr # These are set by _arguments
     typeset -A opt_args
+
+    common=(
+        '(-q --quiet)*'{-v,--verbose}'[use verbose output]'
+        '(-q --quiet -v --verbose)'{-q,--quiet}'[no output printed to stdout]'
+        '-Z+[pass unstable (nightly-only) flags to cargo]: :_cargo_unstable_flags'
+        '--frozen[require that Cargo.lock and cache are up-to-date]'
+        '--locked[require that Cargo.lock is up-to-date]'
+        '--color=[specify colorization option]:coloring:(auto always never)'
+        '(- 1 *)'{-h,--help}'[show help message]'
+    )
 
     # leading items in parentheses are an exclusion list for the arguments following that arg
     # See: http://zsh.sourceforge.net/Doc/Release/Completion-System.html#Completion-Functions
@@ -12,417 +24,319 @@ _cargo() {
     #   1 => exclude positional arg 1
     #   * => exclude all other args
     #   +blah => exclude +blah
-    _arguments \
-        '(- 1 *)'{-h,--help}'[show help message]' \
+    _arguments -s -S -C $common \
         '(- 1 *)--list[list installed commands]' \
+        '(- 1 *)--explain=[provide a detailed explanation of an error message]:error code' \
         '(- 1 *)'{-V,--version}'[show version information]' \
-        {-v,--verbose}'[use verbose output]' \
-        --color'[colorization option]' \
         '(+beta +nightly)+stable[use the stable toolchain]' \
         '(+stable +nightly)+beta[use the beta toolchain]' \
         '(+stable +beta)+nightly[use the nightly toolchain]' \
         '1: :_cargo_cmds' \
         '*:: :->args'
 
+    # These flags are mutually exclusive specifiers for the scope of a command; as
+    # they are used in multiple places without change, they are expanded into the
+    # appropriate command's `_arguments` where appropriate.
+    command_scope_spec=(
+        '(--bin --example --test --lib)--bench=[specify benchmark name]: :_cargo_benchmark_names'
+        '(--bench --bin --test --lib)--example=[specify example name]:example name'
+        '(--bench --example --test --lib)--bin=[specify binary name]:binary name'
+        '(--bench --bin --example --test)--lib=[specify library name]:library name'
+        '(--bench --bin --example --lib)--test=[specify test name]:test name'
+    )
+
+    parallel=(
+        '(-j --jobs)'{-j+,--jobs=}'[specify number of parallel jobs]:jobs [# of CPUs]'
+    )
+
+    features=(
+        '(--all-features)--features=[specify features to activate]:feature'
+        '(--features)--all-features[activate all available features]'
+        "--no-default-features[don't build the default features]"
+    )
+
+    msgfmt='--message-format=[specify error format]:error format [human]:(human json short)'
+    triple='--target=[specify target triple]:target triple'
+    target='--target-dir=[specify directory for all generated artifacts]:directory:_directories'
+    manifest='--manifest-path=[specify path to manifest]:path:_directories'
+    registry='--registry=[specify registry to use]:registry'
+
     case $state in
         args)
+            curcontext="${curcontext%:*}-${words[1]}:"
             case ${words[1]} in
                 bench)
-                    _arguments \
-                        '--features=[space separated feature list]' \
-                        '--all-features[enable all available features]' \
-                        '(-h, --help)'{-h,--help}'[show help message]' \
-                        '(-j, --jobs)'{-j,--jobs}'[number of parallel jobs, defaults to # of CPUs]' \
+                    _arguments -s -A "^--" $common $parallel $features $msgfmt $triple $target $manifest \
                         "${command_scope_spec[@]}" \
-                        '--manifest-path=[path to manifest]: :_files -/' \
-                        '--no-default-features[do not build the default features]' \
-                        '--no-run[compile but do not run]' \
-                        '(-p,--package)'{-p=,--package=}'[package to run benchmarks for]:packages:_get_package_names' \
-                        '--target=[target triple]' \
-                        '(-v, --verbose)'{-v,--verbose}'[use verbose output]' \
-                        '(-q, --quiet)'{-q,--quiet}'[no output printed to stdout]' \
-                        '--color=:colorization option:(auto always never)' \
+                        '--all-targets[benchmark all targets]' \
+                        "--no-run[compile but don't run]" \
+                        '(-p --package)'{-p+,--package=}'[specify package to run benchmarks for]:package:_cargo_package_names' \
+                        '--exclude=[exclude packages from the benchmark]:spec' \
+                        '--no-fail-fast[run all benchmarks regardless of failure]' \
+                        '1: :_guard "^-*" "bench name"' \
+                        '*:args:_default'
                         ;;
 
                 build)
-                    _arguments \
-                        '--features=[space separated feature list]' \
-                        '--all-features[enable all available features]' \
+                    _arguments -s -S $common $parallel $features $msgfmt $triple $target $manifest \
                         '--all-targets[equivalent to specifying --lib --bins --tests --benches --examples]' \
-                        '(-h, --help)'{-h,--help}'[show help message]' \
-                        '(-j, --jobs)'{-j,--jobs}'[number of parallel jobs, defaults to # of CPUs]' \
                         "${command_scope_spec[@]}" \
-                        '--manifest-path=[path to manifest]: :_files -/' \
-                        '--no-default-features[do not build the default features]' \
-                        '(-p,--package)'{-p=,--package=}'[package to build]:packages:_get_package_names' \
-                        '--release=[build in release mode]' \
-                        '--target=[target triple]' \
-                        '(-v, --verbose)'{-v,--verbose}'[use verbose output]' \
-                        '(-q, --quiet)'{-q,--quiet}'[no output printed to stdout]' \
-                        '--color=:colorization option:(auto always never)' \
+                        '(-p --package)'{-p+,--package=}'[specify package to build]:package:_cargo_package_names' \
+                        '--release[build in release mode]' \
+                        '--build-plan[output the build plan in JSON]' \
                         ;;
 
                 check)
-                    _arguments \
-                        '--features=[space separated feature list]' \
-                        '--all-features[enable all available features]' \
+                    _arguments -s -S $common $parallel $features $msgfmt $triple $target $manifest \
                         '--all-targets[equivalent to specifying --lib --bins --tests --benches --examples]' \
-                        '(-h, --help)'{-h,--help}'[show help message]' \
-                        '(-j, --jobs)'{-j,--jobs}'[number of parallel jobs, defaults to # of CPUs]' \
                         "${command_scope_spec[@]}" \
-                        '--manifest-path=[path to manifest]: :_files -/' \
-                        '--no-default-features[do not check the default features]' \
-                        '(-p,--package)'{-p=,--package=}'[package to check]:packages:_get_package_names' \
-                        '--release=[check in release mode]' \
-                        '--target=[target triple]' \
-                        '(-v, --verbose)'{-v,--verbose}'[use verbose output]' \
-                        '(-q, --quiet)'{-q,--quiet}'[no output printed to stdout]' \
-                        '--color=:colorization option:(auto always never)' \
+                        '(-p --package)'{-p+,--package=}'[specify package to check]:package:_cargo_package_names' \
+                        '--release[check in release mode]' \
                         ;;
 
                 clean)
-                    _arguments \
-                        '(-h, --help)'{-h,--help}'[show help message]' \
-                        '--manifest-path=[path to manifest]: :_files -/' \
-                        '(-p,--package)'{-p=,--package=}'[package to clean]:packages:_get_package_names' \
-                        '(-q, --quiet)'{-q,--quiet}'[no output printed to stdout]' \
-                        '--release[whether or not to clean release artifacts]' \
-                        '--target=[target triple(default:all)]' \
-                        '(-v, --verbose)'{-v,--verbose}'[use verbose output]' \
-                        '--color=:colorization option:(auto always never)' \
+                    _arguments -s -S $common $triple $target $manifest \
+                        '(-p --package)'{-p+,--package=}'[specify package to clean]:package:_cargo_package_names' \
+                        '--release[clean release artifacts]' \
+                        '--doc[clean just the documentation directory]'
                         ;;
 
                 doc)
-                    _arguments \
-                        '--features=[space separated feature list]' \
-                        '--all-features[enable all available features]' \
-                        '(-h, --help)'{-h,--help}'[show help message]' \
-                        '(-j, --jobs)'{-j,--jobs}'[number of parallel jobs, defaults to # of CPUs]' \
-                        '--manifest-path=[path to manifest]: :_files -/' \
+                    _arguments -s -S $common $parallel $features $msgfmt $triple $target $manifest \
                         '--no-deps[do not build docs for dependencies]' \
-                        '--no-default-features[do not build the default features]' \
                         '--document-private-items[include non-public items in the documentation]' \
                         '--open[open docs in browser after the build]' \
-                        '(-p, --package)'{-p,--package}'=[package to document]' \
-                        '(-q, --quiet)'{-q,--quiet}'[no output printed to stdout]' \
+                        '(-p --package)'{-p+,--package=}'[specify package to document]:package:_cargo_package_names' \
                         '--release[build artifacts in release mode, with optimizations]' \
-                        '--target=[build for the target triple]' \
-                        '(-v, --verbose)'{-v,--verbose}'[use verbose output]' \
-                        '--color=:colorization option:(auto always never)' \
                         ;;
 
                 fetch)
-                    _arguments \
-                        '(-h, --help)'{-h,--help}'[show help message]' \
-                        '--manifest-path=[path to manifest]: :_files -/' \
-                        '(-q, --quiet)'{-q,--quiet}'[no output printed to stdout]' \
-                        '(-v, --verbose)'{-v,--verbose}'[use verbose output]' \
-                        '--color=:colorization option:(auto always never)' \
+                    _arguments -s -S $common $triple $manifest
                         ;;
 
+                fix)
+                    _arguments -s -S $common $parallel $features $msgfmt $triple $target $manifest \
+                        "${command_scope_spec[@]}" \
+                        '--broken-code[fix code even if it already has compiler errors]' \
+                        '--edition[fix in preparation for the next edition]' \
+                        '--edition-idioms[fix warnings to migrate to the idioms of an edition]' \
+                        '--allow-no-vcs[fix code even if a VCS was not detected]' \
+                        '--allow-dirty[fix code even if the working directory is dirty]' \
+                        '--allow-staged[fix code even if the working directory has staged changes]'
+                ;;
+
                 generate-lockfile)
-                    _arguments \
-                        '(-h, --help)'{-h,--help}'[show help message]' \
-                        '--manifest-path=[path to manifest]: :_files -/' \
-                        '(-q, --quiet)'{-q,--quiet}'[no output printed to stdout]' \
-                        '(-v, --verbose)'{-v,--verbose}'[use verbose output]' \
-                        '--color=:colorization option:(auto always never)' \
+                    _arguments -s -S $common $manifest
                         ;;
 
                 git-checkout)
-                    _arguments \
-                        '(-h, --help)'{-h,--help}'[show help message]' \
-                        '(-q, --quiet)'{-q,--quiet}'[no output printed to stdout]' \
-                        '--reference=[REF]' \
-                        '--url=[URL]' \
-                        '(-v, --verbose)'{-v,--verbose}'[use verbose output]' \
-                        '--color=:colorization option:(auto always never)' \
+                    _arguments -s -S $common \
+                        '--reference=:reference' \
+                        '--url=:url:_urls'
                         ;;
 
                 help)
-                    _arguments \
-                        '(-h, --help)'{-h,--help}'[show help message]' \
-                        '*: :_cargo_cmds' \
+                    _cargo_cmds
                         ;;
 
                 init)
-                    _arguments \
+                    _arguments -s -S $common $registry \
                         '--lib[use library template]' \
-                        '--vcs:initialize a new repo with a given VCS:(git hg none)' \
-                        '(-h, --help)'{-h,--help}'[show help message]' \
-                        '--name=[set the resulting package name]' \
-                        '(-q, --quiet)'{-q,--quiet}'[no output printed to stdout]' \
-                        '(-v, --verbose)'{-v,--verbose}'[use verbose output]' \
-                        '--color=:colorization option:(auto always never)' \
+                        '--edition=[specify edition to set for the crate generated]:edition:(2015 2018)' \
+                        '--vcs=[initialize a new repo with a given VCS]:vcs:(git hg pijul fossil none)' \
+                        '--name=[set the resulting package name]:name' \
+                        '1:path:_directories'
                         ;;
 
                 install)
-                    _arguments \
-                        '--bin=[only install the specified binary]' \
-                        '--branch=[branch to use when installing from git]' \
-                        '--color=:colorization option:(auto always never)' \
+                    _arguments -s -S $common $parallel $features $triple $registry \
+                        '(-f --force)'{-f,--force}'[force overwriting of existing crates or binaries]' \
+                        '--bin=[only install the specified binary]:binary' \
+                        '--branch=[branch to use when installing from git]:branch' \
                         '--debug[build in debug mode instead of release mode]' \
-                        '--example[install the specified example instead of binaries]' \
-                        '--features=[space separated feature list]' \
-                        '--all-features[enable all available features]' \
-                        '--git=[URL from which to install the crate]' \
-                        '(-h, --help)'{-h,--help}'[show help message]' \
-                        '(-j, --jobs)'{-j,--jobs}'[number of parallel jobs, defaults to # of CPUs]' \
-                        '--no-default-features[do not build the default features]' \
-                        '--path=[local filesystem path to crate to install]: :_files -/' \
-                        '(-q, --quiet)'{-q,--quiet}'[no output printed to stdout]' \
-                        '--rev=[specific commit to use when installing from git]' \
-                        '--root=[directory to install packages into]: :_files -/' \
-                        '--tag=[tag to use when installing from git]' \
-                        '(-v, --verbose)'{-v,--verbose}'[use verbose output]' \
-                        '--vers=[version to install from crates.io]' \
+                        '--example=[install the specified example instead of binaries]:example' \
+                        '--git=[specify URL from which to install the crate]:url:_urls' \
+                        '--path=[local filesystem path to crate to install]: :_directories' \
+                        '--rev=[specific commit to use when installing from git]:commit' \
+                        '--root=[directory to install packages into]: :_directories' \
+                        '--tag=[tag to use when installing from git]:tag' \
+                        '--vers=[version to install from crates.io]:version' \
+                        '--list[list all installed packages and their versions]' \
+                        '*: :_guard "^-*" "crate"'
                         ;;
 
                 locate-project)
-                    _arguments \
-                        '(-h, --help)'{-h,--help}'[show help message]' \
-                        '--manifest-path=[path to manifest]: :_files -/' \
+                    _arguments -s -S $common $manifest
                         ;;
 
                 login)
-                    _arguments \
-                        '(-h, --help)'{-h,--help}'[show help message]' \
-                        '--host=[Host to set the token for]' \
-                        '(-q, --quiet)'{-q,--quiet}'[no output printed to stdout]' \
-                        '(-v, --verbose)'{-v,--verbose}'[use verbose output]' \
-                        '--color=:colorization option:(auto always never)' \
+                    _arguments -s -S $common $registry \
+                        '*: :_guard "^-*" "token"'
                         ;;
 
                 metadata)
-                    _arguments \
-                        '(-h, --help)'{-h,--help}'[show help message]' \
-                        '(-q, --quiet)'{-q,--quiet}'[no output printed to stdout]' \
-                        '(-v, --verbose)'{-v,--verbose}'[use verbose output]' \
+                    _arguments -s -S $common $features $manifest \
                         "--no-deps[output information only about the root package and don't fetch dependencies]" \
-                        '--no-default-features[do not include the default feature]' \
-                        '--manifest-path=[path to manifest]: :_files -/' \
-                        '--features=[space separated feature list]' \
-                        '--all-features[enable all available features]' \
-                        '--format-version=[format version(default: 1)]' \
-                        '--color=:colorization option:(auto always never)' \
+                        '--format-version=[specify format version]:version [1]:(1)'
                         ;;
 
                 new)
-                    _arguments \
+                    _arguments -s -S $common $registry \
                         '--lib[use library template]' \
                         '--vcs:initialize a new repo with a given VCS:(git hg none)' \
-                        '(-h, --help)'{-h,--help}'[show help message]' \
-                        '--name=[set the resulting package name]' \
-                        '(-q, --quiet)'{-q,--quiet}'[no output printed to stdout]' \
-                        '(-v, --verbose)'{-v,--verbose}'[use verbose output]' \
-                        '--color=:colorization option:(auto always never)' \
+                        '--name=[set the resulting package name]'
                         ;;
 
                 owner)
-                    _arguments \
-                        '(-a, --add)'{-a,--add}'[add owner LOGIN]' \
-                        '(-h, --help)'{-h,--help}'[show help message]' \
-                        '--index[registry index]' \
-                        '(-l, --list)'{-l,--list}'[list owners of a crate]' \
-                        '(-q, --quiet)'{-q,--quiet}'[no output printed to stdout]' \
-                        '(-r, --remove)'{-r,--remove}'[remove owner LOGIN]' \
-                        '--token[API token to use when authenticating]' \
-                        '(-v, --verbose)'{-v,--verbose}'[use verbose output]' \
-                        '--color=:colorization option:(auto always never)' \
+                    _arguments -s -S $common $registry \
+                        '(-a --add)'{-a,--add}'[specify name of a user or team to invite as an owner]:name' \
+                        '--index=[specify registry index]:index' \
+                        '(-l --list)'{-l,--list}'[list owners of a crate]' \
+                        '(-r --remove)'{-r,--remove}'[specify name of a user or team to remove as an owner]:name' \
+                        '--token=[specify API token to use when authenticating]:token' \
+                        '*: :_guard "^-*" "crate"'
                         ;;
 
                 package)
-                    _arguments \
-                        '(-h, --help)'{-h,--help}'[show help message]' \
-                        '(-l, --list)'{-l,--list}'[print files included in a package without making one]' \
-                        '--manifest-path=[path to manifest]: :_files -/' \
+                    _arguments -s -S $common $parallel $features $triple $target $manifest \
+                        '(-l --list)'{-l,--list}'[print files included in a package without making one]' \
                         '--no-metadata[ignore warnings about a lack of human-usable metadata]' \
-                        '--no-verify[do not build to verify contents]' \
-                        '(-q, --quiet)'{-q,--quiet}'[no output printed to stdout]' \
-                        '(-v, --verbose)'{-v,--verbose}'[use verbose output]' \
-                        '--color=:colorization option:(auto always never)' \
+                        '--allow-dirty[allow dirty working directories to be packaged]' \
+                        "--no-verify[don't build to verify contents]"
                         ;;
 
                 pkgid)
-                    _arguments \
-                        '(-h, --help)'{-h,--help}'[show help message]' \
-                        '--manifest-path=[path to manifest]: :_files -/' \
-                        '(-q, --quiet)'{-q,--quiet}'[no output printed to stdout]' \
-                        '(-v, --verbose)'{-v,--verbose}'[use verbose output]' \
-                        '--color=:colorization option:(auto always never)' \
+                    _arguments -s -S $common $manifest \
+                        '(-p --package)'{-p+,--package=}'[specify package to get ID specifier for]:package:_cargo_package_names' \
+                        '*: :_guard "^-*" "spec"'
                         ;;
 
                 publish)
-                    _arguments \
-                        '(-h, --help)'{-h,--help}'[show help message]' \
-                        '--host=[Host to set the token for]' \
-                        '--manifest-path=[path to manifest]: :_files -/' \
-                        '--no-verify[Do not verify tarball until before publish]' \
-                        '(-q, --quiet)'{-q,--quiet}'[no output printed to stdout]' \
-                        '--token[token to use when uploading]' \
-                        '(-v, --verbose)'{-v,--verbose}'[use verbose output]' \
-                        '--color=:colorization option:(auto always never)' \
+                    _arguments -s -S $common $parallel $features $triple $target $manifest $registry \
+                        '--index=[specify registry index]:index' \
+                        '--allow-dirty[allow dirty working directories to be packaged]' \
+                        "--no-verify[don't verify the contents by building them]" \
+                        '--token=[specify token to use when uploading]:token' \
+                        '--dry-run[perform all checks without uploading]'
                         ;;
 
                 read-manifest)
-                    _arguments \
-                        '(-h, --help)'{-h,--help}'[show help message]' \
-                        '--manifest-path=[path to manifest]: :_files -/' \
-                        '(-v, --verbose)'{-v,--verbose}'[use verbose output]' \
-                        '--color=:colorization option:(auto always never)' \
+                    _arguments -s -S $common $manifest
                         ;;
 
                 run)
-                    _arguments \
-                        '--example=[name of the bin target]' \
-                        '--features=[space separated feature list]' \
-                        '--all-features[enable all available features]' \
-                        '(-h, --help)'{-h,--help}'[show help message]' \
-                        '(-j, --jobs)'{-j,--jobs}'[number of parallel jobs, defaults to # of CPUs]' \
-                        '--manifest-path=[path to manifest]: :_files -/' \
-                        '--bin=[name of the bin target]' \
-                        '--no-default-features[do not build the default features]' \
-                        '(-q, --quiet)'{-q,--quiet}'[no output printed to stdout]' \
-                        '--release=[build in release mode]' \
-                        '--target=[target triple]' \
-                        '(-v, --verbose)'{-v,--verbose}'[use verbose output]' \
-                        '--color=:colorization option:(auto always never)' \
-                        '*: :_normal' \
+                    _arguments -s -S $common $parallel $features $msgfmt $triple $target $manifest \
+                        '--example=[name of the bin target]:name' \
+                        '--bin=[name of the bin target]:name' \
+                        '(-p --package)'{-p+,--package=}'[specify package with the target to run]:package:_cargo_package_names' \
+                        '--release[build in release mode]' \
+                        '*: :_default'
                         ;;
 
                 rustc)
-                    _arguments \
-                        '--color=:colorization option:(auto always never)' \
-                        '--features=[features to compile for the package]' \
-                        '--all-features[enable all available features]' \
-                        '(-h, --help)'{-h,--help}'[show help message]' \
-                        '(-j, --jobs)'{-j,--jobs}'=[number of parallel jobs, defaults to # of CPUs]' \
-                        '--manifest-path=[path to the manifest to fetch dependencies for]: :_files -/' \
-                        '--no-default-features[do not compile default features for the package]' \
-                        '(-p, --package)'{-p,--package}'=[profile to compile for]' \
-                        '--profile=[profile to build the selected target for]' \
-                        '(-q, --quiet)'{-q,--quiet}'[no output printed to stdout]' \
+                    _arguments -s -S $common $parallel $features $msgfmt $triple $target $manifest \
+                        '(-p --package)'{-p+,--package=}'[specify package to build]:package:_cargo_package_names' \
+                        '--profile=[specify profile to build the selected target for]:profile' \
                         '--release[build artifacts in release mode, with optimizations]' \
-                        '--target=[target triple which compiles will be for]' \
-                        '(-v, --verbose)'{-v,--verbose}'[use verbose output]' \
                         "${command_scope_spec[@]}" \
+                        '*: : _dispatch rustc rustc -default-'
                         ;;
 
                 rustdoc)
-                    _arguments \
-                        '--color=:colorization option:(auto always never)' \
-                        '--features=[space-separated list of features to also build]' \
-                        '--all-features[enable all available features]' \
-                        '(-h, --help)'{-h,--help}'[show help message]' \
-                        '(-j, --jobs)'{-j,--jobs}'=[number of parallel jobs, defaults to # of CPUs]' \
-                        '--manifest-path=[path to the manifest to document]: :_files -/' \
-                        '--no-default-features[do not build the `default` feature]' \
+                    _arguments -s -S $common $parallel $features $msgfmt $triple $target $manifest \
                         '--document-private-items[include non-public items in the documentation]' \
                         '--open[open the docs in a browser after the operation]' \
-                        '(-p, --package)'{-p,--package}'=[package to document]' \
-                        '(-q, --quiet)'{-q,--quiet}'[no output printed to stdout]' \
+                        '(-p --package)'{-p+,--package=}'[specify package to document]:package:_cargo_package_names' \
                         '--release[build artifacts in release mode, with optimizations]' \
-                        '--target=[build for the target triple]' \
-                        '(-v, --verbose)'{-v,--verbose}'[use verbose output]' \
                         "${command_scope_spec[@]}" \
+                        '*: : _dispatch rustdoc rustdoc -default-'
                         ;;
 
                 search)
-                    _arguments \
-                        '--color=:colorization option:(auto always never)' \
-                        '(-h, --help)'{-h,--help}'[show help message]' \
-                        '--host=[host of a registry to search in]' \
-                        '--limit=[limit the number of results]' \
-                        '(-q, --quiet)'{-q,--quiet}'[no output printed to stdout]' \
-                        '(-v, --verbose)'{-v,--verbose}'[use verbose output]' \
+                    _arguments -s -S $common $registry \
+                        '--index=[specify registry index]:index' \
+                        '--limit=[limit the number of results]:results [10]' \
+                        '*: :_guard "^-*" "query"'
                         ;;
 
                 test)
-                    _arguments \
-                        '--features=[space separated feature list]' \
-                        '--all-features[enable all available features]' \
-                        '(-h, --help)'{-h,--help}'[show help message]' \
-                        '(-j, --jobs)'{-j,--jobs}'[number of parallel jobs, defaults to # of CPUs]' \
-                        '--manifest-path=[path to manifest]: :_files -/' \
-                        '--test=[test name]: :_test_names' \
-                        '--no-default-features[do not build the default features]' \
+                    _arguments -s -S $common $parallel $features $msgfmt $triple $target $manifest \
+                        '--test=[test name]: :_cargo_test_names' \
                         '--no-fail-fast[run all tests regardless of failure]' \
                         '--no-run[compile but do not run]' \
-                        '(-p,--package)'{-p=,--package=}'[package to run tests for]:packages:_get_package_names' \
-                        '(-q, --quiet)'{-q,--quiet}'[no output printed to stdout]' \
+                        '(-p --package)'{-p+,--package=}'[package to run tests for]:package:_cargo_package_names' \
+                        '--all[test all packages in the workspace]' \
                         '--release[build artifacts in release mode, with optimizations]' \
-                        '--target=[target triple]' \
-                        '(-v, --verbose)'{-v,--verbose}'[use verbose output]' \
-                        '--color=:colorization option:(auto always never)' \
-                        '1: :_test_names' \
+                        '1: :_cargo_test_names' \
                         '(--doc --bin --example --test --bench)--lib[only test library]' \
                         '(--lib --bin --example --test --bench)--doc[only test documentation]' \
                         '(--lib --doc --example --test --bench)--bin=[binary name]' \
                         '(--lib --doc --bin --test --bench)--example=[example name]' \
                         '(--lib --doc --bin --example --bench)--test=[test name]' \
                         '(--lib --doc --bin --example --test)--bench=[benchmark name]' \
-                        '--message-format:error format:(human json short)' \
-                        '--frozen[require lock and cache up to date]' \
-                        '--locked[require lock up to date]'
+                        '*: :_default'
                         ;;
 
                 uninstall)
-                    _arguments \
-                        '--bin=[only uninstall the binary NAME]' \
-                        '--color=:colorization option:(auto always never)' \
-                        '(-h, --help)'{-h,--help}'[show help message]' \
-                        '(-q, --quiet)'{-q,--quiet}'[less output printed to stdout]' \
+                    _arguments -s -S $common \
+                        '(-p --package)'{-p+,--package=}'[specify package to uninstall]:package:_cargo_package_names' \
+                        '--bin=[only uninstall the specified binary]:name' \
                         '--root=[directory to uninstall packages from]: :_files -/' \
-                        '(-v, --verbose)'{-v,--verbose}'[use verbose output]' \
+                        '*:crate:_cargo_installed_crates -F line'
                         ;;
 
                 update)
-                    _arguments \
+                    _arguments -s -S $common $manifest \
                         '--aggressive=[force dependency update]' \
-                        '(-h, --help)'{-h,--help}'[show help message]' \
-                        '--manifest-path=[path to manifest]: :_files -/' \
-                        '(-p,--package)'{-p=,--package=}'[package to update]:packages:_get_package_names' \
-                        '--precise=[update single dependency to PRECISE]: :' \
-                        '(-q, --quiet)'{-q,--quiet}'[no output printed to stdout]' \
-                        '(-v, --verbose)'{-v,--verbose}'[use verbose output]' \
-                        '--color=:colorization option:(auto always never)' \
+                        "--dry-run[don't actually write the lockfile]" \
+                        '(-p --package)'{-p+,--package=}'[specify package to update]:package:_cargo_package_names' \
+                        '--precise=[update single dependency to precise release]:release'
                         ;;
 
                 verify-project)
-                    _arguments \
-                        '(-h, --help)'{-h,--help}'[show help message]' \
-                        '--manifest-path=[path to manifest]: :_files -/' \
-                        '(-q, --quiet)'{-q,--quiet}'[no output printed to stdout]' \
-                        '(-v, --verbose)'{-v,--verbose}'[use verbose output]' \
-                        '--color=:colorization option:(auto always never)' \
+                    _arguments -s -S $common $manifest
                         ;;
 
                 version)
-                    _arguments \
-                        '(-h, --help)'{-h,--help}'[show help message]' \
-                        '(-v, --verbose)'{-v,--verbose}'[use verbose output]' \
-                        '--color=:colorization option:(auto always never)' \
+                    _arguments -s -S $common
                         ;;
 
                 yank)
-                    _arguments \
-                        '(-h, --help)'{-h,--help}'[show help message]' \
-                        '--index[registry index]' \
-                        '(-q, --quiet)'{-q,--quiet}'[no output printed to stdout]' \
-                        '--token[API token to use when authenticating]' \
+                    _arguments -s -S $common $registry \
+                        '--vers=[specify yank version]:version' \
                         '--undo[undo a yank, putting a version back into the index]' \
-                        '(-v, --verbose)'{-v,--verbose}'[use verbose output]' \
-                        '--color=:colorization option:(auto always never)' \
-                        '--vers[yank version]' \
+                        '--index=[specify registry index to yank from]:registry index' \
+                        '--token=[specify API token to use when authenticating]:token' \
+                        '*: :_guard "^-*" "crate"'
                         ;;
+                *)
+                    # allow plugins to define their own functions
+                    if ! _call_function ret _cargo-${words[1]}; then
+                        # fallback on default completion for unknown commands
+                        _default && ret=0
+                    fi
+                    (( ! ret ))
+                ;;
             esac
             ;;
     esac
 }
 
+_cargo_unstable_flags() {
+    local flags
+    flags=( help ${${${(M)${(f)"$(_call_program flags cargo -Z help)"}:#*--*}/ #-- #/:}##*-Z } )
+    _describe -t flags 'unstable flag' flags
+}
+
+_cargo_installed_crates() {
+    local expl
+    _description crates expl 'crate'
+    compadd "$@" "$expl[@]" - ${${${(f)"$(cargo install --list)"}:# *}%% *}
+}
+
 _cargo_cmds() {
     local -a commands
-    # This uses Parameter Expansion Flags, which is an Zsh built-in features.
+    # This uses Parameter Expansion Flags, which are a built-in Zsh feature.
     # See more: http://zsh.sourceforge.net/Doc/Release/Expansion.html#Parameter-Expansion-Flags
     # and       http://zsh.sourceforge.net/Doc/Release/Expansion.html#Parameter-Expansion
     #
@@ -433,29 +347,22 @@ _cargo_cmds() {
     # Then it replaces those spaces between item and description with a `:`
     #
     # [1]: https://github.com/zsh-users/zsh-completions/blob/master/zsh-completions-howto.org#patterns
-    commands=( ${${${(M)"${(f)$(cargo --list)}":#    *}/ ##/}/ ##/:} )
-    _describe 'command' commands
+    commands=( ${${${(M)"${(f)$(_call_program commands cargo --list)}":#    *}/ ##/}/ ##/:} )
+    _describe -t commands 'command' commands
 }
 
 
 #FIXME: Disabled until fixed
 #gets package names from the manifest file
-_get_package_names() {
-    :
-}
-
-#TODO:see if it makes sense to have 'locate-project' to have non-json output.
-#strips package name from json stuff
-_locate_manifest() {
-    local manifest=$(cargo locate-project 2>/dev/null)
-    regexp-replace manifest '\{"root":"|"\}' ''
-    echo "$manifest"
+_cargo_package_names() {
+    _message -e packages package
 }
 
 # Extracts the values of "name" from the array given in $1 and shows them as
 # command line options for completion
-_get_names_from_array() {
-    local manifest=$(_locate_manifest)
+_cargo_names_from_array() {
+    # strip json from the path
+    local manifest=${${${"$(cargo locate-project)"}%\"\}}##*\"}
     if [[ -z $manifest ]]; then
         return 0
     fi
@@ -488,25 +395,13 @@ _get_names_from_array() {
 }
 
 #Gets the test names from the manifest file
-_test_names() {
-    _get_names_from_array "test"
+_cargo_test_names() {
+    _cargo_names_from_array "test"
 }
 
 #Gets the bench names from the manifest file
-_benchmark_names() {
-    _get_names_from_array "bench"
+_cargo_benchmark_names() {
+    _cargo_names_from_array "bench"
 }
-
-# These flags are mutually exclusive specifiers for the scope of a command; as
-# they are used in multiple places without change, they are expanded into the
-# appropriate command's `_arguments` where appropriate.
-set command_scope_spec
-command_scope_spec=(
-    '(--bin --example --test --lib)--bench=[benchmark name]: :_benchmark_names'
-    '(--bench --bin --test --lib)--example=[example name]'
-    '(--bench --example --test --lib)--bin=[binary name]'
-    '(--bench --bin --example --test)--lib=[library name]'
-    '(--bench --bin --example --lib)--test=[test name]'
-)
 
 _cargo


### PR DESCRIPTION
I went through the zsh completion to clean it up, adapt it to zsh conventions, and to bring it up-to-date for new cargo options. For context, I'm one of the zsh developers and do know what I'm doing with zsh completion functions. As for cargo, I do use it but was referring to documentation here.

I added new functions for completion of installed crates and unstable flags.
Many subcommands had out-of-date option lists which I've updated, This isn't yet comprehensive, however.

Factored out the definition of some common options into variables - this explains the greater number of lines deleted than added.

Corrected the syntax of option exclusion lists which erroneously contained commas. It was also common for option arguments to be missing and = to not be allowed before them.

--verbose can be repeated so now has * instead of the self-exclusion. It and --quiet appear to be mutually exclusive, however.

I've given internal functions an _cargo prefix as per zsh conventions. This avoids name clashes. I also removed _get from the names - zsh convention is a plural noun for what is completed.

Completion of normal arguments to many subcommands was missing. In many cases, this is now just a description - e.g. "crate". _guard is needed in some cases so as not to break option completion. For rustc and rustdoc, it'll dispatch to their respective completions if they ever gain one, otherwise using default completion.

It now passes -s to _arguments to allow clumping of short options, -S for correct
handling of -- and -C for correct context handling. _arguments also changes some variables which should be declared local and I've restored these - ShellCheck had persuaded someone to remove them.

For unknown cargo subcommands, it will now try a _cargo-<subcommand>
function if found and fallback to _default allowing cargo plugins to
define their own completion. This is common zsh practice, see e.g. _git. And fallbacks to default completion are always a good idea - users don't tend to like filename completion being broken.

$curcontext is now updated to include the sub-command which provides more flexibility to users configuring zsh completion with zstyle.