### PR TITLE
Disallow invalid dependency names through crate renaming

### DIFF
--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -1082,6 +1082,7 @@ impl TomlManifest {
                 };
                 for (n, v) in dependencies.iter() {
                     let dep = v.to_dependency(n, cx, kind)?;
+                    validate_package_name(dep.name_in_toml().as_str(), "dependency name", "")?;
                     cx.deps.push(dep);
                 }
 

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -911,6 +911,37 @@ required by package `foo v0.0.1 ([CWD])`
         .run();
 }
 
+// Ensure that renamed deps have a valid name
+#[cargo_test]
+fn cargo_compile_with_invalid_dep_rename() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "buggin"
+            version = "0.1.0"
+
+            [dependencies]
+            "haha this isn't a valid name 🐛" = { package = "libc", version = "0.1" }
+        "#,
+        )
+        .file("src/main.rs", &main_file(r#""What's good?""#, &[]))
+        .build();
+
+    p.cargo("build")
+        .with_status(101)
+        .with_stderr(
+            "\
+error: failed to parse manifest at `[..]`
+
+Caused by:
+  invalid character ` ` in dependency name: `haha this isn't a valid name 🐛`, characters must be Unicode XID characters (numbers, `-`, `_`, or most letters)
+",
+        )
+        .run();
+}
+
 #[cargo_test]
 fn cargo_compile_with_filename() {
     let p = project()


### PR DESCRIPTION
resolves #6656

As suggested in the issue, I simply checked the dep names by calling `validate_package_name` on the dependencies during the TOML deserialization process.

It might be a bit too strict (and sudden) to error out in this case, so it might be best to convert this into a warning instead. However, this _is_ pretty invalid behavior so I'm not too sure really.
