### PR TITLE
Check manifest for requiring nonexistent features

### DIFF
--- a/tests/testsuite/bench.rs
+++ b/tests/testsuite/bench.rs
@@ -595,6 +595,9 @@ fn bench_autodiscover_2015() {
                 version = "0.0.1"
                 authors = []
                 edition = "2015"
+                
+                [features]
+                magic = []
 
                 [[bench]]
                 name = "bench_magic"


### PR DESCRIPTION
Fixes #4854: Examples requiring a nonexistent feature should be an error

Thanks @lukaslueg with his https://github.com/rust-lang/cargo/pull/4874 for the inspiration!