### PR TITLE
Support linker with -Zdoctest-xcompile.

### DIFF
--- a/src/cargo/core/compiler/compilation.rs
+++ b/src/cargo/core/compiler/compilation.rs
@@ -20,6 +20,8 @@ pub struct Doctest {
     pub args: Vec<OsString>,
     /// Whether or not -Zunstable-options is needed.
     pub unstable_opts: bool,
+    /// The -Clinker value to use.
+    pub linker: Option<PathBuf>,
 }
 
 /// A structure returning the result of a compilation.

--- a/src/cargo/core/compiler/context/mod.rs
+++ b/src/cargo/core/compiler/context/mod.rs
@@ -209,6 +209,7 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
                     unit: unit.clone(),
                     args,
                     unstable_opts,
+                    linker: self.bcx.linker(unit.kind),
                 });
             }
 

--- a/src/cargo/ops/cargo_test.rs
+++ b/src/cargo/ops/cargo_test.rs
@@ -143,6 +143,7 @@ fn run_doc_tests(
             args,
             unstable_opts,
             unit,
+            linker,
         } = doctest_info;
 
         // Skip any `--target` tests unless `doctest-xcompile` is specified.
@@ -169,6 +170,11 @@ fn run_doc_tests(
                 for arg in runtool_args {
                     p.arg("--runtool-arg").arg(arg);
                 }
+            }
+            if let Some(linker) = linker {
+                let mut joined = OsString::from("linker=");
+                joined.push(linker);
+                p.arg("-C").arg(joined);
             }
         }
 

--- a/tests/testsuite/cross_compile.rs
+++ b/tests/testsuite/cross_compile.rs
@@ -1066,3 +1066,52 @@ fn cross_test_dylib() {
         .with_stdout_contains_n("test foo ... ok", 2)
         .run();
 }
+
+#[cargo_test]
+fn doctest_xcompile_linker() {
+    if cross_compile::disabled() {
+        return;
+    }
+    if !is_nightly() {
+        // -Zdoctest-xcompile is unstable
+        return;
+    }
+
+    let target = cross_compile::alternate();
+    let p = project()
+        .file(
+            ".cargo/config",
+            &format!(
+                r#"
+                    [target.{}]
+                    linker = "my-linker-tool"
+                "#,
+                target
+            ),
+        )
+        .file("Cargo.toml", &basic_manifest("foo", "0.1.0"))
+        .file(
+            "src/lib.rs",
+            r#"
+                /// ```
+                /// assert_eq!(1, 1);
+                /// ```
+                pub fn foo() {}
+            "#,
+        )
+        .build();
+
+    // Fails because `my-linker-tool` doesn't actually exist.
+    p.cargo("test --doc -v -Zdoctest-xcompile --target")
+        .arg(&target)
+        .with_status(101)
+        .masquerade_as_nightly_cargo()
+        .with_stderr_contains(&format!(
+            "\
+[RUNNING] `rustdoc --crate-type lib --test [..]\
+    --target {target} [..] -C linker=my-linker-tool[..]
+",
+            target = target,
+        ))
+        .run();
+}


### PR DESCRIPTION
This adds support for `-Clinker` with `-Zdoctest-xcompile`.

I'm not entirely sure how `-Zdoctest-xcompile` was supposed to work without setting the linker. I tested this with std on arm-unknown-linux-gnueabihf with qemu. It seems to work (although it was quite slow).

Closes #7529.