### PR TITLE
Fix sporadic lto test failures.

### DIFF
--- a/tests/testsuite/lto.rs
+++ b/tests/testsuite/lto.rs
@@ -617,7 +617,8 @@ fn test_profile() {
         .build();
 
     p.cargo("test -v")
-        .with_stderr("\
+        // unordered because the two `foo` builds start in parallel
+        .with_stderr_unordered("\
 [UPDATING] [..]
 [DOWNLOADING] [..]
 [DOWNLOADED] [..]
@@ -669,7 +670,8 @@ fn dev_profile() {
         .build();
 
     p.cargo("test -v")
-        .with_stderr("\
+        // unordered because the two `foo` builds start in parallel
+        .with_stderr_unordered("\
 [UPDATING] [..]
 [DOWNLOADING] [..]
 [DOWNLOADED] [..]


### PR DESCRIPTION
These tests can fail because the order of the messages is not deterministic.  The two `foo` jobs start in parallel, so the order can be swapped.  Results in an error like:

```
---- lto::test_profile stdout ----
running `/home/runner/work/cargo/cargo/target/debug/cargo test -v`
thread 'lto::test_profile' panicked at '
Expected: execs
    but: differences:
  6 - |[RUNNING] `rustc --crate-name foo [..]--crate-type lib --emit=dep-info,metadata,link -Cembed-bitcode=no[..]|
    + |     Running `rustc --crate-name foo --edition=2018 src/lib.rs --error-format=json --json=diagnostic-rendered-ansi --emit=dep-info,link -C lto=thin -C debuginfo=2 --test -C metadata=af771ad588185fac -C extra-filename=-af771ad588185fac --out-dir /home/runner/work/cargo/cargo/target/cit/t1080/foo/target/debug/deps -L dependency=/home/runner/work/cargo/cargo/target/cit/t1080/foo/target/debug/deps --extern bar=/home/runner/work/cargo/cargo/target/cit/t1080/foo/target/debug/deps/libbar-398704963dd4e38b.rlib`|

  7 - |[RUNNING] `rustc --crate-name foo [..]--emit=dep-info,link -C lto=thin [..]--test[..]|
    + |     Running `rustc --crate-name foo --edition=2018 src/lib.rs --error-format=json --json=diagnostic-rendered-ansi --crate-type lib --emit=dep-info,metadata,link -Cembed-bitcode=no -C debuginfo=2 -C metadata=1e8f5d385f4ffeb6 -C extra-filename=-1e8f5d385f4ffeb6 --out-dir /home/runner/work/cargo/cargo/target/cit/t1080/foo/target/debug/deps -L dependency=/home/runner/work/cargo/cargo/target/cit/t1080/foo/target/debug/deps --extern bar=/home/runner/work/cargo/cargo/target/cit/t1080/foo/target/debug/deps/libbar-398704963dd4e38b.rmeta`|
```

The failure rate is pretty small (depends heavily on the hardware).
