### PR TITLE
[WIP] Add flag to warn about unused dependencies

### DIFF
--- a/src/bin/cargo/cli.rs
+++ b/src/bin/cargo/cli.rs
@@ -46,6 +46,7 @@ Available unstable (nightly-only) flags:
     -Z terminal-width      -- Provide a terminal width to rustc for error truncation
     -Z namespaced-features -- Allow features with `dep:` prefix
     -Z weak-dep-features   -- Allow `dep_name?/feature` feature syntax
+    -Z warn-unused-deps -- Emit warnings about unused dependencies
     -Z patch-in-config     -- Allow `[patch]` sections in .cargo/config.toml files
 
 Run with 'cargo -Z [FLAG] [SUBCOMMAND]'"

--- a/src/cargo/core/compiler/build_context/mod.rs
+++ b/src/cargo/core/compiler/build_context/mod.rs
@@ -1,4 +1,5 @@
 use crate::core::compiler::unit_graph::UnitGraph;
+use crate::core::compiler::unused_dependencies::AllowedKinds;
 use crate::core::compiler::{BuildConfig, CompileKind, Unit};
 use crate::core::profiles::Profiles;
 use crate::core::PackageSet;
@@ -30,6 +31,7 @@ pub struct BuildContext<'a, 'cfg> {
     pub profiles: Profiles,
     pub build_config: &'a BuildConfig,
 
+    pub allowed_kinds: AllowedKinds,
     /// Extra compiler args for either `rustc` or `rustdoc`.
     pub extra_compiler_args: HashMap<Unit, Vec<String>>,
 
@@ -56,6 +58,7 @@ impl<'a, 'cfg> BuildContext<'a, 'cfg> {
         ws: &'a Workspace<'cfg>,
         packages: PackageSet<'cfg>,
         build_config: &'a BuildConfig,
+        allowed_kinds: AllowedKinds,
         profiles: Profiles,
         extra_compiler_args: HashMap<Unit, Vec<String>>,
         target_data: RustcTargetData,
@@ -74,6 +77,7 @@ impl<'a, 'cfg> BuildContext<'a, 'cfg> {
             config: ws.config(),
             packages,
             build_config,
+            allowed_kinds,
             profiles,
             extra_compiler_args,
             target_data,

--- a/src/cargo/core/compiler/compilation.rs
+++ b/src/cargo/core/compiler/compilation.rs
@@ -7,7 +7,8 @@ use cargo_platform::CfgExpr;
 use cargo_util::{paths, ProcessBuilder};
 use semver::Version;
 
-use super::BuildContext;
+use super::unused_dependencies::UnusedDepState;
+use super::{BuildContext, UnitDep};
 use crate::core::compiler::{CompileKind, Metadata, Unit};
 use crate::core::Package;
 use crate::util::{config, CargoResult, Config};
@@ -16,6 +17,8 @@ use crate::util::{config, CargoResult, Config};
 pub struct Doctest {
     /// What's being doctested
     pub unit: Unit,
+    /// Dependencies of the unit
+    pub unit_deps: Vec<UnitDep>,
     /// Arguments needed to pass to rustdoc to run this test.
     pub args: Vec<OsString>,
     /// Whether or not -Zunstable-options is needed.
@@ -86,6 +89,8 @@ pub struct Compilation<'cfg> {
     /// The target host triple.
     pub host: String,
 
+    pub(crate) unused_dep_state: Option<UnusedDepState>,
+
     config: &'cfg Config,
 
     /// Rustc process to be used by default
@@ -141,6 +146,7 @@ impl<'cfg> Compilation<'cfg> {
             to_doc_test: Vec::new(),
             config: bcx.config,
             host: bcx.host_triple().to_string(),
+            unused_dep_state: None,
             rustc_process: rustc,
             rustc_workspace_wrapper_process,
             primary_rustc_process,

--- a/src/cargo/core/compiler/context/mod.rs
+++ b/src/cargo/core/compiler/context/mod.rs
@@ -168,7 +168,9 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
         }
 
         // Now that we've figured out everything that we're going to do, do it!
-        queue.execute(&mut self, &mut plan)?;
+        let unused_dep_state = queue.execute(&mut self, &mut plan)?;
+
+        self.compilation.unused_dep_state = Some(unused_dep_state);
 
         if build_plan {
             plan.set_inputs(self.build_plan_inputs()?);
@@ -255,6 +257,7 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
 
                 self.compilation.to_doc_test.push(compilation::Doctest {
                     unit: unit.clone(),
+                    unit_deps: self.unit_deps(&unit).to_vec(),
                     args,
                     unstable_opts,
                     linker: self.bcx.linker(unit.kind),

--- a/src/cargo/core/compiler/job_queue.rs
+++ b/src/cargo/core/compiler/job_queue.rs
@@ -70,7 +70,7 @@ use super::job::{
     Job,
 };
 use super::timings::Timings;
-use super::unused_dependencies::UnusedDepState;
+use super::unused_dependencies::{UnusedDepState, UnusedExterns};
 use super::{BuildContext, BuildPlan, CompileMode, Context, Unit};
 use crate::core::compiler::future_incompat::{
     FutureBreakageItem, OnDiskReport, FUTURE_INCOMPAT_FILE,
@@ -244,7 +244,7 @@ enum Message {
     Token(io::Result<Acquired>),
     Finish(JobId, Artifact, CargoResult<()>),
     FutureIncompatReport(JobId, Vec<FutureBreakageItem>),
-    UnusedExterns(JobId, Vec<String>),
+    UnusedExterns(JobId, UnusedExterns),
 
     // This client should get release_raw called on it with one of our tokens
     NeedsToken(JobId),
@@ -308,7 +308,7 @@ impl<'a> JobState<'a> {
     ///
     /// This is useful for checking unused dependencies.
     /// Should only be called once, as the compiler only emits it once per compilation.
-    pub fn unused_externs(&self, unused_externs: Vec<String>) {
+    pub fn unused_externs(&self, unused_externs: UnusedExterns) {
         self.messages
             .push(Message::UnusedExterns(self.id, unused_externs));
     }

--- a/src/cargo/core/compiler/job_queue.rs
+++ b/src/cargo/core/compiler/job_queue.rs
@@ -457,10 +457,8 @@ impl<'cfg> JobQueue<'cfg> {
             .map(move |srv| srv.start(move |msg| messages.push(Message::FixDiagnostic(msg))));
 
         crossbeam_utils::thread::scope(move |scope| {
-            match state.drain_the_queue(cx, plan, scope, &helper) {
-                Some(err) => Err(err),
-                None => Ok(()),
-            }
+            let (result,) = state.drain_the_queue(cx, plan, scope, &helper);
+            result
         })
         .expect("child threads shouldn't panic")
     }
@@ -691,15 +689,16 @@ impl<'cfg> DrainState<'cfg> {
     /// This is the "main" loop, where Cargo does all work to run the
     /// compiler.
     ///
-    /// This returns an Option to prevent the use of `?` on `Result` types
-    /// because it is important for the loop to carefully handle errors.
+    /// This returns a tuple of `Result` to prevent the use of `?` on
+    /// `Result` types because it is important for the loop to
+    /// carefully handle errors.
     fn drain_the_queue(
         mut self,
         cx: &mut Context<'_, '_>,
         plan: &mut BuildPlan,
         scope: &Scope<'_>,
         jobserver_helper: &HelperThread,
-    ) -> Option<anyhow::Error> {
+    ) -> (Result<(), anyhow::Error>,) {
         trace!("queue: {:#?}", self.queue);
 
         // Iteratively execute the entire dependency graph. Each turn of the
@@ -769,7 +768,7 @@ impl<'cfg> DrainState<'cfg> {
             if error.is_some() {
                 crate::display_error(&e, &mut cx.bcx.config.shell());
             } else {
-                return Some(e);
+                return (Err(e),);
             }
         }
         if cx.bcx.build_config.emit_json() {
@@ -782,13 +781,13 @@ impl<'cfg> DrainState<'cfg> {
                 if error.is_some() {
                     crate::display_error(&e.into(), &mut shell);
                 } else {
-                    return Some(e.into());
+                    return (Err(e.into()),);
                 }
             }
         }
 
         if let Some(e) = error {
-            Some(e)
+            (Err(e),)
         } else if self.queue.is_empty() && self.pending_queue.is_empty() {
             let message = format!(
                 "{} [{}] target(s) in {}",
@@ -800,10 +799,10 @@ impl<'cfg> DrainState<'cfg> {
                 self.emit_future_incompat(cx);
             }
 
-            None
+            (Ok(()),)
         } else {
             debug!("queue: {:#?}", self.queue);
-            Some(internal("finished with jobs still left in the queue"))
+            (Err(internal("finished with jobs still left in the queue")),)
         }
     }
 

--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -20,6 +20,7 @@ mod timings;
 mod unit;
 pub mod unit_dependencies;
 pub mod unit_graph;
+pub mod unused_dependencies;
 
 use std::env;
 use std::ffi::{OsStr, OsString};
@@ -614,7 +615,7 @@ fn rustdoc(cx: &mut Context<'_, '_>, unit: &Unit) -> CargoResult<Work> {
         rustdoc.arg("--cfg").arg(&format!("feature=\"{}\"", feat));
     }
 
-    add_error_format_and_color(cx, &mut rustdoc, false);
+    add_error_format_and_color(cx, unit, &mut rustdoc, false);
     add_allow_features(cx, &mut rustdoc);
 
     if let Some(args) = cx.bcx.extra_args_for(unit) {
@@ -715,13 +716,24 @@ fn add_allow_features(cx: &Context<'_, '_>, cmd: &mut ProcessBuilder) {
 /// intercepting messages like rmeta artifacts, etc. rustc includes a
 /// "rendered" field in the JSON message with the message properly formatted,
 /// which Cargo will extract and display to the user.
-fn add_error_format_and_color(cx: &Context<'_, '_>, cmd: &mut ProcessBuilder, pipelined: bool) {
+fn add_error_format_and_color(
+    cx: &Context<'_, '_>,
+    unit: &Unit,
+    cmd: &mut ProcessBuilder,
+    pipelined: bool,
+) {
     cmd.arg("--error-format=json");
     let mut json = String::from("--json=diagnostic-rendered-ansi");
     if pipelined {
         // Pipelining needs to know when rmeta files are finished. Tell rustc
         // to emit a message that cargo will intercept.
         json.push_str(",artifacts");
+    }
+
+    // Emit unused externs but only if the flag is enabled
+    // and only for units we are interested in.
+    if cx.bcx.config.cli_unstable().warn_unused_deps && unit.show_warnings(cx.bcx.config) {
+        json.push_str(",unused-externs");
     }
 
     match cx.bcx.build_config.message_format {
@@ -782,7 +794,7 @@ fn build_base_args(
     edition.cmd_edition_arg(cmd);
 
     add_path_args(bcx.ws, unit, cmd);
-    add_error_format_and_color(cx, cmd, cx.rmeta_required(unit));
+    add_error_format_and_color(cx, unit, cmd, cx.rmeta_required(unit));
     add_allow_features(cx, cmd);
 
     if !test {
@@ -1036,6 +1048,10 @@ fn build_deps_args(
 
     for arg in extern_args(cx, unit, &mut unstable_opts)? {
         cmd.arg(arg);
+    }
+
+    if cx.bcx.config.cli_unstable().warn_unused_deps {
+        unstable_opts = true;
     }
 
     // This will only be set if we're already using a feature
@@ -1320,6 +1336,19 @@ fn on_stderr_line_inner(
             }
             return Ok(false);
         }
+    }
+
+    #[derive(serde::Deserialize)]
+    struct UnusedExterns {
+        unused_extern_names: Vec<String>,
+    }
+    if let Ok(uext) = serde_json::from_str::<UnusedExterns>(compiler_message.get()) {
+        log::trace!(
+            "obtained unused externs list from rustc: `{:?}`",
+            uext.unused_extern_names
+        );
+        state.unused_externs(uext.unused_extern_names);
+        return Ok(true);
     }
 
     #[derive(serde::Deserialize)]

--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -50,6 +50,7 @@ pub(crate) use self::layout::Layout;
 pub use self::lto::Lto;
 use self::output_depinfo::output_depinfo;
 use self::unit_graph::UnitDep;
+use self::unused_dependencies::UnusedExterns;
 use crate::core::compiler::future_incompat::FutureIncompatReport;
 pub use crate::core::compiler::unit::{Unit, UnitInterner};
 use crate::core::manifest::TargetSourcePath;
@@ -215,6 +216,10 @@ fn rustc(cx: &mut Context<'_, '_>, unit: &Unit, exec: &Arc<dyn Executor>) -> Car
     let buildkey = unit.buildkey();
 
     add_cap_lints(cx.bcx, unit, &mut rustc);
+
+    if cx.bcx.config.cli_unstable().warn_unused_deps && unit.show_warnings(cx.bcx.config) {
+        rustc.arg("-W").arg("unused_crate_dependencies");
+    }
 
     let outputs = cx.outputs(unit)?;
     let root = cx.files().out_dir(unit);
@@ -1338,16 +1343,9 @@ fn on_stderr_line_inner(
         }
     }
 
-    #[derive(serde::Deserialize)]
-    struct UnusedExterns {
-        unused_extern_names: Vec<String>,
-    }
     if let Ok(uext) = serde_json::from_str::<UnusedExterns>(compiler_message.get()) {
-        log::trace!(
-            "obtained unused externs list from rustc: `{:?}`",
-            uext.unused_extern_names
-        );
-        state.unused_externs(uext.unused_extern_names);
+        log::trace!("obtained unused externs message from rustc: `{:?}`", uext);
+        state.unused_externs(uext);
         return Ok(true);
     }
 

--- a/src/cargo/core/compiler/unit_graph.rs
+++ b/src/cargo/core/compiler/unit_graph.rs
@@ -1,11 +1,12 @@
 use crate::core::compiler::Unit;
 use crate::core::compiler::{CompileKind, CompileMode};
 use crate::core::profiles::{Profile, UnitFor};
-use crate::core::{PackageId, Target};
+use crate::core::{Dependency, PackageId, Target};
 use crate::util::interning::InternedString;
 use crate::util::CargoResult;
 use crate::Config;
 use std::collections::HashMap;
+use std::hash::{Hash, Hasher};
 use std::io::Write;
 
 /// The dependency graph of Units.
@@ -16,6 +17,8 @@ pub type UnitGraph = HashMap<Unit, Vec<UnitDep>>;
 pub struct UnitDep {
     /// The dependency unit.
     pub unit: Unit,
+    /// The manifest dependency that gave rise to this dependency
+    pub dependency: UnitDependency,
     /// The purpose of this dependency (a dependency for a test, or a build
     /// script, etc.). Do not use this after the unit graph has been built.
     pub unit_for: UnitFor,
@@ -25,6 +28,15 @@ pub struct UnitDep {
     pub public: bool,
     /// If `true`, the dependency should not be added to Rust's prelude.
     pub noprelude: bool,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, PartialOrd, Ord)]
+pub struct UnitDependency(pub Option<Dependency>);
+
+impl Hash for UnitDependency {
+    fn hash<H: Hasher>(&self, _: &mut H) {
+        // ...
+    }
 }
 
 const VERSION: u32 = 1;

--- a/src/cargo/core/compiler/unused_dependencies.rs
+++ b/src/cargo/core/compiler/unused_dependencies.rs
@@ -1,0 +1,293 @@
+use super::unit::Unit;
+use super::Context;
+use crate::core::compiler::build_config::CompileMode;
+use crate::core::dependency::DepKind;
+use crate::core::manifest::TargetKind;
+use crate::core::Dependency;
+use crate::core::PackageId;
+use crate::util::errors::CargoResult;
+use crate::util::interning::InternedString;
+use log::trace;
+
+use std::collections::{HashMap, HashSet};
+
+pub type AllowedKinds = HashSet<DepKind>;
+
+#[derive(Default)]
+struct State {
+    /// All externs of a root unit.
+    externs: HashMap<InternedString, Option<Dependency>>,
+    /// The used externs so far.
+    /// The DepKind is included so that we can tell when
+    /// a proper dependency should actually be a dev-dependency
+    used_externs: HashSet<(InternedString, DepKind)>,
+    reports_needed_by: HashSet<Unit>,
+}
+
+pub struct UnusedDepState {
+    states: HashMap<(PackageId, Option<DepKind>), State>,
+    /// Tracking for which units we have received reports from.
+    ///
+    /// When we didn't receive reports, e.g. because of an error,
+    /// or because the compiler segfaulted, etc., we don't emit
+    /// any warnings for missing dependencies for the specific
+    /// class.
+    reports_obtained: HashSet<Unit>,
+}
+
+fn dep_kind_desc(kind: Option<DepKind>) -> &'static str {
+    match kind {
+        Some(kind) => match kind {
+            DepKind::Normal => "",
+            DepKind::Development => "dev-",
+            DepKind::Build => "build-",
+        },
+        None => "internal-",
+    }
+}
+
+fn dep_kind_of(unit: &Unit) -> DepKind {
+    match unit.target.kind() {
+        TargetKind::Lib(_) => match unit.mode {
+            // To support lib.rs with #[cfg(test)] use foo_crate as _;
+            CompileMode::Test => DepKind::Development,
+            _ => DepKind::Normal,
+        },
+        TargetKind::Bin => DepKind::Normal,
+        TargetKind::Test => DepKind::Development,
+        TargetKind::Bench => DepKind::Development,
+        TargetKind::ExampleLib(_) => DepKind::Development,
+        TargetKind::ExampleBin => DepKind::Development,
+        TargetKind::CustomBuild => DepKind::Build,
+    }
+}
+
+fn unit_desc(unit: &Unit) -> String {
+    format!(
+        "{}/{}+{:?}",
+        unit.target.name(),
+        unit.target.kind().description(),
+        unit.mode,
+    )
+}
+
+impl UnusedDepState {
+    pub fn new_with_graph(cx: &mut Context<'_, '_>) -> Self {
+        let mut states = HashMap::<_, State>::new();
+
+        let roots_without_build = &cx.bcx.roots;
+
+        // Compute the build scripts of the roots so that we can
+        // lint for unused [build-dependencies].
+        // First iterate on the root's dependencies,
+        // searching for the build-script-run units.
+        // Obtain the build-script-build units from those by
+        // another iteration, as only they depend on the
+        // [build-dependencies] of a package.
+        let mut build_root_runs = HashSet::new();
+        for root in roots_without_build.iter() {
+            for dep in cx.unit_deps(root).iter() {
+                if dep.unit.pkg.package_id() != root.pkg.package_id() {
+                    continue;
+                }
+                if !dep.unit.target.is_custom_build() {
+                    continue;
+                }
+                build_root_runs.insert(dep.unit.clone());
+            }
+        }
+        let mut build_roots = HashSet::new();
+        for root in build_root_runs.iter() {
+            for dep in cx.unit_deps(root).iter() {
+                if dep.unit.pkg.package_id() != root.pkg.package_id() {
+                    continue;
+                }
+                if !dep.unit.target.is_custom_build() {
+                    continue;
+                }
+                if dep.unit.mode != CompileMode::Build {
+                    continue;
+                }
+                build_roots.insert(dep.unit.clone());
+            }
+        }
+
+        // Now build the datastructures
+        for root in roots_without_build.iter().chain(build_roots.iter()) {
+            let pkg_id = root.pkg.package_id();
+            trace!(
+                "Udeps root package {} tgt {}",
+                root.pkg.name(),
+                unit_desc(root),
+            );
+            // We aren't getting output from doctests, so skip them (for now)
+            if root.mode == CompileMode::Doctest {
+                trace!("    -> skipping doctest");
+                continue;
+            }
+            for dep in cx.unit_deps(root).iter() {
+                trace!(
+                    "    => {} {}",
+                    dep.unit.pkg.name(),
+                    dep.dependency.0.is_some()
+                );
+                let dependency = if let Some(dependency) = &dep.dependency.0 {
+                    Some(dependency.clone())
+                } else if dep.unit.pkg.package_id() == root.pkg.package_id() {
+                    None
+                } else {
+                    continue;
+                };
+                let kind = dependency.as_ref().map(|dependency| dependency.kind());
+                let state = states
+                    .entry((pkg_id, kind))
+                    .or_insert_with(Default::default);
+                state.externs.insert(dep.extern_crate_name, dependency);
+                state.reports_needed_by.insert(root.clone());
+            }
+        }
+
+        Self {
+            states,
+            reports_obtained: HashSet::new(),
+        }
+    }
+    /// Records the unused externs coming from the compiler by first inverting them to the used externs
+    /// and then updating the global list of used externs
+    pub fn record_unused_externs_for_unit(
+        &mut self,
+        cx: &mut Context<'_, '_>,
+        unit: &Unit,
+        unused_externs: Vec<String>,
+    ) {
+        self.reports_obtained.insert(unit.clone());
+        let usable_deps_iter = cx
+            .unit_deps(unit)
+            .iter()
+            // compare with similar check in extern_args
+            .filter(|dep| dep.unit.target.is_linkable() && !dep.unit.mode.is_doc());
+
+        let unused_externs_set = unused_externs
+            .iter()
+            .map(|ex| InternedString::new(ex))
+            .collect::<HashSet<InternedString>>();
+        let used_deps_iter =
+            usable_deps_iter.filter(|dep| !unused_externs_set.contains(&dep.extern_crate_name));
+        let pkg_id = unit.pkg.package_id();
+        for used_dep in used_deps_iter {
+            trace!(
+                "Used extern {} for pkg {} v{} tgt {}",
+                used_dep.extern_crate_name,
+                pkg_id.name(),
+                pkg_id.version(),
+                unit_desc(unit),
+            );
+            let kind = if let Some(dependency) = &used_dep.dependency.0 {
+                Some(dependency.kind())
+            } else if used_dep.unit.pkg.package_id() == unit.pkg.package_id() {
+                // Deps within the same crate have no dependency entry
+                None
+            } else {
+                continue;
+            };
+            if let Some(state) = self.states.get_mut(&(pkg_id, kind)) {
+                let record_kind = dep_kind_of(unit);
+                trace!(
+                    "   => updating state of {}dep",
+                    dep_kind_desc(Some(record_kind))
+                );
+                state
+                    .used_externs
+                    .insert((used_dep.extern_crate_name, record_kind));
+            }
+        }
+    }
+    pub fn emit_unused_warnings(&self, cx: &mut Context<'_, '_>) -> CargoResult<()> {
+        trace!(
+            "Allowed dependency kinds for the unused deps check: {:?}",
+            cx.bcx.allowed_kinds
+        );
+
+        // Sort the states to have a consistent output
+        let mut states_sorted = self.states.iter().collect::<Vec<_>>();
+        states_sorted.sort_by_key(|(k, _v)| k.clone());
+        for ((pkg_id, dep_kind), state) in states_sorted.iter() {
+            let outstanding_reports = state
+                .reports_needed_by
+                .iter()
+                .filter(|report| !self.reports_obtained.contains(report))
+                .collect::<Vec<_>>();
+            if !outstanding_reports.is_empty() {
+                trace!("Supressing unused deps warning of pkg {} v{} mode '{}dep' due to outstanding reports {:?}", pkg_id.name(), pkg_id.version(), dep_kind_desc(*dep_kind),
+                outstanding_reports.iter().map(|unit|
+                unit_desc(unit)).collect::<Vec<_>>());
+
+                // Some compilations errored without printing the unused externs.
+                // Don't print the warning in order to reduce false positive
+                // spam during errors.
+                continue;
+            }
+            // Sort the externs to have a consistent output
+            let mut externs_sorted = state.externs.iter().collect::<Vec<_>>();
+            externs_sorted.sort_by_key(|(k, _v)| k.clone());
+            for (ext, dependency) in externs_sorted.iter() {
+                let dep_kind = if let Some(dep_kind) = dep_kind {
+                    dep_kind
+                } else {
+                    // Internal dep_kind isn't interesting to us
+                    continue;
+                };
+                if state.used_externs.contains(&(**ext, *dep_kind)) {
+                    // The dependency is used
+                    continue;
+                }
+                // Implicitly added dependencies (in the same crate) aren't interesting
+                let dependency = if let Some(dependency) = dependency {
+                    dependency
+                } else {
+                    continue;
+                };
+                if !cx.bcx.allowed_kinds.contains(dep_kind) {
+                    // We can't warn for dependencies of this target kind
+                    // as we aren't compiling all the units
+                    // that use the dependency kind
+                    trace!("Supressing unused deps warning of {} in pkg {} v{} as mode '{}dep' not allowed", dependency.name_in_toml(), pkg_id.name(), pkg_id.version(), dep_kind_desc(Some(*dep_kind)));
+                    continue;
+                }
+                if dependency.name_in_toml().starts_with("_") {
+                    // Dependencies starting with an underscore
+                    // are marked as ignored
+                    trace!(
+                        "Supressing unused deps warning of {} in pkg {} v{} due to name",
+                        dependency.name_in_toml(),
+                        pkg_id.name(),
+                        pkg_id.version()
+                    );
+                    continue;
+                }
+                if dep_kind == &DepKind::Normal
+                    && state.used_externs.contains(&(**ext, DepKind::Development))
+                {
+                    // The dependency is used but only by dev targets,
+                    // which means it should be a dev-dependency instead
+                    cx.bcx.config.shell().warn(format!(
+                        "dependency {} in package {} v{} is only used by dev targets",
+                        dependency.name_in_toml(),
+                        pkg_id.name(),
+                        pkg_id.version()
+                    ))?;
+                    continue;
+                }
+
+                cx.bcx.config.shell().warn(format!(
+                    "unused {}dependency {} in package {} v{}",
+                    dep_kind_desc(Some(*dep_kind)),
+                    dependency.name_in_toml(),
+                    pkg_id.name(),
+                    pkg_id.version()
+                ))?;
+            }
+        }
+        Ok(())
+    }
+}

--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -582,6 +582,7 @@ pub struct CliUnstable {
     pub timings: Option<Vec<String>>,
     pub unstable_options: bool,
     pub weak_dep_features: bool,
+    pub warn_unused_deps: bool,
 }
 
 const STABILIZED_COMPILE_PROGRESS: &str = "The progress bar is now always \
@@ -799,6 +800,7 @@ impl CliUnstable {
             "crate-versions" => stabilized_warn(k, "1.47", STABILIZED_CRATE_VERSIONS),
             "package-features" => stabilized_warn(k, "1.51", STABILIZED_PACKAGE_FEATURES),
             "future-incompat-report" => self.enable_future_incompat_feature = parse_empty(k, v)?,
+            "warn-unused-deps" => self.warn_unused_deps = parse_empty(k, v)?,
             _ => bail!("unknown `-Z` flag specified: {}", k),
         }
 

--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -975,7 +975,6 @@ fn generate_targets(
                 }
             }
             allowed_kinds.insert(DepKind::Normal);
-            allowed_kinds.insert(DepKind::Development);
         }
         CompileFilter::Only {
             all_targets,
@@ -1036,12 +1035,6 @@ fn generate_targets(
             };
 
             if *lib != LibRule::False {
-                match (bins, examples, tests, benches) {
-                    (FilterRule::All, FilterRule::All, FilterRule::All, FilterRule::All) => {
-                        allowed_kinds.insert(DepKind::Development);
-                    }
-                    _ => (),
-                }
                 match (bins, examples, tests, benches) {
                     (FilterRule::All, ..) => {
                         allowed_kinds.insert(DepKind::Normal);

--- a/src/cargo/ops/cargo_test.rs
+++ b/src/cargo/ops/cargo_test.rs
@@ -1,3 +1,4 @@
+use crate::core::compiler::unused_dependencies::UnusedExterns;
 use crate::core::compiler::{Compilation, CompileKind, Doctest, UnitOutput};
 use crate::core::shell::Verbosity;
 use crate::core::{TargetKind, Workspace};
@@ -260,16 +261,8 @@ fn run_doc_tests(
                 Ok(())
             },
             &mut |line| {
-                #[derive(serde::Deserialize)]
-                struct UnusedExterns {
-                    unused_extern_names: Vec<String>,
-                }
                 if let Ok(uext) = serde_json::from_str::<UnusedExterns>(line) {
-                    unused_dep_state.record_unused_externs_for_unit(
-                        &unit_deps,
-                        unit,
-                        uext.unused_extern_names,
-                    );
+                    unused_dep_state.record_unused_externs_for_unit(&unit_deps, unit, uext);
                     // Supress output of the json formatted unused extern message
                     return Ok(());
                 }

--- a/tests/testsuite/main.rs
+++ b/tests/testsuite/main.rs
@@ -123,6 +123,7 @@ mod tool_paths;
 mod tree;
 mod tree_graph_features;
 mod unit_graph;
+mod unused_dependencies;
 mod update;
 mod vendor;
 mod verify_project;

--- a/tests/testsuite/unused_dependencies.rs
+++ b/tests/testsuite/unused_dependencies.rs
@@ -1,0 +1,757 @@
+//! A test suite for `-Zwarn-unused-dependencies`
+//!
+//! All tests here should use `#[cargo_test(unused_dependencies)]` to indicate that
+//! boilerplate should be generated to require the nightly toolchain.
+//! Otherwise the tests are skipped.
+
+use cargo_test_support::project;
+use cargo_test_support::registry::Package;
+
+// TODO more dev deps tests
+// TODO more commands for the tests to test the allowed kinds logic
+// TODO document the tests
+
+#[cargo_test(unused_dependencies)]
+fn unused_proper_dep() {
+    // The most basic case where there is an unused dependency
+    Package::new("bar", "0.1.0").publish();
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "foo"
+            version = "0.1.0"
+            authors = []
+            edition = "2018"
+
+            [dependencies]
+            bar = "0.1.0"
+        "#,
+        )
+        .file(
+            "src/main.rs",
+            r#"
+            fn main() {}
+            "#,
+        )
+        .build();
+
+    p.cargo("build -Zwarn-unused-deps")
+        .masquerade_as_nightly_cargo()
+        .with_stderr(
+            "\
+[UPDATING] [..]
+[DOWNLOADING] [..]
+[DOWNLOADED] bar v0.1.0 [..]
+[COMPILING] bar v0.1.0
+[COMPILING] foo [..]
+[WARNING] unused dependency bar in package foo v0.1.0
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]\
+            ",
+        )
+        .run();
+}
+
+#[cargo_test(unused_dependencies)]
+fn unused_build_dep() {
+    // A build dependency is unused
+    Package::new("bar", "0.1.0").publish();
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "foo"
+            version = "0.1.0"
+            authors = []
+            edition = "2018"
+
+            [build-dependencies]
+            bar = "0.1.0"
+        "#,
+        )
+        .file(
+            "src/main.rs",
+            r#"
+            fn main() {}
+            "#,
+        )
+        .file(
+            "build.rs",
+            r#"
+            fn main() {}
+            "#,
+        )
+        .build();
+
+    p.cargo("build -Zwarn-unused-deps")
+        .masquerade_as_nightly_cargo()
+        .with_stderr(
+            "\
+[UPDATING] [..]
+[DOWNLOADING] [..]
+[DOWNLOADED] bar v0.1.0 [..]
+[COMPILING] bar v0.1.0
+[COMPILING] foo [..]
+[WARNING] unused build-dependency bar in package foo v0.1.0
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]\
+            ",
+        )
+        .run();
+}
+
+#[cargo_test(unused_dependencies)]
+fn unused_deps_multiple() {
+    // Multiple dependencies are unused,
+    // also test that re-using dependencies
+    // between proper and build deps doesn't
+    // confuse the lint
+    Package::new("bar", "0.1.0").publish();
+    Package::new("baz", "0.1.0").publish();
+    Package::new("qux", "0.1.0").publish();
+    Package::new("quux", "0.1.0").publish();
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "foo"
+            version = "0.1.0"
+            authors = []
+            edition = "2018"
+
+            [dependencies]
+            bar = "0.1.0"
+            baz = "0.1.0"
+            qux = "0.1.0"
+            quux = "0.1.0"
+
+            [build-dependencies]
+            bar = "0.1.0"
+            baz = "0.1.0"
+            qux = "0.1.0"
+        "#,
+        )
+        .file(
+            "src/main.rs",
+            r#"
+            use qux as _;
+            fn main() {}
+            "#,
+        )
+        .file(
+            "build.rs",
+            r#"
+            use baz as _;
+            fn main() {}
+            "#,
+        )
+        .build();
+
+    p.cargo("build -Zwarn-unused-deps")
+        .masquerade_as_nightly_cargo()
+        .with_stderr(
+            "\
+[UPDATING] [..]
+[DOWNLOADING] [..]
+[DOWNLOADED] qux v0.1.0 [..]
+[DOWNLOADED] quux v0.1.0 [..]
+[DOWNLOADED] baz v0.1.0 [..]
+[DOWNLOADED] bar v0.1.0 [..]
+[COMPILING] [..]
+[COMPILING] [..]
+[COMPILING] [..]
+[COMPILING] [..]
+[COMPILING] foo [..]
+[WARNING] unused dependency bar in package foo v0.1.0
+[WARNING] unused dependency baz in package foo v0.1.0
+[WARNING] unused dependency quux in package foo v0.1.0
+[WARNING] unused build-dependency bar in package foo v0.1.0
+[WARNING] unused build-dependency qux in package foo v0.1.0
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]\
+            ",
+        )
+        .run();
+}
+
+#[cargo_test(unused_dependencies)]
+fn unused_build_dep_used_proper() {
+    // Check sharingof a dependency
+    // between build and proper deps
+    Package::new("bar", "0.1.0").publish();
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "foo"
+            version = "0.1.0"
+            authors = []
+            edition = "2018"
+
+            [dependencies]
+            bar = "0.1.0"
+
+            [build-dependencies]
+            bar = "0.1.0"
+        "#,
+        )
+        .file(
+            "src/main.rs",
+            r#"
+            use bar as _;
+            fn main() {}
+            "#,
+        )
+        .file(
+            "build.rs",
+            r#"
+            fn main() {}
+            "#,
+        )
+        .build();
+
+    p.cargo("build -Zwarn-unused-deps")
+        .masquerade_as_nightly_cargo()
+        .with_stderr(
+            "\
+[UPDATING] [..]
+[DOWNLOADING] [..]
+[DOWNLOADED] bar v0.1.0 [..]
+[COMPILING] bar v0.1.0
+[COMPILING] foo [..]
+[WARNING] unused build-dependency bar in package foo v0.1.0
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]\
+            ",
+        )
+        .run();
+}
+
+#[cargo_test(unused_dependencies)]
+fn unused_dep_renamed() {
+    // Make sure that package renaming works
+    Package::new("bar", "0.1.0").publish();
+    Package::new("baz", "0.2.0").publish();
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "foo"
+            version = "0.1.0"
+            authors = []
+            edition = "2018"
+
+            [dependencies]
+            baz = { package = "bar", version = "0.1.0" }
+            bar = { package = "baz", version = "0.2.0" }
+        "#,
+        )
+        .file(
+            "src/main.rs",
+            r#"
+            use bar as _;
+            fn main() {}
+            "#,
+        )
+        .build();
+
+    p.cargo("build -Zwarn-unused-deps")
+        .masquerade_as_nightly_cargo()
+        .with_stderr(
+            "\
+[UPDATING] [..]
+[DOWNLOADING] [..]
+[DOWNLOADED] baz v0.2.0 [..]
+[DOWNLOADED] bar v0.1.0 [..]
+[COMPILING] [..]
+[COMPILING] [..]
+[COMPILING] foo [..]
+[WARNING] unused dependency baz in package foo v0.1.0
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]\
+            ",
+        )
+        .run();
+}
+
+#[cargo_test(unused_dependencies)]
+fn unused_proper_dep_allowed() {
+    // There is an unused dependency but it's marked as
+    // allowed due to the leading underscore
+    Package::new("bar", "0.1.0").publish();
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "foo"
+            version = "0.1.0"
+            authors = []
+            edition = "2018"
+
+            [dependencies]
+            _bar = { package = "bar", version = "0.1.0" }
+        "#,
+        )
+        .file(
+            "src/main.rs",
+            r#"
+            fn main() {}
+            "#,
+        )
+        .build();
+
+    p.cargo("build -Zwarn-unused-deps")
+        .masquerade_as_nightly_cargo()
+        .with_stderr(
+            "\
+[UPDATING] [..]
+[DOWNLOADING] [..]
+[DOWNLOADED] bar v0.1.0 [..]
+[COMPILING] bar v0.1.0
+[COMPILING] foo [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]\
+            ",
+        )
+        .run();
+}
+
+#[cargo_test(unused_dependencies)]
+fn unused_dep_lib_bin() {
+    // Make sure that dependency uses by both binaries and libraries
+    // are being registered as uses.
+    Package::new("bar", "0.1.0").publish();
+    Package::new("baz", "0.1.0").publish();
+    Package::new("qux", "0.1.0").publish();
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "foo"
+            version = "0.1.0"
+            authors = []
+            edition = "2018"
+
+            [dependencies]
+            bar = "0.1.0"
+            baz = "0.1.0"
+            qux = "0.1.0"
+        "#,
+        )
+        .file(
+            "src/lib.rs",
+            r#"
+            use baz as _;
+            "#,
+        )
+        .file(
+            "src/main.rs",
+            r#"
+            use bar as _;
+            fn main() {}
+            "#,
+        )
+        .build();
+
+    p.cargo("build -Zwarn-unused-deps")
+        .masquerade_as_nightly_cargo()
+        .with_stderr(
+            "\
+[UPDATING] [..]
+[DOWNLOADING] [..]
+[DOWNLOADED] qux v0.1.0 [..]
+[DOWNLOADED] baz v0.1.0 [..]
+[DOWNLOADED] bar v0.1.0 [..]
+[COMPILING] [..]
+[COMPILING] [..]
+[COMPILING] [..]
+[COMPILING] foo [..]
+[WARNING] unused dependency qux in package foo v0.1.0
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]\
+            ",
+        )
+        .run();
+}
+
+#[cargo_test(unused_dependencies)]
+fn should_be_dev() {
+    // Test the warning that a dependency should be a dev dep.
+    // Sometimes, a cargo command doesn't compile the dev unit
+    // that would use the dependency and thus will claim that
+    // the dependency is unused while it actually is used.
+    // However, this behaviour is common in unused lints:
+    // e.g. when you cfg-gate a public function foo that uses
+    // a function bar, the bar function will be marked as
+    // unused even though there is a mode that uses bar.
+    //
+    // So the "should be dev" lint should be seen as a
+    // best-effort improvement over the "unused dep" lint.
+    Package::new("bar", "0.1.0").publish();
+    Package::new("baz", "0.1.0").publish();
+    Package::new("qux", "0.1.0").publish();
+    Package::new("quux", "0.1.0").publish();
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "foo"
+            version = "0.1.0"
+            authors = []
+            edition = "2018"
+
+            [dependencies]
+            bar = "0.1.0"
+            baz = "0.1.0"
+            qux = "0.1.0"
+            quux = "0.1.0"
+        "#,
+        )
+        .file("src/lib.rs", "")
+        .file(
+            "tests/hello.rs",
+            r#"
+            use bar as _;
+            "#,
+        )
+        .file(
+            "examples/hello.rs",
+            r#"
+            use baz as _;
+            fn main() {}
+            "#,
+        )
+        .file(
+            "benches/hello.rs",
+            r#"
+            use qux as _;
+            fn main() {}
+            "#,
+        )
+        .build();
+
+    p.cargo("test --no-run -Zwarn-unused-deps")
+        .masquerade_as_nightly_cargo()
+        .with_stderr(
+            "\
+[UPDATING] [..]
+[DOWNLOADING] [..]
+[DOWNLOADED] qux v0.1.0 [..]
+[DOWNLOADED] quux v0.1.0 [..]
+[DOWNLOADED] baz v0.1.0 [..]
+[DOWNLOADED] bar v0.1.0 [..]
+[COMPILING] [..]
+[COMPILING] [..]
+[COMPILING] [..]
+[COMPILING] [..]
+[COMPILING] foo [..]
+[WARNING] dependency bar in package foo v0.1.0 is only used by dev targets
+[WARNING] dependency baz in package foo v0.1.0 is only used by dev targets
+[WARNING] unused dependency quux in package foo v0.1.0
+[WARNING] unused dependency qux in package foo v0.1.0
+[FINISHED] test [unoptimized + debuginfo] target(s) in [..]\
+            ",
+        )
+        .run();
+
+    p.cargo("test --no-run --all-targets -Zwarn-unused-deps")
+        .masquerade_as_nightly_cargo()
+        .with_stderr(
+            "\
+[COMPILING] foo [..]
+[WARNING] dependency bar in package foo v0.1.0 is only used by dev targets
+[WARNING] dependency baz in package foo v0.1.0 is only used by dev targets
+[WARNING] unused dependency quux in package foo v0.1.0
+[WARNING] dependency qux in package foo v0.1.0 is only used by dev targets
+[FINISHED] test [unoptimized + debuginfo] target(s) in [..]\
+            ",
+        )
+        .run();
+
+    p.cargo("build -Zwarn-unused-deps")
+        .masquerade_as_nightly_cargo()
+        .with_stderr(
+            "\
+[WARNING] unused dependency bar in package foo v0.1.0
+[WARNING] unused dependency baz in package foo v0.1.0
+[WARNING] unused dependency quux in package foo v0.1.0
+[WARNING] unused dependency qux in package foo v0.1.0
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]\
+            ",
+        )
+        .run();
+
+    p.cargo("check --all-targets -Zwarn-unused-deps")
+        .masquerade_as_nightly_cargo()
+        .with_stderr(
+            "\
+[CHECKING] [..]
+[CHECKING] [..]
+[CHECKING] [..]
+[CHECKING] [..]
+[CHECKING] foo [..]
+[WARNING] dependency bar in package foo v0.1.0 is only used by dev targets
+[WARNING] dependency baz in package foo v0.1.0 is only used by dev targets
+[WARNING] unused dependency quux in package foo v0.1.0
+[WARNING] dependency qux in package foo v0.1.0 is only used by dev targets
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]\
+            ",
+        )
+        .run();
+}
+
+#[cargo_test(unused_dependencies)]
+fn dev_deps() {
+    // Test for unused dev dependencies
+    // In this instance,
+    Package::new("bar", "0.1.0").publish();
+    Package::new("baz", "0.1.0").publish();
+    Package::new("qux", "0.1.0").publish();
+    Package::new("quux", "0.1.0").publish();
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "foo"
+            version = "0.1.0"
+            authors = []
+            edition = "2018"
+
+            [dev-dependencies]
+            bar = "0.1.0"
+            baz = "0.1.0"
+            qux = "0.1.0"
+            quux = "0.1.0"
+        "#,
+        )
+        .file("src/lib.rs", "")
+        .file(
+            "tests/hello.rs",
+            r#"
+            use bar as _;
+            "#,
+        )
+        .file(
+            "examples/hello.rs",
+            r#"
+            use baz as _;
+            fn main() {}
+            "#,
+        )
+        .file(
+            "benches/hello.rs",
+            r#"
+            use qux as _;
+            fn main() {}
+            "#,
+        )
+        .build();
+
+    // cargo test --no-run doesn't test the benches
+    // and thus gives false positives
+    p.cargo("test --no-run -Zwarn-unused-deps")
+        .masquerade_as_nightly_cargo()
+        .with_stderr(
+            "\
+[UPDATING] [..]
+[DOWNLOADING] [..]
+[DOWNLOADED] qux v0.1.0 [..]
+[DOWNLOADED] quux v0.1.0 [..]
+[DOWNLOADED] baz v0.1.0 [..]
+[DOWNLOADED] bar v0.1.0 [..]
+[COMPILING] [..]
+[COMPILING] [..]
+[COMPILING] [..]
+[COMPILING] [..]
+[COMPILING] foo [..]
+[WARNING] unused dev-dependency quux in package foo v0.1.0
+[WARNING] unused dev-dependency qux in package foo v0.1.0
+[FINISHED] test [unoptimized + debuginfo] target(s) in [..]\
+            ",
+        )
+        .run();
+
+    // The cargo test --no-run --all-targets tests
+    // everything that can use dev-deps except for doctests
+    p.cargo("test --no-run --all-targets -Zwarn-unused-deps")
+        .masquerade_as_nightly_cargo()
+        .with_stderr(
+            "\
+[COMPILING] foo [..]
+[WARNING] unused dev-dependency quux in package foo v0.1.0
+[FINISHED] test [unoptimized + debuginfo] target(s) in [..]\
+            ",
+        )
+        .run();
+
+    // Check that cargo build doesn't check for unused dev-deps
+    p.cargo("build -Zwarn-unused-deps")
+        .masquerade_as_nightly_cargo()
+        .with_stderr(
+            "\
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]\
+            ",
+        )
+        .run();
+
+    // cargo check --all-targets checks for unused dev-deps (for now)
+    p.cargo("check --all-targets -Zwarn-unused-deps")
+        .masquerade_as_nightly_cargo()
+        .with_stderr(
+            "\
+[CHECKING] [..]
+[CHECKING] [..]
+[CHECKING] [..]
+[CHECKING] [..]
+[CHECKING] foo [..]
+[WARNING] unused dev-dependency quux in package foo v0.1.0
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]\
+            ",
+        )
+        .run();
+}
+
+#[cargo_test(unused_dependencies)]
+fn cfg_test_used() {
+    // Ensure that a dependency only used from #[cfg(test)] code
+    // is still registered as used.
+    Package::new("bar", "0.1.0").publish();
+    Package::new("baz", "0.1.0").publish();
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "foo"
+            version = "0.1.0"
+            authors = []
+            edition = "2018"
+
+            [dev-dependencies]
+            bar = "0.1.0"
+            baz = "0.1.0"
+        "#,
+        )
+        .file(
+            "src/lib.rs",
+            r#"
+            #[cfg(test)]
+            mod tests {
+                use bar as _;
+            }
+            "#,
+        )
+        .build();
+
+    p.cargo("test --no-run -Zwarn-unused-deps")
+        .masquerade_as_nightly_cargo()
+        .with_stderr(
+            "\
+[UPDATING] [..]
+[DOWNLOADING] [..]
+[DOWNLOADED] [..]
+[DOWNLOADED] [..]
+[COMPILING] [..]
+[COMPILING] [..]
+[COMPILING] foo [..]
+[WARNING] unused dev-dependency baz in package foo v0.1.0
+[FINISHED] test [unoptimized + debuginfo] target(s) in [..]\
+            ",
+        )
+        .run();
+}
+
+#[cargo_test(unused_dependencies)]
+fn cfg_test_workspace() {
+    // Make sure that workspaces are supported,
+    // --all params, -p params, etc.
+    Package::new("baz", "0.1.0").publish();
+    Package::new("qux", "0.1.0").publish();
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "foo"
+            version = "0.1.0"
+            authors = []
+            edition = "2018"
+
+            [dependencies]
+            bar = { path = "bar" }
+            baz = "0.1.0"
+
+            [workspace]
+            members = ["bar"]
+        "#,
+        )
+        .file(
+            "src/lib.rs",
+            r#"
+            use bar as _;
+            "#,
+        )
+        .file(
+            "bar/Cargo.toml",
+            r#"
+            [package]
+            name = "bar"
+            version = "0.1.0"
+            authors = []
+            edition = "2018"
+
+            [dependencies]
+            baz = "0.1.0"
+            qux = "0.1.0"
+            "#,
+        )
+        .file(
+            "bar/src/lib.rs",
+            r#"
+            use baz as _;
+            "#,
+        )
+        .build();
+
+    p.cargo("check --all -Zwarn-unused-deps")
+        .masquerade_as_nightly_cargo()
+        .with_stderr(
+            "\
+[UPDATING] [..]
+[DOWNLOADING] [..]
+[DOWNLOADED] [..]
+[DOWNLOADED] [..]
+[CHECKING] [..]
+[CHECKING] [..]
+[CHECKING] bar [..]
+[CHECKING] foo [..]
+[WARNING] unused dependency qux in package bar v0.1.0
+[WARNING] unused dependency baz in package foo v0.1.0
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]\
+            ",
+        )
+        .run();
+
+    p.cargo("check -Zwarn-unused-deps")
+        .masquerade_as_nightly_cargo()
+        .with_stderr(
+            "\
+[WARNING] unused dependency baz in package foo v0.1.0
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]\
+            ",
+        )
+        .run();
+
+    p.cargo("check -p bar -Zwarn-unused-deps")
+        .masquerade_as_nightly_cargo()
+        .with_stderr(
+            "\
+[WARNING] unused dependency qux in package bar v0.1.0
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]\
+            ",
+        )
+        .run();
+}


