### PR TITLE
fixed workspaces issues due to non-canonical manifest path

### DIFF
--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -129,18 +129,6 @@ pub struct Members<'a, 'cfg> {
     iter: slice::Iter<'a, PathBuf>,
 }
 
-fn resolve_path(path: &Path) -> PathBuf {
-    let mut resolved_path = PathBuf::new();
-    for component in path {
-        if component == ".." {
-            resolved_path.pop();
-        } else if component != "." {
-            resolved_path.push(component)
-        }
-    }
-    resolved_path
-}
-
 impl<'cfg> Workspace<'cfg> {
     /// Creates a new workspace given the target manifest pointed to by
     /// `manifest_path`.
@@ -149,7 +137,7 @@ impl<'cfg> Workspace<'cfg> {
     /// root and all member packages. It will then validate the workspace
     /// before returning it, so `Ok` is only returned for valid workspaces.
     pub fn new(manifest_path: &Path, config: &'cfg Config) -> CargoResult<Workspace<'cfg>> {
-        let manifest_path = resolve_path(&manifest_path);
+        let manifest_path = paths::normalize_path(&manifest_path);
         let mut ws = Workspace::new_default(manifest_path.to_path_buf(), config);
         ws.target_dir = config.target_dir()?;
         ws.root_manifest = ws.find_root(&manifest_path)?;

--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -129,6 +129,18 @@ pub struct Members<'a, 'cfg> {
     iter: slice::Iter<'a, PathBuf>,
 }
 
+fn resolve_path(path: &Path) -> PathBuf {
+    let mut resolved_path = PathBuf::new();
+    for component in path {
+        if component == ".." {
+            resolved_path.pop();
+        } else if component != "." {
+            resolved_path.push(component)
+        }
+    }
+    resolved_path
+}
+
 impl<'cfg> Workspace<'cfg> {
     /// Creates a new workspace given the target manifest pointed to by
     /// `manifest_path`.
@@ -137,7 +149,7 @@ impl<'cfg> Workspace<'cfg> {
     /// root and all member packages. It will then validate the workspace
     /// before returning it, so `Ok` is only returned for valid workspaces.
     pub fn new(manifest_path: &Path, config: &'cfg Config) -> CargoResult<Workspace<'cfg>> {
-        let manifest_path = manifest_path.canonicalize()?;
+        let manifest_path = resolve_path(&manifest_path);
         let mut ws = Workspace::new_default(manifest_path.to_path_buf(), config);
         ws.target_dir = config.target_dir()?;
         ws.root_manifest = ws.find_root(&manifest_path)?;

--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -137,9 +137,10 @@ impl<'cfg> Workspace<'cfg> {
     /// root and all member packages. It will then validate the workspace
     /// before returning it, so `Ok` is only returned for valid workspaces.
     pub fn new(manifest_path: &Path, config: &'cfg Config) -> CargoResult<Workspace<'cfg>> {
+        let manifest_path = manifest_path.canonicalize()?;
         let mut ws = Workspace::new_default(manifest_path.to_path_buf(), config);
         ws.target_dir = config.target_dir()?;
-        ws.root_manifest = ws.find_root(manifest_path)?;
+        ws.root_manifest = ws.find_root(&manifest_path)?;
         ws.find_members()?;
         ws.validate()?;
         Ok(ws)

--- a/tests/testsuite/workspaces.rs
+++ b/tests/testsuite/workspaces.rs
@@ -2236,3 +2236,28 @@ Caused by:
         )
         .run();
 }
+
+#[cargo_test]
+fn manifest_path_sanitation() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [workspace]
+            members = ["a"]
+        "#,
+        )
+        .file(
+            "a/Cargo.toml",
+            r#"
+            [project]
+            name = "a"
+            version = "0.1.0"
+            authors = []
+        "#,
+        )
+        .file("a/src/main.rs", "fn main() {}");
+    let p = p.build();
+
+    p.cargo("install --path a/../a").run();
+}


### PR DESCRIPTION
this PR fixes #7686 

comparisons with the root manifest path failed even if paths were identical.
This was due to a comparison with a non-canonical root manifest path with the canonical one.

This PR canonicalizes the manifest path when a Workspace is created, so that all future comparison are using the canonical manifest path.

Before two identical path, just represented differently, where not equal e.g. `a/../a != a`
With this PR the comparison looks like this `a == a`, which is as expected equal