### PR TITLE
Print URL on failure to upload.

### DIFF
--- a/crates/crates-io/lib.rs
+++ b/crates/crates-io/lib.rs
@@ -7,7 +7,7 @@ use std::io::prelude::*;
 use std::io::Cursor;
 use std::time::Instant;
 
-use anyhow::{bail, Result};
+use anyhow::{bail, format_err, Result};
 use curl::easy::{Easy, List};
 use percent_encoding::{percent_encode, NON_ALPHANUMERIC};
 use serde::{Deserialize, Serialize};
@@ -212,7 +212,8 @@ impl Registry {
         headers.append(&format!("Authorization: {}", token))?;
         self.handle.http_headers(headers)?;
 
-        let body = self.handle(&mut |buf| body.read(buf).unwrap_or(0))?;
+        let body = self.handle(&mut |buf| body.read(buf).unwrap_or(0));
+        let body = body.map_err(|e| format_err!("publishing to {}: {}", url, e))?;
 
         let response = if body.is_empty() {
             "{}".parse()?


### PR DESCRIPTION
When setting up a local copy of crates.io, I got error output like this:

   Uploading uploadtest v0.1.0 (/home/jsha/learnrust/uploadtest)
error: [7] Couldn't connect to server

I was pretty sure cargo was getting the wrong URL for my local registry,
so I wanted to amend the error output to include the failed URL. Now the
output looks like this:

   Uploading uploadtest v0.1.0 (/home/jsha/learnrust/uploadtest)
error: publishing to http://localhost:8888//api/v1/crates/new: [7] Couldn't connect to server