### PR TITLE
Fix CARGO_TARGET_triple_LINKER environment variable.

### DIFF
--- a/src/cargo/core/compiler/build_context/mod.rs
+++ b/src/cargo/core/compiler/build_context/mod.rs
@@ -64,7 +64,7 @@ impl<'a, 'cfg> BuildContext<'a, 'cfg> {
     ) -> CargoResult<BuildContext<'a, 'cfg>> {
         let rustc = config.load_global_rustc(Some(ws))?;
 
-        let host_config = config.get(&format!("target.{}", rustc.host))?;
+        let host_config = config.target_cfg_triple(&rustc.host)?;
         let host_info = TargetInfo::new(
             config,
             build_config.requested_kind,
@@ -74,7 +74,7 @@ impl<'a, 'cfg> BuildContext<'a, 'cfg> {
         let mut target_config = HashMap::new();
         let mut target_info = HashMap::new();
         if let CompileKind::Target(target) = build_config.requested_kind {
-            let tcfg = config.get(&format!("target.{}", target.short_name()))?;
+            let tcfg = config.target_cfg_triple(target.short_name())?;
             target_config.insert(target, tcfg);
             target_info.insert(
                 target,
@@ -122,14 +122,6 @@ impl<'a, 'cfg> BuildContext<'a, 'cfg> {
             .linker
             .as_ref()
             .map(|l| l.val.clone().resolve_program(self.config))
-    }
-
-    /// Gets the user-specified `ar` program for a particular host or target.
-    pub fn ar(&self, kind: CompileKind) -> Option<PathBuf> {
-        self.target_config(kind)
-            .ar
-            .as_ref()
-            .map(|ar| ar.val.clone().resolve_program(self.config))
     }
 
     /// Gets the list of `cfg`s printed out from the compiler for the specified kind.

--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -852,12 +852,6 @@ fn build_base_args<'a, 'cfg>(
     opt(
         cmd,
         "-C",
-        "ar=",
-        bcx.ar(unit.kind).as_ref().map(|ar| ar.as_ref()),
-    );
-    opt(
-        cmd,
-        "-C",
         "linker=",
         bcx.linker(unit.kind).as_ref().map(|s| s.as_ref()),
     );

--- a/src/cargo/util/config/mod.rs
+++ b/src/cargo/util/config/mod.rs
@@ -1072,6 +1072,11 @@ impl Config {
             .try_borrow_with(|| target::load_target_cfgs(self))
     }
 
+    /// Returns the `[target]` table definition for the given target triple.
+    pub fn target_cfg_triple(&self, target: &str) -> CargoResult<TargetConfig> {
+        target::load_target_triple(self, target)
+    }
+
     pub fn crates_io_source_id<F>(&self, f: F) -> CargoResult<SourceId>
     where
         F: FnMut() -> CargoResult<SourceId>,

--- a/src/cargo/util/config/target.rs
+++ b/src/cargo/util/config/target.rs
@@ -1,8 +1,9 @@
-use super::{Config, ConfigRelativePath, OptValue, PathAndArgs, StringList};
+use super::{Config, ConfigKey, ConfigRelativePath, OptValue, PathAndArgs, StringList, CV};
 use crate::core::compiler::BuildOutput;
 use crate::util::CargoResult;
 use serde::Deserialize;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
+use std::path::PathBuf;
 
 /// Config definition of a [target.'cfg(…)'] table.
 ///
@@ -19,7 +20,7 @@ pub struct TargetCfgConfig {
 }
 
 /// Config definition of a [target] table.
-#[derive(Debug, Deserialize)]
+#[derive(Debug)]
 pub struct TargetConfig {
     /// Process to run as a wrapper for `cargo run`, `test`, and `bench` commands.
     pub runner: OptValue<PathAndArgs>,
@@ -27,17 +28,15 @@ pub struct TargetConfig {
     pub rustflags: OptValue<StringList>,
     /// The path of the linker for this target.
     pub linker: OptValue<ConfigRelativePath>,
-    /// The path of archiver (lib builder) for this target. DEPRECATED/UNUSED
-    pub ar: OptValue<ConfigRelativePath>,
     /// Build script override for the given library name.
     ///
     /// Any package with a `links` value for the given library name will skip
     /// running its build script and instead use the given output from the
     /// config file.
-    #[serde(flatten)]
     pub links_overrides: BTreeMap<String, BuildOutput>,
 }
 
+/// Loads all of the `target.'cfg()'` tables.
 pub(super) fn load_target_cfgs(config: &Config) -> CargoResult<Vec<(String, TargetCfgConfig)>> {
     // Load all [target] tables, filter out the cfg() entries.
     let mut result = Vec::new();
@@ -45,7 +44,6 @@ pub(super) fn load_target_cfgs(config: &Config) -> CargoResult<Vec<(String, Targ
     // deterministic ordering of rustflags, which affects fingerprinting and
     // rebuilds. We may perhaps one day wish to ensure a deterministic
     // ordering via the order keys were defined in files perhaps.
-    log::debug!("Loading all targets.");
     let target: BTreeMap<String, TargetCfgConfig> = config.get("target")?;
     log::debug!("Got all targets {:#?}", target);
     for (key, cfg) in target {
@@ -64,4 +62,97 @@ pub(super) fn load_target_cfgs(config: &Config) -> CargoResult<Vec<(String, Targ
         }
     }
     Ok(result)
+}
+
+/// Loads a single `[target]` table for the given triple.
+pub(super) fn load_target_triple(config: &Config, triple: &str) -> CargoResult<TargetConfig> {
+    // This needs to get each field individually because it cannot fetch the
+    // struct all at once due to `links_overrides`. Can't use `serde(flatten)`
+    // because it causes serde to use `deserialize_map` which means the config
+    // deserializer does not know which keys to deserialize, which means
+    // environment variables would not work.
+    let runner: OptValue<PathAndArgs> = config.get(&format!("target.{}.runner", triple))?;
+    let rustflags: OptValue<StringList> = config.get(&format!("target.{}.rustflags", triple))?;
+    let linker: OptValue<ConfigRelativePath> = config.get(&format!("target.{}.linker", triple))?;
+    // Links do not support environment variables.
+    let target_key = ConfigKey::from_str(&format!("target.{}", triple));
+    let links_overrides = match config.get_table(&target_key)? {
+        Some(links) => parse_links_overrides(&target_key, links.val)?,
+        None => BTreeMap::new(),
+    };
+    Ok(TargetConfig {
+        runner,
+        rustflags,
+        linker,
+        links_overrides,
+    })
+}
+
+fn parse_links_overrides(
+    target_key: &ConfigKey,
+    links: HashMap<String, CV>,
+) -> CargoResult<BTreeMap<String, BuildOutput>> {
+    let mut links_overrides = BTreeMap::new();
+    for (lib_name, value) in links {
+        // Skip these keys, it shares the namespace with `TargetConfig`.
+        match lib_name.as_str() {
+            // `ar` is a historical thing.
+            "ar" | "linker" | "runner" | "rustflags" => continue,
+            _ => {}
+        }
+        let mut output = BuildOutput::default();
+        let table = value.table(&format!("{}.{}", target_key, lib_name))?.0;
+        // We require deterministic order of evaluation, so we must sort the pairs by key first.
+        let mut pairs = Vec::new();
+        for (k, value) in table {
+            pairs.push((k, value));
+        }
+        pairs.sort_by_key(|p| p.0);
+        for (key, value) in pairs {
+            match key.as_str() {
+                "rustc-flags" => {
+                    let flags = value.string(key)?;
+                    let whence = format!("target config `{}.{}` (in {})", target_key, key, flags.1);
+                    let (paths, links) = BuildOutput::parse_rustc_flags(&flags.0, &whence)?;
+                    output.library_paths.extend(paths);
+                    output.library_links.extend(links);
+                }
+                "rustc-link-lib" => {
+                    let list = value.list(key)?;
+                    output
+                        .library_links
+                        .extend(list.iter().map(|v| v.0.clone()));
+                }
+                "rustc-link-search" => {
+                    let list = value.list(key)?;
+                    output
+                        .library_paths
+                        .extend(list.iter().map(|v| PathBuf::from(&v.0)));
+                }
+                "rustc-cdylib-link-arg" => {
+                    let args = value.list(key)?;
+                    output.linker_args.extend(args.iter().map(|v| v.0.clone()));
+                }
+                "rustc-cfg" => {
+                    let list = value.list(key)?;
+                    output.cfgs.extend(list.iter().map(|v| v.0.clone()));
+                }
+                "rustc-env" => {
+                    for (name, val) in value.table(key)?.0 {
+                        let val = val.string(name)?.0;
+                        output.env.push((name.clone(), val.to_string()));
+                    }
+                }
+                "warning" | "rerun-if-changed" | "rerun-if-env-changed" => {
+                    failure::bail!("`{}` is not supported in build script overrides", key);
+                }
+                _ => {
+                    let val = value.string(key)?.0;
+                    output.metadata.push((key.clone(), val.to_string()));
+                }
+            }
+        }
+        links_overrides.insert(lib_name, output);
+    }
+    Ok(links_overrides)
 }

--- a/tests/testsuite/bad_config.rs
+++ b/tests/testsuite/bad_config.rs
@@ -1377,7 +1377,10 @@ fn bad_target_links_overrides() {
 
     p.cargo("check")
         .with_status(101)
-        .with_stderr("[ERROR] Only `-l` and `-L` flags are allowed in target config: `foo`")
+        .with_stderr(
+            "[ERROR] Only `-l` and `-L` flags are allowed in target config \
+             `target.[..].rustc-flags` (in [..]foo/.cargo/config): `foo`",
+        )
         .run();
 
     p.change_file(

--- a/tests/testsuite/cross_compile.rs
+++ b/tests/testsuite/cross_compile.rs
@@ -148,7 +148,7 @@ fn simple_deps() {
 }
 
 #[cargo_test]
-fn linker_and_ar() {
+fn linker() {
     if cross_compile::disabled() {
         return;
     }
@@ -160,7 +160,6 @@ fn linker_and_ar() {
             &format!(
                 r#"
             [target.{}]
-            ar = "my-ar-tool"
             linker = "my-linker-tool"
         "#,
                 target
@@ -192,7 +191,7 @@ fn linker_and_ar() {
     -C metadata=[..] \
     --out-dir [CWD]/target/{target}/debug/deps \
     --target {target} \
-    -C ar=my-ar-tool -C linker=my-linker-tool \
+    -C linker=my-linker-tool \
     -L dependency=[CWD]/target/{target}/debug/deps \
     -L dependency=[CWD]/target/debug/deps`
 ",

--- a/tests/testsuite/plugins.rs
+++ b/tests/testsuite/plugins.rs
@@ -277,7 +277,7 @@ fn doctest_a_plugin() {
 
 // See #1515
 #[cargo_test]
-fn native_plugin_dependency_with_custom_ar_linker() {
+fn native_plugin_dependency_with_custom_linker() {
     let target = rustc_host();
 
     let _foo = project()
@@ -316,7 +316,6 @@ fn native_plugin_dependency_with_custom_ar_linker() {
             &format!(
                 r#"
             [target.{}]
-            ar = "nonexistent-ar"
             linker = "nonexistent-linker"
         "#,
                 target
@@ -329,7 +328,7 @@ fn native_plugin_dependency_with_custom_ar_linker() {
         .with_stderr_contains(
             "\
 [COMPILING] foo v0.0.1 ([..])
-[RUNNING] `rustc [..] -C ar=nonexistent-ar -C linker=nonexistent-linker [..]`
+[RUNNING] `rustc [..] -C linker=nonexistent-linker [..]`
 [ERROR] [..]linker[..]
 ",
         )


### PR DESCRIPTION
#7649 caused an unfortunate regression where the `CARGO_TARGET_triple_LINKER` environment variable stopped working. I did not realize `serde(flatten)` caused serde to switch to `deserialize_map` which does not support environment variables.

The solution here is to essentially revert back to how the `[target]` table used to be loaded by loading each key individually.

This also removes the `ar` field which is not used by `rustc`.
