### PR TITLE
Allow to unset a default target by setting `build.target` to the empty string

### DIFF
--- a/src/cargo/core/compiler/compile_kind.rs
+++ b/src/cargo/core/compiler/compile_kind.rs
@@ -72,7 +72,11 @@ impl CompileKind {
                 } else {
                     val.raw_value().to_string()
                 };
-                CompileKind::Target(CompileTarget::new(&value)?)
+                if value == "" {
+                    CompileKind::Host
+                } else {
+                    CompileKind::Target(CompileTarget::new(&value)?)
+                }
             }
             None => CompileKind::Host,
         };

--- a/tests/testsuite/cross_compile.rs
+++ b/tests/testsuite/cross_compile.rs
@@ -118,6 +118,37 @@ fn simple_cross_config() {
 }
 
 #[cargo_test]
+fn unset_default_target() {
+    let p = project()
+        .file(
+            ".cargo/config",
+            r#"
+            [build]
+            target = ""
+            "#,
+        )
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "foo"
+            version = "0.0.0"
+            authors = []
+        "#,
+        )
+        .file(
+            "src/main.rs",
+            r#"
+                fn main() {{}}
+            "#,
+        )
+        .build();
+
+    p.cargo("build -v").run();
+    assert!(p.bin("foo").is_file());
+}
+
+#[cargo_test]
 fn simple_deps() {
     if cross_compile::disabled() {
         return;


### PR DESCRIPTION
Right now it is possible to set a default compilation target through a `build.target` key in a `.cargo/config` file. Given the hierachical nature of cargo configuration files, this setting automatically applies to all subdirectories too. This is problematic if there are subdirectories with crates that should be compiled for the host architecture, such as special builder or runner crates. Unfortunately, there is currently no way to reset the default target back to the host target.

This PR fixes this problem by interpreting a `build.target = ""` config key as the host target. This way, subdirectories now have a way to reset the default target if required. Since the empty string was not a valid target before, this change should not break any existing code.

cc #8112 