### PR TITLE
Fix bug with new feature resolver and required-features.

### DIFF
--- a/src/cargo/core/resolver/features.rs
+++ b/src/cargo/core/resolver/features.rs
@@ -194,8 +194,8 @@ impl ResolvedFeatures {
     }
 
     /// Variant of `activated_features` that returns an empty Vec if this is
-    /// not a valid pkg_id/is_build combination. Used by `cargo clean` which
-    /// doesn't know the exact set.
+    /// not a valid pkg_id/is_build combination. Used in places which do
+    /// not know which packages are activated (like `cargo clean`).
     pub fn activated_features_unverified(
         &self,
         pkg_id: PackageId,

--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -956,8 +956,8 @@ fn resolve_all_features(
             } else {
                 FeaturesFor::NormalOrDev
             };
-            for feature in resolved_features.activated_features(dep_id, features_for) {
-                features.insert(dep.name_in_toml().to_string() + "/" + &feature);
+            for feature in resolved_features.activated_features_unverified(dep_id, features_for) {
+                features.insert(format!("{}/{}", dep.name_in_toml(), feature));
             }
         }
     }


### PR DESCRIPTION
If required-features are used, then the code for checking those features would crash if a dependency was not activated.  The solution here is to not be strict about only requesting activated packages.

For context, the reason this can panic is to check for any bugs in the resolver or places that make bad assumptions.  I missed this particular case, though.
