### PR TITLE
Features and dependencies can't have the same name

### DIFF
--- a/src/doc/src/reference/manifest.md
+++ b/src/doc/src/reference/manifest.md
@@ -405,7 +405,7 @@ Cargo supports features to allow expression of:
 
 * conditional compilation options (usable through `cfg` attributes);
 * optional dependencies, which enhance a package, but are not required; and
-* clusters of optional dependencies, such as `postgres`, that would include the
+* clusters of optional dependencies, such as `postgres-all`, that would include the
   `postgres` package, the `postgres-macros` package, and possibly other packages
   (such as development-time mocking libraries, debugging tools, etc.).
 


### PR DESCRIPTION
The document was describing a Cargo.toml containing
```
[dependencies]
postgres = { version = "*", optional = true }
postgres-macros = { version = "*", optional = true }

[features]
postgres = ["postgres", "postgres-macros"]
```

If you tried doing this you'd get an error:
```
error: failed to parse manifest at `/home/jonathan/tmp/features/Cargo.toml`

Caused by:
  Features and dependencies cannot have the same name: `postgres`
```