### PR TITLE
Implement support for rust-version field in project metadata

### DIFF
--- a/crates/cargo-test-support/Cargo.toml
+++ b/crates/cargo-test-support/Cargo.toml
@@ -19,4 +19,5 @@ lazy_static = "1.0"
 remove_dir_all = "0.5"
 serde_json = "1.0"
 tar = { version = "0.4.18", default-features = false }
+toml = "0.5.7"
 url = "2.0"

--- a/src/bin/cargo/commands/bench.rs
+++ b/src/bin/cargo/commands/bench.rs
@@ -39,6 +39,7 @@ pub fn cli() -> App {
         .arg_target_triple("Build for the target triple")
         .arg_target_dir()
         .arg_manifest_path()
+        .arg_ignore_rust_version()
         .arg_message_format()
         .arg(opt(
             "no-fail-fast",

--- a/src/bin/cargo/commands/build.rs
+++ b/src/bin/cargo/commands/build.rs
@@ -39,6 +39,7 @@ pub fn cli() -> App {
             .value_name("PATH"),
         )
         .arg_manifest_path()
+        .arg_ignore_rust_version()
         .arg_message_format()
         .arg_build_plan()
         .arg_unit_graph()

--- a/src/bin/cargo/commands/check.rs
+++ b/src/bin/cargo/commands/check.rs
@@ -32,6 +32,7 @@ pub fn cli() -> App {
         .arg_target_triple("Check for the target triple")
         .arg_target_dir()
         .arg_manifest_path()
+        .arg_ignore_rust_version()
         .arg_message_format()
         .arg_unit_graph()
         .after_help("Run `cargo help check` for more detailed information.\n")

--- a/src/bin/cargo/commands/doc.rs
+++ b/src/bin/cargo/commands/doc.rs
@@ -30,6 +30,7 @@ pub fn cli() -> App {
         .arg_target_dir()
         .arg_manifest_path()
         .arg_message_format()
+        .arg_ignore_rust_version()
         .arg_unit_graph()
         .after_help("Run `cargo help doc` for more detailed information.\n")
 }

--- a/src/bin/cargo/commands/fix.rs
+++ b/src/bin/cargo/commands/fix.rs
@@ -72,6 +72,7 @@ pub fn cli() -> App {
                 .long("allow-staged")
                 .help("Fix code even if the working directory has staged changes"),
         )
+        .arg_ignore_rust_version()
         .after_help("Run `cargo help fix` for more detailed information.\n")
 }
 

--- a/src/bin/cargo/commands/run.rs
+++ b/src/bin/cargo/commands/run.rs
@@ -26,6 +26,7 @@ pub fn cli() -> App {
         .arg_manifest_path()
         .arg_message_format()
         .arg_unit_graph()
+        .arg_ignore_rust_version()
         .after_help("Run `cargo help run` for more detailed information.\n")
 }
 

--- a/src/bin/cargo/commands/rustc.rs
+++ b/src/bin/cargo/commands/rustc.rs
@@ -30,6 +30,7 @@ pub fn cli() -> App {
         .arg_manifest_path()
         .arg_message_format()
         .arg_unit_graph()
+        .arg_ignore_rust_version()
         .after_help("Run `cargo help rustc` for more detailed information.\n")
 }
 

--- a/src/bin/cargo/commands/rustdoc.rs
+++ b/src/bin/cargo/commands/rustdoc.rs
@@ -34,6 +34,7 @@ pub fn cli() -> App {
         .arg_manifest_path()
         .arg_message_format()
         .arg_unit_graph()
+        .arg_ignore_rust_version()
         .after_help("Run `cargo help rustdoc` for more detailed information.\n")
 }
 

--- a/src/bin/cargo/commands/test.rs
+++ b/src/bin/cargo/commands/test.rs
@@ -53,6 +53,7 @@ pub fn cli() -> App {
         .arg_target_triple("Build for the target triple")
         .arg_target_dir()
         .arg_manifest_path()
+        .arg_ignore_rust_version()
         .arg_message_format()
         .arg_unit_graph()
         .after_help("Run `cargo help test` for more detailed information.\n")

--- a/src/cargo/core/compiler/context/mod.rs
+++ b/src/cargo/core/compiler/context/mod.rs
@@ -130,7 +130,7 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
         self.prepare_units()?;
         self.prepare()?;
         custom_build::build_map(&mut self)?;
-        self.check_collistions()?;
+        self.check_collisions()?;
 
         for unit in &self.bcx.roots {
             // Build up a list of pending jobs, each of which represent
@@ -398,7 +398,7 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
         Ok(inputs.into_iter().collect())
     }
 
-    fn check_collistions(&self) -> CargoResult<()> {
+    fn check_collisions(&self) -> CargoResult<()> {
         let mut output_collisions = HashMap::new();
         let describe_collision = |unit: &Unit, other_unit: &Unit, path: &PathBuf| -> String {
             format!(

--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -70,6 +70,17 @@ pub enum Edition {
     Edition2021,
 }
 
+impl Edition {
+    pub(crate) fn first_version(&self) -> Option<semver::Version> {
+        use Edition::*;
+        match self {
+            Edition2015 => None,
+            Edition2018 => Some(semver::Version::new(1, 31, 0)),
+            Edition2021 => Some(semver::Version::new(1, 62, 0)),
+        }
+    }
+}
+
 impl fmt::Display for Edition {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
@@ -218,6 +229,9 @@ features! {
 
         // Allow to specify whether binaries should be stripped.
         [unstable] strip: bool,
+
+        // Specifying a minimal 'rust-version' attribute for crates
+        [unstable] rust_version: bool,
     }
 }
 

--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -46,6 +46,7 @@ pub struct Manifest {
     original: Rc<TomlManifest>,
     unstable_features: Features,
     edition: Edition,
+    rust_version: Option<String>,
     im_a_teapot: Option<bool>,
     default_run: Option<String>,
     metabuild: Option<Vec<String>>,
@@ -379,6 +380,7 @@ impl Manifest {
         workspace: WorkspaceConfig,
         unstable_features: Features,
         edition: Edition,
+        rust_version: Option<String>,
         im_a_teapot: Option<bool>,
         default_run: Option<String>,
         original: Rc<TomlManifest>,
@@ -401,6 +403,7 @@ impl Manifest {
             workspace,
             unstable_features,
             edition,
+            rust_version,
             original,
             im_a_teapot,
             default_run,
@@ -518,6 +521,10 @@ impl Manifest {
 
     pub fn edition(&self) -> Edition {
         self.edition
+    }
+
+    pub fn rust_version(&self) -> Option<&str> {
+        self.rust_version.as_deref()
     }
 
     pub fn custom_metadata(&self) -> Option<&toml::Value> {

--- a/src/cargo/core/package.rs
+++ b/src/cargo/core/package.rs
@@ -170,6 +170,10 @@ impl Package {
     pub fn proc_macro(&self) -> bool {
         self.targets().iter().any(|target| target.proc_macro())
     }
+    /// Gets the package's minimum Rust version.
+    pub fn rust_version(&self) -> Option<&str> {
+        self.manifest().rust_version()
+    }
 
     /// Returns `true` if the package uses a custom build script for any target.
     pub fn has_custom_build(&self) -> bool {

--- a/src/cargo/ops/cargo_package.rs
+++ b/src/cargo/ops/cargo_package.rs
@@ -701,6 +701,7 @@ fn run_verify(ws: &Workspace<'_>, tar: &FileLock, opts: &PackageOpts<'_>) -> Car
             target_rustc_args: rustc_args,
             local_rustdoc_args: None,
             rustdoc_document_private_items: false,
+            honor_rust_version: true,
         },
         &exec,
     )?;

--- a/src/cargo/util/command_prelude.rs
+++ b/src/cargo/util/command_prelude.rs
@@ -212,6 +212,16 @@ pub trait AppExt: Sized {
     fn arg_dry_run(self, dry_run: &'static str) -> Self {
         self._arg(opt("dry-run", dry_run))
     }
+
+    fn arg_ignore_rust_version(self) -> Self {
+        self._arg(
+            opt(
+                "ignore-rust-version",
+                "Ignore `rust-version` specification in packages",
+            )
+            .hidden(true), // nightly only (`rust-version` feature)
+        )
+    }
 }
 
 impl AppExt for App {
@@ -488,7 +498,14 @@ pub trait ArgMatchesExt {
             target_rustc_args: None,
             local_rustdoc_args: None,
             rustdoc_document_private_items: false,
+            honor_rust_version: !self._is_present("ignore-rust-version"),
         };
+
+        if !opts.honor_rust_version {
+            config
+                .cli_unstable()
+                .fail_if_stable_opt("--ignore-rust-version", 8072)?;
+        }
 
         if let Some(ws) = workspace {
             self.check_optional_opts(ws, &opts)?;

--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -1003,3 +1003,22 @@ cargo logout -Z credential-process`
 [`credentials` file]: config.md#credentials
 [crates.io]: https://crates.io/
 [config file]: config.md
+
+### rust-version
+* RFC: [#2495](https://github.com/rust-lang/rfcs/blob/master/text/2495-min-rust-version.md)
+* rustc Tracking Issue: [#65262](https://github.com/rust-lang/rust/issues/65262)
+
+The `-Z rust-version` flag enables the reading the `rust-version` field in the
+Cargo manifest `package` section. This can be used by a package to state a minimal
+version of the compiler required to build the package. An error is generated if
+the version of rustc is older than the stated `rust-version`. The
+`--ignore-rust-version` flag can be used to override the check.
+
+```toml
+cargo-features = ["rust-version"]
+
+[package]
+name = "mypackage"
+version = "0.0.1"
+rust-version = "1.42"
+```

--- a/tests/testsuite/main.rs
+++ b/tests/testsuite/main.rs
@@ -103,6 +103,7 @@ mod rename_deps;
 mod replace;
 mod required_features;
 mod run;
+mod rust_version;
 mod rustc;
 mod rustc_info_cache;
 mod rustdoc;

--- a/tests/testsuite/rust_version.rs
+++ b/tests/testsuite/rust_version.rs
@@ -1,0 +1,260 @@
+//! Tests for targets with `rust-version`.
+
+use cargo_test_support::{project, registry::Package};
+
+#[cargo_test]
+fn rust_version_gated() {
+    project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                rust-version = "1.17"
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .build()
+        .cargo("build")
+        .masquerade_as_nightly_cargo()
+        .with_stderr_contains(
+            "warning: `rust-version` is not supported on this version of Cargo and will be ignored\
+            \n\nconsider adding `cargo-features = [\"rust-version\"]` to the manifest",
+        )
+        .run();
+
+    project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                rust-version = "1.17"
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .build()
+        .cargo("build")
+        .with_stderr_contains(
+            "warning: `rust-version` is not supported on this version of Cargo and will be ignored\
+            \n\nthis Cargo does not support nightly features, but if you\n\
+            switch to nightly channel you can add\n\
+            `cargo-features = [\"rust-version\"]` to enable this feature",
+        )
+        .run();
+}
+
+#[cargo_test]
+fn rust_version_satisfied() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            cargo-features = ["rust-version"]
+
+            [project]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+            rust-version = "1.1.1"
+            [[bin]]
+            name = "foo"
+        "#,
+        )
+        .file("src/main.rs", "fn main() {}")
+        .build();
+
+    p.cargo("build").masquerade_as_nightly_cargo().run();
+    p.cargo("build --ignore-rust-version -Zunstable-options")
+        .masquerade_as_nightly_cargo()
+        .run();
+}
+
+#[cargo_test]
+fn rust_version_bad_caret() {
+    project()
+        .file(
+            "Cargo.toml",
+            r#"
+            cargo-features = ["rust-version"]
+
+            [project]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+            rust-version = "^1.43"
+            [[bin]]
+            name = "foo"
+        "#,
+        )
+        .file("src/main.rs", "fn main() {}")
+        .build()
+        .cargo("build")
+        .masquerade_as_nightly_cargo()
+        .with_status(101)
+        .with_stderr(
+            "error: failed to parse manifest at `[..]`\n\n\
+             Caused by:\n  `rust-version` must be a value like \"1.32\"",
+        )
+        .run();
+}
+
+#[cargo_test]
+fn rust_version_bad_pre_release() {
+    project()
+        .file(
+            "Cargo.toml",
+            r#"
+            cargo-features = ["rust-version"]
+
+            [project]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+            rust-version = "1.43-beta.1"
+            [[bin]]
+            name = "foo"
+        "#,
+        )
+        .file("src/main.rs", "fn main() {}")
+        .build()
+        .cargo("build")
+        .masquerade_as_nightly_cargo()
+        .with_status(101)
+        .with_stderr(
+            "error: failed to parse manifest at `[..]`\n\n\
+             Caused by:\n  `rust-version` must be a value like \"1.32\"",
+        )
+        .run();
+}
+
+#[cargo_test]
+fn rust_version_bad_nonsense() {
+    project()
+        .file(
+            "Cargo.toml",
+            r#"
+            cargo-features = ["rust-version"]
+
+            [project]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+            rust-version = "foodaddle"
+            [[bin]]
+            name = "foo"
+        "#,
+        )
+        .file("src/main.rs", "fn main() {}")
+        .build()
+        .cargo("build")
+        .masquerade_as_nightly_cargo()
+        .with_status(101)
+        .with_stderr(
+            "error: failed to parse manifest at `[..]`\n\n\
+             Caused by:\n  `rust-version` must be a value like \"1.32\"",
+        )
+        .run();
+}
+
+#[cargo_test]
+fn rust_version_too_high() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            cargo-features = ["rust-version"]
+
+            [project]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+            rust-version = "1.9876.0"
+            [[bin]]
+            name = "foo"
+        "#,
+        )
+        .file("src/main.rs", "fn main() {}")
+        .build();
+
+    p.cargo("build")
+        .masquerade_as_nightly_cargo()
+        .with_status(101)
+        .with_stderr(
+            "error: package `foo v0.0.1 ([..])` cannot be built because it requires \
+             rustc 1.9876.0 or newer, while the currently active rustc version is [..]",
+        )
+        .run();
+    p.cargo("build --ignore-rust-version -Zunstable-options")
+        .masquerade_as_nightly_cargo()
+        .run();
+}
+
+#[cargo_test]
+fn rust_version_dependency_fails() {
+    Package::new("bar", "0.0.1")
+        .cargo_feature("rust-version")
+        .rust_version("1.2345.0")
+        .file("src/lib.rs", "fn other_stuff() {}")
+        .publish();
+
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+            [dependencies]
+            bar = "0.0.1"
+        "#,
+        )
+        .file("src/main.rs", "fn main(){}")
+        .build();
+
+    p.cargo("build")
+        .masquerade_as_nightly_cargo()
+        .with_status(101)
+        .with_stderr(
+            "    Updating `[..]` index\n \
+             Downloading crates ...\n  \
+             Downloaded bar v0.0.1 (registry `[..]`)\n\
+             error: package `bar v0.0.1` cannot be built because it requires \
+             rustc 1.2345.0 or newer, while the currently active rustc version is [..]",
+        )
+        .run();
+    p.cargo("build --ignore-rust-version -Zunstable-options")
+        .masquerade_as_nightly_cargo()
+        .run();
+}
+
+#[cargo_test]
+fn rust_version_older_than_edition() {
+    project()
+        .file(
+            "Cargo.toml",
+            r#"
+            cargo-features = ["rust-version"]
+
+            [project]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+            rust-version = "1.1"
+            edition = "2018"
+            [[bin]]
+            name = "foo"
+        "#,
+        )
+        .file("src/main.rs", "fn main() {}")
+        .build()
+        .cargo("build")
+        .masquerade_as_nightly_cargo()
+        .with_status(101)
+        .with_stderr_contains("  rust-version 1.1 is older than first version (1.31.0) required by the specified edition (2018)",
+        )
+        .run();
+}


### PR DESCRIPTION
Needs a bunch more work, but I'd like some early feedback! Remaining work:

- [x] Bikeshedding name (picked `rust-version` here over `msrv` or `min-rust-version`)
- [x] Failing test for local dependency with unsatisfied MSRV
- [x] Requirement cannot be smaller than 1.27
- [x] Requirement cannot be smaller than initial release of edition used
- [x] Check for `run`, `verify` and `publish` subcommands
- [x] More tests (would love feedback on this)
- [x] Handle pre-release identifiers
- [x] Disallow semver range operators
- [x] Feature gate it
- [x] Add documentation for unstable feature

Minimal version of @moxian's earlier take in #7801.

cc rust-lang/rust#65262