### PR TITLE
Provide help when encountering `O` (uppercase `o`) in version numbers #8043

### DIFF
--- a/src/cargo/core/dependency.rs
+++ b/src/cargo/core/dependency.rs
@@ -126,7 +126,17 @@ this warning.
         }
         Err(e) => {
             let err: CargoResult<VersionReq> = Err(e.into());
-            let v: VersionReq = err.chain_err(|| {
+            let v = if req.contains('O') {
+                err.chain_err(|| {
+                    format!(
+                        "requirement `{}` contains uppercase 'o' `O` instead of zero `0`",
+                        req
+                    )
+                })
+            } else {
+                err
+            };
+            let v = v.chain_err(|| {
                 format!(
                     "failed to parse the version requirement `{}` for dependency `{}`",
                     req, name

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -493,6 +493,41 @@ Caused by:
 }
 
 #[cargo_test]
+fn cargo_compile_with_uppercase_o_in_dep_version() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "foo"
+            version = "0.0.1"
+
+            [dependencies]
+            crossbeam = "O.0.2"
+        "#,
+        )
+        .build();
+
+    p.cargo("build")
+        .with_status(101)
+        .with_stderr(
+            "\
+[ERROR] failed to parse manifest at `[CWD]/Cargo.toml`
+
+Caused by:
+  failed to parse the version requirement `O.0.2` for dependency `crossbeam`
+
+Caused by:
+  requirement `O.0.2` contains uppercase 'o' `O` instead of zero `0`
+
+Caused by:
+  the given version requirement is invalid
+",
+        )
+        .run();
+}
+
+#[cargo_test]
 fn cargo_compile_without_manifest() {
     let p = project().no_manifest().build();
 


### PR DESCRIPTION
feature #8043 

Run unit test:

```
cargo test cargo_compile_with_uppercase_o_in_dep_version
```

cargo stderr output when `O` (uppercase `o`) is found in requirements:

```
[ERROR] failed to parse manifest at `[CWD]/Cargo.toml`

Caused by:
  failed to parse the version requirement `O.0.2` for dependency `crossbeam`

Caused by:
  requirement `O.0.2` contains uppercase 'o' `O` instead of zero `0`

Caused by:
  the given version requirement is invalid
```

Note: this is my first contribution to `Cargo`