### PR TITLE
Remove "cargo login" from user input when asking for login token.

### DIFF
--- a/src/cargo/ops/registry.rs
+++ b/src/cargo/ops/registry.rs
@@ -434,6 +434,7 @@ pub fn configure_http_handle(config: &Config, handle: &mut Easy) -> CargoResult<
     if let Some(check) = http.check_revoke {
         handle.ssl_options(SslOpt::new().no_revoke(!check))?;
     }
+    
     if let Some(user_agent) = &http.user_agent {
         handle.useragent(user_agent)?;
     } else {
@@ -598,6 +599,7 @@ pub fn registry_login(
                 .read_line(&mut line)
                 .chain_err(|| "failed to read stdin")
                 .map_err(failure::Error::from)?;
+            // Automatically remove `cargo login` from an inputted token to allow direct pastes from `registry.host()`/me. 
             line.replace("cargo login", "").trim().to_string()
         }
     };

--- a/src/cargo/ops/registry.rs
+++ b/src/cargo/ops/registry.rs
@@ -598,7 +598,7 @@ pub fn registry_login(
                 .read_line(&mut line)
                 .chain_err(|| "failed to read stdin")
                 .map_err(failure::Error::from)?;
-            line.replace("cargo login", "").trim().to_string();
+            line.replace("cargo login", "").trim().to_string()
         }
     };
 

--- a/src/cargo/ops/registry.rs
+++ b/src/cargo/ops/registry.rs
@@ -434,7 +434,7 @@ pub fn configure_http_handle(config: &Config, handle: &mut Easy) -> CargoResult<
     if let Some(check) = http.check_revoke {
         handle.ssl_options(SslOpt::new().no_revoke(!check))?;
     }
-    
+
     if let Some(user_agent) = &http.user_agent {
         handle.useragent(user_agent)?;
     } else {
@@ -599,7 +599,7 @@ pub fn registry_login(
                 .read_line(&mut line)
                 .chain_err(|| "failed to read stdin")
                 .map_err(failure::Error::from)?;
-            // Automatically remove `cargo login` from an inputted token to allow direct pastes from `registry.host()`/me. 
+            // Automatically remove `cargo login` from an inputted token to allow direct pastes from `registry.host()`/me.
             line.replace("cargo login", "").trim().to_string()
         }
     };

--- a/src/cargo/ops/registry.rs
+++ b/src/cargo/ops/registry.rs
@@ -598,7 +598,7 @@ pub fn registry_login(
                 .read_line(&mut line)
                 .chain_err(|| "failed to read stdin")
                 .map_err(failure::Error::from)?;
-            line.trim().to_string()
+            line.replace("cargo login", "").trim().to_string();
         }
     };
 


### PR DESCRIPTION
Hey all!

This is my first time contributing to open source, but I realized that I could help some people out and make a quick change. 😄 

When running cargo login, I was told to `please visit https://crates.io/me and paste the API Token below`. However, me on autopilot accidentally pasted the whole `cargo login $APITOKEN` string on the website into `cargo login` and it took me almost 30 minutes to figure out why I couldn't publish a package. 

I thought it would be useful to automatically remove `cargo login` from the token, just in case someone makes the brain dead mistake like me. 

Hope I can get some good feedback on this, have a great one! ❤️ 
