### PR TITLE
Re-enable rustc-info-cache test again

### DIFF
--- a/tests/testsuite/rustc_info_cache.rs
+++ b/tests/testsuite/rustc_info_cache.rs
@@ -6,9 +6,9 @@ use std::env;
 
 #[cargo_test]
 fn rustc_info_cache() {
-    // TODO: need to gate this on nightly as soon as -Cbitcode-in-rlib lands in
-    // nightly
-    if true {
+    // Needs `-Cbitcode-in-rlib` to ride to stable before this can be enabled
+    // everywhere.
+    if !cargo_test_support::is_nightly() {
         return;
     }
 


### PR DESCRIPTION
Support for `-Cbitcode-in-rlib` is now on nightly!