### PR TITLE
fix mem replace unused

### DIFF
--- a/src/cargo/sources/git/utils.rs
+++ b/src/cargo/sources/git/utils.rs
@@ -11,7 +11,6 @@ use serde::Serialize;
 use std::env;
 use std::fmt;
 use std::fs::File;
-use std::mem;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use url::Url;
@@ -838,7 +837,7 @@ fn maybe_gc_repo(repo: &mut git2::Repository) -> CargoResult<()> {
             );
             if out.status.success() {
                 let new = git2::Repository::open(repo.path())?;
-                let _ = mem::replace(repo, new);
+                *repo = new;
                 return Ok(());
             }
         }

--- a/src/cargo/sources/git/utils.rs
+++ b/src/cargo/sources/git/utils.rs
@@ -838,7 +838,7 @@ fn maybe_gc_repo(repo: &mut git2::Repository) -> CargoResult<()> {
             );
             if out.status.success() {
                 let new = git2::Repository::open(repo.path())?;
-                mem::replace(repo, new);
+                let _ = mem::replace(repo, new);
                 return Ok(());
             }
         }


### PR DESCRIPTION
`mem::replace` will be linted as must_use, so modifying this.

This is currently blocking https://github.com/rust-lang/rust/pull/71256