### PR TITLE
Reject feature flags in a virtual workspace.

### DIFF
--- a/src/cargo/util/command_prelude.rs
+++ b/src/cargo/util/command_prelude.rs
@@ -283,6 +283,16 @@ pub trait ArgMatchesExt {
         if config.cli_unstable().avoid_dev_deps {
             ws.set_require_optional_deps(false);
         }
+        if ws.is_virtual() && !config.cli_unstable().package_features {
+            for flag in &["features", "all-features", "no-default-features"] {
+                if self._is_present(flag) {
+                    bail!(
+                        "--{} is not allowed in the root of a virtual workspace",
+                        flag
+                    );
+                }
+            }
+        }
         Ok(ws)
     }
 


### PR DESCRIPTION
This generates an error if feature flags are used in the root of a virtual workspace. Previously these flags were completely ignored.  In the interest of avoiding confusion, I think it would be good to be explicit that these don't currently work.  This could alternatively be a warning, but I think it is better to reject it outright.

cc #4753, #3620, #5015, #6195, etc.