### PR TITLE
Ignore broken Cargo.toml in git sources

### DIFF
--- a/tests/testsuite/git.rs
+++ b/tests/testsuite/git.rs
@@ -323,6 +323,16 @@ fn cargo_compile_with_malformed_nested_paths() {
             "#,
             )
             .file("vendor/dep2/Cargo.toml", "!INVALID!")
+            .file(
+                "vendor/dep3/Cargo.toml",
+                r#"
+                [project]
+                name = "dep3"
+                version = "0.5.0"
+                [dependencies]
+                subdep1 = { path = "../require-extra-build-step" }"#,
+            )
+            .file("vendor/dep3/src/lib.rs", "")
     });
 
     let p = project()


### PR DESCRIPTION
Commit 3d6de4177489a5d450f35e92288512be85492678 (#3998) made cargo
ignore Cargo.toml files that are invalid TOML in a git source.
This change further ignores Cargo.toml files that are valid TOML but
cannot really be loaded in a git source.

This is potentially an alternative fix for #6822.