### PR TITLE
[WIP] Checking for ssh scheme before trying to set_scheme as https...

### DIFF
--- a/src/cargo/util/canonical_url.rs
+++ b/src/cargo/util/canonical_url.rs
@@ -39,9 +39,14 @@ impl CanonicalUrl {
         // almost certainly not using the same case conversion rules that GitHub
         // does. (See issue #84)
         if url.host_str() == Some("github.com") {
-            url.set_scheme("https").unwrap();
-            let path = url.path().to_lowercase();
-            url.set_path(&path);
+            if url.scheme() == "ssh" {
+                let path = url.path().to_lowercase();
+                url.set_path(&path);
+            } else {
+                url.set_scheme("https").unwrap();
+                let path = url.path().to_lowercase();
+                url.set_path(&path);
+            }
         }
 
         // Repos can generally be accessed with or without `.git` extension.


### PR DESCRIPTION
...This resulted in a return value of `()`. Creating a new workspace with an ssh call, will cause an error when trying to parse this dependency.

This happens when using `cargo` as an API to create a new workspace like in [cargo-outdated](https://github.com/kbknapp/cargo-outdated), specially [here](https://github.com/kbknapp/cargo-outdated/blob/master/src/main.rs#L152). It was reported to us in issue https://github.com/kbknapp/cargo-outdated/issues/195 

I am very happy to discuss this PR and make any other changes recommend (or add this fix onto another branch). I chose the `rust-1.40.0` branch because that is what we are currently testing on, thus would only have this change in the diff for better visibility.