### PR TITLE
Rename `Kind`

### DIFF
--- a/crates/resolver-tests/src/lib.rs
+++ b/crates/resolver-tests/src/lib.rs
@@ -10,7 +10,7 @@ use std::fmt::Write;
 use std::rc::Rc;
 use std::time::Instant;
 
-use cargo::core::dependency::Kind;
+use cargo::core::dependency::DepKind;
 use cargo::core::resolver::{self, ResolveOpts};
 use cargo::core::source::{GitReference, SourceId};
 use cargo::core::Resolve;
@@ -629,7 +629,7 @@ pub fn dep(name: &str) -> Dependency {
 pub fn dep_req(name: &str, req: &str) -> Dependency {
     Dependency::parse_no_deprecated(name, Some(req), registry_loc()).unwrap()
 }
-pub fn dep_req_kind(name: &str, req: &str, kind: Kind, public: bool) -> Dependency {
+pub fn dep_req_kind(name: &str, req: &str, kind: DepKind, public: bool) -> Dependency {
     let mut dep = dep_req(name, req);
     dep.set_kind(kind);
     dep.set_public(public);
@@ -642,7 +642,7 @@ pub fn dep_loc(name: &str, location: &str) -> Dependency {
     let source_id = SourceId::for_git(&url, master).unwrap();
     Dependency::parse_no_deprecated(name, Some("1.0.0"), source_id).unwrap()
 }
-pub fn dep_kind(name: &str, kind: Kind) -> Dependency {
+pub fn dep_kind(name: &str, kind: DepKind) -> Dependency {
     dep(name).set_kind(kind).clone()
 }
 
@@ -677,12 +677,12 @@ impl fmt::Debug for PrettyPrintRegistry {
             } else {
                 write!(f, "pkg!((\"{}\", \"{}\") => [", s.name(), s.version())?;
                 for d in s.dependencies() {
-                    if d.kind() == Kind::Normal
+                    if d.kind() == DepKind::Normal
                         && &d.version_req().to_string() == "*"
                         && !d.is_public()
                     {
                         write!(f, "dep(\"{}\"),", d.name_in_toml())?;
-                    } else if d.kind() == Kind::Normal && !d.is_public() {
+                    } else if d.kind() == DepKind::Normal && !d.is_public() {
                         write!(
                             f,
                             "dep_req(\"{}\", \"{}\"),",
@@ -696,9 +696,9 @@ impl fmt::Debug for PrettyPrintRegistry {
                             d.name_in_toml(),
                             d.version_req(),
                             match d.kind() {
-                                Kind::Development => "Kind::Development",
-                                Kind::Build => "Kind::Build",
-                                Kind::Normal => "Kind::Normal",
+                                DepKind::Development => "DepKind::Development",
+                                DepKind::Build => "DepKind::Build",
+                                DepKind::Normal => "DepKind::Normal",
                             },
                             d.is_public()
                         )?;
@@ -725,8 +725,8 @@ fn meta_test_deep_pretty_print_registry() {
                 pkg!(("bar", "2.0.0") => [dep_req("baz", "=1.0.1")]),
                 pkg!(("baz", "1.0.2") => [dep_req("other", "2")]),
                 pkg!(("baz", "1.0.1")),
-                pkg!(("cat", "1.0.2") => [dep_req_kind("other", "2", Kind::Build, false)]),
-                pkg!(("cat", "1.0.3") => [dep_req_kind("other", "2", Kind::Development, false)]),
+                pkg!(("cat", "1.0.2") => [dep_req_kind("other", "2", DepKind::Build, false)]),
+                pkg!(("cat", "1.0.3") => [dep_req_kind("other", "2", DepKind::Development, false)]),
                 pkg!(("dep_req", "1.0.0")),
                 pkg!(("dep_req", "2.0.0")),
             ])
@@ -738,8 +738,8 @@ fn meta_test_deep_pretty_print_registry() {
          pkg!((\"bar\", \"2.0.0\") => [dep_req(\"baz\", \"= 1.0.1\"),]),\
          pkg!((\"baz\", \"1.0.2\") => [dep_req(\"other\", \"^2\"),]),\
          pkg!((\"baz\", \"1.0.1\")),\
-         pkg!((\"cat\", \"1.0.2\") => [dep_req_kind(\"other\", \"^2\", Kind::Build, false),]),\
-         pkg!((\"cat\", \"1.0.3\") => [dep_req_kind(\"other\", \"^2\", Kind::Development, false),]),\
+         pkg!((\"cat\", \"1.0.2\") => [dep_req_kind(\"other\", \"^2\", DepKind::Build, false),]),\
+         pkg!((\"cat\", \"1.0.3\") => [dep_req_kind(\"other\", \"^2\", DepKind::Development, false),]),\
          pkg!((\"dep_req\", \"1.0.0\")),\
          pkg!((\"dep_req\", \"2.0.0\")),]"
     )
@@ -848,10 +848,10 @@ pub fn registry_strategy(
                             format!(">={}, <={}", s[c].0, s[d].0)
                         },
                         match k {
-                            0 => Kind::Normal,
-                            1 => Kind::Build,
-                            // => Kind::Development, // Development has no impact so don't gen
-                            _ => panic!("bad index for Kind"),
+                            0 => DepKind::Normal,
+                            1 => DepKind::Build,
+                            // => DepKind::Development, // Development has no impact so don't gen
+                            _ => panic!("bad index for DepKind"),
                         },
                         p && k == 0,
                     ))

--- a/crates/resolver-tests/tests/resolve.rs
+++ b/crates/resolver-tests/tests/resolve.rs
@@ -1,4 +1,4 @@
-use cargo::core::dependency::Kind;
+use cargo::core::dependency::DepKind;
 use cargo::core::{enable_nightly_features, Dependency};
 use cargo::util::{is_ci, Config};
 
@@ -232,7 +232,7 @@ fn pub_fail() {
     let input = vec![
         pkg!(("a", "0.0.4")),
         pkg!(("a", "0.0.5")),
-        pkg!(("e", "0.0.6") => [dep_req_kind("a", "<= 0.0.4", Kind::Normal, true),]),
+        pkg!(("e", "0.0.6") => [dep_req_kind("a", "<= 0.0.4", DepKind::Normal, true),]),
         pkg!(("kB", "0.0.3") => [dep_req("a", ">= 0.0.5"),dep("e"),]),
     ];
     let reg = registry(input);
@@ -244,7 +244,7 @@ fn basic_public_dependency() {
     let reg = registry(vec![
         pkg!(("A", "0.1.0")),
         pkg!(("A", "0.2.0")),
-        pkg!("B" => [dep_req_kind("A", "0.1", Kind::Normal, true)]),
+        pkg!("B" => [dep_req_kind("A", "0.1", DepKind::Normal, true)]),
         pkg!("C" => [dep("A"), dep("B")]),
     ]);
 
@@ -279,7 +279,7 @@ fn public_dependency_filling_in() {
         pkg!(("a", "0.1.1")),
         pkg!(("b", "0.0.0") => [dep("bad")]),
         pkg!(("b", "0.0.1") => [dep("bad")]),
-        pkg!(("b", "0.0.2") => [dep_req_kind("a", "=0.0.6", Kind::Normal, true)]),
+        pkg!(("b", "0.0.2") => [dep_req_kind("a", "=0.0.6", DepKind::Normal, true)]),
         pkg!("c" => [dep_req("b", ">=0.0.1")]),
         pkg!("d" => [dep("c"), dep("a"), dep("b")]),
     ]);
@@ -315,7 +315,7 @@ fn public_dependency_filling_in_and_update() {
     let reg = registry(vec![
         pkg!(("A", "0.0.0")),
         pkg!(("A", "0.0.2")),
-        pkg!("B" => [dep_req_kind("A", "=0.0.0", Kind::Normal, true),]),
+        pkg!("B" => [dep_req_kind("A", "=0.0.0", DepKind::Normal, true),]),
         pkg!("C" => [dep("A"),dep("B")]),
         pkg!("D" => [dep("B"),dep("C")]),
     ]);
@@ -341,7 +341,7 @@ fn public_dependency_skipping() {
         pkg!(("a", "0.2.0")),
         pkg!(("a", "2.0.0")),
         pkg!(("b", "0.0.0") => [dep("bad")]),
-        pkg!(("b", "0.2.1") => [dep_req_kind("a", "0.2.0", Kind::Normal, true)]),
+        pkg!(("b", "0.2.1") => [dep_req_kind("a", "0.2.0", DepKind::Normal, true)]),
         pkg!("c" => [dep("a"),dep("b")]),
     ];
     let reg = registry(input);
@@ -361,7 +361,7 @@ fn public_dependency_skipping_in_backtracking() {
         pkg!(("A", "0.0.3") => [dep("bad")]),
         pkg!(("A", "0.0.4")),
         pkg!(("A", "0.0.5")),
-        pkg!("B" => [dep_req_kind("A", ">= 0.0.3", Kind::Normal, true)]),
+        pkg!("B" => [dep_req_kind("A", ">= 0.0.3", DepKind::Normal, true)]),
         pkg!("C" => [dep_req("A", "<= 0.0.4"), dep("B")]),
     ];
     let reg = registry(input);
@@ -374,9 +374,9 @@ fn public_sat_topological_order() {
     let input = vec![
         pkg!(("a", "0.0.1")),
         pkg!(("a", "0.0.0")),
-        pkg!(("b", "0.0.1") => [dep_req_kind("a", "= 0.0.1", Kind::Normal, true),]),
+        pkg!(("b", "0.0.1") => [dep_req_kind("a", "= 0.0.1", DepKind::Normal, true),]),
         pkg!(("b", "0.0.0") => [dep("bad"),]),
-        pkg!("A" => [dep_req("a", "= 0.0.0"),dep_req_kind("b", "*", Kind::Normal, true)]),
+        pkg!("A" => [dep_req("a", "= 0.0.0"),dep_req_kind("b", "*", DepKind::Normal, true)]),
     ];
 
     let reg = registry(input);
@@ -388,7 +388,7 @@ fn public_sat_unused_makes_things_pub() {
     let input = vec![
         pkg!(("a", "0.0.1")),
         pkg!(("a", "0.0.0")),
-        pkg!(("b", "8.0.1") => [dep_req_kind("a", "= 0.0.1", Kind::Normal, true),]),
+        pkg!(("b", "8.0.1") => [dep_req_kind("a", "= 0.0.1", DepKind::Normal, true),]),
         pkg!(("b", "8.0.0") => [dep_req("a", "= 0.0.1"),]),
         pkg!("c" => [dep_req("b", "= 8.0.0"),dep_req("a", "= 0.0.0"),]),
     ];
@@ -403,8 +403,8 @@ fn public_sat_unused_makes_things_pub_2() {
         pkg!(("c", "0.0.2")),
         pkg!(("c", "0.0.1")),
         pkg!(("a-sys", "0.0.2")),
-        pkg!(("a-sys", "0.0.1") => [dep_req_kind("c", "= 0.0.1", Kind::Normal, true),]),
-        pkg!("P" => [dep_req_kind("a-sys", "*", Kind::Normal, true),dep_req("c", "= 0.0.1"),]),
+        pkg!(("a-sys", "0.0.1") => [dep_req_kind("c", "= 0.0.1", DepKind::Normal, true),]),
+        pkg!("P" => [dep_req_kind("a-sys", "*", DepKind::Normal, true),dep_req("c", "= 0.0.1"),]),
         pkg!("A" => [dep("P"),dep_req("c", "= 0.0.2"),]),
     ];
     let reg = registry(input);
@@ -492,13 +492,17 @@ fn test_resolving_with_same_name() {
 #[test]
 fn test_resolving_with_dev_deps() {
     let reg = registry(vec![
-        pkg!("foo" => ["bar", dep_kind("baz", Kind::Development)]),
-        pkg!("baz" => ["bat", dep_kind("bam", Kind::Development)]),
+        pkg!("foo" => ["bar", dep_kind("baz", DepKind::Development)]),
+        pkg!("baz" => ["bat", dep_kind("bam", DepKind::Development)]),
         pkg!("bar"),
         pkg!("bat"),
     ]);
 
-    let res = resolve(vec![dep("foo"), dep_kind("baz", Kind::Development)], &reg).unwrap();
+    let res = resolve(
+        vec![dep("foo"), dep_kind("baz", DepKind::Development)],
+        &reg,
+    )
+    .unwrap();
 
     assert_same(&res, &names(&["root", "foo", "bar", "baz", "bat"]));
 }
@@ -1061,7 +1065,7 @@ fn resolving_with_public_constrained_sibling() {
                                   dep_req("backtrack_trap1", "1.0"),
                                   dep_req("backtrack_trap2", "1.0"),
                                   dep_req("constrained", "<=60")]),
-        pkg!(("bar", "1.0.0") => [dep_req_kind("constrained", ">=60", Kind::Normal, true)]),
+        pkg!(("bar", "1.0.0") => [dep_req_kind("constrained", ">=60", DepKind::Normal, true)]),
     ];
     // Bump these to make the test harder, but you'll also need to
     // change the version constraints on `constrained` above. To correctly

--- a/src/cargo/core/compiler/unit_dependencies.rs
+++ b/src/cargo/core/compiler/unit_dependencies.rs
@@ -17,7 +17,7 @@
 
 use crate::core::compiler::Unit;
 use crate::core::compiler::{BuildContext, CompileKind, CompileMode};
-use crate::core::dependency::Kind as DepKind;
+use crate::core::dependency::DepKind;
 use crate::core::package::Downloads;
 use crate::core::profiles::{Profile, UnitFor};
 use crate::core::resolver::Resolve;

--- a/src/cargo/core/resolver/resolve.rs
+++ b/src/cargo/core/resolver/resolve.rs
@@ -4,7 +4,7 @@ use std::collections::{HashMap, HashSet};
 use std::fmt;
 use std::iter::FromIterator;
 
-use crate::core::dependency::Kind;
+use crate::core::dependency::DepKind;
 use crate::core::{Dependency, PackageId, PackageIdSpec, Summary, Target};
 use crate::util::errors::CargoResult;
 use crate::util::Graph;
@@ -87,7 +87,7 @@ impl Resolve {
                     .edges(p)
                     .filter(|(_, deps)| {
                         deps.iter()
-                            .any(|d| d.kind() == Kind::Normal && d.is_public())
+                            .any(|d| d.kind() == DepKind::Normal && d.is_public())
                     })
                     .map(|(dep_package, _)| *dep_package)
                     .collect::<HashSet<PackageId>>();

--- a/src/cargo/ops/cargo_output_metadata.rs
+++ b/src/cargo/ops/cargo_output_metadata.rs
@@ -90,7 +90,7 @@ struct Dep {
 
 #[derive(Serialize, PartialEq, Eq, PartialOrd, Ord)]
 struct DepKindInfo {
-    kind: dependency::Kind,
+    kind: dependency::DepKind,
     target: Option<Platform>,
 }
 

--- a/src/cargo/ops/registry.rs
+++ b/src/cargo/ops/registry.rs
@@ -12,7 +12,7 @@ use curl::easy::{Easy, InfoType, SslOpt, SslVersion};
 use log::{log, Level};
 use percent_encoding::{percent_encode, NON_ALPHANUMERIC};
 
-use crate::core::dependency::Kind;
+use crate::core::dependency::DepKind;
 use crate::core::manifest::ManifestMetadata;
 use crate::core::source::Source;
 use crate::core::{Package, SourceId, Workspace};
@@ -203,9 +203,9 @@ fn transmit(
                 version_req: dep.version_req().to_string(),
                 target: dep.platform().map(|s| s.to_string()),
                 kind: match dep.kind() {
-                    Kind::Normal => "normal",
-                    Kind::Build => "build",
-                    Kind::Development => "dev",
+                    DepKind::Normal => "normal",
+                    DepKind::Build => "build",
+                    DepKind::Development => "dev",
                 }
                 .to_string(),
                 registry: dep_registry,

--- a/src/cargo/sources/registry/mod.rs
+++ b/src/cargo/sources/registry/mod.rs
@@ -171,7 +171,7 @@ use semver::{Version, VersionReq};
 use serde::Deserialize;
 use tar::Archive;
 
-use crate::core::dependency::{Dependency, Kind};
+use crate::core::dependency::{DepKind, Dependency};
 use crate::core::source::MaybePackage;
 use crate::core::{InternedString, Package, PackageId, Source, SourceId, Summary};
 use crate::sources::PathSource;
@@ -316,9 +316,9 @@ impl<'a> RegistryDependency<'a> {
             dep.set_explicit_name_in_toml(name);
         }
         let kind = match kind.as_ref().map(|s| &s[..]).unwrap_or("") {
-            "dev" => Kind::Development,
-            "build" => Kind::Build,
-            _ => Kind::Normal,
+            "dev" => DepKind::Development,
+            "build" => DepKind::Build,
+            _ => DepKind::Normal,
         };
 
         let platform = match target {

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -14,7 +14,7 @@ use serde::ser;
 use serde::{Deserialize, Serialize};
 use url::Url;
 
-use crate::core::dependency::Kind;
+use crate::core::dependency::DepKind;
 use crate::core::manifest::{LibKind, ManifestMetadata, TargetSourcePath, Warnings};
 use crate::core::profiles::Profiles;
 use crate::core::{Dependency, InternedString, Manifest, PackageId, Summary, Target};
@@ -1057,7 +1057,7 @@ impl TomlManifest {
             fn process_dependencies(
                 cx: &mut Context<'_, '_>,
                 new_deps: Option<&BTreeMap<String, TomlDependency>>,
-                kind: Option<Kind>,
+                kind: Option<DepKind>,
             ) -> CargoResult<()> {
                 let dependencies = match new_deps {
                     Some(dependencies) => dependencies,
@@ -1077,12 +1077,12 @@ impl TomlManifest {
                 .dev_dependencies
                 .as_ref()
                 .or_else(|| me.dev_dependencies2.as_ref());
-            process_dependencies(&mut cx, dev_deps, Some(Kind::Development))?;
+            process_dependencies(&mut cx, dev_deps, Some(DepKind::Development))?;
             let build_deps = me
                 .build_dependencies
                 .as_ref()
                 .or_else(|| me.build_dependencies2.as_ref());
-            process_dependencies(&mut cx, build_deps, Some(Kind::Build))?;
+            process_dependencies(&mut cx, build_deps, Some(DepKind::Build))?;
 
             for (name, platform) in me.target.iter().flatten() {
                 cx.platform = {
@@ -1095,12 +1095,12 @@ impl TomlManifest {
                     .build_dependencies
                     .as_ref()
                     .or_else(|| platform.build_dependencies2.as_ref());
-                process_dependencies(&mut cx, build_deps, Some(Kind::Build))?;
+                process_dependencies(&mut cx, build_deps, Some(DepKind::Build))?;
                 let dev_deps = platform
                     .dev_dependencies
                     .as_ref()
                     .or_else(|| platform.dev_dependencies2.as_ref());
-                process_dependencies(&mut cx, dev_deps, Some(Kind::Development))?;
+                process_dependencies(&mut cx, dev_deps, Some(DepKind::Development))?;
             }
 
             replace = me.replace(&mut cx)?;
@@ -1450,7 +1450,7 @@ impl TomlDependency {
         &self,
         name: &str,
         cx: &mut Context<'_, '_>,
-        kind: Option<Kind>,
+        kind: Option<DepKind>,
     ) -> CargoResult<Dependency> {
         match *self {
             TomlDependency::Simple(ref version) => DetailedTomlDependency {
@@ -1475,7 +1475,7 @@ impl DetailedTomlDependency {
         &self,
         name_in_toml: &str,
         cx: &mut Context<'_, '_>,
-        kind: Option<Kind>,
+        kind: Option<DepKind>,
     ) -> CargoResult<Dependency> {
         if self.version.is_none() && self.path.is_none() && self.git.is_none() {
             let msg = format!(
@@ -1635,7 +1635,7 @@ impl DetailedTomlDependency {
         if let Some(p) = self.public {
             cx.features.require(Feature::public_dependency())?;
 
-            if dep.kind() != Kind::Normal {
+            if dep.kind() != DepKind::Normal {
                 bail!("'public' specifier can only be used on regular dependencies, not {:?} dependencies", dep.kind());
             }
 


### PR DESCRIPTION
Rename `dependency::Kind` → `dependency::DepKind`
Rename `source_id::Kind` → `source_id::SourceKind`

I struggle when there are multiple types with the same name in the same code base. I think this makes it a little clearer what the type is.

I was tempted to also rename `registry::Kind`, but I could not think of a good name. That file is particularly hard for me to understand (locked vs normal sources, abstract trait, etc.), so I don't feel comfortable changing it. It's also localized in one file, so not as important.
