### PR TITLE
Flag git zlib errors as spurious errors

### DIFF
--- a/src/cargo/util/network.rs
+++ b/src/cargo/util/network.rs
@@ -36,7 +36,7 @@ impl<'a> Retry<'a> {
 fn maybe_spurious(err: &Error) -> bool {
     if let Some(git_err) = err.downcast_ref::<git2::Error>() {
         match git_err.class() {
-            git2::ErrorClass::Net | git2::ErrorClass::Os => return true,
+            git2::ErrorClass::Net | git2::ErrorClass::Os | git2::ErrorClass::Zlib => return true,
             _ => (),
         }
     }


### PR DESCRIPTION
This may be a bad band-aid for now, but the goal is to help
address #8517 where this has been showing up in the wild quite a lot.