### PR TITLE
Fix panic with `cargo tree --target=all -Zfeatures=all`

### DIFF
--- a/src/cargo/core/compiler/standard_lib.rs
+++ b/src/cargo/core/compiler/standard_lib.rs
@@ -111,6 +111,7 @@ pub fn resolve_std<'cfg>(
         &opts,
         &specs,
         HasDevUnits::No,
+        crate::core::resolver::features::ForceAllTargets::No,
     )?;
     Ok((
         resolve.pkg_set,

--- a/src/cargo/core/resolver/mod.rs
+++ b/src/cargo/core/resolver/mod.rs
@@ -69,7 +69,7 @@ use self::types::{FeaturesSet, RcVecIter, RemainingDeps, ResolverProgress};
 pub use self::encode::Metadata;
 pub use self::encode::{EncodableDependency, EncodablePackageId, EncodableResolve};
 pub use self::errors::{ActivateError, ActivateResult, ResolveError};
-pub use self::features::HasDevUnits;
+pub use self::features::{ForceAllTargets, HasDevUnits};
 pub use self::resolve::{Resolve, ResolveVersion};
 pub use self::types::{ResolveBehavior, ResolveOpts};
 

--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -327,6 +327,7 @@ pub fn create_bcx<'a, 'cfg>(
         &opts,
         &specs,
         has_dev_units,
+        crate::core::resolver::features::ForceAllTargets::No,
     )?;
     let WorkspaceResolve {
         mut pkg_set,

--- a/src/cargo/ops/cargo_doc.rs
+++ b/src/cargo/ops/cargo_doc.rs
@@ -33,6 +33,7 @@ pub fn doc(ws: &Workspace<'_>, options: &DocOptions) -> CargoResult<()> {
         &opts,
         &specs,
         HasDevUnits::No,
+        crate::core::resolver::features::ForceAllTargets::No,
     )?;
 
     let ids = ws_resolve.targeted_resolve.specs_to_ids(&specs)?;

--- a/src/cargo/ops/cargo_output_metadata.rs
+++ b/src/cargo/ops/cargo_output_metadata.rs
@@ -123,6 +123,7 @@ fn build_resolve_graph(
         &resolve_opts,
         &specs,
         HasDevUnits::Yes,
+        crate::core::resolver::features::ForceAllTargets::No,
     )?;
     // Download all Packages. This is needed to serialize the information
     // for every package. In theory this could honor target filtering,

--- a/src/cargo/ops/resolve.rs
+++ b/src/cargo/ops/resolve.rs
@@ -12,7 +12,7 @@
 
 use crate::core::compiler::{CompileKind, RustcTargetData};
 use crate::core::registry::PackageRegistry;
-use crate::core::resolver::features::{FeatureResolver, ResolvedFeatures};
+use crate::core::resolver::features::{FeatureResolver, ForceAllTargets, ResolvedFeatures};
 use crate::core::resolver::{self, HasDevUnits, Resolve, ResolveOpts};
 use crate::core::summary::Summary;
 use crate::core::Feature;
@@ -79,6 +79,7 @@ pub fn resolve_ws_with_opts<'cfg>(
     opts: &ResolveOpts,
     specs: &[PackageIdSpec],
     has_dev_units: HasDevUnits,
+    force_all_targets: ForceAllTargets,
 ) -> CargoResult<WorkspaceResolve<'cfg>> {
     let mut registry = PackageRegistry::new(ws.config())?;
     let mut add_patches = true;
@@ -148,6 +149,7 @@ pub fn resolve_ws_with_opts<'cfg>(
         specs,
         requested_targets,
         has_dev_units,
+        force_all_targets,
     )?;
 
     Ok(WorkspaceResolve {

--- a/src/cargo/ops/tree/mod.rs
+++ b/src/cargo/ops/tree/mod.rs
@@ -3,7 +3,7 @@
 use self::format::Pattern;
 use crate::core::compiler::{CompileKind, RustcTargetData};
 use crate::core::dependency::DepKind;
-use crate::core::resolver::{HasDevUnits, ResolveOpts};
+use crate::core::resolver::{ForceAllTargets, HasDevUnits, ResolveOpts};
 use crate::core::{Package, PackageId, PackageIdSpec, Workspace};
 use crate::ops::{self, Packages};
 use crate::util::{CargoResult, Config};
@@ -150,6 +150,11 @@ pub fn build_and_print(ws: &Workspace<'_>, opts: &TreeOptions) -> CargoResult<()
     } else {
         HasDevUnits::No
     };
+    let force_all = if opts.target == Target::All {
+        ForceAllTargets::Yes
+    } else {
+        ForceAllTargets::No
+    };
     let ws_resolve = ops::resolve_ws_with_opts(
         ws,
         &target_data,
@@ -157,6 +162,7 @@ pub fn build_and_print(ws: &Workspace<'_>, opts: &TreeOptions) -> CargoResult<()
         &resolve_opts,
         &specs,
         has_dev,
+        force_all,
     )?;
     // Download all Packages. Some display formats need to display package metadata.
     let package_map: HashMap<PackageId, &Package> = ws_resolve


### PR DESCRIPTION
When `cargo tree --target=all` was used with the new feature resolver, this would cause a panic because the feature resolver doesn't know about the "all" behavior, and would filter out packages that don't match.

I don't feel like this is a particularly elegant solution, but I'm uncertain of how to make it better.

Closes #8109
