### PR TITLE
Sweep unrelated message from unnecessary workspace infromation

### DIFF
--- a/src/bin/cargo/commands/install.rs
+++ b/src/bin/cargo/commands/install.rs
@@ -75,13 +75,16 @@ pub fn cli() -> App {
 }
 
 pub fn exec(config: &mut Config, args: &ArgMatches<'_>) -> CliResult {
+    let workspace;
     if let Some(path) = args.value_of_path("path", config) {
         config.reload_rooted_at(path)?;
+        // Only provide worksapce information for local crate installation
+        workspace = args.workspace(config).ok();
     } else {
         config.reload_rooted_at(config.home().clone().into_path_unlocked())?;
+        workspace = None;
     }
 
-    let workspace = args.workspace(config).ok();
     let mut compile_opts = args.compile_options(
         config,
         CompileMode::Build,

--- a/tests/testsuite/install.rs
+++ b/tests/testsuite/install.rs
@@ -1587,3 +1587,57 @@ fn install_yanked_cargo_package() {
         )
         .run();
 }
+
+#[cargo_test]
+fn install_cargo_package_in_a_patched_workspace() {
+    pkg("foo", "0.1.0");
+    pkg("fizz", "1.0.0");
+
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "bar"
+            version = "0.1.0"
+            authors = []
+
+            [workspace]
+            members = ["baz"]
+        "#,
+        )
+        .file("src/main.rs", "fn main() {}")
+        .file(
+            "baz/Cargo.toml",
+            r#"
+            [package]
+            name = "baz"
+            version = "0.1.0"
+            authors = []
+
+            [dependencies]
+            fizz = "1"
+
+            [patch.crates-io]
+            fizz = { version = "=1.0.0" }
+        "#,
+        )
+        .file("baz/src/lib.rs", "")
+        .build();
+
+    let stderr = "\
+[WARNING] patch for the non root package will be ignored, specify patch at the workspace root:
+package:   [..]/foo/baz/Cargo.toml
+workspace: [..]/foo/Cargo.toml
+";
+    p.cargo("check")
+        .with_stderr_contains(&stderr)
+        .run();
+
+    // A crate installation must not emit any message from a workspace under
+    // current working directory.
+    // See https://github.com/rust-lang/cargo/issues/8619
+    p.cargo("install foo")
+        .with_stderr_does_not_contain(&stderr)
+        .run();
+}

--- a/tests/testsuite/install.rs
+++ b/tests/testsuite/install.rs
@@ -1636,6 +1636,19 @@ workspace: [..]/foo/Cargo.toml
     // current working directory.
     // See https://github.com/rust-lang/cargo/issues/8619
     p.cargo("install foo")
-        .with_stderr_does_not_contain(&stderr)
+        .with_stderr(
+            "\
+[UPDATING] `[..]` index
+[DOWNLOADING] crates ...
+[DOWNLOADED] foo v0.1.0 (registry [..])
+[INSTALLING] foo v0.1.0
+[COMPILING] foo v0.1.0
+[FINISHED] release [optimized] target(s) in [..]
+[INSTALLING] [..]foo[EXE]
+[INSTALLED] package `foo v0.1.0` (executable `foo[EXE]`)
+[WARNING] be sure to add `[..]` to your PATH to be able to run the installed binaries
+",
+        )
         .run();
+    assert_has_installed_exe(cargo_home(), "foo");
 }

--- a/tests/testsuite/install.rs
+++ b/tests/testsuite/install.rs
@@ -1630,9 +1630,7 @@ fn install_cargo_package_in_a_patched_workspace() {
 package:   [..]/foo/baz/Cargo.toml
 workspace: [..]/foo/Cargo.toml
 ";
-    p.cargo("check")
-        .with_stderr_contains(&stderr)
-        .run();
+    p.cargo("check").with_stderr_contains(&stderr).run();
 
     // A crate installation must not emit any message from a workspace under
     // current working directory.


### PR DESCRIPTION
Resolves #8619 

Only pass workspace information when the source is from a local crate installation.