### PR TITLE
Use the same filename hash for pre-release channels.

### DIFF
--- a/src/cargo/core/compiler/context/compilation_files.rs
+++ b/src/cargo/core/compiler/context/compilation_files.rs
@@ -644,7 +644,7 @@ fn compute_metadata<'a, 'cfg>(
 
 fn hash_rustc_version(bcx: &BuildContext<'_, '_>, hasher: &mut SipHasher) {
     let vers = &bcx.rustc().version;
-    if vers.pre.is_empty() {
+    if vers.pre.is_empty() || bcx.config.cli_unstable().separate_nightlies {
         // For stable, keep the artifacts separate. This helps if someone is
         // testing multiple versions, to avoid recompiles.
         bcx.rustc().verbose_version.hash(hasher);

--- a/src/cargo/core/compiler/context/compilation_files.rs
+++ b/src/cargo/core/compiler/context/compilation_files.rs
@@ -614,7 +614,7 @@ fn compute_metadata<'a, 'cfg>(
     unit.target.name().hash(&mut hasher);
     unit.target.kind().hash(&mut hasher);
 
-    bcx.rustc().verbose_version.hash(&mut hasher);
+    hash_rustc_version(bcx, &mut hasher);
 
     if cx.bcx.ws.is_member(unit.pkg) {
         // This is primarily here for clippy. This ensures that the clippy
@@ -640,4 +640,36 @@ fn compute_metadata<'a, 'cfg>(
     unit.is_std.hash(&mut hasher);
 
     Some(Metadata(hasher.finish()))
+}
+
+fn hash_rustc_version(bcx: &BuildContext<'_, '_>, hasher: &mut SipHasher) {
+    let vers = &bcx.rustc().version;
+    if vers.pre.is_empty() {
+        // For stable, keep the artifacts separate. This helps if someone is
+        // testing multiple versions, to avoid recompiles.
+        bcx.rustc().verbose_version.hash(hasher);
+        return;
+    }
+    // On "nightly"/"beta"/"dev"/etc, keep each "channel" separate. Don't hash
+    // the date/git information, so that whenever someone updates "nightly",
+    // they won't have a bunch of stale artifacts in the target directory.
+    //
+    // This assumes that the first segment is the important bit ("nightly",
+    // "beta", "dev", etc.). Skip other parts like the `.3` in `-beta.3`.
+    vers.pre[0].hash(hasher);
+    // Keep "host" since some people switch hosts to implicitly change
+    // targets, (like gnu vs musl or gnu vs msvc). In the future, we may want
+    // to consider hashing `unit.kind.short_name()` instead.
+    bcx.rustc().host.hash(hasher);
+    // None of the other lines are important. Currently they are:
+    // binary: rustc  <-- or "rustdoc"
+    // commit-hash: 38114ff16e7856f98b2b4be7ab4cd29b38bed59a
+    // commit-date: 2020-03-21
+    // host: x86_64-apple-darwin
+    // release: 1.44.0-nightly
+    // LLVM version: 9.0
+    //
+    // The backend version ("LLVM version") might become more relevant in
+    // the future when cranelift sees more use, and people want to switch
+    // between different backends without recompiling.
 }

--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -343,6 +343,7 @@ pub struct CliUnstable {
     pub jobserver_per_rustc: bool,
     pub features: Option<Vec<String>>,
     pub crate_versions: bool,
+    pub separate_nightlies: bool,
 }
 
 impl CliUnstable {
@@ -420,6 +421,7 @@ impl CliUnstable {
             "jobserver-per-rustc" => self.jobserver_per_rustc = parse_empty(k, v)?,
             "features" => self.features = Some(parse_features(v)),
             "crate-versions" => self.crate_versions = parse_empty(k, v)?,
+            "separate-nightlies" => self.separate_nightlies = parse_empty(k, v)?,
             _ => bail!("unknown `-Z` flag specified: {}", k),
         }
 


### PR DESCRIPTION
This changes it so that filenames do not hash the entire verbose version from rustc if they are a pre-release version. The intent is to avoid leaving stale artifacts in the target directory whenever someone updates a nightly or beta release. This should help reduce disk space usage for someone who updates these toolchains frequently.

I tested with the rustc repo, and it seems to be OK. It keeps everything in separate target directories, so I think it should be generally safe. This should only affect someone switching between different nightlies and wanting to avoid recompiling when switching back. I suspect that is a rare use case, though if there are complaints this can be easily reverted (or made a config option). cargo-bisect-rustc should also be safe since it uses a different target directory for each toolchain.

One concern here for me was incremental support. It looks like ([src](https://github.com/rust-lang/rust/blob/6387b09153939b2a104cd63148598a5f458de2c2/src/librustc_incremental/persist/file_format.rs#L88-L100)) the incremental cache includes the detailed rustc version, so I think that is safe. It also looks like it is [smart enough](https://github.com/rust-lang/rust/blob/6387b09153939b2a104cd63148598a5f458de2c2/src/librustc_incremental/persist/load.rs#L40-L49) to delete stale files.

We will need to be more careful in the future when changing the target directory structure or the format of files. We previously relied on the fact that each new nightly will use different filenames. If we change the structure in a backwards-incompatible way, we will need to be careful to update the version (`1.hash` in `compute_metadata`).
