### PR TITLE
Add a test for `cargo locate-project`

### DIFF
--- a/tests/testsuite/locate_project.rs
+++ b/tests/testsuite/locate_project.rs
@@ -1,0 +1,16 @@
+//! Tests for the `cargo locate-project` command.
+
+use cargo_test_support::project;
+
+#[cargo_test]
+fn simple() {
+    let p = project().build();
+    let root_manifest_path = p.root().join("Cargo.toml");
+
+    p.cargo("locate-project")
+        .with_stdout(format!(
+            r#"{{"root":"{}"}}"#,
+            root_manifest_path.to_str().unwrap()
+        ))
+        .run();
+}

--- a/tests/testsuite/main.rs
+++ b/tests/testsuite/main.rs
@@ -53,6 +53,7 @@ mod install_upgrade;
 mod jobserver;
 mod list_targets;
 mod local_registry;
+mod locate_project;
 mod lockfile_compat;
 mod login;
 mod member_errors;


### PR DESCRIPTION
There seems to be no test for `cargo locate-project`, so I add the simple test case for this command.