### PR TITLE
Add more fingerprint mtime debug logging.

### DIFF
--- a/src/cargo/core/compiler/custom_build.rs
+++ b/src/cargo/core/compiler/custom_build.rs
@@ -364,6 +364,11 @@ fn build_work<'a, 'cfg>(cx: &mut Context<'a, 'cfg>, unit: &Unit<'a>) -> CargoRes
         // state informing what variables were discovered via our script as
         // well.
         paths::write(&output_file, &output.stdout)?;
+        log::debug!(
+            "rewinding custom script output mtime {:?} to {}",
+            output_file,
+            timestamp
+        );
         filetime::set_file_times(output_file, timestamp, timestamp)?;
         paths::write(&err_file, &output.stderr)?;
         paths::write(&root_output_file, util::path2bytes(&script_out_dir)?)?;

--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -322,6 +322,7 @@ fn rustc<'a, 'cfg>(
                     rustc_dep_info_loc.display()
                 ))
             })?;
+            debug!("rewinding mtime of {:?} to {}", dep_info_loc, timestamp);
             filetime::set_file_times(dep_info_loc, timestamp, timestamp)?;
         }
 

--- a/src/cargo/util/paths.rs
+++ b/src/cargo/util/paths.rs
@@ -192,7 +192,9 @@ pub fn set_invocation_time(path: &Path) -> CargoResult<FileTime> {
         &timestamp,
         b"This file has an mtime of when this was started.",
     )?;
-    mtime(&timestamp)
+    let ft = mtime(&timestamp)?;
+    log::debug!("invocation time for {:?} is {}", path, ft);
+    Ok(ft)
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
Adding some more debug logging on top of #7888.  

There was a mistake in the original PR, where `dep.pkg_id` should have been `dep.name`.
