### PR TITLE
Add `alloc` and `proc_macro` to libstd crates

### DIFF
--- a/src/cargo/core/compiler/standard_lib.rs
+++ b/src/cargo/core/compiler/standard_lib.rs
@@ -17,6 +17,8 @@ pub fn parse_unstable_flag(value: Option<&str>) -> Vec<String> {
     let mut crates: HashSet<&str> = value.split(',').collect();
     if crates.contains("std") {
         crates.insert("core");
+        crates.insert("alloc");
+        crates.insert("proc_macro");
         crates.insert("panic_unwind");
         crates.insert("compiler_builtins");
     } else if crates.contains("core") {

--- a/tests/testsuite/standard_lib.rs
+++ b/tests/testsuite/standard_lib.rs
@@ -237,7 +237,15 @@ fn doc() {
 
 fn check_std() {
     let p = project()
-        .file("src/lib.rs", "pub fn f() {}")
+        .file(
+            "src/lib.rs",
+            "
+                extern crate core;
+                extern crate alloc;
+                extern crate proc_macro;
+                pub fn f() {}
+            ",
+        )
         .file("src/main.rs", "fn main() {}")
         .file(
             "tests/t1.rs",


### PR DESCRIPTION
These two have been stabilized for all targets like `std` so if `std` is
requested let's be sure to make them available to other crates as well.