### PR TITLE
Remove dependency on `winapi` 0.2

### DIFF
--- a/crates/crates-io/Cargo.toml
+++ b/crates/crates-io/Cargo.toml
@@ -16,7 +16,6 @@ path = "lib.rs"
 [dependencies]
 curl = "0.4"
 failure = "0.1.1"
-http = "0.1"
 percent-encoding = "2.0"
 serde = { version = "1.0", features = ['derive'] }
 serde_derive = "1.0"

--- a/crates/crates-io/lib.rs
+++ b/crates/crates-io/lib.rs
@@ -9,7 +9,6 @@ use std::time::Instant;
 
 use curl::easy::{Easy, List};
 use failure::bail;
-use http::status::StatusCode;
 use percent_encoding::{percent_encode, NON_ALPHANUMERIC};
 use serde::{Deserialize, Serialize};
 use serde_json;
@@ -353,8 +352,13 @@ impl Registry {
                  10MB in size, you can email help@crates.io for assistance."
             ),
             (code, Some(errors)) => {
-                let code = StatusCode::from_u16(code as _)?;
-                bail!("api errors (status {}): {}", code, errors.join(", "))
+                let reason = reason(code);
+                bail!(
+                    "api errors (status {} {}): {}",
+                    code,
+                    reason,
+                    errors.join(", ")
+                )
             }
             (code, None) => bail!(
                 "failed to get a 200 OK response, got {}\n\
@@ -369,5 +373,54 @@ impl Registry {
         }
 
         Ok(body)
+    }
+}
+
+fn reason(code: u32) -> &'static str {
+    // Taken from https://developer.mozilla.org/en-US/docs/Web/HTTP/Status
+    match code {
+        100 => "Continue",
+        101 => "Switching Protocol",
+        103 => "Early Hints",
+        200 => "OK",
+        201 => "Created",
+        202 => "Accepted",
+        203 => "Non-Authoritative Information",
+        204 => "No Content",
+        205 => "Reset Content",
+        206 => "Partial Content",
+        300 => "Multiple Choice",
+        301 => "Moved Permanently",
+        302 => "Found",
+        303 => "See Other",
+        304 => "Not Modified",
+        307 => "Temporary Redirect",
+        308 => "Permanent Redirect",
+        400 => "Bad Request",
+        401 => "Unauthorized",
+        402 => "Payment Required",
+        403 => "Forbidden",
+        404 => "Not Found",
+        405 => "Method Not Allowed",
+        406 => "Not Acceptable",
+        407 => "Proxy Authentication Required",
+        408 => "Request Timeout",
+        409 => "Conflict",
+        410 => "Gone",
+        411 => "Length Required",
+        412 => "Precondition Failed",
+        413 => "Payload Too Large",
+        414 => "URI Too Long",
+        415 => "Unsupported Media Type",
+        416 => "Request Range Not Satisfiable",
+        417 => "Expectation Failed",
+        429 => "Too Many Requests",
+        431 => "Request Header Fields Too Large",
+        500 => "Internal Server Error",
+        501 => "Not Implemented",
+        502 => "Bad Gateway",
+        503 => "Service Unavailable",
+        504 => "Gateway Timeout",
+        _ => "<unknown>",
     }
 }


### PR DESCRIPTION
This commit removes Cargo's dependency on `winapi` 0.2 which takes an
excessively long time to build, slowing down Windows builds. The
`winapi` 0.2 crate was pulled in via a dependency chain that looked
like:

    cargo
    \- crates-io
       \- http
          \- bytes
             \- iovec
                \- winapi 0.2

The fix implemented here was to remove the `http` crate dependency from
`crates-io` which is only used for rendering status codes, but it's easy
enough to inline that function locally.