### PR TITLE
Filter out cfgs which should not be used during build

### DIFF
--- a/src/cargo/core/compiler/build_context/target_info.rs
+++ b/src/cargo/core/compiler/build_context/target_info.rs
@@ -153,6 +153,7 @@ impl TargetInfo {
 
         let cfg = lines
             .map(|line| Ok(Cfg::from_str(line)?))
+            .filter(TargetInfo::not_user_specific_cfg)
             .collect::<CargoResult<Vec<_>>>()
             .chain_err(|| {
                 format!(
@@ -187,6 +188,15 @@ impl TargetInfo {
             )?,
             cfg,
         })
+    }
+
+    fn not_user_specific_cfg(cfg: &CargoResult<Cfg>) -> bool {
+        if let Ok(Cfg::Name(cfg_name)) = cfg {
+            if cfg_name == "debug_assertions" || cfg_name == "proc_macro" {
+                return false;
+            }
+        }
+        true
     }
 
     /// All the target `cfg` settings.

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -4739,3 +4739,23 @@ fn build_with_relative_cargo_home_path() {
 
     p.cargo("build").env("CARGO_HOME", "./cargo_home/").run();
 }
+
+#[cargo_test]
+fn user_specific_cfgs_are_filtered_out() {
+    let p = project()
+        .file("Cargo.toml", &basic_bin_manifest("foo"))
+        .file("src/main.rs", r#"fn main() {}"#)
+        .file(
+            "build.rs",
+            r#"
+            fn main() {
+                assert!(std::env::var_os("CARGO_CFG_PROC_MACRO").is_none());
+                assert!(std::env::var_os("CARGO_CFG_DEBUG_ASSERTIONS").is_none());
+            }"#,
+        )
+        .build();
+
+    p.cargo("rustc -- --cfg debug_assertions --cfg proc_macro")
+        .run();
+    p.process(&p.bin("foo")).run();
+}


### PR DESCRIPTION
Fixes #7933: Filter invalid CARGO_CFG_ in build scripts