### PR TITLE
Add new/old rustflags to fingerprint log.

### DIFF
--- a/src/cargo/core/compiler/fingerprint.rs
+++ b/src/cargo/core/compiler/fingerprint.rs
@@ -653,7 +653,11 @@ impl Fingerprint {
             bail!("profile configuration has changed")
         }
         if self.rustflags != old.rustflags {
-            bail!("RUSTFLAGS has changed")
+            bail!(
+                "RUSTFLAGS has changed: {:?} != {:?}",
+                self.rustflags,
+                old.rustflags
+            )
         }
         if self.metadata != old.metadata {
             bail!("metadata changed")


### PR DESCRIPTION
Follow up to #7888. Due to a conversation with someone I had with Discord who was having trouble determining why something was rebuilding.