### PR TITLE
[beta] Add back Manifest::targets_mut

### DIFF
--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -431,6 +431,10 @@ impl Manifest {
     pub fn targets(&self) -> &[Target] {
         &self.targets
     }
+    // It is used by cargo-c, please do not remove it
+    pub fn targets_mut(&mut self) -> &mut [Target] {
+        &mut self.targets
+    }
     pub fn version(&self) -> &Version {
         self.package_id().version()
     }


### PR DESCRIPTION
It is needed by cargo-c, it was removed in df5cb70e7bc8872216af736f108f5a959a6d2302

This is coupled with stable backport approved yesterday, https://github.com/rust-lang/cargo/pull/8527.