### PR TITLE
Update `curl-sys` dependency requirement

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ crates-io = { path = "crates/crates-io", version = "0.29" }
 crossbeam-utils = "0.6"
 crypto-hash = "0.3.1"
 curl = { version = "0.4.23", features = ["http2"] }
-curl-sys = "0.4.21"
+curl-sys = "0.4.22"
 env_logger = "0.7.0"
 pretty_env_logger = { version = "0.3", optional = true }
 failure = "0.1.5"


### PR DESCRIPTION
Pulls in alexcrichton/curl-rust#304 which fixes a bug from the last curl
update in #7308. This bug was not introduced by the Cargo PR itself but
rather by updating the `curl` submodule in the `curl-sys` crate. Without
this bugfix all downloads of a crate will make a new connection to
crates.io, which drastically increases download time since setting up a
connection takes so long.