### PR TITLE
Use Option::as_deref

### DIFF
--- a/crates/cargo-test-support/src/registry.rs
+++ b/crates/cargo-test-support/src/registry.rs
@@ -375,14 +375,13 @@ impl Package {
             .map(|dep| {
                 // In the index, the `registry` is null if it is from the same registry.
                 // In Cargo.toml, it is None if it is from crates.io.
-                let registry_url =
-                    match (self.alternative, dep.registry.as_ref().map(|s| s.as_ref())) {
-                        (false, None) => None,
-                        (false, Some("alternative")) => Some(alt_registry_url().to_string()),
-                        (true, None) => Some(CRATES_IO_INDEX.to_string()),
-                        (true, Some("alternative")) => None,
-                        _ => panic!("registry_dep currently only supports `alternative`"),
-                    };
+                let registry_url = match (self.alternative, dep.registry.as_deref()) {
+                    (false, None) => None,
+                    (false, Some("alternative")) => Some(alt_registry_url().to_string()),
+                    (true, None) => Some(CRATES_IO_INDEX.to_string()),
+                    (true, Some("alternative")) => None,
+                    _ => panic!("registry_dep currently only supports `alternative`"),
+                };
                 serde_json::json!({
                     "name": dep.name,
                     "req": dep.vers,

--- a/src/bin/cargo/cli.rs
+++ b/src/bin/cargo/cli.rs
@@ -179,9 +179,7 @@ fn config_configure(
     let quiet =
         args.is_present("quiet") || subcommand_args.is_present("quiet") || global_args.quiet;
     let global_color = global_args.color; // Extract so it can take reference.
-    let color = args
-        .value_of("color")
-        .or_else(|| global_color.as_ref().map(|s| s.as_ref()));
+    let color = args.value_of("color").or_else(|| global_color.as_deref());
     let frozen = args.is_present("frozen") || global_args.frozen;
     let locked = args.is_present("locked") || global_args.locked;
     let offline = args.is_present("offline") || global_args.offline;

--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -490,7 +490,7 @@ impl Manifest {
         &self.patch
     }
     pub fn links(&self) -> Option<&str> {
-        self.links.as_ref().map(|s| &s[..])
+        self.links.as_deref()
     }
 
     pub fn workspace_config(&self) -> &WorkspaceConfig {
@@ -541,7 +541,7 @@ impl Manifest {
     }
 
     pub fn default_run(&self) -> Option<&str> {
-        self.default_run.as_ref().map(|s| &s[..])
+        self.default_run.as_deref()
     }
 
     pub fn metabuild(&self) -> Option<&Vec<String>> {

--- a/src/cargo/core/package.rs
+++ b/src/cargo/core/package.rs
@@ -87,14 +87,14 @@ impl ser::Serialize for Package {
         let summary = self.manifest.summary();
         let package_id = summary.package_id();
         let manmeta = self.manifest.metadata();
-        let license = manmeta.license.as_ref().map(String::as_ref);
-        let license_file = manmeta.license_file.as_ref().map(String::as_ref);
-        let description = manmeta.description.as_ref().map(String::as_ref);
+        let license = manmeta.license.as_deref();
+        let license_file = manmeta.license_file.as_deref();
+        let description = manmeta.description.as_deref();
         let authors = manmeta.authors.as_ref();
         let categories = manmeta.categories.as_ref();
         let keywords = manmeta.keywords.as_ref();
-        let readme = manmeta.readme.as_ref().map(String::as_ref);
-        let repository = manmeta.repository.as_ref().map(String::as_ref);
+        let readme = manmeta.readme.as_deref();
+        let repository = manmeta.repository.as_deref();
         // Filter out metabuild targets. They are an internal implementation
         // detail that is probably not relevant externally. There's also not a
         // real path to show in `src_path`, and this avoids changing the format.

--- a/src/cargo/core/source/source_id.rs
+++ b/src/cargo/core/source/source_id.rs
@@ -326,7 +326,7 @@ impl SourceId {
 
     /// Gets the value of the precise field.
     pub fn precise(self) -> Option<&'static str> {
-        self.inner.precise.as_ref().map(|s| &s[..])
+        self.inner.precise.as_deref()
     }
 
     /// Gets the Git reference if this is a git source, otherwise `None`.

--- a/src/cargo/core/summary.rs
+++ b/src/cargo/core/summary.rs
@@ -91,7 +91,7 @@ impl Summary {
         &self.inner.features
     }
     pub fn checksum(&self) -> Option<&str> {
-        self.inner.checksum.as_ref().map(|s| &s[..])
+        self.inner.checksum.as_deref()
     }
     pub fn links(&self) -> Option<InternedString> {
         self.inner.links

--- a/src/cargo/ops/cargo_new.rs
+++ b/src/cargo/ops/cargo_new.rs
@@ -375,8 +375,8 @@ pub fn new(opts: &NewOptions, config: &Config) -> CargoResult<()> {
         name,
         source_files: vec![plan_new_source_file(opts.kind.is_bin(), name.to_string())],
         bin: opts.kind.is_bin(),
-        edition: opts.edition.as_ref().map(|s| &**s),
-        registry: opts.registry.as_ref().map(|s| &**s),
+        edition: opts.edition.as_deref(),
+        registry: opts.registry.as_deref(),
     };
 
     mk(config, &mkopts).chain_err(|| {
@@ -465,8 +465,8 @@ pub fn init(opts: &NewOptions, config: &Config) -> CargoResult<()> {
         name,
         bin: has_bin,
         source_files: src_paths_types,
-        edition: opts.edition.as_ref().map(|s| &**s),
-        registry: opts.registry.as_ref().map(|s| &**s),
+        edition: opts.edition.as_deref(),
+        registry: opts.registry.as_deref(),
     };
 
     mk(config, &mkopts).chain_err(|| {

--- a/src/cargo/ops/common_for_install_and_uninstall.rs
+++ b/src/cargo/ops/common_for_install_and_uninstall.rs
@@ -500,7 +500,7 @@ impl InstallInfo {
             && self.all_features == opts.all_features
             && self.no_default_features == opts.no_default_features
             && self.profile.as_str() == opts.build_config.requested_profile.as_str()
-            && (self.target.is_none() || self.target.as_ref().map(|t| t.as_ref()) == Some(target))
+            && (self.target.is_none() || self.target.as_deref() == Some(target))
             && &self.bins == exes
     }
 }
@@ -594,7 +594,7 @@ where
         } else {
             None
         };
-        let vers = vers.as_ref().map(|s| &**s);
+        let vers = vers.as_deref();
         let vers_spec = if vers.is_none() && source.source_id().is_registry() {
             // Avoid pre-release versions from crate.io
             // unless explicitly asked for

--- a/src/cargo/ops/fix.rs
+++ b/src/cargo/ops/fix.rs
@@ -697,7 +697,7 @@ impl FixArgs {
     }
 
     fn next_edition(&self) -> &str {
-        match self.enabled_edition.as_ref().map(|s| &**s) {
+        match self.enabled_edition.as_deref() {
             // 2015 -> 2018,
             None | Some("2015") => "2018",
 

--- a/src/cargo/sources/registry/index.rs
+++ b/src/cargo/sources/registry/index.rs
@@ -336,7 +336,7 @@ impl<'cfg> RegistryIndex<'cfg> {
         // along the way produce helpful "did you mean?" suggestions.
         for path in UncanonicalizedIter::new(&raw_path).take(1024) {
             let summaries = Summaries::parse(
-                index_version.as_ref().map(|s| &**s),
+                index_version.as_deref(),
                 root,
                 &cache_root,
                 path.as_ref(),

--- a/src/cargo/sources/registry/mod.rs
+++ b/src/cargo/sources/registry/mod.rs
@@ -315,7 +315,7 @@ impl<'a> RegistryDependency<'a> {
         if package.is_some() {
             dep.set_explicit_name_in_toml(name);
         }
-        let kind = match kind.as_ref().map(|s| &s[..]).unwrap_or("") {
+        let kind = match kind.as_deref().unwrap_or("") {
             "dev" => DepKind::Development,
             "build" => DepKind::Build,
             _ => DepKind::Normal,

--- a/src/cargo/util/config/mod.rs
+++ b/src/cargo/util/config/mod.rs
@@ -703,7 +703,7 @@ impl Config {
         // Ignore errors in the configuration files.
         let term = self.get::<TermConfig>("term").unwrap_or_default();
 
-        let color = color.or_else(|| term.color.as_ref().map(|s| s.as_ref()));
+        let color = color.or_else(|| term.color.as_deref());
 
         let verbosity = match (verbose, term.verbose, quiet) {
             (true, _, false) | (_, Some(true), false) => Verbosity::Verbose,

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -1624,7 +1624,7 @@ impl DetailedTomlDependency {
             None => (name_in_toml, None),
         };
 
-        let version = self.version.as_ref().map(|v| &v[..]);
+        let version = self.version.as_deref();
         let mut dep = match cx.pkgid {
             Some(id) => Dependency::parse(pkg_name, version, new_source_id, id, cx.config)?,
             None => Dependency::parse_no_deprecated(pkg_name, version, new_source_id)?,


### PR DESCRIPTION
[`Option::as_deref`](https://doc.rust-lang.org/std/option/enum.Option.html#method.as_deref) was stabilized in 1.40.  I think it is slightly cleaner looking (though it requires the reader to know what the method does).
