### PR TITLE
Add a --offline hint.

### DIFF
--- a/src/cargo/ops/lockfile.rs
+++ b/src/cargo/ops/lockfile.rs
@@ -56,8 +56,9 @@ pub fn write_pkg_lockfile(ws: &Workspace<'_>, resolve: &Resolve) -> CargoResult<
             "--frozen"
         };
         failure::bail!(
-            "the lock file {} needs to be updated but {} was passed to \
-             prevent this",
+            "the lock file {} needs to be updated but {} was passed to prevent this\n\
+             If you want to try to generate the lock file without accessing the network, \
+             use the --offline flag.",
             ws.root().to_path_buf().join("Cargo.lock").display(),
             flag
         );

--- a/tests/testsuite/lockfile_compat.rs
+++ b/tests/testsuite/lockfile_compat.rs
@@ -514,6 +514,7 @@ fn locked_correct_error() {
             "\
 [UPDATING] `[..]` index
 error: the lock file [CWD]/Cargo.lock needs to be updated but --locked was passed to prevent this
+If you want to try to generate the lock file without accessing the network, use the --offline flag.
 ",
         )
         .run();


### PR DESCRIPTION
If `--locked` or `--frozen` is used, but the lock file needs to be built or updated, provide a hint for an alternate solution of using `--offline`.

Closes #7584