### PR TITLE
Fix bug with PathAndArg config values

### DIFF
--- a/src/cargo/core/compiler/compilation.rs
+++ b/src/cargo/core/compiler/compilation.rs
@@ -346,6 +346,7 @@ fn target_runner(
 
     // try target.{}.runner
     let key = format!("target.{}.runner", target);
+
     if let Some(v) = bcx.config.get::<Option<config::PathAndArgs>>(&key)? {
         let path = v.path.resolve_program(bcx.config);
         return Ok(Some((path, v.args)));

--- a/src/cargo/util/config/path.rs
+++ b/src/cargo/util/config/path.rs
@@ -1,4 +1,4 @@
-use super::{Config, StringList, Value};
+use super::{Config, UnmergedStringList, Value};
 use serde::{de::Error, Deserialize};
 use std::path::PathBuf;
 
@@ -55,7 +55,7 @@ impl<'de> serde::Deserialize<'de> for PathAndArgs {
     where
         D: serde::Deserializer<'de>,
     {
-        let vsl = Value::<StringList>::deserialize(deserializer)?;
+        let vsl = Value::<UnmergedStringList>::deserialize(deserializer)?;
         let mut strings = vsl.val.0;
         if strings.is_empty() {
             return Err(D::Error::invalid_length(0, &"at least one element"));

--- a/tests/testsuite/tool_paths.rs
+++ b/tests/testsuite/tool_paths.rs
@@ -302,7 +302,6 @@ fn custom_runner_env_overrides_config() {
 
     p.cargo("run")
         .env(&key, "should-run --foo")
-        .stream()
         .with_status(101)
         .with_stderr_contains("[RUNNING] `should-run --foo target/debug/foo[EXE]`")
         .run();


### PR DESCRIPTION
This fixes an issue I noticed when trying to specify a target runner via the [`CARGO_TARGET_{triplet}_RUNNER`](https://doc.rust-lang.org/cargo/reference/config.html#targettriplerunner) environment variable, expecting it to override the value in our `.cargo/config.toml` file, which was giving quite strange errors until I figured out that cargo was actually merging the config file's values with the environment's values.

This change adds a small hack to use and `UnmergedStringList` from `PathAndArgs` instead of just plain `StringList`, which uses the type in the deserializer to determine if `Config::get_list_or_string` should merge the values from the config file(s) with the environment as it was doing before, or else only use the environment to the exclusion of the config file(s) if the key was set in the environment.

I also added a test for this to confirm both the bug and the fix.