### PR TITLE
Only include "already existing ..." comment in gitignore on conflict

### DIFF
--- a/src/cargo/ops/cargo_new.rs
+++ b/src/cargo/ops/cargo_new.rs
@@ -487,10 +487,14 @@ impl IgnoreList {
             _ => &self.ignore,
         };
 
-        let mut out = "\n\n#Added by cargo\n\
-                       #\n\
-                       #already existing elements are commented out\n\n"
-            .to_string();
+        let mut out = "\n\n#Added by cargo\n".to_string();
+        if ignore_items
+            .iter()
+            .any(|item| existing_items.contains(item))
+        {
+            out.push_str("#\n#already existing elements are commented out\n");
+        }
+        out.push('\n');
 
         for item in ignore_items {
             if existing_items.contains(item) {

--- a/src/cargo/ops/cargo_new.rs
+++ b/src/cargo/ops/cargo_new.rs
@@ -492,7 +492,7 @@ impl IgnoreList {
             .iter()
             .any(|item| existing_items.contains(item))
         {
-            out.push_str("#\n#already existing elements are commented out\n");
+            out.push_str("#\n#already existing elements were commented out\n");
         }
         out.push('\n');
 

--- a/tests/testsuite/init.rs
+++ b/tests/testsuite/init.rs
@@ -100,6 +100,33 @@ fn simple_git_ignore_exists() {
 }
 
 #[cargo_test]
+fn git_ignore_exists_no_conflicting_entries() {
+    // write a .gitignore file with one entry
+    fs::create_dir_all(paths::root().join("foo")).unwrap();
+    fs::write(paths::root().join("foo/.gitignore"), "**/some.file").unwrap();
+
+    cargo_process("init --lib foo --edition 2015")
+        .env("USER", "foo")
+        .run();
+
+    let fp = paths::root().join("foo/.gitignore");
+    let mut contents = String::new();
+    File::open(&fp)
+        .unwrap()
+        .read_to_string(&mut contents)
+        .unwrap();
+    assert_eq!(
+        contents,
+        "**/some.file\n\n\
+         #Added by cargo\n\
+         \n\
+         /target\n\
+         **/*.rs.bk\n\
+         Cargo.lock\n",
+    );
+}
+
+#[cargo_test]
 fn both_lib_and_bin() {
     cargo_process("init --lib --bin")
         .env("USER", "foo")

--- a/tests/testsuite/init.rs
+++ b/tests/testsuite/init.rs
@@ -89,7 +89,7 @@ fn simple_git_ignore_exists() {
          **/some.file\n\n\
          #Added by cargo\n\
          #\n\
-         #already existing elements are commented out\n\
+         #already existing elements were commented out\n\
          \n\
          #/target\n\
          **/*.rs.bk\n\

--- a/tests/testsuite/init.rs
+++ b/tests/testsuite/init.rs
@@ -59,7 +59,7 @@ fn simple_bin() {
 
 #[cargo_test]
 fn simple_git_ignore_exists() {
-    // write a .gitignore file with one entry
+    // write a .gitignore file with two entries
     fs::create_dir_all(paths::root().join("foo")).unwrap();
     fs::write(
         paths::root().join("foo/.gitignore"),


### PR DESCRIPTION
I found the comment a bit confusing when I've used `cargo init` when I haven't had any conflicts. I thought it was meaning that my existing entries would be all commented out so I thought there was a bug of some kind.

This PR changes the comment to only be included when there are conflicting entries in the existing file.