### PR TITLE
Mention that cargo_metadata can parse json messages

### DIFF
--- a/src/doc/src/reference/external-tools.md
+++ b/src/doc/src/reference/external-tools.md
@@ -48,7 +48,11 @@ alter the way the JSON messages are computed and rendered. See the description
 of the `--message-format` option in the [build command documentation] for more
 details.
 
+If you are using Rust, the [cargo_metadata] crate can be used to parse these
+messages.
+
 [build command documentation]: ../commands/cargo-build.md
+[cargo_metadata]: https://crates.io/crates/cargo_metadata
 
 #### Compiler messages
 


### PR DESCRIPTION
Prompted by https://github.com/rust-lang/cargo/issues/8142, this updates the documentation to mention that cargo_metadata can parse the external JSON messages emitted when the `--message-format=json` option is set.
