### PR TITLE
Don't overwrite existing `rustdoc` args with --document-private-items

### DIFF
--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -475,13 +475,11 @@ pub fn create_bcx<'a, 'cfg>(
                 extra_args = Some(args);
             }
 
-            if let Some(mut args) = extra_args {
-                match extra_compiler_args.get_mut(&unit) {
-                    None => {
-                        extra_compiler_args.insert(unit.clone(), args);
-                    }
-                    Some(existing) => existing.append(&mut args),
-                }
+            if let Some(args) = extra_args {
+                extra_compiler_args
+                    .entry(unit.clone())
+                    .or_default()
+                    .extend(args);
             }
         }
     }

--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -475,8 +475,13 @@ pub fn create_bcx<'a, 'cfg>(
                 extra_args = Some(args);
             }
 
-            if let Some(args) = extra_args {
-                extra_compiler_args.insert(unit.clone(), args.clone());
+            if let Some(mut args) = extra_args {
+                match extra_compiler_args.get_mut(&unit) {
+                    None => {
+                        extra_compiler_args.insert(unit.clone(), args);
+                    }
+                    Some(existing) => existing.append(&mut args),
+                }
             }
         }
     }

--- a/tests/testsuite/rustdoc.rs
+++ b/tests/testsuite/rustdoc.rs
@@ -40,6 +40,19 @@ fn rustdoc_args() {
 }
 
 #[cargo_test]
+fn rustdoc_binary_args_passed() {
+    let p = project().file("src/main.rs", "").build();
+
+    p.cargo("rustdoc -v")
+        .arg("--")
+        .arg("--theme")
+        .arg("dark")
+        .with_stderr_contains("[RUNNING] `rustdoc [..] --theme dark[..]`")
+        .with_status(101)
+        .run();
+}
+
+#[cargo_test]
 fn rustdoc_foo_with_bar_dependency() {
     let foo = project()
         .file(

--- a/tests/testsuite/rustdoc.rs
+++ b/tests/testsuite/rustdoc.rs
@@ -45,10 +45,8 @@ fn rustdoc_binary_args_passed() {
 
     p.cargo("rustdoc -v")
         .arg("--")
-        .arg("--theme")
-        .arg("dark")
-        .with_stderr_contains("[RUNNING] `rustdoc [..] --theme dark[..]`")
-        .with_status(101)
+        .arg("--markdown-no-toc")
+        .with_stderr_contains("[RUNNING] `rustdoc [..] --markdown-no-toc[..]`")
         .run();
 }
 


### PR DESCRIPTION
Instead, add that flag in addition to any existing flags.

Closes https://github.com/rust-lang/cargo/issues/8445