### PR TITLE
Default values for `readme` if not specified

### DIFF
--- a/crates/cargo-test-support/src/lib.rs
+++ b/crates/cargo-test-support/src/lib.rs
@@ -1630,7 +1630,7 @@ pub fn basic_bin_manifest_with_readme(name: &str, readme_filename: &str) -> Stri
         name = "{}"
         version = "0.5.0"
         authors = ["wycats@example.com"]
-        readme = "{}"
+        readme = {}
 
         [[bin]]
 

--- a/crates/cargo-test-support/src/lib.rs
+++ b/crates/cargo-test-support/src/lib.rs
@@ -1622,24 +1622,6 @@ pub fn basic_lib_manifest(name: &str) -> String {
     )
 }
 
-pub fn basic_bin_manifest_with_readme(name: &str, readme_filename: &str) -> String {
-    format!(
-        r#"
-        [package]
-
-        name = "{}"
-        version = "0.5.0"
-        authors = ["wycats@example.com"]
-        readme = {}
-
-        [[bin]]
-
-        name = "{}"
-    "#,
-        name, readme_filename, name
-    )
-}
-
 pub fn path2url<P: AsRef<Path>>(p: P) -> Url {
     Url::from_file_path(p).ok().unwrap()
 }

--- a/crates/cargo-test-support/src/lib.rs
+++ b/crates/cargo-test-support/src/lib.rs
@@ -1622,6 +1622,24 @@ pub fn basic_lib_manifest(name: &str) -> String {
     )
 }
 
+pub fn basic_bin_manifest_with_readme(name: &str, readme_filename: &str) -> String {
+    format!(
+        r#"
+        [package]
+
+        name = "{}"
+        version = "0.5.0"
+        authors = ["wycats@example.com"]
+        readme = "{}"
+
+        [[bin]]
+
+        name = "{}"
+    "#,
+        name, readme_filename, name
+    )
+}
+
 pub fn path2url<P: AsRef<Path>>(p: P) -> Url {
     Url::from_file_path(p).ok().unwrap()
 }

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -798,7 +798,7 @@ pub struct TomlProject {
     description: Option<String>,
     homepage: Option<String>,
     documentation: Option<String>,
-    readme: Option<String>,
+    readme: Option<StringOrBool>,
     keywords: Option<Vec<String>>,
     categories: Option<Vec<String>>,
     license: Option<String>,
@@ -1518,9 +1518,10 @@ impl TomlManifest {
 fn readme_for_project(package_root: &Path, project: &TomlProject) -> Option<String> {
     match &project.readme {
         None => default_readme_from_package_root(package_root),
-        Some(value) => match value.as_str() {
-            "false" => None,
-            _ => Some(value.clone()),
+        Some(value) => match value {
+            StringOrBool::Bool(false) => None,
+            StringOrBool::Bool(true) => default_readme_from_package_root(package_root),
+            StringOrBool::String(v) => Some(v.clone()),
         },
     }
 }

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -1199,19 +1199,11 @@ impl TomlManifest {
             project.namespaced_features.unwrap_or(false),
         )?;
 
-        let readme = match &project.readme {
-            None => default_readme_from_package_root(package_root),
-            Some(value) => match value.as_str() {
-                "false" => None,
-                _ => Some(value.clone())
-            }
-        };
-
         let metadata = ManifestMetadata {
             description: project.description.clone(),
             homepage: project.homepage.clone(),
             documentation: project.documentation.clone(),
-            readme,
+            readme: readme_for_project(package_root, project),
             authors: project.authors.clone().unwrap_or_default(),
             license: project.license.clone(),
             license_file: project.license_file.clone(),
@@ -1522,17 +1514,37 @@ impl TomlManifest {
     }
 }
 
+/// Returns the name of the README file for a `TomlProject`.
+fn readme_for_project(package_root: &Path, project: &Box<TomlProject>) -> Option<String> {
+    match &project.readme {
+        None => default_readme_from_package_root(package_root),
+        Some(value) => match value.as_str() {
+            "false" => None,
+            _ => Some(value.clone())
+        }
+    }
+}
+
 const DEFAULT_README_FILES: [&str; 3] = ["README.md", "README.txt", "README"];
 
 /// Checks if a file with any of the default README file names exists in the package root.
-/// If so, returns a String representing that name.
+/// If so, returns a `String` representing that name.
 fn default_readme_from_package_root(package_root: &Path) -> Option<String> {
-    DEFAULT_README_FILES
-        .iter()
-        .map(|&fname| package_root.join(Path::new(fname)))
-        .filter(|path| path.is_file())
-        .flat_map(|path| path.file_name().map(|fname| fname.to_string_lossy().into_owned()))
-        .next()
+    _default_readme_from_package_root(package_root).ok()
+}
+
+fn _default_readme_from_package_root(package_root: &Path) -> CargoResult<String> {
+    for entry in package_root.read_dir()? {
+        let entry = entry?;
+
+        let fname = entry.file_name();
+
+        if entry.metadata()?.is_file() && DEFAULT_README_FILES.contains(&fname.to_str().unwrap()) {
+            return Ok(fname.into_string().map_err(|_| anyhow!("Could not convert the README's file name into a String"))?);
+        }
+    }
+
+    Err(anyhow!("No files with the default README file names found in the package root."))
 }
 
 /// Checks a list of build targets, and ensures the target names are unique within a vector.

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -1199,11 +1199,18 @@ impl TomlManifest {
             project.namespaced_features.unwrap_or(false),
         )?;
 
+        let readme = readme_for_project(package_root, project);
+        if let Some(ref r) = readme {
+            if !package_root.join(r).is_file() {
+                bail!("readme file with name '{}' was not found", r);
+            }
+        };
+
         let metadata = ManifestMetadata {
             description: project.description.clone(),
             homepage: project.homepage.clone(),
             documentation: project.documentation.clone(),
-            readme: readme_for_project(package_root, project),
+            readme,
             authors: project.authors.clone().unwrap_or_default(),
             license: project.license.clone(),
             license_file: project.license_file.clone(),
@@ -1520,7 +1527,7 @@ fn readme_for_project(package_root: &Path, project: &TomlProject) -> Option<Stri
         None => default_readme_from_package_root(package_root),
         Some(value) => match value {
             StringOrBool::Bool(false) => None,
-            StringOrBool::Bool(true) => default_readme_from_package_root(package_root),
+            StringOrBool::Bool(true) => Some("README.md".to_string()),
             StringOrBool::String(v) => Some(v.clone()),
         },
     }

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -1520,8 +1520,8 @@ fn readme_for_project(package_root: &Path, project: &Box<TomlProject>) -> Option
         None => default_readme_from_package_root(package_root),
         Some(value) => match value.as_str() {
             "false" => None,
-            _ => Some(value.clone())
-        }
+            _ => Some(value.clone()),
+        },
     }
 }
 
