### PR TITLE
Fix the help display for the target-triple option

### DIFF
--- a/src/cargo/util/command_prelude.rs
+++ b/src/cargo/util/command_prelude.rs
@@ -139,7 +139,7 @@ pub trait AppExt: Sized {
     }
 
     fn arg_target_triple(self, target: &'static str) -> Self {
-        self._arg(multi_opt("target", target, "TRIPLE"))
+        self._arg(multi_opt("target", "TRIPLE", target))
     }
 
     fn arg_target_dir(self) -> Self {


### PR DESCRIPTION
The `--target` option (in `cargo build` for example) had its value name and help text flipped, so it looked like;
```
--target <Build for the target triple>...    TRIPLE
```
This PR swaps the `value_name` and `help` arguments for the `multi_opt` call in `command_prelude.rs`/`fn arg_target_triple()` so the value name and help text are displayed correctly.