### PR TITLE
Simplified usage code of SipHasher

### DIFF
--- a/src/cargo/core/compiler/context/compilation_files.rs
+++ b/src/cargo/core/compiler/context/compilation_files.rs
@@ -562,7 +562,7 @@ fn compute_metadata<'a, 'cfg>(
         return None;
     }
 
-    let mut hasher = SipHasher::new_with_keys(0, 0);
+    let mut hasher = SipHasher::new();
 
     // This is a generic version number that can be changed to make
     // backwards-incompatible changes to any file structures in the output

--- a/src/cargo/util/hex.rs
+++ b/src/cargo/util/hex.rs
@@ -16,7 +16,7 @@ pub fn to_hex(num: u64) -> String {
 }
 
 pub fn hash_u64<H: Hash>(hashable: H) -> u64 {
-    let mut hasher = SipHasher::new_with_keys(0, 0);
+    let mut hasher = SipHasher::new();
     hashable.hash(&mut hasher);
     hasher.finish()
 }

--- a/src/cargo/util/rustc.rs
+++ b/src/cargo/util/rustc.rs
@@ -216,7 +216,7 @@ impl Drop for Cache {
 }
 
 fn rustc_fingerprint(path: &Path, rustup_rustc: &Path) -> CargoResult<u64> {
-    let mut hasher = SipHasher::new_with_keys(0, 0);
+    let mut hasher = SipHasher::new();
 
     let path = paths::resolve_executable(path)?;
     path.hash(&mut hasher);
@@ -260,7 +260,7 @@ fn rustc_fingerprint(path: &Path, rustup_rustc: &Path) -> CargoResult<u64> {
 }
 
 fn process_fingerprint(cmd: &ProcessBuilder) -> u64 {
-    let mut hasher = SipHasher::new_with_keys(0, 0);
+    let mut hasher = SipHasher::new();
     cmd.get_args().hash(&mut hasher);
     let mut env = cmd.get_envs().iter().collect::<Vec<_>>();
     env.sort_unstable();


### PR DESCRIPTION
SipHasher::new_with_keys(0,0) is just a longer version of just _::new()
i.e. the latter is an alias for the former.

Just a bit of a nothing burger I noticed while debugging some other issue.