### PR TITLE
Bump to semver 0.10 for `VersionReq::is_exact`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ percent-encoding = "2.0"
 remove_dir_all = "0.5.2"
 rustfix = "0.5.0"
 same-file = "1"
-semver = { version = "0.9.0", features = ["serde"] }
+semver = { version = "0.10", features = ["serde"] }
 serde = { version = "1.0.82", features = ["derive"] }
 serde_ignored = "0.1.0"
 serde_json = { version = "1.0.30", features = ["raw_value"] }

--- a/crates/resolver-tests/src/lib.rs
+++ b/crates/resolver-tests/src/lib.rs
@@ -734,8 +734,8 @@ fn meta_test_deep_pretty_print_registry() {
         "vec![pkg!((\"foo\", \"1.0.1\") => [dep_req(\"bar\", \"^1\"),]),\
          pkg!((\"foo\", \"1.0.0\") => [dep_req(\"bar\", \"^2\"),]),\
          pkg!((\"foo\", \"2.0.0\") => [dep(\"bar\"),]),\
-         pkg!((\"bar\", \"1.0.0\") => [dep_req(\"baz\", \"= 1.0.2\"),dep_req(\"other\", \"^1\"),]),\
-         pkg!((\"bar\", \"2.0.0\") => [dep_req(\"baz\", \"= 1.0.1\"),]),\
+         pkg!((\"bar\", \"1.0.0\") => [dep_req(\"baz\", \"=1.0.2\"),dep_req(\"other\", \"^1\"),]),\
+         pkg!((\"bar\", \"2.0.0\") => [dep_req(\"baz\", \"=1.0.1\"),]),\
          pkg!((\"baz\", \"1.0.2\") => [dep_req(\"other\", \"^2\"),]),\
          pkg!((\"baz\", \"1.0.1\")),\
          pkg!((\"cat\", \"1.0.2\") => [dep_req_kind(\"other\", \"^2\", DepKind::Build, false),]),\

--- a/src/cargo/core/dependency.rs
+++ b/src/cargo/core/dependency.rs
@@ -393,8 +393,7 @@ impl Dependency {
     /// Returns `true` if this is a "locked" dependency, basically whether it has
     /// an exact version req.
     pub fn is_locked(&self) -> bool {
-        // Kind of a hack to figure this out, but it works!
-        self.inner.req.to_string().starts_with('=')
+        self.inner.req.is_exact()
     }
 
     /// Returns `false` if the dependency is only used to build the local package.

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -1025,7 +1025,7 @@ fn incompatible_dependencies() {
 error: failed to select a version for `bad`.
     ... required by package `qux v0.1.0`
     ... which is depended on by `foo v0.0.1 ([..])`
-versions that meet the requirements `>= 1.0.1` are: 1.0.2, 1.0.1
+versions that meet the requirements `>=1.0.1` are: 1.0.2, 1.0.1
 
 all possible versions conflict with previously selected packages.
 
@@ -1070,7 +1070,7 @@ fn incompatible_dependencies_with_multi_semver() {
             "\
 error: failed to select a version for `bad`.
     ... required by package `foo v0.0.1 ([..])`
-versions that meet the requirements `>= 1.0.1, <= 2.0.0` are: 2.0.0, 1.0.1
+versions that meet the requirements `>=1.0.1, <=2.0.0` are: 2.0.0, 1.0.1
 
 all possible versions conflict with previously selected packages.
 

--- a/tests/testsuite/install.rs
+++ b/tests/testsuite/install.rs
@@ -175,7 +175,7 @@ fn bad_version() {
         .with_stderr(
             "\
 [UPDATING] [..] index
-[ERROR] could not find `foo` in registry `[..]` with version `= 0.2.0`
+[ERROR] could not find `foo` in registry `[..]` with version `=0.2.0`
 ",
         )
         .run();

--- a/tests/testsuite/install_upgrade.rs
+++ b/tests/testsuite/install_upgrade.rs
@@ -802,7 +802,7 @@ fn already_installed_updates_yank_status_on_upgrade() {
         .with_stderr(
             "\
 [UPDATING] `[..]` index
-[ERROR] could not find `foo` in registry `[..]` with version `= 1.0.1`
+[ERROR] could not find `foo` in registry `[..]` with version `=1.0.1`
 ",
         )
         .run();

--- a/tests/testsuite/registry.rs
+++ b/tests/testsuite/registry.rs
@@ -223,7 +223,7 @@ fn wrong_version() {
         .with_status(101)
         .with_stderr_contains(
             "\
-error: failed to select a version for the requirement `foo = \">= 1.0.0\"`
+error: failed to select a version for the requirement `foo = \">=1.0.0\"`
   candidate versions found which didn't match: 0.0.2, 0.0.1
   location searched: `[..]` index (which is replacing registry `[..]`)
 required by package `foo v0.0.1 ([..])`
@@ -238,7 +238,7 @@ required by package `foo v0.0.1 ([..])`
         .with_status(101)
         .with_stderr_contains(
             "\
-error: failed to select a version for the requirement `foo = \">= 1.0.0\"`
+error: failed to select a version for the requirement `foo = \">=1.0.0\"`
   candidate versions found which didn't match: 0.0.4, 0.0.3, 0.0.2, ...
   location searched: `[..]` index (which is replacing registry `[..]`)
 required by package `foo v0.0.1 ([..])`
@@ -543,7 +543,7 @@ fn relying_on_a_yank_is_bad() {
         .with_status(101)
         .with_stderr_contains(
             "\
-error: failed to select a version for the requirement `baz = \"= 0.0.2\"`
+error: failed to select a version for the requirement `baz = \"=0.0.2\"`
   candidate versions found which didn't match: 0.0.1
   location searched: `[..]` index (which is replacing registry `[..]`)
 required by package `bar v0.0.1`

--- a/tests/testsuite/replace.rs
+++ b/tests/testsuite/replace.rs
@@ -549,7 +549,7 @@ fn override_wrong_name() {
 Caused by:
   no matching package for override `[..]baz:0.1.0` found
 location searched: file://[..]
-version required: = 0.1.0
+version required: =0.1.0
 ",
         )
         .run();


### PR DESCRIPTION
This stops using `to_string` as a proxy for this now-provided precise API.

This reverts commit b71927224fd9306b2b5bd2b4f8c22268eadfeb6a and bumps the
dependency version in Cargo.toml.