### PR TITLE
Set CARGO_TARGET_DIR for build scripts

### DIFF
--- a/src/cargo/core/compiler/custom_build.rs
+++ b/src/cargo/core/compiler/custom_build.rs
@@ -181,6 +181,10 @@ fn build_work(cx: &mut Context<'_, '_>, unit: &Unit) -> CargoResult<Job> {
     let debug = unit.profile.debuginfo.unwrap_or(0) != 0;
     cmd.env("OUT_DIR", &script_out_dir)
         .env("CARGO_MANIFEST_DIR", unit.pkg.root())
+        .env(
+            "CARGO_TARGET_DIR",
+            cx.bcx.ws.target_dir().as_path_unlocked(),
+        )
         .env("NUM_JOBS", &bcx.jobs().to_string())
         .env("TARGET", bcx.target_data.short_name(&unit.kind))
         .env("DEBUG", debug.to_string())

--- a/src/doc/src/reference/environment-variables.md
+++ b/src/doc/src/reference/environment-variables.md
@@ -275,6 +275,12 @@ let out_dir = env::var("OUT_DIR").unwrap();
 * `OUT_DIR` — the folder in which all output should be placed. This folder is
               inside the build directory for the package being built, and it is
               unique for the package in question.
+* `CARGO_TARGET_DIR` — Directory where Cargo is placing all generated artifacts.
+                       Erased by `cargo clean`. *Warning: The directory
+                       structure inside is owned by Cargo and private, so any
+                       build script reliant on poking around in the target
+                       directory may be incompatible with a future Cargo
+                       version.*
 * `TARGET` — the target triple that is being compiled for. Native code should be
              compiled for this triple. See the [Target Triple] description
              for more information.

--- a/tests/testsuite/build_script.rs
+++ b/tests/testsuite/build_script.rs
@@ -99,8 +99,12 @@ fn custom_build_env_vars() {
                 let debug = env::var("DEBUG").unwrap();
                 assert_eq!(debug, "true");
 
+                let target_dir = env::var("CARGO_TARGET_DIR").unwrap();
+                assert_eq!(target_dir, "{target_dir}");
+                assert!(Path::new(&target_dir).is_dir());
+
                 let out = env::var("OUT_DIR").unwrap();
-                assert!(out.starts_with(r"{0}"));
+                assert!(out.starts_with(r"{out_dir_prefix}"));
                 assert!(Path::new(&out).is_dir());
 
                 let _host = env::var("HOST").unwrap();
@@ -118,11 +122,13 @@ fn custom_build_env_vars() {
                 assert!(env::var("RUSTC_LINKER").is_err());
             }}
         "#,
-        p.root()
+        target_dir = p.root().join("target").display(),
+        out_dir_prefix = p
+            .root()
             .join("target")
             .join("debug")
             .join("build")
-            .display()
+            .display(),
     );
 
     let p = p.file("bar/build.rs", &file_content).build();

--- a/tests/testsuite/build_script.rs
+++ b/tests/testsuite/build_script.rs
@@ -137,6 +137,31 @@ fn custom_build_env_vars() {
 }
 
 #[cargo_test]
