### PR TITLE
Modified the help information of cargo-rustc

### DIFF
--- a/src/bin/cargo/commands/rustc.rs
+++ b/src/bin/cargo/commands/rustc.rs
@@ -5,9 +5,9 @@ use cargo::ops;
 pub fn cli() -> App {
     subcommand("rustc")
         .setting(AppSettings::TrailingVarArg)
-        .about("Compile a package and all of its dependencies")
+        .about("Compile a package, and pass extra options to the compiler")
         .arg(opt("quiet", "No output printed to stdout").short("q"))
-        .arg(Arg::with_name("args").multiple(true))
+        .arg(Arg::with_name("args").multiple(true).help("Rustc flags"))
         .arg_package("Package to build")
         .arg_jobs()
         .arg_targets_all(


### PR DESCRIPTION
### Motivation
The original help information for `cargo build` is
> Compile a local package and all of its dependencies

And the original help information for `cargo rustc` is
> Compile a package and all of its dependencies

These messages are **too similar** to make it difficult to distinguish the differences between the two commands.

According to the [cargo book](https://doc.rust-lang.org/cargo/commands/cargo-rustc.html), `cargo rustc` is characterized by
> pass extra options to the compiler

I think this should be written into the help text of the command.

In addition, the `<args> ...` parameters of `cargo rustc` lack help text and need to be added.
### Modification
See the commit files.

### Problems
Maybe some words in my modification are not accurate enough. If you have better wording, welcome to point out. Thanks.