### PR TITLE
Fix overflow error on 32-bit.

### DIFF
--- a/src/cargo/core/compiler/fingerprint.rs
+++ b/src/cargo/core/compiler/fingerprint.rs
@@ -1964,7 +1964,6 @@ impl EncodedDepInfo {
             dst.push((val >> 8) as u8);
             dst.push((val >> 16) as u8);
             dst.push((val >> 24) as u8);
-            assert!(val >> 32 == 0);
         }
     }
 }


### PR DESCRIPTION
This fails to compile on 32-bit platforms with an overflow error ("attempt to shift right by 32_i32 which would overflow").

I think it would be highly unlikely for any value to be in the billions.  Alternatively it can be rewritten to something like `assert!(val <= u32::MAX as usize);`.

