### PR TITLE
Distinguish between compiling the build script and the rest

### DIFF
--- a/crates/cargo-test-support/src/lib.rs
+++ b/crates/cargo-test-support/src/lib.rs
@@ -1637,6 +1637,7 @@ fn substitute_macros(input: &str) -> String {
     let macros = [
         ("[RUNNING]", "     Running"),
         ("[COMPILING]", "   Compiling"),
+        ("[COMPILING BUILD SCRIPT]", "Compiling build script for"),
         ("[CHECKING]", "    Checking"),
         ("[COMPLETED]", "   Completed"),
         ("[CREATED]", "     Created"),

--- a/crates/cargo-test-support/src/lib.rs
+++ b/crates/cargo-test-support/src/lib.rs
@@ -1637,7 +1637,6 @@ fn substitute_macros(input: &str) -> String {
     let macros = [
         ("[RUNNING]", "     Running"),
         ("[COMPILING]", "   Compiling"),
-        ("[COMPILING BUILD SCRIPT]", "Compiling build script for"),
         ("[CHECKING]", "    Checking"),
         ("[COMPLETED]", "   Completed"),
         ("[CREATED]", "     Created"),

--- a/src/cargo/core/compiler/job_queue.rs
+++ b/src/cargo/core/compiler/job_queue.rs
@@ -933,6 +933,8 @@ impl<'a, 'cfg> DrainState<'a, 'cfg> {
                     self.compiled.insert(unit.pkg.package_id());
                     if unit.mode.is_check() {
                         config.shell().status("Checking", unit.pkg)?;
+                    } else if unit.mode.is_run_custom_build() {
+                        config.shell().status("Compiling build script for", unit.pkg)?;
                     } else {
                         config.shell().status("Compiling", unit.pkg)?;
                     }

--- a/src/cargo/core/compiler/job_queue.rs
+++ b/src/cargo/core/compiler/job_queue.rs
@@ -933,10 +933,10 @@ impl<'a, 'cfg> DrainState<'a, 'cfg> {
                     self.compiled.insert(unit.pkg.package_id());
                     if unit.mode.is_check() {
                         config.shell().status("Checking", unit.pkg)?;
-                    } else if unit.mode.is_run_custom_build() {
+                    } else if unit.target.is_custom_build() {
                         config
                             .shell()
-                            .status("Compiling build script for", unit.pkg)?;
+                            .status("Compiling", format!("{} (build-script)", unit.pkg))?;
                     } else {
                         config.shell().status("Compiling", unit.pkg)?;
                     }

--- a/src/cargo/core/compiler/job_queue.rs
+++ b/src/cargo/core/compiler/job_queue.rs
@@ -934,7 +934,9 @@ impl<'a, 'cfg> DrainState<'a, 'cfg> {
                     if unit.mode.is_check() {
                         config.shell().status("Checking", unit.pkg)?;
                     } else if unit.mode.is_run_custom_build() {
-                        config.shell().status("Compiling build script for", unit.pkg)?;
+                        config
+                            .shell()
+                            .status("Compiling build script for", unit.pkg)?;
                     } else {
                         config.shell().status("Compiling", unit.pkg)?;
                     }

--- a/tests/testsuite/bench.rs
+++ b/tests/testsuite/bench.rs
@@ -1022,7 +1022,7 @@ fn bench_twice_with_build_cmd() {
     p.cargo("bench")
         .with_stderr(
             "\
-[COMPILING] foo v0.0.1 ([CWD])
+[COMPILING] foo v0.0.1 ([CWD]) (build-script)
 [FINISHED] bench [optimized] target(s) in [..]
 [RUNNING] target/release/deps/foo-[..][EXE]",
         )

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -2185,7 +2185,7 @@ fn rebuild_preserves_out_dir() {
     foo.cargo("build")
         .with_stderr(
             "\
-[COMPILING] foo v0.0.0 ([CWD])
+[COMPILING BUILD SCRIPT] foo v0.0.0 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         )

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -2121,7 +2121,7 @@ fn freshness_ignores_excluded() {
     foo.cargo("build")
         .with_stderr(
             "\
-[COMPILING] foo v0.0.0 ([CWD])
+[COMPILING] foo v0.0.0 ([CWD]) (build-script)
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         )
@@ -2175,7 +2175,7 @@ fn rebuild_preserves_out_dir() {
         .env("FIRST", "1")
         .with_stderr(
             "\
-[COMPILING] foo v0.0.0 ([CWD])
+[COMPILING] foo v0.0.0 ([CWD]) (build-script)
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         )
@@ -2185,7 +2185,7 @@ fn rebuild_preserves_out_dir() {
     foo.cargo("build")
         .with_stderr(
             "\
-[COMPILING BUILD SCRIPT] foo v0.0.0 ([CWD])
+[COMPILING] foo v0.0.0 ([CWD]) (build-script)
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         )

--- a/tests/testsuite/build_script.rs
+++ b/tests/testsuite/build_script.rs
@@ -33,7 +33,7 @@ fn custom_build_script_failed() {
         .with_status(101)
         .with_stderr(
             "\
-[COMPILING] foo v0.5.0 ([CWD])
+[COMPILING] foo v0.5.0 ([CWD]) (build-script)
 [RUNNING] `rustc --crate-name build_script_build build.rs [..]--crate-type bin [..]`
 [RUNNING] `[..]/build-script-build`
 [ERROR] failed to run custom build command for `foo v0.5.0 ([CWD])`
@@ -702,7 +702,7 @@ fn only_rerun_build_script() {
     p.cargo("build -v")
         .with_stderr(
             "\
-[COMPILING BUILD SCRIPT] foo v0.5.0 ([CWD])
+[COMPILING] foo v0.5.0 ([CWD]) (build-script)
 [RUNNING] `[..]/build-script-build`
 [RUNNING] `rustc --crate-name foo [..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
@@ -808,7 +808,7 @@ fn testing_and_such() {
     p.cargo("test -vj1")
         .with_stderr(
             "\
-[COMPILING BUILD SCRIPT] foo v0.5.0 ([CWD])
+[COMPILING] foo v0.5.0 ([CWD]) (build-script)
 [RUNNING] `[..]/build-script-build`
 [RUNNING] `rustc --crate-name foo [..]`
 [RUNNING] `rustc --crate-name foo [..]`
@@ -839,7 +839,7 @@ fn testing_and_such() {
     p.cargo("run")
         .with_stderr(
             "\
-[COMPILING BUILD SCRIPT] foo v0.5.0 ([CWD])
+[COMPILING] foo v0.5.0 ([CWD]) (build-script)
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `target/debug/foo[EXE]`
 ",
@@ -1026,7 +1026,7 @@ fn build_deps_simple() {
             "\
 [COMPILING] a v0.5.0 ([CWD]/a)
 [RUNNING] `rustc --crate-name a [..]`
-[COMPILING] foo v0.5.0 ([CWD])
+[COMPILING] foo v0.5.0 ([CWD]) (build-script)
 [RUNNING] `rustc [..] build.rs [..] --extern a=[..]`
 [RUNNING] `[..]/foo-[..]/build-script-build`
 [RUNNING] `rustc --crate-name foo [..]`
@@ -1135,7 +1135,7 @@ fn build_cmd_with_a_build_cmd() {
             "\
 [COMPILING] b v0.5.0 ([CWD]/b)
 [RUNNING] `rustc --crate-name b [..]`
-[COMPILING] a v0.5.0 ([CWD]/a)
+[COMPILING] a v0.5.0 ([CWD]/a) (build-script)
 [RUNNING] `rustc [..] a/build.rs [..] --extern b=[..]`
 [RUNNING] `[..]/a-[..]/build-script-build`
 [RUNNING] `rustc --crate-name a [..]lib.rs [..]--crate-type lib \
@@ -1143,7 +1143,7 @@ fn build_cmd_with_a_build_cmd() {
     -C metadata=[..] \
     --out-dir [..]target/debug/deps \
     -L [..]target/debug/deps`
-[COMPILING] foo v0.5.0 ([CWD])
+[COMPILING] foo v0.5.0 ([CWD]) (build-script)
 [RUNNING] `rustc --crate-name build_script_build build.rs [..]--crate-type bin \
     --emit=[..]link \
     -C debuginfo=2 -C metadata=[..] --out-dir [..] \
@@ -1246,7 +1246,7 @@ fn output_separate_lines() {
         .with_status(101)
         .with_stderr_contains(
             "\
-[COMPILING] foo v0.5.0 ([CWD])
+[COMPILING] foo v0.5.0 ([CWD]) (build-script)
 [RUNNING] `rustc [..] build.rs [..]`
 [RUNNING] `[..]/foo-[..]/build-script-build`
 [RUNNING] `rustc --crate-name foo [..] -L foo -l static=foo`
@@ -1284,7 +1284,7 @@ fn output_separate_lines_new() {
         .with_status(101)
         .with_stderr_contains(
             "\
-[COMPILING] foo v0.5.0 ([CWD])
+[COMPILING] foo v0.5.0 ([CWD]) (build-script)
 [RUNNING] `rustc [..] build.rs [..]`
 [RUNNING] `[..]/foo-[..]/build-script-build`
 [RUNNING] `rustc --crate-name foo [..] -L foo -l static=foo`
@@ -1342,7 +1342,7 @@ fn code_generation() {
     p.cargo("run")
         .with_stderr(
             "\
-[COMPILING] foo v0.5.0 ([CWD])
+[COMPILING] foo v0.5.0 ([CWD]) (build-script)
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `target/debug/foo`",
         )
@@ -1903,7 +1903,7 @@ fn cfg_test() {
     p.cargo("test -v")
         .with_stderr(
             "\
-[COMPILING] foo v0.0.1 ([CWD])
+[COMPILING] foo v0.0.1 ([CWD]) (build-script)
 [RUNNING] [..] build.rs [..]
 [RUNNING] `[..]/build-script-build`
 [RUNNING] [..] --cfg foo[..]
@@ -2016,7 +2016,7 @@ fn cfg_override_test() {
     p.cargo("test -v")
         .with_stderr(
             "\
-[COMPILING BUILD SCRIPT] foo v0.0.1 ([CWD])
+[COMPILING] foo v0.0.1 ([CWD]) (build-script)
 [RUNNING] `[..]`
 [RUNNING] `[..]`
 [RUNNING] `[..]`
@@ -2150,7 +2150,7 @@ fn env_test() {
     p.cargo("test -v")
         .with_stderr(
             "\
-[COMPILING] foo v0.0.1 ([CWD])
+[COMPILING] foo v0.0.1 ([CWD]) (build-script)
 [RUNNING] [..] build.rs [..]
 [RUNNING] `[..]/build-script-build`
 [RUNNING] [..] --crate-name foo[..]
@@ -2415,7 +2415,7 @@ fn adding_an_override_invalidates() {
     p.cargo("build -v")
         .with_stderr(
             "\
-[COMPILING BUILD SCRIPT] foo v0.5.0 ([..]
+[COMPILING] foo v0.5.0 ([..] (build-script)
 [RUNNING] `rustc [..] -L native=bar`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
@@ -2455,7 +2455,7 @@ fn changing_an_override_invalidates() {
     p.cargo("build -v")
         .with_stderr(
             "\
-[COMPILING BUILD SCRIPT] foo v0.5.0 ([..]
+[COMPILING] foo v0.5.0 ([..]) (build-script)
 [RUNNING] `rustc [..] -L native=foo`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
@@ -2479,7 +2479,7 @@ fn changing_an_override_invalidates() {
     p.cargo("build -v")
         .with_stderr(
             "\
-[COMPILING BUILD SCRIPT] foo v0.5.0 ([..]
+[COMPILING] foo v0.5.0 ([..]
 [RUNNING] `rustc [..] -L native=bar`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
@@ -2522,7 +2522,7 @@ fn fresh_builds_possible_with_link_libs() {
     p.cargo("build -v")
         .with_stderr(
             "\
-[COMPILING BUILD SCRIPT] foo v0.5.0 ([..]
+[COMPILING] foo v0.5.0 ([..]) (build-script)
 [RUNNING] `rustc [..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
@@ -2576,7 +2576,7 @@ fn fresh_builds_possible_with_multiple_metadata_overrides() {
     p.cargo("build -v")
         .with_stderr(
             "\
-[COMPILING BUILD SCRIPT] foo v0.5.0 ([..]
+[COMPILING] foo v0.5.0 ([..]) (build-script)
 [RUNNING] `rustc [..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
@@ -2626,7 +2626,7 @@ fn rebuild_only_on_explicit_paths() {
     p.cargo("build -v")
         .with_stderr(
             "\
-[COMPILING BUILD SCRIPT] foo v0.5.0 ([..])
+[COMPILING] foo v0.5.0 ([..]) (build-script)
 [RUNNING] `[..]/build-script-build`
 [RUNNING] `rustc [..] src/lib.rs [..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
@@ -2644,7 +2644,7 @@ fn rebuild_only_on_explicit_paths() {
     p.cargo("build -v")
         .with_stderr(
             "\
-[COMPILING BUILD SCRIPT] foo v0.5.0 ([..])
+[COMPILING] foo v0.5.0 ([..]) (build-script)
 [RUNNING] `[..]/build-script-build`
 [RUNNING] `rustc [..] src/lib.rs [..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
@@ -2682,7 +2682,7 @@ fn rebuild_only_on_explicit_paths() {
     p.cargo("build -v")
         .with_stderr(
             "\
-[COMPILING BUILD SCRIPT] foo v0.5.0 ([..])
+[COMPILING] foo v0.5.0 ([..]) (build-script)
 [RUNNING] `[..]/build-script-build`
 [RUNNING] `rustc [..] src/lib.rs [..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
@@ -2696,7 +2696,7 @@ fn rebuild_only_on_explicit_paths() {
     p.cargo("build -v")
         .with_stderr(
             "\
-[COMPILING BUILD SCRIPT] foo v0.5.0 ([..])
+[COMPILING] foo v0.5.0 ([..]) (build-script)
 [RUNNING] `[..]/build-script-build`
 [RUNNING] `rustc [..] src/lib.rs [..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
@@ -2968,7 +2968,7 @@ fn warnings_emitted() {
     p.cargo("build -v")
         .with_stderr(
             "\
-[COMPILING] foo v0.5.0 ([..])
+[COMPILING] foo v0.5.0 ([..]) (build-script)
 [RUNNING] `rustc [..]`
 [RUNNING] `[..]`
 warning: foo
@@ -3060,7 +3060,7 @@ fn warnings_hidden_for_upstream() {
 [UPDATING] `[..]` index
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.1.0 ([..])
-[COMPILING] bar v0.1.0
+[COMPILING] bar v0.1.0 (build-script)
 [RUNNING] `rustc [..]`
 [RUNNING] `[..]`
 [RUNNING] `rustc [..]`
@@ -3119,7 +3119,7 @@ fn warnings_printed_on_vv() {
 [UPDATING] `[..]` index
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.1.0 ([..])
-[COMPILING] bar v0.1.0
+[COMPILING] bar v0.1.0 (build-script)
 [RUNNING] `[..] rustc [..]`
 [RUNNING] `[..]`
 warning: foo
@@ -3164,7 +3164,7 @@ fn output_shows_on_vv() {
         .with_stdout("[foo 0.5.0] stdout")
         .with_stderr(
             "\
-[COMPILING] foo v0.5.0 ([..])
+[COMPILING] foo v0.5.0 ([..]) (build-script)
 [RUNNING] `[..] rustc [..]`
 [RUNNING] `[..]`
 [foo 0.5.0] stderr
@@ -3838,7 +3838,7 @@ fn optional_build_dep_and_required_normal_dep() {
         .with_stderr(
             "\
 [COMPILING] bar v0.5.0 ([..])
-[COMPILING] foo v0.1.0 ([..])
+[COMPILING] foo v0.1.0 ([..]) (build-script)
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `[..]foo[EXE]`",
         )
@@ -3848,7 +3848,7 @@ fn optional_build_dep_and_required_normal_dep() {
         .with_stdout("1")
         .with_stderr(
             "\
-[COMPILING] foo v0.1.0 ([..])
+[COMPILING] foo v0.1.0 ([..]) (build-script)
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `[..]foo[EXE]`",
         )

--- a/tests/testsuite/build_script.rs
+++ b/tests/testsuite/build_script.rs
@@ -702,7 +702,7 @@ fn only_rerun_build_script() {
     p.cargo("build -v")
         .with_stderr(
             "\
-[COMPILING] foo v0.5.0 ([CWD])
+[COMPILING BUILD SCRIPT] foo v0.5.0 ([CWD])
 [RUNNING] `[..]/build-script-build`
 [RUNNING] `rustc --crate-name foo [..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
@@ -808,7 +808,7 @@ fn testing_and_such() {
     p.cargo("test -vj1")
         .with_stderr(
             "\
-[COMPILING] foo v0.5.0 ([CWD])
+[COMPILING BUILD SCRIPT] foo v0.5.0 ([CWD])
 [RUNNING] `[..]/build-script-build`
 [RUNNING] `rustc --crate-name foo [..]`
 [RUNNING] `rustc --crate-name foo [..]`
@@ -839,7 +839,7 @@ fn testing_and_such() {
     p.cargo("run")
         .with_stderr(
             "\
-[COMPILING] foo v0.5.0 ([CWD])
+[COMPILING BUILD SCRIPT] foo v0.5.0 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `target/debug/foo[EXE]`
 ",
@@ -2016,7 +2016,7 @@ fn cfg_override_test() {
     p.cargo("test -v")
         .with_stderr(
             "\
-[COMPILING] foo v0.0.1 ([CWD])
+[COMPILING BUILD SCRIPT] foo v0.0.1 ([CWD])
 [RUNNING] `[..]`
 [RUNNING] `[..]`
 [RUNNING] `[..]`
@@ -2415,7 +2415,7 @@ fn adding_an_override_invalidates() {
     p.cargo("build -v")
         .with_stderr(
             "\
-[COMPILING] foo v0.5.0 ([..]
+[COMPILING BUILD SCRIPT] foo v0.5.0 ([..]
 [RUNNING] `rustc [..] -L native=bar`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
@@ -2455,7 +2455,7 @@ fn changing_an_override_invalidates() {
     p.cargo("build -v")
         .with_stderr(
             "\
-[COMPILING] foo v0.5.0 ([..]
+[COMPILING BUILD SCRIPT] foo v0.5.0 ([..]
 [RUNNING] `rustc [..] -L native=foo`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
@@ -2479,7 +2479,7 @@ fn changing_an_override_invalidates() {
     p.cargo("build -v")
         .with_stderr(
             "\
-[COMPILING] foo v0.5.0 ([..]
+[COMPILING BUILD SCRIPT] foo v0.5.0 ([..]
 [RUNNING] `rustc [..] -L native=bar`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
@@ -2522,7 +2522,7 @@ fn fresh_builds_possible_with_link_libs() {
     p.cargo("build -v")
         .with_stderr(
             "\
-[COMPILING] foo v0.5.0 ([..]
+[COMPILING BUILD SCRIPT] foo v0.5.0 ([..]
 [RUNNING] `rustc [..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
@@ -2576,7 +2576,7 @@ fn fresh_builds_possible_with_multiple_metadata_overrides() {
     p.cargo("build -v")
         .with_stderr(
             "\
-[COMPILING] foo v0.5.0 ([..]
+[COMPILING BUILD SCRIPT] foo v0.5.0 ([..]
 [RUNNING] `rustc [..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
@@ -2626,7 +2626,7 @@ fn rebuild_only_on_explicit_paths() {
     p.cargo("build -v")
         .with_stderr(
             "\
-[COMPILING] foo v0.5.0 ([..])
+[COMPILING BUILD SCRIPT] foo v0.5.0 ([..])
 [RUNNING] `[..]/build-script-build`
 [RUNNING] `rustc [..] src/lib.rs [..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
@@ -2644,7 +2644,7 @@ fn rebuild_only_on_explicit_paths() {
     p.cargo("build -v")
         .with_stderr(
             "\
-[COMPILING] foo v0.5.0 ([..])
+[COMPILING BUILD SCRIPT] foo v0.5.0 ([..])
 [RUNNING] `[..]/build-script-build`
 [RUNNING] `rustc [..] src/lib.rs [..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
@@ -2682,7 +2682,7 @@ fn rebuild_only_on_explicit_paths() {
     p.cargo("build -v")
         .with_stderr(
             "\
-[COMPILING] foo v0.5.0 ([..])
+[COMPILING BUILD SCRIPT] foo v0.5.0 ([..])
 [RUNNING] `[..]/build-script-build`
 [RUNNING] `rustc [..] src/lib.rs [..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
@@ -2696,7 +2696,7 @@ fn rebuild_only_on_explicit_paths() {
     p.cargo("build -v")
         .with_stderr(
             "\
-[COMPILING] foo v0.5.0 ([..])
+[COMPILING BUILD SCRIPT] foo v0.5.0 ([..])
 [RUNNING] `[..]/build-script-build`
 [RUNNING] `rustc [..] src/lib.rs [..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]

--- a/tests/testsuite/build_script_env.rs
+++ b/tests/testsuite/build_script_env.rs
@@ -22,7 +22,7 @@ fn rerun_if_env_changes() {
     p.cargo("build")
         .with_stderr(
             "\
-[COMPILING] foo v0.0.1 ([..])
+[COMPILING] foo v0.0.1 ([..]) (build-script)
 [FINISHED] [..]
 ",
         )
@@ -31,7 +31,7 @@ fn rerun_if_env_changes() {
         .env("FOO", "bar")
         .with_stderr(
             "\
-[COMPILING BUILD SCRIPT] foo v0.0.1 ([..])
+[COMPILING] foo v0.0.1 ([..]) (build-script)
 [FINISHED] [..]
 ",
         )
@@ -40,7 +40,7 @@ fn rerun_if_env_changes() {
         .env("FOO", "baz")
         .with_stderr(
             "\
-[COMPILING BUILD SCRIPT] foo v0.0.1 ([..])
+[COMPILING] foo v0.0.1 ([..]) (build-script)
 [FINISHED] [..]
 ",
         )
@@ -52,7 +52,7 @@ fn rerun_if_env_changes() {
     p.cargo("build")
         .with_stderr(
             "\
-[COMPILING BUILD SCRIPT] foo v0.0.1 ([..])
+[COMPILING] foo v0.0.1 ([..]) (build-script)
 [FINISHED] [..]
 ",
         )
@@ -78,7 +78,7 @@ fn rerun_if_env_or_file_changes() {
     p.cargo("build")
         .with_stderr(
             "\
-[COMPILING] foo v0.0.1 ([..])
+[COMPILING] foo v0.0.1 ([..]) (build-script)
 [FINISHED] [..]
 ",
         )
@@ -87,7 +87,7 @@ fn rerun_if_env_or_file_changes() {
         .env("FOO", "bar")
         .with_stderr(
             "\
-[COMPILING BUILD SCRIPT] foo v0.0.1 ([..])
+[COMPILING] foo v0.0.1 ([..]) (build-script)
 [FINISHED] [..]
 ",
         )
@@ -102,7 +102,7 @@ fn rerun_if_env_or_file_changes() {
         .env("FOO", "bar")
         .with_stderr(
             "\
-[COMPILING BUILD SCRIPT] foo v0.0.1 ([..])
+[COMPILING] foo v0.0.1 ([..]) (build-script)
 [FINISHED] [..]
 ",
         )

--- a/tests/testsuite/build_script_env.rs
+++ b/tests/testsuite/build_script_env.rs
@@ -31,7 +31,7 @@ fn rerun_if_env_changes() {
         .env("FOO", "bar")
         .with_stderr(
             "\
-[COMPILING] foo v0.0.1 ([..])
+[COMPILING BUILD SCRIPT] foo v0.0.1 ([..])
 [FINISHED] [..]
 ",
         )
@@ -40,7 +40,7 @@ fn rerun_if_env_changes() {
         .env("FOO", "baz")
         .with_stderr(
             "\
-[COMPILING] foo v0.0.1 ([..])
+[COMPILING BUILD SCRIPT] foo v0.0.1 ([..])
 [FINISHED] [..]
 ",
         )
@@ -52,7 +52,7 @@ fn rerun_if_env_changes() {
     p.cargo("build")
         .with_stderr(
             "\
-[COMPILING] foo v0.0.1 ([..])
+[COMPILING BUILD SCRIPT] foo v0.0.1 ([..])
 [FINISHED] [..]
 ",
         )
@@ -87,7 +87,7 @@ fn rerun_if_env_or_file_changes() {
         .env("FOO", "bar")
         .with_stderr(
             "\
-[COMPILING] foo v0.0.1 ([..])
+[COMPILING BUILD SCRIPT] foo v0.0.1 ([..])
 [FINISHED] [..]
 ",
         )
@@ -102,7 +102,7 @@ fn rerun_if_env_or_file_changes() {
         .env("FOO", "bar")
         .with_stderr(
             "\
-[COMPILING] foo v0.0.1 ([..])
+[COMPILING BUILD SCRIPT] foo v0.0.1 ([..])
 [FINISHED] [..]
 ",
         )

--- a/tests/testsuite/clean.rs
+++ b/tests/testsuite/clean.rs
@@ -198,7 +198,7 @@ fn build_script() {
     p.cargo("build -v")
         .with_stderr(
             "\
-[COMPILING] foo v0.0.1 ([..])
+[COMPILING] foo v0.0.1 ([..]) (build-script)
 [RUNNING] `rustc [..] build.rs [..]`
 [RUNNING] `[..]build-script-build`
 [RUNNING] `rustc [..] src/main.rs [..]`

--- a/tests/testsuite/cross_compile.rs
+++ b/tests/testsuite/cross_compile.rs
@@ -513,7 +513,7 @@ fn cross_with_a_build_script() {
         .arg(&target)
         .with_stderr(&format!(
             "\
-[COMPILING] foo v0.0.0 ([CWD])
+[COMPILING] foo v0.0.0 ([CWD]) (build-script)
 [RUNNING] `rustc [..] build.rs [..] --out-dir [CWD]/target/debug/build/foo-[..]`
 [RUNNING] `[CWD]/target/debug/build/foo-[..]/build-script-build`
 [RUNNING] `rustc [..] src/main.rs [..] --target {target} [..]`
@@ -609,7 +609,7 @@ fn build_script_needed_for_host_and_target() {
 
     p.cargo("build -v --target")
         .arg(&target)
-        .with_stderr_contains(&"[COMPILING] d1 v0.0.0 ([CWD]/d1)")
+        .with_stderr_contains(&"[COMPILING] d1 v0.0.0 ([CWD]/d1) (build-script)")
         .with_stderr_contains(
             "[RUNNING] `rustc [..] d1/build.rs [..] --out-dir [CWD]/target/debug/build/d1-[..]`",
         )
@@ -620,7 +620,7 @@ fn build_script_needed_for_host_and_target() {
             "[RUNNING] `rustc [..] d2/src/lib.rs [..] -L /path/to/{host}`",
             host = host
         ))
-        .with_stderr_contains("[COMPILING] foo v0.0.0 ([CWD])")
+        .with_stderr_contains("[COMPILING] foo v0.0.0 ([CWD]) (build-script)")
         .with_stderr_contains(&format!(
             "[RUNNING] `rustc [..] build.rs [..] --out-dir [CWD]/target/debug/build/foo-[..] \
              -L /path/to/{host}`",
@@ -756,7 +756,7 @@ fn plugin_build_script_right_arch() {
         .arg(cross_compile::alternate())
         .with_stderr(
             "\
-[COMPILING] foo v0.0.1 ([..])
+[COMPILING] foo v0.0.1 ([..]) (build-script)
 [RUNNING] `rustc [..] build.rs [..]`
 [RUNNING] `[..]/build-script-build`
 [RUNNING] `rustc [..] src/lib.rs [..]`
@@ -828,7 +828,7 @@ fn build_script_with_platform_specific_dependencies() {
 [RUNNING] `rustc [..] d2/src/lib.rs [..]`
 [COMPILING] d1 v0.0.0 ([..])
 [RUNNING] `rustc [..] d1/src/lib.rs [..]`
-[COMPILING] foo v0.0.1 ([..])
+[COMPILING] foo v0.0.1 ([..]) (build-script)
 [RUNNING] `rustc [..] build.rs [..]`
 [RUNNING] `[CWD]/target/debug/build/foo-[..]/build-script-build`
 [RUNNING] `rustc [..] src/lib.rs [..] --target {target} [..]`

--- a/tests/testsuite/doc.rs
+++ b/tests/testsuite/doc.rs
@@ -29,7 +29,7 @@ fn simple() {
     p.cargo("doc")
         .with_stderr(
             "\
-[..] foo v0.0.1 ([CWD])
+[..] foo v0.0.1 ([CWD]) (build-script)
 [..] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",

--- a/tests/testsuite/fix.rs
+++ b/tests/testsuite/fix.rs
@@ -632,7 +632,7 @@ fn fixes_missing_ampersand() {
     p.cargo("fix --all-targets --allow-no-vcs")
         .env("__CARGO_FIX_YOLO", "1")
         .with_stdout("")
-        .with_stderr_contains("[COMPILING] foo v0.0.1 ([..])")
+        .with_stderr_contains("[COMPILING] foo v0.0.1 ([..]) (build-script)")
         .with_stderr_contains("[FIXING] build.rs (1 fix)")
         // Don't assert number of fixes for this one, as we don't know if we're
         // fixing it once or twice! We run this all concurrently, and if we

--- a/tests/testsuite/freshness.rs
+++ b/tests/testsuite/freshness.rs
@@ -1873,7 +1873,7 @@ fn simulated_docker_deps_stay_cached() {
 [FRESH] regdep_env [..]
 [FRESH] regdep_old_style [..]
 [FRESH] regdep_rerun [..]
-[COMPILING BUILD SCRIPT] foo [..]
+[COMPILING] foo [..] (build-script)
 [RUNNING] [..]/foo-[..]/build-script-build[..]
 [RUNNING] `rustc --crate-name foo[..]
 [FINISHED] [..]
@@ -2104,7 +2104,7 @@ fn rerun_if_changes() {
         .env("FOO", "1")
         .with_stderr(
             "\
-[COMPILING BUILD SCRIPT] foo [..]
+[COMPILING] foo [..] (build-script)
 [RUNNING] `[..]build-script-build`
 [RUNNING] `rustc [..]
 [FINISHED] [..]
@@ -2121,7 +2121,7 @@ fn rerun_if_changes() {
         .env("BAR", "1")
         .with_stderr(
             "\
-[COMPILING BUILD SCRIPT] foo [..]
+[COMPILING] foo [..]
 [RUNNING] `[..]build-script-build`
 [RUNNING] `rustc [..]
 [FINISHED] [..]
@@ -2138,7 +2138,7 @@ fn rerun_if_changes() {
         .env("BAR", "2")
         .with_stderr(
             "\
-[COMPILING BUILD SCRIPT] foo [..]
+[COMPILING] foo [..]
 [RUNNING] `[..]build-script-build`
 [RUNNING] `rustc [..]
 [FINISHED] [..]

--- a/tests/testsuite/freshness.rs
+++ b/tests/testsuite/freshness.rs
@@ -1873,7 +1873,7 @@ fn simulated_docker_deps_stay_cached() {
 [FRESH] regdep_env [..]
 [FRESH] regdep_old_style [..]
 [FRESH] regdep_rerun [..]
-[COMPILING] foo [..]
+[COMPILING BUILD SCRIPT] foo [..]
 [RUNNING] [..]/foo-[..]/build-script-build[..]
 [RUNNING] `rustc --crate-name foo[..]
 [FINISHED] [..]
@@ -2104,7 +2104,7 @@ fn rerun_if_changes() {
         .env("FOO", "1")
         .with_stderr(
             "\
-[COMPILING] foo [..]
+[COMPILING BUILD SCRIPT] foo [..]
 [RUNNING] `[..]build-script-build`
 [RUNNING] `rustc [..]
 [FINISHED] [..]
@@ -2121,7 +2121,7 @@ fn rerun_if_changes() {
         .env("BAR", "1")
         .with_stderr(
             "\
-[COMPILING] foo [..]
+[COMPILING BUILD SCRIPT] foo [..]
 [RUNNING] `[..]build-script-build`
 [RUNNING] `rustc [..]
 [FINISHED] [..]
@@ -2138,7 +2138,7 @@ fn rerun_if_changes() {
         .env("BAR", "2")
         .with_stderr(
             "\
-[COMPILING] foo [..]
+[COMPILING BUILD SCRIPT] foo [..]
 [RUNNING] `[..]build-script-build`
 [RUNNING] `rustc [..]
 [FINISHED] [..]

--- a/tests/testsuite/git.rs
+++ b/tests/testsuite/git.rs
@@ -2319,7 +2319,7 @@ fn include_overrides_gitignore() {
     p.cargo("build -v")
         .with_stderr(
             "\
-[COMPILING] foo v0.5.0 ([..])
+[COMPILING BUILD SCRIPT] foo v0.5.0 ([..])
 [RUNNING] `[..]build-script-build[..]`
 [RUNNING] `rustc --crate-name foo src/lib.rs [..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]

--- a/tests/testsuite/git.rs
+++ b/tests/testsuite/git.rs
@@ -1349,7 +1349,7 @@ fn git_build_cmd_freshness() {
     foo.cargo("build")
         .with_stderr(
             "\
-[COMPILING] foo v0.0.0 ([CWD])
+[COMPILING] foo v0.0.0 ([CWD]) (build-script)
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         )
@@ -2319,7 +2319,7 @@ fn include_overrides_gitignore() {
     p.cargo("build -v")
         .with_stderr(
             "\
-[COMPILING BUILD SCRIPT] foo v0.5.0 ([..])
+[COMPILING] foo v0.5.0 ([..]) (build-script)
 [RUNNING] `[..]build-script-build[..]`
 [RUNNING] `rustc --crate-name foo src/lib.rs [..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]

--- a/tests/testsuite/path.rs
+++ b/tests/testsuite/path.rs
@@ -734,7 +734,7 @@ fn path_dep_build_cmd() {
 
     p.cargo("build")
         .with_stderr(
-            "[COMPILING] bar v0.5.0 ([CWD]/bar)\n\
+            "[COMPILING BUILD SCRIPT] bar v0.5.0 ([CWD]/bar)\n\
              [COMPILING] foo v0.5.0 ([CWD])\n\
              [FINISHED] dev [unoptimized + debuginfo] target(s) in \
              [..]\n",

--- a/tests/testsuite/path.rs
+++ b/tests/testsuite/path.rs
@@ -713,7 +713,7 @@ fn path_dep_build_cmd() {
 
     p.cargo("build")
         .with_stderr(
-            "[COMPILING] bar v0.5.0 ([CWD]/bar)\n\
+            "[COMPILING] bar v0.5.0 ([CWD]/bar) (build-script)\n\
              [COMPILING] foo v0.5.0 ([CWD])\n\
              [FINISHED] dev [unoptimized + debuginfo] target(s) in \
              [..]\n",
@@ -734,7 +734,7 @@ fn path_dep_build_cmd() {
 
     p.cargo("build")
         .with_stderr(
-            "[COMPILING BUILD SCRIPT] bar v0.5.0 ([CWD]/bar)\n\
+            "[COMPILING] bar v0.5.0 ([CWD]/bar) (build-script)\n\
              [COMPILING] foo v0.5.0 ([CWD])\n\
              [FINISHED] dev [unoptimized + debuginfo] target(s) in \
              [..]\n",

--- a/tests/testsuite/test.rs
+++ b/tests/testsuite/test.rs
@@ -1225,7 +1225,7 @@ fn test_twice_with_build_cmd() {
     p.cargo("test")
         .with_stderr(
             "\
-[COMPILING] foo v0.0.1 ([CWD])
+[COMPILING] foo v0.0.1 ([CWD]) (build-script)
 [FINISHED] test [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target/debug/deps/foo-[..][EXE]
 [DOCTEST] foo",

--- a/tests/testsuite/warn_on_failure.rs
+++ b/tests/testsuite/warn_on_failure.rs
@@ -66,7 +66,7 @@ fn no_warning_on_success() {
 [UPDATING] `[..]` index
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.0.1 ([..])
-[COMPILING] bar v0.0.1
+[COMPILING] bar v0.0.1 (build-script)
 [COMPILING] foo v0.0.1 ([..])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
@@ -87,7 +87,7 @@ fn no_warning_on_bin_failure() {
         .with_stderr_does_not_contain(&format!("[WARNING] {}", WARNING2))
         .with_stderr_contains("[UPDATING] `[..]` index")
         .with_stderr_contains("[DOWNLOADED] bar v0.0.1 ([..])")
-        .with_stderr_contains("[COMPILING] bar v0.0.1")
+        .with_stderr_contains("[COMPILING] bar v0.0.1 (build-script)")
         .with_stderr_contains("[COMPILING] foo v0.0.1 ([..])")
         .run();
 }
@@ -104,7 +104,7 @@ fn warning_on_lib_failure() {
         .with_stderr_does_not_contain("[COMPILING] foo v0.0.1 ([..])")
         .with_stderr_contains("[UPDATING] `[..]` index")
         .with_stderr_contains("[DOWNLOADED] bar v0.0.1 ([..])")
-        .with_stderr_contains("[COMPILING] bar v0.0.1")
+        .with_stderr_contains("[COMPILING] bar v0.0.1 (build-script)")
         .with_stderr_contains(&format!("[WARNING] {}", WARNING1))
         .with_stderr_contains(&format!("[WARNING] {}", WARNING2))
         .run();


### PR DESCRIPTION
Fixes #7921.

Even though unit tests passed. I would like some guidance on why for the same project, some times the build script is compiled but not in others.

One example:
In the `rebuild_preserves_out_dir` test, ln 2178 does not compile the build script but line 2188 does.

Another example:
In the `path_dep_build_cmd` test, ln 716 does not compile the build script but ln 737 does.