### PR TITLE
Show full error context on `cargo run` error.

### DIFF
--- a/src/bin/cargo/commands/run.rs
+++ b/src/bin/cargo/commands/run.rs
@@ -1,5 +1,5 @@
 use crate::command_prelude::*;
-
+use crate::util::ProcessError;
 use cargo::core::Verbosity;
 use cargo::ops::{self, CompileFilter};
 
@@ -68,26 +68,29 @@ pub fn exec(config: &mut Config, args: &ArgMatches<'_>) -> CliResult {
             };
         }
     };
-    match ops::run(&ws, &compile_opts, &values_os(args, "args"))? {
-        None => Ok(()),
-        Some(err) => {
-            // If we never actually spawned the process then that sounds pretty
-            // bad and we always want to forward that up.
-            let exit = match err.exit {
-                Some(exit) => exit,
-                None => return Err(CliError::new(err.into(), 101)),
-            };
 
-            // If `-q` was passed then we suppress extra error information about
-            // a failed process, we assume the process itself printed out enough
-            // information about why it failed so we don't do so as well
-            let exit_code = exit.code().unwrap_or(101);
-            let is_quiet = config.shell().verbosity() == Verbosity::Quiet;
-            Err(if is_quiet {
-                CliError::code(exit_code)
-            } else {
-                CliError::new(err.into(), exit_code)
-            })
+    ops::run(&ws, &compile_opts, &values_os(args, "args")).map_err(|err| {
+        let proc_err = match err.downcast_ref::<ProcessError>() {
+            Some(e) => e,
+            None => return CliError::new(err.into(), 101),
+        };
+
+        // If we never actually spawned the process then that sounds pretty
+        // bad and we always want to forward that up.
+        let exit = match proc_err.exit {
+            Some(exit) => exit,
+            None => return CliError::new(err.into(), 101),
+        };
+
+        // If `-q` was passed then we suppress extra error information about
+        // a failed process, we assume the process itself printed out enough
+        // information about why it failed so we don't do so as well
+        let exit_code = exit.code().unwrap_or(101);
+        let is_quiet = config.shell().verbosity() == Verbosity::Quiet;
+        if is_quiet {
+            CliError::code(exit_code)
+        } else {
+            CliError::new(err.into(), exit_code)
         }
-    }
+    })
 }

--- a/src/cargo/ops/cargo_run.rs
+++ b/src/cargo/ops/cargo_run.rs
@@ -4,13 +4,13 @@ use std::path::Path;
 
 use crate::core::{TargetKind, Workspace};
 use crate::ops;
-use crate::util::{CargoResult, ProcessError};
+use crate::util::CargoResult;
 
 pub fn run(
     ws: &Workspace<'_>,
     options: &ops::CompileOptions,
     args: &[OsString],
-) -> CargoResult<Option<ProcessError>> {
+) -> CargoResult<()> {
     let config = ws.config();
 
     // We compute the `bins` here *just for diagnosis*. The actual set of
@@ -87,13 +87,5 @@ pub fn run(
 
     config.shell().status("Running", process.to_string())?;
 
-    let result = process.exec_replace();
-
-    match result {
-        Ok(()) => Ok(None),
-        Err(e) => {
-            let err = e.downcast::<ProcessError>()?;
-            Ok(Some(err))
-        }
-    }
+    process.exec_replace()
 }

--- a/tests/testsuite/tool_paths.rs
+++ b/tests/testsuite/tool_paths.rs
@@ -1,7 +1,6 @@
 //! Tests for configuration values that point to programs.
 
-use cargo_test_support::rustc_host;
-use cargo_test_support::{basic_lib_manifest, project};
+use cargo_test_support::{basic_lib_manifest, no_such_file_err_msg, project, rustc_host};
 
 #[cargo_test]
 fn pathless_tools() {
@@ -274,7 +273,18 @@ fn custom_runner_env() {
     p.cargo("run")
         .env(&key, "nonexistent-runner --foo")
         .with_status(101)
-        .with_stderr_contains("[RUNNING] `nonexistent-runner --foo target/debug/foo[EXE]`")
+        .with_stderr(&format!(
+            "\
+[COMPILING] foo [..]
+[FINISHED] dev [..]
+[RUNNING] `nonexistent-runner --foo target/debug/foo[EXE]`
+[ERROR] could not execute process `nonexistent-runner --foo target/debug/foo[EXE]` (never executed)
+
+Caused by:
+  {}
+",
+            no_such_file_err_msg()
+        ))
         .run();
 }
 


### PR DESCRIPTION
If there was an error exec-ing a process with `cargo run`, the error message was not displayed. The code was calling `downcast` to a `ProcessError` which erased the surrounding error context.  As shown in the modified test, it should now include a `Caused by:` message with the underlying error message.
