### PR TITLE
Fix order-dependent feature resolution.

### DIFF
--- a/src/cargo/core/resolver/dep_cache.rs
+++ b/src/cargo/core/resolver/dep_cache.rs
@@ -402,15 +402,13 @@ impl Requirements<'_> {
         // If `package` is indeed an optional dependency then we activate the
         // feature named `package`, but otherwise if `package` is a required
         // dependency then there's no feature associated with it.
-        if let Some(dep) = self
+        if self
             .summary
             .dependencies()
             .iter()
-            .find(|p| p.name_in_toml() == package)
+            .any(|dep| dep.name_in_toml() == package && dep.is_optional())
         {
-            if dep.is_optional() {
-                self.used.insert(package);
-            }
+            self.used.insert(package);
         }
         self.deps
             .entry(package)


### PR DESCRIPTION
There is a situation where if you have `pkg/feature` syntax, and `pkg` is an optional dependency, but also a dev-dependency, and the dev-dependency appears before the (optional) normal dependency in the summary, then the optional dependency would not get activated. This is because the feature code used `find` to get the first entry.

Fixes #8394
