### PR TITLE
Make it possible to turn off subcommands that include dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ serde_json = { version = "1.0.30", features = ["raw_value"] }
 shell-escape = "0.1.4"
 strip-ansi-escapes = "0.1.0"
 tar = { version = "0.4.26", default-features = false }
-tempfile = "3.0"
+tempfile = { version = "3.0", optional = true }
 termcolor = "1.0"
 toml = "0.5.3"
 unicode-xid = "0.2.0"
@@ -113,6 +113,8 @@ test = false
 doc = false
 
 [features]
+default = ["op-install"]
 deny-warnings = []
 vendored-openssl = ["openssl/vendored"]
 pretty-env-logger = ["pretty_env_logger"]
+op-install = ["tempfile"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ log = "0.4.6"
 libgit2-sys = "0.12.7"
 memchr = "2.1.3"
 num_cpus = "1.0"
-opener = "0.4"
+opener = { version = "0.4", optional = true }
 percent-encoding = "2.0"
 remove_dir_all = "0.5.2"
 rustfix = "0.5.0"
@@ -113,8 +113,9 @@ test = false
 doc = false
 
 [features]
-default = ["op-install"]
+default = ["op-install", "op-doc-open"]
 deny-warnings = []
 vendored-openssl = ["openssl/vendored"]
 pretty-env-logger = ["pretty_env_logger"]
 op-install = ["tempfile"]
+op-doc-open = ["opener"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ termcolor = "1.0"
 toml = "0.5.3"
 unicode-xid = "0.2.0"
 url = "2.0"
-walkdir = "2.2"
+walkdir = { version = "2.2", optional = true }
 clap = "2.31.2"
 unicode-width = "0.1.5"
 openssl = { version = '0.10.11', optional = true }
@@ -105,6 +105,7 @@ features = [
 [dev-dependencies]
 cargo-test-macro = { path = "crates/cargo-test-macro", version = "0.1.0" }
 cargo-test-support = { path = "crates/cargo-test-support", version = "0.1.0" }
+walkdir = "2.2"
 
 [[bin]]
 name = "cargo"
@@ -112,10 +113,11 @@ test = false
 doc = false
 
 [features]
-default = ["op-install", "op-doc-open", "op-fix"]
+default = ["op-install", "op-doc-open", "op-fix", "op-package-publish"]
 deny-warnings = []
 vendored-openssl = ["openssl/vendored"]
 pretty-env-logger = ["pretty_env_logger"]
 op-install = ["tempfile"]
 op-doc-open = ["opener"]
 op-fix = ["rustfix"]
+op-package-publish = ["walkdir"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,6 @@ memchr = "2.1.3"
 num_cpus = "1.0"
 opener = { version = "0.4", optional = true }
 percent-encoding = "2.0"
-remove_dir_all = "0.5.2"
 rustfix = "0.5.0"
 same-file = "1"
 semver = { version = "0.10", features = ["serde"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ memchr = "2.1.3"
 num_cpus = "1.0"
 opener = { version = "0.4", optional = true }
 percent-encoding = "2.0"
-rustfix = "0.5.0"
+rustfix = { version = "0.5.0", optional = true }
 same-file = "1"
 semver = { version = "0.10", features = ["serde"] }
 serde = { version = "1.0.82", features = ["derive"] }
@@ -112,9 +112,10 @@ test = false
 doc = false
 
 [features]
-default = ["op-install", "op-doc-open"]
+default = ["op-install", "op-doc-open", "op-fix"]
 deny-warnings = []
 vendored-openssl = ["openssl/vendored"]
 pretty-env-logger = ["pretty_env_logger"]
 op-install = ["tempfile"]
 op-doc-open = ["opener"]
+op-fix = ["rustfix"]

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -77,6 +77,16 @@ jobs:
   variables:
     TOOLCHAIN: stable
 
+- job: no_default_features
+  pool:
+    vmImage: ubuntu-16.04
+  steps:
+    - template: ci/azure-install-rust.yml
+    - bash: cargo check --no-default-features
+      displayName: "cargo check --no-default-features"
+  variables:
+    TOOLCHAIN: stable
+
 - job: build_std
   pool:
     vmImage: ubuntu-16.04

--- a/crates/cargo-test-support/Cargo.toml
+++ b/crates/cargo-test-support/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 doctest = false
 
 [dependencies]
-cargo = { path = "../.." }
+cargo = { path = "../..", default-features = false }
 cargo-test-macro = { path = "../cargo-test-macro" }
 filetime = "0.2"
 flate2 = { version = "1.0", default-features = false, features = ["zlib"] }

--- a/crates/resolver-tests/Cargo.toml
+++ b/crates/resolver-tests/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Alex Crichton <alex@alexcrichton.com>"]
 edition = "2018"
 
 [dependencies]
-cargo = { path = "../.." }
+cargo = { path = "../..", default-features = false }
 proptest = "0.9.1"
 lazy_static = "1.3.0"
 varisat = "0.2.1"

--- a/src/bin/cargo/commands/mod.rs
+++ b/src/bin/cargo/commands/mod.rs
@@ -20,8 +20,10 @@ pub fn builtin() -> Vec<App> {
         metadata::cli(),
         new::cli(),
         owner::cli(),
+        #[cfg(feature = "op-package-publish")]
         package::cli(),
         pkgid::cli(),
+        #[cfg(feature = "op-package-publish")]
         publish::cli(),
         read_manifest::cli(),
         run::cli(),
@@ -59,8 +61,10 @@ pub fn builtin_exec(cmd: &str) -> Option<fn(&mut Config, &ArgMatches<'_>) -> Cli
         "metadata" => metadata::exec,
         "new" => new::exec,
         "owner" => owner::exec,
+        #[cfg(feature = "op-package-publish")]
         "package" => package::exec,
         "pkgid" => pkgid::exec,
+        #[cfg(feature = "op-package-publish")]
         "publish" => publish::exec,
         "read-manifest" => read_manifest::exec,
         "run" => run::exec,
@@ -98,8 +102,10 @@ pub mod login;
 pub mod metadata;
 pub mod new;
 pub mod owner;
+#[cfg(feature = "op-package-publish")]
 pub mod package;
 pub mod pkgid;
+#[cfg(feature = "op-package-publish")]
 pub mod publish;
 pub mod read_manifest;
 pub mod run;

--- a/src/bin/cargo/commands/mod.rs
+++ b/src/bin/cargo/commands/mod.rs
@@ -8,6 +8,7 @@ pub fn builtin() -> Vec<App> {
         clean::cli(),
         doc::cli(),
         fetch::cli(),
+        #[cfg(feature = "op-fix")]
         fix::cli(),
         generate_lockfile::cli(),
         git_checkout::cli(),
@@ -46,6 +47,7 @@ pub fn builtin_exec(cmd: &str) -> Option<fn(&mut Config, &ArgMatches<'_>) -> Cli
         "clean" => clean::exec,
         "doc" => doc::exec,
         "fetch" => fetch::exec,
+        #[cfg(feature = "op-fix")]
         "fix" => fix::exec,
         "generate-lockfile" => generate_lockfile::exec,
         "git-checkout" => git_checkout::exec,
@@ -84,6 +86,7 @@ pub mod check;
 pub mod clean;
 pub mod doc;
 pub mod fetch;
+#[cfg(feature = "op-fix")]
 pub mod fix;
 pub mod generate_lockfile;
 pub mod git_checkout;

--- a/src/bin/cargo/commands/mod.rs
+++ b/src/bin/cargo/commands/mod.rs
@@ -12,6 +12,7 @@ pub fn builtin() -> Vec<App> {
         generate_lockfile::cli(),
         git_checkout::cli(),
         init::cli(),
+        #[cfg(feature = "op-install")]
         install::cli(),
         locate_project::cli(),
         login::cli(),
@@ -49,6 +50,7 @@ pub fn builtin_exec(cmd: &str) -> Option<fn(&mut Config, &ArgMatches<'_>) -> Cli
         "generate-lockfile" => generate_lockfile::exec,
         "git-checkout" => git_checkout::exec,
         "init" => init::exec,
+        #[cfg(feature = "op-install")]
         "install" => install::exec,
         "locate-project" => locate_project::exec,
         "login" => login::exec,
@@ -86,6 +88,7 @@ pub mod fix;
 pub mod generate_lockfile;
 pub mod git_checkout;
 pub mod init;
+#[cfg(feature = "op-install")]
 pub mod install;
 pub mod locate_project;
 pub mod login;

--- a/src/bin/cargo/main.rs
+++ b/src/bin/cargo/main.rs
@@ -32,7 +32,12 @@ fn main() {
         }
     };
 
-    let result = match cargo::ops::fix_maybe_exec_rustc() {
+    #[cfg(feature = "op-fix")]
+    let fix_maybe_exec_rustc = cargo::ops::fix_maybe_exec_rustc();
+    #[cfg(not(feature = "op-fix"))]
+    let fix_maybe_exec_rustc = CargoResult::Ok(false);
+
+    let result = match fix_maybe_exec_rustc {
         Ok(true) => Ok(()),
         Ok(false) => {
             let _token = cargo::util::job::setup();

--- a/src/cargo/ops/cargo_doc.rs
+++ b/src/cargo/ops/cargo_doc.rs
@@ -108,10 +108,17 @@ fn open_docs(path: &Path, shell: &mut Shell) -> CargoResult<()> {
             }
         }
         None => {
+            #[cfg(feature = "op-doc-open")]
             if let Err(e) = opener::open(&path) {
                 let e = e.into();
                 crate::display_warning_with_error("couldn't open docs", &e, shell);
             }
+            #[cfg(not(feature = "op-doc-open"))]
+            shell.warn(
+                "Ability to open docs disabled at build time. \
+                Please set the BROWSER env var. "
+                    .to_string(),
+            )?;
         }
     };
 

--- a/src/cargo/ops/common_for_install_and_uninstall.rs
+++ b/src/cargo/ops/common_for_install_and_uninstall.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(not(feature = "op-install"), allow(dead_code))]
+
 use std::collections::{btree_map, BTreeMap, BTreeSet};
 use std::env;
 use std::io::prelude::*;

--- a/src/cargo/ops/mod.rs
+++ b/src/cargo/ops/mod.rs
@@ -8,6 +8,7 @@ pub use self::cargo_fetch::{fetch, FetchOptions};
 pub use self::cargo_generate_lockfile::generate_lockfile;
 pub use self::cargo_generate_lockfile::update_lockfile;
 pub use self::cargo_generate_lockfile::UpdateOptions;
+#[cfg(feature = "op-install")]
 pub use self::cargo_install::{install, install_list};
 pub use self::cargo_new::{init, new, NewOptions, VersionControl};
 pub use self::cargo_output_metadata::{output_metadata, ExportInfo, OutputMetadataOptions};
@@ -34,6 +35,7 @@ mod cargo_compile;
 mod cargo_doc;
 mod cargo_fetch;
 mod cargo_generate_lockfile;
+#[cfg(feature = "op-install")]
 mod cargo_install;
 mod cargo_new;
 mod cargo_output_metadata;

--- a/src/cargo/ops/mod.rs
+++ b/src/cargo/ops/mod.rs
@@ -18,6 +18,7 @@ pub use self::cargo_read_manifest::{read_package, read_packages};
 pub use self::cargo_run::run;
 pub use self::cargo_test::{run_benches, run_tests, TestOptions};
 pub use self::cargo_uninstall::uninstall;
+#[cfg(feature = "op-fix")]
 pub use self::fix::{fix, fix_maybe_exec_rustc, FixOptions};
 pub use self::lockfile::{load_pkg_lockfile, resolve_to_string, write_pkg_lockfile};
 pub use self::registry::HttpTimeout;
@@ -46,6 +47,7 @@ mod cargo_run;
 mod cargo_test;
 mod cargo_uninstall;
 mod common_for_install_and_uninstall;
+#[cfg(feature = "op-fix")]
 mod fix;
 mod lockfile;
 mod registry;

--- a/src/cargo/ops/mod.rs
+++ b/src/cargo/ops/mod.rs
@@ -12,6 +12,7 @@ pub use self::cargo_generate_lockfile::UpdateOptions;
 pub use self::cargo_install::{install, install_list};
 pub use self::cargo_new::{init, new, NewOptions, VersionControl};
 pub use self::cargo_output_metadata::{output_metadata, ExportInfo, OutputMetadataOptions};
+#[cfg(feature = "op-package-publish")]
 pub use self::cargo_package::{package, PackageOpts};
 pub use self::cargo_pkgid::pkgid;
 pub use self::cargo_read_manifest::{read_package, read_packages};
@@ -21,11 +22,13 @@ pub use self::cargo_uninstall::uninstall;
 #[cfg(feature = "op-fix")]
 pub use self::fix::{fix, fix_maybe_exec_rustc, FixOptions};
 pub use self::lockfile::{load_pkg_lockfile, resolve_to_string, write_pkg_lockfile};
+#[cfg(feature = "op-package-publish")]
+pub use self::registry::publish;
 pub use self::registry::HttpTimeout;
 pub use self::registry::{configure_http_handle, http_handle_and_timeout};
 pub use self::registry::{http_handle, needs_custom_http_transport, registry_login, search};
 pub use self::registry::{modify_owners, yank, OwnersOptions, PublishOpts};
-pub use self::registry::{publish, registry_configuration, RegistryConfig};
+pub use self::registry::{registry_configuration, RegistryConfig};
 pub use self::resolve::{
     add_overrides, get_resolved_packages, resolve_with_previous, resolve_ws, resolve_ws_with_opts,
 };
@@ -40,6 +43,7 @@ mod cargo_generate_lockfile;
 mod cargo_install;
 mod cargo_new;
 mod cargo_output_metadata;
+#[cfg(feature = "op-package-publish")]
 mod cargo_package;
 mod cargo_pkgid;
 mod cargo_read_manifest;

--- a/src/cargo/ops/registry.rs
+++ b/src/cargo/ops/registry.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(not(feature = "op-package-publish"), allow(unused))]
+
 use std::collections::{BTreeMap, HashSet};
 use std::fs::File;
 use std::io::{self, BufRead};
@@ -16,6 +18,7 @@ use crate::core::dependency::DepKind;
 use crate::core::manifest::ManifestMetadata;
 use crate::core::source::Source;
 use crate::core::{Package, SourceId, Workspace};
+#[cfg(feature = "op-package-publish")]
 use crate::ops;
 use crate::sources::{RegistrySource, SourceConfigMap, CRATES_IO_REGISTRY};
 use crate::util::config::{self, Config, SslVersionConfig, SslVersionConfigRange};
@@ -50,6 +53,7 @@ pub struct PublishOpts<'cfg> {
     pub no_default_features: bool,
 }
 
+#[cfg(feature = "op-package-publish")]
 pub fn publish(ws: &Workspace<'_>, opts: &PublishOpts<'_>) -> CargoResult<()> {
     let pkg = ws.current()?;
 
@@ -170,6 +174,7 @@ fn verify_dependencies(
     Ok(())
 }
 
+#[cfg(feature = "op-package-publish")]
 fn transmit(
     config: &Config,
     pkg: &Package,


### PR DESCRIPTION
There are some dependencies of the cargo crate that are only used by one or two cargo subcommands. Various tools that use cargo from crates.io don't need most of cargo's built in subcommands, but only a subset. For example, cargo-outdated only does resolving, and cargo-udeps only does `cargo check` with some extras. 

This PR adds default-on cargo features for certain subcommands that pull in dependencies. This allows custom cargo subcommands to have a smaller footprint of transitive dependencies and faster build time.

I ran some tests in this repo with `cargo +nightly build` first with the state prior to this PR and then with `--default-features` enabled. It showed 5 less crates to compile, as well as 2 seconds in saved build time (57.3s to 55.7s), which mostly stemmed from reduced build time for the `cargo` crate (28.1s to 26.5s). Apparently the 5 crates avoided weren't part of the critical path of the compilation DAG, but this might be different in scenarios with more or less parallelism than I have. Check how the green line goes down much quicker prior to the 16 second mark:

Graph prior to this PR:
![grafik](https://user-images.githubusercontent.com/8872119/85173513-b112bd80-b273-11ea-9ece-aeaf1d8d2303.png)
Graph after this PR with `--no-default-features`:
![grafik](https://user-images.githubusercontent.com/8872119/85173703-1ebee980-b274-11ea-9388-051e1e72bb92.png)
