### PR TITLE
Fixed the fossil repo initialization actually run commands

### DIFF
--- a/src/cargo/util/vcs.rs
+++ b/src/cargo/util/vcs.rs
@@ -91,12 +91,16 @@ impl FossilRepo {
             .cwd(cwd)
             .arg("settings")
             .arg("ignore-glob")
-            .arg("target");
+            .arg("target")
+            .exec()?;
+
         process("fossil")
             .cwd(cwd)
             .arg("settings")
             .arg("clean-glob")
-            .arg("target");
+            .arg("target")
+            .exec()?;
+
         Ok(FossilRepo)
     }
 }


### PR DESCRIPTION
I noticed that when using fossil cargo new would not ignore the target directory and that the commands to do so weren't being executed. I wasn't sure if opening an issue was needed as the fix is extremely simple, if an issue is needed I can create one.