### PR TITLE
Several updates to token/index handling.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ path = "src/cargo/lib.rs"
 atty = "0.2"
 bytesize = "1.0"
 cargo-platform = { path = "crates/cargo-platform", version = "0.1.1" }
-crates-io = { path = "crates/crates-io", version = "0.31" }
+crates-io = { path = "crates/crates-io", version = "0.31.1" }
 crossbeam-utils = "0.7"
 crypto-hash = "0.3.1"
 curl = { version = "0.4.23", features = ["http2"] }

--- a/crates/crates-io/Cargo.toml
+++ b/crates/crates-io/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crates-io"
-version = "0.31.0"
+version = "0.31.1"
 edition = "2018"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT OR Apache-2.0"

--- a/crates/crates-io/lib.rs
+++ b/crates/crates-io/lib.rs
@@ -139,9 +139,7 @@ impl Registry {
     }
 
     pub fn host_is_crates_io(&self) -> bool {
-        Url::parse(self.host())
-            .map(|u| u.host_str() == Some("crates.io"))
-            .unwrap_or(false)
+        is_url_crates_io(&self.host)
     }
 
     pub fn add_owners(&mut self, krate: &str, owners: &[&str]) -> Result<String> {
@@ -419,4 +417,11 @@ fn reason(code: u32) -> &'static str {
         504 => "Gateway Timeout",
         _ => "<unknown>",
     }
+}
+
+/// Returns `true` if the host of the given URL is "crates.io".
+pub fn is_url_crates_io(url: &str) -> bool {
+    Url::parse(url)
+        .map(|u| u.host_str() == Some("crates.io"))
+        .unwrap_or(false)
 }

--- a/src/cargo/ops/registry.rs
+++ b/src/cargo/ops/registry.rs
@@ -324,7 +324,7 @@ fn transmit(
 /// Returns the index and token from the config file for the given registry.
 ///
 /// `registry` is typically the registry specified on the command-line. If
-/// `None`, returns the default index.
+/// `None`, `index` is set to `None` to indicate it should use crates.io.
 pub fn registry_configuration(
     config: &Config,
     registry: Option<String>,
@@ -341,13 +341,9 @@ pub fn registry_configuration(
             )
         }
         None => {
-            // Checking for default index and token
-            (
-                config
-                    .get_default_registry_index()?
-                    .map(|url| url.to_string()),
-                config.get_string("registry.token")?.map(|p| p.val),
-            )
+            // Use crates.io default.
+            config.check_registry_index_not_set()?;
+            (None, config.get_string("registry.token")?.map(|p| p.val))
         }
     };
 

