### PR TITLE
Rephrased error message for disallowed sections in virtual workspace

### DIFF
--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -1320,43 +1320,43 @@ impl TomlManifest {
         config: &Config,
     ) -> CargoResult<(VirtualManifest, Vec<PathBuf>)> {
         if me.project.is_some() {
-            bail!("virtual manifests do not define [project]");
+            bail!("this virtual manifest specifies a [project] section, which is not allowed");
         }
         if me.package.is_some() {
-            bail!("virtual manifests do not define [package]");
+            bail!("this virtual manifest specifies a [package] section, which is not allowed");
         }
         if me.lib.is_some() {
-            bail!("virtual manifests do not specify [lib]");
+            bail!("this virtual manifest specifies a [lib] section, which is not allowed");
         }
         if me.bin.is_some() {
-            bail!("virtual manifests do not specify [[bin]]");
+            bail!("this virtual manifest specifies a [[bin]] section, which is not allowed");
         }
         if me.example.is_some() {
-            bail!("virtual manifests do not specify [[example]]");
+            bail!("this virtual manifest specifies a [[example]] section, which is not allowed");
         }
         if me.test.is_some() {
-            bail!("virtual manifests do not specify [[test]]");
+            bail!("this virtual manifest specifies a [[test]] section, which is not allowed");
         }
         if me.bench.is_some() {
-            bail!("virtual manifests do not specify [[bench]]");
+            bail!("this virtual manifest specifies a [[bench]] section, which is not allowed");
         }
         if me.dependencies.is_some() {
-            bail!("virtual manifests do not specify [dependencies]");
+            bail!("this virtual manifest specifies a [dependencies] section, which is not allowed");
         }
         if me.dev_dependencies.is_some() || me.dev_dependencies2.is_some() {
-            bail!("virtual manifests do not specify [dev-dependencies]");
+            bail!("this virtual manifest specifies a [dev-dependencies] section, which is not allowed");
         }
         if me.build_dependencies.is_some() || me.build_dependencies2.is_some() {
-            bail!("virtual manifests do not specify [build-dependencies]");
+            bail!("this virtual manifest specifies a [build-dependencies] section, which is not allowed");
         }
         if me.features.is_some() {
-            bail!("virtual manifests do not specify [features]");
+            bail!("this virtual manifest specifies a [features] section, which is not allowed");
         }
         if me.target.is_some() {
-            bail!("virtual manifests do not specify [target]");
+            bail!("this virtual manifest specifies a [target] section, which is not allowed");
         }
         if me.badges.is_some() {
-            bail!("virtual manifests do not specify [badges]");
+            bail!("this virtual manifest specifies a [badges] section, which is not allowed");
         }
 
         let mut nested_paths = Vec::new();

--- a/tests/testsuite/workspaces.rs
+++ b/tests/testsuite/workspaces.rs
@@ -2117,7 +2117,7 @@ fn ws_err_unused() {
 [ERROR] failed to parse manifest at `[..]/foo/Cargo.toml`
 
 Caused by:
-  virtual manifests do not specify {}
+  this virtual manifest specifies a {} section, which is not allowed
 ",
                 key
             ))


### PR DESCRIPTION
I changed the error message from `virtual manifests do not specify [target]` to `This virtual manifest specifies a [target] section, which is not allowed` because the old one confused me.

I encountered it while hacking on Rustc in CLion. I made a change to the `Cargo.toml` I had copied from StackOverflow and after the next restart code analysis and go-to-definition stopped working. After some fiddling, I tracked that down to my change in `Cargo.toml`. It took me a while because, like I said, the error message from CLion didn't make sense to me.
```
19:13	Cargo project update failed:
	Execution failed (exit code 101).
	        /home/julian/.cargo/bin/cargo metadata --verbose --format-version 1 --all-features
	        stdout : error: failed to parse manifest at `/home/julian/Dokumente/Rust/Compiler/rust/Cargo.toml`
	
	Caused by:
	  virtual manifests do not specify [target]
	
	        stderr : 
```

I hope this change avoids future confusion :)