### PR TITLE
Provide better error messages for a bad `patch`.

### DIFF
--- a/src/cargo/core/registry.rs
+++ b/src/cargo/core/registry.rs
@@ -812,16 +812,18 @@ fn summary_for_patch(
     };
     if found.is_empty() {
         anyhow::bail!(
-            "The patch location does not appear to contain any packages \
+            "The patch location `{}` does not appear to contain any packages \
             matching the name `{}`.",
+            orig_patch.source_id(),
             orig_patch.package_name()
         );
     } else {
         anyhow::bail!(
-            "The patch location contains a `{}` package with {}, but the patch \
+            "The patch location `{}` contains a `{}` package with {}, but the patch \
             definition requires `{}`.\n\
             Check that the version in the patch location is what you expect, \
             and update the patch definition to match.",
+            orig_patch.source_id(),
             orig_patch.package_name(),
             found,
             orig_patch.version_req()

--- a/src/cargo/ops/resolve.rs
+++ b/src/cargo/ops/resolve.rs
@@ -253,7 +253,8 @@ pub fn resolve_with_previous<'cfg>(
             let previous = match previous {
                 Some(r) => r,
                 None => {
-                    registry.patch(url, patches)?;
+                    let patches: Vec<_> = patches.iter().map(|p| (p, None)).collect();
+                    registry.patch(url, &patches)?;
                     continue;
                 }
             };
@@ -264,11 +265,11 @@ pub fn resolve_with_previous<'cfg>(
                     let candidates = previous.iter().chain(unused);
                     match candidates.filter(keep).find(|&id| dep.matches_id(id)) {
                         Some(id) => {
-                            let mut dep = dep.clone();
-                            dep.lock_to(id);
-                            dep
+                            let mut locked_dep = dep.clone();
+                            locked_dep.lock_to(id);
+                            (dep, Some(locked_dep))
                         }
-                        None => dep.clone(),
+                        None => (dep, None),
                     }
                 })
                 .collect::<Vec<_>>();

--- a/src/cargo/ops/resolve.rs
+++ b/src/cargo/ops/resolve.rs
@@ -20,7 +20,7 @@ use crate::core::{PackageId, PackageIdSpec, PackageSet, Source, SourceId, Worksp
 use crate::ops;
 use crate::sources::PathSource;
 use crate::util::errors::{CargoResult, CargoResultExt};
-use crate::util::profile;
+use crate::util::{profile, CanonicalUrl};
 use log::{debug, trace};
 use std::collections::HashSet;
 
@@ -224,13 +224,62 @@ pub fn resolve_with_previous<'cfg>(
         );
     }
 
