### PR TITLE
Emit report on error with Ztimings.

### DIFF
--- a/src/cargo/core/compiler/job_queue.rs
+++ b/src/cargo/core/compiler/job_queue.rs
@@ -676,6 +676,7 @@ impl<'a, 'cfg> DrainState<'a, 'cfg> {
         }
 
         let time_elapsed = util::elapsed(cx.bcx.config.creation_time().elapsed());
+        self.timings.finished(cx.bcx, &error)?;
 
         if let Some(e) = error {
             Err(e)
@@ -687,7 +688,6 @@ impl<'a, 'cfg> DrainState<'a, 'cfg> {
             if !cx.bcx.build_config.build_plan {
                 cx.bcx.config.shell().status("Finished", message)?;
             }
-            self.timings.finished(cx.bcx)?;
             Ok(())
         } else {
             debug!("queue: {:#?}", self.queue);


### PR DESCRIPTION
Previously the report was not saved on error.

I'm not actually sure this is all that useful.  I was using it to gather a picture of what was being built (I wasn't actually interested in the timing data).  There might be better ways to accomplish what I wanted, but it's a small change, so probably doesn't hurt.

Fixes #7413.