### PR TITLE
Check workspace member existence as dir.

### DIFF
--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -1194,7 +1194,16 @@ impl WorkspaceRootConfig {
             if expanded_paths.is_empty() {
                 expanded_list.push(pathbuf);
             } else {
-                expanded_list.extend(expanded_paths);
+                // Some OS can create system support files anywhere.
+                // (e.g. macOS creates `.DS_Store` file if you visit a directory using Finder.)
+                // Such files can be reported as a member path unexpectedly.
+                // Check and filter out non-directory paths to prevent pushing such accidental unwanted path
+                // as a member.
+                for expanded_path in expanded_paths {
+                    if expanded_path.is_dir() {
+                        expanded_list.push(expanded_path);
+                    }
+                }
             }
         }
 

--- a/tests/testsuite/main.rs
+++ b/tests/testsuite/main.rs
@@ -62,6 +62,7 @@ mod locate_project;
 mod lockfile_compat;
 mod login;
 mod lto;
+mod member_discovery;
 mod member_errors;
 mod message_format;
 mod metabuild;

--- a/tests/testsuite/member_discovery.rs
+++ b/tests/testsuite/member_discovery.rs
@@ -1,0 +1,44 @@
+//! Tests for workspace member discovery.
+
+use cargo::core::{Shell, Workspace};
+use cargo::util::config::Config;
+
+use cargo_test_support::install::cargo_home;
+use cargo_test_support::project;
+use cargo_test_support::registry;
+
+/// Tests exclusion of non-directory files from workspace member discovery using glob `*`.
+#[cargo_test]
+fn bad_file_member_exclusion() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [workspace]
+            members = [ "crates/*" ]
+        "#,
+        )
+        .file("crates/.DS_Store", "PLACEHOLDER")
+        .file(
+            "crates/bar/Cargo.toml",
+            r#"
+            [project]
+            name = "bar"
+            version = "0.1.0"
+            authors = []
+        "#,
+        )
+        .file("crates/bar/src/main.rs", "fn main() {}")
+        .build();
+
+    // Prevent this test from accessing the network by setting up .cargo/config.
+    registry::init();
+    let config = Config::new(
+        Shell::from_write(Box::new(Vec::new())),
+        cargo_home(),
+        cargo_home(),
+    );
+    let ws = Workspace::new(&p.root().join("Cargo.toml"), &config).unwrap();
+    assert_eq!(ws.members().count(), 1);
+    assert_eq!(ws.members().next().unwrap().name(), "bar");
+}


### PR DESCRIPTION
Cargo command fails if workspace members are set to something like `crates/*` and if there's any non project file in `crates` directory. This PR makes member discovery logic to exclude non-directory paths.

In my case, `.DS_Store` (which is made automatically by Finder on macOS) file triggered this issue. 