### PR TITLE
Set timestamp on generated files in archive to now

### DIFF
--- a/src/cargo/ops/cargo_package.rs
+++ b/src/cargo/ops/cargo_package.rs
@@ -1,4 +1,5 @@
 use std::collections::{BTreeSet, HashMap};
+use std::fmt::Display;
 use std::fs::{self, File};
 use std::io::prelude::*;
 use std::io::SeekFrom;
@@ -8,6 +9,7 @@ use std::sync::Arc;
 use std::time::SystemTime;
 
 use flate2::read::GzDecoder;
+use flate2::write::GzEncoder;
 use flate2::{Compression, GzBuilder};
 use log::debug;
 use serde_json::{self, json};
@@ -439,22 +441,8 @@ fn tar(
                 internal(format!("could not archive source file `{}`", relative_str))
             })?;
 
-            let mut header = Header::new_ustar();
             let toml = pkg.to_registry_toml(ws.config())?;
-            header.set_path(&path)?;
-            header.set_entry_type(EntryType::file());
-            header.set_mode(0o644);
-            header.set_mtime(
-                SystemTime::now()
-                    .duration_since(SystemTime::UNIX_EPOCH)
-                    .unwrap()
-                    .as_secs(),
-            );
-            header.set_size(toml.len() as u64);
-            header.set_cksum();
-            ar.append(&header, toml.as_bytes()).chain_err(|| {
-                internal(format!("could not archive source file `{}`", relative_str))
-            })?;
+            add_generated_file(&mut ar, &path, &toml, relative_str)?;
         } else {
             header.set_cksum();
             ar.append(&header, &mut file).chain_err(|| {
@@ -482,20 +470,7 @@ fn tar(
             .set_path(&path)
             .chain_err(|| format!("failed to add to archive: `{}`", fnd))?;
         let json = format!("{}\n", serde_json::to_string_pretty(json)?);
-        let mut header = Header::new_ustar();
-        header.set_path(&path)?;
-        header.set_entry_type(EntryType::file());
-        header.set_mode(0o644);
-        header.set_mtime(
-            SystemTime::now()
-                .duration_since(SystemTime::UNIX_EPOCH)
-                .unwrap()
-                .as_secs(),
-        );
-        header.set_size(json.len() as u64);
-        header.set_cksum();
-        ar.append(&header, json.as_bytes())
-            .chain_err(|| internal(format!("could not archive source file `{}`", fnd)))?;
+        add_generated_file(&mut ar, &path, &json, fnd)?;
     }
 
     if pkg.include_lockfile() {
@@ -510,20 +485,7 @@ fn tar(
             pkg.version(),
             path::MAIN_SEPARATOR
         );
-        let mut header = Header::new_ustar();
-        header.set_path(&path)?;
-        header.set_entry_type(EntryType::file());
-        header.set_mode(0o644);
-        header.set_mtime(
-            SystemTime::now()
-                .duration_since(SystemTime::UNIX_EPOCH)
-                .unwrap()
-                .as_secs(),
-        );
-        header.set_size(new_lock.len() as u64);
-        header.set_cksum();
-        ar.append(&header, new_lock.as_bytes())
-            .chain_err(|| internal("could not archive source file `Cargo.lock`"))?;
+        add_generated_file(&mut ar, &path, &new_lock, "Cargo.lock")?;
     }
 
     let encoder = ar.into_inner()?;
@@ -803,5 +765,28 @@ fn check_filename(file: &Path) -> CargoResult<()> {
             file.display()
         )
     }
+    Ok(())
+}
+
+fn add_generated_file<D: Display>(
+    ar: &mut Builder<GzEncoder<&File>>,
+    path: &str,
+    data: &str,
+    display: D,
+) -> CargoResult<()> {
+    let mut header = Header::new_ustar();
+    header.set_path(path)?;
+    header.set_entry_type(EntryType::file());
+    header.set_mode(0o644);
+    header.set_mtime(
+        SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap()
+            .as_secs(),
+    );
+    header.set_size(data.len() as u64);
+    header.set_cksum();
+    ar.append(&header, data.as_bytes())
+        .chain_err(|| internal(format!("could not archive source file `{}`", display)))?;
     Ok(())
 }

--- a/src/cargo/ops/cargo_package.rs
+++ b/src/cargo/ops/cargo_package.rs
@@ -5,6 +5,7 @@ use std::io::SeekFrom;
 use std::path::{self, Path, PathBuf};
 use std::rc::Rc;
 use std::sync::Arc;
+use std::time::SystemTime;
 
 use flate2::read::GzDecoder;
 use flate2::{Compression, GzBuilder};
@@ -443,6 +444,12 @@ fn tar(
             header.set_path(&path)?;
             header.set_entry_type(EntryType::file());
             header.set_mode(0o644);
+            header.set_mtime(
+                SystemTime::now()
+                    .duration_since(SystemTime::UNIX_EPOCH)
+                    .unwrap()
+                    .as_secs(),
+            );
             header.set_size(toml.len() as u64);
             header.set_cksum();
             ar.append(&header, toml.as_bytes()).chain_err(|| {
@@ -479,6 +486,12 @@ fn tar(
         header.set_path(&path)?;
         header.set_entry_type(EntryType::file());
         header.set_mode(0o644);
+        header.set_mtime(
+            SystemTime::now()
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .unwrap()
+                .as_secs(),
+        );
         header.set_size(json.len() as u64);
         header.set_cksum();
         ar.append(&header, json.as_bytes())
@@ -501,6 +514,12 @@ fn tar(
         header.set_path(&path)?;
         header.set_entry_type(EntryType::file());
         header.set_mode(0o644);
+        header.set_mtime(
+            SystemTime::now()
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .unwrap()
+                .as_secs(),
+        );
         header.set_size(new_lock.len() as u64);
         header.set_cksum();
         ar.append(&header, new_lock.as_bytes())


### PR DESCRIPTION
When generating files (Cargo.lock, Cargo.toml, and
.cargo_vcs_info.json), cargo neglected to set any timestamp on the file
in the archive. This results in them being created on disk with a
timestamp of 0 (Jan 1 1970 GMT) which is confusing another tool I use.

This patch alters the behavior to set the mtime to now.

Signed-off-by: Bruce Guenter <bruce@untroubled.org>