### PR TITLE
Fix rare failure in collision_export test.

### DIFF
--- a/tests/testsuite/collisions.rs
+++ b/tests/testsuite/collisions.rs
@@ -91,6 +91,8 @@ This may become a hard error in the future; see <https://github.com/rust-lang/ca
 }
 
 #[cargo_test]
+// --out-dir and examples are currently broken on MSVC.
+// See https://github.com/rust-lang/cargo/issues/7493
 #[cfg(not(target_env = "msvc"))]
 fn collision_export() {
     // `--out-dir` combines some things which can cause conflicts.
@@ -100,7 +102,9 @@ fn collision_export() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    p.cargo("build --out-dir=out -Z unstable-options --bins --examples")
+    // -j1 to avoid issues with two processes writing to the same file at the
+    // same time.
+    p.cargo("build -j1 --out-dir=out -Z unstable-options --bins --examples")
         .masquerade_as_nightly_cargo()
         .with_stderr_contains("\
 [WARNING] `--out-dir` filename collision.


### PR DESCRIPTION
Seen once on CI in #7952 (https://dev.azure.com/rust-lang/cargo/_build/results?buildId=22112&view=logs&j=a5e52b91-c83f-5429-4a68-c246fc63a4f7&t=d4864165-4be3-5e34-b483-a6b05303aa68). I was able to reproduce it locally, though it is rare. There seems to be some kind of race issue on macOS with two processes trying to symlink the same directory at the same time. The solution is to serialize the build so they don't run at the same time.
