### PR TITLE
Update termcolor and fwdansi versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ shell-escape = "0.1.4"
 strip-ansi-escapes = "0.1.0"
 tar = { version = "0.4.26", default-features = false }
 tempfile = "3.0"
-termcolor = "1.0"
+termcolor = "1.1"
 toml = "0.5.3"
 unicode-xid = "0.2.0"
 url = "2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,7 +79,7 @@ core-foundation = { version = "0.9.0", features = ["mac_os_10_7_support"] }
 
 [target.'cfg(windows)'.dependencies]
 miow = "0.3.1"
-fwdansi = "1"
+fwdansi = "1.1.0"
 
 [target.'cfg(windows)'.dependencies.winapi]
 version = "0.3"


### PR DESCRIPTION
A summary of the changes since 1.0.5:

- **wincolor-1.0.3**
- readme: update readme with various things
- ci: switch to GitHub Actions and bump MSRV to 1.34.0
- doc: add notes about tty detection
- doc: clarify how ANSI colors work
- **env: respect NO_COLOR environment variable**
- edition: switch to Rust 2018
- deps: drop wincolor dependency
- msrv: document minimum supported Rust version policy
- style: use rustfmt
- **api: add option to toggle terminal resetting**
- readme: test examples in README
- **bug: fix clear() and is_none()**
- **output: italicized support**
- **wincolor-1.0.2**
- wincolor: specify dual-license
