### PR TITLE
Retry on SSL Connect Error.

### DIFF
--- a/src/cargo/util/network.rs
+++ b/src/cargo/util/network.rs
@@ -51,6 +51,7 @@ fn maybe_spurious(err: &Error) -> bool {
                 || curl_err.is_operation_timedout()
                 || curl_err.is_recv_error()
                 || curl_err.is_http2_stream_error()
+                || curl_err.is_ssl_connect_error()
             {
                 return true;
             }


### PR DESCRIPTION
I have been getting a bunch of spurious `[35] SSL connect error`s on Azure Pipelines, so these should be treated as spurious errors.