### PR TITLE
Stabilize install-upgrade.

### DIFF
--- a/src/bin/cargo/cli.rs
+++ b/src/bin/cargo/cli.rs
@@ -34,7 +34,6 @@ Available unstable (nightly-only) flags:
     -Z no-index-update  -- Do not update the registry, avoids a network request for benchmarking
     -Z unstable-options -- Allow the usage of unstable options such as --registry
     -Z config-profile   -- Read profiles from .cargo/config files
-    -Z install-upgrade  -- `cargo install` will upgrade instead of failing
     -Z timings          -- Display concurrency information
     -Z doctest-xcompile -- Compile and run doctests for non-host target using runner config
 

--- a/src/bin/cargo/commands/install.rs
+++ b/src/bin/cargo/commands/install.rs
@@ -46,10 +46,7 @@ pub fn cli() -> App {
         ))
         .arg_jobs()
         .arg(opt("force", "Force overwriting existing crates or binaries").short("f"))
-        .arg(opt(
-            "no-track",
-            "Do not save tracking information (unstable)",
-        ))
+        .arg(opt("no-track", "Do not save tracking information"))
         .arg_features()
         .arg_profile("Install artifacts with the specified profile")
         .arg(opt("debug", "Build in debug mode instead of release mode"))
@@ -90,13 +87,9 @@ crate has multiple binaries, the `--bin` argument can selectively install only
 one of them, and if you'd rather install examples the `--example` argument can
 be used as well.
 
-By default cargo will refuse to overwrite existing binaries. The `--force` flag
-enables overwriting existing binaries. Thus you can reinstall a crate with
-`cargo install --force <crate>`.
-
-Omitting the <crate> specification entirely will install the crate in the
-current directory. This behaviour is deprecated, and it no longer works in the
-Rust 2018 edition. Use the more explicit `install --path .` instead.
+If the package is already installed, Cargo will reinstall it if the installed
+version does not appear to be up-to-date. Installing with `--path` will always
+build and install, unless there are conflicting binaries from another package.
 
 If the source is crates.io or `--git` then by default the crate will be built
 in a temporary target directory. To avoid this, the target directory can be
