### PR TITLE
bump im-rc version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ walkdir = "2.2"
 clap = "2.31.2"
 unicode-width = "0.1.5"
 openssl = { version = '0.10.11', optional = true }
-im-rc = "13.0.0"
+im-rc = "14.0.0"
 
 # A noop dependency that changes in the Rust repository, it's a bit of a hack.
 # See the `src/tools/rustc-workspace-hack/README.md` file in `rust-lang/rust`


### PR DESCRIPTION
This bumps im-rc to a version that includes (transitively) the soundness fix in https://github.com/bodil/sized-chunks/pull/3.

* [im-rc changelog](https://github.com/bodil/im-rs/blob/master/CHANGELOG.md#1400---2019-11-19)