### PR TITLE
Fix typo in cargo vendor examples

### DIFF
--- a/src/doc/man/cargo-vendor.adoc
+++ b/src/doc/man/cargo-vendor.adoc
@@ -62,7 +62,7 @@ include::section-exit-status.adoc[]
 
     cargo vendor
 
-. Vendor all dependencies into a local "third-part/vendor" folder
+. Vendor all dependencies into a local "third-party/vendor" folder
 
     cargo vendor third-party/vendor
 


### PR DESCRIPTION
This PR fixes a tiny typo in the `cargo vendor` examples, as you can see in the git diff.