### PR TITLE
Switch build-std to use --extern

### DIFF
--- a/src/cargo/core/compiler/compilation.rs
+++ b/src/cargo/core/compiler/compilation.rs
@@ -1,6 +1,6 @@
 use std::collections::{BTreeSet, HashMap, HashSet};
 use std::env;
-use std::ffi::OsStr;
+use std::ffi::{OsStr, OsString};
 use std::path::PathBuf;
 
 use cargo_platform::CfgExpr;
@@ -8,7 +8,7 @@ use semver::Version;
 
 use super::BuildContext;
 use crate::core::compiler::CompileKind;
-use crate::core::{Edition, InternedString, Package, PackageId, Target};
+use crate::core::{Edition, Package, PackageId, Target};
 use crate::util::{self, join_paths, process, CargoResult, Config, ProcessBuilder};
 
 pub struct Doctest {
@@ -16,9 +16,10 @@ pub struct Doctest {
     pub package: Package,
     /// The target being tested (currently always the package's lib).
     pub target: Target,
-    /// Extern dependencies needed by `rustdoc`. The path is the location of
-    /// the compiled lib.
-    pub deps: Vec<(InternedString, PathBuf)>,
+    /// Arguments needed to pass to rustdoc to run this test.
+    pub args: Vec<OsString>,
+    /// Whether or not -Zunstable-options is needed.
+    pub unstable_opts: bool,
 }
 
 /// A structure returning the result of a compilation.

--- a/src/cargo/core/compiler/job_queue.rs
+++ b/src/cargo/core/compiler/job_queue.rs
@@ -17,7 +17,6 @@ use super::job::{
     Freshness::{self, Dirty, Fresh},
     Job,
 };
-use super::standard_lib;
 use super::timings::Timings;
 use super::{BuildContext, BuildPlan, CompileMode, Context, Unit};
 use crate::core::compiler::ProfileKind;
@@ -617,23 +616,6 @@ impl<'a, 'cfg> JobQueue<'a, 'cfg> {
         match artifact {
             Artifact::All => self.timings.unit_finished(id, unlocked),
             Artifact::Metadata => self.timings.unit_rmeta_finished(id, unlocked),
-        }
-        if unit.is_std && !unit.kind.is_host() && !cx.bcx.build_config.build_plan {
-            // This is a bit of an unusual place to copy files around, and
-            // ideally this would be somewhere like the Work closure
-            // (`link_targets`). The tricky issue is handling rmeta files for
-            // pipelining. Since those are emitted asynchronously, the code
-            // path (like `on_stderr_line`) does not have enough information
-            // to know where the sysroot is, and that it is an std unit. If
-            // possible, it might be nice to eventually move this to the
-            // worker thread, but may be tricky to have the paths available.
-            // Another possibility is to disable pipelining between std ->
-            // non-std. The pipelining opportunities are small, and are not a
-            // huge win (in a full build, only proc_macro overlaps for 2
-            // seconds out of a 90s build on my system). Care must also be
-            // taken to properly copy these artifacts for Fresh units.
-            let rmeta = artifact == Artifact::Metadata;
-            standard_lib::add_sysroot_artifact(cx, unit, rmeta)?;
         }
         Ok(())
     }

--- a/src/cargo/core/compiler/layout.rs
+++ b/src/cargo/core/compiler/layout.rs
@@ -53,11 +53,6 @@
 //!         # incremental is enabled.
 //!         incremental/
 //!
-//!         # The sysroot for -Zbuild-std builds. This only appears in
-//!         # target-triple directories (not host), and only if -Zbuild-std is
-//!         # enabled.
-//!         .sysroot/
-//!
 //!     # This is the location at which the output of all custom build
 //!     # commands are rooted.
 //!     build/
@@ -129,10 +124,6 @@ pub struct Layout {
     examples: PathBuf,
     /// The directory for rustdoc output: `$root/doc`
     doc: PathBuf,
-    /// The local sysroot for the build-std feature.
-    sysroot: Option<PathBuf>,
-    /// The "lib" directory within `sysroot`.
-    sysroot_libdir: Option<PathBuf>,
     /// The lockfile for a build (`.cargo-lock`). Will be unlocked when this
     /// struct is `drop`ped.
     _lock: FileLock,
@@ -176,21 +167,6 @@ impl Layout {
         let root = root.into_path_unlocked();
         let dest = dest.into_path_unlocked();
 
-        // Compute the sysroot path for the build-std feature.
-        let build_std = ws.config().cli_unstable().build_std.as_ref();
-        let (sysroot, sysroot_libdir) = if let Some(target) = build_std.and(target) {
-            // This uses a leading dot to avoid collision with named profiles.
-            let sysroot = dest.join(".sysroot");
-            let sysroot_libdir = sysroot
-                .join("lib")
-                .join("rustlib")
-                .join(target.short_name())
-                .join("lib");
-            (Some(sysroot), Some(sysroot_libdir))
-        } else {
-            (None, None)
-        };
-
         Ok(Layout {
             deps: dest.join("deps"),
             build: dest.join("build"),
@@ -200,8 +176,6 @@ impl Layout {
             doc: root.join("doc"),
             root,
             dest,
-            sysroot,
-            sysroot_libdir,
             _lock: lock,
         })
     }
@@ -248,16 +222,6 @@ impl Layout {
     /// Fetch the build script path.
     pub fn build(&self) -> &Path {
         &self.build
-    }
-    /// The local sysroot for the build-std feature.
-    ///
-    /// Returns None if build-std is not enabled or this is the Host layout.
-    pub fn sysroot(&self) -> Option<&Path> {
-        self.sysroot.as_ref().map(|p| p.as_ref())
-    }
-    /// The "lib" directory within `sysroot`.
-    pub fn sysroot_libdir(&self) -> Option<&Path> {
-        self.sysroot_libdir.as_ref().map(|p| p.as_ref())
     }
 }
 

--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -43,8 +43,7 @@ use self::unit_dependencies::UnitDep;
 pub use crate::core::compiler::unit::{Unit, UnitInterner};
 use crate::core::manifest::TargetSourcePath;
 use crate::core::profiles::{Lto, PanicStrategy, Profile};
-use crate::core::Feature;
-use crate::core::{PackageId, Target};
+use crate::core::{Feature, InternedString, PackageId, Target};
 use crate::util::errors::{self, CargoResult, CargoResultExt, Internal, ProcessError};
 use crate::util::machine_message::Message;
 use crate::util::paths;
@@ -894,8 +893,7 @@ fn build_deps_args<'a, 'cfg>(
         });
     }
 
-    // Create Vec since mutable cx is needed in closure below.
-    let deps = Vec::from(cx.unit_deps(unit));
+    let deps = cx.unit_deps(unit);
 
     // If there is not one linkable target but should, rustc fails later
     // on if there is an `extern crate` for it. This may turn into a hard
@@ -922,23 +920,14 @@ fn build_deps_args<'a, 'cfg>(
 
     let mut unstable_opts = false;
 
-    if let Some(sysroot) = cx.files().layout(unit.kind).sysroot() {
-        if !unit.kind.is_host() {
-            cmd.arg("--sysroot").arg(sysroot);
-        }
-    }
-
     for dep in deps {
-        if !unit.is_std && dep.unit.is_std {
-            // Dependency to sysroot crate uses --sysroot.
-            continue;
-        }
         if dep.unit.mode.is_run_custom_build() {
             cmd.env("OUT_DIR", &cx.files().build_script_out_dir(&dep.unit));
         }
-        if dep.unit.target.linkable() && !dep.unit.mode.is_doc() {
-            link_to(cmd, cx, unit, &dep, &mut unstable_opts)?;
-        }
+    }
+
+    for arg in extern_args(cx, unit, &mut unstable_opts)? {
+        cmd.arg(arg);
     }
 
     // This will only be set if we're already using a feature
@@ -948,37 +937,51 @@ fn build_deps_args<'a, 'cfg>(
     }
 
     return Ok(());
+}
 
-    fn link_to<'a, 'cfg>(
-        cmd: &mut ProcessBuilder,
-        cx: &mut Context<'a, 'cfg>,
-        current: &Unit<'a>,
-        dep: &UnitDep<'a>,
-        need_unstable_opts: &mut bool,
-    ) -> CargoResult<()> {
+/// Generates a list of `--extern` arguments.
+pub fn extern_args<'a>(
+    cx: &Context<'a, '_>,
+    unit: &Unit<'a>,
+    unstable_opts: &mut bool,
+) -> CargoResult<Vec<OsString>> {
+    let mut result = Vec::new();
+    let deps = cx.unit_deps(unit);
+
+    // Closure to add one dependency to `result`.
+    let mut link_to = |dep: &UnitDep<'a>,
+                       extern_crate_name: InternedString,
+                       noprelude: bool|
+     -> CargoResult<()> {
         let mut value = OsString::new();
-        value.push(dep.extern_crate_name.as_str());
+        let mut opts = Vec::new();
+        if unit
+            .pkg
+            .manifest()
+            .features()
+            .require(Feature::public_dependency())
+            .is_ok()
+            && !dep.public
+        {
+            opts.push("priv");
+            *unstable_opts = true;
+        }
+        if noprelude {
+            opts.push("noprelude");
+            *unstable_opts = true;
+        }
+        if !opts.is_empty() {
+            value.push(opts.join(","));
+            value.push(":");
+        }
+        value.push(extern_crate_name.as_str());
         value.push("=");
 
         let mut pass = |file| {
             let mut value = value.clone();
             value.push(file);
-
-            if current
-                .pkg
-                .manifest()
-                .features()
-                .require(Feature::public_dependency())
-                .is_ok()
-                && !dep.public
-            {
-                cmd.arg("--extern-private");
-                *need_unstable_opts = true;
-            } else {
-                cmd.arg("--extern");
-            }
-
-            cmd.arg(&value);
+            result.push(OsString::from("--extern"));
+            result.push(value);
         };
 
         let outputs = cx.outputs(&dep.unit)?;
@@ -987,7 +990,7 @@ fn build_deps_args<'a, 'cfg>(
             _ => None,
         });
 
-        if cx.only_requires_rmeta(current, &dep.unit) {
+        if cx.only_requires_rmeta(unit, &dep.unit) {
             let (output, _rmeta) = outputs
                 .find(|(_output, rmeta)| *rmeta)
                 .expect("failed to find rlib dep for pipelined dep");
@@ -1000,7 +1003,15 @@ fn build_deps_args<'a, 'cfg>(
             }
         }
         Ok(())
+    };
+
+    for dep in deps {
+        if dep.unit.target.linkable() && !dep.unit.mode.is_doc() {
+            link_to(&dep, dep.extern_crate_name, dep.noprelude)?;
+        }
     }
+
+    Ok(result)
 }
 
 fn envify(s: &str) -> String {

--- a/src/cargo/core/compiler/unit_dependencies.rs
+++ b/src/cargo/core/compiler/unit_dependencies.rs
@@ -41,6 +41,8 @@ pub struct UnitDep<'a> {
     pub extern_crate_name: InternedString,
     /// Whether or not this is a public dependency.
     pub public: bool,
+    /// If `true`, the dependency should not be added to Rust's prelude.
+    pub noprelude: bool,
 }
 
 /// Collection of stuff used while creating the `UnitGraph`.
@@ -132,6 +134,7 @@ fn attach_std_deps<'a, 'cfg>(
                 extern_crate_name: unit.pkg.name(),
                 // TODO: Does this `public` make sense?
                 public: true,
+                noprelude: true,
             }));
         }
     }
