### PR TITLE
Parse `unsupported crate type` error more tightly

### DIFF
--- a/src/cargo/core/compiler/build_context/target_info.rs
+++ b/src/cargo/core/compiler/build_context/target_info.rs
@@ -333,7 +333,7 @@ fn parse_crate_type(
 ) -> CargoResult<Option<(String, String)>> {
     let not_supported = error.lines().any(|line| {
         (line.contains("unsupported crate type") || line.contains("unknown crate type"))
-            && line.contains(crate_type)
+            && line.contains(&format!("crate type `{}`", crate_type))
     });
     if not_supported {
         return Ok(None);

--- a/tests/testsuite/custom_target.rs
+++ b/tests/testsuite/custom_target.rs
@@ -130,3 +130,50 @@ fn custom_target_dependency() {
 
     p.cargo("build --lib --target custom-target.json -v").run();
 }
+
+#[cargo_test]
+fn custom_bin_target() {
+    if !is_nightly() {
+        // Requires features no_core, lang_items
+        return;
+    }
+    let p = project()
+        .file(
+            "src/main.rs",
+            r#"
+            #![feature(no_core)]
+            #![feature(lang_items)]
+            #![no_core]
+            #![no_main]
+
+            #[lang = "sized"]
+            pub trait Sized {
+                // Empty.
+            }
+            #[lang = "copy"]
+            pub trait Copy {
+                // Empty.
+            }
+        "#,
+        )
+        .file(
+            "custom-bin-target.json",
+            r#"
+            {
+                "llvm-target": "x86_64-unknown-none-gnu",
+                "data-layout": "e-m:e-i64:64-f80:128-n8:16:32:64-S128",
+                "arch": "x86_64",
+                "target-endian": "little",
+                "target-pointer-width": "64",
+                "target-c-int-width": "32",
+                "os": "none",
+                "linker-flavor": "ld.lld",
+                "linker": "rust-lld",
+                "executables": true
+            }
+        "#,
+        )
+        .build();
+
+    p.cargo("build --target custom-bin-target.json -v").run();
+}


### PR DESCRIPTION
Fixes #7363 

Instead of adding a new test, we could also rename the target file in an existing custom target test if you prefer.