### PR TITLE
Don't use debug display for error object.

### DIFF
--- a/src/cargo/ops/cargo_doc.rs
+++ b/src/cargo/ops/cargo_doc.rs
@@ -104,10 +104,8 @@ fn open_docs(path: &Path, shell: &mut Shell) -> CargoResult<()> {
         }
         None => {
             if let Err(e) = opener::open(&path) {
-                shell.warn(format!("Couldn't open docs: {}", e))?;
-                for cause in anyhow::Error::new(e).chain().skip(1) {
-                    shell.warn(format!("Caused by:\n {}", cause))?;
-                }
+                let e = e.into();
+                crate::display_warning_with_error("couldn't open docs", &e, shell);
             }
         }
     };

--- a/src/cargo/ops/cargo_new.rs
+++ b/src/cargo/ops/cargo_new.rs
@@ -762,12 +762,12 @@ mod tests {
     }
 
     if let Err(e) = Workspace::new(&path.join("Cargo.toml"), config) {
-        let msg = format!(
+        crate::display_warning_with_error(
             "compiling this new crate may not work due to invalid \
-             workspace configuration\n\n{:?}",
-            e,
+             workspace configuration",
+            &e,
+            &mut config.shell(),
         );
-        config.shell().warn(msg)?;
     }
 
     Ok(())

--- a/tests/testsuite/workspaces.rs
+++ b/tests/testsuite/workspaces.rs
@@ -1037,8 +1037,7 @@ fn new_warns_you_this_will_not_work() {
         .env("USER", "foo")
         .with_stderr(
             "\
-warning: compiling this new crate may not work due to invalid workspace \
-configuration
+warning: compiling this new crate may not work due to invalid workspace configuration
 
 current package believes it's in a workspace when it's not:
 current: [..]
@@ -1065,8 +1064,10 @@ fn new_warning_with_corrupt_ws() {
 failed to parse manifest at `[..]foo/Cargo.toml`
 
 Caused by:
-    0: could not parse input as TOML
-    1: expected an equals, found eof at line 1 column 5
+  could not parse input as TOML
+
+Caused by:
+  expected an equals, found eof at line 1 column 5
      Created binary (application) `bar` package
 ",
         )


### PR DESCRIPTION
When `cargo new` displays a workspace validation warning, it was using the debug display which we probably shouldn't rely on.

This also consolidates a similar usage when `cargo doc --open` fails.

Closes #8118