### PR TITLE
Fix .gitignore of Cargo.lock in a subdirectory.

### DIFF
--- a/src/cargo/ops/cargo_package.rs
+++ b/src/cargo/ops/cargo_package.rs
@@ -299,7 +299,9 @@ fn check_repo_state(
                 if let Ok(status) = repo.status_file(relative) {
                     if status == git2::Status::CURRENT {
                         false
-                    } else if relative.to_str().unwrap_or("") == "Cargo.lock" {
+                    } else if relative.file_name().and_then(|s| s.to_str()).unwrap_or("")
+                        == "Cargo.lock"
+                    {
                         // It is OK to include this file even if it is ignored.
                         status != git2::Status::IGNORED
                     } else {


### PR DESCRIPTION
The code for checking if `Cargo.lock` is ignored was erroneously assuming it was at the root of the git repo.  This would cause a problem if `Cargo.lock` is in `.gitignore` in a subdirectory.

Fixes issue noted in https://github.com/rust-lang/cargo/issues/7705#issuecomment-572027382
