### PR TITLE
Remove --offline empty index error.

### DIFF
--- a/src/cargo/sources/registry/remote.rs
+++ b/src/cargo/sources/registry/remote.rs
@@ -184,18 +184,6 @@ impl<'cfg> RegistryData for RemoteRegistry<'cfg> {
 
     fn update_index(&mut self) -> CargoResult<()> {
         if self.config.offline() {
-            if self.repo()?.is_empty()? {
-                // An empty repository is guaranteed to fail, since hitting
-                // this path means we need at least one crate. This is an
-                // attempt to provide a better error message other than "no
-                // matching package named …".
-                failure::bail!(
-                    "unable to fetch {} in offline mode\n\
-                     Try running without the offline flag, or try running \
-                     `cargo fetch` within your project directory before going offline.",
-                    self.source_id
-                );
-            }
             return Ok(());
         }
         if self.config.cli_unstable().no_index_update {


### PR DESCRIPTION
This reverts the error added in #6871 which attempts to provide a "nicer" error message if `--offline` is used with an empty index. I was concerned about false positives, and sure enough someone found one. If all deps are patched, it is OK for the index to be empty, because the resolver will just use the patched entries.

I considered trying to move the error to another location, but I think it would require significant changes to the registry API (which is already hard to follow). I figure the "not found" error message is good enough with the "don't use --offline" hint.

Closes #7582
