### PR TITLE
Fix wrong directories in host_libdir.

### DIFF
--- a/src/cargo/core/compiler/compilation.rs
+++ b/src/cargo/core/compiler/compilation.rs
@@ -101,7 +101,7 @@ impl<'cfg> Compilation<'cfg> {
             root_output: PathBuf::from("/"),
             deps_output: PathBuf::from("/"),
             host_deps_output: PathBuf::from("/"),
-            host_dylib_path: bcx.info(default_kind).sysroot_host_libdir.clone(),
+            host_dylib_path: bcx.info(CompileKind::Host).sysroot_host_libdir.clone(),
             target_dylib_path: bcx.info(default_kind).sysroot_target_libdir.clone(),
             tests: Vec::new(),
             binaries: Vec::new(),


### PR DESCRIPTION
This fixes a regression from #7482 where the sysroot_target_libdir leaks into the host libdir. This can cause problems when the dynamic linker does not ignore the target libraries but tries to load them instead. This happens for example when building on x86_64-musl for aarch64-musl.