### PR TITLE
Fix tests with enoent error message on non-english systems.

### DIFF
--- a/crates/cargo-test-support/src/lib.rs
+++ b/crates/cargo-test-support/src/lib.rs
@@ -1841,10 +1841,6 @@ pub fn symlink_supported() -> bool {
 }
 
 /// The error message for ENOENT.
-///
-/// It's generally not good to match against OS error messages, but I think
-/// this one is relatively stable.
-#[cfg(windows)]
-pub const NO_SUCH_FILE_ERR_MSG: &str = "The system cannot find the file specified. (os error 2)";
-#[cfg(not(windows))]
-pub const NO_SUCH_FILE_ERR_MSG: &str = "No such file or directory (os error 2)";
+pub fn no_such_file_err_msg() -> String {
+    std::io::Error::from_raw_os_error(2).to_string()
+}

--- a/tests/testsuite/config_include.rs
+++ b/tests/testsuite/config_include.rs
@@ -3,7 +3,7 @@
 use super::config::{
     assert_error, assert_match, read_output, write_config, write_config_at, ConfigBuilder,
 };
-use cargo_test_support::{paths, NO_SUCH_FILE_ERR_MSG};
+use cargo_test_support::{no_such_file_err_msg, paths};
 use std::fs;
 
 #[cargo_test]
@@ -92,7 +92,7 @@ Caused by:
 
 Caused by:
   {}",
-            NO_SUCH_FILE_ERR_MSG
+            no_such_file_err_msg()
         ),
     );
 }
@@ -179,7 +179,7 @@ Caused by:
 
 Caused by:
   {}",
-            NO_SUCH_FILE_ERR_MSG
+            no_such_file_err_msg()
         ),
     );
 }

--- a/tests/testsuite/install.rs
+++ b/tests/testsuite/install.rs
@@ -11,7 +11,7 @@ use cargo_test_support::install::{
 use cargo_test_support::paths;
 use cargo_test_support::registry::Package;
 use cargo_test_support::{
-    basic_manifest, cargo_process, project, symlink_supported, t, NO_SUCH_FILE_ERR_MSG,
+    basic_manifest, cargo_process, no_such_file_err_msg, project, symlink_supported, t,
 };
 
 fn pkg(name: &str, vers: &str) {
@@ -845,7 +845,7 @@ fn uninstall_cwd_no_project() {
 
 Caused by:
   {err_msg}",
-            err_msg = NO_SUCH_FILE_ERR_MSG,
+            err_msg = no_such_file_err_msg(),
         ))
         .run();
 }


### PR DESCRIPTION
It was kinda dumb to hard-code the text. Tested with German on Windows.

Fixes #8271
