### PR TITLE
Fix bug with -Zfeatures=dev_dep and `check --profile=test`.

### DIFF
--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -608,16 +608,18 @@ impl CompileFilter {
     pub fn need_dev_deps(&self, mode: CompileMode) -> bool {
         match mode {
             CompileMode::Test | CompileMode::Doctest | CompileMode::Bench => true,
-            CompileMode::Build | CompileMode::Doc { .. } | CompileMode::Check { .. } => match *self
-            {
-                CompileFilter::Default { .. } => false,
-                CompileFilter::Only {
-                    ref examples,
-                    ref tests,
-                    ref benches,
-                    ..
-                } => examples.is_specific() || tests.is_specific() || benches.is_specific(),
-            },
+            CompileMode::Check { test: true } => true,
+            CompileMode::Build | CompileMode::Doc { .. } | CompileMode::Check { test: false } => {
+                match *self {
+                    CompileFilter::Default { .. } => false,
+                    CompileFilter::Only {
+                        ref examples,
+                        ref tests,
+                        ref benches,
+                        ..
+                    } => examples.is_specific() || tests.is_specific() || benches.is_specific(),
+                }
+            }
             CompileMode::RunCustomBuild => panic!("Invalid mode"),
         }
     }


### PR DESCRIPTION
`-Zfeatures=dev_dep` with `cargo check --profile=test` would crash because the check of whether or not dev dependencies are needed erroneously ignored the "test" flag of `CompileMode::Check`.  The feature resolver needs to correctly know whether or not dev-dependencies are needed.
