### PR TITLE
Add documentation for the -Zdoctest-xcompile feature

### DIFF
--- a/src/bin/cargo/cli.rs
+++ b/src/bin/cargo/cli.rs
@@ -37,6 +37,7 @@ Available unstable (nightly-only) flags:
     -Z install-upgrade  -- `cargo install` will upgrade instead of failing
     -Z cache-messages   -- Cache compiler messages
     -Z timings          -- Display concurrency information
+    -Z doctest-xcompile -- Compile and run doctests for non-host target using runner config
 
 Run with 'cargo -Z [FLAG] [SUBCOMMAND]'"
         );

--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -58,6 +58,21 @@ directory. Example:
 cargo +nightly build --out-dir=out -Z unstable-options
 ```
 
+### doctest-xcompile
+* Tracking Issue: [#7040](https://github.com/rust-lang/cargo/issues/7040)
+* Tracking Rustc Issue: [#64245](https://github.com/rust-lang/rust/issues/64245)
+
+This flag changes `cargo test`'s behavior when handling doctests when
+a target is passed. Currently, if a target is passed that is different
+from the host cargo will simply skip testing doctests. If this flag is
+present, cargo will continue as normal, passing the tests to doctest,
+while also passing it a `--target` option, as well as enabling
+`-Zunstable-features --enable-per-target-ignores` and passing along
+information from `.cargo/config`. See the rustc issue for more information.
+
+```
+cargo test --target foo -Zdoctest-xcompile
+```
 
 ### Profile Overrides
 * Tracking Issue: [rust-lang/rust#48683](https://github.com/rust-lang/rust/issues/48683)


### PR DESCRIPTION
@alexcrichton This adds the documentation for the `doctest-xcompile` feature that (woops) didn't make it into the first pr