### PR TITLE
Fix -Ztimings with doc tests.

### DIFF
--- a/crates/cargo-test-support/src/lib.rs
+++ b/crates/cargo-test-support/src/lib.rs
@@ -1632,6 +1632,7 @@ fn substitute_macros(input: &str) -> String {
         ("[RUNNING]", "     Running"),
         ("[COMPILING]", "   Compiling"),
         ("[CHECKING]", "    Checking"),
+        ("[COMPLETED]", "   Completed"),
         ("[CREATED]", "     Created"),
         ("[FINISHED]", "    Finished"),
         ("[ERROR]", "error:"),

--- a/src/cargo/core/compiler/timings.rs
+++ b/src/cargo/core/compiler/timings.rs
@@ -444,15 +444,19 @@ impl<'a, 'cfg> Timings<'a, 'cfg> {
                     "todo"
                 }
                 .to_string();
+
+                // These filter on the unlocked units because not all unlocked
+                // units are actually "built". For example, Doctest mode units
+                // don't actually generate artifacts.
                 let unlocked_units: Vec<usize> = ut
                     .unlocked_units
                     .iter()
-                    .map(|unit| unit_map[unit])
+                    .filter_map(|unit| unit_map.get(unit).copied())
                     .collect();
                 let unlocked_rmeta_units: Vec<usize> = ut
                     .unlocked_rmeta_units
                     .iter()
-                    .map(|unit| unit_map[unit])
+                    .filter_map(|unit| unit_map.get(unit).copied())
                     .collect();
                 UnitData {
                     i,

--- a/tests/testsuite/main.rs
+++ b/tests/testsuite/main.rs
@@ -90,6 +90,7 @@ mod shell_quoting;
 mod small_fd_limits;
 mod standard_lib;
 mod test;
+mod timings;
 mod tool_paths;
 mod update;
 mod vendor;

--- a/tests/testsuite/timings.rs
+++ b/tests/testsuite/timings.rs
@@ -1,0 +1,68 @@
+use cargo_test_support::registry::Package;
+use cargo_test_support::{is_nightly, project};
+
+#[cargo_test]
+fn timings_works() {
+    if !is_nightly() {
+        // Requires --json flag, remove this check in 1.38.
+        return;
+    }
+
+    Package::new("dep", "0.1.0").publish();
+
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "foo"
+            version = "0.1.0"
+
+            [dependencies]
+            dep = "0.1"
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .file("src/main.rs", "fn main() {}")
+        .file("tests/t1.rs", "")
+        .file("examples/ex1.rs", "fn main() {}")
+        .build();
+
+    p.cargo("build --all-targets -Ztimings")
+        .masquerade_as_nightly_cargo()
+        .with_stderr_unordered(
+            "\
+[UPDATING] [..]
+[DOWNLOADING] crates ...
+[DOWNLOADED] dep v0.1.0 [..]
+[COMPILING] dep v0.1.0
+[COMPILING] foo v0.1.0 [..]
+[COMPLETED] dep v0.1.0 in [..]s
+[COMPLETED] foo v0.1.0 in [..]s
+[COMPLETED] foo v0.1.0 bin \"foo\" in [..]s
+[COMPLETED] foo v0.1.0 example \"ex1\" in [..]s
+[COMPLETED] foo v0.1.0 lib (test) in [..]s
+[COMPLETED] foo v0.1.0 bin \"foo\" (test) in [..]s
+[COMPLETED] foo v0.1.0 test \"t1\" (test) in [..]s
+[FINISHED] [..]
+      Timing report saved to [..]/foo/cargo-timing-[..].html
+",
+        )
+        .run();
+
+    p.cargo("clean").run();
+
+    p.cargo("test -Ztimings")
+        .masquerade_as_nightly_cargo()
+        .run();
+
+    p.cargo("clean").run();
+
+    p.cargo("check -Ztimings")
+        .masquerade_as_nightly_cargo()
+        .run();
+
+    p.cargo("clean").run();
+
+    p.cargo("doc -Ztimings").masquerade_as_nightly_cargo().run();
+}


### PR DESCRIPTION
`cargo test -Ztimings` would crash if you have any doc tests.  This is because the `Doctest` mode unit doesn't generate any artifacts, so a map lookup was failing.

This also adds a basic test just to ensure it works.
