### PR TITLE
test: allow some flexibility in check::error_from_deep_recursion's expected diagnostic.

### DIFF
--- a/tests/testsuite/check.rs
+++ b/tests/testsuite/check.rs
@@ -766,7 +766,7 @@ fn error_from_deep_recursion() -> Result<(), fmt::Error> {
     p.cargo("check --message-format=json")
         .with_status(101)
         .with_stdout_contains(
-            "[..]\"message\":\"recursion limit reached while expanding the macro `m`\"[..]",
+            "[..]\"message\":\"recursion limit reached while expanding [..]`m[..]`\"[..]",
         )
         .run();
 


### PR DESCRIPTION
This should unblock https://github.com/rust-lang/rust/pull/68407, by loosening the expected output pattern.

As per https://github.com/rust-lang/rust/pull/68407#issuecomment-578189644, this is the change in the diagnostic:
```diff
-recursion limit reached while expanding the macro `m`
+recursion limit reached while expanding `m!`
```

Ideally I would use something like this regex:
```
recursion limit reached while expanding (the macro `m`|`m!`)
```
but AFAIK these tests don't support regexes.