### PR TITLE
Add value OUT_DIR to build-script-executed JSON message

### DIFF
--- a/src/cargo/core/compiler/custom_build.rs
+++ b/src/cargo/core/compiler/custom_build.rs
@@ -106,7 +106,12 @@ pub fn prepare<'a, 'cfg>(cx: &mut Context<'a, 'cfg>, unit: &Unit<'a>) -> CargoRe
     }
 }
 
-fn emit_build_output(state: &JobState<'_>, output: &BuildOutput, package_id: PackageId) {
+fn emit_build_output(
+    state: &JobState<'_>,
+    output: &BuildOutput,
+    out_dir: &Path,
+    package_id: PackageId,
+) {
     let library_paths = output
         .library_paths
         .iter()
@@ -119,6 +124,7 @@ fn emit_build_output(state: &JobState<'_>, output: &BuildOutput, package_id: Pac
         linked_paths: &library_paths,
         cfgs: &output.cfgs,
         env: &output.env,
+        out_dir,
     }
     .to_json_string();
     state.stdout(msg);
@@ -349,7 +355,7 @@ fn build_work<'a, 'cfg>(cx: &mut Context<'a, 'cfg>, unit: &Unit<'a>) -> CargoRes
             BuildOutput::parse(&output.stdout, &pkg_name, &script_out_dir, &script_out_dir)?;
 
         if json_messages {
-            emit_build_output(state, &parsed_output, id);
+            emit_build_output(state, &parsed_output, script_out_dir.as_path(), id);
         }
         build_script_outputs
             .lock()
@@ -374,7 +380,7 @@ fn build_work<'a, 'cfg>(cx: &mut Context<'a, 'cfg>, unit: &Unit<'a>) -> CargoRes
         };
 
         if json_messages {
-            emit_build_output(state, &output, id);
+            emit_build_output(state, &output, script_out_dir.as_path(), id);
         }
 
         build_script_outputs

--- a/src/cargo/util/machine_message.rs
+++ b/src/cargo/util/machine_message.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use serde::ser;
 use serde::Serialize;
@@ -66,6 +66,7 @@ pub struct BuildScript<'a> {
     pub linked_paths: &'a [String],
     pub cfgs: &'a [String],
     pub env: &'a [(String, String)],
+    pub out_dir: &'a Path,
 }
 
 impl<'a> Message for BuildScript<'a> {

--- a/src/doc/src/reference/external-tools.md
+++ b/src/doc/src/reference/external-tools.md
@@ -209,7 +209,7 @@ may be found in [the chapter on build scripts](build-scripts.md).
     "env": [
         ["SOME_KEY", "some value"],
         ["ANOTHER_KEY", "another value"]
-    ]
+    ],
     /* A path which is used as a value of `OUT_DIR` environmental variable
        when compiling current package.
     */

--- a/src/doc/src/reference/external-tools.md
+++ b/src/doc/src/reference/external-tools.md
@@ -210,6 +210,10 @@ may be found in [the chapter on build scripts](build-scripts.md).
         ["SOME_KEY", "some value"],
         ["ANOTHER_KEY", "another value"]
     ]
+    /* A path which is used as a value of `OUT_DIR` environmental variable
+       when compiling current package.
+    */
+    "out_dir": "/some/path/in/target/dir"
 }
 ```
 

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -3095,7 +3095,8 @@ fn compiler_json_error_format() {
         "linked_libs":[],
         "linked_paths":[],
         "env":[],
-        "cfgs":["xyz"]
+        "cfgs":["xyz"],
+        "out_dir": "[..]target/debug/build/foo-[..]/out"
     }
 
     {

--- a/tests/testsuite/metabuild.rs
+++ b/tests/testsuite/metabuild.rs
@@ -711,6 +711,7 @@ fn metabuild_json_artifact() {
   "linked_libs": [],
   "linked_paths": [],
   "package_id": "foo [..]",
+  "out_dir": "[..]",
   "reason": "build-script-executed"
 }
 "#,


### PR DESCRIPTION
The target audience here is IDE authors, who can use this feature to
better support crates which generate code to OUT_DIR