### PR TITLE
Don't ever capture CPU state if timings are disabled

### DIFF
--- a/src/cargo/core/compiler/timings.rs
+++ b/src/cargo/core/compiler/timings.rs
@@ -138,7 +138,7 @@ impl<'a, 'cfg> Timings<'a, 'cfg> {
             unit_times: Vec::new(),
             active: HashMap::new(),
             concurrency: Vec::new(),
-            last_cpu_state: State::current().ok(),
+            last_cpu_state: if enabled { State::current().ok() } else { None },
             last_cpu_recording: Instant::now(),
             cpu_usage: Vec::new(),
         }


### PR DESCRIPTION
This should initially help with the panic in #7427 but doesn't solve it.