### PR TITLE
doc: Qualify GNU licenses in example license field

### DIFF
--- a/src/doc/src/reference/manifest.md
+++ b/src/doc/src/reference/manifest.md
@@ -218,8 +218,8 @@ the user must comply with both licenses simultaneously. The `WITH` operator
 indicates a license with a special exception. Some examples:
 
 * `MIT OR Apache-2.0`
-* `LGPL-2.1 AND MIT AND BSD-2-Clause`
-* `GPL-2.0+ WITH Bison-exception-2.2`
+* `LGPL-2.1-only AND MIT AND BSD-2-Clause`
+* `GPL-2.0-or-later WITH Bison-exception-2.2`
 
 If a package is using a nonstandard license, then the `license-file` field may
 be specified in lieu of the `license` field.


### PR DESCRIPTION
Since SPDX License list 3.0, unqualified GNU licenses are deprecated:

https://www.gnu.org/licenses/identify-licenses-clearly.html

We use version 3.6 of the list so we should not use the deprecated licenses.