### PR TITLE
clean: Do not remove symlinks, only contents

### DIFF
--- a/src/cargo/util/paths.rs
+++ b/src/cargo/util/paths.rs
@@ -285,7 +285,7 @@ pub fn remove_dir_all<P: AsRef<Path>>(p: P) -> CargoResult<()> {
 fn _remove_dir_all(p: &Path, follow_link_limit: usize) -> CargoResult<()> {
     if follow_link_limit == 0 {
         // Too many chained symlinks -- we're probably in a symlink loop!
-        return Err(failure::format_err!("symlink recursion depth limit reached",).into());
+        return Err(failure::format_err!("symlink recursion depth limit reached").into());
     }
 
     let entries = p


### PR DESCRIPTION
Previously, cargo clean would remove symlinks in the target directory,
but not the contents of those symlinks. This meant that `clean` in some
cases (like when the user sets their `CARGO_TARGET_DIR` to a symlink)
did not clean any files. It also causes surprising behavior where a
build following a clean might place build artifacts in the wrong
location, because clean removed symlinks the user expected to be there.

Note that this commit _does_ introduce some security risk. Before this
change, `cargo clean` would never leave the target directory, whereas
now that it follows symlinks, it might recurse into directories beyond
the target directory. We should decide whether we think this is okay.

Fixes #7510.