### PR DESCRIPTION
This commit adds an experimental flag to cargo, -Zwarn-unused-deps.

If the flag is enabled, cargo will warn about unused dependencies. rustc issue for the feature: https://github.com/rust-lang/rust/issues/57274 

The goal is to stabilize it eventually, enabling it by default.

The lint builds upon the --json=unused-externs flag of rustc
that is being proposed for this purpose in the companion PR https://github.com/rust-lang/rust/pull/73945 .
This PR makes cargo pass the flag if -Zwarn-unused-deps is enabled to compilations of units it prints warnings for.

During compilation, cargo collects the unused dependencies
from all units, converts them into used dependencies,
continuously extending the record of used dependencies for
any type of DepKind: [dependencies], [dev-dependencies] and
[build-dependencies].

Once the compilation has ended, this record is used to
obtain those dependencies in a class that weren't used by any unit,
and warn about them.

The goal is to stabilize the flag and enable it by default
once the lint has become robust and the robustness is proven.

Then, cargo shall opportunistically warn about unused dependencies
when it has compiled (or loaded the unused externs from cache of)
all units that could possibly use dependencies of the kind.
Roughly, it's like this:
  * cargo always compiles build.rs
  * cargo check compiles all units that would use [dependencies]
  * cargo test --no-run --all-targets compiles all units that can use
    [dev-dependencies]

# TODO

The PR is still WIP but I've opened it to get initial feedback. TODO list:

- [x] Making cargo figure out the allowed dependency kinds to warn about. Found a solution that should work
- [x] Support `#[cfg(test)] use extern_crate as _;`
 - [x] Doctest support. There is no separation of build vs run steps for them (cc #6424) so we'd have to block after they have finished. And we'll have to add json unused deps reporting to them in the first place. Currently we just skip them leading to false positives if a dev dependency is only used in doc tests.
- [ ] Finish the tests

cc @ehuss @jsgf