### PR TITLE
Hint upgrading for future edition keys

### DIFF
--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -82,6 +82,11 @@ impl FromStr for Edition {
         match s {
             "2015" => Ok(Edition::Edition2015),
             "2018" => Ok(Edition::Edition2018),
+            s if s.parse().map_or(false, |y: u16| y > 2020 && y < 2050) => bail!(
+                "this version of Cargo is older than the `{}` edition, \
+                 and only supports `2015` and `2018` editions.",
+                s
+            ),
             s => bail!(
                 "supported edition values are `2015` or `2018`, but `{}` \
                  is unknown",

--- a/tests/testsuite/package.rs
+++ b/tests/testsuite/package.rs
@@ -1087,6 +1087,38 @@ Caused by:
 }
 
 #[cargo_test]
+fn test_edition_from_the_future() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"[package]
+                edition = "2038"
+                name = "foo"
+                version = "99.99.99"
+                authors = []
+            "#,
+        )
+        .file("src/main.rs", r#""#)
+        .build();
+
+    p.cargo("build")
+        .with_status(101)
+        .with_stderr(
+            "\
+error: failed to parse manifest at `[..]`
+
+Caused by:
+  failed to parse the `edition` key
+
+Caused by:
+  this version of Cargo is older than the `2038` edition, and only supports `2015` and `2018` editions.
+"
+            .to_string(),
+        )
+        .run();
+}
+
+#[cargo_test]
 fn do_not_package_if_src_was_modified() {
     let p = project()
         .file("src/main.rs", r#"fn main() { println!("hello"); }"#)


### PR DESCRIPTION
A more specific error message for potentially-future edition values. 

This error is likely to be seen by people who are not regular Rust users and are just trying to build someone's crate. It may be helpful to stronger hint at upgrading Cargo, rather than display a more general message about an unknown value.

I know Cargo plans to fix it better with explicit MSRV eventually, but that's not ready yet, so it's better to land something sooner.

