### PR TITLE
[beta] Fix LTO with doctests.

### DIFF
--- a/src/cargo/core/compiler/context/mod.rs
+++ b/src/cargo/core/compiler/context/mod.rs
@@ -210,7 +210,8 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
             // Collect information for `rustdoc --test`.
             if unit.mode.is_doc_test() {
                 let mut unstable_opts = false;
-                let args = compiler::extern_args(&self, unit, &mut unstable_opts)?;
+                let mut args = compiler::extern_args(&self, unit, &mut unstable_opts)?;
+                args.extend(compiler::lto_args(&self, unit));
                 self.compilation.to_doc_test.push(compilation::Doctest {
                     unit: unit.clone(),
                     args,

--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -207,7 +207,7 @@ fn rustc(cx: &mut Context<'_, '_>, unit: &Unit, exec: &Arc<dyn Executor>) -> Car
 
     rustc.args(cx.bcx.rustflags_args(unit));
     if cx.bcx.config.cli_unstable().binary_dep_depinfo {
-        rustc.arg("-Zbinary-dep-depinfo");
+        rustc.arg("-Z").arg("binary-dep-depinfo");
     }
     let mut output_options = OutputOptions::new(cx, unit);
     let package_id = unit.pkg.package_id();
@@ -533,7 +533,7 @@ fn prepare_rustc(
     if cx.bcx.config.cli_unstable().jobserver_per_rustc {
         let client = cx.new_jobserver()?;
         base.inherit_jobserver(&client);
-        base.arg("-Zjobserver-token-requests");
+        base.arg("-Z").arg("jobserver-token-requests");
         assert!(cx.rustc_clients.insert(unit.clone(), client).is_none());
     } else {
         base.inherit_jobserver(&cx.jobserver);
@@ -809,10 +809,10 @@ fn build_base_args(
         }
         lto::Lto::ObjectAndBitcode => {} // this is rustc's default
         lto::Lto::OnlyBitcode => {
-            cmd.arg("-Clinker-plugin-lto");
+            cmd.arg("-C").arg("linker-plugin-lto");
         }
         lto::Lto::OnlyObject => {
-            cmd.arg("-Cembed-bitcode=no");
+            cmd.arg("-C").arg("embed-bitcode=no");
         }
     }
 
@@ -862,7 +862,7 @@ fn build_base_args(
         // will simply not be needed when the behavior is stabilized in the Rust
         // compiler itself.
         if *panic == PanicStrategy::Abort {
-            cmd.arg("-Zpanic-abort-tests");
+            cmd.arg("-Z").arg("panic-abort-tests");
         }
     } else if test {
         cmd.arg("--cfg").arg("test");
@@ -922,7 +922,8 @@ fn build_base_args(
         // any non-public crate in the sysroot).
         //
         // RUSTC_BOOTSTRAP allows unstable features on stable.
-        cmd.arg("-Zforce-unstable-if-unmarked")
+        cmd.arg("-Z")
+            .arg("force-unstable-if-unmarked")
             .env("RUSTC_BOOTSTRAP", "1");
     }
 

--- a/src/cargo/core/profiles.rs
+++ b/src/cargo/core/profiles.rs
@@ -299,7 +299,7 @@ impl Profiles {
             let release = matches!(self.requested_profile.as_str(), "release" | "bench");
 
             match mode {
-                CompileMode::Test | CompileMode::Bench => {
+                CompileMode::Test | CompileMode::Bench | CompileMode::Doctest => {
                     if release {
                         (
                             InternedString::new("bench"),
@@ -312,10 +312,7 @@ impl Profiles {
                         )
                     }
                 }
-                CompileMode::Build
-                | CompileMode::Check { .. }
-                | CompileMode::Doctest
-                | CompileMode::RunCustomBuild => {
+                CompileMode::Build | CompileMode::Check { .. } | CompileMode::RunCustomBuild => {
                     // Note: `RunCustomBuild` doesn't normally use this code path.
                     // `build_unit_profiles` normally ensures that it selects the
                     // ancestor's profile. However, `cargo clean -p` can hit this

--- a/tests/testsuite/cache_messages.rs
+++ b/tests/testsuite/cache_messages.rs
@@ -238,12 +238,8 @@ fn rustdoc() {
         .file(
             "src/lib.rs",
             "
-            #![warn(private_doc_tests)]
-            /// asdf
-            /// ```
-            /// let x = 1;
-            /// ```
-            fn f() {}
+            #![warn(missing_docs)]
+            pub fn f() {}
             ",
         )
         .build();
@@ -254,7 +250,7 @@ fn rustdoc() {
         .expect("rustdoc to run");
     assert!(rustdoc_output.status.success());
     let rustdoc_stderr = as_str(&rustdoc_output.stderr);
-    assert!(rustdoc_stderr.contains("private"));
+    assert!(rustdoc_stderr.contains("missing"));
     assert!(rustdoc_stderr.contains("\x1b["));
     assert_eq!(
         p.glob("target/debug/.fingerprint/foo-*/output-*").count(),


### PR DESCRIPTION
Beta packports:
* #8653 Fix cache_messages::rustdoc test broken on beta. — so that CI tests pass
* #8648 Add spaces after -C and -Z flags for consistency — so that #8657 can be merged
* #8657 Fix LTO with doctests.

Although the LTO regression is on 1.46, I probably won't do a stable backport even if there is a point release, as I think it would be good to have sufficient time for testing on nightly, and I don't want to rush it. I'm willing to reconsider that, though.
