### PR TITLE
Add option to strip binaries

### DIFF
--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -46,7 +46,7 @@ use self::output_depinfo::output_depinfo;
 use self::unit_graph::UnitDep;
 pub use crate::core::compiler::unit::{Unit, UnitInterner};
 use crate::core::manifest::TargetSourcePath;
-use crate::core::profiles::{PanicStrategy, Profile};
+use crate::core::profiles::{PanicStrategy, Profile, Strip};
 use crate::core::{Edition, Feature, InternedString, PackageId, Target};
 use crate::util::errors::{self, CargoResult, CargoResultExt, ProcessError, VerboseError};
 use crate::util::machine_message::Message;
@@ -732,6 +732,7 @@ fn build_base_args(
         rpath,
         ref panic,
         incremental,
+        strip,
         ..
     } = unit.profile;
     let test = unit.mode.is_any_test();
@@ -909,6 +910,11 @@ fn build_base_args(
         let dir = cx.files().layout(unit.kind).incremental().as_os_str();
         opt(cmd, "-C", "incremental=", Some(dir));
     }
+
+    if strip != Strip::None {
+        cmd.arg("-Z").arg(format!("strip={}", strip));
+    }
+
 
     if unit.is_std {
         // -Zforce-unstable-if-unmarked prevents the accidental use of

--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -915,7 +915,6 @@ fn build_base_args(
         cmd.arg("-Z").arg(format!("strip={}", strip));
     }
 
-
     if unit.is_std {
         // -Zforce-unstable-if-unmarked prevents the accidental use of
         // unstable crates within the sysroot (such as "extern crate libc" or

--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -356,7 +356,6 @@ pub struct CliUnstable {
     pub crate_versions: bool,
     pub separate_nightlies: bool,
     pub multitarget: bool,
-    pub strip: bool,
 }
 
 impl CliUnstable {
@@ -436,7 +435,6 @@ impl CliUnstable {
             "crate-versions" => self.crate_versions = parse_empty(k, v)?,
             "separate-nightlies" => self.separate_nightlies = parse_empty(k, v)?,
             "multitarget" => self.multitarget = parse_empty(k, v)?,
-            "strip" => self.strip = parse_empty(k, v)?,
             _ => bail!("unknown `-Z` flag specified: {}", k),
         }
 

--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -214,6 +214,9 @@ features! {
 
         // Opt-in new-resolver behavior.
         [unstable] resolver: bool,
+
+        // Allow to specify whether binaries should be stripped.
+        [unstable] strip: bool,
     }
 }
 
@@ -353,6 +356,7 @@ pub struct CliUnstable {
     pub crate_versions: bool,
     pub separate_nightlies: bool,
     pub multitarget: bool,
+    pub strip: bool,
 }
 
 impl CliUnstable {
@@ -432,6 +436,7 @@ impl CliUnstable {
             "crate-versions" => self.crate_versions = parse_empty(k, v)?,
             "separate-nightlies" => self.separate_nightlies = parse_empty(k, v)?,
             "multitarget" => self.multitarget = parse_empty(k, v)?,
+            "strip" => self.strip = parse_empty(k, v)?,
             _ => bail!("unknown `-Z` flag specified: {}", k),
         }
 

--- a/src/cargo/core/profiles.rs
+++ b/src/cargo/core/profiles.rs
@@ -804,7 +804,7 @@ pub enum Strip {
 impl fmt::Display for Strip {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
-            Strip::DebugInfo => "unwind",
+            Strip::DebugInfo => "debuginfo",
             Strip::None => "abort",
             Strip::Symbols => "symbols",
         }

--- a/src/cargo/core/profiles.rs
+++ b/src/cargo/core/profiles.rs
@@ -565,6 +565,14 @@ fn merge_profile(profile: &mut Profile, toml: &TomlProfile) {
     if let Some(incremental) = toml.incremental {
         profile.incremental = incremental;
     }
+    if let Some(strip) = toml.strip {
+        profile.strip = match strip.as_str() {
+            "debuginfo" => Strip::DebugInfo,
+            "none" => Strip::None,
+            "symbols" => Strip::Symbols,
+            _ => panic!("Unexpected strip option `{}`", strip),
+        };
+    }
 }
 
 /// The root profile (dev/release).
@@ -595,6 +603,7 @@ pub struct Profile {
     pub rpath: bool,
     pub incremental: bool,
     pub panic: PanicStrategy,
+    pub strip: Strip,
 }
 
 impl Default for Profile {
@@ -611,6 +620,7 @@ impl Default for Profile {
             rpath: false,
             incremental: false,
             panic: PanicStrategy::Unwind,
+            strip: Strip::None,
         }
     }
 }
@@ -635,6 +645,7 @@ compact_debug! {
                 rpath
                 incremental
                 panic
+                strip
             )]
         }
     }
