### PR TITLE
Migrate from the `failure` crate to `anyhow`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ curl = { version = "0.4.23", features = ["http2"] }
 curl-sys = "0.4.22"
 env_logger = "0.7.0"
 pretty_env_logger = { version = "0.3", optional = true }
-failure = "0.1.5"
+anyhow = "1.0"
 filetime = "0.2"
 flate2 = { version = "1.0.3", features = ["zlib"] }
 fs2 = "0.4"
@@ -51,7 +51,7 @@ num_cpus = "1.0"
 opener = "0.4"
 percent-encoding = "2.0"
 remove_dir_all = "0.5.2"
-rustfix = "0.4.6"
+rustfix = "0.5.0"
 same-file = "1"
 semver = { version = "0.9.0", features = ["serde"] }
 serde = { version = "1.0.82", features = ["derive"] }

--- a/crates/cargo-test-support/src/lib.rs
+++ b/crates/cargo-test-support/src/lib.rs
@@ -916,11 +916,7 @@ impl Execs {
                 {
                     return self.match_output(out);
                 }
-                let mut s = format!("could not exec process {}: {}", process, e);
-                for cause in e.iter_causes() {
-                    s.push_str(&format!("\ncaused by: {}", cause));
-                }
-                Err(s)
+                Err(format!("could not exec process {}: {:?}", process, e))
             }
         }
     }

--- a/crates/crates-io/Cargo.toml
+++ b/crates/crates-io/Cargo.toml
@@ -15,7 +15,7 @@ path = "lib.rs"
 
 [dependencies]
 curl = "0.4"
-failure = "0.1.1"
+anyhow = "1.0.0"
 percent-encoding = "2.0"
 serde = { version = "1.0", features = ['derive'] }
 serde_derive = "1.0"

--- a/crates/crates-io/lib.rs
+++ b/crates/crates-io/lib.rs
@@ -7,8 +7,8 @@ use std::io::prelude::*;
 use std::io::Cursor;
 use std::time::Instant;
 
-use curl::easy::{Easy, List};
 use anyhow::{bail, Result};
+use curl::easy::{Easy, List};
 use percent_encoding::{percent_encode, NON_ALPHANUMERIC};
 use serde::{Deserialize, Serialize};
 use serde_json;

--- a/crates/crates-io/lib.rs
+++ b/crates/crates-io/lib.rs
@@ -8,13 +8,11 @@ use std::io::Cursor;
 use std::time::Instant;
 
 use curl::easy::{Easy, List};
-use failure::bail;
+use anyhow::{bail, Result};
 use percent_encoding::{percent_encode, NON_ALPHANUMERIC};
 use serde::{Deserialize, Serialize};
 use serde_json;
 use url::Url;
