### PR TITLE
Set an environment variable for tests to find executables.

### DIFF
--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -876,6 +876,23 @@ fn build_base_args<'a, 'cfg>(
         cmd.arg("-Zforce-unstable-if-unmarked")
             .env("RUSTC_BOOTSTRAP", "1");
     }
+
+    // Add `CARGO_BIN_` environment variables for building tests.
+    if unit.target.is_test() || unit.target.is_bench() {
+        for bin_target in unit
+            .pkg
+            .manifest()
+            .targets()
+            .iter()
+            .filter(|target| target.is_bin())
+        {
+            let exe_path = cx
+                .files()
+                .bin_link_for_target(bin_target, unit.kind, cx.bcx)?;
+            let key = format!("CARGO_BIN_EXE_{}", bin_target.crate_name().to_uppercase());
+            cmd.env(&key, exe_path);
+        }
+    }
     Ok(())
 }
 

--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -889,7 +889,7 @@ fn build_base_args<'a, 'cfg>(
             let exe_path = cx
                 .files()
                 .bin_link_for_target(bin_target, unit.kind, cx.bcx)?;
-            let key = format!("CARGO_BIN_EXE_{}", bin_target.crate_name().to_uppercase());
+            let key = format!("CARGO_BIN_EXE_{}", bin_target.name());
             cmd.env(&key, exe_path);
         }
     }

--- a/src/doc/man/cargo-test.adoc
+++ b/src/doc/man/cargo-test.adoc
@@ -74,6 +74,14 @@ ignore the `test` flag and will always test the given target.
 Doc tests for libraries may be disabled by setting `doctest = false` for the
 library in the manifest.
 
+Binary targets are automatically built if there is an integration test or
+benchmark. This allows an integration test to execute the binary to exercise
+and test its behavior. The `CARGO_BIN_EXE_<name>`
+linkcargo:reference/environment-variables.html#environment-variables-cargo-sets-for-crates[environment variable]
+is set when the integration test is built so that it can use the
+link:https://doc.rust-lang.org/std/macro.env.html[`env` macro] to locate the
+executable.
+
 include::options-targets.adoc[]
 
 *--doc*::

--- a/src/doc/man/generated/cargo-test.html
+++ b/src/doc/man/generated/cargo-test.html
@@ -154,6 +154,15 @@ ignore the <code>test</code> flag and will always test the given target.</p>
 library in the manifest.</p>
 </div>
 <div class="paragraph">
+<p>Binary targets are automatically built if there is an integration test or
+benchmark. This allows an integration test to execute the binary to exercise
+and test its behavior. The <code>CARGO_BIN_EXE_&lt;name&gt;</code>
+<a href="../reference/environment-variables.html#environment-variables-cargo-sets-for-crates">environment variable</a>
+is set when the integration test is built so that it can use the
+<a href="https://doc.rust-lang.org/std/macro.env.html"><code>env</code> macro</a> to locate the
+executable.</p>
+</div>
+<div class="paragraph">
 <p>Passing target selection flags will test only the
 specified targets.</p>
 </div>

--- a/src/doc/src/reference/cargo-targets.md
+++ b/src/doc/src/reference/cargo-targets.md
@@ -123,6 +123,15 @@ modules. The libtest harness will automatically find all of the `#[test]`
 annotated functions and run them in parallel. You can pass module names to
 [`cargo test`] to only run the tests within that module.
 
+Binary targets are automatically built if there is an integration test. This
+allows an integration test to execute the binary to exercise and test its
+behavior. The `CARGO_BIN_EXE_<name>` [environment variable] is set when the
+integration test is built so that it can use the [`env` macro] to locate the
+executable.
+
+[environment variable]: environment-variables.md#environment-variables-cargo-sets-for-crates
+[`env` macro]: ../../std/macro.env.html
+
 ### Benchmarks
 
 Benchmarks provide a way to test the performance of your code using the

--- a/src/doc/src/reference/environment-variables.md
+++ b/src/doc/src/reference/environment-variables.md
@@ -195,7 +195,7 @@ let version = env!("CARGO_PKG_VERSION");
   Binaries are automatically built when the test is built, unless the binary
   has required features that are not enabled.
 
-[integration test]: manifest.md#integration-tests
+[integration test]: cargo-targets.md#integration-tests
 [`env` macro]: ../../std/macro.env.html
 
 #### Dynamic library paths

