### PR TITLE
Emit the `test` field in cargo metadata

### DIFF
--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -263,6 +263,8 @@ struct SerializedTarget<'a> {
     #[serde(rename = "required-features", skip_serializing_if = "Option::is_none")]
     required_features: Option<Vec<&'a str>>,
     doctest: bool,
+    /// Whether tests should be run for the target (`test` field in `Cargo.toml`)
+    test: bool,
 }
 
 impl ser::Serialize for Target {
@@ -283,6 +285,7 @@ impl ser::Serialize for Target {
                 .required_features()
                 .map(|rf| rf.iter().map(|s| &**s).collect()),
             doctest: self.doctested() && self.doctestable(),
+            test: self.tested(),
         }
         .serialize(s)
     }

--- a/src/doc/man/cargo-metadata.adoc
+++ b/src/doc/man/cargo-metadata.adoc
@@ -134,7 +134,10 @@ The output has the following format:
                     /* Whether or not this target has doc tests enabled, and
                        the target is compatible with doc testing.
                     */
-                    "doctest": false
+                    "doctest": false,
+                    /* Whether or not this target should be built and run with `--test`
+                    */
+                    "test": true
                 }
             ],
             /* Set of features defined for the package.

--- a/src/doc/man/generated/cargo-metadata.html
+++ b/src/doc/man/generated/cargo-metadata.html
@@ -141,7 +141,10 @@ for a Rust API for reading the metadata.</p>
                     /* Whether or not this target has doc tests enabled, and
                        the target is compatible with doc testing.
                     */
-                    "doctest": false
+                    "doctest": false,
+                    /* Whether or not this target should be built and run with `--test`
+                    */
+                    "test": true
                 }
             ],
             /* Set of features defined for the package.

--- a/src/doc/src/reference/external-tools.md
+++ b/src/doc/src/reference/external-tools.md
@@ -142,7 +142,8 @@ following structure:
         "name": "my-package",
         "src_path": "/path/to/my-package/src/lib.rs",
         "edition": "2018",
-        "doctest": true
+        "doctest": true,
+        "test": true
     },
     /* The profile indicates which compiler settings were used. */
     "profile": {

--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -694,6 +694,7 @@ The following is a description of the JSON structure:
         "name": "my-package",
         "src_path": "/path/to/my-package/src/lib.rs",
         "edition": "2018",
+        "test": true,
         "doctest": true
       },
       /* The profile settings for this unit.

--- a/src/etc/man/cargo-metadata.1
+++ b/src/etc/man/cargo-metadata.1
@@ -155,7 +155,11 @@ The output has the following format:
                     /* Whether or not this target has doc tests enabled, and
                        the target is compatible with doc testing.
                     */
