### PR TITLE
Revert "Disable preserving mtimes on archives"

### DIFF
--- a/src/cargo/sources/registry/mod.rs
+++ b/src/cargo/sources/registry/mod.rs
@@ -463,7 +463,6 @@ impl<'cfg> RegistrySource<'cfg> {
 
         let gz = GzDecoder::new(tarball);
         let mut tar = Archive::new(gz);
-        tar.set_preserve_mtime(false);
         let prefix = unpack_dir.file_name().unwrap();
         let parent = unpack_dir.parent().unwrap();
         for entry in tar.entries()? {


### PR DESCRIPTION
This reverts commit 8c92e88765817877f53a9cfb70c3e39853456868.

Fixes #7590 