### PR TITLE
Ignore CARGO_TARGET_DIR if it's the empty string

### DIFF
--- a/src/cargo/util/config/mod.rs
+++ b/src/cargo/util/config/mod.rs
@@ -342,7 +342,7 @@ impl Config {
     pub fn target_dir(&self) -> CargoResult<Option<Filesystem>> {
         if let Some(dir) = &self.target_dir {
             Ok(Some(dir.clone()))
-        } else if let Some(dir) = env::var_os("CARGO_TARGET_DIR") {
+        } else if let Some(dir) = env::var_os("CARGO_TARGET_DIR").filter(|dir| !dir.is_empty()) {
             Ok(Some(Filesystem::new(self.cwd.join(dir))))
         } else if let Some(val) = &self.build_config()?.target_dir {
             let val = val.resolve_path(self);


### PR DESCRIPTION
This change prevents `CARGO_TARGET_DIR= cargo clean` from wiping out the entire
working directory without warning.

Fixes issue #7551.

I'm not sure what's the intended behavior when `CARGO_TARGET_DIR` is `.`, so I left it alone:

```none
maia@fluff (/tmp/tmp.9M7LYP7wJp)$ CARGO_TARGET_DIR=. cargo clean
error: could not remove build directory

Caused by:
  failed to remove directory `/tmp/tmp.9M7LYP7wJp/.`

Caused by:
  Invalid argument (os error 22)
maia@fluff (/tmp/tmp.9M7LYP7wJp)$ 
```