### PR TITLE
Fix required-features using renamed dependencies.

### DIFF
--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -903,9 +903,11 @@ fn resolve_all_features(
 
     // Include features enabled for use by dependencies so targets can also use them with the
     // required-features field when deciding whether to be built or skipped.
-    for (dep, _) in resolve_with_overrides.deps(package_id) {
-        for feature in resolve_with_overrides.features(dep) {
-            features.insert(dep.name().to_string() + "/" + feature);
+    for (dep_id, deps) in resolve_with_overrides.deps(package_id) {
+        for feature in resolve_with_overrides.features(dep_id) {
+            for dep in deps {
+                features.insert(dep.name_in_toml().to_string() + "/" + feature);
+            }
         }
     }
 


### PR DESCRIPTION
The dep_name/feat_name syntax in required-features should use the "name in toml" for dep_name, not the actual package name.  Otherwise, it is impossible to actually enable the feature (because the `--features` flag expects a "name in toml").