### PR TITLE
Fix profile override warning in a workspace.

### DIFF
--- a/src/cargo/core/compiler/standard_lib.rs
+++ b/src/cargo/core/compiler/standard_lib.rs
@@ -103,7 +103,7 @@ pub fn resolve_std<'cfg>(
         /*uses_default_features*/ true,
     );
     let resolve = ops::resolve_ws_with_opts(&std_ws, opts, &specs)?;
-    Ok(resolve)
+    Ok((resolve.pkg_set, resolve.targeted_resolve))
 }
 
 /// Generate a list of root `Unit`s for the standard library.

--- a/src/cargo/ops/cargo_doc.rs
+++ b/src/cargo/ops/cargo_doc.rs
@@ -24,14 +24,13 @@ pub fn doc(ws: &Workspace<'_>, options: &DocOptions<'_>) -> CargoResult<()> {
         options.compile_opts.all_features,
         !options.compile_opts.no_default_features,
     );
-    let resolve = ops::resolve_ws_with_opts(ws, opts, &specs)?;
-    let (packages, resolve_with_overrides) = resolve;
+    let ws_resolve = ops::resolve_ws_with_opts(ws, opts, &specs)?;
 
     let ids = specs
         .iter()
-        .map(|s| s.query(resolve_with_overrides.iter()))
+        .map(|s| s.query(ws_resolve.targeted_resolve.iter()))
         .collect::<CargoResult<Vec<_>>>()?;
-    let pkgs = packages.get_many(ids)?;
+    let pkgs = ws_resolve.pkg_set.get_many(ids)?;
 
     let mut lib_names = HashMap::new();
     let mut bin_names = HashMap::new();

--- a/src/cargo/ops/cargo_install.rs
+++ b/src/cargo/ops/cargo_install.rs
@@ -491,14 +491,14 @@ fn check_yanked_install(ws: &Workspace<'_>) -> CargoResult<()> {
     // It would be best if `source` could be passed in here to avoid a
     // duplicate "Updating", but since `source` is taken by value, then it
     // wouldn't be available for `compile_ws`.
-    let (pkg_set, resolve) = ops::resolve_ws_with_opts(ws, ResolveOpts::everything(), &specs)?;
-    let mut sources = pkg_set.sources_mut();
+    let ws_resolve = ops::resolve_ws_with_opts(ws, ResolveOpts::everything(), &specs)?;
+    let mut sources = ws_resolve.pkg_set.sources_mut();
 
     // Checking the yanked status involves taking a look at the registry and
     // maybe updating files, so be sure to lock it here.
     let _lock = ws.config().acquire_package_cache_lock()?;
 
-    for pkg_id in resolve.iter() {
+    for pkg_id in ws_resolve.targeted_resolve.iter() {
         if let Some(source) = sources.get_mut(pkg_id.source_id()) {
             if source.is_yanked(pkg_id)? {
                 ws.config().shell().warn(format!(

--- a/src/cargo/ops/cargo_output_metadata.rs
+++ b/src/cargo/ops/cargo_output_metadata.rs
@@ -56,9 +56,12 @@ fn metadata_full(ws: &Workspace<'_>, opt: &OutputMetadataOptions) -> CargoResult
         opt.all_features,
         !opt.no_default_features,
     );
-    let (package_set, resolve) = ops::resolve_ws_with_opts(ws, opts, &specs)?;
+    let ws_resolve = ops::resolve_ws_with_opts(ws, opts, &specs)?;
     let mut packages = HashMap::new();
-    for pkg in package_set.get_many(package_set.package_ids())? {
+    for pkg in ws_resolve
+        .pkg_set
+        .get_many(ws_resolve.pkg_set.package_ids())?
+    {
         packages.insert(pkg.package_id(), pkg.clone());
     }
 
@@ -66,7 +69,7 @@ fn metadata_full(ws: &Workspace<'_>, opt: &OutputMetadataOptions) -> CargoResult
         packages: packages.values().map(|p| (*p).clone()).collect(),
         workspace_members: ws.members().map(|pkg| pkg.package_id()).collect(),
         resolve: Some(MetadataResolve {
-            resolve: (packages, resolve),
+            resolve: (packages, ws_resolve.targeted_resolve),
             root: ws.current_opt().map(|pkg| pkg.package_id()),
         }),
         target_directory: ws.target_dir().into_path_unlocked(),

--- a/src/cargo/ops/cargo_package.rs
+++ b/src/cargo/ops/cargo_package.rs
@@ -155,15 +155,19 @@ fn build_lock(ws: &Workspace<'_>) -> CargoResult<String> {
     // Regenerate Cargo.lock using the old one as a guide.
     let specs = vec![PackageIdSpec::from_package_id(new_pkg.package_id())];
     let tmp_ws = Workspace::ephemeral(new_pkg, ws.config(), None, true)?;
-    let (pkg_set, new_resolve) =
-        ops::resolve_ws_with_opts(&tmp_ws, ResolveOpts::everything(), &specs)?;
+    let new_resolve = ops::resolve_ws_with_opts(&tmp_ws, ResolveOpts::everything(), &specs)?;
 
     if let Some(orig_resolve) = orig_resolve {
-        compare_resolve(config, tmp_ws.current()?, &orig_resolve, &new_resolve)?;
+        compare_resolve(
+            config,
+            tmp_ws.current()?,
+            &orig_resolve,
+            &new_resolve.targeted_resolve,
+        )?;
     }
-    check_yanked(config, &pkg_set, &new_resolve)?;
+    check_yanked(config, &new_resolve.pkg_set, &new_resolve.targeted_resolve)?;
 
-    ops::resolve_to_string(&tmp_ws, &new_resolve)
+    ops::resolve_to_string(&tmp_ws, &new_resolve.targeted_resolve)
 }
 
 // Checks that the package has some piece of metadata that a human can


### PR DESCRIPTION
Profile overrides would erroneously warn about unused packages in a workspace if the package was not being built.  The fix here is to retain the `Resolve` for the entire workspace, and use that to determine the valid set of packages.

I think it would be good for a long-term goal to get rid of the second ("targeted") resolve.  I'm still contemplating how a separate features resolver could achieve that, but it seems feasible long-term.

Closes #7378