### PR TITLE
Remove the `git-checkout` subcommand.

### DIFF
--- a/src/bin/cargo/commands/git_checkout.rs
+++ b/src/bin/cargo/commands/git_checkout.rs
@@ -1,37 +1,14 @@
 use crate::command_prelude::*;
 
-use cargo::core::{GitReference, Source, SourceId};
-use cargo::sources::GitSource;
-use cargo::util::IntoUrl;
+const REMOVED: &str = "The `git-checkout` subcommand has been removed.";
 
 pub fn cli() -> App {
     subcommand("git-checkout")
-        .about("Checkout a copy of a Git repository")
-        .arg(opt("quiet", "No output printed to stdout").short("q"))
-        .arg(
-            Arg::with_name("url")
-                .long("url")
-                .value_name("URL")
-                .required(true),
-        )
-        .arg(
-            Arg::with_name("reference")
-                .long("reference")
-                .value_name("REF")
-                .required(true),
-        )
+        .about("This subcommand has been removed")
+        .settings(&[AppSettings::Hidden])
+        .help(REMOVED)
 }
 
-pub fn exec(config: &mut Config, args: &ArgMatches<'_>) -> CliResult {
-    let url = args.value_of("url").unwrap().into_url()?;
-    let reference = args.value_of("reference").unwrap();
-
-    let reference = GitReference::Branch(reference.to_string());
-    let source_id = SourceId::for_git(&url, reference)?;
-
-    let mut source = GitSource::new(source_id, config)?;
-
-    source.update()?;
-
-    Ok(())
+pub fn exec(_config: &mut Config, _args: &ArgMatches<'_>) -> CliResult {
+    Err(anyhow::format_err!(REMOVED).into())
 }

--- a/src/etc/_cargo
+++ b/src/etc/_cargo
@@ -129,12 +129,6 @@ _cargo() {
                     _arguments -s -S $common $manifest
                         ;;
 
-                git-checkout)
-                    _arguments -s -S $common \
-                        '--reference=:reference' \
-                        '--url=:url:_urls'
-                        ;;
-
                 help)
                     _cargo_cmds
                         ;;

--- a/src/etc/cargo.bashcomp.sh
+++ b/src/etc/cargo.bashcomp.sh
@@ -56,7 +56,6 @@ _cargo()
 	local opt__fetch="$opt_common $opt_mani $opt_lock --target"
 	local opt__fix="$opt_common $opt_pkg_spec $opt_feat $opt_mani $opt_jobs $opt_targets $opt_lock --release --target --message-format --broken-code --edition --edition-idioms --allow-no-vcs --allow-dirty --allow-staged --profile --target-dir"
 	local opt__generate_lockfile="$opt_common $opt_mani $opt_lock"
-	local opt__git_checkout="$opt_common $opt_lock --reference --url"
 	local opt__help="$opt_help"
 	local opt__init="$opt_common $opt_lock --bin --lib --name --vcs --edition --registry"
 	local opt__install="$opt_common $opt_feat $opt_jobs $opt_lock $opt_force --bin --bins --branch --debug --example --examples --git --list --path --rev --root --tag --version --registry --target --profile --no-track"


### PR DESCRIPTION
This command has been broken for almost a year (since #6880), and nobody has mentioned it. The command isn't very useful (it checks out into cargo's `db` directory, which can also be accomplished with `cargo fetch`).  Since it doesn't have much utility, I don't see much reason to keep it around.
