### PR TITLE
cargo login: make login message less ambiguous

### DIFF
--- a/src/cargo/ops/registry.rs
+++ b/src/cargo/ops/registry.rs
@@ -665,7 +665,7 @@ pub fn registry_login(
         None => {
             drop_println!(
                 config,
-                "please visit {}/me and paste the API Token below",
+                "please paste the API Token found on {}/me below",
                 registry.host()
             );
             let mut line = String::new();


### PR DESCRIPTION
The previous message
"please visit https://crates.io/me and paste the API Token below"
Had me waiting for a token to appear in the command line which I would then paste into the website.
Rephrase to
"please paste the api token found on https://crates.io/me below"
to clarify where to paste from and where to paste to.