### PR TITLE
[beta] Do not probe for `-Cembed-bitcode` 

### DIFF
--- a/src/cargo/core/compiler/build_context/target_info.rs
+++ b/src/cargo/core/compiler/build_context/target_info.rs
@@ -105,12 +105,7 @@ impl TargetInfo {
             .args(&rustflags)
             .env_remove("RUSTC_LOG");
 
-        let mut embed_bitcode_test = process.clone();
-        embed_bitcode_test.arg("-Cembed-bitcode");
-        let supports_embed_bitcode = match kind {
-            CompileKind::Host => Some(rustc.cached_output(&embed_bitcode_test).is_ok()),
-            _ => None,
-        };
+        let supports_embed_bitcode = Some(false);
 
         if let CompileKind::Target(target) = kind {
             process.arg("--target").arg(target.rustc_target());

--- a/src/cargo/sources/git/utils.rs
+++ b/src/cargo/sources/git/utils.rs
@@ -11,7 +11,6 @@ use serde::Serialize;
 use std::env;
 use std::fmt;
 use std::fs::File;
-use std::mem;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use url::Url;
@@ -838,7 +837,7 @@ fn maybe_gc_repo(repo: &mut git2::Repository) -> CargoResult<()> {
             );
             if out.status.success() {
                 let new = git2::Repository::open(repo.path())?;
-                mem::replace(repo, new);
+                *repo = new;
                 return Ok(());
             }
         }


### PR DESCRIPTION


This flag didn't make it to the beta branch of rustc, so remove the
probe here in Cargo. This is intended to be a very small patch to remove
the probe, since the real support is updated on master and will replace
this eventually anyway.

