### PR TITLE
Disable strip_works test on macos.

### DIFF
--- a/tests/testsuite/profiles.rs
+++ b/tests/testsuite/profiles.rs
@@ -470,6 +470,8 @@ fn thin_lto_works() {
 }
 
 #[cargo_test]
+// Strip doesn't work on macos.
+#[cfg_attr(target_os = "macos", ignore)]
 fn strip_works() {
     if !is_nightly() {
         return;


### PR DESCRIPTION
This feature doesn't work on macOS, because it uses ld64 with clang.  See https://github.com/rust-lang/rust/issues/72110#issuecomment-636609419.
