### PR TITLE
Config enhancements.

### DIFF
--- a/crates/cargo-test-support/src/git.rs
+++ b/crates/cargo-test-support/src/git.rs
@@ -12,7 +12,7 @@ let git_project = git::new("dep1", |project| {
     project
         .file("Cargo.toml", &basic_manifest("dep1"))
         .file("src/lib.rs", r#"pub fn f() { println!("hi!"); } "#)
-}).unwrap();
+});
 
 // Use the `url()` method to get the file url to the new repository.
 let p = project()

--- a/crates/cargo-test-support/src/lib.rs
+++ b/crates/cargo-test-support/src/lib.rs
@@ -1846,3 +1846,12 @@ pub fn symlink_supported() -> bool {
 pub fn symlink_supported() -> bool {
     true
 }
+
+/// The error message for ENOENT.
+///
+/// It's generally not good to match against OS error messages, but I think
+/// this one is relatively stable.
+#[cfg(windows)]
+pub const NO_SUCH_FILE_ERR_MSG: &str = "The system cannot find the file specified. (os error 2)";
+#[cfg(not(windows))]
+pub const NO_SUCH_FILE_ERR_MSG: &str = "No such file or directory (os error 2)";

--- a/crates/resolver-tests/tests/resolve.rs
+++ b/crates/resolver-tests/tests/resolve.rs
@@ -68,6 +68,7 @@ proptest! {
                 false,
                 &None,
                 &["minimal-versions".to_string()],
+                &[],
             )
             .unwrap();
 
@@ -571,6 +572,7 @@ fn test_resolving_minimum_version_with_transitive_deps() {
             false,
             &None,
             &["minimal-versions".to_string()],
+            &[],
         )
         .unwrap();
 

--- a/crates/resolver-tests/tests/resolve.rs
+++ b/crates/resolver-tests/tests/resolve.rs
@@ -62,7 +62,7 @@ proptest! {
             .configure(
                 1,
                 None,
-                &None,
+                None,
                 false,
                 false,
                 false,
@@ -565,7 +565,7 @@ fn test_resolving_minimum_version_with_transitive_deps() {
         .configure(
             1,
             None,
-            &None,
+            None,
             false,
             false,
             false,

--- a/src/bin/cargo/cli.rs
+++ b/src/bin/cargo/cli.rs
@@ -165,7 +165,7 @@ fn execute_subcommand(config: &mut Config, args: &ArgMatches<'_>) -> CliResult {
         } else {
             None
         },
-        &args.value_of("color").map(|s| s.to_string()),
+        args.value_of("color"),
         args.is_present("frozen"),
         args.is_present("locked"),
         args.is_present("offline"),

--- a/src/bin/cargo/cli.rs
+++ b/src/bin/cargo/cli.rs
@@ -10,6 +10,9 @@ use super::list_commands;
 use crate::command_prelude::*;
 
 pub fn main(config: &mut Config) -> CliResult {
+    // CAUTION: Be careful with using `config` until it is configured below.
+    // In general, try to avoid loading config values unless necessary (like
+    // the [alias] table).
     let args = match cli().get_matches_safe() {
         Ok(args) => args,
         Err(e) => {
@@ -90,8 +93,18 @@ Run with 'cargo -Z [FLAG] [SUBCOMMAND]'"
     }
 
     let args = expand_aliases(config, args)?;
+    let (cmd, subcommand_args) = match args.subcommand() {
+        (cmd, Some(args)) => (cmd, args),
+        _ => {
+            // No subcommand provided.
+            cli().print_help()?;
+            return Ok(());
+        }
+    };
+    config_configure(config, &args, subcommand_args)?;
+    super::init_git_transports(&config);
 
-    execute_subcommand(config, &args)
+    execute_subcommand(config, cmd, subcommand_args)
 }
 
 pub fn get_version_string(is_verbose: bool) -> String {
@@ -147,24 +160,21 @@ fn expand_aliases(
     Ok(args)
 }
 
-fn execute_subcommand(config: &mut Config, args: &ArgMatches<'_>) -> CliResult {
-    let (cmd, subcommand_args) = match args.subcommand() {
-        (cmd, Some(args)) => (cmd, args),
-        _ => {
-            cli().print_help()?;
-            return Ok(());
-        }
-    };
-
+fn config_configure(
+    config: &mut Config,
+    args: &ArgMatches<'_>,
+    subcommand_args: &ArgMatches<'_>,
+) -> CliResult {
     let arg_target_dir = &subcommand_args.value_of_path("target-dir", config);
-
+    let config_args: Vec<&str> = args.values_of("config").unwrap_or_default().collect();
+    let quiet = if args.is_present("quiet") || subcommand_args.is_present("quiet") {
+        Some(true)
+    } else {
+        None
+    };
     config.configure(
         args.occurrences_of("verbose") as u32,
-        if args.is_present("quiet") || subcommand_args.is_present("quiet") {
-            Some(true)
-        } else {
-            None
-        },
+        quiet,
         args.value_of("color"),
         args.is_present("frozen"),
         args.is_present("locked"),
@@ -173,8 +183,16 @@ fn execute_subcommand(config: &mut Config, args: &ArgMatches<'_>) -> CliResult {
         &args
             .values_of_lossy("unstable-features")
             .unwrap_or_default(),
+        &config_args,
     )?;
+    Ok(())
+}
 
+fn execute_subcommand(
+    config: &mut Config,
+    cmd: &str,
+    subcommand_args: &ArgMatches<'_>,
+) -> CliResult {
     if let Some(exec) = commands::builtin_exec(cmd) {
         return exec(config, subcommand_args);
     }
@@ -241,6 +259,11 @@ See 'cargo help <command>' for more information on a specific command.\n",
         .arg(opt("frozen", "Require Cargo.lock and cache are up to date").global(true))
         .arg(opt("locked", "Require Cargo.lock is up to date").global(true))
         .arg(opt("offline", "Run without accessing the network").global(true))
+        .arg(
+            multi_opt("config", "KEY=VALUE", "Override a configuration value")
+                .global(true)
+                .hidden(true),
+        )
         .arg(
             Arg::with_name("unstable-features")
                 .help("Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details")

--- a/src/bin/cargo/main.rs
+++ b/src/bin/cargo/main.rs
@@ -35,7 +35,6 @@ fn main() {
     let result = match cargo::ops::fix_maybe_exec_rustc() {
         Ok(true) => Ok(()),
         Ok(false) => {
-            init_git_transports(&config);
             let _token = cargo::util::job::setup();
             cli::main(&mut config)
         }

--- a/src/cargo/core/compiler/custom_build.rs
+++ b/src/cargo/core/compiler/custom_build.rs
@@ -1,18 +1,16 @@
-use cargo_platform::Cfg;
-use std::collections::hash_map::{Entry, HashMap};
-use std::collections::{BTreeSet, HashSet};
-use std::path::{Path, PathBuf};
-use std::str;
-use std::sync::Arc;
-
+use super::job::{Freshness, Job, Work};
+use super::{fingerprint, CompileKind, Context, Unit};
 use crate::core::compiler::job_queue::JobState;
 use crate::core::{profiles::ProfileRoot, PackageId};
 use crate::util::errors::{CargoResult, CargoResultExt};
 use crate::util::machine_message::{self, Message};
 use crate::util::{self, internal, paths, profile};
-
-use super::job::{Freshness, Job, Work};
-use super::{fingerprint, CompileKind, Context, Unit};
+use cargo_platform::Cfg;
+use std::collections::hash_map::{Entry, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashSet};
+use std::path::{Path, PathBuf};
+use std::str;
+use std::sync::Arc;
 
 /// Contains the parsed output of a custom build script.
 #[derive(Clone, Debug, Hash)]
@@ -181,7 +179,10 @@ fn build_work<'a, 'cfg>(cx: &mut Context<'a, 'cfg>, unit: &Unit<'a>) -> CargoRes
         .inherit_jobserver(&cx.jobserver);
 
     if let Some(linker) = &bcx.target_config(unit.kind).linker {
-        cmd.env("RUSTC_LINKER", linker);
+        cmd.env(
+            "RUSTC_LINKER",
+            linker.val.clone().resolve_program(bcx.config),
+        );
     }
 
     if let Some(links) = unit.pkg.manifest().links() {
@@ -739,4 +740,78 @@ fn prev_build_output<'a, 'cfg>(
         .ok(),
         prev_script_out_dir,
     )
+}
+
+impl<'de> serde::Deserialize<'de> for BuildOutput {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        use serde::de::Error;
+        /// Helper to deserialize `BuildOutput`.
+        #[derive(Debug, Default, serde::Deserialize)]
+        #[serde(rename_all = "kebab-case")]
+        #[serde(default)]
+        struct LinksOverride {
+            rustc_flags: Option<String>,
+            rustc_link_lib: Vec<String>,
+            rustc_link_search: Vec<PathBuf>,
+            rustc_cdylib_link_arg: Vec<String>,
+            rustc_cfg: Vec<String>,
+            rustc_env: Option<HashMap<String, String>>,
+            warning: Option<String>,
+            rerun_if_changed: Option<Vec<String>>,
+            rerun_if_env_changed: Option<Vec<String>>,
+            #[serde(flatten)]
+            // Sort so it is consistent and deterministic (for fingerprinting and errors).
+            metadata: BTreeMap<String, String>,
+        }
+
+        // Note: Some of this could be improved, for example using StringList
+        // and other convenience types. I also wonder if it should maybe use
+        // ConfigRelativePath, although that is more awkward, since it would
+        // require an intermediate step to translate LinksOverride to
+        // BuildOutput, converting the ConfigRelativePath values to PathBuf.
+
+        let lo = LinksOverride::deserialize(deserializer)?;
+        if lo.warning.is_some() {
+            return Err(Error::custom(format!(
+                "`warning` is not supported in build script overrides"
+            )));
+        }
+        if lo.rerun_if_changed.is_some() {
+            return Err(Error::custom(format!(
+                "`rerun-if-changed` is not supported in build script overrides"
+            )));
+        }
+        if lo.rerun_if_env_changed.is_some() {
+            return Err(Error::custom(format!(
+                "`rerun-if-env-changed` is not supported in build script overrides"
+            )));
+        }
+        let mut library_paths = lo.rustc_link_search;
+        let mut library_links = lo.rustc_link_lib;
+        if let Some(flags) = lo.rustc_flags {
+            let (paths, links) =
+                BuildOutput::parse_rustc_flags(&flags, "target config").map_err(Error::custom)?;
+            library_paths.extend(paths);
+            library_links.extend(links);
+        }
+        // Convert map to vec of (key, value).
+        let env = lo
+            .rustc_env
+            .map_or_else(Vec::new, |map| map.into_iter().collect());
+        let metadata: Vec<(String, String)> = lo.metadata.into_iter().collect();
+        Ok(BuildOutput {
+            library_paths,
+            library_links,
+            linker_args: lo.rustc_cdylib_link_arg,
+            cfgs: lo.rustc_cfg,
+            env,
+            metadata,
+            rerun_if_changed: Vec::new(),
+            rerun_if_env_changed: Vec::new(),
+            warnings: Vec::new(),
+        })
+    }
 }

--- a/src/cargo/core/compiler/custom_build.rs
+++ b/src/cargo/core/compiler/custom_build.rs
@@ -773,7 +773,12 @@ impl<'de> serde::Deserialize<'de> for BuildOutput {
         // require an intermediate step to translate LinksOverride to
         // BuildOutput, converting the ConfigRelativePath values to PathBuf.
 
-        let lo = LinksOverride::deserialize(deserializer)?;
+        let lo = LinksOverride::deserialize(deserializer).map_err(|e| {
+            serde::de::Error::custom(format!(
+                "failed to load config [target] links override table: {}",
+                e
+            ))
+        })?;
         if lo.warning.is_some() {
             return Err(Error::custom(
                 "`warning` is not supported in build script overrides",

--- a/src/cargo/core/compiler/custom_build.rs
+++ b/src/cargo/core/compiler/custom_build.rs
@@ -775,19 +775,19 @@ impl<'de> serde::Deserialize<'de> for BuildOutput {
 
         let lo = LinksOverride::deserialize(deserializer)?;
         if lo.warning.is_some() {
-            return Err(Error::custom(format!(
-                "`warning` is not supported in build script overrides"
-            )));
+            return Err(Error::custom(
+                "`warning` is not supported in build script overrides",
+            ));
         }
         if lo.rerun_if_changed.is_some() {
-            return Err(Error::custom(format!(
-                "`rerun-if-changed` is not supported in build script overrides"
-            )));
+            return Err(Error::custom(
+                "`rerun-if-changed` is not supported in build script overrides",
+            ));
         }
         if lo.rerun_if_env_changed.is_some() {
-            return Err(Error::custom(format!(
-                "`rerun-if-env-changed` is not supported in build script overrides"
-            )));
+            return Err(Error::custom(
+                "`rerun-if-env-changed` is not supported in build script overrides",
+            ));
         }
         let mut library_paths = lo.rustc_link_search;
         let mut library_links = lo.rustc_link_lib;

--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -28,7 +28,7 @@ use lazycell::LazyCell;
 use log::debug;
 
 pub use self::build_config::{BuildConfig, CompileMode, MessageFormat, ProfileKind};
-pub use self::build_context::{BuildContext, FileFlavor, TargetConfig, TargetInfo};
+pub use self::build_context::{BuildContext, FileFlavor, TargetInfo};
 use self::build_plan::BuildPlan;
 pub use self::compilation::{Compilation, Doctest};
 pub use self::compile_kind::{CompileKind, CompileTarget};
@@ -46,9 +46,8 @@ use crate::core::profiles::{Lto, PanicStrategy, Profile};
 use crate::core::{Edition, Feature, InternedString, PackageId, Target};
 use crate::util::errors::{self, CargoResult, CargoResultExt, Internal, ProcessError};
 use crate::util::machine_message::Message;
-use crate::util::paths;
 use crate::util::{self, machine_message, ProcessBuilder};
-use crate::util::{internal, join_paths, profile};
+use crate::util::{internal, join_paths, paths, profile};
 
 /// A glorified callback for executing calls to rustc. Rather than calling rustc
 /// directly, we'll use an `Executor`, giving clients an opportunity to intercept
@@ -850,12 +849,17 @@ fn build_base_args<'a, 'cfg>(
         cmd.arg("--target").arg(n.rustc_target());
     }
 
-    opt(cmd, "-C", "ar=", bcx.ar(unit.kind).map(|s| s.as_ref()));
+    opt(
+        cmd,
+        "-C",
+        "ar=",
+        bcx.ar(unit.kind).as_ref().map(|ar| ar.as_ref()),
+    );
     opt(
         cmd,
         "-C",
         "linker=",
-        bcx.linker(unit.kind).map(|s| s.as_ref()),
+        bcx.linker(unit.kind).as_ref().map(|s| s.as_ref()),
     );
     if incremental {
         let dir = cx.files().layout(unit.kind).incremental().as_os_str();

--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -332,6 +332,7 @@ pub struct CliUnstable {
     pub package_features: bool,
     pub advanced_env: bool,
     pub config_profile: bool,
+    pub config_include: bool,
     pub dual_proc_macros: bool,
     pub mtime_on_use: bool,
     pub named_profiles: bool,
@@ -396,6 +397,7 @@ impl CliUnstable {
             "package-features" => self.package_features = parse_empty(k, v)?,
             "advanced-env" => self.advanced_env = parse_empty(k, v)?,
             "config-profile" => self.config_profile = parse_empty(k, v)?,
+            "config-include" => self.config_include = parse_empty(k, v)?,
             "dual-proc-macros" => self.dual_proc_macros = parse_empty(k, v)?,
             // can also be set in .cargo/config or with and ENV
             "mtime-on-use" => self.mtime_on_use = parse_empty(k, v)?,

--- a/src/cargo/ops/resolve.rs
+++ b/src/cargo/ops/resolve.rs
@@ -392,16 +392,17 @@ pub fn add_overrides<'a>(
     registry: &mut PackageRegistry<'a>,
     ws: &Workspace<'a>,
 ) -> CargoResult<()> {
-    let paths = match ws.config().get_list("paths")? {
+    let config = ws.config();
+    let paths = match config.get_list("paths")? {
         Some(list) => list,
         None => return Ok(()),
     };
 
-    let paths = paths.val.iter().map(|&(ref s, ref p)| {
+    let paths = paths.val.iter().map(|(s, def)| {
         // The path listed next to the string is the config file in which the
         // key was located, so we want to pop off the `.cargo/config` component
         // to get the directory containing the `.cargo` folder.
-        (p.parent().unwrap().parent().unwrap().join(s), p)
+        (def.root(config).join(s), def)
     });
 
     for (path, definition) in paths {
@@ -412,7 +413,7 @@ pub fn add_overrides<'a>(
                 "failed to update path override `{}` \
                  (defined in `{}`)",
                 path.display(),
-                definition.display()
+                definition
             )
         })?;
         registry.add_override(Box::new(source));

--- a/src/cargo/util/config/mod.rs
+++ b/src/cargo/util/config/mod.rs
@@ -1526,8 +1526,8 @@ pub fn save_credentials(cfg: &Config, token: String, registry: Option<String>) -
 
     if let Some(_) = registry {
         if let Some(table) = toml.as_table_mut().unwrap().remove("registries") {
-            let v = CV::from_toml(file.path(), table)?;
-            value.merge(v)?;
+            let v = CV::from_toml(Definition::Path(file.path().to_path_buf()), table)?;
+            value.merge(v, false)?;
         }
     }
     toml.as_table_mut().unwrap().insert(key, value.into_toml());

--- a/src/cargo/util/config/path.rs
+++ b/src/cargo/util/config/path.rs
@@ -1,5 +1,5 @@
-use crate::util::config::{Config, Value};
-use serde::Deserialize;
+use super::{Config, StringList, Value};
+use serde::{de::Error, Deserialize};
 use std::path::PathBuf;
 
 /// Use with the `get` API to fetch a string that will be converted to a
@@ -31,5 +31,43 @@ impl ConfigRelativePath {
     /// absolute path.
     pub fn resolve_program(self, config: &Config) -> PathBuf {
         config.string_to_path(self.0.val, &self.0.definition)
+    }
+}
+
+/// A config type that is a program to run.
+///
+/// This supports a list of strings like `['/path/to/program', 'somearg']`
+/// or a space separated string like `'/path/to/program somearg'`.
+///
+/// This expects the first value to be the path to the program to run.
+/// Subsequent values are strings of arguments to pass to the program.
+///
+/// Typically you should use `ConfigRelativePath::resolve_program` on the path
+/// to get the actual program.
+#[derive(Debug, Clone)]
+pub struct PathAndArgs {
+    pub path: ConfigRelativePath,
+    pub args: Vec<String>,
+}
+
+impl<'de> serde::Deserialize<'de> for PathAndArgs {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let vsl = Value::<StringList>::deserialize(deserializer)?;
+        let mut strings = vsl.val.list;
+        if strings.len() == 0 {
+            return Err(D::Error::invalid_length(0, &"at least one element"));
+        }
+        let first = strings.remove(0);
+        let crp = Value {
+            val: first,
+            definition: vsl.definition,
+        };
+        Ok(PathAndArgs {
+            path: ConfigRelativePath(crp),
+            args: strings,
+        })
     }
 }

--- a/src/cargo/util/config/path.rs
+++ b/src/cargo/util/config/path.rs
@@ -57,7 +57,7 @@ impl<'de> serde::Deserialize<'de> for PathAndArgs {
     {
         let vsl = Value::<StringList>::deserialize(deserializer)?;
         let mut strings = vsl.val.list;
-        if strings.len() == 0 {
+        if strings.is_empty() {
             return Err(D::Error::invalid_length(0, &"at least one element"));
         }
         let first = strings.remove(0);

--- a/src/cargo/util/config/target.rs
+++ b/src/cargo/util/config/target.rs
@@ -27,7 +27,7 @@ pub struct TargetConfig {
     pub rustflags: OptValue<StringList>,
     /// The path of the linker for this target.
     pub linker: OptValue<ConfigRelativePath>,
-    /// The path of archiver (lib builder) for this target.
+    /// The path of archiver (lib builder) for this target. DEPRECATED/UNUSED
     pub ar: OptValue<ConfigRelativePath>,
     /// Build script override for the given library name.
     ///

--- a/src/cargo/util/config/target.rs
+++ b/src/cargo/util/config/target.rs
@@ -1,0 +1,67 @@
+use super::{Config, ConfigRelativePath, OptValue, PathAndArgs, StringList};
+use crate::core::compiler::BuildOutput;
+use crate::util::CargoResult;
+use serde::Deserialize;
+use std::collections::BTreeMap;
+
+/// Config definition of a [target.'cfg(…)'] table.
+///
+/// This is a subset of `TargetConfig`.
+#[derive(Debug, Deserialize)]
+pub struct TargetCfgConfig {
+    pub runner: OptValue<PathAndArgs>,
+    pub rustflags: OptValue<StringList>,
+    // This is here just to ignore fields from normal `TargetConfig` because
+    // all `[target]` tables are getting deserialized, whether they start with
+    // `cfg(` or not.
+    #[serde(flatten)]
+    pub other: BTreeMap<String, toml::Value>,
+}
+
+/// Config definition of a [target] table.
+#[derive(Debug, Deserialize)]
+pub struct TargetConfig {
+    /// Process to run as a wrapper for `cargo run`, `test`, and `bench` commands.
+    pub runner: OptValue<PathAndArgs>,
+    /// Additional rustc flags to pass.
+    pub rustflags: OptValue<StringList>,
+    /// The path of the linker for this target.
+    pub linker: OptValue<ConfigRelativePath>,
+    /// The path of archiver (lib builder) for this target.
+    pub ar: OptValue<ConfigRelativePath>,
+    /// Build script override for the given library name.
+    ///
+    /// Any package with a `links` value for the given library name will skip
+    /// running its build script and instead use the given output from the
+    /// config file.
+    #[serde(flatten)]
+    pub links_overrides: BTreeMap<String, BuildOutput>,
+}
+
+pub(super) fn load_target_cfgs(config: &Config) -> CargoResult<Vec<(String, TargetCfgConfig)>> {
+    // Load all [target] tables, filter out the cfg() entries.
+    let mut result = Vec::new();
+    // Use a BTreeMap so the keys are sorted. This is important for
+    // deterministic ordering of rustflags, which affects fingerprinting and
+    // rebuilds. We may perhaps one day wish to ensure a deterministic
+    // ordering via the order keys were defined in files perhaps.
+    log::debug!("Loading all targets.");
+    let target: BTreeMap<String, TargetCfgConfig> = config.get("target")?;
+    log::debug!("Got all targets {:#?}", target);
+    for (key, cfg) in target {
+        if key.starts_with("cfg(") {
+            // Unfortunately this is not able to display the location of the
+            // unused key. Using config::Value<toml::Value> doesn't work. One
+            // solution might be to create a special "Any" type, but I think
+            // that will be quite difficult with the current design.
+            for other_key in cfg.other.keys() {
+                config.shell().warn(format!(
+                    "unused key `{}` in [target] config table `{}`",
+                    other_key, key
+                ))?;
+            }
+            result.push((key, cfg));
+        }
+    }
+    Ok(result)
+}

--- a/src/cargo/util/config/value.rs
+++ b/src/cargo/util/config/value.rs
@@ -51,7 +51,7 @@ pub(crate) const DEFINITION_FIELD: &str = "$__cargo_private_definition";
 pub(crate) const NAME: &str = "$__cargo_private_Value";
 pub(crate) static FIELDS: [&str; 2] = [VALUE_FIELD, DEFINITION_FIELD];
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq)]
 pub enum Definition {
     Path(PathBuf),
     Environment(String),
@@ -64,6 +64,14 @@ impl Definition {
             Definition::Environment(_) => config.cwd(),
         }
     }
+
+    pub fn is_higher_priority(&self, other: &Definition) -> bool {
+        // environment > path
+        match (self, other) {
+            (Definition::Environment(_), Definition::Path(_)) => true,
+            _ => false,
+        }
+    }
 }
 
 impl PartialEq for Definition {
@@ -71,7 +79,7 @@ impl PartialEq for Definition {
         // configuration values are equivalent no matter where they're defined,
         // but they need to be defined in the same location. For example if
         // they're defined in the environment that's different than being
-        // defined in a file due to path interepretations.
+        // defined in a file due to path interpretations.
         mem::discriminant(self) == mem::discriminant(other)
     }
 }

--- a/src/cargo/util/config/value.rs
+++ b/src/cargo/util/config/value.rs
@@ -59,6 +59,10 @@ pub enum Definition {
 }
 
 impl Definition {
+    /// Root directory where this is defined.
+    ///
+    /// If from a file, it is the directory above `.cargo/config`.
+    /// CLI and env are the current working directory.
     pub fn root<'a>(&'a self, config: &'a Config) -> &'a Path {
         match self {
             Definition::Path(p) => p.parent().unwrap().parent().unwrap(),

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -724,7 +724,7 @@ impl<'de> de::Deserialize<'de> for StringOrBool {
     }
 }
 
-#[derive(Clone, Debug, Serialize)]
+#[derive(PartialEq, Clone, Debug, Serialize)]
 #[serde(untagged)]
 pub enum VecStringOrBool {
     VecString(Vec<String>),

--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -461,3 +461,27 @@ cargo --config "target.'cfg(all(target_arch = \"arm\", target_os = \"none\"))'.r
 # Example of overriding a profile setting.
 cargo --config profile.dev.package.image.opt-level=3 …
 ```
+
+### config-include
+* Original Issue: [#6699](https://github.com/rust-lang/cargo/issues/6699)
+
+The `include` key in a config file can be used to load another config file. It
+takes a string for a path to another file relative to the config file, or a
+list of strings. It requires the `-Zconfig-include` command-line option.
+
+```toml
+# .cargo/config
+include = '../../some-common-config.toml'
+```
+
+The config values are first loaded from the include path, and then the config
+file's own values are merged on top of it.
+
+This can be paired with [config-cli](#config-cli) to specify a file to load
+from the command-line:
+
+```console
+cargo +nightly -Zunstable-options -Zconfig-include --config 'include="somefile.toml"' build
+```
+
+CLI paths are relative to the current working directory.

--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -427,3 +427,37 @@ It's currently unclear how this feature will be stabilized in Cargo, but we'd
 like to stabilize it somehow!
 
 [rust-lang/rust#64158]: https://github.com/rust-lang/rust/pull/64158
+
+### config-cli
+* Original Issue: [#6699](https://github.com/rust-lang/cargo/issues/6699)
+
+The `--config` CLI option allows arbitrary config values to be passed
+in via the command-line. The argument should be in TOML syntax of KEY=VALUE:
+
+```console
+cargo +nightly -Zunstable-options --config net.git-fetch-with-cli=true fetch
+```
+
+The `--config` option may be specified multiple times, in which case the
+values are merged in left-to-right order, using the same merging logic that
+multiple config files use. CLI values take precedence over environment
+variables, which take precedence over config files.
+
+Some examples of what it looks like using Bourne shell syntax:
+
+```sh
+# Most shells will require escaping.
+cargo --config http.proxy=\"http://example.com\" …
+
+# Spaces may be used.
+cargo --config "net.git-fetch-with-cli = true" …
+
+# TOML array example. Single quotes make it easier to read and write.
+cargo --config 'build.rustdocflags = ["--html-in-header", "header.html"]' …
+
+# Example of a complex TOML key.
+cargo --config "target.'cfg(all(target_arch = \"arm\", target_os = \"none\"))'.runner = 'my-runner'" …
+
+# Example of overriding a profile setting.
+cargo --config profile.dev.package.image.opt-level=3 …
+```

--- a/tests/testsuite/advanced_env.rs
+++ b/tests/testsuite/advanced_env.rs
@@ -1,0 +1,35 @@
+//! -Zadvanced-env tests
+
+use cargo_test_support::{paths, project, registry::Package};
+
+#[cargo_test]
+fn source_config_env() {
+    // Try to define [source] with environment variables.
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "foo"
+            version = "0.1.0"
+
+            [dependencies]
+            somedep = "1.0"
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    Package::new("somedep", "1.0.0")
+        .local(true)
+        .file("src/lib.rs", "")
+        .publish();
+
+    let path = paths::root().join("registry");
+
+    p.cargo("check -Zadvanced-env")
+        .masquerade_as_nightly_cargo()
+        .env("CARGO_SOURCE_crates-io_REPLACE_WITH", "my-local-source")
+        .env("CARGO_SOURCE_my-local-source_LOCAL_REGISTRY", path)
+        .run();
+}

--- a/tests/testsuite/advanced_env.rs
+++ b/tests/testsuite/advanced_env.rs
@@ -3,6 +3,9 @@
 use cargo_test_support::{paths, project, registry::Package};
 
 #[cargo_test]
+// I don't know why, but `Command` forces all env keys to be upper case on
+// Windows. Seems questionable, since I think Windows is case-preserving.
+#[cfg_attr(windows, ignore)]
 fn source_config_env() {
     // Try to define [source] with environment variables.
     let p = project()

--- a/tests/testsuite/bad_config.rs
+++ b/tests/testsuite/bad_config.rs
@@ -1,7 +1,7 @@
 //! Tests for some invalid .cargo/config files.
 
 use cargo_test_support::registry::Package;
-use cargo_test_support::{basic_manifest, project};
+use cargo_test_support::{basic_manifest, project, rustc_host};
 
 #[cargo_test]
 fn bad1() {
@@ -865,7 +865,7 @@ fn bad_source_config1() {
 
     p.cargo("build")
         .with_status(101)
-        .with_stderr("error: no source URL specified for `source.foo`, need [..]")
+        .with_stderr("error: no source location specified for `source.foo`, need [..]")
         .run();
 }
 
@@ -1100,8 +1100,11 @@ fn bad_source_config6() {
         )
         .build();
 
-    p.cargo("build").with_status(101).with_stderr(
-            "error: expected a string, but found a array for `source.crates-io.replace-with` in [..]",
+    p.cargo("build")
+        .with_status(101)
+        .with_stderr(
+            "[ERROR] error in [..]/foo/.cargo/config: `source.crates-io.replace-with` \
+             expected a string, but found a array",
         )
         .run();
 }
@@ -1164,7 +1167,41 @@ fn bad_source_config7() {
 
     p.cargo("build")
         .with_status(101)
-        .with_stderr("error: more than one source URL specified for `source.foo`")
+        .with_stderr("error: more than one source location specified for `source.foo`")
+        .run();
+}
+
+#[cargo_test]
+fn bad_source_config8() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "foo"
+            version = "0.0.0"
+            authors = []
+
+            [dependencies]
+            bar = "*"
+        "#,
+        )
+        .file("src/lib.rs", "")
+        .file(
+            ".cargo/config",
+            r#"
+            [source.foo]
+            branch = "somebranch"
+        "#,
+        )
+        .build();
+
+    p.cargo("build")
+        .with_status(101)
+        .with_stderr(
+            "[ERROR] source definition `source.foo` specifies `branch`, \
+             but that requires a `git` key to be specified (in [..]/foo/.cargo/config)",
+        )
         .run();
 }
 
@@ -1278,5 +1315,82 @@ fn warn_semver_metadata() {
         .build();
     p.cargo("check")
         .with_stderr_contains("[WARNING] version requirement `1.0.0+1234` for dependency `bar`[..]")
+        .run();
+}
+
+#[cargo_test]
+fn bad_target_cfg() {
+    // Invalid type in a StringList.
+    //
+    // The error message is a bit unfortunate here. The type here ends up
+    // being essentially Value<Value<StringList>>, and each layer of "Value"
+    // adds some context to the error message. Also, untagged enums provide
+    // strange error messages. Hopefully most users will be able to untangle
+    // the message.
+    let p = project()
+        .file(
+            ".cargo/config",
+            r#"
+            [target.'cfg(not(target_os = "none"))']
+            runner = false
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    p.cargo("check")
+        .with_status(101)
+        .with_stderr(
+            "\
+[ERROR] error in [..]/foo/.cargo/config: \
+could not load config key `target.cfg(not(target_os = \"none\")).runner`: \
+error in [..]/foo/.cargo/config: \
+could not load config key `target.cfg(not(target_os = \"none\")).runner`: \
+failed to deserialize, expected a string or array of strings: \
+data did not match any variant of untagged enum Target
+",
+        )
+        .run();
+}
+
+#[cargo_test]
+fn bad_target_links_overrides() {
+    // Invalid parsing of links overrides.
+    //
+    // This error message is terrible. Nothing in the deserialization path is
+    // using config::Value<>, so nothing is able to report the location. I
+    // think this illustrates how the way things break down with how it
+    // currently is designed with serde.
+    let p = project()
+        .file(
+            ".cargo/config",
+            &format!(
+                r#"
+                [target.{}.somelib]
+                rustc-flags = 'foo'
+                "#,
+                rustc_host()
+            ),
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    p.cargo("check")
+        .with_status(101)
+        .with_stderr("[ERROR] Only `-l` and `-L` flags are allowed in target config: `foo`")
+        .run();
+
+    p.change_file(
+        ".cargo/config",
+        &format!(
+            "[target.{}.somelib]
+            warning = \"foo\"
+            ",
+            rustc_host(),
+        ),
+    );
+    p.cargo("check")
+        .with_status(101)
+        .with_stderr("[ERROR] `warning` is not supported in build script overrides")
         .run();
 }

--- a/tests/testsuite/config.rs
+++ b/tests/testsuite/config.rs
@@ -113,7 +113,7 @@ fn new_config(env: &[(&str, &str)]) -> Config {
         .configure(
             0,
             None,
-            &None,
+            None,
             false,
             false,
             false,

--- a/tests/testsuite/config.rs
+++ b/tests/testsuite/config.rs
@@ -305,7 +305,7 @@ unused = 456
     let path = paths::root().join("shell.out");
     let output = fs::read_to_string(path).unwrap();
     let expected = "\
-warning: unused key `S.unused` in config file `[..]/.cargo/config`
+warning: unused key `S.unused` in config `[..]/.cargo/config`
 ";
     if !lines_match(expected, &output) {
         panic!(

--- a/tests/testsuite/config_cli.rs
+++ b/tests/testsuite/config_cli.rs
@@ -1,0 +1,275 @@
+//! Tests for the --config CLI option.
+
+use super::config::{write_config, ConfigBuilder};
+use cargo::util::config::Definition;
+use cargo_test_support::{normalized_lines_match, paths, project};
+use std::fs;
+
+#[cargo_test]
+fn config_gated() {
+    // Requires -Zunstable-options
+    let p = project().file("src/lib.rs", "").build();
+
+    p.cargo("build --config --config build.jobs=1")
+        .with_status(101)
+        .with_stderr(
+            "\
+[ERROR] the `--config` flag is unstable, [..]
+See [..]
+See [..]
+",
+        )
+        .run();
+}
+
+#[cargo_test]
+fn basic() {
+    // Simple example.
+    let config = ConfigBuilder::new().config_arg("foo='bar'").build();
+    assert_eq!(config.get::<String>("foo").unwrap(), "bar");
+}
+
+#[cargo_test]
+fn cli_priority() {
+    // Command line takes priority over files and env vars.
+    write_config(
+        "
+        demo_list = ['a']
+        [build]
+        jobs = 3
+        rustc = 'file'
+        [term]
+        verbose = false
+        ",
+    );
+    let config = ConfigBuilder::new().build();
+    assert_eq!(config.get::<i32>("build.jobs").unwrap(), 3);
+    assert_eq!(config.get::<String>("build.rustc").unwrap(), "file");
+    assert_eq!(config.get::<bool>("term.verbose").unwrap(), false);
+
+    let config = ConfigBuilder::new()
+        .env("CARGO_BUILD_JOBS", "2")
+        .env("CARGO_BUILD_RUSTC", "env")
+        .env("CARGO_TERM_VERBOSE", "false")
+        .config_arg("build.jobs=1")
+        .config_arg("build.rustc='cli'")
+        .config_arg("term.verbose=true")
+        .build();
+    assert_eq!(config.get::<i32>("build.jobs").unwrap(), 1);
+    assert_eq!(config.get::<String>("build.rustc").unwrap(), "cli");
+    assert_eq!(config.get::<bool>("term.verbose").unwrap(), true);
+}
+
+#[cargo_test]
+fn merges_array() {
+    // Array entries are appended.
+    write_config(
+        "
+        [build]
+        rustflags = ['--file']
+        ",
+    );
+    let config = ConfigBuilder::new()
+        .config_arg("build.rustflags = ['--cli']")
+        .build();
+    assert_eq!(
+        config.get::<Vec<String>>("build.rustflags").unwrap(),
+        ["--file", "--cli"]
+    );
+
+    // With normal env.
+    let config = ConfigBuilder::new()
+        .env("CARGO_BUILD_RUSTFLAGS", "--env1 --env2")
+        .config_arg("build.rustflags = ['--cli']")
+        .build();
+    // The order of cli/env is a little questionable here, but would require
+    // much more complex merging logic.
+    assert_eq!(
+        config.get::<Vec<String>>("build.rustflags").unwrap(),
+        ["--file", "--cli", "--env1", "--env2"]
+    );
+
+    // With advanced-env.
+    let config = ConfigBuilder::new()
+        .unstable_flag("advanced-env")
+        .env("CARGO_BUILD_RUSTFLAGS", "--env")
+        .config_arg("build.rustflags = ['--cli']")
+        .build();
+    assert_eq!(
+        config.get::<Vec<String>>("build.rustflags").unwrap(),
+        ["--file", "--cli", "--env"]
+    );
+
+    // Merges multiple instances.
+    let config = ConfigBuilder::new()
+        .config_arg("build.rustflags=['--one']")
+        .config_arg("build.rustflags=['--two']")
+        .build();
+    assert_eq!(
+        config.get::<Vec<String>>("build.rustflags").unwrap(),
+        ["--file", "--one", "--two"]
+    );
+}
+
+#[cargo_test]
+fn string_list_array() {
+    // Using the StringList type.
+    write_config(
+        "
+        [build]
+        rustflags = ['--file']
+        ",
+    );
+    let config = ConfigBuilder::new()
+        .config_arg("build.rustflags = ['--cli']")
+        .build();
+    assert_eq!(
+        config
+            .get::<cargo::util::config::StringList>("build.rustflags")
+            .unwrap()
+            .as_slice(),
+        ["--file", "--cli"]
+    );
+
+    // With normal env.
+    let config = ConfigBuilder::new()
+        .env("CARGO_BUILD_RUSTFLAGS", "--env1 --env2")
+        .config_arg("build.rustflags = ['--cli']")
+        .build();
+    assert_eq!(
+        config
+            .get::<cargo::util::config::StringList>("build.rustflags")
+            .unwrap()
+            .as_slice(),
+        ["--file", "--cli", "--env1", "--env2"]
+    );
+
+    // With advanced-env.
+    let config = ConfigBuilder::new()
+        .unstable_flag("advanced-env")
+        .env("CARGO_BUILD_RUSTFLAGS", "['--env']")
+        .config_arg("build.rustflags = ['--cli']")
+        .build();
+    assert_eq!(
+        config
+            .get::<cargo::util::config::StringList>("build.rustflags")
+            .unwrap()
+            .as_slice(),
+        ["--file", "--cli", "--env"]
+    );
+}
+
+#[cargo_test]
+fn merges_table() {
+    // Tables are merged.
+    write_config(
+        "
+        [foo]
+        key1 = 1
+        key2 = 2
+        key3 = 3
+        ",
+    );
+    let config = ConfigBuilder::new()
+        .config_arg("foo.key2 = 4")
+        .config_arg("foo.key3 = 5")
+        .config_arg("foo.key4 = 6")
+        .build();
+    assert_eq!(config.get::<i32>("foo.key1").unwrap(), 1);
+    assert_eq!(config.get::<i32>("foo.key2").unwrap(), 4);
+    assert_eq!(config.get::<i32>("foo.key3").unwrap(), 5);
+    assert_eq!(config.get::<i32>("foo.key4").unwrap(), 6);
+
+    // With env.
+    let config = ConfigBuilder::new()
+        .env("CARGO_FOO_KEY3", "7")
+        .env("CARGO_FOO_KEY4", "8")
+        .env("CARGO_FOO_KEY5", "9")
+        .config_arg("foo.key2 = 4")
+        .config_arg("foo.key3 = 5")
+        .config_arg("foo.key4 = 6")
+        .build();
+    assert_eq!(config.get::<i32>("foo.key1").unwrap(), 1);
+    assert_eq!(config.get::<i32>("foo.key2").unwrap(), 4);
+    assert_eq!(config.get::<i32>("foo.key3").unwrap(), 5);
+    assert_eq!(config.get::<i32>("foo.key4").unwrap(), 6);
+    assert_eq!(config.get::<i32>("foo.key5").unwrap(), 9);
+}
+
+#[cargo_test]
+fn merge_array_mixed_def_paths() {
+    // Merging of arrays with different def sites.
+    write_config(
+        "
+        paths = ['file']
+        ",
+    );
+    // Create a directory for CWD to differentiate the paths.
+    let somedir = paths::root().join("somedir");
+    fs::create_dir(&somedir).unwrap();
+    let config = ConfigBuilder::new()
+        .cwd(&somedir)
+        .config_arg("paths=['cli']")
+        // env is currently ignored for get_list()
+        .env("CARGO_PATHS", "env")
+        .build();
+    let paths = config.get_list("paths").unwrap().unwrap();
+    // The definition for the root value is somewhat arbitrary, but currently starts with the file because that is what is loaded first.
+    assert_eq!(paths.definition, Definition::Path(paths::root()));
+    assert_eq!(paths.val.len(), 2);
+    assert_eq!(paths.val[0].0, "file");
+    assert_eq!(paths.val[0].1.root(&config), paths::root());
+    assert_eq!(paths.val[1].0, "cli");
+    assert_eq!(paths.val[1].1.root(&config), somedir);
+}
+
+#[cargo_test]
+fn unused_key() {
+    // Unused key passed on command line.
+    let config = ConfigBuilder::new()
+        .config_arg("build={jobs=1, unused=2}")
+        .build();
+
+    config.build_config().unwrap();
+    drop(config); // Paranoid about flushing the file.
+    let path = paths::root().join("shell.out");
+    let output = fs::read_to_string(path).unwrap();
+    let expected = "\
+warning: unused config key `build.unused` in `--config cli option`
+";
+    if !normalized_lines_match(expected, &output, None) {
+        panic!(
+            "Did not find expected:\n{}\nActual error:\n{}\n",
+            expected, output
+        );
+    }
+}
+
+#[cargo_test]
+fn rerooted_remains() {
+    // Re-rooting keeps cli args.
+    let somedir = paths::root().join("somedir");
+    fs::create_dir_all(somedir.join(".cargo")).unwrap();
+    fs::write(
+        somedir.join(".cargo").join("config"),
+        "
+        a = 'file1'
+        b = 'file2'
+        ",
+    )
+    .unwrap();
+    let mut config = ConfigBuilder::new()
+        .cwd(&somedir)
+        .config_arg("b='cli1'")
+        .config_arg("c='cli2'")
+        .build();
+    assert_eq!(config.get::<String>("a").unwrap(), "file1");
+    assert_eq!(config.get::<String>("b").unwrap(), "cli1");
+    assert_eq!(config.get::<String>("c").unwrap(), "cli2");
+
+    config.reload_rooted_at(paths::root()).unwrap();
+
+    assert_eq!(config.get::<Option<String>>("a").unwrap(), None);
+    assert_eq!(config.get::<String>("b").unwrap(), "cli1");
+    assert_eq!(config.get::<String>("c").unwrap(), "cli2");
+}

--- a/tests/testsuite/config_include.rs
+++ b/tests/testsuite/config_include.rs
@@ -3,6 +3,7 @@
 use super::config::{
     assert_error, assert_match, read_output, write_config, write_config_at, ConfigBuilder,
 };
+use cargo_test_support::NO_SUCH_FILE_ERR_MSG;
 
 #[cargo_test]
 fn gated() {
@@ -78,7 +79,8 @@ fn missing_file() {
     let config = ConfigBuilder::new().unstable_flag("config-include").build();
     assert_error(
         config.get::<i32>("whatever").unwrap_err(),
-        "\
+        &format!(
+            "\
 could not load Cargo configuration
 
 Caused by:
@@ -88,7 +90,9 @@ Caused by:
   failed to read configuration file `[..]/.cargo/missing`
 
 Caused by:
-  No such file or directory (os error 2)",
+  {}",
+            NO_SUCH_FILE_ERR_MSG
+        ),
     );
 }
 
@@ -162,11 +166,14 @@ fn cli_include_failed() {
         .build_err();
     assert_error(
         config.unwrap_err(),
-        "\
+        &format!(
+            "\
 failed to load --config include
 failed to load config include `foobar` from `--config cli option`
 failed to read configuration file `[..]/foobar`
-No such file or directory (os error 2)",
+{}",
+            NO_SUCH_FILE_ERR_MSG
+        ),
     );
 }
 

--- a/tests/testsuite/config_include.rs
+++ b/tests/testsuite/config_include.rs
@@ -1,0 +1,195 @@
+//! Tests for `include` config field.
+
+use super::config::{
+    assert_error, assert_match, read_output, write_config, write_config_at, ConfigBuilder,
+};
+
+#[cargo_test]
+fn gated() {
+    // Requires -Z flag.
+    write_config("include='other'");
+    let config = ConfigBuilder::new().build();
+    let output = read_output(config);
+    let expected = "\
+warning: config `include` in `[..]/.cargo/config` ignored, \
+the -Zconfig-include command-line flag is required
+";
+    assert_match(expected, &output);
+}
+
+#[cargo_test]
+fn simple() {
+    // Simple test.
+    write_config_at(
+        ".cargo/config",
+        "
+        include = 'other'
+        key1 = 1
+        key2 = 2
+        ",
+    );
+    write_config_at(
+        ".cargo/other",
+        "
+        key2 = 3
+        key3 = 4
+        ",
+    );
+    let config = ConfigBuilder::new().unstable_flag("config-include").build();
+    assert_eq!(config.get::<i32>("key1").unwrap(), 1);
+    assert_eq!(config.get::<i32>("key2").unwrap(), 2);
+    assert_eq!(config.get::<i32>("key3").unwrap(), 4);
+}
+
+#[cargo_test]
+fn left_to_right() {
+    // How it merges multiple includes.
+    write_config_at(
+        ".cargo/config",
+        "
+        include = ['one', 'two']
+        primary = 1
+        ",
+    );
+    write_config_at(
+        ".cargo/one",
+        "
+        one = 1
+        primary = 2
+        ",
+    );
+    write_config_at(
+        ".cargo/two",
+        "
+        two = 2
+        primary = 3
+        ",
+    );
+    let config = ConfigBuilder::new().unstable_flag("config-include").build();
+    assert_eq!(config.get::<i32>("primary").unwrap(), 1);
+    assert_eq!(config.get::<i32>("one").unwrap(), 1);
+    assert_eq!(config.get::<i32>("two").unwrap(), 2);
+}
+
+#[cargo_test]
+fn missing_file() {
+    // Error when there's a missing file.
+    write_config("include='missing'");
+    let config = ConfigBuilder::new().unstable_flag("config-include").build();
+    assert_error(
+        config.get::<i32>("whatever").unwrap_err(),
+        "\
+could not load Cargo configuration
+
+Caused by:
+  failed to load config include `missing` from `[..]/.cargo/config`
+
+Caused by:
+  failed to read configuration file `[..]/.cargo/missing`
+
+Caused by:
+  No such file or directory (os error 2)",
+    );
+}
+
+#[cargo_test]
+fn cycle() {
+    // Detects a cycle.
+    write_config_at(".cargo/config", "include='one'");
+    write_config_at(".cargo/one", "include='two'");
+    write_config_at(".cargo/two", "include='config'");
+    let config = ConfigBuilder::new().unstable_flag("config-include").build();
+    assert_error(
+        config.get::<i32>("whatever").unwrap_err(),
+        "\
+could not load Cargo configuration
+
+Caused by:
+  failed to load config include `one` from `[..]/.cargo/config`
+
+Caused by:
+  failed to load config include `two` from `[..]/.cargo/one`
+
+Caused by:
+  failed to load config include `config` from `[..]/.cargo/two`
+
+Caused by:
+  config `include` cycle detected with path `[..]/.cargo/config`",
+    );
+}
+
+#[cargo_test]
+fn cli_include() {
+    // Using --config with include.
+    // CLI takes priority over files.
+    write_config_at(
+        ".cargo/config",
+        "
+        foo = 1
+        bar = 2
+        ",
+    );
+    write_config_at(".cargo/config-foo", "foo = 2");
+    let config = ConfigBuilder::new()
+        .unstable_flag("config-include")
+        .config_arg("include='.cargo/config-foo'")
+        .build();
+    assert_eq!(config.get::<i32>("foo").unwrap(), 2);
+    assert_eq!(config.get::<i32>("bar").unwrap(), 2);
+}
+
+#[cargo_test]
+fn bad_format() {
+    // Not a valid format.
+    write_config("include = 1");
+    let config = ConfigBuilder::new().unstable_flag("config-include").build();
+    assert_error(
+        config.get::<i32>("whatever").unwrap_err(),
+        "\
+could not load Cargo configuration
+
+Caused by:
+  `include` expected a string or list, but found integer in `[..]/.cargo/config`",
+    );
+}
+
+#[cargo_test]
+fn cli_include_failed() {
+    // Error message when CLI include fails to load.
+    let config = ConfigBuilder::new()
+        .unstable_flag("config-include")
+        .config_arg("include='foobar'")
+        .build_err();
+    assert_error(
+        config.unwrap_err(),
+        "\
+failed to load --config include
+failed to load config include `foobar` from `--config cli option`
+failed to read configuration file `[..]/foobar`
+No such file or directory (os error 2)",
+    );
+}
+
+#[cargo_test]
+fn cli_merge_failed() {
+    // Error message when CLI include merge fails.
+    write_config("foo = ['a']");
+    write_config_at(
+        ".cargo/other",
+        "
+        foo = 'b'
+        ",
+    );
+    let config = ConfigBuilder::new()
+        .unstable_flag("config-include")
+        .config_arg("include='.cargo/other'")
+        .build_err();
+    // Maybe this error message should mention it was from an include file?
+    assert_error(
+        config.unwrap_err(),
+        "\
+failed to merge --config key `foo` into `[..]/.cargo/config`
+failed to merge config value from `[..]/.cargo/other` into `[..]/.cargo/config`: \
+expected array, but found string",
+    );
+}

--- a/tests/testsuite/install.rs
+++ b/tests/testsuite/install.rs
@@ -12,7 +12,7 @@ use cargo_test_support::install::{
 };
 use cargo_test_support::paths;
 use cargo_test_support::registry::Package;
-use cargo_test_support::{basic_manifest, cargo_process, project};
+use cargo_test_support::{basic_manifest, cargo_process, project, NO_SUCH_FILE_ERR_MSG};
 
 fn pkg(name: &str, vers: &str) {
     Package::new(name, vers)
@@ -824,11 +824,6 @@ fn uninstall_cwd_not_installed() {
 
 #[cargo_test]
 fn uninstall_cwd_no_project() {
-    let err_msg = if cfg!(windows) {
-        "The system cannot find the file specified."
-    } else {
-        "No such file or directory"
-    };
     cargo_process("uninstall")
         .with_status(101)
         .with_stdout("")
@@ -837,8 +832,8 @@ fn uninstall_cwd_no_project() {
 [ERROR] failed to read `[CWD]/Cargo.toml`
 
 Caused by:
-  {err_msg} (os error 2)",
-            err_msg = err_msg,
+  {err_msg}",
+            err_msg = NO_SUCH_FILE_ERR_MSG,
         ))
         .run();
 }

--- a/tests/testsuite/main.rs
+++ b/tests/testsuite/main.rs
@@ -32,6 +32,7 @@ mod collisions;
 mod concurrent;
 mod config;
 mod config_cli;
+mod config_include;
 mod corrupt_git;
 mod cross_compile;
 mod cross_publish;

--- a/tests/testsuite/main.rs
+++ b/tests/testsuite/main.rs
@@ -11,6 +11,7 @@
 #[macro_use]
 extern crate cargo_test_macro;
 
+mod advanced_env;
 mod alt_registry;
 mod bad_config;
 mod bad_manifest_path;

--- a/tests/testsuite/main.rs
+++ b/tests/testsuite/main.rs
@@ -31,6 +31,7 @@ mod clippy;
 mod collisions;
 mod concurrent;
 mod config;
+mod config_cli;
 mod corrupt_git;
 mod cross_compile;
 mod cross_publish;

--- a/tests/testsuite/profile_config.rs
+++ b/tests/testsuite/profile_config.rs
@@ -56,11 +56,11 @@ fn profile_config_validate_warnings() {
         .masquerade_as_nightly_cargo()
         .with_stderr_unordered(
             "\
-[WARNING] unused key `profile.asdf` in config file `[..].cargo/config`
-[WARNING] unused key `profile.test` in config file `[..].cargo/config`
-[WARNING] unused key `profile.dev.bad-key` in config file `[..].cargo/config`
-[WARNING] unused key `profile.dev.package.bar.bad-key-bar` in config file `[..].cargo/config`
-[WARNING] unused key `profile.dev.build-override.bad-key-bo` in config file `[..].cargo/config`
+[WARNING] unused key `profile.asdf` in config `[..].cargo/config`
+[WARNING] unused key `profile.test` in config `[..].cargo/config`
+[WARNING] unused key `profile.dev.bad-key` in config `[..].cargo/config`
+[WARNING] unused key `profile.dev.package.bar.bad-key-bar` in config `[..].cargo/config`
+[WARNING] unused key `profile.dev.build-override.bad-key-bo` in config `[..].cargo/config`
 [COMPILING] foo [..]
 [FINISHED] [..]
 ",

--- a/tests/testsuite/profile_config.rs
+++ b/tests/testsuite/profile_config.rs
@@ -56,11 +56,11 @@ fn profile_config_validate_warnings() {
         .masquerade_as_nightly_cargo()
         .with_stderr_unordered(
             "\
-[WARNING] unused key `profile.asdf` in config `[..].cargo/config`
-[WARNING] unused key `profile.test` in config `[..].cargo/config`
-[WARNING] unused key `profile.dev.bad-key` in config `[..].cargo/config`
-[WARNING] unused key `profile.dev.package.bar.bad-key-bar` in config `[..].cargo/config`
-[WARNING] unused key `profile.dev.build-override.bad-key-bo` in config `[..].cargo/config`
+[WARNING] unused config key `profile.asdf` in `[..].cargo/config`
+[WARNING] unused config key `profile.test` in `[..].cargo/config`
+[WARNING] unused config key `profile.dev.bad-key` in `[..].cargo/config`
+[WARNING] unused config key `profile.dev.package.bar.bad-key-bar` in `[..].cargo/config`
+[WARNING] unused config key `profile.dev.build-override.bad-key-bo` in `[..].cargo/config`
 [COMPILING] foo [..]
 [FINISHED] [..]
 ",

--- a/tests/testsuite/tool_paths.rs
+++ b/tests/testsuite/tool_paths.rs
@@ -279,7 +279,7 @@ fn custom_runner_env() {
     p.cargo("run")
         .env(&key, "nonexistent-runner --foo")
         .with_status(101)
-        .with_stderr_contains("[RUNNING] `nonexistent-runner --foo target/debug/foo`")
+        .with_stderr_contains("[RUNNING] `nonexistent-runner --foo target/debug/foo[EXE]`")
         .run();
 }
 

--- a/tests/testsuite/tool_paths.rs
+++ b/tests/testsuite/tool_paths.rs
@@ -256,9 +256,67 @@ fn custom_runner_cfg_collision() {
 
     p.cargo("run -- --param")
         .with_status(101)
-        .with_stderr_contains(
+        .with_stderr(
             "\
 [ERROR] several matching instances of `target.'cfg(..)'.runner` in `.cargo/config`
+first match `cfg(not(target_arch = \"avr\"))` located in [..]/foo/.cargo/config
+second match `cfg(not(target_os = \"none\"))` located in [..]/foo/.cargo/config
+",
+        )
+        .run();
+}
+
+#[cargo_test]
+fn custom_runner_env() {
+    let target = rustc_host();
+    let p = project().file("src/main.rs", "fn main() {}").build();
+
+    let key = format!(
+        "CARGO_TARGET_{}_RUNNER",
+        target.to_uppercase().replace('-', "_")
+    );
+
+    p.cargo("run")
+        .env(&key, "nonexistent-runner --foo")
+        .with_status(101)
+        .with_stderr_contains("[RUNNING] `nonexistent-runner --foo target/debug/foo`")
+        .run();
+}
+
+#[cargo_test]
+fn cfg_ignored_fields() {
+    // Test for some ignored fields in [target.'cfg()'] tables.
+    let p = project()
+        .file(
+            ".cargo/config",
+            r#"
+            # Try some empty tables.
+            [target.'cfg(not(foo))']
+            [target.'cfg(not(bar))'.somelib]
+
+            # A bunch of unused fields.
+            [target.'cfg(not(target_os = "none"))']
+            linker = 'false'
+            ar = 'false'
+            foo = {rustc-flags = "-l foo"}
+            invalid = 1
+            runner = 'false'
+            rustflags = ''
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    p.cargo("check")
+        .with_stderr(
+            "\
+[WARNING] unused key `somelib` in [target] config table `cfg(not(bar))`
+[WARNING] unused key `ar` in [target] config table `cfg(not(target_os = \"none\"))`
+[WARNING] unused key `foo` in [target] config table `cfg(not(target_os = \"none\"))`
+[WARNING] unused key `invalid` in [target] config table `cfg(not(target_os = \"none\"))`
+[WARNING] unused key `linker` in [target] config table `cfg(not(target_os = \"none\"))`
+[CHECKING] foo v0.0.1 ([..])
+[FINISHED] [..]
 ",
         )
         .run();


### PR DESCRIPTION
This is a collection of changes to config handling. I intended to split this into separate PRs, but they all built on one another so I decided to do it as one. However, I can still split this up if desired.

High level overview:

- Refactorings, mainly to remove `pub` from `Config::get_table` and use serde API instead.
- Add `--config` CLI option.
- Add config `include` to include other files.

This makes some progress on #5416.
Closes #6699.

This makes a minor user-visible change in regards to `StringList` types. If an array is specified in a config as a list, and also as an env var, they will now be merged. Previously the environment variable overrode the file value. But if it is a string, then it won't join (env var takes precedence). I can probably change this, but I'm not sure if the old behavior is desired, or if it should merge all the time?

**Future plans**
This lays the groundwork for some more changes:
- Work on #7253 (`debug-assertions` and `debug` fails in environment vars). I have some ideas to try.
- Consider removing use of `get_list` for `paths`, and use a `Vec<ConfigRelativePath>`. This will require some non-trivial changes to how `ConfigSeqAccess` works. This is one of the last parts that does not use the serde API.
- Possibly change `[source]` to load config values in a lazy fashion. This will unlock the ability to use environment variables with source definitions (like CARGO_SOURCE_CRATES_IO_REPLACE_WITH).
- Possibly change `[profile]` to load config profiles in a lazy fashion. This will make it easier to use environment variables with profiles, particularly with arbitrarily named profiles.
- Possibly remove the case-sensitive environment variables in `-Zadvanced-env`. I think they are just too awkward, and prone to problems. Instead, drive people towards using `--config` instead of env vars.
- Add support for TOML tables in env vars (like `CARGO_PROFILES={my-profile={opt-level=1}})`). I started implementing it, but then looking at the use cases, it didn't seem as useful as I initially thought. However, it's still an option to try.

**Refactoring overview**

- `[source]` table now uses the serde API.
- `[target]` table now uses the serde API. This is complicated since the 'cfg()' entries are different from the triple entries. The 'cfg()' tables are loaded separately, and are accessed from `Config::target_cfgs`. Otherwise, it just uses `config.get` of the specific target.TRIPLE.
    - Moved the target config stuff into `config/target.rs`.
- Various changes to make this work:
    - Added `PathAndArgs` type which replaces `config.get_path_and_args`.
    - Changed `ConfigKey` to track the key parts as a list (instead of a string). This fixes an issue where quoted keys weren't handled properly (like `[foo.'a.b'.bar]`). This also seems to make a little more sense (it was joining parts into a string only to immediately call `split` on it). Changed various APIs to take a `ConfigKey` object instead of a string to avoid that splitting behavior.
    - `ValueDeserializer` now pre-computes the `Definition` so that it can provide a better error message when a value fails to deserialize.

Overall, there shouldn't be significant user-visible changes. Some error messages have changed and warnings have been added for some ignored keys. `-Zadvanced-env` now works for source and target tables, though I'm not really happy with that feature.
