### PR TITLE
Remove asciidoc attribute in cargo-metadata man page.

### DIFF
--- a/src/doc/man/cargo-metadata.md
+++ b/src/doc/man/cargo-metadata.md
@@ -1,5 +1,4 @@
 # cargo-metadata(1)
-:source-highlighter: highlightjs
 
 ## NAME
 

--- a/src/doc/man/generated_txt/cargo-metadata.txt
+++ b/src/doc/man/generated_txt/cargo-metadata.txt
@@ -1,7 +1,5 @@
 CARGO-METADATA(1)
 
-:source-highlighter: highlightjs
-
 NAME
        cargo-metadata - Machine-readable metadata about the current package
 

--- a/src/doc/src/commands/cargo-metadata.md
+++ b/src/doc/src/commands/cargo-metadata.md
@@ -1,5 +1,4 @@
 # cargo-metadata(1)
-:source-highlighter: highlightjs
 
 ## NAME
 

--- a/src/etc/man/cargo-metadata.1
+++ b/src/etc/man/cargo-metadata.1
@@ -3,8 +3,6 @@
 .nh
 .ad l
 .ss \n[.ss] 0
-.sp
-:source\-highlighter: highlightjs
 .SH "NAME"
 cargo\-metadata \- Machine\-readable metadata about the current package
 .SH "SYNOPSIS"


### PR DESCRIPTION
I accidentally left this behind during #8577.