### PR TITLE
Don't assume iowait always increases on Linux

### DIFF
--- a/src/cargo/util/cpu.rs
+++ b/src/cargo/util/cpu.rs
@@ -72,7 +72,7 @@ mod imp {
         let nice = next.nice - prev.nice;
         let system = next.system - prev.system;
         let idle = next.idle - prev.idle;
-        let iowait = next.iowait - prev.iowait;
+        let iowait = next.iowait.checked_sub(prev.iowait).unwrap_or(0);
         let irq = next.irq - prev.irq;
         let softirq = next.softirq - prev.softirq;
         let steal = next.steal - prev.steal;


### PR DESCRIPTION
According to [documentation] looks like this value is documented as it
can decrease, so let's handle that without overflowing.

[documentation]: http://man7.org/linux/man-pages/man5/proc.5.html