### PR TITLE
Fix typo in SIGQUIT description

### DIFF
--- a/src/cargo/util/errors.rs
+++ b/src/cargo/util/errors.rs
@@ -401,7 +401,7 @@ pub fn process_error(
                 libc::SIGINT => ", SIGINT: terminal interrupt signal",
                 libc::SIGKILL => ", SIGKILL: kill",
                 libc::SIGPIPE => ", SIGPIPE: write on a pipe with no one to read",
-                libc::SIGQUIT => ", SIGQUIT: terminal quite signal",
+                libc::SIGQUIT => ", SIGQUIT: terminal quit signal",
                 libc::SIGSEGV => ", SIGSEGV: invalid memory reference",
                 libc::SIGTERM => ", SIGTERM: termination signal",
                 libc::SIGBUS => ", SIGBUS: access to undefined memory",


### PR DESCRIPTION
This PR fixes a small typo in the SIGQUIT description.

(edit: removed my notes about automated tests because the PR bot has a more complete summary.)

In terms of manual testing: I had a test that raised `SIGQUIT` using the "coredump" crate.  Previously, it emitted:

```
error: test failed, to rerun pass '--test the_test'

Caused by:
  process didn't exit successfully: `/Users/dap/oxide/experiments/rust-coredump/target/debug/deps/the_test-a8a068307be90649 --nocapture` (signal: 3, SIGQUIT: terminal quite signal)
```

Now, it emits:

```
error: test failed, to rerun pass '--test the_test'

Caused by:
  process didn't exit successfully: `/Users/dap/oxide/experiments/rust-coredump/target/debug/deps/the_test-20c8e90133861ece --nocapture` (signal: 3, SIGQUIT: terminal quit signal)
```

which looks correct.