### PR TITLE
Search for root manifest with ephemeral workspaces

### DIFF
--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -833,13 +833,6 @@ impl<'cfg> Workspace<'cfg> {
     pub fn set_target_dir(&mut self, target_dir: Filesystem) {
         self.target_dir = Some(target_dir);
     }
-
-    // TODO: This seems like the wrong approach
-    pub fn set_package(&mut self, package: Package) {
-        let key = self.current_manifest.parent().unwrap();
-        let package = MaybePackage::Package(package);
-        self.packages.packages.insert(key.to_path_buf(), package);
-    }
 }
 
 impl<'cfg> Packages<'cfg> {

--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -198,7 +198,9 @@ impl<'cfg> Workspace<'cfg> {
         target_dir: Option<Filesystem>,
         require_optional_deps: bool,
     ) -> CargoResult<Workspace<'cfg>> {
-        let mut ws = Workspace::new_default(package.manifest_path().to_path_buf(), config);
+        let manifest_path = package.manifest_path();
+        let mut ws = Workspace::new_default(manifest_path.to_path_buf(), config);
+        ws.root_manifest = ws.find_root(&manifest_path)?;
         ws.is_ephemeral = true;
         ws.require_optional_deps = require_optional_deps;
         let key = ws.current_manifest.parent().unwrap();

--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -198,9 +198,7 @@ impl<'cfg> Workspace<'cfg> {
         target_dir: Option<Filesystem>,
         require_optional_deps: bool,
     ) -> CargoResult<Workspace<'cfg>> {
-        let manifest_path = package.manifest_path();
-        let mut ws = Workspace::new_default(manifest_path.to_path_buf(), config);
-        ws.root_manifest = ws.find_root(&manifest_path)?;
+        let mut ws = Workspace::new_default(package.manifest_path().to_path_buf(), config);
         ws.is_ephemeral = true;
         ws.require_optional_deps = require_optional_deps;
         let key = ws.current_manifest.parent().unwrap();
@@ -830,6 +828,17 @@ impl<'cfg> Workspace<'cfg> {
             }
         }
         Ok(())
+    }
+
+    pub fn set_target_dir(&mut self, target_dir: Filesystem) {
+        self.target_dir = Some(target_dir);
+    }
+
+    // TODO: This seems like the wrong approach
+    pub fn set_package(&mut self, package: Package) {
+        let key = self.current_manifest.parent().unwrap();
+        let package = MaybePackage::Package(package);
+        self.packages.packages.insert(key.to_path_buf(), package);
     }
 }
 

--- a/src/cargo/ops/cargo_install.rs
+++ b/src/cargo/ops/cargo_install.rs
@@ -226,7 +226,11 @@ fn install_one(
             if source_id.is_git() {
                 if config.target_dir()?.is_none() {
                     match TempFileBuilder::new().prefix("cargo-install").tempdir() {
-                        Ok(td) => ws.set_target_dir(Filesystem::new(td.path().to_owned())),
+                        Ok(td) => {
+                            let p = td.path().to_owned();
+                            td_opt = Some(td);
+                            ws.set_target_dir(Filesystem::new(p));
+                        }
                         // If tempfile creation fails, write to cargo cache but clean up afterwards
                         Err(_) => needs_cleanup = true,
                     }

--- a/src/cargo/ops/cargo_install.rs
+++ b/src/cargo/ops/cargo_install.rs
@@ -239,7 +239,7 @@ fn install_one(
             }
 
             ws
-        },
+        }
     };
     ws.set_ignore_lock(config.lock_update_allowed());
     let pkg = git_package.map_or_else(|| ws.current(), |pkg| Ok(pkg))?;

--- a/src/cargo/ops/cargo_install.rs
+++ b/src/cargo/ops/cargo_install.rs
@@ -202,7 +202,7 @@ fn install_one(
 
     let (mut ws, git_package) = if source_id.is_git() {
         // Don't use ws.current() in order to keep the package source as a git source so that
-        // install tracking uses the correct sourc.
+        // install tracking uses the correct source.
         (Workspace::new(pkg.manifest_path(), config)?, Some(&pkg))
     } else if source_id.is_path() {
         (Workspace::new(pkg.manifest_path(), config)?, None)

--- a/tests/testsuite/install.rs
+++ b/tests/testsuite/install.rs
@@ -316,10 +316,10 @@ fn multiple_crates_git_all() {
     let p = git::repo(&paths::root().join("foo"))
         .file(
             "Cargo.toml",
-            r#"\
-[workspace]
-members = ["bin1", "bin2"]
-"#,
+            r#"
+            [workspace]
+            members = ["bin1", "bin2"]
+            "#,
         )
         .file("bin1/Cargo.toml", &basic_manifest("bin1", "0.1.0"))
         .file("bin2/Cargo.toml", &basic_manifest("bin2", "0.1.0"))


### PR DESCRIPTION
Fixes #5495.

This seems like it's too simple to just work like this, but after trying a few different things, this was the only solution which worked reliably for me.

I've verified that no `/target` is present in the actual checkout location, the target directory used is actually the one created in `/tmp`.

I've also verified that both workspaces and "normal" packages still install through git and that a normal `cargo install --path` works too (though that doesn't use ephemeral workspaces anyways).