### PR TITLE
Fix dynamic linking for Windows UWP MSVC targets

### DIFF
--- a/src/cargo/core/compiler/build_context/target_info.rs
+++ b/src/cargo/core/compiler/build_context/target_info.rs
@@ -228,7 +228,7 @@ impl TargetInfo {
         }];
 
         // See rust-lang/cargo#4500.
-        if target_triple.ends_with("pc-windows-msvc")
+        if target_triple.ends_with("-windows-msvc")
             && crate_type.ends_with("dylib")
             && suffix == ".dll"
         {


### PR DESCRIPTION
When creating a dynamic library, the MSVC linker generates an import library (.lib) next to the .dll file. Cargo has explicit knowledge of this and includes those generated .dll.lib on the list of files generated by a Cargo invocation.

However, the check to see if those import libraries must be included is too strict and doesn't match any Windows targets that don't end in `pc-windows-msvc`. For example, https://github.com/rust-lang/rust/pull/63155 added several new Windows targets for targeting UWP called `*-uwp-windows-msvc`. The end result is that the sysroot for these UWP toolchains don't contain a `std-XXX.dll.lib` file and thus any executable that uses `-C prefer-dynamic` will fail to link because the `std` library is not linked at all.

This change relaxes the test and makes Cargo know about those import libraries for all Windows MSVC targets.