### PR TITLE
unify the quote in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,13 +25,13 @@ cargo-platform = { path = "crates/cargo-platform", version = "0.1" }
 crates-io = { path = "crates/crates-io", version = "0.29" }
 crossbeam-utils = "0.6"
 crypto-hash = "0.3.1"
-curl = { version = "0.4.23", features = ['http2'] }
+curl = { version = "0.4.23", features = ["http2"] }
 curl-sys = "0.4.21"
 env_logger = "0.7.0"
 pretty_env_logger = { version = "0.3", optional = true }
 failure = "0.1.5"
 filetime = "0.2"
-flate2 = { version = "1.0.3", features = ['zlib'] }
+flate2 = { version = "1.0.3", features = ["zlib"] }
 fs2 = "0.4"
 git2 = "0.10.0"
 git2-curl = "0.11.0"
@@ -54,7 +54,7 @@ remove_dir_all = "0.5.2"
 rustfix = "0.4.6"
 same-file = "1"
 semver = { version = "0.9.0", features = ["serde"] }
-serde = { version = "1.0.82", features = ['derive'] }
+serde = { version = "1.0.82", features = ["derive"] }
 serde_ignored = "0.1.0"
 serde_json = { version = "1.0.30", features = ["raw_value"] }
 shell-escape = "0.1.4"
@@ -114,5 +114,5 @@ doc = false
 
 [features]
 deny-warnings = []
-vendored-openssl = ['openssl/vendored']
-pretty-env-logger = ['pretty_env_logger']
+vendored-openssl = ["openssl/vendored"]
+pretty-env-logger = ["pretty_env_logger"]


### PR DESCRIPTION
A bit nit-picked...

It tries to use double-quotes in Cargo.toml instead of single quote, that would be more uniform in this file.