### PR TITLE
add readme key to cargos manifest.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ license = "MIT OR Apache-2.0"
 homepage = "https://crates.io"
 repository = "https://github.com/rust-lang/cargo"
 documentation = "https://docs.rs/cargo"
+readme = "README.md"
 description = """
 Cargo, a package manager for Rust.
 """


### PR DESCRIPTION
This should make the readme display on cargos crates.io page