### PR TITLE
Modify test to make `rustc` PR mergeable

### DIFF
--- a/tests/testsuite/check.rs
+++ b/tests/testsuite/check.rs
@@ -64,7 +64,7 @@ fn check_fail() {
 
     foo.cargo("check")
         .with_status(101)
-        .with_stderr_contains("[..]this function takes 0 parameters but 1 parameter was supplied")
+        .with_stderr_contains("[..]this function takes 0[..]")
         .run();
 }
 


### PR DESCRIPTION
Modify a test to be less succeptible to failure for wording changes.