### PR TITLE
Improve error message when user cannot read credentials

### DIFF
--- a/src/cargo/util/config/mod.rs
+++ b/src/cargo/util/config/mod.rs
@@ -807,13 +807,14 @@ impl Config {
         };
 
         let mut contents = String::new();
-        let mut file = File::open(&credentials)?;
-        file.read_to_string(&mut contents).chain_err(|| {
-            format!(
-                "failed to read configuration file `{}`",
-                credentials.display()
-            )
-        })?;
+        File::open(&credentials)
+            .and_then(|mut file| file.read_to_string(&mut contents))
+            .chain_err(|| {
+                format!(
+                    "failed to read configuration file `{}`",
+                    credentials.display()
+                )
+            })?;
 
         let toml = cargo_toml::parse(&contents, &credentials, self).chain_err(|| {
             format!(


### PR DESCRIPTION
Improve error message when user has no permission to read `~/.cargo/credentials`

ref #7624 

error message before:

```
error: Permission denied (os error 13)
```

now:

```
error: failed to read configuration file `/Users/marek/.cargo/credentials`

Caused by:
  Permission denied (os error 13)
```