### PR TITLE
Document that bench is unstable in the man page.

### DIFF
--- a/src/doc/man/cargo-bench.adoc
+++ b/src/doc/man/cargo-bench.adoc
@@ -36,6 +36,16 @@ The libtest harness may be disabled by setting `harness = false` in the target
 manifest settings, in which case your code will need to provide its own `main`
 function to handle running benchmarks.
 
+
+> **Note**: The
+> link:https://doc.rust-lang.org/nightly/unstable-book/library-features/test.html[`#[bench\]` attribute]
+> is currently unstable and only available on the
+> link:https://doc.rust-lang.org/book/appendix-07-nightly-rust.html[nightly channel].
+> There are some packages available on
+> link:https://crates.io/keywords/benchmark[crates.io] that may help with
+> running benchmarks on the stable channel, such as
+> link:https://crates.io/crates/criterion[Criterion].
+
 == OPTIONS
 
 === Benchmark Options

--- a/src/doc/man/generated/cargo-bench.html
+++ b/src/doc/man/generated/cargo-bench.html
@@ -42,6 +42,20 @@ the test harness to tell it to run only benchmarks.</p>
 manifest settings, in which case your code will need to provide its own <code>main</code>
 function to handle running benchmarks.</p>
 </div>
+<div class="quoteblock">
+<blockquote>
+<div class="paragraph">
+<p><strong>Note</strong>: The
+<a href="https://doc.rust-lang.org/nightly/unstable-book/library-features/test.html"><code>#[bench]</code> attribute</a>
+is currently unstable and only available on the
+<a href="https://doc.rust-lang.org/book/appendix-07-nightly-rust.html">nightly channel</a>.
+There are some packages available on
+<a href="https://crates.io/keywords/benchmark">crates.io</a> that may help with
+running benchmarks on the stable channel, such as
+<a href="https://crates.io/crates/criterion">Criterion</a>.</p>
+</div>
+</blockquote>
+</div>
 </div>
 </div>
 <div class="sect1">

--- a/src/etc/man/cargo-bench.1
+++ b/src/etc/man/cargo-bench.1
@@ -2,12 +2,12 @@
 .\"     Title: cargo-bench
 .\"    Author: [see the "AUTHOR(S)" section]
 .\" Generator: Asciidoctor 2.0.10
-.\"      Date: 2020-02-06
+.\"      Date: 2020-05-08
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "CARGO\-BENCH" "1" "2020-02-06" "\ \&" "\ \&"
+.TH "CARGO\-BENCH" "1" "2020-05-08" "\ \&" "\ \&"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0
@@ -59,6 +59,22 @@ the test harness to tell it to run only benchmarks.
 The libtest harness may be disabled by setting \fBharness = false\fP in the target
 manifest settings, in which case your code will need to provide its own \fBmain\fP
 function to handle running benchmarks.
+.RS 3
+.ll -.6i
+.sp
+\fBNote\fP: The
+\c
+.URL "https://doc.rust\-lang.org/nightly/unstable\-book/library\-features/test.html" "\fB#[bench]\fP attribute"
+is currently unstable and only available on the
+.URL "https://doc.rust\-lang.org/book/appendix\-07\-nightly\-rust.html" "nightly channel" "."
+There are some packages available on
+.URL "https://crates.io/keywords/benchmark" "crates.io" " "
+that may help with
+running benchmarks on the stable channel, such as
+.URL "https://crates.io/crates/criterion" "Criterion" "."
+.br
+.RE
+.ll
 .SH "OPTIONS"
 .SS "Benchmark Options"
 .sp


### PR DESCRIPTION
This copies the unstable notice from https://doc.rust-lang.org/cargo/reference/cargo-targets.html#benchmarks.

cc https://github.com/rust-lang/rust/issues/38998#issuecomment-625560220
