### PR TITLE
rustfmt for nightly changes.

### DIFF
--- a/src/cargo/core/package_id.rs
+++ b/src/cargo/core/package_id.rs
@@ -226,7 +226,10 @@ mod tests {
     fn debug() {
         let loc = CRATES_IO_INDEX.into_url().unwrap();
         let pkg_id = PackageId::new("foo", "1.0.0", SourceId::for_registry(&loc).unwrap()).unwrap();
-        assert_eq!(r#"PackageId { name: "foo", version: "1.0.0", source: "registry `https://github.com/rust-lang/crates.io-index`" }"#, format!("{:?}", pkg_id));
+        assert_eq!(
+            r#"PackageId { name: "foo", version: "1.0.0", source: "registry `https://github.com/rust-lang/crates.io-index`" }"#,
+            format!("{:?}", pkg_id)
+        );
 
         let expected = r#"
 PackageId {

--- a/tests/testsuite/install.rs
+++ b/tests/testsuite/install.rs
@@ -1131,12 +1131,20 @@ and will continue to do so, but this behavior will be removed eventually
 
 #[cargo_test]
 fn test_install_git_cannot_be_a_base_url() {
-    cargo_process("install --git github.com:rust-lang-nursery/rustfmt.git").with_status(101).with_stderr("error: invalid url `github.com:rust-lang-nursery/rustfmt.git`: cannot-be-a-base-URLs are not supported").run();
+    cargo_process("install --git github.com:rust-lang-nursery/rustfmt.git")
+        .with_status(101)
+        .with_stderr("\
+[ERROR] invalid url `github.com:rust-lang-nursery/rustfmt.git`: cannot-be-a-base-URLs are not supported")
+        .run();
 }
 
 #[cargo_test]
 fn uninstall_multiple_and_specifying_bin() {
-    cargo_process("uninstall foo bar --bin baz").with_status(101).with_stderr("error: A binary can only be associated with a single installed package, specifying multiple specs with --bin is redundant.").run();
+    cargo_process("uninstall foo bar --bin baz")
+        .with_status(101)
+        .with_stderr("\
+[ERROR] A binary can only be associated with a single installed package, specifying multiple specs with --bin is redundant.")
+        .run();
 }
 
 #[cargo_test]


### PR DESCRIPTION
Something in the latest nightly versions of rustfmt has slightly changed the logic here. Fortunately stable ignores the new formatting, and it looks better to me anyways.  I tend to always use nightly, so this helps me with a slight annoyance where this line keeps getting changed.