@@ -158,13 +151,6 @@ pub fn exec(config: &mut Config, args: &ArgMatches<'_>) -> CliResult {
 
     let version = args.value_of("version");
     let root = args.value_of("root");
-
-    if args.is_present("no-track") && !config.cli_unstable().install_upgrade {
-        return Err(failure::format_err!(
-            "`--no-track` flag is unstable, pass `-Z install-upgrade` to enable it"
-        )
-        .into());
-    };
 
     if args.is_present("list") {
         ops::install_list(root, config)?;

--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -334,7 +334,6 @@ pub struct CliUnstable {
     pub config_profile: bool,
     pub dual_proc_macros: bool,
     pub mtime_on_use: bool,
-    pub install_upgrade: bool,
     pub named_profiles: bool,
     pub binary_dep_depinfo: bool,
     pub build_std: Option<Vec<String>>,
@@ -400,7 +399,6 @@ impl CliUnstable {
             "dual-proc-macros" => self.dual_proc_macros = parse_empty(k, v)?,
             // can also be set in .cargo/config or with and ENV
             "mtime-on-use" => self.mtime_on_use = parse_empty(k, v)?,
-            "install-upgrade" => self.install_upgrade = parse_empty(k, v)?,
             "named-profiles" => self.named_profiles = parse_empty(k, v)?,
             "binary-dep-depinfo" => self.binary_dep_depinfo = parse_empty(k, v)?,
             "build-std" => {

--- a/src/doc/man/cargo-install.adoc
+++ b/src/doc/man/cargo-install.adoc
@@ -37,6 +37,20 @@ crate has multiple binaries, the `--bin` argument can selectively install only
 one of them, and if you'd rather install examples the `--example` argument can
 be used as well.
 
+If the package is already installed, Cargo will reinstall it if the installed
+version does not appear to be up-to-date. If any of the following values
+change, then Cargo will reinstall the package:
+
+- The package version and source.
+- The set of binary names installed.
+- The chosen features.
+- The release mode (`--debug`).
+- The target (`--target`).
+
+Installing with `--path` will always build and install, unless there are
+conflicting binaries from another package. The `--force` flag may be used to
+force Cargo to always reinstall the package.
+
 If the source is crates.io or `--git` then by default the crate will be built
 in a temporary target directory. To avoid this, the target directory can be
 specified by setting the `CARGO_TARGET_DIR` environment variable to a relative
@@ -63,7 +77,13 @@ available.
 
 *--vers* _VERSION_::
 *--version* _VERSION_::
-    Specify a version to install.
+    Specify a version to install. This may be a
+    linkcargo:reference/specifying-dependencies.md[version requirement], like
+    `~1.2`, to have Cargo select the newest version from the given
+    requirement. If the version does not have a requirement operator (such as
+    `^` or `~`), then it must be in the form _MAJOR.MINOR.PATCH_, and will
+    install exactly that version; it is *not* treated as a caret requirement
+    like Cargo dependencies are.
 
 *--git* _URL_::
     Git URL to install the specified crate from.
@@ -85,9 +105,18 @@ available.
 
 *-f*::
 *--force*::
-    Force overwriting existing crates or binaries. This can be used to
-    reinstall or upgrade a crate.
+    Force overwriting existing crates or binaries. This can be used if a
+    package has installed a binary with the same name as another package. This
+    is also useful if something has changed on the system that you want to
+    rebuild with, such as a newer version of `rustc`.
 
+*--no-track*::
+    By default, Cargo keeps track of the installed packages with a metadata
+    file stored in the installation root directory. This flag tells Cargo not
+    to use or create that file. With this flag, Cargo will refuse to overwrite
+    any existing files unless the `--force` flag is used. This also disables
+    Cargo's ability to protect against multiple concurrent invocations of
+    Cargo installing at the same time.
 
 *--bin* _NAME_...::
     Install only the specified binary.
@@ -137,13 +166,17 @@ include::section-exit-status.adoc[]
 
 == EXAMPLES
 
-. Install a package from crates.io:
+. Install or upgrade a package from crates.io:
 
     cargo install ripgrep
 
-. Reinstall or upgrade a package:
+. Install or reinstall the package in the current directory:
 
-    cargo install ripgrep --force
+    cargo install --path .
+
+. View the list of installed packages:
+
+    cargo install --list
 
 == SEE ALSO
 man:cargo[1], man:cargo-uninstall[1], man:cargo-search[1], man:cargo-publish[1]

--- a/src/doc/man/generated/cargo-install.html
+++ b/src/doc/man/generated/cargo-install.html
@@ -60,6 +60,35 @@ one of them, and if you&#8217;d rather install examples the <code>--example</cod
 be used as well.</p>
 </div>
 <div class="paragraph">
+<p>If the package is already installed, Cargo will reinstall it if the installed
+version does not appear to be up-to-date. If any of the following values
+change, then Cargo will reinstall the package:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p>The package version and source.</p>
+</li>
+<li>
+<p>The set of binary names installed.</p>
+</li>
+<li>
+<p>The chosen features.</p>
+</li>
+<li>
+<p>The release mode (<code>--debug</code>).</p>
+</li>
+<li>
+<p>The target (<code>--target</code>).</p>
+</li>
+</ul>
+</div>
+<div class="paragraph">
+<p>Installing with <code>--path</code> will always build and install, unless there are
+conflicting binaries from another package. The <code>--force</code> flag may be used to
+force Cargo to always reinstall the package.</p>
+</div>
+<div class="paragraph">
 <p>If the source is crates.io or <code>--git</code> then by default the crate will be built
 in a temporary target directory. To avoid this, the target directory can be
 specified by setting the <code>CARGO_TARGET_DIR</code> environment variable to a relative
@@ -93,7 +122,13 @@ available.</p>
 <dt class="hdlist1"><strong>--vers</strong> <em>VERSION</em></dt>
 <dt class="hdlist1"><strong>--version</strong> <em>VERSION</em></dt>
 <dd>
-<p>Specify a version to install.</p>
+<p>Specify a version to install. This may be a
+<a href="../reference/specifying-dependencies.md">version requirement</a>, like
+<code>~1.2</code>, to have Cargo select the newest version from the given
+requirement. If the version does not have a requirement operator (such as
+<code>^</code> or <code>~</code>), then it must be in the form <em>MAJOR.MINOR.PATCH</em>, and will
+install exactly that version; it is <strong>not</strong> treated as a caret requirement
+like Cargo dependencies are.</p>
 </dd>
 <dt class="hdlist1"><strong>--git</strong> <em>URL</em></dt>
 <dd>
@@ -122,8 +157,19 @@ available.</p>
 <dt class="hdlist1"><strong>-f</strong></dt>
 <dt class="hdlist1"><strong>--force</strong></dt>
 <dd>
-<p>Force overwriting existing crates or binaries. This can be used to
-reinstall or upgrade a crate.</p>
+<p>Force overwriting existing crates or binaries. This can be used if a
+package has installed a binary with the same name as another package. This
+is also useful if something has changed on the system that you want to
+rebuild with, such as a newer version of <code>rustc</code>.</p>
+</dd>
+<dt class="hdlist1"><strong>--no-track</strong></dt>
+<dd>
+<p>By default, Cargo keeps track of the installed packages with a metadata
+file stored in the installation root directory. This flag tells Cargo not
+to use or create that file. With this flag, Cargo will refuse to overwrite
+any existing files unless the <code>--force</code> flag is used. This also disables
+Cargo&#8217;s ability to protect against multiple concurrent invocations of
+Cargo installing at the same time.</p>
 </dd>
 <dt class="hdlist1"><strong>--bin</strong> <em>NAME</em>&#8230;&#8203;</dt>
 <dd>
@@ -346,7 +392,7 @@ details on environment variables that Cargo reads.</p>
 <div class="olist arabic">
 <ol class="arabic">
 <li>
-<p>Install a package from crates.io:</p>
+<p>Install or upgrade a package from crates.io:</p>
 <div class="literalblock">
 <div class="content">
 <pre>cargo install ripgrep</pre>
@@ -354,10 +400,18 @@ details on environment variables that Cargo reads.</p>
 </div>
 </li>
 <li>
-<p>Reinstall or upgrade a package:</p>
+<p>Install or reinstall the package in the current directory:</p>
 <div class="literalblock">
 <div class="content">
-<pre>cargo install ripgrep --force</pre>
+<pre>cargo install --path .</pre>
+</div>
+</div>
+</li>
+<li>
+<p>View the list of installed packages:</p>
+<div class="literalblock">
+<div class="content">
+<pre>cargo install --list</pre>
 </div>
 </div>
 </li>

--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -280,38 +280,6 @@ extra-info = "qwerty"
 Metabuild packages should have a public function called `metabuild` that
 performs the same actions as a regular `build.rs` script would perform.
 
-### install-upgrade
-* Tracking Issue: [#6797](https://github.com/rust-lang/cargo/issues/6797)
-
-The `install-upgrade` feature changes the behavior of `cargo install` so that
-it will reinstall a package if it is not "up-to-date". If it is "up-to-date",
-it will do nothing and exit with success instead of failing. Example:
-
-```
-cargo +nightly install foo -Z install-upgrade
-```
-
-Cargo tracks some information to determine if a package is "up-to-date",
-including:
-
-- The package version and source.
-- The set of binary names installed.
-- The chosen features.
-- The release mode (`--debug`).
-- The target (`--target`).
-
-If any of these values change, then Cargo will reinstall the package.
-
-Installation will still fail if a different package installs a binary of the
-same name. `--force` may be used to unconditionally reinstall the package.
-
-Installing with `--path` will always build and install, unless there are
-conflicting binaries from another package.
-
-Additionally, a new flag `--no-track` is available to prevent `cargo install`
-from writing tracking information in `$CARGO_HOME` about which packages are
-installed.
-
 ### public-dependency
 * Tracking Issue: [#44663](https://github.com/rust-lang/rust/issues/44663)
 

--- a/src/etc/man/cargo-install.1
+++ b/src/etc/man/cargo-install.1
@@ -2,12 +2,12 @@
 .\"     Title: cargo-install
 .\"    Author: [see the "AUTHOR(S)" section]
 .\" Generator: Asciidoctor 2.0.10
-.\"      Date: 2019-10-09
+.\"      Date: 2019-11-04
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "CARGO\-INSTALL" "1" "2019-10-09" "\ \&" "\ \&"
+.TH "CARGO\-INSTALL" "1" "2019-11-04" "\ \&" "\ \&"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0
@@ -116,6 +116,69 @@ crate has multiple binaries, the \fB\-\-bin\fP argument can selectively install 
 one of them, and if you\(cqd rather install examples the \fB\-\-example\fP argument can
 be used as well.
 .sp
+If the package is already installed, Cargo will reinstall it if the installed
+version does not appear to be up\-to\-date. If any of the following values
+change, then Cargo will reinstall the package:
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.  sp -1
+.  IP \(bu 2.3
+.\}
+The package version and source.
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.  sp -1
+.  IP \(bu 2.3
+.\}
+The set of binary names installed.
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.  sp -1
+.  IP \(bu 2.3
+.\}
+The chosen features.
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.  sp -1
+.  IP \(bu 2.3
+.\}
+The release mode (\fB\-\-debug\fP).
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.  sp -1
+.  IP \(bu 2.3
+.\}
+The target (\fB\-\-target\fP).
+.RE
+.sp
+Installing with \fB\-\-path\fP will always build and install, unless there are
+conflicting binaries from another package. The \fB\-\-force\fP flag may be used to
+force Cargo to always reinstall the package.
+.sp
 If the source is crates.io or \fB\-\-git\fP then by default the crate will be built
 in a temporary target directory. To avoid this, the target directory can be
 specified by setting the \fBCARGO_TARGET_DIR\fP environment variable to a relative
@@ -140,7 +203,14 @@ available.
 .sp
 \fB\-\-vers\fP \fIVERSION\fP, \fB\-\-version\fP \fIVERSION\fP
 .RS 4
-Specify a version to install.
+Specify a version to install. This may be a
+.URL "https://doc.rust\-lang.org/cargo/reference/specifying\-dependencies.md" "version requirement" ","
+like
+\fB~1.2\fP, to have Cargo select the newest version from the given
+requirement. If the version does not have a requirement operator (such as
+\fB^\fP or \fB~\fP), then it must be in the form \fIMAJOR.MINOR.PATCH\fP, and will
+install exactly that version; it is \fBnot\fP treated as a caret requirement
+like Cargo dependencies are.
 .RE
 .sp
 \fB\-\-git\fP \fIURL\fP
@@ -175,8 +245,20 @@ List all installed packages and their versions.
 .sp
 \fB\-f\fP, \fB\-\-force\fP
 .RS 4
-Force overwriting existing crates or binaries. This can be used to
-reinstall or upgrade a crate.
+Force overwriting existing crates or binaries. This can be used if a
+package has installed a binary with the same name as another package. This
+is also useful if something has changed on the system that you want to
+rebuild with, such as a newer version of \fBrustc\fP.
+.RE
+.sp
+\fB\-\-no\-track\fP
+.RS 4
+By default, Cargo keeps track of the installed packages with a metadata
+file stored in the installation root directory. This flag tells Cargo not
+to use or create that file. With this flag, Cargo will refuse to overwrite
+any existing files unless the \fB\-\-force\fP flag is used. This also disables
+Cargo\(cqs ability to protect against multiple concurrent invocations of
+Cargo installing at the same time.
 .RE
 .sp
 \fB\-\-bin\fP \fINAME\fP...
@@ -385,7 +467,7 @@ Cargo failed to complete.
 .  sp -1
 .  IP " 1." 4.2
 .\}
-Install a package from crates.io:
+Install or upgrade a package from crates.io:
 .sp
 .if n .RS 4
 .nf
@@ -402,11 +484,28 @@ cargo install ripgrep
 .  sp -1
 .  IP " 2." 4.2
 .\}
-Reinstall or upgrade a package:
+Install or reinstall the package in the current directory:
 .sp
 .if n .RS 4
 .nf
-cargo install ripgrep \-\-force
+cargo install \-\-path .
+.fi
+.if n .RE
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04' 3.\h'+01'\c
+.\}
+.el \{\
+.  sp -1
+.  IP " 3." 4.2
+.\}
+View the list of installed packages:
+.sp
+.if n .RS 4
+.nf
+cargo install \-\-list
 .fi
 .if n .RE
 .RE

--- a/tests/testsuite/concurrent.rs
+++ b/tests/testsuite/concurrent.rs
@@ -99,20 +99,8 @@ fn one_install_should_be_bad() {
     let b = b.wait_with_output().unwrap();
     let a = a.join().unwrap();
 
-    let (bad, good) = if a.status.code() == Some(101) {
-        (a, b)
-    } else {
-        (b, a)
-    };
-    execs()
-        .with_status(101)
-        .with_stderr_contains(
-            "[ERROR] binary `foo[..]` already exists in destination as part of `[..]`",
-        )
-        .run_output(&bad);
-    execs()
-        .with_stderr_contains("warning: be sure to add `[..]` to your PATH [..]")
-        .run_output(&good);
+    execs().run_output(&a);
+    execs().run_output(&b);
 
     assert_has_installed_exe(cargo_home(), "foo");
 }


### PR DESCRIPTION
Tracking issue: #6797

This stabilizes the install-upgrade feature, which causes `cargo install` to reinstall a package if it appears to be out of date, or exit cleanly if it is up-to-date.

There are no changes from `-Zinstall-upgrade`. See [the old unstable docs](https://github.com/rust-lang/cargo/blob/6a7f505a185b000e38bdad64392098e0b2e50802/src/doc/src/reference/unstable.md#install-upgrade) for a refresher on the details of what it does.

This also stabilizes the following changes:
- `--version` no longer allows an implicit version requirement like `1.2`.  It must be either contain all 3 components (like `1.2.3`) or use a requirement operator (like `^1.2`).  This has been a warning for a very long time, and is now changed to a hard error.
- Added `--no-track` to disable install tracking.

**Motivation**

I just personally prefer this behavior, and it has been requested a few times in the past. I've been using it locally, and haven't run into any issues. If this goes into 1.41, then it will release on Jan 30, about 10 months since it was added in #6798.

**Concerns**

Regarding some of the concerns I had:

- Is it tracking the correct set of information?  

  I'm satisfied with the current set. It also tracks, but does not use, the version of rustc and the version specified in the `--version` flag, in case we ever want to use that in the future. It is also designed to be backwards and forwards compatible, so more information can be added in the future. I think the current set strikes a good balance of tracking the really important things, without causing unnecessary rebuilds.

- Method to upgrade all outdated packages? 

  This can always be added as a new flag or command in the future, and shouldn't block stabilization.

- Should `--no-track` be kept? Does it work correctly? 

  I kept it. It's not too hard to support, and nobody said anything (other than maybe using a less confusing name).

- Should this be the default? Should there be a way to use the old behavior?

  I like it as the default, and don't see a real need for the old behavior. I think we could always bring back the old behavior with a flag in the future, but I would like to avoid it for simplicity. There is also the workaround of `which foo || cargo install foo`.

Closes #6797.
Closes #6727.
Closes #6485.
Closes #2082.
