### PR TITLE
Add and move tests for jobs of `cargo build`

### DIFF
--- a/tests/testsuite/bad_config.rs
+++ b/tests/testsuite/bad_config.rs
@@ -163,36 +163,6 @@ invalid value: integer `-1`, expected u32
 }
 
 #[cargo_test]
-fn default_cargo_config_jobs() {
-    let p = project()
-        .file("src/lib.rs", "")
-        .file(
-            ".cargo/config",
-            r#"
-            [build]
-            jobs = 1
-        "#,
-        )
-        .build();
-    p.cargo("build -v").run();
-}
-
-#[cargo_test]
-fn good_cargo_config_jobs() {
-    let p = project()
-        .file("src/lib.rs", "")
-        .file(
-            ".cargo/config",
-            r#"
-            [build]
-            jobs = 4
-        "#,
-        )
-        .build();
-    p.cargo("build -v").run();
-}
-
-#[cargo_test]
 fn invalid_global_config() {
     let p = project()
         .file(

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -4298,11 +4298,48 @@ required by package `bar v0.1.0 ([..]/foo)`
 }
 
 #[cargo_test]
+fn default_cargo_config_jobs() {
+    let p = project()
+        .file("src/lib.rs", "")
+        .file(
+            ".cargo/config",
+            r#"
+            [build]
+            jobs = 1
+        "#,
+        )
+        .build();
+    p.cargo("build -v").run();
+}
+
+#[cargo_test]
+fn good_cargo_config_jobs() {
+    let p = project()
+        .file("src/lib.rs", "")
+        .file(
+            ".cargo/config",
+            r#"
+            [build]
+            jobs = 4
+        "#,
+        )
+        .build();
+    p.cargo("build -v").run();
+}
+
+#[cargo_test]
 fn invalid_jobs() {
     let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
         .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
         .build();
+
+    p.cargo("build --jobs -1")
+        .with_status(1)
+        .with_stderr_contains(
+            "error: Found argument '-1' which wasn't expected, or isn't valid in this context",
+        )
+        .run();
 
     p.cargo("build --jobs over9000")
         .with_status(1)


### PR DESCRIPTION
A test when argument is negative is added. In addition, `default_cargo_config_jobs` and `good_cargo_config_jobs` is moved from `testsuite/bad_config.rs` to `testsuite/build.rs` because these tests are not for `bad config`.