### PR TITLE
Allow running build-man.sh from any directory

### DIFF
--- a/src/doc/build-man.sh
+++ b/src/doc/build-man.sh
@@ -12,6 +12,8 @@
 
 set -e
 
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
 OPTIONS="--url https://doc.rust-lang.org/cargo/commands/ \
     --man rustc:1=https://doc.rust-lang.org/rustc/index.html \
     --man rustdoc:1=https://doc.rust-lang.org/rustdoc/index.html"


### PR DESCRIPTION
Before:

```console
$ src/doc/build-man.sh
error: manifest path `../../crates/mdman/Cargo.toml` does not exist
```

After: works.