### PR TITLE
Add new feature resolver.

### DIFF
--- a/src/cargo/core/compiler/build_context/mod.rs
+++ b/src/cargo/core/compiler/build_context/mod.rs
@@ -1,19 +1,17 @@
 use crate::core::compiler::unit::UnitInterner;
-use crate::core::compiler::CompileTarget;
 use crate::core::compiler::{BuildConfig, BuildOutput, CompileKind, Unit};
 use crate::core::profiles::Profiles;
-use crate::core::{Dependency, InternedString, Workspace};
+use crate::core::{InternedString, Workspace};
 use crate::core::{PackageId, PackageSet};
-use crate::util::config::{Config, TargetConfig};
+use crate::util::config::Config;
 use crate::util::errors::CargoResult;
 use crate::util::Rustc;
-use cargo_platform::Cfg;
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::str;
 
 mod target_info;
-pub use self::target_info::{FileFlavor, TargetInfo};
+pub use self::target_info::{FileFlavor, RustcTargetData, TargetInfo};
 
 /// The build context, containing all information about a build task.
 ///
@@ -30,26 +28,14 @@ pub struct BuildContext<'a, 'cfg> {
     pub build_config: &'a BuildConfig,
     /// Extra compiler args for either `rustc` or `rustdoc`.
     pub extra_compiler_args: HashMap<Unit<'a>, Vec<String>>,
+    /// Package downloader.
     pub packages: &'a PackageSet<'cfg>,
 
     /// Source of interning new units as they're created.
     pub units: &'a UnitInterner<'a>,
 
-    /// Information about the compiler that we've detected on the local system.
-    pub rustc: Rustc,
-
-    /// Build information for the "host", which is information about when
-    /// `rustc` is invoked without a `--target` flag. This is used for
-    /// procedural macros, build scripts, etc.
-    host_config: TargetConfig,
-    host_info: TargetInfo,
-
-    /// Build information for targets that we're building for. This will be
-    /// empty if the `--target` flag is not passed, and currently also only ever
-    /// has at most one entry, but eventually we'd like to support multi-target
-    /// builds with Cargo.
-    target_config: HashMap<CompileTarget, TargetConfig>,
-    target_info: HashMap<CompileTarget, TargetInfo>,
+    /// Information about rustc and the target platform.
+    pub target_data: RustcTargetData,
 }
 
 impl<'a, 'cfg> BuildContext<'a, 'cfg> {
@@ -61,72 +47,31 @@ impl<'a, 'cfg> BuildContext<'a, 'cfg> {
         profiles: Profiles,
         units: &'a UnitInterner<'a>,
         extra_compiler_args: HashMap<Unit<'a>, Vec<String>>,
+        target_data: RustcTargetData,
     ) -> CargoResult<BuildContext<'a, 'cfg>> {
-        let rustc = config.load_global_rustc(Some(ws))?;
-
-        let host_config = config.target_cfg_triple(&rustc.host)?;
-        let host_info = TargetInfo::new(
-            config,
-            build_config.requested_kind,
-            &rustc,
-            CompileKind::Host,
-        )?;
-        let mut target_config = HashMap::new();
-        let mut target_info = HashMap::new();
-        if let CompileKind::Target(target) = build_config.requested_kind {
-            let tcfg = config.target_cfg_triple(target.short_name())?;
-            target_config.insert(target, tcfg);
-            target_info.insert(
-                target,
-                TargetInfo::new(
-                    config,
-                    build_config.requested_kind,
-                    &rustc,
-                    CompileKind::Target(target),
-                )?,
-            );
-        }
-
         Ok(BuildContext {
             ws,
             packages,
             config,
-            rustc,
-            target_config,
-            target_info,
-            host_config,
-            host_info,
             build_config,
             profiles,
             extra_compiler_args,
             units,
+            target_data,
         })
     }
 
-    /// Whether a dependency should be compiled for the host or target platform,
-    /// specified by `CompileKind`.
-    pub fn dep_platform_activated(&self, dep: &Dependency, kind: CompileKind) -> bool {
-        // If this dependency is only available for certain platforms,
-        // make sure we're only enabling it for that platform.
-        let platform = match dep.platform() {
-            Some(p) => p,
-            None => return true,
-        };
-        let name = kind.short_name(self);
-        platform.matches(name, self.cfg(kind))
+    pub fn rustc(&self) -> &Rustc {
+        &self.target_data.rustc
     }
 
     /// Gets the user-specified linker for a particular host or target.
     pub fn linker(&self, kind: CompileKind) -> Option<PathBuf> {
-        self.target_config(kind)
+        self.target_data
+            .target_config(kind)
             .linker
             .as_ref()
             .map(|l| l.val.clone().resolve_program(self.config))
-    }
-
-    /// Gets the list of `cfg`s printed out from the compiler for the specified kind.
-    pub fn cfg(&self, kind: CompileKind) -> &[Cfg] {
-        self.info(kind).cfg()
     }
 
     /// Gets the host architecture triple.
@@ -136,15 +81,7 @@ impl<'a, 'cfg> BuildContext<'a, 'cfg> {
     /// - hardware-platform: unknown,
     /// - operating system: linux-gnu.
     pub fn host_triple(&self) -> InternedString {
-        self.rustc.host
-    }
-
-    /// Gets the target configuration for a particular host or target.
-    pub fn target_config(&self, kind: CompileKind) -> &TargetConfig {
-        match kind {
-            CompileKind::Host => &self.host_config,
-            CompileKind::Target(s) => &self.target_config[&s],
-        }
+        self.target_data.rustc.host
     }
 
     /// Gets the number of jobs specified for this build.
@@ -153,22 +90,15 @@ impl<'a, 'cfg> BuildContext<'a, 'cfg> {
     }
 
     pub fn rustflags_args(&self, unit: &Unit<'_>) -> &[String] {
-        &self.info(unit.kind).rustflags
+        &self.target_data.info(unit.kind).rustflags
     }
 
     pub fn rustdocflags_args(&self, unit: &Unit<'_>) -> &[String] {
-        &self.info(unit.kind).rustdocflags
+        &self.target_data.info(unit.kind).rustdocflags
     }
 
     pub fn show_warnings(&self, pkg: PackageId) -> bool {
         pkg.source_id().is_path() || self.config.extra_verbose()
-    }
-
-    pub fn info(&self, kind: CompileKind) -> &TargetInfo {
-        match kind {
-            CompileKind::Host => &self.host_info,
-            CompileKind::Target(s) => &self.target_info[&s],
-        }
     }
 
     pub fn extra_args_for(&self, unit: &Unit<'a>) -> Option<&Vec<String>> {
@@ -180,6 +110,9 @@ impl<'a, 'cfg> BuildContext<'a, 'cfg> {
     /// `lib_name` is the `links` library name and `kind` is whether it is for
     /// Host or Target.
     pub fn script_override(&self, lib_name: &str, kind: CompileKind) -> Option<&BuildOutput> {
-        self.target_config(kind).links_overrides.get(lib_name)
+        self.target_data
+            .target_config(kind)
+            .links_overrides
+            .get(lib_name)
     }
 }

--- a/src/cargo/core/compiler/compilation.rs
+++ b/src/cargo/core/compiler/compilation.rs
@@ -84,7 +84,7 @@ impl<'cfg> Compilation<'cfg> {
         bcx: &BuildContext<'a, 'cfg>,
         default_kind: CompileKind,
     ) -> CargoResult<Compilation<'cfg>> {
-        let mut rustc = bcx.rustc.process();
+        let mut rustc = bcx.rustc().process();
 
         let mut primary_unit_rustc_process = bcx.build_config.primary_unit_rustc.clone();
 
@@ -102,8 +102,16 @@ impl<'cfg> Compilation<'cfg> {
             root_output: PathBuf::from("/"),
             deps_output: PathBuf::from("/"),
             host_deps_output: PathBuf::from("/"),
-            host_dylib_path: bcx.info(CompileKind::Host).sysroot_host_libdir.clone(),
-            target_dylib_path: bcx.info(default_kind).sysroot_target_libdir.clone(),
+            host_dylib_path: bcx
+                .target_data
+                .info(CompileKind::Host)
+                .sysroot_host_libdir
+                .clone(),
+            target_dylib_path: bcx
+                .target_data
+                .info(default_kind)
+                .sysroot_target_libdir
+                .clone(),
             tests: Vec::new(),
             binaries: Vec::new(),
             extra_env: HashMap::new(),
@@ -114,7 +122,7 @@ impl<'cfg> Compilation<'cfg> {
             rustc_process: rustc,
             primary_unit_rustc_process,
             host: bcx.host_triple().to_string(),
-            target: default_kind.short_name(bcx).to_string(),
+            target: bcx.target_data.short_name(&default_kind).to_string(),
             target_runner: target_runner(bcx, default_kind)?,
         })
     }
@@ -286,7 +294,7 @@ fn target_runner(
     bcx: &BuildContext<'_, '_>,
     kind: CompileKind,
 ) -> CargoResult<Option<(PathBuf, Vec<String>)>> {
-    let target = kind.short_name(bcx);
+    let target = bcx.target_data.short_name(&kind);
 
     // try target.{}.runner
     let key = format!("target.{}.runner", target);
@@ -296,7 +304,7 @@ fn target_runner(
     }
 
     // try target.'cfg(...)'.runner
-    let target_cfg = bcx.info(kind).cfg();
+    let target_cfg = bcx.target_data.info(kind).cfg();
     let mut cfgs = bcx
         .config
         .target_cfgs()?

--- a/src/cargo/core/compiler/compile_kind.rs
+++ b/src/cargo/core/compiler/compile_kind.rs
@@ -1,4 +1,3 @@
-use crate::core::compiler::BuildContext;
 use crate::core::{InternedString, Target};
 use crate::util::errors::{CargoResult, CargoResultExt};
 use serde::Serialize;
@@ -38,15 +37,6 @@ impl CompileKind {
             CompileKind::Host => CompileKind::Host,
             CompileKind::Target(_) if target.for_host() => CompileKind::Host,
             CompileKind::Target(n) => CompileKind::Target(n),
-        }
-    }
-
-    /// Returns a "short" name for this kind, suitable for keying off
-    /// configuration in Cargo or presenting to users.
-    pub fn short_name(&self, bcx: &BuildContext<'_, '_>) -> &str {
-        match self {
-            CompileKind::Host => bcx.host_triple().as_str(),
-            CompileKind::Target(target) => target.short_name(),
         }
     }
 }

--- a/src/cargo/core/compiler/context/compilation_files.rs
+++ b/src/cargo/core/compiler/context/compilation_files.rs
@@ -147,7 +147,7 @@ impl<'a, 'cfg: 'a> CompilationFiles<'a, 'cfg> {
     /// Returns `None` if the unit should not use a metadata data hash (like
     /// rustdoc, or some dylibs).
     pub fn metadata(&self, unit: &Unit<'a>) -> Option<Metadata> {
-        self.metas[unit].clone()
+        self.metas[unit]
     }
 
     /// Gets the short hash based only on the `PackageId`.
@@ -515,7 +515,7 @@ fn metadata_of<'a, 'cfg>(
             metadata_of(&dep.unit, cx, metas);
         }
     }
-    metas[unit].clone()
+    metas[unit]
 }
 
 fn compute_metadata<'a, 'cfg>(

--- a/src/cargo/core/compiler/context/mod.rs
+++ b/src/cargo/core/compiler/context/mod.rs
@@ -450,7 +450,7 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
                     suggestion,
                     crate::version(),
                     self.bcx.host_triple(),
-                    unit.kind.short_name(self.bcx),
+                    self.bcx.target_data.short_name(&unit.kind),
                     unit,
                     other_unit))
             }

