### PR TITLE
Rework internal errors.

### DIFF
--- a/crates/cargo-test-support/src/lib.rs
+++ b/crates/cargo-test-support/src/lib.rs
@@ -1645,6 +1645,7 @@ fn substitute_macros(input: &str) -> String {
         ("[FINISHED]", "    Finished"),
         ("[ERROR]", "error:"),
         ("[WARNING]", "warning:"),
+        ("[NOTE]", "note:"),
         ("[DOCUMENTING]", " Documenting"),
         ("[FRESH]", "       Fresh"),
         ("[UPDATING]", "    Updating"),
@@ -1666,7 +1667,6 @@ fn substitute_macros(input: &str) -> String {
         ("[IGNORED]", "     Ignored"),
         ("[INSTALLED]", "   Installed"),
         ("[REPLACED]", "    Replaced"),
-        ("[NOTE]", "        Note"),
     ];
     let mut result = input.to_owned();
     for &(pat, subst) in &macros {

--- a/src/cargo/core/compiler/context/mod.rs
+++ b/src/cargo/core/compiler/context/mod.rs
@@ -9,7 +9,7 @@ use jobserver::Client;
 use crate::core::compiler::{self, compilation, Unit};
 use crate::core::PackageId;
 use crate::util::errors::{CargoResult, CargoResultExt};
-use crate::util::{internal, profile, Config};
+use crate::util::{profile, Config};
 
 use super::build_plan::BuildPlan;
 use super::custom_build::{self, BuildDeps, BuildScriptOutputs, BuildScripts};
@@ -313,11 +313,11 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
         self.files_mut()
             .host
             .prepare()
-            .chain_err(|| internal("couldn't prepare build directories"))?;
+            .chain_err(|| "couldn't prepare build directories")?;
         for target in self.files.as_mut().unwrap().target.values_mut() {
             target
                 .prepare()
-                .chain_err(|| internal("couldn't prepare build directories"))?;
+                .chain_err(|| "couldn't prepare build directories")?;
         }
 
         self.compilation.host_deps_output = self.files_mut().host.deps().to_path_buf();

--- a/src/cargo/core/compiler/custom_build.rs
+++ b/src/cargo/core/compiler/custom_build.rs
@@ -292,12 +292,8 @@ fn build_work<'a, 'cfg>(cx: &mut Context<'a, 'cfg>, unit: &Unit<'a>) -> CargoRes
         //
         // If we have an old build directory, then just move it into place,
         // otherwise create it!
-        paths::create_dir_all(&script_out_dir).chain_err(|| {
-            internal(
-                "failed to create script output directory for \
-                 build command",
-            )
-        })?;
+        paths::create_dir_all(&script_out_dir)
+            .chain_err(|| "failed to create script output directory for build command")?;
 
         // For all our native lib dependencies, pick up their metadata to pass
         // along to this custom build command. We're also careful to augment our

--- a/src/cargo/core/compiler/job_queue.rs
+++ b/src/cargo/core/compiler/job_queue.rs
@@ -71,7 +71,6 @@ use super::job::{
 use super::timings::Timings;
 use super::{BuildContext, BuildPlan, CompileMode, Context, Unit};
 use crate::core::{PackageId, TargetKind};
-use crate::handle_error;
 use crate::util;
 use crate::util::diagnostic_server::{self, DiagnosticPrinter};
 use crate::util::{internal, profile, CargoResult, CargoResultExt, ProcessBuilder};
@@ -531,7 +530,7 @@ impl<'a, 'cfg> DrainState<'a, 'cfg> {
                         self.emit_warnings(Some(msg), &unit, cx)?;
 
                         if !self.active.is_empty() {
-                            handle_error(&e, &mut *cx.bcx.config.shell());
+                            crate::display_error(&e, &mut *cx.bcx.config.shell());
                             cx.bcx.config.shell().warn(
                                 "build failed, waiting for other \
                                  jobs to finish...",

--- a/src/cargo/core/compiler/output_depinfo.rs
+++ b/src/cargo/core/compiler/output_depinfo.rs
@@ -44,7 +44,7 @@ fn render_filename<P: AsRef<Path>>(path: P, basedir: Option<&str>) -> CargoResul
     };
     relpath
         .to_str()
-        .ok_or_else(|| internal("path not utf-8"))
+        .ok_or_else(|| internal(format!("path `{:?}` not utf-8", relpath)))
         .map(|f| f.replace(" ", "\\ "))
 }
 
@@ -119,7 +119,7 @@ pub fn output_depinfo<'a, 'b>(cx: &mut Context<'a, 'b>, unit: &Unit<'a>) -> Carg
                 .resolve_path(bcx.config)
                 .as_os_str()
                 .to_str()
-                .ok_or_else(|| internal("build.dep-info-basedir path not utf-8"))?
+                .ok_or_else(|| anyhow::format_err!("build.dep-info-basedir path not utf-8"))?
                 .to_string();
             Some(basedir_string.as_str())
         }

--- a/src/cargo/core/shell.rs
+++ b/src/cargo/core/shell.rs
@@ -228,6 +228,11 @@ impl Shell {
         }
     }
 
+    /// Prints a cyan 'note' message.
+    pub fn note<T: fmt::Display>(&mut self, message: T) -> CargoResult<()> {
+        self.print(&"note", Some(&message), Cyan, false)
+    }
+
     /// Updates the verbosity of the shell.
     pub fn set_verbosity(&mut self, verbosity: Verbosity) {
         self.verbosity = verbosity;

--- a/src/cargo/ops/cargo_install.rs
+++ b/src/cargo/ops/cargo_install.rs
@@ -82,7 +82,7 @@ pub fn install(
             ) {
                 Ok(()) => succeeded.push(krate),
                 Err(e) => {
-                    crate::handle_error(&e, &mut opts.config.shell());
+                    crate::display_error(&e, &mut opts.config.shell());
                     failed.push(krate)
                 }
             }

--- a/src/cargo/ops/cargo_new.rs
+++ b/src/cargo/ops/cargo_new.rs
@@ -362,6 +362,11 @@ pub fn new(opts: &NewOptions, config: &Config) -> CargoResult<()> {
 }
 
 pub fn init(opts: &NewOptions, config: &Config) -> CargoResult<()> {
+    // This is here just as a random location to exercise the internal error handling.
+    if std::env::var_os("__CARGO_TEST_INTERNAL_ERROR").is_some() {
+        return Err(crate::util::internal("internal error test"));
+    }
+
     let path = &opts.path;
 
     if fs::metadata(&path.join("Cargo.toml")).is_ok() {

--- a/src/cargo/ops/cargo_package.rs
+++ b/src/cargo/ops/cargo_package.rs
@@ -14,7 +14,6 @@ use flate2::{Compression, GzBuilder};
 use log::debug;
 use serde_json::{self, json};
 use tar::{Archive, Builder, EntryType, Header};
-use termcolor::Color;
 
 use crate::core::compiler::{BuildConfig, CompileMode, DefaultExecutor, Executor};
 use crate::core::resolver::ResolveOpts;
@@ -27,7 +26,7 @@ use crate::sources::PathSource;
 use crate::util::errors::{CargoResult, CargoResultExt};
 use crate::util::paths;
 use crate::util::toml::TomlManifest;
-use crate::util::{self, internal, Config, FileLock};
+use crate::util::{self, Config, FileLock};
 
 pub struct PackageOpts<'cfg> {
     pub config: &'cfg Config,
@@ -443,17 +442,15 @@ fn tar(
             let orig = Path::new(&path).with_file_name("Cargo.toml.orig");
             header.set_path(&orig)?;
             header.set_cksum();
-            ar.append(&header, &mut file).chain_err(|| {
-                internal(format!("could not archive source file `{}`", relative_str))
-            })?;
+            ar.append(&header, &mut file)
+                .chain_err(|| format!("could not archive source file `{}`", relative_str))?;
 
             let toml = pkg.to_registry_toml(ws.config())?;
             add_generated_file(&mut ar, &path, &toml, relative_str)?;
         } else {
             header.set_cksum();
-            ar.append(&header, &mut file).chain_err(|| {
-                internal(format!("could not archive source file `{}`", relative_str))
-            })?;
+            ar.append(&header, &mut file)
+                .chain_err(|| format!("could not archive source file `{}`", relative_str))?;
         }
     }
 
@@ -581,7 +578,7 @@ fn compare_resolve(
             "package `{}` added to the packaged Cargo.lock file{}",
             pkg_id, extra
         );
-        config.shell().status_with_color("Note", msg, Color::Cyan)?;
+        config.shell().note(msg)?;
     }
     Ok(())
 }
@@ -794,6 +791,6 @@ fn add_generated_file<D: Display>(
     header.set_size(data.len() as u64);
     header.set_cksum();
     ar.append(&header, data.as_bytes())
-        .chain_err(|| internal(format!("could not archive source file `{}`", display)))?;
+        .chain_err(|| format!("could not archive source file `{}`", display))?;
     Ok(())
 }

--- a/src/cargo/ops/cargo_uninstall.rs
+++ b/src/cargo/ops/cargo_uninstall.rs
@@ -35,7 +35,7 @@ pub fn uninstall(
             match uninstall_one(&root, spec, bins, config) {
                 Ok(()) => succeeded.push(spec),
                 Err(e) => {
-                    crate::handle_error(&e, &mut config.shell());
+                    crate::display_error(&e, &mut config.shell());
                     failed.push(spec)
                 }
             }

--- a/src/cargo/sources/registry/mod.rs
+++ b/src/cargo/sources/registry/mod.rs
@@ -178,7 +178,7 @@ use crate::sources::PathSource;
 use crate::util::errors::CargoResultExt;
 use crate::util::hex;
 use crate::util::into_url::IntoUrl;
-use crate::util::{internal, CargoResult, Config, Filesystem};
+use crate::util::{CargoResult, Config, Filesystem};
 
 const PACKAGE_SOURCE_LOCK: &str = ".cargo-ok";
 pub const CRATES_IO_INDEX: &str = "https://github.com/rust-lang/crates.io-index";
@@ -511,7 +511,7 @@ impl<'cfg> RegistrySource<'cfg> {
     fn get_pkg(&mut self, package: PackageId, path: &File) -> CargoResult<Package> {
         let path = self
             .unpack_package(package, path)
-            .chain_err(|| internal(format!("failed to unpack package `{}`", package)))?;
+            .chain_err(|| format!("failed to unpack package `{}`", package))?;
         let mut src = PathSource::new(&path, self.source_id, self.config);
         src.update()?;
         let mut pkg = match src.download(package)? {

--- a/src/cargo/util/config/mod.rs
+++ b/src/cargo/util/config/mod.rs
@@ -73,7 +73,7 @@ use self::ConfigValue as CV;
 use crate::core::shell::Verbosity;
 use crate::core::{nightly_features_allowed, CliUnstable, Shell, SourceId, Workspace};
 use crate::ops;
-use crate::util::errors::{internal, CargoResult, CargoResultExt};
+use crate::util::errors::{CargoResult, CargoResultExt};
 use crate::util::toml as cargo_toml;
 use crate::util::{paths, validate_package_name};
 use crate::util::{FileLock, Filesystem, IntoUrl, IntoUrlWithBase, Rustc};
@@ -1439,13 +1439,13 @@ impl ConfigValue {
             | (expected @ &mut CV::Table(_, _), found)
             | (expected, found @ CV::List(_, _))
             | (expected, found @ CV::Table(_, _)) => {
-                return Err(internal(format!(
+                return Err(anyhow!(
                     "failed to merge config value from `{}` into `{}`: expected {}, but found {}",
                     found.definition(),
                     expected.definition(),
                     expected.desc(),
                     found.desc()
-                )));
+                ));
             }
             (old, mut new) => {
                 if force || new.definition().is_higher_priority(old.definition()) {

--- a/src/cargo/util/rustc.rs
+++ b/src/cargo/util/rustc.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::core::InternedString;
 use crate::util::paths;
-use crate::util::{self, internal, profile, CargoResult, ProcessBuilder};
+use crate::util::{self, profile, CargoResult, CargoResultExt, ProcessBuilder};
 
 /// Information on the `rustc` executable
 #[derive(Debug)]
@@ -186,9 +186,11 @@ impl Cache {
                 debug!("running {}", cmd);
                 let output = cmd.exec_with_output()?;
                 let stdout = String::from_utf8(output.stdout)
-                    .map_err(|_| internal("rustc didn't return utf8 output"))?;
+                    .map_err(|e| anyhow::anyhow!("{}: {:?}", e, e.as_bytes()))
+                    .chain_err(|| anyhow::anyhow!("`{}` didn't return utf8 output", cmd))?;
                 let stderr = String::from_utf8(output.stderr)
-                    .map_err(|_| internal("rustc didn't return utf8 output"))?;
+                    .map_err(|e| anyhow::anyhow!("{}: {:?}", e, e.as_bytes()))
+                    .chain_err(|| anyhow::anyhow!("`{}` didn't return utf8 output", cmd))?;
                 let output = (stdout, stderr);
                 entry.insert(output.clone());
                 self.dirty = true;

--- a/tests/testsuite/error.rs
+++ b/tests/testsuite/error.rs
@@ -1,0 +1,19 @@
+//! General error tests that don't belong anywhere else.
+
+use cargo_test_support::cargo_process;
+
+#[cargo_test]
+fn internal_error() {
+    cargo_process("init")
+        .env("__CARGO_TEST_INTERNAL_ERROR", "1")
+        .with_status(101)
+        .with_stderr(
+            "\
+[ERROR] internal error test
+[NOTE] this is an unexpected cargo internal error
+[NOTE] we would appreciate a bug report: https://github.com/rust-lang/cargo/issues/
+[NOTE] cargo [..]
+",
+        )
+        .run();
+}

--- a/tests/testsuite/main.rs
+++ b/tests/testsuite/main.rs
@@ -42,6 +42,7 @@ mod dep_info;
 mod directory;
 mod doc;
 mod edition;
+mod error;
 mod features;
 mod fetch;
 mod fix;


### PR DESCRIPTION
This changes the behavior of "internal" errors, which were previously hidden and only displayed with `--verbose`. The changes here:

- `internal` now means "a cargo bug", and is always displayed and requests that the user file a bug report.
- Added `VerboseError` to signify an error that should only be displayed with `--verbose`. This is only used in one place, to display the `rustc` compiler command if the compiler exited with a normal error code (i.e. not a crash).
- Audited the uses of internal errors, and promoted some to normal errors, as they seemed to contain useful information, but weren't necessarily bugs in cargo.
- Added some details to some errors.
- Sometimes the "run with --verbose" message wasn't being printed when I think it should. This happened when rustc failed while other rustc processes were running. Another case was with `cargo install` installing multiple packages, and one of them fails.
