### PR TITLE
Fix erroring when explicitly using "--features default" without  specifying one in Cargo.toml

### DIFF
--- a/src/cargo/core/resolver/dep_cache.rs
+++ b/src/cargo/core/resolver/dep_cache.rs
@@ -265,6 +265,8 @@ pub fn resolve_features<'b>(
     let reqs = build_requirements(s, opts)?;
     let mut ret = Vec::new();
     let mut used_features = HashSet::new();
+    // Add `default` as a feature that must exist.
+    used_features.insert("default".into());
     let default_dep = (false, BTreeSet::new());
 
     // Next, collect all actually enabled dependencies and their features.

--- a/tests/testsuite/features.rs
+++ b/tests/testsuite/features.rs
@@ -2113,3 +2113,24 @@ fn slash_optional_enables() {
 
     p.cargo("check --features dep/feat").run();
 }
+
+#[cargo_test]
+fn default_feature() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [project]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+            edition = "2018"
+            
+            [dependencies]
+        "#,
+        )
+        .file("src/main.rs", "fn main() { println!(\"hello\"); }")
+        .build();
+
+    p.cargo("build --features default").with_status(0).run();
+}


### PR DESCRIPTION
Also added a regression test for this.

This will likely cause a problem if a crate specify a "default" feature.

Related: #8164


Edit: This solutions feels clumsy at best xD