### PR TITLE
Adding environment variable CARGO_PKG_LICENSE_FILE

### DIFF
--- a/src/cargo/core/compiler/compilation.rs
+++ b/src/cargo/core/compiler/compilation.rs
@@ -297,6 +297,10 @@ impl<'cfg> Compilation<'cfg> {
                 "CARGO_PKG_LICENSE",
                 metadata.license.as_ref().unwrap_or(&String::new()),
             )
+            .env(
+                "CARGO_PKG_LICENSE_FILE",
+                metadata.license_file.as_ref().unwrap_or(&String::new()),
+            )
             .env("CARGO_PKG_AUTHORS", &pkg.authors().join(":"))
             .cwd(pkg.root());
         Ok(cmd)

--- a/src/doc/src/reference/environment-variables.md
+++ b/src/doc/src/reference/environment-variables.md
@@ -185,6 +185,7 @@ let version = env!("CARGO_PKG_VERSION");
 * `CARGO_PKG_HOMEPAGE` — The home page from the manifest of your package.
 * `CARGO_PKG_REPOSITORY` — The repository from the manifest of your package.
 * `CARGO_PKG_LICENSE` — The license from the manifest of your package.
+* `CARGO_PKG_LICENSE_FILE` — The license file from the manifest of your package.
 * `CARGO_CRATE_NAME` — The name of the crate that is currently being compiled.
 * `CARGO_BIN_NAME` — The name of the binary that is currently being compiled (if it is a binary). This name does not include any file extension, such as `.exe`.
 * `OUT_DIR` — If the package has a build script, this is set to the folder where the build

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -1231,6 +1231,7 @@ fn crate_env_vars() {
         repository = "https://example.com/repo.git"
         authors = ["wycats@example.com"]
         license = "MIT OR Apache-2.0"
+        license_file = "license.txt"
 
         [[bin]]
         name = "foo-bar"
@@ -1253,6 +1254,7 @@ fn crate_env_vars() {
             static HOMEPAGE: &'static str = env!("CARGO_PKG_HOMEPAGE");
             static REPOSITORY: &'static str = env!("CARGO_PKG_REPOSITORY");
             static LICENSE: &'static str = env!("CARGO_PKG_LICENSE");
+            static LICENSE_FILE: &'static str = env!("CARGO_PKG_LICENSE_FILE");
             static DESCRIPTION: &'static str = env!("CARGO_PKG_DESCRIPTION");
             static BIN_NAME: &'static str = env!("CARGO_BIN_NAME");
             static CRATE_NAME: &'static str = env!("CARGO_CRATE_NAME");


### PR DESCRIPTION
When #8325 was added, only CARGO_PKG_LICENSE was added. However, the field license [may be empty](https://doc.rust-lang.org/cargo/reference/manifest.html#the-license-and-license-file-fields) if the license_field is filled in.
