### PR TITLE
Fix error with git repo discovery and symlinks.

### DIFF
--- a/src/cargo/util/paths.rs
+++ b/src/cargo/util/paths.rs
@@ -411,3 +411,25 @@ pub fn set_file_time_no_err<P: AsRef<Path>>(path: P, time: FileTime) {
         ),
     }
 }
+
+/// Strips `base` from `path`.
+///
+/// This canonicalizes both paths before stripping. This is useful if the
+/// paths are obtained in different ways, and one or the other may or may not
+/// have been normalized in some way.
+pub fn strip_prefix_canonical<P: AsRef<Path>>(
+    path: P,
+    base: P,
+) -> Result<PathBuf, std::path::StripPrefixError> {
+    // Not all filesystems support canonicalize. Just ignore if it doesn't work.
+    let safe_canonicalize = |path: &Path| match path.canonicalize() {
+        Ok(p) => p,
+        Err(e) => {
+            log::warn!("cannot canonicalize {:?}: {:?}", path, e);
+            path.to_path_buf()
+        }
+    };
+    let canon_path = safe_canonicalize(path.as_ref());
+    let canon_base = safe_canonicalize(base.as_ref());
+    canon_path.strip_prefix(canon_base).map(|p| p.to_path_buf())
+}


### PR DESCRIPTION
There are some cases where Cargo would generate an error when attempting to discover if a package is inside a git repo when the git repo has a symlink somewhere in its ancestor paths. One way this manifests is with `cargo install --git ...` where the given repo has a `build.rs` script. Another scenario is `cargo build --manifest-path somelink/Cargo.toml` where `somelink` is a symlink to the real thing.

The issue is that libgit2 is normalizing paths and removing symlinks, but the path Cargo uses is the path with symlinks. This was introduced in #8095.

The solution is to try to canonicalize both paths when trying to get a repo-relative path. If that fails for whatever reason, it shouldn't generate an error since this is just a "best effort" attempt to use git to list package files.

Fixes #8183
