### PR TITLE
Packages can inherit fields from their root workspace

### DIFF
--- a/crates/cargo-test-support/src/lib.rs
+++ b/crates/cargo-test-support/src/lib.rs
@@ -1609,6 +1609,19 @@ pub fn basic_lib_manifest(name: &str) -> String {
     )
 }
 
+pub fn basic_workspace_manifest(name: &str, workspace: &str) -> String {
+    format!(
+        r#"
+        [package]
+        name = "{}"
+        version = "0.1.0"
+        authors = []
+        workspace = "{}"
+    "#,
+        name, workspace
+    )
+}
+
 pub fn path2url<P: AsRef<Path>>(p: P) -> Url {
     Url::from_file_path(p).ok().unwrap()
 }

--- a/src/cargo/core/compiler/standard_lib.rs
+++ b/src/cargo/core/compiler/standard_lib.rs
@@ -11,6 +11,7 @@ use crate::util::errors::CargoResult;
 use std::collections::{HashMap, HashSet};
 use std::env;
 use std::path::PathBuf;
+use std::rc::Rc;
 
 /// Parse the `-Zbuild-std` flag.
 pub fn parse_unstable_flag(value: Option<&str>) -> Vec<String> {
@@ -66,7 +67,7 @@ pub fn resolve_std<'cfg>(
     let virtual_manifest = crate::core::VirtualManifest::new(
         /*replace*/ Vec::new(),
         patch,
-        ws_config,
+        Rc::new(ws_config),
         /*profiles*/ None,
         crate::core::Features::default(),
         None,

--- a/src/cargo/core/compiler/standard_lib.rs
+++ b/src/cargo/core/compiler/standard_lib.rs
@@ -60,13 +60,9 @@ pub fn resolve_std<'cfg>(
         String::from("library/alloc"),
         String::from("library/test"),
     ];
-    let ws_config = crate::core::WorkspaceConfig::Root(crate::core::WorkspaceRootConfig::new(
-        &src_path,
-        &Some(members),
-        /*default_members*/ &None,
-        /*exclude*/ &None,
-        /*custom_metadata*/ &None,
-    ));
+    let ws_config = crate::core::WorkspaceConfig::Root(
+        crate::core::WorkspaceRootConfig::from_members(&src_path, members),
+    );
     let virtual_manifest = crate::core::VirtualManifest::new(
         /*replace*/ Vec::new(),
         patch,

--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -24,6 +24,15 @@ pub enum EitherManifest {
     Virtual(VirtualManifest),
 }
 
+impl EitherManifest {
+    pub fn workspace(&self) -> Rc<WorkspaceConfig> {
+        match self {
+            Self::Real(manifest) => Rc::clone(&manifest.workspace),
+            Self::Virtual(virtual_manifest) => Rc::clone(&virtual_manifest.workspace),
+        }
+    }
+}
+
 /// Contains all the information about a package, as loaded from a `Cargo.toml`.
 #[derive(Clone, Debug)]
 pub struct Manifest {
@@ -40,7 +49,7 @@ pub struct Manifest {
     publish_lockfile: bool,
     replace: Vec<(PackageIdSpec, Dependency)>,
     patch: HashMap<Url, Vec<Dependency>>,
-    workspace: WorkspaceConfig,
+    workspace: Rc<WorkspaceConfig>,
     original: Rc<TomlManifest>,
     features: Features,
     edition: Edition,
@@ -66,7 +75,7 @@ pub struct Warnings(Vec<DelayedWarning>);
 pub struct VirtualManifest {
     replace: Vec<(PackageIdSpec, Dependency)>,
     patch: HashMap<Url, Vec<Dependency>>,
-    workspace: WorkspaceConfig,
+    workspace: Rc<WorkspaceConfig>,
     profiles: Option<TomlProfiles>,
     warnings: Warnings,
     features: Features,
@@ -370,7 +379,7 @@ impl Manifest {
         publish_lockfile: bool,
         replace: Vec<(PackageIdSpec, Dependency)>,
         patch: HashMap<Url, Vec<Dependency>>,
-        workspace: WorkspaceConfig,
+        workspace: Rc<WorkspaceConfig>,
         features: Features,
         edition: Edition,
         im_a_teapot: Option<bool>,
@@ -463,8 +472,8 @@ impl Manifest {
         self.links.as_deref()
     }
 
-    pub fn workspace_config(&self) -> &WorkspaceConfig {
-        &self.workspace
+    pub fn workspace_config(&self) -> Rc<WorkspaceConfig> {
+        Rc::clone(&self.workspace)
     }
 
     pub fn features(&self) -> &Features {
@@ -538,7 +547,7 @@ impl VirtualManifest {
     pub fn new(
         replace: Vec<(PackageIdSpec, Dependency)>,
         patch: HashMap<Url, Vec<Dependency>>,
-        workspace: WorkspaceConfig,
+        workspace: Rc<WorkspaceConfig>,
         profiles: Option<TomlProfiles>,
         features: Features,
         resolve_behavior: Option<ResolveBehavior>,
@@ -562,8 +571,8 @@ impl VirtualManifest {
         &self.patch
     }
 
-    pub fn workspace_config(&self) -> &WorkspaceConfig {
-        &self.workspace
+    pub fn workspace_config(&self) -> Rc<WorkspaceConfig> {
+        Rc::clone(&self.workspace)
     }
 
     pub fn profiles(&self) -> Option<&TomlProfiles> {

--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -16,7 +16,7 @@ use crate::core::{Dependency, PackageId, PackageIdSpec, SourceId, Summary};
 use crate::core::{Edition, Feature, Features, WorkspaceConfig};
 use crate::util::errors::*;
 use crate::util::interning::InternedString;
-use crate::util::toml::{TomlManifest, TomlProfiles};
+use crate::util::toml::{DefinedTomlManifest, TomlProfiles};
 use crate::util::{short_hash, Config, Filesystem};
 
 pub enum EitherManifest {
@@ -50,7 +50,7 @@ pub struct Manifest {
     replace: Vec<(PackageIdSpec, Dependency)>,
     patch: HashMap<Url, Vec<Dependency>>,
     workspace: Rc<WorkspaceConfig>,
-    original: Rc<TomlManifest>,
+    original: Rc<DefinedTomlManifest>,
     features: Features,
     edition: Edition,
     im_a_teapot: Option<bool>,
@@ -384,7 +384,7 @@ impl Manifest {
         edition: Edition,
         im_a_teapot: Option<bool>,
         default_run: Option<String>,
-        original: Rc<TomlManifest>,
+        original: Rc<DefinedTomlManifest>,
         metabuild: Option<Vec<String>>,
         resolve_behavior: Option<ResolveBehavior>,
     ) -> Manifest {
@@ -462,7 +462,7 @@ impl Manifest {
     pub fn replace(&self) -> &[(PackageIdSpec, Dependency)] {
         &self.replace
     }
-    pub fn original(&self) -> &TomlManifest {
+    pub fn original(&self) -> &DefinedTomlManifest {
         &self.original
     }
     pub fn patch(&self) -> &HashMap<Url, Vec<Dependency>> {

--- a/src/cargo/core/mod.rs
+++ b/src/cargo/core/mod.rs
@@ -28,4 +28,4 @@ pub mod resolver;
 pub mod shell;
 pub mod source;
 pub mod summary;
-mod workspace;
+pub mod workspace;

--- a/src/cargo/core/package.rs
+++ b/src/cargo/core/package.rs
@@ -240,7 +240,9 @@ impl Package {
         let manifest = self
             .manifest()
             .original()
-            .prepare_for_publish(ws, self.manifest_path())?;
+            .prepare_for_publish(ws, self.manifest_path())?
+            .into_toml_manifest();
+
         let toml = toml::to_string(&manifest)?;
         Ok(format!("{}\n{}", MANIFEST_PREAMBLE, toml))
     }

--- a/src/cargo/core/package.rs
+++ b/src/cargo/core/package.rs
@@ -240,7 +240,7 @@ impl Package {
         let manifest = self
             .manifest()
             .original()
-            .prepare_for_publish(ws, self.root())?;
+            .prepare_for_publish(ws, self.manifest_path())?;
         let toml = toml::to_string(&manifest)?;
         Ok(format!("{}\n{}", MANIFEST_PREAMBLE, toml))
     }

--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -21,7 +21,7 @@ use crate::util::errors::{CargoResult, CargoResultExt, ManifestError};
 use crate::util::interning::InternedString;
 use crate::util::paths;
 use crate::util::toml::{
-    map_deps, parse_manifest, read_manifest, DefinedTomlDependency, ParseOutput, StringOrBool,
+    parse_manifest, prepare_deps, read_manifest, DefinedTomlDependency, ParseOutput, StringOrBool,
     TomlProfiles, TomlWorkspace, VecStringOrBool,
 };
 use crate::util::{Config, Filesystem};
@@ -1146,7 +1146,7 @@ impl WorkspaceRootConfig {
         config: &Config,
         toml_workspace: &TomlWorkspace,
     ) -> CargoResult<Self> {
-        let dependencies = map_deps(
+        let dependencies = prepare_deps(
             config,
             toml_workspace.dependencies.as_ref(),
             |_d: &DefinedTomlDependency| true,

--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -21,7 +21,7 @@ use crate::util::errors::{CargoResult, CargoResultExt, ManifestError};
 use crate::util::interning::InternedString;
 use crate::util::paths;
 use crate::util::toml::{
-    map_deps, parse_manifest, read_manifest, ParseOutput, StringOrBool, TomlDependency,
+    map_deps, parse_manifest, read_manifest, DefinedTomlDependency, ParseOutput, StringOrBool,
     TomlProfiles, TomlWorkspace, VecStringOrBool,
 };
 use crate::util::{Config, Filesystem};
@@ -145,7 +145,7 @@ pub struct WorkspaceRootConfig {
     custom_metadata: Option<toml::Value>,
 
     // Properties that can be inherited by members.
-    dependencies: Option<BTreeMap<String, TomlDependency>>,
+    dependencies: Option<BTreeMap<String, DefinedTomlDependency>>,
     version: Option<semver::Version>,
     authors: Option<Vec<String>>,
     description: Option<String>,
@@ -1149,7 +1149,7 @@ impl WorkspaceRootConfig {
         let dependencies = map_deps(
             config,
             toml_workspace.dependencies.as_ref(),
-            |_d: &TomlDependency| true,
+            |_d: &DefinedTomlDependency| true,
         )?;
 
         Ok(Self {

--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -21,8 +21,8 @@ use crate::util::errors::{CargoResult, CargoResultExt, ManifestError};
 use crate::util::interning::InternedString;
 use crate::util::paths;
 use crate::util::toml::{
-    map_deps, parse_manifest, read_manifest, StringOrBool, TomlDependency, TomlProfiles,
-    TomlWorkspace, VecStringOrBool,
+    map_deps, parse_manifest, read_manifest, ParseOutput, StringOrBool, TomlDependency,
+    TomlProfiles, TomlWorkspace, VecStringOrBool,
 };
 use crate::util::{Config, Filesystem};
 
@@ -1323,4 +1323,15 @@ pub fn find_workspace_root(manifest_path: &Path, config: &Config) -> CargoResult
     }
 
     Ok(None)
+}
+
+pub fn find_and_parse_workspace_root(
+    manifest_file: &Path,
+    config: &Config,
+) -> CargoResult<Option<ParseOutput>> {
+    if let Some(root_path) = find_workspace_root(manifest_file, config)? {
+        Ok(Some(parse_manifest(&root_path, config)?))
+    } else {
+        Ok(None)
+    }
 }

--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -20,7 +20,10 @@ use crate::sources::PathSource;
 use crate::util::errors::{CargoResult, CargoResultExt, ManifestError};
 use crate::util::interning::InternedString;
 use crate::util::paths;
-use crate::util::toml::{read_manifest, TomlProfiles};
+use crate::util::toml::{
+    map_deps, read_manifest, StringOrBool, TomlDependency, TomlProfiles, TomlWorkspace,
+    VecStringOrBool,
+};
 use crate::util::{Config, Filesystem};
 
 /// The core abstraction in Cargo for working with a workspace of crates.
@@ -131,6 +134,23 @@ pub struct WorkspaceRootConfig {
     default_members: Option<Vec<String>>,
     exclude: Vec<String>,
     custom_metadata: Option<toml::Value>,
+
+    // Properties that can be inherited by members.
+    dependencies: Option<BTreeMap<String, TomlDependency>>,
+    version: Option<semver::Version>,
+    authors: Option<Vec<String>>,
+    description: Option<String>,
+    documentation: Option<String>,
+    readme: Option<StringOrBool>,
+    homepage: Option<String>,
+    repository: Option<String>,
+    license: Option<String>,
+    license_file: Option<String>,
+    keywords: Option<Vec<String>>,
+    categories: Option<Vec<String>>,
+    publish: Option<VecStringOrBool>,
+    edition: Option<String>,
+    badges: Option<BTreeMap<String, BTreeMap<String, String>>>,
 }
 
 /// An iterator over the member packages of a workspace, returned by
@@ -1154,21 +1174,64 @@ impl MaybePackage {
 }
 
 impl WorkspaceRootConfig {
-    /// Creates a new Intermediate Workspace Root configuration.
-    pub fn new(
-        root_dir: &Path,
-        members: &Option<Vec<String>>,
-        default_members: &Option<Vec<String>>,
-        exclude: &Option<Vec<String>>,
-        custom_metadata: &Option<toml::Value>,
-    ) -> WorkspaceRootConfig {
-        WorkspaceRootConfig {
+    pub fn from_members(root_dir: &Path, members: Vec<String>) -> WorkspaceRootConfig {
+        Self {
             root_dir: root_dir.to_path_buf(),
-            members: members.clone(),
-            default_members: default_members.clone(),
-            exclude: exclude.clone().unwrap_or_default(),
-            custom_metadata: custom_metadata.clone(),
+            members: Some(members),
+            default_members: None,
+            exclude: Vec::new(),
+            custom_metadata: None,
+            dependencies: None,
+            version: None,
+            authors: None,
+            description: None,
+            documentation: None,
+            readme: None,
+            homepage: None,
+            repository: None,
+            license: None,
+            license_file: None,
+            keywords: None,
+            categories: None,
+            publish: None,
+            edition: None,
+            badges: None,
         }
+    }
+    /// Creates a new Intermediate Workspace Root configuration from a toml workspace.
+    pub fn from_toml_workspace(
+        root_dir: &Path,
+        config: &Config,
+        toml_workspace: &TomlWorkspace,
+    ) -> CargoResult<Self> {
+        let dependencies = map_deps(
+            config,
+            toml_workspace.dependencies.as_ref(),
+            |_d: &TomlDependency| true,
+        )?;
+
+        Ok(Self {
+            root_dir: root_dir.to_path_buf(),
+            members: toml_workspace.members.clone(),
+            default_members: toml_workspace.default_members.clone(),
+            exclude: toml_workspace.exclude.clone().unwrap_or_default(),
+            custom_metadata: toml_workspace.metadata.clone(),
+            dependencies,
+            version: toml_workspace.version.clone(),
+            authors: toml_workspace.authors.clone(),
+            description: toml_workspace.description.clone(),
+            documentation: toml_workspace.documentation.clone(),
+            readme: toml_workspace.readme.clone(),
+            homepage: toml_workspace.homepage.clone(),
+            repository: toml_workspace.repository.clone(),
+            license: toml_workspace.license.clone(),
+            license_file: toml_workspace.license_file.clone(),
+            keywords: toml_workspace.keywords.clone(),
+            categories: toml_workspace.categories.clone(),
+            publish: toml_workspace.publish.clone(),
+            edition: toml_workspace.edition.clone(),
+            badges: toml_workspace.badges.clone(),
+        })
     }
 
     /// Checks the path against the `excluded` list.

--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -21,8 +21,8 @@ use crate::util::errors::{CargoResult, CargoResultExt, ManifestError};
 use crate::util::interning::InternedString;
 use crate::util::paths;
 use crate::util::toml::{
-    parse_manifest, prepare_deps, read_manifest, DefinedTomlDependency, ParseOutput, StringOrBool,
-    TomlProfiles, TomlWorkspace, VecStringOrBool,
+    parse_manifest, prepare_deps, read_manifest, DefinedTomlDependency, StringOrBool, TomlProfiles,
+    TomlWorkspace, VecStringOrBool,
 };
 use crate::util::{Config, Filesystem};
 
@@ -1323,15 +1323,4 @@ pub fn find_workspace_root(manifest_path: &Path, config: &Config) -> CargoResult
     }
 
     Ok(None)
-}
-
-pub fn find_and_parse_workspace_root(
-    manifest_file: &Path,
-    config: &Config,
-) -> CargoResult<Option<ParseOutput>> {
-    if let Some(root_path) = find_workspace_root(manifest_file, config)? {
-        Ok(Some(parse_manifest(&root_path, config)?))
-    } else {
-        Ok(None)
-    }
 }

--- a/src/cargo/ops/cargo_package.rs
+++ b/src/cargo/ops/cargo_package.rs
@@ -270,16 +270,16 @@ fn build_lock(ws: &Workspace<'_>) -> CargoResult<String> {
 
     // Convert Package -> TomlManifest -> Manifest -> Package
     let orig_pkg = ws.current()?;
+    let manifest_path = orig_pkg.manifest_path();
     let toml_manifest = Rc::new(
         orig_pkg
             .manifest()
             .original()
-            .prepare_for_publish(ws, orig_pkg.root())?,
+            .prepare_for_publish(ws, manifest_path)?,
     );
-    let package_root = orig_pkg.root();
     let source_id = orig_pkg.package_id().source_id();
     let (manifest, _nested_paths) =
-        TomlManifest::to_real_manifest(&toml_manifest, source_id, package_root, config)?;
+        TomlManifest::to_real_manifest(&toml_manifest, source_id, manifest_path, config)?;
     let new_pkg = Package::new(manifest, orig_pkg.manifest_path());
 
     // Regenerate Cargo.lock using the old one as a guide.

--- a/src/cargo/ops/cargo_package.rs
+++ b/src/cargo/ops/cargo_package.rs
@@ -105,8 +105,6 @@ pub fn package(ws: &Workspace<'_>, opts: &PackageOpts<'_>) -> CargoResult<Option
         return Ok(None);
     }
 
-    verify_dependencies(pkg)?;
-
     let filename = format!("{}-{}.crate", pkg.name(), pkg.version());
     let dir = ws.target_dir().join("package");
     let mut dst = {
@@ -328,21 +326,6 @@ fn check_metadata(pkg: &Package, config: &Config) -> CargoResult<()> {
         ))?
     }
 
-    Ok(())
-}
-
-// Checks that the package dependencies are safe to deploy.
-fn verify_dependencies(pkg: &Package) -> CargoResult<()> {
-    for dep in pkg.dependencies() {
-        if dep.source_id().is_path() && !dep.specified_req() && dep.is_transitive() {
-            anyhow::bail!(
-                "all path dependencies must have a version specified \
-                 when packaging.\ndependency `{}` does not specify \
-                 a version.",
-                dep.name_in_toml()
-            )
-        }
-    }
     Ok(())
 }
 

--- a/src/cargo/ops/registry.rs
+++ b/src/cargo/ops/registry.rs
@@ -134,7 +134,7 @@ fn verify_dependencies(
     registry_src: SourceId,
 ) -> CargoResult<()> {
     for dep in pkg.dependencies().iter() {
-        if dep.source_id().is_path() || dep.source_id().is_git() {
+        if dep.source_id().is_git() {
             if !dep.specified_req() {
                 if !dep.is_transitive() {
                     // dev-dependencies will be stripped in TomlManifest::prepare_for_publish
@@ -161,7 +161,7 @@ fn verify_dependencies(
             }
         // TomlManifest::prepare_for_publish will rewrite the dependency
         // to be just the `version` field.
-        } else if dep.source_id() != registry_src {
+        } else if !dep.source_id().is_path() && dep.source_id() != registry_src {
             if !dep.source_id().is_registry() {
                 // Consider making SourceId::kind a public type that we can
                 // exhaustively match on. Using match can help ensure that

--- a/src/cargo/util/config/mod.rs
+++ b/src/cargo/util/config/mod.rs
@@ -176,6 +176,8 @@ pub struct Config {
     build_config: LazyCell<CargoBuildConfig>,
     target_cfgs: LazyCell<Vec<(String, TargetCfgConfig)>>,
     doc_extern_map: LazyCell<RustdocExternMap>,
+    /// Cache parsed manifests to avoid parsing twice.
+    manifest_cache: LazyCell<RefCell<cargo_toml::ManifestCache>>,
 }
 
 impl Config {
@@ -247,6 +249,7 @@ impl Config {
             build_config: LazyCell::new(),
             target_cfgs: LazyCell::new(),
             doc_extern_map: LazyCell::new(),
+            manifest_cache: LazyCell::new(),
         }
     }
 
@@ -1206,6 +1209,12 @@ impl Config {
         // nothing to query. Plumbing the name into SourceId is quite challenging.
         self.doc_extern_map
             .try_borrow_with(|| self.get::<RustdocExternMap>("doc.extern-map"))
+    }
+
+    pub fn manifest_cache(&self) -> RefMut<'_, cargo_toml::ManifestCache> {
+        self.manifest_cache
+            .borrow_with(|| RefCell::new(cargo_toml::ManifestCache::new()))
+            .borrow_mut()
     }
 
     /// Returns the `[target]` table definition for the given target triple.

--- a/src/cargo/util/toml/manifest_cache.rs
+++ b/src/cargo/util/toml/manifest_cache.rs
@@ -1,0 +1,88 @@
+use std::collections::{
+    hash_map::{Entry, HashMap},
+    BTreeSet,
+};
+use std::path::{Path, PathBuf};
+use std::rc::Rc;
+
+use super::{parse, TomlManifest};
+use crate::util::errors::{CargoResult, CargoResultExt, ManifestError};
+use crate::util::{paths, Config};
+
+pub type ManifestCache = HashMap<PathBuf, Rc<ParseOutput>>;
+
+#[derive(Debug)]
+pub struct ParseOutput {
+    pub manifest: Rc<TomlManifest>,
+    pub unused: BTreeSet<String>,
+}
+
+pub fn parse_manifest<'a>(
+    manifest_file: &'_ Path,
+    config: &'a Config,
+) -> Result<Rc<ParseOutput>, ManifestError> {
+    let key = manifest_file.parent().unwrap().to_path_buf();
+    let mut cache = config.manifest_cache();
+
+    match cache.entry(key.clone()) {
+        Entry::Occupied(e) => Ok(Rc::clone(e.get())),
+        Entry::Vacant(v) => {
+            let contents = paths::read(manifest_file)
+                .map_err(|err| ManifestError::new(err, manifest_file.into()))?;
+
+            let output = deserialize(contents, manifest_file, config)
+                .chain_err(|| format!("failed to parse manifest at `{}`", manifest_file.display()))
+                .map_err(|err| ManifestError::new(err, manifest_file.into()))?;
+
+            Ok(Rc::clone(v.insert(Rc::new(output))))
+        }
+    }
+}
+
+fn deserialize(
+    contents: String,
+    manifest_file: &Path,
+    config: &Config,
+) -> CargoResult<ParseOutput> {
+    let pretty_filename = manifest_file
+        .strip_prefix(config.cwd())
+        .unwrap_or(manifest_file);
+
+    let toml = parse(&contents, pretty_filename, config)?;
+    let mut unused = BTreeSet::new();
+    let manifest: TomlManifest = serde_ignored::deserialize(toml, |path| {
+        let mut key = String::new();
+        stringify(&mut key, &path);
+        unused.insert(key);
+    })?;
+
+    Ok(ParseOutput {
+        manifest: Rc::new(manifest),
+        unused,
+    })
+}
+
+fn stringify(dst: &mut String, path: &serde_ignored::Path<'_>) {
+    use serde_ignored::Path;
+
+    match *path {
+        Path::Root => {}
+        Path::Seq { parent, index } => {
+            stringify(dst, parent);
+            if !dst.is_empty() {
+                dst.push('.');
+            }
+            dst.push_str(&index.to_string());
+        }
+        Path::Map { parent, ref key } => {
+            stringify(dst, parent);
+            if !dst.is_empty() {
+                dst.push('.');
+            }
+            dst.push_str(key);
+        }
+        Path::Some { parent }
+        | Path::NewtypeVariant { parent }
+        | Path::NewtypeStruct { parent } => stringify(dst, parent),
+    }
+}

--- a/src/cargo/util/toml/manifest_cache.rs
+++ b/src/cargo/util/toml/manifest_cache.rs
@@ -7,7 +7,7 @@ use std::rc::Rc;
 
 use super::{parse, TomlManifest};
 use crate::util::errors::{CargoResult, CargoResultExt, ManifestError};
-use crate::util::toml::TomlWorkspace;
+use crate::util::toml::{TomlProject, TomlWorkspace};
 use crate::util::{paths, Config};
 
 pub type ManifestCache = HashMap<PathBuf, ParseOutput>;
@@ -21,6 +21,13 @@ pub struct ParseOutput {
 impl ParseOutput {
     pub fn workspace(&self) -> Option<&TomlWorkspace> {
         self.manifest.workspace.as_ref()
+    }
+
+    pub fn package(&self) -> Option<&TomlProject> {
+        self.manifest
+            .package
+            .as_deref()
+            .or(self.manifest.project.as_deref())
     }
 }
 

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -921,7 +921,7 @@ pub struct TomlProject {
     license_file: Option<MaybeWorkspace<String>>,
     repository: Option<MaybeWorkspace<String>>,
     metadata: Option<toml::Value>,
-    pub resolver: Option<String>,
+    resolver: Option<String>,
 }
 
 struct WorkspaceFields {
@@ -1042,7 +1042,7 @@ impl TomlManifest {
         }
         let all = |_d: &TomlDependency| true;
         return Ok(TomlManifest {
-            package: Some(Box::new(package)),
+            package: Some(package),
             project: None,
             profile: self.profile.clone(),
             lib: self.lib.clone(),
@@ -1616,7 +1616,7 @@ impl TomlManifest {
         })
     }
 
-    pub fn package(&self) -> CargoResult<&TomlProject> {
+    pub fn package(&self) -> CargoResult<&Box<TomlProject>> {
         Ok(self
             .project
             .as_ref()

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fmt;
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
@@ -27,6 +27,8 @@ use crate::util::{self, paths, validate_package_name, Config, IntoUrl};
 
 mod targets;
 use self::targets::targets;
+mod manifest_cache;
+pub use manifest_cache::{parse_manifest, ManifestCache, ParseOutput};
 
 pub fn read_manifest(
     path: &Path,
@@ -38,44 +40,31 @@ pub fn read_manifest(
         path.display(),
         source_id
     );
-    let contents = paths::read(path).map_err(|err| ManifestError::new(err, path.into()))?;
 
-    do_read_manifest(&contents, path, source_id, config)
+    let output = parse_manifest(path, config)?;
+
+    do_read_manifest(&output, path, source_id, config)
         .chain_err(|| format!("failed to parse manifest at `{}`", path.display()))
         .map_err(|err| ManifestError::new(err, path.into()))
 }
 
 fn do_read_manifest(
-    contents: &str,
+    output: &ParseOutput,
     manifest_file: &Path,
     source_id: SourceId,
     config: &Config,
 ) -> CargoResult<(EitherManifest, Vec<PathBuf>)> {
+    let manifest = &output.manifest;
     let package_root = manifest_file.parent().unwrap();
 
-    let toml = {
-        let pretty_filename = manifest_file
-            .strip_prefix(config.cwd())
-            .unwrap_or(manifest_file);
-        parse(contents, pretty_filename, config)?
-    };
-
-    let mut unused = BTreeSet::new();
-    let manifest: TomlManifest = serde_ignored::deserialize(toml, |path| {
-        let mut key = String::new();
-        stringify(&mut key, &path);
-        unused.insert(key);
-    })?;
     let add_unused = |warnings: &mut Warnings| {
-        for key in unused {
+        for key in &output.unused {
             warnings.add_warning(format!("unused manifest key: {}", key));
             if key == "profiles.debug" {
                 warnings.add_warning("use `[profile.dev]` to configure debug builds".to_string());
             }
         }
     };
-
-    let manifest = Rc::new(manifest);
 
     if let Some(deps) = manifest
         .workspace
@@ -110,31 +99,6 @@ fn do_read_manifest(
         add_unused(m.warnings_mut());
         Ok((EitherManifest::Virtual(m), paths))
     };
-
-    fn stringify(dst: &mut String, path: &serde_ignored::Path<'_>) {
-        use serde_ignored::Path;
-
-        match *path {
-            Path::Root => {}
-            Path::Seq { parent, index } => {
-                stringify(dst, parent);
-                if !dst.is_empty() {
-                    dst.push('.');
-                }
-                dst.push_str(&index.to_string());
-            }
-            Path::Map { parent, ref key } => {
-                stringify(dst, parent);
-                if !dst.is_empty() {
-                    dst.push('.');
-                }
-                dst.push_str(key);
-            }
-            Path::Some { parent }
-            | Path::NewtypeVariant { parent }
-            | Path::NewtypeStruct { parent } => stringify(dst, parent),
-        }
-    }
 }
 
 pub fn parse(toml: &str, file: &Path, config: &Config) -> CargoResult<toml::Value> {
@@ -1260,18 +1224,8 @@ impl TomlManifest {
             links: project.links.clone(),
         };
 
-        let workspace_config = match (me.workspace.as_ref(), project.workspace.as_ref()) {
-            (Some(toml_workspace), None) => WorkspaceConfig::Root(
-                WorkspaceRootConfig::from_toml_workspace(package_root, &config, toml_workspace)?,
-            ),
-            (None, root) => WorkspaceConfig::Member {
-                root: root.cloned(),
-            },
-            (Some(..), Some(..)) => bail!(
-                "cannot configure both `package.workspace` and \
-                 `[workspace]`, only one can be specified"
-            ),
-        };
+        let workspace_config = me.workspace_config(package_root, &config)?;
+
         let profiles = me.profile.clone();
         if let Some(profiles) = &profiles {
             profiles.validate(&features, &mut warnings)?;
@@ -1329,7 +1283,7 @@ impl TomlManifest {
             publish_lockfile,
             replace,
             patch,
-            workspace_config,
+            Rc::new(workspace_config),
             features,
             edition,
             project.im_a_teapot,
@@ -1441,25 +1395,45 @@ impl TomlManifest {
             .and_then(|ws| ws.resolver.as_deref())
             .map(|r| ResolveBehavior::from_manifest(r))
             .transpose()?;
-        let workspace_config = match me.workspace {
-            Some(ref toml_workspace) => WorkspaceConfig::Root(
-                WorkspaceRootConfig::from_toml_workspace(root, config, toml_workspace)?,
-            ),
-            None => {
-                bail!("virtual manifests must be configured with [workspace]");
-            }
-        };
+
+        let workspace_config = me.workspace_config(root, config)?;
+        if !workspace_config.is_root() {
+            bail!("virtual manifests must be configured with [workspace]");
+        }
+
         Ok((
             VirtualManifest::new(
                 replace,
                 patch,
-                workspace_config,
+                Rc::new(workspace_config),
                 profiles,
                 features,
                 resolve_behavior,
             ),
             nested_paths,
         ))
+    }
+
+    pub fn workspace_config(
+        &self,
+        package_root: &Path,
+        config: &Config,
+    ) -> CargoResult<WorkspaceConfig> {
+        let workspace = self.workspace.as_ref();
+        let project_workspace = self.package().ok().and_then(|p| p.workspace.as_ref());
+
+        Ok(match (workspace, project_workspace) {
+            (Some(toml_workspace), None) => WorkspaceConfig::Root(
+                WorkspaceRootConfig::from_toml_workspace(package_root, &config, toml_workspace)?,
+            ),
+            (None, root) => WorkspaceConfig::Member {
+                root: root.cloned(),
+            },
+            (Some(..), Some(..)) => bail!(
+                "cannot configure both `package.workspace` and \
+                 `[workspace]`, only one can be specified"
+            ),
+        })
     }
 
     fn replace(&self, cx: &mut Context<'_, '_>) -> CargoResult<Vec<(PackageIdSpec, Dependency)>> {

--- a/src/cargo/util/toml/targets.rs
+++ b/src/cargo/util/toml/targets.rs
@@ -15,8 +15,8 @@ use std::fs::{self, DirEntry};
 use std::path::{Path, PathBuf};
 
 use super::{
-    PathValue, StringOrBool, StringOrVec, TomlBenchTarget, TomlBinTarget, TomlExampleTarget,
-    TomlLibTarget, TomlManifest, TomlTarget, TomlTestTarget,
+    DefinedTomlManifest, PathValue, StringOrBool, StringOrVec, TomlBenchTarget, TomlBinTarget,
+    TomlExampleTarget, TomlLibTarget, TomlTarget, TomlTestTarget,
 };
 use crate::core::compiler::CrateType;
 use crate::core::{Edition, Feature, Features, Target};
@@ -25,7 +25,7 @@ use crate::util::restricted_names;
 
 pub fn targets(
     features: &Features,
-    manifest: &TomlManifest,
+    manifest: &DefinedTomlManifest,
     package_name: &str,
     package_root: &Path,
     edition: Edition,
@@ -55,7 +55,6 @@ pub fn targets(
     let package = manifest
         .package
         .as_ref()
-        .or_else(|| manifest.project.as_ref())
         .ok_or_else(|| anyhow::format_err!("manifest has no `package` (or `project`)"))?;
 
     targets.extend(clean_bins(

--- a/tests/testsuite/bad_config.rs
+++ b/tests/testsuite/bad_config.rs
@@ -1103,6 +1103,8 @@ fn both_git_and_path_specified() {
     "#,
         )
         .file("src/lib.rs", "")
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.0.1"))
+        .file("bar/lib.rs", "")
         .build();
 
     foo.cargo("build -v")
@@ -1173,6 +1175,8 @@ fn ignored_git_revision() {
     "#,
         )
         .file("src/lib.rs", "")
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.0.1"))
+        .file("bar/lib.rs", "")
         .build();
 
     foo.cargo("build -v")

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -268,7 +268,7 @@ fn cargo_compile_with_invalid_version() {
 [ERROR] failed to parse manifest at `[..]`
 
 Caused by:
-  data did not match any variant of untagged enum MaybeWorkspace for key `package.version`
+  Expected dot for key `package.version`
 ",
         )
         .run();

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -268,7 +268,7 @@ fn cargo_compile_with_invalid_version() {
 [ERROR] failed to parse manifest at `[..]`
 
 Caused by:
-  Expected dot for key `package.version`
+  data did not match any variant of untagged enum MaybeWorkspace for key `package.version`
 ",
         )
         .run();

--- a/tests/testsuite/build_script.rs
+++ b/tests/testsuite/build_script.rs
@@ -382,7 +382,7 @@ fn links_duplicates() {
                        .with_stderr("\
 error: failed to select a version for `a-sys`.
     ... required by package `foo v0.5.0 ([..])`
-versions that meet the requirements `*` are: 0.5.0
+versions that meet the requirements `^0.5.0` are: 0.5.0
 
 the package `a-sys` links to the native library `a`, but it conflicts with a previous package which links to `a` as well:
 package `foo v0.5.0 ([..])`
@@ -501,7 +501,7 @@ fn links_duplicates_deep_dependency() {
 error: failed to select a version for `a-sys`.
     ... required by package `a v0.5.0 ([..])`
     ... which is depended on by `foo v0.5.0 ([..])`
-versions that meet the requirements `*` are: 0.5.0
+versions that meet the requirements `^0.5.0` are: 0.5.0
 
 the package `a-sys` links to the native library `a`, but it conflicts with a previous package which links to `a` as well:
 package `foo v0.5.0 ([..])`
@@ -3579,7 +3579,7 @@ fn links_duplicates_with_cycle() {
                        .with_stderr("\
 error: failed to select a version for `a`.
     ... required by package `foo v0.5.0 ([..])`
-versions that meet the requirements `*` are: 0.5.0
+versions that meet the requirements `^0.5.0` are: 0.5.0
 
 the package `a` links to the native library `a`, but it conflicts with a previous package which links to `a` as well:
 package `foo v0.5.0 ([..])`

--- a/tests/testsuite/deduplicate_workspace.rs
+++ b/tests/testsuite/deduplicate_workspace.rs
@@ -134,8 +134,8 @@ fn inherit_workspace_fields() {
             edition = { workspace = true }
         "#,
         )
-        .file("bar/LICENSE", "license")
-        .file("bar/README.md", "README.md")
+        .file("LICENSE", "license")
+        .file("README.md", "README.md")
         .file("bar/src/main.rs", "fn main() {}")
         .build();
 
@@ -155,11 +155,11 @@ fn inherit_workspace_fields() {
           "homepage": "https://www.rust-lang.org",
           "keywords": ["cli"],
           "license": "MIT",
-          "license_file": "./LICENSE",
+          "license_file": "../LICENSE",
           "links": null,
           "name": "bar",
           "readme": "README.md",
-          "readme_file": "README.md",
+          "readme_file": "../README.md",
           "repository": "https://github.com/example/example",
           "vers": "1.2.3"
           }

--- a/tests/testsuite/deduplicate_workspace.rs
+++ b/tests/testsuite/deduplicate_workspace.rs
@@ -71,7 +71,7 @@ fn deny_optional_dependencies() {
         .with_status(101)
         .with_stderr(
             "\
-[ERROR] failed to parse manifest at `[..]Cargo.toml`
+[ERROR] failed to parse manifest at `[..]foo/Cargo.toml`
 
 Caused by:
   dep1 is optional, but workspace dependencies cannot be optional
@@ -175,4 +175,216 @@ fn inherit_workspace_fields() {
             ".cargo_vcs_info.json",
         ],
     );
+}
+
+#[cargo_test]
+fn inherit_own_workspace_fields() {
+    registry::init();
+
+    let p = project().build();
+
+    let _ = git::repo(&paths::root().join("foo"))
+        .file(
+            "Cargo.toml",
+            r#"
+            badges = { workspace = true }
+
+            [package]
+            name = "foo"
+            version = { workspace = true }
+            authors = { workspace = true }
+            description = { workspace = true }
+            documentation = { workspace = true }
+            readme = { workspace = true }
+            homepage = { workspace = true }
+            repository = { workspace = true }
+            license = { workspace = true }
+            license-file = { workspace = true }
+            keywords = { workspace = true }
+            categories = { workspace = true }
+            publish = { workspace = true }
+            edition = { workspace = true }
+
+            [workspace]
+            members = []
+            version = "1.2.3"
+            authors = ["Rustaceans"]
+            description = "This is a crate"
+            documentation = "https://www.rust-lang.org/learn"
+            readme = "README.md"
+            homepage = "https://www.rust-lang.org"
+            repository = "https://github.com/example/example"
+            license = "MIT"
+            license-file = "./LICENSE"
+            keywords = ["cli"]
+            categories = ["development-tools"]
+            publish = true
+            edition = "2018"
+
+            [workspace.badges]
+            gitlab = { repository = "https://gitlab.com/rust-lang/rust", branch = "master" }
+            "#,
+        )
+        .file("src/main.rs", "fn main() {}")
+        .file("LICENSE", "license")
+        .file("README.md", "README.md")
+        .build();
+
+    p.cargo("publish --token sekrit").run();
+    publish::validate_upload(
+        r#"
+        {
+          "authors": ["Rustaceans"],
+          "badges": {
+            "gitlab": { "branch": "master", "repository": "https://gitlab.com/rust-lang/rust" }
+          },
+          "categories": ["development-tools"],
+          "deps": [],
+          "description": "This is a crate",
+          "documentation": "https://www.rust-lang.org/learn",
+          "features": {},
+          "homepage": "https://www.rust-lang.org",
+          "keywords": ["cli"],
+          "license": "MIT",
+          "license_file": "./LICENSE",
+          "links": null,
+          "name": "foo",
+          "readme": "README.md",
+          "readme_file": "README.md",
+          "repository": "https://github.com/example/example",
+          "vers": "1.2.3"
+          }
+        "#,
+        "foo-1.2.3.crate",
+        &[
+            "Cargo.lock",
+            "Cargo.toml",
+            "Cargo.toml.orig",
+            "src/main.rs",
+            "README.md",
+            "LICENSE",
+            ".cargo_vcs_info.json",
+        ],
+    );
+}
+
+#[cargo_test]
+fn error_inherit_from_undefined_field() {
+    registry::init();
+
+    let p = project().build();
+
+    let _ = git::repo(&paths::root().join("foo"))
+        .file(
+            "Cargo.toml",
+            r#"
+            [workspace]
+            members = ["bar"]
+            "#,
+        )
+        .file("src/main.rs", "fn main() {}")
+        .file(
+            "bar/Cargo.toml",
+            r#"
+            [package]
+            name = "bar"
+            workspace = ".."
+            version = "1.2.3"
+            authors = ["rustaceans"]
+            description = { workspace = true }
+        "#,
+        )
+        .file("bar/src/main.rs", "fn main() {}")
+        .build();
+
+    p.cargo("build")
+        .cwd("bar")
+        .with_status(101)
+        .with_stderr(
+            "\
+[ERROR] failed to parse manifest at `[CWD]/Cargo.toml`
+
+Caused by:
+  error reading description: workspace root does not define [workspace.description]
+",
+        )
+        .run();
+}
+
+#[cargo_test]
+fn error_workspace_false() {
+    registry::init();
+
+    let p = project().build();
+
+    let _ = git::repo(&paths::root().join("foo"))
+        .file(
+            "Cargo.toml",
+            r#"
+            [workspace]
+            members = ["bar"]
+            "#,
+        )
+        .file("src/main.rs", "fn main() {}")
+        .file(
+            "bar/Cargo.toml",
+            r#"
+            [package]
+            name = "bar"
+            workspace = ".."
+            version = "1.2.3"
+            authors = ["rustaceans"]
+            description = { workspace = false }
+        "#,
+        )
+        .file("bar/src/main.rs", "fn main() {}")
+        .build();
+
+    p.cargo("build")
+        .cwd("bar")
+        .with_status(101)
+        .with_stderr(
+            "\
+[ERROR] failed to parse manifest at `[CWD]/Cargo.toml`
+
+Caused by:
+  error reading description: cannot specify { workspace = false }
+",
+        )
+        .run();
+}
+
+#[cargo_test]
+fn error_no_root_workspace() {
+    registry::init();
+
+    let p = project().build();
+
+    let _ = git::repo(&paths::root().join("foo"))
+        .file(
+            "bar/Cargo.toml",
+            r#"
+            [package]
+            name = "bar"
+            workspace = ".."
+            version = "1.2.3"
+            authors = ["rustaceans"]
+            description = { workspace = true }
+        "#,
+        )
+        .file("bar/src/main.rs", "fn main() {}")
+        .build();
+
+    p.cargo("build")
+        .cwd("bar")
+        .with_status(101)
+        .with_stderr(
+            "\
+[ERROR] failed to parse manifest at `[CWD]/Cargo.toml`
+
+Caused by:
+  error reading description: could not read workspace root
+",
+        )
+        .run();
 }

--- a/tests/testsuite/deduplicate_workspace.rs
+++ b/tests/testsuite/deduplicate_workspace.rs
@@ -348,7 +348,7 @@ fn error_workspace_false() {
 [ERROR] failed to parse manifest at `[CWD]/Cargo.toml`
 
 Caused by:
-  error reading description: cannot specify { workspace = false }
+  workspace cannot be false for key `package.description`
 ",
         )
         .run();
@@ -384,6 +384,41 @@ fn error_no_root_workspace() {
 
 Caused by:
   error reading description: could not read workspace root
+",
+        )
+        .run();
+}
+
+#[cargo_test]
+fn error_badges_wrapping() {
+    registry::init();
+
+    let p = project().build();
+
+    let _ = git::repo(&paths::root().join("foo"))
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "bar"
+            version = "1.2.3"
+            authors = ["rustaceans"]
+
+            [badges]
+            gitlab = "1.2.3"
+            "#,
+        )
+        .file("src/main.rs", "fn main() {}")
+        .build();
+
+    p.cargo("build")
+        .with_status(101)
+        .with_stderr(
+            "\
+[ERROR] failed to parse manifest at `[CWD]/Cargo.toml`
+
+Caused by:
+  expected a table of badges or { workspace = true } for key `badges`
 ",
         )
         .run();

--- a/tests/testsuite/deduplicate_workspace.rs
+++ b/tests/testsuite/deduplicate_workspace.rs
@@ -24,7 +24,7 @@ fn permit_additional_workspace_fields() {
             edition = "2018"
 
             [workspace.badges]
-            gitlab = { repository = "https://gitlab.com/rust-lang/rusu", branch = "master" }
+            gitlab = { repository = "https://gitlab.com/rust-lang/rust", branch = "master" }
 
             [workspace.dependencies]
             dep1 = "0.1"
@@ -105,12 +105,17 @@ fn inherit_workspace_fields() {
             categories = ["development-tools"]
             publish = true
             edition = "2018"
+
+            [workspace.badges]
+            gitlab = { repository = "https://gitlab.com/rust-lang/rust", branch = "master" }
             "#,
         )
         .file("src/main.rs", "fn main() {}")
         .file(
             "bar/Cargo.toml",
             r#"
+            badges = { workspace = true }
+
             [package]
             name = "bar"
             workspace = ".."
@@ -139,7 +144,9 @@ fn inherit_workspace_fields() {
         r#"
         {
           "authors": ["Rustaceans"],
-          "badges": {},
+          "badges": {
+            "gitlab": { "branch": "master", "repository": "https://gitlab.com/rust-lang/rust" }
+          },
           "categories": ["development-tools"],
           "deps": [],
           "description": "This is a crate",

--- a/tests/testsuite/deduplicate_workspace.rs
+++ b/tests/testsuite/deduplicate_workspace.rs
@@ -1,0 +1,99 @@
+//! Tests for deduplicating Cargo.toml fields with { workspace = true }
+use cargo_test_support::project;
+
+#[cargo_test]
+fn permit_additional_workspace_fields() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [workspace]
+            members = ["bar"]
+            version = "1.2.3"
+            authors = ["Rustaceans"]
+            description = "This is a crate"
+            documentation = "https://www.rust-lang.org/learn"
+            readme = "README.md"
+            homepage = "https://www.rust-lang.org"
+            repository = "https://github.com/example/example"
+            license = "MIT"
+            license-file = "./LICENSE"
+            keywords = ["cli"]
+            categories = ["development-tools"]
+            publish = false
+            edition = "2018"
+
+            [workspace.badges]
+            gitlab = { repository = "https://gitlab.com/rust-lang/rusu", branch = "master" }
+
+            [workspace.dependencies]
+            dep1 = "0.1"
+        "#,
+        )
+        .file(
+            "bar/Cargo.toml",
+            r#"
+            [package]
+            name = "bar"
+            version = "0.2.0"
+            authors = []
+            workspace = ".."
+        "#,
+        )
+        .file("bar/src/main.rs", "fn main() {}")
+        .build();
+
+    p.cargo("build")
+        // Should not warn about unused fields.
+        .with_stderr(
+            "\
+[COMPILING] bar v0.2.0 ([CWD]/bar)
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+",
+        )
+        .run();
+
+    p.cargo("check").run();
+    let lockfile = p.read_lockfile();
+    assert!(!lockfile.contains("dep1"));
+}
+
+#[cargo_test]
+fn deny_optional_dependencies() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [workspace]
+            members = ["bar"]
+
+            [workspace.dependencies]
+            dep1 = { version = "0.1", optional = true }
+        "#,
+        )
+        .file("src/main.rs", "fn main() {}")
+        .file(
+            "bar/Cargo.toml",
+            r#"
+            [package]
+            name = "bar"
+            version = "0.2.0"
+            authors = []
+            workspace = ".."
+        "#,
+        )
+        .file("bar/src/main.rs", "fn main() {}")
+        .build();
+
+    p.cargo("build")
+        .with_status(101)
+        .with_stderr(
+            "\
+[ERROR] failed to parse manifest at `[..]Cargo.toml`
+
+Caused by:
+  dep1 is optional, but workspace dependencies cannot be optional
+",
+        )
+        .run();
+}

--- a/tests/testsuite/deduplicate_workspace.rs
+++ b/tests/testsuite/deduplicate_workspace.rs
@@ -85,6 +85,8 @@ Caused by:
 }
 
 #[cargo_test]
+// TODO Handle readme copying correctly.
+#[ignore]
 fn inherit_workspace_fields() {
     registry::init();
 
@@ -182,6 +184,8 @@ fn inherit_workspace_fields() {
 }
 
 #[cargo_test]
+#[ignore]
+// TODO Handle readme copying correctly.
 fn inherit_own_workspace_fields() {
     registry::init();
 

--- a/tests/testsuite/features.rs
+++ b/tests/testsuite/features.rs
@@ -54,6 +54,8 @@ fn invalid2() {
         "#,
         )
         .file("src/main.rs", "")
+        .file("foo/Cargo.toml", &basic_manifest("foo", "0.1.2"))
+        .file("foo/src/lib.rs", "")
         .build();
 
     p.cargo("build")
@@ -88,6 +90,8 @@ fn invalid3() {
         "#,
         )
         .file("src/main.rs", "")
+        .file("foo/Cargo.toml", &basic_manifest("foo", "0.1.2"))
+        .file("foo/src/lib.rs", "")
         .build();
 
     p.cargo("build")
@@ -131,7 +135,7 @@ fn invalid4() {
             "\
 error: failed to select a version for `bar`.
     ... required by package `foo v0.0.1 ([..])`
-versions that meet the requirements `*` are: 0.0.1
+versions that meet the requirements `^0.0.1` are: 0.0.1
 
 the package `foo` depends on `bar`, with features: `bar` but `bar` does not have these features.
 
@@ -165,6 +169,8 @@ fn invalid5() {
         "#,
         )
         .file("src/main.rs", "")
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.0.1"))
+        .file("bar/src/lib.rs", "")
         .build();
 
     p.cargo("build")
@@ -335,7 +341,7 @@ fn invalid10() {
     p.cargo("build").with_stderr("\
 error: failed to select a version for `bar`.
     ... required by package `foo v0.0.1 ([..])`
-versions that meet the requirements `*` are: 0.0.1
+versions that meet the requirements `^0.0.1` are: 0.0.1
 
 the package `foo` depends on `bar`, with features: `baz` but `bar` does not have these features.
  It has a required dependency with that name, but only optional dependencies can be used as features.

--- a/tests/testsuite/main.rs
+++ b/tests/testsuite/main.rs
@@ -38,6 +38,7 @@ mod cross_compile;
 mod cross_publish;
 mod custom_target;
 mod death;
+mod deduplicate_workspace;
 mod dep_info;
 mod directory;
 mod doc;

--- a/tests/testsuite/metadata.rs
+++ b/tests/testsuite/metadata.rs
@@ -1902,7 +1902,7 @@ fn deps_with_bin_only() {
         {
           "name": "bdep",
           "source": null,
-          "req": "*",
+          "req": "^0.5.0",
           "kind": null,
           "rename": null,
           "optional": false,

--- a/tests/testsuite/path.rs
+++ b/tests/testsuite/path.rs
@@ -487,8 +487,6 @@ fn nested_deps_recompile() {
 }
 
 #[cargo_test]
-// TODO Improve parse_manifest errors.
-#[ignore]
 fn error_message_for_missing_manifest() {
     let p = project()
         .file(
@@ -513,16 +511,13 @@ fn error_message_for_missing_manifest() {
         .with_status(101)
         .with_stderr(
             "\
-[ERROR] failed to get `bar` as a dependency of package `foo v0.5.0 [..]`
+[ERROR] failed to parse manifest at `[..]/foo/Cargo.toml`
 
 Caused by:
-  failed to load source for dependency `bar`
+  failed to get dependency `bar`
 
 Caused by:
-  Unable to update [CWD]/src/bar
-
-Caused by:
-  failed to read `[..]bar/Cargo.toml`
+  failed to read `[..]/bar/Cargo.toml`
 
 Caused by:
   [..] (os error [..])
@@ -1004,8 +999,6 @@ fn workspace_produces_rlib() {
 }
 
 #[cargo_test]
-// TODO Improve parse_manifest errors.
-#[ignore]
 fn deep_path_error() {
     // Test for an error loading a path deep in the dependency graph.
     let p = project()
@@ -1042,6 +1035,17 @@ fn deep_path_error() {
            "#,
         )
         .file("b/src/lib.rs", "")
+        .file(
+            "c/Cargo.toml",
+            r#"
+            [package]
+            name = "c"
+            version = "0.1.0"
+            [dependencies]
+            d = {path="../d"}
+           "#,
+        )
+        .file("c/src/lib.rs", "")
         .build();
 
     p.cargo("check")
@@ -1059,7 +1063,13 @@ Caused by:
   Unable to update [..]/foo/c
 
 Caused by:
-  failed to read `[..]/foo/c/Cargo.toml`
+  failed to parse manifest at `[..]/foo/c/Cargo.toml`
+
+Caused by:
+  failed to get dependency `d`
+
+Caused by:
+  failed to read `[..]/d/Cargo.toml`
 
 Caused by:
   [..]

--- a/tests/testsuite/path.rs
+++ b/tests/testsuite/path.rs
@@ -487,6 +487,8 @@ fn nested_deps_recompile() {
 }
 
 #[cargo_test]
+// TODO Improve parse_manifest errors.
+#[ignore]
 fn error_message_for_missing_manifest() {
     let p = project()
         .file(
@@ -1002,6 +1004,8 @@ fn workspace_produces_rlib() {
 }
 
 #[cargo_test]
+// TODO Improve parse_manifest errors.
+#[ignore]
 fn deep_path_error() {
     // Test for an error loading a path deep in the dependency graph.
     let p = project()

--- a/tests/testsuite/workspaces.rs
+++ b/tests/testsuite/workspaces.rs
@@ -2172,8 +2172,6 @@ fn ws_warn_path() {
 }
 
 #[cargo_test]
-// TODO Nicer `parse_manifest()` errors
-#[ignore]
 fn invalid_missing() {
     // Make sure errors are not suppressed with -q.
     let p = project()
@@ -2195,13 +2193,10 @@ fn invalid_missing() {
         .with_status(101)
         .with_stderr(
             "\
-[ERROR] failed to get `x` as a dependency of package `foo v0.1.0 [..]`
+[ERROR] failed to parse manifest at `[CWD]/Cargo.toml`
 
 Caused by:
-  failed to load source for dependency `x`
-
-Caused by:
-  Unable to update [..]/foo/x
+  failed to get dependency `x`
 
 Caused by:
   failed to read `[..]foo/x/Cargo.toml`

--- a/tests/testsuite/workspaces.rs
+++ b/tests/testsuite/workspaces.rs
@@ -2172,6 +2172,8 @@ fn ws_warn_path() {
 }
 
 #[cargo_test]
+// TODO Nicer `parse_manifest()` errors
+#[ignore]
 fn invalid_missing() {
     // Make sure errors are not suppressed with -q.
     let p = project()

--- a/tests/testsuite/workspaces.rs
+++ b/tests/testsuite/workspaces.rs
@@ -377,7 +377,10 @@ fn invalid_parent_pointer() {
         .with_status(101)
         .with_stderr(
             "\
-error: failed to read `[..]Cargo.toml`
+error: failed to parse manifest at `[..]Cargo.toml`
+
+Caused by:
+  [..]
 
 Caused by:
   [..]

--- a/tests/testsuite/workspaces.rs
+++ b/tests/testsuite/workspaces.rs
@@ -1,7 +1,9 @@
 //! Tests for workspaces.
 
 use cargo_test_support::registry::Package;
-use cargo_test_support::{basic_lib_manifest, basic_manifest, git, project, sleep_ms};
+use cargo_test_support::{
+    basic_lib_manifest, basic_manifest, basic_workspace_manifest, git, project, sleep_ms,
+};
 use std::env;
 use std::fs;
 
@@ -21,16 +23,7 @@ fn simple_explicit() {
         "#,
         )
         .file("src/main.rs", "fn main() {}")
-        .file(
-            "bar/Cargo.toml",
-            r#"
-            [project]
-            name = "bar"
-            version = "0.1.0"
-            authors = []
-            workspace = ".."
-        "#,
-        )
+        .file("bar/Cargo.toml", &basic_workspace_manifest("bar", ".."))
         .file("bar/src/main.rs", "fn main() {}");
     let p = p.build();
 
@@ -63,16 +56,7 @@ fn simple_explicit_default_members() {
         "#,
         )
         .file("src/main.rs", "fn main() {}")
-        .file(
-            "bar/Cargo.toml",
-            r#"
-            [project]
-            name = "bar"
-            version = "0.1.0"
-            authors = []
-            workspace = ".."
-        "#,
-        )
+        .file("bar/Cargo.toml", &basic_workspace_manifest("bar", ".."))
         .file("bar/src/main.rs", "fn main() {}");
     let p = p.build();
 
@@ -261,16 +245,7 @@ fn parent_pointer_works() {
         "#,
         )
         .file("foo/src/main.rs", "fn main() {}")
-        .file(
-            "bar/Cargo.toml",
-            r#"
-            [project]
-            name = "bar"
-            version = "0.1.0"
-            authors = []
-            workspace = "../foo"
-        "#,
-        )
+        .file("bar/Cargo.toml", &basic_workspace_manifest("bar", "../foo"))
         .file("bar/src/main.rs", "fn main() {}")
         .file("bar/src/lib.rs", "");
     let p = p.build();
@@ -297,16 +272,7 @@ fn same_names_in_workspace() {
         "#,
         )
         .file("src/main.rs", "fn main() {}")
-        .file(
-            "bar/Cargo.toml",
-            r#"
-            [project]
-            name = "foo"
-            version = "0.1.0"
-            authors = []
-            workspace = ".."
-        "#,
-        )
+        .file("bar/Cargo.toml", &basic_workspace_manifest("foo", ".."))
         .file("bar/src/main.rs", "fn main() {}");
     let p = p.build();
 
@@ -360,16 +326,7 @@ this may be fixable [..]
 #[cargo_test]
 fn invalid_parent_pointer() {
     let p = project()
-        .file(
-            "Cargo.toml",
-            r#"
-            [project]
-            name = "foo"
-            version = "0.1.0"
-            authors = []
-            workspace = "foo"
-        "#,
-        )
+        .file("Cargo.toml", &basic_workspace_manifest("foo", "foo"))
         .file("src/main.rs", "fn main() {}");
     let p = p.build();
 
@@ -486,16 +443,7 @@ error: multiple workspace roots found in the same workspace:
 #[cargo_test]
 fn workspace_isnt_root() {
     let p = project()
-        .file(
-            "Cargo.toml",
-            r#"
-            [project]
-            name = "foo"
-            version = "0.1.0"
-            authors = []
-            workspace = "bar"
-        "#,
-        )
+        .file("Cargo.toml", &basic_workspace_manifest("foo", "bar"))
         .file("src/main.rs", "fn main() {}")
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file("bar/src/main.rs", "fn main() {}");
@@ -523,27 +471,9 @@ fn dangling_member() {
         "#,
         )
         .file("src/main.rs", "fn main() {}")
-        .file(
-            "bar/Cargo.toml",
-            r#"
-            [project]
-            name = "bar"
-            version = "0.1.0"
-            authors = []
-            workspace = "../baz"
-        "#,
-        )
+        .file("bar/Cargo.toml", &basic_workspace_manifest("bar", "../baz"))
         .file("bar/src/main.rs", "fn main() {}")
-        .file(
-            "baz/Cargo.toml",
-            r#"
-            [project]
-            name = "baz"
-            version = "0.1.0"
-            authors = []
-            workspace = "../baz"
-        "#,
-        )
+        .file("baz/Cargo.toml", &basic_workspace_manifest("baz", "../baz"))
         .file("baz/src/main.rs", "fn main() {}");
     let p = p.build();
 
@@ -562,27 +492,9 @@ actual: [..]
 #[cargo_test]
 fn cycle() {
     let p = project()
-        .file(
-            "Cargo.toml",
-            r#"
-            [project]
-            name = "foo"
-            version = "0.1.0"
-            authors = []
-            workspace = "bar"
-        "#,
-        )
+        .file("Cargo.toml", &basic_workspace_manifest("foo", "bar"))
         .file("src/main.rs", "fn main() {}")
-        .file(
-            "bar/Cargo.toml",
-            r#"
-            [project]
-            name = "bar"
-            version = "0.1.0"
-            authors = []
-            workspace = ".."
-        "#,
-        )
+        .file("bar/Cargo.toml", &basic_workspace_manifest("bar", ".."))
         .file("bar/src/main.rs", "fn main() {}");
     let p = p.build();
 
@@ -1348,16 +1260,7 @@ fn relative_path_for_member_works() {
     "#,
         )
         .file("foo/src/main.rs", "fn main() {}")
-        .file(
-            "bar/Cargo.toml",
-            r#"
-        [project]
-        name = "bar"
-        version = "0.1.0"
-        authors = []
-        workspace = "../foo"
-    "#,
-        )
+        .file("bar/Cargo.toml", &basic_workspace_manifest("bar", "../foo"))
         .file("bar/src/main.rs", "fn main() {}");
     let p = p.build();
 
@@ -1459,16 +1362,7 @@ fn test_in_and_out_of_workspace() {
             "foo/src/lib.rs",
             "extern crate bar; pub fn f() { bar::f() }",
         )
-        .file(
-            "bar/Cargo.toml",
-            r#"
-            [project]
-            workspace = "../ws"
-            name = "bar"
-            version = "0.1.0"
-            authors = []
-        "#,
-        )
+        .file("bar/Cargo.toml", &basic_workspace_manifest("bar", "../ws"))
         .file("bar/src/lib.rs", "pub fn f() { }");
     let p = p.build();
 
@@ -1740,24 +1634,12 @@ fn glob_syntax() {
         .file("src/main.rs", "fn main() {}")
         .file(
             "crates/bar/Cargo.toml",
-            r#"
-            [project]
-            name = "bar"
-            version = "0.1.0"
-            authors = []
-            workspace = "../.."
-        "#,
+            &basic_workspace_manifest("bar", "../.."),
         )
         .file("crates/bar/src/main.rs", "fn main() {}")
         .file(
             "crates/baz/Cargo.toml",
-            r#"
-            [project]
-            name = "baz"
-            version = "0.1.0"
-            authors = []
-            workspace = "../.."
-        "#,
+            &basic_workspace_manifest("baz", "../.."),
         )
         .file("crates/baz/src/main.rs", "fn main() {}")
         .file(


### PR DESCRIPTION
Tracking issue: #8415 
RFC: https://github.com/rust-lang/rfcs/pull/2906

~This is not finished yet, but I think there's enough to review.~
**9/9**: I've removed the draft status. There are still some items left, but I don't think they will change the high level design.
**9/13**: I think I am blocked on the remaining tasks.

- [x] Additional fields in `[workspace]`
    - [x] Tests for additional fields
- [x] Support `{ workspace = true }` for non-dependency fields
    - [x] `impl Serialize` and `Deserialize`
    - [x] resolve fields with `WorkspaceRootConfig` before they are referenced
    - [x] add tests
    - [x] (add some more tests :sweat_smile: )
    - [x] resolve `license-file`, `readme` relative to the workspace 
    - [ ] copy readme and license file into package root when packaging (Blocked, see inline comment)
- [x] Support `{ workspace = true }` for dependencies
    - [x] add tests for dependencies
- [ ] Update `Cargo.lock` with `[workspace.dependencies]` (even if unreferenced) (Blocked, see Note 2 below)
- [x] Infer version directives
    - [x] Tests
- [x] Nicer errors when `parse_manifest()` fails - normalize paths, smarter context
- [ ] Tests to be added:
    - [x] Path dependency's version/publish are defined in its workspace.
    - [ ] Copying readme and/or license file when packaging
        - [ ] Fail when a file with the same name already exists in the root.

### Notes

0. Thanks for [the great writeup][writeup] that made this approachable even for someone new to the repository like me, and to @yaahc for helping me think through the architecture ^_^
1. `read_manifest()` needs to find the root workspace, which in turn needs to `read_manifest()`. To break this circular dependency, I added a `ManifestCache` which allows `find_workspace_root()` to do its job without parsing it all the way through. This is the biggest change in the PR.
2. When parsing a manifest, we turn it into a `DefinedTomlManifest` which is used by the rest of the app. This is where the bulk of the interesting logic lives (see [`DefinedTomlManifest::from_toml_manifest()`][from_toml_manifest])

[writeup]: https://github.com/rust-lang/cargo/issues/8415#issuecomment-669503100
[from_toml_manifest]: https://github.com/yaymukund/cargo/blob/dedup-cargo-workspaces/src/cargo/util/toml/mod.rs#L389