### PR TITLE
Add a configuration option to force progress output

### DIFF
--- a/src/cargo/core/shell.rs
+++ b/src/cargo/core/shell.rs
@@ -25,6 +25,7 @@ pub struct Shell {
     /// Flag that indicates the current line needs to be cleared before
     /// printing. Used when a progress bar is currently displayed.
     needs_clear: bool,
+    force_progress: bool,
 }
 
 impl fmt::Debug for Shell {
@@ -78,6 +79,7 @@ impl Shell {
             },
             verbosity: Verbosity::Verbose,
             needs_clear: false,
+            force_progress: false,
         }
     }
 
@@ -87,6 +89,7 @@ impl Shell {
             err: ShellOut::Write(out),
             verbosity: Verbosity::Verbose,
             needs_clear: false,
+            force_progress: false,
         }
     }
 
@@ -277,6 +280,24 @@ impl Shell {
             ShellOut::Stream { color_choice, .. } => color_choice,
             ShellOut::Write(_) => ColorChoice::Never,
         }
+    }
+
+    /// Updates the progress choice (always or auto) from a string..
+    pub fn set_progress_choice(&mut self, progress: Option<String>) -> CargoResult<()> {
+        self.force_progress = match progress.as_deref() {
+            Some("always") => true,
+            Some("auto") | None => false,
+            Some(arg) => anyhow::bail!(
+                "value for term.progress must be auto or always, \
+                 but found `{}`",
+                arg
+            ),
+        };
+        Ok(())
+    }
+
+    pub fn progress_choice(&self) -> bool {
+        self.force_progress
     }
 
     /// Whether the shell supports color.

--- a/src/cargo/util/config/mod.rs
+++ b/src/cargo/util/config/mod.rs
@@ -698,6 +698,7 @@ impl Config {
         struct TermConfig {
             verbose: Option<bool>,
             color: Option<String>,
+            progress: Option<String>,
         }
 
         // Ignore errors in the configuration files.
@@ -728,6 +729,7 @@ impl Config {
 
         self.shell().set_verbosity(verbosity);
         self.shell().set_color_choice(color)?;
+        self.shell().set_progress_choice(term.progress)?;
         self.extra_verbose = extra_verbose;
         self.frozen = frozen;
         self.locked = locked;

--- a/src/cargo/util/progress.rs
+++ b/src/cargo/util/progress.rs
@@ -49,8 +49,14 @@ impl<'cfg> Progress<'cfg> {
             return Progress { state: None };
         }
 
+        let err_width = if cfg.shell().progress_choice() {
+            Some(cfg.shell().err_width().unwrap_or(80))
+        } else {
+            cfg.shell().err_width()
+        };
+
         Progress {
-            state: cfg.shell().err_width().map(|n| State {
+            state: err_width.map(|n| State {
                 config: cfg,
                 format: Format {
                     style,


### PR DESCRIPTION
Setting term.progress to "always" will cause progress updates to be
output, even if the output device is not a TTY.  The default is "auto",
which is the current behavior.

Re-open of #6395