### PR TITLE
Stabilize config-profile.

### DIFF
--- a/src/bin/cargo/cli.rs
+++ b/src/bin/cargo/cli.rs
@@ -36,7 +36,6 @@ Available unstable (nightly-only) flags:
     -Z minimal-versions -- Install minimal dependency versions instead of maximum
     -Z no-index-update  -- Do not update the registry, avoids a network request for benchmarking
     -Z unstable-options -- Allow the usage of unstable options
-    -Z config-profile   -- Read profiles from .cargo/config files
     -Z timings          -- Display concurrency information
     -Z doctest-xcompile -- Compile and run doctests for non-host target using runner config
 

--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -331,7 +331,6 @@ pub struct CliUnstable {
     pub minimal_versions: bool,
     pub package_features: bool,
     pub advanced_env: bool,
-    pub config_profile: bool,
     pub config_include: bool,
     pub dual_proc_macros: bool,
     pub mtime_on_use: bool,
@@ -397,7 +396,6 @@ impl CliUnstable {
             "minimal-versions" => self.minimal_versions = parse_empty(k, v)?,
             "package-features" => self.package_features = parse_empty(k, v)?,
             "advanced-env" => self.advanced_env = parse_empty(k, v)?,
-            "config-profile" => self.config_profile = parse_empty(k, v)?,
             "config-include" => self.config_include = parse_empty(k, v)?,
             "dual-proc-macros" => self.dual_proc_macros = parse_empty(k, v)?,
             // can also be set in .cargo/config or with and ENV

--- a/src/doc/src/reference/config.md
+++ b/src/doc/src/reference/config.md
@@ -87,6 +87,21 @@ retry = 2                   # network retries
 git-fetch-with-cli = true   # use the `git` executable for git operations
 offline = false             # do not access the network
 
+[profile.<name>]         # Modify profile settings via config.
+opt-level = 0            # Optimization level.
+debug = true             # Include debug info.
+debug-assertions = true  # Enables debug assertions.
+overflow-checks = true   # Enables runtime integer overflow checks.
+lto = false              # Sets link-time optimization.
+panic = 'unwind'         # The panic strategy.
+incremental = true       # Incremental compilation.
+codegen-units = 16       # Number of code generation units.
+rpath = false            # Sets the rpath linking option.
+[profile.<name>.build-override]  # Overrides build-script settings.
+# Same keys for a normal profile.
+[profile.<name>.package.<name>]  # Override profile for a package.
+# Same keys for a normal profile (minus `panic`, `lto`, and `rpath`).
+
 [registries.<name>]  # registries other than crates.io
 index = "…"          # URL of the registry index
 token = "…"          # authentication token for the registry
@@ -548,6 +563,93 @@ proceed with locally cached data. If `false`, Cargo will access the network as
 needed, and generate an error if it encounters a network error.
 
 Can be overridden with the `--offline` command-line option.
+
+#### `[profile]`
+
+The `[profile]` table can be used to globally change profile settings, and
+override settings specified in `Cargo.toml`. It has the same syntax and
+options as profiles specified in `Cargo.toml`. See the [Profiles chapter] for
+details about the options.
+
+[Profiles chapter]: profiles.md
+
+##### `[profile.<name>.build-override]`
+* Environment: `CARGO_PROFILE_<name>_BUILD_OVERRIDE_<key>`
+
+The build-override table overrides settings for build scripts, proc macros,
+and their dependencies. It has the same keys as a normal profile. See the
+[overrides section](profiles.md#overrides) for more details.
+
+##### `[profile.<name>.package.<name>]`
+* Environment: not supported
+
+The package table overrides settings for specific packages. It has the same
+keys as a normal profile, minus the `panic`, `lto`, and `rpath` settings. See
+the [overrides section](profiles.md#overrides) for more details.
+
+##### `profile.<name>.codegen-units`
+* Type: integer
+* Default: See profile docs.
+* Environment: `CARGO_PROFILE_<name>_CODEGEN_UNITS`
+
+See [codegen-units](profiles.md#codegen-units).
+
+##### `profile.<name>.debug`
+* Type: integer or boolean
+* Default: See profile docs.
+* Environment: `CARGO_PROFILE_<name>_DEBUG`
+
+See [debug](profiles.md#debug).
+
+##### `profile.<name>.debug-assertions`
+* Type: boolean
+* Default: See profile docs.
+* Environment: `CARGO_PROFILE_<name>_DEBUG_ASSERTIONS`
+
+See [debug-assertions](profiles.md#debug-assertions).
+
+##### `profile.<name>.incremental`
+* Type: boolean
+* Default: See profile docs.
+* Environment: `CARGO_PROFILE_<name>_INCREMENTAL`
+
+See [incremental](profiles.md#incremental).
+
+##### `profile.<name>.lto`
+* Type: string or boolean
+* Default: See profile docs.
+* Environment: `CARGO_PROFILE_<name>_LTO`
+
+See [lto](profiles.md#lto).
+
+##### `profile.<name>.overflow-checks`
+* Type: boolean
+* Default: See profile docs.
+* Environment: `CARGO_PROFILE_<name>_OVERFLOW_CHECKS`
+
+See [overflow-checks](profiles.md#overflow-checks).
+
+##### `profile.<name>.opt-level`
+* Type: integer or string
+* Default: See profile docs.
+* Environment: `CARGO_PROFILE_<name>_OPT_LEVEL`
+
+See [opt-level](profiles.md#opt-level).
+
+##### `profile.<name>.panic`
+* Type: string
+* default: See profile docs.
+* Environment: `CARGO_PROFILE_<name>_PANIC`
+
+See [panic](profiles.md#panic).
+
+##### `profile.<name>.rpath`
+* Type: boolean
+* default: See profile docs.
+* Environment: `CARGO_PROFILE_<name>_RPATH`
+
+See [rpath](profiles.md#rpath).
+
 
 #### `[registries]`
 

--- a/src/doc/src/reference/environment-variables.md
+++ b/src/doc/src/reference/environment-variables.md
@@ -84,6 +84,16 @@ supported environment variables are:
 * `CARGO_NET_RETRY` — Number of times to retry network errors, see [`net.retry`].
 * `CARGO_NET_GIT_FETCH_WITH_CLI` — Enables the use of the `git` executable to fetch, see [`net.git-fetch-with-cli`].
 * `CARGO_NET_OFFLINE` — Offline mode, see [`net.offline`].
+* `CARGO_PROFILE_<name>_BUILD_OVERRIDE_<key>` — Override build script profile, see [`profile.<name>.build-override`].
+* `CARGO_PROFILE_<name>_CODEGEN_UNITS` — Set code generation units, see [`profile.<name>.codegen-units`].
+* `CARGO_PROFILE_<name>_DEBUG` — What kind of debug info to include, see [`profile.<name>.debug`].
+* `CARGO_PROFILE_<name>_DEBUG_ASSERTIONS` — Enable/disable debug assertions, see [`profile.<name>.debug-assertions`].
+* `CARGO_PROFILE_<name>_INCREMENTAL` — Enable/disable incremental compilation, see [`profile.<name>.incremental`].
+* `CARGO_PROFILE_<name>_LTO` — Link-time optimization, see [`profile.<name>.lto`].
+* `CARGO_PROFILE_<name>_OVERFLOW_CHECKS` — Enable/disable overflow checks, see [`profile.<name>.overflow-checks`].
+* `CARGO_PROFILE_<name>_OPT_LEVEL` — Set the optimization level, see [`profile.<name>.opt-level`].
+* `CARGO_PROFILE_<name>_PANIC` — The panic strategy to use, see [`profile.<name>.panic`].
+* `CARGO_PROFILE_<name>_RPATH` — The rpath linking option, see [`profile.<name>.rpath`].
 * `CARGO_REGISTRIES_<name>_INDEX` — URL of a registry index, see [`registries.<name>.index`].
 * `CARGO_REGISTRIES_<name>_TOKEN` — Authentication token of a registry, see [`registries.<name>.token`].
 * `CARGO_REGISTRY_DEFAULT` — Default registry for the `--registry` flag, see [`registry.default`].
@@ -129,6 +139,16 @@ supported environment variables are:
 [`net.retry`]: config.md#netretry
 [`net.git-fetch-with-cli`]: config.md#netgit-fetch-with-cli
 [`net.offline`]: config.md#netoffline
+[`profile.<name>.build-override`]: config.md#profilenamebuild-override
+[`profile.<name>.codegen-units`]: config.md#profilenamecodegen-units
+[`profile.<name>.debug`]: config.md#profilenamedebug
+[`profile.<name>.debug-assertions`]: config.md#profilenamedebug-assertions
+[`profile.<name>.incremental`]: config.md#profilenameincremental
+[`profile.<name>.lto`]: config.md#profilenamelto
+[`profile.<name>.overflow-checks`]: config.md#profilenameoverflow-checks
+[`profile.<name>.opt-level`]: config.md#profilenameopt-level
+[`profile.<name>.panic`]: config.md#profilenamepanic
+[`profile.<name>.rpath`]: config.md#profilenamerpath
 [`registries.<name>.index`]: config.md#registriesnameindex
 [`registries.<name>.token`]: config.md#registriesnametoken
 [`registry.default`]: config.md#registrydefault

--- a/src/doc/src/reference/profiles.md
+++ b/src/doc/src/reference/profiles.md
@@ -22,6 +22,12 @@ Cargo only looks at the profile settings in the `Cargo.toml` manifest at the
 root of the workspace. Profile settings defined in dependencies will be
 ignored.
 
+Additionally, profiles can be overridden from a [config] definition.
+Specifying a profile in a config file or environment variable will override
+the settings from `Cargo.toml`.
+
+[config]: config.md
+
 ### Profile settings
 
 The following is a list of settings that can be controlled in a profile.
@@ -392,6 +398,5 @@ will it export locally defined monomorphized items to be shared with other
 crates. When experimenting with optimizing dependencies for development,
 consider trying opt-level 1, which will apply some optimizations while still
 allowing monomorphized items to be shared.
-
 
 [nalgebra]: https://crates.io/crates/nalgebra

--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -151,26 +151,6 @@ lto = true
 ```
 
 
-### Config Profiles
-* Tracking Issue: [rust-lang/rust#48683](https://github.com/rust-lang/rust/issues/48683)
-* RFC: [#2282](https://github.com/rust-lang/rfcs/blob/master/text/2282-profile-dependencies.md)
-
-Profiles can be specified in `.cargo/config` files. The `-Z config-profile`
-command-line flag is required to use this feature. The format is the same as
-in a `Cargo.toml` manifest. If found in multiple config files, settings will
-be merged using the regular [config hierarchy](config.md#hierarchical-structure).
-Config settings take precedence over manifest settings.
-
-```toml
-[profile.dev]
-opt-level = 3
-```
-
-```
-cargo +nightly build -Z config-profile
-```
-
-
 ### Namespaced features
 * Original issue: [#1286](https://github.com/rust-lang/cargo/issues/1286)
 * Tracking Issue: [#5565](https://github.com/rust-lang/cargo/issues/5565)


### PR DESCRIPTION
This is a proposal to stabilize config-profiles. This feature was proposed in [RFC 2282](https://github.com/rust-lang/rfcs/pull/2282) and implemented in #5506. Tracking issue is rust-lang/rust#48683.

This is intended to land in 1.43 which will reach the stable channel on April 23rd.

This is a fairly straightforward extension of profiles where the exact same syntax from `Cargo.toml` can be specified in a config file. Environment variables are supported for everything except the `package` override table, where we do not support the ability to read arbitrary keys in the environment name.
