### PR TITLE
Add missing license field.

### DIFF
--- a/crates/cargo-test-support/Cargo.toml
+++ b/crates/cargo-test-support/Cargo.toml
@@ -2,6 +2,7 @@
 name = "cargo-test-support"
 version = "0.1.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
+license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [lib]


### PR DESCRIPTION
Hi, i was playing with `cargo-deny`, and found that it says this crate doesn't have a license field. So i'm going ahead and add it for consistency.