--- a/src/cargo/core/compiler/custom_build.rs
+++ b/src/cargo/core/compiler/custom_build.rs
@@ -180,7 +180,7 @@ fn build_work<'a, 'cfg>(cx: &mut Context<'a, 'cfg>, unit: &Unit<'a>) -> CargoRes
     cmd.env("OUT_DIR", &script_out_dir)
         .env("CARGO_MANIFEST_DIR", unit.pkg.root())
         .env("NUM_JOBS", &bcx.jobs().to_string())
-        .env("TARGET", unit.kind.short_name(bcx))
+        .env("TARGET", bcx.target_data.short_name(&unit.kind))
         .env("DEBUG", debug.to_string())
         .env("OPT_LEVEL", &unit.profile.opt_level.to_string())
         .env(
@@ -191,11 +191,11 @@ fn build_work<'a, 'cfg>(cx: &mut Context<'a, 'cfg>, unit: &Unit<'a>) -> CargoRes
             },
         )
         .env("HOST", &bcx.host_triple())
-        .env("RUSTC", &bcx.rustc.path)
+        .env("RUSTC", &bcx.rustc().path)
         .env("RUSTDOC", &*bcx.config.rustdoc()?)
         .inherit_jobserver(&cx.jobserver);
 
-    if let Some(linker) = &bcx.target_config(unit.kind).linker {
+    if let Some(linker) = &bcx.target_data.target_config(unit.kind).linker {
         cmd.env(
             "RUSTC_LINKER",
             linker.val.clone().resolve_program(bcx.config),
@@ -213,7 +213,7 @@ fn build_work<'a, 'cfg>(cx: &mut Context<'a, 'cfg>, unit: &Unit<'a>) -> CargoRes
     }
 
     let mut cfg_map = HashMap::new();
-    for cfg in bcx.cfg(unit.kind) {
+    for cfg in bcx.target_data.cfg(unit.kind) {
         match *cfg {
             Cfg::Name(ref n) => {
                 cfg_map.insert(n.clone(), None);

--- a/src/cargo/core/compiler/fingerprint.rs
+++ b/src/cargo/core/compiler/fingerprint.rs
@@ -1122,7 +1122,7 @@ fn calculate_normal<'a, 'cfg>(
     let m = unit.pkg.manifest().metadata();
     let metadata = util::hash_u64((&m.authors, &m.description, &m.homepage, &m.repository));
     Ok(Fingerprint {
-        rustc: util::hash_u64(&cx.bcx.rustc.verbose_version),
+        rustc: util::hash_u64(&cx.bcx.rustc().verbose_version),
         target: util::hash_u64(&unit.target),
         profile: profile_hash,
         // Note that .0 is hashed here, not .1 which is the cwd. That doesn't
@@ -1180,7 +1180,7 @@ fn calculate_run_custom_build<'a, 'cfg>(
 
     Ok(Fingerprint {
         local: Mutex::new(local),
-        rustc: util::hash_u64(&cx.bcx.rustc.verbose_version),
+        rustc: util::hash_u64(&cx.bcx.rustc().verbose_version),
         deps,
         outputs: if overridden { Vec::new() } else { vec![output] },
 

--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -28,7 +28,7 @@ use lazycell::LazyCell;
 use log::debug;
 
 pub use self::build_config::{BuildConfig, CompileMode, MessageFormat};
-pub use self::build_context::{BuildContext, FileFlavor, TargetInfo};
+pub use self::build_context::{BuildContext, FileFlavor, RustcTargetData, TargetInfo};
 use self::build_plan::BuildPlan;
 pub use self::compilation::{Compilation, Doctest};
 pub use self::compile_kind::{CompileKind, CompileTarget};

--- a/src/cargo/core/compiler/standard_lib.rs
+++ b/src/cargo/core/compiler/standard_lib.rs
@@ -103,7 +103,8 @@ pub fn resolve_std<'cfg>(
         /*dev_deps*/ false, &features, /*all_features*/ false,
         /*uses_default_features*/ true,
     );
-    let resolve = ops::resolve_ws_with_opts(&std_ws, target_data, requested_target, &opts, &specs)?;
+    let resolve =
+        ops::resolve_ws_with_opts(&std_ws, target_data, requested_target, &opts, &specs, false)?;
     Ok((
         resolve.pkg_set,
         resolve.targeted_resolve,

--- a/src/cargo/core/compiler/standard_lib.rs
+++ b/src/cargo/core/compiler/standard_lib.rs
@@ -2,7 +2,7 @@
 
 use crate::core::compiler::{BuildContext, CompileKind, CompileMode, RustcTargetData, Unit};
 use crate::core::profiles::UnitFor;
-use crate::core::resolver::features::ResolvedFeatures;
+use crate::core::resolver::features::{FeaturesFor, ResolvedFeatures};
 use crate::core::resolver::{HasDevUnits, ResolveOpts};
 use crate::core::{Dependency, PackageId, PackageSet, Resolve, SourceId, Workspace};
 use crate::ops::{self, Packages};
@@ -154,7 +154,8 @@ pub fn generate_std_roots<'a>(
                 unit_for,
                 mode,
             );
-            let features = std_features.activated_features(pkg.package_id(), false);
+            let features =
+                std_features.activated_features(pkg.package_id(), FeaturesFor::NormalOrDev);
             Ok(bcx.units.intern(
                 pkg, lib, profile, kind, mode, features, /*is_std*/ true,
             ))

--- a/src/cargo/core/compiler/standard_lib.rs
+++ b/src/cargo/core/compiler/standard_lib.rs
@@ -3,7 +3,7 @@
 use crate::core::compiler::{BuildContext, CompileKind, CompileMode, RustcTargetData, Unit};
 use crate::core::profiles::UnitFor;
 use crate::core::resolver::features::ResolvedFeatures;
-use crate::core::resolver::ResolveOpts;
+use crate::core::resolver::{HasDevUnits, ResolveOpts};
 use crate::core::{Dependency, PackageId, PackageSet, Resolve, SourceId, Workspace};
 use crate::ops::{self, Packages};
 use crate::util::errors::CargoResult;
@@ -102,8 +102,14 @@ pub fn resolve_std<'cfg>(
         /*dev_deps*/ false, &features, /*all_features*/ false,
         /*uses_default_features*/ true,
     );
-    let resolve =
-        ops::resolve_ws_with_opts(&std_ws, target_data, requested_target, &opts, &specs, false)?;
+    let resolve = ops::resolve_ws_with_opts(
+        &std_ws,
+        target_data,
+        requested_target,
+        &opts,
+        &specs,
+        HasDevUnits::No,
+    )?;
     Ok((
         resolve.pkg_set,
         resolve.targeted_resolve,

--- a/src/cargo/core/compiler/standard_lib.rs
+++ b/src/cargo/core/compiler/standard_lib.rs
@@ -1,7 +1,6 @@
 //! Code for building the standard library.
 
 use crate::core::compiler::{BuildContext, CompileKind, CompileMode, RustcTargetData, Unit};
-use crate::core::dependency::DepKind;
 use crate::core::profiles::UnitFor;
 use crate::core::resolver::features::ResolvedFeatures;
 use crate::core::resolver::ResolveOpts;
@@ -149,11 +148,7 @@ pub fn generate_std_roots<'a>(
                 unit_for,
                 mode,
             );
-            let features = std_features.activated_features(
-                pkg.package_id(),
-                DepKind::Normal,
-                bcx.build_config.requested_kind,
-            );
+            let features = std_features.activated_features(pkg.package_id(), false);
             Ok(bcx.units.intern(
                 pkg, lib, profile, kind, mode, features, /*is_std*/ true,
             ))

--- a/src/cargo/core/compiler/standard_lib.rs
+++ b/src/cargo/core/compiler/standard_lib.rs
@@ -99,7 +99,7 @@ pub fn resolve_std<'cfg>(
         /*dev_deps*/ false, &features, /*all_features*/ false,
         /*uses_default_features*/ true,
     );
-    let resolve = ops::resolve_ws_with_opts(&std_ws, opts, &specs)?;
+    let resolve = ops::resolve_ws_with_opts(&std_ws, &opts, &specs)?;
     Ok((resolve.pkg_set, resolve.targeted_resolve))
 }
 

--- a/src/cargo/core/compiler/timings.rs
+++ b/src/cargo/core/compiler/timings.rs
@@ -605,15 +605,17 @@ fn d_as_f64(d: Duration) -> f64 {
 
 fn render_rustc_info(bcx: &BuildContext<'_, '_>) -> String {
     let version = bcx
-        .rustc
+        .rustc()
         .verbose_version
         .lines()
         .next()
         .expect("rustc version");
-    let requested_target = bcx.build_config.requested_kind.short_name(bcx);
+    let requested_target = bcx.target_data.short_name(&bcx.build_config.requested_kind);
     format!(
         "{}<br>Host: {}<br>Target: {}",
-        version, bcx.rustc.host, requested_target
+        version,
+        bcx.rustc().host,
+        requested_target
     )
 }
 

--- a/src/cargo/core/compiler/unit.rs
+++ b/src/cargo/core/compiler/unit.rs
@@ -1,5 +1,5 @@
 use crate::core::compiler::{CompileKind, CompileMode};
-use crate::core::{profiles::Profile, Package, Target};
+use crate::core::{profiles::Profile, InternedString, Package, Target};
 use crate::util::hex::short_hash;
 use std::cell::RefCell;
 use std::collections::HashSet;
@@ -50,7 +50,7 @@ pub struct UnitInner<'a> {
     pub mode: CompileMode,
     /// The `cfg` features to enable for this unit.
     /// This must be sorted.
-    pub features: Vec<&'a str>,
+    pub features: Vec<InternedString>,
     /// Whether this is a standard library unit.
     pub is_std: bool,
 }
@@ -145,7 +145,7 @@ impl<'a> UnitInterner<'a> {
         profile: Profile,
         kind: CompileKind,
         mode: CompileMode,
-        features: Vec<&'a str>,
+        features: Vec<InternedString>,
         is_std: bool,
     ) -> Unit<'a> {
         let inner = self.intern_inner(&UnitInner {

--- a/src/cargo/core/compiler/unit_dependencies.rs
+++ b/src/cargo/core/compiler/unit_dependencies.rs
@@ -287,8 +287,15 @@ fn compute_deps<'a, 'cfg>(
         };
         let mode = check_or_build_mode(unit.mode, lib);
         let dep_kind = if unit.target.is_custom_build() {
+            // Custom build scripts can *only* have build-dependencies.
             DepKind::Build
         } else if deps.iter().any(|dep| !dep.is_transitive()) {
+            // A dependency can be listed in both [dependencies] and
+            // [dev-dependencies], so this checks if any of the deps are
+            // listed in dev-dependencies. Note that `filtered_deps` has
+            // already removed dev-dependencies if it is not a
+            // test/bench/example, so it is not necessary to check `unit`
+            // here.
             DepKind::Development
         } else {
             DepKind::Normal

--- a/src/cargo/core/compiler/unit_dependencies.rs
+++ b/src/cargo/core/compiler/unit_dependencies.rs
@@ -250,7 +250,7 @@ fn compute_deps<'a, 'cfg>(
 
             // If this dependency is only available for certain platforms,
             // make sure we're only enabling it for that platform.
-            if !bcx.dep_platform_activated(dep, unit.kind) {
+            if !bcx.target_data.dep_platform_activated(dep, unit.kind) {
                 return false;
             }
 
@@ -396,7 +396,7 @@ fn compute_deps_doc<'a, 'cfg>(
         .deps(unit.pkg.package_id())
         .filter(|&(_id, deps)| {
             deps.iter().any(|dep| match dep.kind() {
-                DepKind::Normal => bcx.dep_platform_activated(dep, unit.kind),
+                DepKind::Normal => bcx.target_data.dep_platform_activated(dep, unit.kind),
                 _ => false,
             })
         });

--- a/src/cargo/core/compiler/unit_dependencies.rs
+++ b/src/cargo/core/compiler/unit_dependencies.rs
@@ -382,6 +382,11 @@ fn compute_deps<'a, 'cfg>(
 ///
 /// The `unit` provided must represent an execution of a build script, and
 /// the returned set of units must all be run before `unit` is run.
+///
+/// `dep_kind` is the dependency kind of the package this build script is
+/// being built for. This ensures that the build script is built with the same
+/// features the package is built with (if the build script has cfg!()
+/// checks).
 fn compute_deps_custom_build<'a, 'cfg>(
     unit: &Unit<'a>,
     dep_kind: DepKind,

--- a/src/cargo/core/dependency.rs
+++ b/src/cargo/core/dependency.rs
@@ -92,23 +92,6 @@ pub enum DepKind {
     Build,
 }
 
-impl DepKind {
-    /// Convert a DepKind from a package to one of its dependencies.
-    ///
-    /// The rules here determine how feature decoupling works. This works in
-    /// conjunction with the new feature resolver.
-    pub fn sticky_kind(&self, to: DepKind) -> DepKind {
-        use DepKind::*;
-        match (self, to) {
-            (Normal, _) => to,
-            (Build, _) => Build,
-            (Development, Normal) => Development,
-            (Development, Build) => Build,
-            (Development, Development) => Development,
-        }
-    }
-}
-
 fn parse_req_with_deprecated(
     name: InternedString,
     req: &str,

--- a/src/cargo/core/dependency.rs
+++ b/src/cargo/core/dependency.rs
@@ -92,6 +92,23 @@ pub enum DepKind {
     Build,
 }
 
+impl DepKind {
+    /// Convert a DepKind from a package to one of its dependencies.
+    ///
+    /// The rules here determine how feature decoupling works. This works in
+    /// conjunction with the new feature resolver.
+    pub fn sticky_kind(&self, to: DepKind) -> DepKind {
+        use DepKind::*;
+        match (self, to) {
+            (Normal, _) => to,
+            (Build, _) => Build,
+            (Development, Normal) => Development,
+            (Development, Build) => Build,
+            (Development, Development) => Development,
+        }
+    }
+}
+
 fn parse_req_with_deprecated(
     name: InternedString,
     req: &str,

--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -341,6 +341,7 @@ pub struct CliUnstable {
     pub doctest_xcompile: bool,
     pub panic_abort_tests: bool,
     pub jobserver_per_rustc: bool,
+    pub features: Option<Vec<String>>,
 }
 
 impl CliUnstable {
@@ -380,6 +381,13 @@ impl CliUnstable {
             }
         }
 
+        fn parse_features(value: Option<&str>) -> Vec<String> {
+            match value {
+                None => Vec::new(),
+                Some(v) => v.split(',').map(|s| s.to_string()).collect(),
+            }
+        }
+
         // Asserts that there is no argument to the flag.
         fn parse_empty(key: &str, value: Option<&str>) -> CargoResult<bool> {
             if let Some(v) = value {
@@ -409,6 +417,7 @@ impl CliUnstable {
             "doctest-xcompile" => self.doctest_xcompile = parse_empty(k, v)?,
             "panic-abort-tests" => self.panic_abort_tests = parse_empty(k, v)?,
             "jobserver-per-rustc" => self.jobserver_per_rustc = parse_empty(k, v)?,
+            "features" => self.features = Some(parse_features(v)),
             _ => bail!("unknown `-Z` flag specified: {}", k),
         }
 

--- a/src/cargo/core/profiles.rs
+++ b/src/cargo/core/profiles.rs
@@ -768,6 +768,15 @@ pub struct UnitFor {
     /// these targets.
     ///
     /// An invariant is that if `build_dep` is true, `host` must be true.
+    ///
+    /// Note that this is `true` for `RunCustomBuild` units, even though that
+    /// unit should *not* use build-override profiles. This is a bit of a
+    /// special case. When computing the `RunCustomBuild` unit, it manually
+    /// uses the `get_profile_run_custom_build` method to get the correct
+    /// profile information for the unit. `host` needs to be true so that all
+    /// of the dependencies of that `RunCustomBuild` unit have this flag be
+    /// sticky (and forced to `true` for all further dependencies) — which is
+    /// the whole point of `UnitFor`.
     host: bool,
     /// A target for a build dependency (or any of its dependencies). This is
     /// used for computing features of build dependencies independently of

--- a/src/cargo/core/resolver/context.rs
+++ b/src/cargo/core/resolver/context.rs
@@ -164,20 +164,21 @@ impl Context {
             }
         }
         debug!("checking if {} is already activated", summary.package_id());
-        if opts.all_features {
+        if opts.features.all_features {
             return Ok(false);
         }
 
         let has_default_feature = summary.features().contains_key("default");
         Ok(match self.resolve_features.get(&id) {
             Some(prev) => {
-                opts.features.is_subset(prev)
-                    && (!opts.uses_default_features
+                opts.features.features.is_subset(prev)
+                    && (!opts.features.uses_default_features
                         || prev.contains("default")
                         || !has_default_feature)
             }
             None => {
-                opts.features.is_empty() && (!opts.uses_default_features || !has_default_feature)
+                opts.features.features.is_empty()
+                    && (!opts.features.uses_default_features || !has_default_feature)
             }
         })
     }

--- a/src/cargo/core/resolver/dep_cache.rs
+++ b/src/cargo/core/resolver/dep_cache.rs
@@ -340,7 +340,7 @@ fn build_requirements<'a, 'b: 'a>(
 ) -> CargoResult<Requirements<'a>> {
     let mut reqs = Requirements::new(s);
 
-    if opts.all_features {
+    if opts.features.all_features {
         for key in s.features().keys() {
             reqs.require_feature(*key)?;
         }
@@ -348,12 +348,12 @@ fn build_requirements<'a, 'b: 'a>(
             reqs.require_dependency(dep.name_in_toml());
         }
     } else {
-        for &f in opts.features.iter() {
+        for &f in opts.features.features.iter() {
             reqs.require_value(&FeatureValue::new(f, s))?;
         }
     }
 
-    if opts.uses_default_features && s.features().contains_key("default") {
+    if opts.features.uses_default_features && s.features().contains_key("default") {
         reqs.require_feature(InternedString::new("default"))?;
     }
 

--- a/src/cargo/core/resolver/encode.rs
+++ b/src/cargo/core/resolver/encode.rs
@@ -365,6 +365,7 @@ impl EncodableResolve {
             metadata,
             unused_patches,
             version,
+            HashMap::new(),
         ))
     }
 }

--- a/src/cargo/core/resolver/features.rs
+++ b/src/cargo/core/resolver/features.rs
@@ -1,0 +1,46 @@
+use crate::core::resolver::types::FeaturesSet;
+use crate::core::InternedString;
+use std::collections::BTreeSet;
+use std::rc::Rc;
+
+/// Features flags requested for a package.
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+pub struct RequestedFeatures {
+    pub features: FeaturesSet,
+    pub all_features: bool,
+    pub uses_default_features: bool,
+}
+
+impl RequestedFeatures {
+    /// Creates a new RequestedFeatures from the given command-line flags.
+    pub fn from_command_line(
+        features: &[String],
+        all_features: bool,
+        uses_default_features: bool,
+    ) -> RequestedFeatures {
+        RequestedFeatures {
+            features: Rc::new(RequestedFeatures::split_features(features)),
+            all_features,
+            uses_default_features,
+        }
+    }
+
+    /// Creates a new RequestedFeatures with the given `all_features` setting.
+    pub fn new_all(all_features: bool) -> RequestedFeatures {
+        RequestedFeatures {
+            features: Rc::new(BTreeSet::new()),
+            all_features,
+            uses_default_features: true,
+        }
+    }
+
+    fn split_features(features: &[String]) -> BTreeSet<InternedString> {
+        features
+            .iter()
+            .flat_map(|s| s.split_whitespace())
+            .flat_map(|s| s.split(','))
+            .filter(|s| !s.is_empty())
+            .map(InternedString::new)
+            .collect::<BTreeSet<InternedString>>()
+    }
+}

--- a/src/cargo/core/resolver/features.rs
+++ b/src/cargo/core/resolver/features.rs
@@ -1,7 +1,92 @@
+//! Feature resolver.
+//!
+//! This is a new feature resolver that runs independently of the main
+//! dependency resolver. It is intended to make it easier to experiment with
+//! new behaviors. When `-Zfeatures` is not used, it will fall back to using
+//! the original `Resolve` feature computation. With `-Zfeatures` enabled,
+//! this will walk the dependency graph and compute the features using a
+//! different algorithm. One of its key characteristics is that it can avoid
+//! unifying features for shared dependencies in some situations.
+//!
+//! The preferred way to engage this new resolver is via
+//! `resolve_ws_with_opts`.
+//!
+//! There are many assumptions made about the resolver itself. It assumes
+//! validation has already been done on the feature maps, and doesn't do any
+//! validation itself. It assumes dev-dependencies within a dependency have
+//! been removed.
+
+use crate::core::compiler::{CompileKind, RustcTargetData};
+use crate::core::dependency::{DepKind, Dependency};
 use crate::core::resolver::types::FeaturesSet;
-use crate::core::InternedString;
-use std::collections::BTreeSet;
+use crate::core::resolver::Resolve;
+use crate::core::{FeatureValue, InternedString, PackageId, PackageIdSpec, Workspace};
+use crate::util::{CargoResult, Config};
+use std::collections::{BTreeSet, HashMap, HashSet};
 use std::rc::Rc;
+
+type ActivateMap = HashMap<(PackageId, DepKind, CompileKind), BTreeSet<InternedString>>;
+
+/// Set of all activated features for all packages in the resolve graph.
+pub struct ResolvedFeatures {
+    activated_features: ActivateMap,
+    /// This is only here for legacy support when `-Zfeatures` is not enabled.
+    legacy: Option<HashMap<PackageId, Vec<InternedString>>>,
+    opts: FeatureOpts,
+}
+
+/// Options for how the feature resolver works.
+#[derive(Default)]
+struct FeatureOpts {
+    /// -Zpackage-features, changes behavior of feature flags in a workspace.
+    package_features: bool,
+    /// -Zfeatures is enabled, use new resolver.
+    new_resolver: bool,
+    /// Build deps will not share share features with other dep kinds.
+    decouple_build_deps: bool,
+    /// Dev dep features will not be activated unless needed.
+    decouple_dev_deps: bool,
+    /// Targets that are not in use will not activate features.
+    ignore_inactive_targets: bool,
+    /// If enabled, compare against old resolver (for testing).
+    compare: bool,
+}
+
+impl FeatureOpts {
+    fn new(config: &Config) -> CargoResult<FeatureOpts> {
+        let mut opts = FeatureOpts::default();
+        let unstable_flags = config.cli_unstable();
+        opts.package_features = unstable_flags.package_features;
+        let mut enable = |feat_opts: &Vec<String>| {
+            opts.new_resolver = true;
+            for opt in feat_opts {
+                match opt.as_ref() {
+                    "build_dep" => opts.decouple_build_deps = true,
+                    "dev_dep" => opts.decouple_dev_deps = true,
+                    "itarget" => opts.ignore_inactive_targets = true,
+                    "compare" => opts.compare = true,
+                    "ws" => unimplemented!(),
+                    "host" => unimplemented!(),
+                    s => anyhow::bail!("-Zfeatures flag `{}` is not supported", s),
+                }
+            }
+            Ok(())
+        };
+        if let Some(feat_opts) = unstable_flags.features.as_ref() {
+            enable(feat_opts)?;
+        }
+        // This env var is intended for testing only.
+        if let Ok(env_opts) = std::env::var("__CARGO_FORCE_NEW_FEATURES") {
+            if env_opts == "1" {
+                opts.new_resolver = true;
+            } else {
+                let env_opts = env_opts.split(',').map(|s| s.to_string()).collect();
+                enable(&env_opts)?;
+            }
+        }
+        Ok(opts)
+    }
+}
 
 /// Features flags requested for a package.
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
@@ -42,5 +127,423 @@ impl RequestedFeatures {
             .filter(|s| !s.is_empty())
             .map(InternedString::new)
             .collect::<BTreeSet<InternedString>>()
+    }
+}
+
+impl ResolvedFeatures {
+    /// Returns the list of features that are enabled for the given package.
+    pub fn activated_features(
+        &self,
+        pkg_id: PackageId,
+        dep_kind: DepKind,
+        compile_kind: CompileKind,
+    ) -> Vec<InternedString> {
+        if let Some(legacy) = &self.legacy {
+            legacy.get(&pkg_id).map_or_else(Vec::new, |v| v.clone())
+        } else {
+            // TODO: Remove panic, return empty set.
+            let dep_kind = if (!self.opts.decouple_build_deps && dep_kind == DepKind::Build)
+                || (!self.opts.decouple_dev_deps && dep_kind == DepKind::Development)
+            {
+                // Decoupling disabled, everything is unified under "Normal".
+                DepKind::Normal
+            } else {
+                dep_kind
+            };
+            let fs = self
+                .activated_features
+                .get(&(pkg_id, dep_kind, compile_kind))
+                .unwrap_or_else(|| panic!("features did not find {:?} {:?}", pkg_id, dep_kind));
+            fs.iter().cloned().collect()
+        }
+    }
+}
+
+pub struct FeatureResolver<'a, 'cfg> {
+    ws: &'a Workspace<'cfg>,
+    target_data: &'a RustcTargetData,
+    /// The platform to build for, requested by the user.
+    requested_target: CompileKind,
+    resolve: &'a Resolve,
+    /// Features requested by the user on the command-line.
+    requested_features: &'a RequestedFeatures,
+    /// Packages to build, requested on the command-line.
+    specs: &'a [PackageIdSpec],
+    /// Options that change how the feature resolver operates.
+    opts: FeatureOpts,
+    /// Map of features activated for each package.
+    activated_features: ActivateMap,
+    /// Keeps track of which packages have had its dependencies processed.
+    /// Used to avoid cycles, and to speed up processing.
+    processed_deps: HashSet<(PackageId, DepKind, CompileKind)>,
+}
+
+impl<'a, 'cfg> FeatureResolver<'a, 'cfg> {
+    /// Runs the resolution algorithm and returns a new `ResolvedFeatures`
+    /// with the result.
+    pub fn resolve(
+        ws: &Workspace<'cfg>,
+        target_data: &RustcTargetData,
+        resolve: &Resolve,
+        requested_features: &RequestedFeatures,
+        specs: &[PackageIdSpec],
+        requested_target: CompileKind,
+    ) -> CargoResult<ResolvedFeatures> {
+        use crate::util::profile;
+        let _p = profile::start("resolve features");
+
+        let opts = FeatureOpts::new(ws.config())?;
+        if !opts.new_resolver {
+            // Legacy mode.
+            return Ok(ResolvedFeatures {
+                activated_features: HashMap::new(),
+                legacy: Some(resolve.features_clone()),
+                opts,
+            });
+        }
+        let mut r = FeatureResolver {
+            ws,
+            target_data,
+            requested_target,
+            resolve,
+            requested_features,
+            specs,
+            opts,
+            activated_features: HashMap::new(),
+            processed_deps: HashSet::new(),
+        };
+        r.do_resolve()?;
+        log::debug!("features={:#?}", r.activated_features);
+        if r.opts.compare {
+            r.compare();
+        }
+        Ok(ResolvedFeatures {
+            activated_features: r.activated_features,
+            legacy: None,
+            opts: r.opts,
+        })
+    }
+
+    /// Performs the process of resolving all features for the resolve graph.
+    fn do_resolve(&mut self) -> CargoResult<()> {
+        if self.opts.package_features {
+            let mut found = false;
+            for member in self.ws.members() {
+                let member_id = member.package_id();
+                if self.specs.iter().any(|spec| spec.matches(member_id)) {
+                    found = true;
+                    self.activate_member(member_id, self.requested_features)?;
+                }
+            }
+            if !found {
+                // -p for a non-member. Just resolve all with defaults.
+                let default = RequestedFeatures::new_all(false);
+                for member in self.ws.members() {
+                    self.activate_member(member.package_id(), &default)?;
+                }
+            }
+        } else {
+            for member in self.ws.members() {
+                let member_id = member.package_id();
+                match self.ws.current_opt() {
+                    Some(current) if member_id == current.package_id() => {
+                        // The "current" member gets activated with the flags
+                        // from the command line.
+                        self.activate_member(member_id, self.requested_features)?;
+                    }
+                    _ => {
+                        // Ignore members that are not enabled on the command-line.
+                        if self.specs.iter().any(|spec| spec.matches(member_id)) {
+                            // -p for a workspace member that is not the
+                            // "current" one, don't use the local `--features`.
+                            let not_current_requested =
+                                RequestedFeatures::new_all(self.requested_features.all_features);
+                            self.activate_member(member_id, &not_current_requested)?;
+                        }
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Enable the given features on the given workspace member.
+    fn activate_member(
+        &mut self,
+        pkg_id: PackageId,
+        requested_features: &RequestedFeatures,
+    ) -> CargoResult<()> {
+        let fvs = self.fvs_from_requested(pkg_id, CompileKind::Host, requested_features);
+        self.activate_member_fvs(pkg_id, CompileKind::Host, &fvs)?;
+        if let CompileKind::Target(_) = self.requested_target {
+            let fvs = self.fvs_from_requested(pkg_id, self.requested_target, requested_features);
+            self.activate_member_fvs(pkg_id, self.requested_target, &fvs)?;
+        }
+        Ok(())
+    }
+
+    fn activate_member_fvs(
+        &mut self,
+        pkg_id: PackageId,
+        compile_kind: CompileKind,
+        fvs: &[FeatureValue],
+    ) -> CargoResult<()> {
+        self.activate_with_platform(pkg_id, DepKind::Normal, compile_kind, &fvs)?;
+        if self.opts.decouple_dev_deps {
+            // Activate the member as a dev dep, assuming it has at least one
+            // test, bench, or example. This ensures the member's normal deps get
+            // unified with its dev deps.
+            self.activate_with_platform(pkg_id, DepKind::Development, compile_kind, &fvs)?;
+        }
+        Ok(())
+    }
+
+    fn activate_with_platform(
+        &mut self,
+        pkg_id: PackageId,
+        dep_kind: DepKind,
+        compile_kind: CompileKind,
+        fvs: &[FeatureValue],
+    ) -> CargoResult<()> {
+        // Add an empty entry to ensure everything is covered. This is intended for
+        // finding bugs where the resolver missed something it should have visited.
+        // Remove this in the future if `activated_features` uses an empty default.
+        self.activated_features
+            .entry((pkg_id, dep_kind, compile_kind))
+            .or_insert_with(BTreeSet::new);
+        for fv in fvs {
+            self.activate_fv(pkg_id, dep_kind, compile_kind, fv)?;
+        }
+        if !self.processed_deps.insert((pkg_id, dep_kind, compile_kind)) {
+            // Already processed dependencies.
+            return Ok(());
+        }
+        // Activate any of its dependencies.
+        for (dep_pkg_id, deps) in self.deps(pkg_id, compile_kind) {
+            for dep in deps {
+                if dep.is_optional() {
+                    continue;
+                }
+                // Recurse into the dependency.
+                let fvs = self.fvs_from_dependency(dep_pkg_id, dep);
+                self.activate_with_platform(
+                    dep_pkg_id,
+                    self.sticky_dep_kind(dep_kind, dep.kind()),
+                    compile_kind,
+                    &fvs,
+                )?;
+            }
+        }
+        return Ok(());
+    }
+
+    fn activate_fv(
+        &mut self,
+        pkg_id: PackageId,
+        dep_kind: DepKind,
+        compile_kind: CompileKind,
+        fv: &FeatureValue,
+    ) -> CargoResult<()> {
+        match fv {
+            FeatureValue::Feature(f) => {
+                self.activate_rec(pkg_id, dep_kind, compile_kind, *f)?;
+            }
+            FeatureValue::Crate(dep_name) => {
+                // Activate the feature name on self.
+                self.activate_rec(pkg_id, dep_kind, compile_kind, *dep_name)?;
+                // Activate the optional dep.
+                for (dep_pkg_id, deps) in self.deps(pkg_id, compile_kind) {
+                    for dep in deps {
+                        if dep.name_in_toml() == *dep_name {
+                            let fvs = self.fvs_from_dependency(dep_pkg_id, dep);
+                            self.activate_with_platform(
+                                dep_pkg_id,
+                                self.sticky_dep_kind(dep_kind, dep.kind()),
+                                compile_kind,
+                                &fvs,
+                            )?;
+                        }
+                    }
+                }
+            }
+            FeatureValue::CrateFeature(dep_name, dep_feature) => {
+                // Activate a feature within a dependency.
+                for (dep_pkg_id, deps) in self.deps(pkg_id, compile_kind) {
+                    for dep in deps {
+                        if dep.name_in_toml() == *dep_name {
+                            if dep.is_optional() {
+                                // Activate the crate on self.
+                                let fv = FeatureValue::Crate(*dep_name);
+                                self.activate_fv(pkg_id, dep_kind, compile_kind, &fv)?;
+                            }
+                            // Activate the feature on the dependency.
+                            let summary = self.resolve.summary(dep_pkg_id);
+                            let fv = FeatureValue::new(*dep_feature, summary);
+                            self.activate_fv(
+                                dep_pkg_id,
+                                self.sticky_dep_kind(dep_kind, dep.kind()),
+                                compile_kind,
+                                &fv,
+                            )?;
+                        }
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Activate the given feature for the given package, and then recursively
+    /// activate any other features that feature enables.
+    fn activate_rec(
+        &mut self,
+        pkg_id: PackageId,
+        dep_kind: DepKind,
+        compile_kind: CompileKind,
+        feature_to_enable: InternedString,
+    ) -> CargoResult<()> {
+        let enabled = self
+            .activated_features
+            .entry((pkg_id, dep_kind, compile_kind))
+            .or_insert_with(BTreeSet::new);
+        if !enabled.insert(feature_to_enable) {
+            // Already enabled.
+            return Ok(());
+        }
+        let summary = self.resolve.summary(pkg_id);
+        let feature_map = summary.features();
+        let fvs = match feature_map.get(&feature_to_enable) {
+            Some(fvs) => fvs,
+            None => {
+                // TODO: this should only happen for optional dependencies.
+                // Other cases should be validated by Summary's `build_feature_map`.
+                // Figure out some way to validate this assumption.
+                log::debug!(
+                    "pkg {:?} does not define feature {}",
+                    pkg_id,
+                    feature_to_enable
+                );
+                return Ok(());
+            }
+        };
+        for fv in fvs {
+            self.activate_fv(pkg_id, dep_kind, compile_kind, fv)?;
+        }
+        Ok(())
+    }
+
+    /// Returns Vec of FeatureValues from a Dependency definition.
+    fn fvs_from_dependency(&self, dep_id: PackageId, dep: &Dependency) -> Vec<FeatureValue> {
+        let summary = self.resolve.summary(dep_id);
+        let feature_map = summary.features();
+        let mut result: Vec<FeatureValue> = dep
+            .features()
+            .iter()
+            .map(|f| FeatureValue::new(*f, summary))
+            .collect();
+        let default = InternedString::new("default");
+        if dep.uses_default_features() && feature_map.contains_key(&default) {
+            result.push(FeatureValue::Feature(default));
+        }
+        result
+    }
+
+    /// Returns Vec of FeatureValues from a set of command-line features.
+    fn fvs_from_requested(
+        &self,
+        pkg_id: PackageId,
+        compile_kind: CompileKind,
+        requested_features: &RequestedFeatures,
+    ) -> Vec<FeatureValue> {
+        let summary = self.resolve.summary(pkg_id);
+        let feature_map = summary.features();
+        if requested_features.all_features {
+            let mut fvs: Vec<FeatureValue> = feature_map
+                .keys()
+                .map(|k| FeatureValue::Feature(*k))
+                .collect();
+            // Add optional deps.
+            for (_dep_pkg_id, deps) in self.deps(pkg_id, compile_kind) {
+                for dep in deps {
+                    if dep.is_optional() {
+                        // This may result in duplicates, but that should be ok.
+                        fvs.push(FeatureValue::Crate(dep.name_in_toml()));
+                    }
+                }
+            }
+            fvs
+        } else {
+            let mut result: Vec<FeatureValue> = requested_features
+                .features
+                .as_ref()
+                .iter()
+                .map(|f| FeatureValue::new(*f, summary))
+                .collect();
+            let default = InternedString::new("default");
+            if requested_features.uses_default_features && feature_map.contains_key(&default) {
+                result.push(FeatureValue::Feature(default));
+            }
+            result
+        }
+    }
+
+    /// Returns the dependencies for a package, filtering out inactive targets.
+    fn deps(
+        &self,
+        pkg_id: PackageId,
+        compile_kind: CompileKind,
+    ) -> Vec<(PackageId, Vec<&'a Dependency>)> {
+        self.resolve
+            .deps(pkg_id)
+            .map(|(dep_id, deps)| {
+                let deps = deps
+                    .iter()
+                    .filter(|dep| {
+                        !dep.platform().is_some()
+                            || !self.opts.ignore_inactive_targets
+                            || self.target_data.dep_platform_activated(dep, compile_kind)
+                    })
+                    .collect::<Vec<_>>();
+                (dep_id, deps)
+            })
+            .collect()
+    }
+
+    /// Convert a DepKind from a package to one of its dependencies.
+    ///
+    /// The rules here determine how decoupling works.
+    fn sticky_dep_kind(&self, from: DepKind, to: DepKind) -> DepKind {
+        if self.opts.decouple_build_deps {
+            if from == DepKind::Build || to == DepKind::Build {
+                return DepKind::Build;
+            }
+        }
+        if self.opts.decouple_dev_deps {
+            if to == DepKind::Development {
+                return DepKind::Development;
+            }
+            if from == DepKind::Development && to != DepKind::Build {
+                return DepKind::Development;
+            }
+        }
+        return DepKind::Normal;
+    }
+
+    /// Compare the activated features to the resolver. Used for testing.
+    fn compare(&self) {
+        let mut found = false;
+        for ((pkg_id, dep_kind, compile_kind), features) in &self.activated_features {
+            let r_features = self.resolve.features(*pkg_id);
+            if !r_features.iter().eq(features.iter()) {
+                eprintln!(
+                    "{}/{:?}/{:?} features mismatch\nresolve: {:?}\nnew: {:?}\n",
+                    pkg_id, dep_kind, compile_kind, r_features, features
+                );
+                found = true;
+            }
+        }
+        if found {
+            panic!("feature mismatch");
+        }
     }
 }

--- a/src/cargo/core/resolver/features.rs
+++ b/src/cargo/core/resolver/features.rs
@@ -72,6 +72,11 @@ impl FeatureOpts {
                     "build_dep" => opts.decouple_build_deps = true,
                     "dev_dep" => opts.decouple_dev_deps = true,
                     "itarget" => opts.ignore_inactive_targets = true,
+                    "all" => {
+                        opts.decouple_build_deps = true;
+                        opts.decouple_dev_deps = true;
+                        opts.ignore_inactive_targets = true;
+                    }
                     "compare" => opts.compare = true,
                     "ws" => unimplemented!(),
                     "host" => unimplemented!(),

--- a/src/cargo/core/resolver/features.rs
+++ b/src/cargo/core/resolver/features.rs
@@ -326,10 +326,11 @@ impl<'a, 'cfg> FeatureResolver<'a, 'cfg> {
                 // Activate the optional dep.
                 for (dep_pkg_id, deps) in self.deps(pkg_id, for_build) {
                     for (dep, dep_for_build) in deps {
-                        if dep.name_in_toml() == *dep_name {
-                            let fvs = self.fvs_from_dependency(dep_pkg_id, dep);
-                            self.activate_pkg(dep_pkg_id, &fvs, dep_for_build)?;
+                        if dep.name_in_toml() != *dep_name {
+                            continue;
                         }
+                        let fvs = self.fvs_from_dependency(dep_pkg_id, dep);
+                        self.activate_pkg(dep_pkg_id, &fvs, dep_for_build)?;
                     }
                 }
             }
@@ -337,17 +338,18 @@ impl<'a, 'cfg> FeatureResolver<'a, 'cfg> {
                 // Activate a feature within a dependency.
                 for (dep_pkg_id, deps) in self.deps(pkg_id, for_build) {
                     for (dep, dep_for_build) in deps {
-                        if dep.name_in_toml() == *dep_name {
-                            if dep.is_optional() {
-                                // Activate the crate on self.
-                                let fv = FeatureValue::Crate(*dep_name);
-                                self.activate_fv(pkg_id, &fv, for_build)?;
-                            }
-                            // Activate the feature on the dependency.
-                            let summary = self.resolve.summary(dep_pkg_id);
-                            let fv = FeatureValue::new(*dep_feature, summary);
-                            self.activate_fv(dep_pkg_id, &fv, dep_for_build)?;
+                        if dep.name_in_toml() != *dep_name {
+                            continue;
                         }
+                        if dep.is_optional() {
+                            // Activate the crate on self.
+                            let fv = FeatureValue::Crate(*dep_name);
+                            self.activate_fv(pkg_id, &fv, for_build)?;
+                        }
+                        // Activate the feature on the dependency.
+                        let summary = self.resolve.summary(dep_pkg_id);
+                        let fv = FeatureValue::new(*dep_feature, summary);
+                        self.activate_fv(dep_pkg_id, &fv, dep_for_build)?;
                     }
                 }
             }

--- a/src/cargo/core/resolver/features.rs
+++ b/src/cargo/core/resolver/features.rs
@@ -25,6 +25,14 @@ use crate::util::{CargoResult, Config};
 use std::collections::{BTreeSet, HashMap, HashSet};
 use std::rc::Rc;
 
+/// Map of activated features for a PackageId/DepKind/CompileKind.
+///
+/// `DepKind` is needed, as the same package can be built multiple times with
+/// different features. For example, with `decouple_build_deps`, a dependency
+/// can be built once as a build dependency (for example with a 'std'
+/// feature), and once as a normal dependency (without that 'std' feature).
+///
+/// `CompileKind` is used currently not needed.
 type ActivateMap = HashMap<(PackageId, DepKind, CompileKind), BTreeSet<InternedString>>;
 
 /// Set of all activated features for all packages in the resolve graph.

--- a/src/cargo/core/resolver/mod.rs
+++ b/src/cargo/core/resolver/mod.rs
@@ -108,9 +108,6 @@ mod types;
 /// * `config` - a location to print warnings and such, or `None` if no warnings
 ///   should be printed
 ///
-/// * `print_warnings` - whether or not to print backwards-compatibility
-///   warnings and such
-///
 /// * `check_public_visible_dependencies` - a flag for whether to enforce the restrictions
 ///     introduced in the "public & private dependencies" RFC (1977). The current implementation
 ///     makes sure that there is only one version of each name visible to each package.
@@ -143,17 +140,27 @@ pub fn resolve(
         let cksum = summary.checksum().map(|s| s.to_string());
         cksums.insert(summary.package_id(), cksum);
     }
+    let graph = cx.graph();
+    let replacements = cx.resolve_replacements(&registry);
+    let features = cx
+        .resolve_features
+        .iter()
+        .map(|(k, v)| (*k, v.iter().cloned().collect()))
+        .collect();
+    let summaries = cx
+        .activations
+        .into_iter()
+        .map(|(_key, (summary, _age))| (summary.package_id(), summary))
+        .collect();
     let resolve = Resolve::new(
-        cx.graph(),
-        cx.resolve_replacements(&registry),
-        cx.resolve_features
-            .iter()
-            .map(|(k, v)| (*k, v.iter().map(|x| x.to_string()).collect()))
-            .collect(),
+        graph,
+        replacements,
+        features,
         cksums,
         BTreeMap::new(),
         Vec::new(),
         ResolveVersion::default_for_new_lockfiles(),
+        summaries,
     );
 
     check_cycles(&resolve)?;
@@ -163,11 +170,11 @@ pub fn resolve(
     Ok(resolve)
 }
 
-/// Recursively activates the dependencies for `top`, in depth-first order,
+/// Recursively activates the dependencies for `summaries`, in depth-first order,
 /// backtracking across possible candidates for each dependency as necessary.
 ///
 /// If all dependencies can be activated and resolved to a version in the
-/// dependency graph, cx.resolve is returned.
+/// dependency graph, `cx` is returned.
 fn activate_deps_loop(
     mut cx: Context,
     registry: &mut RegistryQueryer<'_>,

--- a/src/cargo/core/resolver/mod.rs
+++ b/src/cargo/core/resolver/mod.rs
@@ -62,6 +62,7 @@ use crate::util::profile;
 
 use self::context::Context;
 use self::dep_cache::RegistryQueryer;
+use self::features::RequestedFeatures;
 use self::types::{ConflictMap, ConflictReason, DepsFrame};
 use self::types::{FeaturesSet, RcVecIter, RemainingDeps, ResolverProgress};
 
@@ -76,6 +77,7 @@ mod context;
 mod dep_cache;
 mod encode;
 mod errors;
+pub mod features;
 mod resolve;
 mod types;
 
@@ -368,9 +370,11 @@ fn activate_deps_loop(
             let pid = candidate.package_id();
             let opts = ResolveOpts {
                 dev_deps: false,
-                features: Rc::clone(&features),
-                all_features: false,
-                uses_default_features: dep.uses_default_features(),
+                features: RequestedFeatures {
+                    features: Rc::clone(&features),
+                    all_features: false,
+                    uses_default_features: dep.uses_default_features(),
+                },
             };
             trace!(
                 "{}[{}]>{} trying {}",

--- a/src/cargo/core/resolver/mod.rs
+++ b/src/cargo/core/resolver/mod.rs
@@ -69,6 +69,7 @@ use self::types::{FeaturesSet, RcVecIter, RemainingDeps, ResolverProgress};
 pub use self::encode::Metadata;
 pub use self::encode::{EncodableDependency, EncodablePackageId, EncodableResolve};
 pub use self::errors::{ActivateError, ActivateResult, ResolveError};
+pub use self::features::HasDevUnits;
 pub use self::resolve::{Resolve, ResolveVersion};
 pub use self::types::ResolveOpts;
 

--- a/src/cargo/ops/cargo_clean.rs
+++ b/src/cargo/ops/cargo_clean.rs
@@ -4,8 +4,8 @@ use std::fs;
 use std::path::Path;
 
 use crate::core::compiler::unit_dependencies;
-use crate::core::compiler::UnitInterner;
 use crate::core::compiler::{BuildConfig, BuildContext, CompileKind, CompileMode, Context};
+use crate::core::compiler::{RustcTargetData, UnitInterner};
 use crate::core::profiles::{Profiles, UnitFor};
 use crate::core::Workspace;
 use crate::ops;
@@ -61,6 +61,7 @@ pub fn clean(ws: &Workspace<'_>, opts: &CleanOptions<'_>) -> CargoResult<()> {
     let interner = UnitInterner::new();
     let mut build_config = BuildConfig::new(config, Some(1), &opts.target, CompileMode::Build)?;
     build_config.requested_profile = opts.requested_profile;
+    let target_data = RustcTargetData::new(ws, build_config.requested_kind)?;
     let bcx = BuildContext::new(
         ws,
         &packages,
@@ -69,6 +70,7 @@ pub fn clean(ws: &Workspace<'_>, opts: &CleanOptions<'_>) -> CargoResult<()> {
         profiles,
         &interner,
         HashMap::new(),
+        target_data,
     )?;
     let mut units = Vec::new();
 

--- a/src/cargo/ops/cargo_clean.rs
+++ b/src/cargo/ops/cargo_clean.rs
@@ -116,8 +116,12 @@ pub fn clean(ws: &Workspace<'_>, opts: &CleanOptions<'_>) -> CargoResult<()> {
                                 *mode,
                             )
                         };
-                        let features = features
-                            .activated_features(pkg.package_id(), unit_for.is_for_build_dep());
+                        // Use unverified here since this is being more
+                        // exhaustive than what is actually needed.
+                        let features = features.activated_features_unverified(
+                            pkg.package_id(),
+                            unit_for.is_for_build_dep(),
+                        );
                         units.push(bcx.units.intern(
                             pkg, target, profile, *kind, *mode, features, /*is_std*/ false,
                         ));

--- a/src/cargo/ops/cargo_clean.rs
+++ b/src/cargo/ops/cargo_clean.rs
@@ -7,7 +7,9 @@ use crate::core::compiler::unit_dependencies;
 use crate::core::compiler::{BuildConfig, BuildContext, CompileKind, CompileMode, Context};
 use crate::core::compiler::{RustcTargetData, UnitInterner};
 use crate::core::profiles::{Profiles, UnitFor};
-use crate::core::resolver::features::{FeatureResolver, HasDevUnits, RequestedFeatures};
+use crate::core::resolver::features::{
+    FeatureResolver, FeaturesFor, HasDevUnits, RequestedFeatures,
+};
 use crate::core::{PackageIdSpec, Workspace};
 use crate::ops;
 use crate::util::errors::{CargoResult, CargoResultExt};
@@ -118,10 +120,12 @@ pub fn clean(ws: &Workspace<'_>, opts: &CleanOptions<'_>) -> CargoResult<()> {
                         };
                         // Use unverified here since this is being more
                         // exhaustive than what is actually needed.
-                        let features = features.activated_features_unverified(
-                            pkg.package_id(),
-                            unit_for.is_for_build_dep(),
-                        );
+                        let features_for = match unit_for.is_for_build_dep() {
+                            true => FeaturesFor::BuildDep,
+                            false => FeaturesFor::NormalOrDev,
+                        };
+                        let features =
+                            features.activated_features_unverified(pkg.package_id(), features_for);
                         units.push(bcx.units.intern(
                             pkg, target, profile, *kind, *mode, features, /*is_std*/ false,
                         ));

--- a/src/cargo/ops/cargo_clean.rs
+++ b/src/cargo/ops/cargo_clean.rs
@@ -6,7 +6,6 @@ use std::path::Path;
 use crate::core::compiler::unit_dependencies;
 use crate::core::compiler::{BuildConfig, BuildContext, CompileKind, CompileMode, Context};
 use crate::core::compiler::{RustcTargetData, UnitInterner};
-use crate::core::dependency::DepKind;
 use crate::core::profiles::{Profiles, UnitFor};
 use crate::core::resolver::features::{FeatureResolver, RequestedFeatures};
 use crate::core::{PackageIdSpec, Workspace};
@@ -117,13 +116,11 @@ pub fn clean(ws: &Workspace<'_>, opts: &CleanOptions<'_>) -> CargoResult<()> {
                                 *mode,
                             )
                         };
-                        for dep_kind in &[DepKind::Normal, DepKind::Development, DepKind::Build] {
-                            let features =
-                                features.activated_features(pkg.package_id(), *dep_kind, *kind);
-                            units.push(bcx.units.intern(
-                                pkg, target, profile, *kind, *mode, features, /*is_std*/ false,
-                            ));
-                        }
+                        let features = features
+                            .activated_features(pkg.package_id(), unit_for.is_for_build_dep());
+                        units.push(bcx.units.intern(
+                            pkg, target, profile, *kind, *mode, features, /*is_std*/ false,
+                        ));
                     }
                 }
             }

--- a/src/cargo/ops/cargo_clean.rs
+++ b/src/cargo/ops/cargo_clean.rs
@@ -87,6 +87,7 @@ pub fn clean(ws: &Workspace<'_>, opts: &CleanOptions<'_>) -> CargoResult<()> {
         &requested_features,
         &specs,
         bcx.build_config.requested_kind,
+        true,
     )?;
     let mut units = Vec::new();
 

--- a/src/cargo/ops/cargo_clean.rs
+++ b/src/cargo/ops/cargo_clean.rs
@@ -7,7 +7,7 @@ use crate::core::compiler::unit_dependencies;
 use crate::core::compiler::{BuildConfig, BuildContext, CompileKind, CompileMode, Context};
 use crate::core::compiler::{RustcTargetData, UnitInterner};
 use crate::core::profiles::{Profiles, UnitFor};
-use crate::core::resolver::features::{FeatureResolver, RequestedFeatures};
+use crate::core::resolver::features::{FeatureResolver, HasDevUnits, RequestedFeatures};
 use crate::core::{PackageIdSpec, Workspace};
 use crate::ops;
 use crate::util::errors::{CargoResult, CargoResultExt};
@@ -86,7 +86,7 @@ pub fn clean(ws: &Workspace<'_>, opts: &CleanOptions<'_>) -> CargoResult<()> {
         &requested_features,
         &specs,
         bcx.build_config.requested_kind,
-        true,
+        HasDevUnits::Yes,
     )?;
     let mut units = Vec::new();
 

--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -313,8 +313,15 @@ pub fn compile_ws<'a>(
     let specs = spec.to_package_id_specs(ws)?;
     let dev_deps = ws.require_optional_deps() || filter.need_dev_deps(build_config.mode);
     let opts = ResolveOpts::new(dev_deps, features, all_features, !no_default_features);
-    let resolve =
-        ops::resolve_ws_with_opts(ws, &target_data, build_config.requested_kind, &opts, &specs)?;
+    let has_dev_units = filter.need_dev_deps(build_config.mode);
+    let resolve = ops::resolve_ws_with_opts(
+        ws,
+        &target_data,
+        build_config.requested_kind,
+        &opts,
+        &specs,
+        has_dev_units,
+    )?;
     let WorkspaceResolve {
         mut pkg_set,
         workspace_resolve,

--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -311,7 +311,7 @@ pub fn compile_ws<'a>(
     let specs = spec.to_package_id_specs(ws)?;
     let dev_deps = ws.require_optional_deps() || filter.need_dev_deps(build_config.mode);
     let opts = ResolveOpts::new(dev_deps, features, all_features, !no_default_features);
-    let resolve = ops::resolve_ws_with_opts(ws, opts, &specs)?;
+    let resolve = ops::resolve_ws_with_opts(ws, &opts, &specs)?;
     let WorkspaceResolve {
         mut pkg_set,
         workspace_resolve,

--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -31,7 +31,7 @@ use std::sync::Arc;
 use crate::core::compiler::standard_lib;
 use crate::core::compiler::unit_dependencies::build_unit_dependencies;
 use crate::core::compiler::{BuildConfig, BuildContext, Compilation, Context};
-use crate::core::compiler::{CompileKind, CompileMode, Unit};
+use crate::core::compiler::{CompileKind, CompileMode, RustcTargetData, Unit};
 use crate::core::compiler::{DefaultExecutor, Executor, UnitInterner};
 use crate::core::profiles::{Profiles, UnitFor};
 use crate::core::resolver::{Resolve, ResolveOpts};
@@ -306,6 +306,7 @@ pub fn compile_ws<'a>(
         build_config.requested_profile,
         ws.features(),
     )?;
+    let target_data = RustcTargetData::new(ws, build_config.requested_kind)?;
 
     let specs = spec.to_package_id_specs(ws)?;
     let dev_deps = ws.require_optional_deps() || filter.need_dev_deps(build_config.mode);
@@ -397,7 +398,9 @@ pub fn compile_ws<'a>(
         profiles,
         &interner,
         HashMap::new(),
+        target_data,
     )?;
+
     let units = generate_targets(
         ws,
         &to_builds,

--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -946,8 +946,8 @@ fn resolve_all_features(
     // Include features enabled for use by dependencies so targets can also use them with the
     // required-features field when deciding whether to be built or skipped.
     for (dep_id, deps) in resolve_with_overrides.deps(package_id) {
-        for feature in resolved_features.activated_features(dep_id, false) {
-            for dep in deps {
+        for dep in deps {
+            for feature in resolved_features.activated_features(dep_id, dep.is_build()) {
                 features.insert(dep.name_in_toml().to_string() + "/" + &feature);
             }
         }

--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -35,7 +35,7 @@ use crate::core::compiler::{CompileKind, CompileMode, RustcTargetData, Unit};
 use crate::core::compiler::{DefaultExecutor, Executor, UnitInterner};
 use crate::core::profiles::{Profiles, UnitFor};
 use crate::core::resolver::features;
-use crate::core::resolver::{Resolve, ResolveOpts};
+use crate::core::resolver::{HasDevUnits, Resolve, ResolveOpts};
 use crate::core::{LibKind, Package, PackageSet, Target};
 use crate::core::{PackageId, PackageIdSpec, TargetKind, Workspace};
 use crate::ops;
@@ -312,7 +312,10 @@ pub fn compile_ws<'a>(
     let specs = spec.to_package_id_specs(ws)?;
     let dev_deps = ws.require_optional_deps() || filter.need_dev_deps(build_config.mode);
     let opts = ResolveOpts::new(dev_deps, features, all_features, !no_default_features);
-    let has_dev_units = filter.need_dev_deps(build_config.mode);
+    let has_dev_units = match filter.need_dev_deps(build_config.mode) {
+        true => HasDevUnits::Yes,
+        false => HasDevUnits::No,
+    };
     let resolve = ops::resolve_ws_with_opts(
         ws,
         &target_data,

--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -746,6 +746,9 @@ fn generate_targets<'a>(
             bcx.profiles
                 .get_profile(pkg.package_id(), ws.is_member(pkg), unit_for, target_mode);
 
+        // Root units are not a dependency of anything, so they are always
+        // DepKind::Normal. Their features are driven by the command-line
+        // arguments.
         let features = Vec::from(resolved_features.activated_features(
             pkg.package_id(),
             DepKind::Normal,
@@ -934,6 +937,11 @@ fn generate_targets<'a>(
     Ok(units.into_iter().collect())
 }
 
+/// Gets all of the features enabled for a package, plus its dependencies'
+/// features.
+///
+/// Dependencies are added as `dep_name/feat_name` because `required-features`
+/// wants to support that syntax.
 fn resolve_all_features(
     resolve_with_overrides: &Resolve,
     resolved_features: &features::ResolvedFeatures,

--- a/src/cargo/ops/cargo_doc.rs
+++ b/src/cargo/ops/cargo_doc.rs
@@ -1,5 +1,5 @@
 use crate::core::compiler::RustcTargetData;
-use crate::core::resolver::ResolveOpts;
+use crate::core::resolver::{HasDevUnits, ResolveOpts};
 use crate::core::{Shell, Workspace};
 use crate::ops;
 use crate::util::CargoResult;
@@ -27,8 +27,14 @@ pub fn doc(ws: &Workspace<'_>, options: &DocOptions<'_>) -> CargoResult<()> {
     );
     let requested_kind = options.compile_opts.build_config.requested_kind;
     let target_data = RustcTargetData::new(ws, requested_kind)?;
-    let ws_resolve =
-        ops::resolve_ws_with_opts(ws, &target_data, requested_kind, &opts, &specs, false)?;
+    let ws_resolve = ops::resolve_ws_with_opts(
+        ws,
+        &target_data,
+        requested_kind,
+        &opts,
+        &specs,
+        HasDevUnits::No,
+    )?;
 
     let ids = specs
         .iter()

--- a/src/cargo/ops/cargo_doc.rs
+++ b/src/cargo/ops/cargo_doc.rs
@@ -24,7 +24,7 @@ pub fn doc(ws: &Workspace<'_>, options: &DocOptions<'_>) -> CargoResult<()> {
         options.compile_opts.all_features,
         !options.compile_opts.no_default_features,
     );
-    let ws_resolve = ops::resolve_ws_with_opts(ws, opts, &specs)?;
+    let ws_resolve = ops::resolve_ws_with_opts(ws, &opts, &specs)?;
 
     let ids = specs
         .iter()

--- a/src/cargo/ops/cargo_doc.rs
+++ b/src/cargo/ops/cargo_doc.rs
@@ -27,7 +27,8 @@ pub fn doc(ws: &Workspace<'_>, options: &DocOptions<'_>) -> CargoResult<()> {
     );
     let requested_kind = options.compile_opts.build_config.requested_kind;
     let target_data = RustcTargetData::new(ws, requested_kind)?;
-    let ws_resolve = ops::resolve_ws_with_opts(ws, &target_data, requested_kind, &opts, &specs)?;
+    let ws_resolve =
+        ops::resolve_ws_with_opts(ws, &target_data, requested_kind, &opts, &specs, false)?;
 
     let ids = specs
         .iter()

--- a/src/cargo/ops/cargo_doc.rs
+++ b/src/cargo/ops/cargo_doc.rs
@@ -1,3 +1,4 @@
+use crate::core::compiler::RustcTargetData;
 use crate::core::resolver::ResolveOpts;
 use crate::core::{Shell, Workspace};
 use crate::ops;
@@ -24,7 +25,9 @@ pub fn doc(ws: &Workspace<'_>, options: &DocOptions<'_>) -> CargoResult<()> {
         options.compile_opts.all_features,
         !options.compile_opts.no_default_features,
     );
-    let ws_resolve = ops::resolve_ws_with_opts(ws, &opts, &specs)?;
+    let requested_kind = options.compile_opts.build_config.requested_kind;
+    let target_data = RustcTargetData::new(ws, requested_kind)?;
+    let ws_resolve = ops::resolve_ws_with_opts(ws, &target_data, requested_kind, &opts, &specs)?;
 
     let ids = specs
         .iter()

--- a/src/cargo/ops/cargo_generate_lockfile.rs
+++ b/src/cargo/ops/cargo_generate_lockfile.rs
@@ -24,7 +24,7 @@ pub fn generate_lockfile(ws: &Workspace<'_>) -> CargoResult<()> {
     let resolve = ops::resolve_with_previous(
         &mut registry,
         ws,
-        ResolveOpts::everything(),
+        &ResolveOpts::everything(),
         None,
         None,
         &[],
@@ -64,7 +64,7 @@ pub fn update_lockfile(ws: &Workspace<'_>, opts: &UpdateOptions<'_>) -> CargoRes
                     ops::resolve_with_previous(
                         &mut registry,
                         ws,
-                        ResolveOpts::everything(),
+                        &ResolveOpts::everything(),
                         None,
                         None,
                         &[],
@@ -110,7 +110,7 @@ pub fn update_lockfile(ws: &Workspace<'_>, opts: &UpdateOptions<'_>) -> CargoRes
     let resolve = ops::resolve_with_previous(
         &mut registry,
         ws,
-        ResolveOpts::everything(),
+        &ResolveOpts::everything(),
         Some(&previous_resolve),
         Some(&to_avoid),
         &[],

--- a/src/cargo/ops/cargo_install.rs
+++ b/src/cargo/ops/cargo_install.rs
@@ -8,7 +8,7 @@ use tempfile::Builder as TempFileBuilder;
 
 use crate::core::compiler::Freshness;
 use crate::core::compiler::{CompileKind, DefaultExecutor, Executor, RustcTargetData};
-use crate::core::resolver::ResolveOpts;
+use crate::core::resolver::{HasDevUnits, ResolveOpts};
 use crate::core::{Edition, Package, PackageId, PackageIdSpec, Source, SourceId, Workspace};
 use crate::ops;
 use crate::ops::common_for_install_and_uninstall::*;
@@ -506,7 +506,7 @@ fn check_yanked_install(ws: &Workspace<'_>) -> CargoResult<()> {
         CompileKind::Host,
         &ResolveOpts::everything(),
         &specs,
-        false,
+        HasDevUnits::No,
     )?;
     let mut sources = ws_resolve.pkg_set.sources_mut();
 

--- a/src/cargo/ops/cargo_install.rs
+++ b/src/cargo/ops/cargo_install.rs
@@ -495,7 +495,7 @@ fn check_yanked_install(ws: &Workspace<'_>) -> CargoResult<()> {
     // It would be best if `source` could be passed in here to avoid a
     // duplicate "Updating", but since `source` is taken by value, then it
     // wouldn't be available for `compile_ws`.
-    let ws_resolve = ops::resolve_ws_with_opts(ws, ResolveOpts::everything(), &specs)?;
+    let ws_resolve = ops::resolve_ws_with_opts(ws, &ResolveOpts::everything(), &specs)?;
     let mut sources = ws_resolve.pkg_set.sources_mut();
 
     // Checking the yanked status involves taking a look at the registry and

--- a/src/cargo/ops/cargo_install.rs
+++ b/src/cargo/ops/cargo_install.rs
@@ -506,6 +506,7 @@ fn check_yanked_install(ws: &Workspace<'_>) -> CargoResult<()> {
         CompileKind::Host,
         &ResolveOpts::everything(),
         &specs,
+        false,
     )?;
     let mut sources = ws_resolve.pkg_set.sources_mut();
 

--- a/src/cargo/ops/cargo_install.rs
+++ b/src/cargo/ops/cargo_install.rs
@@ -7,7 +7,7 @@ use anyhow::{bail, format_err};
 use tempfile::Builder as TempFileBuilder;
 
 use crate::core::compiler::Freshness;
-use crate::core::compiler::{CompileKind, DefaultExecutor, Executor};
+use crate::core::compiler::{CompileKind, DefaultExecutor, Executor, RustcTargetData};
 use crate::core::resolver::ResolveOpts;
 use crate::core::{Edition, Package, PackageId, PackageIdSpec, Source, SourceId, Workspace};
 use crate::ops;
@@ -492,10 +492,21 @@ fn check_yanked_install(ws: &Workspace<'_>) -> CargoResult<()> {
         return Ok(());
     }
     let specs = vec![PackageIdSpec::from_package_id(ws.current()?.package_id())];
+    // CompileKind here doesn't really matter, it's only needed for features.
+    let target_data = RustcTargetData::new(ws, CompileKind::Host)?;
     // It would be best if `source` could be passed in here to avoid a
     // duplicate "Updating", but since `source` is taken by value, then it
     // wouldn't be available for `compile_ws`.
-    let ws_resolve = ops::resolve_ws_with_opts(ws, &ResolveOpts::everything(), &specs)?;
+    // TODO: It would be easier to use resolve_ws, but it does not honor
+    // require_optional_deps to avoid writing the lock file. It might be good
+    // to try to fix that.
+    let ws_resolve = ops::resolve_ws_with_opts(
+        ws,
+        &target_data,
+        CompileKind::Host,
+        &ResolveOpts::everything(),
+        &specs,
+    )?;
     let mut sources = ws_resolve.pkg_set.sources_mut();
 
     // Checking the yanked status involves taking a look at the registry and

--- a/src/cargo/ops/cargo_output_metadata.rs
+++ b/src/cargo/ops/cargo_output_metadata.rs
@@ -1,7 +1,6 @@
 use crate::core::compiler::{CompileKind, CompileTarget, RustcTargetData};
-use crate::core::resolver::{Resolve, ResolveOpts};
-
 use crate::core::dependency::DepKind;
+use crate::core::resolver::{HasDevUnits, Resolve, ResolveOpts};
 use crate::core::{Dependency, InternedString, Package, PackageId, Workspace};
 use crate::ops::{self, Packages};
 use crate::util::CargoResult;
@@ -125,7 +124,7 @@ fn build_resolve_graph(
         requested_kind,
         &resolve_opts,
         &specs,
-        true,
+        HasDevUnits::Yes,
     )?;
     // Download all Packages. This is needed to serialize the information
     // for every package. In theory this could honor target filtering,

--- a/src/cargo/ops/cargo_output_metadata.rs
+++ b/src/cargo/ops/cargo_output_metadata.rs
@@ -122,7 +122,7 @@ fn build_resolve_graph(
     };
     // Resolve entire workspace.
     let specs = Packages::All.to_package_id_specs(ws)?;
-    let ws_resolve = ops::resolve_ws_with_opts(ws, resolve_opts, &specs)?;
+    let ws_resolve = ops::resolve_ws_with_opts(ws, &resolve_opts, &specs)?;
     // Download all Packages. This is needed to serialize the information
     // for every package. In theory this could honor target filtering,
     // but that would be somewhat complex.

--- a/src/cargo/ops/cargo_output_metadata.rs
+++ b/src/cargo/ops/cargo_output_metadata.rs
@@ -173,7 +173,7 @@ fn build_resolve_graph_r(
     if node_map.contains_key(&pkg_id) {
         return;
     }
-    let features = resolve.features(pkg_id).into_iter().cloned().collect();
+    let features = resolve.features(pkg_id).iter().cloned().collect();
 
     let deps: Vec<Dep> = resolve
         .deps(pkg_id)

--- a/src/cargo/ops/cargo_output_metadata.rs
+++ b/src/cargo/ops/cargo_output_metadata.rs
@@ -119,8 +119,14 @@ fn build_resolve_graph(
         metadata_opts.all_features,
         !metadata_opts.no_default_features,
     );
-    let ws_resolve =
-        ops::resolve_ws_with_opts(ws, &target_data, requested_kind, &resolve_opts, &specs)?;
+    let ws_resolve = ops::resolve_ws_with_opts(
+        ws,
+        &target_data,
+        requested_kind,
+        &resolve_opts,
+        &specs,
+        true,
+    )?;
     // Download all Packages. This is needed to serialize the information
     // for every package. In theory this could honor target filtering,
     // but that would be somewhat complex.

--- a/src/cargo/ops/cargo_package.rs
+++ b/src/cargo/ops/cargo_package.rs
@@ -154,7 +154,7 @@ fn build_lock(ws: &Workspace<'_>) -> CargoResult<String> {
     // Regenerate Cargo.lock using the old one as a guide.
     let specs = vec![PackageIdSpec::from_package_id(new_pkg.package_id())];
     let tmp_ws = Workspace::ephemeral(new_pkg, ws.config(), None, true)?;
-    let new_resolve = ops::resolve_ws_with_opts(&tmp_ws, ResolveOpts::everything(), &specs)?;
+    let new_resolve = ops::resolve_ws_with_opts(&tmp_ws, &ResolveOpts::everything(), &specs)?;
 
     if let Some(orig_resolve) = orig_resolve {
         compare_resolve(

--- a/src/cargo/ops/resolve.rs
+++ b/src/cargo/ops/resolve.rs
@@ -13,7 +13,7 @@
 use crate::core::compiler::{CompileKind, RustcTargetData};
 use crate::core::registry::PackageRegistry;
 use crate::core::resolver::features::{FeatureResolver, ResolvedFeatures};
-use crate::core::resolver::{self, Resolve, ResolveOpts};
+use crate::core::resolver::{self, HasDevUnits, Resolve, ResolveOpts};
 use crate::core::summary::Summary;
 use crate::core::Feature;
 use crate::core::{PackageId, PackageIdSpec, PackageSet, Source, SourceId, Workspace};
@@ -78,7 +78,7 @@ pub fn resolve_ws_with_opts<'a>(
     requested_target: CompileKind,
     opts: &ResolveOpts,
     specs: &[PackageIdSpec],
-    has_dev_units: bool,
+    has_dev_units: HasDevUnits,
 ) -> CargoResult<WorkspaceResolve<'a>> {
     let mut registry = PackageRegistry::new(ws.config())?;
     let mut add_patches = true;

--- a/src/cargo/ops/resolve.rs
+++ b/src/cargo/ops/resolve.rs
@@ -117,7 +117,7 @@ pub fn resolve_ws_with_opts<'a>(
     let resolved_with_overrides = resolve_with_previous(
         &mut registry,
         ws,
-        &opts,
+        opts,
         resolve.as_ref(),
         None,
         specs,

--- a/src/cargo/ops/resolve.rs
+++ b/src/cargo/ops/resolve.rs
@@ -77,6 +77,7 @@ pub fn resolve_ws_with_opts<'a>(
     requested_target: CompileKind,
     opts: &ResolveOpts,
     specs: &[PackageIdSpec],
+    has_dev_units: bool,
 ) -> CargoResult<WorkspaceResolve<'a>> {
     let mut registry = PackageRegistry::new(ws.config())?;
     let mut add_patches = true;
@@ -131,6 +132,7 @@ pub fn resolve_ws_with_opts<'a>(
         &opts.features,
         specs,
         requested_target,
+        has_dev_units,
     )?;
 
     Ok(WorkspaceResolve {

--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -473,3 +473,65 @@ cargo +nightly -Zunstable-options -Zconfig-include --config somefile.toml build
 ```
 
 CLI paths are relative to the current working directory.
+
+## Features
+
+The `-Zfeatures` option causes Cargo to use a new feature resolver that can
+resolve features differently from before. It takes a comma separated list of
+options to indicate which new behaviors to enable. With no options, it should
+behave the same as without the flag.
+
+```console
+cargo +nightly -Zfeatures=itarget,build_dep
+```
+
+The available options are:
+
+* `itarget` — Ignores features for target-specific dependencies for targets
+  that don't match the current compile target. For example:
+
+  ```toml
+  [dependency.common]
+  version = "1.0"
+  features = ["f1"]
+
+  [target.'cfg(windows)'.dependencies.common]
+  version = "1.0"
+  features = ["f2"]
+  ```
+
+  When building this example for a non-Windows platform, the `f2` feature will
+  *not* be enabled.
+
+* `build_dep` — Prevents features enabled on build dependencies from being
+  enabled for normal dependencies. For example:
+
+  ```toml
+  [dependencies]
+  log = "0.4"
+
+  [build-dependencies]
+  log = {version = "0.4", features=['std']}
+  ```
+
+  When building the build script, the `log` crate will be built with the `std`
+  feature. When building the library of your package, it will not enable the
+  feature.
+
+* `dev_dep` — Prevents features enabled on dev dependencies from being enabled
+  for normal dependencies. For example:
+
+  ```toml
+  [dependencies]
+  serde = {version = "1.0", default-features = false}
+
+  [dev-dependencies]
+  serde = {version = "1.0", features = ["std"]}
+  ```
+
+  In this example, the library will normally link against `serde` without the
+  `std` feature. However, when built as a test or example, it will include the
+  `std` feature.
+
+* `compare` — This option compares the resolved features to the old resolver,
+  and will print any differences.

--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -533,5 +533,9 @@ The available options are:
   `std` feature. However, when built as a test or example, it will include the
   `std` feature.
 
+  This mode is ignored if you are building any test, bench, or example. That
+  is, dev dependency features will still be unified if you run commands like
+  `cargo test` or `cargo build --all-targets`.
+
 * `compare` — This option compares the resolved features to the old resolver,
   and will print any differences.

--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -537,5 +537,7 @@ The available options are:
   is, dev dependency features will still be unified if you run commands like
   `cargo test` or `cargo build --all-targets`.
 
+* `all` — Enable all feature options (`itarget,build_dep,dev_dep`).
+
 * `compare` — This option compares the resolved features to the old resolver,
   and will print any differences.

--- a/tests/testsuite/main.rs
+++ b/tests/testsuite/main.rs
@@ -44,6 +44,7 @@ mod doc;
 mod edition;
 mod error;
 mod features;
+mod features2;
 mod fetch;
 mod fix;
 mod freshness;

--- a/tests/testsuite/profile_config.rs
+++ b/tests/testsuite/profile_config.rs
@@ -413,7 +413,7 @@ fn named_config_profile() {
     assert_eq!(p.overflow_checks, true); // "dev" built-in (ignore package override)
 
     // build-override
-    let bo = profiles.get_profile(a_pkg, true, UnitFor::new_build(), CompileMode::Build);
+    let bo = profiles.get_profile(a_pkg, true, UnitFor::new_build(false), CompileMode::Build);
     assert_eq!(bo.name, "foo");
     assert_eq!(bo.codegen_units, Some(6)); // "foo" build override from config
     assert_eq!(bo.opt_level, "1"); // SAME as normal


### PR DESCRIPTION
This adds a new resolver which handles feature unification independently of the main resolver. This can be enabled with the `-Zfeatures` flag which takes a comma-separated list of options to enable new behaviors. See `unstable.md` docs for details.

There are two significant behavior changes:

1. Ignore targets that are not enabled.
2. Do not unify features between build_deps, dev_deps, and normal deps.

The "forks" in the unit graph are handled by adding `DepKind` to `UnitFor`. The feature resolver tracks features independently for the different dependency kinds.

Unfortunately this currently does not support decoupling proc_macro dependencies. This is because at resolve time it does not know which dependencies are proc_macros. Moving feature resolution to after the packages are downloaded would require massive changes, and would make the unit computation much more complex. Nobody to my knowledge has requested this capability, presumably because proc_macros are relatively new, and they tend not to have very many dependencies, and those dependencies tend to be proc-macro specific (like syn/quote). I'd like to lean towards adding proc-macro to the index so that it can be known during resolve time, which would be much easier to implement, but with the downside of needing to add a new field to the index.

I did not update `cargo metadata`, yet. It's not really clear how it should behave. I think I'll need to investigate how people are currently using the feature information and figure out how it should work. Perhaps adding features to "dep_kinds" will be the solution, but I'm not sure.

The goal is to try to gather feedback about how well this new resolver works. There are two important things to check: whether it breaks a project, and how much does it increases compile time (since packages can be built multiple times with different features). I'd like to stabilize it one piece at a time assuming the disruption is not too great. If a project breaks or builds slower, the user can implement a backwards-compatible workaround of sprinkling additional features into `Cargo.toml` dependencies. I think `itarget` is a good candidate to try to stabilize first, since it is less likely to break things or change how things are built. If it does cause too much disruption, then I think we'll need to consider making it optional, enabled *somehow*.

There is an environment variable that can be set which forces Cargo to use the new feature resolver. This can be used in Cargo's own testsuite to explore which tests behave differently with the different features set.
