### PR TITLE
Added warning when using restricted names in Windows.

### DIFF
--- a/src/cargo/ops/cargo_package.rs
+++ b/src/cargo/ops/cargo_package.rs
@@ -823,25 +823,12 @@ fn check_filename(file: &Path, shell: &mut Shell) -> CargoResult<()> {
             file.display()
         )
     }
-    let mut check_windows = |name| -> CargoResult<()> {
-        if restricted_names::is_windows_reserved(name) {
-            shell.warn(format!(
-                "file {} is a reserved Windows filename, \
+    if restricted_names::is_windows_reserved_path(file) {
+        shell.warn(format!(
+            "file {} is a reserved Windows filename, \
                 it will not work on Windows platforms",
-                file.display()
-            ))?;
-        }
-        Ok(())
-    };
-    for component in file.iter() {
-        if let Some(component) = component.to_str() {
-            check_windows(component)?;
-        }
-    }
-    if file.extension().is_some() {
-        if let Some(stem) = file.file_stem().and_then(|s| s.to_str()) {
-            check_windows(stem)?;
-        }
+            file.display()
+        ))?;
     }
     Ok(())
 }

--- a/src/cargo/util/restricted_names.rs
+++ b/src/cargo/util/restricted_names.rs
@@ -2,6 +2,7 @@
 
 use crate::util::CargoResult;
 use anyhow::bail;
+use std::path::Path;
 
 /// Returns `true` if the name contains non-ASCII characters.
 pub fn is_non_ascii_name(name: &str) -> bool {
@@ -80,4 +81,14 @@ pub fn validate_package_name(name: &str, what: &str, help: &str) -> CargoResult<
         }
     }
     Ok(())
+}
+
+// Check the entire path for names reserved in Windows.
+pub fn is_windows_reserved_path(path: &Path) -> bool {
+    path.iter()
+        .filter_map(|component| component.to_str())
+        .any(|component| {
+            let stem = component.split('.').next().unwrap();
+            is_windows_reserved(stem)
+        })
 }


### PR DESCRIPTION
The implementation could have been better. I think there ought to be a way to only use the views into the `OsString` instead of creating a new one. I am new to Rust so any pointer will help ^^