### PR TITLE
Update the output of `cargo -Z help`

### DIFF
--- a/src/bin/cargo/cli.rs
+++ b/src/bin/cargo/cli.rs
@@ -32,7 +32,7 @@ Available unstable (nightly-only) flags:
     -Z avoid-dev-deps   -- Avoid installing dev-dependencies if possible
     -Z minimal-versions -- Install minimal dependency versions instead of maximum
     -Z no-index-update  -- Do not update the registry, avoids a network request for benchmarking
-    -Z unstable-options -- Allow the usage of unstable options such as --registry
+    -Z unstable-options -- Allow the usage of unstable options
     -Z config-profile   -- Read profiles from .cargo/config files
     -Z timings          -- Display concurrency information
     -Z doctest-xcompile -- Compile and run doctests for non-host target using runner config

--- a/tests/testsuite/cargo_command.rs
+++ b/tests/testsuite/cargo_command.rs
@@ -376,8 +376,6 @@ fn explain() {
 #[cargo_test]
 fn z_flags_help() {
     cargo_process("-Z help")
-        .with_stdout_contains(
-            "    -Z unstable-options -- Allow the usage of unstable options such as --registry",
-        )
+        .with_stdout_contains("    -Z unstable-options -- Allow the usage of unstable options")
         .run();
 }


### PR DESCRIPTION
`--registry` flag is already stabilized at 737382d7e.