### PR TITLE
Remove Config from CompileOptions.

### DIFF
--- a/src/bin/cargo/commands/install.rs
+++ b/src/bin/cargo/commands/install.rs
@@ -156,6 +156,7 @@ pub fn exec(config: &mut Config, args: &ArgMatches<'_>) -> CliResult {
         ops::install_list(root, config)?;
     } else {
         ops::install(
+            config,
             root,
             krates,
             source,

--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -46,8 +46,7 @@ use crate::util::{closest_msg, profile, CargoResult};
 
 /// Contains information about how a package should be compiled.
 #[derive(Debug)]
-pub struct CompileOptions<'a> {
-    pub config: &'a Config,
+pub struct CompileOptions {
     /// Configuration information for a rustc build
     pub build_config: BuildConfig,
     /// Extra features to build for the root package
@@ -79,10 +78,9 @@ pub struct CompileOptions<'a> {
     pub export_dir: Option<PathBuf>,
 }
 
-impl<'a> CompileOptions<'a> {
-    pub fn new(config: &'a Config, mode: CompileMode) -> CargoResult<CompileOptions<'a>> {
+impl<'a> CompileOptions {
+    pub fn new(config: &Config, mode: CompileMode) -> CargoResult<CompileOptions> {
         Ok(CompileOptions {
-            config,
             build_config: BuildConfig::new(config, None, &None, mode)?,
             features: Vec::new(),
             all_features: false,
@@ -242,10 +240,7 @@ pub enum CompileFilter {
     },
 }
 
-pub fn compile<'a>(
-    ws: &Workspace<'a>,
-    options: &CompileOptions<'a>,
-) -> CargoResult<Compilation<'a>> {
+pub fn compile<'a>(ws: &Workspace<'a>, options: &CompileOptions) -> CargoResult<Compilation<'a>> {
     let exec: Arc<dyn Executor> = Arc::new(DefaultExecutor);
     compile_with_exec(ws, options, &exec)
 }
@@ -254,7 +249,7 @@ pub fn compile<'a>(
 /// calls and add custom logic. `compile` uses `DefaultExecutor` which just passes calls through.
 pub fn compile_with_exec<'a>(
     ws: &Workspace<'a>,
-    options: &CompileOptions<'a>,
+    options: &CompileOptions,
     exec: &Arc<dyn Executor>,
 ) -> CargoResult<Compilation<'a>> {
     ws.emit_warnings()?;
@@ -263,11 +258,10 @@ pub fn compile_with_exec<'a>(
 
 pub fn compile_ws<'a>(
     ws: &Workspace<'a>,
-    options: &CompileOptions<'a>,
+    options: &CompileOptions,
     exec: &Arc<dyn Executor>,
 ) -> CargoResult<Compilation<'a>> {
     let CompileOptions {
-        config,
         ref build_config,
         ref spec,
         ref features,
@@ -280,6 +274,7 @@ pub fn compile_ws<'a>(
         rustdoc_document_private_items,
         ref export_dir,
     } = *options;
+    let config = ws.config();
 
     match build_config.mode {
         CompileMode::Test

--- a/src/cargo/ops/cargo_doc.rs
+++ b/src/cargo/ops/cargo_doc.rs
@@ -9,15 +9,15 @@ use std::process::Command;
 
 /// Strongly typed options for the `cargo doc` command.
 #[derive(Debug)]
-pub struct DocOptions<'a> {
+pub struct DocOptions {
     /// Whether to attempt to open the browser after compiling the docs
     pub open_result: bool,
     /// Options to pass through to the compiler
-    pub compile_opts: ops::CompileOptions<'a>,
+    pub compile_opts: ops::CompileOptions,
 }
 
 /// Main method for `cargo doc`.
-pub fn doc(ws: &Workspace<'_>, options: &DocOptions<'_>) -> CargoResult<()> {
+pub fn doc(ws: &Workspace<'_>, options: &DocOptions) -> CargoResult<()> {
     let specs = options.compile_opts.spec.to_package_id_specs(ws)?;
     let opts = ResolveOpts::new(
         /*dev_deps*/ true,
@@ -85,7 +85,7 @@ pub fn doc(ws: &Workspace<'_>, options: &DocOptions<'_>) -> CargoResult<()> {
             .join(&name)
             .join("index.html");
         if path.exists() {
-            let mut shell = options.compile_opts.config.shell();
+            let mut shell = ws.config().shell();
             shell.status("Opening", path.display())?;
             open_docs(&path, &mut shell)?;
         }

--- a/src/cargo/ops/cargo_package.rs
+++ b/src/cargo/ops/cargo_package.rs
@@ -704,7 +704,6 @@ fn run_verify(ws: &Workspace<'_>, tar: &FileLock, opts: &PackageOpts<'_>) -> Car
     ops::compile_with_exec(
         &ws,
         &ops::CompileOptions {
-            config,
             build_config: BuildConfig::new(config, opts.jobs, &opts.target, CompileMode::Build)?,
             features: opts.features.clone(),
             no_default_features: opts.no_default_features,

--- a/src/cargo/ops/cargo_run.rs
+++ b/src/cargo/ops/cargo_run.rs
@@ -8,7 +8,7 @@ use crate::util::{CargoResult, ProcessError};
 
 pub fn run(
     ws: &Workspace<'_>,
-    options: &ops::CompileOptions<'_>,
+    options: &ops::CompileOptions,
     args: &[OsString],
 ) -> CargoResult<Option<ProcessError>> {
     let config = ws.config();

--- a/src/cargo/ops/common_for_install_and_uninstall.rs
+++ b/src/cargo/ops/common_for_install_and_uninstall.rs
@@ -159,7 +159,7 @@ impl InstallTracker {
         dst: &Path,
         pkg: &Package,
         force: bool,
-        opts: &CompileOptions<'_>,
+        opts: &CompileOptions,
         target: &str,
         _rustc: &str,
     ) -> CargoResult<(Freshness, BTreeMap<String, Option<PackageId>>)> {
@@ -267,7 +267,7 @@ impl InstallTracker {
         package: &Package,
         bins: &BTreeSet<String>,
         version_req: Option<String>,
-        opts: &CompileOptions<'_>,
+        opts: &CompileOptions,
         target: &str,
         rustc: &str,
     ) {
@@ -401,7 +401,7 @@ impl CrateListingV2 {
         pkg: &Package,
         bins: &BTreeSet<String>,
         version_req: Option<String>,
-        opts: &CompileOptions<'_>,
+        opts: &CompileOptions,
         target: &str,
         rustc: &str,
     ) {
@@ -490,12 +490,7 @@ impl InstallInfo {
     /// Determine if this installation is "up to date", or if it needs to be reinstalled.
     ///
     /// This does not do Package/Source/Version checking.
-    fn is_up_to_date(
-        &self,
-        opts: &CompileOptions<'_>,
-        target: &str,
-        exes: &BTreeSet<String>,
-    ) -> bool {
+    fn is_up_to_date(&self, opts: &CompileOptions, target: &str, exes: &BTreeSet<String>) -> bool {
         self.features == feature_set(&opts.features)
             && self.all_features == opts.all_features
             && self.no_default_features == opts.no_default_features

--- a/src/cargo/util/command_prelude.rs
+++ b/src/cargo/util/command_prelude.rs
@@ -362,13 +362,13 @@ pub trait ArgMatchesExt {
         }
     }
 
-    fn compile_options<'a>(
+    fn compile_options(
         &self,
-        config: &'a Config,
+        config: &Config,
         mode: CompileMode,
-        workspace: Option<&Workspace<'a>>,
+        workspace: Option<&Workspace<'_>>,
         profile_checking: ProfileChecking,
-    ) -> CargoResult<CompileOptions<'a>> {
+    ) -> CargoResult<CompileOptions> {
         let spec = Packages::from_flags(
             // TODO Integrate into 'workspace'
             self._is_present("workspace") || self._is_present("all"),
@@ -455,7 +455,6 @@ pub trait ArgMatchesExt {
         }
 
         let opts = CompileOptions {
-            config,
             build_config,
             features: self._values_of("features"),
             all_features: self._is_present("all-features"),
@@ -487,13 +486,13 @@ pub trait ArgMatchesExt {
         Ok(opts)
     }
 
-    fn compile_options_for_single_package<'a>(
+    fn compile_options_for_single_package(
         &self,
-        config: &'a Config,
+        config: &Config,
         mode: CompileMode,
-        workspace: Option<&Workspace<'a>>,
+        workspace: Option<&Workspace<'_>>,
         profile_checking: ProfileChecking,
-    ) -> CargoResult<CompileOptions<'a>> {
+    ) -> CargoResult<CompileOptions> {
         let mut compile_opts = self.compile_options(config, mode, workspace, profile_checking)?;
         compile_opts.spec = Packages::Packages(self._values_of("package"));
         Ok(compile_opts)
@@ -566,7 +565,7 @@ about this warning.";
     fn check_optional_opts(
         &self,
         workspace: &Workspace<'_>,
-        compile_opts: &CompileOptions<'_>,
+        compile_opts: &CompileOptions,
     ) -> CargoResult<()> {
         if self.is_present_with_zero_values("example") {
             print_available_examples(workspace, compile_opts)?;

--- a/src/cargo/util/errors.rs
+++ b/src/cargo/util/errors.rs
@@ -259,7 +259,7 @@ impl CargoTestError {
         }
     }
 
-    pub fn hint(&self, ws: &Workspace<'_>, opts: &CompileOptions<'_>) -> String {
+    pub fn hint(&self, ws: &Workspace<'_>, opts: &CompileOptions) -> String {
         match self.test {
             Test::UnitTest {
                 ref kind,

--- a/src/cargo/util/workspace.rs
+++ b/src/cargo/util/workspace.rs
@@ -7,7 +7,7 @@ use std::fmt::Write;
 fn get_available_targets<'a>(
     filter_fn: fn(&Target) -> bool,
     ws: &'a Workspace<'_>,
-    options: &'a CompileOptions<'_>,
+    options: &'a CompileOptions,
 ) -> CargoResult<Vec<&'a Target>> {
     let packages = options.spec.get_packages(ws)?;
 
@@ -29,7 +29,7 @@ fn get_available_targets<'a>(
 fn print_available(
     filter_fn: fn(&Target) -> bool,
     ws: &Workspace<'_>,
-    options: &CompileOptions<'_>,
+    options: &CompileOptions,
     option_name: &str,
     plural_name: &str,
 ) -> CargoResult<()> {
@@ -49,27 +49,18 @@ fn print_available(
     bail!("{}", output)
 }
 
-pub fn print_available_examples(
-    ws: &Workspace<'_>,
-    options: &CompileOptions<'_>,
-) -> CargoResult<()> {
+pub fn print_available_examples(ws: &Workspace<'_>, options: &CompileOptions) -> CargoResult<()> {
     print_available(Target::is_example, ws, options, "--example", "examples")
 }
 
-pub fn print_available_binaries(
-    ws: &Workspace<'_>,
-    options: &CompileOptions<'_>,
-) -> CargoResult<()> {
+pub fn print_available_binaries(ws: &Workspace<'_>, options: &CompileOptions) -> CargoResult<()> {
     print_available(Target::is_bin, ws, options, "--bin", "binaries")
 }
 
-pub fn print_available_benches(
-    ws: &Workspace<'_>,
-    options: &CompileOptions<'_>,
-) -> CargoResult<()> {
+pub fn print_available_benches(ws: &Workspace<'_>, options: &CompileOptions) -> CargoResult<()> {
     print_available(Target::is_bench, ws, options, "--bench", "benches")
 }
 
-pub fn print_available_tests(ws: &Workspace<'_>, options: &CompileOptions<'_>) -> CargoResult<()> {
+pub fn print_available_tests(ws: &Workspace<'_>, options: &CompileOptions) -> CargoResult<()> {
     print_available(Target::is_test, ws, options, "--test", "tests")
 }


### PR DESCRIPTION
This removes Config from CompileOptions. This removes the lifetime parameters, which I think simplifies things slightly (with the drawback that Config now needs to be passed as a parameter to a few functions).
