### PR TITLE
Warn if using hash in git URL, Fixes #8241

### DIFF
--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -1616,7 +1616,7 @@ impl DetailedTomlDependency {
                 if url.fragment().is_some() {
                     let msg = format!(
                         "hash in git url is ignored for dependency ({}). \
-                        if you were trying to specify a specific git revision, use rev = \"revision\".",
+                        If you were trying to specify a specific git revision, use rev = \"revision\".",
                         name_in_toml);
                     cx.warnings.push(msg)
                 }

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -1611,6 +1611,18 @@ impl DetailedTomlDependency {
             }
         }
 
+        if let Some(git) = self.git.clone() {
+            if let Ok(url) = git.into_url() {
+                if url.fragment().is_some() {
+                    let msg = format!(
+                        "hash in git url is ignored for dependency ({}). \
+                        if you were trying to specify a specific git revision, use rev = \"revision\".",
+                        name_in_toml);
+                    cx.warnings.push(msg)
+                }
+            }
+        }
+
         let new_source_id = match (
             self.git.as_ref(),
             self.path.as_ref(),

--- a/tests/testsuite/bad_config.rs
+++ b/tests/testsuite/bad_config.rs
@@ -862,6 +862,36 @@ This will be considered an error in future versions
 }
 
 #[cargo_test]
+fn fragment_in_git_url() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "foo"
+            version = "0.0.0"
+            authors = []
+
+            [dependencies.bar]
+            git = "http://127.0.0.1#foo"
+        "#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    p.cargo("build -v")
+        .with_status(101)
+        .with_stderr_contains(
+            "\
+[WARNING] URL fragment `#foo` in git URL is ignored for dependency (bar). \
+If you were trying to specify a specific git revision, \
+use `rev = \"foo\"` in the dependency declaration.
+",
+        )
+        .run();
+}
+
+#[cargo_test]
 fn bad_source_config1() {
     let p = project()
         .file("src/lib.rs", "")


### PR DESCRIPTION
This fixes an issue where if the user wants to set the git rev but doesn't know how and as results tries to set the ref in the url hash as also shown when downloading the dependency.  
Now cargo returns a warning notifying the user about the correct way to set the ref.  

Fixes #8241 