### PR TITLE
--workspace flag for locate-project to find the workspace root

### DIFF
--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -315,21 +315,20 @@ impl<'cfg> Workspace<'cfg> {
     /// That is, this returns the path of the directory containing the
     /// `Cargo.toml` which is the root of this workspace.
     pub fn root(&self) -> &Path {
-        match self.root_manifest {
-            Some(ref p) => p,
-            None => &self.current_manifest,
-        }
-        .parent()
-        .unwrap()
+        self.root_manifest().parent().unwrap()
+    }
+
+    /// Returns the path of the `Cargo.toml` which is the root of this
+    /// workspace.
+    pub fn root_manifest(&self) -> &Path {
+        self.root_manifest
+            .as_ref()
+            .unwrap_or(&self.current_manifest)
     }
 
     /// Returns the root Package or VirtualManifest.
     fn root_maybe(&self) -> &MaybePackage {
-        let root = self
-            .root_manifest
-            .as_ref()
-            .unwrap_or(&self.current_manifest);
-        self.packages.get(root)
+        self.packages.get(self.root_manifest())
     }
 
     pub fn target_dir(&self) -> Filesystem {

--- a/src/doc/man/cargo-locate-project.md
+++ b/src/doc/man/cargo-locate-project.md
@@ -13,10 +13,16 @@ cargo-locate-project - Print a JSON representation of a Cargo.toml file's locati
 This command will print a JSON object to stdout with the full path to the
 `Cargo.toml` manifest.
 
-See also {{man "cargo-metadata" 1}} which is capable of returning the path to a
-workspace root.
-
 ## OPTIONS
+
+{{#options}}
+
+{{#option "`--workspace`" }}
+Locate the `Cargo.toml` at the root of the workspace, as opposed to the current
+workspace member.
+{{/option}}
+
+{{/options}}
 
 ### Display Options
 

--- a/src/doc/man/generated_txt/cargo-locate-project.txt
+++ b/src/doc/man/generated_txt/cargo-locate-project.txt
@@ -11,10 +11,11 @@ DESCRIPTION
        This command will print a JSON object to stdout with the full path to
        the Cargo.toml manifest.
 
-       See also cargo-metadata(1) which is capable of returning the path to a
-       workspace root.
-
 OPTIONS
+       --workspace
+           Locate the Cargo.toml at the root of the workspace, as opposed to
+           the current workspace member.
+
    Display Options
        --message-format fmt
            The representation in which to print the project location. Valid

--- a/src/doc/src/commands/cargo-locate-project.md
+++ b/src/doc/src/commands/cargo-locate-project.md
@@ -13,10 +13,16 @@ cargo-locate-project - Print a JSON representation of a Cargo.toml file's locati
 This command will print a JSON object to stdout with the full path to the
 `Cargo.toml` manifest.
 
-See also [cargo-metadata(1)](cargo-metadata.md) which is capable of returning the path to a
-workspace root.
-
 ## OPTIONS
+
+<dl>
+
+<dt class="option-term" id="option-cargo-locate-project---workspace"><a class="option-anchor" href="#option-cargo-locate-project---workspace"></a><code>--workspace</code></dt>
+<dd class="option-desc">Locate the <code>Cargo.toml</code> at the root of the workspace, as opposed to the current
+workspace member.</dd>
+
+
+</dl>
 
 ### Display Options
 

--- a/src/etc/_cargo
+++ b/src/etc/_cargo
@@ -162,6 +162,7 @@ _cargo() {
                 locate-project)
                     _arguments -s -S $common $manifest \
                         '--message-format=[specify output representation]:output representation [json]:(json plain)'
+                        '--workspace[locate Cargo.toml of the workspace root]'
                         ;;
 
                 login)

--- a/src/etc/cargo.bashcomp.sh
+++ b/src/etc/cargo.bashcomp.sh
@@ -59,7 +59,7 @@ _cargo()
 	local opt__help="$opt_help"
 	local opt__init="$opt_common $opt_lock --bin --lib --name --vcs --edition --registry"
 	local opt__install="$opt_common $opt_feat $opt_jobs $opt_lock $opt_force --bin --bins --branch --debug --example --examples --git --list --path --rev --root --tag --version --registry --target --profile --no-track"
-	local opt__locate_project="$opt_common $opt_mani $opt_lock --message-format"
+	local opt__locate_project="$opt_common $opt_mani $opt_lock --message-format --workspace"
 	local opt__login="$opt_common $opt_lock --registry"
 	local opt__metadata="$opt_common $opt_feat $opt_mani $opt_lock --format-version=1 --no-deps --filter-platform"
 	local opt__new="$opt_common $opt_lock --vcs --bin --lib --name --edition --registry"

--- a/src/etc/man/cargo-locate-project.1
+++ b/src/etc/man/cargo-locate-project.1
@@ -10,10 +10,13 @@ cargo\-locate\-project \- Print a JSON representation of a Cargo.toml file's loc
 .SH "DESCRIPTION"
 This command will print a JSON object to stdout with the full path to the
 \fBCargo.toml\fR manifest.
-.sp
-See also \fBcargo\-metadata\fR(1) which is capable of returning the path to a
-workspace root.
 .SH "OPTIONS"
+.sp
+\fB\-\-workspace\fR
+.RS 4
+Locate the \fBCargo.toml\fR at the root of the workspace, as opposed to the current
+workspace member.
+.RE
 .SS "Display Options"
 .sp
 \fB\-\-message\-format\fR \fIfmt\fR

--- a/tests/testsuite/locate_project.rs
+++ b/tests/testsuite/locate_project.rs
@@ -34,3 +34,55 @@ fn message_format() {
         .with_status(101)
         .run();
 }
+
+#[cargo_test]
+fn workspace() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "outer"
+                version = "0.0.0"
+
+                [workspace]
+                members = ["inner"]
+            "#,
+        )
+        .file("src/main.rs", "fn main() {}")
+        .file(
+            "inner/Cargo.toml",
+            r#"
+                [package]
+                name = "inner"
+                version = "0.0.0"
+            "#,
+        )
+        .file("inner/src/lib.rs", "")
+        .build();
+
+    let outer_manifest = format!(
+        r#"{{"root":"{}"}}"#,
+        p.root().join("Cargo.toml").to_str().unwrap(),
+    );
+    let inner_manifest = format!(
+        r#"{{"root":"{}"}}"#,
+        p.root().join("inner").join("Cargo.toml").to_str().unwrap(),
+    );
+
+    p.cargo("locate-project").with_stdout(&outer_manifest).run();
+
+    p.cargo("locate-project")
+        .cwd("inner")
+        .with_stdout(&inner_manifest)
+        .run();
+
+    p.cargo("locate-project --workspace")
+        .with_stdout(&outer_manifest)
+        .run();
+
+    p.cargo("locate-project --workspace")
+        .cwd("inner")
+        .with_stdout(&outer_manifest)
+        .run();
+}


### PR DESCRIPTION
<pre>
<i>/git/serde/serde_derive</i>$ <b>cargo locate-project</b>
{"root":"<a href="https://github.com/serde-rs/serde/blob/master/serde_derive/Cargo.toml">/git/serde/serde_derive/Cargo.toml</a>"}

<i>/git/serde/serde_derive</i>$ <b>cargo locate-project --workspace</b>
{"root":"<a href="https://github.com/serde-rs/serde/blob/master/Cargo.toml">/git/serde/Cargo.toml</a>"}
</pre>