### PR TITLE
Use associated constants directly on primitive types instead of modules

### DIFF
--- a/crates/cargo-test-support/src/lib.rs
+++ b/crates/cargo-test-support/src/lib.rs
@@ -118,7 +118,6 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
 use std::str;
 use std::time::{self, Duration};
-use std::usize;
 
 use cargo::util::{is_ci, CargoResult, ProcessBuilder, ProcessError, Rustc};
 use serde_json::{self, Value};

--- a/crates/resolver-tests/tests/resolve.rs
+++ b/crates/resolver-tests/tests/resolve.rs
@@ -25,7 +25,7 @@ proptest! {
                 0
             } else {
                 // but that local builds will give a small clear test case.
-                std::u32::MAX
+                u32::MAX
             },
         result_cache: prop::test_runner::basic_result_cache,
         .. ProptestConfig::default()

--- a/src/cargo/core/resolver/conflict_cache.rs
+++ b/src/cargo/core/resolver/conflict_cache.rs
@@ -175,7 +175,7 @@ impl ConflictCache {
         dep: &Dependency,
         must_contain: Option<PackageId>,
     ) -> Option<&ConflictMap> {
-        let out = self.find(dep, &|id| cx.is_active(id), must_contain, std::usize::MAX);
+        let out = self.find(dep, &|id| cx.is_active(id), must_contain, usize::MAX);
         if cfg!(debug_assertions) {
             if let Some(c) = &out {
                 assert!(cx.is_conflicting(None, c).is_some());

--- a/tests/testsuite/standard_lib.rs
+++ b/tests/testsuite/standard_lib.rs
@@ -297,7 +297,7 @@ fn lib_nostd() {
             r#"
                 #![no_std]
                 pub fn foo() {
-                    assert_eq!(core::u8::MIN, 0);
+                    assert_eq!(u8::MIN, 0);
                 }
             "#,
         )

--- a/tests/testsuite/test.rs
+++ b/tests/testsuite/test.rs
@@ -129,7 +129,7 @@ fn cargo_test_overflow_checks() {
             use std::panic;
             pub fn main() {
                 let r = panic::catch_unwind(|| {
-                    [1, i32::max_value()].iter().sum::<i32>();
+                    [1, i32::MAX].iter().sum::<i32>();
                 });
                 assert!(r.is_err());
             }"#,


### PR DESCRIPTION
This PR is in no way critical. It's more of a code cleanup. It comes as a result of me making https://github.com/rust-lang/rust/pull/70857 and search-and-replacing all usage of the soft-deprecated ways of reaching primitive type constants.

It makes the code slightly shorter, that's basically it. And showcases the recommended way of reaching these consts on new code :)