### PR TITLE
Public dependency refactor and re-allow backjumping

### DIFF
--- a/crates/resolver-tests/tests/resolve.rs
+++ b/crates/resolver-tests/tests/resolve.rs
@@ -1048,6 +1048,41 @@ fn resolving_with_constrained_sibling_backtrack_activation() {
 }
 
 #[test]
+fn resolving_with_public_constrained_sibling() {
+    // It makes sense to resolve most-constrained deps first, but
+    // with that logic the backtrack traps here come between the two
+    // attempted resolutions of 'constrained'. When backtracking,
+    // cargo should skip past them and resume resolution once the
+    // number of activations for 'constrained' changes.
+    let mut reglist = vec![
+        pkg!(("foo", "1.0.0") => [dep_req("bar", "=1.0.0"),
+                                  dep_req("backtrack_trap1", "1.0"),
+                                  dep_req("backtrack_trap2", "1.0"),
+                                  dep_req("constrained", "<=60")]),
+        pkg!(("bar", "1.0.0") => [dep_req_kind("constrained", ">=60", Kind::Normal, true)]),
+    ];
+    // Bump these to make the test harder, but you'll also need to
+    // change the version constraints on `constrained` above. To correctly
+    // exercise Cargo, the relationship between the values is:
+    // NUM_CONSTRAINED - vsn < NUM_TRAPS < vsn
+    // to make sure the traps are resolved between `constrained`.
+    const NUM_TRAPS: usize = 45; // min 1
+    const NUM_CONSTRAINED: usize = 100; // min 1
+    for i in 0..NUM_TRAPS {
+        let vsn = format!("1.0.{}", i);
+        reglist.push(pkg!(("backtrack_trap1", vsn.clone())));
+        reglist.push(pkg!(("backtrack_trap2", vsn.clone())));
+    }
+    for i in 0..NUM_CONSTRAINED {
+        let vsn = format!("{}.0.0", i);
+        reglist.push(pkg!(("constrained", vsn.clone())));
+    }
+    let reg = registry(reglist);
+
+    let _ = resolve_and_validated(vec![dep_req("foo", "1")], &reg, None);
+}
+
+#[test]
 fn resolving_with_constrained_sibling_transitive_dep_effects() {
     // When backtracking due to a failed dependency, if Cargo is
     // trying to be clever and skip irrelevant dependencies, care must

--- a/src/cargo/core/resolver/conflict_cache.rs
+++ b/src/cargo/core/resolver/conflict_cache.rs
@@ -2,7 +2,7 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 
 use log::trace;
 
-use super::types::{ConflictMap, ConflictReason};
+use super::types::ConflictMap;
 use crate::core::resolver::Context;
 use crate::core::{Dependency, PackageId};
 
@@ -194,7 +194,7 @@ impl ConflictCache {
     /// `dep` is known to be unresolvable if
     /// all the `PackageId` entries are activated.
     pub fn insert(&mut self, dep: &Dependency, con: &ConflictMap) {
-        if con.values().any(|c| *c == ConflictReason::PublicDependency) {
+        if con.values().any(|c| c.is_public_dependency()) {
             // TODO: needs more info for back jumping
             // for now refuse to cache it.
             return;

--- a/src/cargo/core/resolver/context.rs
+++ b/src/cargo/core/resolver/context.rs
@@ -23,6 +23,7 @@ pub use super::resolve::Resolve;
 // possible.
 #[derive(Clone)]
 pub struct Context {
+    pub age: ContextAge,
     pub activations: Activations,
     /// list the features that are activated for each package
     pub resolve_features: im_rc::HashMap<PackageId, FeaturesSet>,
@@ -82,6 +83,7 @@ impl PackageId {
 impl Context {
     pub fn new(check_public_visible_dependencies: bool) -> Context {
         Context {
+            age: 0,
             resolve_features: im_rc::HashMap::new(),
             links: im_rc::HashMap::new(),
             public_dependency: if check_public_visible_dependencies {
@@ -108,7 +110,7 @@ impl Context {
         parent: Option<(&Summary, &Dependency)>,
     ) -> ActivateResult<bool> {
         let id = summary.package_id();
-        let age: ContextAge = self.age();
+        let age: ContextAge = self.age;
         match self.activations.entry(id.as_activations_key()) {
             im_rc::hashmap::Entry::Occupied(o) => {
                 debug_assert_eq!(
@@ -178,13 +180,6 @@ impl Context {
                 opts.features.is_empty() && (!opts.uses_default_features || !has_default_feature)
             }
         })
-    }
-
-    /// Returns the `ContextAge` of this `Context`.
-    /// For now we use (len of activations) as the age.
-    /// See the `ContextAge` docs for more details.
-    pub fn age(&self) -> ContextAge {
-        self.activations.len()
     }
 
     /// If the package is active returns the `ContextAge` when it was added

--- a/src/cargo/core/resolver/context.rs
+++ b/src/cargo/core/resolver/context.rs
@@ -245,8 +245,13 @@ impl Graph<PackageId, Rc<Vec<Dependency>>> {
 #[derive(Clone, Debug, Default)]
 pub struct PublicDependency {
     /// For each active package the set of all the names it can see,
-    /// for each name the exact package that name resolves to and whether it exports that visibility.
-    inner: im_rc::HashMap<PackageId, im_rc::HashMap<InternedString, (PackageId, bool)>>,
+    /// for each name the exact package that name resolves to,
+    ///     the `ContextAge` when it was first visible,
+    ///     and the `ContextAge` when it was first exported.
+    inner: im_rc::HashMap<
+        PackageId,
+        im_rc::HashMap<InternedString, (PackageId, ContextAge, Option<ContextAge>)>,
+    >,
 }
 
 impl PublicDependency {
@@ -260,7 +265,7 @@ impl PublicDependency {
             .get(&candidate_pid) // if we have seen it before
             .iter()
             .flat_map(|x| x.values()) // all the things we have stored
-            .filter(|x| x.1) // as publicly exported
+            .filter(|x| x.2.is_some()) // as publicly exported
             .map(|x| x.0)
             .chain(Some(candidate_pid)) // but even if not we know that everything exports itself
             .collect()
@@ -270,6 +275,7 @@ impl PublicDependency {
         candidate_pid: PackageId,
         parent_pid: PackageId,
         is_public: bool,
+        age: ContextAge,
         parents: &Graph<PackageId, Rc<Vec<Dependency>>>,
     ) {
         // one tricky part is that `candidate_pid` may already be active and
@@ -284,7 +290,7 @@ impl PublicDependency {
                     im_rc::hashmap::Entry::Occupied(mut o) => {
                         // the (transitive) parent can already see something by `c`s name, it had better be `c`.
                         assert_eq!(o.get().0, c);
-                        if o.get().1 {
+                        if o.get().2.is_some() {
                             // The previous time the parent saw `c`, it was a public dependency.
                             // So all of its parents already know about `c`
                             // and we can save some time by stopping now.
@@ -292,13 +298,14 @@ impl PublicDependency {
                         }
                         if public {
                             // Mark that `c` has now bean seen publicly
-                            o.insert((c, public));
+                            let old_age = o.get().1;
+                            o.insert((c, old_age, if public { Some(age) } else { None }));
                         }
                     }
                     im_rc::hashmap::Entry::Vacant(v) => {
                         // The (transitive) parent does not have anything by `c`s name,
                         // so we add `c`.
-                        v.insert((c, public));
+                        v.insert((c, age, if public { Some(age) } else { None }));
                     }
                 }
                 // if `candidate_pid` was a private dependency of `p` then `p` parents can't see `c` thru `p`
@@ -331,7 +338,7 @@ impl PublicDependency {
                         // So, adding `b` will cause `p` to have a public dependency conflict on `t`.
                         return Err((p, ConflictReason::PublicDependency));
                     }
-                    if o.1 {
+                    if o.2.is_some() {
                         // The previous time the parent saw `t`, it was a public dependency.
                         // So all of its parents already know about `t`
                         // and we can save some time by stopping now.

--- a/src/cargo/core/resolver/context.rs
+++ b/src/cargo/core/resolver/context.rs
@@ -30,8 +30,7 @@ pub struct Context {
     pub links: im_rc::HashMap<InternedString, PackageId>,
     /// for each package the list of names it can see,
     /// then for each name the exact version that name represents and weather the name is public.
-    pub public_dependency:
-        Option<im_rc::HashMap<PackageId, im_rc::HashMap<InternedString, (PackageId, bool)>>>,
+    pub public_dependency: Option<PublicDependency>,
 
     /// a way to look up for a package in activations what packages required it
     /// and all of the exact deps that it fulfilled.
@@ -86,7 +85,7 @@ impl Context {
             resolve_features: im_rc::HashMap::new(),
             links: im_rc::HashMap::new(),
             public_dependency: if check_public_visible_dependencies {
-                Some(im_rc::HashMap::new())
+                Some(PublicDependency::new())
             } else {
                 None
             },
@@ -238,5 +237,112 @@ impl Context {
             }
         }
         graph
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct PublicDependency {
+    inner: im_rc::HashMap<PackageId, im_rc::HashMap<InternedString, (PackageId, bool)>>,
+}
+
+impl PublicDependency {
+    fn new() -> Self {
+        PublicDependency {
+            inner: im_rc::HashMap::new(),
+        }
+    }
+    pub fn add_edge(
+        &mut self,
+        candidate_pid: PackageId,
+        parent_pid: PackageId,
+        dep: &Dependency,
+        parents: &Graph<PackageId, Rc<Vec<Dependency>>>,
+    ) {
+        // one tricky part is that `candidate_pid` may already be active and
+        // have public dependencies of its own. So we not only need to mark
+        // `candidate_pid` as visible to its parents but also all of its existing
+        // public dependencies.
+        let existing_public_deps: Vec<PackageId> = self
+            .inner
+            .get(&candidate_pid)
+            .iter()
+            .flat_map(|x| x.values())
+            .filter_map(|x| if x.1 { Some(&x.0) } else { None })
+            .chain(&Some(candidate_pid))
+            .cloned()
+            .collect();
+        for c in existing_public_deps {
+            // for each (transitive) parent that can newly see `t`
+            let mut stack = vec![(parent_pid, dep.is_public())];
+            while let Some((p, public)) = stack.pop() {
+                match self.inner.entry(p).or_default().entry(c.name()) {
+                    im_rc::hashmap::Entry::Occupied(mut o) => {
+                        // the (transitive) parent can already see something by `c`s name, it had better be `c`.
+                        assert_eq!(o.get().0, c);
+                        if o.get().1 {
+                            // The previous time the parent saw `c`, it was a public dependency.
+                            // So all of its parents already know about `c`
+                            // and we can save some time by stopping now.
+                            continue;
+                        }
+                        if public {
+                            // Mark that `c` has now bean seen publicly
+                            o.insert((c, public));
+                        }
+                    }
+                    im_rc::hashmap::Entry::Vacant(v) => {
+                        // The (transitive) parent does not have anything by `c`s name,
+                        // so we add `c`.
+                        v.insert((c, public));
+                    }
+                }
+                // if `candidate_pid` was a private dependency of `p` then `p` parents can't see `c` thru `p`
+                if public {
+                    // if it was public, then we add all of `p`s parents to be checked
+                    for &(grand, ref d) in parents.edges(&p) {
+                        stack.push((grand, d.iter().any(|x| x.is_public())));
+                    }
+                }
+            }
+        }
+    }
+    pub fn can_add_edge(
+        &self,
+        b_id: PackageId,
+        parent: PackageId,
+        dep: &Dependency,
+        parents: &Graph<PackageId, Rc<Vec<Dependency>>>,
+    ) -> Result<(), (PackageId, ConflictReason)> {
+        let existing_public_deps: Vec<PackageId> = self
+            .inner
+            .get(&b_id)
+            .iter()
+            .flat_map(|x| x.values())
+            .filter_map(|x| if x.1 { Some(&x.0) } else { None })
+            .chain(&Some(b_id))
+            .cloned()
+            .collect();
+        for t in existing_public_deps {
+            // for each (transitive) parent that can newly see `t`
+            let mut stack = vec![(parent, dep.is_public())];
+            while let Some((p, public)) = stack.pop() {
+                // TODO: dont look at the same thing more then once
+                if let Some(o) = self.inner.get(&p).and_then(|x| x.get(&t.name())) {
+                    if o.0 != t {
+                        // the (transitive) parent can already see a different version by `t`s name.
+                        // So, adding `b` will cause `p` to have a public dependency conflict on `t`.
+                        return Err((p, ConflictReason::PublicDependency));
+                    }
+                }
+                // if `b` was a private dependency of `p` then `p` parents can't see `t` thru `p`
+                if public {
+                    // if it was public, then we add all of `p`s parents to be checked
+                    for &(grand, ref d) in parents.edges(&p) {
+                        stack.push((grand, d.iter().any(|x| x.is_public())));
+                    }
+                }
+            }
+        }
+        Ok(())
     }
 }

--- a/src/cargo/core/resolver/mod.rs
+++ b/src/cargo/core/resolver/mod.rs
@@ -604,7 +604,13 @@ fn activate(
         // and associate dep with that edge
         .push(dep.clone());
         if let Some(public_dependency) = cx.public_dependency.as_mut() {
-            public_dependency.add_edge(candidate_pid, parent_pid, dep.is_public(), &cx.parents);
+            public_dependency.add_edge(
+                candidate_pid,
+                parent_pid,
+                dep.is_public(),
+                cx.age,
+                &cx.parents,
+            );
         }
     }
 

--- a/src/cargo/core/resolver/mod.rs
+++ b/src/cargo/core/resolver/mod.rs
@@ -603,7 +603,7 @@ fn activate(
         // and associate dep with that edge
         .push(dep.clone());
         if let Some(public_dependency) = cx.public_dependency.as_mut() {
-            public_dependency.add_edge(candidate_pid, parent_pid, dep, &cx.parents);
+            public_dependency.add_edge(candidate_pid, parent_pid, dep.is_public(), &cx.parents);
         }
     }
 
@@ -756,7 +756,8 @@ impl RemainingCandidates {
             // activated and have public dependants of its own,
             // all of witch also need to be checked the same way.
             if let Some(public_dependency) = cx.public_dependency.as_ref() {
-                if let Err((p, c)) = public_dependency.can_add_edge(b_id, parent, dep, &cx.parents)
+                if let Err((p, c)) =
+                    public_dependency.can_add_edge(b_id, parent, dep.is_public(), &cx.parents)
                 {
                     conflicting_prev_active.insert(p, c);
                     continue;

--- a/src/cargo/core/resolver/mod.rs
+++ b/src/cargo/core/resolver/mod.rs
@@ -603,52 +603,7 @@ fn activate(
         // and associate dep with that edge
         .push(dep.clone());
         if let Some(public_dependency) = cx.public_dependency.as_mut() {
-            // one tricky part is that `candidate_pid` may already be active and
-            // have public dependencies of its own. So we not only need to mark
-            // `candidate_pid` as visible to its parents but also all of its existing
-            // public dependencies.
-            let existing_public_deps: Vec<PackageId> = public_dependency
-                .get(&candidate_pid)
-                .iter()
-                .flat_map(|x| x.values())
-                .filter_map(|x| if x.1 { Some(&x.0) } else { None })
-                .chain(&Some(candidate_pid))
-                .cloned()
-                .collect();
-            for c in existing_public_deps {
-                // for each (transitive) parent that can newly see `t`
-                let mut stack = vec![(parent_pid, dep.is_public())];
-                while let Some((p, public)) = stack.pop() {
-                    match public_dependency.entry(p).or_default().entry(c.name()) {
-                        im_rc::hashmap::Entry::Occupied(mut o) => {
-                            // the (transitive) parent can already see something by `c`s name, it had better be `c`.
-                            assert_eq!(o.get().0, c);
-                            if o.get().1 {
-                                // The previous time the parent saw `c`, it was a public dependency.
-                                // So all of its parents already know about `c`
-                                // and we can save some time by stopping now.
-                                continue;
-                            }
-                            if public {
-                                // Mark that `c` has now bean seen publicly
-                                o.insert((c, public));
-                            }
-                        }
-                        im_rc::hashmap::Entry::Vacant(v) => {
-                            // The (transitive) parent does not have anything by `c`s name,
-                            // so we add `c`.
-                            v.insert((c, public));
-                        }
-                    }
-                    // if `candidate_pid` was a private dependency of `p` then `p` parents can't see `c` thru `p`
-                    if public {
-                        // if it was public, then we add all of `p`s parents to be checked
-                        for &(grand, ref d) in cx.parents.edges(&p) {
-                            stack.push((grand, d.iter().any(|x| x.is_public())));
-                        }
-                    }
-                }
-            }
+            public_dependency.add_edge(candidate_pid, parent_pid, dep, &cx.parents);
         }
     }
 
@@ -762,7 +717,7 @@ impl RemainingCandidates {
         dep: &Dependency,
         parent: PackageId,
     ) -> Option<(Summary, bool)> {
-        'main: for b in self.remaining.by_ref() {
+        for b in self.remaining.by_ref() {
             let b_id = b.package_id();
             // The `links` key in the manifest dictates that there's only one
             // package in a dependency graph, globally, with that particular
@@ -801,35 +756,10 @@ impl RemainingCandidates {
             // activated and have public dependants of its own,
             // all of witch also need to be checked the same way.
             if let Some(public_dependency) = cx.public_dependency.as_ref() {
-                let existing_public_deps: Vec<PackageId> = public_dependency
-                    .get(&b_id)
-                    .iter()
-                    .flat_map(|x| x.values())
-                    .filter_map(|x| if x.1 { Some(&x.0) } else { None })
-                    .chain(&Some(b_id))
-                    .cloned()
-                    .collect();
-                for t in existing_public_deps {
-                    // for each (transitive) parent that can newly see `t`
-                    let mut stack = vec![(parent, dep.is_public())];
-                    while let Some((p, public)) = stack.pop() {
-                        // TODO: dont look at the same thing more then once
-                        if let Some(o) = public_dependency.get(&p).and_then(|x| x.get(&t.name())) {
-                            if o.0 != t {
-                                // the (transitive) parent can already see a different version by `t`s name.
-                                // So, adding `b` will cause `p` to have a public dependency conflict on `t`.
-                                conflicting_prev_active.insert(p, ConflictReason::PublicDependency);
-                                continue 'main;
-                            }
-                        }
-                        // if `b` was a private dependency of `p` then `p` parents can't see `t` thru `p`
-                        if public {
-                            // if it was public, then we add all of `p`s parents to be checked
-                            for &(grand, ref d) in cx.parents.edges(&p) {
-                                stack.push((grand, d.iter().any(|x| x.is_public())));
-                            }
-                        }
-                    }
+                if let Err((p, c)) = public_dependency.can_add_edge(b_id, parent, dep, &cx.parents)
+                {
+                    conflicting_prev_active.insert(p, c);
+                    continue;
                 }
             }
 

--- a/src/cargo/core/resolver/mod.rs
+++ b/src/cargo/core/resolver/mod.rs
@@ -218,7 +218,7 @@ fn activate_deps_loop(
         trace!(
             "{}[{}]>{} {} candidates",
             parent.name(),
-            cx.age(),
+            cx.age,
             dep.package_name(),
             candidates.len()
         );
@@ -264,7 +264,7 @@ fn activate_deps_loop(
                 trace!(
                     "{}[{}]>{} -- no candidates",
                     parent.name(),
-                    cx.age(),
+                    cx.age,
                     dep.package_name()
                 );
 
@@ -375,7 +375,7 @@ fn activate_deps_loop(
             trace!(
                 "{}[{}]>{} trying {}",
                 parent.name(),
-                cx.age(),
+                cx.age,
                 dep.package_name(),
                 candidate.version()
             );
@@ -525,7 +525,7 @@ fn activate_deps_loop(
                         trace!(
                             "{}[{}]>{} skipping {} ",
                             parent.name(),
-                            cx.age(),
+                            cx.age,
                             dep.package_name(),
                             pid.version()
                         );
@@ -594,6 +594,7 @@ fn activate(
     opts: ResolveOpts,
 ) -> ActivateResult<Option<(DepsFrame, Duration)>> {
     let candidate_pid = candidate.package_id();
+    cx.age += 1;
     if let Some((parent, dep)) = parent {
         let parent_pid = parent.package_id();
         Rc::make_mut(
@@ -947,7 +948,7 @@ fn find_candidate(
         // make any progress. As a result if we hit this condition we can
         // completely skip this backtrack frame and move on to the next.
         if let Some(age) = age {
-            if frame.context.age() > age {
+            if frame.context.age >= age {
                 trace!(
                     "{} = \"{}\" skip as not solving {}: {:?}",
                     frame.dep.package_name(),

--- a/src/cargo/core/resolver/types.rs
+++ b/src/cargo/core/resolver/types.rs
@@ -286,7 +286,8 @@ pub enum ConflictReason {
     // TODO: needs more info for `activation_error`
     // TODO: needs more info for `find_candidate`
     /// pub dep error
-    PublicDependency,
+    PublicDependency(PackageId),
+    PubliclyExports(PackageId),
 }
 
 impl ConflictReason {
@@ -306,6 +307,16 @@ impl ConflictReason {
 
     pub fn is_required_dependency_as_features(&self) -> bool {
         if let ConflictReason::RequiredDependencyAsFeatures(_) = *self {
+            return true;
+        }
+        false
+    }
+
+    pub fn is_public_dependency(&self) -> bool {
+        if let ConflictReason::PublicDependency(_) = *self {
+            return true;
+        }
+        if let ConflictReason::PubliclyExports(_) = *self {
             return true;
         }
         false


### PR DESCRIPTION
There were **three** attempts at vanquishing exponential time spent in Public dependency resolution. All failures. All three started with some refactoring that seams worth saving. Specifically the data structure `public_dependency` that is used to test for Public dependency conflicts is large, tricky, and modified in line. So lets make it a type with a name and move the interactions into methods. 

Next each attempt needed to know how far back to jump to undo any given dependency edge. I am fairly confident that any full solution will need this functionality. I also think any solution will need a way to represent richer conflicts than the existing "is this pid active". So let's keep the `still_applies` structure from the last attempt.

Last each attempt needs to pick a way to represent a Public dependency conflict. The last attempt used three facts about a situation. 

- `a1`: `PublicDependency(p)` witch can be read as the package `p` can see the package `a1`
- `b`: `PublicDependency(p)` witch can be read as the package `p` can see the package `b`
- `a2`: `PubliclyExports(b)` witch can be read as the package `b` has the package `a2` in its publick interface.

This representation is good enough to allow for `backjumping`. I.E. `find_candidate` can go back several frames until the `age` when the Public dependency conflict was introduced. This optimization, added for normal dependencies in #4834, saves the most time in practice. So having it for Public dependency conflicts is important for allowing real world experimentation of the Public dependencies feature.  We will have to alter/improve/replace this representation to unlock all of the important optimizations. But I don't know one that will work for all of them and this is a major step forward.

Can be read one commit at a time.