### PR TITLE
Fix config env vars that are prefix of another with underscore.

### DIFF
--- a/src/cargo/util/config/value.rs
+++ b/src/cargo/util/config/value.rs
@@ -51,10 +51,14 @@ pub(crate) const DEFINITION_FIELD: &str = "$__cargo_private_definition";
 pub(crate) const NAME: &str = "$__cargo_private_Value";
 pub(crate) static FIELDS: [&str; 2] = [VALUE_FIELD, DEFINITION_FIELD];
 
+/// Location where a config value is defined.
 #[derive(Clone, Debug, Eq)]
 pub enum Definition {
+    /// Defined in a `.cargo/config`, includes the path to the file.
     Path(PathBuf),
+    /// Defined in an environment variable, includes the environment key.
     Environment(String),
+    /// Passed in on the command line.
     Cli,
 }
 

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -2806,6 +2806,11 @@ fn custom_target_dir_env() {
     assert!(p.root().join("foo/target/debug").join(&exe_name).is_file());
     assert!(p.root().join("target/debug").join(&exe_name).is_file());
 
+    p.cargo("build")
+        .env("CARGO_BUILD_TARGET_DIR", "foo2/target")
+        .run();
+    assert!(p.root().join("foo2/target/debug").join(&exe_name).is_file());
+
     fs::create_dir(p.root().join(".cargo")).unwrap();
     File::create(p.root().join(".cargo/config"))
         .unwrap()


### PR DESCRIPTION
This fixes the CARGO_BUILD_TARGET_DIR and CARGO_PROFILE_DEV_DEBUG_ASSERTIONS environment variables.  Hopefully the big comment explains everything, but to review:

`deserialize_option` does not know the type of the value it is about to deserialize.  The type could be a struct, in which case it needs to check if `CARGO_FOO_BAR_*` environment variables are set. However, when deserializing something like `build.target`, this prefix check will incorrectly match `CARGO_BUILD_TARGET_DIR` which happens to be a prefix of `CARGO_BUILD_TARGET_*`.  It attempts to call `visit_some` which fails if `CARGO_BUILD_TARGET` is not set.

The solution here is to detect scenarios where one field is a prefix of another, and skip the environment prefix check (by setting `Deserializer::env_prefix_ok` appropriately).  This means we cannot have `Option<SomeStruct>` be a prefix of another field with an underscore.  I think that's fine, and we should try to probably avoid these kinds a prefixes anyways.

Closes #7253.