@@ -577,6 +580,7 @@ fn new_unit_dep_with_profile<'a>(
         unit_for,
         extern_crate_name,
         public,
+        noprelude: false,
     })
 }
 

--- a/src/cargo/ops/cargo_test.rs
+++ b/src/cargo/ops/cargo_test.rs
@@ -155,7 +155,8 @@ fn run_doc_tests(
         let Doctest {
             package,
             target,
-            deps,
+            args,
+            unstable_opts,
         } = doctest_info;
         config.shell().status("Doc-tests", target.name())?;
         let mut p = compilation.rustdoc_process(package, target)?;
@@ -203,11 +204,12 @@ fn run_doc_tests(
             }
         }
 
-        for &(ref extern_crate_name, ref lib) in deps.iter() {
-            let mut arg = OsString::from(extern_crate_name.as_str());
-            arg.push("=");
-            arg.push(lib);
-            p.arg("--extern").arg(&arg);
+        for arg in args {
+            p.arg(arg);
+        }
+
+        if *unstable_opts {
+            p.arg("-Zunstable-options");
         }
 
         if let Some(flags) = compilation.rustdocflags.get(&package.package_id()) {

--- a/tests/testsuite/standard_lib.rs
+++ b/tests/testsuite/standard_lib.rs
@@ -98,8 +98,14 @@ fn setup() -> Option<Setup> {
 
                     let is_sysroot_crate = env::var_os("RUSTC_BOOTSTRAP").is_some();
                     if is_sysroot_crate {
-                        let arg = args.iter().position(|a| a == "--sysroot").unwrap();
-                        args[arg + 1] = env::var("REAL_SYSROOT").unwrap();
+                        args.push("--sysroot".to_string());
+                        args.push(env::var("REAL_SYSROOT").unwrap());
+                    } else if args.iter().any(|arg| arg == "--target") {
+                        // build-std target unit
+                        args.push("--sysroot".to_string());
+                        args.push("/path/to/nowhere".to_string());
+                    } else {
+                        // host unit, do not use sysroot
                     }
 
                     let ret = Command::new(&args[0]).args(&args[1..]).status().unwrap();
@@ -242,7 +248,7 @@ fn basic() {
         )
         .build();
 
-    p.cargo("check").build_std(&setup).target_host().run();
+    p.cargo("check -v").build_std(&setup).target_host().run();
     p.cargo("build").build_std(&setup).target_host().run();
     p.cargo("run").build_std(&setup).target_host().run();
     p.cargo("test").build_std(&setup).target_host().run();


### PR DESCRIPTION
Switch `build-std` to use `--extern` flags instead of `--sysroot`. 

This is mostly a revert of #7421. It uses the new extern flag options introduced in https://github.com/rust-lang/rust/pull/67074. It avoids modifying the extern prelude which was the source of the problem of https://github.com/rust-lang/wg-cargo-std-aware/issues/40.  

Closes https://github.com/rust-lang/wg-cargo-std-aware/issues/49
Reopens https://github.com/rust-lang/wg-cargo-std-aware/issues/31
