### PR TITLE
Add windows-gnu CI and fix tests

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -41,6 +41,9 @@ jobs:
       x86_64-msvc:
         TOOLCHAIN: stable-x86_64-pc-windows-msvc
         OTHER_TARGET: i686-pc-windows-msvc
+      x86_64-gnu:
+        TOOLCHAIN: nightly-x86_64-pc-windows-gnu
+        OTHER_TARGET: i686-pc-windows-gnu
 
 - job: rustfmt
   pool:

--- a/ci/azure-install-rust.yml
+++ b/ci/azure-install-rust.yml
@@ -4,7 +4,7 @@ steps:
       rustup set profile minimal
       rustup component remove --toolchain=$TOOLCHAIN rust-docs || echo "already removed"
       rustup update --no-self-update $TOOLCHAIN
-      if [ "$TOOLCHAIN" = "nightly" ]; then
+      if [[ "$TOOLCHAIN" == "nightly"* ]]; then
         rustup component add --toolchain=$TOOLCHAIN rustc-dev
       fi
       rustup default $TOOLCHAIN

--- a/crates/cargo-test-support/src/cross_compile.rs
+++ b/crates/cargo-test-support/src/cross_compile.rs
@@ -190,6 +190,8 @@ pub fn alternate() -> &'static str {
         "i686-unknown-linux-gnu"
     } else if cfg!(all(target_os = "windows", target_env = "msvc")) {
         "i686-pc-windows-msvc"
+    } else if cfg!(all(target_os = "windows", target_env = "gnu")) {
+        "i686-pc-windows-gnu"
     } else {
         panic!("This test should be gated on cross_compile::disabled.");
     }

