### PR TITLE
Improve support for non-`master` main branches 

### DIFF
--- a/src/bin/cargo/commands/install.rs
+++ b/src/bin/cargo/commands/install.rs
@@ -139,7 +139,7 @@ pub fn exec(config: &mut Config, args: &ArgMatches<'_>) -> CliResult {
         } else if let Some(rev) = args.value_of("rev") {
             GitReference::Rev(rev.to_string())
         } else {
-            GitReference::Branch("master".to_string())
+            GitReference::DefaultBranch
         };
         SourceId::for_git(&url, gitref)?
     } else if let Some(path) = args.value_of_path("path", config) {

--- a/src/cargo/core/source/source_id.rs
+++ b/src/cargo/core/source/source_id.rs
@@ -63,10 +63,12 @@ enum SourceKind {
 pub enum GitReference {
     /// From a tag.
     Tag(String),
-    /// From the HEAD of a branch.
+    /// From a branch.
     Branch(String),
     /// From a specific revision.
     Rev(String),
+    /// The default branch of the repository, the reference named `HEAD`.
+    DefaultBranch,
 }
 
 impl SourceId {
@@ -114,7 +116,7 @@ impl SourceId {
         match kind {
             "git" => {
                 let mut url = url.into_url()?;
-                let mut reference = GitReference::Branch("master".to_string());
+                let mut reference = GitReference::DefaultBranch;
                 for (k, v) in url.query_pairs() {
                     match &k[..] {
                         // Map older 'ref' to branch.
@@ -549,10 +551,10 @@ impl<'a> fmt::Display for SourceIdIntoUrl<'a> {
 
 impl GitReference {
     /// Returns a `Display`able view of this git reference, or None if using
-    /// the head of the "master" branch
+    /// the head of the default branch
     pub fn pretty_ref(&self) -> Option<PrettyRef<'_>> {
         match *self {
-            GitReference::Branch(ref s) if *s == "master" => None,
+            GitReference::DefaultBranch => None,
             _ => Some(PrettyRef { inner: self }),
         }
     }
@@ -569,6 +571,7 @@ impl<'a> fmt::Display for PrettyRef<'a> {
             GitReference::Branch(ref b) => write!(f, "branch={}", b),
             GitReference::Tag(ref s) => write!(f, "tag={}", s),
             GitReference::Rev(ref s) => write!(f, "rev={}", s),
+            GitReference::DefaultBranch => unreachable!(),
         }
     }
 }
@@ -581,11 +584,11 @@ mod tests {
     #[test]
     fn github_sources_equal() {
         let loc = "https://github.com/foo/bar".into_url().unwrap();
-        let master = SourceKind::Git(GitReference::Branch("master".to_string()));
-        let s1 = SourceId::new(master.clone(), loc).unwrap();
+        let default = SourceKind::Git(GitReference::DefaultBranch);
+        let s1 = SourceId::new(default.clone(), loc).unwrap();
 
         let loc = "git://github.com/foo/bar".into_url().unwrap();
-        let s2 = SourceId::new(master, loc.clone()).unwrap();
+        let s2 = SourceId::new(default, loc.clone()).unwrap();
 
         assert_eq!(s1, s2);
 

--- a/src/cargo/ops/vendor.rs
+++ b/src/cargo/ops/vendor.rs
@@ -275,6 +275,7 @@ fn sync(
                     GitReference::Branch(ref b) => branch = Some(b.clone()),
                     GitReference::Tag(ref t) => tag = Some(t.clone()),
                     GitReference::Rev(ref r) => rev = Some(r.clone()),
+                    GitReference::DefaultBranch => {}
                 }
             }
             VendorSource::Git {

--- a/src/cargo/sources/config.rs
+++ b/src/cargo/sources/config.rs
@@ -225,7 +225,7 @@ restore the source replacement configuration to continue the build
                     Some(b) => GitReference::Tag(b.val),
                     None => match def.rev {
                         Some(b) => GitReference::Rev(b.val),
-                        None => GitReference::Branch("master".to_string()),
+                        None => GitReference::DefaultBranch,
                     },
                 },
             };

--- a/src/cargo/sources/git/source.rs
+++ b/src/cargo/sources/git/source.rs
@@ -261,10 +261,6 @@ mod test {
     }
 
     fn src(s: &str) -> SourceId {
-        SourceId::for_git(
-            &s.into_url().unwrap(),
-            GitReference::Branch("master".to_string()),
-        )
-        .unwrap()
+        SourceId::for_git(&s.into_url().unwrap(), GitReference::DefaultBranch).unwrap()
     }
 }

--- a/src/cargo/sources/registry/remote.rs
+++ b/src/cargo/sources/registry/remote.rs
@@ -48,7 +48,7 @@ impl<'cfg> RemoteRegistry<'cfg> {
             source_id,
             config,
             // TODO: we should probably make this configurable
-            index_git_ref: GitReference::Branch("master".to_string()),
+            index_git_ref: GitReference::DefaultBranch,
             tree: RefCell::new(None),
             repo: LazyCell::new(),
             head: Cell::new(None),

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -1686,7 +1686,7 @@ impl DetailedTomlDependency {
                     .map(GitReference::Branch)
                     .or_else(|| self.tag.clone().map(GitReference::Tag))
                     .or_else(|| self.rev.clone().map(GitReference::Rev))
-                    .unwrap_or_else(|| GitReference::Branch("master".to_string()));
+                    .unwrap_or_else(|| GitReference::DefaultBranch);
                 let loc = git.into_url()?;
 
                 if let Some(fragment) = loc.fragment() {

--- a/src/doc/src/reference/specifying-dependencies.md
+++ b/src/doc/src/reference/specifying-dependencies.md
@@ -137,7 +137,7 @@ Cargo will fetch the `git` repository at this location then look for a
 of a workspace and setting `git` to the repository containing the workspace).
 
 Since we haven’t specified any other information, Cargo assumes that
-we intend to use the latest commit on the `master` branch to build our package.
+we intend to use the latest commit on the main branch to build our package.
 You can combine the `git` key with the `rev`, `tag`, or `branch` keys to
 specify something else. Here's an example of specifying that you want to use
 the latest commit on a branch named `next`:

--- a/tests/build-std/main.rs
+++ b/tests/build-std/main.rs
@@ -25,7 +25,6 @@ use std::path::Path;
 fn enable_build_std(e: &mut Execs, arg: Option<&str>) {
     e.env_remove("CARGO_HOME");
     e.env_remove("HOME");
-    e.arg("-Zno-index-update");
 
     // And finally actually enable `build-std` for now
     let arg = match arg {


### PR DESCRIPTION

This commit improves Cargo's support for git repositories whose "main
branch" is not called `master`. Cargo currently pretty liberally assumes
that if nothing else about a git repository is specified then `master`
is the branch name to use. Instead now Cargo has a fourth option as the
desired reference of a repository named `DefaultBranch`. Cargo doesn't
know anything about the actual name of the default branch, it just
updates how git references are fetched internally.

This commit is motivated by news that GitHub is likely to switch away
from the default branch being named `master` in the near future. It
would be a bit of a bummer if from now on everyone had to type
`branch = '...'`, so this tries to improve that!

Closes #3517 
