### PR TITLE
Document private items for binary crates by default

### DIFF
--- a/src/bin/cargo/commands/doc.rs
+++ b/src/bin/cargo/commands/doc.rs
@@ -55,11 +55,8 @@ pub fn exec(config: &mut Config, args: &ArgMatches<'_>) -> CliResult {
     };
     let mut compile_opts =
         args.compile_options(config, mode, Some(&ws), ProfileChecking::Checked)?;
-    compile_opts.local_rustdoc_args = if args.is_present("document-private-items") {
-        Some(vec!["--document-private-items".to_string()])
-    } else {
-        None
-    };
+    compile_opts.rustdoc_document_private_items = args.is_present("document-private-items");
+
     let doc_opts = DocOptions {
         open_result: args.is_present("open"),
         compile_opts,

--- a/src/cargo/ops/cargo_package.rs
+++ b/src/cargo/ops/cargo_package.rs
@@ -661,6 +661,7 @@ fn run_verify(ws: &Workspace<'_>, tar: &FileLock, opts: &PackageOpts<'_>) -> Car
             target_rustdoc_args: None,
             target_rustc_args: rustc_args,
             local_rustdoc_args: None,
+            rustdoc_document_private_items: false,
             export_dir: None,
         },
         &exec,

--- a/src/cargo/util/command_prelude.rs
+++ b/src/cargo/util/command_prelude.rs
@@ -463,6 +463,7 @@ pub trait ArgMatchesExt {
             target_rustdoc_args: None,
             target_rustc_args: None,
             local_rustdoc_args: None,
+            rustdoc_document_private_items: false,
             export_dir: None,
         };
 


### PR DESCRIPTION
I suggested this change in default behavior [a long time ago](https://github.com/rust-lang/cargo/issues/1520#issuecomment-135215284) and [a year ago again](https://github.com/rust-lang/cargo/issues/1520#issuecomment-420616261). Both time, everyone seemed to agree that this is a good idea, so I thought I could just implement it.

This PR already changed the default behavior, but there are a few things we should talk about/I should do before merging:

- [x] ~~Do we *really* want this changed default behavior? If not, *why* not?~~ -> [yip](https://github.com/rust-lang/cargo/pull/7593#issuecomment-556482199)
- [x] Is changing this default behavior OK regarding backwards compatibility? -> [apparently](https://github.com/rust-lang/cargo/pull/7593#issuecomment-556482199)
- [x] ~~We should also probably add a `--document-only-public-items` flag or something like that if we change the default behavior. Otherwise users have no way to not document private items for binary crates. Right?~~ -> [We can do it later](https://github.com/rust-lang/cargo/pull/7593#issuecomment-557152039)
- [x] I should probably add some tests for this new behavior -> I did
- [ ] I don't like that I added `rustdoc_document_private_items` to `CompileOptions`, but this was the sanest way I could think of without rewriting a whole lot. Is this OK or how else would one do it? The flag would belong to `DocOptions`. But `compile` does not have access to that. Any ideas? Btw: If we also add `--document-only-private-items`, I would change the type from `bool` to `Option<bool>`.