### PR TITLE
Fix O0 build scripts by default without `[profile.release]`

### DIFF
--- a/src/doc/src/reference/profiles.md
+++ b/src/doc/src/reference/profiles.md
@@ -282,6 +282,24 @@ codegen-units = 16
 rpath = false
 ```
 
+#### Build Dependencies
+
+All profiles, by default, do not optimize build dependencies (build scripts,
+proc macros, and their dependencies). The default settings for build overrides
+are:
+
+```toml
+[profile.dev.build-override]
+opt-level = 0
+codegen-units = 256
+
+[profile.release.build-override]
+opt-level = 0
+codegen-units = 256
+```
+
+Build dependencies otherwise inherit settings from the active profile in use, as
+described below.
 
 ### Profile selection
 

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -5127,3 +5127,38 @@ fn simple_terminal_width() {
         .with_stderr_contains("3 | ..._: () = 42;")
         .run();
 }
+
+#[cargo_test]
+fn build_script_o0_default() {
+    let p = project()
+        .file("src/lib.rs", "")
+        .file("build.rs", "fn main() {}")
+        .build();
+
+    p.cargo("build -v --release")
+        .with_stderr_does_not_contain("[..]build_script_build[..]opt-level[..]")
+        .run();
+}
+
+#[cargo_test]
+fn build_script_o0_default_even_with_release() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.1.0"
+
+                [profile.release]
+                opt-level = 1
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .file("build.rs", "fn main() {}")
+        .build();
+
+    p.cargo("build -v --release")
+        .with_stderr_does_not_contain("[..]build_script_build[..]opt-level[..]")
+        .run();
+}


### PR DESCRIPTION
This fixes an issue where #8500 didn't quite work as expected, since it
only worked if a crate had a `[profile.release]` section.