### PR TITLE
Fix typo 'more then' -> 'more than' in error and comments

### DIFF
--- a/src/cargo/core/resolver/conflict_cache.rs
+++ b/src/cargo/core/resolver/conflict_cache.rs
@@ -19,7 +19,7 @@ enum ConflictStoreTrie {
 impl ConflictStoreTrie {
     /// Finds any known set of conflicts, if any,
     /// where all elements return some from `is_active` and contain `PackageId` specified.
-    /// If more then one are activated, then it will return
+    /// If more than one are activated, then it will return
     /// one that will allow for the most jump-back.
     fn find(
         &self,
@@ -167,7 +167,7 @@ impl ConflictCache {
     }
     /// Finds any known set of conflicts, if any,
     /// which are activated in `cx` and contain `PackageId` specified.
-    /// If more then one are activated, then it will return
+    /// If more than one are activated, then it will return
     /// one that will allow for the most jump-back.
     pub fn find_conflicting(
         &self,

--- a/src/cargo/core/resolver/context.rs
+++ b/src/cargo/core/resolver/context.rs
@@ -119,7 +119,7 @@ impl Context {
                 if let Some(link) = summary.links() {
                     if self.links.insert(link, id).is_some() {
                         return Err(format_err!(
-                            "Attempting to resolve a dependency with more then \
+                            "Attempting to resolve a dependency with more than \
                              one crate with links={}.\nThis will not build as \
                              is. Consider rebuilding the .lock file.",
                             &*link
@@ -395,7 +395,7 @@ impl PublicDependency {
             // for each (transitive) parent that can newly see `t`
             let mut stack = vec![(parent, is_public)];
             while let Some((p, public)) = stack.pop() {
-                // TODO: don't look at the same thing more then once
+                // TODO: don't look at the same thing more than once
                 if let Some(o) = self.inner.get(&p).and_then(|x| x.get(&t.name())) {
                     if o.0 != t {
                         // the (transitive) parent can already see a different version by `t`s name.

--- a/src/cargo/sources/registry/index.rs
+++ b/src/cargo/sources/registry/index.rs
@@ -116,7 +116,7 @@ impl<'s> Iterator for UncanonicalizedIter<'s> {
                 .chars()
                 .scan(0u16, |s, c| {
                     // the check against 15 here's to prevent
-                    // shift overflow on inputs with more then 15 hyphens
+                    // shift overflow on inputs with more than 15 hyphens
                     if (c == '_' || c == '-') && *s <= 15 {
                         let switch = (self.hyphen_combination_num & (1u16 << *s)) > 0;
                         let out = if (c == '_') ^ switch { '_' } else { '-' };


### PR DESCRIPTION
There were typos in a reported resolution error and in some comments