### PR TITLE
Don't spend build time optimizing build-time-only crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,3 +116,6 @@ doc = false
 deny-warnings = []
 vendored-openssl = ["openssl/vendored"]
 pretty-env-logger = ["pretty_env_logger"]
+
+[profile.release.build-override]
+opt-level = 0


### PR DESCRIPTION
Crates used exclusively at build time, such as proc-macro crates and
their dependencies, don't benefit substantially from optimization; they
take far longer to optimize than time saved when running them during the
build. No machine code from these crates will appear in the final
compiled binary.

Use the new profile-overrides mechanism in Rust 1.41
(https://doc.rust-lang.org/cargo/reference/profiles.html#overrides) to
build such crates with opt-level 0.

Before:
    Finished release [optimized] target(s) in 4m 20s
After:
    Finished release [optimized] target(s) in 4m 07s