### PR TITLE
Revert Cargo Book changes for default edition

### DIFF
--- a/src/doc/src/reference/manifest.md
+++ b/src/doc/src/reference/manifest.md
@@ -112,7 +112,7 @@ brackets at the end of each author.
 
 You can opt in to a specific [Rust Edition] for your package with the
 `edition` key in `Cargo.toml`. If you don't specify the edition, it will
-default to 2018.
+default to 2015.
 
 ```toml
 [package]


### PR DESCRIPTION
On #8543 it was introduced a change on the Cargo Book docs
where it was incorrectly stated that the default edition for
the Cargo Manifest was `2018` when indeed, as @ehuss correctly stated
in https://github.com/rust-lang/cargo/pull/8543#issuecomment-663769077
it is not.

Therefore, as @Eh2406 asked for, I made the PR reverting this changes
and leaving the Cargo Book docs as they were before.