### PR TITLE
Ignore the host in rustc.verbose_version for metadata

### DIFF
--- a/src/cargo/core/compiler/context/compilation_files.rs
+++ b/src/cargo/core/compiler/context/compilation_files.rs
@@ -572,7 +572,13 @@ fn compute_metadata<'a, 'cfg>(
     unit.target.name().hash(&mut hasher);
     unit.target.kind().hash(&mut hasher);
 
-    bcx.rustc.verbose_version.hash(&mut hasher);
+    // Throw in the verbose rustc version output. Cross-compiling the same target from different
+    // hosts should still produce the same output, so filter out the host triple.
+    for line in bcx.rustc.verbose_version.lines() {
+        if !line.starts_with("host:") {
+            line.hash(&mut hasher);
+        }
+    }
 
     if cx.is_primary_package(unit) {
         // This is primarily here for clippy. This ensures that the clippy


### PR DESCRIPTION
Cross-compiling the same target from different hosts should still
produce the same output from rustc, but cargo effects a difference by
hashing the full `rustc.verbose_version`, including `host: <triple>`. We
can filter that particular line to allow different hosts to produce the
same target metadata after all.