### PR TITLE
cargo new: create README in bin crates

### DIFF
--- a/src/cargo/ops/cargo_new.rs
+++ b/src/cargo/ops/cargo_new.rs
@@ -724,7 +724,7 @@ edition = {}
             &path.join("README.md"),
             format!(
                 r#"TODO: add a description of this crate's purpose
-    cargo install [{}]
+cargo install [{}]
         "#,
                 name,
             )

--- a/src/cargo/ops/cargo_new.rs
+++ b/src/cargo/ops/cargo_new.rs
@@ -716,6 +716,22 @@ edition = {}
         .as_bytes(),
     )?;
 
+    // Create README for binary crates
+    // Eventually, we will do something similar for library and workspace crates
+
+    if opts.bin {
+        paths::write(
+            &path.join("README.md"),
+            format!(
+                r#"TODO: add a description of this crate's purpose
+    cargo install [{}]
+        "#,
+                name,
+            )
+            .as_bytes(),
+        )?;
+    }
+
     // Create all specified source files (with respective parent directories) if they don't exist.
 
     for i in &opts.source_files {

--- a/tests/testsuite/new.rs
+++ b/tests/testsuite/new.rs
@@ -25,6 +25,7 @@ fn simple_lib() {
     assert!(paths::root().join("foo/Cargo.toml").is_file());
     assert!(paths::root().join("foo/src/lib.rs").is_file());
     assert!(!paths::root().join("foo/.gitignore").is_file());
+    assert!(!paths::root().join("foo/README.md").is_file());
 
     let lib = paths::root().join("foo/src/lib.rs");
     let mut contents = String::new();
@@ -57,6 +58,7 @@ fn simple_bin() {
     assert!(paths::root().join("foo").is_dir());
     assert!(paths::root().join("foo/Cargo.toml").is_file());
     assert!(paths::root().join("foo/src/main.rs").is_file());
+    assert!(paths::root().join("foo/README.md").is_file());
 
     cargo_process("build").cwd(&paths::root().join("foo")).run();
     assert!(paths::root()
@@ -84,6 +86,7 @@ fn simple_git() {
     assert!(paths::root().join("foo/src/lib.rs").is_file());
     assert!(paths::root().join("foo/.git").is_dir());
     assert!(paths::root().join("foo/.gitignore").is_file());
+    assert!(!paths::root().join("foo/README.md").is_file());
 
     let fp = paths::root().join("foo/.gitignore");
     let mut contents = String::new();


### PR DESCRIPTION
This PR completes some of the work for #3506. 

## Changes
- create `README` for new binary crates as part of `cargo new` 
- adjust tests in `cargo_new` to check/!check for `README`

## Screenshots
Example of new change to `cargo new`:
creates a `README.md` for a new binary crate
![screen recording showing a new README being created when running cargo new](https://user-images.githubusercontent.com/3806031/77264313-53141100-6c57-11ea-9c1f-0e578435b0ef.gif)

Passing tests:
<img width="704" alt="image" src="https://user-images.githubusercontent.com/3806031/77263278-370f7000-6c55-11ea-81fd-81c0303147da.png">

Failing test (safe to ignore):
<img width="674" alt="image" src="https://user-images.githubusercontent.com/3806031/77263231-219a4600-6c55-11ea-915f-757181a0b6d2.png">

## Checklist
- [x] tests are passing 
- [x] added new tests

## Additional Notes

Per the original decision noted in [this comment,](https://github.com/rust-lang/cargo/issues/3506#issuecomment-356103731) these were the requirements (this PR accomplishes the ones that are checked):
- For a binary crate:
   - [X] README.md that contains the text TODO: add a description of this crate's purpose and recommends using cargo install [cratename] to install the crate
- For a library crate:
   - [ ] README.md file that contains the text TODO: add a description of this crate's purpose and recommends adding the crate to one's Cargo.toml to use the crate as a dependency
    - [ ] Module-level documentation in src/lib.rs that contains the text TODO: add a description of this crate's purpose
- For a workspace crate (when you run cargo new within a workspace`):
    - [ ] Do not create README.md
    - [ ] Module-level documentation in src/lib.rs that contains the text TODO: add a description of this crate's purpose

> Re: For a workspace crate (when you run cargo new within a workspace`):
    - Do not create README.md

I was able to detect bin vs library crates, but I struggled to do the same for workspace crates. Open to guidance or feedback on how to detect that within the `new` command file. 

Regarding the remaining todos, my thoughts were to accomplish them in separate PRs. 

