### PR TITLE
Add a `-Zbuild-std-features` flag

### DIFF
--- a/src/cargo/core/compiler/standard_lib.rs
+++ b/src/cargo/core/compiler/standard_lib.rs
@@ -99,11 +99,18 @@ pub fn resolve_std<'cfg>(
     spec_pkgs.push("test".to_string());
     let spec = Packages::Packages(spec_pkgs);
     let specs = spec.to_package_id_specs(&std_ws)?;
-    let features = vec!["panic-unwind".to_string(), "backtrace".to_string()];
+    let features = match &config.cli_unstable().build_std_features {
+        Some(list) => list.clone(),
+        None => vec![
+            "panic-unwind".to_string(),
+            "backtrace".to_string(),
+            "default".to_string(),
+        ],
+    };
     // dev_deps setting shouldn't really matter here.
     let opts = ResolveOpts::new(
         /*dev_deps*/ false, &features, /*all_features*/ false,
-        /*uses_default_features*/ true,
+        /*uses_default_features*/ false,
     );
     let resolve = ops::resolve_ws_with_opts(
         &std_ws,

--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -350,6 +350,7 @@ pub struct CliUnstable {
     pub binary_dep_depinfo: bool,
     #[serde(deserialize_with = "deserialize_build_std")]
     pub build_std: Option<Vec<String>>,
+    pub build_std_features: Option<Vec<String>>,
     pub timings: Option<Vec<String>>,
     pub doctest_xcompile: bool,
     pub panic_abort_tests: bool,
@@ -455,6 +456,7 @@ impl CliUnstable {
             "build-std" => {
                 self.build_std = Some(crate::core::compiler::standard_lib::parse_unstable_flag(v))
             }
+            "build-std-features" => self.build_std_features = Some(parse_features(v)),
             "timings" => self.timings = Some(parse_timings(v)),
             "doctest-xcompile" => self.doctest_xcompile = parse_empty(k, v)?,
             "panic-abort-tests" => self.panic_abort_tests = parse_empty(k, v)?,

--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -358,6 +358,15 @@ something doesn't quite work the way you'd like it to, feel free to check out
 the [issue tracker](https://github.com/rust-lang/wg-cargo-std-aware/issues) of
 the tracking repository, and if it's not there please file a new issue!
 
+### build-std-features
+* Tracking Repository: https://github.com/rust-lang/wg-cargo-std-aware
+
+This flag is a sibling to the `-Zbuild-std` feature flag. This will configure
+the features enabled for the standard library itself when building the standard
+library. The default enabled features, at this time, are `backtrace` and
+`panic_unwind`. This flag expects a comma-separated list and, if provided, will
+override the default list of features enabled.
+
 ### timings
 * Tracking Issue: [#7405](https://github.com/rust-lang/cargo/issues/7405)
 

--- a/tests/testsuite/mock-std/src/libstd/Cargo.toml
+++ b/tests/testsuite/mock-std/src/libstd/Cargo.toml
@@ -9,3 +9,6 @@ path = "lib.rs"
 
 [dependencies]
 registry-dep-using-alloc = { version = "*", features = ['mockbuild'] }
+
+[features]
+feature1 = []

--- a/tests/testsuite/mock-std/src/libstd/lib.rs
+++ b/tests/testsuite/mock-std/src/libstd/lib.rs
@@ -5,5 +5,8 @@
 pub use std::*;
 
 #[stable(since = "1.0.0", feature = "dummy")]
-pub fn custom_api() {
-}
+pub fn custom_api() {}
+
+#[cfg(feature = "feature1")]
+#[stable(since = "1.0.0", feature = "dummy")]
+pub fn conditional_function() {}

--- a/tests/testsuite/mock-std/src/libtest/Cargo.toml
+++ b/tests/testsuite/mock-std/src/libtest/Cargo.toml
@@ -9,6 +9,7 @@ path = "lib.rs"
 
 [dependencies]
 proc_macro = { path = "../libproc_macro" }
+std = { path = "../libstd" }
 panic_unwind = { path = "../libpanic_unwind" }
 compiler_builtins = { path = "../libcompiler_builtins" }
 registry-dep-using-std = { version = "*", features = ['mockbuild'] }
@@ -16,3 +17,5 @@ registry-dep-using-std = { version = "*", features = ['mockbuild'] }
 [features]
 panic-unwind = []
 backtrace = []
+feature1 = ["std/feature1"]
+default = []

--- a/tests/testsuite/standard_lib.rs
+++ b/tests/testsuite/standard_lib.rs
@@ -632,3 +632,26 @@ fn cargo_config_injects_compiler_builtins() {
         .with_stderr_does_not_contain("[..]libstd[..]")
         .run();
 }
+
+#[cargo_test]
+fn different_features() {
+    let setup = match setup() {
+        Some(s) => s,
+        None => return,
+    };
+    let p = project()
+        .file(
+            "src/lib.rs",
+            "
+                pub fn foo() {
+                    std::conditional_function();
+                }
+            ",
+        )
+        .build();
+    p.cargo("build")
+        .build_std(&setup)
+        .arg("-Zbuild-std-features=feature1")
+        .target_host()
+        .run();
+}


### PR DESCRIPTION
This flag is intended to pair with `-Zbuild-std` as necessary to
configure the features that libstd is built with. This is highly
unlikely to ever be stabilized in any form (unlike `-Zbuild-std` which
we'd like to stabilize at some point), but can be useful for
experimenting with the standard library. For example today it can be
used to test changes to binary size by disabling backtraces.

My intention is that we won't need a `--no-default-features` equivalent
for libstd, where after rust-lang/rust#74377 is merged we can
unconditionally specify default features are disabled but the default
set of features lists `default`. That way if users want to override the
list *and* include the default feature, they can just be sure to include
`default`.