### PR TITLE
doc: Replace "regenerate" with "revoke" for API tokens

### DIFF
--- a/src/doc/src/reference/publishing.md
+++ b/src/doc/src/reference/publishing.md
@@ -22,7 +22,7 @@ $ cargo login abcdefghijklmnopqrstuvwxyz012345
 
 This command will inform Cargo of your API token and store it locally in your
 `~/.cargo/credentials.toml`. Note that this token is a **secret** and should not be
-shared with anyone else. If it leaks for any reason, you should regenerate it
+shared with anyone else. If it leaks for any reason, you should revoke it
 immediately.
 
 ### Before publishing a new crate


### PR DESCRIPTION
The current UI supports revoking tokens and creating new ones, not regenerating them.