### PR TITLE
Add cargo space command

### DIFF
--- a/src/bin/cargo/commands/mod.rs
+++ b/src/bin/cargo/commands/mod.rs
@@ -26,6 +26,7 @@ pub fn builtin() -> Vec<App> {
         rustc::cli(),
         rustdoc::cli(),
         search::cli(),
+        space::cli(),
         test::cli(),
         tree::cli(),
         uninstall::cli(),
@@ -63,6 +64,7 @@ pub fn builtin_exec(cmd: &str) -> Option<fn(&mut Config, &ArgMatches<'_>) -> Cli
         "rustc" => rustc::exec,
         "rustdoc" => rustdoc::exec,
         "search" => search::exec,
+        "space" => space::exec,
         "test" => test::exec,
         "tree" => tree::exec,
         "uninstall" => uninstall::exec,
@@ -101,6 +103,7 @@ pub mod run;
 pub mod rustc;
 pub mod rustdoc;
 pub mod search;
+pub mod space;
 pub mod test;
 pub mod tree;
 pub mod uninstall;

--- a/src/bin/cargo/commands/space.rs
+++ b/src/bin/cargo/commands/space.rs
@@ -1,0 +1,11 @@
+use crate::command_prelude::*;
+
+pub fn cli() -> App {
+    subcommand("space")
+        .about("Tell you where cargo")
+        .after_help("Run `cargo help space` for more detailed information.\n")
+}
+
+pub fn exec(_config: &mut Config, _args: &ArgMatches<'_>) -> CliResult {
+    return Err(anyhow::format_err!("Car no go space, cargo road").into());
+}


### PR DESCRIPTION
Add `cargo space` command to provide logistical information about where cargo and where car no go.