### PR TITLE
Update links to rustup docs.

### DIFF
--- a/src/doc/man/cargo.md
+++ b/src/doc/man/cargo.md
@@ -174,7 +174,7 @@ environment variable.
 
 `$CARGO_HOME/bin/`\
 &nbsp;&nbsp;&nbsp;&nbsp;Binaries installed by {{man "cargo-install" 1}} will be located here. If using
-rustup, executables distributed with Rust are also located here.
+[rustup], executables distributed with Rust are also located here.
 
 `$CARGO_HOME/config.toml`\
 &nbsp;&nbsp;&nbsp;&nbsp;The global configuration file. See [the reference](../reference/config.html)
@@ -197,6 +197,8 @@ downloaded dependencies.
 
 Please note that the internal structure of the `$CARGO_HOME` directory is not
 stable yet and may be subject to change.
+
+[rustup]: https://rust-lang.github.io/rustup/
 
 ## EXAMPLES
 

--- a/src/doc/man/generated_txt/cargo-bench.txt
+++ b/src/doc/man/generated_txt/cargo-bench.txt
@@ -286,8 +286,8 @@ OPTIONS
            If Cargo has been installed with rustup, and the first argument to
            cargo begins with +, it will be interpreted as a rustup toolchain
            name (such as +stable or +nightly). See the rustup documentation
-           <https://github.com/rust-lang/rustup/> for more information about
-           how toolchain overrides work.
+           <https://rust-lang.github.io/rustup/overrides.html> for more
+           information about how toolchain overrides work.
 
        -h, --help
            Prints help information.

--- a/src/doc/man/generated_txt/cargo-build.txt
+++ b/src/doc/man/generated_txt/cargo-build.txt
@@ -245,8 +245,8 @@ OPTIONS
            If Cargo has been installed with rustup, and the first argument to
            cargo begins with +, it will be interpreted as a rustup toolchain
            name (such as +stable or +nightly). See the rustup documentation
-           <https://github.com/rust-lang/rustup/> for more information about
-           how toolchain overrides work.
+           <https://rust-lang.github.io/rustup/overrides.html> for more
+           information about how toolchain overrides work.
 
        -h, --help
            Prints help information.

--- a/src/doc/man/generated_txt/cargo-check.txt
+++ b/src/doc/man/generated_txt/cargo-check.txt
@@ -239,8 +239,8 @@ OPTIONS
            If Cargo has been installed with rustup, and the first argument to
            cargo begins with +, it will be interpreted as a rustup toolchain
            name (such as +stable or +nightly). See the rustup documentation
-           <https://github.com/rust-lang/rustup/> for more information about
-           how toolchain overrides work.
+           <https://rust-lang.github.io/rustup/overrides.html> for more
+           information about how toolchain overrides work.
 
        -h, --help
            Prints help information.

--- a/src/doc/man/generated_txt/cargo-clean.txt
+++ b/src/doc/man/generated_txt/cargo-clean.txt
@@ -111,8 +111,8 @@ OPTIONS
            If Cargo has been installed with rustup, and the first argument to
            cargo begins with +, it will be interpreted as a rustup toolchain
            name (such as +stable or +nightly). See the rustup documentation
-           <https://github.com/rust-lang/rustup/> for more information about
-           how toolchain overrides work.
+           <https://rust-lang.github.io/rustup/overrides.html> for more
+           information about how toolchain overrides work.
 
        -h, --help
            Prints help information.

--- a/src/doc/man/generated_txt/cargo-doc.txt
+++ b/src/doc/man/generated_txt/cargo-doc.txt
@@ -206,8 +206,8 @@ OPTIONS
            If Cargo has been installed with rustup, and the first argument to
            cargo begins with +, it will be interpreted as a rustup toolchain
            name (such as +stable or +nightly). See the rustup documentation
-           <https://github.com/rust-lang/rustup/> for more information about
-           how toolchain overrides work.
+           <https://rust-lang.github.io/rustup/overrides.html> for more
+           information about how toolchain overrides work.
 
        -h, --help
            Prints help information.

--- a/src/doc/man/generated_txt/cargo-fetch.txt
+++ b/src/doc/man/generated_txt/cargo-fetch.txt
@@ -98,8 +98,8 @@ OPTIONS
            If Cargo has been installed with rustup, and the first argument to
            cargo begins with +, it will be interpreted as a rustup toolchain
            name (such as +stable or +nightly). See the rustup documentation
-           <https://github.com/rust-lang/rustup/> for more information about
-           how toolchain overrides work.
+           <https://rust-lang.github.io/rustup/overrides.html> for more
+           information about how toolchain overrides work.
 
        -h, --help
            Prints help information.

--- a/src/doc/man/generated_txt/cargo-fix.txt
+++ b/src/doc/man/generated_txt/cargo-fix.txt
@@ -287,8 +287,8 @@ OPTIONS
            If Cargo has been installed with rustup, and the first argument to
            cargo begins with +, it will be interpreted as a rustup toolchain
            name (such as +stable or +nightly). See the rustup documentation
-           <https://github.com/rust-lang/rustup/> for more information about
-           how toolchain overrides work.
+           <https://rust-lang.github.io/rustup/overrides.html> for more
+           information about how toolchain overrides work.
 
        -h, --help
            Prints help information.

--- a/src/doc/man/generated_txt/cargo-generate-lockfile.txt
+++ b/src/doc/man/generated_txt/cargo-generate-lockfile.txt
@@ -74,8 +74,8 @@ OPTIONS
            If Cargo has been installed with rustup, and the first argument to
            cargo begins with +, it will be interpreted as a rustup toolchain
            name (such as +stable or +nightly). See the rustup documentation
-           <https://github.com/rust-lang/rustup/> for more information about
-           how toolchain overrides work.
+           <https://rust-lang.github.io/rustup/overrides.html> for more
+           information about how toolchain overrides work.
 
        -h, --help
            Prints help information.

--- a/src/doc/man/generated_txt/cargo-init.txt
+++ b/src/doc/man/generated_txt/cargo-init.txt
@@ -120,8 +120,8 @@ OPTIONS
            If Cargo has been installed with rustup, and the first argument to
            cargo begins with +, it will be interpreted as a rustup toolchain
            name (such as +stable or +nightly). See the rustup documentation
-           <https://github.com/rust-lang/rustup/> for more information about
-           how toolchain overrides work.
+           <https://rust-lang.github.io/rustup/overrides.html> for more
+           information about how toolchain overrides work.
 
        -h, --help
            Prints help information.

--- a/src/doc/man/generated_txt/cargo-install.txt
+++ b/src/doc/man/generated_txt/cargo-install.txt
@@ -260,8 +260,8 @@ OPTIONS
            If Cargo has been installed with rustup, and the first argument to
            cargo begins with +, it will be interpreted as a rustup toolchain
            name (such as +stable or +nightly). See the rustup documentation
-           <https://github.com/rust-lang/rustup/> for more information about
-           how toolchain overrides work.
+           <https://rust-lang.github.io/rustup/overrides.html> for more
+           information about how toolchain overrides work.
 
        -h, --help
            Prints help information.

--- a/src/doc/man/generated_txt/cargo-locate-project.txt
+++ b/src/doc/man/generated_txt/cargo-locate-project.txt
@@ -57,8 +57,8 @@ OPTIONS
            If Cargo has been installed with rustup, and the first argument to
            cargo begins with +, it will be interpreted as a rustup toolchain
            name (such as +stable or +nightly). See the rustup documentation
-           <https://github.com/rust-lang/rustup/> for more information about
-           how toolchain overrides work.
+           <https://rust-lang.github.io/rustup/overrides.html> for more
+           information about how toolchain overrides work.
 
        -h, --help
            Prints help information.

