### PR TITLE
Show better error message for Windows abnormal termination.

### DIFF
--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -45,7 +45,7 @@ use crate::core::manifest::TargetSourcePath;
 use crate::core::profiles::{Lto, PanicStrategy, Profile};
 use crate::core::Feature;
 use crate::core::{PackageId, Target};
-use crate::util::errors::{CargoResult, CargoResultExt, Internal, ProcessError};
+use crate::util::errors::{self, CargoResult, CargoResultExt, Internal, ProcessError};
 use crate::util::machine_message::Message;
 use crate::util::paths;
 use crate::util::{self, machine_message, ProcessBuilder};
@@ -271,7 +271,7 @@ fn rustc<'a, 'cfg>(
                 .as_ref()
                 .and_then(|perr| perr.exit.and_then(|e| e.code()))
             {
-                Some(n) if n < 128 => Internal::new(err).into(),
+                Some(n) if errors::is_simple_exit_code(n) => Internal::new(err).into(),
                 _ => err,
             }
         }

--- a/src/cargo/util/errors.rs
+++ b/src/cargo/util/errors.rs
@@ -381,6 +381,17 @@ pub fn process_error(
     }
 }
 
+pub fn is_simple_exit_code(code: i32) -> bool {
+    // Typical unix exit codes are 0 to 127.
+    // Windows doesn't have anything "typical", and is a
+    // 32-bit number (which appears signed here, but is really
+    // unsigned). However, most of the interesting NTSTATUS
+    // codes are very large. This is just a rough
+    // approximation of which codes are "normal" and which
+    // ones are abnormal termination.
+    code >= 0 && code <= 127
+}
+
 pub fn internal<S: fmt::Display>(error: S) -> failure::Error {
     _internal(&error)
 }


### PR DESCRIPTION
This helps display better error messages when there is an abnormal termination on Windows.

If rustc crashes, there was a slight mistake in #6270, where the error code was actually negative, so the message was getting hidden behind the `--verbose` flag.  This changes it show that the abnormal error is always shown if rustc crashes in an unusual way.

This also changes `cargo test` to display a better message if the test crashes.  Previously:

```
running 1 test
error: test failed, to rerun pass '--bin crash'
```

New:

```
running 1 test
error: test failed, to rerun pass '--bin crash'

Caused by:
  process didn't exit successfully: `D:\Temp\crash\target\debug\deps\crash-b3c2389529da3d3e.exe` (exit code: 0xc0000374, STATUS_HEAP_CORRUPTION)
```

I didn't add any tests because testing on this on Windows seems a little precarious.  AFAIK, the exact error message depends on the processor (like x86 vs i686), and Windows version.  I was concerned about chasing down every little nuance, though I'm willing to try if it seems important.

Fixes rust-lang/rust#65692 (I think).
