### PR TITLE
Fix unused configuration key warning for a few keys under `build`.

### DIFF
--- a/src/cargo/ops/fix.rs
+++ b/src/cargo/ops/fix.rs
@@ -15,7 +15,7 @@
 //! to print at the same time).
 //!
 //! Cargo begins a normal `cargo check` operation with itself set as a proxy
-//! for rustc by setting `rustc_wrapper` in the build config. When
+//! for rustc by setting `primary_unit_rustc` in the build config. When
 //! cargo launches rustc to check a crate, it is actually launching itself.
 //! The `FIX_ENV` environment variable is set so that cargo knows it is in
 //! fix-proxy-mode.


### PR DESCRIPTION
Recently cargo started to warn about configuration keys that he doesn't know about.  However, there are a few keys under `build` that were used in a dynamic way (`rustc`, `rustdoc`, and `rustc_wrapper`) by `Config::maybe_get_tool()`.

Since these keys are not known to exist when `Config` is deserialized, cargo was emitting unused warnings.

This commit makes those config keys explicit.  Note that by doing so there is a small breaking change: before it was possible to have `build.rustc_wrapper` in the configuration file (even though the documented key uses kebak-case), and now that key will be ignored.  (Good thing we have warnings for unrecognized keys!)