--- a/src/doc/man/generated_txt/cargo-login.txt
+++ b/src/doc/man/generated_txt/cargo-login.txt
@@ -57,8 +57,8 @@ OPTIONS
            If Cargo has been installed with rustup, and the first argument to
            cargo begins with +, it will be interpreted as a rustup toolchain
            name (such as +stable or +nightly). See the rustup documentation
-           <https://github.com/rust-lang/rustup/> for more information about
-           how toolchain overrides work.
+           <https://rust-lang.github.io/rustup/overrides.html> for more
+           information about how toolchain overrides work.
 
        -h, --help
            Prints help information.

--- a/src/doc/man/generated_txt/cargo-metadata.txt
+++ b/src/doc/man/generated_txt/cargo-metadata.txt
@@ -375,8 +375,8 @@ OPTIONS
            If Cargo has been installed with rustup, and the first argument to
            cargo begins with +, it will be interpreted as a rustup toolchain
            name (such as +stable or +nightly). See the rustup documentation
-           <https://github.com/rust-lang/rustup/> for more information about
-           how toolchain overrides work.
+           <https://rust-lang.github.io/rustup/overrides.html> for more
+           information about how toolchain overrides work.
 
        -h, --help
            Prints help information.

--- a/src/doc/man/generated_txt/cargo-new.txt
+++ b/src/doc/man/generated_txt/cargo-new.txt
@@ -115,8 +115,8 @@ OPTIONS
            If Cargo has been installed with rustup, and the first argument to
            cargo begins with +, it will be interpreted as a rustup toolchain
            name (such as +stable or +nightly). See the rustup documentation
-           <https://github.com/rust-lang/rustup/> for more information about
-           how toolchain overrides work.
+           <https://rust-lang.github.io/rustup/overrides.html> for more
+           information about how toolchain overrides work.
 
        -h, --help
            Prints help information.

--- a/src/doc/man/generated_txt/cargo-owner.txt
+++ b/src/doc/man/generated_txt/cargo-owner.txt
@@ -84,8 +84,8 @@ OPTIONS
            If Cargo has been installed with rustup, and the first argument to
            cargo begins with +, it will be interpreted as a rustup toolchain
            name (such as +stable or +nightly). See the rustup documentation
-           <https://github.com/rust-lang/rustup/> for more information about
-           how toolchain overrides work.
+           <https://rust-lang.github.io/rustup/overrides.html> for more
+           information about how toolchain overrides work.
 
        -h, --help
            Prints help information.

--- a/src/doc/man/generated_txt/cargo-package.txt
+++ b/src/doc/man/generated_txt/cargo-package.txt
@@ -174,8 +174,8 @@ OPTIONS
            If Cargo has been installed with rustup, and the first argument to
            cargo begins with +, it will be interpreted as a rustup toolchain
            name (such as +stable or +nightly). See the rustup documentation
-           <https://github.com/rust-lang/rustup/> for more information about
-           how toolchain overrides work.
+           <https://rust-lang.github.io/rustup/overrides.html> for more
+           information about how toolchain overrides work.
 
        -h, --help
            Prints help information.

--- a/src/doc/man/generated_txt/cargo-pkgid.txt
+++ b/src/doc/man/generated_txt/cargo-pkgid.txt
@@ -104,8 +104,8 @@ OPTIONS
            If Cargo has been installed with rustup, and the first argument to
            cargo begins with +, it will be interpreted as a rustup toolchain
            name (such as +stable or +nightly). See the rustup documentation
-           <https://github.com/rust-lang/rustup/> for more information about
-           how toolchain overrides work.
+           <https://rust-lang.github.io/rustup/overrides.html> for more
+           information about how toolchain overrides work.
 
        -h, --help
            Prints help information.

--- a/src/doc/man/generated_txt/cargo-publish.txt
+++ b/src/doc/man/generated_txt/cargo-publish.txt
@@ -180,8 +180,8 @@ OPTIONS
            If Cargo has been installed with rustup, and the first argument to
            cargo begins with +, it will be interpreted as a rustup toolchain
            name (such as +stable or +nightly). See the rustup documentation
-           <https://github.com/rust-lang/rustup/> for more information about
-           how toolchain overrides work.
+           <https://rust-lang.github.io/rustup/overrides.html> for more
+           information about how toolchain overrides work.
 
        -h, --help
            Prints help information.

--- a/src/doc/man/generated_txt/cargo-run.txt
+++ b/src/doc/man/generated_txt/cargo-run.txt
@@ -169,8 +169,8 @@ OPTIONS
            If Cargo has been installed with rustup, and the first argument to
            cargo begins with +, it will be interpreted as a rustup toolchain
            name (such as +stable or +nightly). See the rustup documentation
-           <https://github.com/rust-lang/rustup/> for more information about
-           how toolchain overrides work.
+           <https://rust-lang.github.io/rustup/overrides.html> for more
+           information about how toolchain overrides work.
 
        -h, --help
            Prints help information.

--- a/src/doc/man/generated_txt/cargo-rustc.txt
+++ b/src/doc/man/generated_txt/cargo-rustc.txt
@@ -226,8 +226,8 @@ OPTIONS
            If Cargo has been installed with rustup, and the first argument to
            cargo begins with +, it will be interpreted as a rustup toolchain
            name (such as +stable or +nightly). See the rustup documentation
-           <https://github.com/rust-lang/rustup/> for more information about
-           how toolchain overrides work.
+           <https://rust-lang.github.io/rustup/overrides.html> for more
+           information about how toolchain overrides work.
 
        -h, --help
            Prints help information.

--- a/src/doc/man/generated_txt/cargo-rustdoc.txt
+++ b/src/doc/man/generated_txt/cargo-rustdoc.txt
@@ -233,8 +233,8 @@ OPTIONS
            If Cargo has been installed with rustup, and the first argument to
            cargo begins with +, it will be interpreted as a rustup toolchain
            name (such as +stable or +nightly). See the rustup documentation
-           <https://github.com/rust-lang/rustup/> for more information about
-           how toolchain overrides work.
+           <https://rust-lang.github.io/rustup/overrides.html> for more
+           information about how toolchain overrides work.
 
        -h, --help
            Prints help information.

--- a/src/doc/man/generated_txt/cargo-search.txt
+++ b/src/doc/man/generated_txt/cargo-search.txt
@@ -54,8 +54,8 @@ OPTIONS
            If Cargo has been installed with rustup, and the first argument to
            cargo begins with +, it will be interpreted as a rustup toolchain
            name (such as +stable or +nightly). See the rustup documentation
-           <https://github.com/rust-lang/rustup/> for more information about
-           how toolchain overrides work.
+           <https://rust-lang.github.io/rustup/overrides.html> for more
+           information about how toolchain overrides work.
 
        -h, --help
            Prints help information.

--- a/src/doc/man/generated_txt/cargo-test.txt
+++ b/src/doc/man/generated_txt/cargo-test.txt
@@ -308,8 +308,8 @@ OPTIONS
            If Cargo has been installed with rustup, and the first argument to
            cargo begins with +, it will be interpreted as a rustup toolchain
            name (such as +stable or +nightly). See the rustup documentation
-           <https://github.com/rust-lang/rustup/> for more information about
-           how toolchain overrides work.
+           <https://rust-lang.github.io/rustup/overrides.html> for more
+           information about how toolchain overrides work.
 
        -h, --help
            Prints help information.

--- a/src/doc/man/generated_txt/cargo-tree.txt
+++ b/src/doc/man/generated_txt/cargo-tree.txt
@@ -247,8 +247,8 @@ OPTIONS
            If Cargo has been installed with rustup, and the first argument to
            cargo begins with +, it will be interpreted as a rustup toolchain
            name (such as +stable or +nightly). See the rustup documentation
-           <https://github.com/rust-lang/rustup/> for more information about
-           how toolchain overrides work.
+           <https://rust-lang.github.io/rustup/overrides.html> for more
+           information about how toolchain overrides work.
 
        -h, --help
            Prints help information.

