### PR TITLE
Fix doc_target test which no longer works on stable/beta.

### DIFF
--- a/tests/testsuite/doc.rs
+++ b/tests/testsuite/doc.rs
@@ -584,6 +584,10 @@ fn doc_same_name() {
 
 #[cargo_test]
 fn doc_target() {
+    if !is_nightly() {
+        // no_core, lang_items requires nightly.
+        return;
+    }
     const TARGET: &str = "arm-unknown-linux-gnueabihf";
 
     let p = project()


### PR DESCRIPTION
https://github.com/rust-lang/rust/pull/67989 changed it so that `#![feature]` requires nightly.
