### PR TITLE
Remove unused remove_dir_all dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,6 @@ memchr = "2.1.3"
 num_cpus = "1.0"
 opener = "0.4"
 percent-encoding = "2.0"
-remove_dir_all = "0.5.2"
 rustfix = "0.5.0"
 same-file = "1"
 semver = { version = "0.10", features = ["serde"] }


### PR DESCRIPTION
Originally part of #8384 but sadly the PR got rejected.