### PR TITLE
Propagate existing VCS to subprojects

### DIFF
--- a/src/cargo/ops/fix.rs
+++ b/src/cargo/ops/fix.rs
@@ -52,7 +52,7 @@ use rustfix::diagnostics::Diagnostic;
 use rustfix::{self, CodeFix};
 
 use crate::core::Workspace;
-use crate::ops::{self, CompileOptions};
+use crate::ops::{self, CompileOptions, VersionControl};
 use crate::util::diagnostic_server::{Message, RustfixDiagnosticServer};
 use crate::util::errors::CargoResult;
 use crate::util::{self, paths};
@@ -146,7 +146,7 @@ fn check_version_control(opts: &FixOptions<'_>) -> CargoResult<()> {
         return Ok(());
     }
     let config = opts.compile_opts.config;
-    if !existing_vcs_repo(config.cwd(), config.cwd()) {
+    if VersionControl::NoVcs == existing_vcs_repo(config.cwd(), config.cwd()) {
         failure::bail!(
             "no VCS found for this package and `cargo fix` can potentially \
              perform destructive changes; if you'd like to suppress this \

--- a/src/cargo/util/vcs.rs
+++ b/src/cargo/util/vcs.rs
@@ -1,3 +1,4 @@
+use crate::ops::VersionControl;
 use crate::util::paths;
 use crate::util::{process, CargoResult};
 use git2;
@@ -8,7 +9,7 @@ use std::path::Path;
 // 1. We are in a git repo and the path to the new package is not an ignored
 //    path in that repo.
 // 2. We are in an HG repo.
-pub fn existing_vcs_repo(path: &Path, cwd: &Path) -> bool {
+pub fn existing_vcs_repo(path: &Path, cwd: &Path) -> VersionControl {
     fn in_git_repo(path: &Path, cwd: &Path) -> bool {
         if let Ok(repo) = GitRepo::discover(path, cwd) {
             // Don't check if the working directory itself is ignored.
@@ -22,7 +23,12 @@ pub fn existing_vcs_repo(path: &Path, cwd: &Path) -> bool {
         }
     }
 
-    in_git_repo(path, cwd) || HgRepo::discover(path, cwd).is_ok()
+    if in_git_repo(path, cwd) {
+        return VersionControl::Git;
+    } else if HgRepo::discover(path, cwd).is_ok() {
+        return VersionControl::Hg;
+    }
+    VersionControl::NoVcs
 }
 
 pub struct HgRepo;

--- a/tests/testsuite/new.rs
+++ b/tests/testsuite/new.rs
@@ -422,9 +422,6 @@ fn subpackage_no_git() {
     assert!(!paths::root()
         .join("foo/components/subcomponent/.git")
         .is_file());
-    assert!(!paths::root()
-        .join("foo/components/subcomponent/.gitignore")
-        .is_file());
 }
 
 #[cargo_test]


### PR DESCRIPTION
With this post, when creating a new project within an existing project, any existing VCS is reused by creating a matching ignore file in the new subfolder. (see issue #6357)

- If a VCS is explicitly given, e. g. by config or by command line option a new VCS environment will be initialized
- If there is no VCS explicitly given and we are not in an existing VCS environment, Git will be initialized
- If there is no VCS explicitly given and we are in an existing VCS, we propagate this VCS into the subproject