### PR TITLE
Allow gitignore of Cargo.lock with explicit `include`.

### DIFF
--- a/src/cargo/ops/cargo_package.rs
+++ b/src/cargo/ops/cargo_package.rs
@@ -290,7 +290,16 @@ fn check_repo_state(
             .filter(|file| {
                 let relative = file.strip_prefix(workdir).unwrap();
                 if let Ok(status) = repo.status_file(relative) {
-                    status != git2::Status::CURRENT
+                    if status == git2::Status::CURRENT {
+                        false
+                    } else {
+                        if relative.to_str().unwrap_or("") == "Cargo.lock" {
+                            // It is OK to include this file even if it is ignored.
+                            status != git2::Status::IGNORED
+                        } else {
+                            true
+                        }
+                    }
                 } else {
                     submodule_dirty(file)
                 }


### PR DESCRIPTION
If a package has an `include` list, but `Cargo.lock` is in `.gitignore`, then Cargo would complain that `Cargo.lock` is "dirty".  This changes it so that ignored `Cargo.lock` is allowed, even though it is still packaged.  This is under the presumption that `Cargo.lock` is machine generated, so it is not critical.  This was also an unexpected regression.

If you don't have an `include` list, then there is no complaint about `Cargo.lock` being dirty because Cargo uses git to deduce the file list, and `Cargo.lock` would be skipped for the dirty check (but still included in the package).

Closes #7319