### PR TITLE
Go back to not hashing `RUSTFLAGS` in `-Cmetadata`

### DIFF
--- a/src/cargo/core/compiler/context/compilation_files.rs
+++ b/src/cargo/core/compiler/context/compilation_files.rs
@@ -541,36 +541,6 @@ fn compute_metadata<'a, 'cfg>(
     unit.profile.hash(&mut hasher);
     unit.mode.hash(&mut hasher);
 
-    // Throw in the rustflags we're compiling with.
-    // This helps when the target directory is a shared cache for projects with different cargo configs,
-    // or if the user is experimenting with different rustflags manually.
-    let mut hash_flags = |flags: &[String]| {
-        // Ignore some flags. These may affect reproducible builds if they affect
-        // the path. The fingerprint will handle recompilation if these change.
-        let mut iter = flags.iter();
-        while let Some(flag) = iter.next() {
-            if flag.starts_with("--remap-path-prefix=") {
-                continue;
-            }
-            if flag == "--remap-path-prefix" {
-                iter.next();
-                continue;
-            }
-            flag.hash(&mut hasher);
-        }
-    };
-    if let Some(args) = bcx.extra_args_for(unit) {
-        // Arguments passed to `cargo rustc`.
-        hash_flags(args);
-    }
-    // Arguments passed in via RUSTFLAGS env var.
-    let flags = if unit.mode.is_doc() {
-        bcx.rustdocflags_args(unit)
-    } else {
-        bcx.rustflags_args(unit)
-    };
-    hash_flags(flags);
-
     // Artifacts compiled for the host should have a different metadata
     // piece than those compiled for the target, so make sure we throw in
     // the unit's `kind` as well

--- a/src/cargo/core/compiler/fingerprint.rs
+++ b/src/cargo/core/compiler/fingerprint.rs
@@ -59,7 +59,7 @@
 //! Target flags (test/bench/for_host/edition) | ✓           |
 //! -C incremental=… flag                      | ✓           |
 //! mtime of sources                           | ✓[^3]       |
-//! RUSTFLAGS/RUSTDOCFLAGS                     | ✓           | ✓
+//! RUSTFLAGS/RUSTDOCFLAGS                     | ✓           |
 //!
 //! [^1]: Build script and bin dependencies are not included.
 //!


### PR DESCRIPTION
This is a moral revert of #6503 but not a literal code revert. This
switches Cargo's behavior to avoid hashing compiler flags into
`-Cmetadata` since we've now had multiple requests of excluding flags
from the `-Cmetadata` hash: usage of `--remap-path-prefix` and PGO
options. These options should only affect how the compiler is
invoked/compiled and not radical changes such as symbol names, but
symbol names are changed based on `-Cmetadata`. Instead Cargo will still
track these flags internally, but only for reinvoking rustc, and not for
caching separately based on rustc flags.

Closes #7416