### PR TITLE
Partially revert change to filter debug_assertions.

### DIFF
--- a/src/cargo/core/compiler/build_context/target_info.rs
+++ b/src/cargo/core/compiler/build_context/target_info.rs
@@ -192,7 +192,10 @@ impl TargetInfo {
 
     fn not_user_specific_cfg(cfg: &CargoResult<Cfg>) -> bool {
         if let Ok(Cfg::Name(cfg_name)) = cfg {
-            if cfg_name == "debug_assertions" || cfg_name == "proc_macro" {
+            // This should also include "debug_assertions", but it causes
+            // regressions. Maybe some day in the distant future it can be
+            // added (and possibly change the warning to an error).
+            if cfg_name == "proc_macro" {
                 return false;
             }
         }

--- a/src/cargo/core/compiler/custom_build.rs
+++ b/src/cargo/core/compiler/custom_build.rs
@@ -228,6 +228,11 @@ fn build_work<'a, 'cfg>(cx: &mut Context<'a, 'cfg>, unit: &Unit<'a>) -> CargoRes
         }
     }
     for (k, v) in cfg_map {
+        if k == "debug_assertions" {
+            // This cfg is always true and misleading, so avoid setting it.
+            // That is because Cargo queries rustc without any profile settings.
+            continue;
+        }
         let k = format!("CARGO_CFG_{}", super::envify(&k));
         match v {
             Some(list) => {


### PR DESCRIPTION
This partially reverts the changes from #7943. It caused a regression with the rocket_contrib crate. I knew that was the only crate that had a `cfg(debug_assertions)` dependency, and I saw that it had been fixed, but I did not realize the fix hadn't been published (and will be in a semver incompatible release).

This retains the old behavior for `cfg(debug_assertions)` of issuing a warning. I kept the filter for `CARGO_CFG_DEBUG_ASSERTIONS` for build scripts because that was the original intent for the change, and I don't see anyone using that.

Closes #7966.
