### PR TITLE
Add back support for `BROWSER` envvar in `cargo doc --open`.

### DIFF
--- a/src/doc/man/cargo-doc.adoc
+++ b/src/doc/man/cargo-doc.adoc
@@ -21,7 +21,9 @@ is placed in `target/doc` in rustdoc's usual format.
 === Documentation Options
 
 *--open*::
-    Open the docs in a browser after building them.
+    Open the docs in a browser after building them. This will use your default
+    browser unless you define another one in the `BROWSER` environment
+    variable.
 
 *--no-deps*::
     Do not build documentation for dependencies.

--- a/src/doc/man/cargo-rustdoc.adoc
+++ b/src/doc/man/cargo-rustdoc.adoc
@@ -33,7 +33,9 @@ option.
 === Documentation Options
 
 *--open*::
-    Open the docs in a browser after building them.
+    Open the docs in a browser after building them. This will use your default
+    browser unless you define another one in the `BROWSER` environment
+    variable.
 
 === Package Selection
 

--- a/src/doc/man/generated/cargo-doc.html
+++ b/src/doc/man/generated/cargo-doc.html
@@ -28,7 +28,9 @@ is placed in <code>target/doc</code> in rustdoc&#8217;s usual format.</p>
 <dl>
 <dt class="hdlist1"><strong>--open</strong></dt>
 <dd>
-<p>Open the docs in a browser after building them.</p>
+<p>Open the docs in a browser after building them. This will use your default
+browser unless you define another one in the <code>BROWSER</code> environment
+variable.</p>
 </dd>
 <dt class="hdlist1"><strong>--no-deps</strong></dt>
 <dd>

--- a/src/doc/man/generated/cargo-rustdoc.html
+++ b/src/doc/man/generated/cargo-rustdoc.html
@@ -45,7 +45,9 @@ option.</p>
 <dl>
 <dt class="hdlist1"><strong>--open</strong></dt>
 <dd>
-<p>Open the docs in a browser after building them.</p>
+<p>Open the docs in a browser after building them. This will use your default
+browser unless you define another one in the <code>BROWSER</code> environment
+variable.</p>
 </dd>
 </dl>
 </div>

--- a/src/etc/man/cargo-doc.1
+++ b/src/etc/man/cargo-doc.1
@@ -2,12 +2,12 @@
 .\"     Title: cargo-doc
 .\"    Author: [see the "AUTHOR(S)" section]
 .\" Generator: Asciidoctor 2.0.10
