### PR TITLE
[beta] Disable test not forwards compatible to nightly.

### DIFF
--- a/tests/testsuite/pub_priv.rs
+++ b/tests/testsuite/pub_priv.rs
@@ -4,6 +4,7 @@ use cargo_test_support::registry::Package;
 use cargo_test_support::{is_nightly, project};
 
 #[cargo_test]
+#[ignore] // Not working on nightly https://github.com/rust-lang/cargo/issues/7714.
 fn exported_priv_warning() {
     if !is_nightly() {
         return;


### PR DESCRIPTION
The `--extern` flag format changed (see #7699).  The changes didn't make it into beta, so just disable this test.  This isn't immediately necessary, but will be helpful if we need to make any other changes on the 1.41 branch in the future.

Closes #7714
