### PR TITLE
Propagate linker args upwards in the dependency graph.

### DIFF
--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -350,6 +350,12 @@ fn rustc<'a, 'cfg>(
             for path in output.library_paths.iter() {
                 rustc.arg("-L").arg(path);
             }
+            if pass_cdylib_link_args {
+                for arg in output.linker_args.iter() {
+                    let link_arg = format!("link-arg={}", arg);
+                    rustc.arg("-C").arg(link_arg);
+                }
+            }
             if key.0 == current_id {
                 for cfg in &output.cfgs {
                     rustc.arg("--cfg").arg(cfg);
@@ -357,12 +363,6 @@ fn rustc<'a, 'cfg>(
                 if pass_l_flag {
                     for name in output.library_links.iter() {
                         rustc.arg("-l").arg(name);
-                    }
-                }
-                if pass_cdylib_link_args {
-                    for arg in output.linker_args.iter() {
-                        let link_arg = format!("link-arg={}", arg);
-                        rustc.arg("-C").arg(link_arg);
                     }
                 }
             }


### PR DESCRIPTION
Suggestion from @froydnj to enable a build script to pass linker args
relevant for dependencies of a crate.

The use case is to allow specifying "-Wl,-undefined,dynamic_lookup" on
MacOS for dynamic library crates with undefined symbols, such as a
symbol defined in the program loading the library.

We can consider supporting this case in rustc itself to avoid the need
for platform-specific flags in typical cdylib cases. But this seems
like an independently-useful mechanism that could enable workaround
for other linking problems, as well.

Enables workaround for #62874