### PR TITLE
Introduce CARGO_OUT_DIR environment variable

### DIFF
--- a/src/doc/src/reference/environment-variables.md
+++ b/src/doc/src/reference/environment-variables.md
@@ -186,6 +186,7 @@ let version = env!("CARGO_PKG_VERSION");
 * `CARGO_PKG_REPOSITORY` — The repository from the manifest of your package.
 * `CARGO_CRATE_NAME` — The name of the crate that is currently being compiled.
 * `CARGO_BIN_NAME` — The name of the binary that is currently being compiled (if it is a binary). This name does not include any file extension, such as `.exe`.
+* `CARGO_OUT_DIR` — The target directory of your package.
 * `OUT_DIR` — If the package has a build script, this is set to the folder where the build
               script should place its output. See below for more information.
               (Only set during compilation.)

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -1254,12 +1254,13 @@ fn crate_env_vars() {
             static DESCRIPTION: &'static str = env!("CARGO_PKG_DESCRIPTION");
             static BIN_NAME: &'static str = env!("CARGO_BIN_NAME");
             static CRATE_NAME: &'static str = env!("CARGO_CRATE_NAME");
+            static CARGO_OUT_DIR: &'static str = env!("CARGO_OUT_DIR");
 
 
             fn main() {
-                let s = format!("{}-{}-{} @ {} in {}", VERSION_MAJOR,
+                let s = format!("{}-{}-{} @ {} in {} out {}", VERSION_MAJOR,
                                 VERSION_MINOR, VERSION_PATCH, VERSION_PRE,
-                                CARGO_MANIFEST_DIR);
+                                CARGO_MANIFEST_DIR, CARGO_OUT_DIR);
                  assert_eq!(s, foo::version());
                  println!("{}", s);
                  assert_eq!("foo", PKG_NAME);
@@ -1278,12 +1279,13 @@ fn crate_env_vars() {
             "src/lib.rs",
             r#"
             pub fn version() -> String {
-                format!("{}-{}-{} @ {} in {}",
+                format!("{}-{}-{} @ {} in {} out {}",
                         env!("CARGO_PKG_VERSION_MAJOR"),
                         env!("CARGO_PKG_VERSION_MINOR"),
                         env!("CARGO_PKG_VERSION_PATCH"),
                         env!("CARGO_PKG_VERSION_PRE"),
-                        env!("CARGO_MANIFEST_DIR"))
+                        env!("CARGO_MANIFEST_DIR"),
+                        env!("CARGO_OUT_DIR"))
             }
         "#,
         )
@@ -1294,7 +1296,7 @@ fn crate_env_vars() {
 
     println!("bin");
     p.process(&p.bin("foo-bar"))
-        .with_stdout("0-5-1 @ alpha.1 in [CWD]")
+        .with_stdout("0-5-1 @ alpha.1 in [CWD] out [CWD]/target")
         .run();
 
     println!("test");


### PR DESCRIPTION
The motivation for this change is to allow rust applications to
`include_bytes!` or `include_str!` files that are generated inside the
target directory. Sometimes files can be generated inside the workspace
target directory by custom cargo subcommands that interface with cargo
(via `cargo_metadata` crate) to figure out the target directory. The
`include_*!` macros require the path to be known at compile time. This
makes it impossible do a dynamic lookup for workspace target directory.

Ergnomically speaking, it seems desirable to enable this functionality
through this cargo change, as `CARGO_OUT_DIR` can be considered
conceptually parallel to the already existing `OUT_DIR` env var.

The alternative to `include_*!` is to bundle the generated files with
the application (eg RPM). This, however, introduces packaging failures
and filesystem errors as new error domains. It seems far more reliable
to do the bundling at compile time.