### PR TITLE
Fix `cargo fix` not showing colors.

### DIFF
--- a/src/cargo/ops/fix.rs
+++ b/src/cargo/ops/fix.rs
@@ -281,6 +281,11 @@ pub fn fix_maybe_exec_rustc() -> CargoResult<bool> {
     // - If the fix succeeded, show any remaining warnings.
     let mut cmd = Command::new(&rustc);
     args.apply(&mut cmd);
+    for arg in args.format_args {
+        // Add any json/error format arguments that Cargo wants. This allows
+        // things like colored output to work correctly.
+        cmd.arg(arg);
+    }
     exit_with(cmd.status().context("failed to spawn rustc")?);
 }
 
@@ -587,6 +592,7 @@ struct FixArgs {
     other: Vec<OsString>,
     rustc: Option<PathBuf>,
     clippy_args: Vec<String>,
+    format_args: Vec<String>,
 }
 
 enum PrepareFor {
@@ -627,6 +633,7 @@ impl FixArgs {
                 if s.starts_with("--error-format=") || s.starts_with("--json=") {
                     // Cargo may add error-format in some cases, but `cargo
                     // fix` wants to add its own.
+                    ret.format_args.push(s.to_string());
                     continue;
                 }
             }

--- a/tests/testsuite/fix.rs
+++ b/tests/testsuite/fix.rs
@@ -1289,3 +1289,22 @@ fn fix_with_clippy() {
     "
     );
 }
+
+#[cargo_test]
+fn fix_color_message() {
+    // Check that color appears in diagnostics.
+    let p = project()
+        .file("src/lib.rs", "std::compile_error!{\"color test\"}")
+        .build();
+
+    p.cargo("fix --allow-no-vcs --color=always")
+        .with_stderr_contains("[..]\x1b[[..]")
+        .with_status(101)
+        .run();
+
+    p.cargo("fix --allow-no-vcs --color=never")
+        .with_stderr_contains("error: color test")
+        .with_stderr_does_not_contain("[..]\x1b[[..]")
+        .with_status(101)
+        .run();
+}


### PR DESCRIPTION
`cargo fix` runs `rustc` a final time after it has finished to:
- Show what happened if the fix failed.
- Show errors with `--broken-code`.
- Show any remaining warnings after a successful fix.

This last run was no longer showing colored diagnostics due to the stabilization of cache-messages. Cargo now unconditionally uses colored JSON messages, and then conditionally strips them after the fact.  "cargo as rustc wrapper" was stripping the JSON flags which allowed Cargo to handle colors.

This fix works by putting the json flags back in for this final pass.