--- a/src/doc/man/generated_txt/cargo-uninstall.txt
+++ b/src/doc/man/generated_txt/cargo-uninstall.txt
@@ -66,8 +66,8 @@ OPTIONS
            If Cargo has been installed with rustup, and the first argument to
            cargo begins with +, it will be interpreted as a rustup toolchain
            name (such as +stable or +nightly). See the rustup documentation
-           <https://github.com/rust-lang/rustup/> for more information about
-           how toolchain overrides work.
+           <https://rust-lang.github.io/rustup/overrides.html> for more
+           information about how toolchain overrides work.
 
        -h, --help
            Prints help information.

--- a/src/doc/man/generated_txt/cargo-update.txt
+++ b/src/doc/man/generated_txt/cargo-update.txt
@@ -99,8 +99,8 @@ OPTIONS
            If Cargo has been installed with rustup, and the first argument to
            cargo begins with +, it will be interpreted as a rustup toolchain
            name (such as +stable or +nightly). See the rustup documentation
-           <https://github.com/rust-lang/rustup/> for more information about
-           how toolchain overrides work.
+           <https://rust-lang.github.io/rustup/overrides.html> for more
+           information about how toolchain overrides work.
 
        -h, --help
            Prints help information.

--- a/src/doc/man/generated_txt/cargo-vendor.txt
+++ b/src/doc/man/generated_txt/cargo-vendor.txt
@@ -99,8 +99,8 @@ OPTIONS
            If Cargo has been installed with rustup, and the first argument to
            cargo begins with +, it will be interpreted as a rustup toolchain
            name (such as +stable or +nightly). See the rustup documentation
-           <https://github.com/rust-lang/rustup/> for more information about
-           how toolchain overrides work.
+           <https://rust-lang.github.io/rustup/overrides.html> for more
+           information about how toolchain overrides work.
 
        -h, --help
            Prints help information.

--- a/src/doc/man/generated_txt/cargo-verify-project.txt
+++ b/src/doc/man/generated_txt/cargo-verify-project.txt
@@ -77,8 +77,8 @@ OPTIONS
            If Cargo has been installed with rustup, and the first argument to
            cargo begins with +, it will be interpreted as a rustup toolchain
            name (such as +stable or +nightly). See the rustup documentation
-           <https://github.com/rust-lang/rustup/> for more information about
-           how toolchain overrides work.
+           <https://rust-lang.github.io/rustup/overrides.html> for more
+           information about how toolchain overrides work.
 
        -h, --help
            Prints help information.

--- a/src/doc/man/generated_txt/cargo-yank.txt
+++ b/src/doc/man/generated_txt/cargo-yank.txt
@@ -79,8 +79,8 @@ OPTIONS
            If Cargo has been installed with rustup, and the first argument to
            cargo begins with +, it will be interpreted as a rustup toolchain
            name (such as +stable or +nightly). See the rustup documentation
-           <https://github.com/rust-lang/rustup/> for more information about
-           how toolchain overrides work.
+           <https://rust-lang.github.io/rustup/overrides.html> for more
+           information about how toolchain overrides work.
 
        -h, --help
            Prints help information.

--- a/src/doc/man/generated_txt/cargo.txt
+++ b/src/doc/man/generated_txt/cargo.txt
@@ -183,8 +183,8 @@ OPTIONS
            If Cargo has been installed with rustup, and the first argument to
            cargo begins with +, it will be interpreted as a rustup toolchain
            name (such as +stable or +nightly). See the rustup documentation
-           <https://github.com/rust-lang/rustup/> for more information about
-           how toolchain overrides work.
+           <https://rust-lang.github.io/rustup/overrides.html> for more
+           information about how toolchain overrides work.
 
        -h, --help
            Prints help information.
@@ -211,7 +211,8 @@ FILES
 
        $CARGO_HOME/bin/
            Binaries installed by cargo-install(1) will be located here. If
-       using rustup, executables distributed with Rust are also located here.
+       using rustup <https://rust-lang.github.io/rustup/>, executables
+       distributed with Rust are also located here.
 
        $CARGO_HOME/config.toml
            The global configuration file. See the reference

--- a/src/doc/man/includes/section-options-common.md
+++ b/src/doc/man/includes/section-options-common.md
@@ -6,7 +6,7 @@
 If Cargo has been installed with rustup, and the first argument to `cargo`
 begins with `+`, it will be interpreted as a rustup toolchain name (such
 as `+stable` or `+nightly`).