-
-pub type Result<T> = std::result::Result<T, failure::Error>;
 
 pub struct Registry {
     /// The base URL for issuing API requests.

--- a/src/bin/cargo/commands/bench.rs
+++ b/src/bin/cargo/commands/bench.rs
@@ -100,7 +100,7 @@ pub fn exec(config: &mut Config, args: &ArgMatches<'_>) -> CliResult {
     match err {
         None => Ok(()),
         Some(err) => Err(match err.exit.as_ref().and_then(|e| e.code()) {
-            Some(i) => CliError::new(failure::format_err!("bench failed"), i),
+            Some(i) => CliError::new(anyhow::format_err!("bench failed"), i),
             None => CliError::new(err.into(), 101),
         }),
     }

--- a/src/bin/cargo/commands/check.rs
+++ b/src/bin/cargo/commands/check.rs
@@ -60,7 +60,7 @@ pub fn exec(config: &mut Config, args: &ArgMatches<'_>) -> CliResult {
         Some("test") => true,
         None => false,
         Some(profile) => {
-            let err = failure::format_err!(
+            let err = anyhow::format_err!(
                 "unknown profile: `{}`, only `test` is \
                  currently supported",
                 profile

--- a/src/bin/cargo/commands/clippy.rs
+++ b/src/bin/cargo/commands/clippy.rs
@@ -66,7 +66,7 @@ pub fn exec(config: &mut Config, args: &ArgMatches<'_>) -> CliResult {
         args.compile_options(config, mode, Some(&ws), ProfileChecking::Checked)?;
 
     if !config.cli_unstable().unstable_options {
-        return Err(failure::format_err!(
+        return Err(anyhow::format_err!(
             "`clippy-preview` is unstable, pass `-Z unstable-options` to enable it"
         )
         .into());

--- a/src/bin/cargo/commands/fix.rs
+++ b/src/bin/cargo/commands/fix.rs
@@ -120,7 +120,7 @@ pub fn exec(config: &mut Config, args: &ArgMatches<'_>) -> CliResult {
         Some("test") => true,
         None => false,
         Some(profile) => {
-            let err = failure::format_err!(
+            let err = anyhow::format_err!(
                 "unknown profile: `{}`, only `test` is \
                  currently supported",
                 profile
@@ -143,7 +143,7 @@ pub fn exec(config: &mut Config, args: &ArgMatches<'_>) -> CliResult {
         .filter(|_| use_clippy);
 
     if use_clippy && !config.cli_unstable().unstable_options {
-        return Err(failure::format_err!(
+        return Err(anyhow::format_err!(
             "`cargo fix --clippy` is unstable, pass `-Z unstable-options` to enable it"
         )
         .into());

--- a/src/bin/cargo/commands/locate_project.rs
+++ b/src/bin/cargo/commands/locate_project.rs
@@ -21,7 +21,7 @@ pub fn exec(config: &mut Config, args: &ArgMatches<'_>) -> CliResult {
     let root = root
         .to_str()
         .ok_or_else(|| {
-            failure::format_err!(
+            anyhow::format_err!(
                 "your package path contains characters \
                  not representable in Unicode"
             )

--- a/src/bin/cargo/commands/rustc.rs
+++ b/src/bin/cargo/commands/rustc.rs
@@ -55,7 +55,7 @@ pub fn exec(config: &mut Config, args: &ArgMatches<'_>) -> CliResult {
         Some("bench") => CompileMode::Bench,
         Some("check") => CompileMode::Check { test: false },
         Some(mode) => {
-            let err = failure::format_err!(
+            let err = anyhow::format_err!(
                 "unknown profile: `{}`, use dev,
                                    test, or bench",
                 mode

--- a/src/bin/cargo/commands/test.rs
+++ b/src/bin/cargo/commands/test.rs
@@ -1,7 +1,7 @@
 use crate::command_prelude::*;
+use anyhow::Error;
 use cargo::ops::{self, CompileFilter, FilterRule, LibRule};
 use cargo::util::errors;
-use failure::Fail;
 
 pub fn cli() -> App {
     subcommand("test")
@@ -126,13 +126,13 @@ pub fn exec(config: &mut Config, args: &ArgMatches<'_>) -> CliResult {
     if doc {
         if let CompileFilter::Only { .. } = compile_opts.filter {
             return Err(CliError::new(
-                failure::format_err!("Can't mix --doc with other target selecting options"),
+                anyhow::format_err!("Can't mix --doc with other target selecting options"),
                 101,
             ));
         }
         if no_run {
             return Err(CliError::new(
-                failure::format_err!("Can't skip running doc tests with --no-run"),
+                anyhow::format_err!("Can't skip running doc tests with --no-run"),
                 101,
             ));
         }
@@ -166,12 +166,12 @@ pub fn exec(config: &mut Config, args: &ArgMatches<'_>) -> CliResult {
     match err {
         None => Ok(()),
         Some(err) => {
-            let context = failure::format_err!("{}", err.hint(&ws, &ops.compile_opts));
+            let context = anyhow::format_err!("{}", err.hint(&ws, &ops.compile_opts));
             let e = match err.exit.as_ref().and_then(|e| e.code()) {
                 // Don't show "process didn't exit successfully" for simple errors.
                 Some(i) if errors::is_simple_exit_code(i) => CliError::new(context, i),
-                Some(i) => CliError::new(err.context(context).into(), i),
-                None => CliError::new(err.context(context).into(), 101),
+                Some(i) => CliError::new(Error::from(err).context(context), i),
+                None => CliError::new(Error::from(err).context(context), 101),
             };
             Err(e)
         }

--- a/src/bin/cargo/commands/vendor.rs
+++ b/src/bin/cargo/commands/vendor.rs
@@ -90,7 +90,7 @@ pub fn exec(config: &mut Config, args: &ArgMatches<'_>) -> CliResult {
         None
     };
     if let Some(flag) = crates_io_cargo_vendor_flag {
-        return Err(failure::format_err!(
+        return Err(anyhow::format_err!(
             "\
 the crates.io `cargo vendor` command has now been merged into Cargo itself
 and does not support the flag `{}` currently; to continue using the flag you

--- a/src/bin/cargo/main.rs
+++ b/src/bin/cargo/main.rs
@@ -133,7 +133,7 @@ fn execute_external_subcommand(config: &Config, cmd: &str, args: &[&str]) -> Cli
             let aliases = list_aliases(config);
             let suggestions = commands.iter().chain(aliases.iter());
             let did_you_mean = closest_msg(cmd, suggestions, |c| c);
-            let err = failure::format_err!("no such subcommand: `{}`{}", cmd, did_you_mean);
+            let err = anyhow::format_err!("no such subcommand: `{}`{}", cmd, did_you_mean);
             return Err(CliError::new(err, 101));
         }
     };

--- a/src/cargo/core/compiler/build_config.rs
+++ b/src/cargo/core/compiler/build_config.rs
@@ -78,7 +78,7 @@ impl BuildConfig {
         };
 
         if jobs == Some(0) {
-            failure::bail!("jobs must be at least 1")
+            anyhow::bail!("jobs must be at least 1")
         }
         if jobs.is_some() && config.jobserver_from_env().is_some() {
             config.shell().warn(

--- a/src/cargo/core/compiler/build_context/target_info.rs
+++ b/src/cargo/core/compiler/build_context/target_info.rs
@@ -137,7 +137,7 @@ impl TargetInfo {
 
         let line = match lines.next() {
             Some(line) => line,
-            None => failure::bail!(
+            None => anyhow::bail!(
                 "output of --print=sysroot missing when learning about \
                  target-specific information from rustc\n{}",
                 output_err_info(&process, &output, &error)
@@ -329,7 +329,7 @@ fn parse_crate_type(
     }
     let line = match lines.next() {
         Some(line) => line,
-        None => failure::bail!(
+        None => anyhow::bail!(
             "malformed output when learning about crate-type {} information\n{}",
             crate_type,
             output_err_info(cmd, output, error)
@@ -339,7 +339,7 @@ fn parse_crate_type(
     let prefix = parts.next().unwrap();
     let suffix = match parts.next() {
         Some(part) => part,
-        None => failure::bail!(
+        None => anyhow::bail!(
             "output of --print=file-names has changed in the compiler, cannot parse\n{}",
             output_err_info(cmd, output, error)
         ),

--- a/src/cargo/core/compiler/build_plan.rs
+++ b/src/cargo/core/compiler/build_plan.rs
@@ -74,13 +74,13 @@ impl Invocation {
         self.program = cmd
             .get_program()
             .to_str()
-            .ok_or_else(|| failure::format_err!("unicode program string required"))?
+            .ok_or_else(|| anyhow::format_err!("unicode program string required"))?
             .to_string();
         self.cwd = Some(cmd.get_cwd().unwrap().to_path_buf());
         for arg in cmd.get_args().iter() {
             self.args.push(
                 arg.to_str()
-                    .ok_or_else(|| failure::format_err!("unicode argument string required"))?
+                    .ok_or_else(|| anyhow::format_err!("unicode argument string required"))?
                     .to_string(),
             );
         }
@@ -93,7 +93,7 @@ impl Invocation {
                 var.clone(),
                 value
                     .to_str()
-                    .ok_or_else(|| failure::format_err!("unicode environment value required"))?
+                    .ok_or_else(|| anyhow::format_err!("unicode environment value required"))?
                     .to_string(),
             );
         }

--- a/src/cargo/core/compiler/compilation.rs
+++ b/src/cargo/core/compiler/compilation.rs
@@ -304,7 +304,7 @@ fn target_runner(
         .filter(|(key, _runner)| CfgExpr::matches_key(key, target_cfg));
     let matching_runner = cfgs.next();
     if let Some((key, runner)) = cfgs.next() {
-        failure::bail!(
+        anyhow::bail!(
             "several matching instances of `target.'cfg(..)'.runner` in `.cargo/config`\n\
              first match `{}` located in {}\n\
              second match `{}` located in {}",

--- a/src/cargo/core/compiler/compile_kind.rs
+++ b/src/cargo/core/compiler/compile_kind.rs
@@ -77,7 +77,7 @@ impl CompileTarget {
     pub fn new(name: &str) -> CargoResult<CompileTarget> {
         let name = name.trim();
         if name.is_empty() {
-            failure::bail!("target was empty");
+            anyhow::bail!("target was empty");
         }
         if !name.ends_with(".json") {
             return Ok(CompileTarget { name: name.into() });
@@ -88,12 +88,12 @@ impl CompileTarget {
         // with different paths always produce the same result.
         let path = Path::new(name)
             .canonicalize()
-            .chain_err(|| failure::format_err!("target path {:?} is not a valid file", name))?;
+            .chain_err(|| anyhow::format_err!("target path {:?} is not a valid file", name))?;
 
         let name = path
             .into_os_string()
             .into_string()
-            .map_err(|_| failure::format_err!("target path is not valid unicode"))?;
+            .map_err(|_| anyhow::format_err!("target path is not valid unicode"))?;
         Ok(CompileTarget { name: name.into() })
     }
 

--- a/src/cargo/core/compiler/context/compilation_files.rs
+++ b/src/cargo/core/compiler/context/compilation_files.rs
@@ -431,7 +431,7 @@ impl<'a, 'cfg: 'a> CompilationFiles<'a, 'cfg> {
         }
         if ret.is_empty() {
             if !unsupported.is_empty() {
-                failure::bail!(
+                anyhow::bail!(
                     "cannot produce {} for `{}` as the target `{}` \
                      does not support these crate types",
                     unsupported.join(", "),
@@ -439,7 +439,7 @@ impl<'a, 'cfg: 'a> CompilationFiles<'a, 'cfg> {
                     unit.kind.short_name(bcx),
                 )
             }
-            failure::bail!(
+            anyhow::bail!(
                 "cannot compile `{}` as the target `{}` does not \
                  support any of the output crate types",
                 unit.pkg,

--- a/src/cargo/core/compiler/custom_build.rs
+++ b/src/cargo/core/compiler/custom_build.rs
@@ -460,7 +460,7 @@ impl BuildOutput {
             let (key, value) = match (key, value) {
                 (Some(a), Some(b)) => (a, b.trim_end()),
                 // Line started with `cargo:` but didn't match `key=value`.
-                _ => failure::bail!("Wrong output in {}: `{}`", whence, line),
+                _ => anyhow::bail!("Wrong output in {}: `{}`", whence, line),
             };
 
             // This will rewrite paths if the target directory has been moved.
@@ -520,7 +520,7 @@ impl BuildOutput {
                 if value.is_empty() {
                     value = match flags_iter.next() {
                         Some(v) => v,
-                        None => failure::bail! {
+                        None => anyhow::bail! {
                             "Flag in rustc-flags has no value in {}: {}",
                             whence,
                             value
@@ -536,7 +536,7 @@ impl BuildOutput {
                     _ => unreachable!(),
                 };
             } else {
-                failure::bail!(
+                anyhow::bail!(
                     "Only `-l` and `-L` flags are allowed in {}: `{}`",
                     whence,
                     value
@@ -552,7 +552,7 @@ impl BuildOutput {
         let val = iter.next();
         match (name, val) {
             (Some(n), Some(v)) => Ok((n.to_owned(), v.to_owned())),
-            _ => failure::bail!("Variable rustc-env has no value in {}: {}", whence, value),
+            _ => anyhow::bail!("Variable rustc-env has no value in {}: {}", whence, value),
         }
     }
 }

--- a/src/cargo/core/compiler/fingerprint.rs
+++ b/src/cargo/core/compiler/fingerprint.rs
@@ -194,7 +194,7 @@ use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::time::SystemTime;
 
-use failure::{bail, format_err};
+use anyhow::{bail, format_err};
 use filetime::FileTime;
 use log::{debug, info};
 use serde::de;
@@ -1414,11 +1414,7 @@ fn log_compare(unit: &Unit<'_>, compare: &CargoResult<()>) {
         "fingerprint error for {}/{:?}/{:?}",
         unit.pkg, unit.mode, unit.target,
     );
-    info!("    err: {}", ce);
-
-    for cause in ce.iter_causes() {
-        info!("  cause: {}", cause);
-    }
+    info!("    err: {:?}", ce);
 }
 
 // Parse the dep-info into a list of paths

--- a/src/cargo/core/compiler/job_queue.rs
+++ b/src/cargo/core/compiler/job_queue.rs
@@ -7,8 +7,8 @@ use std::sync::mpsc::{channel, Receiver, Sender};
 use std::sync::Arc;
 use std::time::Duration;
 
+use anyhow::format_err;
 use crossbeam_utils::thread::Scope;
-use failure::format_err;
 use jobserver::{Acquired, HelperThread};
 use log::{debug, info, trace};
 
@@ -393,7 +393,7 @@ impl<'a, 'cfg> JobQueue<'a, 'cfg> {
                                 self.emit_warnings(Some(msg), &unit, cx)?;
 
                                 if !self.active.is_empty() {
-                                    error = Some(failure::format_err!("build failed"));
+                                    error = Some(anyhow::format_err!("build failed"));
                                     handle_error(&e, &mut *cx.bcx.config.shell());
                                     cx.bcx.config.shell().warn(
                                         "build failed, waiting for other \

--- a/src/cargo/core/compiler/links.rs
+++ b/src/cargo/core/compiler/links.rs
@@ -39,7 +39,7 @@ pub fn validate_links(resolve: &Resolve, unit_graph: &UnitGraph<'_>) -> CargoRes
                 dep_path_desc
             };
 
-            failure::bail!(
+            anyhow::bail!(
                 "multiple packages link to native library `{}`, \
                  but a native library can be linked only once\n\
                  \n\

--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -23,7 +23,7 @@ use std::io::{BufRead, Write};
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use failure::Error;
+use anyhow::Error;
 use lazycell::LazyCell;
 use log::debug;
 

--- a/src/cargo/core/compiler/standard_lib.rs
+++ b/src/cargo/core/compiler/standard_lib.rs
@@ -161,12 +161,12 @@ fn detect_sysroot_src_path(ws: &Workspace<'_>) -> CargoResult<PathBuf> {
     let rustc = ws.config().load_global_rustc(Some(ws))?;
     let output = rustc.process().arg("--print=sysroot").exec_with_output()?;
     let s = String::from_utf8(output.stdout)
-        .map_err(|e| failure::format_err!("rustc didn't return utf8 output: {:?}", e))?;
+        .map_err(|e| anyhow::format_err!("rustc didn't return utf8 output: {:?}", e))?;
     let sysroot = PathBuf::from(s.trim());
     let src_path = sysroot.join("lib").join("rustlib").join("src").join("rust");
     let lock = src_path.join("Cargo.lock");
     if !lock.exists() {
-        failure::bail!(
+        anyhow::bail!(
             "{:?} does not exist, unable to build with the standard \
              library, try:\n        rustup component add rust-src",
             lock

--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -50,7 +50,7 @@ use std::env;
 use std::fmt;
 use std::str::FromStr;
 
-use failure::{bail, Error};
+use anyhow::{bail, Error};
 use serde::{Deserialize, Serialize};
 
 use crate::util::errors::CargoResult;

--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -514,7 +514,7 @@ impl Manifest {
             self.features
                 .require(Feature::test_dummy_unstable())
                 .chain_err(|| {
-                    failure::format_err!(
+                    anyhow::format_err!(
                         "the `im-a-teapot` manifest key is unstable and may \
                          not work properly in England"
                     )

--- a/src/cargo/core/package.rs
+++ b/src/cargo/core/package.rs
@@ -7,10 +7,10 @@ use std::mem;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
+use anyhow::Context;
 use bytesize::ByteSize;
 use curl::easy::{Easy, HttpVersion};
 use curl::multi::{EasyHandle, Multi};
-use failure::ResultExt;
 use lazycell::LazyCell;
 use log::{debug, warn};
 use semver::Version;
@@ -485,8 +485,8 @@ macro_rules! try_old_curl {
                 warn!("ignoring libcurl {} error: {}", $msg, e);
             }
         } else {
-            result.with_context(|_| {
-                failure::format_err!("failed to enable {}, is curl not built right?", $msg)
+            result.with_context(|| {
+                anyhow::format_err!("failed to enable {}, is curl not built right?", $msg)
             })?;
         }
     };
@@ -525,7 +525,7 @@ impl<'a, 'cfg> Downloads<'a, 'cfg> {
             .ok_or_else(|| internal(format!("couldn't find source for `{}`", id)))?;
         let pkg = source
             .download(id)
-            .chain_err(|| failure::format_err!("unable to get packages from source"))?;
+            .chain_err(|| anyhow::format_err!("unable to get packages from source"))?;
         let (url, descriptor) = match pkg {
             MaybePackage::Ready(pkg) => {
                 debug!("{} doesn't need a download", id);

--- a/src/cargo/core/package_id_spec.rs
+++ b/src/cargo/core/package_id_spec.rs
@@ -79,7 +79,7 @@ impl PackageIdSpec {
         I: IntoIterator<Item = PackageId>,
     {
         let spec = PackageIdSpec::parse(spec)
-            .chain_err(|| failure::format_err!("invalid package ID specification: `{}`", spec))?;
+            .chain_err(|| anyhow::format_err!("invalid package ID specification: `{}`", spec))?;
         spec.query(i)
     }
 
@@ -96,16 +96,16 @@ impl PackageIdSpec {
     /// Tries to convert a valid `Url` to a `PackageIdSpec`.
     fn from_url(mut url: Url) -> CargoResult<PackageIdSpec> {
         if url.query().is_some() {
-            failure::bail!("cannot have a query string in a pkgid: {}", url)
+            anyhow::bail!("cannot have a query string in a pkgid: {}", url)
         }
         let frag = url.fragment().map(|s| s.to_owned());
         url.set_fragment(None);
         let (name, version) = {
             let mut path = url
                 .path_segments()
-                .ok_or_else(|| failure::format_err!("pkgid urls must have a path: {}", url))?;
+                .ok_or_else(|| anyhow::format_err!("pkgid urls must have a path: {}", url))?;
             let path_name = path.next_back().ok_or_else(|| {
-                failure::format_err!(
+                anyhow::format_err!(
                     "pkgid urls must have at least one path \
                      component: {}",
                     url
@@ -183,7 +183,7 @@ impl PackageIdSpec {
         let mut ids = i.into_iter().filter(|p| self.matches(*p));
         let ret = match ids.next() {
             Some(id) => id,
-            None => failure::bail!(
+            None => anyhow::bail!(
                 "package ID specification `{}` \
                  matched no packages",
                 self
@@ -204,7 +204,7 @@ impl PackageIdSpec {
                 let mut vec = vec![ret, other];
                 vec.extend(ids);
                 minimize(&mut msg, &vec, self);
-                Err(failure::format_err!("{}", msg))
+                Err(anyhow::format_err!("{}", msg))
             }
             None => Ok(ret),
         };

--- a/src/cargo/core/profiles.rs
+++ b/src/cargo/core/profiles.rs
@@ -240,7 +240,7 @@ impl Profiles {
                     match &profile.inherits {
                         None => {}
                         Some(_) => {
-                            failure::bail!(
+                            anyhow::bail!(
                                 "An 'inherits' must not specified root profile '{}'",
                                 name
                             );
@@ -278,7 +278,7 @@ impl Profiles {
             Some(name) => {
                 let name = name.to_owned();
                 if set.get(&name).is_some() {
-                    failure::bail!(
+                    anyhow::bail!(
                         "Inheritance loop of profiles cycles with profile '{}'",
                         name
                     );
@@ -287,13 +287,13 @@ impl Profiles {
                 set.insert(name.clone());
                 match profiles.get(&name) {
                     None => {
-                        failure::bail!("Profile '{}' not found in Cargo.toml", name);
+                        anyhow::bail!("Profile '{}' not found in Cargo.toml", name);
                     }
                     Some(parent) => self.process_chain(&name, parent, set, result, profiles),
                 }
             }
             None => {
-                failure::bail!(
+                anyhow::bail!(
                     "An 'inherits' directive is needed for all \
                      profiles that are not 'dev' or 'release'. Here \
                      it is missing from '{}'",
@@ -415,7 +415,7 @@ impl Profiles {
         };
 
         match self.by_name.get(profile_name) {
-            None => failure::bail!("Profile `{}` undefined", profile_kind.name()),
+            None => anyhow::bail!("Profile `{}` undefined", profile_kind.name()),
             Some(r) => Ok(r.get_profile(None, true, UnitFor::new_normal())),
         }
     }
@@ -546,7 +546,7 @@ impl ProfileMaker {
                         .map(|spec| spec.to_string())
                         .collect::<Vec<_>>()
                         .join(", ");
-                    failure::bail!(
+                    anyhow::bail!(
                         "multiple package overrides in profile `{}` match package `{}`\n\
                          found package specs: {}",
                         self.default.name,
@@ -1021,13 +1021,13 @@ impl ConfigProfiles {
         if let Some(ref profile) = self.dev {
             profile
                 .validate("dev", features, warnings)
-                .chain_err(|| failure::format_err!("config profile `profile.dev` is not valid"))?;
+                .chain_err(|| anyhow::format_err!("config profile `profile.dev` is not valid"))?;
         }
         if let Some(ref profile) = self.release {
             profile
                 .validate("release", features, warnings)
                 .chain_err(|| {
-                    failure::format_err!("config profile `profile.release` is not valid")
+                    anyhow::format_err!("config profile `profile.release` is not valid")
                 })?;
         }
         Ok(())

--- a/src/cargo/core/resolver/context.rs
+++ b/src/cargo/core/resolver/context.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::num::NonZeroU64;
 use std::rc::Rc;
 
-use failure::format_err;
+use anyhow::format_err;
 use log::debug;
 
 use crate::core::interning::InternedString;

--- a/src/cargo/core/resolver/dep_cache.rs
+++ b/src/cargo/core/resolver/dep_cache.rs
@@ -104,7 +104,7 @@ impl<'a> RegistryQueryer<'a> {
 
             let mut summaries = self.registry.query_vec(dep, false)?.into_iter();
             let s = summaries.next().ok_or_else(|| {
-                failure::format_err!(
+                anyhow::format_err!(
                     "no matching package for override `{}` found\n\
                      location searched: {}\n\
                      version required: {}",
@@ -119,7 +119,7 @@ impl<'a> RegistryQueryer<'a> {
                     .iter()
                     .map(|s| format!("  * {}", s.package_id()))
                     .collect::<Vec<_>>();
-                failure::bail!(
+                anyhow::bail!(
                     "the replacement specification `{}` matched \
                      multiple packages:\n  * {}\n{}",
                     spec,
@@ -144,7 +144,7 @@ impl<'a> RegistryQueryer<'a> {
 
             // Make sure no duplicates
             if let Some(&(ref spec, _)) = potential_matches.next() {
-                failure::bail!(
+                anyhow::bail!(
                     "overlapping replacement specifications found:\n\n  \
                      * {}\n  * {}\n\nboth specifications match: {}",
                     matched_spec,
@@ -277,7 +277,7 @@ pub fn resolve_features<'b>(
                 .any(|d| d.is_optional() && d.name_in_toml() == dep.name_in_toml());
         if always_required && base.0 {
             return Err(match parent {
-                None => failure::format_err!(
+                None => anyhow::format_err!(
                     "Package `{}` does not have feature `{}`. It has a required dependency \
                      with that name, but only optional dependencies can be used as features.",
                     s.package_id(),
@@ -295,7 +295,7 @@ pub fn resolve_features<'b>(
         base.extend(dep.features().iter());
         for feature in base.iter() {
             if feature.contains('/') {
-                return Err(failure::format_err!(
+                return Err(anyhow::format_err!(
                     "feature names may not contain slashes: `{}`",
                     feature
                 )
@@ -318,7 +318,7 @@ pub fn resolve_features<'b>(
     if !remaining.is_empty() {
         let features = remaining.join(", ");
         return Err(match parent {
-            None => failure::format_err!(
+            None => anyhow::format_err!(
                 "Package `{}` does not have these features: `{}`",
                 s.package_id(),
                 features
@@ -437,7 +437,7 @@ impl Requirements<'_> {
             .expect("must be a valid feature")
         {
             match *fv {
-                FeatureValue::Feature(ref dep_feat) if **dep_feat == *feat => failure::bail!(
+                FeatureValue::Feature(ref dep_feat) if **dep_feat == *feat => anyhow::bail!(
                     "cyclic feature dependency: feature `{}` depends on itself",
                     feat
                 ),

--- a/src/cargo/core/resolver/encode.rs
+++ b/src/cargo/core/resolver/encode.rs
@@ -160,7 +160,7 @@ impl EncodableResolve {
                 };
 
                 if !all_pkgs.insert(enc_id.clone()) {
-                    failure::bail!("package `{}` is specified twice in the lockfile", pkg.name);
+                    anyhow::bail!("package `{}` is specified twice in the lockfile", pkg.name);
                 }
                 let id = match pkg.source.as_ref().or_else(|| path_deps.get(&pkg.name)) {
                     // We failed to find a local package in the workspace.
@@ -474,7 +474,7 @@ impl fmt::Display for EncodablePackageId {
 }
 
 impl FromStr for EncodablePackageId {
-    type Err = failure::Error;
+    type Err = anyhow::Error;
 
     fn from_str(s: &str) -> CargoResult<EncodablePackageId> {
         let mut s = s.splitn(3, ' ');
@@ -485,7 +485,7 @@ impl FromStr for EncodablePackageId {
                 if s.starts_with('(') && s.ends_with(')') {
                     Some(SourceId::from_url(&s[1..s.len() - 1])?)
                 } else {
-                    failure::bail!("invalid serialized PackageId")
+                    anyhow::bail!("invalid serialized PackageId")
                 }
             }
             None => None,

--- a/src/cargo/core/resolver/mod.rs
+++ b/src/cargo/core/resolver/mod.rs
@@ -1012,7 +1012,7 @@ fn check_cycles(resolve: &Resolve) -> CargoResult<()> {
         path.push(id);
         // See if we visited ourselves
         if !visited.insert(id) {
-            failure::bail!(
+            anyhow::bail!(
                 "cyclic package dependency: package `{}` depends on itself. Cycle:\n{}",
                 id,
                 errors::describe_path(&path.iter().rev().collect::<Vec<_>>()),
@@ -1062,7 +1062,7 @@ fn check_duplicate_pkgs_in_lockfile(resolve: &Resolve) -> CargoResult<()> {
     for pkg_id in resolve.iter() {
         let encodable_pkd_id = encode::encodable_package_id(pkg_id, &state);
         if let Some(prev_pkg_id) = unique_pkg_ids.insert(encodable_pkd_id, pkg_id) {
-            failure::bail!(
+            anyhow::bail!(
                 "package collision in the lockfile: packages {} and {} are different, \
                  but only one can be written to lockfile unambiguously",
                 prev_pkg_id,

--- a/src/cargo/core/resolver/resolve.rs
+++ b/src/cargo/core/resolver/resolve.rs
@@ -150,7 +150,7 @@ impl Resolve {
                 // desires stronger checksum guarantees than can be afforded
                 // elsewhere.
                 if cksum.is_none() {
-                    failure::bail!(
+                    anyhow::bail!(
                         "\
 checksum for `{}` was not previously calculated, but a checksum could now \
 be calculated
@@ -172,7 +172,7 @@ this could be indicative of a few possible situations:
                 // more realistically we were overridden with a source that does
                 // not have checksums.
                 } else if mine.is_none() {
-                    failure::bail!(
+                    anyhow::bail!(
                         "\
 checksum for `{}` could not be calculated, but a checksum is listed in \
 the existing lock file
@@ -193,7 +193,7 @@ unable to verify that `{0}` is the same as when the lockfile was generated
                 // must both be Some, in which case the checksum now differs.
                 // That's quite bad!
                 } else {
-                    failure::bail!(
+                    anyhow::bail!(
                         "\
 checksum for `{}` changed between lock files
 
@@ -338,7 +338,7 @@ unable to verify that `{0}` is the same as when the lockfile was generated
         });
         let name = names.next().unwrap_or_else(|| crate_name.clone());
         for n in names {
-            failure::ensure!(
+            anyhow::ensure!(
                 n == name,
                 "the crate `{}` depends on crate `{}` multiple times with different names",
                 from,

--- a/src/cargo/core/shell.rs
+++ b/src/cargo/core/shell.rs
@@ -252,7 +252,7 @@ impl Shell {
 
                 Some("auto") | None => ColorChoice::CargoAuto,
 
-                Some(arg) => failure::bail!(
+                Some(arg) => anyhow::bail!(
                     "argument for --color must be auto, always, or \
                      never, but found `{}`",
                     arg

--- a/src/cargo/core/source/source_id.rs
+++ b/src/cargo/core/source/source_id.rs
@@ -112,7 +112,7 @@ impl SourceId {
         let kind = parts.next().unwrap();
         let url = parts
             .next()
-            .ok_or_else(|| failure::format_err!("invalid source `{}`", string))?;
+            .ok_or_else(|| anyhow::format_err!("invalid source `{}`", string))?;
 
         match kind {
             "git" => {
@@ -141,10 +141,7 @@ impl SourceId {
                 let url = url.into_url()?;
                 SourceId::new(Kind::Path, url)
             }
-            kind => Err(failure::format_err!(
-                "unsupported source protocol: {}",
-                kind
-            )),
+            kind => Err(anyhow::format_err!("unsupported source protocol: {}", kind)),
         }
     }
 

--- a/src/cargo/core/summary.rs
+++ b/src/cargo/core/summary.rs
@@ -46,14 +46,14 @@ impl Summary {
         for dep in dependencies.iter() {
             let feature = dep.name_in_toml();
             if !namespaced_features && features.get(&*feature).is_some() {
-                failure::bail!(
+                anyhow::bail!(
                     "Features and dependencies cannot have the \
                      same name: `{}`",
                     feature
                 )
             }
             if dep.is_optional() && !dep.is_transitive() {
-                failure::bail!(
+                anyhow::bail!(
                     "Dev-dependencies are not allowed to be optional: `{}`",
                     feature
                 )
@@ -180,7 +180,7 @@ where
             match dep_map.get(feature.borrow()) {
                 Some(dep_data) => {
                     if !dep_data.iter().any(|d| d.is_optional()) {
-                        failure::bail!(
+                        anyhow::bail!(
                             "Feature `{}` includes the dependency of the same name, but this is \
                              left implicit in the features included by this feature.\n\
                              Additionally, the dependency must be marked as optional to be \
@@ -249,7 +249,7 @@ where
                 (&Feature(feat), dep_exists, false) => {
                     if namespaced && !features.contains_key(&*feat) {
                         if dep_exists {
-                            failure::bail!(
+                            anyhow::bail!(
                                 "Feature `{}` includes `{}` which is not defined as a feature.\n\
                                  A non-optional dependency of the same name is defined; consider \
                                  adding `optional = true` to its definition",
@@ -257,7 +257,7 @@ where
                                 feat
                             )
                         } else {
-                            failure::bail!(
+                            anyhow::bail!(
                                 "Feature `{}` includes `{}` which is not defined as a feature",
                                 feature,
                                 feat
@@ -272,7 +272,7 @@ where
                 // just to provide the correct string for the crate dependency in the error.
                 (&Crate(ref dep), true, false) => {
                     if namespaced {
-                        failure::bail!(
+                        anyhow::bail!(
                             "Feature `{}` includes `crate:{}` which is not an \
                              optional dependency.\nConsider adding \
                              `optional = true` to the dependency",
@@ -280,7 +280,7 @@ where
                             dep
                         )
                     } else {
-                        failure::bail!(
+                        anyhow::bail!(
                             "Feature `{}` depends on `{}` which is not an \
                              optional dependency.\nConsider adding \
                              `optional = true` to the dependency",
@@ -295,14 +295,14 @@ where
                 // namespaced here is just to provide the correct string in the error.
                 (&Crate(ref dep), false, _) => {
                     if namespaced {
-                        failure::bail!(
+                        anyhow::bail!(
                             "Feature `{}` includes `crate:{}` which is not a known \
                              dependency",
                             feature,
                             dep
                         )
                     } else {
-                        failure::bail!(
+                        anyhow::bail!(
                             "Feature `{}` includes `{}` which is neither a dependency nor \
                              another feature",
                             feature,
@@ -313,7 +313,7 @@ where
                 (&Crate(_), true, true) => {}
                 // If the value is a feature for one of the dependencies, bail out if no such
                 // dependency is actually defined in the manifest.
-                (&CrateFeature(ref dep, _), false, _) => failure::bail!(
+                (&CrateFeature(ref dep, _), false, _) => anyhow::bail!(
                     "Feature `{}` requires a feature of `{}` which is not a \
                      dependency",
                     feature,
@@ -327,7 +327,7 @@ where
         if !dependency_found {
             // If we have not found the dependency of the same-named feature, we should
             // bail here.
-            failure::bail!(
+            anyhow::bail!(
                 "Feature `{}` includes the optional dependency of the \
                  same name, but this is left implicit in the features \
                  included by this feature.\nConsider adding \

--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -224,7 +224,7 @@ impl<'cfg> Workspace<'cfg> {
     /// indicating that something else should be passed.
     pub fn current(&self) -> CargoResult<&Package> {
         let pkg = self.current_opt().ok_or_else(|| {
-            failure::format_err!(
+            anyhow::format_err!(
                 "manifest path `{}` is a virtual manifest, but this \
                  command requires running against an actual package in \
                  this workspace",
@@ -467,7 +467,7 @@ impl<'cfg> Workspace<'cfg> {
                         None
                     };
                 }
-                _ => failure::bail!(
+                _ => anyhow::bail!(
                     "root of a workspace inferred but wasn't a root: {}",
                     root_manifest_path.display()
                 ),
@@ -482,7 +482,7 @@ impl<'cfg> Workspace<'cfg> {
             for path in default {
                 let manifest_path = paths::normalize_path(&path.join("Cargo.toml"));
                 if !self.members.contains(&manifest_path) {
-                    failure::bail!(
+                    anyhow::bail!(
                         "package `{}` is listed in workspace’s default-members \
                          but is not a member.",
                         path.display()
@@ -592,7 +592,7 @@ impl<'cfg> Workspace<'cfg> {
                     MaybePackage::Virtual(_) => continue,
                 };
                 if let Some(prev) = names.insert(name, member) {
-                    failure::bail!(
+                    anyhow::bail!(
                         "two packages named `{}` in this workspace:\n\
                          - {}\n\
                          - {}",
@@ -605,7 +605,7 @@ impl<'cfg> Workspace<'cfg> {
         }
 
         match roots.len() {
-            0 => failure::bail!(
+            0 => anyhow::bail!(
                 "`package.workspace` configuration points to a crate \
                  which is not configured with [workspace]: \n\
                  configuration at: {}\n\
@@ -615,7 +615,7 @@ impl<'cfg> Workspace<'cfg> {
             ),
             1 => {}
             _ => {
-                failure::bail!(
+                anyhow::bail!(
                     "multiple workspace roots found in the same workspace:\n{}",
                     roots
                         .iter()
@@ -634,7 +634,7 @@ impl<'cfg> Workspace<'cfg> {
 
             match root {
                 Some(root) => {
-                    failure::bail!(
+                    anyhow::bail!(
                         "package `{}` is a member of the wrong workspace\n\
                          expected: {}\n\
                          actual:   {}",
@@ -644,7 +644,7 @@ impl<'cfg> Workspace<'cfg> {
                     );
                 }
                 None => {
-                    failure::bail!(
+                    anyhow::bail!(
                         "workspace member `{}` is not hierarchically below \
                          the workspace root `{}`",
                         member.display(),
@@ -696,7 +696,7 @@ impl<'cfg> Workspace<'cfg> {
                     }
                 }
             };
-            failure::bail!(
+            anyhow::bail!(
                 "current package believes it's in a workspace when it's not:\n\
                  current:   {}\n\
                  workspace: {}\n\n{}\n\
@@ -746,7 +746,7 @@ impl<'cfg> Workspace<'cfg> {
     pub fn load(&self, manifest_path: &Path) -> CargoResult<Package> {
         match self.packages.maybe_get(manifest_path) {
             Some(&MaybePackage::Package(ref p)) => return Ok(p.clone()),
-            Some(&MaybePackage::Virtual(_)) => failure::bail!("cannot load workspace root"),
+            Some(&MaybePackage::Virtual(_)) => anyhow::bail!("cannot load workspace root"),
             None => {}
         }
 
@@ -800,9 +800,9 @@ impl<'cfg> Workspace<'cfg> {
             let path = path.join("Cargo.toml");
             for warning in warnings {
                 if warning.is_critical {
-                    let err = failure::format_err!("{}", warning.message);
+                    let err = anyhow::format_err!("{}", warning.message);
                     let cx =
-                        failure::format_err!("failed to parse manifest at `{}`", path.display());
+                        anyhow::format_err!("failed to parse manifest at `{}`", path.display());
                     return Err(err.context(cx).into());
                 } else {
                     let msg = if self.root_manifest.is_none() {
@@ -941,10 +941,10 @@ impl WorkspaceRootConfig {
             None => return Ok(Vec::new()),
         };
         let res =
-            glob(path).chain_err(|| failure::format_err!("could not parse pattern `{}`", &path))?;
+            glob(path).chain_err(|| anyhow::format_err!("could not parse pattern `{}`", &path))?;
         let res = res
             .map(|p| {
-                p.chain_err(|| failure::format_err!("unable to match path to pattern `{}`", &path))
+                p.chain_err(|| anyhow::format_err!("unable to match path to pattern `{}`", &path))
             })
             .collect::<Result<Vec<_>, _>>()?;
         Ok(res)

--- a/src/cargo/lib.rs
+++ b/src/cargo/lib.rs
@@ -30,15 +30,12 @@
 // https://github.com/rust-lang/cargo/pull/7251#pullrequestreview-274914270
 #![allow(clippy::identity_conversion)]
 
-use std::fmt;
-use std::io;
-
-use failure::Error;
-use log::debug;
-use serde::ser;
-
 use crate::core::shell::Verbosity::Verbose;
 use crate::core::Shell;
+use anyhow::Error;
+use log::debug;
+use serde::ser;
+use std::fmt;
 
 pub use crate::util::errors::Internal;
 pub use crate::util::{CargoResult, CliError, CliResult, Config};
@@ -140,7 +137,7 @@ pub fn exit_with_error(err: CliError, shell: &mut Shell) -> ! {
     std::process::exit(exit_code)
 }
 
-pub fn handle_error(err: &failure::Error, shell: &mut Shell) {
+pub fn handle_error(err: &Error, shell: &mut Shell) {
     debug!("handle_error; err={:?}", err);
 
     let _ignored_result = shell.error(err);
@@ -153,18 +150,10 @@ fn handle_cause(cargo_err: &Error, shell: &mut Shell) -> bool {
         drop(writeln!(shell.err(), "  {}", error));
     }
 
-    fn print_stderror_causes(error: &dyn std::error::Error, shell: &mut Shell) {
-        let mut cur = std::error::Error::source(error);
-        while let Some(err) = cur {
-            print(&err.to_string(), shell);
-            cur = std::error::Error::source(err);
-        }
-    }
-
     let verbose = shell.verbosity();
 
     // The first error has already been printed to the shell.
-    for err in cargo_err.iter_causes() {
+    for err in cargo_err.chain().skip(1) {
         // If we're not in verbose mode then print remaining errors until one
         // marked as `Internal` appears.
         if verbose != Verbose && err.downcast_ref::<Internal>().is_some() {
@@ -172,19 +161,6 @@ fn handle_cause(cargo_err: &Error, shell: &mut Shell) -> bool {
         }
 
         print(&err.to_string(), shell);
-
-        // Using the `failure` crate currently means that when using
-        // `iter_causes` we're only iterating over the `failure` causes, but
-        // this doesn't include the causes from the standard library `Error`
-        // trait. We don't have a great way of getting an `&dyn Error` from a
-        // `&dyn Fail`, so we currently just special case a few errors that are
-        // known to maybe have causes and we try to print them here.
-        //
-        // Note that this isn't an exhaustive match since causes for
-        // `std::error::Error` aren't the most common thing in the world.
-        if let Some(io) = err.downcast_ref::<io::Error>() {
-            print_stderror_causes(io, shell);
-        }
     }
 
     true

--- a/src/cargo/ops/cargo_clean.rs
+++ b/src/cargo/ops/cargo_clean.rs
@@ -155,13 +155,13 @@ fn rm_rf(path: &Path, config: &Config) -> CargoResult<()> {
             .shell()
             .verbose(|shell| shell.status("Removing", path.display()))?;
         paths::remove_dir_all(path)
-            .chain_err(|| failure::format_err!("could not remove build directory"))?;
+            .chain_err(|| anyhow::format_err!("could not remove build directory"))?;
     } else if m.is_ok() {
         config
             .shell()
             .verbose(|shell| shell.status("Removing", path.display()))?;
         paths::remove_file(path)
-            .chain_err(|| failure::format_err!("failed to remove build artifact"))?;
+            .chain_err(|| anyhow::format_err!("failed to remove build artifact"))?;
     }
     Ok(())
 }

--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -111,7 +111,7 @@ impl Packages {
         Ok(match (all, exclude.len(), package.len()) {
             (false, 0, 0) => Packages::Default,
             (false, 0, _) => Packages::Packages(package),
-            (false, _, _) => failure::bail!("--exclude can only be used together with --workspace"),
+            (false, _, _) => anyhow::bail!("--exclude can only be used together with --workspace"),
             (true, 0, _) => Packages::All,
             (true, _, _) => Packages::OptOut(exclude),
         })
@@ -160,13 +160,13 @@ impl Packages {
         };
         if specs.is_empty() {
             if ws.is_virtual() {
-                failure::bail!(
+                anyhow::bail!(
                     "manifest path `{}` contains no package: The manifest is virtual, \
                      and the workspace has no members.",
                     ws.root().display()
                 )
             }
-            failure::bail!("no packages to compile")
+            anyhow::bail!("no packages to compile")
         }
         Ok(specs)
     }
@@ -185,7 +185,7 @@ impl Packages {
                     ws.members()
                         .find(|pkg| pkg.name().as_str() == name)
                         .ok_or_else(|| {
-                            failure::format_err!(
+                            anyhow::format_err!(
                                 "package `{}` is not a member of the workspace",
                                 name
                             )
@@ -325,7 +325,7 @@ pub fn compile_ws<'a>(
             // TODO: This should eventually be fixed. Unfortunately it is not
             // easy to get the host triple in BuildConfig. Consider changing
             // requested_target to an enum, or some other approach.
-            failure::bail!("-Zbuild-std requires --target");
+            anyhow::bail!("-Zbuild-std requires --target");
         }
         let (mut std_package_set, std_resolve) = standard_lib::resolve_std(ws, crates)?;
         remove_dylib_crate_type(&mut std_package_set)?;
@@ -359,7 +359,7 @@ pub fn compile_ws<'a>(
             && !ws.is_member(pkg)
             && pkg.dependencies().iter().any(|dep| !dep.is_transitive())
         {
-            failure::bail!(
+            anyhow::bail!(
                 "package `{}` cannot be tested because it requires dev-dependencies \
                  and is not a member of the workspace",
                 pkg.name()
@@ -430,7 +430,7 @@ pub fn compile_ws<'a>(
 
     if let Some(args) = extra_args {
         if units.len() != 1 {
-            failure::bail!(
+            anyhow::bail!(
                 "extra arguments to `{}` can only be passed to one \
                  target, consider filtering\nthe package by passing, \
                  e.g., `--lib` or `--bin NAME` to specify a single target",
@@ -793,12 +793,9 @@ fn generate_targets<'a>(
                 if !all_targets && libs.is_empty() && *lib == LibRule::True {
                     let names = packages.iter().map(|pkg| pkg.name()).collect::<Vec<_>>();
                     if names.len() == 1 {
-                        failure::bail!("no library targets found in package `{}`", names[0]);
+                        anyhow::bail!("no library targets found in package `{}`", names[0]);
                     } else {
-                        failure::bail!(
-                            "no library targets found in packages: {}",
-                            names.join(", ")
-                        );
+                        anyhow::bail!("no library targets found in packages: {}", names.join(", "));
                     }
                 }
                 proposals.extend(libs);
@@ -887,7 +884,7 @@ fn generate_targets<'a>(
                 .iter()
                 .map(|s| format!("`{}`", s))
                 .collect();
-            failure::bail!(
+            anyhow::bail!(
                 "target `{}` in package `{}` requires the features: {}\n\
                  Consider enabling them by passing, e.g., `--features=\"{}\"`",
                 target.name(),
@@ -991,7 +988,7 @@ fn find_named_targets<'a>(
                 .filter(|target| is_expected_kind(target))
         });
         let suggestion = closest_msg(target_name, targets, |t| t.name());
-        failure::bail!(
+        anyhow::bail!(
             "no {} target named `{}`{}",
             target_desc,
             target_name,

--- a/src/cargo/ops/cargo_generate_lockfile.rs
+++ b/src/cargo/ops/cargo_generate_lockfile.rs
@@ -36,15 +36,15 @@ pub fn generate_lockfile(ws: &Workspace<'_>) -> CargoResult<()> {
 
 pub fn update_lockfile(ws: &Workspace<'_>, opts: &UpdateOptions<'_>) -> CargoResult<()> {
     if opts.aggressive && opts.precise.is_some() {
-        failure::bail!("cannot specify both aggressive and precise simultaneously")
+        anyhow::bail!("cannot specify both aggressive and precise simultaneously")
     }
 
     if ws.members().count() == 0 {
-        failure::bail!("you can't generate a lockfile for an empty workspace.")
+        anyhow::bail!("you can't generate a lockfile for an empty workspace.")
     }
 
     if opts.config.offline() {
-        failure::bail!("you can't update in the offline mode");
+        anyhow::bail!("you can't update in the offline mode");
     }
 
     // Updates often require a lot of modifications to the registry, so ensure

--- a/src/cargo/ops/cargo_install.rs
+++ b/src/cargo/ops/cargo_install.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::{env, fs};
 
-use failure::{bail, format_err};
+use anyhow::{bail, format_err};
 use tempfile::Builder as TempFileBuilder;
 
 use crate::core::compiler::Freshness;

--- a/src/cargo/ops/cargo_output_metadata.rs
+++ b/src/cargo/ops/cargo_output_metadata.rs
@@ -24,7 +24,7 @@ pub struct OutputMetadataOptions {
 /// format to stdout.
 pub fn output_metadata(ws: &Workspace<'_>, opt: &OutputMetadataOptions) -> CargoResult<ExportInfo> {
     if opt.version != VERSION {
-        failure::bail!(
+        anyhow::bail!(
             "metadata version {} not supported, only {} is currently supported",
             opt.version,
             VERSION

--- a/src/cargo/ops/cargo_package.rs
+++ b/src/cargo/ops/cargo_package.rs
@@ -123,7 +123,7 @@ pub fn package(ws: &Workspace<'_>, opts: &PackageOpts<'_>) -> CargoResult<Option
         .status("Packaging", pkg.package_id().to_string())?;
     dst.file().set_len(0)?;
     tar(ws, &src_files, vcs_info.as_ref(), dst.file(), &filename)
-        .chain_err(|| failure::format_err!("failed to prepare local package for uploading"))?;
+        .chain_err(|| anyhow::format_err!("failed to prepare local package for uploading"))?;
     if opts.verify {
         dst.seek(SeekFrom::Start(0))?;
         run_verify(ws, &dst, opts).chain_err(|| "failed to verify package tarball")?
@@ -214,7 +214,7 @@ fn check_metadata(pkg: &Package, config: &Config) -> CargoResult<()> {
 fn verify_dependencies(pkg: &Package) -> CargoResult<()> {
     for dep in pkg.dependencies() {
         if dep.source_id().is_path() && !dep.specified_req() && dep.is_transitive() {
-            failure::bail!(
+            anyhow::bail!(
                 "all path dependencies must have a version specified \
                  when packaging.\ndependency `{}` does not specify \
                  a version.",
@@ -321,7 +321,7 @@ fn check_repo_state(
             Ok(Some(rev_obj.id().to_string()))
         } else {
             if !allow_dirty {
-                failure::bail!(
+                anyhow::bail!(
                     "{} files in the working directory contain changes that were \
                      not yet committed into git:\n\n{}\n\n\
                      to proceed despite this and include the uncommitted changes, pass the `--allow-dirty` flag",
@@ -359,7 +359,7 @@ fn check_vcs_file_collision(pkg: &Package, src_files: &[PathBuf]) -> CargoResult
         .iter()
         .find(|&p| p.strip_prefix(root).unwrap() == vcs_info_path);
     if collision.is_some() {
-        failure::bail!(
+        anyhow::bail!(
             "Invalid inclusion of reserved file name \
              {} in package source",
             VCS_INFO_FILE
@@ -391,7 +391,7 @@ fn tar(
         let relative = src_file.strip_prefix(root)?;
         check_filename(relative)?;
         let relative_str = relative.to_str().ok_or_else(|| {
-            failure::format_err!("non-utf8 path in source directory: {}", relative.display())
+            anyhow::format_err!("non-utf8 path in source directory: {}", relative.display())
         })?;
         if relative_str == "Cargo.lock" {
             // This is added manually below.
@@ -671,7 +671,7 @@ fn run_verify(ws: &Workspace<'_>, tar: &FileLock, opts: &PackageOpts<'_>) -> Car
     let ws_fingerprint = hash_all(&dst)?;
     if pkg_fingerprint != ws_fingerprint {
         let changes = report_hash_difference(&pkg_fingerprint, &ws_fingerprint);
-        failure::bail!(
+        anyhow::bail!(
             "Source directory was modified by build.rs during cargo publish. \
              Build scripts should not modify anything outside of OUT_DIR.\n\
              {}\n\n\
@@ -756,7 +756,7 @@ fn check_filename(file: &Path) -> CargoResult<()> {
     };
     let name = match name.to_str() {
         Some(name) => name,
-        None => failure::bail!(
+        None => anyhow::bail!(
             "path does not have a unicode filename which may not unpack \
              on all platforms: {}",
             file.display()
@@ -764,7 +764,7 @@ fn check_filename(file: &Path) -> CargoResult<()> {
     };
     let bad_chars = ['/', '\\', '<', '>', ':', '"', '|', '?', '*'];
     if let Some(c) = bad_chars.iter().find(|c| name.contains(**c)) {
-        failure::bail!(
+        anyhow::bail!(
             "cannot package a filename with a special character `{}`: {}",
             c,
             file.display()

--- a/src/cargo/ops/cargo_pkgid.rs
+++ b/src/cargo/ops/cargo_pkgid.rs
@@ -5,7 +5,7 @@ use crate::util::CargoResult;
 pub fn pkgid(ws: &Workspace<'_>, spec: Option<&str>) -> CargoResult<PackageIdSpec> {
     let resolve = match ops::load_pkg_lockfile(ws)? {
         Some(resolve) => resolve,
-        None => failure::bail!("a Cargo.lock must exist for this command"),
+        None => anyhow::bail!("a Cargo.lock must exist for this command"),
     };
 
     let pkgid = match spec {

--- a/src/cargo/ops/cargo_read_manifest.rs
+++ b/src/cargo/ops/cargo_read_manifest.rs
@@ -24,7 +24,7 @@ pub fn read_package(
     let (manifest, nested) = read_manifest(path, source_id, config)?;
     let manifest = match manifest {
         EitherManifest::Real(manifest) => manifest,
-        EitherManifest::Virtual(..) => failure::bail!(
+        EitherManifest::Virtual(..) => anyhow::bail!(
             "found a virtual manifest at `{}` instead of a package \
              manifest",
             path.display()
@@ -41,7 +41,7 @@ pub fn read_packages(
 ) -> CargoResult<Vec<Package>> {
     let mut all_packages = HashMap::new();
     let mut visited = HashSet::<PathBuf>::new();
-    let mut errors = Vec::<failure::Error>::new();
+    let mut errors = Vec::<anyhow::Error>::new();
 
     trace!(
         "looking for root package: {}, source_id={}",
@@ -88,7 +88,7 @@ pub fn read_packages(
     if all_packages.is_empty() {
         match errors.pop() {
             Some(err) => Err(err),
-            None => Err(failure::format_err!(
+            None => Err(anyhow::format_err!(
                 "Could not find Cargo.toml in `{}`",
                 path.display()
             )),
@@ -111,7 +111,7 @@ fn walk(path: &Path, callback: &mut dyn FnMut(&Path) -> CargoResult<bool>) -> Ca
         Err(ref e) if e.kind() == io::ErrorKind::PermissionDenied => return Ok(()),
         Err(e) => {
             let cx = format!("failed to read directory `{}`", path.display());
-            let e = failure::Error::from(e);
+            let e = anyhow::Error::from(e);
             return Err(e.context(cx).into());
         }
     };
@@ -134,7 +134,7 @@ fn read_nested_packages(
     source_id: SourceId,
     config: &Config,
     visited: &mut HashSet<PathBuf>,
-    errors: &mut Vec<failure::Error>,
+    errors: &mut Vec<anyhow::Error>,
 ) -> CargoResult<()> {
     if !visited.insert(path.to_path_buf()) {
         return Ok(());

--- a/src/cargo/ops/cargo_run.rs
+++ b/src/cargo/ops/cargo_run.rs
@@ -33,7 +33,7 @@ pub fn run(
 
     if bins.is_empty() {
         if !options.filter.is_specific() {
-            failure::bail!("a bin target must be available for `cargo run`")
+            anyhow::bail!("a bin target must be available for `cargo run`")
         } else {
             // This will be verified in `cargo_compile`.
         }
@@ -42,7 +42,7 @@ pub fn run(
     if bins.len() == 1 {
         let target = bins[0].1;
         if let TargetKind::ExampleLib(..) = target.kind() {
-            failure::bail!(
+            anyhow::bail!(
                 "example target `{}` is a library and cannot be executed",
                 target.name()
             )
@@ -55,7 +55,7 @@ pub fn run(
                 .into_iter()
                 .map(|(_pkg, target)| target.name())
                 .collect();
-            failure::bail!(
+            anyhow::bail!(
                 "`cargo run` could not determine which binary to run. \
                  Use the `--bin` option to specify a binary, \
                  or the `default-run` manifest key.\n\
@@ -63,7 +63,7 @@ pub fn run(
                 names.join(", ")
             )
         } else {
-            failure::bail!(
+            anyhow::bail!(
                 "`cargo run` can run at most one executable, but \
                  multiple were specified"
             )

--- a/src/cargo/ops/cargo_uninstall.rs
+++ b/src/cargo/ops/cargo_uninstall.rs
@@ -1,4 +1,4 @@
-use failure::bail;
+use anyhow::bail;
 use std::collections::BTreeSet;
 use std::env;
 

--- a/src/cargo/ops/common_for_install_and_uninstall.rs
+++ b/src/cargo/ops/common_for_install_and_uninstall.rs
@@ -4,7 +4,7 @@ use std::io::prelude::*;
 use std::io::SeekFrom;
 use std::path::{Path, PathBuf};
 
-use failure::{bail, format_err};
+use anyhow::{bail, format_err};
 use semver::VersionReq;
 use serde::{Deserialize, Serialize};
 

--- a/src/cargo/ops/lockfile.rs
+++ b/src/cargo/ops/lockfile.rs
@@ -47,7 +47,7 @@ pub fn write_pkg_lockfile(ws: &Workspace<'_>, resolve: &Resolve) -> CargoResult<
 
     if !ws.config().lock_update_allowed() {
         if ws.config().offline() {
-            failure::bail!("can't update in the offline mode");
+            anyhow::bail!("can't update in the offline mode");
         }
 
         let flag = if ws.config().network_allowed() {
@@ -55,7 +55,7 @@ pub fn write_pkg_lockfile(ws: &Workspace<'_>, resolve: &Resolve) -> CargoResult<
         } else {
             "--frozen"
         };
-        failure::bail!(
+        anyhow::bail!(
             "the lock file {} needs to be updated but {} was passed to prevent this\n\
              If you want to try to generate the lock file without accessing the network, \
              use the --offline flag.",

--- a/src/cargo/ops/registry.rs
+++ b/src/cargo/ops/registry.rs
@@ -6,9 +6,9 @@ use std::str;
 use std::time::Duration;
 use std::{cmp, env};
 
+use anyhow::{bail, format_err};
 use crates_io::{NewCrate, NewCrateDependency, Registry};
 use curl::easy::{Easy, InfoType, SslOpt, SslVersion};
-use failure::{bail, format_err};
 use log::{log, Level};
 use percent_encoding::{percent_encode, NON_ALPHANUMERIC};
 
@@ -603,7 +603,7 @@ pub fn registry_login(
                 .lock()
                 .read_line(&mut line)
                 .chain_err(|| "failed to read stdin")
-                .map_err(failure::Error::from)?;
+                .map_err(anyhow::Error::from)?;
             // Automatically remove `cargo login` from an inputted token to allow direct pastes from `registry.host()`/me.
             line.replace("cargo login", "").trim().to_string()
         }

--- a/src/cargo/ops/resolve.rs
+++ b/src/cargo/ops/resolve.rs
@@ -265,7 +265,7 @@ pub fn resolve_with_previous<'cfg>(
             members.extend(ws.members());
         } else {
             if specs.len() > 1 && !opts.features.is_empty() {
-                failure::bail!("cannot specify features for more than one package");
+                anyhow::bail!("cannot specify features for more than one package");
             }
             members.extend(
                 ws.members()
@@ -276,7 +276,7 @@ pub fn resolve_with_previous<'cfg>(
             // into the resolution graph.
             if members.is_empty() {
                 if !(opts.features.is_empty() && !opts.all_features && opts.uses_default_features) {
-                    failure::bail!("cannot specify features for packages outside of workspace");
+                    anyhow::bail!("cannot specify features for packages outside of workspace");
                 }
                 members.extend(ws.members());
             }

--- a/src/cargo/ops/vendor.rs
+++ b/src/cargo/ops/vendor.rs
@@ -4,7 +4,7 @@ use crate::ops;
 use crate::sources::path::PathSource;
 use crate::util::Sha256;
 use crate::util::{paths, CargoResult, CargoResultExt, Config};
-use failure::bail;
+use anyhow::bail;
 use serde::Serialize;
 use std::collections::HashSet;
 use std::collections::{BTreeMap, BTreeSet, HashMap};

--- a/src/cargo/sources/config.rs
+++ b/src/cargo/sources/config.rs
@@ -9,7 +9,7 @@ use crate::sources::{ReplacedSource, CRATES_IO_REGISTRY};
 use crate::util::config::{self, ConfigRelativePath, OptValue};
 use crate::util::errors::{CargoResult, CargoResultExt};
 use crate::util::{Config, IntoUrl};
-use failure::bail;
+use anyhow::bail;
 use log::debug;
 use std::collections::{HashMap, HashSet};
 use url::Url;

--- a/src/cargo/sources/directory.rs
+++ b/src/cargo/sources/directory.rs
@@ -151,7 +151,7 @@ impl<'cfg> Source for DirectorySource<'cfg> {
             .map(|p| &p.0)
             .cloned()
             .map(MaybePackage::Ready)
-            .ok_or_else(|| failure::format_err!("failed to find package with id: {}", id))
+            .ok_or_else(|| anyhow::format_err!("failed to find package with id: {}", id))
     }
 
     fn finish_download(&mut self, _id: PackageId, _data: Vec<u8>) -> CargoResult<Package> {
@@ -165,7 +165,7 @@ impl<'cfg> Source for DirectorySource<'cfg> {
     fn verify(&self, id: PackageId) -> CargoResult<()> {
         let (pkg, cksum) = match self.packages.get(&id) {
             Some(&(ref pkg, ref cksum)) => (pkg, cksum),
-            None => failure::bail!("failed to find entry for `{}` in directory source", id),
+            None => anyhow::bail!("failed to find entry for `{}` in directory source", id),
         };
 
         for (file, cksum) in cksum.files.iter() {
@@ -175,7 +175,7 @@ impl<'cfg> Source for DirectorySource<'cfg> {
                 .chain_err(|| format!("failed to calculate checksum of: {}", file.display()))?
                 .finish_hex();
             if &*actual != cksum {
-                failure::bail!(
+                anyhow::bail!(
                     "the listed checksum of `{}` has changed:\n\
                      expected: {}\n\
                      actual:   {}\n\

--- a/src/cargo/sources/git/source.rs
+++ b/src/cargo/sources/git/source.rs
@@ -118,7 +118,7 @@ impl<'cfg> Source for GitSource<'cfg> {
         let db_path = git_path.join("db").join(&self.ident);
 
         if self.config.offline() && !db_path.exists() {
-            failure::bail!(
+            anyhow::bail!(
                 "can't checkout from '{}': you are in the offline mode (--offline)",
                 self.remote.url()
             );

--- a/src/cargo/sources/git/utils.rs
+++ b/src/cargo/sources/git/utils.rs
@@ -67,7 +67,7 @@ pub struct GitDatabase {
 
 /// `GitCheckout` is a local checkout of a particular revision. Calling
 /// `clone_into` with a reference will resolve the reference into a revision,
-/// and return a `failure::Error` if no revision for that reference was found.
+/// and return a `anyhow::Error` if no revision for that reference was found.
 #[derive(Serialize)]
 pub struct GitCheckout<'a> {
     database: &'a GitDatabase,
@@ -219,7 +219,7 @@ impl GitReference {
                     .chain_err(|| format!("failed to find branch `{}`", s))?;
                 b.get()
                     .target()
-                    .ok_or_else(|| failure::format_err!("branch `{}` did not have a target", s))?
+                    .ok_or_else(|| anyhow::format_err!("branch `{}` did not have a target", s))?
             }
             GitReference::Rev(ref s) => {
                 let obj = repo.revparse_single(s)?;
@@ -588,7 +588,7 @@ where
     // In the case of an authentication failure (where we tried something) then
     // we try to give a more helpful error message about precisely what we
     // tried.
-    let res = res.map_err(failure::Error::from).chain_err(|| {
+    let res = res.map_err(anyhow::Error::from).chain_err(|| {
         let mut msg = "failed to authenticate when downloading \
                        repository"
             .to_string();
@@ -669,13 +669,13 @@ pub fn fetch(
     config: &Config,
 ) -> CargoResult<()> {
     if config.frozen() {
-        failure::bail!(
+        anyhow::bail!(
             "attempting to update a git repository, but --frozen \
              was specified"
         )
     }
     if !config.network_allowed() {
-        failure::bail!("can't update a git repository in the offline mode")
+        anyhow::bail!("can't update a git repository in the offline mode")
     }
 
     // If we're fetching from GitHub, attempt GitHub's special fast path for

--- a/src/cargo/sources/path.rs
+++ b/src/cargo/sources/path.rs
@@ -290,7 +290,7 @@ impl<'cfg> PathSource<'cfg> {
                 warn!("  found submodule {}", file_path.display());
                 let rel = file_path.strip_prefix(root)?;
                 let rel = rel.to_str().ok_or_else(|| {
-                    failure::format_err!("invalid utf-8 filename: {}", rel.display())
+                    anyhow::format_err!("invalid utf-8 filename: {}", rel.display())
                 })?;
                 // Git submodules are currently only named through `/` path
                 // separators, explicitly not `\` which windows uses. Who knew?

--- a/src/cargo/sources/registry/index.rs
+++ b/src/cargo/sources/registry/index.rs
@@ -628,21 +628,21 @@ impl<'a> SummariesCache<'a> {
         // NB: keep this method in sync with `serialize` below
         let (first_byte, rest) = data
             .split_first()
-            .ok_or_else(|| failure::format_err!("malformed cache"))?;
+            .ok_or_else(|| anyhow::format_err!("malformed cache"))?;
         if *first_byte != CURRENT_CACHE_VERSION {
-            failure::bail!("looks like a different Cargo's cache, bailing out");
+            anyhow::bail!("looks like a different Cargo's cache, bailing out");
         }
         let mut iter = split(rest, 0);
         if let Some(update) = iter.next() {
             if update != last_index_update.as_bytes() {
-                failure::bail!(
+                anyhow::bail!(
                     "cache out of date: current index ({}) != cache ({})",
                     last_index_update,
                     str::from_utf8(update)?,
                 )
             }
         } else {
-            failure::bail!("malformed file");
+            anyhow::bail!("malformed file");
         }
         let mut ret = SummariesCache::default();
         while let Some(version) = iter.next() {

--- a/src/cargo/sources/registry/local.rs
+++ b/src/cargo/sources/registry/local.rs
@@ -66,11 +66,11 @@ impl<'cfg> RegistryData for LocalRegistry<'cfg> {
         // these directories exist.
         let root = self.root.clone().into_path_unlocked();
         if !root.is_dir() {
-            failure::bail!("local registry path is not a directory: {}", root.display())
+            anyhow::bail!("local registry path is not a directory: {}", root.display())
         }
         let index_path = self.index_path.clone().into_path_unlocked();
         if !index_path.is_dir() {
-            failure::bail!(
+            anyhow::bail!(
                 "local registry index path is not a directory: {}",
                 index_path.display()
             )
@@ -100,7 +100,7 @@ impl<'cfg> RegistryData for LocalRegistry<'cfg> {
         // verify the checksum matches the .crate file itself.
         let actual = Sha256::new().update_file(&crate_file)?.finish_hex();
         if actual != checksum {
-            failure::bail!("failed to verify the checksum of `{}`", pkg)
+            anyhow::bail!("failed to verify the checksum of `{}`", pkg)
         }
 
         crate_file.seek(SeekFrom::Start(0))?;

--- a/src/cargo/sources/registry/mod.rs
+++ b/src/cargo/sources/registry/mod.rs
@@ -480,7 +480,7 @@ impl<'cfg> RegistrySource<'cfg> {
             // crates.io should also block uploads with these sorts of tarballs,
             // but be extra sure by adding a check here as well.
             if !entry_path.starts_with(prefix) {
-                failure::bail!(
+                anyhow::bail!(
                     "invalid tarball downloaded, contains \
                      a file at {:?} which isn't under {:?}",
                     entry_path,

--- a/src/cargo/sources/registry/remote.rs
+++ b/src/cargo/sources/registry/remote.rs
@@ -164,7 +164,7 @@ impl<'cfg> RegistryData for RemoteRegistry<'cfg> {
         let object = entry.to_object(repo)?;
         let blob = match object.as_blob() {
             Some(blob) => blob,
-            None => failure::bail!("path `{}` is not a blob in the git repo", path.display()),
+            None => anyhow::bail!("path `{}` is not a blob in the git repo", path.display()),
         };
         data(blob.content())
     }
@@ -272,7 +272,7 @@ impl<'cfg> RegistryData for RemoteRegistry<'cfg> {
         // Verify what we just downloaded
         let actual = Sha256::new().update(data).finish_hex();
         if actual != checksum {
-            failure::bail!("failed to verify the checksum of `{}`", pkg)
+            anyhow::bail!("failed to verify the checksum of `{}`", pkg)
         }
 
         let filename = self.filename(pkg);

--- a/src/cargo/util/canonical_url.rs
+++ b/src/cargo/util/canonical_url.rs
@@ -22,7 +22,7 @@ impl CanonicalUrl {
         // cannot-be-a-base-urls (e.g., `github.com:rust-lang-nursery/rustfmt.git`)
         // are not supported.
         if url.cannot_be_a_base() {
-            failure::bail!(
+            anyhow::bail!(
                 "invalid url `{}`: cannot-be-a-base-URLs are not supported",
                 url
             )

--- a/src/cargo/util/command_prelude.rs
+++ b/src/cargo/util/command_prelude.rs
@@ -9,8 +9,8 @@ use crate::util::{
     print_available_tests,
 };
 use crate::CargoResult;
+use anyhow::bail;
 use clap::{self, SubCommand};
-use failure::bail;
 use std::ffi::{OsStr, OsString};
 use std::fs;
 use std::path::PathBuf;
@@ -264,10 +264,10 @@ pub trait ArgMatchesExt {
             // but in this particular case we need it to fix #3586.
             let path = paths::normalize_path(&path);
             if !path.ends_with("Cargo.toml") {
-                failure::bail!("the manifest-path must be a path to a Cargo.toml file")
+                anyhow::bail!("the manifest-path must be a path to a Cargo.toml file")
             }
             if fs::metadata(&path).is_err() {
-                failure::bail!(
+                anyhow::bail!(
                     "manifest path `{}` does not exist",
                     self._value_of("manifest-path").unwrap()
                 )
@@ -327,7 +327,7 @@ pub trait ArgMatchesExt {
             ProfileChecking::Unchecked => {}
             ProfileChecking::Checked => {
                 if specified_profile.is_some() && !config.cli_unstable().unstable_options {
-                    failure::bail!("Usage of `--profile` requires `-Z unstable-options`")
+                    anyhow::bail!("Usage of `--profile` requires `-Z unstable-options`")
                 }
             }
         }
@@ -338,7 +338,7 @@ pub trait ArgMatchesExt {
             } else {
                 match specified_profile {
                     None | Some(ProfileKind::Release) => Ok(ProfileKind::Release),
-                    _ => failure::bail!("Conflicting usage of --profile and --release"),
+                    _ => anyhow::bail!("Conflicting usage of --profile and --release"),
                 }
             }
         } else if self._is_present("debug") {
@@ -347,7 +347,7 @@ pub trait ArgMatchesExt {
             } else {
                 match specified_profile {
                     None | Some(ProfileKind::Dev) => Ok(ProfileKind::Dev),
-                    _ => failure::bail!("Conflicting usage of --profile and --debug"),
+                    _ => anyhow::bail!("Conflicting usage of --profile and --debug"),
                 }
             }
         } else {

--- a/src/cargo/util/config/de.rs
+++ b/src/cargo/util/config/de.rs
@@ -429,7 +429,7 @@ impl<'config> ValueDeserializer<'config> {
                 (false, Some(cv)) => cv.definition().clone(),
                 (false, None) => {
                     return Err(
-                        failure::format_err!("failed to find definition of `{}`", de.key).into(),
+                        anyhow::format_err!("failed to find definition of `{}`", de.key).into(),
                     )
                 }
             }

--- a/src/cargo/util/config/target.rs
+++ b/src/cargo/util/config/target.rs
@@ -144,7 +144,7 @@ fn parse_links_overrides(
                     }
                 }
                 "warning" | "rerun-if-changed" | "rerun-if-env-changed" => {
-                    failure::bail!("`{}` is not supported in build script overrides", key);
+                    anyhow::bail!("`{}` is not supported in build script overrides", key);
                 }
                 _ => {
                     let val = value.string(key)?.0;

--- a/src/cargo/util/diagnostic_server.rs
+++ b/src/cargo/util/diagnostic_server.rs
@@ -9,7 +9,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::thread::{self, JoinHandle};
 
-use failure::{Error, ResultExt};
+use anyhow::{Context, Error};
 use log::warn;
 use serde::{Deserialize, Serialize};
 
@@ -229,7 +229,7 @@ pub struct StartedServer {
 impl RustfixDiagnosticServer {
     pub fn new() -> Result<Self, Error> {
         let listener = TcpListener::bind("127.0.0.1:0")
-            .with_context(|_| "failed to bind TCP listener to manage locking")?;
+            .with_context(|| "failed to bind TCP listener to manage locking")?;
         let addr = listener.local_addr()?;
 
         Ok(RustfixDiagnosticServer { listener, addr })

--- a/src/cargo/util/errors.rs
+++ b/src/cargo/util/errors.rs
@@ -1,12 +1,12 @@
 #![allow(unknown_lints)]
 
+use crate::core::{TargetKind, Workspace};
+use crate::ops::CompileOptions;
+use anyhow::Error;
 use std::fmt;
 use std::path::PathBuf;
 use std::process::{ExitStatus, Output};
 use std::str;
-use anyhow::Error;
-use crate::core::{TargetKind, Workspace};
-use crate::ops::CompileOptions;
 
 pub type CargoResult<T> = anyhow::Result<T>;
 

--- a/src/cargo/util/errors.rs
+++ b/src/cargo/util/errors.rs
@@ -4,18 +4,15 @@ use std::fmt;
 use std::path::PathBuf;
 use std::process::{ExitStatus, Output};
 use std::str;
-
-use clap;
-use failure::{Context, Error, Fail};
-use log::trace;
-
+use anyhow::Error;
 use crate::core::{TargetKind, Workspace};
 use crate::ops::CompileOptions;
 
-pub type CargoResult<T> = failure::Fallible<T>; // Alex's body isn't quite ready to give up "Result"
+pub type CargoResult<T> = anyhow::Result<T>;
 
+// TODO: should delete this trait and just use `with_context` instead
 pub trait CargoResultExt<T, E> {
-    fn chain_err<F, D>(self, f: F) -> Result<T, Context<D>>
+    fn chain_err<F, D>(self, f: F) -> CargoResult<T>
     where
         F: FnOnce() -> D,
         D: fmt::Display + Send + Sync + 'static;
@@ -25,27 +22,32 @@ impl<T, E> CargoResultExt<T, E> for Result<T, E>
 where
     E: Into<Error>,
 {
-    fn chain_err<F, D>(self, f: F) -> Result<T, Context<D>>
+    fn chain_err<F, D>(self, f: F) -> CargoResult<T>
     where
         F: FnOnce() -> D,
         D: fmt::Display + Send + Sync + 'static,
     {
-        self.map_err(|failure| {
-            let err = failure.into();
-            let context = f();
-            trace!("error: {}", err);
-            trace!("\tcontext: {}", context);
-            err.context(context)
-        })
+        self.map_err(|e| e.into().context(f()))
     }
 }
 
-#[derive(Debug, Fail)]
-#[fail(display = "failed to get 200 response from `{}`, got {}", url, code)]
+#[derive(Debug)]
 pub struct HttpNot200 {
     pub code: u32,
     pub url: String,
 }
+
+impl fmt::Display for HttpNot200 {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "failed to get 200 response from `{}`, got {}",
+            self.url, self.code
+        )
+    }
+}
+
+impl std::error::Error for HttpNot200 {}
 
 pub struct Internal {
     inner: Error,
@@ -57,9 +59,9 @@ impl Internal {
     }
 }
 
-impl Fail for Internal {
-    fn cause(&self) -> Option<&dyn Fail> {
-        self.inner.as_fail().cause()
+impl std::error::Error for Internal {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        self.inner.source()
     }
 }
 
@@ -103,9 +105,9 @@ impl ManifestError {
     }
 }
 
-impl Fail for ManifestError {
-    fn cause(&self) -> Option<&dyn Fail> {
-        self.cause.as_fail().cause()
+impl std::error::Error for ManifestError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        self.cause.source()
     }
 }
 
@@ -139,26 +141,40 @@ impl<'a> ::std::iter::FusedIterator for ManifestCauses<'a> {}
 
 // =============================================================================
 // Process errors
-#[derive(Debug, Fail)]
-#[fail(display = "{}", desc)]
+#[derive(Debug)]
 pub struct ProcessError {
     pub desc: String,
     pub exit: Option<ExitStatus>,
     pub output: Option<Output>,
 }
 
+impl fmt::Display for ProcessError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.desc.fmt(f)
+    }
+}
+
+impl std::error::Error for ProcessError {}
+
 // =============================================================================
 // Cargo test errors.
 
 /// Error when testcases fail
-#[derive(Debug, Fail)]
-#[fail(display = "{}", desc)]
+#[derive(Debug)]
 pub struct CargoTestError {
     pub test: Test,
     pub desc: String,
     pub exit: Option<ExitStatus>,
     pub causes: Vec<ProcessError>,
 }
+
+impl fmt::Display for CargoTestError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.desc.fmt(f)
+    }
+}
+
+impl std::error::Error for CargoTestError {}
 
 #[derive(Debug)]
 pub enum Test {
@@ -232,14 +248,17 @@ pub type CliResult = Result<(), CliError>;
 
 #[derive(Debug)]
 pub struct CliError {
-    pub error: Option<failure::Error>,
+    pub error: Option<anyhow::Error>,
     pub unknown: bool,
     pub exit_code: i32,
 }
 
 impl CliError {
-    pub fn new(error: failure::Error, code: i32) -> CliError {
-        let unknown = error.downcast_ref::<Internal>().is_some();
+    pub fn new(error: anyhow::Error, code: i32) -> CliError {
+        // Specifically deref the error to a standard library error to only
+        // check the top-level error to see if it's an `Internal`, we don't want
+        // `anyhow::Error`'s behavior of recursively checking.
+        let unknown = (&*error).downcast_ref::<Internal>().is_some();
         CliError {
             error: Some(error),
             exit_code: code,
@@ -256,8 +275,8 @@ impl CliError {
     }
 }
 
-impl From<failure::Error> for CliError {
-    fn from(err: failure::Error) -> CliError {
+impl From<anyhow::Error> for CliError {
+    fn from(err: anyhow::Error) -> CliError {
         CliError::new(err, 101)
     }
 }
@@ -392,18 +411,10 @@ pub fn is_simple_exit_code(code: i32) -> bool {
     code >= 0 && code <= 127
 }
 
-pub fn internal<S: fmt::Display>(error: S) -> failure::Error {
+pub fn internal<S: fmt::Display>(error: S) -> anyhow::Error {
     _internal(&error)
 }
 
-fn _internal(error: &dyn fmt::Display) -> failure::Error {
-    Internal::new(failure::format_err!("{}", error)).into()
-}
-
-pub fn display_causes(error: &Error) -> String {
-    error
-        .iter_chain()
-        .map(|e| e.to_string())
-        .collect::<Vec<_>>()
-        .join("\n\nCaused by:\n  ")
+fn _internal(error: &dyn fmt::Display) -> anyhow::Error {
+    Internal::new(anyhow::format_err!("{}", error)).into()
 }

--- a/src/cargo/util/flock.rs
+++ b/src/cargo/util/flock.rs
@@ -227,7 +227,7 @@ impl Filesystem {
                     paths::create_dir_all(path.parent().unwrap())?;
                     Ok(opts.open(&path)?)
                 } else {
-                    Err(failure::Error::from(e))
+                    Err(anyhow::Error::from(e))
                 }
             })
             .chain_err(|| format!("failed to open: {}", path.display()))?;
@@ -318,7 +318,7 @@ fn acquire(
 
         Err(e) => {
             if e.raw_os_error() != lock_contended_error().raw_os_error() {
-                let e = failure::Error::from(e);
+                let e = anyhow::Error::from(e);
                 let cx = format!("failed to lock file: {}", path.display());
                 return Err(e.context(cx).into());
             }

--- a/src/cargo/util/important_paths.rs
+++ b/src/cargo/util/important_paths.rs
@@ -13,7 +13,7 @@ pub fn find_root_manifest_for_wd(cwd: &Path) -> CargoResult<PathBuf> {
         }
     }
 
-    failure::bail!(
+    anyhow::bail!(
         "could not find `{}` in `{}` or any parent directory",
         file,
         cwd.display()
@@ -27,6 +27,6 @@ pub fn find_project_manifest_exact(pwd: &Path, file: &str) -> CargoResult<PathBu
     if manifest.exists() {
         Ok(manifest)
     } else {
-        failure::bail!("Could not find `{}` in `{}`", file, pwd.display())
+        anyhow::bail!("Could not find `{}` in `{}`", file, pwd.display())
     }
 }

--- a/src/cargo/util/into_url.rs
+++ b/src/cargo/util/into_url.rs
@@ -12,14 +12,14 @@ pub trait IntoUrl {
 
 impl<'a> IntoUrl for &'a str {
     fn into_url(self) -> CargoResult<Url> {
-        Url::parse(self).map_err(|s| failure::format_err!("invalid url `{}`: {}", self, s))
+        Url::parse(self).map_err(|s| anyhow::format_err!("invalid url `{}`: {}", self, s))
     }
 }
 
 impl<'a> IntoUrl for &'a Path {
     fn into_url(self) -> CargoResult<Url> {
         Url::from_file_path(self)
-            .map_err(|()| failure::format_err!("invalid path url `{}`", self.display()))
+            .map_err(|()| anyhow::format_err!("invalid path url `{}`", self.display()))
     }
 }
 

--- a/src/cargo/util/into_url_with_base.rs
+++ b/src/cargo/util/into_url_with_base.rs
@@ -14,7 +14,7 @@ impl<'a> IntoUrlWithBase for &'a str {
         let base_url = match base {
             Some(base) => Some(
                 base.into_url()
-                    .map_err(|s| failure::format_err!("invalid url `{}`: {}", self, s))?,
+                    .map_err(|s| anyhow::format_err!("invalid url `{}`: {}", self, s))?,
             ),
             None => None,
         };
@@ -22,7 +22,7 @@ impl<'a> IntoUrlWithBase for &'a str {
         Url::options()
             .base_url(base_url.as_ref())
             .parse(self)
-            .map_err(|s| failure::format_err!("invalid url `{}`: {}", self, s))
+            .map_err(|s| anyhow::format_err!("invalid url `{}`: {}", self, s))
     }
 }
 

--- a/src/cargo/util/mod.rs
+++ b/src/cargo/util/mod.rs
@@ -79,7 +79,7 @@ pub fn validate_package_name(name: &str, what: &str, help: &str) -> CargoResult<
         .chars()
         .find(|ch| !ch.is_alphanumeric() && *ch != '_' && *ch != '-')
     {
-        failure::bail!("Invalid character `{}` in {}: `{}`{}", ch, what, name, help);
+        anyhow::bail!("Invalid character `{}` in {}: `{}`{}", ch, what, name, help);
     }
     Ok(())
 }

--- a/src/cargo/util/paths.rs
+++ b/src/cargo/util/paths.rs
@@ -16,12 +16,12 @@ pub fn join_paths<T: AsRef<OsStr>>(paths: &[T], env: &str) -> CargoResult<OsStri
         Err(e) => e,
     };
     let paths = paths.iter().map(Path::new).collect::<Vec<_>>();
-    let err = failure::Error::from(err);
-    let explain = Internal::new(failure::format_err!(
+    let err = anyhow::Error::from(err);
+    let explain = Internal::new(anyhow::format_err!(
         "failed to join path array: {:?}",
         paths
     ));
-    let err = failure::Error::from(err.context(explain));
+    let err = anyhow::Error::from(err.context(explain));
     let more_explain = format!(
         "failed to join search paths together\n\
          Does ${} have an unterminated quote character?",
@@ -91,7 +91,7 @@ pub fn normalize_path(path: &Path) -> PathBuf {
 
 pub fn resolve_executable(exec: &Path) -> CargoResult<PathBuf> {
     if exec.components().count() == 1 {
-        let paths = env::var_os("PATH").ok_or_else(|| failure::format_err!("no PATH"))?;
+        let paths = env::var_os("PATH").ok_or_else(|| anyhow::format_err!("no PATH"))?;
         let candidates = env::split_paths(&paths).flat_map(|path| {
             let candidate = path.join(&exec);
             let with_exe = if env::consts::EXE_EXTENSION == "" {
@@ -109,7 +109,7 @@ pub fn resolve_executable(exec: &Path) -> CargoResult<PathBuf> {
             }
         }
 
-        failure::bail!("no executable for `{}` found in PATH", exec.display())
+        anyhow::bail!("no executable for `{}` found in PATH", exec.display())
     } else {
         Ok(exec.canonicalize()?)
     }
@@ -118,7 +118,7 @@ pub fn resolve_executable(exec: &Path) -> CargoResult<PathBuf> {
 pub fn read(path: &Path) -> CargoResult<String> {
     match String::from_utf8(read_bytes(path)?) {
         Ok(s) => Ok(s),
-        Err(_) => failure::bail!("path at `{}` was not valid utf-8", path.display()),
+        Err(_) => anyhow::bail!("path at `{}` was not valid utf-8", path.display()),
     }
 }
 
@@ -209,7 +209,7 @@ pub fn path2bytes(path: &Path) -> CargoResult<&[u8]> {
 pub fn path2bytes(path: &Path) -> CargoResult<&[u8]> {
     match path.as_os_str().to_str() {
         Some(s) => Ok(s.as_bytes()),
-        None => Err(failure::format_err!(
+        None => Err(anyhow::format_err!(
             "invalid non-unicode path: {}",
             path.display()
         )),
@@ -226,7 +226,7 @@ pub fn bytes2path(bytes: &[u8]) -> CargoResult<PathBuf> {
     use std::str;
     match str::from_utf8(bytes) {
         Ok(s) => Ok(PathBuf::from(s)),
-        Err(..) => Err(failure::format_err!("invalid non-unicode path")),
+        Err(..) => Err(anyhow::format_err!("invalid non-unicode path")),
     }
 }
 

--- a/src/cargo/util/rustc.rs
+++ b/src/cargo/util/rustc.rs
@@ -54,7 +54,7 @@ impl Rustc {
                 .find(|l| l.starts_with("host: "))
                 .map(|l| &l[6..])
                 .ok_or_else(|| {
-                    failure::format_err!(
+                    anyhow::format_err!(
                         "`rustc -vV` didn't have a line for `host:`, got:\n{}",
                         verbose_version
                     )
@@ -250,7 +250,7 @@ fn rustc_fingerprint(path: &Path, rustup_rustc: &Path) -> CargoResult<u64> {
                 .with_extension(env::consts::EXE_EXTENSION);
             paths::mtime(&real_rustc)?.hash(&mut hasher);
         }
-        (true, _, _) => failure::bail!("probably rustup rustc, but without rustup's env vars"),
+        (true, _, _) => anyhow::bail!("probably rustup rustc, but without rustup's env vars"),
         _ => (),
     }
 

--- a/src/cargo/util/to_semver.rs
+++ b/src/cargo/util/to_semver.rs
@@ -15,7 +15,7 @@ impl<'a> ToSemver for &'a str {
     fn to_semver(self) -> CargoResult<Version> {
         match Version::parse(self) {
             Ok(v) => Ok(v),
-            Err(..) => Err(failure::format_err!("cannot parse '{}' as a semver", self)),
+            Err(..) => Err(anyhow::format_err!("cannot parse '{}' as a semver", self)),
         }
     }
 }

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -5,8 +5,8 @@ use std::path::{Path, PathBuf};
 use std::rc::Rc;
 use std::str;
 
+use anyhow::{anyhow, bail};
 use cargo_platform::Platform;
-use failure::bail;
 use log::{debug, trace};
 use semver::{self, VersionReq};
 use serde::de;
@@ -162,7 +162,7 @@ and this will become a hard error in the future.",
         return Ok(ret);
     }
 
-    let first_error = failure::Error::from(first_error);
+    let first_error = anyhow::Error::from(first_error);
     Err(first_error.context("could not parse input as TOML").into())
 }
 
@@ -546,22 +546,22 @@ impl TomlProfile {
             .chars()
             .find(|ch| !ch.is_alphanumeric() && *ch != '_' && *ch != '-')
         {
-            failure::bail!("Invalid character `{}` in {}: `{}`", ch, what, name);
+            bail!("Invalid character `{}` in {}: `{}`", ch, what, name);
         }
 
         match name {
             "package" | "build" => {
-                failure::bail!("Invalid {}: `{}`", what, name);
+                bail!("Invalid {}: `{}`", what, name);
             }
             "debug" if what == "profile" => {
                 if what == "profile name" {
                     // Allowed, but will emit warnings
                 } else {
-                    failure::bail!("Invalid {}: `{}`", what, name);
+                    bail!("Invalid {}: `{}`", what, name);
                 }
             }
             "doc" if what == "dir-name" => {
-                failure::bail!("Invalid {}: `{}`", what, name);
+                bail!("Invalid {}: `{}`", what, name);
             }
             _ => {}
         }
@@ -973,7 +973,7 @@ impl TomlManifest {
         let features = Features::new(cargo_features, &mut warnings)?;
 
         let project = me.project.as_ref().or_else(|| me.package.as_ref());
-        let project = project.ok_or_else(|| failure::format_err!("no `package` section found"))?;
+        let project = project.ok_or_else(|| anyhow!("no `package` section found"))?;
 
         let package_name = project.name.trim();
         if package_name.is_empty() {
@@ -1367,7 +1367,7 @@ impl TomlManifest {
             let mut dep = replacement.to_dependency(spec.name().as_str(), cx, None)?;
             {
                 let version = spec.version().ok_or_else(|| {
-                    failure::format_err!(
+                    anyhow!(
                         "replacements must specify a version \
                          to replace, but `{}` does not",
                         spec

--- a/src/cargo/util/workspace.rs
+++ b/src/cargo/util/workspace.rs
@@ -1,7 +1,7 @@
 use crate::core::{Target, Workspace};
 use crate::ops::CompileOptions;
 use crate::util::CargoResult;
-
+use anyhow::bail;
 use std::fmt::Write;
 
 fn get_available_targets<'a>(
@@ -46,7 +46,7 @@ fn print_available(
             writeln!(output, "    {}", target.name())?;
         }
     }
-    Err(failure::err_msg(output))
+    bail!("{}", output)
 }
 
 pub fn print_available_examples(

--- a/tests/testsuite/config_cli.rs
+++ b/tests/testsuite/config_cli.rs
@@ -275,7 +275,9 @@ fn bad_parse() {
         config.unwrap_err(),
         "\
 failed to parse --config argument `abc`
-expected an equals, found eof at line 1 column 4",
+
+Caused by:
+  expected an equals, found eof at line 1 column 4",
     );
 }
 
@@ -306,8 +308,12 @@ fn bad_cv_convert() {
         config.unwrap_err(),
         "\
 failed to convert --config argument `a=2019-12-01`
-failed to parse key `a`
-found TOML configuration value of unknown type `datetime`",
+
+Caused by:
+  failed to parse key `a`
+
+Caused by:
+  found TOML configuration value of unknown type `datetime`",
     );
 }
 
@@ -323,8 +329,12 @@ fn fail_to_merge_multiple_args() {
         config.unwrap_err(),
         "\
 failed to merge --config argument `foo=['a']`
-failed to merge key `foo` between --config cli option and --config cli option
-failed to merge config value from `--config cli option` into `--config cli option`: \
-expected string, but found array",
+
+Caused by:
+  failed to merge key `foo` between --config cli option and --config cli option
+
+Caused by:
+  failed to merge config value from `--config cli option` into `--config cli option`: \
+  expected string, but found array",
     );
 }

--- a/tests/testsuite/config_include.rs
+++ b/tests/testsuite/config_include.rs
@@ -169,9 +169,15 @@ fn cli_include_failed() {
         &format!(
             "\
 failed to load --config include
-failed to load config include `foobar` from `--config cli option`
-failed to read configuration file `[..]/foobar`
-{}",
+
+Caused by:
+  failed to load config include `foobar` from `--config cli option`
+
+Caused by:
+  failed to read configuration file `[..]/foobar`
+
+Caused by:
+  {}",
             NO_SUCH_FILE_ERR_MSG
         ),
     );
@@ -196,7 +202,9 @@ fn cli_merge_failed() {
         config.unwrap_err(),
         "\
 failed to merge --config key `foo` into `[..]/.cargo/config`
-failed to merge config value from `[..]/.cargo/other` into `[..]/.cargo/config`: \
-expected array, but found string",
+
+Caused by:
+  failed to merge config value from `[..]/.cargo/other` into `[..]/.cargo/config`: \
+  expected array, but found string",
     );
 }

--- a/tests/testsuite/workspaces.rs
+++ b/tests/testsuite/workspaces.rs
@@ -1065,10 +1065,8 @@ fn new_warning_with_corrupt_ws() {
 failed to parse manifest at `[..]foo/Cargo.toml`
 
 Caused by:
-  could not parse input as TOML
-
-Caused by:
-  expected an equals, found eof at line 1 column 5
+    0: could not parse input as TOML
+    1: expected an equals, found eof at line 1 column 5
      Created binary (application) `bar` package
 ",
         )


### PR DESCRIPTION
The `anyhow` crate interoperates with the `std::error::Error` trait
rather than a custom `Fail` trait, and this is the general trend of
error handling in Rust as well.

Note that this is mostly mechanical (sed) and intended to get the test
suite passing. As usual there's still more idiomatic cleanup that can
happen, but that's left to later commits.