### PR TITLE
Reserve space based on size_hint prior to pushing.

### DIFF
--- a/src/cargo/util/dependency_queue.rs
+++ b/src/cargo/util/dependency_queue.rs
@@ -66,7 +66,9 @@ impl<N: Hash + Eq + Clone, E: Eq + Hash + Clone, V> DependencyQueue<N, E, V> {
     pub fn queue(&mut self, key: N, value: V, dependencies: impl IntoIterator<Item = (N, E)>) {
         assert!(!self.dep_map.contains_key(&key));
 
-        let mut my_dependencies = HashSet::new();
+        let dependencies = dependencies.into_iter();
+        let mut my_dependencies = HashSet::with_capacity(dependencies.size_hint().0);
+
         for (dep, edge) in dependencies {
             my_dependencies.insert((dep.clone(), edge.clone()));
             self.reverse_dep_map


### PR DESCRIPTION
Not sure how much this will effect. Is there any benchmark that can be run? I assume this is _almost always_ a good thing