### PR TITLE
Don't create hardlink for library test and integrations tests, fixing #7960

### DIFF
--- a/src/cargo/core/compiler/context/compilation_files.rs
+++ b/src/cargo/core/compiler/context/compilation_files.rs
@@ -421,9 +421,14 @@ impl<'a, 'cfg: 'a> CompilationFiles<'a, 'cfg> {
                 Some(types) => {
                     for file_type in types {
                         let path = out_dir.join(file_type.filename(&file_stem));
-                        let hardlink = link_stem
-                            .as_ref()
-                            .map(|&(ref ld, ref ls)| ld.join(file_type.filename(ls)));
+                        // Don't create hardlink for tests
+                        let hardlink = if unit.mode.is_any_test() {
+                            None
+                        } else {
+                            link_stem
+                                .as_ref()
+                                .map(|&(ref ld, ref ls)| ld.join(file_type.filename(ls)))
+                        };
                         let export_path = if unit.target.is_custom_build() {
                             None
                         } else {

--- a/tests/testsuite/bench.rs
+++ b/tests/testsuite/bench.rs
@@ -1612,9 +1612,9 @@ fn json_artifact_includes_executable_for_benchmark() {
         .with_json(
             r#"
             {
-                "executable": "[..]/foo/target/release/benchmark-[..][EXE]",
+                "executable": "[..]/foo/target/release/deps/benchmark-[..][EXE]",
                 "features": [],
-                "filenames": [ "[..]/foo/target/release/benchmark-[..][EXE]" ],
+                "filenames": [ "[..]/foo/target/release/deps/benchmark-[..][EXE]" ],
                 "fresh": false,
                 "package_id": "foo 0.0.1 ([..])",
                 "profile": "{...}",

--- a/tests/testsuite/test.rs
+++ b/tests/testsuite/test.rs
@@ -3379,7 +3379,7 @@ fn json_artifact_includes_executable_for_library_tests() {
         .with_json(
             r#"
             {
-                "executable": "[..]/foo/target/debug/foo-[..][EXE]",
+                "executable": "[..]/foo/target/debug/deps/foo-[..][EXE]",
                 "features": [],
                 "filenames": "{...}",
                 "fresh": false,
@@ -3413,7 +3413,7 @@ fn json_artifact_includes_executable_for_integration_tests() {
         .with_json(
             r#"
             {
-                "executable": "[..]/foo/target/debug/integration_test-[..][EXE]",
+                "executable": "[..]/foo/target/debug/deps/integration_test-[..][EXE]",
                 "features": [],
                 "filenames": "{...}",
                 "fresh": false,


### PR DESCRIPTION
Related issue: #7960 

Problem:

Tests are run under deps, but it is still copied to its parent directory. It leads to separation between the executable and its debug symbols (.dSYM directory).

Solution:

Set hardlink to None.
