### PR TITLE
`map_dependencies` is doing a deep clone, so lets make it cheaper

### DIFF
--- a/src/cargo/core/summary.rs
+++ b/src/cargo/core/summary.rs
@@ -26,7 +26,7 @@ pub struct Summary {
 struct Inner {
     package_id: PackageId,
     dependencies: Vec<Dependency>,
-    features: FeatureMap,
+    features: Rc<FeatureMap>,
     checksum: Option<String>,
     links: Option<InternedString>,
     namespaced_features: bool,
@@ -64,7 +64,7 @@ impl Summary {
             inner: Rc::new(Inner {
                 package_id: pkg_id,
                 dependencies,
-                features: feature_map,
+                features: Rc::new(feature_map),
                 checksum: None,
                 links: links.map(|l| l.into()),
                 namespaced_features,


### PR DESCRIPTION
This removes a `FeatureMap::clone` that I noticed when profiling no-op builds of cargo, benchmarks show a ~5% improvement. Looks like #6880 means that there is a ref to every `Summery` so the `Rc::make_mut` dose a deep clone.