### PR TITLE
Renames SourceId::into_url -> SourceId::as_url

### DIFF
--- a/src/cargo/core/package_id.rs
+++ b/src/cargo/core/package_id.rs
@@ -58,7 +58,7 @@ impl ser::Serialize for PackageId {
             "{} {} ({})",
             self.inner.name,
             self.inner.version,
-            self.inner.source_id.into_url()
+            self.inner.source_id.as_url()
         ))
     }
 }

--- a/src/cargo/core/resolver/encode.rs
+++ b/src/cargo/core/resolver/encode.rs
@@ -500,7 +500,7 @@ impl fmt::Display for EncodablePackageId {
             write!(f, " {}", s)?;
         }
         if let Some(s) = &self.source {
-            write!(f, " ({})", s.into_url())?;
+            write!(f, " ({})", s.as_url())?;
         }
         Ok(())
     }

--- a/src/cargo/core/source/source_id.rs
+++ b/src/cargo/core/source/source_id.rs
@@ -144,7 +144,7 @@ impl SourceId {
     }
 
     /// A view of the `SourceId` that can be `Display`ed as a URL.
-    pub fn into_url(&self) -> SourceIdIntoUrl<'_> {
+    pub fn as_url(&self) -> SourceIdIntoUrl<'_> {
         SourceIdIntoUrl {
             inner: &*self.inner,
         }
@@ -445,7 +445,7 @@ impl ser::Serialize for SourceId {
         if self.is_path() {
             None::<String>.serialize(s)
         } else {
-            s.collect_str(&self.into_url())
+            s.collect_str(&self.as_url())
         }
     }
 }

--- a/src/cargo/core/source/source_id.rs
+++ b/src/cargo/core/source/source_id.rs
@@ -144,8 +144,8 @@ impl SourceId {
     }
 
     /// A view of the `SourceId` that can be `Display`ed as a URL.
-    pub fn as_url(&self) -> SourceIdIntoUrl<'_> {
-        SourceIdIntoUrl {
+    pub fn as_url(&self) -> SourceIdAsUrl<'_> {
+        SourceIdAsUrl {
             inner: &*self.inner,
         }
     }
@@ -545,11 +545,11 @@ impl Hash for SourceId {
 }
 
 /// A `Display`able view into a `SourceId` that will write it as a url
-pub struct SourceIdIntoUrl<'a> {
+pub struct SourceIdAsUrl<'a> {
     inner: &'a SourceIdInner,
 }
 
-impl<'a> fmt::Display for SourceIdIntoUrl<'a> {
+impl<'a> fmt::Display for SourceIdAsUrl<'a> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self.inner {
             SourceIdInner {


### PR DESCRIPTION
While studying the source code, I am surprised to see that `into_url`
does not actually consume its caller when a function with such name
usually does. Additionally, there is a trait in `cargo::util::IntoUrl`
with the same and does exactly what you expect, consumes itself and yields
a `CargoResult<Url>`.

I hope this is not too nitpicky.
Thank you!