### PR TITLE
Improvements to StringList config handling.

### DIFF
--- a/src/cargo/util/config/path.rs
+++ b/src/cargo/util/config/path.rs
@@ -56,7 +56,7 @@ impl<'de> serde::Deserialize<'de> for PathAndArgs {
         D: serde::Deserializer<'de>,
     {
         let vsl = Value::<StringList>::deserialize(deserializer)?;
-        let mut strings = vsl.val.list;
+        let mut strings = vsl.val.0;
         if strings.is_empty() {
             return Err(D::Error::invalid_length(0, &"at least one element"));
         }

--- a/tests/testsuite/bad_config.rs
+++ b/tests/testsuite/bad_config.rs
@@ -1355,8 +1355,9 @@ Caused by:
   could not load config key `target.cfg(not(target_os = \"none\")).runner`
 
 Caused by:
-  failed to deserialize, expected a string or array of strings: \
-  data did not match any variant of untagged enum Target
+  invalid configuration for key `target.cfg(not(target_os = \"none\")).runner`
+expected a string or array of strings, but found a boolean for \
+`target.cfg(not(target_os = \"none\")).runner` in [..]/foo/.cargo/config
 ",
         )
         .run();

--- a/tests/testsuite/config.rs
+++ b/tests/testsuite/config.rs
@@ -1205,3 +1205,56 @@ fn overlapping_env_config() {
     assert_eq!(s.debug_assertions, Some(true));
     assert_eq!(s.debug, Some(1));
 }
+
+#[cargo_test]
+fn string_list_tricky_env() {
+    // Make sure StringList handles typed env values.
+    let config = ConfigBuilder::new()
+        .env("CARGO_KEY1", "123")
+        .env("CARGO_KEY2", "true")
+        .env("CARGO_KEY3", "1 2")
+        .build();
+    let x = config.get::<StringList>("key1").unwrap();
+    assert_eq!(x.as_slice(), &["123".to_string()]);
+    let x = config.get::<StringList>("key2").unwrap();
+    assert_eq!(x.as_slice(), &["true".to_string()]);
+    let x = config.get::<StringList>("key3").unwrap();
+    assert_eq!(x.as_slice(), &["1".to_string(), "2".to_string()]);
+}
+
+#[cargo_test]
+fn string_list_wrong_type() {
+    // What happens if StringList is given then wrong type.
+    write_config("some_list = 123");
+    let config = ConfigBuilder::new().build();
+    assert_error(
+        config.get::<StringList>("some_list").unwrap_err(),
+        "\
+invalid configuration for key `some_list`
+expected a string or array of strings, but found a integer for `some_list` in [..]/.cargo/config",
+    );
+
+    write_config("some_list = \"1 2\"");
+    let config = ConfigBuilder::new().build();
+    let x = config.get::<StringList>("some_list").unwrap();
+    assert_eq!(x.as_slice(), &["1".to_string(), "2".to_string()]);
+}
+
+#[cargo_test]
+fn string_list_advanced_env() {
+    // StringList with advanced env.
+    let config = ConfigBuilder::new()
+        .unstable_flag("advanced-env")
+        .env("CARGO_KEY1", "[]")
+        .env("CARGO_KEY2", "['1 2', '3']")
+        .env("CARGO_KEY3", "[123]")
+        .build();
+    let x = config.get::<StringList>("key1").unwrap();
+    assert_eq!(x.as_slice(), &[] as &[String]);
+    let x = config.get::<StringList>("key2").unwrap();
+    assert_eq!(x.as_slice(), &["1 2".to_string(), "3".to_string()]);
+    assert_error(
+        config.get::<StringList>("key3").unwrap_err(),
+        "error in environment variable `CARGO_KEY3`: expected string, found integer",
+    );
+}

--- a/tests/testsuite/tool_paths.rs
+++ b/tests/testsuite/tool_paths.rs
@@ -279,6 +279,25 @@ fn custom_runner_env() {
 }
 
 #[cargo_test]
+#[cfg(unix)] // Assumes `true` is in PATH.
+fn custom_runner_env_true() {
+    // Check for a bug where "true" was interpreted as a boolean instead of
+    // the executable.
+    let target = rustc_host();
+    let p = project().file("src/main.rs", "fn main() {}").build();
+
+    let key = format!(
+        "CARGO_TARGET_{}_RUNNER",
+        target.to_uppercase().replace('-', "_")
+    );
+
+    p.cargo("run")
+        .env(&key, "true")
+        .with_stderr_contains("[RUNNING] `true target/debug/foo[EXE]`")
+        .run();
+}
+
+#[cargo_test]
 fn custom_linker_env() {
     let target = rustc_host();
     let p = project().file("src/main.rs", "fn main() {}").build();


### PR DESCRIPTION
`StringList` was using an untagged enum to deserialize a string or list.  Unfortunately, serde does not handle untagged enums very well.  The error messages are not very good, and it doesn't interact with untyped deserializers (like our environment variables).  This switches it to a newtype struct, and then has hard-coded support for it in the deserializer.  This fixes some deserialization errors (like treating `true` as a boolean) and provides better error messages.

`StringList` is currently used for `build.rustflags`, `target.*.rustflags`, and `target.*.runner`.

Fixes #7780
Fixes #7781
