### PR TITLE
Fix cache replay including extra newlines.

### DIFF
--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -1257,7 +1257,8 @@ fn replay_output_cache(
             if length == 0 {
                 break;
             }
-            on_stderr_line(state, line.as_str(), package_id, &target, &mut options)?;
+            let trimmed = line.trim_end_matches(&['\n', '\r'][..]);
+            on_stderr_line(state, trimmed, package_id, &target, &mut options)?;
             line.clear();
         }
         Ok(())


### PR DESCRIPTION
The compiler output cache replay was changed in #7737 to use `BufReader::read_line` instead of `str::lines`. `read_line`, unlike `lines`, includes the trailing line ending. The code is written assuming that the line endings are stripped, so make sure they are stripped here, too.

This only happens for non-JSON messages, like `RUSTC_LOG`.
