### PR TITLE
add dependencies for `pkg-config`

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Cargo requires the following tools and packages to build:
 * `git`
 * `python`
 * `curl` (on Unix)
+* `pkg-config` (on Unix, used to figure out the `libssl` headers/libraries)
 * OpenSSL headers (only for Unix, this is the `libssl-dev` package on ubuntu)
 * `cargo` and `rustc`
 


### PR DESCRIPTION
Otherwise, it complains:

    run pkg_config fail: "Failed to run `\"pkg-config\" \"--libs\" \"--cflags\" \"openssl\"`: No such file or directory (os error 2)"