### PR TITLE
set -Zmtime_on_use from config or ENV

### DIFF
--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -386,6 +386,7 @@ impl CliUnstable {
             "advanced-env" => self.advanced_env = true,
             "config-profile" => self.config_profile = true,
             "dual-proc-macros" => self.dual_proc_macros = true,
+            // can also be set in .cargo/config or with and ENV
             "mtime-on-use" => self.mtime_on_use = true,
             "install-upgrade" => self.install_upgrade = true,
             "cache-messages" => self.cache_messages = true,

--- a/src/cargo/util/config.rs
+++ b/src/cargo/util/config.rs
@@ -627,7 +627,7 @@ impl Config {
         self.cli_flags.parse(unstable_flags)?;
 
         if nightly_features_allowed() {
-            if let Some(val) = self.get_bool("unstable.mtime_on_use")?.map(|t| t.val) {
+            if let Some(val) = self.get::<Option<bool>>("unstable.mtime_on_use")? {
                 self.cli_flags.mtime_on_use |= val;
             }
         }

--- a/src/cargo/util/config.rs
+++ b/src/cargo/util/config.rs
@@ -23,7 +23,7 @@ use url::Url;
 use self::ConfigValue as CV;
 use crate::core::profiles::ConfigProfiles;
 use crate::core::shell::Verbosity;
-use crate::core::{CliUnstable, Shell, SourceId, Workspace};
+use crate::core::{nightly_features_allowed, CliUnstable, Shell, SourceId, Workspace};
 use crate::ops;
 use crate::util::errors::{self, internal, CargoResult, CargoResultExt};
 use crate::util::toml as cargo_toml;
@@ -625,6 +625,12 @@ impl Config {
                 .unwrap_or(false);
         self.target_dir = cli_target_dir;
         self.cli_flags.parse(unstable_flags)?;
+
+        if nightly_features_allowed() {
+            if let Some(val) = self.get_bool("unstable.mtime_on_use")?.map(|t| t.val) {
+                self.cli_flags.mtime_on_use |= val;
+            }
+        }
 
         Ok(())
     }

--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -19,6 +19,17 @@ the registry index. This is intended for tools such as Crater that issue many
 Cargo commands, and you want to avoid the network latency for updating the
 index each time.
 
+### mtime-on-use
+* Original Issue: [#6477](https://github.com/rust-lang/cargo/pull/6477)
+* Cache usage meta tracking issue: [#7150](https://github.com/rust-lang/cargo/issues/7150)
+
+The `-Z mtime-on-use` flag is an experiment to have Cargo update the mtime of 
+used files to make it easier for tools like cargo-sweep to detect which files 
+are stale. For many workflows this needs to be set on *all* invocations of cargo.
+To make this more practical setting the `unstable.mtime_on_use` flag in `.cargo/config`
+or the corresponding ENV variable will apply the `-Z mtime-on-use` to all 
+invocations of nightly cargo. (the config flag is ignored by stable)
+
 ### avoid-dev-deps
 * Original Issue: [#4988](https://github.com/rust-lang/cargo/issues/4988)
 * Stabilization Issue: [#5133](https://github.com/rust-lang/cargo/issues/5133)


### PR DESCRIPTION
This lets you set the `-Zmtime_on_use` in config, it worked for me with
```toml
[unstable]
mtime_on_use=true
```
I did not find the ENV that would allow work. Suggestions?
Does this need tests?

Closes: #6978