### PR TITLE
Checking for binary that is built as an implicit dependency of an integration test.

### DIFF
--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -949,7 +949,7 @@ fn generate_targets<'a>(
 ///
 /// Dependencies are added as `dep_name/feat_name` because `required-features`
 /// wants to support that syntax.
-fn resolve_all_features(
+pub fn resolve_all_features(
     resolve_with_overrides: &Resolve,
     resolved_features: &features::ResolvedFeatures,
     package_set: &PackageSet<'_>,

--- a/src/cargo/ops/mod.rs
+++ b/src/cargo/ops/mod.rs
@@ -1,5 +1,7 @@
 pub use self::cargo_clean::{clean, CleanOptions};
-pub use self::cargo_compile::{compile, compile_with_exec, compile_ws, CompileOptions};
+pub use self::cargo_compile::{
+    compile, compile_with_exec, compile_ws, resolve_all_features, CompileOptions,
+};
 pub use self::cargo_compile::{CompileFilter, FilterRule, LibRule, Packages};
 pub use self::cargo_doc::{doc, DocOptions};
 pub use self::cargo_fetch::{fetch, FetchOptions};


### PR DESCRIPTION
When a project containing binary with required-features, the binary will only be built with the given dependency's feature is enabled. But this feature syntax is not checked when the binary is built as an implicit dependency of an integration test. This pr addresses this issue. 

More info is in the issue page: this pr fixes #7853.