--- a/src/cargo/ops/registry.rs
+++ b/src/cargo/ops/registry.rs
@@ -369,6 +369,10 @@ fn registry(
     force_update: bool,
     validate_token: bool,
 ) -> CargoResult<(Registry, SourceId)> {
+    if index.is_some() && registry.is_some() {
+        // Otherwise we would silently ignore one or the other.
+        bail!("both `--index` and `--registry` should not be set at the same time");
+    }
     // Parse all configuration options
     let RegistryConfig {
         token: token_config,

--- a/src/cargo/util/config/mod.rs
+++ b/src/cargo/util/config/mod.rs
@@ -1016,12 +1016,15 @@ impl Config {
         )
     }
 
-    /// Gets the index for the default registry.
-    pub fn get_default_registry_index(&self) -> CargoResult<Option<Url>> {
-        Ok(match self.get_string("registry.index")? {
-            Some(index) => Some(self.resolve_registry_index(index)?),
-            None => None,
-        })
+    /// Returns an error if `registry.index` is set.
+    pub fn check_registry_index_not_set(&self) -> CargoResult<()> {
+        if self.get_string("registry.index")?.is_some() {
+            bail!(
+                "the `registry.index` config value is no longer supported\n\
+                Use `[source]` replacement to alter the default index for crates.io."
+            );
+        }
+        Ok(())
     }
 
     fn resolve_registry_index(&self, index: Value<String>) -> CargoResult<Url> {

--- a/src/doc/src/reference/config.md
+++ b/src/doc/src/reference/config.md
@@ -686,7 +686,7 @@ specified.
 
 ##### `registry.index`
 
-This value is deprecated and should not be used.
+This value is no longer accepted and should not be used.
 
 ##### `registry.default`
 * Type: string

--- a/tests/testsuite/alt_registry.rs
+++ b/tests/testsuite/alt_registry.rs
@@ -1247,3 +1247,19 @@ Caused by:
         .with_status(101)
         .run();
 }
+
+#[cargo_test]
+fn both_index_and_registry() {
+    let p = project().file("src/lib.rs", "").build();
+    for cmd in &["publish", "owner", "search", "yank --vers 1.0.0"] {
+        p.cargo(cmd)
+            .arg("--registry=foo")
+            .arg("--index=foo")
+            .with_status(101)
+            .with_stderr(
+                "[ERROR] both `--index` and `--registry` \
+                should not be set at the same time",
+            )
+            .run();
+    }
+}

--- a/tests/testsuite/alt_registry.rs
+++ b/tests/testsuite/alt_registry.rs
@@ -298,7 +298,7 @@ fn cannot_publish_to_crates_io_with_registry_dependency() {
         .with_stderr_contains("[ERROR] crates cannot be published to crates.io[..]")
         .run();
 
-    p.cargo("publish --index")
+    p.cargo("publish --token sekrit --index")
         .arg(fakeio_url.to_string())
         .with_status(101)
         .with_stderr_contains("[ERROR] crates cannot be published to crates.io[..]")
@@ -413,17 +413,18 @@ fn alt_registry_and_crates_io_deps() {
 
 #[cargo_test]
 fn block_publish_due_to_no_token() {
-    let p = project().file("src/main.rs", "fn main() {}").build();
-
-    // Setup the registry by publishing a package
-    Package::new("bar", "0.0.1").alternative(true).publish();
+    registry::init();
+    let p = project().file("src/lib.rs", "").build();
 
     fs::remove_file(paths::home().join(".cargo/credentials")).unwrap();
 
     // Now perform the actual publish
     p.cargo("publish --registry alternative")
         .with_status(101)
-        .with_stderr_contains("error: no upload token found, please run `cargo login`")
+        .with_stderr_contains(
+            "error: no upload token found, \
+            please run `cargo login` or pass `--token`",
+        )
         .run();
 }
 

--- a/tests/testsuite/alt_registry.rs
+++ b/tests/testsuite/alt_registry.rs
@@ -529,28 +529,6 @@ fn publish_with_crates_io_dep() {
 }
 
 #[cargo_test]
-fn passwords_in_registry_index_url_forbidden() {
-    registry::init();
-
-    let config = paths::home().join(".cargo/config");
-    fs::write(
-        config,
-        r#"
-        [registry]
-        index = "ssh://git:secret@foobar.com"
-        "#,
-    )
-    .unwrap();
-
-    let p = project().file("src/main.rs", "fn main() {}").build();
-
-    p.cargo("publish")
-        .with_status(101)
-        .with_stderr_contains("error: Registry URLs may not contain passwords")
-        .run();
-}
-
-#[cargo_test]
 fn passwords_in_registries_index_url_forbidden() {
     registry::init();
 
@@ -1210,57 +1188,6 @@ fn registries_index_relative_url() {
     p.cargo("build")
         .with_stderr(&format!(
             "\
-[UPDATING] `{reg}` index
-[DOWNLOADING] crates ...
-[DOWNLOADED] bar v0.0.1 (registry `[ROOT][..]`)
-[COMPILING] bar v0.0.1 (registry `[ROOT][..]`)
-[COMPILING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
-",
-            reg = registry::alt_registry_path().to_str().unwrap()
-        ))
-        .run();
-}
-
-#[cargo_test]
-fn registry_index_relative_url() {
-    let config = paths::root().join(".cargo/config");
-    fs::create_dir_all(config.parent().unwrap()).unwrap();
-    fs::write(
-        &config,
-        r#"
-            [registry]
-            index = "file:alternative-registry"
-        "#,
-    )
-    .unwrap();
-
-    registry::init();
-
-    let p = project()
-        .file(
-            "Cargo.toml",
-            r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-
-            [dependencies.bar]
-            version = "0.0.1"
-        "#,
-        )
-        .file("src/main.rs", "fn main() {}")
-        .build();
-
-    Package::new("bar", "0.0.1").alternative(true).publish();
-
-    fs::remove_file(paths::home().join(".cargo/config")).unwrap();
-
-    p.cargo("build")
-        .with_stderr(&format!(
-            "\
-warning: custom registry support via the `registry.index` configuration is being removed, this functionality will not work in the future
 [UPDATING] `{reg}` index
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.0.1 (registry `[ROOT][..]`)

--- a/tests/testsuite/cargo_features.rs
+++ b/tests/testsuite/cargo_features.rs
@@ -323,8 +323,7 @@ fn publish_allowed() {
         )
         .file("src/lib.rs", "")
         .build();
-    p.cargo("publish --index")
-        .arg(registry::registry_url().to_string())
+    p.cargo("publish --token sekrit")
         .masquerade_as_nightly_cargo()
         .run();
 }

--- a/tests/testsuite/cross_publish.rs
+++ b/tests/testsuite/cross_publish.rs
@@ -97,8 +97,7 @@ fn publish_with_target() {
 
     let target = cross_compile::alternate();
 
-    p.cargo("publish --index")
-        .arg(registry::registry_url().to_string())
+    p.cargo("publish --token sekrit")
         .arg("--target")
         .arg(&target)
         .with_stderr(&format!(

--- a/tests/testsuite/owner.rs
+++ b/tests/testsuite/owner.rs
@@ -4,7 +4,7 @@ use std::fs;
 
 use cargo_test_support::paths::CargoPathExt;
 use cargo_test_support::project;
-use cargo_test_support::registry::{self, api_path, registry_url};
+use cargo_test_support::registry::{self, api_path};
 
 fn setup(name: &str, content: Option<&str>) {
     let dir = api_path().join(format!("api/v1/crates/{}", name));
@@ -43,9 +43,7 @@ fn simple_list() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    p.cargo("owner -l --index")
-        .arg(registry_url().to_string())
-        .run();
+    p.cargo("owner -l --token sekrit").run();
 }
 
 #[cargo_test]
@@ -68,8 +66,7 @@ fn simple_add() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    p.cargo("owner -a username --index")
-        .arg(registry_url().to_string())
+    p.cargo("owner -a username --token sekrit")
         .with_status(101)
         .with_stderr(
             "    Updating `[..]` index
@@ -98,8 +95,7 @@ fn simple_remove() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    p.cargo("owner -r username --index")
-        .arg(registry_url().to_string())
+    p.cargo("owner -r username --token sekrit")
         .with_status(101)
         .with_stderr(
             "    Updating `[..]` index

--- a/tests/testsuite/registry.rs
+++ b/tests/testsuite/registry.rs
@@ -4,7 +4,7 @@ use cargo::util::paths::remove_dir_all;
 use cargo_test_support::cargo_process;
 use cargo_test_support::git;
 use cargo_test_support::paths::{self, CargoPathExt};
-use cargo_test_support::registry::{self, registry_path, registry_url, Dependency, Package};
+use cargo_test_support::registry::{self, registry_path, Dependency, Package};
 use cargo_test_support::{basic_manifest, project, t};
 use std::fs::{self, File};
 use std::path::Path;
@@ -896,8 +896,7 @@ fn bad_license_file() {
         )
         .file("src/main.rs", "fn main() {}")
         .build();
-    p.cargo("publish -v --index")
-        .arg(registry_url().to_string())
+    p.cargo("publish -v --token sekrit")
         .with_status(101)
         .with_stderr_contains("[ERROR] the license file `foo` does not exist")
         .run();

--- a/tests/testsuite/yank.rs
+++ b/tests/testsuite/yank.rs
@@ -4,10 +4,10 @@ use std::fs;
 
 use cargo_test_support::paths::CargoPathExt;
 use cargo_test_support::project;
-use cargo_test_support::registry::{self, api_path, registry_url};
+use cargo_test_support::registry;
 
 fn setup(name: &str, version: &str) {
-    let dir = api_path().join(format!("api/v1/crates/{}/{}", name, version));
+    let dir = registry::api_path().join(format!("api/v1/crates/{}/{}", name, version));
     dir.mkdir_p();
     fs::write(dir.join("yank"), r#"{"ok": true}"#).unwrap();
 }
@@ -32,12 +32,9 @@ fn simple() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    p.cargo("yank --vers 0.0.1 --index")
-        .arg(registry_url().to_string())
-        .run();
+    p.cargo("yank --vers 0.0.1 --token sekrit").run();
 
-    p.cargo("yank --undo --vers 0.0.1 --index")
-        .arg(registry_url().to_string())
+    p.cargo("yank --undo --vers 0.0.1 --token sekrit")
         .with_status(101)
         .with_stderr(
             "    Updating `[..]` index


### PR DESCRIPTION
This attempts to tighten up the usage of token/index handling, to prevent accidental leakage of the crates.io token.

* Make `registry.index` config a hard error. This was deprecated 4 years ago in #2857, and removing it helps simplify things.
* Don't allow both `--index` and `--registry` to be specified at the same time. Otherwise `--index` was being silently ignored.
* `registry.token` is not allowed to be used with the `--index` flag. The intent here is to avoid possibly leaking a crates.io token to another host.
* Added a warning if source replacement is used and the token is loaded from `registry.token`.

Closes #6545
