### PR TITLE
Fix pdb uplift when executable has dashes.

### DIFF
--- a/src/cargo/core/compiler/build_context/target_info.rs
+++ b/src/cargo/core/compiler/build_context/target_info.rs
@@ -292,7 +292,9 @@ impl TargetInfo {
                     suffix: ".pdb".to_string(),
                     prefix: prefix.clone(),
                     flavor: FileFlavor::DebugInfo,
-                    should_replace_hyphens: false,
+                    // rustc calls the linker with underscores, and the
+                    // filename is embedded in the executable.
+                    should_replace_hyphens: true,
                 })
             }
         }

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -4201,6 +4201,7 @@ fn uplift_pdb_of_bin_on_windows() {
     let p = project()
         .file("src/main.rs", "fn main() { panic!(); }")
         .file("src/bin/b.rs", "fn main() { panic!(); }")
+        .file("src/bin/foo-bar.rs", "fn main() { panic!(); }")
         .file("examples/c.rs", "fn main() { panic!(); }")
         .file("tests/d.rs", "fn main() { panic!(); }")
         .build();
@@ -4209,6 +4210,8 @@ fn uplift_pdb_of_bin_on_windows() {
     assert!(p.target_debug_dir().join("foo.pdb").is_file());
     assert!(p.target_debug_dir().join("b.pdb").is_file());
     assert!(p.target_debug_dir().join("examples/c.pdb").exists());
+    assert!(p.target_debug_dir().join("foo-bar.exe").is_file());
+    assert!(p.target_debug_dir().join("foo_bar.pdb").is_file());
     assert!(!p.target_debug_dir().join("c.pdb").exists());
     assert!(!p.target_debug_dir().join("d.pdb").exists());
 }


### PR DESCRIPTION
Windows `.pdb` files were not being uplifted for executables with dashes in their name. `rustc` calls the linker with the crate name (with underscores), which creates a pdb with underscores. Cargo renames the executable (`foo_bar.exe` to `foo-bar.exe`), and it was expecting the pdb to have the same form, but it doesn't.

Note: There shouldn't be any effect for using a debugger. Because the pdb path is embedded in the executable, the debugger was already looking in the `deps/` folder.  Uplifting is only useful if you want to copy the exe/pdb pair to some other machine.  In that case, it looks in the same directory as the `exe` for the pdb file.

Fixes #8117
