### PR TITLE
minimal-copy `deserialize` for `InternedString`

### DIFF
--- a/crates/resolver-tests/src/lib.rs
+++ b/crates/resolver-tests/src/lib.rs
@@ -171,7 +171,7 @@ pub fn resolve_with_config_raw(
         pkg_id("root"),
         deps,
         &BTreeMap::<String, Vec<String>>::new(),
-        None::<String>,
+        None::<&String>,
         false,
     )
     .unwrap();

--- a/crates/resolver-tests/tests/resolve.rs
+++ b/crates/resolver-tests/tests/resolve.rs
@@ -1,5 +1,3 @@
-use std::env;
-
 use cargo::core::dependency::Kind;
 use cargo::core::{enable_nightly_features, Dependency};
 use cargo::util::{is_ci, Config};

--- a/src/cargo/core/package_id.rs
+++ b/src/cargo/core/package_id.rs
@@ -113,9 +113,13 @@ impl Hash for PackageId {
 }
 
 impl PackageId {
-    pub fn new<T: ToSemver>(name: &str, version: T, sid: SourceId) -> CargoResult<PackageId> {
+    pub fn new<T: ToSemver>(
+        name: impl Into<InternedString>,
+        version: T,
+        sid: SourceId,
+    ) -> CargoResult<PackageId> {
         let v = version.to_semver()?;
-        Ok(PackageId::pure(InternedString::new(name), v, sid))
+        Ok(PackageId::pure(name.into(), v, sid))
     }
 
     pub fn pure(name: InternedString, version: semver::Version, source_id: SourceId) -> PackageId {

--- a/src/cargo/core/registry.rs
+++ b/src/cargo/core/registry.rs
@@ -366,7 +366,7 @@ impl<'cfg> PackageRegistry<'cfg> {
     fn query_overrides(&mut self, dep: &Dependency) -> CargoResult<Option<Summary>> {
         for &s in self.overrides.iter() {
             let src = self.sources.get_mut(s).unwrap();
-            let dep = Dependency::new_override(&*dep.package_name(), s);
+            let dep = Dependency::new_override(dep.package_name(), s);
             let mut results = src.query_vec(&dep)?;
             if !results.is_empty() {
                 return Ok(Some(results.remove(0)));

--- a/src/cargo/core/resolver/dep_cache.rs
+++ b/src/cargo/core/resolver/dep_cache.rs
@@ -433,7 +433,7 @@ impl Requirements<'_> {
         for fv in self
             .summary
             .features()
-            .get(feat.as_str())
+            .get(&feat)
             .expect("must be a valid feature")
         {
             match *fv {

--- a/src/cargo/core/summary.rs
+++ b/src/cargo/core/summary.rs
@@ -37,7 +37,7 @@ impl Summary {
         pkg_id: PackageId,
         dependencies: Vec<Dependency>,
         features: &BTreeMap<K, Vec<impl AsRef<str>>>,
-        links: Option<impl AsRef<str>>,
+        links: Option<impl Into<InternedString>>,
         namespaced_features: bool,
     ) -> CargoResult<Summary>
     where
@@ -66,7 +66,7 @@ impl Summary {
                 dependencies,
                 features: feature_map,
                 checksum: None,
-                links: links.map(|l| InternedString::new(l.as_ref())),
+                links: links.map(|l| l.into()),
                 namespaced_features,
             }),
         })

--- a/src/cargo/sources/registry/index.rs
+++ b/src/cargo/sources/registry/index.rs
@@ -716,7 +716,7 @@ impl IndexSummary {
             links,
         } = serde_json::from_slice(line)?;
         log::trace!("json parsed registry {}/{}", name, vers);
-        let pkgid = PackageId::new(&name, &vers, source_id)?;
+        let pkgid = PackageId::new(name, &vers, source_id)?;
         let deps = deps
             .into_iter()
             .map(|dep| dep.into_dep(source_id))

--- a/src/cargo/sources/registry/mod.rs
+++ b/src/cargo/sources/registry/mod.rs
@@ -219,17 +219,18 @@ pub struct RegistryConfig {
 
 #[derive(Deserialize)]
 pub struct RegistryPackage<'a> {
-    name: Cow<'a, str>,
+    name: InternedString,
     vers: Version,
+    #[serde(borrow)]
     deps: Vec<RegistryDependency<'a>>,
-    features: BTreeMap<Cow<'a, str>, Vec<Cow<'a, str>>>,
+    features: BTreeMap<InternedString, Vec<InternedString>>,
     cksum: String,
     yanked: Option<bool>,
-    links: Option<Cow<'a, str>>,
+    links: Option<InternedString>,
 }
 
 #[test]
-fn escaped_cher_in_json() {
+fn escaped_char_in_json() {
     let _: RegistryPackage<'_> = serde_json::from_str(
         r#"{"name":"a","vers":"0.0.1","deps":[],"cksum":"bae3","features":{}}"#,
     )
@@ -275,15 +276,16 @@ enum Field {
 
 #[derive(Deserialize)]
 struct RegistryDependency<'a> {
-    name: Cow<'a, str>,
+    name: InternedString,
+    #[serde(borrow)]
     req: Cow<'a, str>,
-    features: Vec<Cow<'a, str>>,
+    features: Vec<InternedString>,
     optional: bool,
     default_features: bool,
     target: Option<Cow<'a, str>>,
     kind: Option<Cow<'a, str>>,
     registry: Option<Cow<'a, str>>,
-    package: Option<Cow<'a, str>>,
+    package: Option<InternedString>,
     public: Option<bool>,
 }
 
@@ -309,10 +311,9 @@ impl<'a> RegistryDependency<'a> {
             default
         };
 
-        let mut dep =
-            Dependency::parse_no_deprecated(package.as_ref().unwrap_or(&name), Some(&req), id)?;
+        let mut dep = Dependency::parse_no_deprecated(package.unwrap_or(name), Some(&req), id)?;
         if package.is_some() {
-            dep.set_explicit_name_in_toml(&name);
+            dep.set_explicit_name_in_toml(name);
         }
         let kind = match kind.as_ref().map(|s| &s[..]).unwrap_or("") {
             "dev" => Kind::Development,

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -16,7 +16,7 @@ use url::Url;
 use crate::core::dependency::{Kind, Platform};
 use crate::core::manifest::{LibKind, ManifestMetadata, TargetSourcePath, Warnings};
 use crate::core::profiles::Profiles;
-use crate::core::{Dependency, Manifest, PackageId, Summary, Target};
+use crate::core::{Dependency, InternedString, Manifest, PackageId, Summary, Target};
 use crate::core::{Edition, EitherManifest, Feature, Features, VirtualManifest};
 use crate::core::{GitReference, PackageIdSpec, SourceId, WorkspaceConfig, WorkspaceRootConfig};
 use crate::sources::{CRATES_IO_INDEX, CRATES_IO_REGISTRY};
@@ -650,7 +650,7 @@ impl<'de> de::Deserialize<'de> for VecStringOrBool {
 #[derive(Deserialize, Serialize, Clone, Debug)]
 pub struct TomlProject {
     edition: Option<String>,
-    name: String,
+    name: InternedString,
     version: semver::Version,
     authors: Option<Vec<String>>,
     build: Option<StringOrBool>,
@@ -697,7 +697,7 @@ pub struct TomlWorkspace {
 
 impl TomlProject {
     pub fn to_package_id(&self, source_id: SourceId) -> CargoResult<PackageId> {
-        PackageId::new(&self.name, self.version.clone(), source_id)
+        PackageId::new(self.name, self.version.clone(), source_id)
     }
 }
 


### PR DESCRIPTION
I just learnt that `serde::Deserialize` for `Cow<'a, str>` allocates by default! Thus negating the intended benefit of https://github.com/rust-lang/cargo/pull/5694/commits/ea957da75a29583626707463e05767f2c6f32469, and this is in the hot loop for no-op builds #6908. The docs https://serde.rs/lifetimes.html#borrowing-data-in-a-derived-impl say you can fix this with a `#[serde(borrow)]`, but in practice this does not work on  `Option<Cow<'a, str>>`.  Some of these are just going to be turned into `InternedString`s, so we can tell serde to do that directly saving an allocation while we are at it! 

So is this faster, or just reducing the number of `InternedString` <-> `&str` conversions?
I ran the benchmark script developed for https://github.com/rust-lang/cargo/pull/7168#issuecomment-517032074. Looks like no change for Cargo's lockfile and a ~7% improvement for the 2000 crate stress test. 