### PR TITLE
Support git-sparse-checkout option to check out a subset of a git dependency

### DIFF
--- a/src/cargo/util/config/mod.rs
+++ b/src/cargo/util/config/mod.rs
@@ -171,6 +171,7 @@ pub struct Config {
     /// Cached configuration parsed by Cargo
     http_config: LazyCell<CargoHttpConfig>,
     net_config: LazyCell<CargoNetConfig>,
+    git_config: LazyCell<CargoGitConfig>,
     build_config: LazyCell<CargoBuildConfig>,
     target_cfgs: LazyCell<Vec<(String, TargetCfgConfig)>>,
     doc_extern_map: LazyCell<RustdocExternMap>,
@@ -241,6 +242,7 @@ impl Config {
             package_cache_lock: RefCell::new(None),
             http_config: LazyCell::new(),
             net_config: LazyCell::new(),
+            git_config: LazyCell::new(),
             build_config: LazyCell::new(),
             target_cfgs: LazyCell::new(),
             doc_extern_map: LazyCell::new(),
@@ -1156,6 +1158,11 @@ impl Config {
             .try_borrow_with(|| Ok(self.get::<CargoNetConfig>("net")?))
     }
 
+    pub fn git_config(&self) -> CargoResult<&CargoGitConfig> {
+        self.git_config
+            .try_borrow_with(|| Ok(self.get::<CargoGitConfig>("git")?))
+    }
+
     pub fn build_config(&self) -> CargoResult<&CargoBuildConfig> {
         self.build_config
             .try_borrow_with(|| Ok(self.get::<CargoBuildConfig>("build")?))
@@ -1727,6 +1734,12 @@ pub struct CargoNetConfig {
     pub retry: Option<u32>,
     pub offline: Option<bool>,
     pub git_fetch_with_cli: Option<bool>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct CargoGitConfig {
+    pub ignore_fetch_modules: Option<Vec<String>>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/doc/src/reference/config.md
+++ b/src/doc/src/reference/config.md
@@ -92,6 +92,9 @@ retry = 2                   # network retries
 git-fetch-with-cli = true   # use the `git` executable for git operations
 offline = false             # do not access the network
 
+[git]
+ignore-fetch-modules = ["submodule1"] # git submodule will not be fetched
+
 [profile.<name>]         # Modify profile settings via config.
 opt-level = 0            # Optimization level.
 debug = true             # Include debug info.


### PR DESCRIPTION
Added new param into .cargo/config to skip fetching of git submodules during the cargo build/run.

_Per my understanding, this param will not be widely used in open-source community where every module is available, but it will be mostly used in commercial development._

**Current behavior:** if user has no access to the git submodule(e.g. trade-secret), then build fails because git fetch fails. This PR solves that by allowing users to skip fetching for optional submodules.

**Added:**
new section: `git`
new param in git section: `ignore-fetch-modules`

PR simulates GIT's setting to skip submodule's updating. e.g. setting in .gitconfig may look like this:
```
[submodule "somename1"]
        active = false
        ignore = all
        url = https://github.somelink.com/soemname1.git
        update = none
```

