### PR TITLE
Allow -Zconfig-profile for rust 1.43.0

### DIFF
--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -406,6 +406,8 @@ impl CliUnstable {
             "package-features" => self.package_features = parse_empty(k, v)?,
             "advanced-env" => self.advanced_env = parse_empty(k, v)?,
             "config-include" => self.config_include = parse_empty(k, v)?,
+            // Keep this around for rust 1.43.0 because its rustbuild still uses it
+            "config-profile" => {}
             "dual-proc-macros" => self.dual_proc_macros = parse_empty(k, v)?,
             // can also be set in .cargo/config or with and ENV
             "mtime-on-use" => self.mtime_on_use = parse_empty(k, v)?,


### PR DESCRIPTION
While -Zconfig-profile doesn't do anything since the stabilisation of this feature, rust 1.43.0 still passes this to cargo, so allow (but ignore) it to allow rust 1.43.0 to build itself.

Fixes https://github.com/rust-lang/rust/issues/69975 once cargo gets updated in the beta branch