### PR TITLE
Allow configuring unstable flags via config file

### DIFF
--- a/src/cargo/core/compiler/rustdoc.rs
+++ b/src/cargo/core/compiler/rustdoc.rs
@@ -52,7 +52,8 @@ impl<'de> serde::de::Deserialize<'de> for RustdocExternMode {
     }
 }
 
-#[derive(serde::Deserialize, Debug)]
+#[derive(serde::Deserialize, Debug, Default)]
+#[serde(default)]
 pub struct RustdocExternMap {
     registries: HashMap<String, String>,
     std: Option<RustdocExternMode>,

--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -429,7 +429,9 @@ impl CliUnstable {
             Ok(true)
         };
 
-        match k {
+        // Permit dashes or underscores in parsing these
+        let normalized_key = k.replace("_", "-");
+        match normalized_key.as_str() {
             "print-im-a-teapot" => self.print_im_a_teapot = parse_bool(k, v)?,
             "unstable-options" => self.unstable_options = parse_empty(k, v)?,
             "no-index-update" => self.no_index_update = parse_empty(k, v)?,

--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -334,66 +334,30 @@ impl Features {
 ///
 /// If you have any trouble with this, please let us know!
 #[derive(Default, Debug, Deserialize)]
-#[serde(rename_all="kebab-case")]
+#[serde(default, rename_all = "kebab-case")]
 pub struct CliUnstable {
-    #[serde(deserialize_with="default_false")]
     pub print_im_a_teapot: bool,
-    #[serde(deserialize_with="default_false")]
     pub unstable_options: bool,
-    #[serde(deserialize_with="default_false")]
     pub no_index_update: bool,
-    #[serde(deserialize_with="default_false")]
     pub avoid_dev_deps: bool,
-    #[serde(deserialize_with="default_false")]
     pub minimal_versions: bool,
-    #[serde(deserialize_with="default_false")]
     pub package_features: bool,
-    #[serde(deserialize_with="default_false")]
     pub advanced_env: bool,
-    #[serde(deserialize_with="default_false")]
     pub config_include: bool,
-    #[serde(deserialize_with="default_false")]
     pub dual_proc_macros: bool,
-    #[serde(deserialize_with="default_false")]
     pub mtime_on_use: bool,
-    #[serde(deserialize_with="default_false")]
     pub named_profiles: bool,
-    #[serde(deserialize_with="default_false")]
     pub binary_dep_depinfo: bool,
     pub build_std: Option<Vec<String>>,
     pub timings: Option<Vec<String>>,
-    #[serde(deserialize_with="default_false")]
     pub doctest_xcompile: bool,
-    #[serde(deserialize_with="default_false")]
     pub panic_abort_tests: bool,
-    #[serde(deserialize_with="default_false")]
     pub jobserver_per_rustc: bool,
     pub features: Option<Vec<String>>,
-    #[serde(deserialize_with="default_false")]
     pub crate_versions: bool,
-    #[serde(deserialize_with="default_false")]
     pub separate_nightlies: bool,
-    #[serde(deserialize_with="default_false")]
     pub multitarget: bool,
-    #[serde(deserialize_with="default_false")]
     pub rustdoc_map: bool,
-}
-
-/// Treat boolean Zflags as optionals for deserializing them.
-/// This allows missing settings to default to disabled (effectively recreating
-/// the serde `default` behavior). Our Deserializer merges multiple sources
-/// inline, so the serde facilities for handling missing or additional fields
-/// don't quite fit.
-///
-/// TODO: This limitation can likely be removed by refactoring 
-///       `de::ConfigMapAccess` to iterate the union of the config and env sets.
-fn default_false<'de, D, T>(deserializer: D) -> Result<T, D::Error>
-where
-    D: serde::Deserializer<'de>,
-    T: Deserialize<'de> + Default,
-{
-    let option = Option::deserialize(deserializer)?;
-    Ok(option.unwrap_or_default())
 }
 
 impl CliUnstable {

--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -334,30 +334,66 @@ impl Features {
 ///
 /// If you have any trouble with this, please let us know!
 #[derive(Default, Debug, Deserialize)]
-#[serde(default, deny_unknown_fields, rename_all="kebab-case")]
+#[serde(rename_all="kebab-case")]
 pub struct CliUnstable {
+    #[serde(deserialize_with="default_false")]
     pub print_im_a_teapot: bool,
+    #[serde(deserialize_with="default_false")]
     pub unstable_options: bool,
+    #[serde(deserialize_with="default_false")]
     pub no_index_update: bool,
+    #[serde(deserialize_with="default_false")]
     pub avoid_dev_deps: bool,
+    #[serde(deserialize_with="default_false")]
     pub minimal_versions: bool,
+    #[serde(deserialize_with="default_false")]
     pub package_features: bool,
+    #[serde(deserialize_with="default_false")]
     pub advanced_env: bool,
+    #[serde(deserialize_with="default_false")]
     pub config_include: bool,
+    #[serde(deserialize_with="default_false")]
     pub dual_proc_macros: bool,
+    #[serde(deserialize_with="default_false")]
     pub mtime_on_use: bool,
+    #[serde(deserialize_with="default_false")]
     pub named_profiles: bool,
+    #[serde(deserialize_with="default_false")]
     pub binary_dep_depinfo: bool,
     pub build_std: Option<Vec<String>>,
     pub timings: Option<Vec<String>>,
+    #[serde(deserialize_with="default_false")]
     pub doctest_xcompile: bool,
+    #[serde(deserialize_with="default_false")]
     pub panic_abort_tests: bool,
+    #[serde(deserialize_with="default_false")]
     pub jobserver_per_rustc: bool,
     pub features: Option<Vec<String>>,
+    #[serde(deserialize_with="default_false")]
     pub crate_versions: bool,
+    #[serde(deserialize_with="default_false")]
     pub separate_nightlies: bool,
+    #[serde(deserialize_with="default_false")]
     pub multitarget: bool,
+    #[serde(deserialize_with="default_false")]
     pub rustdoc_map: bool,
+}
+
+/// Treat boolean Zflags as optionals for deserializing them.
+/// This allows missing settings to default to disabled (effectively recreating
+/// the serde `default` behavior). Our Deserializer merges multiple sources
+/// inline, so the serde facilities for handling missing or additional fields
+/// don't quite fit.
+///
+/// TODO: This limitation can likely be removed by refactoring 
+///       `de::ConfigMapAccess` to iterate the union of the config and env sets.
+fn default_false<'de, D, T>(deserializer: D) -> Result<T, D::Error>
+where
+    D: serde::Deserializer<'de>,
+    T: Deserialize<'de> + Default,
+{
+    let option = Option::deserialize(deserializer)?;
+    Ok(option.unwrap_or_default())
 }
 
 impl CliUnstable {

--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -333,7 +333,10 @@ impl Features {
 ///    and then test for your flag or your value and act accordingly.
 ///
 /// If you have any trouble with this, please let us know!
-#[derive(Default, Debug)]
+#[derive(Default, Debug, Deserialize)]
+#[serde(default)]
+#[serde(deny_unknown_fields)]
+#[serde(rename_all="kebab-case")]
 pub struct CliUnstable {
     pub print_im_a_teapot: bool,
     pub unstable_options: bool,

--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -361,6 +361,7 @@ pub struct CliUnstable {
 }
 
 impl CliUnstable {
+    /// Update unstable options in-place from a slice of flag strings
     pub fn parse(&mut self, flags: &[String]) -> CargoResult<()> {
         if !flags.is_empty() && !nightly_features_allowed() {
             bail!(
@@ -380,9 +381,9 @@ impl CliUnstable {
         Ok(())
     }
 
-    /// Read unstable options from a hashmap.
+    /// Read unstable options from a hashmap, updating in-place.
     /// Intended for consuming unstable settings from config files
-    pub fn from_table(&mut self, flags: &HashMap<String, String>) -> CargoResult<()> {
+    pub fn update_with_table(&mut self, flags: &HashMap<String, String>) -> CargoResult<()> {
         if !flags.is_empty() && !nightly_features_allowed() {
             bail!(
                 "the `-Z` flag is only accepted on the nightly channel of Cargo, \

--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -334,9 +334,7 @@ impl Features {
 ///
 /// If you have any trouble with this, please let us know!
 #[derive(Default, Debug, Deserialize)]
-#[serde(default)]
-#[serde(deny_unknown_fields)]
-#[serde(rename_all="kebab-case")]
+#[serde(default, deny_unknown_fields, rename_all="kebab-case")]
 pub struct CliUnstable {
     pub print_im_a_teapot: bool,
     pub unstable_options: bool,

--- a/src/cargo/util/config/de.rs
+++ b/src/cargo/util/config/de.rs
@@ -298,20 +298,11 @@ impl<'config> ConfigMapAccess<'config> {
         // If the caller is interested in a field which we can provide from
         // the environment, get it from there.
         for field in given_fields {
-            let is_prefix = given_fields
-                .iter()
-                .any(|f| f != field && f.starts_with(field));
             let mut field_key = de.key.clone();
             field_key.push(field);
             for env_key in de.config.env.keys() {
-                if is_prefix {
-                    if env_key == field_key.as_env_key() {
-                        fields.insert(KeyKind::Normal(field.to_string()));
-                    }
-                } else {
-                    if env_key.starts_with(field_key.as_env_key()) {
-                        fields.insert(KeyKind::Normal(field.to_string()));
-                    }
+                if env_key.starts_with(field_key.as_env_key()) {
+                    fields.insert(KeyKind::Normal(field.to_string()));
                 }
             }
         }

--- a/src/cargo/util/config/de.rs
+++ b/src/cargo/util/config/de.rs
@@ -4,6 +4,7 @@ use crate::util::config::value;
 use crate::util::config::{Config, ConfigError, ConfigKey};
 use crate::util::config::{ConfigValue as CV, Definition, Value};
 use serde::{de, de::IntoDeserializer};
+use std::collections::HashSet;
 use std::vec;
 
 /// Serde deserializer used to convert config values to a target type using
@@ -269,37 +270,54 @@ impl<'config> ConfigMapAccess<'config> {
 
     fn new_struct(
         de: Deserializer<'config>,
-        fields: &'static [&'static str],
+        given_fields: &'static [&'static str],
     ) -> Result<ConfigMapAccess<'config>, ConfigError> {
-        let fields: Vec<KeyKind> = fields
-            .iter()
-            .map(|field| KeyKind::Normal(field.to_string()))
-            .collect();
+        let table = de.config.get_table(&de.key)?;
 
         // Assume that if we're deserializing a struct it exhaustively lists all
         // possible fields on this key that we're *supposed* to use, so take
         // this opportunity to warn about any keys that aren't recognized as
         // fields and warn about them.
-        if let Some(mut v) = de.config.get_table(&de.key)? {
-            for (t_key, value) in v.val.drain() {
-                if fields.iter().any(|k| match k {
-                    KeyKind::Normal(s) => s == &t_key,
-                    KeyKind::CaseSensitive(s) => s == &t_key,
-                }) {
-                    continue;
-                }
+        if let Some(v) = table.as_ref() {
+            let unused_keys = v
+                .val
+                .iter()
+                .filter(|(k, _v)| !given_fields.iter().any(|gk| gk == k));
+            for (unused_key, unused_value) in unused_keys {
                 de.config.shell().warn(format!(
                     "unused config key `{}.{}` in `{}`",
                     de.key,
-                    t_key,
-                    value.definition()
+                    unused_key,
+                    unused_value.definition()
                 ))?;
+            }
+        }
+
+        let mut fields = HashSet::new();
+
+        // If the caller is interested in a field which we can provide from
+        // the environment, get it from there.
+        for field in given_fields {
+            let mut field_key = de.key.clone();
+            field_key.push(field);
+            for env_key in de.config.env.keys() {
+                if env_key.starts_with(field_key.as_env_key()) {
+                    fields.insert(KeyKind::Normal(field.to_string()));
+                }
+            }
+        }
+
+        // Add everything from the config table we're interested in that we
+        // haven't already provided via an environment variable
+        if let Some(v) = table {
+            for key in v.val.keys() {
+                fields.insert(KeyKind::Normal(key.clone()));
             }
         }
 
         Ok(ConfigMapAccess {
             de,
-            fields,
+            fields: fields.into_iter().collect(),
             field_index: 0,
         })
     }

--- a/src/cargo/util/config/de.rs
+++ b/src/cargo/util/config/de.rs
@@ -298,11 +298,20 @@ impl<'config> ConfigMapAccess<'config> {
         // If the caller is interested in a field which we can provide from
         // the environment, get it from there.
         for field in given_fields {
+            let is_prefix = given_fields
+                .iter()
+                .any(|f| f != field && f.starts_with(field));
             let mut field_key = de.key.clone();
             field_key.push(field);
             for env_key in de.config.env.keys() {
-                if env_key.starts_with(field_key.as_env_key()) {
-                    fields.insert(KeyKind::Normal(field.to_string()));
+                if is_prefix {
+                    if env_key == field_key.as_env_key() {
+                        fields.insert(KeyKind::Normal(field.to_string()));
+                    }
+                } else {
+                    if env_key.starts_with(field_key.as_env_key()) {
+                        fields.insert(KeyKind::Normal(field.to_string()));
+                    }
                 }
             }
         }

--- a/src/cargo/util/config/mod.rs
+++ b/src/cargo/util/config/mod.rs
@@ -748,9 +748,10 @@ impl Config {
             if let Some(unstable_flags) = self.get::<Option<CliUnstable>>("unstable")? {
                 self.unstable_flags = unstable_flags;
             }
-            // NB. It sucks to parse these twice, but doing it again here
+            // NB. It's not ideal to parse these twice, but doing it again here
             //     allows the CLI to override config files for both enabling
-            //     and disabling.
+            //     and disabling, and doing it up top allows CLI Zflags to
+            //     control config parsing behavior.
             self.unstable_flags.parse(unstable_flags)?;
         }
 

--- a/src/cargo/util/config/mod.rs
+++ b/src/cargo/util/config/mod.rs
@@ -749,7 +749,7 @@ impl Config {
                 self.get::<Option<HashMap<String, String>>>("unstable")?
             {
                 self.unstable_flags
-                    .from_table(&unstable_configs)
+                    .update_with_table(&unstable_configs)
                     .with_context(|| "Invalid [unstable] entry in Cargo config")?;
 
                 // NB. It sucks to parse these twice, but doing it again here

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -394,7 +394,7 @@ impl<'de> de::Deserialize<'de> for U32OrBool {
 }
 
 #[derive(Deserialize, Serialize, Clone, Debug, Default, Eq, PartialEq)]
-#[serde(rename_all = "kebab-case")]
+#[serde(default, rename_all = "kebab-case")]
 pub struct TomlProfile {
     pub opt_level: Option<TomlOptLevel>,
     pub lto: Option<StringOrBool>,

--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -2,8 +2,7 @@
 
 Experimental Cargo features are only available on the nightly channel. You
 typically use one of the `-Z` flags to enable them. Run `cargo -Z help` to
-see a list of flags available. All Z flags accept either dashes or underscores
-as separators.
+see a list of flags available.
 
 `-Z unstable-options` is a generic flag for enabling other unstable
 command-line flags. Options requiring this will be called out below.

--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -2,7 +2,8 @@
 
 Experimental Cargo features are only available on the nightly channel. You
 typically use one of the `-Z` flags to enable them. Run `cargo -Z help` to
-see a list of flags available.
+see a list of flags available. All Z flags accept either dashes or underscores
+as separators.
 
 `-Z unstable-options` is a generic flag for enabling other unstable
 command-line flags. Options requiring this will be called out below.

--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -11,7 +11,7 @@ command-line flags. Options requiring this will be called out below.
 Anything which can be configured with a Z flag can also be set in the cargo
 config file (`.cargo/config.toml`) in the `unstable` table. For example:
 
-```
+```toml
 [unstable]
 mtime-on-use = 'yes'
 multitarget = 'yes'

--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -7,6 +7,16 @@ see a list of flags available.
 `-Z unstable-options` is a generic flag for enabling other unstable
 command-line flags. Options requiring this will be called out below.
 
+Anything which can be configured with a Z flag can also be set in the cargo
+config file (`.cargo/config.toml`) in the `unstable` table. For example:
+
+```
+[unstable]
+mtime-on-use = 'yes'
+multitarget = 'yes'
+timings = 'yes'
+```
+
 Some unstable features will require you to specify the `cargo-features` key in
 `Cargo.toml`.
 

--- a/tests/testsuite/config.rs
+++ b/tests/testsuite/config.rs
@@ -687,10 +687,7 @@ Caused by:
         f3: i64,
         big: i64,
     }
-    assert_error(
-        config.get::<S>("S").unwrap_err(),
-        "missing config key `S.f3`",
-    );
+    assert_error(config.get::<S>("S").unwrap_err(), "missing field `f3`");
 }
 
 #[cargo_test]

--- a/tests/testsuite/config.rs
+++ b/tests/testsuite/config.rs
@@ -1142,26 +1142,6 @@ unstable.print-im-a-teapot = true
 
 #[cargo_test]
 /// Assert that atempting to set an unstable flag that doesn't exist via config
-/// errors out the same as it would on the command line (nightly only)
-fn unstable_invalid_flag_errors_on_nightly() {
-    cargo::core::enable_nightly_features();
-    write_config(
-        "\
-unstable.an-invalid-flag = 'yes'
-",
-    );
-    assert_error(
-        ConfigBuilder::new().build_err().unwrap_err(),
-        "\
-Invalid [unstable] entry in Cargo config
-
-Caused by:
-  unknown `-Z` flag specified: an-invalid-flag",
-    );
-}
-
-#[cargo_test]
-/// Assert that atempting to set an unstable flag that doesn't exist via config
 /// is ignored on stable
 fn unstable_invalid_flag_ignored_on_stable() {
     write_config(

--- a/tests/testsuite/config.rs
+++ b/tests/testsuite/config.rs
@@ -1097,12 +1097,12 @@ Caused by:
 #[cargo_test]
 /// Assert that unstable options can be configured with the `unstable` table in
 /// cargo config files
-fn config_unstable_table() {
+fn unstable_table_notation() {
     cargo::core::enable_nightly_features();
     write_config(
         "\
 [unstable]
-print-im-a-teapot = 'yes'
+print-im-a-teapot = true
 ",
     );
     let config = ConfigBuilder::new().build();
@@ -1111,11 +1111,11 @@ print-im-a-teapot = 'yes'
 
 #[cargo_test]
 /// Assert that dotted notation works for configuring unstable options
-fn config_unstable_dotted() {
+fn unstable_dotted_notation() {
     cargo::core::enable_nightly_features();
     write_config(
         "\
-unstable.print-im-a-teapot = 'yes'
+unstable.print-im-a-teapot = true
 ",
     );
     let config = ConfigBuilder::new().build();
@@ -1124,11 +1124,11 @@ unstable.print-im-a-teapot = 'yes'
 
 #[cargo_test]
 /// Assert that Zflags on the CLI take precedence over those from config
-fn config_unstable_cli_wins() {
+fn unstable_cli_precedence() {
     cargo::core::enable_nightly_features();
     write_config(
         "\
-unstable.print-im-a-teapot = 'yes'
+unstable.print-im-a-teapot = true
 ",
     );
     let config = ConfigBuilder::new().build();
@@ -1142,8 +1142,8 @@ unstable.print-im-a-teapot = 'yes'
 
 #[cargo_test]
 /// Assert that atempting to set an unstable flag that doesn't exist via config
-/// errors out the same as it would on the command line
-fn config_unstable_invalid_flag() {
+/// errors out the same as it would on the command line (nightly only)
+fn unstable_invalid_flag_errors_on_nightly() {
     cargo::core::enable_nightly_features();
     write_config(
         "\
@@ -1158,6 +1158,32 @@ Invalid [unstable] entry in Cargo config
 Caused by:
   unknown `-Z` flag specified: an-invalid-flag",
     );
+}
+
+#[cargo_test]
+/// Assert that atempting to set an unstable flag that doesn't exist via config
+/// is ignored on stable
+fn unstable_invalid_flag_ignored_on_stable() {
+    write_config(
+        "\
+unstable.an-invalid-flag = 'yes'
+",
+    );
+    assert!(ConfigBuilder::new().build_err().is_ok());
+}
+
+#[cargo_test]
+/// Assert that unstable options can be configured with the `unstable` table in
+/// cargo config files
+fn unstable_flags_ignored_on_stable() {
+    write_config(
+        "\
+[unstable]
+print-im-a-teapot = true
+",
+    );
+    let config = ConfigBuilder::new().build();
+    assert_eq!(config.cli_unstable().print_im_a_teapot, false);
 }
 
 #[cargo_test]

--- a/tests/testsuite/config_cli.rs
+++ b/tests/testsuite/config_cli.rs
@@ -268,26 +268,6 @@ fn rerooted_remains() {
 }
 
 #[cargo_test]
-fn unstable_dash_underscore_interchangable() {
-    // Confirm unstable flag parsing treats underscores and dashes
-    // interchangably when coming from the CLI.
-    let config = ConfigBuilder::new()
-        .unstable_flag("print_im_a_teapot")
-        .build();
-    assert_eq!(config.cli_unstable().print_im_a_teapot, true);
-
-    let config = ConfigBuilder::new()
-        .unstable_flag("print-im-a-teapot")
-        .build();
-    assert_eq!(config.cli_unstable().print_im_a_teapot, true);
-
-    let config = ConfigBuilder::new()
-        .unstable_flag("print_im-a_teapot")
-        .build();
-    assert_eq!(config.cli_unstable().print_im_a_teapot, true);
-}
-
-#[cargo_test]
 fn bad_parse() {
     // Fail to TOML parse.
     let config = ConfigBuilder::new().config_arg("abc").build_err();

--- a/tests/testsuite/config_cli.rs
+++ b/tests/testsuite/config_cli.rs
@@ -268,6 +268,26 @@ fn rerooted_remains() {
 }
 
 #[cargo_test]
+fn unstable_dash_underscore_interchangable() {
+    // Confirm unstable flag parsing treats underscores and dashes
+    // interchangably when coming from the CLI.
+    let config = ConfigBuilder::new()
+        .unstable_flag("print_im_a_teapot")
+        .build();
+    assert_eq!(config.cli_unstable().print_im_a_teapot, true);
+
+    let config = ConfigBuilder::new()
+        .unstable_flag("print-im-a-teapot")
+        .build();
+    assert_eq!(config.cli_unstable().print_im_a_teapot, true);
+
+    let config = ConfigBuilder::new()
+        .unstable_flag("print_im-a_teapot")
+        .build();
+    assert_eq!(config.cli_unstable().print_im_a_teapot, true);
+}
+
+#[cargo_test]
 fn bad_parse() {
     // Fail to TOML parse.
     let config = ConfigBuilder::new().config_arg("abc").build_err();


### PR DESCRIPTION
# Summary

This fixes #8127 by mapping the `unstable` key in `.cargo/config` to Z flags.

It should have no impact on stable/beta cargo, and on nightlies it gives folks the ability to configure Z flags for an entire project or workspace. This is meant to make it easier to try things like the [new features resolver](https://github.com/rust-lang/cargo/issues/8088) behavior, mtime-on-use, build-std, or timing reports across a whole project.

I've also included a small (but entirely independent) ergonomics change -- treating dashes and underscores identically in Z flags. That's along for the ride in this PR as the last commit, and is included here because it makes for more idiomatic toml file keys (`print_im_a_teapot = yes` vs `print-im-a-teapot = yes`). Please let me know if y'all would prefer that be in a separate PR, or not happen at all.

# Test Plan

Apologies if I've missed anything -- this is my first cargo contrib and I've tried to hew to the contributing guide. If I've slipped up, please let me know how and I'll fix it.

NB. My linux machine doesn't have multilib set up, so I disabled cross tests.

 * `cargo test` passes for each commit in the stack
 * I formatted each commit in the stack with `rustfmt` 
 * New tests are included alongside the relevant change for each change
 * I've validated each test by locally undoing the code change they support and confirming failure.
 * The CLI wins, for both enable and disabling Z flags, as you'd expect.

Keys in `unstable` which do not correspond with a Z flag will trigger an error indicating the invalid flag came from a config file read:

```
Invalid [unstable] entry in Cargo config

Caused by:
  unknown `-Z` flag specified: an-invalid-flag
```

If you'd like to see a test case which isn't represented here, I'm happy to add it. Just let me know.

# Documentation

I've included commits in this stack updating the only docs page that seemed relevant to me, skimming the book -- `unstable.md`.