### PR TITLE
Use stabilized version of rustdoc's --crate-version

### DIFF
--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -653,8 +653,6 @@ fn crate_version_flag_already_present(rustdoc: &ProcessBuilder) -> bool {
 
 fn append_crate_version_flag(unit: &Unit<'_>, rustdoc: &mut ProcessBuilder) {
     rustdoc
-        .arg("-Z")
-        .arg("unstable-options")
         .arg(RUSTDOC_CRATE_VERSION_FLAG)
         .arg(unit.pkg.version().to_string());
 }

--- a/tests/testsuite/doc.rs
+++ b/tests/testsuite/doc.rs
@@ -1513,7 +1513,7 @@ fn bin_private_items_deps() {
 
 #[cargo_test]
 fn crate_versions() {
-    // Testing unstable flag
+    // Testing flag that will reach stable on 1.44
     if !is_nightly() {
         return;
     }
@@ -1542,7 +1542,7 @@ fn crate_versions() {
 
 #[cargo_test]
 fn crate_versions_flag_is_overridden() {
-    // Testing unstable flag
+    // Testing flag that will reach stable on 1.44
     if !is_nightly() {
         return;
     }
@@ -1570,13 +1570,13 @@ fn crate_versions_flag_is_overridden() {
 
     p.cargo("-Z crate-versions doc")
         .masquerade_as_nightly_cargo()
-        .env("RUSTDOCFLAGS", "-Z unstable-options --crate-version 2.0.3")
+        .env("RUSTDOCFLAGS", "--crate-version 2.0.3")
         .run();
     asserts(output_documentation());
 
     p.build_dir().rm_rf();
 
-    p.cargo("-Z crate-versions rustdoc -- -Z unstable-options --crate-version 2.0.3")
+    p.cargo("-Z crate-versions rustdoc -- --crate-version 2.0.3")
         .masquerade_as_nightly_cargo()
         .run();
     asserts(output_documentation());


### PR DESCRIPTION
Since --crate-version flag of rustdoc was stabilized, there is no need to enable its unstable features when using it.