### PR TITLE
fix: remove unnecessary allocations

### DIFF
--- a/src/cargo/ops/lockfile.rs
+++ b/src/cargo/ops/lockfile.rs
@@ -188,20 +188,7 @@ fn are_equal_lockfiles(orig: &str, current: &str, ws: &Workspace<'_>) -> bool {
         }
     }
 
-    let mut orig_iter = orig.lines();
-    let mut current_iter = current.lines();
-    loop {
-        match (orig_iter.next(), current_iter.next()) {
-            (Some(o), Some(c)) => {
-                if o != c {
-                    return false;
-                }
-            }
-            (Some(_), None) => return false,
-            (None, Some(_)) => return false,
-            (None, None) => return true,
-        }
-    }
+    orig.lines().eq(current.lines())
 }
 
 fn emit_package(dep: &toml::value::Table, out: &mut String) {


### PR DESCRIPTION
Remove unnecessary `str::to_string` and `str::replace` allocations by using iterators. This PR is almost identical to #8622 except it does not skip the generated header.

Sorry that I did not profile the changes by myself. Seems that valgrind does not support macOS 10.15.6, I have not idea how to profile cargo subcommand. It would be great for an instruction to run a memory profiling for Rust program on macOS.