### PR TITLE
resolve build dependencies independently [WIP]

### DIFF
--- a/src/cargo/core/compiler/unit_dependencies.rs
+++ b/src/cargo/core/compiler/unit_dependencies.rs
@@ -228,7 +228,12 @@ fn compute_deps<'a, 'cfg>(
 
     let bcx = state.bcx;
     let id = unit.pkg.package_id();
-    let deps = state.resolve().deps(id).filter(|&(_id, deps)| {
+    let deps = if unit.target.is_custom_build() {
+        state.resolve().build_graph(id).map(|x| x.deps(id)).into_iter().flatten()
+    } else {
+        Some(state.resolve().deps(id)).into_iter().flatten()
+    };
+    let deps = deps.filter(|&(_id, deps)| {
         assert!(!deps.is_empty());
         deps.iter().any(|dep| {
             // If this target is a build command, then we only want build

--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -436,6 +436,12 @@ impl Manifest {
         }
     }
 
+    pub fn run_dependencies(&self) -> impl Iterator<Item=&Dependency> {
+        self.summary.run_dependencies()
+    }
+    pub fn build_dependencies(&self) -> impl Iterator<Item=&Dependency> {
+        self.summary.build_dependencies()
+    }
     pub fn dependencies(&self) -> &[Dependency] {
         self.summary.dependencies()
     }

--- a/src/cargo/core/package.rs
+++ b/src/cargo/core/package.rs
@@ -141,7 +141,15 @@ impl Package {
         }
     }
 
-    /// Gets the manifest dependencies.
+    /// Gets the manifest runtime (i.e. normal and development) dependencies.
+    pub fn run_dependencies(&self) -> impl Iterator<Item=&Dependency> {
+        self.manifest.run_dependencies()
+    }
+    /// Gets the manifest build dependencies.
+    pub fn build_dependencies(&self) -> impl Iterator<Item=&Dependency> {
+        self.manifest.build_dependencies()
+    }
+    /// Gets all dependencies.
     pub fn dependencies(&self) -> &[Dependency] {
         self.manifest.dependencies()
     }

--- a/src/cargo/core/resolver/context.rs
+++ b/src/cargo/core/resolver/context.rs
@@ -36,6 +36,9 @@ pub struct Context {
     /// a way to look up for a package in activations what packages required it
     /// and all of the exact deps that it fulfilled.
     pub parents: Graph<PackageId, Rc<Vec<Dependency>>>,
+
+    /// full resolution for build dependencies
+    pub build_graphs: im_rc::HashMap<PackageId, Resolve>,
 }
 
 /// When backtracking it can be useful to know how far back to go.
@@ -93,6 +96,7 @@ impl Context {
             },
             parents: Graph::new(),
             activations: im_rc::HashMap::new(),
+            build_graphs: im_rc::HashMap::new(),
         }
     }
 
@@ -268,6 +272,10 @@ impl Context {
             }
         }
         graph
+    }
+
+    pub fn build_graphs(&self) -> HashMap<PackageId, Resolve> {
+        self.build_graphs.iter().cloned().collect()
     }
 }
 

--- a/src/cargo/core/resolver/encode.rs
+++ b/src/cargo/core/resolver/encode.rs
@@ -364,6 +364,7 @@ impl EncodableResolve {
             checksums,
             metadata,
             unused_patches,
+            HashMap::new(), // TODO how to serialize??
             version,
         ))
     }

--- a/src/cargo/core/summary.rs
+++ b/src/cargo/core/summary.rs
@@ -84,6 +84,12 @@ impl Summary {
     pub fn source_id(&self) -> SourceId {
         self.package_id().source_id()
     }
+    pub fn run_dependencies(&self) -> impl Iterator<Item=&Dependency> {
+        self.inner.dependencies.iter().filter(|dep| !dep.is_build())
+    }
+    pub fn build_dependencies(&self) -> impl Iterator<Item=&Dependency> {
+        self.inner.dependencies.iter().filter(|dep| dep.is_build())
+    }
     pub fn dependencies(&self) -> &[Dependency] {
         &self.inner.dependencies
     }

--- a/tests/testsuite/build_script.rs
+++ b/tests/testsuite/build_script.rs
@@ -4032,6 +4032,5 @@ fn links_duplicated_across_build_deps() {
         .build();
 
     p.cargo("build")
-        .env("CARGO_LOG", "trace")
         .run();
 }


### PR DESCRIPTION
## motivation

the unification of build dependencies with runtime dependencies creates a lot of counterintuitive behavior (#5237 and #4866 are two areas where this has been a long-standing issue). the most straightforward approach to fixing this, as far as i can tell, is to not unify build dependencies with runtime dependencies.

## approach

unfortunately, *everything about cargo* is built around a monolithic dependency resolution DAG.

there are a lot of ways that this could be implemented, but what i've (tentatively) chosen is to add a field `build_graphs: HashMap<PackageId, Resolve>` to the existing `Resolve`, and when a package with at least one build dependency is encountered, the resolution process recurses to generate the build dependency DAG for that package. this approach seems good to me - it preserves existing code's assumption that all dependency resolution information is in the `Resolve`, and it allows for reuse of most of the existing dependency resolution code - but i'm certainly open to suggestions if there's a better approach.

## status

right now, the resolver tests are broken and i don't understand enough about proptest to fix them, and a few dozen integration tests are failing for reasons that i don't quite understand. my intuition is that there's some gap in the translation from the cargo-internal `Resolve` to the rustc-attached `UnitGraph`, but i need to do more poking around to be confident of that.

pending actions i could use some help with:
- [ ] confirm that this approach is reasonable
- [ ] fix resolver tests
- [ ] fix integration tests
- [ ] write tests for feature selection