### PR TITLE
Uncapitalize "Could not compile" error message

### DIFF
--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -300,7 +300,7 @@ fn rustc<'a, 'cfg>(
                 &mut |line| on_stderr_line(state, line, package_id, &target, &mut output_options),
             )
             .map_err(internal_if_simple_exit_code)
-            .chain_err(|| format!("Could not compile `{}`.", name))?;
+            .chain_err(|| format!("could not compile `{}`.", name))?;
         }
 
         if do_rename && real_name != crate_name {

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -511,7 +511,7 @@ fn cargo_compile_with_invalid_code() {
         .with_status(101)
         .with_stderr_contains(
             "\
-[ERROR] Could not compile `foo`.
+[ERROR] could not compile `foo`.
 
 To learn more, run the command again with --verbose.\n",
         )
@@ -551,7 +551,7 @@ fn cargo_compile_with_invalid_code_in_deps() {
     p.cargo("build")
         .with_status(101)
         .with_stderr_contains("[..]invalid rust code[..]")
-        .with_stderr_contains("[ERROR] Could not compile [..]")
+        .with_stderr_contains("[ERROR] could not compile [..]")
         .run();
 }
 
@@ -4528,7 +4528,7 @@ fn signal_display() {
             "\
 [COMPILING] pm [..]
 [COMPILING] foo [..]
-[ERROR] Could not compile `foo`.
+[ERROR] could not compile `foo`.
 
 Caused by:
   process didn't exit successfully: `rustc [..]` (signal: 6, SIGABRT: process abort signal)
@@ -4660,7 +4660,7 @@ fn pipelining_big_graph() {
     foo.cargo("build -p foo")
         .env("CARGO_BUILD_PIPELINING", "true")
         .with_status(101)
-        .with_stderr_contains("[ERROR] Could not compile `a30`[..]")
+        .with_stderr_contains("[ERROR] could not compile `a30`[..]")
         .run();
 }
 

--- a/tests/testsuite/build_script.rs
+++ b/tests/testsuite/build_script.rs
@@ -1072,7 +1072,7 @@ fn build_deps_not_for_normal() {
         .with_stderr_contains("[..]can't find crate for `aaaaa`[..]")
         .with_stderr_contains(
             "\
-[ERROR] Could not compile `foo`.
+[ERROR] could not compile `foo`.
 
 Caused by:
   process didn't exit successfully: [..]

--- a/tests/testsuite/check.rs
+++ b/tests/testsuite/check.rs
@@ -684,7 +684,7 @@ fn short_message_format() {
             "\
 src/lib.rs:1:27: error[E0308]: mismatched types
 error: aborting due to previous error
-error: Could not compile `foo`.
+error: could not compile `foo`.
 ",
         )
         .run();

--- a/tests/testsuite/fix.rs
+++ b/tests/testsuite/fix.rs
@@ -26,7 +26,7 @@ fn do_not_fix_broken_builds() {
     p.cargo("fix --allow-no-vcs")
         .env("__CARGO_FIX_YOLO", "1")
         .with_status(101)
-        .with_stderr_contains("[ERROR] Could not compile `foo`.")
+        .with_stderr_contains("[ERROR] could not compile `foo`.")
         .run();
     assert!(p.read_file("src/lib.rs").contains("let mut x = 3;"));
 }

--- a/tests/testsuite/install.rs
+++ b/tests/testsuite/install.rs
@@ -606,7 +606,7 @@ fn compile_failure() {
     found at `[..]target`
 
 Caused by:
-  Could not compile `foo`.
+  could not compile `foo`.
 
 To learn more, run the command again with --verbose.
 ",


### PR DESCRIPTION
"could not compile ..." matches other Cargo and rustc errors and
warnings better.