### PR TITLE
Bump stable version to 0.43.1

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,10 +115,8 @@ may also need to install additional tools for the target. For example, on Ubuntu
 you should install the `gcc-multilib` package.
 
 If you can't install an alternate target, you can set the
-`CFG_DISABLE_CROSS_TESTS=1` environment variable to disable these tests.
-Unfortunately 32-bit support on macOS is going away, so you may not be able to
-run these tests on macOS. The Windows cross tests only support the MSVC
-toolchain.
+`CFG_DISABLE_CROSS_TESTS=1` environment variable to disable these tests. The
+Windows cross tests only support the MSVC toolchain.
 
 Some of the nightly tests require the `rustc-dev` component installed. This
 component includes the compiler as a library. This may already be installed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo"
-version = "0.43.0"
+version = "0.43.1"
 edition = "2018"
 authors = ["Yehuda Katz <wycats@gmail.com>",
            "Carl Lerche <me@carllerche.com>",

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,12 +26,12 @@ jobs:
 
 - job: macOS
   pool:
-    vmImage: macos-10.13
+    vmImage: macos-10.15
   steps:
     - template: ci/azure-test-all.yml
   variables:
     TOOLCHAIN: stable
-    OTHER_TARGET: i686-apple-darwin
+    OTHER_TARGET: x86_64-apple-ios
 
 - job: Windows
   pool:

--- a/ci/azure-install-rust.yml
+++ b/ci/azure-install-rust.yml
@@ -1,17 +1,6 @@
 steps:
   - bash: |
       set -e
-      if command -v rustup; then
-        echo `command -v rustup` `rustup -V` already installed
-        rustup self update
-      else
-        curl -sSL https://sh.rustup.rs | sh -s -- -y --default-toolchain="$TOOLCHAIN" --profile=minimal
-        echo "##vso[task.prependpath]$HOME/.cargo/bin"
-      fi
-    displayName: Install rustup
-
-  - bash: |
-      set -e
       rustup set profile minimal
       rustup component remove --toolchain=$TOOLCHAIN rust-docs || echo "already removed"
       rustup update --no-self-update $TOOLCHAIN

--- a/crates/cargo-test-support/src/cross_compile.rs
+++ b/crates/cargo-test-support/src/cross_compile.rs
@@ -9,22 +9,26 @@
 //!
 //! These tests are all disabled on rust-lang/rust's CI, but run in Cargo's CI.
 
-use crate::{basic_bin_manifest, main_file, project};
+use crate::{basic_manifest, main_file, project};
+use cargo::util::ProcessError;
+use cargo::CargoResult;
 use std::env;
-use std::process::Command;
+use std::fmt::Write;
+use std::process::{Command, Output};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Once;
 
+/// Whether or not the resulting cross binaries can run on the host.
+static CAN_RUN_ON_HOST: AtomicBool = AtomicBool::new(false);
+
 pub fn disabled() -> bool {
-    // First, disable if `./configure` requested so.
+    // First, disable if requested.
     match env::var("CFG_DISABLE_CROSS_TESTS") {
         Ok(ref s) if *s == "1" => return true,
         _ => {}
     }
 
-    // Right now, the Windows bots cannot cross compile due to the Mingw setup,
-    // so we disable ourselves on all but macOS/Linux setups where the rustc
-    // install script ensures we have both architectures.
+    // Cross tests are only tested to work on macos, linux, and MSVC windows.
     if !(cfg!(target_os = "macos") || cfg!(target_os = "linux") || cfg!(target_env = "msvc")) {
         return true;
     }
@@ -32,29 +36,43 @@ pub fn disabled() -> bool {
     // It's not particularly common to have a cross-compilation setup, so
     // try to detect that before we fail a bunch of tests through no fault
     // of the user.
-    static CAN_RUN_CROSS_TESTS: AtomicBool = AtomicBool::new(false);
+    static CAN_BUILD_CROSS_TESTS: AtomicBool = AtomicBool::new(false);
     static CHECK: Once = Once::new();
 
     let cross_target = alternate();
 
-    CHECK.call_once(|| {
+    let run_cross_test = || -> CargoResult<Output> {
         let p = project()
             .at("cross_test")
-            .file("Cargo.toml", &basic_bin_manifest("cross_test"))
-            .file("src/cross_test.rs", &main_file(r#""testing!""#, &[]))
+            .file("Cargo.toml", &basic_manifest("cross_test", "1.0.0"))
+            .file("src/main.rs", &main_file(r#""testing!""#, &[]))
             .build();
 
-        let result = p
+        let build_result = p
             .cargo("build --target")
             .arg(&cross_target)
             .exec_with_output();
 
-        if result.is_ok() {
-            CAN_RUN_CROSS_TESTS.store(true, Ordering::SeqCst);
+        if build_result.is_ok() {
+            CAN_BUILD_CROSS_TESTS.store(true, Ordering::SeqCst);
         }
+
+        let result = p
+            .cargo("run --target")
+            .arg(&cross_target)
+            .exec_with_output();
+
+        if result.is_ok() {
+            CAN_RUN_ON_HOST.store(true, Ordering::SeqCst);
+        }
+        build_result
+    };
+
+    CHECK.call_once(|| {
+        drop(run_cross_test());
     });
 
-    if CAN_RUN_CROSS_TESTS.load(Ordering::SeqCst) {
+    if CAN_BUILD_CROSS_TESTS.load(Ordering::SeqCst) {
         // We were able to compile a simple project, so the user has the
         // necessary `std::` bits installed. Therefore, tests should not
         // be disabled.
@@ -75,74 +93,134 @@ pub fn disabled() -> bool {
     }
 
     // We are responsible for warning the user, which we do by panicking.
-    let rustup_available = Command::new("rustup").output().is_ok();
-
-    let linux_help = if cfg!(target_os = "linux") {
+    let mut message = format!(
         "
-
-You may need to install runtime libraries for your Linux distribution as well."
-            .to_string()
-    } else {
-        "".to_string()
-    };
-
-    let rustup_help = if rustup_available {
-        format!(
-            "
-
-Alternatively, you can install the necessary libraries for cross-compilation with
-
-    rustup target add {}{}",
-            cross_target, linux_help
-        )
-    } else {
-        "".to_string()
-    };
-
-    panic!(
-        "Cannot cross compile to {}.
+Cannot cross compile to {}.
 
 This failure can be safely ignored. If you would prefer to not see this
-failure, you can set the environment variable CFG_DISABLE_CROSS_TESTS to \"1\".{}
+failure, you can set the environment variable CFG_DISABLE_CROSS_TESTS to \"1\".
+
+Alternatively, you can install the necessary libraries to enable cross
+compilation tests. Cross compilation tests depend on your host platform.
 ",
-        cross_target, rustup_help
+        cross_target
     );
+
+    if cfg!(target_os = "linux") {
+        message.push_str(
+            "
+Linux cross tests target i686-unknown-linux-gnu, which requires the ability to
+build and run 32-bit targets. This requires the 32-bit libraries to be
+installed. For example, on Ubuntu, run `sudo apt install gcc-multilib` to
+install the necessary libraries.
+",
+        );
+    } else if cfg!(target_os = "macos") {
+        message.push_str(
+            "
+macOS cross tests target x86_64-apple-ios, which requires the iOS SDK to be
+installed. This should be included with Xcode automatically. If you are using
+the Xcode command line tools, you'll need to install the full Xcode app (from
+the Apple App Store), and switch to it with this command:
+
+    sudo xcode-select --switch /Applications/Xcode.app/Contents/Developer
+
+Some cross-tests want to *run* the executables on the host. These tests will
+be ignored if this is not possible. On macOS, this means you need an iOS
+simulator installed to run these tests. To install a simulator, open Xcode, go
+to preferences > Components, and download the latest iOS simulator.
+",
+        );
+    } else if cfg!(target_os = "windows") {
+        message.push_str(
+            "
+Windows cross tests target i686-pc-windows-msvc, which requires the ability
+to build and run 32-bit targets. This should work automatically if you have
+properly installed Visual Studio build tools.
+",
+        );
+    } else {
+        // The check at the top should prevent this.
+        panic!("platform should have been skipped");
+    }
+
+    let rustup_available = Command::new("rustup").output().is_ok();
+    if rustup_available {
+        write!(
+            message,
+            "
+Make sure that the appropriate `rustc` target is installed with rustup:
+
+    rustup target add {}
+",
+            cross_target
+        )
+        .unwrap();
+    } else {
+        write!(
+            message,
+            "
+rustup does not appear to be installed. Make sure that the appropriate
+`rustc` target is installed for the target `{}`.
+",
+            cross_target
+        )
+        .unwrap();
+    }
+
+    // Show the actual error message.
+    match run_cross_test() {
+        Ok(_) => message.push_str("\nUh oh, second run succeeded?\n"),
+        Err(err) => match err.downcast_ref::<ProcessError>() {
+            Some(proc_err) => write!(message, "\nTest error: {}\n", proc_err).unwrap(),
+            None => write!(message, "\nUnexpected non-process error: {}\n", err).unwrap(),
+        },
+    }
+
+    panic!(message);
 }
 
-pub fn alternate() -> String {
-    let platform = match env::consts::OS {
-        "linux" => "unknown-linux-gnu",
-        "macos" => "apple-darwin",
-        "windows" => "pc-windows-msvc",
-        _ => unreachable!(),
-    };
-    let arch = match env::consts::ARCH {
-        "x86" => "x86_64",
-        "x86_64" => "i686",
-        _ => unreachable!(),
-    };
-    format!("{}-{}", arch, platform)
-}
-
-pub fn alternate_arch() -> &'static str {
-    match env::consts::ARCH {
-        "x86" => "x86_64",
-        "x86_64" => "x86",
-        _ => unreachable!(),
+/// The alternate target-triple to build with.
+///
+/// Only use this function on tests that check `cross_compile::disabled`.
+pub fn alternate() -> &'static str {
+    if cfg!(target_os = "macos") {
+        "x86_64-apple-ios"
+    } else if cfg!(target_os = "linux") {
+        "i686-unknown-linux-gnu"
+    } else if cfg!(all(target_os = "windows", target_env = "msvc")) {
+        "i686-pc-windows-msvc"
+    } else {
+        panic!("This test should be gated on cross_compile::disabled.");
     }
 }
 
-pub fn host() -> String {
-    let platform = match env::consts::OS {
-        "linux" => "unknown-linux-gnu",
-        "macos" => "apple-darwin",
-        "windows" => "pc-windows-msvc",
-        _ => unreachable!(),
-    };
-    let arch = match env::consts::ARCH {
-        "x86" => "i686",
-        "x86_64" => "x86_64",
-        _ => unreachable!(),
-    };
-    format!("{}-{}", arch, platform)
+pub fn alternate_arch() -> &'static str {
+    if cfg!(target_os = "macos") {
+        "x86_64"
+    } else {
+        "x86"
+    }
+}
+
+/// Whether or not the host can run cross-compiled executables.
+pub fn can_run_on_host() -> bool {
+    if disabled() {
+        return false;
+    }
+    // macos is currently configured to cross compile to x86_64-apple-ios
+    // which requires a simulator to run. Azure's CI image appears to have the
+    // SDK installed, but are not configured to launch iOS images with a
+    // simulator.
+    if cfg!(target_os = "macos") {
+        if CAN_RUN_ON_HOST.load(Ordering::SeqCst) {
+            return true;
+        } else {
+            println!("Note: Cannot run on host, skipping.");
+            return false;
+        }
+    } else {
+        assert!(CAN_RUN_ON_HOST.load(Ordering::SeqCst));
+        return true;
+    }
 }

--- a/crates/cargo-test-support/src/lib.rs
+++ b/crates/cargo-test-support/src/lib.rs
@@ -1741,6 +1741,10 @@ fn _process(t: &OsStr) -> cargo::util::ProcessBuilder {
         .env_remove("GIT_COMMITTER_NAME")
         .env_remove("GIT_COMMITTER_EMAIL")
         .env_remove("MSYSTEM"); // assume cmd.exe everywhere on windows
+    if cfg!(target_os = "macos") {
+        // Work-around a bug in macOS 10.15, see `link_or_copy` for details.
+        p.env("__CARGO_COPY_DONT_LINK_DO_NOT_USE_THIS", "1");
+    }
     p
 }
 

--- a/tests/testsuite/build_script.rs
+++ b/tests/testsuite/build_script.rs
@@ -3554,6 +3554,8 @@ fn rename_with_link_search_path() {
 }
 
 #[cargo_test]
+// Don't have a cdylib cross target on macos.
+#[cfg_attr(target_os = "macos", ignore)]
 fn rename_with_link_search_path_cross() {
     if cross_compile::disabled() {
         return;

--- a/tests/testsuite/check.rs
+++ b/tests/testsuite/check.rs
@@ -64,7 +64,7 @@ fn check_fail() {
 
     foo.cargo("check")
         .with_status(101)
-        .with_stderr_contains("[..]this function takes 0 parameters but 1 parameter was supplied")
+        .with_stderr_contains("[..]this function takes 0[..]")
         .run();
 }
 

--- a/tests/testsuite/cross_compile.rs
+++ b/tests/testsuite/cross_compile.rs
@@ -51,7 +51,9 @@ fn simple_cross() {
     p.cargo("build -v --target").arg(&target).run();
     assert!(p.target_bin(&target, "foo").is_file());
 
-    p.process(&p.target_bin(&target, "foo")).run();
+    if cross_compile::can_run_on_host() {
+        p.process(&p.target_bin(&target, "foo")).run();
+    }
 }
 
 #[cargo_test]
@@ -110,7 +112,9 @@ fn simple_cross_config() {
     p.cargo("build -v").run();
     assert!(p.target_bin(&target, "foo").is_file());
 
-    p.process(&p.target_bin(&target, "foo")).run();
+    if cross_compile::can_run_on_host() {
+        p.process(&p.target_bin(&target, "foo")).run();
+    }
 }
 
 #[cargo_test]
@@ -144,7 +148,9 @@ fn simple_deps() {
     p.cargo("build --target").arg(&target).run();
     assert!(p.target_bin(&target, "foo").is_file());
 
-    p.process(&p.target_bin(&target, "foo")).run();
+    if cross_compile::can_run_on_host() {
+        p.process(&p.target_bin(&target, "foo")).run();
+    }
 }
 
 #[cargo_test]
@@ -292,7 +298,7 @@ fn plugin_with_extra_dylib_dep() {
 
 #[cargo_test]
 fn cross_tests() {
-    if cross_compile::disabled() {
+    if !cross_compile::can_run_on_host() {
         return;
     }
 
@@ -382,7 +388,7 @@ fn no_cross_doctests() {
     p.cargo("test").with_stderr(&host_output).run();
 
     println!("b");
-    let target = cross_compile::host();
+    let target = rustc_host();
     p.cargo("test --target")
         .arg(&target)
         .with_stderr(&format!(
@@ -398,13 +404,33 @@ fn no_cross_doctests() {
 
     println!("c");
     let target = cross_compile::alternate();
-    p.cargo("test --target")
+
+    // This will build the library, but does not build or run doc tests.
+    // This should probably be a warning or error.
+    p.cargo("test -v --doc --target")
+        .arg(&target)
+        .with_stderr(
+            "\
+[COMPILING] foo v0.0.1 ([CWD])
+[RUNNING] `rustc --crate-name foo [..]
+[FINISHED] test [unoptimized + debuginfo] target(s) in [..]
+",
+        )
+        .run();
+
+    if !cross_compile::can_run_on_host() {
+        return;
+    }
+
+    // This tests the library, but does not run the doc tests.
+    p.cargo("test -v --target")
         .arg(&target)
         .with_stderr(&format!(
             "\
 [COMPILING] foo v0.0.1 ([CWD])
+[RUNNING] `rustc --crate-name foo [..]--test[..]
 [FINISHED] test [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target/{triple}/debug/deps/foo-[..][EXE]
+[RUNNING] `[CWD]/target/{triple}/debug/deps/foo-[..][EXE]`
 ",
             triple = target
         ))
@@ -413,7 +439,7 @@ fn no_cross_doctests() {
 
 #[cargo_test]
 fn simple_cargo_run() {
-    if cross_compile::disabled() {
+    if !cross_compile::can_run_on_host() {
         return;
     }
 
@@ -954,6 +980,8 @@ fn platform_specific_variables_reflected_in_build_scripts() {
 }
 
 #[cargo_test]
+// Don't have a dylib cross target on macos.
+#[cfg_attr(target_os = "macos", ignore)]
 fn cross_test_dylib() {
     if cross_compile::disabled() {
         return;

--- a/tests/testsuite/plugins.rs
+++ b/tests/testsuite/plugins.rs
@@ -375,7 +375,7 @@ fn panic_abort_plugins() {
             "bar/src/lib.rs",
             r#"
             #![feature(rustc_private)]
-            extern crate syntax;
+            extern crate rustc_ast;
         "#,
         )
         .build();
@@ -427,7 +427,7 @@ fn shared_panic_abort_plugins() {
             "bar/src/lib.rs",
             r#"
             #![feature(rustc_private)]
-            extern crate syntax;
+            extern crate rustc_ast;
             extern crate baz;
         "#,
         )

--- a/tests/testsuite/test.rs
+++ b/tests/testsuite/test.rs
@@ -3664,6 +3664,8 @@ fn cargo_test_doctest_xcompile_ignores() {
         // -Zdoctest-xcompile is unstable
         return;
     }
+    // -Zdoctest-xcompile also enables --enable-per-target-ignores which
+    // allows the ignore-TARGET syntax.
     let p = project()
         .file("Cargo.toml", &basic_lib_manifest("foo"))
         .file(
@@ -3713,7 +3715,7 @@ fn cargo_test_doctest_xcompile_ignores() {
 
 #[cargo_test]
 fn cargo_test_doctest_xcompile() {
-    if cross_compile::disabled() {
+    if !cross_compile::can_run_on_host() {
         return;
     }
     if !is_nightly() {
@@ -3753,7 +3755,7 @@ fn cargo_test_doctest_xcompile() {
 
 #[cargo_test]
 fn cargo_test_doctest_xcompile_runner() {
-    if cross_compile::disabled() {
+    if !cross_compile::can_run_on_host() {
         return;
     }
     if !is_nightly() {
@@ -3789,9 +3791,10 @@ fn cargo_test_doctest_xcompile_runner() {
         config,
         format!(
             r#"
-[target.'cfg(target_arch = "x86")']
+[target.'cfg(target_arch = "{}")']
 runner = "{}"
 "#,
+            cross_compile::alternate_arch(),
             runner_str
         ),
     )
@@ -3801,14 +3804,17 @@ runner = "{}"
         .file("Cargo.toml", &basic_lib_manifest("foo"))
         .file(
             "src/lib.rs",
-            r#"
-            ///```
-            ///assert!(cfg!(target_arch = "x86"));
-            ///```
-            pub fn foo() -> u8 {
-                4
-            }
-            "#,
+            &format!(
+                r#"
+                ///```
+                ///assert!(cfg!(target_arch = "{}"));
+                ///```
+                pub fn foo() -> u8 {{
+                    4
+                }}
+                "#,
+                cross_compile::alternate_arch()
+            ),
         )
         .build();
 
@@ -3830,7 +3836,7 @@ runner = "{}"
 
 #[cargo_test]
 fn cargo_test_doctest_xcompile_no_runner() {
-    if cross_compile::disabled() {
+    if !cross_compile::can_run_on_host() {
         return;
     }
     if !is_nightly() {
@@ -3842,15 +3848,17 @@ fn cargo_test_doctest_xcompile_no_runner() {
         .file("Cargo.toml", &basic_lib_manifest("foo"))
         .file(
             "src/lib.rs",
-            r#"
-
-            ///```
-            ///assert!(cfg!(target_arch = "x86"));
-            ///```
-            pub fn foo() -> u8 {
-                4
-            }
-            "#,
+            &format!(
+                r#"
+                ///```
+                ///assert!(cfg!(target_arch = "{}"));
+                ///```
+                pub fn foo() -> u8 {{
+                    4
+                }}
+                "#,
+                cross_compile::alternate_arch()
+            ),
         )
         .build();
 


### PR DESCRIPTION
There was a hiccup where 0.43.0 was published to crates.io missing a change (#7848), see #7994 for details. It is not super critical, but in rare cases the bug can cause cargo used as a library to hang.  I think bumping the version and re-publishing is relatively low-effort and low-risk. 

This also includes backports to appease CI: #7883 #7906 #7955.