### PR TITLE
Fix nightly test matching rustc "warning" output.

### DIFF
--- a/tests/testsuite/pub_priv.rs
+++ b/tests/testsuite/pub_priv.rs
@@ -37,15 +37,9 @@ fn exported_priv_warning() {
 
     p.cargo("build --message-format=short")
         .masquerade_as_nightly_cargo()
-        .with_stderr(
+        .with_stderr_contains(
             "\
-[UPDATING] `[..]` index
-[DOWNLOADING] crates ...
-[DOWNLOADED] priv_dep v0.1.0 ([..])
-[COMPILING] priv_dep v0.1.0
-[COMPILING] foo v0.0.1 ([CWD])
 src/lib.rs:3:13: warning: type `priv_dep::FromPriv` from private dependency 'priv_dep' in public interface
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 "
         )
         .run()


### PR DESCRIPTION
https://github.com/rust-lang/rust/pull/69926 changed the warning output from rustc.  https://github.com/rust-lang/cargo/pull/8080 attempted to compensate for it, but missed one of the cases.  I don't think this test needs to be quite so exhaustive about checking the output.
