### PR TITLE
Rename `overrides` to `package` in profiles.

### DIFF
--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -23,11 +23,11 @@ index each time.
 * Original Issue: [#6477](https://github.com/rust-lang/cargo/pull/6477)
 * Cache usage meta tracking issue: [#7150](https://github.com/rust-lang/cargo/issues/7150)
 
-The `-Z mtime-on-use` flag is an experiment to have Cargo update the mtime of 
-used files to make it easier for tools like cargo-sweep to detect which files 
+The `-Z mtime-on-use` flag is an experiment to have Cargo update the mtime of
+used files to make it easier for tools like cargo-sweep to detect which files
 are stale. For many workflows this needs to be set on *all* invocations of cargo.
 To make this more practical setting the `unstable.mtime_on_use` flag in `.cargo/config`
-or the corresponding ENV variable will apply the `-Z mtime-on-use` to all 
+or the corresponding ENV variable will apply the `-Z mtime-on-use` to all
 invocations of nightly cargo. (the config flag is ignored by stable)
 
 ### avoid-dev-deps
@@ -104,12 +104,12 @@ opt-level = 0
 debug = true
 
 # the `image` crate will be compiled with -Copt-level=3
-[profile.dev.overrides.image]
+[profile.dev.package.image]
 opt-level = 3
 
 # All dependencies (but not this crate itself or any workspace member)
 # will be compiled with -Copt-level=2 . This includes build dependencies.
-[profile.dev.overrides."*"]
+[profile.dev.package."*"]
 opt-level = 2
 
 # Build scripts or proc-macros and their dependencies will be compiled with

--- a/tests/testsuite/config.rs
+++ b/tests/testsuite/config.rs
@@ -302,7 +302,7 @@ incremental = true
 [profile.dev.build-override]
 opt-level = 1
 
-[profile.dev.overrides.bar]
+[profile.dev.package.bar]
 codegen-units = 9
 
 [profile.no-lto]
@@ -315,26 +315,26 @@ lto = false
     let config = new_config(&[
         ("CARGO_PROFILE_DEV_CODEGEN_UNITS", "5"),
         ("CARGO_PROFILE_DEV_BUILD_OVERRIDE_CODEGEN_UNITS", "11"),
-        ("CARGO_PROFILE_DEV_OVERRIDES_env_CODEGEN_UNITS", "13"),
-        ("CARGO_PROFILE_DEV_OVERRIDES_bar_OPT_LEVEL", "2"),
+        ("CARGO_PROFILE_DEV_PACKAGE_env_CODEGEN_UNITS", "13"),
+        ("CARGO_PROFILE_DEV_PACKAGE_bar_OPT_LEVEL", "2"),
     ]);
 
     // TODO: don't use actual `tomlprofile`.
     let p: toml::TomlProfile = config.get("profile.dev").unwrap();
-    let mut overrides = collections::BTreeMap::new();
+    let mut packages = collections::BTreeMap::new();
     let key = toml::ProfilePackageSpec::Spec(::cargo::core::PackageIdSpec::parse("bar").unwrap());
     let o_profile = toml::TomlProfile {
         opt_level: Some(toml::TomlOptLevel("2".to_string())),
         codegen_units: Some(9),
         ..Default::default()
     };
-    overrides.insert(key, o_profile);
+    packages.insert(key, o_profile);
     let key = toml::ProfilePackageSpec::Spec(::cargo::core::PackageIdSpec::parse("env").unwrap());
     let o_profile = toml::TomlProfile {
         codegen_units: Some(13),
         ..Default::default()
     };
-    overrides.insert(key, o_profile);
+    packages.insert(key, o_profile);
 
     assert_eq!(
         p,
@@ -348,7 +348,7 @@ lto = false
             panic: Some("abort".to_string()),
             overflow_checks: Some(true),
             incremental: Some(true),
-            overrides: Some(overrides),
+            package: Some(packages),
             build_override: Some(Box::new(toml::TomlProfile {
                 opt_level: Some(toml::TomlOptLevel("1".to_string())),
                 codegen_units: Some(11),

--- a/tests/testsuite/profile_config.rs
+++ b/tests/testsuite/profile_config.rs
@@ -53,7 +53,7 @@ fn profile_config_validate_warnings() {
             [profile.dev.build-override]
             bad-key-bo = true
 
-            [profile.dev.overrides.bar]
+            [profile.dev.package.bar]
             bad-key-bar = true
         "#,
         )
@@ -66,7 +66,7 @@ fn profile_config_validate_warnings() {
 [WARNING] unused key `profile.asdf` in config file `[..].cargo/config`
 [WARNING] unused key `profile.test` in config file `[..].cargo/config`
 [WARNING] unused key `profile.dev.bad-key` in config file `[..].cargo/config`
-[WARNING] unused key `profile.dev.overrides.bar.bad-key-bar` in config file `[..].cargo/config`
+[WARNING] unused key `profile.dev.package.bar.bad-key-bar` in config file `[..].cargo/config`
 [WARNING] unused key `profile.dev.build-override.bad-key-bo` in config file `[..].cargo/config`
 [COMPILING] foo [..]
 [FINISHED] [..]
@@ -127,7 +127,7 @@ fn profile_config_validate_errors() {
         .file(
             ".cargo/config",
             r#"
-            [profile.dev.overrides.foo]
+            [profile.dev.package.foo]
             panic = "abort"
         "#,
         )
@@ -141,7 +141,7 @@ fn profile_config_validate_errors() {
 [ERROR] config profile `profile.dev` is not valid
 
 Caused by:
-  `panic` may not be specified in a profile override.
+  `panic` may not be specified in a `package` profile
 ",
         )
         .run();
@@ -194,10 +194,10 @@ fn profile_config_override_spec_multiple() {
         .file(
             ".cargo/config",
             r#"
-            [profile.dev.overrides.bar]
+            [profile.dev.package.bar]
             opt-level = 3
 
-            [profile.dev.overrides."bar:0.5.0"]
+            [profile.dev.package."bar:0.5.0"]
             opt-level = 3
         "#,
         )
@@ -222,8 +222,8 @@ fn profile_config_override_spec_multiple() {
         .with_status(101)
         .with_stderr(
             "\
-[ERROR] multiple profile overrides in profile `dev` match package `bar v0.5.0 ([..])`
-found profile override specs: bar, bar:0.5.0",
+[ERROR] multiple package overrides in profile `dev` match package `bar v0.5.0 ([..])`
+found package specs: bar, bar:0.5.0",
         )
         .run();
 }
@@ -291,7 +291,7 @@ fn profile_config_override_precedence() {
             [profile.dev]
             codegen-units = 2
 
-            [profile.dev.overrides.bar]
+            [profile.dev.package.bar]
             opt-level = 3
         "#,
         )
@@ -310,7 +310,7 @@ fn profile_config_override_precedence() {
         .file(
             ".cargo/config",
             r#"
-            [profile.dev.overrides.bar]
+            [profile.dev.package.bar]
             opt-level = 2
         "#,
         )
@@ -346,7 +346,7 @@ fn profile_config_no_warn_unknown_override() {
         .file(
             ".cargo/config",
             r#"
-            [profile.dev.overrides.bar]
+            [profile.dev.package.bar]
             codegen-units = 4
         "#,
         )

--- a/tests/testsuite/profile_custom.rs
+++ b/tests/testsuite/profile_custom.rs
@@ -296,16 +296,16 @@ fn overrides_with_custom() {
             [profile.dev]
             codegen-units = 7
 
-            [profile.dev.overrides.xxx]
+            [profile.dev.package.xxx]
             codegen-units = 5
-            [profile.dev.overrides.yyy]
+            [profile.dev.package.yyy]
             codegen-units = 3
 
             [profile.other]
             inherits = "dev"
             codegen-units = 2
 
-            [profile.other.overrides.yyy]
+            [profile.other.package.yyy]
             codegen-units = 6
         "#,
         )


### PR DESCRIPTION
Renaming per the discussion at https://github.com/rust-lang/rust/issues/48683#issuecomment-488842694.

I left backwards-compatibility in case anyone is using it, since it required very little effort.

cc @da-x, FYI.
