### PR TITLE
Flag git http errors as maybe spurious

### DIFF
--- a/src/cargo/util/network.rs
+++ b/src/cargo/util/network.rs
@@ -36,7 +36,10 @@ impl<'a> Retry<'a> {
 fn maybe_spurious(err: &Error) -> bool {
     if let Some(git_err) = err.downcast_ref::<git2::Error>() {
         match git_err.class() {
-            git2::ErrorClass::Net | git2::ErrorClass::Os | git2::ErrorClass::Zlib => return true,
+            git2::ErrorClass::Net
+            | git2::ErrorClass::Os
+            | git2::ErrorClass::Zlib
+            | git2::ErrorClass::Http => return true,
             _ => (),
         }
     }


### PR DESCRIPTION
This showed up in #8544 with an error message of "stream ended at an
unexpected time; class=Http" which sounds like a spurious error.
Termination of a network connection can happen at any time! For now try
to assist in that error by adding another class of error to the list of
maybe spurious errors.