### PR TITLE
[-Zbuild-std] Only build libtest when libstd is built

### DIFF
--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -398,7 +398,10 @@ pub fn compile_ws<'a>(
                 .iter()
                 .any(|unit| unit.mode.is_rustc_test() && unit.target.harness())
         {
-            crates.push("test".to_string());
+            // Only build libtest when libstd is built (libtest depends on libstd)
+            if crates.iter().any(|c| c == "std") {
+                crates.push("test".to_string());
+            }
         }
         standard_lib::generate_std_roots(&bcx, &crates, std_resolve.as_ref().unwrap())?
     } else {


### PR DESCRIPTION
Currently `libtest` is always compiled when a compilation unit uses a test harness. This implicitly adds builds the standard library too because `libtest` depends on it. This breaks the use of custom test frameworks in `no_std` crates as reported in https://github.com/rust-lang/cargo/pull/7216#issuecomment-529433594.

This pull request fixes the issue by only building `libtest` if `libstd` is built. This makes sense in my opinion because when the user explicitly specified `-Zbuild-std=core`, they probably don't want to build the full standard library and rather get a compilation error when they accidentally use `libtest`.