-    let keep = |p: &PackageId| {
+    let pre_patch_keep = |p: &PackageId| {
         !to_avoid_sources.contains(&p.source_id())
             && match to_avoid {
                 Some(set) => !set.contains(p),
                 None => true,
             }
     };
+
+    // This is a set of PackageIds of `[patch]` entries that should not be
+    // locked.
+    let mut avoid_patch_ids = HashSet::new();
+    if register_patches {
+        for (url, patches) in ws.root_patch() {
+            let previous = match previous {
+                Some(r) => r,
+                None => {
+                    let patches: Vec<_> = patches.iter().map(|p| (p, None)).collect();
+                    let unlock_ids = registry.patch(url, &patches)?;
+                    // Since nothing is locked, this shouldn't possibly return anything.
+                    assert!(unlock_ids.is_empty());
+                    continue;
+                }
+            };
+            let patches = patches
+                .iter()
+                .map(|dep| {
+                    let unused = previous.unused_patches().iter().cloned();
+                    let candidates = previous.iter().chain(unused);
+                    match candidates
+                        .filter(pre_patch_keep)
+                        .find(|&id| dep.matches_id(id))
+                    {
+                        Some(id) => {
+                            let mut locked_dep = dep.clone();
+                            locked_dep.lock_to(id);
+                            (dep, Some((locked_dep, id)))
+                        }
+                        None => (dep, None),
+                    }
+                })
+                .collect::<Vec<_>>();
+            let canonical = CanonicalUrl::new(url)?;
+            for (orig_patch, unlock_id) in registry.patch(url, &patches)? {
+                // Avoid the locked patch ID.
+                avoid_patch_ids.insert(unlock_id);
+                // Also avoid the thing it is patching.
+                avoid_patch_ids.extend(previous.iter().filter(|id| {
+                    orig_patch.matches_ignoring_source(*id)
+                        && *id.source_id().canonical_url() == canonical
+                }));
+            }
+        }
+    }
+    debug!("avoid_patch_ids={:?}", avoid_patch_ids);
+
+    let keep = |p: &PackageId| pre_patch_keep(p) && !avoid_patch_ids.contains(p);
 
     // In the case where a previous instance of resolve is available, we
     // want to lock as many packages as possible to the previous version
@@ -249,33 +298,6 @@ pub fn resolve_with_previous<'cfg>(
     }
 
     if register_patches {
-        for (url, patches) in ws.root_patch() {
-            let previous = match previous {
-                Some(r) => r,
-                None => {
-                    let patches: Vec<_> = patches.iter().map(|p| (p, None)).collect();
-                    registry.patch(url, &patches)?;
-                    continue;
-                }
-            };
-            let patches = patches
-                .iter()
-                .map(|dep| {
-                    let unused = previous.unused_patches().iter().cloned();
-                    let candidates = previous.iter().chain(unused);
-                    match candidates.filter(keep).find(|&id| dep.matches_id(id)) {
-                        Some(id) => {
-                            let mut locked_dep = dep.clone();
-                            locked_dep.lock_to(id);
-                            (dep, Some(locked_dep))
-                        }
-                        None => (dep, None),
-                    }
-                })
-                .collect::<Vec<_>>();
-            registry.patch(url, &patches)?;
-        }
-
         registry.lock_patches();
     }
 

--- a/tests/testsuite/patch.rs
+++ b/tests/testsuite/patch.rs
@@ -1614,7 +1614,7 @@ Caused by:
   patch for `bar` in `https://github.com/rust-lang/crates.io-index` did not resolve to any crates
 
 Caused by:
-  The patch location does not appear to contain any packages matching the name `bar`.
+  The patch location `[..]/foo/bar` does not appear to contain any packages matching the name `bar`.
 ",
         )
         .run();
@@ -1653,7 +1653,7 @@ Caused by:
   patch for `bar` in `https://github.com/rust-lang/crates.io-index` did not resolve to any crates
 
 Caused by:
-  The patch location contains a `bar` package with version `0.1.0`, \
+  The patch location `[..]/foo/bar` contains a `bar` package with version `0.1.0`, \
 but the patch definition requires `^0.1.1`.
 Check that the version in the patch location is what you expect, \
 and update the patch definition to match.
@@ -1763,7 +1763,7 @@ Caused by:
   patch for `bar` in `https://github.com/rust-lang/crates.io-index` did not resolve to any crates
 
 Caused by:
-  The patch location contains a `bar` package with version `0.1.0`, but the patch definition requires `^0.1.1`.
+  The patch location `[..]/foo/bar` contains a `bar` package with version `0.1.0`, but the patch definition requires `^0.1.1`.
 Check that the version in the patch location is what you expect, and update the patch definition to match.
 ",
         )

--- a/tests/testsuite/patch.rs
+++ b/tests/testsuite/patch.rs
@@ -1763,8 +1763,8 @@ Caused by:
   patch for `bar` in `https://github.com/rust-lang/crates.io-index` did not resolve to any crates
 
 Caused by:
-  The patch is locked to = 0.1.1 in Cargo.lock, but the version in the patch location does not match any packages in the patch location.
-Make sure the patch points to the correct version.
+  The patch location contains a `bar` package with version `0.1.0`, but the patch definition requires `^0.1.1`.
+Check that the version in the patch location is what you expect, and update the patch definition to match.
 ",
         )
         .run();


### PR DESCRIPTION
This attempts to provide more user-friendly error messages for some situations with a bad `patch`.  This is a follow-up to #8243.

I think this more or less covers all the issues from #4678.  I imagine there are other corner cases, but those will need to wait for another day. The main one I can think of is when the patch location is missing required features.  Today you get a "blah was not used in the crate graph." warning, with some suggestions added in #6470, but it doesn't actually check if there is a feature mismatch.

Closes #4678
