### PR TITLE
Finish implementation of `-Zextra-link-arg`.

### DIFF
--- a/src/cargo/core/compiler/custom_build.rs
+++ b/src/cargo/core/compiler/custom_build.rs
@@ -1,5 +1,5 @@
 use super::job::{Freshness, Job, Work};
-use super::{fingerprint, Context, Unit};
+use super::{fingerprint, Context, LinkType, Unit};
 use crate::core::compiler::context::Metadata;
 use crate::core::compiler::job_queue::JobState;
 use crate::core::{profiles::ProfileRoot, PackageId};
@@ -23,7 +23,7 @@ pub struct BuildOutput {
     /// Names and link kinds of libraries, suitable for the `-l` flag.
     pub library_links: Vec<String>,
     /// Linker arguments suitable to be passed to `-C link-arg=<args>`
-    pub linker_args: Vec<String>,
+    pub linker_args: Vec<(Option<LinkType>, String)>,
     /// Various `--cfg` flags to pass to the compiler.
     pub cfgs: Vec<String>,
     /// Additional environment variables to run the compiler with.
@@ -535,7 +535,9 @@ impl BuildOutput {
                 }
                 "rustc-link-lib" => library_links.push(value.to_string()),
                 "rustc-link-search" => library_paths.push(PathBuf::from(value)),
-                "rustc-cdylib-link-arg" => linker_args.push(value.to_string()),
+                "rustc-cdylib-link-arg" => linker_args.push((Some(LinkType::Cdylib), value)),
+                "rustc-bin-link-arg" => linker_args.push((Some(LinkType::Bin), value)),
+                "rustc-link-arg" => linker_args.push((None, value)),
                 "rustc-cfg" => cfgs.push(value.to_string()),
                 "rustc-env" => env.push(BuildOutput::parse_rustc_env(&value, &whence)?),
                 "warning" => warnings.push(value.to_string()),

--- a/src/cargo/core/compiler/custom_build.rs
+++ b/src/cargo/core/compiler/custom_build.rs
@@ -547,7 +547,7 @@ impl BuildOutput {
                 "rustc-link-lib" => library_links.push(value.to_string()),
                 "rustc-link-search" => library_paths.push(PathBuf::from(value)),
                 "rustc-cdylib-link-arg" => linker_args.push((Some(LinkType::Cdylib), value)),
-                "rustc-bin-link-arg" => {
+                "rustc-link-arg-bins" => {
                     if extra_link_arg {
                         linker_args.push((Some(LinkType::Bin), value));
                     } else {

--- a/src/cargo/core/compiler/custom_build.rs
+++ b/src/cargo/core/compiler/custom_build.rs
@@ -546,7 +546,9 @@ impl BuildOutput {
                 }
                 "rustc-link-lib" => library_links.push(value.to_string()),
                 "rustc-link-search" => library_paths.push(PathBuf::from(value)),
-                "rustc-cdylib-link-arg" => linker_args.push((Some(LinkType::Cdylib), value)),
+                "rustc-link-arg-cdylib" | "rustc-cdylib-link-arg" => {
+                    linker_args.push((Some(LinkType::Cdylib), value))
+                }
                 "rustc-link-arg-bins" => {
                     if extra_link_arg {
                         linker_args.push((Some(LinkType::Bin), value));

--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -214,7 +214,7 @@ fn rustc(cx: &mut Context<'_, '_>, unit: &Unit, exec: &Arc<dyn Executor>) -> Car
     // If we are a binary and the package also contains a library, then we
     // don't pass the `-l` flags.
     let pass_l_flag = unit.target.is_lib() || !unit.pkg.targets().iter().any(|t| t.is_lib());
-    let link_type = unit.target.into();
+    let link_type = (&unit.target).into();
     let extra_link_arg = cx.bcx.config.cli_unstable().extra_link_arg;
 
     let dep_info_name = match cx.files().metadata(unit) {

--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -63,6 +63,9 @@ const RUSTDOC_CRATE_VERSION_FLAG: &str = "--crate-version";
 pub enum LinkType {
     Cdylib,
     Bin,
+    Test,
+    Bench,
+    Example,
 }
 
 impl From<&super::Target> for Option<LinkType> {
@@ -71,6 +74,12 @@ impl From<&super::Target> for Option<LinkType> {
             Some(LinkType::Cdylib)
         } else if value.is_bin() {
             Some(LinkType::Bin)
+        } else if value.is_test() {
+            Some(LinkType::Test)
+        } else if value.is_bench() {
+            Some(LinkType::Bench)
+        } else if value.is_exe_example() {
+            Some(LinkType::Example)
         } else {
             None
         }

--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -59,6 +59,24 @@ use crate::util::{internal, join_paths, paths, profile};
 
 const RUSTDOC_CRATE_VERSION_FLAG: &str = "--crate-version";
 
+#[derive(Copy, Clone, Hash, Debug, PartialEq, Eq)]
+pub enum LinkType {
+    Cdylib,
+    Bin,
+}
+
+impl From<&super::Target> for Option<LinkType> {
+    fn from(value: &super::Target) -> Self {
+        if value.is_cdylib() {
+            Some(LinkType::Cdylib)
+        } else if value.is_bin() {
+            Some(LinkType::Bin)
+        } else {
+            None
+        }
+    }
+}
+
 /// A glorified callback for executing calls to rustc. Rather than calling rustc
 /// directly, we'll use an `Executor`, giving clients an opportunity to intercept
 /// the build calls.
@@ -196,7 +214,7 @@ fn rustc(cx: &mut Context<'_, '_>, unit: &Unit, exec: &Arc<dyn Executor>) -> Car
     // If we are a binary and the package also contains a library, then we
     // don't pass the `-l` flags.
     let pass_l_flag = unit.target.is_lib() || !unit.pkg.targets().iter().any(|t| t.is_lib());
-    let pass_cdylib_link_args = unit.target.is_cdylib();
+    let link_type = unit.target.into();
 
     let dep_info_name = match cx.files().metadata(unit) {
         Some(metadata) => format!("{}-{}.d", unit.target.crate_name(), metadata),
@@ -244,7 +262,7 @@ fn rustc(cx: &mut Context<'_, '_>, unit: &Unit, exec: &Arc<dyn Executor>) -> Car
                     &script_outputs,
                     &build_scripts,
                     pass_l_flag,
-                    pass_cdylib_link_args,
+                    link_type,
                     current_id,
                 )?;
                 add_plugin_deps(&mut rustc, &script_outputs, &build_scripts, &root_output)?;
@@ -326,7 +344,7 @@ fn rustc(cx: &mut Context<'_, '_>, unit: &Unit, exec: &Arc<dyn Executor>) -> Car
         build_script_outputs: &BuildScriptOutputs,
         build_scripts: &BuildScripts,
         pass_l_flag: bool,
-        pass_cdylib_link_args: bool,
+        link_type: Option<LinkType>,
         current_id: PackageId,
     ) -> CargoResult<()> {
         for key in build_scripts.to_link.iter() {
@@ -348,8 +366,14 @@ fn rustc(cx: &mut Context<'_, '_>, unit: &Unit, exec: &Arc<dyn Executor>) -> Car
                         rustc.arg("-l").arg(name);
                     }
                 }
-                if pass_cdylib_link_args {
-                    for arg in output.linker_args.iter() {
+
+                if link_type.is_some() {
+                    for arg in output
+                        .linker_args
+                        .iter()
+                        .filter(|x| x.0.is_none() || x.0 == link_type)
+                        .map(|x| &x.1)
+                    {
                         let link_arg = format!("link-arg={}", arg);
                         rustc.arg("-C").arg(link_arg);
                     }

--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -357,6 +357,7 @@ fn rustc(cx: &mut Context<'_, '_>, unit: &Unit, exec: &Arc<dyn Executor>) -> Car
             for path in output.library_paths.iter() {
                 rustc.arg("-L").arg(path);
             }
+
             if key.0 == current_id {
                 for cfg in &output.cfgs {
                     rustc.arg("--cfg").arg(cfg);
@@ -366,11 +367,12 @@ fn rustc(cx: &mut Context<'_, '_>, unit: &Unit, exec: &Arc<dyn Executor>) -> Car
                         rustc.arg("-l").arg(name);
                     }
                 }
-                if link_type.is_some() {
-                    for (lt, arg) in &output.linker_args {
-                        if lt.is_none() || *lt == link_type {
-                            rustc.arg("-C").arg(format!("link-arg={}", arg));
-                        }
+            }
+
+            if link_type.is_some() {
+                for (lt, arg) in &output.linker_args {
+                    if lt.is_none() || *lt == link_type {
+                        rustc.arg("-C").arg(format!("link-arg={}", arg));
                     }
                 }
             }

--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -359,6 +359,7 @@ pub struct CliUnstable {
     pub terminal_width: Option<Option<usize>>,
     pub namespaced_features: bool,
     pub weak_dep_features: bool,
+    pub extra_link_arg: bool,
 }
 
 fn deserialize_build_std<'de, D>(deserializer: D) -> Result<Option<Vec<String>>, D::Error>
@@ -466,6 +467,7 @@ impl CliUnstable {
             "terminal-width" => self.terminal_width = Some(parse_usize_opt(v)?),
             "namespaced-features" => self.namespaced_features = parse_empty(k, v)?,
             "weak-dep-features" => self.weak_dep_features = parse_empty(k, v)?,
+            "extra-link-arg" => self.extra_link_arg = parse_empty(k, v)?,
             _ => bail!("unknown `-Z` flag specified: {}", k),
         }
 

--- a/src/cargo/util/config/target.rs
+++ b/src/cargo/util/config/target.rs
@@ -132,7 +132,7 @@ fn parse_links_overrides(
                         .library_paths
                         .extend(list.iter().map(|v| PathBuf::from(&v.0)));
                 }
-                "rustc-cdylib-link-arg" => {
+                "rustc-link-arg-cdylib" | "rustc-cdylib-link-arg" => {
                     let args = value.list(key)?;
                     let args = args.iter().map(|v| (Some(LinkType::Cdylib), v.0.clone()));
                     output.linker_args.extend(args);

--- a/src/cargo/util/config/target.rs
+++ b/src/cargo/util/config/target.rs
@@ -137,7 +137,7 @@ fn parse_links_overrides(
                     let args = args.iter().map(|v| (Some(LinkType::Cdylib), v.0.clone()));
                     output.linker_args.extend(args);
                 }
-                "rustc-bin-link-arg" => {
+                "rustc-link-arg-bins" => {
                     if extra_link_arg {
                         let args = value.list(key)?;
                         let args = args.iter().map(|v| (Some(LinkType::Bin), v.0.clone()));

--- a/src/cargo/util/config/target.rs
+++ b/src/cargo/util/config/target.rs
@@ -1,5 +1,5 @@
 use super::{Config, ConfigKey, ConfigRelativePath, OptValue, PathAndArgs, StringList, CV};
-use crate::core::compiler::BuildOutput;
+use crate::core::compiler::{BuildOutput, LinkType};
 use crate::util::CargoResult;
 use serde::Deserialize;
 use std::collections::{BTreeMap, HashMap};
@@ -131,7 +131,18 @@ fn parse_links_overrides(
                 }
                 "rustc-cdylib-link-arg" => {
                     let args = value.list(key)?;
-                    output.linker_args.extend(args.iter().map(|v| v.0.clone()));
+                    let args = args.iter().map(|v| (Some(LinkType::Cdylib), v.0.clone()));
+                    output.linker_args.extend(args);
+                }
+                "rustc-bin-link-arg" => {
+                    let args = value.list(key)?;
+                    let args = args.iter().map(|v| (Some(LinkType::Bin), v.0.clone()));
+                    output.linker_args.extend(args);
+                }
+                "rustc-link-arg" => {
+                    let args = value.list(key)?;
+                    let args = args.iter().map(|v| (None, v.0.clone()));
+                    output.linker_args.extend(args);
                 }
                 "rustc-cfg" => {
                     let list = value.list(key)?;

--- a/src/doc/src/reference/build-scripts.md
+++ b/src/doc/src/reference/build-scripts.md
@@ -105,6 +105,10 @@ one detailed below.
 * [`cargo:rustc-env=VAR=VALUE`](#rustc-env) — Sets an environment variable.
 * [`cargo:rustc-cdylib-link-arg=FLAG`](#rustc-cdylib-link-arg) — Passes custom
   flags to a linker for cdylib crates.
+* [`cargo:rustc-bin-link-arg=FLAG`](#rustc-bin-link-arg) — Passes custom
+  flags to a linker for bin crates.
+* [`cargo:rustc-link-arg=FLAG`](#rustc-link-arg) — Passes custom
+  flags to a linker for all supported crates.
 * [`cargo:warning=MESSAGE`](#cargo-warning) — Displays a warning on the
   terminal.
 * [`cargo:KEY=VALUE`](#the-links-manifest-key) — Metadata, used by `links`
@@ -202,6 +206,26 @@ The `rustc-cdylib-link-arg` instruction tells Cargo to pass the [`-C
 link-arg=FLAG` option][link-arg] to the compiler, but only when building a
 `cdylib` library target. Its usage is highly platform specific. It is useful
 to set the shared library version or the runtime-path.
+
+[link-arg]: ../../rustc/codegen-options/index.md#link-arg
+
+<a id="rustc-bin-link-arg"></a>
+#### `cargo:rustc-bin-link-arg=FLAG`
+
+The `rustc-bin-link-arg` instruction tells Cargo to pass the [`-C
+link-arg=FLAG` option][link-arg] to the compiler, but only when building a
+binary target. Its usage is highly platform specific. It is useful
+to set a linker script or other linker options.
+
+[link-arg]: ../../rustc/codegen-options/index.md#link-arg
+
+<a id="rustc-link-arg"></a>
+#### `cargo:rustc-link-arg=FLAG`
+
+The `rustc-link-arg` instruction tells Cargo to pass the [`-C link-arg=FLAG`
+option][link-arg] to the compiler, but only when building a supported target
+(currently a binary or `cdylib` library). Its usage is highly platform
+specific. It is useful to set the shared library version or linker script.
 
 [link-arg]: ../../rustc/codegen-options/index.md#link-arg
 
@@ -372,6 +396,8 @@ rustc-flags = "-L /some/path"
 rustc-cfg = ['key="value"']
 rustc-env = {key = "value"}
 rustc-cdylib-link-arg = ["…"]
+rustc-bin-link-arg = ["…"]
+rustc-link-arg = ["…"]
 metadata_key1 = "value"
 metadata_key2 = "value"
 ```

--- a/src/doc/src/reference/build-scripts.md
+++ b/src/doc/src/reference/build-scripts.md
@@ -105,10 +105,6 @@ one detailed below.
 * [`cargo:rustc-env=VAR=VALUE`](#rustc-env) — Sets an environment variable.
 * [`cargo:rustc-cdylib-link-arg=FLAG`](#rustc-cdylib-link-arg) — Passes custom
   flags to a linker for cdylib crates.
-* [`cargo:rustc-bin-link-arg=FLAG`](#rustc-bin-link-arg) — Passes custom
-  flags to a linker for bin crates.
-* [`cargo:rustc-link-arg=FLAG`](#rustc-link-arg) — Passes custom
-  flags to a linker for all supported crates.
 * [`cargo:warning=MESSAGE`](#cargo-warning) — Displays a warning on the
   terminal.
 * [`cargo:KEY=VALUE`](#the-links-manifest-key) — Metadata, used by `links`
@@ -206,26 +202,6 @@ The `rustc-cdylib-link-arg` instruction tells Cargo to pass the [`-C
 link-arg=FLAG` option][link-arg] to the compiler, but only when building a
 `cdylib` library target. Its usage is highly platform specific. It is useful
 to set the shared library version or the runtime-path.
-
-[link-arg]: ../../rustc/codegen-options/index.md#link-arg
-
-<a id="rustc-bin-link-arg"></a>
-#### `cargo:rustc-bin-link-arg=FLAG`
-
-The `rustc-bin-link-arg` instruction tells Cargo to pass the [`-C
-link-arg=FLAG` option][link-arg] to the compiler, but only when building a
-binary target. Its usage is highly platform specific. It is useful
-to set a linker script or other linker options.
-
-[link-arg]: ../../rustc/codegen-options/index.md#link-arg
-
-<a id="rustc-link-arg"></a>
-#### `cargo:rustc-link-arg=FLAG`
-
-The `rustc-link-arg` instruction tells Cargo to pass the [`-C link-arg=FLAG`
-option][link-arg] to the compiler, but only when building a supported target
-(currently a binary or `cdylib` library). Its usage is highly platform
-specific. It is useful to set the shared library version or linker script.
 
 [link-arg]: ../../rustc/codegen-options/index.md#link-arg
 
@@ -396,8 +372,6 @@ rustc-flags = "-L /some/path"
 rustc-cfg = ['key="value"']
 rustc-env = {key = "value"}
 rustc-cdylib-link-arg = ["…"]
-rustc-bin-link-arg = ["…"]
-rustc-link-arg = ["…"]
 metadata_key1 = "value"
 metadata_key2 = "value"
 ```

--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -20,6 +20,37 @@ timings = 'yes'
 Some unstable features will require you to specify the `cargo-features` key in
 `Cargo.toml`.
 
+### extra-link-arg
+* Original Pull Request: [#7811](https://github.com/rust-lang/cargo/pull/7811)
+
+The `-Z extra-link-arg` flag makes the following two instructions available
+in build scripts:
+
+* [`cargo:rustc-bin-link-arg=FLAG`](#rustc-bin-link-arg) — Passes custom
+  flags to a linker for bin crates.
+* [`cargo:rustc-link-arg=FLAG`](#rustc-link-arg) — Passes custom
+  flags to a linker for all supported crates.
+
+<a id="rustc-bin-link-arg"></a>
+#### `cargo:rustc-bin-link-arg=FLAG`
+
+The `rustc-bin-link-arg` instruction tells Cargo to pass the [`-C
+link-arg=FLAG` option][link-arg] to the compiler, but only when building a
+binary target. Its usage is highly platform specific. It is useful
+to set a linker script or other linker options.
+
+[link-arg]: ../../rustc/codegen-options/index.md#link-arg
+
+<a id="rustc-link-arg"></a>
+#### `cargo:rustc-link-arg=FLAG`
+
+The `rustc-link-arg` instruction tells Cargo to pass the [`-C link-arg=FLAG`
+option][link-arg] to the compiler, but only when building a supported target
+(currently a binary or `cdylib` library). Its usage is highly platform
+specific. It is useful to set the shared library version or linker script.
+
+[link-arg]: ../../rustc/codegen-options/index.md#link-arg
+
 ### no-index-update
 * Original Issue: [#3479](https://github.com/rust-lang/cargo/issues/3479)
 * Tracking Issue: [#7404](https://github.com/rust-lang/cargo/issues/7404)

--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -26,10 +26,10 @@ Some unstable features will require you to specify the `cargo-features` key in
 The `-Z extra-link-arg` flag makes the following two instructions available
 in build scripts:
 
-* [`cargo:rustc-link-arg-bins=FLAG`](#rustc-link-arg-bins) — Passes custom
-  flags to a linker for bin crates.
-* [`cargo:rustc-link-arg=FLAG`](#rustc-link-arg) — Passes custom
-  flags to a linker for all supported crates.
+* [`cargo:rustc-link-arg-bins=FLAG`](#rustc-link-arg-bins) – Passes custom
+  flags to a linker for binaries.
+* [`cargo:rustc-link-arg=FLAG`](#rustc-link-arg) – Passes custom flags to a
+  linker for benchmarks, binaries, `cdylib` crates, examples, and tests.
 
 <a id="rustc-link-arg-bins"></a>
 #### `cargo:rustc-link-arg-bins=FLAG`
@@ -45,9 +45,10 @@ to set a linker script or other linker options.
 #### `cargo:rustc-link-arg=FLAG`
 
 The `rustc-link-arg` instruction tells Cargo to pass the [`-C link-arg=FLAG`
-option][link-arg] to the compiler, but only when building a supported target
-(currently a binary or `cdylib` library). Its usage is highly platform
-specific. It is useful to set the shared library version or linker script.
+option][link-arg] to the compiler, but only when building supported targets
+(benchmarks, binaries, `cdylib` crates, examples, and tests). Its usage is
+highly platform specific. It is useful to set the shared library version or
+linker script.
 
 [link-arg]: ../../rustc/codegen-options/index.md#link-arg
 

--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -26,15 +26,15 @@ Some unstable features will require you to specify the `cargo-features` key in
 The `-Z extra-link-arg` flag makes the following two instructions available
 in build scripts:
 
-* [`cargo:rustc-bin-link-arg=FLAG`](#rustc-bin-link-arg) — Passes custom
+* [`cargo:rustc-link-arg-bins=FLAG`](#rustc-link-arg-bins) — Passes custom
   flags to a linker for bin crates.
 * [`cargo:rustc-link-arg=FLAG`](#rustc-link-arg) — Passes custom
   flags to a linker for all supported crates.
 
-<a id="rustc-bin-link-arg"></a>
-#### `cargo:rustc-bin-link-arg=FLAG`
+<a id="rustc-link-arg-bins"></a>
+#### `cargo:rustc-link-arg-bins=FLAG`
 
-The `rustc-bin-link-arg` instruction tells Cargo to pass the [`-C
+The `rustc-link-arg-bins` instruction tells Cargo to pass the [`-C
 link-arg=FLAG` option][link-arg] to the compiler, but only when building a
 binary target. Its usage is highly platform specific. It is useful
 to set a linker script or other linker options.

--- a/tests/testsuite/build_script_extra_link_arg.rs
+++ b/tests/testsuite/build_script_extra_link_arg.rs
@@ -19,7 +19,7 @@ fn build_script_extra_link_arg_bin() {
 
     p.cargo("build -Zextra-link-arg -v")
         .masquerade_as_nightly_cargo()
-        .with_status(101)
+        .without_status()
         .with_stderr_contains(
             "[RUNNING] `rustc --crate-name foo [..]-C link-arg=--this-is-a-bogus-flag[..]",
         )
@@ -43,7 +43,7 @@ fn build_script_extra_link_arg() {
 
     p.cargo("build -Zextra-link-arg -v")
         .masquerade_as_nightly_cargo()
-        .with_status(101)
+        .without_status()
         .with_stderr_contains(
             "[RUNNING] `rustc --crate-name foo [..]-C link-arg=--this-is-a-bogus-flag[..]",
         )

--- a/tests/testsuite/build_script_extra_link_arg.rs
+++ b/tests/testsuite/build_script_extra_link_arg.rs
@@ -65,7 +65,7 @@ fn build_script_extra_link_arg_warn_without_flag() {
         )
         .build();
 
-    p.cargo("build -vv")
+    p.cargo("build -v")
         .with_status(0)
         .with_stderr_contains("warning: cargo:rustc-link-arg requires -Zextra-link-arg flag")
         .run();

--- a/tests/testsuite/build_script_extra_link_arg.rs
+++ b/tests/testsuite/build_script_extra_link_arg.rs
@@ -1,0 +1,72 @@
+//! Tests for -Zextra-link-arg.
+
+use cargo_test_support::{basic_bin_manifest, project};
+
+#[cargo_test]
+fn build_script_extra_bin_link_args() {
+    let p = project()
+        .file("Cargo.toml", &basic_bin_manifest("foo"))
+        .file("src/main.rs", "fn main() {}")
+        .file(
+            "build.rs",
+            r#"
+                fn main() {
+                    println!("cargo:rustc-bin-link-arg=--this-is-a-bogus-flag");
+                }
+            "#,
+        )
+        .build();
+
+    p.cargo("build -Zextra-link-arg -v")
+        .masquerade_as_nightly_cargo()
+        .with_status(101)
+        .with_stderr_contains(
+            "[RUNNING] `rustc --crate-name foo [..]-C link-arg=--this-is-a-bogus-flag[..]",
+        )
+        .run();
+}
+
+#[cargo_test]
+fn build_script_extra_link_args() {
+    let p = project()
+        .file("Cargo.toml", &basic_bin_manifest("foo"))
+        .file("src/main.rs", "fn main() {}")
+        .file(
+            "build.rs",
+            r#"
+                fn main() {
+                    println!("cargo:rustc-link-arg=--this-is-a-bogus-flag");
+                }
+            "#,
+        )
+        .build();
+
+    p.cargo("build -Zextra-link-arg -v")
+        .masquerade_as_nightly_cargo()
+        .with_status(101)
+        .with_stderr_contains(
+            "[RUNNING] `rustc --crate-name foo [..]-C link-arg=--this-is-a-bogus-flag[..]",
+        )
+        .run();
+}
+
+#[cargo_test]
+fn build_script_extra_link_args_warn_on_stable() {
+    let p = project()
+        .file("Cargo.toml", &basic_bin_manifest("foo"))
+        .file("src/main.rs", "fn main() {}")
+        .file(
+            "build.rs",
+            r#"
+                fn main() {
+                    println!("cargo:rustc-link-arg=--this-is-a-bogus-flag");
+                }
+            "#,
+        )
+        .build();
+
+    p.cargo("build -vv")
+        .with_status(0)
+        .with_stderr_contains("warning: cargo:rustc-link-arg requires -Zextra-link-arg flag")
+        .run();
+}

--- a/tests/testsuite/build_script_extra_link_arg.rs
+++ b/tests/testsuite/build_script_extra_link_arg.rs
@@ -11,7 +11,7 @@ fn build_script_extra_link_arg_bin() {
             "build.rs",
             r#"
                 fn main() {
-                    println!("cargo:rustc-bin-link-arg=--this-is-a-bogus-flag");
+                    println!("cargo:rustc-link-arg-bins=--this-is-a-bogus-flag");
                 }
             "#,
         )

--- a/tests/testsuite/build_script_extra_link_arg.rs
+++ b/tests/testsuite/build_script_extra_link_arg.rs
@@ -3,7 +3,7 @@
 use cargo_test_support::{basic_bin_manifest, project};
 
 #[cargo_test]
-fn build_script_extra_bin_link_args() {
+fn build_script_extra_link_arg_bin() {
     let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
         .file("src/main.rs", "fn main() {}")
@@ -27,7 +27,7 @@ fn build_script_extra_bin_link_args() {
 }
 
 #[cargo_test]
-fn build_script_extra_link_args() {
+fn build_script_extra_link_arg() {
     let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
         .file("src/main.rs", "fn main() {}")
@@ -51,7 +51,7 @@ fn build_script_extra_link_args() {
 }
 
 #[cargo_test]
-fn build_script_extra_link_args_warn_on_stable() {
+fn build_script_extra_link_arg_warn_without_flag() {
     let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
         .file("src/main.rs", "fn main() {}")

--- a/tests/testsuite/main.rs
+++ b/tests/testsuite/main.rs
@@ -20,6 +20,7 @@ mod build;
 mod build_plan;
 mod build_script;
 mod build_script_env;
+mod build_script_extra_link_arg;
 mod cache_messages;
 mod cargo_alias_config;
 mod cargo_command;


### PR DESCRIPTION
This is a continuation of https://github.com/rust-lang/cargo/pull/7811, which adds tests and a warning if the `-Zextra-link-arg` flag is not specified. Also moved the documentation into `unstable.md`.