### PR TITLE
Fix freshness checks for build scripts on renamed dirs

### DIFF
--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -873,11 +873,7 @@ impl<'cfg> Workspace<'cfg> {
                 MaybePackage::Package(ref p) => p.clone(),
                 MaybePackage::Virtual(_) => continue,
             };
-            let mut src = PathSource::new(
-                pkg.manifest_path(),
-                pkg.package_id().source_id(),
-                self.config,
-            );
+            let mut src = PathSource::new(pkg.root(), pkg.package_id().source_id(), self.config);
             src.preload_with(pkg);
             registry.add_preloaded(Box::new(src));
         }

--- a/src/cargo/sources/path.rs
+++ b/src/cargo/sources/path.rs
@@ -522,6 +522,10 @@ impl<'cfg> Source for PathSource<'cfg> {
 
     fn fingerprint(&self, pkg: &Package) -> CargoResult<String> {
         let (max, max_path) = self.last_modified_file(pkg)?;
+        // Note that we try to strip the prefix of this package to get a
+        // relative path to ensure that the fingerprint remains consistent
+        // across entire project directory renames.
+        let max_path = max_path.strip_prefix(&self.path).unwrap_or(&max_path);
         Ok(format!("{} ({})", max, max_path.display()))
     }
 


### PR DESCRIPTION
This commit fixes an issue in Cargo where when an entire project
directory is renamed (preserving the target directory) then path
dependencies with build scripts would have their build scripts rereun
when building again. The problem with this was that when a build script
doesn't print `rerun-if-changed` Cargo's conservative fingerprint listed
an absolute path in it, which was intended to be a relative path.

The fix here is to use a relative path in the fingerprint to ensure that
it's not the reason a rebuild happens when directories are renamed.