### PR TITLE
Add --name suggestion for cargo new

### DIFF
--- a/src/cargo/ops/cargo_new.rs
+++ b/src/cargo/ops/cargo_new.rs
@@ -154,7 +154,19 @@ fn get_name<'a>(path: &'a Path, opts: &'a NewOptions) -> CargoResult<&'a str> {
     })
 }
 
-fn check_name(name: &str, name_help: &str, has_bin: bool, shell: &mut Shell) -> CargoResult<()> {
+fn check_name(
+    name: &str,
+    show_name_help: bool,
+    has_bin: bool,
+    shell: &mut Shell,
+) -> CargoResult<()> {
+    // If --name is already used to override, no point in suggesting it
+    // again as a fix.
+    let name_help = if show_name_help {
+        "\nuse --name to override crate name"
+    } else {
+        ""
+    };
     restricted_names::validate_package_name(name, "crate name", name_help)?;
 
     if restricted_names::is_keyword(name) {
@@ -363,7 +375,12 @@ pub fn new(opts: &NewOptions, config: &Config) -> CargoResult<()> {
     }
 
     let name = get_name(path, opts)?;
-    check_name(name, "", opts.kind.is_bin(), &mut config.shell())?;
+    check_name(
+        name,
+        opts.name.is_none(),
+        opts.kind.is_bin(),
+        &mut config.shell(),
+    )?;
 
     let mkopts = MkOptions {
         version_control: opts.version_control,
@@ -411,13 +428,7 @@ pub fn init(opts: &NewOptions, config: &Config) -> CargoResult<()> {
         // user may mean "initialize for library, but also add binary target"
     }
     let has_bin = src_paths_types.iter().any(|x| x.bin);
-    // If --name is already used to override, no point in suggesting it
-    // again as a fix.
-    let name_help = match opts.name {
-        Some(_) => "",
-        None => "\nuse --name to override crate name",
-    };
-    check_name(name, name_help, has_bin, &mut config.shell())?;
+    check_name(name, opts.name.is_none(), has_bin, &mut config.shell())?;
 
     let mut version_control = opts.version_control;
 

--- a/src/cargo/ops/cargo_new.rs
+++ b/src/cargo/ops/cargo_new.rs
@@ -163,7 +163,7 @@ fn check_name(
     // If --name is already used to override, no point in suggesting it
     // again as a fix.
     let name_help = if show_name_help {
-        "\nuse --name to override crate name"
+        "\nIf you need a crate name to not match the directory name, consider using --name flag."
     } else {
         ""
     };

--- a/tests/testsuite/init.rs
+++ b/tests/testsuite/init.rs
@@ -305,7 +305,8 @@ fn invalid_dir_name() {
         .with_stderr(
             "\
 [ERROR] invalid character `.` in crate name: `foo.bar`, [..]
-use --name to override crate name",
+If you need a crate name to not match the directory name, consider using --name flag.
+",
         )
         .run();
 
@@ -323,7 +324,7 @@ fn reserved_name() {
         .with_stderr(
             "\
 [ERROR] the name `test` cannot be used as a crate name, it conflicts [..]\n\
-use --name to override crate name
+If you need a crate name to not match the directory name, consider using --name flag.
 ",
         )
         .run();

--- a/tests/testsuite/new.rs
+++ b/tests/testsuite/new.rs
@@ -543,8 +543,7 @@ fn restricted_windows_name() {
             .with_stderr(
                 "\
 [ERROR] cannot use name `nul`, it is a reserved Windows filename
-If you need a crate name to not match the directory name, consider using --name fla
-g.
+If you need a crate name to not match the directory name, consider using --name flag.
 ",
             )
             .run();

--- a/tests/testsuite/new.rs
+++ b/tests/testsuite/new.rs
@@ -119,7 +119,8 @@ fn invalid_characters() {
         .with_stderr(
             "\
 [ERROR] invalid character `.` in crate name: `foo.rs`, [..]
-use --name to override crate name",
+If you need a crate name to not match the directory name, consider using --name flag.
+",
         )
         .run();
 }
@@ -131,7 +132,8 @@ fn reserved_name() {
         .with_stderr(
             "\
 [ERROR] the name `test` cannot be used as a crate name, it conflicts [..]
-use --name to override crate name",
+If you need a crate name to not match the directory name, consider using --name flag.
+",
         )
         .run();
 }
@@ -143,7 +145,8 @@ fn reserved_binary_name() {
         .with_stderr(
             "\
 [ERROR] the name `incremental` cannot be used as a crate name, it conflicts [..]
-use --name to override crate name",
+If you need a crate name to not match the directory name, consider using --name flag.
+",
         )
         .run();
 
@@ -166,7 +169,8 @@ fn keyword_name() {
         .with_stderr(
             "\
 [ERROR] the name `pub` cannot be used as a crate name, it is a Rust keyword
-use --name to override crate name",
+If you need a crate name to not match the directory name, consider using --name flag.
+",
         )
         .run();
 }
@@ -539,7 +543,9 @@ fn restricted_windows_name() {
             .with_stderr(
                 "\
 [ERROR] cannot use name `nul`, it is a reserved Windows filename
-use --name to override crate name",
+If you need a crate name to not match the directory name, consider using --name fla
+g.
+",
             )
             .run();
     } else {
@@ -580,7 +586,8 @@ fn non_ascii_name_invalid() {
             "\
 [ERROR] invalid character `Ⓐ` in crate name: `ⒶⒷⒸ`, \
 the first character must be a Unicode XID start character (most letters or `_`)
-use --name to override crate name",
+If you need a crate name to not match the directory name, consider using --name flag.
+",
         )
         .run();
 
@@ -591,7 +598,8 @@ use --name to override crate name",
             "\
 [ERROR] invalid character `¼` in crate name: `a¼`, \
 characters must be Unicode XID characters (numbers, `-`, `_`, or most letters)
-use --name to override crate name",
+If you need a crate name to not match the directory name, consider using --name flag.
+",
         )
         .run();
 }

--- a/tests/testsuite/new.rs
+++ b/tests/testsuite/new.rs
@@ -116,7 +116,11 @@ fn existing() {
 fn invalid_characters() {
     cargo_process("new foo.rs")
         .with_status(101)
-        .with_stderr("[ERROR] invalid character `.` in crate name: `foo.rs`, [..]")
+        .with_stderr(
+            "\
+[ERROR] invalid character `.` in crate name: `foo.rs`, [..]
+use --name to override crate name",
+        )
         .run();
 }
 
@@ -124,7 +128,11 @@ fn invalid_characters() {
 fn reserved_name() {
     cargo_process("new test")
         .with_status(101)
-        .with_stderr("[ERROR] the name `test` cannot be used as a crate name, it conflicts [..]")
+        .with_stderr(
+            "\
+[ERROR] the name `test` cannot be used as a crate name, it conflicts [..]
+use --name to override crate name",
+        )
         .run();
 }
 
@@ -133,7 +141,9 @@ fn reserved_binary_name() {
     cargo_process("new --bin incremental")
         .with_status(101)
         .with_stderr(
-            "[ERROR] the name `incremental` cannot be used as a crate name, it conflicts [..]",
+            "\
+[ERROR] the name `incremental` cannot be used as a crate name, it conflicts [..]
+use --name to override crate name",
         )
         .run();
 
@@ -153,7 +163,11 @@ it conflicts with cargo's build directory names
 fn keyword_name() {
     cargo_process("new pub")
         .with_status(101)
-        .with_stderr("[ERROR] the name `pub` cannot be used as a crate name, it is a Rust keyword")
+        .with_stderr(
+            "\
+[ERROR] the name `pub` cannot be used as a crate name, it is a Rust keyword
+use --name to override crate name",
+        )
         .run();
 }
 
@@ -559,8 +573,10 @@ fn non_ascii_name_invalid() {
         .env("USER", "foo")
         .with_status(101)
         .with_stderr(
-            "[ERROR] invalid character `Ⓐ` in crate name: `ⒶⒷⒸ`, \
-            the first character must be a Unicode XID start character (most letters or `_`)",
+            "\
+[ERROR] invalid character `Ⓐ` in crate name: `ⒶⒷⒸ`, \
+the first character must be a Unicode XID start character (most letters or `_`)
+use --name to override crate name",
         )
         .run();
 
@@ -568,8 +584,10 @@ fn non_ascii_name_invalid() {
         .env("USER", "foo")
         .with_status(101)
         .with_stderr(
-            "[ERROR] invalid character `¼` in crate name: `a¼`, \
-            characters must be Unicode XID characters (numbers, `-`, `_`, or most letters)",
+            "\
+[ERROR] invalid character `¼` in crate name: `a¼`, \
+characters must be Unicode XID characters (numbers, `-`, `_`, or most letters)
+use --name to override crate name",
         )
         .run();
 }

--- a/tests/testsuite/new.rs
+++ b/tests/testsuite/new.rs
@@ -536,7 +536,11 @@ fn restricted_windows_name() {
         cargo_process("new nul")
             .env("USER", "foo")
             .with_status(101)
-            .with_stderr("[ERROR] cannot use name `nul`, it is a reserved Windows filename")
+            .with_stderr(
+                "\
+[ERROR] cannot use name `nul`, it is a reserved Windows filename
+use --name to override crate name",
+            )
             .run();
     } else {
         cargo_process("new nul")


### PR DESCRIPTION
Resolves #8613 

Since `check_name` have already got a parameter to show name help, I reuse the logic and sync the behavior between `cargo init` and `cargo new`. The divergence seems to be intentionally made in #7959: 

_...Only print the --name suggestion for `cargo init`._ 

Feel free to discuss.