### PR TITLE
fix: remove unnecessary lockfile header comparison

### DIFF
--- a/src/cargo/ops/lockfile.rs
+++ b/src/cargo/ops/lockfile.rs
@@ -174,34 +174,30 @@ fn serialize_resolve(resolve: &Resolve, orig: Option<&str>) -> String {
 }
 
 fn are_equal_lockfiles(orig: &str, current: &str, ws: &Workspace<'_>) -> bool {
-    let mut orig = orig.to_string();
-    if has_crlf_line_endings(&orig) {
-        orig = orig.replace("\r\n", "\n");
-    }
-
     // If we want to try and avoid updating the lock file, parse both and
     // compare them; since this is somewhat expensive, don't do it in the
     // common case where we can update lock files.
     if !ws.config().lock_update_allowed() {
         let res: CargoResult<bool> = (|| {
-            let old: resolver::EncodableResolve = toml::from_str(&orig)?;
+            let old: resolver::EncodableResolve = toml::from_str(orig)?;
             let new: resolver::EncodableResolve = toml::from_str(current)?;
-            Ok(old.into_resolve(&orig, ws)? == new.into_resolve(current, ws)?)
+            Ok(old.into_resolve(orig, ws)? == new.into_resolve(current, ws)?)
         })();
         if let Ok(true) = res {
             return true;
         }
     }
 
-    current == orig
-}
-
-fn has_crlf_line_endings(s: &str) -> bool {
-    // Only check the first line.
-    if let Some(lf) = s.find('\n') {
-        s[..lf].ends_with('\r')
-    } else {
-        false
+    // Skip generated marker lines.
+    let mut orig_iter = orig.lines().skip_while(|line| line.starts_with('#'));
+    let mut current_iter = current.lines().skip_while(|line| line.starts_with('#'));
+    loop {
+        match (orig_iter.next(), current_iter.next()) {
+            (Some(o), Some(c)) => if o != c { return false },
+            (Some(_), None) => return false,
+            (None, Some(_)) => return false,
+            (None, None) => return true,
+        }
     }
 }
 


### PR DESCRIPTION
Closes #8610

## What

#6548 introduced generated headers https://github.com/rust-lang/cargo/pull/6548, which makes `fn are_equal_lockfiles()` always return false when containing the header. This PR let the equality check **1)** skip lines of header and **2)** remove unnecessary `to_string()` and `String::replace` allocations by using iterators to solve the minor regression bug.