### PR TITLE
Add support for deserializing enums in config files

### DIFF
--- a/tests/testsuite/config.rs
+++ b/tests/testsuite/config.rs
@@ -1,5 +1,6 @@
 //! Tests for config settings.
 
+use cargo::core::profiles::Strip;
 use cargo::core::{enable_nightly_features, Shell};
 use cargo::util::config::{self, Config, SslVersionConfig, StringList};
 use cargo::util::interning::InternedString;
@@ -1258,4 +1259,20 @@ fn string_list_advanced_env() {
         config.get::<StringList>("key3").unwrap_err(),
         "error in environment variable `CARGO_KEY3`: expected string, found integer",
     );
+}
+
+#[cargo_test]
+fn parse_enum() {
+    write_config(
+        "\
+[profile.release]
+strip = 'debuginfo'
+",
+    );
+
+    let config = new_config();
+
+    let p: toml::TomlProfile = config.get("profile.release").unwrap();
+    let strip = p.strip.unwrap();
+    assert_eq!(strip, Strip::DebugInfo);
 }

--- a/tests/testsuite/config.rs
+++ b/tests/testsuite/config.rs
@@ -1276,3 +1276,26 @@ strip = 'debuginfo'
     let strip = p.strip.unwrap();
     assert_eq!(strip, Strip::DebugInfo);
 }
+
+#[cargo_test]
+fn parse_enum_fail() {
+    write_config(
+        "\
+[profile.release]
+strip = 'invalid'
+",
+    );
+
+    let config = new_config();
+
+    assert_error(
+        config
+            .get::<toml::TomlProfile>("profile.release")
+            .unwrap_err(),
+        "\
+error in [..]/.cargo/config: could not load config key `profile.release.strip`
+
+Caused by:
+  unknown variant `invalid`, expected one of `debuginfo`, `none`, `symbols`",
+    );
+}


### PR DESCRIPTION
Implements `deserialize_enum` functionality to allow config options which are Rust enums.

@ehuss The code currently has some `todo!`s because I'm not sure how the custom `Deserializer` is supposed to do error handling.

Fixes #8450