### PR TITLE
fix mdbook test with ```ignore

### DIFF
--- a/src/doc/src/guide/dependencies.md
+++ b/src/doc/src/guide/dependencies.md
@@ -71,7 +71,7 @@ we choose to `cargo update`.
 
 You can now use the `regex` library in `main.rs`.
 
-```rust
+```rust,ignore
 use regex::Regex;
 
 fn main() {

--- a/src/doc/src/reference/build-script-examples.md
+++ b/src/doc/src/reference/build-script-examples.md
@@ -30,7 +30,7 @@ library call as part of the build script.
 
 First, let’s take a look at the directory structure of this package:
 
-```
+```ignore
 .
 ├── Cargo.toml
 ├── build.rs
@@ -128,7 +128,7 @@ a Rust library which calls into C to print “Hello, World!”.
 
 Like above, let’s first take a look at the package layout:
 
-```
+```ignore
 .
 ├── Cargo.toml
 ├── build.rs

--- a/src/doc/src/reference/cargo-targets.md
+++ b/src/doc/src/reference/cargo-targets.md
@@ -325,7 +325,7 @@ situations. For example, if you have a library where you want a *module* named
 compile anything in the `bin` directory as an executable. Here is a sample
 layout of this scenario:
 
-```
+```ignore
 ├── Cargo.toml
 └── src
     ├── lib.rs

--- a/src/doc/src/reference/environment-variables.md
+++ b/src/doc/src/reference/environment-variables.md
@@ -146,7 +146,7 @@ Note that this applies for running binaries with `cargo run` and `cargo test`
 as well. To get the value of any of these variables in a Rust program, do
 this:
 
-```rust
+```rust,ignore
 let version = env!("CARGO_PKG_VERSION");
 ```
 
@@ -201,7 +201,7 @@ Cargo sets several environment variables when build scripts are run. Because the
 are not yet set when the build script is compiled, the above example using `env!` won't work
 and instead you'll need to retrieve the values when the build script is run:
 
-```rust
+```rust,ignore
 use std::env;
 let out_dir = env::var("OUT_DIR").unwrap();
 ```

--- a/src/doc/src/reference/publishing.md
+++ b/src/doc/src/reference/publishing.md
@@ -221,7 +221,9 @@ for permission if [crates.io] doesn’t have all the scopes it would like to.
 An additional barrier to querying GitHub is that the organization may be
 actively denying third party access. To check this, you can go to:
 
-    https://github.com/organizations/:org/settings/oauth_application_policy
+```ignore
+https://github.com/organizations/:org/settings/oauth_application_policy
+```
 
 where `:org` is the name of the organization (e.g., `rust-lang`). You may see
 something like:

--- a/src/doc/src/reference/registries.md
+++ b/src/doc/src/reference/registries.md
@@ -38,7 +38,7 @@ As with most config values, the index may be specified with an environment
 variable instead of a config file. For example, setting the following
 environment variable will accomplish the same thing as defining a config file:
 
-```
+```ignore
 CARGO_REGISTRIES_MY_REGISTRY_INDEX=https://my-intranet:8080/git/index
 ```
 

--- a/src/doc/src/reference/specifying-dependencies.md
+++ b/src/doc/src/reference/specifying-dependencies.md
@@ -1,4 +1,4 @@
-## Specifying Dependencies
+# Specifying Dependencies
 
 Your crates can depend on other libraries from [crates.io] or other
 registries, `git` repositories, or subdirectories on your local file system.
@@ -393,7 +393,7 @@ baz = { version = "0.1", registry = "custom", package = "foo" }
 
 In this example, three crates are now available in your Rust code:
 
-```rust
+```rust,ignore
 extern crate foo; // crates.io
 extern crate bar; // git repository
 extern crate baz; // registry `custom`

--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -72,7 +72,7 @@ exact filename can be tricky since you need to parse JSON output. The
 that the artifacts are copied, so the originals are still in the `target`
 directory. Example:
 
-```
+```ignore
 cargo +nightly build --out-dir=out -Z unstable-options
 ```
 
@@ -88,7 +88,7 @@ while also passing it a `--target` option, as well as enabling
 `-Zunstable-features --enable-per-target-ignores` and passing along
 information from `.cargo/config`. See the rustc issue for more information.
 
-```
+```ignore
 cargo test --target foo -Zdoctest-xcompile
 ```
 
@@ -127,7 +127,7 @@ profiles from which the custom profile inherits are inherited too.
 
 For example, using `cargo build` with `--profile` and the manifest from above:
 
-```
+```ignore
 cargo +nightly build --profile release-lto -Z unstable-options
 ```
 
@@ -166,7 +166,7 @@ Config settings take precedence over manifest settings.
 opt-level = 3
 ```
 
-```
+```ignore
 cargo +nightly build -Z config-profile
 ```
 
@@ -207,7 +207,7 @@ information about which commands would be run without actually executing
 anything. This can be useful when integrating with another build tool.
 Example:
 
-```
+```ignore
 cargo +nightly build --build-plan -Z unstable-options
 ```
 
@@ -280,7 +280,7 @@ need to have the source code for the standard library available, and at this
 time the only supported method of doing so is to add the `rust-src` rust rustup
 component:
 
-```
+```ignore
 $ rustup component add rust-src --toolchain nightly
 ```
 
@@ -290,7 +290,7 @@ just forced to pass `--target` in one form or another.
 
 Usage looks like:
 
-```
+```ignore
 $ cargo new foo
 $ cd foo
 $ cargo +nightly run -Z build-std --target x86_64-unknown-linux-gnu
@@ -310,7 +310,7 @@ Using `-Z build-std` will implicitly compile the stable crates `core`, `std`,
 `test` crate. If you're working with an environment which does not support some
 of these crates, then you can pass an argument to `-Zbuild-std` as well:
 
-```
+```ignore
 $ cargo +nightly build -Z build-std=core,alloc
 ```
 
@@ -348,7 +348,7 @@ the tracking repository, and if it's not there please file a new issue!
 The `timings` feature gives some information about how long each compilation
 takes, and tracks concurrency information over time.
 
-```
+```ignore
 cargo +nightly build -Z timings
 ```
 


### PR DESCRIPTION
The rust reference repo has `mdbook test` as part of its CI, so when I was working on a PR here, `mdbook test` being broken confused me, so I figured I would make a PR to fix it.

I added some ignores to the problematic blocks (basically those with dependencies or using env vars)
and fixed some links to use ``` ``` formatting instead of tab formatting