### PR TITLE
Enable binary crates as dependencies

### DIFF
--- a/src/cargo/core/compiler/unit_dependencies.rs
+++ b/src/cargo/core/compiler/unit_dependencies.rs
@@ -266,7 +266,7 @@ fn compute_deps<'a, 'cfg>(
             Some(pkg) => pkg,
             None => continue,
         };
-        let lib = match pkg.targets().iter().find(|t| t.is_lib()) {
+        let lib = match pkg.targets().iter().find(|t| t.is_lib() || t.is_bin()) {
             Some(t) => t,
             None => continue,
         };

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -2194,8 +2194,6 @@ fn rebuild_preserves_out_dir() {
 
 #[cargo_test]
 fn dep_no_libs() {
-    let exe_name = format!("bar{}", env::consts::EXE_SUFFIX);
-
     let foo = project()
         .file(
             "Cargo.toml",
@@ -2211,11 +2209,17 @@ fn dep_no_libs() {
         )
         .file("src/lib.rs", "pub fn bar() -> i32 { 1 }")
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.0.0"))
-        .file("bar/src/main.rs", "fn main() {}")
+        .file("bar/src/bin/baz.rs", "fn main() {}")
+        .file("bar/src/bin/qux.rs", "fn main() {}")
         .build();
 
     foo.cargo("build").run();
-    assert!(foo.target_debug_dir().join(exe_name).exists());
+
+    let baz = format!("baz{}", env::consts::EXE_SUFFIX);
+    assert!(foo.target_debug_dir().join(baz).exists());
+
+    let qux = format!("qux{}", env::consts::EXE_SUFFIX);
+    assert!(foo.target_debug_dir().join(qux).exists());
 }
 
 #[cargo_test]
@@ -3400,8 +3404,8 @@ fn build_all_workspace_implicit_examples() {
     assert!(!p.bin("b").is_file());
     assert!(p.bin("examples/c").is_file());
     assert!(p.bin("examples/d").is_file());
-    assert!(!p.bin("e").is_file());
-    assert!(!p.bin("f").is_file());
+    assert!(p.bin("e").is_file());
+    assert!(p.bin("f").is_file());
     assert!(p.bin("examples/g").is_file());
     assert!(p.bin("examples/h").is_file());
 }

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -2194,6 +2194,8 @@ fn rebuild_preserves_out_dir() {
 
 #[cargo_test]
 fn dep_no_libs() {
+    let exe_name = format!("bar{}", env::consts::EXE_SUFFIX);
+
     let foo = project()
         .file(
             "Cargo.toml",
@@ -2209,9 +2211,11 @@ fn dep_no_libs() {
         )
         .file("src/lib.rs", "pub fn bar() -> i32 { 1 }")
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.0.0"))
-        .file("bar/src/main.rs", "")
+        .file("bar/src/main.rs", "fn main() {}")
         .build();
+
     foo.cargo("build").run();
+    assert!(foo.target_debug_dir().join(exe_name).exists());
 }
 
 #[cargo_test]

--- a/tests/testsuite/test.rs
+++ b/tests/testsuite/test.rs
@@ -1688,9 +1688,13 @@ fn selective_testing() {
 
     println!("whole");
     p.cargo("test")
+        // NOTE: The compilation order appears to be unpredictable.
+        // Therefore, the test will sporadically fail. How do I solve for this?
+        // I've tried reducing parallelism to 1 without success.
         .with_stderr(
-            "\
-[COMPILING] foo v0.0.1 ([CWD])
+"   Compiling d2 v0.0.1 ([CWD]/d2)
+   Compiling d1 v0.0.1 ([CWD]/d1)
+   Compiling foo v0.0.1 ([CWD])
 [FINISHED] test [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target/debug/deps/foo-[..][EXE]",
         )

--- a/tests/testsuite/workspaces.rs
+++ b/tests/testsuite/workspaces.rs
@@ -179,7 +179,7 @@ fn inferred_path_dep() {
 
     p.cargo("build").run();
     assert!(p.bin("foo").is_file());
-    assert!(!p.bin("bar").is_file());
+    assert!(p.bin("bar").is_file());
 
     p.cargo("build").cwd("bar").run();
     assert!(p.bin("foo").is_file());
@@ -228,13 +228,13 @@ fn transitive_path_dep() {
 
     p.cargo("build").run();
     assert!(p.bin("foo").is_file());
-    assert!(!p.bin("bar").is_file());
-    assert!(!p.bin("baz").is_file());
+    assert!(p.bin("bar").is_file());
+    assert!(p.bin("baz").is_file());
 
     p.cargo("build").cwd("bar").run();
     assert!(p.bin("foo").is_file());
     assert!(p.bin("bar").is_file());
-    assert!(!p.bin("baz").is_file());
+    assert!(p.bin("baz").is_file());
 
     p.cargo("build").cwd("baz").run();
     assert!(p.bin("foo").is_file());


### PR DESCRIPTION
This is useful in a variety of situations such as:
  * Embedding one binary into another (i.e. BIOS, kernel)
  * Testing using a third-party utility (i.e. nc)

Fixes #4316.