### PR TITLE
Mask out system core.autocrlf settings before resetting git repos

### DIFF
--- a/src/cargo/sources/git/utils.rs
+++ b/src/cargo/sources/git/utils.rs
@@ -328,6 +328,12 @@ impl<'a> GitCheckout<'a> {
         let ok_file = self.location.join(".cargo-ok");
         let _ = paths::remove_file(&ok_file);
         info!("reset {} to {}", self.repo.path().display(), self.revision);
+
+        // Ensure libgit2 won't mess with newlines when we vendor.
+        if let Ok(mut git_config) = self.repo.config() {
+            git_config.set_bool("core.autocrlf", false)?;
+        }
+
         let object = self.repo.find_object(self.revision, None)?;
         reset(&self.repo, &object, config)?;
         paths::create(ok_file)?;


### PR DESCRIPTION
This fixes an issue the gecko developers noticed when vendoring
on windows. \[0\] If a user has `core.autocrlf=true` set
(a reasonable default on windows), vendoring from a git source
would cause all the newlines to be rewritten to include carriage
returns, creating churn and platform-specific results.

To fix this, we simply set the global cargo checkout's "local"
core.autocrlf value before performing a `reset`. This masks out
the system configuration without interfering with the user's
own system/project settings.

\[0\]:  https://bugzilla.mozilla.org/show_bug.cgi?id=1647582