-.\"      Date: 2019-09-05
+.\"      Date: 2019-11-11
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "CARGO\-DOC" "1" "2019-09-05" "\ \&" "\ \&"
+.TH "CARGO\-DOC" "1" "2019-11-11" "\ \&" "\ \&"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0
@@ -41,7 +41,9 @@ is placed in \fBtarget/doc\fP in rustdoc\(cqs usual format.
 .sp
 \fB\-\-open\fP
 .RS 4
-Open the docs in a browser after building them.
+Open the docs in a browser after building them. This will use your default
+browser unless you define another one in the \fBBROWSER\fP environment
+variable.
 .RE
 .sp
 \fB\-\-no\-deps\fP

--- a/src/etc/man/cargo-help.1
+++ b/src/etc/man/cargo-help.1
@@ -1,13 +1,13 @@
 '\" t
 .\"     Title: cargo-help
 .\"    Author: [see the "AUTHOR(S)" section]
-.\" Generator: Asciidoctor 2.0.8
-.\"      Date: 2019-06-07
+.\" Generator: Asciidoctor 2.0.10
+.\"      Date: 2019-06-03
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "CARGO\-HELP" "1" "2019-06-07" "\ \&" "\ \&"
+.TH "CARGO\-HELP" "1" "2019-06-03" "\ \&" "\ \&"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0

--- a/src/etc/man/cargo-init.1
+++ b/src/etc/man/cargo-init.1
@@ -1,13 +1,13 @@
 '\" t
 .\"     Title: cargo-init
 .\"    Author: [see the "AUTHOR(S)" section]
-.\" Generator: Asciidoctor 2.0.8
-.\"      Date: 2019-06-07
+.\" Generator: Asciidoctor 2.0.10
+.\"      Date: 2019-06-03
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "CARGO\-INIT" "1" "2019-06-07" "\ \&" "\ \&"
+.TH "CARGO\-INIT" "1" "2019-06-03" "\ \&" "\ \&"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0

--- a/src/etc/man/cargo-install.1
+++ b/src/etc/man/cargo-install.1
@@ -1,13 +1,13 @@
 '\" t
 .\"     Title: cargo-install
 .\"    Author: [see the "AUTHOR(S)" section]
-.\" Generator: Asciidoctor 2.0.8
-.\"      Date: 2019-07-15
+.\" Generator: Asciidoctor 2.0.10
+.\"      Date: 2019-10-09
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "CARGO\-INSTALL" "1" "2019-07-15" "\ \&" "\ \&"
+.TH "CARGO\-INSTALL" "1" "2019-10-09" "\ \&" "\ \&"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0

--- a/src/etc/man/cargo-login.1
+++ b/src/etc/man/cargo-login.1
@@ -1,13 +1,13 @@
 '\" t
 .\"     Title: cargo-login
 .\"    Author: [see the "AUTHOR(S)" section]
-.\" Generator: Asciidoctor 2.0.8
-.\"      Date: 2019-06-07
+.\" Generator: Asciidoctor 2.0.10
+.\"      Date: 2019-06-03
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "CARGO\-LOGIN" "1" "2019-06-07" "\ \&" "\ \&"
+.TH "CARGO\-LOGIN" "1" "2019-06-03" "\ \&" "\ \&"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0

--- a/src/etc/man/cargo-new.1
+++ b/src/etc/man/cargo-new.1
@@ -1,13 +1,13 @@
 '\" t
 .\"     Title: cargo-new
 .\"    Author: [see the "AUTHOR(S)" section]
-.\" Generator: Asciidoctor 2.0.8
-.\"      Date: 2019-06-07
+.\" Generator: Asciidoctor 2.0.10
+.\"      Date: 2019-06-03
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "CARGO\-NEW" "1" "2019-06-07" "\ \&" "\ \&"
+.TH "CARGO\-NEW" "1" "2019-06-03" "\ \&" "\ \&"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0

--- a/src/etc/man/cargo-owner.1
+++ b/src/etc/man/cargo-owner.1
@@ -1,13 +1,13 @@
 '\" t
 .\"     Title: cargo-owner
 .\"    Author: [see the "AUTHOR(S)" section]
-.\" Generator: Asciidoctor 2.0.8
-.\"      Date: 2019-06-07
+.\" Generator: Asciidoctor 2.0.10
+.\"      Date: 2019-06-03
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "CARGO\-OWNER" "1" "2019-06-07" "\ \&" "\ \&"
+.TH "CARGO\-OWNER" "1" "2019-06-03" "\ \&" "\ \&"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0

--- a/src/etc/man/cargo-rustdoc.1
+++ b/src/etc/man/cargo-rustdoc.1
@@ -2,12 +2,12 @@
 .\"     Title: cargo-rustdoc
 .\"    Author: [see the "AUTHOR(S)" section]
 .\" Generator: Asciidoctor 2.0.10
-.\"      Date: 2019-09-05
+.\"      Date: 2019-11-11
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "CARGO\-RUSTDOC" "1" "2019-09-05" "\ \&" "\ \&"
+.TH "CARGO\-RUSTDOC" "1" "2019-11-11" "\ \&" "\ \&"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0
@@ -58,7 +58,9 @@ option.
 .sp
 \fB\-\-open\fP
 .RS 4
-Open the docs in a browser after building them.
+Open the docs in a browser after building them. This will use your default
+browser unless you define another one in the \fBBROWSER\fP environment
+variable.
 .RE
 .SS "Package Selection"
 .sp

--- a/src/etc/man/cargo-search.1
+++ b/src/etc/man/cargo-search.1
@@ -1,13 +1,13 @@
 '\" t
 .\"     Title: cargo-search
 .\"    Author: [see the "AUTHOR(S)" section]
-.\" Generator: Asciidoctor 2.0.8
-.\"      Date: 2019-06-07
+.\" Generator: Asciidoctor 2.0.10
+.\"      Date: 2019-06-03
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "CARGO\-SEARCH" "1" "2019-06-07" "\ \&" "\ \&"
+.TH "CARGO\-SEARCH" "1" "2019-06-03" "\ \&" "\ \&"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0

--- a/src/etc/man/cargo-uninstall.1
+++ b/src/etc/man/cargo-uninstall.1
@@ -1,13 +1,13 @@
 '\" t
 .\"     Title: cargo-uninstall
 .\"    Author: [see the "AUTHOR(S)" section]
-.\" Generator: Asciidoctor 2.0.8
-.\"      Date: 2019-06-07
+.\" Generator: Asciidoctor 2.0.10
+.\"      Date: 2019-06-03
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "CARGO\-UNINSTALL" "1" "2019-06-07" "\ \&" "\ \&"
+.TH "CARGO\-UNINSTALL" "1" "2019-06-03" "\ \&" "\ \&"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0

--- a/src/etc/man/cargo-version.1
+++ b/src/etc/man/cargo-version.1
@@ -1,13 +1,13 @@
 '\" t
 .\"     Title: cargo-version
 .\"    Author: [see the "AUTHOR(S)" section]
-.\" Generator: Asciidoctor 2.0.8
-.\"      Date: 2019-06-07
+.\" Generator: Asciidoctor 2.0.10
+.\"      Date: 2019-06-03
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "CARGO\-VERSION" "1" "2019-06-07" "\ \&" "\ \&"
+.TH "CARGO\-VERSION" "1" "2019-06-03" "\ \&" "\ \&"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0

--- a/src/etc/man/cargo-yank.1
+++ b/src/etc/man/cargo-yank.1
@@ -1,13 +1,13 @@
 '\" t
 .\"     Title: cargo-yank
 .\"    Author: [see the "AUTHOR(S)" section]
-.\" Generator: Asciidoctor 2.0.8
-.\"      Date: 2019-06-07
+.\" Generator: Asciidoctor 2.0.10
+.\"      Date: 2019-06-03
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "CARGO\-YANK" "1" "2019-06-07" "\ \&" "\ \&"
+.TH "CARGO\-YANK" "1" "2019-06-03" "\ \&" "\ \&"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0

--- a/src/etc/man/cargo.1
+++ b/src/etc/man/cargo.1
@@ -2,12 +2,12 @@
 .\"     Title: cargo
 .\"    Author: [see the "AUTHOR(S)" section]
 .\" Generator: Asciidoctor 2.0.10
-.\"      Date: 2019-09-05
+.\"      Date: 2019-10-09
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "CARGO" "1" "2019-09-05" "\ \&" "\ \&"
+.TH "CARGO" "1" "2019-10-09" "\ \&" "\ \&"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0


### PR DESCRIPTION
Fixes #6064.
Fixes #5965.