### PR TITLE
Load credentials only when needed

### DIFF
--- a/src/bin/cargo/commands/owner.rs
+++ b/src/bin/cargo/commands/owner.rs
@@ -39,6 +39,8 @@ Explicitly named owners can also modify the set of owners, so take care!
 }
 
 pub fn exec(config: &mut Config, args: &ArgMatches<'_>) -> CliResult {
+    config.load_credentials()?;
+
     let registry = args.registry(config)?;
     let opts = OwnersOptions {
         krate: args.value_of("crate").map(|s| s.to_string()),

--- a/src/bin/cargo/commands/publish.rs
+++ b/src/bin/cargo/commands/publish.rs
@@ -26,6 +26,8 @@ pub fn cli() -> App {
 }
 
 pub fn exec(config: &mut Config, args: &ArgMatches<'_>) -> CliResult {
+    config.load_credentials()?;
+
     let registry = args.registry(config)?;
     let ws = args.workspace(config)?;
     let index = args.index(config)?;

--- a/src/bin/cargo/commands/yank.rs
+++ b/src/bin/cargo/commands/yank.rs
@@ -29,6 +29,8 @@ crates to be locked to any yanked version.
 }
 
 pub fn exec(config: &mut Config, args: &ArgMatches<'_>) -> CliResult {
+    config.load_credentials()?;
+
     let registry = args.registry(config)?;
 
     ops::yank(

--- a/src/cargo/util/config/mod.rs
+++ b/src/cargo/util/config/mod.rs
@@ -1004,25 +1004,13 @@ impl Config {
             }
         }
 
-        if let CV::Table(mut map, _) = value {
-            if map.contains_key("registry") {
-                if let Some(mut new_map) = self.values_mut()?.remove("registry") {
-                    let token = map.remove("registry").unwrap();
-                    new_map.merge(token, true)?;
-                    self.values_mut()?.insert("registry".into(), new_map);
+        if let CV::Table(map, _) = value {
+            for (k, v) in map {
+                if let Some(mut base_map) = self.values_mut()?.remove(&k) {
+                    base_map.merge(v, true)?;
+                    self.values_mut()?.insert(k.into(), base_map);
                 } else {
-                    self.values_mut()?
-                        .insert("registry".into(), map.remove("registry").unwrap());
-                }
-            }
-            if map.contains_key("registries") {
-                if let Some(mut new_map) = self.values_mut()?.remove("registries") {
-                    let token = map.remove("registries").unwrap();
-                    new_map.merge(token, true)?;
-                    self.values_mut()?.insert("registries".into(), new_map);
-                } else {
-                    self.values_mut()?
-                        .insert("registries".into(), map.remove("registries").unwrap());
+                    self.values_mut()?.insert(k.into(), v);
                 }
             }
         }

--- a/src/cargo/util/config/mod.rs
+++ b/src/cargo/util/config/mod.rs
@@ -1005,12 +1005,15 @@ impl Config {
         }
 
         if let CV::Table(map, _) = value {
+            let base_map = self.values_mut()?;
             for (k, v) in map {
-                if let Some(mut base_map) = self.values_mut()?.remove(&k) {
-                    base_map.merge(v, true)?;
-                    self.values_mut()?.insert(k.into(), base_map);
-                } else {
-                    self.values_mut()?.insert(k.into(), v);
+                match base_map.entry(k) {
+                    Vacant(entry) => {
+                        entry.insert(v);
+                    }
+                    Occupied(mut entry) => {
+                        entry.get_mut().merge(v, true)?;
+                    }
                 }
             }
         }

--- a/tests/testsuite/main.rs
+++ b/tests/testsuite/main.rs
@@ -68,6 +68,7 @@ mod net_config;
 mod new;
 mod offline;
 mod out_dir;
+mod owner;
 mod package;
 mod patch;
 mod path;
@@ -106,6 +107,7 @@ mod verify_project;
 mod version;
 mod warn_on_failure;
 mod workspaces;
+mod yank;
 
 #[cargo_test]
 fn aaa_trigger_cross_compile_disabled_check() {

--- a/tests/testsuite/owner.rs
+++ b/tests/testsuite/owner.rs
@@ -1,0 +1,53 @@
+//! Tests for the `cargo owner` command.
+
+use std::fs::{self, File};
+use std::io::prelude::*;
+
+use cargo_test_support::project;
+use cargo_test_support::registry::{self, api_path, registry_url};
+
+fn setup(name: &str) {
+    fs::create_dir_all(&api_path().join(format!("api/v1/crates/{}", name))).unwrap();
+
+    let dest = api_path().join(format!("api/v1/crates/{}/owners", name));
+
+    let content = r#"{
+        "users": [
+            {
+                "id": 70,
+                "login": "github:rust-lang:core",
+                "name": "Core"
+            }
+        ]
+    }"#;
+
+    File::create(&dest)
+        .unwrap()
+        .write_all(content.as_bytes())
+        .unwrap();
+}
+
+#[cargo_test]
+fn simple_list() {
+    registry::init();
+    setup("foo");
+
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [project]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+            license = "MIT"
+            description = "foo"
+        "#,
+        )
+        .file("src/main.rs", "fn main() {}")
+        .build();
+
+    p.cargo("owner -l --index")
+        .arg(registry_url().to_string())
+        .run();
+}

--- a/tests/testsuite/owner.rs
+++ b/tests/testsuite/owner.rs
@@ -1,17 +1,17 @@
 //! Tests for the `cargo owner` command.
 
-use std::fs::{self, File};
-use std::io::prelude::*;
+use std::fs;
 
+use cargo_test_support::paths::CargoPathExt;
 use cargo_test_support::project;
 use cargo_test_support::registry::{self, api_path, registry_url};
 
 fn setup(name: &str) {
-    fs::create_dir_all(&api_path().join(format!("api/v1/crates/{}", name))).unwrap();
-
-    let dest = api_path().join(format!("api/v1/crates/{}/owners", name));
-
-    let content = r#"{
+    let dir = api_path().join(format!("api/v1/crates/{}", name));
+    dir.mkdir_p();
+    fs::write(
+        dir.join("owners"),
+        r#"{
         "users": [
             {
                 "id": 70,
@@ -19,12 +19,9 @@ fn setup(name: &str) {
                 "name": "Core"
             }
         ]
-    }"#;
-
-    File::create(&dest)
-        .unwrap()
-        .write_all(content.as_bytes())
-        .unwrap();
+    }"#,
+    )
+    .unwrap();
 }
 
 #[cargo_test]

--- a/tests/testsuite/publish.rs
+++ b/tests/testsuite/publish.rs
@@ -1267,10 +1267,7 @@ fn credentials_ambiguous_filename() {
     registry::init();
 
     let credentials_toml = paths::home().join(".cargo/credentials.toml");
-    File::create(&credentials_toml)
-        .unwrap()
-        .write_all(br#"token = "api-token""#)
-        .unwrap();
+    fs::write(credentials_toml, r#"token = "api-token""#).unwrap();
 
     let p = project()
         .file(

--- a/tests/testsuite/yank.rs
+++ b/tests/testsuite/yank.rs
@@ -1,24 +1,15 @@
 //! Tests for the `cargo yank` command.
 
-use std::fs::{self, File};
-use std::io::prelude::*;
+use std::fs;
 
+use cargo_test_support::paths::CargoPathExt;
 use cargo_test_support::project;
 use cargo_test_support::registry::{self, api_path, registry_url};
 
 fn setup(name: &str, version: &str) {
-    fs::create_dir_all(&api_path().join(format!("api/v1/crates/{}/{}", name, version))).unwrap();
-
-    let dest = api_path().join(format!("api/v1/crates/{}/{}/yank", name, version));
-
-    let content = r#"{
-        "ok": true
-    }"#;
-
-    File::create(&dest)
-        .unwrap()
-        .write_all(content.as_bytes())
-        .unwrap();
+    let dir = api_path().join(format!("api/v1/crates/{}/{}", name, version));
+    dir.mkdir_p();
+    fs::write(dir.join("yank"), r#"{"ok": true}"#).unwrap();
 }
 
 #[cargo_test]

--- a/tests/testsuite/yank.rs
+++ b/tests/testsuite/yank.rs
@@ -1,0 +1,47 @@
+//! Tests for the `cargo yank` command.
+
+use std::fs::{self, File};
+use std::io::prelude::*;
+
+use cargo_test_support::project;
+use cargo_test_support::registry::{self, api_path, registry_url};
+
+fn setup(name: &str, version: &str) {
+    fs::create_dir_all(&api_path().join(format!("api/v1/crates/{}/{}", name, version))).unwrap();
+
+    let dest = api_path().join(format!("api/v1/crates/{}/{}/yank", name, version));
+
+    let content = r#"{
+        "ok": true
+    }"#;
+
+    File::create(&dest)
+        .unwrap()
+        .write_all(content.as_bytes())
+        .unwrap();
+}
+
+#[cargo_test]
+fn simple() {
+    registry::init();
+    setup("foo", "0.0.1");
+
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [project]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+            license = "MIT"
+            description = "foo"
+        "#,
+        )
+        .file("src/main.rs", "fn main() {}")
+        .build();
+
+    p.cargo("yank --vers 0.0.1 --index")
+        .arg(registry_url().to_string())
+        .run();
+}


### PR DESCRIPTION
Credentials are always loaded, even if these are not used. If
access to confidential files such as credentials is not given,
`cargo build` fails despite not using credentials.

Fixes #7624.