### PR TITLE
Store maximum queue length

### DIFF
--- a/src/cargo/util/progress.rs
+++ b/src/cargo/util/progress.rs
@@ -224,6 +224,7 @@ impl<'cfg> State<'cfg> {
 
 impl Format {
     fn progress(&self, cur: usize, max: usize) -> Option<String> {
+        assert!(cur <= max);
         // Render the percentage at the far right and then figure how long the
         // progress bar is
         let pct = (cur as f64) / (max as f64);


### PR DESCRIPTION
Previously, the queue length was constantly decreasing as we built crates, which
meant that we were incorrectly displaying the progress bar. In debug builds,
this even led to panics (due to underflow on subtraction).

Not sure if we can add a test case for this. I have made the panic unconditional on release/debug though by explicitly checking that current is less than the maximum for the progress bar.

Fixes https://github.com/rust-lang/cargo/pull/7731#issuecomment-578358824.