### PR TITLE
Fix warning for `resolve` mismatch in workspace.

### DIFF
--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -792,7 +792,9 @@ impl<'cfg> Workspace<'cfg> {
                 if !manifest.patch().is_empty() {
                     emit_warning("patch")?;
                 }
-                if manifest.resolve_behavior() != self.resolve_behavior {
+                if manifest.resolve_behavior().is_some()
+                    && manifest.resolve_behavior() != self.resolve_behavior
+                {
                     // Only warn if they don't match.
                     emit_warning("resolver")?;
                 }

--- a/tests/testsuite/features2.rs
+++ b/tests/testsuite/features2.rs
@@ -1592,6 +1592,17 @@ fn resolver_enables_new_features() {
     p.cargo("run --bin a")
         .masquerade_as_nightly_cargo()
         .env("EXPECTED_FEATS", "1")
+        .with_stderr(
+            "\
+[UPDATING] [..]
+[DOWNLOADING] crates ...
+[DOWNLOADED] common [..]
+[COMPILING] common v1.0.0
+[COMPILING] a v0.1.0 [..]
+[FINISHED] [..]
+[RUNNING] `target/debug/a[EXE]`
+",
+        )
         .run();
 
     // only normal+dev


### PR DESCRIPTION
Using the new `resolve` field would cause a warning in a workspace that the member's resolve setting will be ignored, even if it is not set. 

`warning: resolver for the non root package will be ignored, specify resolver at the workspace root:`

The code should only check the package member if the member's value is set.
