### PR TITLE
Clear `RUSTDOCFLAGS` before running tests

### DIFF
--- a/crates/cargo-test-support/src/lib.rs
+++ b/crates/cargo-test-support/src/lib.rs
@@ -1723,6 +1723,7 @@ fn _process(t: &OsStr) -> cargo::util::ProcessBuilder {
         .env_remove("RUSTDOC")
         .env_remove("RUSTC_WRAPPER")
         .env_remove("RUSTFLAGS")
+        .env_remove("RUSTDOCFLAGS")
         .env_remove("XDG_CONFIG_HOME") // see #2345
         .env("GIT_CONFIG_NOSYSTEM", "1") // keep trying to sandbox ourselves
         .env_remove("EMAIL")


### PR DESCRIPTION
It turns out that this test will fail if `RUSTDOCFLAGS` is set in the test runner. This was found in
https://github.com/rust-lang/rust/pull/71458#issuecomment-619101858 when that PR attempted to set the proper `RUSTDOCFLAGS` to enable `./x.py doc --stage 0 src/libstd`. Run the test with no `RUSTDOCFLAGS` so that the config file always gets used.