### PR TITLE
Improve test output with `--quiet`

### DIFF
--- a/src/cargo/util/network.rs
+++ b/src/cargo/util/network.rs
@@ -92,8 +92,11 @@ where
         }
     }
 }
+
 #[test]
 fn with_retry_repeats_the_call_then_works() {
+    use crate::core::Shell;
+
     //Error HTTP codes (5xx) are considered maybe_spurious and will prompt retry
     let error1 = HttpNot200 {
         code: 501,
@@ -107,12 +110,15 @@ fn with_retry_repeats_the_call_then_works() {
     .into();
     let mut results: Vec<CargoResult<()>> = vec![Ok(()), Err(error1), Err(error2)];
     let config = Config::default().unwrap();
+    *config.shell() = Shell::from_write(Box::new(Vec::new()));
     let result = with_retry(&config, || results.pop().unwrap());
     assert_eq!(result.unwrap(), ())
 }
 
 #[test]
 fn with_retry_finds_nested_spurious_errors() {
+    use crate::core::Shell;
+
     //Error HTTP codes (5xx) are considered maybe_spurious and will prompt retry
     //String error messages are not considered spurious
     let error1 = failure::Error::from(HttpNot200 {
@@ -127,6 +133,7 @@ fn with_retry_finds_nested_spurious_errors() {
     let error2 = failure::Error::from(error2.context("A second chained error"));
     let mut results: Vec<CargoResult<()>> = vec![Ok(()), Err(error1), Err(error2)];
     let config = Config::default().unwrap();
+    *config.shell() = Shell::from_write(Box::new(Vec::new()));
     let result = with_retry(&config, || results.pop().unwrap());
     assert_eq!(result.unwrap(), ())
 }

--- a/tests/testsuite/member_errors.rs
+++ b/tests/testsuite/member_errors.rs
@@ -143,7 +143,11 @@ fn member_manifest_version_error() {
 
     // Prevent this test from accessing the network by setting up .cargo/config.
     registry::init();
-    let config = Config::new(Shell::new(), cargo_home(), cargo_home());
+    let config = Config::new(
+        Shell::from_write(Box::new(Vec::new())),
+        cargo_home(),
+        cargo_home(),
+    );
     let ws = Workspace::new(&p.root().join("Cargo.toml"), &config).unwrap();
     let compile_options = CompileOptions::new(&config, CompileMode::Build).unwrap();
     let member_bar = ws.members().find(|m| &*m.name() == "bar").unwrap();

--- a/tests/testsuite/new.rs
+++ b/tests/testsuite/new.rs
@@ -264,7 +264,7 @@ fn finds_author_git() {
 
 #[cargo_test]
 fn finds_local_author_git() {
-    git_process("init").exec().unwrap();
+    git_process("init").exec_with_output().unwrap();
     git_process("config --global user.name foo").exec().unwrap();
     git_process("config --global user.email foo@bar")
         .exec()

--- a/tests/testsuite/search.rs
+++ b/tests/testsuite/search.rs
@@ -107,7 +107,11 @@ fn not_update() {
     use cargo::util::Config;
 
     let sid = SourceId::for_registry(&registry_url()).unwrap();
-    let cfg = Config::new(Shell::new(), paths::root(), paths::home().join(".cargo"));
+    let cfg = Config::new(
+        Shell::from_write(Box::new(Vec::new())),
+        paths::root(),
+        paths::home().join(".cargo"),
+    );
     let lock = cfg.acquire_package_cache_lock().unwrap();
     let mut regsrc = RegistrySource::remote(sid, &HashSet::new(), &cfg);
     regsrc.update().unwrap();


### PR DESCRIPTION
We had a few locations where the shell was written to raw instead of
through the test harness or through other captured mechanisms. This
updates the test suite so testing Cargo with `--quiet` provides a nice
and clean report of tests executed.