### PR TITLE
don't download std-docs on CI

### DIFF
--- a/ci/azure-install-rust.yml
+++ b/ci/azure-install-rust.yml
@@ -18,7 +18,7 @@ steps:
       set -e
       rustup set profile minimal
       rustup component remove --toolchain=$TOOLCHAIN rust-docs || echo "already removed"
-      rustup update $TOOLCHAIN
+      rustup update --no-self-update $TOOLCHAIN
       rustup default $TOOLCHAIN
     displayName: Install rust
 

--- a/ci/azure-install-rust.yml
+++ b/ci/azure-install-rust.yml
@@ -15,7 +15,9 @@ steps:
       rustup set profile minimal
       rustup component remove --toolchain=$TOOLCHAIN rust-docs || echo "already removed"
       rustup update --no-self-update $TOOLCHAIN
-      rustup component add --toolchain=$TOOLCHAIN rustc-dev
+      if [ "$TOOLCHAIN" = "nightly" ]; then
+        rustup component add --toolchain=$TOOLCHAIN rustc-dev
+      fi
       rustup default $TOOLCHAIN
     displayName: Install rust
 

--- a/ci/azure-install-rust.yml
+++ b/ci/azure-install-rust.yml
@@ -15,6 +15,7 @@ steps:
       rustup set profile minimal
       rustup component remove --toolchain=$TOOLCHAIN rust-docs || echo "already removed"
       rustup update --no-self-update $TOOLCHAIN
+      rustup component add --toolchain=$TOOLCHAIN rustc-dev
       rustup default $TOOLCHAIN
     displayName: Install rust
 

--- a/ci/azure-install-rust.yml
+++ b/ci/azure-install-rust.yml
@@ -17,6 +17,7 @@ steps:
   - bash: |
       set -e
       rustup set profile minimal
+      rustup component remove --toolchain=$TOOLCHAIN rust-docs || echo "already removed"
       rustup update $TOOLCHAIN
       rustup default $TOOLCHAIN
     displayName: Install rust

--- a/ci/azure-install-rust.yml
+++ b/ci/azure-install-rust.yml
@@ -4,7 +4,6 @@ steps:
       if command -v rustup; then
         echo `command -v rustup` `rustup -V` already installed
         rustup self update
-        rustup set profile minimal
       elif [ "$AGENT_OS" = "Windows_NT" ]; then
         curl -sSf -o rustup-init.exe https://win.rustup.rs
         rustup-init.exe -y --default-toolchain $TOOLCHAIN --profile=minimal
@@ -17,6 +16,7 @@ steps:
 
   - bash: |
       set -e
+      rustup set profile minimal
       rustup update $TOOLCHAIN
       rustup default $TOOLCHAIN
     displayName: Install rust

--- a/ci/azure-install-rust.yml
+++ b/ci/azure-install-rust.yml
@@ -4,12 +4,8 @@ steps:
       if command -v rustup; then
         echo `command -v rustup` `rustup -V` already installed
         rustup self update
-      elif [ "$AGENT_OS" = "Windows_NT" ]; then
-        curl -sSf -o rustup-init.exe https://win.rustup.rs
-        rustup-init.exe -y --default-toolchain $TOOLCHAIN --profile=minimal
-        echo "##vso[task.prependpath]$USERPROFILE/.cargo/bin"
       else
-        curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain $TOOLCHAIN --profile=minimal
+        curl -sSL https://sh.rustup.rs | sh -s -- -y --default-toolchain="$TOOLCHAIN" --profile=minimal
         echo "##vso[task.prependpath]$HOME/.cargo/bin"
       fi
     displayName: Install rustup

--- a/ci/azure-install-rust.yml
+++ b/ci/azure-install-rust.yml
@@ -4,12 +4,13 @@ steps:
       if command -v rustup; then
         echo `command -v rustup` `rustup -V` already installed
         rustup self update
+        rustup set profile minimal
       elif [ "$AGENT_OS" = "Windows_NT" ]; then
         curl -sSf -o rustup-init.exe https://win.rustup.rs
-        rustup-init.exe -y --default-toolchain $TOOLCHAIN
+        rustup-init.exe -y --default-toolchain $TOOLCHAIN --profile=minimal
         echo "##vso[task.prependpath]$USERPROFILE/.cargo/bin"
       else
-        curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain $TOOLCHAIN
+        curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain $TOOLCHAIN --profile=minimal
         echo "##vso[task.prependpath]$HOME/.cargo/bin"
       fi
     displayName: Install rustup


### PR DESCRIPTION
Now that we have a way to do it, lets not download std-docs on CI. Based on the blog post:
https://blog.rust-lang.org/2019/10/15/Rustup-1.20.0.html