### PR TITLE
Fix interpretation of `--features a b` on the CLI

### DIFF
--- a/src/cargo/util/command_prelude.rs
+++ b/src/cargo/util/command_prelude.rs
@@ -100,11 +100,11 @@ pub trait AppExt: Sized {
     }
 
     fn arg_features(self) -> Self {
-        self._arg(
-            opt("features", "Space-separated list of features to activate")
-                .multiple(true)
-                .value_name("FEATURES"),
-        )
+        self._arg(multi_opt(
+            "features",
+            "FEATURES",
+            "Space-separated list of features to activate",
+        ))
         ._arg(opt("all-features", "Activate all available features"))
         ._arg(opt(
             "no-default-features",

--- a/tests/testsuite/features.rs
+++ b/tests/testsuite/features.rs
@@ -1959,3 +1959,32 @@ fn multi_multi_features() {
 
     p.cargo("build --features a --features").arg("b c").run();
 }
+
+#[cargo_test]
+fn cli_parse_ok() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+
+                [features]
+                a = []
+            "#,
+        )
+        .file(
+            "src/main.rs",
+            r#"
+               #[cfg(feature = "a")]
+               fn main() {
+                    assert_eq!(std::env::args().nth(1).unwrap(), "b");
+               }
+            "#,
+        )
+        .build();
+
+    p.cargo("run --features a b").run();
+}


### PR DESCRIPTION
Fixes an accidental regression from #7084 where `--features a b` was
erroneously mistinterpreted as `--features "a b"`.

Closes #7418