+fn custom_build_target_dir() {
+    let p = project();
+
+    let build_rs = format!(
+        r#"
+            use std::env;
+            use std::path::Path;
+
+            fn main() {{
+                let target_dir = env::var("CARGO_TARGET_DIR").unwrap();
+                assert_eq!(target_dir, "{target_dir}");
+                assert!(Path::new(&target_dir).is_dir());
+            }}
+        "#,
+        target_dir = p.root().join("custom").join("target").display(),
+    );
+
+    p.file("src/main.rs", "fn main() {}")
+        .file("build.rs", &build_rs)
+        .build()
+        .cargo("build --target-dir custom/target")
+        .run();
+}
+
+#[cargo_test]
 fn custom_build_env_var_rustc_linker() {
     if cross_compile::disabled() {
         return;

--- a/tests/testsuite/build_script.rs
+++ b/tests/testsuite/build_script.rs
@@ -100,7 +100,7 @@ fn custom_build_env_vars() {
                 assert_eq!(debug, "true");
 
                 let target_dir = env::var("CARGO_TARGET_DIR").unwrap();
-                assert_eq!(target_dir, "{target_dir}");
+                assert_eq!(target_dir, r"{target_dir}");
                 assert!(Path::new(&target_dir).is_dir());
 
                 let out = env::var("OUT_DIR").unwrap();
@@ -147,11 +147,11 @@ fn custom_build_target_dir() {
 
             fn main() {{
                 let target_dir = env::var("CARGO_TARGET_DIR").unwrap();
-                assert_eq!(target_dir, "{target_dir}");
+                assert_eq!(target_dir, r"{target_dir}");
                 assert!(Path::new(&target_dir).is_dir());
             }}
         "#,
-        target_dir = p.root().join("custom").join("target").display(),
+        target_dir = p.root().join("custom/target").display(),
     );
 
     p.file("src/main.rs", "fn main() {}")


### PR DESCRIPTION
In public GitHub repos one can find almost infinite creative and awful ways that crates try to guess the Cargo target dir.

- [The old way, which "didn't work for workspaces", and the new way, which "doesn't work for doc-tests"](https://github.com/robyoung/dicom-test-files/commit/e5490df7c30c59c608a35456efe25077ca30d801)
- The `$manifest_dir/target` way, which does not work when built with `--target-dir` or when building as a dependency of a different crate
    - https://github.com/rust-lang/rust-clippy/blob/5af88e3c2d8cc4fb74a0e455381669930ee3a31a/tests/integration.rs#L30-L32
    - https://github.com/rust-lang/rust/blob/f3c923a13a458c35ee26b3513533fce8a15c9c05/src/tools/clippy/src/main.rs#L135-L143
    - https://github.com/cmyr/cargo-instruments/blob/27f62c0c6e6359bd8293e2697f4aabfd60d5b93e/src/instruments.rs#L119-L128
    - https://github.com/swc-project/swc/blob/24c597f097235c9756a5d8d6e1e2bdf76b3261cb/testing/src/paths.rs#L4-L19
    - https://github.com/cloudflare/quiche/blob/72a2fe96d2610d8da889713f1ce71ba3d4c1150e/src/build.rs#L170-L172
- The `cargo metadata | jq .target_directory` way, which does not work when built with `--target-dir`
    - https://github.com/gnzlbg/cargo-asm/blob/577f890ebd4a09c8265710261e976fe7bfce8668/src/target.rs#L157-L169
- The `$out_dir/../../..` way, which is an assumption about how deeply nested Cargo's placement of out dirs will be in the future
    - https://github.com/budziq/rust-skeptic/blob/e271ea6acdc61fc2102af98e0415b09b539ca9af/src/skeptic/lib.rs#L783-L795
- The `$current_dir/target` way, which does not work when built with `--target-dir` or as a dependency
    - https://github.com/zombodb/pgx/blob/454eddf22d9d6e746b52698f829381170239f73f/pgx-utils/src/lib.rs#L154-L163
- The `$manifest_dir/../target` way, as above but hardcoding this crate's placement in its workspace
    - https://github.com/anp/moxie/blob/07638e7b9785a94216f9fdeb38ab585ca6806173/ofl/src/main.rs#L19-L22 + https://github.com/anp/moxie/blob/07638e7b9785a94216f9fdeb38ab585ca6806173/ofl/src/coverage.rs#L104
- The way that involves trying to parse `.cargo/config` and `.cargo/config.toml` before falling back to one of the previous
    - https://github.com/tauri-apps/tauri/blob/e760331fa1c93dde1465308cf42abe17a80a231e/cli/tauri-bundler/src/bundle/settings.rs#L464-L492
- The `$current_exe/../..` way
    - https://github.com/conradkleinespel/rpassword/blob/c786de157b15ea326c5e21f6270b0b5ca1e498f9/tests/piped.rs#L9-L16
    - https://github.com/denoland/deno/blob/d245ececb6c3eed9d6a01b877cfbbf7642454fc3/test_util/src/lib.rs#L75-L80
- The <code>$current_exe/../../<i>conditional</i> ..</code> way
    - https://github.com/rust-lang/cargo/blob/e4b65bdc80f2a293447f2f6a808fa7c84bf9a357/crates/cargo-test-support/src/paths.rs#L18-L29

Now, it's likely many of these should not be trying to poke around in the target dir in the first place, but the fact remains that there are motivating reasons for wanting to. For example, to perform some work once that will be shared/available to multiple crates' build scripts to avoid repeating the same work in each -- https://github.com/dtolnay/scratch supports this use case but it involves crates writing into a different crate's OUT_DIR, which is even more of a hack than just using a well-namespaced subdirectory of the target dir.

This PR adds an environment variable CARGO_TARGET_DIR set by Cargo for build scripts to inform them of Cargo's placement of the target dir. This provides the correct value even when your build was invoked with `--target-dir` or when the build script is for a crate that is not the build root so $manifest_dir/target would not be a good guess.