### PR TITLE
Add `rustless.org` to documented blocklist.

### DIFF
--- a/src/doc/src/reference/manifest.md
+++ b/src/doc/src/reference/manifest.md
@@ -149,10 +149,6 @@ automatically link your crate to the corresponding [docs.rs] page.
 documentation = "https://docs.rs/bitflags"
 ```
 
-> **Note**: [crates.io] may not show certain sites if they are known to not be
-> hosting documentation and are possibly of malicious intent e.g., ad tracking
-> networks. At this time; `rust-ci.org`, and `rustless.org` are not allowed.
-
 #### The `readme` field
 
 The `readme` field should be the path to a file in the package root (relative

--- a/src/doc/src/reference/manifest.md
+++ b/src/doc/src/reference/manifest.md
@@ -151,7 +151,7 @@ documentation = "https://docs.rs/bitflags"
 
 > **Note**: [crates.io] may not show certain sites if they are known to not be
 > hosting documentation and are possibly of malicious intent e.g., ad tracking
-> networks. At this time, the site `rust-ci.org` is not allowed.
+> networks. At this time; `rust-ci.org`, and `rustless.org` are not allowed.
 
 #### The `readme` field
 


### PR DESCRIPTION
Sibling PR to rust-lang/crates.io#2202, don't merge or close until the sibling PR is resolved first.