### PR TITLE
Disable preserving mtimes on archives

### DIFF
--- a/src/cargo/sources/registry/mod.rs
+++ b/src/cargo/sources/registry/mod.rs
@@ -463,6 +463,7 @@ impl<'cfg> RegistrySource<'cfg> {
 
         let gz = GzDecoder::new(tarball);
         let mut tar = Archive::new(gz);
+        tar.set_preserve_mtime(false);
         let prefix = unpack_dir.file_name().unwrap();
         let parent = unpack_dir.parent().unwrap();
         for entry in tar.entries()? {


### PR DESCRIPTION
These are just wasted syscalls for our purposes, no need to issue
updates to the modification/creation/access times of files we unpack!