### PR TITLE
Change the link destination of cargo book contribution

### DIFF
--- a/src/doc/src/index.md
+++ b/src/doc/src/index.md
@@ -27,4 +27,4 @@ The reference covers the details of various areas of Cargo.
 
 [rust]: https://www.rust-lang.org/
 [crates.io]: https://crates.io/
-[GitHub]: https://github.com/rust-lang/cargo/tree/master/src/doc/src
+[GitHub]: https://github.com/rust-lang/cargo/tree/master/src/doc


### PR DESCRIPTION
`src/doc` directory has `README.md` about Cargo documentation
including description for contribution, while `src/doc/src` does not
have such a document.

I change the link destination of `GitHub` in the image below, https://doc.rust-lang.org/cargo/.

<img width="791" alt="スクリーンショット 2019-12-04 9 12 47" src="https://user-images.githubusercontent.com/17407489/70100804-4eaaf480-1676-11ea-9a0e-868119732631.png">
