### PR TITLE
Improve the description of Config.home_path

### DIFF
--- a/src/cargo/util/config/mod.rs
+++ b/src/cargo/util/config/mod.rs
@@ -122,7 +122,7 @@ macro_rules! get_value_typed {
 /// relating to cargo itself.
 #[derive(Debug)]
 pub struct Config {
-    /// The location of the user's 'home' directory. OS-dependent.
+    /// The location of the user's Cargo home directory. OS-dependent.
     home_path: Filesystem,
     /// Information about how to write messages to the shell
     shell: RefCell<Shell>,


### PR DESCRIPTION
I poked around and it seems it's not the user's home directory but Cargo
home (which may or may not be in user's home).