### PR TITLE
Add environment variables to identify the binary and crate name

### DIFF
--- a/src/cargo/core/compiler/compilation.rs
+++ b/src/cargo/core/compiler/compilation.rs
@@ -151,17 +151,15 @@ impl<'cfg> Compilation<'cfg> {
             self.rustc_process.clone()
         };
 
-        self.fill_env(rustc, &unit.pkg, unit.kind, true)
+        let cmd = fill_rustc_tool_env(rustc, unit);
+        self.fill_env(cmd, &unit.pkg, unit.kind, true)
     }
 
     /// See `process`.
     pub fn rustdoc_process(&self, unit: &Unit) -> CargoResult<ProcessBuilder> {
-        let mut p = self.fill_env(
-            process(&*self.config.rustdoc()?),
-            &unit.pkg,
-            unit.kind,
-            true,
-        )?;
+        let rustdoc = process(&*self.config.rustdoc()?);
+        let cmd = fill_rustc_tool_env(rustdoc, unit);
+        let mut p = self.fill_env(cmd, &unit.pkg, unit.kind, true)?;
         if unit.target.edition() != Edition::Edition2015 {
             p.arg(format!("--edition={}", unit.target.edition()));
         }
@@ -293,6 +291,16 @@ impl<'cfg> Compilation<'cfg> {
             .cwd(pkg.root());
         Ok(cmd)
     }
+}
+
+/// Prepares a rustc_tool process with additional environment variables
+/// that are only relevant in a context that has a unit
+fn fill_rustc_tool_env(mut cmd: ProcessBuilder, unit: &Unit) -> ProcessBuilder {
+    if unit.target.is_bin() {
+        cmd.env("CARGO_BIN_NAME", unit.target.name());
+    }
+    cmd.env("CARGO_CRATE_NAME", unit.target.crate_name());
+    cmd
 }
 
 fn pre_version_component(v: &Version) -> String {

--- a/src/doc/src/reference/environment-variables.md
+++ b/src/doc/src/reference/environment-variables.md
@@ -184,6 +184,8 @@ let version = env!("CARGO_PKG_VERSION");
 * `CARGO_PKG_DESCRIPTION` — The description from the manifest of your package.
 * `CARGO_PKG_HOMEPAGE` — The home page from the manifest of your package.
 * `CARGO_PKG_REPOSITORY` — The repository from the manifest of your package.
+* `CARGO_CRATE_NAME` — The name of the crate that is currently being compiled.
+* `CARGO_BIN_NAME` — The name of the binary that is currently being compiled (if it is a binary).
 * `OUT_DIR` — If the package has a build script, this is set to the folder where the build
               script should place its output. See below for more information.
               (Only set during compilation.)

--- a/src/doc/src/reference/environment-variables.md
+++ b/src/doc/src/reference/environment-variables.md
@@ -185,7 +185,7 @@ let version = env!("CARGO_PKG_VERSION");
 * `CARGO_PKG_HOMEPAGE` — The home page from the manifest of your package.
 * `CARGO_PKG_REPOSITORY` — The repository from the manifest of your package.
 * `CARGO_CRATE_NAME` — The name of the crate that is currently being compiled.
-* `CARGO_BIN_NAME` — The name of the binary that is currently being compiled (if it is a binary).
+* `CARGO_BIN_NAME` — The name of the binary that is currently being compiled (if it is a binary). This name does not include any file extension, such as `.exe`.
 * `OUT_DIR` — If the package has a build script, this is set to the folder where the build
               script should place its output. See below for more information.
               (Only set during compilation.)

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -1230,6 +1230,10 @@ fn crate_env_vars() {
         homepage = "https://example.com"
         repository = "https://example.com/repo.git"
         authors = ["wycats@example.com"]
+
+        [[bin]]
+        name = "foo-bar"
+        path = "src/main.rs"
         "#,
         )
         .file(
@@ -1248,6 +1252,9 @@ fn crate_env_vars() {
             static HOMEPAGE: &'static str = env!("CARGO_PKG_HOMEPAGE");
             static REPOSITORY: &'static str = env!("CARGO_PKG_REPOSITORY");
             static DESCRIPTION: &'static str = env!("CARGO_PKG_DESCRIPTION");
+            static BIN_NAME: &'static str = env!("CARGO_BIN_NAME");
+            static CRATE_NAME: &'static str = env!("CARGO_CRATE_NAME");
+
 
             fn main() {
                 let s = format!("{}-{}-{} @ {} in {}", VERSION_MAJOR,
@@ -1256,6 +1263,8 @@ fn crate_env_vars() {
                  assert_eq!(s, foo::version());
                  println!("{}", s);
                  assert_eq!("foo", PKG_NAME);
+                 assert_eq!("foo-bar", BIN_NAME);
+                 assert_eq!("foo_bar", CRATE_NAME);
                  assert_eq!("https://example.com", HOMEPAGE);
                  assert_eq!("https://example.com/repo.git", REPOSITORY);
                  assert_eq!("This is foo", DESCRIPTION);
@@ -1284,7 +1293,7 @@ fn crate_env_vars() {
     p.cargo("build -v").run();
 
     println!("bin");
-    p.process(&p.bin("foo"))
+    p.process(&p.bin("foo-bar"))
         .with_stdout("0-5-1 @ alpha.1 in [CWD]")
         .run();
 


### PR DESCRIPTION
Closes #8251

This adds `CARGO_BIN_NAME` and `CARGO_CRATE_NAME` to rustc/rustdoc process env.

`CARGO_BIN_NAME` is added for binary compilation units, `CARGO_CRATE_NAME` is added for binary and library units. 

The `build::crate_env_vars` test was updated to test for this. The test is currently only checking behavior for the binary compile unit.

Documentation was updated to reflect the added environment variables.