### PR TITLE
Add another curl spurious network error

### DIFF
--- a/src/cargo/util/network.rs
+++ b/src/cargo/util/network.rs
@@ -52,6 +52,7 @@ fn maybe_spurious(err: &Error) -> bool {
                 || curl_err.is_recv_error()
                 || curl_err.is_http2_stream_error()
                 || curl_err.is_ssl_connect_error()
+                || curl_err.is_partial_file()
             {
                 return true;
             }


### PR DESCRIPTION
Witnessed in a [recent build][1] looks like this is another error that
should be safe to retry.

[1]: https://github.com/bytecodealliance/wasmtime/pull/788/checks?check_run_id=383658098#step:7:16