### PR TITLE
Link the licenses into crates/cargo-platform

### DIFF
--- a/crates/cargo-platform/LICENSE-APACHE
+++ b/crates/cargo-platform/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../../LICENSE-APACHE

--- a/crates/cargo-platform/LICENSE-MIT
+++ b/crates/cargo-platform/LICENSE-MIT
@@ -1,0 +1,1 @@
+../../LICENSE-MIT


### PR DESCRIPTION
The licenses should be included in the package published on crates.io