### PR TITLE
Allow publishing with dev-dependencies without a version.

### DIFF
--- a/src/cargo/ops/cargo_package.rs
+++ b/src/cargo/ops/cargo_package.rs
@@ -206,7 +206,7 @@ fn check_metadata(pkg: &Package, config: &Config) -> CargoResult<()> {
 // Checks that the package dependencies are safe to deploy.
 fn verify_dependencies(pkg: &Package) -> CargoResult<()> {
     for dep in pkg.dependencies() {
-        if dep.source_id().is_path() && !dep.specified_req() {
+        if dep.source_id().is_path() && !dep.specified_req() && dep.is_transitive() {
             failure::bail!(
                 "all path dependencies must have a version specified \
                  when packaging.\ndependency `{}` does not specify \

--- a/src/doc/man/cargo-package.adoc
+++ b/src/doc/man/cargo-package.adoc
@@ -21,6 +21,7 @@ steps:
 . Load and check the current workspace, performing some basic checks.
     - Path dependencies are not allowed unless they have a version key. Cargo
       will ignore the path key for dependencies in published packages.
+      `dev-dependencies` do not have this restriction.
 . Create the compressed `.crate` file.
     - The original `Cargo.toml` file is rewritten and normalized.
     - `[patch]`, `[replace]`, and `[workspace]` sections are removed from the

--- a/src/doc/man/generated/cargo-package.html
+++ b/src/doc/man/generated/cargo-package.html
@@ -27,7 +27,8 @@ steps:</p>
 <ul>
 <li>
 <p>Path dependencies are not allowed unless they have a version key. Cargo
-will ignore the path key for dependencies in published packages.</p>
+will ignore the path key for dependencies in published packages.
+<code>dev-dependencies</code> do not have this restriction.</p>
 </li>
 </ul>
 </div>

--- a/src/etc/man/cargo-package.1
+++ b/src/etc/man/cargo-package.1
@@ -1,13 +1,13 @@
 '\" t
 .\"     Title: cargo-package
 .\"    Author: [see the "AUTHOR(S)" section]
-.\" Generator: Asciidoctor 2.0.8
-.\"      Date: 2019-07-15
+.\" Generator: Asciidoctor 2.0.10
+.\"      Date: 2019-09-05
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "CARGO\-PACKAGE" "1" "2019-07-15" "\ \&" "\ \&"
+.TH "CARGO\-PACKAGE" "1" "2019-09-05" "\ \&" "\ \&"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0
@@ -59,6 +59,7 @@ Load and check the current workspace, performing some basic checks.
 .\}
 Path dependencies are not allowed unless they have a version key. Cargo
 will ignore the path key for dependencies in published packages.
+\fBdev\-dependencies\fP do not have this restriction.
 .RE
 .RE
 .sp

--- a/tests/testsuite/publish.rs
+++ b/tests/testsuite/publish.rs
@@ -1217,7 +1217,7 @@ fn publish_dev_dep_no_version() {
         )
         .run();
 
-    publish::validate_upload(
+    publish::validate_upload_with_contents(
         r#"
         {
           "authors": [],
@@ -1241,5 +1241,21 @@ fn publish_dev_dep_no_version() {
         "#,
         "foo-0.1.0.crate",
         &["Cargo.toml", "Cargo.toml.orig", "src/lib.rs"],
+        &[(
+            "Cargo.toml",
+            r#"[..]
+[package]
+name = "foo"
+version = "0.1.0"
+authors = []
+description = "foo"
+homepage = "foo"
+documentation = "foo"
+license = "MIT"
+repository = "foo"
+
+[dev-dependencies]
+"#,
+        )],
     );
 }

--- a/tests/testsuite/publish.rs
+++ b/tests/testsuite/publish.rs
@@ -1178,3 +1178,68 @@ fn publish_git_with_version() {
         ],
     );
 }
+
+#[cargo_test]
+fn publish_dev_dep_no_version() {
+    registry::init();
+
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "foo"
+            version = "0.1.0"
+            authors = []
+            license = "MIT"
+            description = "foo"
+            documentation = "foo"
+            homepage = "foo"
+            repository = "foo"
+
+            [dev-dependencies]
+            bar = { path = "bar" }
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.0.1"))
+        .file("bar/src/lib.rs", "")
+        .build();
+
+    p.cargo("publish --no-verify --index")
+        .arg(registry_url().to_string())
+        .with_stderr(
+            "\
+[UPDATING] [..]
+[PACKAGING] foo v0.1.0 [..]
+[UPLOADING] foo v0.1.0 [..]
+",
+        )
+        .run();
+
+    publish::validate_upload(
+        r#"
+        {
+          "authors": [],
+          "badges": {},
+          "categories": [],
+          "deps": [],
+          "description": "foo",
+          "documentation": "foo",
+          "features": {},
+          "homepage": "foo",
+          "keywords": [],
+          "license": "MIT",
+          "license_file": null,
+          "links": null,
+          "name": "foo",
+          "readme": null,
+          "readme_file": null,
+          "repository": "foo",
+          "vers": "0.1.0"
+        }
+        "#,
+        "foo-0.1.0.crate",
+        &["Cargo.toml", "Cargo.toml.orig", "src/lib.rs"],
+    );
+}


### PR DESCRIPTION
This change allows dev-dependencies without a `version` key to be published.  If a dev-dependency is missing the `version`, it will be stripped from the packaged manifest.
