### PR TITLE
Skip serializing missing target

### DIFF
--- a/crates/crates-io/lib.rs
+++ b/crates/crates-io/lib.rs
@@ -64,6 +64,7 @@ pub struct NewCrateDependency {
     pub name: String,
     pub features: Vec<String>,
     pub version_req: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub target: Option<String>,
     pub kind: String,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/tests/testsuite/alt_registry.rs
+++ b/tests/testsuite/alt_registry.rs
@@ -344,7 +344,6 @@ fn publish_with_registry_dependency() {
                 "kind": "normal",
                 "name": "bar",
                 "optional": false,
-                "target": null,
                 "version_req": "^0.0.1"
               }
             ],
@@ -506,7 +505,6 @@ fn publish_with_crates_io_dep() {
                 "name": "bar",
                 "optional": false,
                 "registry": "https://github.com/rust-lang/crates.io-index",
-                "target": null,
                 "version_req": "^0.0.1"
               }
             ],

--- a/tests/testsuite/publish.rs
+++ b/tests/testsuite/publish.rs
@@ -966,7 +966,6 @@ fn publish_with_patch() {
               "name": "bar",
               "optional": false,
               "registry": "https://github.com/rust-lang/crates.io-index",
-              "target": null,
               "version_req": "^1.0"
             }
           ],
@@ -1135,7 +1134,6 @@ fn publish_git_with_version() {
               "name": "dep1",
               "optional": false,
               "registry": "https://github.com/rust-lang/crates.io-index",
-              "target": null,
               "version_req": "^1.0"
             }
           ],


### PR DESCRIPTION
`"target":null` is unnecessarily increasing crates.io index size. When deserializing to `Option`, `serde_json` treats `null` and missing fields the same.