### PR TITLE
Fix some duplicate artifact problems.

### DIFF
--- a/crates/cargo-test-support/Cargo.toml
+++ b/crates/cargo-test-support/Cargo.toml
@@ -17,5 +17,5 @@ glob = "0.3"
 lazy_static = "1.0"
 remove_dir_all = "0.5"
 serde_json = "1.0"
-tar = "0.4"
+tar = { version = "0.4.18", default-features = false }
 url = "2.0"


### PR DESCRIPTION
The recent cargo update failed because of duplicate artifacts with rls.

`tar` should mirror what the main manifest contains.

Partially revert #7374 by adding `serde` back to `url`.  Unfortunately the `lsp-types` crate (used by rls) needs this feature.  Unless anyone has a good idea on how to handle that, I don't think it can be removed.

Unblocks cargo update, which I'd like to get done before the beta branch.