### PR TITLE
Fix some erroneous em-dashes in man pages.

### DIFF
--- a/src/doc/man/cargo-bench.adoc
+++ b/src/doc/man/cargo-bench.adoc
@@ -21,7 +21,7 @@ the two dashes (`--`) are passed to the benchmark binaries and thus to
 _libtest_ (rustc's built in unit-test and micro-benchmarking framework).  If
 you're passing arguments to both Cargo and the binary, the ones after `--` go
 to the binary, the ones before go to Cargo.  For details about libtest's
-arguments see the output of `cargo bench -- --help`.  As an example, this will
+arguments see the output of `cargo bench \-- --help`.  As an example, this will
 run only the benchmark named `foo` (and skip other similarly named benchmarks
 like `foobar`):
 

--- a/src/doc/man/cargo-test.adoc
+++ b/src/doc/man/cargo-test.adoc
@@ -21,7 +21,7 @@ dashes (`--`) are passed to the test binaries and thus to _libtest_ (rustc's
 built in unit-test and micro-benchmarking framework).  If you're passing
 arguments to both Cargo and the binary, the ones after `--` go to the binary,
 the ones before go to Cargo.  For details about libtest's arguments see the
-output of `cargo test -- --help`.  As an example, this will run all tests with
+output of `cargo test \-- --help`.  As an example, this will run all tests with
 `foo` in their name on 3 threads in parallel:
 
     cargo test foo -- --test-threads 3

--- a/src/doc/man/generated/cargo-bench.html
+++ b/src/doc/man/generated/cargo-bench.html
@@ -22,7 +22,7 @@ the two dashes (<code>--</code>) are passed to the benchmark binaries and thus t
 <em>libtest</em> (rustc&#8217;s built in unit-test and micro-benchmarking framework).  If
 you&#8217;re passing arguments to both Cargo and the binary, the ones after <code>--</code> go
 to the binary, the ones before go to Cargo.  For details about libtest&#8217;s
-arguments see the output of <code>cargo bench&#8201;&#8212;&#8201;--help</code>.  As an example, this will
+arguments see the output of <code>cargo bench -- --help</code>.  As an example, this will
 run only the benchmark named <code>foo</code> (and skip other similarly named benchmarks
 like <code>foobar</code>):</p>
 </div>

--- a/src/doc/man/generated/cargo-test.html
+++ b/src/doc/man/generated/cargo-test.html
@@ -22,7 +22,7 @@ dashes (<code>--</code>) are passed to the test binaries and thus to <em>libtest
 built in unit-test and micro-benchmarking framework).  If you&#8217;re passing
 arguments to both Cargo and the binary, the ones after <code>--</code> go to the binary,
 the ones before go to Cargo.  For details about libtest&#8217;s arguments see the
-output of <code>cargo test&#8201;&#8212;&#8201;--help</code>.  As an example, this will run all tests with
+output of <code>cargo test -- --help</code>.  As an example, this will run all tests with
 <code>foo</code> in their name on 3 threads in parallel:</p>
 </div>
 <div class="literalblock">

--- a/src/etc/man/cargo-bench.1
+++ b/src/etc/man/cargo-bench.1
@@ -2,12 +2,12 @@
 .\"     Title: cargo-bench
 .\"    Author: [see the "AUTHOR(S)" section]
 .\" Generator: Asciidoctor 2.0.10
-.\"      Date: 2019-12-05
+.\"      Date: 2020-01-18
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "CARGO\-BENCH" "1" "2019-12-05" "\ \&" "\ \&"
+.TH "CARGO\-BENCH" "1" "2020-01-18" "\ \&" "\ \&"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0
@@ -41,7 +41,7 @@ the two dashes (\fB\-\-\fP) are passed to the benchmark binaries and thus to
 \fIlibtest\fP (rustc\(cqs built in unit\-test and micro\-benchmarking framework).  If
 you\(cqre passing arguments to both Cargo and the binary, the ones after \fB\-\-\fP go
 to the binary, the ones before go to Cargo.  For details about libtest\(cqs
-arguments see the output of \fBcargo bench \(em \-\-help\fP.  As an example, this will
+arguments see the output of \fBcargo bench \-\- \-\-help\fP.  As an example, this will
 run only the benchmark named \fBfoo\fP (and skip other similarly named benchmarks
 like \fBfoobar\fP):
 .sp

--- a/src/etc/man/cargo-test.1
+++ b/src/etc/man/cargo-test.1
@@ -2,12 +2,12 @@
 .\"     Title: cargo-test
 .\"    Author: [see the "AUTHOR(S)" section]
 .\" Generator: Asciidoctor 2.0.10
-.\"      Date: 2019-09-05
+.\"      Date: 2020-01-18
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "CARGO\-TEST" "1" "2019-09-05" "\ \&" "\ \&"
+.TH "CARGO\-TEST" "1" "2020-01-18" "\ \&" "\ \&"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0
@@ -41,7 +41,7 @@ dashes (\fB\-\-\fP) are passed to the test binaries and thus to \fIlibtest\fP (r
 built in unit\-test and micro\-benchmarking framework).  If you\(cqre passing
 arguments to both Cargo and the binary, the ones after \fB\-\-\fP go to the binary,
 the ones before go to Cargo.  For details about libtest\(cqs arguments see the
-output of \fBcargo test \(em \-\-help\fP.  As an example, this will run all tests with
+output of \fBcargo test \-\- \-\-help\fP.  As an example, this will run all tests with
 \fBfoo\fP in their name on 3 threads in parallel:
 .sp
 .if n .RS 4


### PR DESCRIPTION
Unfortunately asciidoctor has a built-in substitution pass that cannot be disabled.

Fixes #7807.