### PR TITLE
Implement the --dependencies and --remote-dependencies options for cargo build

### DIFF
--- a/crates/cargo-test-support/src/lib.rs
+++ b/crates/cargo-test-support/src/lib.rs
@@ -401,6 +401,13 @@ impl Project {
             .expect("failed to glob")
     }
 
+    /// Checks whether a dependency library is built
+    /// within the workspace taget dir. Debug build is assumed.
+    pub fn dep_built(&self, name: &str) -> bool {
+        let pattern = format!("target/debug/deps/lib{}-*.rlib", name);
+        self.glob(&pattern).next().is_some()
+    }
+
     /// Changes the contents of an existing file.
     pub fn change_file(&self, path: &str, body: &str) {
         FileBuilder::new(self.root().join(path), body).mk()

--- a/src/bin/cargo/commands/build.rs
+++ b/src/bin/cargo/commands/build.rs
@@ -42,6 +42,8 @@ pub fn cli() -> App {
         .arg_message_format()
         .arg_build_plan()
         .arg_unit_graph()
+        .arg_deps()
+        .arg_deps_remote()
         .after_help(
             "\
 All packages in the workspace are built if the `--workspace` flag is supplied. The
@@ -63,6 +65,19 @@ pub fn exec(config: &mut Config, args: &ArgMatches<'_>) -> CliResult {
         Some(&ws),
         ProfileChecking::Checked,
     )?;
+
+    compile_opts.deps_only = args.is_present_with_zero_values("dependencies");
+    if compile_opts.deps_only {
+        config
+            .cli_unstable()
+            .fail_if_stable_opt("--dependencies", 2644)?;
+    };
+    compile_opts.deps_remote_only = args.is_present_with_zero_values("remote-dependencies");
+    if compile_opts.deps_only {
+        config
+            .cli_unstable()
+            .fail_if_stable_opt("--remote-dependencies", 2644)?;
+    };
 
     if let Some(out_dir) = args.value_of_path("out-dir", config) {
         compile_opts.export_dir = Some(out_dir);

--- a/src/cargo/core/compiler/build_context/mod.rs
+++ b/src/cargo/core/compiler/build_context/mod.rs
@@ -6,7 +6,8 @@ use crate::core::{PackageId, PackageSet};
 use crate::util::config::Config;
 use crate::util::errors::CargoResult;
 use crate::util::Rustc;
-use std::collections::HashMap;
+use std::cell::RefCell;
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::str;
 
@@ -36,6 +37,9 @@ pub struct BuildContext<'a, 'cfg> {
 
     /// Information about rustc and the target platform.
     pub target_data: RustcTargetData,
+
+    /// Units which should be skipped, use in dependency builds
+    pub skip_units: RefCell<HashSet<Unit<'a>>>,
 }
 
 impl<'a, 'cfg> BuildContext<'a, 'cfg> {
@@ -58,6 +62,7 @@ impl<'a, 'cfg> BuildContext<'a, 'cfg> {
             extra_compiler_args,
             units,
             target_data,
+            skip_units: RefCell::new(HashSet::new()),
         })
     }
 

--- a/src/cargo/ops/cargo_package.rs
+++ b/src/cargo/ops/cargo_package.rs
@@ -712,6 +712,8 @@ fn run_verify(ws: &Workspace<'_>, tar: &FileLock, opts: &PackageOpts<'_>) -> Car
             filter: ops::CompileFilter::Default {
                 required_features_filterable: true,
             },
+            deps_only: false,
+            deps_remote_only: false,
             target_rustdoc_args: None,
             target_rustc_args: rustc_args,
             local_rustdoc_args: None,

--- a/src/cargo/util/command_prelude.rs
+++ b/src/cargo/util/command_prelude.rs
@@ -154,6 +154,20 @@ pub trait AppExt: Sized {
         self._arg(opt("unit-graph", "Output build graph in JSON (unstable)").hidden(true))
     }
 
+    fn arg_deps(self) -> Self {
+        self._arg(opt(
+            "dependencies",
+            "Build dependencies of the selected packages (unstable)",
+        ).conflicts_with("remote-dependencies"))
+    }
+
+    fn arg_deps_remote(self) -> Self {
+        self._arg(opt(
+            "remote-dependencies",
+            "Build remote dependencies of the selected packages (unstable)",
+        ).conflicts_with("dependencies"))
+    }
+
     fn arg_new_opts(self) -> Self {
         self._arg(
             opt(
@@ -472,6 +486,8 @@ pub trait ArgMatchesExt {
                 self._is_present("benches"),
                 self._is_present("all-targets"),
             ),
+            deps_only: false,
+            deps_remote_only: false,
             target_rustdoc_args: None,
             target_rustc_args: None,
             local_rustdoc_args: None,

--- a/src/doc/man/cargo-build.adoc
+++ b/src/doc/man/cargo-build.adoc
@@ -37,6 +37,15 @@ include::options-target-triple.adoc[]
 
 include::options-release.adoc[]
 
+*--dependencies*::
+    Only build dependencies of the selected packages,
+    but not the selected packages themselves.
+
+*--remote-dependencies*::
+    Only build remote (ie. git and registry) dependencies of the selected packages.
+    If a remote dependency is patched, it is only built if another remote package
+    depends on it.
+
 === Output Options
 
 include::options-target-dir.adoc[]

--- a/tests/testsuite/build_deps_only.rs
+++ b/tests/testsuite/build_deps_only.rs
@@ -1,0 +1,539 @@
+//! Tests of cargo build --dependencies and --remote-dependencies
+
+use cargo_test_support::{basic_lib_manifest, git, main_file, project, registry};
+
+#[cargo_test]
+fn build_deps_basic() {
+    // Setup a project with two local (by path) dependencies
+    // foo -> bar -> baz
+    //
+    // Test that with --dependencies only bar & baz are built & cached
+
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+
+            [dependencies]
+            bar = { path = "../bar" }
+        "#,
+        )
+        .file("src/main.rs", &main_file(r#""I am foo""#, &["bar"]))
+        .build();
+
+    project()
+        .at("bar")
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "bar"
+            version = "0.0.1"
+            authors = []
+
+            [dependencies]
+            baz = { path = "../baz" }
+        "#,
+        )
+        .file("src/lib.rs", &main_file(r#""I am bar""#, &["baz"]))
+        .build();
+
+    project()
+        .at("baz")
+        .file("Cargo.toml", &basic_lib_manifest("baz"))
+        .file("src/lib.rs", &main_file(r#""I am baz""#, &[]))
+        .build();
+
+    p.cargo("build -Z unstable-options --dependencies")
+        .masquerade_as_nightly_cargo()
+        .with_stderr_contains("[COMPILING] baz [..]")
+        .with_stderr_contains("[COMPILING] bar [..]")
+        .with_stderr_does_not_contain("[COMPILING] foo [..]")
+        .run();
+
+    // The `bar` & `baz` dependencies should now be built
+    // but the top-level `foo` bin should *not* be built
+    assert!(p.dep_built("baz"));
+    assert!(p.dep_built("bar"));
+    assert!(!p.bin("foo").is_file());
+
+    // A subsequent build command should build `foo` only
+    p.cargo("build")
+        .with_stderr_does_not_contain("[COMPILING] baz [..]")
+        .with_stderr_does_not_contain("[COMPILING] bar [..]")
+        .with_stderr_contains("[COMPILING] foo [..]")
+        .run();
+
+    assert!(p.bin("foo").is_file());
+}
+
+#[cargo_test]
+fn build_deps_remote() {
+    // Setup a project with both local and remote dependencies
+    // foo -> bar (path) -> baz (git)
+
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+
+            [dependencies]
+            bar = { path = "../bar" }
+        "#,
+        )
+        .file("src/main.rs", &main_file(r#""I am foo""#, &["bar"]))
+        .build();
+
+    let baz = git::new("baz", |project| {
+        project
+            .file("Cargo.toml", &basic_lib_manifest("baz"))
+            .file("src/lib.rs", "")
+    });
+
+    let bar_toml = format!(
+        r#"[package]
+        name = "bar"
+        version = "0.0.1"
+        authors = []
+
+        [dependencies.baz]
+        git = "{}"
+        "#,
+        baz.url()
+    );
+    project()
+        .at("bar")
+        .file("Cargo.toml", &bar_toml)
+        .file("src/lib.rs", &main_file(r#""I am bar""#, &["baz"]))
+        .build();
+
+    // First, only build remote dependencies; this should only build
+    // `baz` but not `bar` and `foo`:
+    p.cargo("build -Z unstable-options --remote-dependencies")
+        .masquerade_as_nightly_cargo()
+        .with_stderr_contains("[COMPILING] baz [..]")
+        .with_stderr_does_not_contain("[COMPILING] bar [..]")
+        .with_stderr_does_not_contain("[COMPILING] foo [..]")
+        .run();
+
+    assert!(p.dep_built("baz"));
+    assert!(!p.dep_built("bar"));
+    assert!(!p.bin("foo").is_file());
+
+    // Second, build all dependencies; this should only build
+    // `bar` as `baz` should already be built and `foo` still
+    // should not be built:
+    p.cargo("build -Z unstable-options --dependencies")
+        .masquerade_as_nightly_cargo()
+        .with_stderr_does_not_contain("[COMPILING] baz [..]")
+        .with_stderr_contains("[COMPILING] bar [..]")
+        .with_stderr_does_not_contain("[COMPILING] foo [..]")
+        .run();
+
+    assert!(p.dep_built("baz"));
+    assert!(p.dep_built("bar"));
+    assert!(!p.bin("foo").is_file());
+
+    // Finally, build all. This should build `foo` since
+    // `bar` and `baz` should already be cached
+    p.cargo("build")
+        .with_stderr_does_not_contain("[COMPILING] bar [..]")
+        .with_stderr_does_not_contain("[COMPILING] baz [..]")
+        .with_stderr_contains("[COMPILING] foo [..]")
+        .run();
+
+    assert!(p.bin("foo").is_file());
+}
+
+#[cargo_test]
+fn build_deps_features() {
+    // Setup a project with features & optional dependencies
+    // foo -> bar (path, feature use_bar)
+    // foo -> baz (git, feature use_baz)
+
+    let baz = git::new("baz", |project| {
+        project
+            .file("Cargo.toml", &basic_lib_manifest("baz"))
+            .file("src/lib.rs", "")
+    });
+
+    let p_toml = format!(
+        r#"[package]
+        name = "foo"
+        version = "0.0.1"
+        authors = []
+
+        [features]
+        use_bar = ["bar"]
+        use_baz = ["baz"]
+
+        [dependencies]
+        bar = {{ path = "../bar", optional = true }}
+        baz = {{ git = "{}", optional = true }}
+        "#,
+        baz.url()
+    );
+    let p_main = r#"
+        #[cfg(use_bar)] extern crate bar;
+        #[cfg(use_baz)] extern crate baz;
+
+        pub fn main() {
+            println!("I am foo");
+        }
+        "#;
+    let p = project()
+        .file("Cargo.toml", &p_toml)
+        .file("src/main.rs", p_main)
+        .build();
+
+    project()
+        .at("bar")
+        .file(
+            "Cargo.toml",
+            r#"[package]
+            name = "bar"
+            version = "0.0.1"
+            authors = []
+            "#,
+        )
+        .file("src/lib.rs", &main_file(r#""i am bar""#, &[]))
+        .build();
+
+    // Build with no features turned on, check that building
+    // dependencies doesn't build them
+    p.cargo("build -Z unstable-options --remote-dependencies")
+        .masquerade_as_nightly_cargo()
+        .with_stderr_does_not_contain("[COMPILING] bar [..]")
+        .with_stderr_does_not_contain("[COMPILING] baz [..]")
+        .with_stderr_does_not_contain("[COMPILING] foo [..]")
+        .run();
+    p.cargo("build -Z unstable-options --dependencies")
+        .masquerade_as_nightly_cargo()
+        .with_stderr_does_not_contain("[COMPILING] bar [..]")
+        .with_stderr_does_not_contain("[COMPILING] baz [..]")
+        .with_stderr_does_not_contain("[COMPILING] foo [..]")
+        .run();
+    p.cargo("build")
+        .with_stderr_does_not_contain("[COMPILING] bar [..]")
+        .with_stderr_does_not_contain("[COMPILING] baz [..]")
+        .with_stderr_contains("[COMPILING] foo [..]")
+        .run();
+    assert!(!p.dep_built("bar"));
+    assert!(!p.dep_built("baz"));
+    assert!(p.bin("foo").is_file());
+    p.cargo("clean").run();
+
+    // Build with use_bar, check bar is built in the --dependencies step
+    p.cargo("build --features use_bar -Z unstable-options --remote-dependencies")
+        .masquerade_as_nightly_cargo()
+        .with_stderr_does_not_contain("[COMPILING] bar [..]")
+        .with_stderr_does_not_contain("[COMPILING] baz [..]")
+        .with_stderr_does_not_contain("[COMPILING] foo [..]")
+        .run();
+    p.cargo("build --features use_bar -Z unstable-options --dependencies")
+        .masquerade_as_nightly_cargo()
+        .with_stderr_contains("[COMPILING] bar [..]")
+        .with_stderr_does_not_contain("[COMPILING] baz [..]")
+        .with_stderr_does_not_contain("[COMPILING] foo [..]")
+        .run();
+    p.cargo("build --features use_bar")
+        .masquerade_as_nightly_cargo()
+        .with_stderr_does_not_contain("[COMPILING] bar [..]")
+        .with_stderr_does_not_contain("[COMPILING] baz [..]")
+        .with_stderr_contains("[COMPILING] foo [..]")
+        .run();
+    assert!(p.dep_built("bar"));
+    assert!(!p.dep_built("baz"));
+    assert!(p.bin("foo").is_file());
+    p.cargo("clean").run();
+
+    // Build with use_baz, check baz is built in the --remote-dependencies step
+    p.cargo("build --features use_baz -Z unstable-options --remote-dependencies")
+        .masquerade_as_nightly_cargo()
+        .with_stderr_does_not_contain("[COMPILING] bar [..]")
+        .with_stderr_contains("[COMPILING] baz [..]")
+        .with_stderr_does_not_contain("[COMPILING] foo [..]")
+        .run();
+    p.cargo("build --features use_baz -Z unstable-options --dependencies")
+        .masquerade_as_nightly_cargo()
+        .with_stderr_does_not_contain("[COMPILING] bar [..]")
+        .with_stderr_does_not_contain("[COMPILING] baz [..]")
+        .with_stderr_does_not_contain("[COMPILING] foo [..]")
+        .run();
+    p.cargo("build --features use_baz")
+        .masquerade_as_nightly_cargo()
+        .with_stderr_does_not_contain("[COMPILING] bar [..]")
+        .with_stderr_does_not_contain("[COMPILING] baz [..]")
+        .with_stderr_contains("[COMPILING] foo [..]")
+        .run();
+    assert!(!p.dep_built("bar"));
+    assert!(p.dep_built("baz"));
+    assert!(p.bin("foo").is_file());
+    p.cargo("clean").run();
+}
+
+#[cargo_test]
+fn build_deps_complex() {
+    // Setup a more complex project with workspace members,
+    // local dependencies, git dependencies, registry dependencies,
+    // and patches.
+    //
+    // The structure is as follows:
+    // workspace: [foo, foo1, foo2]
+    //     - foo ----------> foo1
+    //          `--> foo2 ----^
+    // dependencies:
+    //     - foo -> bar (path) -> baz (path) -------------v
+    //     - foo1 -> dex (registry) -> hex (registry) -> qux (registry)
+    //     - foo2 -> ook (git) ---------------------------^
+    //     - foo2 -> eek (registry)
+    // pathces:
+    //     - hex
+    //     - qux
+    //     - eek
+    //
+    // What is verified here:
+    //   1. That --remote-dependencies works, ie. builds git and registry
+    //      dependencies but not workspace packages and local (path) deps.
+    //   2. That --dependencies works, ie. build all dependencies, but not
+    //      packages in the workspace
+    //   3. That --remote-dependencies treats patches reasonably, ie.
+    //      it builds `hex` and `qux` since a remote dependency `dex` needs them,
+    //      but not `eek`, since no remote package needs it.
+    //   4. That --dependencies treats patches reasonably, ie. builds all patched
+    //      dependencies.
+
+    // Registry packages:
+    registry::Package::new("qux", "0.5.0").publish();
+    registry::Package::new("hex", "0.5.0")
+        .dep("qux", "0.5.0")
+        .publish();
+    registry::Package::new("dex", "0.5.0")
+        .dep("hex", "0.5.0")
+        .publish();
+    registry::Package::new("eek", "0.5.0").publish();
+
+    // Git packages:
+    let ook = git::new("ook", |project| {
+        let ook_toml = r#"[package]
+            name = "ook"
+            version = "0.5.0"
+            authors = []
+
+            [dependencies]
+            qux = "0.5.0"
+            "#;
+        project
+            .file("Cargo.toml", ook_toml)
+            .file("src/lib.rs", "extern crate qux;")
+    });
+
+    // Patch packages:
+    project()
+        .at("hex")
+        .file(
+            "Cargo.toml",
+            r#"[package]
+            name = "hex"
+            version = "0.5.0"
+            authors = []
+
+            [dependencies]
+            qux = "0.5.0"
+            "#,
+        )
+        .file("src/lib.rs", &main_file(r#""I am hex""#, &["qux"]))
+        .build();
+    project()
+        .at("qux")
+        .file("Cargo.toml", &basic_lib_manifest("qux"))
+        .file("src/lib.rs", &main_file(r#""I am qux""#, &[]))
+        .build();
+    project()
+        .at("eek")
+        .file("Cargo.toml", &basic_lib_manifest("eek"))
+        .file("src/lib.rs", &main_file(r#""I am eek""#, &[]))
+        .build();
+
+    // Local non-workspace packages:
+    project()
+        .at("baz")
+        .file(
+            "Cargo.toml",
+            r#"[package]
+            name = "baz"
+            version = "0.5.0"
+            authors = []
+
+            [dependencies]
+            qux = "0.5.0"
+            "#,
+        )
+        .file("src/lib.rs", &main_file(r#""I am baz""#, &["qux"]))
+        .build();
+    project()
+        .at("bar")
+        .file(
+            "Cargo.toml",
+            r#"[package]
+            name = "bar"
+            version = "0.5.0"
+            authors = []
+
+            [dependencies]
+            baz = { path = "../baz" }
+            "#,
+        )
+        .file("src/lib.rs", &main_file(r#""I am bar""#, &["baz"]))
+        .build();
+
+    // Workspace:
+    let foo2_toml = format!(
+        r#"[package]
+        name = "foo2"
+        version = "0.1.0"
+        authors = []
+
+        [dependencies]
+        foo1 = {{ path = "../foo1" }}
+        ook = {{ git = "{}" }}
+        eek = "0.5.0"
+        "#,
+        ook.url()
+    );
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+
+            [[bin]]
+            name = "foo"
+
+            [dependencies]
+            foo1 = { path = "foo1" }
+            foo2 = { path = "foo2" }
+            bar = { path = "../bar" }
+
+            [workspace]
+            members = ["foo1", "foo2"]
+
+            [patch.crates-io]
+            hex = { path = "../hex" }
+            qux = { path = "../qux" }
+            eek = { path = "../eek" }
+        "#,
+        )
+        .file("src/main.rs", &main_file(r#""I am foo""#, &["foo1", "foo2"]))
+        .file(
+            "foo1/Cargo.toml",
+            r#"[package]
+            name = "foo1"
+            version = "0.1.0"
+            authors = []
+
+            [dependencies]
+            dex = "0.5.0"
+            "#,
+        )
+        .file("foo1/src/lib.rs", &main_file(r#""I am foo1""#, &["dex"]))
+        .file("foo2/Cargo.toml", &foo2_toml)
+        .file(
+            "foo2/src/lib.rs",
+            &main_file(r#""I am foo2""#, &["ook", "eek"]),
+        )
+        .build();
+
+    // Build:
+
+    // First, only build remote dependencies
+    p.cargo("build -Z unstable-options --remote-dependencies")
+        .masquerade_as_nightly_cargo()
+        .with_stderr_does_not_contain("[COMPILING] bar [..]")
+        .with_stderr_does_not_contain("[COMPILING] baz [..]")
+        .with_stderr_contains("[COMPILING] dex [..]")
+        .with_stderr_contains("[COMPILING] hex [..]")
+        .with_stderr_contains("[COMPILING] qux [..]")
+        .with_stderr_contains("[COMPILING] ook [..]")
+        .with_stderr_does_not_contain("[COMPILING] eek [..]")
+        .with_stderr_does_not_contain("[COMPILING] foo [..]")
+        .with_stderr_does_not_contain("[COMPILING] foo1 [..]")
+        .with_stderr_does_not_contain("[COMPILING] foo2 [..]")
+        .run();
+
+    assert!(!p.dep_built("bar"));
+    assert!(!p.dep_built("baz"));
+    assert!(p.dep_built("dex"));
+    assert!(p.dep_built("hex"));
+    assert!(p.dep_built("qux"));
+    assert!(p.dep_built("ook"));
+    assert!(!p.dep_built("eek"));
+    assert!(!p.dep_built("foo1"));
+    assert!(!p.dep_built("foo2"));
+    assert!(!p.bin("foo").is_file());
+
+    // Second, build all dependencies
+    // (remote ones should now be cached)
+    p.cargo("build -Z unstable-options --dependencies")
+        .masquerade_as_nightly_cargo()
+        .with_stderr_contains("[COMPILING] bar [..]")
+        .with_stderr_contains("[COMPILING] baz [..]")
+        .with_stderr_does_not_contain("[COMPILING] dex [..]")
+        .with_stderr_does_not_contain("[COMPILING] hex [..]")
+        .with_stderr_does_not_contain("[COMPILING] qux [..]")
+        .with_stderr_does_not_contain("[COMPILING] ook [..]")
+        .with_stderr_contains("[COMPILING] eek [..]")
+        .with_stderr_does_not_contain("[COMPILING] foo [..]")
+        .with_stderr_does_not_contain("[COMPILING] foo1 [..]")
+        .with_stderr_does_not_contain("[COMPILING] foo2 [..]")
+        .run();
+
+    assert!(p.dep_built("bar"));
+    assert!(p.dep_built("baz"));
+    assert!(p.dep_built("dex"));
+    assert!(p.dep_built("hex"));
+    assert!(p.dep_built("qux"));
+    assert!(p.dep_built("ook"));
+    assert!(p.dep_built("eek"));
+    assert!(!p.dep_built("foo1"));
+    assert!(!p.dep_built("foo2"));
+    assert!(!p.bin("foo").is_file());
+
+    // Finally, build all. This should build the workspace
+    // packages, the dependencies should be cached.
+    p.cargo("build")
+        .masquerade_as_nightly_cargo()
+        .with_stderr_does_not_contain("[COMPILING] bar [..]")
+        .with_stderr_does_not_contain("[COMPILING] baz [..]")
+        .with_stderr_does_not_contain("[COMPILING] dex [..]")
+        .with_stderr_does_not_contain("[COMPILING] hex [..]")
+        .with_stderr_does_not_contain("[COMPILING] qux [..]")
+        .with_stderr_does_not_contain("[COMPILING] ook [..]")
+        .with_stderr_does_not_contain("[COMPILING] eek [..]")
+        .with_stderr_contains("[COMPILING] foo [..]")
+        .with_stderr_contains("[COMPILING] foo1 [..]")
+        .with_stderr_contains("[COMPILING] foo2 [..]")
+        .run();
+
+    assert!(p.dep_built("bar"));
+    assert!(p.dep_built("baz"));
+    assert!(p.dep_built("dex"));
+    assert!(p.dep_built("hex"));
+    assert!(p.dep_built("qux"));
+    assert!(p.dep_built("ook"));
+    assert!(p.dep_built("eek"));
+    assert!(p.dep_built("foo1"));
+    assert!(p.dep_built("foo2"));
+    assert!(p.bin("foo").is_file());
+}

--- a/tests/testsuite/main.rs
+++ b/tests/testsuite/main.rs
@@ -17,6 +17,7 @@ mod bad_config;
 mod bad_manifest_path;
 mod bench;
 mod build;
+mod build_deps_only;
 mod build_plan;
 mod build_script;
 mod build_script_env;


### PR DESCRIPTION
Implement options for building dependencies only, useful for docker builds.
See discussion in #2644

~~No tests and docs so far, sorry! I'll be sure to add them if folks say this is an ok approach...~~
Edit: Tests & docs added.

Description copied from my [comment](https://github.com/rust-lang/cargo/issues/2644#issuecomment-606898600) in the issue thread:

What is included:

- Option `--dependencies` to build all dependencies, including local ones, basically everything except root packages
- Option `--remote-dependencies` to build all remote dependencies, excluding root packages _and_ local packages.

The naming of the options follows the same logic as the already existing option `--tests`, the command `cargo build --tests` sounds like an english sentence _"cargo, build tests"_. I have named the options similarly, ie. `cargo build --remote-dependencies` sounds like _"cargo, build remote dependencies"_. The two options are mutually exclusive.

- `patch` sections are supported, the semantics are as follows: if a remote dependency is patched with a local one (`path`) and `--remote-dependencies` is used, the dependency is built _iff_ another remote dependency depends on it. Otherwise it is not built.
