### PR TITLE
no need for `dyn` if we only use it with `PackageRegistry`

### DIFF
--- a/crates/resolver-tests/tests/resolve.rs
+++ b/crates/resolver-tests/tests/resolve.rs
@@ -1,5 +1,3 @@
-use std::env;
-
 use cargo::core::dependency::Kind;
 use cargo::core::{enable_nightly_features, Dependency};
 use cargo::util::{is_ci, Config};

--- a/src/cargo/core/resolver/context.rs
+++ b/src/cargo/core/resolver/context.rs
@@ -8,6 +8,7 @@ use failure::{bail, ensure};
 use log::debug;
 
 use crate::core::interning::InternedString;
+use crate::core::registry::Registry;
 use crate::core::{Dependency, PackageId, SourceId, Summary};
 use crate::util::CargoResult;
 use crate::util::Graph;
@@ -211,7 +212,7 @@ impl Context {
 
     pub fn resolve_replacements(
         &self,
-        registry: &RegistryQueryer<'_>,
+        registry: &RegistryQueryer<'_, impl Registry>,
     ) -> HashMap<PackageId, PackageId> {
         self.activations
             .values()

--- a/src/cargo/core/resolver/dep_cache.rs
+++ b/src/cargo/core/resolver/dep_cache.rs
@@ -22,8 +22,8 @@ use crate::util::errors::CargoResult;
 use crate::core::resolver::types::{ConflictReason, DepInfo, FeaturesSet};
 use crate::core::resolver::{ActivateResult, ResolveOpts};
 
-pub struct RegistryQueryer<'a> {
-    pub registry: &'a mut (dyn Registry + 'a),
+pub struct RegistryQueryer<'a, R: Registry> {
+    pub registry: &'a mut R,
     replacements: &'a [(PackageIdSpec, Dependency)],
     try_to_use: &'a HashSet<PackageId>,
     /// If set the list of dependency candidates will be sorted by minimal
@@ -41,9 +41,9 @@ pub struct RegistryQueryer<'a> {
     used_replacements: HashMap<PackageId, Summary>,
 }
 
-impl<'a> RegistryQueryer<'a> {
+impl<'a, R: Registry> RegistryQueryer<'a, R> {
     pub fn new(
-        registry: &'a mut dyn Registry,
+        registry: &'a mut R,
         replacements: &'a [(PackageIdSpec, Dependency)],
         try_to_use: &'a HashSet<PackageId>,
         minimal_versions: bool,

--- a/src/cargo/core/resolver/errors.rs
+++ b/src/cargo/core/resolver/errors.rs
@@ -70,7 +70,7 @@ impl From<(PackageId, ConflictReason)> for ActivateError {
 
 pub(super) fn activation_error(
     cx: &Context,
-    registry: &mut dyn Registry,
+    registry: &mut impl Registry,
     parent: &Summary,
     dep: &Dependency,
     conflicting_activations: &ConflictMap,

--- a/src/cargo/core/resolver/mod.rs
+++ b/src/cargo/core/resolver/mod.rs
@@ -122,7 +122,7 @@ mod types;
 pub fn resolve(
     summaries: &[(Summary, ResolveOpts)],
     replacements: &[(PackageIdSpec, Dependency)],
-    registry: &mut dyn Registry,
+    registry: &mut impl Registry,
     try_to_use: &HashSet<PackageId>,
     config: Option<&Config>,
     check_public_visible_dependencies: bool,
@@ -168,7 +168,7 @@ pub fn resolve(
 /// dependency graph, cx.resolve is returned.
 fn activate_deps_loop(
     mut cx: Context,
-    registry: &mut RegistryQueryer<'_>,
+    registry: &mut RegistryQueryer<'_, impl Registry>,
     summaries: &[(Summary, ResolveOpts)],
     config: Option<&Config>,
 ) -> CargoResult<Context> {
@@ -588,7 +588,7 @@ fn activate_deps_loop(
 /// iterate through next.
 fn activate(
     cx: &mut Context,
-    registry: &mut RegistryQueryer<'_>,
+    registry: &mut RegistryQueryer<'_, impl Registry>,
     parent: Option<(&Summary, &Dependency)>,
     candidate: Summary,
     opts: ResolveOpts,
@@ -856,7 +856,7 @@ impl RemainingCandidates {
 /// Panics if the input conflict is not all active in `cx`.
 fn generalize_conflicting(
     cx: &Context,
-    registry: &mut RegistryQueryer<'_>,
+    registry: &mut RegistryQueryer<'_, impl Registry>,
     past_conflicting_activations: &mut conflict_cache::ConflictCache,
     parent: &Summary,
     dep: &Dependency,


### PR DESCRIPTION
Poking around I was reminded that the Resolver has always used a `dyn Registry`. With some digging it is clear that it is only called with a `PackageRegistry`, so switching to an `impl Registry` does not lead to any more monomorphizations. So I tried making the switch to find out why it was needed, looks to me like this worked. 

Any reason to use dynamic dispatch?