### PR TITLE
clippy cleanups

### DIFF
--- a/src/cargo/lib.rs
+++ b/src/cargo/lib.rs
@@ -165,7 +165,7 @@ fn _display_error(err: &Error, shell: &mut Shell, as_err: bool) -> bool {
         drop(writeln!(shell.err(), "\nCaused by:"));
         for line in cause.to_string().lines() {
             if line.is_empty() {
-                drop(writeln!(shell.err(), ""));
+                drop(writeln!(shell.err()));
             } else {
                 drop(writeln!(shell.err(), "  {}", line));
             }

--- a/src/cargo/lib.rs
+++ b/src/cargo/lib.rs
@@ -18,8 +18,8 @@
 #![allow(clippy::wrong_self_convention)] // perhaps `Rc` should be special-cased in Clippy?
 #![allow(clippy::write_with_newline)] // too pedantic
 #![allow(clippy::inefficient_to_string)] // this causes suggestions that result in `(*s).to_string()`
+#![allow(clippy::collapsible_if)] // too pedantic
 #![warn(clippy::needless_borrow)]
-#![warn(clippy::redundant_clone)]
 // Unit is now interned, and would probably be better as pass-by-copy, but
 // doing so causes a lot of & and * shenanigans that makes the code arguably
 // less clear and harder to read.

--- a/src/cargo/sources/git/source.rs
+++ b/src/cargo/sources/git/source.rs
@@ -173,7 +173,7 @@ impl<'cfg> Source for GitSource<'cfg> {
             .join("checkouts")
             .join(&self.ident)
             .join(short_id.as_str());
-        db.copy_to(actual_rev.clone(), &checkout_path, self.config)?;
+        db.copy_to(actual_rev, &checkout_path, self.config)?;
 
         let source_id = self.source_id.with_precise(Some(actual_rev.to_string()));
         let path_source = PathSource::new_recursive(&checkout_path, source_id, self.config);

--- a/src/cargo/sources/git/utils.rs
+++ b/src/cargo/sources/git/utils.rs
@@ -150,7 +150,7 @@ impl GitDatabase {
     ) -> CargoResult<GitCheckout<'_>> {
         let mut checkout = None;
         if let Ok(repo) = git2::Repository::open(dest) {
-            let mut co = GitCheckout::new(dest, self, rev.clone(), repo);
+            let mut co = GitCheckout::new(dest, self, rev, repo);
             if !co.is_fresh() {
                 // After a successful fetch operation the subsequent reset can
                 // fail sometimes for corrupt repositories where the fetch
@@ -751,15 +751,15 @@ pub fn fetch(
         }
 
         GitReference::DefaultBranch => {
-            refspecs.push(format!("HEAD:refs/remotes/origin/HEAD"));
+            refspecs.push(String::from("HEAD:refs/remotes/origin/HEAD"));
         }
 
         // For `rev` dependencies we don't know what the rev will point to. To
         // handle this situation we fetch all branches and tags, and then we
         // pray it's somewhere in there.
         GitReference::Rev(_) => {
-            refspecs.push(format!("refs/heads/*:refs/remotes/origin/*"));
-            refspecs.push(format!("HEAD:refs/remotes/origin/HEAD"));
+            refspecs.push(String::from("refs/heads/*:refs/remotes/origin/*"));
+            refspecs.push(String::from("HEAD:refs/remotes/origin/HEAD"));
             tags = true;
         }
     }

--- a/src/cargo/sources/registry/remote.rs
+++ b/src/cargo/sources/registry/remote.rs
@@ -22,8 +22,8 @@ use std::str;
 
 fn make_crate_prefix(name: &str) -> String {
     match name.len() {
-        1 => format!("1"),
-        2 => format!("2"),
+        1 => String::from("1"),
+        2 => String::from("2"),
         3 => format!("3/{}", &name[..1]),
         _ => format!("{}/{}", &name[0..2], &name[2..4]),
     }

--- a/src/cargo/util/paths.rs
+++ b/src/cargo/util/paths.rs
@@ -487,7 +487,7 @@ pub fn create_dir_all_excluded_from_backups_atomic(p: impl AsRef<Path>) -> Cargo
     // easily sure that rename() will succeed (the new name needs to be on the same mount
     // point as the old one).
     let tempdir = TempFileBuilder::new().prefix(base).tempdir_in(parent)?;
-    exclude_from_backups(&tempdir.path());
+    exclude_from_backups(tempdir.path());
     // Previously std::fs::create_dir_all() (through paths::create_dir_all()) was used
     // here to create the directory directly and fs::create_dir_all() explicitly treats
     // the directory being created concurrently by another thread or process as success,

--- a/tests/testsuite/dep_info.rs
+++ b/tests/testsuite/dep_info.rs
@@ -37,7 +37,7 @@ fn assert_deps(project: &Project, fingerprint: &str, test_cb: impl Fn(&Path, &[(
     fn read_usize(bytes: &mut &[u8]) -> usize {
         let ret = &bytes[..4];
         *bytes = &bytes[4..];
-        ((ret[0] as usize) << 0)
+        (ret[0] as usize)
             | ((ret[1] as usize) << 8)
             | ((ret[2] as usize) << 16)
             | ((ret[3] as usize) << 24)


### PR DESCRIPTION
Fixes a couple of clippy warnings.
Ignores clippy::collapsible_if warnings in the future (iirc there were not desired)
clippy::redundant_clone is enabled by default by clippy already. 