--- a/src/doc/src/reference/environment-variables.md
+++ b/src/doc/src/reference/environment-variables.md
@@ -187,6 +187,15 @@ let version = env!("CARGO_PKG_VERSION");
 * `OUT_DIR` — If the package has a build script, this is set to the folder where the build
               script should place its output. See below for more information.
               (Only set during compilation.)
+* `CARGO_BIN_EXE_<name>` — The absolute path to a binary target's executable.
+  This is only set when building an [integration test] or benchmark. This may
+  be used with the [`env` macro] to find the executable to run for testing
+  purposes. The `<name>` is the name of the binary converted to uppercase, and
+  `-` converted to `_`. Binaries are automatically built when the test is
+  built, unless the binary has required features that are not enabled.
+
+[integration test]: manifest.md#integration-tests
+[`env` macro]: ../../std/macro.env.html
 
 #### Dynamic library paths
 

--- a/src/doc/src/reference/environment-variables.md
+++ b/src/doc/src/reference/environment-variables.md
@@ -190,9 +190,10 @@ let version = env!("CARGO_PKG_VERSION");
 * `CARGO_BIN_EXE_<name>` — The absolute path to a binary target's executable.
   This is only set when building an [integration test] or benchmark. This may
   be used with the [`env` macro] to find the executable to run for testing
-  purposes. The `<name>` is the name of the binary converted to uppercase, and
-  `-` converted to `_`. Binaries are automatically built when the test is
-  built, unless the binary has required features that are not enabled.
+  purposes. The `<name>` is the name of the binary target, exactly as-is. For
+  example, `CARGO_BIN_EXE_my-program` for a binary named `my-program`.
+  Binaries are automatically built when the test is built, unless the binary
+  has required features that are not enabled.
 
 [integration test]: manifest.md#integration-tests
 [`env` macro]: ../../std/macro.env.html

--- a/src/etc/man/cargo-test.1
+++ b/src/etc/man/cargo-test.1
@@ -2,12 +2,12 @@
 .\"     Title: cargo-test
 .\"    Author: [see the "AUTHOR(S)" section]
 .\" Generator: Asciidoctor 2.0.10
-.\"      Date: 2020-01-18
+.\"      Date: 2020-02-06
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "CARGO\-TEST" "1" "2020-01-18" "\ \&" "\ \&"
+.TH "CARGO\-TEST" "1" "2020-02-06" "\ \&" "\ \&"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0
@@ -205,6 +205,16 @@ ignore the \fBtest\fP flag and will always test the given target.
 .sp
 Doc tests for libraries may be disabled by setting \fBdoctest = false\fP for the
 library in the manifest.
+.sp
+Binary targets are automatically built if there is an integration test or
+benchmark. This allows an integration test to execute the binary to exercise
+and test its behavior. The \fBCARGO_BIN_EXE_<name>\fP
+\c
+.URL "https://doc.rust\-lang.org/cargo/reference/environment\-variables.html#environment\-variables\-cargo\-sets\-for\-crates" "environment variable"
+is set when the integration test is built so that it can use the
+.URL "https://doc.rust\-lang.org/std/macro.env.html" "\fBenv\fP macro" " "
+to locate the
+executable.
 .sp
 Passing target selection flags will test only the
 specified targets.

--- a/tests/testsuite/test.rs
+++ b/tests/testsuite/test.rs
@@ -4029,9 +4029,9 @@ fn bin_env_for_test() {
         &r#"
             #[test]
             fn run_bins() {
-                assert_eq!(env!("CARGO_BIN_EXE_FOO"), "<FOO_PATH>");
-                assert_eq!(env!("CARGO_BIN_EXE_WITH_DASH"), "<WITH_DASH_PATH>");
-                assert_eq!(env!("CARGO_BIN_EXE_GRÜSSEN"), "<GRÜSSEN_PATH>");
+                assert_eq!(env!("CARGO_BIN_EXE_foo"), "<FOO_PATH>");
+                assert_eq!(env!("CARGO_BIN_EXE_with-dash"), "<WITH_DASH_PATH>");
+                assert_eq!(env!("CARGO_BIN_EXE_grüßen"), "<GRÜSSEN_PATH>");
             }
         "#
         .replace("<FOO_PATH>", &bin_path("foo"))


### PR DESCRIPTION
This adds the environment variable `CARGO_BIN_EXE_<name>` so that integration tests can find binaries to execute, instead of doing things like inspecting `env::current_exe()`.

The use of uppercase is primarily motivated by Windows whose Rust implementation behaves in a strange way.  It always ascii-upper-cases keys to implement case-insensitive matching (which loses the original case).  Seems less likely to result in confusion?

Closes #5758.
