### PR TITLE
Update documentation for custom target dependencies.

### DIFF
--- a/src/doc/src/reference/specifying-dependencies.md
+++ b/src/doc/src/reference/specifying-dependencies.md
@@ -483,20 +483,16 @@ winhttp = "0.4.0"
 openssl = "1.0.1"
 ```
 
-If you’re using a custom target specification, quote the full path and file
-name:
+If you’re using a custom target specification (such as `--target
+foo/bar.json`), use the base filename without the `.json` extension:
 
 ```toml
-[target."x86_64/windows.json".dependencies]
+[target.bar.dependencies]
 winhttp = "0.4.0"
 
-[target."i686/linux.json".dependencies]
+[target.my-special-i686-platform.dependencies]
 openssl = "1.0.1"
 native = { path = "native/i686" }
-
-[target."x86_64/linux.json".dependencies]
-openssl = "1.0.1"
-native = { path = "native/x86_64" }
 ```
 
 ### Development dependencies

--- a/tests/build-std/main.rs
+++ b/tests/build-std/main.rs
@@ -114,7 +114,24 @@ fn basic() {
 #[cargo_test(build_std)]
 fn cross_custom() {
     let p = project()
-        .file("src/lib.rs", "#![no_std] pub fn f() {}")
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.1.0"
+                edition = "2018"
+
+                [target.custom-target.dependencies]
+                dep = { path = "dep" }
+            "#,
+        )
+        .file(
+            "src/lib.rs",
+            "#![no_std] pub fn f() -> u32 { dep::answer() }",
+        )
+        .file("dep/Cargo.toml", &basic_manifest("dep", "0.1.0"))
+        .file("dep/src/lib.rs", "#![no_std] pub fn answer() -> u32 { 42 }")
         .file(
             "custom-target.json",
             r#"


### PR DESCRIPTION
Closes #7613.

The old documentation was wrong, and hasn't worked for some time. It needs to be the file stem (see issue for discussion).

I also added a test, since I couldn't find any.  It was remarkably awkward to add the test without build-std, so I just added it to a build-std test.
