### PR TITLE
Default cargo publish to the alt registry if it's the only allowed one

### DIFF
--- a/src/cargo/core/package.rs
+++ b/src/cargo/core/package.rs
@@ -210,7 +210,10 @@ impl Package {
     pub fn authors(&self) -> &Vec<String> {
         &self.manifest().metadata().authors
     }
-    /// Returns `true` if the package is set to publish.
+
+    /// Returns `None` if the package is set to publish.
+    /// Returns `Some(allowed_registries)` if publishing is limited to specified
+    /// registries or if package is set to not publish.
     pub fn publish(&self) -> &Option<Vec<String>> {
         self.manifest().publish()
     }

--- a/src/doc/man/cargo-publish.md
+++ b/src/doc/man/cargo-publish.md
@@ -51,7 +51,15 @@ Allow working directories with uncommitted VCS changes to be packaged.
 
 {{> options-index }}
 
-{{> options-registry }}
+{{#option "`--registry` _registry_"}}
+Name of the registry to publish to. Registry names are defined in [Cargo
+config files](../reference/config.html). If not specified, and there is a
+[`package.publish`](../reference/manifest.html#the-publish-field) field in
+`Cargo.toml` with a single registry, then it will publish to that registry.
+Otherwise it will use the default registry, which is defined by the
+[`registry.default`](../reference/config.html#registry-default) config key
+which defaults to `crates-io`.
+{{/option}}
 
 {{/options}}
 

--- a/src/doc/man/generated_txt/cargo-publish.txt
+++ b/src/doc/man/generated_txt/cargo-publish.txt
@@ -56,11 +56,16 @@ OPTIONS
            The URL of the registry index to use.
 
        --registry registry
-           Name of the registry to use. Registry names are defined in Cargo
-           config files
+           Name of the registry to publish to. Registry names are defined in
+           Cargo config files
            <https://doc.rust-lang.org/cargo/reference/config.html>. If not
-           specified, the default registry is used, which is defined by the
-           registry.default config key which defaults to crates-io.
+           specified, and there is a package.publish
+           <https://doc.rust-lang.org/cargo/reference/manifest.html#the-publish-field>
+           field in Cargo.toml with a single registry, then it will publish to
+           that registry. Otherwise it will use the default registry, which is
+           defined by the registry.default
+           <https://doc.rust-lang.org/cargo/reference/config.html#registry-default>
+           config key which defaults to crates-io.
 
    Compilation Options
        --target triple

--- a/src/doc/src/commands/cargo-publish.md
+++ b/src/doc/src/commands/cargo-publish.md
@@ -65,11 +65,13 @@ of the registry in all capital letters.</dd>
 
 
 <dt class="option-term" id="option-cargo-publish---registry"><a class="option-anchor" href="#option-cargo-publish---registry"></a><code>--registry</code> <em>registry</em></dt>
-<dd class="option-desc">Name of the registry to use. Registry names are defined in <a href="https://doc.rust-lang.org/cargo/reference/config.html">Cargo config
-files</a>. If not specified, the default registry is used,
-which is defined by the <code>registry.default</code> config key which defaults to
-<code>crates-io</code>.</dd>
-
+<dd class="option-desc">Name of the registry to publish to. Registry names are defined in <a href="https://doc.rust-lang.org/cargo/reference/config.html">Cargo
+config files</a>. If not specified, and there is a
+<a href="https://doc.rust-lang.org/cargo/reference/manifest.html#the-publish-field"><code>package.publish</code></a> field in
+<code>Cargo.toml</code> with a single registry, then it will publish to that registry.
+Otherwise it will use the default registry, which is defined by the
+<a href="https://doc.rust-lang.org/cargo/reference/config.html#registry-default"><code>registry.default</code></a> config key
+which defaults to <code>crates-io</code>.</dd>
 
 
 </dl>

--- a/src/doc/src/reference/manifest.md
+++ b/src/doc/src/reference/manifest.md
@@ -406,6 +406,9 @@ allowed to be published to.
 publish = ["some-registry-name"]
 ```
 
+If publish array contains a single registry, `cargo publish` command will use
+it when `--registry` flag is not specified.
+
 <a id="the-metadata-table-optional"></a>
 #### The `metadata` table
 

--- a/src/etc/man/cargo-publish.1
+++ b/src/etc/man/cargo-publish.1
@@ -74,10 +74,13 @@ The URL of the registry index to use.
 .sp
 \fB\-\-registry\fR \fIregistry\fR
 .RS 4
-Name of the registry to use. Registry names are defined in \fICargo config
-files\fR <https://doc.rust\-lang.org/cargo/reference/config.html>\&. If not specified, the default registry is used,
-which is defined by the \fBregistry.default\fR config key which defaults to
-\fBcrates\-io\fR\&.
+Name of the registry to publish to. Registry names are defined in \fICargo
+config files\fR <https://doc.rust\-lang.org/cargo/reference/config.html>\&. If not specified, and there is a
+\fI\f(BIpackage.publish\fI\fR <https://doc.rust\-lang.org/cargo/reference/manifest.html#the\-publish\-field> field in
+\fBCargo.toml\fR with a single registry, then it will publish to that registry.
+Otherwise it will use the default registry, which is defined by the
+\fI\f(BIregistry.default\fI\fR <https://doc.rust\-lang.org/cargo/reference/config.html#registry\-default> config key
+which defaults to \fBcrates\-io\fR\&.
 .RE
 .SS "Compilation Options"
 .sp


### PR DESCRIPTION
Hi, this PR fixes #8036. Previously if we had only one allowed registry in Cargo.toml file, `cargo publish` was failing. But with this PR, we are defaulting to the only allowed registry with printing a note if there is only one registry in that array. I believe this will make things easier for people who use an alternative registry all the time.