### PR TITLE
Fix doctests not running with --target=HOST.

### DIFF
--- a/src/cargo/core/compiler/compilation.rs
+++ b/src/cargo/core/compiler/compilation.rs
@@ -66,6 +66,9 @@ pub struct Compilation<'cfg> {
     /// Flags to pass to rustdoc when invoked from cargo test, per package.
     pub rustdocflags: HashMap<PackageId, Vec<String>>,
 
+    /// The target host triple.
+    pub host: String,
+
     config: &'cfg Config,
 
     /// Rustc process to be used by default
@@ -123,6 +126,7 @@ impl<'cfg> Compilation<'cfg> {
             cfgs: HashMap::new(),
             rustdocflags: HashMap::new(),
             config: bcx.config,
+            host: bcx.host_triple().to_string(),
             rustc_process: rustc,
             rustc_workspace_wrapper_process,
             primary_rustc_process,

--- a/tests/testsuite/cross_compile.rs
+++ b/tests/testsuite/cross_compile.rs
@@ -396,6 +396,7 @@ fn no_cross_doctests() {
 [COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] test [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] target/{triple}/debug/deps/foo-[..][EXE]
+[DOCTEST] foo
 ",
             triple = target
         ))


### PR DESCRIPTION
There was a regression in #8167 where `cargo test --target=$HOST` stopped running doctests. This caused doctests to silently stop running in rust-lang/rust (https://github.com/rust-lang/rust/issues/73286).  This PR restores the original behavior where `--target=$HOST` behaves as-if it is a normal host test.

There was a discussion about this at https://github.com/rust-lang/cargo/pull/8167#pullrequestreview-402196323, but I think I let it slip through the cracks.