### PR TITLE
Handle LTO with an rlib/cdylib crate type

### DIFF
--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -842,17 +842,6 @@ impl Target {
         self.kind().rustc_crate_types()
     }
 
-    pub fn can_lto(&self) -> bool {
-        match self.kind() {
-            TargetKind::Lib(v) => {
-                !v.contains(&CrateType::Rlib)
-                    && !v.contains(&CrateType::Dylib)
-                    && !v.contains(&CrateType::Lib)
-            }
-            _ => true,
-        }
-    }
-
     pub fn set_tested(&mut self, tested: bool) -> &mut Target {
         Arc::make_mut(&mut self.inner).tested = tested;
         self


### PR DESCRIPTION
In the case that LTO is happening but we're also generating a
cdylib/rlib simultatneously that means that the final artifact will use
the rlib but the cdylib still needs to be produced. To get this to work
the cdylib's dependency tree needs to be compiled with embedded bitcode.
The cdylib itself will be linked with the linker because we can't LTO an
rlib+cdylib compilation, but the final executable will need to load
bitcode from all its deps.

This is meant to address rust-lang/rust#72268