### PR TITLE
Ignore file lock errors if unsupported, on Windows

### DIFF
--- a/src/cargo/util/flock.rs
+++ b/src/cargo/util/flock.rs
@@ -7,6 +7,8 @@ use fs2::{lock_contended_error, FileExt};
 #[allow(unused_imports)]
 use libc;
 use termcolor::Color::Cyan;
+#[cfg(windows)]
+use winapi::shared::winerror::ERROR_INVALID_FUNCTION;
 
 use crate::util::errors::{CargoResult, CargoResultExt};
 use crate::util::paths;
@@ -310,6 +312,9 @@ fn acquire(
 
         #[cfg(target_os = "linux")]
         Err(ref e) if e.raw_os_error() == Some(libc::ENOSYS) => return Ok(()),
+
+        #[cfg(windows)]
+        Err(ref e) if e.raw_os_error() == Some(ERROR_INVALID_FUNCTION as i32) => return Ok(()),
 
         Err(e) => {
             if e.raw_os_error() != lock_contended_error().raw_os_error() {


### PR DESCRIPTION
Not all file systems support file locking; WSL’s network file system doesn’t seem to, and I don’t think other network file systems will, either (though I haven’t checked them). ERROR_INVALID_FUNCTION is Windows’ equivalent to Unix’s ENOTSUP and Linux’s ENOSYS which are checked just above.

Fixes #7511.