### PR TITLE
Include `+` for crates.io feature requirements in the Cargo Book section on features

### DIFF
--- a/src/doc/src/reference/features.md
+++ b/src/doc/src/reference/features.md
@@ -87,7 +87,7 @@ optional dependencies. This allows packages to internally enable/disable
 features without requiring a new dependency.
 
 > **Note**: [crates.io] requires feature names to only contain ASCII letters,
-> digits, `_`, or `-`.
+> digits, `_`, `-`, or `+`.
 
 ### Usage in end products
 


### PR DESCRIPTION
This change was introduced in commit 5f842f7 of rust-lang/crates.io but was not subsequently added to the Cargo Book.