### PR TITLE
Try to avoid panics on buggy (?) clocks

### DIFF
--- a/src/cargo/core/package.rs
+++ b/src/cargo/core/package.rs
@@ -934,7 +934,7 @@ impl<'a, 'cfg> Downloads<'a, 'cfg> {
         }
 
         // If we've spent too long not actually receiving any data we time out.
-        if now - self.updated_at.get() > self.timeout.dur {
+        if now > self.updated_at.get() + self.timeout.dur {
             self.updated_at.set(now);
             let msg = format!(
                 "failed to download any data for `{}` within {}s",


### PR DESCRIPTION
Try to avoid panics with `Instant` by only performing infallible
operations. This tweaks a comparison located in #8042 to use `Instant`
comparisons rather than `Duration` comparisons which should hopefully
eliminate a source of panics in the face of buggy (maybe?) clocks.

I'm not sure whether this actually fixes the original issue, but seeing
that we have a pretty low chance of the issue recurring, it's probably
fine to go ahead and say...

Closes #8042