### PR TITLE
vendor: support alt registries

### DIFF
--- a/src/cargo/ops/vendor.rs
+++ b/src/cargo/ops/vendor.rs
@@ -258,6 +258,12 @@ fn sync(
                 registry: None,
                 replace_with: merged_source_name.to_string(),
             }
+        } else if source_id.is_remote_registry() {
+            let registry = source_id.url().to_string();
+            VendorSource::Registry {
+                registry: Some(registry),
+                replace_with: merged_source_name.to_string(),
+            }
         } else if source_id.is_git() {
             let mut branch = None;
             let mut tag = None;


### PR DESCRIPTION
Adds support for alt registries to `cargo vendor`. It mostly worked before, but panicked when trying to display the `.cargo/config` instructions.

This isn't entirely elegant, as the source replacement looks like this:

```toml
[source.crates-io]
replace-with = "vendored-sources"

[source."file:///Users/eric/Proj/rust/cargo/target/cit/t0/alternative-registry"]
registry = "file:///Users/eric/Proj/rust/cargo/target/cit/t0/alternative-registry"
replace-with = "vendored-sources"

[source."file:///Users/eric/Proj/rust/cargo/target/cit/t0/gitdep"]
git = "file:///Users/eric/Proj/rust/cargo/target/cit/t0/gitdep"
branch = "master"
replace-with = "vendored-sources"

[source.vendored-sources]
directory = "vendor"
```

The duplication of the URLs is a little unfortunate.  It could use the name of the registry, but that is not readily available and is tricky to obtain.  I feel like that is a challenge for another day.

Closes #7674.
