### PR TITLE
Build supports a crate-type flag.

### DIFF
--- a/src/bin/cargo/commands/build.rs
+++ b/src/bin/cargo/commands/build.rs
@@ -41,6 +41,7 @@ pub fn cli() -> App {
         .arg_manifest_path()
         .arg_message_format()
         .arg_build_plan()
+        .arg_crate_type()
         .after_help(
             "\
 All packages in the workspace are built if the `--workspace` flag is supplied. The

--- a/src/cargo/core/compiler/context/mod.rs
+++ b/src/cargo/core/compiler/context/mod.rs
@@ -74,6 +74,8 @@ pub struct Context<'a, 'cfg> {
     /// jobserver clients for each Unit (which eventually becomes a rustc
     /// process).
     pub rustc_clients: HashMap<Unit<'a>, Client>,
+
+    pub crate_type: Option<String>,
 }
 
 impl<'a, 'cfg> Context<'a, 'cfg> {
@@ -82,6 +84,7 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
         bcx: &'a BuildContext<'a, 'cfg>,
         unit_dependencies: UnitGraph<'a>,
         default_kind: CompileKind,
+        crate_type: Option<String>,
     ) -> CargoResult<Self> {
         // Load up the jobserver that we'll use to manage our parallelism. This
         // is the same as the GNU make implementation of a jobserver, and
@@ -119,6 +122,7 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
             rmeta_required: HashSet::new(),
             rustc_clients: HashMap::new(),
             pipelining,
+            crate_type,
         })
     }
 

--- a/src/cargo/core/compiler/custom_build.rs
+++ b/src/cargo/core/compiler/custom_build.rs
@@ -777,7 +777,7 @@ impl BuildScriptOutputs {
             }
             Entry::Occupied(entry) => panic!(
                 "build script output collision for {}/{}\n\
-                old={:?}\nnew={:?}",
+                 old={:?}\nnew={:?}",
                 pkg_id,
                 metadata,
                 entry.get(),

--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -737,8 +737,12 @@ fn build_base_args<'a, 'cfg>(
     add_error_format_and_color(cx, cmd, cx.rmeta_required(unit))?;
 
     if !test {
-        for crate_type in crate_types.iter() {
-            cmd.arg("--crate-type").arg(crate_type);
+        if cx.crate_type.is_some() && cx.is_primary_package(unit) {
+            cmd.arg("--crate-type").arg(cx.crate_type.as_ref().unwrap());
+        } else {
+            for crate_type in crate_types.iter() {
+                cmd.arg("--crate-type").arg(crate_type);
+            }
         }
     }
 

--- a/src/cargo/ops/cargo_clean.rs
+++ b/src/cargo/ops/cargo_clean.rs
@@ -110,7 +110,13 @@ pub fn clean(ws: &Workspace<'_>, opts: &CleanOptions<'_>) -> CargoResult<()> {
 
     let unit_dependencies =
         unit_dependencies::build_unit_dependencies(&bcx, &resolve, None, &units, &[])?;
-    let mut cx = Context::new(config, &bcx, unit_dependencies, build_config.requested_kind)?;
+    let mut cx = Context::new(
+        config,
+        &bcx,
+        unit_dependencies,
+        build_config.requested_kind,
+        None,
+    )?;
     cx.prepare_units(None, &units)?;
 
     for unit in units.iter() {

--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -75,6 +75,8 @@ pub struct CompileOptions<'a> {
     // Note that, although the cmd-line flag name is `out-dir`, in code we use
     // `export_dir`, to avoid confusion with out dir at `target/debug/deps`.
     pub export_dir: Option<PathBuf>,
+    /// Crate type
+    pub crate_type: Option<String>,
 }
 
 impl<'a> CompileOptions<'a> {
@@ -94,6 +96,7 @@ impl<'a> CompileOptions<'a> {
             local_rustdoc_args: None,
             rustdoc_document_private_items: false,
             export_dir: None,
+            crate_type: None,
         })
     }
 }
@@ -277,6 +280,7 @@ pub fn compile_ws<'a>(
         ref local_rustdoc_args,
         rustdoc_document_private_items,
         ref export_dir,
+        ref crate_type,
     } = *options;
 
     match build_config.mode {
@@ -465,7 +469,13 @@ pub fn compile_ws<'a>(
 
     let ret = {
         let _p = profile::start("compiling");
-        let cx = Context::new(config, &bcx, unit_dependencies, build_config.requested_kind)?;
+        let cx = Context::new(
+            config,
+            &bcx,
+            unit_dependencies,
+            build_config.requested_kind,
+            crate_type.clone(),
+        )?;
         cx.compile(&units, export_dir.clone(), exec)?
     };
 

--- a/src/cargo/ops/cargo_package.rs
+++ b/src/cargo/ops/cargo_package.rs
@@ -665,6 +665,7 @@ fn run_verify(ws: &Workspace<'_>, tar: &FileLock, opts: &PackageOpts<'_>) -> Car
             local_rustdoc_args: None,
             rustdoc_document_private_items: false,
             export_dir: None,
+            crate_type: None,
         },
         &exec,
     )?;

--- a/src/cargo/util/command_prelude.rs
+++ b/src/cargo/util/command_prelude.rs
@@ -150,6 +150,10 @@ pub trait AppExt: Sized {
         ))
     }
 
+    fn arg_crate_type(self) -> Self {
+        self._arg(opt("crate-type", "Crate type").value_name("CRATE-TYPE"))
+    }
+
     fn arg_new_opts(self) -> Self {
         self._arg(
             opt(
@@ -468,6 +472,7 @@ pub trait ArgMatchesExt {
             local_rustdoc_args: None,
             rustdoc_document_private_items: false,
             export_dir: None,
+            crate_type: self._value_of("crate-type").map(|s| s.to_string()),
         };
 
         if let Some(ws) = workspace {


### PR DESCRIPTION
So it seemed like #7899 it would be easy to fix, but the same error as in #7899 occurs. It works well for compiling examples, but fails to compile a library with `crate required to be in rlib format`. What is the difference between how libs are handled and how examples are handled?