### PR TITLE
Fix non-determinism with new feature resolver.

### DIFF
--- a/src/cargo/core/compiler/build_context/target_info.rs
+++ b/src/cargo/core/compiler/build_context/target_info.rs
@@ -683,6 +683,17 @@ impl RustcTargetData {
             }
         }
 
+        // This is a hack. The unit_dependency graph builder "pretends" that
+        // `CompileKind::Host` is `CompileKind::Target(host)` if the
+        // `--target` flag is not specified. Since the unit_dependency code
+        // needs access to the target config data, create a copy so that it
+        // can be found. See `rebuild_unit_graph_shared` for why this is done.
+        if requested_kinds.iter().any(CompileKind::is_host) {
+            let ct = CompileTarget::new(&rustc.host)?;
+            target_info.insert(ct, host_info.clone());
+            target_config.insert(ct, host_config.clone());
+        }
+
         Ok(RustcTargetData {
             rustc,
             target_config,

--- a/src/cargo/core/compiler/standard_lib.rs
+++ b/src/cargo/core/compiler/standard_lib.rs
@@ -179,6 +179,7 @@ pub fn generate_std_roots(
                 mode,
                 features.clone(),
                 /*is_std*/ true,
+                /*dep_hash*/ 0,
             ));
         }
     }

--- a/src/cargo/core/compiler/unit_dependencies.rs
+++ b/src/cargo/core/compiler/unit_dependencies.rs
@@ -612,7 +612,7 @@ fn new_unit_dep_with_profile(
     let features = state.activated_features(pkg.package_id(), features_for);
     let unit = state
         .interner
-        .intern(pkg, target, profile, kind, mode, features, state.is_std);
+        .intern(pkg, target, profile, kind, mode, features, state.is_std, 0);
     Ok(UnitDep {
         unit,
         unit_for,

--- a/src/cargo/core/compiler/unit_graph.rs
+++ b/src/cargo/core/compiler/unit_graph.rs
@@ -16,7 +16,7 @@ pub struct UnitDep {
     /// The dependency unit.
     pub unit: Unit,
     /// The purpose of this dependency (a dependency for a test, or a build
-    /// script, etc.).
+    /// script, etc.). Do not use this after the unit graph has been built.
     pub unit_for: UnitFor,
     /// The name the parent uses to refer to this dependency.
     pub extern_crate_name: InternedString,

--- a/src/cargo/util/config/mod.rs
+++ b/src/cargo/util/config/mod.rs
@@ -1788,7 +1788,7 @@ pub struct CargoBuildConfig {
 /// a = 'a b c'
 /// b = ['a', 'b', 'c']
 /// ```
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone)]
 pub struct StringList(Vec<String>);
 
 impl StringList {

--- a/src/cargo/util/config/target.rs
+++ b/src/cargo/util/config/target.rs
@@ -20,7 +20,7 @@ pub struct TargetCfgConfig {
 }
 
 /// Config definition of a `[target]` table.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct TargetConfig {
     /// Process to run as a wrapper for `cargo run`, `test`, and `bench` commands.
     pub runner: OptValue<PathAndArgs>,


### PR DESCRIPTION
This fixes a problem where Cargo was getting confused when two units were identical, but linked to different dependencies. Cargo generally assumes `Unit` is unique, but the new feature resolver can introduce a situation where two identical `Unit`s need to link to different dependencies. In particular, when building without the `--target` flag, the difference between a host unit and a target unit is not captured in the `Unit` structure. A dependency shared between normal dependencies and build dependencies can need to link to a second shared dependency whose features may be different.

The solution here is to build the unit graph pretending that `--target` was specified. Then, after the graph has been built, a second pass replaces `CompileKind::Target(host)` with `CompileKind::Host`, and adds a hash of the dependencies to the `Unit` to ensure it stays unique when necessary. This is done to ensure that dependencies are shared if possible.

I did a little performance testing, and I couldn't measure an appreciable difference. I also ran the tests in a loop for a few hours without problems.

An alternate solution here is to assume `--target=host` if `--target` isn't specified, and then have some kind of backwards-compatible linking in the `target` directory to retain the old directory layout. However, this would result in building shared host/normal dependencies twice. For *most* projects, this isn't a problem. This already happens when `--target` is specified, or `--release` is used (due to #8500). I'm just being very cautious because in a few projects this can be a large increase in build times. Maybe some day in the future we can be more bold and force this division, but I'm a little hesitant to make that jump.

Fixes #8549
