### PR TITLE
RFC First cut support for sandboxing procmacros with wasm

### DIFF
--- a/src/cargo/core/compiler/context/compilation_files.rs
+++ b/src/cargo/core/compiler/context/compilation_files.rs
@@ -53,6 +53,8 @@ impl fmt::Display for Metadata {
 pub struct CompilationFiles<'a, 'cfg> {
     /// The target directory layout for the host (and target if it is the same as host).
     pub(super) host: Layout,
+    /// The target directory layout for the host sandbox architecture
+    pub(super) host_sandbox: Layout,
     /// The target directory layout for the target (if different from then host).
     pub(super) target: Option<Layout>,
     /// Additional directory to include a copy of the outputs.
@@ -93,6 +95,7 @@ impl<'a, 'cfg: 'a> CompilationFiles<'a, 'cfg> {
     pub(super) fn new(
         roots: &[Unit<'a>],
         host: Layout,
+        host_sandbox: Layout,
         target: Option<Layout>,
         export_dir: Option<PathBuf>,
         ws: &'a Workspace<'cfg>,
@@ -110,6 +113,7 @@ impl<'a, 'cfg: 'a> CompilationFiles<'a, 'cfg> {
         CompilationFiles {
             ws,
             host,
+            host_sandbox,
             target,
             export_dir,
             roots: roots.to_vec(),
@@ -122,6 +126,7 @@ impl<'a, 'cfg: 'a> CompilationFiles<'a, 'cfg> {
     pub fn layout(&self, kind: Kind) -> &Layout {
         match kind {
             Kind::Host => &self.host,
+            Kind::HostSandbox => &self.host_sandbox,
             Kind::Target => self.target.as_ref().unwrap_or(&self.host),
         }
     }
@@ -345,10 +350,10 @@ impl<'a, 'cfg: 'a> CompilationFiles<'a, 'cfg> {
 
         let out_dir = self.out_dir(unit);
         let link_stem = self.link_stem(unit);
-        let info = if unit.kind == Kind::Host {
-            &bcx.host_info
-        } else {
-            &bcx.target_info
+        let info = match unit.kind {
+            Kind::Host => &bcx.host_info,
+            Kind::HostSandbox => &bcx.host_sandbox_info,
+            Kind::Target => &bcx.target_info,
         };
         let file_stem = self.file_stem(unit);
 

--- a/src/cargo/core/compiler/context/mod.rs
+++ b/src/cargo/core/compiler/context/mod.rs
@@ -298,6 +298,7 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
             "debug"
         };
         let host_layout = Layout::new(self.bcx.ws, None, dest)?;
+        let host_sandbox_layout = Layout::new(self.bcx.ws, Some(super::build_context::HOST_SANDBOX_TARGET), dest)?;
         let target_layout = match self.bcx.build_config.requested_target.as_ref() {
             Some(target) => Some(Layout::new(self.bcx.ws, Some(target), dest)?),
             None => None,
@@ -309,6 +310,7 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
         let files = CompilationFiles::new(
             units,
             host_layout,
+            host_sandbox_layout,
             target_layout,
             export_dir,
             self.bcx.ws,
@@ -325,6 +327,10 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
 
         self.files_mut()
             .host
+            .prepare()
+            .chain_err(|| internal("couldn't prepare build directories"))?;
+        self.files_mut()
+            .host_sandbox
             .prepare()
             .chain_err(|| internal("couldn't prepare build directories"))?;
         if let Some(ref mut target) = self.files.as_mut().unwrap().target {

--- a/src/cargo/core/compiler/context/unit_dependencies.rs
+++ b/src/cargo/core/compiler/context/unit_dependencies.rs
@@ -187,7 +187,7 @@ fn compute_deps<'a, 'cfg, 'tmp>(
         {
             let unit = new_unit(bcx, pkg, lib, dep_unit_for, Kind::Target, mode);
             ret.push((unit, dep_unit_for));
-            let unit = new_unit(bcx, pkg, lib, dep_unit_for, Kind::Host, mode);
+            let unit = new_unit(bcx, pkg, lib, dep_unit_for, unit.kind.for_target(lib), mode);
             ret.push((unit, dep_unit_for));
         } else {
             let unit = new_unit(bcx, pkg, lib, dep_unit_for, unit.kind.for_target(lib), mode);
@@ -199,6 +199,7 @@ fn compute_deps<'a, 'cfg, 'tmp>(
     // all we need. If this isn't a build script, then it depends on the
     // build script if there is one.
     if unit.target.is_custom_build() {
+        assert_eq!(unit.kind, Kind::Host, "unit.target {:?}", unit.target);
         return Ok(ret);
     }
     ret.extend(dep_build_script(unit, bcx));

--- a/src/cargo/core/compiler/custom_build.rs
+++ b/src/cargo/core/compiler/custom_build.rs
@@ -163,6 +163,7 @@ fn build_work<'a, 'cfg>(cx: &mut Context<'a, 'cfg>, unit: &Unit<'a>) -> CargoRes
             "TARGET",
             &match unit.kind {
                 Kind::Host => bcx.host_triple(),
+                Kind::HostSandbox => bcx.host_sandbox_triple(),
                 Kind::Target => bcx.target_triple(),
             },
         )

--- a/src/cargo/core/compiler/unit.rs
+++ b/src/cargo/core/compiler/unit.rs
@@ -140,6 +140,9 @@ impl<'a> UnitInterner<'a> {
         kind: Kind,
         mode: CompileMode,
     ) -> Unit<'a> {
+        // building custom_build implies Host
+        assert!(!(target.is_custom_build() && mode == CompileMode::Build) || kind == Kind::Host,
+            "target {:?} kind {:?} mode {:?}", target, kind, mode);
         let inner = self.intern_inner(&UnitInner {
             pkg,
             target,

--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -241,6 +241,7 @@ pub struct Target {
     harness: bool, // whether to use the test harness (--test)
     for_host: bool,
     proc_macro: bool,
+    wasm_sandbox: bool,
     edition: Edition,
 }
 
@@ -296,6 +297,7 @@ struct SerializedTarget<'a> {
     /// Corresponds to `--crate-type` compiler attribute.
     /// See https://doc.rust-lang.org/reference/linkage.html
     crate_types: Vec<&'a str>,
+    wasm_sandbox: bool,
     name: &'a str,
     src_path: Option<&'a PathBuf>,
     edition: &'a str,
@@ -315,6 +317,7 @@ impl ser::Serialize for Target {
         SerializedTarget {
             kind: &self.kind,
             crate_types: self.rustc_crate_types(),
+            wasm_sandbox: self.wasm_sandbox,
             name: &self.name,
             src_path,
             edition: &self.edition.to_string(),
@@ -384,6 +387,7 @@ compact_debug! {
                 harness
                 for_host
                 proc_macro
+                wasm_sandbox
                 edition
             )]
         }
@@ -614,6 +618,7 @@ impl Target {
             harness: true,
             for_host: false,
             proc_macro: false,
+            wasm_sandbox: false,
             edition,
             tested: true,
             benched: true,
@@ -768,6 +773,9 @@ impl Target {
     pub fn proc_macro(&self) -> bool {
         self.proc_macro
     }
+    pub fn wasm_sandbox(&self) -> bool {
+        self.wasm_sandbox
+    }
     pub fn edition(&self) -> Edition {
         self.edition
     }
@@ -906,6 +914,10 @@ impl Target {
     }
     pub fn set_proc_macro(&mut self, proc_macro: bool) -> &mut Target {
         self.proc_macro = proc_macro;
+        self
+    }
+    pub fn set_wasm_sandbox(&mut self, wasm_sandbox: bool) -> &mut Target {
+        self.wasm_sandbox = wasm_sandbox;
         self
     }
     pub fn set_edition(&mut self, edition: Edition) -> &mut Target {

--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -875,7 +875,17 @@ impl Target {
     pub fn rustc_crate_types(&self) -> Vec<&str> {
         match self.kind {
             TargetKind::Lib(ref kinds) | TargetKind::ExampleLib(ref kinds) => {
-                kinds.iter().map(LibKind::crate_type).collect()
+                kinds
+                    .iter()
+                    .map(|kind| {
+                        // wasm32-unknown-unknown doesn't support proc-macro, so just use cdylib
+                        if self.wasm_sandbox() && kind == &LibKind::ProcMacro {
+                            "cdylib"
+                        } else {
+                            kind.crate_type()
+                        }
+                    })
+                    .collect()
             }
             TargetKind::CustomBuild
             | TargetKind::Bench

--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -640,10 +640,10 @@ fn generate_targets<'a>(
             _ => target_mode,
         };
         // Plugins or proc macros should be built for the host.
-        let kind = if target.for_host() {
-            Kind::Host
-        } else {
-            default_arch_kind
+        let kind = match (target.for_host(), target.wasm_sandbox()) {
+            (true, false) => Kind::Host,
+            (true, true) => Kind::HostSandbox,
+            (false, _) => default_arch_kind,
         };
         let profile = profiles.get_profile(
             pkg.package_id(),

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -1517,6 +1517,8 @@ struct TomlTarget {
     proc_macro: Option<bool>,
     #[serde(rename = "proc_macro")]
     proc_macro2: Option<bool>,
+    #[serde(rename = "wasm-sandbox")]
+    wasm_sandbox: Option<bool>,
     harness: Option<bool>,
     #[serde(rename = "required-features")]
     required_features: Option<Vec<String>>,

--- a/src/cargo/util/toml/targets.rs
+++ b/src/cargo/util/toml/targets.rs
@@ -769,7 +769,8 @@ fn configure(features: &Features, toml: &TomlTarget, target: &mut Target) -> Car
             (None, None) => t2.for_host(),
             (Some(true), _) | (_, Some(true)) => true,
             (Some(false), _) | (_, Some(false)) => false,
-        });
+        })
+        .set_wasm_sandbox(toml.wasm_sandbox.unwrap_or_else(|| t2.wasm_sandbox()));
     if let Some(edition) = toml.edition.clone() {
         features
             .require(Feature::edition())


### PR DESCRIPTION
This is a first cut experiment at building proc-macros with wasm in order to sandbox them.

It adds a new `Kind`: `HostSandbox`, in addition to `Host` and `Target`. This is treated as a host build, but its always `wasm32-unknown-unknown`. 

In Cargo.toml, you can set `wasm_sandbox = true` in addition to `proc-macro = true`, which enables the use of `HostSandbox`.

When the compilation actually happens, it's treated as a cross-build to wasm32-unknown-unknown.

Lightly tested on `serde`, which worked until it couldn't find `proc_macro` from rustc (well, proc-macro2's build.rs assumes it can't exist and so fakes it out).

Assuming this basic approach is sound, I'm thinking that the `wasm_sandbox` flag will become a marker that the procmacro *could* be sandboxed, and then a command-line or cargo config option would request that procmacros be built sandboxed (with further config to forbid non-sandboxed).

TODO:
- the rustc side
- what happens if we're cross-compiling to wasm32? Does it conflict or is it ok?

cc @alexcrichton, @dtolnay 