### PR TITLE
Fix typo in git index initialization error path

### DIFF
--- a/src/cargo/sources/registry/remote.rs
+++ b/src/cargo/sources/registry/remote.rs
@@ -77,7 +77,7 @@ impl<'cfg> RemoteRegistry<'cfg> {
                     let mut opts = git2::RepositoryInitOptions::new();
                     opts.external_template(false);
                     Ok(git2::Repository::init_opts(&path, &opts)
-                        .chain_err(|| "failed to initialized index git repository")?)
+                        .chain_err(|| "failed to initialize index git repository")?)
                 }
             }
         })


### PR DESCRIPTION
This PR proposes a fix for a small typo I ran into while using `cargo`.