### PR TITLE
Add support for `workspace.metadata` table

### DIFF
--- a/src/cargo/core/compiler/standard_lib.rs
+++ b/src/cargo/core/compiler/standard_lib.rs
@@ -65,6 +65,7 @@ pub fn resolve_std<'cfg>(
         &Some(members),
         /*default_members*/ &None,
         /*exclude*/ &None,
+        /*custom_metadata*/ &None,
     ));
     let virtual_manifest = crate::core::VirtualManifest::new(
         /*replace*/ Vec::new(),

--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -405,6 +405,26 @@ impl<'cfg> Workspace<'cfg> {
         self.custom_metadata.as_ref()
     }
 
+    pub fn load_workspace_config(&mut self) -> CargoResult<Option<WorkspaceRootConfig>> {
+        // If we didn't find a root, it must mean there is no [workspace] section, and thus no
+        // metadata.
+        if let Some(root_path) = &self.root_manifest {
+            let root_package = self.packages.load(root_path)?;
+            match root_package.workspace_config() {
+                WorkspaceConfig::Root(ref root_config) => {
+                    return Ok(Some(root_config.clone()));
+                }
+
+                _ => anyhow::bail!(
+                    "root of a workspace inferred but wasn't a root: {}",
+                    root_path.display()
+                ),
+            }
+        }
+
+        Ok(None)
+    }
+
     /// Finds the root of a workspace for the crate whose manifest is located
     /// at `manifest_path`.
     ///
@@ -478,25 +498,10 @@ impl<'cfg> Workspace<'cfg> {
         Ok(None)
     }
 
-    /// After the root of a workspace has been located, loads the `workspace.metadata` table from
-    /// the workspace root file.
-    ///
-    /// If no workspace was defined, then no changes occur.
-    fn load_workspace_metadata(&mut self) -> CargoResult<()> {
-        // If we didn't find a root, it must mean there is no [workspace] section, and thus no
-        // metadata.
-        if let Some(root_path) = &self.root_manifest {
-            let root_package = self.packages.load(root_path)?;
-            match root_package.workspace_config() {
-                WorkspaceConfig::Root(ref root_config) => {
-                    self.custom_metadata = root_config.custom_metadata.clone();
-                }
-
-                _ => anyhow::bail!(
-                    "root of a workspace inferred but wasn't a root: {}",
-                    root_path.display()
-                ),
-            }
+    /// After the root of a workspace has been located, sets the custom_metadata, if it exists.
+    pub fn load_workspace_metadata(&mut self) -> CargoResult<()> {
+        if let Some(workspace_config) = self.load_workspace_config()? {
+            self.custom_metadata = workspace_config.custom_metadata;
         }
 
         Ok(())
@@ -510,8 +515,8 @@ impl<'cfg> Workspace<'cfg> {
     /// will transitively follow all `path` dependencies looking for members of
     /// the workspace.
     fn find_members(&mut self) -> CargoResult<()> {
-        let root_manifest_path = match self.root_manifest {
-            Some(ref path) => path.clone(),
+        let workspace_config = match self.load_workspace_config()? {
+            Some(workspace_config) => workspace_config,
             None => {
                 debug!("find_members - only me as a member");
                 self.members.push(self.current_manifest.clone());
@@ -524,30 +529,20 @@ impl<'cfg> Workspace<'cfg> {
             }
         };
 
-        let members_paths;
-        let default_members_paths;
-        {
-            let root_package = self.packages.load(&root_manifest_path)?;
-            match *root_package.workspace_config() {
-                WorkspaceConfig::Root(ref root_config) => {
-                    members_paths = root_config
-                        .members_paths(root_config.members.as_ref().unwrap_or(&vec![]))?;
-                    default_members_paths = if root_manifest_path == self.current_manifest {
-                        if let Some(ref default) = root_config.default_members {
-                            Some(root_config.members_paths(default)?)
-                        } else {
-                            None
-                        }
-                    } else {
-                        None
-                    };
-                }
-                _ => anyhow::bail!(
-                    "root of a workspace inferred but wasn't a root: {}",
-                    root_manifest_path.display()
-                ),
+        // self.root_manifest must be Some to have retrieved workspace_config
+        let root_manifest_path = self.root_manifest.clone().unwrap();
+
+        let members_paths =
+            workspace_config.members_paths(workspace_config.members.as_ref().unwrap_or(&vec![]))?;
+        let default_members_paths = if root_manifest_path == self.current_manifest {
+            if let Some(ref default) = workspace_config.default_members {
+                Some(workspace_config.members_paths(default)?)
+            } else {
+                None
             }
-        }
+        } else {
+            None
+        };
 
         for path in members_paths {
             self.find_path_deps(&path.join("Cargo.toml"), &root_manifest_path, false)?;

--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -159,7 +159,9 @@ impl<'cfg> Workspace<'cfg> {
             ws.root_manifest = ws.find_root(manifest_path)?;
         }
 
-        ws.custom_metadata = ws.load_workspace_config()?.and_then(|cfg| cfg.custom_metadata);
+        ws.custom_metadata = ws
+            .load_workspace_config()?
+            .and_then(|cfg| cfg.custom_metadata);
         ws.find_members()?;
         ws.resolve_behavior = match ws.root_maybe() {
             MaybePackage::Package(p) => p.manifest().resolve_behavior(),

--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -159,7 +159,7 @@ impl<'cfg> Workspace<'cfg> {
             ws.root_manifest = ws.find_root(manifest_path)?;
         }
 
-        ws.load_workspace_metadata()?;
+        ws.custom_metadata = ws.load_workspace_config()?.and_then(|cfg| cfg.custom_metadata);
         ws.find_members()?;
         ws.resolve_behavior = match ws.root_maybe() {
             MaybePackage::Package(p) => p.manifest().resolve_behavior(),
@@ -496,15 +496,6 @@ impl<'cfg> Workspace<'cfg> {
         }
 
         Ok(None)
-    }
-
-    /// After the root of a workspace has been located, sets the custom_metadata, if it exists.
-    pub fn load_workspace_metadata(&mut self) -> CargoResult<()> {
-        if let Some(workspace_config) = self.load_workspace_config()? {
-            self.custom_metadata = workspace_config.custom_metadata;
-        }
-
-        Ok(())
     }
 
     /// After the root of a workspace has been located, probes for all members

--- a/src/cargo/ops/cargo_output_metadata.rs
+++ b/src/cargo/ops/cargo_output_metadata.rs
@@ -46,6 +46,7 @@ pub fn output_metadata(ws: &Workspace<'_>, opt: &OutputMetadataOptions) -> Cargo
         target_directory: ws.target_dir().into_path_unlocked(),
         version: VERSION,
         workspace_root: ws.root().to_path_buf(),
+        metadata: ws.custom_metadata().cloned(),
     })
 }
 
@@ -60,6 +61,7 @@ pub struct ExportInfo {
     target_directory: PathBuf,
     version: u32,
     workspace_root: PathBuf,
+    metadata: Option<toml::Value>,
 }
 
 #[derive(Serialize)]

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -825,6 +825,7 @@ pub struct TomlWorkspace {
     #[serde(rename = "default-members")]
     default_members: Option<Vec<String>>,
     exclude: Option<Vec<String>>,
+    metadata: Option<toml::Value>,
     resolver: Option<String>,
 }
 
@@ -1229,6 +1230,7 @@ impl TomlManifest {
                 &config.members,
                 &config.default_members,
                 &config.exclude,
+                &config.metadata,
             )),
             (None, root) => WorkspaceConfig::Member {
                 root: root.cloned(),
@@ -1413,6 +1415,7 @@ impl TomlManifest {
                 &config.members,
                 &config.default_members,
                 &config.exclude,
+                &config.metadata,
             )),
             None => {
                 bail!("virtual manifests must be configured with [workspace]");

--- a/src/doc/man/cargo-metadata.adoc
+++ b/src/doc/man/cargo-metadata.adoc
@@ -268,6 +268,15 @@ The output has the following format:
     "version": 1,
     /* The absolute path to the root of the workspace. */
     "workspace_root": "/path/to/my-package"
+    /* Workspace metadata.
+       This is null if no metadata is specified. */
+    "metadata": {
+        "docs": {
+            "rs": {
+                "all-features": true
+            }
+        }
+    }
 }
 ----
 

--- a/src/doc/src/reference/manifest.md
+++ b/src/doc/src/reference/manifest.md
@@ -427,7 +427,7 @@ external tools may wish to use them in a consistent fashion, such as referring
 to the data in `workspace.metadata` if data is missing from `package.metadata`,
 if that makes sense for the tool in question.
 
-[workspace-metadata](workspaces.md#the-workspace-metadata-table)
+[workspace-metadata]: workspaces.md#the-workspacemetadata-table
 
 #### The `default-run` field
 

--- a/src/doc/src/reference/manifest.md
+++ b/src/doc/src/reference/manifest.md
@@ -427,7 +427,7 @@ external tools may wish to use them in a consistent fashion, such as referring
 to the data in `workspace.metadata` if data is missing from `package.metadata`,
 if that makes sense for the tool in question.
 
-[workspace-metadata](workspaces.md#the-metadata-table)
+[workspace-metadata](workspaces.md#the-workspace-metadata-table)
 
 #### The `default-run` field
 

--- a/src/doc/src/reference/manifest.md
+++ b/src/doc/src/reference/manifest.md
@@ -420,6 +420,15 @@ package-name = "my-awesome-android-app"
 assets = "path/to/static"
 ```
 
+There is a similar table at the workspace level at
+[`workspace.metadata`][workspace-metadata]. While cargo does not specify a
+format for the content of either of these tables, it is suggested that
+external tools may wish to use them in a consistent fashion, such as referring
+to the data in `workspace.metadata` if data is missing from `package.metadata`,
+if that makes sense for the tool in question.
+
+[workspace-metadata](workspaces.md#the-metadata-table)
+
 #### The `default-run` field
 
 The `default-run` field in the `[package]` section of the manifest can be used

--- a/src/doc/src/reference/workspaces.md
+++ b/src/doc/src/reference/workspaces.md
@@ -82,12 +82,12 @@ default-members = ["path/to/member2", "path/to/member3/foo"]
 
 When specified, `default-members` must expand to a subset of `members`.
 
+<a id="the-metadata-table"></a>
 ### The `workspace.metadata` table
 
-Like the [`package.metadata`][package-metadata] table, the `workspace.metadata`
-table is ignored by Cargo and will not be warned about. This section can be
-used for tools that would like to store workspace configuration in
-`Cargo.toml`. For example:
+The `workspace.metadata` table is ignored by Cargo and will not be warned
+about. This section can be used for tools that would like to store workspace
+configuration in `Cargo.toml`. For example:
 
 ```toml
 [workspace]
@@ -98,6 +98,13 @@ root = "path/to/webproject"
 tool = ["npm", "run", "build"]
 # ...
 ```
+
+There is a similar set of tables at the package level at
+[`package.metadata`][package-metadata]. While cargo does not specify a
+format for the content of either of these tables, it is suggested that
+external tools may wish to use them in a consistent fashion, such as referring
+to the data in `workspace.metadata` if data is missing from `package.metadata`,
+if that makes sense for the tool in question.
 
 [package]: manifest.md#the-package-section
 [package-metadata]: manifest.md#the-metadata-table

--- a/src/doc/src/reference/workspaces.md
+++ b/src/doc/src/reference/workspaces.md
@@ -82,7 +82,7 @@ default-members = ["path/to/member2", "path/to/member3/foo"]
 
 When specified, `default-members` must expand to a subset of `members`.
 
-<a id="the-metadata-table"></a>
+<a id="the-workspace-metadata-table"></a>
 ### The `workspace.metadata` table
 
 The `workspace.metadata` table is ignored by Cargo and will not be warned

--- a/src/doc/src/reference/workspaces.md
+++ b/src/doc/src/reference/workspaces.md
@@ -82,7 +82,25 @@ default-members = ["path/to/member2", "path/to/member3/foo"]
 
 When specified, `default-members` must expand to a subset of `members`.
 
+### The `workspace.metadata` table
+
+Like the [`package.metadata`][package-metadata] table, the `workspace.metadata`
+table is ignored by Cargo and will not be warned about. This section can be
+used for tools that would like to store workspace configuration in
+`Cargo.toml`. For example:
+
+```toml
+[workspace]
+members = ["member1", "member2"]
+
+[workspace.metadata.webcontents]
+root = "path/to/webproject"
+tool = ["npm", "run", "build"]
+# ...
+```
+
 [package]: manifest.md#the-package-section
+[package-metadata]: manifest.md#the-metadata-table
 [output directory]: ../guide/build-cache.md
 [patch]: overriding-dependencies.md#the-patch-section
 [replace]: overriding-dependencies.md#the-replace-section

--- a/src/doc/src/reference/workspaces.md
+++ b/src/doc/src/reference/workspaces.md
@@ -82,7 +82,6 @@ default-members = ["path/to/member2", "path/to/member3/foo"]
 
 When specified, `default-members` must expand to a subset of `members`.
 
-<a id="the-workspace-metadata-table"></a>
 ### The `workspace.metadata` table
 
 The `workspace.metadata` table is ignored by Cargo and will not be warned

--- a/tests/testsuite/alt_registry.rs
+++ b/tests/testsuite/alt_registry.rs
@@ -824,7 +824,8 @@ fn alt_reg_metadata() {
                 "resolve": null,
                 "target_directory": "[..]/foo/target",
                 "version": 1,
-                "workspace_root": "[..]/foo"
+                "workspace_root": "[..]/foo",
+                "metadata": null
             }"#,
         )
         .run();
@@ -1003,7 +1004,8 @@ fn alt_reg_metadata() {
                 "resolve": "{...}",
                 "target_directory": "[..]/foo/target",
                 "version": 1,
-                "workspace_root": "[..]/foo"
+                "workspace_root": "[..]/foo",
+                "metadata": null
             }"#,
         )
         .run();
@@ -1152,7 +1154,8 @@ fn unknown_registry() {
               "resolve": "{...}",
               "target_directory": "[..]/foo/target",
               "version": 1,
-              "workspace_root": "[..]/foo"
+              "workspace_root": "[..]/foo",
+              "metadata": null
             }
             "#,
         )

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -3299,6 +3299,43 @@ fn no_warn_about_package_metadata() {
 }
 
 #[cargo_test]
+fn no_warn_about_workspace_metadata() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [workspace]
+            members = ["foo"]
+
+            [workspace.metadata]
+            something = "something_else"
+            x = 1
+            y = 2
+
+            [workspace.metadata.another]
+            bar = 12
+            "#,
+        )
+        .file(
+            "foo/Cargo.toml",
+            r#"
+            [package]
+            name = "foo"
+            version = "0.0.1"
+            "#,
+        )
+        .file("foo/src/lib.rs", "")
+        .build();
+
+    p.cargo("build")
+        .with_stderr(
+            "[..] foo v0.0.1 ([..])\n\
+             [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]\n",
+        )
+        .run();
+}
+
+#[cargo_test]
 fn cargo_build_empty_target() {
     let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))

--- a/tests/testsuite/metadata.rs
+++ b/tests/testsuite/metadata.rs
@@ -67,7 +67,8 @@ fn cargo_metadata_simple() {
         },
         "target_directory": "[..]foo/target",
         "version": 1,
-        "workspace_root": "[..]/foo"
+        "workspace_root": "[..]/foo",
+        "metadata": null
     }"#,
         )
         .run();
@@ -159,7 +160,8 @@ crate-type = ["lib", "staticlib"]
         },
         "target_directory": "[..]foo/target",
         "version": 1,
-        "workspace_root": "[..]/foo"
+        "workspace_root": "[..]/foo",
+        "metadata": null
     }"#,
         )
         .run();
@@ -248,7 +250,8 @@ optional_feat = []
         },
         "target_directory": "[..]foo/target",
         "version": 1,
-        "workspace_root": "[..]/foo"
+        "workspace_root": "[..]/foo",
+        "metadata": null
     }"#,
         )
         .run();
@@ -537,7 +540,8 @@ fn cargo_metadata_with_deps_and_version() {
         "workspace_members": [
             "foo 0.5.0 (path+file:[..]foo)"
         ],
-        "workspace_root": "[..]/foo"
+        "workspace_root": "[..]/foo",
+        "metadata": null
     }"#,
         )
         .run();
@@ -622,7 +626,8 @@ name = "ex"
         },
         "target_directory": "[..]foo/target",
         "version": 1,
-        "workspace_root": "[..]/foo"
+        "workspace_root": "[..]/foo",
+        "metadata": null
     }"#,
         )
         .run();
@@ -708,7 +713,8 @@ crate-type = ["rlib", "dylib"]
         },
         "target_directory": "[..]foo/target",
         "version": 1,
-        "workspace_root": "[..]/foo"
+        "workspace_root": "[..]/foo",
+        "metadata": null
     }"#,
         )
         .run();
@@ -722,6 +728,14 @@ fn workspace_metadata() {
             r#"
             [workspace]
             members = ["bar", "baz"]
+
+            [workspace.metadata]
+            tool1 = "hello"
+            tool2 = [1, 2, 3]
+
+            [workspace.metadata.foo]
+            bar = 3
+
         "#,
         )
         .file("bar/Cargo.toml", &basic_lib_manifest("bar"))
@@ -822,7 +836,14 @@ fn workspace_metadata() {
         },
         "target_directory": "[..]foo/target",
         "version": 1,
-        "workspace_root": "[..]/foo"
+        "workspace_root": "[..]/foo",
+        "metadata": {
+            "tool1": "hello",
+            "tool2": [1, 2, 3],
+            "foo": {
+              "bar": 3
+            }
+        }
     }"#,
         )
         .run();
@@ -920,7 +941,8 @@ fn workspace_metadata_no_deps() {
         "resolve": null,
         "target_directory": "[..]foo/target",
         "version": 1,
-        "workspace_root": "[..]/foo"
+        "workspace_root": "[..]/foo",
+        "metadata": null
     }"#,
         )
         .run();
@@ -979,7 +1001,8 @@ const MANIFEST_OUTPUT: &str = r#"
     "resolve": null,
     "target_directory": "[..]foo/target",
     "version": 1,
-    "workspace_root": "[..]/foo"
+    "workspace_root": "[..]/foo",
+    "metadata": null
 }"#;
 
 #[cargo_test]
@@ -1163,7 +1186,8 @@ fn package_metadata() {
         "resolve": null,
         "target_directory": "[..]foo/target",
         "version": 1,
-        "workspace_root": "[..]/foo"
+        "workspace_root": "[..]/foo",
+        "metadata": null
     }"#,
         )
         .run();
@@ -1230,7 +1254,8 @@ fn package_publish() {
         "resolve": null,
         "target_directory": "[..]foo/target",
         "version": 1,
-        "workspace_root": "[..]/foo"
+        "workspace_root": "[..]/foo",
+        "metadata": null
     }"#,
         )
         .run();
@@ -1315,7 +1340,8 @@ fn cargo_metadata_path_to_cargo_toml_project() {
             "workspace_members": [
                 "bar 0.5.0 (path+file:[..])"
             ],
-            "workspace_root": "[..]"
+            "workspace_root": "[..]",
+            "metadata": null
         }
 "#,
         )
@@ -1396,7 +1422,8 @@ fn package_edition_2018() {
             "workspace_members": [
                 "foo 0.1.0 (path+file:[..])"
             ],
-            "workspace_root": "[..]"
+            "workspace_root": "[..]",
+            "metadata": null
         }
         "#,
         )
@@ -1493,7 +1520,8 @@ fn target_edition_2018() {
             "workspace_members": [
                 "foo 0.1.0 (path+file:[..])"
             ],
-            "workspace_root": "[..]"
+            "workspace_root": "[..]",
+            "metadata": null
         }
         "#,
         )
@@ -1710,7 +1738,8 @@ fn rename_dependency() {
     "workspace_members": [
         "foo 0.0.1[..]"
     ],
-    "workspace_root": "[..]"
+    "workspace_root": "[..]",
+    "metadata": null
 }"#,
         )
         .run();
@@ -1801,7 +1830,8 @@ fn metadata_links() {
   "workspace_members": [
     "foo 0.5.0 [..]"
   ],
-  "workspace_root": "[..]/foo"
+  "workspace_root": "[..]/foo",
+  "metadata": null
 }
 "#,
         )
@@ -1896,7 +1926,8 @@ fn deps_with_bin_only() {
   },
   "target_directory": "[..]/foo/target",
   "version": 1,
-  "workspace_root": "[..]foo"
+  "workspace_root": "[..]foo",
+  "metadata": null
 }
 "#,
         )
@@ -2280,7 +2311,8 @@ fn filter_platform() {
   },
   "target_directory": "[..]/foo/target",
   "version": 1,
-  "workspace_root": "[..]/foo"
+  "workspace_root": "[..]/foo",
+  "metadata": null
 }
 "#
             .replace("$ALT_TRIPLE", alt_target)
@@ -2354,7 +2386,8 @@ fn filter_platform() {
   },
   "target_directory": "[..]foo/target",
   "version": 1,
-  "workspace_root": "[..]foo"
+  "workspace_root": "[..]foo",
+  "metadata": null
 }
 "#
             .replace("$ALT_TRIPLE", alt_target)
@@ -2425,7 +2458,8 @@ fn filter_platform() {
   },
   "target_directory": "[..]foo/target",
   "version": 1,
-  "workspace_root": "[..]foo"
+  "workspace_root": "[..]foo",
+  "metadata": null
 }
 "#
             .replace("$HOST_TRIPLE", &rustc_host())
@@ -2515,7 +2549,8 @@ fn filter_platform() {
   },
   "target_directory": "[..]/foo/target",
   "version": 1,
-  "workspace_root": "[..]/foo"
+  "workspace_root": "[..]/foo",
+  "metadata": null
 }
 "#
             .replace("$HOST_TRIPLE", &rustc_host())
@@ -2565,6 +2600,7 @@ fn dep_kinds() {
   "target_directory": "{...}",
   "version": 1,
   "workspace_root": "{...}",
+  "metadata": null,
   "resolve": {
     "nodes": [
       {
@@ -2679,6 +2715,7 @@ fn dep_kinds_workspace() {
   "target_directory": "[..]/foo/target",
   "version": 1,
   "workspace_root": "[..]/foo",
+  "metadata": null,
   "resolve": {
     "nodes": [
       {

--- a/tests/testsuite/update.rs
+++ b/tests/testsuite/update.rs
@@ -549,7 +549,8 @@ fn update_precise_first_run() {
   "workspace_members": [
     "bar 0.0.1 (path+file://[..]/foo)"
   ],
-  "workspace_root": "[..]/foo"
+  "workspace_root": "[..]/foo",
+  "metadata": null
 }"#,
         )
         .run();


### PR DESCRIPTION
Implements feature request #8309

Additionally includes the information in the output of "cargo metadata" through a new top-level field `metadata`, similar to the per-package `metadata` field