### PR TITLE
Scalable jobserver for rustc

### DIFF
--- a/src/cargo/core/compiler/context/mod.rs
+++ b/src/cargo/core/compiler/context/mod.rs
@@ -69,6 +69,11 @@ pub struct Context<'a, 'cfg> {
     /// metadata files in addition to the rlib itself. This is only filled in
     /// when `pipelining` above is enabled.
     rmeta_required: HashSet<Unit<'a>>,
+
+    /// When we're in jobserver-per-rustc process mode, this keeps those
+    /// jobserver clients for each Unit (which eventually becomes a rustc
+    /// process).
+    pub rustc_clients: HashMap<Unit<'a>, Client>,
 }
 
 impl<'a, 'cfg> Context<'a, 'cfg> {
@@ -112,6 +117,7 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
             unit_dependencies,
             files: None,
             rmeta_required: HashSet::new(),
+            rustc_clients: HashMap::new(),
             pipelining,
         })
     }

--- a/src/cargo/core/compiler/job_queue.rs
+++ b/src/cargo/core/compiler/job_queue.rs
@@ -96,6 +96,9 @@ pub struct JobQueue<'a, 'cfg> {
 
     tokens: Vec<Acquired>,
     rustc_tokens: HashMap<JobId, Vec<Acquired>>,
+
+    // We use a vec here as we don't want to order randomly which rustc we give
+    // tokens to.
     to_send_clients: Vec<(JobId, Client)>,
     pending_queue: Vec<(Unit<'a>, Job)>,
     print: DiagnosticPrinter<'cfg>,

--- a/src/cargo/core/compiler/job_queue.rs
+++ b/src/cargo/core/compiler/job_queue.rs
@@ -326,7 +326,7 @@ impl<'a, 'cfg> JobQueue<'a, 'cfg> {
     /// This function will spawn off `config.jobs()` workers to build all of the
     /// necessary dependencies, in order. Freshness is propagated as far as
     /// possible along each dependency chain.
-    pub fn execute(&mut self, cx: &mut Context<'a, '_>, plan: &mut BuildPlan) -> CargoResult<()> {
+    pub fn execute(mut self, cx: &mut Context<'a, '_>, plan: &mut BuildPlan) -> CargoResult<()> {
         let _p = profile::start("executing the job graph");
         self.queue.queue_finished();
 
@@ -534,7 +534,7 @@ impl<'a, 'cfg> JobQueue<'a, 'cfg> {
     }
 
     fn drain_the_queue(
-        &mut self,
+        mut self,
         cx: &mut Context<'a, '_>,
         plan: &mut BuildPlan,
         jobserver_helper: &HelperThread,

--- a/src/cargo/core/compiler/job_queue.rs
+++ b/src/cargo/core/compiler/job_queue.rs
@@ -425,7 +425,10 @@ impl<'a, 'cfg> DrainState<'a, 'cfg> {
         // If we managed to acquire some extra tokens, send them off to a waiting rustc.
         let extra_tokens = self.tokens.len() - (self.active.len() - 1);
         for _ in 0..extra_tokens {
-            if let Some((id, client)) = self.to_send_clients.pop() {
+            if !self.to_send_clients.is_empty() {
+                // remove from the front so we grant the token to the oldest
+                // waiter
+                let (id, client) = self.to_send_clients.remove(0);
                 let token = self.tokens.pop().expect("an extra token");
                 self.rustc_tokens
                     .entry(id)

--- a/src/cargo/core/compiler/job_queue.rs
+++ b/src/cargo/core/compiler/job_queue.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 
 use anyhow::format_err;
 use crossbeam_utils::thread::Scope;
-use jobserver::{Acquired, HelperThread};
+use jobserver::{Acquired, Client, HelperThread};
 use log::{debug, info, trace};
 
 use super::context::OutputFile;
@@ -127,6 +127,22 @@ impl<'a> JobState<'a> {
         let _ = self
             .tx
             .send(Message::Finish(self.id, Artifact::Metadata, Ok(())));
+    }
+
+    /// The rustc underlying this Job is about to acquire a jobserver token (i.e., block)
+    /// on the passed client.
+    ///
+    /// This should arrange for the passed client to eventually get a token via
+    /// `client.release_raw()`.
+    pub fn will_acquire(&self, _client: &Client) {
+        // ...
+    }
+
+    /// The rustc underlying this Job is informing us that it is done with a jobserver token.
+    ///
+    /// Note that it does *not* write that token back anywhere.
+    pub fn release_token(&self) {
+        // ...
     }
 }
 

--- a/src/cargo/core/compiler/job_queue.rs
+++ b/src/cargo/core/compiler/job_queue.rs
@@ -478,14 +478,7 @@ impl<'a, 'cfg> JobQueue<'a, 'cfg> {
             }
             Message::Token(acquired_token) => {
                 let token = acquired_token.chain_err(|| "failed to acquire jobserver token")?;
-                if let Some((id, client)) = self.to_send_clients.pop() {
-                    self.rustc_tokens.push((id, token));
-                    client
-                        .release_raw()
-                        .chain_err(|| "failed to release jobserver token")?;
-                } else {
-                    self.tokens.push(token);
-                }
+                self.tokens.push(token);
             }
             Message::NeedsToken(id, client) => {
                 log::info!("queue token request");

--- a/src/cargo/core/compiler/job_queue.rs
+++ b/src/cargo/core/compiler/job_queue.rs
@@ -363,8 +363,12 @@ impl<'a, 'cfg> JobQueue<'a, 'cfg> {
             // Record some timing information if `-Ztimings` is enabled, and
             // this'll end up being a noop if we're not recording this
             // information.
-            self.timings
-                .mark_concurrency(self.active.len(), queue.len(), self.queue.len());
+            self.timings.mark_concurrency(
+                self.active.len(),
+                queue.len(),
+                self.queue.len(),
+                rustc_tokens.len(),
+            );
             self.timings.record_cpu();
 
             // Drain all events at once to avoid displaying the progress bar

--- a/src/cargo/core/compiler/job_queue.rs
+++ b/src/cargo/core/compiler/job_queue.rs
@@ -542,12 +542,12 @@ impl<'a, 'cfg> DrainState<'a, 'cfg> {
                 // Note that this pops off potentially a completely
                 // different token, but all tokens of the same job are
                 // conceptually the same so that's fine.
-                if let Some(rustc_tokens) = self.rustc_tokens.get_mut(&id) {
-                    self.tokens
-                        .push(rustc_tokens.pop().expect("rustc releases token it has"));
-                } else {
-                    panic!("This job does not have tokens associated with it");
-                }
+                let rustc_tokens = self
+                    .rustc_tokens
+                    .get_mut(&id)
+                    .expect("no tokens associated");
+                self.tokens
+                    .push(rustc_tokens.pop().expect("rustc releases token it has"));
             }
         }
 

--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -1240,7 +1240,7 @@ fn on_stderr_line_inner(
     if let Ok(JobserverNotification { jobserver_event }) =
         serde_json::from_str::<JobserverNotification>(compiler_message.get())
     {
-        log::trace!(
+        log::info!(
             "found jobserver directive from rustc: `{:?}`",
             jobserver_event
         );

--- a/src/cargo/core/compiler/timings.rs
+++ b/src/cargo/core/compiler/timings.rs
@@ -3,6 +3,7 @@
 //! This module implements some simple tracking information for timing of how
 //! long it takes for different units to compile.
 use super::{CompileMode, Unit};
+use crate::core::compiler::job_queue::JobId;
 use crate::core::compiler::BuildContext;
 use crate::core::PackageId;
 use crate::util::cpu::State;
@@ -41,7 +42,7 @@ pub struct Timings<'a, 'cfg> {
     unit_times: Vec<UnitTime<'a>>,
     /// Units that are in the process of being built.
     /// When they finished, they are moved to `unit_times`.
-    active: HashMap<u32, UnitTime<'a>>,
+    active: HashMap<JobId, UnitTime<'a>>,
     /// Concurrency-tracking information. This is periodically updated while
     /// compilation progresses.
     concurrency: Vec<Concurrency>,
@@ -144,7 +145,7 @@ impl<'a, 'cfg> Timings<'a, 'cfg> {
     }
 
     /// Mark that a unit has started running.
-    pub fn unit_start(&mut self, id: u32, unit: Unit<'a>) {
+    pub fn unit_start(&mut self, id: JobId, unit: Unit<'a>) {
         if !self.enabled {
             return;
         }
@@ -178,7 +179,7 @@ impl<'a, 'cfg> Timings<'a, 'cfg> {
     }
 
     /// Mark that the `.rmeta` file as generated.
-    pub fn unit_rmeta_finished(&mut self, id: u32, unlocked: Vec<&Unit<'a>>) {
+    pub fn unit_rmeta_finished(&mut self, id: JobId, unlocked: Vec<&Unit<'a>>) {
         if !self.enabled {
             return;
         }
@@ -196,7 +197,7 @@ impl<'a, 'cfg> Timings<'a, 'cfg> {
     }
 
     /// Mark that a unit has finished running.
-    pub fn unit_finished(&mut self, id: u32, unlocked: Vec<&Unit<'a>>) {
+    pub fn unit_finished(&mut self, id: JobId, unlocked: Vec<&Unit<'a>>) {
         if !self.enabled {
             return;
         }

--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -341,6 +341,7 @@ pub struct CliUnstable {
     pub timings: Option<Vec<String>>,
     pub doctest_xcompile: bool,
     pub panic_abort_tests: bool,
+    pub jobserver_per_rustc: bool,
 }
 
 impl CliUnstable {
@@ -409,6 +410,7 @@ impl CliUnstable {
             "timings" => self.timings = Some(parse_timings(v)),
             "doctest-xcompile" => self.doctest_xcompile = parse_empty(k, v)?,
             "panic-abort-tests" => self.panic_abort_tests = parse_empty(k, v)?,
+            "jobserver-per-rustc" => self.jobserver_per_rustc = parse_empty(k, v)?,
             _ => bail!("unknown `-Z` flag specified: {}", k),
         }
 


### PR DESCRIPTION
This refactors the job queue code for support of [per-rustc process jobservers](https://github.com/rust-lang/rust/pull/67398). Furthermore, it also cleans up the code and refactors the main loop to be more amenable to understanding (splitting into methods and such).

Assignment of tokens to either rustc "threads" or processes is dedicated to the main loop, which proceeds in a strict "least recently requested" fashion among both thread and process token requests. Specifically, we will first allocate tokens to all pending process token requests (i.e., high-level units of work), and then (in per-rustc jobserver mode) follow up by assigning any remaining tokens to rustcs, again in the order that requests came into cargo (first request served first).

It's not quite clear that that model is good (no modeling or so has been done). On the other hand this strategy should mean that long-running crates will get more thread tokens once we bottom out in terms of rustc parallelism than short-running crates, which means that crates like syn which start early on but finish pretty late should hopefully get more parallelism nicely (without any more complex heuristics).

One plausible change that may be worth exploring is making the assignment prefer earlier rustc's, globally, rather than first attempting to spawn new crates and only then increasing parallelism for old crates. syn for example frequently gets compiled in the early storm of dozens of crates so is somewhat unlikely to have parallelism, until fairly late in its compilation.

We also currently conflate under this model the rayon threads and codegen threads. Eventually inside rustc those will probably(?) also be just one thing, and the rustc side of this implementation provides no information as to what the token request is for so we can't do better here yet.
