### PR TITLE
Add "Updating" status for git submodules.

### DIFF
--- a/src/cargo/sources/git/utils.rs
+++ b/src/cargo/sources/git/utils.rs
@@ -392,6 +392,9 @@ impl<'a> GitCheckout<'a> {
             };
             // Fetch data from origin and reset to the head commit
             let refspec = "refs/heads/*:refs/heads/*";
+            cargo_config
+                .shell()
+                .status("Updating", format!("git submodule `{}`", url))?;
             fetch(&mut repo, url, refspec, cargo_config).chain_err(|| {
                 format!(
                     "failed to fetch submodule `{}` from {}",

--- a/tests/testsuite/git.rs
+++ b/tests/testsuite/git.rs
@@ -878,6 +878,7 @@ fn dep_with_submodule() {
         .with_stderr(
             "\
 [UPDATING] git repository [..]
+[UPDATING] git submodule `file://[..]/dep2`
 [COMPILING] dep1 [..]
 [COMPILING] foo [..]
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]\n",
@@ -941,6 +942,7 @@ fn dep_with_bad_submodule() {
     let expected = format!(
         "\
 [UPDATING] git repository [..]
+[UPDATING] git submodule `file://[..]/dep2`
 [ERROR] failed to get `dep1` as a dependency of package `foo v0.5.0 [..]`
 
 Caused by:
@@ -1182,6 +1184,7 @@ fn dep_with_changed_submodule() {
     p.cargo("run")
         .with_stderr(
             "[UPDATING] git repository `[..]`\n\
+             [UPDATING] git submodule `file://[..]/dep2`\n\
              [COMPILING] dep1 v0.5.0 ([..])\n\
              [COMPILING] foo v0.5.0 ([..])\n\
              [FINISHED] dev [unoptimized + debuginfo] target(s) in \
@@ -1229,6 +1232,7 @@ fn dep_with_changed_submodule() {
         .with_stderr("")
         .with_stderr(&format!(
             "[UPDATING] git repository `{}`\n\
+             [UPDATING] git submodule `file://[..]/dep3`\n\
              [UPDATING] dep1 v0.5.0 ([..]) -> #[..]\n\
              ",
             git_project.url()


### PR DESCRIPTION
This adds a status message when updating a git submodule.  Downloading these can be very slow (often submodules are much larger than their parents).  I think it is helpful to provide some more feedback as to what it is doing.
