### PR TITLE
Add test for `cargo pkgid`

### DIFF
--- a/tests/testsuite/main.rs
+++ b/tests/testsuite/main.rs
@@ -72,6 +72,7 @@ mod package;
 mod patch;
 mod path;
 mod paths;
+mod pkgid;
 mod plugins;
 mod proc_macro;
 mod profile_config;

--- a/tests/testsuite/pkgid.rs
+++ b/tests/testsuite/pkgid.rs
@@ -1,0 +1,34 @@
+//! Tests for the `cargo pkgid` command.
+
+use cargo_test_support::project;
+use cargo_test_support::registry::Package;
+
+#[cargo_test]
+fn simple() {
+    Package::new("bar", "0.1.0").publish();
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "foo"
+            version = "0.1.0"
+            edition = "2018"
+
+            [dependencies]
+            bar = "0.1.0"
+        "#,
+        )
+        .file("src/main.rs", "fn main() {}")
+        .build();
+
+    p.cargo("generate-lockfile").run();
+
+    p.cargo("pkgid foo")
+        .with_stdout(format!("file://[..]{}#0.1.0", p.root().to_str().unwrap()))
+        .run();
+
+    p.cargo("pkgid bar")
+        .with_stdout("https://github.com/rust-lang/crates.io-index#bar:0.1.0")
+        .run();
+}


### PR DESCRIPTION
There was no test for `cargo pkgid` command.