### PR TITLE
Work with canonical URLs in `[patch]`

### DIFF
--- a/src/cargo/core/resolver/resolve.rs
+++ b/src/cargo/core/resolver/resolve.rs
@@ -3,8 +3,6 @@ use std::collections::{HashMap, HashSet};
 use std::fmt;
 use std::iter::FromIterator;
 
-use url::Url;
-
 use crate::core::dependency::Kind;
 use crate::core::{Dependency, PackageId, PackageIdSpec, Summary, Target};
 use crate::util::errors::CargoResult;
@@ -114,8 +112,8 @@ impl Resolve {
         self.graph.path_to_top(pkg)
     }
 
-    pub fn register_used_patches(&mut self, patches: &HashMap<Url, Vec<Summary>>) {
-        for summary in patches.values().flat_map(|v| v) {
+    pub fn register_used_patches(&mut self, patches: &[Summary]) {
+        for summary in patches {
             if self.iter().any(|id| id == summary.package_id()) {
                 continue;
             }

--- a/src/cargo/ops/resolve.rs
+++ b/src/cargo/ops/resolve.rs
@@ -343,7 +343,7 @@ pub fn resolve_with_previous<'cfg>(
         Some(ws.config()),
         ws.features().require(Feature::public_dependency()).is_ok(),
     )?;
-    resolved.register_used_patches(registry.patches());
+    resolved.register_used_patches(&registry.patches());
     if register_patches {
         // It would be good if this warning was more targeted and helpful
         // (such as showing close candidates that failed to match). However,

--- a/src/cargo/sources/git/mod.rs
+++ b/src/cargo/sources/git/mod.rs
@@ -1,4 +1,4 @@
-pub use self::source::{canonicalize_url, GitSource};
+pub use self::source::GitSource;
 pub use self::utils::{fetch, GitCheckout, GitDatabase, GitRemote, GitRevision};
 mod source;
 mod utils;

--- a/src/cargo/util/canonical_url.rs
+++ b/src/cargo/util/canonical_url.rs
@@ -1,0 +1,73 @@
+use crate::util::errors::CargoResult;
+use std::hash::{self, Hash};
+use url::Url;
+
+/// A newtype wrapper around `Url` which represents a "canonical" version of an
+/// original URL.
+///
+/// A "canonical" url is only intended for internal comparison purposes in
+/// Cargo. It's to help paper over mistakes such as depending on
+/// `github.com/foo/bar` vs `github.com/foo/bar.git`. This is **only** for
+/// internal purposes within Cargo and provides no means to actually read the
+/// underlying string value of the `Url` it contains. This is intentional,
+/// because all fetching should still happen within the context of the original
+/// URL.
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
+pub struct CanonicalUrl(Url);
+
+impl CanonicalUrl {
+    pub fn new(url: &Url) -> CargoResult<CanonicalUrl> {
+        let mut url = url.clone();
+
+        // cannot-be-a-base-urls (e.g., `github.com:rust-lang-nursery/rustfmt.git`)
+        // are not supported.
+        if url.cannot_be_a_base() {
+            failure::bail!(
+                "invalid url `{}`: cannot-be-a-base-URLs are not supported",
+                url
+            )
+        }
+
+        // Strip a trailing slash.
+        if url.path().ends_with('/') {
+            url.path_segments_mut().unwrap().pop_if_empty();
+        }
+
+        // For GitHub URLs specifically, just lower-case everything. GitHub
+        // treats both the same, but they hash differently, and we're gonna be
+        // hashing them. This wants a more general solution, and also we're
+        // almost certainly not using the same case conversion rules that GitHub
+        // does. (See issue #84)
+        if url.host_str() == Some("github.com") {
+            url.set_scheme("https").unwrap();
+            let path = url.path().to_lowercase();
+            url.set_path(&path);
+        }
+
+        // Repos can generally be accessed with or without `.git` extension.
+        let needs_chopping = url.path().ends_with(".git");
+        if needs_chopping {
+            let last = {
+                let last = url.path_segments().unwrap().next_back().unwrap();
+                last[..last.len() - 4].to_owned()
+            };
+            url.path_segments_mut().unwrap().pop().push(&last);
+        }
+
+        Ok(CanonicalUrl(url))
+    }
+
+    /// Returns the raw canonicalized URL, although beware that this should
+    /// never be used/displayed/etc, it should only be used for internal data
+    /// structures and hashes and such.
+    pub fn raw_canonicalized_url(&self) -> &Url {
+        &self.0
+    }
+}
+
+// See comment in `source_id.rs` for why we explicitly use `as_str()` here.
+impl Hash for CanonicalUrl {
+    fn hash<S: hash::Hasher>(&self, into: &mut S) {
+        self.0.as_str().hash(into);
+    }
+}

--- a/src/cargo/util/mod.rs
+++ b/src/cargo/util/mod.rs
@@ -1,5 +1,6 @@
 use std::time::Duration;
 
+pub use self::canonical_url::CanonicalUrl;
 pub use self::cfg::{Cfg, CfgExpr};
 pub use self::config::{homedir, Config, ConfigValue};
 pub use self::dependency_queue::DependencyQueue;
@@ -28,6 +29,7 @@ pub use self::workspace::{
     print_available_tests,
 };
 
+mod canonical_url;
 mod cfg;
 pub mod command_prelude;
 pub mod config;


### PR DESCRIPTION
This commit addresses an issue with how the resolver processes `[patch]`
annotations in manifests and lock files. Previously the resolver would
use the raw `Url` coming out of a manifest, but the rest of resolution,
when comparing `SourceId`, uses a canonical form of a `Url` rather than
the actual raw `Url`. This ended up causing discrepancies like those
found in #7282.

To fix the issue all `patch` intermediate storage in the resolver uses a
newly-added `CanonicalUrl` type instead of a `Url`. This
`CanonicalUrl` is then also used throughout the codebase, and all
lookups in the resolver as switched to using `CanonicalUrl` instead of
`Url`, which...

Closes #7282