### PR TITLE
include dotfiles in packages

### DIFF
--- a/src/cargo/sources/path.rs
+++ b/src/cargo/sources/path.rs
@@ -356,7 +356,12 @@ impl<'cfg> PathSource<'cfg> {
             return Ok(());
         }
         // Skip dotfile directories.
-        if path.file_name().and_then(|s| s.to_str()).map(|s| s.starts_with('.')) == Some(true) {
+        if path
+            .file_name()
+            .and_then(|s| s.to_str())
+            .map(|s| s.starts_with('.'))
+            == Some(true)
+        {
             return Ok(());
         }
 

--- a/src/cargo/sources/path.rs
+++ b/src/cargo/sources/path.rs
@@ -339,7 +339,6 @@ impl<'cfg> PathSource<'cfg> {
         let root = pkg.root();
         let mut exclude_dot_files_dir_builder = GitignoreBuilder::new(root);
         exclude_dot_files_dir_builder.add_line(None, ".*")?;
-        exclude_dot_files_dir_builder.add_line(None, "*/.*/*")?;
         let ignore_dot_files_and_dirs = exclude_dot_files_dir_builder.build()?;
 
         let mut filter_ignore_dot_files_and_dirs = |path: &Path| -> CargoResult<bool> {

--- a/src/cargo/sources/path.rs
+++ b/src/cargo/sources/path.rs
@@ -355,6 +355,10 @@ impl<'cfg> PathSource<'cfg> {
         if !is_root && fs::metadata(&path.join("Cargo.toml")).is_ok() {
             return Ok(());
         }
+        // Skip dotfile directories.
+        if path.file_name().and_then(|s| s.to_str()).map(|s| s.starts_with('.')) == Some(true) {
+            return Ok(());
+        }
 
         // For package integration tests, we need to sort the paths in a deterministic order to
         // be able to match stdout warnings in the same order.
@@ -368,10 +372,6 @@ impl<'cfg> PathSource<'cfg> {
         entries.sort_unstable_by(|a, b| a.as_os_str().cmp(b.as_os_str()));
         for path in entries {
             let name = path.file_name().and_then(|s| s.to_str());
-            // Skip dotfile directories.
-            if name.map(|s| s.starts_with('.')) == Some(true) {
-                continue;
-            }
             if is_root && name == Some("target") {
                 // Skip Cargo artifacts.
                 continue;

--- a/tests/testsuite/package.rs
+++ b/tests/testsuite/package.rs
@@ -1422,3 +1422,26 @@ fn gitignore_negate() {
          ",
     );
 }
+
+#[cargo_test]
+fn exclude_dot_files_and_directories_by_default() {
+    include_exclude_test(
+        "[]",
+        "[]",
+        &["src/lib.rs", ".dotfile", ".dotdir/file"],
+        "Cargo.toml\n\
+         src/lib.rs\n\
+         ",
+    );
+
+    include_exclude_test(
+        r#"["Cargo.toml", "src/lib.rs", ".dotfile", ".dotdir/file"]"#,
+        "[]",
+        &["src/lib.rs", ".dotfile", ".dotdir/file"],
+        ".dotdir/file\n\
+         .dotfile\n\
+         Cargo.toml\n\
+         src/lib.rs\n\
+         ",
+    );
+}

--- a/tests/testsuite/package.rs
+++ b/tests/testsuite/package.rs
@@ -1420,3 +1420,51 @@ fn gitignore_negate() {
          ",
     );
 }
+
+#[cargo_test]
+fn include_dotfile() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [project]
+            name = "foo"
+            version = "0.0.1"
+        "#,
+        )
+        .file("src/main.rs", r#"fn main() { println!("hello"); }"#)
+        .file(".hidden", "") // should be included when packaging
+        .build();
+
+    p.cargo("package")
+        .with_stderr(
+            "\
+[WARNING] manifest has no [..]
+See [..]
+[PACKAGING] foo v0.0.1 ([CWD])
+[VERIFYING] foo v0.0.1 ([CWD])
+[COMPILING] foo v0.0.1 ([CWD][..])
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+",
+        )
+        .run();
+    assert!(p.root().join("target/package/foo-0.0.1.crate").is_file());
+    p.cargo("package -l")
+        .with_stdout(
+            "\
+.hidden
+Cargo.lock
+Cargo.toml
+src/main.rs
+",
+        )
+        .run();
+
+        let f = File::open(&p.root().join("target/package/foo-0.0.1.crate")).unwrap();
+        validate_crate_contents(
+            f,
+            "foo-0.0.1.crate",
+            &[".hidden", "Cargo.lock", "Cargo.toml", "Cargo.toml.orig", "src/main.rs"],
+            &[],
+        );
+}

--- a/tests/testsuite/package.rs
+++ b/tests/testsuite/package.rs
@@ -1460,11 +1460,17 @@ src/main.rs
         )
         .run();
 
-        let f = File::open(&p.root().join("target/package/foo-0.0.1.crate")).unwrap();
-        validate_crate_contents(
-            f,
-            "foo-0.0.1.crate",
-            &[".hidden", "Cargo.lock", "Cargo.toml", "Cargo.toml.orig", "src/main.rs"],
-            &[],
-        );
+    let f = File::open(&p.root().join("target/package/foo-0.0.1.crate")).unwrap();
+    validate_crate_contents(
+        f,
+        "foo-0.0.1.crate",
+        &[
+            ".hidden",
+            "Cargo.lock",
+            "Cargo.toml",
+            "Cargo.toml.orig",
+            "src/main.rs",
+        ],
+        &[],
+    );
 }


### PR DESCRIPTION
This PR solves #7183

It changes the behavior of `cargo package` to also include dotfiles by default.

It should be discussed if this is intended or if the implementation should be changed to only include dotfiles which are specified in the `include` section.

From the [existing comment](https://github.com/stefanhoelzl/cargo/blob/40885dfab40a1bf62b22aa03f732ef45163c013f/src/cargo/sources/path.rs#L358) it is a little bit unclear to me, but I supposed it was intended only to exclude directories starting with a dot?