### PR TITLE
vendor: don't use canonical path in .cargo/config

### DIFF
--- a/src/cargo/ops/vendor.rs
+++ b/src/cargo/ops/vendor.rs
@@ -240,7 +240,7 @@ fn sync(
     config.insert(
         merged_source_name.to_string(),
         VendorSource::Directory {
-            directory: canonical_destination.to_path_buf(),
+            directory: opts.destination.to_path_buf(),
         },
     );
 


### PR DESCRIPTION
Use the user-specified path as-is, so it remains relative if specified as relative.
Should also address Windows path canonicalization issues.

Resolves issue #7316