-                    "doctest": false
+                    "doctest": false,
+                    /* Whether or not this target has the `test` field set in the manifest,
+                       causing it to be compiled with `--test`.
+                    */
+                    "test": true
                 }
             ],
             /* Set of features defined for the package.

--- a/tests/testsuite/bench.rs
+++ b/tests/testsuite/bench.rs
@@ -595,7 +595,7 @@ fn bench_autodiscover_2015() {
                 version = "0.0.1"
                 authors = []
                 edition = "2015"
-                
+
                 [features]
                 magic = []
 
@@ -1628,7 +1628,8 @@ fn json_artifact_includes_executable_for_benchmark() {
                     "doctest": false,
                     "edition": "2015",
                     "name": "benchmark",
-                    "src_path": "[..]/foo/benches/benchmark.rs"
+                    "src_path": "[..]/foo/benches/benchmark.rs",
+                    "test": false
                 }
             }
 

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -3142,7 +3142,8 @@ fn compiler_json_error_format() {
             "doctest": false,
             "edition": "2015",
             "name":"build-script-build",
-            "src_path":"[..]build.rs"
+            "src_path":"[..]build.rs",
+            "test": false
         },
         "profile": {
             "debug_assertions": true,
@@ -3166,7 +3167,8 @@ fn compiler_json_error_format() {
             "doctest": true,
             "edition": "2015",
             "name":"bar",
-            "src_path":"[..]lib.rs"
+            "src_path":"[..]lib.rs",
+            "test": true
         },
         "message":"{...}"
     }
@@ -3189,7 +3191,8 @@ fn compiler_json_error_format() {
             "doctest": true,
             "edition": "2015",
             "name":"bar",
-            "src_path":"[..]lib.rs"
+            "src_path":"[..]lib.rs",
+            "test": true
         },
         "filenames":[
             "[..].rlib",
@@ -3217,7 +3220,8 @@ fn compiler_json_error_format() {
             "doctest": false,
             "edition": "2015",
             "name":"foo",
-            "src_path":"[..]main.rs"
+            "src_path":"[..]main.rs",
+            "test": true
         },
         "message":"{...}"
     }
@@ -3231,7 +3235,8 @@ fn compiler_json_error_format() {
             "doctest": false,
             "edition": "2015",
             "name":"foo",
-            "src_path":"[..]main.rs"
+            "src_path":"[..]main.rs",
+            "test": true
         },
         "profile": {
             "debug_assertions": true,
@@ -3299,7 +3304,8 @@ fn message_format_json_forward_stderr() {
             "doctest": false,
             "edition": "2015",
             "name":"foo",
-            "src_path":"[..]"
+            "src_path":"[..]",
+            "test": true
         },
         "message":"{...}"
     }
@@ -3313,7 +3319,8 @@ fn message_format_json_forward_stderr() {
             "doctest": false,
             "edition": "2015",
             "name":"foo",
-            "src_path":"[..]"
+            "src_path":"[..]",
+            "test": true
         },
         "profile":{
             "debug_assertions":false,

--- a/tests/testsuite/metabuild.rs
+++ b/tests/testsuite/metabuild.rs
@@ -701,7 +701,8 @@ fn metabuild_json_artifact() {
       "custom-build"
     ],
     "name": "metabuild-foo",
-    "src_path": "[..]/foo/target/.metabuild/metabuild-foo-[..].rs"
+    "src_path": "[..]/foo/target/.metabuild/metabuild-foo-[..].rs",
+    "test": false
   }
 }
 
@@ -750,7 +751,8 @@ fn metabuild_failed_build_json() {
       "custom-build"
     ],
     "name": "metabuild-foo",
-    "src_path": null
+    "src_path": null,
+    "test": false
   }
 }
 "#,

--- a/tests/testsuite/metadata.rs
+++ b/tests/testsuite/metadata.rs
@@ -42,6 +42,7 @@ fn cargo_metadata_simple() {
                             "bin"
                         ],
                         "doctest": false,
+                        "test": true,
                         "edition": "2015",
                         "name": "foo",
                         "src_path": "[..]/foo/src/foo.rs"
@@ -135,6 +136,7 @@ crate-type = ["lib", "staticlib"]
                             "staticlib"
                         ],
                         "doctest": true,
+                        "test": true,
                         "edition": "2015",
                         "name": "foo",
                         "src_path": "[..]/foo/src/lib.rs"
@@ -216,6 +218,7 @@ optional_feat = []
                             "lib"
                         ],
                         "doctest": true,
+                        "test": true,
                         "edition": "2015",
                         "name": "foo",
                         "src_path": "[..]/foo/src/lib.rs"
@@ -328,6 +331,7 @@ fn cargo_metadata_with_deps_and_version() {
                             "lib"
                         ],
                         "doctest": true,
+                        "test": true,
                         "edition": "2015",
                         "kind": [
                             "lib"
@@ -363,6 +367,7 @@ fn cargo_metadata_with_deps_and_version() {
                             "lib"
                         ],
                         "doctest": true,
+                        "test": true,
                         "edition": "2015",
                         "kind": [
                             "lib"
@@ -423,6 +428,7 @@ fn cargo_metadata_with_deps_and_version() {
                             "bin"
                         ],
                         "doctest": false,
+                        "test": true,
                         "edition": "2015",
                         "kind": [
                             "bin"
@@ -458,6 +464,7 @@ fn cargo_metadata_with_deps_and_version() {
                             "lib"
                         ],
                         "doctest": true,
+                        "test": true,
                         "edition": "2015",
                         "kind": [
                             "lib"
@@ -591,6 +598,7 @@ name = "ex"
                         "kind": [ "lib" ],
                         "crate_types": [ "lib" ],
                         "doctest": true,
+                        "test": true,
                         "edition": "2015",
                         "name": "foo",
                         "src_path": "[..]/foo/src/lib.rs"
@@ -599,6 +607,7 @@ name = "ex"
                         "kind": [ "example" ],
                         "crate_types": [ "bin" ],
                         "doctest": false,
+                        "test": false,
                         "edition": "2015",
                         "name": "ex",
                         "src_path": "[..]/foo/examples/ex.rs"
@@ -678,6 +687,7 @@ crate-type = ["rlib", "dylib"]
                         "kind": [ "lib" ],
                         "crate_types": [ "lib" ],
                         "doctest": true,
+                        "test": true,
                         "edition": "2015",
                         "name": "foo",
                         "src_path": "[..]/foo/src/lib.rs"
@@ -686,6 +696,7 @@ crate-type = ["rlib", "dylib"]
                         "kind": [ "example" ],
                         "crate_types": [ "rlib", "dylib" ],
                         "doctest": false,
+                        "test": false,
                         "edition": "2015",
                         "name": "ex",
                         "src_path": "[..]/foo/examples/ex.rs"
@@ -772,6 +783,7 @@ fn workspace_metadata() {
                         "kind": [ "lib" ],
                         "crate_types": [ "lib" ],
                         "doctest": true,
+                        "test": true,
                         "edition": "2015",
                         "name": "bar",
                         "src_path": "[..]bar/src/lib.rs"
@@ -805,6 +817,7 @@ fn workspace_metadata() {
                         "kind": [ "lib" ],
                         "crate_types": [ "lib" ],
                         "doctest": true,
+                        "test": true,
                         "edition": "2015",
                         "name": "baz",
                         "src_path": "[..]baz/src/lib.rs"
@@ -893,6 +906,7 @@ fn workspace_metadata_no_deps() {
                         "kind": [ "lib" ],
                         "crate_types": [ "lib" ],
                         "doctest": true,
+                        "test": true,
                         "edition": "2015",
                         "name": "bar",
                         "src_path": "[..]bar/src/lib.rs"
@@ -926,6 +940,7 @@ fn workspace_metadata_no_deps() {
                         "kind": [ "lib" ],
                         "crate_types": ["lib"],
                         "doctest": true,
+                        "test": true,
                         "edition": "2015",
                         "name": "baz",
                         "src_path": "[..]baz/src/lib.rs"
@@ -986,6 +1001,7 @@ const MANIFEST_OUTPUT: &str = r#"
             "kind":["bin"],
             "crate_types":["bin"],
             "doctest": false,
+            "test": true,
             "edition": "2015",
             "name":"foo",
             "src_path":"[..]/foo/src/foo.rs"
@@ -1168,6 +1184,7 @@ fn package_metadata() {
                         "kind": [ "lib" ],
                         "crate_types": [ "lib" ],
                         "doctest": true,
+                        "test": true,
                         "edition": "2015",
                         "name": "foo",
                         "src_path": "[..]foo/src/lib.rs"
@@ -1241,6 +1258,7 @@ fn package_publish() {
                         "kind": [ "lib" ],
                         "crate_types": [ "lib" ],
                         "doctest": true,
+                        "test": true,
                         "edition": "2015",
                         "name": "foo",
                         "src_path": "[..]foo/src/lib.rs"
@@ -1315,6 +1333,7 @@ fn cargo_metadata_path_to_cargo_toml_project() {
                         "lib"
                     ],
                     "doctest": true,
+                    "test": true,
                     "edition": "2015",
                     "kind": [
                         "lib"
@@ -1397,6 +1416,7 @@ fn package_edition_2018() {
                                 "lib"
                             ],
                             "doctest": true,
+                            "test": true,
                             "edition": "2018",
                             "kind": [
                                 "lib"
@@ -1483,6 +1503,7 @@ fn target_edition_2018() {
                                 "lib"
                             ],
                             "doctest": true,
+                            "test": true,
                             "edition": "2018",
                             "kind": [
                                 "lib"
@@ -1495,6 +1516,7 @@ fn target_edition_2018() {
                                 "bin"
                             ],
                             "doctest": false,
+                            "test": true,
                             "edition": "2015",
                             "kind": [
                                 "bin"
@@ -1582,6 +1604,7 @@ fn rename_dependency() {
                         "lib"
                     ],
                     "doctest": true,
+                    "test": true,
                     "edition": "2015",
                     "kind": [
                         "lib"
@@ -1617,6 +1640,7 @@ fn rename_dependency() {
                         "lib"
                     ],
                     "doctest": true,
+                    "test": true,
                     "edition": "2015",
                     "kind": [
                         "lib"
@@ -1677,6 +1701,7 @@ fn rename_dependency() {
                         "lib"
                     ],
                     "doctest": true,
+                    "test": true,
                     "edition": "2015",
                     "kind": [
                         "lib"
@@ -1793,6 +1818,7 @@ fn metadata_links() {
             "lib"
           ],
           "doctest": true,
+          "test": true,
           "edition": "2015",
           "kind": [
             "lib"
@@ -1805,6 +1831,7 @@ fn metadata_links() {
             "bin"
           ],
           "doctest": false,
+          "test": false,
           "edition": "2015",
           "kind": [
             "custom-build"
@@ -1896,7 +1923,8 @@ fn deps_with_bin_only() {
           "name": "foo",
           "src_path": "[..]/foo/src/lib.rs",
           "edition": "2015",
-          "doctest": true
+          "doctest": true,
+          "test": true
         }
       ],
       "features": {},
@@ -1995,6 +2023,7 @@ fn filter_platform() {
           "name": "alt-dep",
           "src_path": "[..]/alt-dep-0.0.1/src/lib.rs",
           "edition": "2015",
+          "test": true,
           "doctest": true
         }
       ],
@@ -2033,6 +2062,7 @@ fn filter_platform() {
           "name": "cfg-dep",
           "src_path": "[..]/cfg-dep-0.0.1/src/lib.rs",
           "edition": "2015",
+          "test": true,
           "doctest": true
         }
       ],
@@ -2071,6 +2101,7 @@ fn filter_platform() {
           "name": "host-dep",
           "src_path": "[..]/host-dep-0.0.1/src/lib.rs",
           "edition": "2015",
+          "test": true,
           "doctest": true
         }
       ],
@@ -2109,6 +2140,7 @@ fn filter_platform() {
           "name": "normal-dep",
           "src_path": "[..]/normal-dep-0.0.1/src/lib.rs",
           "edition": "2015",
+          "test": true,
           "doctest": true
         }
       ],
@@ -2196,6 +2228,7 @@ fn filter_platform() {
           "name": "foo",
           "src_path": "[..]/foo/src/lib.rs",
           "edition": "2015",
+          "test": true,
           "doctest": true
         }
       ],

--- a/tests/testsuite/read_manifest.rs
+++ b/tests/testsuite/read_manifest.rs
@@ -27,6 +27,7 @@ fn manifest_output(readme_value: &str) -> String {
         "kind":["bin"],
         "crate_types":["bin"],
         "doctest": false,
+        "test": true,
         "edition": "2015",
         "name":"foo",
         "src_path":"[..]/foo/src/foo.rs"

--- a/tests/testsuite/test.rs
+++ b/tests/testsuite/test.rs
@@ -1984,7 +1984,7 @@ fn bin_is_preserved() {
     p.cargo("build -v").run();
     assert!(p.bin("foo").is_file());
 
-    println!("testing");
+    println!("test");
     p.cargo("test -v").run();
     assert!(p.bin("foo").is_file());
 }
@@ -3358,7 +3358,8 @@ fn json_artifact_includes_test_flag() {
             "doctest": true,
             "edition": "2015",
             "name":"foo",
-            "src_path":"[..]lib.rs"
+            "src_path":"[..]lib.rs",
+            "test": true
         },
         "filenames":"{...}",
         "fresh": false
@@ -3394,7 +3395,8 @@ fn json_artifact_includes_executable_for_library_tests() {
                     "doctest": true,
                     "edition": "2015",
                     "name": "foo",
-                    "src_path": "[..]/foo/src/lib.rs"
+                    "src_path": "[..]/foo/src/lib.rs",
+                    "test": true
                 }
             }
 
@@ -3430,7 +3432,8 @@ fn json_artifact_includes_executable_for_integration_tests() {
                     "doctest": false,
                     "edition": "2015",
                     "name": "integration_test",
-                    "src_path": "[..]/foo/tests/integration_test.rs"
+                    "src_path": "[..]/foo/tests/integration_test.rs",
+                    "test": true
                 }
             }
 

--- a/tests/testsuite/unit_graph.rs
+++ b/tests/testsuite/unit_graph.rs
@@ -63,7 +63,8 @@ fn simple() {
         "name": "a",
         "src_path": "[..]/a-1.0.0/src/lib.rs",
         "edition": "2015",
-        "doctest": true
+        "doctest": true,
+        "test": true
       },
       "profile": {
         "name": "dev",
@@ -104,7 +105,8 @@ fn simple() {
         "name": "b",
         "src_path": "[..]/b-1.0.0/src/lib.rs",
         "edition": "2015",
-        "doctest": true
+        "doctest": true,
+        "test": true
       },
       "profile": {
         "name": "dev",
@@ -145,6 +147,7 @@ fn simple() {
         "name": "c",
         "src_path": "[..]/c-1.0.0/src/lib.rs",
         "edition": "2015",
+        "test": true,
         "doctest": true
       },
       "profile": {
@@ -179,6 +182,7 @@ fn simple() {
         "name": "foo",
         "src_path": "[..]/foo/src/lib.rs",
         "edition": "2015",
+        "test": true,
         "doctest": true
       },
       "profile": {

--- a/tests/testsuite/update.rs
+++ b/tests/testsuite/update.rs
@@ -468,6 +468,7 @@ fn update_precise_first_run() {
             "lib"
           ],
           "doctest": true,
+          "test": true,
           "edition": "2015",
           "kind": [
             "lib"
@@ -508,7 +509,8 @@ fn update_precise_first_run() {
             "lib"
           ],
           "name": "serde",
-          "src_path": "[..]/home/.cargo/registry/src/-[..]/serde-0.2.0/src/lib.rs"
+          "src_path": "[..]/home/.cargo/registry/src/-[..]/serde-0.2.0/src/lib.rs",
+          "test": true
         }
       ],
       "version": "0.2.0"


### PR DESCRIPTION
This is needed so `cargo-metadata` can expose it: https://github.com/oli-obk/cargo_metadata/issues/114