### PR TITLE
Fix several needless_borrow clippy lints.

### DIFF
--- a/src/bin/cargo/cli.rs
+++ b/src/bin/cargo/cli.rs
@@ -102,7 +102,7 @@ Run with 'cargo -Z [FLAG] [SUBCOMMAND]'"
         }
     };
     config_configure(config, &args, subcommand_args)?;
-    super::init_git_transports(&config);
+    super::init_git_transports(config);
 
     execute_subcommand(config, cmd, subcommand_args)
 }

--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -1008,7 +1008,7 @@ pub fn extern_args<'a>(
 
     for dep in deps {
         if dep.unit.target.linkable() && !dep.unit.mode.is_doc() {
-            link_to(&dep, dep.extern_crate_name, dep.noprelude)?;
+            link_to(dep, dep.extern_crate_name, dep.noprelude)?;
         }
     }
     if unit.target.proc_macro()

--- a/src/cargo/util/config/de.rs
+++ b/src/cargo/util/config/de.rs
@@ -291,11 +291,11 @@ impl<'de, 'config> de::MapAccess<'de> for ConfigMapAccess<'config> {
         // Set this as the current key in the deserializer.
         let field = match field {
             KeyKind::Normal(field) => {
-                self.de.key.push(&field);
+                self.de.key.push(field);
                 field
             }
             KeyKind::CaseSensitive(field) => {
-                self.de.key.push_sensitive(&field);
+                self.de.key.push_sensitive(field);
                 field
             }
         };

--- a/src/cargo/util/config/mod.rs
+++ b/src/cargo/util/config/mod.rs
@@ -832,7 +832,7 @@ impl Config {
         for arg in cli_args {
             // TODO: This should probably use a more narrow parser, reject
             // comments, blank lines, [headers], etc.
-            let toml_v: toml::Value = toml::de::from_str(&arg)
+            let toml_v: toml::Value = toml::de::from_str(arg)
                 .chain_err(|| format!("failed to parse --config argument `{}`", arg))?;
             let toml_table = toml_v.as_table().unwrap();
             if toml_table.len() != 1 {

--- a/src/cargo/util/config/target.rs
+++ b/src/cargo/util/config/target.rs
@@ -113,7 +113,7 @@ fn parse_links_overrides(
                 "rustc-flags" => {
                     let flags = value.string(key)?;
                     let whence = format!("target config `{}.{}` (in {})", target_key, key, flags.1);
-                    let (paths, links) = BuildOutput::parse_rustc_flags(&flags.0, &whence)?;
+                    let (paths, links) = BuildOutput::parse_rustc_flags(flags.0, &whence)?;
                     output.library_paths.extend(paths);
                     output.library_links.extend(links);
                 }


### PR DESCRIPTION
Fixes several [needless_borrow](https://rust-lang.github.io/rust-clippy/v0.0.212/index.html#needless_borrow) clippy lints.

I've only fixed this kind of lint errors and not others, since for some reason these are the only ones that show as red squigglies in my editor of choice.