### PR TITLE
Warn if env varible contains lower case 

### DIFF
--- a/src/cargo/util/config/mod.rs
+++ b/src/cargo/util/config/mod.rs
@@ -532,6 +532,21 @@ impl Config {
                 return true;
             }
         }
+
+        self.env
+            .iter()
+            .filter(|(k, _)| k.to_uppercase().contains("CARGO_TARGET"))
+            .for_each(|(k, _)| {
+                // Warn if the env variable match with env_key
+                // but the env variable contains lower case character(s)
+                let env_key = key.as_env_key();
+                if k.to_uppercase() == env_key && k != env_key {
+                    let _ = self
+                        .shell()
+                        .warn(format!("{} env variable contains lowercase.", k));
+                }
+            });
+
         false
     }
 

--- a/tests/testsuite/tool_paths.rs
+++ b/tests/testsuite/tool_paths.rs
@@ -352,3 +352,19 @@ fn cfg_ignored_fields() {
         )
         .run();
 }
+
+#[cargo_test]
+fn env_var_contain_lower_case() {
+    let p = project().file("src/main.rs", "fn main() {}").build();
+
+    let env_key = "CARGO_TARGET_X86_64_UNKNOWN_LINUX_musl_LINKER";
+
+    p.cargo("build -v --target X86_64_unknown_linux_musl")
+        .env(env_key, "nonexistent-linker")
+        .with_status(101)
+        .with_stderr_contains(format!(
+            "warning: {} env variable contains lowercase.",
+            env_key
+        ))
+        .run();
+}


### PR DESCRIPTION
When running "cargo --target TRIPPLE", cargo expects to find the env
variable CARGO_TARGET_[TRIPPLE]_* in uppercase. This fix checks if the
env variable and the `--target TRIPPLE` match but the env variable has
the wrong casing. Cargo will then warn the user that lower case
characters is found in the relevant env variable.

Fixes #8285