### PR TITLE
Drop current_exe pop hack in favor of CARGO_TARGET_DIR

### DIFF
--- a/crates/cargo-test-support/build.rs
+++ b/crates/cargo-test-support/build.rs
@@ -1,0 +1,18 @@
+use std::env;
+use std::fs;
+use std::path::Path;
+
+static CARGO_INTEGRATION_TEST_DIR: &str = "cit";
+
+fn main() {
+    let target_dir = env::var_os("CARGO_TARGET_DIR").unwrap();
+    let test_dir = Path::new(&target_dir).join(CARGO_INTEGRATION_TEST_DIR);
+    if let Err(e) = fs::create_dir_all(&test_dir) {
+        panic!(
+            "failed to create directory for integration tests ({}): {}",
+            test_dir.display(),
+            e,
+        );
+    }
+    println!("cargo:rustc-env=GLOBAL_ROOT={}", test_dir.display());
+}

--- a/crates/cargo-test-support/src/paths.rs
+++ b/crates/cargo-test-support/src/paths.rs
@@ -11,28 +11,7 @@ use std::process::Command;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Mutex;
 
-static CARGO_INTEGRATION_TEST_DIR: &str = "cit";
-
 lazy_static! {
-    static ref GLOBAL_ROOT: PathBuf = {
-        let mut path = t!(env::current_exe());
-        path.pop(); // chop off exe name
-        path.pop(); // chop off 'debug'
-
-        // If `cargo test` is run manually then our path looks like
-        // `target/debug/foo`, in which case our `path` is already pointing at
-        // `target`. If, however, `cargo test --target $target` is used then the
-        // output is `target/$target/debug/foo`, so our path is pointing at
-        // `target/$target`. Here we conditionally pop the `$target` name.
-        if path.file_name().and_then(|s| s.to_str()) != Some("target") {
-            path.pop();
-        }
-
-        path.push(CARGO_INTEGRATION_TEST_DIR);
-        path.mkdir_p();
-        path
-    };
-
     static ref TEST_ROOTS: Mutex<HashMap<String, PathBuf>> = Default::default();
 }
 
@@ -80,7 +59,7 @@ pub fn root() -> PathBuf {
              order to be able to use the crate root.",
         )
     });
-    GLOBAL_ROOT.join(&format!("t{}", id))
+    Path::new(env!("GLOBAL_ROOT")).join(format!("t{}", id))
 }
 
 pub fn home() -> PathBuf {


### PR DESCRIPTION
Depends on #8710 being included into the cargo with which the test suite is built. (I'm not sure exactly how this happens but I am guessing it would be after the next rustc release is out.)

Tested with:

```console
$ cargo build --release
$ target/release/cargo test
```