### PR TITLE
Add named config profiles.

### DIFF
--- a/src/bin/cargo/commands/bench.rs
+++ b/src/bin/cargo/commands/bench.rs
@@ -1,5 +1,4 @@
 use crate::command_prelude::*;
-
 use cargo::ops::{self, TestOptions};
 
 pub fn cli() -> App {
@@ -80,11 +79,8 @@ pub fn exec(config: &mut Config, args: &ArgMatches<'_>) -> CliResult {
         ProfileChecking::Checked,
     )?;
 
-    compile_opts.build_config.profile_kind = args.get_profile_kind(
-        config,
-        ProfileKind::Custom("bench".to_owned()),
-        ProfileChecking::Checked,
-    )?;
+    compile_opts.build_config.requested_profile =
+        args.get_profile_name(config, "bench", ProfileChecking::Checked)?;
 
     let ops = TestOptions {
         no_run: args.is_present("no-run"),

--- a/src/bin/cargo/commands/clean.rs
+++ b/src/bin/cargo/commands/clean.rs
@@ -29,7 +29,7 @@ pub fn exec(config: &mut Config, args: &ArgMatches<'_>) -> CliResult {
         config,
         spec: values(args, "package"),
         target: args.target(),
-        profile_kind: args.get_profile_kind(config, ProfileKind::Dev, ProfileChecking::Checked)?,
+        requested_profile: args.get_profile_name(config, "dev", ProfileChecking::Checked)?,
         profile_specified: args.is_present("profile") || args.is_present("release"),
         doc: args.is_present("doc"),
     };

--- a/src/bin/cargo/commands/install.rs
+++ b/src/bin/cargo/commands/install.rs
@@ -116,8 +116,8 @@ pub fn exec(config: &mut Config, args: &ArgMatches<'_>) -> CliResult {
         ProfileChecking::Checked,
     )?;
 
-    compile_opts.build_config.profile_kind =
-        args.get_profile_kind(config, ProfileKind::Release, ProfileChecking::Checked)?;
+    compile_opts.build_config.requested_profile =
+        args.get_profile_name(config, "release", ProfileChecking::Checked)?;
 
     let krates = args
         .values_of("crate")

--- a/src/bin/cargo/commands/test.rs
+++ b/src/bin/cargo/commands/test.rs
@@ -108,11 +108,8 @@ pub fn exec(config: &mut Config, args: &ArgMatches<'_>) -> CliResult {
         ProfileChecking::Checked,
     )?;
 
-    compile_opts.build_config.profile_kind = args.get_profile_kind(
-        config,
-        ProfileKind::Custom("test".to_owned()),
-        ProfileChecking::Checked,
-    )?;
+    compile_opts.build_config.requested_profile =
+        args.get_profile_name(config, "test", ProfileChecking::Checked)?;
 
     // `TESTNAME` is actually an argument of the test binary, but it's
     // important, so we explicitly mention it and reconfigure.

--- a/src/cargo/core/compiler/build_config.rs
+++ b/src/cargo/core/compiler/build_config.rs
@@ -1,27 +1,9 @@
-use std::cell::RefCell;
-
-use serde::ser;
-
 use crate::core::compiler::{CompileKind, CompileTarget};
+use crate::core::interning::InternedString;
 use crate::util::ProcessBuilder;
 use crate::util::{CargoResult, Config, RustfixDiagnosticServer};
-
-#[derive(Debug, Clone)]
-pub enum ProfileKind {
-    Dev,
-    Release,
-    Custom(String),
-}
-
-impl ProfileKind {
-    pub fn name(&self) -> &str {
-        match self {
-            ProfileKind::Dev => "dev",
-            ProfileKind::Release => "release",
-            ProfileKind::Custom(name) => name,
-        }
-    }
-}
+use serde::ser;
+use std::cell::RefCell;
 
 /// Configuration information for a rustc build.
 #[derive(Debug)]
@@ -31,7 +13,7 @@ pub struct BuildConfig {
     /// Number of rustc jobs to run in parallel.
     pub jobs: u32,
     /// Build profile
-    pub profile_kind: ProfileKind,
+    pub requested_profile: InternedString,
     /// The mode we are compiling in.
     pub mode: CompileMode,
     /// `true` to print stdout in JSON format (for machine reading).
@@ -92,7 +74,7 @@ impl BuildConfig {
         Ok(BuildConfig {
             requested_kind,
             jobs,
-            profile_kind: ProfileKind::Dev,
+            requested_profile: InternedString::new("dev"),
             mode,
             message_format: MessageFormat::Human,
             force_rebuild: false,
@@ -109,10 +91,6 @@ impl BuildConfig {
             MessageFormat::Json { .. } => true,
             _ => false,
         }
-    }
-
-    pub fn profile_name(&self) -> &str {
-        self.profile_kind.name()
     }
 
     pub fn test(&self) -> bool {

--- a/src/cargo/core/compiler/build_context/mod.rs
+++ b/src/cargo/core/compiler/build_context/mod.rs
@@ -26,7 +26,7 @@ pub struct BuildContext<'a, 'cfg> {
     pub ws: &'a Workspace<'cfg>,
     /// The cargo configuration.
     pub config: &'cfg Config,
-    pub profiles: &'a Profiles,
+    pub profiles: Profiles,
     pub build_config: &'a BuildConfig,
     /// Extra compiler args for either `rustc` or `rustdoc`.
     pub extra_compiler_args: HashMap<Unit<'a>, Vec<String>>,
@@ -58,7 +58,7 @@ impl<'a, 'cfg> BuildContext<'a, 'cfg> {
         packages: &'a PackageSet<'cfg>,
         config: &'cfg Config,
         build_config: &'a BuildConfig,
-        profiles: &'a Profiles,
+        profiles: Profiles,
         units: &'a UnitInterner<'a>,
         extra_compiler_args: HashMap<Unit<'a>, Vec<String>>,
     ) -> CargoResult<BuildContext<'a, 'cfg>> {

--- a/src/cargo/core/compiler/context/mod.rs
+++ b/src/cargo/core/compiler/context/mod.rs
@@ -281,8 +281,7 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
         export_dir: Option<PathBuf>,
         units: &[Unit<'a>],
     ) -> CargoResult<()> {
-        let profile_kind = &self.bcx.build_config.profile_kind;
-        let dest = self.bcx.profiles.get_dir_name(profile_kind);
+        let dest = self.bcx.profiles.get_dir_name();
         let host_layout = Layout::new(self.bcx.ws, None, &dest)?;
         let mut targets = HashMap::new();
         if let CompileKind::Target(target) = self.bcx.build_config.requested_kind {

--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -27,7 +27,7 @@ use anyhow::Error;
 use lazycell::LazyCell;
 use log::debug;
 
-pub use self::build_config::{BuildConfig, CompileMode, MessageFormat, ProfileKind};
+pub use self::build_config::{BuildConfig, CompileMode, MessageFormat};
 pub use self::build_context::{BuildContext, FileFlavor, TargetInfo};
 use self::build_plan::BuildPlan;
 pub use self::compilation::{Compilation, Doctest};

--- a/src/cargo/core/compiler/standard_lib.rs
+++ b/src/cargo/core/compiler/standard_lib.rs
@@ -66,8 +66,7 @@ pub fn resolve_std<'cfg>(
         /*replace*/ Vec::new(),
         patch,
         ws_config,
-        // Profiles are not used here, but we need something to pass in.
-        ws.profiles().clone(),
+        /*profiles*/ None,
         crate::core::Features::default(),
     );
 
@@ -139,7 +138,6 @@ pub fn generate_std_roots<'a>(
                 /*is_member*/ false,
                 unit_for,
                 mode,
-                bcx.build_config.profile_kind.clone(),
             );
             let features = std_resolve.features_sorted(pkg.package_id());
             Ok(bcx.units.intern(

--- a/src/cargo/core/compiler/timings.rs
+++ b/src/cargo/core/compiler/timings.rs
@@ -116,7 +116,7 @@ impl<'a, 'cfg> Timings<'a, 'cfg> {
             })
             .collect();
         let start_str = humantime::format_rfc3339_seconds(SystemTime::now()).to_string();
-        let profile = bcx.build_config.profile_kind.name().to_owned();
+        let profile = bcx.build_config.requested_profile.to_string();
 
         Timings {
             config: bcx.config,

--- a/src/cargo/core/compiler/unit_dependencies.rs
+++ b/src/cargo/core/compiler/unit_dependencies.rs
@@ -546,7 +546,6 @@ fn new_unit_dep<'a>(
         state.bcx.ws.is_member(pkg),
         unit_for,
         mode,
-        state.bcx.build_config.profile_kind.clone(),
     );
     new_unit_dep_with_profile(state, parent, pkg, target, unit_for, kind, mode, profile)
 }

--- a/src/cargo/core/interning.rs
+++ b/src/cargo/core/interning.rs
@@ -48,6 +48,18 @@ impl PartialEq for InternedString {
     }
 }
 
+impl PartialEq<str> for InternedString {
+    fn eq(&self, other: &str) -> bool {
+        *self == other
+    }
+}
+
+impl<'a> PartialEq<&'a str> for InternedString {
+    fn eq(&self, other: &&str) -> bool {
+        **self == **other
+    }
+}
+
 impl Eq for InternedString {}
 
 impl InternedString {

--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -10,11 +10,10 @@ use serde::Serialize;
 use url::Url;
 
 use crate::core::interning::InternedString;
-use crate::core::profiles::Profiles;
 use crate::core::{Dependency, PackageId, PackageIdSpec, SourceId, Summary};
 use crate::core::{Edition, Feature, Features, WorkspaceConfig};
 use crate::util::errors::*;
-use crate::util::toml::TomlManifest;
+use crate::util::toml::{TomlManifest, TomlProfiles};
 use crate::util::{short_hash, Config, Filesystem};
 
 pub enum EitherManifest {
@@ -33,7 +32,7 @@ pub struct Manifest {
     include: Vec<String>,
     metadata: ManifestMetadata,
     custom_metadata: Option<toml::Value>,
-    profiles: Profiles,
+    profiles: Option<TomlProfiles>,
     publish: Option<Vec<String>>,
     publish_lockfile: bool,
     replace: Vec<(PackageIdSpec, Dependency)>,
@@ -64,7 +63,7 @@ pub struct VirtualManifest {
     replace: Vec<(PackageIdSpec, Dependency)>,
     patch: HashMap<Url, Vec<Dependency>>,
     workspace: WorkspaceConfig,
-    profiles: Profiles,
+    profiles: Option<TomlProfiles>,
     warnings: Warnings,
     features: Features,
 }
@@ -399,7 +398,7 @@ impl Manifest {
         links: Option<String>,
         metadata: ManifestMetadata,
         custom_metadata: Option<toml::Value>,
-        profiles: Profiles,
+        profiles: Option<TomlProfiles>,
         publish: Option<Vec<String>>,
         publish_lockfile: bool,
         replace: Vec<(PackageIdSpec, Dependency)>,
@@ -475,8 +474,8 @@ impl Manifest {
     pub fn warnings(&self) -> &Warnings {
         &self.warnings
     }
-    pub fn profiles(&self) -> &Profiles {
-        &self.profiles
+    pub fn profiles(&self) -> Option<&TomlProfiles> {
+        self.profiles.as_ref()
     }
     pub fn publish(&self) -> &Option<Vec<String>> {
         &self.publish
@@ -563,7 +562,7 @@ impl VirtualManifest {
         replace: Vec<(PackageIdSpec, Dependency)>,
         patch: HashMap<Url, Vec<Dependency>>,
         workspace: WorkspaceConfig,
-        profiles: Profiles,
+        profiles: Option<TomlProfiles>,
         features: Features,
     ) -> VirtualManifest {
         VirtualManifest {
@@ -588,8 +587,8 @@ impl VirtualManifest {
         &self.workspace
     }
 
-    pub fn profiles(&self) -> &Profiles {
-        &self.profiles
+    pub fn profiles(&self) -> Option<&TomlProfiles> {
+        self.profiles.as_ref()
     }
 
     pub fn warnings_mut(&mut self) -> &mut Warnings {

--- a/src/cargo/ops/common_for_install_and_uninstall.rs
+++ b/src/cargo/ops/common_for_install_and_uninstall.rs
@@ -427,7 +427,7 @@ impl CrateListingV2 {
             info.features = feature_set(&opts.features);
             info.all_features = opts.all_features;
             info.no_default_features = opts.no_default_features;
-            info.profile = opts.build_config.profile_name().to_string();
+            info.profile = opts.build_config.requested_profile.to_string();
             info.target = Some(target.to_string());
             info.rustc = Some(rustc.to_string());
         } else {
@@ -439,7 +439,7 @@ impl CrateListingV2 {
                     features: feature_set(&opts.features),
                     all_features: opts.all_features,
                     no_default_features: opts.no_default_features,
-                    profile: opts.build_config.profile_name().to_string(),
+                    profile: opts.build_config.requested_profile.to_string(),
                     target: Some(target.to_string()),
                     rustc: Some(rustc.to_string()),
                     other: BTreeMap::new(),
@@ -499,7 +499,7 @@ impl InstallInfo {
         self.features == feature_set(&opts.features)
             && self.all_features == opts.all_features
             && self.no_default_features == opts.no_default_features
-            && self.profile == opts.build_config.profile_name()
+            && self.profile.as_str() == opts.build_config.requested_profile.as_str()
             && (self.target.is_none() || self.target.as_ref().map(|t| t.as_ref()) == Some(target))
             && &self.bins == exes
     }

--- a/src/cargo/util/command_prelude.rs
+++ b/src/cargo/util/command_prelude.rs
@@ -1,4 +1,5 @@
 use crate::core::compiler::{BuildConfig, MessageFormat};
+use crate::core::InternedString;
 use crate::core::Workspace;
 use crate::ops::{CompileFilter, CompileOptions, NewOptions, Packages, VersionControl};
 use crate::sources::CRATES_IO_REGISTRY;
@@ -15,7 +16,7 @@ use std::ffi::{OsStr, OsString};
 use std::fs;
 use std::path::PathBuf;
 
-pub use crate::core::compiler::{CompileMode, ProfileKind};
+pub use crate::core::compiler::CompileMode;
 pub use crate::{CliError, CliResult, Config};
 pub use clap::{AppSettings, Arg, ArgMatches};
 
@@ -307,19 +308,17 @@ pub trait ArgMatchesExt {
         self._value_of("target").map(|s| s.to_string())
     }
 
-    fn get_profile_kind(
+    fn get_profile_name(
         &self,
         config: &Config,
-        default: ProfileKind,
+        default: &str,
         profile_checking: ProfileChecking,
-    ) -> CargoResult<ProfileKind> {
+    ) -> CargoResult<InternedString> {
         let specified_profile = match self._value_of("profile") {
             None => None,
-            Some("dev") => Some(ProfileKind::Dev),
-            Some("release") => Some(ProfileKind::Release),
             Some(name) => {
                 TomlProfile::validate_name(name, "profile name")?;
-                Some(ProfileKind::Custom(name.to_string()))
+                Some(InternedString::new(name))
             }
         };
 
@@ -334,24 +333,28 @@ pub trait ArgMatchesExt {
 
         if self._is_present("release") {
             if !config.cli_unstable().unstable_options {
-                Ok(ProfileKind::Release)
+                Ok(InternedString::new("release"))
             } else {
                 match specified_profile {
-                    None | Some(ProfileKind::Release) => Ok(ProfileKind::Release),
-                    _ => anyhow::bail!("Conflicting usage of --profile and --release"),
+                    Some(name) if name != "release" => {
+                        anyhow::bail!("Conflicting usage of --profile and --release")
+                    }
+                    _ => Ok(InternedString::new("release")),
                 }
             }
         } else if self._is_present("debug") {
             if !config.cli_unstable().unstable_options {
-                Ok(ProfileKind::Dev)
+                Ok(InternedString::new("dev"))
             } else {
                 match specified_profile {
-                    None | Some(ProfileKind::Dev) => Ok(ProfileKind::Dev),
-                    _ => anyhow::bail!("Conflicting usage of --profile and --debug"),
+                    Some(name) if name != "dev" => {
+                        anyhow::bail!("Conflicting usage of --profile and --debug")
+                    }
+                    _ => Ok(InternedString::new("dev")),
                 }
             }
         } else {
-            Ok(specified_profile.unwrap_or(default))
+            Ok(specified_profile.unwrap_or_else(|| InternedString::new(default)))
         }
     }
 
@@ -433,8 +436,7 @@ pub trait ArgMatchesExt {
 
         let mut build_config = BuildConfig::new(config, self.jobs()?, &self.target(), mode)?;
         build_config.message_format = message_format.unwrap_or(MessageFormat::Human);
-        build_config.profile_kind =
-            self.get_profile_kind(config, ProfileKind::Dev, profile_checking)?;
+        build_config.requested_profile = self.get_profile_name(config, "dev", profile_checking)?;
         build_config.build_plan = self._is_present("build-plan");
         if build_config.build_plan {
             config

--- a/src/cargo/util/config/de.rs
+++ b/src/cargo/util/config/de.rs
@@ -425,13 +425,11 @@ impl<'config> ValueDeserializer<'config> {
                         cv.definition().clone()
                     }
                 }
-                (true, None) => env_def,
                 (false, Some(cv)) => cv.definition().clone(),
-                (false, None) => {
-                    return Err(
-                        anyhow::format_err!("failed to find definition of `{}`", de.key).into(),
-                    )
-                }
+                // Assume it is an environment, even if the key is not set.
+                // This can happen for intermediate tables, like
+                // CARGO_FOO_BAR_* where `CARGO_FOO_BAR` is not set.
+                (_, None) => env_def,
             }
         };
         Ok(ValueDeserializer {

--- a/tests/testsuite/config.rs
+++ b/tests/testsuite/config.rs
@@ -1,18 +1,17 @@
 //! Tests for config settings.
 
+use cargo::core::{enable_nightly_features, InternedString, Shell};
+use cargo::util::config::{self, Config, SslVersionConfig, StringList};
+use cargo::util::toml::{self, VecStringOrBool as VSOB};
+use cargo::CargoResult;
+use cargo_test_support::{normalized_lines_match, paths, project, t};
+use serde::Deserialize;
 use std::borrow::Borrow;
 use std::collections::{BTreeMap, HashMap};
 use std::fs;
 use std::io;
 use std::os;
 use std::path::{Path, PathBuf};
-
-use cargo::core::{enable_nightly_features, Shell};
-use cargo::util::config::{self, Config, SslVersionConfig, StringList};
-use cargo::util::toml::{self, VecStringOrBool as VSOB};
-use cargo::CargoResult;
-use cargo_test_support::{normalized_lines_match, paths, project, t};
-use serde::Deserialize;
 
 /// Helper for constructing a `Config` object.
 pub struct ConfigBuilder {
@@ -424,8 +423,8 @@ lto = false
         p,
         toml::TomlProfile {
             lto: Some(toml::StringOrBool::Bool(false)),
-            dir_name: Some("without-lto".to_string()),
-            inherits: Some("dev".to_string()),
+            dir_name: Some(InternedString::new("without-lto")),
+            inherits: Some(InternedString::new("dev")),
             ..Default::default()
         }
     );

--- a/tests/testsuite/profile_config.rs
+++ b/tests/testsuite/profile_config.rs
@@ -125,10 +125,10 @@ fn profile_config_error_paths() {
         .with_status(101)
         .with_stderr(
             "\
-[ERROR] error in [..]/foo/.cargo/config: \
-    could not load config key `profile.dev`: \
-    error in [..]/home/.cargo/config: \
-    `profile.dev.rpath` expected true/false, but found a string
+[ERROR] error in [..]/foo/.cargo/config: could not load config key `profile.dev`
+
+Caused by:
+  error in [..]/home/.cargo/config: `profile.dev.rpath` expected true/false, but found a string
 ",
         )
         .run();
@@ -181,10 +181,10 @@ fn profile_config_syntax_errors() {
         .with_status(101)
         .with_stderr(
             "\
-[ERROR] error in [..]/foo/.cargo/config: \
-    could not load config key `profile.dev`: \
-    error in [..]/foo/.cargo/config: \
-    `profile.dev.codegen-units` expected an integer, but found a string
+[ERROR] error in [..]/.cargo/config: could not load config key `profile.dev`
+
+Caused by:
+  error in [..]/foo/.cargo/config: `profile.dev.codegen-units` expected an integer, but found a string
 ",
         )
         .run();

--- a/tests/testsuite/profile_config.rs
+++ b/tests/testsuite/profile_config.rs
@@ -1,5 +1,6 @@
 //! Tests for profiles defined in config files.
 
+use cargo_test_support::paths::CargoPathExt;
 use cargo_test_support::{basic_lib_manifest, paths, project};
 
 #[cargo_test]
@@ -19,10 +20,41 @@ fn profile_config_gated() {
     p.cargo("build -v")
         .with_stderr_contains(
             "\
-[WARNING] profiles in config files require `-Z config-profile` command-line option
+[WARNING] config profiles require the `-Z config-profile` command-line option \
+    (found profile `dev` in [..]/foo/.cargo/config)
 ",
         )
         .with_stderr_contains("[..]-C debuginfo=2[..]")
+        .run();
+}
+
+#[cargo_test]
+fn named_profile_gated() {
+    // Named profile in config requires enabling in Cargo.toml.
+    let p = project()
+        .file("src/lib.rs", "")
+        .file(
+            ".cargo/config",
+            r#"
+            [profile.foo]
+            inherits = 'dev'
+            opt-level = 1
+            "#,
+        )
+        .build();
+    p.cargo("build --profile foo -Zunstable-options -Zconfig-profile")
+        .masquerade_as_nightly_cargo()
+        .with_stderr(
+            "\
+[ERROR] config profile `foo` is not valid (defined in `[..]/foo/.cargo/config`)
+
+Caused by:
+  feature `named-profiles` is required
+
+consider adding `cargo-features = [\"named-profiles\"]` to the manifest
+",
+        )
+        .with_status(101)
         .run();
 }
 
@@ -56,8 +88,6 @@ fn profile_config_validate_warnings() {
         .masquerade_as_nightly_cargo()
         .with_stderr_unordered(
             "\
-[WARNING] unused config key `profile.asdf` in `[..].cargo/config`
-[WARNING] unused config key `profile.test` in `[..].cargo/config`
 [WARNING] unused config key `profile.dev.bad-key` in `[..].cargo/config`
 [WARNING] unused config key `profile.dev.package.bar.bad-key-bar` in `[..].cargo/config`
 [WARNING] unused config key `profile.dev.build-override.bad-key-bo` in `[..].cargo/config`
@@ -70,6 +100,7 @@ fn profile_config_validate_warnings() {
 
 #[cargo_test]
 fn profile_config_error_paths() {
+    // Errors in config show where the error is located.
     let p = project()
         .file("Cargo.toml", &basic_lib_manifest("foo"))
         .file("src/lib.rs", "")
@@ -94,10 +125,10 @@ fn profile_config_error_paths() {
         .with_status(101)
         .with_stderr(
             "\
-[ERROR] failed to parse manifest at `[CWD]/Cargo.toml`
-
-Caused by:
-  error in [..].cargo/config: `profile.dev.rpath` expected true/false, but found a string
+[ERROR] error in [..]/foo/.cargo/config: \
+    could not load config key `profile.dev`: \
+    error in [..]/home/.cargo/config: \
+    `profile.dev.rpath` expected true/false, but found a string
 ",
         )
         .run();
@@ -122,7 +153,7 @@ fn profile_config_validate_errors() {
         .with_status(101)
         .with_stderr(
             "\
-[ERROR] config profile `profile.dev` is not valid
+[ERROR] config profile `dev` is not valid (defined in `[..]/foo/.cargo/config`)
 
 Caused by:
   `panic` may not be specified in a `package` profile
@@ -150,10 +181,10 @@ fn profile_config_syntax_errors() {
         .with_status(101)
         .with_stderr(
             "\
-[ERROR] failed to parse manifest at [..]
-
-Caused by:
-  error in [..].cargo/config: `profile.dev.codegen-units` expected an integer, but found a string
+[ERROR] error in [..]/foo/.cargo/config: \
+    could not load config key `profile.dev`: \
+    error in [..]/foo/.cargo/config: \
+    `profile.dev.codegen-units` expected an integer, but found a string
 ",
         )
         .run();
@@ -335,5 +366,125 @@ fn profile_config_mixed_types() {
     p.cargo("build -v -Z config-profile")
         .masquerade_as_nightly_cargo()
         .with_stderr_contains("[..]-C opt-level=3 [..]")
+        .run();
+}
+
+#[cargo_test]
+fn named_config_profile() {
+    // Exercises config named profies.
+    // foo -> middle -> bar -> dev
+    // middle exists in Cargo.toml, the others in .cargo/config
+    use super::config::ConfigBuilder;
+    use cargo::core::compiler::CompileMode;
+    use cargo::core::enable_nightly_features;
+    use cargo::core::features::Features;
+    use cargo::core::profiles::{Profiles, UnitFor};
+    use cargo::core::{InternedString, PackageId};
+    use cargo::util::toml::TomlProfiles;
+    use std::fs;
+    enable_nightly_features();
+    paths::root().join(".cargo").mkdir_p();
+    fs::write(
+        paths::root().join(".cargo/config"),
+        r#"
+        [profile.foo]
+        inherits = "middle"
+        codegen-units = 2
+        [profile.foo.build-override]
+        codegen-units = 6
+        [profile.foo.package.dep]
+        codegen-units = 7
+
+        [profile.middle]
+        inherits = "bar"
+        codegen-units = 3
+
+        [profile.bar]
+        inherits = "dev"
+        codegen-units = 4
+        debug = 1
+        "#,
+    )
+    .unwrap();
+    let config = ConfigBuilder::new().unstable_flag("config-profile").build();
+    let mut warnings = Vec::new();
+    let features = Features::new(&["named-profiles".to_string()], &mut warnings).unwrap();
+    assert_eq!(warnings.len(), 0);
+    let profile_name = InternedString::new("foo");
+    let toml = r#"
+        [profile.middle]
+        inherits = "bar"
+        codegen-units = 1
+        opt-level = 1
+        [profile.middle.package.dep]
+        overflow-checks = false
+
+        [profile.foo.build-override]
+        codegen-units = 5
+        debug-assertions = false
+        [profile.foo.package.dep]
+        codegen-units = 8
+    "#;
+    #[derive(serde::Deserialize)]
+    struct TomlManifest {
+        profile: Option<TomlProfiles>,
+    }
+    let manifest: TomlManifest = toml::from_str(toml).unwrap();
+    let profiles =
+        Profiles::new(manifest.profile.as_ref(), &config, profile_name, &features).unwrap();
+
+    let crates_io = cargo::core::source::SourceId::crates_io(&config).unwrap();
+    let a_pkg = PackageId::new("a", "0.1.0", crates_io).unwrap();
+    let dep_pkg = PackageId::new("dep", "0.1.0", crates_io).unwrap();
+
+    // normal package
+    let p = profiles.get_profile(a_pkg, true, UnitFor::new_normal(), CompileMode::Build);
+    assert_eq!(p.name, "foo");
+    assert_eq!(p.codegen_units, Some(2)); // "foo" from config
+    assert_eq!(p.opt_level, "1"); // "middle" from manifest
+    assert_eq!(p.debuginfo, Some(1)); // "bar" from config
+    assert_eq!(p.debug_assertions, true); // "dev" built-in (ignore build-override)
+    assert_eq!(p.overflow_checks, true); // "dev" built-in (ignore package override)
+
+    // build-override
+    let bo = profiles.get_profile(a_pkg, true, UnitFor::new_build(), CompileMode::Build);
+    assert_eq!(bo.name, "foo");
+    assert_eq!(bo.codegen_units, Some(6)); // "foo" build override from config
+    assert_eq!(bo.opt_level, "1"); // SAME as normal
+    assert_eq!(bo.debuginfo, Some(1)); // SAME as normal
+    assert_eq!(bo.debug_assertions, false); // "foo" build override from manifest
+    assert_eq!(bo.overflow_checks, true); // SAME as normal
+
+    // package overrides
+    let po = profiles.get_profile(dep_pkg, false, UnitFor::new_normal(), CompileMode::Build);
+    assert_eq!(po.name, "foo");
+    assert_eq!(po.codegen_units, Some(7)); // "foo" package override from config
+    assert_eq!(po.opt_level, "1"); // SAME as normal
+    assert_eq!(po.debuginfo, Some(1)); // SAME as normal
+    assert_eq!(po.debug_assertions, true); // SAME as normal
+    assert_eq!(po.overflow_checks, false); // "middle" package override from manifest
+}
+
+#[cargo_test]
+fn named_env_profile() {
+    // Environment variables used to define a named profile.
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            cargo-features = ["named-profiles"]
+            [package]
+            name = "foo"
+            version = "0.1.0"
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    p.cargo("build -v -Zconfig-profile -Zunstable-options --profile=other")
+        .masquerade_as_nightly_cargo()
+        .env("CARGO_PROFILE_OTHER_CODEGEN_UNITS", "1")
+        .env("CARGO_PROFILE_OTHER_INHERITS", "dev")
+        .with_stderr_contains("[..]-C codegen-units=1 [..]")
         .run();
 }


### PR DESCRIPTION
This adds support for named config profiles. Previously, only `dev` and `release` were allowed in config files, it now supports all profile names. I think it would be strange to have arbitrarily named profiles in `Cargo.toml`, but not allow them in config. This is a deviation from the RFC, but RFC 2282 was written before named profiles which I think changes the landscape.

This diff is a little large due to some refactoring to make it work well. Overview of the changes:
- Removed `ProfileKind` and only use an `InternedString` to track the name of the profile. I didn't feel like the enum carried its cognitive weight, and it seems to simplify some things.
- `Profiles` is no longer stored in the manifest. There was no need to do a bunch of processing for each manifest. `Manifest` now only retains the low-level `TomlProfiles`. A single `Profiles` now lives in `BuildContext`.
- The profile name requested by the user is no longer passed around. It is given to `Profiles::new` and retained inside `Profiles`.
- `Profiles::get_profile` no longer follows the priority stack and inheritance each time a profile is requested. Instead, the profile is computed once (in `Profile::new`) and merged into a single profile. This simplifies getting a profile, and makes it easier to deal with getting the config values in one place.
- I switched profile names to be `InternedString` instead of `String`. There's not a strong reason to do this, other than it seemed a little strange to be creating lots of `String`s.
    - I also added `PartialEq<str>` for `InternedString`. It has come up a few times in the past, and it seems useful. I'm not sure if it was excluded intentionally?
- The validation that the profile exists is now done in one place (`Profiles::new`).
- I removed the back-compatibility for the `overrides` key (which was renamed to `package` back in October).

Notes:
- Some of the error messages aren't as good as before, because they don't tell you where the error is located (`Cargo.toml` or `.cargo/config`). This is because the location data is lost by the time validation is done. Hopefully it will be obvious from the profile name and error message. I tried to improve error messages wherever I could.
- There are more calls to `clone()` than I would like, but they are kinda hard to avoid. Should be fewer than before.
- I noticed a bug with `-Zpanic-abort-tests` not supporting named profiles. I'll fix that separately.
- I think this fixes some bugs where package overrides in config weren't merging properly with package overrides defined in `Cargo.toml`.
