### PR TITLE
Improve error message when running `cargo install .`

### DIFF
--- a/src/cargo/ops/cargo_install.rs
+++ b/src/cargo/ops/cargo_install.rs
@@ -146,6 +146,15 @@ fn install_one(
     no_track: bool,
     is_first_install: bool,
 ) -> CargoResult<()> {
+    if let Some(name) = krate {
+        if name == "." {
+            bail!(
+                "To install the binaries for the package in current working \
+                 directory use `cargo install --path .`. \
+                 Use `cargo build` if you want to simply build the package."
+            )
+        }
+    }
     let pkg = if source_id.is_git() {
         select_pkg(
             GitSource::new(source_id, config)?,

--- a/tests/testsuite/install.rs
+++ b/tests/testsuite/install.rs
@@ -152,6 +152,20 @@ fn missing() {
 }
 
 #[cargo_test]
+fn missing_current_working_directory() {
+    cargo_process("install .")
+        .with_status(101)
+        .with_stderr(
+            "\
+error: To install the binaries for the package in current working \
+directory use `cargo install --path .`. Use `cargo build` if you \
+want to simply build the package.
+",
+        )
+        .run();
+}
+
+#[cargo_test]
 fn bad_version() {
     pkg("foo", "0.0.1");
     cargo_process("install foo --vers=0.2.0")


### PR DESCRIPTION
Existing error:

```
$ cargo install .
    Updating crates.io index
error: could not find `.` in registry `https://github.com/rust-lang/crates.io-index`
```

New error:

```
$ cargo install .
error: To install the binaries for the package in current working directory use `cargo install --path .`. Use `cargo build` if you want to simply build the package.
```

Existing related errors:

```
$ cargo install
error: Using `cargo install` to install the binaries for the package in current working directory is no longer supported, use `cargo install --path .` instead. Use `cargo build` if you want to simply build the package.
$ cargo uninstall .
error: invalid package ID specification: `.`

Caused by:
  Invalid character `.` in pkgid: `.`
```