### PR TITLE
Allow failure when setting file mtime.

### DIFF
--- a/src/cargo/core/compiler/custom_build.rs
+++ b/src/cargo/core/compiler/custom_build.rs
@@ -387,12 +387,9 @@ fn build_work(cx: &mut Context<'_, '_>, unit: &Unit) -> CargoResult<Job> {
         // state informing what variables were discovered via our script as
         // well.
         paths::write(&output_file, &output.stdout)?;
-        log::debug!(
-            "rewinding custom script output mtime {:?} to {}",
-            output_file,
-            timestamp
-        );
-        filetime::set_file_times(output_file, timestamp, timestamp)?;
+        // This mtime shift allows Cargo to detect if a source file was
+        // modified in the middle of the build.
+        paths::set_file_time_no_err(output_file, timestamp);
         paths::write(&err_file, &output.stderr)?;
         paths::write(&root_output_file, util::path2bytes(&script_out_dir)?)?;
         let parsed_output =

--- a/src/cargo/core/compiler/fingerprint.rs
+++ b/src/cargo/core/compiler/fingerprint.rs
@@ -1537,7 +1537,7 @@ fn compare_old_fingerprint(
         // update the mtime so other cleaners know we used it
         let t = FileTime::from_system_time(SystemTime::now());
         debug!("mtime-on-use forcing {:?} to {}", loc, t);
-        filetime::set_file_times(loc, t, t)?;
+        paths::set_file_time_no_err(loc, t);
     }
 
     let new_hash = new_fingerprint.hash();

--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -321,8 +321,9 @@ fn rustc(cx: &mut Context<'_, '_>, unit: &Unit, exec: &Arc<dyn Executor>) -> Car
                     rustc_dep_info_loc.display()
                 ))
             })?;
-            debug!("rewinding mtime of {:?} to {}", dep_info_loc, timestamp);
-            filetime::set_file_times(dep_info_loc, timestamp, timestamp)?;
+            // This mtime shift allows Cargo to detect if a source file was
+            // modified in the middle of the build.
+            paths::set_file_time_no_err(dep_info_loc, timestamp);
         }
 
         Ok(())

--- a/src/cargo/util/paths.rs
+++ b/src/cargo/util/paths.rs
@@ -393,3 +393,21 @@ fn _link_or_copy(src: &Path, dst: &Path) -> CargoResult<()> {
         })?;
     Ok(())
 }
+
+/// Changes the filesystem mtime (and atime if possible) for the given file.
+///
+/// This intentionally does not return an error, as this is sometimes not
+/// supported on network filesystems. For the current uses in Cargo, this is a
+/// "best effort" approach, and errors shouldn't be propagated.
+pub fn set_file_time_no_err<P: AsRef<Path>>(path: P, time: FileTime) {
+    let path = path.as_ref();
+    match filetime::set_file_times(path, time, time) {
+        Ok(()) => log::debug!("set file mtime {} to {}", path.display(), time),
+        Err(e) => log::warn!(
+            "could not set mtime of {} to {}: {:?}",
+            path.display(),
+            time,
+            e
+        ),
+    }
+}


### PR DESCRIPTION
Some filesystems do not allow changing file mtimes (most recent example is a Windows mount in WSL). Since these operations are not critical to Cargo's operation, errors should probably just be ignored. (Currently they are used for mid-build modification protection, and the unstable mtime-on-use).

Fixes #8184