-See the [rustup documentation](https://github.com/rust-lang/rustup/)
+See the [rustup documentation](https://rust-lang.github.io/rustup/overrides.html)
 for more information about how toolchain overrides work.
 {{/option}}
 

--- a/src/doc/src/commands/cargo-bench.md
+++ b/src/doc/src/commands/cargo-bench.md
@@ -348,7 +348,7 @@ offline.</p>
 <dd class="option-desc">If Cargo has been installed with rustup, and the first argument to <code>cargo</code>
 begins with <code>+</code>, it will be interpreted as a rustup toolchain name (such
 as <code>+stable</code> or <code>+nightly</code>).
-See the <a href="https://github.com/rust-lang/rustup/">rustup documentation</a>
+See the <a href="https://rust-lang.github.io/rustup/overrides.html">rustup documentation</a>
 for more information about how toolchain overrides work.</dd>
 
 

--- a/src/doc/src/commands/cargo-build.md
+++ b/src/doc/src/commands/cargo-build.md
@@ -304,7 +304,7 @@ offline.</p>
 <dd class="option-desc">If Cargo has been installed with rustup, and the first argument to <code>cargo</code>
 begins with <code>+</code>, it will be interpreted as a rustup toolchain name (such
 as <code>+stable</code> or <code>+nightly</code>).
-See the <a href="https://github.com/rust-lang/rustup/">rustup documentation</a>
+See the <a href="https://rust-lang.github.io/rustup/overrides.html">rustup documentation</a>
 for more information about how toolchain overrides work.</dd>
 
 

--- a/src/doc/src/commands/cargo-check.md
+++ b/src/doc/src/commands/cargo-check.md
@@ -300,7 +300,7 @@ offline.</p>
 <dd class="option-desc">If Cargo has been installed with rustup, and the first argument to <code>cargo</code>
 begins with <code>+</code>, it will be interpreted as a rustup toolchain name (such
 as <code>+stable</code> or <code>+nightly</code>).
-See the <a href="https://github.com/rust-lang/rustup/">rustup documentation</a>
+See the <a href="https://rust-lang.github.io/rustup/overrides.html">rustup documentation</a>
 for more information about how toolchain overrides work.</dd>
 
 

--- a/src/doc/src/commands/cargo-clean.md
+++ b/src/doc/src/commands/cargo-clean.md
@@ -140,7 +140,7 @@ offline.</p>
 <dd class="option-desc">If Cargo has been installed with rustup, and the first argument to <code>cargo</code>
 begins with <code>+</code>, it will be interpreted as a rustup toolchain name (such
 as <code>+stable</code> or <code>+nightly</code>).
-See the <a href="https://github.com/rust-lang/rustup/">rustup documentation</a>
+See the <a href="https://rust-lang.github.io/rustup/overrides.html">rustup documentation</a>
 for more information about how toolchain overrides work.</dd>
 
 

--- a/src/doc/src/commands/cargo-doc.md
+++ b/src/doc/src/commands/cargo-doc.md
@@ -264,7 +264,7 @@ offline.</p>
 <dd class="option-desc">If Cargo has been installed with rustup, and the first argument to <code>cargo</code>
 begins with <code>+</code>, it will be interpreted as a rustup toolchain name (such
 as <code>+stable</code> or <code>+nightly</code>).
-See the <a href="https://github.com/rust-lang/rustup/">rustup documentation</a>
+See the <a href="https://rust-lang.github.io/rustup/overrides.html">rustup documentation</a>
 for more information about how toolchain overrides work.</dd>
 
 

--- a/src/doc/src/commands/cargo-fetch.md
+++ b/src/doc/src/commands/cargo-fetch.md
@@ -117,7 +117,7 @@ offline.</p>
 <dd class="option-desc">If Cargo has been installed with rustup, and the first argument to <code>cargo</code>
 begins with <code>+</code>, it will be interpreted as a rustup toolchain name (such
 as <code>+stable</code> or <code>+nightly</code>).
-See the <a href="https://github.com/rust-lang/rustup/">rustup documentation</a>
+See the <a href="https://rust-lang.github.io/rustup/overrides.html">rustup documentation</a>
 for more information about how toolchain overrides work.</dd>
 
 

--- a/src/doc/src/commands/cargo-fix.md
+++ b/src/doc/src/commands/cargo-fix.md
@@ -360,7 +360,7 @@ offline.</p>
 <dd class="option-desc">If Cargo has been installed with rustup, and the first argument to <code>cargo</code>
 begins with <code>+</code>, it will be interpreted as a rustup toolchain name (such
 as <code>+stable</code> or <code>+nightly</code>).
-See the <a href="https://github.com/rust-lang/rustup/">rustup documentation</a>
+See the <a href="https://rust-lang.github.io/rustup/overrides.html">rustup documentation</a>
 for more information about how toolchain overrides work.</dd>
 
 

--- a/src/doc/src/commands/cargo-generate-lockfile.md
+++ b/src/doc/src/commands/cargo-generate-lockfile.md
@@ -92,7 +92,7 @@ offline.</p>
 <dd class="option-desc">If Cargo has been installed with rustup, and the first argument to <code>cargo</code>
 begins with <code>+</code>, it will be interpreted as a rustup toolchain name (such
 as <code>+stable</code> or <code>+nightly</code>).
-See the <a href="https://github.com/rust-lang/rustup/">rustup documentation</a>
+See the <a href="https://rust-lang.github.io/rustup/overrides.html">rustup documentation</a>
 for more information about how toolchain overrides work.</dd>
 
 

--- a/src/doc/src/commands/cargo-init.md
+++ b/src/doc/src/commands/cargo-init.md
@@ -131,7 +131,7 @@ terminal.</li>
 <dd class="option-desc">If Cargo has been installed with rustup, and the first argument to <code>cargo</code>
 begins with <code>+</code>, it will be interpreted as a rustup toolchain name (such
 as <code>+stable</code> or <code>+nightly</code>).
-See the <a href="https://github.com/rust-lang/rustup/">rustup documentation</a>
+See the <a href="https://rust-lang.github.io/rustup/overrides.html">rustup documentation</a>
 for more information about how toolchain overrides work.</dd>
 
 

--- a/src/doc/src/commands/cargo-install.md
+++ b/src/doc/src/commands/cargo-install.md
@@ -308,7 +308,7 @@ terminal.</li>
 <dd class="option-desc">If Cargo has been installed with rustup, and the first argument to <code>cargo</code>
 begins with <code>+</code>, it will be interpreted as a rustup toolchain name (such
 as <code>+stable</code> or <code>+nightly</code>).
-See the <a href="https://github.com/rust-lang/rustup/">rustup documentation</a>
+See the <a href="https://rust-lang.github.io/rustup/overrides.html">rustup documentation</a>
 for more information about how toolchain overrides work.</dd>
 
 

--- a/src/doc/src/commands/cargo-locate-project.md
+++ b/src/doc/src/commands/cargo-locate-project.md
@@ -81,7 +81,7 @@ terminal.</li>
 <dd class="option-desc">If Cargo has been installed with rustup, and the first argument to <code>cargo</code>
 begins with <code>+</code>, it will be interpreted as a rustup toolchain name (such
 as <code>+stable</code> or <code>+nightly</code>).
-See the <a href="https://github.com/rust-lang/rustup/">rustup documentation</a>
+See the <a href="https://rust-lang.github.io/rustup/overrides.html">rustup documentation</a>
 for more information about how toolchain overrides work.</dd>
 
 

--- a/src/doc/src/commands/cargo-login.md
+++ b/src/doc/src/commands/cargo-login.md
@@ -73,7 +73,7 @@ terminal.</li>
 <dd class="option-desc">If Cargo has been installed with rustup, and the first argument to <code>cargo</code>
 begins with <code>+</code>, it will be interpreted as a rustup toolchain name (such
 as <code>+stable</code> or <code>+nightly</code>).
-See the <a href="https://github.com/rust-lang/rustup/">rustup documentation</a>
+See the <a href="https://rust-lang.github.io/rustup/overrides.html">rustup documentation</a>
 for more information about how toolchain overrides work.</dd>
 
 

--- a/src/doc/src/commands/cargo-metadata.md
+++ b/src/doc/src/commands/cargo-metadata.md
@@ -409,7 +409,7 @@ offline.</p>
 <dd class="option-desc">If Cargo has been installed with rustup, and the first argument to <code>cargo</code>
 begins with <code>+</code>, it will be interpreted as a rustup toolchain name (such
 as <code>+stable</code> or <code>+nightly</code>).
-See the <a href="https://github.com/rust-lang/rustup/">rustup documentation</a>
+See the <a href="https://rust-lang.github.io/rustup/overrides.html">rustup documentation</a>
 for more information about how toolchain overrides work.</dd>
 
 

--- a/src/doc/src/commands/cargo-new.md
+++ b/src/doc/src/commands/cargo-new.md
@@ -126,7 +126,7 @@ terminal.</li>
 <dd class="option-desc">If Cargo has been installed with rustup, and the first argument to <code>cargo</code>
 begins with <code>+</code>, it will be interpreted as a rustup toolchain name (such
 as <code>+stable</code> or <code>+nightly</code>).
-See the <a href="https://github.com/rust-lang/rustup/">rustup documentation</a>
+See the <a href="https://rust-lang.github.io/rustup/overrides.html">rustup documentation</a>
 for more information about how toolchain overrides work.</dd>
 
 

--- a/src/doc/src/commands/cargo-owner.md
+++ b/src/doc/src/commands/cargo-owner.md
@@ -111,7 +111,7 @@ terminal.</li>
 <dd class="option-desc">If Cargo has been installed with rustup, and the first argument to <code>cargo</code>
 begins with <code>+</code>, it will be interpreted as a rustup toolchain name (such
 as <code>+stable</code> or <code>+nightly</code>).
-See the <a href="https://github.com/rust-lang/rustup/">rustup documentation</a>
+See the <a href="https://rust-lang.github.io/rustup/overrides.html">rustup documentation</a>
 for more information about how toolchain overrides work.</dd>
 
 

--- a/src/doc/src/commands/cargo-package.md
+++ b/src/doc/src/commands/cargo-package.md
@@ -213,7 +213,7 @@ terminal.</li>
 <dd class="option-desc">If Cargo has been installed with rustup, and the first argument to <code>cargo</code>
 begins with <code>+</code>, it will be interpreted as a rustup toolchain name (such
 as <code>+stable</code> or <code>+nightly</code>).
-See the <a href="https://github.com/rust-lang/rustup/">rustup documentation</a>
+See the <a href="https://rust-lang.github.io/rustup/overrides.html">rustup documentation</a>
 for more information about how toolchain overrides work.</dd>
 
 

--- a/src/doc/src/commands/cargo-pkgid.md
+++ b/src/doc/src/commands/cargo-pkgid.md
@@ -121,7 +121,7 @@ offline.</p>
 <dd class="option-desc">If Cargo has been installed with rustup, and the first argument to <code>cargo</code>
 begins with <code>+</code>, it will be interpreted as a rustup toolchain name (such
 as <code>+stable</code> or <code>+nightly</code>).
-See the <a href="https://github.com/rust-lang/rustup/">rustup documentation</a>
+See the <a href="https://rust-lang.github.io/rustup/overrides.html">rustup documentation</a>
 for more information about how toolchain overrides work.</dd>
 
 

--- a/src/doc/src/commands/cargo-publish.md
+++ b/src/doc/src/commands/cargo-publish.md
@@ -221,7 +221,7 @@ terminal.</li>
 <dd class="option-desc">If Cargo has been installed with rustup, and the first argument to <code>cargo</code>
 begins with <code>+</code>, it will be interpreted as a rustup toolchain name (such
 as <code>+stable</code> or <code>+nightly</code>).
-See the <a href="https://github.com/rust-lang/rustup/">rustup documentation</a>
+See the <a href="https://rust-lang.github.io/rustup/overrides.html">rustup documentation</a>
 for more information about how toolchain overrides work.</dd>
 
 

--- a/src/doc/src/commands/cargo-run.md
+++ b/src/doc/src/commands/cargo-run.md
@@ -222,7 +222,7 @@ offline.</p>
 <dd class="option-desc">If Cargo has been installed with rustup, and the first argument to <code>cargo</code>
 begins with <code>+</code>, it will be interpreted as a rustup toolchain name (such
 as <code>+stable</code> or <code>+nightly</code>).
-See the <a href="https://github.com/rust-lang/rustup/">rustup documentation</a>
+See the <a href="https://rust-lang.github.io/rustup/overrides.html">rustup documentation</a>
 for more information about how toolchain overrides work.</dd>
 
 

--- a/src/doc/src/commands/cargo-rustc.md
+++ b/src/doc/src/commands/cargo-rustc.md
@@ -283,7 +283,7 @@ offline.</p>
 <dd class="option-desc">If Cargo has been installed with rustup, and the first argument to <code>cargo</code>
 begins with <code>+</code>, it will be interpreted as a rustup toolchain name (such
 as <code>+stable</code> or <code>+nightly</code>).
-See the <a href="https://github.com/rust-lang/rustup/">rustup documentation</a>
+See the <a href="https://rust-lang.github.io/rustup/overrides.html">rustup documentation</a>
 for more information about how toolchain overrides work.</dd>
 
 

--- a/src/doc/src/commands/cargo-rustdoc.md
+++ b/src/doc/src/commands/cargo-rustdoc.md
@@ -292,7 +292,7 @@ offline.</p>
 <dd class="option-desc">If Cargo has been installed with rustup, and the first argument to <code>cargo</code>
 begins with <code>+</code>, it will be interpreted as a rustup toolchain name (such
 as <code>+stable</code> or <code>+nightly</code>).
-See the <a href="https://github.com/rust-lang/rustup/">rustup documentation</a>
+See the <a href="https://rust-lang.github.io/rustup/overrides.html">rustup documentation</a>
 for more information about how toolchain overrides work.</dd>
 
 

--- a/src/doc/src/commands/cargo-search.md
+++ b/src/doc/src/commands/cargo-search.md
@@ -77,7 +77,7 @@ terminal.</li>
 <dd class="option-desc">If Cargo has been installed with rustup, and the first argument to <code>cargo</code>
 begins with <code>+</code>, it will be interpreted as a rustup toolchain name (such
 as <code>+stable</code> or <code>+nightly</code>).
-See the <a href="https://github.com/rust-lang/rustup/">rustup documentation</a>
+See the <a href="https://rust-lang.github.io/rustup/overrides.html">rustup documentation</a>
 for more information about how toolchain overrides work.</dd>
 
 

--- a/src/doc/src/commands/cargo-test.md
+++ b/src/doc/src/commands/cargo-test.md
@@ -376,7 +376,7 @@ offline.</p>
 <dd class="option-desc">If Cargo has been installed with rustup, and the first argument to <code>cargo</code>
 begins with <code>+</code>, it will be interpreted as a rustup toolchain name (such
 as <code>+stable</code> or <code>+nightly</code>).
-See the <a href="https://github.com/rust-lang/rustup/">rustup documentation</a>
+See the <a href="https://rust-lang.github.io/rustup/overrides.html">rustup documentation</a>
 for more information about how toolchain overrides work.</dd>
 
 

--- a/src/doc/src/commands/cargo-tree.md
+++ b/src/doc/src/commands/cargo-tree.md
@@ -291,7 +291,7 @@ terminal.</li>
 <dd class="option-desc">If Cargo has been installed with rustup, and the first argument to <code>cargo</code>
 begins with <code>+</code>, it will be interpreted as a rustup toolchain name (such
 as <code>+stable</code> or <code>+nightly</code>).
-See the <a href="https://github.com/rust-lang/rustup/">rustup documentation</a>
+See the <a href="https://rust-lang.github.io/rustup/overrides.html">rustup documentation</a>
 for more information about how toolchain overrides work.</dd>
 
 

--- a/src/doc/src/commands/cargo-uninstall.md
+++ b/src/doc/src/commands/cargo-uninstall.md
@@ -87,7 +87,7 @@ terminal.</li>
 <dd class="option-desc">If Cargo has been installed with rustup, and the first argument to <code>cargo</code>
 begins with <code>+</code>, it will be interpreted as a rustup toolchain name (such
 as <code>+stable</code> or <code>+nightly</code>).
-See the <a href="https://github.com/rust-lang/rustup/">rustup documentation</a>
+See the <a href="https://rust-lang.github.io/rustup/overrides.html">rustup documentation</a>
 for more information about how toolchain overrides work.</dd>
 
 

--- a/src/doc/src/commands/cargo-update.md
+++ b/src/doc/src/commands/cargo-update.md
@@ -124,7 +124,7 @@ offline.</p>
 <dd class="option-desc">If Cargo has been installed with rustup, and the first argument to <code>cargo</code>
 begins with <code>+</code>, it will be interpreted as a rustup toolchain name (such
 as <code>+stable</code> or <code>+nightly</code>).
-See the <a href="https://github.com/rust-lang/rustup/">rustup documentation</a>
+See the <a href="https://rust-lang.github.io/rustup/overrides.html">rustup documentation</a>
 for more information about how toolchain overrides work.</dd>
 
 

--- a/src/doc/src/commands/cargo-vendor.md
+++ b/src/doc/src/commands/cargo-vendor.md
@@ -128,7 +128,7 @@ terminal.</li>
 <dd class="option-desc">If Cargo has been installed with rustup, and the first argument to <code>cargo</code>
 begins with <code>+</code>, it will be interpreted as a rustup toolchain name (such
 as <code>+stable</code> or <code>+nightly</code>).
-See the <a href="https://github.com/rust-lang/rustup/">rustup documentation</a>
+See the <a href="https://rust-lang.github.io/rustup/overrides.html">rustup documentation</a>
 for more information about how toolchain overrides work.</dd>
 
 

--- a/src/doc/src/commands/cargo-verify-project.md
+++ b/src/doc/src/commands/cargo-verify-project.md
@@ -98,7 +98,7 @@ offline.</p>
 <dd class="option-desc">If Cargo has been installed with rustup, and the first argument to <code>cargo</code>
 begins with <code>+</code>, it will be interpreted as a rustup toolchain name (such
 as <code>+stable</code> or <code>+nightly</code>).
-See the <a href="https://github.com/rust-lang/rustup/">rustup documentation</a>
+See the <a href="https://rust-lang.github.io/rustup/overrides.html">rustup documentation</a>
 for more information about how toolchain overrides work.</dd>
 
 

--- a/src/doc/src/commands/cargo-yank.md
+++ b/src/doc/src/commands/cargo-yank.md
@@ -105,7 +105,7 @@ terminal.</li>
 <dd class="option-desc">If Cargo has been installed with rustup, and the first argument to <code>cargo</code>
 begins with <code>+</code>, it will be interpreted as a rustup toolchain name (such
 as <code>+stable</code> or <code>+nightly</code>).
-See the <a href="https://github.com/rust-lang/rustup/">rustup documentation</a>
+See the <a href="https://rust-lang.github.io/rustup/overrides.html">rustup documentation</a>
 for more information about how toolchain overrides work.</dd>
 
 

--- a/src/doc/src/commands/cargo.md
+++ b/src/doc/src/commands/cargo.md
@@ -215,7 +215,7 @@ offline.</p>
 <dd class="option-desc">If Cargo has been installed with rustup, and the first argument to <code>cargo</code>
 begins with <code>+</code>, it will be interpreted as a rustup toolchain name (such
 as <code>+stable</code> or <code>+nightly</code>).
-See the <a href="https://github.com/rust-lang/rustup/">rustup documentation</a>
+See the <a href="https://rust-lang.github.io/rustup/overrides.html">rustup documentation</a>
 for more information about how toolchain overrides work.</dd>
 
 
@@ -252,7 +252,7 @@ environment variable.
 
 `$CARGO_HOME/bin/`\
 &nbsp;&nbsp;&nbsp;&nbsp;Binaries installed by [cargo-install(1)](cargo-install.md) will be located here. If using
-rustup, executables distributed with Rust are also located here.
+[rustup], executables distributed with Rust are also located here.
 
 `$CARGO_HOME/config.toml`\
 &nbsp;&nbsp;&nbsp;&nbsp;The global configuration file. See [the reference](../reference/config.html)
@@ -275,6 +275,8 @@ downloaded dependencies.
 
 Please note that the internal structure of the `$CARGO_HOME` directory is not
 stable yet and may be subject to change.
+
+[rustup]: https://rust-lang.github.io/rustup/
 
 ## EXAMPLES
 

--- a/src/doc/src/guide/cargo-home.md
+++ b/src/doc/src/guide/cargo-home.md
@@ -24,7 +24,7 @@ The Cargo home consists of following components:
 ## Directories:
 
 * `bin`
-The bin directory contains executables of crates that were installed via [`cargo install`] or [`rustup`](https://github.com/rust-lang/rustup.rs).
+The bin directory contains executables of crates that were installed via [`cargo install`] or [`rustup`](https://rust-lang.github.io/rustup/).
 To be able to make these binaries accessible, add the path of the directory to your `$PATH` environment variable.
 
  *  `git`

--- a/src/etc/man/cargo-bench.1
+++ b/src/etc/man/cargo-bench.1
@@ -372,7 +372,7 @@ May also be specified with the \fBnet.offline\fR \fIconfig value\fR <https://doc
 If Cargo has been installed with rustup, and the first argument to \fBcargo\fR
 begins with \fB+\fR, it will be interpreted as a rustup toolchain name (such
 as \fB+stable\fR or \fB+nightly\fR).
-See the \fIrustup documentation\fR <https://github.com/rust\-lang/rustup/>
+See the \fIrustup documentation\fR <https://rust\-lang.github.io/rustup/overrides.html>
 for more information about how toolchain overrides work.
 .RE
 .sp

--- a/src/etc/man/cargo-build.1
+++ b/src/etc/man/cargo-build.1
@@ -312,7 +312,7 @@ May also be specified with the \fBnet.offline\fR \fIconfig value\fR <https://doc
 If Cargo has been installed with rustup, and the first argument to \fBcargo\fR
 begins with \fB+\fR, it will be interpreted as a rustup toolchain name (such
 as \fB+stable\fR or \fB+nightly\fR).
-See the \fIrustup documentation\fR <https://github.com/rust\-lang/rustup/>
+See the \fIrustup documentation\fR <https://rust\-lang.github.io/rustup/overrides.html>
 for more information about how toolchain overrides work.
 .RE
 .sp

--- a/src/etc/man/cargo-check.1
+++ b/src/etc/man/cargo-check.1
@@ -305,7 +305,7 @@ May also be specified with the \fBnet.offline\fR \fIconfig value\fR <https://doc
 If Cargo has been installed with rustup, and the first argument to \fBcargo\fR
 begins with \fB+\fR, it will be interpreted as a rustup toolchain name (such
 as \fB+stable\fR or \fB+nightly\fR).
-See the \fIrustup documentation\fR <https://github.com/rust\-lang/rustup/>
+See the \fIrustup documentation\fR <https://rust\-lang.github.io/rustup/overrides.html>
 for more information about how toolchain overrides work.
 .RE
 .sp

--- a/src/etc/man/cargo-clean.1
+++ b/src/etc/man/cargo-clean.1
@@ -138,7 +138,7 @@ May also be specified with the \fBnet.offline\fR \fIconfig value\fR <https://doc
 If Cargo has been installed with rustup, and the first argument to \fBcargo\fR
 begins with \fB+\fR, it will be interpreted as a rustup toolchain name (such
 as \fB+stable\fR or \fB+nightly\fR).
-See the \fIrustup documentation\fR <https://github.com/rust\-lang/rustup/>
+See the \fIrustup documentation\fR <https://rust\-lang.github.io/rustup/overrides.html>
 for more information about how toolchain overrides work.
 .RE
 .sp

--- a/src/etc/man/cargo-doc.1
+++ b/src/etc/man/cargo-doc.1
@@ -263,7 +263,7 @@ May also be specified with the \fBnet.offline\fR \fIconfig value\fR <https://doc
 If Cargo has been installed with rustup, and the first argument to \fBcargo\fR
 begins with \fB+\fR, it will be interpreted as a rustup toolchain name (such
 as \fB+stable\fR or \fB+nightly\fR).
-See the \fIrustup documentation\fR <https://github.com/rust\-lang/rustup/>
+See the \fIrustup documentation\fR <https://rust\-lang.github.io/rustup/overrides.html>
 for more information about how toolchain overrides work.
 .RE
 .sp

--- a/src/etc/man/cargo-fetch.1
+++ b/src/etc/man/cargo-fetch.1
@@ -117,7 +117,7 @@ May also be specified with the \fBnet.offline\fR \fIconfig value\fR <https://doc
 If Cargo has been installed with rustup, and the first argument to \fBcargo\fR
 begins with \fB+\fR, it will be interpreted as a rustup toolchain name (such
 as \fB+stable\fR or \fB+nightly\fR).
-See the \fIrustup documentation\fR <https://github.com/rust\-lang/rustup/>
+See the \fIrustup documentation\fR <https://rust\-lang.github.io/rustup/overrides.html>
 for more information about how toolchain overrides work.
 .RE
 .sp

--- a/src/etc/man/cargo-fix.1
+++ b/src/etc/man/cargo-fix.1
@@ -378,7 +378,7 @@ May also be specified with the \fBnet.offline\fR \fIconfig value\fR <https://doc
 If Cargo has been installed with rustup, and the first argument to \fBcargo\fR
 begins with \fB+\fR, it will be interpreted as a rustup toolchain name (such
 as \fB+stable\fR or \fB+nightly\fR).
-See the \fIrustup documentation\fR <https://github.com/rust\-lang/rustup/>
+See the \fIrustup documentation\fR <https://rust\-lang.github.io/rustup/overrides.html>
 for more information about how toolchain overrides work.
 .RE
 .sp

--- a/src/etc/man/cargo-generate-lockfile.1
+++ b/src/etc/man/cargo-generate-lockfile.1
@@ -95,7 +95,7 @@ May also be specified with the \fBnet.offline\fR \fIconfig value\fR <https://doc
 If Cargo has been installed with rustup, and the first argument to \fBcargo\fR
 begins with \fB+\fR, it will be interpreted as a rustup toolchain name (such
 as \fB+stable\fR or \fB+nightly\fR).
-See the \fIrustup documentation\fR <https://github.com/rust\-lang/rustup/>
+See the \fIrustup documentation\fR <https://rust\-lang.github.io/rustup/overrides.html>
 for more information about how toolchain overrides work.
 .RE
 .sp

--- a/src/etc/man/cargo-init.1
+++ b/src/etc/man/cargo-init.1
@@ -173,7 +173,7 @@ May also be specified with the \fBterm.color\fR
 If Cargo has been installed with rustup, and the first argument to \fBcargo\fR
 begins with \fB+\fR, it will be interpreted as a rustup toolchain name (such
 as \fB+stable\fR or \fB+nightly\fR).
-See the \fIrustup documentation\fR <https://github.com/rust\-lang/rustup/>
+See the \fIrustup documentation\fR <https://rust\-lang.github.io/rustup/overrides.html>
 for more information about how toolchain overrides work.
 .RE
 .sp

--- a/src/etc/man/cargo-install.1
+++ b/src/etc/man/cargo-install.1
@@ -340,7 +340,7 @@ May also be specified with the \fBterm.color\fR
 If Cargo has been installed with rustup, and the first argument to \fBcargo\fR
 begins with \fB+\fR, it will be interpreted as a rustup toolchain name (such
 as \fB+stable\fR or \fB+nightly\fR).
-See the \fIrustup documentation\fR <https://github.com/rust\-lang/rustup/>
+See the \fIrustup documentation\fR <https://rust\-lang.github.io/rustup/overrides.html>
 for more information about how toolchain overrides work.
 .RE
 .sp

--- a/src/etc/man/cargo-locate-project.1
+++ b/src/etc/man/cargo-locate-project.1
@@ -81,7 +81,7 @@ Path to the \fBCargo.toml\fR file. By default, Cargo searches for the
 If Cargo has been installed with rustup, and the first argument to \fBcargo\fR
 begins with \fB+\fR, it will be interpreted as a rustup toolchain name (such
 as \fB+stable\fR or \fB+nightly\fR).
-See the \fIrustup documentation\fR <https://github.com/rust\-lang/rustup/>
+See the \fIrustup documentation\fR <https://rust\-lang.github.io/rustup/overrides.html>
 for more information about how toolchain overrides work.
 .RE
 .sp

--- a/src/etc/man/cargo-login.1
+++ b/src/etc/man/cargo-login.1
@@ -72,7 +72,7 @@ May also be specified with the \fBterm.color\fR
 If Cargo has been installed with rustup, and the first argument to \fBcargo\fR
 begins with \fB+\fR, it will be interpreted as a rustup toolchain name (such
 as \fB+stable\fR or \fB+nightly\fR).
-See the \fIrustup documentation\fR <https://github.com/rust\-lang/rustup/>
+See the \fIrustup documentation\fR <https://rust\-lang.github.io/rustup/overrides.html>
 for more information about how toolchain overrides work.
 .RE
 .sp

--- a/src/etc/man/cargo-metadata.1
+++ b/src/etc/man/cargo-metadata.1
@@ -407,7 +407,7 @@ May also be specified with the \fBnet.offline\fR \fIconfig value\fR <https://doc
 If Cargo has been installed with rustup, and the first argument to \fBcargo\fR
 begins with \fB+\fR, it will be interpreted as a rustup toolchain name (such
 as \fB+stable\fR or \fB+nightly\fR).
-See the \fIrustup documentation\fR <https://github.com/rust\-lang/rustup/>
+See the \fIrustup documentation\fR <https://rust\-lang.github.io/rustup/overrides.html>
 for more information about how toolchain overrides work.
 .RE
 .sp

--- a/src/etc/man/cargo-new.1
+++ b/src/etc/man/cargo-new.1
@@ -168,7 +168,7 @@ May also be specified with the \fBterm.color\fR
 If Cargo has been installed with rustup, and the first argument to \fBcargo\fR
 begins with \fB+\fR, it will be interpreted as a rustup toolchain name (such
 as \fB+stable\fR or \fB+nightly\fR).
-See the \fIrustup documentation\fR <https://github.com/rust\-lang/rustup/>
+See the \fIrustup documentation\fR <https://rust\-lang.github.io/rustup/overrides.html>
 for more information about how toolchain overrides work.
 .RE
 .sp

--- a/src/etc/man/cargo-owner.1
+++ b/src/etc/man/cargo-owner.1
@@ -114,7 +114,7 @@ May also be specified with the \fBterm.color\fR
 If Cargo has been installed with rustup, and the first argument to \fBcargo\fR
 begins with \fB+\fR, it will be interpreted as a rustup toolchain name (such
 as \fB+stable\fR or \fB+nightly\fR).
-See the \fIrustup documentation\fR <https://github.com/rust\-lang/rustup/>
+See the \fIrustup documentation\fR <https://rust\-lang.github.io/rustup/overrides.html>
 for more information about how toolchain overrides work.
 .RE
 .sp

--- a/src/etc/man/cargo-package.1
+++ b/src/etc/man/cargo-package.1
@@ -231,7 +231,7 @@ May also be specified with the \fBterm.color\fR
 If Cargo has been installed with rustup, and the first argument to \fBcargo\fR
 begins with \fB+\fR, it will be interpreted as a rustup toolchain name (such
 as \fB+stable\fR or \fB+nightly\fR).
-See the \fIrustup documentation\fR <https://github.com/rust\-lang/rustup/>
+See the \fIrustup documentation\fR <https://rust\-lang.github.io/rustup/overrides.html>
 for more information about how toolchain overrides work.
 .RE
 .sp

--- a/src/etc/man/cargo-pkgid.1
+++ b/src/etc/man/cargo-pkgid.1
@@ -150,7 +150,7 @@ May also be specified with the \fBnet.offline\fR \fIconfig value\fR <https://doc
 If Cargo has been installed with rustup, and the first argument to \fBcargo\fR
 begins with \fB+\fR, it will be interpreted as a rustup toolchain name (such
 as \fB+stable\fR or \fB+nightly\fR).
-See the \fIrustup documentation\fR <https://github.com/rust\-lang/rustup/>
+See the \fIrustup documentation\fR <https://rust\-lang.github.io/rustup/overrides.html>
 for more information about how toolchain overrides work.
 .RE
 .sp

--- a/src/etc/man/cargo-publish.1
+++ b/src/etc/man/cargo-publish.1
@@ -222,7 +222,7 @@ May also be specified with the \fBterm.color\fR
 If Cargo has been installed with rustup, and the first argument to \fBcargo\fR
 begins with \fB+\fR, it will be interpreted as a rustup toolchain name (such
 as \fB+stable\fR or \fB+nightly\fR).
-See the \fIrustup documentation\fR <https://github.com/rust\-lang/rustup/>
+See the \fIrustup documentation\fR <https://rust\-lang.github.io/rustup/overrides.html>
 for more information about how toolchain overrides work.
 .RE
 .sp

--- a/src/etc/man/cargo-run.1
+++ b/src/etc/man/cargo-run.1
@@ -216,7 +216,7 @@ May also be specified with the \fBnet.offline\fR \fIconfig value\fR <https://doc
 If Cargo has been installed with rustup, and the first argument to \fBcargo\fR
 begins with \fB+\fR, it will be interpreted as a rustup toolchain name (such
 as \fB+stable\fR or \fB+nightly\fR).
-See the \fIrustup documentation\fR <https://github.com/rust\-lang/rustup/>
+See the \fIrustup documentation\fR <https://rust\-lang.github.io/rustup/overrides.html>
 for more information about how toolchain overrides work.
 .RE
 .sp

--- a/src/etc/man/cargo-rustc.1
+++ b/src/etc/man/cargo-rustc.1
@@ -283,7 +283,7 @@ May also be specified with the \fBnet.offline\fR \fIconfig value\fR <https://doc
 If Cargo has been installed with rustup, and the first argument to \fBcargo\fR
 begins with \fB+\fR, it will be interpreted as a rustup toolchain name (such
 as \fB+stable\fR or \fB+nightly\fR).
-See the \fIrustup documentation\fR <https://github.com/rust\-lang/rustup/>
+See the \fIrustup documentation\fR <https://rust\-lang.github.io/rustup/overrides.html>
 for more information about how toolchain overrides work.
 .RE
 .sp

--- a/src/etc/man/cargo-rustdoc.1
+++ b/src/etc/man/cargo-rustdoc.1
@@ -292,7 +292,7 @@ May also be specified with the \fBnet.offline\fR \fIconfig value\fR <https://doc
 If Cargo has been installed with rustup, and the first argument to \fBcargo\fR
 begins with \fB+\fR, it will be interpreted as a rustup toolchain name (such
 as \fB+stable\fR or \fB+nightly\fR).
-See the \fIrustup documentation\fR <https://github.com/rust\-lang/rustup/>
+See the \fIrustup documentation\fR <https://rust\-lang.github.io/rustup/overrides.html>
 for more information about how toolchain overrides work.
 .RE
 .sp

--- a/src/etc/man/cargo-search.1
+++ b/src/etc/man/cargo-search.1
@@ -75,7 +75,7 @@ May also be specified with the \fBterm.color\fR
 If Cargo has been installed with rustup, and the first argument to \fBcargo\fR
 begins with \fB+\fR, it will be interpreted as a rustup toolchain name (such
 as \fB+stable\fR or \fB+nightly\fR).
-See the \fIrustup documentation\fR <https://github.com/rust\-lang/rustup/>
+See the \fIrustup documentation\fR <https://rust\-lang.github.io/rustup/overrides.html>
 for more information about how toolchain overrides work.
 .RE
 .sp

--- a/src/etc/man/cargo-test.1
+++ b/src/etc/man/cargo-test.1
@@ -396,7 +396,7 @@ May also be specified with the \fBnet.offline\fR \fIconfig value\fR <https://doc
 If Cargo has been installed with rustup, and the first argument to \fBcargo\fR
 begins with \fB+\fR, it will be interpreted as a rustup toolchain name (such
 as \fB+stable\fR or \fB+nightly\fR).
-See the \fIrustup documentation\fR <https://github.com/rust\-lang/rustup/>
+See the \fIrustup documentation\fR <https://rust\-lang.github.io/rustup/overrides.html>
 for more information about how toolchain overrides work.
 .RE
 .sp

--- a/src/etc/man/cargo-tree.1
+++ b/src/etc/man/cargo-tree.1
@@ -324,7 +324,7 @@ May also be specified with the \fBterm.color\fR
 If Cargo has been installed with rustup, and the first argument to \fBcargo\fR
 begins with \fB+\fR, it will be interpreted as a rustup toolchain name (such
 as \fB+stable\fR or \fB+nightly\fR).
-See the \fIrustup documentation\fR <https://github.com/rust\-lang/rustup/>
+See the \fIrustup documentation\fR <https://rust\-lang.github.io/rustup/overrides.html>
 for more information about how toolchain overrides work.
 .RE
 .sp

--- a/src/etc/man/cargo-uninstall.1
+++ b/src/etc/man/cargo-uninstall.1
@@ -98,7 +98,7 @@ May also be specified with the \fBterm.color\fR
 If Cargo has been installed with rustup, and the first argument to \fBcargo\fR
 begins with \fB+\fR, it will be interpreted as a rustup toolchain name (such
 as \fB+stable\fR or \fB+nightly\fR).
-See the \fIrustup documentation\fR <https://github.com/rust\-lang/rustup/>
+See the \fIrustup documentation\fR <https://rust\-lang.github.io/rustup/overrides.html>
 for more information about how toolchain overrides work.
 .RE
 .sp

--- a/src/etc/man/cargo-update.1
+++ b/src/etc/man/cargo-update.1
@@ -126,7 +126,7 @@ May also be specified with the \fBnet.offline\fR \fIconfig value\fR <https://doc
 If Cargo has been installed with rustup, and the first argument to \fBcargo\fR
 begins with \fB+\fR, it will be interpreted as a rustup toolchain name (such
 as \fB+stable\fR or \fB+nightly\fR).
-See the \fIrustup documentation\fR <https://github.com/rust\-lang/rustup/>
+See the \fIrustup documentation\fR <https://rust\-lang.github.io/rustup/overrides.html>
 for more information about how toolchain overrides work.
 .RE
 .sp

--- a/src/etc/man/cargo-vendor.1
+++ b/src/etc/man/cargo-vendor.1
@@ -126,7 +126,7 @@ May also be specified with the \fBterm.color\fR
 If Cargo has been installed with rustup, and the first argument to \fBcargo\fR
 begins with \fB+\fR, it will be interpreted as a rustup toolchain name (such
 as \fB+stable\fR or \fB+nightly\fR).
-See the \fIrustup documentation\fR <https://github.com/rust\-lang/rustup/>
+See the \fIrustup documentation\fR <https://rust\-lang.github.io/rustup/overrides.html>
 for more information about how toolchain overrides work.
 .RE
 .sp

--- a/src/etc/man/cargo-verify-project.1
+++ b/src/etc/man/cargo-verify-project.1
@@ -105,7 +105,7 @@ May also be specified with the \fBnet.offline\fR \fIconfig value\fR <https://doc
 If Cargo has been installed with rustup, and the first argument to \fBcargo\fR
 begins with \fB+\fR, it will be interpreted as a rustup toolchain name (such
 as \fB+stable\fR or \fB+nightly\fR).
-See the \fIrustup documentation\fR <https://github.com/rust\-lang/rustup/>
+See the \fIrustup documentation\fR <https://rust\-lang.github.io/rustup/overrides.html>
 for more information about how toolchain overrides work.
 .RE
 .sp

--- a/src/etc/man/cargo-yank.1
+++ b/src/etc/man/cargo-yank.1
@@ -103,7 +103,7 @@ May also be specified with the \fBterm.color\fR
 If Cargo has been installed with rustup, and the first argument to \fBcargo\fR
 begins with \fB+\fR, it will be interpreted as a rustup toolchain name (such
 as \fB+stable\fR or \fB+nightly\fR).
-See the \fIrustup documentation\fR <https://github.com/rust\-lang/rustup/>
+See the \fIrustup documentation\fR <https://rust\-lang.github.io/rustup/overrides.html>
 for more information about how toolchain overrides work.
 .RE
 .sp

--- a/src/etc/man/cargo.1
+++ b/src/etc/man/cargo.1
@@ -238,7 +238,7 @@ May also be specified with the \fBnet.offline\fR \fIconfig value\fR <https://doc
 If Cargo has been installed with rustup, and the first argument to \fBcargo\fR
 begins with \fB+\fR, it will be interpreted as a rustup toolchain name (such
 as \fB+stable\fR or \fB+nightly\fR).
-See the \fIrustup documentation\fR <https://github.com/rust\-lang/rustup/>
+See the \fIrustup documentation\fR <https://rust\-lang.github.io/rustup/overrides.html>
 for more information about how toolchain overrides work.
 .RE
 .sp
@@ -274,7 +274,7 @@ environment variable.
 \fB$CARGO_HOME/bin/\fR
 .br
 \ \ \ \ Binaries installed by \fBcargo\-install\fR(1) will be located here. If using
-rustup, executables distributed with Rust are also located here.
+\fIrustup\fR <https://rust\-lang.github.io/rustup/>, executables distributed with Rust are also located here.
 .sp
 \fB$CARGO_HOME/config.toml\fR
 .br


### PR DESCRIPTION
The rustup docs have moved, so update some of the documentation links.