--- a/src/cargo/core/compiler/context/compilation_files.rs
+++ b/src/cargo/core/compiler/context/compilation_files.rs
@@ -332,7 +332,7 @@ impl<'a, 'cfg: 'a> CompilationFiles<'a, 'cfg> {
         // we don't want to link it up.
         if out_dir.ends_with("deps") {
             // Don't lift up library dependencies.
-            if unit.target.is_bin() || self.roots.contains(unit) {
+            if unit.target.is_bin() || self.roots.contains(unit) || unit.target.is_dylib() {
                 Some((
                     out_dir.parent().unwrap().to_owned(),
                     if unit.mode.is_any_test() {

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -3769,7 +3769,11 @@ fn cdylib_not_lifted() {
     p.cargo("build").run();
 
     let files = if cfg!(windows) {
-        vec!["foo.dll.lib", "foo.dll.exp", "foo.dll"]
+        if cfg!(target_env = "msvc") {
+            vec!["foo.dll.lib", "foo.dll.exp", "foo.dll"]
+        } else {
+            vec!["libfoo.dll.a", "foo.dll"]
+        }
     } else if cfg!(target_os = "macos") {
         vec!["libfoo.dylib"]
     } else {
@@ -3803,7 +3807,12 @@ fn cdylib_final_outputs() {
     p.cargo("build").run();
 
     let files = if cfg!(windows) {
-        vec!["foo_bar.dll.lib", "foo_bar.dll"]
+        if cfg!(target_env = "msvc") {
+            vec!["foo_bar.dll.lib", "foo_bar.dll"]
+        } else {
+            // FIXME https://github.com/rust-lang/cargo/pull/6875
+            vec!["foo_bar.dll"]
+        }
     } else if cfg!(target_os = "macos") {
         vec!["libfoo_bar.dylib"]
     } else {

--- a/tests/testsuite/build_script.rs
+++ b/tests/testsuite/build_script.rs
@@ -1663,7 +1663,8 @@ fn build_script_with_dynamic_native_dependency() {
                 let src = root.join(&file);
                 let dst = out_dir.join(&file);
                 fs::copy(src, dst).unwrap();
-                if cfg!(windows) {
+                // FIXME https://github.com/rust-lang/cargo/pull/6875
+                if cfg!(target_env = "msvc") {
                     fs::copy(root.join("builder.dll.lib"),
                              out_dir.join("builder.dll.lib")).unwrap();
                 }

--- a/tests/testsuite/out_dir.rs
+++ b/tests/testsuite/out_dir.rs
@@ -20,6 +20,7 @@ fn binary_with_debug() {
         &["foo"],
         &["foo", "foo.dSYM"],
         &["foo.exe", "foo.pdb"],
+        &["foo.exe"],
     );
 }
 
@@ -55,6 +56,7 @@ fn static_library_with_debug() {
         &["libfoo.a"],
         &["libfoo.a"],
         &["foo.lib"],
+        &["libfoo.a"],
     );
 }
 
@@ -90,6 +92,8 @@ fn dynamic_library_with_debug() {
         &["libfoo.so"],
         &["libfoo.dylib"],
         &["foo.dll", "foo.dll.lib"],
+        // FIXME https://github.com/rust-lang/cargo/pull/6875
+        &["foo.dll"],
     );
 }
 
@@ -121,6 +125,7 @@ fn rlib_with_debug() {
         .run();
     check_dir_contents(
         &p.root().join("out"),
+        &["libfoo.rlib"],
         &["libfoo.rlib"],
         &["libfoo.rlib"],
         &["libfoo.rlib"],
@@ -167,6 +172,7 @@ fn include_only_the_binary_from_the_current_package() {
         &["foo"],
         &["foo", "foo.dSYM"],
         &["foo.exe", "foo.pdb"],
+        &["foo.exe"],
     );
 }
 
@@ -242,6 +248,7 @@ fn avoid_build_scripts() {
         &["a", "b"],
         &["a", "a.dSYM", "b", "b.dSYM"],
         &["a.exe", "a.pdb", "b.exe", "b.pdb"],
+        &["a.exe", "b.exe"],
     );
 }
 
@@ -266,6 +273,7 @@ fn cargo_build_out_dir() {
         &["foo"],
         &["foo", "foo.dSYM"],
         &["foo.exe", "foo.pdb"],
+        &["foo.exe"],
     );
 }
 
@@ -273,10 +281,15 @@ fn check_dir_contents(
     out_dir: &Path,
     expected_linux: &[&str],
     expected_mac: &[&str],
-    expected_win: &[&str],
+    expected_win_msvc: &[&str],
+    expected_win_gnu: &[&str],
 ) {
     let expected = if cfg!(target_os = "windows") {
-        expected_win
+        if cfg!(target_env = "msvc") {
+            expected_win_msvc
+        } else {
+            expected_win_gnu
+        }
     } else if cfg!(target_os = "macos") {
         expected_mac
     } else {

--- a/tests/testsuite/plugins.rs
+++ b/tests/testsuite/plugins.rs
@@ -180,7 +180,8 @@ fn plugin_with_dynamic_native_dependency() {
                 let src = root.join(&file);
                 let dst = out_dir.join(&file);
                 fs::copy(src, dst).unwrap();
-                if cfg!(windows) {
+                // FIXME https://github.com/rust-lang/cargo/pull/6875
+                    if cfg!(target_env = "msvc") {
                     fs::copy(root.join("builder.dll.lib"),
                              out_dir.join("builder.dll.lib")).unwrap();
                 }

--- a/tests/testsuite/standard_lib.rs
+++ b/tests/testsuite/standard_lib.rs
@@ -21,6 +21,12 @@ fn setup() -> Option<Setup> {
         return None;
     }
 
+    if cfg!(all(target_os = "windows", target_env = "gnu")) {
+        // FIXME: contains object files that we don't handle yet:
+        // https://github.com/rust-lang/wg-cargo-std-aware/issues/46
+        return None;
+    }
+
     // Our mock sysroot requires a few packages from crates.io, so make sure
     // they're "published" to crates.io. Also edit their code a bit to make sure
     // that they have access to our custom crates with custom apis.


### PR DESCRIPTION
One remaining failure:
```
---- features::feature_off_dylib stdout ----
running `d:\a\1\s\target\debug\cargo.exe build --features f1`
running `d:\a\1\s\target\debug\cargo.exe run -p bar`
thread 'features::feature_off_dylib' panicked at '
Expected: execs
    but: exited with exit code: 101
--- stdout

--- stderr
   Compiling foo v0.0.1 (D:\a\1\s\target\cit\t663\foo)
   Compiling bar v0.0.1 (D:\a\1\s\target\cit\t663\foo\bar)
    Finished dev [unoptimized + debuginfo] target(s) in 0.69s
     Running `target\debug\bar.exe`
thread 'main' panicked at 'assertion failed: `(left == right)`
  left: `"f1"`,
 right: `"no f1"`', bar\src\main.rs:5:17
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
error: process didn't exit successfully: `target\debug\bar.exe` (exit code: 101)
', crates\cargo-test-support\src\lib.rs:833:13
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    features::feature_off_dylib
```

I disassembled the dylibs and `cargo run -p bar` correctly rebuilt it inside `target/debug/deps/` but did not copy it to `target/debug`. To further confirm, calling `cp target/debug/deps/foo.dll target/debug/` manually solved the issue.
Any idea?

----

I left `FIXME` in places where import lib should be added with https://github.com/rust-lang/cargo/pull/6875.

`TOOLCHAIN: nightly-x86_64-pc-windows-gnu` can be replaced with beta on Thursday.