### PR TITLE
[stable] Add back Manifest::targets_mut

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo"
-version = "0.46.0"
+version = "0.46.1"
 edition = "2018"
 authors = ["Yehuda Katz <wycats@gmail.com>",
            "Carl Lerche <me@carllerche.com>",

--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -431,6 +431,10 @@ impl Manifest {
     pub fn targets(&self) -> &[Target] {
         &self.targets
     }
+    // It is used by cargo-c, please do not remove it
+    pub fn targets_mut(&mut self) -> &mut [Target] {
+        &mut self.targets
+    }
     pub fn version(&self) -> &Version {
         self.package_id().version()
     }


### PR DESCRIPTION
It is needed by cargo-c, it was removed in df5cb70e7bc8872216af736f108f5a959a6d2302.

This is a stable backport of #8494. It's technically fixing a stable/stable regression, so this seemed like a good idea. If this is accepted I can also prepare a backport to 1.46 (current beta).