### PR TITLE
Mark Emscripten's .wasm files auxiliary

### DIFF
--- a/src/cargo/core/compiler/build_context/target_info.rs
+++ b/src/cargo/core/compiler/build_context/target_info.rs
@@ -255,15 +255,10 @@ impl TargetInfo {
 
         // See rust-lang/cargo#4535.
         if target_triple.starts_with("wasm32-") && crate_type == "bin" && suffix == ".js" {
-            let flavor = if target_triple.contains("emscripten") {
-                FileFlavor::Auxiliary
-            } else {
-                FileFlavor::Normal
-            };
             ret.push(FileType {
                 suffix: ".wasm".to_string(),
                 prefix: prefix.clone(),
-                flavor,
+                flavor: FileFlavor::Auxiliary,
                 should_replace_hyphens: true,
             })
         }

--- a/src/cargo/core/compiler/build_context/target_info.rs
+++ b/src/cargo/core/compiler/build_context/target_info.rs
@@ -42,6 +42,8 @@ pub struct TargetInfo {
 pub enum FileFlavor {
     /// Not a special file type.
     Normal,
+    /// Like `Normal`, but not directly executable
+    Auxiliary,
     /// Something you can link against (e.g., a library).
     Linkable { rmeta: bool },
     /// Piece of external debug information (e.g., `.dSYM`/`.pdb` file).
@@ -253,10 +255,15 @@ impl TargetInfo {
 
         // See rust-lang/cargo#4535.
         if target_triple.starts_with("wasm32-") && crate_type == "bin" && suffix == ".js" {
+            let flavor = if target_triple.contains("emscripten") {
+                FileFlavor::Auxiliary
+            } else {
+                FileFlavor::Normal
+            };
             ret.push(FileType {
                 suffix: ".wasm".to_string(),
                 prefix: prefix.clone(),
-                flavor: FileFlavor::Normal,
+                flavor,
                 should_replace_hyphens: true,
             })
         }

--- a/src/cargo/core/compiler/context/mod.rs
+++ b/src/cargo/core/compiler/context/mod.rs
@@ -167,8 +167,8 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
 
         for unit in units.iter() {
             for output in self.outputs(unit)?.iter() {
-                if output.flavor == FileFlavor::DebugInfo ||
-                    output.flavor == FileFlavor::Auxiliary {
+                if output.flavor == FileFlavor::DebugInfo || output.flavor == FileFlavor::Auxiliary
+                {
                     continue;
                 }
 

--- a/src/cargo/core/compiler/context/mod.rs
+++ b/src/cargo/core/compiler/context/mod.rs
@@ -167,7 +167,8 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
 
         for unit in units.iter() {
             for output in self.outputs(unit)?.iter() {
-                if output.flavor == FileFlavor::DebugInfo {
+                if output.flavor == FileFlavor::DebugInfo ||
+                    output.flavor == FileFlavor::Auxiliary {
                     continue;
                 }
 


### PR DESCRIPTION
This fixes #7471 and fixes #7255 by preventing the .wasm file from
being treated as an executable binary, so `cargo test` and `cargo run`
will no longer try to execute it directly. This change is only made
for Emscripten, which outputs a .js file as the primary executable
entry point, as opposed to other WebAssembly targets for which the
.wasm file is the only output.