### PR TITLE
Document build dependencies and dev dependencies

### DIFF
--- a/src/bin/cargo/commands/rustdoc.rs
+++ b/src/bin/cargo/commands/rustdoc.rs
@@ -41,7 +41,7 @@ pub fn exec(config: &mut Config, args: &ArgMatches<'_>) -> CliResult {
     let ws = args.workspace(config)?;
     let mut compile_opts = args.compile_options_for_single_package(
         config,
-        CompileMode::Doc { deps: false },
+        CompileMode::Doc(DocDepsMode::default()),
         Some(&ws),
         ProfileChecking::Checked,
     )?;

--- a/src/cargo/core/compiler/build_config.rs
+++ b/src/cargo/core/compiler/build_config.rs
@@ -139,12 +139,24 @@ pub enum CompileMode {
     /// allows some de-duping of Units to occur.
     Bench,
     /// A target that will be documented with `rustdoc`.
-    /// If `deps` is true, then it will also document all dependencies.
-    Doc { deps: bool },
+    Doc(DocDepsMode),
     /// A target that will be tested with `rustdoc`.
     Doctest,
     /// A marker for Units that represent the execution of a `build.rs` script.
     RunCustomBuild,
+}
+
+/// Describes what kinds of dependencies should be documented.
+#[derive(Clone, Copy, Default, PartialEq, Debug, Eq, Hash, PartialOrd, Ord)]
+pub struct DocDepsMode {
+    /// Document build dependencies.
+    pub build: bool,
+    /// Document development dependencies.
+    pub dev: bool,
+    /// Document normal dependencies.
+    pub normal: bool,
+    /// Whether to document dependencies of other crates being documented.
+    pub deps: bool,
 }
 
 impl ser::Serialize for CompileMode {

--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -31,7 +31,7 @@ use anyhow::Error;
 use lazycell::LazyCell;
 use log::debug;
 
-pub use self::build_config::{BuildConfig, CompileMode, MessageFormat};
+pub use self::build_config::{BuildConfig, CompileMode, DocDepsMode, MessageFormat};
 pub use self::build_context::{BuildContext, FileFlavor, FileType, RustcTargetData, TargetInfo};
 use self::build_plan::BuildPlan;
 pub use self::compilation::{Compilation, Doctest};

--- a/src/cargo/util/command_prelude.rs
+++ b/src/cargo/util/command_prelude.rs
@@ -15,7 +15,7 @@ use clap::{self, SubCommand};
 use std::ffi::{OsStr, OsString};
 use std::path::PathBuf;
 
-pub use crate::core::compiler::CompileMode;
+pub use crate::core::compiler::{CompileMode, DocDepsMode};
 pub use crate::{CliError, CliResult, Config};
 pub use clap::{AppSettings, Arg, ArgMatches};
 


### PR DESCRIPTION
Add a new `--kinds` option to cargo doc, which allows to select what
kinds of dependencies should be documented: build dependencies, dev
dependencies, or normal dependencies. Multiple kinds of dependencies
can be specified, e.g., `cargo doc --kinds=dev,normal`.

When `--kinds` options is used, the default behaviour of documenting
normal dependencies is suppressed unless asked for explicitly with
`--kinds=normal`. The `--kinds` option also conflicts with `--no-deps`.

Follow up on proposal from #7077. Resolves #3475. 

Open questions:

1. Should `--kinds` document normal dependencies by default, obviating the need
   for normal kind of dependencies? Current answer is no.
2. Should `--kinds` interact with `--no-deps` flag? Current answer is no, but
   presence or absence of `--no-deps` could control if dependencies of selected
   dependencies are also documented.