### PR TITLE
Run rustc with `--cfg doc` when analyzing dependencies in `cargo doc`.

### DIFF
--- a/src/bin/cargo/commands/check.rs
+++ b/src/bin/cargo/commands/check.rs
@@ -51,7 +51,7 @@ pub fn exec(config: &mut Config, args: &ArgMatches<'_>) -> CliResult {
             return Err(CliError::new(err, 101));
         }
     };
-    let mode = CompileMode::Check { test };
+    let mode = CompileMode::Check { test, doc: false };
     let compile_opts = args.compile_options(config, mode, Some(&ws), ProfileChecking::Unchecked)?;
 
     ops::compile(&ws, &compile_opts)?;

--- a/src/bin/cargo/commands/fix.rs
+++ b/src/bin/cargo/commands/fix.rs
@@ -89,7 +89,7 @@ pub fn exec(config: &mut Config, args: &ArgMatches<'_>) -> CliResult {
             return Err(CliError::new(err, 101));
         }
     };
-    let mode = CompileMode::Check { test };
+    let mode = CompileMode::Check { test, doc: false };
 
     // Unlike other commands default `cargo fix` to all targets to fix as much
     // code as we can.

--- a/src/bin/cargo/commands/rustc.rs
+++ b/src/bin/cargo/commands/rustc.rs
@@ -39,7 +39,7 @@ pub fn exec(config: &mut Config, args: &ArgMatches<'_>) -> CliResult {
         Some("dev") | None => CompileMode::Build,
         Some("test") => CompileMode::Test,
         Some("bench") => CompileMode::Bench,
-        Some("check") => CompileMode::Check { test: false },
+        Some("check") => CompileMode::Check { test: false, doc: false },
         Some(mode) => {
             let err = anyhow::format_err!(
                 "unknown profile: `{}`, use dev,

--- a/src/bin/cargo/commands/rustc.rs
+++ b/src/bin/cargo/commands/rustc.rs
@@ -39,7 +39,10 @@ pub fn exec(config: &mut Config, args: &ArgMatches<'_>) -> CliResult {
         Some("dev") | None => CompileMode::Build,
         Some("test") => CompileMode::Test,
         Some("bench") => CompileMode::Bench,
-        Some("check") => CompileMode::Check { test: false, doc: false },
+        Some("check") => CompileMode::Check {
+            test: false,
+            doc: false,
+        },
         Some(mode) => {
             let err = anyhow::format_err!(
                 "unknown profile: `{}`, use dev,

--- a/src/cargo/core/compiler/build_config.rs
+++ b/src/cargo/core/compiler/build_config.rs
@@ -131,8 +131,8 @@ pub enum CompileMode {
     Build,
     /// Building a target with `rustc` to emit `rmeta` metadata only. If
     /// `test` is true, then it is also compiled with `--test` to check it like
-    /// a test.
-    Check { test: bool },
+    /// a test. If `doc` is true, then it is compiled with `--cfg doc`.
+    Check { test: bool, doc: bool },
     /// Used to indicate benchmarks should be built. This is not used in
     /// `Unit`, because it is essentially the same as `Test` (indicating
     /// `--test` should be passed to rustc) and by using `Test` instead it
@@ -188,7 +188,7 @@ impl CompileMode {
             self,
             CompileMode::Test
                 | CompileMode::Bench
-                | CompileMode::Check { test: true }
+                | CompileMode::Check { test: true, .. }
                 | CompileMode::Doctest
         )
     }
@@ -197,7 +197,7 @@ impl CompileMode {
     pub fn is_rustc_test(self) -> bool {
         matches!(
             self,
-            CompileMode::Test | CompileMode::Bench | CompileMode::Check { test: true }
+            CompileMode::Test | CompileMode::Bench | CompileMode::Check { test: true, .. }
         )
     }
 

--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -872,6 +872,13 @@ fn build_base_args(
         cmd.arg("--cfg").arg(&format!("feature=\"{}\"", feat));
     }
 
+    match unit.mode {
+        CompileMode::Check { doc: true, .. } | CompileMode::Doc { .. } => {
+            cmd.arg("--cfg").arg("doc");
+        }
+        _ => {},
+    }
+
     match cx.files().metadata(unit) {
         Some(m) => {
             cmd.arg("-C").arg(&format!("metadata={}", m));

--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -876,7 +876,7 @@ fn build_base_args(
         CompileMode::Check { doc: true, .. } | CompileMode::Doc { .. } => {
             cmd.arg("--cfg").arg("doc");
         }
-        _ => {},
+        _ => {}
     }
 
     match cx.files().metadata(unit) {

--- a/src/cargo/core/compiler/timings.rs
+++ b/src/cargo/core/compiler/timings.rs
@@ -169,8 +169,8 @@ impl<'cfg> Timings<'cfg> {
         match unit.mode {
             CompileMode::Test => target.push_str(" (test)"),
             CompileMode::Build => {}
-            CompileMode::Check { test: true } => target.push_str(" (check-test)"),
-            CompileMode::Check { test: false } => target.push_str(" (check)"),
+            CompileMode::Check { test: true, .. } => target.push_str(" (check-test)"),
+            CompileMode::Check { test: false, .. } => target.push_str(" (check)"),
             CompileMode::Bench => target.push_str(" (bench)"),
             CompileMode::Doc { .. } => target.push_str(" (doc)"),
             CompileMode::Doctest => target.push_str(" (doc test)"),

--- a/src/cargo/core/compiler/unit_dependencies.rs
+++ b/src/cargo/core/compiler/unit_dependencies.rs
@@ -561,7 +561,12 @@ fn check_or_build_mode(mode: CompileMode, target: &Target) -> CompileMode {
             } else {
                 // Regular dependencies should not be checked with --test.
                 // Regular dependencies of doc targets should emit rmeta only.
-                CompileMode::Check { test: false }
+                let doc = match mode {
+                    CompileMode::Check { doc, .. } => doc,
+                    CompileMode::Doc { .. } => true,
+                    _ => false,
+                };
+                CompileMode::Check { test: false, doc }
             }
         }
         _ => CompileMode::Build,

--- a/src/cargo/ops/cargo_clean.rs
+++ b/src/cargo/ops/cargo_clean.rs
@@ -140,7 +140,7 @@ pub fn clean(ws: &Workspace<'_>, opts: &CleanOptions<'_>) -> CargoResult<()> {
             for &mode in &[
                 CompileMode::Build,
                 CompileMode::Test,
-                CompileMode::Check { test: false },
+                CompileMode::Check { test: false, doc: false },
             ] {
                 for (compile_kind, layout) in &layouts {
                     let triple = target_data.short_name(compile_kind);

--- a/src/cargo/ops/cargo_clean.rs
+++ b/src/cargo/ops/cargo_clean.rs
@@ -140,7 +140,10 @@ pub fn clean(ws: &Workspace<'_>, opts: &CleanOptions<'_>) -> CargoResult<()> {
             for &mode in &[
                 CompileMode::Build,
                 CompileMode::Test,
-                CompileMode::Check { test: false, doc: false },
+                CompileMode::Check {
+                    test: false,
+                    doc: false,
+                },
             ] {
                 for (compile_kind, layout) in &layouts {
                     let triple = target_data.short_name(compile_kind);

--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -621,8 +621,8 @@ impl CompileFilter {
     pub fn need_dev_deps(&self, mode: CompileMode) -> bool {
         match mode {
             CompileMode::Test | CompileMode::Doctest | CompileMode::Bench => true,
-            CompileMode::Check { test: true } => true,
-            CompileMode::Build | CompileMode::Doc { .. } | CompileMode::Check { test: false } => {
+            CompileMode::Check { test: true, .. } => true,
+            CompileMode::Build | CompileMode::Doc { .. } | CompileMode::Check { test: false, .. } => {
                 match *self {
                     CompileFilter::Default { .. } => false,
                     CompileFilter::Only {
@@ -868,7 +868,7 @@ fn generate_targets(
             };
             let test_mode = match mode {
                 CompileMode::Build => CompileMode::Test,
-                CompileMode::Check { .. } => CompileMode::Check { test: true },
+                CompileMode::Check { doc, .. } => CompileMode::Check { doc, test: true },
                 _ => mode,
             };
             // If `--benches` was specified, add all targets that would be
@@ -879,7 +879,7 @@ fn generate_targets(
             };
             let bench_mode = match mode {
                 CompileMode::Build => CompileMode::Bench,
-                CompileMode::Check { .. } => CompileMode::Check { test: true },
+                CompileMode::Check { doc, .. } => CompileMode::Check { doc, test: true },
                 _ => mode,
             };
 

--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -622,17 +622,17 @@ impl CompileFilter {
         match mode {
             CompileMode::Test | CompileMode::Doctest | CompileMode::Bench => true,
             CompileMode::Check { test: true, .. } => true,
-            CompileMode::Build | CompileMode::Doc { .. } | CompileMode::Check { test: false, .. } => {
-                match *self {
-                    CompileFilter::Default { .. } => false,
-                    CompileFilter::Only {
-                        ref examples,
-                        ref tests,
-                        ref benches,
-                        ..
-                    } => examples.is_specific() || tests.is_specific() || benches.is_specific(),
-                }
-            }
+            CompileMode::Build
+            | CompileMode::Doc { .. }
+            | CompileMode::Check { test: false, .. } => match *self {
+                CompileFilter::Default { .. } => false,
+                CompileFilter::Only {
+                    ref examples,
+                    ref tests,
+                    ref benches,
+                    ..
+                } => examples.is_specific() || tests.is_specific() || benches.is_specific(),
+            },
             CompileMode::RunCustomBuild => panic!("Invalid mode"),
         }
     }

--- a/tests/testsuite/doc.rs
+++ b/tests/testsuite/doc.rs
@@ -1565,7 +1565,8 @@ fn dependency_cfg_doc() {
             #[cfg(doc)]
             pub const A: u32 = 0;
             pub const B: u32 = A;
-        ")
+        ",
+        )
         .file("main.rs", "fn main() { let _ = foo::B; }")
         .build();
 


### PR DESCRIPTION
Proposed fix for https://github.com/rust-lang/cargo/issues/8601

This is my first PR to Cargo and I am not familiar with the codebase. If this isn't implemented properly, please tell me and I'd be happy to make changes.