### PR TITLE
Pass --edition after --crate-name

### DIFF
--- a/src/cargo/core/compiler/compilation.rs
+++ b/src/cargo/core/compiler/compilation.rs
@@ -119,12 +119,7 @@ impl<'cfg> Compilation<'cfg> {
     }
 
     /// See `process`.
-    pub fn rustc_process(
-        &self,
-        pkg: &Package,
-        target: &Target,
-        is_primary: bool,
-    ) -> CargoResult<ProcessBuilder> {
+    pub fn rustc_process(&self, pkg: &Package, is_primary: bool) -> CargoResult<ProcessBuilder> {
         let rustc = if is_primary {
             self.primary_unit_rustc_process
                 .clone()
@@ -133,11 +128,7 @@ impl<'cfg> Compilation<'cfg> {
             self.rustc_process.clone()
         };
 
-        let mut p = self.fill_env(rustc, pkg, true)?;
-        if target.edition() != Edition::Edition2015 {
-            p.arg(format!("--edition={}", target.edition()));
-        }
-        Ok(p)
+        self.fill_env(rustc, pkg, true)
     }
 
     /// See `process`.


### PR DESCRIPTION
This PR swaps the order of the --edition and --crate-name args in the rustc invocation.

- Before: `rustc --edition=2018 --crate-name cargo ...`
- After: `rustc --crate-name cargo --edition=2018 ...`

The crate name is a lot more relevant when looking at processes in `top` for example, and should appear first.