### PR TITLE
Stop ignoring .rs.bk files; rustfmt hasn't generated them in years

### DIFF
--- a/src/cargo/ops/cargo_new.rs
+++ b/src/cargo/ops/cargo_new.rs
@@ -581,7 +581,6 @@ fn mk(config: &Config, opts: &MkOptions<'_>) -> CargoResult<()> {
     // both `ignore` and `hgignore` are in sync.
     let mut ignore = IgnoreList::new();
     ignore.push("/target", "^target/");
-    ignore.push("**/*.rs.bk", "glob:*.rs.bk");
     if !opts.bin {
         ignore.push("Cargo.lock", "glob:Cargo.lock");
     }

--- a/tests/testsuite/init.rs
+++ b/tests/testsuite/init.rs
@@ -94,7 +94,6 @@ fn simple_git_ignore_exists() {
          #already existing elements were commented out\n\
          \n\
          #/target\n\
-         **/*.rs.bk\n\
          Cargo.lock\n",
     );
 
@@ -123,7 +122,6 @@ fn git_ignore_exists_no_conflicting_entries() {
          #Added by cargo\n\
          \n\
          /target\n\
-         **/*.rs.bk\n\
          Cargo.lock\n",
     );
 }

--- a/tests/testsuite/new.rs
+++ b/tests/testsuite/new.rs
@@ -91,7 +91,7 @@ fn simple_git() {
         .unwrap()
         .read_to_string(&mut contents)
         .unwrap();
-    assert_eq!(contents, "/target\n**/*.rs.bk\nCargo.lock\n",);
+    assert_eq!(contents, "/target\nCargo.lock\n",);
 
     cargo_process("build").cwd(&paths::root().join("foo")).run();
 }


### PR DESCRIPTION
cargo currently generates a .gitignore file that ignores .rs.bk files,
historically because rustfmt would sometimes generate such files.
However, rustfmt and cargo fmt don't generate backup files by default
(only when requested), and even when requested, they generate .bk files,
not .rs.bk files (as of rustfmt commit
fad903fd14ad0df045dc574cac0717312860c380 in 2017). And nobody seems to
have noticed or complained since then, likely because rustfmt doesn't
generate backup files by default.

rustfmt also plans to deprecate the --backup option entirely, in rustfmt
2.0, and instead always rely on version control to track changes.

In addition, these types of ignores, just like ignores of editor backup
files, don't belong in .gitignore; they belong in people's personal
ignore files, such as `~/.config/git/ignore`.  See
https://julien.danjou.info/properly-managing-your-gitignore/ for further
explanation of that.

Given all three of those factors, drop the code to add `**/*.rs.bk` to
.gitignore, and update tests accordingly.