### PR TITLE
Share target directory with sub-crates

### DIFF
--- a/crates/.cargo/config.toml
+++ b/crates/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+target-dir = "../target"


### PR DESCRIPTION
This gets us as close to workspaces as we can do without actually
building a workspace. That isn't possible as currently there is no
support for nested workspaces, and cargo is included into
rustc's workspace.

The benefit of this PR is a shared dependency cache.