### PR TITLE
Fix nightly exported_priv_warning test.

### DIFF
--- a/tests/testsuite/pub_priv.rs
+++ b/tests/testsuite/pub_priv.rs
@@ -39,8 +39,8 @@ fn exported_priv_warning() {
         .masquerade_as_nightly_cargo()
         .with_stderr_contains(
             "\
-src/lib.rs:3:13: warning: type `priv_dep::FromPriv` from private dependency 'priv_dep' in public interface
-"
+src/lib.rs:3:13: warning: type `[..]FromPriv` from private dependency 'priv_dep' in public interface
+",
         )
         .run()
 }


### PR DESCRIPTION
Error messages have slightly changed due to https://github.com/rust-lang/rust/pull/73996 to not include the full path.  I used a `[..]` match just in case anyone is still using a slightly older nightly, or if it changes again in the future.
