### PR TITLE
Add a note to discourage the use of -Zminimal-versions.

### DIFF
--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -44,6 +44,12 @@ generated if dev-dependencies are skipped.
 * Original Issue: [#4100](https://github.com/rust-lang/cargo/issues/4100)
 * Tracking Issue: [#5657](https://github.com/rust-lang/cargo/issues/5657)
 
+> Note: It is not recommended to use this feature. Because it enforces minimal
+> versions for all transitive dependencies, its usefulness is limited since
+> not all external dependencies declare proper lower version bounds. It is
+> intended that it will be changed in the future to only enforce minimal
+> versions for direct dependencies.
+
 When a `Cargo.lock` file is generated, the `-Z minimal-versions` flag will
 resolve the dependencies to the minimum semver version that will satisfy the
 requirements (instead of the greatest version).


### PR DESCRIPTION
We've discussed this a few times, that the current implementation isn't working out, so let's be more transparent about it.
