### PR TITLE
when -Z unstable-options not specified, don't validate --profile

### DIFF
--- a/src/cargo/util/command_prelude.rs
+++ b/src/cargo/util/command_prelude.rs
@@ -322,14 +322,22 @@ pub trait ArgMatchesExt {
         }
 
         if self._is_present("release") {
-            match specified_profile {
-                None | Some(ProfileKind::Release) => Ok(ProfileKind::Release),
-                _ => failure::bail!("Conflicting usage of --profile and --release"),
+            if !config.cli_unstable().unstable_options {
+                Ok(ProfileKind::Release)
+            } else {
+                match specified_profile {
+                    None | Some(ProfileKind::Release) => Ok(ProfileKind::Release),
+                    _ => failure::bail!("Conflicting usage of --profile and --release"),
+                }
             }
         } else if self._is_present("debug") {
-            match specified_profile {
-                None | Some(ProfileKind::Dev) => Ok(ProfileKind::Dev),
-                _ => failure::bail!("Conflicting usage of --profile and --debug"),
+            if !config.cli_unstable().unstable_options {
+                Ok(ProfileKind::Dev)
+            } else {
+                match specified_profile {
+                    None | Some(ProfileKind::Dev) => Ok(ProfileKind::Dev),
+                    _ => failure::bail!("Conflicting usage of --profile and --debug"),
+                }
             }
         } else {
             Ok(specified_profile.unwrap_or(default))

--- a/tests/testsuite/check.rs
+++ b/tests/testsuite/check.rs
@@ -337,8 +337,10 @@ fn rustc_check() {
     foo.cargo("rustc --profile check -- --emit=metadata").run();
 
     // Verify compatible usage of --profile with --release, issue #7488
-    foo.cargo("rustc --profile check --release -- --emit=metadata").run();
-    foo.cargo("rustc --profile test --release -- --emit=metadata").run();
+    foo.cargo("rustc --profile check --release -- --emit=metadata")
+        .run();
+    foo.cargo("rustc --profile test --release -- --emit=metadata")
+        .run();
 }
 
 #[cargo_test]

--- a/tests/testsuite/check.rs
+++ b/tests/testsuite/check.rs
@@ -335,6 +335,10 @@ fn rustc_check() {
         .build();
 
     foo.cargo("rustc --profile check -- --emit=metadata").run();
+
+    // Verify compatible usage of --profile with --release, issue #7488
+    foo.cargo("rustc --profile check --release -- --emit=metadata").run();
+    foo.cargo("rustc --profile test --release -- --emit=metadata").run();
 }
 
 #[cargo_test]


### PR DESCRIPTION
This fixes a regression caused by 8b0561d68f12 - Closes #7488.