### PR TITLE
Allow --all-features in root of virtual workspace.

### DIFF
--- a/src/cargo/util/command_prelude.rs
+++ b/src/cargo/util/command_prelude.rs
@@ -284,7 +284,9 @@ pub trait ArgMatchesExt {
             ws.set_require_optional_deps(false);
         }
         if ws.is_virtual() && !config.cli_unstable().package_features {
-            for flag in &["features", "all-features", "no-default-features"] {
+            // --all-features is actually honored. In general, workspaces and
+            // feature flags are a bit of a mess right now.
+            for flag in &["features", "no-default-features"] {
                 if self._is_present(flag) {
                     bail!(
                         "--{} is not allowed in the root of a virtual workspace",


### PR DESCRIPTION
Accidentally restricted in #7507, pointed out by @hjmallon, `--all-features` flag is allowed in the root of a virtual workspace.  Added a test to demonstrate its strange behavior.  

For anyone that is curious, [this line](https://github.com/rust-lang/cargo/blob/3a9abe3f065554a7fbc59f440df2baba4a6e47ee/src/cargo/ops/resolve.rs#L302) is the code responsible for this behavior.