### PR TITLE
Allow passing a registry index url directly to `cargo install`

### DIFF
--- a/src/bin/cargo/commands/install.rs
+++ b/src/bin/cargo/commands/install.rs
@@ -18,7 +18,7 @@ pub fn cli() -> App {
         .arg(
             opt("git", "Git URL to install the specified crate from")
                 .value_name("URL")
-                .conflicts_with_all(&["path", "registry"]),
+                .conflicts_with_all(&["path", "index", "registry"]),
         )
         .arg(
             opt("branch", "Branch to use when installing from git")
@@ -38,7 +38,7 @@ pub fn cli() -> App {
         .arg(
             opt("path", "Filesystem path to local crate to install")
                 .value_name("PATH")
-                .conflicts_with_all(&["git", "registry"]),
+                .conflicts_with_all(&["git", "index", "registry"]),
         )
         .arg(opt(
             "list",
@@ -59,10 +59,16 @@ pub fn cli() -> App {
         .arg_target_triple("Build for the target triple")
         .arg(opt("root", "Directory to install packages into").value_name("DIR"))
         .arg(
+            opt("index", "Registry index to install from")
+                .value_name("INDEX")
+                .requires("crate")
+                .conflicts_with_all(&["git", "path", "registry"]),
+        )
+        .arg(
             opt("registry", "Registry to use")
                 .value_name("REGISTRY")
                 .requires("crate")
-                .conflicts_with_all(&["git", "path"]),
+                .conflicts_with_all(&["git", "path", "index"]),
         )
         .after_help(
             "\
@@ -100,8 +106,6 @@ continuous integration systems.",
 }
 
 pub fn exec(config: &mut Config, args: &ArgMatches<'_>) -> CliResult {
-    let registry = args.registry(config)?;
-
     if let Some(path) = args.value_of_path("path", config) {
         config.reload_rooted_at(path)?;
     } else {
@@ -143,8 +147,10 @@ pub fn exec(config: &mut Config, args: &ArgMatches<'_>) -> CliResult {
     } else if krates.is_empty() {
         from_cwd = true;
         SourceId::for_path(config.cwd())?
-    } else if let Some(registry) = registry {
+    } else if let Some(registry) = args.registry(config)? {
         SourceId::alt_registry(config, &registry)?
+    } else if let Some(index) = args.value_of("index") {
+        SourceId::for_registry(&index.into_url()?)?
     } else {
         SourceId::crates_io(config)?
     };

--- a/src/doc/man/cargo-install.adoc
+++ b/src/doc/man/cargo-install.adoc
@@ -135,6 +135,8 @@ available.
 
 include::options-registry.adoc[]
 
+include::options-index.adoc[]
+
 include::options-features.adoc[]
 
 === Compilation Options

--- a/src/doc/man/generated/cargo-install.html
+++ b/src/doc/man/generated/cargo-install.html
@@ -197,6 +197,10 @@ Cargo installing at the same time.</p>
 If not specified, the default registry is used, which is defined by the
 <code>registry.default</code> config key which defaults to <code>crates-io</code>.</p>
 </dd>
+<dt class="hdlist1"><strong>--index</strong> <em>INDEX</em></dt>
+<dd>
+<p>The URL of the registry index to use.</p>
+</dd>
 </dl>
 </div>
 </div>

--- a/src/etc/man/cargo-install.1
+++ b/src/etc/man/cargo-install.1
@@ -2,12 +2,12 @@
 .\"     Title: cargo-install
 .\"    Author: [see the "AUTHOR(S)" section]
 .\" Generator: Asciidoctor 2.0.10
-.\"      Date: 2020-02-06
+.\"      Date: 2020-06-14
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "CARGO\-INSTALL" "1" "2020-02-06" "\ \&" "\ \&"
+.TH "CARGO\-INSTALL" "1" "2020-06-14" "\ \&" "\ \&"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0
@@ -292,6 +292,11 @@ Name of the registry to use. Registry names are defined in \c
 .URL "https://doc.rust\-lang.org/cargo/reference/config.html" "Cargo config files" "."
 If not specified, the default registry is used, which is defined by the
 \fBregistry.default\fP config key which defaults to \fBcrates\-io\fP.
+.RE
+.sp
+\fB\-\-index\fP \fIINDEX\fP
+.RS 4
+The URL of the registry index to use.
 .RE
 .SS "Feature Selection"
 .sp

--- a/tests/testsuite/install.rs
+++ b/tests/testsuite/install.rs
@@ -9,7 +9,7 @@ use cargo_test_support::install::{
     assert_has_installed_exe, assert_has_not_installed_exe, cargo_home,
 };
 use cargo_test_support::paths;
-use cargo_test_support::registry::Package;
+use cargo_test_support::registry::{registry_path, registry_url, Package};
 use cargo_test_support::{
     basic_manifest, cargo_process, no_such_file_err_msg, project, symlink_supported, t,
 };
@@ -42,6 +42,35 @@ fn simple() {
 [WARNING] be sure to add `[..]` to your PATH to be able to run the installed binaries
 ",
         )
+        .run();
+    assert_has_installed_exe(cargo_home(), "foo");
+
+    cargo_process("uninstall foo")
+        .with_stderr("[REMOVING] [CWD]/home/.cargo/bin/foo[EXE]")
+        .run();
+    assert_has_not_installed_exe(cargo_home(), "foo");
+}
+
+#[cargo_test]
+fn with_index() {
+    pkg("foo", "0.0.1");
+
+    cargo_process("install foo --index")
+        .arg(registry_url().to_string())
+        .with_stderr(&format!(
+            "\
+[UPDATING] `{reg}` index
+[DOWNLOADING] crates ...
+[DOWNLOADED] foo v0.0.1 (registry `{reg}`)
+[INSTALLING] foo v0.0.1 (registry `{reg}`)
+[COMPILING] foo v0.0.1 (registry `{reg}`)
+[FINISHED] release [optimized] target(s) in [..]
+[INSTALLING] [CWD]/home/.cargo/bin/foo[EXE]
+[INSTALLED] package `foo v0.0.1 (registry `{reg}`)` (executable `foo[EXE]`)
+[WARNING] be sure to add `[..]` to your PATH to be able to run the installed binaries
+",
+            reg = registry_path().to_str().unwrap()
+        ))
         .run();
     assert_has_installed_exe(cargo_home(), "foo");
 


### PR DESCRIPTION
Fixes #8318 