### PR TITLE
Fix failure with missing readme.

### DIFF
--- a/src/cargo/ops/registry.rs
+++ b/src/cargo/ops/registry.rs
@@ -233,10 +233,13 @@ fn transmit(
         ref badges,
         ref links,
     } = *manifest.metadata();
-    let readme_content = match *readme {
-        Some(ref readme) => Some(paths::read(&pkg.root().join(readme))?),
-        None => None,
-    };
+    let readme_content = readme
+        .as_ref()
+        .map(|readme| {
+            paths::read(&pkg.root().join(readme))
+                .chain_err(|| format!("failed to read `readme` file for package `{}`", pkg))
+        })
+        .transpose()?;
     if let Some(ref file) = *license_file {
         if !pkg.root().join(file).exists() {
             bail!("the license file `{}` does not exist", file)

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -1209,18 +1209,11 @@ impl TomlManifest {
             project.namespaced_features.unwrap_or(false),
         )?;
 
-        let readme = readme_for_project(package_root, project);
-        if let Some(ref r) = readme {
-            if !package_root.join(r).is_file() {
-                bail!("readme file with name '{}' was not found", r);
-            }
-        };
-
         let metadata = ManifestMetadata {
             description: project.description.clone(),
             homepage: project.homepage.clone(),
             documentation: project.documentation.clone(),
-            readme,
+            readme: readme_for_project(package_root, project),
             authors: project.authors.clone().unwrap_or_default(),
             license: project.license.clone(),
             license_file: project.license_file.clone(),

--- a/tests/testsuite/read_manifest.rs
+++ b/tests/testsuite/read_manifest.rs
@@ -195,19 +195,6 @@ fn cargo_read_manifest_defaults_readme_if_true() {
         .build();
 
     p.cargo("read-manifest")
-        .with_json(&manifest_output(&format!(r#""{}""#, "README.md")))
+        .with_json(&manifest_output(r#""README.md""#))
         .run();
-}
-
-// If a file named README.md does not exist, and `readme = true`, it should panic.
-#[cargo_test]
-#[should_panic]
-fn cargo_read_manifest_panics_if_default_readme_not_found() {
-    let p = project()
-        .file("Cargo.toml", &basic_bin_manifest_with_readme("foo", "true"))
-        .file("README.txt", "Sample project")
-        .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
-        .build();
-
-    p.cargo("read-manifest").run();
 }


### PR DESCRIPTION
#8277 added implicit README support, but it also rejected parsing any manifest where the README was missing.  This causes a problem because the README is often missing in many registry packages (for various reasons).

This removes the validation at parsing time.  Cargo has historically not had hard enforcement at the parsing stage.  Whether or not the readme exists has always been enforced during publishing. I have added some extra context to the error message, and added a test to that effect.

Fixes #8351
