### PR TITLE
Expose built cdylib artifacts in the Compilation structure

### DIFF
--- a/src/cargo/core/compiler/compilation.rs
+++ b/src/cargo/core/compiler/compilation.rs
@@ -34,6 +34,9 @@ pub struct Compilation<'cfg> {
     /// An array of all binaries created.
     pub binaries: Vec<(Unit, PathBuf)>,
 
+    /// An array of all cdylibs created.
+    pub cdylibs: Vec<(Unit, PathBuf)>,
+
     /// All directories for the output of native build commands.
     ///
     /// This is currently used to drive some entries which are added to the
@@ -123,6 +126,7 @@ impl<'cfg> Compilation<'cfg> {
                 .collect(),
             tests: Vec::new(),
             binaries: Vec::new(),
+            cdylibs: Vec::new(),
             extra_env: HashMap::new(),
             to_doc_test: Vec::new(),
             cfgs: HashMap::new(),

--- a/src/cargo/core/compiler/context/mod.rs
+++ b/src/cargo/core/compiler/context/mod.rs
@@ -179,6 +179,12 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
                     self.compilation
                         .binaries
                         .push((unit.clone(), bindst.clone()));
+                } else if unit.target.is_cdylib() {
+                    if !self.compilation.cdylibs.iter().any(|(u, _)| u == unit) {
+                        self.compilation
+                            .cdylibs
+                            .push((unit.clone(), bindst.clone()));
+                    }
                 }
             }
 


### PR DESCRIPTION
This change makes it much easier to find these artifacts in a
platform-independent way when writing automation around the cargo API.