@@ -721,6 +732,7 @@ impl Profile {
         bool,
         bool,
         PanicStrategy,
+        Strip,
     ) {
         (
             self.opt_level,
@@ -732,6 +744,7 @@ impl Profile {
             self.rpath,
             self.incremental,
             self.panic,
+            self.strip,
         )
     }
 }
@@ -776,6 +789,28 @@ impl fmt::Display for PanicStrategy {
     }
 }
 
+/// The setting for choosing which symbols to strip
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Hash, PartialOrd, Ord, serde::Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Strip {
+    /// Only strip debugging symbols
+    DebugInfo,
+    /// Don't remove any symbols
+    None,
+    /// Strip all non-exported symbols from the final binary
+    Symbols,
+}
+
+impl fmt::Display for Strip {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match *self {
+            Strip::DebugInfo => "unwind",
+            Strip::None => "abort",
+            Strip::Symbols => "symbols",
+        }
+        .fmt(f)
+    }
+}
 /// Flags used in creating `Unit`s to indicate the purpose for the target, and
 /// to ensure the target's dependencies have the correct settings.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]

--- a/src/cargo/core/profiles.rs
+++ b/src/cargo/core/profiles.rs
@@ -566,12 +566,7 @@ fn merge_profile(profile: &mut Profile, toml: &TomlProfile) {
         profile.incremental = incremental;
     }
     if let Some(strip) = toml.strip {
-        profile.strip = match strip.as_str() {
-            "debuginfo" => Strip::DebugInfo,
-            "none" => Strip::None,
-            "symbols" => Strip::Symbols,
-            _ => panic!("Unexpected strip option `{}`", strip),
-        };
+        profile.strip = strip;
     }
 }
 
@@ -790,7 +785,9 @@ impl fmt::Display for PanicStrategy {
 }
 
 /// The setting for choosing which symbols to strip
-#[derive(Clone, Copy, PartialEq, Eq, Debug, Hash, PartialOrd, Ord, serde::Serialize)]
+#[derive(
+    Clone, Copy, PartialEq, Eq, Debug, Hash, PartialOrd, Ord, serde::Serialize, serde::Deserialize,
+)]
 #[serde(rename_all = "lowercase")]
 pub enum Strip {
     /// Only strip debugging symbols

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -525,6 +525,7 @@ impl TomlProfile {
         }
 
         if let Some(strip) = &self.strip {
+            features.require(Feature::strip())?;
             if strip != "debuginfo" && strip != "none" && strip != "symbols" {
                 bail!(
                     "`strip` setting of `{}` is not a valid setting,\

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -15,6 +15,7 @@ use url::Url;
 
 use crate::core::dependency::DepKind;
 use crate::core::manifest::{ManifestMetadata, TargetSourcePath, Warnings};
+use crate::core::profiles::Strip;
 use crate::core::resolver::ResolveBehavior;
 use crate::core::{Dependency, InternedString, Manifest, PackageId, Summary, Target};
 use crate::core::{Edition, EitherManifest, Feature, Features, VirtualManifest, Workspace};
@@ -407,7 +408,7 @@ pub struct TomlProfile {
     pub build_override: Option<Box<TomlProfile>>,
     pub dir_name: Option<InternedString>,
     pub inherits: Option<InternedString>,
-    pub strip: Option<InternedString>,
+    pub strip: Option<Strip>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Ord, PartialOrd, Hash)]
@@ -524,15 +525,8 @@ impl TomlProfile {
             }
         }
 
-        if let Some(strip) = &self.strip {
+        if self.strip.is_some() {
             features.require(Feature::strip())?;
-            if strip != "debuginfo" && strip != "none" && strip != "symbols" {
-                bail!(
-                    "`strip` setting of `{}` is not a valid setting,\
-                     must be `debuginfo`, `none` or `symbols`",
-                    strip
-                );
-            }
         }
         Ok(())
     }

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -407,6 +407,7 @@ pub struct TomlProfile {
     pub build_override: Option<Box<TomlProfile>>,
     pub dir_name: Option<InternedString>,
     pub inherits: Option<InternedString>,
+    pub strip: Option<InternedString>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Ord, PartialOrd, Hash)]
@@ -519,6 +520,16 @@ impl TomlProfile {
                     "`panic` setting of `{}` is not a valid setting,\
                      must be `unwind` or `abort`",
                     panic
+                );
+            }
+        }
+
+        if let Some(strip) = &self.strip {
+            if strip != "debuginfo" && strip != "none" && strip != "symbols" {
+                bail!(
+                    "`strip` setting of `{}` is not a valid setting,\
+                     must be `debuginfo`, `none` or `symbols`",
+                    strip
                 );
             }
         }
