### PR TITLE
Expand error message to explain that a string was found

### DIFF
--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -321,7 +321,7 @@ impl<'de> de::Deserialize<'de> for TomlOptLevel {
                 } else {
                     Err(E::custom(format!(
                         "must be an integer, `z`, or `s`, \
-                         but found: {}",
+                         but found the string: \"{}\"",
                         value
                     )))
                 }

--- a/tests/testsuite/config.rs
+++ b/tests/testsuite/config.rs
@@ -574,7 +574,7 @@ opt-level = 'foo'
 error in [..]/.cargo/config: could not load config key `profile.dev.opt-level`
 
 Caused by:
-  must be an integer, `z`, or `s`, but found: foo",
+  must be an integer, `z`, or `s`, but found the string: \"foo\"",
     );
 
     let config = ConfigBuilder::new()
@@ -587,7 +587,7 @@ Caused by:
 error in environment variable `CARGO_PROFILE_DEV_OPT_LEVEL`: could not load config key `profile.dev.opt-level`
 
 Caused by:
-  must be an integer, `z`, or `s`, but found: asdf",
+  must be an integer, `z`, or `s`, but found the string: \"asdf\"",
     );
 }
 


### PR DESCRIPTION
With `opt-level = "3"` this previously said:

    must be an integer, `z`, or `s`, but found: 3 for ...

The error message doesn't make that super clear.
This should now be a bit more clear.

Fixes #8234

---

We could even include a bit more saying that `"3"` should become 3 (either unconditionally or after trying to parse `"3"` into an integer?

cc @steveklabnik 