### PR TITLE
Add rustc-bin-link-arg and rustc-link-arg custom build options

### DIFF
--- a/src/cargo/core/compiler/custom_build.rs
+++ b/src/cargo/core/compiler/custom_build.rs
@@ -1,5 +1,5 @@
 use super::job::{Freshness, Job, Work};
-use super::{fingerprint, CompileKind, Context, Unit};
+use super::{fingerprint, CompileKind, Context, LinkType, Unit};
 use crate::core::compiler::job_queue::JobState;
 use crate::core::{profiles::ProfileRoot, PackageId};
 use crate::util::errors::{CargoResult, CargoResultExt};
@@ -20,7 +20,7 @@ pub struct BuildOutput {
     /// Names and link kinds of libraries, suitable for the `-l` flag.
     pub library_links: Vec<String>,
     /// Linker arguments suitable to be passed to `-C link-arg=<args>`
-    pub linker_args: Vec<String>,
+    pub linker_args: Vec<(Option<LinkType>, String)>,
     /// Various `--cfg` flags to pass to the compiler.
     pub cfgs: Vec<String>,
     /// Additional environment variables to run the compiler with.
@@ -478,7 +478,9 @@ impl BuildOutput {
                 }
                 "rustc-link-lib" => library_links.push(value.to_string()),
                 "rustc-link-search" => library_paths.push(PathBuf::from(value)),
-                "rustc-cdylib-link-arg" => linker_args.push(value.to_string()),
+                "rustc-cdylib-link-arg" => linker_args.push((Some(LinkType::Cdylib), value)),
+                "rustc-bin-link-arg" => linker_args.push((Some(LinkType::Bin), value)),
+                "rustc-link-arg" => linker_args.push((None, value)),
                 "rustc-cfg" => cfgs.push(value.to_string()),
                 "rustc-env" => env.push(BuildOutput::parse_rustc_env(&value, &whence)?),
                 "warning" => warnings.push(value.to_string()),

--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -342,6 +342,7 @@ pub struct CliUnstable {
     pub doctest_xcompile: bool,
     pub panic_abort_tests: bool,
     pub jobserver_per_rustc: bool,
+    pub extra_link_arg: bool,
 }
 
 impl CliUnstable {
@@ -411,6 +412,7 @@ impl CliUnstable {
             "doctest-xcompile" => self.doctest_xcompile = parse_empty(k, v)?,
             "panic-abort-tests" => self.panic_abort_tests = parse_empty(k, v)?,
             "jobserver-per-rustc" => self.jobserver_per_rustc = parse_empty(k, v)?,
+            "extra-link-arg" => self.extra_link_arg = parse_empty(k, v)?,
             _ => bail!("unknown `-Z` flag specified: {}", k),
         }
 

--- a/src/cargo/util/config/target.rs
+++ b/src/cargo/util/config/target.rs
@@ -1,5 +1,5 @@
 use super::{Config, ConfigKey, ConfigRelativePath, OptValue, PathAndArgs, StringList, CV};
-use crate::core::compiler::BuildOutput;
+use crate::core::compiler::{BuildOutput, LinkType};
 use crate::util::CargoResult;
 use serde::Deserialize;
 use std::collections::{BTreeMap, HashMap};
@@ -131,7 +131,18 @@ fn parse_links_overrides(
                 }
                 "rustc-cdylib-link-arg" => {
                     let args = value.list(key)?;
-                    output.linker_args.extend(args.iter().map(|v| v.0.clone()));
+                    let args = args.iter().map(|v| (Some(LinkType::Cdylib), v.0.clone()));
+                    output.linker_args.extend(args);
+                }
+                "rustc-bin-link-arg" => {
+                    let args = value.list(key)?;
+                    let args = args.iter().map(|v| (Some(LinkType::Bin), v.0.clone()));
+                    output.linker_args.extend(args);
+                }
+                "rustc-link-arg" => {
+                    let args = value.list(key)?;
+                    let args = args.iter().map(|v| (None, v.0.clone()));
+                    output.linker_args.extend(args);
                 }
                 "rustc-cfg" => {
                     let list = value.list(key)?;

--- a/src/doc/src/reference/build-scripts.md
+++ b/src/doc/src/reference/build-scripts.md
@@ -105,6 +105,10 @@ one detailed below.
 * [`cargo:rustc-env=VAR=VALUE`](#rustc-env) — Sets an environment variable.
 * [`cargo:rustc-cdylib-link-arg=FLAG`](#rustc-cdylib-link-arg) — Passes custom
   flags to a linker for cdylib crates.
+* [`cargo:rustc-bin-link-arg=FLAG`](#rustc-bin-link-arg) — Passes custom
+  flags to a linker for bin crates.
+* [`cargo:rustc-link-arg=FLAG`](#rustc-link-arg) — Passes custom
+  flags to a linker for all supported crates.
 * [`cargo:warning=MESSAGE`](#cargo-warning) — Displays a warning on the
   terminal.
 * [`cargo:KEY=VALUE`](#the-links-manifest-key) — Metadata, used by `links`
@@ -202,6 +206,26 @@ The `rustc-cdylib-link-arg` instruction tells Cargo to pass the [`-C
 link-arg=FLAG` option][link-arg] to the compiler, but only when building a
 `cdylib` library target. Its usage is highly platform specific. It is useful
 to set the shared library version or the runtime-path.
+
+[link-arg]: ../../rustc/codegen-options/index.md#link-arg
+
+<a id="rustc-bin-link-arg"></a>
+#### `cargo:rustc-bin-link-arg=FLAG`
+
+The `rustc-bin-link-arg` instruction tells Cargo to pass the [`-C
+link-arg=FLAG` option][link-arg] to the compiler, but only when building a
+binary target. Its usage is highly platform specific. It is useful
+to set a linker script or other linker options.
+
+[link-arg]: ../../rustc/codegen-options/index.md#link-arg
+
+<a id="rustc-link-arg"></a>
+#### `cargo:rustc-link-arg=FLAG`
+
+The `rustc-link-arg` instruction tells Cargo to pass the [`-C link-arg=FLAG`
+option][link-arg] to the compiler, but only when building a supported target
+(currently a binary or `cdylib` library). Its usage is highly platform
+specific. It is useful to set the shared library version or linker script.
 
 [link-arg]: ../../rustc/codegen-options/index.md#link-arg
 
@@ -372,6 +396,8 @@ rustc-flags = "-L /some/path"
 rustc-cfg = ['key="value"']
 rustc-env = {key = "value"}
 rustc-cdylib-link-arg = ["…"]
+rustc-bin-link-arg = ["…"]
+rustc-link-arg = ["…"]
 metadata_key1 = "value"
 metadata_key2 = "value"
 ```


### PR DESCRIPTION
Both are similar to `rustc-cdylib-link-arg`. The `rustc-bin-link-arg` option adds `-C link-arg=...` on binary targets. The `rustc-link-arg` option adds `-C link-arg=...` on all supported targets (currently only binaries and cdylib libraries).