### PR TITLE
Parse `# env-dep` directives in dep-info files

### DIFF
--- a/src/cargo/core/compiler/context/compilation_files.rs
+++ b/src/cargo/core/compiler/context/compilation_files.rs
@@ -490,7 +490,7 @@ fn compute_metadata(
     // cause a new hash due to the rustc version changing, but this allows
     // cargo to be extra careful to deal with different versions of cargo that
     // use the same rustc version.
-    1.hash(&mut hasher);
+    2.hash(&mut hasher);
 
     // Unique metadata per (name, source, version) triple. This'll allow us
     // to pull crates from anywhere without worrying about conflicts.

--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -70,7 +70,7 @@ pub trait Executor: Send + Sync + 'static {
     /// this package.
     fn exec(
         &self,
-        cmd: ProcessBuilder,
+        cmd: &ProcessBuilder,
         id: PackageId,
         target: &Target,
         mode: CompileMode,
@@ -93,7 +93,7 @@ pub struct DefaultExecutor;
 impl Executor for DefaultExecutor {
     fn exec(
         &self,
-        cmd: ProcessBuilder,
+        cmd: &ProcessBuilder,
         _id: PackageId,
         _target: &Target,
         _mode: CompileMode,
@@ -281,7 +281,7 @@ fn rustc(cx: &mut Context<'_, '_>, unit: &Unit, exec: &Arc<dyn Executor>) -> Car
             state.build_plan(buildkey, rustc.clone(), outputs.clone());
         } else {
             exec.exec(
-                rustc,
+                &rustc,
                 package_id,
                 &target,
                 mode,
@@ -299,6 +299,7 @@ fn rustc(cx: &mut Context<'_, '_>, unit: &Unit, exec: &Arc<dyn Executor>) -> Car
                 &cwd,
                 &pkg_root,
                 &target_dir,
+                &rustc,
                 // Do not track source files in the fingerprint for registry dependencies.
                 is_local,
             )

--- a/src/cargo/core/compiler/output_depinfo.rs
+++ b/src/cargo/core/compiler/output_depinfo.rs
@@ -65,7 +65,7 @@ fn add_deps_for_unit(
         if let Some(paths) =
             fingerprint::parse_dep_info(unit.pkg.root(), cx.files().host_root(), &dep_info_loc)?
         {
-            for path in paths {
+            for path in paths.files {
                 deps.insert(path);
             }
         } else {
@@ -141,7 +141,7 @@ pub fn output_depinfo(cx: &mut Context<'_, '_>, unit: &Unit) -> CargoResult<()> 
                 // If nothing changed don't recreate the file which could alter
                 // its mtime
                 if let Ok(previous) = fingerprint::parse_rustc_dep_info(&output_path) {
-                    if previous.len() == 1 && previous[0].0 == target_fn && previous[0].1 == deps {
+                    if previous.files.iter().eq(deps.iter().map(Path::new)) {
                         continue;
                     }
                 }

--- a/tests/internal.rs
+++ b/tests/internal.rs
@@ -24,6 +24,9 @@ fn check_forbidden_code() {
         }
         let c = fs::read_to_string(path).unwrap();
         for (line_index, line) in c.lines().enumerate() {
+            if line.trim().starts_with("//") {
+                continue;
+            }
             if line_has_print(line) {
                 if entry.file_name().to_str().unwrap() == "cargo_new.rs" && line.contains("Hello") {
                     // An exception.

--- a/tests/testsuite/freshness.rs
+++ b/tests/testsuite/freshness.rs
@@ -2493,6 +2493,7 @@ fn env_in_code_causes_rebuild() {
             r#"
                 fn main() {
                     println!("{:?}", option_env!("FOO"));
+                    println!("{:?}", option_env!("FOO\nBAR"));
                 }
             "#,
         )
@@ -2525,6 +2526,19 @@ fn env_in_code_causes_rebuild() {
         .run();
     p.cargo("build")
         .env_remove("FOO")
+        .with_stderr("[FINISHED][..]")
+        .run();
+
+    let interesting = " #!$\nabc\r\\\t\u{8}\r\n";
+    p.cargo("build").env("FOO", interesting).run();
+    p.cargo("build")
+        .env("FOO", interesting)
+        .with_stderr("[FINISHED][..]")
+        .run();
+
+    p.cargo("build").env("FOO\nBAR", interesting).run();
+    p.cargo("build")
+        .env("FOO\nBAR", interesting)
         .with_stderr("[FINISHED][..]")
         .run();
 }

--- a/tests/testsuite/freshness.rs
+++ b/tests/testsuite/freshness.rs
@@ -2475,7 +2475,7 @@ fn lld_is_fresh() {
 
 #[cargo_test]
 fn env_in_code_causes_rebuild() {
-    // Only nightly has support in dep-info files for this
+    // Only nightly 1.46 has support in dep-info files for this
     if !cargo_test_support::is_nightly() {
         return;
     }
@@ -2531,7 +2531,7 @@ fn env_in_code_causes_rebuild() {
 
 #[cargo_test]
 fn env_build_script_no_rebuild() {
-    // Only nightly has support in dep-info files for this
+    // Only nightly 1.46 has support in dep-info files for this
     if !cargo_test_support::is_nightly() {
         return;
     }


### PR DESCRIPTION
This commit updates Cargo's parsing of rustc's dep-info files to account
for changes made upstream in rust-lang/rust#71858. This means that if
`env!` or `option_env!` is used in crate files Cargo will correctly
rebuild the crate if the env var changes.

Closes #8417