### PR TITLE
Add option to strip binaries

### DIFF
--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -748,6 +748,7 @@ fn build_base_args(
         rpath,
         ref panic,
         incremental,
+        strip,
         ..
     } = unit.profile;
     let test = unit.mode.is_any_test();
@@ -917,6 +918,10 @@ fn build_base_args(
     if incremental {
         let dir = cx.files().layout(unit.kind).incremental().as_os_str();
         opt(cmd, "-C", "incremental=", Some(dir));
+    }
+
+    if strip {
+        opt(cmd, "-C", "link-arg=", Some(OsStr::new("-s")));
     }
 
     if unit.is_std {

--- a/src/cargo/core/profiles.rs
+++ b/src/cargo/core/profiles.rs
@@ -565,6 +565,9 @@ fn merge_profile(profile: &mut Profile, toml: &TomlProfile) {
     if let Some(incremental) = toml.incremental {
         profile.incremental = incremental;
     }
+    if let Some(strip) = toml.strip {
+        profile.strip = strip;
+    }
 }
 
 /// The root profile (dev/release).
@@ -595,6 +598,7 @@ pub struct Profile {
     pub rpath: bool,
     pub incremental: bool,
     pub panic: PanicStrategy,
+    pub strip: bool,
 }
 
 impl Default for Profile {
@@ -611,6 +615,7 @@ impl Default for Profile {
             rpath: false,
             incremental: false,
             panic: PanicStrategy::Unwind,
+            strip: false,
         }
     }
 }
@@ -635,6 +640,7 @@ compact_debug! {
                 rpath
                 incremental
                 panic
+                strip
             )]
         }
     }
@@ -721,6 +727,7 @@ impl Profile {
         bool,
         bool,
         PanicStrategy,
+        bool,
     ) {
         (
             self.opt_level,
@@ -732,6 +739,7 @@ impl Profile {
             self.rpath,
             self.incremental,
             self.panic,
+            self.strip,
         )
     }
 }

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -407,6 +407,7 @@ pub struct TomlProfile {
     pub build_override: Option<Box<TomlProfile>>,
     pub dir_name: Option<InternedString>,
     pub inherits: Option<InternedString>,
+    pub strip: Option<bool>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Ord, PartialOrd, Hash)]
@@ -640,6 +641,10 @@ impl TomlProfile {
 
         if let Some(v) = &profile.dir_name {
             self.dir_name = Some(*v);
+        }
+
+        if let Some(v) = profile.strip {
+            self.strip = Some(v);
         }
     }
 }


### PR DESCRIPTION
I want to help add an option to Cargo to **strip symbols** from built binaries. Currently this PR just adds a linker flag, as suggested [in this comment](https://github.com/rust-lang/cargo/issues/3483#issuecomment-431209957).

Questions for reviewers:

- I've tried looking at the existing code to add a new `Cargo.toml` option, and I've added this to the `[profile.*]` section. Please tell me if it would be better to move it somewhere else.
 
- How do we handle this on non-*NIX/non-`ld` platforms? I'm guessing we'll need to detect the configured linker for the respective platform.

- How do we test this? I could add a test for the config option, but a real test would check that the produced binaries _are_ stripped.

If merged, this closes #3483.