@@ -640,6 +651,10 @@ impl TomlProfile {
 
         if let Some(v) = &profile.dir_name {
             self.dir_name = Some(*v);
+        }
+
+        if let Some(v) = profile.strip {
+            self.strip = Some(v);
         }
     }
 }

--- a/tests/testsuite/profiles.rs
+++ b/tests/testsuite/profiles.rs
@@ -468,3 +468,34 @@ fn thin_lto_works() {
         )
         .run();
 }
+
+#[cargo_test]
+fn strip_works() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            cargo-features = ["strip"]
+
+            [package]
+            name = "foo"
+            version = "0.1.0"
+
+            [profile.release]
+            strip = 'symbols'
+        "#,
+        )
+        .file("src/main.rs", "fn main() {}")
+        .build();
+
+    p.cargo("build --release -v")
+        .masquerade_as_nightly_cargo()
+        .with_stderr(
+            "\
+[COMPILING] foo [..]
+[RUNNING] `rustc [..] -Z strip=symbols [..]`
+[FINISHED] [..]
+",
+        )
+        .run();
+}

--- a/tests/testsuite/profiles.rs
+++ b/tests/testsuite/profiles.rs
@@ -2,7 +2,7 @@
 
 use std::env;
 
-use cargo_test_support::project;
+use cargo_test_support::{is_nightly, project};
 
 #[cargo_test]
 fn profile_overrides() {
@@ -471,6 +471,10 @@ fn thin_lto_works() {
 
 #[cargo_test]
 fn strip_works() {
+    if !is_nightly() {
+        return;
+    }
+
     let p = project()
         .file(
             "Cargo.toml",
@@ -495,6 +499,79 @@ fn strip_works() {
 [COMPILING] foo [..]
 [RUNNING] `rustc [..] -Z strip=symbols [..]`
 [FINISHED] [..]
+",
+        )
+        .run();
+}
+
+#[cargo_test]
+fn strip_requires_cargo_feature() {
+    if !is_nightly() {
+        return;
+    }
+
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "foo"
+            version = "0.1.0"
+
+            [profile.release]
+            strip = 'symbols'
+        "#,
+        )
+        .file("src/main.rs", "fn main() {}")
+        .build();
+
+    p.cargo("build --release -v")
+        .masquerade_as_nightly_cargo()
+        .with_status(101)
+        .with_stderr(
+            "\
+[ERROR] failed to parse manifest at `[CWD]/Cargo.toml`
+
+Caused by:
+  feature `strip` is required
+
+consider adding `cargo-features = [\"strip\"]` to the manifest
+",
+        )
+        .run();
+}
+#[cargo_test]
+fn strip_rejects_invalid_option() {
+    if !is_nightly() {
+        return;
+    }
+
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            cargo-features = ["strip"]
+
+            [package]
+            name = "foo"
+            version = "0.1.0"
+
+            [profile.release]
+            strip = 'wrong'
+        "#,
+        )
+        .file("src/main.rs", "fn main() {}")
+        .build();
+
+    p.cargo("build --release -v")
+        .masquerade_as_nightly_cargo()
+        .with_status(101)
+        .with_stderr(
+            "\
+[ERROR] failed to parse manifest at `[CWD]/Cargo.toml`
+
+Caused by:
+  unknown variant `wrong`, expected one of `debuginfo`, `none`, `symbols` for key [..]
 ",
         )
         .run();

--- a/tests/testsuite/unit_graph.rs
+++ b/tests/testsuite/unit_graph.rs
@@ -75,7 +75,8 @@ fn simple() {
         "overflow_checks": true,
         "rpath": false,
         "incremental": false,
-        "panic": "unwind"
+        "panic": "unwind",
+        "strip": "none"
       },
       "platform": null,
       "mode": "build",
@@ -115,7 +116,8 @@ fn simple() {
         "overflow_checks": true,
         "rpath": false,
         "incremental": false,
-        "panic": "unwind"
+        "panic": "unwind",
+        "strip": "none"
       },
       "platform": null,
       "mode": "build",
@@ -155,7 +157,8 @@ fn simple() {
         "overflow_checks": true,
         "rpath": false,
         "incremental": false,
-        "panic": "unwind"
+        "panic": "unwind",
+        "strip": "none"
       },
       "platform": null,
       "mode": "build",
@@ -188,7 +191,8 @@ fn simple() {
         "overflow_checks": true,
         "rpath": false,
         "incremental": false,
-        "panic": "unwind"
+        "panic": "unwind",
+        "strip": "none"
       },
       "platform": null,
       "mode": "build",


### PR DESCRIPTION
This PR adds a Cargo option for stripping symbols from generated binaries.

This is based on the `-Z strip` flag for `rustc`, which has been [recently implemented](https://github.com/rust-lang/rust/issues/71757).

Notes for reviewers: I'm not entirely sure how we test this, I've created a crate locally and it seems to be working.

Supersedes my previous work in #8191.
Fixes #3483.