### PR TITLE
features: allow activated_features_unverified to communicate not-present

### DIFF
--- a/src/cargo/ops/cargo_clean.rs
+++ b/src/cargo/ops/cargo_clean.rs
@@ -129,8 +129,9 @@ pub fn clean(ws: &Workspace<'_>, opts: &CleanOptions<'_>) -> CargoResult<()> {
                         // Use unverified here since this is being more
                         // exhaustive than what is actually needed.
                         let features_for = unit_for.map_to_features_for();
-                        let features =
-                            features.activated_features_unverified(pkg.package_id(), features_for);
+                        let features = features
+                            .activated_features_unverified(pkg.package_id(), features_for)
+                            .unwrap_or_default();
                         units.push(interner.intern(
                             pkg, target, profile, *kind, *mode, features, /*is_std*/ false,
                         ));

--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -978,7 +978,10 @@ pub fn resolve_all_features(
             .proc_macro();
         for dep in deps {
             let features_for = FeaturesFor::from_for_host(is_proc_macro || dep.is_build());
-            for feature in resolved_features.activated_features_unverified(dep_id, features_for) {
+            for feature in resolved_features
+                .activated_features_unverified(dep_id, features_for)
+                .unwrap_or_default()
+            {
                 features.insert(format!("{}/{}", dep.name_in_toml(), feature));
             }
         }


### PR DESCRIPTION
Hi there! :)

I'm currently writing [`cargo-guppy`](https://github.com/facebookincubator/cargo-guppy), a toolkit for analyzing Rust dependency graphs. As part of that I'm writing some tests to compare guppy to `cargo` (see https://github.com/facebookincubator/cargo-guppy/pull/126), to ensure that it produces the same results for the subset of analyses `cargo` can do.

While writing tests I found it useful to distinguish between packages that weren't present at all and packages that were activated but with no features. This commit adds that functionality to the `_unverified` method.

(BTW, of possible interest to @ehuss, I've also found some interesting behavior differences between the v1 and v2 resolvers. Will file issues for them soon!)