@@ -1540,11 +1540,15 @@ fn _default_readme_from_package_root(package_root: &Path) -> CargoResult<String>
         let fname = entry.file_name();
 
         if entry.metadata()?.is_file() && DEFAULT_README_FILES.contains(&fname.to_str().unwrap()) {
-            return Ok(fname.into_string().map_err(|_| anyhow!("Could not convert the README's file name into a String"))?);
+            return Ok(fname
+                .into_string()
+                .map_err(|_| anyhow!("Could not convert the README's file name into a String"))?);
         }
     }
 
-    Err(anyhow!("No files with the default README file names found in the package root."))
+    Err(anyhow!(
+        "No files with the default README file names found in the package root."
+    ))
 }
 
 /// Checks a list of build targets, and ensures the target names are unique within a vector.

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -1200,7 +1200,7 @@ impl TomlManifest {
         )?;
 
         let readme = match &project.readme {
-            None => Some(String::from("README.md")),
+            None => default_readme_from_package_root(package_root),
             Some(value) => match value.as_str() {
                 "false" => None,
                 _ => Some(value.clone())
@@ -1520,6 +1520,19 @@ impl TomlManifest {
     pub fn has_profiles(&self) -> bool {
         self.profile.is_some()
     }
+}
+
+const DEFAULT_README_FILES: [&str; 3] = ["README.md", "README.txt", "README"];
+
+/// Checks if a file with any of the default README file names exists in the package root.
+/// If so, returns a String representing that name.
+fn default_readme_from_package_root(package_root: &Path) -> Option<String> {
+    DEFAULT_README_FILES
+        .iter()
+        .map(|&fname| package_root.join(Path::new(fname)))
+        .filter(|path| path.is_file())
+        .flat_map(|path| path.file_name().map(|fname| fname.to_string_lossy().into_owned()))
+        .nth(0)
 }
 
 /// Checks a list of build targets, and ensures the target names are unique within a vector.

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -1198,11 +1198,20 @@ impl TomlManifest {
             project.links.as_deref(),
             project.namespaced_features.unwrap_or(false),
         )?;
+
+        let readme = match &project.readme {
+            None => Some(String::from("README.md")),
+            Some(value) => match value.as_str() {
+                "false" => None,
+                _ => Some(value.clone())
+            }
+        };
+
         let metadata = ManifestMetadata {
             description: project.description.clone(),
             homepage: project.homepage.clone(),
             documentation: project.documentation.clone(),
-            readme: project.readme.clone(),
+            readme,
             authors: project.authors.clone().unwrap_or_default(),
             license: project.license.clone(),
             license_file: project.license_file.clone(),

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -1515,7 +1515,7 @@ impl TomlManifest {
 }
 
 /// Returns the name of the README file for a `TomlProject`.
-fn readme_for_project(package_root: &Path, project: &Box<TomlProject>) -> Option<String> {
+fn readme_for_project(package_root: &Path, project: &TomlProject) -> Option<String> {
     match &project.readme {
         None => default_readme_from_package_root(package_root),
         Some(value) => match value.as_str() {
@@ -1530,25 +1530,13 @@ const DEFAULT_README_FILES: [&str; 3] = ["README.md", "README.txt", "README"];
 /// Checks if a file with any of the default README file names exists in the package root.
 /// If so, returns a `String` representing that name.
 fn default_readme_from_package_root(package_root: &Path) -> Option<String> {
-    _default_readme_from_package_root(package_root).ok()
-}
-
-fn _default_readme_from_package_root(package_root: &Path) -> CargoResult<String> {
-    for entry in package_root.read_dir()? {
-        let entry = entry?;
-
-        let fname = entry.file_name();
-
-        if entry.metadata()?.is_file() && DEFAULT_README_FILES.contains(&fname.to_str().unwrap()) {
-            return Ok(fname
-                .into_string()
-                .map_err(|_| anyhow!("Could not convert the README's file name into a String"))?);
+    for &readme_filename in DEFAULT_README_FILES.iter() {
+        if package_root.join(readme_filename).is_file() {
+            return Some(readme_filename.to_string());
         }
     }
 
-    Err(anyhow!(
-        "No files with the default README file names found in the package root."
-    ))
+    None
 }
 
 /// Checks a list of build targets, and ensures the target names are unique within a vector.

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -1532,7 +1532,7 @@ fn default_readme_from_package_root(package_root: &Path) -> Option<String> {
         .map(|&fname| package_root.join(Path::new(fname)))
         .filter(|path| path.is_file())
         .flat_map(|path| path.file_name().map(|fname| fname.to_string_lossy().into_owned()))
-        .nth(0)
+        .next()
 }
 
 /// Checks a list of build targets, and ensures the target names are unique within a vector.

--- a/src/doc/src/reference/manifest.md
+++ b/src/doc/src/reference/manifest.md
@@ -168,7 +168,7 @@ readme = "README.md"
 If no value is specified for this field, and a file named `README.md`,
 `README.txt` or `README` exists in the package root, then the name of that
 file will be used. You can suppress this behavior by setting this field to
-`"false"`.
+`false`.
 
 #### The `homepage` field
 

--- a/src/doc/src/reference/manifest.md
+++ b/src/doc/src/reference/manifest.md
@@ -165,6 +165,11 @@ will interpret it as Markdown and render it on the crate's page.
 readme = "README.md"
 ```
 
+If no value is specified for this field, and a file named `README.md`,
+`README.txt` or `README` exists in the package root, then the name of that
+file will be used. You can suppress this behavior by setting this field to
+`"false"`.
+
 #### The `homepage` field
 
 The `homepage` field should be a URL to a site that is the home page for your

--- a/src/doc/src/reference/manifest.md
+++ b/src/doc/src/reference/manifest.md
@@ -168,7 +168,8 @@ readme = "README.md"
 If no value is specified for this field, and a file named `README.md`,
 `README.txt` or `README` exists in the package root, then the name of that
 file will be used. You can suppress this behavior by setting this field to
-`false`.
+`false`. If the field is set to `true`, a default value of `README.md` will
+be assumed.
 
 #### The `homepage` field
 

--- a/tests/testsuite/metadata.rs
+++ b/tests/testsuite/metadata.rs
@@ -1115,6 +1115,7 @@ fn package_metadata() {
             baz = "quux"
         "#,
         )
+        .file("README.md", "")
         .file("src/lib.rs", "")
         .build();
 
@@ -1186,6 +1187,7 @@ fn package_publish() {
             publish = ["my-registry"]
         "#,
         )
+        .file("README.md", "")
         .file("src/lib.rs", "")
         .build();
 

--- a/tests/testsuite/read_manifest.rs
+++ b/tests/testsuite/read_manifest.rs
@@ -1,15 +1,17 @@
 //! Tests for the `cargo read-manifest` command.
 
-use cargo_test_support::{basic_bin_manifest, main_file, project};
+use cargo_test_support::{basic_bin_manifest, basic_bin_manifest_with_readme, main_file, project};
 
-static MANIFEST_OUTPUT: &str = r#"
-{
+fn manifest_output(readme_value: &str) -> String {
+    format!(
+        r#"
+{{
     "authors": [
         "wycats@example.com"
     ],
     "categories": [],
     "name":"foo",
-    "readme": null,
+    "readme": {},
     "repository": null,
     "version":"0.5.0",
     "id":"foo[..]0.5.0[..](path+file://[..]/foo)",
@@ -21,19 +23,25 @@ static MANIFEST_OUTPUT: &str = r#"
     "edition": "2015",
     "source":null,
     "dependencies":[],
-    "targets":[{
+    "targets":[{{
         "kind":["bin"],
         "crate_types":["bin"],
         "doctest": false,
         "edition": "2015",
         "name":"foo",
         "src_path":"[..]/foo/src/foo.rs"
-    }],
-    "features":{},
+    }}],
+    "features":{{}},
     "manifest_path":"[..]Cargo.toml",
     "metadata": null,
     "publish": null
-}"#;
+}}"#, readme_value
+    )
+}
+
+fn manifest_output_no_readme() -> String {
+    manifest_output("null")
+}
 
 #[cargo_test]
 fn cargo_read_manifest_path_to_cargo_toml_relative() {
@@ -44,7 +52,7 @@ fn cargo_read_manifest_path_to_cargo_toml_relative() {
 
     p.cargo("read-manifest --manifest-path foo/Cargo.toml")
         .cwd(p.root().parent().unwrap())
-        .with_json(MANIFEST_OUTPUT)
+        .with_json(&manifest_output_no_readme())
         .run();
 }
 
@@ -58,7 +66,7 @@ fn cargo_read_manifest_path_to_cargo_toml_absolute() {
     p.cargo("read-manifest --manifest-path")
         .arg(p.root().join("Cargo.toml"))
         .cwd(p.root().parent().unwrap())
-        .with_json(MANIFEST_OUTPUT)
+        .with_json(&manifest_output_no_readme())
         .run();
 }
 
@@ -104,5 +112,32 @@ fn cargo_read_manifest_cwd() {
         .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
         .build();
 
-    p.cargo("read-manifest").with_json(MANIFEST_OUTPUT).run();
+    p.cargo("read-manifest").with_json(&manifest_output_no_readme()).run();
 }
+
+#[cargo_test]
+fn cargo_read_manifest_default_readme() {
+    let readme_filenames = ["README.md", "README.txt", "README"];
+
+    for readme in readme_filenames.iter() {
+        let p = project()
+            .file("Cargo.toml", &basic_bin_manifest("foo"))
+            .file(readme, "Sample project")
+            .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
+            .build();
+
+        p.cargo("read-manifest").with_json(&manifest_output(&format!(r#""{}""#, readme))).run();
+    }
+}
+
+#[cargo_test]
+fn cargo_read_manifest_suppress_default_readme() {
+    let p = project()
+        .file("Cargo.toml", &basic_bin_manifest_with_readme("foo", "false"))
+        .file("README.txt", "Sample project")
+        .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
+        .build();
+
+    p.cargo("read-manifest").with_json(&manifest_output_no_readme()).run();
+}
+

--- a/tests/testsuite/read_manifest.rs
+++ b/tests/testsuite/read_manifest.rs
@@ -185,16 +185,29 @@ fn cargo_read_manifest_suppress_default_readme() {
         .run();
 }
 
-// If a file named README.txt exists, and `readme = true`, the value `README.txt` should be defaulted in.
+// If a file named README.md exists, and `readme = true`, the value `README.md` should be defaulted in.
 #[cargo_test]
 fn cargo_read_manifest_defaults_readme_if_true() {
+    let p = project()
+        .file("Cargo.toml", &basic_bin_manifest_with_readme("foo", "true"))
+        .file("README.md", "Sample project")
+        .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
+        .build();
+
+    p.cargo("read-manifest")
+        .with_json(&manifest_output(&format!(r#""{}""#, "README.md")))
+        .run();
+}
+
+// If a file named README.md does not exist, and `readme = true`, it should panic.
+#[cargo_test]
+#[should_panic]
+fn cargo_read_manifest_panics_if_default_readme_not_found() {
     let p = project()
         .file("Cargo.toml", &basic_bin_manifest_with_readme("foo", "true"))
         .file("README.txt", "Sample project")
         .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
         .build();
 
-    p.cargo("read-manifest")
-        .with_json(&manifest_output(&format!(r#""{}""#, "README.txt")))
-        .run();
+    p.cargo("read-manifest").run();
 }

--- a/tests/testsuite/read_manifest.rs
+++ b/tests/testsuite/read_manifest.rs
@@ -1,6 +1,6 @@
 //! Tests for the `cargo read-manifest` command.
 
-use cargo_test_support::{basic_bin_manifest, basic_bin_manifest_with_readme, main_file, project};
+use cargo_test_support::{basic_bin_manifest, main_file, project};
 
 fn manifest_output(readme_value: &str) -> String {
     format!(
@@ -42,6 +42,24 @@ fn manifest_output(readme_value: &str) -> String {
 
 fn manifest_output_no_readme() -> String {
     manifest_output("null")
+}
+
+pub fn basic_bin_manifest_with_readme(name: &str, readme_filename: &str) -> String {
+    format!(
+        r#"
+        [package]
+
+        name = "{}"
+        version = "0.5.0"
+        authors = ["wycats@example.com"]
+        readme = {}
+
+        [[bin]]
+
+        name = "{}"
+    "#,
+        name, readme_filename, name
+    )
 }
 
 #[cargo_test]

--- a/tests/testsuite/read_manifest.rs
+++ b/tests/testsuite/read_manifest.rs
@@ -35,7 +35,8 @@ fn manifest_output(readme_value: &str) -> String {
     "manifest_path":"[..]Cargo.toml",
     "metadata": null,
     "publish": null
-}}"#, readme_value
+}}"#,
+        readme_value
     )
 }
 
@@ -112,7 +113,9 @@ fn cargo_read_manifest_cwd() {
         .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
         .build();
 
-    p.cargo("read-manifest").with_json(&manifest_output_no_readme()).run();
+    p.cargo("read-manifest")
+        .with_json(&manifest_output_no_readme())
+        .run();
 }
 
 #[cargo_test]
@@ -126,18 +129,24 @@ fn cargo_read_manifest_default_readme() {
             .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
             .build();
 
-        p.cargo("read-manifest").with_json(&manifest_output(&format!(r#""{}""#, readme))).run();
+        p.cargo("read-manifest")
+            .with_json(&manifest_output(&format!(r#""{}""#, readme)))
+            .run();
     }
 }
 
 #[cargo_test]
 fn cargo_read_manifest_suppress_default_readme() {
     let p = project()
-        .file("Cargo.toml", &basic_bin_manifest_with_readme("foo", "false"))
+        .file(
+            "Cargo.toml",
+            &basic_bin_manifest_with_readme("foo", "false"),
+        )
         .file("README.txt", "Sample project")
         .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
         .build();
 
-    p.cargo("read-manifest").with_json(&manifest_output_no_readme()).run();
+    p.cargo("read-manifest")
+        .with_json(&manifest_output_no_readme())
+        .run();
 }
-

--- a/tests/testsuite/read_manifest.rs
+++ b/tests/testsuite/read_manifest.rs
@@ -119,6 +119,22 @@ fn cargo_read_manifest_cwd() {
 }
 
 #[cargo_test]
+fn cargo_read_manifest_with_specified_readme() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            &basic_bin_manifest_with_readme("foo", r#""SomeReadme.txt""#),
+        )
+        .file("SomeReadme.txt", "Sample Project")
+        .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
+        .build();
+
+    p.cargo("read-manifest")
+        .with_json(&manifest_output(&format!(r#""{}""#, "SomeReadme.txt")))
+        .run();
+}
+
+#[cargo_test]
 fn cargo_read_manifest_default_readme() {
     let readme_filenames = ["README.md", "README.txt", "README"];
 
@@ -148,5 +164,19 @@ fn cargo_read_manifest_suppress_default_readme() {
 
     p.cargo("read-manifest")
         .with_json(&manifest_output_no_readme())
+        .run();
+}
+
+// If a file named README.txt exists, and `readme = true`, the value `README.txt` should be defaulted in.
+#[cargo_test]
+fn cargo_read_manifest_defaults_readme_if_true() {
+    let p = project()
+        .file("Cargo.toml", &basic_bin_manifest_with_readme("foo", "true"))
+        .file("README.txt", "Sample project")
+        .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
+        .build();
+
+    p.cargo("read-manifest")
+        .with_json(&manifest_output(&format!(r#""{}""#, "README.txt")))
         .run();
 }


### PR DESCRIPTION
If the a value for `readme` is not specified in Cargo.toml, we will now check for the existence of files named `README.md`, `README.txt` or `README`. If one does exist, the name of that file will be defaulted in to the manifest for the project.

This behavior can be suppressed if `readme` is set to `false`.

Closes #8133 