### PR TITLE
Add a unstable `--ignore-local-config` flag

### DIFF
--- a/src/bin/cargo/cli.rs
+++ b/src/bin/cargo/cli.rs
@@ -218,6 +218,10 @@ fn execute_subcommand(
     cmd: &str,
     subcommand_args: &ArgMatches<'_>,
 ) -> CliResult {
+    if subcommand_args.is_present("ignore-local-config") {
+        config.reload_rooted_at(config.home().clone().into_path_unlocked())?;
+    }
+
     if let Some(exec) = commands::builtin_exec(cmd) {
         return exec(config, subcommand_args);
     }
@@ -326,6 +330,11 @@ See 'cargo help <command>' for more information on a specific command.\n",
         .arg(opt("offline", "Run without accessing the network").global(true))
         .arg(
             multi_opt("config", "KEY=VALUE", "Override a configuration value")
+                .global(true)
+                .hidden(true),
+        )
+        .arg(
+            opt("ignore-local-config", "Ignore local `.cargo/config` files")
                 .global(true)
                 .hidden(true),
         )

--- a/src/cargo/core/compiler/build_config.rs
+++ b/src/cargo/core/compiler/build_config.rs
@@ -37,6 +37,7 @@ pub struct BuildConfig {
     // Note that, although the cmd-line flag name is `out-dir`, in code we use
     // `export_dir`, to avoid confusion with out dir at `target/debug/deps`.
     pub export_dir: Option<PathBuf>,
+    pub ignore_local_config: bool,
 }
 
 impl BuildConfig {
@@ -80,6 +81,7 @@ impl BuildConfig {
             primary_unit_rustc: None,
             rustfix_diagnostic_server: RefCell::new(None),
             export_dir: None,
+            ignore_local_config: false,
         })
     }
 

--- a/src/cargo/util/command_prelude.rs
+++ b/src/cargo/util/command_prelude.rs
@@ -163,6 +163,13 @@ pub trait AppExt: Sized {
         ))
     }
 
+    fn arg_ignore_local_config(self) -> Self {
+        self._arg(opt(
+            "ignore-local-config",
+            "Ignore local `.cargo/config.toml` files (unstable)",
+        ))
+    }
+
     fn arg_unit_graph(self) -> Self {
         self._arg(opt("unit-graph", "Output build graph in JSON (unstable)").hidden(true))
     }
@@ -459,6 +466,7 @@ pub trait ArgMatchesExt {
         build_config.requested_profile = self.get_profile_name(config, "dev", profile_checking)?;
         build_config.build_plan = self._is_present("build-plan");
         build_config.unit_graph = self._is_present("unit-graph");
+        build_config.ignore_local_config = self._is_present("ignore-local-config");
         if build_config.build_plan {
             config
                 .cli_unstable()
@@ -468,6 +476,11 @@ pub trait ArgMatchesExt {
             config
                 .cli_unstable()
                 .fail_if_stable_opt("--unit-graph", 8002)?;
+        }
+        if build_config.ignore_local_config {
+            config
+                .cli_unstable()
+                .fail_if_stable_opt("--ignore-local-config", 0000)?;
         }
 
         let opts = CompileOptions {

--- a/tests/testsuite/config.rs
+++ b/tests/testsuite/config.rs
@@ -1483,3 +1483,49 @@ Caused by:
   unknown variant `invalid`, expected one of `debuginfo`, `none`, `symbols`",
     );
 }
+
+#[cargo_test]
+fn ignore_local_config_gated() {
+    // Requires -Zunstable-options
+    let p = project().file("src/lib.rs", "").build();
+
+    p.cargo("build --ignore-local-config")
+        .with_status(101)
+        .with_stderr(
+            "\
+[ERROR] the `--ignore-local-config` flag is unstable, and only available \
+on the nightly channel of Cargo, [..]
+See [..]
+See [..]
+",
+        )
+        .run();
+
+    p.cargo("build --ignore-local-config")
+        .masquerade_as_nightly_cargo()
+        .with_status(101)
+        .with_stderr(
+            "\
+[ERROR] the `--ignore-local-config` flag is unstable, pass `-Z unstable-options` to enable it
+See [..]
+",
+        )
+        .run();
+}
+
+#[cargo_test]
+fn ignore_local_config_basic() {
+    let p = project()
+        .file("src/lib.rs", "")
+        .file(
+            ".cargo/config",
+            r#"
+            [build]
+            target = "non-existent"
+        "#,
+        )
+        .build();
+    p.cargo("build -v --ignore-local-config -Z unstable-options")
+        .masquerade_as_nightly_cargo()
+        .run();
+}


### PR DESCRIPTION
This adds a new unstable `--ignore-local-config` flag to all subcommands that makes cargo ignore all `.cargo/config` files except for the config file in the user's home directory (similar to the behavior of `cargo install`). This is useful because some config values cannot be reset through command line parameters, e.g. the `build.target` flag. See #8643 for more motivation.

This is the first time that I'm adding new command line parameters to `cargo`, so please let me know if I'm doing something wrong.

Fixes #8643